### PR TITLE
implement flexible issuer validation for OIDC discovery

### DIFF
--- a/cmd/thv/app/proxy.go
+++ b/cmd/thv/app/proxy.go
@@ -295,14 +295,15 @@ func handleOutgoingAuthentication(ctx context.Context) (*oauth2.TokenSource, *oa
 		}
 
 		flowConfig := &discovery.OAuthFlowConfig{
-			ClientID:     remoteAuthFlags.RemoteAuthClientID,
-			ClientSecret: clientSecret,
-			AuthorizeURL: remoteAuthFlags.RemoteAuthAuthorizeURL,
-			TokenURL:     remoteAuthFlags.RemoteAuthTokenURL,
-			Scopes:       remoteAuthFlags.RemoteAuthScopes,
-			CallbackPort: remoteAuthFlags.RemoteAuthCallbackPort,
-			Timeout:      remoteAuthFlags.RemoteAuthTimeout,
-			SkipBrowser:  remoteAuthFlags.RemoteAuthSkipBrowser,
+			ClientID:       remoteAuthFlags.RemoteAuthClientID,
+			ClientSecret:   clientSecret,
+			AuthorizeURL:   remoteAuthFlags.RemoteAuthAuthorizeURL,
+			TokenURL:       remoteAuthFlags.RemoteAuthTokenURL,
+			Scopes:         remoteAuthFlags.RemoteAuthScopes,
+			CallbackPort:   remoteAuthFlags.RemoteAuthCallbackPort,
+			Timeout:        remoteAuthFlags.RemoteAuthTimeout,
+			SkipBrowser:    remoteAuthFlags.RemoteAuthSkipBrowser,
+			IssuerProvided: remoteAuthFlags.RemoteAuthIssuer != "", // Issuer was explicitly provided
 		}
 
 		result, err := discovery.PerformOAuthFlow(ctx, remoteAuthFlags.RemoteAuthIssuer, flowConfig)
