### PR TITLE
adds exclusions for codecov

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -8,4 +8,3 @@ coverage:
     - "test/e2e"
     - "deploy"
     - "**/mocks/"
-    - "pkg/api/"

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,0 +1,11 @@
+coverage:
+  ignore:
+    - "cmd/"
+    - "containers/egress-proxy"
+    - "docs/"
+    - "examples/"
+    - "hack"
+    - "test/e2e"
+    - "deploy"
+    - "**/mocks/"
+    - "pkg/api/"


### PR DESCRIPTION
There are a bunch of folders and packages that we don't want codecov to report coverage (or lackthereof) on.