### PR TITLE
Hardcode TOOLHIVE_RUNTIME=kubernetes in operator proxy deployments

### DIFF
--- a/cmd/thv-operator/controllers/mcpserver_controller.go
+++ b/cmd/thv-operator/controllers/mcpserver_controller.go
@@ -672,16 +672,20 @@ func (r *MCPServerReconciler) deploymentForMCPServer(m *mcpv1alpha1.MCPServer) *
 }
 
 func ensureRequiredEnvVars(env []corev1.EnvVar) []corev1.EnvVar {
-	// Check for the existence of the XDG_CONFIG_HOME and HOME environment variables
-	// and set them to /tmp if they don't exist
+	// Check for the existence of the XDG_CONFIG_HOME, HOME, and TOOLHIVE_RUNTIME environment variables
+	// and set them to defaults if they don't exist
 	xdgConfigHomeFound := false
 	homeFound := false
+	toolhiveRuntimeFound := false
 	for _, envVar := range env {
 		if envVar.Name == "XDG_CONFIG_HOME" {
 			xdgConfigHomeFound = true
 		}
 		if envVar.Name == "HOME" {
 			homeFound = true
+		}
+		if envVar.Name == "TOOLHIVE_RUNTIME" {
+			toolhiveRuntimeFound = true
 		}
 	}
 	if !xdgConfigHomeFound {
@@ -696,6 +700,13 @@ func ensureRequiredEnvVars(env []corev1.EnvVar) []corev1.EnvVar {
 		env = append(env, corev1.EnvVar{
 			Name:  "HOME",
 			Value: "/tmp",
+		})
+	}
+	if !toolhiveRuntimeFound {
+		logger.Debugf("TOOLHIVE_RUNTIME not found, setting to kubernetes")
+		env = append(env, corev1.EnvVar{
+			Name:  "TOOLHIVE_RUNTIME",
+			Value: "kubernetes",
 		})
 	}
 	return env

--- a/cmd/thv-operator/controllers/mcpserver_resource_overrides_test.go
+++ b/cmd/thv-operator/controllers/mcpserver_resource_overrides_test.go
@@ -288,18 +288,20 @@ func TestResourceOverrides(t *testing.T) {
 				var expectedEnvVars map[string]string
 				if tt.name == "with proxy environment variables" {
 					expectedEnvVars = map[string]string{
-						"HTTP_PROXY":      "http://proxy.example.com:8080",
-						"NO_PROXY":        "localhost,127.0.0.1",
-						"CUSTOM_ENV":      "custom-value",
-						"XDG_CONFIG_HOME": "/tmp",
-						"HOME":            "/tmp",
+						"HTTP_PROXY":       "http://proxy.example.com:8080",
+						"NO_PROXY":         "localhost,127.0.0.1",
+						"CUSTOM_ENV":       "custom-value",
+						"XDG_CONFIG_HOME":  "/tmp",
+						"HOME":             "/tmp",
+						"TOOLHIVE_RUNTIME": "kubernetes",
 					}
 				} else {
 					expectedEnvVars = map[string]string{
-						"LOG_LEVEL":       "debug",
-						"METRICS_ENABLED": "true",
-						"XDG_CONFIG_HOME": "/tmp",
-						"HOME":            "/tmp",
+						"LOG_LEVEL":        "debug",
+						"METRICS_ENABLED":  "true",
+						"XDG_CONFIG_HOME":  "/tmp",
+						"HOME":             "/tmp",
+						"TOOLHIVE_RUNTIME": "kubernetes",
 					}
 				}
 


### PR DESCRIPTION
## Summary

This PR implements the requirement to hardcode the operator to deploy the proxy runner with `TOOLHIVE_RUNTIME=kubernetes`.

## Changes

- **Modified `ensureRequiredEnvVars` function**: Added logic to automatically set `TOOLHIVE_RUNTIME=kubernetes` environment variable for all proxy runner deployments created by the operator
- **Updated test expectations**: Modified test cases to include the new environment variable in expected results
- **Follows existing patterns**: Uses the same approach as other required environment variables like `HOME` and `XDG_CONFIG_HOME`

## How it works

The operator now automatically adds the `TOOLHIVE_RUNTIME=kubernetes` environment variable to every proxy runner deployment it creates. This happens in the `ensureRequiredEnvVars` function during deployment creation. The environment variable is only added if it's not already present, allowing for potential future customization while ensuring the default behavior sets it to "kubernetes".

## Testing

- ✅ All existing tests pass
- ✅ Linting passes with 0 issues  
- ✅ Updated test expectations to verify the new environment variable is set correctly

## Related

This change builds on the `TOOLHIVE_RUNTIME` environment variable introduced in PR #1525, ensuring that all operator-deployed proxy runners have consistent runtime configuration.