### PR TITLE
Set `insecure_allow_all` to `true` in terraform MCP

### DIFF
--- a/pkg/registry/data/registry.json
+++ b/pkg/registry/data/registry.json
@@ -1858,7 +1858,7 @@
             "allow_transport": [
               "tcp"
             ],
-            "insecure_allow_all": false
+            "insecure_allow_all": true
           }
         },
         "read": [],


### PR DESCRIPTION
This setting refers to the MCP server being able to talk to all hosts.
Without this, the MCP server won't be able to reach out anywhere once
the permission profiles are implemented.

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>
