### PR TITLE
Fix connection and auth issues with Inspector

### DIFF
--- a/cmd/thv/app/inspector/version.go
+++ b/cmd/thv/app/inspector/version.go
@@ -8,4 +8,4 @@ package inspector
 // TODO: https://github.com/modelcontextprotocol/inspector/issues/237
 // Pinning to a specific version for stability. The latest version
 // as of 2025-07-09 broke the inspector command.
-var Image = "npx://@modelcontextprotocol/inspector@0.15.0"
+var Image = "npx://@modelcontextprotocol/inspector@0.16.6"


### PR DESCRIPTION
Fixes #997

This fixes multiple issues with the `thv inspector` command, mostly related to changes introduced with Inspector v0.14.1 and above:

1. Fixes the transport for stdio servers; ToolHive was using the underlying transport when building the Inspector URL instead of sse.

2. Added `HOST=0.0.0.0` env var to the Inspector container; v0.14.1 changed the inspector proxy's binding to 127.0.0.1, fixing the problem where the web interface could not connect through to the container.

3. Inspector also introduced an authentication token which is now required. Added code to generate this (so we know the value), inject it via the `MCP_PROXY_AUTH_TOKEN` env var, and then append it to the generated URL (following the default behavior where the token is generated at startup and printed on the console).

With these fixes, was able to bump Inspector to the latest v0.16.6.

Signed-off-by: Dan Barr <6922515+danbarr@users.noreply.github.com>