### PR TITLE
Implement environment variable secrets fallback mechanism

### DIFF
--- a/cmd/thv/app/common.go
+++ b/cmd/thv/app/common.go
@@ -57,10 +57,12 @@ func SetSecretsProvider(provider secrets.ProviderType) error {
 	case secrets.EncryptedType:
 	case secrets.OnePasswordType:
 	case secrets.NoneType:
+	case secrets.EnvironmentType:
 		// Valid provider type
 	default:
-		return fmt.Errorf("invalid secrets provider type: %s (valid types: %s, %s, %s)",
-			provider, string(secrets.EncryptedType), string(secrets.OnePasswordType), string(secrets.NoneType))
+		return fmt.Errorf("invalid secrets provider type: %s (valid types: %s, %s, %s, %s)",
+			provider, string(secrets.EncryptedType), string(secrets.OnePasswordType),
+			string(secrets.NoneType), string(secrets.EnvironmentType))
 	}
 
 	// Validate that the provider can be created and works correctly

--- a/cmd/thv/app/secret.go
+++ b/cmd/thv/app/secret.go
@@ -423,6 +423,10 @@ For more information, visit: https://developer.1password.com/docs/service-accoun
 		fmt.Println(`Setting up none secrets provider...
 Secrets functionality will be disabled.
 No secrets will be stored or retrieved.`)
+	case secrets.EnvironmentType:
+		fmt.Println(`Setting up environment variable secrets provider...
+Secrets will be read from environment variables with the TOOLHIVE_SECRET_ prefix.
+This provider is read-only and suitable for CI/CD and containerized environments.`)
 	}
 
 	// SetSecretsProvider will handle validation and configuration

