### PR TITLE
Fix protocol scheme workload name validation issue

### DIFF
--- a/cmd/thv/app/run.go
+++ b/cmd/thv/app/run.go
@@ -210,6 +210,16 @@ func runForeground(ctx context.Context, workloadManager workloads.Manager, runne
 func validateGroup(ctx context.Context, workloadsManager workloads.Manager, serverOrImage string) error {
 	workloadName := runFlags.Name
 	if workloadName == "" {
+		// For protocol schemes without an explicit name, skip group validation.
+		// Protocol schemes (like npx://@scope/package) contain characters that are invalid
+		// for filesystem operations. The actual workload name will be generated during
+		// the build process (in BuildRunnerConfig) where it gets properly sanitized.
+		// Since the workload doesn't exist yet with the protocol URL as its name,
+		// and we can't check for conflicts without the final sanitized name,
+		// we defer group validation to when the workload is actually created.
+		if runner.IsImageProtocolScheme(serverOrImage) {
+			return nil
+		}
 		workloadName = serverOrImage
 	}
 


### PR DESCRIPTION
## Description

This PR fixes an issue where running MCP servers with protocol schemes (like `npx://@scope/package`) would fail due to the raw protocol URL being used as the workload name, causing filesystem errors from invalid characters (colons and slashes).

## Problem

When running:
```bash
thv run npx://@modelcontextprotocol/server-sequential-thinking
```

The command would fail with:
```
Error: failed to get workload: failed to acquire read lock for workload npx://@modelcontextprotocol/server-sequential-thinking: open /var/home/user/.local/share/toolhive/statuses/npx:/@modelcontextprotocol/server-sequential-thinking.lock: no such file or directory
```

## Solution

The fix skips group validation for protocol schemes when no explicit name is provided, because:
1. The workload doesn't exist yet with the protocol URL as its name
2. The actual sanitized name is generated later during the build process
3. Group validation can't be performed without the final sanitized name

The proper workload name is generated during `BuildRunnerConfig` where the protocol URL is converted to a valid container/workload name.

## Testing

Tested with:
- `npx://@modelcontextprotocol/server-sequential-thinking` - ✅ Works
- Regular image names continue to work as before
- Named workloads with `--name` flag work as expected

## Changes

- Modified `validateGroup` function in `cmd/thv/app/run.go` to skip validation for protocol schemes without explicit names
- Added detailed comments explaining the rationale for skipping validation