### PR TITLE
refactor: rename Runtime interface from container to workload terminology

### DIFF
--- a/cmd/thv/app/config.go
+++ b/cmd/thv/app/config.go
@@ -210,8 +210,8 @@ func addRunningMCPsToClient(ctx context.Context, clientName string) error {
 		return fmt.Errorf("failed to create container runtime: %v", err)
 	}
 
-	// List containers
-	containers, err := runtime.ListContainers(ctx)
+	// List workloads
+	containers, err := runtime.ListWorkloads(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to list containers: %v", err)
 	}

--- a/cmd/thv/app/logs.go
+++ b/cmd/thv/app/logs.go
@@ -47,8 +47,8 @@ func logsCmdFunc(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to create container runtime: %v", err)
 	}
 
-	// List containers to find the one with the given name
-	containers, err := runtime.ListContainers(ctx)
+	// List workloads to find the one with the given name
+	containers, err := runtime.ListWorkloads(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to list containers: %w", err)
 	}
@@ -80,7 +80,7 @@ func logsCmdFunc(cmd *cobra.Command, args []string) error {
 	}
 
 	follow := viper.GetBool("follow")
-	logs, err := runtime.ContainerLogs(ctx, containerID, follow)
+	logs, err := runtime.GetWorkloadLogs(ctx, containerID, follow)
 	if err != nil {
 		return fmt.Errorf("failed to get container logs: %v", err)
 	}

--- a/pkg/container/docker/monitor.go
+++ b/pkg/container/docker/monitor.go
@@ -41,8 +41,8 @@ func (m *ContainerMonitor) StartMonitoring(ctx context.Context) (<-chan error, e
 		return m.errorCh, nil // Already monitoring
 	}
 
-	// Check if the container exists and is running
-	running, err := m.runtime.IsContainerRunning(ctx, m.containerID)
+	// Check if the workload exists and is running
+	running, err := m.runtime.IsWorkloadRunning(ctx, m.containerID)
 	if err != nil {
 		return nil, err
 	}
