### PR TITLE
Add OpenTelemetry Configuration Management

### DIFF
--- a/cmd/thv/app/config.go
+++ b/cmd/thv/app/config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -114,6 +115,84 @@ var unsetRegistryURLCmd = &cobra.Command{
 	RunE:  unsetRegistryURLCmdFunc,
 }
 
+var setOtelEndpointCmd = &cobra.Command{
+	Use:   "set-otel-endpoint <endpoint>",
+	Short: "Set the OpenTelemetry endpoint URL",
+	Long: `Set the OpenTelemetry OTLP endpoint URL for tracing and metrics.
+This endpoint will be used by default when running MCP servers unless overridden by the --otel-endpoint flag.
+
+Example:
+  thv config set-otel-endpoint https://api.honeycomb.io`,
+	Args: cobra.ExactArgs(1),
+	RunE: setOtelEndpointCmdFunc,
+}
+
+var getOtelEndpointCmd = &cobra.Command{
+	Use:   "get-otel-endpoint",
+	Short: "Get the currently configured OpenTelemetry endpoint",
+	Long:  "Display the OpenTelemetry endpoint URL that is currently configured.",
+	RunE:  getOtelEndpointCmdFunc,
+}
+
+var unsetOtelEndpointCmd = &cobra.Command{
+	Use:   "unset-otel-endpoint",
+	Short: "Remove the configured OpenTelemetry endpoint",
+	Long:  "Remove the OpenTelemetry endpoint configuration.",
+	RunE:  unsetOtelEndpointCmdFunc,
+}
+
+var setOtelSamplingRateCmd = &cobra.Command{
+	Use:   "set-otel-sampling-rate <rate>",
+	Short: "Set the OpenTelemetry sampling rate",
+	Long: `Set the OpenTelemetry trace sampling rate (between 0.0 and 1.0).
+This sampling rate will be used by default when running MCP servers unless overridden by the --otel-sampling-rate flag.
+
+Example:
+  thv config set-otel-sampling-rate 0.1`,
+	Args: cobra.ExactArgs(1),
+	RunE: setOtelSamplingRateCmdFunc,
+}
+
+var getOtelSamplingRateCmd = &cobra.Command{
+	Use:   "get-otel-sampling-rate",
+	Short: "Get the currently configured OpenTelemetry sampling rate",
+	Long:  "Display the OpenTelemetry sampling rate that is currently configured.",
+	RunE:  getOtelSamplingRateCmdFunc,
+}
+
+var unsetOtelSamplingRateCmd = &cobra.Command{
+	Use:   "unset-otel-sampling-rate",
+	Short: "Remove the configured OpenTelemetry sampling rate",
+	Long:  "Remove the OpenTelemetry sampling rate configuration.",
+	RunE:  unsetOtelSamplingRateCmdFunc,
+}
+
+var setOtelEnvVarsCmd = &cobra.Command{
+	Use:   "set-otel-env-vars <var1,var2,...>",
+	Short: "Set the OpenTelemetry environment variables",
+	Long: `Set the list of environment variable names to include in OpenTelemetry spans.
+These environment variables will be used by default when running MCP servers unless overridden by the --otel-env-vars flag.
+
+Example:
+  thv config set-otel-env-vars USER,HOME,PATH`,
+	Args: cobra.ExactArgs(1),
+	RunE: setOtelEnvVarsCmdFunc,
+}
+
+var getOtelEnvVarsCmd = &cobra.Command{
+	Use:   "get-otel-env-vars",
+	Short: "Get the currently configured OpenTelemetry environment variables",
+	Long:  "Display the OpenTelemetry environment variables that are currently configured.",
+	RunE:  getOtelEnvVarsCmdFunc,
+}
+
+var unsetOtelEnvVarsCmd = &cobra.Command{
+	Use:   "unset-otel-env-vars",
+	Short: "Remove the configured OpenTelemetry environment variables",
+	Long:  "Remove the OpenTelemetry environment variables configuration.",
+	RunE:  unsetOtelEnvVarsCmdFunc,
+}
+
 func init() {
 	// Add config command to root command
 	rootCmd.AddCommand(configCmd)
@@ -128,6 +207,15 @@ func init() {
 	configCmd.AddCommand(setRegistryURLCmd)
 	configCmd.AddCommand(getRegistryURLCmd)
 	configCmd.AddCommand(unsetRegistryURLCmd)
+	configCmd.AddCommand(setOtelEndpointCmd)
+	configCmd.AddCommand(getOtelEndpointCmd)
+	configCmd.AddCommand(unsetOtelEndpointCmd)
+	configCmd.AddCommand(setOtelSamplingRateCmd)
+	configCmd.AddCommand(getOtelSamplingRateCmd)
+	configCmd.AddCommand(unsetOtelSamplingRateCmd)
+	configCmd.AddCommand(setOtelEnvVarsCmd)
+	configCmd.AddCommand(getOtelEnvVarsCmd)
+	configCmd.AddCommand(unsetOtelEnvVarsCmd)
 }
 
 func registerClientCmdFunc(cmd *cobra.Command, args []string) error {
@@ -445,5 +533,164 @@ func listRegisteredClientsCmdFunc(_ *cobra.Command, _ []string) error {
 		fmt.Printf("  - %s\n", clientName)
 	}
 
+	return nil
+}
+
+func setOtelEndpointCmdFunc(_ *cobra.Command, args []string) error {
+	endpoint := args[0]
+
+	// The endpoint should not start with http:// or https://
+	if endpoint != "" && (strings.HasPrefix(endpoint, "http://") || strings.HasPrefix(endpoint, "https://")) {
+		return fmt.Errorf("endpoint URL should not start with http:// or https://")
+	}
+
+	// Update the configuration
+	err := config.UpdateConfig(func(c *config.Config) {
+		c.OTEL.Endpoint = endpoint
+	})
+	if err != nil {
+		return fmt.Errorf("failed to update configuration: %w", err)
+	}
+
+	fmt.Printf("Successfully set OpenTelemetry endpoint: %s\n", endpoint)
+	return nil
+}
+
+func getOtelEndpointCmdFunc(_ *cobra.Command, _ []string) error {
+	cfg := config.GetConfig()
+
+	if cfg.OTEL.Endpoint == "" {
+		fmt.Println("No OpenTelemetry endpoint is currently configured.")
+		return nil
+	}
+
+	fmt.Printf("Current OpenTelemetry endpoint: %s\n", cfg.OTEL.Endpoint)
+	return nil
+}
+
+func unsetOtelEndpointCmdFunc(_ *cobra.Command, _ []string) error {
+	cfg := config.GetConfig()
+
+	if cfg.OTEL.Endpoint == "" {
+		fmt.Println("No OpenTelemetry endpoint is currently configured.")
+		return nil
+	}
+
+	// Update the configuration
+	err := config.UpdateConfig(func(c *config.Config) {
+		c.OTEL.Endpoint = ""
+	})
+	if err != nil {
+		return fmt.Errorf("failed to update configuration: %w", err)
+	}
+
+	fmt.Println("Successfully removed OpenTelemetry endpoint configuration.")
+	return nil
+}
+
+func setOtelSamplingRateCmdFunc(_ *cobra.Command, args []string) error {
+	rate, err := strconv.ParseFloat(args[0], 64)
+	if err != nil {
+		return fmt.Errorf("invalid sampling rate format: %w", err)
+	}
+
+	// Validate the rate
+	if rate < 0.0 || rate > 1.0 {
+		return fmt.Errorf("sampling rate must be between 0.0 and 1.0")
+	}
+
+	// Update the configuration
+	err = config.UpdateConfig(func(c *config.Config) {
+		c.OTEL.SamplingRate = rate
+	})
+	if err != nil {
+		return fmt.Errorf("failed to update configuration: %w", err)
+	}
+
+	fmt.Printf("Successfully set OpenTelemetry sampling rate: %f\n", rate)
+	return nil
+}
+
+func getOtelSamplingRateCmdFunc(_ *cobra.Command, _ []string) error {
+	cfg := config.GetConfig()
+
+	if cfg.OTEL.SamplingRate == 0.0 {
+		fmt.Println("No OpenTelemetry sampling rate is currently configured.")
+		return nil
+	}
+
+	fmt.Printf("Current OpenTelemetry sampling rate: %f\n", cfg.OTEL.SamplingRate)
+	return nil
+}
+
+func unsetOtelSamplingRateCmdFunc(_ *cobra.Command, _ []string) error {
+	cfg := config.GetConfig()
+
+	if cfg.OTEL.SamplingRate == 0.0 {
+		fmt.Println("No OpenTelemetry sampling rate is currently configured.")
+		return nil
+	}
+
+	// Update the configuration
+	err := config.UpdateConfig(func(c *config.Config) {
+		c.OTEL.SamplingRate = 0.0
+	})
+	if err != nil {
+		return fmt.Errorf("failed to update configuration: %w", err)
+	}
+
+	fmt.Println("Successfully removed OpenTelemetry sampling rate configuration.")
+	return nil
+}
+
+func setOtelEnvVarsCmdFunc(_ *cobra.Command, args []string) error {
+	vars := strings.Split(args[0], ",")
+
+	// Trim whitespace from each variable name
+	for i, varName := range vars {
+		vars[i] = strings.TrimSpace(varName)
+	}
+
+	// Update the configuration
+	err := config.UpdateConfig(func(c *config.Config) {
+		c.OTEL.EnvVars = vars
+	})
+	if err != nil {
+		return fmt.Errorf("failed to update configuration: %w", err)
+	}
+
+	fmt.Printf("Successfully set OpenTelemetry environment variables: %v\n", vars)
+	return nil
+}
+
+func getOtelEnvVarsCmdFunc(_ *cobra.Command, _ []string) error {
+	cfg := config.GetConfig()
+
+	if len(cfg.OTEL.EnvVars) == 0 {
+		fmt.Println("No OpenTelemetry environment variables are currently configured.")
+		return nil
+	}
+
+	fmt.Printf("Current OpenTelemetry environment variables: %v\n", cfg.OTEL.EnvVars)
+	return nil
+}
+
+func unsetOtelEnvVarsCmdFunc(_ *cobra.Command, _ []string) error {
+	cfg := config.GetConfig()
+
+	if len(cfg.OTEL.EnvVars) == 0 {
+		fmt.Println("No OpenTelemetry environment variables are currently configured.")
+		return nil
+	}
+
+	// Update the configuration
+	err := config.UpdateConfig(func(c *config.Config) {
+		c.OTEL.EnvVars = []string{}
+	})
+	if err != nil {
+		return fmt.Errorf("failed to update configuration: %w", err)
+	}
+
+	fmt.Println("Successfully removed OpenTelemetry environment variables configuration.")
 	return nil
 }

--- a/docs/cli/thv_config.md
+++ b/docs/cli/thv_config.md
@@ -22,12 +22,21 @@ The config command provides subcommands to manage application configuration sett
 
 * [thv](thv.md)	 - ToolHive (thv) is a lightweight, secure, and fast manager for MCP servers
 * [thv config get-ca-cert](thv_config_get-ca-cert.md)	 - Get the currently configured CA certificate path
+* [thv config get-otel-endpoint](thv_config_get-otel-endpoint.md)	 - Get the currently configured OpenTelemetry endpoint
+* [thv config get-otel-env-vars](thv_config_get-otel-env-vars.md)	 - Get the currently configured OpenTelemetry environment variables
+* [thv config get-otel-sampling-rate](thv_config_get-otel-sampling-rate.md)	 - Get the currently configured OpenTelemetry sampling rate
 * [thv config get-registry-url](thv_config_get-registry-url.md)	 - Get the currently configured registry URL
 * [thv config list-registered-clients](thv_config_list-registered-clients.md)	 - List all registered MCP clients
 * [thv config register-client](thv_config_register-client.md)	 - Register a client for MCP server configuration
 * [thv config remove-client](thv_config_remove-client.md)	 - Remove a client from MCP server configuration
 * [thv config set-ca-cert](thv_config_set-ca-cert.md)	 - Set the default CA certificate for container builds
+* [thv config set-otel-endpoint](thv_config_set-otel-endpoint.md)	 - Set the OpenTelemetry endpoint URL
+* [thv config set-otel-env-vars](thv_config_set-otel-env-vars.md)	 - Set the OpenTelemetry environment variables
+* [thv config set-otel-sampling-rate](thv_config_set-otel-sampling-rate.md)	 - Set the OpenTelemetry sampling rate
 * [thv config set-registry-url](thv_config_set-registry-url.md)	 - Set the MCP server registry URL
 * [thv config unset-ca-cert](thv_config_unset-ca-cert.md)	 - Remove the configured CA certificate
+* [thv config unset-otel-endpoint](thv_config_unset-otel-endpoint.md)	 - Remove the configured OpenTelemetry endpoint
+* [thv config unset-otel-env-vars](thv_config_unset-otel-env-vars.md)	 - Remove the configured OpenTelemetry environment variables
+* [thv config unset-otel-sampling-rate](thv_config_unset-otel-sampling-rate.md)	 - Remove the configured OpenTelemetry sampling rate
 * [thv config unset-registry-url](thv_config_unset-registry-url.md)	 - Remove the configured registry URL
 

--- a/docs/cli/thv_config_get-otel-endpoint.md
+++ b/docs/cli/thv_config_get-otel-endpoint.md
@@ -1,0 +1,28 @@
+## thv config get-otel-endpoint
+
+Get the currently configured OpenTelemetry endpoint
+
+### Synopsis
+
+Display the OpenTelemetry endpoint URL that is currently configured.
+
+```
+thv config get-otel-endpoint [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for get-otel-endpoint
+```
+
+### Options inherited from parent commands
+
+```
+      --debug   Enable debug mode
+```
+
+### SEE ALSO
+
+* [thv config](thv_config.md)	 - Manage application configuration
+

--- a/docs/cli/thv_config_get-otel-env-vars.md
+++ b/docs/cli/thv_config_get-otel-env-vars.md
@@ -1,0 +1,28 @@
+## thv config get-otel-env-vars
+
+Get the currently configured OpenTelemetry environment variables
+
+### Synopsis
+
+Display the OpenTelemetry environment variables that are currently configured.
+
+```
+thv config get-otel-env-vars [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for get-otel-env-vars
+```
+
+### Options inherited from parent commands
+
+```
+      --debug   Enable debug mode
+```
+
+### SEE ALSO
+
+* [thv config](thv_config.md)	 - Manage application configuration
+

--- a/docs/cli/thv_config_get-otel-sampling-rate.md
+++ b/docs/cli/thv_config_get-otel-sampling-rate.md
@@ -1,0 +1,28 @@
+## thv config get-otel-sampling-rate
+
+Get the currently configured OpenTelemetry sampling rate
+
+### Synopsis
+
+Display the OpenTelemetry sampling rate that is currently configured.
+
+```
+thv config get-otel-sampling-rate [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for get-otel-sampling-rate
+```
+
+### Options inherited from parent commands
+
+```
+      --debug   Enable debug mode
+```
+
+### SEE ALSO
+
+* [thv config](thv_config.md)	 - Manage application configuration
+

--- a/docs/cli/thv_config_set-otel-endpoint.md
+++ b/docs/cli/thv_config_set-otel-endpoint.md
@@ -1,0 +1,32 @@
+## thv config set-otel-endpoint
+
+Set the OpenTelemetry endpoint URL
+
+### Synopsis
+
+Set the OpenTelemetry OTLP endpoint URL for tracing and metrics.
+This endpoint will be used by default when running MCP servers unless overridden by the --otel-endpoint flag.
+
+Example:
+  thv config set-otel-endpoint https://api.honeycomb.io
+
+```
+thv config set-otel-endpoint <endpoint> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for set-otel-endpoint
+```
+
+### Options inherited from parent commands
+
+```
+      --debug   Enable debug mode
+```
+
+### SEE ALSO
+
+* [thv config](thv_config.md)	 - Manage application configuration
+

--- a/docs/cli/thv_config_set-otel-env-vars.md
+++ b/docs/cli/thv_config_set-otel-env-vars.md
@@ -1,0 +1,32 @@
+## thv config set-otel-env-vars
+
+Set the OpenTelemetry environment variables
+
+### Synopsis
+
+Set the list of environment variable names to include in OpenTelemetry spans.
+These environment variables will be used by default when running MCP servers unless overridden by the --otel-env-vars flag.
+
+Example:
+  thv config set-otel-env-vars USER,HOME,PATH
+
+```
+thv config set-otel-env-vars <var1,var2,...> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for set-otel-env-vars
+```
+
+### Options inherited from parent commands
+
+```
+      --debug   Enable debug mode
+```
+
+### SEE ALSO
+
+* [thv config](thv_config.md)	 - Manage application configuration
+

--- a/docs/cli/thv_config_set-otel-sampling-rate.md
+++ b/docs/cli/thv_config_set-otel-sampling-rate.md
@@ -1,0 +1,32 @@
+## thv config set-otel-sampling-rate
+
+Set the OpenTelemetry sampling rate
+
+### Synopsis
+
+Set the OpenTelemetry trace sampling rate (between 0.0 and 1.0).
+This sampling rate will be used by default when running MCP servers unless overridden by the --otel-sampling-rate flag.
+
+Example:
+  thv config set-otel-sampling-rate 0.1
+
+```
+thv config set-otel-sampling-rate <rate> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for set-otel-sampling-rate
+```
+
+### Options inherited from parent commands
+
+```
+      --debug   Enable debug mode
+```
+
+### SEE ALSO
+
+* [thv config](thv_config.md)	 - Manage application configuration
+

--- a/docs/cli/thv_config_unset-otel-endpoint.md
+++ b/docs/cli/thv_config_unset-otel-endpoint.md
@@ -1,0 +1,28 @@
+## thv config unset-otel-endpoint
+
+Remove the configured OpenTelemetry endpoint
+
+### Synopsis
+
+Remove the OpenTelemetry endpoint configuration.
+
+```
+thv config unset-otel-endpoint [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for unset-otel-endpoint
+```
+
+### Options inherited from parent commands
+
+```
+      --debug   Enable debug mode
+```
+
+### SEE ALSO
+
+* [thv config](thv_config.md)	 - Manage application configuration
+

--- a/docs/cli/thv_config_unset-otel-env-vars.md
+++ b/docs/cli/thv_config_unset-otel-env-vars.md
@@ -1,0 +1,28 @@
+## thv config unset-otel-env-vars
+
+Remove the configured OpenTelemetry environment variables
+
+### Synopsis
+
+Remove the OpenTelemetry environment variables configuration.
+
+```
+thv config unset-otel-env-vars [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for unset-otel-env-vars
+```
+
+### Options inherited from parent commands
+
+```
+      --debug   Enable debug mode
+```
+
+### SEE ALSO
+
+* [thv config](thv_config.md)	 - Manage application configuration
+

--- a/docs/cli/thv_config_unset-otel-sampling-rate.md
+++ b/docs/cli/thv_config_unset-otel-sampling-rate.md
@@ -1,0 +1,28 @@
+## thv config unset-otel-sampling-rate
+
+Remove the configured OpenTelemetry sampling rate
+
+### Synopsis
+
+Remove the OpenTelemetry sampling rate configuration.
+
+```
+thv config unset-otel-sampling-rate [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for unset-otel-sampling-rate
+```
+
+### Options inherited from parent commands
+
+```
+      --debug   Enable debug mode
+```
+
+### SEE ALSO
+
+* [thv config](thv_config.md)	 - Manage application configuration
+

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -23,10 +23,11 @@ const lockTimeout = 1 * time.Second
 
 // Config represents the configuration of the application.
 type Config struct {
-	Secrets           Secrets `yaml:"secrets"`
-	Clients           Clients `yaml:"clients"`
-	RegistryUrl       string  `yaml:"registry_url"`
-	CACertificatePath string  `yaml:"ca_certificate_path,omitempty"`
+	Secrets           Secrets             `yaml:"secrets"`
+	Clients           Clients             `yaml:"clients"`
+	RegistryUrl       string              `yaml:"registry_url"`
+	CACertificatePath string              `yaml:"ca_certificate_path,omitempty"`
+	OTEL              OpenTelemetryConfig `yaml:"otel,omitempty"`
 }
 
 // Secrets contains the settings for secrets management.
@@ -268,4 +269,11 @@ func UpdateConfigAtPath(configPath string, updateFn func(*Config)) error {
 
 	// Lock is released automatically when the function returns.
 	return nil
+}
+
+// OpenTelemetryConfig contains the settings for OpenTelemetry configuration.
+type OpenTelemetryConfig struct {
+	Endpoint     string   `yaml:"endpoint,omitempty"`
+	SamplingRate float64  `yaml:"sampling-rate,omitempty"`
+	EnvVars      []string `yaml:"env-vars,omitempty"`
 }


### PR DESCRIPTION
Issue: https://github.com/stacklok/toolhive/issues/860

This commit introduces new commands for managing OpenTelemetry settings in the application, including setting, getting, and unsetting the OpenTelemetry endpoint, sampling rate, and environment variables. The configuration structure has been updated to include an OpenTelemetryConfig type, allowing for better management of these settings. Additionally, the run command has been modified to utilize these new configuration options as fallbacks.

New commands added:
- set-otel-endpoint
- get-otel-endpoint
- unset-otel-endpoint
- set-otel-sampling-rate
- get-otel-sampling-rate
- unset-otel-sampling-rate
- set-otel-env-vars
- get-otel-env-vars
- unset-otel-env-vars

Documentation for the new commands has also been created.