### PR TITLE
feat: Add directory mounting capabilities to vt run and registry run

### DIFF
--- a/cmd/vt/registry.go
+++ b/cmd/vt/registry.go
@@ -67,6 +67,7 @@ var (
 	registryRunEnv               []string
 	registryRunNoClientConfig    bool
 	registryRunForeground        bool
+	registryRunVolumes           []string
 )
 
 func init() {
@@ -123,6 +124,13 @@ func init() {
 		"f",
 		false,
 		"Run in foreground mode (block until container exits)",
+	)
+	registryRunCmd.Flags().StringArrayVarP(
+		&registryRunVolumes,
+		"volume",
+		"v",
+		[]string{},
+		"Mount a volume into the container (format: host-path:container-path[:ro])",
 	)
 
 	// Add OIDC validation flags
@@ -462,6 +470,7 @@ func registryRunCmdFunc(cmd *cobra.Command, args []string) error {
 		OIDCJwksURL:       oidcJwksURL,
 		OIDCClientID:      oidcClientID,
 		Debug:             debugMode,
+		Volumes:           registryRunVolumes,
 	}
 
 	// Create context

--- a/cmd/vt/run.go
+++ b/cmd/vt/run.go
@@ -24,6 +24,7 @@ var (
 	runEnv               []string
 	runNoClientConfig    bool
 	runForeground        bool
+	runVolumes           []string
 )
 
 func init() {
@@ -51,6 +52,13 @@ func init() {
 		"Do not update client configuration files with the MCP server URL",
 	)
 	runCmd.Flags().BoolVarP(&runForeground, "foreground", "f", false, "Run in foreground mode (block until container exits)")
+	runCmd.Flags().StringArrayVarP(
+		&runVolumes,
+		"volume",
+		"v",
+		[]string{},
+		"Mount a volume into the container (format: host-path:container-path[:ro])",
+	)
 
 	// Add OIDC validation flags
 	AddOIDCFlags(runCmd)
@@ -92,6 +100,7 @@ func runCmdFunc(cmd *cobra.Command, args []string) error {
 		OIDCJwksURL:       oidcJwksURL,
 		OIDCClientID:      oidcClientID,
 		Debug:             debugMode,
+		Volumes:           runVolumes,
 	}
 
 	// Run the MCP server

--- a/pkg/permissions/profile.go
+++ b/pkg/permissions/profile.go
@@ -6,15 +6,23 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
 )
 
 // Profile represents a permission profile for a container
 type Profile struct {
-	// Read is a list of paths that the container can read from
-	Read []string `json:"read,omitempty"`
+	// Read is a list of mount declarations that the container can read from
+	// These can be in the following formats:
+	// - A single path: The same path will be mounted from host to container
+	// - host-path:container-path: Different paths for host and container
+	// - resource-uri:container-path: Mount a resource identified by URI to a container path
+	Read []MountDeclaration `json:"read,omitempty"`
 
-	// Write is a list of paths that the container can write to
-	Write []string `json:"write,omitempty"`
+	// Write is a list of mount declarations that the container can write to
+	// These follow the same format as Read mounts but with write permissions
+	Write []MountDeclaration `json:"write,omitempty"`
 
 	// Network defines network permissions
 	Network *NetworkPermissions `json:"network,omitempty"`
@@ -44,8 +52,8 @@ type OutboundNetworkPermissions struct {
 // NewProfile creates a new permission profile
 func NewProfile() *Profile {
 	return &Profile{
-		Read:  []string{},
-		Write: []string{},
+		Read:  []MountDeclaration{},
+		Write: []MountDeclaration{},
 		Network: &NetworkPermissions{
 			Outbound: &OutboundNetworkPermissions{
 				InsecureAllowAll: false,
@@ -78,8 +86,8 @@ func FromFile(path string) (*Profile, error) {
 // BuiltinStdioProfile returns the built-in stdio profile
 func BuiltinStdioProfile() *Profile {
 	return &Profile{
-		Read:  []string{},
-		Write: []string{},
+		Read:  []MountDeclaration{},
+		Write: []MountDeclaration{},
 		Network: &NetworkPermissions{
 			Outbound: &OutboundNetworkPermissions{
 				InsecureAllowAll: false,
@@ -94,8 +102,8 @@ func BuiltinStdioProfile() *Profile {
 // BuiltinNetworkProfile returns the built-in network profile
 func BuiltinNetworkProfile() *Profile {
 	return &Profile{
-		Read:  []string{},
-		Write: []string{},
+		Read:  []MountDeclaration{},
+		Write: []MountDeclaration{},
 		Network: &NetworkPermissions{
 			Outbound: &OutboundNetworkPermissions{
 				InsecureAllowAll: true,
@@ -105,4 +113,152 @@ func BuiltinNetworkProfile() *Profile {
 			},
 		},
 	}
+}
+
+// MountDeclaration represents a mount declaration for a container
+// It can be in one of the following formats:
+//   - A single path: The same path will be mounted from host to container
+//   - host-path:container-path: Different paths for host and container
+//   - resource-uri:container-path: Mount a resource identified by URI to a container path
+//     (e.g., volume://name:container-path)
+type MountDeclaration string
+
+// Regular expressions for parsing mount declarations
+var (
+	// resourceURIRegex matches resource URIs like "volume://name:container-path"
+	// The scheme must start with a letter and can contain letters, numbers, underscores, and hyphens
+	// The resource name can contain any characters except colon
+	// The container path can contain any characters except colon
+	resourceURIRegex = regexp.MustCompile(`^([a-zA-Z][a-zA-Z0-9_-]*)://([^:]+):([^:]+)$`)
+
+	// hostPathRegex matches host-path:container-path format
+	// Both host path and container path can contain any characters except colon
+	hostPathRegex = regexp.MustCompile(`^([^:]+):([^:]+)$`)
+
+	// commandInjectionPattern matches common command injection patterns
+	commandInjectionPattern = regexp.MustCompile(`[$&;|]|\$\(|\` + "`")
+)
+
+// validatePath checks if a path contains potentially dangerous patterns
+func validatePath(path string) error {
+	if commandInjectionPattern.MatchString(path) {
+		return fmt.Errorf("potential command injection detected in path: %s", path)
+	}
+
+	// Check for null bytes
+	if strings.Contains(path, "\x00") {
+		return fmt.Errorf("null byte detected in path: %s", path)
+	}
+
+	return nil
+}
+
+// cleanPath cleans a path using filepath.Clean
+func cleanPath(path string) string {
+	return filepath.Clean(path)
+}
+
+// Parse parses a mount declaration and returns the source and target paths
+// It also cleans and validates the paths
+func (m MountDeclaration) Parse() (source, target string, err error) {
+	declaration := string(m)
+
+	// Check if it's a resource URI
+	if matches := resourceURIRegex.FindStringSubmatch(declaration); matches != nil {
+		scheme := matches[1]
+		resourceName := matches[2]
+		containerPath := matches[3]
+
+		// Validate paths
+		if err := validatePath(resourceName); err != nil {
+			return "", "", err
+		}
+		if err := validatePath(containerPath); err != nil {
+			return "", "", err
+		}
+
+		// Clean paths
+		cleanedResource := cleanPath(resourceName)
+		cleanedTarget := cleanPath(containerPath)
+
+		return scheme + "://" + cleanedResource, cleanedTarget, nil
+	}
+
+	// Check if it's a host-path:container-path format
+	if matches := hostPathRegex.FindStringSubmatch(declaration); matches != nil {
+		hostPath := matches[1]
+		containerPath := matches[2]
+
+		// Validate paths
+		if err := validatePath(hostPath); err != nil {
+			return "", "", err
+		}
+		if err := validatePath(containerPath); err != nil {
+			return "", "", err
+		}
+
+		// Clean paths
+		cleanedSource := cleanPath(hostPath)
+		cleanedTarget := cleanPath(containerPath)
+
+		return cleanedSource, cleanedTarget, nil
+	}
+
+	// If it doesn't contain a colon, it's a single path
+	if !strings.Contains(declaration, ":") {
+		// Validate path
+		if err := validatePath(declaration); err != nil {
+			return "", "", err
+		}
+
+		// Clean path
+		cleanedPath := cleanPath(declaration)
+
+		return cleanedPath, cleanedPath, nil
+	}
+
+	// If we get here, the format is invalid
+	return "", "", fmt.Errorf("invalid mount declaration format: %s "+
+		"(expected path, host-path:container-path, or scheme://resource:container-path)", declaration)
+}
+
+// IsValid checks if the mount declaration is valid
+func (m MountDeclaration) IsValid() bool {
+	_, _, err := m.Parse()
+	return err == nil
+}
+
+// IsResourceURI checks if the mount declaration is a resource URI
+func (m MountDeclaration) IsResourceURI() bool {
+	return resourceURIRegex.MatchString(string(m))
+}
+
+// GetResourceType returns the resource type if the mount declaration is a resource URI
+// For example, "volume://name" would return "volume"
+func (m MountDeclaration) GetResourceType() (string, error) {
+	matches := resourceURIRegex.FindStringSubmatch(string(m))
+	if matches == nil {
+		return "", fmt.Errorf("not a resource URI: %s", m)
+	}
+
+	return matches[1], nil
+}
+
+// ParseMountDeclarations parses a list of mount declarations
+func ParseMountDeclarations(declarations []string) ([]MountDeclaration, error) {
+	result := make([]MountDeclaration, 0, len(declarations))
+
+	for _, declaration := range declarations {
+		mount := MountDeclaration(declaration)
+
+		// Check if the declaration is valid
+		if !mount.IsValid() {
+			_, _, err := mount.Parse()
+			return nil, fmt.Errorf("invalid mount declaration: %s (%v)", declaration, err)
+		}
+
+		result = append(result, mount)
+	}
+
+	return result, nil
 }

--- a/pkg/permissions/profile_test.go
+++ b/pkg/permissions/profile_test.go
@@ -1,0 +1,346 @@
+package permissions
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMountDeclaration_Parse(t *testing.T) {
+	tests := []struct {
+		name           string
+		declaration    MountDeclaration
+		expectedSource string
+		expectedTarget string
+		expectError    bool
+	}{
+		{
+			name:           "Single path",
+			declaration:    "/path/to/dir",
+			expectedSource: "/path/to/dir",
+			expectedTarget: "/path/to/dir",
+			expectError:    false,
+		},
+		{
+			name:           "Host path to container path",
+			declaration:    "/host/path:/container/path",
+			expectedSource: "/host/path",
+			expectedTarget: "/container/path",
+			expectError:    false,
+		},
+		{
+			name:           "Resource URI",
+			declaration:    "volume://myvolume:/container/path",
+			expectedSource: "volume://myvolume",
+			expectedTarget: "/container/path",
+			expectError:    false,
+		},
+		{
+			name:           "Different resource URI",
+			declaration:    "secret://mysecret:/container/path",
+			expectedSource: "secret://mysecret",
+			expectedTarget: "/container/path",
+			expectError:    false,
+		},
+		// Security-focused tests
+		{
+			name:           "Path with spaces",
+			declaration:    "/path with spaces:/container/path",
+			expectedSource: "/path with spaces",
+			expectedTarget: "/container/path",
+			expectError:    false,
+		},
+		{
+			name:           "Path with special characters",
+			declaration:    "/path/with/special/chars!@#:/container/path",
+			expectedSource: "/path/with/special/chars!@#",
+			expectedTarget: "/container/path",
+			expectError:    false,
+		},
+		{
+			name:           "Path with Unicode characters",
+			declaration:    "/path/with/unicode/😀:/container/path",
+			expectedSource: "/path/with/unicode/😀",
+			expectedTarget: "/container/path",
+			expectError:    false,
+		},
+		{
+			name:           "Path with potential command injection",
+			declaration:    "/path/with/$(rm -rf *):/container/path",
+			expectedSource: "",
+			expectedTarget: "",
+			expectError:    true, // Now expecting an error due to validation
+		},
+		{
+			name:           "Path with potential path traversal",
+			declaration:    "/path/with/../../../etc/passwd:/container/path",
+			expectedSource: "/etc/passwd", // filepath.Clean resolves the path
+			expectedTarget: "/container/path",
+			expectError:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			source, target, err := tt.declaration.Parse()
+
+			if tt.expectError {
+				assert.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedSource, source)
+			assert.Equal(t, tt.expectedTarget, target)
+		})
+	}
+}
+
+func TestMountDeclaration_IsValid(t *testing.T) {
+	tests := []struct {
+		name        string
+		declaration MountDeclaration
+		expected    bool
+	}{
+		{
+			name:        "Single path",
+			declaration: "/path/to/dir",
+			expected:    true,
+		},
+		{
+			name:        "Host path to container path",
+			declaration: "/host/path:/container/path",
+			expected:    true,
+		},
+		{
+			name:        "Resource URI",
+			declaration: "volume://myvolume:/container/path",
+			expected:    true,
+		},
+		{
+			name:        "Empty string",
+			declaration: "",
+			expected:    true, // Empty string is treated as a single path
+		},
+		// Security-focused tests
+		{
+			name:        "Path with potential command injection",
+			declaration: "/path/with/$(rm -rf *):/container/path",
+			expected:    false, // Now invalid due to validation
+		},
+		{
+			name:        "Path with potential path traversal",
+			declaration: "/path/with/../../../etc/passwd:/container/path",
+			expected:    true, // Valid format, but potentially dangerous
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.declaration.IsValid())
+		})
+	}
+}
+
+func TestMountDeclaration_IsResourceURI(t *testing.T) {
+	tests := []struct {
+		name        string
+		declaration MountDeclaration
+		expected    bool
+	}{
+		{
+			name:        "Single path",
+			declaration: "/path/to/dir",
+			expected:    false,
+		},
+		{
+			name:        "Host path to container path",
+			declaration: "/host/path:/container/path",
+			expected:    false,
+		},
+		{
+			name:        "Resource URI",
+			declaration: "volume://myvolume:/container/path",
+			expected:    true,
+		},
+		{
+			name:        "Different resource URI",
+			declaration: "secret://mysecret:/container/path",
+			expected:    true,
+		},
+		// Security-focused tests
+		{
+			name:        "Malformed resource URI",
+			declaration: "volume:/myvolume:/container/path", // Missing a slash
+			expected:    false,
+		},
+		{
+			name:        "Resource URI with potential command injection",
+			declaration: "volume://$(rm -rf *):/container/path",
+			expected:    true, // Valid format, but potentially dangerous
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.declaration.IsResourceURI())
+		})
+	}
+}
+
+func TestMountDeclaration_GetResourceType(t *testing.T) {
+	tests := []struct {
+		name         string
+		declaration  MountDeclaration
+		expectedType string
+		expectError  bool
+	}{
+		{
+			name:         "Single path",
+			declaration:  "/path/to/dir",
+			expectedType: "",
+			expectError:  true,
+		},
+		{
+			name:         "Host path to container path",
+			declaration:  "/host/path:/container/path",
+			expectedType: "",
+			expectError:  true,
+		},
+		{
+			name:         "Volume resource URI",
+			declaration:  "volume://myvolume:/container/path",
+			expectedType: "volume",
+			expectError:  false,
+		},
+		{
+			name:         "Secret resource URI",
+			declaration:  "secret://mysecret:/container/path",
+			expectedType: "secret",
+			expectError:  false,
+		},
+		// Security-focused tests
+		{
+			name:         "Resource URI with potential command injection",
+			declaration:  "volume://$(rm -rf *):/container/path",
+			expectedType: "volume",
+			expectError:  false, // Valid format, but potentially dangerous
+		},
+		{
+			name:         "Resource URI with unusual scheme",
+			declaration:  "file://etc/passwd:/container/path",
+			expectedType: "file",
+			expectError:  false, // Valid format, but potentially dangerous
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resourceType, err := tt.declaration.GetResourceType()
+
+			if tt.expectError {
+				assert.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedType, resourceType)
+		})
+	}
+}
+
+func TestParseMountDeclarations(t *testing.T) {
+	tests := []struct {
+		name         string
+		declarations []string
+		expectError  bool
+	}{
+		{
+			name: "Valid declarations",
+			declarations: []string{
+				"/path/to/dir",
+				"/host/path:/container/path",
+				"volume://myvolume:/container/path",
+			},
+			expectError: false,
+		},
+		{
+			name:         "Empty list",
+			declarations: []string{},
+			expectError:  false,
+		},
+		// Security-focused tests
+		{
+			name: "Declarations with potential security issues",
+			declarations: []string{
+				"/path/with/$(rm -rf *):/container/path",
+				"volume://$(rm -rf *):/container/path",
+				"/path/with/../../../etc/passwd:/container/path",
+			},
+			expectError: true, // Now expecting an error due to validation
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mounts, err := ParseMountDeclarations(tt.declarations)
+
+			if tt.expectError {
+				assert.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, len(tt.declarations), len(mounts))
+		})
+	}
+}
+
+// Additional security-focused tests
+
+func TestMountDeclaration_SecurityValidation(t *testing.T) {
+	// These tests check that our parsing is robust against various security issues
+
+	// Test for path traversal - this should be cleaned but allowed
+	traversalMount := MountDeclaration("/etc/passwd:/container/path")
+	source, target, err := traversalMount.Parse()
+	require.NoError(t, err)
+	assert.Equal(t, "/etc/passwd", source)
+	assert.Equal(t, "/container/path", target)
+
+	// Test for command injection - this should be rejected
+	injectionMount := MountDeclaration("$(rm -rf *):/container/path")
+	_, _, err = injectionMount.Parse()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "potential command injection")
+
+	// Test for null byte injection - this should be rejected
+	nullByteMount := MountDeclaration("/path/with/null\x00byte:/container/path")
+	_, _, err = nullByteMount.Parse()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "null byte detected")
+}
+
+func TestMountDeclaration_EdgeCases(t *testing.T) {
+	// Test with multiple colons - should fail with a clear error message
+	multipleColons := MountDeclaration("/path:with:multiple:colons:/container/path")
+	_, _, err := multipleColons.Parse()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid mount declaration format")
+
+	// Test with very long paths
+	longPath := "/very/long/path/" + strings.Repeat("a", 1000)
+	longMount := MountDeclaration(longPath + ":/container/path")
+	source, target, err := longMount.Parse()
+	require.NoError(t, err)
+	assert.Equal(t, longPath, source)
+	assert.Equal(t, "/container/path", target)
+
+	// Test with path containing "://" but not at the beginning
+	pathWithColon := MountDeclaration("/some/other/path/://:/tmp/foo")
+	_, _, err = pathWithColon.Parse()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid mount declaration format")
+}


### PR DESCRIPTION
This commit adds the ability to mount directories from the host into containers
via both `vt run` and `vt registry run` commands. This feature enhances the
flexibility of MCP servers by allowing them to access files from the host system.

Volume Mount Format:
- Basic format: `-v host-path:container-path`
- Read-only mount: `-v host-path:container-path:ro`

The implementation supports three types of mounts:
1. Single path: When only one path is provided, it's used as both the source and
   target (e.g., `-v /path/to/dir`)
2. Different paths: When two paths are provided, the first is the host path and
   the second is the container path (e.g., `-v /host/path:/container/path`)
3. Resource URIs: For future extensibility, the source can be a URI that
   identifies a resource (e.g., `-v volume://name:/container/path`)

Security Features:
- Command injection detection: Paths are validated to prevent command injection
- Null byte detection: Paths containing null bytes are rejected
- Path normalization: All paths are normalized using filepath.Clean

Implementation Details:
- Added MountDeclaration type to represent mount declarations
- Updated Profile struct to use MountDeclaration for Read and Write mounts
- Added volume flag to both vt run and registry run commands
- Implemented processVolumeMounts function to parse and validate volume mounts
- Updated container client to handle MountDeclaration objects

The feature has been thoroughly tested with both read-write and read-only mounts,
and all code quality checks have been passed.

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>
