### PR TITLE
Add Cobra auto-completion for MCP server names

### DIFF
--- a/cmd/thv/app/logs.go
+++ b/cmd/thv/app/logs.go
@@ -33,6 +33,7 @@ func logsCommand() *cobra.Command {
 			}
 			return logsCmdFunc(cmd, args)
 		},
+		ValidArgsFunction: completeLogsArgs,
 	}
 
 	logsCommand.Flags().BoolVarP(&followFlag, "follow", "f", false, "Follow log output (only for container logs)")

--- a/cmd/thv/app/restart.go
+++ b/cmd/thv/app/restart.go
@@ -15,11 +15,12 @@ var (
 )
 
 var restartCmd = &cobra.Command{
-	Use:   "restart [container-name]",
-	Short: "Restart a tooling server",
-	Long:  `Restart a running tooling server managed by ToolHive. If the server is not running, it will be started.`,
-	Args:  cobra.RangeArgs(0, 1),
-	RunE:  restartCmdFunc,
+	Use:               "restart [container-name]",
+	Short:             "Restart a tooling server",
+	Long:              `Restart a running tooling server managed by ToolHive. If the server is not running, it will be started.`,
+	Args:              cobra.RangeArgs(0, 1),
+	RunE:              restartCmdFunc,
+	ValidArgsFunction: completeMCPServerNames,
 }
 
 func init() {

--- a/cmd/thv/app/rm.go
+++ b/cmd/thv/app/rm.go
@@ -9,11 +9,12 @@ import (
 )
 
 var rmCmd = &cobra.Command{
-	Use:   "rm [container-name]",
-	Short: "Remove an MCP server",
-	Long:  `Remove an MCP server managed by ToolHive.`,
-	Args:  cobra.ExactArgs(1),
-	RunE:  rmCmdFunc,
+	Use:               "rm [container-name]",
+	Short:             "Remove an MCP server",
+	Long:              `Remove an MCP server managed by ToolHive.`,
+	Args:              cobra.ExactArgs(1),
+	RunE:              rmCmdFunc,
+	ValidArgsFunction: completeMCPServerNames,
 }
 
 //nolint:gocyclo // This function is complex but manageable

--- a/cmd/thv/app/stop.go
+++ b/cmd/thv/app/stop.go
@@ -11,11 +11,12 @@ import (
 )
 
 var stopCmd = &cobra.Command{
-	Use:   "stop [container-name]",
-	Short: "Stop an MCP server",
-	Long:  `Stop a running MCP server managed by ToolHive.`,
-	Args:  validateStopArgs,
-	RunE:  stopCmdFunc,
+	Use:               "stop [container-name]",
+	Short:             "Stop an MCP server",
+	Long:              `Stop a running MCP server managed by ToolHive.`,
+	Args:              validateStopArgs,
+	RunE:              stopCmdFunc,
+	ValidArgsFunction: completeMCPServerNames,
 }
 
 var (


### PR DESCRIPTION
## Summary

This PR implements auto-completion functionality for the `thv` CLI using Cobra's completion features. Users can now use tab completion when typing MCP server names for commands that operate on containers, significantly improving the CLI user experience.

## Changes

- **Added `completeMCPServerNames` function**: Provides auto-completion for MCP server names by querying the workloads manager to get currently managed MCP servers
- **Added `completeLogsArgs` function**: Specialized completion for the logs command that includes both server names and the special "prune" option
- **Enhanced commands with `ValidArgsFunction`**:
  - `thv rm [container-name]` - completes with available MCP server names
  - `thv stop [container-name]` - completes with available MCP server names
  - `thv restart [container-name]` - completes with available MCP server names
  - `thv logs [container-name|prune]` - completes with server names and "prune" option

## Implementation Details

1. **Dynamic completion**: The completion functions query the live state of MCP servers using `workloads.Manager.ListWorkloads()`, ensuring completions are always current
2. **Context-aware**: For `rm` and `restart` commands, includes all workloads (running and stopped) since these commands can operate on stopped containers
3. **Command-specific logic**: The `logs` command provides both MCP server names and the special "prune" argument
4. **Performance**: Completion is only provided for the first argument to avoid unnecessary API calls
5. **Error handling**: Gracefully handles cases where the workloads manager cannot be created or containers cannot be listed

## Usage

After installing shell completion:

```bash
# Generate completion script
thv completion bash > /etc/bash_completion.d/thv
# or for other shells: zsh, fish, powershell

# Tab completion examples
thv rm <TAB>        # Shows available MCP server names
thv stop <TAB>      # Shows available MCP server names
thv restart <TAB>   # Shows available MCP server names
thv logs <TAB>      # Shows 'prune' + available MCP server names
```

## Benefits

- **Improved UX**: Reduces typing and prevents typos when managing MCP servers
- **Discoverability**: Users can see what MCP servers are available without running `thv list` first
- **Consistency**: Uses the same underlying API as the `list` command, ensuring accuracy
- **Shell integration**: Works with bash, zsh, fish, and PowerShell through Cobra's built-in completion support

## Testing

- ✅ Code compiles successfully
- ✅ Linting passes with no issues (`golangci-lint`)
- ✅ Completion functions handle error cases gracefully
- ✅ Integration with existing Cobra command structure