### PR TITLE
Make transparent proxy healthcheck configurable

### DIFF
--- a/cmd/thv/app/proxy.go
+++ b/cmd/thv/app/proxy.go
@@ -214,7 +214,7 @@ func proxyCmdFunc(cmd *cobra.Command, args []string) error {
 		port, proxyTargetURI)
 
 	// Create the transparent proxy with middlewares
-	proxy := transparent.NewTransparentProxy(proxyHost, port, serverName, proxyTargetURI, nil, middlewares...)
+	proxy := transparent.NewTransparentProxy(proxyHost, port, serverName, proxyTargetURI, nil, false, middlewares...)
 	if err := proxy.Start(ctx); err != nil {
 		return fmt.Errorf("failed to start proxy: %v", err)
 	}

--- a/pkg/transport/http.go
+++ b/pkg/transport/http.go
@@ -229,8 +229,9 @@ func (t *HTTPTransport) Start(ctx context.Context) error {
 	logger.Infof("Setting up transparent proxy to forward from host port %d to %s",
 		t.proxyPort, targetURI)
 
-	// Create the transparent proxy with middlewares
-	t.proxy = transparent.NewTransparentProxy(t.host, t.proxyPort, t.containerName, targetURI, t.prometheusHandler, t.middlewares...)
+	// Create the transparent proxy with middlewares (enable healthcheck for MCP servers)
+	t.proxy = transparent.NewTransparentProxy(
+		t.host, t.proxyPort, t.containerName, targetURI, t.prometheusHandler, true, t.middlewares...)
 	if err := t.proxy.Start(ctx); err != nil {
 		return err
 	}

--- a/pkg/transport/proxy/transparent/transparent_test.go
+++ b/pkg/transport/proxy/transparent/transparent_test.go
@@ -20,7 +20,7 @@ func init() {
 
 func TestStreamingSessionIDDetection(t *testing.T) {
 	t.Parallel()
-	proxy := NewTransparentProxy("127.0.0.1", 0, "test", "http://example.com", nil)
+	proxy := NewTransparentProxy("127.0.0.1", 0, "test", "http://example.com", nil, true)
 	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream; charset=utf-8")
 		w.WriteHeader(200)
@@ -77,7 +77,7 @@ func createBasicProxy(p *TransparentProxy, targetURL *url.URL) *httputil.Reverse
 func TestNoSessionIDInNonSSE(t *testing.T) {
 	t.Parallel()
 
-	p := NewTransparentProxy("127.0.0.1", 0, "test", "", nil)
+	p := NewTransparentProxy("127.0.0.1", 0, "test", "", nil, false)
 
 	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		// Set both content-type and also optionally MCP header to test behavior
@@ -102,7 +102,7 @@ func TestNoSessionIDInNonSSE(t *testing.T) {
 func TestHeaderBasedSessionInitialization(t *testing.T) {
 	t.Parallel()
 
-	p := NewTransparentProxy("127.0.0.1", 0, "test", "", nil)
+	p := NewTransparentProxy("127.0.0.1", 0, "test", "", nil, false)
 
 	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		// Set both content-type and also optionally MCP header to test behavior


### PR DESCRIPTION
## Summary

Makes the healthcheck functionality in the transparent proxy configurable to avoid unnecessary health monitoring for standalone proxy usage.

## Changes

- Added `enableHealthCheck` parameter to `NewTransparentProxy()`
- Health checker is only created when enabled
- Health monitoring goroutine only starts when health checker exists
- `/health` endpoint only added when health checker exists
- Updated callers:
  - `pkg/transport/http.go` (used by `thv run`) - enables healthcheck
  - `cmd/thv/app/proxy.go` (used by `thv proxy`) - disables healthcheck
- Updated tests to handle the new parameter

## Motivation

The proxy is used both by MCP servers spawned by `thv run` and by the standalone `thv proxy` command. For servers it makes sense to spawn a healthcheck, but this doesn't make sense for `thv proxy`. This change makes that configurable.

## Testing

- All existing tests pass
- Linting passes
- No breaking changes to existing functionality