### PR TITLE
Add backward compatibility for PID file location changes

### DIFF
--- a/pkg/process/pid.go
+++ b/pkg/process/pid.go
@@ -87,8 +87,9 @@ func ReadPIDFile(containerBaseName string) (int, error) {
 		// If we can't read from the new location, try the old location explicitly
 		oldPath := getOldPIDFilePath(containerBaseName)
 		if oldPath != pidFilePath {
-			// #nosec G304 - This is safe as the path is constructed from a known prefix and container name
-			pidBytes, err = os.ReadFile(oldPath)
+			// Clean the path to prevent directory traversal
+			cleanOldPath := filepath.Clean(oldPath)
+			pidBytes, err = os.ReadFile(cleanOldPath)
 			if err != nil {
 				return 0, fmt.Errorf("failed to read PID file from both new and old locations: %w", err)
 			}

--- a/pkg/process/pid.go
+++ b/pkg/process/pid.go
@@ -12,13 +12,46 @@ import (
 	"github.com/adrg/xdg"
 )
 
+// getOldPIDFilePath returns the legacy path to the PID file for a container (for backward compatibility)
+func getOldPIDFilePath(containerBaseName string) string {
+	// Use the system temporary directory (old behavior)
+	tmpDir := os.TempDir()
+	return filepath.Join(tmpDir, fmt.Sprintf("toolhive-%s.pid", containerBaseName))
+}
+
 // GetPIDFilePath returns the path to the PID file for a container
+// It first tries the new XDG location, then falls back to the old temp directory location
 func GetPIDFilePath(containerBaseName string) (string, error) {
+	// Get the new XDG-based path
 	pidPath, err := xdg.DataFile(filepath.Join("toolhive", "pids", fmt.Sprintf("toolhive-%s.pid", containerBaseName)))
 	if err != nil {
 		return "", fmt.Errorf("failed to get PID file path: %w", err)
 	}
 	return pidPath, nil
+}
+
+// GetPIDFilePathWithFallback returns the path to an existing PID file for a container
+// It checks both the new XDG location and the old temp directory location
+func GetPIDFilePathWithFallback(containerBaseName string) (string, error) {
+	// First try the new XDG-based path
+	newPath, err := GetPIDFilePath(containerBaseName)
+	if err != nil {
+		return "", err
+	}
+
+	// Check if file exists at new location
+	if _, err := os.Stat(newPath); err == nil {
+		return newPath, nil
+	}
+
+	// Fall back to old location
+	oldPath := getOldPIDFilePath(containerBaseName)
+	if _, err := os.Stat(oldPath); err == nil {
+		return oldPath, nil
+	}
+
+	// If neither exists, return the new path (for new files)
+	return newPath, nil
 }
 
 // WritePIDFile writes a process ID to a file
@@ -39,9 +72,10 @@ func WriteCurrentPIDFile(containerBaseName string) error {
 }
 
 // ReadPIDFile reads the process ID from a file
+// It checks both the new XDG location and the old temp directory location
 func ReadPIDFile(containerBaseName string) (int, error) {
-	// Get the PID file path
-	pidFilePath, err := GetPIDFilePath(containerBaseName)
+	// Get the PID file path with fallback
+	pidFilePath, err := GetPIDFilePathWithFallback(containerBaseName)
 	if err != nil {
 		return 0, fmt.Errorf("failed to get PID file path: %v", err)
 	}
@@ -50,7 +84,17 @@ func ReadPIDFile(containerBaseName string) (int, error) {
 	// #nosec G304 - This is safe as the path is constructed from a known prefix and container name
 	pidBytes, err := os.ReadFile(pidFilePath)
 	if err != nil {
-		return 0, fmt.Errorf("failed to read PID file: %w", err)
+		// If we can't read from the new location, try the old location explicitly
+		oldPath := getOldPIDFilePath(containerBaseName)
+		if oldPath != pidFilePath {
+			// #nosec G304 - This is safe as the path is constructed from a known prefix and container name
+			pidBytes, err = os.ReadFile(oldPath)
+			if err != nil {
+				return 0, fmt.Errorf("failed to read PID file from both new and old locations: %w", err)
+			}
+		} else {
+			return 0, fmt.Errorf("failed to read PID file: %w", err)
+		}
 	}
 
 	// Parse the PID
@@ -64,13 +108,34 @@ func ReadPIDFile(containerBaseName string) (int, error) {
 }
 
 // RemovePIDFile removes the PID file
+// It attempts to remove from both the new XDG location and the old temp directory location
 func RemovePIDFile(containerBaseName string) error {
-	// Get the PID file path
-	pidFilePath, err := GetPIDFilePath(containerBaseName)
+	var lastErr error
+
+	// Try to remove from the new location
+	newPath, err := GetPIDFilePath(containerBaseName)
 	if err != nil {
 		return fmt.Errorf("failed to get PID file path: %v", err)
 	}
 
-	// Remove the file
-	return os.Remove(pidFilePath)
+	if err := os.Remove(newPath); err != nil && !os.IsNotExist(err) {
+		lastErr = err
+	}
+
+	// Also try to remove from the old location (cleanup legacy files)
+	oldPath := getOldPIDFilePath(containerBaseName)
+	if err := os.Remove(oldPath); err != nil && !os.IsNotExist(err) {
+		// If we couldn't remove either file and both had errors, return the error
+		if lastErr != nil {
+			return fmt.Errorf("failed to remove PID files: new location: %v, old location: %v", lastErr, err)
+		}
+		lastErr = err
+	}
+
+	// If at least one was removed successfully (or didn't exist), consider it success
+	if lastErr != nil && !os.IsNotExist(lastErr) {
+		return lastErr
+	}
+
+	return nil
 }

--- a/pkg/process/pid_test.go
+++ b/pkg/process/pid_test.go
@@ -1,0 +1,419 @@
+package process
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/adrg/xdg"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPIDFileBackwardCompatibility(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ReadPIDFile_FromOldLocation", func(t *testing.T) {
+		t.Parallel()
+
+		containerName := "test-container-old-read"
+		testPID := 12345
+
+		// Clean up any existing files
+		t.Cleanup(func() {
+			// Clean up new location
+			if newPath, err := GetPIDFilePath(containerName); err == nil {
+				os.Remove(newPath)
+			}
+			// Clean up old location
+			oldPath := getOldPIDFilePath(containerName)
+			os.Remove(oldPath)
+		})
+
+		// Write PID file to old location
+		oldPath := getOldPIDFilePath(containerName)
+		oldDir := filepath.Dir(oldPath)
+		require.NoError(t, os.MkdirAll(oldDir, 0755), "Failed to create old directory")
+		require.NoError(t, os.WriteFile(oldPath, []byte(fmt.Sprintf("%d", testPID)), 0600),
+			"Failed to write PID file to old location")
+
+		// Read PID file (should find it in old location)
+		pid, err := ReadPIDFile(containerName)
+		require.NoError(t, err, "Failed to read PID file from old location")
+		assert.Equal(t, testPID, pid, "PID mismatch")
+	})
+
+	t.Run("ReadPIDFile_PreferNewLocation", func(t *testing.T) {
+		t.Parallel()
+
+		containerName := "test-container-prefer-new"
+		oldPID := 11111
+		newPID := 22222
+
+		// Clean up any existing files
+		t.Cleanup(func() {
+			// Clean up new location
+			if newPath, err := GetPIDFilePath(containerName); err == nil {
+				os.Remove(newPath)
+			}
+			// Clean up old location
+			oldPath := getOldPIDFilePath(containerName)
+			os.Remove(oldPath)
+		})
+
+		// Write PID file to old location
+		oldPath := getOldPIDFilePath(containerName)
+		require.NoError(t, os.WriteFile(oldPath, []byte(fmt.Sprintf("%d", oldPID)), 0600),
+			"Failed to write PID file to old location")
+
+		// Write PID file to new location
+		newPath, err := GetPIDFilePath(containerName)
+		require.NoError(t, err, "Failed to get new PID file path")
+
+		newDir := filepath.Dir(newPath)
+		require.NoError(t, os.MkdirAll(newDir, 0755), "Failed to create new directory")
+		require.NoError(t, os.WriteFile(newPath, []byte(fmt.Sprintf("%d", newPID)), 0600),
+			"Failed to write PID file to new location")
+
+		// Read PID file (should prefer new location)
+		pid, err := ReadPIDFile(containerName)
+		require.NoError(t, err, "Failed to read PID file")
+		assert.Equal(t, newPID, pid, "Should read from new location when both exist")
+	})
+
+	t.Run("WritePIDFile_UsesNewLocation", func(t *testing.T) {
+		t.Parallel()
+
+		containerName := "test-container-write-new"
+		testPID := 33333
+
+		// Clean up any existing files
+		t.Cleanup(func() {
+			// Clean up new location
+			if newPath, err := GetPIDFilePath(containerName); err == nil {
+				os.Remove(newPath)
+			}
+			// Clean up old location
+			oldPath := getOldPIDFilePath(containerName)
+			os.Remove(oldPath)
+		})
+
+		// Write PID file
+		require.NoError(t, WritePIDFile(containerName, testPID), "Failed to write PID file")
+
+		// Verify it was written to new location
+		newPath, err := GetPIDFilePath(containerName)
+		require.NoError(t, err, "Failed to get new PID file path")
+
+		_, err = os.Stat(newPath)
+		assert.NoError(t, err, "PID file should exist in new location")
+
+		// Verify old location was not used
+		oldPath := getOldPIDFilePath(containerName)
+		_, err = os.Stat(oldPath)
+		assert.True(t, os.IsNotExist(err), "PID file should not exist in old location")
+	})
+
+	t.Run("RemovePIDFile_RemovesBothLocations", func(t *testing.T) {
+		t.Parallel()
+
+		containerName := "test-container-remove-both"
+		testPID := 44444
+
+		// Clean up any existing files
+		t.Cleanup(func() {
+			// Clean up new location
+			if newPath, err := GetPIDFilePath(containerName); err == nil {
+				os.Remove(newPath)
+			}
+			// Clean up old location
+			oldPath := getOldPIDFilePath(containerName)
+			os.Remove(oldPath)
+		})
+
+		// Create PID files in both locations
+		oldPath := getOldPIDFilePath(containerName)
+		require.NoError(t, os.WriteFile(oldPath, []byte(fmt.Sprintf("%d", testPID)), 0600),
+			"Failed to write PID file to old location")
+
+		newPath, err := GetPIDFilePath(containerName)
+		require.NoError(t, err, "Failed to get new PID file path")
+
+		newDir := filepath.Dir(newPath)
+		require.NoError(t, os.MkdirAll(newDir, 0755), "Failed to create new directory")
+		require.NoError(t, os.WriteFile(newPath, []byte(fmt.Sprintf("%d", testPID)), 0600),
+			"Failed to write PID file to new location")
+
+		// Remove PID files
+		require.NoError(t, RemovePIDFile(containerName), "Failed to remove PID files")
+
+		// Verify both locations are cleaned up
+		_, err = os.Stat(oldPath)
+		assert.True(t, os.IsNotExist(err), "Old PID file should be removed")
+
+		_, err = os.Stat(newPath)
+		assert.True(t, os.IsNotExist(err), "New PID file should be removed")
+	})
+
+	t.Run("RemovePIDFile_HandlesPartialExistence", func(t *testing.T) {
+		t.Parallel()
+
+		containerName := "test-container-partial"
+		testPID := 55555
+
+		// Clean up any existing files
+		t.Cleanup(func() {
+			// Clean up new location
+			if newPath, err := GetPIDFilePath(containerName); err == nil {
+				os.Remove(newPath)
+			}
+			// Clean up old location
+			oldPath := getOldPIDFilePath(containerName)
+			os.Remove(oldPath)
+		})
+
+		// Test removing when only old file exists
+		oldPath := getOldPIDFilePath(containerName)
+		require.NoError(t, os.WriteFile(oldPath, []byte(fmt.Sprintf("%d", testPID)), 0600),
+			"Failed to write PID file to old location")
+
+		err := RemovePIDFile(containerName)
+		assert.NoError(t, err, "Should handle removing only old file")
+
+		_, err = os.Stat(oldPath)
+		assert.True(t, os.IsNotExist(err), "Old PID file should be removed")
+	})
+
+	t.Run("RemovePIDFile_NewFileOnly", func(t *testing.T) {
+		t.Parallel()
+
+		containerName := "test-container-new-only"
+		testPID := 66666
+
+		// Clean up any existing files
+		t.Cleanup(func() {
+			// Clean up new location
+			if newPath, err := GetPIDFilePath(containerName); err == nil {
+				os.Remove(newPath)
+			}
+			// Clean up old location
+			oldPath := getOldPIDFilePath(containerName)
+			os.Remove(oldPath)
+		})
+
+		// Test removing when only new file exists
+		require.NoError(t, WritePIDFile(containerName, testPID), "Failed to write PID file")
+
+		err := RemovePIDFile(containerName)
+		assert.NoError(t, err, "Should handle removing only new file")
+
+		newPath, _ := GetPIDFilePath(containerName)
+		_, err = os.Stat(newPath)
+		assert.True(t, os.IsNotExist(err), "New PID file should be removed")
+	})
+
+	t.Run("GetPIDFilePathWithFallback", func(t *testing.T) {
+		t.Parallel()
+
+		containerName := "test-container-fallback"
+
+		// Clean up any existing files
+		t.Cleanup(func() {
+			// Clean up new location
+			if newPath, err := GetPIDFilePath(containerName); err == nil {
+				os.Remove(newPath)
+			}
+			// Clean up old location
+			oldPath := getOldPIDFilePath(containerName)
+			os.Remove(oldPath)
+		})
+
+		// Test when neither file exists (should return new path)
+		path, err := GetPIDFilePathWithFallback(containerName)
+		require.NoError(t, err, "Failed to get PID file path with fallback")
+
+		expectedPath, _ := GetPIDFilePath(containerName)
+		assert.Equal(t, expectedPath, path, "Should return new path when no files exist")
+
+		// Test when only old file exists
+		oldPath := getOldPIDFilePath(containerName)
+		require.NoError(t, os.WriteFile(oldPath, []byte("test"), 0600),
+			"Failed to create old PID file")
+
+		path, err = GetPIDFilePathWithFallback(containerName)
+		require.NoError(t, err, "Failed to get PID file path with fallback")
+		assert.Equal(t, oldPath, path, "Should return old path when only old file exists")
+
+		// Test when both files exist (should prefer new)
+		newPath, _ := GetPIDFilePath(containerName)
+		newDir := filepath.Dir(newPath)
+		require.NoError(t, os.MkdirAll(newDir, 0755), "Failed to create new directory")
+		require.NoError(t, os.WriteFile(newPath, []byte("test"), 0600),
+			"Failed to create new PID file")
+
+		path, err = GetPIDFilePathWithFallback(containerName)
+		require.NoError(t, err, "Failed to get PID file path with fallback")
+		assert.Equal(t, newPath, path, "Should prefer new path when both files exist")
+	})
+}
+
+func TestPIDFileOperations(t *testing.T) {
+	t.Parallel()
+
+	t.Run("WriteAndReadPIDFile", func(t *testing.T) {
+		t.Parallel()
+
+		containerName := "test-basic-write-read"
+		testPID := 54321
+
+		// Clean up before and after
+		t.Cleanup(func() {
+			RemovePIDFile(containerName)
+		})
+
+		// Write PID
+		require.NoError(t, WritePIDFile(containerName, testPID), "Failed to write PID file")
+
+		// Read PID
+		pid, err := ReadPIDFile(containerName)
+		require.NoError(t, err, "Failed to read PID file")
+		assert.Equal(t, testPID, pid, "PID mismatch")
+	})
+
+	t.Run("WriteCurrentPIDFile", func(t *testing.T) {
+		t.Parallel()
+
+		containerName := "test-current-pid"
+
+		// Clean up before and after
+		t.Cleanup(func() {
+			RemovePIDFile(containerName)
+		})
+
+		// Write current process PID
+		require.NoError(t, WriteCurrentPIDFile(containerName), "Failed to write current PID file")
+
+		// Read and verify
+		pid, err := ReadPIDFile(containerName)
+		require.NoError(t, err, "Failed to read PID file")
+		assert.Equal(t, os.Getpid(), pid, "Should match current process PID")
+	})
+
+	t.Run("ReadNonExistentPIDFile", func(t *testing.T) {
+		t.Parallel()
+
+		containerName := "test-non-existent-read"
+
+		// Clean up to ensure file doesn't exist
+		t.Cleanup(func() {
+			RemovePIDFile(containerName)
+		})
+
+		// Try to read non-existent file
+		_, err := ReadPIDFile(containerName)
+		assert.Error(t, err, "Should error when reading non-existent PID file")
+	})
+
+	t.Run("RemoveNonExistentPIDFile", func(t *testing.T) {
+		t.Parallel()
+
+		containerName := "test-non-existent-remove"
+
+		// Clean up to ensure file doesn't exist
+		t.Cleanup(func() {
+			RemovePIDFile(containerName)
+		})
+
+		// Removing non-existent file may or may not error (implementation dependent)
+		// Just ensure it doesn't panic
+		_ = RemovePIDFile(containerName)
+	})
+}
+
+func TestGetPIDFilePath(t *testing.T) {
+	t.Parallel()
+
+	t.Run("GetPIDFilePath", func(t *testing.T) {
+		t.Parallel()
+
+		containerName := "test-path"
+
+		path, err := GetPIDFilePath(containerName)
+		require.NoError(t, err, "Failed to get PID file path")
+
+		// Verify it's in the XDG data directory
+		expectedDir := filepath.Join(xdg.DataHome, "toolhive", "pids")
+		assert.Contains(t, path, expectedDir,
+			"PID file path should be in XDG data directory")
+
+		// Verify filename format
+		expectedFilename := fmt.Sprintf("toolhive-%s.pid", containerName)
+		assert.Equal(t, expectedFilename, filepath.Base(path),
+			"PID file should have correct filename format")
+	})
+
+	t.Run("GetOldPIDFilePath", func(t *testing.T) {
+		t.Parallel()
+
+		containerName := "test-old-path"
+
+		// Test the internal function for old path
+		oldPath := getOldPIDFilePath(containerName)
+
+		// Verify it's in the temp directory
+		tmpDir := os.TempDir()
+		assert.Contains(t, oldPath, tmpDir,
+			"Old PID file path should be in temp directory")
+
+		// Verify filename format
+		expectedFilename := fmt.Sprintf("toolhive-%s.pid", containerName)
+		assert.Equal(t, expectedFilename, filepath.Base(oldPath),
+			"Old PID file should have correct filename format")
+	})
+}
+
+func TestPIDFileMigration(t *testing.T) {
+	t.Parallel()
+
+	t.Run("MigrationScenario", func(t *testing.T) {
+		t.Parallel()
+
+		containerName := "test-migration"
+		oldPID := 99999
+
+		// Clean up
+		t.Cleanup(func() {
+			RemovePIDFile(containerName)
+		})
+
+		// Simulate existing deployment with PID file in old location
+		oldPath := getOldPIDFilePath(containerName)
+		require.NoError(t, os.WriteFile(oldPath, []byte(fmt.Sprintf("%d", oldPID)), 0600),
+			"Failed to create old PID file")
+
+		// New code should still be able to read the old PID
+		pid, err := ReadPIDFile(containerName)
+		require.NoError(t, err, "Should read PID from old location")
+		assert.Equal(t, oldPID, pid, "Should read correct PID from old location")
+
+		// When writing a new PID, it should go to the new location
+		newPID := 88888
+		require.NoError(t, WritePIDFile(containerName, newPID), "Failed to write new PID")
+
+		// Now reading should get the new PID from the new location
+		pid, err = ReadPIDFile(containerName)
+		require.NoError(t, err, "Should read PID from new location")
+		assert.Equal(t, newPID, pid, "Should read new PID from new location")
+
+		// Cleanup should remove both files
+		require.NoError(t, RemovePIDFile(containerName), "Failed to remove PID files")
+
+		_, err = os.Stat(oldPath)
+		assert.True(t, os.IsNotExist(err), "Old file should be removed")
+
+		newPath, _ := GetPIDFilePath(containerName)
+		_, err = os.Stat(newPath)
+		assert.True(t, os.IsNotExist(err), "New file should be removed")
+	})
+}


### PR DESCRIPTION
## Summary

This PR implements a fallback mechanism to maintain backward compatibility with existing deployments after PR #1604 changed the PID file location from `os.TempDir()` to XDG data directories.

## Problem

PR #1604 introduced a breaking change by moving PID files from `/tmp/` to XDG data directories (typically `~/.local/share/toolhive/pids/`). This breaks existing deployments that still look for PID files in the old location.

## Solution

This PR adds backward compatibility by:
1. **Reading**: First checking the new XDG location, then falling back to the old `/tmp/` location
2. **Writing**: Always writing to the new XDG location (for forward migration)
3. **Removing**: Cleaning up PID files from both locations to ensure proper cleanup during migration

## Changes

- Added `getOldPIDFilePath()` helper to get the legacy PID file path
- Added `GetPIDFilePathWithFallback()` to check both new and old locations
- Updated `ReadPIDFile()` to try the old location if the new location fails
- Updated `RemovePIDFile()` to clean up both old and new locations
- Added comprehensive tests for backward compatibility scenarios
- Fixed linting issues (gosec warning and deprecated `filepath.HasPrefix`)

## Testing

- ✅ All existing tests pass
- ✅ Added new tests specifically for backward compatibility:
  - Reading from old location when only old file exists
  - Preferring new location when both exist
  - Writing always goes to new location
  - Cleanup removes files from both locations
  - Migration scenario test
- ✅ Tests are parallelizable and use `t.Cleanup()`
- ✅ Linter passes with no issues

## Migration Path

This provides a smooth migration path:
1. Existing deployments with PID files in `/tmp/` will continue to work
2. New PID files are written to the XDG location
3. When a process is restarted, it migrates from old to new location
4. Cleanup operations remove files from both locations

Fixes concerns raised about PR #1604 breaking existing deployments.