### PR TITLE
feat: adds doc auto generation for CLI commands

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# This file is documented at https://git-scm.com/docs/gitattributes.
+# Linguist-specific attributes are documented at
+# https://github.com/github/linguist.
+
+docs/cli/thv*.md linguist-generated=true

--- a/.github/workflows/image-build-and-publish.yml
+++ b/.github/workflows/image-build-and-publish.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Build and Push Image to GHCR
         run: |
           TAG=$(echo "${{ steps.version-string.outputs.tag }}" | sed 's/+/_/g')
-          KO_DOCKER_REPO=$BASE_REPO ko build --platform=linux/amd64,linux/arm64 --bare -t $TAG ./cmd/thv \
+          KO_DOCKER_REPO=$BASE_REPO ko build --platform=linux/amd64,linux/arm64 --bare -t $TAG ./cmd \
             --image-label=org.opencontainers.image.source=https://github.com/StacklokLabs/toolhive,org.opencontainers.image.title="toolhive",org.opencontainers.image.vendor=Stacklok
 
       - name: Sign Image with Cosign

--- a/.github/workflows/run-on-pr.yml
+++ b/.github/workflows/run-on-pr.yml
@@ -12,3 +12,6 @@ jobs:
   tests:
     name: Tests
     uses: ./.github/workflows/test.yml
+  docs:
+    name: Docs
+    uses: ./.github/workflows/verify-docgen.yml

--- a/.github/workflows/verify-docgen.yml
+++ b/.github/workflows/verify-docgen.yml
@@ -1,0 +1,16 @@
+name: Docgen
+
+on:
+  workflow_call:
+
+jobs:
+  docgen:
+    name: Verify Docgen
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5
+        with:
+          go-version: '1.24.x'
+      - run: ./cmd/help/verify.sh

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -22,7 +22,7 @@ builds:
     goarch:
       - amd64
       - arm64
-    main: ./cmd/thv
+    main: ./cmd
     binary: thv
 # This section defines the release format.
 archives:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,6 +1,12 @@
 version: '3'
 
 tasks:
+
+  docs:
+    desc: Generate the docs
+    cmds:
+      - go run cmd/help/main.go --dir docs/cli
+
   lint:
     desc: Run linting tools
     cmds:
@@ -37,7 +43,7 @@ tasks:
         sh: date -u +"%Y-%m-%dT%H:%M:%SZ"
     cmds:
       - mkdir -p bin
-      - go build -ldflags "-s -w -X github.com/StacklokLabs/toolhive/cmd/thv.Version={{.VERSION}} -X github.com/stacklok/toolhive/cmd/thv.Commit={{.COMMIT}} -X github.com/stacklok/toolhive/cmd/thv.BuildDate={{.BUILD_DATE}}" -o bin/thv ./cmd/thv
+      - go build -ldflags "-s -w -X github.com/StacklokLabs/toolhive/cmd/thv.Version={{.VERSION}} -X github.com/StacklokLabs/toolhive/cmd/thv.Commit={{.COMMIT}} -X github.com/StacklokLabs/toolhive/cmd/thv.BuildDate={{.BUILD_DATE}}" -o bin/thv ./cmd
 
   install:
     desc: Install the thv binary to GOPATH/bin
@@ -49,7 +55,7 @@ tasks:
       BUILD_DATE:
         sh: date -u +"%Y-%m-%dT%H:%M:%SZ"
     cmds:
-      - go install -ldflags "-s -w -X github.com/StacklokLabs/toolhive/cmd/thv.Version={{.VERSION}} -X github.com/stacklok/toolhive/cmd/thv.Commit={{.COMMIT}} -X github.com/stacklok/toolhive/cmd/thv.BuildDate={{.BUILD_DATE}}" -v ./cmd/thv
+      - go install -ldflags "-s -w -X github.com/StacklokLabs/toolhive/cmd/thv.Version={{.VERSION}} -X github.com/StacklokLabs/toolhive/cmd/thv.Commit={{.COMMIT}} -X github.com/StacklokLabs/toolhive/cmd/thv.BuildDate={{.BUILD_DATE}}" -v ./cmd
 
   all:
     desc: Run linting, tests, and build
@@ -62,13 +68,13 @@ tasks:
   build-image:
     desc: Build the image with ko
     cmds:
