### PR TITLE
fix: ensure proxy processes are terminated when using thv rm

### DIFF
--- a/pkg/workloads/manager.go
+++ b/pkg/workloads/manager.go
@@ -109,6 +109,14 @@ func (d *defaultManager) DeleteWorkload(ctx context.Context, name string) error 
 
 	// Check if the container is running
 	if isRunning {
+		// Get the base container name for proxy stopping
+		containerBaseName := labels.GetContainerBaseName(containerLabels)
+
+		// Stop the proxy process first (like StopWorkload does)
+		if containerBaseName != "" {
+			proxy.StopProcess(containerBaseName)
+		}
+
 		// Stop the container if it's running
 		if err := d.stopContainer(ctx, containerID, name); err != nil {
 			return fmt.Errorf("failed to stop container: %v", err)

--- a/test/e2e/fetch_mcp_server_test.go
+++ b/test/e2e/fetch_mcp_server_test.go
@@ -31,7 +31,8 @@ var _ = Describe("FetchMcpServer", func() {
 	AfterEach(func() {
 		if config.CleanupAfter {
 			// Clean up the server if it exists
-			_ = e2e.StopAndRemoveMCPServer(config, serverName)
+			err := e2e.StopAndRemoveMCPServer(config, serverName)
+			Expect(err).ToNot(HaveOccurred(), "Should be able to stop and remove server")
 		}
 	})
 

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -137,13 +137,21 @@ func WaitForMCPServer(config *TestConfig, serverName string, timeout time.Durati
 }
 
 // StopAndRemoveMCPServer stops and removes an MCP server
+// This function is designed for cleanup and tolerates servers that don't exist
 func StopAndRemoveMCPServer(config *TestConfig, serverName string) error {
-	// Try to stop the server first
+	// Try to stop the server first (ignore errors as server might not exist)
 	_, _, _ = NewTHVCommand(config, "stop", serverName).Run()
 
 	// Then remove it
-	_, _, err := NewTHVCommand(config, "rm", "-f", serverName).Run()
-	return err
+	_, stderr, err := NewTHVCommand(config, "rm", serverName).Run()
+	if err != nil {
+		// In cleanup scenarios, it's okay if the container doesn't exist
+		if strings.Contains(stderr, "not found") {
+			return nil
+		}
+		return err
+	}
+	return nil
 }
 
 // GetMCPServerURL gets the URL for an MCP server

--- a/test/e2e/inspector_test.go
+++ b/test/e2e/inspector_test.go
@@ -41,8 +41,10 @@ var _ = Describe("Inspector", func() {
 	AfterEach(func() {
 		if config.CleanupAfter {
 			// Clean up both servers
-			_ = e2e.StopAndRemoveMCPServer(config, inspectorName)
-			_ = e2e.StopAndRemoveMCPServer(config, mcpServerName)
+			err := e2e.StopAndRemoveMCPServer(config, inspectorName)
+			Expect(err).ToNot(HaveOccurred(), "Should be able to stop and remove inspector")
+			err = e2e.StopAndRemoveMCPServer(config, mcpServerName)
+			Expect(err).ToNot(HaveOccurred(), "Should be able to stop and remove MCP server")
 		}
 	})
 
@@ -102,8 +104,10 @@ var _ = Describe("Inspector", func() {
 		AfterEach(func() {
 			if config.CleanupAfter {
 				// Clean up both servers
-				_ = e2e.StopAndRemoveMCPServer(config, inspectorName)
-				_ = e2e.StopAndRemoveMCPServer(config, mcpServerName)
+				err := e2e.StopAndRemoveMCPServer(config, inspectorName)
+				Expect(err).ToNot(HaveOccurred(), "Should be able to stop and remove inspector")
+				err = e2e.StopAndRemoveMCPServer(config, mcpServerName)
+				Expect(err).ToNot(HaveOccurred(), "Should be able to stop and remove MCP server")
 			}
 		})
 

--- a/test/e2e/osv_authz_test.go
+++ b/test/e2e/osv_authz_test.go
@@ -98,7 +98,8 @@ var _ = Describe("OSV MCP Server with Authorization", Serial, func() {
 			AfterAll(func() {
 				if config.CleanupAfter {
 					// Clean up the shared server after all tests
-					_ = e2e.StopAndRemoveMCPServer(config, serverName)
+					err := e2e.StopAndRemoveMCPServer(config, serverName)
+					Expect(err).ToNot(HaveOccurred(), "Should be able to stop and remove server")
 
 					// Clean up the temporary config file
 					if authzConfigPath != "" {

--- a/test/e2e/osv_mcp_server_test.go
+++ b/test/e2e/osv_mcp_server_test.go
@@ -40,7 +40,8 @@ var _ = Describe("OsvMcpServer", Serial, func() {
 			AfterEach(func() {
 				if config.CleanupAfter {
 					// Clean up the server after each test in this context
-					_ = e2e.StopAndRemoveMCPServer(config, serverName)
+					err := e2e.StopAndRemoveMCPServer(config, serverName)
+					Expect(err).ToNot(HaveOccurred(), "Should be able to stop and remove server")
 				}
 			})
 
@@ -191,7 +192,8 @@ var _ = Describe("OsvMcpServer", Serial, func() {
 			AfterAll(func() {
 				if config.CleanupAfter {
 					// Clean up the shared server after all tests
-					_ = e2e.StopAndRemoveMCPServer(config, serverName)
+					err := e2e.StopAndRemoveMCPServer(config, serverName)
+					Expect(err).ToNot(HaveOccurred(), "Should be able to stop and remove server")
 				}
 			})
 
@@ -307,7 +309,8 @@ var _ = Describe("OsvMcpServer", Serial, func() {
 			AfterEach(func() {
 				if config.CleanupAfter {
 					// Clean up the server after each lifecycle test
-					_ = e2e.StopAndRemoveMCPServer(config, serverName)
+					err := e2e.StopAndRemoveMCPServer(config, serverName)
+					Expect(err).ToNot(HaveOccurred(), "Should be able to stop and remove server")
 				}
 			})
 
@@ -361,7 +364,8 @@ var _ = Describe("OsvMcpServer", Serial, func() {
 			AfterEach(func() {
 				if config.CleanupAfter {
 					// Clean up any server that might have been created
-					_ = e2e.StopAndRemoveMCPServer(config, serverName)
+					err := e2e.StopAndRemoveMCPServer(config, serverName)
+					Expect(err).ToNot(HaveOccurred(), "Should be able to stop and remove server")
 				}
 			})
 

--- a/test/e2e/proxy_oauth_test.go
+++ b/test/e2e/proxy_oauth_test.go
@@ -98,7 +98,8 @@ var _ = Describe("Proxy OAuth Authentication E2E", Serial, func() {
 
 		// Stop and remove OSV server
 		if config.CleanupAfter {
-			_ = e2e.StopAndRemoveMCPServer(config, osvServerName)
+			err := e2e.StopAndRemoveMCPServer(config, osvServerName)
+			Expect(err).ToNot(HaveOccurred(), "Should be able to stop and remove server")
 		}
 
 		// Stop mock OIDC server


### PR DESCRIPTION
## Summary

Fixes #350 - Proxy processes were not being terminated when using `thv rm` command.

## Changes

- **Fixed DeleteWorkload()**: Added `proxy.StopProcess()` call before stopping container to match the pattern used in `StopWorkload()`
- **Updated e2e tests**: Modified test helpers to properly check for errors in cleanup instead of ignoring them
- **Removed obsolete flag**: Removed `-f` flag usage in `StopAndRemoveMCPServer` helper as it no longer exists

## Root Cause

The issue was that `DeleteWorkload()` was calling `stopContainer()` directly instead of following the same pattern as `StopWorkload()` which calls `proxy.StopProcess()` first to terminate the proxy process before stopping the container.

## Testing

✅ **Manual verification**: 
- Started MCP server with defined port
- Verified proxy process was running
- Used `thv rm` to remove server
- Confirmed proxy process was properly terminated
- Verified output now includes "Stopping proxy process" messages

✅ **Before fix**: `thv rm` left proxy processes running
✅ **After fix**: `thv rm` properly terminates proxy processes

## Comparison

**Before (broken behavior):**
```
12:19PM INF Stopping container test-process-cleanup...
12:19PM INF Container test-process-cleanup stopped
# No proxy stopping messages
```

**After (fixed behavior):**
```
12:21PM INF Stopping proxy process (PID: 15587)...
12:21PM INF Proxy process stopped
12:21PM INF Stopping container test-fix-verification...
12:21PM INF Container test-fix-verification stopped
```