### PR TITLE
feat: adds missing local toolhive image build for kind

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ go.work
 .roo/
 ^thv$
 
+.claude/
 kconfig.yaml
 
 .DS_Store

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -160,13 +160,17 @@ tasks:
       - helm upgrade --install toolhive-operator deploy/charts/operator --namespace toolhive-system --create-namespace --kubeconfig kconfig.yaml
 
   operator-deploy-local:
-    desc: Build the Operator image locally and deploy it to the K8s cluster
+    desc: Build the ToolHive runtime and Operator image locally and deploy it to the K8s cluster
     vars:
-      IMAGE:
+      OPERATOR_IMAGE:
         sh: KO_DOCKER_REPO=kind.local ko build --platform linux/amd64 --local -B ./cmd/thv-operator | tail -n 1
+      TOOLHIVE_IMAGE:
+        sh: KO_DOCKER_REPO=kind.local ko build --platform linux/amd64 --local -B ./cmd/thv | tail -n 1
     cmds:
-      - echo "Loading image {{.IMAGE}} into kind..."
-      - kind load docker-image {{.IMAGE}}
+      - echo "Loading toolhive operator image {{.OPERATOR_IMAGE}} into kind..."
+      - kind load docker-image {{.OPERATOR_IMAGE}}
+      - echo "Loading toolhive image {{.TOOLHIVE_IMAGE}} into kind..."
+      - kind load docker-image {{.TOOLHIVE_IMAGE}}
       - kubectl apply -f deploy/operator/namespace.yaml --kubeconfig kconfig.yaml
       - kubectl apply -f deploy/operator/rbac.yaml --kubeconfig kconfig.yaml
       - kubectl apply -f deploy/operator/toolhive_rbac.yaml --kubeconfig kconfig.yaml

--- a/deploy/operator/operator_local.yaml
+++ b/deploy/operator/operator_local.yaml
@@ -24,6 +24,9 @@ spec:
         imagePullPolicy: Never
         args:
         - --leader-elect
+        env:
+        - name: TOOLHIVE_RUNNER_IMAGE
+          value: ko://github.com/stacklok/toolhive/cmd/thv
         resources:
           limits:
             cpu: 500m


### PR DESCRIPTION
before we weren't building the toolhive image when deploying a local operator to kind, this resulted in the operator always deploying the latest toolhive runtime image. this PR ensures to build the toolhive runtime image AND deploy it when using kind to deploy the operator