### PR TITLE
Allow for relative paths when mounting volumes

### DIFF
--- a/pkg/container/docker/client.go
+++ b/pkg/container/docker/client.go
@@ -560,10 +560,18 @@ func (*Client) addReadOnlyMounts(config *runtime.PermissionConfig, mounts []perm
 			continue
 		}
 
-		// Skip relative paths
+		// Convert relative paths to absolute paths
 		if !filepath.IsAbs(source) {
-			fmt.Printf("Warning: Skipping relative source path: %s\n", source)
-			continue
+			// Get the current working directory
+			cwd, err := os.Getwd()
+			if err != nil {
+				fmt.Printf("Warning: Failed to get current working directory: %v\n", err)
+				continue
+			}
+
+			// Convert relative path to absolute path
+			source = filepath.Join(cwd, source)
+			fmt.Printf("Converting relative path to absolute: %s -> %s\n", mountDecl, source)
 		}
 
 		config.Mounts = append(config.Mounts, runtime.Mount{
@@ -590,10 +598,18 @@ func (*Client) addReadWriteMounts(config *runtime.PermissionConfig, mounts []per
 			continue
 		}
 
-		// Skip relative paths
+		// Convert relative paths to absolute paths
 		if !filepath.IsAbs(source) {
-			fmt.Printf("Warning: Skipping relative source path: %s\n", source)
-			continue
+			// Get the current working directory
+			cwd, err := os.Getwd()
+			if err != nil {
+				fmt.Printf("Warning: Failed to get current working directory: %v\n", err)
+				continue
+			}
+
+			// Convert relative path to absolute path
+			source = filepath.Join(cwd, source)
+			fmt.Printf("Converting relative path to absolute: %s -> %s\n", mountDecl, source)
 		}
 
 		// Check if the path is already mounted read-only

--- a/pkg/registry/data/registry.json
+++ b/pkg/registry/data/registry.json
@@ -59,13 +59,9 @@
         "network": {
           "outbound": {
             "insecure_allow_all": false,
-            "allow_transport": [
-              "tcp"
-            ],
+            "allow_transport": [],
             "allow_host": [],
-            "allow_port": [
-              443
-            ]
+            "allow_port": []
           }
         }
       },


### PR DESCRIPTION
This makes running MCPs a little easier since we can do relative paths
now.

Note that I also removed networking entirely from the git MCP, since it doesn't really use it.

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>
