### PR TITLE
fix: reduce update check timeout from 30s to 3s

### DIFF
--- a/pkg/updates/client.go
+++ b/pkg/updates/client.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"time"
 )
 
 // VersionClient is an interface for calling the update service API.
@@ -35,6 +36,7 @@ const (
 	instanceIDHeader  = "X-Instance-ID"
 	userAgentHeader   = "User-Agent"
 	defaultVersionAPI = "https://updates.codegate.ai/api/v1/version"
+	defaultTimeout    = 3 * time.Second
 )
 
 // GetLatestVersion sends a GET request to the update API endpoint and returns the version from the response.
@@ -58,8 +60,10 @@ func (d *defaultVersionClient) GetLatestVersion(instanceID string, currentVersio
 	req.Header.Set(instanceIDHeader, instanceID)
 	req.Header.Set(userAgentHeader, userAgent)
 
-	// Send the request
-	client := &http.Client{}
+	// Send the request with a reasonable timeout
+	client := &http.Client{
+		Timeout: defaultTimeout,
+	}
 	resp, err := client.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("failed to send request to update API: %w", err)


### PR DESCRIPTION
## Summary

This PR addresses issue #694 by implementing a much shorter timeout for update checks, improving CLI responsiveness when the update service is unreachable.

## Changes

- Add `defaultTimeout` constant set to 3 seconds
- Configure HTTP client with timeout to prevent long waits (previously defaulted to 30+ seconds)
- Improves user experience for all CLI commands, especially `thv --help`

## Problem

The update check was taking 30+ seconds to timeout when the update service was unreachable, causing poor user experience:

```
$ time thv version
checking for updates...
7:15PM WRN could not check for updates: failed to check for updates: failed to send request to update API: Get "https://updates.codegate.ai/api/v1/version": dial tcp <bad ip>:443: i/o timeout
...
thv version  0.02s user 0.04s system 0% cpu 30.134 total
```

## Solution

With this change, the timeout is reduced from 30+ seconds to just 3 seconds, making the CLI much more responsive while still allowing sufficient time for legitimate update checks.

## Testing

- ✅ All existing tests pass
- ✅ Code passes golangci-lint with 0 issues
- ✅ Timeout constant follows Go best practices

Fixes #694