### PR TITLE
Add Docker client adapter and unit tests for list/inspect paths

### DIFF
--- a/pkg/container/docker/client_info_test.go
+++ b/pkg/container/docker/client_info_test.go
@@ -1,0 +1,126 @@
+package docker
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/go-connections/nat"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rt "github.com/stacklok/toolhive/pkg/container/runtime"
+)
+
+func TestGetWorkloadInfo_MapsInspectResponseToDomain(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC().Truncate(time.Second)
+	createdStr := now.Format(time.RFC3339)
+
+	call := 0
+	api := &fakeDockerAPI{
+		listFunc: func(_ context.Context, _ container.ListOptions) ([]container.Summary, error) {
+			call++
+			if call == 1 {
+				// First call: find by base name label -> return empty to force fallback
+				return []container.Summary{}, nil
+			}
+			// Second call: exact name search -> return match
+			return []container.Summary{
+				{
+					ID:     "cid-123",
+					Names:  []string{"/mcp"},
+					Labels: map[string]string{"toolhive": "true"},
+					State:  "running",
+				},
+			}, nil
+		},
+		inspectFunc: func(_ context.Context, id string) (container.InspectResponse, error) {
+			require.Equal(t, "cid-123", id)
+			p8080, err := nat.NewPort("tcp", "8080")
+			require.NoError(t, err)
+
+			ns := &container.NetworkSettings{}
+			ns.Ports = nat.PortMap{
+				p8080: []nat.PortBinding{{HostIP: "127.0.0.1", HostPort: "18080"}},
+			}
+
+			return container.InspectResponse{
+				ContainerJSONBase: &container.ContainerJSONBase{
+					Name:    "/mcp",
+					Created: createdStr,
+					State:   &container.State{Status: "running", Running: true},
+				},
+				Config: &container.Config{
+					Image:  "ghcr.io/example/mcp:latest",
+					Labels: map[string]string{"toolhive": "true", "k": "v"},
+				},
+				NetworkSettings: ns,
+			}, nil
+		},
+	}
+
+	c := &Client{api: api}
+
+	info, err := c.GetWorkloadInfo(context.Background(), "mcp")
+	require.NoError(t, err)
+
+	assert.Equal(t, "mcp", info.Name)
+	assert.Equal(t, "ghcr.io/example/mcp:latest", info.Image)
+	assert.Equal(t, "running", info.Status)
+	assert.Equal(t, rt.WorkloadStatusRunning, info.State)
+	assert.WithinDuration(t, now, info.Created, time.Second)
+	assert.Equal(t, map[string]string{"toolhive": "true", "k": "v"}, info.Labels)
+
+	require.Len(t, info.Ports, 1)
+	assert.Equal(t, rt.PortMapping{ContainerPort: 8080, HostPort: 18080, Protocol: "tcp"}, info.Ports[0])
+}
+
+func TestIsWorkloadRunning_TrueWhenDockerReportsRunning(t *testing.T) {
+	t.Parallel()
+
+	call := 0
+	api := &fakeDockerAPI{
+		listFunc: func(_ context.Context, _ container.ListOptions) ([]container.Summary, error) {
+			call++
+			if call == 1 {
+				// First call: base name lookup -> not found
+				return []container.Summary{}, nil
+			}
+			// Second call: exact name lookup
+			return []container.Summary{
+				{
+					ID:     "cid-xyz",
+					Names:  []string{"/server"},
+					Labels: map[string]string{"toolhive": "true"},
+					State:  "running",
+				},
+			}, nil
+		},
+		inspectFunc: func(_ context.Context, id string) (container.InspectResponse, error) {
+			require.Equal(t, "cid-xyz", id)
+
+			ns := &container.NetworkSettings{}
+			ns.Ports = nat.PortMap{}
+
+			return container.InspectResponse{
+				ContainerJSONBase: &container.ContainerJSONBase{
+					Name:  "/server",
+					State: &container.State{Status: "running", Running: true},
+				},
+				Config: &container.Config{
+					Image: "img",
+				},
+				NetworkSettings: ns,
+			}, nil
+		},
+	}
+
+	c := &Client{api: api}
+
+	ok, err := c.IsWorkloadRunning(context.Background(), "server")
+	require.NoError(t, err)
+	assert.True(t, ok)
+}

