### PR TITLE
operator: fix data race by removing global ctx logger

### DIFF
--- a/cmd/thv-operator/controllers/mcpserver_controller.go
+++ b/cmd/thv-operator/controllers/mcpserver_controller.go
@@ -78,8 +78,6 @@ var defaultRBACRules = []rbacv1.PolicyRule{
 	},
 }
 
-var ctxLogger = log.FromContext(context.Background())
-
 // mcpContainerName is the name of the mcp container used in pod templates
 const mcpContainerName = "mcp"
 
@@ -146,7 +144,7 @@ func (r *MCPServerReconciler) detectPlatform(ctx context.Context) (kubernetes.Pl
 //
 //nolint:gocyclo
 func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	ctxLogger = log.FromContext(ctx)
+	ctxLogger := log.FromContext(ctx)
 
 	// Fetch the MCPServer instance
 	mcpServer := &mcpv1alpha1.MCPServer{}
@@ -358,6 +356,7 @@ func (r *MCPServerReconciler) createRBACResource(
 	resourceType string,
 	createResource func() client.Object,
 ) error {
+	ctxLogger := log.FromContext(ctx)
 	desired := createResource()
 	if err := controllerutil.SetControllerReference(mcpServer, desired, r.Scheme); err != nil {
 		logger.Errorf("Failed to set controller reference for %s: %v", resourceType, err)
@@ -384,6 +383,7 @@ func (r *MCPServerReconciler) updateRBACResourceIfNeeded(
 	createResource func() client.Object,
 	current client.Object,
 ) error {
+	ctxLogger := log.FromContext(ctx)
 	desired := createResource()
 	if err := controllerutil.SetControllerReference(mcpServer, desired, r.Scheme); err != nil {
 		logger.Errorf("Failed to set controller reference for %s: %v", resourceType, err)
@@ -408,6 +408,7 @@ func (r *MCPServerReconciler) updateRBACResourceIfNeeded(
 
 // handleToolConfig handles MCPToolConfig reference for an MCPServer
 func (r *MCPServerReconciler) handleToolConfig(ctx context.Context, m *mcpv1alpha1.MCPServer) error {
+	ctxLogger := log.FromContext(ctx)
 	if m.Spec.ToolConfigRef == nil {
 		// No MCPToolConfig referenced, clear any stored hash
 		if m.Status.ToolConfigHash != "" {
@@ -1022,6 +1023,7 @@ func (r *MCPServerReconciler) updateMCPServerStatus(ctx context.Context, m *mcpv
 
 // finalizeMCPServer performs the finalizer logic for the MCPServer
 func (r *MCPServerReconciler) finalizeMCPServer(ctx context.Context, m *mcpv1alpha1.MCPServer) error {
+	ctxLogger := log.FromContext(ctx)
 	// Update the MCPServer status
 	m.Status.Phase = mcpv1alpha1.MCPServerPhaseTerminating
 	m.Status.Message = "MCP server is being terminated"
@@ -1835,6 +1837,7 @@ func (*MCPServerReconciler) generateOpenTelemetryEnvVars(m *mcpv1alpha1.MCPServe
 
 // ensureAuthzConfigMap ensures the authorization ConfigMap exists for inline configuration
 func (r *MCPServerReconciler) ensureAuthzConfigMap(ctx context.Context, m *mcpv1alpha1.MCPServer) error {
+	ctxLogger := log.FromContext(ctx)
 	// Only create ConfigMap for inline authorization configuration
 	if m.Spec.AuthzConfig == nil || m.Spec.AuthzConfig.Type != mcpv1alpha1.AuthzConfigTypeInline ||
 		m.Spec.AuthzConfig.Inline == nil {

--- a/cmd/thv-operator/controllers/mcpserver_runconfig.go
+++ b/cmd/thv-operator/controllers/mcpserver_runconfig.go
@@ -18,6 +18,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	mcpv1alpha1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1alpha1"
 	"github.com/stacklok/toolhive/pkg/authz"
@@ -127,6 +128,7 @@ func (r *MCPServerReconciler) ensureRunConfigConfigMapResource(
 	mcpServer *mcpv1alpha1.MCPServer,
 	desired *corev1.ConfigMap,
 ) error {
+	ctxLogger := log.FromContext(ctx)
 	current := &corev1.ConfigMap{}
 	objectKey := types.NamespacedName{Name: desired.Name, Namespace: desired.Namespace}
 	err := r.Get(ctx, objectKey, current)


### PR DESCRIPTION
Summary
- Remove the package-level ctx logger and use request-scoped loggers via controller-runtime's log.FromContext(ctx) to avoid concurrent writes/reads.
- Replace all logging in MCPServer controller and runconfig paths with context-derived loggers.

Files changed
- [`mcpserver_controller.go`](cmd/thv-operator/controllers/mcpserver_controller.go)
- [`mcpserver_runconfig.go`](cmd/thv-operator/controllers/mcpserver_runconfig.go)

Motivation
Race detector reported a data race between concurrent Reconcile and ensureRunConfigConfigMapResource paths:
- Write at [`MCPServerReconciler.Reconcile()`](cmd/thv-operator/controllers/mcpserver_controller.go:148)
- Read at [`ensureRunConfigConfigMapResource()`](cmd/thv-operator/controllers/mcpserver_runconfig.go:131)
Root cause was a global mutable logger reassigned per request and read concurrently elsewhere. This PR removes the shared global and scopes logging to ctx, which is concurrency-safe.

Validation
- Lint fix: `task lint-fix` => 0 issues.
- Unit tests with race detector: `go test ./cmd/thv-operator/controllers -race -count=1` => ok, no races.

Notes
- No behavioral changes other than logging context; reconciliation logic remains the same.
- This should stabilize parallel test runs and any concurrent reconciliations.