### PR TITLE
Implement `vt restart`

### DIFF
--- a/cmd/vt/main.go
+++ b/cmd/vt/main.go
@@ -45,6 +45,7 @@ func init() {
 	rootCmd.AddCommand(proxyCmd)
 	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(newSecretCommand())
+	rootCmd.AddCommand(restartCmd)
 }
 
 func main() {

--- a/cmd/vt/restart.go
+++ b/cmd/vt/restart.go
@@ -1,0 +1,236 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+
+	"github.com/spf13/cobra"
+
+	"github.com/stacklok/vibetool/pkg/container"
+	rt "github.com/stacklok/vibetool/pkg/container/runtime"
+	"github.com/stacklok/vibetool/pkg/labels"
+	"github.com/stacklok/vibetool/pkg/transport"
+)
+
+var (
+	restartForeground bool
+)
+
+var restartCmd = &cobra.Command{
+	Use:   "restart [container-name]",
+	Short: "Restart an MCP server",
+	Long:  `Restart an MCP server managed by Vibe Tool.`,
+	Args:  cobra.ExactArgs(1),
+	RunE:  restartCmdFunc,
+}
+
+func init() {
+	restartCmd.Flags().BoolVar(&restartForeground, "foreground", false, "Run in foreground mode (default: false)")
+}
+
+// getPortConfiguration gets the port configuration based on transport type and container info
+func getPortConfiguration(transportType string, containerInfo rt.ContainerInfo) (targetPort int) {
+	return transport.GetPortConfiguration(transport.TransportType(transportType), containerInfo)
+}
+
+func restartCmdFunc(cmd *cobra.Command, args []string) error {
+	// Get container name
+	containerName := args[0]
+
+	// Create context
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Get debug mode flag
+	debugMode, _ := cmd.Flags().GetBool("debug")
+
+	// Create container runtime
+	runtime, err := container.NewFactory().Create(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to create container runtime: %v", err)
+	}
+
+	// Check if we're running in detached mode
+	if os.Getenv("VIBETOOL_DETACHED") != "1" && !restartForeground {
+		return detachRestartProcess(cmd, args[0])
+	}
+
+	// Find the container with the given name
+	containerID, _, err := findContainerAndBaseName(ctx, runtime, containerName)
+	if err != nil {
+		return err
+	}
+
+	// Get container info to preserve configuration
+	containerInfo, err := runtime.GetContainerInfo(ctx, containerID)
+	if err != nil {
+		return fmt.Errorf("failed to get container info: %v", err)
+	}
+
+	// Extract transport type from labels
+	transportType := labels.GetTransportType(containerInfo.Labels)
+	if transportType == "" {
+		return fmt.Errorf("failed to determine transport type from container labels")
+	}
+
+	// Get port configuration based on transport type
+	targetPort := getPortConfiguration(transportType, containerInfo)
+
+	// get the host port from the container labels
+	proxyPort, err := labels.GetPort(containerInfo.Labels)
+	if err != nil {
+		return fmt.Errorf("failed to get port from container labels: %v", err)
+	}
+
+	// Create transport configuration
+	transportConfig := transport.Config{
+		Type:       transport.TransportType(transportType),
+		Runtime:    runtime,
+		Debug:      debugMode,
+		Port:       proxyPort,
+		TargetPort: targetPort,
+	}
+
+	// Create transport handler
+	transportHandler, err := transport.NewFactory().Create(transportConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create transport: %v", err)
+	}
+
+	// Set up the transport
+	fmt.Printf("Setting up %s transport...\n", transportType)
+	if err := transportHandler.Setup(
+		ctx,
+		runtime,
+		containerName,
+		containerInfo,
+		nil, // Use default command from image
+		nil, // Use default permission profile
+	); err != nil {
+		return fmt.Errorf("failed to set up transport: %v", err)
+	}
+
+	// Start the transport (which also starts the container and proxy)
+	fmt.Printf("Starting %s transport...\n", transportType)
+	if err := transportHandler.Start(ctx); err != nil {
+		return fmt.Errorf("failed to start transport: %v", err)
+	}
+
+	fmt.Printf("Container %s restarted successfully\n", containerName)
+	return nil
+}
+
+// detachRestartProcess starts a new detached process with the restart command
+func detachRestartProcess(_ *cobra.Command, containerName string) error {
+	// Get the current executable path
+	execPath, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("failed to get executable path: %v", err)
+	}
+
+	// Create context to find the container's base name
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Create container runtime
+	runtime, err := container.NewFactory().Create(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to create container runtime: %v", err)
+	}
+
+	// Find the container to get its base name for the log file
+	_, containerBaseName, err := findContainerAndBaseName(ctx, runtime, containerName)
+	if err != nil {
+		return err
+	}
+
+	// Create a log file for the detached process using the same pattern as run command
+	logFilePath := fmt.Sprintf("/tmp/vibetool-%s.log", containerBaseName)
+	// #nosec G304 - This is safe as containerBaseName comes from container labels
+	logFile, err := os.OpenFile(logFilePath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)
+	if err != nil {
+		fmt.Printf("Warning: Failed to create log file: %v\n", err)
+	} else {
+		defer logFile.Close()
+		fmt.Printf("Logging to: %s\n", logFilePath)
+	}
+
+	// Prepare the command arguments for the detached process
+	detachedArgs := []string{"restart", "--foreground", containerName}
+
+	// Create a new command
+	// #nosec G204 - This is safe as execPath is the path to the current binary
+	detachedCmd := exec.Command(execPath, detachedArgs...)
+
+	// Set environment variables for the detached process
+	detachedCmd.Env = append(os.Environ(), "VIBETOOL_DETACHED=1")
+
+	// Redirect stdout and stderr to the log file if it was created successfully
+	if logFile != nil {
+		detachedCmd.Stdout = logFile
+		detachedCmd.Stderr = logFile
+	} else {
+		// Otherwise, discard the output
+		detachedCmd.Stdout = nil
+		detachedCmd.Stderr = nil
+	}
+
+	// Detach the process from the terminal
+	detachedCmd.Stdin = nil
+	detachedCmd.SysProcAttr = &syscall.SysProcAttr{
+		Setsid: true, // Create a new session
+	}
+
+	// Start the detached process
+	if err := detachedCmd.Start(); err != nil {
+		return fmt.Errorf("failed to start detached process: %v", err)
+	}
+
+	fmt.Printf("Restarting MCP server %s in the background (PID: %d)\n", containerName, detachedCmd.Process.Pid)
+	return nil
+}
+
+// findContainerAndBaseName finds a container by name and returns its ID and base name
+func findContainerAndBaseName(ctx context.Context, runtime rt.Runtime, containerName string) (string, string, error) {
+	containers, err := runtime.ListContainers(ctx)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to list containers: %v", err)
+	}
+
+	for _, c := range containers {
+		// Check if the container is managed by Vibe Tool
+		if !labels.IsVibeToolContainer(c.Labels) {
+			continue
+		}
+
+		// Check if the container name matches
+		name := labels.GetContainerName(c.Labels)
+		if name == "" {
+			name = c.Name // Fallback to container name
+		}
+
+		// Check if the name matches (exact match or prefix match)
+		if name == containerName || strings.HasPrefix(c.ID, containerName) {
+			baseName := labels.GetContainerBaseName(c.Labels)
+			return c.ID, baseName, nil
+		}
+	}
+
+	return "", "", fmt.Errorf("container %s not found", containerName)
+}
+
+// RestartCmd creates a new cobra command for restarting containers
+func RestartCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "restart",
+		Short: "Restart a container",
+		Long:  "Restart a container managed by vibetool",
+		RunE:  restartCmdFunc,
+	}
+
+	return cmd
+}

