### PR TITLE
operator: Embed Authz config from ConfigMap into runconfig

### DIFF
--- a/cmd/thv-operator/controllers/mcpserver_runconfig_test.go
+++ b/cmd/thv-operator/controllers/mcpserver_runconfig_test.go
@@ -26,6 +26,7 @@ const (
 	stdioTransport          = "stdio"
 	sseProxyMode            = "sse"
 	streamableHTTPProxyMode = "streamable-http"
+	defaultAuthzKey         = "authz.json"
 )
 
 func createRunConfigTestScheme() *runtime.Scheme {
@@ -456,7 +457,7 @@ func TestCreateRunConfigFromMCPServer(t *testing.T) {
 						Type: mcpv1alpha1.AuthzConfigTypeConfigMap,
 						ConfigMap: &mcpv1alpha1.ConfigMapAuthzRef{
 							Name: "test-authz-config",
-							Key:  "authz.json",
+							Key:  defaultAuthzKey,
 						},
 					},
 				},
@@ -465,9 +466,14 @@ func TestCreateRunConfigFromMCPServer(t *testing.T) {
 			expected: func(t *testing.T, config *runner.RunConfig) {
 				assert.Equal(t, "authz-configmap-server", config.Name)
 
-				// For ConfigMap type, authorization config should not be set directly in RunConfig
-				// since it will be handled by proxyrunner when reading from ConfigMap
-				assert.Nil(t, config.AuthzConfig)
+				// For ConfigMap type, with new feature, authorization config is embedded in RunConfig
+				require.NotNil(t, config.AuthzConfig)
+				assert.Equal(t, "v1", config.AuthzConfig.Version)
+				assert.Equal(t, authz.ConfigTypeCedarV1, config.AuthzConfig.Type)
+				require.NotNil(t, config.AuthzConfig.Cedar)
+				assert.Len(t, config.AuthzConfig.Cedar.Policies, 1)
+				assert.Contains(t, config.AuthzConfig.Cedar.Policies[0], "call_tool")
+				assert.Equal(t, "[]", config.AuthzConfig.Cedar.EntitiesJSON)
 			},
 		},
 		{
@@ -594,7 +600,54 @@ func TestCreateRunConfigFromMCPServer(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			r := &MCPServerReconciler{}
+
+			// Build reconciler; if test uses ConfigMap-based authz, provide a fake client with that ConfigMap
+			var r *MCPServerReconciler
+			if tt.mcpServer != nil &&
+				tt.mcpServer.Spec.AuthzConfig != nil &&
+				tt.mcpServer.Spec.AuthzConfig.Type == mcpv1alpha1.AuthzConfigTypeConfigMap &&
+				tt.mcpServer.Spec.AuthzConfig.ConfigMap != nil {
+
+				scheme := createRunConfigTestScheme()
+
+				// Prepare a ConfigMap with authorization configuration content
+				cm := &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      tt.mcpServer.Spec.AuthzConfig.ConfigMap.Name,
+						Namespace: tt.mcpServer.Namespace,
+					},
+					Data: map[string]string{
+						func() string {
+							if k := tt.mcpServer.Spec.AuthzConfig.ConfigMap.Key; k != "" {
+								return k
+							}
+							return defaultAuthzKey
+						}(): `{
+							"version": "v1",
+							"type": "cedarv1",
+							"cedar": {
+								"policies": [
+									"permit(principal, action == Action::\"call_tool\", resource == Tool::\"weather\");"
+								],
+								"entities_json": "[]"
+							}
+						}`,
+					},
+				}
+
+				fakeClient := fake.NewClientBuilder().
+					WithScheme(scheme).
+					WithRuntimeObjects(cm).
+					Build()
+
+				r = &MCPServerReconciler{
+					Client: fakeClient,
+					Scheme: scheme,
+				}
+			} else {
+				r = &MCPServerReconciler{}
+			}
+
 			result, err := r.createRunConfigFromMCPServer(tt.mcpServer)
 			require.NoError(t, err)
 			assert.NotNil(t, result)
