### PR TITLE
Ensure that container lookup is done by container name

### DIFF
--- a/pkg/container/docker/client.go
+++ b/pkg/container/docker/client.go
@@ -1513,12 +1513,9 @@ func dockerToDomainStatus(status string) runtime.WorkloadStatus {
 	return runtime.WorkloadStatusUnknown
 }
 
-// inspectContainerByName finds a container by the workload name and inspects it.
-// It first tries to find by base name label, then falls back to exact name matching.
-func (c *Client) inspectContainerByName(ctx context.Context, workloadName string) (container.InspectResponse, error) {
-	empty := container.InspectResponse{}
-
-	// First try to find container by base name label
+// findContainerByLabel finds a container by the base name label.
+// Returns the container ID if found, empty string otherwise.
+func (c *Client) findContainerByLabel(ctx context.Context, workloadName string) (string, error) {
 	filterArgs := filters.NewArgs()
 	filterArgs.Add("label", "toolhive=true")
 	filterArgs.Add("label", fmt.Sprintf("toolhive-basename=%s", workloadName))
@@ -1528,42 +1525,48 @@ func (c *Client) inspectContainerByName(ctx context.Context, workloadName string
 		Filters: filterArgs,
 	})
 	if err != nil {
-		return empty, NewContainerError(err, "", fmt.Sprintf("failed to list containers: %v", err))
+		return "", NewContainerError(err, "", fmt.Sprintf("failed to list containers: %v", err))
 	}
 
-	// If found by base name label, use it
-	if len(containers) > 0 {
-		// If multiple containers have the same base name, prefer the running one
-		var containerID string
-		for _, cont := range containers {
-			if cont.State == "running" {
-				containerID = cont.ID
-				break
-			}
-		}
-		// If no running container found, use the first one
-		if containerID == "" {
-			containerID = containers[0].ID
-		}
-		return c.client.ContainerInspect(ctx, containerID)
+	if len(containers) == 0 {
+		return "", nil
 	}
 
-	// Fall back to exact name matching for backward compatibility
-	filterArgs = filters.NewArgs()
+	// If multiple containers have the same base name, prefer the running one
+	var containerID string
+	for _, cont := range containers {
+		if cont.State == "running" {
+			containerID = cont.ID
+			break
+		}
+	}
+	// If no running container found, use the first one
+	if containerID == "" {
+		containerID = containers[0].ID
+	}
+
+	return containerID, nil
+}
+
+// findContainerByExactName finds a container by exact name matching.
+// Returns the container ID if found, empty string otherwise.
+func (c *Client) findContainerByExactName(ctx context.Context, workloadName string) (string, error) {
+	filterArgs := filters.NewArgs()
 	filterArgs.Add("label", "toolhive=true")
 	filterArgs.Add("name", workloadName)
 
-	containers, err = c.client.ContainerList(ctx, container.ListOptions{
+	containers, err := c.client.ContainerList(ctx, container.ListOptions{
 		All:     true,
 		Filters: filterArgs,
 	})
 	if err != nil {
-		return empty, NewContainerError(err, "", fmt.Sprintf("failed to list containers: %v", err))
+		return "", NewContainerError(err, "", fmt.Sprintf("failed to list containers: %v", err))
 	}
 
 	if len(containers) == 0 {
-		return empty, NewContainerError(runtime.ErrWorkloadNotFound, workloadName, "no containers found")
+		return "", nil
 	}
+
 	// Docker does a prefix match on the name. If we find multiple containers,
 	// we need to filter down to the exact name requested.
 	var containerID string
@@ -1578,11 +1581,37 @@ func (c *Client) inspectContainerByName(ctx context.Context, workloadName string
 			return slices.Contains(c.Names, prefixedName)
 		})
 		if idx == -1 {
-			return empty, NewContainerError(runtime.ErrWorkloadNotFound, workloadName, "no containers found with the exact name")
+			return "", nil
 		}
 		containerID = containers[idx].ID
 	} else {
 		containerID = containers[0].ID
+	}
+
+	return containerID, nil
+}
+
+// inspectContainerByName finds a container by the workload name and inspects it.
+// It first tries to find by base name label, then falls back to exact name matching.
+func (c *Client) inspectContainerByName(ctx context.Context, workloadName string) (container.InspectResponse, error) {
+	empty := container.InspectResponse{}
+
+	// First try to find container by base name label
+	containerID, err := c.findContainerByLabel(ctx, workloadName)
+	if err != nil {
+		return empty, err
+	}
+	if containerID != "" {
+		return c.client.ContainerInspect(ctx, containerID)
+	}
+
+	// Fall back to exact name matching for backward compatibility
+	containerID, err = c.findContainerByExactName(ctx, workloadName)
+	if err != nil {
+		return empty, err
+	}
+	if containerID == "" {
+		return empty, NewContainerError(runtime.ErrWorkloadNotFound, workloadName, "no containers found")
 	}
 
 	return c.client.ContainerInspect(ctx, containerID)


### PR DESCRIPTION
Following on from yesterday's changes, we can encounter situations where the container is looked up using the workload name instead of the container name. If we cannot find the container by workload name, attempt to find a container with the workload name set in the labels.