### PR TITLE
feat: enhance thv mcp list to accept server names in addition to URLs

### DIFF
--- a/docs/cli/thv_mcp_list.md
+++ b/docs/cli/thv_mcp_list.md
@@ -26,7 +26,7 @@ thv mcp list [tools|resources|prompts] [flags]
 ```
       --format string      Output format (json or text) (default "text")
   -h, --help               help for list
-      --server string      MCP server URL (required)
+      --server string      MCP server URL or name from ToolHive registry (required)
       --timeout duration   Connection timeout (default 30s)
       --transport string   Transport type (auto, sse, streamable-http) (default "auto")
 ```

--- a/docs/cli/thv_mcp_list_prompts.md
+++ b/docs/cli/thv_mcp_list_prompts.md
@@ -26,7 +26,7 @@ thv mcp list prompts [flags]
 ```
       --format string      Output format (json or text) (default "text")
   -h, --help               help for prompts
-      --server string      MCP server URL (required)
+      --server string      MCP server URL or name from ToolHive registry (required)
       --timeout duration   Connection timeout (default 30s)
       --transport string   Transport type (auto, sse, streamable-http) (default "auto")
 ```

--- a/docs/cli/thv_mcp_list_resources.md
+++ b/docs/cli/thv_mcp_list_resources.md
@@ -26,7 +26,7 @@ thv mcp list resources [flags]
 ```
       --format string      Output format (json or text) (default "text")
   -h, --help               help for resources
-      --server string      MCP server URL (required)
+      --server string      MCP server URL or name from ToolHive registry (required)
       --timeout duration   Connection timeout (default 30s)
       --transport string   Transport type (auto, sse, streamable-http) (default "auto")
 ```

--- a/docs/cli/thv_mcp_list_tools.md
+++ b/docs/cli/thv_mcp_list_tools.md
@@ -26,7 +26,7 @@ thv mcp list tools [flags]
 ```
       --format string      Output format (json or text) (default "text")
   -h, --help               help for tools
-      --server string      MCP server URL (required)
+      --server string      MCP server URL or name from ToolHive registry (required)
       --timeout duration   Connection timeout (default 30s)
       --transport string   Transport type (auto, sse, streamable-http) (default "auto")
 ```


### PR DESCRIPTION
## Summary

This PR enhances the `thv mcp list` command to accept both server URLs and server names from running workloads via the `--server` flag.

## Changes

- Modified `--server` flag to accept both URLs and server names from running workloads
- Added `resolveServerURL` function to look up running servers by name using the efficient `GetWorkload` method
- Improved error messages for better user experience
- Removed unnecessary logger calls that could corrupt JSON output
- Updated flag documentation to reflect the new functionality

## Benefits

This allows users to conveniently reference MCP servers by their friendly names instead of having to remember or look up their URLs, while maintaining backward compatibility with direct URL usage.

## Examples

### Using server name:
```bash
thv mcp list tools --server fetch
```

### Using URL (backward compatible):
```bash
thv mcp list tools --server http://127.0.0.1:29104/mcp
```

## Testing

- ✅ Tested with server name: `./bin/thv mcp list tools --server fetch`
- ✅ Tested with URL: `./bin/thv mcp list tools --server http://127.0.0.1:29104/mcp`
- ✅ JSON output works correctly without corruption
- ✅ Error handling works for non-existent servers

Fixes the issue discussed where users wanted to use server names instead of URLs for the `--server` flag.