--- a/cmd/vt/run_common.go
+++ b/cmd/vt/run_common.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stacklok/vibetool/pkg/authz"
 	"github.com/stacklok/vibetool/pkg/client"
 	"github.com/stacklok/vibetool/pkg/container"
+	rt "github.com/stacklok/vibetool/pkg/container/runtime"
 	"github.com/stacklok/vibetool/pkg/environment"
 	"github.com/stacklok/vibetool/pkg/labels"
 	"github.com/stacklok/vibetool/pkg/networking"
@@ -232,11 +233,18 @@ func RunMCPServer(ctx context.Context, cmd *cobra.Command, options RunOptions) e
 		return err
 	}
 
+	// Create a ContainerInfo for the initial setup
+	containerInfo := rt.ContainerInfo{
+		Image:  options.Image,
+		Labels: containerLabels,
+		Env:    options.EnvVars,
+	}
+
 	// Set up the transport
 	fmt.Printf("Setting up %s transport...\n", transportType)
 	if err := transportHandler.Setup(
-		ctx, runtime, containerName, options.Image, options.CmdArgs,
-		envVars, containerLabels, permProfile,
+		ctx, runtime, containerName, containerInfo, options.CmdArgs,
+		permProfile,
 	); err != nil {
 		return fmt.Errorf("failed to set up transport: %v", err)
 	}

