### PR TITLE
Update network permission profiles in the registry

### DIFF
--- a/pkg/registry/data/registry.json
+++ b/pkg/registry/data/registry.json
@@ -1347,7 +1347,7 @@
             "allow_transport": [
               "tcp"
             ],
-            "insecure_allow_all": false
+            "insecure_allow_all": true
           }
         },
         "read": [],


### PR DESCRIPTION
In anticipation of the next release...

- Match subdomain matching to the implementation using squid's syntax
- Clean up some unneeded ports/protos for MCPs that don't need network
  connectivity
- Add specific allow_hosts for the Firecrawl, Netbird, and Terraform MCPs
- Not directly related, but also fixes the semgrep MCP's sse config which wasn't working before