### PR TITLE
Fix OAuth issuer discovery to comply with RFC 8414 and RFC 9728

### DIFF
--- a/pkg/auth/discovery/discovery_test.go
+++ b/pkg/auth/discovery/discovery_test.go
@@ -159,41 +159,52 @@ func TestExtractParameter(t *testing.T) {
 	}
 }
 
-func TestDeriveIssuerFromURL(t *testing.T) {
+func TestDeriveIssuerFromRealm(t *testing.T) {
 	t.Parallel()
+
 	tests := []struct {
 		name     string
-		url      string
+		realm    string
 		expected string
 	}{
 		{
-			name:     "https url",
-			url:      "https://example.com/api",
+			name:     "valid https issuer url",
+			realm:    "https://example.com",
 			expected: "https://example.com",
 		},
 		{
-			name:     "http url",
-			url:      "http://localhost:8080/api",
-			expected: "https://localhost",
+			name:     "https url with path",
+			realm:    "https://api.example.com/v1",
+			expected: "https://api.example.com/v1",
 		},
 		{
-			name:     "url with path",
-			url:      "https://api.example.com/v1/endpoint",
-			expected: "https://api.example.com",
-		},
-		{
-			name:     "url with query params",
-			url:      "https://example.com/api?param=value",
+			name:     "https url with query params (should be removed)",
+			realm:    "https://example.com?param=value",
 			expected: "https://example.com",
 		},
 		{
-			name:     "invalid url",
-			url:      "not-a-url",
+			name:     "https url with fragment (should be removed)",
+			realm:    "https://example.com#fragment",
+			expected: "https://example.com",
+		},
+		{
+			name:     "http url (not valid for issuer)",
+			realm:    "http://example.com",
 			expected: "",
 		},
 		{
-			name:     "empty url",
-			url:      "",
+			name:     "non-url realm string",
+			realm:    "MyRealm",
+			expected: "",
+		},
+		{
+			name:     "invalid url",
+			realm:    "not-a-url",
+			expected: "",
+		},
+		{
+			name:     "empty realm",
+			realm:    "",
 			expected: "",
 		},
 	}
@@ -201,14 +212,13 @@ func TestDeriveIssuerFromURL(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			result := DeriveIssuerFromURL(tt.url)
+			result := DeriveIssuerFromRealm(tt.realm)
 			if result != tt.expected {
-				t.Errorf("DeriveIssuerFromURL() = %v, want %v", result, tt.expected)
+				t.Errorf("DeriveIssuerFromRealm() = %v, want %v", result, tt.expected)
 			}
 		})
 	}
 }
