### PR TITLE
Format docs, polish kind guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,57 +2,86 @@
 
 <img src="docs/images/toolhive.png" alt="ToolHive Logo" width="300" />
 
-ToolHive (thv) is a lightweight, secure, and fast manager for MCP (Model Context Protocol) servers. It is written in Golang and has extensive test coverage—including input validation—to ensure reliability and security.
+ToolHive (thv) is a lightweight, secure, and fast manager for MCP (Model Context
+Protocol) servers. It is written in Golang and has extensive test
+coverage—including input validation—to ensure reliability and security.
 
-Under the hood, ToolHive acts as a very thin client for the Docker/Podman Unix socket API. This design choice allows it to remain both efficient and lightweight while still providing powerful, container-based isolation for running MCP servers.
+Under the hood, ToolHive acts as a very thin client for the Docker/Podman Unix
+socket API. This design choice allows it to remain both efficient and
+lightweight while still providing powerful, container-based isolation for
+running MCP servers.
 
 <img src="./docs/images/thv-readme-demo.svg" alt="Terminal Recording">
 
 ## Why ToolHive?
 
-Deploying MCP servers requires complex multi-step processes with a lot of friction: involving running random potentially harmful commands (e.g. using `uv` or `npx`), manually managing security credentials (e.g. putting an api token into a text file), and wrestling with inconsistent packaging methods. ToolHive aims to solve this by starting containers in a locked-down environment, granting only the minimal permissions required to run. This significantly reduces the attack surface, imporves usability, and enforces best practices for container security.
+Deploying MCP servers requires complex multi-step processes with a lot of
+friction: involving running random potentially harmful commands (e.g. using `uv`
+or `npx`), manually managing security credentials (e.g. putting an api token
+into a text file), and wrestling with inconsistent packaging methods. ToolHive
+aims to solve this by starting containers in a locked-down environment, granting
+only the minimal permissions required to run. This significantly reduces the
+attack surface, improves usability, and enforces best practices for container
+security.
 
 ToolHive radically simplifies MCP deployment by:
- - Ease of Use: Instantly deploy MCP servers through Docker containers. Users can start their MCP servers with a single, straightforward command. No need to install and fight with different versions of python / node / etc.
 
-- Enhanced Security: Secure by default: the tool securely manages secrets and configurations, greatly reducing leaks & risks. No more plaintext secrets in configuration files
+- Ease of use: Instantly deploy MCP servers through Docker containers. Users can
+  start their MCP servers with a single, straightforward command. No need to
+  install and fight with different versions of python / node / etc.
 
-- Standardized Packaging: Leveraging OCI container standards, the project provides a repeatable, standardized packaging method for MCP servers, ensuring compatibility and reliability.
+- Enhanced security: Secure by default: the tool securely manages secrets and
+  configurations, greatly reducing leaks & risks. No more plaintext secrets in
+  configuration files
 
+- Standardized packaging: Leveraging OCI container standards, the project
+  provides a repeatable, standardized packaging method for MCP servers, ensuring
+  compatibility and reliability.
 
-### Key Benefits
-- Curated MCP Registry: Includes a registry of curated MCPs with verified configurations — users can effortlessly discover and deploy MCP servers without any manual setup. Just select one from the list and safely run it with just one command.
+### Key benefits
 
-- Enterprise-Ready Authorization: Offers robust authorization controls tailored for enterprise environments, securely managing tool access and integrating seamlessly with existing infrastructures (e.g., Kubernetes).
+- Curated MCP registry: Includes a registry of curated MCPs with verified
+  configurations — users can effortlessly discover and deploy MCP servers
+  without any manual setup. Just select one from the list and safely run it with
+  just one command.
 
-- Seamless Integration: Compatible with popular development tools such as Copilot, Continue, Claude Desktop, Stitch, and more, streamlining your workflow.
+- Enterprise-ready authorization: Offers robust authorization controls tailored
+  for enterprise environments, securely managing tool access and integrating
+  seamlessly with existing infrastructures (e.g., Kubernetes).
 
-## Getting Started
+- Seamless integration: Compatible with popular development tools such as GitHub
+  Copilot, Cursor, Roo Code, and more, streamlining your workflow.
+
+## Getting started
 
 TODO: Add simple installation instructions
 
 ## Usage
 
-### Running an MCP Server
+### Running an MCP server
 
