### PR TITLE
use server url as issuer if not derived from realm or resource metadata

### DIFF
--- a/cmd/thv/app/auth_flags.go
+++ b/cmd/thv/app/auth_flags.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/stacklok/toolhive/pkg/runner"
 )
 
 // RemoteAuthFlags holds the common remote authentication configuration
@@ -39,7 +40,7 @@ func AddRemoteAuthFlags(cmd *cobra.Command, config *RemoteAuthFlags) {
 		"Skip opening browser for remote server OAuth flow")
 	cmd.Flags().DurationVar(&config.RemoteAuthTimeout, "remote-auth-timeout", 30*time.Second,
 		"Timeout for OAuth authentication flow (e.g., 30s, 1m, 2m30s)")
-	cmd.Flags().IntVar(&config.RemoteAuthCallbackPort, "remote-auth-callback-port", 8666,
+	cmd.Flags().IntVar(&config.RemoteAuthCallbackPort, "remote-auth-callback-port", runner.DefaultCallbackPort,
 		"Port for OAuth callback server during remote authentication")
 	cmd.Flags().StringVar(&config.RemoteAuthAuthorizeURL, "remote-auth-authorize-url", "",
 		"OAuth authorization endpoint URL (alternative to --remote-auth-issuer for non-OIDC OAuth)")

--- a/cmd/thv/app/run_flags.go
+++ b/cmd/thv/app/run_flags.go
@@ -455,14 +455,12 @@ func buildRunnerConfig(
 	)
 
 	if remoteServerMetadata, ok := serverMetadata.(*registry.RemoteServerMetadata); ok {
-		if remoteAuthConfig := getRemoteAuthFromRemoteServerMetadata(remoteServerMetadata); remoteAuthConfig != nil {
-			opts = append(opts, runner.WithRemoteAuth(remoteAuthConfig), runner.WithRemoteURL(remoteServerMetadata.URL))
-		}
+		remoteAuthConfig := getRemoteAuthFromRemoteServerMetadata(remoteServerMetadata)
+		opts = append(opts, runner.WithRemoteAuth(remoteAuthConfig), runner.WithRemoteURL(remoteServerMetadata.URL))
 	}
 	if runFlags.RemoteURL != "" {
-		if remoteAuthConfig := getRemoteAuthFromRunFlags(runFlags); remoteAuthConfig != nil {
-			opts = append(opts, runner.WithRemoteAuth(remoteAuthConfig))
-		}
+		remoteAuthConfig := getRemoteAuthFromRunFlags(runFlags)
+		opts = append(opts, runner.WithRemoteAuth(remoteAuthConfig))
 	}
 
 	// Load authz config if path is provided
@@ -527,6 +525,9 @@ func getRemoteAuthFromRemoteServerMetadata(remoteServerMetadata *registry.Remote
 	}
 
 	if remoteServerMetadata.OAuthConfig != nil {
+		if remoteServerMetadata.OAuthConfig.CallbackPort == 0 {
+			remoteServerMetadata.OAuthConfig.CallbackPort = runner.DefaultCallbackPort
+		}
 		return &runner.RemoteAuthConfig{
 			ClientID:     runFlags.RemoteAuthFlags.RemoteAuthClientID,
 			ClientSecret: runFlags.RemoteAuthFlags.RemoteAuthClientSecret,

--- a/pkg/auth/discovery/discovery.go
+++ b/pkg/auth/discovery/discovery.go
@@ -231,6 +231,33 @@ func ParseWWWAuthenticate(header string) (*AuthInfo, error) {
 	return nil, fmt.Errorf("no supported authentication type found in header: %s", header)
 }
 
+// DeriveIssuerFromURL attempts to derive the OAuth issuer from the remote URL using general patterns
+func DeriveIssuerFromURL(remoteURL string) string {
+	// Parse the URL to extract the domain
+	parsedURL, err := url.Parse(remoteURL)
+	if err != nil {
+		logger.Debugf("Failed to parse remote URL: %v", err)
+		return ""
+	}
+
+	host := parsedURL.Hostname()
+	if host == "" {
+		return ""
+	}
+
+	scheme := parsedURL.Scheme
+	if scheme == "" {
+		scheme = "https"
+	}
+
+	// General pattern: use the domain as the issuer
+	// This works for most OAuth providers that use their domain as the issuer
+	issuer := fmt.Sprintf("%s://%s", scheme, host)
+
+	logger.Debugf("Derived issuer from URL - remoteURL: %s, issuer: %s", remoteURL, issuer)
+	return issuer
+}
+
 // ExtractParameter extracts a parameter value from an authentication header
 // Handles both quoted and unquoted values according to RFC 2617 and RFC 6750
 func ExtractParameter(params, paramName string) string {

--- a/pkg/runner/config.go
+++ b/pkg/runner/config.go
@@ -464,3 +464,5 @@ type ToolOverride struct {
 	// Description is the redefined description of the tool
 	Description string `json:"description,omitempty"`
 }
+
+const DefaultCallbackPort = 8666

--- a/pkg/runner/config_builder.go
+++ b/pkg/runner/config_builder.go
@@ -76,6 +76,11 @@ func WithRemoteURL(remoteURL string) RunConfigBuilderOption {
 // WithRemoteAuth sets the remote authentication configuration
 func WithRemoteAuth(config *RemoteAuthConfig) RunConfigBuilderOption {
 	return func(b *runConfigBuilder) error {
+		if config == nil {
+			config = &RemoteAuthConfig{
+				CallbackPort: DefaultCallbackPort,
+			}
+		}
 		b.config.RemoteAuthConfig = config
 		return nil
 	}

--- a/pkg/runner/remote_auth.go
+++ b/pkg/runner/remote_auth.go
@@ -40,7 +40,7 @@ func (h *RemoteAuthHandler) Authenticate(ctx context.Context, remoteURL string) 
 		// Handle OAuth authentication
 		if authInfo.Type == "OAuth" {
 			// Discover the issuer and potentially update scopes
-			issuer, scopes, authServerInfo, err := h.discoverIssuerAndScopes(ctx, authInfo)
+			issuer, scopes, authServerInfo, err := h.discoverIssuerAndScopes(ctx, authInfo, remoteURL)
 			if err != nil {
 				return nil, err
 			}
@@ -91,6 +91,7 @@ func (h *RemoteAuthHandler) Authenticate(ctx context.Context, remoteURL string) 
 func (h *RemoteAuthHandler) discoverIssuerAndScopes(
 	ctx context.Context,
 	authInfo *discovery.AuthInfo,
+	remoteURL string,
 ) (string, []string, *discovery.AuthServerInfo, error) {
 	// Priority 1: Use configured issuer if available
 	if h.config.Issuer != "" {
@@ -110,6 +111,11 @@ func (h *RemoteAuthHandler) discoverIssuerAndScopes(
 	// Priority 3: Fetch from resource metadata (RFC 9728)
 	if authInfo.ResourceMetadata != "" {
 		return h.tryDiscoverFromResourceMetadata(ctx, authInfo.ResourceMetadata)
+	}
+
+	issuer := discovery.DeriveIssuerFromURL(remoteURL)
+	if issuer != "" {
+		return issuer, h.config.Scopes, nil, nil
 	}
 
 	// No issuer could be determined


### PR DESCRIPTION
## Problem Statement

Our `discoverIssuerAndScopes` function currently assumes that the `realm` parameter from the `WWW-Authenticate` header is a fully qualified HTTPS issuer URL (per RFC 8414).  

However, in practice many MCP servers — including the one we are testing against — only set `realm` to a simple string (e.g. `"OAuth"`) as a protection space identifier, **not** a URL.

As a result:

- `DeriveIssuerFromRealm` rejects the value since it is not a valid HTTPS URL.
- `ResourceMetadata` is empty (because the server does not include a `resource_metadata` parameter).
- No issuer is discovered, causing OAuth discovery and authentication to fail.

This strict interpretation of `realm` breaks compatibility with servers that follow the more common pattern of exposing their authorization server metadata via standard well-known endpoints but use a non-URL `realm`.

## Impact

- Clients cannot authenticate against servers that return a non-URL `realm` and do not provide `resource_metadata`.
- OAuth discovery stops prematurely, forcing users to manually configure the issuer.

## Solution (Implemented)

- Preserve existing behavior when `realm` is a valid HTTPS URL.
- If `realm` is present but **not** a URL, attempt to discover the issuer by probing:
  - `/.well-known/oauth-authorization-server`
  - `/.well-known/openid-configuration`
- Return the discovered `issuer` and `scopes_supported` if found, falling back gracefully if not.

This makes discovery compliant with RFC 8414/RFC 9728 but more robust against real-world server configurations.
