### PR TITLE
fix: removes auto-discovery check for rm

### DIFF
--- a/cmd/thv/rm.go
+++ b/cmd/thv/rm.go
@@ -118,7 +118,7 @@ func rmCmdFunc(_ *cobra.Command, args []string) error {
 
 func shouldRemoveClientConfig() bool {
 	c := config.GetConfig()
-	return len(c.Clients.RegisteredClients) > 0 && c.Clients.AutoDiscovery
+	return len(c.Clients.RegisteredClients) > 0 || c.Clients.AutoDiscovery
 }
 
 // updateClientConfigurations updates client configuration files with the MCP server URL


### PR DESCRIPTION
I left the auto-discovery check in earlier on because of a misunderstanding of what it was, however, it should be an "or" and not an "and" because in the cases where someone hasn't explicitly registered a client but has autodiscovery enabled, the configuration is still updated. For this reason, we also want to remove the configuration on `rm`.