### PR TITLE
Change Taskfile for lighter ko builds

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -67,8 +67,10 @@ tasks:
 
   build-image:
     desc: Build the image with ko
+    env:
+      KO_DOCKER_REPO: ghcr.io/stacklok/toolhive
     cmds:
-      - ko build --platform linux/amd64,linux/arm64 --local ./cmd/thv
+      - ko build --local --bare ./cmd/thv
 
   kind-setup:
     desc: Setup a local Kind cluster


### PR DESCRIPTION
This stops building multi-arch images in the local `ko` build. This will
make local builds a lot faster. It also changes the image reference to
use the one we build upstream.

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>
