### PR TITLE
Initial support for update checks for toolhive operator

### DIFF
--- a/cmd/thv-operator/controllers/mcpserver_controller.go
+++ b/cmd/thv-operator/controllers/mcpserver_controller.go
@@ -47,8 +47,8 @@ type MCPServerReconciler struct {
 // Allow the operator read manage Pods
 // +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch
 
-// Allow the operator read manage ConfigMaps
-// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
+// Allow the operator to manage ConfigMaps (including telemetry data)
+// +kubebuilder:rbac:groups="",resources=configmaps,verbs=create;delete;get;list;patch;update;watch
 
 // Allow the operator read manage Secrets
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch

--- a/cmd/thv-operator/main.go
+++ b/cmd/thv-operator/main.go
@@ -21,6 +21,7 @@ import (
 	mcpv1alpha1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1alpha1"
 	"github.com/stacklok/toolhive/cmd/thv-operator/controllers"
 	"github.com/stacklok/toolhive/pkg/logger"
+	"github.com/stacklok/toolhive/pkg/operator/telemetry"
 )
 
 var (
@@ -79,6 +80,15 @@ func main() {
 	}
 	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
 		setupLog.Error(err, "unable to set up ready check")
+		os.Exit(1)
+	}
+
+	// Set up telemetry service - only runs when elected as leader
+	telemetryService := telemetry.NewService(mgr.GetClient(), "")
+	if err := mgr.Add(&telemetry.LeaderTelemetryRunnable{
+		TelemetryService: telemetryService,
+	}); err != nil {
+		setupLog.Error(err, "unable to add telemetry runnable")
 		os.Exit(1)
 	}
 

--- a/deploy/charts/operator/Chart.yaml
+++ b/deploy/charts/operator/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: toolhive-operator
 description: A Helm chart for deploying the ToolHive Operator into Kubernetes.
 type: application
-version: 0.0.7
+version: 0.0.8
 appVersion: "0.0.38"

--- a/deploy/charts/operator/README.md
+++ b/deploy/charts/operator/README.md
@@ -1,7 +1,7 @@
 
 # ToolHive Operator Helm Chart
 
-![Version: 0.0.7](https://img.shields.io/badge/Version-0.0.7-informational?style=flat-square)
+![Version: 0.0.8](https://img.shields.io/badge/Version-0.0.8-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying the ToolHive Operator into Kubernetes.

--- a/deploy/charts/operator/templates/clusterrole/role.yaml
+++ b/deploy/charts/operator/templates/clusterrole/role.yaml
@@ -8,11 +8,14 @@ rules:
   - ""
   resources:
   - configmaps
-  - pods
-  - secrets
+  - services
   verbs:
+  - create
+  - delete
   - get
   - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - ""
@@ -24,14 +27,11 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - services
+  - pods
+  - secrets
   verbs:
-  - create
-  - delete
   - get
   - list
-  - patch
-  - update
   - watch
 - apiGroups:
   - apps

--- a/pkg/operator/telemetry/telemetry.go
+++ b/pkg/operator/telemetry/telemetry.go
@@ -1,0 +1,242 @@
+// Package telemetry provides telemetry functionality for the ToolHive operator.
+package telemetry
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/stacklok/toolhive/pkg/updates"
+	"github.com/stacklok/toolhive/pkg/versions"
+)
+
+const (
+	// updateInterval defines how often to check for updates
+	updateInterval = 4 * time.Hour
+	// configMapName is the name of the ConfigMap used to store telemetry data
+	configMapName = "toolhive-operator-telemetry"
+	// configMapNamespace is the namespace where the ConfigMap is stored
+	configMapNamespace = "toolhive-system"
+	// instanceIDKey is the key used to store the instance ID in the ConfigMap
+	instanceIDKey = "instance-id"
+)
+
+// Service handles telemetry operations for the operator
+type Service struct {
+	client        client.Client
+	versionClient updates.VersionClient
+	namespace     string
+}
+
+// LeaderTelemetryRunnable runs telemetry checks only when this instance is the leader
+type LeaderTelemetryRunnable struct {
+	TelemetryService *Service
+}
+
+// Start starts the telemetry runner
+func (t *LeaderTelemetryRunnable) Start(ctx context.Context) error {
+	ctxLogger := log.FromContext(ctx)
+	ctxLogger.Info("Leader elected, starting telemetry worker")
+
+	// Start telemetry worker in a goroutine with the leader context
+	// When leadership is lost, ctx will be cancelled and telemetry will stop
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				ctxLogger.Error(fmt.Errorf("telemetry worker panic: %v", r), "Telemetry worker panicked")
+			}
+		}()
+		t.TelemetryService.StartTelemetryWorker(ctx)
+	}()
+
+	// Wait for context cancellation (leadership lost or shutdown)
+	<-ctx.Done()
+	ctxLogger.Info("Leadership lost, telemetry worker stopped")
+	return nil
+}
+
+// NeedsLeaderElection indicates whether this runnable needs leader election
+func (*LeaderTelemetryRunnable) NeedsLeaderElection() bool {
+	// This runnable should only run when this instance is the leader
+	return true
+}
+
+// telemetryData represents the structure of telemetry data stored in ConfigMap
+type telemetryData struct {
+	InstanceID      string    `json:"instance_id"`
+	LastUpdateCheck time.Time `json:"last_update_check"`
+	LatestVersion   string    `json:"latest_version"`
+}
+
+// NewService creates a new Service instance
+func NewService(k8sClient client.Client, namespace string) *Service {
+	if namespace == "" {
+		namespace = configMapNamespace
+	}
+	return &Service{
+		client:        k8sClient,
+		versionClient: updates.NewVersionClientWithSuffix("operator"),
+		namespace:     namespace,
+	}
+}
+
+// CheckForUpdates checks for updates and sends telemetry data
+func (s *Service) CheckForUpdates(ctx context.Context) error {
+	logger := log.FromContext(ctx)
+
+	// Get or create telemetry data
+	data, err := s.getTelemetryData(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get telemetry data: %w", err)
+	}
+
+	// Check if we need to make an API request based on last update time
+	if time.Since(data.LastUpdateCheck) < updateInterval {
+		// Too soon, skip the check
+		logger.V(1).Info("Skipping update check, too soon since last check",
+			"lastCheck", data.LastUpdateCheck,
+			"interval", updateInterval)
+		return nil
+	}
+
+	logger.Info("Checking for updates...")
+
+	// Get the latest version from the API
+	currentVersion := versions.GetVersionInfo().Version
+	latestVersion, err := s.versionClient.GetLatestVersion(data.InstanceID, currentVersion)
+	if err != nil {
+		logger.Error(err, "Failed to check for updates")
+		return fmt.Errorf("failed to check for updates: %w", err)
+	}
+
+	// Update telemetry data
+	data.LastUpdateCheck = time.Now()
+	data.LatestVersion = latestVersion
+
+	// Save updated telemetry data
+	if err := s.saveTelemetryData(ctx, data); err != nil {
+		return fmt.Errorf("failed to save telemetry data: %w", err)
+	}
+
+	logger.Info("Update check completed",
+		"currentVersion", currentVersion,
+		"latestVersion", latestVersion)
+
+	return nil
+}
+
+// getTelemetryData retrieves telemetry data from ConfigMap or creates new data
+func (s *Service) getTelemetryData(ctx context.Context) (*telemetryData, error) {
+	cm := &corev1.ConfigMap{}
+	err := s.client.Get(ctx, types.NamespacedName{
+		Name:      configMapName,
+		Namespace: s.namespace,
+	}, cm)
+
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// ConfigMap doesn't exist, create new telemetry data
+			return &telemetryData{
+				InstanceID:      uuid.NewString(),
+				LastUpdateCheck: time.Time{}, // Zero time to force immediate check
+				LatestVersion:   "",
+			}, nil
+		}
+		return nil, fmt.Errorf("failed to get ConfigMap: %w", err)
+	}
+
+	// Parse existing data
+	data := &telemetryData{}
+	if rawData, exists := cm.Data[instanceIDKey]; exists {
+		if err := json.Unmarshal([]byte(rawData), data); err != nil {
+			// If we can't parse the data, create new data
+			return &telemetryData{
+				InstanceID:      uuid.NewString(),
+				LastUpdateCheck: time.Time{},
+				LatestVersion:   "",
+			}, nil
+		}
+	} else {
+		// No data in ConfigMap, create new
+		return &telemetryData{
+			InstanceID:      uuid.NewString(),
+			LastUpdateCheck: time.Time{},
+			LatestVersion:   "",
+		}, nil
+	}
+
+	return data, nil
+}
+
+// saveTelemetryData saves telemetry data to ConfigMap
+func (s *Service) saveTelemetryData(ctx context.Context, data *telemetryData) error {
+	dataBytes, err := json.Marshal(data)
+	if err != nil {
+		return fmt.Errorf("failed to marshal telemetry data: %w", err)
+	}
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      configMapName,
+			Namespace: s.namespace,
+		},
+		Data: map[string]string{
+			instanceIDKey: string(dataBytes),
+		},
+	}
+
+	// Try to get existing ConfigMap first
+	existingCM := &corev1.ConfigMap{}
+	err = s.client.Get(ctx, types.NamespacedName{
+		Name:      configMapName,
+		Namespace: s.namespace,
+	}, existingCM)
+
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// ConfigMap doesn't exist, create it
+			return s.client.Create(ctx, cm)
+		}
+		return fmt.Errorf("failed to get existing ConfigMap: %w", err)
+	}
+
+	// ConfigMap exists, update it
+	existingCM.Data = cm.Data
+	return s.client.Update(ctx, existingCM)
+}
+
+// StartTelemetryWorker starts a background worker that periodically checks for updates
+// This should only be called by the leader
+func (s *Service) StartTelemetryWorker(ctx context.Context) {
+	logger := log.FromContext(ctx)
+	logger.Info("Starting telemetry worker")
+
+	ticker := time.NewTicker(updateInterval)
+	defer ticker.Stop()
+
+	// Run initial check
+	if err := s.CheckForUpdates(ctx); err != nil {
+		logger.Error(err, "Failed initial telemetry check")
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			logger.Info("Telemetry worker stopped")
+			return
+		case <-ticker.C:
+			if err := s.CheckForUpdates(ctx); err != nil {
+				logger.Error(err, "Failed telemetry check")
+			}
+		}
+	}
+}

