### PR TITLE
feat: add MCP debug commands for listing tools, resources, and prompts

### DIFF
--- a/cmd/thv/app/commands.go
+++ b/cmd/thv/app/commands.go
@@ -51,6 +51,7 @@ func NewRootCmd(enableUpdates bool) *cobra.Command {
 	rootCmd.AddCommand(logsCommand())
 	rootCmd.AddCommand(newSecretCommand())
 	rootCmd.AddCommand(inspectorCommand())
+	rootCmd.AddCommand(newMCPCommand())
 
 	// Silence printing the usage on error
 	rootCmd.SilenceUsage = true

--- a/cmd/thv/app/mcp.go
+++ b/cmd/thv/app/mcp.go
@@ -1,0 +1,336 @@
+package app
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"text/tabwriter"
+	"time"
+
+	"github.com/mark3labs/mcp-go/client"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/spf13/cobra"
+
+	"github.com/stacklok/toolhive/pkg/logger"
+	"github.com/stacklok/toolhive/pkg/versions"
+)
+
+var (
+	mcpServerURL string
+	mcpFormat    string
+	mcpTimeout   time.Duration
+)
+
+func newMCPCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "mcp",
+		Short: "Interact with MCP servers for debugging",
+		Long:  `The mcp command provides subcommands to interact with MCP (Model Context Protocol) servers for debugging purposes.`,
+	}
+
+	// Create list command
+	listCmd := &cobra.Command{
+		Use:   "list [tools|resources|prompts]",
+		Short: "List MCP server capabilities",
+		Long:  `List tools, resources, and prompts available from an MCP server. Use subcommands to list specific types.`,
+		RunE:  mcpListCmdFunc,
+	}
+
+	// Create specific list subcommands
+	toolsCmd := &cobra.Command{
+		Use:   "tools",
+		Short: "List available tools from MCP server",
+		Long:  `List all tools available from the specified MCP server.`,
+		RunE:  mcpListToolsCmdFunc,
+	}
+
+	resourcesCmd := &cobra.Command{
+		Use:   "resources",
+		Short: "List available resources from MCP server",
+		Long:  `List all resources available from the specified MCP server.`,
+		RunE:  mcpListResourcesCmdFunc,
+	}
+
+	promptsCmd := &cobra.Command{
+		Use:   "prompts",
+		Short: "List available prompts from MCP server",
+		Long:  `List all prompts available from the specified MCP server.`,
+		RunE:  mcpListPromptsCmdFunc,
+	}
+
+	// Add flags to all MCP commands
+	addMCPFlags(listCmd)
+	addMCPFlags(toolsCmd)
+	addMCPFlags(resourcesCmd)
+	addMCPFlags(promptsCmd)
+
+	// Add specific list subcommands to list command
+	listCmd.AddCommand(toolsCmd)
+	listCmd.AddCommand(resourcesCmd)
+	listCmd.AddCommand(promptsCmd)
+
+	// Add list subcommand to mcp
+	cmd.AddCommand(listCmd)
+
+	return cmd
+}
+
+func addMCPFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&mcpServerURL, "server", "", "MCP server URL (required)")
+	cmd.Flags().StringVar(&mcpFormat, "format", FormatText, "Output format (json or text)")
+	cmd.Flags().DurationVar(&mcpTimeout, "timeout", 30*time.Second, "Connection timeout")
+	_ = cmd.MarkFlagRequired("server")
+}
+
+// mcpListCmdFunc lists all capabilities (tools, resources, prompts)
+func mcpListCmdFunc(cmd *cobra.Command, _ []string) error {
+	ctx, cancel := context.WithTimeout(cmd.Context(), mcpTimeout)
+	defer cancel()
+
+	mcpClient, err := createMCPClient()
+	if err != nil {
+		return err
+	}
+	defer mcpClient.Close()
+
+	if err := initializeMCPClient(ctx, mcpClient); err != nil {
+		return err
+	}
+
+	// Collect all data
+	data := make(map[string]interface{})
+
+	// List tools
+	if tools, err := mcpClient.ListTools(ctx, mcp.ListToolsRequest{}); err != nil {
+		logger.Warnf("Failed to list tools: %v", err)
+		data["tools"] = []mcp.Tool{}
+	} else {
+		data["tools"] = tools.Tools
+	}
+
+	// List resources
+	if resources, err := mcpClient.ListResources(ctx, mcp.ListResourcesRequest{}); err != nil {
+		logger.Warnf("Failed to list resources: %v", err)
+		data["resources"] = []mcp.Resource{}
+	} else {
+		data["resources"] = resources.Resources
+	}
+
+	// List prompts
+	if prompts, err := mcpClient.ListPrompts(ctx, mcp.ListPromptsRequest{}); err != nil {
+		logger.Warnf("Failed to list prompts: %v", err)
+		data["prompts"] = []mcp.Prompt{}
+	} else {
+		data["prompts"] = prompts.Prompts
+	}
+
+	return outputMCPData(data, mcpFormat)
+}
+
+// mcpListToolsCmdFunc lists only tools
+func mcpListToolsCmdFunc(cmd *cobra.Command, _ []string) error {
+	ctx, cancel := context.WithTimeout(cmd.Context(), mcpTimeout)
+	defer cancel()
+
+	mcpClient, err := createMCPClient()
+	if err != nil {
+		return err
+	}
+	defer mcpClient.Close()
+
+	if err := initializeMCPClient(ctx, mcpClient); err != nil {
+		return err
+	}
+
+	result, err := mcpClient.ListTools(ctx, mcp.ListToolsRequest{})
+	if err != nil {
+		return fmt.Errorf("failed to list tools: %w", err)
+	}
+
+	return outputMCPData(map[string]interface{}{"tools": result.Tools}, mcpFormat)
+}
+
+// mcpListResourcesCmdFunc lists only resources
+func mcpListResourcesCmdFunc(cmd *cobra.Command, _ []string) error {
+	ctx, cancel := context.WithTimeout(cmd.Context(), mcpTimeout)
+	defer cancel()
+
+	mcpClient, err := createMCPClient()
+	if err != nil {
+		return err
+	}
+	defer mcpClient.Close()
+
+	if err := initializeMCPClient(ctx, mcpClient); err != nil {
+		return err
+	}
+
+	result, err := mcpClient.ListResources(ctx, mcp.ListResourcesRequest{})
+	if err != nil {
+		return fmt.Errorf("failed to list resources: %w", err)
+	}
+
+	return outputMCPData(map[string]interface{}{"resources": result.Resources}, mcpFormat)
+}
+
+// mcpListPromptsCmdFunc lists only prompts
+func mcpListPromptsCmdFunc(cmd *cobra.Command, _ []string) error {
+	ctx, cancel := context.WithTimeout(cmd.Context(), mcpTimeout)
+	defer cancel()
+
+	mcpClient, err := createMCPClient()
+	if err != nil {
+		return err
+	}
+	defer mcpClient.Close()
+
+	if err := initializeMCPClient(ctx, mcpClient); err != nil {
+		return err
+	}
+
+	result, err := mcpClient.ListPrompts(ctx, mcp.ListPromptsRequest{})
+	if err != nil {
+		return fmt.Errorf("failed to list prompts: %w", err)
+	}
+
+	return outputMCPData(map[string]interface{}{"prompts": result.Prompts}, mcpFormat)
+}
+
+// createMCPClient creates an MCP client based on the server URL
+func createMCPClient() (*client.Client, error) {
+	// For now, we'll use SSE client as the default
+	// In the future, we could auto-detect or allow specifying the transport type
+	mcpClient, err := client.NewSSEMCPClient(mcpServerURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create MCP client: %w", err)
+	}
+	return mcpClient, nil
+}
+
+// initializeMCPClient initializes the MCP client connection
+func initializeMCPClient(ctx context.Context, mcpClient *client.Client) error {
+	// Start the transport
+	if err := mcpClient.Start(ctx); err != nil {
+		return fmt.Errorf("failed to start MCP transport: %w", err)
+	}
+
+	// Initialize the connection
+	initRequest := mcp.InitializeRequest{}
+	initRequest.Params.ProtocolVersion = mcp.LATEST_PROTOCOL_VERSION
+	initRequest.Params.Capabilities = mcp.ClientCapabilities{
+		// Basic client capabilities for listing
+	}
+	versionInfo := versions.GetVersionInfo()
+	initRequest.Params.ClientInfo = mcp.Implementation{
+		Name:    "toolhive-cli",
+		Version: versionInfo.Version,
+	}
+
+	_, err := mcpClient.Initialize(ctx, initRequest)
+	if err != nil {
+		return fmt.Errorf("failed to initialize MCP client: %w", err)
+	}
+
+	return nil
+}
+
+// outputMCPData outputs the MCP data in the specified format
+func outputMCPData(data map[string]interface{}, format string) error {
+	switch format {
+	case FormatJSON:
+		return outputMCPJSON(data)
+	default:
+		return outputMCPText(data)
+	}
+}
+
+// outputMCPJSON outputs MCP data in JSON format
+func outputMCPJSON(data map[string]interface{}) error {
+	jsonData, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal JSON: %w", err)
+	}
+	fmt.Println(string(jsonData))
+	return nil
+}
+
+// outputMCPText outputs MCP data in text format
+func outputMCPText(data map[string]interface{}) error {
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+
+	hasData := outputMCPTools(w, data) ||
+		outputMCPResources(w, data) ||
+		outputMCPPrompts(w, data)
+
+	if !hasData {
+		fmt.Println("No tools, resources, or prompts found")
+		return nil
+	}
+
+	return w.Flush()
+}
+
+// outputMCPTools outputs tools data to the tabwriter
+func outputMCPTools(w *tabwriter.Writer, data map[string]interface{}) bool {
+	tools, ok := data["tools"].([]mcp.Tool)
+	if !ok || len(tools) == 0 {
+		return false
+	}
+
+	fmt.Fprintln(w, "TOOLS:")
+	fmt.Fprintln(w, "NAME\tDESCRIPTION")
+	for _, tool := range tools {
+		fmt.Fprintf(w, "%s\t%s\n", tool.Name, tool.Description)
+	}
+	fmt.Fprintln(w, "")
+	return true
+}
+
+// outputMCPResources outputs resources data to the tabwriter
+func outputMCPResources(w *tabwriter.Writer, data map[string]interface{}) bool {
+	resources, ok := data["resources"].([]mcp.Resource)
+	if !ok || len(resources) == 0 {
+		return false
+	}
+
+	fmt.Fprintln(w, "RESOURCES:")
+	fmt.Fprintln(w, "NAME\tURI\tDESCRIPTION\tMIME_TYPE")
+	for _, resource := range resources {
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n",
+			resource.Name, resource.URI, resource.Description, resource.MIMEType)
+	}
+	fmt.Fprintln(w, "")
+	return true
+}
+
+// outputMCPPrompts outputs prompts data to the tabwriter
+func outputMCPPrompts(w *tabwriter.Writer, data map[string]interface{}) bool {
+	prompts, ok := data["prompts"].([]mcp.Prompt)
+	if !ok || len(prompts) == 0 {
+		return false
+	}
+
+	fmt.Fprintln(w, "PROMPTS:")
+	fmt.Fprintln(w, "NAME\tDESCRIPTION\tARGUMENTS")
+	for _, prompt := range prompts {
+		argStr := formatPromptArguments(prompt.Arguments)
+		fmt.Fprintf(w, "%s\t%s\t%s\n", prompt.Name, prompt.Description, argStr)
+	}
+	fmt.Fprintln(w, "")
+	return true
+}
+
+// formatPromptArguments formats the prompt arguments for display
+func formatPromptArguments(arguments []mcp.PromptArgument) string {
+	argCount := len(arguments)
+	if argCount == 0 {
+		return "0"
+	}
+
+	argNames := make([]string, len(arguments))
+	for i, arg := range arguments {
+		argNames[i] = arg.Name
+	}
+	return fmt.Sprintf("%d (%v)", argCount, argNames)
+}

