### PR TITLE
Fix description of the `--otel-insecure` flag

### DIFF
--- a/cmd/thv-proxyrunner/app/run.go
+++ b/cmd/thv-proxyrunner/app/run.go
@@ -174,7 +174,7 @@ func init() {
 	runCmd.Flags().StringArrayVar(&runOtelHeaders, "otel-headers", nil,
 		"OpenTelemetry OTLP headers in key=value format (e.g., x-honeycomb-team=your-api-key)")
 	runCmd.Flags().BoolVar(&runOtelInsecure, "otel-insecure", false,
-		"Disable TLS verification for OpenTelemetry endpoint")
+		"Connect to the OpenTelemetry endpoint using HTTP instead of HTTPS")
 	runCmd.Flags().BoolVar(&runOtelEnablePrometheusMetricsPath, "otel-enable-prometheus-metrics-path", false,
 		"Enable Prometheus-style /metrics endpoint on the main transport port")
 	runCmd.Flags().BoolVar(&runIsolateNetwork, "isolate-network", false,

--- a/cmd/thv/app/run.go
+++ b/cmd/thv/app/run.go
@@ -218,7 +218,7 @@ func init() {
 	runCmd.Flags().StringArrayVar(&runOtelHeaders, "otel-headers", nil,
 		"OpenTelemetry OTLP headers in key=value format (e.g., x-honeycomb-team=your-api-key)")
 	runCmd.Flags().BoolVar(&runOtelInsecure, "otel-insecure", false,
-		"Disable TLS verification for OpenTelemetry endpoint")
+		"Connect to the OpenTelemetry endpoint using HTTP instead of HTTPS")
 	runCmd.Flags().BoolVar(&runOtelEnablePrometheusMetricsPath, "otel-enable-prometheus-metrics-path", false,
 		"Enable Prometheus-style /metrics endpoint on the main transport port")
 	runCmd.Flags().StringArrayVar(&runOtelEnvironmentVariables, "otel-env-vars", nil,

--- a/docs/cli/thv_run.md
+++ b/docs/cli/thv_run.md
@@ -69,7 +69,7 @@ thv run [flags] SERVER_OR_IMAGE_OR_PROTOCOL [-- ARGS...]
       --otel-endpoint string                  OpenTelemetry OTLP endpoint URL (e.g., https://api.honeycomb.io)
       --otel-env-vars stringArray             Environment variable names to include in OpenTelemetry spans (comma-separated: ENV1,ENV2)
       --otel-headers stringArray              OpenTelemetry OTLP headers in key=value format (e.g., x-honeycomb-team=your-api-key)
-      --otel-insecure                         Disable TLS verification for OpenTelemetry endpoint
+      --otel-insecure                         Connect to the OpenTelemetry endpoint using HTTP instead of HTTPS
       --otel-sampling-rate float              OpenTelemetry trace sampling rate (0.0-1.0) (default 0.1)
       --otel-service-name string              OpenTelemetry service name (defaults to toolhive-mcp-proxy)
       --permission-profile string             Permission profile to use (none, network, or path to JSON file)

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -73,7 +73,7 @@ thv run \
 | `--otel-service-name` | Service name for telemetry | `toolhive-mcp-proxy` |
 | `--otel-sampling-rate` | Trace sampling rate (0.0-1.0) | `0.1` (10%) |
 | `--otel-headers` | Authentication headers (key=value format) | None |
-| `--otel-insecure` | Disable TLS verification | `false` |
+| `--otel-insecure` | Connect using HTTP instead of HTTPS | `false` |
 | `--otel-enable-prometheus-metrics-path` | Enable Prometheus `/metrics` endpoint on main transport port | `false` (disabled) |
 | `--otel-env-vars` | Environment variable names to include as span attributes (comma-separated) | None |
 
@@ -497,7 +497,6 @@ Control trace volume and costs with sampling:
 - Verify OTLP endpoint URL and authentication headers
 - Check network connectivity to the endpoint
 - Ensure sampling rate is not too low
-- Verify TLS configuration with `--otel-insecure` for testing
 
 **Prometheus metrics not available**:
 - Confirm `--otel-enable-prometheus-metrics-path` is set

--- a/pkg/telemetry/config.go
+++ b/pkg/telemetry/config.go
@@ -45,7 +45,7 @@ type Config struct {
 	// Headers contains authentication headers for the OTLP endpoint
 	Headers map[string]string
 
-	// Insecure indicates whether to disable TLS verification
+	// Insecure indicates whether to use HTTP instead of HTTPS for the OTLP endpoint
 	Insecure bool
 
 	// EnablePrometheusMetricsPath controls whether to expose Prometheus-style /metrics endpoint


### PR DESCRIPTION
The `--otel-insecure` option is described incorredtly in the CLI; it doesn't disable TLS verification, it causes HTTP to be used instead of HTTPS.

Per the `otlptracehttp.WithInsecure()` [docs](https://pkg.go.dev/go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp@v1.37.0#WithInsecure)