### PR TITLE
Raise scanner max token size in transparent proxy.

### DIFF
--- a/pkg/transport/proxy/transparent/transparent_proxy.go
+++ b/pkg/transport/proxy/transparent/transparent_proxy.go
@@ -275,9 +275,16 @@ func (p *TransparentProxy) modifyForSessionID(resp *http.Response) error {
 	originalBody := resp.Body
 	resp.Body = pr
 
+	// NOTE: it would be better to have a proper function instead of a goroutine, as this
+	// makes it harder to debug and test.
 	go func() {
 		defer pw.Close()
 		scanner := bufio.NewScanner(originalBody)
+		// NOTE: The following line mitigates the issue of the response body being too large.
+		// By default, the maximum token size of the scanner is 64KB, which is too small in
+		// the case of e.g. images. This raises the limit to 1MB. This is a workaround, and
+		// not a proper fix.
+		scanner.Buffer(make([]byte, 0, 1024), 1024*1024*1)
 		found := false
 
 		for scanner.Scan() {
@@ -300,6 +307,13 @@ func (p *TransparentProxy) modifyForSessionID(resp *http.Response) error {
 				return
 			}
 		}
+
+		// NOTE: this line is always necessary since scanner.Scan() will return false
+		// in case of an error.
+		if err := scanner.Err(); err != nil {
+			logger.Errorf("Failed to scan response body: %v", err)
+		}
+
 		_, err := io.Copy(pw, originalBody)
 		if err != nil && err != io.EOF {
 			logger.Errorf("Failed to copy response body: %v", err)


### PR DESCRIPTION
The routine `modifyForSessionId` in our implementation of transparent proxy uses `bufio.Scanner` to scan through the response bytes in search of the session id.

Said `bufio.Scanner` internally sets a maximum token size of 64kB which is easily exceeded by `plotting-mcp` which returns images. When such a threshold is reached, the scanner's `Scan` method returns `false` and sets the error to `ErrTooLong`
([here](https://github.com/golang/go/blob/release-branch.go1.25/src/bufio/scan.go#L200-L203), which our code ignored.

This change mitigates the issue by raising the maximum token size to 1MB and adds basic error handling at the end of the scan loop.

Fixes #1535