### PR TITLE
feat: adds yardstick examples for Kubernetes MCPServer

### DIFF
--- a/examples/operator/mcp-servers/mcpserver_yardstick_sse.yaml
+++ b/examples/operator/mcp-servers/mcpserver_yardstick_sse.yaml
@@ -1,0 +1,23 @@
+apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: MCPServer
+metadata:
+  name: yardstick
+  namespace: toolhive-system
+spec:
+  image: ghcr.io/stackloklabs/yardstick/yardstick-server:0.0.2
+  transport: sse
+  env:
+  - name: TRANSPORT
+    value: sse
+  port: 8080
+  targetPort: 8080
+  permissionProfile:
+    type: builtin
+    name: network
+  resources:
+    limits:
+      cpu: "100m"
+      memory: "128Mi"
+    requests:
+      cpu: "50m"
+      memory: "64Mi"

--- a/examples/operator/mcp-servers/mcpserver_yardstick_stdio.yaml
+++ b/examples/operator/mcp-servers/mcpserver_yardstick_stdio.yaml
@@ -1,0 +1,19 @@
+apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: MCPServer
+metadata:
+  name: yardstick
+  namespace: toolhive-system
+spec:
+  image: ghcr.io/stackloklabs/yardstick/yardstick-server:0.0.2
+  transport: stdio
+  port: 8080
+  permissionProfile:
+    type: builtin
+    name: network
+  resources:
+    limits:
+      cpu: "100m"
+      memory: "128Mi"
+    requests:
+      cpu: "50m"
+      memory: "64Mi"

--- a/examples/operator/mcp-servers/mcpserver_yardstick_streamablehttp.yaml
+++ b/examples/operator/mcp-servers/mcpserver_yardstick_streamablehttp.yaml
@@ -1,0 +1,23 @@
+apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: MCPServer
+metadata:
+  name: yardstick
+  namespace: toolhive-system
+spec:
+  image: ghcr.io/stackloklabs/yardstick/yardstick-server:0.0.2
+  transport: streamable-http
+  env:
+  - name: TRANSPORT
+    value: streamable-http
+  port: 8080
+  targetPort: 8080
+  permissionProfile:
+    type: builtin
+    name: network
+  resources:
+    limits:
+      cpu: "100m"
+      memory: "128Mi"
+    requests:
+      cpu: "50m"
+      memory: "64Mi"


### PR DESCRIPTION
[`yardstick`](https://github.com/StacklokLabs/yardstick) is our deterministic MCP server for testing. This PR adds three yardstick examples that allow us to test all transport types for Kubernetes.