### PR TITLE
Fix list command output formats for empty MCP server lists

### DIFF
--- a/cmd/thv/app/list.go
+++ b/cmd/thv/app/list.go
@@ -59,15 +59,6 @@ func listCmdFunc(cmd *cobra.Command, _ []string) error {
 		}
 	}
 
-	if len(workloadList) == 0 {
-		if listGroupFilter != "" {
-			fmt.Printf("No MCP servers found in group '%s'\n", listGroupFilter)
-		} else {
-			fmt.Println("No MCP servers found")
-		}
-		return nil
-	}
-
 	// Output based on format
 	switch listFormat {
 	case FormatJSON:
@@ -75,6 +66,15 @@ func listCmdFunc(cmd *cobra.Command, _ []string) error {
 	case "mcpservers":
 		return printMCPServersOutput(workloadList)
 	default:
+		// For text format, handle empty list with a message
+		if len(workloadList) == 0 {
+			if listGroupFilter != "" {
+				fmt.Printf("No MCP servers found in group '%s'\n", listGroupFilter)
+			} else {
+				fmt.Println("No MCP servers found")
+			}
+			return nil
+		}
 		printTextOutput(workloadList)
 		return nil
 	}
@@ -82,6 +82,11 @@ func listCmdFunc(cmd *cobra.Command, _ []string) error {
 
 // printJSONOutput prints workload information in JSON format
 func printJSONOutput(workloadList []core.Workload) error {
+	// Ensure we have a non-nil slice to avoid null in JSON output
+	if workloadList == nil {
+		workloadList = []core.Workload{}
+	}
+
 	// Marshal to JSON
 	jsonData, err := json.MarshalIndent(workloadList, "", "  ")
 	if err != nil {


### PR DESCRIPTION
## Problem

The `thv list --format mcpservers` command was returning the text message "No MCP servers found" instead of the expected empty JSON structure when no MCP servers were running.

Additionally, `thv list --format json` was returning `null` instead of an empty array `[]` for empty lists.

## Solution

This PR fixes the output formatting for all three formats when the MCP server list is empty:

### Changes Made

1. **Fixed mcpservers format**: Now returns `{"mcpServers": {}}` instead of text message
2. **Fixed JSON format**: Now returns `[]` instead of `null` for empty lists  
3. **Preserved text format**: Still shows "No MCP servers found" message as expected
4. **Added nil slice check**: Ensures proper JSON formatting in `printJSONOutput`

### Technical Details

- Moved format-specific logic before the empty list check in `listCmdFunc`
- Only the text format now handles empty lists with a user-friendly message
- JSON and mcpservers formats now properly handle empty lists through their respective functions
- Added nil slice check in `printJSONOutput` to prevent `null` output

### Testing

✅ **Text format**: `thv list` → "No MCP servers found"  
✅ **JSON format**: `thv list --format json` → `[]`  
✅ **mcpservers format**: `thv list --format mcpservers` → `{"mcpServers": {}}`  
✅ **All linting checks pass**  
✅ **Backward compatibility maintained**

## Verification

Tested with no running MCP servers:

```bash
# Text format (unchanged behavior)
$ thv list
No MCP servers found

# JSON format (fixed: now returns empty array)
$ thv list --format json
[]

# mcpservers format (fixed: now returns empty JSON object)
$ thv list --format mcpservers
{
  "mcpServers": {}
}
```

This ensures consistent JSON output for programmatic consumption while preserving the user-friendly text message for interactive use.