### PR TITLE
Fix Windows build error

### DIFF
--- a/pkg/container/docker/sdk/client_windows.go
+++ b/pkg/container/docker/sdk/client_windows.go
@@ -17,6 +17,8 @@ import (
 	"github.com/stacklok/toolhive/pkg/logger"
 )
 
+var ErrRuntimeNotFound = fmt.Errorf("container runtime not found")
+
 // Windows named pipe paths
 const (
 	// DockerDesktopWindowsPipePath is the Docker Desktop named pipe path on Windows


### PR DESCRIPTION
The refactoring in #775 broke the build on Windows due to a missing variable. Added to match the Unix version.