### PR TITLE
Add support tools filtering.

### DIFF
--- a/cmd/thv/app/run.go
+++ b/cmd/thv/app/run.go
@@ -92,6 +92,9 @@ var (
 
 	// Network isolation flag
 	runIsolateNetwork bool
+
+	// Tool filtering flag
+	runTools []string
 )
 
 func init() {
@@ -224,6 +227,10 @@ func init() {
 			"(comma-separated: ENV1,ENV2)")
 	runCmd.Flags().BoolVar(&runIsolateNetwork, "isolate-network", false,
 		"Isolate the container network from the host (default: false)")
+
+	// Tool filtering flag
+	runCmd.Flags().StringArrayVar(&runTools, "tools", []string{},
+		"Comma-separated list of tools to enable (e.g., --tools=weather,calculator). If not specified, all tools are enabled.")
 
 }
 
@@ -383,6 +390,7 @@ func runCmdFunc(cmd *cobra.Command, args []string) error {
 		runThvCABundle,
 		runJWKSAuthTokenFile,
 		runJWKSAllowPrivateIP,
+		runTools,
 		envVarValidator,
 		types.ProxyMode(runProxyMode),
 	)

--- a/docs/cli/thv_run.md
+++ b/docs/cli/thv_run.md
@@ -78,6 +78,7 @@ thv run [flags] SERVER_OR_IMAGE_OR_PROTOCOL [-- ARGS...]
       --target-host string                    Host to forward traffic to (only applicable to SSE or Streamable HTTP transport) (default "127.0.0.1")
       --target-port int                       Port for the container to expose (only applicable to SSE or Streamable HTTP transport)
       --thv-ca-bundle string                  Path to CA certificate bundle for ToolHive HTTP operations (JWKS, OIDC discovery, etc.)
