### PR TITLE
Add initial API server to ToolHive

### DIFF
--- a/cmd/thv/app/commands.go
+++ b/cmd/thv/app/commands.go
@@ -48,6 +48,7 @@ func NewRootCmd() *cobra.Command {
 	rootCmd.AddCommand(rmCmd)
 	rootCmd.AddCommand(proxyCmd)
 	rootCmd.AddCommand(restartCmd)
+	rootCmd.AddCommand(serveCmd)
 	rootCmd.AddCommand(newVersionCmd())
 	rootCmd.AddCommand(logsCommand())
 	rootCmd.AddCommand(newSecretCommand())

--- a/cmd/thv/app/server.go
+++ b/cmd/thv/app/server.go
@@ -1,0 +1,34 @@
+package app
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+
+	"github.com/spf13/cobra"
+
+	s "github.com/stacklok/toolhive/pkg/api"
+)
+
+var (
+	host string
+	port int
+)
+
+var serveCmd = &cobra.Command{
+	Use:   "serve",
+	Short: "Start the ToolHive API server",
+	Long:  `Starts the ToolHive API server and listen for HTTP requests.`,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		// Ensure server is shutdown gracefully on Ctrl+C.
+		ctx, cancel := signal.NotifyContext(cmd.Context(), os.Interrupt)
+		defer cancel()
+		address := fmt.Sprintf("%s:%d", host, port)
+		return s.Serve(ctx, address)
+	},
+}
+
+func init() {
+	serveCmd.Flags().StringVar(&host, "host", "127.0.0.1", "Host address to bind the server to")
+	serveCmd.Flags().IntVar(&port, "port", 8080, "Port to bind the server to")
+}

--- a/docs/cli/thv.md
+++ b/docs/cli/thv.md
@@ -34,6 +34,7 @@ thv [flags]
 * [thv run](thv_run.md)	 - Run an MCP server
 * [thv search](thv_search.md)	 - Search for MCP servers
 * [thv secret](thv_secret.md)	 - Manage secrets
+* [thv serve](thv_serve.md)	 - Start the ToolHive API server
 * [thv stop](thv_stop.md)	 - Stop an MCP server
 * [thv version](thv_version.md)	 - Show the version of ToolHive
 

--- a/docs/cli/thv_serve.md
+++ b/docs/cli/thv_serve.md
@@ -1,0 +1,30 @@
+## thv serve
+
+Start the ToolHive API server
+
+### Synopsis
+
+Starts the ToolHive API server and listen for HTTP requests.
+
+```
+thv serve [flags]
+```
+
+### Options
+
+```
+  -h, --help          help for serve
+      --host string   Host address to bind the server to (default "127.0.0.1")
+      --port int      Port to bind the server to (default 8080)
+```
+
+### Options inherited from parent commands
+
+```
+      --debug   Enable debug mode
+```
+
+### SEE ALSO
+
+* [thv](thv.md)	 - ToolHive (thv) is a lightweight, secure, and fast manager for MCP servers
+

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/docker/docker v28.1.1+incompatible
 	github.com/docker/go-connections v0.5.0
+	github.com/go-chi/chi/v5 v5.2.1
 	github.com/gofrs/flock v0.12.1
 	github.com/google/go-containerregistry v0.20.3
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -57,6 +57,8 @@ github.com/fsnotify/fsnotify v1.8.0 h1:dAwr6QBTBZIkG8roQaJjGof0pp0EeF+tNV7YBP3F/
 github.com/fsnotify/fsnotify v1.8.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/fxamacker/cbor/v2 v2.7.0 h1:iM5WgngdRBanHcxugY4JySA0nk1wZorNOpTgCMedv5E=
 github.com/fxamacker/cbor/v2 v2.7.0/go.mod h1:pxXPTn3joSm21Gbwsv0w9OSA2y1HFR9qXEeXQVeNoDQ=
+github.com/go-chi/chi/v5 v5.2.1 h1:KOIHODQj58PmL80G2Eak4WdvUzjSJSm0vG72crDCqb8=
+github.com/go-chi/chi/v5 v5.2.1/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
 github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -1,0 +1,67 @@
+// Package api contains the REST API for ToolHive.
+package api
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
+
+	v1 "github.com/stacklok/toolhive/pkg/api/v1"
+	"github.com/stacklok/toolhive/pkg/logger"
+)
+
+// Not sure if these values need to be configurable.
+const (
+	middlewareTimeout = 60 * time.Second
+	readHeaderTimeout = 10 * time.Second
+)
+
+// Serve starts the HTTP server on the given address and serves the API.
+// It is assumed that the caller sets up appropriate signal handling.
+func Serve(ctx context.Context, address string) error {
+	r := chi.NewRouter()
+	r.Use(
+		middleware.RequestID,
+		// TODO: Figure out logging middleware. We may want to use a different logger.
+		middleware.Timeout(middlewareTimeout),
+	)
+
+	routers := map[string]http.Handler{
+		"/health":         v1.HealthcheckRouter(),
+		"/api/v1/version": v1.VersionRouter(),
+	}
+	for prefix, router := range routers {
+		r.Mount(prefix, router)
+	}
+
+	srv := &http.Server{
+		BaseContext:       func(net.Listener) context.Context { return ctx },
+		Addr:              address,
+		Handler:           r,
+		ReadHeaderTimeout: readHeaderTimeout,
+	}
+
+	logger.Infof("starting http server on %s", srv.Addr)
+
+	// Start server.
+	go func() {
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			logger.Panicf("server stopped with error: %v", err)
+		}
+	}()
+
+	// Kill server on context shutdown.
+	<-ctx.Done()
+	if err := srv.Shutdown(ctx); err != nil {
+		return fmt.Errorf("server shutdown failed:%+v", err)
+	}
+
+	logger.Infof("http server stopped")
+	return nil
+}

