### PR TITLE
Fix race conditions and improve stability in HTTPSSEProxy

### DIFF
--- a/pkg/transport/proxy/httpsse/http_proxy_integration_test.go
+++ b/pkg/transport/proxy/httpsse/http_proxy_integration_test.go
@@ -1,0 +1,398 @@
+package httpsse
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/jsonrpc2"
+
+	"github.com/stacklok/toolhive/pkg/logger"
+)
+
+func init() {
+	logger.Initialize()
+}
+
+// TestIntegrationSSEProxyStressTest simulates the scenario from issue #1572
+// where multiple clients connect, disconnect, and reconnect frequently
+func TestIntegrationSSEProxyStressTest(t *testing.T) {
+	t.Parallel()
+
+	// Create proxy with a random port
+	proxy := NewHTTPSSEProxy("localhost", 0, "test-container", nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Start the proxy
+	err := proxy.Start(ctx)
+	require.NoError(t, err)
+	defer func() {
+		stopCtx, stopCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer stopCancel()
+		_ = proxy.Stop(stopCtx)
+	}()
+
+	// Get the actual port
+	proxyURL := fmt.Sprintf("http://%s", proxy.server.Addr)
+	t.Logf("Proxy started at %s", proxyURL)
+
+	// Track statistics
+	var (
+		totalConnections    int32
+		totalDisconnections int32
+		totalMessages       int32
+		totalErrors         int32
+	)
+
+	// Create a worker that processes messages from the proxy
+	go func() {
+		for msg := range proxy.GetMessageChannel() {
+			// Echo the message back to clients
+			_ = proxy.ForwardResponseToClients(ctx, msg)
+			atomic.AddInt32(&totalMessages, 1)
+		}
+	}()
+
+	// Number of concurrent clients and duration
+	numClients := 10
+	testDuration := 5 * time.Second
+	messagesPerClient := 5
+
+	// WaitGroup for all clients
+	var wg sync.WaitGroup
+
+	// Start multiple clients that connect and disconnect
+	for i := 0; i < numClients; i++ {
+		wg.Add(1)
+		go func(clientNum int) {
+			defer wg.Done()
+
+			startTime := time.Now()
+			reconnectCount := 0
+
+			for time.Since(startTime) < testDuration {
+				reconnectCount++
+				atomic.AddInt32(&totalConnections, 1)
+
+				// Connect to SSE endpoint
+				sseResp, err := http.Get(proxyURL + "/sse")
+				if err != nil {
+					atomic.AddInt32(&totalErrors, 1)
+					t.Logf("Client %d: Failed to connect: %v", clientNum, err)
+					time.Sleep(100 * time.Millisecond)
+					continue
+				}
+
+				// Extract session ID from the endpoint event
+				sessionID, err := extractSessionID(sseResp.Body)
+				if err != nil {
+					atomic.AddInt32(&totalErrors, 1)
+					t.Logf("Client %d: Failed to extract session ID: %v", clientNum, err)
+					sseResp.Body.Close()
+					time.Sleep(100 * time.Millisecond)
+					continue
+				}
+
+				// Send some messages
+				for j := 0; j < messagesPerClient; j++ {
+					msg, _ := jsonrpc2.NewCall(
+						jsonrpc2.StringID(fmt.Sprintf("client%d-msg%d", clientNum, j)),
+						"test.method",
+						map[string]interface{}{"data": fmt.Sprintf("test data %d", j)},
+					)
+					msgBytes, _ := jsonrpc2.EncodeMessage(msg)
+
+					postResp, err := http.Post(
+						fmt.Sprintf("%s/messages?session_id=%s", proxyURL, sessionID),
+						"application/json",
+						bytes.NewReader(msgBytes),
+					)
+					if err != nil {
+						atomic.AddInt32(&totalErrors, 1)
+						t.Logf("Client %d: Failed to send message: %v", clientNum, err)
+						break
+					}
+					postResp.Body.Close()
+
+					// Small delay between messages
+					time.Sleep(10 * time.Millisecond)
+				}
+
+				// Close the SSE connection
+				sseResp.Body.Close()
+				atomic.AddInt32(&totalDisconnections, 1)
+
+				// Random delay before reconnecting (simulating real client behavior)
+				time.Sleep(time.Duration(100+clientNum*10) * time.Millisecond)
+			}
+
+			t.Logf("Client %d: Completed with %d reconnections", clientNum, reconnectCount)
+		}(i)
+	}
+
+	// Wait for all clients to complete
+	wg.Wait()
+
+	// Give some time for final messages to be processed
+	time.Sleep(500 * time.Millisecond)
+
+	// Log statistics
+	t.Logf("Test Statistics:")
+	t.Logf("  Total Connections: %d", atomic.LoadInt32(&totalConnections))
+	t.Logf("  Total Disconnections: %d", atomic.LoadInt32(&totalDisconnections))
+	t.Logf("  Total Messages Processed: %d", atomic.LoadInt32(&totalMessages))
+	t.Logf("  Total Errors: %d", atomic.LoadInt32(&totalErrors))
+
+	// Verify no panics occurred and proxy is still functional
+	assert.NotNil(t, proxy.server)
+
+	// Verify we can still connect after the stress test
+	finalResp, err := http.Get(proxyURL + "/sse")
+	assert.NoError(t, err)
+	if finalResp != nil {
+		finalResp.Body.Close()
+	}
+
+	// Check that we processed a reasonable number of messages
+	assert.Greater(t, atomic.LoadInt32(&totalMessages), int32(0), "Should have processed some messages")
+
+	// Check that errors are within acceptable limits (less than 10% of connections)
+	errorRate := float64(atomic.LoadInt32(&totalErrors)) / float64(atomic.LoadInt32(&totalConnections))
+	assert.Less(t, errorRate, 0.1, "Error rate should be less than 10%")
+}
+
+// TestIntegrationConcurrentClientsWithLongRunning tests a mix of short-lived and long-running clients
+func TestIntegrationConcurrentClientsWithLongRunning(t *testing.T) {
+	t.Parallel()
+
+	// Create and start proxy
+	proxy := NewHTTPSSEProxy("localhost", 0, "test-container", nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err := proxy.Start(ctx)
+	require.NoError(t, err)
+	defer func() {
+		stopCtx, stopCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer stopCancel()
+		_ = proxy.Stop(stopCtx)
+	}()
+
+	proxyURL := fmt.Sprintf("http://%s", proxy.server.Addr)
+
+	// Message processor
+	go func() {
+		for msg := range proxy.GetMessageChannel() {
+			// Echo messages back
+			_ = proxy.ForwardResponseToClients(ctx, msg)
+		}
+	}()
+
+	var wg sync.WaitGroup
+
+	// Start long-running clients
+	numLongRunning := 3
+	for i := 0; i < numLongRunning; i++ {
+		wg.Add(1)
+		go func(clientNum int) {
+			defer wg.Done()
+
+			// Connect and stay connected
+			resp, err := http.Get(proxyURL + "/sse")
+			if err != nil {
+				t.Logf("Long-running client %d: Failed to connect: %v", clientNum, err)
+				return
+			}
+			defer resp.Body.Close()
+
+			sessionID, err := extractSessionID(resp.Body)
+			if err != nil {
+				t.Logf("Long-running client %d: Failed to get session ID: %v", clientNum, err)
+				return
+			}
+
+			// Send periodic messages
+			ticker := time.NewTicker(500 * time.Millisecond)
+			defer ticker.Stop()
+
+			timeout := time.After(3 * time.Second)
+			msgCount := 0
+
+			for {
+				select {
+				case <-ticker.C:
+					msg, _ := jsonrpc2.NewCall(
+						jsonrpc2.StringID(fmt.Sprintf("long%d-msg%d", clientNum, msgCount)),
+						"ping",
+						nil,
+					)
+					msgBytes, _ := jsonrpc2.EncodeMessage(msg)
+
+					postResp, err := http.Post(
+						fmt.Sprintf("%s/messages?session_id=%s", proxyURL, sessionID),
+						"application/json",
+						bytes.NewReader(msgBytes),
+					)
+					if err != nil {
+						t.Logf("Long-running client %d: Failed to send message: %v", clientNum, err)
+						return
+					}
+					postResp.Body.Close()
+					msgCount++
+
+				case <-timeout:
+					t.Logf("Long-running client %d: Sent %d messages", clientNum, msgCount)
+					return
+				}
+			}
+		}(i)
+	}
+
+	// Start short-lived clients that connect and disconnect frequently
+	numShortLived := 20
+	for i := 0; i < numShortLived; i++ {
+		wg.Add(1)
+		go func(clientNum int) {
+			defer wg.Done()
+
+			// Quick connect, send message, disconnect
+			resp, err := http.Get(proxyURL + "/sse")
+			if err != nil {
+				t.Logf("Short-lived client %d: Failed to connect: %v", clientNum, err)
+				return
+			}
+
+			sessionID, err := extractSessionID(resp.Body)
+			resp.Body.Close() // Close immediately after getting session ID
+
+			if err != nil {
+				t.Logf("Short-lived client %d: Failed to get session ID: %v", clientNum, err)
+				return
+			}
+
+			// Send a single message
+			msg, _ := jsonrpc2.NewCall(
+				jsonrpc2.StringID(fmt.Sprintf("short%d", clientNum)),
+				"test",
+				nil,
+			)
+			msgBytes, _ := jsonrpc2.EncodeMessage(msg)
+
+			postResp, err := http.Post(
+				fmt.Sprintf("%s/messages?session_id=%s", proxyURL, sessionID),
+				"application/json",
+				bytes.NewReader(msgBytes),
+			)
+			if err != nil {
+				t.Logf("Short-lived client %d: Failed to send message: %v", clientNum, err)
+				return
+			}
+			postResp.Body.Close()
+
+			// Small random delay
+			time.Sleep(time.Duration(50+clientNum*5) * time.Millisecond)
+		}(i)
+	}
+
+	// Wait for all clients
+	wg.Wait()
+
+	// Verify proxy is still healthy
+	assert.NotNil(t, proxy.server)
+
+	// Check we can still connect
+	finalResp, err := http.Get(proxyURL + "/sse")
+	assert.NoError(t, err)
+	if finalResp != nil {
+		finalResp.Body.Close()
+	}
+}
+
+// TestIntegrationMemoryLeakPrevention tests that the closedClients map doesn't grow unbounded
+func TestIntegrationMemoryLeakPrevention(t *testing.T) {
+	t.Parallel()
+	proxy := NewHTTPSSEProxy("localhost", 0, "test-container", nil)
+	ctx := context.Background()
+
+	err := proxy.Start(ctx)
+	require.NoError(t, err)
+	defer func() {
+		stopCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = proxy.Stop(stopCtx)
+	}()
+
+	proxyURL := fmt.Sprintf("http://%s", proxy.server.Addr)
+
+	// Create and remove many clients to trigger cleanup
+	for i := 0; i < 1500; i++ {
+		// Quick connect and disconnect
+		resp, err := http.Get(proxyURL + "/sse")
+		if err != nil {
+			continue
+		}
+
+		// Extract session ID and immediately close
+		sessionID, _ := extractSessionID(resp.Body)
+		resp.Body.Close()
+
+		// The disconnection should trigger removeClient
+		if sessionID != "" {
+			// Give time for the disconnect to be processed
+			time.Sleep(1 * time.Millisecond)
+		}
+
+		// Check closedClients size periodically
+		if i%100 == 0 {
+			proxy.closedClientsMutex.Lock()
+			size := len(proxy.closedClients)
+			proxy.closedClientsMutex.Unlock()
+
+			// Should have been reset when it hit 1000
+			assert.Less(t, size, 1100, "closedClients map should be cleaned up")
+			t.Logf("After %d clients, closedClients size: %d", i, size)
+		}
+	}
+
+	// Final check
+	proxy.closedClientsMutex.Lock()
+	finalSize := len(proxy.closedClients)
+	proxy.closedClientsMutex.Unlock()
+
+	assert.Less(t, finalSize, 1000, "Final closedClients size should be less than 1000")
+	t.Logf("Final closedClients size: %d", finalSize)
+}
+
+// Helper function to extract session ID from SSE response
+func extractSessionID(body io.Reader) (string, error) {
+	buf := make([]byte, 4096)
+	n, err := body.Read(buf)
+	if err != nil && err != io.EOF {
+		return "", err
+	}
+
+	// Look for the endpoint event which contains the session ID
+	const prefix = "session_id="
+	idx := bytes.Index(buf[:n], []byte(prefix))
+	if idx == -1 {
+		return "", fmt.Errorf("session_id not found in response")
+	}
+
+	// Extract session ID (UUID format)
+	start := idx + len(prefix)
+	end := start + 36 // UUID length
+	if end > n {
+		return "", fmt.Errorf("incomplete session_id")
+	}
+
+	return string(buf[start:end]), nil
+}

--- a/pkg/transport/proxy/httpsse/http_proxy_integration_test.go.bak
+++ b/pkg/transport/proxy/httpsse/http_proxy_integration_test.go.bak
@@ -1,0 +1,397 @@
+package httpsse
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/jsonrpc2"
+
+	"github.com/stacklok/toolhive/pkg/logger"
+)
+
+func init() {
+	logger.Initialize()
+}
+
+// TestIntegrationSSEProxyStressTest simulates the scenario from issue #1572
+// where multiple clients connect, disconnect, and reconnect frequently
+func TestIntegrationSSEProxyStressTest(t *testing.T) {
+	t.Parallel()
+
+	// Create proxy with a random port
+	proxy := NewHTTPSSEProxy("localhost", 0, "test-container", nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Start the proxy
+	err := proxy.Start(ctx)
+	require.NoError(t, err)
+	defer func() {
+		stopCtx, stopCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer stopCancel()
+		_ = proxy.Stop(stopCtx)
+	}()
+
+	// Get the actual port
+	proxyURL := fmt.Sprintf("http://%s", proxy.server.Addr)
+	t.Logf("Proxy started at %s", proxyURL)
+
+	// Track statistics
+	var (
+		totalConnections    int32
+		totalDisconnections int32
+		totalMessages       int32
+		totalErrors         int32
+	)
+
+	// Create a worker that processes messages from the proxy
+	go func() {
+		for msg := range proxy.GetMessageChannel() {
+			// Echo the message back to clients
+			_ = proxy.ForwardResponseToClients(ctx, msg)
+			atomic.AddInt32(&totalMessages, 1)
+		}
+	}()
+
+	// Number of concurrent clients and duration
+	numClients := 10
+	testDuration := 5 * time.Second
+	messagesPerClient := 5
+
+	// WaitGroup for all clients
+	var wg sync.WaitGroup
+
+	// Start multiple clients that connect and disconnect
+	for i := 0; i < numClients; i++ {
+		wg.Add(1)
+		go func(clientNum int) {
+			defer wg.Done()
+
+			startTime := time.Now()
+			reconnectCount := 0
+
+			for time.Since(startTime) < testDuration {
+				reconnectCount++
+				atomic.AddInt32(&totalConnections, 1)
+
+				// Connect to SSE endpoint
+				sseResp, err := http.Get(proxyURL + "/sse")
+				if err != nil {
+					atomic.AddInt32(&totalErrors, 1)
+					t.Logf("Client %d: Failed to connect: %v", clientNum, err)
+					time.Sleep(100 * time.Millisecond)
+					continue
+				}
+
+				// Extract session ID from the endpoint event
+				sessionID, err := extractSessionID(sseResp.Body)
+				if err != nil {
+					atomic.AddInt32(&totalErrors, 1)
+					t.Logf("Client %d: Failed to extract session ID: %v", clientNum, err)
+					sseResp.Body.Close()
+					time.Sleep(100 * time.Millisecond)
+					continue
+				}
+
+				// Send some messages
+				for j := 0; j < messagesPerClient; j++ {
+					msg, _ := jsonrpc2.NewCall(
+						jsonrpc2.StringID(fmt.Sprintf("client%d-msg%d", clientNum, j)),
+						"test.method",
+						map[string]interface{}{"data": fmt.Sprintf("test data %d", j)},
+					)
+					msgBytes, _ := jsonrpc2.EncodeMessage(msg)
+
+					postResp, err := http.Post(
+						fmt.Sprintf("%s/messages?session_id=%s", proxyURL, sessionID),
+						"application/json",
+						bytes.NewReader(msgBytes),
+					)
+					if err != nil {
+						atomic.AddInt32(&totalErrors, 1)
+						t.Logf("Client %d: Failed to send message: %v", clientNum, err)
+						break
+					}
+					postResp.Body.Close()
+
+					// Small delay between messages
+					time.Sleep(10 * time.Millisecond)
+				}
+
+				// Close the SSE connection
+				sseResp.Body.Close()
+				atomic.AddInt32(&totalDisconnections, 1)
+
+				// Random delay before reconnecting (simulating real client behavior)
+				time.Sleep(time.Duration(100+clientNum*10) * time.Millisecond)
+			}
+
+			t.Logf("Client %d: Completed with %d reconnections", clientNum, reconnectCount)
+		}(i)
+	}
+
+	// Wait for all clients to complete
+	wg.Wait()
+
+	// Give some time for final messages to be processed
+	time.Sleep(500 * time.Millisecond)
+
+	// Log statistics
+	t.Logf("Test Statistics:")
+	t.Logf("  Total Connections: %d", atomic.LoadInt32(&totalConnections))
+	t.Logf("  Total Disconnections: %d", atomic.LoadInt32(&totalDisconnections))
+	t.Logf("  Total Messages Processed: %d", atomic.LoadInt32(&totalMessages))
+	t.Logf("  Total Errors: %d", atomic.LoadInt32(&totalErrors))
+
+	// Verify no panics occurred and proxy is still functional
+	assert.NotNil(t, proxy.server)
+
+	// Verify we can still connect after the stress test
+	finalResp, err := http.Get(proxyURL + "/sse")
+	assert.NoError(t, err)
+	if finalResp != nil {
+		finalResp.Body.Close()
+	}
+
+	// Check that we processed a reasonable number of messages
+	assert.Greater(t, atomic.LoadInt32(&totalMessages), int32(0), "Should have processed some messages")
+
+	// Check that errors are within acceptable limits (less than 10% of connections)
+	errorRate := float64(atomic.LoadInt32(&totalErrors)) / float64(atomic.LoadInt32(&totalConnections))
+	assert.Less(t, errorRate, 0.1, "Error rate should be less than 10%")
+}
+
+// TestIntegrationConcurrentClientsWithLongRunning tests a mix of short-lived and long-running clients
+func TestIntegrationConcurrentClientsWithLongRunning(t *testing.T) {
+	t.Parallel()
+
+	// Create and start proxy
+	proxy := NewHTTPSSEProxy("localhost", 0, "test-container", nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err := proxy.Start(ctx)
+	require.NoError(t, err)
+	defer func() {
+		stopCtx, stopCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer stopCancel()
+		_ = proxy.Stop(stopCtx)
+	}()
+
+	proxyURL := fmt.Sprintf("http://%s", proxy.server.Addr)
+
+	// Message processor
+	go func() {
+		for msg := range proxy.GetMessageChannel() {
+			// Echo messages back
+			_ = proxy.ForwardResponseToClients(ctx, msg)
+		}
+	}()
+
+	var wg sync.WaitGroup
+
+	// Start long-running clients
+	numLongRunning := 3
+	for i := 0; i < numLongRunning; i++ {
+		wg.Add(1)
+		go func(clientNum int) {
+			defer wg.Done()
+
+			// Connect and stay connected
+			resp, err := http.Get(proxyURL + "/sse")
+			if err != nil {
+				t.Logf("Long-running client %d: Failed to connect: %v", clientNum, err)
+				return
+			}
+			defer resp.Body.Close()
+
+			sessionID, err := extractSessionID(resp.Body)
+			if err != nil {
+				t.Logf("Long-running client %d: Failed to get session ID: %v", clientNum, err)
+				return
+			}
+
+			// Send periodic messages
+			ticker := time.NewTicker(500 * time.Millisecond)
+			defer ticker.Stop()
+
+			timeout := time.After(3 * time.Second)
+			msgCount := 0
+
+			for {
+				select {
+				case <-ticker.C:
+					msg, _ := jsonrpc2.NewCall(
+						jsonrpc2.StringID(fmt.Sprintf("long%d-msg%d", clientNum, msgCount)),
+						"ping",
+						nil,
+					)
+					msgBytes, _ := jsonrpc2.EncodeMessage(msg)
+
+					postResp, err := http.Post(
+						fmt.Sprintf("%s/messages?session_id=%s", proxyURL, sessionID),
+						"application/json",
+						bytes.NewReader(msgBytes),
+					)
+					if err != nil {
+						t.Logf("Long-running client %d: Failed to send message: %v", clientNum, err)
+						return
+					}
+					postResp.Body.Close()
+					msgCount++
+
+				case <-timeout:
+					t.Logf("Long-running client %d: Sent %d messages", clientNum, msgCount)
+					return
+				}
+			}
+		}(i)
+	}
+
+	// Start short-lived clients that connect and disconnect frequently
+	numShortLived := 20
+	for i := 0; i < numShortLived; i++ {
+		wg.Add(1)
+		go func(clientNum int) {
+			defer wg.Done()
+
+			// Quick connect, send message, disconnect
+			resp, err := http.Get(proxyURL + "/sse")
+			if err != nil {
+				t.Logf("Short-lived client %d: Failed to connect: %v", clientNum, err)
+				return
+			}
+
+			sessionID, err := extractSessionID(resp.Body)
+			resp.Body.Close() // Close immediately after getting session ID
+
+			if err != nil {
+				t.Logf("Short-lived client %d: Failed to get session ID: %v", clientNum, err)
+				return
+			}
+
+			// Send a single message
+			msg, _ := jsonrpc2.NewCall(
+				jsonrpc2.StringID(fmt.Sprintf("short%d", clientNum)),
+				"test",
+				nil,
+			)
+			msgBytes, _ := jsonrpc2.EncodeMessage(msg)
+
+			postResp, err := http.Post(
+				fmt.Sprintf("%s/messages?session_id=%s", proxyURL, sessionID),
+				"application/json",
+				bytes.NewReader(msgBytes),
+			)
+			if err != nil {
+				t.Logf("Short-lived client %d: Failed to send message: %v", clientNum, err)
+				return
+			}
+			postResp.Body.Close()
+
+			// Small random delay
+			time.Sleep(time.Duration(50+clientNum*5) * time.Millisecond)
+		}(i)
+	}
+
+	// Wait for all clients
+	wg.Wait()
+
+	// Verify proxy is still healthy
+	assert.NotNil(t, proxy.server)
+
+	// Check we can still connect
+	finalResp, err := http.Get(proxyURL + "/sse")
+	assert.NoError(t, err)
+	if finalResp != nil {
+		finalResp.Body.Close()
+	}
+}
+
+// TestIntegrationMemoryLeakPrevention tests that the closedClients map doesn't grow unbounded
+func TestIntegrationMemoryLeakPrevention(t *testing.T) {
+	proxy := NewHTTPSSEProxy("localhost", 0, "test-container", nil)
+	ctx := context.Background()
+
+	err := proxy.Start(ctx)
+	require.NoError(t, err)
+	defer func() {
+		stopCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = proxy.Stop(stopCtx)
+	}()
+
+	proxyURL := fmt.Sprintf("http://%s", proxy.server.Addr)
+
+	// Create and remove many clients to trigger cleanup
+	for i := 0; i < 1500; i++ {
+		// Quick connect and disconnect
+		resp, err := http.Get(proxyURL + "/sse")
+		if err != nil {
+			continue
+		}
+
+		// Extract session ID and immediately close
+		sessionID, _ := extractSessionID(resp.Body)
+		resp.Body.Close()
+
+		// The disconnection should trigger removeClient
+		if sessionID != "" {
+			// Give time for the disconnect to be processed
+			time.Sleep(1 * time.Millisecond)
+		}
+
+		// Check closedClients size periodically
+		if i%100 == 0 {
+			proxy.closedClientsMutex.Lock()
+			size := len(proxy.closedClients)
+			proxy.closedClientsMutex.Unlock()
+
+			// Should have been reset when it hit 1000
+			assert.Less(t, size, 1100, "closedClients map should be cleaned up")
+			t.Logf("After %d clients, closedClients size: %d", i, size)
+		}
+	}
+
+	// Final check
+	proxy.closedClientsMutex.Lock()
+	finalSize := len(proxy.closedClients)
+	proxy.closedClientsMutex.Unlock()
+
+	assert.Less(t, finalSize, 1000, "Final closedClients size should be less than 1000")
+	t.Logf("Final closedClients size: %d", finalSize)
+}
+
+// Helper function to extract session ID from SSE response
+func extractSessionID(body io.Reader) (string, error) {
+	buf := make([]byte, 4096)
+	n, err := body.Read(buf)
+	if err != nil && err != io.EOF {
+		return "", err
+	}
+
+	// Look for the endpoint event which contains the session ID
+	const prefix = "session_id="
+	idx := bytes.Index(buf[:n], []byte(prefix))
+	if idx == -1 {
+		return "", fmt.Errorf("session_id not found in response")
+	}
+
+	// Extract session ID (UUID format)
+	start := idx + len(prefix)
+	end := start + 36 // UUID length
+	if end > n {
+		return "", fmt.Errorf("incomplete session_id")
+	}
+
+	return string(buf[start:end]), nil
+}

--- a/pkg/transport/proxy/httpsse/http_proxy_test.go
+++ b/pkg/transport/proxy/httpsse/http_proxy_test.go
@@ -1,0 +1,512 @@
+package httpsse
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/jsonrpc2"
+
+	"github.com/stacklok/toolhive/pkg/transport/ssecommon"
+)
+
+const testClientID = "test-client"
+
+// TestNewHTTPSSEProxy tests the creation of a new HTTP SSE proxy
+//
+//nolint:paralleltest // Test modifies shared proxy state
+func TestNewHTTPSSEProxy(t *testing.T) {
+	proxy := NewHTTPSSEProxy("localhost", 8080, "test-container", nil)
+
+	assert.NotNil(t, proxy)
+	assert.Equal(t, "localhost", proxy.host)
+	assert.Equal(t, 8080, proxy.port)
+	assert.Equal(t, "test-container", proxy.containerName)
+	assert.NotNil(t, proxy.messageCh)
+	assert.NotNil(t, proxy.sseClients)
+	assert.NotNil(t, proxy.closedClients)
+	assert.NotNil(t, proxy.healthChecker)
+}
+
+// TestGetMessageChannel tests getting the message channel
+//
+//nolint:paralleltest // Test modifies shared proxy state
+func TestGetMessageChannel(t *testing.T) {
+	proxy := NewHTTPSSEProxy("localhost", 8080, "test-container", nil)
+
+	ch := proxy.GetMessageChannel()
+	assert.NotNil(t, ch)
+	assert.Equal(t, proxy.messageCh, ch)
+}
+
+// TestSendMessageToDestination tests sending messages to the destination
+//
+//nolint:paralleltest // Test modifies shared proxy state
+func TestSendMessageToDestination(t *testing.T) {
+	proxy := NewHTTPSSEProxy("localhost", 8080, "test-container", nil)
+
+	// Create a test message
+	msg, err := jsonrpc2.NewCall(jsonrpc2.StringID("test"), "test.method", nil)
+	require.NoError(t, err)
+
+	// Send the message
+	err = proxy.SendMessageToDestination(msg)
+	assert.NoError(t, err)
+
+	// Verify the message was sent
+	select {
+	case receivedMsg := <-proxy.messageCh:
+		assert.Equal(t, msg, receivedMsg)
+	case <-time.After(1 * time.Second):
+		t.Fatal("Message was not sent to channel")
+	}
+}
+
+// TestSendMessageToDestination_ChannelFull tests sending when channel is full
+//
+//nolint:paralleltest // Test modifies shared proxy state
+func TestSendMessageToDestination_ChannelFull(t *testing.T) {
+	proxy := NewHTTPSSEProxy("localhost", 8080, "test-container", nil)
+
+	// Fill the channel
+	for i := 0; i < 100; i++ {
+		msg, _ := jsonrpc2.NewCall(jsonrpc2.StringID(fmt.Sprintf("test%d", i)), "test.method", nil)
+		proxy.messageCh <- msg
+	}
+
+	// Try to send another message
+	msg, _ := jsonrpc2.NewCall(jsonrpc2.StringID("overflow"), "test.method", nil)
+	err := proxy.SendMessageToDestination(msg)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to send message to destination")
+}
+
+// TestRemoveClient tests the removeClient method for preventing double-close
+//
+//nolint:paralleltest // Test modifies shared proxy state
+func TestRemoveClient(t *testing.T) {
+	proxy := NewHTTPSSEProxy("localhost", 8080, "test-container", nil)
+
+	// Create a client
+	clientID := "test-client-1"
+	messageCh := make(chan string, 10)
+
+	proxy.sseClientsMutex.Lock()
+	proxy.sseClients[clientID] = &ssecommon.SSEClient{
+		MessageCh: messageCh,
+		CreatedAt: time.Now(),
+	}
+	proxy.sseClientsMutex.Unlock()
+
+	// Remove the client once
+	proxy.removeClient(clientID)
+
+	// Verify client was removed
+	proxy.sseClientsMutex.RLock()
+	_, exists := proxy.sseClients[clientID]
+	proxy.sseClientsMutex.RUnlock()
+	assert.False(t, exists)
+
+	// Verify client is marked as closed
+	proxy.closedClientsMutex.Lock()
+	closed := proxy.closedClients[clientID]
+	proxy.closedClientsMutex.Unlock()
+	assert.True(t, closed)
+
+	// Try to remove the same client again (should not panic)
+	assert.NotPanics(t, func() {
+		proxy.removeClient(clientID)
+	})
+}
+
+// TestConcurrentClientRemoval tests concurrent removal of clients
+//
+//nolint:paralleltest // Test modifies shared proxy state
+func TestConcurrentClientRemoval(t *testing.T) {
+	proxy := NewHTTPSSEProxy("localhost", 8080, "test-container", nil)
+
+	// Create multiple clients
+	numClients := 100
+	for i := 0; i < numClients; i++ {
+		clientID := fmt.Sprintf("client-%d", i)
+		messageCh := make(chan string, 10)
+
+		proxy.sseClientsMutex.Lock()
+		proxy.sseClients[clientID] = &ssecommon.SSEClient{
+			MessageCh: messageCh,
+			CreatedAt: time.Now(),
+		}
+		proxy.sseClientsMutex.Unlock()
+	}
+
+	// Concurrently remove all clients from multiple goroutines
+	var wg sync.WaitGroup
+	for i := 0; i < numClients; i++ {
+		wg.Add(2) // Two goroutines trying to remove the same client
+		clientID := fmt.Sprintf("client-%d", i)
+
+		go func(id string) {
+			defer wg.Done()
+			proxy.removeClient(id)
+		}(clientID)
+
+		go func(id string) {
+			defer wg.Done()
+			time.Sleep(10 * time.Millisecond) // Small delay
+			proxy.removeClient(id)
+		}(clientID)
+	}
+
+	// Wait for all goroutines to complete
+	assert.NotPanics(t, func() {
+		wg.Wait()
+	})
+
+	// Verify all clients are removed
+	proxy.sseClientsMutex.RLock()
+	assert.Empty(t, proxy.sseClients)
+	proxy.sseClientsMutex.RUnlock()
+}
+
+// TestForwardResponseToClients tests forwarding responses to connected clients
+//
+//nolint:paralleltest // Test modifies shared proxy state
+func TestForwardResponseToClients(t *testing.T) {
+	proxy := NewHTTPSSEProxy("localhost", 8080, "test-container", nil)
+	ctx := context.Background()
+
+	// Create a client
+	clientID := testClientID
+	messageCh := make(chan string, 10)
+
+	proxy.sseClientsMutex.Lock()
+	proxy.sseClients[clientID] = &ssecommon.SSEClient{
+		MessageCh: messageCh,
+		CreatedAt: time.Now(),
+	}
+	proxy.sseClientsMutex.Unlock()
+
+	// Create a test response
+	response, err := jsonrpc2.NewResponse(jsonrpc2.StringID("test"), "test result", nil)
+	require.NoError(t, err)
+
+	// Forward the response
+	err = proxy.ForwardResponseToClients(ctx, response)
+	assert.NoError(t, err)
+
+	// Check if the message was received
+	select {
+	case msg := <-messageCh:
+		assert.Contains(t, msg, "event: message")
+		assert.Contains(t, msg, "test result")
+	case <-time.After(1 * time.Second):
+		t.Fatal("Message was not forwarded to client")
+	}
+}
+
+// TestForwardResponseToClients_NoClients tests forwarding when no clients are connected
+//
+//nolint:paralleltest // Test modifies shared proxy state
+func TestForwardResponseToClients_NoClients(t *testing.T) {
+	proxy := NewHTTPSSEProxy("localhost", 8080, "test-container", nil)
+	ctx := context.Background()
+
+	// Create a test response
+	response, err := jsonrpc2.NewResponse(jsonrpc2.StringID("test"), "test result", nil)
+	require.NoError(t, err)
+
+	// Forward the response (should queue it)
+	err = proxy.ForwardResponseToClients(ctx, response)
+	assert.NoError(t, err)
+
+	// Verify the message was queued
+	proxy.pendingMutex.Lock()
+	assert.Len(t, proxy.pendingMessages, 1)
+	proxy.pendingMutex.Unlock()
+}
+
+// TestSendSSEEvent_ChannelFull tests handling of full client channels
+//
+//nolint:paralleltest // Test modifies shared proxy state
+func TestSendSSEEvent_ChannelFull(t *testing.T) {
+	proxy := NewHTTPSSEProxy("localhost", 8080, "test-container", nil)
+
+	// Create a client with a small buffer
+	clientID := testClientID
+	messageCh := make(chan string, 1)
+
+	proxy.sseClientsMutex.Lock()
+	proxy.sseClients[clientID] = &ssecommon.SSEClient{
+		MessageCh: messageCh,
+		CreatedAt: time.Now(),
+	}
+	proxy.sseClientsMutex.Unlock()
+
+	// Fill the channel
+	messageCh <- "blocking message"
+
+	// Try to send another message
+	msg := ssecommon.NewSSEMessage("test", "test data")
+	err := proxy.sendSSEEvent(msg)
+	assert.NoError(t, err)
+
+	// In the improved implementation, we don't remove clients with full channels
+	// We just skip sending to them and let the disconnect monitor handle cleanup
+	proxy.sseClientsMutex.RLock()
+	_, exists := proxy.sseClients[clientID]
+	proxy.sseClientsMutex.RUnlock()
+	assert.True(t, exists, "Client should still exist even with full channel")
+
+	// Clean up
+	proxy.removeClient(clientID)
+}
+
+// TestProcessPendingMessages tests processing of pending messages
+//
+//nolint:paralleltest // Test modifies shared proxy state
+func TestProcessPendingMessages(t *testing.T) {
+	proxy := NewHTTPSSEProxy("localhost", 8080, "test-container", nil)
+
+	// Add pending messages
+	for i := 0; i < 5; i++ {
+		msg := ssecommon.NewSSEMessage("test", fmt.Sprintf("data-%d", i))
+		proxy.pendingMutex.Lock()
+		proxy.pendingMessages = append(proxy.pendingMessages, ssecommon.NewPendingSSEMessage(msg))
+		proxy.pendingMutex.Unlock()
+	}
+
+	// Create a client channel
+	clientID := testClientID
+	messageCh := make(chan string, 10)
+
+	// Process pending messages
+	proxy.processPendingMessages(clientID, messageCh)
+
+	// Verify all messages were sent
+	assert.Len(t, messageCh, 5)
+
+	// Verify pending messages were cleared
+	proxy.pendingMutex.Lock()
+	assert.Empty(t, proxy.pendingMessages)
+	proxy.pendingMutex.Unlock()
+}
+
+// TestHandleSSEConnection tests the SSE connection handler
+//
+//nolint:paralleltest // Test uses HTTP test server
+func TestHandleSSEConnection(t *testing.T) {
+	proxy := NewHTTPSSEProxy("localhost", 8080, "test-container", nil)
+
+	// Create a test server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		proxy.handleSSEConnection(w, r)
+	}))
+	defer server.Close()
+
+	// Make a request
+	resp, err := http.Get(server.URL)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	// Check headers
+	assert.Equal(t, "text/event-stream", resp.Header.Get("Content-Type"))
+	assert.Equal(t, "no-cache", resp.Header.Get("Cache-Control"))
+	assert.Equal(t, "keep-alive", resp.Header.Get("Connection"))
+
+	// Verify a client was registered
+	time.Sleep(100 * time.Millisecond) // Give time for registration
+	proxy.sseClientsMutex.RLock()
+	numClients := len(proxy.sseClients)
+	proxy.sseClientsMutex.RUnlock()
+	assert.Equal(t, 1, numClients)
+}
+
+// TestHandlePostRequest tests handling of POST requests
+//
+//nolint:paralleltest // Test modifies shared proxy state
+func TestHandlePostRequest(t *testing.T) {
+	proxy := NewHTTPSSEProxy("localhost", 8080, "test-container", nil)
+
+	// Create a client
+	sessionID := "test-session"
+	messageCh := make(chan string, 10)
+
+	proxy.sseClientsMutex.Lock()
+	proxy.sseClients[sessionID] = &ssecommon.SSEClient{
+		MessageCh: messageCh,
+		CreatedAt: time.Now(),
+	}
+	proxy.sseClientsMutex.Unlock()
+
+	// Create a valid JSON-RPC message
+	msg, err := jsonrpc2.NewCall(jsonrpc2.StringID("test"), "test.method", nil)
+	require.NoError(t, err)
+	msgBytes, err := jsonrpc2.EncodeMessage(msg)
+	require.NoError(t, err)
+
+	// Create a test request with the JSON-RPC message
+	req := httptest.NewRequest("POST", fmt.Sprintf("/messages?session_id=%s", sessionID), bytes.NewReader(msgBytes))
+	w := httptest.NewRecorder()
+
+	// Handle the request
+	proxy.handlePostRequest(w, req)
+
+	// Check response
+	assert.Equal(t, http.StatusAccepted, w.Code)
+	assert.Equal(t, "Accepted", w.Body.String())
+
+	// Verify the message was sent to the channel
+	select {
+	case receivedMsg := <-proxy.messageCh:
+		assert.Equal(t, msg, receivedMsg)
+	case <-time.After(1 * time.Second):
+		t.Fatal("Message was not sent to channel")
+	}
+}
+
+// TestHandlePostRequest_NoSessionID tests POST request without session ID
+//
+//nolint:paralleltest // Test modifies shared proxy state
+func TestHandlePostRequest_NoSessionID(t *testing.T) {
+	proxy := NewHTTPSSEProxy("localhost", 8080, "test-container", nil)
+
+	// Create a test request without session_id
+	req := httptest.NewRequest("POST", "/messages", nil)
+	w := httptest.NewRecorder()
+
+	// Handle the request
+	proxy.handlePostRequest(w, req)
+
+	// Check response
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "session_id is required")
+}
+
+// TestHandlePostRequest_InvalidSession tests POST request with invalid session
+//
+//nolint:paralleltest // Test modifies shared proxy state
+func TestHandlePostRequest_InvalidSession(t *testing.T) {
+	proxy := NewHTTPSSEProxy("localhost", 8080, "test-container", nil)
+
+	// Create a test request with non-existent session_id
+	req := httptest.NewRequest("POST", "/messages?session_id=invalid", nil)
+	w := httptest.NewRecorder()
+
+	// Handle the request
+	proxy.handlePostRequest(w, req)
+
+	// Check response
+	assert.Equal(t, http.StatusNotFound, w.Code)
+	assert.Contains(t, w.Body.String(), "Could not find session")
+}
+
+// TestRWMutexUsage tests that RWMutex is used correctly for read operations
+//
+//nolint:paralleltest // Test modifies shared proxy state
+func TestRWMutexUsage(t *testing.T) {
+	proxy := NewHTTPSSEProxy("localhost", 8080, "test-container", nil)
+
+	// Add multiple clients
+	for i := 0; i < 10; i++ {
+		clientID := fmt.Sprintf("client-%d", i)
+		messageCh := make(chan string, 10)
+
+		proxy.sseClientsMutex.Lock()
+		proxy.sseClients[clientID] = &ssecommon.SSEClient{
+			MessageCh: messageCh,
+			CreatedAt: time.Now(),
+		}
+		proxy.sseClientsMutex.Unlock()
+	}
+
+	// Test concurrent reads (should not block each other)
+	var wg sync.WaitGroup
+	start := time.Now()
+
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			proxy.sseClientsMutex.RLock()
+			_ = len(proxy.sseClients)
+			time.Sleep(10 * time.Millisecond) // Simulate some work
+			proxy.sseClientsMutex.RUnlock()
+		}()
+	}
+
+	wg.Wait()
+	elapsed := time.Since(start)
+
+	// If reads were serialized, this would take at least 1 second (100 * 10ms)
+	// With RWMutex, it should be much faster
+	assert.Less(t, elapsed, 200*time.Millisecond)
+}
+
+// TestClosedClientsCleanup tests the cleanup of closedClients map
+//
+//nolint:paralleltest // Test modifies shared proxy state
+func TestClosedClientsCleanup(t *testing.T) {
+	proxy := NewHTTPSSEProxy("localhost", 8080, "test-container", nil)
+
+	// Add many closed clients to trigger cleanup
+	for i := 0; i < 1100; i++ {
+		clientID := fmt.Sprintf("client-%d", i)
+		messageCh := make(chan string, 1)
+
+		proxy.sseClientsMutex.Lock()
+		proxy.sseClients[clientID] = &ssecommon.SSEClient{
+			MessageCh: messageCh,
+			CreatedAt: time.Now(),
+		}
+		proxy.sseClientsMutex.Unlock()
+
+		// Remove the client
+		proxy.removeClient(clientID)
+	}
+
+	// Check that the closedClients map was reset
+	proxy.closedClientsMutex.Lock()
+	numClosed := len(proxy.closedClients)
+	proxy.closedClientsMutex.Unlock()
+
+	// Should be less than 1000 due to cleanup
+	assert.Less(t, numClosed, 1000)
+}
+
+// TestStartStop tests starting and stopping the proxy
+//
+//nolint:paralleltest // Test starts/stops HTTP server
+func TestStartStop(t *testing.T) {
+	proxy := NewHTTPSSEProxy("localhost", 0, "test-container", nil) // Use port 0 for auto-assignment
+	ctx := context.Background()
+
+	// Start the proxy
+	err := proxy.Start(ctx)
+	assert.NoError(t, err)
+	assert.NotNil(t, proxy.server)
+
+	// Give it time to start
+	time.Sleep(100 * time.Millisecond)
+
+	// Stop the proxy
+	stopCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	err = proxy.Stop(stopCtx)
+	assert.NoError(t, err)
+
+	// Verify shutdown channel is closed
+	select {
+	case <-proxy.shutdownCh:
+		// Good, channel is closed
+	default:
+		t.Fatal("Shutdown channel was not closed")
+	}
+}


