### PR TITLE
fix: Add option to list from remote cluster

### DIFF
--- a/cmd/thv/app/list.go
+++ b/cmd/thv/app/list.go
@@ -7,6 +7,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 
 	"github.com/stacklok/toolhive/pkg/core"
 	"github.com/stacklok/toolhive/pkg/logger"
@@ -26,12 +27,14 @@ var (
 	listFormat      string
 	listLabelFilter []string
 	listGroupFilter string
+	listRuntime     string
 )
 
 func init() {
 	listCmd.Flags().BoolVarP(&listAll, "all", "a", false, "Show all workloads (default shows just running)")
 	listCmd.Flags().StringVar(&listFormat, "format", FormatText, "Output format (json, text, or mcpservers)")
 	listCmd.Flags().StringArrayVarP(&listLabelFilter, "label", "l", []string{}, "Filter workloads by labels (format: key=value)")
+	listCmd.Flags().StringVar(&listRuntime, "runtime", "", "Container runtime to use (docker, kubernetes)")
 	// TODO: Re-enable when group functionality is complete
 	// listCmd.Flags().StringVar(&listGroupFilter, "group", "", "Filter workloads by group")
 
@@ -40,6 +43,11 @@ func init() {
 
 func listCmdFunc(cmd *cobra.Command, _ []string) error {
 	ctx := cmd.Context()
+
+	// Set runtime flag in viper if specified for this command
+	if listRuntime != "" {
+		viper.Set("runtime", listRuntime)
+	}
 
 	// Instantiate the status manager.
 	manager, err := workloads.NewManager(ctx)

--- a/docs/cli/thv_list.md
+++ b/docs/cli/thv_list.md
@@ -28,6 +28,7 @@ thv list [flags]
       --format string       Output format (json, text, or mcpservers) (default "text")
   -h, --help                help for list
   -l, --label stringArray   Filter workloads by labels (format: key=value)
+      --runtime string      Container runtime to use (docker, kubernetes)
 ```
 
 ### Options inherited from parent commands

--- a/pkg/container/runtime/types.go
+++ b/pkg/container/runtime/types.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/spf13/viper"
 	"github.com/stacklok/toolhive/pkg/ignore"
 	"github.com/stacklok/toolhive/pkg/permissions"
 )
@@ -285,6 +286,11 @@ type Mount struct {
 // IsKubernetesRuntime returns true if the runtime is Kubernetes
 // isn't the best way to do this, but for now it's good enough
 func IsKubernetesRuntime() bool {
+	// Check explicit flag first
+	if runtimeFlag := viper.GetString("runtime"); runtimeFlag != "" {
+		return runtimeFlag == "kubernetes"
+	}
+	// Fall back to environment detection (original logic)
 	return os.Getenv("KUBERNETES_SERVICE_HOST") != ""
 }
 


### PR DESCRIPTION
Initial commit for #1429

- Adds runtime flag to `thv list` command to limit the extent of changes
- Keeps fallback for in-cluster deployment

Keeping in draft mode until there's some decision about the other commands.