### PR TITLE
fix: Don't check for statefulset in CreateContainer function in k8s runtime

### DIFF
--- a/pkg/container/kubernetes/client.go
+++ b/pkg/container/kubernetes/client.go
@@ -201,16 +201,7 @@ func (c *Client) CreateContainer(ctx context.Context,
 	_ *permissions.Profile,
 	_ string,
 	options *runtime.CreateContainerOptions) (string, error) {
-
-	fmt.Printf("Checking if container exists...\n")
-	// Check if a statefulset with this name already exists
 	namespace := getCurrentNamespace()
-	_, err := c.client.AppsV1().StatefulSets(namespace).Get(ctx, containerName, metav1.GetOptions{})
-	if err == nil {
-		return "", fmt.Errorf("statefulset %s already exists", containerName)
-	}
-	fmt.Printf("Container doesn't exist, creating container %s from image %s...\n", containerName, image)
-
 	containerLabels["app"] = containerName
 	containerLabels["vibetool"] = "true"
 


### PR DESCRIPTION
We use the apply construct which is idempotent, so we don't need to do
this. We'll just apply and it'll be fine.

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>
