### PR TITLE
Make workload deletion asynchronous

### DIFF
--- a/cmd/thv/app/rm.go
+++ b/cmd/thv/app/rm.go
@@ -29,7 +29,13 @@ func rmCmdFunc(cmd *cobra.Command, args []string) error {
 	}
 
 	// Delete container.
-	if err := manager.DeleteWorkload(ctx, containerName); err != nil {
+	group, err := manager.DeleteWorkload(ctx, containerName)
+	if err != nil {
+		return fmt.Errorf("failed to delete container: %v", err)
+	}
+
+	// Wait for the deletion to complete.
+	if err := group.Wait(); err != nil {
 		return fmt.Errorf("failed to delete container: %v", err)
 	}
 

--- a/pkg/api/v1/workloads.go
+++ b/pkg/api/v1/workloads.go
@@ -124,7 +124,7 @@ func (s *WorkloadRoutes) stopWorkload(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	name := chi.URLParam(r, "name")
 	// Note that this is an asynchronous operation.
-	// In the API, we do not wait for the operation to complete.
+	// The request is not blocked on completion.
 	_, err := s.manager.StopWorkload(ctx, name)
 	if err != nil {
 		if errors.Is(err, workloads.ErrContainerNotFound) {
@@ -174,7 +174,9 @@ func (s *WorkloadRoutes) stopAllWorkloads(w http.ResponseWriter, r *http.Request
 func (s *WorkloadRoutes) deleteWorkload(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	name := chi.URLParam(r, "name")
-	err := s.manager.DeleteWorkload(ctx, name)
+	// Note that this is an asynchronous operation.
+	// The request is not blocked on completion.
+	_, err := s.manager.DeleteWorkload(ctx, name)
 	if err != nil {
 		if errors.Is(err, workloads.ErrContainerNotFound) {
 			http.Error(w, "Workload not found", http.StatusNotFound)


### PR DESCRIPTION
This copies the same behaviour added recently for stop. This change also fixes a bug where the deletion operation did not clean up the ingress/egress containers.

While looking at the runtime code, I discovered that the runtime does a force delete of containers, so there is no need to explicitly stop the container before force deleting.