### PR TITLE
Auto-load required secrets from secrets manager, if they exist

### DIFF
--- a/pkg/runner/env.go
+++ b/pkg/runner/env.go
@@ -101,6 +101,17 @@ func (*CLIEnvVarValidator) Validate(
 			}
 
 			if envVar.Required {
+
+				if envVar.Secret {
+					value, err := secretsManager.GetSecret(ctx, envVar.Name)
+					if err != nil {
+						logger.Warnf("Unable to find secret %s in the secrets manager: %v", envVar.Name, err)
+					} else {
+						addNewVariable(ctx, envVar, value, secretsManager, &envVars, &secretsList)
+						continue
+					}
+				}
+
 				value, err := promptForEnvironmentVariable(envVar)
 				if err != nil {
 					logger.Warnf("Warning: Failed to read input for %s: %v", envVar.Name, err)


### PR DESCRIPTION
**Use case for this feature**
We want to enable a "no args" experience when using MCP servers locally, where `thv run {{server_name}}` will result in a successful start of the server with no additional flags/arguments needs. A gap in the functionality required to accomplish this is the inability to specify a default behavior for secret environment variables. Within a custom registry, default values may be specified for non-secret environment variables within the `ImageMetadata` for each server. There is no similar functionality for secret environment variables.

This PR addresses this gap by finding required secret environment variables values in the secrets manager. I think this solution is imperfect, and maybe should be optional. I have created this PR to get feedback on the feature gap and proposed solution.