### PR TITLE
Add Docker runtime unit tests for monitor, squid config, and helpers

### DIFF
--- a/pkg/container/docker/client_config_test.go
+++ b/pkg/container/docker/client_config_test.go
@@ -1,0 +1,263 @@
+package docker
+
+import (
+	"testing"
+
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/mount"
+	"github.com/docker/go-connections/nat"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stacklok/toolhive/pkg/container/runtime"
+)
+
+func TestSetupExposedPorts_SetsPorts(t *testing.T) {
+	t.Parallel()
+
+	cfg := &container.Config{}
+	exposed := map[string]struct{}{
+		"8080/tcp": {},
+		"9090/tcp": {},
+	}
+
+	err := setupExposedPorts(cfg, exposed)
+	require.NoError(t, err)
+	require.NotNil(t, cfg.ExposedPorts)
+
+	p8080, err := nat.NewPort("tcp", "8080")
+	require.NoError(t, err)
+	p9090, err := nat.NewPort("tcp", "9090")
+	require.NoError(t, err)
+
+	assert.Contains(t, cfg.ExposedPorts, p8080)
+	assert.Contains(t, cfg.ExposedPorts, p9090)
+	assert.Len(t, cfg.ExposedPorts, 2)
+}
+
+func TestSetupExposedPorts_EmptyNoChange(t *testing.T) {
+	t.Parallel()
+
+	cfg := &container.Config{}
+	err := setupExposedPorts(cfg, map[string]struct{}{})
+	require.NoError(t, err)
+	// No ports set at all
+	assert.Nil(t, cfg.ExposedPorts)
+}
+
+func TestSetupPortBindings_SetsBindings(t *testing.T) {
+	t.Parallel()
+
+	hostCfg := &container.HostConfig{}
+	bindings := map[string][]runtime.PortBinding{
+		"8080/tcp": {
+			{HostIP: "127.0.0.1", HostPort: "8081"},
+			{HostIP: "", HostPort: "8082"},
+		},
+	}
+
+	err := setupPortBindings(hostCfg, bindings)
+	require.NoError(t, err)
+
+	require.NotNil(t, hostCfg.PortBindings)
+	p8080, err := nat.NewPort("tcp", "8080")
+	require.NoError(t, err)
+
+	got, ok := hostCfg.PortBindings[p8080]
+	require.True(t, ok)
+	require.Len(t, got, 2)
+	assert.Equal(t, nat.PortBinding{HostIP: "127.0.0.1", HostPort: "8081"}, got[0])
+	assert.Equal(t, nat.PortBinding{HostIP: "", HostPort: "8082"}, got[1])
+}
+
+func TestConvertMounts_BindMounts(t *testing.T) {
+	t.Parallel()
+
+	in := []runtime.Mount{
+		{Source: "/src1", Target: "/dst1", ReadOnly: true},
+		{Source: "/src2", Target: "/dst2", ReadOnly: false},
+	}
+	out := convertMounts(in)
+
+	require.Len(t, out, 2)
+	assert.Equal(t, mount.TypeBind, out[0].Type)
+	assert.Equal(t, "/src1", out[0].Source)
+	assert.Equal(t, "/dst1", out[0].Target)
+	assert.Equal(t, true, out[0].ReadOnly)
+
+	assert.Equal(t, mount.TypeBind, out[1].Type)
+	assert.Equal(t, "/src2", out[1].Source)
+	assert.Equal(t, "/dst2", out[1].Target)
+	assert.Equal(t, false, out[1].ReadOnly)
+}
+
+func TestCompareEnvVars_SubsetMatches(t *testing.T) {
+	t.Parallel()
+
+	existing := []string{"A=a", "B=b"}
+	desired := []string{"A=a"} // subset must be OK
+	assert.True(t, compareEnvVars(existing, desired))
+
+	assert.False(t, compareEnvVars(existing, []string{"A=x"}))   // wrong value
+	assert.False(t, compareEnvVars(existing, []string{"C=c"}))   // missing key
+	assert.True(t, compareEnvVars(existing, []string{}))         // empty desired OK
+	assert.True(t, compareEnvVars(existing, existing))           // exact match OK
+	assert.True(t, compareEnvVars([]string{"A=a"}, []string{}))  // empty desired
+	assert.False(t, compareEnvVars([]string{}, []string{"A=a"})) // desired not subset
+}
+
+func TestCompareLabels_SubsetMatches(t *testing.T) {
+	t.Parallel()
+
+	existing := map[string]string{"k1": "v1", "k2": "v2"}
+	assert.True(t, compareLabels(existing, map[string]string{"k1": "v1"})) // subset
+	assert.False(t, compareLabels(existing, map[string]string{"k1": "x"})) // wrong value
+	assert.False(t, compareLabels(existing, map[string]string{"k3": "v3"}))
+	assert.True(t, compareLabels(existing, map[string]string{})) // empty desired OK
+}
+
+func TestCompareHostConfig_EqualAndMismatch(t *testing.T) {
+	t.Parallel()
+
+	existing := &container.InspectResponse{
+		ContainerJSONBase: &container.ContainerJSONBase{
+			HostConfig: &container.HostConfig{
+				NetworkMode:   "bridge",
+				CapAdd:        []string{"CAP_A"},
+				CapDrop:       []string{"ALL"},
+				SecurityOpt:   []string{"seccomp:unconfined"},
+				Privileged:    false,
+				RestartPolicy: container.RestartPolicy{Name: "unless-stopped"},
+			},
+		},
+	}
+
+	desired := &container.HostConfig{
+		NetworkMode:   "bridge",
+		CapAdd:        []string{"CAP_A"},
+		CapDrop:       []string{"ALL"},
+		SecurityOpt:   []string{"seccomp:unconfined"},
+		Privileged:    false,
+		RestartPolicy: container.RestartPolicy{Name: "unless-stopped"},
+	}
+
+	assert.True(t, compareHostConfig(existing, desired))
+
+	desired.Privileged = true
+	assert.False(t, compareHostConfig(existing, desired))
+}
+
+func TestComparePortConfig_EqualAndMismatch(t *testing.T) {
+	t.Parallel()
+
+	// Build desired
+	desiredCfg := &container.Config{}
+	require.NoError(t, setupExposedPorts(desiredCfg, map[string]struct{}{
+		"8080/tcp": {},
+	}))
+	desiredHost := &container.HostConfig{}
+	require.NoError(t, setupPortBindings(desiredHost, map[string][]runtime.PortBinding{
+		"8080/tcp": {{HostIP: "0.0.0.0", HostPort: "18080"}},
+	}))
+
+	// Build existing to match desired
+	p8080, err := nat.NewPort("tcp", "8080")
+	require.NoError(t, err)
+
+	existing := &container.InspectResponse{
+		Config: &container.Config{
+			ExposedPorts: nat.PortSet{p8080: {}},
+		},
+		ContainerJSONBase: &container.ContainerJSONBase{
+			HostConfig: &container.HostConfig{
+				PortBindings: nat.PortMap{
+					p8080: []nat.PortBinding{{HostIP: "0.0.0.0", HostPort: "18080"}},
+				},
+			},
+		},
+	}
+
+	assert.True(t, comparePortConfig(existing, desiredCfg, desiredHost))
+
+	// Mismatch: different host port
+	existing.HostConfig.PortBindings[p8080] = []nat.PortBinding{{HostIP: "0.0.0.0", HostPort: "18081"}}
+	assert.False(t, comparePortConfig(existing, desiredCfg, desiredHost))
+}
+
+func TestCompareContainerConfig_AllMatch(t *testing.T) {
+	t.Parallel()
+
+	// Desired configuration
+	desiredCfg := &container.Config{
+		Image:        "ghcr.io/stacklok/toolhive/mcp:latest",
+		Cmd:          []string{"serve"},
+		Env:          []string{"A=a", "B=b"},
+		Labels:       map[string]string{"toolhive": "true", "name": "w1"},
+		AttachStdin:  true,
+		AttachStdout: true,
+		AttachStderr: true,
+		OpenStdin:    true,
+		Tty:          false,
+	}
+	require.NoError(t, setupExposedPorts(desiredCfg, map[string]struct{}{
+		"8080/tcp": {},
+	}))
+	desiredHost := &container.HostConfig{
+		NetworkMode:   "bridge",
+		CapAdd:        []string{"NET_BIND_SERVICE"},
+		CapDrop:       []string{"ALL"},
+		SecurityOpt:   []string{"seccomp:unconfined"},
+		Privileged:    false,
+		RestartPolicy: container.RestartPolicy{Name: "unless-stopped"},
+		Mounts: []mount.Mount{
+			{Type: mount.TypeBind, Source: "/src1", Target: "/dst1", ReadOnly: true},
+			{Type: mount.TypeBind, Source: "/src2", Target: "/dst2", ReadOnly: false},
+		},
+	}
+	require.NoError(t, setupPortBindings(desiredHost, map[string][]runtime.PortBinding{
+		"8080/tcp": {{HostIP: "", HostPort: "18080"}},
+	}))
+
+	// Existing configuration (must be a superset for env vars)
+	p8080, err := nat.NewPort("tcp", "8080")
+	require.NoError(t, err)
+
+	existing := &container.InspectResponse{
+		Config: &container.Config{
+			Image:        desiredCfg.Image,
+			Cmd:          desiredCfg.Cmd,
+			Env:          []string{"A=a", "B=b", "EXTRA=x"}, // superset OK
+			Labels:       map[string]string{"toolhive": "true", "name": "w1"},
+			AttachStdin:  true,
+			AttachStdout: true,
+			AttachStderr: true,
+			OpenStdin:    true,
+			Tty:          false,
+			ExposedPorts: nat.PortSet{p8080: {}},
+		},
+		ContainerJSONBase: &container.ContainerJSONBase{
+			HostConfig: &container.HostConfig{
+				NetworkMode:   "bridge",
+				CapAdd:        []string{"NET_BIND_SERVICE"},
+				CapDrop:       []string{"ALL"},
+				SecurityOpt:   []string{"seccomp:unconfined"},
+				Privileged:    false,
+				RestartPolicy: container.RestartPolicy{Name: "unless-stopped"},
+				Mounts: []mount.Mount{
+					{Type: mount.TypeBind, Source: "/src1", Target: "/dst1", ReadOnly: true},
+					{Type: mount.TypeBind, Source: "/src2", Target: "/dst2", ReadOnly: false},
+				},
+				PortBindings: nat.PortMap{
+					p8080: []nat.PortBinding{{HostIP: "", HostPort: "18080"}},
+				},
+			},
+		},
+	}
+
+	assert.True(t, compareContainerConfig(existing, desiredCfg, desiredHost))
+
+	// Change image -> mismatch
+	desiredCfg2 := *desiredCfg
+	desiredCfg2.Image = "different"
+	assert.False(t, compareContainerConfig(existing, &desiredCfg2, desiredHost))
+}

