### PR TITLE
Don't override non-nil PermissionsProfile

### DIFF
--- a/pkg/api/v1/workloads.go
+++ b/pkg/api/v1/workloads.go
@@ -227,7 +227,7 @@ func (s *WorkloadRoutes) createWorkload(w http.ResponseWriter, r *http.Request) 
 
 	// Mimic behavior of the CLI by defaulting to the "network" permission profile.
 	// TODO: Consider moving this into the run config creation logic.
-	if req.PermissionProfile != nil {
+	if req.PermissionProfile == nil {
 		req.PermissionProfile = permissions.BuiltinNetworkProfile()
 	}
 


### PR DESCRIPTION
The condition was probably reversed, meaning that any explicitly set
PermissionProfile requests would be set to the default.
