### PR TITLE
adds kubernetes issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/kubernetes-issue.md
+++ b/.github/ISSUE_TEMPLATE/kubernetes-issue.md
@@ -1,0 +1,7 @@
+---
+name: Kubernetes Issue / Feature Request
+about: Issues or feature requests relating to ToolHive a Kubernetes Context (ToolHive Operator, Helm Charts, general Kubernetes etc)
+title: ''
+labels: kubernetes
+assignees: ChrisJBurns
+---


### PR DESCRIPTION
Adds a Kubernetes issue template so that newly created issues  can be assigned to @ChrisJBurns by default with the correct labels allowing for easier filtering.