### PR TITLE
Trigger remote docs workflow on operator releases

### DIFF
--- a/.github/workflows/update-docs-website.yml
+++ b/.github/workflows/update-docs-website.yml
@@ -8,9 +8,6 @@ on:
 
 jobs:
   trigger:
-    # Don't trigger on operator releases
-    # On a release event, ref is the release tag
-    if: ${{ startsWith(github.event.release.tag_name, 'v') }}
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
The update script in the docs repo now handles operator releases (currently, to refresh the CRD reference if updated), so this removes the release tag conditional on the triggering run.