### PR TITLE
Fix update-docs-website workflow triggers

### DIFF
--- a/.github/workflows/releaser-helm-charts.yml
+++ b/.github/workflows/releaser-helm-charts.yml
@@ -11,6 +11,9 @@ jobs:
       packages: write
       id-token: write
 
+    outputs:
+      released_charts: ${{ steps.prepare-matrix.outputs.published_charts_matrix }}
+
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
@@ -52,3 +55,36 @@ jobs:
           done
         env:
           COSIGN_EXPERIMENTAL: 1
+
+      - name: Prepare Matrix Output
+        id: prepare-matrix
+        run: |
+          # Build JSON array from chart files
+          json_array="["
+          first=true
+          for chart in `find .cr-release-packages -name '*.tgz' -print`; do
+            file_name=${chart##*/}
+            release_name=${file_name%.tgz}
+            
+            if [ "$first" = true ]; then
+              first=false
+            else
+              json_array="${json_array},"
+            fi
+            json_array="${json_array}\"${release_name}\""
+          done
+          json_array="${json_array}]"
+          echo "published_charts_matrix=${json_array}" >> $GITHUB_OUTPUT
+
+  update-docs-website:
+    name: Trigger Docs Update
+    needs: [ release ]
+    permissions: {}
+    uses: ./.github/workflows/update-docs-website.yml
+    strategy:
+      matrix:
+        version: ${{ fromJSON(needs.release.outputs.released_charts) }}
+    with:
+      version: ${{ matrix.version }}
+    secrets:
+      DOCS_REPO_DISPATCH_TOKEN: ${{ secrets.DOCS_REPO_DISPATCH_TOKEN }}

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -114,6 +114,16 @@ jobs:
       id-token: write
     uses: ./.github/workflows/image-build-and-publish.yml
 
+  update-docs-website:
+    name: Trigger Docs Update
+    needs: [ release ]
+    permissions: {}
+    uses: ./.github/workflows/update-docs-website.yml
+    with:
+      version: ${{ github.ref_name }}
+    secrets:
+      DOCS_REPO_DISPATCH_TOKEN: ${{ secrets.DOCS_REPO_DISPATCH_TOKEN }}
+
 #  provenance:
 #    name: Generate provenance (SLSA3)
 #    needs:

--- a/.github/workflows/run-on-main-charts.yml
+++ b/.github/workflows/run-on-main-charts.yml
@@ -16,3 +16,4 @@ jobs:
       packages: write
       id-token: write
     uses: ./.github/workflows/releaser-helm-charts.yml
+    secrets: inherit # So the releaser workflow can pass a token down to the docs update workflow

--- a/.github/workflows/update-docs-website.yml
+++ b/.github/workflows/update-docs-website.yml
@@ -3,8 +3,15 @@ name: Trigger Docs Update
 permissions: {}
 
 on:
-  release:
-    types: [published]
+  workflow_call:
+    inputs:
+      version:
+        description: 'Version tag for the release'
+        required: true
+        type: string
+    secrets:
+      DOCS_REPO_DISPATCH_TOKEN:
+        required: true
 
 jobs:
   trigger:
@@ -15,7 +22,7 @@ jobs:
         run: |
           repo="stacklok/docs-website"
           event_type="published-release"
-          version="${{ github.event.release.tag_name }}"
+          version="${{ inputs.version }}"
 
           echo "Triggering docs update for $repo with version $version"
   


### PR DESCRIPTION
Changes the update-docs-website workflow to trigger explicitly as a reusable workflow instead of relying on the release event.

This addresses the issue of automatic PRs not being opened for Operator/CRD Helm chart releases since those are created via another workflow's GITHUB_TOKEN.

Fixes stacklok/docs-website#74

The previous attempt, #1477 failed and was reverted because the helm releaser needed `secrets: inherit` passed to it from its own parent (run-on-main-charts.yml), and because the chart-releaser-action output was not as expected. This revision fixes both.

Note for the helm releaser; since chart-releaser-action might process multiple Helm charts in one workflow, I had to build a JSON list of the releases to then matrix the docs update workflow call. It's ugly, but it works.

Signed-off-by: Dan Barr <6922515+danbarr@users.noreply.github.com>