### PR TITLE
fix: Look for the correct type when processing the claims during authz

### DIFF
--- a/pkg/authz/cedar.go
+++ b/pkg/authz/cedar.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 
 	cedar "github.com/cedar-policy/cedar-go"
+	"github.com/golang-jwt/jwt/v5"
 
 	"github.com/stacklok/vibetool/pkg/auth"
 )
@@ -269,20 +270,20 @@ func (a *CedarAuthorizer) IsAuthorized(
 
 // extractClaimsFromContext extracts JWT claims from the context.
 // This assumes that the JWT middleware has already run and added the claims to the context.
-func extractClaimsFromContext(ctx context.Context) (map[string]interface{}, bool) {
+func extractClaimsFromContext(ctx context.Context) (jwt.MapClaims, bool) {
 	// Import the auth package to use its ClaimsContextKey
 	// Get the claims from the context
-	claims, ok := ctx.Value(auth.ClaimsContextKey{}).(map[string]interface{})
+	claims, ok := ctx.Value(auth.ClaimsContextKey{}).(jwt.MapClaims)
 	return claims, ok
 }
 
 // extractClientIDFromClaims extracts the client ID from JWT claims.
 // By default, it uses the "sub" (subject) claim as the client ID.
 // This can be customized based on your JWT token structure.
-func extractClientIDFromClaims(claims map[string]interface{}) (string, bool) {
-	// Use the "sub" claim as the client ID
-	sub, ok := claims["sub"].(string)
-	if !ok || sub == "" {
+func extractClientIDFromClaims(claims jwt.MapClaims) (string, bool) {
+	// Use the GetSubject method to safely extract the "sub" claim
+	sub, err := claims.GetSubject()
+	if err != nil || sub == "" {
 		return "", false
 	}
 
@@ -291,7 +292,7 @@ func extractClientIDFromClaims(claims map[string]interface{}) (string, bool) {
 
 // preprocessClaims adds a "claim_" prefix to all claim keys.
 // This makes it clear which values are from the JWT claims.
-func preprocessClaims(claims map[string]interface{}) map[string]interface{} {
+func preprocessClaims(claims jwt.MapClaims) map[string]interface{} {
 	preprocessed := make(map[string]interface{})
 	for k, v := range claims {
 		claimKey := fmt.Sprintf("claim_%s", k)

--- a/pkg/authz/cedar_test.go
+++ b/pkg/authz/cedar_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -91,7 +92,7 @@ func TestAuthorizeWithJWTClaims(t *testing.T) {
 	testCases := []struct {
 		name             string
 		policy           string
-		claims           map[string]interface{}
+		claims           jwt.MapClaims
 		feature          MCPFeature
 		operation        MCPOperation
 		resourceID       string
@@ -110,7 +111,7 @@ func TestAuthorizeWithJWTClaims(t *testing.T) {
 				context.claim_name == "John Doe"
 			};
 			`,
-			claims: map[string]interface{}{
+			claims: jwt.MapClaims{
 				"sub":   "user123",
 				"name":  "John Doe",
 				"roles": []string{"user", "reader"},
@@ -133,7 +134,7 @@ func TestAuthorizeWithJWTClaims(t *testing.T) {
 				context.claim_name == "John Doe"
 			};
 			`,
-			claims: map[string]interface{}{
+			claims: jwt.MapClaims{
 				"sub":   "user123",
 				"name":  "Jane Smith",
 				"roles": []string{"user", "reader"},
@@ -205,7 +206,7 @@ func TestAuthorizeWithJWTClaims(t *testing.T) {
 				context.claim_groups.contains("editor")
 			};
 			`,
-			claims: map[string]interface{}{
+			claims: jwt.MapClaims{
 				"sub":    "user123",
 				"name":   "John Doe",
 				"groups": []string{"reader", "editor", "viewer"},
@@ -225,7 +226,7 @@ func TestAuthorizeWithJWTClaims(t *testing.T) {
 				resource == Prompt::"greeting"
 			);
 			`,
-			claims: map[string]interface{}{
+			claims: jwt.MapClaims{
 				"sub":  "user123",
 				"name": "John Doe",
 				"role": "user",
@@ -245,7 +246,7 @@ func TestAuthorizeWithJWTClaims(t *testing.T) {
 				resource == FeatureType::"tool"
 			);
 			`,
-			claims: map[string]interface{}{
+			claims: jwt.MapClaims{
 				"sub":  "user123",
 				"name": "John Doe",
 				"role": "user",
@@ -265,7 +266,7 @@ func TestAuthorizeWithJWTClaims(t *testing.T) {
 				resource == FeatureType::"prompt"
 			);
 			`,
-			claims: map[string]interface{}{
+			claims: jwt.MapClaims{
 				"sub":  "user123",
 				"name": "John Doe",
 				"role": "user",
@@ -285,7 +286,7 @@ func TestAuthorizeWithJWTClaims(t *testing.T) {
 				resource == FeatureType::"resource"
 			);
 			`,
-			claims: map[string]interface{}{
+			claims: jwt.MapClaims{
 				"sub":  "user123",
 				"name": "John Doe",
 				"role": "user",
@@ -362,7 +363,7 @@ func TestAuthorizeWithJWTClaimsErrors(t *testing.T) {
 			name: "Missing sub claim",
 			setupCtx: func(ctx context.Context) context.Context {
 				// Add claims without sub
-				claims := map[string]interface{}{
+				claims := jwt.MapClaims{
 					"name": "John Doe",
 					"role": "user",
 				}
@@ -379,7 +380,7 @@ func TestAuthorizeWithJWTClaimsErrors(t *testing.T) {
 			name: "Empty sub claim",
 			setupCtx: func(ctx context.Context) context.Context {
 				// Add claims with empty sub
-				claims := map[string]interface{}{
+				claims := jwt.MapClaims{
 					"sub":  "",
 					"name": "John Doe",
 					"role": "user",
@@ -397,7 +398,7 @@ func TestAuthorizeWithJWTClaimsErrors(t *testing.T) {
 			name: "Unsupported feature/operation combination",
 			setupCtx: func(ctx context.Context) context.Context {
 				// Add valid claims
-				claims := map[string]interface{}{
+				claims := jwt.MapClaims{
 					"sub":  "user123",
 					"name": "John Doe",
 					"role": "user",

--- a/pkg/authz/middleware_test.go
+++ b/pkg/authz/middleware_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/jsonrpc2"
@@ -33,7 +34,7 @@ func TestMiddleware(t *testing.T) {
 		name             string
 		method           string
 		params           map[string]interface{}
-		claims           map[string]interface{}
+		claims           jwt.MapClaims
 		expectStatus     int
 		expectAuthorized bool
 	}{
@@ -46,7 +47,7 @@ func TestMiddleware(t *testing.T) {
 					"location": "New York",
 				},
 			},
-			claims: map[string]interface{}{
+			claims: jwt.MapClaims{
 				"sub":  "user123",
 				"name": "John Doe",
 			},
@@ -64,7 +65,7 @@ func TestMiddleware(t *testing.T) {
 					"value2":    10,
 				},
 			},
-			claims: map[string]interface{}{
+			claims: jwt.MapClaims{
 				"sub":  "user123",
 				"name": "John Doe",
 			},
@@ -77,7 +78,7 @@ func TestMiddleware(t *testing.T) {
 			params: map[string]interface{}{
 				"name": "greeting",
 			},
-			claims: map[string]interface{}{
+			claims: jwt.MapClaims{
 				"sub":  "user123",
 				"name": "John Doe",
 			},
@@ -90,7 +91,7 @@ func TestMiddleware(t *testing.T) {
 			params: map[string]interface{}{
 				"name": "farewell",
 			},
-			claims: map[string]interface{}{
+			claims: jwt.MapClaims{
 				"sub":  "user123",
 				"name": "John Doe",
 			},
@@ -103,7 +104,7 @@ func TestMiddleware(t *testing.T) {
 			params: map[string]interface{}{
 				"uri": "data",
 			},
-			claims: map[string]interface{}{
+			claims: jwt.MapClaims{
 				"sub":  "user123",
 				"name": "John Doe",
 			},
@@ -116,7 +117,7 @@ func TestMiddleware(t *testing.T) {
 			params: map[string]interface{}{
 				"uri": "secret",
 			},
-			claims: map[string]interface{}{
+			claims: jwt.MapClaims{
 				"sub":  "user123",
 				"name": "John Doe",
 			},
@@ -127,7 +128,7 @@ func TestMiddleware(t *testing.T) {
 			name:   "Ping is always allowed",
 			method: "ping",
 			params: map[string]interface{}{},
-			claims: map[string]interface{}{
+			claims: jwt.MapClaims{
 				"sub":  "user123",
 				"name": "John Doe",
 			},
@@ -150,7 +151,7 @@ func TestMiddleware(t *testing.T) {
 					"version": "1.0.0",
 				},
 			},
-			claims: map[string]interface{}{
+			claims: jwt.MapClaims{
 				"sub":  "user123",
 				"name": "John Doe",
 			},


### PR DESCRIPTION
I had used map of any instead of the actual type

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>
