### PR TITLE
Ensure proxy process is killed during workload delete

### DIFF
--- a/pkg/workloads/manager.go
+++ b/pkg/workloads/manager.go
@@ -538,6 +538,15 @@ func (d *defaultManager) DeleteWorkloads(_ context.Context, names []string) (*er
 			containerID := container.ID
 			containerLabels := container.Labels
 			baseName := labels.GetContainerBaseName(containerLabels)
+			isRunning := isContainerRunning(container)
+
+			if isRunning {
+				// Stop the proxy process first (like StopWorkload does)
+				logger.Infof("Removing proxy process for %s...", name)
+				if baseName != "" {
+					proxy.StopProcess(baseName)
+				}
+			}
 
 			// Remove the container
 			logger.Infof("Removing container %s...", name)


### PR DESCRIPTION
Recently, the delete workload was changed to not call the StopWorkload method since the runtime kill running containers for us. However, the call to delete the proxy runner was left out, leaving orphaned processes. This change will kill the proxy process if it is running.