### PR TITLE
Continuously check if group migration is needed

### DIFF
--- a/pkg/migration/default_group.go
+++ b/pkg/migration/default_group.go
@@ -22,12 +22,18 @@ func (m *DefaultGroupMigrator) Migrate(ctx context.Context) error {
 		return fmt.Errorf("failed to initialize managers: %w", err)
 	}
 
-	// Create default group
-	if err := m.createDefaultGroup(ctx); err != nil {
-		return fmt.Errorf("failed to create default group: %w", err)
+	// Create default group if it doesn't exist
+	defaultGroupExists, err := m.groupManager.Exists(ctx, groups.DefaultGroupName)
+	if err != nil {
+		return fmt.Errorf("failed to check if default group exists: %w", err)
+	}
+	if !defaultGroupExists {
+		if err := m.createDefaultGroup(ctx); err != nil {
+			return fmt.Errorf("failed to create default group: %w", err)
+		}
 	}
 
-	// Migrate workloads to default group
+	// Migrate workloads to default group if they don't have a group assigned
 	migratedCount, err := m.migrateWorkloadsToDefaultGroup(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to migrate workloads: %w", err)
@@ -35,8 +41,6 @@ func (m *DefaultGroupMigrator) Migrate(ctx context.Context) error {
 
 	if migratedCount > 0 {
 		fmt.Printf("\nSuccessfully migrated %d workloads to default group '%s'\n", migratedCount, groups.DefaultGroupName)
-	} else {
-		fmt.Println("No workloads needed migration to default group")
 	}
 
 	// Migrate client configurations from global config to default group
@@ -108,11 +112,9 @@ func (m *DefaultGroupMigrator) migrateClientConfigs(ctx context.Context) error {
 
 	// If there are no registered clients, nothing to migrate
 	if len(appConfig.Clients.RegisteredClients) == 0 {
-		logger.Infof("No client configurations to migrate")
+		logger.Debugf("No client configurations to migrate")
 		return nil
 	}
-
-	fmt.Printf("Migrating %d client configurations to default group...\n", len(appConfig.Clients.RegisteredClients))
 
 	// Get the default group
 	defaultGroup, err := m.groupManager.Get(ctx, groups.DefaultGroupName)
@@ -151,10 +153,10 @@ func (m *DefaultGroupMigrator) migrateClientConfigs(ctx context.Context) error {
 		if err != nil {
 			logger.Warnf("Failed to clear global client configurations after migration: %v", err)
 		} else {
-			logger.Infof("Cleared global client configurations")
+			logger.Debugf("Cleared global client configurations")
 		}
 	} else {
-		logger.Infof("No client configurations needed migration")
+		logger.Debugf("No client configurations needed migration")
 	}
 
 	return nil

--- a/pkg/migration/migration.go
+++ b/pkg/migration/migration.go
@@ -3,10 +3,8 @@ package migration
 
 import (
 	"context"
-	"fmt"
 	"sync"
 
-	"github.com/stacklok/toolhive/pkg/config"
 	"github.com/stacklok/toolhive/pkg/logger"
 )
 
@@ -17,13 +15,6 @@ var migrationOnce sync.Once
 // This is called once at application startup
 func CheckAndPerformDefaultGroupMigration() {
 	migrationOnce.Do(func() {
-		appConfig := config.GetConfig()
-
-		// Check if default group migration has already been performed
-		if appConfig.DefaultGroupMigration {
-			return
-		}
-
 		if err := performDefaultGroupMigration(); err != nil {
 			logger.Errorf("Failed to perform default group migration: %v", err)
 			return
@@ -33,9 +24,6 @@ func CheckAndPerformDefaultGroupMigration() {
 
 // performDefaultGroupMigration migrates all existing workloads to the default group
 func performDefaultGroupMigration() error {
-	fmt.Println("Migrating existing workloads to default group...")
-	fmt.Println()
-
 	migrator := &DefaultGroupMigrator{}
 	return migrator.Migrate(context.Background())
 }


### PR DESCRIPTION
This is to handle the UI and CLI using different thv versions. The CLI will now always check if any workloads or clients need to be migrated.

Also, only creates the default group if not present and silences some of the noisy logs.