### PR TITLE
Fix authorization middleware chain for filterToolsResponse

### DIFF
--- a/pkg/lifecycle/manager.go
+++ b/pkg/lifecycle/manager.go
@@ -291,6 +291,11 @@ func (*defaultManager) RunContainerDetached(runConfig *runner.RunConfig) error {
 		}
 	}
 
+	// Add authz config if it was provided
+	if runConfig.AuthzConfigPath != "" {
+		detachedArgs = append(detachedArgs, "--authz-config", runConfig.AuthzConfigPath)
+	}
+
 	// Add the image and any arguments
 	detachedArgs = append(detachedArgs, runConfig.Image)
 	if len(runConfig.CmdArgs) > 0 {

--- a/pkg/mcp/parser.go
+++ b/pkg/mcp/parser.go
@@ -117,7 +117,9 @@ func shouldParseMCPRequest(r *http.Request) bool {
 	}
 
 	// Parse requests to MCP message endpoints
-	return strings.Contains(r.URL.Path, "/messages") || strings.Contains(r.URL.Path, "/mcp")
+	return strings.Contains(r.URL.Path, "/messages") ||
+		strings.Contains(r.URL.Path, "/message") ||
+		strings.Contains(r.URL.Path, "/mcp")
 }
 
 // parseMCPRequest parses the JSON-RPC message and extracts MCP-specific information.


### PR DESCRIPTION
## Problem

The `filterToolsResponse` function was not being called in the authorization middleware chain, preventing proper filtering of tools/prompts/resources based on Cedar policies.

## Root Causes & Solutions

### 1. Missing authz config in detached processes
- **Problem**: The `--authz-config` flag wasn't being passed when processes detached
- **Solution**: Added the missing flag to detached process arguments in lifecycle manager
- **Impact**: Authorization middleware now gets properly configured in detached mode

### 2. MCP parsing middleware endpoint mismatch  
- **Problem**: Parser only recognized `/messages` but requests came to `/message` (singular)
- **Solution**: Updated endpoint recognition to include both `/messages` and `/message`
- **Impact**: MCP requests are now properly parsed and available for authorization

### 3. Empty response buffer handling for SSE
- **Problem**: SSE-based responses return 202 with empty bodies, causing JSON parsing failures
- **Solution**: Added empty buffer check and support for `http.StatusAccepted` status code
- **Impact**: SSE responses are handled gracefully without breaking the filtering pipeline

## Changes Made

- **pkg/lifecycle/manager.go**: Add `--authz-config` flag to detached process arguments
- **pkg/mcp/parser.go**: Update endpoint recognition to include `/message` endpoint
- **pkg/authz/response_filter.go**: Add empty buffer handling and `StatusAccepted` support
- **pkg/authz/middleware.go**: Minor cleanup of outdated comment

## Testing

All authorization tests pass:
- ✅ Basic user sees filtered tools list
- ✅ Admin user sees all tools  
- ✅ Authorization middleware correctly filters based on Cedar policies
- ✅ SSE responses are handled properly

## Impact

The authorization middleware chain now correctly filters tools/prompts/resources based on Cedar policies, ensuring users only see resources they're authorized to access.