### PR TITLE
Expose resource-url parameter through MCPServer CRD

### DIFF
--- a/cmd/thv-operator/api/v1alpha1/mcpserver_types.go
+++ b/cmd/thv-operator/api/v1alpha1/mcpserver_types.go
@@ -74,6 +74,11 @@ type MCPServerSpec struct {
 	// ToolsFilter is the filter on tools applied to the MCP server
 	// +optional
 	ToolsFilter []string `json:"tools,omitempty"`
+
+	// ResourceURL is the explicit resource URL for OAuth discovery endpoint (RFC 9728)
+	// If not specified, defaults to the in-cluster Kubernetes service URL
+	// +optional
+	ResourceURL string `json:"resourceUrl,omitempty"`
 }
 
 // ResourceOverrides defines overrides for annotations and labels on created resources

--- a/cmd/thv-operator/controllers/mcpserver_controller.go
+++ b/cmd/thv-operator/controllers/mcpserver_controller.go
@@ -431,7 +431,10 @@ func (r *MCPServerReconciler) deploymentForMCPServer(m *mcpv1alpha1.MCPServer) *
 		args = append(args, oidcArgs...)
 
 		// Add OAuth discovery resource URL for RFC 9728 compliance
-		resourceURL := createServiceURL(m.Name, m.Namespace, m.Spec.Port)
+		resourceURL := m.Spec.ResourceURL
+		if resourceURL == "" {
+			resourceURL = createServiceURL(m.Name, m.Namespace, m.Spec.Port)
+		}
 		args = append(args, fmt.Sprintf("--resource-url=%s", resourceURL))
 	}
 


### PR DESCRIPTION
Add support for specifying custom resource URL for OAuth discovery through the MCPServer custom resource. This addresses the need to override the default in-cluster service URL for services exposed outside the cluster, as required by RFC-9728.

**Changes:**
- Add ResourceURL field to MCPServerSpec
- Update controller to use custom ResourceURL when provided
- Fallback to default in-cluster service URL when not specified

Fixes #1311

Generated with [Claude Code](https://claude.ai/code)