### PR TITLE
Remove GetContainerIP from container interface

### DIFF
--- a/pkg/container/docker/client.go
+++ b/pkg/container/docker/client.go
@@ -497,28 +497,6 @@ func (c *Client) GetContainerInfo(ctx context.Context, containerID string) (runt
 	}, nil
 }
 
-// GetContainerIP gets container IP address
-func (c *Client) GetContainerIP(ctx context.Context, containerID string) (string, error) {
-	// Inspect container
-	info, err := c.client.ContainerInspect(ctx, containerID)
-	if err != nil {
-		// Check if the error is because the container doesn't exist
-		if client.IsErrNotFound(err) {
-			return "", NewContainerError(ErrContainerNotFound, containerID, "container not found")
-		}
-		return "", NewContainerError(err, containerID, fmt.Sprintf("failed to inspect container: %v", err))
-	}
-
-	// Get IP address from the default network
-	for _, netInfo := range info.NetworkSettings.Networks {
-		if netInfo.IPAddress != "" {
-			return netInfo.IPAddress, nil
-		}
-	}
-
-	return "", NewContainerError(fmt.Errorf("no IP address found"), containerID, "container has no IP address")
-}
-
 // readCloserWrapper wraps an io.Reader to implement io.ReadCloser
 type readCloserWrapper struct {
 	reader io.Reader

--- a/pkg/container/kubernetes/client.go
+++ b/pkg/container/kubernetes/client.go
@@ -295,32 +295,6 @@ func (c *Client) CreateContainer(ctx context.Context,
 	return createdStatefulSet.Name, nil
 }
 
-// GetContainerIP implements runtime.Runtime.
-func (c *Client) GetContainerIP(ctx context.Context, containerID string) (string, error) {
-	// In Kubernetes, containerID is the statefulset name
-	namespace := getCurrentNamespace()
-
-	// Get the pods associated with this statefulset
-	pods, err := c.client.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
-		LabelSelector: fmt.Sprintf("app=%s", containerID),
-	})
-	if err != nil {
-		return "", fmt.Errorf("failed to list pods for statefulset %s: %w", containerID, err)
-	}
-
-	if len(pods.Items) == 0 {
-		return "", fmt.Errorf("no pods found for statefulset %s", containerID)
-	}
-
-	// Use the first pod's IP
-	podIP := pods.Items[0].Status.PodIP
-	if podIP == "" {
-		return "", fmt.Errorf("pod for statefulset %s has no IP address", containerID)
-	}
-
-	return podIP, nil
-}
-
 // GetContainerInfo implements runtime.Runtime.
 func (c *Client) GetContainerInfo(ctx context.Context, containerID string) (runtime.ContainerInfo, error) {
 	// In Kubernetes, containerID is the statefulset name

--- a/pkg/container/runtime/types.go
+++ b/pkg/container/runtime/types.go
@@ -76,9 +76,6 @@ type Runtime interface {
 	// GetContainerInfo gets container information
 	GetContainerInfo(ctx context.Context, containerID string) (ContainerInfo, error)
 
-	// GetContainerIP gets container IP address
-	GetContainerIP(ctx context.Context, containerID string) (string, error)
-
 	// AttachContainer attaches to a container
 	AttachContainer(ctx context.Context, containerID string) (io.WriteCloser, io.ReadCloser, error)
 

--- a/pkg/runner/config_test.go
+++ b/pkg/runner/config_test.go
@@ -60,10 +60,6 @@ func (*mockRuntime) GetContainerInfo(_ context.Context, _ string) (rt.ContainerI
 	return rt.ContainerInfo{}, nil
 }
 
-func (*mockRuntime) GetContainerIP(_ context.Context, _ string) (string, error) {
-	return "127.0.0.1", nil
-}
-
 func (*mockRuntime) AttachContainer(_ context.Context, _ string) (io.WriteCloser, io.ReadCloser, error) {
 	return nil, nil, nil
 }


### PR DESCRIPTION
This was not used and not needed in the end.

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>
