### PR TITLE
Ignore notifications when waiting for responses in streamable proxy

### DIFF
--- a/pkg/transport/proxy/streamable/streamable_proxy_integration_test.go
+++ b/pkg/transport/proxy/streamable/streamable_proxy_integration_test.go
@@ -1,0 +1,92 @@
+package streamable
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/jsonrpc2"
+)
+
+// TestHTTPRequestIgnoresNotifications tests that HTTP requests ignore notifications
+// and only return the actual response. This addresses the fix for issue #1568.
+//
+//nolint:paralleltest // Test starts HTTP server
+func TestHTTPRequestIgnoresNotifications(t *testing.T) {
+	proxy := NewHTTPProxy("localhost", 8091, "test-container", nil)
+	ctx := context.Background()
+
+	// Start the proxy server
+	err := proxy.Start(ctx)
+	require.NoError(t, err)
+	defer proxy.Stop(ctx)
+
+	// Give the server a moment to start
+	time.Sleep(100 * time.Millisecond)
+
+	// Simulate MCP server that sends notifications before responses
+	go func() {
+		for {
+			select {
+			case msg := <-proxy.GetMessageChannel():
+				// Send notification first (should be ignored by HTTP handler)
+				notification, _ := jsonrpc2.NewNotification("progress", map[string]interface{}{
+					"status": "processing",
+				})
+				proxy.ForwardResponseToClients(ctx, notification)
+
+				// Finally send the actual response
+				if req, ok := msg.(*jsonrpc2.Request); ok && req.ID.IsValid() {
+					response, _ := jsonrpc2.NewResponse(req.ID, "operation complete", nil)
+					proxy.ForwardResponseToClients(ctx, response)
+				}
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	proxyURL := "http://localhost:8091" + StreamableHTTPEndpoint
+
+	// Test single request
+	requestJSON := `{"jsonrpc": "2.0", "method": "test.method", "id": "req-123"}`
+	resp, err := http.Post(proxyURL, "application/json", bytes.NewReader([]byte(requestJSON)))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	// Should get the response, not notifications
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
+
+	var responseData map[string]interface{}
+	err = json.NewDecoder(resp.Body).Decode(&responseData)
+	require.NoError(t, err)
+
+	// Verify we got the actual response (proving notifications were ignored)
+	assert.Equal(t, "2.0", responseData["jsonrpc"])
+	assert.Equal(t, "req-123", responseData["id"])
+	assert.Equal(t, "operation complete", responseData["result"])
+
+	// Test batch request
+	batchJSON := `[{"jsonrpc": "2.0", "method": "test.batch", "id": "batch-1"}]`
+	resp2, err := http.Post(proxyURL, "application/json", bytes.NewReader([]byte(batchJSON)))
+	require.NoError(t, err)
+	defer resp2.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp2.StatusCode)
+
+	var batchResponse []map[string]interface{}
+	err = json.NewDecoder(resp2.Body).Decode(&batchResponse)
+	require.NoError(t, err)
+
+	// Should have one response (notifications filtered out)
+	require.Len(t, batchResponse, 1)
+	assert.Equal(t, "2.0", batchResponse[0]["jsonrpc"])
+	assert.Equal(t, "batch-1", batchResponse[0]["id"])
+	assert.Equal(t, "operation complete", batchResponse[0]["result"])
+}

--- a/pkg/transport/proxy/streamable/streamable_proxy_test.go
+++ b/pkg/transport/proxy/streamable/streamable_proxy_test.go
@@ -1,0 +1,137 @@
+package streamable
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/jsonrpc2"
+)
+
+// TestNewHTTPProxy tests the creation of a new HTTP proxy
+//
+//nolint:paralleltest // Test modifies shared proxy state
+func TestNewHTTPProxy(t *testing.T) {
+	proxy := NewHTTPProxy("localhost", 8080, "test-container", nil)
+
+	assert.NotNil(t, proxy)
+	assert.Equal(t, "localhost", proxy.host)
+	assert.Equal(t, 8080, proxy.port)
+	assert.Equal(t, "test-container", proxy.containerName)
+	assert.NotNil(t, proxy.messageCh)
+	assert.NotNil(t, proxy.responseCh)
+}
+
+// TestProxyChannelCommunication tests basic proxy channel communication
+//
+//nolint:paralleltest // Test modifies shared proxy state
+func TestProxyChannelCommunication(t *testing.T) {
+	proxy := NewHTTPProxy("localhost", 8080, "test-container", nil)
+	ctx := context.Background()
+
+	// Test that we can send a message to the destination
+	request, err := jsonrpc2.NewCall(jsonrpc2.StringID("test"), "test.method", nil)
+	require.NoError(t, err)
+
+	err = proxy.SendMessageToDestination(request)
+	assert.NoError(t, err)
+
+	// Verify message was received
+	select {
+	case msg := <-proxy.GetMessageChannel():
+		assert.Equal(t, request, msg)
+	case <-time.After(1 * time.Second):
+		t.Fatal("Message not received")
+	}
+
+	// Test that we can forward a response
+	response, err := jsonrpc2.NewResponse(jsonrpc2.StringID("test"), "result", nil)
+	require.NoError(t, err)
+
+	err = proxy.ForwardResponseToClients(ctx, response)
+	assert.NoError(t, err)
+
+	// Verify response was forwarded
+	select {
+	case msg := <-proxy.GetResponseChannel():
+		assert.Equal(t, response, msg)
+	case <-time.After(1 * time.Second):
+		t.Fatal("Response not forwarded")
+	}
+}
+
+// TestSendMessageToDestination tests sending messages to the destination
+//
+//nolint:paralleltest // Test modifies shared proxy state
+func TestSendMessageToDestination(t *testing.T) {
+	proxy := NewHTTPProxy("localhost", 8080, "test-container", nil)
+
+	// Create a test message
+	msg, err := jsonrpc2.NewCall(jsonrpc2.StringID("test"), "test.method", nil)
+	require.NoError(t, err)
+
+	// Send the message
+	err = proxy.SendMessageToDestination(msg)
+	assert.NoError(t, err)
+
+	// Verify the message was sent
+	select {
+	case receivedMsg := <-proxy.messageCh:
+		assert.Equal(t, msg, receivedMsg)
+	case <-time.After(1 * time.Second):
+		t.Fatal("Message was not sent to channel")
+	}
+}
+
+// TestSendMessageToDestination_ChannelFull tests sending when channel is full
+//
+//nolint:paralleltest // Test modifies shared proxy state
+func TestSendMessageToDestination_ChannelFull(t *testing.T) {
+	proxy := NewHTTPProxy("localhost", 8080, "test-container", nil)
+
+	// Fill the channel
+	for i := 0; i < 100; i++ {
+		msg, _ := jsonrpc2.NewCall(jsonrpc2.StringID(fmt.Sprintf("test%d", i)), "test.method", nil)
+		proxy.messageCh <- msg
+	}
+
+	// Try to send another message
+	msg, _ := jsonrpc2.NewCall(jsonrpc2.StringID("overflow"), "test.method", nil)
+	err := proxy.SendMessageToDestination(msg)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to send message to destination")
+}
+
+// TestStartStop tests starting and stopping the proxy
+//
+//nolint:paralleltest // Test starts/stops HTTP server
+func TestStartStop(t *testing.T) {
+	proxy := NewHTTPProxy("localhost", 0, "test-container", nil) // Use port 0 for auto-assignment
+	ctx := context.Background()
+
+	// Start the proxy
+	err := proxy.Start(ctx)
+	assert.NoError(t, err)
+	assert.NotNil(t, proxy.server)
+
+	// Give it time to start
+	time.Sleep(100 * time.Millisecond)
+
+	// Stop the proxy
+	stopCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	err = proxy.Stop(stopCtx)
+	assert.NoError(t, err)
+
+	// Verify shutdown channel is closed
+	select {
+	case <-proxy.shutdownCh:
+		// Good, channel is closed
+	default:
+		t.Fatal("Shutdown channel was not closed")
+	}
+}


### PR DESCRIPTION
Filter out notification messages received from MCP servers when waiting for responses to specific requests. This prevents notifications from being incorrectly treated as responses in both single and batch request handling.

Fix #1568