### PR TITLE
Initialize logger on command run

### DIFF
--- a/cmd/thv/app/commands.go
+++ b/cmd/thv/app/commands.go
@@ -73,12 +73,12 @@ func checkForUpdates() {
 	updateChecker, err := updates.NewUpdateChecker(versionClient)
 	// treat update-related errors as non-fatal
 	if err != nil {
-		logger.Errorf("unable to create update client: %w", err)
+		logger.Warnf("unable to create update client: %s", err)
 		return
 	}
 
 	err = updateChecker.CheckLatestVersion()
 	if err != nil {
-		logger.Errorf("error while checking for updates: %w", err)
+		logger.Warnf("could not check for updates: %s", err)
 	}
 }

--- a/cmd/thv/main.go
+++ b/cmd/thv/main.go
@@ -6,9 +6,13 @@ import (
 	"os"
 
 	"github.com/stacklok/toolhive/cmd/thv/app"
+	"github.com/stacklok/toolhive/pkg/logger"
 )
 
 func main() {
+	// Initialize the logger
+	logger.Initialize()
+
 	if err := app.NewRootCmd().Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "there was an error: %v\n", err)
 		os.Exit(1)


### PR DESCRIPTION
This ensures that we have a valid logger when needed. And it addresses
the issue reported by Andrew Block in #342 where we'd segfault.

The segfault was actually not because of the user being different, but
because we were trying to log an error on a logger that's nil.

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>
