### PR TITLE
Fix `no exposed ports specified in options.ExposedPorts` bug

### DIFF
--- a/pkg/container/docker/client.go
+++ b/pkg/container/docker/client.go
@@ -462,20 +462,9 @@ func (c *Client) DeployWorkload(
 		return containerId, 0, nil
 	}
 
-	var firstPort string
-	if len(options.ExposedPorts) == 0 {
-		return "", 0, fmt.Errorf("no exposed ports specified in options.ExposedPorts")
-	}
-	for port := range options.ExposedPorts {
-		firstPort = port
-
-		// need to strip the protocol
-		firstPort = strings.Split(firstPort, "/")[0]
-		break // take only the first one
-	}
-	firstPortInt, err := strconv.Atoi(firstPort)
+	firstPortInt, err := extractFirstPort(options)
 	if err != nil {
-		return "", 0, fmt.Errorf("failed to convert port %s to int: %v", firstPort, err)
+		return "", 0, err // extractFirstPort already wraps the error with context.
 	}
 
 	if isolateNetwork {
@@ -486,6 +475,25 @@ func (c *Client) DeployWorkload(
 	}
 
 	return containerId, firstPortInt, nil
+}
+
+func extractFirstPort(options *runtime.DeployWorkloadOptions) (int, error) {
+	var firstPort string
+	if len(options.ExposedPorts) == 0 {
+		return 0, fmt.Errorf("no exposed ports specified in options.ExposedPorts")
+	}
+	for port := range options.ExposedPorts {
+		firstPort = port
+
+		// need to strip the protocol
+		firstPort = strings.Split(firstPort, "/")[0]
+		break // take only the first one
+	}
+	firstPortInt, err := strconv.Atoi(firstPort)
+	if err != nil {
+		return 0, fmt.Errorf("failed to convert port %s to int: %v", firstPort, err)
+	}
+	return firstPortInt, nil
 }
 
 // ListWorkloads lists workloads

--- a/pkg/container/docker/client.go
+++ b/pkg/container/docker/client.go
@@ -457,24 +457,25 @@ func (c *Client) DeployWorkload(
 		return "", 0, fmt.Errorf("failed to create mcp container: %v", err)
 	}
 
-	// now create ingress container
-	var firstPort string
-	if len(options.ExposedPorts) == 0 {
-		return "", 0, fmt.Errorf("no exposed ports specified in options.ExposedPorts")
-	}
-	for port := range options.ExposedPorts {
-		firstPort = port
-
-		// need to strip the protocol
-		firstPort = strings.Split(firstPort, "/")[0]
-		break // take only the first one
-	}
-	firstPortInt, err := strconv.Atoi(firstPort)
-	if err != nil {
-		return "", 0, fmt.Errorf("failed to convert port %s to int: %v", firstPort, err)
-	}
-
+	firstPortInt := 0
 	if isolateNetwork {
+		var firstPort string
+		// now create ingress container
+		if len(options.ExposedPorts) == 0 {
+			return "", 0, fmt.Errorf("no exposed ports specified in options.ExposedPorts")
+		}
+		for port := range options.ExposedPorts {
+			firstPort = port
+
+			// need to strip the protocol
+			firstPort = strings.Split(firstPort, "/")[0]
+			break // take only the first one
+		}
+		firstPortInt, err = strconv.Atoi(firstPort)
+		if err != nil {
+			return "", 0, fmt.Errorf("failed to convert port %s to int: %v", firstPort, err)
+		}
+
 		firstPortInt, err = c.createIngressContainer(ctx, name, firstPortInt, attachStdio, externalEndpointsConfig)
 		if err != nil {
 			return "", 0, fmt.Errorf("failed to create ingress container: %v", err)


### PR DESCRIPTION
As part of the network isolation changes, an assumption was introduced that all MCP servers have an exposed port. This is not the case for stdio - the proxy runner attaches to a stdio MCP server via the container's stdin/stdout. When the new code was run with a stdio container, the MCP container would run, the proxy runner process would die, and the following error would appear in the logs - `Error: failed to set up transport: failed to create container: no exposed ports specified in options.ExposedPorts`.

This PR changes the logic to skip parsing the exposed ports when the transport type is stdio.