### PR TITLE
Advertise toolhive as thv for winget

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -32,7 +32,7 @@ archives:
         format: zip
 # This section defines how to release to winget.
 winget:
- - name: toolhive
+ - name: thv
    publisher: stacklok
    license: Apache-2.0
    license_url: "https://github.com/stacklok/toolhive/blob/main/LICENSE"
@@ -40,7 +40,7 @@ winget:
    homepage: https://stacklok.com
    short_description: 'ToolHive is a lightweight, secure, and fast manager for MCP (Model Context Protocol) servers'
    publisher_support_url: "https://github.com/stacklok/toolhive/issues/new/choose"
-   package_identifier: "stacklok.toolhive"
+   package_identifier: "stacklok.thv"
    url_template: "https://github.com/stacklok/toolhive/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
    skip_upload: auto
    release_notes: "{{.Changelog}}"
@@ -59,7 +59,7 @@ winget:
    repository:
      owner: stacklok
      name: winget-pkgs
-     branch: "toolhive-{{.Version}}"
+     branch: "thv-{{.Version}}"
      token: "{{ .Env.WINGET_GITHUB_TOKEN }}"
      pull_request:
        enabled: true

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ If you're on Windows, you can install ToolHive using the Windows Package Manager
 > Note: Make sure you have [Winget](https://learn.microsoft.com/en-us/windows/package-manager/winget/) installed.
 
 ```bash
-winget install stacklok.toolhive
+winget install stacklok.thv
 ```
 
 #### Build from source <!-- omit in toc -->


### PR DESCRIPTION
The following PR updates the goreleaser config so we advertise toolhive as thv for winget