### PR TITLE
Add an explicit BuildType build variable

### DIFF
--- a/.github/workflows/image-build-and-publish.yml
+++ b/.github/workflows/image-build-and-publish.yml
@@ -53,6 +53,8 @@ jobs:
         uses: sigstore/cosign-installer@3454372f43399081ed03b604cb2d021dabca52bb # v3.8.2
 
       - name: Build and Push Image to GHCR
+        env:
+          GOFLAGS: "-ldflags=-s -w -X github.com/stacklok/toolhive/pkg/versions.Version=${{ steps.version-string.outputs.tag }} -X github.com/stacklok/toolhive/pkg/versions.Commit=${{ github.sha }} -X github.com/stacklok/toolhive/pkg/versions.BuildDate=${{ github.event.head_commit.timestamp }} -X github.com/stacklok/toolhive/pkg/versions.BuildType=release"
         run: |
           TAG=$(echo "${{ steps.version-string.outputs.tag }}" | sed 's/+/_/g')
           TAGS="-t $TAG"
@@ -209,6 +211,8 @@ jobs:
         uses: sigstore/cosign-installer@3454372f43399081ed03b604cb2d021dabca52bb # v3.8.2
 
       - name: Build and Push Image to GHCR
+        env:
+          GOFLAGS: "-ldflags=-s -w -X github.com/stacklok/toolhive/pkg/versions.Version=${{ steps.version-string.outputs.tag }} -X github.com/stacklok/toolhive/pkg/versions.Commit=${{ github.sha }} -X github.com/stacklok/toolhive/pkg/versions.BuildDate=${{ github.event.head_commit.timestamp }} -X github.com/stacklok/toolhive/pkg/versions.BuildType=release"
         run: |
           TAG=$(echo "${{ steps.version-string.outputs.tag }}" | sed 's/+/_/g')
           TAGS="-t $TAG"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -14,6 +14,7 @@ builds:
       - "-X github.com/stacklok/toolhive/pkg/versions.Version={{ .Env.VERSION }}"
       - "-X github.com/stacklok/toolhive/pkg/versions.Commit={{ .Env.COMMIT }}"
       - "-X github.com/stacklok/toolhive/pkg/versions.BuildDate={{ .Date }}"
+      - "-X github.com/stacklok/toolhive/pkg/versions.BuildType=release"
     goos:
       - linux
       - windows

--- a/pkg/updates/client.go
+++ b/pkg/updates/client.go
@@ -5,8 +5,9 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"time"
+
+	"github.com/stacklok/toolhive/pkg/versions"
 )
 
 // VersionClient is an interface for calling the update service API.
@@ -49,13 +50,17 @@ func (d *defaultVersionClient) GetLatestVersion(instanceID string, currentVersio
 	}
 
 	// Set headers
-	userAgent := fmt.Sprintf("toolhive/%s", currentVersion)
+	// Determine user agent based on build type
+	var userAgent string
+	if versions.BuildType == "release" {
+		userAgent = fmt.Sprintf("toolhive/%s", currentVersion)
+	} else {
+		userAgent = fmt.Sprintf("toolhive/development-%s", currentVersion)
+	}
+
+	// Add suffix
 	if d.userAgentSuffix != "" {
 		userAgent += " " + d.userAgentSuffix
-	}
-	// Add `dev` to the user agent for Stacklok devs.
-	if os.Getenv("TOOLHIVE_DEV") != "" {
-		userAgent += " dev"
 	}
 	req.Header.Set(instanceIDHeader, instanceID)
 	req.Header.Set(userAgentHeader, userAgent)

--- a/pkg/versions/version.go
+++ b/pkg/versions/version.go
@@ -23,6 +23,9 @@ var (
 	// BuildDate is the date when the binary was built
 	// nolint:goconst // This is a placeholder for the build date
 	BuildDate = unknownStr
+	// BuildType indicates if this is a release build.
+	// Set to "release" only in official release builds, everything else is considered "development".
+	BuildType = "development"
 )
 
 // VersionInfo represents the version information


### PR DESCRIPTION
The following PR adds an explicit BuildType variable (defaults to `development`, set during official releases to `release`) which removes the need to set an explicit env var for when we want to indicate that this is a development build.