### PR TITLE
Add support for Sourcegraph Amp (#1202)

### DIFF
--- a/cmd/thv/app/client.go
+++ b/cmd/thv/app/client.go
@@ -35,6 +35,11 @@ var clientRegisterCmd = &cobra.Command{
 	Short: "Register a client for MCP server configuration",
 	Long: `Register a client for MCP server configuration.
 Valid clients are:
+  - amp-cli: Sourcegraph Amp CLI
+  - amp-cursor: Sourcegraph Amp extension for Cursor
+  - amp-vscode: Sourcegraph Amp extension for VS Code
+  - amp-vscode-insider: Sourcegraph Amp extension for VS Code Insiders
+  - amp-windsurf: Sourcegraph Amp extension for Windsurf
   - claude-code: Claude Code CLI
   - cline: Cline extension for VS Code
   - cursor: Cursor editor
@@ -50,6 +55,11 @@ var clientRemoveCmd = &cobra.Command{
 	Short: "Remove a client from MCP server configuration",
 	Long: `Remove a client from MCP server configuration.
 Valid clients are:
+  - amp-cli: Sourcegraph Amp CLI
+  - amp-cursor: Sourcegraph Amp extension for Cursor
+  - amp-vscode: Sourcegraph Amp extension for VS Code
+  - amp-vscode-insider: Sourcegraph Amp extension for VS Code Insiders
+  - amp-windsurf: Sourcegraph Amp extension for Windsurf
   - claude-code: Claude Code CLI
   - cline: Cline extension for VS Code
   - cursor: Cursor editor
@@ -148,11 +158,13 @@ func clientRegisterCmdFunc(cmd *cobra.Command, args []string) error {
 
 	// Validate the client type
 	switch clientType {
-	case "roo-code", "cline", "cursor", "claude-code", "vscode-insider", "vscode":
+	case "roo-code", "cline", "cursor", "claude-code", "vscode-insider", "vscode",
+		"amp-cli", "amp-vscode", "amp-vscode-insider", "amp-cursor", "amp-windsurf":
 		// Valid client type
 	default:
 		return fmt.Errorf(
-			"invalid client type: %s (valid types: roo-code, cline, cursor, claude-code, vscode, vscode-insider)",
+			"invalid client type: %s (valid types: roo-code, cline, cursor, claude-code, vscode, vscode-insider, "+
+				"amp-cli, amp-vscode, amp-vscode-insider, amp-cursor, amp-windsurf)",
 			clientType)
 	}
 
@@ -178,11 +190,13 @@ func clientRemoveCmdFunc(cmd *cobra.Command, args []string) error {
 
 	// Validate the client type
 	switch clientType {
-	case "roo-code", "cline", "cursor", "claude-code", "vscode-insider", "vscode":
+	case "roo-code", "cline", "cursor", "claude-code", "vscode-insider", "vscode",
+		"amp-cli", "amp-vscode", "amp-vscode-insider", "amp-cursor", "amp-windsurf":
 		// Valid client type
 	default:
 		return fmt.Errorf(
-			"invalid client type: %s (valid types: roo-code, cline, cursor, claude-code, vscode, vscode-insider)",
+			"invalid client type: %s (valid types: roo-code, cline, cursor, claude-code, vscode, vscode-insider, "+
+				"amp-cli, amp-vscode, amp-vscode-insider, amp-cursor, amp-windsurf)",
 			clientType)
 	}
 

--- a/docs/cli/thv_client_register.md
+++ b/docs/cli/thv_client_register.md
@@ -15,6 +15,11 @@ Register a client for MCP server configuration
 
 Register a client for MCP server configuration.
 Valid clients are:
+  - amp-cli: Sourcegraph Amp CLI
+  - amp-vscode: Sourcegraph Amp extension for VS Code
+  - amp-vscode-insider: Sourcegraph Amp extension for VS Code Insiders
+  - amp-cursor: Sourcegraph Amp extension for Cursor
+  - amp-windsurf: Sourcegraph Amp extension for Windsurf
   - claude-code: Claude Code CLI
   - cline: Cline extension for VS Code
   - cursor: Cursor editor

--- a/docs/cli/thv_client_remove.md
+++ b/docs/cli/thv_client_remove.md
@@ -15,6 +15,11 @@ Remove a client from MCP server configuration
 
 Remove a client from MCP server configuration.
 Valid clients are:
+  - amp-cli: Sourcegraph Amp CLI
+  - amp-vscode: Sourcegraph Amp extension for VS Code
+  - amp-vscode-insider: Sourcegraph Amp extension for VS Code Insiders
+  - amp-cursor: Sourcegraph Amp extension for Cursor
+  - amp-windsurf: Sourcegraph Amp extension for Windsurf
   - claude-code: Claude Code CLI
   - cline: Cline extension for VS Code
   - cursor: Cursor editor

--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -38,6 +38,16 @@ const (
 	VSCode MCPClient = "vscode"
 	// ClaudeCode represents the Claude Code CLI.
 	ClaudeCode MCPClient = "claude-code"
+	// AmpCli represents the Sourcegraph Amp CLI.
+	AmpCli MCPClient = "amp-cli"
+	// AmpVSCode represents the Sourcegraph Amp extension for VS Code.
+	AmpVSCode MCPClient = "amp-vscode"
+	// AmpCursor represents the Sourcegraph Amp extension for Cursor.
+	AmpCursor MCPClient = "amp-cursor"
+	// AmpVSCodeInsider represents the Sourcegraph Amp extension for VS Code Insiders.
+	AmpVSCodeInsider MCPClient = "amp-vscode-insider"
+	// AmpWindsurf represents the Sourcegraph Amp extension for Windsurf.
+	AmpWindsurf MCPClient = "amp-windsurf"
 )
 
 // Extension is extension of the client config file.
@@ -173,6 +183,101 @@ var supportedClientIntegrations = []mcpClientConfig{
 		MCPServersPathPrefix: "/mcpServers",
 		RelPath:              []string{},
 		Extension:            JSON,
+		SupportedTransportTypesMap: map[types.TransportType]string{
+			types.TransportTypeStdio:          "sse",
+			types.TransportTypeSSE:            "sse",
+			types.TransportTypeStreamableHTTP: "http",
+		},
+		IsTransportTypeFieldSupported: true,
+	},
+	{
+		ClientType:           AmpCli,
+		Description:          "Sourcegraph Amp CLI",
+		SettingsFile:         "settings.json",
+		MCPServersPathPrefix: "/amp.mcpServers",
+		RelPath:              []string{"amp"},
+		PlatformPrefix: map[string][]string{
+			"linux":   {".config"},
+			"darwin":  {".config"},
+			"windows": {"AppData", "Roaming"},
+		},
+		Extension: JSON,
+		SupportedTransportTypesMap: map[types.TransportType]string{
+			types.TransportTypeStdio:          "sse",
+			types.TransportTypeSSE:            "sse",
+			types.TransportTypeStreamableHTTP: "http",
+		},
+		IsTransportTypeFieldSupported: true,
+	},
+	{
+		ClientType:           AmpVSCode,
+		Description:          "VS Code Sourcegraph Amp extension",
+		SettingsFile:         "settings.json",
+		MCPServersPathPrefix: "/amp.mcpServers",
+		RelPath:              []string{"Code", "User"},
+		PlatformPrefix: map[string][]string{
+			"linux":   {".config"},
+			"darwin":  {"Library", "Application Support"},
+			"windows": {"AppData", "Roaming"},
+		},
+		Extension: JSON,
+		SupportedTransportTypesMap: map[types.TransportType]string{
+			types.TransportTypeStdio:          "sse",
+			types.TransportTypeSSE:            "sse",
+			types.TransportTypeStreamableHTTP: "http",
+		},
+		IsTransportTypeFieldSupported: true,
+	},
+	{
+		ClientType:           AmpVSCodeInsider,
+		Description:          "VS Code Insiders Sourcegraph Amp extension",
+		SettingsFile:         "settings.json",
+		MCPServersPathPrefix: "/amp.mcpServers",
+		RelPath:              []string{"Code - Insiders", "User"},
+		PlatformPrefix: map[string][]string{
+			"linux":   {".config"},
+			"darwin":  {"Library", "Application Support"},
+			"windows": {"AppData", "Roaming"},
+		},
+		Extension: JSON,
+		SupportedTransportTypesMap: map[types.TransportType]string{
+			types.TransportTypeStdio:          "sse",
+			types.TransportTypeSSE:            "sse",
+			types.TransportTypeStreamableHTTP: "http",
+		},
+		IsTransportTypeFieldSupported: true,
+	},
+	{
+		ClientType:           AmpCursor,
+		Description:          "Cursor Sourcegraph Amp extension",
+		SettingsFile:         "settings.json",
+		MCPServersPathPrefix: "/amp.mcpServers",
+		RelPath:              []string{"Cursor", "User"},
+		PlatformPrefix: map[string][]string{
+			"linux":   {".config"},
+			"darwin":  {"Library", "Application Support"},
+			"windows": {"AppData", "Roaming"},
+		},
+		Extension: JSON,
+		SupportedTransportTypesMap: map[types.TransportType]string{
+			types.TransportTypeStdio:          "sse",
+			types.TransportTypeSSE:            "sse",
+			types.TransportTypeStreamableHTTP: "http",
+		},
+		IsTransportTypeFieldSupported: true,
+	},
+	{
+		ClientType:           AmpWindsurf,
+		Description:          "Windsurf Sourcegraph Amp extension",
+		SettingsFile:         "settings.json",
+		MCPServersPathPrefix: "/amp.mcpServers",
+		RelPath:              []string{"Windsurf", "User"},
+		PlatformPrefix: map[string][]string{
+			"linux":   {".config"},
+			"darwin":  {"Library", "Application Support"},
+			"windows": {"AppData", "Roaming"},
+		},
+		Extension: JSON,
 		SupportedTransportTypesMap: map[types.TransportType]string{
 			types.TransportTypeStdio:          "sse",
 			types.TransportTypeSSE:            "sse",

--- a/pkg/client/config_test.go
+++ b/pkg/client/config_test.go
@@ -53,6 +53,22 @@ func createMockClientConfigs() []mcpClientConfig {
 			MCPServersPathPrefix: "/mcpServers",
 			Extension:            JSON,
 		},
+		{
+			ClientType:           AmpCli,
+			Description:          "Sourcegraph Amp CLI (Mock)",
+			RelPath:              []string{"mock_amp_cli"},
+			SettingsFile:         "settings.json",
+			MCPServersPathPrefix: "/amp.mcpServers",
+			Extension:            JSON,
+		},
+		{
+			ClientType:           AmpCursor,
+			Description:          "Cursor Sourcegraph Amp extension (Mock)",
+			RelPath:              []string{"mock_amp_cursor"},
+			SettingsFile:         "settings.json",
+			MCPServersPathPrefix: "/amp.mcpServers",
+			Extension:            JSON,
+		},
 	}
 }
 
@@ -260,6 +276,11 @@ func TestSuccessfulClientConfigOperations(t *testing.T) {
 					string(RooCode),
 					string(ClaudeCode),
 					string(Cline),
+					string(AmpCli),
+					string(AmpVSCode),
+					string(AmpCursor),
+					string(AmpVSCodeInsider),
+					string(AmpWindsurf),
 				},
 			},
 		}
@@ -312,6 +333,21 @@ func TestSuccessfulClientConfigOperations(t *testing.T) {
 			case Cline:
 				assert.Contains(t, string(content), `"mcpServers":`,
 					"Cline config should contain mcpServers key")
+			case AmpCli:
+				assert.Contains(t, string(content), `"mcpServers":`,
+					"AmpCli config should contain mcpServers key")
+			case AmpVSCode:
+				assert.Contains(t, string(content), `"mcpServers":`,
+					"AmpVSCode config should contain mcpServers key")
+			case AmpVSCodeInsider:
+				assert.Contains(t, string(content), `"mcpServers":`,
+					"AmpVSCodeInsider config should contain mcpServers key")
+			case AmpCursor:
+				assert.Contains(t, string(content), `"mcpServers":`,
+					"AmpCursor config should contain mcpServers key")
+			case AmpWindsurf:
+				assert.Contains(t, string(content), `"mcpServers":`,
+					"AmpWindsurf config should contain mcpServers key")
 			}
 		}
 	})
