### PR TITLE
always write a pid file even if we run in foreground

### DIFF
--- a/cmd/thv/app/proxy_stdio.go
+++ b/cmd/thv/app/proxy_stdio.go
@@ -33,9 +33,16 @@ func proxyStdioCmdFunc(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to create workload manager: %w", err)
 	}
+
+	// just get details of workload without doing status check
 	stdioWorkload, err := workloadManager.GetWorkload(ctx, workloadName)
 	if err != nil {
 		return fmt.Errorf("failed to get workload %q: %w", workloadName, err)
+	}
+
+	// check if we have details for the workload or not
+	if stdioWorkload.URL == "" || stdioWorkload.TransportType == "" {
+		return fmt.Errorf("workload %q does not have connection details (is it running?)", workloadName)
 	}
 	logger.Infof("Starting stdio proxy for workload=%q", workloadName)
 

--- a/pkg/process/detached.go
+++ b/pkg/process/detached.go
@@ -1,6 +1,8 @@
 package process
 
-import "os"
+import (
+	"os"
+)
 
 // ToolHiveDetachedEnv is the environment variable used to indicate that the process is running in detached mode.
 const ToolHiveDetachedEnv = "TOOLHIVE_DETACHED"

--- a/pkg/process/pid.go
+++ b/pkg/process/pid.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+
+	"github.com/stacklok/toolhive/pkg/logger"
 )
 
 // GetPIDFilePath returns the path to the PID file for a container
