### PR TITLE
Enhance Streamable HTTP proxy with session management and ID routing

### DIFF
--- a/pkg/authz/middleware.go
+++ b/pkg/authz/middleware.go
@@ -9,6 +9,7 @@ import (
 
 	"golang.org/x/exp/jsonrpc2"
 
+	"github.com/stacklok/toolhive/pkg/logger"
 	"github.com/stacklok/toolhive/pkg/mcp"
 	"github.com/stacklok/toolhive/pkg/transport/ssecommon"
 	"github.com/stacklok/toolhive/pkg/transport/types"
@@ -179,8 +180,7 @@ func (a *CedarAuthorizer) Middleware(next http.Handler) http.Handler {
 			if err := filteringWriter.Flush(); err != nil {
 				// If flushing fails, we've already started writing the response,
 				// so we can't return an error response. Just log it.
-				// In a real application, you might want to use a proper logger here.
-				fmt.Printf("Error flushing filtered response: %v\n", err)
+				logger.Warnf("Error flushing filtered response: %v", err)
 			}
 			return
 		}

--- a/pkg/transport/proxy/streamable/dispatcher.go
+++ b/pkg/transport/proxy/streamable/dispatcher.go
@@ -1,0 +1,62 @@
+package streamable
+
+import (
+	"time"
+
+	"golang.org/x/exp/jsonrpc2"
+
+	"github.com/stacklok/toolhive/pkg/logger"
+)
+
+// dispatchResponses routes container responses to the appropriate waiter by request ID.
+// Notifications are ignored for streamable HTTP.
+func (p *HTTPProxy) dispatchResponses() {
+	for {
+		select {
+		case <-p.shutdownCh:
+			return
+		case resp := <-p.responseCh:
+			// Ignore notifications
+			if isNotification(resp) {
+				continue
+			}
+			r, ok := resp.(*jsonrpc2.Response)
+			if !ok || !r.ID.IsValid() {
+				logger.Warnf("Received invalid message that is not a valid response: %T", resp)
+				continue
+			}
+
+			rawID := r.ID.Raw()
+			// Composite-only routing: responses must carry composite ID (sessID|idKey)
+			if sID, ok := rawID.(string); ok {
+				if chVal, ok := p.waiters.Load(sID); ok {
+					if ch, ok := chVal.(chan jsonrpc2.Message); ok {
+						select {
+						case ch <- resp:
+						default:
+							logger.Warnf("Waiter channel full for compositeKey=%s; dropping response", sID)
+						}
+						continue
+					}
+				}
+				logger.Warnf("No waiter found for compositeKey=%s; dropping", sID)
+				continue
+			}
+			logger.Warnf("Non-string response id (expected composite string); dropping: %v", rawID)
+		}
+	}
+}
+
+// waitForResponse waits for a response on the given channel with timeout.
+func (p *HTTPProxy) waitForResponse(ch <-chan jsonrpc2.Message, timeout time.Duration) jsonrpc2.Message {
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case msg := <-ch:
+		return msg
+	case <-timer.C:
+		return nil
+	case <-p.shutdownCh:
+		return nil
+	}
+}

--- a/pkg/transport/proxy/streamable/streamable_proxy.go
+++ b/pkg/transport/proxy/streamable/streamable_proxy.go
@@ -5,20 +5,28 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
+	"sync"
 	"time"
 
+	"github.com/google/uuid"
 	"golang.org/x/exp/jsonrpc2"
 
 	"github.com/stacklok/toolhive/pkg/logger"
+	"github.com/stacklok/toolhive/pkg/transport/session"
 	"github.com/stacklok/toolhive/pkg/transport/types"
 )
 
 const (
 	// StreamableHTTPEndpoint is the endpoint for streamable HTTP.
 	StreamableHTTPEndpoint = "/mcp"
+
+	// Default timeouts and buffer sizes
+	defaultResponseTimeout = 30 * time.Second
 )
 
 // HTTPProxy implements a proxy for streamable HTTP transport.
@@ -30,12 +38,21 @@ type HTTPProxy struct {
 	prometheusHandler http.Handler
 	middlewares       []types.MiddlewareFunction
 
-	// Message channel for sending JSON-RPC to the container
+	// Message channel for sending JSON-RPC to the container (from HTTP -> runner)
 	messageCh chan jsonrpc2.Message
-	// Response channel for receiving JSON-RPC from the container
+	// Response channel for receiving JSON-RPC from the container (runner -> HTTP)
 	responseCh chan jsonrpc2.Message
 
-	server *http.Server
+	// Session manager for streamable HTTP sessions
+	sessionManager *session.Manager
+
+	// Waiters keyed by JSON-encoded request ID -> one-shot channel for response delivery
+	waiters sync.Map // map[string]chan jsonrpc2.Message
+	// Map of compositeKey(sessID|idKey) -> original client JSON-RPC ID to restore before replying
+	idRestore sync.Map // map[string]jsonrpc2.ID
+
+	server   *http.Server
+	stopOnce sync.Once
 }
 
 // NewHTTPProxy creates a new HTTPProxy for streamable HTTP transport.
