### PR TITLE
Reorganize client files for runtime

### DIFF
--- a/pkg/container/docker/client.go
+++ b/pkg/container/docker/client.go
@@ -69,376 +69,6 @@ func NewClient(ctx context.Context) (*Client, error) {
 	return c, nil
 }
 
-// CreateContainer creates a container without starting it
-// If options is nil, default options will be used
-// convertEnvVars converts a map of environment variables to a slice
-func convertEnvVars(envVars map[string]string) []string {
-	env := make([]string, 0, len(envVars))
-	for k, v := range envVars {
-		env = append(env, fmt.Sprintf("%s=%s", k, v))
-	}
-	return env
-}
-
-// convertMounts converts internal mount format to Docker mount format
-func convertMounts(mounts []runtime.Mount) []mount.Mount {
-	result := make([]mount.Mount, 0, len(mounts))
-	for _, m := range mounts {
-		if m.Type == runtime.MountTypeTmpfs {
-			// Create tmpfs mount to mask/hide sensitive directories
-			result = append(result, mount.Mount{
-				Type:   mount.TypeTmpfs,
-				Target: m.Target,
-				// No TmpfsOptions needed - default size is sufficient for masking
-			})
-		} else {
-			result = append(result, mount.Mount{
-				Type:     mount.TypeBind,
-				Source:   m.Source,
-				Target:   m.Target,
-				ReadOnly: m.ReadOnly,
-			})
-		}
-	}
-	return result
-}
-
-// setupExposedPorts configures exposed ports for a container
-func setupExposedPorts(config *container.Config, exposedPorts map[string]struct{}) error {
-	if len(exposedPorts) == 0 {
-		return nil
-	}
-
-	config.ExposedPorts = nat.PortSet{}
-	for port := range exposedPorts {
-		natPort, err := nat.NewPort("tcp", strings.Split(port, "/")[0])
-		if err != nil {
-			return fmt.Errorf("failed to parse port: %v", err)
-		}
-		config.ExposedPorts[natPort] = struct{}{}
-	}
-
-	return nil
-}
-
-// setupPortBindings configures port bindings for a container
-func setupPortBindings(hostConfig *container.HostConfig, portBindings map[string][]runtime.PortBinding) error {
-	if len(portBindings) == 0 {
-		return nil
-	}
-
-	hostConfig.PortBindings = nat.PortMap{}
-	for port, bindings := range portBindings {
-		natPort, err := nat.NewPort("tcp", strings.Split(port, "/")[0])
-		if err != nil {
-			return fmt.Errorf("failed to parse port: %v", err)
-		}
-
-		natBindings := make([]nat.PortBinding, len(bindings))
-		for i, binding := range bindings {
-			natBindings[i] = nat.PortBinding{
-				HostIP:   binding.HostIP,
-				HostPort: binding.HostPort,
-			}
-		}
-		hostConfig.PortBindings[natPort] = natBindings
-	}
-
-	return nil
-}
-
-func (c *Client) createContainer(ctx context.Context, containerName string, config *container.Config,
-	hostConfig *container.HostConfig, endpointsConfig map[string]*network.EndpointSettings) (string, error) {
-	existingID, err := c.findExistingContainer(ctx, containerName)
-	if err != nil {
-		return "", err
-	}
-
-	// If container exists, check if we need to recreate it
-	if existingID != "" {
-		canReuse, err := c.handleExistingContainer(ctx, existingID, config, hostConfig)
-		if err != nil {
-			return "", err
-		}
-
-		if canReuse {
-			// Container exists with the right configuration, return its ID
-			return existingID, nil
-		}
-		// Container was removed and needs to be recreated
-	}
-
-	// network config
-	networkConfig := &network.NetworkingConfig{
-		EndpointsConfig: endpointsConfig,
-	}
-
-	// Create the container
-	resp, err := c.client.ContainerCreate(
-		ctx,
-		config,
-		hostConfig,
-		networkConfig,
-		nil,
-		containerName,
-	)
-	if err != nil {
-		return "", NewContainerError(err, "", fmt.Sprintf("failed to create container: %v", err))
-	}
-
-	// Start the container
-	err = c.client.ContainerStart(ctx, resp.ID, container.StartOptions{})
-	if err != nil {
-		return "", NewContainerError(err, resp.ID, fmt.Sprintf("failed to start container: %v", err))
-	}
-
-	return resp.ID, nil
-}
-
-func (c *Client) createDnsContainer(ctx context.Context, dnsContainerName string,
-	attachStdio bool, networkName string, endpointsConfig map[string]*network.EndpointSettings) (string, string, error) {
-	logger.Infof("Setting up DNS container for %s with image %s...", dnsContainerName, DnsImage)
-	dnsLabels := map[string]string{}
-	lb.AddStandardLabels(dnsLabels, dnsContainerName, dnsContainerName, "stdio", 80)
-	dnsLabels[ToolhiveAuxiliaryWorkloadLabel] = LabelValueTrue
-
-	// pull the dns image if it is not already pulled
-	err := c.imageManager.PullImage(ctx, DnsImage)
-	if err != nil {
-		// Check if the DNS image exists locally before failing
-		_, inspectErr := c.client.ImageInspect(ctx, DnsImage)
-		if inspectErr == nil {
-			logger.Infof("DNS image %s exists locally, continuing despite pull failure", DnsImage)
-		} else {
-			return "", "", fmt.Errorf("failed to pull DNS image: %v", err)
-		}
-	}
-
-	configDns := &container.Config{
-		Image:        DnsImage,
-		Cmd:          nil,
-		Env:          nil,
-		Labels:       dnsLabels,
-		AttachStdin:  attachStdio,
-		AttachStdout: attachStdio,
-		AttachStderr: attachStdio,
-		OpenStdin:    attachStdio,
-		Tty:          false,
-	}
-
-	dnsHostConfig := &container.HostConfig{
-		Mounts:      nil,
-		NetworkMode: container.NetworkMode("bridge"),
-		CapAdd:      nil,
-		CapDrop:     nil,
-		SecurityOpt: nil,
-		RestartPolicy: container.RestartPolicy{
-			Name: "unless-stopped",
-		},
-	}
-
-	// now create the dns container
-	dnsContainerId, err := c.createContainer(ctx, dnsContainerName, configDns, dnsHostConfig, endpointsConfig)
-	if err != nil {
-		return "", "", fmt.Errorf("failed to create dns container: %v", err)
-	}
-
-	dnsContainerResponse, err := c.client.ContainerInspect(ctx, dnsContainerId)
-	if err != nil {
-		return "", "", fmt.Errorf("failed to inspect DNS container: %v", err)
-	}
-
-	dnsNetworkSettings, ok := dnsContainerResponse.NetworkSettings.Networks[networkName]
-	if !ok {
-		return "", "", fmt.Errorf("network %s not found in container's network settings", networkName)
-	}
-	dnsContainerIP := dnsNetworkSettings.IPAddress
-
-	return dnsContainerId, dnsContainerIP, nil
-}
-
-func (c *Client) createMcpContainer(ctx context.Context, name string, networkName string, image string, command []string,
-	envVars map[string]string, labels map[string]string, attachStdio bool, permissionConfig *runtime.PermissionConfig,
-	additionalDNS string, exposedPorts map[string]struct{}, portBindings map[string][]runtime.PortBinding,
-	isolateNetwork bool) (string, error) {
-	// Create container configuration
-	config := &container.Config{
-		Image:        image,
-		Cmd:          command,
-		Env:          convertEnvVars(envVars),
-		Labels:       labels,
-		AttachStdin:  attachStdio,
-		AttachStdout: attachStdio,
-		AttachStderr: attachStdio,
-		OpenStdin:    attachStdio,
-		Tty:          false,
-	}
-
-	// Create host configuration
-	hostConfig := &container.HostConfig{
-		Mounts:      convertMounts(permissionConfig.Mounts),
-		NetworkMode: container.NetworkMode(permissionConfig.NetworkMode),
-		CapAdd:      permissionConfig.CapAdd,
-		CapDrop:     permissionConfig.CapDrop,
-		SecurityOpt: permissionConfig.SecurityOpt,
-		RestartPolicy: container.RestartPolicy{
-			Name: "unless-stopped",
-		},
-	}
-	if additionalDNS != "" {
-		hostConfig.DNS = []string{additionalDNS}
-	}
-
-	// Configure ports if options are provided
-	// Setup exposed ports
-	if err := setupExposedPorts(config, exposedPorts); err != nil {
-		return "", NewContainerError(err, "", err.Error())
-	}
-
-	// Setup port bindings
-	if err := setupPortBindings(hostConfig, portBindings); err != nil {
-		return "", NewContainerError(err, "", err.Error())
-	}
-
-	// create mcp container
-	internalEndpointsConfig := map[string]*network.EndpointSettings{}
-	if isolateNetwork {
-		internalEndpointsConfig[networkName] = &network.EndpointSettings{
-			NetworkID: networkName,
-		}
-	} else {
-		// for other workloads such as inspector, add to external network
-		internalEndpointsConfig["toolhive-external"] = &network.EndpointSettings{
-			NetworkID: "toolhive-external",
-		}
-	}
-	containerId, err := c.createContainer(ctx, name, config, hostConfig, internalEndpointsConfig)
-	if err != nil {
-		return "", fmt.Errorf("failed to create container: %v", err)
-	}
-
-	return containerId, nil
-
-}
-
-// addEgressEnvVars adds environment variables for egress proxy configuration.
-func addEgressEnvVars(envVars map[string]string, egressContainerName string) map[string]string {
-	egressHost := fmt.Sprintf("http://%s:3128", egressContainerName)
-	if envVars == nil {
-		envVars = make(map[string]string)
-	}
-	envVars["HTTP_PROXY"] = egressHost
-	envVars["HTTPS_PROXY"] = egressHost
-	envVars["http_proxy"] = egressHost
-	envVars["https_proxy"] = egressHost
-	envVars["NO_PROXY"] = "localhost,127.0.0.1,::1"
-	envVars["no_proxy"] = "localhost,127.0.0.1,::1"
-	return envVars
-}
-
-func (c *Client) createIngressContainer(ctx context.Context, containerName string, upstreamPort int, attachStdio bool,
-	externalEndpointsConfig map[string]*network.EndpointSettings) (int, error) {
-	squidPort, err := networking.FindOrUsePort(upstreamPort + 1)
-	if err != nil {
-		return 0, fmt.Errorf("failed to find or use port %d: %v", squidPort, err)
-	}
-	squidExposedPorts := map[string]struct{}{
-		fmt.Sprintf("%d/tcp", squidPort): {},
-	}
-	squidPortBindings := map[string][]runtime.PortBinding{
-		fmt.Sprintf("%d/tcp", squidPort): {
-			{
-				HostIP:   "127.0.0.1",
-				HostPort: fmt.Sprintf("%d", squidPort),
-			},
-		},
-	}
-	ingressContainerName := fmt.Sprintf("%s-ingress", containerName)
-	_, err = createIngressSquidContainer(
-		ctx,
-		c,
-		containerName,
-		ingressContainerName,
-		attachStdio,
-		upstreamPort,
-		squidPort,
-		squidExposedPorts,
-		externalEndpointsConfig,
-		squidPortBindings,
-	)
-	if err != nil {
-		return 0, fmt.Errorf("failed to create ingress container: %v", err)
-	}
-	return squidPort, nil
-
-}
-
-func extractFirstPort(options *runtime.DeployWorkloadOptions) (int, error) {
-	var firstPort string
-	if len(options.ExposedPorts) == 0 {
-		return 0, fmt.Errorf("no exposed ports specified in options.ExposedPorts")
-	}
-	for port := range options.ExposedPorts {
-		firstPort = port
-
-		// need to strip the protocol
-		firstPort = strings.Split(firstPort, "/")[0]
-		break // take only the first one
-	}
-	firstPortInt, err := strconv.Atoi(firstPort)
-	if err != nil {
-		return 0, fmt.Errorf("failed to convert port %s to int: %v", firstPort, err)
-	}
-	return firstPortInt, nil
-}
-
-func (c *Client) createExternalNetworks(ctx context.Context) error {
-	externalNetworkLabels := map[string]string{}
-	lb.AddNetworkLabels(externalNetworkLabels, "toolhive-external")
-	err := c.createNetwork(ctx, "toolhive-external", externalNetworkLabels, false)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func generatePortBindings(labels map[string]string,
-	portBindings map[string][]runtime.PortBinding) (map[string][]runtime.PortBinding, int, error) {
-	var hostPort int
-	// check if we need to map to a random port of not
-	if _, ok := labels["toolhive-auxiliary"]; ok && labels["toolhive-auxiliary"] == "true" {
-		// find first port
-		var err error
-		for _, bindings := range portBindings {
-			if len(bindings) > 0 {
-				hostPortStr := bindings[0].HostPort
-				hostPort, err = strconv.Atoi(hostPortStr)
-				if err != nil {
-					return nil, 0, fmt.Errorf("failed to convert host port %s to int: %v", hostPortStr, err)
-				}
-				break
-			}
-		}
-	} else {
-		// bind to a random host port
-		hostPort = networking.FindAvailable()
-		if hostPort == 0 {
-			return nil, 0, fmt.Errorf("could not find an available port")
-		}
-
-		// first port binding needs to map to the host port
-		for key, bindings := range portBindings {
-			if len(bindings) > 0 {
-				bindings[0].HostPort = fmt.Sprintf("%d", hostPort)
-				portBindings[key] = bindings
-				break
-			}
-		}
-	}
-
-	return portBindings, hostPort, nil
-}
-
 // DeployWorkload creates and starts a workload.
 // It configures the workload based on the provided permission profile and transport type.
 // If options is nil, default options will be used.
@@ -678,45 +308,6 @@ func (c *Client) StopWorkload(ctx context.Context, workloadID string) error {
 		c.stopProxyContainer(ctx, name, timeoutSeconds)
 	}
 
-	return nil
-}
-
-func (c *Client) stopProxyContainer(ctx context.Context, containerName string, timeoutSeconds int) {
-	containerId, err := c.findExistingContainer(ctx, containerName)
-	if err != nil {
-		logger.Debugf("Failed to find internal container %s: %v", containerName, err)
-	} else {
-		err = c.client.ContainerStop(ctx, containerId, container.StopOptions{Timeout: &timeoutSeconds})
-		if err != nil {
-			logger.Debugf("Failed to stop internal container %s: %v", containerName, err)
-		}
-	}
-}
-
-func (c *Client) deleteNetworks(ctx context.Context, containerName string) error {
-	// Delete networks if there are no containers using them.
-	toolHiveContainers, err := c.client.ContainerList(ctx, container.ListOptions{
-		All:     true,
-		Filters: filters.NewArgs(filters.Arg("label", "toolhive=true")),
-	})
-	if err != nil {
-		return fmt.Errorf("failed to list containers: %v", err)
-	}
-
-	// Delete associated internal network
-	networkName := fmt.Sprintf("toolhive-%s-internal", containerName)
-	if err := c.deleteNetwork(ctx, networkName); err != nil {
-		// just log the error and continue
-		logger.Warnf("failed to delete network %q: %v", networkName, err)
-	}
-
-	if len(toolHiveContainers) == 0 {
-		// remove external network
-		if err := c.deleteNetwork(ctx, "toolhive-external"); err != nil {
-			// just log the error and continue
-			logger.Warnf("failed to delete network %q: %v", "toolhive-external", err)
-		}
-	}
 	return nil
 }
 
