### PR TITLE
modify the secrets propagation in the --from-configmap use case

### DIFF
--- a/cmd/thv-proxyrunner/app/run.go
+++ b/cmd/thv-proxyrunner/app/run.go
@@ -298,8 +298,9 @@ func validateConfigMapOnlyMode(cmd *cobra.Command) error {
 // These are typically operational flags that don't affect the RunConfig
 func isSafeFlagWithConfigMap(flagName string) bool {
 	safeFlagsWithConfigMap := map[string]bool{
-		"help":  true,
-		"debug": true,
+		"help":          true,
+		"debug":         true,
+		"k8s-pod-patch": true, // Allow pod template patch to be used with ConfigMap
 		// Add other safe flags here if needed
 	}
 	return safeFlagsWithConfigMap[flagName]
@@ -378,6 +379,11 @@ func runCmdFunc(cmd *cobra.Command, args []string) error {
 			runner.WithDebug(debugMode),
 		}
 		opts = applyRunConfigToBuilder(opts, configMapRunConfig)
+
+		// Apply CLI-only flags that can override or supplement ConfigMap settings
+		if runFlags.runK8sPodPatch != "" {
+			opts = append(opts, runner.WithK8sPodPatch(runFlags.runK8sPodPatch))
+		}
 	} else {
 		// Initialize a new set of options with values from command-line flags
 		opts = []runner.RunConfigBuilderOption{

--- a/test/e2e/chainsaw/operator/single-tenancy/test-scenarios/configmap-mode/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/operator/single-tenancy/test-scenarios/configmap-mode/chainsaw-test.yaml
@@ -41,6 +41,14 @@ spec:
             exit 1
           fi
       
+  - name: deploy-test-secret
+    description: Deploy test secret for MCPServer
+    try:
+    - apply:
+        file: test-secret.yaml
+    - assert:
+        file: test-secret.yaml
+
   - name: deploy-mcpserver-configmap-mode
     description: Deploy MCPServer instance (will use ConfigMap mode due to env var)
     try:
@@ -92,14 +100,21 @@ spec:
           fi
           
           # Verify deployment arguments
-          echo "Verifying deployment uses --from-configmap flag..."
+          echo "Verifying deployment uses --from-configmap and --k8s-pod-patch flags..."
           DEPLOYMENT_ARGS=$(kubectl get deployment yardstick -n toolhive-system -o jsonpath='{.spec.template.spec.containers[0].args}')
           echo "Deployment args: $DEPLOYMENT_ARGS"
-          
+
           if echo "$DEPLOYMENT_ARGS" | grep -q -- "--from-configmap=toolhive-system/yardstick-runconfig"; then
             echo "✓ Deployment uses --from-configmap flag"
           else
             echo "✗ Deployment does not use --from-configmap flag"
+            exit 1
+          fi
+
+          if echo "$DEPLOYMENT_ARGS" | grep -q -- "--k8s-pod-patch="; then
+            echo "✓ Deployment uses --k8s-pod-patch flag"
+          else
+            echo "✗ Deployment does not use --k8s-pod-patch flag"
             exit 1
           fi
           
@@ -115,12 +130,54 @@ spec:
           fi
           
           echo "✓ Individual config flags correctly omitted"
-          
-          # Wait for pod to be ready
-          echo "Waiting for pod to be ready..."
-          kubectl wait --for=condition=Ready pod -l app=mcpserver,app.kubernetes.io/instance=yardstick -n toolhive-system --timeout=120s
-          
-          echo "✅ ConfigMap mode functionality verified successfully!"
+
+          # Validate k8s-pod-patch contains secrets
+          echo "Validating k8s-pod-patch contains secrets..."
+          # Extract the JSON argument by finding the --k8s-pod-patch flag in the args array
+          POD_PATCH_ARG=$(echo "$DEPLOYMENT_ARGS" | jq -r '.[] | select(startswith("--k8s-pod-patch=")) | sub("^--k8s-pod-patch="; "")')
+
+          if [ -n "$POD_PATCH_ARG" ]; then
+            echo "Pod patch argument found, validating contents..."
+            echo "Pod patch JSON: $POD_PATCH_ARG"
+
+            # Check if pod patch contains MCP container with env vars
+            if echo "$POD_PATCH_ARG" | jq -e '.spec.containers[] | select(.name=="mcp") | .env[]' > /dev/null 2>&1; then
+              echo "✓ Pod patch contains MCP container with environment variables"
+            else
+              echo "✗ Pod patch does not contain MCP container with environment variables"
+              echo "Pod patch contents: $POD_PATCH_ARG"
+              exit 1
+            fi
+
+            # Validate specific secret environment variables
+            if echo "$POD_PATCH_ARG" | jq -e '.spec.containers[] | select(.name=="mcp") | .env[] | select(.name=="YARDSTICK_API_TOKEN")' > /dev/null 2>&1; then
+              echo "✓ Pod patch contains YARDSTICK_API_TOKEN environment variable"
+            else
+              echo "✗ Pod patch missing YARDSTICK_API_TOKEN environment variable"
+              exit 1
+            fi
+
+            if echo "$POD_PATCH_ARG" | jq -e '.spec.containers[] | select(.name=="mcp") | .env[] | select(.name=="GITHUB_TOKEN")' > /dev/null 2>&1; then
+              echo "✓ Pod patch contains GITHUB_TOKEN environment variable"
+            else
+              echo "✗ Pod patch missing GITHUB_TOKEN environment variable"
+              exit 1
+            fi
+
+            # Validate secretKeyRef structure
+            if echo "$POD_PATCH_ARG" | jq -e '.spec.containers[] | select(.name=="mcp") | .env[] | select(.name=="YARDSTICK_API_TOKEN") | .valueFrom.secretKeyRef | select(.name=="yardstick-test-secret" and .key=="api-token")' > /dev/null 2>&1; then
+              echo "✓ YARDSTICK_API_TOKEN has correct secretKeyRef structure"
+            else
+              echo "✗ YARDSTICK_API_TOKEN secretKeyRef structure is incorrect"
+              exit 1
+            fi
+
+          else
+            echo "✗ No pod patch argument found"
+            exit 1
+          fi
+
+          echo "✅ ConfigMap mode functionality with secrets verified successfully!"
 
   - name: cleanup-configmap-mode
     description: Disable ConfigMap mode to avoid affecting subsequent tests

--- a/test/e2e/chainsaw/operator/single-tenancy/test-scenarios/configmap-mode/mcpserver.yaml
+++ b/test/e2e/chainsaw/operator/single-tenancy/test-scenarios/configmap-mode/mcpserver.yaml
@@ -10,6 +10,13 @@ spec:
   permissionProfile:
     type: builtin
     name: network
+  secrets:
+  - name: yardstick-test-secret
+    key: api-token
+    targetEnvName: YARDSTICK_API_TOKEN
+  - name: yardstick-test-secret
+    key: github-token
+    targetEnvName: GITHUB_TOKEN
   resources:
     limits:
       cpu: "100m"

--- a/test/e2e/chainsaw/operator/single-tenancy/test-scenarios/configmap-mode/test-secret.yaml
+++ b/test/e2e/chainsaw/operator/single-tenancy/test-scenarios/configmap-mode/test-secret.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: yardstick-test-secret
+  namespace: toolhive-system
+type: Opaque
+data:
+  # base64 encoded values for testing
+  # api-token: "test-api-token-value" (base64 encoded)
+  api-token: dGVzdC1hcGktdG9rZW4tdmFsdWU=
+  # github-token: "test-github-token-value" (base64 encoded)
+  github-token: dGVzdC1naXRodWItdG9rZW4tdmFsdWU=


### PR DESCRIPTION
They need to be propagated as env vars, using the pod-patch, instead of being propagated as secrets, as they cause issue with the provider

In the future, we should actually modify that and use the withsecrets command, maybe adding some k8s secrets provider

Closes: #1873