### PR TITLE
Refactor tool middlewares configuration mechanism.

### DIFF
--- a/pkg/mcp/middleware.go
+++ b/pkg/mcp/middleware.go
@@ -70,7 +70,7 @@ func CreateToolFilterMiddleware(config *types.MiddlewareConfig, runner types.Mid
 		return fmt.Errorf("failed to unmarshal tool filter middleware parameters: %w", err)
 	}
 
-	middleware, err := NewToolFilterMiddleware(params.FilterTools)
+	middleware, err := NewListToolsMappingMiddleware(WithToolsFilter(params.FilterTools...))
 	if err != nil {
 		return fmt.Errorf("failed to create tool filter middleware: %w", err)
 	}
@@ -88,7 +88,7 @@ func CreateToolCallFilterMiddleware(config *types.MiddlewareConfig, runner types
 		return fmt.Errorf("failed to unmarshal tool call filter middleware parameters: %w", err)
 	}
 
-	middleware, err := NewToolCallFilterMiddleware(params.FilterTools)
+	middleware, err := NewToolCallMappingMiddleware(WithToolsFilter(params.FilterTools...))
 	if err != nil {
 		return fmt.Errorf("failed to create tool call filter middleware: %w", err)
 	}


### PR DESCRIPTION
This change prepares the ground for the implementation of tool override by changing the way tool middlewares are configured.

As of now, tool middlewares accept a flat list of strings acting as a filter on the tools available to the Client. This is not sufficient once tool override is implemented, since we have to distinguish between a tool being filtered, being overridden, or both.

This is meant to be 100% backwards compatible, as the feature will be implemented in a follow-up PR.