### PR TITLE
Use xdg data dir to store pid files for toolhive

### DIFF
--- a/test/e2e/osv_mcp_server_test.go
+++ b/test/e2e/osv_mcp_server_test.go
@@ -488,7 +488,8 @@ var _ = Describe("OsvMcpServer", Serial, func() {
 
 				// 3) PID file should be created at the known location.
 				By("verifying PID file is created")
-				pidFile := process.GetPIDFilePath(serverName)
+				pidFile, err := process.GetPIDFilePath(serverName)
+				Expect(err).ToNot(HaveOccurred(), "should be able to get PID file path")
 				Eventually(func() bool {
 					_, statErr := os.Stat(pidFile)
 					return statErr == nil


### PR DESCRIPTION
Before that it was using os.tempdir() that was not deterministic and actually being different depending on how thv was called. Using xdg vars allows the directory to be predictable and persistent, fixing those stability problems.

Closes: #1600