-First, find the MCP server you want to run. You can search for available MCP servers in the registry using:
+First, find the MCP server you want to run. You can search for available MCP
+servers in the registry using:
 
 ```bash
 thv search <search-term>
 ```
 
-This command will return a list of available MCP servers that match the search term.
+This command will return a list of available MCP servers that match the search
+term.
 
-Once you find the MCP server you want to run, you can start it using the `thv run` command. For example, to run a specific MCP server:
+Once you find the MCP server you want to run, you can start it using the
+`thv run` command. For example, to run a specific MCP server:
 
 ```bash
 thv run <name-of-mcp-server>
 ```
 
-The registry already contains all the parameters needed to run the server, so you don't need to specify any additional arguments.
-ToolHive will automatically pull the image and start the server.
+The registry already contains all the parameters needed to run the server, so
+you don't need to specify any additional arguments. ToolHive will automatically
+pull the image and start the server.
 
-### Listing Running MCP Servers
+### Listing running MCP servers
 
 Use:
 
@@ -60,17 +89,20 @@ Use:
 thv list
 ```
 
-This lists all active MCP servers managed by ToolHive, along with their current status.
+This lists all active MCP servers managed by ToolHive, along with their current
+status.
 
-### Browsing the Registry
+### Browsing the registry
 
-You can also browse the registry to see all available MCP servers. Use the following command:
+You can also browse the registry to see all available MCP servers. Use the
+following command:
 
 ```bash
 thv registry list
 ```
 
-This will display a list of all available MCP servers in the registry, along with their descriptions and other relevant information.
+This will display a list of all available MCP servers in the registry, along
+with their descriptions and other relevant information.
 
 To view detailed information about a specific MCP server, use:
 
@@ -78,102 +110,108 @@ To view detailed information about a specific MCP server, use:
 thv registry info <name-of-mcp-server>
 ```
 
-This command will provide you with detailed information about the MCP server, including its configuration, available options, and any other relevant details.
+This command will provide you with detailed information about the MCP server,
+including its configuration, available options, and any other relevant details.
 
-We're open to adding more MCP servers to the registry. If you have a specific server in mind, please submit a pull request or open an issue on our GitHub repository.
-We're tracking the the list in [registry.json](pkg/registry/data/registry.json).
+We're open to adding more MCP servers to the registry. If you have a specific
+server in mind, please submit a pull request or open an issue on our GitHub
+repository. We're tracking the the list in
+[registry.json](pkg/registry/data/registry.json).
 
-### Running a Custom MCP Server
+### Running a custom MCP server
 
-If you want to run a custom MCP server that is not in the registry, you can do so by specifying the image name and any additional arguments. For example:
+If you want to run a custom MCP server that is not in the registry, you can do
+so by specifying the image name and any additional arguments. For example:
 
 ```bash
 thv run --transport sse --name my-mcp-server --port 8080 my-mcp-server-image:latest -- my-mcp-server-args
 ```
 
-This command closely resembles `docker run` but focuses on security and simplicity. When invoked:
+This command closely resembles `docker run` but focuses on security and
+simplicity. When invoked:
 
-* ToolHive creates a container from the specified image (`my-mcp-server-image:latest`).
+- ToolHive creates a container from the specified image
+  (`my-mcp-server-image:latest`).
 
-* It configures the container to listen on the chosen port (8080).
+- It configures the container to listen on the chosen port (8080).
 
-* Labels the container so it can be tracked by ToolHive:
+- Labels the container so it can be tracked by ToolHive:
 
-    ```yaml
-    toolhive: true
-    toolhive-name: my-mcp-server
-    ```
+  ```yaml
+  toolhive: true
+  toolhive-name: my-mcp-server
+  ```
 
-* Sets up the specified transport (e.g., SSE, stdio), potentially using a reverse proxy, depending on user choice.
+- Sets up the specified transport (e.g., SSE, stdio), potentially using a
+  reverse proxy, depending on user choice.
 
-### Transport Modes
+### Transport modes
 
-* **SSE**:
+- **SSE**:
 
-    If the transport is `sse`, ToolHive creates a reverse proxy on a random port that forwards requests to the container. This means the container itself does not directly expose any ports.
+  If the transport is `sse`, ToolHive creates a reverse proxy on a random port
+  that forwards requests to the container. This means the container itself does
+  not directly expose any ports.
 
-* **STDIO**:
+- **STDIO**:
 
