### PR TITLE
Add support for --host flag

### DIFF
--- a/cmd/thv/app/config.go
+++ b/cmd/thv/app/config.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stacklok/toolhive/pkg/labels"
 	"github.com/stacklok/toolhive/pkg/logger"
 	"github.com/stacklok/toolhive/pkg/secrets"
+	"github.com/stacklok/toolhive/pkg/transport"
 )
 
 var configCmd = &cobra.Command{
@@ -262,7 +263,7 @@ func addRunningMCPsToClient(ctx context.Context, clientName string) error {
 		}
 
 		// Generate URL for the MCP server
-		url := client.GenerateMCPServerURL("localhost", port, name)
+		url := client.GenerateMCPServerURL(transport.LocalhostIPv4, port, name)
 
 		// Update each configuration file
 		for _, clientConfig := range clientConfigs {

--- a/cmd/thv/app/list.go
+++ b/cmd/thv/app/list.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stacklok/toolhive/pkg/labels"
 	"github.com/stacklok/toolhive/pkg/lifecycle"
 	"github.com/stacklok/toolhive/pkg/logger"
+	"github.com/stacklok/toolhive/pkg/transport"
 )
 
 var listCmd = &cobra.Command{
@@ -28,10 +29,7 @@ var (
 )
 
 // Constants for list command
-const (
-	defaultHost      = "localhost"
-	unknownTransport = "unknown"
-)
+const unknownTransport = "unknown"
 
 // ContainerOutput represents container information for JSON output
 type ContainerOutput struct {
@@ -100,9 +98,9 @@ func printJSONOutput(containers []rt.ContainerInfo) error {
 		}
 
 		// Get transport type from labels
-		transport := labels.GetTransportType(c.Labels)
-		if transport == "" {
-			transport = unknownTransport
+		t := labels.GetTransportType(c.Labels)
+		if t == "" {
+			t = unknownTransport
 		}
 
 		// Get tool type from labels
@@ -117,7 +115,7 @@ func printJSONOutput(containers []rt.ContainerInfo) error {
 		// Generate URL for the MCP server
 		url := ""
 		if port > 0 {
-			url = client.GenerateMCPServerURL(defaultHost, port, name)
+			url = client.GenerateMCPServerURL(transport.LocalhostIPv4, port, name)
 		}
 
 		output = append(output, ContainerOutput{
@@ -125,7 +123,7 @@ func printJSONOutput(containers []rt.ContainerInfo) error {
 			Name:      name,
 			Image:     c.Image,
 			State:     c.State,
-			Transport: transport,
+			Transport: t,
 			ToolType:  toolType,
 			Port:      port,
 			URL:       url,
@@ -173,7 +171,7 @@ func printMCPServersOutput(containers []rt.ContainerInfo) error {
 		// Generate URL for the MCP server
 		url := ""
 		if port > 0 {
-			url = client.GenerateMCPServerURL(defaultHost, port, name)
+			url = client.GenerateMCPServerURL(transport.LocalhostIPv4, port, name)
 		}
 
 		// Add the MCP server to the map
@@ -216,9 +214,9 @@ func printTextOutput(containers []rt.ContainerInfo) {
 		}
 
 		// Get transport type from labels
-		transport := labels.GetTransportType(c.Labels)
-		if transport == "" {
-			transport = unknownTransport
+		t := labels.GetTransportType(c.Labels)
+		if t == "" {
+			t = unknownTransport
 		}
 
 		// Get port from labels
@@ -230,7 +228,7 @@ func printTextOutput(containers []rt.ContainerInfo) {
 		// Generate URL for the MCP server
 		url := ""
 		if port > 0 {
-			url = client.GenerateMCPServerURL(defaultHost, port, name)
+			url = client.GenerateMCPServerURL(transport.LocalhostIPv4, port, name)
 		}
 
 		// Print container information
@@ -239,7 +237,7 @@ func printTextOutput(containers []rt.ContainerInfo) {
 			name,
 			c.Image,
 			c.State,
-			transport,
+			t,
 			port,
 			url,
 		)

--- a/cmd/thv/app/proxy.go
+++ b/cmd/thv/app/proxy.go
@@ -32,7 +32,7 @@ var (
 )
 
 func init() {
-	proxyCmd.Flags().StringVar(&proxyHost, "host", transport.LocalhostName, "Host for the HTTP proxy to listen on (IP or hostname)")
+	proxyCmd.Flags().StringVar(&proxyHost, "host", transport.LocalhostIPv4, "Host for the HTTP proxy to listen on (IP or hostname)")
 	proxyCmd.Flags().IntVar(&proxyPort, "port", 0, "Port for the HTTP proxy to listen on (host port)")
 	proxyCmd.Flags().StringVar(
 		&proxyTargetURI,

--- a/cmd/thv/app/run.go
+++ b/cmd/thv/app/run.go
@@ -75,13 +75,13 @@ var (
 func init() {
 	runCmd.Flags().StringVar(&runTransport, "transport", "stdio", "Transport mode (sse or stdio)")
 	runCmd.Flags().StringVar(&runName, "name", "", "Name of the MCP server (auto-generated from image if not provided)")
-	runCmd.Flags().StringVar(&runHost, "host", transport.LocalhostName, "Host for the HTTP proxy to listen on (IP or hostname)")
+	runCmd.Flags().StringVar(&runHost, "host", transport.LocalhostIPv4, "Host for the HTTP proxy to listen on (IP or hostname)")
 	runCmd.Flags().IntVar(&runPort, "port", 0, "Port for the HTTP proxy to listen on (host port)")
 	runCmd.Flags().IntVar(&runTargetPort, "target-port", 0, "Port for the container to expose (only applicable to SSE transport)")
 	runCmd.Flags().StringVar(
 		&runTargetHost,
 		"target-host",
-		"localhost",
+		transport.LocalhostIPv4,
 		"Host to forward traffic to (only applicable to SSE transport)")
 	runCmd.Flags().StringVar(
 		&runPermissionProfile,

--- a/docs/cli/thv_proxy.md
+++ b/docs/cli/thv_proxy.md
@@ -15,6 +15,7 @@ thv proxy [flags] SERVER_NAME
 
 ```
   -h, --help                    help for proxy
+      --host string             Host for the HTTP proxy to listen on (IP or hostname) (default "localhost")
       --oidc-audience string    Expected audience for the token
       --oidc-client-id string   OIDC client ID
       --oidc-issuer string      OIDC issuer URL (e.g., https://accounts.google.com)

--- a/docs/cli/thv_proxy.md
+++ b/docs/cli/thv_proxy.md
@@ -15,7 +15,7 @@ thv proxy [flags] SERVER_NAME
 
 ```
   -h, --help                    help for proxy
-      --host string             Host for the HTTP proxy to listen on (IP or hostname) (default "localhost")
+      --host string             Host for the HTTP proxy to listen on (IP or hostname) (default "127.0.0.1")
       --oidc-audience string    Expected audience for the token
       --oidc-client-id string   OIDC client ID
       --oidc-issuer string      OIDC issuer URL (e.g., https://accounts.google.com)

--- a/docs/cli/thv_run.md
+++ b/docs/cli/thv_run.md
@@ -40,6 +40,7 @@ thv run [flags] SERVER_OR_IMAGE_OR_PROTOCOL [-- ARGS...]
   -e, --env stringArray             Environment variables to pass to the MCP server (format: KEY=VALUE)
   -f, --foreground                  Run in foreground mode (block until container exits)
   -h, --help                        help for run
+      --host string                 Host for the HTTP proxy to listen on (IP or hostname) (default "localhost")
       --k8s-pod-patch string        JSON string to patch the Kubernetes pod template (only applicable when using Kubernetes runtime)
       --name string                 Name of the MCP server (auto-generated from image if not provided)
       --oidc-audience string        Expected audience for the token

--- a/docs/cli/thv_run.md
+++ b/docs/cli/thv_run.md
@@ -40,7 +40,7 @@ thv run [flags] SERVER_OR_IMAGE_OR_PROTOCOL [-- ARGS...]
   -e, --env stringArray             Environment variables to pass to the MCP server (format: KEY=VALUE)
   -f, --foreground                  Run in foreground mode (block until container exits)
   -h, --help                        help for run
-      --host string                 Host for the HTTP proxy to listen on (IP or hostname) (default "localhost")
+      --host string                 Host for the HTTP proxy to listen on (IP or hostname) (default "127.0.0.1")
       --k8s-pod-patch string        JSON string to patch the Kubernetes pod template (only applicable when using Kubernetes runtime)
       --name string                 Name of the MCP server (auto-generated from image if not provided)
       --oidc-audience string        Expected audience for the token
@@ -50,7 +50,7 @@ thv run [flags] SERVER_OR_IMAGE_OR_PROTOCOL [-- ARGS...]
       --permission-profile string   Permission profile to use (none, network, or path to JSON file) (default "network")
       --port int                    Port for the HTTP proxy to listen on (host port)
       --secret stringArray          Specify a secret to be fetched from the secrets manager and set as an environment variable (format: NAME,target=TARGET)
-      --target-host string          Host to forward traffic to (only applicable to SSE transport) (default "localhost")
+      --target-host string          Host to forward traffic to (only applicable to SSE transport) (default "127.0.0.1")
       --target-port int             Port for the container to expose (only applicable to SSE transport)
       --transport string            Transport mode (sse or stdio) (default "stdio")
   -v, --volume stringArray          Mount a volume into the container (format: host-path:container-path[:ro])

--- a/pkg/api/v1/servers.go
+++ b/pkg/api/v1/servers.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stacklok/toolhive/pkg/permissions"
 	"github.com/stacklok/toolhive/pkg/runner"
 	"github.com/stacklok/toolhive/pkg/secrets"
+	"github.com/stacklok/toolhive/pkg/transport"
 )
 
 // ServerRoutes defines the routes for server management.
@@ -144,12 +145,13 @@ func (s *ServerRoutes) createServer(w http.ResponseWriter, r *http.Request) {
 		s.containerRuntime,
 		req.CmdArguments,
 		req.Name,
+		req.Host,
 		s.debugMode,
 		req.Volumes,
 		runSecrets,
 		req.AuthzConfig,
 		req.PermissionProfile,
-		"localhost", // Seems like a reasonable default for now.
+		transport.LocalhostIPv4, // Seems like a reasonable default for now.
 		req.OIDC.Issuer,
 		req.OIDC.Audience,
 		req.OIDC.JwksURL,
@@ -227,6 +229,7 @@ type serverListResponse struct {
 type createRequest struct {
 	Name              string                    `json:"name"`
 	Image             string                    `json:"image"`
+	Host              string                    `json:"host"`
 	CmdArguments      []string                  `json:"cmd_arguments"`
 	TargetPort        int                       `json:"target_port"`
 	EnvVars           []string                  `json:"env_vars"`

--- a/pkg/lifecycle/manager.go
+++ b/pkg/lifecycle/manager.go
@@ -209,9 +209,14 @@ func (*defaultManager) RunContainerDetached(runConfig *runner.RunConfig) error {
 		detachedArgs = append(detachedArgs, "--name", runConfig.ContainerName)
 	}
 
+	if runConfig.Host != "" {
+		detachedArgs = append(detachedArgs, "--host", runConfig.Host)
+	}
+
 	if runConfig.Port != 0 {
 		detachedArgs = append(detachedArgs, "--port", fmt.Sprintf("%d", runConfig.Port))
 	}
+
 	if runConfig.TargetPort != 0 {
 		detachedArgs = append(detachedArgs, "--target-port", fmt.Sprintf("%d", runConfig.TargetPort))
 	}

--- a/pkg/runner/config.go
+++ b/pkg/runner/config.go
@@ -41,6 +41,9 @@ type RunConfig struct {
 	// Transport is the transport mode (sse or stdio)
 	Transport types.TransportType `json:"transport" yaml:"transport"`
 
+	// Host is the host for the HTTP proxy
+	Host string `json:"host" yaml:"host"`
+
 	// Port is the port for the HTTP proxy to listen on (host port)
 	Port int `json:"port" yaml:"port"`
 
@@ -120,6 +123,7 @@ func NewRunConfigFromFlags(
 	runtime rt.Runtime,
 	cmdArgs []string,
 	name string,
+	host string,
 	debug bool,
 	volumes []string,
 	secretsList []string,
@@ -143,6 +147,7 @@ func NewRunConfigFromFlags(
 		TargetHost:                  targetHost,
 		ContainerLabels:             make(map[string]string),
 		EnvVars:                     make(map[string]string),
+		Host:                        host,
 	}
 
 	// Set OIDC config if any values are provided

--- a/pkg/runner/config.go
+++ b/pkg/runner/config.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stacklok/toolhive/pkg/networking"
 	"github.com/stacklok/toolhive/pkg/permissions"
 	"github.com/stacklok/toolhive/pkg/secrets"
+	"github.com/stacklok/toolhive/pkg/transport"
 	"github.com/stacklok/toolhive/pkg/transport/types"
 )
 
@@ -135,6 +136,13 @@ func NewRunConfigFromFlags(
 	oidcJwksURL string,
 	oidcClientID string,
 ) *RunConfig {
+	// Ensure default values for host and targetHost
+	if host == "" {
+		host = transport.LocalhostIPv4
+	}
+	if targetHost == "" {
+		targetHost = transport.LocalhostIPv4
+	}
 	config := &RunConfig{
 		Runtime:                     runtime,
 		CmdArgs:                     cmdArgs,
@@ -170,10 +178,10 @@ func (c *RunConfig) WithAuthz(config *authz.Config) *RunConfig {
 }
 
 // WithTransport parses and sets the transport type
-func (c *RunConfig) WithTransport(transport string) (*RunConfig, error) {
-	transportType, err := types.ParseTransportType(transport)
+func (c *RunConfig) WithTransport(t string) (*RunConfig, error) {
+	transportType, err := types.ParseTransportType(t)
 	if err != nil {
-		return c, fmt.Errorf("invalid transport mode: %s. Valid modes are: sse, stdio", transport)
+		return c, fmt.Errorf("invalid transport mode: %s. Valid modes are: sse, stdio", t)
 	}
 	c.Transport = transportType
 	return c, nil

--- a/pkg/runner/config_test.go
+++ b/pkg/runner/config_test.go
@@ -804,6 +804,7 @@ func TestNewRunConfigFromFlags(t *testing.T) {
 	runtime := &mockRuntime{}
 	cmdArgs := []string{"arg1", "arg2"}
 	name := "test-server"
+	host := "localhost"
 	debug := true
 	volumes := []string{"/host:/container"}
 	secretsList := []string{"secret1,target=ENV_VAR1"}
@@ -819,6 +820,7 @@ func TestNewRunConfigFromFlags(t *testing.T) {
 		runtime,
 		cmdArgs,
 		name,
+		host,
 		debug,
 		volumes,
 		secretsList,

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -41,7 +41,7 @@ func (r *Runner) Run(ctx context.Context) error {
 		Type:       r.Config.Transport,
 		Port:       r.Config.Port,
 		TargetPort: r.Config.TargetPort,
-		Host:       "localhost",
+		Host:       r.Config.Host,
 		TargetHost: r.Config.TargetHost,
 		Runtime:    r.Config.Runtime,
 		Debug:      r.Config.Debug,

--- a/pkg/transport/factory.go
+++ b/pkg/transport/factory.go
@@ -19,7 +19,7 @@ func NewFactory() *Factory {
 func (*Factory) Create(config types.Config) (types.Transport, error) {
 	switch config.Type {
 	case types.TransportTypeStdio:
-		return NewStdioTransport(config.Port, config.Runtime, config.Debug, config.Middlewares...), nil
+		return NewStdioTransport(config.Host, config.Port, config.Runtime, config.Debug, config.Middlewares...), nil
 	case types.TransportTypeSSE:
 		return NewSSETransport(
 			config.Host,

--- a/pkg/transport/sse.go
+++ b/pkg/transport/sse.go
@@ -17,6 +17,8 @@ import (
 const (
 	// LocalhostName is the standard hostname for localhost
 	LocalhostName = "localhost"
+	// LocalhostIPv4 is the standard IPv4 address for localhost
+	LocalhostIPv4 = "127.0.0.1"
 )
 
 // SSETransport implements the Transport interface using Server-Sent Events.
@@ -56,12 +58,12 @@ func NewSSETransport(
 	middlewares ...types.Middleware,
 ) *SSETransport {
 	if host == "" {
-		host = LocalhostName
+		host = LocalhostIPv4
 	}
 
 	// If targetHost is not specified, default to localhost
 	if targetHost == "" {
-		targetHost = LocalhostName
+		targetHost = LocalhostIPv4
 	}
 
 	return &SSETransport{

--- a/pkg/transport/sse.go
+++ b/pkg/transport/sse.go
@@ -8,7 +8,6 @@ import (
 	"github.com/stacklok/toolhive/pkg/container"
 	rt "github.com/stacklok/toolhive/pkg/container/runtime"
 	"github.com/stacklok/toolhive/pkg/logger"
-	"github.com/stacklok/toolhive/pkg/networking"
 	"github.com/stacklok/toolhive/pkg/permissions"
 	"github.com/stacklok/toolhive/pkg/transport/errors"
 	"github.com/stacklok/toolhive/pkg/transport/proxy/transparent"
@@ -112,21 +111,21 @@ func (t *SSETransport) Setup(ctx context.Context, runtime rt.Runtime, containerN
 	containerPortStr := fmt.Sprintf("%d/tcp", t.targetPort)
 	containerOptions.ExposedPorts[containerPortStr] = struct{}{}
 
-	// Create port bindings for localhost
+	// Create host port bindings (configurable through the --host flag)
 	portBindings := []rt.PortBinding{
 		{
-			HostIP:   "127.0.0.1", // IPv4 localhost
+			HostIP:   t.host,
 			HostPort: fmt.Sprintf("%d", t.targetPort),
 		},
 	}
 
-	// Check if IPv6 is available and add IPv6 localhost binding
-	if networking.IsIPv6Available() {
-		portBindings = append(portBindings, rt.PortBinding{
-			HostIP:   "::1", // IPv6 localhost
-			HostPort: fmt.Sprintf("%d", t.targetPort),
-		})
-	}
+	// Check if IPv6 is available and add IPv6 localhost binding (commented out for now)
+	//if networking.IsIPv6Available() {
+	//	portBindings = append(portBindings, rt.PortBinding{
+	//		HostIP:   "::1", // IPv6 localhost
+	//		HostPort: fmt.Sprintf("%d", t.targetPort),
+	//	})
+	//}
 
 	// Set the port bindings
 	containerOptions.PortBindings[containerPortStr] = portBindings
@@ -195,7 +194,7 @@ func (t *SSETransport) Start(ctx context.Context) error {
 		t.port, targetURI)
 
 	// Create the transparent proxy with middlewares
-	t.proxy = transparent.NewTransparentProxy(t.port, t.containerName, targetURI, t.middlewares...)
+	t.proxy = transparent.NewTransparentProxy(t.host, t.port, t.containerName, targetURI, t.middlewares...)
 	if err := t.proxy.Start(ctx); err != nil {
 		return err
 	}

--- a/pkg/transport/stdio.go
+++ b/pkg/transport/stdio.go
@@ -24,6 +24,7 @@ import (
 // StdioTransport implements the Transport interface using standard input/output.
 // It acts as a proxy between the MCP client and the container's stdin/stdout.
 type StdioTransport struct {
+	host          string
 	port          int
 	containerID   string
 	containerName string
@@ -51,12 +52,14 @@ type StdioTransport struct {
 
 // NewStdioTransport creates a new stdio transport.
 func NewStdioTransport(
+	host string,
 	port int,
 	runtime rt.Runtime,
 	debug bool,
 	middlewares ...types.Middleware,
 ) *StdioTransport {
 	return &StdioTransport{
+		host:        host,
 		port:        port,
 		runtime:     runtime,
 		debug:       debug,
@@ -148,7 +151,7 @@ func (t *StdioTransport) Start(ctx context.Context) error {
 	}
 
 	// Create and start the HTTP SSE proxy with middlewares
-	t.httpProxy = httpsse.NewHTTPSSEProxy(t.port, t.containerName, t.middlewares...)
+	t.httpProxy = httpsse.NewHTTPSSEProxy(t.host, t.port, t.containerName, t.middlewares...)
 	if err := t.httpProxy.Start(ctx); err != nil {
 		return err
 	}


### PR DESCRIPTION
The following PR adds support for the `--host` CLI flag which should make the host address of the proxies configurable. 

Unfortunately I was not able to reproduce this issue in the first place on my machine, so I'll appreciate a more detailed review or if someone can reproduce it on their side it would be even better.

Related: #362 