### PR TITLE
Use pushd instead of cd in update registry job

### DIFF
--- a/.github/workflows/update-registry.yml
+++ b/.github/workflows/update-registry.yml
@@ -54,7 +54,9 @@ jobs:
           # Verify checksum if available
           if [ "${{ steps.get-release.outputs.has_checksum }}" = "true" ]; then
             echo "Verifying checksum..."
-            cd /tmp && sha256sum -c registry.json.sha256
+            pushd /tmp
+            sha256sum -c registry.json.sha256
+            popd
             echo "✅ Checksum verification passed"
           else
             echo "⚠️ No checksum available for verification"


### PR DESCRIPTION
the usage of `cd` was setting us in the wrong directory so we couldn't
overwrite the registry file.

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>
