### PR TITLE
k8s: Use statefulset for MCPs

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -63,5 +63,3 @@ tasks:
       - echo "Applying Kubernetes manifest..."
       - kubectl apply -f <(KO_DOCKER_REPO=kind.local ko resolve --platform linux/amd64 -f deploy/k8s/vt.yml)
       # Wait for the deployment to be available
-      - echo "Waiting for deployment to be available..."
-      - kubectl wait --for=condition=ready --timeout=60s statefulset/vibetool


### PR DESCRIPTION
At the moment, MCPs are mostly stateful, so let's use a statefulset to
deploy them.

This removes waiting for the stateful set as they don't have conditions
like deployments to.

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>
