### PR TITLE
Add 10 new MCP servers to registry

### DIFF
--- a/pkg/registry/data/registry.json
+++ b/pkg/registry/data/registry.json
@@ -1,7 +1,62 @@
 {
   "$schema": "https://raw.githubusercontent.com/stacklok/toolhive/main/docs/registry/schema.json",
-  "last_updated": "2025-08-13T00:22:55Z",
+  "last_updated": "2025-08-13T08:42:55Z",
   "servers": {
+    "arxiv-mcp-server": {
+      "args": [
+        "--storage-path",
+        "/arxiv-papers"
+      ],
+      "description": "Enables AI assistants to search and access arXiv research papers through MCP protocol. Mount a volume to /arxiv-papers for persistent paper storage.",
+      "env_vars": [
+        {
+          "default": "/arxiv-papers",
+          "description": "Directory path where downloaded papers will be stored",
+          "name": "ARXIV_STORAGE_PATH",
+          "required": false
+        }
+      ],
+      "image": "ghcr.io/stacklok/dockyard/uvx/arxiv-mcp-server:0.3.0",
+      "metadata": {
+        "last_updated": "2025-08-13T08:42:29Z",
+        "pulls": 77,
+        "stars": 1559
+      },
+      "permissions": {
+        "network": {
+          "outbound": {
+            "allow_host": [
+              "arxiv.org",
+              "export.arxiv.org"
+            ],
+            "allow_port": [
+              443,
+              80
+            ],
+            "insecure_allow_all": false
+          }
+        },
+        "read": [],
+        "write": []
+      },
+      "repository_url": "https://github.com/blazickjp/arxiv-mcp-server",
+      "status": "Active",
+      "tags": [
+        "research",
+        "academic",
+        "papers",
+        "arxiv",
+        "search"
+      ],
+      "tier": "Community",
+      "tools": [
+        "search_papers",
+        "download_paper",
+        "list_papers",
+        "read_paper"
+      ],
+      "transport": "stdio"
+    },
     "atlassian": {
       "args": [],
       "description": "Connect to Atlassian products like Confluence, Jira Cloud and Server/Data deployments.",
@@ -88,9 +143,9 @@
       ],
       "image": "ghcr.io/sooperset/mcp-atlassian:0.11.9",
       "metadata": {
-        "last_updated": "2025-08-13T00:22:46Z",
-        "pulls": 12739,
-        "stars": 2781
+        "last_updated": "2025-08-13T08:42:39Z",
+        "pulls": 12849,
+        "stars": 2787
       },
       "permissions": {
         "network": {
@@ -181,9 +236,9 @@
       ],
       "image": "docker.io/mcp/aws-diagram:latest",
       "metadata": {
-        "last_updated": "2025-08-13T00:22:54Z",
-        "pulls": 7243,
-        "stars": 5318
+        "last_updated": "2025-08-13T08:42:54Z",
+        "pulls": 7294,
+        "stars": 5324
       },
       "permissions": {
         "network": {
@@ -233,9 +288,9 @@
       ],
       "image": "docker.io/mcp/aws-documentation:latest",
       "metadata": {
-        "last_updated": "2025-08-13T00:22:53Z",
-        "pulls": 10323,
-        "stars": 5318
+        "last_updated": "2025-08-13T08:42:51Z",
+        "pulls": 10451,
+        "stars": 5324
       },
       "permissions": {
         "network": {
@@ -306,9 +361,9 @@
       ],
       "image": "public.ecr.aws/f3y8w4n0/awslabs/aws-pricing-mcp-server:1.0.8",
       "metadata": {
-        "last_updated": "2025-08-13T00:22:47Z",
-        "pulls": 8105,
-        "stars": 5318
+        "last_updated": "2025-08-13T08:42:40Z",
+        "pulls": 8179,
+        "stars": 5324
       },
       "permissions": {
         "network": {
@@ -394,8 +449,8 @@
       ],
       "image": "mcr.microsoft.com/azure-sdk/azure-mcp:0.5.1",
       "metadata": {
-        "last_updated": "2025-08-13T00:22:46Z",
-        "pulls": 1708,
+        "last_updated": "2025-08-13T08:42:38Z",
+        "pulls": 1809,
         "stars": 1080
       },
       "permissions": {
@@ -466,6 +521,212 @@
       ],
       "transport": "stdio"
     },
+    "brightdata-mcp": {
+      "args": [],
+      "description": "An MCP interface into the Bright Data toolset for web scraping and data extraction",
+      "env_vars": [
+        {
+          "description": "Bright Data API token for authentication",
+          "name": "API_TOKEN",
+          "required": true,
+          "secret": true
+        },
+        {
+          "description": "Rate limiting configuration (format: limit/time+unit, e.g., 100/1h, 50/30m, 10/5s)",
+          "name": "RATE_LIMIT",
+          "required": false
+        },
+        {
+          "default": "mcp_unlocker",
+          "description": "Custom Web Unlocker zone name",
+          "name": "WEB_UNLOCKER_ZONE",
+          "required": false
+        },
+        {
+          "default": "mcp_browser",
+          "description": "Custom Browser API zone name",
+          "name": "BROWSER_ZONE",
+          "required": false
+        },
+        {
+          "default": "false",
+          "description": "Enable pro mode to access all tools including browser automation and web data extraction",
+          "name": "PRO_MODE",
+          "required": false
+        }
+      ],
+      "image": "ghcr.io/stacklok/dockyard/npx/brightdata-mcp:2.4.2",
+      "metadata": {
+        "last_updated": "2025-08-13T08:42:29Z",
+        "pulls": 65,
+        "stars": 1065
+      },
+      "permissions": {
+        "network": {
+          "outbound": {
+            "allow_host": [
+              "api.brightdata.com",
+              "brightdata.com"
+            ],
+            "allow_port": [
+              443,
+              80
+            ],
+            "insecure_allow_all": false
+          }
+        },
+        "read": [],
+        "write": []
+      },
+      "repository_url": "https://github.com/brightdata/brightdata-mcp",
+      "status": "Active",
+      "tags": [
+        "web-scraping",
+        "data-extraction",
+        "api",
+        "automation",
+        "browser"
+      ],
+      "tier": "Community",
+      "tools": [
+        "search_engine",
+        "scrape_as_markdown",
+        "scrape_as_html",
+        "extract",
+        "session_stats",
+        "web_data_amazon_product",
+        "web_data_amazon_product_reviews",
+        "web_data_amazon_product_search",
+        "web_data_walmart_product",
+        "web_data_walmart_seller",
+        "web_data_ebay_product",
+        "web_data_homedepot_products",
+        "web_data_zara_products",
+        "web_data_etsy_products",
+        "web_data_bestbuy_products",
+        "web_data_linkedin_person_profile",
+        "web_data_linkedin_company_profile",
+        "web_data_linkedin_job_listings",
+        "web_data_linkedin_posts",
+        "web_data_linkedin_people_search",
+        "web_data_crunchbase_company",
+        "web_data_zoominfo_company_profile",
+        "web_data_instagram_profiles",
+        "web_data_instagram_posts",
+        "web_data_instagram_reels",
+        "web_data_instagram_comments",
+        "web_data_facebook_posts",
+        "web_data_facebook_marketplace_listings",
+        "web_data_facebook_company_reviews",
+        "web_data_facebook_events",
+        "web_data_tiktok_profiles",
+        "web_data_tiktok_posts",
+        "web_data_tiktok_shop",
+        "web_data_tiktok_comments",
+        "web_data_google_maps_reviews",
+        "web_data_google_shopping",
+        "web_data_google_play_store",
+        "web_data_apple_app_store",
+        "web_data_reuter_news",
+        "web_data_github_repository_file",
+        "web_data_yahoo_finance_business",
+        "web_data_x_posts",
+        "web_data_zillow_properties_listing",
+        "web_data_booking_hotel_listings",
+        "web_data_youtube_profiles",
+        "web_data_youtube_comments",
+        "web_data_youtube_videos",
+        "web_data_reddit_posts",
+        "browser_create_session",
+        "browser_navigate",
+        "browser_click",
+        "browser_type",
+        "browser_scroll",
+        "browser_screenshot",
+        "browser_get_page_content",
+        "browser_wait_for_element",
+        "browser_execute_script",
+        "browser_close_session"
+      ],
+      "transport": "stdio"
+    },
+    "browserbase": {
+      "args": [],
+      "description": "MCP server for cloud browser automation with Browserbase and Stagehand",
+      "env_vars": [
+        {
+          "description": "Browserbase API key",
+          "name": "BROWSERBASE_API_KEY",
+          "required": true,
+          "secret": true
+        },
+        {
+          "description": "Browserbase project ID",
+          "name": "BROWSERBASE_PROJECT_ID",
+          "required": true,
+          "secret": false
+        },
+        {
+          "description": "Google Gemini API key for Stagehand",
+          "name": "GEMINI_API_KEY",
+          "required": true,
+          "secret": true
+        }
+      ],
+      "image": "ghcr.io/stacklok/dockyard/npx/browserbase-mcp-server:2.0.0",
+      "metadata": {
+        "last_updated": "2025-08-13T08:42:35Z",
+        "pulls": 133,
+        "stars": 2411
+      },
+      "permissions": {
+        "network": {
+          "outbound": {
+            "allow_host": [],
+            "allow_port": [],
+            "insecure_allow_all": true
+          }
+        },
+        "read": [],
+        "write": []
+      },
+      "provenance": {
+        "cert_issuer": "https://token.actions.githubusercontent.com",
+        "repository_uri": "https://github.com/stacklok/dockyard",
+        "runner_environment": "github-hosted",
+        "signer_identity": "/.github/workflows/build-containers.yml",
+        "sigstore_url": "tuf-repo-cdn.sigstore.dev"
+      },
+      "repository_url": "https://github.com/browserbase/mcp-server-browserbase",
+      "status": "Active",
+      "tags": [
+        "browser",
+        "automation",
+        "web-scraping",
+        "testing",
+        "stagehand"
+      ],
+      "tier": "Official",
+      "tools": [
+        "createSession",
+        "listSessions",
+        "closeSession",
+        "navigateWithSession",
+        "actWithSession",
+        "extractWithSession",
+        "observeWithSession",
+        "getUrlWithSession",
+        "getAllUrlsWithSession",
+        "closeAllSessions",
+        "navigate",
+        "act",
+        "extract",
+        "observe",
+        "screenshot",
+        "getUrl"
+      ],
+      "transport": "stdio"
+    },
     "buildkite": {
       "args": [
         "stdio"
@@ -486,8 +747,8 @@
       ],
       "image": "ghcr.io/buildkite/buildkite-mcp-server:0.5.8",
       "metadata": {
-        "last_updated": "2025-08-13T00:22:51Z",
-        "pulls": 3317,
+        "last_updated": "2025-08-13T08:42:47Z",
+        "pulls": 3424,
         "stars": 25
       },
       "permissions": {
@@ -546,92 +807,15 @@
       ],
       "transport": "stdio"
     },
-    "browserbase": {
-      "args": [],
-      "description": "MCP server for cloud browser automation with Browserbase and Stagehand",
-      "env_vars": [
-        {
-          "description": "Browserbase API key",
-          "name": "BROWSERBASE_API_KEY",
-          "required": true,
-          "secret": true
-        },
-        {
-          "description": "Browserbase project ID",
-          "name": "BROWSERBASE_PROJECT_ID",
-          "required": true,
-          "secret": false
-        },
-        {
-          "description": "Google Gemini API key for Stagehand",
-          "name": "GEMINI_API_KEY",
-          "required": true,
-          "secret": true
-        }
-      ],
-      "image": "ghcr.io/stacklok/dockyard/npx/browserbase-mcp-server:2.0.0",
-      "metadata": {
-        "last_updated": "2025-08-11T15:29:09Z",
-        "pulls": 0,
-        "stars": 2401
-      },
-      "permissions": {
-        "network": {
-          "outbound": {
-            "allow_host": [],
-            "allow_port": [],
-            "insecure_allow_all": true
-          }
-        },
-        "read": [],
-        "write": []
-      },
-      "provenance": {
-        "cert_issuer": "https://token.actions.githubusercontent.com",
-        "repository_uri": "https://github.com/stacklok/dockyard",
-        "runner_environment": "github-hosted",
-        "signer_identity": "/.github/workflows/build-containers.yml",
-        "sigstore_url": "tuf-repo-cdn.sigstore.dev"
-      },
-      "repository_url": "https://github.com/browserbase/mcp-server-browserbase",
-      "status": "Active",
-      "tags": [
-        "browser",
-        "automation",
-        "web-scraping",
-        "testing",
-        "stagehand"
-      ],
-      "tier": "Official",
-      "tools": [
-        "createSession",
-        "listSessions",
-        "closeSession",
-        "navigateWithSession",
-        "actWithSession",
-        "extractWithSession",
-        "observeWithSession",
-        "getUrlWithSession",
-        "getAllUrlsWithSession",
-        "closeAllSessions",
-        "navigate",
-        "act",
-        "extract",
-        "observe",
-        "screenshot",
-        "getUrl"
-      ],
-      "transport": "stdio"
-    },
     "context7": {
       "args": [],
       "description": "Context7 MCP pulls up-to-date, version-specific documentation and code examples straight from the source — and places them directly into your prompt",
       "env_vars": [],
       "image": "ghcr.io/stacklok/dockyard/npx/context7:1.0.14",
       "metadata": {
-        "last_updated": "2025-08-13T00:22:55Z",
-        "pulls": 235,
-        "stars": 25333
+        "last_updated": "2025-08-13T08:42:55Z",
+        "pulls": 313,
+        "stars": 25386
       },
       "permissions": {
         "network": {
@@ -707,9 +891,9 @@
       ],
       "image": "quay.io/crowdstrike/falcon-mcp:latest",
       "metadata": {
-        "last_updated": "2025-08-13T00:22:52Z",
-        "pulls": 3648,
-        "stars": 35
+        "last_updated": "2025-08-13T08:42:49Z",
+        "pulls": 3771,
+        "stars": 36
       },
       "permissions": {
         "network": {
@@ -823,9 +1007,9 @@
       ],
       "image": "docker.io/mcp/elasticsearch:latest",
       "metadata": {
-        "last_updated": "2025-08-13T00:22:51Z",
-        "pulls": 10874,
-        "stars": 406
+        "last_updated": "2025-08-13T08:42:48Z",
+        "pulls": 10995,
+        "stars": 407
       },
       "permissions": {
         "network": {
@@ -870,9 +1054,9 @@
       "env_vars": [],
       "image": "docker.io/mcp/everything:latest",
       "metadata": {
-        "last_updated": "2025-08-13T00:22:50Z",
-        "pulls": 16876,
-        "stars": 63970
+        "last_updated": "2025-08-13T08:42:46Z",
+        "pulls": 17019,
+        "stars": 64037
       },
       "permissions": {
         "network": {
@@ -917,8 +1101,8 @@
       "env_vars": [],
       "image": "ghcr.io/stackloklabs/gofetch/server:0.0.4",
       "metadata": {
-        "last_updated": "2025-08-13T00:22:53Z",
-        "pulls": 12318,
+        "last_updated": "2025-08-13T08:42:51Z",
+        "pulls": 12390,
         "stars": 17
       },
       "permissions": {
@@ -969,9 +1153,9 @@
       "env_vars": [],
       "image": "docker.io/mcp/filesystem:latest",
       "metadata": {
-        "last_updated": "2025-08-13T00:22:47Z",
-        "pulls": 20476,
-        "stars": 63970
+        "last_updated": "2025-08-13T08:42:40Z",
+        "pulls": 20619,
+        "stars": 64037
       },
       "permissions": {
         "network": {
@@ -1062,9 +1246,9 @@
       ],
       "image": "docker.io/mcp/firecrawl:latest",
       "metadata": {
-        "last_updated": "2025-08-13T00:22:47Z",
-        "pulls": 12535,
-        "stars": 4128
+        "last_updated": "2025-08-13T08:42:42Z",
+        "pulls": 12644,
+        "stars": 4135
       },
       "permissions": {
         "network": {
@@ -1116,9 +1300,9 @@
       "env_vars": [],
       "image": "us-central1-docker.pkg.dev/database-toolbox/toolbox/toolbox:0.11.0",
       "metadata": {
-        "last_updated": "2025-08-13T00:22:46Z",
-        "pulls": 2322,
-        "stars": 9171
+        "last_updated": "2025-08-13T08:42:37Z",
+        "pulls": 2408,
+        "stars": 9191
       },
       "permissions": {
         "network": {
@@ -1160,9 +1344,9 @@
       "env_vars": [],
       "image": "docker.io/mcp/git:latest",
       "metadata": {
-        "last_updated": "2025-08-13T00:22:47Z",
-        "pulls": 10330,
-        "stars": 63970
+        "last_updated": "2025-08-13T08:42:42Z",
+        "pulls": 10404,
+        "stars": 64037
       },
       "permissions": {
         "network": {
@@ -1223,9 +1407,9 @@
       ],
       "image": "ghcr.io/github/github-mcp-server:v0.10.0",
       "metadata": {
-        "last_updated": "2025-08-13T00:22:48Z",
+        "last_updated": "2025-08-13T08:42:43Z",
         "pulls": 5000,
-        "stars": 20719
+        "stars": 20766
       },
       "permissions": {
         "network": {
@@ -1365,9 +1549,9 @@
       ],
       "image": "docker.io/mcp/grafana:latest",
       "metadata": {
-        "last_updated": "2025-08-13T00:22:53Z",
-        "pulls": 8050,
-        "stars": 1379
+        "last_updated": "2025-08-13T08:42:53Z",
+        "pulls": 8120,
+        "stars": 1385
       },
       "permissions": {
         "network": {
@@ -1537,9 +1721,9 @@
       ],
       "image": "ghcr.io/stacklok/dockyard/npx/graphlit-mcp-server:1.0.20250808001",
       "metadata": {
-        "last_updated": "2025-08-11T15:29:09Z",
-        "pulls": 0,
-        "stars": 346
+        "last_updated": "2025-08-13T08:42:34Z",
+        "pulls": 109,
+        "stars": 347
       },
       "permissions": {
         "network": {
@@ -1640,8 +1824,8 @@
       ],
       "image": "docker.io/voska/hass-mcp:0.1.1",
       "metadata": {
-        "last_updated": "2025-08-13T00:22:51Z",
-        "pulls": 16936,
+        "last_updated": "2025-08-13T08:42:47Z",
+        "pulls": 17082,
         "stars": 151
       },
       "permissions": {
@@ -1696,17 +1880,17 @@
           "secret": true
         },
         {
+          "default": "15000",
           "description": "Timeout in milliseconds for command execution",
           "name": "MCP_SERVER_REQUEST_TIMEOUT",
           "required": false,
-          "default": "15000",
           "secret": false
         }
       ],
       "image": "ghcr.io/stacklok/dockyard/npx/heroku-mcp-server:1.0.7",
       "metadata": {
-        "last_updated": "2025-08-11T15:29:10Z",
-        "pulls": 0,
+        "last_updated": "2025-08-13T08:42:36Z",
+        "pulls": 104,
         "stars": 55
       },
       "permissions": {
@@ -1778,6 +1962,78 @@
       ],
       "transport": "stdio"
     },
+    "ida-pro-mcp": {
+      "args": [],
+      "description": "MCP server for IDA Pro reverse engineering and analysis",
+      "env_vars": [],
+      "image": "ghcr.io/stacklok/dockyard/uvx/ida-pro-mcp:1.4.0",
+      "metadata": {
+        "last_updated": "2025-08-13T08:42:30Z",
+        "pulls": 99,
+        "stars": 2998
+      },
+      "permissions": {
+        "network": {
+          "outbound": {
+            "allow_host": [],
+            "allow_port": [],
+            "insecure_allow_all": true
+          }
+        },
+        "read": [],
+        "write": []
+      },
+      "repository_url": "https://github.com/mrexodia/ida-pro-mcp",
+      "status": "Active",
+      "tags": [
+        "reverse-engineering",
+        "ida-pro",
+        "analysis",
+        "security",
+        "disassembly",
+        "decompilation"
+      ],
+      "tier": "Community",
+      "tools": [
+        "check_connection",
+        "get_metadata",
+        "get_function_by_name",
+        "get_function_by_address",
+        "get_current_address",
+        "get_current_function",
+        "convert_number",
+        "list_functions",
+        "list_globals_filter",
+        "list_globals",
+        "list_strings_filter",
+        "list_strings",
+        "list_local_types",
+        "decompile_function",
+        "disassemble_function",
+        "get_xrefs_to",
+        "get_xrefs_to_field",
+        "get_entry_points",
+        "set_comment",
+        "rename_local_variable",
+        "rename_global_variable",
+        "set_global_variable_type",
+        "rename_function",
+        "set_function_prototype",
+        "declare_c_type",
+        "set_local_variable_type",
+        "dbg_get_registers",
+        "dbg_get_call_stack",
+        "dbg_list_breakpoints",
+        "dbg_start_process",
+        "dbg_exit_process",
+        "dbg_continue_process",
+        "dbg_run_to",
+        "dbg_set_breakpoint",
+        "dbg_delete_breakpoint",
+        "dbg_enable_breakpoint"
+      ],
+      "transport": "stdio"
+    },
     "k8s": {
       "args": [],
       "description": "Allows LLM-powered applications to interact with Kubernetes clusters.",
@@ -1790,8 +2046,8 @@
       ],
       "image": "ghcr.io/stackloklabs/mkp/server:0.0.10",
       "metadata": {
-        "last_updated": "2025-08-13T00:22:52Z",
-        "pulls": 13824,
+        "last_updated": "2025-08-13T08:42:49Z",
+        "pulls": 13952,
         "stars": 44
       },
       "permissions": {
@@ -1847,8 +2103,8 @@
       ],
       "image": "ghcr.io/nirmata/kyverno-mcp:v0.2.2",
       "metadata": {
-        "last_updated": "2025-08-13T00:22:47Z",
-        "pulls": 4814,
+        "last_updated": "2025-08-13T08:42:41Z",
+        "pulls": 4946,
         "stars": 6
       },
       "permissions": {
@@ -1895,28 +2151,33 @@
       ],
       "transport": "stdio"
     },
-    "memory": {
+    "magic-mcp": {
       "args": [],
-      "description": "Provides persistent memory to an LLMs application for storing information about the user across chats. Implemented using a local knowledge graph.",
+      "description": "AI-powered UI component generator MCP server by 21st.dev",
       "env_vars": [
         {
-          "description": "Path to the memory storage JSON file (default: memory.json in the server directory)",
-          "name": "MEMORY_FILE_PATH",
-          "required": false
+          "description": "21st.dev Magic API key for component generation",
+          "name": "API_KEY",
+          "required": true,
+          "secret": true
         }
       ],
-      "image": "docker.io/mcp/memory:latest",
+      "image": "ghcr.io/stacklok/dockyard/npx/magic-mcp:0.1.0",
       "metadata": {
-        "last_updated": "2025-08-13T00:22:46Z",
-        "pulls": 15739,
-        "stars": 63970
+        "last_updated": "2025-08-13T08:42:30Z",
+        "pulls": 128,
+        "stars": 3315
       },
       "permissions": {
         "network": {
           "outbound": {
-            "allow_host": [],
+            "allow_host": [
+              "21st.dev",
+              "api.21st.dev"
+            ],
             "allow_port": [
-              443
+              443,
+              80
             ],
             "insecure_allow_all": false
           }
@@ -1924,28 +2185,22 @@
         "read": [],
         "write": []
       },
-      "repository_url": "https://github.com/modelcontextprotocol/servers",
+      "repository_url": "https://github.com/21st-dev/magic-mcp",
       "status": "Active",
       "tags": [
-        "entities",
-        "graph",
-        "knowledge",
-        "memory",
-        "observations",
-        "persistent",
-        "relations"
+        "ui",
+        "frontend",
+        "components",
+        "ai",
+        "generator",
+        "react"
       ],
       "tier": "Community",
       "tools": [
-        "create_entities",
-        "create_relations",
-        "add_observations",
-        "delete_entities",
-        "delete_observations",
-        "delete_relations",
-        "read_graph",
-        "search_nodes",
-        "open_nodes"
+        "create_ui",
+        "fetch_ui",
+        "logo_search",
+        "refine_ui"
       ],
       "transport": "stdio"
     },
@@ -1972,24 +2227,24 @@
           "secret": true
         },
         {
+          "default": "8443",
           "description": "The port number of your ClickHouse server",
           "name": "CLICKHOUSE_PORT",
           "required": false,
-          "default": "8443",
           "secret": false
         },
         {
+          "default": "true",
           "description": "Enable/disable HTTPS connection",
           "name": "CLICKHOUSE_SECURE",
           "required": false,
-          "default": "true",
           "secret": false
         },
         {
+          "default": "true",
           "description": "Enable/disable SSL certificate verification",
           "name": "CLICKHOUSE_VERIFY",
           "required": false,
-          "default": "true",
           "secret": false
         },
         {
@@ -1999,25 +2254,25 @@
           "secret": false
         },
         {
+          "default": "false",
           "description": "Enable/disable chDB functionality",
           "name": "CHDB_ENABLED",
           "required": false,
-          "default": "false",
           "secret": false
         },
         {
+          "default": ":memory:",
           "description": "The path to the chDB data directory",
           "name": "CHDB_DATA_PATH",
           "required": false,
-          "default": ":memory:",
           "secret": false
         }
       ],
       "image": "ghcr.io/stacklok/dockyard/uvx/mcp-clickhouse:0.1.11",
       "metadata": {
-        "last_updated": "2025-08-11T15:29:08Z",
-        "pulls": 0,
-        "stars": 485
+        "last_updated": "2025-08-13T08:42:33Z",
+        "pulls": 81,
+        "stars": 487
       },
       "permissions": {
         "network": {
@@ -2055,6 +2310,270 @@
       ],
       "transport": "stdio"
     },
+    "mcp-jetbrains": {
+      "args": [],
+      "description": "A MCP proxy to redirect requests to JetBrains IDEs",
+      "env_vars": [
+        {
+          "description": "Port of IDE's built-in webserver (if running multiple IDEs)",
+          "name": "IDE_PORT",
+          "required": false
+        },
+        {
+          "default": "127.0.0.1",
+          "description": "Host/address of IDE's built-in webserver",
+          "name": "HOST",
+          "required": false
+        },
+        {
+          "default": "false",
+          "description": "Enable logging for debugging",
+          "name": "LOG_ENABLED",
+          "required": false
+        }
+      ],
+      "image": "ghcr.io/stacklok/dockyard/npx/mcp-jetbrains:1.8.0",
+      "metadata": {
+        "last_updated": "2025-08-13T08:42:31Z",
+        "pulls": 77,
+        "stars": 905
+      },
+      "permissions": {
+        "network": {
+          "outbound": {
+            "allow_host": [],
+            "allow_port": [],
+            "insecure_allow_all": true
+          }
+        },
+        "read": [],
+        "write": []
+      },
+      "repository_url": "https://github.com/JetBrains/mcp-jetbrains",
+      "status": "Active",
+      "tags": [
+        "ide",
+        "jetbrains",
+        "proxy",
+        "development",
+        "intellij"
+      ],
+      "tier": "Official",
+      "tools": [
+        "dynamic_tools_from_ide"
+      ],
+      "transport": "stdio"
+    },
+    "mcp-neo4j-aura-manager": {
+      "args": [],
+      "description": "MCP server for managing Neo4j Aura cloud instances and services",
+      "env_vars": [
+        {
+          "description": "Neo4j Aura API client ID",
+          "name": "AURA_CLIENT_ID",
+          "required": true,
+          "secret": true
+        },
+        {
+          "description": "Neo4j Aura API client secret",
+          "name": "AURA_CLIENT_SECRET",
+          "required": true,
+          "secret": true
+        },
+        {
+          "description": "Neo4j Aura tenant ID",
+          "name": "AURA_TENANT_ID",
+          "required": false,
+          "secret": true
+        }
+      ],
+      "image": "ghcr.io/stacklok/dockyard/uvx/mcp-neo4j-aura-manager:0.3.0",
+      "metadata": {
+        "last_updated": "2025-08-13T08:42:31Z",
+        "pulls": 141,
+        "stars": 610
+      },
+      "permissions": {
+        "network": {
+          "outbound": {
+            "allow_host": [
+              "api.neo4j.io",
+              "console.neo4j.io",
+              "*.neo4j.io"
+            ],
+            "allow_port": [
+              443,
+              80
+            ],
+            "insecure_allow_all": false
+          }
+        },
+        "read": [],
+        "write": []
+      },
+      "repository_url": "https://github.com/neo4j-contrib/mcp-neo4j",
+      "status": "Active",
+      "tags": [
+        "database",
+        "neo4j",
+        "aura",
+        "cloud",
+        "management"
+      ],
+      "tier": "Community",
+      "tools": [
+        "list_instances",
+        "create_instance",
+        "delete_instance",
+        "get_instance",
+        "update_instance",
+        "scale_instance",
+        "enable_features"
+      ],
+      "transport": "stdio"
+    },
+    "mcp-neo4j-cypher": {
+      "args": [],
+      "description": "MCP server for executing Cypher queries against Neo4j databases with natural language interface",
+      "env_vars": [
+        {
+          "default": "bolt://localhost:7687",
+          "description": "Neo4j database connection URI",
+          "name": "NEO4J_URI",
+          "required": true
+        },
+        {
+          "default": "neo4j",
+          "description": "Neo4j database username",
+          "name": "NEO4J_USERNAME",
+          "required": false
+        },
+        {
+          "description": "Neo4j database password",
+          "name": "NEO4J_PASSWORD",
+          "required": false,
+          "secret": true
+        },
+        {
+          "default": "neo4j",
+          "description": "Neo4j database name",
+          "name": "NEO4J_DATABASE",
+          "required": false
+        }
+      ],
+      "image": "ghcr.io/stacklok/dockyard/uvx/mcp-neo4j-cypher:0.3.0",
+      "metadata": {
+        "last_updated": "2025-08-13T08:42:32Z",
+        "pulls": 91,
+        "stars": 610
+      },
+      "permissions": {
+        "network": {
+          "outbound": {
+            "allow_host": [
+              "localhost",
+              "*.neo4j.io",
+              "*.databases.neo4j.io"
+            ],
+            "allow_port": [
+              7687,
+              7473,
+              7474,
+              443
+            ],
+            "insecure_allow_all": false
+          }
+        },
+        "read": [],
+        "write": []
+      },
+      "repository_url": "https://github.com/neo4j-contrib/mcp-neo4j",
+      "status": "Active",
+      "tags": [
+        "database",
+        "neo4j",
+        "cypher",
+        "query",
+        "graph-database"
+      ],
+      "tier": "Community",
+      "tools": [
+        "execute_cypher",
+        "get_schema",
+        "explain_query",
+        "validate_cypher",
+        "get_database_info"
+      ],
+      "transport": "stdio"
+    },
+    "mcp-neo4j-memory": {
+      "args": [],
+      "description": "MCP server for Neo4j memory management and knowledge graph storage operations",
+      "env_vars": [
+        {
+          "default": "bolt://localhost:7687",
+          "description": "Neo4j database connection URI",
+          "name": "NEO4J_URI",
+          "required": true
+        },
+        {
+          "default": "neo4j",
+          "description": "Neo4j database username",
+          "name": "NEO4J_USERNAME",
+          "required": false
+        },
+        {
+          "description": "Neo4j database password",
+          "name": "NEO4J_PASSWORD",
+          "required": false,
+          "secret": true
+        }
+      ],
+      "image": "ghcr.io/stacklok/dockyard/uvx/mcp-neo4j-memory:0.2.0",
+      "metadata": {
+        "last_updated": "2025-08-13T08:42:32Z",
+        "pulls": 105,
+        "stars": 610
+      },
+      "permissions": {
+        "network": {
+          "outbound": {
+            "allow_host": [
+              "localhost",
+              "*.neo4j.io",
+              "*.databases.neo4j.io"
+            ],
+            "allow_port": [
+              7687,
+              7473,
+              7474,
+              443
+            ],
+            "insecure_allow_all": false
+          }
+        },
+        "read": [],
+        "write": []
+      },
+      "repository_url": "https://github.com/neo4j-contrib/mcp-neo4j",
+      "status": "Active",
+      "tags": [
+        "database",
+        "neo4j",
+        "memory",
+        "knowledge-graph",
+        "graph-database"
+      ],
+      "tier": "Community",
+      "tools": [
+        "store_memory",
+        "retrieve_memory",
+        "search_memories",
+        "delete_memory",
+        "list_memories"
+      ],
+      "transport": "stdio"
+    },
     "mcp-server-box": {
       "args": [],
       "description": "MCP server that integrates with the Box API to perform file operations, AI-based querying, metadata management, and document generation",
@@ -2074,8 +2593,8 @@
       ],
       "image": "ghcr.io/stacklok/dockyard/uvx/mcp-server-box:0.1.2",
       "metadata": {
-        "last_updated": "2025-08-11T15:29:08Z",
-        "pulls": 0,
+        "last_updated": "2025-08-13T08:42:34Z",
+        "pulls": 52,
         "stars": 43
       },
       "permissions": {
@@ -2145,6 +2664,132 @@
       ],
       "transport": "stdio"
     },
+    "mcp-server-neon": {
+      "args": [],
+      "description": "MCP server for interacting with Neon Management API and databases",
+      "env_vars": [
+        {
+          "description": "API key for Neon database service",
+          "name": "NEON_API_KEY",
+          "required": true,
+          "secret": true
+        }
+      ],
+      "image": "ghcr.io/stacklok/dockyard/npx/mcp-server-neon:0.6.3",
+      "metadata": {
+        "last_updated": "2025-08-13T08:42:33Z",
+        "pulls": 55,
+        "stars": 405
+      },
+      "permissions": {
+        "network": {
+          "outbound": {
+            "allow_host": [
+              "console.neon.tech",
+              "api.neon.tech",
+              "neon.tech"
+            ],
+            "allow_port": [
+              443,
+              5432
+            ],
+            "insecure_allow_all": false
+          }
+        },
+        "read": [],
+        "write": []
+      },
+      "repository_url": "https://github.com/neondatabase-labs/mcp-server-neon",
+      "status": "Active",
+      "tags": [
+        "database",
+        "postgresql",
+        "api",
+        "management",
+        "sql",
+        "migration",
+        "branching"
+      ],
+      "tier": "Official",
+      "tools": [
+        "list_projects",
+        "describe_project",
+        "create_project",
+        "delete_project",
+        "create_branch",
+        "delete_branch",
+        "describe_branch",
+        "list_branch_computes",
+        "list_organizations",
+        "get_connection_string",
+        "run_sql",
+        "run_sql_transaction",
+        "get_database_tables",
+        "describe_table_schema",
+        "list_slow_queries",
+        "prepare_database_migration",
+        "complete_database_migration",
+        "explain_sql_statement",
+        "prepare_query_tuning",
+        "complete_query_tuning",
+        "provision_neon_auth"
+      ],
+      "transport": "stdio"
+    },
+    "memory": {
+      "args": [],
+      "description": "Provides persistent memory to an LLMs application for storing information about the user across chats. Implemented using a local knowledge graph.",
+      "env_vars": [
+        {
+          "description": "Path to the memory storage JSON file (default: memory.json in the server directory)",
+          "name": "MEMORY_FILE_PATH",
+          "required": false
+        }
+      ],
+      "image": "docker.io/mcp/memory:latest",
+      "metadata": {
+        "last_updated": "2025-08-13T08:42:40Z",
+        "pulls": 15854,
+        "stars": 64037
+      },
+      "permissions": {
+        "network": {
+          "outbound": {
+            "allow_host": [],
+            "allow_port": [
+              443
+            ],
+            "insecure_allow_all": false
+          }
+        },
+        "read": [],
+        "write": []
+      },
+      "repository_url": "https://github.com/modelcontextprotocol/servers",
+      "status": "Active",
+      "tags": [
+        "entities",
+        "graph",
+        "knowledge",
+        "memory",
+        "observations",
+        "persistent",
+        "relations"
+      ],
+      "tier": "Community",
+      "tools": [
+        "create_entities",
+        "create_relations",
+        "add_observations",
+        "delete_entities",
+        "delete_observations",
+        "delete_relations",
+        "read_graph",
+        "search_nodes",
+        "open_nodes"
+      ],
+      "transport": "stdio"
+    },
     "mongodb": {
       "args": [],
       "description": "Provides support for interacting with MongoDB Databases and MongoDB Atlas.",
@@ -2205,9 +2850,9 @@
       ],
       "image": "docker.io/mongodb/mongodb-mcp-server:0.2.0",
       "metadata": {
-        "last_updated": "2025-08-13T00:22:45Z",
-        "pulls": 4968,
-        "stars": 555
+        "last_updated": "2025-08-13T08:42:37Z",
+        "pulls": 5060,
+        "stars": 556
       },
       "permissions": {
         "network": {
@@ -2296,8 +2941,8 @@
       ],
       "image": "docker.io/aantti/mcp-netbird:latest",
       "metadata": {
-        "last_updated": "2025-08-13T00:22:53Z",
-        "pulls": 10810,
+        "last_updated": "2025-08-13T08:42:50Z",
+        "pulls": 10904,
         "stars": 38
       },
       "permissions": {
@@ -2353,9 +2998,9 @@
       ],
       "image": "docker.io/mcp/notion:latest",
       "metadata": {
-        "last_updated": "2025-08-13T00:22:52Z",
-        "pulls": 6194,
-        "stars": 2931
+        "last_updated": "2025-08-13T08:42:50Z",
+        "pulls": 6307,
+        "stars": 2933
       },
       "permissions": {
         "network": {
@@ -2426,8 +3071,8 @@
       ],
       "image": "ghcr.io/stackloklabs/ocireg-mcp/server:0.0.4",
       "metadata": {
-        "last_updated": "2025-08-13T00:22:54Z",
-        "pulls": 7930,
+        "last_updated": "2025-08-13T08:42:54Z",
+        "pulls": 8029,
         "stars": 9
       },
       "permissions": {
@@ -2478,8 +3123,8 @@
       "env_vars": [],
       "image": "ghcr.io/stackloklabs/osv-mcp/server:0.0.7",
       "metadata": {
-        "last_updated": "2025-08-13T00:22:50Z",
-        "pulls": 10224,
+        "last_updated": "2025-08-13T08:42:45Z",
+        "pulls": 10318,
         "stars": 17
       },
       "permissions": {
@@ -2539,9 +3184,9 @@
       ],
       "image": "docker.io/mcp/perplexity-ask:latest",
       "metadata": {
-        "last_updated": "2025-08-13T00:22:49Z",
-        "pulls": 15064,
-        "stars": 1491
+        "last_updated": "2025-08-13T08:42:45Z",
+        "pulls": 15188,
+        "stars": 1493
       },
       "permissions": {
         "network": {
@@ -2582,9 +3227,9 @@
       "env_vars": [],
       "image": "mcr.microsoft.com/playwright/mcp:v0.0.32",
       "metadata": {
-        "last_updated": "2025-08-13T00:22:54Z",
-        "pulls": 23473,
-        "stars": 16807
+        "last_updated": "2025-08-13T08:42:53Z",
+        "pulls": 23622,
+        "stars": 16840
       },
       "permissions": {
         "network": {
@@ -2644,8 +3289,8 @@
       "env_vars": [],
       "image": "ghcr.io/stackloklabs/plotting-mcp:v0.0.2",
       "metadata": {
-        "last_updated": "2025-08-13T00:22:50Z",
-        "pulls": 1183,
+        "last_updated": "2025-08-13T08:42:46Z",
+        "pulls": 1314,
         "stars": 0
       },
       "permissions": {
@@ -2708,9 +3353,9 @@
       ],
       "image": "crystaldba/postgres-mcp:0.3.0",
       "metadata": {
-        "last_updated": "2025-08-13T00:22:46Z",
-        "pulls": 10319,
-        "stars": 901
+        "last_updated": "2025-08-13T08:42:39Z",
+        "pulls": 10403,
+        "stars": 902
       },
       "permissions": {
         "network": {
@@ -2825,9 +3470,9 @@
       ],
       "image": "docker.io/mcp/redis:latest",
       "metadata": {
-        "last_updated": "2025-08-13T00:22:49Z",
-        "pulls": 10281,
-        "stars": 199
+        "last_updated": "2025-08-13T08:42:44Z",
+        "pulls": 10366,
+        "stars": 200
       },
       "permissions": {
         "network": {
@@ -2918,8 +3563,8 @@
       ],
       "image": "ghcr.io/semgrep/mcp:0.4.1",
       "metadata": {
-        "last_updated": "2025-08-13T00:22:51Z",
-        "pulls": 12075,
+        "last_updated": "2025-08-13T08:42:47Z",
+        "pulls": 12180,
         "stars": 413
       },
       "permissions": {
@@ -2988,8 +3633,8 @@
       ],
       "image": "ghcr.io/stacklok/dockyard/npx/sentry-mcp-server:latest",
       "metadata": {
-        "last_updated": "2025-08-11T15:29:10Z",
-        "pulls": 0,
+        "last_updated": "2025-08-13T08:42:35Z",
+        "pulls": 127,
         "stars": 292
       },
       "permissions": {
@@ -3054,9 +3699,9 @@
       "env_vars": [],
       "image": "docker.io/mcp/sequentialthinking:latest",
       "metadata": {
-        "last_updated": "2025-08-13T00:22:49Z",
-        "pulls": 14726,
-        "stars": 63970
+        "last_updated": "2025-08-13T08:42:45Z",
+        "pulls": 14819,
+        "stars": 64037
       },
       "permissions": {
         "network": {
@@ -3097,8 +3742,8 @@
       "env_vars": [],
       "image": "ghcr.io/stackloklabs/sqlite-mcp/server:0.0.1",
       "metadata": {
-        "last_updated": "2025-08-13T00:22:46Z",
-        "pulls": 4104,
+        "last_updated": "2025-08-13T08:42:38Z",
+        "pulls": 4212,
         "stars": 9
       },
       "permissions": {
@@ -3143,9 +3788,9 @@
       ],
       "image": "ghcr.io/stacklok/dockyard/npx/supabase-mcp-server:latest",
       "metadata": {
-        "last_updated": "2025-08-11T15:29:11Z",
-        "pulls": 0,
-        "stars": 1940
+        "last_updated": "2025-08-13T08:42:36Z",
+        "pulls": 102,
+        "stars": 1942
       },
       "permissions": {
         "network": {
@@ -3215,15 +3860,69 @@
       ],
       "transport": "stdio"
     },
+    "tavily-mcp": {
+      "args": [],
+      "description": "MCP server for advanced web search using Tavily's AI search engine",
+      "env_vars": [
+        {
+          "description": "API key for Tavily search service",
+          "name": "TAVILY_API_KEY",
+          "required": true,
+          "secret": true
+        }
+      ],
+      "image": "ghcr.io/stacklok/dockyard/npx/tavily-mcp:0.2.9",
+      "metadata": {
+        "last_updated": "2025-08-13T08:42:33Z",
+        "pulls": 80,
+        "stars": 664
+      },
+      "permissions": {
+        "network": {
+          "outbound": {
+            "allow_host": [
+              "api.tavily.com",
+              "mcp.tavily.com"
+            ],
+            "allow_port": [
+              443,
+              80
+            ],
+            "insecure_allow_all": false
+          }
+        },
+        "read": [],
+        "write": []
+      },
+      "repository_url": "https://github.com/tavily-ai/tavily-mcp",
+      "status": "Active",
+      "tags": [
+        "search",
+        "web-search",
+        "ai-search",
+        "crawl",
+        "extract",
+        "api",
+        "real-time"
+      ],
+      "tier": "Official",
+      "tools": [
+        "tavily-search",
+        "tavily-extract",
+        "tavily-crawl",
+        "tavily-map"
+      ],
+      "transport": "stdio"
+    },
     "terraform": {
       "args": [],
       "description": "Provides integration with the Terraform ecosystem and interaction capabilities for Infrastructure as Code (IaC) development.",
       "env_vars": [],
       "image": "docker.io/hashicorp/terraform-mcp-server:0.2.2",
       "metadata": {
-        "last_updated": "2025-08-13T00:22:52Z",
-        "pulls": 9472,
-        "stars": 807
+        "last_updated": "2025-08-13T08:42:49Z",
+        "pulls": 9600,
+        "stars": 809
       },
       "permissions": {
         "network": {
@@ -3272,9 +3971,9 @@
       "env_vars": [],
       "image": "docker.io/mcp/time:latest",
       "metadata": {
-        "last_updated": "2025-08-13T00:22:47Z",
-        "pulls": 10905,
-        "stars": 63970
+        "last_updated": "2025-08-13T08:42:41Z",
+        "pulls": 10986,
+        "stars": 64037
       },
       "permissions": {
         "network": {


### PR DESCRIPTION
This PR adds 10 new MCP servers from the uncommitted registry to the main registry in alphabetical order:

## New MCP Servers Added:

- **arxiv-mcp-server**: AI assistant for searching and accessing arXiv research papers through MCP protocol
- **brightdata-mcp**: Web scraping and data extraction interface to Bright Data toolset with browser automation
- **ida-pro-mcp**: IDA Pro reverse engineering and analysis server for security research
- **magic-mcp**: AI-powered UI component generator by 21st.dev for React components
- **mcp-jetbrains**: MCP proxy for redirecting requests to JetBrains IDEs (Official tier)
- **mcp-neo4j-aura-manager**: Neo4j Aura cloud instance management and services
- **mcp-neo4j-cypher**: Cypher query execution against Neo4j databases with natural language interface
- **mcp-neo4j-memory**: Neo4j memory management and knowledge graph storage operations
- **mcp-server-neon**: Neon Management API and database interaction server (Official tier)
- **tavily-mcp**: Advanced web search using Tavily's AI search engine (Official tier)

All entries have been added in proper alphabetical order with complete configuration including permissions, environment variables, tools, and metadata. The last_updated timestamp has been updated to reflect the changes.