### PR TITLE
fix: use correct container name when updating mcpServer client config and display stop command

### DIFF
--- a/pkg/lifecycle/manager.go
+++ b/pkg/lifecycle/manager.go
@@ -197,6 +197,11 @@ func (*defaultManager) RunContainerDetached(runConfig *runner.RunConfig) error {
 		detachedArgs = append(detachedArgs, "--name", runConfig.Name)
 	}
 
+	// Use ContainerName if available
+	if runConfig.ContainerName != "" {
+		detachedArgs = append(detachedArgs, "--name", runConfig.ContainerName)
+	}
+
 	if runConfig.Port != 0 {
 		detachedArgs = append(detachedArgs, "--port", fmt.Sprintf("%d", runConfig.Port))
 	}
@@ -304,7 +309,7 @@ func (*defaultManager) RunContainerDetached(runConfig *runner.RunConfig) error {
 	}
 
 	logger.Infof("MCP server is running in the background (PID: %d)", detachedCmd.Process.Pid)
-	logger.Infof("Use 'thv stop %s' to stop the server", runConfig.Name)
+	logger.Infof("Use 'thv stop %s' to stop the server", runConfig.ContainerName)
 
 	return nil
 }

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -130,7 +130,7 @@ func (r *Runner) Run(ctx context.Context) error {
 	// Update client configurations with the MCP server URL.
 	// Note that this function checks the configuration to determine which
 	// clients should be updated, if any.
-	if err := updateClientConfigurations(r.Config.BaseName, "localhost", r.Config.Port); err != nil {
+	if err := updateClientConfigurations(r.Config.ContainerName, "localhost", r.Config.Port); err != nil {
 		logger.Warnf("Warning: Failed to update client configurations: %v", err)
 	}
 


### PR DESCRIPTION
If you run `thv run uvx://mcp-server-fetch` then the server name thats inserted into the mcp server client config isn't actually the server name that you get from `thv list`. This PR fixes that by using the correct name.

In addition, it was spotted that in the case where you run the above command, the `thv stop` output was empty in the run log line:
```log
2:17PM INF Use 'thv stop []' to stop the server
```

This was because we are only setting the value if the `--name` isn't empty. In this case it is, so the fix here is to use the `containerName` if it is not nil.

Results:
```log
2:17PM INF Use 'thv stop [toolhivelocal-uvx-mcp-server-fetch-1747135035]' to stop the server
```

Ref: https://github.com/stacklok/toolhive/issues/360