### PR TITLE
Change the everything MCP registry's transport to stdio

### DIFF
--- a/pkg/registry/data/registry.json
+++ b/pkg/registry/data/registry.json
@@ -465,7 +465,7 @@
     "everything": {
       "image": "mcp/everything:latest",
       "description": "This MCP server attempts to exercise all the features of the MCP protocol",
-      "transport": "sse",
+      "transport": "stdio",
       "permissions": {
         "read": [],
         "write": [],


### PR DESCRIPTION
The package itself supports SSE but it's not what's packaged by default
in the dockerfile.

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>
