### PR TITLE
Add JSON schema validation for registry.json

### DIFF
--- a/docs/registry/schema.md
+++ b/docs/registry/schema.md
@@ -21,7 +21,44 @@ This can also be used to validate a custom registry file to be used with the
 
 ## Usage
 
-### Local validation
+### Automated validation (Go tests)
+
+The registry is automatically validated against the schema during development
+and CI/CD through Go tests. This ensures that any changes to the registry data
+are immediately validated.
+
+The validation is implemented in
+[`pkg/registry/schema_validation.go`](../../pkg/registry/schema_validation.go)
+and tested in
+[`pkg/registry/schema_validation_test.go`](../../pkg/registry/schema_validation_test.go).
+
+**Key tests:**
+
+- `TestEmbeddedRegistrySchemaValidation` - Validates the embedded
+  `registry.json` against the schema
+- `TestRegistrySchemaValidation` - Comprehensive test suite with valid and
+  invalid registry examples
+
+**Running the validation:**
+
+```bash
+# Run all schema validation tests
+go test -v ./pkg/registry -run ".*Schema.*"
+
+# Run just the embedded registry validation
+go test -v ./pkg/registry -run TestEmbeddedRegistrySchemaValidation
+
+# Run all registry tests (includes schema validation)
+go test -v ./pkg/registry
+```
+
+This validation runs automatically as part of:
+
+- Local development (`go test`)
+- CI/CD pipeline (GitHub Actions)
+- Pre-commit hooks (if configured)
+
+### Manual validation
 
 #### Using check-jsonschema
 

