### PR TITLE
Add `thv ls` as an alias of `thv list`

### DIFF
--- a/cmd/thv/app/list.go
+++ b/cmd/thv/app/list.go
@@ -14,10 +14,11 @@ import (
 )
 
 var listCmd = &cobra.Command{
-	Use:   "list",
-	Short: "List running MCP servers",
-	Long:  `List all MCP servers managed by ToolHive, including their status and configuration.`,
-	RunE:  listCmdFunc,
+	Use:     "list",
+	Aliases: []string{"ls"},
+	Short:   "List running MCP servers",
+	Long:    `List all MCP servers managed by ToolHive, including their status and configuration.`,
+	RunE:    listCmdFunc,
 }
 
 var (


### PR DESCRIPTION
I kept typing `ls` instead of `list`. It was easier to fix the codebase than fix my fingers.