--- a/pkg/operator/telemetry/telemetry.go
+++ b/pkg/operator/telemetry/telemetry.go
@@ -114,7 +114,6 @@ func (s *Service) CheckForUpdates(ctx context.Context) error {
 	currentVersion := versions.GetVersionInfo().Version
 	latestVersion, err := s.versionClient.GetLatestVersion(data.InstanceID, currentVersion)
 	if err != nil {
-		logger.Error(err, "Failed to check for updates")
 		return fmt.Errorf("failed to check for updates: %w", err)
 	}
 

--- a/pkg/operator/telemetry/telemetry_test.go
+++ b/pkg/operator/telemetry/telemetry_test.go
@@ -1,0 +1,198 @@
+package telemetry
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// mockVersionClient is a mock implementation of the VersionClient interface
+type mockVersionClient struct {
+	version string
+	err     error
+}
+
+func (m *mockVersionClient) GetLatestVersion(_ string, _ string) (string, error) {
+	if m.err != nil {
+		return "", m.err
+	}
+	return m.version, nil
+}
+
+func TestService_CheckForUpdates(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	tests := []struct {
+		name              string
+		existingConfigMap *corev1.ConfigMap
+		mockVersion       string
+		mockError         error
+		expectedError     bool
+		expectedCallToAPI bool
+	}{
+		{
+			name:              "first time check creates new data",
+			existingConfigMap: nil,
+			mockVersion:       "v1.2.3",
+			expectedCallToAPI: true,
+		},
+		{
+			name: "recent check skips API call",
+			existingConfigMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      configMapName,
+					Namespace: configMapNamespace,
+				},
+				Data: map[string]string{
+					instanceIDKey: `{"instance_id":"test-id","last_update_check":"` + time.Now().Format(time.RFC3339) + `","latest_version":"v1.2.2"}`,
+				},
+			},
+			expectedCallToAPI: false,
+		},
+		{
+			name: "old check triggers API call",
+			existingConfigMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      configMapName,
+					Namespace: configMapNamespace,
+				},
+				Data: map[string]string{
+					instanceIDKey: `{"instance_id":"test-id","last_update_check":"` + time.Now().Add(-5*time.Hour).Format(time.RFC3339) + `","latest_version":"v1.2.2"}`,
+				},
+			},
+			mockVersion:       "v1.2.3",
+			expectedCallToAPI: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create fake client
+			objects := []client.Object{}
+			if tt.existingConfigMap != nil {
+				objects = append(objects, tt.existingConfigMap)
+			}
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(objects...).
+				Build()
+
+			// Create telemetry service with mock version client
+			service := &Service{
+				client: fakeClient,
+				versionClient: &mockVersionClient{
+					version: tt.mockVersion,
+					err:     tt.mockError,
+				},
+				namespace: configMapNamespace,
+			}
+
+			// Run the check
+			err := service.CheckForUpdates(context.Background())
+
+			if tt.expectedError {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+
+			// Verify ConfigMap was created/updated if API call was expected
+			if tt.expectedCallToAPI {
+				cm := &corev1.ConfigMap{}
+				err = fakeClient.Get(context.Background(), types.NamespacedName{
+					Name:      configMapName,
+					Namespace: configMapNamespace,
+				}, cm)
+				require.NoError(t, err)
+				assert.Contains(t, cm.Data, instanceIDKey)
+			}
+		})
+	}
+}
+
+func TestService_GetTelemetryData(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	tests := []struct {
+		name               string
+		existingConfigMap  *corev1.ConfigMap
+		expectedInstanceID string
+		expectNewID        bool
+	}{
+		{
+			name:              "no configmap creates new data",
+			existingConfigMap: nil,
+			expectNewID:       true,
+		},
+		{
+			name: "existing valid data",
+			existingConfigMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      configMapName,
+					Namespace: configMapNamespace,
+				},
+				Data: map[string]string{
+					instanceIDKey: `{"instance_id":"existing-id","last_update_check":"2023-01-01T00:00:00Z","latest_version":"v1.0.0"}`,
+				},
+			},
+			expectedInstanceID: "existing-id",
+		},
+		{
+			name: "corrupted data creates new data",
+			existingConfigMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      configMapName,
+					Namespace: configMapNamespace,
+				},
+				Data: map[string]string{
+					instanceIDKey: "invalid json",
+				},
+			},
+			expectNewID: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create fake client
+			objects := []client.Object{}
+			if tt.existingConfigMap != nil {
+				objects = append(objects, tt.existingConfigMap)
+			}
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(objects...).
+				Build()
+
+			service := &Service{
+				client:    fakeClient,
+				namespace: configMapNamespace,
+			}
+
+			data, err := service.getTelemetryData(context.Background())
+			require.NoError(t, err)
+
+			if tt.expectNewID {
+				assert.NotEmpty(t, data.InstanceID)
+				// Verify it's a valid UUID
+				_, err := uuid.Parse(data.InstanceID)
+				assert.NoError(t, err)
+			} else {
+				assert.Equal(t, tt.expectedInstanceID, data.InstanceID)
+			}
+		})
+	}
+}

