### PR TITLE
chore: add workflow to trigger docs update

### DIFF
--- a/.github/workflows/update-docs-website.yml
+++ b/.github/workflows/update-docs-website.yml
@@ -1,7 +1,6 @@
 name: Trigger Docs Update
 
-permissions:
-  contents: read
+permissions: {}
 
 on:
   release:

--- a/.github/workflows/update-docs-website.yml
+++ b/.github/workflows/update-docs-website.yml
@@ -1,0 +1,32 @@
+name: Trigger Docs Update
+
+permissions:
+  contents: read
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  trigger:
+    # Don't trigger on operator releases
+    # On a release event, ref is the release tag
+    if: ${{ startsWith(github.event.release.tag_name, 'v') }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Trigger docs update workflow
+        run: |
+          repo="stacklok/docs-website"
+          event_type="published-release"
+          version="${{ github.event.release.tag_name }}"
+
+          echo "Triggering docs update for $repo with version $version"
+  
+          curl --fail -L \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.DOCS_REPO_DISPATCH_TOKEN }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/$repo/dispatches \
+            -d "{\"event_type\": \"$event_type\", \"client_payload\": {\"version\": \"$version\"}}"


### PR DESCRIPTION
Adds a GitHub Actions workflow to send a repository_dispatch event to the docs-website repo when a new release is published.

Currently, it will only trigger on a CLI release (tag starting with "v") and not on operator releases, since the docs update workflow only refreshes CLI and API references at present.

Tested locally using [`act`](https://nektosact.com/introduction.html) to verify functionality.

Closes #656
Closes stacklok/docs-website#1