### PR TITLE
Fix the Operator example for GitHub

### DIFF
--- a/examples/operator/mcp-servers/mcpserver_github.yaml
+++ b/examples/operator/mcp-servers/mcpserver_github.yaml
@@ -10,15 +10,21 @@ spec:
   permissionProfile:
     type: builtin
     name: network
-  secrets:
-    - name: github-token
-      token: token
-      targetEnvName: GITHUB_PERSONAL_ACCESS_TOKEN
   env:
     - name: GITHUB_API_URL
       value: https://api.github.com
     - name: LOG_LEVEL
       value: info
+  podTemplateSpec:
+    spec:
+      containers:
+      - name: mcp
+        env:
+        - name: GITHUB_PERSONAL_ACCESS_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: github-token
+              key: token
   resources:
     limits:
       cpu: "200m"


### PR DESCRIPTION
### Overview

This PR updates the GitHub example for the Operator to use `podTemplateSpec` to inject the secret instead of using the `secrets` property.

### Background

Currently, the `secrets` struct in the MCPServer CRD does not function, users get an error (see #521):

```
Error: failed to get secrets: secret not found: github-token/token (none provider doesn't store secrets)
```

While we work on a permanent solution to secrets handling in K8s, injecting secrets via `podTemplateSpec` works.