### PR TITLE
operator: use defaultAuthzKey for authz filename

### DIFF
--- a/cmd/thv-operator/controllers/mcpserver_controller.go
+++ b/cmd/thv-operator/controllers/mcpserver_controller.go
@@ -1419,9 +1419,9 @@ func (*MCPServerReconciler) generateAuthzVolumeConfig(m *mcpv1alpha1.MCPServer) 
 								if m.Spec.AuthzConfig.ConfigMap.Key != "" {
 									return m.Spec.AuthzConfig.ConfigMap.Key
 								}
-								return "authz.json"
+								return defaultAuthzKey
 							}(),
-							Path: "authz.json",
+							Path: defaultAuthzKey,
 						},
 					},
 				},
@@ -1450,8 +1450,8 @@ func (*MCPServerReconciler) generateAuthzVolumeConfig(m *mcpv1alpha1.MCPServer) 
 					},
 					Items: []corev1.KeyToPath{
 						{
-							Key:  "authz.json",
-							Path: "authz.json",
+							Key:  defaultAuthzKey,
+							Path: defaultAuthzKey,
 						},
 					},
 				},
@@ -1734,7 +1734,7 @@ func (*MCPServerReconciler) generateAuthzArgs(m *mcpv1alpha1.MCPServer) []string
 	}
 
 	// Both ConfigMap and inline configurations use the same mounted path
-	authzConfigPath := "/etc/toolhive/authz/authz.json"
+	authzConfigPath := fmt.Sprintf("/etc/toolhive/authz/%s", defaultAuthzKey)
 	args = append(args, fmt.Sprintf("--authz-config=%s", authzConfigPath))
 
 	return args
@@ -1872,7 +1872,7 @@ func (r *MCPServerReconciler) ensureAuthzConfigMap(ctx context.Context, m *mcpv1
 			Labels:    labelsForInlineAuthzConfig(m.Name),
 		},
 		Data: map[string]string{
-			"authz.json": string(authzConfigJSON),
+			defaultAuthzKey: string(authzConfigJSON),
 		},
 	}
 

--- a/cmd/thv-operator/controllers/mcpserver_runconfig.go
+++ b/cmd/thv-operator/controllers/mcpserver_runconfig.go
@@ -32,6 +32,9 @@ const defaultProxyHost = "0.0.0.0"
 // defaultAPITimeout is the default timeout for Kubernetes API calls made during reconciliation
 const defaultAPITimeout = 15 * time.Second
 
+// defaultAuthzKey is the default key in the ConfigMap for authorization configuration
+const defaultAuthzKey = "authz.json"
+
 // RunConfig management methods
 
 // computeConfigMapChecksum computes a SHA256 checksum of the ConfigMap content for change detection
@@ -674,7 +677,7 @@ func (r *MCPServerReconciler) addAuthzConfigOptions(
 		}
 		key := authzRef.ConfigMap.Key
 		if key == "" {
-			key = "authz.json"
+			key = defaultAuthzKey
 		}
 
 		// Ensure we have a Kubernetes client to fetch the ConfigMap

--- a/cmd/thv-operator/controllers/mcpserver_runconfig_test.go
+++ b/cmd/thv-operator/controllers/mcpserver_runconfig_test.go
@@ -26,7 +26,6 @@ const (
 	stdioTransport          = "stdio"
 	sseProxyMode            = "sse"
 	streamableHTTPProxyMode = "streamable-http"
-	defaultAuthzKey         = "authz.json"
 )
 
 func createRunConfigTestScheme() *runtime.Scheme {


### PR DESCRIPTION
Replace hardcoded "authz.json" with the existing package-level constant defaultAuthzKey in the operator controllers to centralize the default and avoid drift.

What/Why:
- Centralize the default authorization filename into a single constant used across controller code paths.
- Prevent future divergence and make updates easier.

Changes:
- Use defaultAuthzKey when deriving the ConfigMap key fallback.
- Use defaultAuthzKey for volume items (key/path) for both ConfigMap and inline authz.
- Build the --authz-config flag path using defaultAuthzKey instead of a literal.
- Remove the redundant test-local constant so tests rely on the shared package constant.

Validation:
- Operator unit tests pass locally.