### PR TITLE
Fix proxy memory allocation error

### DIFF
--- a/pkg/container/docker/squid.go
+++ b/pkg/container/docker/squid.go
@@ -59,7 +59,7 @@ func createEgressSquidContainer(
 	endpointsConfig map[string]*network.EndpointSettings,
 	perm *permissions.NetworkPermissions,
 ) (string, error) {
-	squidConfPath, err := createTempSquidConf(perm, containerName)
+	squidConfPath, err := createTempEgressSquidConf(perm, containerName)
 	if err != nil {
 		return "", fmt.Errorf("failed to create temporary squid.conf: %v", err)
 	}
@@ -160,7 +160,7 @@ func createSquidContainer(
 	return squidContainerId, nil
 }
 
-func createTempSquidConf(
+func createTempEgressSquidConf(
 	networkPermissions *permissions.NetworkPermissions,
 	serverHostname string,
 ) (string, error) {

--- a/pkg/container/docker/squid.go
+++ b/pkg/container/docker/squid.go
@@ -216,6 +216,8 @@ func writeCommonConfig(sb *strings.Builder, hostnameBase string, direction proxy
 		"visible_hostname " + serverHostname + "\n" +
 			"access_log stdio:/dev/stdout squid\n" +
 			"pid_filename /tmp/squid.pid\n" +
+			"# Avoid allocation errors caused by max_filedescriptors inference\n" +
+			"max_filedescriptors 1024\n" +
 			"# Disable memory and disk caching\n" +
 			"cache deny all\n" +
 			"cache_mem 0 MB\n" +

--- a/pkg/container/docker/squid.go
+++ b/pkg/container/docker/squid.go
@@ -224,7 +224,6 @@ func writeCommonConfig(sb *strings.Builder, hostnameBase string, direction proxy
 			"maximum_object_size 0 KB\n" +
 			"maximum_object_size_in_memory 0 KB\n" +
 			"# Don't use cache directories\n" +
-			"cache_dir null /tmp\n" +
 			"cache_store_log none\n\n")
 }
 


### PR DESCRIPTION
## Problem

Ingress and egress proxy containers end up in a bootloop upon start in some cases.

I have faced this issue when setting up an MCP with network isolation like this:

```sh
thv run --name fetch1 --isolate-network --permission-profile ./fetch-profile.json fetch
```

<details>
  <summary>fetch-profile.json</summary>

  ```json
  {
    "network": {
      "outbound": {
        "insecure_allow_all": false,
        "allow_host": [
          "httpbin.io"
        ],
        "allow_port": [
          443
        ]
      }
    }
  }
  ```

</details>

## Steps to Reproduce

Prepare the Squid config file as generated by Toolhive for the egress proxy container:

<details>
  <summary>squid-original.conf</summary>

  ```text
  http_port 3128
  visible_hostname fetch1-egress
  access_log stdio:/dev/stdout squid
  pid_filename /tmp/squid.pid
  # Disable memory and disk caching
  cache deny all
  cache_mem 0 MB
  maximum_object_size 0 KB
  maximum_object_size_in_memory 0 KB
  # Don't use cache directories
  cache_dir null /tmp
  cache_store_log none
  
  # Define allowed ports
  acl allowed_ports port 443
  # Define allowed destinations
  acl allowed_dsts dstdomain httpbin.io
  
  # Define http_access rules
  http_access allow allowed_ports allowed_dsts
  http_access deny all
  ```
</details>

Define the helper function to run the Squid container:

```sh
run_squid() {
    "$1" run -it --rm -v "./squid-$2.conf:/etc/squid/squid.conf:ro,z" ghcr.io/stacklok/toolhive/egress-proxy:v0.2.11
}
```

Run the scripts once on Ubuntu 25.04 and then once on Fedora 42:

```sh
run_squid docker original
run_squid podman original
```

| Distribution | Runtime       |  SELinux            |    Outcome     | Errors Logged |
|:-------------|:--------------|:--------------------|:--------------:|---------------|
| Ubuntu 25.04 | Docker 28.3.3 | :no_entry_sign: N/A | :boom: Crashes | <ul><li>`ERROR: This proxy does not support the 'null' cache type. Ignoring.`</li><li>`FATAL: xcalloc: Unable to allocate 1073741816 blocks of 432 bytes!`</li></ul> |
| Ubuntu 25.04 | Podman 5.4.1  | :no_entry_sign: N/A | :rocket: Runs  | <ul><li>`ERROR: This proxy does not support the 'null' cache type. Ignoring.`</li></ul> |
| Fedora 42    | Docker 28.3.3 | :lock: Enforced     | :boom: Crashes | <ul><li>`ERROR: This proxy does not support the 'null' cache type. Ignoring.`</li><li>`FATAL: xcalloc: Unable to allocate 1073741816 blocks of 432 bytes!`</li></ul> |
| Fedora 42    | Podman 5.5.2  | :lock: Enforced     | :rocket: Runs  | <ul><li>`ERROR: This proxy does not support the 'null' cache type. Ignoring.`</li></ul> |

Note the `Z` flag appended to all the `docker` and `podman` invocations for consistency.

There are three cases, though:

1. If SELinux is not enabled or not enforced, both Docker and Podman just ignore this flag, which is safe.

2. If SELinux is enabled and enforced, Docker works by adding `z` (or `Z`, not sure which one) implicitly if you omit it, and it works.

3. If SELinux is enabled and enforced, Podman doesn't do any implicit stuff and fails with this error:

    ```text
    FATAL: Unable to open configuration file: /etc/squid/squid.conf: (13) Permission denied
    ```

    With `Z` or `z` added explicitly, everything works.

So it is safe to consistently append `Z` in all the cases. This would make Podman work on SELinux systems.

The difference between `z` and `Z` is that the lowercase one allows sharing the bind-mounted file between multiple containers, while `Z` does not.
Since each ingress and egress container gets its own config, `Z` makes more sense to use.

## Fixes

The `xalloc` error from the logs is the one causing the crash.

Squid tries to allocate memory based on the value of [`max_filedescriptors`](http://www.squid-cache.org/Versions/v6/cfgman/max_filedescriptors.html).
If not set explicitly, it sets the value based on the system's limits, and the values it gets vary depending on the distro and the container runtime.
That's why it might work on Podman but fail on Docker, or vice versa.

The fix for it is to set `max_filedescriptors` explicitly to avoid guessing.

The whole history and investigation can be found in [Launchpad bug #1978272](https://bugs.launchpad.net/ubuntu-docker-images/+bug/1978272).

The error mentioning the unsupported `'null' cache type` is caused by the `cache_dir null /tmp` stanza.

The `null` store type was supported in [Squid 3.0](http://www.squid-cache.org/Versions/v3/3.0/cfgman/cache_dir.html),
but is no longer available (at least in the documentation) starting from [Squid 3.1](http://www.squid-cache.org/Versions/v3/3.1/cfgman/cache_dir.html).

The alpine package, which the proxy image is based on, ships Squid 6.12.

Here's a quote from the [`cache_dir`](http://www.squid-cache.org/Versions/v6/cfgman/cache_dir.html) doc:

> **Default Value:**	No disk cache. Store cache objects only in memory. 

So dropping the stanza altogether achieves the initial goal while removing the error from the logs.

-----

To test the fixes, prepare the fixed Squid config file for the egress proxy container:

<details>
  <summary>squid-fixed.conf</summary>

  ```text
  http_port 3128
  visible_hostname fetch1-egress
  access_log stdio:/dev/stdout logformat=squid
  pid_filename /tmp/squid.pid
  # Disable memory and disk caching
  cache deny all
  cache_mem 0 MB
  maximum_object_size 0 KB
  maximum_object_size_in_memory 0 KB
  # Don't use cache directories
  cache_store_log none
  
  # Define allowed ports
  acl allowed_ports port 443
  # Define allowed destinations
  acl allowed_dsts dstdomain httpbin.io
  
  # Define http_access rules
  http_access allow allowed_ports allowed_dsts
  http_access deny all
  
  max_filedescriptors 1024
  ```
</details>

Run the scripts once on Ubuntu 25.04 and then once on Fedora 42:

```sh
run_squid docker fixed
run_squid podman fixed
```

Observe all 4 cases run and don't log any errors.