@@ -1053,7 +1106,7 @@ func TestEnsureRunConfigConfigMap(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			testScheme := createRunConfigTestScheme()
-			objects := []runtime.Object{}
+			objects := []runtime.Object{tt.mcpServer}
 			if tt.existingCM != nil {
 				objects = append(objects, tt.existingCM)
 			}
@@ -1100,6 +1153,87 @@ func TestEnsureRunConfigConfigMap(t *testing.T) {
 			}
 		})
 	}
+
+	// Additional test: ConfigMap-based Authz referenced externally should be embedded into runconfig.json
+	t.Run("configmap with external authorization configuration", func(t *testing.T) {
+		t.Parallel()
+		testScheme := createRunConfigTestScheme()
+
+		mcpServer := &mcpv1alpha1.MCPServer{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "authz-cm-ext",
+				Namespace: "toolhive-system",
+			},
+			Spec: mcpv1alpha1.MCPServerSpec{
+				Image:     "ghcr.io/example/server:v1.0.0",
+				Transport: "stdio",
+				Port:      8080,
+				AuthzConfig: &mcpv1alpha1.AuthzConfigRef{
+					Type: mcpv1alpha1.AuthzConfigTypeConfigMap,
+					ConfigMap: &mcpv1alpha1.ConfigMapAuthzRef{
+						Name: "ext-authz-config",
+						Key:  "authz.json",
+					},
+				},
+			},
+		}
+
+		authzCM := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "ext-authz-config",
+				Namespace: "toolhive-system",
+			},
+			Data: map[string]string{
+				"authz.json": `{
+					"version": "v1",
+					"type": "cedarv1",
+					"cedar": {
+						"policies": [
+							"permit(principal, action == Action::\"call_tool\", resource == Tool::\"weather\");",
+							"permit(principal, action == Action::\"get_prompt\", resource == Prompt::\"greeting\");"
+						],
+						"entities_json": "[{\"uid\": {\"type\": \"User\", \"id\": \"user1\"}, \"attrs\": {}}]"
+					}
+				}`,
+			},
+		}
+
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(testScheme).
+			WithRuntimeObjects(mcpServer, authzCM).
+			Build()
+
+		reconciler := &MCPServerReconciler{
+			Client: fakeClient,
+			Scheme: testScheme,
+		}
+
+		err := reconciler.ensureRunConfigConfigMap(context.TODO(), mcpServer)
+		require.NoError(t, err)
+
+		// Fetch the generated runconfig ConfigMap
+		configMapName := fmt.Sprintf("%s-runconfig", mcpServer.Name)
+		configMap := &corev1.ConfigMap{}
+		err = fakeClient.Get(context.TODO(), types.NamespacedName{
+			Name:      configMapName,
+			Namespace: mcpServer.Namespace,
+		}, configMap)
+		require.NoError(t, err)
+
+		// Validate that authz config is embedded
+		var runConfig runner.RunConfig
+		err = json.Unmarshal([]byte(configMap.Data["runconfig.json"]), &runConfig)
+		require.NoError(t, err)
+
+		require.NotNil(t, runConfig.AuthzConfig)
+		assert.Equal(t, "v1", runConfig.AuthzConfig.Version)
+		assert.Equal(t, authz.ConfigTypeCedarV1, runConfig.AuthzConfig.Type)
+		require.NotNil(t, runConfig.AuthzConfig.Cedar)
+		assert.Len(t, runConfig.AuthzConfig.Cedar.Policies, 2)
+		assert.Contains(t, runConfig.AuthzConfig.Cedar.Policies, `permit(principal, action == Action::"call_tool", resource == Tool::"weather");`)
+		assert.Contains(t, runConfig.AuthzConfig.Cedar.Policies, `permit(principal, action == Action::"get_prompt", resource == Prompt::"greeting");`)
+		assert.Equal(t, `[{"uid": {"type": "User", "id": "user1"}, "attrs": {}}]`, runConfig.AuthzConfig.Cedar.EntitiesJSON)
+	})
 }
 
 // TestRunConfigContentEquals tests the content comparison logic

