### PR TITLE
Potential fix for code scanning alert no. 39: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/run-on-pr.yml
+++ b/.github/workflows/run-on-pr.yml
@@ -22,6 +22,8 @@ jobs:
     uses: ./.github/workflows/e2e-tests.yml
   docs:
     name: Docs
+    permissions:
+      contents: read
     uses: ./.github/workflows/verify-docgen.yml
   swagger:
     name: Swagger


### PR DESCRIPTION
Potential fix for [https://github.com/stacklok/toolhive/security/code-scanning/39](https://github.com/stacklok/toolhive/security/code-scanning/39)

To fix the problem, we need to add a `permissions` block to the `docs` job in `.github/workflows/run-on-pr.yml`. This block should specify the minimal permissions required for the job to run successfully. If the job only needs to read repository contents (which is typical for documentation verification), we can set `contents: read`. If it needs to write to pull requests or issues, those permissions should be added as needed. Since we do not have further information about the requirements of the `verify-docgen.yml` workflow, the safest minimal starting point is `contents: read`. The change should be made by adding the following lines under the `docs` job, before the `uses` key.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
