### PR TITLE
feat: implement none secrets provider for Kubernetes environments

### DIFF
--- a/cmd/thv/app/common.go
+++ b/cmd/thv/app/common.go
@@ -38,7 +38,7 @@ func IsOIDCEnabled(cmd *cobra.Command) bool {
 
 // SetSecretsProvider sets the secrets provider type in the configuration.
 // It validates the input and updates the configuration.
-// Choices are `encrypted` and `1password`.
+// Choices are `encrypted`, `1password`, and `none`.
 func SetSecretsProvider(provider secrets.ProviderType) error {
 
 	// Validate input
@@ -51,9 +51,10 @@ func SetSecretsProvider(provider secrets.ProviderType) error {
 	switch provider {
 	case secrets.EncryptedType:
 	case secrets.OnePasswordType:
+	case secrets.NoneType:
 		// Valid provider type
 	default:
-		return fmt.Errorf("invalid secrets provider type: %s (valid types: encrypted, 1password)", provider)
+		return fmt.Errorf("invalid secrets provider type: %s (valid types: encrypted, 1password, none)", provider)
 	}
 
 	// Update the secrets provider type

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -42,8 +42,10 @@ func validateProviderType(provider string) (secrets.ProviderType, error) {
 		return secrets.EncryptedType, nil
 	case string(secrets.OnePasswordType):
 		return secrets.OnePasswordType, nil
+	case string(secrets.NoneType):
+		return secrets.NoneType, nil
 	default:
-		return "", fmt.Errorf("invalid secrets provider type: %s (valid types: encrypted, 1password)", provider)
+		return "", fmt.Errorf("invalid secrets provider type: %s (valid types: encrypted, 1password, none)", provider)
 	}
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -262,7 +262,20 @@ func TestSecrets_GetProviderType_EnvironmentVariable(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, secrets.OnePasswordType, got, "Should fallback to config value when env var is unset")
 
-	// Test 3: Invalid environment variable returns error
+	// Test 3: None provider via environment variable
+	os.Setenv(secrets.ProviderEnvVar, "none")
+	got, err = s.GetProviderType()
+	require.NoError(t, err)
+	assert.Equal(t, secrets.NoneType, got, "Environment variable should support none provider")
+
+	// Test 4: None provider via config
+	os.Unsetenv(secrets.ProviderEnvVar)
+	s.ProviderType = "none"
+	got, err = s.GetProviderType()
+	require.NoError(t, err)
+	assert.Equal(t, secrets.NoneType, got, "Config should support none provider")
+
+	// Test 5: Invalid environment variable returns error
 	os.Setenv(secrets.ProviderEnvVar, "invalid")
 	_, err = s.GetProviderType()
 	assert.Error(t, err, "Should return error for invalid environment variable")

--- a/pkg/secrets/factory.go
+++ b/pkg/secrets/factory.go
@@ -33,6 +33,9 @@ const (
 
 	// OnePasswordType represents the 1Password secret provider.
 	OnePasswordType ProviderType = "1password"
+
+	// NoneType represents the none secret provider.
+	NoneType ProviderType = "none"
 )
 
 // ErrUnknownManagerType is returned when an invalid value for ProviderType is specified.
@@ -55,6 +58,8 @@ func CreateSecretProvider(managerType ProviderType) (Provider, error) {
 		return NewEncryptedManager(secretsPath, key[:])
 	case OnePasswordType:
 		return NewOnePasswordManager()
+	case NoneType:
+		return NewNoneManager()
 	default:
 		return nil, ErrUnknownManagerType
 	}

--- a/pkg/secrets/none.go
+++ b/pkg/secrets/none.go
@@ -1,0 +1,64 @@
+package secrets
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+// NoneManager is a no-op secrets provider that doesn't store or retrieve secrets.
+// It's designed for use in Kubernetes environments where secrets are provided
+// as environment variables or file mounts, eliminating the need for interactive
+// password prompts.
+type NoneManager struct{}
+
+// GetSecret always returns an error indicating that the none provider doesn't support secret retrieval.
+func (*NoneManager) GetSecret(_ context.Context, name string) (string, error) {
+	if name == "" {
+		return "", errors.New("secret name cannot be empty")
+	}
+	return "", fmt.Errorf("secret not found: %s (none provider doesn't store secrets)", name)
+}
+
+// SetSecret always returns an error indicating that the none provider doesn't support secret storage.
+func (*NoneManager) SetSecret(_ context.Context, name, _ string) error {
+	if name == "" {
+		return errors.New("secret name cannot be empty")
+	}
+	return errors.New("none provider doesn't support storing secrets")
+}
+
+// DeleteSecret always returns an error indicating that the none provider doesn't support secret deletion.
+func (*NoneManager) DeleteSecret(_ context.Context, name string) error {
+	if name == "" {
+		return errors.New("secret name cannot be empty")
+	}
+	return fmt.Errorf("cannot delete non-existent secret: %s (none provider doesn't store secrets)", name)
+}
+
+// ListSecrets returns an empty list since the none provider doesn't store any secrets.
+func (*NoneManager) ListSecrets(_ context.Context) ([]SecretDescription, error) {
+	return []SecretDescription{}, nil
+}
+
+// Cleanup is a no-op for the none provider since there's nothing to clean up.
+func (*NoneManager) Cleanup() error {
+	return nil
+}
+
+// Capabilities returns the capabilities of the none provider.
+// The none provider is essentially read-only but doesn't actually read anything.
+func (*NoneManager) Capabilities() ProviderCapabilities {
+	return ProviderCapabilities{
+		CanRead:    false,
+		CanWrite:   false,
+		CanDelete:  false,
+		CanList:    true,
+		CanCleanup: true,
+	}
+}
+
+// NewNoneManager creates an instance of NoneManager.
+func NewNoneManager() (Provider, error) {
+	return &NoneManager{}, nil
+}

--- a/pkg/secrets/none_test.go
+++ b/pkg/secrets/none_test.go
@@ -1,0 +1,125 @@
+package secrets
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewNoneManager(t *testing.T) {
+	t.Parallel()
+	manager, err := NewNoneManager()
+	require.NoError(t, err)
+	assert.NotNil(t, manager)
+}
+
+func TestNoneManager_GetSecret(t *testing.T) {
+	t.Parallel()
+	manager, err := NewNoneManager()
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	// Test with valid name
+	secret, err := manager.GetSecret(ctx, "test-secret")
+	assert.Error(t, err)
+	assert.Empty(t, secret)
+	assert.Contains(t, err.Error(), "secret not found: test-secret")
+	assert.Contains(t, err.Error(), "none provider doesn't store secrets")
+
+	// Test with empty name
+	secret, err = manager.GetSecret(ctx, "")
+	assert.Error(t, err)
+	assert.Empty(t, secret)
+	assert.Contains(t, err.Error(), "secret name cannot be empty")
+}
+
+func TestNoneManager_SetSecret(t *testing.T) {
+	t.Parallel()
+	manager, err := NewNoneManager()
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	// Test with valid name and value
+	err = manager.SetSecret(ctx, "test-secret", "test-value")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "none provider doesn't support storing secrets")
+
+	// Test with empty name
+	err = manager.SetSecret(ctx, "", "test-value")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "secret name cannot be empty")
+}
+
+func TestNoneManager_DeleteSecret(t *testing.T) {
+	t.Parallel()
+	manager, err := NewNoneManager()
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	// Test with valid name
+	err = manager.DeleteSecret(ctx, "test-secret")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot delete non-existent secret: test-secret")
+	assert.Contains(t, err.Error(), "none provider doesn't store secrets")
+
+	// Test with empty name
+	err = manager.DeleteSecret(ctx, "")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "secret name cannot be empty")
+}
+
+func TestNoneManager_ListSecrets(t *testing.T) {
+	t.Parallel()
+	manager, err := NewNoneManager()
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	secrets, err := manager.ListSecrets(ctx)
+	assert.NoError(t, err)
+	assert.Empty(t, secrets)
+	assert.Equal(t, []SecretDescription{}, secrets)
+}
+
+func TestNoneManager_Cleanup(t *testing.T) {
+	t.Parallel()
+	manager, err := NewNoneManager()
+	require.NoError(t, err)
+
+	err = manager.Cleanup()
+	assert.NoError(t, err)
+}
+
+func TestNoneManager_Capabilities(t *testing.T) {
+	t.Parallel()
+	manager, err := NewNoneManager()
+	require.NoError(t, err)
+
+	capabilities := manager.Capabilities()
+	assert.False(t, capabilities.CanRead)
+	assert.False(t, capabilities.CanWrite)
+	assert.False(t, capabilities.CanDelete)
+	assert.True(t, capabilities.CanList)
+	assert.True(t, capabilities.CanCleanup)
+
+	// Test capability helper methods
+	assert.False(t, capabilities.IsReadOnly())
+	assert.False(t, capabilities.IsReadWrite())
+	assert.Equal(t, "custom", capabilities.String())
+}
+
+func TestCreateSecretProvider_None(t *testing.T) {
+	t.Parallel()
+	provider, err := CreateSecretProvider(NoneType)
+	require.NoError(t, err)
+	assert.NotNil(t, provider)
+
+	// Verify it's actually a NoneManager
+	_, ok := provider.(*NoneManager)
+	assert.True(t, ok)
+}