--- a/test/e2e/chainsaw/operator/single-tenancy/test-scenarios/authz-configmap-ref/assert-mcpserver-pod-running.yaml
+++ b/test/e2e/chainsaw/operator/single-tenancy/test-scenarios/authz-configmap-ref/assert-mcpserver-pod-running.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  namespace: toolhive-system
+  labels:
+    app: mcpserver
+    app.kubernetes.io/instance: authz-configmap-ref-test
+status:
+  phase: Running

--- a/test/e2e/chainsaw/operator/single-tenancy/test-scenarios/authz-configmap-ref/assert-mcpserver-running.yaml
+++ b/test/e2e/chainsaw/operator/single-tenancy/test-scenarios/authz-configmap-ref/assert-mcpserver-running.yaml
@@ -1,0 +1,7 @@
+apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: MCPServer
+metadata:
+  name: authz-configmap-ref-test
+  namespace: toolhive-system
+status:
+  phase: Running

--- a/test/e2e/chainsaw/operator/single-tenancy/test-scenarios/authz-configmap-ref/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/operator/single-tenancy/test-scenarios/authz-configmap-ref/chainsaw-test.yaml
@@ -1,0 +1,148 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: authz-configmap-ref-test
+spec:
+  description: Test that external ConfigMap-based authorization config is embedded into runconfig.json and used via --from-configmap
+  steps:
+  - name: enable-configmap-mode
+    try:
+    - script:
+        content: |
+          echo "Setting TOOLHIVE_USE_CONFIGMAP=true on operator deployment..."
+
+          kubectl patch deployment toolhive-operator -n toolhive-system --type='strategic' -p='{"spec":{"template":{"spec":{"containers":[{"name":"manager","env":[{"name":"TOOLHIVE_USE_CONFIGMAP","value":"true"}]}]}}}}'
+
+          kubectl rollout status deployment/toolhive-operator -n toolhive-system --timeout=60s
+
+          echo "Verifying TOOLHIVE_USE_CONFIGMAP environment variable is set..."
+          ENV_VAR=$(kubectl get deployment toolhive-operator -n toolhive-system -o jsonpath='{.spec.template.spec.containers[?(@.name=="manager")].env[?(@.name=="TOOLHIVE_USE_CONFIGMAP")].value}')
+          if [ "$ENV_VAR" = "true" ]; then
+            echo "✓ TOOLHIVE_USE_CONFIGMAP=true verified on operator deployment"
+          else
+            echo "✗ Failed to set TOOLHIVE_USE_CONFIGMAP environment variable"
+            exit 1
+          fi
+        timeout: 120s
+
+  - name: create-external-authz-configmap
+    try:
+    - script:
+        content: |
+          echo "Creating external authorization ConfigMap..."
+          kubectl apply -n toolhive-system -f - <<'EOF'
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: external-authz-config
+            namespace: toolhive-system
+          data:
+            authz.json: |
+              {
+                "version": "v1",
+                "type": "cedarv1",
+                "cedar": {
+                  "policies": [
+                    "permit(principal, action == Action::\"call_tool\", resource == Tool::\"weather\");",
+                    "permit(principal, action == Action::\"get_prompt\", resource == Prompt::\"greeting\");",
+                    "forbid(principal, action == Action::\"call_tool\", resource == Tool::\"sensitive_data\");"
+                  ],
+                  "entities_json": "[{\"uid\": {\"type\": \"User\", \"id\": \"user1\"}, \"attrs\": {\"role\": \"viewer\"}}, {\"uid\": {\"type\": \"User\", \"id\": \"admin\"}, \"attrs\": {\"role\": \"admin\"}}]"
+                }
+              }
+          EOF
+          echo "✓ External authorization ConfigMap created"
+        timeout: 60s
+
+  - name: create-mcpserver-with-authz-ref
+    try:
+    - apply:
+        file: mcpserver-authz-ref.yaml
+    - assert:
+        file: assert-mcpserver-running.yaml
+        timeout: 180s
+
+  - name: verify-pod-running
+    try:
+    - assert:
+        file: assert-mcpserver-pod-running.yaml
+        timeout: 180s
+
+  - name: verify-configmap-authz-config-embedded
+    try:
+    - script:
+        content: |
+          echo "Verifying RunConfig ConfigMap includes embedded authorization config..."
+
+          for i in $(seq 1 20); do
+            if kubectl get configmap -n toolhive-system -l toolhive.stacklok.io/mcp-server=authz-configmap-ref-test >/dev/null 2>&1; then
+              echo "✓ RunConfig ConfigMap exists"
+              break
+            fi
+            echo "  Waiting for runconfig ConfigMap... (attempt $i/20)"
+            sleep 3
+          done
+
+          CONFIGMAP_JSON=$(kubectl get configmap -n toolhive-system -l toolhive.stacklok.io/mcp-server=authz-configmap-ref-test -o jsonpath='{.items[0].data.runconfig\.json}' 2>/dev/null || echo "")
+          if [ -z "$CONFIGMAP_JSON" ]; then
+            echo "✗ ConfigMap does not contain runconfig.json data"
+            kubectl get configmap -n toolhive-system -l toolhive.stacklok.io/mcp-server=authz-configmap-ref-test -o yaml
+            exit 1
+          fi
+
+          echo "$CONFIGMAP_JSON" | jq -e '.authz_config' >/dev/null
+          VERSION=$(echo "$CONFIGMAP_JSON" | jq -r '.authz_config.version // empty')
+          TYPE=$(echo "$CONFIGMAP_JSON" | jq -r '.authz_config.type // empty')
+          test "$VERSION" = "v1"
+          test "$TYPE" = "cedarv1"
+
+          echo "$CONFIGMAP_JSON" | jq -e '.authz_config.cedar' >/dev/null
+          POLICIES_COUNT=$(echo "$CONFIGMAP_JSON" | jq '.authz_config.cedar.policies | length')
+          test "$POLICIES_COUNT" = "3"
+
+          echo "$CONFIGMAP_JSON" | jq -r '.authz_config.cedar.policies[]' | grep -q "weather"
+          echo "$CONFIGMAP_JSON" | jq -r '.authz_config.cedar.policies[]' | grep -q "greeting"
+          echo "$CONFIGMAP_JSON" | jq -r '.authz_config.cedar.policies[]' | grep -qi "forbid"
+
+          ENTITIES_JSON=$(echo "$CONFIGMAP_JSON" | jq -r '.authz_config.cedar.entities_json // empty')
+          test -n "$ENTITIES_JSON"
+          ENTITIES_COUNT=$(echo "$ENTITIES_JSON" | jq '. | length')
+          test "$ENTITIES_COUNT" = "2"
+
+          echo "✓ Authorization configuration embedded and validated in runconfig.json"
+        timeout: 120s
+
+  - name: verify-proxyrunner-uses-from-configmap
+    try:
+    - script:
+        content: |
+          echo "Verifying proxyrunner uses --from-configmap and no --authz-config flag..."
+
+          DEPLOYMENT_ARGS=$(kubectl get deployment authz-configmap-ref-test -n toolhive-system -o jsonpath='{.spec.template.spec.containers[0].args}' 2>/dev/null || echo "")
+          if [ -z "$DEPLOYMENT_ARGS" ]; then
+            echo "✗ Could not find deployment arguments"
+            exit 1
+          fi
+
+          echo "$DEPLOYMENT_ARGS" | grep -q -- "--from-configmap"
+          if echo "$DEPLOYMENT_ARGS" | grep -q -- "--authz-config"; then
+            echo "✗ --authz-config flag found in deployment arguments (should not be present when using ConfigMap)"
+            echo "Deployment args: $DEPLOYMENT_ARGS"
+            exit 1
+          fi
+
+          echo "✓ Deployment args validated"
+        timeout: 60s
+
+  - name: cleanup-configmap-mode
+    try:
+    - script:
+        content: |
+          echo "Cleaning up external authz ConfigMap and disabling ConfigMap mode..."
+          kubectl delete configmap external-authz-config -n toolhive-system --ignore-not-found
+          kubectl wait --for=delete configmap external-authz-config -n toolhive-system --timeout=60s || true
+
+          kubectl patch deployment toolhive-operator -n toolhive-system --type='strategic' -p='{"spec":{"template":{"spec":{"containers":[{"name":"manager","env":[{"name":"TOOLHIVE_USE_CONFIGMAP","value":"false"}]}]}}}}'
+          kubectl rollout status deployment/toolhive-operator -n toolhive-system --timeout=60s
+          echo "✓ Cleanup completed"
+        timeout: 120s

