### PR TITLE
Use new MCP config path for VS Code 1.102 and later

### DIFF
--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -111,7 +111,7 @@ var supportedClientIntegrations = []mcpClientConfig{
 	{
 		ClientType:   VSCodeInsider,
 		Description:  "Visual Studio Code Insiders",
-		SettingsFile: "settings.json",
+		SettingsFile: "mcp.json",
 		RelPath: []string{
 			"Code - Insiders", "User",
 		},
@@ -120,7 +120,7 @@ var supportedClientIntegrations = []mcpClientConfig{
 			"darwin":  {"Library", "Application Support"},
 			"windows": {"AppData", "Roaming"},
 		},
-		MCPServersPathPrefix: "/mcp/servers",
+		MCPServersPathPrefix: "/servers",
 		Extension:            JSON,
 		SupportedTransportTypesMap: map[types.TransportType]string{
 			types.TransportTypeStdio:          "sse",
@@ -132,11 +132,11 @@ var supportedClientIntegrations = []mcpClientConfig{
 	{
 		ClientType:   VSCode,
 		Description:  "Visual Studio Code",
-		SettingsFile: "settings.json",
+		SettingsFile: "mcp.json",
 		RelPath: []string{
 			"Code", "User",
 		},
-		MCPServersPathPrefix: "/mcp/servers",
+		MCPServersPathPrefix: "/servers",
 		PlatformPrefix: map[string][]string{
 			"linux":   {".config"},
 			"darwin":  {"Library", "Application Support"},


### PR DESCRIPTION
Release 1.102 of VS Code expects MCP configuration to be defined in an `mcp.json` file instead of the `settings.json` file. Change the configuration code to use this new file instead.

As part of this change, we debated whether we should support the old path as well. We decided not to since:

1) VS Code pushes updates aggressively, so we do not think that old
   versions will remain in use long term.
2) MCP support in the older releases was in a "preview" mode, so it was
   not intended to be stable long term.