### PR TITLE
feat: adds integration tests for toolhive kubernetes

### DIFF
--- a/.github/workflows/operator-ci.yml
+++ b/.github/workflows/operator-ci.yml
@@ -146,6 +146,9 @@ jobs:
     name: E2E Tests
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    defaults:
+      run:
+        shell: bash
     strategy:
       fail-fast: false
       matrix:
@@ -168,12 +171,22 @@ jobs:
 
     - name: Setup Ko
       uses: ko-build/setup-ko@d006021bd0c28d1ce33a07e7943d48b079944c8d # v0.9
+
+    - name: Set up Go
+      uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
+      with:
+        go-version-file: 'go.mod'
+        cache: true
         
     - name: Install Task
       uses: arduino/setup-task@v2
       with:
         version: 3.x
         repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Install yardstick client
+      run: |
+        go install github.com/stackloklabs/yardstick/cmd/yardstick-client@v0.0.2
         
     - name: Install Chainsaw
       uses: kyverno/action-install-chainsaw@f2b47b97dc889c12702113753d713f01ec268de5 # v0.2.12

--- a/test/e2e/chainsaw/operator/test-scenarios/sse/assert-mcpserver-headless-svc.yaml
+++ b/test/e2e/chainsaw/operator/test-scenarios/sse/assert-mcpserver-headless-svc.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: mcp-test-fetch-headless
+  name: mcp-yardstick-headless
   namespace: toolhive-system

--- a/test/e2e/chainsaw/operator/test-scenarios/sse/assert-mcpserver-pod-running.yaml
+++ b/test/e2e/chainsaw/operator/test-scenarios/sse/assert-mcpserver-pod-running.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: test-fetch
+  name: yardstick
   namespace: toolhive-system
 status:
   availableReplicas: 1

--- a/test/e2e/chainsaw/operator/test-scenarios/sse/assert-mcpserver-proxy-runner-running.yaml
+++ b/test/e2e/chainsaw/operator/test-scenarios/sse/assert-mcpserver-proxy-runner-running.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: test-fetch
+  name: yardstick
   namespace: toolhive-system
 status:
   (conditions[?type == 'Available'] | [0].status): "True"

--- a/test/e2e/chainsaw/operator/test-scenarios/sse/assert-mcpserver-proxy-runner-svc.yaml
+++ b/test/e2e/chainsaw/operator/test-scenarios/sse/assert-mcpserver-proxy-runner-svc.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: mcp-test-fetch-proxy
+  name: mcp-yardstick-proxy
   namespace: toolhive-system

--- a/test/e2e/chainsaw/operator/test-scenarios/sse/assert-mcpserver-running.yaml
+++ b/test/e2e/chainsaw/operator/test-scenarios/sse/assert-mcpserver-running.yaml
@@ -1,7 +1,7 @@
 apiVersion: toolhive.stacklok.dev/v1alpha1
 kind: MCPServer
 metadata:
-  name: test-fetch
+  name: yardstick
   namespace: toolhive-system
 status:
   message: "MCP server is running"

--- a/test/e2e/chainsaw/operator/test-scenarios/sse/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/operator/test-scenarios/sse/chainsaw-test.yaml
@@ -33,3 +33,67 @@ spec:
         file: assert-mcpserver-pod-running.yaml
     - assert:
         file: assert-mcpserver-headless-svc.yaml
