### PR TITLE
Enforce go mod tidy on renovate updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,5 +15,6 @@
       ],
       "matchFileNames": ["deploy/charts/operator/**"]
     }
-  ]
+  ],
+ "postUpdateOptions": ["gomodTidy"]
 }


### PR DESCRIPTION
Default behaviour was leaving stale entries in the go.sum file, which caused various problems.