### PR TITLE
feat: use different port for ingress proxy

### DIFF
--- a/cmd/thv/app/inspector.go
+++ b/cmd/thv/app/inspector.go
@@ -106,7 +106,7 @@ func inspectorCmdFunc(cmd *cobra.Command, args []string) error {
 
 	labelsMap := map[string]string{}
 	labels.AddStandardLabels(labelsMap, "inspector", "inspector", string(types.TransportTypeInspector), inspectorUIPort)
-	_, err = rt.DeployWorkload(
+	_, _, err = rt.DeployWorkload(
 		ctx,
 		processedImage,
 		"inspector",

--- a/pkg/container/kubernetes/client_test.go
+++ b/pkg/container/kubernetes/client_test.go
@@ -171,7 +171,7 @@ func TestCreateContainerWithPodTemplatePatch(t *testing.T) {
 			options.K8sPodTemplatePatch = tc.k8sPodTemplatePatch
 
 			// Deploy the workload
-			containerID, err := client.DeployWorkload(
+			containerID, _, err := client.DeployWorkload(
 				context.Background(),
 				"test-image",
 				"test-container",
@@ -667,7 +667,7 @@ func TestCreateContainerWithMCP(t *testing.T) {
 			}
 
 			// Deploy the workload
-			containerID, err := client.DeployWorkload(
+			containerID, _, err := client.DeployWorkload(
 				context.Background(),
 				tc.image,
 				"test-container",

--- a/pkg/container/runtime/types.go
+++ b/pkg/container/runtime/types.go
@@ -81,7 +81,7 @@ type Runtime interface {
 		transportType string,
 		options *DeployWorkloadOptions,
 		isolateNetwork bool,
-	) (string, error)
+	) (string, int, error)
 
 	// ListWorkloads lists all deployed workloads managed by this runtime.
 	// Returns information about each workload including its components,

--- a/pkg/runner/config_test.go
+++ b/pkg/runner/config_test.go
@@ -32,8 +32,8 @@ func (*mockRuntime) DeployWorkload(
 	_ string,
 	_ *rt.DeployWorkloadOptions,
 	_ bool,
-) (string, error) {
-	return "container-id", nil
+) (string, int, error) {
+	return "container-id", 8080, nil
 }
 
 func (*mockRuntime) StartContainer(_ context.Context, _ string) error {

--- a/pkg/transport/sse.go
+++ b/pkg/transport/sse.go
@@ -144,7 +144,7 @@ func (t *SSETransport) Setup(ctx context.Context, runtime rt.Runtime, containerN
 
 	// Create the container
 	logger.Infof("Deploying workload %s from image %s...", containerName, image)
-	containerID, err := t.runtime.DeployWorkload(
+	containerID, exposedPort, err := t.runtime.DeployWorkload(
 		ctx,
 		image,
 		containerName,
@@ -168,6 +168,9 @@ func (t *SSETransport) Setup(ctx context.Context, runtime rt.Runtime, containerN
 	if containerOptions.SSEHeadlessServiceName != "" {
 		t.targetHost = containerOptions.SSEHeadlessServiceName
 	}
+
+	// also override the exposed port, in case we need it via ingress
+	t.targetPort = exposedPort
 
 	return nil
 }

--- a/pkg/transport/stdio.go
+++ b/pkg/transport/stdio.go
@@ -110,7 +110,7 @@ func (t *StdioTransport) Setup(
 
 	// Create the container
 	logger.Infof("Deploying workload %s from image %s...", containerName, image)
-	containerID, err := t.runtime.DeployWorkload(
+	containerID, _, err := t.runtime.DeployWorkload(
 		ctx,
 		image,
 		containerName,

--- a/pkg/workloads/manager.go
+++ b/pkg/workloads/manager.go
@@ -233,6 +233,10 @@ func (*defaultManager) RunWorkloadDetached(runConfig *runner.RunConfig) error {
 		detachedArgs = append(detachedArgs, "--debug")
 	}
 
+	if runConfig.IsolateNetwork {
+		detachedArgs = append(detachedArgs, "--isolate-network")
+	}
+
 	// Use Name if available
 	if runConfig.Name != "" {
 		detachedArgs = append(detachedArgs, "--name", runConfig.Name)


### PR DESCRIPTION
with latest config changes released in docker version, our approach of reusing same port for ingress and upstream stopped working. Expose a different port in case of squid ingress, that fixes the issue