### PR TITLE
Disable caching the registry

### DIFF
--- a/pkg/registry/provider_embedded.go
+++ b/pkg/registry/provider_embedded.go
@@ -20,7 +20,7 @@ func NewEmbeddedRegistryProvider() *EmbeddedRegistryProvider {
 }
 
 // GetRegistry returns the embedded registry data
-func (p *EmbeddedRegistryProvider) GetRegistry() (*Registry, error) {
+func (*EmbeddedRegistryProvider) GetRegistry() (*Registry, error) {
 	data, err := embeddedRegistryFS.ReadFile("data/registry.json")
 	if err != nil {
 		return nil, fmt.Errorf("failed to read embedded registry data: %w", err)

--- a/pkg/registry/provider_remote.go
+++ b/pkg/registry/provider_remote.go
@@ -31,7 +31,7 @@ func (p *RemoteRegistryProvider) GetRegistry() (*Registry, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to build http client: %w", err)
 	}
-	
+
 	resp, err := client.Get(p.registryURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch registry data from URL %s: %w", p.registryURL, err)


### PR DESCRIPTION
The following PR disables the registry caching for both pre-built and remote registries.

Fixes: https://github.com/stacklok/toolhive/issues/1112