### PR TITLE
Implement the new User Agent sent to the update service

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -94,21 +94,35 @@ func updateCheckMiddleware() func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			go func() {
-				versionClient := updates.NewVersionClient()
+				component, version := getComponentAndVersionFromRequest(r)
+				versionClient := updates.NewVersionClientForComponent(component, version)
+
 				updateChecker, err := updates.NewUpdateChecker(versionClient)
 				if err != nil {
-					logger.Warnf("unable to create update client for API: %s", err)
+					logger.Warnf("unable to create update client for %s: %s", component, err)
 					return
 				}
 
 				err = updateChecker.CheckLatestVersion()
 				if err != nil {
-					logger.Warnf("could not check for updates for API: %s", err)
+					logger.Warnf("could not check for updates for %s: %s", component, err)
 				}
 			}()
 			next.ServeHTTP(w, r)
 		})
 	}
+}
+
+// getComponentAndVersionFromRequest determines the component name and version from the request
+func getComponentAndVersionFromRequest(r *http.Request) (string, string) {
+	clientType := r.Header.Get("X-Client-Type")
+
+	if clientType == "toolhive-studio" {
+		version := r.Header.Get("X-Client-Version")
+		return "UI", version
+	}
+
+	return "API", ""
 }
 
 // Serve starts the server on the given address and serves the API.

--- a/pkg/operator/telemetry/telemetry.go
+++ b/pkg/operator/telemetry/telemetry.go
@@ -84,7 +84,7 @@ func NewService(k8sClient client.Client, namespace string) *Service {
 	}
 	return &Service{
 		client:        k8sClient,
-		versionClient: updates.NewVersionClientForComponent("operator", ""),
+		versionClient: updates.NewVersionClientForComponent("operator", "", false),
 		namespace:     namespace,
 	}
 }

--- a/pkg/operator/telemetry/telemetry.go
+++ b/pkg/operator/telemetry/telemetry.go
@@ -84,7 +84,7 @@ func NewService(k8sClient client.Client, namespace string) *Service {
 	}
 	return &Service{
 		client:        k8sClient,
-		versionClient: updates.NewVersionClientWithSuffix("operator"),
+		versionClient: updates.NewVersionClientForComponent("operator", ""),
 		namespace:     namespace,
 	}
 }

--- a/pkg/updates/client_test.go
+++ b/pkg/updates/client_test.go
@@ -6,37 +6,48 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestNewVersionClientWithSuffix(t *testing.T) {
+func TestNewVersionClientForComponent(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name     string
-		suffix   string
-		expected string
+		name      string
+		component string
+		version   string
+		expected  string
 	}{
 		{
-			name:     "no suffix",
-			suffix:   "",
-			expected: "",
+			name:      "CLI component",
+			component: "CLI",
+			version:   "",
+			expected:  "CLI",
 		},
 		{
-			name:     "operator suffix",
-			suffix:   "operator",
-			expected: "operator",
+			name:      "operator component",
+			component: "operator",
+			version:   "",
+			expected:  "operator",
 		},
 		{
-			name:     "custom suffix",
-			suffix:   "custom",
-			expected: "custom",
+			name:      "UI component with version",
+			component: "UI",
+			version:   "2.0.0",
+			expected:  "UI",
+		},
+		{
+			name:      "API component",
+			component: "API",
+			version:   "",
+			expected:  "API",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			client := NewVersionClientWithSuffix(tt.suffix)
+			client := NewVersionClientForComponent(tt.component, tt.version)
 			defaultClient, ok := client.(*defaultVersionClient)
 			assert.True(t, ok, "Expected defaultVersionClient type")
-			assert.Equal(t, tt.expected, defaultClient.userAgentSuffix)
+			assert.Equal(t, tt.expected, defaultClient.component)
+			assert.Equal(t, tt.version, defaultClient.customVersion)
 		})
 	}
 }

--- a/pkg/updates/client_test.go
+++ b/pkg/updates/client_test.go
@@ -9,45 +9,58 @@ import (
 func TestNewVersionClientForComponent(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name      string
-		component string
-		version   string
-		expected  string
+		name           string
+		component      string
+		version        string
+		uiReleaseBuild bool
+		expected       string
 	}{
 		{
-			name:      "CLI component",
-			component: "CLI",
-			version:   "",
-			expected:  "CLI",
+			name:           "CLI component",
+			component:      "CLI",
+			version:        "",
+			uiReleaseBuild: false,
+			expected:       "CLI",
 		},
 		{
-			name:      "operator component",
-			component: "operator",
-			version:   "",
-			expected:  "operator",
+			name:           "operator component",
+			component:      "operator",
+			version:        "",
+			uiReleaseBuild: false,
+			expected:       "operator",
 		},
 		{
-			name:      "UI component with version",
-			component: "UI",
-			version:   "2.0.0",
-			expected:  "UI",
+			name:           "UI component with version and release build",
+			component:      "UI",
+			version:        "2.0.0",
+			uiReleaseBuild: true,
+			expected:       "UI",
 		},
 		{
-			name:      "API component",
-			component: "API",
-			version:   "",
-			expected:  "API",
+			name:           "UI component with version and local build",
+			component:      "UI",
+			version:        "2.0.0",
+			uiReleaseBuild: false,
+			expected:       "UI",
+		},
+		{
+			name:           "API component",
+			component:      "API",
+			version:        "",
+			uiReleaseBuild: false,
+			expected:       "API",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			client := NewVersionClientForComponent(tt.component, tt.version)
+			client := NewVersionClientForComponent(tt.component, tt.version, tt.uiReleaseBuild)
 			defaultClient, ok := client.(*defaultVersionClient)
 			assert.True(t, ok, "Expected defaultVersionClient type")
 			assert.Equal(t, tt.expected, defaultClient.component)
 			assert.Equal(t, tt.version, defaultClient.customVersion)
+			assert.Equal(t, tt.uiReleaseBuild, defaultClient.uiReleaseBuild)
 		})
 	}
 }


### PR DESCRIPTION
Implements the new User Agent sent to the update service. The new User Agent now has the following format:
`toolhive/[component] [vXX] [release/local_build] ([operating_system])`

This PR includes the logic to obtain the component (CLI, API, operator, Toolhive UI), gets the version, adds the release/local_build flag based on the BuildType, and gets some base OS information.