--- a/test/e2e/chainsaw/operator/single-tenancy/test-scenarios/authz-configmap-ref/mcpserver-authz-ref.yaml
+++ b/test/e2e/chainsaw/operator/single-tenancy/test-scenarios/authz-configmap-ref/mcpserver-authz-ref.yaml
@@ -1,0 +1,27 @@
+apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: MCPServer
+metadata:
+  name: authz-configmap-ref-test
+  namespace: toolhive-system
+spec:
+  image: ghcr.io/stackloklabs/yardstick/yardstick-server:0.0.2
+  transport: stdio
+  port: 8080
+
+  # Reference external ConfigMap-based authorization configuration
+  authzConfig:
+    type: configMap
+    configMap:
+      name: external-authz-config
+      key: authz.json
+
+  permissionProfile:
+    type: builtin
+    name: network
+  resources:
+    limits:
+      cpu: "100m"
+      memory: "128Mi"
+    requests:
+      cpu: "50m"
+      memory: "64Mi"


### PR DESCRIPTION
Summary
- Implement ConfigMap support for authorization (Authz) configuration in the operator-managed RunConfig.
- When AuthzConfigRef.type=configMap, the operator fetches the referenced ConfigMap, parses YAML/JSON into authz.Config, validates it, and embeds it into runconfig.json.
- In ConfigMap mode, the proxyrunner deployment uses --from-configmap and does not pass --authz-config.

