### PR TITLE
fix: stop proxy when main container dies

### DIFF
--- a/pkg/transport/proxy/transparent/transparent_proxy.go
+++ b/pkg/transport/proxy/transparent/transparent_proxy.go
@@ -163,7 +163,9 @@ func (p *TransparentProxy) monitorHealth(parentCtx context.Context) {
 			alive := p.healthChecker.CheckHealth(parentCtx)
 			if alive.Status != healthcheck.StatusHealthy {
 				logger.Infof("Health check failed for %s; initiating proxy shutdown", p.containerName)
-				_ = p.Stop(context.Background())
+				if err := p.Stop(parentCtx); err != nil {
+					logger.Errorf("Failed to stop proxy for %s: %v", p.containerName, err)
+				}
 				return
 			}
 		}


### PR DESCRIPTION
If we stop the container manually via docker rm, the proxy routine is still there, as the flow is outside of our control. So add a healthcheck inside transparent proxy itself, and stop it when the main container is unhealthy

Closes: #411