+
+  - name: test-mcp-server
+    description: Test the SSE->SSE MCP server by sending requests at the toolhive proxy
+    try:
+    - script:
+        content: |
+          # Start port-forward in background
+          kubectl port-forward svc/mcp-yardstick-proxy -n toolhive-system 8080:8080 > /dev/null 2>&1 &
+          PORT_FORWARD_PID=$!
+          
+          # Function to cleanup port-forward
+          cleanup() {
+            if [ -n "$PORT_FORWARD_PID" ]; then
+              echo "Killing port-forward process $PORT_FORWARD_PID"
+              kill $PORT_FORWARD_PID 2>/dev/null || true
+            fi
+          }
+          
+          # Trap to ensure cleanup on exit
+          trap cleanup EXIT
+          
+          # Wait for port-forward to be ready (longer in CI)
+          sleep 5
+          
+          echo "🌊 ========== SSE->SSE TRANSPORT TESTING =========="
+          echo "📡 Testing SSE transport on port 8080..."
+          
+          # Test SSE endpoint with client binary
+          echo "🌊 Testing SSE endpoint with client binary..."
+          if yardstick-client -transport sse -address localhost -port 8080 -action info; then
+              echo "✓ SSE client connection successful"
+          else
+              echo "! SSE client connection failed"
+              exit 1
+          fi
+          
+          # Longer delay between calls for CI stability
+          sleep 3
+          
+          # Test listing tools via SSE
+          echo "📋 Testing tool listing via SSE..."
+          if yardstick-client -transport sse -address localhost -port 8080 -action list-tools; then
+              echo "✓ SSE tools listing successful"
+          else
+              echo "! SSE tools listing failed"
+              exit 1
+          fi
+          
+          # Longer delay between calls for CI stability
+          sleep 3
+          
+          echo "🔧 Testing tool calling via SSE..."
+          # We want to generate a random string to test the tool calling
+          # and then check if the output contains the string
+          TEST_INPUT_OUTPUT=$(openssl rand -hex 16)
+          if timeout 30 yardstick-client -transport sse -address localhost -port 8080 -action=call-tool -tool=echo -args="{\"input\":\"$TEST_INPUT_OUTPUT\"}" | grep -q "$TEST_INPUT_OUTPUT"; then
+              echo "✓ SSE tool call returned expected output: $TEST_INPUT_OUTPUT"
+          else
+              echo "! SSE tool call failed or timed out"
+              exit 1
+          fi
+          
+          echo "✅ All SSE->SSE transport tests passed!"
+          exit 0

--- a/test/e2e/chainsaw/operator/test-scenarios/sse/mcpserver.yaml
+++ b/test/e2e/chainsaw/operator/test-scenarios/sse/mcpserver.yaml
@@ -1,19 +1,19 @@
 apiVersion: toolhive.stacklok.dev/v1alpha1
 kind: MCPServer
 metadata:
-  name: test-fetch
+  name: yardstick
   namespace: toolhive-system
 spec:
-  image: ghcr.io/stackloklabs/gofetch/server
+  image: ghcr.io/stackloklabs/yardstick/yardstick-server:0.0.2
   transport: sse
+  env:
+  - name: TRANSPORT
+    value: sse
   port: 8080
+  targetPort: 8080
   permissionProfile:
     type: builtin
     name: network
-  podTemplateSpec:
-    spec:
-      containers:
-        - name: mcp
   resources:
     limits:
       cpu: "100m"

--- a/test/e2e/chainsaw/operator/test-scenarios/stdio/assert-mcpserver-pod-running.yaml
+++ b/test/e2e/chainsaw/operator/test-scenarios/stdio/assert-mcpserver-pod-running.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: test-fetch
+  name: yardstick
   namespace: toolhive-system
 status:
   availableReplicas: 1

--- a/test/e2e/chainsaw/operator/test-scenarios/stdio/assert-mcpserver-proxy-runner-running.yaml
+++ b/test/e2e/chainsaw/operator/test-scenarios/stdio/assert-mcpserver-proxy-runner-running.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: test-fetch
+  name: yardstick
   namespace: toolhive-system
 status:
   (conditions[?type == 'Available'] | [0].status): "True"

--- a/test/e2e/chainsaw/operator/test-scenarios/stdio/assert-mcpserver-proxy-runner-svc.yaml
+++ b/test/e2e/chainsaw/operator/test-scenarios/stdio/assert-mcpserver-proxy-runner-svc.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: mcp-test-fetch-proxy
+  name: mcp-yardstick-proxy
   namespace: toolhive-system

--- a/test/e2e/chainsaw/operator/test-scenarios/stdio/assert-mcpserver-running.yaml
+++ b/test/e2e/chainsaw/operator/test-scenarios/stdio/assert-mcpserver-running.yaml
@@ -1,7 +1,7 @@
 apiVersion: toolhive.stacklok.dev/v1alpha1
 kind: MCPServer
 metadata:
-  name: test-fetch
+  name: yardstick
   namespace: toolhive-system
 status:
   message: "MCP server is running"

--- a/test/e2e/chainsaw/operator/test-scenarios/stdio/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/operator/test-scenarios/stdio/chainsaw-test.yaml
@@ -31,3 +31,67 @@ spec:
         file: assert-mcpserver-proxy-runner-svc.yaml
     - assert:
         file: assert-mcpserver-pod-running.yaml
