### PR TITLE
Add env files support

### DIFF
--- a/cmd/thv/app/run_flags.go
+++ b/cmd/thv/app/run_flags.go
@@ -84,6 +84,10 @@ type RunFlags struct {
 	// Configuration import
 	FromConfig string
 
+	// Environment file processing
+	EnvFile    string
+	EnvFileDir string
+
 	// Ignore functionality
 	IgnoreGlobally bool
 	PrintOverlays  bool
@@ -177,6 +181,10 @@ func AddRunFlags(cmd *cobra.Command, config *RunFlags) {
 		"Filter MCP server tools (comma-separated list of tool names)",
 	)
 	cmd.Flags().StringVar(&config.FromConfig, "from-config", "", "Load configuration from exported file")
+
+	// Environment file processing flags
+	cmd.Flags().StringVar(&config.EnvFile, "env-file", "", "Load environment variables from a single file")
+	cmd.Flags().StringVar(&config.EnvFileDir, "env-file-dir", "", "Load environment variables from all files in a directory")
 
 	// Ignore functionality flags
 	cmd.Flags().BoolVar(&config.IgnoreGlobally, "ignore-globally", true,
@@ -385,6 +393,21 @@ func buildRunnerConfig(
 		WithTelemetryConfig(finalOtelEndpoint, runFlags.OtelEnablePrometheusMetricsPath, runFlags.OtelServiceName,
 			finalOtelSamplingRate, runFlags.OtelHeaders, runFlags.OtelInsecure, finalOtelEnvironmentVariables).
 		WithToolsFilter(runFlags.ToolsFilter)
+
+	// Process environment files
+	var err error
+	if runFlags.EnvFile != "" {
+		builder, err = builder.WithEnvFile(runFlags.EnvFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to process env file %s: %v", runFlags.EnvFile, err)
+		}
+	}
+	if runFlags.EnvFileDir != "" {
+		builder, err = builder.WithEnvFilesFromDirectory(runFlags.EnvFileDir)
+		if err != nil {
+			return nil, fmt.Errorf("failed to process env files from directory %s: %v", runFlags.EnvFileDir, err)
+		}
+	}
 
 	return builder.Build(ctx, imageMetadata, envVars, envVarValidator)
 }

--- a/docs/cli/thv_run.md
+++ b/docs/cli/thv_run.md
@@ -65,6 +65,8 @@ thv run [flags] SERVER_OR_IMAGE_OR_PROTOCOL [-- ARGS...]
       --ca-cert string                        Path to a custom CA certificate file to use for container builds
       --enable-audit                          Enable audit logging with default configuration
   -e, --env stringArray                       Environment variables to pass to the MCP server (format: KEY=VALUE)
+      --env-file string                       Load environment variables from a single file
+      --env-file-dir string                   Load environment variables from all files in a directory
   -f, --foreground                            Run in foreground mode (block until container exits)
       --from-config string                    Load configuration from exported file
       --group string                          Name of the group this workload belongs to (defaults to 'default' if not specified) (default "default")

--- a/pkg/runner/config.go
+++ b/pkg/runner/config.go
@@ -312,6 +312,41 @@ func (c *RunConfig) WithSecrets(ctx context.Context, secretManager secrets.Provi
 	return c, nil
 }
 
+// mergeEnvVars is a helper method to merge environment variables into RunConfig
+func (c *RunConfig) mergeEnvVars(envVars map[string]string) *RunConfig {
+	// Initialize EnvVars if it's nil
+	if c.EnvVars == nil {
+		c.EnvVars = make(map[string]string)
+	}
+
+	// Add env vars to environment variables
+	for key, value := range envVars {
+		c.EnvVars[key] = value
+	}
+
+	return c
+}
+
+// WithEnvFilesFromDirectory processes environment files from a directory and adds them to environment variables
+func (c *RunConfig) WithEnvFilesFromDirectory(dirPath string) (*RunConfig, error) {
+	envVars, err := processEnvFilesDirectory(dirPath)
+	if err != nil {
+		return c, fmt.Errorf("failed to process env files from %s: %w", dirPath, err)
+	}
+
+	return c.mergeEnvVars(envVars), nil
+}
+
+// WithEnvFile processes a single environment file and adds it to environment variables
+func (c *RunConfig) WithEnvFile(filePath string) (*RunConfig, error) {
+	envVars, err := processEnvFile(filePath)
+	if err != nil {
+		return c, fmt.Errorf("failed to process env file %s: %w", filePath, err)
+	}
+
+	return c.mergeEnvVars(envVars), nil
+}
+
 // WithContainerName generates container name if not already set
 func (c *RunConfig) WithContainerName() *RunConfig {
 	if c.ContainerName == "" && c.Image != "" {

--- a/pkg/runner/config_builder.go
+++ b/pkg/runner/config_builder.go
@@ -692,3 +692,19 @@ func (b *RunConfigBuilder) processVolumeMounts() error {
 
 	return nil
 }
+
+// WithEnvFile adds environment variables from a single file
+func (b *RunConfigBuilder) WithEnvFile(filePath string) (*RunConfigBuilder, error) {
+	if _, err := b.config.WithEnvFile(filePath); err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+// WithEnvFilesFromDirectory adds environment variables from all files in a directory
+func (b *RunConfigBuilder) WithEnvFilesFromDirectory(dirPath string) (*RunConfigBuilder, error) {
+	if _, err := b.config.WithEnvFilesFromDirectory(dirPath); err != nil {
+		return nil, err
+	}
+	return b, nil
+}

--- a/pkg/runner/config_env_files_test.go
+++ b/pkg/runner/config_env_files_test.go
@@ -1,0 +1,205 @@
+package runner
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stacklok/toolhive/pkg/logger"
+)
+
+func TestRunConfig_WithEnvFile(t *testing.T) {
+	t.Parallel()
+
+	// Initialize logger to prevent nil pointer dereference
+	logger.Initialize()
+
+	tests := []struct {
+		name            string
+		initialEnvVars  map[string]string
+		fileContent     string
+		expectedEnvVars map[string]string
+		wantErr         bool
+	}{
+		{
+			name:           "basic env file",
+			initialEnvVars: nil,
+			fileContent:    "API_KEY=test123\nDB_URL=postgres://localhost:5432/db",
+			expectedEnvVars: map[string]string{
+				"API_KEY": "test123",
+				"DB_URL":  "postgres://localhost:5432/db",
+			},
+		},
+		{
+			name:            "env file with existing env vars",
+			initialEnvVars:  map[string]string{"EXISTING": "value"},
+			fileContent:     "API_KEY=test123",
+			expectedEnvVars: map[string]string{"EXISTING": "value", "API_KEY": "test123"},
+		},
+		{
+			name:            "env file overrides existing",
+			initialEnvVars:  map[string]string{"API_KEY": "old_value"},
+			fileContent:     "API_KEY=new_value",
+			expectedEnvVars: map[string]string{"API_KEY": "new_value"},
+		},
+		{
+			name:            "empty env file",
+			initialEnvVars:  map[string]string{"EXISTING": "value"},
+			fileContent:     "# Just comments\n",
+			expectedEnvVars: map[string]string{"EXISTING": "value"},
+		},
+		{
+			name:           "env file with export statements",
+			initialEnvVars: nil,
+			fileContent:    "export API_KEY=test123\nexport DB_URL=postgres://localhost:5432/db\nNORMAL=value",
+			expectedEnvVars: map[string]string{
+				"API_KEY": "test123",
+				"DB_URL":  "postgres://localhost:5432/db",
+				"NORMAL":  "value",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Create temporary env file
+			tmpDir := t.TempDir()
+			envFile := filepath.Join(tmpDir, "test.env")
+			err := os.WriteFile(envFile, []byte(tt.fileContent), 0644)
+			require.NoError(t, err)
+
+			// Create RunConfig
+			config := &RunConfig{
+				EnvVars: tt.initialEnvVars,
+			}
+
+			// Call WithEnvFile
+			result, err := config.WithEnvFile(envFile)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, config, result) // Should return same instance
+			assert.Equal(t, tt.expectedEnvVars, config.EnvVars)
+		})
+	}
+}
+
+func TestRunConfig_WithEnvFilesFromDirectory(t *testing.T) {
+	t.Parallel()
+
+	// Initialize logger to prevent nil pointer dereference
+	logger.Initialize()
+
+	tests := []struct {
+		name            string
+		initialEnvVars  map[string]string
+		files           map[string]string // filename -> content
+		expectedEnvVars map[string]string
+		wantErr         bool
+	}{
+		{
+			name:           "single env file",
+			initialEnvVars: nil,
+			files: map[string]string{
+				"app.env": "API_KEY=test123",
+			},
+			expectedEnvVars: map[string]string{"API_KEY": "test123"},
+		},
+		{
+			name:           "multiple env files",
+			initialEnvVars: nil,
+			files: map[string]string{
+				"app.env": "API_KEY=test123",
+				"db.env":  "DB_URL=postgres://localhost:5432/db",
+			},
+			expectedEnvVars: map[string]string{
+				"API_KEY": "test123",
+				"DB_URL":  "postgres://localhost:5432/db",
+			},
+		},
+		{
+			name:           "files override each other",
+			initialEnvVars: nil,
+			files: map[string]string{
+				"01-base.env":     "API_KEY=original\nDB_HOST=localhost",
+				"02-override.env": "API_KEY=overridden",
+			},
+			expectedEnvVars: map[string]string{
+				"API_KEY": "overridden",
+				"DB_HOST": "localhost",
+			},
+		},
+		{
+			name:            "merge with existing env vars",
+			initialEnvVars:  map[string]string{"EXISTING": "value"},
+			files:           map[string]string{"app.env": "API_KEY=test123"},
+			expectedEnvVars: map[string]string{"EXISTING": "value", "API_KEY": "test123"},
+		},
+		{
+			name:            "nonexistent directory",
+			initialEnvVars:  map[string]string{"EXISTING": "value"},
+			files:           nil, // Will use nonexistent directory path
+			expectedEnvVars: map[string]string{"EXISTING": "value"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var dirPath string
+			if tt.files != nil {
+				// Create temporary directory with files
+				tmpDir := t.TempDir()
+				dirPath = tmpDir
+				for filename, content := range tt.files {
+					err := os.WriteFile(filepath.Join(tmpDir, filename), []byte(content), 0644)
+					require.NoError(t, err)
+				}
+			} else {
+				// Use nonexistent directory
+				dirPath = "/path/that/does/not/exist"
+			}
+
+			// Create RunConfig
+			config := &RunConfig{
+				EnvVars: tt.initialEnvVars,
+			}
+
+			// Call WithEnvFilesFromDirectory
+			result, err := config.WithEnvFilesFromDirectory(dirPath)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, config, result) // Should return same instance
+			assert.Equal(t, tt.expectedEnvVars, config.EnvVars)
+		})
+	}
+}
+
+func TestRunConfig_WithEnvFile_ErrorHandling(t *testing.T) {
+	t.Parallel()
+
+	// Initialize logger to prevent nil pointer dereference
+	logger.Initialize()
+
+	config := &RunConfig{}
+
+	// Test with nonexistent file
+	_, err := config.WithEnvFile("/path/that/does/not/exist.env")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to process env file")
+}

--- a/pkg/runner/env_files.go
+++ b/pkg/runner/env_files.go
@@ -1,0 +1,102 @@
+package runner
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/stacklok/toolhive/pkg/environment"
+	"github.com/stacklok/toolhive/pkg/logger"
+)
+
+// processEnvFilesDirectory detects and processes environment files from a directory
+// Returns a map of environment variables to be merged with RunConfig.EnvVars
+func processEnvFilesDirectory(dirPath string) (map[string]string, error) {
+	// Check if directory exists
+	entries, err := os.ReadDir(dirPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			logger.Debugf("Env files directory %s does not exist", dirPath)
+			return make(map[string]string), nil // Return empty map, not an error
+		}
+		return nil, fmt.Errorf("failed to read env files directory %s: %w", dirPath, err)
+	}
+
+	logger.Infof("Env files directory %s detected, processing environment files", dirPath)
+
+	allEnvVars := make(map[string]string)
+	processedCount := 0
+
+	for _, entry := range entries {
+		// Skip directories
+		if entry.IsDir() {
+			continue
+		}
+
+		// Skip hidden files
+		if strings.HasPrefix(entry.Name(), ".") {
+			continue
+		}
+
+		filePath := filepath.Join(dirPath, entry.Name())
+		fileEnvVars, err := processEnvFile(filePath)
+		if err != nil {
+			logger.Warnf("Failed to process env file %s: %v", entry.Name(), err)
+			continue
+		}
+
+		// Merge env vars, with later files potentially overriding earlier ones
+		for key, value := range fileEnvVars {
+			allEnvVars[key] = value
+		}
+		processedCount++
+	}
+
+	logger.Infof("Processed %d env files, %d environment variables extracted", processedCount, len(allEnvVars))
+	return allEnvVars, nil
+}
+
+// processEnvFile reads and processes a single environment file
+// Uses existing ToolHive environment parsing utilities
+func processEnvFile(path string) (map[string]string, error) {
+	content, err := os.ReadFile(path) // #nosec G304 - path is controlled internally, validated by caller
+	if err != nil {
+		return nil, fmt.Errorf("failed to read file: %w", err)
+	}
+
+	// Convert content to slice of KEY=VALUE lines for existing parser
+	lines := strings.Split(string(content), "\n")
+	var envLines []string
+
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+
+		// Skip empty lines and comments
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		// Handle export statements (common in shell env files)
+		line = strings.TrimPrefix(line, "export ")
+
+		// Only process lines that contain '=' (KEY=VALUE format)
+		if strings.Contains(line, "=") {
+			envLines = append(envLines, line)
+		}
+	}
+
+	if len(envLines) == 0 {
+		logger.Debugf("No environment variables found in %s", filepath.Base(path))
+		return make(map[string]string), nil
+	}
+
+	// Use existing ToolHive utility to parse KEY=VALUE format
+	envVars, err := environment.ParseEnvironmentVariables(envLines)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse environment variables in %s: %w", filepath.Base(path), err)
+	}
+
+	logger.Debugf("Extracted %d environment variables from %s", len(envVars), filepath.Base(path))
+	return envVars, nil
+}

