### PR TITLE
Add support for upstream MCP registry format

### DIFF
--- a/docs/proposals/upstream-mcp-registry-format-support.md
+++ b/docs/proposals/upstream-mcp-registry-format-support.md
@@ -1,0 +1,377 @@
+# Upstream MCP Registry Format Support
+
+## Problem Statement
+
+ToolHive currently uses its own registry format for MCP servers, which is optimized for container execution and ToolHive's specific needs. However, the Model Context Protocol community has developed a standardized `server.json` format for describing MCP servers in a vendor-neutral way. This creates a barrier for:
+
+- **Server developers**: Must maintain separate metadata for different registries
+- **Registry interoperability**: Cannot easily share server definitions between registries
+- **Community adoption**: ToolHive servers cannot be easily discovered by other MCP clients
+- **Ecosystem fragmentation**: Different formats prevent a unified MCP server ecosystem
+
+## Goals
+
+- Add support for ingesting upstream MCP registry format (`server.json`) into ToolHive
+- Enable conversion from ToolHive format to upstream format for ecosystem compatibility
+- Maintain backward compatibility with existing ToolHive registry format
+- Leverage ToolHive-specific extensions for features not covered by upstream format
+- Provide seamless conversion between formats with minimal data loss
+
+## Non-Goals
+
+- Replace ToolHive's existing registry format entirely
+- Support every possible upstream format variation immediately
+- Automatic synchronization with upstream registries (future enhancement)
+- Breaking changes to existing ToolHive APIs
+
+## Architecture Overview
+
+The solution adds bidirectional conversion between ToolHive's container-focused format and the upstream community format:
+
+```
+Upstream Format (server.json)     ToolHive Format (registry.json)
+┌─────────────────────────┐       ┌─────────────────────────┐
+│ • Abstract description  │ ←───→ │ • Container execution   │
+│ • Package-centric       │       │ • Security profiles     │
+│ • Runtime hints         │       │ • Proxy configuration   │
+│ • Multi-deployment      │       │ • ToolHive-specific     │
+└─────────────────────────┘       └─────────────────────────┘
+```
+
+## Detailed Design
+
+### 1. Upstream Format Structs (`pkg/registry/upstream.go`)
+
+Define Go structs that match the upstream `server.json` schema:
+
+```go
+// UpstreamServerDetail represents the complete upstream format
+type UpstreamServerDetail struct {
+    Server     UpstreamServer     `json:"server"`
+    XPublisher *UpstreamPublisher `json:"x-publisher,omitempty"`
+}
+
+// UpstreamServer contains core server information
+type UpstreamServer struct {
+    Name          string                `json:"name"`
+    Description   string                `json:"description"`
+    Status        UpstreamServerStatus  `json:"status,omitempty"`
+    Repository    *UpstreamRepository   `json:"repository,omitempty"`
+    VersionDetail UpstreamVersionDetail `json:"version_detail"`
+    Packages      []UpstreamPackage     `json:"packages,omitempty"`
+    Remotes       []UpstreamRemote      `json:"remotes,omitempty"`
+}
+```
+
+Key features:
+- **Package Support**: npm, pypi, docker, nuget registries
+- **Remote Support**: SSE and streamable HTTP transports
+- **Flexible Arguments**: Named and positional arguments with variable substitution
+- **Environment Variables**: Required/optional, secret/plain, with choices
+
+### 2. ToolHive Extension Format
+
+ToolHive-specific metadata is stored in the `x-publisher` extension field:
+
+```go
+type ToolhivePublisherExtension struct {
+    Tier           string                `json:"tier,omitempty"`
+    Transport      string                `json:"transport,omitempty"`
+    Tools          []string              `json:"tools,omitempty"`
+    Metadata       *Metadata             `json:"metadata,omitempty"`
+    Tags           []string              `json:"tags,omitempty"`
+    CustomMetadata map[string]any        `json:"custom_metadata,omitempty"`
+    Permissions    *permissions.Profile  `json:"permissions,omitempty"`
+    TargetPort     int                   `json:"target_port,omitempty"`
+    DockerTags     []string              `json:"docker_tags,omitempty"`
+    Provenance     *Provenance           `json:"provenance,omitempty"`
+}
+```
+
+This approach:
+- **Preserves ToolHive features** not in upstream format
+- **Maintains compatibility** with upstream tooling
+- **Enables round-trip conversion** without data loss
+- **Follows extension conventions** used by other tools
+
+### 3. Conversion Functions (`pkg/registry/upstream_conversion.go`)
+
+#### Upstream → ToolHive Conversion
+
+```go
+func ConvertUpstreamToToolhive(upstream *UpstreamServerDetail) (ServerMetadata, error)
+```
+
+**Package Type Handling**:
+- `docker` packages → Direct Docker image references (`nginx:latest`)
+- `npm` packages → NPX protocol scheme (`npx://@scope/package@1.0.0`)
+- `pypi` packages → UVX protocol scheme (`uvx://package@1.0.0`)
+- Other packages → Best-effort conversion
+
+**Server Type Detection**:
+- Servers with `remotes` → `RemoteServerMetadata`
+- Servers with `packages` → `ImageMetadata`
+
+**Metadata Extraction**:
+- ToolHive extensions from `x-publisher.build_info.toolhive`
+- Default values for missing ToolHive-specific fields
+- Conversion of upstream enums to ToolHive values
+
+#### ToolHive → Upstream Conversion
+
+```go
+func ConvertToolhiveToUpstream(server ServerMetadata) (*UpstreamServerDetail, error)
+```
+
+**Package Generation**:
+- Docker images → `docker` registry packages
+- Protocol schemes → Appropriate registry packages
+- Environment variables → Package environment variables
+
+**Extension Population**:
+- ToolHive-specific metadata → `x-publisher.build_info.toolhive`
+- Standard upstream fields from ToolHive metadata
+- Publisher information for provenance
+
+### 4. Protocol Scheme Handling
+
+ToolHive supports protocol schemes that the upstream format describes as packages:
+
+| Upstream Package | ToolHive Image Format | ToolHive Execution |
+|------------------|----------------------|-------------------|
+| `npm` registry   | `npx://package@version` | Dynamic container build |
+| `pypi` registry  | `uvx://package@version` | Dynamic container build |
+| `docker` registry| `image:tag` | Direct container run |
+
+This mapping allows ToolHive to:
+- **Execute upstream packages** using existing protocol scheme support
+- **Preserve package metadata** for round-trip conversion
+- **Leverage dynamic builds** for non-Docker packages
+
+## Implementation Examples
+
+### Example 1: NPM Package Conversion
+
+**Upstream Format**:
+```json
+{
+  "server": {
+    "name": "io.modelcontextprotocol/brave-search",
+    "description": "MCP server for Brave Search API integration",
+    "packages": [{
+      "registry_name": "npm",
+      "name": "@modelcontextprotocol/server-brave-search",
+      "version": "1.0.2",
+      "environment_variables": [{
+        "name": "BRAVE_API_KEY",
+        "description": "Brave Search API Key",
+        "is_required": true,
+        "is_secret": true
+      }]
+    }]
+  }
+}
+```
+
+**ToolHive Format**:
+```json
+{
+  "name": "io.modelcontextprotocol/brave-search",
+  "description": "MCP server for Brave Search API integration",
+  "tier": "Community",
+  "status": "active",
+  "transport": "stdio",
+  "image": "npx://@modelcontextprotocol/server-brave-search@1.0.2",
+  "env_vars": [{
+    "name": "BRAVE_API_KEY",
+    "description": "Brave Search API Key",
+    "required": true,
+    "secret": true
+  }]
+}
+```
+
+### Example 2: Remote Server Conversion
+
+**Upstream Format**:
+```json
+{
+  "server": {
+    "name": "Remote Filesystem Server",
+    "description": "Cloud-hosted MCP filesystem server",
+    "remotes": [{
+      "transport_type": "sse",
+      "url": "https://mcp-fs.example.com/sse",
+      "headers": [{
+        "name": "X-API-Key",
+        "description": "API key for authentication",
+        "is_required": true,
+        "is_secret": true
+      }]
+    }]
+  }
+}
+```
+
+**ToolHive Format**:
+```json
+{
+  "name": "Remote Filesystem Server",
+  "description": "Cloud-hosted MCP filesystem server",
+  "tier": "Community",
+  "status": "active",
+  "transport": "sse",
+  "url": "https://mcp-fs.example.com/sse",
+  "headers": [{
+    "name": "X-API-Key",
+    "description": "API key for authentication",
+    "required": true,
+    "secret": true
+  }]
+}
+```
+
+## Integration Points
+
+### 1. Registry Loading
+
+Extend existing registry loading to support upstream format:
+
+```go
+// pkg/registry/loader.go
+func LoadUpstreamServer(path string) (*UpstreamServerDetail, error)
+func LoadAndConvertUpstream(path string) (ServerMetadata, error)
+```
+
+### 2. CLI Commands
+
+Add support for upstream format in existing commands:
+
+```bash
+# Import upstream server definition
+thv registry import server.json
+
+# Export ToolHive server to upstream format
+thv registry export --format=upstream server-name
+
+# Validate upstream format
+thv registry validate server.json
+```
+
+### 3. Registry Management
+
+Enhance registry operations to handle both formats:
+
+```go
+// pkg/registry/manager.go
+func (m *Manager) ImportUpstream(path string) error
+func (m *Manager) ExportUpstream(serverName, outputPath string) error
+```
+
+## Testing Strategy
+
+### 1. Unit Tests (`pkg/registry/upstream_conversion_test.go`)
+
+Comprehensive test coverage for:
+- **Conversion accuracy**: Verify data preservation in both directions
+- **Package type handling**: Test npm, pypi, docker, unknown packages
+- **Server type detection**: Remote vs container server classification
+- **Error handling**: Invalid inputs, missing fields, malformed data
+- **Edge cases**: Empty packages, multiple remotes, complex arguments
+
+### 2. Integration Tests
+
+- **Round-trip conversion**: Upstream → ToolHive → Upstream
+- **Real server definitions**: Test with actual community server.json files
+- **CLI integration**: Import/export commands with various formats
+- **Registry operations**: Loading and managing mixed format registries
+
+### 3. Compatibility Tests
+
+- **Upstream schema validation**: Ensure generated upstream format is valid
+- **ToolHive functionality**: Verify converted servers work with existing features
+- **Protocol scheme execution**: Test npm/pypi package execution
+
+## Security Considerations
+
+### 1. Input Validation
+
+- **Schema validation**: Validate upstream format against JSON schema
+- **Package name validation**: Prevent malicious package references
+- **URL validation**: Validate remote server URLs and headers
+- **Path sanitization**: Ensure safe file paths in package arguments
+
+### 2. Extension Field Security
+
+- **Trusted sources**: Only process ToolHive extensions from trusted publishers
+- **Permission validation**: Validate permission profiles in extensions
+- **Metadata sanitization**: Sanitize custom metadata fields
+
+### 3. Conversion Safety
+
+- **Data preservation**: Ensure no sensitive data leaks during conversion
+- **Default security**: Apply secure defaults for missing security fields
+- **Audit logging**: Log conversion operations for security auditing
+
+## Migration Strategy
+
+### Phase 1: Core Implementation
+- Implement upstream format structs and conversion functions
+- Add comprehensive test coverage
+- Create basic CLI import/export commands
+
+### Phase 2: Integration
+- Integrate with existing registry loading
+- Add validation and error handling
+- Enhance CLI commands with format detection
+
+### Phase 3: Ecosystem Support
+- Add support for community registry URLs
+- Implement automatic format detection
+- Create migration tools for existing servers
+
+### Phase 4: Advanced Features
+- Bidirectional synchronization with upstream registries
+- Advanced validation and linting
+- Community contribution workflows
+
+## Success Metrics
+
+1. **Conversion Accuracy**: 100% round-trip conversion for supported features
+2. **Format Coverage**: Support for 95% of upstream format features
+3. **Performance**: Conversion operations complete in <100ms
+4. **Compatibility**: Converted servers execute successfully in ToolHive
+5. **Community Adoption**: Enable contribution to upstream registries
+
+## Alternatives Considered
+
+### 1. Replace ToolHive Format Entirely
+**Rejected**: Would break existing deployments and lose ToolHive-specific features like permission profiles and container optimization.
+
+### 2. Separate Registry for Upstream Format
+**Rejected**: Would fragment the ecosystem and require users to manage multiple registries.
+
+### 3. Custom Extension Mechanism
+**Rejected**: The `x-publisher` field provides a standard way to extend upstream format without breaking compatibility.
+
+### 4. Automatic Format Detection
+**Considered**: Could be added in future phases, but explicit conversion provides better control and error handling.
+
+## Future Enhancements
+
+1. **Registry Synchronization**: Automatic sync with upstream community registries
+2. **Format Migration Tools**: Bulk conversion utilities for existing registries
+3. **Validation Enhancements**: Advanced linting and compatibility checking
+4. **Community Integration**: Direct publishing to upstream registries
+5. **Schema Evolution**: Support for future upstream format versions
+
+## Conclusion
+
+Adding upstream MCP registry format support to ToolHive enables:
+
+- **Ecosystem Interoperability**: Share server definitions with other MCP tools
+- **Community Participation**: Contribute to and benefit from community registries
+- **Developer Experience**: Single source of truth for server metadata
+- **Future Compatibility**: Prepare for ecosystem standardization
+
+The implementation leverages ToolHive's extension mechanism to preserve advanced features while maintaining compatibility with the community standard. This positions ToolHive as both a powerful container execution platform and a good citizen in the broader MCP ecosystem.

