### PR TITLE
create configmap when spinning an mcp server via operator

### DIFF
--- a/cmd/thv-operator/controllers/mcpserver_runconfig.go
+++ b/cmd/thv-operator/controllers/mcpserver_runconfig.go
@@ -1,0 +1,474 @@
+package controllers
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	mcpv1alpha1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1alpha1"
+	"github.com/stacklok/toolhive/pkg/logger"
+	"github.com/stacklok/toolhive/pkg/runner"
+	transporttypes "github.com/stacklok/toolhive/pkg/transport/types"
+)
+
+// defaultProxyHost is the default host for proxy binding
+const defaultProxyHost = "0.0.0.0"
+
+// RunConfig management methods
+
+// computeConfigMapChecksum computes a SHA256 checksum of the ConfigMap content for change detection
+func computeConfigMapChecksum(cm *corev1.ConfigMap) string {
+	h := sha256.New()
+
+	// Include data content in checksum
+	var dataKeys []string
+	for key := range cm.Data {
+		dataKeys = append(dataKeys, key)
+	}
+	sort.Strings(dataKeys)
+
+	for _, key := range dataKeys {
+		h.Write([]byte(key))
+		h.Write([]byte(cm.Data[key]))
+	}
+
+	// Include labels in checksum (excluding checksum annotation itself)
+	var labelKeys []string
+	for key := range cm.Labels {
+		labelKeys = append(labelKeys, key)
+	}
+	sort.Strings(labelKeys)
+
+	for _, key := range labelKeys {
+		h.Write([]byte(key))
+		h.Write([]byte(cm.Labels[key]))
+	}
+
+	// Include relevant annotations in checksum (excluding checksum annotation itself)
+	var annotationKeys []string
+	for key := range cm.Annotations {
+		if key != "toolhive.stacklok.dev/content-checksum" {
+			annotationKeys = append(annotationKeys, key)
+		}
+	}
+	sort.Strings(annotationKeys)
+
+	for _, key := range annotationKeys {
+		h.Write([]byte(key))
+		h.Write([]byte(cm.Annotations[key]))
+	}
+
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// ensureRunConfigConfigMap ensures the RunConfig ConfigMap exists and is up to date
+func (r *MCPServerReconciler) ensureRunConfigConfigMap(ctx context.Context, m *mcpv1alpha1.MCPServer) error {
+	runConfig, err := r.createRunConfigFromMCPServer(m)
+	if err != nil {
+		return fmt.Errorf("failed to create RunConfig from MCPServer: %w", err)
+	}
+
+	// Validate the RunConfig before creating the ConfigMap
+	if err := r.validateRunConfig(runConfig); err != nil {
+		return fmt.Errorf("invalid RunConfig: %w", err)
+	}
+
+	runConfigJSON, err := json.MarshalIndent(runConfig, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal run config: %w", err)
+	}
+
+	configMapName := fmt.Sprintf("%s-runconfig", m.Name)
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      configMapName,
+			Namespace: m.Namespace,
+			Labels:    labelsForRunConfig(m.Name),
+		},
+		Data: map[string]string{
+			"runconfig.json": string(runConfigJSON),
+		},
+	}
+
+	// Compute and add content checksum annotation
+	checksum := computeConfigMapChecksum(configMap)
+	configMap.Annotations = map[string]string{
+		"toolhive.stacklok.dev/content-checksum": checksum,
+	}
+
+	return r.ensureRunConfigConfigMapResource(ctx, m, configMap)
+}
+
+// ensureRunConfigConfigMapResource ensures the RunConfig ConfigMap exists and is up to date
+// This method handles content changes by comparing checksums
+func (r *MCPServerReconciler) ensureRunConfigConfigMapResource(
+	ctx context.Context,
+	mcpServer *mcpv1alpha1.MCPServer,
+	desired *corev1.ConfigMap,
+) error {
+	current := &corev1.ConfigMap{}
+	objectKey := types.NamespacedName{Name: desired.Name, Namespace: desired.Namespace}
+	err := r.Get(ctx, objectKey, current)
+
+	if errors.IsNotFound(err) {
+		// ConfigMap doesn't exist, create it
+		if err := controllerutil.SetControllerReference(mcpServer, desired, r.Scheme); err != nil {
+			return fmt.Errorf("failed to set controller reference for RunConfig ConfigMap: %w", err)
+		}
+
+		ctxLogger.Info("RunConfig ConfigMap does not exist, creating", "ConfigMap.Name", desired.Name)
+		if err := r.Create(ctx, desired); err != nil {
+			return fmt.Errorf("failed to create RunConfig ConfigMap: %w", err)
+		}
+		ctxLogger.Info("RunConfig ConfigMap created", "ConfigMap.Name", desired.Name)
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("failed to get RunConfig ConfigMap: %w", err)
+	}
+
+	// ConfigMap exists, check if content has changed by comparing checksums
+	currentChecksum := current.Annotations["toolhive.stacklok.dev/content-checksum"]
+	desiredChecksum := desired.Annotations["toolhive.stacklok.dev/content-checksum"]
+
+	if currentChecksum != desiredChecksum {
+		// Content changed, update the ConfigMap with new checksum
+		// Copy resource version and other metadata for update
+		desired.ResourceVersion = current.ResourceVersion
+		desired.UID = current.UID
+
+		if err := controllerutil.SetControllerReference(mcpServer, desired, r.Scheme); err != nil {
+			return fmt.Errorf("failed to set controller reference for RunConfig ConfigMap: %w", err)
+		}
+
+		ctxLogger.Info("RunConfig ConfigMap content changed, updating",
+			"ConfigMap.Name", desired.Name,
+			"oldChecksum", currentChecksum,
+			"newChecksum", desiredChecksum)
+		if err := r.Update(ctx, desired); err != nil {
+			return fmt.Errorf("failed to update RunConfig ConfigMap: %w", err)
+		}
+		ctxLogger.Info("RunConfig ConfigMap updated", "ConfigMap.Name", desired.Name)
+	}
+
+	return nil
+}
+
+// runConfigContentEquals compares the actual content of RunConfig ConfigMaps using checksums
+func (*MCPServerReconciler) runConfigContentEquals(current, desired *corev1.ConfigMap) bool {
+	// Compare checksums - if both have checksums, use them for comparison
+	currentChecksum := current.Annotations["toolhive.stacklok.dev/content-checksum"]
+	desiredChecksum := desired.Annotations["toolhive.stacklok.dev/content-checksum"]
+
+	if currentChecksum != "" && desiredChecksum != "" {
+		return currentChecksum == desiredChecksum
+	}
+
+	// Fallback to compute checksums if they don't exist (for backward compatibility)
+	if currentChecksum == "" {
+		currentChecksum = computeConfigMapChecksum(current)
+	}
+	if desiredChecksum == "" {
+		desiredChecksum = computeConfigMapChecksum(desired)
+	}
+
+	return currentChecksum == desiredChecksum
+}
+
+// createRunConfigFromMCPServer converts MCPServer spec to RunConfig using the builder pattern
+// This creates a RunConfig for serialization to ConfigMap, not for direct execution
+func (*MCPServerReconciler) createRunConfigFromMCPServer(m *mcpv1alpha1.MCPServer) (*runner.RunConfig, error) {
+	proxyHost := defaultProxyHost
+	if envHost := os.Getenv("TOOLHIVE_PROXY_HOST"); envHost != "" {
+		proxyHost = envHost
+	}
+
+	port := 8080
+	if m.Spec.Port != 0 {
+		port = int(m.Spec.Port)
+	}
+
+	// Helper functions to convert MCPServer spec to builder format
+	envVars := convertEnvVarsFromMCPServer(m.Spec.Env)
+	volumes := convertVolumesFromMCPServer(m.Spec.Volumes)
+	secrets := convertSecretsFromMCPServer(m.Spec.Secrets)
+
+	// Create K8s pod template patch if needed
+	var k8sPodPatch string
+	if podSpec := NewMCPServerPodTemplateSpecBuilder(m.Spec.PodTemplateSpec).
+		WithServiceAccount(m.Spec.ServiceAccount).
+		WithSecrets(m.Spec.Secrets).
+		Build(); podSpec != nil {
+		if patch, err := json.Marshal(podSpec); err == nil {
+			k8sPodPatch = string(patch)
+		} else {
+			logger.Errorf("Failed to marshal pod template spec: %v", err)
+		}
+	}
+
+	// Use the RunConfigBuilder for operator context with full builder pattern
+	config, err := runner.NewOperatorRunConfigBuilder().
+		WithName(m.Name).
+		WithImage(m.Spec.Image).
+		WithCmdArgs(m.Spec.Args).
+		WithTransportAndPorts(m.Spec.Transport, port, int(m.Spec.TargetPort)).
+		WithHost(proxyHost).
+		WithToolsFilter(m.Spec.ToolsFilter).
+		WithEnvVars(envVars).
+		WithVolumes(volumes).
+		WithSecrets(secrets).
+		WithK8sPodPatch(k8sPodPatch).
+		BuildForOperator()
+
+	if err != nil {
+		return nil, err
+	}
+
+	return config, nil
+}
+
+// labelsForRunConfig returns labels for run config ConfigMap
+func labelsForRunConfig(mcpServerName string) map[string]string {
+	return map[string]string{
+		"toolhive.stacklok.io/component":  "run-config",
+		"toolhive.stacklok.io/mcp-server": mcpServerName,
+		"toolhive.stacklok.io/managed-by": "toolhive-operator",
+	}
+}
+
+// validateRunConfig validates a RunConfig for operator-managed deployments
+func (r *MCPServerReconciler) validateRunConfig(config *runner.RunConfig) error {
+	if config == nil {
+		return fmt.Errorf("RunConfig cannot be nil")
+	}
+
+	if err := r.validateRequiredFields(config); err != nil {
+		return err
+	}
+
+	if err := r.validateTransportAndPorts(config); err != nil {
+		return err
+	}
+
+	if err := r.validateHost(config); err != nil {
+		return err
+	}
+
+	if err := r.validateEnvironmentVariables(config); err != nil {
+		return err
+	}
+
+	if err := r.validateVolumeMounts(config); err != nil {
+		return err
+	}
+
+	if err := r.validateSecrets(config); err != nil {
+		return err
+	}
+
+	if err := r.validateToolsFilter(config); err != nil {
+		return err
+	}
+
+	logger.Debugf("RunConfig validation passed for %s", config.Name)
+	return nil
+}
+
+// validateRequiredFields validates required fields in the RunConfig
+func (*MCPServerReconciler) validateRequiredFields(config *runner.RunConfig) error {
+	if config.Image == "" {
+		return fmt.Errorf("image is required")
+	}
+
+	if config.Name == "" {
+		return fmt.Errorf("name is required")
+	}
+
+	if config.Transport == "" {
+		return fmt.Errorf("transport is required")
+	}
+
+	return nil
+}
+
+// validateTransportAndPorts validates transport type and associated port configuration
+func (*MCPServerReconciler) validateTransportAndPorts(config *runner.RunConfig) error {
+	validTransports := []transporttypes.TransportType{
+		transporttypes.TransportTypeStdio,
+		transporttypes.TransportTypeSSE,
+		transporttypes.TransportTypeStreamableHTTP,
+	}
+
+	validTransport := false
+	for _, valid := range validTransports {
+		if config.Transport == valid {
+			validTransport = true
+			break
+		}
+	}
+	if !validTransport {
+		return fmt.Errorf("invalid transport type: %s, must be one of: stdio, sse, streamable-http", config.Transport)
+	}
+
+	// Validate ports for HTTP-based transports
+	if config.Transport == transporttypes.TransportTypeSSE || config.Transport == transporttypes.TransportTypeStreamableHTTP {
+		if config.Port <= 0 {
+			return fmt.Errorf("port is required for transport type %s", config.Transport)
+		}
+		if config.TargetPort <= 0 {
+			return fmt.Errorf("target port is required for transport type %s", config.Transport)
+		}
+		if config.Port < 1 || config.Port > 65535 {
+			return fmt.Errorf("port must be between 1 and 65535, got: %d", config.Port)
+		}
+		if config.TargetPort < 1 || config.TargetPort > 65535 {
+			return fmt.Errorf("target port must be between 1 and 65535, got: %d", config.TargetPort)
+		}
+	}
+
+	return nil
+}
+
+// validateHost validates the host configuration
+func (*MCPServerReconciler) validateHost(config *runner.RunConfig) error {
+	if config.Host == "" {
+		return nil
+	}
+
+	// Basic validation - could be enhanced with more sophisticated checks
+	if config.Host != defaultProxyHost && config.Host != "127.0.0.1" && config.Host != "localhost" {
+		// For custom hosts, basic format check
+		if len(config.Host) == 0 || strings.Contains(config.Host, " ") {
+			return fmt.Errorf("invalid host format: %s", config.Host)
+		}
+	}
+
+	return nil
+}
+
+// validateEnvironmentVariables validates environment variable format
+func (*MCPServerReconciler) validateEnvironmentVariables(config *runner.RunConfig) error {
+	for key, value := range config.EnvVars {
+		if key == "" {
+			return fmt.Errorf("environment variable key cannot be empty")
+		}
+		// Check for invalid characters in key (basic validation)
+		if strings.ContainsAny(key, "=\n\r") {
+			return fmt.Errorf("invalid environment variable key: %s", key)
+		}
+		// Check for control characters in value
+		if strings.ContainsAny(value, "\n\r") {
+			return fmt.Errorf("environment variable value for %s contains invalid characters", key)
+		}
+	}
+
+	return nil
+}
+
+// validateVolumeMounts validates volume mount format
+func (*MCPServerReconciler) validateVolumeMounts(config *runner.RunConfig) error {
+	for _, volume := range config.Volumes {
+		if volume == "" {
+			return fmt.Errorf("volume mount cannot be empty")
+		}
+		parts := strings.Split(volume, ":")
+		if len(parts) < 2 || len(parts) > 3 {
+			return fmt.Errorf("invalid volume mount format: %s, expected host-path:container-path[:ro]", volume)
+		}
+		if parts[0] == "" || parts[1] == "" {
+			return fmt.Errorf("volume mount paths cannot be empty in: %s", volume)
+		}
+		if len(parts) == 3 && parts[2] != "ro" {
+			return fmt.Errorf("invalid volume mount option: %s, only 'ro' is supported", parts[2])
+		}
+	}
+
+	return nil
+}
+
+// validateSecrets validates secret format
+func (*MCPServerReconciler) validateSecrets(config *runner.RunConfig) error {
+	for _, secret := range config.Secrets {
+		if secret == "" {
+			return fmt.Errorf("secret cannot be empty")
+		}
+		// Basic format validation: should contain secret name and target
+		if !strings.Contains(secret, ",target=") {
+			return fmt.Errorf("invalid secret format: %s, expected secret-name,target=env-var-name", secret)
+		}
+		parts := strings.Split(secret, ",target=")
+		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+			return fmt.Errorf("invalid secret format: %s, expected secret-name,target=env-var-name", secret)
+		}
+	}
+
+	return nil
+}
+
+// validateToolsFilter validates tools filter format
+func (*MCPServerReconciler) validateToolsFilter(config *runner.RunConfig) error {
+	for _, tool := range config.ToolsFilter {
+		if tool == "" {
+			return fmt.Errorf("tool filter cannot contain empty values")
+		}
+		if strings.ContainsAny(tool, ",\n\r") {
+			return fmt.Errorf("invalid tool name: %s, cannot contain commas or newlines", tool)
+		}
+	}
+
+	return nil
+}
+
+// convertEnvVarsFromMCPServer converts MCPServer environment variables to builder format
+func convertEnvVarsFromMCPServer(envs []mcpv1alpha1.EnvVar) map[string]string {
+	if len(envs) == 0 {
+		return nil
+	}
+	envVars := make(map[string]string, len(envs))
+	for _, env := range envs {
+		envVars[env.Name] = env.Value
+	}
+	return envVars
+}
+
+// convertVolumesFromMCPServer converts MCPServer volumes to builder format
+func convertVolumesFromMCPServer(vols []mcpv1alpha1.Volume) []string {
+	if len(vols) == 0 {
+		return nil
+	}
+	volumes := make([]string, 0, len(vols))
+	for _, vol := range vols {
+		volStr := fmt.Sprintf("%s:%s", vol.HostPath, vol.MountPath)
+		if vol.ReadOnly {
+			volStr += ":ro"
+		}
+		volumes = append(volumes, volStr)
+	}
+	return volumes
+}
+
+// convertSecretsFromMCPServer converts MCPServer secrets to builder format
+func convertSecretsFromMCPServer(secs []mcpv1alpha1.SecretRef) []string {
+	if len(secs) == 0 {
+		return nil
+	}
+	secrets := make([]string, 0, len(secs))
+	for _, secret := range secs {
+		target := secret.TargetEnvName
+		if target == "" {
+			target = secret.Key
+		}
+		secrets = append(secrets, fmt.Sprintf("%s,target=%s", secret.Name, target))
+	}
+	return secrets
+}

