### PR TITLE
Changes MCP_HOST set by toolhive to 0.0.0.0

### DIFF
--- a/cmd/thv/app/run_flags.go
+++ b/cmd/thv/app/run_flags.go
@@ -95,7 +95,7 @@ func AddRunFlags(cmd *cobra.Command, config *RunFlags) {
 	cmd.Flags().StringVar(
 		&config.TargetHost,
 		"target-host",
-		transport.LocalhostIPv4,
+		transport.TargetHostIPv4,
 		"Host to forward traffic to (only applicable to SSE or Streamable HTTP transport)")
 	cmd.Flags().StringVar(
 		&config.PermissionProfile,

--- a/docs/cli/thv_run.md
+++ b/docs/cli/thv_run.md
@@ -93,7 +93,7 @@ thv run [flags] SERVER_OR_IMAGE_OR_PROTOCOL [-- ARGS...]
       --proxy-mode string                     Proxy mode for stdio transport (sse or streamable-http) (default "sse")
       --proxy-port int                        Port for the HTTP proxy to listen on (host port)
       --secret stringArray                    Specify a secret to be fetched from the secrets manager and set as an environment variable (format: NAME,target=TARGET)
-      --target-host string                    Host to forward traffic to (only applicable to SSE or Streamable HTTP transport) (default "127.0.0.1")
+      --target-host string                    Host to forward traffic to (only applicable to SSE or Streamable HTTP transport) (default "0.0.0.0")
       --target-port int                       Port for the container to expose (only applicable to SSE or Streamable HTTP transport)
       --thv-ca-bundle string                  Path to CA certificate bundle for ToolHive HTTP operations (JWKS, OIDC discovery, etc.)
       --tools stringArray                     Filter MCP server tools (comma-separated list of tool names)

--- a/pkg/transport/http.go
+++ b/pkg/transport/http.go
@@ -21,6 +21,8 @@ const (
 	LocalhostName = "localhost"
 	// LocalhostIPv4 is the standard IPv4 address for localhost
 	LocalhostIPv4 = "127.0.0.1"
+	// TargetHostIPv4 is the standard IPv4 address for the target host
+	TargetHostIPv4 = "0.0.0.0"
 )
 
 // HTTPTransport implements the Transport interface using Server-Sent/Streamable Events.
@@ -66,9 +68,9 @@ func NewHTTPTransport(
 		host = LocalhostIPv4
 	}
 
-	// If targetHost is not specified, default to localhost
+	// If targetHost is not specified, default to bind to all interfaces
 	if targetHost == "" {
-		targetHost = LocalhostIPv4
+		targetHost = TargetHostIPv4
 	}
 
 	return &HTTPTransport{


### PR DESCRIPTION
Bind `MCP_HOST` in the container to all interfaces by default so that the mcp server is reachable from the host