### PR TITLE
Update Grafana MCP to SSE mode in registry

### DIFF
--- a/pkg/registry/data/registry.json
+++ b/pkg/registry/data/registry.json
@@ -982,7 +982,11 @@
         "get_analysis",
         "list_investigations",
         "find_error_pattern_logs",
-        "find_slow_requests"
+        "find_slow_requests",
+        "list_pyroscope_label_names",
+        "list_pyroscope_label_values",
+        "list_pyroscope_profile_types",
+        "fetch_pyroscope_profile"
       ],
       "transport": "sse",
       "target_port": 8000


### PR DESCRIPTION
The official Grafana MCP server image defaults to SSE mode via its ENTRYPOINT, so it was not working with our stdio config. Need to correct this in our registry.

Also refreshed the list of tools available in the server.