@@ -95,7 +95,7 @@ func (m *ContainerMonitor) monitor(ctx context.Context) {
 			// Check if the container is still running
 			// Create a short timeout context for this check
 			checkCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-			running, err := m.runtime.IsContainerRunning(checkCtx, m.containerID)
+			running, err := m.runtime.IsWorkloadRunning(checkCtx, m.containerID)
 			cancel() // Always cancel the context to avoid leaks
 			if err != nil {
 				// If the container is not found, it may have been removed
@@ -117,8 +117,8 @@ func (m *ContainerMonitor) monitor(ctx context.Context) {
 				// Container has exited, get logs and info
 				// Create a short timeout context for these operations
 				infoCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-				logs, _ := m.runtime.ContainerLogs(infoCtx, m.containerID, false)
-				info, _ := m.runtime.GetContainerInfo(infoCtx, m.containerID)
+				logs, _ := m.runtime.GetWorkloadLogs(infoCtx, m.containerID, false)
+				info, _ := m.runtime.GetWorkloadInfo(infoCtx, m.containerID)
 				cancel() // Always cancel the context to avoid leaks
 
 				exitErr := NewContainerError(

--- a/pkg/container/kubernetes/client_test.go
+++ b/pkg/container/kubernetes/client_test.go
@@ -164,12 +164,12 @@ func TestCreateContainerWithPodTemplatePatch(t *testing.T) {
 				client:                      clientset,
 				waitForStatefulSetReadyFunc: mockWaitForStatefulSetReady,
 			}
-			// Create container options with the pod template patch
-			options := runtime.NewCreateContainerOptions()
+			// Create workload options with the pod template patch
+			options := runtime.NewDeployWorkloadOptions()
 			options.K8sPodTemplatePatch = tc.k8sPodTemplatePatch
 
-			// Create the container
-			containerID, err := client.CreateContainer(
+			// Deploy the workload
+			containerID, err := client.DeployWorkload(
 				context.Background(),
 				"test-image",
 				"test-container",
@@ -437,7 +437,7 @@ func TestConfigureMCPContainer(t *testing.T) {
 		attachStdio         bool
 		envVars             []*corev1apply.EnvVarApplyConfiguration
 		transportType       string
-		options             *runtime.CreateContainerOptions
+		options             *runtime.DeployWorkloadOptions
 		expectedContainers  int
 		expectedImage       string
 		expectedCommand     []string
@@ -487,7 +487,7 @@ func TestConfigureMCPContainer(t *testing.T) {
 			attachStdio:     true,
 			envVars:         []*corev1apply.EnvVarApplyConfiguration{corev1apply.EnvVar().WithName("TEST_ENV").WithValue("test-value")},
 			transportType:   "sse",
-			options: &runtime.CreateContainerOptions{
+			options: &runtime.DeployWorkloadOptions{
 				ExposedPorts: map[string]struct{}{
 					"8080/tcp": {},
 				},
@@ -564,7 +564,7 @@ func TestCreateContainerWithMCP(t *testing.T) {
 		envVars             map[string]string
 		attachStdio         bool
 		transportType       string
-		options             *runtime.CreateContainerOptions
+		options             *runtime.DeployWorkloadOptions
 		expectedContainers  int
 		expectedImage       string
 		expectedCommand     []string
@@ -653,8 +653,8 @@ func TestCreateContainerWithMCP(t *testing.T) {
 				waitForStatefulSetReadyFunc: mockWaitForStatefulSetReady,
 			}
 
-			// Create the container
-			containerID, err := client.CreateContainer(
+			// Deploy the workload
+			containerID, err := client.DeployWorkload(
 				context.Background(),
 				tc.image,
 				"test-container",

--- a/pkg/lifecycle/manager.go
+++ b/pkg/lifecycle/manager.go
@@ -68,7 +68,7 @@ func (d *defaultManager) GetContainer(ctx context.Context, name string) (*rt.Con
 
 func (d *defaultManager) ListContainers(ctx context.Context, listAll bool) ([]rt.ContainerInfo, error) {
 	// List containers
-	containers, err := d.runtime.ListContainers(ctx)
+	containers, err := d.runtime.ListWorkloads(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list containers: %v", err)
 	}
@@ -109,7 +109,7 @@ func (d *defaultManager) DeleteContainer(ctx context.Context, name string, force
 
 	// Remove the container
 	logger.Infof("Removing container %s...", name)
-	if err := d.runtime.RemoveContainer(ctx, containerID); err != nil {
+	if err := d.runtime.RemoveWorkload(ctx, containerID); err != nil {
 		return fmt.Errorf("failed to remove container: %v", err)
 	}
 
@@ -145,7 +145,7 @@ func (d *defaultManager) StopContainer(ctx context.Context, name string) error {
 	}
 
 	// Check if the container is running
-	running, err := d.runtime.IsContainerRunning(ctx, containerID)
+	running, err := d.runtime.IsWorkloadRunning(ctx, containerID)
 	if err != nil {
 		return fmt.Errorf("failed to check if container is running: %v", err)
 	}
@@ -359,7 +359,7 @@ func (d *defaultManager) RestartContainer(ctx context.Context, name string) erro
 	// If the container is running but the proxy is not, stop the container first
 	if container.ID != "" && running { // && !proxyRunning was previously here but is implied by previous if statement.
 		logger.Infof("Container %s is running but proxy is not. Stopping container...", name)
-		if err := d.runtime.StopContainer(ctx, containerID); err != nil {
+		if err := d.runtime.StopWorkload(ctx, containerID); err != nil {
 			return fmt.Errorf("failed to stop container: %v", err)
 		}
 		logger.Infof("Container %s stopped", name)
@@ -388,7 +388,7 @@ func (d *defaultManager) findContainerID(ctx context.Context, name string) (stri
 
 func (d *defaultManager) findContainerByName(ctx context.Context, name string) (*rt.ContainerInfo, error) {
 	// List containers to find the one with the given name
-	containers, err := d.runtime.ListContainers(ctx)
+	containers, err := d.runtime.ListWorkloads(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list containers: %v", err)
 	}
@@ -417,7 +417,7 @@ func (d *defaultManager) findContainerByName(ctx context.Context, name string) (
 
 // getContainerBaseName gets the base container name from the container labels
 func (d *defaultManager) getContainerBaseName(ctx context.Context, containerID string) (string, error) {
-	containers, err := d.runtime.ListContainers(ctx)
+	containers, err := d.runtime.ListWorkloads(ctx)
 	if err != nil {
 		return "", fmt.Errorf("failed to list containers: %v", err)
 	}
@@ -434,7 +434,7 @@ func (d *defaultManager) getContainerBaseName(ctx context.Context, containerID s
 // stopContainer stops the container
 func (d *defaultManager) stopContainer(ctx context.Context, containerID, containerName string) error {
 	logger.Infof("Stopping container %s...", containerName)
-	if err := d.runtime.StopContainer(ctx, containerID); err != nil {
+	if err := d.runtime.StopWorkload(ctx, containerID); err != nil {
 		return fmt.Errorf("failed to stop container: %w", err)
 	}
 

--- a/pkg/runner/config_test.go
+++ b/pkg/runner/config_test.go
@@ -22,14 +22,14 @@ import (
 // mockRuntime implements the Runtime interface for testing
 type mockRuntime struct{}
 
-func (*mockRuntime) CreateContainer(
+func (*mockRuntime) DeployWorkload(
 	_ context.Context,
 	_, _ string,
 	_ []string,
 	_, _ map[string]string,
 	_ *permissions.Profile,
 	_ string,
-	_ *rt.CreateContainerOptions,
+	_ *rt.DeployWorkloadOptions,
 ) (string, error) {
 	return "container-id", nil
 }
@@ -38,31 +38,31 @@ func (*mockRuntime) StartContainer(_ context.Context, _ string) error {
 	return nil
 }
 
-func (*mockRuntime) ListContainers(_ context.Context) ([]rt.ContainerInfo, error) {
+func (*mockRuntime) ListWorkloads(_ context.Context) ([]rt.ContainerInfo, error) {
 	return []rt.ContainerInfo{}, nil
 }
 
-func (*mockRuntime) StopContainer(_ context.Context, _ string) error {
+func (*mockRuntime) StopWorkload(_ context.Context, _ string) error {
 	return nil
 }
 
-func (*mockRuntime) RemoveContainer(_ context.Context, _ string) error {
+func (*mockRuntime) RemoveWorkload(_ context.Context, _ string) error {
 	return nil
 }
 
-func (*mockRuntime) ContainerLogs(_ context.Context, _ string, _ bool) (string, error) {
+func (*mockRuntime) GetWorkloadLogs(_ context.Context, _ string, _ bool) (string, error) {
 	return "", nil
 }
 
-func (*mockRuntime) IsContainerRunning(_ context.Context, _ string) (bool, error) {
+func (*mockRuntime) IsWorkloadRunning(_ context.Context, _ string) (bool, error) {
 	return true, nil
 }
 
-func (*mockRuntime) GetContainerInfo(_ context.Context, _ string) (rt.ContainerInfo, error) {
+func (*mockRuntime) GetWorkloadInfo(_ context.Context, _ string) (rt.ContainerInfo, error) {
 	return rt.ContainerInfo{}, nil
 }
 
-func (*mockRuntime) AttachContainer(_ context.Context, _ string) (io.WriteCloser, io.ReadCloser, error) {
+func (*mockRuntime) AttachToWorkload(_ context.Context, _ string) (io.WriteCloser, io.ReadCloser, error) {
 	return nil, nil, nil
 }
 

--- a/pkg/transport/sse.go
+++ b/pkg/transport/sse.go
@@ -105,8 +105,8 @@ func (t *SSETransport) Setup(ctx context.Context, runtime rt.Runtime, containerN
 	envVars["FASTMCP_PORT"] = fmt.Sprintf("%d", t.targetPort)
 	envVars["MCP_HOST"] = t.targetHost
 
-	// Create container options
-	containerOptions := rt.NewCreateContainerOptions()
+	// Create workload options
+	containerOptions := rt.NewDeployWorkloadOptions()
 	containerOptions.K8sPodTemplatePatch = k8sPodTemplatePatch
 
 	// For SSE transport, expose the target port in the container
@@ -138,8 +138,8 @@ func (t *SSETransport) Setup(ctx context.Context, runtime rt.Runtime, containerN
 	containerOptions.AttachStdio = false
 
 	// Create the container
-	logger.Infof("Creating container %s from image %s...", containerName, image)
-	containerID, err := t.runtime.CreateContainer(
+	logger.Infof("Deploying workload %s from image %s...", containerName, image)
+	containerID, err := t.runtime.DeployWorkload(
 		ctx,
 		image,
 		containerName,
@@ -245,8 +245,8 @@ func (t *SSETransport) Stop(ctx context.Context) error {
 
 	// Stop the container if runtime is available
 	if t.runtime != nil && t.containerID != "" {
-		if err := t.runtime.StopContainer(ctx, t.containerID); err != nil {
-			return fmt.Errorf("failed to stop container: %w", err)
+		if err := t.runtime.StopWorkload(ctx, t.containerID); err != nil {
+			return fmt.Errorf("failed to stop workload: %w", err)
 		}
 	}
 

--- a/pkg/transport/stdio.go
+++ b/pkg/transport/stdio.go
@@ -98,14 +98,14 @@ func (t *StdioTransport) Setup(
 	// Add transport-specific environment variables
 	envVars["MCP_TRANSPORT"] = "stdio"
 
-	// Create container options
-	containerOptions := rt.NewCreateContainerOptions()
+	// Create workload options
+	containerOptions := rt.NewDeployWorkloadOptions()
 	containerOptions.AttachStdio = true
 	containerOptions.K8sPodTemplatePatch = k8sPodTemplatePatch
 
 	// Create the container
-	logger.Infof("Creating container %s from image %s...", containerName, image)
-	containerID, err := t.runtime.CreateContainer(
+	logger.Infof("Deploying workload %s from image %s...", containerName, image)
+	containerID, err := t.runtime.DeployWorkload(
 		ctx,
 		image,
 		containerName,
@@ -145,7 +145,7 @@ func (t *StdioTransport) Start(ctx context.Context) error {
 
 	// Attach to the container
 	var err error
-	t.stdin, t.stdout, err = t.runtime.AttachContainer(ctx, t.containerID)
+	t.stdin, t.stdout, err = t.runtime.AttachToWorkload(ctx, t.containerID)
 	if err != nil {
 		return fmt.Errorf("failed to attach to container: %w", err)
 	}
@@ -229,15 +229,15 @@ func (t *StdioTransport) Stop(ctx context.Context) error {
 
 	// Stop the container if runtime is available and we haven't already stopped it
 	if t.runtime != nil && t.containerID != "" {
-		// Check if the container is still running before trying to stop it
-		running, err := t.runtime.IsContainerRunning(ctx, t.containerID)
+		// Check if the workload is still running before trying to stop it
+		running, err := t.runtime.IsWorkloadRunning(ctx, t.containerID)
 		if err != nil {
-			// If there's an error checking the container status, it might be gone already
-			logger.Warnf("Warning: Failed to check container status: %v", err)
+			// If there's an error checking the workload status, it might be gone already
+			logger.Warnf("Warning: Failed to check workload status: %v", err)
 		} else if running {
-			// Only try to stop the container if it's still running
-			if err := t.runtime.StopContainer(ctx, t.containerID); err != nil {
-				logger.Warnf("Warning: Failed to stop container: %v", err)
+			// Only try to stop the workload if it's still running
+			if err := t.runtime.StopWorkload(ctx, t.containerID); err != nil {
+				logger.Warnf("Warning: Failed to stop workload: %v", err)
 			}
 		}
 	}


### PR DESCRIPTION
## Overview

This PR refactors the Runtime interface to use workload-centric naming that better reflects the system's current capabilities of managing complex deployments with multiple containers, sidecars, and networks.

## Key Changes

### Interface Method Renames
- `CreateContainer` → `DeployWorkload` (creates and starts complete workloads)
- `ListContainers` → `ListWorkloads`
- `StopContainer` → `StopWorkload`
- `RemoveContainer` → `RemoveWorkload`
- `ContainerLogs` → `GetWorkloadLogs`
- `IsContainerRunning` → `IsWorkloadRunning`
- `GetContainerInfo` → `GetWorkloadInfo`
- `AttachContainer` → `AttachToWorkload`
- `CreateContainerOptions` → `DeployWorkloadOptions`

### Documentation Updates
- Added comprehensive documentation explaining what a workload is
- Clarified that workloads include primary containers, sidecars, networks, volumes, and other orchestrated components
- Updated method documentation to reflect workload-centric operations

### Implementation Updates
- Updated Docker and Kubernetes runtime implementations
- Updated transport layer (SSE and stdio) to use new method names
- Updated monitoring and lifecycle management components
- Updated test mocks and test cases
- **Preserved manager interface methods as requested**

## Why This Change?

The original `CreateContainer` naming was misleading since the system now handles much more than single containers:
- Primary MCP server containers
- Sidecar containers for logging, monitoring, proxying
- Network configurations and port mappings
- Volume mounts and storage
- Service discovery and load balancing
- Security policies and permission profiles

`DeployWorkload` accurately captures this expanded scope and better represents the system's multi-container orchestration capabilities.

## Testing

- ✅ All unit tests pass
- ✅ Linting is clean (0 issues)
- ✅ No compilation errors
- ✅ Type safety maintained throughout

## Breaking Changes

This is a breaking change to the Runtime interface, but it improves API clarity and accurately represents the system's capabilities. The manager interface remains unchanged as requested.