### PR TITLE
Update .codespellrc rules to skip *.mod and *.sum files

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
 ignore-words-list = NotIn,notin
-skip = *.svg
+skip = *.svg,*.mod,*.sum


### PR DESCRIPTION
The following PR updates .codespellrc rules to skip *.mod and *.sum files