### PR TITLE
Remove `target_port` from registry entries for k8s, osv, and oci MCP servers

### DIFF
--- a/pkg/registry/data/registry.json
+++ b/pkg/registry/data/registry.json
@@ -1078,7 +1078,6 @@
         "get",
         "list"
       ],
-      "target_port": 8080,
       "tools": [
         "list_resources",
         "get_resource",
@@ -1269,7 +1268,6 @@
         "mcp",
         "docker"
       ],
-      "target_port": 8080,
       "tools": [
         "get_image_info",
         "list_tags",
@@ -1326,7 +1324,6 @@
         "security-scanning",
         "vulnerability-detection"
       ],
-      "target_port": 8080,
       "tools": [
         "query_vulnerability",
         "query_vulnerabilities_batch",


### PR DESCRIPTION
This is no longer needed since they now support the `MCP_PORT`
environment variable. ToolHive can then use this to inject a random port
that will just work.

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>
