### PR TITLE
removes autoremove on run

### DIFF
--- a/cmd/thv/run.go
+++ b/cmd/thv/run.go
@@ -40,11 +40,9 @@ var (
 	runVolumes           []string
 	runSecrets           []string
 	runAuthzConfig       string
-	autoRemove           bool
 )
 
 func init() {
-	runCmd.Flags().BoolVar(&autoRemove, "rm", false, "Auto-remove the server container when the server has been stopped")
 	runCmd.Flags().StringVar(&runTransport, "transport", "stdio", "Transport mode (sse or stdio)")
 	runCmd.Flags().StringVar(&runName, "name", "", "Name of the MCP server (auto-generated from image if not provided)")
 	runCmd.Flags().IntVar(&runPort, "port", 0, "Port for the HTTP proxy to listen on (host port)")
@@ -122,7 +120,6 @@ func runCmdFunc(cmd *cobra.Command, args []string) error {
 		cmdArgs,
 		runName,
 		debugMode,
-		autoRemove,
 		runVolumes,
 		runSecrets,
 		runAuthzConfig,

--- a/cmd/thv/run_common.go
+++ b/cmd/thv/run_common.go
@@ -71,10 +71,6 @@ func detachProcess(cmd *cobra.Command, options *runner.RunConfig) error {
 		detachedArgs = append(detachedArgs, "--debug")
 	}
 
-	if options.AutoRemove {
-		detachedArgs = append(detachedArgs, "--rm")
-	}
-
 	// Use Name if available
 	if options.Name != "" {
 		detachedArgs = append(detachedArgs, "--name", options.Name)

--- a/pkg/container/docker/client.go
+++ b/pkg/container/docker/client.go
@@ -238,7 +238,6 @@ func (c *Client) CreateContainer(
 
 	// Create host configuration
 	hostConfig := &container.HostConfig{
-		AutoRemove:  false,
 		Mounts:      convertMounts(permissionConfig.Mounts),
 		NetworkMode: container.NetworkMode(permissionConfig.NetworkMode),
 		CapAdd:      permissionConfig.CapAdd,

--- a/pkg/runner/config.go
+++ b/pkg/runner/config.go
@@ -62,9 +62,6 @@ type RunConfig struct {
 	// Debug indicates whether debug mode is enabled
 	Debug bool `json:"debug,omitempty" yaml:"debug,omitempty"`
 
-	// AutoRemove indicates whether the container should be removed when the server has been stopped
-	AutoRemove bool `json:"auto_remove,omitempty" yaml:"auto_remove,omitempty"`
-
 	// Volumes are the directory mounts to pass to the container
 	// Format: "host-path:container-path[:ro]"
 	Volumes []string `json:"volumes,omitempty" yaml:"volumes,omitempty"`
@@ -120,7 +117,6 @@ func NewRunConfigFromFlags(
 	cmdArgs []string,
 	name string,
 	debug bool,
-	autoRemove bool,
 	volumes []string,
 	secretsList []string,
 	authzConfigPath string,
@@ -136,7 +132,6 @@ func NewRunConfigFromFlags(
 		CmdArgs:                     cmdArgs,
 		Name:                        name,
 		Debug:                       debug,
-		AutoRemove:                  autoRemove,
 		Volumes:                     volumes,
 		Secrets:                     secretsList,
 		AuthzConfigPath:             authzConfigPath,

--- a/pkg/runner/config_test.go
+++ b/pkg/runner/config_test.go
@@ -801,7 +801,6 @@ func TestNewRunConfigFromFlags(t *testing.T) {
 	cmdArgs := []string{"arg1", "arg2"}
 	name := "test-server"
 	debug := true
-	autoRemove := true
 	volumes := []string{"/host:/container"}
 	secretsList := []string{"secret1,target=ENV_VAR1"}
 	authzConfigPath := "/path/to/authz.json"
@@ -817,7 +816,6 @@ func TestNewRunConfigFromFlags(t *testing.T) {
 		cmdArgs,
 		name,
 		debug,
-		autoRemove,
 		volumes,
 		secretsList,
 		authzConfigPath,

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -43,7 +43,6 @@ func (r *Runner) Run(ctx context.Context) error {
 		TargetHost: r.Config.TargetHost,
 		Runtime:    r.Config.Runtime,
 		Debug:      r.Config.Debug,
-		AutoRemove: r.Config.AutoRemove,
 	}
 
 	// Add OIDC middleware if OIDC validation is enabled

--- a/pkg/transport/factory.go
+++ b/pkg/transport/factory.go
@@ -19,7 +19,7 @@ func NewFactory() *Factory {
 func (*Factory) Create(config types.Config) (types.Transport, error) {
 	switch config.Type {
 	case types.TransportTypeStdio:
-		return NewStdioTransport(config.Port, config.Runtime, config.Debug, config.AutoRemove, config.Middlewares...), nil
+		return NewStdioTransport(config.Port, config.Runtime, config.Debug, config.Middlewares...), nil
 	case types.TransportTypeSSE:
 		return NewSSETransport(
 			config.Host,
@@ -27,7 +27,6 @@ func (*Factory) Create(config types.Config) (types.Transport, error) {
 			config.TargetPort,
 			config.Runtime,
 			config.Debug,
-			config.AutoRemove,
 			config.TargetHost,
 			config.Middlewares...,
 		), nil

--- a/pkg/transport/sse.go
+++ b/pkg/transport/sse.go
@@ -30,7 +30,6 @@ type SSETransport struct {
 	containerName string
 	runtime       rt.Runtime
 	debug         bool
-	autoRemove    bool
 	middlewares   []types.Middleware
 
 	// Mutex for protecting shared state
@@ -54,7 +53,6 @@ func NewSSETransport(
 	targetPort int,
 	runtime rt.Runtime,
 	debug bool,
-	autoRemove bool,
 	targetHost string,
 	middlewares ...types.Middleware,
 ) *SSETransport {
@@ -75,7 +73,6 @@ func NewSSETransport(
 		targetHost:  targetHost,
 		runtime:     runtime,
 		debug:       debug,
-		autoRemove:  autoRemove,
 		shutdownCh:  make(chan struct{}),
 	}
 }
@@ -248,17 +245,6 @@ func (t *SSETransport) Stop(ctx context.Context) error {
 	if t.runtime != nil && t.containerID != "" {
 		if err := t.runtime.StopContainer(ctx, t.containerID); err != nil {
 			return fmt.Errorf("failed to stop container: %w", err)
-		}
-
-		// Remove the container if auto-remove is enabled
-		if t.autoRemove {
-			logger.Log.Info(fmt.Sprintf("Removing container %s...", t.containerName))
-			if err := t.runtime.RemoveContainer(ctx, t.containerID); err != nil {
-				logger.Log.Warn(fmt.Sprintf("Warning: Failed to remove container: %v", err))
-			}
-			logger.Log.Info(fmt.Sprintf("Container %s removed", t.containerName))
-		} else {
-			logger.Log.Info(fmt.Sprintf("Auto-remove disabled, container %s not removed", t.containerName))
 		}
 	}
 

--- a/pkg/transport/stdio.go
+++ b/pkg/transport/stdio.go
@@ -29,7 +29,6 @@ type StdioTransport struct {
 	containerName string
 	runtime       rt.Runtime
 	debug         bool
-	autoRemove    bool
 	middlewares   []types.Middleware
 
 	// Mutex for protecting shared state
@@ -55,14 +54,12 @@ func NewStdioTransport(
 	port int,
 	runtime rt.Runtime,
 	debug bool,
-	autoRemove bool,
 	middlewares ...types.Middleware,
 ) *StdioTransport {
 	return &StdioTransport{
 		port:        port,
 		runtime:     runtime,
 		debug:       debug,
-		autoRemove:  autoRemove,
 		middlewares: middlewares,
 		shutdownCh:  make(chan struct{}),
 	}
@@ -237,18 +234,6 @@ func (t *StdioTransport) Stop(ctx context.Context) error {
 			if err := t.runtime.StopContainer(ctx, t.containerID); err != nil {
 				logger.Log.Warn(fmt.Sprintf("Warning: Failed to stop container: %v", err))
 			}
-		}
-
-		// Remove the container if auto-remove is enabled
-		if t.autoRemove {
-			logger.Log.Info(fmt.Sprintf("Removing container %s...", t.containerName))
-			if err := t.runtime.RemoveContainer(ctx, t.containerID); err != nil {
-				logger.Log.Error(fmt.Sprintf("Warning: Failed to remove container: %v", err))
-			} else {
-				logger.Log.Info(fmt.Sprintf("Container %s removed", t.containerName))
-			}
-		} else {
-			logger.Log.Info(fmt.Sprintf("Auto-remove disabled, container %s not removed", t.containerName))
 		}
 	}
 

--- a/pkg/transport/types/transport.go
+++ b/pkg/transport/types/transport.go
@@ -123,9 +123,6 @@ type Config struct {
 	// If debug mode is enabled, containers will not be removed when stopped.
 	Debug bool
 
-	// AutoRemove indicates whether the container should be removed when the server has been stopped.
-	AutoRemove bool
-
 	// Middlewares is a list of middleware functions to apply to the transport.
 	// These are applied in order, with the first middleware being the outermost wrapper.
 	Middlewares []Middleware


### PR DESCRIPTION
We want to make the removing of a container/mcp server explicitly driven via `thv rm`. in this case we can properly clean up client configs. otherwise when `thv stop` is run, the container gets removed but not the client configs for them, leaving orphaned configs that users have to clean up manually