### PR TITLE
feat: add support for custom container socket paths in Docker client

### DIFF
--- a/pkg/container/docker/client.go
+++ b/pkg/container/docker/client.go
@@ -41,6 +41,14 @@ const (
 	DockerDesktopMacSocketPath = ".docker/run/docker.sock"
 )
 
+// Environment variable names
+const (
+	// DockerSocketEnv is the environment variable for custom Docker socket path
+	DockerSocketEnv = "TOOLHIVE_DOCKER_SOCKET"
+	// PodmanSocketEnv is the environment variable for custom Podman socket path
+	PodmanSocketEnv = "TOOLHIVE_PODMAN_SOCKET"
+)
+
 var supportedSocketPaths = []runtime.Type{runtime.TypePodman, runtime.TypeDocker}
 
 // Client implements the Runtime interface for container operations
@@ -133,9 +141,8 @@ func (c *Client) ping(ctx context.Context) error {
 
 // findContainerSocket finds a container socket path, preferring Podman over Docker
 func findContainerSocket(rt runtime.Type) (string, runtime.Type, error) {
-
 	// First check for custom socket paths via environment variables
-	if customSocketPath := os.Getenv("TOOLHIVE_PODMAN_SOCKET"); customSocketPath != "" {
+	if customSocketPath := os.Getenv(PodmanSocketEnv); customSocketPath != "" {
 		logger.Debugf("Found custom Podman socket at %s", customSocketPath)
 		// validate the socket path
 		if _, err := os.Stat(customSocketPath); err != nil {
@@ -144,7 +151,7 @@ func findContainerSocket(rt runtime.Type) (string, runtime.Type, error) {
 		return customSocketPath, runtime.TypePodman, nil
 	}
 
-	if customSocketPath := os.Getenv("TOOLHIVE_DOCKER_SOCKET"); customSocketPath != "" {
+	if customSocketPath := os.Getenv(DockerSocketEnv); customSocketPath != "" {
 		logger.Debugf("Found custom Docker socket at %s", customSocketPath)
 		// validate the socket path
 		if _, err := os.Stat(customSocketPath); err != nil {

--- a/pkg/container/docker/client.go
+++ b/pkg/container/docker/client.go
@@ -39,6 +39,10 @@ const (
 	DockerSocketPath = "/var/run/docker.sock"
 	// DockerDesktopMacSocketPath is the Docker Desktop socket path on macOS
 	DockerDesktopMacSocketPath = ".docker/run/docker.sock"
+	// DockerSocketSuffix is the suffix for Docker socket files
+	DockerSocketSuffix = "docker.sock"
+	// PodmanSocketSuffix is the suffix for Podman socket files
+	PodmanSocketSuffix = "podman.sock"
 )
 
 var supportedSocketPaths = []runtime.Type{runtime.TypePodman, runtime.TypeDocker}
@@ -137,10 +141,10 @@ func findContainerSocket(rt runtime.Type) (string, runtime.Type, error) {
 	if customSocketPath := os.Getenv("TOOLHIVE_CONTAINER_SOCKET"); customSocketPath != "" {
 		logger.Debugf("Found custom container socket at %s", customSocketPath)
 		// check if it's docker or podman
-		if strings.HasSuffix(customSocketPath, "docker.sock") {
+		if strings.HasSuffix(customSocketPath, DockerSocketSuffix) {
 			return customSocketPath, runtime.TypeDocker, nil
 		}
-		if strings.HasSuffix(customSocketPath, "podman.sock") {
+		if strings.HasSuffix(customSocketPath, PodmanSocketSuffix) {
 			return customSocketPath, runtime.TypePodman, nil
 		}
 		return "", rt, fmt.Errorf("unsupported container runtime: %s", rt)

--- a/pkg/container/docker/client.go
+++ b/pkg/container/docker/client.go
@@ -133,6 +133,18 @@ func (c *Client) ping(ctx context.Context) error {
 
 // findContainerSocket finds a container socket path, preferring Podman over Docker
 func findContainerSocket(rt runtime.Type) (string, runtime.Type, error) {
+	// check if there is a custom socket path
+	if customSocketPath := os.Getenv("TOOLHIVE_CONTAINER_SOCKET"); customSocketPath != "" {
+		logger.Debugf("Found custom container socket at %s", customSocketPath)
+		// check if it's docker or podman
+		if strings.HasSuffix(customSocketPath, "docker.sock") {
+			return customSocketPath, runtime.TypeDocker, nil
+		}
+		if strings.HasSuffix(customSocketPath, "podman.sock") {
+			return customSocketPath, runtime.TypePodman, nil
+		}
+		return "", rt, fmt.Errorf("unsupported container runtime: %s", rt)
+	}
 
 	if rt == runtime.TypePodman {
 		// Try Podman sockets first

--- a/pkg/container/docker/client.go
+++ b/pkg/container/docker/client.go
@@ -143,7 +143,7 @@ func (c *Client) ping(ctx context.Context) error {
 func findContainerSocket(rt runtime.Type) (string, runtime.Type, error) {
 	// First check for custom socket paths via environment variables
 	if customSocketPath := os.Getenv(PodmanSocketEnv); customSocketPath != "" {
-		logger.Debugf("Found custom Podman socket at %s", customSocketPath)
+		logger.Debugf("Using Podman socket from env: %s", customSocketPath)
 		// validate the socket path
 		if _, err := os.Stat(customSocketPath); err != nil {
 			return "", runtime.TypePodman, fmt.Errorf("invalid Podman socket path: %w", err)
@@ -152,7 +152,7 @@ func findContainerSocket(rt runtime.Type) (string, runtime.Type, error) {
 	}
 
 	if customSocketPath := os.Getenv(DockerSocketEnv); customSocketPath != "" {
-		logger.Debugf("Found custom Docker socket at %s", customSocketPath)
+		logger.Debugf("Using Docker socket from env: %s", customSocketPath)
 		// validate the socket path
 		if _, err := os.Stat(customSocketPath); err != nil {
 			return "", runtime.TypeDocker, fmt.Errorf("invalid Docker socket path: %w", err)


### PR DESCRIPTION
# Docker Socket Customization Support

This update enhances the Docker client to support runtime-specific socket paths through environment variables `TOOLHIVE_DOCKER_SOCKET` and `TOOLHIVE_PODMAN_SOCKET`. The implementation validates the provided socket paths and returns the appropriate runtime type. If the socket path is invalid or not found, an error is returned.

## Use Case: Remote MCP Server Management

This feature enables managing MCP servers on remote machines through SSH socket forwarding. Here's how to use it:

1. Create an SSH config file (`ssh_config`):

```ssh
Host docker-remote
    HostName <remote-server>
    User <remote-user>
    LocalForward /tmp/remote-docker.sock /var/run/docker.sock
    NoHostAuthenticationForLocalhost yes
    RequestTTY no
    ExitOnForwardFailure yes
    PermitLocalCommand no
    ServerAliveInterval 60
    ServerAliveCountMax 3
```

2. Start an SSH tunnel to forward the remote Docker socket:

```bash
rm -f /tmp/remote-docker.sock && ssh -N -F ssh_config docker-remote
```

3. Set the custom socket path:

```bash
export TOOLHIVE_DOCKER_SOCKET=/tmp/remote-docker.sock
```

4. Run THV operations on the remote server:

```bash
thv run fetch
```

## Complete Example Script

Here's a complete script that sets up and manages a remote MCP server:

```bash
#!/bin/bash

# Configuration
REMOTE_HOST="remote-server-host"
REMOTE_USER="remote-server-user"
LOCAL_SOCKET="/tmp/remote-docker.sock"

# Function to cleanup on exit
cleanup() {
    echo "Cleaning up..."
    kill $SSH_PID 2>/dev/null
    rm -f "$LOCAL_SOCKET"
    unset TOOLHIVE_DOCKER_SOCKET
}

# Set up cleanup on script exit
trap cleanup EXIT

# Start SSH tunnel
echo "Starting SSH tunnel..."
rm -f "$LOCAL_SOCKET"
ssh -N \
    -o "LocalForward $LOCAL_SOCKET /var/run/docker.sock" \
    -o "NoHostAuthenticationForLocalhost yes" \
    -o "RequestTTY no" \
    -o "ExitOnForwardFailure yes" \
    -o "PermitLocalCommand no" \
    -o "ServerAliveInterval 60" \
    -o "ServerAliveCountMax 3" \
    "$REMOTE_USER@$REMOTE_HOST" &
SSH_PID=$!

# Wait for socket to be created
echo "Waiting for socket..."
while [ ! -S "$LOCAL_SOCKET" ]; do
    sleep 1
done

# Set custom socket
export TOOLHIVE_DOCKER_SOCKET="$LOCAL_SOCKET"
echo "Using remote Docker socket at $LOCAL_SOCKET"

# Run THV operations
echo "Running THV operations..."

# run the fetch mcp server on the remote host
./toolhive/thv run fetch --debug

# uncomment this to remove the fetch container
# ./toolhive/thv rm -f fetch --debug

# Keep script running until Ctrl+C
echo "Press Ctrl+C to exit..."
wait $SSH_PID
```

This script:

1. Creates the SSH config file dynamically
2. Starts the SSH tunnel in the background
3. Sets the custom socket environment variable
4. Runs PoC THV operations with debug logging
