### PR TITLE
Format unit test output with gotestfmt and upload raw log

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,3 +27,11 @@ jobs:
 
       - name: Run tests
         run: task test
+
+      - name: Upload test log
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        if: always()
+        with:
+          name: test-log
+          path: /tmp/gotest.log
+          if-no-files-found: error

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -24,6 +24,11 @@ tasks:
     cmds:
       - go install go.uber.org/mock/mockgen@latest
 
+  gotestfmt-install:
+    desc: Install gotestfmt for pretty test output
+    cmds:
+      - go install github.com/gotesttools/gotestfmt/v2/cmd/gotestfmt@latest
+
   gen:
     desc: Generate mock files using go generate
     deps: [mock-install]
@@ -42,11 +47,12 @@ tasks:
       - golangci-lint run --fix ./...
 
   test-unixlike:
-    desc: Run unit tests (excluding e2e tests) on Linux and macOS with race detection
+    desc: Run unit tests (excluding e2e tests) on Linux and macOS with race detection (formatted)
     platforms: [linux, darwin]
     internal: true
+    deps: [gotestfmt-install]
     cmds:
-      - go test -v -race $(go list ./... | grep -v '/test/e2e')
+      - bash -o pipefail -c 'set -euo pipefail; go test -json -v -race $(go list ./... | grep -v "/test/e2e") 2>&1 | tee /tmp/gotest.log | gotestfmt -hide successful-tests,successful-packages,empty-packages'
 
   test-windows:
     desc: Run unit tests (excluding e2e tests) on Windows with race detection


### PR DESCRIPTION
Summary
- Integrate gotestfmt for unit test output formatting
- Reduce verbosity by hiding successful tests/packages and empty packages
- Upload the raw /tmp/gotest.log as a workflow artifact for debugging

Details
- Taskfile: added gotestfmt-install task and updated the Linux/macOS unit test path to run `go test -json -v -race` piped to `gotestfmt -hide successful-tests,successful-packages,empty-packages`, while saving the unformatted log to /tmp/gotest.log
- GitHub Actions: Tests workflow now uploads /tmp/gotest.log as an artifact (always)

Notes
- This change touches only standard unit tests; coverage and e2e tasks remain unchanged
- gotestfmt v2 returns non-zero on failing tests by design; we use `set -euo pipefail` so CI correctly fails on test failures
- Platform filters in the Taskfile remain as-is; prior editor warnings appear to be a schema validation issue and not a Taskfile syntax problem

References
- gotestfmt: https://github.com/GoTestTools/gotestfmt