--- a/cmd/thv-operator/controllers/mcpserver_runconfig_test.go
+++ b/cmd/thv-operator/controllers/mcpserver_runconfig_test.go
@@ -1,0 +1,1091 @@
+package controllers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	mcpv1alpha1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1alpha1"
+	"github.com/stacklok/toolhive/pkg/runner"
+	transporttypes "github.com/stacklok/toolhive/pkg/transport/types"
+)
+
+func createRunConfigTestScheme() *runtime.Scheme {
+	testScheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(testScheme)
+	_ = mcpv1alpha1.AddToScheme(testScheme)
+	return testScheme
+}
+
+func createTestMCPServerWithConfig(name, namespace, image string, envVars []mcpv1alpha1.EnvVar) *mcpv1alpha1.MCPServer {
+	return &mcpv1alpha1.MCPServer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: mcpv1alpha1.MCPServerSpec{
+			Image:     image,
+			Transport: "stdio",
+			Port:      8080,
+			Env:       envVars,
+		},
+	}
+}
+
+// TestCreateRunConfigFromMCPServer tests the conversion from MCPServer to RunConfig
+func TestCreateRunConfigFromMCPServer(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		mcpServer *mcpv1alpha1.MCPServer
+		expected  func(config *runner.RunConfig) bool
+	}{
+		{
+			name: "basic conversion",
+			mcpServer: &mcpv1alpha1.MCPServer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-server",
+					Namespace: "test-ns",
+				},
+				Spec: mcpv1alpha1.MCPServerSpec{
+					Image:     "test-image:latest",
+					Transport: "stdio",
+					Port:      8080,
+				},
+			},
+			expected: func(config *runner.RunConfig) bool {
+				return config.Name == "test-server" &&
+					config.Image == "test-image:latest" &&
+					config.Transport == "stdio" &&
+					config.Port == 8080
+			},
+		},
+		{
+			name: "with environment variables",
+			mcpServer: &mcpv1alpha1.MCPServer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "env-server",
+					Namespace: "test-ns",
+				},
+				Spec: mcpv1alpha1.MCPServerSpec{
+					Image:     "env-image:latest",
+					Transport: "sse",
+					Port:      9090,
+					Env: []mcpv1alpha1.EnvVar{
+						{Name: "VAR1", Value: "value1"},
+						{Name: "VAR2", Value: "value2"},
+					},
+				},
+			},
+			expected: func(config *runner.RunConfig) bool {
+				return config.Name == "env-server" &&
+					len(config.EnvVars) == 2 &&
+					config.EnvVars["VAR1"] == "value1" &&
+					config.EnvVars["VAR2"] == "value2"
+			},
+		},
+		{
+			name: "with volumes",
+			mcpServer: &mcpv1alpha1.MCPServer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "vol-server",
+					Namespace: "test-ns",
+				},
+				Spec: mcpv1alpha1.MCPServerSpec{
+					Image:     "vol-image:latest",
+					Transport: "stdio",
+					Port:      8080,
+					Volumes: []mcpv1alpha1.Volume{
+						{Name: "vol1", HostPath: "/host/path1", MountPath: "/mount/path1", ReadOnly: false},
+						{Name: "vol2", HostPath: "/host/path2", MountPath: "/mount/path2", ReadOnly: true},
+					},
+				},
+			},
+			expected: func(config *runner.RunConfig) bool {
+				return config.Name == "vol-server" &&
+					len(config.Volumes) == 2 &&
+					config.Volumes[0] == "/host/path1:/mount/path1" &&
+					config.Volumes[1] == "/host/path2:/mount/path2:ro"
+			},
+		},
+		{
+			name: "with secrets",
+			mcpServer: &mcpv1alpha1.MCPServer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "secret-server",
+					Namespace: "test-ns",
+				},
+				Spec: mcpv1alpha1.MCPServerSpec{
+					Image:     "secret-image:latest",
+					Transport: "stdio",
+					Port:      8080,
+					Secrets: []mcpv1alpha1.SecretRef{
+						{Name: "secret1", Key: "key1", TargetEnvName: "TARGET1"},
+						{Name: "secret2", Key: "key2"}, // No target, should use key as target
+					},
+				},
+			},
+			expected: func(config *runner.RunConfig) bool {
+				return config.Name == "secret-server" &&
+					len(config.Secrets) == 2 &&
+					config.Secrets[0] == "secret1,target=TARGET1" &&
+					config.Secrets[1] == "secret2,target=key2"
+			},
+		},
+		{
+			name: "comprehensive test with all fields",
+			mcpServer: &mcpv1alpha1.MCPServer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "comprehensive-server",
+					Namespace: "test-ns",
+				},
+				Spec: mcpv1alpha1.MCPServerSpec{
+					Image:       "comprehensive:latest",
+					Transport:   "streamable-http",
+					Port:        9090,
+					TargetPort:  8080,
+					Args:        []string{"--comprehensive", "--test"},
+					ToolsFilter: []string{"tool1", "tool2"},
+					Env: []mcpv1alpha1.EnvVar{
+						{Name: "ENV1", Value: "value1"},
+						{Name: "ENV2", Value: "value2"},
+						{Name: "EMPTY_VALUE", Value: ""},
+					},
+					Volumes: []mcpv1alpha1.Volume{
+						{Name: "vol1", HostPath: "/host/path1", MountPath: "/mount/path1", ReadOnly: false},
+						{Name: "vol2", HostPath: "/host/path2", MountPath: "/mount/path2", ReadOnly: true},
+					},
+					Secrets: []mcpv1alpha1.SecretRef{
+						{Name: "secret1", Key: "key1", TargetEnvName: "CUSTOM_TARGET"},
+						{Name: "secret2", Key: "key2"}, // Uses key as target
+					},
+				},
+			},
+			expected: func(config *runner.RunConfig) bool {
+				return config.Name == "comprehensive-server" &&
+					config.Image == "comprehensive:latest" &&
+					config.Transport == "streamable-http" &&
+					config.Port == 9090 &&
+					config.TargetPort == 8080 &&
+					len(config.CmdArgs) == 2 &&
+					config.CmdArgs[0] == "--comprehensive" &&
+					len(config.ToolsFilter) == 2 &&
+					len(config.EnvVars) == 3 &&
+					config.EnvVars["ENV1"] == "value1" &&
+					config.EnvVars["EMPTY_VALUE"] == "" &&
+					len(config.Volumes) == 2 &&
+					config.Volumes[0] == "/host/path1:/mount/path1" &&
+					config.Volumes[1] == "/host/path2:/mount/path2:ro" &&
+					len(config.Secrets) == 2 &&
+					config.Secrets[0] == "secret1,target=CUSTOM_TARGET" &&
+					config.Secrets[1] == "secret2,target=key2"
+			},
+		},
+		{
+			name: "edge case: empty/nil slices",
+			mcpServer: &mcpv1alpha1.MCPServer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "edge-server",
+					Namespace: "test-ns",
+				},
+				Spec: mcpv1alpha1.MCPServerSpec{
+					Image:       "edge:latest",
+					Transport:   "stdio",
+					Port:        8080,
+					Args:        []string{},             // Empty slice
+					ToolsFilter: nil,                    // Nil slice
+					Env:         nil,                    // Nil slice
+					Volumes:     []mcpv1alpha1.Volume{}, // Empty slice
+					Secrets:     nil,                    // Nil slice
+				},
+			},
+			expected: func(config *runner.RunConfig) bool {
+				return config.Name == "edge-server" &&
+					config.Image == "edge:latest" &&
+					len(config.CmdArgs) == 0 &&
+					len(config.ToolsFilter) == 0 &&
+					len(config.EnvVars) == 0 &&
+					len(config.Volumes) == 0 &&
+					len(config.Secrets) == 0
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			r := &MCPServerReconciler{}
+			result, err := r.createRunConfigFromMCPServer(tt.mcpServer)
+			require.NoError(t, err)
+			assert.NotNil(t, result)
+			assert.Equal(t, runner.CurrentSchemaVersion, result.SchemaVersion)
+			assert.True(t, tt.expected(result))
+		})
+	}
+}
+
+// TestDeterministicConfigMapGeneration tests that the same MCPServer always generates identical ConfigMaps
+func TestDeterministicConfigMapGeneration(t *testing.T) {
+	t.Parallel()
+
+	// Create a complex MCPServer with all possible fields to ensure comprehensive testing
+	mcpServer := &mcpv1alpha1.MCPServer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "deterministic-server",
+			Namespace: "test-namespace",
+		},
+		Spec: mcpv1alpha1.MCPServerSpec{
+			Image:       "deterministic-test:v1.2.3",
+			Transport:   "sse",
+			Port:        9090,
+			TargetPort:  8080,
+			Args:        []string{"--arg1", "--arg2", "--complex-flag=value"},
+			ToolsFilter: []string{"tool3", "tool1", "tool2"}, // Different order to test sorting
+			Env: []mcpv1alpha1.EnvVar{
+				{Name: "VAR_C", Value: "value_c"},
+				{Name: "VAR_A", Value: "value_a"},
+				{Name: "VAR_B", Value: "value_b"},
+				{Name: "EMPTY_VAR", Value: ""},
+			},
+			Volumes: []mcpv1alpha1.Volume{
+				{Name: "vol2", HostPath: "/host/path2", MountPath: "/container/path2", ReadOnly: true},
+				{Name: "vol1", HostPath: "/host/path1", MountPath: "/container/path1", ReadOnly: false},
+			},
+			Secrets: []mcpv1alpha1.SecretRef{
+				{Name: "secret2", Key: "key2", TargetEnvName: "CUSTOM_TARGET2"},
+				{Name: "secret1", Key: "key1"}, // Uses key as target
+			},
+		},
+	}
+
+	reconciler := &MCPServerReconciler{}
+
+	// Generate RunConfig and ConfigMap 10 times
+	var configMaps []*corev1.ConfigMap
+	var runConfigs []*runner.RunConfig
+	var checksums []string
+
+	for i := 0; i < 10; i++ {
+		// Generate RunConfig from MCPServer
+		runConfig, err := reconciler.createRunConfigFromMCPServer(mcpServer)
+		require.NoError(t, err, "Run %d: Failed to create RunConfig", i+1)
+		require.NotNil(t, runConfig, "Run %d: RunConfig should not be nil", i+1)
+
+		// Serialize RunConfig to JSON
+		runConfigJSON, err := json.MarshalIndent(runConfig, "", "  ")
+		require.NoError(t, err, "Run %d: Failed to marshal RunConfig", i+1)
+
+		// Create ConfigMap as the operator would
+		configMapName := fmt.Sprintf("%s-runconfig", mcpServer.Name)
+		configMap := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      configMapName,
+				Namespace: mcpServer.Namespace,
+				Labels:    labelsForRunConfig(mcpServer.Name),
+			},
+			Data: map[string]string{
+				"runconfig.json": string(runConfigJSON),
+			},
+		}
+
+		// Compute and add checksum
+		checksum := computeConfigMapChecksum(configMap)
+		configMap.Annotations = map[string]string{
+			"toolhive.stacklok.dev/content-checksum": checksum,
+		}
+
+		// Store results
+		runConfigs = append(runConfigs, runConfig)
+		configMaps = append(configMaps, configMap)
+		checksums = append(checksums, checksum)
+	}
+
+	// Verify all RunConfigs are identical
+	baseRunConfig := runConfigs[0]
+	for i := 1; i < len(runConfigs); i++ {
+		assert.True(t, reflect.DeepEqual(baseRunConfig, runConfigs[i]),
+			"RunConfig %d differs from base RunConfig", i+1)
+	}
+
+	// Verify all ConfigMaps have identical content
+	baseConfigMap := configMaps[0]
+	baseJSON := baseConfigMap.Data["runconfig.json"]
+
+	for i := 1; i < len(configMaps); i++ {
+		currentJSON := configMaps[i].Data["runconfig.json"]
+		assert.Equal(t, baseJSON, currentJSON,
+			"ConfigMap %d JSON content differs from base", i+1)
+
+		assert.Equal(t, baseConfigMap.Name, configMaps[i].Name,
+			"ConfigMap %d name differs from base", i+1)
+		assert.Equal(t, baseConfigMap.Namespace, configMaps[i].Namespace,
+			"ConfigMap %d namespace differs from base", i+1)
+		assert.True(t, reflect.DeepEqual(baseConfigMap.Labels, configMaps[i].Labels),
+			"ConfigMap %d labels differ from base", i+1)
+	}
+
+	// Verify all checksums are identical
+	baseChecksum := checksums[0]
+	for i := 1; i < len(checksums); i++ {
+		assert.Equal(t, baseChecksum, checksums[i],
+			"Checksum %d differs from base checksum", i+1)
+	}
+
+	// Additional verification: manually check the RunConfig content makes sense
+	assert.Equal(t, "deterministic-server", baseRunConfig.Name)
+	assert.Equal(t, "deterministic-test:v1.2.3", baseRunConfig.Image)
+	assert.Equal(t, transporttypes.TransportTypeSSE, baseRunConfig.Transport)
+	assert.Equal(t, 9090, baseRunConfig.Port)
+	assert.Equal(t, 8080, baseRunConfig.TargetPort)
+	assert.Equal(t, []string{"--arg1", "--arg2", "--complex-flag=value"}, baseRunConfig.CmdArgs)
+	assert.Equal(t, []string{"tool3", "tool1", "tool2"}, baseRunConfig.ToolsFilter)
+
+	// Verify environment variables
+	assert.Len(t, baseRunConfig.EnvVars, 4)
+	assert.Equal(t, "value_a", baseRunConfig.EnvVars["VAR_A"])
+	assert.Equal(t, "value_b", baseRunConfig.EnvVars["VAR_B"])
+	assert.Equal(t, "value_c", baseRunConfig.EnvVars["VAR_C"])
+	assert.Equal(t, "", baseRunConfig.EnvVars["EMPTY_VAR"])
+
+	// Verify volumes (should maintain order from MCPServer)
+	assert.Len(t, baseRunConfig.Volumes, 2)
+	assert.Equal(t, "/host/path2:/container/path2:ro", baseRunConfig.Volumes[0])
+	assert.Equal(t, "/host/path1:/container/path1", baseRunConfig.Volumes[1])
+
+	// Verify secrets (should maintain order from MCPServer)
+	assert.Len(t, baseRunConfig.Secrets, 2)
+	assert.Equal(t, "secret2,target=CUSTOM_TARGET2", baseRunConfig.Secrets[0])
+	assert.Equal(t, "secret1,target=key1", baseRunConfig.Secrets[1])
+
+	t.Logf("✅ Deterministic test passed: Generated identical ConfigMaps 10 times")
+	t.Logf("   Checksum: %s", baseChecksum)
+	t.Logf("   ConfigMap size: %d bytes", len(baseJSON))
+}
+
+// TestEnsureRunConfigConfigMap tests the ConfigMap creation and update logic
+func TestEnsureRunConfigConfigMap(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name            string
+		mcpServer       *mcpv1alpha1.MCPServer
+		existingCM      *corev1.ConfigMap
+		expectUpdate    bool
+		expectError     bool
+		validateContent func(*testing.T, *corev1.ConfigMap)
+	}{
+		{
+			name:        "create new configmap",
+			mcpServer:   createTestMCPServerWithConfig("new-server", "default", "test:v1", nil),
+			existingCM:  nil,
+			expectError: false,
+			validateContent: func(t *testing.T, cm *corev1.ConfigMap) {
+				t.Helper()
+				assert.Equal(t, "new-server-runconfig", cm.Name)
+				assert.Equal(t, "default", cm.Namespace)
+				assert.Contains(t, cm.Data, "runconfig.json")
+				assert.Contains(t, cm.Annotations, "toolhive.stacklok.dev/content-checksum")
+
+				var runConfig runner.RunConfig
+				err := json.Unmarshal([]byte(cm.Data["runconfig.json"]), &runConfig)
+				require.NoError(t, err)
+				assert.Equal(t, "new-server", runConfig.Name)
+				assert.Equal(t, "test:v1", runConfig.Image)
+			},
+		},
+		{
+			name:      "update existing configmap with changed content",
+			mcpServer: createTestMCPServerWithConfig("update-server", "default", "test:v2", nil),
+			existingCM: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "update-server-runconfig",
+					Namespace: "default",
+					Labels:    labelsForRunConfig("update-server"),
+					Annotations: map[string]string{
+						"toolhive.stacklok.dev/content-checksum": "oldchecksum123",
+					},
+				},
+				Data: map[string]string{
+					"runconfig.json": `{"schemaVersion":"v1","name":"update-server","image":"test:v1","transport":"stdio","port":8080}`,
+				},
+			},
+			expectUpdate: true,
+			expectError:  false,
+			validateContent: func(t *testing.T, cm *corev1.ConfigMap) {
+				t.Helper()
+				var runConfig runner.RunConfig
+				err := json.Unmarshal([]byte(cm.Data["runconfig.json"]), &runConfig)
+				require.NoError(t, err)
+				assert.Equal(t, "test:v2", runConfig.Image)
+				assert.NotEqual(t, "oldchecksum123", cm.Annotations["toolhive.stacklok.dev/content-checksum"])
+				assert.NotEmpty(t, cm.Annotations["toolhive.stacklok.dev/content-checksum"])
+			},
+		},
+		{
+			name:      "no update when content unchanged",
+			mcpServer: createTestMCPServerWithConfig("same-server", "default", "test:v1", nil),
+			existingCM: func() *corev1.ConfigMap {
+				// Create a ConfigMap with the same content that would be generated
+				r := &MCPServerReconciler{}
+				mcpServer := createTestMCPServerWithConfig("same-server", "default", "test:v1", nil)
+				runConfig, err := r.createRunConfigFromMCPServer(mcpServer)
+				if err != nil {
+					panic(fmt.Sprintf("Failed to create RunConfig: %v", err))
+				}
+				runConfigJSON, _ := json.MarshalIndent(runConfig, "", "  ")
+
+				configMap := &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "same-server-runconfig",
+						Namespace: "default",
+						Labels:    labelsForRunConfig("same-server"),
+					},
+					Data: map[string]string{
+						"runconfig.json": string(runConfigJSON),
+					},
+				}
+
+				// Compute the actual checksum for this content
+				checksum := computeConfigMapChecksum(configMap)
+				configMap.Annotations = map[string]string{
+					"toolhive.stacklok.dev/content-checksum": checksum,
+				}
+
+				return configMap
+			}(),
+			expectUpdate: false,
+			expectError:  false,
+			validateContent: func(t *testing.T, cm *corev1.ConfigMap) {
+				t.Helper()
+				// Should have a valid checksum for the content
+				assert.NotEmpty(t, cm.Annotations["toolhive.stacklok.dev/content-checksum"])
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			testScheme := createRunConfigTestScheme()
+			objects := []runtime.Object{}
+			if tt.existingCM != nil {
+				objects = append(objects, tt.existingCM)
+			}
+			fakeClient := fake.NewClientBuilder().WithScheme(testScheme).WithRuntimeObjects(objects...).Build()
+
+			reconciler := &MCPServerReconciler{
+				Client: fakeClient,
+				Scheme: testScheme,
+			}
+
+			// Execute the method under test
+			err := reconciler.ensureRunConfigConfigMap(context.TODO(), tt.mcpServer)
+			if tt.expectError {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			// Verify the ConfigMap exists
+			configMapName := fmt.Sprintf("%s-runconfig", tt.mcpServer.Name)
+			configMap := &corev1.ConfigMap{}
+			err = fakeClient.Get(context.TODO(), types.NamespacedName{
+				Name:      configMapName,
+				Namespace: tt.mcpServer.Namespace,
+			}, configMap)
+			require.NoError(t, err)
+
+			// Verify basic structure
+			assert.Equal(t, configMapName, configMap.Name)
+			assert.Equal(t, tt.mcpServer.Namespace, configMap.Namespace)
+			assert.Equal(t, labelsForRunConfig(tt.mcpServer.Name), configMap.Labels)
+			assert.Contains(t, configMap.Data, "runconfig.json")
+
+			// Verify the RunConfig content is correct
+			var runConfig runner.RunConfig
+			err = json.Unmarshal([]byte(configMap.Data["runconfig.json"]), &runConfig)
+			require.NoError(t, err)
+			assert.Equal(t, tt.mcpServer.Name, runConfig.Name)
+			assert.Equal(t, tt.mcpServer.Spec.Image, runConfig.Image)
+
+			// Verify annotation behavior
+			if tt.validateContent != nil {
+				tt.validateContent(t, configMap)
+			}
+		})
+	}
+}
+
+// TestRunConfigContentEquals tests the content comparison logic
+func TestRunConfigContentEquals(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		current  *corev1.ConfigMap
+		desired  *corev1.ConfigMap
+		expected bool
+	}{
+		{
+			name: "identical content with same checksum",
+			current: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"key": "value"},
+					Annotations: map[string]string{
+						"other":                                  "annotation",
+						"toolhive.stacklok.dev/content-checksum": "samechecksum123",
+					},
+				},
+				Data: map[string]string{"runconfig.json": "content"},
+			},
+			desired: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"key": "value"},
+					Annotations: map[string]string{
+						"other":                                  "annotation",
+						"toolhive.stacklok.dev/content-checksum": "samechecksum123",
+					},
+				},
+				Data: map[string]string{"runconfig.json": "content"},
+			},
+			expected: true,
+		},
+		{
+			name: "different data content",
+			current: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"toolhive.stacklok.dev/content-checksum": "oldchecksum123",
+					},
+				},
+				Data: map[string]string{"runconfig.json": "old-content"},
+			},
+			desired: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"toolhive.stacklok.dev/content-checksum": "newchecksum456",
+					},
+				},
+				Data: map[string]string{"runconfig.json": "new-content"},
+			},
+			expected: false,
+		},
+		{
+			name: "different labels",
+			current: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"key": "old-value"},
+					Annotations: map[string]string{
+						"toolhive.stacklok.dev/content-checksum": "oldchecksum123",
+					},
+				},
+				Data: map[string]string{"runconfig.json": "content"},
+			},
+			desired: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"key": "new-value"},
+					Annotations: map[string]string{
+						"toolhive.stacklok.dev/content-checksum": "newchecksum456",
+					},
+				},
+				Data: map[string]string{"runconfig.json": "content"},
+			},
+			expected: false,
+		},
+		{
+			name: "different non-checksum annotations",
+			current: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"other":                                  "old-annotation",
+						"toolhive.stacklok.dev/content-checksum": "oldchecksum123",
+					},
+				},
+				Data: map[string]string{"runconfig.json": "content"},
+			},
+			desired: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"other":                                  "new-annotation",
+						"toolhive.stacklok.dev/content-checksum": "newchecksum456",
+					},
+				},
+				Data: map[string]string{"runconfig.json": "content"},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			r := &MCPServerReconciler{}
+			result := r.runConfigContentEquals(tt.current, tt.desired)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// TestValidateRunConfig tests the validation logic
+func TestValidateRunConfig(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		config    *runner.RunConfig
+		expectErr bool
+		errMsg    string
+	}{
+		{
+			name: "valid config",
+			config: &runner.RunConfig{
+				Name:      "valid-server",
+				Image:     "test:latest",
+				Transport: "stdio",
+				Port:      8080,
+			},
+			expectErr: false,
+		},
+		{
+			name:      "nil config",
+			config:    nil,
+			expectErr: true,
+			errMsg:    "RunConfig cannot be nil",
+		},
+		{
+			name: "missing image",
+			config: &runner.RunConfig{
+				Name:      "no-image",
+				Transport: "stdio",
+			},
+			expectErr: true,
+			errMsg:    "image is required",
+		},
+		{
+			name: "missing name",
+			config: &runner.RunConfig{
+				Image:     "test:latest",
+				Transport: "stdio",
+			},
+			expectErr: true,
+			errMsg:    "name is required",
+		},
+		{
+			name: "invalid transport",
+			config: &runner.RunConfig{
+				Name:      "invalid-transport",
+				Image:     "test:latest",
+				Transport: "invalid",
+			},
+			expectErr: true,
+			errMsg:    "invalid transport type",
+		},
+		{
+			name: "invalid environment variable key",
+			config: &runner.RunConfig{
+				Name:      "invalid-env",
+				Image:     "test:latest",
+				Transport: "stdio",
+				EnvVars:   map[string]string{"INVALID=KEY": "value"},
+			},
+			expectErr: true,
+			errMsg:    "invalid environment variable key",
+		},
+		{
+			name: "invalid volume format",
+			config: &runner.RunConfig{
+				Name:      "invalid-vol",
+				Image:     "test:latest",
+				Transport: "stdio",
+				Volumes:   []string{"invalid-format"},
+			},
+			expectErr: true,
+			errMsg:    "invalid volume mount format",
+		},
+		{
+			name: "invalid secret format",
+			config: &runner.RunConfig{
+				Name:      "invalid-secret",
+				Image:     "test:latest",
+				Transport: "stdio",
+				Secrets:   []string{"invalid-format"},
+			},
+			expectErr: true,
+			errMsg:    "invalid secret format",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			r := &MCPServerReconciler{}
+			err := r.validateRunConfig(tt.config)
+
+			if tt.expectErr {
+				assert.Error(t, err)
+				if tt.errMsg != "" {
+					assert.Contains(t, err.Error(), tt.errMsg)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestLabelsForRunConfig tests the label generation
+func TestLabelsForRunConfig(t *testing.T) {
+	t.Parallel()
+	expected := map[string]string{
+		"toolhive.stacklok.io/component":  "run-config",
+		"toolhive.stacklok.io/mcp-server": "test-server",
+		"toolhive.stacklok.io/managed-by": "toolhive-operator",
+	}
+
+	result := labelsForRunConfig("test-server")
+	assert.Equal(t, expected, result)
+}
+
+// TestComputeConfigMapChecksum tests the checksum computation
+func TestComputeConfigMapChecksum(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name               string
+		cm1                *corev1.ConfigMap
+		cm2                *corev1.ConfigMap
+		sameShouldChecksum bool
+	}{
+		{
+			name: "identical configmaps have same checksum",
+			cm1: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels:      map[string]string{"key": "value"},
+					Annotations: map[string]string{"other": "annotation"},
+				},
+				Data: map[string]string{"runconfig.json": "content"},
+			},
+			cm2: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels:      map[string]string{"key": "value"},
+					Annotations: map[string]string{"other": "annotation"},
+				},
+				Data: map[string]string{"runconfig.json": "content"},
+			},
+			sameShouldChecksum: true,
+		},
+		{
+			name: "different data content produces different checksum",
+			cm1: &corev1.ConfigMap{
+				Data: map[string]string{"runconfig.json": "content1"},
+			},
+			cm2: &corev1.ConfigMap{
+				Data: map[string]string{"runconfig.json": "content2"},
+			},
+			sameShouldChecksum: false,
+		},
+		{
+			name: "different labels produce different checksum",
+			cm1: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"key": "value1"},
+				},
+				Data: map[string]string{"runconfig.json": "content"},
+			},
+			cm2: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"key": "value2"},
+				},
+				Data: map[string]string{"runconfig.json": "content"},
+			},
+			sameShouldChecksum: false,
+		},
+		{
+			name: "checksum annotation is ignored in computation",
+			cm1: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"other":                                  "annotation",
+						"toolhive.stacklok.dev/content-checksum": "checksum1",
+					},
+				},
+				Data: map[string]string{"runconfig.json": "content"},
+			},
+			cm2: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"other":                                  "annotation",
+						"toolhive.stacklok.dev/content-checksum": "checksum2",
+					},
+				},
+				Data: map[string]string{"runconfig.json": "content"},
+			},
+			sameShouldChecksum: true, // Should be same because checksum annotation is ignored
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			checksum1 := computeConfigMapChecksum(tt.cm1)
+			checksum2 := computeConfigMapChecksum(tt.cm2)
+
+			assert.NotEmpty(t, checksum1)
+			assert.NotEmpty(t, checksum2)
+
+			if tt.sameShouldChecksum {
+				assert.Equal(t, checksum1, checksum2)
+			} else {
+				assert.NotEqual(t, checksum1, checksum2)
+			}
+		})
+	}
+}
+
+// TestEnsureRunConfigConfigMapCompleteFlow tests the complete flow from MCPServer changes to ConfigMap updates
+func TestEnsureRunConfigConfigMapCompleteFlow(t *testing.T) {
+	t.Parallel()
+	testScheme := createRunConfigTestScheme()
+	fakeClient := fake.NewClientBuilder().WithScheme(testScheme).Build()
+	reconciler := &MCPServerReconciler{
+		Client: fakeClient,
+		Scheme: testScheme,
+	}
+
+	// Step 1: Create initial MCPServer and ConfigMap
+	mcpServer := createTestMCPServerWithConfig("flow-server", "flow-ns", "test:v1", []mcpv1alpha1.EnvVar{
+		{Name: "ENV1", Value: "value1"},
+	})
+
+	err := reconciler.ensureRunConfigConfigMap(context.TODO(), mcpServer)
+	require.NoError(t, err)
+
+	// Verify initial ConfigMap
+	configMapName := fmt.Sprintf("%s-runconfig", mcpServer.Name)
+	configMap1 := &corev1.ConfigMap{}
+	err = fakeClient.Get(context.TODO(), types.NamespacedName{
+		Name:      configMapName,
+		Namespace: mcpServer.Namespace,
+	}, configMap1)
+	require.NoError(t, err)
+
+	initialChecksum := configMap1.Annotations["toolhive.stacklok.dev/content-checksum"]
+	assert.NotEmpty(t, initialChecksum)
+
+	// Verify initial content
+	var initialRunConfig runner.RunConfig
+	err = json.Unmarshal([]byte(configMap1.Data["runconfig.json"]), &initialRunConfig)
+	require.NoError(t, err)
+	assert.Equal(t, "test:v1", initialRunConfig.Image)
+	assert.Len(t, initialRunConfig.EnvVars, 1)
+	assert.Equal(t, "value1", initialRunConfig.EnvVars["ENV1"])
+
+	// Step 2: Update MCPServer with new environment variable
+	// The checksum will automatically change when content changes
+
+	mcpServer.Spec.Image = "test:v2"
+	mcpServer.Spec.Env = []mcpv1alpha1.EnvVar{
+		{Name: "ENV1", Value: "value1"},
+		{Name: "ENV2", Value: "value2"},
+	}
+
+	err = reconciler.ensureRunConfigConfigMap(context.TODO(), mcpServer)
+	require.NoError(t, err)
+
+	// Verify ConfigMap was updated
+	configMap2 := &corev1.ConfigMap{}
+	err = fakeClient.Get(context.TODO(), types.NamespacedName{
+		Name:      configMapName,
+		Namespace: mcpServer.Namespace,
+	}, configMap2)
+	require.NoError(t, err)
+
+	updatedChecksum := configMap2.Annotations["toolhive.stacklok.dev/content-checksum"]
+	assert.NotEmpty(t, updatedChecksum)
+	assert.NotEqual(t, initialChecksum, updatedChecksum, "Checksum should be updated when content changes")
+
+	// Verify updated content
+	var updatedRunConfig runner.RunConfig
+	err = json.Unmarshal([]byte(configMap2.Data["runconfig.json"]), &updatedRunConfig)
+	require.NoError(t, err)
+	assert.Equal(t, "test:v2", updatedRunConfig.Image)
+	assert.Len(t, updatedRunConfig.EnvVars, 2)
+	assert.Equal(t, "value1", updatedRunConfig.EnvVars["ENV1"])
+	assert.Equal(t, "value2", updatedRunConfig.EnvVars["ENV2"])
+
+	// Step 3: No-op update (same content)
+	err = reconciler.ensureRunConfigConfigMap(context.TODO(), mcpServer)
+	require.NoError(t, err)
+
+	// Verify ConfigMap timestamp didn't change
+	configMap3 := &corev1.ConfigMap{}
+	err = fakeClient.Get(context.TODO(), types.NamespacedName{
+		Name:      configMapName,
+		Namespace: mcpServer.Namespace,
+	}, configMap3)
+	require.NoError(t, err)
+
+	finalChecksum := configMap3.Annotations["toolhive.stacklok.dev/content-checksum"]
+	assert.Equal(t, updatedChecksum, finalChecksum, "Checksum should not change for no-op update")
+}
+
+func TestMCPServerModificationScenarios(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name            string
+		initialServer   func() *mcpv1alpha1.MCPServer
+		modifyServer    func(*mcpv1alpha1.MCPServer)
+		expectedChanges map[string]interface{}
+	}{
+		{
+			name: "Transport change",
+			initialServer: func() *mcpv1alpha1.MCPServer {
+				return createTestMCPServerWithConfig("transport-test", "default", "test:v1", nil)
+			},
+			modifyServer: func(server *mcpv1alpha1.MCPServer) {
+				server.Spec.Transport = "sse"
+				server.Spec.Port = 9090
+				server.Spec.TargetPort = 8080
+			},
+			expectedChanges: map[string]interface{}{
+				"Transport": transporttypes.TransportTypeSSE,
+				"Port":      9090,
+			},
+		},
+		{
+			name: "Args modification",
+			initialServer: func() *mcpv1alpha1.MCPServer {
+				server := createTestMCPServerWithConfig("args-test", "default", "test:v1", nil)
+				server.Spec.Args = []string{"--initial", "--arg"}
+				return server
+			},
+			modifyServer: func(server *mcpv1alpha1.MCPServer) {
+				server.Spec.Args = []string{"--modified", "--different", "--args"}
+			},
+			expectedChanges: map[string]interface{}{
+				"CmdArgs": []string{"--modified", "--different", "--args"},
+			},
+		},
+		{
+			name: "ToolsFilter change",
+			initialServer: func() *mcpv1alpha1.MCPServer {
+				server := createTestMCPServerWithConfig("tools-test", "default", "test:v1", nil)
+				server.Spec.ToolsFilter = []string{"tool1", "tool2"}
+				return server
+			},
+			modifyServer: func(server *mcpv1alpha1.MCPServer) {
+				server.Spec.ToolsFilter = []string{"tool3", "tool4", "tool5"}
+			},
+			expectedChanges: map[string]interface{}{
+				"ToolsFilter": []string{"tool3", "tool4", "tool5"},
+			},
+		},
+		{
+			name: "Volume changes",
+			initialServer: func() *mcpv1alpha1.MCPServer {
+				server := createTestMCPServerWithConfig("volume-test", "default", "test:v1", nil)
+				server.Spec.Volumes = []mcpv1alpha1.Volume{
+					{HostPath: "/host/path1", MountPath: "/container/path1"},
+				}
+				return server
+			},
+			modifyServer: func(server *mcpv1alpha1.MCPServer) {
+				server.Spec.Volumes = []mcpv1alpha1.Volume{
+					{HostPath: "/host/path1", MountPath: "/container/path1", ReadOnly: true},
+					{HostPath: "/host/path2", MountPath: "/container/path2"},
+				}
+			},
+			expectedChanges: map[string]interface{}{
+				"Volumes": []string{"/host/path1:/container/path1:ro", "/host/path2:/container/path2"},
+			},
+		},
+		{
+			name: "Secret changes",
+			initialServer: func() *mcpv1alpha1.MCPServer {
+				server := createTestMCPServerWithConfig("secret-test", "default", "test:v1", nil)
+				server.Spec.Secrets = []mcpv1alpha1.SecretRef{
+					{Name: "secret1", Key: "key1"},
+				}
+				return server
+			},
+			modifyServer: func(server *mcpv1alpha1.MCPServer) {
+				server.Spec.Secrets = []mcpv1alpha1.SecretRef{
+					{Name: "secret1", Key: "key1", TargetEnvName: "CUSTOM_ENV1"},
+					{Name: "secret2", Key: "key2"},
+				}
+			},
+			expectedChanges: map[string]interface{}{
+				"Secrets": []string{"secret1,target=CUSTOM_ENV1", "secret2,target=key2"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			// Setup - create a new scheme for each test to avoid concurrent access
+			testScheme := createRunConfigTestScheme()
+
+			fakeClient := fake.NewClientBuilder().WithScheme(testScheme).Build()
+			reconciler := &MCPServerReconciler{
+				Client: fakeClient,
+				Scheme: testScheme,
+			}
+
+			// Create initial MCPServer and ConfigMap
+			mcpServer := tt.initialServer()
+			err := reconciler.ensureRunConfigConfigMap(context.TODO(), mcpServer)
+			require.NoError(t, err)
+
+			// Get initial ConfigMap
+			configMapName := fmt.Sprintf("%s-runconfig", mcpServer.Name)
+			initialConfigMap := &corev1.ConfigMap{}
+			err = fakeClient.Get(context.TODO(), types.NamespacedName{
+				Name:      configMapName,
+				Namespace: mcpServer.Namespace,
+			}, initialConfigMap)
+			require.NoError(t, err)
+			initialChecksum := initialConfigMap.Annotations["toolhive.stacklok.dev/content-checksum"]
+
+			// Modify the MCPServer
+			tt.modifyServer(mcpServer)
+
+			// Ensure ConfigMap is updated
+			err = reconciler.ensureRunConfigConfigMap(context.TODO(), mcpServer)
+			require.NoError(t, err)
+
+			// Verify ConfigMap was updated
+			updatedConfigMap := &corev1.ConfigMap{}
+			err = fakeClient.Get(context.TODO(), types.NamespacedName{
+				Name:      configMapName,
+				Namespace: mcpServer.Namespace,
+			}, updatedConfigMap)
+			require.NoError(t, err)
+
+			// Verify checksum changed
+			updatedChecksum := updatedConfigMap.Annotations["toolhive.stacklok.dev/content-checksum"]
+			assert.NotEqual(t, initialChecksum, updatedChecksum, "Checksum should change when content changes")
+
+			// Verify specific changes in RunConfig
+			var updatedRunConfig runner.RunConfig
+			err = json.Unmarshal([]byte(updatedConfigMap.Data["runconfig.json"]), &updatedRunConfig)
+			require.NoError(t, err)
+
+			// Check expected changes using reflection
+			runConfigValue := reflect.ValueOf(updatedRunConfig)
+			for fieldName, expectedValue := range tt.expectedChanges {
+				field := runConfigValue.FieldByName(fieldName)
+				require.True(t, field.IsValid(), "Field %s should exist in RunConfig", fieldName)
+
+				actualValue := field.Interface()
+				assert.Equal(t, expectedValue, actualValue, "Field %s should have expected value", fieldName)
+			}
+		})
+	}
+}

