### PR TITLE
Improve version handling for local builds

### DIFF
--- a/pkg/api/v1/version_test.go
+++ b/pkg/api/v1/version_test.go
@@ -16,5 +16,5 @@ func TestGetVersion(t *testing.T) {
 	require.Equal(t, http.StatusOK, resp.Code)
 	var version versionResponse
 	require.NoError(t, json.NewDecoder(resp.Body).Decode(&version))
-	require.Equal(t, "dev", version.Version)
+	require.Contains(t, version.Version, "build-")
 }

--- a/pkg/updates/checker.go
+++ b/pkg/updates/checker.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/adrg/xdg"
@@ -125,8 +126,12 @@ func (d *defaultUpdateChecker) CheckLatestVersion() error {
 	return nil
 }
 
-func notifyIfUpdateAvailable(currentVersion, latestVersion string) {
-	current, latest := currentVersion, latestVersion
+func notifyIfUpdateAvailable(current, latest string) {
+	// Print a meaningful message for people running local builds.
+	if strings.HasPrefix(current, "build-") {
+		fmt.Printf("You are running a local build of ToolHive, latest release is: %s\n", latest)
+		return
+	}
 	// Ensure both versions have the 'v' prefix for proper semantic version comparison
 	if !semver.IsValid(current) {
 		current = fmt.Sprintf("v%s", current)
@@ -136,6 +141,6 @@ func notifyIfUpdateAvailable(currentVersion, latestVersion string) {
 	}
 	// Compare the versions ensuring their canonical forms
 	if semver.Compare(semver.Canonical(current), semver.Canonical(latest)) < 0 {
-		fmt.Printf("A new version of ToolHive is available: %s\nCurrently running: %s\n", latestVersion, currentVersion)
+		fmt.Printf("A new version of ToolHive is available: %s\nCurrently running: %s\n", latest, current)
 	}
 }

--- a/pkg/versions/version.go
+++ b/pkg/versions/version.go
@@ -66,6 +66,14 @@ func GetVersionInfo() VersionInfo {
 		}
 	}
 
+	// If the version is just "dev" - manufacture a version string using the commit.
+	// NOTE: Ignore any IDE warnings about this condition always being true - it is
+	// overridden by the build flags.
+	if ver == "dev" {
+		// Truncate commit to 8 characters for brevity.
+		ver = fmt.Sprintf("build-%s", fmt.Sprintf("%.*s", 8, commit))
+	}
+
 	return VersionInfo{
 		Version:   ver,
 		Commit:    commit,


### PR DESCRIPTION
Previously the application defaulted to a version of "dev" when building thv from source. Change the logic to manufacture a version string consisting of "build-" followed by the first eight characters of the commit SHA. If the commit SHA is unavailable, the version will be "build-unknown".

As part of this change, the update checking logic will print a more meaningful message instead of blindly telling the user that an update is available.