### PR TITLE
Add a new explicit secret provider setup and force its use

### DIFF
--- a/cmd/thv/app/common.go
+++ b/cmd/thv/app/common.go
@@ -57,9 +57,10 @@ func SetSecretsProvider(provider secrets.ProviderType) error {
 		return fmt.Errorf("invalid secrets provider type: %s (valid types: encrypted, 1password, none)", provider)
 	}
 
-	// Update the secrets provider type
+	// Update the secrets provider type and mark setup as completed
 	err := config.UpdateConfig(func(c *config.Config) {
 		c.Secrets.ProviderType = string(provider)
+		c.Secrets.SetupCompleted = true
 	})
 	if err != nil {
 		return fmt.Errorf("failed to update configuration: %w", err)

--- a/cmd/thv/app/config.go
+++ b/cmd/thv/app/config.go
@@ -16,7 +16,6 @@ import (
 	rt "github.com/stacklok/toolhive/pkg/container/runtime"
 	"github.com/stacklok/toolhive/pkg/labels"
 	"github.com/stacklok/toolhive/pkg/logger"
-	"github.com/stacklok/toolhive/pkg/secrets"
 	"github.com/stacklok/toolhive/pkg/transport"
 )
 
@@ -31,16 +30,6 @@ var listRegisteredClientsCmd = &cobra.Command{
 	Short: "List all registered MCP clients",
 	Long:  "List all clients that are registered for MCP server configuration.",
 	RunE:  listRegisteredClientsCmdFunc,
-}
-
-var secretsProviderCmd = &cobra.Command{
-	Use:   "secrets-provider [provider]",
-	Short: "Set the secrets provider type",
-	Long: `Set the secrets provider type for storing and retrieving secrets.
-Valid providers are:
-  - encrypted: Stores secrets in an encrypted file using AES-256-GCM`,
-	Args: cobra.ExactArgs(1),
-	RunE: secretsProviderCmdFunc,
 }
 
 var autoDiscoveryCmd = &cobra.Command{
@@ -140,7 +129,6 @@ func init() {
 	rootCmd.AddCommand(configCmd)
 
 	// Add subcommands to config command
-	configCmd.AddCommand(secretsProviderCmd)
 	configCmd.AddCommand(autoDiscoveryCmd)
 	configCmd.AddCommand(registerClientCmd)
 	configCmd.AddCommand(removeClientCmd)
@@ -151,11 +139,6 @@ func init() {
 	configCmd.AddCommand(setRegistryURLCmd)
 	configCmd.AddCommand(getRegistryURLCmd)
 	configCmd.AddCommand(unsetRegistryURLCmd)
-}
-
-func secretsProviderCmdFunc(_ *cobra.Command, args []string) error {
-	provider := args[0]
-	return SetSecretsProvider(secrets.ProviderType(provider))
 }
 
 func autoDiscoveryCmdFunc(cmd *cobra.Command, args []string) error {

--- a/cmd/thv/app/run.go
+++ b/cmd/thv/app/run.go
@@ -507,6 +507,13 @@ func initializeSecretsManagerIfNeeded(registryEnvVars []*registry.EnvVar) secret
 		return nil
 	}
 
+	// Check if secrets setup has been completed
+	cfg := config.GetConfig()
+	if !cfg.Secrets.SetupCompleted {
+		logger.Warnf("Warning: Secrets provider not configured. Run 'thv secrets setup' to configure a secrets provider")
+		return nil
+	}
+
 	secretsManager, err := getSecretsManager()
 	if err != nil {
 		logger.Warnf("Warning: Failed to initialize secrets manager: %v", err)

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -134,7 +134,12 @@ func (r *Runner) Run(ctx context.Context) error {
 	// NOTE: This MUST happen after we save the run config to avoid storing
 	// the secrets in the state store.
 	if len(r.Config.Secrets) > 0 {
-		providerType, err := config.GetConfig().Secrets.GetProviderType()
+		cfg := config.GetConfig()
+		if !cfg.Secrets.SetupCompleted {
+			return fmt.Errorf("secrets provider not configured. Please run 'thv secrets setup' to configure a secrets provider first")
+		}
+		
+		providerType, err := cfg.Secrets.GetProviderType()
 		if err != nil {
 			return fmt.Errorf("error determining secrets provider type: %w", err)
 		}

--- a/pkg/secrets/factory.go
+++ b/pkg/secrets/factory.go
@@ -41,6 +41,9 @@ const (
 // ErrUnknownManagerType is returned when an invalid value for ProviderType is specified.
 var ErrUnknownManagerType = errors.New("unknown secret manager type")
 
+// ErrSecretsNotSetup is returned when secrets functionality is used before running setup.
+var ErrSecretsNotSetup = errors.New("secrets provider not configured. Please run 'thv secrets setup' to configure a secrets provider first")
+
 // CreateSecretProvider creates the specified type of secrets provider.
 func CreateSecretProvider(managerType ProviderType) (Provider, error) {
 	switch managerType {


### PR DESCRIPTION
**Summary**
This PR addresses the requirement to enforce a separate setup step for ToolHive secrets functionality. Previously, the system defaulted to the encrypted provider and prompted users for passwords interactively on first use. This implementation introduces a mandatory setup step that must be completed before any secrets functionality can be used.

**Key Features**

- Dedicated CLI Command: New `thv secret setup` command for configuring secrets providers, taking the place of `thv secret provider`
- Setup Validation: All secrets-related operations now require setup completion
- Provider Selection: Interactive setup with support for encrypted, 1Password, and none providers
- Backward Compatibility: Existing configurations are automatically marked as setup-complete


**Breaking Changes**

- For New Users: Secrets functionality now requires an explicit setup step before use
- For Existing Users: No breaking changes - existing configurations are automatically migrated to the new setup model

**Migration Guide**

- New Users: run `thv secrets setup`
- Existing Users: No action required - existing configurations will continue to work unchanged