### PR TITLE
add missing support for proxy mode in proxy runner

### DIFF
--- a/cmd/thv-operator/api/v1alpha1/mcpserver_types.go
+++ b/cmd/thv-operator/api/v1alpha1/mcpserver_types.go
@@ -16,6 +16,13 @@ type MCPServerSpec struct {
 	// +kubebuilder:default=stdio
 	Transport string `json:"transport,omitempty"`
 
+	// ProxyMode is the proxy mode for stdio transport (sse or streamable-http)
+	// This setting is only used when Transport is "stdio"
+	// +kubebuilder:validation:Enum=sse;streamable-http
+	// +kubebuilder:default=sse
+	// +optional
+	ProxyMode string `json:"proxyMode,omitempty"`
+
 	// Port is the port to expose the MCP server on
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:validation:Maximum=65535

--- a/cmd/thv-operator/controllers/mcpserver_runconfig.go
+++ b/cmd/thv-operator/controllers/mcpserver_runconfig.go
@@ -216,11 +216,18 @@ func (*MCPServerReconciler) createRunConfigFromMCPServer(m *mcpv1alpha1.MCPServe
 		}
 	}
 
+	// Set proxy mode, defaulting to "sse" if not specified
+	proxyMode := m.Spec.ProxyMode
+	if proxyMode == "" {
+		proxyMode = "sse" // Default to SSE for backward compatibility
+	}
+
 	builder := runner.NewOperatorRunConfigBuilder().
 		WithName(m.Name).
 		WithImage(m.Spec.Image).
 		WithCmdArgs(m.Spec.Args).
 		WithTransportAndPorts(m.Spec.Transport, port, int(m.Spec.TargetPort)).
+		WithProxyMode(transporttypes.ProxyMode(proxyMode)).
 		WithHost(proxyHost).
 		WithToolsFilter(m.Spec.ToolsFilter).
 		WithEnvVars(envVars).

--- a/deploy/charts/operator-crds/Chart.yaml
+++ b/deploy/charts/operator-crds/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: toolhive-operator-crds
 description: A Helm chart for installing the ToolHive Operator CRDs into Kubernetes.
 type: application
-version: 0.0.21
+version: 0.0.22
 appVersion: "0.0.1"

--- a/deploy/charts/operator-crds/README.md
+++ b/deploy/charts/operator-crds/README.md
@@ -1,7 +1,7 @@
 
 # ToolHive Operator CRDs Helm Chart
 
-![Version: 0.0.21](https://img.shields.io/badge/Version-0.0.21-informational?style=flat-square)
+![Version: 0.0.22](https://img.shields.io/badge/Version-0.0.22-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for installing the ToolHive Operator CRDs into Kubernetes.

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpservers.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpservers.yaml
@@ -8704,6 +8704,15 @@ spec:
                 maximum: 65535
                 minimum: 1
                 type: integer
+              proxyMode:
+                default: sse
+                description: |-
+                  ProxyMode is the proxy mode for stdio transport (sse or streamable-http)
+                  This setting is only used when Transport is "stdio"
+                enum:
+                - sse
+                - streamable-http
+                type: string
               resourceOverrides:
                 description: ResourceOverrides allows overriding annotations and labels
                   for resources created by the operator

--- a/docs/operator/crd-api.md
+++ b/docs/operator/crd-api.md
@@ -385,6 +385,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `image` _string_ | Image is the container image for the MCP server |  | Required: \{\} <br /> |
 | `transport` _string_ | Transport is the transport method for the MCP server (stdio, streamable-http or sse) | stdio | Enum: [stdio streamable-http sse] <br /> |
+| `proxyMode` _string_ | ProxyMode is the proxy mode for stdio transport (sse or streamable-http)<br />This setting is only used when Transport is "stdio" | sse | Enum: [sse streamable-http] <br /> |
 | `port` _integer_ | Port is the port to expose the MCP server on | 8080 | Maximum: 65535 <br />Minimum: 1 <br /> |
 | `targetPort` _integer_ | TargetPort is the port that MCP server listens to |  | Maximum: 65535 <br />Minimum: 1 <br /> |
 | `args` _string array_ | Args are additional arguments to pass to the MCP server |  |  |

--- a/test/e2e/chainsaw/operator/single-tenancy/test-scenarios/configmap-mode/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/operator/single-tenancy/test-scenarios/configmap-mode/chainsaw-test.yaml
@@ -94,7 +94,12 @@ spec:
             echo "⚠ ConfigMap validation message not found yet (server might still be starting)"
           fi
           
+          # Note: ConfigMap mode currently only validates the ConfigMap but doesn't use it for configuration
+          # The proxy runner still uses default proxy mode (SSE) regardless of ConfigMap content
+          echo "✓ ConfigMap validation working - proxy runner can identify and validate ConfigMap"
+          
           echo "✅ SUCCESS: Pod arguments and logs verified - ConfigMap mode working correctly!"
+          
           echo "Test completed successfully, exiting without waiting for full server startup."
 
   - name: cleanup-configmap-mode


### PR DESCRIPTION
It is covered as part of the runconfig but it was not supported as flag on the proxyrunner itself, while it was supported in run command

Related-to: #1638