### PR TITLE
Split the transport package mess

### DIFF
--- a/cmd/vt/proxy.go
+++ b/cmd/vt/proxy.go
@@ -11,7 +11,8 @@ import (
 
 	"github.com/stacklok/vibetool/pkg/auth"
 	"github.com/stacklok/vibetool/pkg/networking"
-	"github.com/stacklok/vibetool/pkg/transport"
+	"github.com/stacklok/vibetool/pkg/transport/proxy/transparent"
+	"github.com/stacklok/vibetool/pkg/transport/types"
 )
 
 var proxyCmd = &cobra.Command{
@@ -62,7 +63,7 @@ func proxyCmdFunc(cmd *cobra.Command, args []string) error {
 	defer cancel()
 
 	// Create middlewares slice
-	var middlewares []transport.Middleware
+	var middlewares []types.Middleware
 
 	// Create JWT validator if OIDC flags are provided
 	if IsOIDCEnabled(cmd) {
@@ -96,7 +97,7 @@ func proxyCmdFunc(cmd *cobra.Command, args []string) error {
 		port, proxyTargetURI)
 
 	// Create the transparent proxy with middlewares
-	proxy := transport.NewTransparentProxy(port, serverName, proxyTargetURI, middlewares...)
+	proxy := transparent.NewTransparentProxy(port, serverName, proxyTargetURI, middlewares...)
 	if err := proxy.Start(ctx); err != nil {
 		return fmt.Errorf("failed to start proxy: %v", err)
 	}

--- a/cmd/vt/run_common.go
+++ b/cmd/vt/run_common.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stacklok/vibetool/pkg/process"
 	"github.com/stacklok/vibetool/pkg/secrets"
 	"github.com/stacklok/vibetool/pkg/transport"
+	"github.com/stacklok/vibetool/pkg/transport/types"
 )
 
 // RunOptions contains all the options for running an MCP server
@@ -124,7 +125,7 @@ func RunMCPServer(ctx context.Context, cmd *cobra.Command, options RunOptions) e
 	}
 
 	// Parse transport mode
-	transportType, err := transport.ParseTransportType(options.Transport)
+	transportType, err := types.ParseTransportType(options.Transport)
 	if err != nil {
 		return fmt.Errorf("invalid transport mode: %s. Valid modes are: sse, stdio", options.Transport)
 	}
@@ -138,7 +139,7 @@ func RunMCPServer(ctx context.Context, cmd *cobra.Command, options RunOptions) e
 
 	// Select a target port for the container
 	targetPort := 0
-	if transportType == transport.TransportTypeSSE {
+	if transportType == types.TransportTypeSSE {
 		targetPort, err = networking.FindOrUsePort(options.TargetPort)
 		if err != nil {
 			return fmt.Errorf("target port error: %w", err)
@@ -161,7 +162,7 @@ func RunMCPServer(ctx context.Context, cmd *cobra.Command, options RunOptions) e
 	labels.AddStandardLabels(containerLabels, containerName, baseName, string(transportType), port)
 
 	// Create transport with runtime
-	transportConfig := transport.Config{
+	transportConfig := types.Config{
 		Type:       transportType,
 		Port:       port,
 		TargetPort: targetPort,

--- a/pkg/authz/middleware_test.go
+++ b/pkg/authz/middleware_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/stacklok/vibetool/pkg/auth"
-	"github.com/stacklok/vibetool/pkg/transport"
+	"github.com/stacklok/vibetool/pkg/transport/jsonrpc"
 )
 
 func TestMiddleware(t *testing.T) {
@@ -163,7 +163,7 @@ func TestMiddleware(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// Create a JSON-RPC request
-			request, err := transport.NewRequestMessage(tc.method, tc.params, 1)
+			request, err := jsonrpc.NewRequestMessage(tc.method, tc.params, 1)
 			require.NoError(t, err, "Failed to create JSON-RPC request")
 
 			// Marshal the request to JSON

--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -14,7 +14,7 @@ import (
 	"github.com/gofrs/flock"
 	"gopkg.in/yaml.v3"
 
-	"github.com/stacklok/vibetool/pkg/transport"
+	"github.com/stacklok/vibetool/pkg/transport/ssecommon"
 )
 
 // lockTimeout is the maximum time to wait for a file lock
@@ -370,5 +370,5 @@ func (c *ConfigFile) SaveWithLock(serverName, url string) error {
 func GenerateMCPServerURL(host string, port int, containerName string) string {
 	// The URL format is: http://host:port/sse#container-name
 	// Both SSE and STDIO transport types use an SSE proxy
-	return fmt.Sprintf("http://%s:%d%s#%s", host, port, transport.HTTPSSEEndpoint, containerName)
+	return fmt.Sprintf("http://%s:%d%s#%s", host, port, ssecommon.HTTPSSEEndpoint, containerName)
 }

--- a/pkg/client/config_test.go
+++ b/pkg/client/config_test.go
@@ -9,7 +9,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/stacklok/vibetool/pkg/transport"
+	"github.com/stacklok/vibetool/pkg/transport/ssecommon"
 )
 
 // setupTestConfig creates a temporary directory and config file for testing
@@ -84,7 +84,7 @@ func getMCPServers(t *testing.T, configPath string) map[string]interface{} {
 func testUpdateExistingServer(t *testing.T, config ConfigFile, configPath string) {
 	t.Helper()
 	// Test updating an existing server with lock
-	expectedURL := "http://localhost:54321" + transport.HTTPSSEEndpoint + "#test-container"
+	expectedURL := "http://localhost:54321" + ssecommon.HTTPSSEEndpoint + "#test-container"
 	err := config.SaveWithLock("existing-server", expectedURL)
 	if err != nil {
 		t.Fatalf("Failed to update MCP server config: %v", err)
@@ -111,7 +111,7 @@ func testUpdateExistingServer(t *testing.T, config ConfigFile, configPath string
 func testAddNewServer(t *testing.T, config ConfigFile, configPath string) {
 	t.Helper()
 	// Test adding a new server with lock
-	expectedURL := "http://localhost:9876" + transport.HTTPSSEEndpoint + "#new-container"
+	expectedURL := "http://localhost:9876" + ssecommon.HTTPSSEEndpoint + "#new-container"
 	err := config.SaveWithLock("new-server", expectedURL)
 	if err != nil {
 		t.Fatalf("Failed to add new MCP server config: %v", err)
@@ -229,14 +229,14 @@ func TestGenerateMCPServerURL(t *testing.T) {
 			host:          "localhost",
 			port:          12345,
 			containerName: "test-container",
-			expected:      "http://localhost:12345" + transport.HTTPSSEEndpoint + "#test-container",
+			expected:      "http://localhost:12345" + ssecommon.HTTPSSEEndpoint + "#test-container",
 		},
 		{
 			name:          "Different host",
 			host:          "192.168.1.100",
 			port:          54321,
 			containerName: "another-container",
-			expected:      "http://192.168.1.100:54321" + transport.HTTPSSEEndpoint + "#another-container",
+			expected:      "http://192.168.1.100:54321" + ssecommon.HTTPSSEEndpoint + "#another-container",
 		},
 	}
 

--- a/pkg/transport/errors/errors.go
+++ b/pkg/transport/errors/errors.go
@@ -1,0 +1,58 @@
+// Package errors provides error types and constants for the transport package.
+package errors
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Common transport errors
+var (
+	ErrUnsupportedTransport = errors.New("unsupported transport type")
+	ErrTransportNotStarted  = errors.New("transport not started")
+	ErrTransportClosed      = errors.New("transport closed")
+	ErrInvalidMessage       = errors.New("invalid message")
+	ErrRuntimeNotSet        = errors.New("container runtime not set")
+	ErrContainerIDNotSet    = errors.New("container ID not set")
+	ErrContainerNameNotSet  = errors.New("container name not set")
+)
+
+// TransportError represents an error related to transport operations
+type TransportError struct {
+	// Err is the underlying error
+	Err error
+	// ContainerID is the ID of the container
+	ContainerID string
+	// Message is an optional error message
+	Message string
+}
+
+// Error returns the error message
+func (e *TransportError) Error() string {
+	if e.Message != "" {
+		if e.ContainerID != "" {
+			return fmt.Sprintf("%s: %s (container: %s)", e.Err, e.Message, e.ContainerID)
+		}
+		return fmt.Sprintf("%s: %s", e.Err, e.Message)
+	}
+
+	if e.ContainerID != "" {
+		return fmt.Sprintf("%s (container: %s)", e.Err, e.ContainerID)
+	}
+
+	return e.Err.Error()
+}
+
+// Unwrap returns the underlying error
+func (e *TransportError) Unwrap() error {
+	return e.Err
+}
+
+// NewTransportError creates a new transport error
+func NewTransportError(err error, containerID, message string) *TransportError {
+	return &TransportError{
+		Err:         err,
+		ContainerID: containerID,
+		Message:     message,
+	}
+}

--- a/pkg/transport/factory.go
+++ b/pkg/transport/factory.go
@@ -1,0 +1,28 @@
+// Package transport provides utilities for handling different transport modes
+// for communication between the client and MCP server.
+package transport
+
+import (
+	"github.com/stacklok/vibetool/pkg/transport/errors"
+	"github.com/stacklok/vibetool/pkg/transport/types"
+)
+
+// Factory creates transports
+type Factory struct{}
+
+// NewFactory creates a new transport factory
+func NewFactory() *Factory {
+	return &Factory{}
+}
+
+// Create creates a transport based on the provided configuration
+func (*Factory) Create(config types.Config) (types.Transport, error) {
+	switch config.Type {
+	case types.TransportTypeStdio:
+		return NewStdioTransport(config.Port, config.Runtime, config.Debug, config.Middlewares...), nil
+	case types.TransportTypeSSE:
+		return NewSSETransport(config.Host, config.Port, config.TargetPort, config.Runtime, config.Debug, config.Middlewares...), nil
+	default:
+		return nil, errors.ErrUnsupportedTransport
+	}
+}

--- a/pkg/transport/jsonrpc/jsonrpc.go
+++ b/pkg/transport/jsonrpc/jsonrpc.go
@@ -1,4 +1,6 @@
-package transport
+// Package jsonrpc provides utilities for handling JSON-RPC messages
+// used in communication between the client and MCP server.
+package jsonrpc
 
 import (
 	"encoding/json"
@@ -6,6 +8,8 @@ import (
 )
 
 // JSONRPCMessage represents a JSON-RPC message
+//
+//nolint:revive // Intentionally named JSONRPCMessage despite package name
 type JSONRPCMessage struct {
 	JSONRPC string          `json:"jsonrpc"`
 	ID      interface{}     `json:"id,omitempty"`
@@ -16,6 +20,8 @@ type JSONRPCMessage struct {
 }
 
 // JSONRPCError represents a JSON-RPC error
+//
+//nolint:revive // Intentionally named JSONRPCError despite package name
 type JSONRPCError struct {
 	Code    int             `json:"code"`
 	Message string          `json:"message"`

--- a/pkg/transport/proxy/transparent/transparent_proxy.go
+++ b/pkg/transport/proxy/transparent/transparent_proxy.go
@@ -1,4 +1,6 @@
-package transport
+// Package transparent provides a transparent HTTP proxy implementation
+// that forwards requests to a destination without modifying them.
+package transparent
 
 import (
 	"context"
@@ -8,14 +10,16 @@ import (
 	"net/url"
 	"sync"
 	"time"
-)
 
-// Middleware is a function that wraps an http.Handler with additional functionality.
-type Middleware func(http.Handler) http.Handler
+	"github.com/stacklok/vibetool/pkg/transport/jsonrpc"
+	"github.com/stacklok/vibetool/pkg/transport/types"
+)
 
 // TransparentProxy implements the Proxy interface as a transparent HTTP proxy
 // that forwards requests to a destination.
 // It's used by the SSE transport to forward requests to the container's HTTP server.
+//
+//nolint:revive // Intentionally named TransparentProxy despite package name
 type TransparentProxy struct {
 	// Basic configuration
 	port          int
@@ -26,7 +30,7 @@ type TransparentProxy struct {
 	server *http.Server
 
 	// Middleware chain
-	middlewares []Middleware
+	middlewares []types.Middleware
 
 	// Mutex for protecting shared state
 	mutex sync.Mutex
@@ -40,7 +44,7 @@ func NewTransparentProxy(
 	port int,
 	containerName string,
 	targetURI string,
-	middlewares ...Middleware,
+	middlewares ...types.Middleware,
 ) *TransparentProxy {
 	return &TransparentProxy{
 		port:          port,
@@ -130,30 +134,30 @@ func (p *TransparentProxy) IsRunning(_ context.Context) (bool, error) {
 
 // GetMessageChannel returns the channel for messages to/from the destination.
 // This is not used in the TransparentProxy implementation as it forwards HTTP requests directly.
-func (*TransparentProxy) GetMessageChannel() chan *JSONRPCMessage {
+func (*TransparentProxy) GetMessageChannel() chan *jsonrpc.JSONRPCMessage {
 	return nil
 }
 
 // GetResponseChannel returns the channel for receiving messages from the destination.
 // This is not used in the TransparentProxy implementation as it forwards HTTP requests directly.
-func (*TransparentProxy) GetResponseChannel() <-chan *JSONRPCMessage {
+func (*TransparentProxy) GetResponseChannel() <-chan *jsonrpc.JSONRPCMessage {
 	return nil
 }
 
 // SendMessageToDestination sends a message to the destination.
 // This is not used in the TransparentProxy implementation as it forwards HTTP requests directly.
-func (*TransparentProxy) SendMessageToDestination(_ *JSONRPCMessage) error {
+func (*TransparentProxy) SendMessageToDestination(_ *jsonrpc.JSONRPCMessage) error {
 	return fmt.Errorf("SendMessageToDestination not implemented for TransparentProxy")
 }
 
 // ForwardResponseToClients forwards a response from the destination to clients.
 // This is not used in the TransparentProxy implementation as it forwards HTTP requests directly.
-func (*TransparentProxy) ForwardResponseToClients(_ context.Context, _ *JSONRPCMessage) error {
+func (*TransparentProxy) ForwardResponseToClients(_ context.Context, _ *jsonrpc.JSONRPCMessage) error {
 	return fmt.Errorf("ForwardResponseToClients not implemented for TransparentProxy")
 }
 
 // SendResponseMessage sends a message to the response channel.
 // This is not used in the TransparentProxy implementation as it forwards HTTP requests directly.
-func (*TransparentProxy) SendResponseMessage(_ *JSONRPCMessage) error {
+func (*TransparentProxy) SendResponseMessage(_ *jsonrpc.JSONRPCMessage) error {
 	return fmt.Errorf("SendResponseMessage not implemented for TransparentProxy")
 }

--- a/pkg/transport/ssecommon/sse_common.go
+++ b/pkg/transport/ssecommon/sse_common.go
@@ -1,4 +1,6 @@
-package transport
+// Package ssecommon provides common types and utilities for Server-Sent Events (SSE)
+// used in communication between the client and MCP server.
+package ssecommon
 
 import (
 	"fmt"


### PR DESCRIPTION
This builds smaller packages for the different components that encompass
dealing with MCP transports.

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>