--- a/go.mod
+++ b/go.mod
@@ -193,6 +193,7 @@ require (
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/sagikazarmark/locafero v0.7.0 // indirect
+	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 // indirect
 	github.com/sassoftware/relic v7.2.1+incompatible // indirect
 	github.com/seatgeek/logrus-gelf-formatter v0.0.0-20210414080842-5b05eb8ff761 // indirect
 	github.com/secure-systems-lab/go-securesystemslib v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1461,6 +1461,8 @@ github.com/ryanuber/go-glob v1.0.0 h1:iQh3xXAumdQ+4Ufa5b25cRpC5TYKlno6hsv6Cb3pkB
 github.com/ryanuber/go-glob v1.0.0/go.mod h1:807d1WSdnB0XRJzKNil9Om6lcp/3a0v4qIHxIXzX/Yc=
 github.com/sagikazarmark/locafero v0.7.0 h1:5MqpDsTGNDhY8sGp0Aowyf0qKsPrhewaLSsFaodPcyo=
 github.com/sagikazarmark/locafero v0.7.0/go.mod h1:2za3Cg5rMaTMoG/2Ulr9AwtFaIppKXTRYnozin4aB5k=
+github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 h1:lZUw3E0/J3roVtGQ+SCrUrg3ON6NgVqpn3+iol9aGu4=
+github.com/santhosh-tekuri/jsonschema/v5 v5.3.1/go.mod h1:uToXkOrWAZ6/Oc07xWQrPOhJotwFIyu2bBVN41fcDUY=
 github.com/sassoftware/relic v7.2.1+incompatible h1:Pwyh1F3I0r4clFJXkSI8bOyJINGqpgjJU3DYAZeI05A=
 github.com/sassoftware/relic v7.2.1+incompatible/go.mod h1:CWfAxv73/iLZ17rbyhIEq3K9hs5w6FpNMdUT//qR+zk=
 github.com/sassoftware/relic/v7 v7.6.2 h1:rS44Lbv9G9eXsukknS4mSjIAuuX+lMq/FnStgmZlUv4=

--- a/pkg/registry/schema_validation.go
+++ b/pkg/registry/schema_validation.go
@@ -1,0 +1,145 @@
+package registry
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/santhosh-tekuri/jsonschema/v5"
+)
+
+// ValidateRegistrySchema validates registry JSON data against the registry schema
+func ValidateRegistrySchema(registryData []byte) error {
+	// Load the schema from the docs directory
+	// We need to find the schema file relative to the current working directory
+	schemaPath := "docs/registry/schema.json"
+
+	// Try to find the schema file
+	var schemaData []byte
+	var err error
+
+	// First try the direct path
+	if _, err := os.Stat(schemaPath); err == nil {
+		schemaData, err = os.ReadFile(schemaPath)
+		if err != nil {
+			return fmt.Errorf("failed to read registry schema: %w", err)
+		}
+	} else {
+		// Try to find it relative to the module root
+		wd, err := os.Getwd()
+		if err != nil {
+			return fmt.Errorf("failed to get working directory: %w", err)
+		}
+
+		// Walk up the directory tree to find the schema
+		for {
+			testPath := filepath.Join(wd, schemaPath)
+			if _, err := os.Stat(testPath); err == nil {
+				schemaData, err = os.ReadFile(testPath)
+				if err != nil {
+					return fmt.Errorf("failed to read registry schema: %w", err)
+				}
+				break
+			}
+
+			parent := filepath.Dir(wd)
+			if parent == wd {
+				return fmt.Errorf("registry schema not found: %s", schemaPath)
+			}
+			wd = parent
+		}
+	}
+
+	// Compile the schema
+	compiler := jsonschema.NewCompiler()
+	schemaID := "file://local/registry-schema.json"
+	if err := compiler.AddResource(schemaID, strings.NewReader(string(schemaData))); err != nil {
+		return fmt.Errorf("failed to add schema resource: %w", err)
+	}
+	schema, err := compiler.Compile(schemaID)
+	if err != nil {
+		return fmt.Errorf("failed to compile registry schema: %w", err)
+	}
+
+	// Parse the registry data
+	var registryDoc interface{}
+	if err := json.Unmarshal(registryData, &registryDoc); err != nil {
+		return fmt.Errorf("failed to parse registry data: %w", err)
+	}
+
+	// Validate the registry data against the schema
+	if err := schema.Validate(registryDoc); err != nil {
+		// Extract all validation errors for better user experience
+		if validationErr, ok := err.(*jsonschema.ValidationError); ok {
+			return formatValidationErrors(validationErr)
+		}
+		return fmt.Errorf("registry schema validation failed: %w", err)
+	}
+
+	return nil
+}
+
+// formatValidationErrors formats all validation errors into a comprehensive error message
+func formatValidationErrors(validationErr *jsonschema.ValidationError) error {
+	var errorMessages []string
+
+	// Collect all validation errors recursively
+	collectErrors(validationErr, &errorMessages)
+
+	if len(errorMessages) == 0 {
+		return fmt.Errorf("registry schema validation failed: %s", validationErr.Error())
+	}
+
+	if len(errorMessages) == 1 {
+		return fmt.Errorf("registry schema validation failed: %s", errorMessages[0])
+	}
+
+	// Format multiple errors
+	result := fmt.Sprintf("registry schema validation failed with %d errors:\n", len(errorMessages))
+	for i, msg := range errorMessages {
+		result += fmt.Sprintf("  %d. %s\n", i+1, msg)
+	}
+
+	return fmt.Errorf("%s", strings.TrimSuffix(result, "\n"))
+}
+
+// collectErrors recursively collects all validation error messages
+func collectErrors(err *jsonschema.ValidationError, messages *[]string) {
+	if err == nil {
+		return
+	}
+
+	// If this error has causes, recurse into them instead of adding this error
+	// This avoids duplicate parent/child error messages
+	if len(err.Causes) > 0 {
+		for _, cause := range err.Causes {
+			collectErrors(cause, messages)
+		}
+		return
+	}
+
+	// This is a leaf error - add it if it has a meaningful message
+	if err.Message != "" {
+		// Create a descriptive error message with path context
+		var pathStr string
+		if err.InstanceLocation != "" {
+			pathStr = fmt.Sprintf(" at '%s'", err.InstanceLocation)
+		}
+
+		errorMsg := fmt.Sprintf("%s%s", err.Message, pathStr)
+		*messages = append(*messages, errorMsg)
+	}
+}
+
+// ValidateEmbeddedRegistry validates the embedded registry.json against the schema
+func ValidateEmbeddedRegistry() error {
+	// Load the embedded registry data
+	registryData, err := embeddedRegistryFS.ReadFile("data/registry.json")
+	if err != nil {
+		return fmt.Errorf("failed to load embedded registry: %w", err)
+	}
+
+	return ValidateRegistrySchema(registryData)
+}

