### PR TITLE
Support colima

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,14 +34,15 @@ require (
 	github.com/tailscale/hujson v0.0.0-20250605163823-992244df8c5a
 	github.com/tidwall/gjson v1.18.0
 	github.com/zalando/go-keyring v0.2.6
-	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.37.0
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.37.0
-	go.opentelemetry.io/otel/exporters/prometheus v0.59.1
-	go.opentelemetry.io/otel/sdk v1.37.0
-	go.opentelemetry.io/otel/sdk/metric v1.37.0
-	go.uber.org/mock v0.5.2
-	golang.ngrok.com/ngrok/v2 v2.0.0
-	golang.org/x/exp/jsonrpc2 v0.0.0-20250718183923-645b1fa84792
+	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.38.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.38.0
+	go.opentelemetry.io/otel/exporters/prometheus v0.60.0
+	go.opentelemetry.io/otel/sdk v1.38.0
+	go.opentelemetry.io/otel/sdk/metric v1.38.0
+	go.uber.org/mock v0.6.0
+	go.uber.org/zap v1.27.0
+	golang.ngrok.com/ngrok/v2 v2.1.0
+	golang.org/x/exp/jsonrpc2 v0.0.0-20250819193227-8b4c13bb791b
 	golang.org/x/mod v0.27.0
 	golang.org/x/oauth2 v0.30.0
 	golang.org/x/sync v0.16.0
@@ -237,15 +238,9 @@ require (
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.ngrok.com/muxado/v2 v2.0.1 // indirect
-<<<<<<< HEAD
 	golang.org/x/exp/event v0.0.0-20250718183923-645b1fa84792 // indirect
 	golang.org/x/net v0.43.0 // indirect
 	golang.org/x/text v0.28.0 // indirect
-=======
-	golang.org/x/exp/event v0.0.0-20250620022241-b7579e27df2b // indirect
-	golang.org/x/net v0.42.0 // indirect
-	golang.org/x/text v0.27.0 // indirect
->>>>>>> 8ef1a70 (support colima on mac)
 	golang.org/x/time v0.12.0 // indirect
 	golang.org/x/tools v0.36.0 // indirect
 	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da // indirect

--- a/go.mod
+++ b/go.mod
@@ -34,15 +34,14 @@ require (
 	github.com/tailscale/hujson v0.0.0-20250605163823-992244df8c5a
 	github.com/tidwall/gjson v1.18.0
 	github.com/zalando/go-keyring v0.2.6
-	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.38.0
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.38.0
-	go.opentelemetry.io/otel/exporters/prometheus v0.60.0
-	go.opentelemetry.io/otel/sdk v1.38.0
-	go.opentelemetry.io/otel/sdk/metric v1.38.0
-	go.uber.org/mock v0.6.0
-	go.uber.org/zap v1.27.0
-	golang.ngrok.com/ngrok/v2 v2.1.0
-	golang.org/x/exp/jsonrpc2 v0.0.0-20250819193227-8b4c13bb791b
+	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.37.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.37.0
+	go.opentelemetry.io/otel/exporters/prometheus v0.59.1
+	go.opentelemetry.io/otel/sdk v1.37.0
+	go.opentelemetry.io/otel/sdk/metric v1.37.0
+	go.uber.org/mock v0.5.2
+	golang.ngrok.com/ngrok/v2 v2.0.0
+	golang.org/x/exp/jsonrpc2 v0.0.0-20250718183923-645b1fa84792
 	golang.org/x/mod v0.27.0
 	golang.org/x/oauth2 v0.30.0
 	golang.org/x/sync v0.16.0
@@ -238,9 +237,15 @@ require (
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.ngrok.com/muxado/v2 v2.0.1 // indirect
+<<<<<<< HEAD
 	golang.org/x/exp/event v0.0.0-20250718183923-645b1fa84792 // indirect
 	golang.org/x/net v0.43.0 // indirect
 	golang.org/x/text v0.28.0 // indirect
+=======
+	golang.org/x/exp/event v0.0.0-20250620022241-b7579e27df2b // indirect
+	golang.org/x/net v0.42.0 // indirect
+	golang.org/x/text v0.27.0 // indirect
+>>>>>>> 8ef1a70 (support colima on mac)
 	golang.org/x/time v0.12.0 // indirect
 	golang.org/x/tools v0.36.0 // indirect
 	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da // indirect

--- a/pkg/container/docker/sdk/factory.go
+++ b/pkg/container/docker/sdk/factory.go
@@ -36,6 +36,8 @@ const (
 	DockerDesktopMacSocketPath = ".docker/run/docker.sock"
 	// RancherDesktopMacSocketPath is the Docker socket path for Rancher Desktop on macOS
 	RancherDesktopMacSocketPath = ".rd/docker.sock"
+	// ColimaDesktopMacSocketPath is the Docker socket path for Colima on macOS
+	ColimaDesktopMacSocketPath = ".colima/default/docker.sock"
 )
 
 var supportedSocketPaths = []runtime.Type{runtime.TypePodman, runtime.TypeDocker}

--- a/pkg/container/docker/sdk/factory.go
+++ b/pkg/container/docker/sdk/factory.go
@@ -22,6 +22,8 @@ const (
 	DockerSocketEnv = "TOOLHIVE_DOCKER_SOCKET"
 	// PodmanSocketEnv is the environment variable for custom Podman socket path
 	PodmanSocketEnv = "TOOLHIVE_PODMAN_SOCKET"
+	// ColimaSocketEnv is the environment variable for custom Colima socket path
+	ColimaSocketEnv = "TOOLHIVE_COLIMA_SOCKET"
 )
 
 // Common socket paths
@@ -40,7 +42,7 @@ const (
 	ColimaDesktopMacSocketPath = ".colima/default/docker.sock"
 )
 
-var supportedSocketPaths = []runtime.Type{runtime.TypePodman, runtime.TypeDocker}
+var supportedSocketPaths = []runtime.Type{runtime.TypePodman, runtime.TypeDocker, runtime.TypeColima}
 
 // NewDockerClient creates a new container client
 func NewDockerClient(ctx context.Context) (*client.Client, string, runtime.Type, error) {

--- a/pkg/container/runtime/types.go
+++ b/pkg/container/runtime/types.go
@@ -187,6 +187,8 @@ const (
 	TypeDocker Type = "docker"
 	// TypeKubernetes represents the Kubernetes runtime
 	TypeKubernetes Type = "kubernetes"
+	// TypeColima represents the Colima runtime
+	TypeColima Type = "colima"
 )
 
 // MountType represents the type of mount


### PR DESCRIPTION
I needed to add `colima` in order to use `thv` in my current setup. Opening as draft as I'm traveling as I write this PR and haven't given due diligence of going through the Dev Guide. Hoping to share for guidance.

Before:
```sh
bin/thv client setup                       
A new version of ToolHive is available: v0.2.5
Currently running: v8ef1a70-dirty
Error: failed to create client manager: no supported container runtime available: container runtime not found
```

After:
```sh
bin/thv client setup
A new version of ToolHive is available: v0.2.5
Currently running: v8ef1a70-dirty
Successfully registered client: vscode
Successfully registered client: cursor
10:02AM INF Creating new client config file at /Users/rhartje/Library/Application Support/Code/User/mcp.json
10:02AM INF Creating new client config file at /Users/rhartje/.cursor/mcp.json
```