### PR TITLE
feat: adds streamable-http support for Toolhive in Kubernetes

### DIFF
--- a/pkg/container/kubernetes/client.go
+++ b/pkg/container/kubernetes/client.go
@@ -326,7 +326,7 @@ func (c *Client) DeployWorkload(ctx context.Context,
 
 	logger.Infof("Applied statefulset %s", createdStatefulSet.Name)
 
-	if transportType == string(transtypes.TransportTypeSSE) && options != nil {
+	if (transportType == string(transtypes.TransportTypeSSE) || transportType == string(transtypes.TransportTypeStreamableHTTP)) && options != nil {
 		// Create a headless service for SSE transport
 		err := c.createHeadlessService(ctx, containerName, namespace, containerLabels, options)
 		if err != nil {
@@ -830,6 +830,10 @@ func extractPortMappingsFromPod(pod *corev1.Pod) []runtime.PortMapping {
 	}
 
 	return ports
+}
+
+func shouldCreateHeadlessService(transportType string) bool {
+	return transportType == string(transtypes.TransportTypeSSE) || transportType == string(transtypes.TransportTypeStreamableHTTP)
 }
 
 // extractPortMappingsFromService extracts port mappings from a Kubernetes service

--- a/pkg/transport/http.go
+++ b/pkg/transport/http.go
@@ -171,7 +171,7 @@ func (t *HTTPTransport) Setup(ctx context.Context, runtime rt.Runtime, container
 	t.containerID = containerID
 	logger.Infof("Container created with ID: %s", containerID)
 
-	if t.Mode() == types.TransportTypeSSE && container.IsKubernetesRuntime() {
+	if (t.Mode() == types.TransportTypeSSE || t.Mode() == types.TransportTypeStreamableHTTP) && container.IsKubernetesRuntime() {
 		// If the SSEHeadlessServiceName is set, use it as the target host
 		// This is useful for Kubernetes deployments where the workload is
 		// exposed as a headless service.

--- a/test/e2e/chainsaw/operator/test-scenarios/streamable-http/assert-mcpserver-headless-svc.yaml
+++ b/test/e2e/chainsaw/operator/test-scenarios/streamable-http/assert-mcpserver-headless-svc.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mcp-yardstick-headless
+  namespace: toolhive-system

--- a/test/e2e/chainsaw/operator/test-scenarios/streamable-http/assert-mcpserver-pod-running.yaml
+++ b/test/e2e/chainsaw/operator/test-scenarios/streamable-http/assert-mcpserver-pod-running.yaml
@@ -1,0 +1,7 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: yardstick
+  namespace: toolhive-system
+status:
+  availableReplicas: 1

--- a/test/e2e/chainsaw/operator/test-scenarios/streamable-http/assert-mcpserver-proxy-runner-running.yaml
+++ b/test/e2e/chainsaw/operator/test-scenarios/streamable-http/assert-mcpserver-proxy-runner-running.yaml
@@ -1,0 +1,8 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: yardstick
+  namespace: toolhive-system
+status:
+  (conditions[?type == 'Available'] | [0].status): "True"
+  (readyReplicas): 1

--- a/test/e2e/chainsaw/operator/test-scenarios/streamable-http/assert-mcpserver-proxy-runner-svc.yaml
+++ b/test/e2e/chainsaw/operator/test-scenarios/streamable-http/assert-mcpserver-proxy-runner-svc.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mcp-yardstick-proxy
+  namespace: toolhive-system

--- a/test/e2e/chainsaw/operator/test-scenarios/streamable-http/assert-mcpserver-running.yaml
+++ b/test/e2e/chainsaw/operator/test-scenarios/streamable-http/assert-mcpserver-running.yaml
@@ -1,0 +1,8 @@
+apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: MCPServer
+metadata:
+  name: yardstick
+  namespace: toolhive-system
+status:
+  message: "MCP server is running"
+  phase: "Running"

--- a/test/e2e/chainsaw/operator/test-scenarios/streamable-http/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/operator/test-scenarios/streamable-http/chainsaw-test.yaml
@@ -1,0 +1,99 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: streamable-http-mcp-server
+spec:
+  description: Deploys Streamable HTTP MCP server and verifies it's running
+  timeouts:
+    apply: 30s
+    assert: 60s
+    cleanup: 30s
+    exec: 300s
+  steps:
+  - name: verify-operator
+    description: Ensure operator is ready before testing
+    try:
+    - assert:
+        file: ../../setup/assert-operator-ready.yaml
+      
+  - name: deploy-mcpserver
+    description: Deploy a basic Streamable HTTP MCPServer instance and verify it's ready
+    try:
+    - apply:
+        file: mcpserver.yaml
+    - assert:
+        file: mcpserver.yaml
+    - assert:
+        file: assert-mcpserver-running.yaml
+    - assert:
+        file: assert-mcpserver-proxy-runner-running.yaml
+    - assert:
+        file: assert-mcpserver-proxy-runner-svc.yaml
+    - assert:
+        file: assert-mcpserver-pod-running.yaml
+    - assert:
+        file: assert-mcpserver-headless-svc.yaml
+
+  - name: test-mcp-server
+    description: Test the StreamableHTTP->StreamableHTTP MCP server by sending requests at the toolhive proxy
+    try:
+    - script:
+        content: |
+          # Start port-forward in background
+          kubectl port-forward svc/mcp-yardstick-proxy -n toolhive-system 8080:8080 > /dev/null 2>&1 &
+          PORT_FORWARD_PID=$!
+          
+          # Function to cleanup port-forward
+          cleanup() {
+            if [ -n "$PORT_FORWARD_PID" ]; then
+              echo "Killing port-forward process $PORT_FORWARD_PID"
+              kill $PORT_FORWARD_PID 2>/dev/null || true
+            fi
+          }
+          
+          # Trap to ensure cleanup on exit
+          trap cleanup EXIT
+          
+          # Wait for port-forward to be ready (longer in CI)
+          sleep 5
+          
+          echo "🌊 ========== StreamableHTTP->StreamableHTTP TRANSPORT TESTING =========="
+          echo "📡 Testing StreamableHTTP transport on port 8080..."
+          
+          # Test StreamableHTTP endpoint with client binary
+          echo "🌊 Testing StreamableHTTP endpoint with client binary..."
+          if yardstick-client -transport streamable-http -address localhost -port 8080 -action info; then
+              echo "✓ StreamableHTTP client connection successful"
+          else
+              echo "! StreamableHTTP client connection failed"
+              exit 1
+          fi
+          
+          # Longer delay between calls for CI stability
+          sleep 3
+          
+          # Test listing tools via StreamableHTTP
+          echo "📋 Testing tool listing via StreamableHTTP..."
+          if yardstick-client -transport streamable-http -address localhost -port 8080 -action list-tools; then
+              echo "✓ StreamableHTTP tools listing successful"
+          else
+              echo "! StreamableHTTP tools listing failed"
+              exit 1
+          fi
+          
+          # Longer delay between calls for CI stability
+          sleep 3
+          
+          echo "🔧 Testing tool calling via StreamableHTTP..."
+          # We want to generate a random string to test the tool calling
+          # and then check if the output contains the string
+          TEST_INPUT_OUTPUT=$(openssl rand -hex 16)
+          if timeout 30 yardstick-client -transport streamable-http -address localhost -port 8080 -action=call-tool -tool=echo -args="{\"input\":\"$TEST_INPUT_OUTPUT\"}" | grep -q "$TEST_INPUT_OUTPUT"; then
+              echo "✓ StreamableHTTP tool call returned expected output: $TEST_INPUT_OUTPUT"
+          else
+              echo "! StreamableHTTP tool call failed or timed out"
+              exit 1
+          fi
+          
+          echo "✅ All StreamableHTTP->StreamableHTTP transport tests passed!"
+          exit 0

--- a/test/e2e/chainsaw/operator/test-scenarios/streamable-http/mcpserver.yaml
+++ b/test/e2e/chainsaw/operator/test-scenarios/streamable-http/mcpserver.yaml
@@ -1,0 +1,23 @@
+apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: MCPServer
+metadata:
+  name: yardstick
+  namespace: toolhive-system
+spec:
+  image: ghcr.io/stackloklabs/yardstick/yardstick-server:0.0.2
+  transport: streamable-http
+  env:
+  - name: TRANSPORT
+    value: streamable-http
+  port: 8080
+  targetPort: 8080
+  permissionProfile:
+    type: builtin
+    name: network
+  resources:
+    limits:
+      cpu: "100m"
+      memory: "128Mi"
+    requests:
+      cpu: "50m"
+      memory: "64Mi"


### PR DESCRIPTION
ToolHive had StreamableHTTP support for local CLI but not for Kubernetes. The bulk of the code has been done already but there were a couple of missing StreamableHTTP checks when creating the headless service for the ToolHive Proxy to contact the StreamableHTTP MCPServer.

This adds those checks as well as the streamableHTTP e2e tests for chainsaw.

Ref: https://github.com/stacklok/toolhive/issues/968