### PR TITLE
Add optional keycloak deployment for the local kind cluster

### DIFF
--- a/cmd/thv-operator/CLAUDE.md
+++ b/cmd/thv-operator/CLAUDE.md
@@ -3,3 +3,12 @@
     - `task operator-generate`, `task operator-manifests` and `task crdref-gen`.
     - it is important to run `task crdref-gen` inside cmd/thv-operator as the current directory
 - When committing a change that changes CRDs, it is important to bump the chart version in deploy/charts/operator-crds/Chart.yaml and deploy/charts/operator-crds/README.md
+
+## Keycloak Development Setup
+
+```bash
+task keycloak:install-operator    # Install Keycloak operator
+task keycloak:deploy-dev         # Deploy Keycloak and setup ToolHive realm  
+task keycloak:get-admin-creds    # Get admin credentials
+task keycloak:port-forward       # Access admin UI at http://localhost:8080
+```

--- a/cmd/thv-operator/Taskfile.yml
+++ b/cmd/thv-operator/Taskfile.yml
@@ -23,6 +23,7 @@ vars:
       else
         echo "docker"
       fi
+  KEYCLOAK_VERSION: '26.3.2'
 
 
 tasks:
@@ -263,3 +264,49 @@ tasks:
         --namespace {{.OCP_PROJECT}} \
         --create-namespace \
         {{ .CLI_ARGS }}
