### PR TITLE
Remove unused JWKSAllowPrivateIP from the runConfig struct

### DIFF
--- a/pkg/runner/config.go
+++ b/pkg/runner/config.go
@@ -126,9 +126,6 @@ type RunConfig struct {
 	// JWKSAuthTokenFile is the path to file containing auth token for JWKS/OIDC requests
 	JWKSAuthTokenFile string `json:"jwks_auth_token_file,omitempty" yaml:"jwks_auth_token_file,omitempty"`
 
-	// JWKSAllowPrivateIP allows JWKS/OIDC endpoints on private IP addresses
-	JWKSAllowPrivateIP bool `json:"jwks_allow_private_ip,omitempty" yaml:"jwks_allow_private_ip,omitempty"`
-
 	// Group is the name of the group this workload belongs to, if any
 	Group string `json:"group,omitempty" yaml:"group,omitempty"`
 

--- a/pkg/runner/config_builder.go
+++ b/pkg/runner/config_builder.go
@@ -228,7 +228,6 @@ func (b *RunConfigBuilder) WithOIDCConfig(
 	// Set JWKS-related configuration
 	b.config.ThvCABundle = thvCABundle
 	b.config.JWKSAuthTokenFile = jwksAuthTokenFile
-	b.config.JWKSAllowPrivateIP = jwksAllowPrivateIP
 
 	// Set ResourceURL if OIDCConfig exists or if resourceURL is not empty
 	if b.config.OIDCConfig != nil {


### PR DESCRIPTION
I don't know how this parameter got in, but it's unused and only ever written to. Let's remove it.