### PR TITLE
Move MCP URL generator to transport package

### DIFF
--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -13,8 +13,6 @@ import (
 	"github.com/tailscale/hujson"
 
 	"github.com/stacklok/toolhive/pkg/logger"
-	"github.com/stacklok/toolhive/pkg/transport/ssecommon"
-	"github.com/stacklok/toolhive/pkg/transport/streamable"
 	"github.com/stacklok/toolhive/pkg/transport/types"
 )
 
@@ -458,18 +456,6 @@ func Upsert(cf ConfigFile, name string, url string, transportType string) error 
 		return cf.ConfigUpdater.Upsert(name, MCPServer{Url: url})
 	}
 	return nil
-}
-
-// GenerateMCPServerURL generates the URL for an MCP server
-func GenerateMCPServerURL(transportType string, host string, port int, containerName string) string {
-	// The URL format is: http://host:port/sse#container-name
-	// Both SSE and STDIO transport types use an SSE proxy
-	if transportType == types.TransportTypeSSE.String() || transportType == types.TransportTypeStdio.String() {
-		return fmt.Sprintf("http://%s:%d%s#%s", host, port, ssecommon.HTTPSSEEndpoint, containerName)
-	} else if transportType == types.TransportTypeStreamableHTTP.String() {
-		return fmt.Sprintf("http://%s:%d/%s", host, port, streamable.HTTPStreamableHTTPEndpoint)
-	}
-	return ""
 }
 
 // retrieveConfigFileMetadata retrieves the metadata for client configuration files for a given client type.

--- a/pkg/client/config_test.go
+++ b/pkg/client/config_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/stacklok/toolhive/pkg/config"
 	"github.com/stacklok/toolhive/pkg/logger"
-	"github.com/stacklok/toolhive/pkg/transport/ssecommon"
 	"github.com/stacklok/toolhive/pkg/transport/types"
 )
 
@@ -202,42 +201,6 @@ func TestFindClientConfigs(t *testing.T) { //nolint:paralleltest // Uses environ
 		assert.Contains(t, logOutput, "failed to validate config file format", "Should log the specific validation error")
 		assert.Contains(t, logOutput, "cursor", "Should mention cursor in the error message")
 	})
