### PR TITLE
fix: filter VERSION tags to only include v* tags for thv builds

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -64,7 +64,7 @@ tasks:
     desc: Build the binary
     vars:
       VERSION:
-        sh: git describe --tags --always --dirty || echo "dev"
+        sh: git describe --tags --always --dirty --match "v*" || echo "dev"
       COMMIT:
         sh: git rev-parse --short HEAD || echo "unknown"
       BUILD_DATE:
@@ -77,7 +77,7 @@ tasks:
     desc: Install the thv binary to GOPATH/bin
     vars:
       VERSION:
-        sh: git describe --tags --always --dirty || echo "dev"
+        sh: git describe --tags --always --dirty --match "v*" || echo "dev"
       COMMIT:
         sh: git rev-parse --short HEAD || echo "unknown"
       BUILD_DATE:


### PR DESCRIPTION
## Problem

The `VERSION` helper in Taskfile.yml was broken because it was picking up all tags, including operator tags like `toolhive-operator-0.0.11` and `toolhive-operator-crds-0.0.6`. This caused the thv binary to get incorrect version information when building.

## Solution

Modified the `VERSION` variable in both the `build` and `install` tasks to use `git describe --tags --always --dirty --match "v*"`, which filters to only consider tags that start with `v`.

## Changes

- Updated `Taskfile.yml` VERSION variable to use `--match "v*"` filter
- Applied to both `build` and `install` tasks for consistency

## Verification

- **Before fix**: `git describe --tags --always --dirty` returned `toolhive-operator-0.0.11-dirty`
- **After fix**: `git describe --tags --always --dirty --match "v*"` returns `v0.0.45-1-g19461cf-dirty`
- Build test confirmed the correct version is now being used in ldflags

## Impact

This ensures that thv builds will only use proper semantic version tags (v0.0.45, etc.) and ignore the operator-specific tags, providing consistent and correct version information for the thv binary.