+      --tools stringArray                     Comma-separated list of tools to enable (e.g., --tools=weather,calculator). If not specified, all tools are enabled.
       --transport string                      Transport mode (sse, streamable-http or stdio)
   -v, --volume stringArray                    Mount a volume into the container (format: host-path:container-path[:ro])
 ```

--- a/pkg/authz/middleware.go
+++ b/pkg/authz/middleware.go
@@ -30,9 +30,8 @@ var MCPMethodToFeatureOperation = map[string]struct {
 	"initialize":      {Feature: "", Operation: ""}, // Always allowed
 }
 
-// shouldSkipInitialAuthorization checks if the request should skip authorization
-// before reading the request body.
-func shouldSkipInitialAuthorization(r *http.Request) bool {
+// shouldSkip checks if the request should skip authorization
+func shouldSkip(r *http.Request) bool {
 	// Skip authorization for non-POST requests and non-JSON content types
 	if r.Method != http.MethodPost || !strings.HasPrefix(r.Header.Get("Content-Type"), "application/json") {
 		return true
@@ -138,7 +137,7 @@ func handleUnauthorized(w http.ResponseWriter, msgID interface{}, err error) {
 func (a *CedarAuthorizer) Middleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Check if we should skip authorization before checking parsed data
-		if shouldSkipInitialAuthorization(r) {
+		if shouldSkip(r) {
 			next.ServeHTTP(w, r)
 			return
 		}

--- a/pkg/authz/templates/tool_filtering_policy.cedar
+++ b/pkg/authz/templates/tool_filtering_policy.cedar
@@ -1,0 +1,9 @@
+// Tool filtering policy template
+// This policy allows access to specific tools based on the --tools flag
+// The tools are interpolated into this template at runtime
+
+// Allow access to specific tools only{{range .Tools}}
+permit(principal, action == Action::"call_tool", resource == Tool::"{{.}}");{{end}}
+
+// Allow listing of tools (for tools/list operations)
+permit(principal, action == Action::"list_tools", resource == FeatureType::"tool");

--- a/pkg/authz/tool_filter.go
+++ b/pkg/authz/tool_filter.go
@@ -1,0 +1,381 @@
+package authz
+
+import (
+	"bytes"
+	"embed"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"text/template"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"golang.org/x/exp/jsonrpc2"
+
+	mcpparser "github.com/stacklok/toolhive/pkg/mcp"
+)
+
+//go:embed templates
+var templateFS embed.FS
+
+// ToolFilteringWriter wraps an http.ResponseWriter to intercept and filter MCP list responses
+// based on configured Cedar policies. It supports filtering tools only.
+// (restored version)
+type ToolFilteringWriter struct {
+	http.ResponseWriter
+	authorizer    *CedarAuthorizer
+	request       *http.Request
+	parsedRequest *mcpparser.ParsedMCPRequest
+	buffer        *bytes.Buffer
+	statusCode    int
+}
+
+// NewToolFilteringWriter creates a new response filtering writer
+func NewToolFilteringWriter(
+	w http.ResponseWriter,
+	authorizer *CedarAuthorizer,
+	r *http.Request,
+	parsedRequest *mcpparser.ParsedMCPRequest,
+) *ToolFilteringWriter {
+	return &ToolFilteringWriter{
+		ResponseWriter: w,
+		authorizer:     authorizer,
+		request:        r,
+		parsedRequest:  parsedRequest,
+		buffer:         &bytes.Buffer{},
+		statusCode:     http.StatusOK,
+	}
+}
+
+// Write captures the response body for filtering
+func (tfw *ToolFilteringWriter) Write(data []byte) (int, error) {
+	return tfw.buffer.Write(data)
+}
+
+// WriteHeader captures the status code
+func (tfw *ToolFilteringWriter) WriteHeader(statusCode int) {
+	tfw.statusCode = statusCode
+}
+
+// Flush processes the captured response and applies filtering if needed
+func (tfw *ToolFilteringWriter) Flush() error {
+	if tfw.statusCode != http.StatusOK && tfw.statusCode != http.StatusAccepted {
+		tfw.ResponseWriter.WriteHeader(tfw.statusCode)
+		_, err := tfw.ResponseWriter.Write(tfw.buffer.Bytes())
+		return err
+	}
+
+	// Check if this is a tools list operation that needs filtering
+	if tfw.parsedRequest.Method != string(mcp.MethodToolsList) {
+		tfw.ResponseWriter.WriteHeader(tfw.statusCode)
+		_, err := tfw.ResponseWriter.Write(tfw.buffer.Bytes())
+		return err
+	}
+
+	rawResponse := tfw.buffer.Bytes()
+	if len(rawResponse) == 0 {
+		tfw.ResponseWriter.WriteHeader(tfw.statusCode)
+		_, err := tfw.ResponseWriter.Write(rawResponse)
+		return err
+	}
+
+	var response jsonrpc2.Response
+	if err := json.Unmarshal(rawResponse, &response); err != nil {
+		tfw.ResponseWriter.WriteHeader(tfw.statusCode)
+		_, err := tfw.ResponseWriter.Write(rawResponse)
+		return err
+	}
+
+	filteredResponse, err := tfw.filterListResponse(&response)
+	if err != nil {
+		return tfw.writeErrorResponse(response.ID, err)
+	}
+
+	filteredData, err := json.Marshal(filteredResponse)
+	if err != nil {
+		return tfw.writeErrorResponse(response.ID, err)
+	}
+
+	tfw.ResponseWriter.WriteHeader(tfw.statusCode)
+	_, err = tfw.ResponseWriter.Write(filteredData)
+	return err
+}
+
+// filterListResponse filters tools based on Cedar policies
+func (tfw *ToolFilteringWriter) filterListResponse(response *jsonrpc2.Response) (*jsonrpc2.Response, error) {
+	if response.Error != nil {
+		// If there's an error in the response, don't filter
+		return response, nil
+	}
+
+	if response.Result == nil {
+		// If there's no result, don't filter
+		return response, nil
+	}
+
+	var listResult mcp.ListToolsResult
+	if err := json.Unmarshal(response.Result, &listResult); err != nil {
+		// If we can't parse it as a list response, just return it as-is
+		return response, nil
+	}
+
+	var filteredTools []mcp.Tool
+
+	for _, tool := range listResult.Tools {
+		if tfw.authorizer != nil {
+			authorized, err := tfw.authorizer.AuthorizeWithJWTClaims(
+				tfw.request.Context(),
+				MCPFeatureTool,
+				MCPOperationCall,
+				tool.Name,
+				nil, // No arguments for the authorization check
+			)
+			if err != nil {
+				// If there's an error checking authorization, skip this tool
+				continue
+			}
+
+			if !authorized {
+				continue
+			}
+		}
+		filteredTools = append(filteredTools, tool)
+	}
+
+	// Create a new result with filtered tools
+	filteredResult := mcp.ListToolsResult{
+		PaginatedResult: listResult.PaginatedResult,
+		Tools:           filteredTools,
+	}
+
+	// Marshal the filtered result back
+	filteredResultData, err := json.Marshal(filteredResult)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create a new response with the filtered result
+	filteredResponse := &jsonrpc2.Response{
+		ID:     response.ID,
+		Result: json.RawMessage(filteredResultData),
+	}
+
+	return filteredResponse, nil
+}
+
+// writeErrorResponse writes an error response
+func (tfw *ToolFilteringWriter) writeErrorResponse(id jsonrpc2.ID, err error) error {
+	errorResponse := &jsonrpc2.Response{
+		ID:    id,
+		Error: jsonrpc2.NewError(500, fmt.Sprintf("Error filtering response: %v", err)),
+	}
+	errorData, err := json.Marshal(errorResponse)
+	if err != nil {
+		return err
+	}
+	tfw.ResponseWriter.WriteHeader(http.StatusInternalServerError)
+	_, err = tfw.ResponseWriter.Write(errorData)
+	return err
+}
+
+// ToolFilteringMiddleware creates an HTTP middleware that filters MCP list responses based on
+// Cedar policies. This middleware intercepts responses
+// and filters out items that are not authorized by Cedar policies.
+// For tools/call requests, it checks authorization before allowing the request to proceed.
+func ToolFilteringMiddleware(
+	authorizer *CedarAuthorizer,
+) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if shouldSkip(r) {
+				next.ServeHTTP(w, r)
+				return
+			}
+			parsedRequest := mcpparser.GetParsedMCPRequest(r.Context())
+			if parsedRequest == nil {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			switch parsedRequest.Method {
+			case string(mcp.MethodToolsCall):
+				handleToolsCall(w, r, parsedRequest, authorizer, next)
+			case string(mcp.MethodToolsList):
+				handleToolsList(w, r, parsedRequest, authorizer, next)
+			default:
+				// For other methods, just pass through
+				next.ServeHTTP(w, r)
+			}
+		})
+	}
+}
+
+// handleToolsCall handles tools/call requests with authorization checks
+func handleToolsCall(
+	w http.ResponseWriter,
+	r *http.Request,
+	parsedRequest *mcpparser.ParsedMCPRequest,
+	authorizer *CedarAuthorizer,
+	next http.Handler,
+) {
+	if authorizer != nil {
+		// Extract tool name from the request
+		toolName := parsedRequest.ResourceID
+		if toolName == "" {
+			// Try to get tool name from arguments
+			if args := parsedRequest.Arguments; args != nil {
+				if name, exists := args["name"]; exists {
+					if nameStr, ok := name.(string); ok {
+						toolName = nameStr
+					}
+				}
+			}
+		}
+
+		if toolName != "" {
+			// Check if the tool is authorized
+			authorized, err := authorizer.AuthorizeWithJWTClaims(
+				r.Context(),
+				MCPFeatureTool,
+				MCPOperationCall,
+				toolName,
+				nil, // No arguments for the authorization check
+			)
+			if err != nil {
+				// If there's an error checking authorization, deny the request
+				writeInvalidParamsResponse(w, parsedRequest.ID, "Authorization check failed")
+				return
+			}
+
+			if !authorized {
+				// Tool is not authorized, return invalid params error
+				writeInvalidParamsResponse(w, parsedRequest.ID, "Unauthorized")
+				return
+			}
+		}
+	}
+	// If authorized or no authorizer, proceed with the request
+	next.ServeHTTP(w, r)
+}
+
+// handleToolsList handles tools/list requests with response filtering
+func handleToolsList(
+	w http.ResponseWriter,
+	r *http.Request,
+	parsedRequest *mcpparser.ParsedMCPRequest,
+	authorizer *CedarAuthorizer,
+	next http.Handler,
+) {
+	filteringWriter := NewToolFilteringWriter(w, authorizer, r, parsedRequest)
+	next.ServeHTTP(filteringWriter, r)
+	if err := filteringWriter.Flush(); err != nil {
+		fmt.Printf("Error flushing filtered response: %v\n", err)
+	}
+}
+
+// writeInvalidParamsResponse writes an invalid params error response
+func writeInvalidParamsResponse(w http.ResponseWriter, id any, message string) {
+	// Convert ID to jsonrpc2.ID
+	var jsonrpcID jsonrpc2.ID
+	switch v := id.(type) {
+	case string:
+		jsonrpcID = jsonrpc2.StringID(v)
+	case int:
+		jsonrpcID = jsonrpc2.Int64ID(int64(v))
+	case int64:
+		jsonrpcID = jsonrpc2.Int64ID(v)
+	case float64:
+		jsonrpcID = jsonrpc2.Int64ID(int64(v))
+	default:
+		jsonrpcID = jsonrpc2.ID{}
+	}
+
+	errorResponse := &jsonrpc2.Response{
+		ID:    jsonrpcID,
+		Error: jsonrpc2.NewError(-32602, message), // -32602 is "Invalid params" error code
+	}
+	errorData, err := json.Marshal(errorResponse)
+	if err != nil {
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, err = w.Write(errorData)
+	if err != nil {
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+}
+
+// CreateToolFilteringAuthorizer creates a Cedar authorizer specifically for tool filtering
+// that interpolates the allowed tools into a policy template
+func CreateToolFilteringAuthorizer(allowedTools []string) (*CedarAuthorizer, error) {
+	if len(allowedTools) == 0 {
+		// If no tools specified, return an error
+		return nil, fmt.Errorf("no tools specified for filtering")
+	}
+
+	// Read the policy template
+	templateData, err := templateFS.ReadFile("templates/tool_filtering_policy.cedar")
+	if err != nil {
+		return nil, fmt.Errorf("failed to read policy template: %w", err)
+	}
+
+	// Parse the template
+	tmpl, err := template.New("tool_filtering_policy").Parse(string(templateData))
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse policy template: %w", err)
+	}
+
+	// Prepare template data
+	data := struct {
+		Tools []string
+	}{
+		Tools: allowedTools,
+	}
+
+	// Execute the template
+	var policyBuilder strings.Builder
+	if err := tmpl.Execute(&policyBuilder, data); err != nil {
+		return nil, fmt.Errorf("failed to execute policy template: %w", err)
+	}
+
+	// Split the policy into individual permit statements
+	policyLines := strings.Split(policyBuilder.String(), "\n")
+	var policies []string
+	for _, line := range policyLines {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "permit(") {
+			policies = append(policies, line)
+		}
+	}
+
+	// Create entities for the allowed tools
+	entities := createToolEntities(allowedTools)
+
+	// Create the authorizer with separate policies for each tool
+	return NewCedarAuthorizer(CedarAuthorizerConfig{
+		Policies:     policies,
+		EntitiesJSON: entities,
+	})
+}
+
+// createToolEntities creates Cedar entities for the allowed tools
+func createToolEntities(allowedTools []string) string {
+	if len(allowedTools) == 0 {
+		return "[]"
+	}
+	entities := make([]map[string]any, 0, len(allowedTools))
+	for _, tool := range allowedTools {
+		entities = append(entities, map[string]any{
+			"uid": map[string]any{
+				"type": "Tool",
+				"id":   tool,
+			},
+			"attrs": map[string]any{"name": tool},
+		})
+	}
+	entitiesJSON, _ := json.Marshal(entities)
+	return string(entitiesJSON)
+}

--- a/pkg/authz/tool_filter_test.go
+++ b/pkg/authz/tool_filter_test.go
@@ -1,0 +1,568 @@
+package authz
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/jsonrpc2"
+
+	"github.com/stacklok/toolhive/pkg/auth"
+	"github.com/stacklok/toolhive/pkg/logger"
+	mcpparser "github.com/stacklok/toolhive/pkg/mcp"
+)
+
+func init() {
+	// Initialize logger for tests
+	logger.Initialize()
+}
+
+func TestToolFilteringMiddleware(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name          string
+		allowedTools  []string
+		inputTools    []mcp.Tool
+		expectedTools []mcp.Tool
+	}{
+		{
+			name:         "no tools configured - allow all",
+			allowedTools: []string{},
+			inputTools: []mcp.Tool{
+				{Name: "weather", Description: "Get weather info"},
+				{Name: "calculator", Description: "Calculate math"},
+			},
+			expectedTools: []mcp.Tool{
+				{Name: "weather", Description: "Get weather info"},
+				{Name: "calculator", Description: "Calculate math"},
+			},
+		},
+		{
+			name:         "specific tools configured - filter",
+			allowedTools: []string{"weather"},
+			inputTools: []mcp.Tool{
+				{Name: "weather", Description: "Get weather info"},
+				{Name: "calculator", Description: "Calculate math"},
+				{Name: "translator", Description: "Translate text"},
+			},
+			expectedTools: []mcp.Tool{
+				{Name: "weather", Description: "Get weather info"},
+			},
+		},
+		{
+			name:         "multiple tools configured - filter",
+			allowedTools: []string{"weather", "calculator"},
+			inputTools: []mcp.Tool{
+				{Name: "weather", Description: "Get weather info"},
+				{Name: "calculator", Description: "Calculate math"},
+				{Name: "translator", Description: "Translate text"},
+			},
+			expectedTools: []mcp.Tool{
+				{Name: "weather", Description: "Get weather info"},
+				{Name: "calculator", Description: "Calculate math"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			// Create a test handler that returns the input tools
+			handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				// Create a tools list response
+				result := mcp.ListToolsResult{
+					Tools: tt.inputTools,
+				}
+
+				// Create JSON-RPC response
+				response := &jsonrpc2.Response{
+					ID: jsonrpc2.StringID("1"),
+					Result: func() json.RawMessage {
+						data, _ := json.Marshal(result)
+						return data
+					}(),
+				}
+
+				// Write response
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode(response)
+			})
+
+			var authorizer *CedarAuthorizer
+			var err error
+			if len(tt.allowedTools) > 0 {
+				authorizer, err = CreateToolFilteringAuthorizer(tt.allowedTools)
+				require.NoError(t, err)
+			} else {
+				// When no tools specified, we can't create an authorizer - this should be handled by the caller
+				// For this test, we'll use nil authorizer which means no filtering
+				authorizer = nil
+			}
+			middleware := ToolFilteringMiddleware(authorizer)
+			filteredHandler := middleware(handler)
+
+			// Create a test request
+			req, err := http.NewRequest("POST", "/messages", bytes.NewBuffer([]byte(`{
+				"jsonrpc": "2.0",
+				"id": "1",
+				"method": "tools/list",
+				"params": {}
+			}`)))
+			require.NoError(t, err)
+			req.Header.Set("Content-Type", "application/json")
+
+			// Add parsed MCP request to context
+			parsedRequest := &mcpparser.ParsedMCPRequest{
+				ID:     "1",
+				Method: string(mcp.MethodToolsList),
+			}
+			ctx := context.WithValue(req.Context(), mcpparser.MCPRequestContextKey, parsedRequest)
+
+			// Add JWT claims to context for authorization
+			claims := jwt.MapClaims{
+				"sub":  "testuser",
+				"name": "Test User",
+				"role": "user",
+			}
+			ctx = context.WithValue(ctx, auth.ClaimsContextKey{}, claims)
+			req = req.WithContext(ctx)
+
+			// Create response recorder
+			rr := httptest.NewRecorder()
+
+			// Call the handler
+			filteredHandler.ServeHTTP(rr, req)
+
+			// Check response
+			assert.Equal(t, http.StatusOK, rr.Code)
+
+			// Parse the response
+			var response jsonrpc2.Response
+			err = json.Unmarshal(rr.Body.Bytes(), &response)
+			require.NoError(t, err)
+
+			// Parse the result
+			var result mcp.ListToolsResult
+			err = json.Unmarshal(response.Result, &result)
+			require.NoError(t, err)
+
+			// Check that the tools are filtered correctly
+			assert.Equal(t, len(tt.expectedTools), len(result.Tools))
+
+			for i, expectedTool := range tt.expectedTools {
+				assert.Equal(t, expectedTool.Name, result.Tools[i].Name)
+				assert.Equal(t, expectedTool.Description, result.Tools[i].Description)
+			}
+		})
+	}
+}
+
+func TestToolFilteringMiddleware_NonToolsListRequest(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name         string
+		method       string
+		params       map[string]any
+		allowedTools []string
+		expectedCode int
+		expectedBody string
+		description  string
+	}{
+		{
+			name:         "tools/call request passes through unchanged when no authorizer",
+			method:       string(mcp.MethodToolsCall),
+			params:       map[string]any{"name": "weather"},
+			allowedTools: []string{},
+			expectedCode: http.StatusOK,
+			expectedBody: "success",
+			description:  "When no authorizer is configured, tools/call requests should pass through",
+		},
+		{
+			name:         "tools/call request for allowed tool passes through",
+			method:       string(mcp.MethodToolsCall),
+			params:       map[string]any{"name": "weather"},
+			allowedTools: []string{"weather"},
+			expectedCode: http.StatusOK,
+			expectedBody: "success",
+			description:  "When tool is in allowed list, tools/call request should pass through",
+		},
+		{
+			name:         "tools/call request for blocked tool is denied",
+			method:       string(mcp.MethodToolsCall),
+			params:       map[string]any{"name": "calculator"},
+			allowedTools: []string{"weather"},
+			expectedCode: http.StatusOK,
+			expectedBody: `{"Result":null,"Error":{"code":-32602,"message":"Unauthorized"},"ID":{}}`,
+			description:  "When tool is not in allowed list, tools/call request should be denied with Invalid Params error",
+		},
+		{
+			name:         "tools/call request for multiple allowed tools passes through",
+			method:       string(mcp.MethodToolsCall),
+			params:       map[string]any{"name": "calculator"},
+			allowedTools: []string{"weather", "calculator", "translator"},
+			expectedCode: http.StatusOK,
+			expectedBody: "success",
+			description:  "When tool is in multiple allowed tools list, tools/call request should pass through",
+		},
+		{
+			name:         "tools/call request for unauthorized tool in multiple allowed list is denied",
+			method:       string(mcp.MethodToolsCall),
+			params:       map[string]any{"name": "unauthorized_tool"},
+			allowedTools: []string{"weather", "calculator", "translator"},
+			expectedCode: http.StatusOK,
+			expectedBody: `{"Result":null,"Error":{"code":-32602,"message":"Unauthorized"},"ID":{}}`,
+			description:  "When tool is not in multiple allowed tools list, tools/call request should be denied with Invalid Params error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			// Create a test handler that returns success
+			handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte("success"))
+			})
+
+			// Create authorizer if tools are specified
+			var authorizer *CedarAuthorizer
+			var err error
+			if len(tt.allowedTools) > 0 {
+				authorizer, err = CreateToolFilteringAuthorizer(tt.allowedTools)
+				require.NoError(t, err)
+			}
+
+			// Create middleware - use ToolFilteringMiddleware for authorization
+			middleware := ToolFilteringMiddleware(authorizer)
+
+			filteredHandler := middleware(handler)
+
+			// Create request body
+			requestBody := map[string]any{
+				"jsonrpc": "2.0",
+				"id":      "1",
+				"method":  tt.method,
+				"params":  tt.params,
+			}
+			requestJSON, _ := json.Marshal(requestBody)
+
+			req, err := http.NewRequest("POST", "/messages", bytes.NewBuffer(requestJSON))
+			require.NoError(t, err)
+			req.Header.Set("Content-Type", "application/json")
+
+			// Add parsed MCP request to context
+			parsedRequest := &mcpparser.ParsedMCPRequest{
+				ID:         "1",
+				Method:     tt.method,
+				ResourceID: tt.params["name"].(string),
+				Arguments:  tt.params,
+			}
+			ctx := context.WithValue(req.Context(), mcpparser.MCPRequestContextKey, parsedRequest)
+
+			// Add JWT claims to context for authorization
+			claims := jwt.MapClaims{
+				"sub":  "testuser",
+				"name": "Test User",
+				"role": "user",
+			}
+			ctx = context.WithValue(ctx, auth.ClaimsContextKey{}, claims)
+			req = req.WithContext(ctx)
+
+			rr := httptest.NewRecorder()
+			filteredHandler.ServeHTTP(rr, req)
+
+			// Check response
+			assert.Equal(t, tt.expectedCode, rr.Code, tt.description)
+
+			if tt.expectedCode == http.StatusOK {
+				assert.Equal(t, tt.expectedBody, rr.Body.String(), tt.description)
+			} else {
+				// For error responses, check that it's a JSON-RPC error with Invalid Params error code
+				responseBody := rr.Body.String()
+				assert.Contains(t, responseBody, "Error", tt.description)
+				assert.Contains(t, responseBody, "-32602", tt.description)
+				assert.Contains(t, responseBody, "Unauthorized", tt.description)
+			}
+		})
+	}
+}
+
+func TestToolFilteringMiddleware_NonPOSTRequest(t *testing.T) {
+	t.Parallel()
+	// Test that non-POST requests pass through unchanged
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("success"))
+	})
+
+	middleware := ToolFilteringMiddleware(nil)
+	filteredHandler := middleware(handler)
+
+	req, err := http.NewRequest("GET", "/messages", nil)
+	require.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+	filteredHandler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, "success", rr.Body.String())
+}
+
+func TestCreateToolFilteringAuthorizer(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name         string
+		allowedTools []string
+		expectError  bool
+	}{
+		{
+			name:         "no tools specified - should error",
+			allowedTools: []string{},
+			expectError:  true,
+		},
+		{
+			name:         "single tool specified",
+			allowedTools: []string{"weather"},
+			expectError:  false,
+		},
+		{
+			name:         "multiple tools specified",
+			allowedTools: []string{"weather", "calculator", "translator"},
+			expectError:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			authorizer, err := CreateToolFilteringAuthorizer(tt.allowedTools)
+
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Nil(t, authorizer)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.NotNil(t, authorizer)
+
+			// Test that the authorizer can authorize tool calls using IsAuthorized directly
+			// When specific tools specified, should only allow those tools
+			for _, tool := range tt.allowedTools {
+				authorizer, err := CreateToolFilteringAuthorizer([]string{tool})
+				assert.NoError(t, err)
+				assert.NotNil(t, authorizer)
+				principal := "Client::testuser"
+				action := "Action::call_tool"
+				resource := fmt.Sprintf("Tool::%s", tool)
+				authorized, err := authorizer.IsAuthorized(
+					principal,
+					action,
+					resource,
+					map[string]any{},
+				)
+				assert.NoError(t, err)
+				assert.True(t, authorized, "Should authorize allowed tool: %s", tool)
+			}
+
+			// Test that unauthorized tools are denied
+			unauthorizedTool := "unauthorized_tool"
+			authorized, err := authorizer.IsAuthorized(
+				"Client::testuser",
+				"Action::call_tool",
+				fmt.Sprintf("Tool::%s", unauthorizedTool),
+				map[string]any{},
+			)
+			assert.NoError(t, err)
+			assert.False(t, authorized, "Should deny unauthorized tool: %s", unauthorizedTool)
+		})
+	}
+}
+
+// TestCedarPolicyTemplateComprehensive tests the Cedar policy template functionality comprehensively
+// including rendering, entities, integration, and error handling
+func TestCedarPolicyTemplateComprehensive(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name            string
+		allowedTools    []string
+		testTools       []string
+		expectedResults []bool
+		expectError     bool
+		testType        string // "rendering", "entities", "integration", "error"
+	}{
+		// Rendering test cases
+		{
+			name:            "rendering - no tools specified - should error",
+			allowedTools:    []string{},
+			testTools:       []string{"any_tool", "another_tool"},
+			expectedResults: []bool{true, true},
+			expectError:     true,
+			testType:        "rendering",
+		},
+		{
+			name:            "rendering - single tool specified - allow only that tool",
+			allowedTools:    []string{"weather"},
+			testTools:       []string{"weather", "calculator", "translator"},
+			expectedResults: []bool{true, false, false},
+			expectError:     false,
+			testType:        "rendering",
+		},
+		{
+			name:            "rendering - multiple tools specified - allow only those tools",
+			allowedTools:    []string{"weather", "calculator", "translator"},
+			testTools:       []string{"weather", "calculator", "translator", "unauthorized"},
+			expectedResults: []bool{true, true, true, false},
+			expectError:     false,
+			testType:        "rendering",
+		},
+		{
+			name:            "rendering - tools with special characters",
+			allowedTools:    []string{"tool-with-dash", "tool_with_underscore", "tool.with.dot"},
+			testTools:       []string{"tool-with-dash", "tool_with_underscore", "tool.with.dot", "normal_tool"},
+			expectedResults: []bool{true, true, true, false},
+			expectError:     false,
+			testType:        "rendering",
+		},
+
+		// Entities test cases
+		{
+			name:            "entities - no tools specified - should error",
+			allowedTools:    []string{},
+			testTools:       []string{"any_tool", "another_tool"},
+			expectedResults: []bool{true, true},
+			expectError:     true,
+			testType:        "entities",
+		},
+		{
+			name:            "entities - single tool specified - allow only that tool",
+			allowedTools:    []string{"weather"},
+			testTools:       []string{"weather", "calculator", "translator"},
+			expectedResults: []bool{true, false, false},
+			expectError:     false,
+			testType:        "entities",
+		},
+		{
+			name:            "entities - multiple tools specified - allow only those tools",
+			allowedTools:    []string{"weather", "calculator", "translator"},
+			testTools:       []string{"weather", "calculator", "translator", "unauthorized"},
+			expectedResults: []bool{true, true, true, false},
+			expectError:     false,
+			testType:        "entities",
+		},
+		{
+			name:            "entities - tools with special characters",
+			allowedTools:    []string{"tool-with-dash", "tool_with_underscore", "tool.with.dot"},
+			testTools:       []string{"tool-with-dash", "tool_with_underscore", "tool.with.dot", "normal_tool"},
+			expectedResults: []bool{true, true, true, false},
+			expectError:     false,
+			testType:        "entities",
+		},
+
+		// Integration test cases
+		{
+			name:            "integration - no tools specified - should error",
+			allowedTools:    []string{},
+			testTools:       []string{"any_tool", "another_tool", "third_tool"},
+			expectedResults: []bool{true, true, true},
+			expectError:     true,
+			testType:        "integration",
+		},
+		{
+			name:            "integration - specific tools - allow only specified",
+			allowedTools:    []string{"weather", "calculator"},
+			testTools:       []string{"weather", "calculator", "translator", "unauthorized"},
+			expectedResults: []bool{true, true, false, false},
+			expectError:     false,
+			testType:        "integration",
+		},
+		{
+			name:            "integration - single tool - allow only that tool",
+			allowedTools:    []string{"weather"},
+			testTools:       []string{"weather", "calculator", "translator"},
+			expectedResults: []bool{true, false, false},
+			expectError:     false,
+			testType:        "integration",
+		},
+
+		// Error handling test cases
+		{
+			name:         "error - no tools specified - should error",
+			allowedTools: []string{},
+			testTools:    []string{},
+			expectError:  true,
+			testType:     "error",
+		},
+		{
+			name:         "error - empty tool name",
+			allowedTools: []string{""},
+			testTools:    []string{},
+			expectError:  false, // Should handle empty strings gracefully
+			testType:     "error",
+		},
+		{
+			name:         "error - tool with quotes",
+			allowedTools: []string{"tool\"with\"quotes"},
+			testTools:    []string{},
+			expectError:  true, // Should error because quotes break Cedar policy syntax
+			testType:     "error",
+		},
+		{
+			name:         "error - tool with newlines",
+			allowedTools: []string{"tool\nwith\nnewlines"},
+			testTools:    []string{},
+			expectError:  true, // Should error because newlines break Cedar policy syntax
+			testType:     "error",
+		},
+		{
+			name:         "error - tool with template syntax",
+			allowedTools: []string{"tool{{with}}template"},
+			testTools:    []string{},
+			expectError:  false, // Should handle template-like syntax in tool names
+			testType:     "error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			authorizer, err := CreateToolFilteringAuthorizer(tt.allowedTools)
+
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Nil(t, authorizer)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, authorizer)
+
+			// For error handling tests, we only test that the authorizer was created successfully
+			if tt.testType == "error" {
+				return
+			}
+
+			// Test each tool to verify the policy and entities work correctly
+			for i, tool := range tt.testTools {
+				authorized, err := authorizer.IsAuthorized(
+					"Client::testuser",
+					"Action::call_tool",
+					fmt.Sprintf("Tool::%s", tool),
+					map[string]any{},
+				)
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedResults[i], authorized,
+					"Tool %s should be %v", tool, tt.expectedResults[i])
+			}
+		})
+	}
+}

--- a/pkg/runner/config.go
+++ b/pkg/runner/config.go
@@ -119,6 +119,9 @@ type RunConfig struct {
 
 	// JWKSAllowPrivateIP allows JWKS/OIDC endpoints on private IP addresses
 	JWKSAllowPrivateIP bool `json:"jwks_allow_private_ip,omitempty" yaml:"jwks_allow_private_ip,omitempty"`
+
+	// Tools is the list of tools to enable for this MCP server
+	Tools []string `json:"tools,omitempty" yaml:"tools,omitempty"`
 }
 
 // WriteJSON serializes the RunConfig to JSON and writes it to the provided writer
@@ -184,6 +187,7 @@ func NewRunConfigFromFlags(
 	thvCABundle string,
 	jwksAuthTokenFile string,
 	jwksAllowPrivateIP bool,
+	tools []string,
 	envVarValidator EnvVarValidator,
 	proxyMode types.ProxyMode,
 ) (*RunConfig, error) {
@@ -209,6 +213,7 @@ func NewRunConfigFromFlags(
 			thvCABundle, jwksAuthTokenFile, jwksAllowPrivateIP).
 		WithTelemetryConfig(otelEndpoint, otelEnablePrometheusMetricsPath, otelServiceName,
 			otelSamplingRate, otelHeaders, otelInsecure, otelEnvironmentVariables).
+		WithTools(tools).
 		Build(ctx, imageMetadata, envVars, envVarValidator)
 }
 

--- a/pkg/runner/config_builder.go
+++ b/pkg/runner/config_builder.go
@@ -234,6 +234,12 @@ func (b *RunConfigBuilder) WithTelemetryConfig(otelEndpoint string, otelEnablePr
 	return b
 }
 
+// WithTools sets the list of tools to enable for this MCP server
+func (b *RunConfigBuilder) WithTools(tools []string) *RunConfigBuilder {
+	b.config.Tools = tools
+	return b
+}
+
 // Build creates the final RunConfig instance with validation and processing
 func (b *RunConfigBuilder) Build(ctx context.Context, imageMetadata *registry.ImageMetadata,
 	envVars []string, envVarValidator EnvVarValidator) (*RunConfig, error) {

--- a/pkg/runner/config_test.go
+++ b/pkg/runner/config_test.go
@@ -859,6 +859,7 @@ func TestNewRunConfigFromFlags(t *testing.T) {
 		"",    // thvCABundle
 		"",    // jwksAuthTokenFile
 		false, // jwksAllowPrivateIP
+		nil,   // tools
 		envVarValidator,
 		"sse",
 	)
@@ -1114,6 +1115,7 @@ func TestNewRunConfigFromFlags_MetadataOverrides(t *testing.T) {
 				"",    // thvCABundle
 				"",    // jwksAuthTokenFile
 				false, // jwksAllowPrivateIP
+				nil,   // tools
 				validator,
 				types.ProxyModeSSE,
 			)
@@ -1163,6 +1165,7 @@ func TestNewRunConfigFromFlags_EnvironmentVariableTransportDependency(t *testing
 		"",    // thvCABundle
 		"",    // jwksAuthTokenFile
 		false, // jwksAllowPrivateIP
+		nil,   // tools
 		validator,
 		types.ProxyModeSSE,
 	)
@@ -1215,6 +1218,7 @@ func TestNewRunConfigFromFlags_CmdArgsMetadataPrepending(t *testing.T) {
 		"",    // thvCABundle
 		"",    // jwksAuthTokenFile
 		false, // jwksAllowPrivateIP
+		nil,   // tools
 		validator,
 		types.ProxyModeSSE,
 	)
@@ -1268,6 +1272,7 @@ func TestNewRunConfigFromFlags_VolumeProcessing(t *testing.T) {
 		"",    // thvCABundle
 		"",    // jwksAuthTokenFile
 		false, // jwksAllowPrivateIP
+		nil,   // tools
 		validator,
 		types.ProxyModeSSE,
 	)


### PR DESCRIPTION
Add tool filtering functionality that intercepts MCP tools/list and tools/call requests using Cedar policies; unauthorized tool calls return HTTP 200 with JSON-RPC "Invalid params" error (-32602); includes template-based policy generation, response filtering, and extensive test coverage for both allowed and denied scenarios.

An additional option `--tools` is available for the `thv run` command.