### PR TITLE
Add AWS docs, diagrams, and cost analysis MCPs

### DIFF
--- a/pkg/registry/data/registry.json
+++ b/pkg/registry/data/registry.json
@@ -171,6 +171,196 @@
       ],
       "transport": "stdio"
     },
+    "aws-cost-analysis": {
+      "args": [],
+      "description": "Generate upfront AWS service cost estimates and cost insights.",
+      "env_vars": [
+        {
+          "description": "AWS access key ID with access to the AWS Pricing API",
+          "name": "AWS_ACCESS_KEY_ID",
+          "required": false,
+          "secret": true
+        },
+        {
+          "description": "AWS secret access key",
+          "name": "AWS_SECRET_ACCESS_KEY",
+          "required": false,
+          "secret": true
+        },
+        {
+          "description": "AWS sesison token for temporary credentials",
+          "name": "AWS_SESSION_TOKEN",
+          "required": false,
+          "secret": true
+        },
+        {
+          "default": "us-east-1",
+          "description": "AWS region for the Pricing API endpoint (us-east-1, eu-central-1, ap-southeast-1)",
+          "name": "AWS_REGION",
+          "required": false
+        },
+        {
+          "default": "ERROR",
+          "description": "Logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL)",
+          "name": "FASTMCP_LOG_LEVEL",
+          "required": false
+        }
+      ],
+      "image": "public.ecr.aws/f3y8w4n0/awslabs/cost-analysis-mcp-server:latest",
+      "metadata": {
+        "last_updated": "2025-07-07T17:26:18Z",
+        "pulls": 5283,
+        "stars": 4422
+      },
+      "permissions": {
+        "network": {
+          "outbound": {
+            "allow_host": [
+              "aws.amazon.com",
+              "pricing.us-east-1.amazonaws.com",
+              "api.pricing.us-east-1.amazonaws.com",
+              "api.pricing.eu-central-1.amazonaws.com",
+              "api.pricing.ap-southeast-1.amazonaws.com"
+            ],
+            "allow_port": [
+              443
+            ],
+            "allow_transport": [
+              "tcp"
+            ],
+            "insecure_allow_all": false
+          }
+        },
+        "read": [],
+        "write": []
+      },
+      "repository_url": "https://github.com/awslabs/mcp",
+      "status": "Active",
+      "tags": [
+        "aws",
+        "cost-analysis",
+        "pricing",
+        "estimates",
+        "cost-insights",
+        "aws-costs",
+        "aws-pricing"
+      ],
+      "tier": "Official",
+      "tools": [
+        "analyze_cdk_project",
+        "analyze_terraform_project",
+        "get_pricing_from_web",
+        "get_pricing_from_api",
+        "get_bedrock_patterns",
+        "generate_cost_report"
+      ],
+      "transport": "stdio"
+    },
+    "aws-diagram": {
+      "args": [],
+      "description": "Generate AWS diagrams, sequence diagrams, flow diagrams, and class diagrams using Python code.",
+      "env_vars": [
+        {
+          "default": "ERROR",
+          "description": "Logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL)",
+          "name": "FASTMCP_LOG_LEVEL",
+          "required": false
+        }
+      ],
+      "image": "mcp/aws-diagram:latest",
+      "metadata": {
+        "last_updated": "2025-07-07T17:26:15Z",
+        "pulls": 5305,
+        "stars": 4422
+      },
+      "permissions": {
+        "network": {
+          "outbound": {
+            "allow_host": [],
+            "allow_port": [],
+            "allow_transport": [],
+            "insecure_allow_all": false
+          }
+        },
+        "read": [],
+        "write": []
+      },
+      "repository_url": "https://github.com/awslabs/mcp",
+      "status": "Active",
+      "tags": [
+        "aws",
+        "diagram",
+        "sequence-diagram",
+        "flow-diagram",
+        "class-diagram",
+        "python"
+      ],
+      "tier": "Official",
+      "tools": [
+        "generate_diagram",
+        "get_diagram_examples",
+        "list_icons"
+      ],
+      "transport": "stdio"
+    },
+    "aws-documentation": {
+      "args": [],
+      "description": "Access AWS documentation, search for content, and get recommendations.",
+      "env_vars": [
+        {
+          "default": "aws",
+          "description": "AWS documentation partition (aws, aws-cn)",
+          "name": "AWS_DOCUMENTATION_PARTITION",
+          "required": false
+        },
+        {
+          "default": "ERROR",
+          "description": "Logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL)",
+          "name": "FASTMCP_LOG_LEVEL",
+          "required": false
+        }
+      ],
+      "image": "mcp/aws-documentation:latest",
+      "metadata": {
+        "last_updated": "2025-07-07T17:26:20Z",
+        "pulls": 5459,
+        "stars": 4422
+      },
+      "permissions": {
+        "network": {
+          "outbound": {
+            "allow_host": [
+              ".docs.aws.amazon.com",
+              ".docs.amazonaws.cn"
+            ],
+            "allow_port": [
+              443
+            ],
+            "allow_transport": [
+              "tcp"
+            ],
+            "insecure_allow_all": false
+          }
+        },
+        "read": [],
+        "write": []
+      },
+      "repository_url": "https://github.com/awslabs/mcp",
+      "status": "Active",
+      "tags": [
+        "aws",
+        "content",
+        "documentation",
+        "knowledge-base"
+      ],
+      "tier": "Official",
+      "tools": [
+        "read_documentation",
+        "recommend",
+        "search_documentation"
+      ],
+      "transport": "stdio"
+    },
     "elasticsearch": {
       "args": [],
       "description": "Connect to your Elasticsearch data directly from any MCP Client.",


### PR DESCRIPTION
Adds three official AWS MCP servers to the registry:

- [AWS Cost Analysis](https://github.com/awslabs/mcp/blob/main/src/cost-analysis-mcp-server)
- [AWS Diagram](https://github.com/awslabs/mcp/tree/main/src/aws-diagram-mcp-server)
- [AWS Documentation](https://github.com/awslabs/mcp/blob/main/src/aws-documentation-mcp-server)

Closes #866