@@ -337,7 +373,7 @@ func TestSuccessfulClientConfigOperations(t *testing.T) {
 			case VSCode, VSCodeInsider:
 				assert.Contains(t, string(content), testURL,
 					"VSCode config should contain the server URL")
-			case Cursor, RooCode, ClaudeCode, Cline:
+			case Cursor, RooCode, ClaudeCode, Cline, AmpCli, AmpVSCode, AmpCursor, AmpVSCodeInsider, AmpWindsurf:
 				assert.Contains(t, string(content), testURL,
 					"Config should contain the server URL")
 			}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -106,7 +106,9 @@ func TestSave(t *testing.T) {
 				ProviderType: string(secrets.EncryptedType),
 			},
 			Clients: Clients{
-				RegisteredClients: []string{"vscode", "cursor", "roo-code", "cline", "claude-code"},
+				RegisteredClients: []string{
+					"vscode", "cursor", "roo-code", "cline", "claude-code", "amp-cli", "amp-vscode", "amp-cursor",
+				},
 			},
 		}
 


### PR DESCRIPTION
Adds [Sourcegraph Amp](https://ampcode.com/) to the supported MCP client integrations. This is available as both a CLI tool and as an extension for 4 VSCode-based IDEs (VSCode, VSCode Insiders, Cursor, and Windsurf), so these are all added as options.

Updates documentation and tests to reflect the new client options.

Closes https://github.com/stacklok/toolhive/issues/1202.