### PR TITLE
Allow individual clients to be registered for autoconfiguration

### DIFF
--- a/cmd/vt/common.go
+++ b/cmd/vt/common.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/stacklok/vibetool/pkg/config"
 	"github.com/stacklok/vibetool/pkg/secrets"
 )
 
@@ -37,7 +38,7 @@ func IsOIDCEnabled(cmd *cobra.Command) bool {
 
 // GetSecretsProviderType returns the secrets provider type from the command flags
 func GetSecretsProviderType(_ *cobra.Command) (secrets.ProviderType, error) {
-	provider := GetConfig().Secrets.ProviderType
+	provider := config.GetConfig().Secrets.ProviderType
 	switch provider {
 	case string(secrets.BasicType):
 		return secrets.BasicType, nil

--- a/cmd/vt/main.go
+++ b/cmd/vt/main.go
@@ -5,8 +5,6 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-
-	"github.com/stacklok/vibetool/pkg/config"
 )
 
 var rootCmd = &cobra.Command{
@@ -34,27 +32,7 @@ var versionCmd = &cobra.Command{
 	},
 }
 
-// Singleton value - should only be written to by the init function.
-var appConfig *config.Config
-
-// GetConfig returns the application configuration.
-// This can only be called after it is initialized in the init function.
-func GetConfig() *config.Config {
-	if appConfig == nil {
-		panic("configuration is not initialized")
-	}
-	return appConfig
-}
-
 func init() {
-	// Initialize the application configuration.
-	var err error
-	appConfig, err = config.LoadOrCreateConfig()
-	if err != nil {
-		fmt.Printf("error loading configuration: %v\n", err)
-		os.Exit(1)
-	}
-
 	// Add persistent flags
 	rootCmd.PersistentFlags().Bool("debug", false, "Enable debug mode")
 

--- a/cmd/vt/run.go
+++ b/cmd/vt/run.go
@@ -34,7 +34,6 @@ var (
 	runTargetPort        int
 	runPermissionProfile string
 	runEnv               []string
-	runNoClientConfig    bool
 	runForeground        bool
 	runVolumes           []string
 	runSecrets           []string
@@ -58,12 +57,6 @@ func init() {
 		"e",
 		[]string{},
 		"Environment variables to pass to the MCP server (format: KEY=VALUE)",
-	)
-	runCmd.Flags().BoolVar(
-		&runNoClientConfig,
-		"no-client-config",
-		false,
-		"Do not update client configuration files with the MCP server URL",
 	)
 	runCmd.Flags().BoolVarP(&runForeground, "foreground", "f", false, "Run in foreground mode (block until container exits)")
 	runCmd.Flags().StringArrayVarP(
@@ -123,7 +116,6 @@ func runCmdFunc(cmd *cobra.Command, args []string) error {
 		runVolumes,
 		runSecrets,
 		runAuthzConfig,
-		runNoClientConfig,
 		runPermissionProfile,
 		oidcIssuer,
 		oidcAudience,

--- a/cmd/vt/run_common.go
+++ b/cmd/vt/run_common.go
@@ -90,10 +90,6 @@ func detachProcess(cmd *cobra.Command, options *runner.RunConfig) error {
 		detachedArgs = append(detachedArgs, "--env", fmt.Sprintf("%s=%s", key, value))
 	}
 
-	if options.NoClientConfig {
-		detachedArgs = append(detachedArgs, "--no-client-config")
-	}
-
 	// Add volume mounts if they were provided
 	for _, volume := range options.Volumes {
 		detachedArgs = append(detachedArgs, "--volume", volume)
@@ -257,11 +253,6 @@ func configureRunConfig(
 			return fmt.Errorf("failed to load authorization configuration: %v", err)
 		}
 		config.WithAuthz(authzConfig)
-	}
-
-	// Set NoClientConfig flag if not already set
-	if !config.NoClientConfig {
-		config.NoClientConfig = !GetConfig().Clients.AutoDiscovery
 	}
 
 	return nil

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -28,7 +28,8 @@ type Secrets struct {
 
 // Clients contains settings for client configuration.
 type Clients struct {
-	AutoDiscovery bool `yaml:"auto_discovery"`
+	AutoDiscovery     bool     `yaml:"auto_discovery"`
+	RegisteredClients []string `yaml:"registered_clients"`
 }
 
 // LoadOrCreateConfig fetches the application configuration.

--- a/pkg/config/singleton.go
+++ b/pkg/config/singleton.go
@@ -1,0 +1,28 @@
+package config
+
+import (
+	"fmt"
+	"os"
+)
+
+// Singleton value - should only be written to by the init function.
+var appConfig *Config
+
+// GetConfig returns the application configuration.
+// This can only be called after it is initialized in the init function.
+func GetConfig() *Config {
+	if appConfig == nil {
+		panic("configuration is not initialized")
+	}
+	return appConfig
+}
+
+func init() {
+	// Initialize the application configuration.
+	var err error
+	appConfig, err = LoadOrCreateConfig()
+	if err != nil {
+		fmt.Printf("error loading configuration: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/pkg/runner/config.go
+++ b/pkg/runner/config.go
@@ -74,9 +74,6 @@ type RunConfig struct {
 	// AuthzConfigPath is the path to the authorization configuration file
 	AuthzConfigPath string `json:"authz_config_path,omitempty" yaml:"authz_config_path,omitempty"`
 
-	// NoClientConfig indicates whether to update client configuration files
-	NoClientConfig bool `json:"no_client_config,omitempty" yaml:"no_client_config,omitempty"`
-
 	// Secrets are the secret parameters to pass to the container
 	// Format: "<secret name>,target=<target environment variable>"
 	Secrets []string `json:"secrets,omitempty" yaml:"secrets,omitempty"`
@@ -119,7 +116,6 @@ func NewRunConfigFromFlags(
 	volumes []string,
 	secretsList []string,
 	authzConfigPath string,
-	noClientConfig bool,
 	permissionProfile string,
 	oidcIssuer string,
 	oidcAudience string,
@@ -134,7 +130,6 @@ func NewRunConfigFromFlags(
 		Volumes:                     volumes,
 		Secrets:                     secretsList,
 		AuthzConfigPath:             authzConfigPath,
-		NoClientConfig:              noClientConfig,
 		PermissionProfileNameOrPath: permissionProfile,
 		ContainerLabels:             make(map[string]string),
 		EnvVars:                     make(map[string]string),
@@ -156,12 +151,6 @@ func NewRunConfigFromFlags(
 // WithAuthz adds authorization configuration to the RunConfig
 func (c *RunConfig) WithAuthz(config *authz.Config) *RunConfig {
 	c.AuthzConfig = config
-	return c
-}
-
-// WithNoClientConfig sets the NoClientConfig flag
-func (c *RunConfig) WithNoClientConfig(noClientConfig bool) *RunConfig {
-	c.NoClientConfig = noClientConfig
 	return c
 }
 

--- a/pkg/runner/config_test.go
+++ b/pkg/runner/config_test.go
@@ -805,7 +805,6 @@ func TestNewRunConfigFromFlags(t *testing.T) {
 	volumes := []string{"/host:/container"}
 	secretsList := []string{"secret1,target=ENV_VAR1"}
 	authzConfigPath := "/path/to/authz.json"
-	noClientConfig := true
 	permissionProfile := "stdio"
 	oidcIssuer := "https://issuer.example.com"
 	oidcAudience := "test-audience"
@@ -820,7 +819,6 @@ func TestNewRunConfigFromFlags(t *testing.T) {
 		volumes,
 		secretsList,
 		authzConfigPath,
-		noClientConfig,
 		permissionProfile,
 		oidcIssuer,
 		oidcAudience,
@@ -836,7 +834,6 @@ func TestNewRunConfigFromFlags(t *testing.T) {
 	assert.Equal(t, volumes, config.Volumes, "Volumes should match")
 	assert.Equal(t, secretsList, config.Secrets, "Secrets should match")
 	assert.Equal(t, authzConfigPath, config.AuthzConfigPath, "AuthzConfigPath should match")
-	assert.Equal(t, noClientConfig, config.NoClientConfig, "NoClientConfig should match")
 	assert.Equal(t, permissionProfile, config.PermissionProfileNameOrPath, "PermissionProfileNameOrPath should match")
 	assert.NotNil(t, config.ContainerLabels, "ContainerLabels should be initialized")
 	assert.NotNil(t, config.EnvVars, "EnvVars should be initialized")

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -103,11 +103,11 @@ func (r *Runner) Run(ctx context.Context) error {
 		fmt.Printf("Warning: Failed to save run configuration: %v\n", err)
 	}
 
-	// Update client configurations if not disabled
-	if !r.Config.NoClientConfig {
-		if err := updateClientConfigurations(r.Config.BaseName, "localhost", r.Config.Port); err != nil {
-			fmt.Printf("Warning: Failed to update client configurations: %v\n", err)
-		}
+	// Update client configurations with the MCP server URL.
+	// Note that this function checks the configuration to determine which
+	// clients should be updated, if any.
+	if err := updateClientConfigurations(r.Config.BaseName, "localhost", r.Config.Port); err != nil {
+		fmt.Printf("Warning: Failed to update client configurations: %v\n", err)
 	}
 
 	// Define a function to stop the MCP server


### PR DESCRIPTION
If a user does not want the auto-discovery mode enabled, they can now register individual clients for update with the `vt config register-client <client>` and unregister with `vt config remove-client <client>`. The logic for selecting configurations to alter has been changed to allow this new logic, and the `--no-client-configuration` flag has been removed to simplify the logic of deciding whether or not to change client configs.