--- a/pkg/runner/config.go
+++ b/pkg/runner/config.go
@@ -123,6 +123,9 @@ type RunConfig struct {
 	// Deployer is the container runtime to use (not serialized)
 	Deployer rt.Deployer `json:"-" yaml:"-"`
 
+	// buildContext indicates whether this config is being built for CLI or operator use (not serialized)
+	buildContext BuildContext
+
 	// IsolateNetwork indicates whether to isolate the network for the container
 	IsolateNetwork bool `json:"isolate_network,omitempty" yaml:"isolate_network,omitempty"`
 
@@ -240,6 +243,14 @@ func (c *RunConfig) WithTransport(t string) (*RunConfig, error) {
 
 // WithPorts configures the host and target ports
 func (c *RunConfig) WithPorts(proxyPort, targetPort int) (*RunConfig, error) {
+	// Skip port validation for operator context - ports will be used in containers, not on operator host
+	if c.buildContext == BuildContextOperator {
+		c.Port = proxyPort
+		c.TargetPort = targetPort
+		return c, nil
+	}
+
+	// CLI context: perform port validation as before
 	var selectedPort int
 	var err error
 


### PR DESCRIPTION
It will manage the whole lifecycle of the configmap, including creation and deletion, and tracking modification via checksum

Related-to: #1638