### PR TITLE
Do not pin the platform for ko builds

### DIFF
--- a/cmd/thv-operator/Taskfile.yml
+++ b/cmd/thv-operator/Taskfile.yml
@@ -71,7 +71,7 @@ tasks:
   build-operator-image:
     desc: Build the operator image with ko
     cmds:
-      - ko build --platform linux/amd64,linux/arm64 --local ./cmd/thv-operator
+      - ko build --local -B ./cmd/thv-operator
 
   operator-install-crds:
     desc: Install CRDs into the K8s cluster
@@ -92,9 +92,9 @@ tasks:
     desc: Build the ToolHive runtime and Operator image locally and deploy it to the K8s cluster
     vars:
       OPERATOR_IMAGE:
-        sh: KO_DOCKER_REPO=kind.local ko build --platform linux/amd64 --local -B ./cmd/thv-operator | tail -n 1
+        sh: KO_DOCKER_REPO=kind.local ko build --local -B ./cmd/thv-operator | tail -n 1
       TOOLHIVE_IMAGE:
-        sh: KO_DOCKER_REPO=kind.local ko build --platform linux/amd64 --local -B ./cmd/thv | tail -n 1
+        sh: KO_DOCKER_REPO=kind.local ko build --local -B ./cmd/thv | tail -n 1
     cmds:
       - echo "Loading toolhive operator image {{.OPERATOR_IMAGE}} into kind..."
       - kind load docker-image {{.OPERATOR_IMAGE}}
@@ -103,7 +103,7 @@ tasks:
       - kubectl apply -f deploy/operator/namespace.yaml --kubeconfig kconfig.yaml
       - kubectl apply -f deploy/operator/rbac.yaml --kubeconfig kconfig.yaml
       - kubectl apply -f deploy/operator/toolhive_rbac.yaml --kubeconfig kconfig.yaml
-      - kubectl apply -f <(KO_DOCKER_REPO=kind.local ko resolve --platform linux/amd64 -B -f deploy/operator/operator_local.yaml) --kubeconfig kconfig.yaml
+      - kubectl apply -f <(KO_DOCKER_REPO=kind.local ko resolve -B -f deploy/operator/operator_local.yaml) --kubeconfig kconfig.yaml
 
   operator-undeploy:
     desc: Undeploy operator from the K8s cluster


### PR DESCRIPTION
The following PR fixes a segfault - 

```bash
You are running a local build of ToolHive, latest release is: v0.0.33
11:49AM INF Processed cmdArgs: [[]]
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1faa79a]

goroutine 1 [running]:
github.com/stacklok/toolhive/cmd/thv/app.verifyImage({0x2a9bcd0?, 0x488ec00?}, {0x7ffffffffc9e?, 0xc00070e270?}, {0x2ab1948?, 0xc00070e270?}, 0x0, {0x26d5199, 0x4})
        github.com/stacklok/toolhive/cmd/thv/app/run.go:326 +0x37a
github.com/stacklok/toolhive/cmd/thv/app.runCmdFunc(0x48426a0, {0xc0000ae1c0, 0x1, 0x26d5181?})
        github.com/stacklok/toolhive/cmd/thv/app/run.go:246 +0xdfb
github.com/spf13/cobra.(*Command).execute(0x48426a0, {0xc0000ae0e0, 0x7, 0x7})
        github.com/spf13/cobra@v1.9.1/command.go:1015 +0xaaa
github.com/spf13/cobra.(*Command).ExecuteC(0x4840020)
        github.com/spf13/cobra@v1.9.1/command.go:1148 +0x46f
github.com/spf13/cobra.(*Command).Execute(0x0?)
        github.com/spf13/cobra@v1.9.1/command.go:1071 +0x13
main.main()
        github.com/stacklok/toolhive/cmd/thv/main.go:16 +0x1d
```