### PR TITLE
Fix nil pointer dereference when using protocol schemes

### DIFF
--- a/pkg/registry/types.go
+++ b/pkg/registry/types.go
@@ -219,51 +219,81 @@ type ServerMetadata interface {
 
 // GetName returns the server name
 func (i *ImageMetadata) GetName() string {
+	if i == nil {
+		return ""
+	}
 	return i.Name
 }
 
 // GetDescription returns the server description
 func (i *ImageMetadata) GetDescription() string {
+	if i == nil {
+		return ""
+	}
 	return i.Description
 }
 
 // GetTier returns the server tier
 func (i *ImageMetadata) GetTier() string {
+	if i == nil {
+		return ""
+	}
 	return i.Tier
 }
 
 // GetStatus returns the server status
 func (i *ImageMetadata) GetStatus() string {
+	if i == nil {
+		return ""
+	}
 	return i.Status
 }
 
 // GetTransport returns the server transport
 func (i *ImageMetadata) GetTransport() string {
+	if i == nil {
+		return ""
+	}
 	return i.Transport
 }
 
 // GetTools returns the list of tools provided by the server
 func (i *ImageMetadata) GetTools() []string {
+	if i == nil {
+		return nil
+	}
 	return i.Tools
 }
 
 // GetMetadata returns the server metadata
 func (i *ImageMetadata) GetMetadata() *Metadata {
+	if i == nil {
+		return nil
+	}
 	return i.Metadata
 }
 
 // GetRepositoryURL returns the repository URL
 func (i *ImageMetadata) GetRepositoryURL() string {
+	if i == nil {
+		return ""
+	}
 	return i.RepositoryURL
 }
 
 // GetTags returns the server tags
 func (i *ImageMetadata) GetTags() []string {
+	if i == nil {
+		return nil
+	}
 	return i.Tags
 }
 
 // GetCustomMetadata returns custom metadata
 func (i *ImageMetadata) GetCustomMetadata() map[string]any {
+	if i == nil {
+		return nil
+	}
 	return i.CustomMetadata
 }
 
@@ -274,6 +304,9 @@ func (*ImageMetadata) IsRemote() bool {
 
 // GetEnvVars returns environment variables
 func (i *ImageMetadata) GetEnvVars() []*EnvVar {
+	if i == nil {
+		return nil
+	}
 	return i.EnvVars
 }
 
@@ -281,51 +314,81 @@ func (i *ImageMetadata) GetEnvVars() []*EnvVar {
 
 // GetName returns the server name
 func (r *RemoteServerMetadata) GetName() string {
+	if r == nil {
+		return ""
+	}
 	return r.Name
 }
 
 // GetDescription returns the server description
 func (r *RemoteServerMetadata) GetDescription() string {
+	if r == nil {
+		return ""
+	}
 	return r.Description
 }
 
 // GetTier returns the server tier
 func (r *RemoteServerMetadata) GetTier() string {
+	if r == nil {
+		return ""
+	}
 	return r.Tier
 }
 
 // GetStatus returns the server status
 func (r *RemoteServerMetadata) GetStatus() string {
+	if r == nil {
+		return ""
+	}
 	return r.Status
 }
 
 // GetTransport returns the server transport
 func (r *RemoteServerMetadata) GetTransport() string {
+	if r == nil {
+		return ""
+	}
 	return r.Transport
 }
 
 // GetTools returns the list of tools provided by the server
 func (r *RemoteServerMetadata) GetTools() []string {
+	if r == nil {
+		return nil
+	}
 	return r.Tools
 }
 
 // GetMetadata returns the server metadata
 func (r *RemoteServerMetadata) GetMetadata() *Metadata {
+	if r == nil {
+		return nil
+	}
 	return r.Metadata
 }
 
 // GetRepositoryURL returns the repository URL
 func (r *RemoteServerMetadata) GetRepositoryURL() string {
+	if r == nil {
+		return ""
+	}
 	return r.RepositoryURL
 }
 
 // GetTags returns the server tags
 func (r *RemoteServerMetadata) GetTags() []string {
+	if r == nil {
+		return nil
+	}
 	return r.Tags
 }
 
 // GetCustomMetadata returns custom metadata
 func (r *RemoteServerMetadata) GetCustomMetadata() map[string]any {
+	if r == nil {
+		return nil
+	}
 	return r.CustomMetadata
 }
 
@@ -336,11 +399,17 @@ func (*RemoteServerMetadata) IsRemote() bool {
 
 // GetEnvVars returns environment variables
 func (r *RemoteServerMetadata) GetEnvVars() []*EnvVar {
+	if r == nil {
+		return nil
+	}
 	return r.EnvVars
 }
 
 // GetRawImplementation returns the underlying RemoteServerMetadata pointer
 func (r *RemoteServerMetadata) GetRawImplementation() any {
+	if r == nil {
+		return nil
+	}
 	return r
 }
 


### PR DESCRIPTION
## Summary

Fixes a nil pointer dereference panic that occurs when using protocol schemes like `npx://`, `uvx://`, or `go://`.

## Problem

When using protocol schemes, the `retriever.GetMCPServer()` function returns a non-nil `ServerMetadata` interface that contains a nil underlying `ImageMetadata` pointer. This causes a segmentation fault when methods like `GetTransport()` are called on the nil receiver.

The issue occurs because:
1. Protocol schemes are processed and build Docker images dynamically
2. The `imageMetadata` variable remains `nil` in the protocol scheme branch
3. This `nil` pointer is returned as a `ServerMetadata` interface
4. In Go, a `nil` pointer cast to an interface is not `nil` - it's an interface with a `nil` underlying value
5. When `serverMetadata != nil` check passes but `GetTransport()` is called, it tries to access fields of a `nil` struct

## Solution

Added nil checks to all `ServerMetadata` interface methods in both `ImageMetadata` and `RemoteServerMetadata` structs to handle nil receivers gracefully. This follows Go best practices for method receivers and prevents panics when methods are called on nil pointers.

## Testing

- ✅ Reproduced the original panic with `./bin/thv run --name gitlab npx://@zereight/mcp-gitlab`
- ✅ Verified the fix resolves the panic and the command runs successfully
- ✅ Confirmed linting passes with 0 issues
- ✅ Verified registry tests pass

## Changes

- Added nil checks to all `ImageMetadata` methods: `GetName()`, `GetDescription()`, `GetTier()`, `GetStatus()`, `GetTransport()`, `GetTools()`, `GetMetadata()`, `GetRepositoryURL()`, `GetTags()`, `GetCustomMetadata()`, `GetEnvVars()`
- Added nil checks to all `RemoteServerMetadata` methods with the same pattern
- Methods return appropriate zero values (empty strings, nil slices/maps) when receiver is nil

Fixes #1536