### PR TITLE
Fix the GitHub K8s example

### DIFF
--- a/cmd/thv-operator/README.md
+++ b/cmd/thv-operator/README.md
@@ -76,8 +76,9 @@ apiVersion: toolhive.stacklok.dev/v1alpha1
 kind: MCPServer
 metadata:
   name: github
+  namespace: toolhive-system
 spec:
-  image: docker.io/mcp/github
+  image: ghcr.io/github/github-mcp-server
   transport: stdio
   port: 8080
   permissionProfile:
@@ -92,7 +93,7 @@ spec:
 First, create the secret:
 
 ```bash
-kubectl create secret generic github-token --from-literal=token=your-token
+kubectl create secret generic github-token -n toolhive-system --from-literal=token=<YOUR_GITHUB_TOKEN>
 ```
 
 Then apply the MCPServer resource.

--- a/examples/operator/mcp-servers/mcpserver_github.yaml
+++ b/examples/operator/mcp-servers/mcpserver_github.yaml
@@ -4,7 +4,7 @@ metadata:
   name: github
   namespace: toolhive-system
 spec:
-  image: docker.io/mcp/github
+  image: ghcr.io/github/github-mcp-server
   transport: stdio
   port: 8080
   permissionProfile:
@@ -12,7 +12,8 @@ spec:
     name: network
   secrets:
     - name: github-token
-      key: GITHUB_PERSONAL_ACCESS_TOKEN
+      token: token
+      targetEnvName: GITHUB_PERSONAL_ACCESS_TOKEN
   env:
     - name: GITHUB_API_URL
       value: https://api.github.com


### PR DESCRIPTION
Updates the operator README and the mcp_server_github.yaml example.

- Use the official server image
- Fix the secrets section (partial resolution for #521)
- Add namespace to README example