### PR TITLE
fix: cleanup temporary permission profile files on container removal

### DIFF
--- a/pkg/lifecycle/permissions_test.go
+++ b/pkg/lifecycle/permissions_test.go
@@ -1,0 +1,114 @@
+package lifecycle
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stacklok/toolhive/pkg/logger"
+)
+
+func TestIsTempPermissionProfile(t *testing.T) {
+	logger.Initialize()
+	tests := []struct {
+		name     string
+		filePath string
+		expected bool
+	}{
+		{
+			name:     "valid temp file in temp dir",
+			filePath: filepath.Join(os.TempDir(), "toolhive-fetch-permissions-123.json"),
+			expected: true,
+		},
+		{
+			name:     "valid temp file with different server name",
+			filePath: filepath.Join(os.TempDir(), "toolhive-github-permissions-456.json"),
+			expected: true,
+		},
+		{
+			name:     "not a toolhive file",
+			filePath: filepath.Join(os.TempDir(), "other-file.json"),
+			expected: false,
+		},
+		{
+			name:     "toolhive file but not permissions",
+			filePath: filepath.Join(os.TempDir(), "toolhive-fetch-config-123.json"),
+			expected: false,
+		},
+		{
+			name:     "toolhive permissions file but not in temp dir",
+			filePath: "/home/user/toolhive-fetch-permissions-123.json",
+			expected: false,
+		},
+		{
+			name:     "empty path",
+			filePath: "",
+			expected: false,
+		},
+		{
+			name:     "not json file",
+			filePath: filepath.Join(os.TempDir(), "toolhive-fetch-permissions-123.txt"),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isTempPermissionProfile(tt.filePath)
+			if result != tt.expected {
+				t.Errorf("isTempPermissionProfile(%q) = %v, expected %v", tt.filePath, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestCleanupTempPermissionProfile(t *testing.T) {
+	logger.Initialize()
+	// Create a temporary file that matches our pattern
+	tempFile, err := os.CreateTemp("", "toolhive-test-permissions-*.json")
+	if err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+	tempPath := tempFile.Name()
+	tempFile.Close()
+
+	// Verify the file exists
+	if _, err := os.Stat(tempPath); os.IsNotExist(err) {
+		t.Fatalf("Temp file should exist: %s", tempPath)
+	}
+
+	// Clean up the temp file
+	err = CleanupTempPermissionProfile(tempPath)
+	if err != nil {
+		t.Fatalf("CleanupTempPermissionProfile failed: %v", err)
+	}
+
+	// Verify the file is removed
+	if _, err := os.Stat(tempPath); !os.IsNotExist(err) {
+		t.Errorf("Temp file should be removed: %s", tempPath)
+	}
+}
+
+func TestCleanupTempPermissionProfile_NonTempFile(t *testing.T) {
+	logger.Initialize()
+	// Test with a non-temp file path
+	nonTempPath := "/home/user/my-permissions.json"
+
+	// This should not fail and should not attempt to remove the file
+	err := CleanupTempPermissionProfile(nonTempPath)
+	if err != nil {
+		t.Errorf("CleanupTempPermissionProfile should not fail for non-temp files: %v", err)
+	}
+}
+
+func TestCleanupTempPermissionProfile_NonExistentFile(t *testing.T) {
+	logger.Initialize()
+	// Test with a temp file pattern that doesn't exist
+	nonExistentPath := filepath.Join(os.TempDir(), "toolhive-nonexistent-permissions-999.json")
+
+	// This should not fail
+	err := CleanupTempPermissionProfile(nonExistentPath)
+	if err != nil {
+		t.Errorf("CleanupTempPermissionProfile should not fail for non-existent files: %v", err)
+	}
+}


### PR DESCRIPTION
## Description

This PR fixes the issue where temporary permission profile files were not being removed when using `thv rm`. When running an MCP server without explicitly setting the `--permission-profile` flag, toolhive creates temporary permission profile files named `toolhive-<server-name>-permissions-*.json` in the temp directory. Previously, these files were not cleaned up when the container was removed.

## Changes Made

### 1. Added Cleanup Functions (`pkg/lifecycle/permissions.go`)
- **`CleanupTempPermissionProfile()`**: Safely removes temporary permission profile files created by toolhive
- **`isTempPermissionProfile()`**: Helper function to identify if a file path is a temporary permission profile by checking:
  - File name pattern: `toolhive-*-permissions-*.json`
  - Location in system temp directory
  - File extension is `.json`

### 2. Modified Container Deletion Logic (`pkg/lifecycle/manager.go`)
- Updated `DeleteContainer()` method to call cleanup before deleting saved state
- Added `cleanupTempPermissionProfile()` method that:
  - Loads the saved configuration to get the permission profile path
  - Calls the cleanup function if a permission profile path exists
  - Handles errors gracefully with warnings

### 3. Added Comprehensive Tests (`pkg/lifecycle/permissions_test.go`)
- Tests for identifying temporary permission profile files
- Tests for successful cleanup of temporary files
- Tests for handling non-temporary files (should be ignored)
- Tests for handling non-existent files (should not error)

## Key Features of the Solution
- **Safe**: Only removes files that match the exact pattern created by toolhive
- **Robust**: Handles edge cases like missing files or non-temporary files gracefully
- **Non-breaking**: Existing functionality remains unchanged
- **Well-tested**: Comprehensive test coverage for all scenarios

## Testing
- All existing tests continue to pass
- New tests added with 100% coverage for the cleanup functionality
- Linting and formatting checks pass

## How to Test
1. Run `thv run <server-name>` without `--permission-profile` flag
2. Check that a temporary file is created in `$TMPDIR/toolhive-<server-name>-permissions-*.json`
3. Run `thv rm <server-name>`
4. Verify that the temporary permission profile file is removed

Fixes #443