### PR TITLE
Mute the version check output

### DIFF
--- a/cmd/thv/app/version.go
+++ b/cmd/thv/app/version.go
@@ -3,6 +3,7 @@ package app
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -46,6 +47,9 @@ func newVersionCmd() *cobra.Command {
 
 // printVersionInfo prints the version information
 func printVersionInfo(info versions.VersionInfo) {
+	if strings.HasPrefix(info.Version, "build-") {
+		fmt.Printf("You are running a local build of ToolHive\n\n")
+	}
 	fmt.Printf("ToolHive %s\n", info.Version)
 	fmt.Printf("Commit: %s\n", info.Commit)
 	fmt.Printf("Built: %s\n", info.BuildDate)

--- a/pkg/updates/checker.go
+++ b/pkg/updates/checker.go
@@ -127,7 +127,7 @@ func (d *defaultUpdateChecker) CheckLatestVersion() error {
 func notifyIfUpdateAvailable(current, latest string) {
 	// Print a meaningful message for people running local builds.
 	if strings.HasPrefix(current, "build-") {
-		fmt.Fprintf(os.Stderr, "You are running a local build of ToolHive, latest release is: %s\n", latest)
+		// No need to compare versions, user is already aware they are not on the latest release.
 		return
 	}
 	// Ensure both versions have the 'v' prefix for proper semantic version comparison
@@ -140,7 +140,5 @@ func notifyIfUpdateAvailable(current, latest string) {
 	// Compare the versions ensuring their canonical forms
 	if semver.Compare(semver.Canonical(current), semver.Canonical(latest)) < 0 {
 		fmt.Fprintf(os.Stderr, "A new version of ToolHive is available: %s\nCurrently running: %s\n", latest, current)
-	} else if semver.Compare(semver.Canonical(current), semver.Canonical(latest)) == 0 {
-		fmt.Fprintf(os.Stderr, "You are running the latest version of ToolHive: %s\n", current)
 	}
 }


### PR DESCRIPTION
The following PR reduces the clutter from the version checks.