### PR TITLE
Fix issue with starting workload over API

### DIFF
--- a/pkg/api/v1/workloads.go
+++ b/pkg/api/v1/workloads.go
@@ -283,6 +283,14 @@ func (s *WorkloadRoutes) createWorkload(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	// Start workload with specified RunConfig.
+	err = s.manager.RunWorkloadDetached(runConfig)
+	if err != nil {
+		logger.Errorf("Failed to start workload: %v", err)
+		http.Error(w, "Failed to start workload", http.StatusInternalServerError)
+		return
+	}
+
 	// Return name so that the client will get the auto-generated name.
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)


### PR DESCRIPTION
When cleaning up some unused code, I deleted a necessary function by mistake. This will reinstate it.