### PR TITLE
[Kubernetes Operator] Add support for target-port

### DIFF
--- a/cmd/thv-operator/README.md
+++ b/cmd/thv-operator/README.md
@@ -127,7 +127,7 @@ kubectl describe mcpserver <name>
 | `image`             | Container image for the MCP server              | Yes      | -       |
 | `transport`         | Transport method (stdio or sse)                 | No       | stdio   |
 | `port`              | Port to expose the MCP server on                | No       | 8080    |
-| `targetPort`        | Port to that MCP server listens on              | No       | -       |
+| `targetPort`        | Port that MCP server listens to                 | No       | -       |
 | `args`              | Additional arguments to pass to the MCP server  | No       | -       |
 | `env`               | Environment variables to set in the container   | No       | -       |
 | `volumes`           | Volumes to mount in the container               | No       | -       |

--- a/cmd/thv-operator/README.md
+++ b/cmd/thv-operator/README.md
@@ -122,17 +122,18 @@ kubectl describe mcpserver <name>
 
 ### MCPServer Spec
 
-| Field | Description | Required | Default |
-|-------|-------------|----------|---------|
-| `image` | Container image for the MCP server | Yes | - |
-| `transport` | Transport method (stdio or sse) | No | stdio |
-| `port` | Port to expose the MCP server on | No | 8080 |
-| `args` | Additional arguments to pass to the MCP server | No | - |
-| `env` | Environment variables to set in the container | No | - |
-| `volumes` | Volumes to mount in the container | No | - |
-| `resources` | Resource requirements for the container | No | - |
-| `secrets` | References to secrets to mount in the container | No | - |
-| `permissionProfile` | Permission profile configuration | No | - |
+| Field               | Description                                     | Required | Default |
+|---------------------|-------------------------------------------------|----------|---------|
+| `image`             | Container image for the MCP server              | Yes      | -       |
+| `transport`         | Transport method (stdio or sse)                 | No       | stdio   |
+| `port`              | Port to expose the MCP server on                | No       | 8080    |
+| `targetPort`        | Port to that MCP server listens on              | No       | -       |
+| `args`              | Additional arguments to pass to the MCP server  | No       | -       |
+| `env`               | Environment variables to set in the container   | No       | -       |
+| `volumes`           | Volumes to mount in the container               | No       | -       |
+| `resources`         | Resource requirements for the container         | No       | -       |
+| `secrets`           | References to secrets to mount in the container | No       | -       |
+| `permissionProfile` | Permission profile configuration                | No       | -       |
 
 ### Permission Profiles
 

--- a/cmd/thv-operator/api/v1alpha1/mcpserver_types.go
+++ b/cmd/thv-operator/api/v1alpha1/mcpserver_types.go
@@ -22,6 +22,12 @@ type MCPServerSpec struct {
 	// +kubebuilder:default=8080
 	Port int32 `json:"port,omitempty"`
 
+	// TargetPort is the port that MCP server listens on
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Maximum=65535
+	// +optional
+	TargetPort int32 `json:"targetPort,omitempty"`
+
 	// Args are additional arguments to pass to the MCP server
 	// +optional
 	Args []string `json:"args,omitempty"`

--- a/cmd/thv-operator/api/v1alpha1/mcpserver_types.go
+++ b/cmd/thv-operator/api/v1alpha1/mcpserver_types.go
@@ -22,7 +22,7 @@ type MCPServerSpec struct {
 	// +kubebuilder:default=8080
 	Port int32 `json:"port,omitempty"`
 
-	// TargetPort is the port that MCP server listens on
+	// TargetPort is the port that MCP server listens to
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:validation:Maximum=65535
 	// +optional

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpservers.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpservers.yaml
@@ -8194,7 +8194,7 @@ spec:
                   type: object
                 type: array
               targetPort:
-                description: TargetPort is the port that MCP server listens on
+                description: TargetPort is the port that MCP server listens to
                 format: int32
                 maximum: 65535
                 minimum: 1

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpservers.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpservers.yaml
@@ -8193,6 +8193,12 @@ spec:
                   - name
                   type: object
                 type: array
+              targetPort:
+                description: TargetPort is the port that MCP server listens on
+                format: int32
+                maximum: 65535
+                minimum: 1
+                type: integer
               transport:
                 default: stdio
                 description: Transport is the transport method for the MCP server


### PR DESCRIPTION
Introduce a `targetPort` field to the `MCPServer` resource. The operator now uses this field to set the `--target-port` command-line argument for the runner. 

Fixes #522 