### PR TITLE
feat: completes local toolhive operator helm install for task

### DIFF
--- a/cmd/thv-operator/Taskfile.yml
+++ b/cmd/thv-operator/Taskfile.yml
@@ -100,10 +100,13 @@ tasks:
       - kind load docker-image {{.OPERATOR_IMAGE}}
       - echo "Loading toolhive image {{.TOOLHIVE_IMAGE}} into kind..."
       - kind load docker-image {{.TOOLHIVE_IMAGE}}
-      - kubectl apply -f deploy/operator/namespace.yaml --kubeconfig kconfig.yaml
-      - kubectl apply -f deploy/operator/rbac.yaml --kubeconfig kconfig.yaml
-      - kubectl apply -f deploy/operator/toolhive_rbac.yaml --kubeconfig kconfig.yaml
-      - kubectl apply -f <(KO_DOCKER_REPO=kind.local ko resolve --platform linux/amd64 -B -f deploy/operator/operator_local.yaml) --kubeconfig kconfig.yaml
+      - |
+        helm upgrade --install toolhive-operator deploy/charts/operator \
+        --set operator.image={{.OPERATOR_IMAGE}} \
+        --set operator.toolhiveRunnerImage={{.TOOLHIVE_IMAGE}} \
+        --namespace toolhive-system \
+        --create-namespace \
+        --kubeconfig kconfig.yaml
 
   operator-undeploy:
     desc: Undeploy operator from the K8s cluster

--- a/deploy/charts/operator/templates/deployment.yaml
+++ b/deploy/charts/operator/templates/deployment.yaml
@@ -42,6 +42,12 @@ spec:
           - --leader-elect
           ports:
             {{- toYaml .Values.operator.ports | nindent 12 }}
+          env:
+          - name: TOOLHIVE_RUNNER_IMAGE
+            value: "{{ .Values.operator.toolhiveRunnerImage }}"
+          {{- if .Values.operator.env }}
+            {{- toYaml .Values.operator.env | nindent 12 }}
+          {{- end }}
           livenessProbe:
             {{- toYaml .Values.operator.livenessProbe | nindent 12 }}
           readinessProbe:

--- a/deploy/charts/operator/values.yaml
+++ b/deploy/charts/operator/values.yaml
@@ -13,6 +13,10 @@ operator:
   image: ghcr.io/stacklok/toolhive/operator:latest
   imagePullPolicy: IfNotPresent
 
+  toolhiveRunnerImage: ghcr.io/stacklok/toolhive:latest
+
+  env: {}
+
   ports:
   - containerPort: 8080
     name: metrics


### PR DESCRIPTION
Up to now using `task` and `kind` we've installed the toolhive operator via yaml manifests in combination with `ko resolve` to replace the image references with locally built image reference. With this PR we move towards a helm install instead so that we can start utilising the helm charts for more customisability for deployments using helm values.

Ref: https://github.com/stacklok/toolhive/issues/314