### PR TITLE
Avoid checking for updates on CI environments and increase check frequency

### DIFF
--- a/cmd/thv/app/commands.go
+++ b/cmd/thv/app/commands.go
@@ -74,6 +74,10 @@ func IsCompletionCommand(args []string) bool {
 }
 
 func checkForUpdates() {
+	if updates.ShouldSkipUpdateChecks() {
+		return
+	}
+
 	versionClient := updates.NewVersionClient()
 	updateChecker, err := updates.NewUpdateChecker(versionClient)
 	// treat update-related errors as non-fatal

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -95,6 +95,9 @@ func updateCheckMiddleware() func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			go func() {
+				if updates.ShouldSkipUpdateChecks() {
+					return
+				}
 				component, version, uiReleaseBuild := getComponentAndVersionFromRequest(r)
 				versionClient := updates.NewVersionClientForComponent(component, version, uiReleaseBuild)
 

--- a/pkg/operator/telemetry/telemetry.go
+++ b/pkg/operator/telemetry/telemetry.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	// updateInterval defines how often to check for updates
-	updateInterval = 4 * time.Hour
+	updateInterval = 30 * time.Minute
 	// configMapName is the name of the ConfigMap used to store telemetry data
 	configMapName = "toolhive-operator-telemetry"
 	// configMapNamespace is the namespace where the ConfigMap is stored
@@ -91,6 +91,10 @@ func NewService(k8sClient client.Client, namespace string) *Service {
 
 // CheckForUpdates checks for updates and sends telemetry data
 func (s *Service) CheckForUpdates(ctx context.Context) error {
+	if updates.ShouldSkipUpdateChecks() {
+		return nil
+	}
+
 	logger := log.FromContext(ctx)
 
 	// Get or create telemetry data

--- a/pkg/updates/checker.go
+++ b/pkg/updates/checker.go
@@ -65,7 +65,7 @@ func NewUpdateChecker(versionClient VersionClient) (UpdateChecker, error) {
 
 const (
 	updateFilePathSuffix = "toolhive/updates.json"
-	updateInterval       = 4 * time.Hour
+	updateInterval       = 30 * time.Minute
 )
 
 // componentInfo represents component-specific update timing information.

--- a/pkg/updates/checker_test.go
+++ b/pkg/updates/checker_test.go
@@ -147,7 +147,7 @@ func TestCheckLatestVersion(t *testing.T) {
 			LatestVersion: existingVersion,
 			Components: map[string]componentInfo{
 				componentName: {
-					LastCheck: time.Now().UTC().Add(-1 * time.Hour), // Within 4-hour window
+					LastCheck: time.Now().UTC().Add(-15 * time.Minute), // Within 4-hour window
 				},
 			},
 		}

--- a/pkg/updates/client.go
+++ b/pkg/updates/client.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"runtime"
 	"strings"
 	"time"
@@ -49,6 +50,11 @@ const (
 	buildTypeRelease    = "release"
 	buildTypeLocalBuild = "local_build"
 )
+
+// ciEnvVars contains environment variables that indicate CI environments
+var ciEnvVars = []string{
+	"GITHUB_ACTIONS",
+}
 
 // GetLatestVersion sends a GET request to the update API endpoint and returns the version from the response.
 // It returns an error if the request fails or if the response status code is not 200.
@@ -129,4 +135,16 @@ func (d *defaultVersionClient) GetLatestVersion(instanceID string, currentVersio
 // GetComponent returns the component name for this version client.
 func (d *defaultVersionClient) GetComponent() string {
 	return d.component
+}
+
+// ShouldSkipUpdateChecks returns true if update checks should be skipped.
+// This includes CI environments and other scenarios where automated update checking is undesirable.
+func ShouldSkipUpdateChecks() bool {
+	// Check if running in any known CI environment
+	for _, envVar := range ciEnvVars {
+		if os.Getenv(envVar) != "" {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/updates/client.go
+++ b/pkg/updates/client.go
@@ -54,6 +54,13 @@ const (
 // ciEnvVars contains environment variables that indicate CI environments
 var ciEnvVars = []string{
 	"GITHUB_ACTIONS",
+	"CI",
+	"GITLAB_CI",
+	"CIRCLECI",
+	"TRAVIS",
+	"BUILDKITE",
+	"DRONE",
+	"CONTINUOUS_INTEGRATION",
 }
 
 // GetLatestVersion sends a GET request to the update API endpoint and returns the version from the response.


### PR DESCRIPTION
Adds a new mechanism to avoid checking for updates when running Toolhive in CI environments.

Also increases the frequency of checking for update from 4 hours to 30 minutes.