### PR TITLE
Clear the docs before regenerating them

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -7,8 +7,9 @@ includes:
 
 tasks:
   docs:
-    desc: Generate the docs
+    desc: Regenerate the docs
     cmds:
+      - rm -rf docs/cli/*
       - go run cmd/help/main.go --dir docs/cli
 
   swagger-install:


### PR DESCRIPTION
The following PR adds a change to the docs target which ensures we are always deleting the docs before generating them. Otherwise when a command is removed its md file is left there.