### PR TITLE
Refactor session management to support multiple storage backends

### DIFF
--- a/pkg/transport/session/errors.go
+++ b/pkg/transport/session/errors.go
@@ -1,0 +1,21 @@
+package session
+
+import "errors"
+
+// Common session errors
+var (
+	// ErrSessionDisconnected is returned when trying to send to a disconnected session
+	ErrSessionDisconnected = errors.New("session is disconnected")
+
+	// ErrMessageChannelFull is returned when the message channel is full
+	ErrMessageChannelFull = errors.New("message channel is full")
+
+	// ErrSessionNotFound is returned when a session cannot be found
+	ErrSessionNotFound = errors.New("session not found")
+
+	// ErrSessionAlreadyExists is returned when trying to create a session with an existing ID
+	ErrSessionAlreadyExists = errors.New("session already exists")
+
+	// ErrInvalidSessionType is returned when an invalid session type is provided
+	ErrInvalidSessionType = errors.New("invalid session type")
+)

--- a/pkg/transport/session/manager.go
+++ b/pkg/transport/session/manager.go
@@ -24,18 +24,63 @@ type Manager struct {
 }
 
 // Factory defines a function type for creating new sessions.
-type Factory func(id string) *ProxySession
+// It now returns the Session interface to support different session types.
+type Factory func(id string) Session
+
+// LegacyFactory is the old factory type for backward compatibility
+type LegacyFactory func(id string) *ProxySession
 
 // NewManager creates a session manager with TTL and starts cleanup worker.
