### PR TITLE
feat: adds serviceaccount for mkp sample and adds design & decision md

### DIFF
--- a/cmd/thv-operator/DESIGN.md
+++ b/cmd/thv-operator/DESIGN.md
@@ -1,0 +1,44 @@
+# Design & Decisions
+
+This document aims to help fill in gaps of any decision that are made around the design of the ToolHive Operator.
+
+## CRD Attribute vs `PodTemplateSpec`
+
+When building operators, the decision of when to use a `podTemplateSpec` and when to use a CRD attribute is always disputed. For the ToolHive Operator we have a defined rule of thumb.
+
+### Use Dedicated CRD Attributes For:
+- **Business logic** that affects your operator's behavior
+- **Validation requirements** (ranges, formats, constraints)  
+- **Cross-resource coordination** (affects Services, ConfigMaps, etc.)
+- **Operator decision making** (triggers different reconciliation paths)
+
+```yaml
+spec:
+  version: "13.4"           # Affects operator logic
+  replicas: 3               # Affects scaling behavior  
+  backupSchedule: "0 2 * * *"  # Needs validation
+```
+
+### Use PodTemplateSpec For:
+- **Infrastructure concerns** (node selection, resources, affinity)
+- **Sidecar containers** 
+- **Standard Kubernetes pod configuration**
+- **Things a cluster admin would typically configure**
+
+```yaml
+spec:
+  podTemplate:
+    spec:
+      nodeSelector:
+        disktype: ssd
+      containers:
+      - name: sidecar
+        image: monitoring:latest
+```
+
+## Quick Decision Test:
+1. **"Does this affect my operator's reconciliation logic?"** -> Dedicated attribute
+2. **"Is this standard Kubernetes pod configuration?"** -> PodTemplateSpec  
+3. **"Do I need to validate this beyond basic Kubernetes validation?"** -> Dedicated attribute
+
+This gives you a clean API for core functionality while maintaining flexibility for infrastructure concerns.

--- a/deploy/operator/samples/mcpserver_mkp.yaml
+++ b/deploy/operator/samples/mcpserver_mkp.yaml
@@ -10,6 +10,12 @@ spec:
   permissionProfile:
     type: builtin
     name: network
+  # Example of using the PodTemplateSpec to customize the pod
+  podTemplateSpec:
+    spec:
+      # this value has to be set to a serviceaccount that has the necessary permissions
+      # will use the default toolhive service account for an example
+      serviceAccountName: toolhive
   resources:
     limits:
       cpu: "100m"


### PR DESCRIPTION
- The MKP MCP server needs a serviceAccount to be able to work. We've added a sample example of this.
- We add a design & decisions doc that aims to detail the design and any decisions that have been consciously made around the operator. 