### PR TITLE
add new noop state storage for k8s

### DIFF
--- a/pkg/config/interface.go
+++ b/pkg/config/interface.go
@@ -1,5 +1,9 @@
 package config
 
+import (
+	"github.com/stacklok/toolhive/pkg/container/runtime"
+)
+
 // Provider defines the interface for configuration operations
 type Provider interface {
 	GetConfig() *Config
@@ -28,12 +32,12 @@ func (*DefaultProvider) GetConfig() *Config {
 
 // UpdateConfig updates the config using the default path
 func (*DefaultProvider) UpdateConfig(updateFn func(*Config)) error {
-	return UpdateConfig(updateFn)
+	return UpdateConfigAtPath("", updateFn)
 }
 
 // LoadOrCreateConfig loads or creates config using the default path
 func (*DefaultProvider) LoadOrCreateConfig() (*Config, error) {
-	return LoadOrCreateConfig()
+	return LoadOrCreateConfigWithDefaultPath()
 }
 
 // SetRegistryURL validates and sets a registry URL
@@ -105,4 +109,58 @@ func (p *PathProvider) UnsetRegistry() error {
 // GetRegistryConfig returns current registry configuration
 func (p *PathProvider) GetRegistryConfig() (url, localPath string, allowPrivateIP bool, registryType string) {
 	return getRegistryConfig(p)
+}
+
+// KubernetesProvider is a no-op implementation of Provider for Kubernetes environments.
+// In Kubernetes, configuration is managed by the cluster, not by local files.
+type KubernetesProvider struct{}
+
+// NewKubernetesProvider creates a new no-op config provider for Kubernetes environments
+func NewKubernetesProvider() *KubernetesProvider {
+	return &KubernetesProvider{}
+}
+
+// GetConfig returns a default config for Kubernetes environments
+func (*KubernetesProvider) GetConfig() *Config {
+	config := createNewConfigWithDefaults()
+	return &config
+}
+
+// UpdateConfig is a no-op for Kubernetes environments
+func (*KubernetesProvider) UpdateConfig(_ func(*Config)) error {
+	return nil
+}
+
+// LoadOrCreateConfig returns a default config for Kubernetes environments
+func (*KubernetesProvider) LoadOrCreateConfig() (*Config, error) {
+	config := createNewConfigWithDefaults()
+	return &config, nil
+}
+
+// SetRegistryURL is a no-op for Kubernetes environments
+func (*KubernetesProvider) SetRegistryURL(_ string, _ bool) error {
+	return nil
+}
+
+// SetRegistryFile is a no-op for Kubernetes environments
+func (*KubernetesProvider) SetRegistryFile(_ string) error {
+	return nil
+}
+
+// UnsetRegistry is a no-op for Kubernetes environments
+func (*KubernetesProvider) UnsetRegistry() error {
+	return nil
+}
+
+// GetRegistryConfig returns empty registry configuration for Kubernetes environments
+func (*KubernetesProvider) GetRegistryConfig() (url, localPath string, allowPrivateIP bool, registryType string) {
+	return "", "", false, ""
+}
+
+// NewProvider creates the appropriate config provider based on the runtime environment
+func NewProvider() Provider {
+	if runtime.IsKubernetesRuntime() {
+		return NewKubernetesProvider()
+	}
+	return NewDefaultProvider()
 }

--- a/pkg/config/interface_test.go
+++ b/pkg/config/interface_test.go
@@ -1,0 +1,348 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/stacklok/toolhive/pkg/logger"
+)
+
+func TestNewDefaultProvider(t *testing.T) {
+	t.Parallel()
+	provider := NewDefaultProvider()
+	assert.NotNil(t, provider)
+	assert.IsType(t, &DefaultProvider{}, provider)
+}
+
+func TestNewPathProvider(t *testing.T) {
+	t.Parallel()
+	configPath := "/test/path/config.yaml"
+	provider := NewPathProvider(configPath)
+	assert.NotNil(t, provider)
+	assert.IsType(t, &PathProvider{}, provider)
+	assert.Equal(t, configPath, provider.configPath)
+}
+
+func TestNewKubernetesProvider(t *testing.T) {
+	t.Parallel()
+	provider := NewKubernetesProvider()
+	assert.NotNil(t, provider)
+	assert.IsType(t, &KubernetesProvider{}, provider)
+}
+
+func TestDefaultProvider(t *testing.T) {
+	t.Parallel()
+	logger.Initialize()
+
+	t.Run("GetConfig", func(t *testing.T) {
+		t.Parallel()
+
+		// Use PathProvider instead to avoid singleton issues in parallel tests
+		tempDir := t.TempDir()
+		configPath := filepath.Join(tempDir, "config.yaml")
+		pathProvider := NewPathProvider(configPath)
+
+		config := pathProvider.GetConfig()
+		assert.NotNil(t, config)
+		assert.IsType(t, &Config{}, config)
+	})
+
+	t.Run("LoadOrCreateConfig", func(t *testing.T) {
+		t.Parallel()
+
+		// Use PathProvider instead to avoid singleton issues in parallel tests
+		tempDir := t.TempDir()
+		configPath := filepath.Join(tempDir, "config.yaml")
+		pathProvider := NewPathProvider(configPath)
+
+		config, err := pathProvider.LoadOrCreateConfig()
+		assert.NoError(t, err)
+		assert.NotNil(t, config)
+		assert.FileExists(t, configPath)
+	})
+
+	t.Run("UpdateConfig", func(t *testing.T) {
+		t.Parallel()
+
+		// Use PathProvider instead to avoid singleton issues in parallel tests
+		tempDir := t.TempDir()
+		configPath := filepath.Join(tempDir, "config.yaml")
+		pathProvider := NewPathProvider(configPath)
+
+		// Create initial config
+		_, err := pathProvider.LoadOrCreateConfig()
+		require.NoError(t, err)
+
+		// Update config
+		err = pathProvider.UpdateConfig(func(c *Config) {
+			c.RegistryUrl = "https://example.com"
+		})
+		assert.NoError(t, err)
+
+		// Verify update - just check that we can load the config
+		_, err = LoadOrCreateConfigFromPath(configPath)
+		assert.NoError(t, err)
+	})
+}
+
+func TestPathProvider(t *testing.T) {
+	t.Parallel()
+	logger.Initialize()
+
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "config.yaml")
+	provider := NewPathProvider(configPath)
+
+	t.Run("GetConfig_NewFile", func(t *testing.T) {
+		t.Parallel()
+		config := provider.GetConfig()
+		assert.NotNil(t, config)
+		assert.IsType(t, &Config{}, config)
+		assert.FileExists(t, configPath)
+	})
+
+	t.Run("GetConfig_ExistingFile", func(t *testing.T) {
+		t.Parallel()
+		// Create a config with specific content
+		testConfig := &Config{
+			RegistryUrl: "https://test.com",
+			Secrets: Secrets{
+				ProviderType:   "encrypted",
+				SetupCompleted: true,
+			},
+		}
+		configBytes, err := yaml.Marshal(testConfig)
+		require.NoError(t, err)
+
+		configPath2 := filepath.Join(tempDir, "config2.yaml")
+		err = os.WriteFile(configPath2, configBytes, 0600)
+		require.NoError(t, err)
+
+		provider2 := NewPathProvider(configPath2)
+		config := provider2.GetConfig()
+		assert.NotNil(t, config)
+		assert.Equal(t, "https://test.com", config.RegistryUrl)
+		assert.Equal(t, "encrypted", config.Secrets.ProviderType)
+	})
+
+	t.Run("GetConfig_ErrorFallback", func(t *testing.T) {
+		t.Parallel()
+		// Use a path that will cause an error (directory instead of file)
+		dirPath := filepath.Join(tempDir, "dir")
+		err := os.MkdirAll(dirPath, 0755)
+		require.NoError(t, err)
+
+		provider := NewPathProvider(dirPath)
+		config := provider.GetConfig()
+		assert.NotNil(t, config)
+		// Should return default config on error
+		assert.Equal(t, "", config.RegistryUrl)
+		assert.False(t, config.Secrets.SetupCompleted)
+	})
+
+	t.Run("LoadOrCreateConfig", func(t *testing.T) {
+		t.Parallel()
+		configPath3 := filepath.Join(tempDir, "config3.yaml")
+		provider := NewPathProvider(configPath3)
+
+		config, err := provider.LoadOrCreateConfig()
+		assert.NoError(t, err)
+		assert.NotNil(t, config)
+		assert.FileExists(t, configPath3)
+	})
+
+	t.Run("UpdateConfig", func(t *testing.T) {
+		t.Parallel()
+		configPath4 := filepath.Join(tempDir, "config4.yaml")
+		provider := NewPathProvider(configPath4)
+
+		// Create initial config
+		_, err := provider.LoadOrCreateConfig()
+		require.NoError(t, err)
+
+		// Update config
+		err = provider.UpdateConfig(func(c *Config) {
+			c.RegistryUrl = "https://updated.com"
+		})
+		assert.NoError(t, err)
+
+		// Verify update
+		config, err := LoadOrCreateConfigFromPath(configPath4)
+		require.NoError(t, err)
+		assert.Equal(t, "https://updated.com", config.RegistryUrl)
+	})
+}
+
+func TestKubernetesProvider(t *testing.T) {
+	t.Parallel()
+	provider := NewKubernetesProvider()
+
+	t.Run("GetConfig", func(t *testing.T) {
+		t.Parallel()
+		config := provider.GetConfig()
+		assert.NotNil(t, config)
+		assert.IsType(t, &Config{}, config)
+		// Should return default config
+		assert.Equal(t, "", config.RegistryUrl)
+		assert.False(t, config.Secrets.SetupCompleted)
+	})
+
+	t.Run("LoadOrCreateConfig", func(t *testing.T) {
+		t.Parallel()
+		config, err := provider.LoadOrCreateConfig()
+		assert.NoError(t, err)
+		assert.NotNil(t, config)
+		// Should return default config
+		assert.Equal(t, "", config.RegistryUrl)
+		assert.False(t, config.Secrets.SetupCompleted)
+	})
+
+	t.Run("UpdateConfig", func(t *testing.T) {
+		t.Parallel()
+		err := provider.UpdateConfig(func(c *Config) {
+			c.RegistryUrl = "https://example.com"
+		})
+		assert.NoError(t, err) // Should be no-op
+	})
+
+	t.Run("SetRegistryURL", func(t *testing.T) {
+		t.Parallel()
+		err := provider.SetRegistryURL("https://example.com", true)
+		assert.NoError(t, err) // Should be no-op
+	})
+
+	t.Run("SetRegistryFile", func(t *testing.T) {
+		t.Parallel()
+		err := provider.SetRegistryFile("/path/to/registry.yaml")
+		assert.NoError(t, err) // Should be no-op
+	})
+
+	t.Run("UnsetRegistry", func(t *testing.T) {
+		t.Parallel()
+		err := provider.UnsetRegistry()
+		assert.NoError(t, err) // Should be no-op
+	})
+
+	t.Run("GetRegistryConfig", func(t *testing.T) {
+		t.Parallel()
+		url, localPath, allowPrivateIP, registryType := provider.GetRegistryConfig()
+		assert.Equal(t, "", url)
+		assert.Equal(t, "", localPath)
+		assert.False(t, allowPrivateIP)
+		assert.Equal(t, "", registryType)
+	})
+}
+
+func TestNewProvider(t *testing.T) {
+	t.Run("DefaultProvider", func(t *testing.T) {
+		// Ensure no Kubernetes environment variables are set
+		originalKubeEnv := os.Getenv("KUBERNETES_SERVICE_HOST")
+		originalPodEnv := os.Getenv("KUBERNETES_SERVICE_PORT")
+		if originalKubeEnv != "" {
+			t.Setenv("KUBERNETES_SERVICE_HOST", "")
+		}
+		if originalPodEnv != "" {
+			t.Setenv("KUBERNETES_SERVICE_PORT", "")
+		}
+
+		provider := NewProvider()
+		assert.NotNil(t, provider)
+		assert.IsType(t, &DefaultProvider{}, provider)
+	})
+
+	t.Run("KubernetesProvider", func(t *testing.T) {
+		// Set Kubernetes environment variables
+		t.Setenv("KUBERNETES_SERVICE_HOST", "10.96.0.1")
+		t.Setenv("KUBERNETES_SERVICE_PORT", "443")
+
+		provider := NewProvider()
+		assert.NotNil(t, provider)
+		assert.IsType(t, &KubernetesProvider{}, provider)
+	})
+}
+
+func TestProviderRegistryOperations(t *testing.T) {
+	t.Parallel()
+	logger.Initialize()
+
+	tempDir := t.TempDir()
+
+	t.Run("DefaultProvider_RegistryOperations", func(t *testing.T) {
+		t.Parallel()
+
+		// Use PathProvider to avoid singleton issues in parallel tests
+		tempDir := t.TempDir()
+		configPath := filepath.Join(tempDir, "default_config.yaml")
+		pathProvider := NewPathProvider(configPath)
+
+		// Create initial config
+		_, err := pathProvider.LoadOrCreateConfig()
+		require.NoError(t, err)
+
+		// Test SetRegistryURL
+		err = pathProvider.SetRegistryURL("https://example.com", true)
+		assert.NoError(t, err)
+
+		// Test GetRegistryConfig after setting URL
+		url, localPath, allowPrivateIP, registryType := pathProvider.GetRegistryConfig()
+		assert.Equal(t, "https://example.com", url)
+		assert.Equal(t, "", localPath)
+		assert.True(t, allowPrivateIP)
+		assert.Equal(t, "url", registryType)
+
+		// Test SetRegistryFile (must be a JSON file)
+		registryFilePath := filepath.Join(tempDir, "registry.json")
+		err = os.WriteFile(registryFilePath, []byte(`{"test": "registry"}`), 0600)
+		require.NoError(t, err)
+		err = pathProvider.SetRegistryFile(registryFilePath)
+		assert.NoError(t, err)
+
+		// Test UnsetRegistry
+		err = pathProvider.UnsetRegistry()
+		assert.NoError(t, err)
+	})
+
+	t.Run("PathProvider_RegistryOperations", func(t *testing.T) {
+		t.Parallel()
+		configPath := filepath.Join(tempDir, "path_config.yaml")
+		provider := NewPathProvider(configPath)
+
+		// Create initial config
+		_, err := provider.LoadOrCreateConfig()
+		require.NoError(t, err)
+
+		// Test SetRegistryURL
+		err = provider.SetRegistryURL("https://path-example.com", false)
+		assert.NoError(t, err)
+
+		// Test GetRegistryConfig after setting URL
+		url, localPath, allowPrivateIP, registryType := provider.GetRegistryConfig()
+		assert.Equal(t, "https://path-example.com", url)
+		assert.Equal(t, "", localPath)
+		assert.False(t, allowPrivateIP)
+		assert.Equal(t, "url", registryType)
+
+		// Test SetRegistryFile (must be a JSON file)
+		registryFilePath := filepath.Join(tempDir, "path_registry.json")
+		err = os.WriteFile(registryFilePath, []byte(`{"test": "registry"}`), 0600)
+		require.NoError(t, err)
+		err = provider.SetRegistryFile(registryFilePath)
+		assert.NoError(t, err)
+
+		// Test GetRegistryConfig after setting file
+		url, localPath, allowPrivateIP, registryType = provider.GetRegistryConfig()
+		assert.Equal(t, "", url)
+		assert.Equal(t, registryFilePath, localPath)
+		assert.False(t, allowPrivateIP)
+		assert.Equal(t, "file", registryType)
+
+		// Test UnsetRegistry
+		err = provider.UnsetRegistry()
+		assert.NoError(t, err)
+	})
+}

--- a/pkg/state/factory.go
+++ b/pkg/state/factory.go
@@ -1,5 +1,9 @@
 package state
 
+import (
+	"github.com/stacklok/toolhive/pkg/container/runtime"
+)
+
 const (
 	// RunConfigsDir is the directory name for storing run configurations
 	RunConfigsDir = "runconfigs"
@@ -10,10 +14,26 @@ const (
 
 // NewRunConfigStore creates a store for run configuration state
 func NewRunConfigStore(appName string) (Store, error) {
+	return NewRunConfigStoreWithDetector(appName)
+}
+
+// NewRunConfigStoreWithDetector creates a store
+func NewRunConfigStoreWithDetector(appName string) (Store, error) {
+	if runtime.IsKubernetesRuntime() {
+		return NewKubernetesStore(), nil
+	}
 	return NewLocalStore(appName, RunConfigsDir)
 }
 
 // NewGroupConfigStore creates a store for group configurations
 func NewGroupConfigStore(appName string) (Store, error) {
+	return NewGroupConfigStoreWithDetector(appName)
+}
+
+// NewGroupConfigStoreWithDetector creates a store
+func NewGroupConfigStoreWithDetector(appName string) (Store, error) {
+	if runtime.IsKubernetesRuntime() {
+		return NewKubernetesStore(), nil
+	}
 	return NewLocalStore(appName, GroupConfigsDir)
 }

--- a/pkg/state/factory_test.go
+++ b/pkg/state/factory_test.go
@@ -1,0 +1,44 @@
+package state
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewRunConfigStoreWithDetector(t *testing.T) {
+	t.Parallel()
+
+	store, err := NewRunConfigStoreWithDetector("toolhive")
+
+	require.NoError(t, err)
+	assert.IsType(t, &LocalStore{}, store)
+}
+
+func TestNewGroupConfigStoreWithDetector(t *testing.T) {
+	t.Parallel()
+
+	store, err := NewGroupConfigStoreWithDetector("toolhive")
+
+	require.NoError(t, err)
+	assert.IsType(t, &LocalStore{}, store)
+}
+
+func TestNewRunConfigStore(t *testing.T) {
+	t.Parallel()
+
+	store, err := NewRunConfigStore("toolhive")
+
+	require.NoError(t, err)
+	assert.IsType(t, &LocalStore{}, store)
+}
+
+func TestNewGroupConfigStore(t *testing.T) {
+	t.Parallel()
+
+	store, err := NewGroupConfigStore("toolhive")
+
+	require.NoError(t, err)
+	assert.IsType(t, &LocalStore{}, store)
+}

--- a/pkg/state/kubernetes.go
+++ b/pkg/state/kubernetes.go
@@ -1,0 +1,54 @@
+package state
+
+import (
+	"context"
+	"io"
+	"strings"
+)
+
+// KubernetesStore is a no-op implementation of Store for Kubernetes environments.
+// In Kubernetes, workload state is managed by the cluster, not by local files.
+type KubernetesStore struct{}
+
+// NewKubernetesStore creates a new no-op store for Kubernetes environments.
+func NewKubernetesStore() Store {
+	return &KubernetesStore{}
+}
+
+// Exists always returns false for Kubernetes stores since state is not persisted locally.
+func (*KubernetesStore) Exists(_ context.Context, _ string) (bool, error) {
+	return false, nil
+}
+
+// List always returns an empty slice for Kubernetes stores.
+func (*KubernetesStore) List(_ context.Context) ([]string, error) {
+	return []string{}, nil
+}
+
+// GetReader returns a no-op reader for Kubernetes stores.
+func (*KubernetesStore) GetReader(_ context.Context, _ string) (io.ReadCloser, error) {
+	return io.NopCloser(strings.NewReader("")), nil
+}
+
+// GetWriter returns a no-op writer for Kubernetes stores.
+func (*KubernetesStore) GetWriter(_ context.Context, _ string) (io.WriteCloser, error) {
+	return &noopWriteCloser{}, nil
+}
+
+// Delete is a no-op for Kubernetes stores.
+func (*KubernetesStore) Delete(_ context.Context, _ string) error {
+	return nil
+}
+
+// noopWriteCloser is a writer that discards all writes.
+type noopWriteCloser struct{}
+
+// Write discards all data and returns success.
+func (*noopWriteCloser) Write(p []byte) (n int, err error) {
+	return len(p), nil
+}
+
+// Close is a no-op.
+func (*noopWriteCloser) Close() error {
+	return nil
+}

--- a/pkg/state/kubernetes_test.go
+++ b/pkg/state/kubernetes_test.go
@@ -1,0 +1,202 @@
+package state
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewKubernetesStore(t *testing.T) {
+	t.Parallel()
+	store := NewKubernetesStore()
+	assert.NotNil(t, store)
+	assert.IsType(t, &KubernetesStore{}, store)
+}
+
+func TestKubernetesStore_Exists(t *testing.T) {
+	t.Parallel()
+	store := &KubernetesStore{}
+	ctx := context.Background()
+
+	// Test with various names
+	testCases := []string{
+		"test-workload",
+		"another-workload",
+		"",
+		"workload-with-special-chars-123",
+	}
+
+	for _, name := range testCases {
+		name := name
+		t.Run("name_"+name, func(t *testing.T) {
+			t.Parallel()
+			exists, err := store.Exists(ctx, name)
+			assert.NoError(t, err)
+			assert.False(t, exists, "Exists should always return false for KubernetesStore")
+		})
+	}
+}
+
+func TestKubernetesStore_List(t *testing.T) {
+	t.Parallel()
+	store := &KubernetesStore{}
+	ctx := context.Background()
+
+	list, err := store.List(ctx)
+	assert.NoError(t, err)
+	assert.NotNil(t, list)
+	assert.Empty(t, list, "List should always return an empty slice for KubernetesStore")
+}
+
+func TestKubernetesStore_GetReader(t *testing.T) {
+	t.Parallel()
+	store := &KubernetesStore{}
+	ctx := context.Background()
+
+	testCases := []string{
+		"test-workload",
+		"another-workload",
+		"",
+	}
+
+	for _, name := range testCases {
+		name := name
+		t.Run("name_"+name, func(t *testing.T) {
+			t.Parallel()
+			reader, err := store.GetReader(ctx, name)
+			assert.NoError(t, err)
+			assert.NotNil(t, reader)
+
+			// Verify it's a no-op reader that returns empty content
+			data, err := io.ReadAll(reader)
+			assert.NoError(t, err)
+			assert.Empty(t, data, "Reader should return empty content")
+
+			// Verify we can close it without error
+			err = reader.Close()
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestKubernetesStore_GetWriter(t *testing.T) {
+	t.Parallel()
+	store := &KubernetesStore{}
+	ctx := context.Background()
+
+	testCases := []string{
+		"test-workload",
+		"another-workload",
+		"",
+	}
+
+	for _, name := range testCases {
+		name := name
+		t.Run("name_"+name, func(t *testing.T) {
+			t.Parallel()
+			writer, err := store.GetWriter(ctx, name)
+			assert.NoError(t, err)
+			assert.NotNil(t, writer)
+			assert.IsType(t, &noopWriteCloser{}, writer)
+		})
+	}
+}
+
+func TestKubernetesStore_Delete(t *testing.T) {
+	t.Parallel()
+	store := &KubernetesStore{}
+	ctx := context.Background()
+
+	testCases := []string{
+		"test-workload",
+		"another-workload",
+		"",
+		"non-existent-workload",
+	}
+
+	for _, name := range testCases {
+		name := name
+		t.Run("name_"+name, func(t *testing.T) {
+			t.Parallel()
+			err := store.Delete(ctx, name)
+			assert.NoError(t, err, "Delete should always succeed for KubernetesStore")
+		})
+	}
+}
+
+func TestNoopWriteCloser_Write(t *testing.T) {
+	t.Parallel()
+	writer := &noopWriteCloser{}
+
+	testCases := [][]byte{
+		[]byte("hello world"),
+		[]byte(""),
+		[]byte("test data with special chars: 你好世界"),
+		make([]byte, 1024), // Large buffer
+		nil,
+	}
+
+	for i, data := range testCases {
+		data := data
+		t.Run(fmt.Sprintf("case_%d", i), func(t *testing.T) {
+			t.Parallel()
+			n, err := writer.Write(data)
+			assert.NoError(t, err)
+			assert.Equal(t, len(data), n, "Write should return the length of input data")
+		})
+	}
+}
+
+func TestNoopWriteCloser_Close(t *testing.T) {
+	t.Parallel()
+	writer := &noopWriteCloser{}
+
+	// Test multiple closes
+	for i := 0; i < 3; i++ {
+		i := i
+		t.Run(fmt.Sprintf("close_%d", i), func(t *testing.T) {
+			t.Parallel()
+			err := writer.Close()
+			assert.NoError(t, err, "Close should always succeed")
+		})
+	}
+}
+
+func TestNoopWriteCloser_WriteAndClose(t *testing.T) {
+	t.Parallel()
+	writer := &noopWriteCloser{}
+
+	// Write some data
+	data := []byte("test data")
+	n, err := writer.Write(data)
+	require.NoError(t, err)
+	assert.Equal(t, len(data), n)
+
+	// Close the writer
+	err = writer.Close()
+	assert.NoError(t, err)
+
+	// Write after close should still work (it's a no-op)
+	n, err = writer.Write([]byte("more data"))
+	assert.NoError(t, err)
+	assert.Equal(t, 9, n) // len("more data")
+}
+
+// TestKubernetesStore_InterfaceCompliance verifies that KubernetesStore implements the Store interface
+func TestKubernetesStore_InterfaceCompliance(t *testing.T) {
+	t.Parallel()
+	var _ Store = &KubernetesStore{}
+	var _ = NewKubernetesStore()
+}
+
+// TestNoopWriteCloser_InterfaceCompliance verifies that noopWriteCloser implements io.WriteCloser
+func TestNoopWriteCloser_InterfaceCompliance(t *testing.T) {
+	t.Parallel()
+	var _ io.WriteCloser = &noopWriteCloser{}
+	var _ io.Writer = &noopWriteCloser{}
+	var _ io.Closer = &noopWriteCloser{}
+}


### PR DESCRIPTION
It will avoid any errors when trying to create state files in a read-only filesystem in k8s

Related-to: #1638