### PR TITLE
Add support for private OCI registries

### DIFF
--- a/cmd/thv/app/run.go
+++ b/cmd/thv/app/run.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stacklok/toolhive/pkg/config"
 	"github.com/stacklok/toolhive/pkg/container"
+	"github.com/stacklok/toolhive/pkg/container/runtime"
 	"github.com/stacklok/toolhive/pkg/logger"
 	"github.com/stacklok/toolhive/pkg/permissions"
 	"github.com/stacklok/toolhive/pkg/process"
@@ -285,7 +286,7 @@ func runCmdFunc(cmd *cobra.Command, args []string) error {
 	// If we are running in detached mode, or the CLI is wrapped by the K8s operator,
 	// we use the DetachedEnvVarValidator.
 	var envVarValidator runner.EnvVarValidator
-	if process.IsDetached() || container.IsKubernetesRuntime() {
+	if process.IsDetached() || runtime.IsKubernetesRuntime() {
 		envVarValidator = &runner.DetachedEnvVarValidator{}
 	} else {
 		envVarValidator = &runner.CLIEnvVarValidator{}
@@ -297,7 +298,7 @@ func runCmdFunc(cmd *cobra.Command, args []string) error {
 	// Only pull image if we are not running in Kubernetes mode.
 	// This split will go away if we implement a separate command or binary
 	// for running MCP servers in Kubernetes.
-	if !container.IsKubernetesRuntime() {
+	if !runtime.IsKubernetesRuntime() {
 		// Take the MCP server we were supplied and either fetch the image, or
 		// build it from a protocol scheme. If the server URI refers to an image
 		// in our trusted registry, we will also fetch the image metadata.

--- a/cmd/thv/main.go
+++ b/cmd/thv/main.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stacklok/toolhive/cmd/thv/app"
 	"github.com/stacklok/toolhive/pkg/client"
-	"github.com/stacklok/toolhive/pkg/container"
+	"github.com/stacklok/toolhive/pkg/container/runtime"
 	"github.com/stacklok/toolhive/pkg/logger"
 )
 
@@ -19,7 +19,7 @@ func main() {
 	client.CheckAndPerformAutoDiscoveryMigration()
 
 	// Skip update check for completion command or if we are running in kubernetes
-	if err := app.NewRootCmd(!app.IsCompletionCommand(os.Args) && !container.IsKubernetesRuntime()).Execute(); err != nil {
+	if err := app.NewRootCmd(!app.IsCompletionCommand(os.Args) && !runtime.IsKubernetesRuntime()).Execute(); err != nil {
 		os.Exit(1)
 	}
 }

--- a/pkg/container/docker/client.go
+++ b/pkg/container/docker/client.go
@@ -56,7 +56,7 @@ func NewClient(ctx context.Context) (*Client, error) {
 		return nil, err // there is already enough context in the error.
 	}
 
-	imageManager := images.NewDockerImageManager(dockerClient)
+	imageManager := images.NewRegistryImageManager(dockerClient)
 
 	c := &Client{
 		runtimeType:  runtimeType,

--- a/pkg/container/factory.go
+++ b/pkg/container/factory.go
@@ -4,7 +4,6 @@ package container
 
 import (
 	"context"
-	"os"
 
 	"github.com/stacklok/toolhive/pkg/container/docker"
 	"github.com/stacklok/toolhive/pkg/container/kubernetes"
@@ -21,7 +20,7 @@ func NewFactory() *Factory {
 
 // Create creates a container runtime
 func (*Factory) Create(ctx context.Context) (runtime.Runtime, error) {
-	if !IsKubernetesRuntime() {
+	if !runtime.IsKubernetesRuntime() {
 		client, err := docker.NewClient(ctx)
 		if err != nil {
 			return nil, err
@@ -40,10 +39,4 @@ func (*Factory) Create(ctx context.Context) (runtime.Runtime, error) {
 // NewMonitor creates a new container monitor
 func NewMonitor(rt runtime.Runtime, containerID, containerName string) runtime.Monitor {
 	return docker.NewMonitor(rt, containerID, containerName)
-}
-
-// IsKubernetesRuntime returns true if the runtime is Kubernetes
-// isn't the best way to do this, but for now it's good enough
-func IsKubernetesRuntime() bool {
-	return os.Getenv("KUBERNETES_SERVICE_HOST") != ""
 }

--- a/pkg/container/images/image.go
+++ b/pkg/container/images/image.go
@@ -3,6 +3,7 @@ package images
 
 import (
 	"context"
+	"github.com/stacklok/toolhive/pkg/container"
 
 	"github.com/stacklok/toolhive/pkg/container/docker/sdk"
 	"github.com/stacklok/toolhive/pkg/logger"
@@ -26,6 +27,12 @@ type ImageManager interface {
 // NewImageManager creates an instance of ImageManager appropriate
 // for the current environment, or returns an error if it is not supported.
 func NewImageManager(ctx context.Context) ImageManager {
+	// Check if we are running in a Kubernetes environment
+	if container.IsKubernetesRuntime() {
+		logger.Debug("running in Kubernetes environment, using no-op image manager")
+		return &NoopImageManager{}
+	}
+
 	// First try the registry-based implementation (no Docker daemon required)
 	registryManager := NewRegistryImageManager()
 	if registryManager != nil {

--- a/pkg/container/images/image.go
+++ b/pkg/container/images/image.go
@@ -3,9 +3,9 @@ package images
 
 import (
 	"context"
-	"github.com/stacklok/toolhive/pkg/container"
 
 	"github.com/stacklok/toolhive/pkg/container/docker/sdk"
+	"github.com/stacklok/toolhive/pkg/container/runtime"
 	"github.com/stacklok/toolhive/pkg/logger"
 )
 
@@ -28,7 +28,7 @@ type ImageManager interface {
 // for the current environment, or returns an error if it is not supported.
 func NewImageManager(ctx context.Context) ImageManager {
 	// Check if we are running in a Kubernetes environment
-	if container.IsKubernetesRuntime() {
+	if runtime.IsKubernetesRuntime() {
 		logger.Debug("running in Kubernetes environment, using no-op image manager")
 		return &NoopImageManager{}
 	}

--- a/pkg/container/images/image.go
+++ b/pkg/container/images/image.go
@@ -33,22 +33,14 @@ func NewImageManager(ctx context.Context) ImageManager {
 		return &NoopImageManager{}
 	}
 
-	// First try the registry-based implementation (no Docker daemon required)
-	registryManager := NewRegistryImageManager()
-	if registryManager != nil {
-		logger.Debug("using registry-based image manager")
-		return registryManager
-	}
-
-	// Fall back to Docker client if registry manager is not available
+	// Check if we are running in a Docker or compatible environment
 	dockerClient, _, _, err := sdk.NewDockerClient(ctx)
 	if err != nil {
 		logger.Debug("no docker runtime found, using no-op image manager")
 		return &NoopImageManager{}
 	}
 
-	logger.Debug("using docker-based image manager")
-	return NewDockerImageManager(dockerClient)
+	return NewRegistryImageManager(dockerClient)
 }
 
 // NoopImageManager is a no-op implementation of ImageManager.

--- a/pkg/container/images/keychain.go
+++ b/pkg/container/images/keychain.go
@@ -1,0 +1,79 @@
+package images
+
+import (
+	"os"
+	"strings"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+)
+
+// envKeychain implements a keychain that reads credentials from environment variables
+type envKeychain struct{}
+
+// Resolve implements the authn.Keychain interface
+func (*envKeychain) Resolve(target authn.Resource) (authn.Authenticator, error) {
+	registry := target.RegistryStr()
+
+	// Try registry-specific environment variables first
+	// Format: REGISTRY_<NORMALIZED_REGISTRY_NAME>_USERNAME/PASSWORD
+	normalizedRegistry := strings.ToUpper(strings.ReplaceAll(registry, ".", "_"))
+	normalizedRegistry = strings.ReplaceAll(normalizedRegistry, "-", "_")
+
+	username := os.Getenv("REGISTRY_" + normalizedRegistry + "_USERNAME")
+	password := os.Getenv("REGISTRY_" + normalizedRegistry + "_PASSWORD")
+
+	// If registry-specific vars not found, try generic ones
+	if username == "" || password == "" {
+		username = os.Getenv("DOCKER_USERNAME")
+		password = os.Getenv("DOCKER_PASSWORD")
+	}
+
+	// If still not found, try REGISTRY_USERNAME/PASSWORD
+	if username == "" || password == "" {
+		username = os.Getenv("REGISTRY_USERNAME")
+		password = os.Getenv("REGISTRY_PASSWORD")
+	}
+
+	if username != "" && password != "" {
+		return &authn.Basic{
+			Username: username,
+			Password: password,
+		}, nil
+	}
+
+	return authn.Anonymous, nil
+}
+
+// compositeKeychain combines multiple keychains and tries them in order
+type compositeKeychain struct {
+	keychains []authn.Keychain
+}
+
+// Resolve implements the authn.Keychain interface
+func (c *compositeKeychain) Resolve(target authn.Resource) (authn.Authenticator, error) {
+	for _, keychain := range c.keychains {
+		auth, err := keychain.Resolve(target)
+		if err != nil {
+			continue
+		}
+
+		// Check if we got actual credentials (not anonymous)
+		if auth != authn.Anonymous {
+			return auth, nil
+		}
+	}
+
+	// If no keychain provided credentials, return anonymous
+	return authn.Anonymous, nil
+}
+
+// NewCompositeKeychain creates a keychain that tries environment variables first,
+// then falls back to the default keychain
+func NewCompositeKeychain() authn.Keychain {
+	return &compositeKeychain{
+		keychains: []authn.Keychain{
+			&envKeychain{},        // Try environment variables first
+			authn.DefaultKeychain, // Then try default keychain (Docker config, etc.)
+		},
+	}
+}

--- a/pkg/container/images/keychain.go
+++ b/pkg/container/images/keychain.go
@@ -15,20 +15,14 @@ func (*envKeychain) Resolve(target authn.Resource) (authn.Authenticator, error) 
 	registry := target.RegistryStr()
 
 	// Try registry-specific environment variables first
-	// Format: REGISTRY_<NORMALIZED_REGISTRY_NAME>_USERNAME/PASSWORD
+	// Format: REGISTRY_<NORMALIZED_REGISTRY_NAME>_USERNAME/PASSWORD, i.e., REGISTRY_DOCKER_IO_USERNAME
 	normalizedRegistry := strings.ToUpper(strings.ReplaceAll(registry, ".", "_"))
 	normalizedRegistry = strings.ReplaceAll(normalizedRegistry, "-", "_")
 
 	username := os.Getenv("REGISTRY_" + normalizedRegistry + "_USERNAME")
 	password := os.Getenv("REGISTRY_" + normalizedRegistry + "_PASSWORD")
 
-	// If registry-specific vars not found, try generic ones
-	if username == "" || password == "" {
-		username = os.Getenv("DOCKER_USERNAME")
-		password = os.Getenv("DOCKER_PASSWORD")
-	}
-
-	// If still not found, try REGISTRY_USERNAME/PASSWORD
+	// If registry-specific vars not found, try generic one REGISTRY_USERNAME/PASSWORD
 	if username == "" || password == "" {
 		username = os.Getenv("REGISTRY_USERNAME")
 		password = os.Getenv("REGISTRY_PASSWORD")

--- a/pkg/container/images/registry.go
+++ b/pkg/container/images/registry.go
@@ -41,7 +41,7 @@ func getDefaultPlatform() *v1.Platform {
 }
 
 // ImageExists checks if an image exists locally in the daemon or remotely in the registry
-func (r *RegistryImageManager) ImageExists(ctx context.Context, imageName string) (bool, error) {
+func (*RegistryImageManager) ImageExists(_ context.Context, imageName string) (bool, error) {
 	// Parse the image reference
 	ref, err := name.ParseReference(imageName)
 	if err != nil {
@@ -49,27 +49,11 @@ func (r *RegistryImageManager) ImageExists(ctx context.Context, imageName string
 	}
 
 	// First check if image exists locally in daemon
-	if _, err := daemon.Image(ref); err == nil {
-		return true, nil
-	}
-
-	// If not found locally, check if it exists in the remote registry
-	remoteOpts := []remote.Option{
-		remote.WithAuthFromKeychain(r.keychain),
-		remote.WithContext(ctx),
-	}
-
-	if r.platform != nil {
-		remoteOpts = append(remoteOpts, remote.WithPlatform(*r.platform))
-	}
-
-	// Use HEAD request to check if image exists without downloading
-	_, err = remote.Head(ref, remoteOpts...)
-	if err != nil {
-		// If we get an error, the image likely doesn't exist
+	if _, err := daemon.Image(ref); err != nil {
+		// Image does not exist locally
 		return false, nil
 	}
-
+	// Image exists locally
 	return true, nil
 }
 

--- a/pkg/container/images/registry.go
+++ b/pkg/container/images/registry.go
@@ -1,0 +1,254 @@
+package images
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/daemon"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/tarball"
+
+	"github.com/stacklok/toolhive/pkg/logger"
+)
+
+// RegistryImageManager implements the ImageManager interface using go-containerregistry
+// for direct registry operations without requiring a Docker daemon.
+type RegistryImageManager struct {
+	keychain authn.Keychain
+	platform *v1.Platform
+}
+
+// NewRegistryImageManager creates a new RegistryImageManager instance
+func NewRegistryImageManager() *RegistryImageManager {
+	return &RegistryImageManager{
+		keychain: newCompositeKeychain(), // Use composite keychain (env vars + default)
+		platform: nil,                   // Use default platform
+	}
+}
+
+// ImageExists checks if an image exists locally in the daemon or remotely in the registry
+func (r *RegistryImageManager) ImageExists(ctx context.Context, imageName string) (bool, error) {
+	// Parse the image reference
+	ref, err := name.ParseReference(imageName)
+	if err != nil {
+		return false, fmt.Errorf("failed to parse image reference %q: %w", imageName, err)
+	}
+
+	// First check if image exists locally in daemon
+	if _, err := daemon.Image(ref); err == nil {
+		return true, nil
+	}
+
+	// If not found locally, check if it exists in the remote registry
+	remoteOpts := []remote.Option{
+		remote.WithAuthFromKeychain(r.keychain),
+		remote.WithContext(ctx),
+	}
+
+	if r.platform != nil {
+		remoteOpts = append(remoteOpts, remote.WithPlatform(*r.platform))
+	}
+
+	// Use HEAD request to check if image exists without downloading
+	_, err = remote.Head(ref, remoteOpts...)
+	if err != nil {
+		// If we get an error, the image likely doesn't exist
+		return false, nil
+	}
+
+	return true, nil
+}
+
+// PullImage pulls an image from a registry and saves it to the local daemon
+func (r *RegistryImageManager) PullImage(ctx context.Context, imageName string) error {
+	logger.Infof("Pulling image: %s", imageName)
+
+	// Parse the image reference
+	ref, err := name.ParseReference(imageName)
+	if err != nil {
+		return fmt.Errorf("failed to parse image reference %q: %w", imageName, err)
+	}
+
+	// Configure remote options
+	remoteOpts := []remote.Option{
+		remote.WithAuthFromKeychain(r.keychain),
+		remote.WithContext(ctx),
+	}
+
+	if r.platform != nil {
+		remoteOpts = append(remoteOpts, remote.WithPlatform(*r.platform))
+	}
+
+	// Pull the image from the registry
+	img, err := remote.Image(ref, remoteOpts...)
+	if err != nil {
+		return fmt.Errorf("failed to pull image from registry: %w", err)
+	}
+
+	// Convert reference to tag for daemon.Write
+	tag, ok := ref.(name.Tag)
+	if !ok {
+		// If it's not a tag, try to convert to tag
+		tag, err = name.NewTag(ref.String())
+		if err != nil {
+			return fmt.Errorf("failed to convert reference to tag: %w", err)
+		}
+	}
+
+	// Save the image to the local daemon
+	response, err := daemon.Write(tag, img)
+	if err != nil {
+		return fmt.Errorf("failed to write image to daemon: %w", err)
+	}
+
+	// Display success message
+	fmt.Fprintf(os.Stdout, "Successfully pulled %s\n", imageName)
+	logger.Infof("Pull complete for image: %s, response: %s", imageName, response)
+
+	return nil
+}
+
+// BuildImage builds a Docker image from a Dockerfile in the specified context directory
+func (r *RegistryImageManager) BuildImage(ctx context.Context, contextDir, imageName string) error {
+	logger.Infof("Building image %s from context directory %s", imageName, contextDir)
+
+	// Parse the image reference
+	ref, err := name.ParseReference(imageName)
+	if err != nil {
+		return fmt.Errorf("failed to parse image reference %q: %w", imageName, err)
+	}
+
+	// Create a tar archive of the context directory (reusing existing logic)
+	tarFile, err := os.CreateTemp("", "registry-build-context-*.tar")
+	if err != nil {
+		return fmt.Errorf("failed to create temporary tar file: %w", err)
+	}
+	defer os.Remove(tarFile.Name())
+	defer tarFile.Close()
+
+	// Create a tar archive of the context directory
+	if err := createTarFromDir(contextDir, tarFile); err != nil {
+		return fmt.Errorf("failed to create tar archive: %w", err)
+	}
+
+	// Reset the file pointer to the beginning of the file
+	if _, err := tarFile.Seek(0, 0); err != nil {
+		return fmt.Errorf("failed to reset tar file pointer: %w", err)
+	}
+
+	// Build the image from the tarball
+	img, err := tarball.ImageFromPath(tarFile.Name(), nil)
+	if err != nil {
+		return fmt.Errorf("failed to build image from tarball: %w", err)
+	}
+
+	// Convert reference to tag for daemon.Write
+	tag, ok := ref.(name.Tag)
+	if !ok {
+		// If it's not a tag, try to convert to tag
+		tag, err = name.NewTag(ref.String())
+		if err != nil {
+			return fmt.Errorf("failed to convert reference to tag: %w", err)
+		}
+	}
+
+	// Save the image to the local daemon
+	response, err := daemon.Write(tag, img)
+	if err != nil {
+		return fmt.Errorf("failed to write built image to daemon: %w", err)
+	}
+
+	// Display success message
+	fmt.Fprintf(os.Stdout, "Successfully built %s\n", imageName)
+	logger.Infof("Build complete for image: %s, response: %s", imageName, response)
+
+	return nil
+}
+
+// WithPlatform sets the platform for the RegistryImageManager
+func (r *RegistryImageManager) WithPlatform(platform *v1.Platform) *RegistryImageManager {
+	r.platform = platform
+	return r
+}
+
+// WithKeychain sets the keychain for authentication
+func (r *RegistryImageManager) WithKeychain(keychain authn.Keychain) *RegistryImageManager {
+	r.keychain = keychain
+	return r
+}
+
+// envKeychain implements a keychain that reads credentials from environment variables
+type envKeychain struct{}
+
+// Resolve implements the authn.Keychain interface
+func (e *envKeychain) Resolve(target authn.Resource) (authn.Authenticator, error) {
+	registry := target.RegistryStr()
+	
+	// Try registry-specific environment variables first
+	// Format: REGISTRY_<NORMALIZED_REGISTRY_NAME>_USERNAME/PASSWORD
+	normalizedRegistry := strings.ToUpper(strings.ReplaceAll(registry, ".", "_"))
+	normalizedRegistry = strings.ReplaceAll(normalizedRegistry, "-", "_")
+	
+	username := os.Getenv("REGISTRY_" + normalizedRegistry + "_USERNAME")
+	password := os.Getenv("REGISTRY_" + normalizedRegistry + "_PASSWORD")
+	
+	// If registry-specific vars not found, try generic ones
+	if username == "" || password == "" {
+		username = os.Getenv("DOCKER_USERNAME")
+		password = os.Getenv("DOCKER_PASSWORD")
+	}
+	
+	// If still not found, try REGISTRY_USERNAME/PASSWORD
+	if username == "" || password == "" {
+		username = os.Getenv("REGISTRY_USERNAME")
+		password = os.Getenv("REGISTRY_PASSWORD")
+	}
+	
+	if username != "" && password != "" {
+		return &authn.Basic{
+			Username: username,
+			Password: password,
+		}, nil
+	}
+	
+	return authn.Anonymous, nil
+}
+
+// compositeKeychain combines multiple keychains and tries them in order
+type compositeKeychain struct {
+	keychains []authn.Keychain
+}
+
+// Resolve implements the authn.Keychain interface
+func (c *compositeKeychain) Resolve(target authn.Resource) (authn.Authenticator, error) {
+	for _, keychain := range c.keychains {
+		auth, err := keychain.Resolve(target)
+		if err != nil {
+			continue
+		}
+		
+		// Check if we got actual credentials (not anonymous)
+		if auth != authn.Anonymous {
+			return auth, nil
+		}
+	}
+	
+	// If no keychain provided credentials, return anonymous
+	return authn.Anonymous, nil
+}
+
+// newCompositeKeychain creates a keychain that tries environment variables first,
+// then falls back to the default keychain
+func newCompositeKeychain() authn.Keychain {
+	return &compositeKeychain{
+		keychains: []authn.Keychain{
+			&envKeychain{},           // Try environment variables first
+			authn.DefaultKeychain,    // Then try default keychain (Docker config, etc.)
+		},
+	}
+}

--- a/pkg/container/runtime/types.go
+++ b/pkg/container/runtime/types.go
@@ -5,6 +5,7 @@ package runtime
 import (
 	"context"
 	"io"
+	"os"
 	"time"
 
 	"github.com/stacklok/toolhive/pkg/permissions"
@@ -218,4 +219,10 @@ type Mount struct {
 	Target string
 	// ReadOnly indicates if the mount is read-only
 	ReadOnly bool
+}
+
+// IsKubernetesRuntime returns true if the runtime is Kubernetes
+// isn't the best way to do this, but for now it's good enough
+func IsKubernetesRuntime() bool {
+	return os.Getenv("KUBERNETES_SERVICE_HOST") != ""
 }

--- a/pkg/container/verifier/utils.go
+++ b/pkg/container/verifier/utils.go
@@ -8,7 +8,6 @@ import (
 	"path"
 
 	"github.com/google/go-containerregistry/pkg/authn"
-	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/sigstore/sigstore-go/pkg/tuf"
 	"github.com/sigstore/sigstore-go/pkg/verify"
 )
@@ -112,14 +111,14 @@ func embeddedRootJson(tufRootURL string) ([]byte, error) {
 // getSigstoreBundles returns the sigstore bundles, either through the OCI registry or the GitHub attestation endpoint
 func getSigstoreBundles(
 	imageRef string,
+	keychain authn.Keychain,
 ) ([]sigstoreBundle, error) {
-	auth := authn.Anonymous
 	// Try to build a bundle from a Sigstore signed image
-	bundles, err := bundleFromSigstoreSignedImage(imageRef, auth)
+	bundles, err := bundleFromSigstoreSignedImage(imageRef, keychain)
 	if errors.Is(err, ErrProvenanceNotFoundOrIncomplete) {
 		// If we get this error, it means that the image is not signed
 		// or the signature is incomplete. Let's try to see if we can find attestation for the image.
-		return bundleFromAttestation(imageRef, auth, []remote.Option{})
+		return bundleFromAttestation(imageRef, keychain)
 	} else if err != nil {
 		return nil, err
 	}

--- a/pkg/transport/http.go
+++ b/pkg/transport/http.go
@@ -171,7 +171,7 @@ func (t *HTTPTransport) Setup(ctx context.Context, runtime rt.Runtime, container
 	t.containerID = containerID
 	logger.Infof("Container created with ID: %s", containerID)
 
-	if (t.Mode() == types.TransportTypeSSE || t.Mode() == types.TransportTypeStreamableHTTP) && container.IsKubernetesRuntime() {
+	if (t.Mode() == types.TransportTypeSSE || t.Mode() == types.TransportTypeStreamableHTTP) && rt.IsKubernetesRuntime() {
 		// If the SSEHeadlessServiceName is set, use it as the target host
 		// This is useful for Kubernetes deployments where the workload is
 		// exposed as a headless service.
@@ -186,7 +186,7 @@ func (t *HTTPTransport) Setup(ctx context.Context, runtime rt.Runtime, container
 	// Issues:
 	// - https://github.com/stacklok/toolhive/issues/902
 	// - https://github.com/stacklok/toolhive/issues/924
-	if !container.IsKubernetesRuntime() {
+	if !rt.IsKubernetesRuntime() {
 		// also override the exposed port, in case we need it via ingress
 		t.targetPort = exposedPort
 	}


### PR DESCRIPTION
The following PR:
* Implements a new `RegistryImageManager` based on `go-containerregistry`
* Adds authentication support for both image lookup and pull
* Adds authentication support for the provenance verification features
* Keeps backwards compatibility with the DefaultKeychain (local docker config for example). The flow is we'll look for potential credentials stored as env vars, if nothing is set we'll default to looking for credentials in the docker config file.
* Defaults to noop for k8s case
* Replaces the existing DockerImageManager
* **Continues to use the docker client for building the image in case of schema-based MCP servers** (needed because `go-containerregistry` does not support building images from Dockerfiles)

**What's left:**
 - [x] Test this a bit more so we are more confident the implementation is a fully working alternative to the existing docker client approach.

**Tests done:**
- [x] Tested with a private image authenticated using env vars
- [x] Tested with a private image authenticated using the docker config file (populated when you do `docker login <registry>`)
- [x] Tested with public images without any authentication
- [x] Tested with packaged server, i.e. npx

Fixes: #926 