### PR TITLE
Increase session TTL from 30 minutes to 2 hours

### DIFF
--- a/pkg/transport/proxy/httpsse/http_proxy.go
+++ b/pkg/transport/proxy/httpsse/http_proxy.go
@@ -98,7 +98,7 @@ func NewHTTPSSEProxy(
 		containerName:     containerName,
 		shutdownCh:        make(chan struct{}),
 		messageCh:         make(chan jsonrpc2.Message, 100),
-		sessionManager:    session.NewManager(30*time.Minute, sseFactory),
+		sessionManager:    session.NewManager(session.DefaultSessionTTL, sseFactory),
 		pendingMessages:   []*ssecommon.PendingSSEMessage{},
 		prometheusHandler: prometheusHandler,
 		closedClients:     make(map[string]bool),

--- a/pkg/transport/proxy/streamable/streamable_proxy.go
+++ b/pkg/transport/proxy/streamable/streamable_proxy.go
@@ -75,7 +75,7 @@ func NewHTTPProxy(
 		middlewares:       middlewares,
 		messageCh:         make(chan jsonrpc2.Message, 100),
 		responseCh:        make(chan jsonrpc2.Message, 100),
-		sessionManager:    session.NewManager(30*time.Minute, sFactory),
+		sessionManager:    session.NewManager(session.DefaultSessionTTL, sFactory),
 	}
 }
 

--- a/pkg/transport/proxy/transparent/transparent_proxy.go
+++ b/pkg/transport/proxy/transparent/transparent_proxy.go
@@ -99,7 +99,7 @@ func NewTransparentProxy(
 		shutdownCh:        make(chan struct{}),
 		prometheusHandler: prometheusHandler,
 		authInfoHandler:   authInfoHandler,
-		sessionManager:    session.NewManager(30*time.Minute, session.NewProxySession),
+		sessionManager:    session.NewManager(session.DefaultSessionTTL, session.NewProxySession),
 		isRemote:          isRemote,
 		transportType:     transportType,
 	}

--- a/pkg/transport/session/proxy_session.go
+++ b/pkg/transport/session/proxy_session.go
@@ -19,6 +19,11 @@ const (
 	SessionTypeStreamable SessionType = "streamable"
 )
 
+const (
+	// DefaultSessionTTL is the default time-to-live for sessions (2 hours)
+	DefaultSessionTTL = 2 * time.Hour
+)
+
 // ProxySession implements the Session interface for proxy sessions.
 // It now includes support for session types, metadata, and custom data.
 type ProxySession struct {


### PR DESCRIPTION
This PR increases the session time-to-live (TTL) in the proxy session management from 30 minutes to 2 hours to provide better user experience for longer-running sessions.

## Changes Made

- **Add DefaultSessionTTL constant**: Created a new constant in `pkg/transport/session/proxy_session.go` set to 2 hours
- **Update transparent proxy**: Modified `pkg/transport/proxy/transparent/transparent_proxy.go` to use the new constant
- **Update streamable proxy**: Modified `pkg/transport/proxy/streamable/streamable_proxy.go` to use the new constant
- **Update HTTP SSE proxy**: Modified `pkg/transport/proxy/httpsse/http_proxy.go` to use the new constant

## Benefits

- Longer session duration reduces the need for frequent re-authentication
- Centralized constant makes it easy to adjust TTL in the future
- Consistent session management across all proxy types
- Better user experience for long-running operations

## Testing

- All session management tests pass
- All proxy tests pass (transparent, streamable, HTTP SSE)
- Linting passes with 0 issues