### PR TITLE
fix: resolve path error with test-e2e task on macOS

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -40,7 +40,7 @@ tasks:
     desc: Run end-to-end tests
     deps: [build]
     env:
-      THV_BINARY: ./bin/thv
+      THV_BINARY: "{{.PWD}}/bin/thv"
     cmds:
       - go install github.com/onsi/ginkgo/v2/ginkgo
       - ./test/e2e/run_tests.sh


### PR DESCRIPTION
Fixes #518

A difference in path handling on macOS vs. Linux was causing the test-e2e task to fail:

```text
  [FAILED] thv binary should be available
  Unexpected error:
      <*fmt.wrapError | 0x1400060e0c0>: 
      thv binary not available at ./bin/thv: fork/exec ./bin/thv: no such file or directory
      {
          msg: "thv binary not available at ./bin/thv: fork/exec ./bin/thv: no such file or directory",
          err: <*fs.PathError | 0x14000216e70>{
              Op: "fork/exec",
              Path: "./bin/thv",
              Err: <syscall.Errno>0x2,
          },
      }
  occurred
  In [BeforeEach] at: /Users/dan/code/stacklok/toolhive/test/e2e/fetch_mcp_server_test.go:28 @ 05/31/25 14:08:17.223
```

Making THV_BINARY absolute fixes it.