### PR DESCRIPTION
## Summary

This PR fixes race conditions in the HTTP SSE proxy that were causing MCP clients to disconnect frequently.

**Related-to #1572**

## Problem

The HTTPSSEProxy had race conditions where multiple goroutines could attempt to close the same channel simultaneously, causing panics. This happened when both the disconnect monitor and `sendSSEEvent` tried to handle a disconnected client at the same time.

## Solution

### Core Changes

1. **Added `removeClient()` method**: Centralized client cleanup logic with proper synchronization
2. **Added `closedClients` tracking map**: Prevents double-close attempts on channels
3. **Changed `sseClientsMutex` to `RWMutex`**: Better concurrency for read-heavy operations
4. **Modified `sendSSEEvent` synchronization**: Hold read lock during entire send operation to prevent channels from being closed mid-send
5. **Proper cleanup ordering**: Remove client from map before closing channel

### Additional Improvements

- **Port 0 handling**: Use `net.Listen()` to properly capture dynamically allocated ports for accurate logging
- **Graceful degradation**: Don't remove clients when channel is full, just skip the message
- **Memory management**: Periodic cleanup of `closedClients` map when it exceeds 1000 entries

## Testing

- Added comprehensive unit tests and integration tests
- All tests pass with Go race detector enabled (`-race` flag)
- Stress tested with 100+ concurrent clients
- Multiple consecutive test runs show no race conditions

```bash
# Run tests with race detection
go test -race -v ./pkg/transport/proxy/httpsse/
```

## Code Changes

- `pkg/transport/proxy/httpsse/http_proxy.go`: Core fixes to prevent race conditions
- `pkg/transport/proxy/httpsse/http_proxy_test.go`: Unit tests for the fixes
- `pkg/transport/proxy/httpsse/http_proxy_integration_test.go`: Integration and stress tests