### PR TITLE
fix: correct remote path handling in GenerateMCPServerURL

### DIFF
--- a/pkg/transport/url.go
+++ b/pkg/transport/url.go
@@ -11,30 +11,49 @@ import (
 	"github.com/stacklok/toolhive/pkg/transport/types"
 )
 
-// GenerateMCPServerURL generates the URL for an MCP server
-// if remoteURL is provided, remote server path will be used as the path of the proxy
+// GenerateMCPServerURL generates the URL for an MCP server.
+// If remoteURL is provided, the remote server's path will be used as the path of the proxy.
+// For SSE/STDIO transports, a "#<containerName>" fragment is appended.
+// For StreamableHTTP, no fragment is appended.
 func GenerateMCPServerURL(transportType string, host string, port int, containerName, remoteURL string) string {
-	path := ""
+	base := fmt.Sprintf("http://%s:%d", host, port)
+
+	isSSE := transportType == types.TransportTypeSSE.String() || transportType == types.TransportTypeStdio.String()
+	isStreamable := transportType == types.TransportTypeStreamableHTTP.String()
+
+	// ---- Remote path case ----
 	if remoteURL != "" {
 		targetURL, err := url.Parse(remoteURL)
 		if err != nil {
 			logger.Errorf("Failed to parse target URI: %v", err)
 			return ""
 		}
-		path = targetURL.Path
-	}
-	// The URL format is: http://host:port/sse#container-name
-	// Both SSE and STDIO transport types use an SSE proxy
-	if transportType == types.TransportTypeSSE.String() || transportType == types.TransportTypeStdio.String() {
-		if path == "" || path == "/" {
-			path = ssecommon.HTTPSSEEndpoint
+
+		// Use remote path as-is; treat "/" as empty
+		path := targetURL.EscapedPath()
+		if path == "/" {
+			path = ""
 		}
-		return fmt.Sprintf("http://%s:%d%s#%s", host, port, path, containerName)
-	} else if transportType == types.TransportTypeStreamableHTTP.String() {
-		if path == "" || path == "/" {
-			path = "/" + streamable.HTTPStreamableHTTPEndpoint
+
+		if isSSE {
+			return fmt.Sprintf("%s%s#%s", base, path, url.PathEscape(containerName))
 		}
-		return fmt.Sprintf("http://%s:%d%s", host, port, path)
+		if isStreamable {
+			return fmt.Sprintf("%s%s", base, path)
+		}
+		return ""
 	}
+
+	// ---- Local path case (use constants as-is) ----
+	if isSSE {
+		// ssecommon.HTTPSSEEndpoint already includes "/sse"
+		return fmt.Sprintf("%s%s#%s", base, ssecommon.HTTPSSEEndpoint, url.PathEscape(containerName))
+	}
+
+	if isStreamable {
+		// streamable.HTTPStreamableHTTPEndpoint is "mcp"
+		return fmt.Sprintf("%s/%s", base, streamable.HTTPStreamableHTTPEndpoint)
+	}
+
 	return ""
 }

--- a/pkg/transport/url_test.go
+++ b/pkg/transport/url_test.go
@@ -72,7 +72,7 @@ func TestGenerateMCPServerURL(t *testing.T) {
 			port:          12345,
 			containerName: "test-container",
 			targetURI:     "http://example.com",
-			expected:      "http://localhost:12345/sse#test-container",
+			expected:      "http://localhost:12345#test-container",
 		},
 		{
 			name:          "SSE transport with targetURI root path",
@@ -81,7 +81,7 @@ func TestGenerateMCPServerURL(t *testing.T) {
 			port:          12345,
 			containerName: "test-container",
 			targetURI:     "http://example.com/",
-			expected:      "http://localhost:12345/sse#test-container",
+			expected:      "http://localhost:12345#test-container",
 		},
 		// Major targetURI test cases - Streamable HTTP transport
 		{
@@ -100,7 +100,7 @@ func TestGenerateMCPServerURL(t *testing.T) {
 			port:          12345,
 			containerName: "test-container",
 			targetURI:     "http://remote-server.com",
-			expected:      "http://localhost:12345/mcp",
+			expected:      "http://localhost:12345",
 		},
 		{
 			name:          "Streamable HTTP transport with targetURI root path",
@@ -109,7 +109,7 @@ func TestGenerateMCPServerURL(t *testing.T) {
 			port:          12345,
 			containerName: "test-container",
 			targetURI:     "http://remote-server.com/",
-			expected:      "http://localhost:12345/mcp",
+			expected:      "http://localhost:12345",
 		},
 	}
 


### PR DESCRIPTION
## Fix remote path handling in `GenerateMCPServerURL`

This PR updates `GenerateMCPServerURL` to handle remote paths correctly:

- Use remote URL path as-is (`/` normalized to empty).  
- Append `#<containerName>` only for SSE/STDIO.  
- No fragment for StreamableHTTP.  
- Local constants (`/sse`, `mcp`) unchanged.  

### Examples

**SSE / STDIO**
- `http://example.com` → `http://localhost:12345#test-container`  
- `http://example.com/foo` → `http://localhost:12345/foo#test-container`  

**StreamableHTTP**
- `http://example.com` → `http://localhost:12345`  
- `http://example.com/mcp` → `http://localhost:12345/mcp`

This makes remote path handling consistent, avoids injecting local defaults into remote configurations, and ensures correct fragment usage for SSE/STDIO.