### PR TITLE
Add --github-output flag to e2e tests when running in GitHub Actions

### DIFF
--- a/test/e2e/run_tests.sh
+++ b/test/e2e/run_tests.sh
@@ -57,10 +57,12 @@ echo ""
 cd "$(dirname "$0")"
 
 # Build ginkgo command with conditional GitHub output flag
-GINKGO_CMD="ginkgo run --timeout=\"$TEST_TIMEOUT\" --vv --show-node-events --trace"
+GINKGO_CMD="ginkgo run --timeout=\"$TEST_TIMEOUT\""
 if [ -n "$GITHUB_ACTIONS" ]; then
     echo -e "${GREEN}✓${NC} GitHub Actions detected, enabling GitHub output format"
     GINKGO_CMD="$GINKGO_CMD --github-output"
+else
+    GINKGO_CMD="$GINKGO_CMD --vv --show-node-events --trace"
 fi
 GINKGO_CMD="$GINKGO_CMD ."
 

--- a/test/e2e/run_tests.sh
+++ b/test/e2e/run_tests.sh
@@ -55,7 +55,16 @@ echo ""
 
 # Run the tests
 cd "$(dirname "$0")"
-if ginkgo run --timeout="$TEST_TIMEOUT" --vv --show-node-events --trace .; then
+
+# Build ginkgo command with conditional GitHub output flag
+GINKGO_CMD="ginkgo run --timeout=\"$TEST_TIMEOUT\" --vv --show-node-events --trace"
+if [ -n "$GITHUB_ACTIONS" ]; then
+    echo -e "${GREEN}✓${NC} GitHub Actions detected, enabling GitHub output format"
+    GINKGO_CMD="$GINKGO_CMD --github-output"
+fi
+GINKGO_CMD="$GINKGO_CMD ."
+
+if eval "$GINKGO_CMD"; then
     echo ""
     echo -e "${GREEN}✓ All E2E tests passed!${NC}"
     exit 0


### PR DESCRIPTION
This PR adds automatic detection of GitHub Actions environment and enables the `--github-output` flag for ginkgo when running e2e tests in GitHub Workflows.

## Changes
- Modified `test/e2e/run_tests.sh` to check for `GITHUB_ACTIONS` environment variable
- When detected, automatically adds `--github-output` flag to ginkgo command
- Maintains backward compatibility for local runs
- Added user feedback message when GitHub Actions is detected

## Benefits
- Better integration with GitHub Actions workflow reporting
- Automatic detection without manual configuration
- No impact on local development workflow