### PR TITLE
fix: only override `targetPort` for docker runtime

### DIFF
--- a/pkg/transport/http.go
+++ b/pkg/transport/http.go
@@ -180,8 +180,17 @@ func (t *HTTPTransport) Setup(ctx context.Context, runtime rt.Runtime, container
 		}
 	}
 
-	// also override the exposed port, in case we need it via ingress
-	t.targetPort = exposedPort
+	// ChrisB: I really don't like this, but it's a workaround for the fact that
+	// we don't want to override the targetPort in a Kubernetes deployment. Because
+	// by default the Kubernetes container runtime returns `0` for the exposedPort anyways
+	// therefore causing the "target port not set" error when it is assigned to the targetPort.
+	// Issues:
+	// - https://github.com/stacklok/toolhive/issues/902
+	// - https://github.com/stacklok/toolhive/issues/924
+	if k8sPodTemplatePatch == "" {
+		// also override the exposed port, in case we need it via ingress
+		t.targetPort = exposedPort
+	}
 
 	return nil
 }


### PR DESCRIPTION
There was a regression introduced this [commit](https://github.com/stacklok/toolhive/commit/106ea358c15c94db0841d8c2537ca6c1dead34bc#diff-38fecb0789c3417dfc50bf25d6986584a8821f57fc4ff0474c1f2ad4123fb3a0) that returned a default `0` value from the Kubernetes container runtime. This 0 value then gets returned to [exposedPort](https://github.com/stacklok/toolhive/blob/main/pkg/transport/http.go#L156) which is then is used to [override the targetport](https://github.com/stacklok/toolhive/blob/main/pkg/transport/http.go#L184), later suffering from the ["targetPort not set error"](https://github.com/stacklok/toolhive/blob/main/pkg/transport/http.go#L214) because the targetPort is set to `0`.

This (hacky) fix introduces a change that only overrides the targetPort with the exposed port if it is not in a Kubernetes context. Since we don't have access to runtime specific information at the transport layer, I've had to check if the `k8sPodTemplatePatch` is empty. If it's empty, it's assumed that it is a docker runtime, if it's not, the assumption is that it's Kubernetes. It's not perfect, but at the moment, until we move away from shared interfaces between the Docker/Kubernetes container runtime and transport layer, we won't have a way of cleanly doing this without refactoring a bunch of code.

Ref:
- https://github.com/stacklok/toolhive/issues/924
- https://github.com/stacklok/toolhive/issues/902