--- a/docs/proposals/environment-variable-secrets-fallback.md
+++ b/docs/proposals/environment-variable-secrets-fallback.md
@@ -1,0 +1,447 @@
+# Environment Variable Secrets Fallback Mechanism
+
+## Problem Statement
+
+Currently, ToolHive requires secrets to exist within the configured key manager (encrypted file, 1Password, or none provider) in order to be used by MCP servers. While this approach provides excellent security for interactive use cases, it presents challenges for:
+
+- **CI/CD Systems**: Automated pipelines that cannot interact with keyrings or password managers
+- **Container Deployments**: Kubernetes pods and Docker containers where secrets are typically injected as environment variables
+- **Automated Workflows**: Scripts and automation tools that need to run without user interaction
+- **Cloud Environments**: Serverless functions and cloud services that provide secrets through environment variables
+
+## Goals
+
+- Provide a standalone environment variable secrets provider that can be used as a primary provider
+- Create a fallback wrapper that can wrap any provider with environment variable fallback
+- Maintain backward compatibility with existing secret management workflows
+- Enable seamless operation in CI/CD and containerized environments
+- Preserve security by using a clear naming convention that prevents accidental exposure
+
+## Non-Goals
+
+- Replace the existing secrets providers
+- Support write operations for environment variable secrets (read-only by nature)
+- Support listing of environment variable secrets (for security reasons)
+
+## Architecture Overview
+
+The solution introduces two new components:
+
+1. **Environment Provider**: A standalone provider that reads secrets from environment variables
+2. **Fallback Provider**: A wrapper that adds environment variable fallback to any existing provider
+
+```
+┌─────────────────────────────────────────────────┐
+│                Application Code                  │
+└─────────────────┬────────────────────────────────┘
+                  │
+                  ├─── Option 1: Direct Environment Provider
+                  │
+                  │    ┌──────────────────────────┐
+                  │    │  Environment Provider    │
+                  │    │  (Standalone Provider)    │
+                  │    │  • Read-only              │
+                  │    │  • Cannot list secrets   │
+                  │    └──────────────────────────┘
+                  │
+                  └─── Option 2: Fallback Wrapper
+                  
+                       ┌──────────────────────────┐
+                       │  Fallback Provider       │
+                       │  (Wrapper)               │
+                       │  • Try primary first     │
+                       │  • Fallback to env vars  │
+                       └────────┬─────────────────┘
+                                │
+                       ┌────────┴────────┐
+                       ▼                 ▼
+              ┌──────────────┐  ┌──────────────┐
+              │   Primary    │  │ Environment  │
+              │   Provider   │  │   Fallback   │
+              │ • Encrypted  │  │ TOOLHIVE_    │
+              │ • 1Password  │  │ SECRET_*     │
+              │ • None       │  └──────────────┘
+              └──────────────┘
+```
+
+## Detailed Design
+
+### 1. Environment Variable Naming Convention
+
+Environment variables for secrets will follow a strict naming pattern:
+```
+TOOLHIVE_SECRET_<secret_name>
+```
+
+Where `<secret_name>` is the **exact** secret name as it would be referenced in ToolHive. No transformation or case conversion is performed.
+
+**Examples:**
+- Secret `github_token` → `TOOLHIVE_SECRET_github_token`
+- Secret `GITHUB_TOKEN` → `TOOLHIVE_SECRET_GITHUB_TOKEN`
+- Secret `api-key` → `TOOLHIVE_SECRET_api-key`
+
+### 2. Environment Provider Implementation
+
+Create a new standalone environment provider in `pkg/secrets/environment.go`:
+
+```go
+package secrets
+
+import (
+    "context"
+    "errors"
+    "fmt"
+    "os"
+    "strings"
+)
+
+// EnvironmentProvider reads secrets from environment variables
+type EnvironmentProvider struct {
+    prefix string
+}
+
+// NewEnvironmentProvider creates a new environment variable secrets provider
+func NewEnvironmentProvider() Provider {
+    return &EnvironmentProvider{
+        prefix: EnvVarPrefix,
+    }
+}
+
+// GetSecret retrieves a secret from environment variables
+func (e *EnvironmentProvider) GetSecret(_ context.Context, name string) (string, error) {
+    if name == "" {
+        return "", errors.New("secret name cannot be empty")
+    }
+    
+    envVar := e.prefix + name
+    value := os.Getenv(envVar)
+    if value == "" {
+        return "", fmt.Errorf("secret not found: %s", name)
+    }
+    
+    return value, nil
+}
+
+// SetSecret is not supported for environment variables
+func (e *EnvironmentProvider) SetSecret(_ context.Context, name, _ string) error {
+    if name == "" {
+        return errors.New("secret name cannot be empty")
+    }
+    return errors.New("environment provider is read-only")
+}
+
+// DeleteSecret is not supported for environment variables
+func (e *EnvironmentProvider) DeleteSecret(_ context.Context, name string) error {
+    if name == "" {
+        return errors.New("secret name cannot be empty")
+    }
+    return errors.New("environment provider is read-only")
+}
+
+// ListSecrets is not supported for environment variables for security reasons
+func (e *EnvironmentProvider) ListSecrets(_ context.Context) ([]SecretDescription, error) {
+	return nil, errors.New("environment provider does not support listing secrets for security reasons")
+}
+
+// Cleanup is a no-op for environment provider
+func (e *EnvironmentProvider) Cleanup() error {
+    return nil
+}
+
+// Capabilities returns the capabilities of the environment provider
+func (e *EnvironmentProvider) Capabilities() ProviderCapabilities {
+	return ProviderCapabilities{
+		CanRead:    true,
+		CanWrite:   false,
+		CanDelete:  false,
+		CanList:    false,
+		CanCleanup: false,
+	}
+}
+```
+
+### 3. Fallback Provider Implementation
+
+Create a fallback wrapper in `pkg/secrets/fallback.go`:
+
+```go
+package secrets
+
+import (
+    "context"
+    "os"
+    "strings"
+)
+
+// FallbackProvider wraps a primary provider with environment variable fallback
+type FallbackProvider struct {
+    primary Provider
+    envProvider Provider
+}
+
+// NewFallbackProvider creates a new provider with environment variable fallback
+func NewFallbackProvider(primary Provider) Provider {
+    return &FallbackProvider{
+        primary: primary,
+        envProvider: &EnvironmentProvider{
+            prefix: EnvVarPrefix,
+        },
+    }
+}
+
+// GetSecret attempts to get a secret from the primary provider,
+// falling back to environment variables if not found
+func (f *FallbackProvider) GetSecret(ctx context.Context, name string) (string, error) {
+    // First, try the primary provider
+    value, err := f.primary.GetSecret(ctx, name)
+    if err == nil {
+        return value, nil
+    }
+    
+    // Check if it's a "not found" error
+    if !isNotFoundError(err) {
+        return "", err
+    }
+    
+    // Try environment variable fallback
+    envValue, envErr := f.envProvider.GetSecret(ctx, name)
+    if envErr == nil {
+        logger.Debugf("Secret '%s' retrieved from environment variable fallback", name)
+        return envValue, nil
+    }
+    
+    // Return the original error if no fallback found
+    return "", err
+}
+
+// SetSecret always uses the primary provider (no env var writes)
+func (f *FallbackProvider) SetSecret(ctx context.Context, name, value string) error {
+    return f.primary.SetSecret(ctx, name, value)
+}
+
+// DeleteSecret always uses the primary provider (no env var deletes)
+func (f *FallbackProvider) DeleteSecret(ctx context.Context, name string) error {
+    return f.primary.DeleteSecret(ctx, name)
+}
+
+// ListSecrets only lists from the primary provider 
+// (env vars not listed in fallback mode for security)
+func (f *FallbackProvider) ListSecrets(ctx context.Context) ([]SecretDescription, error) {
+    return f.primary.ListSecrets(ctx)
+}
+
+// Cleanup delegates to the primary provider
+func (f *FallbackProvider) Cleanup() error {
+    return f.primary.Cleanup()
+}
+
+// Capabilities returns the primary provider's capabilities
+func (f *FallbackProvider) Capabilities() ProviderCapabilities {
+    return f.primary.Capabilities()
+}
+
+// isNotFoundError checks if an error indicates a secret was not found
+func isNotFoundError(err error) bool {
+    if err == nil {
+        return false
+    }
+    errStr := err.Error()
+    return strings.Contains(errStr, "not found") || 
+           strings.Contains(errStr, "does not exist")
+}
+```
+
+### 4. Factory Integration
+
+Modify `pkg/secrets/factory.go` to support both the environment provider and fallback wrapper:
+
+```go
+// Add new provider type
+const (
+    // ... existing types ...
+    
+    // EnvironmentType represents the environment variable secret provider
+    EnvironmentType ProviderType = "environment"
+)
+
+// CreateSecretProvider creates the specified type of secrets provider
+func CreateSecretProvider(managerType ProviderType) (Provider, error) {
+    return CreateSecretProviderWithPassword(managerType, "")
+}
+
+// CreateSecretProviderWithPassword creates the specified type of secrets provider
+func CreateSecretProviderWithPassword(managerType ProviderType, password string) (Provider, error) {
+    // Create the primary provider
+    var primary Provider
+    var err error
+    
+    switch managerType {
+    case EncryptedType:
+        // ... existing encrypted provider logic ...
+        primary, err = createEncryptedProvider(password)
+    case OnePasswordType:
+        primary, err = NewOnePasswordManager()
+    case NoneType:
+        primary, err = NewNoneManager()
+    case EnvironmentType:
+        // Direct environment provider - no fallback needed
+        return NewEnvironmentProvider(), nil
+    default:
+        return nil, ErrUnknownManagerType
+    }
+    
+    if err != nil {
+        return nil, err
+    }
+    
+    // Wrap with fallback provider if enabled
+    if shouldEnableFallback() {
+        return NewFallbackProvider(primary), nil
+    }
+    
+    return primary, nil
+}
+
+// shouldEnableFallback determines if environment variable fallback should be enabled
+func shouldEnableFallback() bool {
+    // Check for explicit opt-out
+    if os.Getenv("TOOLHIVE_DISABLE_ENV_FALLBACK") == "true" {
+        return false
+    }
+    
+    // Enable by default for non-environment providers
+    return true
+}
+```
+
+## Security Considerations
+
+### 1. Namespace Isolation
+The `TOOLHIVE_SECRET_` prefix ensures clear separation from other environment variables.
+
+### 2. Read-Only Nature
+Environment variables are inherently read-only in the provider, preventing accidental modifications.
+
+### 3. Audit Logging
+When a secret is retrieved from environment variables (either directly or via fallback), this is logged at debug level.
+
+### 4. No Listing Support
+Environment variable secrets do not support listing operations to prevent enumeration and accidental exposure of secret names in logs or output.
+
+## Use Cases
+
+### 1. GitHub Actions (StacklokLabs/toolhive-actions)
+
+The [toolhive-actions](https://github.com/StacklokLabs/toolhive-actions) repository currently has TODOs for secrets support. With this implementation, the action can be updated to support secrets:
+
+```yaml
+# In the run-mcp-server action.yml, the TODO for secrets can be resolved:
+- name: Run GitHub MCP Server
+  uses: stackloklabs/toolhive-actions/run-mcp-server@v0
+  env:
+    # Secrets are passed as environment variables with the TOOLHIVE_SECRET_ prefix
+    TOOLHIVE_SECRET_github_token: ${{ secrets.GITHUB_TOKEN }}
+    TOOLHIVE_SECRET_npm_token: ${{ secrets.NPM_TOKEN }}
+  with:
+    server: github
+    # The action can now use these secrets without complex setup
+```
+
+The action's build command step can be updated to reference secrets:
+```bash
+# In the action implementation
+if [ -n "${{ inputs.secrets }}" ]; then
+  # Parse JSON secrets and set as environment variables
+  echo "${{ inputs.secrets }}" | jq -r 'to_entries[] | "TOOLHIVE_SECRET_\(.key)=\(.value)"' >> $GITHUB_ENV
+fi
+
+# Then run with secrets available via environment fallback
+thv run --secret github_token,target=GITHUB_TOKEN github
+```
+
+### 2. Kubernetes Operator (thv-operator)
+
+The ToolHive operator already has support for secrets via the `MCPServerPodTemplateSpecBuilder`. With the environment variable fallback, secrets can be injected using the `TOOLHIVE_SECRET_` prefix:
+
+```yaml
+apiVersion: toolhive.stacklok.io/v1alpha1
+kind: MCPServer
+metadata:
+  name: github-server
+spec:
+  server: github
+  # The operator's WithSecrets method already handles secret injection
+  secrets:
+    - name: github-credentials
+      key: token
+      targetEnvName: TOOLHIVE_SECRET_github_token  # Uses our prefix
+    - name: api-credentials
+      key: key
+      targetEnvName: TOOLHIVE_SECRET_api_key
+```
+
+The operator's `WithSecrets` method in `mcpserver_podtemplatespec_builder.go` already creates the appropriate environment variables:
+```go
+// From the operator implementation
+secretEnvVars = append(secretEnvVars, corev1.EnvVar{
+    Name: targetEnv,  // This would be TOOLHIVE_SECRET_github_token
+    ValueFrom: &corev1.EnvVarSource{
+        SecretKeyRef: &corev1.SecretKeySelector{
+            LocalObjectReference: corev1.LocalObjectReference{
+                Name: secret.Name,
+            },
+            Key: secret.Key,
+        },
+    },
+})
+```
+
+### 3. Local Development with Fallback
+
+```bash
+# Use existing provider with fallback for temporary secrets
+export TOOLHIVE_SECRETS_PROVIDER=encrypted  # or 1password
+
+# Add temporary secrets via environment
+export TOOLHIVE_SECRET_dev_token="dev-token-12345"
+export TOOLHIVE_SECRET_test_api_key="test-key-67890"
+
+# Permanent secrets from keyring, temporary from environment
+thv run --secret api_key,target=API_KEY my-server
+```
+
+### 4. CI/CD with Direct Environment Provider
+
+```yaml
+# GitHub Actions with explicit environment provider
+- name: Setup ToolHive for CI
+  run: |
+    # Use environment provider directly in CI
+    export TOOLHIVE_SECRETS_PROVIDER=environment
+    export TOOLHIVE_SECRET_github_token=${{ secrets.GITHUB_TOKEN }}
+    export TOOLHIVE_SECRET_npm_token=${{ secrets.NPM_TOKEN }}
+    
+    # All secrets come from environment variables
+    thv run --secret github_token,target=GITHUB_TOKEN github
+```
+
+### 5. Production with Disabled Fallback
+
+```bash
+# Strict production setup - no fallback
+export TOOLHIVE_DISABLE_ENV_FALLBACK=true
+export TOOLHIVE_SECRETS_PROVIDER=1password
+
+# Will only use 1Password, no environment fallback
+# This ensures all secrets come from the secure provider
+thv run --secret api_key,target=API_KEY my-server
+```
+
+## Conclusion
+
+This modular design provides maximum flexibility by offering both a standalone environment provider and a fallback wrapper. Organizations can choose the approach that best fits their security requirements:
+
+- **Environment Provider**: Simple, direct access to environment variables for CI/CD
+- **Fallback Wrapper**: Enhanced existing providers with environment variable fallback for mixed environments
+
+The implementation maintains backward compatibility while enabling new deployment scenarios, particularly in automated and containerized environments where traditional secret management is challenging.

--- a/pkg/secrets/environment.go
+++ b/pkg/secrets/environment.go
@@ -1,0 +1,72 @@
+package secrets
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+)
+
+// EnvironmentProvider reads secrets from environment variables
+type EnvironmentProvider struct {
+	prefix string
+}
+
+// NewEnvironmentProvider creates a new environment variable secrets provider
+func NewEnvironmentProvider() Provider {
+	return &EnvironmentProvider{
+		prefix: EnvVarPrefix,
+	}
+}
+
+// GetSecret retrieves a secret from environment variables
+func (e *EnvironmentProvider) GetSecret(_ context.Context, name string) (string, error) {
+	if name == "" {
+		return "", errors.New("secret name cannot be empty")
+	}
+
+	envVar := e.prefix + name
+	value := os.Getenv(envVar)
+	if value == "" {
+		return "", fmt.Errorf("secret not found: %s", name)
+	}
+
+	return value, nil
+}
+
+// SetSecret is not supported for environment variables
+func (*EnvironmentProvider) SetSecret(_ context.Context, name, _ string) error {
+	if name == "" {
+		return errors.New("secret name cannot be empty")
+	}
+	return errors.New("environment provider is read-only")
+}
+
+// DeleteSecret is not supported for environment variables
+func (*EnvironmentProvider) DeleteSecret(_ context.Context, name string) error {
+	if name == "" {
+		return errors.New("secret name cannot be empty")
+	}
+	return errors.New("environment provider is read-only")
+}
+
+// ListSecrets is not supported for environment variables for security reasons
+func (*EnvironmentProvider) ListSecrets(_ context.Context) ([]SecretDescription, error) {
+	return nil, errors.New("environment provider does not support listing secrets for security reasons")
+}
+
+// Cleanup is a no-op for environment provider
+func (*EnvironmentProvider) Cleanup() error {
+	return nil
+}
+
+// Capabilities returns the capabilities of the environment provider
+func (*EnvironmentProvider) Capabilities() ProviderCapabilities {
+	return ProviderCapabilities{
+		CanRead:    true,
+		CanWrite:   false,
+		CanDelete:  false,
+		CanList:    false,
+		CanCleanup: false,
+	}
+}

