### PR TITLE
Return registered groups from API

### DIFF
--- a/pkg/api/v1/clients.go
+++ b/pkg/api/v1/clients.go
@@ -51,10 +51,10 @@ func ClientRouter(
 //	@Description	List all registered clients in ToolHive
 //	@Tags			clients
 //	@Produce		json
-//	@Success		200	{array}	client.Client
+//	@Success		200	{array}	client.RegisteredClient
 //	@Router			/api/v1beta/clients [get]
-func (c *ClientRoutes) listClients(w http.ResponseWriter, _ *http.Request) {
-	clients, err := c.clientManager.ListClients()
+func (c *ClientRoutes) listClients(w http.ResponseWriter, r *http.Request) {
+	clients, err := c.clientManager.ListClients(r.Context())
 	if err != nil {
 		logger.Errorf("Failed to list clients: %v", err)
 		http.Error(w, "Failed to list clients", http.StatusInternalServerError)

--- a/pkg/client/mocks/mock_manager.go
+++ b/pkg/client/mocks/mock_manager.go
@@ -57,18 +57,18 @@ func (mr *MockManagerMockRecorder) AddServerToClients(ctx, serverName, serverURL
 }
 
 // ListClients mocks base method.
-func (m *MockManager) ListClients() ([]client.Client, error) {
+func (m *MockManager) ListClients(ctx context.Context) ([]client.RegisteredClient, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListClients")
-	ret0, _ := ret[0].([]client.Client)
+	ret := m.ctrl.Call(m, "ListClients", ctx)
+	ret0, _ := ret[0].([]client.RegisteredClient)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListClients indicates an expected call of ListClients.
-func (mr *MockManagerMockRecorder) ListClients() *gomock.Call {
+func (mr *MockManagerMockRecorder) ListClients(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListClients", reflect.TypeOf((*MockManager)(nil).ListClients))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListClients", reflect.TypeOf((*MockManager)(nil).ListClients), ctx)
 }
 
 // RegisterClients mocks base method.


### PR DESCRIPTION
Move client listing logic into client manager so it can be reused.