--- a/pkg/updates/client.go
+++ b/pkg/updates/client.go
@@ -15,13 +15,20 @@ type VersionClient interface {
 
 // NewVersionClient creates a new instance of VersionClient.
 func NewVersionClient() VersionClient {
+	return NewVersionClientWithSuffix("")
+}
+
+// NewVersionClientWithSuffix creates a new instance of VersionClient with an optional user agent suffix.
+func NewVersionClientWithSuffix(suffix string) VersionClient {
 	return &defaultVersionClient{
 		versionEndpoint: defaultVersionAPI,
+		userAgentSuffix: suffix,
 	}
 }
 
 type defaultVersionClient struct {
 	versionEndpoint string
+	userAgentSuffix string
 }
 
 const (
@@ -41,6 +48,9 @@ func (d *defaultVersionClient) GetLatestVersion(instanceID string, currentVersio
 
 	// Set headers
 	userAgent := fmt.Sprintf("toolhive/%s", currentVersion)
+	if d.userAgentSuffix != "" {
+		userAgent += " " + d.userAgentSuffix
+	}
 	// Add `dev` to the user agent for Stacklok devs.
 	if os.Getenv("TOOLHIVE_DEV") != "" {
 		userAgent += " dev"

--- a/pkg/updates/client_test.go
+++ b/pkg/updates/client_test.go
@@ -1,0 +1,40 @@
+package updates
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewVersionClientWithSuffix(t *testing.T) {
+	tests := []struct {
+		name     string
+		suffix   string
+		expected string
+	}{
+		{
+			name:     "no suffix",
+			suffix:   "",
+			expected: "",
+		},
+		{
+			name:     "operator suffix",
+			suffix:   "operator",
+			expected: "operator",
+		},
+		{
+			name:     "custom suffix",
+			suffix:   "custom",
+			expected: "custom",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := NewVersionClientWithSuffix(tt.suffix)
+			defaultClient, ok := client.(*defaultVersionClient)
+			assert.True(t, ok, "Expected defaultVersionClient type")
+			assert.Equal(t, tt.expected, defaultClient.userAgentSuffix)
+		})
+	}
+}


### PR DESCRIPTION
The following PR adds support for update checks for the ToolHive operator. The telemetry runs every 4 hours and respects leadership changes, automatically stopping when leadership is lost.

**Details:**
- Add telemetry support for the ToolHive operator to periodically check for updates
- Implement leader election for telemetry operations to ensure only one instance performs checks
- Uses ConfigMaps to store instance IDs and last check timestamps
- Updated permissions to allow ConfigMap management for telemetry data
- Updated the version client to support adding a suffix to the user agent
