### PR TITLE
Ensure that we do not prompt for passwords in detached mode

### DIFF
--- a/cmd/thv/app/run_common.go
+++ b/cmd/thv/app/run_common.go
@@ -144,7 +144,7 @@ func detachProcess(cmd *cobra.Command, options *runner.RunConfig) error {
 	detachedCmd := exec.Command(execPath, detachedArgs...)
 
 	// Set environment variables for the detached process
-	detachedCmd.Env = append(os.Environ(), "TOOLHIVE_DETACHED=1")
+	detachedCmd.Env = append(os.Environ(), fmt.Sprintf("%s=%s", process.ToolHiveDetachedEnv, process.ToolHiveDetachedValue))
 
 	// If the process needs the decrypt password, pass it as an environment variable.
 	if NeedSecretsPassword(cmd, options.Secrets) {

--- a/pkg/process/detached.go
+++ b/pkg/process/detached.go
@@ -1,0 +1,14 @@
+package process
+
+import "os"
+
+// ToolHiveDetachedEnv is the environment variable used to indicate that the process is running in detached mode.
+const ToolHiveDetachedEnv = "TOOLHIVE_DETACHED"
+
+// ToolHiveDetachedValue is the expected value of ToolHiveDetachedEnv when set.
+const ToolHiveDetachedValue = "1"
+
+// IsDetached checks if the process is running in detached mode.
+func IsDetached() bool {
+	return os.Getenv(ToolHiveDetachedEnv) == ToolHiveDetachedValue
+}

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -130,8 +130,7 @@ func (r *Runner) Run(ctx context.Context) error {
 		logger.Infof("MCP server %s stopped", r.Config.ContainerName)
 	}
 
-	// Check if we're a detached process
-	if os.Getenv("TOOLHIVE_DETACHED") == "1" {
+	if process.IsDetached() {
 		// We're a detached process running in foreground mode
 		// Write the PID to a file so the stop command can kill the process
 		if err := process.WriteCurrentPIDFile(r.Config.BaseName); err != nil {

--- a/pkg/secrets/encrypted.go
+++ b/pkg/secrets/encrypted.go
@@ -1,7 +1,5 @@
 package secrets
 
-// TODO: this file duplicates logic with basic.go. Refactor to share common code.
-
 import (
 	"encoding/json"
 	"errors"

--- a/pkg/secrets/factory.go
+++ b/pkg/secrets/factory.go
@@ -11,6 +11,7 @@ import (
 	"golang.org/x/term"
 
 	"github.com/stacklok/toolhive/pkg/logger"
+	"github.com/stacklok/toolhive/pkg/process"
 )
 
 const (
@@ -60,6 +61,13 @@ func CreateSecretManager(managerType ProviderType) (Provider, error) {
 // It will attempt to retrieve it from the environment variable TOOLHIVE_SECRETS_PASSWORD.
 // If the environment variable is not set, it will prompt the user to enter a password.
 func GetSecretsPassword() ([]byte, error) {
+	// We cannot ask for a password in a detached process.
+	// We should never trigger this, but this ensures that if there's a bug
+	// then it's easier to find.
+	if process.IsDetached() {
+		return nil, fmt.Errorf("detached process detected, cannot ask for password")
+	}
+
 	// First, attempt to load the password from the environment variable.
 	password := []byte(os.Getenv(PasswordEnvVar))
 	if len(password) > 0 {


### PR DESCRIPTION
Enforcing this invariant to simplify some upcoming changes. This also refactors the logic for detecting if we are in a detached processes.