### PR TITLE
Fix ProxyMode flag missing in Kubernetes operator

### DIFF
--- a/cmd/thv-operator/controllers/mcpserver_controller.go
+++ b/cmd/thv-operator/controllers/mcpserver_controller.go
@@ -543,6 +543,10 @@ func (r *MCPServerReconciler) deploymentForMCPServer(ctx context.Context, m *mcp
 		if m.Spec.TargetPort != 0 {
 			args = append(args, fmt.Sprintf("--target-port=%d", m.Spec.TargetPort))
 		}
+		// Add proxy mode for stdio transport
+		if m.Spec.ProxyMode != "" {
+			args = append(args, fmt.Sprintf("--proxy-mode=%s", m.Spec.ProxyMode))
+		}
 	}
 
 	// Add pod template patch and permission profile only if not using ConfigMap


### PR DESCRIPTION
Fixes #1874

## Problem
When deploying MCPServers in Kubernetes, setting `proxyMode: streamable-http` in the MCPServer spec was being ignored. The ProxyRunner container would always default to SSE mode regardless of the configured value.

## Root Cause
The Kubernetes operator was missing the `--proxy-mode` flag when constructing command-line arguments for the ProxyRunner container in non-ConfigMap mode. 

While the operator correctly passed other flags like:
- `--proxy-port=8080`
- `--name=my-server` 
- `--transport=stdio`

It was completely missing:
- `--proxy-mode=` ❌

This caused the ProxyRunner to fall back to its default value of "sse" instead of using the user-specified mode.

## Solution
Added the missing `--proxy-mode` flag to the argument construction in the operator controller

