### PR TITLE
Remove priority label step from Claude triage

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -71,14 +71,12 @@ jobs:
              - The issue title and description
              - The type of issue (bug report, feature request, question, etc.)
              - Technical areas mentioned
-             - Severity or priority indicators
              - User impact
              - Components affected
 
           4. Select appropriate labels from the available labels list provided above:
              - Choose labels that accurately reflect the issue's nature
              - Be specific but comprehensive
-             - Select priority labels if you can determine urgency (p0, p1, or p2)
              - Consider platform labels (kubernetes) if applicable
              - If you find similar issues using mcp__github__search_issues, consider using a "duplicate" label if appropriate. Only do so if the issue is a duplicate of another OPEN issue.
 


### PR DESCRIPTION
We haven't given Claude any guidelines on how to assess priority and it lacks the context, meaning the priority labels assigned are incorrect.