### PR TITLE
fix: normalize last_updated format in registry

### DIFF
--- a/cmd/regup/app/update.go
+++ b/cmd/regup/app/update.go
@@ -186,7 +186,7 @@ func saveResults(reg *registry.Registry, updatedServers []string) error {
 	// If we updated any servers, save the registry
 	if len(updatedServers) > 0 {
 		// Update the last_updated timestamp
-		reg.LastUpdated = time.Now().Format("2006-01-02 15:04:05")
+		reg.LastUpdated = time.Now().UTC().Format(time.RFC3339)
 
 		// Save the updated registry
 		if err := saveRegistry(reg, updatedServers); err != nil {
@@ -240,7 +240,7 @@ func updateServerInfo(name string, server *registry.ImageMetadata) error {
 	// Update the metadata
 	server.Metadata.Stars = stars
 	server.Metadata.Pulls = pulls
-	server.Metadata.LastUpdated = time.Now().Format(time.RFC3339)
+	server.Metadata.LastUpdated = time.Now().UTC().Format(time.RFC3339)
 
 	return nil
 }

--- a/cmd/regup/app/update_test.go
+++ b/cmd/regup/app/update_test.go
@@ -171,7 +171,7 @@ func setupTestRegistryWithMultipleServers(t *testing.T) (string, func()) {
 
 	// Create test registry with multiple servers
 	testRegistry := &registry.Registry{
-		LastUpdated: "2025-06-17 12:00:00",
+		LastUpdated: "2025-06-16T12:00:00Z",
 		Servers: map[string]*registry.ImageMetadata{
 			"github": {
 				Name:          "github",
@@ -236,7 +236,7 @@ func setupEmptyTestRegistry(t *testing.T) (string, func()) {
 
 	// Create empty test registry
 	testRegistry := &registry.Registry{
-		LastUpdated: "2025-06-17 12:00:00",
+		LastUpdated: "2025-06-16T12:00:00Z",
 		Servers:     map[string]*registry.ImageMetadata{},
 	}
 

--- a/pkg/registry/data/registry.json
+++ b/pkg/registry/data/registry.json
@@ -1,5 +1,5 @@
 {
-  "last_updated": "2025-06-26 00:21:54",
+  "last_updated": "2025-06-26T21:14:24Z",
   "servers": {
     "atlassian": {
       "args": [],
@@ -334,9 +334,9 @@
       ],
       "image": "mcp/elasticsearch:latest",
       "metadata": {
-        "last_updated": "2025-06-26T13:29:23-04:00",
-        "pulls": 4703,
-        "stars": 298
+        "last_updated": "2025-06-26T21:14:24Z",
+        "pulls": 5187,
+        "stars": 299
       },
       "permissions": {
         "network": {


### PR DESCRIPTION
Makes the top-level last_updated RFC3339 format to match the individual server entries.

Also normalizes both to UTC, which is what ends up happening in the scheduled run anyway.