### PR TITLE
fix(test): resolve flaky TestSave in pkg/config

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -113,15 +113,9 @@ func TestSave(t *testing.T) {
 	logger.Initialize()
 
 	t.Run("TestSave", func(t *testing.T) {
-		// Create a temporary directory for the test
-		tempDir := t.TempDir()
-
-		// Save original XDG_CONFIG_HOME and restore after test
-		originalXDGConfigHome := os.Getenv("XDG_CONFIG_HOME")
-		t.Setenv("XDG_CONFIG_HOME", tempDir)
-		defer func() {
-			t.Setenv("XDG_CONFIG_HOME", originalXDGConfigHome)
-		}()
+		// Use the same pattern as other tests with proper mocking
+		tempDir, cleanup := SetupTestConfig(t, nil)
+		defer cleanup()
 
 		// Create a config instance
 		config := &Config{


### PR DESCRIPTION
## Problem

The \`TestSave\` test in \`pkg/config\` was failing intermittently in CI with the error:
\`yaml: line 6: did not find expected key\`

This was identified as the root cause of test failures in PR #600, where the flaky test was incorrectly attributed to logger changes.

## Root Cause

The test was using an unreliable approach:
- Setting \`XDG_CONFIG_HOME\` environment variable 
- Relying on XDG directory creation timing
- Not using the established test infrastructure

This created race conditions where the directory structure wasn't properly set up before the YAML file was written, leading to malformed files.

## Solution

- Replace environment variable approach with proper test mocking
- Use \`SetupTestConfig\` helper function (same pattern as other tests in the file)
- Eliminates race conditions by ensuring reliable directory setup
- Maintains consistency with existing test patterns

## Testing

- Verified fix with 10 consecutive test runs - all passed
- Previously, the test would fail intermittently
- Unit tests continue to pass consistently

## Impact

- Eliminates flaky test that was causing false CI failures
- Improves test reliability and developer experience
- No functional changes to production code