### PR TITLE
Add config + logic for loading remote registry

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -24,8 +24,9 @@ const lockTimeout = 1 * time.Second
 
 // Config represents the configuration of the application.
 type Config struct {
-	Secrets Secrets `yaml:"secrets"`
-	Clients Clients `yaml:"clients"`
+	Secrets        Secrets        `yaml:"secrets"`
+	Clients        Clients        `yaml:"clients"`
+	RegistryConfig RegistryConfig `yaml:"registry_config"`
 }
 
 // Secrets contains the settings for secrets management.
@@ -51,6 +52,11 @@ func (s *Secrets) GetProviderType() (secrets.ProviderType, error) {
 type Clients struct {
 	AutoDiscovery     bool     `yaml:"auto_discovery"`
 	RegisteredClients []string `yaml:"registered_clients"`
+}
+
+// Registry contains settings for the MCP server registry.
+type RegistryConfig struct {
+	Url string `yaml:"url"` //~/Library/Application\ Support/toolhive/config.yaml
 }
 
 // defaultPathGenerator generates the default config path using xdg
@@ -92,6 +98,9 @@ func LoadOrCreateConfig() (*Config, error) {
 			},
 			Clients: Clients{
 				AutoDiscovery: true,
+			},
+			RegistryConfig: RegistryConfig{
+				Url: "",
 			},
 		}
 


### PR DESCRIPTION
This adds the ability to load the MCP server registry from a remote URL. The URL from which the registry is loaded can be set in the config file.

By default, the registry URL is not set in the config. In this case, the local registry will be loaded for backwards compatibility.