--- a/docs/cli/thv.md
+++ b/docs/cli/thv.md
@@ -29,6 +29,7 @@ thv [flags]
 * [thv inspector](thv_inspector.md)	 - Launches the MCP Inspector UI and connects it to the specified MCP server
 * [thv list](thv_list.md)	 - List running MCP servers
 * [thv logs](thv_logs.md)	 - Output the logs of an MCP server or manage log files
+* [thv mcp](thv_mcp.md)	 - Interact with MCP servers for debugging
 * [thv proxy](thv_proxy.md)	 - Create a transparent proxy for an MCP server with authentication support
 * [thv registry](thv_registry.md)	 - Manage MCP server registry
 * [thv restart](thv_restart.md)	 - Restart a tooling server

--- a/docs/cli/thv_mcp.md
+++ b/docs/cli/thv_mcp.md
@@ -1,0 +1,25 @@
+## thv mcp
+
+Interact with MCP servers for debugging
+
+### Synopsis
+
+The mcp command provides subcommands to interact with MCP (Model Context Protocol) servers for debugging purposes.
+
+### Options
+
+```
+  -h, --help   help for mcp
+```
+
+### Options inherited from parent commands
+
+```
+      --debug   Enable debug mode
+```
+
+### SEE ALSO
+
+* [thv](thv.md)	 - ToolHive (thv) is a lightweight, secure, and fast manager for MCP servers
+* [thv mcp list](thv_mcp_list.md)	 - List MCP server capabilities
+

