### PR TITLE
fix default callback port for registry

### DIFF
--- a/cmd/thv/app/auth_flags.go
+++ b/cmd/thv/app/auth_flags.go
@@ -4,6 +4,8 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+
+	"github.com/stacklok/toolhive/pkg/runner"
 )
 
 // RemoteAuthFlags holds the common remote authentication configuration
@@ -39,7 +41,7 @@ func AddRemoteAuthFlags(cmd *cobra.Command, config *RemoteAuthFlags) {
 		"Skip opening browser for remote server OAuth flow")
 	cmd.Flags().DurationVar(&config.RemoteAuthTimeout, "remote-auth-timeout", 30*time.Second,
 		"Timeout for OAuth authentication flow (e.g., 30s, 1m, 2m30s)")
-	cmd.Flags().IntVar(&config.RemoteAuthCallbackPort, "remote-auth-callback-port", 8666,
+	cmd.Flags().IntVar(&config.RemoteAuthCallbackPort, "remote-auth-callback-port", runner.DefaultCallbackPort,
 		"Port for OAuth callback server during remote authentication")
 	cmd.Flags().StringVar(&config.RemoteAuthAuthorizeURL, "remote-auth-authorize-url", "",
 		"OAuth authorization endpoint URL (alternative to --remote-auth-issuer for non-OIDC OAuth)")

--- a/cmd/thv/app/run_flags.go
+++ b/cmd/thv/app/run_flags.go
@@ -457,14 +457,12 @@ func buildRunnerConfig(
 	)
 
 	if remoteServerMetadata, ok := serverMetadata.(*registry.RemoteServerMetadata); ok {
-		if remoteAuthConfig := getRemoteAuthFromRemoteServerMetadata(remoteServerMetadata); remoteAuthConfig != nil {
-			opts = append(opts, runner.WithRemoteAuth(remoteAuthConfig), runner.WithRemoteURL(remoteServerMetadata.URL))
-		}
+		remoteAuthConfig := getRemoteAuthFromRemoteServerMetadata(remoteServerMetadata)
+		opts = append(opts, runner.WithRemoteAuth(remoteAuthConfig), runner.WithRemoteURL(remoteServerMetadata.URL))
 	}
 	if runFlags.RemoteURL != "" {
-		if remoteAuthConfig := getRemoteAuthFromRunFlags(runFlags); remoteAuthConfig != nil {
-			opts = append(opts, runner.WithRemoteAuth(remoteAuthConfig))
-		}
+		remoteAuthConfig := getRemoteAuthFromRunFlags(runFlags)
+		opts = append(opts, runner.WithRemoteAuth(remoteAuthConfig))
 	}
 
 	// Load authz config if path is provided
@@ -529,6 +527,9 @@ func getRemoteAuthFromRemoteServerMetadata(remoteServerMetadata *registry.Remote
 	}
 
 	if remoteServerMetadata.OAuthConfig != nil {
+		if remoteServerMetadata.OAuthConfig.CallbackPort == 0 {
+			remoteServerMetadata.OAuthConfig.CallbackPort = runner.DefaultCallbackPort
+		}
 		return &runner.RemoteAuthConfig{
 			ClientID:     runFlags.RemoteAuthFlags.RemoteAuthClientID,
 			ClientSecret: runFlags.RemoteAuthFlags.RemoteAuthClientSecret,

--- a/pkg/runner/config.go
+++ b/pkg/runner/config.go
@@ -464,3 +464,6 @@ type ToolOverride struct {
 	// Description is the redefined description of the tool
 	Description string `json:"description,omitempty"`
 }
+
+// DefaultCallbackPort is the default port for the OAuth callback server
+const DefaultCallbackPort = 8666

--- a/pkg/runner/config_builder.go
+++ b/pkg/runner/config_builder.go
@@ -76,6 +76,11 @@ func WithRemoteURL(remoteURL string) RunConfigBuilderOption {
 // WithRemoteAuth sets the remote authentication configuration
 func WithRemoteAuth(config *RemoteAuthConfig) RunConfigBuilderOption {
 	return func(b *runConfigBuilder) error {
+		if config == nil {
+			config = &RemoteAuthConfig{
+				CallbackPort: DefaultCallbackPort,
+			}
+		}
 		b.config.RemoteAuthConfig = config
 		return nil
 	}


### PR DESCRIPTION
## Problem

When using a registry without an explicit OAuth configuration:

- The `oauth` configuration object remained `nil`.
- The default callback port was never set.


## Solution

This PR:

- Initializes a default OAuth configuration when none is provided.
- Sets a default callback port of **8666** to ensure a predictable callback URL.

