### PR TITLE
Reset the cached registry provider upon update

### DIFF
--- a/pkg/api/v1/registry.go
+++ b/pkg/api/v1/registry.go
@@ -200,6 +200,9 @@ func (*RegistryRoutes) updateRegistry(w http.ResponseWriter, r *http.Request) {
 		message = fmt.Sprintf("Successfully set local registry file: %s", *req.LocalPath)
 	}
 
+	// Reset the default provider to pick up configuration changes
+	registry.ResetDefaultProvider()
+
 	response := UpdateRegistryResponse{
 		Message: message,
 		Type:    responseType,

--- a/pkg/registry/factory.go
+++ b/pkg/registry/factory.go
@@ -37,3 +37,11 @@ func GetDefaultProvider() (Provider, error) {
 
 	return defaultProvider, defaultProviderErr
 }
+
+// ResetDefaultProvider clears the cached default provider instance
+// This allows the provider to be recreated with updated configuration
+func ResetDefaultProvider() {
+	defaultProviderOnce = sync.Once{}
+	defaultProvider = nil
+	defaultProviderErr = nil
+}


### PR DESCRIPTION
The following PR clears the cached registry provider when the registry was updated. 

This is mainly needed for the API server since it's a long running process. The CLI doesn't have this issue since the provider is re-created upon every command.