### PR TITLE
docs: adds basic ingress docs

### DIFF
--- a/docs/ingress.md
+++ b/docs/ingress.md
@@ -1,0 +1,53 @@
+# Setting up Ingress on a Local Kind Cluster
+
+> Disclaimer: ChrisB to refine when back home.
+
+Prereqs:
+- have a local kind cluster running and working, and running an MCP server with the proxy workload fronting it
+
+Run the local Kind Go binary that acts as a small LoadBalancer that gives IPs to ingress controllers inside of the cluster. This mimicks the behaviour of Cloud LBs
+
+```
+go install sigs.k8s.io/cloud-provider-kind@latest
+sudo ~/go/bin/cloud-provider-kind
+```
+
+Install the Nginx controller
+```
+kubectl apply -f https://kind.sigs.k8s.io/examples/ingress/deploy-ingress-nginx.yaml
+```
+
+When the ingress controller is running, you should have an external IP set for it. Take not of this IP.
+
+Add the following Ingress yaml that points to your vibetool service:
+```yaml
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: example-ingress
+spec:
+  ingressClassName: nginx
+  rules:
+  - http:
+      paths:
+      - pathType: Prefix
+        path: /sse
+        backend:
+          service:
+            name: vibetool
+            port:
+              number: 8080
+      - pathType: Prefix
+        path: /messages
+        backend:
+          service:
+            name: vibetool
+            port:
+              number: 8080
+```
+
+Now, you _should_ be able to curl the endpoint via `curl http://$EXTERNAL_IP/sse` and see a connection.
+
+## Chris To Do
+- adds the docs for the addition of a host name to make it look more ingressy, this avoids the IP requirement.g


### PR DESCRIPTION
I want to put something up for folks to try and don't want to block until I'm home (currently at KubeConn). This _should_ get folks somewhere. I can add the hostname docs later on to make it feel a bit more ingressy.

This doc should show how to add ingress to a local kind cluster using the dedicated kind LB that mimics cloud provider LB by assigning an external IP