### PR TITLE
Add adapter and unit tests for Docker query paths

### DIFF
--- a/pkg/container/docker/client_info_test.go
+++ b/pkg/container/docker/client_info_test.go
@@ -124,3 +124,65 @@ func TestIsWorkloadRunning_TrueWhenDockerReportsRunning(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, ok)
 }
+
+// Additional coverage: port parse fallback and created time parse fallback
+func TestGetWorkloadInfo_PortParseAndCreatedFallback(t *testing.T) {
+	t.Parallel()
+
+	call := 0
+	api := &fakeDockerAPI{
+		listFunc: func(_ context.Context, _ container.ListOptions) ([]container.Summary, error) {
+			call++
+			if call == 1 {
+				// First attempt (label-based) -> none found
+				return []container.Summary{}, nil
+			}
+			// Second attempt (exact name) -> found one
+			return []container.Summary{
+				{
+					ID:     "cid-badfields",
+					Names:  []string{"/svc-bad"},
+					Labels: map[string]string{"toolhive": "true"},
+					State:  "exited",
+				},
+			}, nil
+		},
+		inspectFunc: func(_ context.Context, id string) (container.InspectResponse, error) {
+			require.Equal(t, "cid-badfields", id)
+
+			// Non-numeric host port; GetWorkloadInfo should log a warning and fall back to 0
+			p8080, err := nat.NewPort("tcp", "8080")
+			require.NoError(t, err)
+			ns := &container.NetworkSettings{}
+			ns.Ports = nat.PortMap{
+				p8080: []nat.PortBinding{{HostIP: "127.0.0.1", HostPort: "abc"}},
+			}
+
+			return container.InspectResponse{
+				ContainerJSONBase: &container.ContainerJSONBase{
+					Name:    "/svc-bad",
+					State:   &container.State{Status: "exited", Running: false},
+					Created: "not-a-time", // invalid RFC3339 -> Created should be zero time
+				},
+				Config:          &container.Config{Image: "img", Labels: map[string]string{"toolhive": "true"}},
+				NetworkSettings: ns,
+			}, nil
+		},
+	}
+
+	c := &Client{api: api}
+
+	info, err := c.GetWorkloadInfo(context.Background(), "svc-bad")
+	require.NoError(t, err)
+
+	// Created time should fall back to zero when parsing fails
+	assert.True(t, info.Created.IsZero(), "expected zero time for invalid Created field")
+	// State mapping for "exited" -> stopped
+	assert.Equal(t, rt.WorkloadStatusStopped, info.State)
+
+	// Port mapping should include container 8080/tcp with hostPort == 0 due to parse failure
+	require.Len(t, info.Ports, 1)
+	assert.Equal(t, 8080, info.Ports[0].ContainerPort)
+	assert.Equal(t, 0, info.Ports[0].HostPort)
+	assert.Equal(t, "tcp", info.Ports[0].Protocol)
+}

--- a/pkg/container/docker/client_list_test.go
+++ b/pkg/container/docker/client_list_test.go
@@ -12,26 +12,6 @@ import (
 	rt "github.com/stacklok/toolhive/pkg/container/runtime"
 )
 