--- a/docs/cli/thv_mcp_list.md
+++ b/docs/cli/thv_mcp_list.md
@@ -1,0 +1,34 @@
+## thv mcp list
+
+List MCP server capabilities
+
+### Synopsis
+
+List tools, resources, and prompts available from an MCP server. Use subcommands to list specific types.
+
+```
+thv mcp list [tools|resources|prompts] [flags]
+```
+
+### Options
+
+```
+      --format string      Output format (json or text) (default "text")
+  -h, --help               help for list
+      --server string      MCP server URL (required)
+      --timeout duration   Connection timeout (default 30s)
+```
+
+### Options inherited from parent commands
+
+```
+      --debug   Enable debug mode
+```
+
+### SEE ALSO
+
+* [thv mcp](thv_mcp.md)	 - Interact with MCP servers for debugging
+* [thv mcp list prompts](thv_mcp_list_prompts.md)	 - List available prompts from MCP server
+* [thv mcp list resources](thv_mcp_list_resources.md)	 - List available resources from MCP server
+* [thv mcp list tools](thv_mcp_list_tools.md)	 - List available tools from MCP server
+

--- a/docs/cli/thv_mcp_list_prompts.md
+++ b/docs/cli/thv_mcp_list_prompts.md
@@ -1,0 +1,31 @@
+## thv mcp list prompts
+
+List available prompts from MCP server
+
+### Synopsis
+
+List all prompts available from the specified MCP server.
+
+```
+thv mcp list prompts [flags]
+```
+
+### Options
+
+```
+      --format string      Output format (json or text) (default "text")
+  -h, --help               help for prompts
+      --server string      MCP server URL (required)
+      --timeout duration   Connection timeout (default 30s)
+```
+
+### Options inherited from parent commands
+
+```
+      --debug   Enable debug mode
+```
+
+### SEE ALSO
+
+* [thv mcp list](thv_mcp_list.md)	 - List MCP server capabilities
+

