### PR TITLE
Add --proxy flag to thv logs command to view proxy logs

### DIFF
--- a/docs/cli/thv_logs.md
+++ b/docs/cli/thv_logs.md
@@ -17,6 +17,9 @@ Output the logs of an MCP server or manage log files
 
 Output the logs of an MCP server managed by ToolHive, or manage log files.
 
+By default, this command shows the logs from the MCP server container.
+Use --proxy to view the logs from the ToolHive proxy process instead.
+
 ```
 thv logs [workload-name|prune] [flags]
 ```
@@ -26,6 +29,7 @@ thv logs [workload-name|prune] [flags]
 ```
   -f, --follow   Follow log output (only for workload logs)
   -h, --help     help for logs
+  -p, --proxy    Show proxy logs instead of container logs
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
This PR adds a `--proxy` flag to the `thv logs` command that allows users to view the logs from the ToolHive proxy process instead of the MCP server container logs.

## Changes

- Added `--proxy` (`-p`) flag to the `thv logs` command
- Implemented `getProxyLogs()` function to read proxy log files from XDG data directory
- Added `followProxyLogFile()` function to support `--follow` flag for proxy logs
- Updated command help text to document the new functionality
- Used `filepath.Clean()` for secure file path handling

## Usage

```bash
# View container logs (default behavior)
thv logs my-server

# View proxy logs
thv logs my-server --proxy
thv logs my-server -p

# Follow proxy logs
thv logs my-server --proxy --follow
```