### PR TITLE
Drop patch coverage check in codecov

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -11,3 +11,5 @@ coverage:
     - "test/e2e"
     - "deploy"
     - "*/mocks/*"
+  status:
+    patch: false


### PR DESCRIPTION
This causes many PRs to be marked as red, and to be honest, I don't think it's a useful quality gate.