--- a/docs/cli/thv_mcp_list_resources.md
+++ b/docs/cli/thv_mcp_list_resources.md
@@ -1,0 +1,31 @@
+## thv mcp list resources
+
+List available resources from MCP server
+
+### Synopsis
+
+List all resources available from the specified MCP server.
+
+```
+thv mcp list resources [flags]
+```
+
+### Options
+
+```
+      --format string      Output format (json or text) (default "text")
+  -h, --help               help for resources
+      --server string      MCP server URL (required)
+      --timeout duration   Connection timeout (default 30s)
+```
+
+### Options inherited from parent commands
+
+```
+      --debug   Enable debug mode
+```
+
+### SEE ALSO
+
+* [thv mcp list](thv_mcp_list.md)	 - List MCP server capabilities
+

--- a/docs/cli/thv_mcp_list_tools.md
+++ b/docs/cli/thv_mcp_list_tools.md
@@ -1,0 +1,31 @@
+## thv mcp list tools
+
+List available tools from MCP server
+
+### Synopsis
+
+List all tools available from the specified MCP server.
+
+```
+thv mcp list tools [flags]
+```
+
+### Options
+
+```
+      --format string      Output format (json or text) (default "text")
+  -h, --help               help for tools
+      --server string      MCP server URL (required)
+      --timeout duration   Connection timeout (default 30s)
+```
+
+### Options inherited from parent commands
+
+```
+      --debug   Enable debug mode
+```
+
+### SEE ALSO
+
+* [thv mcp list](thv_mcp_list.md)	 - List MCP server capabilities
+


### PR DESCRIPTION
Note: Originally opened by Ozz.

- Add new 'thv mcp' subcommand for debugging MCP servers
- Support listing tools, resources, and prompts from MCP servers
- Provide both JSON and text output formats
- Include timeout and server URL configuration options
- Use mcp-go library for MCP protocol communication
- Add proper error handling for unsupported capabilities
- Follow existing code patterns and pass all linting checks

This enables developers to easily inspect MCP server capabilities for debugging and development purposes.