### PR TITLE
Keep grouped servers in sync with client

### DIFF
--- a/pkg/client/manager.go
+++ b/pkg/client/manager.go
@@ -9,6 +9,7 @@ import (
 	ct "github.com/stacklok/toolhive/pkg/container"
 	rt "github.com/stacklok/toolhive/pkg/container/runtime"
 	"github.com/stacklok/toolhive/pkg/core"
+	"github.com/stacklok/toolhive/pkg/groups"
 	"github.com/stacklok/toolhive/pkg/labels"
 	"github.com/stacklok/toolhive/pkg/logger"
 )
@@ -30,10 +31,15 @@ type Manager interface {
 	RegisterClients(clients []Client, workloads []core.Workload) error
 	// UnregisterClients unregisters multiple clients from ToolHive.
 	UnregisterClients(ctx context.Context, clients []Client) error
+	// AddServerToClients adds an MCP server to the appropriate client configurations.
+	AddServerToClients(ctx context.Context, serverName, serverURL, transportType, group string) error
+	// RemoveServerFromClients removes an MCP server from the appropriate client configurations.
+	RemoveServerFromClients(ctx context.Context, serverName, group string) error
 }
 
 type defaultManager struct {
-	runtime rt.Runtime
+	runtime      rt.Runtime
+	groupManager groups.Manager
 }
 
 // NewManager creates a new client manager instance.
@@ -43,8 +49,14 @@ func NewManager(ctx context.Context) (Manager, error) {
 		return nil, err
 	}
 
+	groupManager, err := groups.NewManager()
+	if err != nil {
+		return nil, err
+	}
+
 	return &defaultManager{
-		runtime: runtime,
+		runtime:      runtime,
+		groupManager: groupManager,
 	}, nil
 }
 
@@ -96,6 +108,49 @@ func (m *defaultManager) UnregisterClients(ctx context.Context, clients []Client
 	return nil
 }
 
