### PR TITLE
Update Helm deployment name for CRDs in Taskfile

### DIFF
--- a/cmd/thv-operator/Taskfile.yml
+++ b/cmd/thv-operator/Taskfile.yml
@@ -110,12 +110,12 @@ tasks:
   operator-install-crds:
     desc: Install CRDs into the K8s cluster
     cmds:
-      - helm upgrade --install operator-crds deploy/charts/operator-crds --kubeconfig kconfig.yaml
+      - helm upgrade --install toolhive-operator-crds deploy/charts/operator-crds --kubeconfig kconfig.yaml
 
   operator-uninstall-crds:
     desc: Uninstall CRDs from the K8s cluster
     cmds:
-      - helm uninstall operator-crds --kubeconfig kconfig.yaml
+      - helm uninstall toolhive-operator-crds --kubeconfig kconfig.yaml
 
   operator-deploy-latest:
     desc: Deploy latest built Operator image from Github to the K8s cluster


### PR DESCRIPTION
Makes the CRDs deployment name in the Taskfile consistent with all our docs. Just a minor quality of life improvement in case someone is running the tasks against an existing deployment created per the docs.

Signed-off-by: Dan Barr <6922515+danbarr@users.noreply.github.com>