### PR TITLE
Exit early if container runtime is not found

### DIFF
--- a/cmd/thv/main.go
+++ b/cmd/thv/main.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stacklok/toolhive/cmd/thv/app"
 	"github.com/stacklok/toolhive/pkg/client"
+	"github.com/stacklok/toolhive/pkg/container"
 	"github.com/stacklok/toolhive/pkg/container/runtime"
 	"github.com/stacklok/toolhive/pkg/lockfile"
 	"github.com/stacklok/toolhive/pkg/logger"
@@ -26,6 +27,12 @@ func main() {
 
 	// Clean up stale lock files on startup
 	cleanupStaleLockFiles()
+
+	// Check if container runtime is available early
+	if err := container.CheckRuntimeAvailable(); err != nil {
+		logger.Errorf("%s", err.Error())
+		os.Exit(1)
+	}
 
 	// Check and perform auto-discovery migration if needed
 	// Handles the auto-discovery flag depreciation, only executes once on old config files

--- a/pkg/container/factory.go
+++ b/pkg/container/factory.go
@@ -231,3 +231,17 @@ func (*Factory) getRuntimeFromEnv() string {
 func NewMonitor(rt runtime.Runtime, containerName string) runtime.Monitor {
 	return docker.NewMonitor(rt, containerName)
 }
+
+// CheckRuntimeAvailable checks if any container runtime is available
+// and returns a user-friendly error message if none are found
+func CheckRuntimeAvailable() error {
+	factory := NewFactory()
+	available := factory.ListAvailableRuntimes()
+
+	if len(available) == 0 {
+		return fmt.Errorf("no container runtime available. ToolHive requires Docker, Podman, Colima, " +
+			"or a Kubernetes environment to run MCP servers")
+	}
+
+	return nil
+}


### PR DESCRIPTION
The following PR makes the no container runtime error message a bit better by doing the check early so it's not being wrapped up in a few other error messages. 

Before:
```
7:56PM  ERROR   Failed to perform default group migration: failed to initialize managers: failed to create workloads manager: no available runtime fou
nd
```
After:
```
1:49AM  ERROR   no container runtime available. ToolHive requires Docker, Podman, Colima, or a Kubernetes environment to run MCP servers
```