### PR TITLE
Allow setting environment variables for the proxy through operator CRDs

### DIFF
--- a/cmd/thv-operator/api/v1alpha1/mcpserver_types.go
+++ b/cmd/thv-operator/api/v1alpha1/mcpserver_types.go
@@ -36,6 +36,11 @@ type MCPServerSpec struct {
 	// +optional
 	Env []EnvVar `json:"env,omitempty"`
 
+	// ProxyEnv are environment variables to set in the proxy container (thv run process)
+	// These affect the toolhive proxy itself, not the MCP server it manages
+	// +optional
+	ProxyEnv []EnvVar `json:"proxyEnv,omitempty"`
+
 	// Volumes are volumes to mount in the MCP server container
 	// +optional
 	Volumes []Volume `json:"volumes,omitempty"`

--- a/cmd/thv-operator/api/v1alpha1/zz_generated.deepcopy.go
+++ b/cmd/thv-operator/api/v1alpha1/zz_generated.deepcopy.go
@@ -158,6 +158,11 @@ func (in *MCPServerSpec) DeepCopyInto(out *MCPServerSpec) {
 		*out = make([]EnvVar, len(*in))
 		copy(*out, *in)
 	}
+	if in.ProxyEnv != nil {
+		in, out := &in.ProxyEnv, &out.ProxyEnv
+		*out = make([]EnvVar, len(*in))
+		copy(*out, *in)
+	}
 	if in.Volumes != nil {
 		in, out := &in.Volumes, &out.Volumes
 		*out = make([]Volume, len(*in))

--- a/cmd/thv-operator/controllers/mcpserver_controller.go
+++ b/cmd/thv-operator/controllers/mcpserver_controller.go
@@ -431,6 +431,14 @@ func (r *MCPServerReconciler) deploymentForMCPServer(m *mcpv1alpha1.MCPServer) *
 	// Prepare container env vars for the proxy container
 	env := []corev1.EnvVar{}
 
+	// Add user-specified proxy environment variables
+	for _, envVar := range m.Spec.ProxyEnv {
+		env = append(env, corev1.EnvVar{
+			Name:  envVar.Name,
+			Value: envVar.Value,
+		})
+	}
+
 	// Prepare container volume mounts
 	volumeMounts := []corev1.VolumeMount{}
 	volumes := []corev1.Volume{}

--- a/deploy/charts/operator-crds/Chart.yaml
+++ b/deploy/charts/operator-crds/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: toolhive-operator-crds
 description: A Helm chart for installing the ToolHive Operator CRDs into Kubernetes.
 type: application
-version: 0.0.7
+version: 0.0.8
 appVersion: "0.0.1"

--- a/deploy/charts/operator-crds/README.md
+++ b/deploy/charts/operator-crds/README.md
@@ -1,7 +1,7 @@
 
 # ToolHive Operator CRDs Helm Chart
 
-![Version: 0.0.7](https://img.shields.io/badge/Version-0.0.7-informational?style=flat-square)
+![Version: 0.0.8](https://img.shields.io/badge/Version-0.0.8-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for installing the ToolHive Operator CRDs into Kubernetes.

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpservers.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpservers.yaml
@@ -8219,6 +8219,24 @@ spec:
                 maximum: 65535
                 minimum: 1
                 type: integer
+              proxyEnv:
+                description: |-
+                  ProxyEnv are environment variables to set in the proxy container (thv run process)
+                  These affect the toolhive proxy itself, not the MCP server it manages
+                items:
+                  description: EnvVar represents an environment variable in a container
+                  properties:
+                    name:
+                      description: Name of the environment variable
+                      type: string
+                    value:
+                      description: Value of the environment variable
+                      type: string
+                  required:
+                  - name
+                  - value
+                  type: object
+                type: array
               resourceOverrides:
                 description: ResourceOverrides allows overriding annotations and labels
                   for resources created by the operator

--- a/docs/operator/crd-api.md
+++ b/docs/operator/crd-api.md
@@ -168,6 +168,7 @@ _Appears in:_
 | `targetPort` _integer_ | TargetPort is the port that MCP server listens to |  | Maximum: 65535 <br />Minimum: 1 <br /> |
 | `args` _string array_ | Args are additional arguments to pass to the MCP server |  |  |
 | `env` _[EnvVar](#envvar) array_ | Env are environment variables to set in the MCP server container |  |  |
+| `proxyEnv` _[EnvVar](#envvar) array_ | ProxyEnv are environment variables to set in the proxy container (thv run process)<br />These affect the toolhive proxy itself, not the MCP server it manages |  |  |
 | `volumes` _[Volume](#volume) array_ | Volumes are volumes to mount in the MCP server container |  |  |
 | `resources` _[ResourceRequirements](#resourcerequirements)_ | Resources defines the resource requirements for the MCP server container |  |  |
 | `secrets` _[SecretRef](#secretref) array_ | Secrets are references to secrets to mount in the MCP server container |  |  |


### PR DESCRIPTION
- **Allow setting environment for the proxy server through the operator**
In some cases it's useful to set an environment variable for the proxy
runner itself. I used it locally to work around issue #886.

This patch adds a new field `proxyEnv` that the user can use to pass
key-value pairs to the runner.

Example use:
```
	proxyEnv:
		- name: XDG_CONFIG_HOME
		value: "/dev/shm/xdg-config-home"
```

- **Set a default value of XDG_CONFIG_HOME for the pods spawned by the operator**
Since the operator can't spawn pods with the current cgr images, let's
add a working value of XDG_CONFIG_HOME by default.

Related: #886

