### PR TITLE
fix: show errors when running a detached process

### DIFF
--- a/cmd/thv/app/run.go
+++ b/cmd/thv/app/run.go
@@ -346,7 +346,11 @@ func runCmdFunc(cmd *cobra.Command, args []string) error {
 	if runForeground {
 		return workloadManager.RunWorkload(ctx, runConfig)
 	}
-	return workloadManager.RunWorkloadDetached(runConfig)
+	err = workloadManager.RunWorkloadDetached(runConfig)
+	if err != nil {
+		return fmt.Errorf("failed to run MCP workload detached: %v", err)
+	}
+	return nil
 }
 
 // parseCommandArguments processes command-line arguments to find everything after the -- separator

--- a/pkg/transport/proxy/transparent/transparent_proxy.go
+++ b/pkg/transport/proxy/transparent/transparent_proxy.go
@@ -148,7 +148,7 @@ func (p *TransparentProxy) Start(ctx context.Context) error {
 }
 
 func (p *TransparentProxy) monitorHealth(parentCtx context.Context) {
-	ticker := time.NewTicker(10 * time.Second)
+	ticker := time.NewTicker(30 * time.Second)
 	defer ticker.Stop()
 
 	var failCount int
@@ -166,7 +166,6 @@ func (p *TransparentProxy) monitorHealth(parentCtx context.Context) {
 			alive := p.healthChecker.CheckHealth(parentCtx)
 			if alive.Status != healthcheck.StatusHealthy {
 				failCount++
-				logger.Warnf("Health check %d/%d failed for %s", failCount, maxFails, p.containerName)
 				if failCount >= maxFails {
 					logger.Infof("Health check failed %d times; shutting down proxy for %s", maxFails, p.containerName)
 					if err := p.Stop(parentCtx); err != nil {

--- a/test/e2e/proxy_oauth_test.go
+++ b/test/e2e/proxy_oauth_test.go
@@ -443,7 +443,7 @@ var _ = Describe("Proxy OAuth Authentication E2E", Serial, func() {
 
 			By("Reconnecting via MCP to trigger token refresh")
 			proxyURL := fmt.Sprintf("http://localhost:%d/sse", proxyPort)
-			err = e2e.WaitForMCPServerReady(config, proxyURL, "sse", 10*time.Second)
+			err = e2e.WaitForMCPServerReady(config, proxyURL, "sse", 30*time.Second)
 			Expect(err).ToNot(HaveOccurred(), "MCP server not ready after token expiry")
 
 			mcpClient, err := e2e.NewMCPClientForSSE(config, proxyURL)


### PR DESCRIPTION
This was raised by this issue, but is a common problem, when toolhive is run in detached mode, all the errors are masked, only can be seen in foreground.
This PR populates error logs in detached mode, so problems are visible to the end user

Closes: #704