-    If the transport is `stdio`, ToolHive redirects SSE traffic to the container's standard input and output.
-    This acts as a secure proxy, ensuring that the container does not have direct access to the network nor
-    the host machine.
+  If the transport is `stdio`, ToolHive redirects SSE traffic to the container's
+  standard input and output. This acts as a secure proxy, ensuring that the
+  container does not have direct access to the network nor the host machine.
 
 ## Permissions
 
-Containers launched by ToolHive come with a minimal set of permissions, strictly limited to what is required. Permissions can be further customized via a JSON-based permission profile provided with the `--permission-profile` flag.
+Containers launched by ToolHive come with a minimal set of permissions, strictly
+limited to what is required. Permissions can be further customized via a
+JSON-based permission profile provided with the `--permission-profile` flag.
 
 An example permission profile file could be:
 
 ```json
 {
-  "read": [
-    "/var/run/mcp.sock"
-  ],
-  "write": [
-    "/var/run/mcp.sock"
-  ],
+  "read": ["/var/run/mcp.sock"],
+  "write": ["/var/run/mcp.sock"],
   "network": {
     "outbound": {
       "insecure_allow_all": false,
-      "allow_transport": [
-        "tcp",
-        "udp"
-      ],
-      "allow_host": [
-        "localhost",
-        "google.com"
-      ],
-      "allow_port": [
-        80,
-        443
-      ]
+      "allow_transport": ["tcp", "udp"],
+      "allow_host": ["localhost", "google.com"],
+      "allow_port": [80, 443]
     }
   }
 }
 ```
 
-This profile lets the container read and write to the `/var/run/mcp.sock` Unix socket and also make outbound network requests to `localhost` and `google.com` on ports `80` and `443`.
+This profile lets the container read and write to the `/var/run/mcp.sock` Unix
+socket and also make outbound network requests to `localhost` and `google.com`
+on ports `80` and `443`.
 
 Two built-in profiles are included for convenience:
 
-* `stdio`: Grants minimal permissions with no network access.
-* `network`: Permits outbound network connections to any host on any port (not recommended for production use).
+- `stdio`: Grants minimal permissions with no network access.
+- `network`: Permits outbound network connections to any host on any port (not
+  recommended for production use).
 
-## Client Compability
+## Client compatibility
 
-| Client | Supported | Notes |
-|--------|-----------|-------|
-| Copilot (VS Code) | ✅ |
-| Cursor | ✅ |
-| Roo Code | ✅ |
-| PydanticAI | ✅ |
-| Continue| ❌ | Continue doesn't yet support SSE
-| Claude Desktop | ❌ | Claude Desktop doesn't yet support SSE
+| Client            | Supported | Notes                                  |
+| ----------------- | --------- | -------------------------------------- |
+| Copilot (VS Code) | ✅        | v1.99.0+ or Insiders version           |
+| Cursor            | ✅        |                                        |
+| Roo Code          | ✅        |                                        |
+| PydanticAI        | ✅        |                                        |
+| Continue          | ❌        | Continue doesn't yet support SSE       |
+| Claude Desktop    | ❌        | Claude Desktop doesn't yet support SSE |
 
-## Running ToolHive Inside of a Local Kind Cluster
+## Running ToolHive in a local kind cluster
 
