### PR TITLE
Fix network host subdomain entries

### DIFF
--- a/pkg/registry/data/registry.json
+++ b/pkg/registry/data/registry.json
@@ -2537,7 +2537,7 @@
             "allow_host": [
               "api.neo4j.io",
               "console.neo4j.io",
-              "*.neo4j.io"
+              ".neo4j.io"
             ],
             "allow_port": [
               443,
@@ -2617,8 +2617,8 @@
           "outbound": {
             "allow_host": [
               "localhost",
-              "*.neo4j.io",
-              "*.databases.neo4j.io"
+              ".neo4j.io",
+              ".databases.neo4j.io"
             ],
             "allow_port": [
               7687,
@@ -2692,8 +2692,8 @@
           "outbound": {
             "allow_host": [
               "localhost",
-              "*.neo4j.io",
-              "*.databases.neo4j.io"
+              ".neo4j.io",
+              ".databases.neo4j.io"
             ],
             "allow_port": [
               7687,


### PR DESCRIPTION
Glob wildcards aren't supported, Squid just uses a leading `.`

Signed-off-by: Dan Barr <6922515+danbarr@users.noreply.github.com>