### PR TITLE
Deprecate the serviceAccount/ClientID parameters from the CRDs

### DIFF
--- a/cmd/thv-operator/api/v1alpha1/mcpserver_types.go
+++ b/cmd/thv-operator/api/v1alpha1/mcpserver_types.go
@@ -266,8 +266,7 @@ type OIDCConfigRef struct {
 
 // KubernetesOIDCConfig configures OIDC for Kubernetes service account token validation
 type KubernetesOIDCConfig struct {
-	// ServiceAccount is the name of the service account to validate tokens for
-	// If empty, uses the pod's service account
+	// ServiceAccount is deprecated and will be removed in a future release.
 	// +optional
 	ServiceAccount string `json:"serviceAccount,omitempty"`
 
@@ -318,7 +317,7 @@ type InlineOIDCConfig struct {
 	// +optional
 	JWKSURL string `json:"jwksUrl,omitempty"`
 
-	// ClientID is the OIDC client ID
+	// ClientID is deprecated and will be removed in a future release.
 	// +optional
 	ClientID string `json:"clientId,omitempty"`
 }

--- a/cmd/thv-operator/controllers/mcpserver_controller.go
+++ b/cmd/thv-operator/controllers/mcpserver_controller.go
@@ -1027,20 +1027,6 @@ func (*MCPServerReconciler) generateKubernetesOIDCArgs(m *mcpv1alpha1.MCPServer)
 	}
 	args = append(args, fmt.Sprintf("--oidc-jwks-url=%s", jwksURL))
 
-	// Client ID (format: {serviceAccount}.{namespace}.svc.cluster.local)
-	serviceAccount := config.ServiceAccount
-	if serviceAccount == "" {
-		serviceAccount = "default" // Use default service account if not specified
-	}
-
-	namespace := config.Namespace
-	if namespace == "" {
-		namespace = m.Namespace // Use MCPServer's namespace if not specified
-	}
-
-	clientID := fmt.Sprintf("%s.%s.svc.cluster.local", serviceAccount, namespace)
-	args = append(args, fmt.Sprintf("--oidc-client-id=%s", clientID))
-
 	return args
 }
 
@@ -1103,11 +1089,6 @@ func (*MCPServerReconciler) generateInlineOIDCArgs(m *mcpv1alpha1.MCPServer) []s
 	// JWKS URL (optional)
 	if config.JWKSURL != "" {
 		args = append(args, fmt.Sprintf("--oidc-jwks-url=%s", config.JWKSURL))
-	}
-
-	// Client ID (optional)
-	if config.ClientID != "" {
-		args = append(args, fmt.Sprintf("--oidc-client-id=%s", config.ClientID))
 	}
 
 	return args

--- a/cmd/thv-operator/controllers/mcpserver_oidc_test.go
+++ b/cmd/thv-operator/controllers/mcpserver_oidc_test.go
@@ -74,7 +74,6 @@ func TestGenerateOIDCArgs(t *testing.T) {
 				"--oidc-issuer=https://kubernetes.default.svc",
 				"--oidc-audience=toolhive",
 				"--oidc-jwks-url=https://kubernetes.default.svc/openid/v1/jwks",
-				"--oidc-client-id=default.test-namespace.svc.cluster.local",
 			},
 		},
 		{
@@ -89,11 +88,10 @@ func TestGenerateOIDCArgs(t *testing.T) {
 					OIDCConfig: &mcpv1alpha1.OIDCConfigRef{
 						Type: mcpv1alpha1.OIDCConfigTypeKubernetes,
 						Kubernetes: &mcpv1alpha1.KubernetesOIDCConfig{
-							ServiceAccount: "custom-sa",
-							Namespace:      "custom-namespace",
-							Audience:       "custom-audience",
-							Issuer:         "https://custom.issuer.com",
-							JWKSURL:        "https://custom.issuer.com/jwks",
+							Namespace: "custom-namespace",
+							Audience:  "custom-audience",
+							Issuer:    "https://custom.issuer.com",
+							JWKSURL:   "https://custom.issuer.com/jwks",
 						},
 					},
 				},
@@ -102,7 +100,6 @@ func TestGenerateOIDCArgs(t *testing.T) {
 				"--oidc-issuer=https://custom.issuer.com",
 				"--oidc-audience=custom-audience",
 				"--oidc-jwks-url=https://custom.issuer.com/jwks",
-				"--oidc-client-id=custom-sa.custom-namespace.svc.cluster.local",
 			},
 		},
 		{
@@ -120,7 +117,6 @@ func TestGenerateOIDCArgs(t *testing.T) {
 							Issuer:   "https://accounts.google.com",
 							Audience: "my-google-client",
 							JWKSURL:  "https://www.googleapis.com/oauth2/v3/certs",
-							ClientID: "my-client-id",
 						},
 					},
 				},
