### PR TITLE
Ensure MCP servers from the registry match their expected provenance information

### DIFF
--- a/.github/workflows/update-registry.yml
+++ b/.github/workflows/update-registry.yml
@@ -67,13 +67,14 @@ jobs:
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: "Update registry with latest stars and pulls"
-          title: "Update registry with latest stars and pulls"
+          commit-message: "Refresh registry data - pulls, stars, etc."
+          title: "Refresh registry data - pulls, stars, etc."
           body: |
-            This PR updates the registry with the latest GitHub stars and pulls information.
+            This PR refreshes the registry with the latest GitHub stars and pulls information.
             
             The update was performed automatically by the `regup` command with provenance verification enabled.
-            Any servers that failed provenance verification have been automatically removed from the registry.
+
+            ** Note: Any servers that failed provenance verification have been automatically removed from the registry. **
           branch: update-registry
           base: main
           delete-branch: true

--- a/.github/workflows/update-registry.yml
+++ b/.github/workflows/update-registry.yml
@@ -45,8 +45,8 @@ jobs:
       - name: Update registry
         id: update
         run: |
-          # Run regup with the specified count
-          ./bin/regup update --count ${{ steps.set-count.outputs.count }}
+          # Run regup with the specified count and provenance verification
+          ./bin/regup update --count ${{ steps.set-count.outputs.count }} --verify-provenance
           
           # Check if there are changes
           if git diff --exit-code pkg/registry/data/registry.json; then
@@ -55,6 +55,9 @@ jobs:
           else
             echo "changes=true" >> $GITHUB_OUTPUT
             echo "Changes detected in the registry"
+            # Log what changed for debugging
+            git diff --name-only --diff-filter=M pkg/registry/data/registry.json || true
+            git diff --stat pkg/registry/data/registry.json || true
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -69,7 +72,8 @@ jobs:
           body: |
             This PR updates the registry with the latest GitHub stars and pulls information.
             
-            The update was performed automatically by the `regup` command.
+            The update was performed automatically by the `regup` command with provenance verification enabled.
+            Any servers that failed provenance verification have been automatically removed from the registry.
           branch: update-registry
           base: main
           delete-branch: true

--- a/cmd/regup/app/update.go
+++ b/cmd/regup/app/update.go
@@ -310,22 +310,15 @@ func verifyServerProvenance(name string, server *registry.ImageMetadata) error {
 	}
 
 	// Get verification results
-	results, err := v.GetVerificationResults(server.Image)
+	isVerified, err := v.VerifyServer(server.Image, server)
 	if err != nil {
 		return fmt.Errorf("verification failed: %w", err)
 	}
 
 	// Check if we have valid verification results
-	if len(results) == 0 {
-		return fmt.Errorf("no valid signatures found")
-	}
-
-	// Check if any result is verified
-	for _, result := range results {
-		if result != nil {
-			logger.Infof("Provenance verification successful for server %s", name)
-			return nil
-		}
+	if isVerified {
+		logger.Infof("Server %s verified successfully", name)
+		return nil
 	}
 
 	return fmt.Errorf("no verified signatures found")


### PR DESCRIPTION
The following PR:
* Updates the `regup update` command with `--verify-provenance` flag
* Updates the daily registry refresh job to verify if the MCP servers with provenance information continue to match it
* Removes any MCP servers that have provenance information configured but fail to match it during validation.