-func NewManager(ttl time.Duration, factory Factory) *Manager {
+// It accepts either the new Factory or the legacy factory for backward compatibility.
+func NewManager(ttl time.Duration, factory interface{}) *Manager {
+	var f Factory
+
+	switch factoryFunc := factory.(type) {
+	case Factory:
+		f = factoryFunc
+	case LegacyFactory:
+		// Wrap legacy factory to return Session interface
+		f = func(id string) Session {
+			return factoryFunc(id)
+		}
+	case func(id string) *ProxySession:
+		// Also support direct function for backward compatibility
+		f = func(id string) Session {
+			return factoryFunc(id)
+		}
+	default:
+		// Default to creating basic ProxySession
+		f = func(id string) Session {
+			return NewProxySession(id)
+		}
+	}
+
 	m := &Manager{
 		sessions: sync.Map{},
 		ttl:      ttl,
 		stopCh:   make(chan struct{}),
-		factory:  factory,
+		factory:  f,
 	}
 	go m.cleanupRoutine()
 	return m
+}
+
+// NewTypedManager creates a session manager for a specific session type.
+func NewTypedManager(ttl time.Duration, sessionType SessionType) *Manager {
+	factory := func(id string) Session {
+		switch sessionType {
+		case SessionTypeSSE:
+			return NewSSESession(id)
+		case SessionTypeMCP:
+			return NewProxySession(id)
+		case SessionTypeStreamable:
+			return NewTypedProxySession(id, sessionType)
+		default:
+			return NewTypedProxySession(id, sessionType)
+		}
+	}
+
+	return NewManager(ttl, factory)
 }
 
 func (m *Manager) cleanupRoutine() {
@@ -77,6 +122,23 @@ func (m *Manager) AddWithID(id string) error {
 	return nil
 }
 
+// AddSession adds an existing session to the manager.
+// This is useful when you need to create a session with specific properties.
+func (m *Manager) AddSession(session Session) error {
+	if session == nil {
+		return fmt.Errorf("session cannot be nil")
+	}
+	if session.ID() == "" {
+		return fmt.Errorf("session ID cannot be empty")
+	}
+
+	_, loaded := m.sessions.LoadOrStore(session.ID(), session)
+	if loaded {
+		return fmt.Errorf("session ID %q already exists", session.ID())
+	}
+	return nil
+}
+
 // Get retrieves a session by ID. Returns (session, true) if found,
 // and also updates its UpdatedAt timestamp.
 func (m *Manager) Get(id string) (Session, bool) {
@@ -101,6 +163,22 @@ func (m *Manager) Delete(id string) {
 // Stop stops the cleanup worker.
 func (m *Manager) Stop() {
 	close(m.stopCh)
+}
+
+// Range calls f sequentially for each key and value present in the map.
+// If f returns false, range stops the iteration.
+func (m *Manager) Range(f func(key, value interface{}) bool) {
+	m.sessions.Range(f)
+}
+
+// Count returns the number of active sessions.
+func (m *Manager) Count() int {
+	count := 0
+	m.sessions.Range(func(_, _ interface{}) bool {
+		count++
+		return true
+	})
+	return count
 }
 
 func (m *Manager) cleanupExpiredOnce() {

--- a/pkg/transport/session/proxy_session.go
+++ b/pkg/transport/session/proxy_session.go
@@ -1,18 +1,59 @@
 package session
 
-import "time"
+import (
+	"sync"
+	"time"
+)
+
+// SessionType represents the type of session
+//
+//revive:disable-next-line:exported
+type SessionType string
+
+const (
+	// SessionTypeMCP represents a standard MCP session
+	SessionTypeMCP SessionType = "mcp"
+	// SessionTypeSSE represents an SSE (Server-Sent Events) session
+	SessionTypeSSE SessionType = "sse"
+	// SessionTypeStreamable represents a streamable HTTP session
+	SessionTypeStreamable SessionType = "streamable"
+)
 
 // ProxySession implements the Session interface for proxy sessions.
+// It now includes support for session types, metadata, and custom data.
 type ProxySession struct {
-	id      string
-	created time.Time
-	updated time.Time
+	id       string
+	created  time.Time
+	updated  time.Time
+	sessType SessionType
+	data     interface{}
+	metadata map[string]string
+	mu       sync.RWMutex // Protect concurrent access to metadata and data
 }
 
 // NewProxySession creates a new ProxySession with the given ID.
+// It defaults to SessionTypeMCP for backward compatibility.
 func NewProxySession(id string) *ProxySession {
 	now := time.Now()
-	return &ProxySession{id: id, created: now, updated: now}
+	return &ProxySession{
+		id:       id,
+		created:  now,
+		updated:  now,
+		sessType: SessionTypeMCP,
+		metadata: make(map[string]string),
+	}
+}
+
+// NewTypedProxySession creates a new ProxySession with the given ID and type.
+func NewTypedProxySession(id string, sessType SessionType) *ProxySession {
+	now := time.Now()
+	return &ProxySession{
+		id:       id,
+		created:  now,
+		updated:  now,
+		sessType: sessType,
+		metadata: make(map[string]string),
+	}
 }
 
 // ID returns the session ID.
@@ -22,7 +63,69 @@ func (s *ProxySession) ID() string { return s.id }
 func (s *ProxySession) CreatedAt() time.Time { return s.created }
 
 // UpdatedAt returns the last updated time of the session.
-func (s *ProxySession) UpdatedAt() time.Time { return s.updated }
+func (s *ProxySession) UpdatedAt() time.Time {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.updated
+}
 
 // Touch updates the session's last updated time to the current time.
-func (s *ProxySession) Touch() { s.updated = time.Now() }
+func (s *ProxySession) Touch() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.updated = time.Now()
+}
+
+// Type returns the session type.
+func (s *ProxySession) Type() SessionType { return s.sessType }
+
+// GetData returns the session-specific data.
+func (s *ProxySession) GetData() interface{} {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.data
+}
+
+// SetData sets the session-specific data.
+func (s *ProxySession) SetData(data interface{}) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.data = data
+}
+
+// GetMetadata returns all metadata as a map.
+func (s *ProxySession) GetMetadata() map[string]string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	// Return a copy to prevent external modification
+	result := make(map[string]string, len(s.metadata))
+	for k, v := range s.metadata {
+		result[k] = v
+	}
+	return result
+}
+
+// SetMetadata sets a metadata key-value pair.
+func (s *ProxySession) SetMetadata(key, value string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.metadata == nil {
+		s.metadata = make(map[string]string)
+	}
+	s.metadata[key] = value
+}
+
+// GetMetadataValue gets a specific metadata value.
+func (s *ProxySession) GetMetadataValue(key string) (string, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	value, ok := s.metadata[key]
+	return value, ok
+}
+
+// DeleteMetadata removes a metadata key.
+func (s *ProxySession) DeleteMetadata(key string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.metadata, key)
+}

--- a/pkg/transport/session/sse_session.go
+++ b/pkg/transport/session/sse_session.go
@@ -1,0 +1,100 @@
+package session
+
+import (
+	"time"
+
+	"github.com/stacklok/toolhive/pkg/transport/ssecommon"
+)
+
+// SSESession represents an SSE (Server-Sent Events) session.
+// It embeds ProxySession and adds SSE-specific functionality.
+type SSESession struct {
+	*ProxySession
+
+	// SSE-specific fields
+	MessageCh   chan string
+	ClientInfo  *ssecommon.SSEClient
+	IsConnected bool
+}
+
+// NewSSESession creates a new SSE session with the given ID.
+func NewSSESession(id string) *SSESession {
+	return &SSESession{
+		ProxySession: NewTypedProxySession(id, SessionTypeSSE),
+		MessageCh:    make(chan string, 100),
+		IsConnected:  true,
+	}
+}
+
+// NewSSESessionWithClient creates a new SSE session with the given ID and client info.
+func NewSSESessionWithClient(id string, client *ssecommon.SSEClient) *SSESession {
+	sess := NewSSESession(id)
+	sess.ClientInfo = client
+	if client != nil {
+		sess.MessageCh = client.MessageCh
+	}
+	return sess
+}
+
+// Disconnect marks the session as disconnected and closes the message channel.
+func (s *SSESession) Disconnect() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.IsConnected {
+		s.IsConnected = false
+		if s.MessageCh != nil {
+			close(s.MessageCh)
+		}
+	}
+}
+
+// SendMessage sends a message to the SSE client if connected.
+func (s *SSESession) SendMessage(msg string) error {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if !s.IsConnected {
+		return ErrSessionDisconnected
+	}
+
+	select {
+	case s.MessageCh <- msg:
+		return nil
+	default:
+		return ErrMessageChannelFull
+	}
+}
+
+// GetClientInfo returns the SSE client information.
+func (s *SSESession) GetClientInfo() *ssecommon.SSEClient {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.ClientInfo
+}
+
+// SetClientInfo sets the SSE client information.
+func (s *SSESession) SetClientInfo(client *ssecommon.SSEClient) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.ClientInfo = client
+	if client != nil && client.MessageCh != nil {
+		s.MessageCh = client.MessageCh
+	}
+}
+
+// GetConnectionStatus returns whether the SSE session is connected.
+func (s *SSESession) GetConnectionStatus() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.IsConnected
+}
+
+// GetCreatedAt returns when the SSE session was created.
+// This is useful for tracking connection duration.
+func (s *SSESession) GetCreatedAt() time.Time {
+	if s.ClientInfo != nil {
+		return s.ClientInfo.CreatedAt
+	}
+	return s.CreatedAt()
+}


### PR DESCRIPTION
Unified session management across all transport types by migrating
HTTPSSEProxy from direct map storage to use the centralized session
manager. Extended the session interface to support type differentiation
and metadata storage, enabling future support for distributed session
storage backends like Redis/Valkey.

Key changes:
- Added session types (MCP, SSE, Streamable) for better session handling
- Created SSESession type with SSE-specific functionality
- Migrated HTTPSSEProxy to use session manager with proper TTL
- Updated factory pattern to support different session types
- Fixed all tests to work with the new session management
- Maintained backward compatibility with existing code

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>