--- a/pkg/container/docker/client_helpers_test.go
+++ b/pkg/container/docker/client_helpers_test.go
@@ -1,0 +1,143 @@
+package docker
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stacklok/toolhive/pkg/container/runtime"
+)
+
+func TestDockerToDomainStatus(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		input  string
+		expect runtime.WorkloadStatus
+	}{
+		{"running", "running", runtime.WorkloadStatusRunning},
+		{"created", "created", runtime.WorkloadStatusStarting},
+		{"restarting", "restarting", runtime.WorkloadStatusStarting},
+		{"paused", "paused", runtime.WorkloadStatusStopped},
+		{"exited", "exited", runtime.WorkloadStatusStopped},
+		{"dead", "dead", runtime.WorkloadStatusStopped},
+		{"removing", "removing", runtime.WorkloadStatusRemoving},
+		{"unknown", "something-else", runtime.WorkloadStatusUnknown},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := dockerToDomainStatus(tt.input)
+			assert.Equal(t, tt.expect, got)
+		})
+	}
+}
+
+func TestExtractFirstPort(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns one of the exposed ports", func(t *testing.T) {
+		t.Parallel()
+		opts := &runtime.DeployWorkloadOptions{
+			ExposedPorts: map[string]struct{}{
+				"8080/tcp": {},
+				"9090/tcp": {},
+			},
+		}
+		got, err := extractFirstPort(opts)
+		require.NoError(t, err)
+		// Map iteration order is randomized; assert membership
+		assert.True(t, got == 8080 || got == 9090, "got %d, expected 8080 or 9090", got)
+	})
+
+	t.Run("error on empty", func(t *testing.T) {
+		t.Parallel()
+		opts := &runtime.DeployWorkloadOptions{
+			ExposedPorts: map[string]struct{}{},
+		}
+		_, err := extractFirstPort(opts)
+		require.Error(t, err)
+	})
+}
+
+func TestGeneratePortBindings_AuxiliaryKeepsHostPort(t *testing.T) {
+	t.Parallel()
+
+	labels := map[string]string{
+		"toolhive-auxiliary": "true",
+	}
+	in := map[string][]runtime.PortBinding{
+		"8080/tcp": {
+			{HostIP: "", HostPort: "12345"},
+		},
+	}
+	out, hostPort, err := generatePortBindings(labels, in)
+	require.NoError(t, err)
+
+	require.Contains(t, out, "8080/tcp")
+	require.Len(t, out["8080/tcp"], 1)
+	assert.Equal(t, "12345", out["8080/tcp"][0].HostPort)
+	assert.Equal(t, 12345, hostPort)
+}
+
+func TestGeneratePortBindings_NonAuxiliaryAssignsRandomPortAndMutatesFirstBinding(t *testing.T) {
+	t.Parallel()
+
+	labels := map[string]string{} // not auxiliary
+	in := map[string][]runtime.PortBinding{
+		"8080/tcp": {
+			{HostIP: "", HostPort: ""}, // to be filled by function
+		},
+		"9090/tcp": {
+			{HostIP: "", HostPort: ""}, // additional entry to ensure only first binding gets updated
+		},
+	}
+	out, hostPort, err := generatePortBindings(labels, in)
+	require.NoError(t, err)
+	require.NotZero(t, hostPort)
+
+	// The function updates the first binding it encounters with the random host port.
+	// We don't know which key is first (map iteration), but exactly one binding's HostPort
+	// should be set to hostPort (as string). Validate this invariant.
+	expected := fmt.Sprintf("%d", hostPort)
+
+	countMatches := 0
+	for _, bindings := range out {
+		if len(bindings) > 0 && bindings[0].HostPort == expected {
+			countMatches++
+		}
+	}
+
+	assert.Equal(t, 1, countMatches, "expected exactly one first binding to be updated to hostPort=%s", expected)
+}
+
+func TestAddEgressEnvVars_SetsAll(t *testing.T) {
+	t.Parallel()
+
+	vars := addEgressEnvVars(nil, "egress-proxy")
+	require.NotNil(t, vars)
+
+	host := "http://egress-proxy:3128"
+	assert.Equal(t, host, vars["HTTP_PROXY"])
+	assert.Equal(t, host, vars["HTTPS_PROXY"])
+	assert.Equal(t, host, vars["http_proxy"])
+	assert.Equal(t, host, vars["https_proxy"])
+	assert.Equal(t, "localhost,127.0.0.1,::1", vars["NO_PROXY"])
+	assert.Equal(t, "localhost,127.0.0.1,::1", vars["no_proxy"])
+}
+
+func TestAddEgressEnvVars_PreservesExistingAndOverrides(t *testing.T) {
+	t.Parallel()
+
+	input := map[string]string{"EXISTING": "1", "HTTP_PROXY": "old"}
+	out := addEgressEnvVars(input, "egress-proxy")
+	require.NotNil(t, out)
+	assert.Equal(t, "1", out["EXISTING"])
+
+	// Should override HTTP_PROXY
+	assert.Equal(t, "http://egress-proxy:3128", out["HTTP_PROXY"])
+}

