### PR TITLE
Fix MCP structured content validation errors

### DIFF
--- a/pkg/mcp/server/list_servers.go
+++ b/pkg/mcp/server/list_servers.go
@@ -16,6 +16,11 @@ type WorkloadInfo struct {
 	URL       string `json:"url,omitempty"`
 }
 
+// ListServersResponse represents the response from listing servers
+type ListServersResponse struct {
+	Servers []WorkloadInfo `json:"servers"`
+}
+
 // ListServers lists all running MCP servers
 func (h *Handler) ListServers(ctx context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	// List all workloads (including stopped ones)
@@ -46,5 +51,10 @@ func (h *Handler) ListServers(ctx context.Context, _ mcp.CallToolRequest) (*mcp.
 		results = append(results, info)
 	}
 
-	return mcp.NewToolResultStructuredOnly(results), nil
+	// Create structured response
+	response := ListServersResponse{
+		Servers: results,
+	}
+
+	return mcp.NewToolResultStructuredOnly(response), nil
 }

--- a/pkg/mcp/server/search_registry.go
+++ b/pkg/mcp/server/search_registry.go
@@ -25,6 +25,11 @@ type Info struct {
 	Tags        []string `json:"tags,omitempty"`
 }
 
+// SearchRegistryResponse represents the response from searching the registry
+type SearchRegistryResponse struct {
+	Servers []Info `json:"servers"`
+}
+
 // SearchRegistry searches the ToolHive registry
 func (h *Handler) SearchRegistry(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	// Parse arguments using BindArguments
@@ -59,6 +64,10 @@ func (h *Handler) SearchRegistry(_ context.Context, request mcp.CallToolRequest)
 		results = append(results, info)
 	}
 
-	// Use StructuredOnly to get JSON serialization automatically
-	return mcp.NewToolResultStructuredOnly(results), nil
+	// Create structured response
+	response := SearchRegistryResponse{
+		Servers: results,
+	}
+
+	return mcp.NewToolResultStructuredOnly(response), nil
 }


### PR DESCRIPTION
## Problem

The MCP protocol expects structured content to be an object, not an array. This was causing ZodError validation failures when using `search_registry` and `list_servers` tools with the error:

```
Error executing MCP tool: {
  "issues": [{
    "code": "invalid_type",
    "expected": "object",
    "received": "array",
    "path": ["structuredContent"],
    "message": "Expected object, received array"
  }]
}
```

## Solution

- Added `SearchRegistryResponse` struct to wrap the servers array in `search_registry.go`
- Added `ListServersResponse` struct to wrap the servers array in `list_servers.go`
- Updated both functions to return properly structured objects instead of raw arrays

## Testing

- ✅ Verified `search_registry` now returns structured data correctly
- ✅ Verified `list_servers` now returns structured data correctly
- ✅ Tested `stop_server`, `remove_server`, and `run_server` operations work properly
- ✅ All MCP tool operations now function without validation errors

## Changes

- `pkg/mcp/server/search_registry.go`: Added `SearchRegistryResponse` struct and updated return format
- `pkg/mcp/server/list_servers.go`: Added `ListServersResponse` struct and updated return format

Fixes the 'Expected object, received array' error in structuredContent validation.