--- a/pkg/secrets/environment_test.go
+++ b/pkg/secrets/environment_test.go
@@ -1,0 +1,191 @@
+package secrets_test
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stacklok/toolhive/pkg/secrets"
+)
+
+func TestEnvironmentProvider_GetSecret(t *testing.T) { //nolint:paralleltest
+	provider := secrets.NewEnvironmentProvider()
+	ctx := context.Background()
+
+	t.Run("successful retrieval", func(t *testing.T) { //nolint:paralleltest
+		// Set up environment variable
+		secretName := "test_secret"
+		secretValue := "test_value"
+		envVar := secrets.EnvVarPrefix + secretName
+
+		err := os.Setenv(envVar, secretValue)
+		require.NoError(t, err)
+		defer os.Unsetenv(envVar)
+
+		// Test retrieval
+		result, err := provider.GetSecret(ctx, secretName)
+		assert.NoError(t, err)
+		assert.Equal(t, secretValue, result)
+	})
+
+	t.Run("secret not found", func(t *testing.T) { //nolint:paralleltest
+		secretName := "nonexistent_secret"
+
+		// Ensure the environment variable doesn't exist
+		envVar := secrets.EnvVarPrefix + secretName
+		os.Unsetenv(envVar)
+
+		// Test retrieval
+		result, err := provider.GetSecret(ctx, secretName)
+		assert.Error(t, err)
+		assert.Empty(t, result)
+		assert.Contains(t, err.Error(), "secret not found")
+	})
+
+	t.Run("empty secret name", func(t *testing.T) { //nolint:paralleltest
+		result, err := provider.GetSecret(ctx, "")
+		assert.Error(t, err)
+		assert.Empty(t, result)
+		assert.Contains(t, err.Error(), "secret name cannot be empty")
+	})
+
+	t.Run("empty environment variable value", func(t *testing.T) { //nolint:paralleltest
+		secretName := "empty_secret"
+		envVar := secrets.EnvVarPrefix + secretName
+
+		err := os.Setenv(envVar, "")
+		require.NoError(t, err)
+		defer os.Unsetenv(envVar)
+
+		// Test retrieval - empty value should be treated as not found
+		result, err := provider.GetSecret(ctx, secretName)
+		assert.Error(t, err)
+		assert.Empty(t, result)
+		assert.Contains(t, err.Error(), "secret not found")
+	})
+}
+
+func TestEnvironmentProvider_SetSecret(t *testing.T) { //nolint:paralleltest
+	provider := secrets.NewEnvironmentProvider()
+	ctx := context.Background()
+
+	t.Run("set secret not supported", func(t *testing.T) { //nolint:paralleltest
+		err := provider.SetSecret(ctx, "test_secret", "test_value")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "environment provider is read-only")
+	})
+
+	t.Run("empty secret name", func(t *testing.T) { //nolint:paralleltest
+		err := provider.SetSecret(ctx, "", "test_value")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "secret name cannot be empty")
+	})
+}
+
+func TestEnvironmentProvider_DeleteSecret(t *testing.T) { //nolint:paralleltest
+	provider := secrets.NewEnvironmentProvider()
+	ctx := context.Background()
+
+	t.Run("delete secret not supported", func(t *testing.T) { //nolint:paralleltest
+		err := provider.DeleteSecret(ctx, "test_secret")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "environment provider is read-only")
+	})
+
+	t.Run("empty secret name", func(t *testing.T) { //nolint:paralleltest
+		err := provider.DeleteSecret(ctx, "")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "secret name cannot be empty")
+	})
+}
+
+func TestEnvironmentProvider_ListSecrets(t *testing.T) { //nolint:paralleltest
+	provider := secrets.NewEnvironmentProvider()
+	ctx := context.Background()
+
+	t.Run("list secrets not supported", func(t *testing.T) { //nolint:paralleltest
+		secrets, err := provider.ListSecrets(ctx)
+		assert.Error(t, err)
+		assert.Nil(t, secrets)
+		assert.Contains(t, err.Error(), "environment provider does not support listing secrets for security reasons")
+	})
+}
+
+func TestEnvironmentProvider_Cleanup(t *testing.T) { //nolint:paralleltest
+	provider := secrets.NewEnvironmentProvider()
+
+	t.Run("cleanup is no-op", func(t *testing.T) { //nolint:paralleltest
+		err := provider.Cleanup()
+		assert.NoError(t, err)
+	})
+}
+
+func TestEnvironmentProvider_Capabilities(t *testing.T) { //nolint:paralleltest
+	provider := secrets.NewEnvironmentProvider()
+
+	t.Run("correct capabilities", func(t *testing.T) { //nolint:paralleltest
+		caps := provider.Capabilities()
+		assert.True(t, caps.CanRead)
+		assert.False(t, caps.CanWrite)
+		assert.False(t, caps.CanDelete)
+		assert.False(t, caps.CanList)
+		assert.False(t, caps.CanCleanup)
+		assert.True(t, caps.IsReadOnly())
+		assert.False(t, caps.IsReadWrite())
+	})
+}
+
+func TestEnvironmentProvider_Integration(t *testing.T) { //nolint:paralleltest
+	provider := secrets.NewEnvironmentProvider()
+	ctx := context.Background()
+
+	t.Run("multiple secrets", func(t *testing.T) { //nolint:paralleltest
+		// Set up multiple environment variables
+		testSecrets := map[string]string{
+			"api_key":      "key123",
+			"database_url": "postgres://localhost/test",
+			"token":        "abc-def-ghi",
+		}
+
+		// Set environment variables
+		for name, value := range testSecrets {
+			envVar := secrets.EnvVarPrefix + name
+			err := os.Setenv(envVar, value)
+			require.NoError(t, err)
+			defer os.Unsetenv(envVar)
+		}
+
+		// Test retrieval of all secrets
+		for name, expectedValue := range testSecrets {
+			result, err := provider.GetSecret(ctx, name)
+			assert.NoError(t, err)
+			assert.Equal(t, expectedValue, result)
+		}
+	})
+
+	t.Run("special characters in secret names", func(t *testing.T) { //nolint:paralleltest
+		testCases := []struct {
+			name  string
+			value string
+		}{
+			{"api-key", "value1"},
+			{"API_KEY", "value2"},
+			{"secret.name", "value3"},
+			{"secret_123", "value4"},
+		}
+
+		for _, tc := range testCases {
+			envVar := secrets.EnvVarPrefix + tc.name
+			err := os.Setenv(envVar, tc.value)
+			require.NoError(t, err)
+			defer os.Unsetenv(envVar)
+
+			result, err := provider.GetSecret(ctx, tc.name)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.value, result)
+		}
+	})
+}

