### PR TITLE
Implement endpoint for starting MCP servers

### DIFF
--- a/cmd/thv/app/run.go
+++ b/cmd/thv/app/run.go
@@ -218,7 +218,7 @@ func runCmdFunc(cmd *cobra.Command, args []string) error {
 	}
 
 	// Configure the RunConfig with transport, ports, permissions, etc.
-	if err := configureRunConfig(config, runTransport, runPort, runTargetPort, runTargetHost, runEnv); err != nil {
+	if err := configureRunConfig(config, runTransport, runPort, runTargetPort, runEnv); err != nil {
 		return err
 	}
 

--- a/cmd/thv/app/run_common.go
+++ b/cmd/thv/app/run_common.go
@@ -31,15 +31,9 @@ func configureRunConfig(
 	transport string,
 	port int,
 	targetPort int,
-	targetHost string,
 	envVarStrings []string,
 ) error {
 	var err error
-
-	// Check if permission profile is provided
-	if config.PermissionProfileNameOrPath == "" {
-		return fmt.Errorf("permission profile is required")
-	}
 
 	// Set transport
 	if _, err = config.WithTransport(transport); err != nil {
@@ -50,9 +44,6 @@ func configureRunConfig(
 	if _, err = config.WithPorts(port, targetPort); err != nil {
 		return err
 	}
-
-	// Set target host
-	config.TargetHost = targetHost
 
 	// Set permission profile (mandatory)
 	if _, err = config.ParsePermissionProfile(); err != nil {

--- a/cmd/thv/app/server.go
+++ b/cmd/thv/app/server.go
@@ -23,8 +23,12 @@ var serveCmd = &cobra.Command{
 		// Ensure server is shutdown gracefully on Ctrl+C.
 		ctx, cancel := signal.NotifyContext(cmd.Context(), os.Interrupt)
 		defer cancel()
+
+		// Get debug mode flag
+		debugMode, _ := cmd.Flags().GetBool("debug")
+
 		address := fmt.Sprintf("%s:%d", host, port)
-		return s.Serve(ctx, address)
+		return s.Serve(ctx, address, debugMode)
 	},
 }
 

--- a/pkg/api/v1/servers.go
+++ b/pkg/api/v1/servers.go
@@ -167,7 +167,7 @@ func (s *ServerRoutes) createServer(w http.ResponseWriter, r *http.Request) {
 	}
 	// Let the manager handle the port mapping.
 	// Configure ports and target host
-	if _, err := runConfig.WithPorts(0, 0); err != nil {
+	if _, err := runConfig.WithPorts(0, req.TargetPort); err != nil {
 		http.Error(w, "Unable to configure ports", http.StatusInternalServerError)
 	}
 
@@ -228,6 +228,7 @@ type createRequest struct {
 	Name              string                    `json:"name"`
 	Image             string                    `json:"image"`
 	CmdArguments      []string                  `json:"cmd_arguments"`
+	TargetPort        int                       `json:"target_port"`
 	EnvVars           []string                  `json:"env_vars"`
 	Secrets           []secrets.SecretParameter `json:"secrets"`
 	Volumes           []string                  `json:"volumes"`

--- a/pkg/api/v1/servers.go
+++ b/pkg/api/v1/servers.go
@@ -208,7 +208,11 @@ func (s *ServerRoutes) createServer(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Return name so that the client will get the auto-generated name.
-	if err = json.NewEncoder(w).Encode(createServerResponse{Name: runConfig.ContainerName}); err != nil {
+	resp := createServerResponse{
+		Name: runConfig.ContainerName,
+		Port: runConfig.Port,
+	}
+	if err = json.NewEncoder(w).Encode(resp); err != nil {
 		http.Error(w, "Failed to marshal server details", http.StatusInternalServerError)
 		return
 	}
@@ -242,4 +246,5 @@ type oidcOptions struct {
 
 type createServerResponse struct {
 	Name string `json:"name"`
+	Port int    `json:"port"`
 }

--- a/pkg/api/v1/servers.go
+++ b/pkg/api/v1/servers.go
@@ -10,18 +10,33 @@ import (
 	"github.com/stacklok/toolhive/pkg/container/runtime"
 	"github.com/stacklok/toolhive/pkg/lifecycle"
 	"github.com/stacklok/toolhive/pkg/logger"
+	"github.com/stacklok/toolhive/pkg/permissions"
+	"github.com/stacklok/toolhive/pkg/runner"
+	"github.com/stacklok/toolhive/pkg/secrets"
 )
 
 // ServerRoutes defines the routes for server management.
 type ServerRoutes struct {
-	manager lifecycle.Manager
+	manager          lifecycle.Manager
+	containerRuntime runtime.Runtime
+	debugMode        bool
 }
 
 // ServerRouter creates a new ServerRoutes instance.
-func ServerRouter(manager lifecycle.Manager) http.Handler {
-	routes := ServerRoutes{manager: manager}
+func ServerRouter(
+	manager lifecycle.Manager,
+	containerRuntime runtime.Runtime,
+	debugMode bool,
+) http.Handler {
+	routes := ServerRoutes{
+		manager:          manager,
+		containerRuntime: containerRuntime,
+		debugMode:        debugMode,
+	}
+
 	r := chi.NewRouter()
 	r.Get("/", routes.listServers)
+	r.Post("/", routes.createServer)
 	r.Get("/{name}", routes.getServer)
 	r.Post("/{name}/stop", routes.stopServer)
 	r.Post("/{name}/restart", routes.restartServer)
@@ -116,8 +131,115 @@ func (s *ServerRoutes) restartServer(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
+func (s *ServerRoutes) createServer(w http.ResponseWriter, r *http.Request) {
+	var req createRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Failed to decode request", http.StatusBadRequest)
+		return
+	}
+
+	// NOTE: None of the k8s-related config logic is included here.
+	runSecrets := secrets.SecretParametersToCLI(req.Secrets)
+	runConfig := runner.NewRunConfigFromFlags(
+		s.containerRuntime,
+		req.CmdArguments,
+		req.Name,
+		s.debugMode,
+		req.Volumes,
+		runSecrets,
+		req.AuthzConfig,
+		req.PermissionProfile,
+		"localhost", // Seems like a reasonable default for now.
+		req.OIDC.Issuer,
+		req.OIDC.Audience,
+		req.OIDC.JwksURL,
+		req.OIDC.ClientID,
+	)
+
+	// TODO: De-dupe from `configureRunConfig` in `cmd/thv/app/run_common.go`.
+	if req.Transport == "" {
+		req.Transport = "stdio"
+	}
+	if _, err := runConfig.WithTransport(req.Transport); err != nil {
+		// TODO: More fine grained error handling.
+		http.Error(w, "Unable to configure transport", http.StatusBadRequest)
+		return
+	}
+	// Let the manager handle the port mapping.
+	// Configure ports and target host
+	if _, err := runConfig.WithPorts(0, 0); err != nil {
+		http.Error(w, "Unable to configure ports", http.StatusInternalServerError)
+	}
+
+	if runConfig.PermissionProfileNameOrPath == "" {
+		runConfig.PermissionProfileNameOrPath = permissions.ProfileNetwork
+	}
+
+	// Set permission profile (mandatory)
+	if _, err := runConfig.ParsePermissionProfile(); err != nil {
+		http.Error(w, "Unable to configure permission profile", http.StatusBadRequest)
+	}
+
+	// Process volume mounts
+	if err := runConfig.ProcessVolumeMounts(); err != nil {
+		http.Error(w, "Unable to configure volume mounts", http.StatusBadRequest)
+	}
+
+	// Parse and set environment variables
+	if _, err := runConfig.WithEnvironmentVariables(req.EnvVars); err != nil {
+		http.Error(w, "Unable to configure ports", http.StatusBadRequest)
+	}
+
+	runConfig.Image = req.Image
+	runConfig.WithContainerName()
+	runConfig.WithStandardLabels()
+
+	// ASSUMPTION MADE: The CLI parses the image and pulls it, but since the
+	// same code is called when the process is detached, I do not call it here.
+	// Some basic testing has confirmed this, but it may need some further
+	// testing with npx/uvx.
+	// TODO: Refactor the code out of the CLI.
+
+	err := s.manager.RunContainerDetached(runConfig)
+	if err != nil {
+		logger.Errorf("Failed to start server: %v", err)
+		http.Error(w, "Failed to start server", http.StatusInternalServerError)
+		return
+	}
+
+	// Return name so that the client will get the auto-generated name.
+	if err = json.NewEncoder(w).Encode(createServerResponse{Name: runConfig.ContainerName}); err != nil {
+		http.Error(w, "Failed to marshal server details", http.StatusInternalServerError)
+		return
+	}
+}
+
 // Response type definitions.
 // TODO: Generate these from OpenAPI specs.
 type serverListResponse struct {
 	Servers []runtime.ContainerInfo `json:"servers"`
+}
+
+type createRequest struct {
+	Name              string                    `json:"name"`
+	Image             string                    `json:"image"`
+	CmdArguments      []string                  `json:"cmd_arguments"`
+	EnvVars           []string                  `json:"env_vars"`
+	Secrets           []secrets.SecretParameter `json:"secrets"`
+	Volumes           []string                  `json:"volumes"`
+	Transport         string                    `json:"transport"`
+	AuthzConfig       string                    `json:"authz_config"`
+	OIDC              oidcOptions               `json:"oidc"`
+	PermissionProfile string                    `json:"permission_profile"`
+}
+
+type oidcOptions struct {
+	Issuer   string `json:"issuer"`
+	Audience string `json:"audience"`
+	JwksURL  string `json:"jwks_url"`
+	ClientID string `json:"client_id"`
+}
+
+type createServerResponse struct {
+	Name string `json:"name"`
 }

--- a/pkg/secrets/types.go
+++ b/pkg/secrets/types.go
@@ -20,8 +20,8 @@ type Provider interface {
 
 // SecretParameter represents a parsed `--secret` parameter.
 type SecretParameter struct {
-	Name   string
-	Target string
+	Name   string `json:"name"`
+	Target string `json:"target"`
 }
 
 // ParseSecretParameter creates an instance of SecretParameter from a string.
@@ -44,4 +44,14 @@ func ParseSecretParameter(parameter string) (SecretParameter, error) {
 		Name:   name,
 		Target: target,
 	}, nil
+}
+
+// SecretParametersToCLI does the reverse of `ParseSecretParameter`
+// TODO: It may be possible to get rid of this with refactoring.
+func SecretParametersToCLI(params []SecretParameter) []string {
+	result := make([]string, len(params))
+	for i, p := range params {
+		result[i] = fmt.Sprintf("%s,target=%s", p.Name, p.Target)
+	}
+	return result
 }


### PR DESCRIPTION
This implements the API for starting MCP servers. An MCP server can be started with as little as:

```
curl -XPOST -v localhost:8080/api/v1beta/servers --header "Content-Type: application/json" --data '{"image": "fetch"}'
Note: Unnecessary use of -X or --request, POST is already inferred.
* Host localhost:8080 was resolved.
* IPv6: ::1
* IPv4: 127.0.0.1
*   Trying [::1]:8080...
* connect to ::1 port 8080 from ::1 port 53812 failed: Connection refused
*   Trying 127.0.0.1:8080...
* Connected to localhost (127.0.0.1) port 8080
> POST /api/v1beta/servers HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/8.7.1
> Accept: */*
> Content-Type: application/json
> Content-Length: 18
>
* upload completely sent off: 18 bytes
< HTTP/1.1 200 OK
< Date: Fri, 16 May 2025 17:57:41 GMT
< Content-Length: 28
< Content-Type: text/plain; charset=utf-8
<
{"name":"fetch-1747418261"}
* Connection #0 to host localhost left intact
```

More parameters can be specified as needed - see the request structure. Sensible defaults are assumed where possible.

There is some further refactoring needed to rip out duplicated code between the CLI and API - this will be implemented in a future PR.