### PR TITLE
Pull image in-process before detaching and show nicer output

### DIFF
--- a/cmd/vt/run_common.go
+++ b/cmd/vt/run_common.go
@@ -99,19 +99,6 @@ func RunMCPServer(ctx context.Context, cmd *cobra.Command, options RunOptions) e
 		return fmt.Errorf("failed to create container runtime: %v", err)
 	}
 
-	// Check if the image exists locally, and pull it if not
-	imageExists, err := runtime.ImageExists(ctx, options.Image)
-	if err != nil {
-		return fmt.Errorf("failed to check if image exists: %v", err)
-	}
-	if !imageExists {
-		fmt.Printf("Image %s not found locally, pulling...\n", options.Image)
-		if err := runtime.PullImage(ctx, options.Image); err != nil {
-			return fmt.Errorf("failed to pull image: %v", err)
-		}
-		fmt.Printf("Successfully pulled image: %s\n", options.Image)
-	}
-
 	// Generate a container name if not provided
 	containerName, baseName := container.GetOrGenerateContainerName(options.Name, options.Image)
 


### PR DESCRIPTION
This allows us to catch issues earlier where you might have mistyped the
image... or to simply wait for the image to be pulled.

So, we pull the image first, and then run the detach. Image pulling is
no longer part of the common run function.

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>
