### PR TITLE
Do not error when creating server with prefixes of others

### DIFF
--- a/pkg/workloads/manager.go
+++ b/pkg/workloads/manager.go
@@ -726,9 +726,17 @@ func (d *defaultManager) getWorkloadState(ctx context.Context, name string) (*wo
 			return nil, fmt.Errorf("failed to find workload %s: %v", name, err)
 		}
 	} else {
-		// Container found, check if it's running and get the base name
-		workloadSt.Running = container.IsRunning()
-		workloadSt.BaseName = labels.GetContainerBaseName(container.Labels)
+		// Verify exact name match to prevent Docker prefix matching false positives
+		if container.Name != name {
+			logger.Warnf("Warning: Found container %s but requested %s (prefix match)", container.Name, name)
+			// Treat as if container not found
+			workloadSt.BaseName = name
+			workloadSt.Running = false
+		} else {
+			// Container found with exact name, check if it's running and get the base name
+			workloadSt.Running = container.IsRunning()
+			workloadSt.BaseName = labels.GetContainerBaseName(container.Labels)
+		}
 	}
 
 	// Check if the proxy process is running

--- a/pkg/workloads/statuses/file_status.go
+++ b/pkg/workloads/statuses/file_status.go
@@ -416,6 +416,11 @@ func (f *fileStatusManager) getWorkloadFromRuntime(ctx context.Context, workload
 		return core.Workload{}, fmt.Errorf("failed to get workload info from runtime: %w", err)
 	}
 
+	// Verify exact name match to prevent Docker prefix matching false positives
+	if info.Name != workloadName {
+		return core.Workload{}, rt.ErrWorkloadNotFound
+	}
+
 	return types.WorkloadFromContainerInfo(&info)
 }
 


### PR DESCRIPTION
Prevents false positives when checking workload existence or state by
adding exact name matching verification in both getWorkloadFromRuntime and getWorkloadState methods.

Closes: #1613