--- a/pkg/registry/schema_validation_test.go
+++ b/pkg/registry/schema_validation_test.go
@@ -1,0 +1,391 @@
+package registry
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEmbeddedRegistrySchemaValidation validates that the embedded registry.json
+// conforms to the registry schema. This is the main test that ensures our
+// registry data is always valid.
+func TestEmbeddedRegistrySchemaValidation(t *testing.T) {
+	t.Parallel()
+
+	err := ValidateEmbeddedRegistry()
+	require.NoError(t, err, "Embedded registry.json must conform to the registry schema")
+}
+
+// TestRegistrySchemaValidation tests the schema validation function with various inputs
+func TestRegistrySchemaValidation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		registryJSON  string
+		expectError   bool
+		errorContains string
+	}{
+		{
+			name: "valid minimal registry",
+			registryJSON: `{
+				"version": "1.0.0",
+				"last_updated": "2025-01-01T00:00:00Z",
+				"servers": {}
+			}`,
+			expectError: false,
+		},
+		{
+			name: "valid registry with server",
+			registryJSON: `{
+				"version": "1.0.0",
+				"last_updated": "2025-01-01T00:00:00Z",
+				"servers": {
+					"test-server": {
+						"description": "A test server for validation",
+						"image": "test/server:latest",
+						"status": "Active",
+						"tier": "Community",
+						"tools": ["test_tool"],
+						"transport": "stdio"
+					}
+				}
+			}`,
+			expectError: false,
+		},
+		{
+			name: "missing required version field",
+			registryJSON: `{
+				"last_updated": "2025-01-01T00:00:00Z",
+				"servers": {}
+			}`,
+			expectError:   true,
+			errorContains: "version",
+		},
+		{
+			name: "missing required last_updated field",
+			registryJSON: `{
+				"version": "1.0.0",
+				"servers": {}
+			}`,
+			expectError:   true,
+			errorContains: "last_updated",
+		},
+		{
+			name: "missing required servers field",
+			registryJSON: `{
+				"version": "1.0.0",
+				"last_updated": "2025-01-01T00:00:00Z"
+			}`,
+			expectError:   true,
+			errorContains: "servers",
+		},
+		{
+			name: "invalid version format",
+			registryJSON: `{
+				"version": "invalid-version",
+				"last_updated": "2025-01-01T00:00:00Z",
+				"servers": {}
+			}`,
+			expectError:   true,
+			errorContains: "version",
+		},
+		{
+			name: "invalid date format",
+			registryJSON: `{
+				"version": "1.0.0",
+				"last_updated": "invalid-date",
+				"servers": {}
+			}`,
+			expectError:   true,
+			errorContains: "last_updated",
+		},
+		{
+			name: "server missing required description",
+			registryJSON: `{
+				"version": "1.0.0",
+				"last_updated": "2025-01-01T00:00:00Z",
+				"servers": {
+					"test-server": {
+						"image": "test/server:latest",
+						"status": "Active",
+						"tier": "Community",
+						"tools": ["test_tool"],
+						"transport": "stdio"
+					}
+				}
+			}`,
+			expectError:   true,
+			errorContains: "description",
+		},
+		{
+			name: "server missing required image",
+			registryJSON: `{
+				"version": "1.0.0",
+				"last_updated": "2025-01-01T00:00:00Z",
+				"servers": {
+					"test-server": {
+						"description": "A test server for validation",
+						"status": "Active",
+						"tier": "Community",
+						"tools": ["test_tool"],
+						"transport": "stdio"
+					}
+				}
+			}`,
+			expectError:   true,
+			errorContains: "image",
+		},
+		{
+			name: "server with invalid status",
+			registryJSON: `{
+				"version": "1.0.0",
+				"last_updated": "2025-01-01T00:00:00Z",
+				"servers": {
+					"test-server": {
+						"description": "A test server for validation",
+						"image": "test/server:latest",
+						"status": "InvalidStatus",
+						"tier": "Community",
+						"tools": ["test_tool"],
+						"transport": "stdio"
+					}
+				}
+			}`,
+			expectError:   true,
+			errorContains: "status",
+		},
+		{
+			name: "server with invalid tier",
+			registryJSON: `{
+				"version": "1.0.0",
+				"last_updated": "2025-01-01T00:00:00Z",
+				"servers": {
+					"test-server": {
+						"description": "A test server for validation",
+						"image": "test/server:latest",
+						"status": "Active",
+						"tier": "InvalidTier",
+						"tools": ["test_tool"],
+						"transport": "stdio"
+					}
+				}
+			}`,
+			expectError:   true,
+			errorContains: "tier",
+		},
+		{
+			name: "server with invalid transport",
+			registryJSON: `{
+				"version": "1.0.0",
+				"last_updated": "2025-01-01T00:00:00Z",
+				"servers": {
+					"test-server": {
+						"description": "A test server for validation",
+						"image": "test/server:latest",
+						"status": "Active",
+						"tier": "Community",
+						"tools": ["test_tool"],
+						"transport": "invalid-transport"
+					}
+				}
+			}`,
+			expectError:   true,
+			errorContains: "transport",
+		},
+		{
+			name: "server with empty tools array",
+			registryJSON: `{
+				"version": "1.0.0",
+				"last_updated": "2025-01-01T00:00:00Z",
+				"servers": {
+					"test-server": {
+						"description": "A test server for validation",
+						"image": "test/server:latest",
+						"status": "Active",
+						"tier": "Community",
+						"tools": [],
+						"transport": "stdio"
+					}
+				}
+			}`,
+			expectError:   true,
+			errorContains: "tools",
+		},
+		{
+			name: "server with description too short",
+			registryJSON: `{
+				"version": "1.0.0",
+				"last_updated": "2025-01-01T00:00:00Z",
+				"servers": {
+					"test-server": {
+						"description": "Short",
+						"image": "test/server:latest",
+						"status": "Active",
+						"tier": "Community",
+						"tools": ["test_tool"],
+						"transport": "stdio"
+					}
+				}
+			}`,
+			expectError:   true,
+			errorContains: "description",
+		},
+		{
+			name: "invalid server name pattern",
+			registryJSON: `{
+				"version": "1.0.0",
+				"last_updated": "2025-01-01T00:00:00Z",
+				"servers": {
+					"Invalid_Server_Name": {
+						"description": "A test server for validation",
+						"image": "test/server:latest",
+						"status": "Active",
+						"tier": "Community",
+						"tools": ["test_tool"],
+						"transport": "stdio"
+					}
+				}
+			}`,
+			expectError:   true,
+			errorContains: "additionalProperties",
+		},
+		{
+			name: "valid remote server",
+			registryJSON: `{
+				"version": "1.0.0",
+				"last_updated": "2025-01-01T00:00:00Z",
+				"servers": {},
+				"remote_servers": {
+					"test-remote": {
+						"url": "https://api.example.com/mcp",
+						"description": "A test remote server for validation",
+						"status": "Active",
+						"tier": "Community",
+						"tools": ["remote_tool"],
+						"transport": "sse"
+					}
+				}
+			}`,
+			expectError: false,
+		},
+		{
+			name: "remote server with invalid transport (stdio not allowed)",
+			registryJSON: `{
+				"version": "1.0.0",
+				"last_updated": "2025-01-01T00:00:00Z",
+				"servers": {},
+				"remote_servers": {
+					"test-remote": {
+						"url": "https://api.example.com/mcp",
+						"description": "A test remote server for validation",
+						"status": "Active",
+						"tier": "Community",
+						"tools": ["remote_tool"],
+						"transport": "stdio"
+					}
+				}
+			}`,
+			expectError:   true,
+			errorContains: "transport",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := ValidateRegistrySchema([]byte(tt.registryJSON))
+
+			if tt.expectError {
+				require.Error(t, err, "Expected validation to fail for test case: %s", tt.name)
+				if tt.errorContains != "" {
+					assert.Contains(t, err.Error(), tt.errorContains, "Error should contain expected text")
+				}
+			} else {
+				require.NoError(t, err, "Expected validation to pass for test case: %s", tt.name)
+			}
+		})
+	}
+}
+
+// TestValidateRegistrySchemaWithInvalidJSON tests that the function handles invalid JSON gracefully
+func TestValidateRegistrySchemaWithInvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	invalidJSON := `{
+		"version": "1.0.0",
+		"last_updated": "2025-01-01T00:00:00Z",
+		"servers": {
+			"test-server": {
+				"description": "A test server"
+				// Missing comma - invalid JSON
+				"image": "test/server:latest"
+			}
+		}
+	}`
+
+	err := ValidateRegistrySchema([]byte(invalidJSON))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse registry data")
+}
+
+// TestValidateEmbeddedRegistryCanLoadData tests that we can actually load the embedded registry
+func TestValidateEmbeddedRegistryCanLoadData(t *testing.T) {
+	t.Parallel()
+
+	// Load the embedded registry data
+	registryData, err := embeddedRegistryFS.ReadFile("data/registry.json")
+	require.NoError(t, err, "Should be able to load embedded registry data")
+
+	// Verify it's valid JSON
+	var registry Registry
+	err = json.Unmarshal(registryData, &registry)
+	require.NoError(t, err, "Embedded registry should be valid JSON")
+
+	// Verify basic structure
+	assert.NotEmpty(t, registry.Version, "Registry should have a version")
+	assert.NotEmpty(t, registry.LastUpdated, "Registry should have a last_updated timestamp")
+	assert.NotNil(t, registry.Servers, "Registry should have a servers map")
+}
+
+// TestMultipleValidationErrors tests that multiple validation errors are reported together
+func TestMultipleValidationErrors(t *testing.T) {
+	t.Parallel()
+
+	// Registry with multiple validation errors
+	invalidRegistryJSON := `{
+		"servers": {
+			"test-server": {
+				"description": "Short",
+				"status": "InvalidStatus",
+				"tier": "InvalidTier",
+				"tools": [],
+				"transport": "invalid-transport"
+			}
+		}
+	}`
+
+	err := ValidateRegistrySchema([]byte(invalidRegistryJSON))
+	require.Error(t, err, "Expected validation to fail with multiple errors")
+
+	errorMsg := err.Error()
+
+	// Should contain multiple errors
+	assert.Contains(t, errorMsg, "validation failed with", "Should indicate multiple errors")
+
+	// Should contain specific error details
+	assert.Contains(t, errorMsg, "version", "Should mention missing version")
+	assert.Contains(t, errorMsg, "last_updated", "Should mention missing last_updated")
+	assert.Contains(t, errorMsg, "description", "Should mention description length issue")
+	assert.Contains(t, errorMsg, "status", "Should mention invalid status")
+	assert.Contains(t, errorMsg, "tools", "Should mention empty tools array")
+
+	// Verify it's formatted as a numbered list
+	assert.Contains(t, errorMsg, "1.", "Should have numbered error list")
+	assert.Contains(t, errorMsg, "2.", "Should have multiple numbered errors")
+
+	t.Logf("Multi-error output:\n%s", errorMsg)
+}

