### PR TITLE
gives the GH_TOKEN to claude code so that gh commands work

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -104,3 +104,5 @@ jobs:
           mcp_config: /tmp/mcp-config/mcp-servers.json
           timeout_minutes: "5"
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
There is an error in the triage action https://github.com/stacklok/toolhive/actions/runs/17047863550/job/48328145486 that suggests the GH_TOKEN variable needs to be set in the Claude Code action and not just given to the Github MCP Server

```
{
  "type": "user",
  "message": {
    "role": "user",
    "content": [
      {
        "type": "tool_result",
        "content": "gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable. Example:\n  env:\n    GH_TOKEN: ${{ github.token }}",
        "is_error": true,
        "tool_use_id": "toolu_01MELzaYgzAhRNUvAVu3zWVd"
      }
    ]
  }
```