### PR TITLE
Fix the short form of logs --follow

### DIFF
--- a/cmd/thv/app/logs.go
+++ b/cmd/thv/app/logs.go
@@ -27,7 +27,7 @@ func logsCommand() *cobra.Command {
 		},
 	}
 
-	logsCommand.Flags().BoolVarP(&followFlag, "follow", "t", false, "Follow log output")
+	logsCommand.Flags().BoolVarP(&followFlag, "follow", "f", false, "Follow log output")
 	err := viper.BindPFlag("follow", logsCommand.Flags().Lookup("follow"))
 	if err != nil {
 		logger.Errorf("failed to bind flag: %v", err)

--- a/docs/cli/thv_logs.md
+++ b/docs/cli/thv_logs.md
@@ -13,7 +13,7 @@ thv logs [container-name] [flags]
 ### Options
 
 ```
-  -t, --follow   Follow log output
+  -f, --follow   Follow log output
   -h, --help     help for logs
 ```
 


### PR DESCRIPTION
I missed updating the short form for `thv logs --follow` from `-t` to `-f` in #452