-}
-
-func TestGenerateMCPServerURL(t *testing.T) {
-	t.Parallel()
-	tests := []struct {
-		name          string
-		host          string
-		port          int
-		containerName string
-		expected      string
-	}{
-		{
-			name:          "Standard URL",
-			host:          "localhost",
-			port:          12345,
-			containerName: "test-container",
-			expected:      "http://localhost:12345" + ssecommon.HTTPSSEEndpoint + "#test-container",
-		},
-		{
-			name:          "Different host",
-			host:          "192.168.1.100",
-			port:          54321,
-			containerName: "another-container",
-			expected:      "http://192.168.1.100:54321" + ssecommon.HTTPSSEEndpoint + "#another-container",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			url := GenerateMCPServerURL(types.TransportTypeSSE.String(), tt.host, tt.port, tt.containerName)
-			if url != tt.expected {
-				t.Errorf("GenerateMCPServerURL() = %v, want %v", url, tt.expected)
-			}
-		})
-	}
 }
 
 func TestSuccessfulClientConfigOperations(t *testing.T) {

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -320,7 +320,7 @@ func updateClientConfigurations(
 
 	// Generate the URL for the MCP server
 	transportType := labels.GetTransportType(containerLabels)
-	url := client.GenerateMCPServerURL(transportType, host, proxyPort, containerName)
+	url := transport.GenerateMCPServerURL(transportType, host, proxyPort, containerName)
 
 	// Update each configuration file
 	for _, clientConfig := range clientConfigs {

--- a/pkg/transport/url.go
+++ b/pkg/transport/url.go
@@ -1,0 +1,22 @@
+// Package transport provides utilities for MCP transport operations
+package transport
+
+import (
+	"fmt"
+
+	"github.com/stacklok/toolhive/pkg/transport/ssecommon"
+	"github.com/stacklok/toolhive/pkg/transport/streamable"
+	"github.com/stacklok/toolhive/pkg/transport/types"
+)
+
+// GenerateMCPServerURL generates the URL for an MCP server
+func GenerateMCPServerURL(transportType string, host string, port int, containerName string) string {
+	// The URL format is: http://host:port/sse#container-name
+	// Both SSE and STDIO transport types use an SSE proxy
+	if transportType == types.TransportTypeSSE.String() || transportType == types.TransportTypeStdio.String() {
+		return fmt.Sprintf("http://%s:%d%s#%s", host, port, ssecommon.HTTPSSEEndpoint, containerName)
+	} else if transportType == types.TransportTypeStreamableHTTP.String() {
+		return fmt.Sprintf("http://%s:%d/%s", host, port, streamable.HTTPStreamableHTTPEndpoint)
+	}
+	return ""
+}

--- a/pkg/transport/url_test.go
+++ b/pkg/transport/url_test.go
@@ -1,0 +1,73 @@
+package transport
+
+import (
+	"testing"
+
+	"github.com/stacklok/toolhive/pkg/transport/ssecommon"
+	"github.com/stacklok/toolhive/pkg/transport/streamable"
+	"github.com/stacklok/toolhive/pkg/transport/types"
+)
+
+func TestGenerateMCPServerURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		transportType string
+		host          string
+		port          int
+		containerName string
+		expected      string
+	}{
+		{
+			name:          "SSE transport",
+			transportType: types.TransportTypeSSE.String(),
+			host:          "localhost",
+			port:          12345,
+			containerName: "test-container",
+			expected:      "http://localhost:12345" + ssecommon.HTTPSSEEndpoint + "#test-container",
+		},
+		{
+			name:          "STDIO transport (uses SSE proxy)",
+			transportType: types.TransportTypeStdio.String(),
+			host:          "localhost",
+			port:          12345,
+			containerName: "test-container",
+			expected:      "http://localhost:12345" + ssecommon.HTTPSSEEndpoint + "#test-container",
+		},
+		{
+			name:          "Streamable HTTP transport",
+			transportType: types.TransportTypeStreamableHTTP.String(),
+			host:          "localhost",
+			port:          12345,
+			containerName: "test-container",
+			expected:      "http://localhost:12345/" + streamable.HTTPStreamableHTTPEndpoint,
+		},
+		{
+			name:          "Different host with SSE",
+			transportType: types.TransportTypeSSE.String(),
+			host:          "192.168.1.100",
+			port:          54321,
+			containerName: "another-container",
+			expected:      "http://192.168.1.100:54321" + ssecommon.HTTPSSEEndpoint + "#another-container",
+		},
+		{
+			name:          "Unsupported transport type",
+			transportType: "unsupported",
+			host:          "localhost",
+			port:          12345,
+			containerName: "test-container",
+			expected:      "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			url := GenerateMCPServerURL(tt.transportType, tt.host, tt.port, tt.containerName)
+			if url != tt.expected {
+				t.Errorf("GenerateMCPServerURL() = %v, want %v", url, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/workloads/types.go
+++ b/pkg/workloads/types.go
@@ -3,7 +3,6 @@ package workloads
 import (
 	"context"
 
-	"github.com/stacklok/toolhive/pkg/client"
 	"github.com/stacklok/toolhive/pkg/container/runtime"
 	"github.com/stacklok/toolhive/pkg/core"
 	"github.com/stacklok/toolhive/pkg/errors"
@@ -52,7 +51,7 @@ func WorkloadFromContainerInfo(container *runtime.ContainerInfo) (core.Workload,
 	// Generate URL for the MCP server
 	url := ""
 	if port > 0 {
-		url = client.GenerateMCPServerURL(transportType, transport.LocalhostIPv4, port, name)
+		url = transport.GenerateMCPServerURL(transportType, transport.LocalhostIPv4, port, name)
 	}
 
 	tType, err := types.ParseTransportType(transportType)


### PR DESCRIPTION
This is a better fit in the transport package than in the client package.