### PR TITLE
Use Infof for formatted logging message

### DIFF
--- a/pkg/container/verifier/verifier.go
+++ b/pkg/container/verifier/verifier.go
@@ -119,7 +119,7 @@ func getVerifiedResults(
 			verify.WithoutIdentitiesUnsafe(),
 		))
 		if err != nil {
-			logger.Info("bundle verification failed: %v", err)
+			logger.Infof("bundle verification failed: %v", err)
 			continue
 		}
 		// We've successfully verified and extracted the artifact provenance information


### PR DESCRIPTION
Sorry for creating this PR directly without an issue first - it's such a small formatting fix that I felt an issue would be overkill.

This changes `logger.Info` to `logger.Infof` for the bundle verification error in the verifier, since the message uses `%v` formatting and to remain consistent with the rest of the repository.