### PR TITLE
Fix listing and removing workloads in inconsistent state

### DIFF
--- a/pkg/workloads/manager.go
+++ b/pkg/workloads/manager.go
@@ -336,30 +336,29 @@ func (d *defaultManager) deleteWorkload(ctx context.Context, name string) error 
 	if err != nil {
 		return err
 	}
-	if container == nil {
-		return nil // Container not found, but operation should succeed
-	}
 
 	// Set status to removing
 	if err := d.statuses.SetWorkloadStatus(ctx, name, rt.WorkloadStatusRemoving, ""); err != nil {
 		logger.Warnf("Failed to set workload %s status to removing: %v", name, err)
 	}
 
-	containerLabels := container.Labels
-	baseName := labels.GetContainerBaseName(containerLabels)
+	if container != nil {
+		containerLabels := container.Labels
+		baseName := labels.GetContainerBaseName(containerLabels)
 
-	// Stop proxy if running
-	if container.IsRunning() {
-		d.stopProxyIfNeeded(name, baseName)
+		// Stop proxy if running
+		if container.IsRunning() {
+			d.stopProxyIfNeeded(name, baseName)
+		}
+
+		// Remove the container
+		if err := d.removeContainer(childCtx, ctx, name); err != nil {
+			return err
+		}
+
+		// Clean up associated resources
+		d.cleanupWorkloadResources(childCtx, name, baseName)
 	}
-
-	// Remove the container
-	if err := d.removeContainer(childCtx, ctx, name); err != nil {
-		return err
-	}
-
-	// Clean up associated resources
-	d.cleanupWorkloadResources(childCtx, name, baseName)
 
 	// Remove the workload status from the status store
 	if err := d.statuses.DeleteWorkloadStatus(ctx, name); err != nil {
@@ -375,7 +374,7 @@ func (d *defaultManager) getWorkloadContainer(childCtx, ctx context.Context, nam
 	if err != nil {
 		if errors.Is(err, rt.ErrWorkloadNotFound) {
 			// Log but don't fail the entire operation for not found containers
-			logger.Warnf("Warning: Failed to delete workload %s: %v", name, err)
+			logger.Warnf("Warning: Failed to get workload %s: %v", name, err)
 			return nil, nil
 		}
 		if statusErr := d.statuses.SetWorkloadStatus(ctx, name, rt.WorkloadStatusError, err.Error()); statusErr != nil {


### PR DESCRIPTION
This can occur when the CLI and UI are using different versions of thv.

- Update the workload status to unhealthy if the file status claims that a workload is running or stopped, but the runtime has no knowledge of the container.
- During removal, clean up status files even if the runtime is not aware of the workload.

Fix #1493