### PR TITLE
Fix bug where one workload name is a prefix substring of another

### DIFF
--- a/pkg/container/docker/client.go
+++ b/pkg/container/docker/client.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -1528,14 +1529,27 @@ func (c *Client) inspectContainerByName(ctx context.Context, workloadName string
 		return empty, NewContainerError(err, "", fmt.Sprintf("failed to list containers: %v", err))
 	}
 
-	// ASSUMPTION: There should either be no containers found, or exactly one.
 	if len(containers) == 0 {
 		return empty, NewContainerError(runtime.ErrWorkloadNotFound, workloadName, "no containers found")
 	}
-	// This should never happen (I hope).
+	// Docker does a prefix match on the name. If we find multiple containers,
+	// we need to filter down to the exact name requested.
+	var containerID string
 	if len(containers) > 1 {
-		return empty, NewContainerError(ErrMultipleContainersFound, workloadName, "multiple containers found with the same name")
+		idx := slices.IndexFunc(containers, func(c container.Summary) bool {
+			// The name in the API has a leading slash, so we need to check for that.
+			prefixedName := "/" + workloadName
+			// The name in the API is a list of names, so we need to check if the prefixed name is in the list.
+			// The extra names are used for docker network functionality which is not relevant for us.
+			return slices.Contains(c.Names, prefixedName)
+		})
+		if idx == -1 {
+			return empty, NewContainerError(runtime.ErrWorkloadNotFound, workloadName, "no containers found with the exact name")
+		}
+		containerID = containers[idx].ID
+	} else {
+		containerID = containers[0].ID
 	}
 
-	return c.client.ContainerInspect(ctx, containers[0].ID)
+	return c.client.ContainerInspect(ctx, containerID)
 }


### PR DESCRIPTION
My recent change to use names as IDs included a function which uses the Docker API to search for the matching workload container by name. The Docker API uses prefix searching. If you have two workloads, and one workload is a prefix substring of the other, searching for the shorter name will match both and return an error (an error case I ironically assumed would never happen...)

This changes the code to explicitly filter down the list using the exact name in the case where more than one container is returned by Docker. I have validated this by reproducing the scenario that was provided when the bug was reported.