### PR TITLE
Standardize kind cluster naming across documentation and operator configs

### DIFF
--- a/cmd/thv-operator/Taskfile.yml
+++ b/cmd/thv-operator/Taskfile.yml
@@ -4,13 +4,13 @@ tasks:
   kind-setup:
     desc: Setup a local Kind cluster
     cmds:
-      - kind create cluster --name kind
-      - kind get kubeconfig > kconfig.yaml
+      - kind create cluster --name toolhive
+      - kind get kubeconfig --name toolhive > kconfig.yaml
 
   kind-destroy:
     desc: Destroy a local Kind cluster
     cmds:
-      - kind delete cluster --name kind
+      - kind delete cluster --name toolhive
       - rm kconfig.yaml
 
   kind-ingress-setup:
@@ -97,9 +97,9 @@ tasks:
         sh: KO_DOCKER_REPO=kind.local ko build --local -B ./cmd/thv | tail -n 1
     cmds:
       - echo "Loading toolhive operator image {{.OPERATOR_IMAGE}} into kind..."
-      - kind load docker-image {{.OPERATOR_IMAGE}}
+      - kind load docker-image --name toolhive {{.OPERATOR_IMAGE}}
       - echo "Loading toolhive image {{.TOOLHIVE_IMAGE}} into kind..."
-      - kind load docker-image {{.TOOLHIVE_IMAGE}}
+      - kind load docker-image --name toolhive {{.TOOLHIVE_IMAGE}}
       - |
         helm upgrade --install toolhive-operator deploy/charts/operator \
         --set operator.image={{.OPERATOR_IMAGE}} \

--- a/docs/kind/deploying-mcp-server-with-operator.md
+++ b/docs/kind/deploying-mcp-server-with-operator.md
@@ -11,10 +11,10 @@ The [ToolHive Kubernetes Operator](../../cmd/thv-operator/README.md) manages MCP
 With the ToolHive Operator running, you can deploy an MCP server into the cluster by running the following:
 
 ```bash
-$ kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/main/examples/operator/mcp-servers/mcpserver_fetch.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/main/examples/operator/mcp-servers/mcpserver_fetch.yaml
 ```
 
 You should now be able to see the MCP server pods being created/running:
 ```bash
-$ kubectl get pods -n toolhive-system
+kubectl get pods -n toolhive-system
 ```

--- a/docs/kind/deploying-toolhive-operator.md
+++ b/docs/kind/deploying-toolhive-operator.md
@@ -62,10 +62,10 @@ Run:
 
 ```bash
 # If you want to install the latest built operator image from Github (recommended)
-$ task operator-deploy-latest
+task operator-deploy-latest
 
 # If you want to built the operator image locally and deploy it (only recommended if you're doing development around the Operator)
-$ task operator-deploy-local
+task operator-deploy-local
 ```
 
 ### Manually

--- a/docs/kind/ingress.md
+++ b/docs/kind/ingress.md
@@ -13,7 +13,7 @@ This document walks through setting up Ingress in a local Kind cluster. There ar
 To install the Nginx Ingress Controller, run the following:
 
 ```bash
-$ kubectl apply -f https://kind.sigs.k8s.io/examples/ingress/deploy-ingress-nginx.yaml
+kubectl apply -f https://kind.sigs.k8s.io/examples/ingress/deploy-ingress-nginx.yaml
 ```
 
 There are [known issues](https://github.com/kubernetes/ingress-nginx/issues/5968#issuecomment-849772666) around inconsistencies between the secret and the webhook `caBundle` resulting in the Nginx Ingress Controller not being fully running and operational.
@@ -38,7 +38,7 @@ Now, although the Nginx Ingress Controller is running, we need to hook with an I
 To confirm there is no IP, run:
 
 ```bash
-$ kubectl get svc/ingress-nginx-controller -n ingress-nginx -o=jsonpath='{.status.loadBalancer.ingress[0].ip}'
+kubectl get svc/ingress-nginx-controller -n ingress-nginx -o=jsonpath='{.status.loadBalancer.ingress[0].ip}'
 ```
 
 Follow the next section to learn how to assign an ExternalIP to an Ingress Controller in Kind.
@@ -54,7 +54,7 @@ After following the documentation, it should now be installed and running and qu
 To confirm that it has provided an IP address, you should now see an IP returned when you run:
 
 ```bash
-$ kubectl get svc/ingress-nginx-controller -n ingress-nginx -o=jsonpath='{.status.loadBalancer.ingress[0].ip}'
+kubectl get svc/ingress-nginx-controller -n ingress-nginx -o=jsonpath='{.status.loadBalancer.ingress[0].ip}'
 ```
 
 ### Test Nginx Ingress Controller and Kind Load Balancer Setup
@@ -128,7 +128,7 @@ We have also automated the installation of the Nginx Ingress Controller using a 
 To use, run:
 
 ```bash
-$ task kind-ingress-setup
+task kind-ingress-setup
 ```
 
 It will install the Nginx Ingress Controller and fix the secret inconsistencies. It does nothing with the `cloud-provider-kind` Load Balancer, so you will still need to run that yourself. But by the end of the task run, the controller will be waiting for an assigned IP.

--- a/docs/kind/setup-kind-cluster.md
+++ b/docs/kind/setup-kind-cluster.md
@@ -29,7 +29,7 @@ You can perform Kind operations manually by following the sections below.
 To setup a Local Kind Cluster manually, run:
 
 ```bash
-$ kind create cluster --name kind
+kind create cluster --name kind
 ```
 
 #### Getting Kind Config
@@ -39,7 +39,7 @@ We recommend having a dedicated kubeconfig file to keep things isolated from you
 To do this, run:
 
 ```bash
-$ kind get kubeconfig > kconfig.yaml
+kind get kubeconfig > kconfig.yaml
 ```
 
 This will output the kind cluster config to a file called `kconfig.yaml` in the directory of which the command is ran in. This file is added to the `.gitignore` of this repository, so there is no worry about checking it in.
@@ -49,7 +49,7 @@ This will output the kind cluster config to a file called `kconfig.yaml` in the 
 To destroy a local Kind cluster, run:
 
 ```bash
-$ kind delete clusters kind
+kind delete clusters kind
 ```
 
 ### Automatic Setup: Setup & Destroy a Local Kind Cluster
@@ -61,7 +61,7 @@ To automate the creation/destruction of a local Kind cluster, we have added a Ta
 To setup a Local Kind Cluster using Task, run:
 
 ```bash
-$ task kind-setup
+task kind-setup
 ```
 
 This will create a single node Kind cluster and it will output the kubeconfig into the `kconfig.yaml` file. This file is added to the `.gitignore` of this repository, so there is no worry about checking it in.
@@ -71,7 +71,7 @@ This will create a single node Kind cluster and it will output the kubeconfig in
 To destroy a local Kind cluster using Task, run:
 
 ```bash
-$ task kind-destroy
+task kind-destroy
 ```
 
 This will destroy the Kind cluster, as well as removing the `kconfig.yaml` kubeconfig file.


### PR DESCRIPTION
- The changes rename the kind cluster consistently across docs and Taskfile configuration for better clarity.
- Also removes the `$` symbols from single line commands for easier copying and pasting