### PR TITLE
Update filesystem MCP and remove default file permissions

### DIFF
--- a/pkg/registry/data/registry.json
+++ b/pkg/registry/data/registry.json
@@ -387,12 +387,8 @@
             "insecure_allow_all": false
           }
         },
-        "read": [
-          "/tmp"
-        ],
-        "write": [
-          "/tmp"
-        ]
+        "read": [],
+        "write": []
       },
       "repository_url": "https://github.com/buildkite/buildkite-mcp-server",
       "status": "Active",
@@ -625,8 +621,10 @@
       "transport": "streamable-http"
     },
     "filesystem": {
-      "args": [],
-      "description": "Allows you to do filesystem operations.",
+      "args": [
+        "/projects"
+      ],
+      "description": "Allows you to do filesystem operations. Mount paths under /projects using --volume.",
       "env_vars": [],
       "image": "mcp/filesystem:latest",
       "metadata": {
@@ -642,12 +640,8 @@
             "insecure_allow_all": false
           }
         },
-        "read": [
-          "/tmp"
-        ],
-        "write": [
-          "/tmp"
-        ]
+        "read": [],
+        "write": []
       },
       "repository_url": "https://github.com/modelcontextprotocol/servers",
       "status": "Active",
@@ -671,6 +665,7 @@
         "edit_file",
         "create_directory",
         "list_directory",
+        "directory_tree",
         "move_file",
         "search_files",
         "get_file_info",


### PR DESCRIPTION
The filesystem MCP requires command-line args to set the allowed directories (relative to the container). It fails to start if no arg is provided.

Adding `/projects` to the default CLI args in the registry to match the default Docker approach [documented here](https://github.com/modelcontextprotocol/servers/tree/main/src/filesystem#docker). This way, users can mount into /projects using `--volume` without also having to add the args.

Also removing some default filesystem permissions from the registry; we shouldn't mount any host paths into MCPs by default.