+// AddServerToClients adds an MCP server to the appropriate client configurations.
+// If the workload belongs to a group, only clients registered with that group are updated.
+// If the workload has no group, all registered clients are updated (backward compatibility).
+func (m *defaultManager) AddServerToClients(
+	ctx context.Context, serverName, serverURL, transportType, group string,
+) error {
+	targetClients := m.getTargetClients(ctx, serverName, group)
+
+	if len(targetClients) == 0 {
+		logger.Infof("No target clients found for server %s", serverName)
+		return nil
+	}
+
+	// Add the server to each target client
+	for _, clientName := range targetClients {
+		if err := m.updateClientWithServer(clientName, serverName, serverURL, transportType); err != nil {
+			logger.Warnf("Warning: Failed to update client %s: %v", clientName, err)
+		}
+	}
+	return nil
+}
+
+// RemoveServerFromClients removes an MCP server from the appropriate client configurations.
+// If the server belongs to a group, only clients registered with that group are updated.
+// If the server has no group, all registered clients are updated (backward compatibility).
+func (m *defaultManager) RemoveServerFromClients(ctx context.Context, serverName, group string) error {
+	targetClients := m.getTargetClients(ctx, serverName, group)
+
+	if len(targetClients) == 0 {
+		logger.Infof("No target clients found for server %s", serverName)
+		return nil
+	}
+
+	// Remove the server from each target client
+	for _, clientName := range targetClients {
+		if err := m.removeServerFromClient(MCPClient(clientName), serverName); err != nil {
+			logger.Warnf("Warning: Failed to remove server from client %s: %v", clientName, err)
+		}
+	}
+
+	return nil
+}
+
 // removeMCPsFromClient removes currently running MCP servers from the specified client's configuration
 func (m *defaultManager) removeMCPsFromClient(ctx context.Context, clientType MCPClient) error {
 	// List workloads
@@ -117,12 +172,6 @@ func (m *defaultManager) removeMCPsFromClient(ctx context.Context, clientType MC
 		return nil
 	}
 
-	// Find the client configuration for the specified client
-	clientConfig, err := FindClientConfig(clientType)
-	if err != nil {
-		return fmt.Errorf("failed to find client configurations: %w", err)
-	}
-
 	// For each running container, remove it from the client configuration
 	for _, c := range runningContainers {
 		// Get container name from labels
@@ -139,34 +188,17 @@ func (m *defaultManager) removeMCPsFromClient(ctx context.Context, clientType MC
 			continue
 		}
 
-		// Remove the MCP server configuration with locking
-		if err := clientConfig.ConfigUpdater.Remove(name); err != nil {
-			logger.Warnf("Warning: Failed to remove MCP server configuration from %s: %v", clientConfig.Path, err)
+		if err := m.removeServerFromClient(clientType, name); err != nil {
+			logger.Warnf("Warning: %v", err)
 			continue
 		}
-
-		logger.Infof("Removed MCP server %s from client %s\n", name, clientType)
 	}
 
 	return nil
 }
 
 // addWorkloadsToClient adds the specified workloads to the client's configuration
-func (*defaultManager) addWorkloadsToClient(clientType MCPClient, workloads []core.Workload) error {
-	// Find the client configuration for the specified client
-	clientConfig, err := FindClientConfig(clientType)
-	if err != nil {
-		if errors.Is(err, ErrConfigFileNotFound) {
-			// Create a new client configuration if it doesn't exist
-			clientConfig, err = CreateClientConfig(clientType)
-			if err != nil {
-				return fmt.Errorf("failed to create client configuration for %s: %w", clientType, err)
-			}
-		} else {
-			return fmt.Errorf("failed to find client configuration: %w", err)
-		}
-	}
-
+func (m *defaultManager) addWorkloadsToClient(clientType MCPClient, workloads []core.Workload) error {
 	if len(workloads) == 0 {
 		// No workloads to add, nothing more to do
 		return nil
@@ -178,14 +210,87 @@ func (*defaultManager) addWorkloadsToClient(clientType MCPClient, workloads []co
 			continue
 		}
 
-		// Update the MCP server configuration with locking
-		if err := Upsert(*clientConfig, workload.Name, workload.URL, string(workload.TransportType)); err != nil {
-			logger.Warnf("Warning: Failed to update MCP server configuration in %s: %v", clientConfig.Path, err)
-			continue
+		// Use the common update function (creates config if needed)
+		err := m.updateClientWithServer(
+			string(clientType), workload.Name, workload.URL, string(workload.TransportType),
+		)
+		if err != nil {
+			return fmt.Errorf("failed to add workload %s to client %s: %v", workload.Name, clientType, err)
 		}
 
 		logger.Infof("Added MCP server %s to client %s\n", workload.Name, clientType)
 	}
 
 	return nil
+}
+
+// removeServerFromClient removes an MCP server from a single client configuration
+func (*defaultManager) removeServerFromClient(clientName MCPClient, serverName string) error {
+	clientConfig, err := FindClientConfig(clientName)
+	if err != nil {
+		return fmt.Errorf("failed to find client configurations: %w", err)
+	}
+
+	// Remove the MCP server configuration with locking
+	if err := clientConfig.ConfigUpdater.Remove(serverName); err != nil {
+		return fmt.Errorf("failed to remove MCP server configuration from %s: %v", clientConfig.Path, err)
+	}
+
+	logger.Infof("Removed MCP server %s from client %s\n", serverName, clientName)
+	return nil
+}
+
+// updateClientWithServer updates a single client with an MCP server configuration, creating config if needed
+func (*defaultManager) updateClientWithServer(clientName, serverName, serverURL, transportType string) error {
+	clientConfig, err := FindClientConfig(MCPClient(clientName))
+	if err != nil {
+		if errors.Is(err, ErrConfigFileNotFound) {
+			// Create a new client configuration if it doesn't exist
+			clientConfig, err = CreateClientConfig(MCPClient(clientName))
+			if err != nil {
+				return fmt.Errorf("failed to create client configuration for %s: %w", clientName, err)
+			}
+		} else {
+			return fmt.Errorf("failed to find client configuration: %w", err)
+		}
+	}
+
+	logger.Infof("Updating client configuration: %s", clientConfig.Path)
+
+	if err := Upsert(*clientConfig, serverName, serverURL, transportType); err != nil {
+		return fmt.Errorf("failed to update MCP server configuration in %s: %v", clientConfig.Path, err)
+	}
+
+	logger.Infof("Successfully updated client configuration: %s", clientConfig.Path)
+	return nil
+}
+
+// getTargetClients determines which clients should be updated based on workload group
+func (m *defaultManager) getTargetClients(ctx context.Context, serverName, groupName string) []string {
+	// Server belongs to a group - only update clients registered with that group
+	if groupName != "" {
+		group, err := m.groupManager.Get(ctx, groupName)
+		if err != nil {
+			logger.Warnf(
+				"Warning: Failed to get group %s for server %s, skipping client config updates: %v",
+				group, serverName, err,
+			)
+			return nil
+		}
+
+		logger.Infof(
+			"Server %s belongs to group %s, updating %d registered client(s)",
+			serverName, group, len(group.RegisteredClients),
+		)
+		return group.RegisteredClients
+	}
+
+	// Server has no group - use backward compatible behavior (update all registered clients)
+	appConfig := config.GetConfig()
+	targetClients := appConfig.Clients.RegisteredClients
+	logger.Infof(
+		"Server %s has no group, updating %d globally registered client(s) for backward compatibility",
+		serverName, len(targetClients),
+	)
+	return targetClients
 }

--- a/pkg/workloads/manager.go
+++ b/pkg/workloads/manager.go
@@ -364,12 +364,10 @@ func (d *defaultManager) DeleteWorkloads(ctx context.Context, names []string) (*
 
 				logger.Infof("Container %s removed", name)
 
-				if shouldRemoveClientConfig() {
-					if err := removeClientConfigurations(name); err != nil {
-						logger.Warnf("Warning: Failed to remove client configurations: %v", err)
-					} else {
-						logger.Infof("Client configurations for %s removed", name)
-					}
+				if err := removeClientConfigurations(name); err != nil {
+					logger.Warnf("Warning: Failed to remove client configurations: %v", err)
+				} else {
+					logger.Infof("Client configurations for %s removed", name)
 				}
 			}
 
@@ -470,37 +468,26 @@ func (d *defaultManager) RestartWorkloads(ctx context.Context, names []string, f
 	return group, nil
 }
 
-func shouldRemoveClientConfig() bool {
-	c := config.GetConfig()
-	return len(c.Clients.RegisteredClients) > 0
-}
-
 // TODO: Move to dedicated config management interface.
 // updateClientConfigurations updates client configuration files with the MCP server URL
 func removeClientConfigurations(containerName string) error {
-	// Find client configuration files
-	configs, err := client.FindRegisteredClientConfigs()
+	// Get the workload's group by loading its run config
+	runConfig, err := runner.LoadState(context.Background(), containerName)
+	var group string
 	if err != nil {
-		return fmt.Errorf("failed to find client configurations: %w", err)
+		logger.Warnf("Warning: Failed to load run config for %s, will use backward compatible behavior: %v", containerName, err)
+		// Continue with empty group (backward compatibility)
+	} else {
+		group = runConfig.Group
 	}
 
-	if len(configs) == 0 {
-		logger.Info("No client configuration files found")
+	clientManager, err := client.NewManager(context.Background())
+	if err != nil {
+		logger.Warnf("Warning: Failed to create client manager for %s, skipping client config removal: %v", containerName, err)
 		return nil
 	}
 
-	for _, c := range configs {
-		logger.Infof("Removing MCP server from client configuration: %s", c.Path)
-
-		if err := c.ConfigUpdater.Remove(containerName); err != nil {
-			logger.Warnf("Warning: Failed to remove MCP server from client configuration %s: %v", c.Path, err)
-			continue
-		}
-
-		logger.Infof("Successfully removed MCP server from client configuration: %s", c.Path)
-	}
-
-	return nil
+	return clientManager.RemoveServerFromClients(context.Background(), containerName, group)
 }
 
 // loadRunnerFromState attempts to load a Runner from the state store
@@ -569,12 +556,10 @@ func (d *defaultManager) stopWorkloads(ctx context.Context, workloads []*rt.Cont
 				return fmt.Errorf("failed to stop container: %w", err)
 			}
 
-			if shouldRemoveClientConfig() {
-				if err := removeClientConfigurations(name); err != nil {
-					logger.Warnf("Warning: Failed to remove client configurations: %v", err)
-				} else {
-					logger.Infof("Client configurations for %s removed", name)
-				}
+			if err := removeClientConfigurations(name); err != nil {
+				logger.Warnf("Warning: Failed to remove client configurations: %v", err)
+			} else {
+				logger.Infof("Client configurations for %s removed", name)
 			}
 
 			d.statuses.SetWorkloadStatus(ctx, name, rt.WorkloadStatusStopped, "")


### PR DESCRIPTION
This is the final step for #1224. It ensures that the client configuration is updated as servers are added and removed.