--- a/pkg/container/docker/client_list_test.go
+++ b/pkg/container/docker/client_list_test.go
@@ -1,0 +1,86 @@
+package docker
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/docker/docker/api/types/container"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rt "github.com/stacklok/toolhive/pkg/container/runtime"
+)
+
+// fakeDockerAPI provides a minimal test double for dockerAPI used by Client.
+type fakeDockerAPI struct {
+	listFunc    func(ctx context.Context, options container.ListOptions) ([]container.Summary, error)
+	inspectFunc func(ctx context.Context, id string) (container.InspectResponse, error)
+}
+
+func (f *fakeDockerAPI) ContainerList(ctx context.Context, options container.ListOptions) ([]container.Summary, error) {
+	if f.listFunc != nil {
+		return f.listFunc(ctx, options)
+	}
+	return nil, nil
+}
+
+func (f *fakeDockerAPI) ContainerInspect(ctx context.Context, id string) (container.InspectResponse, error) {
+	if f.inspectFunc != nil {
+		return f.inspectFunc(ctx, id)
+	}
+	return container.InspectResponse{}, nil
+}
+
+func TestListWorkloads_FiltersAuxiliaryAndMapsFields(t *testing.T) {
+	t.Parallel()
+
+	created := time.Now().Add(-1 * time.Hour).Unix()
+
+	api := &fakeDockerAPI{
+		listFunc: func(_ context.Context, _ container.ListOptions) ([]container.Summary, error) {
+			return []container.Summary{
+				{
+					ID:      "aux1",
+					Image:   "aux:image",
+					Status:  "Up 10 minutes",
+					State:   "running",
+					Names:   []string{"/aux-name"},
+					Labels:  map[string]string{ToolhiveAuxiliaryWorkloadLabel: LabelValueTrue, "toolhive": "true"},
+					Ports:   []container.Port{{PrivatePort: 3128, PublicPort: 0, Type: "tcp"}},
+					Created: created,
+				},
+				{
+					ID:      "cid1",
+					Image:   "srv:image",
+					Status:  "Up 1 minute",
+					State:   "running",
+					Names:   []string{"/mcp-name"},
+					Labels:  map[string]string{"toolhive": "true", "custom": "x"},
+					Ports:   []container.Port{{PrivatePort: 8080, PublicPort: 18080, Type: "tcp"}},
+					Created: created,
+				},
+			}, nil
+		},
+	}
+
+	c := &Client{api: api}
+
+	ctx := context.Background()
+	items, err := c.ListWorkloads(ctx)
+	require.NoError(t, err)
+
+	// Auxiliary container should be filtered out
+	require.Len(t, items, 1)
+
+	got := items[0]
+	assert.Equal(t, "mcp-name", got.Name)
+	assert.Equal(t, "srv:image", got.Image)
+	assert.Equal(t, "Up 1 minute", got.Status)
+	assert.Equal(t, rt.WorkloadStatusRunning, got.State) // via dockerToDomainStatus("running")
+	assert.WithinDuration(t, time.Unix(created, 0), got.Created, time.Second)
+	assert.Equal(t, map[string]string{"toolhive": "true", "custom": "x"}, got.Labels)
+
+	require.Len(t, got.Ports, 1)
+	assert.Equal(t, rt.PortMapping{ContainerPort: 8080, HostPort: 18080, Protocol: "tcp"}, got.Ports[0])
+}


### PR DESCRIPTION
Summary

Introduce a minimal adapter around the Docker SDK client so we can unit test list and inspect code paths without a running Docker daemon. Add focused tests that validate list mapping and inspect-to-domain conversion. No behavior changes.

Validation

- task lint-fix: 0 issues
- go test ./pkg/container/docker: ok
- golangci-lint for this package: 0 issues

Follow-up

With this seam in place, we can extend tests to additional lifecycle and error scenarios in subsequent PRs.