### PR TITLE
Change thv logs --tail flag to --follow

### DIFF
--- a/cmd/thv/app/logs.go
+++ b/cmd/thv/app/logs.go
@@ -13,22 +13,22 @@ import (
 )
 
 var (
-	tailFlag bool
+	followFlag bool
 )
 
 func logsCommand() *cobra.Command {
 	logsCommand := &cobra.Command{
 		Use:   "logs [container-name]",
 		Short: "Output the logs of an MCP server",
-		Long:  `Output the logs of an MCP server managed by Vibe Tool.`,
+		Long:  `Output the logs of an MCP server managed by ToolHive.`,
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return logsCmdFunc(cmd, args)
 		},
 	}
 
-	logsCommand.Flags().BoolVarP(&tailFlag, "tail", "t", false, "Tail the logs")
-	err := viper.BindPFlag("tail", logsCommand.Flags().Lookup("tail"))
+	logsCommand.Flags().BoolVarP(&followFlag, "follow", "t", false, "Follow log output")
+	err := viper.BindPFlag("follow", logsCommand.Flags().Lookup("follow"))
 	if err != nil {
 		logger.Errorf("failed to bind flag: %v", err)
 	}
@@ -56,7 +56,7 @@ func logsCmdFunc(cmd *cobra.Command, args []string) error {
 	// Find the container with the given name
 	var containerID string
 	for _, c := range containers {
-		// Check if the container is managed by Vibe Tool
+		// Check if the container is managed by ToolHive
 		if !labels.IsToolHiveContainer(c.Labels) {
 			continue
 		}
@@ -79,8 +79,8 @@ func logsCmdFunc(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	tail := viper.GetBool("tail")
-	logs, err := runtime.ContainerLogs(ctx, containerID, tail)
+	follow := viper.GetBool("follow")
+	logs, err := runtime.ContainerLogs(ctx, containerID, follow)
 	if err != nil {
 		return fmt.Errorf("failed to get container logs: %v", err)
 	}

--- a/docs/cli/thv_logs.md
+++ b/docs/cli/thv_logs.md
@@ -4,7 +4,7 @@ Output the logs of an MCP server
 
 ### Synopsis
 
-Output the logs of an MCP server managed by Vibe Tool.
+Output the logs of an MCP server managed by ToolHive.
 
 ```
 thv logs [container-name] [flags]
@@ -13,8 +13,8 @@ thv logs [container-name] [flags]
 ### Options
 
 ```
-  -h, --help   help for logs
-  -t, --tail   Tail the logs
+  -t, --follow   Follow log output
+  -h, --help     help for logs
 ```
 
 ### Options inherited from parent commands

--- a/pkg/container/docker/client.go
+++ b/pkg/container/docker/client.go
@@ -495,11 +495,11 @@ func (c *Client) RemoveContainer(ctx context.Context, containerID string) error 
 }
 
 // ContainerLogs gets container logs
-func (c *Client) ContainerLogs(ctx context.Context, containerID string, tail bool) (string, error) {
+func (c *Client) ContainerLogs(ctx context.Context, containerID string, follow bool) (string, error) {
 	options := container.LogsOptions{
 		ShowStdout: true,
 		ShowStderr: true,
-		Follow:     tail,
+		Follow:     follow,
 		Tail:       "100",
 	}
 
@@ -510,11 +510,11 @@ func (c *Client) ContainerLogs(ctx context.Context, containerID string, tail boo
 	}
 	defer logs.Close()
 
-	if tail {
+	if follow {
 		_, err = io.Copy(os.Stdout, logs)
 		if err != nil && err != io.EOF {
 			logger.Errorf("Error reading container logs: %v", err)
-			return "", NewContainerError(err, containerID, fmt.Sprintf("failed to tail container logs: %v", err))
+			return "", NewContainerError(err, containerID, fmt.Sprintf("failed to follow container logs: %v", err))
 		}
 	}
 

--- a/pkg/container/kubernetes/client.go
+++ b/pkg/container/kubernetes/client.go
@@ -204,7 +204,7 @@ func (c *Client) AttachContainer(ctx context.Context, containerID string) (io.Wr
 }
 
 // ContainerLogs implements runtime.Runtime.
-func (c *Client) ContainerLogs(ctx context.Context, containerID string, tail bool) (string, error) {
+func (c *Client) ContainerLogs(ctx context.Context, containerID string, follow bool) (string, error) {
 	// In Kubernetes, containerID is the statefulset name
 	namespace := getCurrentNamespace()
 
@@ -226,7 +226,7 @@ func (c *Client) ContainerLogs(ctx context.Context, containerID string, tail boo
 	// Get logs from the pod
 	logOptions := &corev1.PodLogOptions{
 		Container:  mcpContainerName,
-		Follow:     tail,
+		Follow:     follow,
 		Previous:   false,
 		Timestamps: true,
 	}

--- a/pkg/container/runtime/types.go
+++ b/pkg/container/runtime/types.go
@@ -66,7 +66,7 @@ type Runtime interface {
 	RemoveContainer(ctx context.Context, containerID string) error
 
 	// ContainerLogs gets container logs
-	ContainerLogs(ctx context.Context, containerID string, tail bool) (string, error)
+	ContainerLogs(ctx context.Context, containerID string, follow bool) (string, error)
 
 	// IsContainerRunning checks if a container is running
 	IsContainerRunning(ctx context.Context, containerID string) (bool, error)


### PR DESCRIPTION
This updates the `--tail` flag for `thv logs` to `--follow`, to align with the expected behavior from `docker logs`.