### PR TITLE
Add new fields to registry info output

### DIFF
--- a/cmd/thv/app/registry.go
+++ b/cmd/thv/app/registry.go
@@ -154,11 +154,14 @@ func printTextServerInfo(name string, server *registry.ImageMetadata) {
 	fmt.Printf("Name: %s\n", server.Name)
 	fmt.Printf("Image: %s\n", server.Image)
 	fmt.Printf("Description: %s\n", server.Description)
+	fmt.Printf("Tier: %s\n", server.Tier)
+	fmt.Printf("Status: %s\n", server.Status)
 	fmt.Printf("Transport: %s\n", server.Transport)
 	if (server.Transport == "sse" || server.Transport == "streamable-http") && server.TargetPort > 0 {
 		fmt.Printf("Target Port: %d\n", server.TargetPort)
 	}
 	fmt.Printf("Repository URL: %s\n", server.RepositoryURL)
+	fmt.Printf("Has Provenance: %s\n", map[bool]string{true: "Yes", false: "No"}[server.Provenance != nil])
 
 	if server.Metadata != nil {
 		fmt.Printf("Popularity: %d stars, %d pulls\n", server.Metadata.Stars, server.Metadata.Pulls)


### PR DESCRIPTION
Include additional fields for Tier, Status, and Provenance in the `thv registry info` text-formatted output.

Old:
```text
Name: github
Image: ghcr.io/github/github-mcp-server:latest
Description: The GitHub MCP Server provides seamless integration with GitHub APIs, enabling advanced automation and interaction capabilities for developers and tools
Transport: stdio
Repository URL: https://github.com/github/github-mcp-server
Popularity: 16397 stars, 5000 pulls
Last Updated: 2025-06-26T00:21:51Z
```

New:
```text
Name: github
Image: ghcr.io/github/github-mcp-server:latest
Description: The GitHub MCP Server provides seamless integration with GitHub APIs, enabling advanced automation and interaction capabilities for developers and tools
Tier: Official
Status: Active
Transport: stdio
Repository URL: https://github.com/github/github-mcp-server
Has Provenance: Yes
Popularity: 16453 stars, 5000 pulls
Last Updated: 2025-06-27T00:22:09Z
```