### PR TITLE
Run client config CLI tests sequentially

### DIFF
--- a/cmd/thv/app/client_test.go
+++ b/cmd/thv/app/client_test.go
@@ -26,8 +26,7 @@ func removeClientViaCLI(cmd *cobra.Command, client string) error {
 	return cmd.Execute()
 }
 
-func TestClientRegisterCmd(t *testing.T) {
-	t.Parallel()
+func TestClientRegisterCmd(t *testing.T) { //nolint:paralleltest // Uses environment variables
 	tempDir := t.TempDir()
 	os.Setenv("XDG_CONFIG_HOME", tempDir)
 
@@ -40,11 +39,7 @@ func TestClientRegisterCmd(t *testing.T) {
 	assert.Contains(t, cfg.Clients.RegisteredClients, "vscode", "Client should be registered")
 }
 
-// This test is failing due to a race condition.
-// We probably should refactor the code to accept a path instead of using the global config path.
-/*
-func TestClientRemoveCmd(t *testing.T) {
-	t.Parallel()
+func TestClientRemoveCmd(t *testing.T) { //nolint:paralleltest // Uses environment variables
 	tempDir := t.TempDir()
 	os.Setenv("XDG_CONFIG_HOME", tempDir)
 
@@ -62,10 +57,8 @@ func TestClientRemoveCmd(t *testing.T) {
 	cfg := config.GetConfig()
 	assert.NotContains(t, cfg.Clients.RegisteredClients, "vscode", "Client should be removed")
 }
-*/
 
-func TestClientRegisterCmd_InvalidClient(t *testing.T) {
-	t.Parallel()
+func TestClientRegisterCmd_InvalidClient(t *testing.T) { //nolint:paralleltest // Uses environment variables
 	tempDir := t.TempDir()
 	os.Setenv("XDG_CONFIG_HOME", tempDir)
 
@@ -76,8 +69,7 @@ func TestClientRegisterCmd_InvalidClient(t *testing.T) {
 	assert.True(t, strings.Contains(err.Error(), "invalid client type"))
 }
 
-func TestClientRemoveCmd_InvalidClient(t *testing.T) {
-	t.Parallel()
+func TestClientRemoveCmd_InvalidClient(t *testing.T) { //nolint:paralleltest // Uses environment variables
 	tempDir := t.TempDir()
 	os.Setenv("XDG_CONFIG_HOME", tempDir)
 

--- a/pkg/runner/config_test.go
+++ b/pkg/runner/config_test.go
@@ -858,7 +858,7 @@ func TestNewRunConfigFromFlags_MetadataOverrides(t *testing.T) {
 				permissions.ProfileNone,
 				"localhost",
 				tt.userTransport,
-				8080, // port
+				0, // port
 				tt.userTargetPort,
 				nil, // envVars
 				nil, // labels

--- a/pkg/runner/config_test.go
+++ b/pkg/runner/config_test.go
@@ -486,14 +486,14 @@ func TestRunConfig_WithStandardLabels(t *testing.T) {
 				Name:            "test-server",
 				Image:           "test-image",
 				Transport:       types.TransportTypeSSE,
-				Port:            8080,
+				Port:            60000,
 				ContainerLabels: map[string]string{},
 			},
 			expected: map[string]string{
 				"toolhive":           "true",
 				"toolhive-name":      "test-server",
 				"toolhive-transport": "sse",
-				"toolhive-port":      "8080",
+				"toolhive-port":      "60000",
 				"toolhive-tool-type": "mcp",
 			},
 		},
@@ -575,7 +575,7 @@ func TestNewRunConfigFromFlags(t *testing.T) { //nolint:paralleltest
 	permissionProfile := permissions.ProfileNone
 	targetHost := "localhost"
 	mcpTransport := "sse"
-	port := 8080
+	proxyPort := 60000
 	targetPort := 9000
 	envVars := []string{"TEST_ENV=test_value"}
 	oidcIssuer := "https://issuer.example.com"
@@ -602,7 +602,7 @@ func TestNewRunConfigFromFlags(t *testing.T) { //nolint:paralleltest
 		permissionProfile,
 		targetHost,
 		mcpTransport,
-		port,
+		proxyPort,
 		targetPort,
 		envVars,
 		nil, // labels
@@ -651,7 +651,7 @@ func TestNewRunConfigFromFlags(t *testing.T) { //nolint:paralleltest
 
 	// Check transport settings
 	assert.Equal(t, types.TransportTypeSSE, config.Transport, "Transport should be set to SSE")
-	assert.Equal(t, port, config.Port, "ProxyPort should match")
+	assert.Equal(t, proxyPort, config.Port, "ProxyPort should match")
 	assert.Equal(t, targetPort, config.TargetPort, "TargetPort should match")
 
 	// Check OIDC config
@@ -675,7 +675,7 @@ func TestRunConfig_WriteJSON_ReadJSON(t *testing.T) {
 		ContainerName: "test-container",
 		BaseName:      "test-base",
 		Transport:     types.TransportTypeSSE,
-		Port:          8080,
+		Port:          60000,
 		TargetPort:    9000,
 		Debug:         true,
 		ContainerLabels: map[string]string{
@@ -918,7 +918,7 @@ func TestNewRunConfigFromFlags_EnvironmentVariableTransportDependency(t *testing
 		permissions.ProfileNone,
 		"localhost",
 		"sse", // This should result in MCP_TRANSPORT=sse in env vars
-		8080,
+		0,
 		9000, // This should result in MCP_PORT=9000 in env vars
 		[]string{"USER_VAR=value"},
 		nil,                   // labels
@@ -971,7 +971,7 @@ func TestNewRunConfigFromFlags_CmdArgsMetadataPrepending(t *testing.T) {
 		permissions.ProfileNone,
 		"localhost",
 		"",
-		8080,
+		0,
 		0,
 		nil,
 		nil, // labels
@@ -1025,7 +1025,7 @@ func TestNewRunConfigFromFlags_VolumeProcessing(t *testing.T) {
 		permissions.ProfileNone, // Start with none profile
 		"localhost",
 		"",
-		8080,
+		0,
 		0,
 		nil,
 		nil, // labels

--- a/pkg/runner/config_test.go
+++ b/pkg/runner/config_test.go
@@ -554,9 +554,7 @@ func (*mockEnvVarValidator) Validate(_ context.Context, _ *registry.ImageMetadat
 	return suppliedEnvVars, nil
 }
 
-func TestNewRunConfigFromFlags(t *testing.T) {
-	t.Parallel()
-
+func TestNewRunConfigFromFlags(t *testing.T) { //nolint:paralleltest
 	// Needed to prevent a nil pointer dereference in the logger.
 	logger.Initialize()
 	runtime := &mocks.MockRuntime{}

--- a/pkg/runner/config_test.go
+++ b/pkg/runner/config_test.go
@@ -554,7 +554,9 @@ func (*mockEnvVarValidator) Validate(_ context.Context, _ *registry.ImageMetadat
 	return suppliedEnvVars, nil
 }
 
-func TestNewRunConfigFromFlags(t *testing.T) { //nolint:paralleltest
+func TestNewRunConfigFromFlags(t *testing.T) {
+	t.Parallel()
+
 	// Needed to prevent a nil pointer dereference in the logger.
 	logger.Initialize()
 	runtime := &mocks.MockRuntime{}


### PR DESCRIPTION
These are causing race conditions since they execute in parallel and need to set an environment variable in order to work.

Another issue I found: Now that we enforce that the proxy port is not already used, tests would fail locally when the sample port of 8080 was already in used.

Regarding the config env var race condition - In future, we may move the config to a database file, and we should address the lack of parameterization of the path at that point in time.