@@ -46,6 +63,9 @@ func NewHTTPProxy(
 	prometheusHandler http.Handler,
 	middlewares ...types.MiddlewareFunction,
 ) *HTTPProxy {
+	// Use typed Streamable sessions
+	sFactory := func(id string) session.Session { return session.NewStreamableSession(id) }
+
 	return &HTTPProxy{
 		host:              host,
 		port:              port,
@@ -55,13 +75,13 @@ func NewHTTPProxy(
 		middlewares:       middlewares,
 		messageCh:         make(chan jsonrpc2.Message, 100),
 		responseCh:        make(chan jsonrpc2.Message, 100),
+		sessionManager:    session.NewManager(30*time.Minute, sFactory),
 	}
 }
 
 // Start starts the HTTPProxy server.
 func (p *HTTPProxy) Start(_ context.Context) error {
 	mux := http.NewServeMux()
-
 	mux.Handle(StreamableHTTPEndpoint, p.applyMiddlewares(http.HandlerFunc(p.handleStreamableRequest)))
 
 	if p.prometheusHandler != nil {
@@ -73,6 +93,9 @@ func (p *HTTPProxy) Start(_ context.Context) error {
 		Handler:           mux,
 		ReadHeaderTimeout: 10 * time.Second,
 	}
+
+	// Route container responses to matching waiter channels
+	go p.dispatchResponses()
 
 	go func() {
 		logger.Infof("Streamable HTTP proxy started for container %s on port %d", p.containerName, p.port)
@@ -87,11 +110,30 @@ func (p *HTTPProxy) Start(_ context.Context) error {
 
 // Stop gracefully shuts down the HTTPProxy server.
 func (p *HTTPProxy) Stop(ctx context.Context) error {
-	close(p.shutdownCh)
-	if p.server != nil {
-		return p.server.Shutdown(ctx)
-	}
-	return nil
+	var err error
+
+	p.stopOnce.Do(func() {
+		close(p.shutdownCh)
+
+		// Stop session manager cleanup and disconnect sessions
+		if p.sessionManager != nil {
+			p.sessionManager.Stop()
+			p.sessionManager.Range(func(_, value interface{}) bool {
+				if ss, ok := value.(*session.StreamableSession); ok {
+					ss.Disconnect()
+				}
+				return true
+			})
+		}
+
+		if p.server != nil {
+			if e := p.server.Shutdown(ctx); e != nil {
+				err = e
+			}
+		}
+	})
+
+	return err
 }
 
 // GetMessageChannel returns the message channel for sending JSON-RPC to the container.
@@ -129,87 +171,65 @@ func (p *HTTPProxy) SendResponseMessage(msg jsonrpc2.Message) error {
 	return p.ForwardResponseToClients(context.Background(), msg)
 }
 
-func (p *HTTPProxy) applyMiddlewares(handler http.Handler) http.Handler {
-	for i := len(p.middlewares) - 1; i >= 0; i-- {
-		handler = p.middlewares[i](handler)
-	}
-	return handler
-}
-
-func isNotification(msg jsonrpc2.Message) bool {
-	if req, ok := msg.(*jsonrpc2.Request); ok {
-		return req.ID.Raw() == nil
-	}
-	return false
-}
-
-// handleBatchRequest processes a batch JSON-RPC request and returns true if it handled the request.
-func (p *HTTPProxy) handleBatchRequest(w http.ResponseWriter, body []byte) bool {
-	trimmed := bytes.TrimSpace(body)
-	if len(trimmed) == 0 || trimmed[0] != '[' {
-		return false
-	}
-
-	// Decode batch
-	var rawMessages []json.RawMessage
-	if err := json.Unmarshal(trimmed, &rawMessages); err != nil {
-		logger.Warnf("Failed to decode batch JSON-RPC: %s", string(body))
-		http.Error(w, "Invalid batch JSON-RPC", http.StatusBadRequest)
-		return true
-	}
-
-	var responses []json.RawMessage
-	for _, raw := range rawMessages {
-		msg, err := jsonrpc2.DecodeMessage(raw)
-		if err != nil {
-			logger.Warnf("Skipping invalid message in batch: %s", string(raw))
-			continue
-		}
-
-		// Send each message to the container
-		if err := p.SendMessageToDestination(msg); err != nil {
-			logger.Errorf("Failed to send message to destination: %v", err)
-			continue
-		}
-
-		// Wait for response (sequential, can be improved for concurrency)
-		if response := p.waitForBatchResponse(); response != nil {
-			responses = append(responses, response)
-		}
-	}
-
-	// Write the batch response
-	w.Header().Set("Content-Type", "application/json")
-	if len(responses) == 0 {
-		w.WriteHeader(http.StatusNoContent)
-		return true
-	}
-	respBytes, err := json.Marshal(responses)
-	if err != nil {
-		logger.Errorf("Failed to marshal batch response: %v", err)
-		http.Error(w, "Failed to encode batch response", http.StatusInternalServerError)
-		return true
-	}
-	if _, err := w.Write(respBytes); err != nil {
-		logger.Errorf("Failed to write batch response: %v", err)
-	}
-	return true
-}
+// ------------------------- HTTP handlers -------------------------
 
 // handleStreamableRequest handles HTTP POST requests to /mcp.
 func (p *HTTPProxy) handleStreamableRequest(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+	switch r.Method {
+	case http.MethodGet:
+		p.handleGet(w, r)
+	case http.MethodDelete:
+		p.handleDelete(w, r)
+	case http.MethodPost:
+		p.handlePost(w, r)
+	default:
+		writeHTTPError(w, http.StatusMethodNotAllowed, "Method not allowed")
+	}
+}
+
+func (*HTTPProxy) handleGet(w http.ResponseWriter, _ *http.Request) {
+	// SSE not offered here; explicit 405 is spec-compliant
+	writeHTTPError(w, http.StatusMethodNotAllowed, "SSE not supported on this endpoint")
+}
+
+func (p *HTTPProxy) handleDelete(w http.ResponseWriter, r *http.Request) {
+	sessID := r.Header.Get("Mcp-Session-Id")
+	if sessID == "" {
+		writeHTTPError(w, http.StatusBadRequest, "Mcp-Session-Id header required for DELETE")
+		return
+	}
+	if _, ok := p.sessionManager.Get(sessID); !ok {
+		writeHTTPError(w, http.StatusNotFound, "session not found")
+		return
+	}
+	p.sessionManager.Delete(sessID)
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (p *HTTPProxy) handlePost(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	// Optionally validate MCP-Protocol-Version; accept missing for compatibility
+	protoVer := r.Header.Get("MCP-Protocol-Version")
+	if protoVer != "" && !isSupportedMCPVersion(protoVer) {
+		writeHTTPError(w, http.StatusBadRequest, "Unsupported MCP-Protocol-Version")
 		return
 	}
 
+	// Read request body
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
-		http.Error(w, fmt.Sprintf("Error reading request body: %v", err), http.StatusInternalServerError)
+		writeHTTPError(w, http.StatusInternalServerError, fmt.Sprintf("Error reading request body: %v", err))
 		return
 	}
 
-	if p.handleBatchRequest(w, body) {
+	// Batch vs single message
+	if isBatch(body) {
+		sessID, err := p.resolveSessionForBatch(w, r)
+		if err != nil {
+			return
+		}
+		p.handleBatchRequest(w, body, sessID)
 		return
 	}
 
@@ -218,14 +238,407 @@ func (p *HTTPProxy) handleStreamableRequest(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	if p.handleNotificationOrResponse(w, msg) {
+	// Notifications or client responses are accepted and forwarded (202)
+	if p.handleNotificationOrClientResponse(w, msg) {
 		return
 	}
 
-	p.handleRequestResponse(w, msg)
+	req, ok := msg.(*jsonrpc2.Request)
+	if !ok || !req.ID.IsValid() {
+		writeHTTPError(w, http.StatusBadRequest, "Invalid JSON-RPC request (missing id)")
+		return
+	}
+
+	// Resolve session per spec (initialize vs ordinary)
+	sessID, setSessionHeader, err := p.resolveSessionForRequest(w, r, req)
+	if err != nil {
+		return
+	}
+
+	// If client accepts SSE, stream the response on an SSE stream for this request
+	if strings.Contains(r.Header.Get("Accept"), "text/event-stream") {
+		p.handleSingleRequestSSE(ctx, w, sessID, req, setSessionHeader)
+		return
+	}
+
+	// Request/response path with correlation (JSON response)
+	p.handleSingleRequest(ctx, w, sessID, req, setSessionHeader)
 }
 
-func (p *HTTPProxy) handleNotificationOrResponse(w http.ResponseWriter, msg jsonrpc2.Message) bool {
+// handleBatchRequest processes a batch JSON-RPC request and writes a batch response.
+func (p *HTTPProxy) handleBatchRequest(w http.ResponseWriter, body []byte, sessID string) {
+	rawMessages, ok := decodeBatch(w, body)
+	if !ok {
+		return
+	}
+
+	var responses []json.RawMessage
+	hadRequest := false
+
+	for _, raw := range rawMessages {
+		// Detect if this element is a request with an ID
+		if msg, err := jsonrpc2.DecodeMessage(raw); err == nil {
+			if req, ok := msg.(*jsonrpc2.Request); ok && req.ID.IsValid() {
+				hadRequest = true
+			}
+		}
+		resp := p.processSingleMessage(sessID, raw)
+		if resp != nil {
+			responses = append(responses, resp)
+		}
+	}
+
+	if !hadRequest {
+		// Per spec: batches containing only notifications/responses -> 202 Accepted, no body
+		w.WriteHeader(http.StatusAccepted)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	// It's valid to return an empty array if requests produced no responses
+	if err := json.NewEncoder(w).Encode(responses); err != nil {
+		logger.Errorf("Failed to encode batch response: %v", err)
+	}
+}
+
+// handleSingleRequest handles a single JSON-RPC request message end-to-end.
+func (p *HTTPProxy) handleSingleRequest(
+	ctx context.Context,
+	w http.ResponseWriter,
+	sessID string,
+	req *jsonrpc2.Request,
+	setSessionHeader bool,
+) {
+	ctx, cancel := context.WithTimeout(ctx, defaultResponseTimeout)
+	defer cancel()
+
+	msg, err := p.doRequest(ctx, sessID, req)
+	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+			logger.Warnf("Timeout waiting for response for method=%s", req.Method)
+			writeHTTPError(w, http.StatusGatewayTimeout, "Timeout waiting for response from container")
+		} else {
+			logger.Errorf("Failed to process request method=%s: %v", req.Method, err)
+			writeHTTPError(w, http.StatusInternalServerError, "Failed to process request")
+		}
+		return
+	}
+
+	if setSessionHeader {
+		w.Header().Set("Mcp-Session-Id", sessID)
+	}
+	if err := writeJSONRPC(w, msg); err != nil {
+		logger.Errorf("Failed to write JSON-RPC response: %v", err)
+	}
+}
+
+func (p *HTTPProxy) handleSingleRequestSSE(
+	ctx context.Context,
+	w http.ResponseWriter,
+	sessID string,
+	req *jsonrpc2.Request,
+	setSessionHeader bool,
+) {
+	ctx, cancel := context.WithTimeout(ctx, defaultResponseTimeout)
+	defer cancel()
+
+	// Prepare SSE response headers
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		writeHTTPError(w, http.StatusInternalServerError, "Streaming not supported")
+		return
+	}
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	if setSessionHeader {
+		w.Header().Set("Mcp-Session-Id", sessID)
+	}
+	flusher.Flush()
+
+	msg, err := p.doRequest(ctx, sessID, req)
+	if err != nil {
+		// Send a best-effort error event
+		errMsg := "Internal error"
+		code := -32603
+		if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+			errMsg = "Timeout"
+			code = -32000
+		}
+		errObj := map[string]any{
+			"jsonrpc": "2.0",
+			"id":      req.ID.Raw(),
+			"error": map[string]any{
+				"code":    code,
+				"message": errMsg,
+			},
+		}
+		if data, mErr := json.Marshal(errObj); mErr == nil {
+			fmt.Fprintf(w, "data: %s\n\n", data)
+			flusher.Flush()
+		}
+		return
+	}
+
+	data, err := jsonrpc2.EncodeMessage(msg)
+	if err != nil {
+		logger.Errorf("Failed to encode JSON-RPC response: %v", err)
+		writeHTTPError(w, http.StatusInternalServerError, "Failed to encode response")
+		return
+	}
+	// Write SSE event with the JSON-RPC response and flush
+	fmt.Fprintf(w, "data: %s\n\n", data)
+	flusher.Flush()
+}
+
+// processSingleMessage processes one raw JSON-RPC in a batch and returns encoded response bytes or nil.
+func (p *HTTPProxy) processSingleMessage(sessID string, raw json.RawMessage) json.RawMessage {
+	// Note: batch processing path
+	msg, err := jsonrpc2.DecodeMessage(raw)
+	if err != nil {
+		logger.Warnf("Skipping invalid message in batch: %s", string(raw))
+		return nil
+	}
+
+	// Notifications: just forward and continue
+	if isNotification(msg) {
+		if err := p.SendMessageToDestination(msg); err != nil {
+			logger.Errorf("Failed to send notification to destination: %v", err)
+		}
+		return nil
+	}
+
+	// Client responses: accept and forward, no HTTP body
+	if _, ok := msg.(*jsonrpc2.Response); ok {
+		if err := p.SendMessageToDestination(msg); err != nil {
+			logger.Errorf("Failed to forward client response to destination: %v", err)
+		}
+		return nil
+	}
+
+	req, ok := msg.(*jsonrpc2.Request)
+	if !ok || !req.ID.IsValid() {
+		logger.Warnf("Skipping invalid batch item (not a request with ID/response/notification): %T", msg)
+		return nil
+	}
+
+	waitCh, cleanup := p.createWaiter(sessID, req.ID)
+	defer cleanup()
+	bkey := idKeyFromID(req.ID)
+
+	// Transform outgoing request ID to composite and send
+	ck := compositeKey(sessID, bkey)
+	proxiedMsg, err := encodeRequestWithID(req, ck)
+	if err != nil {
+		logger.Errorf("Failed to encode batch request: %v", err)
+		return nil
+	}
+	if err := p.SendMessageToDestination(proxiedMsg); err != nil {
+		logger.Errorf("Failed to send message to destination: %v", err)
+		return nil
+	}
+
+	response := p.waitForResponse(waitCh, defaultResponseTimeout)
+	if response == nil {
+		logger.Warnf("StreamableHTTP: batch timeout waiting for key=%s", bkey)
+		return nil
+	}
+
+	if r, ok := response.(*jsonrpc2.Response); ok && r.ID.IsValid() {
+		restored, err := p.restoreResponseID(r, ck)
+		if err != nil {
+			logger.Errorf("Failed to restore response ID: %v", err)
+			return nil
+		}
+		data, err := jsonrpc2.EncodeMessage(restored)
+		if err != nil {
+			logger.Errorf("Failed to encode JSON-RPC response: %v", err)
+			return nil
+		}
+		return data
+	}
+
+	logger.Warnf("Received invalid message that is not a valid response: %T", response)
+	return nil
+}
+
+func encodeRequestWithID(req *jsonrpc2.Request, newID string) (jsonrpc2.Message, error) {
+	data, err := jsonrpc2.EncodeMessage(req)
+	if err != nil {
+		return nil, err
+	}
+	var m map[string]any
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, err
+	}
+	m["id"] = newID
+	data2, err := json.Marshal(m)
+	if err != nil {
+		return nil, err
+	}
+	return jsonrpc2.DecodeMessage(data2)
+}
+
+func (p *HTTPProxy) restoreResponseID(resp *jsonrpc2.Response, ck string) (jsonrpc2.Message, error) {
+	orig, ok := p.idRestore.Load(ck)
+	if !ok {
+		// No restore information; return as-is
+		return resp, nil
+	}
+	origID, _ := orig.(jsonrpc2.ID)
+
+	data, err := jsonrpc2.EncodeMessage(resp)
+	if err != nil {
+		return nil, err
+	}
+	var m map[string]any
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, err
+	}
+	m["id"] = origID.Raw()
+	data2, err := json.Marshal(m)
+	if err != nil {
+		return nil, err
+	}
+	return jsonrpc2.DecodeMessage(data2)
+}
+
+func (p *HTTPProxy) doRequest(ctx context.Context, sessID string, req *jsonrpc2.Request) (jsonrpc2.Message, error) {
+	key := idKeyFromID(req.ID)
+	ck := compositeKey(sessID, key)
+
+	waitCh, cleanup := p.createWaiter(sessID, req.ID)
+	defer cleanup()
+
+	proxiedMsg, err := encodeRequestWithID(req, ck)
+	if err != nil {
+		return nil, fmt.Errorf("encode request: %w", err)
+	}
+	if err := p.SendMessageToDestination(proxiedMsg); err != nil {
+		return nil, fmt.Errorf("send message: %w", err)
+	}
+
+	select {
+	case msg := <-waitCh:
+		if r, ok := msg.(*jsonrpc2.Response); ok && r.ID.IsValid() {
+			restored, err := p.restoreResponseID(r, ck)
+			if err != nil {
+				return nil, fmt.Errorf("restore id: %w", err)
+			}
+			return restored, nil
+		}
+		return msg, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-p.shutdownCh:
+		return nil, context.Canceled
+	}
+}
+
+// ------------------------- Helpers: middleware, parsing, correlation -------------------------
+
+func (p *HTTPProxy) applyMiddlewares(handler http.Handler) http.Handler {
+	for i := len(p.middlewares) - 1; i >= 0; i-- {
+		handler = p.middlewares[i](handler)
+	}
+	return handler
+}
+
+func (p *HTTPProxy) ensureSession(id string) error {
+	if _, ok := p.sessionManager.Get(id); ok {
+		return nil
+	}
+	return p.sessionManager.AddWithID(id)
+}
+
+// resolveSessionForBatch resolves or creates an ephemeral session for batch POSTs.
+// Writes appropriate HTTP errors and returns an error when handling should stop.
+func (p *HTTPProxy) resolveSessionForBatch(w http.ResponseWriter, r *http.Request) (string, error) {
+	sessID := r.Header.Get("Mcp-Session-Id")
+	if sessID == "" {
+		sessID = uuid.New().String()
+		if err := p.ensureSession(sessID); err != nil {
+			writeHTTPError(w, http.StatusInternalServerError, fmt.Sprintf("Failed to create session: %v", err))
+			return "", err
+		}
+		return sessID, nil
+	}
+	if _, ok := p.sessionManager.Get(sessID); !ok {
+		writeHTTPError(w, http.StatusNotFound, "session not found")
+		return "", fmt.Errorf("session not found")
+	}
+	return sessID, nil
+}
+
+// resolveSessionForRequest resolves session rules for a single JSON-RPC request.
+// On initialize, assigns session if missing and returns setSessionHeader=true.
+// For other methods, allows optional session by creating ephemeral (no header set).
+// Writes HTTP errors on failure and returns error to stop handling.
+func (p *HTTPProxy) resolveSessionForRequest(
+	w http.ResponseWriter,
+	r *http.Request,
+	req *jsonrpc2.Request,
+) (string, bool, error) {
+	var setSessionHeader bool
+	sessID := r.Header.Get("Mcp-Session-Id")
+
+	if req.Method == "initialize" {
+		if sessID == "" {
+			sessID = uuid.New().String()
+			setSessionHeader = true
+		}
+		if err := p.ensureSession(sessID); err != nil {
+			writeHTTPError(w, http.StatusInternalServerError, fmt.Sprintf("Failed to create session: %v", err))
+			return "", false, err
+		}
+		return sessID, setSessionHeader, nil
+	}
+
+	// Non-initialize path: sessions are optional; create ephemeral if missing
+	if sessID == "" {
+		sessID = uuid.New().String()
+		if err := p.ensureSession(sessID); err != nil {
+			writeHTTPError(w, http.StatusInternalServerError, fmt.Sprintf("Failed to create session: %v", err))
+			return "", false, err
+		}
+		return sessID, false, nil
+	}
+
+	// If session is provided, ensure it exists
+	if _, ok := p.sessionManager.Get(sessID); !ok {
+		writeHTTPError(w, http.StatusNotFound, "session not found")
+		return "", false, fmt.Errorf("session not found")
+	}
+	return sessID, false, nil
+}
+
+func isBatch(body []byte) bool {
+	t := bytes.TrimSpace(body)
+	return len(t) > 0 && t[0] == '['
+}
+
+func decodeBatch(w http.ResponseWriter, body []byte) ([]json.RawMessage, bool) {
+	var rawMessages []json.RawMessage
+	if err := json.Unmarshal(bytes.TrimSpace(body), &rawMessages); err != nil {
+		logger.Warnf("Failed to decode batch JSON-RPC: %s", string(body))
+		writeHTTPError(w, http.StatusBadRequest, "Invalid batch JSON-RPC")
+		return nil, false
+	}
+	return rawMessages, true
+}
+
+// decodeJSONRPCMessage decodes a JSON-RPC message from the request body.
+func decodeJSONRPCMessage(w http.ResponseWriter, body []byte) (jsonrpc2.Message, bool) {
+	msg, err := jsonrpc2.DecodeMessage(body)
+	if err != nil {
+		logger.Warnf("Skipping message that failed to decode: %s", string(body))
+		writeHTTPError(w, http.StatusBadRequest, "Invalid JSON-RPC 2.0 message")
+		return nil, false
+	}
+	return msg, true
+}
+
+func (p *HTTPProxy) handleNotificationOrClientResponse(w http.ResponseWriter, msg jsonrpc2.Message) bool {
 	if isNotification(msg) || (func() bool { _, ok := msg.(*jsonrpc2.Response); return ok })() {
 		if err := p.SendMessageToDestination(msg); err != nil {
 			logger.Errorf("Failed to send message to destination: %v", err)
@@ -236,101 +649,19 @@ func (p *HTTPProxy) handleNotificationOrResponse(w http.ResponseWriter, msg json
 	return false
 }
 
-func (p *HTTPProxy) handleRequestResponse(w http.ResponseWriter, msg jsonrpc2.Message) {
-	if err := p.SendMessageToDestination(msg); err != nil {
-		http.Error(w, "Failed to send message to destination", http.StatusInternalServerError)
-		return
+// createWaiter registers a waiter channel for the given request ID and returns cleanup fn.
+func (p *HTTPProxy) createWaiter(sessID string, id jsonrpc2.ID) (chan jsonrpc2.Message, func()) {
+	key := idKeyFromID(id)
+	ck := compositeKey(sessID, key)
+	// store original client id to restore before replying
+	p.idRestore.Store(ck, id)
+
+	ch := make(chan jsonrpc2.Message, 1)
+	p.waiters.Store(ck, ch)
+
+	cleanup := func() {
+		p.waiters.Delete(ck)
+		p.idRestore.Delete(ck)
 	}
-
-	// Keep reading from responseCh until we get a proper response (not a notification)
-	timeout := time.After(10 * time.Second)
-	for {
-		select {
-		case resp := <-p.responseCh:
-			// Check if this is a notification message - handle it and continue waiting
-			if isNotification(resp) {
-				logger.Debugf("Ignoring notification (no SSE stream available): %T", resp)
-				continue
-			}
-
-			// Check if this is a valid response
-			if r, ok := resp.(*jsonrpc2.Response); ok && r.ID.IsValid() {
-				w.Header().Set("Content-Type", "application/json")
-				data, err := jsonrpc2.EncodeMessage(r)
-				if err != nil {
-					logger.Errorf("Failed to encode JSON-RPC response: %v", err)
-					http.Error(w, "Failed to encode response", http.StatusInternalServerError)
-					return
-				}
-				if _, err := w.Write(data); err != nil {
-					logger.Errorf("Failed to write response: %v", err)
-				}
-				return
-			} else {
-				logger.Warnf("Received invalid message that is not a notification or valid response: %T", resp)
-				w.Header().Set("Content-Type", "application/json")
-				errResp := getInvalidJsonrpcError()
-				if err := json.NewEncoder(w).Encode(errResp); err != nil {
-					logger.Errorf("Failed to encode error response: %v", err)
-				}
-				return
-			}
-		case <-timeout:
-			http.Error(w, "Timeout waiting for response from container", http.StatusGatewayTimeout)
-			return
-		}
-	}
-}
-
-func getInvalidJsonrpcError() map[string]interface{} {
-	errResp := map[string]interface{}{
-		"jsonrpc": "2.0",
-		"id":      nil,
-		"error": map[string]interface{}{
-			"code":    -32603,
-			"message": "Invalid JSON-RPC 2.0 response from server",
-		},
-	}
-	return errResp
-}
-
-// decodeJSONRPCMessage decodes a JSON-RPC message from the request body.
-func decodeJSONRPCMessage(w http.ResponseWriter, body []byte) (jsonrpc2.Message, bool) {
-	msg, err := jsonrpc2.DecodeMessage(body)
-	if err != nil {
-		logger.Warnf("Skipping message that failed to decode: %s", string(body))
-		http.Error(w, "Invalid JSON-RPC 2.0 message", http.StatusBadRequest)
-		return nil, false
-	}
-	return msg, true
-}
-
-// waitForBatchResponse waits for a response from the container, ignoring notifications.
-// Returns the encoded response data or nil if timeout/error occurs.
-func (p *HTTPProxy) waitForBatchResponse() json.RawMessage {
-	timeout := time.After(10 * time.Second)
-	for {
-		select {
-		case resp := <-p.responseCh:
-			// Check if this is a notification message - handle it and continue waiting
-			if isNotification(resp) {
-				// TODO: We could buffer these notifications and send them via SSE if needed
-				logger.Debugf("Ignoring notification (no SSE stream available): %T", resp)
-				continue
-			}
-
-			// Check if this is a valid response
-			if r, ok := resp.(*jsonrpc2.Response); ok && r.ID.IsValid() {
-				data, err := jsonrpc2.EncodeMessage(r)
-				if err != nil {
-					logger.Errorf("Failed to encode JSON-RPC response: %v", err)
-					return nil
-				}
-				return data
-			}
-		case <-timeout:
-			logger.Warnf("Timeout waiting for response from container for batch message")
-			return nil
-		}
-	}
+	return ch, cleanup
 }

--- a/pkg/transport/proxy/streamable/streamable_proxy_mcp_client_integration_test.go
+++ b/pkg/transport/proxy/streamable/streamable_proxy_mcp_client_integration_test.go
@@ -1,0 +1,403 @@
+package streamable
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/mark3labs/mcp-go/client"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/jsonrpc2"
+)
+
+const (
+	methodInitialize    = "initialize"
+	methodToolsList     = "tools/list"
+	methodToolsCall     = "tools/call"
+	methodResourcesList = "resources/list"
+	methodPing          = "ping"
+
+	protoVersion = "2024-11-05"
+	toolEcho     = "echo"
+)
+
+// TestMCPGoClientInitializeAndPing spins up the Streamable HTTP proxy and uses the real mcp-go client
+// to perform Initialize and Ping over Streamable HTTP transport. The backend is simulated in-process
+// by reading proxy.GetMessageChannel() and writing JSON-RPC responses via ForwardResponseToClients.
+func TestMCPGoClientInitializeAndPing(t *testing.T) {
+	t.Parallel()
+
+	// Use a dedicated port to avoid clashes with other tests
+	const port = 8096
+	proxy := NewHTTPProxy("127.0.0.1", port, "test-container", http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		// no-op prometheus handler, safe for tests
+	}))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	require.NoError(t, proxy.Start(ctx), "proxy start")
+	t.Cleanup(func() { _ = proxy.Stop(ctx) })
+
+	// Give the server a moment to start listening
+	time.Sleep(50 * time.Millisecond)
+
+	// Simulated MCP server backend: respond to initialize and ping
+	go func() {
+		for {
+			select {
+			case msg := <-proxy.GetMessageChannel():
+				req, ok := msg.(*jsonrpc2.Request)
+				if !ok || !req.ID.IsValid() {
+					// ignore notifications/non-requests
+					continue
+				}
+				switch req.Method {
+				case methodInitialize:
+					// Minimal initialize result matching MCP schema
+					result := map[string]any{
+						"protocolVersion": "2024-11-05",
+						"serverInfo": map[string]any{
+							"name":    "toolhive-test-server",
+							"version": "0.0.0-test",
+						},
+						"capabilities": map[string]any{},
+					}
+					resp, _ := jsonrpc2.NewResponse(req.ID, result, nil)
+					_ = proxy.ForwardResponseToClients(ctx, resp)
+				case methodToolsList:
+					result := map[string]any{
+						"tools": []map[string]any{
+							{"name": toolEcho, "description": "Echo test tool"},
+						},
+					}
+					resp, _ := jsonrpc2.NewResponse(req.ID, result, nil)
+					_ = proxy.ForwardResponseToClients(ctx, resp)
+				case methodToolsCall:
+					result := map[string]any{
+						"content": []map[string]any{
+							{"type": "text", "text": "ok"},
+						},
+					}
+					resp, _ := jsonrpc2.NewResponse(req.ID, result, nil)
+					_ = proxy.ForwardResponseToClients(ctx, resp)
+				case methodResourcesList:
+					result := map[string]any{"resources": []any{}}
+					resp, _ := jsonrpc2.NewResponse(req.ID, result, nil)
+					_ = proxy.ForwardResponseToClients(ctx, resp)
+				case methodPing:
+					// Empty result is acceptable
+					result := map[string]any{}
+					resp, _ := jsonrpc2.NewResponse(req.ID, result, nil)
+					_ = proxy.ForwardResponseToClients(ctx, resp)
+				default:
+					// Generic empty success for any other method used by client
+					result := map[string]any{}
+					resp, _ := jsonrpc2.NewResponse(req.ID, result, nil)
+					_ = proxy.ForwardResponseToClients(ctx, resp)
+				}
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	// Create real MCP client for Streamable HTTP and exercise Initialize + Ping
+	serverURL := "http://127.0.0.1:8096" + StreamableHTTPEndpoint
+	cl, err := client.NewStreamableHttpClient(serverURL)
+	require.NoError(t, err, "create mcp-go streamable http client")
+	t.Cleanup(func() { _ = cl.Close() })
+
+	startCtx, startCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer startCancel()
+	require.NoError(t, cl.Start(startCtx), "start mcp transport")
+
+	// Build an initialize request with minimal fields
+	initCtx, initCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer initCancel()
+
+	initRequest := mcp.InitializeRequest{}
+	initRequest.Params.ProtocolVersion = protoVersion
+	initRequest.Params.ClientInfo = mcp.Implementation{
+		Name:    "toolhive-streamable-proxy-integration-test",
+		Version: "1.0.0",
+	}
+	initRequest.Params.Capabilities = mcp.ClientCapabilities{}
+
+	_, err = cl.Initialize(initCtx, initRequest)
+	require.NoError(t, err, "initialize over streamable http")
+
+	// List tools and ensure server returns expected tool
+	ltCtx, ltCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer ltCancel()
+	ltReq := mcp.ListToolsRequest{}
+	ltRes, err := cl.ListTools(ltCtx, ltReq)
+	require.NoError(t, err, "list tools over streamable http")
+	require.NotNil(t, ltRes)
+	require.GreaterOrEqual(t, len(ltRes.Tools), 1)
+	assert.Equal(t, toolEcho, ltRes.Tools[0].Name)
+
+	// Call a tool and verify content
+	ctCtx, ctCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer ctCancel()
+	ctReq := mcp.CallToolRequest{}
+	ctReq.Params.Name = toolEcho
+	ctReq.Params.Arguments = map[string]any{"input": "hello"}
+	ctRes, err := cl.CallTool(ctCtx, ctReq)
+	require.NoError(t, err, "call tool over streamable http")
+	require.NotNil(t, ctRes)
+	require.GreaterOrEqual(t, len(ctRes.Content), 1)
+}
+
+// TestMCPGoConcurrentClientsAndPings spins up several MCP clients against the same proxy and
+// executes many concurrent Ping operations to validate routing and waiter correlation reliability.
+func TestMCPGoConcurrentClientsAndPings(t *testing.T) {
+	t.Parallel()
+
+	const port = 8097
+	proxy := NewHTTPProxy("127.0.0.1", port, "test-container", nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	require.NoError(t, proxy.Start(ctx), "proxy start")
+	t.Cleanup(func() { _ = proxy.Stop(ctx) })
+
+	time.Sleep(50 * time.Millisecond)
+
+	// Backend: handle initialize + ping
+	go func() {
+		for {
+			select {
+			case msg := <-proxy.GetMessageChannel():
+				req, ok := msg.(*jsonrpc2.Request)
+				if !ok || !req.ID.IsValid() {
+					continue
+				}
+				switch req.Method {
+				case methodInitialize:
+					result := map[string]any{
+						"protocolVersion": "2024-11-05",
+						"serverInfo":      map[string]any{"name": "toolhive-test-server", "version": "0.0.0-test"},
+						"capabilities":    map[string]any{},
+					}
+					resp, _ := jsonrpc2.NewResponse(req.ID, result, nil)
+					_ = proxy.ForwardResponseToClients(ctx, resp)
+				case methodToolsList:
+					result := map[string]any{
+						"tools": []map[string]any{
+							{"name": toolEcho, "description": "Echo test tool"},
+						},
+					}
+					resp, _ := jsonrpc2.NewResponse(req.ID, result, nil)
+					_ = proxy.ForwardResponseToClients(ctx, resp)
+				case methodToolsCall:
+					result := map[string]any{
+						"content": []map[string]any{
+							{"type": "text", "text": "ok"},
+						},
+					}
+					resp, _ := jsonrpc2.NewResponse(req.ID, result, nil)
+					_ = proxy.ForwardResponseToClients(ctx, resp)
+				case methodResourcesList:
+					result := map[string]any{"resources": []any{}}
+					resp, _ := jsonrpc2.NewResponse(req.ID, result, nil)
+					_ = proxy.ForwardResponseToClients(ctx, resp)
+				case methodPing:
+					resp, _ := jsonrpc2.NewResponse(req.ID, map[string]any{}, nil)
+					_ = proxy.ForwardResponseToClients(ctx, resp)
+				default:
+					resp, _ := jsonrpc2.NewResponse(req.ID, map[string]any{}, nil)
+					_ = proxy.ForwardResponseToClients(ctx, resp)
+				}
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	serverURL := "http://127.0.0.1:8097" + StreamableHTTPEndpoint
+
+	// Create multiple clients
+	const clientCount = 5
+	const pingsPerClient = 5
+
+	clients := make([]*client.Client, 0, clientCount)
+	for i := 0; i < clientCount; i++ {
+		cl, err := client.NewStreamableHttpClient(serverURL)
+		require.NoError(t, err, "create client %d", i)
+		clients = append(clients, cl)
+	}
+
+	// Start and initialize each client concurrently, then wait for readiness
+	var initWG sync.WaitGroup
+	initWG.Add(len(clients))
+	initErrCh := make(chan error, len(clients))
+
+	for i, cl := range clients {
+		i, cl := i, cl
+		go func() {
+			defer initWG.Done()
+
+			startCtx, startCancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer startCancel()
+			if err := cl.Start(startCtx); err != nil {
+				initErrCh <- fmt.Errorf("start client %d: %w", i, err)
+				return
+			}
+
+			initCtx, initCancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer initCancel()
+			initRequest := mcp.InitializeRequest{}
+			initRequest.Params.ProtocolVersion = protoVersion
+			initRequest.Params.ClientInfo = mcp.Implementation{Name: "client", Version: "test"}
+			initRequest.Params.Capabilities = mcp.ClientCapabilities{}
+			if _, err := cl.Initialize(initCtx, initRequest); err != nil {
+				initErrCh <- fmt.Errorf("init client %d: %w", i, err)
+				return
+			}
+		}()
+	}
+
+	initWG.Wait()
+	close(initErrCh)
+	for err := range initErrCh {
+		require.NoError(t, err, "client initialization should succeed")
+	}
+
+	// Concurrent pings for all clients
+	var wg sync.WaitGroup
+	errCh := make(chan error, clientCount*pingsPerClient)
+
+	for i, cl := range clients {
+		for j := 0; j < pingsPerClient; j++ {
+			wg.Add(1)
+			go func(_, _ int, c *client.Client) {
+				defer wg.Done()
+				callCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				defer cancel()
+				ctReq := mcp.CallToolRequest{}
+				ctReq.Params.Name = toolEcho
+				ctReq.Params.Arguments = map[string]any{"input": "ok"}
+				if _, err := c.CallTool(callCtx, ctReq); err != nil {
+					errCh <- err
+				}
+			}(i, j, cl)
+		}
+	}
+
+	wg.Wait()
+	close(errCh)
+
+	for err := range errCh {
+		require.NoError(t, err, "concurrent pings should succeed")
+	}
+
+	// Close all clients
+	for _, cl := range clients {
+		_ = cl.Close()
+	}
+}
+
+// TestMCPGoManySequentialPingsSingleClient stresses a single client issuing many pings sequentially
+// to validate there are no waiter leaks or routing failures under load.
+func TestMCPGoManySequentialPingsSingleClient(t *testing.T) {
+	t.Parallel()
+
+	const port = 8098
+	proxy := NewHTTPProxy("127.0.0.1", port, "test-container", nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	require.NoError(t, proxy.Start(ctx), "proxy start")
+	t.Cleanup(func() { _ = proxy.Stop(ctx) })
+
+	time.Sleep(50 * time.Millisecond)
+
+	// Backend handler
+	go func() {
+		for {
+			select {
+			case msg := <-proxy.GetMessageChannel():
+				req, ok := msg.(*jsonrpc2.Request)
+				if !ok || !req.ID.IsValid() {
+					continue
+				}
+				switch req.Method {
+				case methodInitialize:
+					result := map[string]any{
+						"protocolVersion": "2024-11-05",
+						"serverInfo":      map[string]any{"name": "toolhive-test-server", "version": "0.0.0-test"},
+						"capabilities":    map[string]any{},
+					}
+					resp, _ := jsonrpc2.NewResponse(req.ID, result, nil)
+					_ = proxy.ForwardResponseToClients(ctx, resp)
+				case methodToolsList:
+					result := map[string]any{
+						"tools": []map[string]any{
+							{"name": toolEcho, "description": "Echo test tool"},
+						},
+					}
+					resp, _ := jsonrpc2.NewResponse(req.ID, result, nil)
+					_ = proxy.ForwardResponseToClients(ctx, resp)
+				case methodToolsCall:
+					result := map[string]any{
+						"content": []map[string]any{
+							{"type": "text", "text": "ok"},
+						},
+					}
+					resp, _ := jsonrpc2.NewResponse(req.ID, result, nil)
+					_ = proxy.ForwardResponseToClients(ctx, resp)
+				case methodResourcesList:
+					result := map[string]any{"resources": []any{}}
+					resp, _ := jsonrpc2.NewResponse(req.ID, result, nil)
+					_ = proxy.ForwardResponseToClients(ctx, resp)
+				case methodPing:
+					resp, _ := jsonrpc2.NewResponse(req.ID, map[string]any{}, nil)
+					_ = proxy.ForwardResponseToClients(ctx, resp)
+				default:
+					resp, _ := jsonrpc2.NewResponse(req.ID, map[string]any{}, nil)
+					_ = proxy.ForwardResponseToClients(ctx, resp)
+				}
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	serverURL := "http://127.0.0.1:8098" + StreamableHTTPEndpoint
+
+	cl, err := client.NewStreamableHttpClient(serverURL)
+	require.NoError(t, err, "create client")
+	t.Cleanup(func() { _ = cl.Close() })
+
+	startCtx, startCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer startCancel()
+	require.NoError(t, cl.Start(startCtx), "start client")
+
+	initCtx, initCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer initCancel()
+	initRequest := mcp.InitializeRequest{}
+	initRequest.Params.ProtocolVersion = protoVersion
+	initRequest.Params.ClientInfo = mcp.Implementation{Name: "single-client", Version: "test"}
+	initRequest.Params.Capabilities = mcp.ClientCapabilities{}
+	_, err = cl.Initialize(initCtx, initRequest)
+	require.NoError(t, err, "initialize")
+
+	const iterations = 100
+	for i := 0; i < iterations; i++ {
+		callCtx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		ctReq := mcp.CallToolRequest{}
+		ctReq.Params.Name = toolEcho
+		ctReq.Params.Arguments = map[string]any{"input": "ok"}
+		_, err := cl.CallTool(callCtx, ctReq)
+		cancel()
+		require.NoErrorf(t, err, "call-tool %d should succeed", i)
+	}
+}

--- a/pkg/transport/proxy/streamable/streamable_proxy_spec_test.go
+++ b/pkg/transport/proxy/streamable/streamable_proxy_spec_test.go
@@ -1,0 +1,229 @@
+package streamable
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/jsonrpc2"
+)
+
+// startProxyWithBackend starts an HTTP proxy on the given port and a simple backend goroutine
+// that responds to JSON-RPC requests by echoing a minimal success result.
+func startProxyWithBackend(t *testing.T, port int) (*HTTPProxy, context.Context, context.CancelFunc) {
+	t.Helper()
+
+	proxy := NewHTTPProxy("127.0.0.1", port, "test-container", nil)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	require.NoError(t, proxy.Start(ctx), "proxy start")
+	t.Cleanup(func() { _ = proxy.Stop(ctx) })
+
+	// Give the server a moment to start listening
+	time.Sleep(50 * time.Millisecond)
+
+	// Backend responder
+	go func() {
+		for {
+			select {
+			case msg := <-proxy.GetMessageChannel():
+				// Only respond to requests with IDs
+				if req, ok := msg.(*jsonrpc2.Request); ok && req.ID.IsValid() {
+					result := map[string]any{"ok": true}
+					resp, _ := jsonrpc2.NewResponse(req.ID, result, nil)
+					_ = proxy.ForwardResponseToClients(ctx, resp)
+				}
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	return proxy, ctx, cancel
+}
+
+// TestGETReturns405 validates that GET on MCP endpoint returns 405 (server does not offer SSE here).
+func TestGETReturns405(t *testing.T) {
+	t.Parallel()
+
+	const port = 8101
+	proxy := NewHTTPProxy("127.0.0.1", port, "test-container", nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	require.NoError(t, proxy.Start(ctx), "proxy start")
+	defer func() { _ = proxy.Stop(ctx) }()
+
+	time.Sleep(50 * time.Millisecond)
+
+	req, _ := http.NewRequest(http.MethodGet, "http://127.0.0.1:8101"+StreamableHTTPEndpoint, nil)
+	req.Header.Set("Accept", "text/event-stream")
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusMethodNotAllowed, resp.StatusCode)
+}
+
+// TestDeleteTerminatesSession validates DELETE ends session with 204 and subsequent use returns 404.
+func TestDeleteTerminatesSession(t *testing.T) {
+	t.Parallel()
+
+	const port = 8102
+	proxy, ctx, cancel := startProxyWithBackend(t, port)
+	defer cancel()
+	defer func() { _ = proxy.Stop(ctx) }()
+
+	url := "http://127.0.0.1:8102" + StreamableHTTPEndpoint
+
+	// Initialize without session header - server should assign one in response header
+	initJSON := `{"jsonrpc":"2.0","id":"1","method":"initialize","params":{"protocolVersion":"2025-03-26","clientInfo":{"name":"spec-test","version":"0.0.0"},"capabilities":{}}}`
+	resp, err := http.Post(url, "application/json", bytes.NewReader([]byte(initJSON)))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	sessID := resp.Header.Get("Mcp-Session-Id")
+	require.NotEmpty(t, sessID, "server should set Mcp-Session-Id header on initialize response")
+
+	// DELETE the session
+	delReq, _ := http.NewRequest(http.MethodDelete, url, nil)
+	delReq.Header.Set("Mcp-Session-Id", sessID)
+	delResp, err := http.DefaultClient.Do(delReq)
+	require.NoError(t, err)
+	defer delResp.Body.Close()
+	assert.Equal(t, http.StatusNoContent, delResp.StatusCode)
+
+	// Use the same session id again for a regular request - expect 404
+	reqJSON := `{"jsonrpc":"2.0","id":"2","method":"tools/list","params":{}}`
+	postReq, _ := http.NewRequest(http.MethodPost, url, bytes.NewReader([]byte(reqJSON)))
+	postReq.Header.Set("Content-Type", "application/json")
+	postReq.Header.Set("Mcp-Session-Id", sessID)
+	postResp, err := http.DefaultClient.Do(postReq)
+	require.NoError(t, err)
+	defer postResp.Body.Close()
+	assert.Equal(t, http.StatusNotFound, postResp.StatusCode)
+}
+
+// TestInitializeSetsSessionHeader ensures server assigns Mcp-Session-Id on initialize when client omits it.
+func TestInitializeSetsSessionHeader(t *testing.T) {
+	t.Parallel()
+
+	const port = 8103
+	proxy, ctx, cancel := startProxyWithBackend(t, port)
+	defer cancel()
+	defer func() { _ = proxy.Stop(ctx) }()
+
+	url := "http://127.0.0.1:8103" + StreamableHTTPEndpoint
+
+	initJSON := `{"jsonrpc":"2.0","id":"1","method":"initialize","params":{"protocolVersion":"2025-03-26","clientInfo":{"name":"spec-test","version":"0.0.0"},"capabilities":{}}}`
+	resp, err := http.Post(url, "application/json", bytes.NewReader([]byte(initJSON)))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
+
+	sessID := resp.Header.Get("Mcp-Session-Id")
+	require.NotEmpty(t, sessID, "server should set Mcp-Session-Id header")
+}
+
+// TestPOSTNotificationOnlyAccepted checks single notification POST returns 202 with no body.
+func TestPOSTNotificationOnlyAccepted(t *testing.T) {
+	t.Parallel()
+
+	const port = 8104
+	// No backend needed for notification-only submission, but starting is fine.
+	proxy := NewHTTPProxy("127.0.0.1", port, "test-container", nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, proxy.Start(ctx), "proxy start")
+	defer func() { _ = proxy.Stop(ctx) }()
+
+	time.Sleep(50 * time.Millisecond)
+
+	url := "http://127.0.0.1:8104" + StreamableHTTPEndpoint
+	// Notification (no id)
+	notif := `{"jsonrpc":"2.0","method":"progress","params":{"pct":50}}`
+
+	req, _ := http.NewRequest(http.MethodPost, url, bytes.NewReader([]byte(notif)))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusAccepted, resp.StatusCode)
+	body, _ := io.ReadAll(resp.Body)
+	assert.Equal(t, 0, len(body), "202 should have no body")
+}
+
+// TestBatchOnlyNotificationsAccepted returns 202 and no body per spec when no requests are present.
+func TestBatchOnlyNotificationsAccepted(t *testing.T) {
+	t.Parallel()
+
+	const port = 8105
+	proxy := NewHTTPProxy("127.0.0.1", port, "test-container", nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, proxy.Start(ctx), "proxy start")
+	defer func() { _ = proxy.Stop(ctx) }()
+
+	time.Sleep(50 * time.Millisecond)
+
+	url := "http://127.0.0.1:8105" + StreamableHTTPEndpoint
+
+	// Batch of only notifications (no ids)
+	batch := `[{"jsonrpc":"2.0","method":"progress","params":{"pct":10}},{"jsonrpc":"2.0","method":"progress","params":{"pct":20}}]`
+	req, _ := http.NewRequest(http.MethodPost, url, bytes.NewReader([]byte(batch)))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusAccepted, resp.StatusCode)
+	body, _ := io.ReadAll(resp.Body)
+	assert.Equal(t, 0, len(body))
+}
+
+// TestBatchMixedNotificationsAndRequest returns an array with one response corresponding to the request id.
+func TestBatchMixedNotificationsAndRequest(t *testing.T) {
+	t.Parallel()
+
+	const port = 8106
+	proxy, ctx, cancel := startProxyWithBackend(t, port)
+	defer cancel()
+	defer func() { _ = proxy.Stop(ctx) }()
+
+	url := "http://127.0.0.1:8106" + StreamableHTTPEndpoint
+
+	// Batch includes a notification and a request "r1"
+	batch := `[{"jsonrpc":"2.0","method":"progress","params":{"pct":99}},{"jsonrpc":"2.0","id":"r1","method":"tools/list","params":{}}]`
+	req, _ := http.NewRequest(http.MethodPost, url, bytes.NewReader([]byte(batch)))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
+
+	var arr []map[string]any
+	err = json.NewDecoder(resp.Body).Decode(&arr)
+	require.NoError(t, err)
+	require.Len(t, arr, 1)
+
+	// Response should correspond to id "r1"
+	assert.Equal(t, "2.0", arr[0]["jsonrpc"])
+	assert.Equal(t, "r1", arr[0]["id"])
+	// And include a result map as sent by backend
+	_, hasResult := arr[0]["result"]
+	assert.True(t, hasResult, "batch response should include result")
+}

--- a/pkg/transport/proxy/streamable/utils.go
+++ b/pkg/transport/proxy/streamable/utils.go
@@ -1,0 +1,64 @@
+package streamable
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"golang.org/x/exp/jsonrpc2"
+)
+
+// isNotification returns true if the JSON-RPC message is a notification (no ID).
+func isNotification(msg jsonrpc2.Message) bool {
+	if req, ok := msg.(*jsonrpc2.Request); ok {
+		return req.ID.Raw() == nil
+	}
+	return false
+}
+
+// writeHTTPError writes a plain HTTP error with status.
+func writeHTTPError(w http.ResponseWriter, status int, msg string) {
+	http.Error(w, msg, status)
+}
+
+// writeJSONRPC writes a jsonrpc2.Message using the library's encoder to ensure proper serialization.
+func writeJSONRPC(w http.ResponseWriter, msg jsonrpc2.Message) error {
+	w.Header().Set("Content-Type", "application/json")
+	data, err := jsonrpc2.EncodeMessage(msg)
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(data)
+	return err
+}
+
+// idKeyFromID returns a stable string key for a jsonrpc2.ID using its raw value.
+// We prefix with type to avoid collisions between numeric and string IDs.
+func idKeyFromID(id jsonrpc2.ID) string {
+	raw := id.Raw()
+	switch v := raw.(type) {
+	case string:
+		return "s:" + v
+	case float64:
+		// JSON numbers decode to float64
+		return fmt.Sprintf("n:%v", v)
+	case json.Number:
+		return "n:" + v.String()
+	case nil:
+		return "nil"
+	default:
+		return fmt.Sprintf("%T:%v", v, v)
+	}
+}
+
+// compositeKey builds a stable composite key from session ID and request ID key.
+func compositeKey(sessID, idKey string) string {
+	return sessID + "|" + idKey
+}
+
+// isSupportedMCPVersion is intentionally permissive: we accept any present version string.
+// This avoids being pedantic and breaking on new protocol dates while remaining compliant,
+// since this proxy is transport-level and does not depend on specific MCP versions.
+func isSupportedMCPVersion(_ string) bool {
+	return true
+}

--- a/pkg/transport/session/streamable_session.go
+++ b/pkg/transport/session/streamable_session.go
@@ -1,0 +1,76 @@
+package session
+
+import (
+	"errors"
+
+	"golang.org/x/exp/jsonrpc2"
+)
+
+// StreamableSession represents a Streamable HTTP session
+type StreamableSession struct {
+	*ProxySession
+	MessageCh    chan jsonrpc2.Message
+	ResponseCh   chan jsonrpc2.Message
+	disconnected bool
+}
+
+// NewStreamableSession constructs a new streamable session with buffered channels
+func NewStreamableSession(id string) Session {
+	return &StreamableSession{
+		ProxySession: &ProxySession{id: id},
+		MessageCh:    make(chan jsonrpc2.Message, 100),
+		ResponseCh:   make(chan jsonrpc2.Message, 100),
+	}
+}
+
+// Type identifies this as a streamable session
+func (*StreamableSession) Type() SessionType {
+	return SessionTypeStreamable
+}
+
+// GetData exposes buffer stats for observability/debugging
+func (s *StreamableSession) GetData() interface{} {
+	return map[string]int{
+		"message_buffer":  len(s.MessageCh),
+		"response_buffer": len(s.ResponseCh),
+	}
+}
+
+// SetData is a no-op for StreamableSession; channel stats are exposed via GetData.
+func (*StreamableSession) SetData(interface{}) {}
+
+// Disconnect closes channels and marks session as disconnected
+func (s *StreamableSession) Disconnect() {
+	if s.disconnected {
+		return
+	}
+	close(s.MessageCh)
+	close(s.ResponseCh)
+	s.disconnected = true
+}
+
+// SendMessage pushes message to MessageCh
+func (s *StreamableSession) SendMessage(msg jsonrpc2.Message) error {
+	if s.disconnected {
+		return errors.New("session disconnected")
+	}
+	select {
+	case s.MessageCh <- msg:
+		return nil
+	default:
+		return errors.New("message buffer full")
+	}
+}
+
+// SendResponse pushes message to ResponseCh
+func (s *StreamableSession) SendResponse(msg jsonrpc2.Message) error {
+	if s.disconnected {
+		return errors.New("session disconnected")
+	}
+	select {
+	case s.ResponseCh <- msg:
+		return nil
+	default:
+		return errors.New("response buffer full")
+	}
+}

--- a/pkg/transport/stdio.go
+++ b/pkg/transport/stdio.go
@@ -146,9 +146,6 @@ func (t *StdioTransport) Start(ctx context.Context) error {
 	t.mutex.Lock()
 	defer t.mutex.Unlock()
 
-	// logger.Infof("Starting stdio transport with proxy mode: %s", t.proxyMode)
-	fmt.Printf("DEBUG: Starting stdio transport with proxy mode: %s\n", t.proxyMode)
-
 	if t.containerName == "" {
 		return errors.ErrContainerNameNotSet
 	}


### PR DESCRIPTION
## Summary

Refactor the existing Streamable HTTP proxy to improve request/response correlation and add proper session management per MCP specification.

## Changes

### Core Improvements
- **Composite ID Routing**: Implement sessID|idKey routing for reliable request/response correlation across concurrent clients
- **Response Dispatcher**: Extract response dispatching into dedicated dispatcher with waiter-based routing mechanism
- **Session Management**: Introduce proper session management with Manager and StreamableSession types for session lifecycle control

### Spec Compliance
- Implement spec-compliant HTTP method handlers:
  - GET returns 405 (SSE not offered on this endpoint)
  - DELETE properly terminates sessions with 204
  - POST handles single/batch requests and SSE streaming
- Fix session header handling with automatic Mcp-Session-Id assignment on initialize
- Support both synchronous batch processing and async SSE streaming

### Performance & Reliability
- Add 30-second default timeout for response handling
- Implement proper waiter cleanup to prevent memory leaks
- Support concurrent client connections with isolated session contexts

### Testing
- Include comprehensive test coverage with mcp-go client integration
- Add spec compliance tests validating HTTP status codes
- Test concurrent clients and stress scenarios
- Validate session lifecycle management

### Code Quality
- Clean up logging by replacing `fmt.Printf` with proper logger in authz middleware
- Remove debug print statement from stdio transport
- Add proper error handling and context cancellation

## Impact

The refactoring ensures proper message correlation between multiple concurrent clients and container backends while maintaining full MCP specification compliance. This improves reliability for production deployments with multiple simultaneous MCP client connections.

## Testing

- [x] Unit tests pass
- [x] Integration tests with mcp-go client
- [x] Spec compliance tests
- [x] Concurrent client stress tests
- [x] Manual testing with real MCP servers