### PR TITLE
Support non-OIDC OAuth in thv proxy

### DIFF
--- a/docs/cli/thv_proxy.md
+++ b/docs/cli/thv_proxy.md
@@ -48,10 +48,19 @@ Basic transparent proxy:
 
 	thv proxy my-server --target-uri http://localhost:8080
 
-Proxy with OAuth authentication to remote server:
+Proxy with OIDC authentication to remote server:
 
 	thv proxy my-server --target-uri https://api.example.com \
 	  --remote-auth --remote-auth-issuer https://auth.example.com \
+	  --remote-auth-client-id my-client-id \
+	  --remote-auth-client-secret-file /path/to/secret
+
+Proxy with non-OIDC OAuth authentication to remote server:
+
+	thv proxy my-server --target-uri https://api.example.com \
+	  --remote-auth \
+	  --remote-auth-authorize-url https://auth.example.com/oauth/authorize \
+	  --remote-auth-token-url https://auth.example.com/oauth/token \
 	  --remote-auth-client-id my-client-id \
 	  --remote-auth-client-secret-file /path/to/secret
 
@@ -83,14 +92,16 @@ thv proxy [flags] SERVER_NAME
       --oidc-jwks-url string                    URL to fetch the JWKS from
       --port int                                Port for the HTTP proxy to listen on (host port)
       --remote-auth                             Enable OAuth authentication to remote MCP server
