### PR TITLE
feat: properly manage interrupt signal on foreground process

### DIFF
--- a/cmd/thv/app/run.go
+++ b/cmd/thv/app/run.go
@@ -106,7 +106,7 @@ func runCmdFunc(cmd *cobra.Command, args []string) error {
 
 	// Check if we should load configuration from a file
 	if runFlags.FromConfig != "" {
-		return runFromConfigFile(ctx)
+		return runFromConfigFile(baseCtx)
 	}
 
 	// Get the name of the MCP server to run.

--- a/pkg/workloads/manager.go
+++ b/pkg/workloads/manager.go
@@ -12,7 +12,6 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/adrg/xdg"
@@ -449,11 +448,6 @@ func (d *defaultManager) RunWorkloadDetached(ctx context.Context, runConfig *run
 	// Create a new command
 	// #nosec G204 - This is safe as execPath is the path to the current binary
 	detachedCmd := exec.Command(execPath, detachedArgs...)
-	// Prevent the detached child process from inheriting the CLI's signal group
-	detachedCmd.SysProcAttr = &syscall.SysProcAttr{
-		Setpgid: true,
-		Pgid:    0, // sets new PGID equal to new PID
-	}
 
 	// Set environment variables for the detached process
 	detachedCmd.Env = append(os.Environ(), fmt.Sprintf("%s=%s", process.ToolHiveDetachedEnv, process.ToolHiveDetachedValue))

--- a/pkg/workloads/manager.go
+++ b/pkg/workloads/manager.go
@@ -12,6 +12,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/adrg/xdg"
@@ -448,6 +449,11 @@ func (d *defaultManager) RunWorkloadDetached(ctx context.Context, runConfig *run
 	// Create a new command
 	// #nosec G204 - This is safe as execPath is the path to the current binary
 	detachedCmd := exec.Command(execPath, detachedArgs...)
+	// Prevent the detached child process from inheriting the CLI's signal group
+	detachedCmd.SysProcAttr = &syscall.SysProcAttr{
+		Setpgid: true,
+		Pgid:    0, // sets new PGID equal to new PID
+	}
 
 	// Set environment variables for the detached process
 	detachedCmd.Env = append(os.Environ(), fmt.Sprintf("%s=%s", process.ToolHiveDetachedEnv, process.ToolHiveDetachedValue))


### PR DESCRIPTION
Run the process in a go routine so it can be canceled properly. Also add removal of workloads when process is stopped

Closes: #1146