### PR TITLE
also retrieve workload details if status is unhealthy

### DIFF
--- a/pkg/workloads/statuses/file_status.go
+++ b/pkg/workloads/statuses/file_status.go
@@ -151,7 +151,7 @@ func (f *fileStatusManager) GetWorkload(ctx context.Context, workloadName string
 		}
 
 		// If workload is running, validate against runtime
-		if result.Status == rt.WorkloadStatusRunning {
+		if result.Status == rt.WorkloadStatusRunning || result.Status == rt.WorkloadStatusUnhealthy {
 			return f.validateRunningWorkload(ctx, workloadName, result)
 		}
 


### PR DESCRIPTION
it is a valid status, because workloads are always unhealthy until they have been initialized