### PR TITLE
Updated the operator deployment README with a custom example. Include 0.2.8.

### DIFF
--- a/deploy/charts/operator/Chart.yaml
+++ b/deploy/charts/operator/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: toolhive-operator
 description: A Helm chart for deploying the ToolHive Operator into Kubernetes.
 type: application
-version: 0.2.5
+version: 0.2.6
 appVersion: "0.2.8"

--- a/deploy/charts/operator/README.md
+++ b/deploy/charts/operator/README.md
@@ -1,7 +1,7 @@
 
 # ToolHive Operator Helm Chart
 
-![Version: 0.2.5](https://img.shields.io/badge/Version-0.2.5-informational?style=flat-square)
+![Version: 0.2.6](https://img.shields.io/badge/Version-0.2.6-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying the ToolHive Operator into Kubernetes.
@@ -12,6 +12,12 @@ A Helm chart for deploying the ToolHive Operator into Kubernetes.
 
 ```console
 helm upgrade -i toolhive-operator oci://ghcr.io/stacklok/toolhive/toolhive-operator -n toolhive-system --create-namespace
+```
+
+Or for a custom values file:
+
+```consoleCustom
+helm upgrade -i toolhive-operator oci://ghcr.io/stacklok/toolhive/toolhive-operator -n toolhive-system --create-namespace --values values-openshift.yaml
 ```
 
 ## Prerequisites

--- a/deploy/charts/operator/README.md.gotmpl
+++ b/deploy/charts/operator/README.md.gotmpl
@@ -21,6 +21,12 @@
 helm upgrade -i toolhive-operator oci://ghcr.io/stacklok/toolhive/toolhive-operator -n toolhive-system --create-namespace
 ```
 
+Or for a custom values file:
+
+```consoleCustom
+helm upgrade -i toolhive-operator oci://ghcr.io/stacklok/toolhive/toolhive-operator -n toolhive-system --create-namespace --values values-openshift.yaml
+```
+
 ## Prerequisites
 
 - Kubernetes 1.25+


### PR DESCRIPTION
Small update to include a reference on how to use a custom values file to install via helm chart. References the newly included values-openshift.yaml which has been bumped to include the latest released version of the operator 0.2.8.

Open question; for the custom values file, values-openshift.yaml in this case, how should it be referenced to be consistent with other README's and the docs?
./values-openshift.yaml (assuming it's in the current dir but being explicit)
values-openshift.yaml (also assuming it's in the current directory but implicit)
./deploy/charts/operator/values-openshift.yaml (assuming one has cloned the repo and is in the root of the project)
raw github ref?

Please feel free to update as required.