### PR TITLE
remove secret provider dependency from workload apis

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -29,12 +29,10 @@ import (
 	v1 "github.com/stacklok/toolhive/pkg/api/v1"
 	"github.com/stacklok/toolhive/pkg/auth"
 	"github.com/stacklok/toolhive/pkg/client"
-	"github.com/stacklok/toolhive/pkg/config"
 	"github.com/stacklok/toolhive/pkg/container"
 	"github.com/stacklok/toolhive/pkg/container/runtime"
 	"github.com/stacklok/toolhive/pkg/groups"
 	"github.com/stacklok/toolhive/pkg/logger"
-	"github.com/stacklok/toolhive/pkg/secrets"
 	"github.com/stacklok/toolhive/pkg/updates"
 	"github.com/stacklok/toolhive/pkg/workloads"
 )
@@ -59,7 +57,6 @@ type ServerBuilder struct {
 	clientManager    client.Manager
 	workloadManager  workloads.Manager
 	groupManager     groups.Manager
-	secretsProvider  secrets.Provider
 }
 
 // NewServerBuilder creates a new ServerBuilder with default configuration
@@ -133,12 +130,6 @@ func (b *ServerBuilder) WithWorkloadManager(manager workloads.Manager) *ServerBu
 // WithGroupManager sets the group manager
 func (b *ServerBuilder) WithGroupManager(manager groups.Manager) *ServerBuilder {
 	b.groupManager = manager
-	return b
-}
-
-// WithSecretsProvider sets the secrets provider
-func (b *ServerBuilder) WithSecretsProvider(provider secrets.Provider) *ServerBuilder {
-	b.secretsProvider = provider
 	return b
 }
 
@@ -216,31 +207,8 @@ func (b *ServerBuilder) createDefaultManagers(ctx context.Context) error {
 			return fmt.Errorf("failed to create group manager: %v", err)
 		}
 	}
-	if b.secretsProvider == nil {
-		b.secretsProvider, err = getSecretsManager()
-		if err != nil {
-			return fmt.Errorf("failed to create secrets provider: %v", err)
-		}
-	}
 
 	return nil
-}
-
-// getSecretsManager is a helper function to get the secrets manager
-func getSecretsManager() (secrets.Provider, error) {
-	cfg := config.NewDefaultProvider().GetConfig()
-
-	// Check if secrets setup has been completed
-	if !cfg.Secrets.SetupCompleted {
-		return nil, secrets.ErrSecretsNotSetup
-	}
-
-	providerType, err := cfg.Secrets.GetProviderType()
-	if err != nil {
-		return nil, err
-	}
-
-	return secrets.CreateSecretProvider(providerType)
 }
 
 // setupDefaultRoutes sets up the default API routes
@@ -252,13 +220,12 @@ func (b *ServerBuilder) setupDefaultRoutes(r *chi.Mux) {
 			b.workloadManager,
 			b.containerRuntime,
 			b.groupManager,
-			b.secretsProvider,
 			b.debugMode,
 		),
 		"/api/v1beta/registry":  v1.RegistryRouter(),
 		"/api/v1beta/discovery": v1.DiscoveryRouter(),
 		"/api/v1beta/clients":   v1.ClientRouter(b.clientManager, b.workloadManager, b.groupManager),
-		"/api/v1beta/secrets":   v1.SecretsRouter(b.secretsProvider),
+		"/api/v1beta/secrets":   v1.SecretsRouter(),
 		"/api/v1beta/groups":    v1.GroupsRouter(b.groupManager, b.workloadManager, b.clientManager),
 	}
 

