### PR TITLE
Revert "Fix workflow triggers for docs updates"

### DIFF
--- a/.github/workflows/releaser-helm-charts.yml
+++ b/.github/workflows/releaser-helm-charts.yml
@@ -11,9 +11,6 @@ jobs:
       packages: write
       id-token: write
 
-    outputs:
-      chart_version: ${{ steps.chart-releaser.outputs.chart_version }}
-
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
@@ -26,7 +23,6 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Run chart-releaser
-        id: chart-releaser
         uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f # v1.7.0
         with:
           config: cr.yaml
@@ -56,13 +52,3 @@ jobs:
           done
         env:
           COSIGN_EXPERIMENTAL: 1
-
-  update-docs-website:
-    name: Trigger Docs Update
-    needs: [ release ]
-    permissions: {}
-    uses: ./.github/workflows/update-docs-website.yml
-    with:
-      version: ${{ needs.release.outputs.chart_version }}
-    secrets:
-      DOCS_REPO_DISPATCH_TOKEN: ${{ secrets.DOCS_REPO_DISPATCH_TOKEN }}

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -114,16 +114,6 @@ jobs:
       id-token: write
     uses: ./.github/workflows/image-build-and-publish.yml
 
-  update-docs-website:
-    name: Trigger Docs Update
-    needs: [ release ]
-    permissions: {}
-    uses: ./.github/workflows/update-docs-website.yml
-    with:
-      version: ${{ github.ref_name }}
-    secrets:
-      DOCS_REPO_DISPATCH_TOKEN: ${{ secrets.DOCS_REPO_DISPATCH_TOKEN }}
-
 #  provenance:
 #    name: Generate provenance (SLSA3)
 #    needs:

--- a/.github/workflows/update-docs-website.yml
+++ b/.github/workflows/update-docs-website.yml
@@ -3,15 +3,8 @@ name: Trigger Docs Update
 permissions: {}
 
 on:
-  workflow_call:
-    inputs:
-      version:
-        description: 'Version tag for the release'
-        required: true
-        type: string
-    secrets:
-      DOCS_REPO_DISPATCH_TOKEN:
-        required: true
+  release:
+    types: [published]
 
 jobs:
   trigger:
@@ -22,7 +15,7 @@ jobs:
         run: |
           repo="stacklok/docs-website"
           event_type="published-release"
-          version="${{ inputs.version }}"
+          version="${{ github.event.release.tag_name }}"
 
           echo "Triggering docs update for $repo with version $version"
   


### PR DESCRIPTION
Reverts stacklok/toolhive#1477

Did not work as intended:

1. Issue with passing the secret from `releaser-helm-charts`
2. The chart-releaser action's `chart_version` output wasn't as expected