--- a/pkg/container/docker/monitor_test.go
+++ b/pkg/container/docker/monitor_test.go
@@ -1,0 +1,174 @@
+package docker
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	rt "github.com/stacklok/toolhive/pkg/container/runtime"
+	rtmocks "github.com/stacklok/toolhive/pkg/container/runtime/mocks"
+)
+
+func TestNewMonitor_Constructs(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockRT := rtmocks.NewMockRuntime(ctrl)
+
+	m := NewMonitor(mockRT, "workload-1")
+	require.NotNil(t, m)
+}
+
+func TestContainerMonitor_StartMonitoring_WhenRunningStarts(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockRT := rtmocks.NewMockRuntime(ctrl)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// StartMonitoring should verify running exactly once on first call.
+	mockRT.EXPECT().IsWorkloadRunning(ctx, "workload-1").Return(true, nil).Times(1)
+
+	m := NewMonitor(mockRT, "workload-1")
+	ch, err := m.StartMonitoring(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, ch)
+
+	// Idempotent: subsequent call returns same channel and does not call runtime again.
+	ch2, err := m.StartMonitoring(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, ch, ch2)
+
+	// Ensure StopMonitoring is safe and unblocks the background goroutine quickly
+	// without needing to wait for the 5s ticker.
+	m.StopMonitoring()
+}
+
+func TestContainerMonitor_StartMonitoring_WhenNotRunningErrors(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockRT := rtmocks.NewMockRuntime(ctrl)
+
+	ctx := context.Background()
+
+	mockRT.EXPECT().IsWorkloadRunning(ctx, "workload-2").Return(false, nil)
+
+	m := NewMonitor(mockRT, "workload-2")
+	ch, err := m.StartMonitoring(ctx)
+	require.Error(t, err)
+	assert.Nil(t, ch)
+	assert.ErrorIs(t, err, ErrContainerNotRunning)
+}
+
+func TestContainerMonitor_StartMonitoring_RuntimeErrorBubblesUp(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockRT := rtmocks.NewMockRuntime(ctrl)
+
+	ctx := context.Background()
+
+	mockRT.EXPECT().IsWorkloadRunning(ctx, "workload-3").Return(false, errors.New("boom"))
+
+	m := NewMonitor(mockRT, "workload-3")
+	ch, err := m.StartMonitoring(ctx)
+	require.Error(t, err)
+	assert.Nil(t, ch)
+	assert.EqualError(t, err, "boom")
+}
+
+func TestContainerMonitor_StopMonitoring_NotRunningIsNoop(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockRT := rtmocks.NewMockRuntime(ctrl)
+
+	// Construct monitor but do not start
+	m := NewMonitor(mockRT, "workload-4")
+	// Should not panic or deadlock
+	m.StopMonitoring()
+}
+
+func TestIsContainerNotFound(t *testing.T) {
+	t.Parallel()
+
+	t.Run("direct", func(t *testing.T) {
+		t.Parallel()
+		assert.True(t, IsContainerNotFound(ErrContainerNotFound))
+	})
+
+	t.Run("wrapped", func(t *testing.T) {
+		t.Parallel()
+		err := NewContainerError(ErrContainerNotFound, "cid", "not found")
+		assert.True(t, IsContainerNotFound(err))
+	})
+
+	t.Run("other", func(t *testing.T) {
+		t.Parallel()
+		assert.False(t, IsContainerNotFound(errors.New("different")))
+	})
+
+	t.Run("nil", func(t *testing.T) {
+		t.Parallel()
+		assert.False(t, IsContainerNotFound(nil))
+	})
+}
+
+func TestContainerMonitor_StartStop_TerminatesQuickly(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockRT := rtmocks.NewMockRuntime(ctrl)
+
+	// Start path: initially running
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	mockRT.EXPECT().IsWorkloadRunning(ctx, "workload-5").Return(true, nil).Times(1)
+
+	m := NewMonitor(mockRT, "workload-5")
+	ch, err := m.StartMonitoring(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, ch)
+
+	// Stop should complete promptly (no waits on the 5s ticker).
+	done := make(chan struct{})
+	go func() {
+		m.StopMonitoring()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// ok
+	case <-time.After(2 * time.Second):
+		t.Fatal("StopMonitoring did not return promptly")
+	}
+}
+
+// The following stubs are required by the Runtime interface when using gomock in these tests,
+// but they are not exercised by these specific scenarios. We let gomock enforce that they are
+// not called by not setting any expectations for them.
+// ListWorkloads, RemoveWorkload, GetWorkloadLogs, GetWorkloadInfo, IsRunning are already available
+// on the generated mock. We include a minimal compile-time assertion on Monitor usage here.
+var _ rt.Monitor = (*ContainerMonitor)(nil)

