### PR TITLE
feat: Exposes toolhive server via a UNIX socket

### DIFF
--- a/cmd/thv/app/server.go
+++ b/cmd/thv/app/server.go
@@ -14,6 +14,7 @@ var (
 	host       string
 	port       int
 	enableDocs bool
+	socketPath string
 )
 
 var serveCmd = &cobra.Command{
@@ -28,8 +29,15 @@ var serveCmd = &cobra.Command{
 		// Get debug mode flag
 		debugMode, _ := cmd.Flags().GetBool("debug")
 
+		// If socket path is provided, use it; otherwise use host:port
 		address := fmt.Sprintf("%s:%d", host, port)
-		return s.Serve(ctx, address, debugMode, enableDocs)
+		isUnixSocket := false
+		if socketPath != "" {
+			address = socketPath
+			isUnixSocket = true
+		}
+
+		return s.Serve(ctx, address, isUnixSocket, debugMode, enableDocs)
 	},
 }
 
@@ -38,4 +46,5 @@ func init() {
 	serveCmd.Flags().IntVar(&port, "port", 8080, "Port to bind the server to")
 	serveCmd.Flags().BoolVar(&enableDocs, "openapi", false,
 		"Enable OpenAPI documentation endpoints (/api/openapi.json and /api/doc)")
+	serveCmd.Flags().StringVar(&socketPath, "socket", "", "UNIX socket path to bind the server to (overrides host and port if provided)")
 }

--- a/cmd/thv/app/server.go
+++ b/cmd/thv/app/server.go
@@ -46,5 +46,6 @@ func init() {
 	serveCmd.Flags().IntVar(&port, "port", 8080, "Port to bind the server to")
 	serveCmd.Flags().BoolVar(&enableDocs, "openapi", false,
 		"Enable OpenAPI documentation endpoints (/api/openapi.json and /api/doc)")
-	serveCmd.Flags().StringVar(&socketPath, "socket", "", "UNIX socket path to bind the server to (overrides host and port if provided)")
+	serveCmd.Flags().StringVar(&socketPath, "socket", "", "UNIX socket path to bind the "+
+		"server to (overrides host and port if provided)")
 }

--- a/docs/cli/thv_serve.md
+++ b/docs/cli/thv_serve.md
@@ -17,6 +17,7 @@ thv serve [flags]
       --host string   Host address to bind the server to (default "127.0.0.1")
       --openapi       Enable OpenAPI documentation endpoints (/api/openapi.json and /api/doc)
       --port int      Port to bind the server to (default 8080)
+      --socket string UNIX socket path to bind the server to (overrides host and port if provided)
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli/thv_serve.md
+++ b/docs/cli/thv_serve.md
@@ -13,11 +13,11 @@ thv serve [flags]
 ### Options
 
 ```
-  -h, --help          help for serve
-      --host string   Host address to bind the server to (default "127.0.0.1")
-      --openapi       Enable OpenAPI documentation endpoints (/api/openapi.json and /api/doc)
-      --port int      Port to bind the server to (default 8080)
-      --socket string UNIX socket path to bind the server to (overrides host and port if provided)
+  -h, --help            help for serve
+      --host string     Host address to bind the server to (default "127.0.0.1")
+      --openapi         Enable OpenAPI documentation endpoints (/api/openapi.json and /api/doc)
+      --port int        Port to bind the server to (default 8080)
+      --socket string   UNIX socket path to bind the server to (overrides host and port if provided)
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
fixes #410 

Exposes toolhive server via UNIX socket. Providing a --socket argument to the `thv serve` command overrides the host:port address with the provided socket.

Example usage:

`/thv serve --socket /tmp/toolhive.sock`

`curl --unix-socket /tmp/toolhive.sock http://localhost/api/v1beta/version`
`{"version":"build-42ad77b0"}`