### PR TITLE
Pass allowPrivateIP into createOIDCConfig

### DIFF
--- a/cmd/thv/app/run_flags.go
+++ b/cmd/thv/app/run_flags.go
@@ -254,7 +254,7 @@ func setupOIDCConfiguration(cmd *cobra.Command, runFlags *RunFlags) (*auth.Token
 	}
 
 	return createOIDCConfig(oidcIssuer, oidcAudience, oidcJwksURL, oidcIntrospectionURL,
-		oidcClientID, oidcClientSecret, runFlags.ResourceURL), nil
+		oidcClientID, oidcClientSecret, runFlags.ResourceURL, runFlags.JWKSAllowPrivateIP), nil
 }
 
 // setupTelemetryConfiguration sets up telemetry configuration with config fallbacks
@@ -442,7 +442,7 @@ func getTelemetryFromFlags(cmd *cobra.Command, config *cfg.Config, otelEndpoint 
 
 // createOIDCConfig creates an OIDC configuration if any OIDC parameters are provided
 func createOIDCConfig(oidcIssuer, oidcAudience, oidcJwksURL, oidcIntrospectionURL,
-	oidcClientID, oidcClientSecret, resourceURL string) *auth.TokenValidatorConfig {
+	oidcClientID, oidcClientSecret, resourceURL string, allowPrivateIP bool) *auth.TokenValidatorConfig {
 	if oidcIssuer != "" || oidcAudience != "" || oidcJwksURL != "" || oidcIntrospectionURL != "" ||
 		oidcClientID != "" || oidcClientSecret != "" || resourceURL != "" {
 		return &auth.TokenValidatorConfig{
@@ -453,6 +453,7 @@ func createOIDCConfig(oidcIssuer, oidcAudience, oidcJwksURL, oidcIntrospectionUR
 			ClientID:         oidcClientID,
 			ClientSecret:     oidcClientSecret,
 			ResourceURL:      resourceURL,
+			AllowPrivateIP:   allowPrivateIP,
 		}
 	}
 	return nil


### PR DESCRIPTION
I've been working on deploying Keycloak into our test cluster and noticed that the --jwks-allow-private-ip flag is not being passed down at all which is something we'd appreciate to run a dev KC instance.