### PR TITLE
feat: add 'thv logs prune' subcommand to clean up orphaned log files

### DIFF
--- a/cmd/thv/app/logs.go
+++ b/cmd/thv/app/logs.go
@@ -1,14 +1,19 @@
 package app
 
 import (
+	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 
+	"github.com/adrg/xdg"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
 	"github.com/stacklok/toolhive/pkg/container"
 	"github.com/stacklok/toolhive/pkg/labels"
+	"github.com/stacklok/toolhive/pkg/lifecycle"
 	"github.com/stacklok/toolhive/pkg/logger"
 )
 
@@ -18,20 +23,37 @@ var (
 
 func logsCommand() *cobra.Command {
 	logsCommand := &cobra.Command{
-		Use:   "logs [container-name]",
-		Short: "Output the logs of an MCP server",
-		Long:  `Output the logs of an MCP server managed by ToolHive.`,
+		Use:   "logs [container-name|prune]",
+		Short: "Output the logs of an MCP server or manage log files",
+		Long:  `Output the logs of an MCP server managed by ToolHive, or manage log files.`,
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// Check if the argument is "prune"
+			if args[0] == "prune" {
+				return logsPruneCmdFunc(cmd)
+			}
 			return logsCmdFunc(cmd, args)
 		},
 	}
 
-	logsCommand.Flags().BoolVarP(&followFlag, "follow", "f", false, "Follow log output")
+	logsCommand.Flags().BoolVarP(&followFlag, "follow", "f", false, "Follow log output (only for container logs)")
 	err := viper.BindPFlag("follow", logsCommand.Flags().Lookup("follow"))
 	if err != nil {
 		logger.Errorf("failed to bind flag: %v", err)
 	}
+
+	// Add prune subcommand for better discoverability
+	pruneCmd := &cobra.Command{
+		Use:   "prune",
+		Short: "Delete log files from servers not currently managed by ToolHive",
+		Long: `Delete log files from servers that are not currently managed by ToolHive (running or stopped).
+This helps clean up old log files that accumulate over time from removed servers.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return logsPruneCmdFunc(cmd)
+		},
+	}
+	logsCommand.AddCommand(pruneCmd)
 
 	return logsCommand
 }
@@ -86,4 +108,124 @@ func logsCmdFunc(cmd *cobra.Command, args []string) error {
 	}
 	fmt.Print(logs)
 	return nil
+}
+
+func logsPruneCmdFunc(cmd *cobra.Command) error {
+	ctx := cmd.Context()
+
+	logsDir, err := getLogsDirectory()
+	if err != nil {
+		return err
+	}
+
+	managedNames, err := getManagedContainerNames(ctx)
+	if err != nil {
+		return err
+	}
+
+	logFiles, err := getLogFiles(logsDir)
+	if err != nil {
+		return err
+	}
+
+	if len(logFiles) == 0 {
+		logger.Info("No log files found")
+		return nil
+	}
+
+	prunedFiles, errors := pruneOrphanedLogFiles(logFiles, managedNames)
+	reportPruneResults(prunedFiles, errors)
+
+	return nil
+}
+
+func getLogsDirectory() (string, error) {
+	logsDir, err := xdg.DataFile("toolhive/logs")
+	if err != nil {
+		return "", fmt.Errorf("failed to get logs directory path: %v", err)
+	}
+
+	if _, err := os.Stat(logsDir); os.IsNotExist(err) {
+		logger.Info("No logs directory found, nothing to prune")
+		return "", nil
+	}
+
+	return logsDir, nil
+}
+
+func getManagedContainerNames(ctx context.Context) (map[string]bool, error) {
+	manager, err := lifecycle.NewManager(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create container manager: %v", err)
+	}
+
+	managedContainers, err := manager.ListContainers(ctx, true)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list containers: %v", err)
+	}
+
+	managedNames := make(map[string]bool)
+	for _, c := range managedContainers {
+		name := labels.GetContainerName(c.Labels)
+		if name == "" {
+			name = c.Name // Fallback to container name
+		}
+		if name != "" {
+			managedNames[name] = true
+		}
+	}
+
+	return managedNames, nil
+}
+
+func getLogFiles(logsDir string) ([]string, error) {
+	if logsDir == "" {
+		return nil, nil
+	}
+
+	logFiles, err := filepath.Glob(filepath.Join(logsDir, "*.log"))
+	if err != nil {
+		return nil, fmt.Errorf("failed to list log files: %v", err)
+	}
+
+	return logFiles, nil
+}
+
+func pruneOrphanedLogFiles(logFiles []string, managedNames map[string]bool) ([]string, []string) {
+	var prunedFiles []string
+	var errors []string
+
+	for _, logFile := range logFiles {
+		baseName := strings.TrimSuffix(filepath.Base(logFile), ".log")
+
+		if !managedNames[baseName] {
+			if err := os.Remove(logFile); err != nil {
+				errors = append(errors, fmt.Sprintf("failed to remove %s: %v", logFile, err))
+				logger.Warnf("Failed to remove log file %s: %v", logFile, err)
+			} else {
+				prunedFiles = append(prunedFiles, logFile)
+				logger.Infof("Removed log file: %s", logFile)
+			}
+		}
+	}
+
+	return prunedFiles, errors
+}
+
+func reportPruneResults(prunedFiles, errors []string) {
+	if len(prunedFiles) == 0 {
+		logger.Info("No orphaned log files found to prune")
+	} else {
+		logger.Infof("Successfully pruned %d log file(s)", len(prunedFiles))
+		for _, file := range prunedFiles {
+			fmt.Printf("Removed: %s\n", file)
+		}
+	}
+
+	if len(errors) > 0 {
+		logger.Warnf("Encountered %d error(s) during pruning:", len(errors))
+		for _, errMsg := range errors {
+			fmt.Fprintf(os.Stderr, "Error: %s\n", errMsg)
+		}
+	}
 }

--- a/docs/cli/thv.md
+++ b/docs/cli/thv.md
@@ -27,7 +27,7 @@ thv [flags]
 * [thv config](thv_config.md)	 - Manage application configuration
 * [thv inspector](thv_inspector.md)	 - Launches the MCP Inspector UI and connects it to the specified MCP server
 * [thv list](thv_list.md)	 - List running MCP servers
-* [thv logs](thv_logs.md)	 - Output the logs of an MCP server
+* [thv logs](thv_logs.md)	 - Output the logs of an MCP server or manage log files
 * [thv proxy](thv_proxy.md)	 - Spawn a transparent proxy for an MCP server
 * [thv registry](thv_registry.md)	 - Manage MCP server registry
 * [thv restart](thv_restart.md)	 - Restart a tooling server

--- a/docs/cli/thv_logs.md
+++ b/docs/cli/thv_logs.md
@@ -1,19 +1,19 @@
 ## thv logs
 
-Output the logs of an MCP server
+Output the logs of an MCP server or manage log files
 
 ### Synopsis
 
-Output the logs of an MCP server managed by ToolHive.
+Output the logs of an MCP server managed by ToolHive, or manage log files.
 
 ```
-thv logs [container-name] [flags]
+thv logs [container-name|prune] [flags]
 ```
 
 ### Options
 
 ```
-  -f, --follow   Follow log output
+  -f, --follow   Follow log output (only for container logs)
   -h, --help     help for logs
 ```
 
@@ -26,4 +26,5 @@ thv logs [container-name] [flags]
 ### SEE ALSO
 
 * [thv](thv.md)	 - ToolHive (thv) is a lightweight, secure, and fast manager for MCP servers
+* [thv logs prune](thv_logs_prune.md)	 - Delete log files from servers not currently managed by ToolHive
 

--- a/docs/cli/thv_logs_prune.md
+++ b/docs/cli/thv_logs_prune.md
@@ -1,0 +1,29 @@
+## thv logs prune
+
+Delete log files from servers not currently managed by ToolHive
+
+### Synopsis
+
+Delete log files from servers that are not currently managed by ToolHive (running or stopped).
+This helps clean up old log files that accumulate over time from removed servers.
+
+```
+thv logs prune [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for prune
+```
+
+### Options inherited from parent commands
+
+```
+      --debug   Enable debug mode
+```
+
+### SEE ALSO
+
+* [thv logs](thv_logs.md)	 - Output the logs of an MCP server or manage log files
+


### PR DESCRIPTION
## Summary

Implements the `thv logs prune` subcommand as requested in issue #447. This feature allows users to clean up old log files from servers that are no longer managed by ToolHive.

## Changes

- ✅ Added `prune` subcommand to `thv logs`
- ✅ Maintains full backward compatibility with existing `thv logs [container-name]` functionality
- ✅ Provides dual access methods: both as subcommand and direct argument
- ✅ Smart cleanup logic that only removes log files from unmanaged servers
- ✅ Comprehensive error handling and user feedback
- ✅ Follows project coding standards (0 linting issues)
- ✅ Reduced cyclomatic complexity using helper functions

## Usage

```bash
# Clean up orphaned log files
thv logs prune

# View help for the prune command
thv logs prune --help

# Existing functionality still works unchanged
thv logs fetch
thv logs osv --follow
```

## Testing

- ✅ Successfully builds without errors
- ✅ Passes all linting checks
- ✅ Existing logs functionality verified working
- ✅ Prune functionality tested with real orphaned files
- ✅ Edge cases handled (no logs directory, no orphaned files)

## Implementation Details

The implementation:
1. Uses XDG Base Directory specification for log file location
2. Compares log file names against currently managed container names
3. Only removes files that don't correspond to any managed container
4. Provides detailed feedback on what was removed
5. Handles errors gracefully without stopping the cleanup process

Closes #447