### PR TITLE
solution for Workloads API return HTTP 500 on invalid config #1676

### DIFF
--- a/pkg/api/v1/workloads.go
+++ b/pkg/api/v1/workloads.go
@@ -300,6 +300,8 @@ func (s *WorkloadRoutes) createWorkload(w http.ResponseWriter, r *http.Request) 
 		// Error messages already logged in createWorkloadFromRequest
 		if errors.Is(err, retriever.ErrImageNotFound) || err.Error() == "MCP server image not found" {
 			http.Error(w, err.Error(), http.StatusNotFound)
+		} else if errors.Is(err, retriever.ErrInvalidRunConfig) {
+			http.Error(w, err.Error(), http.StatusBadRequest)
 		} else {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
@@ -834,7 +836,7 @@ func (s *WorkloadRoutes) createWorkloadFromRequest(ctx context.Context, req *cre
 		Build(ctx, imageMetadata, req.EnvVars, &runner.DetachedEnvVarValidator{})
 	if err != nil {
 		logger.Errorf("Failed to build run config: %v", err)
-		return nil, fmt.Errorf("invalid configuration: %v", err)
+		return nil, fmt.Errorf("%w: %v", retriever.ErrInvalidRunConfig, err)
 	}
 
 	// Save the workload state

--- a/pkg/runner/retriever/retriever.go
+++ b/pkg/runner/retriever/retriever.go
@@ -30,6 +30,8 @@ var (
 	ErrBadProtocolScheme = errors.New("invalid protocol scheme provided for MCP server")
 	// ErrImageNotFound is returned when the specified image is not found in the registry.
 	ErrImageNotFound = errors.New("image not found in registry, please check the image name or tag")
+	// ErrInvalidRunConfig is returned when the run configuration built by RunConfigBuilder is invalid
+	ErrInvalidRunConfig = errors.New("invalid run configuration provided")
 )
 
 // GetMCPServer retrieves the MCP server definition from the registry.


### PR DESCRIPTION
Hi @blkt,
I worked on the issue where API endpoints for creating and updating workloads returned HTTP 500 even when the error was due to invalid user input in the run config.
Please let me know if any adjustments are needed — happy to refine further 🙂
Thanks!