-// fakeDockerAPI provides a minimal test double for dockerAPI used by Client.
-type fakeDockerAPI struct {
-	listFunc    func(ctx context.Context, options container.ListOptions) ([]container.Summary, error)
-	inspectFunc func(ctx context.Context, id string) (container.InspectResponse, error)
-}
-
-func (f *fakeDockerAPI) ContainerList(ctx context.Context, options container.ListOptions) ([]container.Summary, error) {
-	if f.listFunc != nil {
-		return f.listFunc(ctx, options)
-	}
-	return nil, nil
-}
-
-func (f *fakeDockerAPI) ContainerInspect(ctx context.Context, id string) (container.InspectResponse, error) {
-	if f.inspectFunc != nil {
-		return f.inspectFunc(ctx, id)
-	}
-	return container.InspectResponse{}, nil
-}
-
 func TestListWorkloads_FiltersAuxiliaryAndMapsFields(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/container/docker/client_stop_test.go
+++ b/pkg/container/docker/client_stop_test.go
@@ -1,0 +1,140 @@
+package docker
+
+import (
+	"context"
+	"testing"
+
+	"github.com/containerd/errdefs"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/go-connections/nat"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStopWorkload_NotRunning_ReturnsNil(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: find by exact name and inspect -> not running
+	call := 0
+	api := &fakeDockerAPI{
+		listFunc: func(_ context.Context, _ container.ListOptions) ([]container.Summary, error) {
+			call++
+			if call == 1 {
+				// First call: base-name label lookup -> none found
+				return []container.Summary{}, nil
+			}
+			// Second call: exact name lookup -> found one
+			return []container.Summary{
+				{
+					ID:     "cid-not-running",
+					Names:  []string{"/svc"},
+					Labels: map[string]string{"toolhive": "true"},
+					State:  "exited",
+				},
+			}, nil
+		},
+		inspectFunc: func(_ context.Context, id string) (container.InspectResponse, error) {
+			require.Equal(t, "cid-not-running", id)
+			// Not running
+			ns := &container.NetworkSettings{}
+			ns.Ports = nat.PortMap{}
+			return container.InspectResponse{
+				ContainerJSONBase: &container.ContainerJSONBase{
+					Name:  "/svc",
+					State: &container.State{Status: "exited", Running: false},
+				},
+				Config:                  &container.Config{Image: "img", Labels: map[string]string{"toolhive": "true"}},
+				NetworkSettings:         ns,
+				ImageManifestDescriptor: nil,
+			}, nil
+		},
+		// stopFunc should not be called
+		stopFunc: func(_ context.Context, _ string, _ container.StopOptions) error {
+			t.Fatalf("ContainerStop should not be called for not-running container")
+			return nil
+		},
+	}
+	c := &Client{api: api}
+
+	// Act
+	err := c.StopWorkload(t.Context(), "svc")
+
+	// Assert
+	require.NoError(t, err)
+}
+
+func TestStopWorkload_Running_CallsContainerStop(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	call := 0
+	api := &fakeDockerAPI{
+		listFunc: func(_ context.Context, _ container.ListOptions) ([]container.Summary, error) {
+			call++
+			if call == 1 {
+				return []container.Summary{}, nil
+			}
+			return []container.Summary{
+				{
+					ID:     "cid-running",
+					Names:  []string{"/app"},
+					Labels: map[string]string{"toolhive": "true"}, // no network isolation -> avoids proxy stops
+					State:  "running",
+				},
+			}, nil
+		},
+		inspectFunc: func(_ context.Context, id string) (container.InspectResponse, error) {
+			require.Equal(t, "cid-running", id)
+			ns := &container.NetworkSettings{}
+			ns.Ports = nat.PortMap{}
+			return container.InspectResponse{
+				ContainerJSONBase: &container.ContainerJSONBase{
+					Name:  "/app",
+					State: &container.State{Status: "running", Running: true},
+				},
+				Config:          &container.Config{Image: "img", Labels: map[string]string{"toolhive": "true"}},
+				NetworkSettings: ns,
+			}, nil
+		},
+		stopFunc: func(_ context.Context, id string, _ container.StopOptions) error {
+			// The implementation stops by workloadName (not ID), verify that
+			assert.Equal(t, "app", id)
+			called = true
+			return nil
+		},
+	}
+	c := &Client{api: api}
+
+	err := c.StopWorkload(t.Context(), "app")
+	require.NoError(t, err)
+	assert.True(t, called, "expected ContainerStop to be called")
+}
+
+func TestStopWorkload_NotFound_ReturnsNil(t *testing.T) {
+	t.Parallel()
+
+	// Simulate a case where a container appears in listing, but inspect returns NotFound
+	api := &fakeDockerAPI{
+		listFunc: func(_ context.Context, _ container.ListOptions) ([]container.Summary, error) {
+			// Exact name lookup will find a candidate
+			return []container.Summary{
+				{
+					ID:     "cid-missing",
+					Names:  []string{"/gone"},
+					Labels: map[string]string{"toolhive": "true"},
+					State:  "exited",
+				},
+			}, nil
+		},
+		inspectFunc: func(_ context.Context, id string) (container.InspectResponse, error) {
+			require.Equal(t, "cid-missing", id)
+			// Return a NotFound error that satisfies errdefs.IsNotFound
+			return container.InspectResponse{}, errdefs.ErrNotFound
+		},
+	}
+	c := &Client{api: api}
+
+	err := c.StopWorkload(t.Context(), "gone")
+	// StopWorkload should treat a not-found workload as success
+	require.NoError(t, err)
+}

--- a/pkg/container/docker/mocks_test.go
+++ b/pkg/container/docker/mocks_test.go
@@ -1,0 +1,36 @@
+package docker
+
+import (
+	"context"
+
+	"github.com/docker/docker/api/types/container"
+)
+
+// fakeDockerAPI provides a minimal test double for dockerAPI used by Client.
+// Centralized here for reuse across tests.
+type fakeDockerAPI struct {
+	listFunc    func(ctx context.Context, options container.ListOptions) ([]container.Summary, error)
+	inspectFunc func(ctx context.Context, id string) (container.InspectResponse, error)
+	stopFunc    func(ctx context.Context, containerID string, options container.StopOptions) error
+}
+
+func (f *fakeDockerAPI) ContainerList(ctx context.Context, options container.ListOptions) ([]container.Summary, error) {
+	if f.listFunc != nil {
+		return f.listFunc(ctx, options)
+	}
+	return nil, nil
+}
+
+func (f *fakeDockerAPI) ContainerInspect(ctx context.Context, id string) (container.InspectResponse, error) {
+	if f.inspectFunc != nil {
+		return f.inspectFunc(ctx, id)
+	}
+	return container.InspectResponse{}, nil
+}
+
+func (f *fakeDockerAPI) ContainerStop(ctx context.Context, containerID string, options container.StopOptions) error {
+	if f.stopFunc != nil {
+		return f.stopFunc(ctx, containerID, options)
+	}
+	return nil
+}


### PR DESCRIPTION
Summary

Add a minimal adapter around the Docker SDK client and unit tests for key Docker runtime query paths. This enables fast, deterministic tests without requiring a running Docker daemon.

What changed

- Introduced a small docker client adapter in the Docker runtime client and routed list/inspect/stop through it.
- Added unit tests for listing workloads, inspecting workloads (including port parsing and created time fallback), checking running status, and stopping workloads.
- Centralized a small test fake for the adapter in mocks_test.go.

Motivation

Increase test coverage for logic-heavy query paths and make them easier to evolve safely.

Validation

- task lint-fix: 0 issues
- go test ./pkg/container/docker: ok
- golangci-lint (package scope): 0 issues