### PR TITLE
Do not treat missing network as error when deleting

### DIFF
--- a/pkg/container/docker/client.go
+++ b/pkg/container/docker/client.go
@@ -1386,8 +1386,11 @@ func (c *Client) deleteNetwork(ctx context.Context, name string) error {
 	if err != nil {
 		return err
 	}
+
+	// If the network does not exist, return nil.
 	if len(networks) == 0 {
-		return fmt.Errorf("network %s not found", name)
+		logger.Debugf("network %s not found, nothing to delete", name)
+		return nil
 	}
 
 	if err := c.client.NetworkRemove(ctx, networks[0].ID); err != nil {


### PR DESCRIPTION
Previously the code treated a missing network as an error condition during deletion. This leads to some unhelpful warning messages in the log when cleaning up a workload. Remove the error, but leave a debug-level log in case it is useful for debugging networking problems.