Key Changes
- Added ConfigMap-based Authz handling in the RunConfig builder path to embed authz.Config:
  - Fetch ConfigMap (same namespace as MCPServer), default key "authz.json" when unspecified, parse YAML/JSON, validate, and include via WithAuthzConfig.
- Ensure proxyrunner args use --from-configmap when TOOLHIVE_USE_CONFIGMAP is true and omit --authz-config to avoid conflicting flags.
- Added checksum-based update logic already in place to reflect runconfig.json changes.

Files
- cmd/thv-operator/controllers/mcpserver_runconfig.go: addAuthzConfigOptions(ctx, m, &options, m.Spec.AuthzConfig) to support Inline and ConfigMap; use YAML/JSON unmarshal and cfg.Validate().
- cmd/thv-operator/controllers/mcpserver_runconfig_test.go: unit tests for inline and ConfigMap-based Authz embedding into runconfig.json, plus deterministic and ensure logic tests.
- test/e2e/chainsaw/operator/single-tenancy/test-scenarios/authz-configmap-ref/*: Chainsaw scenario validating external ConfigMap reference results in embedded authz_config in runconfig.json, correct policies/entities, and deployment args include --from-configmap only.

Testing
- golangci-lint run --fix ./... passes cleanly.
- Unit tests pass: go test -v ./cmd/thv-operator/controllers
- Chainsaw E2E scenario added to validate operator behavior in cluster with external Authz ConfigMap.

Notes
- Default key for Authz ConfigMap content is authz.json when not provided.
- Authz config supports both JSON and YAML content formats.
- This change aligns with configmap-driven runconfig mode and avoids conflicting flags when --from-configmap is used.