### PR DESCRIPTION
## Summary

Implements a `none` secrets provider to address issue #536. This provider is designed for Kubernetes environments where ToolHive should not prompt for passwords interactively, as secrets are provided via environment variables or file mounts.

## Changes

### New Files:
- `pkg/secrets/none.go` - NoneManager implementation with no-op secret operations
- `pkg/secrets/none_test.go` - Comprehensive test suite with parallel tests

### Modified Files:
- `pkg/secrets/factory.go` - Added NoneType constant and factory support
- `pkg/config/config.go` - Updated validateProviderType() to support "none"
- `cmd/thv/app/common.go` - Updated SetSecretsProvider() to accept "none"
- `pkg/config/config_test.go` - Added tests for none provider

## Key Features

### NoneManager Implementation:
- **GetSecret()**: Returns "secret not found" error
- **SetSecret()**: Returns "doesn't support storing secrets" error  
- **DeleteSecret()**: Returns "cannot delete non-existent secret" error
- **ListSecrets()**: Returns empty list
- **Cleanup()**: No-op operation
- **Capabilities()**: Limited capabilities (only CanList and CanCleanup are true)

### Usage:
Users can set the secrets provider to "none" via:
1. Environment variable: `TOOLHIVE_SECRETS_PROVIDER=none`
2. Config command: `thv config secrets-provider none`

## Testing

- All existing tests continue to pass
- Comprehensive test coverage for the new provider
- Integration tests verify environment variable and config file support
- All tests use `t.Parallel()` for better performance

## Benefits

- Solves Kubernetes container failures due to interactive password prompts
- Maintains consistency with existing provider patterns
- Provides clear error messages for unsupported operations
- Enables ToolHive to run in environments where secrets are externally managed

Fixes #536