--- a/pkg/api/v1/healtcheck_test.go
+++ b/pkg/api/v1/healtcheck_test.go
@@ -1,0 +1,17 @@
+package v1
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetHealthcheck(t *testing.T) {
+	t.Parallel()
+	resp := httptest.NewRecorder()
+	getHealthcheck(resp, nil)
+	require.Equal(t, http.StatusNoContent, resp.Code)
+	require.Empty(t, resp.Body)
+}

--- a/pkg/api/v1/healthcheck.go
+++ b/pkg/api/v1/healthcheck.go
@@ -1,0 +1,18 @@
+package v1
+
+import (
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// HealthcheckRouter sets up healthcheck route.
+func HealthcheckRouter() http.Handler {
+	r := chi.NewRouter()
+	r.Get("/", getHealthcheck)
+	return r
+}
+
+func getHealthcheck(w http.ResponseWriter, _ *http.Request) {
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/pkg/api/v1/version.go
+++ b/pkg/api/v1/version.go
@@ -1,0 +1,32 @@
+// Package v1 contains the V1 API for ToolHive.
+package v1
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/stacklok/toolhive/pkg/versions"
+)
+
+// VersionRouter sets up version route.
+func VersionRouter() http.Handler {
+	r := chi.NewRouter()
+	r.Get("/", getVersion)
+	return r
+}
+
+type versionResponse struct {
+	Version string `json:"version"`
+}
+
+func getVersion(w http.ResponseWriter, _ *http.Request) {
+	versionInfo := versions.GetVersionInfo()
+	err := json.NewEncoder(w).Encode(versionResponse{Version: versionInfo.Version})
+	if err != nil {
+		http.Error(w, "Failed to marshal version info", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+}

--- a/pkg/api/v1/version_test.go
+++ b/pkg/api/v1/version_test.go
@@ -1,0 +1,20 @@
+package v1
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetVersion(t *testing.T) {
+	t.Parallel()
+	resp := httptest.NewRecorder()
+	getVersion(resp, nil)
+	require.Equal(t, http.StatusOK, resp.Code)
+	var version versionResponse
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&version))
+	require.Equal(t, "dev", version.Version)
+}

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -55,6 +55,16 @@ func Errorf(msg string, args ...any) {
 	log.Errorf(msg, args)
 }
 
+// Panic logs a message at error level using the singleton logger and panics the program.
+func Panic(msg string, args ...any) {
+	log.Panic(msg, args)
+}
+
+// Panicf logs a message at error level using the singleton logger and panics the program.
+func Panicf(msg string, args ...any) {
+	log.Panicf(msg, args)
+}
+
 // Logger provides a unified interface for logging
 type Logger interface {
 	Debug(msg string, args ...any)
@@ -65,6 +75,8 @@ type Logger interface {
 	Warnf(msg string, args ...any)
 	Error(msg string, args ...any)
 	Errorf(msg string, args ...any)
+	Panic(msg string, args ...any)
+	Panicf(msg string, args ...any)
 }
 
 // Implementation using slog
@@ -88,6 +100,12 @@ func (l *slogLogger) Errorf(msg string, args ...any) {
 	l.logger.Error(fmt.Sprintf(msg, args...))
 }
 
+func (l *slogLogger) Panicf(msg string, args ...any) {
+	l.logger.Error(fmt.Sprintf(msg, args...))
+	// TODO: Check if logger has native panic method.
+	panic(msg)
+}
+
 func (l *slogLogger) Debug(msg string, args ...any) {
 	l.logger.Debug(msg, args...)
 }
@@ -102,6 +120,11 @@ func (l *slogLogger) Warn(msg string, args ...any) {
 
 func (l *slogLogger) Error(msg string, args ...any) {
 	l.logger.Error(msg, args...)
+}
+
+func (l *slogLogger) Panic(msg string, args ...any) {
+	l.logger.Error(msg, args...)
+	panic(msg)
 }
 
 func unstructuredLogs() bool {


### PR DESCRIPTION
This PR adds a `serve` command along with scaffolding for the API. Two basic endpoints are provided - a healthcheck, and a version endpoint.

The HTTP server is not yet integrated with logging - I think we need to consider getting rid of our own logging interface and use something like zerolog instead.