@@ -21,6 +23,7 @@ func GetPIDFilePath(containerBaseName string) string {
 func WritePIDFile(containerBaseName string, pid int) error {
 	// Get the PID file path
 	pidFilePath := GetPIDFilePath(containerBaseName)
+	logger.Debugf("Writing PID file to %s", pidFilePath)
 
 	// Write the PID to the file
 	return os.WriteFile(pidFilePath, []byte(fmt.Sprintf("%d", pid)), 0600)
@@ -28,6 +31,7 @@ func WritePIDFile(containerBaseName string, pid int) error {
 
 // WriteCurrentPIDFile writes the current process ID to a file
 func WriteCurrentPIDFile(containerBaseName string) error {
+	logger.Infof("Writing current PID (%d) to PID file", os.Getpid())
 	return WritePIDFile(containerBaseName, os.Getpid())
 }
 
@@ -35,6 +39,7 @@ func WriteCurrentPIDFile(containerBaseName string) error {
 func ReadPIDFile(containerBaseName string) (int, error) {
 	// Get the PID file path
 	pidFilePath := GetPIDFilePath(containerBaseName)
+	logger.Debugf("Reading PID file from %s", pidFilePath)
 
 	// Read the PID from the file
 	// #nosec G304 - This is safe as the path is constructed from a known prefix and container name
@@ -55,6 +60,7 @@ func ReadPIDFile(containerBaseName string) (int, error) {
 
 // RemovePIDFile removes the PID file
 func RemovePIDFile(containerBaseName string) error {
+	logger.Infof("Removing PID file for container %s", containerBaseName)
 	// Get the PID file path
 	pidFilePath := GetPIDFilePath(containerBaseName)
 

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -239,13 +239,12 @@ func (r *Runner) Run(ctx context.Context) error {
 		logger.Infof("MCP server %s stopped", r.Config.ContainerName)
 	}
 
+	if err := process.WriteCurrentPIDFile(r.Config.BaseName); err != nil {
+		logger.Warnf("Warning: Failed to write PID file: %v", err)
+	}
 	if process.IsDetached() {
 		// We're a detached process running in foreground mode
 		// Write the PID to a file so the stop command can kill the process
-		if err := process.WriteCurrentPIDFile(r.Config.BaseName); err != nil {
-			logger.Warnf("Warning: Failed to write PID file: %v", err)
-		}
-
 		logger.Infof("Running as detached process (PID: %d)", os.Getpid())
 	} else {
 		logger.Info("Press Ctrl+C to stop or wait for container to exit")

--- a/pkg/transport/proxy/manager.go
+++ b/pkg/transport/proxy/manager.go
@@ -39,17 +39,22 @@ func StopProcess(containerBaseName string) {
 
 // IsRunning checks if the proxy process is running
 func IsRunning(containerBaseName string) bool {
+	logger.Debugf("Checking if proxy process is running for container %s", containerBaseName)
 	if containerBaseName == "" {
+		logger.Warnf("Warning: Could not find base container name in labels")
 		return false
 	}
 
 	// Try to read the PID file
+	logger.Debugf("Reading PID file for container %s", containerBaseName)
 	pid, err := process.ReadPIDFile(containerBaseName)
 	if err != nil {
+		logger.Debugf("No PID file found for container %s", containerBaseName)
 		return false
 	}
 
 	// Check if the process exists and is running
+	logger.Debugf("Checking if process with PID %d is running", pid)
 	isRunning, err := process.FindProcess(pid)
 	if err != nil {
 		logger.Warnf("Warning: Error checking process: %v", err)

--- a/test/e2e/osv_mcp_server_test.go
+++ b/test/e2e/osv_mcp_server_test.go
@@ -5,11 +5,13 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"syscall"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/stacklok/toolhive/pkg/process"
 	"github.com/stacklok/toolhive/test/e2e"
 )
 
@@ -444,6 +446,99 @@ var _ = Describe("OsvMcpServer", Serial, func() {
 				cerr := e2e.StopAndRemoveMCPServer(config, serverName)
 				Expect(cerr).ToNot(HaveOccurred(), "cleanup should succeed")
 			}
+		})
+
+	})
+
+	Describe("Running OSV MCP server in the foreground", func() {
+		Context("when running OSV server in foreground", func() {
+			It("starts, creates PID file, stays healthy, then stops & removes PID file [Serial]", func() {
+				serverName := generateUniqueServerName("osv-foreground-test")
+
+				// 1) Start the foreground process in the background (goroutine) with a generous timeout.
+				done := make(chan struct{})
+				fgStdout := ""
+				fgStderr := ""
+				go func() {
+					out, errOut, _ := e2e.NewTHVCommand(
+						config, "run",
+						"--name", serverName,
+						"--transport", "sse",
+						"--foreground",
+						"osv",
+					).RunWithTimeout(5 * time.Minute)
+					fgStdout, fgStderr = out, errOut
+					close(done)
+				}()
+
+				// Always try to stop the server at the end so the goroutine returns.
+				defer func() {
+					_, _, _ = e2e.NewTHVCommand(config, "stop", serverName).Run()
+					select {
+					case <-done:
+					case <-time.After(15 * time.Second):
+						// Nothing else we can signal directly; the RunWithTimeout will eventually kill it.
+					}
+				}()
+
+				// 2) Wait until the server is reported as running.
+				By("waiting for foreground server to be running")
+				err := e2e.WaitForMCPServer(config, serverName, 60*time.Second)
+				Expect(err).ToNot(HaveOccurred(), "server should reach running state")
+
+				// 3) PID file should be created at the known location.
+				By("verifying PID file is created")
+				pidFile := process.GetPIDFilePath(serverName)
+				Eventually(func() bool {
+					_, statErr := os.Stat(pidFile)
+					return statErr == nil
+				}, 15*time.Second, 200*time.Millisecond).Should(BeTrue(), "PID file should exist")
+
+				// 4) Read PID and sanity-check it's a live process.
+				pid, readErr := process.ReadPIDFile(serverName)
+				Expect(readErr).ToNot(HaveOccurred(), "should be able to read PID file")
+				Expect(pid).To(BeNumerically(">", 0), "PID should be a positive integer")
+
+				// Optional: on Unix, send signal 0 as a non-killing liveness probe.
+				if os.PathSeparator == '/' {
+					p, findErr := os.FindProcess(pid)
+					Expect(findErr).ToNot(HaveOccurred())
+					_ = p.Signal(syscall.Signal(0)) // best-effort; error handling not strict here
+				}
+
+				// 5) Dwell 5 seconds, then confirm health/ready.
+				By("waiting 5 seconds and checking health")
+				time.Sleep(5 * time.Second)
+
+				stdout, _ := e2e.NewTHVCommand(config, "list").ExpectSuccess()
+				Expect(stdout).To(ContainSubstring(serverName), "server should be listed")
+				Expect(stdout).To(ContainSubstring("running"), "server should be running")
+
+				if serverURL, gerr := e2e.GetMCPServerURL(config, serverName); gerr == nil {
+					rerr := e2e.WaitForMCPServerReady(config, serverURL, "sse", 15*time.Second)
+					Expect(rerr).ToNot(HaveOccurred(), "server should be protocol-ready")
+				}
+
+				// 6) Stop the server; this should unblock the goroutine.
+				By("stopping the foreground server")
+				_, _ = e2e.NewTHVCommand(config, "stop", serverName).ExpectSuccess()
+
+				// Wait for the run goroutine to exit.
+				select {
+				case <-done:
+					// ok
+				case <-time.After(15 * time.Second):
+					Fail("foreground run did not exit after stop; stdout="+fgStdout+" stderr="+fgStderr, 1)
+				}
+
+				// 7) PID file should be removed after stop.
+				By("verifying PID file removal")
+				Eventually(func() bool {
+					_, statErr := os.Stat(pidFile)
+					return os.IsNotExist(statErr)
+				}, 15*time.Second, 200*time.Millisecond).Should(BeTrue(), "PID file should be removed after stop")
+
+			})
 		})
 
 	})


### PR DESCRIPTION
If not, the proxy pid file is not detected and workload is marked as unhealthy

Closes: #1587