+      --remote-auth-authorize-url string        OAuth authorization endpoint URL (alternative to --remote-auth-issuer for non-OIDC OAuth)
       --remote-auth-callback-port int           Port for OAuth callback server during remote authentication (default: 8666) (default 8666)
       --remote-auth-client-id string            OAuth client ID for remote server authentication
       --remote-auth-client-secret string        OAuth client secret for remote server authentication (optional for PKCE)
       --remote-auth-client-secret-file string   Path to file containing OAuth client secret (alternative to --remote-auth-client-secret)
       --remote-auth-issuer string               OAuth/OIDC issuer URL for remote server authentication (e.g., https://accounts.google.com)
-      --remote-auth-scopes strings              OAuth scopes to request for remote server authentication (default [openid,profile,email])
+      --remote-auth-scopes strings              OAuth scopes to request for remote server authentication (defaults: OIDC uses 'openid,profile,email')
       --remote-auth-skip-browser                Skip opening browser for remote server OAuth flow
       --remote-auth-timeout duration            Timeout for OAuth authentication flow (e.g., 30s, 1m, 2m30s) (default 30s)
+      --remote-auth-token-url string            OAuth token endpoint URL (alternative to --remote-auth-issuer for non-OIDC OAuth)
       --resource-url string                     Explicit resource URL for OAuth discovery endpoint (RFC 9728)
       --target-uri string                       URI for the target MCP server (e.g., http://localhost:8080) (required)
 ```

--- a/pkg/auth/oauth/manual.go
+++ b/pkg/auth/oauth/manual.go
@@ -1,0 +1,50 @@
+// Package oauth provides OAuth 2.0 and OIDC authentication functionality.
+package oauth
+
+import (
+	"fmt"
+
+	"github.com/stacklok/toolhive/pkg/networking"
+)
+
+// CreateOAuthConfigManual creates an OAuth config with manually provided endpoints
+func CreateOAuthConfigManual(
+	clientID, clientSecret string,
+	authURL, tokenURL string,
+	scopes []string,
+	usePKCE bool,
+	callbackPort int,
+) (*Config, error) {
+	if clientID == "" {
+		return nil, fmt.Errorf("client ID is required")
+	}
+	if authURL == "" {
+		return nil, fmt.Errorf("authorization URL is required")
+	}
+	if tokenURL == "" {
+		return nil, fmt.Errorf("token URL is required")
+	}
+
+	// Validate URLs
+	if err := networking.ValidateEndpointURL(authURL); err != nil {
+		return nil, fmt.Errorf("invalid authorization URL: %w", err)
+	}
+	if err := networking.ValidateEndpointURL(tokenURL); err != nil {
+		return nil, fmt.Errorf("invalid token URL: %w", err)
+	}
+
+	// Default scopes for regular OAuth (don't assume OIDC scopes)
+	if len(scopes) == 0 {
+		scopes = []string{}
+	}
+
+	return &Config{
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
+		AuthURL:      authURL,
+		TokenURL:     tokenURL,
+		Scopes:       scopes,
+		UsePKCE:      usePKCE,
+		CallbackPort: callbackPort,
+	}, nil
+}

--- a/pkg/auth/oauth/manual_test.go
+++ b/pkg/auth/oauth/manual_test.go
@@ -1,0 +1,391 @@
+package oauth
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateOAuthConfigManual(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		clientID     string
+		clientSecret string
+		authURL      string
+		tokenURL     string
+		scopes       []string
+		usePKCE      bool
+		callbackPort int
+		expectError  bool
+		errorMsg     string
+		validate     func(t *testing.T, config *Config)
+	}{
+		{
+			name:         "valid config with all parameters",
+			clientID:     "test-client",
+			clientSecret: "test-secret",
+			authURL:      "https://example.com/oauth/authorize",
+			tokenURL:     "https://example.com/oauth/token",
+			scopes:       []string{"read", "write"},
+			usePKCE:      true,
+			callbackPort: 8080,
+			expectError:  false,
+			validate: func(t *testing.T, config *Config) {
+				t.Helper()
+				assert.Equal(t, "test-client", config.ClientID)
+				assert.Equal(t, "test-secret", config.ClientSecret)
+				assert.Equal(t, "https://example.com/oauth/authorize", config.AuthURL)
+				assert.Equal(t, "https://example.com/oauth/token", config.TokenURL)
+				assert.Equal(t, []string{"read", "write"}, config.Scopes)
+				assert.True(t, config.UsePKCE)
+				assert.Equal(t, 8080, config.CallbackPort)
+			},
+		},
+		{
+			name:         "valid config without client secret (PKCE flow)",
+			clientID:     "test-client",
+			clientSecret: "",
+			authURL:      "https://example.com/oauth/authorize",
+			tokenURL:     "https://example.com/oauth/token",
+			scopes:       []string{"read"},
+			usePKCE:      true,
+			callbackPort: 0,
+			expectError:  false,
+			validate: func(t *testing.T, config *Config) {
+				t.Helper()
+				assert.Equal(t, "test-client", config.ClientID)
+				assert.Equal(t, "", config.ClientSecret)
+				assert.Equal(t, []string{"read"}, config.Scopes)
+				assert.True(t, config.UsePKCE)
+				assert.Equal(t, 0, config.CallbackPort)
+			},
+		},
+		{
+			name:         "valid config with empty scopes (OAuth default)",
+			clientID:     "test-client",
+			clientSecret: "test-secret",
+			authURL:      "https://example.com/oauth/authorize",
+			tokenURL:     "https://example.com/oauth/token",
+			scopes:       nil, // Should default to empty for OAuth
+			usePKCE:      false,
+			callbackPort: 8666,
+			expectError:  false,
+			validate: func(t *testing.T, config *Config) {
+				t.Helper()
+				assert.Equal(t, []string{}, config.Scopes)
+				assert.False(t, config.UsePKCE)
+			},
+		},
+		{
+			name:         "localhost URLs allowed for development",
+			clientID:     "test-client",
+			clientSecret: "test-secret",
+			authURL:      "http://localhost:8080/oauth/authorize",
+			tokenURL:     "http://localhost:8080/oauth/token",
+			scopes:       []string{"read"},
+			usePKCE:      true,
+			callbackPort: 8080,
+			expectError:  false,
+			validate: func(t *testing.T, config *Config) {
+				t.Helper()
+				assert.Equal(t, "http://localhost:8080/oauth/authorize", config.AuthURL)
+				assert.Equal(t, "http://localhost:8080/oauth/token", config.TokenURL)
+			},
+		},
+		{
+			name:         "127.0.0.1 URLs allowed for development",
+			clientID:     "test-client",
+			clientSecret: "test-secret",
+			authURL:      "http://127.0.0.1:3000/auth",
+			tokenURL:     "http://127.0.0.1:3000/token",
+			scopes:       []string{"read"},
+			usePKCE:      false,
+			callbackPort: 8080,
+			expectError:  false,
+			validate: func(t *testing.T, config *Config) {
+				t.Helper()
+				assert.Equal(t, "http://127.0.0.1:3000/auth", config.AuthURL)
+				assert.Equal(t, "http://127.0.0.1:3000/token", config.TokenURL)
+			},
+		},
+		{
+			name:         "GitHub OAuth configuration",
+			clientID:     "github-client-id",
+			clientSecret: "github-client-secret",
+			authURL:      "https://github.com/login/oauth/authorize",
+			tokenURL:     "https://github.com/login/oauth/access_token",
+			scopes:       []string{"repo", "user:email"},
+			usePKCE:      true,
+			callbackPort: 8666,
+			expectError:  false,
+			validate: func(t *testing.T, config *Config) {
+				t.Helper()
+				assert.Equal(t, "github-client-id", config.ClientID)
+				assert.Equal(t, "github-client-secret", config.ClientSecret)
+				assert.Equal(t, "https://github.com/login/oauth/authorize", config.AuthURL)
+				assert.Equal(t, "https://github.com/login/oauth/access_token", config.TokenURL)
+				assert.Equal(t, []string{"repo", "user:email"}, config.Scopes)
+				assert.True(t, config.UsePKCE)
+			},
+		},
+		// Error cases
+		{
+			name:         "missing client ID",
+			clientID:     "",
+			clientSecret: "test-secret",
+			authURL:      "https://example.com/oauth/authorize",
+			tokenURL:     "https://example.com/oauth/token",
+			scopes:       []string{"read"},
+			usePKCE:      true,
+			callbackPort: 8080,
+			expectError:  true,
+			errorMsg:     "client ID is required",
+		},
+		{
+			name:         "missing authorization URL",
+			clientID:     "test-client",
+			clientSecret: "test-secret",
+			authURL:      "",
+			tokenURL:     "https://example.com/oauth/token",
+			scopes:       []string{"read"},
+			usePKCE:      true,
+			callbackPort: 8080,
+			expectError:  true,
+			errorMsg:     "authorization URL is required",
+		},
+		{
+			name:         "missing token URL",
+			clientID:     "test-client",
+			clientSecret: "test-secret",
+			authURL:      "https://example.com/oauth/authorize",
+			tokenURL:     "",
+			scopes:       []string{"read"},
+			usePKCE:      true,
+			callbackPort: 8080,
+			expectError:  true,
+			errorMsg:     "token URL is required",
+		},
+		{
+			name:         "invalid authorization URL",
+			clientID:     "test-client",
+			clientSecret: "test-secret",
+			authURL:      "not-a-url",
+			tokenURL:     "https://example.com/oauth/token",
+			scopes:       []string{"read"},
+			usePKCE:      true,
+			callbackPort: 8080,
+			expectError:  true,
+			errorMsg:     "invalid authorization URL",
+		},
+		{
+			name:         "invalid token URL",
+			clientID:     "test-client",
+			clientSecret: "test-secret",
+			authURL:      "https://example.com/oauth/authorize",
+			tokenURL:     "not-a-url",
+			scopes:       []string{"read"},
+			usePKCE:      true,
+			callbackPort: 8080,
+			expectError:  true,
+			errorMsg:     "invalid token URL",
+		},
+		{
+			name:         "non-HTTPS authorization URL (security check)",
+			clientID:     "test-client",
+			clientSecret: "test-secret",
+			authURL:      "http://example.com/oauth/authorize",
+			tokenURL:     "https://example.com/oauth/token",
+			scopes:       []string{"read"},
+			usePKCE:      true,
+			callbackPort: 8080,
+			expectError:  true,
+			errorMsg:     "invalid authorization URL",
+		},
+		{
+			name:         "non-HTTPS token URL (security check)",
+			clientID:     "test-client",
+			clientSecret: "test-secret",
+			authURL:      "https://example.com/oauth/authorize",
+			tokenURL:     "http://example.com/oauth/token",
+			scopes:       []string{"read"},
+			usePKCE:      true,
+			callbackPort: 8080,
+			expectError:  true,
+			errorMsg:     "invalid token URL",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			config, err := CreateOAuthConfigManual(
+				tt.clientID,
+				tt.clientSecret,
+				tt.authURL,
+				tt.tokenURL,
+				tt.scopes,
+				tt.usePKCE,
+				tt.callbackPort,
+			)
+
+			if tt.expectError {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errorMsg)
+				assert.Nil(t, config)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, config)
+
+			// Common validations for all successful cases
+			assert.Equal(t, tt.clientID, config.ClientID)
+			assert.Equal(t, tt.clientSecret, config.ClientSecret)
+			assert.Equal(t, tt.authURL, config.AuthURL)
+			assert.Equal(t, tt.tokenURL, config.TokenURL)
+			assert.Equal(t, tt.usePKCE, config.UsePKCE)
+			assert.Equal(t, tt.callbackPort, config.CallbackPort)
+
+			if tt.validate != nil {
+				tt.validate(t, config)
+			}
+		})
+	}
+}
+
+func TestCreateOAuthConfigManual_ScopeDefaultBehavior(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		scopes   []string
+		expected []string
+	}{
+		{
+			name:     "nil scopes should default to empty",
+			scopes:   nil,
+			expected: []string{},
+		},
+		{
+			name:     "empty slice should remain empty",
+			scopes:   []string{},
+			expected: []string{},
+		},
+		{
+			name:     "provided scopes should be preserved",
+			scopes:   []string{"read", "write", "admin"},
+			expected: []string{"read", "write", "admin"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			config, err := CreateOAuthConfigManual(
+				"test-client",
+				"test-secret",
+				"https://example.com/oauth/authorize",
+				"https://example.com/oauth/token",
+				tt.scopes,
+				true,
+				8080,
+			)
+
+			require.NoError(t, err)
+			require.NotNil(t, config)
+			assert.Equal(t, tt.expected, config.Scopes)
+		})
+	}
+}
+
+func TestCreateOAuthConfigManual_PKCEBehavior(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		usePKCE  bool
+		expected bool
+	}{
+		{
+			name:     "PKCE enabled",
+			usePKCE:  true,
+			expected: true,
+		},
+		{
+			name:     "PKCE disabled",
+			usePKCE:  false,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			config, err := CreateOAuthConfigManual(
+				"test-client",
+				"test-secret",
+				"https://example.com/oauth/authorize",
+				"https://example.com/oauth/token",
+				[]string{"read"},
+				tt.usePKCE,
+				8080,
+			)
+
+			require.NoError(t, err)
+			require.NotNil(t, config)
+			assert.Equal(t, tt.expected, config.UsePKCE)
+		})
+	}
+}
+
+func TestCreateOAuthConfigManual_CallbackPortBehavior(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		port     int
+		expected int
+	}{
+		{
+			name:     "default port (0 means auto-select)",
+			port:     0,
+			expected: 0,
+		},
+		{
+			name:     "custom port",
+			port:     9000,
+			expected: 9000,
+		},
+		{
+			name:     "standard OAuth port",
+			port:     8666,
+			expected: 8666,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			config, err := CreateOAuthConfigManual(
+				"test-client",
+				"test-secret",
+				"https://example.com/oauth/authorize",
+				"https://example.com/oauth/token",
+				[]string{"read"},
+				true,
+				tt.port,
+			)
+
+			require.NoError(t, err)
+			require.NotNil(t, config)
+			assert.Equal(t, tt.expected, config.CallbackPort)
+		})
+	}
+}

--- a/pkg/auth/oauth/oidc.go
+++ b/pkg/auth/oauth/oidc.go
@@ -180,7 +180,7 @@ func createOAuthConfigFromOIDCWithClient(
 		return nil, fmt.Errorf("failed to discover OIDC endpoints: %w", err)
 	}
 
-	// Default scopes if none provided
+	// Default scopes for OIDC if none provided
 	if len(scopes) == 0 {
 		scopes = []string{"openid", "profile", "email"}
 	}


### PR DESCRIPTION
Fix #1232

Introduce `--remote-auth-authorize-url` and `--remote-auth-token-url` flags to `thv proxy` to set the endpoints that are needed for the OAuth flow.