### PR TITLE
Fix tool filtering for SSE missing `data:` prefix.

### DIFF
--- a/pkg/mcp/tool_filter.go
+++ b/pkg/mcp/tool_filter.go
@@ -250,6 +250,13 @@ func processSSEEvents(filterTools map[string]struct{}, buffer []byte, w io.Write
 		if data, ok := bytes.CutPrefix(line, []byte("data:")); ok {
 			var toolsListResponse toolsListResponse
 			if err := json.Unmarshal(data, &toolsListResponse); err == nil && toolsListResponse.Result.Tools != nil {
+				// We got to the point of processing a real tools list response,
+				// so we need to write the "data: " prefix first.
+				_, err := w.Write([]byte("data: "))
+				if err != nil {
+					return fmt.Errorf("%w: %v", errBug, err)
+				}
+
 				if err := processToolsListResponse(filterTools, toolsListResponse, w); err != nil {
 					return err
 				}

--- a/pkg/mcp/tool_filter_test.go
+++ b/pkg/mcp/tool_filter_test.go
@@ -303,7 +303,7 @@ data: {"type":"info","message":"Processing complete"}
 
 `),
 			expected: `event: message
-{"jsonrpc":"2.0","id":1,"result":{"tools":[{"description":"First","name":"tool1"},{"description":"Third","name":"tool3"}]}}
+data: {"jsonrpc":"2.0","id":1,"result":{"tools":[{"description":"First","name":"tool1"},{"description":"Third","name":"tool3"}]}}
 
 event: notification
 data: {"type":"info","message":"Processing complete"}
@@ -317,7 +317,7 @@ data: {"type":"info","message":"Processing complete"}
 				"allowed_tool": {},
 			},
 			inputBuffer: []byte("event: message\r\ndata: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"tools\":[{\"name\":\"allowed_tool\",\"description\":\"Allowed\"},{\"name\":\"blocked_tool\",\"description\":\"Blocked\"}]}}\r\n\r\n"),
-			expected:    "event: message\r\n{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"tools\":[{\"description\":\"Allowed\",\"name\":\"allowed_tool\"}]}}\n\r\n\r\n",
+			expected:    "event: message\r\ndata: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"tools\":[{\"description\":\"Allowed\",\"name\":\"allowed_tool\"}]}}\n\r\n\r\n",
 			expectError: false,
 		},
 		{
@@ -326,7 +326,7 @@ data: {"type":"info","message":"Processing complete"}
 				"allowed_tool": {},
 			},
 			inputBuffer: []byte("event: message\rdata: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"tools\":[{\"name\":\"allowed_tool\",\"description\":\"Allowed\"}]}}\r\r"),
-			expected:    "event: message\r{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"tools\":[{\"description\":\"Allowed\",\"name\":\"allowed_tool\"}]}}\n\r\r",
+			expected:    "event: message\rdata: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"tools\":[{\"description\":\"Allowed\",\"name\":\"allowed_tool\"}]}}\n\r\r",
 			expectError: false,
 		},
 		{


### PR DESCRIPTION
Tool filtering for SSE transport was not adding back the stripped `data:` prefix, breaking client parsing.

Basically it was sending
```
event: message
{"foo": "bar"}
```
Instead of
```
event: message
data: {"foo": "bar"}
```