### PR TITLE
Fix elasticsearch in registry

### DIFF
--- a/pkg/registry/data/registry.json
+++ b/pkg/registry/data/registry.json
@@ -352,7 +352,7 @@
       "transport": "stdio"
     },
     "elasticsearch": {
-      "args": [],
+      "args": ["http"],
       "description": "Connect to your Elasticsearch data directly from any MCP Client.",
       "env_vars": [
         {
@@ -430,14 +430,16 @@
         "metrics",
         "logs"
       ],
+      "target_port": 8080,
       "tier": "Official",
       "tools": [
+        "esql",
         "get_mappings",
         "get_shards",
         "list_indices",
         "search"
       ],
-      "transport": "stdio"
+      "transport": "streamable-http"
     },
     "everything": {
       "args": [],


### PR DESCRIPTION
The elasticsearch MCP now requires the transport as a command-line argument. It was failing to start without it.

Took the opportunity to switch it from `stdio` to `streamable-http`. Also refreshed the tools list to add a new one.

I've tested with a local ES stack.