### PR TITLE
fix: resolve sporadic CI test failure due to port conflicts

### DIFF
--- a/pkg/runner/config_test.go
+++ b/pkg/runner/config_test.go
@@ -159,8 +159,8 @@ func TestRunConfig_WithPorts(t *testing.T) {
 		{
 			name:        "SSE transport with specific ports",
 			config:      &RunConfig{Transport: types.TransportTypeSSE},
-			port:        8000,
-			targetPort:  9000,
+			port:        8001,
+			targetPort:  9001,
 			expectError: false,
 		},
 		{
@@ -173,8 +173,8 @@ func TestRunConfig_WithPorts(t *testing.T) {
 		{
 			name:        "Stdio transport with specific port",
 			config:      &RunConfig{Transport: types.TransportTypeStdio},
-			port:        8000,
-			targetPort:  9000, // This should be ignored for stdio
+			port:        8002,
+			targetPort:  9002, // This should be ignored for stdio
 			expectError: false,
 		},
 	}


### PR DESCRIPTION
## Summary

Fixes sporadic CI test failures in `TestRunConfig_WithPorts` that were occurring due to port conflicts when tests run in parallel.

## Problem

The CI was experiencing sporadic failures with the error:
```
port 8000 is already in use
```

This was happening because two test cases in `TestRunConfig_WithPorts` were trying to use the same port (8000) simultaneously:
- "SSE transport with specific ports" 
- "Stdio transport with specific port"

Since tests run in parallel (`t.Parallel()`), they could conflict when both tried to bind to port 8000 at the same time.

## Solution

Changed the port numbers in the test cases to avoid conflicts:
- **SSE transport test**: Now uses port **8001** and target port **9001** (was 8000/9000)
- **Stdio transport test**: Now uses port **8002** and target port **9002** (was 8000/9000)

## Testing

- ✅ All unit tests pass consistently
- ✅ No linting issues
- ✅ Verified the specific failing test now passes

## Impact

This resolves the sporadic CI failures that were affecting builds like PR #640. The fix is simple and eliminates the race condition without over-engineering the solution.