### PR TITLE
Add ability to set, get, and unset registry URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ consistency, and security.
 - [Architecture overview](#architecture-overview)
 - [Usage examples](#usage-examples)
   - [Register clients](#register-clients)
+  - [Configure custom registry](#configure-custom-registry)
   - [Find and run an MCP server](#find-and-run-an-mcp-server)
   - [Manage MCP servers](#manage-mcp-servers)
   - [Secrets management](#secrets-management)
@@ -236,6 +237,27 @@ thv config list-registered-clients
 # Remove a client
 thv config remove-client <client-name>
 ```
+
+### Configure custom registry
+
+By default, ToolHive uses a built-in registry of curated MCP servers. However, you can configure ToolHive to use a custom remote registry instead.
+
+To set a custom registry URL:
+
+```bash
+# Set a custom registry URL
+thv config set-registry-url https://example.com/custom-registry.json
+
+# View the currently configured registry URL
+thv config get-registry-url
+
+# Remove the custom registry URL and revert to the built-in registry
+thv config unset-registry-url
+```
+
+The custom registry must be a JSON file that follows the same format as the [built-in registry](pkg/registry/data/registry.json). When a custom registry URL is configured, ToolHive will fetch the registry data from that URL instead of using the embedded registry.
+
+This feature is useful for organizations that want to maintain their own curated list of MCP servers or for testing custom registry configurations.
 
 ### Find and run an MCP server
 

--- a/docs/cli/thv_config.md
+++ b/docs/cli/thv_config.md
@@ -23,10 +23,13 @@ The config command provides subcommands to manage application configuration sett
 * [thv](thv.md)	 - ToolHive (thv) is a lightweight, secure, and fast manager for MCP servers
 * [thv config auto-discovery](thv_config_auto-discovery.md)	 - Set whether to enable auto-discovery of MCP clients
 * [thv config get-ca-cert](thv_config_get-ca-cert.md)	 - Get the currently configured CA certificate path
+* [thv config get-registry-url](thv_config_get-registry-url.md)	 - Get the currently configured registry URL
 * [thv config list-registered-clients](thv_config_list-registered-clients.md)	 - List all registered MCP clients
 * [thv config register-client](thv_config_register-client.md)	 - Register a client for MCP server configuration
 * [thv config remove-client](thv_config_remove-client.md)	 - Remove a client from MCP server configuration
 * [thv config secrets-provider](thv_config_secrets-provider.md)	 - Set the secrets provider type
 * [thv config set-ca-cert](thv_config_set-ca-cert.md)	 - Set the default CA certificate for container builds
+* [thv config set-registry-url](thv_config_set-registry-url.md)	 - Set the MCP server registry URL
 * [thv config unset-ca-cert](thv_config_unset-ca-cert.md)	 - Remove the configured CA certificate
+* [thv config unset-registry-url](thv_config_unset-registry-url.md)	 - Remove the configured registry URL
 

--- a/docs/cli/thv_config_get-registry-url.md
+++ b/docs/cli/thv_config_get-registry-url.md
@@ -1,0 +1,28 @@
+## thv config get-registry-url
+
+Get the currently configured registry URL
+
+### Synopsis
+
+Display the URL of the remote registry that is currently configured.
+
+```
+thv config get-registry-url [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for get-registry-url
+```
+
+### Options inherited from parent commands
+
+```
+      --debug   Enable debug mode
+```
+
+### SEE ALSO
+
+* [thv config](thv_config.md)	 - Manage application configuration
+

--- a/docs/cli/thv_config_set-registry-url.md
+++ b/docs/cli/thv_config_set-registry-url.md
@@ -1,0 +1,32 @@
+## thv config set-registry-url
+
+Set the MCP server registry URL
+
+### Synopsis
+
+Set the URL for the remote MCP server registry.
+This allows you to use a custom registry instead of the built-in one.
+
+Example:
+  thv config set-registry-url https://example.com/registry.json
+
+```
+thv config set-registry-url <url> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for set-registry-url
+```
+
+### Options inherited from parent commands
+
+```
+      --debug   Enable debug mode
+```
+
+### SEE ALSO
+
+* [thv config](thv_config.md)	 - Manage application configuration
+

--- a/docs/cli/thv_config_unset-registry-url.md
+++ b/docs/cli/thv_config_unset-registry-url.md
@@ -1,0 +1,28 @@
+## thv config unset-registry-url
+
+Remove the configured registry URL
+
+### Synopsis
+
+Remove the registry URL configuration, reverting to the built-in registry.
+
+```
+thv config unset-registry-url [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for unset-registry-url
+```
+
+### Options inherited from parent commands
+
+```
+      --debug   Enable debug mode
+```
+
+### SEE ALSO
+
+* [thv config](thv_config.md)	 - Manage application configuration
+

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -166,3 +166,74 @@ func TestSave(t *testing.T) {
 		})
 	})
 }
+
+func TestRegistryURLConfig(t *testing.T) {
+	logger.Initialize()
+
+	t.Run("TestSetAndGetRegistryURL", func(t *testing.T) {
+		tempDir, cleanup := SetupTestConfig(t, &Config{
+			Secrets: Secrets{
+				ProviderType: "encrypted",
+			},
+			Clients: Clients{
+				AutoDiscovery:     false,
+				RegisteredClients: []string{},
+			},
+			RegistryUrl: "",
+		})
+		defer cleanup()
+
+		// Test setting a registry URL
+		testURL := "https://example.com/registry.json"
+		err := UpdateConfig(func(c *Config) {
+			c.RegistryUrl = testURL
+		})
+		require.NoError(t, err)
+
+		// Load the config and verify the URL was set
+		config, err := LoadOrCreateConfig()
+		require.NoError(t, err)
+		assert.Equal(t, testURL, config.RegistryUrl)
+
+		// Test unsetting the registry URL
+		err = UpdateConfig(func(c *Config) {
+			c.RegistryUrl = ""
+		})
+		require.NoError(t, err)
+
+		// Load the config and verify the URL was unset
+		config, err = LoadOrCreateConfig()
+		require.NoError(t, err)
+		assert.Equal(t, "", config.RegistryUrl)
+
+		t.Cleanup(func() {
+			if err := os.RemoveAll(tempDir); err != nil {
+				t.Logf("Failed to remove temp dir: %v", err)
+			}
+		})
+	})
+
+	t.Run("TestRegistryURLPersistence", func(t *testing.T) {
+		tempDir, cleanup := SetupTestConfig(t, nil)
+		defer cleanup()
+
+		testURL := "https://custom-registry.example.com/registry.json"
+
+		// Set the registry URL
+		err := UpdateConfig(func(c *Config) {
+			c.RegistryUrl = testURL
+		})
+		require.NoError(t, err)
+
+		// Load config again to verify persistence
+		config, err := LoadOrCreateConfig()
+		require.NoError(t, err)
+		assert.Equal(t, testURL, config.RegistryUrl)
+
+		t.Cleanup(func() {
+			if err := os.RemoveAll(tempDir); err != nil {
+				t.Logf("Failed to remove temp dir: %v", err)
+			}
+		})
+	})
+}


### PR DESCRIPTION
https://github.com/stacklok/toolhive/pull/423 added support for configurable remote MCP registries. In response to [this comment](https://github.com/stacklok/toolhive/pull/423#issuecomment-2913212769), this PR adds documentation to the README as well as 3 new `config` commands:

* `set-registry-url <url>`: Set the URL for the remote MCP server registry.
* `get-registry-url`: Display the URL of the remote registry that is currently configured
* `unset-registry-url`: Remove the registry URL configuration, reverting to the built-in registry

## 👀 For Reviewers

Are adding 3 separate subcommands to `thv config` okay here or would we prefer using a different set CLI subcommands?