--- a/pkg/runner/env_files_test.go
+++ b/pkg/runner/env_files_test.go
@@ -1,0 +1,260 @@
+package runner
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stacklok/toolhive/pkg/logger"
+)
+
+func TestProcessEnvFile(t *testing.T) {
+	t.Parallel()
+
+	// Needed to prevent a nil pointer dereference in the logger.
+	logger.Initialize()
+
+	tests := []struct {
+		name     string
+		content  string
+		expected map[string]string
+		wantErr  bool
+	}{
+		{
+			name:     "standard env file format",
+			content:  "GITHUB_PERSONAL_ACCESS_TOKEN=ghp_test_token_12345",
+			expected: map[string]string{"GITHUB_PERSONAL_ACCESS_TOKEN": "ghp_test_token_12345"},
+			wantErr:  false,
+		},
+		{
+			name:    "multiple variables",
+			content: "GITHUB_TOKEN=ghp_123\nAPI_KEY=secret456\nDATABASE_URL=postgres://user:pass@localhost:5432/db",
+			expected: map[string]string{
+				"GITHUB_TOKEN": "ghp_123",
+				"API_KEY":      "secret456",
+				"DATABASE_URL": "postgres://user:pass@localhost:5432/db",
+			},
+			wantErr: false,
+		},
+		{
+			name:     "with comments and empty lines",
+			content:  "# Environment configuration\nGITHUB_TOKEN=ghp_test\n\n# Database config\nDB_PASSWORD=secretpass",
+			expected: map[string]string{"GITHUB_TOKEN": "ghp_test", "DB_PASSWORD": "secretpass"},
+			wantErr:  false,
+		},
+		{
+			name:     "empty file",
+			content:  "",
+			expected: map[string]string{},
+			wantErr:  false,
+		},
+		{
+			name:     "only comments",
+			content:  "# This is a comment\n# Another comment",
+			expected: map[string]string{},
+			wantErr:  false,
+		},
+		{
+			name:     "mixed valid and invalid lines",
+			content:  "VALID_KEY=value123\nINVALID_LINE_WITHOUT_EQUALS\nANOTHER_KEY=another_value",
+			expected: map[string]string{"VALID_KEY": "value123", "ANOTHER_KEY": "another_value"},
+			wantErr:  false, // We skip invalid lines, don't error
+		},
+		{
+			name:    "values with spaces and special chars",
+			content: "API_URL=https://api.example.com/v1\nSECRET_WITH_SPACES=value with spaces\nSPECIAL_CHARS=!@#$%^&*()",
+			expected: map[string]string{
+				"API_URL":            "https://api.example.com/v1",
+				"SECRET_WITH_SPACES": "value with spaces",
+				"SPECIAL_CHARS":      "!@#$%^&*()",
+			},
+			wantErr: false,
+		},
+		{
+			name:    "export statements (common in shell env files)",
+			content: "export API_KEY=test123\nexport DB_URL=postgres://localhost:5432/db\nNORMAL_VAR=value",
+			expected: map[string]string{
+				"API_KEY":    "test123",
+				"DB_URL":     "postgres://localhost:5432/db",
+				"NORMAL_VAR": "value",
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Create temporary file
+			tmpDir := t.TempDir()
+			tmpFile := filepath.Join(tmpDir, "test.env")
+
+			err := os.WriteFile(tmpFile, []byte(tt.content), 0644)
+			require.NoError(t, err)
+
+			// Test the function
+			result, err := processEnvFile(tmpFile)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestProcessEnvFilesDirectory_FileFiltering(t *testing.T) {
+	t.Parallel()
+
+	// Needed to prevent a nil pointer dereference in the logger.
+	logger.Initialize()
+
+	// Create temporary directory structure
+	tmpDir := t.TempDir()
+	envDir := filepath.Join(tmpDir, "env")
+	err := os.MkdirAll(envDir, 0755)
+	require.NoError(t, err)
+
+	// Create test files
+	err = os.WriteFile(filepath.Join(envDir, "github.env"), []byte("GITHUB_TOKEN=token123"), 0644)
+	require.NoError(t, err)
+
+	err = os.WriteFile(filepath.Join(envDir, "api"), []byte("API_KEY=key456"), 0644)
+	require.NoError(t, err)
+
+	// Create hidden file (should be ignored)
+	err = os.WriteFile(filepath.Join(envDir, ".hidden"), []byte("HIDDEN=value"), 0644)
+	require.NoError(t, err)
+
+	// Create subdirectory (should be ignored)
+	err = os.MkdirAll(filepath.Join(envDir, "subdir"), 0755)
+	require.NoError(t, err)
+
+	// Test directory processing
+	entries, err := os.ReadDir(envDir)
+	require.NoError(t, err)
+
+	var processedFiles []string
+	for _, entry := range entries {
+		// Skip directories
+		if entry.IsDir() {
+			continue
+		}
+
+		// Skip hidden files
+		if entry.Name()[0] == '.' {
+			continue
+		}
+
+		processedFiles = append(processedFiles, entry.Name())
+	}
+
+	// Should only process github.env and api files, not .hidden or subdir
+	assert.ElementsMatch(t, []string{"github.env", "api"}, processedFiles)
+}
+
+func TestProcessEnvFilesDirectory_Integration(t *testing.T) {
+	t.Parallel()
+
+	// Needed to prevent a nil pointer dereference in the logger.
+	logger.Initialize()
+
+	tests := []struct {
+		name         string
+		fileContents map[string]string // filename -> content
+		expected     map[string]string // expected env vars
+	}{
+		{
+			name: "single env file",
+			fileContents: map[string]string{
+				"app.env": "GITHUB_PERSONAL_ACCESS_TOKEN=ghp_test_token_12345",
+			},
+			expected: map[string]string{
+				"GITHUB_PERSONAL_ACCESS_TOKEN": "ghp_test_token_12345",
+			},
+		},
+		{
+			name: "multiple env files",
+			fileContents: map[string]string{
+				"github.env":   "GITHUB_TOKEN=ghp_123\nGITHUB_ORG=myorg",
+				"database.env": "DATABASE_URL=postgres://localhost:5432/mydb\nDB_PASSWORD=secret123",
+				"api.env":      "API_KEY=key456\nAPI_URL=https://api.example.com",
+			},
+			expected: map[string]string{
+				"GITHUB_TOKEN": "ghp_123",
+				"GITHUB_ORG":   "myorg",
+				"DATABASE_URL": "postgres://localhost:5432/mydb",
+				"DB_PASSWORD":  "secret123",
+				"API_KEY":      "key456",
+				"API_URL":      "https://api.example.com",
+			},
+		},
+		{
+			name: "complex env file with comments",
+			fileContents: map[string]string{
+				"app.env": `# Application configuration
+# GitHub integration
+GITHUB_TOKEN=ghp_very_long_token_with_numbers_123456789
+GITHUB_WEBHOOK_SECRET=super_secret_webhook_key
+
+# Database connection
+DATABASE_URL=postgres://user:complex_password_with_symbols_!@#$@db.example.com:5432/production_db?sslmode=require`,
+			},
+			expected: map[string]string{
+				"GITHUB_TOKEN":          "ghp_very_long_token_with_numbers_123456789",
+				"GITHUB_WEBHOOK_SECRET": "super_secret_webhook_key",
+				"DATABASE_URL":          "postgres://user:complex_password_with_symbols_!@#$@db.example.com:5432/production_db?sslmode=require",
+			},
+		},
+		{
+			name: "variable override behavior (later files win)",
+			fileContents: map[string]string{
+				"01-base.env":     "API_KEY=original_key\nDB_HOST=localhost",
+				"02-override.env": "API_KEY=overridden_key\nAPI_URL=https://api.example.com",
+			},
+			expected: map[string]string{
+				"API_KEY": "overridden_key",          // Should be overridden by later file
+				"DB_HOST": "localhost",               // Should remain from first file
+				"API_URL": "https://api.example.com", // Should be added from second file
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Create temporary directory
+			tmpDir := t.TempDir()
+
+			// Create all files
+			for filename, content := range tt.fileContents {
+				err := os.WriteFile(filepath.Join(tmpDir, filename), []byte(content), 0644)
+				require.NoError(t, err)
+			}
+
+			// Process directory
+			result, err := processEnvFilesDirectory(tmpDir)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestProcessEnvFilesDirectory_NonExistentDirectory(t *testing.T) {
+	t.Parallel()
+
+	// Needed to prevent a nil pointer dereference in the logger.
+	logger.Initialize()
+
+	result, err := processEnvFilesDirectory("/path/that/does/not/exist")
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]string{}, result)
+}


### PR DESCRIPTION
This patch is cherry-picked from a larger branch that adds support for Vault. This part is useful on its own and has been requested by our users.

Adds two new flags to `thv run`:
```
--env-file string   Load environment variables from a single file
--env-file-dir string  Load environment variables from all files in a directory
```

Adds the latter to the proxyrunner as well.

Fixes: #1286