### PR TITLE
Fix the ldflags for building via the task targets

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -71,7 +71,7 @@ tasks:
         sh: date -u +"%Y-%m-%dT%H:%M:%SZ"
     cmds:
       - mkdir -p bin
-      - go build -ldflags "-s -w -X github.com/stacklok/toolhive/cmd/thv/app.Version={{.VERSION}} -X github.com/stacklok/toolhive/cmd/thv/app.Commit={{.COMMIT}} -X github.com/stacklok/toolhive/cmd/thv/app.BuildDate={{.BUILD_DATE}}" -o bin/thv ./cmd/thv
+      - go build -ldflags "-s -w -X github.com/stacklok/toolhive/pkg/versions.Version={{.VERSION}} -X github.com/stacklok/toolhive/pkg/versions.Commit={{.COMMIT}} -X github.com/stacklok/toolhive/pkg/versions.BuildDate={{.BUILD_DATE}}" -o bin/thv ./cmd/thv
 
   install:
     desc: Install the thv binary to GOPATH/bin

--- a/cmd/thv-operator/Taskfile.yml
+++ b/cmd/thv-operator/Taskfile.yml
@@ -54,7 +54,7 @@ tasks:
         sh: date -u +"%Y-%m-%dT%H:%M:%SZ"
     cmds:
       - mkdir -p bin
-      - go build -ldflags "-s -w -X github.com/stacklok/toolhive/cmd/thv-operator/app.Version={{.VERSION}} -X github.com/stacklok/toolhive/cmd/thv-operator/app.Commit={{.COMMIT}} -X github.com/stacklok/toolhive/cmd/thv-operator/app.BuildDate={{.BUILD_DATE}}" -o bin/thv-operator ./cmd/thv-operator
+      - go build -ldflags "-s -w -X github.com/stacklok/toolhive/pkg/versions.Version={{.VERSION}} -X github.com/stacklok/toolhive/pkg/versions.Commit={{.COMMIT}} -X github.com/stacklok/toolhive/pkg/versions.BuildDate={{.BUILD_DATE}}" -o bin/thv-operator ./cmd/thv-operator
 
   install-operator:
     desc: Install the thv-operator binary to GOPATH/bin
@@ -66,7 +66,7 @@ tasks:
       BUILD_DATE:
         sh: date -u +"%Y-%m-%dT%H:%M:%SZ"
     cmds:
-      - go install -ldflags "-s -w -X github.com/stacklok/toolhive/cmd/thv-operator/app.Version={{.VERSION}} -X github.com/stacklok/toolhive/cmd/thv-operator/app.Commit={{.COMMIT}} -X github.com/stacklok/toolhive/cmd/thv-operator/app.BuildDate={{.BUILD_DATE}}" -v ./cmd/thv-operator
+      - go install -ldflags "-s -w -X github.com/stacklok/toolhive/pkg/versions.Version={{.VERSION}} -X github.com/stacklok/toolhive/pkg/versions.Commit={{.COMMIT}} -X github.com/stacklok/toolhive/pkg/versions.BuildDate={{.BUILD_DATE}}" -v ./cmd/thv-operator
 
   build-operator-image:
     desc: Build the operator image with ko


### PR DESCRIPTION
The following PR fixes broken paths in the ldflags section which means there was affect from setting these for quite some time which makes me think we should probably just avoid setting these for local builds.