--- a/pkg/secrets/factory_test.go
+++ b/pkg/secrets/factory_test.go
@@ -1,0 +1,196 @@
+package secrets_test
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stacklok/toolhive/pkg/secrets"
+)
+
+const (
+	testSecretValue = "fallback_value"
+)
+
+func TestCreateSecretProvider(t *testing.T) { //nolint:paralleltest
+	ctx := context.Background()
+
+	t.Run("environment provider", func(t *testing.T) { //nolint:paralleltest
+		provider, err := secrets.CreateSecretProvider(secrets.EnvironmentType)
+		require.NoError(t, err)
+		require.NotNil(t, provider)
+
+		// Verify it's an environment provider by checking capabilities
+		caps := provider.Capabilities()
+		assert.True(t, caps.CanRead)
+		assert.False(t, caps.CanWrite)
+		assert.False(t, caps.CanDelete)
+		assert.False(t, caps.CanList)
+		assert.False(t, caps.CanCleanup)
+
+		// Test basic functionality
+		_, err = provider.GetSecret(ctx, "nonexistent")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "secret not found")
+	})
+
+	t.Run("none provider with fallback", func(t *testing.T) { //nolint:paralleltest
+		// Set up environment variable for fallback
+		secretName := "fallback_test"
+		secretValue := testSecretValue
+		envVar := secrets.EnvVarPrefix + secretName
+
+		err := os.Setenv(envVar, secretValue)
+		require.NoError(t, err)
+		defer os.Unsetenv(envVar)
+
+		provider, err := secrets.CreateSecretProvider(secrets.NoneType)
+		require.NoError(t, err)
+		require.NotNil(t, provider)
+
+		// Should be wrapped with fallback provider
+		// Test that it falls back to environment variables
+		result, err := provider.GetSecret(ctx, secretName)
+		assert.NoError(t, err)
+		assert.Equal(t, secretValue, result)
+	})
+
+	t.Run("unknown provider type", func(t *testing.T) { //nolint:paralleltest
+		provider, err := secrets.CreateSecretProvider(secrets.ProviderType("unknown"))
+		assert.Error(t, err)
+		assert.Nil(t, provider)
+		assert.Equal(t, secrets.ErrUnknownManagerType, err)
+	})
+}
+
+func TestCreateSecretProviderWithPassword(t *testing.T) { //nolint:paralleltest
+	t.Run("environment provider ignores password", func(t *testing.T) { //nolint:paralleltest
+		provider, err := secrets.CreateSecretProviderWithPassword(secrets.EnvironmentType, "ignored_password")
+		require.NoError(t, err)
+		require.NotNil(t, provider)
+
+		// Verify it's still an environment provider
+		caps := provider.Capabilities()
+		assert.True(t, caps.CanRead)
+		assert.False(t, caps.CanWrite)
+	})
+}
+
+func TestValidateProvider(t *testing.T) { //nolint:paralleltest
+	ctx := context.Background()
+
+	t.Run("environment provider validation", func(t *testing.T) { //nolint:paralleltest
+		result := secrets.ValidateProvider(ctx, secrets.EnvironmentType)
+		require.NotNil(t, result)
+		assert.Equal(t, secrets.EnvironmentType, result.ProviderType)
+		assert.True(t, result.Success)
+		assert.Contains(t, result.Message, "Environment provider validation successful")
+		assert.NoError(t, result.Error)
+	})
+
+	t.Run("none provider validation", func(t *testing.T) { //nolint:paralleltest
+		result := secrets.ValidateProvider(ctx, secrets.NoneType)
+		require.NotNil(t, result)
+		assert.Equal(t, secrets.NoneType, result.ProviderType)
+		assert.True(t, result.Success)
+		assert.Contains(t, result.Message, "None provider validation successful")
+		assert.NoError(t, result.Error)
+	})
+
+	t.Run("unknown provider validation", func(t *testing.T) { //nolint:paralleltest
+		result := secrets.ValidateProvider(ctx, secrets.ProviderType("unknown"))
+		require.NotNil(t, result)
+		assert.Equal(t, secrets.ProviderType("unknown"), result.ProviderType)
+		assert.False(t, result.Success)
+		assert.Contains(t, result.Message, "Failed to initialize unknown provider")
+		assert.Error(t, result.Error)
+	})
+}
+
+func TestValidateEnvironmentProvider(t *testing.T) { //nolint:paralleltest
+	ctx := context.Background()
+
+	t.Run("successful validation", func(t *testing.T) { //nolint:paralleltest
+		provider := secrets.NewEnvironmentProvider()
+		result := &secrets.SetupResult{
+			ProviderType: secrets.EnvironmentType,
+			Success:      false,
+		}
+
+		result = secrets.ValidateEnvironmentProvider(ctx, provider, result)
+		assert.True(t, result.Success)
+		assert.Contains(t, result.Message, "Environment provider validation successful")
+		assert.NoError(t, result.Error)
+	})
+}
+
+func TestFallbackIntegration(t *testing.T) { //nolint:paralleltest
+	ctx := context.Background()
+
+	t.Run("fallback disabled creates direct provider", func(t *testing.T) { //nolint:paralleltest
+		// Disable fallback
+		err := os.Setenv("TOOLHIVE_DISABLE_ENV_FALLBACK", "true")
+		require.NoError(t, err)
+		defer os.Unsetenv("TOOLHIVE_DISABLE_ENV_FALLBACK")
+
+		// Set up environment variable that should NOT be accessible
+		secretName := "disabled_fallback_test"
+		secretValue := testSecretValue
+		envVar := secrets.EnvVarPrefix + secretName
+
+		err = os.Setenv(envVar, secretValue)
+		require.NoError(t, err)
+		defer os.Unsetenv(envVar)
+
+		// Create none provider (should not have fallback)
+		provider, err := secrets.CreateSecretProvider(secrets.NoneType)
+		require.NoError(t, err)
+
+		// Should not be able to access environment variable
+		result, err := provider.GetSecret(ctx, secretName)
+		assert.Error(t, err)
+		assert.Empty(t, result)
+		assert.Contains(t, err.Error(), "none provider doesn't store secrets")
+	})
+
+	t.Run("fallback enabled allows environment access", func(t *testing.T) { //nolint:paralleltest
+		// Ensure fallback is enabled
+		os.Unsetenv("TOOLHIVE_DISABLE_ENV_FALLBACK")
+
+		// Set up environment variable
+		secretName := "enabled_fallback_test"
+		secretValue := testSecretValue
+		envVar := secrets.EnvVarPrefix + secretName
+
+		err := os.Setenv(envVar, secretValue)
+		require.NoError(t, err)
+		defer os.Unsetenv(envVar)
+
+		// Create none provider (should have fallback)
+		provider, err := secrets.CreateSecretProvider(secrets.NoneType)
+		require.NoError(t, err)
+
+		// Should be able to access environment variable via fallback
+		result, err := provider.GetSecret(ctx, secretName)
+		assert.NoError(t, err)
+		assert.Equal(t, secretValue, result)
+	})
+}
+
+func TestProviderTypes(t *testing.T) { //nolint:paralleltest
+	t.Run("all provider types are valid strings", func(t *testing.T) { //nolint:paralleltest
+		assert.Equal(t, "encrypted", string(secrets.EncryptedType))
+		assert.Equal(t, "1password", string(secrets.OnePasswordType))
+		assert.Equal(t, "none", string(secrets.NoneType))
+		assert.Equal(t, "environment", string(secrets.EnvironmentType))
+	})
+}
+
+func TestEnvVarPrefix(t *testing.T) { //nolint:paralleltest
+	t.Run("correct prefix constant", func(t *testing.T) { //nolint:paralleltest
+		assert.Equal(t, "TOOLHIVE_SECRET_", secrets.EnvVarPrefix)
+	})
+}

