### PR TITLE
Add --dry-run and -o flags to thv build command

### DIFF
--- a/docs/cli/thv_build.md
+++ b/docs/cli/thv_build.md
@@ -44,8 +44,10 @@ thv build [flags] PROTOCOL
 ### Options
 
 ```
-  -h, --help         help for build
-  -t, --tag string   Name and optionally a tag in the 'name:tag' format for the built image
+      --dry-run         Generate Dockerfile without building (stdout output unless -o is set)
+  -h, --help            help for build
+  -o, --output string   Write the Dockerfile to the specified file instead of building
+  -t, --tag string      Name and optionally a tag in the 'name:tag' format for the built image
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
## Summary

This PR adds two new flags to the `thv build` command to allow generating Dockerfiles without building containers:

- `--dry-run`: Generates the Dockerfile and outputs it to stdout without building
- `-o, --output <file>`: Writes the generated Dockerfile to a specified file

These flags can be used together or separately. When both are used, the Dockerfile is written to the file without building.

## Changes

- Added `Output` and `DryRun` fields to `BuildFlags` struct
- Modified `BuildFromProtocolSchemeWithName` to accept a `dryRun` parameter
- Updated `buildCmdFunc` to handle the new flags appropriately
- Fixed linting issues (file permissions, line length)

## Testing

Tested the following scenarios:
- `thv build --dry-run uvx://mcp-server-git` - outputs Dockerfile to stdout
- `thv build -o /tmp/test.Dockerfile npx://@modelcontextprotocol/server-filesystem` - writes Dockerfile to file
- `thv build --dry-run -o /tmp/go-test.Dockerfile go://github.com/example/test` - writes Dockerfile to file without building
- `thv build --tag test-image:latest uvx://mcp-server-git` - normal build still works

All tests pass and linting is clean.