### PR TITLE
fix: corrects serviceaccount for mkp example

### DIFF
--- a/examples/operator/mcp-servers/mcpserver_mkp.yaml
+++ b/examples/operator/mcp-servers/mcpserver_mkp.yaml
@@ -10,11 +10,6 @@ spec:
   permissionProfile:
     type: builtin
     name: network
-  podTemplateSpec:
-    spec:
-      serviceAccountName: mkp
-      containers:
-      - name: mcp
   resources:
     limits:
       cpu: "100m"

--- a/examples/operator/mcp-servers/mcpserver_mkp.yaml
+++ b/examples/operator/mcp-servers/mcpserver_mkp.yaml
@@ -10,6 +10,13 @@ spec:
   permissionProfile:
     type: builtin
     name: network
+  podTemplateSpec:
+    spec:
+      # this will not be needed once we have implemented separate 
+      # service accounts for each MCP server and its proxyrunner
+      serviceAccountName: mkp-proxy-runner
+      containers:
+      - name: mcp
   resources:
     limits:
       cpu: "100m"


### PR DESCRIPTION
We need to hardcode the serviceaccount name of the proxyrunner for now. Once we have implemented https://github.com/stacklok/toolhive/issues/654 this will not be needed anymore as the serviceaccounts will be created by the operator and the need for an override will not be necessary