### PR TITLE
fix: only assign a random host port for docker

### DIFF
--- a/cmd/thv/app/inspector.go
+++ b/cmd/thv/app/inspector.go
@@ -128,6 +128,7 @@ func inspectorCmdFunc(cmd *cobra.Command, args []string) error {
 
 	labelsMap := map[string]string{}
 	labels.AddStandardLabels(labelsMap, "inspector", "inspector", string(types.TransportTypeInspector), inspectorUIPort)
+	labelsMap["toolhive-auxiliary"] = "true"
 	_, _, err = rt.DeployWorkload(
 		ctx,
 		processedImage,

--- a/pkg/transport/http.go
+++ b/pkg/transport/http.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stacklok/toolhive/pkg/container"
 	rt "github.com/stacklok/toolhive/pkg/container/runtime"
 	"github.com/stacklok/toolhive/pkg/logger"
-	"github.com/stacklok/toolhive/pkg/networking"
 	"github.com/stacklok/toolhive/pkg/permissions"
 	"github.com/stacklok/toolhive/pkg/transport/errors"
 	"github.com/stacklok/toolhive/pkg/transport/proxy/transparent"
@@ -130,17 +129,11 @@ func (t *HTTPTransport) Setup(ctx context.Context, runtime rt.Runtime, container
 	containerPortStr := fmt.Sprintf("%d/tcp", t.targetPort)
 	containerOptions.ExposedPorts[containerPortStr] = struct{}{}
 
-	// bind to a random host port
 	// Create host port bindings (configurable through the --host flag)
-	hostPort := networking.FindAvailable()
-	if hostPort == 0 {
-		return fmt.Errorf("could not find an available port")
-	}
-
 	portBindings := []rt.PortBinding{
 		{
 			HostIP:   t.host,
-			HostPort: fmt.Sprintf("%d", hostPort),
+			HostPort: fmt.Sprintf("%d", t.targetPort),
 		},
 	}
 


### PR DESCRIPTION
The logic for assigning a random port on the host was done at transport level, which was causing k8s to fail. Instead, move it to docker itself, so we continue with the regular logic in k8s

Closes: #902