### PR TITLE
Handle empty client config files

### DIFF
--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -411,6 +411,10 @@ func validateConfigFileFormat(cf *ConfigFile) error {
 		return fmt.Errorf("failed to read file %s: %w", cf.Path, err)
 	}
 
+	if len(data) == 0 {
+		data = []byte("{}") // Default to an empty JSON object if the file is empty
+	}
+
 	// Default to JSON
 	// we don't care about the contents of the file, we just want to validate that it's valid JSON
 	_, err = hujson.Parse(data)

--- a/pkg/client/config_editor.go
+++ b/pkg/client/config_editor.go
@@ -58,6 +58,11 @@ func (jcu *JSONConfigUpdater) Upsert(serverName string, data MCPServer) error {
 		logger.Errorf("Failed to read file: %v", err)
 	}
 
+	if len(content) == 0 {
+		// If the file is empty, we need to initialize it with an empty JSON object
+		content = []byte("{}")
+	}
+
 	content = ensurePathExists(content, jcu.MCPServersPathPrefix)
 
 	v, _ := hujson.Parse(content)
@@ -110,6 +115,11 @@ func (jcu *JSONConfigUpdater) Remove(serverName string) error {
 	content, err := os.ReadFile(jcu.Path)
 	if err != nil {
 		logger.Errorf("Failed to read file: %v", err)
+	}
+
+	if len(content) == 0 {
+		// If the file is empty, there is nothing to remove.
+		return nil
 	}
 
 	v, _ := hujson.Parse(content)


### PR DESCRIPTION
If the config file for an MCP server was empty during an insert or delete, thv would error out. Change the behaviour to:

1. When inserting, check if the file is empty, and set its contents to an empty JSON object.
2. When removing, check if the file is empty and do nothing - if the file is empty, then there's no point in changing it.

Fixes: #1094 