### PR TITLE
Add Pushover MCP

### DIFF
--- a/pkg/registry/data/registry.json
+++ b/pkg/registry/data/registry.json
@@ -858,6 +858,63 @@
         "sql"
       ]
     },
+    "pushover": {
+      "image": "ashiknesin/pushover-mcp:latest",
+      "description": "A Model Context Protocol implementation for sending notifications via Pushover.net, enabling AI agents to send customizable push notifications to devices.",
+      "transport": "stdio",
+      "permissions": {
+        "read": [],
+        "write": [],
+        "network": {
+          "outbound": {
+            "insecure_allow_all": false,
+            "allow_transport": [
+              "tcp"
+            ],
+            "allow_host": [
+              "api.pushover.net"
+            ],
+            "allow_port": [
+              443
+            ]
+          }
+        }
+      },
+      "tools": [
+        "send"
+      ],
+      "env_vars": [
+        {
+          "name": "PUSHOVER_TOKEN",
+          "description": "Application token from Pushover.net",
+          "required": true
+        },
+        {
+          "name": "PUSHOVER_USER",
+          "description": "User key from Pushover.net",
+          "required": true
+        }
+      ],
+      "args": [],
+      "metadata": {
+        "stars": 7,
+        "pulls": 0,
+        "last_updated": "2025-03-25T16:58:54Z"
+      },
+      "repository_url": "https://github.com/ashiknesin/pushover-mcp",
+      "tags": [
+        "notifications",
+        "push-notifications",
+        "pushover",
+        "alerts",
+        "messaging",
+        "mobile",
+        "devices",
+        "communication",
+        "real-time",
+        "monitoring"
+      ]
+    },
     "puppeteer": {
       "image": "mcp/puppeteer:latest",
       "description": "A Model Context Protocol server that provides browser automation capabilities using Puppeteer",


### PR DESCRIPTION
This uses https://github.com/ashiknesin/pushover-mcp as an MCP for the
Pushover API.