### PR TITLE
Fix JSON output inconsistencies across commands

### DIFF
--- a/cmd/thv/app/list.go
+++ b/cmd/thv/app/list.go
@@ -47,7 +47,7 @@ type ContainerOutput struct {
 
 func init() {
 	listCmd.Flags().BoolVarP(&listAll, "all", "a", false, "Show all containers (default shows just running)")
-	listCmd.Flags().StringVar(&listFormat, "format", "text", "Output format (json, text, or mcpservers)")
+	listCmd.Flags().StringVar(&listFormat, "format", FormatText, "Output format (json, text, or mcpservers)")
 }
 
 func listCmdFunc(cmd *cobra.Command, _ []string) error {
@@ -66,14 +66,13 @@ func listCmdFunc(cmd *cobra.Command, _ []string) error {
 	}
 
 	if len(toolHiveContainers) == 0 {
-		logger.Info("No MCP servers found")
+		fmt.Println("No MCP servers found")
 		return nil
 	}
 
 	// Output based on format
 	switch listFormat {
-	//nolint:goconst
-	case "json":
+	case FormatJSON:
 		return printJSONOutput(toolHiveContainers)
 	case "mcpservers":
 		return printMCPServersOutput(toolHiveContainers)
@@ -139,8 +138,8 @@ func printJSONOutput(containers []rt.ContainerInfo) error {
 		return fmt.Errorf("failed to marshal JSON: %v", err)
 	}
 
-	// Print JSON
-	logger.Info(string(jsonData))
+	// Print JSON directly to stdout
+	fmt.Println(string(jsonData))
 	return nil
 }
 
@@ -191,8 +190,8 @@ func printMCPServersOutput(containers []rt.ContainerInfo) error {
 		return fmt.Errorf("failed to marshal JSON: %v", err)
 	}
 
-	// Print JSON
-	logger.Info(string(jsonData))
+	// Print JSON directly to stdout
+	fmt.Println(string(jsonData))
 	return nil
 }
 
@@ -248,6 +247,6 @@ func printTextOutput(containers []rt.ContainerInfo) {
 
 	// Flush the tabwriter
 	if err := w.Flush(); err != nil {
-		logger.Infof("Warning: Failed to flush tabwriter: %v", err)
+		logger.Errorf("Warning: Failed to flush tabwriter: %v", err)
 	}
 }

--- a/cmd/thv/app/registry.go
+++ b/cmd/thv/app/registry.go
@@ -48,8 +48,8 @@ func init() {
 	registryCmd.AddCommand(registryInfoCmd)
 
 	// Add flags for list and info commands
-	registryListCmd.Flags().StringVar(&registryFormat, "format", "text", "Output format (json or text)")
-	registryInfoCmd.Flags().StringVar(&registryFormat, "format", "text", "Output format (json or text)")
+	registryListCmd.Flags().StringVar(&registryFormat, "format", FormatText, "Output format (json or text)")
+	registryInfoCmd.Flags().StringVar(&registryFormat, "format", FormatText, "Output format (json or text)")
 }
 
 func registryListCmdFunc(_ *cobra.Command, _ []string) error {
@@ -66,7 +66,7 @@ func registryListCmdFunc(_ *cobra.Command, _ []string) error {
 
 	// Output based on format
 	switch registryFormat {
-	case "json":
+	case FormatJSON:
 		return printJSONServers(servers)
 	default:
 		printTextServers(servers)
@@ -84,7 +84,7 @@ func registryInfoCmdFunc(_ *cobra.Command, args []string) error {
 
 	// Output based on format
 	switch registryFormat {
-	case "json":
+	case FormatJSON:
 		return printJSONServer(server)
 	default:
 		printTextServerInfo(serverName, server)

--- a/docs/cli/thv_version.md
+++ b/docs/cli/thv_version.md
@@ -13,8 +13,9 @@ thv version [flags]
 ### Options
 
 ```
-  -h, --help   help for version
-      --json   Output version information as JSON
+      --format string   Output format (json or text) (default "text")
+  -h, --help            help for version
+      --json            Output version information as JSON (deprecated, use --format instead)
 ```
 
 ### Options inherited from parent commands

--- a/pkg/updates/checker.go
+++ b/pkg/updates/checker.go
@@ -94,7 +94,7 @@ func (d *defaultUpdateChecker) CheckLatestVersion() error {
 		return nil
 	}
 
-	fmt.Println("checking for updates...")
+	fmt.Fprintln(os.Stderr, "checking for updates...")
 
 	// If the update file is stale or does not exist - get the latest version
 	// from the API.
@@ -129,7 +129,7 @@ func (d *defaultUpdateChecker) CheckLatestVersion() error {
 func notifyIfUpdateAvailable(current, latest string) {
 	// Print a meaningful message for people running local builds.
 	if strings.HasPrefix(current, "build-") {
-		fmt.Printf("You are running a local build of ToolHive, latest release is: %s\n", latest)
+		fmt.Fprintf(os.Stderr, "You are running a local build of ToolHive, latest release is: %s\n", latest)
 		return
 	}
 	// Ensure both versions have the 'v' prefix for proper semantic version comparison
@@ -141,6 +141,6 @@ func notifyIfUpdateAvailable(current, latest string) {
 	}
 	// Compare the versions ensuring their canonical forms
 	if semver.Compare(semver.Canonical(current), semver.Canonical(latest)) < 0 {
-		fmt.Printf("A new version of ToolHive is available: %s\nCurrently running: %s\n", latest, current)
+		fmt.Fprintf(os.Stderr, "A new version of ToolHive is available: %s\nCurrently running: %s\n", latest, current)
 	}
 }


### PR DESCRIPTION
This PR fixes the issues reported in #384:

- Makes format flags consistent by using `--format json` across all commands
- Maintains backward compatibility with `--json` for the version command
- Ensures JSON output goes to stdout instead of stderr
- Moves update check messages to stderr
- Improves JSON formatting using encoding/json

Fixes #384