### PR TITLE
Lazily register JWKS endpoint with a 5 second timeout instead of on s…

### DIFF
--- a/pkg/auth/token_test.go
+++ b/pkg/auth/token_test.go
@@ -75,6 +75,12 @@ func TestTokenValidator(t *testing.T) {
 		t.Fatalf("Failed to create token validator: %v", err)
 	}
 
+	// Ensure JWKS is registered before lookup
+	err = validator.ensureJWKSRegistered(ctx)
+	if err != nil {
+		t.Fatalf("Failed to register JWKS: %v", err)
+	}
+
 	// Force a refresh of the JWKS cache
 	_, err = validator.jwksClient.Lookup(ctx, jwksServer.URL)
 	if err != nil {
@@ -215,6 +221,12 @@ func TestTokenValidatorMiddleware(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("Failed to create token validator: %v", err)
+	}
+
+	// Ensure JWKS is registered before lookup
+	err = validator.ensureJWKSRegistered(ctx)
+	if err != nil {
+		t.Fatalf("Failed to register JWKS: %v", err)
 	}
 
 	// Force a refresh of the JWKS cache
@@ -605,6 +617,12 @@ func TestNewTokenValidatorWithOIDCDiscovery(t *testing.T) {
 		tokenString, err := token.SignedString(privateKey)
 		if err != nil {
 			t.Fatalf("Failed to sign token: %v", err)
+		}
+
+		// Ensure JWKS is registered before lookup
+		err = validator.ensureJWKSRegistered(ctx)
+		if err != nil {
+			t.Fatalf("Failed to register JWKS: %v", err)
 		}
 
 		// Force a refresh of the JWKS cache


### PR DESCRIPTION
…tartup

When working on patches for PRs #1470 and #1471 I've been initially seeing very long timeouts on toolhive startup. The underlying reason were the transports not allowing me but the fact that the timeout was so long and happened on toolhive startup was really irritating. I think we should fetch the JWKs when we needed, not on startup in order to not block the startup.