--- a/pkg/registry/types.go
+++ b/pkg/registry/types.go
@@ -10,6 +10,9 @@ import (
 
 // Updates to the registry schema should be reflected in the JSON schema file located at docs/registry/schema.json.
 // The schema is used for validation and documentation purposes.
+//
+// The embedded registry.json is automatically validated against the schema during tests.
+// See pkg/registry/schema_validation_test.go for the validation implementation.
 
 // Registry represents the top-level structure of the MCP registry
 type Registry struct {


### PR DESCRIPTION
## Summary

Adds JSON schema validation for registry.json using Go tests. Validates the embedded registry data against the schema during development and CI/CD.

## Implementation

- `pkg/registry/schema_validation.go` - Core validation functions
- `pkg/registry/schema_validation_test.go` - Comprehensive test suite with 17+ test cases
- Updated documentation in `docs/registry/schema.md`
- Added `github.com/santhosh-tekuri/jsonschema/v5` dependency

## Key Features

- **Automated validation**: `TestEmbeddedRegistrySchemaValidation` validates registry.json against schema
- **Local schema consistency**: Uses local schema file for validation, ensuring compatibility with schema changes
- **Comprehensive error reporting**: Shows all validation errors with location information

## Usage

```bash
# Run schema validation tests
go test -v ./pkg/registry -run ".*Schema.*"

# Run main registry validation
go test -v ./pkg/registry -run TestEmbeddedRegistrySchemaValidation
```

## Benefits

- Prevents invalid registry data from being committed
- Immediate feedback during development
- Works with existing CI/CD workflows
- No infrastructure changes required