### PR TITLE
Delete mcpServer configuration from supported clients when server is stopped

### DIFF
--- a/pkg/lifecycle/manager.go
+++ b/pkg/lifecycle/manager.go
@@ -166,7 +166,20 @@ func (d *defaultManager) StopContainer(ctx context.Context, name string) error {
 	proxy.StopProcess(containerBaseName)
 
 	// Stop the container
-	return d.stopContainer(ctx, containerID, name)
+	err = d.stopContainer(ctx, containerID, name)
+	if err != nil {
+		return err
+	}
+
+	if shouldRemoveClientConfig() {
+		if err := removeClientConfigurations(name); err != nil {
+			logger.Warnf("Warning: Failed to remove client configurations: %v", err)
+		} else {
+			logger.Infof("Client configurations for %s removed", name)
+		}
+	}
+
+	return nil
 }
 
 func (*defaultManager) RunContainer(ctx context.Context, runConfig *runner.RunConfig) error {


### PR DESCRIPTION
fixes #341 

When the server is stopped, deletes the configure from supported clients and the configuration is added when it is restarted.