+
+  - name: test-mcp-server
+    description: Test the SSE->STDIO MCP server by sending requests at the toolhive proxy
+    try:
+    - script:
+        content: |
+          # Start port-forward in background
+          kubectl port-forward svc/mcp-yardstick-proxy -n toolhive-system 8080:8080 > /dev/null 2>&1 &
+          PORT_FORWARD_PID=$!
+          
+          # Function to cleanup port-forward
+          cleanup() {
+            if [ -n "$PORT_FORWARD_PID" ]; then
+              echo "Killing port-forward process $PORT_FORWARD_PID"
+              kill $PORT_FORWARD_PID 2>/dev/null || true
+            fi
+          }
+          
+          # Trap to ensure cleanup on exit
+          trap cleanup EXIT
+          
+          # Wait for port-forward to be ready (longer in CI)
+          sleep 5
+          
+          echo "🌊 ========== SSE->STDIO TRANSPORT TESTING =========="
+          echo "📡 Testing SSE transport on port 8080..."
+          
+          # Test SSE endpoint with client binary
+          echo "🌊 Testing SSE endpoint with client binary..."
+          if yardstick-client -transport sse -address localhost -port 8080 -action info; then
+              echo "✓ SSE client connection successful"
+          else
+              echo "! SSE client connection failed"
+              exit 1
+          fi
+          
+          # Longer delay between calls for CI stability
+          sleep 3
+          
+          # Test listing tools via SSE
+          echo "📋 Testing tool listing via SSE..."
+          if yardstick-client -transport sse -address localhost -port 8080 -action list-tools; then
+              echo "✓ SSE tools listing successful"
+          else
+              echo "! SSE tools listing failed"
+              exit 1
+          fi
+          
+          # Longer delay between calls for CI stability
+          sleep 3
+          
+          echo "🔧 Testing tool calling via SSE..."
+          # We want to generate a random string to test the tool calling
+          # and then check if the output contains the string
+          TEST_INPUT_OUTPUT=$(openssl rand -hex 16)
+          if timeout 30 yardstick-client -transport sse -address localhost -port 8080 -action=call-tool -tool=echo -args="{\"input\":\"$TEST_INPUT_OUTPUT\"}" | grep -q "$TEST_INPUT_OUTPUT"; then
+              echo "✓ SSE tool call returned expected output: $TEST_INPUT_OUTPUT"
+          else
+              echo "! SSE tool call failed or timed out"
+              exit 1
+          fi
+          
+          echo "✅ All SSE->STDIO transport tests passed!"
+          exit 0

--- a/test/e2e/chainsaw/operator/test-scenarios/stdio/mcpserver.yaml
+++ b/test/e2e/chainsaw/operator/test-scenarios/stdio/mcpserver.yaml
@@ -1,40 +1,15 @@
 apiVersion: toolhive.stacklok.dev/v1alpha1
 kind: MCPServer
 metadata:
-  name: test-fetch
+  name: yardstick
   namespace: toolhive-system
 spec:
-  image: docker.io/mcp/fetch
+  image: ghcr.io/stackloklabs/yardstick/yardstick-server:0.0.2
   transport: stdio
   port: 8080
   permissionProfile:
     type: builtin
     name: network
-  podTemplateSpec:
-    spec:
-      containers:
-        - name: mcp
-          securityContext:
-            allowPrivilegeEscalation: false
-            runAsNonRoot: false
-            runAsUser: 0
-            runAsGroup: 0
-            capabilities:
-              drop:
-              - ALL
-          resources:
-            limits:
-              cpu: "500m"
-              memory: "512Mi"
-            requests:
-              cpu: "100m"
-              memory: "128Mi"
-      securityContext:
-        runAsNonRoot: false
-        runAsUser: 0
-        runAsGroup: 0
-        seccompProfile:
-          type: RuntimeDefault
   resources:
     limits:
       cpu: "100m"


### PR DESCRIPTION
Adds integration tests for `sse` and `stdio` to ensure toolhive proxy and MCP servers work as expected when called. In order to call the MCP server, we use [yardstick](https://github.com/StacklokLabs/yardstick). 

We're also using the [yardstick MCP server](https://github.com/StacklokLabs/yardstick/tree/main/cmd/yardstick-server) because: 
1) it is more reliable than fetch 
2) doesn't require the enhanced privileges 
3) supports all three transport types 
4) build specifically for automated testing via deterministic responses

As spoken to @JAORMX privately, we're both united in our hatred for bash, but for now we just want something simple that works. I fully expect the scripts in the chainsaw tests that test the MCP server usage to evolve into something more robust as a solution in future, but for now, for a stable base, they are ok.

Ref: https://github.com/stacklok/toolhive/issues/1001