### PR TITLE
fix: adds a better check for kubernetes runtime

### DIFF
--- a/cmd/thv-operator/Taskfile.yml
+++ b/cmd/thv-operator/Taskfile.yml
@@ -147,13 +147,6 @@ tasks:
       - chainsaw test --test-dir test/e2e/chainsaw/operator/test-scenarios
       - chainsaw test --test-dir test/e2e/chainsaw/operator/cleanup
 
-  operator-e2e-test:
-    desc: Run E2E tests for the operator
-    cmds:
-      - chainsaw test --test-dir test/e2e/chainsaw/operator/setup
-      - chainsaw test --test-dir test/e2e/chainsaw/operator/test-scenarios
-      - chainsaw test --test-dir test/e2e/chainsaw/operator/cleanup
-
   crdref-install:
     desc: Install elastic/crd-ref-docs
     cmds:


### PR DESCRIPTION
We currently use `k8sPodTemplatePatch` to check if its a kubernetes runtime, which isn't always reliable. This PR adds a more reliable check.

Fixes: https://github.com/stacklok/toolhive/issues/932
