### PR TITLE
Name the released binaries as vt instead of vibetool and don't build for windows

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -19,12 +19,13 @@ builds:
 #      - "-X github.com/stacklok/vibetool/---/cli.CLIVersion={{ .Env.VERSION }}"
     goos:
       - linux
-      - windows
+#      - windows
       - darwin
     goarch:
       - amd64
       - arm64
     main: ./cmd/vt
+    binary: vt
 # This section defines the release format.
 archives:
   - format: tar.gz # we can use binary, but it seems there's an issue where goreleaser skips the sboms


### PR DESCRIPTION
The following PR:
* Renames the released binaries to `vt` as expected (as oppose to `vibetool`)
* Disables releasing for windows for faster builds (we can enable it later)