-In order to run this against a local Kind Cluster, follow the [# Running ToolHive Inside a Local Kubernetes Kind Cluster With Ingress](./docs/running-toolhive-in-kind-cluster.md) doc.
+To run ToolHive in a local lind cluster, follow the
+[# Running ToolHive Inside a Local Kubernetes Kind Cluster With Ingress](./docs/running-toolhive-in-kind-cluster.md)
+doc.
 
 ## License
 
-This project is licensed under the Apache 2.0 License. See the LICENSE file for details.
+This project is licensed under the Apache 2.0 License. See the
+[LICENSE](./LICENSE) file for details.
+
+<!-- markdownlint-disable-file MD033 -->

--- a/docs/authz.md
+++ b/docs/authz.md
@@ -1,34 +1,49 @@
-# Authorization Framework
+# Authorization framework
 
-This document describes the authorization framework for MCP servers managed by ToolHive. The framework uses Cedar policies to authorize MCP operations based on the client's identity and the requested operation.
+This document describes the authorization framework for MCP servers managed by
+ToolHive. The framework uses Cedar policies to authorize MCP operations based on
+the client's identity and the requested operation.
 
 ## Overview
 
-ToolHive now supports adding authorization to MCP servers it manages. This is implemented using Cedar, a policy language developed by Amazon. The authorization framework consists of the following components:
+ToolHive now supports adding authorization to MCP servers it manages. This is
+implemented using Cedar, a policy language developed by Amazon. The
+authorization framework consists of the following components:
 
-1. **Cedar Authorizer**: A component that evaluates Cedar policies to determine if a request is authorized.
-2. **Authorization Middleware**: An HTTP middleware that extracts information from MCP requests and uses the Cedar Authorizer to authorize the request.
-3. **Configuration**: A JSON configuration file that specifies the Cedar policies and entities.
+1. **Cedar authorizer**: A component that evaluates Cedar policies to determine
+   if a request is authorized.
+2. **Authorization middleware**: An HTTP middleware that extracts information
+   from MCP requests and uses the Cedar Authorizer to authorize the request.
+3. **Configuration**: A JSON configuration file that specifies the Cedar
+   policies and entities.
 
-The framework integrates with the existing JWT authentication middleware to provide a complete authentication and authorization solution.
+The framework integrates with the existing JWT authentication middleware to
+provide a complete authentication and authorization solution.
 
-## How It Works
+## How it works
 
-When an MCP server is started with authorization enabled, the following process occurs:
+When an MCP server is started with authorization enabled, the following process
+occurs:
 
-1. The JWT middleware authenticates the client and adds the JWT claims to the request context.
-2. The authorization middleware extracts information from the MCP request, including the feature, operation, and resource ID.
-3. The Cedar authorizer evaluates the Cedar policies to determine if the request is authorized.
-4. If the request is authorized, it is passed to the next handler. Otherwise, a 403 Forbidden response is returned.
+1. The JWT middleware authenticates the client and adds the JWT claims to the
+   request context.
+2. The authorization middleware extracts information from the MCP request,
+   including the feature, operation, and resource ID.
+3. The Cedar authorizer evaluates the Cedar policies to determine if the request
+   is authorized.
+4. If the request is authorized, it is passed to the next handler. Otherwise, a
+   403 Forbidden response is returned.
 
-## Setting Up Authorization
+## Configure authorization
 
-To set up authorization for an MCP server managed by ToolHive, follow these steps:
+To set up authorization for an MCP server managed by ToolHive, follow these
+steps:
 
 1. Create a Cedar authorization configuration file.
-2. Start the MCP server with the `--authz-config` flag pointing to your configuration file.
+2. Start the MCP server with the `--authz-config` flag pointing to your
+   configuration file.
 
-### Creating a Cedar Authorization Configuration File
+### Create an authorization configuration file
 
 Create a JSON file with the following structure:
 
@@ -50,12 +65,13 @@ Create a JSON file with the following structure:
 The configuration file has the following fields:
 
 - `version`: The version of the configuration format.
-- `type`: The type of authorization configuration. Currently, only `cedarv1` is supported.
+- `type`: The type of authorization configuration. Currently, only `cedarv1` is
+  supported.
 - `cedar`: The Cedar-specific configuration.
   - `policies`: An array of Cedar policy strings.
   - `entities_json`: A JSON string representing Cedar entities.
 
-### Starting an MCP Server with Authorization
+### Start an MCP server with authorization
 
 To start an MCP server with authorization, use the `--authz-config` flag:
 
@@ -69,15 +85,16 @@ You can also use the `registry run` command with the same flag:
 thv registry run my-mcp-server --authz-config /path/to/authz-config.json -- my-mcp-server-args
 ```
 
-## Writing Cedar Policies
+## Writing Cedar policies
 
-Cedar is a powerful policy language that allows you to express complex authorization rules. Here's a guide to writing Cedar policies for MCP servers.
+Cedar is a powerful policy language that allows you to express complex
+authorization rules. Here's a guide to writing Cedar policies for MCP servers.
 
-### Policy Structure
+### Policy structure
 
 A Cedar policy has the following structure:
 
-```
+```plain
 permit|forbid(principal, action, resource) when { conditions };
 ```
 
@@ -85,17 +102,21 @@ permit|forbid(principal, action, resource) when { conditions };
 - `principal`: The entity making the request.
 - `action`: The operation being performed.
 - `resource`: The object being accessed.
-- `conditions`: Optional conditions that must be satisfied for the policy to apply.
+- `conditions`: Optional conditions that must be satisfied for the policy to
+  apply.
 
-### MCP Entities
+### MCP entities
 
 In the context of MCP servers, the following entities are used:
 
-- **Principal**: The client making the request, identified by the `sub` claim in the JWT token.
+- **Principal**: The client making the request, identified by the `sub` claim in
+  the JWT token.
+
   - Format: `Client::<client_id>`
   - Example: `Client::user123`
 
 - **Action**: The operation being performed on an MCP feature.
+
   - Format: `Action::<operation>`
   - Examples:
     - `Action::"call_tool"`: Call a tool
@@ -113,13 +134,13 @@ In the context of MCP servers, the following entities are used:
     - `Resource::"data"`: The data resource
     - `FeatureType::"tool"`: The tool feature type (used for list operations)
 
-### Example Policies
+### Example policies
 
 Here are some example policies for common scenarios:
 
 #### Allow a specific tool
 
-```
+```plain
 permit(principal, action == Action::"call_tool", resource == Tool::"weather");
 ```
 
@@ -127,7 +148,7 @@ This policy allows any client to call the weather tool.
 
 #### Allow a specific prompt
 
-```
+```plain
 permit(principal, action == Action::"get_prompt", resource == Prompt::"greeting");
 ```
 
@@ -135,7 +156,7 @@ This policy allows any client to get the greeting prompt.
 
 #### Allow a specific resource
 
-```
+```plain
 permit(principal, action == Action::"read_resource", resource == Resource::"data");
 ```
 
@@ -143,7 +164,7 @@ This policy allows any client to read the data resource.
 
 #### Allow listing tools
 
-```
+```plain
 permit(principal, action == Action::"list_tools", resource == FeatureType::"tool");
 ```
 
@@ -151,7 +172,7 @@ This policy allows any client to list available tools.
 
 #### Allow a specific client to call any tool
 
-```
+```plain
 permit(principal == Client::"user123", action == Action::"call_tool", resource);
 ```
 
@@ -159,57 +180,69 @@ This policy allows the client with ID `user123` to call any tool.
 
 #### Allow clients with a specific role to call any tool
 
-```
+```plain
 permit(principal, action == Action::"call_tool", resource) when { principal.claim_roles.contains("admin") };
 ```
 
-This policy allows any client with the `admin` role to call any tool. The `claim_roles` attribute is extracted from the JWT claims.
+This policy allows any client with the `admin` role to call any tool. The
+`claim_roles` attribute is extracted from the JWT claims.
 
 #### Allow clients to call tools based on arguments
 
-```
-permit(principal, action == Action::"call_tool", resource == Tool::"calculator") when { 
-  principal.arg_operation == "add" || principal.arg_operation == "subtract" 
+```plain
+permit(principal, action == Action::"call_tool", resource == Tool::"calculator") when {
+  principal.arg_operation == "add" || principal.arg_operation == "subtract"
 };
 ```
 
-This policy allows any client to call the calculator tool, but only for the "add" and "subtract" operations. The `arg_operation` attribute is extracted from the tool arguments.
+This policy allows any client to call the calculator tool, but only for the
+"add" and "subtract" operations. The `arg_operation` attribute is extracted from
+the tool arguments.
 
-### Using JWT Claims in Policies
+### Using JWT claims in policies
 
-The authorization middleware automatically extracts JWT claims from the request context and adds them to the Cedar context with a `claim_` prefix. For example, the `sub` claim becomes `claim_sub`, and the `name` claim becomes `claim_name`.
+The authorization middleware automatically extracts JWT claims from the request
+context and adds them to the Cedar context with a `claim_` prefix. For example,
+the `sub` claim becomes `claim_sub`, and the `name` claim becomes `claim_name`.
 
 You can use these claims in your policies:
 
-```
-permit(principal, action == Action::"call_tool", resource == Tool::"weather") when { 
-  principal.claim_name == "John Doe" 
+```plain
+permit(principal, action == Action::"call_tool", resource == Tool::"weather") when {
+  principal.claim_name == "John Doe"
 };
 ```
 
-This policy allows only clients with the name "John Doe" to call the weather tool.
+This policy allows only clients with the name "John Doe" to call the weather
+tool.
 
-### Using Tool Arguments in Policies
+### Using tool arguments in policies
 
-The authorization middleware also extracts tool arguments from the request and adds them to the Cedar context with an `arg_` prefix. For example, the `location` argument becomes `arg_location`.
+The authorization middleware also extracts tool arguments from the request and
+adds them to the Cedar context with an `arg_` prefix. For example, the
+`location` argument becomes `arg_location`.
 
 You can use these arguments in your policies:
 
-```
-permit(principal, action == Action::"call_tool", resource == Tool::"weather") when { 
-  principal.arg_location == "New York" || principal.arg_location == "London" 
+```plain
+permit(principal, action == Action::"call_tool", resource == Tool::"weather") when {
+  principal.arg_location == "New York" || principal.arg_location == "London"
 };
 ```
 
-This policy allows any client to call the weather tool, but only for the locations "New York" and "London".
+This policy allows any client to call the weather tool, but only for the
+locations "New York" and "London".
 
-## Advanced Topics
+## Advanced topics
 
-### Entity Attributes
+### Entity attributes
 
-Cedar entities can have attributes that can be used in policy conditions. The authorization middleware automatically adds JWT claims and tool arguments as attributes to the principal entity.
+Cedar entities can have attributes that can be used in policy conditions. The
+authorization middleware automatically adds JWT claims and tool arguments as
+attributes to the principal entity.
 
-You can also define custom entities with attributes in the `entities_json` field of the configuration file:
+You can also define custom entities with attributes in the `entities_json` field
+of the configuration file:
 
 ```json
 {
@@ -231,9 +264,11 @@ You can also define custom entities with attributes in the `entities_json` field
 }
 ```
 
-This configuration defines a custom entity for the weather tool with an `owner` attribute set to `user123`. The policy allows clients to call tools only if they own them.
+This configuration defines a custom entity for the weather tool with an `owner`
+attribute set to `user123`. The policy allows clients to call tools only if they
+own them.
 
-### Policy Evaluation
+### Policy evaluation
 
 Cedar policies are evaluated in the following order:
 
@@ -245,22 +280,28 @@ This means that `forbid` policies take precedence over `permit` policies.
 
 ## Troubleshooting
 
-If you're having issues with authorization, here are some common problems and solutions:
+If you're having issues with authorization, here are some common problems and
+solutions:
 
 ### Request is denied unexpectedly
 
 - Check that your policies are correctly formatted.
-- Check that the principal, action, and resource in your policies match the actual values in the request.
+- Check that the principal, action, and resource in your policies match the
+  actual values in the request.
 - Check that any conditions in your policies are satisfied by the request.
-- Remember that Cedar uses a default deny policy, so if no policy explicitly permits the request, it will be denied.
+- Remember that Cedar uses a default deny policy, so if no policy explicitly
+  permits the request, it will be denied.
 
 ### JWT claims are not available in policies
 
-- Make sure that the JWT middleware is configured correctly and is running before the authorization middleware.
+- Make sure that the JWT middleware is configured correctly and is running
+  before the authorization middleware.
 - Check that the JWT token contains the expected claims.
-- Remember that JWT claims are added to the Cedar context with a `claim_` prefix.
+- Remember that JWT claims are added to the Cedar context with a `claim_`
+  prefix.
 
 ### Tool arguments are not available in policies
 
 - Check that the tool arguments are correctly specified in the request.
-- Remember that tool arguments are added to the Cedar context with an `arg_` prefix.
+- Remember that tool arguments are added to the Cedar context with an `arg_`
+  prefix.

--- a/docs/running-toolhive-in-kind-cluster.md
+++ b/docs/running-toolhive-in-kind-cluster.md
@@ -1,35 +1,60 @@
-# Running ToolHive Inside a Local Kubernetes Kind Cluster With Ingress
+# Running ToolHive in a local Kubernetes kind cluster with ingress
 
-## Prerequisites:
-- Have a local Kind Cluster running (`kind create cluster`)
-- Have [`ko`](https://ko.build/install/) installed (for building the ToolHive image locally)
-- Have [Taskfile](https://taskfile.dev/installation/) installed (to run automated steps)
-- Git Clone the ToolHive repository
+## Prerequisites
 
-## Deploy an MCP Server into Kind Cluster
+- A [kind](https://kind.sigs.k8s.io/) cluster running locally
+  (`kind create cluster`)
+- [`ko`](https://ko.build/install/) to build the ToolHive image
+- [Task](https://taskfile.dev/installation/) to run automated steps
+- A copy of the ToolHive repository
+  (`git clone https://github.com/StacklokLabs/toolhive`)
 
-To make the deployment of an MCP server easier, we have setup the `test-k8s-apply` task. It will go through and perform the following actions:
+## Deploy an MCP server into a kind cluster
+
+To simplify the deployment of an MCP server, you can use the `test-k8s-apply`
+task. This task performs the following actions:
+
 - Builds the ToolHive container image
-- Outputs the local `kind` cluster config into a local file
-- Loads ToolHive image into Kind
-- Applies example [Kubernetes manifests](../deploy/k8s/thv.yaml) of a Fetch MCP Server
-- Creates a RoleBinding for the ToolHive container to be able to create resources
-- Applies and configures the Nginx Controller manifests for Ingress
+- Outputs the local `kind` cluster configuration to a local file
+- Loads the ToolHive image into the kind cluster
+- Applies example [Kubernetes manifests](../deploy/k8s/thv.yaml) for the
+  [Fetch MCP server](https://github.com/modelcontextprotocol/servers/tree/main/src/fetch)
+- Creates a RoleBinding for the ToolHive container, allowing it to create
+  resources
+- Applies and configures the Nginx Ingress controller manifests
 
-To run this task, in the root of this repository, run `task test-k8s-apply`. Once it has finished, you should have a local Kind cluster with a deployed MCP server. To access it, you can follow the next section of setting up a simple Ingress for it.
+To run this task, navigate to the root of this repository and execute
+`task test-k8s-apply`. Once it completes, you should have a local kind cluster
+with a deployed MCP server. To access it, follow the next section to set up a
+simple ingress controller.
 
-## Setting Up Ingress
+## Ingress configuration
 
-There should now be a local Kind cluster with an MCP server running and a ToolHive proxy running, in addition to an Nginx Ingress controller running and pending an ExternalIP.
+You now have a local kind cluster with an MCP server, ToolHive proxy, and an
+Nginx ingress controller awaiting an ExternalIP.
 
-To give the ingress controller an IP, we will run a local Kind Go binary that acts as a small LoadBalancer that gives IPs to ingress controllers inside of the Kind Cluster. This binary mimicks Cloud Providers LoadBalancers functionality for local Kind setups.
+To assign an IP to the ingress controller, run
+[`cloud-provider-kind`](https://github.com/kubernetes-sigs/cloud-provider-kind),
+a tool that acts as a small LoadBalancer to assign IPs to ingress controllers in
+the kind cluster. This binary mimics the functionality of a cloud provider's
+load balancer capabilities for local kind setups.
+
+In a new terminal, run the following commands and keep the terminal open:
 
 ```shell
+# Linux / macOS with Go installed:
 go install sigs.k8s.io/cloud-provider-kind@latest
 sudo ~/go/bin/cloud-provider-kind
+
+# macOS with Homebrew:
+brew install cloud-provider-kind
+sudo cloud-provider-kind
 ```
 
-After a few moments, the ingress controller should be running and the service should have an external IP set for it. Run the below to get the IP and store it in a variable, and then curl the MCP server endpoint to see a connection.
+After a few moments, the ingress controller should be running, and the service
+should have an external IP assigned. Run the following command to retrieve the
+IP and store it in a variable. Then, curl the MCP server endpoint to verify the
+connection:
 
 ```shell
 $ LB_IP=$(kubectl get svc/ingress-nginx-controller -n ingress-nginx -o=jsonpath='{.status.loadBalancer.ingress[0].ip}')
@@ -38,15 +63,17 @@ event: endpoint
 data: http://172.20.0.3/messages?session_id=637d766e-354a-45b6-bc91-e153a35bc49f
 ```
 
-### Ingress with Local Hostname
+### Ingress with a local hostname
 
-In order to avoid using of the IP you can use a hostname instead of preferred. This can be achieved by modifying the `/etc/hosts` file to include a mapping for the load balancer IP to a friendly hostname.
+If you prefer to use a friendly hostname instead of an IP address, modify your
+`/etc/hosts` file to include a mapping for the load balancer IP. This example
+creates the hostname `mcp-server.dev`:
 
 ```shell
 sudo sh -c "echo '$LB_IP mcp-server.dev' >> /etc/hosts"
 ```
 
-Now when you curl that endpoint, it should connect as it did with the IP
+Now, when you curl that endpoint, it should connect as it did with the IP:
 
 ```shell
 $ curl mcp-server.dev/sse


### PR DESCRIPTION
Run docs thru Prettier and markdownlint, apply some basics from our style guide.

Also polishes the kind guide a bit.