### PR TITLE
Fix nil pointer dereference in registry commands

### DIFF
--- a/cmd/regup/app/update.go
+++ b/cmd/regup/app/update.go
@@ -71,8 +71,18 @@ func updateCmdFunc(_ *cobra.Command, _ []string) error {
 
 	// Sort servers by last updated time (oldest first)
 	sort.Slice(servers, func(i, j int) bool {
-		timeI, errI := time.Parse(time.RFC3339, servers[i].server.Metadata.LastUpdated)
-		timeJ, errJ := time.Parse(time.RFC3339, servers[j].server.Metadata.LastUpdated)
+		var lastUpdatedI, lastUpdatedJ string
+
+		// Handle nil metadata
+		if servers[i].server.Metadata != nil {
+			lastUpdatedI = servers[i].server.Metadata.LastUpdated
+		}
+		if servers[j].server.Metadata != nil {
+			lastUpdatedJ = servers[j].server.Metadata.LastUpdated
+		}
+
+		timeI, errI := time.Parse(time.RFC3339, lastUpdatedI)
+		timeJ, errJ := time.Parse(time.RFC3339, lastUpdatedJ)
 
 		// If we can't parse either time, put it at the beginning to ensure it gets updated
 		if errI != nil {
@@ -137,6 +147,11 @@ func updateServerInfo(name string, server *registry.Server) error {
 	if server.RepositoryURL == "" {
 		logger.Warnf("Server %s has no repository URL, skipping", name)
 		return nil
+	}
+
+	// Initialize metadata if it's nil
+	if server.Metadata == nil {
+		server.Metadata = &registry.Metadata{}
 	}
 
 	// Extract owner and repo from repository URL

--- a/cmd/thv/app/registry.go
+++ b/cmd/thv/app/registry.go
@@ -126,12 +126,19 @@ func printTextServers(servers []*registry.Server) {
 
 	// Print server information
 	for _, server := range servers {
+		stars := 0
+		pulls := 0
+		if server.Metadata != nil {
+			stars = server.Metadata.Stars
+			pulls = server.Metadata.Pulls
+		}
+
 		fmt.Fprintf(w, "%s\t%s\t%s\t%d\t%d\n",
 			server.Name,
 			truncateString(server.Description, 60),
 			server.Transport,
-			server.Metadata.Stars,
-			server.Metadata.Pulls,
+			stars,
+			pulls,
 		)
 	}
 
@@ -152,8 +159,14 @@ func printTextServerInfo(name string, server *registry.Server) {
 		fmt.Printf("Target Port: %d\n", server.TargetPort)
 	}
 	fmt.Printf("Repository URL: %s\n", server.RepositoryURL)
-	fmt.Printf("Popularity: %d stars, %d pulls\n", server.Metadata.Stars, server.Metadata.Pulls)
-	fmt.Printf("Last Updated: %s\n", server.Metadata.LastUpdated)
+
+	if server.Metadata != nil {
+		fmt.Printf("Popularity: %d stars, %d pulls\n", server.Metadata.Stars, server.Metadata.Pulls)
+		fmt.Printf("Last Updated: %s\n", server.Metadata.LastUpdated)
+	} else {
+		fmt.Printf("Popularity: 0 stars, 0 pulls\n")
+		fmt.Printf("Last Updated: N/A\n")
+	}
 
 	// Print tools
 	if len(server.Tools) > 0 {


### PR DESCRIPTION
## Problem

PR #463 added a new Terraform MCP server to the registry without a `metadata` field, causing nil pointer dereferences in the registry commands when trying to access `server.Metadata.Stars` and `server.Metadata.Pulls`.

This resulted in E2E test failures with the error:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x203fd71]
```

## Solution

- **Fixed `printTextServers`**: Added nil checks for `server.Metadata` before accessing stars and pulls, defaulting to 0 when metadata is nil
- **Fixed `printTextServerInfo`**: Added nil checks for `server.Metadata` before accessing metadata fields, showing appropriate fallback values
- **Fixed `regup` command**: 
  - Added nil checks in sorting logic to handle servers without metadata
  - Initialize metadata when nil in `updateServerInfo` function

## Testing

- ✅ Manual testing: `thv registry list` and `thv registry info terraform` work correctly
- ✅ Manual testing: `regup update --dry-run` works without crashing
- ✅ Linting: All code passes golangci-lint checks
- ✅ Unit tests: All existing tests pass

## Changes

- `cmd/thv/app/registry.go`: Added nil checks in `printTextServers` and `printTextServerInfo`
- `cmd/regup/app/update.go`: Added nil checks in sorting logic and `updateServerInfo`

Fixes the E2E test failure: 'should list available servers in registry'