### PR TITLE
Silence showing the usage on error and fail on forced image verification

### DIFF
--- a/cmd/thv/app/commands.go
+++ b/cmd/thv/app/commands.go
@@ -53,6 +53,9 @@ func NewRootCmd() *cobra.Command {
 	rootCmd.AddCommand(logsCommand())
 	rootCmd.AddCommand(newSecretCommand())
 
+	// Silence printing the usage on error
+	rootCmd.SilenceUsage = true
+
 	// Skip update check for completion command
 	if !IsCompletionCommand(os.Args) {
 		checkForUpdates()

--- a/cmd/thv/app/run.go
+++ b/cmd/thv/app/run.go
@@ -315,8 +315,9 @@ func verifyImage(ctx context.Context, image string, rt runtime.Runtime, server *
 	case verifyImageWarn, verifyImageEnabled:
 		isSafe, err := rt.VerifyImage(ctx, server, image)
 		if err != nil {
-			// This happens if we have no provenance entry in the registry for this server. No need to fail, but do warn.
-			if errors.Is(err, verifier.ErrProvenanceServerInformationNotSet) {
+			// This happens if we have no provenance entry in the registry for this server.
+			// Not finding provenance info in the registry is not a fatal error if the setting is "warn".
+			if errors.Is(err, verifier.ErrProvenanceServerInformationNotSet) && verifySetting == verifyImageWarn {
 				logger.Warnf("⚠️  MCP server %s has no provenance information set, skipping image verification", image)
 				return nil
 			}

--- a/cmd/thv/main.go
+++ b/cmd/thv/main.go
@@ -2,7 +2,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/stacklok/toolhive/cmd/thv/app"
@@ -14,7 +13,6 @@ func main() {
 	logger.Initialize()
 
 	if err := app.NewRootCmd().Execute(); err != nil {
-		fmt.Fprintf(os.Stderr, "there was an error: %v\n", err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
The following PR:
* Silence showing the usage on error
* Fail on forced image verification
* Removes a duplicated error message being printed