### PR TITLE
Add OIDC authentication support to ToolHive management API server

### DIFF
--- a/docs/cli/thv_serve.md
+++ b/docs/cli/thv_serve.md
@@ -13,11 +13,15 @@ thv serve [flags]
 ### Options
 
 ```
-  -h, --help            help for serve
-      --host string     Host address to bind the server to (default "127.0.0.1")
-      --openapi         Enable OpenAPI documentation endpoints (/api/openapi.json and /api/doc)
-      --port int        Port to bind the server to (default 8080)
-      --socket string   UNIX socket path to bind the server to (overrides host and port if provided)
+  -h, --help                    help for serve
+      --host string             Host address to bind the server to (default "127.0.0.1")
+      --oidc-audience string    Expected audience for the token
+      --oidc-client-id string   OIDC client ID
+      --oidc-issuer string      OIDC issuer URL (e.g., https://accounts.google.com)
+      --oidc-jwks-url string    URL to fetch the JWKS from
+      --openapi                 Enable OpenAPI documentation endpoints (/api/openapi.json and /api/doc)
+      --port int                Port to bind the server to (default 8080)
+      --socket string           UNIX socket path to bind the server to (overrides host and port if provided)
 ```
 
 ### Options inherited from parent commands

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -26,6 +26,7 @@ import (
 	"github.com/go-chi/chi/v5/middleware"
 
 	v1 "github.com/stacklok/toolhive/pkg/api/v1"
+	"github.com/stacklok/toolhive/pkg/auth"
 	"github.com/stacklok/toolhive/pkg/container"
 	"github.com/stacklok/toolhive/pkg/lifecycle"
 	"github.com/stacklok/toolhive/pkg/logger"
@@ -78,13 +79,28 @@ func cleanupUnixSocket(address string) {
 // Serve starts the server on the given address and serves the API.
 // It is assumed that the caller sets up appropriate signal handling.
 // If isUnixSocket is true, address is treated as a UNIX socket path.
-func Serve(ctx context.Context, address string, isUnixSocket bool, debugMode bool, enableDocs bool) error {
+// If oidcConfig is provided, OIDC authentication will be enabled for all API endpoints.
+func Serve(
+	ctx context.Context,
+	address string,
+	isUnixSocket bool,
+	debugMode bool,
+	enableDocs bool,
+	oidcConfig *auth.JWTValidatorConfig,
+) error {
 	r := chi.NewRouter()
 	r.Use(
 		middleware.RequestID,
 		// TODO: Figure out logging middleware. We may want to use a different logger.
 		middleware.Timeout(middlewareTimeout),
 	)
+
+	// Add authentication middleware
+	authMiddleware, err := auth.GetAuthenticationMiddleware(ctx, oidcConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create authentication middleware: %v", err)
+	}
+	r.Use(authMiddleware)
 
 	manager, err := lifecycle.NewManager(ctx)
 	if err != nil {


### PR DESCRIPTION
## Summary

This PR adds OIDC authentication support to the ToolHive management API server by reusing the existing authentication middleware from the `pkg/auth` package.

## Changes

- **Added OIDC flags to `thv serve` command**: `--oidc-issuer`, `--oidc-audience`, `--oidc-jwks-url`, `--oidc-client-id`
- **Integrated existing auth middleware**: Reuses the same middleware architecture already used by MCP servers in `thv run` and `thv proxy` commands
- **Support for both OIDC and local authentication**: When OIDC is not configured, falls back to local user authentication for development
- **All API endpoints protected**: Authentication middleware is applied to all management API endpoints

## Architecture

The implementation follows the same pattern used in other ToolHive commands:

1. **OIDC Configuration**: Uses `auth.JWTValidatorConfig` to configure JWT validation with OIDC discovery support
2. **Middleware Selection**: `auth.GetAuthenticationMiddleware()` automatically chooses between:
   - JWT validation middleware (when OIDC config is provided)
   - Local user middleware (when OIDC config is nil)
3. **Consistent Security Model**: Same security architecture as MCP servers

## Benefits

- **Enterprise-ready**: Enables robust authentication for the management API
- **Consistent**: Uses the same middleware architecture across all ToolHive components
- **Flexible**: Supports both production OIDC and development local authentication
- **Secure by default**: All endpoints are now protected by authentication

## Testing

- ✅ All existing tests pass
- ✅ Linting passes with no issues
- ✅ Build succeeds
- ✅ OIDC flags are available in `thv serve --help`

## Usage Examples

```bash
# Local development (uses local user authentication)
thv serve --port 8080

# Production with OIDC
thv serve --port 8080 \
  --oidc-issuer https://accounts.google.com \
  --oidc-audience my-toolhive-api \
  --oidc-client-id my-client-id
```

This addresses the need for enterprise-ready authorization in the management API server while maintaining consistency with the existing security architecture.