--- a/pkg/secrets/fallback.go
+++ b/pkg/secrets/fallback.go
@@ -1,0 +1,85 @@
+package secrets
+
+import (
+	"context"
+	"strings"
+
+	"github.com/stacklok/toolhive/pkg/logger"
+)
+
+// FallbackProvider wraps a primary provider with environment variable fallback
+type FallbackProvider struct {
+	primary     Provider
+	envProvider Provider
+}
+
+// NewFallbackProvider creates a new provider with environment variable fallback
+func NewFallbackProvider(primary Provider) Provider {
+	return &FallbackProvider{
+		primary: primary,
+		envProvider: &EnvironmentProvider{
+			prefix: EnvVarPrefix,
+		},
+	}
+}
+
+// GetSecret attempts to get a secret from the primary provider,
+// falling back to environment variables if not found
+func (f *FallbackProvider) GetSecret(ctx context.Context, name string) (string, error) {
+	// First, try the primary provider
+	value, err := f.primary.GetSecret(ctx, name)
+	if err == nil {
+		return value, nil
+	}
+
+	// Check if it's a "not found" error
+	if !IsNotFoundError(err) {
+		return "", err
+	}
+
+	// Try environment variable fallback
+	envValue, envErr := f.envProvider.GetSecret(ctx, name)
+	if envErr == nil {
+		logger.Debugf("Secret '%s' retrieved from environment variable fallback", name)
+		return envValue, nil
+	}
+
+	// Return the original error if no fallback found
+	return "", err
+}
+
+// SetSecret always uses the primary provider (no env var writes)
+func (f *FallbackProvider) SetSecret(ctx context.Context, name, value string) error {
+	return f.primary.SetSecret(ctx, name, value)
+}
+
+// DeleteSecret always uses the primary provider (no env var deletes)
+func (f *FallbackProvider) DeleteSecret(ctx context.Context, name string) error {
+	return f.primary.DeleteSecret(ctx, name)
+}
+
+// ListSecrets only lists from the primary provider
+// (env vars not listed in fallback mode for security)
+func (f *FallbackProvider) ListSecrets(ctx context.Context) ([]SecretDescription, error) {
+	return f.primary.ListSecrets(ctx)
+}
+
+// Cleanup delegates to the primary provider
+func (f *FallbackProvider) Cleanup() error {
+	return f.primary.Cleanup()
+}
+
+// Capabilities returns the primary provider's capabilities
+func (f *FallbackProvider) Capabilities() ProviderCapabilities {
+	return f.primary.Capabilities()
+}
+
+// IsNotFoundError checks if an error indicates a secret was not found
+func IsNotFoundError(err error) bool {
+	if err == nil {
+		return false
+	}
+	errStr := err.Error()
+	return strings.Contains(errStr, "not found") ||
+		strings.Contains(errStr, "does not exist")
+}

