### PR TITLE
feat: add TOOLHIVE_SECRETS_PROVIDER environment variable support

### DIFF
--- a/pkg/secrets/factory.go
+++ b/pkg/secrets/factory.go
@@ -18,6 +18,9 @@ const (
 	// PasswordEnvVar is the environment variable used to specify the password for encrypting and decrypting secrets.
 	PasswordEnvVar = "TOOLHIVE_SECRETS_PASSWORD"
 
+	// ProviderEnvVar is the environment variable used to specify the secrets provider type.
+	ProviderEnvVar = "TOOLHIVE_SECRETS_PROVIDER"
+
 	keyringService = "toolhive"
 )
 


### PR DESCRIPTION
## Summary

This PR adds support for the `TOOLHIVE_SECRETS_PROVIDER` environment variable to allow overriding the secrets provider configuration without modifying the config file.

## Changes

- **Added `ProviderEnvVar` constant** to `pkg/secrets/factory.go` for the environment variable name
- **Modified `GetProviderType()`** in `pkg/config/config.go` to check environment variable first, then fallback to config file
- **Environment variable takes precedence** over configuration file setting
- **Added comprehensive test coverage** for environment variable functionality
- **Maintains backward compatibility** with existing configuration approach

## Usage

Users can now set the secrets provider using:

```bash
export TOOLHIVE_SECRETS_PROVIDER=encrypted
# or
export TOOLHIVE_SECRETS_PROVIDER=1password
```

This will override any setting in the configuration file.

## Testing

- Added `TestSecrets_GetProviderType_EnvironmentVariable` test that verifies:
  - Environment variable takes precedence over config
  - Fallback to config when env var is unset
  - Error handling for invalid environment variable values
- All existing tests continue to pass
- Linting passes with no issues

## Backward Compatibility

This change is fully backward compatible. Existing configurations will continue to work exactly as before. The environment variable is only checked if it's set.