### PR TITLE
Remove StartContainer from container interface

### DIFF
--- a/pkg/container/docker/client.go
+++ b/pkg/container/docker/client.go
@@ -292,29 +292,13 @@ func (c *Client) CreateContainer(
 		return "", NewContainerError(err, "", fmt.Sprintf("failed to create container: %v", err))
 	}
 
-	return resp.ID, nil
-}
-
-// StartContainer starts a container
-// If the container is already running, it returns success
-func (c *Client) StartContainer(ctx context.Context, containerID string) error {
-	// Check if the container is already running
-	running, err := c.IsContainerRunning(ctx, containerID)
-	if err != nil {
-		return err
-	}
-
-	// If the container is already running, return success
-	if running {
-		return nil
-	}
-
 	// Start the container
-	err = c.client.ContainerStart(ctx, containerID, container.StartOptions{})
+	err = c.client.ContainerStart(ctx, resp.ID, container.StartOptions{})
 	if err != nil {
-		return NewContainerError(err, containerID, fmt.Sprintf("failed to start container: %v", err))
+		return "", NewContainerError(err, resp.ID, fmt.Sprintf("failed to start container: %v", err))
 	}
-	return nil
+
+	return resp.ID, nil
 }
 
 // ListContainers lists containers

--- a/pkg/container/kubernetes/client.go
+++ b/pkg/container/kubernetes/client.go
@@ -523,14 +523,6 @@ func (c *Client) RemoveContainer(ctx context.Context, containerID string) error 
 	return nil
 }
 
-// StartContainer implements runtime.Runtime.
-func (*Client) StartContainer(_ context.Context, containerID string) error {
-	// In Kubernetes, we don't need to explicitly start containers as they are started
-	// automatically when created. However, we could scale up a statefulset if it's scaled to 0.
-	logger.Log.Info(fmt.Sprintf("Container %s is managed by Kubernetes and started automatically", containerID))
-	return nil
-}
-
 // StopContainer implements runtime.Runtime.
 func (*Client) StopContainer(_ context.Context, _ string) error {
 	return nil

--- a/pkg/container/runtime/types.go
+++ b/pkg/container/runtime/types.go
@@ -55,9 +55,6 @@ type Runtime interface {
 		options *CreateContainerOptions,
 	) (string, error)
 
-	// StartContainer starts a container
-	StartContainer(ctx context.Context, containerID string) error
-
 	// ListContainers lists containers
 	ListContainers(ctx context.Context) ([]ContainerInfo, error)
 

--- a/pkg/transport/sse.go
+++ b/pkg/transport/sse.go
@@ -178,12 +178,6 @@ func (t *SSETransport) Start(ctx context.Context) error {
 		return fmt.Errorf("container runtime not set")
 	}
 
-	// Start the container
-	logger.Log.Info(fmt.Sprintf("Starting container %s...", t.containerName))
-	if err := t.runtime.StartContainer(ctx, t.containerID); err != nil {
-		return fmt.Errorf("failed to start container: %v", err)
-	}
-
 	// Create and start the transparent proxy
 	// The SSE transport forwards requests from the host port to the container's target port
 	// In a Docker bridge network, we need to use the specified target host

--- a/pkg/transport/stdio.go
+++ b/pkg/transport/stdio.go
@@ -141,12 +141,6 @@ func (t *StdioTransport) Start(ctx context.Context) error {
 		return fmt.Errorf("container runtime not set")
 	}
 
-	// Start the container
-	logger.Log.Info(fmt.Sprintf("Starting container %s...", t.containerName))
-	if err := t.runtime.StartContainer(ctx, t.containerID); err != nil {
-		return fmt.Errorf("failed to start container: %v", err)
-	}
-
 	// Attach to the container
 	var err error
 	t.stdin, t.stdout, err = t.runtime.AttachContainer(ctx, t.containerID)


### PR DESCRIPTION
This has now been converged into `CreateContainer` since we want to make
it idempotent and simpler.

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>
