### PR TITLE
feat: Add Google Cloud Run MCP server to registry

### DIFF
--- a/pkg/registry/data/registry.json
+++ b/pkg/registry/data/registry.json
@@ -807,6 +807,87 @@
       ],
       "transport": "stdio"
     },
+    "cloud-run": {
+      "args": [],
+      "description": "Deploy apps to Google Cloud Run directly from AI assistants. Enables deployment of containerized applications, local files, and folders to Cloud Run with integrated logging and service management.",
+      "env_vars": [
+        {
+          "description": "Path to Google Cloud credentials JSON file",
+          "name": "GOOGLE_APPLICATION_CREDENTIALS",
+          "required": false,
+          "secret": true
+        },
+        {
+          "description": "Google Cloud project ID for deployments",
+          "name": "GOOGLE_CLOUD_PROJECT",
+          "required": false
+        },
+        {
+          "description": "Default Google Cloud region for deployments",
+          "name": "GOOGLE_CLOUD_REGION",
+          "required": false
+        },
+        {
+          "description": "Default Cloud Run service name",
+          "name": "DEFAULT_SERVICE_NAME",
+          "required": false
+        },
+        {
+          "description": "Skip IAM permission checks (true/false)",
+          "name": "SKIP_IAM_CHECK",
+          "required": false
+        }
+      ],
+      "image": "docker.io/mcp/cloud-run-mcp:latest",
+      "metadata": {
+        "last_updated": "2025-08-13T06:16:55Z",
+        "pulls": 273,
+        "stars": 316
+      },
+      "permissions": {
+        "network": {
+          "outbound": {
+            "allow_host": [
+              "run.googleapis.com",
+              "cloudbuild.googleapis.com",
+              "storage.googleapis.com",
+              "logging.googleapis.com",
+              "cloudresourcemanager.googleapis.com"
+            ],
+            "allow_port": [
+              443
+            ],
+            "insecure_allow_all": false
+          }
+        },
+        "read": [],
+        "write": []
+      },
+      "repository_url": "https://github.com/GoogleCloudPlatform/cloud-run-mcp",
+      "status": "Active",
+      "tags": [
+        "google-cloud",
+        "cloud-run",
+        "deployment",
+        "gcp",
+        "serverless",
+        "containers",
+        "devops"
+      ],
+      "tier": "Official",
+      "tools": [
+        "deploy_file_contents",
+        "deploy_local_files",
+        "deploy_local_folder",
+        "deploy_container_image",
+        "list_services",
+        "get_service",
+        "get_service_log",
+        "list_projects",
+        "create_project"
+      ],
+      "transport": "stdio"
+    },
     "context7": {
       "args": [],
       "description": "Context7 MCP pulls up-to-date, version-specific documentation and code examples straight from the source — and places them directly into your prompt",


### PR DESCRIPTION
This PR adds the Google Cloud Run MCP server to the ToolHive registry.

## Summary

Adds the official Google Cloud Run MCP server that enables AI assistants to deploy applications directly to Google Cloud Run.

## Key Features

- Deploy file contents, local files, and folders to Cloud Run
- Deploy container images directly  
- List and manage Cloud Run services
- View service logs and diagnostics
- Create and list GCP projects

## Details

- **Docker Image**: `docker.io/mcp/cloud-run-mcp:latest`
- **Repository**: https://github.com/GoogleCloudPlatform/cloud-run-mcp
- **Tier**: Official (developed by Google Cloud Platform team)
- **Transport**: stdio
- **Stars**: 316
- **Docker Hub Pulls**: 273

## Security Considerations

The server has been configured with minimal required permissions, only allowing connections to essential Google Cloud APIs:
- `run.googleapis.com` - Cloud Run API
- `cloudbuild.googleapis.com` - Cloud Build API for deployments
- `storage.googleapis.com` - Storage API for artifacts
- `logging.googleapis.com` - Logging API for service logs
- `cloudresourcemanager.googleapis.com` - Resource Manager API for project management

## Testing

- ✅ JSON validation passes
- ✅ Registry tests pass (`go test ./pkg/registry/...`)

Closes #[issue-number]