### PR TITLE
Update Cline client config

### DIFF
--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -117,10 +117,11 @@ var supportedClientIntegrations = []mcpClientConfig{
 		MCPServersPathPrefix: "/mcpServers",
 		Extension:            JSON,
 		SupportedTransportTypesMap: map[types.TransportType]string{
-			types.TransportTypeSSE:   "sse",
-			types.TransportTypeStdio: "sse",
+			types.TransportTypeStdio:          "sse",
+			types.TransportTypeSSE:            "sse",
+			types.TransportTypeStreamableHTTP: "streamableHttp",
 		},
-		IsTransportTypeFieldSupported: false,
+		IsTransportTypeFieldSupported: true,
 		MCPServersUrlLabel:            "url",
 	},
 	{


### PR DESCRIPTION
Cline fixed up their Streamable HTTP support back in v3.17.10; updating our config to match.

Tested with latest version of Cline using stdio, sse, and stramable-http servers.

Signed-off-by: Dan Barr <6922515+danbarr@users.noreply.github.com>