--- a/pkg/container/docker/squid_test.go
+++ b/pkg/container/docker/squid_test.go
@@ -1,0 +1,152 @@
+package docker
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stacklok/toolhive/pkg/permissions"
+)
+
+func TestCreateTempEgressSquidConf_AllowAllWhenNil(t *testing.T) {
+	t.Parallel()
+
+	fp, err := createTempEgressSquidConf(nil, "server")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.Remove(fp) })
+
+	b, err := os.ReadFile(fp)
+	require.NoError(t, err)
+	s := string(b)
+
+	assert.Contains(t, s, "visible_hostname server-egress")
+	assert.Contains(t, s, "http_port 3128")
+	assert.Contains(t, s, "http_access allow all")
+	assert.True(t, strings.HasSuffix(strings.TrimSpace(s), "http_access deny all"))
+
+	info, err := os.Stat(fp)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o644), info.Mode().Perm())
+}
+
+func TestCreateTempEgressSquidConf_AllowAllWhenInsecure(t *testing.T) {
+	t.Parallel()
+
+	cfg := &permissions.NetworkPermissions{
+		Outbound: &permissions.OutboundNetworkPermissions{
+			InsecureAllowAll: true,
+		},
+	}
+	fp, err := createTempEgressSquidConf(cfg, "server")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.Remove(fp) })
+
+	b, err := os.ReadFile(fp)
+	require.NoError(t, err)
+	s := string(b)
+
+	assert.Contains(t, s, "visible_hostname server-egress")
+	assert.Contains(t, s, "http_port 3128")
+	assert.Contains(t, s, "http_access allow all")
+	assert.True(t, strings.HasSuffix(strings.TrimSpace(s), "http_access deny all"))
+
+	info, err := os.Stat(fp)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o644), info.Mode().Perm())
+}
+
+func TestCreateTempEgressSquidConf_WithACLs(t *testing.T) {
+	t.Parallel()
+
+	cfg := &permissions.NetworkPermissions{
+		Outbound: &permissions.OutboundNetworkPermissions{
+			InsecureAllowAll: false,
+			AllowPort:        []int{80, 443},
+			AllowHost:        []string{"example.com", "api.github.com"},
+		},
+	}
+	fp, err := createTempEgressSquidConf(cfg, "edge")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.Remove(fp) })
+
+	b, err := os.ReadFile(fp)
+	require.NoError(t, err)
+	s := string(b)
+
+	assert.Contains(t, s, "visible_hostname edge-egress")
+	assert.Contains(t, s, "# Define allowed ports\nacl allowed_ports port 80 443")
+	assert.Contains(t, s, "# Define allowed destinations\nacl allowed_dsts dstdomain example.com api.github.com")
+	assert.Contains(t, s, "\n# Define http_access rules\n")
+	assert.Contains(t, s, "http_access allow allowed_ports allowed_dsts")
+	assert.True(t, strings.HasSuffix(strings.TrimSpace(s), "http_access deny all"))
+
+	info, err := os.Stat(fp)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o644), info.Mode().Perm())
+}
+
+func TestCreateTempIngressSquidConf_Basics(t *testing.T) {
+	t.Parallel()
+
+	fp, err := createTempIngressSquidConf("svc-example", 8080, 18080)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.Remove(fp) })
+
+	b, err := os.ReadFile(fp)
+	require.NoError(t, err)
+	s := string(b)
+
+	assert.Contains(t, s, "visible_hostname svc-example-ingress")
+	assert.Contains(t, s, "\n# Reverse proxy setup for port 8080\n")
+	assert.Contains(t, s, "http_port 0.0.0.0:18080 accel defaultsite=svc-example")
+	assert.Contains(t, s, "cache_peer svc-example parent 8080 0 no-query originserver name=origin_8080")
+	assert.Contains(t, s, "acl site_8080 dstdomain svc-example")
+	assert.Contains(t, s, "http_access allow site_8080")
+	assert.True(t, strings.HasSuffix(strings.TrimSpace(s), "http_access deny all"))
+
+	info, err := os.Stat(fp)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o644), info.Mode().Perm())
+}
+
+func TestGetSquidImage(t *testing.T) {
+	t.Parallel()
+
+	// Save and restore env
+	orig, had := os.LookupEnv("TOOLHIVE_EGRESS_IMAGE")
+	if had {
+		t.Cleanup(func() { _ = os.Setenv("TOOLHIVE_EGRESS_IMAGE", orig) })
+	} else {
+		t.Cleanup(func() { _ = os.Unsetenv("TOOLHIVE_EGRESS_IMAGE") })
+	}
+
+	// Default
+	_ = os.Unsetenv("TOOLHIVE_EGRESS_IMAGE")
+	assert.Equal(t, "ghcr.io/stacklok/toolhive/egress-proxy:latest", getSquidImage())
+
+	// Override
+	override := "ghcr.io/example/custom-squid:1.2.3"
+	_ = os.Setenv("TOOLHIVE_EGRESS_IMAGE", override)
+	assert.Equal(t, override, getSquidImage())
+}
+
+// Safety: ensure generated files are written under system temp directory for cleanup logic assumptions
+func TestTempFilesWrittenToSystemTempDir(t *testing.T) {
+	t.Parallel()
+
+	fp1, err := createTempEgressSquidConf(nil, "s1")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.Remove(fp1) })
+
+	fp2, err := createTempIngressSquidConf("s2", 8081, 18081)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.Remove(fp2) })
+
+	tempDir := os.TempDir()
+	assert.True(t, strings.HasPrefix(filepath.Clean(fp1), filepath.Clean(tempDir)))
+	assert.True(t, strings.HasPrefix(filepath.Clean(fp2), filepath.Clean(tempDir)))
+}


### PR DESCRIPTION
Summary

Adds focused unit tests for the Docker runtime targeting logic-heavy and regression-prone areas. No production code changes.

Scope

- Monitor: start preconditions, idempotent start, clean stop, not-found handling using go.uber.org/mock and testify.
- Squid config: deterministic egress/ingress configuration generation (hostname, ACLs, deny-all) and environment override for squid image; verifies temp file permissions.
- Helpers/config: exposed ports, port bindings, bind mounts conversion, env/label comparisons, status mapping, first-port extraction, random host port assignment logic, and proxy env var injection.

Motivation

Improve confidence around monitoring behavior and config generation without requiring a Docker daemon. These tests are deterministic and fast, providing early signal for CI.

Validation

- task lint-fix → 0 issues
- go test ./pkg/container/docker → ok
- golangci-lint run ./pkg/container/docker/... → 0 issues

Follow-up

Consider introducing a small Docker client adapter interface to enable tests for runtime-facing methods (e.g., listing/inspecting workloads) in a subsequent PR.