@@ -1098,61 +689,6 @@ func (c *Client) getPermissionConfigFromProfile(
 	}
 
 	return config, nil
-}
-
-// Error types for container operations
-var (
-	// ErrContainerNotFound is returned when a container is not found
-	ErrContainerNotFound = fmt.Errorf("container not found")
-
-	// ErrContainerNotRunning is returned when a container is not running
-	ErrContainerNotRunning = fmt.Errorf("container not running")
-
-	// ErrAttachFailed is returned when attaching to a container fails
-	ErrAttachFailed = fmt.Errorf("failed to attach to container")
-
-	// ErrContainerExited is returned when a container has exited unexpectedly
-	ErrContainerExited = fmt.Errorf("container exited unexpectedly")
-)
-
-// ContainerError represents an error related to container operations
-type ContainerError struct {
-	// Err is the underlying error
-	Err error
-	// ContainerID is the ID of the container
-	ContainerID string
-	// Message is an optional error message
-	Message string
-}
-
-// Error returns the error message
-func (e *ContainerError) Error() string {
-	if e.Message != "" {
-		if e.ContainerID != "" {
-			return fmt.Sprintf("%s: %s (container: %s)", e.Err, e.Message, e.ContainerID)
-		}
-		return fmt.Sprintf("%s: %s", e.Err, e.Message)
-	}
-
-	if e.ContainerID != "" {
-		return fmt.Sprintf("%s (container: %s)", e.Err, e.ContainerID)
-	}
-
-	return e.Err.Error()
-}
-
-// Unwrap returns the underlying error
-func (e *ContainerError) Unwrap() error {
-	return e.Err
-}
-
-// NewContainerError creates a new container error
-func NewContainerError(err error, containerID, message string) *ContainerError {
-	return &ContainerError{
-		Err:         err,
-		ContainerID: containerID,
-		Message:     message,
-	}
 }
 
 // findExistingContainer finds a container with the exact name