--- a/pkg/api/v1/secrets.go
+++ b/pkg/api/v1/secrets.go
@@ -22,14 +22,12 @@ const (
 // SecretsRoutes defines the routes for the secrets API.
 type SecretsRoutes struct {
 	configProvider config.Provider
-	provider       secrets.Provider
 }
 
 // NewSecretsRoutes creates a new SecretsRoutes with the default config provider
-func NewSecretsRoutes(provider secrets.Provider) *SecretsRoutes {
+func NewSecretsRoutes() *SecretsRoutes {
 	return &SecretsRoutes{
 		configProvider: config.NewDefaultProvider(),
-		provider:       provider,
 	}
 }
 
@@ -41,8 +39,8 @@ func NewSecretsRoutesWithProvider(provider config.Provider) *SecretsRoutes {
 }
 
 // SecretsRouter creates a new router for the secrets API.
-func SecretsRouter(provider secrets.Provider) http.Handler {
-	routes := NewSecretsRoutes(provider)
+func SecretsRouter() http.Handler {
+	routes := NewSecretsRoutes()
 	return secretsRouterWithRoutes(routes)
 }
 
@@ -234,8 +232,15 @@ func (s *SecretsRoutes) getSecretsProvider(w http.ResponseWriter, _ *http.Reques
 		http.Error(w, "Failed to get provider type", http.StatusInternalServerError)
 		return
 	}
+	// Get provider capabilities
+	provider, err := s.getSecretsManager()
+	if err != nil {
+		logger.Errorf("Failed to create secrets provider: %v", err)
+		http.Error(w, "Failed to access secrets provider", http.StatusInternalServerError)
+		return
+	}
 
-	capabilities := s.provider.Capabilities()
+	capabilities := provider.Capabilities()
 
 	w.Header().Set("Content-Type", "application/json")
 	resp := getSecretsProviderResponse{
@@ -269,13 +274,24 @@ func (s *SecretsRoutes) getSecretsProvider(w http.ResponseWriter, _ *http.Reques
 //	@Router			/api/v1beta/secrets/default/keys [get]
 func (s *SecretsRoutes) listSecrets(w http.ResponseWriter, r *http.Request) {
 
+	provider, err := s.getSecretsManager()
+	if err != nil {
+		if errors.Is(err, secrets.ErrSecretsNotSetup) {
+			http.Error(w, "Secrets provider not setup", http.StatusNotFound)
+			return
+		}
+		logger.Errorf("Failed to get secrets manager: %v", err)
+		http.Error(w, "Failed to access secrets provider", http.StatusInternalServerError)
+		return
+	}
+
 	// Check if provider supports listing
-	if !s.provider.Capabilities().CanList {
+	if !provider.Capabilities().CanList {
 		http.Error(w, "Secrets provider does not support listing keys", http.StatusMethodNotAllowed)
 		return
 	}
 
-	secretDescriptions, err := s.provider.ListSecrets(r.Context())
+	secretDescriptions, err := provider.ListSecrets(r.Context())
 	if err != nil {
 		logger.Errorf("Failed to list secrets: %v", err)
 		http.Error(w, "Failed to list secrets", http.StatusInternalServerError)
@@ -327,15 +343,26 @@ func (s *SecretsRoutes) createSecret(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	provider, err := s.getSecretsManager()
+	if err != nil {
+		if errors.Is(err, secrets.ErrSecretsNotSetup) {
+			http.Error(w, "Secrets provider not setup", http.StatusNotFound)
+			return
+		}
+		logger.Errorf("Failed to get secrets manager: %v", err)
+		http.Error(w, "Failed to access secrets provider", http.StatusInternalServerError)
+		return
+	}
+
 	// Check if provider supports writing
-	if !s.provider.Capabilities().CanWrite {
+	if !provider.Capabilities().CanWrite {
 		http.Error(w, "Secrets provider does not support creating secrets", http.StatusMethodNotAllowed)
 		return
 	}
 
 	// Check if secret already exists (if provider supports reading)
-	if s.provider.Capabilities().CanRead {
-		_, err := s.provider.GetSecret(r.Context(), req.Key)
+	if provider.Capabilities().CanRead {
+		_, err := provider.GetSecret(r.Context(), req.Key)
 		if err == nil {
 			http.Error(w, "Secret already exists", http.StatusConflict)
 			return
@@ -343,7 +370,7 @@ func (s *SecretsRoutes) createSecret(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Create the secret
-	if err := s.provider.SetSecret(r.Context(), req.Key, req.Value); err != nil {
+	if err := provider.SetSecret(r.Context(), req.Key, req.Value); err != nil {
 		logger.Errorf("Failed to create secret: %v", err)
 		http.Error(w, "Failed to create secret", http.StatusInternalServerError)
 		return
@@ -396,15 +423,26 @@ func (s *SecretsRoutes) updateSecret(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	provider, err := s.getSecretsManager()
+	if err != nil {
+		if errors.Is(err, secrets.ErrSecretsNotSetup) {
+			http.Error(w, "Secrets provider not setup", http.StatusNotFound)
+			return
+		}
+		logger.Errorf("Failed to get secrets manager: %v", err)
+		http.Error(w, "Failed to access secrets provider", http.StatusInternalServerError)
+		return
+	}
+
 	// Check if provider supports writing
-	if !s.provider.Capabilities().CanWrite {
+	if !provider.Capabilities().CanWrite {
 		http.Error(w, "Secrets provider does not support updating secrets", http.StatusMethodNotAllowed)
 		return
 	}
 
 	// Check if secret exists (if provider supports reading)
-	if s.provider.Capabilities().CanRead {
-		_, err := s.provider.GetSecret(r.Context(), key)
+	if provider.Capabilities().CanRead {
+		_, err := provider.GetSecret(r.Context(), key)
 		if err != nil {
 			http.Error(w, "Secret not found", http.StatusNotFound)
 			return
@@ -412,7 +450,7 @@ func (s *SecretsRoutes) updateSecret(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Update the secret
-	if err := s.provider.SetSecret(r.Context(), key, req.Value); err != nil {
+	if err := provider.SetSecret(r.Context(), key, req.Value); err != nil {
 		logger.Errorf("Failed to update secret: %v", err)
 		http.Error(w, "Failed to update secret", http.StatusInternalServerError)
 		return
@@ -448,14 +486,25 @@ func (s *SecretsRoutes) deleteSecret(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	provider, err := s.getSecretsManager()
+	if err != nil {
+		if errors.Is(err, secrets.ErrSecretsNotSetup) {
+			http.Error(w, "Secrets provider not setup", http.StatusNotFound)
+			return
+		}
+		logger.Errorf("Failed to get secrets manager: %v", err)
+		http.Error(w, "Failed to access secrets provider", http.StatusInternalServerError)
+		return
+	}
+
 	// Check if provider supports deletion
-	if !s.provider.Capabilities().CanDelete {
+	if !provider.Capabilities().CanDelete {
 		http.Error(w, "Secrets provider does not support deleting secrets", http.StatusMethodNotAllowed)
 		return
 	}
 
 	// Delete the secret
-	if err := s.provider.DeleteSecret(r.Context(), key); err != nil {
+	if err := provider.DeleteSecret(r.Context(), key); err != nil {
 		logger.Errorf("Failed to delete secret: %v", err)
 		// Check if it's a "not found" error
 		if err.Error() == "cannot delete non-existent secret: "+key {
@@ -467,6 +516,23 @@ func (s *SecretsRoutes) deleteSecret(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// getSecretsManager is a helper function to get the secrets manager
+func (s *SecretsRoutes) getSecretsManager() (secrets.Provider, error) {
+	cfg := s.configProvider.GetConfig()
+
+	// Check if secrets setup has been completed
+	if !cfg.Secrets.SetupCompleted {
+		return nil, secrets.ErrSecretsNotSetup
+	}
+
+	providerType, err := cfg.Secrets.GetProviderType()
+	if err != nil {
+		return nil, err
+	}
+
+	return secrets.CreateSecretProvider(providerType)
 }
 
 // Request and response type definitions

--- a/pkg/api/v1/workload_service.go
+++ b/pkg/api/v1/workload_service.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/stacklok/toolhive/pkg/config"
 	"github.com/stacklok/toolhive/pkg/container/runtime"
 	"github.com/stacklok/toolhive/pkg/groups"
 	"github.com/stacklok/toolhive/pkg/logger"
@@ -28,7 +29,6 @@ const (
 type WorkloadService struct {
 	workloadManager  workloads.Manager
 	groupManager     groups.Manager
-	secretsProvider  secrets.Provider
 	containerRuntime runtime.Runtime
 	debugMode        bool
 	imageRetriever   retriever.Retriever
@@ -38,14 +38,12 @@ type WorkloadService struct {
 func NewWorkloadService(
 	workloadManager workloads.Manager,
 	groupManager groups.Manager,
-	secretsProvider secrets.Provider,
 	containerRuntime runtime.Runtime,
 	debugMode bool,
 ) *WorkloadService {
 	return &WorkloadService{
 		workloadManager:  workloadManager,
 		groupManager:     groupManager,
-		secretsProvider:  secretsProvider,
 		containerRuntime: containerRuntime,
 		debugMode:        debugMode,
 		imageRetriever:   retriever.GetMCPServer,
@@ -128,7 +126,7 @@ func (s *WorkloadService) BuildFullRunConfig(ctx context.Context, req *createReq
 		if req.Transport == "" {
 			req.Transport = types.TransportTypeStreamableHTTP.String()
 		}
-		remoteAuthConfig, err = s.createRequestToRemoteAuthConfig(ctx, req)
+		remoteAuthConfig, err = createRequestToRemoteAuthConfig(ctx, req)
 		if err != nil {
 			return nil, err
 		}
@@ -156,7 +154,7 @@ func (s *WorkloadService) BuildFullRunConfig(ctx context.Context, req *createReq
 
 		if remoteServerMetadata, ok := serverMetadata.(*registry.RemoteServerMetadata); ok {
 			if remoteServerMetadata.OAuthConfig != nil {
-				clientSecret, err := s.resolveClientSecret(ctx, req.OAuthConfig.ClientSecret)
+				clientSecret, err := resolveClientSecret(ctx, req.OAuthConfig.ClientSecret)
 				if err != nil {
 					return nil, err
 				}
@@ -242,13 +240,13 @@ func (s *WorkloadService) BuildFullRunConfig(ctx context.Context, req *createReq
 }
 
 // createRequestToRemoteAuthConfig converts API request to runner RemoteAuthConfig
-func (s *WorkloadService) createRequestToRemoteAuthConfig(
+func createRequestToRemoteAuthConfig(
 	ctx context.Context,
 	req *createRequest,
 ) (*runner.RemoteAuthConfig, error) {
 
 	// Resolve client secret from secret management if provided
-	clientSecret, err := s.resolveClientSecret(ctx, req.OAuthConfig.ClientSecret)
+	clientSecret, err := resolveClientSecret(ctx, req.OAuthConfig.ClientSecret)
 	if err != nil {
 		return nil, err
 	}
@@ -269,11 +267,16 @@ func (s *WorkloadService) createRequestToRemoteAuthConfig(
 }
 
 // resolveClientSecret resolves client secret from secret management
-func (s *WorkloadService) resolveClientSecret(ctx context.Context, secretParam *secrets.SecretParameter) (string, error) {
+func resolveClientSecret(ctx context.Context, secretParam *secrets.SecretParameter) (string, error) {
 	var clientSecret string
 	if secretParam != nil {
+
+		secretsProvider, err := getSecretsManager()
+		if err != nil {
+			return "", fmt.Errorf("failed to get secrets manager: %w", err)
+		}
 		// Get the secret from the secrets manager
-		secretValue, err := s.secretsProvider.GetSecret(ctx, secretParam.Name)
+		secretValue, err := secretsProvider.GetSecret(ctx, secretParam.Name)
 		if err != nil {
 			return "", fmt.Errorf("failed to resolve OAuth client secret: %w", err)
 		}
@@ -308,4 +311,21 @@ func (s *WorkloadService) GetWorkloadNamesFromRequest(ctx context.Context, req b
 	}
 
 	return workloadNames, nil
+}
+
+// getSecretsManager is a helper function to get the secrets manager
+func getSecretsManager() (secrets.Provider, error) {
+	cfg := config.NewDefaultProvider().GetConfig()
+
+	// Check if secrets setup has been completed
+	if !cfg.Secrets.SetupCompleted {
+		return nil, secrets.ErrSecretsNotSetup
+	}
+
+	providerType, err := cfg.Secrets.GetProviderType()
+	if err != nil {
+		return nil, err
+	}
+
+	return secrets.CreateSecretProvider(providerType)
 }

--- a/pkg/api/v1/workloads.go
+++ b/pkg/api/v1/workloads.go
@@ -14,7 +14,6 @@ import (
 	"github.com/stacklok/toolhive/pkg/logger"
 	"github.com/stacklok/toolhive/pkg/runner"
 	"github.com/stacklok/toolhive/pkg/runner/retriever"
-	"github.com/stacklok/toolhive/pkg/secrets"
 	"github.com/stacklok/toolhive/pkg/validation"
 	"github.com/stacklok/toolhive/pkg/workloads"
 	wt "github.com/stacklok/toolhive/pkg/workloads/types"
@@ -26,7 +25,6 @@ type WorkloadRoutes struct {
 	containerRuntime runtime.Runtime
 	debugMode        bool
 	groupManager     groups.Manager
-	secretsProvider  secrets.Provider
 	workloadService  *WorkloadService
 }
 
@@ -41,13 +39,11 @@ func WorkloadRouter(
 	workloadManager workloads.Manager,
 	containerRuntime runtime.Runtime,
 	groupManager groups.Manager,
-	secretsProvider secrets.Provider,
 	debugMode bool,
 ) http.Handler {
 	workloadService := NewWorkloadService(
 		workloadManager,
 		groupManager,
-		secretsProvider,
 		containerRuntime,
 		debugMode,
 	)
@@ -57,7 +53,6 @@ func WorkloadRouter(
 		containerRuntime: containerRuntime,
 		debugMode:        debugMode,
 		groupManager:     groupManager,
-		secretsProvider:  secretsProvider,
 		workloadService:  workloadService,
 	}
 


### PR DESCRIPTION
In [PR #1693](https://github.com/stacklok/toolhive/pull/1693/files), the secret provider was refactored and made part of the constructor. However, this caused the server to fail to start when the secret provider was unavailable.

This PR reverts that change and restores the previous behavior, ensuring the server can start even when the secret provider is not available.