@@ -129,7 +125,6 @@ func TestGenerateOIDCArgs(t *testing.T) {
 				"--oidc-issuer=https://accounts.google.com",
 				"--oidc-audience=my-google-client",
 				"--oidc-jwks-url=https://www.googleapis.com/oauth2/v3/certs",
-				"--oidc-client-id=my-client-id",
 			},
 		},
 		{
@@ -264,7 +259,6 @@ func TestGenerateKubernetesOIDCArgs(t *testing.T) {
 				"--oidc-issuer=https://kubernetes.default.svc",
 				"--oidc-audience=toolhive",
 				"--oidc-jwks-url=https://kubernetes.default.svc/openid/v1/jwks",
-				"--oidc-client-id=default.test-namespace.svc.cluster.local",
 			},
 		},
 		{
@@ -285,7 +279,6 @@ func TestGenerateKubernetesOIDCArgs(t *testing.T) {
 				"--oidc-issuer=https://kubernetes.default.svc",
 				"--oidc-audience=toolhive",
 				"--oidc-jwks-url=https://kubernetes.default.svc/openid/v1/jwks",
-				"--oidc-client-id=default.test-namespace.svc.cluster.local",
 			},
 		},
 		{
@@ -297,10 +290,8 @@ func TestGenerateKubernetesOIDCArgs(t *testing.T) {
 				},
 				Spec: mcpv1alpha1.MCPServerSpec{
 					OIDCConfig: &mcpv1alpha1.OIDCConfigRef{
-						Type: mcpv1alpha1.OIDCConfigTypeKubernetes,
-						Kubernetes: &mcpv1alpha1.KubernetesOIDCConfig{
-							ServiceAccount: "my-service-account",
-						},
+						Type:       mcpv1alpha1.OIDCConfigTypeKubernetes,
+						Kubernetes: &mcpv1alpha1.KubernetesOIDCConfig{},
 					},
 				},
 			},
@@ -308,7 +299,6 @@ func TestGenerateKubernetesOIDCArgs(t *testing.T) {
 				"--oidc-issuer=https://kubernetes.default.svc",
 				"--oidc-audience=toolhive",
 				"--oidc-jwks-url=https://kubernetes.default.svc/openid/v1/jwks",
-				"--oidc-client-id=my-service-account.test-namespace.svc.cluster.local",
 			},
 		},
 		{
@@ -331,7 +321,6 @@ func TestGenerateKubernetesOIDCArgs(t *testing.T) {
 				"--oidc-issuer=https://kubernetes.default.svc",
 				"--oidc-audience=toolhive",
 				"--oidc-jwks-url=https://kubernetes.default.svc/openid/v1/jwks",
-				"--oidc-client-id=default.my-namespace.svc.cluster.local",
 			},
 		},
 	}
@@ -406,7 +395,6 @@ func TestGenerateInlineOIDCArgs(t *testing.T) {
 							Issuer:   "https://accounts.google.com",
 							Audience: "my-audience",
 							JWKSURL:  "https://www.googleapis.com/oauth2/v3/certs",
-							ClientID: "my-client-id",
 						},
 					},
 				},
@@ -415,7 +403,6 @@ func TestGenerateInlineOIDCArgs(t *testing.T) {
 				"--oidc-issuer=https://accounts.google.com",
 				"--oidc-audience=my-audience",
 				"--oidc-jwks-url=https://www.googleapis.com/oauth2/v3/certs",
-				"--oidc-client-id=my-client-id",
 			},
 		},
 	}

--- a/deploy/charts/operator-crds/Chart.yaml
+++ b/deploy/charts/operator-crds/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: toolhive-operator-crds
 description: A Helm chart for installing the ToolHive Operator CRDs into Kubernetes.
 type: application
-version: 0.0.7
+version: 0.0.8
 appVersion: "0.0.1"

--- a/deploy/charts/operator-crds/README.md
+++ b/deploy/charts/operator-crds/README.md
@@ -1,7 +1,7 @@
 
 # ToolHive Operator CRDs Helm Chart
 
-![Version: 0.0.7](https://img.shields.io/badge/Version-0.0.7-informational?style=flat-square)
+![Version: 0.0.8](https://img.shields.io/badge/Version-0.0.8-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for installing the ToolHive Operator CRDs into Kubernetes.

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpservers.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpservers.yaml
@@ -103,7 +103,8 @@ spec:
                         description: Audience is the expected audience for the token
                         type: string
                       clientId:
-                        description: ClientID is the OIDC client ID
+                        description: ClientID is deprecated and will be removed in
+                          a future release.
                         type: string
                       issuer:
                         description: Issuer is the OIDC issuer URL
@@ -137,9 +138,8 @@ spec:
                           If empty, uses the MCPServer's namespace
                         type: string
                       serviceAccount:
-                        description: |-
-                          ServiceAccount is the name of the service account to validate tokens for
-                          If empty, uses the pod's service account
+                        description: ServiceAccount is deprecated and will be removed
+                          in a future release.
                         type: string
                     type: object
                   type:

--- a/docs/operator/crd-api.md
+++ b/docs/operator/crd-api.md
@@ -64,7 +64,7 @@ _Appears in:_
 | `issuer` _string_ | Issuer is the OIDC issuer URL |  | Required: \{\} <br /> |
 | `audience` _string_ | Audience is the expected audience for the token |  |  |
 | `jwksUrl` _string_ | JWKSURL is the URL to fetch the JWKS from |  |  |
-| `clientId` _string_ | ClientID is the OIDC client ID |  |  |
+| `clientId` _string_ | ClientID is deprecated and will be removed in a future release. |  |  |
 
 
 #### KubernetesOIDCConfig
@@ -80,7 +80,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `serviceAccount` _string_ | ServiceAccount is the name of the service account to validate tokens for<br />If empty, uses the pod's service account |  |  |
+| `serviceAccount` _string_ | ServiceAccount is deprecated and will be removed in a future release. |  |  |
 | `namespace` _string_ | Namespace is the namespace of the service account<br />If empty, uses the MCPServer's namespace |  |  |
 | `audience` _string_ | Audience is the expected audience for the token | toolhive |  |
 | `issuer` _string_ | Issuer is the OIDC issuer URL | https://kubernetes.default.svc |  |


### PR DESCRIPTION
Since the functionality on the thv side is not (and will not) be
implemented, let's deprecate the fields from the CRDs before removing
them in a subsequent release.
