### PR TITLE
docker: Restart container if it's found but not running already

### DIFF
--- a/pkg/container/docker/client.go
+++ b/pkg/container/docker/client.go
@@ -1062,6 +1062,16 @@ func (c *Client) handleExistingContainer(
 	// Compare configurations
 	if compareContainerConfig(&info, desiredConfig, desiredHostConfig) {
 		// Configurations match, container can be reused
+
+		// Check if the container is running
+		if !info.State.Running {
+			// Container exists but is not running, start it
+			err = c.client.ContainerStart(ctx, containerID, container.StartOptions{})
+			if err != nil {
+				return false, NewContainerError(err, containerID, fmt.Sprintf("failed to start existing container: %v", err))
+			}
+		}
+
 		return true, nil
 	}
 


### PR DESCRIPTION
This was working at some point but I broke it when simplifying the
signature for the container runtime interface.

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>