--- a/pkg/container/docker/errors.go
+++ b/pkg/container/docker/errors.go
@@ -1,0 +1,91 @@
+// Package docker provides Docker-specific implementation of container runtime.
+package docker
+
+import "fmt"
+
+// Error types for container operations
+var (
+	// ErrContainerNotFound is returned when attempting to operate on a container
+	// that does not exist in the runtime.
+	ErrContainerNotFound = fmt.Errorf("container not found")
+
+	// ErrContainerAlreadyExists is returned when attempting to create a container
+	// with a name that is already in use, but with different configuration.
+	ErrContainerAlreadyExists = fmt.Errorf("container already exists")
+
+	// ErrContainerNotRunning is returned when attempting to perform an operation
+	// that requires a running container (e.g., attaching to stdin/stdout).
+	ErrContainerNotRunning = fmt.Errorf("container not running")
+
+	// ErrContainerAlreadyRunning is returned when attempting to start a container
+	// that is already in a running state.
+	ErrContainerAlreadyRunning = fmt.Errorf("container already running")
+
+	// ErrRuntimeNotFound is returned when the container runtime (Docker/Podman)
+	// is not available on the system or cannot be accessed.
+	ErrRuntimeNotFound = fmt.Errorf("container runtime not found")
+
+	// ErrInvalidRuntimeType is returned when an unsupported or invalid runtime
+	// type is specified in the configuration.
+	ErrInvalidRuntimeType = fmt.Errorf("invalid runtime type")
+
+	// ErrAttachFailed is returned when the attempt to attach to a container's
+	// stdin/stdout/stderr streams fails.
+	ErrAttachFailed = fmt.Errorf("failed to attach to container")
+
+	// ErrContainerExited is returned when a container unexpectedly exits or
+	// stops while an operation is being performed.
+	ErrContainerExited = fmt.Errorf("container exited unexpectedly")
+)
+
+// ContainerError represents a detailed error related to container operations.
+// It provides context about the specific container and operation that failed.
+type ContainerError struct {
+	// Err is the underlying error that occurred
+	Err error
+
+	// ContainerID is the ID of the container involved in the error.
+	// This may be empty if the error occurred before a container was created.
+	ContainerID string
+
+	// Message is a human-readable description of what went wrong
+	Message string
+}
+
+// Error returns a formatted error message that includes the container ID
+// (if available) and additional context about what went wrong.
+func (e *ContainerError) Error() string {
+	if e.Message != "" {
+		if e.ContainerID != "" {
+			return fmt.Sprintf("%s: %s (container: %s)", e.Err, e.Message, e.ContainerID)
+		}
+		return fmt.Sprintf("%s: %s", e.Err, e.Message)
+	}
+
+	if e.ContainerID != "" {
+		return fmt.Sprintf("%s (container: %s)", e.Err, e.ContainerID)
+	}
+
+	return e.Err.Error()
+}
+
+// Unwrap returns the underlying error, allowing ContainerError to work with
+// the standard errors.Is and errors.As functions.
+func (e *ContainerError) Unwrap() error {
+	return e.Err
+}
+
+// NewContainerError creates a new ContainerError with the specified details.
+// This is a helper function to ensure consistent error creation throughout the package.
+//
+// Parameters:
+//   - err: The underlying error that occurred
+//   - containerID: The ID of the container involved (may be empty)
+//   - message: A human-readable description of what went wrong
+func NewContainerError(err error, containerID, message string) *ContainerError {
+	return &ContainerError{
+		Err:         err,
+		ContainerID: containerID,
+		Message:     message,
+	}
+}