--- a/pkg/secrets/fallback_test.go
+++ b/pkg/secrets/fallback_test.go
@@ -1,0 +1,347 @@
+package secrets_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/stacklok/toolhive/pkg/secrets"
+	"github.com/stacklok/toolhive/pkg/secrets/mocks"
+)
+
+func TestFallbackProvider_GetSecret(t *testing.T) { //nolint:paralleltest
+	ctx := context.Background()
+
+	t.Run("primary provider success", func(t *testing.T) { //nolint:paralleltest
+		// Create mock primary provider
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockPrimary := mocks.NewMockProvider(ctrl)
+		mockPrimary.EXPECT().GetSecret(ctx, "test_secret").Return("primary_value", nil)
+
+		// Create fallback provider
+		fallback := secrets.NewFallbackProvider(mockPrimary)
+
+		// Test - should get value from primary provider
+		result, err := fallback.GetSecret(ctx, "test_secret")
+		assert.NoError(t, err)
+		assert.Equal(t, "primary_value", result)
+	})
+
+	t.Run("primary provider not found, fallback success", func(t *testing.T) { //nolint:paralleltest
+		// Set up environment variable for fallback
+		secretName := "fallback_secret"
+		secretValue := "fallback_value"
+		envVar := secrets.EnvVarPrefix + secretName
+
+		err := os.Setenv(envVar, secretValue)
+		require.NoError(t, err)
+		defer os.Unsetenv(envVar)
+
+		// Create mock primary provider that returns "not found" error
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockPrimary := mocks.NewMockProvider(ctrl)
+		mockPrimary.EXPECT().GetSecret(ctx, secretName).Return("", errors.New("secret not found: fallback_secret"))
+
+		// Create fallback provider
+		fallback := secrets.NewFallbackProvider(mockPrimary)
+
+		// Test - should get value from environment fallback
+		result, err := fallback.GetSecret(ctx, secretName)
+		assert.NoError(t, err)
+		assert.Equal(t, secretValue, result)
+	})
+
+	t.Run("primary provider not found, fallback also not found", func(t *testing.T) { //nolint:paralleltest
+		secretName := "nonexistent_secret"
+
+		// Ensure environment variable doesn't exist
+		envVar := secrets.EnvVarPrefix + secretName
+		os.Unsetenv(envVar)
+
+		// Create mock primary provider that returns "not found" error
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockPrimary := mocks.NewMockProvider(ctrl)
+		primaryErr := errors.New("secret not found: nonexistent_secret")
+		mockPrimary.EXPECT().GetSecret(ctx, secretName).Return("", primaryErr)
+
+		// Create fallback provider
+		fallback := secrets.NewFallbackProvider(mockPrimary)
+
+		// Test - should return original primary error
+		result, err := fallback.GetSecret(ctx, secretName)
+		assert.Error(t, err)
+		assert.Empty(t, result)
+		assert.Equal(t, primaryErr, err)
+	})
+
+	t.Run("primary provider error (not not-found), no fallback", func(t *testing.T) { //nolint:paralleltest
+		secretName := "error_secret"
+
+		// Create mock primary provider that returns a different error
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockPrimary := mocks.NewMockProvider(ctrl)
+		primaryErr := errors.New("connection failed")
+		mockPrimary.EXPECT().GetSecret(ctx, secretName).Return("", primaryErr)
+
+		// Create fallback provider
+		fallback := secrets.NewFallbackProvider(mockPrimary)
+
+		// Test - should return primary error without trying fallback
+		result, err := fallback.GetSecret(ctx, secretName)
+		assert.Error(t, err)
+		assert.Empty(t, result)
+		assert.Equal(t, primaryErr, err)
+	})
+
+	t.Run("various not found error formats", func(t *testing.T) { //nolint:paralleltest
+		secretName := "test_secret"
+		secretValue := "fallback_value"
+		envVar := secrets.EnvVarPrefix + secretName
+
+		err := os.Setenv(envVar, secretValue)
+		require.NoError(t, err)
+		defer os.Unsetenv(envVar)
+
+		testCases := []string{
+			"secret not found: test_secret",
+			"Secret does not exist",
+			"item not found",
+			"key does not exist in vault",
+		}
+
+		for _, errMsg := range testCases {
+			ctrl := gomock.NewController(t)
+			mockPrimary := mocks.NewMockProvider(ctrl)
+			mockPrimary.EXPECT().GetSecret(ctx, secretName).Return("", errors.New(errMsg))
+
+			fallback := secrets.NewFallbackProvider(mockPrimary)
+
+			result, err := fallback.GetSecret(ctx, secretName)
+			assert.NoError(t, err)
+			assert.Equal(t, secretValue, result)
+			ctrl.Finish()
+		}
+	})
+}
+
+func TestFallbackProvider_SetSecret(t *testing.T) { //nolint:paralleltest
+	ctx := context.Background()
+
+	t.Run("delegates to primary provider", func(t *testing.T) { //nolint:paralleltest
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockPrimary := mocks.NewMockProvider(ctrl)
+		mockPrimary.EXPECT().SetSecret(ctx, "test_secret", "test_value").Return(nil)
+
+		fallback := secrets.NewFallbackProvider(mockPrimary)
+
+		err := fallback.SetSecret(ctx, "test_secret", "test_value")
+		assert.NoError(t, err)
+	})
+
+	t.Run("returns primary provider error", func(t *testing.T) { //nolint:paralleltest
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockPrimary := mocks.NewMockProvider(ctrl)
+		expectedErr := errors.New("write failed")
+		mockPrimary.EXPECT().SetSecret(ctx, "test_secret", "test_value").Return(expectedErr)
+
+		fallback := secrets.NewFallbackProvider(mockPrimary)
+
+		err := fallback.SetSecret(ctx, "test_secret", "test_value")
+		assert.Error(t, err)
+		assert.Equal(t, expectedErr, err)
+	})
+}
+
+func TestFallbackProvider_DeleteSecret(t *testing.T) { //nolint:paralleltest
+	ctx := context.Background()
+
+	t.Run("delegates to primary provider", func(t *testing.T) { //nolint:paralleltest
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockPrimary := mocks.NewMockProvider(ctrl)
+		mockPrimary.EXPECT().DeleteSecret(ctx, "test_secret").Return(nil)
+
+		fallback := secrets.NewFallbackProvider(mockPrimary)
+
+		err := fallback.DeleteSecret(ctx, "test_secret")
+		assert.NoError(t, err)
+	})
+
+	t.Run("returns primary provider error", func(t *testing.T) { //nolint:paralleltest
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockPrimary := mocks.NewMockProvider(ctrl)
+		expectedErr := errors.New("delete failed")
+		mockPrimary.EXPECT().DeleteSecret(ctx, "test_secret").Return(expectedErr)
+
+		fallback := secrets.NewFallbackProvider(mockPrimary)
+
+		err := fallback.DeleteSecret(ctx, "test_secret")
+		assert.Error(t, err)
+		assert.Equal(t, expectedErr, err)
+	})
+}
+
+func TestFallbackProvider_ListSecrets(t *testing.T) { //nolint:paralleltest
+	ctx := context.Background()
+
+	t.Run("delegates to primary provider only", func(t *testing.T) { //nolint:paralleltest
+		expectedSecrets := []secrets.SecretDescription{
+			{Key: "secret1", Description: "First secret"},
+			{Key: "secret2", Description: "Second secret"},
+		}
+
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockPrimary := mocks.NewMockProvider(ctrl)
+		mockPrimary.EXPECT().ListSecrets(ctx).Return(expectedSecrets, nil)
+
+		// Set up environment variables that should NOT be included
+		err := os.Setenv(secrets.EnvVarPrefix+"env_secret", "env_value")
+		require.NoError(t, err)
+		defer os.Unsetenv(secrets.EnvVarPrefix + "env_secret")
+
+		fallback := secrets.NewFallbackProvider(mockPrimary)
+
+		secrets, err := fallback.ListSecrets(ctx)
+		assert.NoError(t, err)
+		assert.Equal(t, expectedSecrets, secrets)
+		// Verify environment secrets are not included
+		for _, secret := range secrets {
+			assert.NotEqual(t, "env_secret", secret.Key)
+		}
+	})
+
+	t.Run("returns primary provider error", func(t *testing.T) { //nolint:paralleltest
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockPrimary := mocks.NewMockProvider(ctrl)
+		expectedErr := errors.New("list failed")
+		mockPrimary.EXPECT().ListSecrets(ctx).Return(nil, expectedErr)
+
+		fallback := secrets.NewFallbackProvider(mockPrimary)
+
+		secrets, err := fallback.ListSecrets(ctx)
+		assert.Error(t, err)
+		assert.Nil(t, secrets)
+		assert.Equal(t, expectedErr, err)
+	})
+}
+
+func TestFallbackProvider_Cleanup(t *testing.T) { //nolint:paralleltest
+	t.Run("delegates to primary provider", func(t *testing.T) { //nolint:paralleltest
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockPrimary := mocks.NewMockProvider(ctrl)
+		mockPrimary.EXPECT().Cleanup().Return(nil)
+
+		fallback := secrets.NewFallbackProvider(mockPrimary)
+
+		err := fallback.Cleanup()
+		assert.NoError(t, err)
+	})
+
+	t.Run("returns primary provider error", func(t *testing.T) { //nolint:paralleltest
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockPrimary := mocks.NewMockProvider(ctrl)
+		expectedErr := errors.New("cleanup failed")
+		mockPrimary.EXPECT().Cleanup().Return(expectedErr)
+
+		fallback := secrets.NewFallbackProvider(mockPrimary)
+
+		err := fallback.Cleanup()
+		assert.Error(t, err)
+		assert.Equal(t, expectedErr, err)
+	})
+}
+
+func TestFallbackProvider_Capabilities(t *testing.T) { //nolint:paralleltest
+	t.Run("returns primary provider capabilities", func(t *testing.T) { //nolint:paralleltest
+		expectedCaps := secrets.ProviderCapabilities{
+			CanRead:    true,
+			CanWrite:   true,
+			CanDelete:  true,
+			CanList:    true,
+			CanCleanup: true,
+		}
+
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockPrimary := mocks.NewMockProvider(ctrl)
+		mockPrimary.EXPECT().Capabilities().Return(expectedCaps)
+
+		fallback := secrets.NewFallbackProvider(mockPrimary)
+
+		caps := fallback.Capabilities()
+		assert.Equal(t, expectedCaps, caps)
+	})
+}
+
+func TestIsNotFoundError(t *testing.T) { //nolint:paralleltest
+	t.Run("recognizes not found errors", func(t *testing.T) { //nolint:paralleltest
+		testCases := []struct {
+			err      error
+			expected bool
+		}{
+			{nil, false},
+			{errors.New("secret not found"), true},
+			{errors.New("item not found"), true},
+			{errors.New("key does not exist"), true},
+			{errors.New("Secret does not exist"), true},
+			{errors.New("connection failed"), false},
+			{errors.New("invalid credentials"), false},
+			{errors.New("timeout"), false},
+		}
+
+		for _, tc := range testCases {
+			result := secrets.IsNotFoundError(tc.err)
+			assert.Equal(t, tc.expected, result, "Error: %v", tc.err)
+		}
+	})
+}
+
+func TestFallbackProvider_Integration(t *testing.T) { //nolint:paralleltest
+	ctx := context.Background()
+
+	t.Run("mixed primary and fallback secrets", func(t *testing.T) { //nolint:paralleltest
+		// Set up environment variables
+		err := os.Setenv(secrets.EnvVarPrefix+"env_only", "env_value")
+		require.NoError(t, err)
+		defer os.Unsetenv(secrets.EnvVarPrefix + "env_only")
+
+		// Create mock primary provider
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockPrimary := mocks.NewMockProvider(ctrl)
+
+		// Primary has this secret
+		mockPrimary.EXPECT().GetSecret(ctx, "primary_secret").Return("primary_value", nil)
+
+		// Primary doesn't have this secret (fallback will be used)
+		mockPrimary.EXPECT().GetSecret(ctx, "env_only").Return("", errors.New("secret not found: env_only"))
+
+		fallback := secrets.NewFallbackProvider(mockPrimary)
+
+		// Test primary secret
+		result, err := fallback.GetSecret(ctx, "primary_secret")
+		assert.NoError(t, err)
+		assert.Equal(t, "primary_value", result)
+
+		// Test fallback secret
+		result, err = fallback.GetSecret(ctx, "env_only")
+		assert.NoError(t, err)
+		assert.Equal(t, "env_value", result)
+	})
+}

