### PR TITLE
Add --all/-a flag to restart command

### DIFF
--- a/cmd/thv/app/restart.go
+++ b/cmd/thv/app/restart.go
@@ -1,29 +1,41 @@
 package app
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/spf13/cobra"
 
+	"github.com/stacklok/toolhive/pkg/labels"
 	"github.com/stacklok/toolhive/pkg/lifecycle"
+)
+
+var (
+	restartAll bool
 )
 
 var restartCmd = &cobra.Command{
 	Use:   "restart [container-name]",
 	Short: "Restart a tooling server",
 	Long:  `Restart a running tooling server managed by ToolHive. If the server is not running, it will be started.`,
-	Args:  cobra.ExactArgs(1),
+	Args:  cobra.RangeArgs(0, 1),
 	RunE:  restartCmdFunc,
 }
 
 func init() {
-	// No specific flags needed for restart command
+	restartCmd.Flags().BoolVarP(&restartAll, "all", "a", false, "Restart all MCP servers")
 }
 
 func restartCmdFunc(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
-	// Get container name
-	containerName := args[0]
+
+	// Validate arguments
+	if restartAll && len(args) > 0 {
+		return fmt.Errorf("cannot specify both --all flag and container name")
+	}
+	if !restartAll && len(args) == 0 {
+		return fmt.Errorf("must specify either --all flag or container name")
+	}
 
 	// Create lifecycle manager.
 	manager, err := lifecycle.NewManager(ctx)
@@ -31,12 +43,68 @@ func restartCmdFunc(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to create lifecycle manager: %v", err)
 	}
 
-	// Restart the container in a detached process.
+	if restartAll {
+		return restartAllContainers(ctx, manager)
+	}
+
+	// Restart single container
+	containerName := args[0]
 	err = manager.RestartContainer(ctx, containerName)
 	if err != nil {
 		return err
 	}
 
 	fmt.Printf("Container %s restarted successfully\n", containerName)
+	return nil
+}
+
+func restartAllContainers(ctx context.Context, manager lifecycle.Manager) error {
+	// Get all containers (including stopped ones since restart can start stopped containers)
+	containers, err := manager.ListContainers(ctx, true)
+	if err != nil {
+		return fmt.Errorf("failed to list containers: %v", err)
+	}
+
+	if len(containers) == 0 {
+		fmt.Println("No MCP servers found to restart")
+		return nil
+	}
+
+	var restartedCount int
+	var failedCount int
+	var errors []string
+
+	fmt.Printf("Restarting %d MCP server(s)...\n", len(containers))
+
+	for _, container := range containers {
+		// Get container name from labels
+		containerName := labels.GetContainerName(container.Labels)
+		if containerName == "" {
+			containerName = container.Name // Fallback to container name
+		}
+
+		fmt.Printf("Restarting %s...", containerName)
+		err := manager.RestartContainer(ctx, containerName)
+		if err != nil {
+			fmt.Printf(" failed: %v\n", err)
+			failedCount++
+			errors = append(errors, fmt.Sprintf("%s: %v", containerName, err))
+		} else {
+			fmt.Printf(" success\n")
+			restartedCount++
+		}
+	}
+
+	// Print summary
+	fmt.Printf("\nRestart summary: %d succeeded, %d failed\n", restartedCount, failedCount)
+
+	if failedCount > 0 {
+		fmt.Println("\nFailed restarts:")
+		for _, errMsg := range errors {
+			fmt.Printf("  - %s\n", errMsg)
+		}
+		return fmt.Errorf("%d container(s) failed to restart", failedCount)
+	}
+
 	return nil
 }

--- a/docs/cli/thv_restart.md
+++ b/docs/cli/thv_restart.md
@@ -13,6 +13,7 @@ thv restart [container-name] [flags]
 ### Options
 
 ```
+  -a, --all    Restart all MCP servers
   -h, --help   help for restart
 ```
 


### PR DESCRIPTION
## Summary

This PR adds the `--all` or `-a` flag to the `thv restart` command, allowing users to restart all MCP servers at once instead of having to restart them individually.

## Changes

- **Added `--all/-a` flag**: Users can now run `thv restart --all` to restart all MCP servers
- **Proper argument validation**: Cannot specify both `--all` flag and a container name
- **Comprehensive error handling**: Clear error messages and progress reporting
- **Backward compatibility**: Single container restart functionality remains unchanged
- **CLI documentation**: Automatically updated to reflect the new flag

## Usage Examples

```bash
# Restart all MCP servers
thv restart --all
thv restart -a

# Restart a specific server (existing functionality)
thv restart fetch
```

## Testing

- ✅ Tested `--all` flag with multiple servers
- ✅ Tested error handling for invalid argument combinations
- ✅ Tested backward compatibility with single container restart
- ✅ Verified CLI documentation updates
- ✅ Confirmed project builds successfully
- ✅ Passed linting checks

## Output Example

```
$ thv restart --all
Restarting 4 MCP server(s)...
Restarting sequentialthinking... success
Restarting fetch... success
Restarting brave-search... success
Restarting github... success

Restart summary: 4 succeeded, 0 failed
```

Resolves the need to restart multiple servers individually, improving user experience when managing multiple MCP servers.