--- a/pkg/container/docker/helpers.go
+++ b/pkg/container/docker/helpers.go
@@ -1,0 +1,261 @@
+// Package docker provides Docker-specific implementation of container runtime.
+package docker
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/mount"
+	"github.com/docker/go-connections/nat"
+
+	"github.com/stacklok/vibetool/pkg/container/runtime"
+)
+
+// convertEnvVars converts a map of environment variables to a slice of strings
+// in the format "KEY=VALUE" that Docker expects.
+//
+// Parameters:
+//   - envVars: Map of environment variable names to values
+//
+// Returns:
+//   - Slice of strings in "KEY=VALUE" format
+func convertEnvVars(envVars map[string]string) []string {
+	env := make([]string, 0, len(envVars))
+	for k, v := range envVars {
+		env = append(env, fmt.Sprintf("%s=%s", k, v))
+	}
+	return env
+}
+
+// convertMounts converts our internal mount format to Docker's mount format.
+// This ensures consistent mount handling across different container runtimes.
+//
+// Parameters:
+//   - mounts: Slice of internal mount configurations
+//
+// Returns:
+//   - Slice of Docker mount configurations
+func convertMounts(mounts []runtime.Mount) []mount.Mount {
+	result := make([]mount.Mount, 0, len(mounts))
+	for _, m := range mounts {
+		result = append(result, mount.Mount{
+			Type:     mount.TypeBind,
+			Source:   m.Source,
+			Target:   m.Target,
+			ReadOnly: m.ReadOnly,
+		})
+	}
+	return result
+}
+
+// setupExposedPorts configures exposed ports for a container.
+// This sets up which ports the container will listen on internally.
+//
+// Parameters:
+//   - config: Docker container configuration to modify
+//   - exposedPorts: Map of port specifications to empty structs
+//
+// Returns:
+//   - Error if port parsing fails
+func setupExposedPorts(config *container.Config, exposedPorts map[string]struct{}) error {
+	if len(exposedPorts) == 0 {
+		return nil
+	}
+
+	config.ExposedPorts = nat.PortSet{}
+	for port := range exposedPorts {
+		natPort, err := nat.NewPort("tcp", strings.Split(port, "/")[0])
+		if err != nil {
+			return fmt.Errorf("failed to parse port: %v", err)
+		}
+		config.ExposedPorts[natPort] = struct{}{}
+	}
+
+	return nil
+}
+
+// setupPortBindings configures port bindings for a container.
+// This maps container ports to host ports, allowing external access.
+//
+// Parameters:
+//   - hostConfig: Docker host configuration to modify
+//   - portBindings: Map of container ports to host binding specifications
+//
+// Returns:
+//   - Error if port parsing fails
+func setupPortBindings(hostConfig *container.HostConfig, portBindings map[string][]runtime.PortBinding) error {
+	if len(portBindings) == 0 {
+		return nil
+	}
+
+	hostConfig.PortBindings = nat.PortMap{}
+	for port, bindings := range portBindings {
+		natPort, err := nat.NewPort("tcp", strings.Split(port, "/")[0])
+		if err != nil {
+			return fmt.Errorf("failed to parse port: %v", err)
+		}
+
+		natBindings := make([]nat.PortBinding, len(bindings))
+		for i, binding := range bindings {
+			natBindings[i] = nat.PortBinding{
+				HostIP:   binding.HostIP,
+				HostPort: binding.HostPort,
+			}
+		}
+		hostConfig.PortBindings[natPort] = natBindings
+	}
+
+	return nil
+}
+
+// compareStringSlices compares two string slices for equality, ignoring order.
+// This is used for comparing commands, capabilities, and security options.
+//
+// Parameters:
+//   - a, b: String slices to compare
+//
+// Returns:
+//   - true if slices contain the same elements, false otherwise
+func compareStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	aMap := make(map[string]struct{}, len(a))
+	for _, s := range a {
+		aMap[s] = struct{}{}
+	}
+	for _, s := range b {
+		if _, ok := aMap[s]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// compareMounts compares Docker mount configurations with our internal mount format.
+// This ensures that container recreation uses identical mount points.
+//
+// Parameters:
+//   - actual: Docker mount configurations
+//   - expected: Internal mount configurations
+//
+// Returns:
+//   - true if mount configurations match, false otherwise
+func compareMounts(actual []container.MountPoint, expected []runtime.Mount) bool {
+	if len(actual) != len(expected) {
+		return false
+	}
+
+	// Create maps for easier comparison
+	actualMap := make(map[string]container.MountPoint)
+	for _, m := range actual {
+		actualMap[m.Destination] = m
+	}
+
+	// Compare each expected mount with its actual counterpart
+	for _, expectedMount := range expected {
+		actualMount, exists := actualMap[expectedMount.Target]
+		if !exists {
+			return false
+		}
+
+		// Compare mount properties
+		if actualMount.Source != expectedMount.Source ||
+			actualMount.RW == expectedMount.ReadOnly {
+			return false
+		}
+	}
+
+	return true
+}
+
+// compareEnvVars compares environment variables between actual and expected configurations.
+// This ensures that container recreation uses identical environment variables.
+//
+// Parameters:
+//   - actual: Current environment variables in container
+//   - expected: Desired environment variables
+//
+// Returns:
+//   - true if environment variables match, false otherwise
+func compareEnvVars(actual, expected []string) bool {
+	if len(actual) < len(expected) {
+		return false
+	}
+	expectedMap := make(map[string]string, len(expected))
+	for _, env := range expected {
+		parts := strings.SplitN(env, "=", 2)
+		if len(parts) == 2 {
+			expectedMap[parts[0]] = parts[1]
+		}
+	}
+	for _, env := range actual {
+		parts := strings.SplitN(env, "=", 2)
+		if len(parts) == 2 {
+			if expected, ok := expectedMap[parts[0]]; ok {
+				if expected != parts[1] {
+					return false
+				}
+			}
+		}
+	}
+	return true
+}
+
+// compareExposedPorts compares exposed ports between actual and expected configurations.
+// This ensures that container recreation exposes the same ports.
+//
+// Parameters:
+//   - actual: Current exposed ports in container
+//   - expected: Desired exposed ports
+//
+// Returns:
+//   - true if exposed ports match, false otherwise
+func compareExposedPorts(actual nat.PortSet, expected map[string]struct{}) bool {
+	if len(actual) != len(expected) {
+		return false
+	}
+	for port := range expected {
+		natPort, err := nat.NewPort("tcp", strings.Split(port, "/")[0])
+		if err != nil {
+			return false
+		}
+		if _, ok := actual[natPort]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// comparePortBindings compares port bindings between actual and expected configurations.
+// This ensures that container recreation uses identical port bindings.
+//
+// Parameters:
+//   - actual: Current port bindings in container
+//   - expected: Desired port bindings
+//
+// Returns:
+//   - true if port bindings match, false otherwise
+func comparePortBindings(actual nat.PortMap, expected map[string][]runtime.PortBinding) bool {
+	if len(actual) != len(expected) {
+		return false
+	}
+	for port, bindings := range expected {
+		natPort, err := nat.NewPort("tcp", strings.Split(port, "/")[0])
+		if err != nil {
+			return false
+		}
+		actualBindings, ok := actual[natPort]
+		if !ok || len(actualBindings) != len(bindings) {
+			return false
+		}
+		for i, binding := range bindings {
+			if actualBindings[i].HostIP != binding.HostIP ||
+				actualBindings[i].HostPort != binding.HostPort {
+				return false
+			}
+		}
+	}
+	return true
+}

--- a/pkg/container/kubernetes/client.go
+++ b/pkg/container/kubernetes/client.go
@@ -1,5 +1,4 @@
 // Package kubernetes provides a client for the Kubernetes runtime
-// including creating, starting, stopping, and retrieving container information.
 package kubernetes
 
 import (

--- a/pkg/container/runtime/types.go
+++ b/pkg/container/runtime/types.go
@@ -28,6 +28,8 @@ type ContainerInfo struct {
 	Labels map[string]string
 	// Ports is the container port mappings
 	Ports []PortMapping
+	// Env is the container environment variables
+	Env []string
 }
 
 // PortMapping represents a port mapping for a container


### PR DESCRIPTION
This makes some changes to vibetool in order to allow for restarting a
proxy+container combo. This makes the CreateContainer from the runtime
idempotent, as well as the StartContainer function. This applies to the
docker implementation.

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>
