### PR TITLE
Update proxy to send the ID token

### DIFF
--- a/cmd/thv/app/proxy.go
+++ b/cmd/thv/app/proxy.go
@@ -406,6 +406,11 @@ func performOAuthFlow(ctx context.Context, issuer, clientID, clientSecret string
 		}
 	}
 
+	// Always return the ID token (JWT) for Authorization header
+	if tokenResult.IDToken != "" {
+		return tokenResult.IDToken, nil
+	}
+	// Fallback: if no ID token, return access token (may be JWT for some IdPs)
 	return tokenResult.AccessToken, nil
 }
 

--- a/pkg/auth/oauth/flow.go
+++ b/pkg/auth/oauth/flow.go
@@ -70,6 +70,7 @@ type TokenResult struct {
 	TokenType    string
 	Expiry       time.Time
 	Claims       jwt.MapClaims
+	IDToken      string // The OIDC ID token (JWT), if present
 }
 
 // NewFlow creates a new OAuth flow
@@ -434,6 +435,7 @@ func (f *Flow) processToken(token *oauth2.Token) *TokenResult {
 
 	// Prefer extracting claims from the ID token if present (OIDC, e.g., Google)
 	if idToken, ok := token.Extra("id_token").(string); ok && idToken != "" {
+		result.IDToken = idToken
 		if claims, err := f.extractJWTClaims(idToken); err == nil {
 			result.Claims = claims
 			logger.Debugf("Successfully extracted JWT claims from ID token")


### PR DESCRIPTION
The proxy should send the ID token (if available) instead of the access token.

With some providers (like Google), the access token is an opaque token and not the JWT like it is with Keycloak.

Fixes the proxy-to-mcp-server auth flow for Google and other IdPs.