### PR TITLE
If no secrets are needed, don't ask for the password

### DIFF
--- a/cmd/thv/common.go
+++ b/cmd/thv/common.go
@@ -51,7 +51,12 @@ func GetSecretsProviderType(_ *cobra.Command) (secrets.ProviderType, error) {
 }
 
 // NeedSecretsPassword returns true if the secrets provider requires a password.
-func NeedSecretsPassword(cmd *cobra.Command) bool {
+func NeedSecretsPassword(cmd *cobra.Command, secretOptions []string) bool {
+	// If the user did not ask for any secrets, then don't attempt to instantiate
+	// the secrets manager.
+	if len(secretOptions) == 0 {
+		return false
+	}
 	// Ignore err - if the flag is not set, it's not needed.
 	providerType, _ := GetSecretsProviderType(cmd)
 	return providerType == secrets.EncryptedType

--- a/cmd/thv/run_common.go
+++ b/cmd/thv/run_common.go
@@ -135,7 +135,7 @@ func detachProcess(cmd *cobra.Command, options *runner.RunConfig) error {
 	detachedCmd.Env = append(os.Environ(), "TOOLHIVE_DETACHED=1")
 
 	// If the process needs the decrypt password, pass it as an environment variable.
-	if NeedSecretsPassword(cmd) {
+	if NeedSecretsPassword(cmd, options.Secrets) {
 		password, err := secrets.GetSecretsPassword()
 		if err != nil {
 			return fmt.Errorf("failed to get secrets password: %v", err)


### PR DESCRIPTION
This was the original behaviour of the encrypted secrets manager, but one of the changes I introduced broke it, and led to the encryption password being loaded when it was not needed. This ensures that secret management does not get loaded unnecessarily.