@@ -1540,5 +1076,414 @@ func (c *Client) removeProxyContainers(
 		}
 	}
 
+	return nil
+}
+
+// CreateContainer creates a container without starting it
+// If options is nil, default options will be used
+// convertEnvVars converts a map of environment variables to a slice
+func convertEnvVars(envVars map[string]string) []string {
+	env := make([]string, 0, len(envVars))
+	for k, v := range envVars {
+		env = append(env, fmt.Sprintf("%s=%s", k, v))
+	}
+	return env
+}
+
+// convertMounts converts internal mount format to Docker mount format
+func convertMounts(mounts []runtime.Mount) []mount.Mount {
+	result := make([]mount.Mount, 0, len(mounts))
+	for _, m := range mounts {
+		if m.Type == runtime.MountTypeTmpfs {
+			// Create tmpfs mount to mask/hide sensitive directories
+			result = append(result, mount.Mount{
+				Type:   mount.TypeTmpfs,
+				Target: m.Target,
+				// No TmpfsOptions needed - default size is sufficient for masking
+			})
+		} else {
+			result = append(result, mount.Mount{
+				Type:     mount.TypeBind,
+				Source:   m.Source,
+				Target:   m.Target,
+				ReadOnly: m.ReadOnly,
+			})
+		}
+	}
+	return result
+}
+
+// setupExposedPorts configures exposed ports for a container
+func setupExposedPorts(config *container.Config, exposedPorts map[string]struct{}) error {
+	if len(exposedPorts) == 0 {
+		return nil
+	}
+
+	config.ExposedPorts = nat.PortSet{}
+	for port := range exposedPorts {
+		natPort, err := nat.NewPort("tcp", strings.Split(port, "/")[0])
+		if err != nil {
+			return fmt.Errorf("failed to parse port: %v", err)
+		}
+		config.ExposedPorts[natPort] = struct{}{}
+	}
+
+	return nil
+}
+
+// setupPortBindings configures port bindings for a container
+func setupPortBindings(hostConfig *container.HostConfig, portBindings map[string][]runtime.PortBinding) error {
+	if len(portBindings) == 0 {
+		return nil
+	}
+
+	hostConfig.PortBindings = nat.PortMap{}
+	for port, bindings := range portBindings {
+		natPort, err := nat.NewPort("tcp", strings.Split(port, "/")[0])
+		if err != nil {
+			return fmt.Errorf("failed to parse port: %v", err)
+		}
+
+		natBindings := make([]nat.PortBinding, len(bindings))
+		for i, binding := range bindings {
+			natBindings[i] = nat.PortBinding{
+				HostIP:   binding.HostIP,
+				HostPort: binding.HostPort,
+			}
+		}
+		hostConfig.PortBindings[natPort] = natBindings
+	}
+
+	return nil
+}
+
+func (c *Client) createContainer(ctx context.Context, containerName string, config *container.Config,
+	hostConfig *container.HostConfig, endpointsConfig map[string]*network.EndpointSettings) (string, error) {
+	existingID, err := c.findExistingContainer(ctx, containerName)
+	if err != nil {
+		return "", err
+	}
+
+	// If container exists, check if we need to recreate it
+	if existingID != "" {
+		canReuse, err := c.handleExistingContainer(ctx, existingID, config, hostConfig)
+		if err != nil {
+			return "", err
+		}
+
+		if canReuse {
+			// Container exists with the right configuration, return its ID
+			return existingID, nil
+		}
+		// Container was removed and needs to be recreated
+	}
+
+	// network config
+	networkConfig := &network.NetworkingConfig{
+		EndpointsConfig: endpointsConfig,
+	}
+
+	// Create the container
+	resp, err := c.client.ContainerCreate(
+		ctx,
+		config,
+		hostConfig,
+		networkConfig,
+		nil,
+		containerName,
+	)
+	if err != nil {
+		return "", NewContainerError(err, "", fmt.Sprintf("failed to create container: %v", err))
+	}
+
+	// Start the container
+	err = c.client.ContainerStart(ctx, resp.ID, container.StartOptions{})
+	if err != nil {
+		return "", NewContainerError(err, resp.ID, fmt.Sprintf("failed to start container: %v", err))
+	}
+
+	return resp.ID, nil
+}
+
+func (c *Client) createDnsContainer(ctx context.Context, dnsContainerName string,
+	attachStdio bool, networkName string, endpointsConfig map[string]*network.EndpointSettings) (string, string, error) {
+	logger.Infof("Setting up DNS container for %s with image %s...", dnsContainerName, DnsImage)
+	dnsLabels := map[string]string{}
+	lb.AddStandardLabels(dnsLabels, dnsContainerName, dnsContainerName, "stdio", 80)
+	dnsLabels[ToolhiveAuxiliaryWorkloadLabel] = LabelValueTrue
+
+	// pull the dns image if it is not already pulled
+	err := c.imageManager.PullImage(ctx, DnsImage)
+	if err != nil {
+		// Check if the DNS image exists locally before failing
+		_, inspectErr := c.client.ImageInspect(ctx, DnsImage)
+		if inspectErr == nil {
+			logger.Infof("DNS image %s exists locally, continuing despite pull failure", DnsImage)
+		} else {
+			return "", "", fmt.Errorf("failed to pull DNS image: %v", err)
+		}
+	}
+
+	configDns := &container.Config{
+		Image:        DnsImage,
+		Cmd:          nil,
+		Env:          nil,
+		Labels:       dnsLabels,
+		AttachStdin:  attachStdio,
+		AttachStdout: attachStdio,
+		AttachStderr: attachStdio,
+		OpenStdin:    attachStdio,
+		Tty:          false,
+	}
+
+	dnsHostConfig := &container.HostConfig{
+		Mounts:      nil,
+		NetworkMode: container.NetworkMode("bridge"),
+		CapAdd:      nil,
+		CapDrop:     nil,
+		SecurityOpt: nil,
+		RestartPolicy: container.RestartPolicy{
+			Name: "unless-stopped",
+		},
+	}
+
+	// now create the dns container
+	dnsContainerId, err := c.createContainer(ctx, dnsContainerName, configDns, dnsHostConfig, endpointsConfig)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to create dns container: %v", err)
+	}
+
+	dnsContainerResponse, err := c.client.ContainerInspect(ctx, dnsContainerId)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to inspect DNS container: %v", err)
+	}
+
+	dnsNetworkSettings, ok := dnsContainerResponse.NetworkSettings.Networks[networkName]
+	if !ok {
+		return "", "", fmt.Errorf("network %s not found in container's network settings", networkName)
+	}
+	dnsContainerIP := dnsNetworkSettings.IPAddress
+
+	return dnsContainerId, dnsContainerIP, nil
+}
+
+func (c *Client) createMcpContainer(ctx context.Context, name string, networkName string, image string, command []string,
+	envVars map[string]string, labels map[string]string, attachStdio bool, permissionConfig *runtime.PermissionConfig,
+	additionalDNS string, exposedPorts map[string]struct{}, portBindings map[string][]runtime.PortBinding,
+	isolateNetwork bool) (string, error) {
+	// Create container configuration
+	config := &container.Config{
+		Image:        image,
+		Cmd:          command,
+		Env:          convertEnvVars(envVars),
+		Labels:       labels,
+		AttachStdin:  attachStdio,
+		AttachStdout: attachStdio,
+		AttachStderr: attachStdio,
+		OpenStdin:    attachStdio,
+		Tty:          false,
+	}
+
+	// Create host configuration
+	hostConfig := &container.HostConfig{
+		Mounts:      convertMounts(permissionConfig.Mounts),
+		NetworkMode: container.NetworkMode(permissionConfig.NetworkMode),
+		CapAdd:      permissionConfig.CapAdd,
+		CapDrop:     permissionConfig.CapDrop,
+		SecurityOpt: permissionConfig.SecurityOpt,
+		RestartPolicy: container.RestartPolicy{
+			Name: "unless-stopped",
+		},
+	}
+	if additionalDNS != "" {
+		hostConfig.DNS = []string{additionalDNS}
+	}
+
+	// Configure ports if options are provided
+	// Setup exposed ports
+	if err := setupExposedPorts(config, exposedPorts); err != nil {
+		return "", NewContainerError(err, "", err.Error())
+	}
+
+	// Setup port bindings
+	if err := setupPortBindings(hostConfig, portBindings); err != nil {
+		return "", NewContainerError(err, "", err.Error())
+	}
+
+	// create mcp container
+	internalEndpointsConfig := map[string]*network.EndpointSettings{}
+	if isolateNetwork {
+		internalEndpointsConfig[networkName] = &network.EndpointSettings{
+			NetworkID: networkName,
+		}
+	} else {
+		// for other workloads such as inspector, add to external network
+		internalEndpointsConfig["toolhive-external"] = &network.EndpointSettings{
+			NetworkID: "toolhive-external",
+		}
+	}
+	containerId, err := c.createContainer(ctx, name, config, hostConfig, internalEndpointsConfig)
+	if err != nil {
+		return "", fmt.Errorf("failed to create container: %v", err)
+	}
+
+	return containerId, nil
+
+}
+
+// addEgressEnvVars adds environment variables for egress proxy configuration.
+func addEgressEnvVars(envVars map[string]string, egressContainerName string) map[string]string {
+	egressHost := fmt.Sprintf("http://%s:3128", egressContainerName)
+	if envVars == nil {
+		envVars = make(map[string]string)
+	}
+	envVars["HTTP_PROXY"] = egressHost
+	envVars["HTTPS_PROXY"] = egressHost
+	envVars["http_proxy"] = egressHost
+	envVars["https_proxy"] = egressHost
+	envVars["NO_PROXY"] = "localhost,127.0.0.1,::1"
+	envVars["no_proxy"] = "localhost,127.0.0.1,::1"
+	return envVars
+}
+
+func (c *Client) createIngressContainer(ctx context.Context, containerName string, upstreamPort int, attachStdio bool,
+	externalEndpointsConfig map[string]*network.EndpointSettings) (int, error) {
+	squidPort, err := networking.FindOrUsePort(upstreamPort + 1)
+	if err != nil {
+		return 0, fmt.Errorf("failed to find or use port %d: %v", squidPort, err)
+	}
+	squidExposedPorts := map[string]struct{}{
+		fmt.Sprintf("%d/tcp", squidPort): {},
+	}
+	squidPortBindings := map[string][]runtime.PortBinding{
+		fmt.Sprintf("%d/tcp", squidPort): {
+			{
+				HostIP:   "127.0.0.1",
+				HostPort: fmt.Sprintf("%d", squidPort),
+			},
+		},
+	}
+	ingressContainerName := fmt.Sprintf("%s-ingress", containerName)
+	_, err = createIngressSquidContainer(
+		ctx,
+		c,
+		containerName,
+		ingressContainerName,
+		attachStdio,
+		upstreamPort,
+		squidPort,
+		squidExposedPorts,
+		externalEndpointsConfig,
+		squidPortBindings,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("failed to create ingress container: %v", err)
+	}
+	return squidPort, nil
+
+}
+
+func extractFirstPort(options *runtime.DeployWorkloadOptions) (int, error) {
+	var firstPort string
+	if len(options.ExposedPorts) == 0 {
+		return 0, fmt.Errorf("no exposed ports specified in options.ExposedPorts")
+	}
+	for port := range options.ExposedPorts {
+		firstPort = port
+
+		// need to strip the protocol
+		firstPort = strings.Split(firstPort, "/")[0]
+		break // take only the first one
+	}
+	firstPortInt, err := strconv.Atoi(firstPort)
+	if err != nil {
+		return 0, fmt.Errorf("failed to convert port %s to int: %v", firstPort, err)
+	}
+	return firstPortInt, nil
+}
+
+func (c *Client) createExternalNetworks(ctx context.Context) error {
+	externalNetworkLabels := map[string]string{}
+	lb.AddNetworkLabels(externalNetworkLabels, "toolhive-external")
+	err := c.createNetwork(ctx, "toolhive-external", externalNetworkLabels, false)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func generatePortBindings(labels map[string]string,
+	portBindings map[string][]runtime.PortBinding) (map[string][]runtime.PortBinding, int, error) {
+	var hostPort int
+	// check if we need to map to a random port of not
+	if _, ok := labels["toolhive-auxiliary"]; ok && labels["toolhive-auxiliary"] == "true" {
+		// find first port
+		var err error
+		for _, bindings := range portBindings {
+			if len(bindings) > 0 {
+				hostPortStr := bindings[0].HostPort
+				hostPort, err = strconv.Atoi(hostPortStr)
+				if err != nil {
+					return nil, 0, fmt.Errorf("failed to convert host port %s to int: %v", hostPortStr, err)
+				}
+				break
+			}
+		}
+	} else {
+		// bind to a random host port
+		hostPort = networking.FindAvailable()
+		if hostPort == 0 {
+			return nil, 0, fmt.Errorf("could not find an available port")
+		}
+
+		// first port binding needs to map to the host port
+		for key, bindings := range portBindings {
+			if len(bindings) > 0 {
+				bindings[0].HostPort = fmt.Sprintf("%d", hostPort)
+				portBindings[key] = bindings
+				break
+			}
+		}
+	}
+
+	return portBindings, hostPort, nil
+}
+
+func (c *Client) stopProxyContainer(ctx context.Context, containerName string, timeoutSeconds int) {
+	containerId, err := c.findExistingContainer(ctx, containerName)
+	if err != nil {
+		logger.Debugf("Failed to find internal container %s: %v", containerName, err)
+	} else {
+		err = c.client.ContainerStop(ctx, containerId, container.StopOptions{Timeout: &timeoutSeconds})
+		if err != nil {
+			logger.Debugf("Failed to stop internal container %s: %v", containerName, err)
+		}
+	}
+}
+
+func (c *Client) deleteNetworks(ctx context.Context, containerName string) error {
+	// Delete networks if there are no containers using them.
+	toolHiveContainers, err := c.client.ContainerList(ctx, container.ListOptions{
+		All:     true,
+		Filters: filters.NewArgs(filters.Arg("label", "toolhive=true")),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to list containers: %v", err)
+	}
+
+	// Delete associated internal network
+	networkName := fmt.Sprintf("toolhive-%s-internal", containerName)
+	if err := c.deleteNetwork(ctx, networkName); err != nil {
+		// just log the error and continue
+		logger.Warnf("failed to delete network %q: %v", networkName, err)
+	}
+
+	if len(toolHiveContainers) == 0 {
+		// remove external network
+		if err := c.deleteNetwork(ctx, "toolhive-external"); err != nil {
+			// just log the error and continue
+			logger.Warnf("failed to delete network %q: %v", "toolhive-external", err)
+		}
+	}
 	return nil
 }

--- a/pkg/container/docker/errors.go
+++ b/pkg/container/docker/errors.go
@@ -1,0 +1,58 @@
+package docker
+
+import "fmt"
+
+// Error types for container operations
+var (
+	// ErrContainerNotFound is returned when a container is not found
+	ErrContainerNotFound = fmt.Errorf("container not found")
+
+	// ErrContainerNotRunning is returned when a container is not running
+	ErrContainerNotRunning = fmt.Errorf("container not running")
+
+	// ErrAttachFailed is returned when attaching to a container fails
+	ErrAttachFailed = fmt.Errorf("failed to attach to container")
+
+	// ErrContainerExited is returned when a container has exited unexpectedly
+	ErrContainerExited = fmt.Errorf("container exited unexpectedly")
+)
+
+// ContainerError represents an error related to container operations
+type ContainerError struct {
+	// Err is the underlying error
+	Err error
+	// ContainerID is the ID of the container
+	ContainerID string
+	// Message is an optional error message
+	Message string
+}
+
+// Error returns the error message
+func (e *ContainerError) Error() string {
+	if e.Message != "" {
+		if e.ContainerID != "" {
+			return fmt.Sprintf("%s: %s (container: %s)", e.Err, e.Message, e.ContainerID)
+		}
+		return fmt.Sprintf("%s: %s", e.Err, e.Message)
+	}
+
+	if e.ContainerID != "" {
+		return fmt.Sprintf("%s (container: %s)", e.Err, e.ContainerID)
+	}
+
+	return e.Err.Error()
+}
+
+// Unwrap returns the underlying error
+func (e *ContainerError) Unwrap() error {
+	return e.Err
+}
+
+// NewContainerError creates a new container error
+func NewContainerError(err error, containerID, message string) *ContainerError {
+	return &ContainerError{
+		Err:         err,
+		ContainerID: containerID,
+		Message:     message,
+	}
+}

--- a/pkg/container/kubernetes/client.go
+++ b/pkg/container/kubernetes/client.go
@@ -69,46 +69,6 @@ func NewClient(_ context.Context) (*Client, error) {
 	}, nil
 }
 
-// getNamespaceFromServiceAccount attempts to read the namespace from the service account token file
-func getNamespaceFromServiceAccount() (string, error) {
-	data, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
-	if err != nil {
-		return "", fmt.Errorf("failed to read namespace file: %w", err)
-	}
-	return string(data), nil
-}
-
-// getNamespaceFromEnv attempts to get the namespace from environment variables
-func getNamespaceFromEnv() (string, error) {
-	ns := os.Getenv("POD_NAMESPACE")
-	if ns == "" {
-		return "", fmt.Errorf("POD_NAMESPACE environment variable not set")
-	}
-	return ns, nil
-}
-
-// getCurrentNamespace returns the namespace the pod is running in.
-// It tries multiple methods in order:
-// 1. Reading from the service account token file
-// 2. Getting the namespace from environment variables
-// 3. Falling back to "default" if both methods fail
-func getCurrentNamespace() string {
-	// Method 1: Try to read from the service account namespace file
-	ns, err := getNamespaceFromServiceAccount()
-	if err == nil {
-		return ns
-	}
-
-	// Method 2: Try to get the namespace from environment variables
-	ns, err = getNamespaceFromEnv()
-	if err == nil {
-		return ns
-	}
-
-	// Method 3: Fall back to default
-	return "default"
-}
-
 // AttachToWorkload implements runtime.Runtime.
 func (c *Client) AttachToWorkload(ctx context.Context, workloadID string) (io.WriteCloser, io.ReadCloser, error) {
 	// AttachToWorkload attaches to a workload in Kubernetes
@@ -1115,4 +1075,44 @@ func configureMCPContainer(
 	}
 
 	return nil
+}
+
+// getNamespaceFromServiceAccount attempts to read the namespace from the service account token file
+func getNamespaceFromServiceAccount() (string, error) {
+	data, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+	if err != nil {
+		return "", fmt.Errorf("failed to read namespace file: %w", err)
+	}
+	return string(data), nil
+}
+
+// getNamespaceFromEnv attempts to get the namespace from environment variables
+func getNamespaceFromEnv() (string, error) {
+	ns := os.Getenv("POD_NAMESPACE")
+	if ns == "" {
+		return "", fmt.Errorf("POD_NAMESPACE environment variable not set")
+	}
+	return ns, nil
+}
+
+// getCurrentNamespace returns the namespace the pod is running in.
+// It tries multiple methods in order:
+// 1. Reading from the service account token file
+// 2. Getting the namespace from environment variables
+// 3. Falling back to "default" if both methods fail
+func getCurrentNamespace() string {
+	// Method 1: Try to read from the service account namespace file
+	ns, err := getNamespaceFromServiceAccount()
+	if err == nil {
+		return ns
+	}
+
+	// Method 2: Try to get the namespace from environment variables
+	ns, err = getNamespaceFromEnv()
+	if err == nil {
+		return ns
+	}
+
+	// Method 3: Fall back to default
+	return "default"
 }


### PR DESCRIPTION
* Group the methods in the files so that the public methods come before private. I find this makes it much easier to read the files and find the relevant parts of the logic.
* Move the error logic for the Docker client into a separate file for readability.