### PR TITLE
Add tool name override to tool middleware.

### DIFF
--- a/pkg/mcp/tool_filter.go
+++ b/pkg/mcp/tool_filter.go
@@ -14,7 +14,6 @@ import (
 )
 
 var errToolNameNotFound = errors.New("tool name not found")
-var errToolNotInFilter = errors.New("tool not in filter")
 var errBug = errors.New("there's a bug")
 
 // toolOverrideEntry is a struct that represents a tool override entry.
@@ -40,6 +39,33 @@ type toolMiddlewareConfig struct {
 	filterTools          map[string]struct{}
 	actualToUserOverride map[string]toolOverrideEntry
 	userToActualOverride map[string]toolOverrideEntry
+}
+
+func (c *toolMiddlewareConfig) isToolInFilter(toolName string) bool {
+	if c.filterTools == nil {
+		return true
+	}
+
+	_, ok := c.filterTools[toolName]
+	return ok
+}
+
+func (c *toolMiddlewareConfig) getToolCallActualName(toolName string) (string, bool) {
+	if c.userToActualOverride == nil {
+		return "", false
+	}
+
+	entry, ok := c.userToActualOverride[toolName]
+	return entry.ActualName, ok
+}
+
+func (c *toolMiddlewareConfig) getToolListOverride(toolName string) (*toolOverrideEntry, bool) {
+	if c.actualToUserOverride == nil {
+		return nil, false
+	}
+
+	entry, ok := c.actualToUserOverride[toolName]
+	return &entry, ok
 }
 
 // ToolMiddlewareOption is a function that can be used to configure the tool
