### PR TITLE
feat: track Docker base images in container templates via Renovate regex manager

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,7 +14,23 @@
         "ghcr.io/stacklok/toolhive/operator"
       ],
       "matchFileNames": ["deploy/charts/operator/**"]
+    },
+    {
+      "groupName": "dockerfile template base images",
+      "matchDatasources": ["docker"],
+      "matchManagers": ["custom.regex"]
     }
   ],
- "postUpdateOptions": ["gomodTidy"]
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Update Docker base images in template files",
+      "managerFilePatterns": ["pkg/container/templates/*.tmpl"],
+      "matchStrings": [
+        "FROM (?<depName>[a-z0-9.-]+):(?<currentValue>[a-z0-9.-]+)"
+      ],
+      "datasourceTemplate": "docker"
+    }
+  ],
+  "postUpdateOptions": ["gomodTidy"]
 }


### PR DESCRIPTION
This PR adds a Renovate custom regex manager configuration to track and update Docker base images used in our container template files.

## Changes
- Added a `customManagers` configuration to track Docker base images in `pkg/container/templates/*.tmpl` files
- The regex manager will detect FROM statements and extract the image name and version
- Grouped these updates under "dockerfile template base images" for better organization

## Files tracked
- `pkg/container/templates/go.tmpl` - golang:1.24-alpine
- `pkg/container/templates/npx.tmpl` - node:22-alpine
- `pkg/container/templates/uvx.tmpl` - python:3.12-slim

## How it works
The regex manager uses the pattern `FROM (?<depName>[a-z0-9.-]+):(?<currentValue>[a-z0-9.-]+)` to:
1. Match FROM statements in the template files
2. Extract the image name (depName)
3. Extract the current version (currentValue)
4. Use the Docker datasource to check for updates

This will allow Renovate to automatically create PRs when new versions of these base images are available.