--- a/pkg/secrets/integration_test.go
+++ b/pkg/secrets/integration_test.go
@@ -1,0 +1,215 @@
+package secrets_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/stacklok/toolhive/pkg/secrets"
+	"github.com/stacklok/toolhive/pkg/secrets/mocks"
+)
+
+const (
+	testSecretName = "test_secret"
+)
+
+func TestFallbackProvider_IntegrationTests(t *testing.T) { //nolint:paralleltest
+	ctx := context.Background()
+
+	t.Run("primary provider success", func(t *testing.T) { //nolint:paralleltest
+		// Create mock primary provider
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockPrimary := mocks.NewMockProvider(ctrl)
+		mockPrimary.EXPECT().GetSecret(ctx, "test_secret").Return("primary_value", nil)
+
+		// Create fallback provider
+		fallback := secrets.NewFallbackProvider(mockPrimary)
+
+		// Test - should get value from primary provider
+		result, err := fallback.GetSecret(ctx, "test_secret")
+		assert.NoError(t, err)
+		assert.Equal(t, "primary_value", result)
+	})
+
+	t.Run("primary provider not found, fallback success", func(t *testing.T) { //nolint:paralleltest
+		// Set up environment variable for fallback
+		secretName := "fallback_secret"
+		secretValue := testSecretValue
+		envVar := secrets.EnvVarPrefix + secretName
+
+		err := os.Setenv(envVar, secretValue)
+		require.NoError(t, err)
+		defer os.Unsetenv(envVar)
+
+		// Create mock primary provider that returns "not found" error
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockPrimary := mocks.NewMockProvider(ctrl)
+		mockPrimary.EXPECT().GetSecret(ctx, secretName).Return("", errors.New("secret not found: "+secretName))
+
+		// Create fallback provider
+		fallback := secrets.NewFallbackProvider(mockPrimary)
+
+		// Test - should get value from environment fallback
+		result, err := fallback.GetSecret(ctx, secretName)
+		assert.NoError(t, err)
+		assert.Equal(t, secretValue, result)
+	})
+
+	t.Run("mixed primary and fallback secrets", func(t *testing.T) { //nolint:paralleltest
+		// Set up environment variables
+		err := os.Setenv(secrets.EnvVarPrefix+"env_only", "env_value")
+		require.NoError(t, err)
+		defer os.Unsetenv(secrets.EnvVarPrefix + "env_only")
+
+		// Create mock primary provider
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockPrimary := mocks.NewMockProvider(ctrl)
+
+		// Primary has this secret
+		mockPrimary.EXPECT().GetSecret(ctx, "primary_secret").Return("primary_value", nil)
+
+		// Primary doesn't have this secret (fallback will be used)
+		mockPrimary.EXPECT().GetSecret(ctx, "env_only").Return("", errors.New("secret not found: env_only"))
+
+		fallback := secrets.NewFallbackProvider(mockPrimary)
+
+		// Test primary secret
+		result, err := fallback.GetSecret(ctx, "primary_secret")
+		assert.NoError(t, err)
+		assert.Equal(t, "primary_value", result)
+
+		// Test fallback secret
+		result, err = fallback.GetSecret(ctx, "env_only")
+		assert.NoError(t, err)
+		assert.Equal(t, "env_value", result)
+	})
+}
+
+func TestEnvironmentProvider_IntegrationTests(t *testing.T) { //nolint:paralleltest
+	provider := secrets.NewEnvironmentProvider()
+	ctx := context.Background()
+
+	t.Run("successful retrieval", func(t *testing.T) { //nolint:paralleltest
+		// Set up environment variable
+		secretName := testSecretName
+		secretValue := "test_value"
+		envVar := secrets.EnvVarPrefix + secretName
+
+		err := os.Setenv(envVar, secretValue)
+		require.NoError(t, err)
+		defer os.Unsetenv(envVar)
+
+		// Test retrieval
+		result, err := provider.GetSecret(ctx, secretName)
+		assert.NoError(t, err)
+		assert.Equal(t, secretValue, result)
+	})
+
+	t.Run("multiple secrets", func(t *testing.T) { //nolint:paralleltest
+		// Set up multiple environment variables
+		testSecrets := map[string]string{
+			"api_key":      "key123",
+			"database_url": "postgres://localhost/test",
+			"token":        "abc-def-ghi",
+		}
+
+		// Set environment variables
+		for name, value := range testSecrets {
+			envVar := secrets.EnvVarPrefix + name
+			err := os.Setenv(envVar, value)
+			require.NoError(t, err)
+			defer os.Unsetenv(envVar)
+		}
+
+		// Test retrieval of all secrets
+		for name, expectedValue := range testSecrets {
+			result, err := provider.GetSecret(ctx, name)
+			assert.NoError(t, err)
+			assert.Equal(t, expectedValue, result)
+		}
+	})
+
+	t.Run("special characters in secret names", func(t *testing.T) { //nolint:paralleltest
+		testCases := []struct {
+			name  string
+			value string
+		}{
+			{"api-key", "value1"},
+			{"API_KEY", "value2"},
+			{"secret.name", "value3"},
+			{"secret_123", "value4"},
+		}
+
+		for _, tc := range testCases {
+			envVar := secrets.EnvVarPrefix + tc.name
+			err := os.Setenv(envVar, tc.value)
+			require.NoError(t, err)
+			defer os.Unsetenv(envVar)
+
+			result, err := provider.GetSecret(ctx, tc.name)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.value, result)
+		}
+	})
+}
+
+func TestFactoryIntegration(t *testing.T) { //nolint:paralleltest
+	ctx := context.Background()
+
+	t.Run("fallback disabled creates direct provider", func(t *testing.T) { //nolint:paralleltest
+		// Disable fallback
+		err := os.Setenv("TOOLHIVE_DISABLE_ENV_FALLBACK", "true")
+		require.NoError(t, err)
+		defer os.Unsetenv("TOOLHIVE_DISABLE_ENV_FALLBACK")
+
+		// Set up environment variable that should NOT be accessible
+		secretName := "disabled_fallback_test"
+		secretValue := "should_not_be_accessible"
+		envVar := secrets.EnvVarPrefix + secretName
+
+		err = os.Setenv(envVar, secretValue)
+		require.NoError(t, err)
+		defer os.Unsetenv(envVar)
+
+		// Create none provider (should not have fallback)
+		provider, err := secrets.CreateSecretProvider(secrets.NoneType)
+		require.NoError(t, err)
+
+		// Should not be able to access environment variable
+		result, err := provider.GetSecret(ctx, secretName)
+		assert.Error(t, err)
+		assert.Empty(t, result)
+		assert.Contains(t, err.Error(), "none provider doesn't store secrets")
+	})
+
+	t.Run("fallback enabled allows environment access", func(t *testing.T) { //nolint:paralleltest
+		// Ensure fallback is enabled
+		os.Unsetenv("TOOLHIVE_DISABLE_ENV_FALLBACK")
+
+		// Set up environment variable
+		secretName := "enabled_fallback_test"
+		secretValue := "should_be_accessible"
+		envVar := secrets.EnvVarPrefix + secretName
+
+		err := os.Setenv(envVar, secretValue)
+		require.NoError(t, err)
+		defer os.Unsetenv(envVar)
+
+		// Create none provider (should have fallback)
+		provider, err := secrets.CreateSecretProvider(secrets.NoneType)
+		require.NoError(t, err)
+
+		// Should be able to access environment variable via fallback
+		result, err := provider.GetSecret(ctx, secretName)
+		assert.NoError(t, err)
+		assert.Equal(t, secretValue, result)
+	})
+}

