### PR TITLE
fix: Add retry with backoff when trying to attach to pod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,10 @@
 module github.com/stacklok/vibetool
 
 go 1.24.1
+
 require (
 	github.com/cedar-policy/cedar-go v1.1.1
+	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/docker/docker v28.0.4+incompatible
 	github.com/docker/go-connections v0.5.0
 	github.com/gofrs/flock v0.12.1


### PR DESCRIPTION
In cases where the k8s deployment takes a long time to run (e.g. because
downloading the image might take too long), this ensures
that we fail and retry some times until it succeeds or ultimately fails.

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>
