### PR TITLE
Move runner protocol code into pkg

### DIFF
--- a/cmd/thv/app/run.go
+++ b/cmd/thv/app/run.go
@@ -157,8 +157,6 @@ func runCmdFunc(cmd *cobra.Command, args []string) error {
 
 	// Check if the serverOrImage contains a protocol scheme (uvx://, npx://, or go://)
 	// and build a Docker image for it if needed
-	// TODO: Fix log level handling
-	//processedImage, err := handleProtocolScheme(ctx, rt, serverOrImage, debugMode, runCACertPath)
 	processedImage, err := runner.HandleProtocolScheme(ctx, rt, serverOrImage, runCACertPath)
 	if err != nil {
 		return fmt.Errorf("failed to process protocol scheme: %v", err)

--- a/cmd/thv/app/run.go
+++ b/cmd/thv/app/run.go
@@ -157,14 +157,16 @@ func runCmdFunc(cmd *cobra.Command, args []string) error {
 
 	// Check if the serverOrImage contains a protocol scheme (uvx://, npx://, or go://)
 	// and build a Docker image for it if needed
-	processedImage, err := handleProtocolScheme(ctx, rt, serverOrImage, debugMode, runCACertPath)
+	// TODO: Fix log level handling
+	//processedImage, err := handleProtocolScheme(ctx, rt, serverOrImage, debugMode, runCACertPath)
+	processedImage, err := runner.HandleProtocolScheme(ctx, rt, serverOrImage, runCACertPath)
 	if err != nil {
 		return fmt.Errorf("failed to process protocol scheme: %v", err)
 	}
 
 	// Update serverOrImage with the processed image if it was changed
 	if processedImage != serverOrImage {
-		logDebug(debugMode, "Using built image: %s instead of %s", processedImage, serverOrImage)
+		logger.Debugf("Using built image: %s instead of %s", processedImage, serverOrImage)
 		serverOrImage = processedImage
 	}
 

--- a/pkg/runner/protocol.go
+++ b/pkg/runner/protocol.go
@@ -1,4 +1,4 @@
-package app
+package runner
 
 import (
 	"context"
@@ -20,14 +20,13 @@ const (
 	GOScheme  = "go://"
 )
 
-// handleProtocolScheme checks if the serverOrImage string contains a protocol scheme (uvx://, npx://, or go://)
+// HandleProtocolScheme checks if the serverOrImage string contains a protocol scheme (uvx://, npx://, or go://)
 // and builds a Docker image for it if needed.
 // Returns the Docker image name to use and any error encountered.
-func handleProtocolScheme(
+func HandleProtocolScheme(
 	ctx context.Context,
 	runtime rt.Runtime,
 	serverOrImage string,
-	debugMode bool,
 	caCertPath string,
 ) (string, error) {
 	// Check if the serverOrImage starts with a protocol scheme
@@ -63,7 +62,7 @@ func handleProtocolScheme(
 
 	// If a CA certificate path is provided, read the certificate and add it to the template data
 	if caCertPath != "" {
-		logDebug(debugMode, "Using custom CA certificate from: %s", caCertPath)
+		logger.Debugf("Using custom CA certificate from: %s", caCertPath)
 
 		// Read the CA certificate file
 		// #nosec G304 -- This is a user-provided file path that we need to read
@@ -101,7 +100,7 @@ func handleProtocolScheme(
 		if err := os.WriteFile(caCertFilePath, []byte(templateData.CACertContent), 0600); err != nil {
 			return "", fmt.Errorf("failed to write CA certificate file: %w", err)
 		}
-		logDebug(debugMode, "Added CA certificate to build context: %s", caCertFilePath)
+		logger.Debugf("Added CA certificate to build context: %s", caCertFilePath)
 	}
 
 	//dynamically generate tag from timestamp
@@ -114,8 +113,8 @@ func handleProtocolScheme(
 		tag)
 
 	// Log the build process
-	logDebug(debugMode, "Building Docker image for %s package: %s", transportType, packageName)
-	logDebug(debugMode, "Using Dockerfile:\n%s", dockerfileContent)
+	logger.Debugf("Building Docker image for %s package: %s", transportType, packageName)
+	logger.Debugf("Using Dockerfile:\n%s", dockerfileContent)
 
 	// Build the Docker image
 	logger.Infof("Building Docker image for %s package: %s", transportType, packageName)


### PR DESCRIPTION
Since this logic will be reused by the API, move it inside the pkg package.

One minor piece of refactoring: Get rid of the `logDebug` function - the logger code sets the log level to debug if the `--debug` flag is passed to the CLI, so this should not be necessary.