-      - ko build --platform linux/amd64,linux/arm64 --local ./cmd/thv
+      - ko build --platform linux/amd64,linux/arm64 --local ./cmd
 
   test-k8s-apply:
     desc: Builds the image, loads it into kind, and applies the Kubernetes manifests
     vars:
       IMAGE:
-        sh: ko build --platform linux/amd64 --local -B ./cmd/thv | tail -n 1
+        sh: ko build --platform linux/amd64 --local -B ./cmd | tail -n 1
     cmds:
       # gets the local kind kubeconfig
       - kind get kubeconfig > kconfig.yaml

--- a/cmd/help/main.go
+++ b/cmd/help/main.go
@@ -1,0 +1,30 @@
+// Package main is the entry point for the ToolHive CLI Doc Generator.
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/cobra/doc"
+
+	cli "github.com/StacklokLabs/toolhive/cmd/thv"
+)
+
+func main() {
+	var dir string
+	root := &cobra.Command{
+		Use:          "gendoc",
+		Short:        "Generate ToolHive's help docs",
+		SilenceUsage: true,
+		Args:         cobra.NoArgs,
+		RunE: func(*cobra.Command, []string) error {
+			return doc.GenMarkdownTree(cli.NewRootCmd(), dir)
+		},
+	}
+	root.Flags().StringVarP(&dir, "dir", "d", "doc", "Path to directory in which to generate docs")
+	if err := root.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}

--- a/cmd/help/verify.sh
+++ b/cmd/help/verify.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -e
+
+# Verify that generated Markdown docs are up-to-date.
+tmpdir=$(mktemp -d)
+go run cmd/help/main.go --dir "$tmpdir"
+echo "###########################################"
+echo "If diffs are found, run: `task docs`"
+echo "###########################################"
+diff -Naur "$tmpdir" docs/cli/

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,0 +1,19 @@
+// Package main is the entry point for the ToolHive CLI.
+package main
+
+import (
+	"os"
+
+	cli "github.com/StacklokLabs/toolhive/cmd/thv"
+	"github.com/StacklokLabs/toolhive/pkg/logger"
+)
+
+func main() {
+	// Initialize the logger system
+	logger.Initialize()
+
+	if err := cli.NewRootCmd().Execute(); err != nil {
+		logger.Log.Error("%v, %v", os.Stderr, err)
+		os.Exit(1)
+	}
+}

--- a/cmd/thv/commands.go
+++ b/cmd/thv/commands.go
@@ -1,8 +1,8 @@
-package main
+// Package cli provides the entry point for the toolhive command-line application.
+package cli
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 
@@ -10,8 +10,9 @@ import (
 )
 
 var rootCmd = &cobra.Command{
-	Use:   "thv",
-	Short: "ToolHive (thv) is a lightweight, secure, and fast manager for MCP servers",
+	Use:               "thv",
+	DisableAutoGenTag: true,
+	Short:             "ToolHive (thv) is a lightweight, secure, and fast manager for MCP servers",
 	Long: `ToolHive (thv) is a lightweight, secure, and fast manager for MCP (Model Context Protocol) servers.
 It is written in Go and has extensive test coverage—including input validation—to ensure reliability and security.
 
@@ -26,10 +27,8 @@ container-based isolation for running MCP servers.`,
 	},
 }
 
