### PR TITLE
Add thv group run command with full container and remote server support

### DIFF
--- a/cmd/thv/app/group.go
+++ b/cmd/thv/app/group.go
@@ -11,9 +11,14 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/stacklok/toolhive/pkg/client"
+	"github.com/stacklok/toolhive/pkg/container"
 	runtime "github.com/stacklok/toolhive/pkg/container/runtime"
 	"github.com/stacklok/toolhive/pkg/core"
 	"github.com/stacklok/toolhive/pkg/groups"
+	"github.com/stacklok/toolhive/pkg/logger"
+	"github.com/stacklok/toolhive/pkg/registry"
+	"github.com/stacklok/toolhive/pkg/runner/retriever"
+	"github.com/stacklok/toolhive/pkg/transport"
 	"github.com/stacklok/toolhive/pkg/validation"
 	"github.com/stacklok/toolhive/pkg/workloads"
 )
@@ -51,6 +56,16 @@ var groupRmCmd = &cobra.Command{
 	RunE:    groupRmCmdFunc,
 }
 
+var groupRunCmd = &cobra.Command{
+	Use:   "run [group-name]",
+	Short: "Deploy all MCP servers from a registry group",
+	Long: `Deploy all MCP servers defined in a registry group.
+		 This creates a new runtime group and starts all MCP servers within it.`,
+	Args:    cobra.ExactArgs(1),
+	PreRunE: validateGroupArg(),
+	RunE:    groupRunCmdFunc,
+}
+
 func validateGroupArg() func(cmd *cobra.Command, args []string) error {
 	return func(_ *cobra.Command, args []string) error {
 		if len(args) == 0 {
@@ -63,7 +78,11 @@ func validateGroupArg() func(cmd *cobra.Command, args []string) error {
 	}
 }
 
-var withWorkloadsFlag bool
+var (
+	withWorkloadsFlag bool
+	groupSecrets      []string
+	groupEnvVars      []string
+)
 
 func groupCreateCmdFunc(cmd *cobra.Command, args []string) error {
 	groupName := args[0]
@@ -309,12 +328,381 @@ func updateClientConfigurations(ctx context.Context, groupWorkloads []core.Workl
 	return nil
 }
 
+func groupRunCmdFunc(cmd *cobra.Command, args []string) error {
+	groupName := args[0]
+	ctx := cmd.Context()
+
+	// Get registry provider
+	registryProvider, err := registry.GetDefaultProvider()
+	if err != nil {
+		return fmt.Errorf("failed to get registry provider: %w", err)
+	}
+
+	// Get registry data
+	reg, err := registryProvider.GetRegistry()
+	if err != nil {
+		return fmt.Errorf("failed to get registry: %w", err)
+	}
+
+	// Find the group in the registry
+	registryGroup, found := reg.GetGroupByName(groupName)
+	if !found {
+		return fmt.Errorf("group '%s' not found in registry", groupName)
+	}
+
+	totalServers := len(registryGroup.Servers) + len(registryGroup.RemoteServers)
+	fmt.Printf("Found registry group '%s' with %d servers (%d container, %d remote)\n",
+		registryGroup.Name, totalServers, len(registryGroup.Servers), len(registryGroup.RemoteServers))
+
+	// Validate all preconditions before making any changes
+	if err := validateGroupRunPreconditions(ctx, groupName, registryGroup, groupSecrets, groupEnvVars); err != nil {
+		return err
+	}
+
+	// Create managers
+	groupManager, err := groups.NewManager()
+	if err != nil {
+		return fmt.Errorf("failed to create group manager: %w", err)
+	}
+
+	// Create the runtime group
+	if err := groupManager.Create(ctx, groupName); err != nil {
+		return fmt.Errorf("failed to create group '%s': %w", groupName, err)
+	}
+	fmt.Printf("Created runtime group '%s'\n", groupName)
+
+	// Deploy servers - continue on failure but warn user
+	var successfulServers []string
+	var failedServers []string
+
+	// Deploy container servers
+	for serverName, serverMetadata := range registryGroup.Servers {
+		fmt.Printf("Deploying server '%s' from image '%s'\n", serverName, serverMetadata.Image)
+
+		if err := deployServer(ctx, serverName, serverMetadata, groupName, groupSecrets, groupEnvVars, cmd); err != nil {
+			fmt.Printf("Warning: failed to deploy server '%s': %v\n", serverName, err)
+			failedServers = append(failedServers, serverName)
+			continue
+		}
+
+		successfulServers = append(successfulServers, serverName)
+		fmt.Printf("Started server '%s'\n", serverName)
+	}
+
+	// Deploy remote servers
+	for serverName, serverMetadata := range registryGroup.RemoteServers {
+		fmt.Printf("Deploying remote server '%s' at URL '%s'\n", serverName, serverMetadata.URL)
+
+		if err := deployRemoteServer(ctx, serverName, groupName, groupSecrets, groupEnvVars, cmd); err != nil {
+			fmt.Printf("Warning: failed to deploy remote server '%s': %v\n", serverName, err)
+			failedServers = append(failedServers, serverName)
+			continue
+		}
+
+		successfulServers = append(successfulServers, serverName)
+		fmt.Printf("Started remote server '%s'\n", serverName)
+	}
+
+	// Report deployment results
+	if len(successfulServers) > 0 {
+		fmt.Printf("Successfully deployed %d servers in group '%s': %v\n", len(successfulServers), groupName, successfulServers)
+	}
+	if len(failedServers) > 0 {
+		fmt.Printf("Warning: %d servers failed to deploy: %v\n", len(failedServers), failedServers)
+	}
+
+	return nil
+}
+
+// validateGroupRunPreconditions validates all conditions before making any changes
+func validateGroupRunPreconditions(ctx context.Context, groupName string,
+	registryGroup *registry.Group, secrets []string, envVars []string) error {
+	if err := validateRuntimeGroupDoesNotExist(ctx, groupName); err != nil {
+		return err
+	}
+	if err := validateServersDoNotExist(ctx, registryGroup); err != nil {
+		return err
+	}
+	if err := validateSecretsFormat(secrets, registryGroup); err != nil {
+		return err
+	}
+	return validateEnvVarsFormat(envVars, registryGroup)
+}
+
+// validateRuntimeGroupDoesNotExist checks that the runtime group doesn't already exist
+func validateRuntimeGroupDoesNotExist(ctx context.Context, groupName string) error {
+	groupManager, err := groups.NewManager()
+	if err != nil {
+		return fmt.Errorf("failed to create group manager: %w", err)
+	}
+
+	exists, err := groupManager.Exists(ctx, groupName)
+	if err != nil {
+		return fmt.Errorf("failed to check if group exists: %w", err)
+	}
+	if exists {
+		return fmt.Errorf("runtime group '%s' already exists", groupName)
+	}
+	return nil
+}
+
+// validateServersDoNotExist checks that no servers in the group already exist as workloads
+func validateServersDoNotExist(ctx context.Context, registryGroup *registry.Group) error {
+	rt, err := container.NewFactory().Create(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to create container runtime: %w", err)
+	}
+	workloadManager, err := workloads.NewManagerFromRuntime(rt)
+	if err != nil {
+		return fmt.Errorf("failed to create workload manager: %w", err)
+	}
+
+	// Check container servers
+	for serverName := range registryGroup.Servers {
+		exists, err := workloadManager.DoesWorkloadExist(ctx, serverName)
+		if err != nil {
+			return fmt.Errorf("failed to check if server '%s' exists: %w", serverName, err)
+		}
+		if exists {
+			return fmt.Errorf("MCP server '%s' already exists", serverName)
+		}
+	}
+
+	// Check remote servers
+	for serverName := range registryGroup.RemoteServers {
+		exists, err := workloadManager.DoesWorkloadExist(ctx, serverName)
+		if err != nil {
+			return fmt.Errorf("failed to check if server '%s' exists: %w", serverName, err)
+		}
+		if exists {
+			return fmt.Errorf("MCP server '%s' already exists", serverName)
+		}
+	}
+
+	return nil
+}
+
+// validateSecretsFormat validates all secrets have correct format and target existing servers
+func validateSecretsFormat(secrets []string, registryGroup *registry.Group) error {
+	for _, secret := range secrets {
+		if err := validateSecretFormat(secret, registryGroup); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// validateEnvVarsFormat validates all environment variables have correct format and target existing servers
+func validateEnvVarsFormat(envVars []string, registryGroup *registry.Group) error {
+	for _, envVar := range envVars {
+		if err := validateEnvVarFormat(envVar, registryGroup); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// deployServer deploys a single server using the same path as the normal run command
+func deployServer(ctx context.Context, serverName string,
+	serverMetadata *registry.ImageMetadata, groupName string, secrets []string, envVars []string, cmd *cobra.Command) error {
+
+	// Filter secrets and env vars for this specific server
+	serverSecrets := filterSecretsForServer(secrets, serverName)
+	serverEnvVars := filterEnvVarsForServer(envVars, serverName)
+
+	// Create RunFlags similar to normal run command
+	runFlags := &RunFlags{
+		Name:        serverName,
+		Group:       groupName,
+		Transport:   "", // Let normal defaulting logic handle it (matches cobra default)
+		Host:        transport.LocalhostIPv4,
+		ProxyPort:   0,
+		TargetPort:  serverMetadata.TargetPort,
+		Foreground:  false,
+		VerifyImage: retriever.VerifyImageWarn, // Matches cobra default
+		Env:         serverEnvVars,
+		Volumes:     []string{},
+		Secrets:     serverSecrets,
+	}
+
+	logger.Errorf("Server name is %s", serverName)
+	// Use the shared runSingleServer function
+	return runSingleServer(ctx, runFlags, serverName, []string{}, false, cmd, groupName)
+}
+
+// deployRemoteServer deploys a single remote server using the same path as the normal run command
+func deployRemoteServer(ctx context.Context, serverName string,
+	groupName string, secrets []string, envVars []string, cmd *cobra.Command) error {
+
+	// Filter secrets and env vars for this specific server
+	serverSecrets := filterSecretsForServer(secrets, serverName)
+	serverEnvVars := filterEnvVarsForServer(envVars, serverName)
+
+	// Create RunFlags for remote server
+	runFlags := &RunFlags{
+		Name:        serverName,
+		Group:       groupName,
+		Transport:   "", // Let normal defaulting logic handle it (matches cobra default)
+		Host:        transport.LocalhostIPv4,
+		ProxyPort:   0,
+		TargetPort:  0,
+		Foreground:  false,
+		VerifyImage: retriever.VerifyImageWarn, // Matches cobra default
+		Env:         serverEnvVars,
+		Volumes:     []string{},
+		Secrets:     serverSecrets,
+		// Don't pre-set RemoteURL - let GetMCPServer discover it through group lookup
+	}
+
+	logger.Errorf("Server name is %s", serverName)
+	// Use the shared runSingleServer function, passing the serverName
+	return runSingleServer(ctx, runFlags, serverName, []string{}, false, cmd, groupName)
+}
+
+// validateSecretFormat validates secret format and checks if target server exists in the group
+func validateSecretFormat(secret string, registryGroup *registry.Group) error {
+	// Expected format: NAME,target=SERVER_NAME.TARGET
+	parts := strings.Split(secret, ",target=")
+	if len(parts) != 2 {
+		return fmt.Errorf("invalid secret format '%s': expected 'NAME,target=SERVER_NAME.TARGET'", secret)
+	}
+
+	secretName := parts[0]
+	if secretName == "" {
+		return fmt.Errorf("secret name cannot be empty in '%s'", secret)
+	}
+
+	targetPart := parts[1]
+	if targetPart == "" {
+		return fmt.Errorf("target cannot be empty in secret '%s'", secret)
+	}
+
+	// Extract server name from target (SERVER_NAME.TARGET)
+	targetParts := strings.Split(targetPart, ".")
+	if len(targetParts) < 2 {
+		return fmt.Errorf("invalid target format in secret '%s': expected 'SERVER_NAME.TARGET'", secret)
+	}
+
+	serverName := targetParts[0]
+	if serverName == "" {
+		return fmt.Errorf("server name cannot be empty in secret target '%s'", secret)
+	}
+
+	// Check if server exists in the registry group (check both container and remote servers)
+	_, existsInServers := registryGroup.Servers[serverName]
+	_, existsInRemoteServers := registryGroup.RemoteServers[serverName]
+	if !existsInServers && !existsInRemoteServers {
+		return fmt.Errorf("secret cannot be set because the MCP server named '%s' does not exist in group", serverName)
+	}
+
+	return nil
+}
+
+// validateEnvVarFormat validates environment variable format and checks if target server exists in the group
+func validateEnvVarFormat(envVar string, registryGroup *registry.Group) error {
+	// Expected format: SERVER_NAME.KEY=VALUE
+	parts := strings.Split(envVar, "=")
+	if len(parts) < 2 {
+		return fmt.Errorf("invalid env var format '%s': expected 'SERVER_NAME.KEY=VALUE'", envVar)
+	}
+
+	keyPart := parts[0]
+	keyParts := strings.Split(keyPart, ".")
+	if len(keyParts) < 2 {
+		return fmt.Errorf("invalid env var format '%s': expected 'SERVER_NAME.KEY=VALUE'", envVar)
+	}
+
+	serverName := keyParts[0]
+	keyName := strings.Join(keyParts[1:], ".")
+
+	if serverName == "" {
+		return fmt.Errorf("server name cannot be empty in env var '%s'", envVar)
+	}
+
+	if keyName == "" {
+		return fmt.Errorf("key name cannot be empty in env var '%s'", envVar)
+	}
+
+	// Check if server exists in the registry group (check both container and remote servers)
+	_, existsInServers := registryGroup.Servers[serverName]
+	_, existsInRemoteServers := registryGroup.RemoteServers[serverName]
+	if !existsInServers && !existsInRemoteServers {
+		return fmt.Errorf("env var cannot be set because the MCP server named '%s' does not exist in group", serverName)
+	}
+
+	return nil
+}
+
+// filterSecretsForServer filters secrets that are targeted for a specific server
+func filterSecretsForServer(secrets []string, serverName string) []string {
+	var serverSecrets []string
+	for _, secret := range secrets {
+		// Expected format: NAME,target=SERVER_NAME.TARGET
+		parts := strings.Split(secret, ",target=")
+		if len(parts) != 2 {
+			continue // Skip invalid formats (should have been caught in validation)
+		}
+
+		targetPart := parts[1]
+		targetParts := strings.Split(targetPart, ".")
+		if len(targetParts) < 2 {
+			continue // Skip invalid formats (should have been caught in validation)
+		}
+
+		targetServerName := targetParts[0]
+		if targetServerName == serverName {
+			// Convert from group format to normal run format
+			// From: GITHUB_TOKEN,target=github.GITHUB_PERSONAL_ACCESS_TOKEN
+			// To: GITHUB_TOKEN,target=GITHUB_PERSONAL_ACCESS_TOKEN
+			secretName := parts[0]
+			targetEnvVar := strings.Join(targetParts[1:], ".") // Join in case env var has dots
+			normalRunFormat := fmt.Sprintf("%s,target=%s", secretName, targetEnvVar)
+			serverSecrets = append(serverSecrets, normalRunFormat)
+		}
+	}
+	return serverSecrets
+}
+
+// filterEnvVarsForServer filters environment variables that are targeted for a specific server
+func filterEnvVarsForServer(envVars []string, serverName string) []string {
+	var serverEnvVars []string
+	for _, envVar := range envVars {
+		// Expected format: SERVER_NAME.KEY=VALUE
+		parts := strings.Split(envVar, "=")
+		if len(parts) < 2 {
+			continue // Skip invalid formats (should have been caught in validation)
+		}
+
+		keyPart := parts[0]
+		keyParts := strings.Split(keyPart, ".")
+		if len(keyParts) < 2 {
+			continue // Skip invalid formats (should have been caught in validation)
+		}
+
+		targetServerName := keyParts[0]
+		if targetServerName == serverName {
+			// Convert to standard env var format by removing server prefix
+			keyName := strings.Join(keyParts[1:], ".")
+			value := strings.Join(parts[1:], "=")
+			serverEnvVars = append(serverEnvVars, fmt.Sprintf("%s=%s", keyName, value))
+		}
+	}
+	return serverEnvVars
+}
+
 func init() {
 	groupCmd.AddCommand(groupCreateCmd)
 	groupCmd.AddCommand(groupListCmd)
 	groupCmd.AddCommand(groupRmCmd)
+	groupCmd.AddCommand(groupRunCmd)
 
 	// Add --with-workloads flag to group rm command
 	groupRmCmd.Flags().BoolVar(&withWorkloadsFlag, "with-workloads", false,
 		"Delete all workloads in the group along with the group")
+
+	// Add flags to group run command
+	groupRunCmd.Flags().StringArrayVar(&groupSecrets, "secret", []string{},
+		"Secrets to be fetched from the secrets manager and set as environment variables (format: NAME,target=SERVER_NAME.TARGET)")
+	groupRunCmd.Flags().StringArrayVar(&groupEnvVars, "env", []string{},
+		"Environment variables to pass to an MCP server in the group (format: SERVER_NAME.KEY=VALUE)")
 }

--- a/cmd/thv/app/run.go
+++ b/cmd/thv/app/run.go
@@ -173,6 +173,11 @@ func runCmdFunc(cmd *cobra.Command, args []string) error {
 	// Get debug mode flag
 	debugMode, _ := cmd.Flags().GetBool("debug")
 
+	return runSingleServer(ctx, &runFlags, serverOrImage, cmdArgs, debugMode, cmd, "")
+}
+
+// runSingleServer handles the core logic for running a single MCP server
+func runSingleServer(ctx context.Context, runFlags *RunFlags, serverOrImage string, cmdArgs []string, debugMode bool, cmd *cobra.Command, groupName string) error { //nolint:lll
 	// Create container runtime
 	rt, err := container.NewFactory().Create(ctx)
 	if err != nil {
@@ -200,7 +205,7 @@ func runCmdFunc(cmd *cobra.Command, args []string) error {
 	}
 
 	// Build the run configuration
-	runnerConfig, err := BuildRunnerConfig(ctx, &runFlags, serverOrImage, cmdArgs, debugMode, cmd)
+	runnerConfig, err := BuildRunnerConfig(ctx, runFlags, serverOrImage, cmdArgs, debugMode, cmd, groupName)
 	if err != nil {
 		return err
 	}

--- a/cmd/thv/app/run_flags.go
+++ b/cmd/thv/app/run_flags.go
@@ -230,6 +230,7 @@ func BuildRunnerConfig(
 	cmdArgs []string,
 	debugMode bool,
 	cmd *cobra.Command,
+	groupName string,
 ) (*runner.RunConfig, error) {
 	// Validate and setup basic configuration
 	validatedHost, err := ValidateAndNormaliseHostFlag(runFlags.Host)
@@ -258,7 +259,7 @@ func BuildRunnerConfig(
 	}
 
 	// Handle image retrieval
-	imageURL, serverMetadata, err := handleImageRetrieval(ctx, serverOrImage, runFlags)
+	imageURL, serverMetadata, err := handleImageRetrieval(ctx, serverOrImage, runFlags, groupName)
 	if err != nil {
 		return nil, err
 	}
@@ -335,6 +336,7 @@ func handleImageRetrieval(
 	ctx context.Context,
 	serverOrImage string,
 	runFlags *RunFlags,
+	groupName string,
 ) (
 	string,
 	registry.ServerMetadata,
@@ -343,7 +345,7 @@ func handleImageRetrieval(
 
 	// Try to get server from registry (container or remote) or direct URL
 	imageURL, serverMetadata, err := retriever.GetMCPServer(
-		ctx, serverOrImage, runFlags.CACertPath, runFlags.VerifyImage)
+		ctx, serverOrImage, runFlags.CACertPath, runFlags.VerifyImage, groupName)
 	if err != nil {
 		return "", nil, fmt.Errorf("failed to find or create the MCP server %s: %v", serverOrImage, err)
 	}

--- a/pkg/api/v1/workload_service.go
+++ b/pkg/api/v1/workload_service.go
@@ -144,6 +144,7 @@ func (s *WorkloadService) BuildFullRunConfig(ctx context.Context, req *createReq
 			req.Image,
 			"", // We do not let the user specify a CA cert path here.
 			retriever.VerifyImageWarn,
+			"", // TODO Add support for registry groups lookups for APi
 		)
 		if err != nil {
 			// Check if the error is due to context timeout

--- a/pkg/api/v1/workloads_test.go
+++ b/pkg/api/v1/workloads_test.go
@@ -441,7 +441,7 @@ func makeMockRetriever(
 ) retriever.Retriever {
 	t.Helper()
 
-	return func(_ context.Context, serverOrImage string, _ string, verificationType string) (string, registry.ServerMetadata, error) {
+	return func(_ context.Context, serverOrImage string, _ string, verificationType string, _ string) (string, registry.ServerMetadata, error) {
 		assert.Equal(t, expectedServerOrImage, serverOrImage)
 		assert.Equal(t, retriever.VerifyImageWarn, verificationType)
 		return returnedImage, returnedServerMetadata, returnedError

--- a/pkg/mcp/server/run_server.go
+++ b/pkg/mcp/server/run_server.go
@@ -32,7 +32,7 @@ func (h *Handler) RunServer(ctx context.Context, request mcp.CallToolRequest) (*
 
 	// Use retriever to properly fetch and prepare the MCP server
 	// TODO: make this configurable so we could warn or even fail
-	imageURL, serverMetadata, err := retriever.GetMCPServer(ctx, args.Server, "", "disabled")
+	imageURL, serverMetadata, err := retriever.GetMCPServer(ctx, args.Server, "", "disabled", "")
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("Failed to get MCP server: %v", err)), nil
 	}

--- a/pkg/registry/provider_local.go
+++ b/pkg/registry/provider_local.go
@@ -72,6 +72,18 @@ func (p *LocalRegistryProvider) GetRegistry() (*Registry, error) {
 		server.Name = name
 	}
 
+	// Set name field on servers within groups
+	for _, group := range registry.Groups {
+		if group != nil {
+			for name, server := range group.Servers {
+				server.Name = name
+			}
+			for name, server := range group.RemoteServers {
+				server.Name = name
+			}
+		}
+	}
+
 	return registry, nil
 }
 

--- a/pkg/registry/provider_remote.go
+++ b/pkg/registry/provider_remote.go
@@ -69,5 +69,17 @@ func (p *RemoteRegistryProvider) GetRegistry() (*Registry, error) {
 		server.Name = name
 	}
 
+	// Set name field on servers within groups
+	for _, group := range registry.Groups {
+		if group != nil {
+			for name, server := range group.Servers {
+				server.Name = name
+			}
+			for name, server := range group.RemoteServers {
+				server.Name = name
+			}
+		}
+	}
+
 	return registry, nil
 }


### PR DESCRIPTION
  ## Summary
  - Adds new `thv group run <group-name>` command that deploys all MCP servers from a registry group
  - Supports both container-based and remote servers with OAuth authentication flows
  - Maintains identical behavior and code paths as individual `thv run` commands when possible

  ## New Command: `thv group run`

  The new command allows deploying entire groups of MCP servers with a single command:


  # Basic usage - deploy all servers in a group
  ```  
thv group run simple-test
  ```

  # With secrets and environment variables
```
  thv group run simple-test \
    --secret GITHUB_TOKEN,target=github.GITHUB_PERSONAL_ACCESS_TOKEN \
    --secret API_KEY,target=fetch.API_KEY \
    --env fetch.DEBUG=true \
    --env github.LOG_LEVEL=info
```

  Key Features

  - Registry groups: Reads metadata from registry groups instead of top level registry entries if given a group name
  - Full server type support: Deploys both container servers and remote servers with OAuth authentication
  - Targeted secrets & environment variables: Use `--secret VAR,target=server.TARGET_VAR` and `--env server.VAR=valu`e syntax to specify per-server configuration
  - Comprehensive validation: Pre-flight checks ensure no naming conflicts and validate secret/env variable targets exist in the group

  Architecture Changes

  - Enhanced registry reading: GetMCPServer now accepts group names and reads from group.Servers and group.RemoteServers collections if given a group name
  - Shared deployment logic: Extracted runSingleServer function used by both thv run and thv group run commands
  - Smart filtering system: Automatically filters secrets/env vars per server and converts between group syntax (server.VAR) and individual run syntax (VAR)

  Testing Examples

  # Test basic group deployment
  thv group run simple-test

  # Test with targeted secrets
  thv group run simple-test --secret GITHUB_TOKEN,target=github.GITHUB_PERSONAL_ACCESS_TOKEN

  # Test with environment variables  
  thv group run simple-test --env fetch.DEBUG=true --env github.LOG_LEVEL=info
