### PR TITLE
Disable SLSA for now and rename formula release to vt

### DIFF
--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -105,55 +105,55 @@ jobs:
           fi
           echo "hashes=$hashes" >> $GITHUB_OUTPUT
 
-  provenance:
-    name: Generate provenance (SLSA3)
-    needs:
-      - release
-    permissions:
-      actions: read # To read the workflow path.
-      id-token: write # To sign the provenance.
-      contents: write # To add assets to a release.
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
-    with:
-      base64-subjects: "${{ needs.release.outputs.hashes }}"
-      upload-assets: true # upload to a new release
+#  provenance:
+#    name: Generate provenance (SLSA3)
+#    needs:
+#      - release
+#    permissions:
+#      actions: read # To read the workflow path.
+#      id-token: write # To sign the provenance.
+#      contents: write # To add assets to a release.
+#    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
+#    with:
+#      base64-subjects: "${{ needs.release.outputs.hashes }}"
+#      upload-assets: true # upload to a new release
 
-  verification:
-    name: Verify provenance of assets (SLSA3)
-    needs:
-      - release
-      - provenance
-    runs-on: ubuntu-latest
-    permissions: read-all
-    steps:
-      - name: Install the SLSA verifier
-        uses: slsa-framework/slsa-verifier/actions/installer@3714a2a4684014deb874a0e737dffa0ee02dd647 # v2.6.0
-      - name: Download assets
-        env:
-          GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-          CHECKSUMS: "${{ needs.release.outputs.hashes }}"
-          ATT_FILE_NAME: "${{ needs.provenance.outputs.provenance-name }}"
-        run: |
-          set -euo pipefail
-          checksums=$(echo "$CHECKSUMS" | base64 -d)
-          while read -r line; do
-              fn=$(echo $line | cut -d ' ' -f2)
-              echo "Downloading $fn"
-              gh -R "$GITHUB_REPOSITORY" release download "$GITHUB_REF_NAME" -p "$fn"
-          done <<<"$checksums"
-          gh -R "$GITHUB_REPOSITORY" release download "$GITHUB_REF_NAME" -p "$ATT_FILE_NAME"
-      - name: Verify assets
-        env:
-          CHECKSUMS: "${{ needs.release.outputs.hashes }}"
-          PROVENANCE: "${{ needs.provenance.outputs.provenance-name }}"
-        run: |
-          set -euo pipefail
-          checksums=$(echo "$CHECKSUMS" | base64 -d)
-          while read -r line; do
-              fn=$(echo $line | cut -d ' ' -f2)
-              echo "Verifying SLSA provenance for $fn"
-              slsa-verifier verify-artifact --provenance-path "$PROVENANCE" \
-                                            --source-uri "github.com/$GITHUB_REPOSITORY" \
-                                            --source-tag "$GITHUB_REF_NAME" \
-                                            "$fn"
-          done <<<"$checksums"
+#  verification:
+#    name: Verify provenance of assets (SLSA3)
+#    needs:
+#      - release
+#      - provenance
+#    runs-on: ubuntu-latest
+#    permissions: read-all
+#    steps:
+#      - name: Install the SLSA verifier
+#        uses: slsa-framework/slsa-verifier/actions/installer@3714a2a4684014deb874a0e737dffa0ee02dd647 # v2.6.0
+#      - name: Download assets
+#        env:
+#          GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+#          CHECKSUMS: "${{ needs.release.outputs.hashes }}"
+#          ATT_FILE_NAME: "${{ needs.provenance.outputs.provenance-name }}"
+#        run: |
+#          set -euo pipefail
+#          checksums=$(echo "$CHECKSUMS" | base64 -d)
+#          while read -r line; do
+#              fn=$(echo $line | cut -d ' ' -f2)
+#              echo "Downloading $fn"
+#              gh -R "$GITHUB_REPOSITORY" release download "$GITHUB_REF_NAME" -p "$fn"
+#          done <<<"$checksums"
+#          gh -R "$GITHUB_REPOSITORY" release download "$GITHUB_REF_NAME" -p "$ATT_FILE_NAME"
+#      - name: Verify assets
+#        env:
+#          CHECKSUMS: "${{ needs.release.outputs.hashes }}"
+#          PROVENANCE: "${{ needs.provenance.outputs.provenance-name }}"
+#        run: |
+#          set -euo pipefail
+#          checksums=$(echo "$CHECKSUMS" | base64 -d)
+#          while read -r line; do
+#              fn=$(echo $line | cut -d ' ' -f2)
+#              echo "Verifying SLSA provenance for $fn"
+#              slsa-verifier verify-artifact --provenance-path "$PROVENANCE" \
+#                                            --source-uri "github.com/$GITHUB_REPOSITORY" \
+#                                            --source-tag "$GITHUB_REF_NAME" \
+#                                            "$fn"
+#          done <<<"$checksums"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -68,7 +68,8 @@ archives:
 #           branch: master
 # This section defines how to release to homebrew.
 brews:
-  - homepage: 'https://github.com/stacklok/vibetool'
+  - name: vt
+    homepage: 'https://github.com/stacklok/vibetool'
     description: 'vibetool is a lightweight, secure, and fast manager for MCP (Model Context Protocol) servers'
     directory: Formula
     commit_author:


### PR DESCRIPTION
The following PR:
* Renames the formula as vt (so one can do `brew install stacklok/tap/vt` instead of `vibetool`)
* Temporarily disables the SLSA provenance generation (for some reason it fails, did not debug this but might be because the repo is still private since the same workflow works for `frizbee` for example)