@@ -128,7 +154,7 @@ func NewListToolsMappingMiddleware(opts ...ToolMiddlewareOption) (types.Middlewa
 			// modify it before returning it to the client.
 			rw := &toolFilterWriter{
 				ResponseWriter: w,
-				filterTools:    config.filterTools,
+				config:         config,
 			}
 
 			// Call the next handler
@@ -181,8 +207,16 @@ func NewToolCallMappingMiddleware(opts ...ToolMiddlewareOption) (types.Middlewar
 			// just pass it through.
 			var toolCallRequest toolCallRequest
 			err = json.Unmarshal(bodyBytes, &toolCallRequest)
-			if err == nil && toolCallRequest.Params != nil && toolCallRequest.Method == "tools/call" {
-				err = processToolCallRequest(config.filterTools, toolCallRequest)
+			if err == nil && toolCallRequest.Method == "tools/call" {
+				fix := processToolCallRequest(config, toolCallRequest)
+
+				switch fix := fix.(type) {
+
+				// If the tool call request is allowed, and the tool name is not overridden,
+				// we just pass it through unmodified.
+				case *toolCallNoAction:
+					next.ServeHTTP(w, r)
+					return
 
 				// NOTE: ideally, trying to call that was filtered out by config should be
 				// equivalent to calling a nonexisting tool; in such cases and when the SSE
@@ -197,11 +231,34 @@ func NewToolCallMappingMiddleware(opts ...ToolMiddlewareOption) (types.Middlewar
 				// different thread of execution. As a consequence, the best thing we can
 				// do that is still compliant with the spec is to return a 400 Bad Request
 				// to the client.
-				if errors.Is(err, errToolNotInFilter) {
+				case *toolCallFilter:
 					w.WriteHeader(http.StatusBadRequest)
 					return
-				}
-				if err != nil {
+
+				// In case of a tool name override, we need to fix the tool call request
+				// and then forward it to the next handler.
+				case *toolCallOverride:
+					(*toolCallRequest.Params)["name"] = fix.Name()
+					bodyBytes, err = json.Marshal(toolCallRequest)
+					if err != nil {
+						logger.Errorf("Error marshalling tool call request: %v", err)
+						next.ServeHTTP(w, r)
+						return
+					}
+					r.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+					return
+
+				// According to the current version of the MCP spec at
+				// https://modelcontextprotocol.io/specification/2025-06-18/schema#calltoolrequest
+				// this case can only happen if the request is malformed. The proxied MCP
+				// server should be able to process the request, but since we detect it here
+				// we short-circuit returning an error.
+				case *toolCallBogus:
+					w.WriteHeader(http.StatusBadRequest)
+					return
+
+				// This should never happen, but we handle it just in case.
+				default:
 					logger.Errorf("Error processing tool call of a filtered tool: %v", err)
 					next.ServeHTTP(w, r)
 					return
@@ -216,8 +273,8 @@ func NewToolCallMappingMiddleware(opts ...ToolMiddlewareOption) (types.Middlewar
 // toolFilterWriter wraps http.ResponseWriter to capture and process SSE responses
 type toolFilterWriter struct {
 	http.ResponseWriter
-	buffer      []byte
-	filterTools map[string]struct{}
+	buffer []byte
+	config *toolMiddlewareConfig
 }
 
 // WriteHeader captures the status code
@@ -245,7 +302,7 @@ func (rw *toolFilterWriter) Flush() {
 		}
 
 		var b bytes.Buffer
-		if err := processBuffer(rw.filterTools, rw.buffer, mimeType, &b); err != nil {
+		if err := processBuffer(rw.config, rw.buffer, mimeType, &b); err != nil {
 			logger.Errorf("Error flushing response: %v", err)
 		}
 
@@ -277,7 +334,12 @@ type toolCallRequest struct {
 }
 
 // processSSEBuffer processes any complete SSE events in the buffer
-func processBuffer(filterTools map[string]struct{}, buffer []byte, mimeType string, w io.Writer) error {
+func processBuffer(
+	config *toolMiddlewareConfig,
+	buffer []byte,
+	mimeType string,
+	w io.Writer,
+) error {
 	if len(buffer) == 0 {
 		return nil
 	}
@@ -287,10 +349,10 @@ func processBuffer(filterTools map[string]struct{}, buffer []byte, mimeType stri
 		var toolsListResponse toolsListResponse
 		err := json.Unmarshal(buffer, &toolsListResponse)
 		if err == nil && toolsListResponse.Result.Tools != nil {
-			return processToolsListResponse(filterTools, toolsListResponse, w)
+			return processToolsListResponse(config, toolsListResponse, w)
 		}
 	case "text/event-stream":
-		return processSSEEvents(filterTools, buffer, w)
+		return processEventStream(config, buffer, w)
 	default:
 		// NOTE: Content-Type header is mandatory in the spec, and as of the
 		// time of this writing, the only allowed content types are
@@ -306,7 +368,11 @@ func processBuffer(filterTools map[string]struct{}, buffer []byte, mimeType stri
 }
 
 //nolint:gocyclo
-func processSSEEvents(filterTools map[string]struct{}, buffer []byte, w io.Writer) error {
+func processEventStream(
+	config *toolMiddlewareConfig,
+	buffer []byte,
+	w io.Writer,
+) error {
 	var linesep []byte
 	if bytes.Contains(buffer, []byte("\r\n")) {
 		linesep = []byte("\r\n")
@@ -337,7 +403,7 @@ func processSSEEvents(filterTools map[string]struct{}, buffer []byte, w io.Write
 					return fmt.Errorf("%w: %v", errBug, err)
 				}
 
-				if err := processToolsListResponse(filterTools, toolsListResponse, w); err != nil {
+				if err := processToolsListResponse(config, toolsListResponse, w); err != nil {
 					return err
 				}
 				written = true
@@ -372,15 +438,35 @@ func processSSEEvents(filterTools map[string]struct{}, buffer []byte, w io.Write
 
 // processToolsListResponse processes a tools list response filtering out
 // tools that are not in the filter list.
-func processToolsListResponse(filterTools map[string]struct{}, toolsListResponse toolsListResponse, w io.Writer) error {
+func processToolsListResponse(
+	config *toolMiddlewareConfig,
+	toolsListResponse toolsListResponse,
+	w io.Writer,
+) error {
 	filteredTools := []map[string]any{}
 	for _, tool := range *toolsListResponse.Result.Tools {
+		// NOTE: the spec does not allow for name to be missing.
 		toolName, ok := tool["name"].(string)
 		if !ok {
 			return errToolNameNotFound
 		}
 
-		if isToolInFilter(filterTools, toolName) {
+		// NOTE: the spec does not allow for empty tool names.
+		if toolName == "" {
+			return errToolNameNotFound
+		}
+
+		// If the tool is overridden, we need to use the override name and description.
+		if entry, ok := config.getToolListOverride(toolName); ok {
+			tool["name"] = entry.OverrideName
+			tool["description"] = entry.OverrideDescription
+			toolName = entry.OverrideName
+		}
+
+		// If the tool is in the filter, we add it to the filtered tools list.
+		// Note that lookup is done using the user-known name, which might be
+		// different from the actual tool name.
+		if config.isToolInFilter(toolName) {
 			filteredTools = append(filteredTools, tool)
 		}
 	}
@@ -393,23 +479,84 @@ func processToolsListResponse(filterTools map[string]struct{}, toolsListResponse
 	return nil
 }
 
-// processToolCallRequest processes a tool call request checking if the tool
-// is in the filter list.
-func processToolCallRequest(filterTools map[string]struct{}, toolCallRequest toolCallRequest) error {
-	toolName, ok := (*toolCallRequest.Params)["name"].(string)
-	if !ok {
-		return errToolNameNotFound
-	}
+// toolCallFix mimics a sum type in Go. The actual types represent the
+// possible manipulations to perform on the tool call request, namely:
+// - filter the tool call request
+// - override the tool call request
+// - return a bogus tool call request
+// - do nothing
+//
+// The actual types are not exported, and the only way to get a value of a specific type
+// is to use a type assertion.
+//
+// Technical note: it might be tempting to build this into toolMiddlewareConfig, but this
+// would leave out the case in which the request is malformed, scenario that does not
+// belong to the logic implementing config.
+type toolCallFixAction interface{}
 
-	if isToolInFilter(filterTools, toolName) {
-		return nil
-	}
+// toolCallFilter is a struct that represents a tool call filter, i.e.
+// the tool call request is not allowed.
+type toolCallFilter struct{}
 
-	return errToolNotInFilter
+// toolCallOverride is a struct that represents a tool call override, i.e.
+// the tool call request is allowed, but the tool name is overridden.
+type toolCallOverride struct {
+	actualName string
 }
 
-// isToolInFilter checks if a tool name is in the filter
-func isToolInFilter(filterTools map[string]struct{}, toolName string) bool {
-	_, ok := filterTools[toolName]
-	return ok
+// Name returns the actual name of the tool.
+func (t *toolCallOverride) Name() string {
+	return t.actualName
+}
+
+// toolCallBogus is a struct that represents a bogus tool call request, i.e.
+// the tool call request is not allowed and the tool name is not overridden.
+type toolCallBogus struct{}
+
+// toolCallNoAction is a struct that represents a tool call no action, i.e.
+// the tool call request is allowed and the tool name is not overridden.
+type toolCallNoAction struct{}
+
+// processToolCallRequest processes a tool call request checking if the tool
+// is in the filter list. Note that the tool name received in the toolCallRequest
+// is going to be the user-provided name, which might be different from the actual
+// tool name.
+func processToolCallRequest(
+	config *toolMiddlewareConfig,
+	toolCallRequest toolCallRequest,
+) toolCallFixAction {
+	// NOTE: the spec does not allow for nil params.
+	if toolCallRequest.Params == nil {
+		return &toolCallBogus{}
+	}
+
+	// NOTE: the spec does not allow for name to be missing.
+	toolName, ok := (*toolCallRequest.Params)["name"].(string)
+	if !ok {
+		return &toolCallBogus{}
+	}
+
+	// NOTE: the spec does not allow for empty tool names.
+	if toolName == "" {
+		return &toolCallBogus{}
+	}
+
+	// If the tool is not in the filter list, return an error.
+	// Note that the tool name we use here is the user-provided name, which
+	// might be different from the actual tool name, but filters are expressed
+	// in terms of tool names as known to the user, so this is correct.
+	if !config.isToolInFilter(toolName) {
+		return &toolCallFilter{}
+	}
+
+	// If the tool is allowed by the filter, and has an override, return the
+	// actual name to fix the tool call request.
+	if actualName, ok := config.getToolCallActualName(toolName); ok {
+		return &toolCallOverride{actualName: actualName}
+	}
+
+	// If the tool is allowed by the filter, and does not have an override,
+	// return an empty string and no error, signaling the fact that the tool
+	// call request is ok as is.
+	return &toolCallNoAction{}
 }

--- a/pkg/mcp/tool_filter_test.go
+++ b/pkg/mcp/tool_filter_test.go
@@ -16,16 +16,21 @@ func TestProcessToolCallRequest(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name        string
-		filterTools map[string]struct{}
-		request     toolCallRequest
-		expectError error
+		name           string
+		config         *toolMiddlewareConfig
+		request        toolCallRequest
+		expectedResult string // "filter", "override", "bogus", "noaction"
+		expectedName   string // only relevant for override case
 	}{
 		{
 			name: "tool in filter - should succeed",
-			filterTools: map[string]struct{}{
-				"test_tool":  {},
-				"other_tool": {},
+			config: &toolMiddlewareConfig{
+				filterTools: map[string]struct{}{
+					"test_tool":  {},
+					"other_tool": {},
+				},
+				actualToUserOverride: map[string]toolOverrideEntry{},
+				userToActualOverride: map[string]toolOverrideEntry{},
 			},
 			request: toolCallRequest{
 				JSONRPC: "2.0",
@@ -38,12 +43,15 @@ func TestProcessToolCallRequest(t *testing.T) {
 					},
 				},
 			},
-			expectError: nil,
+			expectedResult: "noaction",
+			expectedName:   "",
 		},
 		{
 			name: "tool not in filter - should fail",
-			filterTools: map[string]struct{}{
-				"allowed_tool": {},
+			config: &toolMiddlewareConfig{
+				filterTools: map[string]struct{}{
+					"allowed_tool": {},
+				},
 			},
 			request: toolCallRequest{
 				JSONRPC: "2.0",
@@ -56,12 +64,15 @@ func TestProcessToolCallRequest(t *testing.T) {
 					},
 				},
 			},
-			expectError: errToolNotInFilter,
+			expectedResult: "filter",
+			expectedName:   "",
 		},
 		{
 			name: "tool name not found in params - should fail",
-			filterTools: map[string]struct{}{
-				"test_tool": {},
+			config: &toolMiddlewareConfig{
+				filterTools: map[string]struct{}{
+					"test_tool": {},
+				},
 			},
 			request: toolCallRequest{
 				JSONRPC: "2.0",
@@ -73,12 +84,15 @@ func TestProcessToolCallRequest(t *testing.T) {
 					},
 				},
 			},
-			expectError: errToolNameNotFound,
+			expectedResult: "bogus",
+			expectedName:   "",
 		},
 		{
 			name: "tool name is not string - should fail",
-			filterTools: map[string]struct{}{
-				"test_tool": {},
+			config: &toolMiddlewareConfig{
+				filterTools: map[string]struct{}{
+					"test_tool": {},
+				},
 			},
 			request: toolCallRequest{
 				JSONRPC: "2.0",
@@ -89,11 +103,14 @@ func TestProcessToolCallRequest(t *testing.T) {
 					"arguments": map[string]any{},
 				},
 			},
-			expectError: errToolNameNotFound,
+			expectedResult: "bogus",
+			expectedName:   "",
 		},
 		{
-			name:        "empty filter - should fail for any tool",
-			filterTools: map[string]struct{}{},
+			name: "empty filter - should fail for any tool",
+			config: &toolMiddlewareConfig{
+				filterTools: map[string]struct{}{},
+			},
 			request: toolCallRequest{
 				JSONRPC: "2.0",
 				ID:      1,
@@ -102,7 +119,108 @@ func TestProcessToolCallRequest(t *testing.T) {
 					"name": "any_tool",
 				},
 			},
-			expectError: errToolNotInFilter,
+			expectedResult: "filter",
+			expectedName:   "",
+		},
+		{
+			name: "empty params",
+			config: &toolMiddlewareConfig{
+				filterTools:          map[string]struct{}{"any_tool": {}},
+				actualToUserOverride: map[string]toolOverrideEntry{},
+				userToActualOverride: map[string]toolOverrideEntry{},
+			},
+			request: toolCallRequest{
+				JSONRPC: "2.0",
+				ID:      1,
+				Method:  "tools/call",
+				Params:  &map[string]any{},
+			},
+			expectedResult: "bogus",
+			expectedName:   "",
+		},
+		{
+			name: "params with nil name",
+			config: &toolMiddlewareConfig{
+				filterTools:          map[string]struct{}{"any_tool": {}},
+				actualToUserOverride: map[string]toolOverrideEntry{},
+				userToActualOverride: map[string]toolOverrideEntry{},
+			},
+			request: toolCallRequest{
+				JSONRPC: "2.0",
+				ID:      1,
+				Method:  "tools/call",
+				Params: &map[string]any{
+					"name": nil,
+				},
+			},
+			expectedResult: "bogus",
+			expectedName:   "",
+		},
+		{
+			name: "tool with override - should return override",
+			config: &toolMiddlewareConfig{
+				filterTools: map[string]struct{}{
+					"user_tool": {},
+				},
+				actualToUserOverride: map[string]toolOverrideEntry{
+					"actual_tool": {
+						ActualName:          "actual_tool",
+						OverrideName:        "user_tool",
+						OverrideDescription: "User friendly name",
+					},
+				},
+				userToActualOverride: map[string]toolOverrideEntry{
+					"user_tool": {
+						ActualName:          "actual_tool",
+						OverrideName:        "user_tool",
+						OverrideDescription: "User friendly name",
+					},
+				},
+			},
+			request: toolCallRequest{
+				JSONRPC: "2.0",
+				ID:      1,
+				Method:  "tools/call",
+				Params: &map[string]any{
+					"name": "user_tool",
+				},
+			},
+			expectedResult: "override",
+			expectedName:   "actual_tool",
+		},
+		{
+			name: "empty tool name - should fail",
+			config: &toolMiddlewareConfig{
+				filterTools: map[string]struct{}{
+					"any_tool": {},
+				},
+			},
+			request: toolCallRequest{
+				JSONRPC: "2.0",
+				ID:      1,
+				Method:  "tools/call",
+				Params: &map[string]any{
+					"name": "",
+				},
+			},
+			expectedResult: "bogus",
+			expectedName:   "",
+		},
+		{
+			name: "nil params - should fail",
+			config: &toolMiddlewareConfig{
+				filterTools: map[string]struct{}{
+					"any_tool": {},
+				},
+			},
+			request: toolCallRequest{
+				JSONRPC: "2.0",
+				ID:      1,
+				Method:  "tools/call",
+				Params:  nil,
+			},
+			expectedResult: "bogus",
+			expectedName:   "",
 		},
 	}
 
@@ -110,11 +228,24 @@ func TestProcessToolCallRequest(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			err := processToolCallRequest(tt.filterTools, tt.request)
-			if tt.expectError != nil {
-				assert.ErrorIs(t, err, tt.expectError)
-			} else {
-				assert.NoError(t, err)
+			result := processToolCallRequest(tt.config, tt.request)
+
+			switch tt.expectedResult {
+			case "filter":
+				_, ok := result.(*toolCallFilter)
+				assert.True(t, ok, "Expected toolCallFilter result")
+			case "override":
+				override, ok := result.(*toolCallOverride)
+				assert.True(t, ok, "Expected toolCallOverride result")
+				assert.Equal(t, tt.expectedName, override.Name())
+			case "bogus":
+				_, ok := result.(*toolCallBogus)
+				assert.True(t, ok, "Expected toolCallBogus result")
+			case "noaction":
+				_, ok := result.(*toolCallNoAction)
+				assert.True(t, ok, "Expected toolCallNoAction result")
+			default:
+				t.Errorf("Unknown expected result: %s", tt.expectedResult)
 			}
 		})
 	}
@@ -124,17 +255,20 @@ func TestProcessToolsListResponse(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name          string
-		filterTools   map[string]struct{}
-		inputResponse toolsListResponse
-		expectedTools []string
-		expectError   error
+		name                 string
+		config               *toolMiddlewareConfig
+		inputResponse        toolsListResponse
+		expectedTools        []string
+		expectedDescriptions map[string]string // map of tool name to expected description
+		expectError          error
 	}{
 		{
 			name: "filter tools - keep only allowed tools",
-			filterTools: map[string]struct{}{
-				"allowed_tool1": {},
-				"allowed_tool2": {},
+			config: &toolMiddlewareConfig{
+				filterTools: map[string]struct{}{
+					"allowed_tool1": {},
+					"allowed_tool2": {},
+				},
 			},
 			inputResponse: toolsListResponse{
 				JSONRPC: "2.0",
@@ -150,14 +284,20 @@ func TestProcessToolsListResponse(t *testing.T) {
 				},
 			},
 			expectedTools: []string{"allowed_tool1", "allowed_tool2"},
-			expectError:   nil,
+			expectedDescriptions: map[string]string{
+				"allowed_tool1": "First tool",
+				"allowed_tool2": "Second tool",
+			},
+			expectError: nil,
 		},
 		{
 			name: "no filter - keep all tools",
-			filterTools: map[string]struct{}{
-				"tool1": {},
-				"tool2": {},
-				"tool3": {},
+			config: &toolMiddlewareConfig{
+				filterTools: map[string]struct{}{
+					"tool1": {},
+					"tool2": {},
+					"tool3": {},
+				},
 			},
 			inputResponse: toolsListResponse{
 				JSONRPC: "2.0",
@@ -173,12 +313,19 @@ func TestProcessToolsListResponse(t *testing.T) {
 				},
 			},
 			expectedTools: []string{"tool1", "tool2", "tool3"},
-			expectError:   nil,
+			expectedDescriptions: map[string]string{
+				"tool1": "First tool",
+				"tool2": "Second tool",
+				"tool3": "Third tool",
+			},
+			expectError: nil,
 		},
 		{
 			name: "tool without name field - should fail",
-			filterTools: map[string]struct{}{
-				"allowed_tool": {},
+			config: &toolMiddlewareConfig{
+				filterTools: map[string]struct{}{
+					"allowed_tool": {},
+				},
 			},
 			inputResponse: toolsListResponse{
 				JSONRPC: "2.0",
@@ -191,12 +338,15 @@ func TestProcessToolsListResponse(t *testing.T) {
 					},
 				},
 			},
-			expectError: errToolNameNotFound,
+			expectedDescriptions: nil,
+			expectError:          errToolNameNotFound,
 		},
 		{
 			name: "tool name is not string - should fail",
-			filterTools: map[string]struct{}{
-				"allowed_tool": {},
+			config: &toolMiddlewareConfig{
+				filterTools: map[string]struct{}{
+					"allowed_tool": {},
+				},
 			},
 			inputResponse: toolsListResponse{
 				JSONRPC: "2.0",
@@ -209,12 +359,113 @@ func TestProcessToolsListResponse(t *testing.T) {
 					},
 				},
 			},
-			expectError: errToolNameNotFound,
+			expectedDescriptions: nil,
+			expectError:          errToolNameNotFound,
+		},
+		{
+			name: "empty tool name - should fail",
+			config: &toolMiddlewareConfig{
+				filterTools: map[string]struct{}{
+					"any_tool": {},
+				},
+			},
+			inputResponse: toolsListResponse{
+				JSONRPC: "2.0",
+				ID:      1,
+				Result: struct {
+					Tools *[]map[string]any `json:"tools"`
+				}{
+					Tools: &[]map[string]any{
+						{"name": "", "description": "Tool with empty name"},
+					},
+				},
+			},
+			expectedDescriptions: nil,
+			expectError:          errToolNameNotFound,
+		},
+		{
+			name: "tool with override - name and description changed",
+			config: &toolMiddlewareConfig{
+				filterTools: map[string]struct{}{
+					"user_friendly_name": {},
+				},
+				actualToUserOverride: map[string]toolOverrideEntry{
+					"actual_tool": {
+						ActualName:          "actual_tool",
+						OverrideName:        "user_friendly_name",
+						OverrideDescription: "User friendly description",
+					},
+				},
+				userToActualOverride: map[string]toolOverrideEntry{
+					"user_friendly_name": {
+						ActualName:          "actual_tool",
+						OverrideName:        "user_friendly_name",
+						OverrideDescription: "User friendly description",
+					},
+				},
+			},
+			inputResponse: toolsListResponse{
+				JSONRPC: "2.0",
+				ID:      1,
+				Result: struct {
+					Tools *[]map[string]any `json:"tools"`
+				}{
+					Tools: &[]map[string]any{
+						{"name": "actual_tool", "description": "Original description"},
+					},
+				},
+			},
+			expectedTools: []string{"user_friendly_name"},
+			expectedDescriptions: map[string]string{
+				"user_friendly_name": "User friendly description",
+			},
+			expectError: nil,
+		},
+		{
+			name: "tool with override - filtered out after override",
+			config: &toolMiddlewareConfig{
+				filterTools: map[string]struct{}{
+					"allowed_tool": {},
+				},
+				actualToUserOverride: map[string]toolOverrideEntry{
+					"actual_tool": {
+						ActualName:          "actual_tool",
+						OverrideName:        "blocked_tool",
+						OverrideDescription: "Blocked tool description",
+					},
+				},
+				userToActualOverride: map[string]toolOverrideEntry{
+					"blocked_tool": {
+						ActualName:          "actual_tool",
+						OverrideName:        "blocked_tool",
+						OverrideDescription: "Blocked tool description",
+					},
+				},
+			},
+			inputResponse: toolsListResponse{
+				JSONRPC: "2.0",
+				ID:      1,
+				Result: struct {
+					Tools *[]map[string]any `json:"tools"`
+				}{
+					Tools: &[]map[string]any{
+						{"name": "actual_tool", "description": "Original description"},
+						{"name": "allowed_tool", "description": "Allowed tool"},
+					},
+				},
+			},
+			expectedTools: []string{"allowed_tool"},
+			expectedDescriptions: map[string]string{
+				"allowed_tool": "Allowed tool",
+			},
+			expectError: nil,
 		},
 		{
 			name: "empty tools list - should succeed",
-			filterTools: map[string]struct{}{
-				"any_tool": {},
+			config: &toolMiddlewareConfig{
+				filterTools: map[string]struct{}{
+					"any_tool": {},
+				},
 			},
 			inputResponse: toolsListResponse{
 				JSONRPC: "2.0",
@@ -225,8 +476,137 @@ func TestProcessToolsListResponse(t *testing.T) {
 					Tools: &[]map[string]any{},
 				},
 			},
-			expectedTools: []string{},
-			expectError:   nil,
+			expectedTools:        []string{},
+			expectedDescriptions: map[string]string{},
+			expectError:          nil,
+		},
+		{
+			name: "multiple tools with overrides",
+			config: &toolMiddlewareConfig{
+				filterTools: map[string]struct{}{
+					"user_tool1": {},
+					"user_tool2": {},
+				},
+				actualToUserOverride: map[string]toolOverrideEntry{
+					"actual_tool1": {
+						ActualName:          "actual_tool1",
+						OverrideName:        "user_tool1",
+						OverrideDescription: "User friendly tool 1",
+					},
+					"actual_tool2": {
+						ActualName:          "actual_tool2",
+						OverrideName:        "user_tool2",
+						OverrideDescription: "User friendly tool 2",
+					},
+				},
+				userToActualOverride: map[string]toolOverrideEntry{
+					"user_tool1": {
+						ActualName:          "actual_tool1",
+						OverrideName:        "user_tool1",
+						OverrideDescription: "User friendly tool 1",
+					},
+					"user_tool2": {
+						ActualName:          "actual_tool2",
+						OverrideName:        "user_tool2",
+						OverrideDescription: "User friendly tool 2",
+					},
+				},
+			},
+			inputResponse: toolsListResponse{
+				JSONRPC: "2.0",
+				ID:      1,
+				Result: struct {
+					Tools *[]map[string]any `json:"tools"`
+				}{
+					Tools: &[]map[string]any{
+						{"name": "actual_tool1", "description": "Original description 1"},
+						{"name": "actual_tool2", "description": "Original description 2"},
+						{"name": "other_tool", "description": "Other tool"},
+					},
+				},
+			},
+			expectedTools: []string{"user_tool1", "user_tool2"},
+			expectedDescriptions: map[string]string{
+				"user_tool1": "User friendly tool 1",
+				"user_tool2": "User friendly tool 2",
+			},
+			expectError: nil,
+		},
+		{
+			name: "tool override with description verification",
+			config: &toolMiddlewareConfig{
+				filterTools: map[string]struct{}{
+					"user_tool": {},
+				},
+				actualToUserOverride: map[string]toolOverrideEntry{
+					"actual_tool": {
+						ActualName:          "actual_tool",
+						OverrideName:        "user_tool",
+						OverrideDescription: "User friendly description",
+					},
+				},
+				userToActualOverride: map[string]toolOverrideEntry{
+					"user_tool": {
+						ActualName:          "actual_tool",
+						OverrideName:        "user_tool",
+						OverrideDescription: "User friendly description",
+					},
+				},
+			},
+			inputResponse: toolsListResponse{
+				JSONRPC: "2.0",
+				ID:      1,
+				Result: struct {
+					Tools *[]map[string]any `json:"tools"`
+				}{
+					Tools: &[]map[string]any{
+						{"name": "actual_tool", "description": "Original description", "inputSchema": map[string]any{"type": "object"}},
+					},
+				},
+			},
+			expectedTools: []string{"user_tool"},
+			expectedDescriptions: map[string]string{
+				"user_tool": "User friendly description",
+			},
+			expectError: nil,
+		},
+		{
+			name: "verify description override",
+			config: &toolMiddlewareConfig{
+				filterTools: map[string]struct{}{
+					"user_tool": {},
+				},
+				actualToUserOverride: map[string]toolOverrideEntry{
+					"actual_tool": {
+						ActualName:          "actual_tool",
+						OverrideName:        "user_tool",
+						OverrideDescription: "User friendly description",
+					},
+				},
+				userToActualOverride: map[string]toolOverrideEntry{
+					"user_tool": {
+						ActualName:          "actual_tool",
+						OverrideName:        "user_tool",
+						OverrideDescription: "User friendly description",
+					},
+				},
+			},
+			inputResponse: toolsListResponse{
+				JSONRPC: "2.0",
+				ID:      1,
+				Result: struct {
+					Tools *[]map[string]any `json:"tools"`
+				}{
+					Tools: &[]map[string]any{
+						{"name": "actual_tool", "description": "Original description", "inputSchema": map[string]any{"type": "object"}},
+					},
+				},
+			},
+			expectedTools: []string{"user_tool"},
+			expectedDescriptions: map[string]string{
+				"user_tool": "User friendly description",
+			},
+			expectError: nil,
 		},
 	}
 
@@ -235,7 +615,7 @@ func TestProcessToolsListResponse(t *testing.T) {
 			t.Parallel()
 
 			var buf bytes.Buffer
-			err := processToolsListResponse(tt.filterTools, tt.inputResponse, &buf)
+			err := processToolsListResponse(tt.config, tt.inputResponse, &buf)
 
 			if tt.expectError != nil {
 				assert.ErrorIs(t, err, tt.expectError)
@@ -259,7 +639,42 @@ func TestProcessToolsListResponse(t *testing.T) {
 				}
 			}
 
-			assert.ElementsMatch(t, tt.expectedTools, actualTools)
+			// Only compare expected tools if we're not expecting an error
+			if tt.expectError == nil {
+				assert.ElementsMatch(t, tt.expectedTools, actualTools)
+
+				// Verify descriptions if expectedDescriptions is provided
+				if tt.expectedDescriptions != nil {
+					require.NotNil(t, outputResponse.Result.Tools)
+
+					// Create a map of actual tool descriptions for easy lookup
+					actualDescriptions := make(map[string]string)
+					for _, tool := range *outputResponse.Result.Tools {
+						if name, ok := tool["name"].(string); ok {
+							if description, ok := tool["description"].(string); ok {
+								actualDescriptions[name] = description
+							}
+						}
+					}
+
+					// Verify each expected description
+					for toolName, expectedDescription := range tt.expectedDescriptions {
+						actualDescription, exists := actualDescriptions[toolName]
+						assert.True(t, exists, "Tool %s should exist in output", toolName)
+						assert.Equal(t, expectedDescription, actualDescription,
+							"Description for tool %s should match expected", toolName)
+					}
+
+					// For test cases with inputSchema, verify that other fields are preserved
+					if len(*outputResponse.Result.Tools) == 1 {
+						tool := (*outputResponse.Result.Tools)[0]
+						if _, hasInputSchema := tool["inputSchema"]; hasInputSchema {
+							// Verify that other fields are preserved
+							assert.Equal(t, map[string]any{"type": "object"}, tool["inputSchema"])
+						}
+					}
+				}
+			}
 		})
 	}
 }
@@ -269,15 +684,17 @@ func TestProcessSSEEvents(t *testing.T) {
 
 	tests := []struct {
 		name        string
-		filterTools map[string]struct{}
+		config      *toolMiddlewareConfig
 		inputBuffer []byte
 		expected    string
 		expectError bool
 	}{
 		{
 			name: "SSE with non-tools data - pass through unchanged",
-			filterTools: map[string]struct{}{
-				"any_tool": {},
+			config: &toolMiddlewareConfig{
+				filterTools: map[string]struct{}{
+					"any_tool": {},
+				},
 			},
 			inputBuffer: []byte(`event: message
 data: {"jsonrpc":"2.0","id":1,"result":{"status":"ok"}}
@@ -291,9 +708,11 @@ data: {"jsonrpc":"2.0","id":1,"result":{"status":"ok"}}
 		},
 		{
 			name: "SSE with mixed content - filter tools and pass through other data",
-			filterTools: map[string]struct{}{
-				"tool1": {},
-				"tool3": {},
+			config: &toolMiddlewareConfig{
+				filterTools: map[string]struct{}{
+					"tool1": {},
+					"tool3": {},
+				},
 			},
 			inputBuffer: []byte(`event: message
 data: {"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"tool1","description":"First"},{"name":"tool2","description":"Second"},{"name":"tool3","description":"Third"}]}}
@@ -313,8 +732,10 @@ data: {"type":"info","message":"Processing complete"}
 		},
 		{
 			name: "SSE with CRLF line endings",
-			filterTools: map[string]struct{}{
-				"allowed_tool": {},
+			config: &toolMiddlewareConfig{
+				filterTools: map[string]struct{}{
+					"allowed_tool": {},
+				},
 			},
 			inputBuffer: []byte("event: message\r\ndata: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"tools\":[{\"name\":\"allowed_tool\",\"description\":\"Allowed\"},{\"name\":\"blocked_tool\",\"description\":\"Blocked\"}]}}\r\n\r\n"),
 			expected:    "event: message\r\ndata: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"tools\":[{\"description\":\"Allowed\",\"name\":\"allowed_tool\"}]}}\n\r\n\r\n",
@@ -322,8 +743,10 @@ data: {"type":"info","message":"Processing complete"}
 		},
 		{
 			name: "SSE with CR line endings",
-			filterTools: map[string]struct{}{
-				"allowed_tool": {},
+			config: &toolMiddlewareConfig{
+				filterTools: map[string]struct{}{
+					"allowed_tool": {},
+				},
 			},
 			inputBuffer: []byte("event: message\rdata: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"tools\":[{\"name\":\"allowed_tool\",\"description\":\"Allowed\"}]}}\r\r"),
 			expected:    "event: message\rdata: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"tools\":[{\"description\":\"Allowed\",\"name\":\"allowed_tool\"}]}}\n\r\r",
@@ -331,16 +754,20 @@ data: {"type":"info","message":"Processing complete"}
 		},
 		{
 			name: "SSE with unsupported line separator - should fail",
-			filterTools: map[string]struct{}{
-				"any_tool": {},
+			config: &toolMiddlewareConfig{
+				filterTools: map[string]struct{}{
+					"any_tool": {},
+				},
 			},
 			inputBuffer: []byte("event: message\vdata: {\"jsonrpc\":\"2.0\",\"id\":1}\v\v"),
 			expectError: true,
 		},
 		{
 			name: "SSE with malformed JSON in data - pass through unchanged",
-			filterTools: map[string]struct{}{
-				"any_tool": {},
+			config: &toolMiddlewareConfig{
+				filterTools: map[string]struct{}{
+					"any_tool": {},
+				},
 			},
 			inputBuffer: []byte(`event: message
 data: {"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"tool1"}]}
@@ -352,6 +779,39 @@ data: {"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"tool1"}]}
 `,
 			expectError: false,
 		},
+		{
+			name: "SSE with only line separators",
+			config: &toolMiddlewareConfig{
+				filterTools: map[string]struct{}{
+					"any_tool": {},
+				},
+			},
+			inputBuffer: []byte("\n\n"),
+			expected:    "\n",
+			expectError: false,
+		},
+		{
+			name: "SSE with single line",
+			config: &toolMiddlewareConfig{
+				filterTools: map[string]struct{}{
+					"any_tool": {},
+				},
+			},
+			inputBuffer: []byte("event: message\n"),
+			expected:    "event: message\n",
+			expectError: false,
+		},
+		{
+			name: "SSE with data line without event line",
+			config: &toolMiddlewareConfig{
+				filterTools: map[string]struct{}{
+					"any_tool": {},
+				},
+			},
+			inputBuffer: []byte("data: {\"jsonrpc\":\"2.0\",\"id\":1}\n\n"),
+			expected:    "data: {\"jsonrpc\":\"2.0\",\"id\":1}\n\n",
+			expectError: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -359,7 +819,7 @@ data: {"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"tool1"}]}
 			t.Parallel()
 
 			var buf bytes.Buffer
-			err := processSSEEvents(tt.filterTools, tt.inputBuffer, &buf)
+			err := processEventStream(tt.config, tt.inputBuffer, &buf)
 
 			if tt.expectError {
 				assert.Error(t, err)
@@ -377,15 +837,17 @@ func TestProcessBuffer(t *testing.T) {
 
 	tests := []struct {
 		name        string
-		filterTools map[string]struct{}
+		config      *toolMiddlewareConfig
 		buffer      []byte
 		mimeType    string
 		expectError bool
 	}{
 		{
 			name: "JSON with tools list",
-			filterTools: map[string]struct{}{
-				"allowed_tool": {},
+			config: &toolMiddlewareConfig{
+				filterTools: map[string]struct{}{
+					"allowed_tool": {},
+				},
 			},
 			buffer:      []byte(`{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"allowed_tool","description":"Allowed"},{"name":"blocked_tool","description":"Blocked"}]}}`),
 			mimeType:    "application/json",
@@ -393,8 +855,10 @@ func TestProcessBuffer(t *testing.T) {
 		},
 		{
 			name: "SSE with tools list",
-			filterTools: map[string]struct{}{
-				"allowed_tool": {},
+			config: &toolMiddlewareConfig{
+				filterTools: map[string]struct{}{
+					"allowed_tool": {},
+				},
 			},
 			buffer: []byte(`event: message
 data: {"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"allowed_tool","description":"Allowed"},{"name":"blocked_tool","description":"Blocked"}]}}
@@ -405,8 +869,10 @@ data: {"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"allowed_tool","descrip
 		},
 		{
 			name: "Unsupported mime type",
-			filterTools: map[string]struct{}{
-				"any_tool": {},
+			config: &toolMiddlewareConfig{
+				filterTools: map[string]struct{}{
+					"any_tool": {},
+				},
 			},
 			buffer:      []byte(`some data`),
 			mimeType:    "text/plain",
@@ -414,8 +880,10 @@ data: {"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"allowed_tool","descrip
 		},
 		{
 			name: "Empty buffer",
-			filterTools: map[string]struct{}{
-				"any_tool": {},
+			config: &toolMiddlewareConfig{
+				filterTools: map[string]struct{}{
+					"any_tool": {},
+				},
 			},
 			buffer:      []byte{},
 			mimeType:    "application/json",
@@ -428,7 +896,7 @@ data: {"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"allowed_tool","descrip
 			t.Parallel()
 
 			var buf bytes.Buffer
-			err := processBuffer(tt.filterTools, tt.buffer, tt.mimeType, &buf)
+			err := processBuffer(tt.config, tt.buffer, tt.mimeType, &buf)
 
 			if tt.expectError {
 				assert.Error(t, err)
@@ -439,33 +907,133 @@ data: {"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"allowed_tool","descrip
 	}
 }
 
-func TestIsToolInFilter(t *testing.T) {
+func TestToolMiddlewareConfig(t *testing.T) {
 	t.Parallel()
 
-	filterTools := map[string]struct{}{
-		"tool1": {},
-		"tool2": {},
-	}
-
 	tests := []struct {
-		name     string
-		toolName string
-		expected bool
+		name           string
+		config         *toolMiddlewareConfig
+		toolName       string
+		expectedFilter bool
+		expectedCall   string
+		expectedList   *toolOverrideEntry
 	}{
 		{
-			name:     "tool in filter",
-			toolName: "tool1",
-			expected: true,
+			name: "tool in filter - should be allowed",
+			config: &toolMiddlewareConfig{
+				filterTools: map[string]struct{}{
+					"allowed_tool": {},
+					"other_tool":   {},
+				},
+			},
+			toolName:       "allowed_tool",
+			expectedFilter: true,
+			expectedCall:   "",
+			expectedList:   nil,
 		},
 		{
-			name:     "tool not in filter",
-			toolName: "tool3",
-			expected: false,
+			name: "tool not in filter - should be blocked",
+			config: &toolMiddlewareConfig{
+				filterTools: map[string]struct{}{
+					"allowed_tool": {},
+				},
+			},
+			toolName:       "blocked_tool",
+			expectedFilter: false,
+			expectedCall:   "",
+			expectedList:   nil,
 		},
 		{
-			name:     "empty tool name",
-			toolName: "",
-			expected: false,
+			name: "nil filter - all tools allowed",
+			config: &toolMiddlewareConfig{
+				filterTools: nil,
+			},
+			toolName:       "any_tool",
+			expectedFilter: true,
+			expectedCall:   "",
+			expectedList:   nil,
+		},
+		{
+			name: "tool call override - should return actual name",
+			config: &toolMiddlewareConfig{
+				filterTools: map[string]struct{}{
+					"user_tool": {},
+				},
+				actualToUserOverride: map[string]toolOverrideEntry{
+					"actual_tool": {
+						ActualName:          "actual_tool",
+						OverrideName:        "user_tool",
+						OverrideDescription: "User friendly description",
+					},
+				},
+				userToActualOverride: map[string]toolOverrideEntry{
+					"user_tool": {
+						ActualName:          "actual_tool",
+						OverrideName:        "user_tool",
+						OverrideDescription: "User friendly description",
+					},
+				},
+			},
+			toolName:       "user_tool",
+			expectedFilter: true,
+			expectedCall:   "actual_tool",
+			expectedList:   nil,
+		},
+		{
+			name: "tool list override - should return override entry",
+			config: &toolMiddlewareConfig{
+				filterTools: map[string]struct{}{
+					"user_tool": {},
+				},
+				actualToUserOverride: map[string]toolOverrideEntry{
+					"actual_tool": {
+						ActualName:          "actual_tool",
+						OverrideName:        "user_tool",
+						OverrideDescription: "User friendly description",
+					},
+				},
+				userToActualOverride: map[string]toolOverrideEntry{
+					"user_tool": {
+						ActualName:          "actual_tool",
+						OverrideName:        "user_tool",
+						OverrideDescription: "User friendly description",
+					},
+				},
+			},
+			toolName:       "actual_tool",
+			expectedFilter: false, // actual_tool not in filter, only user_tool is
+			expectedCall:   "",
+			expectedList: &toolOverrideEntry{
+				ActualName:          "actual_tool",
+				OverrideName:        "user_tool",
+				OverrideDescription: "User friendly description",
+			},
+		},
+		{
+			name: "no override found - should return empty",
+			config: &toolMiddlewareConfig{
+				filterTools: map[string]struct{}{
+					"allowed_tool": {},
+				},
+				actualToUserOverride: map[string]toolOverrideEntry{
+					"actual_tool": {
+						ActualName:          "actual_tool",
+						OverrideName:        "user_tool",
+						OverrideDescription: "User friendly description",
+					},
+				},
+				userToActualOverride: map[string]toolOverrideEntry{
+					"user_tool": {
+						ActualName:          "actual_tool",
+						OverrideName:        "user_tool",
+						OverrideDescription: "User friendly description",
+					},
+				},
+			},
+			toolName:       "unknown_tool",
+			expectedFilter: false,
+			expectedCall:   "",
+			expectedList:   nil,
 		},
 	}
 
@@ -473,8 +1041,39 @@ func TestIsToolInFilter(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			result := isToolInFilter(filterTools, tt.toolName)
-			assert.Equal(t, tt.expected, result)
+			// Test isToolInFilter
+			result := tt.config.isToolInFilter(tt.toolName)
+			assert.Equal(t, tt.expectedFilter, result, "isToolInFilter should return expected result")
+
+			// Test getToolCallActualName
+			actualName, found := tt.config.getToolCallActualName(tt.toolName)
+			if tt.expectedCall != "" {
+				assert.True(t, found, "getToolCallActualName should find override")
+				assert.Equal(t, tt.expectedCall, actualName, "getToolCallActualName should return expected actual name")
+			} else {
+				assert.False(t, found, "getToolCallActualName should not find override")
+				assert.Equal(t, "", actualName, "getToolCallActualName should return empty string when no override")
+			}
+
+			// Test getToolListOverride
+			overrideEntry, found := tt.config.getToolListOverride(tt.toolName)
+			if tt.expectedList != nil {
+				assert.True(t, found, "getToolListOverride should find override")
+				assert.Equal(t, tt.expectedList.ActualName, overrideEntry.ActualName, "ActualName should match")
+				assert.Equal(t, tt.expectedList.OverrideName, overrideEntry.OverrideName, "OverrideName should match")
+				assert.Equal(t, tt.expectedList.OverrideDescription, overrideEntry.OverrideDescription, "OverrideDescription should match")
+			} else {
+				assert.False(t, found, "getToolListOverride should not find override")
+				// When no override is found, it returns nil if the map is nil, or a pointer to zero-value struct
+				if tt.config.actualToUserOverride == nil {
+					assert.Nil(t, overrideEntry, "getToolListOverride should return nil when map is nil")
+				} else {
+					assert.NotNil(t, overrideEntry, "getToolListOverride should return a pointer (even if to zero-value)")
+					assert.Equal(t, "", overrideEntry.ActualName, "ActualName should be empty when no override")
+					assert.Equal(t, "", overrideEntry.OverrideName, "OverrideName should be empty when no override")
+					assert.Equal(t, "", overrideEntry.OverrideDescription, "OverrideDescription should be empty when no override")
+				}
+			}
 		})
 	}
 }
@@ -496,9 +1095,11 @@ func TestProcessToolsListResponse_JSONEncoding(t *testing.T) {
 	t.Parallel()
 
 	// Test that the JSON encoding preserves the structure correctly
-	filterTools := map[string]struct{}{
-		"tool1": {},
-		"tool3": {},
+	config := &toolMiddlewareConfig{
+		filterTools: map[string]struct{}{
+			"tool1": {},
+			"tool3": {},
+		},
 	}
 
 	inputResponse := createToolsListResponse([]map[string]any{
@@ -508,7 +1109,7 @@ func TestProcessToolsListResponse_JSONEncoding(t *testing.T) {
 	})
 
 	var buf bytes.Buffer
-	err := processToolsListResponse(filterTools, inputResponse, &buf)
+	err := processToolsListResponse(config, inputResponse, &buf)
 	require.NoError(t, err)
 
 	// Verify the output can be parsed back as valid JSON
@@ -533,126 +1134,6 @@ func TestProcessToolsListResponse_JSONEncoding(t *testing.T) {
 	assert.ElementsMatch(t, []string{"tool1", "tool3"}, toolNames)
 }
 
-func TestProcessSSEEvents_EdgeCases(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name        string
-		filterTools map[string]struct{}
-		inputBuffer []byte
-		expected    string
-	}{
-		{
-			name: "SSE with only line separators",
-			filterTools: map[string]struct{}{
-				"any_tool": {},
-			},
-			inputBuffer: []byte("\n\n"),
-			expected:    "\n",
-		},
-		{
-			name: "SSE with single line",
-			filterTools: map[string]struct{}{
-				"any_tool": {},
-			},
-			inputBuffer: []byte("event: message\n"),
-			expected:    "event: message\n",
-		},
-		{
-			name: "SSE with data line without event line",
-			filterTools: map[string]struct{}{
-				"any_tool": {},
-			},
-			inputBuffer: []byte("data: {\"jsonrpc\":\"2.0\",\"id\":1}\n\n"),
-			expected:    "data: {\"jsonrpc\":\"2.0\",\"id\":1}\n\n",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			var buf bytes.Buffer
-			err := processSSEEvents(tt.filterTools, tt.inputBuffer, &buf)
-
-			require.NoError(t, err)
-			assert.Equal(t, tt.expected, buf.String())
-		})
-	}
-}
-
-func TestProcessToolCallRequest_EdgeCases(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name        string
-		filterTools map[string]struct{}
-		request     toolCallRequest
-		expectError error
-	}{
-		{
-			name: "nil params",
-			filterTools: map[string]struct{}{
-				"any_tool": {},
-			},
-			request: toolCallRequest{
-				JSONRPC: "2.0",
-				ID:      1,
-				Method:  "tools/call",
-				Params:  nil,
-			},
-			expectError: errToolNameNotFound,
-		},
-		{
-			name: "empty params",
-			filterTools: map[string]struct{}{
-				"any_tool": {},
-			},
-			request: toolCallRequest{
-				JSONRPC: "2.0",
-				ID:      1,
-				Method:  "tools/call",
-				Params:  &map[string]any{},
-			},
-			expectError: errToolNameNotFound,
-		},
-		{
-			name: "params with nil name",
-			filterTools: map[string]struct{}{
-				"any_tool": {},
-			},
-			request: toolCallRequest{
-				JSONRPC: "2.0",
-				ID:      1,
-				Method:  "tools/call",
-				Params: &map[string]any{
-					"name": nil,
-				},
-			},
-			expectError: errToolNameNotFound,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			// For nil params, we expect a panic, so we need to recover
-			if tt.request.Params == nil {
-				defer func() {
-					if r := recover(); r != nil {
-						// Expected panic for nil params
-						logger.Infof("Recovered from panic: %v", r)
-					}
-				}()
-			}
-
-			err := processToolCallRequest(tt.filterTools, tt.request)
-			assert.ErrorIs(t, err, tt.expectError)
-		})
-	}
-}
-
 func TestToolFilterWriter_Flush(t *testing.T) {
 	t.Parallel()
 
@@ -664,7 +1145,7 @@ func TestToolFilterWriter_Flush(t *testing.T) {
 		writeData   []byte
 		contentType string
 		statusCode  int
-		filterTools map[string]struct{}
+		config      *toolMiddlewareConfig
 		expectWrite bool
 		expectReset bool
 	}{
@@ -673,8 +1154,10 @@ func TestToolFilterWriter_Flush(t *testing.T) {
 			writeData:   []byte{},
 			contentType: "application/json",
 			statusCode:  200,
-			filterTools: map[string]struct{}{
-				"tool1": {},
+			config: &toolMiddlewareConfig{
+				filterTools: map[string]struct{}{
+					"tool1": {},
+				},
 			},
 			expectWrite: false,
 			expectReset: false,
@@ -684,8 +1167,10 @@ func TestToolFilterWriter_Flush(t *testing.T) {
 			writeData:   []byte(`{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"tool1","description":"First"},{"name":"tool2","description":"Second"}]}}`),
 			contentType: "application/json",
 			statusCode:  200,
-			filterTools: map[string]struct{}{
-				"tool1": {},
+			config: &toolMiddlewareConfig{
+				filterTools: map[string]struct{}{
+					"tool1": {},
+				},
 			},
 			expectWrite: true,
 			expectReset: true,
@@ -695,8 +1180,10 @@ func TestToolFilterWriter_Flush(t *testing.T) {
 			writeData:   []byte(`{"test":"data"}`),
 			contentType: "",
 			statusCode:  200,
-			filterTools: map[string]struct{}{
-				"tool1": {},
+			config: &toolMiddlewareConfig{
+				filterTools: map[string]struct{}{
+					"tool1": {},
+				},
 			},
 			expectWrite: true,
 			expectReset: false, // Buffer is not reset when no content type
@@ -706,8 +1193,10 @@ func TestToolFilterWriter_Flush(t *testing.T) {
 			writeData:   []byte(`{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"tool1","description":"First"}]}}`),
 			contentType: "application/json",
 			statusCode:  201,
-			filterTools: map[string]struct{}{
-				"tool1": {},
+			config: &toolMiddlewareConfig{
+				filterTools: map[string]struct{}{
+					"tool1": {},
+				},
 			},
 			expectWrite: true,
 			expectReset: true,
@@ -729,7 +1218,7 @@ func TestToolFilterWriter_Flush(t *testing.T) {
 			rw := &toolFilterWriter{
 				ResponseWriter: mockWriter,
 				buffer:         []byte{},
-				filterTools:    tt.filterTools,
+				config:         tt.config,
 			}
 
 			// Set status code using WriteHeader

--- a/pkg/mcp/tool_filter_test.go
+++ b/pkg/mcp/tool_filter_test.go
@@ -107,7 +107,7 @@ func TestProcessToolCallRequest(t *testing.T) {
 			expectedName:   "",
 		},
 		{
-			name: "empty filter - should fail for any tool",
+			name: "empty filter - should succeed",
 			config: &toolMiddlewareConfig{
 				filterTools: map[string]struct{}{},
 			},
@@ -119,7 +119,7 @@ func TestProcessToolCallRequest(t *testing.T) {
 					"name": "any_tool",
 				},
 			},
-			expectedResult: "filter",
+			expectedResult: "noaction",
 			expectedName:   "",
 		},
 		{

--- a/pkg/mcp/tool_middleware_test.go
+++ b/pkg/mcp/tool_middleware_test.go
@@ -1,0 +1,612 @@
+package mcp
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stacklok/toolhive/pkg/transport/types"
+)
+
+// Helper function to create a test server with middlewares
+func createTestServer(t *testing.T, middlewares ...types.MiddlewareFunction) *httptest.Server {
+	t.Helper()
+
+	toolsListHandler := func(w http.ResponseWriter, _ *http.Request) {
+		// Simulate different endpoints
+		// Return a tools list response
+		response := toolsListResponse{
+			JSONRPC: "2.0",
+			ID:      1,
+		}
+		tools := []map[string]any{
+			{"name": "Foo", "description": "Foo tool"},
+			{"name": "Bar", "description": "Bar tool"},
+		}
+		response.Result.Tools = &tools
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(response)
+
+		// Ensure the response is flushed
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+	}
+
+	toolsCallHandler := func(w http.ResponseWriter, r *http.Request) {
+		// Handle tool call requests
+		var req toolCallRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "Invalid JSON", http.StatusBadRequest)
+			return
+		}
+
+		// Simulate successful tool call
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		name, ok := (*req.Params)["name"].(string)
+		if !ok {
+			http.Error(w, "Invalid JSON", http.StatusBadRequest)
+			return
+		}
+		json.NewEncoder(w).Encode(map[string]any{
+			"jsonrpc": "2.0",
+			"id":      req.ID,
+			"result":  map[string]any{"return_value": name},
+		})
+
+		// Ensure the response is flushed
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+	}
+
+	sseToolsListHandler := func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.Header().Set("Connection", "keep-alive")
+
+		// Create SSE response
+		response := toolsListResponse{
+			JSONRPC: "2.0",
+			ID:      1,
+		}
+		tools := []map[string]any{
+			{"name": "Foo", "description": "Foo tool"},
+			{"name": "Bar", "description": "Bar tool"},
+		}
+		response.Result.Tools = &tools
+
+		responseBytes, err := json.Marshal(response)
+		require.NoError(t, err)
+
+		// Write SSE format
+		fmt.Fprintf(w, "data: %s\n\n", string(responseBytes))
+
+		// Ensure the response is flushed
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/tools/list", toolsListHandler)
+	mux.HandleFunc("/tools/call", toolsCallHandler)
+	mux.HandleFunc("/tools/list/sse", sseToolsListHandler)
+
+	var handler http.Handler = mux
+	for _, middleware := range middlewares {
+		handler = middleware(handler)
+	}
+
+	return httptest.NewServer(handler)
+}
+
+// Helper function to make a tools list request
+func makeToolsListRequest(t *testing.T, server *httptest.Server) *toolsListResponse {
+	t.Helper()
+
+	resp, err := http.Get(server.URL + "/tools/list")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	var response toolsListResponse
+	err = json.NewDecoder(resp.Body).Decode(&response)
+	require.NoError(t, err)
+
+	return &response
+}
+
+// Helper function to make a tool call request
+func makeToolCallRequest(t *testing.T, server *httptest.Server, toolName string) (*http.Response, error) {
+	t.Helper()
+
+	req := toolCallRequest{
+		JSONRPC: "2.0",
+		ID:      1,
+		Method:  "tools/call",
+		Params: &map[string]any{
+			"name": toolName,
+			"arguments": map[string]any{
+				"arg1": "value1",
+			},
+		},
+	}
+
+	body, err := json.Marshal(req)
+	require.NoError(t, err)
+
+	return http.Post(server.URL+"/tools/call", "application/json", bytes.NewBuffer(body))
+}
+
+func TestNewListToolsMappingMiddleware_Scenarios(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		opts     *[]ToolMiddlewareOption
+		expected *[]map[string]any
+	}{
+		{
+			name: "No filter, No override",
+			opts: nil,
+			expected: &[]map[string]any{
+				{"name": "Foo", "description": "Foo tool"},
+				{"name": "Bar", "description": "Bar tool"},
+			},
+		},
+		{
+			name: "Filter Foo, No override",
+			opts: &[]ToolMiddlewareOption{
+				WithToolsFilter("Foo"),
+			},
+			expected: &[]map[string]any{
+				{"name": "Foo", "description": "Foo tool"},
+			},
+		},
+		{
+			name: "No filter, Override MyFoo -> Foo",
+			opts: &[]ToolMiddlewareOption{
+				WithToolsOverride("Foo", "MyFoo", "Override description"),
+			},
+			expected: &[]map[string]any{
+				{"name": "MyFoo", "description": "Override description"},
+				{"name": "Bar", "description": "Bar tool"},
+			},
+		},
+		{
+			name: "Filter MyFoo, Override MyFoo -> Foo",
+			opts: &[]ToolMiddlewareOption{
+				WithToolsFilter("MyFoo"),
+				WithToolsOverride("Foo", "MyFoo", "Override description"),
+			},
+			expected: &[]map[string]any{
+				{"name": "MyFoo", "description": "Override description"},
+			},
+		},
+		{
+			name: "No filter, Override Bar -> Foo",
+			opts: &[]ToolMiddlewareOption{
+				WithToolsOverride("Bar", "Foo", ""),
+			},
+			expected: &[]map[string]any{
+				{"name": "Foo", "description": "Foo tool"},
+				{"name": "Foo", "description": "Bar tool"},
+			},
+		},
+		{
+			name: "Filter MyFoo, Override Foo -> MyFoo",
+			opts: &[]ToolMiddlewareOption{
+				WithToolsFilter("MyFoo"),
+				WithToolsOverride("Foo", "MyFoo", ""),
+			},
+			expected: &[]map[string]any{
+				{"name": "MyFoo", "description": "Foo tool"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			middlewares := []types.MiddlewareFunction{}
+
+			// Create the middleware
+			if tt.opts != nil {
+				toolsListmiddleware, err := NewListToolsMappingMiddleware(*tt.opts...)
+				assert.NoError(t, err)
+				toolsCallMiddleware, err := NewToolCallMappingMiddleware(*tt.opts...)
+				assert.NoError(t, err)
+
+				middlewares = append(middlewares,
+					toolsCallMiddleware,
+					toolsListmiddleware,
+				)
+			}
+
+			// Create test server
+			server := createTestServer(t, middlewares...)
+			defer server.Close()
+
+			// Make request
+			response := makeToolsListRequest(t, server)
+
+			assert.Equal(t, tt.expected, response.Result.Tools)
+		})
+	}
+}
+
+func TestNewToolCallMappingMiddleware_Scenarios(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		opts           *[]ToolMiddlewareOption
+		expected       *map[string]any
+		callToolName   string
+		expectedStatus int
+	}{
+		{
+			name:           "No filter, No override - Call Foo",
+			opts:           nil,
+			expected:       &map[string]any{"return_value": "Foo"},
+			callToolName:   "Foo",
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name: "Filter Foo, No override - Call Foo",
+			opts: &[]ToolMiddlewareOption{
+				WithToolsFilter("Foo"),
+			},
+			expected:       &map[string]any{"return_value": "Foo"},
+			callToolName:   "Foo",
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name: "Filter Foo, No override - Call Bar",
+			opts: &[]ToolMiddlewareOption{
+				WithToolsFilter("Foo"),
+			},
+			expected:       nil,
+			callToolName:   "Bar",
+			expectedStatus: http.StatusBadRequest, // Bar is filtered out
+		},
+		{
+			name: "No filter, Override MyFoo -> Foo - Call MyFoo",
+			opts: &[]ToolMiddlewareOption{
+				WithToolsOverride("Foo", "MyFoo", "Override description"),
+			},
+			expected:       &map[string]any{"return_value": "Foo"},
+			callToolName:   "MyFoo",
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name: "No filter, Override MyFoo -> Foo - Call Bar",
+			opts: &[]ToolMiddlewareOption{
+				WithToolsOverride("Foo", "MyFoo", "Override description"),
+			},
+			expected:       &map[string]any{"return_value": "Bar"},
+			callToolName:   "Bar",
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name: "Filter MyFoo, Override MyFoo -> Foo - Call MyFoo",
+			opts: &[]ToolMiddlewareOption{
+				WithToolsFilter("MyFoo"),
+				WithToolsOverride("Foo", "MyFoo", "Override description"),
+			},
+			expected:       &map[string]any{"return_value": "Foo"},
+			callToolName:   "MyFoo",
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name: "Filter MyFoo, Override MyFoo -> Foo - Call Bar",
+			opts: &[]ToolMiddlewareOption{
+				WithToolsFilter("MyFoo"),
+				WithToolsOverride("Foo", "MyFoo", "Override description"),
+			},
+			expected:       nil,
+			callToolName:   "Bar",
+			expectedStatus: http.StatusBadRequest, // Bar is filtered out
+		},
+		{
+			name: "No filter, Override Bar -> Foo - Call Foo",
+			opts: &[]ToolMiddlewareOption{
+				WithToolsOverride("Bar", "Foo", ""),
+			},
+			expected:       &map[string]any{"return_value": "Bar"},
+			callToolName:   "Foo",
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name: "No filter, Override Bar -> Foo - Call Bar",
+			opts: &[]ToolMiddlewareOption{
+				WithToolsOverride("Foo", "Bar", ""),
+			},
+			expected:       &map[string]any{"return_value": "Foo"},
+			callToolName:   "Bar",
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name: "Filter MyFoo, Override Foo -> MyFoo",
+			opts: &[]ToolMiddlewareOption{
+				WithToolsFilter("Foo"),
+				WithToolsOverride("Foo", "MyFoo", "Override description"),
+			},
+			expected:       nil,
+			callToolName:   "MyFoo",
+			expectedStatus: http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			middlewares := []types.MiddlewareFunction{}
+
+			// Create the middleware
+			if tt.opts != nil {
+				toolsListmiddleware, err := NewListToolsMappingMiddleware(*tt.opts...)
+				assert.NoError(t, err)
+				toolsCallMiddleware, err := NewToolCallMappingMiddleware(*tt.opts...)
+				assert.NoError(t, err)
+
+				middlewares = append(middlewares,
+					toolsCallMiddleware,
+					toolsListmiddleware,
+				)
+			}
+
+			// Create test server
+			server := createTestServer(t, middlewares...)
+			defer server.Close()
+
+			// Make request
+			resp, err := makeToolCallRequest(t, server, tt.callToolName)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+
+			assert.Equal(t, tt.expectedStatus, resp.StatusCode)
+
+			// Read response body
+			bodyBytes, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+
+			if tt.expected != nil {
+				var response map[string]any
+				err = json.Unmarshal(bodyBytes, &response)
+				require.NoError(t, err)
+
+				require.NotNil(t, response["result"])
+				require.Equal(t, *tt.expected, response["result"].(map[string]any))
+			}
+		})
+	}
+}
+
+func TestNewListToolsMappingMiddleware_SSE_Scenarios(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		opts            *[]ToolMiddlewareOption
+		expected        *[]map[string]any
+		expectedFoo     bool
+		expectedBar     bool
+		expectedFooName string
+		expectedBarName string
+		expectError     bool
+	}{
+		{
+			name: "SSE - Filter Foo, No override",
+			opts: &[]ToolMiddlewareOption{
+				WithToolsFilter("Foo"),
+			},
+			expected: &[]map[string]any{
+				{"name": "Foo", "description": "Foo tool"},
+			},
+			expectedFoo:     true,
+			expectedBar:     false,
+			expectedFooName: "Foo",
+			expectedBarName: "",
+		},
+		{
+			name: "SSE - No filter, Override MyFoo -> Foo (Current implementation bug - all tools filtered out)",
+			opts: &[]ToolMiddlewareOption{
+				WithToolsOverride("Foo", "MyFoo", "Override description"),
+			},
+			expected: &[]map[string]any{
+				{"name": "MyFoo", "description": "Override description"},
+				{"name": "Bar", "description": "Bar tool"},
+			},
+			expectedFoo:     false,
+			expectedBar:     false,
+			expectedFooName: "",
+			expectedBarName: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			middlewares := []types.MiddlewareFunction{}
+
+			// Create the middleware
+			if tt.opts != nil {
+				toolsListmiddleware, err := NewListToolsMappingMiddleware(*tt.opts...)
+				assert.NoError(t, err)
+				toolsCallMiddleware, err := NewToolCallMappingMiddleware(*tt.opts...)
+				assert.NoError(t, err)
+
+				middlewares = append(middlewares,
+					toolsCallMiddleware,
+					toolsListmiddleware,
+				)
+			}
+
+			// Create test server
+			server := createTestServer(t, middlewares...)
+			defer server.Close()
+
+			// Make request
+			resp, err := http.Get(server.URL + "/tools/list/sse")
+			require.NoError(t, err)
+			defer resp.Body.Close()
+
+			// Read SSE response
+			body, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+
+			if tt.expected != nil {
+				// Parse SSE response
+				lines := strings.Split(string(body), "\n")
+				var dataLine string
+				for _, line := range lines {
+					if after, ok := strings.CutPrefix(line, "data: "); ok {
+						dataLine = after
+						break
+					}
+				}
+
+				require.NotEmpty(t, dataLine, "No data line found in SSE response")
+
+				// Parse JSON response
+				var response toolsListResponse
+				err = json.Unmarshal([]byte(dataLine), &response)
+				require.NoError(t, err)
+
+				// Verify results
+				assert.Equal(t, "2.0", response.JSONRPC)
+				assert.Equal(t, float64(1), response.ID)
+				assert.Equal(t, tt.expected, response.Result.Tools)
+			}
+		})
+	}
+}
+
+func TestNewListToolsMappingMiddleware_ErrorCases(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		opts        []ToolMiddlewareOption
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name:        "Empty options - should error",
+			opts:        []ToolMiddlewareOption{},
+			expectError: true,
+			errorMsg:    "tools list for filtering or overriding is empty",
+		},
+		{
+			name: "Empty tool name in filter - should error",
+			opts: []ToolMiddlewareOption{
+				WithToolsFilter(""),
+			},
+			expectError: true,
+			errorMsg:    "tool name cannot be empty",
+		},
+		{
+			name: "Empty actual name in override - should error",
+			opts: []ToolMiddlewareOption{
+				WithToolsOverride("", "MyFoo", "description"),
+			},
+			expectError: true,
+			errorMsg:    "tool name cannot be empty",
+		},
+		{
+			name: "Empty override name and description - should error",
+			opts: []ToolMiddlewareOption{
+				WithToolsOverride("Foo", "", ""),
+			},
+			expectError: true,
+			errorMsg:    "override name and description cannot both be empty",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			middleware, err := NewListToolsMappingMiddleware(tt.opts...)
+
+			if tt.expectError {
+				assert.Error(t, err)
+				if tt.errorMsg != "" {
+					assert.Contains(t, err.Error(), tt.errorMsg)
+				}
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, middleware)
+			}
+		})
+	}
+}
+
+func TestNewToolCallMappingMiddleware_ErrorCases(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		opts        []ToolMiddlewareOption
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name:        "Empty options - should error",
+			opts:        []ToolMiddlewareOption{},
+			expectError: true,
+			errorMsg:    "tools list for filtering or overriding is empty",
+		},
+		{
+			name: "Empty tool name in filter - should error",
+			opts: []ToolMiddlewareOption{
+				WithToolsFilter(""),
+			},
+			expectError: true,
+			errorMsg:    "tool name cannot be empty",
+		},
+		{
+			name: "Empty actual name in override - should error",
+			opts: []ToolMiddlewareOption{
+				WithToolsOverride("", "MyFoo", "description"),
+			},
+			expectError: true,
+			errorMsg:    "tool name cannot be empty",
+		},
+		{
+			name: "Empty override name and description - should error",
+			opts: []ToolMiddlewareOption{
+				WithToolsOverride("Foo", "", ""),
+			},
+			expectError: true,
+			errorMsg:    "override name and description cannot both be empty",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			middleware, err := NewToolCallMappingMiddleware(tt.opts...)
+
+			if tt.expectError {
+				assert.Error(t, err)
+				if tt.errorMsg != "" {
+					assert.Contains(t, err.Error(), tt.errorMsg)
+				}
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, middleware)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This change makes use of the provided filter and override configuration in tool middlewares. Both middlewares now process `tools/call` and `tools/list` commands by checking both overrides and filtering, specifically:

* `tools/list` responses, which the proxy received from the real MCP server, must be modified to contain tools whose names might be overridden (as well as filtered)
* `tools/call` requests, which the proxy received from the Client, must be modified to refer to the original tool name

As a refresher for the reviewer, keep in mind that filtering is expressed in terms of tool names used by the client, so the user-visible (or client-visible) name must be determined before the lookup on the filter. This makes it so that

* `tools/list` must first look the override up and only then check the filter, while
* `tools/call` must first check the filter and only then look the override up

Fixes #1513