### PR TITLE
feat: set TOOLHIVE_SECRETS_PROVIDER=none for K8s proxy runner pods

### DIFF
--- a/cmd/thv-operator/controllers/mcpserver_controller.go
+++ b/cmd/thv-operator/controllers/mcpserver_controller.go
@@ -431,6 +431,12 @@ func (r *MCPServerReconciler) deploymentForMCPServer(m *mcpv1alpha1.MCPServer) *
 		})
 	}
 
+	// Add TOOLHIVE_SECRETS_PROVIDER=none for Kubernetes deployments
+	env = append(env, corev1.EnvVar{
+		Name:  "TOOLHIVE_SECRETS_PROVIDER",
+		Value: "none",
+	})
+
 	// Prepare container volume mounts
 	volumeMounts := []corev1.VolumeMount{}
 	volumes := []corev1.Volume{}


### PR DESCRIPTION
## Summary

This PR adds the `TOOLHIVE_SECRETS_PROVIDER=none` environment variable to all proxy runner pods created by the thv-operator in Kubernetes.

## Changes

- Modified `mcpserver_controller.go` to automatically set `TOOLHIVE_SECRETS_PROVIDER=none` for all proxy runner pods
- Added test `TestDeploymentForMCPServerSecretsProviderEnv` to verify the environment variable is correctly set
- Ensures proper secrets provider configuration for Kubernetes deployments
- Maintains backwards compatibility with existing MCPServer configurations

## Testing

- All existing tests continue to pass
- New test specifically validates the environment variable presence and value
- Linting passes with no issues

## Related

This addresses the requirement to set the TOOLHIVE_SECRETS_PROVIDER environment variable to `none` when running in Kubernetes environments.