### PR TITLE
Move GetWorkload/ListWorkload to status manager interface

### DIFF
--- a/pkg/container/runtime/types.go
+++ b/pkg/container/runtime/types.go
@@ -38,6 +38,7 @@ const (
 )
 
 // ContainerInfo represents information about a container
+// TODO: Consider merging this with workloads.Workload
 type ContainerInfo struct {
 	// Name is the container name
 	Name string
@@ -54,6 +55,11 @@ type ContainerInfo struct {
 	Labels map[string]string
 	// Ports is the container port mappings
 	Ports []PortMapping
+}
+
+// IsRunning returns true if the container is currently running.
+func (c *ContainerInfo) IsRunning() bool {
+	return c.State == WorkloadStatusRunning
 }
 
 // PortMapping represents a port mapping for a container

--- a/pkg/workloads/file_status_test.go
+++ b/pkg/workloads/file_status_test.go
@@ -3,6 +3,7 @@ package workloads
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -10,8 +11,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 
-	"github.com/stacklok/toolhive/pkg/container/runtime"
+	rt "github.com/stacklok/toolhive/pkg/container/runtime"
+	"github.com/stacklok/toolhive/pkg/container/runtime/mocks"
 	"github.com/stacklok/toolhive/pkg/logger"
 )
 
@@ -43,7 +46,7 @@ func TestFileStatusManager_CreateWorkloadStatus(t *testing.T) {
 	err = json.Unmarshal(data, &statusFileData)
 	require.NoError(t, err)
 
-	assert.Equal(t, runtime.WorkloadStatusStarting, statusFileData.Status)
+	assert.Equal(t, rt.WorkloadStatusStarting, statusFileData.Status)
 	assert.Empty(t, statusFileData.StatusContext)
 	assert.False(t, statusFileData.CreatedAt.IsZero())
 	assert.False(t, statusFileData.UpdatedAt.IsZero())
@@ -65,33 +68,142 @@ func TestFileStatusManager_CreateWorkloadStatus_AlreadyExists(t *testing.T) {
 	assert.Contains(t, err.Error(), "already exists")
 }
 
-func TestFileStatusManager_GetWorkloadStatus(t *testing.T) {
+func TestFileStatusManager_GetWorkload(t *testing.T) {
 	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
 	tempDir := t.TempDir()
-	manager := &fileStatusManager{baseDir: tempDir}
+	mockRuntime := mocks.NewMockRuntime(ctrl)
+	manager := &fileStatusManager{
+		baseDir: tempDir,
+		runtime: mockRuntime,
+	}
 	ctx := context.Background()
 
 	// Create a workload status
 	err := manager.CreateWorkloadStatus(ctx, "test-workload")
 	require.NoError(t, err)
 
-	// Get the status
-	status, statusContext, err := manager.GetWorkloadStatus(ctx, "test-workload")
+	// Get the workload (no runtime call expected for starting workload)
+	workload, err := manager.GetWorkload(ctx, "test-workload")
 	require.NoError(t, err)
-	assert.Equal(t, runtime.WorkloadStatusStarting, status)
-	assert.Empty(t, statusContext)
+	assert.Equal(t, "test-workload", workload.Name)
+	assert.Equal(t, rt.WorkloadStatusStarting, workload.Status)
+	assert.Empty(t, workload.StatusContext)
 }
 
-func TestFileStatusManager_GetWorkloadStatus_NotFound(t *testing.T) {
+func TestFileStatusManager_GetWorkload_NotFound(t *testing.T) {
 	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
 	tempDir := t.TempDir()
-	manager := &fileStatusManager{baseDir: tempDir}
+	mockRuntime := mocks.NewMockRuntime(ctrl)
+	manager := &fileStatusManager{
+		baseDir: tempDir,
+		runtime: mockRuntime,
+	}
 	ctx := context.Background()
 
-	// Try to get status for non-existent workload
-	_, _, err := manager.GetWorkloadStatus(ctx, "non-existent")
+	// Mock runtime to return error for non-existent workload
+	mockRuntime.EXPECT().GetWorkloadInfo(gomock.Any(), "non-existent").Return(rt.ContainerInfo{}, errors.New("workload not found in runtime"))
+
+	// Try to get workload for non-existent workload - should now fall back to runtime
+	_, err := manager.GetWorkload(ctx, "non-existent")
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "not found")
+	assert.Contains(t, err.Error(), "workload not found in runtime")
+}
+
+func TestFileStatusManager_GetWorkload_RuntimeFallback(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	tempDir := t.TempDir()
+	mockRuntime := mocks.NewMockRuntime(ctrl)
+	manager := &fileStatusManager{
+		baseDir: tempDir,
+		runtime: mockRuntime,
+	}
+	ctx := context.Background()
+
+	// Mock runtime to return a workload when file doesn't exist
+	info := rt.ContainerInfo{
+		Name:    "runtime-only-workload",
+		Image:   "test-image:latest",
+		Status:  "running",
+		State:   rt.WorkloadStatusRunning,
+		Created: time.Now(),
+		Labels: map[string]string{
+			"toolhive":           "true",
+			"toolhive-name":      "runtime-only-workload",
+			"toolhive-transport": "sse",
+			"toolhive-port":      "8080",
+			"toolhive-tool-type": "mcp",
+		},
+	}
+	mockRuntime.EXPECT().GetWorkloadInfo(gomock.Any(), "runtime-only-workload").Return(info, nil)
+
+	// Get workload that exists only in runtime
+	workload, err := manager.GetWorkload(ctx, "runtime-only-workload")
+	require.NoError(t, err)
+	assert.Equal(t, "runtime-only-workload", workload.Name)
+	assert.Equal(t, rt.WorkloadStatusRunning, workload.Status)
+	assert.Equal(t, "test-image:latest", workload.Package)
+}
+
+func TestFileStatusManager_GetWorkload_FileAndRuntimeCombination(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	tempDir := t.TempDir()
+	mockRuntime := mocks.NewMockRuntime(ctrl)
+	manager := &fileStatusManager{
+		baseDir: tempDir,
+		runtime: mockRuntime,
+	}
+	ctx := context.Background()
+
+	// Create a workload status file and set it to running
+	err := manager.CreateWorkloadStatus(ctx, "running-workload")
+	require.NoError(t, err)
+	manager.SetWorkloadStatus(ctx, "running-workload", rt.WorkloadStatusRunning, "container started")
+
+	// Mock runtime to return detailed info for running workload
+	info := rt.ContainerInfo{
+		Name:    "running-workload",
+		Image:   "test-image:latest",
+		Status:  "Up 5 minutes",
+		State:   rt.WorkloadStatusRunning,
+		Created: time.Now(),
+		Labels: map[string]string{
+			"toolhive":           "true",
+			"toolhive-name":      "running-workload",
+			"toolhive-transport": "sse",
+			"toolhive-port":      "8080",
+			"toolhive-tool-type": "mcp",
+			"custom-label":       "value1",
+		},
+	}
+	mockRuntime.EXPECT().GetWorkloadInfo(gomock.Any(), "running-workload").Return(info, nil)
+
+	// Get workload - should combine file status with runtime info
+	workload, err := manager.GetWorkload(ctx, "running-workload")
+	require.NoError(t, err)
+
+	// Should preserve file-based status but get runtime details
+	assert.Equal(t, "running-workload", workload.Name)
+	assert.Equal(t, rt.WorkloadStatusRunning, workload.Status)   // From file
+	assert.Equal(t, "container started", workload.StatusContext) // From file
+	assert.Equal(t, "test-image:latest", workload.Package)       // From runtime
+	assert.Equal(t, 8080, workload.Port)                         // From runtime
+	assert.Contains(t, workload.Labels, "custom-label")          // From runtime
 }
 
 func TestFileStatusManager_SetWorkloadStatus(t *testing.T) {
@@ -105,13 +217,10 @@ func TestFileStatusManager_SetWorkloadStatus(t *testing.T) {
 	require.NoError(t, err)
 
 	// Update the status
-	manager.SetWorkloadStatus(ctx, "test-workload", runtime.WorkloadStatusRunning, "container started")
+	manager.SetWorkloadStatus(ctx, "test-workload", rt.WorkloadStatusRunning, "container started")
 
-	// Verify the status was updated
-	status, statusContext, err := manager.GetWorkloadStatus(ctx, "test-workload")
-	require.NoError(t, err)
-	assert.Equal(t, runtime.WorkloadStatusRunning, status)
-	assert.Equal(t, "container started", statusContext)
+	// Note: Cannot verify status was updated via GetWorkload since current implementation returns empty Workload
+	// Instead verify by reading the file directly
 
 	// Verify the file on disk
 	statusFile := filepath.Join(tempDir, "test-workload.json")
@@ -122,7 +231,7 @@ func TestFileStatusManager_SetWorkloadStatus(t *testing.T) {
 	err = json.Unmarshal(data, &statusFileData)
 	require.NoError(t, err)
 
-	assert.Equal(t, runtime.WorkloadStatusRunning, statusFileData.Status)
+	assert.Equal(t, rt.WorkloadStatusRunning, statusFileData.Status)
 	assert.Equal(t, "container started", statusFileData.StatusContext)
 	// CreatedAt should be preserved, UpdatedAt should be newer
 	assert.False(t, statusFileData.CreatedAt.IsZero())
@@ -138,7 +247,7 @@ func TestFileStatusManager_SetWorkloadStatus_NotFound(t *testing.T) {
 	ctx := context.Background()
 
 	// Try to set status for non-existent workload - should not error but do nothing
-	manager.SetWorkloadStatus(ctx, "non-existent", runtime.WorkloadStatusRunning, "test")
+	manager.SetWorkloadStatus(ctx, "non-existent", rt.WorkloadStatusRunning, "test")
 
 	// Verify no file was created
 	statusFile := filepath.Join(tempDir, "non-existent.json")
@@ -179,8 +288,16 @@ func TestFileStatusManager_DeleteWorkloadStatus_NotFound(t *testing.T) {
 
 func TestFileStatusManager_ConcurrentAccess(t *testing.T) {
 	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
 	tempDir := t.TempDir()
-	manager := &fileStatusManager{baseDir: tempDir}
+	mockRuntime := mocks.NewMockRuntime(ctrl)
+	manager := &fileStatusManager{
+		baseDir: tempDir,
+		runtime: mockRuntime,
+	}
 	ctx := context.Background()
 
 	// Create a workload status
@@ -192,10 +309,10 @@ func TestFileStatusManager_ConcurrentAccess(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		go func() {
 			defer func() { done <- true }()
-			status, statusContext, err := manager.GetWorkloadStatus(ctx, "test-workload")
+			workload, err := manager.GetWorkload(ctx, "test-workload")
 			assert.NoError(t, err)
-			assert.Equal(t, runtime.WorkloadStatusStarting, status)
-			assert.Empty(t, statusContext)
+			assert.Equal(t, "test-workload", workload.Name)
+			assert.Equal(t, rt.WorkloadStatusStarting, workload.Status)
 		}()
 	}
 
@@ -211,8 +328,16 @@ func TestFileStatusManager_ConcurrentAccess(t *testing.T) {
 
 func TestFileStatusManager_FullLifecycle(t *testing.T) {
 	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
 	tempDir := t.TempDir()
-	manager := &fileStatusManager{baseDir: tempDir}
+	mockRuntime := mocks.NewMockRuntime(ctrl)
+	manager := &fileStatusManager{
+		baseDir: tempDir,
+		runtime: mockRuntime,
+	}
 	ctx := context.Background()
 
 	workloadName := "lifecycle-test"
@@ -221,42 +346,265 @@ func TestFileStatusManager_FullLifecycle(t *testing.T) {
 	err := manager.CreateWorkloadStatus(ctx, workloadName)
 	require.NoError(t, err)
 
-	// 2. Verify initial status
-	status, statusContext, err := manager.GetWorkloadStatus(ctx, workloadName)
-	require.NoError(t, err)
-	assert.Equal(t, runtime.WorkloadStatusStarting, status)
-	assert.Empty(t, statusContext)
+	// 2. Update to running
+	manager.SetWorkloadStatus(ctx, workloadName, rt.WorkloadStatusRunning, "started successfully")
 
-	// 3. Update to running
-	manager.SetWorkloadStatus(ctx, workloadName, runtime.WorkloadStatusRunning, "started successfully")
+	// 3. Update to stopping
+	manager.SetWorkloadStatus(ctx, workloadName, rt.WorkloadStatusStopping, "shutdown initiated")
 
-	status, statusContext, err = manager.GetWorkloadStatus(ctx, workloadName)
-	require.NoError(t, err)
-	assert.Equal(t, runtime.WorkloadStatusRunning, status)
-	assert.Equal(t, "started successfully", statusContext)
+	// 4. Update to stopped
+	manager.SetWorkloadStatus(ctx, workloadName, rt.WorkloadStatusStopped, "shutdown complete")
 
-	// 4. Update to stopping
-	manager.SetWorkloadStatus(ctx, workloadName, runtime.WorkloadStatusStopping, "shutdown initiated")
-
-	status, statusContext, err = manager.GetWorkloadStatus(ctx, workloadName)
-	require.NoError(t, err)
-	assert.Equal(t, runtime.WorkloadStatusStopping, status)
-	assert.Equal(t, "shutdown initiated", statusContext)
-
-	// 5. Update to stopped
-	manager.SetWorkloadStatus(ctx, workloadName, runtime.WorkloadStatusStopped, "shutdown complete")
-
-	status, statusContext, err = manager.GetWorkloadStatus(ctx, workloadName)
-	require.NoError(t, err)
-	assert.Equal(t, runtime.WorkloadStatusStopped, status)
-	assert.Equal(t, "shutdown complete", statusContext)
-
-	// 6. Delete workload
+	// 5. Delete workload
 	err = manager.DeleteWorkloadStatus(ctx, workloadName)
 	require.NoError(t, err)
 
-	// 7. Verify it's gone
-	_, _, err = manager.GetWorkloadStatus(ctx, workloadName)
+	// Mock runtime to return error for deleted workload (now falls back to runtime)
+	mockRuntime.EXPECT().GetWorkloadInfo(gomock.Any(), workloadName).Return(rt.ContainerInfo{}, errors.New("workload not found in runtime"))
+
+	// Verify GetWorkload properly returns an error for deleted workload
+	_, err = manager.GetWorkload(ctx, workloadName)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "not found")
+	assert.Contains(t, err.Error(), "workload not found in runtime")
+}
+
+func TestFileStatusManager_ListWorkloads(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		setup            func(*fileStatusManager) error
+		listAll          bool
+		labelFilters     []string
+		setupRuntimeMock func(*mocks.MockRuntime)
+		expectedCount    int
+		expectedError    string
+		checkWorkloads   func([]Workload)
+	}{
+		{
+			name:    "empty directory",
+			setup:   func(_ *fileStatusManager) error { return nil },
+			listAll: true,
+			setupRuntimeMock: func(m *mocks.MockRuntime) {
+				// Runtime is always called, even for empty directory
+				m.EXPECT().ListWorkloads(gomock.Any()).Return([]rt.ContainerInfo{}, nil)
+			},
+			expectedCount: 0,
+		},
+		{
+			name: "single starting workload",
+			setup: func(f *fileStatusManager) error {
+				ctx := context.Background()
+				return f.CreateWorkloadStatus(ctx, "test-workload")
+			},
+			listAll: true,
+			setupRuntimeMock: func(m *mocks.MockRuntime) {
+				// Runtime is always called - return empty for file-only workload
+				m.EXPECT().ListWorkloads(gomock.Any()).Return([]rt.ContainerInfo{}, nil)
+			},
+			expectedCount: 1,
+			checkWorkloads: func(workloads []Workload) {
+				assert.Equal(t, "test-workload", workloads[0].Name)
+				assert.Equal(t, rt.WorkloadStatusStarting, workloads[0].Status)
+			},
+		},
+		{
+			name: "mixed workload statuses with listAll=false",
+			setup: func(f *fileStatusManager) error {
+				ctx := context.Background()
+				// Create a starting workload
+				if err := f.CreateWorkloadStatus(ctx, "starting-workload"); err != nil {
+					return err
+				}
+				// Create a running workload
+				if err := f.CreateWorkloadStatus(ctx, "running-workload"); err != nil {
+					return err
+				}
+				f.SetWorkloadStatus(ctx, "running-workload", rt.WorkloadStatusRunning, "container started")
+				return nil
+			},
+			listAll: false, // Only running workloads
+			setupRuntimeMock: func(m *mocks.MockRuntime) {
+				// Mock runtime call for running workload
+				info := rt.ContainerInfo{
+					Name:   "running-workload",
+					Image:  "test-image:latest",
+					Status: "running",
+					State:  rt.WorkloadStatusRunning,
+					Labels: map[string]string{
+						"toolhive":           "true",
+						"toolhive-name":      "running-workload",
+						"toolhive-transport": "sse",
+						"toolhive-port":      "8080",
+						"toolhive-tool-type": "mcp",
+					},
+				}
+				m.EXPECT().ListWorkloads(gomock.Any()).Return([]rt.ContainerInfo{info}, nil)
+			},
+			expectedCount: 1,
+			checkWorkloads: func(workloads []Workload) {
+				assert.Equal(t, "running-workload", workloads[0].Name)
+				assert.Equal(t, rt.WorkloadStatusRunning, workloads[0].Status)
+			},
+		},
+		{
+			name: "mixed workload statuses with listAll=true",
+			setup: func(f *fileStatusManager) error {
+				ctx := context.Background()
+				// Create a starting workload
+				if err := f.CreateWorkloadStatus(ctx, "starting-workload"); err != nil {
+					return err
+				}
+				// Create a running workload
+				if err := f.CreateWorkloadStatus(ctx, "running-workload"); err != nil {
+					return err
+				}
+				f.SetWorkloadStatus(ctx, "running-workload", rt.WorkloadStatusRunning, "container started")
+				return nil
+			},
+			listAll: true, // All workloads
+			setupRuntimeMock: func(m *mocks.MockRuntime) {
+				// Mock runtime call for running workload
+				info := rt.ContainerInfo{
+					Name:   "running-workload",
+					Image:  "test-image:latest",
+					Status: "running",
+					State:  rt.WorkloadStatusRunning,
+					Labels: map[string]string{
+						"toolhive":           "true",
+						"toolhive-name":      "running-workload",
+						"toolhive-transport": "sse",
+						"toolhive-port":      "8080",
+						"toolhive-tool-type": "mcp",
+					},
+				}
+				m.EXPECT().ListWorkloads(gomock.Any()).Return([]rt.ContainerInfo{info}, nil)
+			},
+			expectedCount: 2,
+		},
+		{
+			name: "invalid label filter",
+			setup: func(f *fileStatusManager) error {
+				ctx := context.Background()
+				return f.CreateWorkloadStatus(ctx, "test-workload")
+			},
+			listAll:      true,
+			labelFilters: []string{"invalid-filter"},
+			setupRuntimeMock: func(_ *mocks.MockRuntime) {
+				// Runtime is not called due to early filter parsing error
+			},
+			expectedError: "failed to parse label filters",
+		},
+		{
+			name: "merge runtime and file workloads",
+			setup: func(f *fileStatusManager) error {
+				ctx := context.Background()
+				// Create file workload that will merge with runtime
+				if err := f.CreateWorkloadStatus(ctx, "merge-workload"); err != nil {
+					return err
+				}
+				f.SetWorkloadStatus(ctx, "merge-workload", rt.WorkloadStatusStopping, "shutting down")
+				return nil
+			},
+			listAll: true,
+			setupRuntimeMock: func(m *mocks.MockRuntime) {
+				containers := []rt.ContainerInfo{
+					{
+						Name:   "merge-workload",
+						Image:  "runtime-image:latest",
+						Status: "Up 1 hour",
+						State:  rt.WorkloadStatusRunning, // Runtime says running
+						Labels: map[string]string{
+							"toolhive":           "true",
+							"toolhive-name":      "merge-workload",
+							"toolhive-transport": "http",
+							"toolhive-port":      "9090",
+							"toolhive-tool-type": "mcp",
+							"runtime-label":      "runtime-value",
+						},
+					},
+					{
+						Name:   "runtime-only-workload",
+						Image:  "runtime-only:latest",
+						Status: "Up 30 minutes",
+						State:  rt.WorkloadStatusRunning,
+						Labels: map[string]string{
+							"toolhive":           "true",
+							"toolhive-name":      "runtime-only-workload",
+							"toolhive-transport": "sse",
+							"toolhive-port":      "8080",
+							"toolhive-tool-type": "mcp",
+						},
+					},
+				}
+				m.EXPECT().ListWorkloads(gomock.Any()).Return(containers, nil)
+			},
+			expectedCount: 2,
+			checkWorkloads: func(workloads []Workload) {
+				// Find the merged workload
+				var mergedWorkload *Workload
+				var runtimeOnlyWorkload *Workload
+				for i := range workloads {
+					switch workloads[i].Name {
+					case "merge-workload":
+						mergedWorkload = &workloads[i]
+					case "runtime-only-workload":
+						runtimeOnlyWorkload = &workloads[i]
+					}
+				}
+
+				require.NotNil(t, mergedWorkload, "merged workload should exist")
+				require.NotNil(t, runtimeOnlyWorkload, "runtime-only workload should exist")
+
+				// Merged workload should prefer file status but have runtime details
+				assert.Equal(t, "merge-workload", mergedWorkload.Name)
+				assert.Equal(t, rt.WorkloadStatusStopping, mergedWorkload.Status) // From file
+				assert.Equal(t, "shutting down", mergedWorkload.StatusContext)    // From file
+				assert.Equal(t, "runtime-image:latest", mergedWorkload.Package)   // From runtime
+				assert.Equal(t, 9090, mergedWorkload.Port)                        // From runtime
+				assert.Contains(t, mergedWorkload.Labels, "runtime-label")        // From runtime
+
+				// Runtime-only workload should be normal
+				assert.Equal(t, "runtime-only-workload", runtimeOnlyWorkload.Name)
+				assert.Equal(t, rt.WorkloadStatusRunning, runtimeOnlyWorkload.Status)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			tempDir := t.TempDir()
+			mockRuntime := mocks.NewMockRuntime(ctrl)
+			tt.setupRuntimeMock(mockRuntime)
+
+			manager := &fileStatusManager{
+				baseDir: tempDir,
+				runtime: mockRuntime,
+			}
+
+			// Setup test data
+			err := tt.setup(manager)
+			require.NoError(t, err)
+
+			ctx := context.Background()
+			workloads, err := manager.ListWorkloads(ctx, tt.listAll, tt.labelFilters)
+
+			if tt.expectedError != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedError)
+				assert.Nil(t, workloads)
+			} else {
+				assert.NoError(t, err)
+				assert.Len(t, workloads, tt.expectedCount)
+				if tt.checkWorkloads != nil {
+					tt.checkWorkloads(workloads)
+				}
+			}
+		})
+	}
 }

--- a/pkg/workloads/status.go
+++ b/pkg/workloads/status.go
@@ -2,8 +2,10 @@ package workloads
 
 import (
 	"context"
+	"fmt"
 
 	rt "github.com/stacklok/toolhive/pkg/container/runtime"
+	"github.com/stacklok/toolhive/pkg/labels"
 	"github.com/stacklok/toolhive/pkg/logger"
 )
 
@@ -13,8 +15,10 @@ type StatusManager interface {
 	// Unlike SetWorkloadStatus, this will create a new entry in the status store,
 	// but will do nothing if the workload already exists.
 	CreateWorkloadStatus(ctx context.Context, workloadName string) error
-	// GetWorkloadStatus retrieves the status of a workload by its name.
-	GetWorkloadStatus(ctx context.Context, workloadName string) (rt.WorkloadStatus, string, error)
+	// GetWorkload retrieves details of a workload by its name.
+	GetWorkload(ctx context.Context, workloadName string) (Workload, error)
+	// ListWorkloads returns details of all workloads.
+	ListWorkloads(ctx context.Context, listAll bool, labelFilters []string) ([]Workload, error)
 	// SetWorkloadStatus sets the status of a workload by its name.
 	// Note that this does not return errors, but logs them instead.
 	// This method will do nothing if the workload does not exist.
@@ -43,8 +47,50 @@ func (*runtimeStatusManager) CreateWorkloadStatus(_ context.Context, workloadNam
 	return nil
 }
 
-func (*runtimeStatusManager) GetWorkloadStatus(_ context.Context, _ string) (rt.WorkloadStatus, string, error) {
-	return rt.WorkloadStatusUnknown, "", nil
+func (r *runtimeStatusManager) GetWorkload(ctx context.Context, workloadName string) (Workload, error) {
+	if err := validateWorkloadName(workloadName); err != nil {
+		return Workload{}, err
+	}
+
+	info, err := r.runtime.GetWorkloadInfo(ctx, workloadName)
+	if err != nil {
+		// The error from the runtime is already wrapped in context.
+		return Workload{}, err
+	}
+
+	return WorkloadFromContainerInfo(&info)
+}
+
+func (r *runtimeStatusManager) ListWorkloads(ctx context.Context, listAll bool, labelFilters []string) ([]Workload, error) {
+	// List containers
+	containers, err := r.runtime.ListWorkloads(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list containers: %v", err)
+	}
+
+	// Parse the filters into a format we can use for matching.
+	parsedFilters, err := parseLabelFilters(labelFilters)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse label filters: %v", err)
+	}
+
+	// Filter containers to only show those managed by ToolHive
+	var workloads []Workload
+	for _, c := range containers {
+		// If the caller did not set `listAll` to true, only include running containers.
+		if c.IsRunning() || listAll {
+			workload, err := WorkloadFromContainerInfo(&c)
+			if err != nil {
+				return nil, err
+			}
+			// If label filters are provided, check if the workload matches them.
+			if matchesLabelFilters(workload.Labels, parsedFilters) {
+				workloads = append(workloads, workload)
+			}
+		}
+	}
+
+	return workloads, nil
 }
 
 func (*runtimeStatusManager) SetWorkloadStatus(
@@ -61,4 +107,28 @@ func (*runtimeStatusManager) DeleteWorkloadStatus(_ context.Context, _ string) e
 	// TODO: This will need to handle concurrent updates.
 	// Noop
 	return nil
+}
+
+// parseLabelFilters parses label filters from a slice of strings and validates them.
+func parseLabelFilters(labelFilters []string) (map[string]string, error) {
+	filters := make(map[string]string, len(labelFilters))
+	for _, filter := range labelFilters {
+		key, value, err := labels.ParseLabel(filter)
+		if err != nil {
+			return nil, fmt.Errorf("invalid label filter '%s': %v", filter, err)
+		}
+		filters[key] = value
+	}
+	return filters, nil
+}
+
+// matchesLabelFilters checks if workload labels match all the specified filters
+func matchesLabelFilters(workloadLabels, filters map[string]string) bool {
+	for filterKey, filterValue := range filters {
+		workloadValue, exists := workloadLabels[filterKey]
+		if !exists || workloadValue != filterValue {
+			return false
+		}
+	}
+	return true
 }

--- a/pkg/workloads/status_test.go
+++ b/pkg/workloads/status_test.go
@@ -1,0 +1,452 @@
+package workloads
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+
+	rt "github.com/stacklok/toolhive/pkg/container/runtime"
+	"github.com/stacklok/toolhive/pkg/container/runtime/mocks"
+	"github.com/stacklok/toolhive/pkg/logger"
+)
+
+const testWorkloadName = "test-workload"
+
+func init() {
+	logger.Initialize()
+}
+
+func TestNewStatusManagerFromRuntime(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockRuntime := mocks.NewMockRuntime(ctrl)
+	manager := NewStatusManagerFromRuntime(mockRuntime)
+
+	assert.NotNil(t, manager)
+	assert.IsType(t, &runtimeStatusManager{}, manager)
+
+	rsm := manager.(*runtimeStatusManager)
+	assert.Equal(t, mockRuntime, rsm.runtime)
+}
+
+func TestRuntimeStatusManager_CreateWorkloadStatus(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockRuntime := mocks.NewMockRuntime(ctrl)
+	manager := &runtimeStatusManager{runtime: mockRuntime}
+
+	ctx := context.Background()
+
+	err := manager.CreateWorkloadStatus(ctx, testWorkloadName)
+	assert.NoError(t, err)
+}
+
+func TestRuntimeStatusManager_GetWorkload(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		workloadName  string
+		setupMock     func(*mocks.MockRuntime)
+		expectedError string
+		expectedName  string
+	}{
+		{
+			name:         "successful get workload",
+			workloadName: "test-workload",
+			setupMock: func(m *mocks.MockRuntime) {
+				info := rt.ContainerInfo{
+					Name:    "test-workload",
+					Image:   "test-image:latest",
+					Status:  "running",
+					State:   rt.WorkloadStatusRunning,
+					Created: time.Now(),
+					Labels: map[string]string{
+						"toolhive":           "true",
+						"toolhive-name":      "test-workload",
+						"toolhive-transport": "sse",
+						"toolhive-port":      "8080",
+						"toolhive-tool-type": "mcp",
+					},
+				}
+				m.EXPECT().GetWorkloadInfo(gomock.Any(), "test-workload").Return(info, nil)
+			},
+			expectedName: "test-workload",
+		},
+		{
+			name:          "invalid workload name",
+			workloadName:  "",
+			setupMock:     func(_ *mocks.MockRuntime) {},
+			expectedError: "workload name cannot be empty",
+		},
+		{
+			name:         "runtime error",
+			workloadName: "test-workload",
+			setupMock: func(m *mocks.MockRuntime) {
+				m.EXPECT().GetWorkloadInfo(gomock.Any(), "test-workload").Return(rt.ContainerInfo{}, errors.New("runtime error"))
+			},
+			expectedError: "runtime error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockRuntime := mocks.NewMockRuntime(ctrl)
+			tt.setupMock(mockRuntime)
+
+			manager := &runtimeStatusManager{runtime: mockRuntime}
+			ctx := context.Background()
+
+			workload, err := manager.GetWorkload(ctx, tt.workloadName)
+
+			if tt.expectedError != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedError)
+				assert.Empty(t, workload.Name)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedName, workload.Name)
+			}
+		})
+	}
+}
+
+func TestRuntimeStatusManager_ListWorkloads(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	runningContainer := rt.ContainerInfo{
+		Name:    "running-workload",
+		Image:   "test-image:latest",
+		Status:  "Up 5 minutes",
+		State:   rt.WorkloadStatusRunning,
+		Created: now,
+		Labels: map[string]string{
+			"toolhive":           "true",
+			"toolhive-name":      "running-workload",
+			"toolhive-transport": "sse",
+			"toolhive-port":      "8080",
+			"toolhive-tool-type": "mcp",
+			"custom-label":       "value1",
+		},
+	}
+
+	stoppedContainer := rt.ContainerInfo{
+		Name:    "stopped-workload",
+		Image:   "test-image:latest",
+		Status:  "Exited (0) 2 minutes ago",
+		State:   rt.WorkloadStatusStopped,
+		Created: now.Add(-time.Hour),
+		Labels: map[string]string{
+			"toolhive":           "true",
+			"toolhive-name":      "stopped-workload",
+			"toolhive-transport": "http",
+			"toolhive-port":      "8081",
+			"toolhive-tool-type": "mcp",
+			"environment":        "test",
+		},
+	}
+
+	tests := []struct {
+		name           string
+		listAll        bool
+		labelFilters   []string
+		setupMock      func(*mocks.MockRuntime)
+		expectedCount  int
+		expectedError  string
+		checkWorkloads func([]Workload)
+	}{
+		{
+			name:    "list running workloads only",
+			listAll: false,
+			setupMock: func(m *mocks.MockRuntime) {
+				containers := []rt.ContainerInfo{runningContainer, stoppedContainer}
+				m.EXPECT().ListWorkloads(gomock.Any()).Return(containers, nil)
+			},
+			expectedCount: 1,
+			checkWorkloads: func(workloads []Workload) {
+				assert.Equal(t, "running-workload", workloads[0].Name)
+				assert.Equal(t, rt.WorkloadStatusRunning, workloads[0].Status)
+			},
+		},
+		{
+			name:    "list all workloads",
+			listAll: true,
+			setupMock: func(m *mocks.MockRuntime) {
+				containers := []rt.ContainerInfo{runningContainer, stoppedContainer}
+				m.EXPECT().ListWorkloads(gomock.Any()).Return(containers, nil)
+			},
+			expectedCount: 2,
+		},
+		{
+			name:         "list with label filter",
+			listAll:      true,
+			labelFilters: []string{"environment=test"},
+			setupMock: func(m *mocks.MockRuntime) {
+				containers := []rt.ContainerInfo{runningContainer, stoppedContainer}
+				m.EXPECT().ListWorkloads(gomock.Any()).Return(containers, nil)
+			},
+			expectedCount: 1,
+			checkWorkloads: func(workloads []Workload) {
+				assert.Equal(t, "stopped-workload", workloads[0].Name)
+			},
+		},
+		{
+			name:         "invalid label filter",
+			listAll:      true,
+			labelFilters: []string{"invalid-filter"},
+			setupMock: func(m *mocks.MockRuntime) {
+				// Runtime is called before label parsing, so we need to mock it
+				containers := []rt.ContainerInfo{runningContainer}
+				m.EXPECT().ListWorkloads(gomock.Any()).Return(containers, nil)
+			},
+			expectedError: "failed to parse label filters",
+		},
+		{
+			name:    "runtime error",
+			listAll: true,
+			setupMock: func(m *mocks.MockRuntime) {
+				m.EXPECT().ListWorkloads(gomock.Any()).Return(nil, errors.New("runtime error"))
+			},
+			expectedError: "failed to list containers",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockRuntime := mocks.NewMockRuntime(ctrl)
+			tt.setupMock(mockRuntime)
+
+			manager := &runtimeStatusManager{runtime: mockRuntime}
+			ctx := context.Background()
+
+			workloads, err := manager.ListWorkloads(ctx, tt.listAll, tt.labelFilters)
+
+			if tt.expectedError != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedError)
+				assert.Nil(t, workloads)
+			} else {
+				assert.NoError(t, err)
+				assert.Len(t, workloads, tt.expectedCount)
+				if tt.checkWorkloads != nil {
+					tt.checkWorkloads(workloads)
+				}
+			}
+		})
+	}
+}
+
+func TestRuntimeStatusManager_SetWorkloadStatus(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockRuntime := mocks.NewMockRuntime(ctrl)
+	manager := &runtimeStatusManager{runtime: mockRuntime}
+
+	ctx := context.Background()
+	status := rt.WorkloadStatusRunning
+	contextMsg := "test context"
+
+	manager.SetWorkloadStatus(ctx, testWorkloadName, status, contextMsg)
+}
+
+func TestRuntimeStatusManager_DeleteWorkloadStatus(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockRuntime := mocks.NewMockRuntime(ctrl)
+	manager := &runtimeStatusManager{runtime: mockRuntime}
+
+	ctx := context.Background()
+
+	err := manager.DeleteWorkloadStatus(ctx, testWorkloadName)
+	assert.NoError(t, err)
+}
+
+func TestParseLabelFilters(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		labelFilters   []string
+		expectedResult map[string]string
+		expectedError  string
+	}{
+		{
+			name:           "empty filters",
+			labelFilters:   []string{},
+			expectedResult: map[string]string{},
+		},
+		{
+			name:         "single valid filter",
+			labelFilters: []string{"key=value"},
+			expectedResult: map[string]string{
+				"key": "value",
+			},
+		},
+		{
+			name:         "multiple valid filters",
+			labelFilters: []string{"env=prod", "version=1.0"},
+			expectedResult: map[string]string{
+				"env":     "prod",
+				"version": "1.0",
+			},
+		},
+		{
+			name:          "invalid filter format",
+			labelFilters:  []string{"invalid-filter"},
+			expectedError: "invalid label filter 'invalid-filter'",
+		},
+		{
+			name:          "mixed valid and invalid filters",
+			labelFilters:  []string{"env=prod", "invalid"},
+			expectedError: "invalid label filter 'invalid'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := parseLabelFilters(tt.labelFilters)
+
+			if tt.expectedError != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedError)
+				assert.Nil(t, result)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedResult, result)
+			}
+		})
+	}
+}
+
+func TestMatchesLabelFilters(t *testing.T) {
+	t.Parallel()
+
+	workloadLabels := map[string]string{
+		"env":     "prod",
+		"version": "1.0",
+		"team":    "platform",
+	}
+
+	tests := []struct {
+		name     string
+		filters  map[string]string
+		expected bool
+	}{
+		{
+			name:     "empty filters",
+			filters:  map[string]string{},
+			expected: true,
+		},
+		{
+			name: "single matching filter",
+			filters: map[string]string{
+				"env": "prod",
+			},
+			expected: true,
+		},
+		{
+			name: "multiple matching filters",
+			filters: map[string]string{
+				"env":     "prod",
+				"version": "1.0",
+			},
+			expected: true,
+		},
+		{
+			name: "single non-matching filter",
+			filters: map[string]string{
+				"env": "dev",
+			},
+			expected: false,
+		},
+		{
+			name: "missing label in workload",
+			filters: map[string]string{
+				"missing": "value",
+			},
+			expected: false,
+		},
+		{
+			name: "mixed matching and non-matching",
+			filters: map[string]string{
+				"env":     "prod",
+				"version": "2.0",
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := matchesLabelFilters(workloadLabels, tt.filters)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestValidateWorkloadName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		testWorkloadName string
+		expectError      bool
+	}{
+		{
+			name:             "valid workload name",
+			testWorkloadName: "test-workload",
+			expectError:      false,
+		},
+		{
+			name:             "empty workload name",
+			testWorkloadName: "",
+			expectError:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := validateWorkloadName(tt.testWorkloadName)
+
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "workload name cannot be empty")
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/workloads/types.go
+++ b/pkg/workloads/types.go
@@ -110,8 +110,7 @@ func WorkloadFromContainerInfo(container *runtime.ContainerInfo) (Workload, erro
 
 	// Translate to the domain model.
 	return Workload{
-		Name: container.Name,
-		// TODO: make this return the thv-specific name.
+		Name:          container.Name,
 		Package:       container.Image,
 		URL:           url,
 		ToolType:      toolType,


### PR DESCRIPTION
This moves the Get/List workload operations to the status manager interface. This is needed because the status manager implementation dictates which workloads can be found, and what their statuses should be.

The runtimeStatusManager implementation now relies on the runtime to provide details of which workloads are available, and their state. The fileStatusManager uses the status files, but also delegates to the runtime in order to handle workloads created before the status files were created.

Unit tests are added for workloads/status.go

Note that this does not wire in the file-based status tracking. That will be introduced in the next PR.