### PR TITLE
Registry schema: normalize tags for server and remote_server

### DIFF
--- a/pkg/registry/data/schema.json
+++ b/pkg/registry/data/schema.json
@@ -534,7 +534,7 @@
           "description": "Categorization tags for search and filtering",
           "items": {
             "type": "string",
-            "pattern": "^[a-z0-9][a-z0-9_-]+[a-z0-9]$"
+            "pattern": "^[a-z0-9][a-z0-9_-]*[a-z0-9]$"
           },
           "minItems": 1,
           "uniqueItems": true


### PR DESCRIPTION
#1436 allowed for two-character tags in `server` entries in the registry JSON schema.

Normalizing to also apply to `remote_server` entries.

Signed-off-by: Dan Barr <6922515+danbarr@users.noreply.github.com>