-func init() {
-	// Initialize the logger system
-	logger.Initialize()
-
+// NewRootCmd creates a new root command for the ToolHive CLI.
+func NewRootCmd() *cobra.Command {
 	// Add persistent flags
 	rootCmd.PersistentFlags().Bool("debug", false, "Enable debug mode")
 
@@ -43,11 +42,6 @@ func init() {
 	rootCmd.AddCommand(newVersionCmd())
 	rootCmd.AddCommand(newLogsCommand())
 	rootCmd.AddCommand(newSecretCommand())
-}
 
-func main() {
-	if err := rootCmd.Execute(); err != nil {
-		logger.Log.Error("%v, %v", os.Stderr, err)
-		os.Exit(1)
-	}
+	return rootCmd
 }

--- a/cmd/thv/common.go
+++ b/cmd/thv/common.go
@@ -1,4 +1,4 @@
-package main
+package cli
 
 import (
 	"fmt"

--- a/cmd/thv/config.go
+++ b/cmd/thv/config.go
@@ -1,4 +1,4 @@
-package main
+package cli
 
 import (
 	"fmt"

--- a/cmd/thv/list.go
+++ b/cmd/thv/list.go
@@ -1,6 +1,4 @@
-// Package main provides the entry point for the toolhive command-line application.
-// This file contains the implementation of the 'list' command.
-package main
+package cli
 
 import (
 	"context"

--- a/cmd/thv/logs.go
+++ b/cmd/thv/logs.go
@@ -1,4 +1,4 @@
-package main
+package cli
 
 import (
 	"context"

--- a/cmd/thv/proxy.go
+++ b/cmd/thv/proxy.go
@@ -1,4 +1,4 @@
-package main
+package cli
 
 import (
 	"context"

--- a/cmd/thv/registry.go
+++ b/cmd/thv/registry.go
@@ -1,6 +1,4 @@
-// Package main provides the entry point for the toolhive command-line application.
-// This file contains the implementation of the 'registry' command.
-package main
+package cli
 
 import (
 	"encoding/json"

--- a/cmd/thv/restart.go
+++ b/cmd/thv/restart.go
@@ -1,4 +1,4 @@
-package main
+package cli
 
 import (
 	"context"

--- a/cmd/thv/rm.go
+++ b/cmd/thv/rm.go
@@ -1,4 +1,4 @@
-package main
+package cli
 
 import (
 	"context"

--- a/cmd/thv/run.go
+++ b/cmd/thv/run.go
@@ -1,4 +1,4 @@
-package main
+package cli
 
 import (
 	"context"

--- a/cmd/thv/run_common.go
+++ b/cmd/thv/run_common.go
@@ -1,4 +1,4 @@
-package main
+package cli
 
 import (
 	"context"

--- a/cmd/thv/search.go
+++ b/cmd/thv/search.go
@@ -1,6 +1,4 @@
-// Package main provides the entry point for the toolhive command-line application.
-// This file contains the implementation of the 'search' command.
-package main
+package cli
 
 import (
 	"encoding/json"

--- a/cmd/thv/secret.go
+++ b/cmd/thv/secret.go
@@ -1,4 +1,4 @@
-package main
+package cli
 
 import (
 	"fmt"

--- a/cmd/thv/stop.go
+++ b/cmd/thv/stop.go
@@ -1,4 +1,4 @@
-package main
+package cli
 
 import (
 	"context"

--- a/cmd/thv/version.go
+++ b/cmd/thv/version.go
@@ -1,6 +1,4 @@
-// Package main provides the entry point for the toolhive command-line application.
-// This file contains the implementation of the 'version' command.
-package main
+package cli
 
 import (
 	"fmt"

--- a/deploy/k8s/thv.yaml
+++ b/deploy/k8s/thv.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: toolhive
-        image: ko://github.com/StacklokLabs/toolhive/cmd/thv
+        image: ko://github.com/StacklokLabs/toolhive/cmd
         args: ["run", "--foreground=true", "--port=8080", "--name=mcp-fetch", "docker.io/mcp/fetch"]
         env:
         - name: UNSTRUCTURED_LOGS

--- a/docs/cli/thv.md
+++ b/docs/cli/thv.md
@@ -1,0 +1,39 @@
+## thv
+
+ToolHive (thv) is a lightweight, secure, and fast manager for MCP servers
+
+### Synopsis
+
+ToolHive (thv) is a lightweight, secure, and fast manager for MCP (Model Context Protocol) servers.
+It is written in Go and has extensive test coverage—including input validation—to ensure reliability and security.
+
+Under the hood, ToolHive acts as a very thin client for the Docker/Podman Unix socket API.
+This design choice allows it to remain both efficient and lightweight while still providing powerful,
+container-based isolation for running MCP servers.
+
+```
+thv [flags]
+```
+
+### Options
+
+```
+      --debug   Enable debug mode
+  -h, --help    help for thv
+```
+
+### SEE ALSO
+
+* [thv config](thv_config.md)	 - Manage application configuration
+* [thv list](thv_list.md)	 - List running MCP servers
+* [thv logs](thv_logs.md)	 - Output the logs of an MCP server
+* [thv proxy](thv_proxy.md)	 - Spawn a transparent proxy for an MCP server
+* [thv registry](thv_registry.md)	 - Manage MCP server registry
+* [thv restart](thv_restart.md)	 - Restart a tooling server
+* [thv rm](thv_rm.md)	 - Remove an MCP server
+* [thv run](thv_run.md)	 - Run an MCP server
+* [thv search](thv_search.md)	 - Search for MCP servers
+* [thv secret](thv_secret.md)	 - Manage secrets
+* [thv stop](thv_stop.md)	 - Stop an MCP server
+* [thv version](thv_version.md)	 - Show the version of ToolHive
+

--- a/docs/cli/thv_config.md
+++ b/docs/cli/thv_config.md
@@ -1,0 +1,29 @@
+## thv config
+
+Manage application configuration
+
+### Synopsis
+
+The config command provides subcommands to manage application configuration settings.
+
+### Options
+
+```
+  -h, --help   help for config
+```
+
+### Options inherited from parent commands
+
+```
+      --debug   Enable debug mode
+```
+
+### SEE ALSO
+
+* [thv](thv.md)	 - ToolHive (thv) is a lightweight, secure, and fast manager for MCP servers
+* [thv config auto-discovery](thv_config_auto-discovery.md)	 - Set whether to enable auto-discovery of MCP clients
+* [thv config list-registered-clients](thv_config_list-registered-clients.md)	 - List all registered MCP clients
+* [thv config register-client](thv_config_register-client.md)	 - Register a client for MCP server configuration
+* [thv config remove-client](thv_config_remove-client.md)	 - Remove a client from MCP server configuration
+* [thv config secrets-provider](thv_config_secrets-provider.md)	 - Set the secrets provider type
+

--- a/docs/cli/thv_config_auto-discovery.md
+++ b/docs/cli/thv_config_auto-discovery.md
@@ -1,0 +1,30 @@
+## thv config auto-discovery
+
+Set whether to enable auto-discovery of MCP clients
+
+### Synopsis
+
+Set whether to enable auto-discovery and configuration of MCP clients.
+When enabled, ToolHive will automatically update client configuration files
+with the URLs of running MCP servers.
+
+```
+thv config auto-discovery [true|false] [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for auto-discovery
+```
+
+### Options inherited from parent commands
+
+```
+      --debug   Enable debug mode
+```
+
+### SEE ALSO
+
+* [thv config](thv_config.md)	 - Manage application configuration
+

--- a/docs/cli/thv_config_list-registered-clients.md
+++ b/docs/cli/thv_config_list-registered-clients.md
@@ -1,0 +1,28 @@
+## thv config list-registered-clients
+
+List all registered MCP clients
+
+### Synopsis
+
+List all clients that are registered for MCP server configuration.
+
+```
+thv config list-registered-clients [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for list-registered-clients
+```
+
+### Options inherited from parent commands
+
+```
+      --debug   Enable debug mode
+```
+
+### SEE ALSO
+
+* [thv config](thv_config.md)	 - Manage application configuration
+

--- a/docs/cli/thv_config_register-client.md
+++ b/docs/cli/thv_config_register-client.md
@@ -1,0 +1,33 @@
+## thv config register-client
+
+Register a client for MCP server configuration
+
+### Synopsis
+
+Register a client for MCP server configuration.
+Valid clients are:
+  - roo-code: Roo Code extension for VS Code
+  - cursor: Cursor editor
+  - vscode: Visual Studio Code
+  - vscode-insider: Visual Studio Code Insiders edition
+
+```
+thv config register-client [client] [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for register-client
+```
+
+### Options inherited from parent commands
+
+```
+      --debug   Enable debug mode
+```
+
+### SEE ALSO
+
+* [thv config](thv_config.md)	 - Manage application configuration
+

--- a/docs/cli/thv_config_remove-client.md
+++ b/docs/cli/thv_config_remove-client.md
@@ -1,0 +1,33 @@
+## thv config remove-client
+
+Remove a client from MCP server configuration
+
+### Synopsis
+
+Remove a client from MCP server configuration.
+Valid clients are:
+  - roo-code: Roo Code extension for VS Code
+  - cursor: Cursor editor
+  - vscode: Visual Studio Code
+  - vscode-insider: Visual Studio Code Insiders edition
+
+```
+thv config remove-client [client] [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for remove-client
+```
+
+### Options inherited from parent commands
+
+```
+      --debug   Enable debug mode
+```
+
+### SEE ALSO
+
+* [thv config](thv_config.md)	 - Manage application configuration
+

--- a/docs/cli/thv_config_secrets-provider.md
+++ b/docs/cli/thv_config_secrets-provider.md
@@ -1,0 +1,31 @@
+## thv config secrets-provider
+
+Set the secrets provider type
+
+### Synopsis
+
+Set the secrets provider type for storing and retrieving secrets.
+Valid providers are:
+  - basic: Stores secrets in an unencrypted file (not recommended for production)
+  - encrypted: Stores secrets in an encrypted file using AES-256-GCM
+
+```
+thv config secrets-provider [provider] [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for secrets-provider
+```
+
+### Options inherited from parent commands
+
+```
+      --debug   Enable debug mode
+```
+
+### SEE ALSO
+
+* [thv config](thv_config.md)	 - Manage application configuration
+

--- a/docs/cli/thv_list.md
+++ b/docs/cli/thv_list.md
@@ -1,0 +1,30 @@
+## thv list
+
+List running MCP servers
+
+### Synopsis
+
+List all MCP servers managed by ToolHive, including their status and configuration.
+
+```
+thv list [flags]
+```
+
+### Options
+
+```
+  -a, --all             Show all containers (default shows just running)
+      --format string   Output format (json, text, or mcpservers) (default "text")
+  -h, --help            help for list
+```
+
+### Options inherited from parent commands
+
+```
+      --debug   Enable debug mode
+```
+
+### SEE ALSO
+
+* [thv](thv.md)	 - ToolHive (thv) is a lightweight, secure, and fast manager for MCP servers
+

--- a/docs/cli/thv_logs.md
+++ b/docs/cli/thv_logs.md
@@ -1,0 +1,28 @@
+## thv logs
+
+Output the logs of an MCP server
+
+### Synopsis
+
+Output the logs of an MCP server managed by Vibe Tool.
+
+```
+thv logs [container-name] [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for logs
+```
+
+### Options inherited from parent commands
+
+```
+      --debug   Enable debug mode
+```
+
+### SEE ALSO
+
+* [thv](thv.md)	 - ToolHive (thv) is a lightweight, secure, and fast manager for MCP servers
+

--- a/docs/cli/thv_proxy.md
+++ b/docs/cli/thv_proxy.md
@@ -1,0 +1,35 @@
+## thv proxy
+
+Spawn a transparent proxy for an MCP server
+
+### Synopsis
+
+Spawn a transparent proxy that will redirect to an MCP server endpoint.
+This command creates a standalone proxy without starting a container.
+
+```
+thv proxy [flags] SERVER_NAME
+```
+
+### Options
+
+```
+  -h, --help                    help for proxy
+      --oidc-audience string    Expected audience for the token
+      --oidc-client-id string   OIDC client ID
+      --oidc-issuer string      OIDC issuer URL (e.g., https://accounts.google.com)
+      --oidc-jwks-url string    URL to fetch the JWKS from
+      --port int                Port for the HTTP proxy to listen on (host port)
+      --target-uri string       URI for the target MCP server (e.g., http://localhost:8080) (required)
+```
+
+### Options inherited from parent commands
+
+```
+      --debug   Enable debug mode
+```
+
+### SEE ALSO
+
+* [thv](thv.md)	 - ToolHive (thv) is a lightweight, secure, and fast manager for MCP servers
+

--- a/docs/cli/thv_registry.md
+++ b/docs/cli/thv_registry.md
@@ -1,0 +1,26 @@
+## thv registry
+
+Manage MCP server registry
+
+### Synopsis
+
+Manage the MCP server registry, including listing and getting information about available MCP servers.
+
+### Options
+
+```
+  -h, --help   help for registry
+```
+
+### Options inherited from parent commands
+
+```
+      --debug   Enable debug mode
+```
+
+### SEE ALSO
+
+* [thv](thv.md)	 - ToolHive (thv) is a lightweight, secure, and fast manager for MCP servers
+* [thv registry info](thv_registry_info.md)	 - Get information about an MCP server
+* [thv registry list](thv_registry_list.md)	 - List available MCP servers
+

--- a/docs/cli/thv_registry_info.md
+++ b/docs/cli/thv_registry_info.md
@@ -1,0 +1,29 @@
+## thv registry info
+
+Get information about an MCP server
+
+### Synopsis
+
+Get detailed information about a specific MCP server in the registry.
+
+```
+thv registry info [server] [flags]
+```
+
+### Options
+
+```
+      --format string   Output format (json or text) (default "text")
+  -h, --help            help for info
+```
+
+### Options inherited from parent commands
+
+```
+      --debug   Enable debug mode
+```
+
+### SEE ALSO
+
+* [thv registry](thv_registry.md)	 - Manage MCP server registry
+

--- a/docs/cli/thv_registry_list.md
+++ b/docs/cli/thv_registry_list.md
@@ -1,0 +1,29 @@
+## thv registry list
+
+List available MCP servers
+
+### Synopsis
+
+List all available MCP servers in the registry.
+
+```
+thv registry list [flags]
+```
+
+### Options
+
+```
+      --format string   Output format (json or text) (default "text")
+  -h, --help            help for list
+```
+
+### Options inherited from parent commands
+
+```
+      --debug   Enable debug mode
+```
+
+### SEE ALSO
+
+* [thv registry](thv_registry.md)	 - Manage MCP server registry
+

--- a/docs/cli/thv_restart.md
+++ b/docs/cli/thv_restart.md
@@ -1,0 +1,28 @@
+## thv restart
+
+Restart a tooling server
+
+### Synopsis
+
+Restart a running tooling server managed by ToolHive. If the server is not running, it will be started.
+
+```
+thv restart [container-name] [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for restart
+```
+
+### Options inherited from parent commands
+
+```
+      --debug   Enable debug mode
+```
+
+### SEE ALSO
+
+* [thv](thv.md)	 - ToolHive (thv) is a lightweight, secure, and fast manager for MCP servers
+

--- a/docs/cli/thv_rm.md
+++ b/docs/cli/thv_rm.md
@@ -1,0 +1,29 @@
+## thv rm
+
+Remove an MCP server
+
+### Synopsis
+
+Remove an MCP server managed by ToolHive.
+
+```
+thv rm [container-name] [flags]
+```
+
+### Options
+
+```
+  -f, --force   Force removal of a running container
+  -h, --help    help for rm
+```
+
+### Options inherited from parent commands
+
+```
+      --debug   Enable debug mode
+```
+
+### SEE ALSO
+
+* [thv](thv.md)	 - ToolHive (thv) is a lightweight, secure, and fast manager for MCP servers
+

--- a/docs/cli/thv_run.md
+++ b/docs/cli/thv_run.md
@@ -1,0 +1,47 @@
+## thv run
+
+Run an MCP server
+
+### Synopsis
+
+Run an MCP server in a container with the specified server name or image and arguments.
+If a server name is provided, it will first try to find it in the registry.
+If found, it will use the registry defaults for transport, permissions, etc.
+If not found, it will treat the argument as a Docker image and run it directly.
+The container will be started with minimal permissions and the specified transport mode.
+
+```
+thv run [flags] SERVER_OR_IMAGE [-- ARGS...]
+```
+
+### Options
+
+```
+      --authz-config string         Path to the authorization configuration file
+  -e, --env stringArray             Environment variables to pass to the MCP server (format: KEY=VALUE)
+  -f, --foreground                  Run in foreground mode (block until container exits)
+  -h, --help                        help for run
+      --name string                 Name of the MCP server (auto-generated from image if not provided)
+      --oidc-audience string        Expected audience for the token
+      --oidc-client-id string       OIDC client ID
+      --oidc-issuer string          OIDC issuer URL (e.g., https://accounts.google.com)
+      --oidc-jwks-url string        URL to fetch the JWKS from
+      --permission-profile string   Permission profile to use (stdio, network, or path to JSON file) (default "stdio")
+      --port int                    Port for the HTTP proxy to listen on (host port)
+      --secret stringArray          Specify a secret to be fetched from the secrets manager and set as an environment variable (format: NAME,target=TARGET)
+      --target-host string          Host to forward traffic to (only applicable to SSE transport) (default "localhost")
+      --target-port int             Port for the container to expose (only applicable to SSE transport)
+      --transport string            Transport mode (sse or stdio) (default "stdio")
+  -v, --volume stringArray          Mount a volume into the container (format: host-path:container-path[:ro])
+```
+
+### Options inherited from parent commands
+
+```
+      --debug   Enable debug mode
+```
+
+### SEE ALSO
+
+* [thv](thv.md)	 - ToolHive (thv) is a lightweight, secure, and fast manager for MCP servers
+

--- a/docs/cli/thv_search.md
+++ b/docs/cli/thv_search.md
@@ -1,0 +1,29 @@
+## thv search
+
+Search for MCP servers
+
+### Synopsis
+
+Search for MCP servers in the registry by name, description, or tags.
+
+```
+thv search [query] [flags]
+```
+
+### Options
+
+```
+      --format string   Output format (json or text) (default "text")
+  -h, --help            help for search
+```
+
+### Options inherited from parent commands
+
+```
+      --debug   Enable debug mode
+```
+
+### SEE ALSO
+
+* [thv](thv.md)	 - ToolHive (thv) is a lightweight, secure, and fast manager for MCP servers
+

--- a/docs/cli/thv_secret.md
+++ b/docs/cli/thv_secret.md
@@ -1,0 +1,29 @@
+## thv secret
+
+Manage secrets
+
+### Synopsis
+
+The secret command provides subcommands to set, get, delete, and list secrets.
+
+### Options
+
+```
+  -h, --help   help for secret
+```
+
+### Options inherited from parent commands
+
+```
+      --debug   Enable debug mode
+```
+
+### SEE ALSO
+
+* [thv](thv.md)	 - ToolHive (thv) is a lightweight, secure, and fast manager for MCP servers
+* [thv secret delete](thv_secret_delete.md)	 - Delete a secret
+* [thv secret get](thv_secret_get.md)	 - Get a secret
+* [thv secret list](thv_secret_list.md)	 - List all available secrets
+* [thv secret reset-keyring](thv_secret_reset-keyring.md)	 - Reset the keyring secret
+* [thv secret set](thv_secret_set.md)	 - Set a secret
+

--- a/docs/cli/thv_secret_delete.md
+++ b/docs/cli/thv_secret_delete.md
@@ -1,0 +1,24 @@
+## thv secret delete
+
+Delete a secret
+
+```
+thv secret delete <name> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for delete
+```
+
+### Options inherited from parent commands
+
+```
+      --debug   Enable debug mode
+```
+
+### SEE ALSO
+
+* [thv secret](thv_secret.md)	 - Manage secrets
+

--- a/docs/cli/thv_secret_get.md
+++ b/docs/cli/thv_secret_get.md
@@ -1,0 +1,24 @@
+## thv secret get
+
+Get a secret
+
+```
+thv secret get <name> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for get
+```
+
+### Options inherited from parent commands
+
+```
+      --debug   Enable debug mode
+```
+
+### SEE ALSO
+
+* [thv secret](thv_secret.md)	 - Manage secrets
+

--- a/docs/cli/thv_secret_list.md
+++ b/docs/cli/thv_secret_list.md
@@ -1,0 +1,24 @@
+## thv secret list
+
+List all available secrets
+
+```
+thv secret list [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for list
+```
+
+### Options inherited from parent commands
+
+```
+      --debug   Enable debug mode
+```
+
+### SEE ALSO
+
+* [thv secret](thv_secret.md)	 - Manage secrets
+

--- a/docs/cli/thv_secret_reset-keyring.md
+++ b/docs/cli/thv_secret_reset-keyring.md
@@ -1,0 +1,24 @@
+## thv secret reset-keyring
+
+Reset the keyring secret
+
+```
+thv secret reset-keyring [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for reset-keyring
+```
+
+### Options inherited from parent commands
+
+```
+      --debug   Enable debug mode
+```
+
+### SEE ALSO
+
+* [thv secret](thv_secret.md)	 - Manage secrets
+

--- a/docs/cli/thv_secret_set.md
+++ b/docs/cli/thv_secret_set.md
@@ -1,0 +1,42 @@
+## thv secret set
+
+Set a secret
+
+### Synopsis
+
+Set a secret with the given name.
+
+Input Methods:
+		- Piped Input: If data is piped to the command, the secret value will be read from stdin.
+		  Examples:
+		    echo "my-secret-value" | thv secret set my-secret
+		    cat secret-file.txt | thv secret set my-secret
+		
+		- Interactive Input: If no data is piped, you will be prompted to enter the secret value securely
+		  (input will be hidden).
+		  Example:
+		    thv secret set my-secret
+		    Enter secret value (input will be hidden): _
+
+The secret will be stored securely using the configured secrets provider.
+
+```
+thv secret set <name> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for set
+```
+
+### Options inherited from parent commands
+
+```
+      --debug   Enable debug mode
+```
+
+### SEE ALSO
+
+* [thv secret](thv_secret.md)	 - Manage secrets
+

--- a/docs/cli/thv_stop.md
+++ b/docs/cli/thv_stop.md
@@ -1,0 +1,29 @@
+## thv stop
+
+Stop an MCP server
+
+### Synopsis
+
+Stop a running MCP server managed by ToolHive.
+
+```
+thv stop [container-name] [flags]
+```
+
+### Options
+
+```
+  -h, --help          help for stop
+      --timeout int   Timeout in seconds before forcibly stopping the container (default 30)
+```
+
+### Options inherited from parent commands
+
+```
+      --debug   Enable debug mode
+```
+
+### SEE ALSO
+
+* [thv](thv.md)	 - ToolHive (thv) is a lightweight, secure, and fast manager for MCP servers
+

--- a/docs/cli/thv_version.md
+++ b/docs/cli/thv_version.md
@@ -1,0 +1,29 @@
+## thv version
+
+Show the version of ToolHive
+
+### Synopsis
+
+Display detailed version information about ToolHive, including version number, git commit, build date, and Go version.
+
+```
+thv version [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for version
+      --json   Output version information as JSON
+```
+
+### Options inherited from parent commands
+
+```
+      --debug   Enable debug mode
+```
+
+### SEE ALSO
+
+* [thv](thv.md)	 - ToolHive (thv) is a lightweight, secure, and fast manager for MCP servers
+

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 require (
 	al.essio.dev/pkg/shellescape v1.6.0 // indirect
 	github.com/containerd/log v0.1.0 // indirect
+	github.com/cpuguy83/go-md2man/v2 v2.0.6 // indirect
 	github.com/danieljoos/wincred v1.2.2 // indirect
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.7.0 // indirect
@@ -45,6 +46,7 @@ require (
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
+	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.35.0 // indirect
 	golang.org/x/exp/event v0.0.0-20220217172124-1812c5b45e43 // indirect

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,7 @@ github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK3
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=
 github.com/containerd/log v0.1.0/go.mod h1:VRRf09a7mHDIRezVKTRCrOq78v577GXq3bSa3EhrzVo=
+github.com/cpuguy83/go-md2man/v2 v2.0.6 h1:XJtiaUW6dEEqVuZiMTn1ldk455QWwEIsMIJlo5vtkx0=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/danieljoos/wincred v1.2.2 h1:774zMFJrqaeYCK2W57BgAem/MLi6mtSE47MB6BOJ0i0=
@@ -148,6 +149,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=
 github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
+github.com/russross/blackfriday v1.6.0 h1:KqfZb0pUVN2lYqZUYRddxF4OR8ZMURnJIG5Y3VRLtww=
+github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/segmentio/asm v1.2.0 h1:9BQrFxC+YOHJlTlHGkTrFWf59nbL3XnCoFLTwDCI7ys=
 github.com/segmentio/asm v1.2.0/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=


### PR DESCRIPTION
- Adds auto generation of docs for all `thv` commands.
- Adds a task `docs` to generate all docs
- Adds pipeline workflow to fail if there is are uncommitted doc changes

Unfortunately, have had to refactor some of the packages to allow for the calling of the `rootCmd` to generate the command tree. Because everything in the `cmd/thv` was in the main package, I've had to repackage it as `cli` and add a `main.go` in `./cmd` that calls the `cli` package when executing. On the up side, got rid of another `init()` function

Completes https://github.com/StacklokLabs/toolhive/issues/139