### PR TITLE
Log the Cedar diagnostics policy

### DIFF
--- a/pkg/authz/cedar.go
+++ b/pkg/authz/cedar.go
@@ -13,6 +13,7 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 
 	"github.com/stacklok/toolhive/pkg/auth"
+	"github.com/stacklok/toolhive/pkg/logger"
 )
 
 // Common errors for Cedar authorization
@@ -258,8 +259,17 @@ func (a *CedarAuthorizer) IsAuthorized(
 		entityMap = mergedEntities
 	}
 
+	// Debug logging for authorization
+	logger.Debugf("Cedar authorization check - Principal: %s, Action: %s, Resource: %s",
+		req.Principal, req.Action, req.Resource)
+	logger.Debugf("Cedar context: %+v", req.Context)
+
 	// Check authorization
 	decision, diagnostic := cedar.Authorize(a.policySet, entityMap, req)
+
+	// Log the decision
+	logger.Debugf("Cedar decision: %v, diagnostic: %+v", decision, diagnostic)
+
 	// Cedar's Authorize returns a Decision and a Diagnostic
 	// Check if the Diagnostic contains any errors
 	if len(diagnostic.Errors) > 0 {

--- a/pkg/authz/cedar_test.go
+++ b/pkg/authz/cedar_test.go
@@ -9,11 +9,15 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/stacklok/toolhive/pkg/auth"
+	"github.com/stacklok/toolhive/pkg/logger"
 )
 
 // TestNewCedarAuthorizer tests the creation of a new Cedar authorizer with different configurations.
 func TestNewCedarAuthorizer(t *testing.T) {
 	t.Parallel()
+
+	// Initialize logger for tests
+	logger.Initialize()
 	// Test cases
 	testCases := []struct {
 		name         string

--- a/pkg/authz/integration_test.go
+++ b/pkg/authz/integration_test.go
@@ -15,6 +15,7 @@ import (
 	"golang.org/x/exp/jsonrpc2"
 
 	"github.com/stacklok/toolhive/pkg/auth"
+	"github.com/stacklok/toolhive/pkg/logger"
 	mcpparser "github.com/stacklok/toolhive/pkg/mcp"
 )
 
@@ -22,6 +23,9 @@ import (
 // with realistic policies and shows how list responses are filtered
 func TestIntegrationListFiltering(t *testing.T) {
 	t.Parallel()
+
+	// Initialize logger for tests
+	logger.Initialize()
 	// Create a realistic Cedar authorizer with role-based policies
 	authorizer, err := NewCedarAuthorizer(CedarAuthorizerConfig{
 		Policies: []string{

--- a/pkg/authz/middleware_test.go
+++ b/pkg/authz/middleware_test.go
@@ -15,11 +15,15 @@ import (
 	"golang.org/x/exp/jsonrpc2"
 
 	"github.com/stacklok/toolhive/pkg/auth"
+	"github.com/stacklok/toolhive/pkg/logger"
 	mcpparser "github.com/stacklok/toolhive/pkg/mcp"
 )
 
 func TestMiddleware(t *testing.T) {
 	t.Parallel()
+
+	// Initialize logger for tests
+	logger.Initialize()
 
 	// Create a Cedar authorizer
 	authorizer, err := NewCedarAuthorizer(CedarAuthorizerConfig{

--- a/pkg/authz/response_filter_test.go
+++ b/pkg/authz/response_filter_test.go
@@ -14,10 +14,15 @@ import (
 	"golang.org/x/exp/jsonrpc2"
 
 	"github.com/stacklok/toolhive/pkg/auth"
+	"github.com/stacklok/toolhive/pkg/logger"
 )
 
 func TestResponseFilteringWriter(t *testing.T) {
 	t.Parallel()
+
+	// Initialize logger for tests
+	logger.Initialize()
+
 	// Create a Cedar authorizer with specific tool permissions
 	authorizer, err := NewCedarAuthorizer(CedarAuthorizerConfig{
 		Policies: []string{


### PR DESCRIPTION
I found it useful to dump what the principal was when I was
fat-fingering the policy
