### PR TITLE
Fix setting the helm chart GitHub release as latest

### DIFF
--- a/.github/workflows/releaser-helm-charts.yml
+++ b/.github/workflows/releaser-helm-charts.yml
@@ -27,6 +27,7 @@ jobs:
         with:
           config: cr.yaml
           charts_dir: deploy/charts
+          mark_as_latest: false
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 


### PR DESCRIPTION
The following PR fixes an issue with the release process of the helm charts which was causing the update check flow to return wrongful data. 

The root cause is we were marking the helm chart release as latest which was overwriting the previous toolhive release which resulted in wrong processing on update checks both on the client and on the server side.