+
+  # Keycloak tasks
+  keycloak:install-operator:
+    desc: Install Keycloak Operator using official manifests (v{{.KEYCLOAK_VERSION}})
+    cmds:
+      - echo "Creating keycloak namespace..."
+      - kubectl create namespace keycloak --dry-run=client -o yaml --kubeconfig kconfig.yaml | kubectl apply -f - --kubeconfig kconfig.yaml
+      - echo "Installing Keycloak CRDs and Operator (version {{.KEYCLOAK_VERSION}})..."
+      - kubectl apply -f https://raw.githubusercontent.com/keycloak/keycloak-k8s-resources/{{.KEYCLOAK_VERSION}}/kubernetes/keycloaks.k8s.keycloak.org-v1.yml --kubeconfig kconfig.yaml
+      - kubectl apply -f https://raw.githubusercontent.com/keycloak/keycloak-k8s-resources/{{.KEYCLOAK_VERSION}}/kubernetes/keycloakrealmimports.k8s.keycloak.org-v1.yml --kubeconfig kconfig.yaml
+      - kubectl apply -f https://raw.githubusercontent.com/keycloak/keycloak-k8s-resources/{{.KEYCLOAK_VERSION}}/kubernetes/kubernetes.yml -n keycloak --kubeconfig kconfig.yaml
+      - echo "Waiting for Keycloak Operator to be ready..."
+      - kubectl wait --for=condition=ready --timeout=300s pod -l app.kubernetes.io/name=keycloak-operator -n keycloak --kubeconfig kconfig.yaml
+
+  keycloak:deploy-dev:
+    desc: Deploy Keycloak for development and setup ToolHive realm
+    deps: [keycloak:install-operator]
+    cmds:
+      - echo "Deploying Keycloak for development..."
+      - kubectl apply -f deploy/keycloak/keycloak-dev.yaml --kubeconfig kconfig.yaml
+      - echo "Waiting for Keycloak to be ready..."
+      - kubectl wait --for=condition=Ready --timeout=600s keycloaks.k8s.keycloak.org/keycloak-dev -n keycloak --kubeconfig kconfig.yaml
+      # Using REST API instead of KeycloakRealmImport because with embedded H2 database,
+      # KeycloakRealmImport creates a separate temporary database that doesn't persist
+      # to the main running Keycloak instance
+      - echo "Starting port-forward for realm setup..."
+      - kubectl port-forward service/keycloak-dev-service -n keycloak 8080:8080 --kubeconfig kconfig.yaml &
+      - sleep 5  # Wait for port-forward to be ready
+      - echo "Setting up ToolHive realm via REST API..."
+      - deploy/keycloak/setup-realm.sh
+      - echo "Stopping port-forward..."
+      - pkill -f "kubectl port-forward.*keycloak-dev-service" || true
+      - echo "Keycloak is ready with ToolHive realm! Use 'task keycloak:port-forward' to access it."
+
+  keycloak:get-admin-creds:
+    desc: Get Keycloak admin credentials
+    cmds:
+      - echo "Username:" && kubectl get secret keycloak-dev-initial-admin -n keycloak -o jsonpath='{.data.username}' --kubeconfig kconfig.yaml | base64 --decode
+      - echo "Password:" && kubectl get secret keycloak-dev-initial-admin -n keycloak -o jsonpath='{.data.password}' --kubeconfig kconfig.yaml | base64 --decode
+
+  keycloak:port-forward:
+    desc: Port forward to Keycloak service (http://localhost:8080)
+    cmds:
+      - echo "Keycloak will be available at http://localhost:8080"
+      - echo "Use 'task keycloak:get-admin-creds' to get login credentials"
+      - kubectl port-forward service/keycloak-dev-service -n keycloak 8080:8080 --kubeconfig kconfig.yaml

--- a/deploy/keycloak/README.md
+++ b/deploy/keycloak/README.md
@@ -1,0 +1,49 @@
+# Keycloak Development Setup
+
+This directory contains configuration for setting up Keycloak authentication with ToolHive MCP servers in development environments.
+
+## Quick Start
+
+1. **Deploy Keycloak and setup realm** (from `cmd/thv-operator/` directory):
+   ```bash
+   task kind-setup
+   task operator-install-crds
+   task operator-deploy-local
+   task keycloak:deploy-dev
+   ```
+
+2. **Access Keycloak admin UI**:
+   ```bash
+   task keycloak:port-forward
+   ```
+   Open http://localhost:8080 and login with operator-generated credentials:
+   ```bash
+   task keycloak:get-admin-creds
+   ```
+
+3. **Deploy authenticated MCP server**:
+   ```bash
+   kubectl apply -f deploy/keycloak/mcpserver-with-auth.yaml --kubeconfig kconfig.yaml
+   ```
+
+## Testing Authentication
+
+1. **Get access token**:
+   ```bash
+   curl -d "client_id=mcp-test-client" \
+        -d "username=toolhive-user" \
+        -d "password=user123" \
+        -d "grant_type=password" \
+        "http://localhost:8080/realms/toolhive/protocol/openid-connect/token"
+   ```
+
+2. **Use token with MCP server**:
+   ```bash
+   curl -H "Authorization: Bearer YOUR_TOKEN" \
+        http://your-mcp-server-url/
+   ```
+   An easy to test example is to forward the port to your MCP server:
+   ```
+   kubectl port-forward svc/mcp-fetch-server-keycloak-proxy 9090:9090 -ntoolhive-system
+   ```
+   then launch the MCP inspector connect to `localhost:9090/mcp` and use the token from earlier as a bearer token.

--- a/deploy/keycloak/keycloak-dev.yaml
+++ b/deploy/keycloak/keycloak-dev.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: keycloak
+---
+apiVersion: k8s.keycloak.org/v2alpha1
+kind: Keycloak
+metadata:
+  name: keycloak-dev
+  namespace: keycloak
+spec:
+  instances: 1
+  startOptimized: false  # Use start-dev mode for development
+  hostname:
+    hostname: keycloak
+  http:
+    # Enable HTTP for development (no TLS complexity in kind)
+    httpEnabled: true
+    httpPort: 8080
+  proxy:
+    headers: xforwarded
+  # Use embedded H2 database for development
+  db:
+    vendor: dev-file  # Embedded H2 with file persistence
+  # Resource limits for development
+  resources:
+    requests:
+      cpu: 500m
+      memory: 1Gi
+    limits:
+      cpu: 2000m
+      memory: 2Gi
+  # Additional server configuration for development
+  additionalOptions:
+    - name: health-enabled
+      value: "true"
+    - name: metrics-enabled 
+      value: "true"
+    - name: log-level
+      value: INFO

--- a/deploy/keycloak/mcpserver-with-auth.yaml
+++ b/deploy/keycloak/mcpserver-with-auth.yaml
@@ -1,0 +1,45 @@
+apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: MCPServer
+metadata:
+  name: fetch-server-keycloak
+  namespace: toolhive-system
+spec:
+  # Simple echo MCP server for testing
+  image: ghcr.io/stackloklabs/gofetch/server:0.0.4
+  resourceOverrides:
+    proxyDeployment:
+      env:
+        # by default we deploy KC w/o SSL
+        - name: INSECURE_DISABLE_URL_VALIDATION
+          value: "true"
+  transport: streamable-http
+  port: 9090
+  targetPort: 9090
+  env:
+
+  # OIDC authentication with Keycloak
+  oidcConfig:
+    type: inline
+    inline:
+      # Keycloak issuer URL for the toolhive realm
+      issuer: http://keycloak:8080/realms/toolhive
+      # Explicit JWKS URL to avoid OIDC discovery issues
+      jwksUrl: http://keycloak-dev-service.keycloak.svc.cluster.local:8080/realms/toolhive/protocol/openid-connect/certs
+      # MCP server client ID - tokens must have this in their audience claim
+      audience: mcp-server
+      # Optional: Allow private IP addresses for development
+      jwksAllowPrivateIP: true
+
+  # Basic permission profile allowing network access
+  permissionProfile:
+    type: builtin
+    name: network
+
+  # Resource limits
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi

--- a/deploy/keycloak/setup-realm.sh
+++ b/deploy/keycloak/setup-realm.sh
@@ -1,0 +1,184 @@
+#!/bin/bash
+set -e
+
+KEYCLOAK_URL="http://localhost:8080"
+# Get admin credentials from the operator-created secret
+ADMIN_USER=$(kubectl get secret keycloak-dev-initial-admin -n keycloak -o jsonpath='{.data.username}' --kubeconfig kconfig.yaml | base64 --decode)
+ADMIN_PASS=$(kubectl get secret keycloak-dev-initial-admin -n keycloak -o jsonpath='{.data.password}' --kubeconfig kconfig.yaml | base64 --decode)
+
+echo "Using operator-generated admin credentials..."
+
+echo "Getting admin token..."
+TOKEN=$(curl -s -d "client_id=admin-cli" \
+  -d "username=$ADMIN_USER" \
+  -d "password=$ADMIN_PASS" \
+  -d "grant_type=password" \
+  "$KEYCLOAK_URL/realms/master/protocol/openid-connect/token" | jq -r '.access_token')
+
+if [ "$TOKEN" = "null" ] || [ -z "$TOKEN" ]; then
+    echo "Failed to get admin token"
+    exit 1
+fi
+
+echo "Setting up ToolHive realm..."
+
+# First create the realm
+echo "Creating toolhive realm..."
+curl -s -X POST "$KEYCLOAK_URL/admin/realms" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "realm": "toolhive",
+    "displayName": "ToolHive Realm",
+    "enabled": true,
+    "accessTokenLifespan": 3600,
+    "accessTokenLifespanForImplicitFlow": 1800,
+    "ssoSessionIdleTimeout": 3600,
+    "ssoSessionMaxLifespan": 72000,
+    "offlineSessionIdleTimeout": 2592000
+  }' || echo "Realm may already exist"
+
+# Create clients
+echo "Creating mcp-test-client..."
+curl -s -X POST "$KEYCLOAK_URL/admin/realms/toolhive/clients" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "clientId": "mcp-test-client",
+    "enabled": true,
+    "publicClient": true,
+    "standardFlowEnabled": true,
+    "directAccessGrantsEnabled": true,
+    "redirectUris": ["http://localhost:*", "http://127.0.0.1:*"],
+    "webOrigins": ["http://localhost:*", "http://127.0.0.1:*"],
+    "description": "Public client for MCP testing"
+  }' || echo "Client may already exist"
+
+echo "Creating mcp-server..."
+curl -s -X POST "$KEYCLOAK_URL/admin/realms/toolhive/clients" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "clientId": "mcp-server",
+    "enabled": true,
+    "publicClient": false,
+    "secret": "PLOs4j6ti521kb5ZVVwi5GWi9eDYTwq",
+    "serviceAccountsEnabled": true,
+    "standardFlowEnabled": false,
+    "directAccessGrantsEnabled": false,
+    "description": "Confidential client for MCP server"
+  }' || echo "Client may already exist"
+
+# Create users
+echo "Creating toolhive-admin..."
+curl -s -X POST "$KEYCLOAK_URL/admin/realms/toolhive/users" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "username": "toolhive-admin",
+    "enabled": true,
+    "email": "admin@toolhive.example.com",
+    "emailVerified": true,
+    "firstName": "ToolHive",
+    "lastName": "Admin",
+    "credentials": [{
+      "type": "password",
+      "value": "admin123",
+      "temporary": false
+    }]
+  }' || echo "User may already exist"
+
+echo "Creating toolhive-user..."
+curl -s -X POST "$KEYCLOAK_URL/admin/realms/toolhive/users" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "username": "toolhive-user",
+    "enabled": true,
+    "email": "user@toolhive.example.com",
+    "emailVerified": true,
+    "firstName": "ToolHive", 
+    "lastName": "User",
+    "credentials": [{
+      "type": "password",
+      "value": "user123",
+      "temporary": false
+    }]
+  }' || echo "User may already exist"
+
+echo "Creating toolhive-readonly..."
+curl -s -X POST "$KEYCLOAK_URL/admin/realms/toolhive/users" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "username": "toolhive-readonly",
+    "enabled": true,
+    "email": "readonly@toolhive.example.com",
+    "emailVerified": true,
+    "firstName": "ToolHive",
+    "lastName": "ReadOnly",
+    "credentials": [{
+      "type": "password",
+      "value": "readonly123",
+      "temporary": false
+    }]
+  }' || echo "User may already exist"
+
+# Create client scope for audience mapping
+echo "Creating mcp-server-audience client scope..."
+curl -s -X POST "$KEYCLOAK_URL/admin/realms/toolhive/client-scopes" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "mcp-server-audience",
+    "description": "Adds mcp-server to token audience",
+    "protocol": "openid-connect",
+    "attributes": {
+      "include.in.token.scope": "true",
+      "display.on.consent.screen": "false"
+    }
+  }' || echo "Client scope may already exist"
+
+# Get the client scope ID
+SCOPE_ID=$(curl -s -H "Authorization: Bearer $TOKEN" \
+  "$KEYCLOAK_URL/admin/realms/toolhive/client-scopes" | \
+  jq -r '.[] | select(.name=="mcp-server-audience") | .id')
+
+if [ "$SCOPE_ID" != "null" ] && [ -n "$SCOPE_ID" ]; then
+  echo "Adding audience mapper to client scope..."
+  curl -s -X POST "$KEYCLOAK_URL/admin/realms/toolhive/client-scopes/$SCOPE_ID/protocol-mappers/models" \
+    -H "Authorization: Bearer $TOKEN" \
+    -H "Content-Type: application/json" \
+    -d '{
+      "name": "mcp-server-audience-mapper",
+      "protocol": "openid-connect",
+      "protocolMapper": "oidc-audience-mapper",
+      "config": {
+        "included.client.audience": "mcp-server",
+        "id.token.claim": "false",
+        "access.token.claim": "true"
+      }
+    }' || echo "Audience mapper may already exist"
+
+  # Assign the client scope as default to mcp-test-client
+  CLIENT_ID=$(curl -s -H "Authorization: Bearer $TOKEN" \
+    "$KEYCLOAK_URL/admin/realms/toolhive/clients" | \
+    jq -r '.[] | select(.clientId=="mcp-test-client") | .id')
+
+  if [ "$CLIENT_ID" != "null" ] && [ -n "$CLIENT_ID" ]; then
+    echo "Assigning audience scope to mcp-test-client..."
+    curl -s -X PUT "$KEYCLOAK_URL/admin/realms/toolhive/clients/$CLIENT_ID/default-client-scopes/$SCOPE_ID" \
+      -H "Authorization: Bearer $TOKEN" || echo "Scope assignment may already exist"
+  fi
+fi
+
+echo "ToolHive realm setup complete!"
+echo ""
+echo "Access your realm at: $KEYCLOAK_URL/admin/master/console/#/toolhive"
+echo "Users created:"
+echo "   - toolhive-admin (admin123)"
+echo "   - toolhive-user (user123)" 
+echo "   - toolhive-readonly (readonly123)"
+echo "Clients created:"
+echo "   - mcp-test-client (public)"
+echo "   - mcp-server (confidential)"


### PR DESCRIPTION
The motivation behind this is 2-fold:
1) make it easier for developers to play with auth
2) serve as a base for future e2e tests

Adds a keycloak deployment and a setup script plus an example manifest of an authenticated MCP server. Several things to note:
- the audience is set to mcp-server which is then enforced by thv proxy runner
- I wanted to also add authorization tests, that's why I added several users, but I haven't created the custom scopes or cedar policies yet