### PR TITLE
Allow two-character tags in registry schema

### DIFF
--- a/docs/registry/schema.json
+++ b/docs/registry/schema.json
@@ -126,7 +126,7 @@
           "description": "Categorization tags for search and filtering",
           "items": {
             "type": "string",
-            "pattern": "^[a-z0-9][a-z0-9_-]+[a-z0-9]$"
+            "pattern": "^[a-z0-9][a-z0-9_-]*[a-z0-9]$"
           },
           "minItems": 1,
           "uniqueItems": true


### PR DESCRIPTION
Signed-off-by: Dan Barr <6922515+danbarr@users.noreply.github.com>