@@ -325,14 +326,15 @@ func handleOutgoingAuthentication(ctx context.Context) (*oauth2.TokenSource, *oa
 
 		// Perform OAuth flow with discovered configuration
 		flowConfig := &discovery.OAuthFlowConfig{
-			ClientID:     remoteAuthFlags.RemoteAuthClientID,
-			ClientSecret: clientSecret,
-			AuthorizeURL: remoteAuthFlags.RemoteAuthAuthorizeURL,
-			TokenURL:     remoteAuthFlags.RemoteAuthTokenURL,
-			Scopes:       remoteAuthFlags.RemoteAuthScopes,
-			CallbackPort: remoteAuthFlags.RemoteAuthCallbackPort,
-			Timeout:      remoteAuthFlags.RemoteAuthTimeout,
-			SkipBrowser:  remoteAuthFlags.RemoteAuthSkipBrowser,
+			ClientID:       remoteAuthFlags.RemoteAuthClientID,
+			ClientSecret:   clientSecret,
+			AuthorizeURL:   remoteAuthFlags.RemoteAuthAuthorizeURL,
+			TokenURL:       remoteAuthFlags.RemoteAuthTokenURL,
+			Scopes:         remoteAuthFlags.RemoteAuthScopes,
+			CallbackPort:   remoteAuthFlags.RemoteAuthCallbackPort,
+			Timeout:        remoteAuthFlags.RemoteAuthTimeout,
+			SkipBrowser:    remoteAuthFlags.RemoteAuthSkipBrowser,
+			IssuerProvided: false, // Issuer was derived from WWW-Authenticate header
 		}
 
 		result, err := discovery.PerformOAuthFlow(ctx, authInfo.Realm, flowConfig)

--- a/pkg/auth/discovery/discovery.go
+++ b/pkg/auth/discovery/discovery.go
@@ -240,15 +240,16 @@ func DeriveIssuerFromURL(remoteURL string) string {
 
 // OAuthFlowConfig contains configuration for performing OAuth flows
 type OAuthFlowConfig struct {
-	ClientID     string
-	ClientSecret string
-	AuthorizeURL string // Manual OAuth endpoint (optional)
-	TokenURL     string // Manual OAuth endpoint (optional)
-	Scopes       []string
-	CallbackPort int
-	Timeout      time.Duration
-	SkipBrowser  bool
-	OAuthParams  map[string]string
+	ClientID       string
+	ClientSecret   string
+	AuthorizeURL   string // Manual OAuth endpoint (optional)
+	TokenURL       string // Manual OAuth endpoint (optional)
+	Scopes         []string
+	CallbackPort   int
+	Timeout        time.Duration
+	SkipBrowser    bool
+	OAuthParams    map[string]string
+	IssuerProvided bool // Whether the issuer was explicitly provided (not derived from URL)
 }
 
 // OAuthFlowResult contains the result of an OAuth flow
@@ -272,7 +273,7 @@ func PerformOAuthFlow(ctx context.Context, issuer string, config *OAuthFlowConfi
 	var oauthConfig *oauth.Config
 	var err error
 	if shouldDynamicallyRegisterClient(config) {
-		discoveredDoc, err := oauth.DiscoverOIDCEndpoints(ctx, issuer)
+		discoveredDoc, err := oauth.DiscoverOIDCEndpoints(ctx, issuer, config.IssuerProvided)
 		if err != nil {
 			return nil, fmt.Errorf("failed to discover registration endpoint: %w", err)
 		}

--- a/pkg/auth/oauth/dynamic_registration_test.go
+++ b/pkg/auth/oauth/dynamic_registration_test.go
@@ -125,7 +125,7 @@ func TestDiscoverOIDCEndpointsWithRegistration(t *testing.T) {
 				issuer = server.URL
 			}
 
-			result, err := DiscoverOIDCEndpoints(context.Background(), issuer)
+			result, err := DiscoverOIDCEndpoints(context.Background(), issuer, false)
 
 			if tt.expectedError {
 				assert.Error(t, err)

--- a/pkg/runner/remote_auth.go
+++ b/pkg/runner/remote_auth.go
@@ -40,6 +40,7 @@ func (h *RemoteAuthHandler) Authenticate(ctx context.Context, remoteURL string) 
 		// Handle OAuth authentication
 		if authInfo.Type == "OAuth" {
 			issuer := h.config.Issuer
+			issuerProvided := issuer != ""
 			if issuer == "" {
 				issuer = discovery.DeriveIssuerFromURL(remoteURL)
 			}
@@ -51,15 +52,16 @@ func (h *RemoteAuthHandler) Authenticate(ctx context.Context, remoteURL string) 
 
 			// Create OAuth flow config from RemoteAuthConfig
 			flowConfig := &discovery.OAuthFlowConfig{
-				ClientID:     h.config.ClientID,
-				ClientSecret: h.config.ClientSecret,
-				AuthorizeURL: h.config.AuthorizeURL,
-				TokenURL:     h.config.TokenURL,
-				Scopes:       h.config.Scopes,
-				CallbackPort: h.config.CallbackPort,
-				Timeout:      h.config.Timeout,
-				SkipBrowser:  h.config.SkipBrowser,
-				OAuthParams:  h.config.OAuthParams,
+				ClientID:       h.config.ClientID,
+				ClientSecret:   h.config.ClientSecret,
+				AuthorizeURL:   h.config.AuthorizeURL,
+				TokenURL:       h.config.TokenURL,
+				Scopes:         h.config.Scopes,
+				CallbackPort:   h.config.CallbackPort,
+				Timeout:        h.config.Timeout,
+				SkipBrowser:    h.config.SkipBrowser,
+				OAuthParams:    h.config.OAuthParams,
+				IssuerProvided: issuerProvided,
 			}
 
 			result, err := discovery.PerformOAuthFlow(ctx, issuer, flowConfig)


### PR DESCRIPTION
When using dynamic client registration with some MCP servers, the system was failing with "issuer mismatch" errors because:

The issuer was derived from the MCP server URL.
- The OIDC discovery document returned a different issuer.
- The system performed strict issuer validation even for derived issuers.