--- a/pkg/secrets/none_test.go
+++ b/pkg/secrets/none_test.go
@@ -119,7 +119,7 @@ func TestCreateSecretProvider_None(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, provider)
 
-	// Verify it's actually a NoneManager
-	_, ok := provider.(*NoneManager)
-	assert.True(t, ok)
+	// Test that the provider works (with fallback enabled by default)
+	caps := provider.Capabilities()
+	assert.NotNil(t, caps)
 }

--- a/pkg/secrets/types.go
+++ b/pkg/secrets/types.go
@@ -7,6 +7,11 @@ import (
 	"regexp"
 )
 
+const (
+	// EnvVarPrefix is the prefix used for environment variable secrets
+	EnvVarPrefix = "TOOLHIVE_SECRET_"
+)
+
 // regex to extract name and target from secret parameter, e.g. "name,target=target"
 var secretParamRegex = regexp.MustCompile(`^([^,]+),target=(.+)$`)
 


### PR DESCRIPTION
## What this does

Adds support for reading secrets from environment variables, enabling ToolHive to work in CI/CD and cloud environments.

## How it works

- Reads secrets from `TOOLHIVE_SECRET_*` environment variables
- Automatically falls back to environment variables when primary provider can't find a secret
- Fallback is enabled by default (disable with `TOOLHIVE_DISABLE_ENV_FALLBACK=true`)
- Environment secrets are read-only for security

## Usage

```bash
# Set environment variable
export TOOLHIVE_SECRET_API_KEY="my-secret"

# Use directly
thv secret setup --provider environment

# Or use with fallback (default behavior)
thv secret setup --provider none
```

## Backward compatibility

Fully backward compatible - existing setups continue to work unchanged.