### PR TITLE
Refactors Accessor Logic for `MCPServer` Fields Into Specific Package

### DIFF
--- a/pkg/operator/accessors/mcpserver_accessor.go
+++ b/pkg/operator/accessors/mcpserver_accessor.go
@@ -25,7 +25,9 @@ func NewMCPServerFieldAccessor() MCPServerFieldAccessor {
 }
 
 // GetProxyDeploymentLabelsAndAnnotations returns labels and annotations for the deployment
-func (f *mcpServerFieldAccessor) GetProxyDeploymentLabelsAndAnnotations(mcpServer *mcpv1alpha1.MCPServer) (map[string]string, map[string]string) {
+func (*mcpServerFieldAccessor) GetProxyDeploymentLabelsAndAnnotations(
+	mcpServer *mcpv1alpha1.MCPServer,
+) (map[string]string, map[string]string) {
 	baseAnnotations := make(map[string]string)
 	baseLabels := make(map[string]string)
 
@@ -48,7 +50,9 @@ func (f *mcpServerFieldAccessor) GetProxyDeploymentLabelsAndAnnotations(mcpServe
 }
 
 // GetProxyDeploymentTemplateLabelsAndAnnotations returns labels and annotations for the deployment pod template
-func (f *mcpServerFieldAccessor) GetProxyDeploymentTemplateLabelsAndAnnotations(mcpServer *mcpv1alpha1.MCPServer) (map[string]string, map[string]string) {
+func (*mcpServerFieldAccessor) GetProxyDeploymentTemplateLabelsAndAnnotations(
+	mcpServer *mcpv1alpha1.MCPServer,
+) (map[string]string, map[string]string) {
 	baseAnnotations := make(map[string]string)
 	baseLabels := make(map[string]string)
 
@@ -65,7 +69,8 @@ func (f *mcpServerFieldAccessor) GetProxyDeploymentTemplateLabelsAndAnnotations(
 		deploymentLabels = mergeLabels(baseLabels, mcpServer.Spec.ResourceOverrides.ProxyDeployment.PodTemplateMetadataOverrides.Labels)
 	}
 	if mcpServer.Spec.ResourceOverrides.ProxyDeployment.PodTemplateMetadataOverrides.Annotations != nil {
-		deploymentAnnotations = mergeAnnotations(baseAnnotations, mcpServer.Spec.ResourceOverrides.ProxyDeployment.PodTemplateMetadataOverrides.Annotations)
+		overrides := mcpServer.Spec.ResourceOverrides.ProxyDeployment.PodTemplateMetadataOverrides.Annotations
+		deploymentAnnotations = mergeAnnotations(baseAnnotations, overrides)
 	}
 
 	return deploymentLabels, deploymentAnnotations

--- a/pkg/operator/accessors/mcpserver_accessor.go
+++ b/pkg/operator/accessors/mcpserver_accessor.go
@@ -1,0 +1,98 @@
+// Package accessors provides accessor functions for the ToolHive operator
+package accessors
+
+import (
+	"maps"
+
+	mcpv1alpha1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1alpha1"
+)
+
+// MCPServerFieldAccessor provides accessor methods for handling labels and annotations
+type MCPServerFieldAccessor interface {
+	// GetProxyDeploymentLabelsAndAnnotations returns labels and annotations for the deployment
+	GetProxyDeploymentLabelsAndAnnotations(mcpServer *mcpv1alpha1.MCPServer) (labels, annotations map[string]string)
+
+	// GetProxyDeploymentTemplateLabelsAndAnnotations returns labels and annotations for the deployment pod template
+	GetProxyDeploymentTemplateLabelsAndAnnotations(mcpServer *mcpv1alpha1.MCPServer) (labels, annotations map[string]string)
+}
+
+// mcpServerFieldAccessor implements MCPServerFieldAccessor
+type mcpServerFieldAccessor struct{}
+
+// NewMCPServerFieldAccessor creates a new MCPServerFieldAccessor instance
+func NewMCPServerFieldAccessor() MCPServerFieldAccessor {
+	return &mcpServerFieldAccessor{}
+}
+
+// GetProxyDeploymentLabelsAndAnnotations returns labels and annotations for the deployment
+func (f *mcpServerFieldAccessor) GetProxyDeploymentLabelsAndAnnotations(mcpServer *mcpv1alpha1.MCPServer) (map[string]string, map[string]string) {
+	baseAnnotations := make(map[string]string)
+	baseLabels := make(map[string]string)
+
+	if mcpServer.Spec.ResourceOverrides == nil ||
+		mcpServer.Spec.ResourceOverrides.ProxyDeployment == nil {
+		return baseLabels, baseAnnotations
+	}
+
+	deploymentLabels := baseLabels
+	deploymentAnnotations := baseAnnotations
+
+	if mcpServer.Spec.ResourceOverrides.ProxyDeployment.Labels != nil {
+		deploymentLabels = mergeLabels(baseLabels, mcpServer.Spec.ResourceOverrides.ProxyDeployment.Labels)
+	}
+	if mcpServer.Spec.ResourceOverrides.ProxyDeployment.Annotations != nil {
+		deploymentAnnotations = mergeAnnotations(baseAnnotations, mcpServer.Spec.ResourceOverrides.ProxyDeployment.Annotations)
+	}
+
+	return deploymentLabels, deploymentAnnotations
+}
+
+// GetProxyDeploymentTemplateLabelsAndAnnotations returns labels and annotations for the deployment pod template
+func (f *mcpServerFieldAccessor) GetProxyDeploymentTemplateLabelsAndAnnotations(mcpServer *mcpv1alpha1.MCPServer) (map[string]string, map[string]string) {
+	baseAnnotations := make(map[string]string)
+	baseLabels := make(map[string]string)
+
+	if mcpServer.Spec.ResourceOverrides == nil ||
+		mcpServer.Spec.ResourceOverrides.ProxyDeployment == nil ||
+		mcpServer.Spec.ResourceOverrides.ProxyDeployment.PodTemplateMetadataOverrides == nil {
+		return baseLabels, baseAnnotations
+	}
+
+	deploymentLabels := baseLabels
+	deploymentAnnotations := baseAnnotations
+
+	if mcpServer.Spec.ResourceOverrides.ProxyDeployment.PodTemplateMetadataOverrides.Labels != nil {
+		deploymentLabels = mergeLabels(baseLabels, mcpServer.Spec.ResourceOverrides.ProxyDeployment.PodTemplateMetadataOverrides.Labels)
+	}
+	if mcpServer.Spec.ResourceOverrides.ProxyDeployment.PodTemplateMetadataOverrides.Annotations != nil {
+		deploymentAnnotations = mergeAnnotations(baseAnnotations, mcpServer.Spec.ResourceOverrides.ProxyDeployment.PodTemplateMetadataOverrides.Annotations)
+	}
+
+	return deploymentLabels, deploymentAnnotations
+}
+
+// mergeLabels merges override labels with default labels, with default labels taking precedence
+func mergeLabels(defaultLabels, overrideLabels map[string]string) map[string]string {
+	return mergeStringMaps(defaultLabels, overrideLabels)
+}
+
+// mergeAnnotations merges override annotations with default annotations, with default annotations taking precedence
+func mergeAnnotations(defaultAnnotations, overrideAnnotations map[string]string) map[string]string {
+	return mergeStringMaps(defaultAnnotations, overrideAnnotations)
+}
+
+// mergeStringMaps merges override map with default map, with default map taking precedence
+// This ensures that operator-required metadata is preserved for proper functionality
+func mergeStringMaps(defaultMap, overrideMap map[string]string) map[string]string {
+	if overrideMap == nil && defaultMap == nil {
+		return make(map[string]string)
+	}
+	if overrideMap == nil {
+		return maps.Clone(defaultMap)
+	}
+	result := maps.Clone(overrideMap)
+	if defaultMap != nil {
+		maps.Copy(result, defaultMap) // default map takes precedence
+	}
+	return result
+}

--- a/pkg/operator/accessors/mcpserver_accessor_test.go
+++ b/pkg/operator/accessors/mcpserver_accessor_test.go
@@ -1,0 +1,338 @@
+package accessors
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	mcpv1alpha1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1alpha1"
+)
+
+func TestNewMCPServerFieldAccessor(t *testing.T) {
+	accessor := NewMCPServerFieldAccessor()
+	require.NotNil(t, accessor)
+	_, ok := accessor.(*mcpServerFieldAccessor)
+	assert.True(t, ok, "NewMCPServerFieldAccessor should return *mcpServerFieldAccessor")
+}
+
+func TestGetProxyDeploymentLabelsAndAnnotations(t *testing.T) {
+	tests := []struct {
+		name                string
+		mcpServer           *mcpv1alpha1.MCPServer
+		expectedLabels      map[string]string
+		expectedAnnotations map[string]string
+	}{
+		{
+			name: "nil resource overrides",
+			mcpServer: &mcpv1alpha1.MCPServer{
+				Spec: mcpv1alpha1.MCPServerSpec{
+					ResourceOverrides: nil,
+				},
+			},
+			expectedLabels:      map[string]string{},
+			expectedAnnotations: map[string]string{},
+		},
+		{
+			name: "nil proxy deployment overrides",
+			mcpServer: &mcpv1alpha1.MCPServer{
+				Spec: mcpv1alpha1.MCPServerSpec{
+					ResourceOverrides: &mcpv1alpha1.ResourceOverrides{
+						ProxyDeployment: nil,
+					},
+				},
+			},
+			expectedLabels:      map[string]string{},
+			expectedAnnotations: map[string]string{},
+		},
+		{
+			name: "with labels only",
+			mcpServer: &mcpv1alpha1.MCPServer{
+				Spec: mcpv1alpha1.MCPServerSpec{
+					ResourceOverrides: &mcpv1alpha1.ResourceOverrides{
+						ProxyDeployment: &mcpv1alpha1.ProxyDeploymentOverrides{
+							ResourceMetadataOverrides: mcpv1alpha1.ResourceMetadataOverrides{
+								Labels: map[string]string{
+									"app":     "my-app",
+									"version": "v1",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedLabels: map[string]string{
+				"app":     "my-app",
+				"version": "v1",
+			},
+			expectedAnnotations: map[string]string{},
+		},
+		{
+			name: "with annotations only",
+			mcpServer: &mcpv1alpha1.MCPServer{
+				Spec: mcpv1alpha1.MCPServerSpec{
+					ResourceOverrides: &mcpv1alpha1.ResourceOverrides{
+						ProxyDeployment: &mcpv1alpha1.ProxyDeploymentOverrides{
+							ResourceMetadataOverrides: mcpv1alpha1.ResourceMetadataOverrides{
+								Annotations: map[string]string{
+									"prometheus.io/scrape": "true",
+									"prometheus.io/port":   "9090",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedLabels: map[string]string{},
+			expectedAnnotations: map[string]string{
+				"prometheus.io/scrape": "true",
+				"prometheus.io/port":   "9090",
+			},
+		},
+		{
+			name: "with both labels and annotations",
+			mcpServer: &mcpv1alpha1.MCPServer{
+				Spec: mcpv1alpha1.MCPServerSpec{
+					ResourceOverrides: &mcpv1alpha1.ResourceOverrides{
+						ProxyDeployment: &mcpv1alpha1.ProxyDeploymentOverrides{
+							ResourceMetadataOverrides: mcpv1alpha1.ResourceMetadataOverrides{
+								Labels: map[string]string{
+									"env":                    "production",
+									"team":                   "platform",
+									"app.kubernetes.io/name": "toolhive",
+								},
+								Annotations: map[string]string{
+									"description":             "MCP Server Proxy",
+									"owner":                   "platform-team",
+									"sidecar.istio.io/inject": "false",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedLabels: map[string]string{
+				"env":                    "production",
+				"team":                   "platform",
+				"app.kubernetes.io/name": "toolhive",
+			},
+			expectedAnnotations: map[string]string{
+				"description":             "MCP Server Proxy",
+				"owner":                   "platform-team",
+				"sidecar.istio.io/inject": "false",
+			},
+		},
+		{
+			name: "nil labels and annotations maps",
+			mcpServer: &mcpv1alpha1.MCPServer{
+				Spec: mcpv1alpha1.MCPServerSpec{
+					ResourceOverrides: &mcpv1alpha1.ResourceOverrides{
+						ProxyDeployment: &mcpv1alpha1.ProxyDeploymentOverrides{
+							ResourceMetadataOverrides: mcpv1alpha1.ResourceMetadataOverrides{
+								Labels:      nil,
+								Annotations: nil,
+							},
+						},
+					},
+				},
+			},
+			expectedLabels:      map[string]string{},
+			expectedAnnotations: map[string]string{},
+		},
+		{
+			name: "empty labels and annotations maps",
+			mcpServer: &mcpv1alpha1.MCPServer{
+				Spec: mcpv1alpha1.MCPServerSpec{
+					ResourceOverrides: &mcpv1alpha1.ResourceOverrides{
+						ProxyDeployment: &mcpv1alpha1.ProxyDeploymentOverrides{
+							ResourceMetadataOverrides: mcpv1alpha1.ResourceMetadataOverrides{
+								Labels:      map[string]string{},
+								Annotations: map[string]string{},
+							},
+						},
+					},
+				},
+			},
+			expectedLabels:      map[string]string{},
+			expectedAnnotations: map[string]string{},
+		},
+	}
+
+	accessor := NewMCPServerFieldAccessor()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			labels, annotations := accessor.GetProxyDeploymentLabelsAndAnnotations(tt.mcpServer)
+			assert.Equal(t, tt.expectedLabels, labels)
+			assert.Equal(t, tt.expectedAnnotations, annotations)
+		})
+	}
+}
+
+func TestGetProxyDeploymentTemplateLabelsAndAnnotations(t *testing.T) {
+	tests := []struct {
+		name                string
+		mcpServer           *mcpv1alpha1.MCPServer
+		expectedLabels      map[string]string
+		expectedAnnotations map[string]string
+	}{
+		{
+			name: "nil resource overrides",
+			mcpServer: &mcpv1alpha1.MCPServer{
+				Spec: mcpv1alpha1.MCPServerSpec{
+					ResourceOverrides: nil,
+				},
+			},
+			expectedLabels:      map[string]string{},
+			expectedAnnotations: map[string]string{},
+		},
+		{
+			name: "nil proxy deployment overrides",
+			mcpServer: &mcpv1alpha1.MCPServer{
+				Spec: mcpv1alpha1.MCPServerSpec{
+					ResourceOverrides: &mcpv1alpha1.ResourceOverrides{
+						ProxyDeployment: nil,
+					},
+				},
+			},
+			expectedLabels:      map[string]string{},
+			expectedAnnotations: map[string]string{},
+		},
+		{
+			name: "nil pod template metadata overrides",
+			mcpServer: &mcpv1alpha1.MCPServer{
+				Spec: mcpv1alpha1.MCPServerSpec{
+					ResourceOverrides: &mcpv1alpha1.ResourceOverrides{
+						ProxyDeployment: &mcpv1alpha1.ProxyDeploymentOverrides{
+							PodTemplateMetadataOverrides: nil,
+						},
+					},
+				},
+			},
+			expectedLabels:      map[string]string{},
+			expectedAnnotations: map[string]string{},
+		},
+		{
+			name: "with pod template labels only",
+			mcpServer: &mcpv1alpha1.MCPServer{
+				Spec: mcpv1alpha1.MCPServerSpec{
+					ResourceOverrides: &mcpv1alpha1.ResourceOverrides{
+						ProxyDeployment: &mcpv1alpha1.ProxyDeploymentOverrides{
+							PodTemplateMetadataOverrides: &mcpv1alpha1.ResourceMetadataOverrides{
+								Labels: map[string]string{
+									"pod-label-1": "value1",
+									"pod-label-2": "value2",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedLabels: map[string]string{
+				"pod-label-1": "value1",
+				"pod-label-2": "value2",
+			},
+			expectedAnnotations: map[string]string{},
+		},
+		{
+			name: "with pod template annotations only",
+			mcpServer: &mcpv1alpha1.MCPServer{
+				Spec: mcpv1alpha1.MCPServerSpec{
+					ResourceOverrides: &mcpv1alpha1.ResourceOverrides{
+						ProxyDeployment: &mcpv1alpha1.ProxyDeploymentOverrides{
+							PodTemplateMetadataOverrides: &mcpv1alpha1.ResourceMetadataOverrides{
+								Annotations: map[string]string{
+									"pod-annotation-1": "value1",
+									"pod-annotation-2": "value2",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedLabels: map[string]string{},
+			expectedAnnotations: map[string]string{
+				"pod-annotation-1": "value1",
+				"pod-annotation-2": "value2",
+			},
+		},
+		{
+			name: "with both pod template labels and annotations",
+			mcpServer: &mcpv1alpha1.MCPServer{
+				Spec: mcpv1alpha1.MCPServerSpec{
+					ResourceOverrides: &mcpv1alpha1.ResourceOverrides{
+						ProxyDeployment: &mcpv1alpha1.ProxyDeploymentOverrides{
+							PodTemplateMetadataOverrides: &mcpv1alpha1.ResourceMetadataOverrides{
+								Labels: map[string]string{
+									"app.kubernetes.io/component": "proxy",
+									"app.kubernetes.io/instance":  "server-1",
+								},
+								Annotations: map[string]string{
+									"co.elastic.logs/enabled": "true",
+									"fluentbit.io/parser":     "json",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedLabels: map[string]string{
+				"app.kubernetes.io/component": "proxy",
+				"app.kubernetes.io/instance":  "server-1",
+			},
+			expectedAnnotations: map[string]string{
+				"co.elastic.logs/enabled": "true",
+				"fluentbit.io/parser":     "json",
+			},
+		},
+		{
+			name: "deployment overrides don't affect pod template",
+			mcpServer: &mcpv1alpha1.MCPServer{
+				Spec: mcpv1alpha1.MCPServerSpec{
+					ResourceOverrides: &mcpv1alpha1.ResourceOverrides{
+						ProxyDeployment: &mcpv1alpha1.ProxyDeploymentOverrides{
+							ResourceMetadataOverrides: mcpv1alpha1.ResourceMetadataOverrides{
+								Labels: map[string]string{
+									"deployment-label": "should-not-appear",
+								},
+								Annotations: map[string]string{
+									"deployment-annotation": "should-not-appear",
+								},
+							},
+							PodTemplateMetadataOverrides: &mcpv1alpha1.ResourceMetadataOverrides{
+								Labels: map[string]string{
+									"pod-label": "should-appear",
+								},
+								Annotations: map[string]string{
+									"pod-annotation": "should-appear",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedLabels: map[string]string{
+				"pod-label": "should-appear",
+			},
+			expectedAnnotations: map[string]string{
+				"pod-annotation": "should-appear",
+			},
+		},
+	}
+
+	accessor := NewMCPServerFieldAccessor()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			labels, annotations := accessor.GetProxyDeploymentTemplateLabelsAndAnnotations(tt.mcpServer)
+			assert.Equal(t, tt.expectedLabels, labels)
+			assert.Equal(t, tt.expectedAnnotations, annotations)
+		})
+	}
+}
+
+func TestInterfaceContract(t *testing.T) {
+	// Test that the concrete type implements the interface
+	var _ MCPServerFieldAccessor = (*mcpServerFieldAccessor)(nil)
+	var _ MCPServerFieldAccessor = NewMCPServerFieldAccessor()
+}

--- a/pkg/operator/accessors/mcpserver_accessor_test.go
+++ b/pkg/operator/accessors/mcpserver_accessor_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestNewMCPServerFieldAccessor(t *testing.T) {
+	t.Parallel()
 	accessor := NewMCPServerFieldAccessor()
 	require.NotNil(t, accessor)
 	_, ok := accessor.(*mcpServerFieldAccessor)
@@ -17,6 +18,7 @@ func TestNewMCPServerFieldAccessor(t *testing.T) {
 }
 
 func TestGetProxyDeploymentLabelsAndAnnotations(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name                string
 		mcpServer           *mcpv1alpha1.MCPServer
@@ -162,6 +164,7 @@ func TestGetProxyDeploymentLabelsAndAnnotations(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			labels, annotations := accessor.GetProxyDeploymentLabelsAndAnnotations(tt.mcpServer)
 			assert.Equal(t, tt.expectedLabels, labels)
 			assert.Equal(t, tt.expectedAnnotations, annotations)
@@ -170,6 +173,7 @@ func TestGetProxyDeploymentLabelsAndAnnotations(t *testing.T) {
 }
 
 func TestGetProxyDeploymentTemplateLabelsAndAnnotations(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name                string
 		mcpServer           *mcpv1alpha1.MCPServer
@@ -324,6 +328,7 @@ func TestGetProxyDeploymentTemplateLabelsAndAnnotations(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			labels, annotations := accessor.GetProxyDeploymentTemplateLabelsAndAnnotations(tt.mcpServer)
 			assert.Equal(t, tt.expectedLabels, labels)
 			assert.Equal(t, tt.expectedAnnotations, annotations)
@@ -332,7 +337,8 @@ func TestGetProxyDeploymentTemplateLabelsAndAnnotations(t *testing.T) {
 }
 
 func TestInterfaceContract(t *testing.T) {
+	t.Parallel()
 	// Test that the concrete type implements the interface
 	var _ MCPServerFieldAccessor = (*mcpServerFieldAccessor)(nil)
-	var _ MCPServerFieldAccessor = NewMCPServerFieldAccessor()
+	var _ = NewMCPServerFieldAccessor()
 }


### PR DESCRIPTION
The ToolHive Operator controller files are getting quite large now and there seems to be some duplication appearing. In this PR we add a simple addition by creating a new `accessors` package in `pkg/operator` that is responsible for getting specific fields on the `MCPServer` spec and performing nil checks in the right places. 

This allows for:
- Reduces code in the operator controller files
- Allows for more granular tests
- Allows for reuse

This somewhat opens the door for future helper interfaces/functions that allow for more granular testing ensuring we adhere to DRY without it all being among thousands of lines of code of certain controller files. Some of the operator code is at a point now where it needs to be refactored and split out. This is the start of some of that effort