-
 func TestDetectAuthenticationFromServer(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/pkg/auth/discovery/resource_metadata_test.go
+++ b/pkg/auth/discovery/resource_metadata_test.go
@@ -1,0 +1,382 @@
+package discovery
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stacklok/toolhive/pkg/auth"
+)
+
+func TestFetchResourceMetadata(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		serverResponse interface{}
+		serverStatus   int
+		contentType    string
+		expectedError  bool
+		validateFunc   func(*testing.T, *auth.RFC9728AuthInfo)
+	}{
+		{
+			name: "valid resource metadata",
+			serverResponse: auth.RFC9728AuthInfo{
+				Resource:               "https://resource.example.com",
+				AuthorizationServers:   []string{"https://auth.example.com"},
+				ScopesSupported:        []string{"read", "write"},
+				BearerMethodsSupported: []string{"header"},
+			},
+			serverStatus:  http.StatusOK,
+			contentType:   "application/json",
+			expectedError: false,
+			validateFunc: func(t *testing.T, metadata *auth.RFC9728AuthInfo) {
+				t.Helper()
+
+				assert.Equal(t, "https://resource.example.com", metadata.Resource)
+				assert.Len(t, metadata.AuthorizationServers, 1)
+				assert.Len(t, metadata.ScopesSupported, 2)
+			},
+		},
+		{
+			name: "metadata with multiple authorization servers",
+			serverResponse: auth.RFC9728AuthInfo{
+				Resource: "https://resource.example.com",
+				AuthorizationServers: []string{
+					"https://auth1.example.com",
+					"https://auth2.example.com",
+				},
+			},
+			serverStatus:  http.StatusOK,
+			contentType:   "application/json",
+			expectedError: false,
+			validateFunc: func(t *testing.T, metadata *auth.RFC9728AuthInfo) {
+				t.Helper()
+
+				assert.Len(t, metadata.AuthorizationServers, 2)
+			},
+		},
+		{
+			name: "missing resource field",
+			serverResponse: map[string]interface{}{
+				"authorization_servers": []string{"https://auth.example.com"},
+			},
+			serverStatus:  http.StatusOK,
+			contentType:   "application/json",
+			expectedError: true,
+		},
+		{
+			name:           "server returns 404",
+			serverResponse: "Not Found",
+			serverStatus:   http.StatusNotFound,
+			contentType:    "text/plain",
+			expectedError:  true,
+		},
+		{
+			name:           "server returns wrong content type",
+			serverResponse: "Not JSON",
+			serverStatus:   http.StatusOK,
+			contentType:    "text/html",
+			expectedError:  true,
+		},
+		{
+			name:           "invalid JSON response",
+			serverResponse: "{ invalid json",
+			serverStatus:   http.StatusOK,
+			contentType:    "application/json",
+			expectedError:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Create test server - use regular HTTP for localhost (allowed by our validation)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", tt.contentType)
+				w.WriteHeader(tt.serverStatus)
+
+				switch v := tt.serverResponse.(type) {
+				case string:
+					w.Write([]byte(v))
+				default:
+					json.NewEncoder(w).Encode(v)
+				}
+			}))
+			defer server.Close()
+
+			// Replace http with https in the URL to simulate a real HTTPS server
+			// but use localhost which is allowed to bypass HTTPS requirement
+			testURL := strings.Replace(server.URL, "http://", "https://", 1)
+
+			// For testing, we need to actually use localhost HTTP since we can't easily
+			// create a valid HTTPS test server. The function allows localhost to use HTTP.
+			if strings.Contains(server.URL, "127.0.0.1") {
+				testURL = server.URL // Keep it as HTTP for localhost
+			}
+
+			// Test the function
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+
+			metadata, err := FetchResourceMetadata(ctx, testURL)
+
+			if tt.expectedError {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				if tt.validateFunc != nil && metadata != nil {
+					tt.validateFunc(t, metadata)
+				}
+			}
+		})
+	}
+}
+
+func TestFetchResourceMetadata_InvalidURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		metadataURL string
+	}{
+		{
+			name:        "empty URL",
+			metadataURL: "",
+		},
+		{
+			name:        "invalid URL",
+			metadataURL: "not-a-url",
+		},
+		{
+			name:        "http URL (not HTTPS)",
+			metadataURL: "http://example.com/.well-known/oauth-protected-resource",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			_, err := FetchResourceMetadata(ctx, tt.metadataURL)
+			assert.Error(t, err, "Expected error for URL %s", tt.metadataURL)
+		})
+	}
+}
+
+func TestValidateAndDiscoverAuthServer(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		serverPath     string
+		serverResponse interface{}
+		serverStatus   int
+		contentType    string
+		expectedIssuer string
+		expectedError  bool
+	}{
+		{
+			name:       "valid authorization server with matching issuer",
+			serverPath: "/.well-known/oauth-authorization-server",
+			serverResponse: map[string]interface{}{
+				"issuer":                 "https://auth.example.com",
+				"authorization_endpoint": "https://auth.example.com/authorize",
+				"token_endpoint":         "https://auth.example.com/token",
+			},
+			serverStatus:   http.StatusOK,
+			contentType:    "application/json",
+			expectedIssuer: "https://auth.example.com",
+			expectedError:  false,
+		},
+		{
+			name:       "authorization server with different issuer (Stripe case)",
+			serverPath: "/.well-known/oauth-authorization-server",
+			serverResponse: map[string]interface{}{
+				"issuer":                 "https://marketplace.stripe.com",
+				"authorization_endpoint": "https://marketplace.stripe.com/oauth/v2/authorize",
+				"token_endpoint":         "https://marketplace.stripe.com/oauth/v2/token",
+				"registration_endpoint":  "https://marketplace.stripe.com/oauth/v2/register",
+			},
+			serverStatus:   http.StatusOK,
+			contentType:    "application/json",
+			expectedIssuer: "https://marketplace.stripe.com",
+			expectedError:  false,
+		},
+		{
+			name:           "server returns 404",
+			serverPath:     "/.well-known/oauth-authorization-server",
+			serverResponse: "Not Found",
+			serverStatus:   http.StatusNotFound,
+			contentType:    "text/plain",
+			expectedError:  true,
+		},
+		{
+			name:       "missing required fields",
+			serverPath: "/.well-known/oauth-authorization-server",
+			serverResponse: map[string]interface{}{
+				"issuer": "https://auth.example.com",
+				// Missing authorization_endpoint and token_endpoint
+			},
+			serverStatus:  http.StatusOK,
+			contentType:   "application/json",
+			expectedError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Create test server - use regular HTTP for localhost (allowed by our validation)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != tt.serverPath && r.URL.Path != "/.well-known/openid-configuration" {
+					w.WriteHeader(http.StatusNotFound)
+					return
+				}
+
+				w.Header().Set("Content-Type", tt.contentType)
+				w.WriteHeader(tt.serverStatus)
+
+				switch v := tt.serverResponse.(type) {
+				case string:
+					w.Write([]byte(v))
+				default:
+					json.NewEncoder(w).Encode(v)
+				}
+			}))
+			defer server.Close()
+
+			// For testing with localhost, we can use HTTP
+			testURL := server.URL
+
+			// Test the function
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+
+			authInfo, err := ValidateAndDiscoverAuthServer(ctx, testURL)
+
+			if tt.expectedError {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				if authInfo != nil {
+					assert.Equal(t, tt.expectedIssuer, authInfo.Issuer)
+				}
+			}
+		})
+	}
+}
+
+func TestParseWWWAuthenticate_WithResourceMetadata(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                     string
+		header                   string
+		expectedType             string
+		expectedRealm            string
+		expectedResourceMetadata string
+		expectedError            bool
+	}{
+		{
+			name:                     "bearer with resource_metadata",
+			header:                   `Bearer resource_metadata="https://mcp.stripe.com/.well-known/oauth-protected-resource"`,
+			expectedType:             "OAuth",
+			expectedResourceMetadata: "https://mcp.stripe.com/.well-known/oauth-protected-resource",
+			expectedError:            false,
+		},
+		{
+			name:                     "bearer with realm and resource_metadata",
+			header:                   `Bearer realm="https://auth.example.com", resource_metadata="https://resource.example.com/.well-known/oauth-protected-resource"`,
+			expectedType:             "OAuth",
+			expectedRealm:            "https://auth.example.com",
+			expectedResourceMetadata: "https://resource.example.com/.well-known/oauth-protected-resource",
+			expectedError:            false,
+		},
+		{
+			name:          "bearer with error and error_description",
+			header:        `Bearer error="invalid_token", error_description="The access token expired"`,
+			expectedType:  "OAuth",
+			expectedError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			authInfo, err := ParseWWWAuthenticate(tt.header)
+
+			if tt.expectedError {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, authInfo)
+				assert.Equal(t, tt.expectedType, authInfo.Type)
+				assert.Equal(t, tt.expectedRealm, authInfo.Realm)
+				assert.Equal(t, tt.expectedResourceMetadata, authInfo.ResourceMetadata)
+			}
+		})
+	}
+}
+
+func TestExtractParameter_EdgeCases(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		params    string
+		paramName string
+		expected  string
+	}{
+		{
+			name:      "parameter with escaped quotes",
+			params:    `realm="My \"Quoted\" Realm"`,
+			paramName: "realm",
+			expected:  `My "Quoted" Realm`,
+		},
+		{
+			name:      "parameter at end without comma",
+			params:    `realm="https://auth.example.com"`,
+			paramName: "realm",
+			expected:  "https://auth.example.com",
+		},
+		{
+			name:      "unquoted parameter",
+			params:    `max_age=3600`,
+			paramName: "max_age",
+			expected:  "3600",
+		},
+		{
+			name:      "mixed quoted and unquoted",
+			params:    `realm="https://auth.example.com", max_age=3600, scope="read write"`,
+			paramName: "scope",
+			expected:  "read write",
+		},
+		{
+			name:      "parameter with equals in value",
+			params:    `resource_metadata="https://example.com?param=value"`,
+			paramName: "resource_metadata",
+			expected:  "https://example.com?param=value",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := ExtractParameter(tt.params, tt.paramName)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/pkg/runner/remote_auth.go
+++ b/pkg/runner/remote_auth.go
@@ -39,12 +39,10 @@ func (h *RemoteAuthHandler) Authenticate(ctx context.Context, remoteURL string) 
 
 		// Handle OAuth authentication
 		if authInfo.Type == "OAuth" {
-			issuer := h.config.Issuer
-			if issuer == "" {
-				issuer = discovery.DeriveIssuerFromURL(remoteURL)
-			}
-			if issuer == "" {
-				return nil, fmt.Errorf("could not determine OAuth issuer from realm or URL")
+			// Discover the issuer and potentially update scopes
+			issuer, scopes, authServerInfo, err := h.discoverIssuerAndScopes(ctx, authInfo)
+			if err != nil {
+				return nil, err
 			}
 
 			logger.Infof("Starting OAuth authentication flow with issuer: %s", issuer)
@@ -55,11 +53,21 @@ func (h *RemoteAuthHandler) Authenticate(ctx context.Context, remoteURL string) 
 				ClientSecret: h.config.ClientSecret,
 				AuthorizeURL: h.config.AuthorizeURL,
 				TokenURL:     h.config.TokenURL,
-				Scopes:       h.config.Scopes,
+				Scopes:       scopes,
 				CallbackPort: h.config.CallbackPort,
 				Timeout:      h.config.Timeout,
 				SkipBrowser:  h.config.SkipBrowser,
 				OAuthParams:  h.config.OAuthParams,
+			}
+
+			// If we have discovered endpoints from the authorization server metadata,
+			// use them instead of trying to discover them again
+			if authServerInfo != nil && h.config.AuthorizeURL == "" && h.config.TokenURL == "" {
+				flowConfig.AuthorizeURL = authServerInfo.AuthorizationURL
+				flowConfig.TokenURL = authServerInfo.TokenURL
+				flowConfig.RegistrationEndpoint = authServerInfo.RegistrationEndpoint
+				logger.Infof("Using discovered OAuth endpoints - authorize: %s, token: %s, registration: %s",
+					authServerInfo.AuthorizationURL, authServerInfo.TokenURL, authServerInfo.RegistrationEndpoint)
 			}
 
 			result, err := discovery.PerformOAuthFlow(ctx, issuer, flowConfig)
@@ -76,4 +84,95 @@ func (h *RemoteAuthHandler) Authenticate(ctx context.Context, remoteURL string) 
 	}
 
 	return nil, nil // No authentication required
+}
+
+// discoverIssuerAndScopes attempts to discover the OAuth issuer and scopes from various sources
+// following RFC 8414 and RFC 9728 standards
+func (h *RemoteAuthHandler) discoverIssuerAndScopes(
+	ctx context.Context,
+	authInfo *discovery.AuthInfo,
+) (string, []string, *discovery.AuthServerInfo, error) {
+	// Priority 1: Use configured issuer if available
+	if h.config.Issuer != "" {
+		logger.Debugf("Using configured issuer: %s", h.config.Issuer)
+		return h.config.Issuer, h.config.Scopes, nil, nil
+	}
+
+	// Priority 2: Try to derive from realm (RFC 8414)
+	if authInfo.Realm != "" {
+		derivedIssuer := discovery.DeriveIssuerFromRealm(authInfo.Realm)
+		if derivedIssuer != "" {
+			logger.Infof("Derived issuer from realm: %s", derivedIssuer)
+			return derivedIssuer, h.config.Scopes, nil, nil
+		}
+	}
+
+	// Priority 3: Fetch from resource metadata (RFC 9728)
+	if authInfo.ResourceMetadata != "" {
+		return h.tryDiscoverFromResourceMetadata(ctx, authInfo.ResourceMetadata)
+	}
+
+	// No issuer could be determined
+	return "", nil, nil, fmt.Errorf("could not determine OAuth issuer. Please provide issuer in configuration, " +
+		"or ensure the server provides a valid realm parameter or resource_metadata URL in the WWW-Authenticate header")
+}
+
+// tryDiscoverFromResourceMetadata attempts to discover issuer and scopes from resource metadata
+func (h *RemoteAuthHandler) tryDiscoverFromResourceMetadata(
+	ctx context.Context,
+	resourceMetadataURL string,
+) (string, []string, *discovery.AuthServerInfo, error) {
+	logger.Infof("Fetching resource metadata from: %s", resourceMetadataURL)
+
+	metadata, err := discovery.FetchResourceMetadata(ctx, resourceMetadataURL)
+	if err != nil {
+		logger.Debugf("Failed to fetch resource metadata: %v", err)
+		return "", nil, nil, fmt.Errorf("could not determine OAuth issuer")
+	}
+
+	if metadata == nil {
+		return "", nil, nil, fmt.Errorf("could not determine OAuth issuer")
+	}
+
+	// Try to find a valid authorization server from the list
+	authServerInfo, issuer := h.findValidAuthServer(ctx, metadata.AuthorizationServers)
+	if authServerInfo == nil {
+		if len(metadata.AuthorizationServers) > 0 {
+			logger.Warnf("Resource metadata contained authorization_servers, " +
+				"but none could be validated as actual OAuth authorization servers")
+		}
+		return "", nil, nil, fmt.Errorf("could not determine OAuth issuer")
+	}
+
+	// Determine scopes - use configured or fall back to metadata
+	scopes := h.config.Scopes
+	if len(scopes) == 0 && len(metadata.ScopesSupported) > 0 {
+		scopes = metadata.ScopesSupported
+		logger.Infof("Using scopes from resource metadata: %v", scopes)
+	}
+
+	return issuer, scopes, authServerInfo, nil
+}
+
+// findValidAuthServer validates authorization servers and returns the first valid one
+func (*RemoteAuthHandler) findValidAuthServer(
+	ctx context.Context,
+	authServers []string,
+) (*discovery.AuthServerInfo, string) {
+	for _, authServer := range authServers {
+		logger.Debugf("Validating authorization server: %s", authServer)
+
+		authServerInfo, err := discovery.ValidateAndDiscoverAuthServer(ctx, authServer)
+		if err != nil {
+			logger.Debugf("Authorization server validation failed for %s: %v", authServer, err)
+			continue
+		}
+
+		// Found a valid authorization server
+		logger.Infof("Using validated authorization server: %s (actual issuer: %s)",
+			authServer, authServerInfo.Issuer)
+		return authServerInfo, authServerInfo.Issuer
+	}
+
+	return nil, ""
 }


### PR DESCRIPTION
- Add support for RFC 9728 Protected Resource Metadata discovery
- Fix issuer detection to properly handle cases where the metadata URL differs from the actual issuer (e.g., Stripe's case)
- Add resource_metadata parameter parsing from WWW-Authenticate header
- Implement FetchResourceMetadata to retrieve protected resource metadata
- Add ValidateAndDiscoverAuthServer to handle issuer validation and discovery
- Update OAuth flow to use pre-discovered endpoints when available
- Fix DeriveIssuerFromRealm to validate realm as a proper HTTPS URL
- Add DiscoverActualIssuer in OIDC package to handle issuer mismatch cases
- Add workaround for resource metadata that incorrectly lists authorization servers that don't match the actual issuer (validates each server and uses the discovered issuer)

This fixes the bug where issuer detection was incorrectly trying to derive
the issuer from the remote URL instead of using the realm parameter or
fetching resource metadata as specified in the RFCs.

The implementation now properly handles edge cases like Stripe's where the
resource metadata URL hosts the authorization server metadata but the actual
issuer identifier is different.
