### PR TITLE
Fix protocol handler compatibility with mixed-case packages

### DIFF
--- a/pkg/runner/protocol.go
+++ b/pkg/runner/protocol.go
@@ -230,10 +230,10 @@ func writeCACertificate(buildContextDir, caCertContent string, isLocalPath bool)
 // generateImageName generates a unique Docker image name based on the package and transport type.
 func generateImageName(transportType templates.TransportType, packageName string) string {
 	tag := time.Now().Format("20060102150405")
-	return fmt.Sprintf("toolhivelocal/%s-%s:%s",
+	return strings.ToLower(fmt.Sprintf("toolhivelocal/%s-%s:%s",
 		string(transportType),
 		packageNameToImageName(packageName),
-		tag)
+		tag))
 }
 
 // buildImageFromTemplate builds a Docker image from the template data.


### PR DESCRIPTION
Converts the generated image name to lowercase for Docker compatibility.

Fixes issue with mixed-case protocol URIs, for example a Go module in a repo with mixed-case org name.

Previously:

```bash
$ ./bin/thv run --name osv --transport sse go://github.com/StacklokLabs/osv-mcp/cmd/server@latest

5:14PM INF Processed cmdArgs: [[]]
5:14PM INF Building Docker image for [go github.com/StacklokLabs/osv-mcp/cmd/server] package: %!s(MISSING)
5:14PM INF Building image [toolhivelocal/go-github-com-StacklokLabs-osv-mcp-cmd-server:20250529171420 /var/folders/qc/rrhc78216yg6x990srv7szfh0000gn/T/toolhive-docker-build-1602286757] from context directory %!s(MISSING)
Error: failed to process protocol scheme: failed to build Docker image: Error response from daemon: invalid reference format: repository name (toolhivelocal/go-github-com-StacklokLabs-osv-mcp-cmd-server) must be lowercase: failed to build image: Error response from daemon: invalid reference format: repository name (toolhivelocal/go-github-com-StacklokLabs-osv-mcp-cmd-server) must be lowercase
```

Now:
```bash
$ ./bin/thv run --name osv --transport sse go://github.com/StacklokLabs/osv-mcp/cmd/server@latest

5:14PM INF Processed cmdArgs: [[]]
5:14PM INF Building Docker image for [go github.com/stackloklabs/osv-mcp/cmd/server] package: %!s(MISSING)
5:14PM INF Building image [toolhivelocal/go-github-com-stackloklabs-osv-mcp-cmd-server:20250529171428 /var/folders/qc/rrhc78216yg6x990srv7szfh0000gn/T/toolhive-docker-build-3987470298] from context directory %!s(MISSING)
Step 1/7 : FROM golang:1.24-alpine
 ---> ef18ee711746

...
```