### PR TITLE
fix/otel-config-file-fallback-1355 - Pass cmd parameter to getTelemetryFromFlags instead of nil. Remove unnecessary nil checks since cmd is now properly passed to the function, allowing config file fallbacks to work correctly for OTEL flags.

### DIFF
--- a/cmd/thv/app/run_flags.go
+++ b/cmd/thv/app/run_flags.go
@@ -211,7 +211,7 @@ func BuildRunnerConfig(
 
 	// Get OTEL flag values with config fallbacks
 	config := cfg.GetConfig()
-	finalOtelEndpoint, finalOtelSamplingRate, finalOtelEnvironmentVariables := getTelemetryFromFlags(nil, config,
+	finalOtelEndpoint, finalOtelSamplingRate, finalOtelEnvironmentVariables := getTelemetryFromFlags(cmd, config,
 		runConfig.OtelEndpoint, runConfig.OtelSamplingRate, runConfig.OtelEnvironmentVariables)
 
 	// Create container runtime
@@ -306,17 +306,17 @@ func getTelemetryFromFlags(cmd *cobra.Command, config *cfg.Config, otelEndpoint 
 	otelEnvironmentVariables []string) (string, float64, []string) {
 	// Use config values as fallbacks for OTEL flags if not explicitly set
 	finalOtelEndpoint := otelEndpoint
-	if cmd != nil && !cmd.Flags().Changed("otel-endpoint") && config.OTEL.Endpoint != "" {
+	if !cmd.Flags().Changed("otel-endpoint") && config.OTEL.Endpoint != "" {
 		finalOtelEndpoint = config.OTEL.Endpoint
 	}
 
 	finalOtelSamplingRate := otelSamplingRate
-	if cmd != nil && !cmd.Flags().Changed("otel-sampling-rate") && config.OTEL.SamplingRate != 0.0 {
+	if !cmd.Flags().Changed("otel-sampling-rate") && config.OTEL.SamplingRate != 0.0 {
 		finalOtelSamplingRate = config.OTEL.SamplingRate
 	}
 
 	finalOtelEnvironmentVariables := otelEnvironmentVariables
-	if cmd != nil && !cmd.Flags().Changed("otel-env-vars") && len(config.OTEL.EnvVars) > 0 {
+	if !cmd.Flags().Changed("otel-env-vars") && len(config.OTEL.EnvVars) > 0 {
 		finalOtelEnvironmentVariables = config.OTEL.EnvVars
 	}
 

--- a/cmd/thv/app/run_flags_test.go
+++ b/cmd/thv/app/run_flags_test.go
@@ -1,0 +1,220 @@
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/adrg/xdg"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stacklok/toolhive/pkg/config"
+	"github.com/stacklok/toolhive/pkg/logger"
+)
+
+// mockConfig creates a temporary config file with the provided configuration.
+func mockConfig(t *testing.T, cfg *config.Config) func() {
+	t.Helper()
+	tempDir := t.TempDir()
+	originalXDGConfigHome := os.Getenv("XDG_CONFIG_HOME")
+	t.Setenv("XDG_CONFIG_HOME", tempDir)
+	xdg.Reload()
+	configDir := filepath.Join(tempDir, "toolhive")
+	err := os.MkdirAll(configDir, 0755)
+	require.NoError(t, err)
+	if cfg != nil {
+		err = config.UpdateConfig(func(c *config.Config) { *c = *cfg })
+		require.NoError(t, err)
+	}
+	return func() {
+		t.Setenv("XDG_CONFIG_HOME", originalXDGConfigHome)
+		xdg.Reload()
+	}
+}
+
+//nolint:paralleltest // Cannot use t.Parallel() with t.Setenv() in Go 1.24+
+func TestBuildRunnerConfig_TelemetryProcessing(t *testing.T) {
+	// Initialize logger to prevent nil pointer dereference
+	logger.Initialize()
+
+	tests := []struct {
+		name                         string
+		setupFlags                   func(*cobra.Command)
+		configOTEL                   config.OpenTelemetryConfig
+		runFlags                     *RunFlags
+		expectedEndpoint             string
+		expectedSamplingRate         float64
+		expectedEnvironmentVariables []string
+	}{
+		{
+			name: "CLI flags provided, taking precedence over config file",
+			setupFlags: func(cmd *cobra.Command) {
+				// Mark CLI flags as changed to simulate user providing them
+				cmd.Flags().Set("otel-endpoint", "https://cli-endpoint.example.com")
+				cmd.Flags().Set("otel-sampling-rate", "0.8")
+				cmd.Flags().Set("otel-env-vars", "CLI_VAR1=value1")
+				cmd.Flags().Set("otel-env-vars", "CLI_VAR2=value2")
+			},
+			configOTEL: config.OpenTelemetryConfig{
+				Endpoint:     "https://config-endpoint.example.com",
+				SamplingRate: 0.2,
+				EnvVars:      []string{"CONFIG_VAR1=configvalue1", "CONFIG_VAR2=configvalue2"},
+			},
+			runFlags: &RunFlags{
+				OtelEndpoint:             "https://cli-endpoint.example.com",
+				OtelSamplingRate:         0.8,
+				OtelEnvironmentVariables: []string{"CLI_VAR1=value1", "CLI_VAR2=value2"},
+				// Set other required fields to avoid nil pointer errors
+				Transport:         "sse",
+				ProxyMode:         "sse",
+				Host:              "localhost",
+				PermissionProfile: "none",
+			},
+			expectedEndpoint:             "https://cli-endpoint.example.com",
+			expectedSamplingRate:         0.8,
+			expectedEnvironmentVariables: []string{"CLI_VAR1=value1", "CLI_VAR2=value2"},
+		},
+		{
+			name: "No CLI flags provided, config takes precedence",
+			setupFlags: func(_ *cobra.Command) {
+				// Don't set any flags - they should remain unchanged/default
+				// This simulates the case where user doesn't provide CLI flags
+			},
+			configOTEL: config.OpenTelemetryConfig{
+				Endpoint:     "https://config-endpoint.example.com",
+				SamplingRate: 0.3,
+				EnvVars:      []string{"CONFIG_VAR1=configvalue1", "CONFIG_VAR2=configvalue2"},
+			},
+			runFlags: &RunFlags{
+				OtelEndpoint:             "",
+				OtelSamplingRate:         0.1,
+				OtelEnvironmentVariables: nil,
+				Transport:                "sse",
+				ProxyMode:                "sse",
+				Host:                     "localhost",
+				PermissionProfile:        "none",
+			},
+			expectedEndpoint:             "https://config-endpoint.example.com",
+			expectedSamplingRate:         0.3,
+			expectedEnvironmentVariables: []string{"CONFIG_VAR1=configvalue1", "CONFIG_VAR2=configvalue2"},
+		},
+		{
+			name: "Partial CLI flags provided, mix of CLI and config values",
+			setupFlags: func(cmd *cobra.Command) {
+				// Only set endpoint flag, leave others to use config values
+				cmd.Flags().Set("otel-endpoint", "https://partial-cli-endpoint.example.com")
+			},
+			configOTEL: config.OpenTelemetryConfig{
+				Endpoint:     "https://config-endpoint.example.com",
+				SamplingRate: 0.5,
+				EnvVars:      []string{"CONFIG_VAR1=configvalue1"},
+			},
+			runFlags: &RunFlags{
+				OtelEndpoint:             "https://partial-cli-endpoint.example.com",
+				OtelSamplingRate:         0.1,
+				OtelEnvironmentVariables: nil,
+				Transport:                "sse",
+				ProxyMode:                "sse",
+				Host:                     "localhost",
+				PermissionProfile:        "none",
+			},
+			expectedEndpoint:             "https://partial-cli-endpoint.example.com",
+			expectedSamplingRate:         0.5,
+			expectedEnvironmentVariables: []string{"CONFIG_VAR1=configvalue1"},
+		},
+		{
+			name: "Empty config values, CLI flags should be used",
+			setupFlags: func(cmd *cobra.Command) {
+				cmd.Flags().Set("otel-endpoint", "https://cli-only-endpoint.example.com")
+				cmd.Flags().Set("otel-sampling-rate", "0.9")
+			},
+			configOTEL: config.OpenTelemetryConfig{
+				Endpoint:     "",
+				SamplingRate: 0.0,
+				EnvVars:      nil,
+			},
+			runFlags: &RunFlags{
+				OtelEndpoint:             "https://cli-only-endpoint.example.com",
+				OtelSamplingRate:         0.9,
+				OtelEnvironmentVariables: nil,
+				Transport:                "sse",
+				ProxyMode:                "sse",
+				Host:                     "localhost",
+				PermissionProfile:        "none",
+			},
+			expectedEndpoint:             "https://cli-only-endpoint.example.com",
+			expectedSamplingRate:         0.9,
+			expectedEnvironmentVariables: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := &cobra.Command{}
+			AddRunFlags(cmd, &RunFlags{})
+			tt.setupFlags(cmd)
+			cleanup := mockConfig(t, &config.Config{
+				OTEL: tt.configOTEL,
+			})
+			defer cleanup()
+			configInstance := config.GetConfig()
+			finalEndpoint, finalSamplingRate, finalEnvVars := getTelemetryFromFlags(
+				cmd,
+				configInstance,
+				tt.runFlags.OtelEndpoint,
+				tt.runFlags.OtelSamplingRate,
+				tt.runFlags.OtelEnvironmentVariables,
+			)
+
+			// Assert the results
+			assert.Equal(t, tt.expectedEndpoint, finalEndpoint, "OTEL endpoint should match expected value")
+			assert.Equal(t, tt.expectedSamplingRate, finalSamplingRate, "OTEL sampling rate should match expected value")
+			assert.Equal(t, tt.expectedEnvironmentVariables, finalEnvVars, "OTEL environment variables should match expected value")
+		})
+	}
+}
+
+//nolint:paralleltest // Cannot use t.Parallel() with t.Setenv() in Go 1.24+
+func TestBuildRunnerConfig_TelemetryProcessing_Integration(t *testing.T) {
+	// This is a more complete integration test that tests telemetry processing
+	// within the full BuildRunnerConfig function context
+	logger.Initialize()
+	cmd := &cobra.Command{}
+	runFlags := &RunFlags{
+		Transport:         "sse",
+		ProxyMode:         "sse",
+		Host:              "localhost",
+		PermissionProfile: "none",
+		OtelEndpoint:      "https://integration-test.example.com",
+		OtelSamplingRate:  0.7,
+	}
+	AddRunFlags(cmd, runFlags)
+	err := cmd.Flags().Set("otel-endpoint", "https://integration-test.example.com")
+	require.NoError(t, err)
+	err = cmd.Flags().Set("otel-sampling-rate", "0.7")
+	require.NoError(t, err)
+	cleanup := mockConfig(t, &config.Config{
+		OTEL: config.OpenTelemetryConfig{
+			Endpoint:     "https://config-fallback.example.com",
+			SamplingRate: 0.2,
+			EnvVars:      []string{"CONFIG_VAR=value"},
+		},
+	})
+	defer cleanup()
+
+	configInstance := config.GetConfig()
+	finalEndpoint, finalSamplingRate, finalEnvVars := getTelemetryFromFlags(
+		cmd,
+		configInstance,
+		runFlags.OtelEndpoint,
+		runFlags.OtelSamplingRate,
+		runFlags.OtelEnvironmentVariables,
+	)
+
+	// Verify that CLI values take precedence
+	assert.Equal(t, "https://integration-test.example.com", finalEndpoint, "CLI endpoint should take precedence over config")
+	assert.Equal(t, 0.7, finalSamplingRate, "CLI sampling rate should take precedence over config")
+	assert.Equal(t, []string{"CONFIG_VAR=value"}, finalEnvVars, "Environment variables should fall back to config when not set via CLI")
+}


### PR DESCRIPTION
fix/otel-config-file-fallback-1355 - Pass cmd parameter to getTelemetryFromFlags instead of nil. Remove unnecessary nil checks since cmd is now properly passed to the function, allowing config file fallbacks to work correctly for OTEL flags.