--- a/docs/proposals/upstream-mcp-registry-format-support.md
+++ b/docs/proposals/upstream-mcp-registry-format-support.md
@@ -113,7 +113,7 @@ func ConvertUpstreamToToolhive(upstream *UpstreamServerDetail) (ServerMetadata, 
 - Servers with `packages` → `ImageMetadata`
 
 **Metadata Extraction**:
-- ToolHive extensions from `x-publisher.build_info.toolhive`
+- ToolHive extensions from `x-publisher.x-dev.toolhive`
 - Default values for missing ToolHive-specific fields
 - Conversion of upstream enums to ToolHive values
 
@@ -129,7 +129,7 @@ func ConvertToolhiveToUpstream(server ServerMetadata) (*UpstreamServerDetail, er
 - Environment variables → Package environment variables
 
 **Extension Population**:
-- ToolHive-specific metadata → `x-publisher.build_info.toolhive`
+- ToolHive-specific metadata → `x-publisher.x-dev.toolhive`
 - Standard upstream fields from ToolHive metadata
 - Publisher information for provenance
 

--- a/pkg/registry/upstream.go
+++ b/pkg/registry/upstream.go
@@ -1,0 +1,195 @@
+// Package registry provides access to the MCP server registry
+package registry
+
+// UpstreamServerDetail represents the upstream MCP server format as defined in the community registry
+// This follows the schema at https://modelcontextprotocol.io/schemas/draft/2025-07-09/server.json
+type UpstreamServerDetail struct {
+	// Server contains the core server information
+	Server UpstreamServer `json:"server" yaml:"server"`
+	// XPublisher contains optional publisher metadata (extension field)
+	XPublisher *UpstreamPublisher `json:"x-publisher,omitempty" yaml:"x-publisher,omitempty"`
+}
+
+// UpstreamServer represents the core server information in the upstream format
+type UpstreamServer struct {
+	// Name is the server name/identifier (e.g., "io.modelcontextprotocol/filesystem")
+	Name string `json:"name" yaml:"name"`
+	// Description is a human-readable description of the server's functionality
+	Description string `json:"description" yaml:"description"`
+	// Status indicates the server lifecycle status
+	Status UpstreamServerStatus `json:"status,omitempty" yaml:"status,omitempty"`
+	// Repository contains repository information
+	Repository *UpstreamRepository `json:"repository,omitempty" yaml:"repository,omitempty"`
+	// VersionDetail contains version information
+	VersionDetail UpstreamVersionDetail `json:"version_detail" yaml:"version_detail"`
+	// Packages contains package installation options
+	Packages []UpstreamPackage `json:"packages,omitempty" yaml:"packages,omitempty"`
+	// Remotes contains remote server connection options
+	Remotes []UpstreamRemote `json:"remotes,omitempty" yaml:"remotes,omitempty"`
+}
+
+// UpstreamServerStatus represents the server lifecycle status
+type UpstreamServerStatus string
+
+const (
+	// UpstreamServerStatusActive indicates the server is actively maintained
+	UpstreamServerStatusActive UpstreamServerStatus = "active"
+	// UpstreamServerStatusDeprecated indicates the server is deprecated
+	UpstreamServerStatusDeprecated UpstreamServerStatus = "deprecated"
+)
+
+// UpstreamRepository contains repository information
+type UpstreamRepository struct {
+	// URL is the repository URL
+	URL string `json:"url" yaml:"url"`
+	// Source is the repository hosting service (e.g., "github")
+	Source string `json:"source" yaml:"source"`
+	// ID is an optional repository identifier
+	ID string `json:"id,omitempty" yaml:"id,omitempty"`
+}
+
+// UpstreamVersionDetail contains version information
+type UpstreamVersionDetail struct {
+	// Version is the server version (equivalent to Implementation.version in MCP spec)
+	Version string `json:"version" yaml:"version"`
+}
+
+// UpstreamPackage represents a package installation option
+type UpstreamPackage struct {
+	// RegistryName is the package registry type (e.g., "npm", "pypi", "docker", "nuget")
+	RegistryName string `json:"registry_name" yaml:"registry_name"`
+	// Name is the package name in the registry
+	Name string `json:"name" yaml:"name"`
+	// Version is the package version
+	Version string `json:"version" yaml:"version"`
+	// RuntimeHint provides a hint for the appropriate runtime (e.g., "npx", "uvx", "dnx")
+	RuntimeHint string `json:"runtime_hint,omitempty" yaml:"runtime_hint,omitempty"`
+	// RuntimeArguments are arguments passed to the package's runtime command
+	RuntimeArguments []UpstreamArgument `json:"runtime_arguments,omitempty" yaml:"runtime_arguments,omitempty"`
+	// PackageArguments are arguments passed to the package's binary
+	PackageArguments []UpstreamArgument `json:"package_arguments,omitempty" yaml:"package_arguments,omitempty"`
+	// EnvironmentVariables are environment variables for the package
+	EnvironmentVariables []UpstreamKeyValueInput `json:"environment_variables,omitempty" yaml:"environment_variables,omitempty"`
+}
+
+// UpstreamRemote represents a remote server connection option
+type UpstreamRemote struct {
+	// TransportType is the transport protocol type
+	TransportType UpstreamTransportType `json:"transport_type" yaml:"transport_type"`
+	// URL is the remote server URL
+	URL string `json:"url" yaml:"url"`
+	// Headers are HTTP headers to include
+	Headers []UpstreamKeyValueInput `json:"headers,omitempty" yaml:"headers,omitempty"`
+}
+
+// UpstreamTransportType represents the transport protocol type
+type UpstreamTransportType string
+
+const (
+	// UpstreamTransportTypeStreamable represents streamable HTTP transport
+	UpstreamTransportTypeStreamable UpstreamTransportType = "streamable"
+	// UpstreamTransportTypeSSE represents Server-Sent Events transport
+	UpstreamTransportTypeSSE UpstreamTransportType = "sse"
+)
+
+// UpstreamArgument represents a command-line argument
+type UpstreamArgument struct {
+	// Type is the argument type
+	Type UpstreamArgumentType `json:"type" yaml:"type"`
+	// Name is the flag name for named arguments (including leading dashes)
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+	// ValueHint is an identifier-like hint for positional arguments
+	ValueHint string `json:"value_hint,omitempty" yaml:"value_hint,omitempty"`
+	// Description describes the argument's purpose
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+	// IsRequired indicates if the argument is required
+	IsRequired bool `json:"is_required,omitempty" yaml:"is_required,omitempty"`
+	// IsRepeated indicates if the argument can be repeated
+	IsRepeated bool `json:"is_repeated,omitempty" yaml:"is_repeated,omitempty"`
+	// Format specifies the input format
+	Format UpstreamInputFormat `json:"format,omitempty" yaml:"format,omitempty"`
+	// Value is the default or fixed value
+	Value string `json:"value,omitempty" yaml:"value,omitempty"`
+	// IsSecret indicates if the value is sensitive
+	IsSecret bool `json:"is_secret,omitempty" yaml:"is_secret,omitempty"`
+	// Default is the default value
+	Default string `json:"default,omitempty" yaml:"default,omitempty"`
+	// Choices are valid values for the argument
+	Choices []string `json:"choices,omitempty" yaml:"choices,omitempty"`
+	// Variables are variable substitutions for the value
+	Variables map[string]UpstreamInput `json:"variables,omitempty" yaml:"variables,omitempty"`
+}
+
+// UpstreamArgumentType represents the type of command-line argument
+type UpstreamArgumentType string
+
+const (
+	// UpstreamArgumentTypePositional represents a positional argument
+	UpstreamArgumentTypePositional UpstreamArgumentType = "positional"
+	// UpstreamArgumentTypeNamed represents a named argument (flag)
+	UpstreamArgumentTypeNamed UpstreamArgumentType = "named"
+)
+
+// UpstreamKeyValueInput represents a key-value input (environment variable or header)
+type UpstreamKeyValueInput struct {
+	// Name is the variable or header name
+	Name string `json:"name" yaml:"name"`
+	// Description describes the input's purpose
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+	// IsRequired indicates if the input is required
+	IsRequired bool `json:"is_required,omitempty" yaml:"is_required,omitempty"`
+	// Format specifies the input format
+	Format UpstreamInputFormat `json:"format,omitempty" yaml:"format,omitempty"`
+	// Value is the default or fixed value
+	Value string `json:"value,omitempty" yaml:"value,omitempty"`
+	// IsSecret indicates if the value is sensitive
+	IsSecret bool `json:"is_secret,omitempty" yaml:"is_secret,omitempty"`
+	// Default is the default value
+	Default string `json:"default,omitempty" yaml:"default,omitempty"`
+	// Choices are valid values for the input
+	Choices []string `json:"choices,omitempty" yaml:"choices,omitempty"`
+	// Variables are variable substitutions for the value
+	Variables map[string]UpstreamInput `json:"variables,omitempty" yaml:"variables,omitempty"`
+}
+
+// UpstreamInput represents a generic input with validation and formatting
+type UpstreamInput struct {
+	// Description describes the input's purpose
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+	// IsRequired indicates if the input is required
+	IsRequired bool `json:"is_required,omitempty" yaml:"is_required,omitempty"`
+	// Format specifies the input format
+	Format UpstreamInputFormat `json:"format,omitempty" yaml:"format,omitempty"`
+	// Value is the default or fixed value
+	Value string `json:"value,omitempty" yaml:"value,omitempty"`
+	// IsSecret indicates if the value is sensitive
+	IsSecret bool `json:"is_secret,omitempty" yaml:"is_secret,omitempty"`
+	// Default is the default value
+	Default string `json:"default,omitempty" yaml:"default,omitempty"`
+	// Choices are valid values for the input
+	Choices []string `json:"choices,omitempty" yaml:"choices,omitempty"`
+}
+
+// UpstreamInputFormat represents the format of an input value
+type UpstreamInputFormat string
+
+const (
+	// UpstreamInputFormatString represents a string input
+	UpstreamInputFormatString UpstreamInputFormat = "string"
+	// UpstreamInputFormatNumber represents a numeric input
+	UpstreamInputFormatNumber UpstreamInputFormat = "number"
+	// UpstreamInputFormatBoolean represents a boolean input
+	UpstreamInputFormatBoolean UpstreamInputFormat = "boolean"
+	// UpstreamInputFormatFilepath represents a file path input
+	UpstreamInputFormatFilepath UpstreamInputFormat = "filepath"
+)
+
+// UpstreamPublisher contains optional publisher metadata (extension field)
+type UpstreamPublisher struct {
+	// Tool is the name of the publishing tool
+	Tool string `json:"tool,omitempty" yaml:"tool,omitempty"`
+	// Version is the version of the publishing tool
+	Version string `json:"version,omitempty" yaml:"version,omitempty"`
+	// BuildInfo contains additional build metadata
+	BuildInfo map[string]any `json:"build_info,omitempty" yaml:"build_info,omitempty"`
+}

--- a/pkg/registry/upstream.go
+++ b/pkg/registry/upstream.go
@@ -186,10 +186,6 @@ const (
 
 // UpstreamPublisher contains optional publisher metadata (extension field)
 type UpstreamPublisher struct {
-	// Tool is the name of the publishing tool
-	Tool string `json:"tool,omitempty" yaml:"tool,omitempty"`
-	// Version is the version of the publishing tool
-	Version string `json:"version,omitempty" yaml:"version,omitempty"`
-	// BuildInfo contains additional build metadata
-	BuildInfo map[string]any `json:"build_info,omitempty" yaml:"build_info,omitempty"`
+	// XDevToolhive contains ToolHive-specific extension data
+	XDevToolhive *ToolhivePublisherExtension `json:"x-dev.toolhive,omitempty" yaml:"x-dev.toolhive,omitempty"`
 }

--- a/pkg/registry/upstream_conversion.go
+++ b/pkg/registry/upstream_conversion.go
@@ -1,0 +1,516 @@
+package registry
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/stacklok/toolhive/pkg/permissions"
+)
+
+// ToolhivePublisherExtension contains toolhive-specific metadata in the x-publisher field
+type ToolhivePublisherExtension struct {
+	// Tier represents the tier classification level of the server
+	Tier string `json:"tier,omitempty" yaml:"tier,omitempty"`
+	// Transport defines the communication protocol for the server
+	Transport string `json:"transport,omitempty" yaml:"transport,omitempty"`
+	// Tools is a list of tool names provided by this MCP server
+	Tools []string `json:"tools,omitempty" yaml:"tools,omitempty"`
+	// Metadata contains additional information about the server
+	Metadata *Metadata `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+	// Tags are categorization labels for the server
+	Tags []string `json:"tags,omitempty" yaml:"tags,omitempty"`
+	// CustomMetadata allows for additional user-defined metadata
+	CustomMetadata map[string]any `json:"custom_metadata,omitempty" yaml:"custom_metadata,omitempty"`
+	// Permissions defines the security profile and access permissions for the server
+	Permissions *permissions.Profile `json:"permissions,omitempty" yaml:"permissions,omitempty"`
+	// TargetPort is the port for the container to expose (only applicable to SSE and Streamable HTTP transports)
+	TargetPort int `json:"target_port,omitempty" yaml:"target_port,omitempty"`
+	// DockerTags lists the available Docker tags for this server image
+	DockerTags []string `json:"docker_tags,omitempty" yaml:"docker_tags,omitempty"`
+	// Provenance contains verification and signing metadata
+	Provenance *Provenance `json:"provenance,omitempty" yaml:"provenance,omitempty"`
+}
+
+// ConvertUpstreamToToolhive converts an upstream server detail to toolhive format
+func ConvertUpstreamToToolhive(upstream *UpstreamServerDetail) (ServerMetadata, error) {
+	if upstream == nil {
+		return nil, fmt.Errorf("upstream server detail is nil")
+	}
+
+	// Extract toolhive-specific metadata from x-publisher field
+	var toolhiveExt *ToolhivePublisherExtension
+	if upstream.XPublisher != nil && upstream.XPublisher.BuildInfo != nil {
+		if toolhiveData, ok := upstream.XPublisher.BuildInfo["toolhive"]; ok {
+			if toolhiveMap, ok := toolhiveData.(map[string]any); ok {
+				toolhiveExt = parseToolhiveExtension(toolhiveMap)
+			}
+		}
+	}
+
+	// Determine if this is a remote server or container server
+	if len(upstream.Server.Remotes) > 0 {
+		return convertToRemoteServer(upstream, toolhiveExt), nil
+	}
+
+	return convertToImageMetadata(upstream, toolhiveExt)
+}
+
+// convertToRemoteServer converts upstream format to RemoteServerMetadata
+func convertToRemoteServer(upstream *UpstreamServerDetail, toolhiveExt *ToolhivePublisherExtension) *RemoteServerMetadata {
+	remote := &RemoteServerMetadata{
+		BaseServerMetadata: BaseServerMetadata{
+			Name:          upstream.Server.Name,
+			Description:   upstream.Server.Description,
+			Tier:          getStringOrDefault(toolhiveExt, func(t *ToolhivePublisherExtension) string { return t.Tier }, "Community"),
+			Status:        convertStatus(upstream.Server.Status),
+			Transport:     convertTransport(upstream.Server.Remotes[0].TransportType),
+			Tools:         getSliceOrDefault(toolhiveExt, func(t *ToolhivePublisherExtension) []string { return t.Tools }, []string{}),
+			Metadata:      getMetadataOrDefault(toolhiveExt),
+			RepositoryURL: getRepositoryURL(upstream.Server.Repository),
+			Tags:          getSliceOrDefault(toolhiveExt, func(t *ToolhivePublisherExtension) []string { return t.Tags }, []string{}),
+			CustomMetadata: getMapOrDefault(toolhiveExt,
+				func(t *ToolhivePublisherExtension) map[string]any { return t.CustomMetadata }, nil),
+		},
+		URL:     upstream.Server.Remotes[0].URL,
+		Headers: convertHeaders(upstream.Server.Remotes[0].Headers),
+		EnvVars: convertEnvironmentVariables(getPackageEnvVars(upstream.Server.Packages)),
+	}
+
+	// Override transport if specified in toolhive extension
+	if toolhiveExt != nil && toolhiveExt.Transport != "" {
+		remote.Transport = toolhiveExt.Transport
+	}
+
+	return remote
+}
+
+// convertToImageMetadata converts upstream format to ImageMetadata
+func convertToImageMetadata(upstream *UpstreamServerDetail, toolhiveExt *ToolhivePublisherExtension) (*ImageMetadata, error) {
+	if len(upstream.Server.Packages) == 0 {
+		return nil, fmt.Errorf("no packages found for container server")
+	}
+
+	// Find the primary package (prefer Docker, then others)
+	var primaryPackage *UpstreamPackage
+	for i := range upstream.Server.Packages {
+		pkg := &upstream.Server.Packages[i]
+		if pkg.RegistryName == "docker" {
+			primaryPackage = pkg
+			break
+		}
+		if primaryPackage == nil {
+			primaryPackage = pkg
+		}
+	}
+
+	image := &ImageMetadata{
+		BaseServerMetadata: BaseServerMetadata{
+			Name:          upstream.Server.Name,
+			Description:   upstream.Server.Description,
+			Tier:          getStringOrDefault(toolhiveExt, func(t *ToolhivePublisherExtension) string { return t.Tier }, "Community"),
+			Status:        convertStatus(upstream.Server.Status),
+			Transport:     getStringOrDefault(toolhiveExt, func(t *ToolhivePublisherExtension) string { return t.Transport }, "stdio"),
+			Tools:         getSliceOrDefault(toolhiveExt, func(t *ToolhivePublisherExtension) []string { return t.Tools }, []string{}),
+			Metadata:      getMetadataOrDefault(toolhiveExt),
+			RepositoryURL: getRepositoryURL(upstream.Server.Repository),
+			Tags:          getSliceOrDefault(toolhiveExt, func(t *ToolhivePublisherExtension) []string { return t.Tags }, []string{}),
+			CustomMetadata: getMapOrDefault(toolhiveExt,
+				func(t *ToolhivePublisherExtension) map[string]any { return t.CustomMetadata }, nil),
+		},
+		Image:       formatImageName(primaryPackage),
+		TargetPort:  getIntOrDefault(toolhiveExt, func(t *ToolhivePublisherExtension) int { return t.TargetPort }, 0),
+		Permissions: getPermissionsOrDefault(toolhiveExt),
+		EnvVars:     convertEnvironmentVariables(primaryPackage.EnvironmentVariables),
+		Args:        convertPackageArguments(primaryPackage.PackageArguments),
+		DockerTags:  getSliceOrDefault(toolhiveExt, func(t *ToolhivePublisherExtension) []string { return t.DockerTags }, []string{}),
+		Provenance:  getProvenanceOrDefault(toolhiveExt),
+	}
+
+	return image, nil
+}
+
+// ConvertToolhiveToUpstream converts toolhive format to upstream format
+func ConvertToolhiveToUpstream(server ServerMetadata) (*UpstreamServerDetail, error) {
+	if server == nil {
+		return nil, fmt.Errorf("server metadata is nil")
+	}
+
+	upstream := &UpstreamServerDetail{
+		Server: UpstreamServer{
+			Name:        server.GetName(),
+			Description: server.GetDescription(),
+			Status:      convertStatusToUpstream(server.GetStatus()),
+			VersionDetail: UpstreamVersionDetail{
+				Version: "1.0.0", // Default version, could be extracted from metadata
+			},
+		},
+	}
+
+	// Set repository if available
+	if repoURL := server.GetRepositoryURL(); repoURL != "" {
+		upstream.Server.Repository = &UpstreamRepository{
+			URL:    repoURL,
+			Source: extractSourceFromURL(repoURL),
+		}
+	}
+
+	// Create toolhive extension for x-publisher
+	toolhiveExt := &ToolhivePublisherExtension{
+		Tier:           server.GetTier(),
+		Transport:      server.GetTransport(),
+		Tools:          server.GetTools(),
+		Metadata:       server.GetMetadata(),
+		Tags:           server.GetTags(),
+		CustomMetadata: server.GetCustomMetadata(),
+	}
+
+	if server.IsRemote() {
+		if remoteServer, ok := server.(*RemoteServerMetadata); ok {
+			upstream.Server.Remotes = []UpstreamRemote{
+				{
+					TransportType: convertTransportToUpstream(remoteServer.Transport),
+					URL:           remoteServer.URL,
+					Headers:       convertHeadersToUpstream(remoteServer.Headers),
+				},
+			}
+			upstream.Server.Packages = convertEnvVarsToPackages(remoteServer.EnvVars)
+		}
+	} else {
+		if imageServer, ok := server.(*ImageMetadata); ok {
+			toolhiveExt.TargetPort = imageServer.TargetPort
+			toolhiveExt.Permissions = imageServer.Permissions
+			toolhiveExt.DockerTags = imageServer.DockerTags
+			toolhiveExt.Provenance = imageServer.Provenance
+
+			upstream.Server.Packages = []UpstreamPackage{
+				{
+					RegistryName:         "docker",
+					Name:                 extractImageName(imageServer.Image),
+					Version:              extractImageTag(imageServer.Image),
+					PackageArguments:     convertArgsToUpstream(imageServer.Args),
+					EnvironmentVariables: convertEnvVarsToUpstream(imageServer.EnvVars),
+				},
+			}
+		}
+	}
+
+	// Add toolhive extension to x-publisher
+	upstream.XPublisher = &UpstreamPublisher{
+		Tool:    "toolhive",
+		Version: "1.0.0",
+		BuildInfo: map[string]any{
+			"toolhive":  toolhiveExt,
+			"timestamp": time.Now().Format(time.RFC3339),
+		},
+	}
+
+	return upstream, nil
+}
+
+// Helper functions for conversion
+
+func parseToolhiveExtension(data map[string]any) *ToolhivePublisherExtension {
+	ext := &ToolhivePublisherExtension{}
+
+	if tier, ok := data["tier"].(string); ok {
+		ext.Tier = tier
+	}
+	if transport, ok := data["transport"].(string); ok {
+		ext.Transport = transport
+	}
+	if tools, ok := data["tools"].([]any); ok {
+		ext.Tools = convertInterfaceSliceToStringSlice(tools)
+	}
+	if tags, ok := data["tags"].([]any); ok {
+		ext.Tags = convertInterfaceSliceToStringSlice(tags)
+	}
+	if customMetadata, ok := data["custom_metadata"].(map[string]any); ok {
+		ext.CustomMetadata = customMetadata
+	}
+	if targetPort, ok := data["target_port"].(float64); ok {
+		ext.TargetPort = int(targetPort)
+	}
+	if dockerTags, ok := data["docker_tags"].([]any); ok {
+		ext.DockerTags = convertInterfaceSliceToStringSlice(dockerTags)
+	}
+
+	return ext
+}
+
+func convertInterfaceSliceToStringSlice(slice []any) []string {
+	result := make([]string, 0, len(slice))
+	for _, item := range slice {
+		if str, ok := item.(string); ok {
+			result = append(result, str)
+		}
+	}
+	return result
+}
+
+func convertStatus(status UpstreamServerStatus) string {
+	switch status {
+	case UpstreamServerStatusActive:
+		return "active"
+	case UpstreamServerStatusDeprecated:
+		return "deprecated"
+	default:
+		return "active"
+	}
+}
+
+func convertStatusToUpstream(status string) UpstreamServerStatus {
+	switch status {
+	case "deprecated":
+		return UpstreamServerStatusDeprecated
+	default:
+		return UpstreamServerStatusActive
+	}
+}
+
+func convertTransport(transportType UpstreamTransportType) string {
+	switch transportType {
+	case UpstreamTransportTypeSSE:
+		return "sse"
+	case UpstreamTransportTypeStreamable:
+		return "streamable-http"
+	default:
+		return "stdio"
+	}
+}
+
+func convertTransportToUpstream(transport string) UpstreamTransportType {
+	switch transport {
+	case "sse":
+		return UpstreamTransportTypeSSE
+	case "streamable-http":
+		return UpstreamTransportTypeStreamable
+	default:
+		return UpstreamTransportTypeSSE // Default for remote
+	}
+}
+
+func convertHeaders(headers []UpstreamKeyValueInput) []*Header {
+	result := make([]*Header, 0, len(headers))
+	for _, h := range headers {
+		result = append(result, &Header{
+			Name:        h.Name,
+			Description: h.Description,
+			Required:    h.IsRequired,
+			Default:     h.Default,
+			Secret:      h.IsSecret,
+			Choices:     h.Choices,
+		})
+	}
+	return result
+}
+
+func convertHeadersToUpstream(headers []*Header) []UpstreamKeyValueInput {
+	result := make([]UpstreamKeyValueInput, 0, len(headers))
+	for _, h := range headers {
+		result = append(result, UpstreamKeyValueInput{
+			Name:        h.Name,
+			Description: h.Description,
+			IsRequired:  h.Required,
+			Default:     h.Default,
+			IsSecret:    h.Secret,
+			Choices:     h.Choices,
+		})
+	}
+	return result
+}
+
+func convertEnvironmentVariables(envVars []UpstreamKeyValueInput) []*EnvVar {
+	result := make([]*EnvVar, 0, len(envVars))
+	for _, ev := range envVars {
+		result = append(result, &EnvVar{
+			Name:        ev.Name,
+			Description: ev.Description,
+			Required:    ev.IsRequired,
+			Default:     ev.Default,
+			Secret:      ev.IsSecret,
+		})
+	}
+	return result
+}
+
+func convertEnvVarsToUpstream(envVars []*EnvVar) []UpstreamKeyValueInput {
+	result := make([]UpstreamKeyValueInput, 0, len(envVars))
+	for _, ev := range envVars {
+		result = append(result, UpstreamKeyValueInput{
+			Name:        ev.Name,
+			Description: ev.Description,
+			IsRequired:  ev.Required,
+			Default:     ev.Default,
+			IsSecret:    ev.Secret,
+		})
+	}
+	return result
+}
+
+func convertPackageArguments(args []UpstreamArgument) []string {
+	result := make([]string, 0, len(args))
+	for _, arg := range args {
+		switch arg.Type {
+		case UpstreamArgumentTypePositional:
+			if arg.Value != "" {
+				result = append(result, arg.Value)
+			} else if arg.ValueHint != "" {
+				result = append(result, arg.ValueHint)
+			}
+		case UpstreamArgumentTypeNamed:
+			if arg.Value != "" {
+				result = append(result, arg.Name, arg.Value)
+			} else if arg.Default != "" {
+				result = append(result, arg.Name, arg.Default)
+			}
+		}
+	}
+	return result
+}
+
+func convertArgsToUpstream(args []string) []UpstreamArgument {
+	result := make([]UpstreamArgument, 0, len(args))
+	for _, arg := range args {
+		result = append(result, UpstreamArgument{
+			Type:  UpstreamArgumentTypePositional,
+			Value: arg,
+		})
+	}
+	return result
+}
+
+func formatImageName(pkg *UpstreamPackage) string {
+	switch pkg.RegistryName {
+	case "docker":
+		return fmt.Sprintf("%s:%s", pkg.Name, pkg.Version)
+	case "npm":
+		// For npm packages, use the npx:// protocol scheme that toolhive supports
+		return fmt.Sprintf("npx://%s@%s", pkg.Name, pkg.Version)
+	case "pypi":
+		// For Python packages, use the uvx:// protocol scheme that toolhive supports
+		return fmt.Sprintf("uvx://%s@%s", pkg.Name, pkg.Version)
+	default:
+		// For unknown registries, return the package name as-is
+		// This might need manual handling or could be a direct image reference
+		return pkg.Name
+	}
+}
+
+func extractImageName(image string) string {
+	parts := strings.Split(image, ":")
+	return parts[0]
+}
+
+func extractImageTag(image string) string {
+	parts := strings.Split(image, ":")
+	if len(parts) > 1 {
+		return parts[1]
+	}
+	return "latest"
+}
+
+func getRepositoryURL(repo *UpstreamRepository) string {
+	if repo != nil {
+		return repo.URL
+	}
+	return ""
+}
+
+func extractSourceFromURL(url string) string {
+	if strings.Contains(url, "github.com") {
+		return "github"
+	}
+	if strings.Contains(url, "gitlab.com") {
+		return "gitlab"
+	}
+	return "unknown"
+}
+
+func getPackageEnvVars(packages []UpstreamPackage) []UpstreamKeyValueInput {
+	for _, pkg := range packages {
+		if len(pkg.EnvironmentVariables) > 0 {
+			return pkg.EnvironmentVariables
+		}
+	}
+	return nil
+}
+
+func convertEnvVarsToPackages(envVars []*EnvVar) []UpstreamPackage {
+	if len(envVars) == 0 {
+		return nil
+	}
+
+	upstreamEnvVars := convertEnvVarsToUpstream(envVars)
+	return []UpstreamPackage{
+		{
+			RegistryName:         "remote",
+			Name:                 "remote-server",
+			Version:              "1.0.0",
+			EnvironmentVariables: upstreamEnvVars,
+		},
+	}
+}
+
+// Helper functions for extracting values with defaults
+
+func getStringOrDefault[T any](ext *T, getter func(*T) string, defaultValue string) string {
+	if ext != nil {
+		if value := getter(ext); value != "" {
+			return value
+		}
+	}
+	return defaultValue
+}
+
+func getSliceOrDefault[T any](ext *T, getter func(*T) []string, defaultValue []string) []string {
+	if ext != nil {
+		if value := getter(ext); len(value) > 0 {
+			return value
+		}
+	}
+	return defaultValue
+}
+
+func getMapOrDefault[T any](ext *T, getter func(*T) map[string]any, defaultValue map[string]any) map[string]any {
+	if ext != nil {
+		if value := getter(ext); len(value) > 0 {
+			return value
+		}
+	}
+	return defaultValue
+}
+
+func getIntOrDefault[T any](ext *T, getter func(*T) int, defaultValue int) int {
+	if ext != nil {
+		if value := getter(ext); value != 0 {
+			return value
+		}
+	}
+	return defaultValue
+}
+
+func getMetadataOrDefault(ext *ToolhivePublisherExtension) *Metadata {
+	if ext != nil && ext.Metadata != nil {
+		return ext.Metadata
+	}
+	return &Metadata{
+		Stars:       0,
+		Pulls:       0,
+		LastUpdated: time.Now().Format(time.RFC3339),
+	}
+}
+
+func getPermissionsOrDefault(ext *ToolhivePublisherExtension) *permissions.Profile {
+	if ext != nil && ext.Permissions != nil {
+		return ext.Permissions
+	}
+	return nil
+}
+
+func getProvenanceOrDefault(ext *ToolhivePublisherExtension) *Provenance {
+	if ext != nil && ext.Provenance != nil {
+		return ext.Provenance
+	}
+	return nil
+}

--- a/pkg/registry/upstream_conversion_test.go
+++ b/pkg/registry/upstream_conversion_test.go
@@ -1,0 +1,545 @@
+package registry
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stacklok/toolhive/pkg/permissions"
+)
+
+func TestConvertUpstreamToToolhive_DockerPackage(t *testing.T) {
+	t.Parallel()
+	upstream := &UpstreamServerDetail{
+		Server: UpstreamServer{
+			Name:        "io.modelcontextprotocol/filesystem",
+			Description: "Node.js server implementing Model Context Protocol (MCP) for filesystem operations.",
+			Status:      UpstreamServerStatusActive,
+			Repository: &UpstreamRepository{
+				URL:    "https://github.com/modelcontextprotocol/servers",
+				Source: "github",
+				ID:     "b94b5f7e-c7c6-d760-2c78-a5e9b8a5b8c9",
+			},
+			VersionDetail: UpstreamVersionDetail{
+				Version: "1.0.2",
+			},
+			Packages: []UpstreamPackage{
+				{
+					RegistryName: "docker",
+					Name:         "mcp/filesystem",
+					Version:      "1.0.2",
+					PackageArguments: []UpstreamArgument{
+						{
+							Type:      UpstreamArgumentTypePositional,
+							ValueHint: "target_dir",
+							Value:     "/project",
+						},
+					},
+					EnvironmentVariables: []UpstreamKeyValueInput{
+						{
+							Name:        "LOG_LEVEL",
+							Description: "Logging level (debug, info, warn, error)",
+							Default:     "info",
+						},
+					},
+				},
+			},
+		},
+		XPublisher: &UpstreamPublisher{
+			Tool:    "toolhive",
+			Version: "1.0.0",
+			BuildInfo: map[string]any{
+				"toolhive": map[string]any{
+					"tier":      "Official",
+					"transport": "stdio",
+					"tools":     []any{"read_file", "write_file", "list_directory"},
+					"tags":      []any{"filesystem", "files"},
+				},
+			},
+		},
+	}
+
+	result, err := ConvertUpstreamToToolhive(upstream)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	imageMetadata, ok := result.(*ImageMetadata)
+	require.True(t, ok, "Expected ImageMetadata")
+
+	assert.Equal(t, "io.modelcontextprotocol/filesystem", imageMetadata.GetName())
+	assert.Equal(t, "Node.js server implementing Model Context Protocol (MCP) for filesystem operations.", imageMetadata.GetDescription())
+	assert.Equal(t, "Official", imageMetadata.GetTier())
+	assert.Equal(t, "active", imageMetadata.GetStatus())
+	assert.Equal(t, "stdio", imageMetadata.GetTransport())
+	assert.Equal(t, "mcp/filesystem:1.0.2", imageMetadata.Image)
+	assert.Equal(t, []string{"read_file", "write_file", "list_directory"}, imageMetadata.GetTools())
+	assert.Equal(t, []string{"filesystem", "files"}, imageMetadata.GetTags())
+	assert.Equal(t, "https://github.com/modelcontextprotocol/servers", imageMetadata.GetRepositoryURL())
+	assert.False(t, imageMetadata.IsRemote())
+
+	// Check environment variables
+	require.Len(t, imageMetadata.EnvVars, 1)
+	assert.Equal(t, "LOG_LEVEL", imageMetadata.EnvVars[0].Name)
+	assert.Equal(t, "Logging level (debug, info, warn, error)", imageMetadata.EnvVars[0].Description)
+	assert.Equal(t, "info", imageMetadata.EnvVars[0].Default)
+	assert.False(t, imageMetadata.EnvVars[0].Required)
+
+	// Check arguments
+	require.Len(t, imageMetadata.Args, 1)
+	assert.Equal(t, "/project", imageMetadata.Args[0])
+}
+
+func TestConvertUpstreamToToolhive_NPMPackage(t *testing.T) {
+	t.Parallel()
+	upstream := &UpstreamServerDetail{
+		Server: UpstreamServer{
+			Name:        "io.modelcontextprotocol/brave-search",
+			Description: "MCP server for Brave Search API integration",
+			Status:      UpstreamServerStatusActive,
+			Repository: &UpstreamRepository{
+				URL:    "https://github.com/modelcontextprotocol/servers",
+				Source: "github",
+			},
+			VersionDetail: UpstreamVersionDetail{
+				Version: "1.0.2",
+			},
+			Packages: []UpstreamPackage{
+				{
+					RegistryName: "npm",
+					Name:         "@modelcontextprotocol/server-brave-search",
+					Version:      "1.0.2",
+					EnvironmentVariables: []UpstreamKeyValueInput{
+						{
+							Name:        "BRAVE_API_KEY",
+							Description: "Brave Search API Key",
+							IsRequired:  true,
+							IsSecret:    true,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	result, err := ConvertUpstreamToToolhive(upstream)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	imageMetadata, ok := result.(*ImageMetadata)
+	require.True(t, ok, "Expected ImageMetadata")
+
+	assert.Equal(t, "io.modelcontextprotocol/brave-search", imageMetadata.GetName())
+	assert.Equal(t, "MCP server for Brave Search API integration", imageMetadata.GetDescription())
+	assert.Equal(t, "Community", imageMetadata.GetTier()) // Default value
+	assert.Equal(t, "active", imageMetadata.GetStatus())
+	assert.Equal(t, "stdio", imageMetadata.GetTransport())                                        // Default value
+	assert.Equal(t, "npx://@modelcontextprotocol/server-brave-search@1.0.2", imageMetadata.Image) // NPM package as protocol scheme
+
+	// Check environment variables
+	require.Len(t, imageMetadata.EnvVars, 1)
+	assert.Equal(t, "BRAVE_API_KEY", imageMetadata.EnvVars[0].Name)
+	assert.Equal(t, "Brave Search API Key", imageMetadata.EnvVars[0].Description)
+	assert.True(t, imageMetadata.EnvVars[0].Required)
+	assert.True(t, imageMetadata.EnvVars[0].Secret)
+}
+
+func TestConvertUpstreamToToolhive_RemoteServer(t *testing.T) {
+	t.Parallel()
+	upstream := &UpstreamServerDetail{
+		Server: UpstreamServer{
+			Name:        "Remote Filesystem Server",
+			Description: "Cloud-hosted MCP filesystem server",
+			Repository: &UpstreamRepository{
+				URL:    "https://github.com/example/remote-fs",
+				Source: "github",
+				ID:     "xyz789ab-cdef-0123-4567-890ghijklmno",
+			},
+			VersionDetail: UpstreamVersionDetail{
+				Version: "2.0.0",
+			},
+			Remotes: []UpstreamRemote{
+				{
+					TransportType: UpstreamTransportTypeSSE,
+					URL:           "https://mcp-fs.example.com/sse",
+					Headers: []UpstreamKeyValueInput{
+						{
+							Name:        "X-API-Key",
+							Description: "API key for authentication",
+							IsRequired:  true,
+							IsSecret:    true,
+						},
+					},
+				},
+			},
+		},
+		XPublisher: &UpstreamPublisher{
+			Tool:    "toolhive",
+			Version: "1.0.0",
+			BuildInfo: map[string]any{
+				"toolhive": map[string]any{
+					"tier":      "Community",
+					"transport": "sse",
+					"tools":     []any{"remote_read", "remote_write"},
+				},
+			},
+		},
+	}
+
+	result, err := ConvertUpstreamToToolhive(upstream)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	remoteMetadata, ok := result.(*RemoteServerMetadata)
+	require.True(t, ok, "Expected RemoteServerMetadata")
+
+	assert.Equal(t, "Remote Filesystem Server", remoteMetadata.GetName())
+	assert.Equal(t, "Cloud-hosted MCP filesystem server", remoteMetadata.GetDescription())
+	assert.Equal(t, "Community", remoteMetadata.GetTier())
+	assert.Equal(t, "active", remoteMetadata.GetStatus())
+	assert.Equal(t, "sse", remoteMetadata.GetTransport())
+	assert.Equal(t, "https://mcp-fs.example.com/sse", remoteMetadata.URL)
+	assert.Equal(t, []string{"remote_read", "remote_write"}, remoteMetadata.GetTools())
+	assert.Equal(t, "https://github.com/example/remote-fs", remoteMetadata.GetRepositoryURL())
+	assert.True(t, remoteMetadata.IsRemote())
+
+	// Check headers
+	require.Len(t, remoteMetadata.Headers, 1)
+	assert.Equal(t, "X-API-Key", remoteMetadata.Headers[0].Name)
+	assert.Equal(t, "API key for authentication", remoteMetadata.Headers[0].Description)
+	assert.True(t, remoteMetadata.Headers[0].Required)
+	assert.True(t, remoteMetadata.Headers[0].Secret)
+}
+
+func TestConvertToolhiveToUpstream_ImageMetadata(t *testing.T) {
+	t.Parallel()
+	imageMetadata := &ImageMetadata{
+		BaseServerMetadata: BaseServerMetadata{
+			Name:          "test-server",
+			Description:   "Test MCP server",
+			Tier:          "Official",
+			Status:        "active",
+			Transport:     "stdio",
+			Tools:         []string{"test_tool1", "test_tool2"},
+			RepositoryURL: "https://github.com/example/test-server",
+			Tags:          []string{"test", "example"},
+			CustomMetadata: map[string]any{
+				"custom_field": "custom_value",
+			},
+		},
+		Image:      "test/server:1.0.0",
+		TargetPort: 8080,
+		Permissions: &permissions.Profile{
+			Network: &permissions.NetworkPermissions{
+				Outbound: &permissions.OutboundNetworkPermissions{
+					AllowHost: []string{"example.com"},
+				},
+			},
+		},
+		EnvVars: []*EnvVar{
+			{
+				Name:        "TEST_VAR",
+				Description: "Test environment variable",
+				Required:    true,
+				Secret:      false,
+			},
+		},
+		Args:       []string{"--config", "/app/config.json"},
+		DockerTags: []string{"1.0.0", "latest"},
+	}
+
+	result, err := ConvertToolhiveToUpstream(imageMetadata)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	assert.Equal(t, "test-server", result.Server.Name)
+	assert.Equal(t, "Test MCP server", result.Server.Description)
+	assert.Equal(t, UpstreamServerStatusActive, result.Server.Status)
+	assert.Equal(t, "1.0.0", result.Server.VersionDetail.Version)
+
+	// Check repository
+	require.NotNil(t, result.Server.Repository)
+	assert.Equal(t, "https://github.com/example/test-server", result.Server.Repository.URL)
+	assert.Equal(t, "github", result.Server.Repository.Source)
+
+	// Check packages
+	require.Len(t, result.Server.Packages, 1)
+	pkg := result.Server.Packages[0]
+	assert.Equal(t, "docker", pkg.RegistryName)
+	assert.Equal(t, "test/server", pkg.Name)
+	assert.Equal(t, "1.0.0", pkg.Version)
+
+	// Check package arguments
+	require.Len(t, pkg.PackageArguments, 2)
+	assert.Equal(t, UpstreamArgumentTypePositional, pkg.PackageArguments[0].Type)
+	assert.Equal(t, "--config", pkg.PackageArguments[0].Value)
+	assert.Equal(t, UpstreamArgumentTypePositional, pkg.PackageArguments[1].Type)
+	assert.Equal(t, "/app/config.json", pkg.PackageArguments[1].Value)
+
+	// Check environment variables
+	require.Len(t, pkg.EnvironmentVariables, 1)
+	envVar := pkg.EnvironmentVariables[0]
+	assert.Equal(t, "TEST_VAR", envVar.Name)
+	assert.Equal(t, "Test environment variable", envVar.Description)
+	assert.True(t, envVar.IsRequired)
+	assert.False(t, envVar.IsSecret)
+
+	// Check x-publisher
+	require.NotNil(t, result.XPublisher)
+	assert.Equal(t, "toolhive", result.XPublisher.Tool)
+	assert.Equal(t, "1.0.0", result.XPublisher.Version)
+
+	// Check toolhive extension in build_info
+	require.NotNil(t, result.XPublisher.BuildInfo)
+	toolhiveData, ok := result.XPublisher.BuildInfo["toolhive"]
+	require.True(t, ok)
+
+	toolhiveExt, ok := toolhiveData.(*ToolhivePublisherExtension)
+	require.True(t, ok)
+	assert.Equal(t, "Official", toolhiveExt.Tier)
+	assert.Equal(t, "stdio", toolhiveExt.Transport)
+	assert.Equal(t, []string{"test_tool1", "test_tool2"}, toolhiveExt.Tools)
+	assert.Equal(t, []string{"test", "example"}, toolhiveExt.Tags)
+	assert.Equal(t, 8080, toolhiveExt.TargetPort)
+	assert.Equal(t, []string{"1.0.0", "latest"}, toolhiveExt.DockerTags)
+	assert.NotNil(t, toolhiveExt.Permissions)
+}
+
+func TestConvertUpstreamToToolhive_NilInput(t *testing.T) {
+	t.Parallel()
+	result, err := ConvertUpstreamToToolhive(nil)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "upstream server detail is nil")
+}
+
+func TestConvertToolhiveToUpstream_NilInput(t *testing.T) {
+	t.Parallel()
+	result, err := ConvertToolhiveToUpstream(nil)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "server metadata is nil")
+}
+
+func TestConvertUpstreamToToolhive_NoPackagesOrRemotes(t *testing.T) {
+	t.Parallel()
+	upstream := &UpstreamServerDetail{
+		Server: UpstreamServer{
+			Name:        "empty-server",
+			Description: "Server with no packages or remotes",
+			VersionDetail: UpstreamVersionDetail{
+				Version: "1.0.0",
+			},
+		},
+	}
+
+	result, err := ConvertUpstreamToToolhive(upstream)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "no packages found for container server")
+}
+
+func TestConvertStatus(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		input    UpstreamServerStatus
+		expected string
+	}{
+		{UpstreamServerStatusActive, "active"},
+		{UpstreamServerStatusDeprecated, "deprecated"},
+		{"", "active"}, // Default case
+	}
+
+	for _, test := range tests {
+		result := convertStatus(test.input)
+		assert.Equal(t, test.expected, result)
+	}
+}
+
+func TestConvertTransport(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		input    UpstreamTransportType
+		expected string
+	}{
+		{UpstreamTransportTypeSSE, "sse"},
+		{UpstreamTransportTypeStreamable, "streamable-http"},
+		{"", "stdio"}, // Default case
+	}
+
+	for _, test := range tests {
+		result := convertTransport(test.input)
+		assert.Equal(t, test.expected, result)
+	}
+}
+
+func TestFormatImageName(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		pkg      *UpstreamPackage
+		expected string
+	}{
+		{
+			name: "Docker package",
+			pkg: &UpstreamPackage{
+				RegistryName: "docker",
+				Name:         "nginx",
+				Version:      "latest",
+			},
+			expected: "nginx:latest",
+		},
+		{
+			name: "NPM package",
+			pkg: &UpstreamPackage{
+				RegistryName: "npm",
+				Name:         "@modelcontextprotocol/server-filesystem",
+				Version:      "1.0.2",
+			},
+			expected: "npx://@modelcontextprotocol/server-filesystem@1.0.2",
+		},
+		{
+			name: "Python package",
+			pkg: &UpstreamPackage{
+				RegistryName: "pypi",
+				Name:         "weather-mcp-server",
+				Version:      "0.5.0",
+			},
+			expected: "uvx://weather-mcp-server@0.5.0",
+		},
+		{
+			name: "Unknown registry",
+			pkg: &UpstreamPackage{
+				RegistryName: "unknown",
+				Name:         "some-package",
+				Version:      "1.0.0",
+			},
+			expected: "some-package",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			result := formatImageName(test.pkg)
+			assert.Equal(t, test.expected, result)
+		})
+	}
+}
+
+func TestExtractImageName(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"nginx:latest", "nginx"},
+		{"registry.example.com/myapp:v1.0.0", "registry.example.com/myapp"},
+		{"simple-name", "simple-name"},
+	}
+
+	for _, test := range tests {
+		result := extractImageName(test.input)
+		assert.Equal(t, test.expected, result)
+	}
+}
+
+func TestExtractImageTag(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"nginx:latest", "latest"},
+		{"registry.example.com/myapp:v1.0.0", "v1.0.0"},
+		{"simple-name", "latest"},
+	}
+
+	for _, test := range tests {
+		result := extractImageTag(test.input)
+		assert.Equal(t, test.expected, result)
+	}
+}
+
+func TestExtractSourceFromURL(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"https://github.com/example/repo", "github"},
+		{"https://gitlab.com/example/repo", "gitlab"},
+		{"https://bitbucket.org/example/repo", "unknown"},
+		{"https://example.com/repo", "unknown"},
+	}
+
+	for _, test := range tests {
+		result := extractSourceFromURL(test.input)
+		assert.Equal(t, test.expected, result)
+	}
+}
+
+func TestConvertUpstreamToToolhive_PythonPackage(t *testing.T) {
+	t.Parallel()
+	upstream := &UpstreamServerDetail{
+		Server: UpstreamServer{
+			Name:        "weather-mcp-server",
+			Description: "Python MCP server for weather data access",
+			Repository: &UpstreamRepository{
+				URL:    "https://github.com/example/weather-mcp",
+				Source: "github",
+			},
+			VersionDetail: UpstreamVersionDetail{
+				Version: "0.5.0",
+			},
+			Packages: []UpstreamPackage{
+				{
+					RegistryName: "pypi",
+					Name:         "weather-mcp-server",
+					Version:      "0.5.0",
+					RuntimeHint:  "uvx",
+					EnvironmentVariables: []UpstreamKeyValueInput{
+						{
+							Name:        "WEATHER_API_KEY",
+							Description: "API key for weather service",
+							IsRequired:  true,
+							IsSecret:    true,
+						},
+						{
+							Name:        "WEATHER_UNITS",
+							Description: "Temperature units (celsius, fahrenheit)",
+							Default:     "celsius",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	result, err := ConvertUpstreamToToolhive(upstream)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	imageMetadata, ok := result.(*ImageMetadata)
+	require.True(t, ok, "Expected ImageMetadata")
+
+	assert.Equal(t, "weather-mcp-server", imageMetadata.GetName())
+	assert.Equal(t, "Python MCP server for weather data access", imageMetadata.GetDescription())
+	assert.Equal(t, "uvx://weather-mcp-server@0.5.0", imageMetadata.Image)
+
+	// Check environment variables
+	require.Len(t, imageMetadata.EnvVars, 2)
+
+	// First env var
+	assert.Equal(t, "WEATHER_API_KEY", imageMetadata.EnvVars[0].Name)
+	assert.Equal(t, "API key for weather service", imageMetadata.EnvVars[0].Description)
+	assert.True(t, imageMetadata.EnvVars[0].Required)
+	assert.True(t, imageMetadata.EnvVars[0].Secret)
+
+	// Second env var
+	assert.Equal(t, "WEATHER_UNITS", imageMetadata.EnvVars[1].Name)
+	assert.Equal(t, "Temperature units (celsius, fahrenheit)", imageMetadata.EnvVars[1].Description)
+	assert.False(t, imageMetadata.EnvVars[1].Required)
+	assert.False(t, imageMetadata.EnvVars[1].Secret)
+	assert.Equal(t, "celsius", imageMetadata.EnvVars[1].Default)
+}

--- a/pkg/registry/upstream_conversion_test.go
+++ b/pkg/registry/upstream_conversion_test.go
@@ -47,15 +47,11 @@ func TestConvertUpstreamToToolhive_DockerPackage(t *testing.T) {
 			},
 		},
 		XPublisher: &UpstreamPublisher{
-			Tool:    "toolhive",
-			Version: "1.0.0",
-			BuildInfo: map[string]any{
-				"toolhive": map[string]any{
-					"tier":      "Official",
-					"transport": "stdio",
-					"tools":     []any{"read_file", "write_file", "list_directory"},
-					"tags":      []any{"filesystem", "files"},
-				},
+			XDevToolhive: &ToolhivePublisherExtension{
+				Tier:      "Official",
+				Transport: "stdio",
+				Tools:     []string{"read_file", "write_file", "list_directory"},
+				Tags:      []string{"filesystem", "files"},
 			},
 		},
 	}
@@ -174,14 +170,10 @@ func TestConvertUpstreamToToolhive_RemoteServer(t *testing.T) {
 			},
 		},
 		XPublisher: &UpstreamPublisher{
-			Tool:    "toolhive",
-			Version: "1.0.0",
-			BuildInfo: map[string]any{
-				"toolhive": map[string]any{
-					"tier":      "Community",
-					"transport": "sse",
-					"tools":     []any{"remote_read", "remote_write"},
-				},
+			XDevToolhive: &ToolhivePublisherExtension{
+				Tier:      "Community",
+				Transport: "sse",
+				Tools:     []string{"remote_read", "remote_write"},
 			},
 		},
 	}
@@ -286,16 +278,10 @@ func TestConvertToolhiveToUpstream_ImageMetadata(t *testing.T) {
 
 	// Check x-publisher
 	require.NotNil(t, result.XPublisher)
-	assert.Equal(t, "toolhive", result.XPublisher.Tool)
-	assert.Equal(t, "1.0.0", result.XPublisher.Version)
 
-	// Check toolhive extension in build_info
-	require.NotNil(t, result.XPublisher.BuildInfo)
-	toolhiveData, ok := result.XPublisher.BuildInfo["toolhive"]
-	require.True(t, ok)
-
-	toolhiveExt, ok := toolhiveData.(*ToolhivePublisherExtension)
-	require.True(t, ok)
+	// Check toolhive extension
+	require.NotNil(t, result.XPublisher.XDevToolhive)
+	toolhiveExt := result.XPublisher.XDevToolhive
 	assert.Equal(t, "Official", toolhiveExt.Tier)
 	assert.Equal(t, "stdio", toolhiveExt.Transport)
 	assert.Equal(t, []string{"test_tool1", "test_tool2"}, toolhiveExt.Tools)


### PR DESCRIPTION
## Problem

ToolHive currently uses its own registry format, which creates barriers for ecosystem interoperability. The MCP community has developed a standardized \`server.json\` format that other tools use, but ToolHive cannot consume or produce this format.

## Solution

This PR adds bidirectional conversion between ToolHive's registry format and the upstream MCP community format. This enables ToolHive to participate in the broader MCP ecosystem while preserving its advanced container-focused features.

## Key Changes

### New Go Packages
- **\`pkg/registry/upstream.go\`**: Structs matching the upstream \`server.json\` schema
- **\`pkg/registry/upstream_conversion.go\`**: Conversion functions in both directions
- **\`pkg/registry/upstream_conversion_test.go\`**: Comprehensive test coverage

### Format Mapping Strategy

**Upstream → ToolHive:**
- \`docker\` packages → Direct image references (\`nginx:latest\`)
- \`npm\` packages → NPX protocol schemes (\`npx://package@version\`)
- \`pypi\` packages → UVX protocol schemes (\`uvx://package@version\`)
- \`remotes\` → \`RemoteServerMetadata\`

**ToolHive → Upstream:**
- Container servers → \`docker\` packages
- Protocol schemes → Appropriate registry packages
- ToolHive-specific metadata → \`x-publisher.build_info.toolhive\` extension

### Extension Mechanism

ToolHive's advanced features (permissions, tiers, provenance) are preserved using the \`x-publisher\` extension field, following community conventions for vendor-specific metadata.

## Design Decisions

1. **Bidirectional conversion**: Enables both consuming upstream formats and contributing back to community registries
2. **Extension-based approach**: Preserves ToolHive features without breaking upstream compatibility
3. **Protocol scheme mapping**: Leverages ToolHive's existing \`npx://\`/\`uvx://\` support for non-Docker packages
4. **Zero breaking changes**: Existing ToolHive registry format remains unchanged

## Review Focus Areas

- **Conversion accuracy**: Check the mapping logic in \`upstream_conversion.go\`
- **Extension design**: Review the \`ToolhivePublisherExtension\` struct for completeness
- **Error handling**: Verify graceful handling of malformed or incomplete upstream data
- **Test coverage**: Ensure edge cases are covered in the test suite

## Future Work

This foundation enables future features like:
- CLI commands for importing/exporting upstream formats
- Automatic synchronization with community registries
- Validation tools for upstream format compliance

See \`docs/proposals/upstream-mcp-registry-format-support.md\` for detailed technical design.