### PR TITLE
removes path ignore as it only allows paths on its own

### DIFF
--- a/.github/workflows/run-on-main-charts.yml
+++ b/.github/workflows/run-on-main-charts.yml
@@ -7,10 +7,6 @@ on:
     branches: [ main ]
     paths:
       - deploy/charts/**
-    paths-ignore:
-      - deploy/charts/**/CONTRIBUTING.md
-      - deploy/charts/**/ci/**
-      - deploy/charts/**/CLAUDE.md
 
 jobs:
   publish-charts:

--- a/.github/workflows/run-on-pr-charts.yml
+++ b/.github/workflows/run-on-pr-charts.yml
@@ -8,10 +8,6 @@ on:
   pull_request:
     paths:
       - deploy/charts/**
-    paths-ignore:
-      - deploy/charts/**/CONTRIBUTING.md
-      - deploy/charts/**/ci/**
-      - deploy/charts/**/CLAUDE.md
 
 jobs:
   spellcheck:


### PR DESCRIPTION
both paths and paths-ignore aren't allowed and causes build failures. example https://github.com/stacklok/toolhive/actions/runs/17592909145