### PR TITLE
Split e2e tests via labels

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -8,8 +8,21 @@ permissions:
 
 jobs:
   e2e-tests:
-    name: E2E Tests
+    name: E2E Tests (${{ matrix.title }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - title: core
+            label_filter: core
+            artifact: e2e-test-results-core
+          - title: mcp
+            label_filter: mcp
+            artifact: e2e-test-results-mcp
+          - title: proxy-mw
+            label_filter: 'proxy || middleware || stability'
+            artifact: e2e-test-results-proxy-mw
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
 
@@ -42,18 +55,19 @@ jobs:
           # Start Docker daemon if not running
           sudo systemctl start docker
 
-      - name: Run E2E tests
+      - name: Run E2E tests (${{ matrix.title }})
         env:
           THV_BINARY: ${{ github.workspace }}/bin/thv
           TOOLHIVE_EGRESS_IMAGE: ghcr.io/stacklok/toolhive/egress-proxy:latest
           TEST_TIMEOUT: 15m
+          LABEL_FILTER: ${{ matrix.label_filter }}
         run: ./test/e2e/run_tests.sh
 
-      - name: Upload test results
+      - name: Upload test results (${{ matrix.title }})
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: e2e-test-results
+          name: ${{ matrix.artifact }}
           path: |
             test/e2e/ginkgo-report.xml
             test/e2e/junit-report.xml

--- a/test/e2e/audit_middleware_e2e_test.go
+++ b/test/e2e/audit_middleware_e2e_test.go
@@ -20,7 +20,7 @@ func generateUniqueAuditServerName(prefix string) string {
 	return fmt.Sprintf("%s-%d-%d-%d", prefix, os.Getpid(), time.Now().UnixNano(), GinkgoRandomSeed())
 }
 
-var _ = Describe("Audit Middleware E2E", Serial, func() {
+var _ = Describe("Audit Middleware E2E", Label("middleware", "audit", "sse", "e2e"), Serial, func() {
 	var (
 		config          *e2e.TestConfig
 		mcpServerName   string

--- a/test/e2e/client_test.go
+++ b/test/e2e/client_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stacklok/toolhive/test/e2e"
 )
 
-var _ = Describe("Client Management", func() {
+var _ = Describe("Client Management", Label("core", "client", "e2e"), func() {
 	var (
 		testConfig        *e2e.TestConfig
 		tempXdgConfigHome string

--- a/test/e2e/fetch_mcp_server_test.go
+++ b/test/e2e/fetch_mcp_server_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stacklok/toolhive/test/e2e"
 )
 
-var _ = Describe("FetchMcpServer", func() {
+var _ = Describe("FetchMcpServer", Label("mcp", "e2e"), func() {
 	var (
 		config     *e2e.TestConfig
 		serverName string

--- a/test/e2e/group_list_e2e_test.go
+++ b/test/e2e/group_list_e2e_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stacklok/toolhive/test/e2e"
 )
 
-var _ = Describe("Group List E2E", func() {
+var _ = Describe("Group List E2E", Label("core", "groups", "e2e"), func() {
 	var testGroupName string
 	var config *e2e.TestConfig
 	var createdGroups []string

--- a/test/e2e/group_rm_test.go
+++ b/test/e2e/group_rm_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stacklok/toolhive/test/e2e"
 )
 
-var _ = Describe("Group RM E2E Tests", func() {
+var _ = Describe("Group RM E2E Tests", Label("core", "groups", "e2e"), func() {
 	var (
 		config           *e2e.TestConfig
 		groupName        string

--- a/test/e2e/group_test.go
+++ b/test/e2e/group_test.go
@@ -19,7 +19,7 @@ func init() {
 	logger.Initialize()
 }
 
-var _ = Describe("Group", func() {
+var _ = Describe("Group", Label("core", "groups", "e2e"), func() {
 	var (
 		config           *e2e.TestConfig
 		groupName        string

--- a/test/e2e/inspector_test.go
+++ b/test/e2e/inspector_test.go
@@ -21,7 +21,7 @@ type inspectorTestHelper struct {
 	inspectorURL  string
 }
 
-var _ = Describe("Inspector", func() {
+var _ = Describe("Inspector", Label("mcp", "e2e"), func() {
 	var (
 		config        *e2e.TestConfig
 		mcpServerName string

--- a/test/e2e/list_group_e2e_test.go
+++ b/test/e2e/list_group_e2e_test.go
@@ -16,7 +16,7 @@ func init() {
 	logger.Initialize()
 }
 
-var _ = Describe("List Group", func() {
+var _ = Describe("List Group", Label("core", "groups", "e2e"), func() {
 	var (
 		config          *e2e.TestConfig
 		groupName       string

--- a/test/e2e/osv_authz_test.go
+++ b/test/e2e/osv_authz_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stacklok/toolhive/test/e2e"
 )
 
-var _ = Describe("OSV MCP Server with Authorization", Serial, func() {
+var _ = Describe("OSV MCP Server with Authorization", Label("middleware", "authz", "sse", "e2e"), Serial, func() {
 	var config *e2e.TestConfig
 
 	BeforeEach(func() {

--- a/test/e2e/osv_mcp_server_test.go
+++ b/test/e2e/osv_mcp_server_test.go
@@ -20,7 +20,7 @@ func generateUniqueServerName(prefix string) string {
 	return fmt.Sprintf("%s-%d-%d-%d", prefix, os.Getpid(), time.Now().UnixNano(), GinkgoRandomSeed())
 }
 
-var _ = Describe("OsvMcpServer", Serial, func() {
+var _ = Describe("OsvMcpServer", Label("mcp", "sse", "e2e"), Serial, func() {
 	var config *e2e.TestConfig
 
 	BeforeEach(func() {

--- a/test/e2e/osv_streamable_http_mcp_server_test.go
+++ b/test/e2e/osv_streamable_http_mcp_server_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stacklok/toolhive/test/e2e"
 )
 
-var _ = Describe("OsvStreamableHttpMcpServer", Serial, func() {
+var _ = Describe("OsvStreamableHttpMcpServer", Label("mcp", "streamable-http", "e2e"), Serial, func() {
 	var config *e2e.TestConfig
 
 	BeforeEach(func() {

--- a/test/e2e/protocol_builds_e2e_test.go
+++ b/test/e2e/protocol_builds_e2e_test.go
@@ -16,7 +16,7 @@ func generateUniqueProtocolServerName(prefix string) string {
 	return fmt.Sprintf("%s-%d-%d-%d", prefix, os.Getpid(), time.Now().UnixNano(), GinkgoRandomSeed())
 }
 
-var _ = Describe("Protocol Builds E2E", Serial, func() {
+var _ = Describe("Protocol Builds E2E", Label("mcp", "protocols", "e2e"), Serial, func() {
 	var config *e2e.TestConfig
 
 	BeforeEach(func() {

--- a/test/e2e/proxy_oauth_test.go
+++ b/test/e2e/proxy_oauth_test.go
@@ -26,7 +26,7 @@ func generateUniqueOIDCServerName(prefix string) string {
 	return fmt.Sprintf("%s-%d-%d-%d", prefix, os.Getpid(), time.Now().UnixNano(), GinkgoRandomSeed())
 }
 
-var _ = Describe("Proxy OAuth Authentication E2E", Serial, func() {
+var _ = Describe("Proxy OAuth Authentication E2E", Label("proxy", "oauth", "e2e"), Serial, func() {
 	var (
 		config          *e2e.TestConfig
 		mockOIDCPort    int

--- a/test/e2e/proxy_stdio_test.go
+++ b/test/e2e/proxy_stdio_test.go
@@ -24,7 +24,7 @@ func generateUniqueProxyStdioServerName(prefix string) string {
 	return fmt.Sprintf("%s-%d-%d-%d", prefix, os.Getpid(), time.Now().UnixNano(), GinkgoRandomSeed())
 }
 
-var _ = Describe("Proxy Stdio E2E", Serial, func() {
+var _ = Describe("Proxy Stdio E2E", Label("proxy", "stdio", "e2e"), Serial, func() {
 	var (
 		config        *e2e.TestConfig
 		proxyCmd      *exec.Cmd

--- a/test/e2e/proxy_tunnel_e2e_test.go
+++ b/test/e2e/proxy_tunnel_e2e_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stacklok/toolhive/test/e2e"
 )
 
-var _ = Describe("Proxy Tunnel E2E", Serial, func() {
+var _ = Describe("Proxy Tunnel E2E", Label("proxy", "tunnel", "e2e"), Serial, func() {
 	var (
 		config          *e2e.TestConfig
 		proxyTunnelCmd  *exec.Cmd

--- a/test/e2e/restart_test.go
+++ b/test/e2e/restart_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stacklok/toolhive/test/e2e"
 )
 
-var _ = Describe("Server Restart", func() {
+var _ = Describe("Server Restart", Label("core", "restart", "e2e"), func() {
 	var (
 		config     *e2e.TestConfig
 		serverName string

--- a/test/e2e/rm_group_test.go
+++ b/test/e2e/rm_group_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stacklok/toolhive/test/e2e"
 )
 
-var _ = Describe("Group Remove E2E Tests", func() {
+var _ = Describe("Group Remove E2E Tests", Label("core", "groups", "e2e"), func() {
 	var (
 		config           *e2e.TestConfig
 		testGroupName    string

--- a/test/e2e/run_tests.bat
+++ b/test/e2e/run_tests.bat
@@ -70,6 +70,22 @@ if defined GITHUB_ACTIONS (
 ) else (
     set "GINKGO_CMD=%GINKGO_CMD% --vv --show-node-events --trace"
 )
+
+REM Optional label filter (LABEL_FILTER or E2E_LABEL_FILTER)
+set "LABEL_FILTER_EFFECTIVE="
+if defined LABEL_FILTER (
+    set "LABEL_FILTER_EFFECTIVE=%LABEL_FILTER%"
+) else (
+    if defined E2E_LABEL_FILTER (
+        set "LABEL_FILTER_EFFECTIVE=%E2E_LABEL_FILTER%"
+    )
+)
+
+if defined LABEL_FILTER_EFFECTIVE (
+    echo ✓ Using label filter: %LABEL_FILTER_EFFECTIVE%
+    set GINKGO_CMD=%GINKGO_CMD% --label-filter="%LABEL_FILTER_EFFECTIVE%"
+)
+
 set "GINKGO_CMD=%GINKGO_CMD% ."
 
 REM Execute the ginkgo command
@@ -82,4 +98,4 @@ if %errorlevel% equ 0 (
     echo.
     echo ✗ Some E2E tests failed
     exit /b 1
-) 
+)

--- a/test/e2e/run_tests.sh
+++ b/test/e2e/run_tests.sh
@@ -64,6 +64,14 @@ if [ -n "$GITHUB_ACTIONS" ]; then
 else
     GINKGO_CMD="$GINKGO_CMD --vv --show-node-events --trace"
 fi
+
+# Optional label filter (LABEL_FILTER or E2E_LABEL_FILTER)
+LABEL_FILTER_EFFECTIVE="${LABEL_FILTER:-${E2E_LABEL_FILTER:-}}"
+if [ -n "$LABEL_FILTER_EFFECTIVE" ]; then
+    echo -e "${GREEN}✓${NC} Using label filter: $LABEL_FILTER_EFFECTIVE"
+    GINKGO_CMD="$GINKGO_CMD --label-filter=\"$LABEL_FILTER_EFFECTIVE\""
+fi
+
 GINKGO_CMD="$GINKGO_CMD ."
 
 if eval "$GINKGO_CMD"; then

--- a/test/e2e/stdio_proxy_over_streamable_http_mcp_server_test.go
+++ b/test/e2e/stdio_proxy_over_streamable_http_mcp_server_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stacklok/toolhive/test/e2e"
 )
 
-var _ = Describe("TimeStreamableHttpMcpServer", Serial, func() {
+var _ = Describe("TimeStreamableHttpMcpServer", Label("proxy", "streamable-http", "e2e"), Serial, func() {
 	var config *e2e.TestConfig
 
 	BeforeEach(func() {

--- a/test/e2e/telemetry_middleware_e2e_test.go
+++ b/test/e2e/telemetry_middleware_e2e_test.go
@@ -22,7 +22,7 @@ func generateUniqueTelemetryServerName(prefix string) string {
 	return fmt.Sprintf("%s-%d-%d-%d", prefix, os.Getpid(), time.Now().UnixNano(), GinkgoRandomSeed())
 }
 
-var _ = Describe("Telemetry Middleware E2E", Serial, func() {
+var _ = Describe("Telemetry Middleware E2E", Label("middleware", "telemetry", "e2e"), Serial, func() {
 	var (
 		config        *e2e.TestConfig
 		proxyCmd      *exec.Cmd

--- a/test/e2e/thvignore_test.go
+++ b/test/e2e/thvignore_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stacklok/toolhive/test/e2e"
 )
 
-var _ = Describe("THVIgnore E2E Tests", func() {
+var _ = Describe("THVIgnore E2E Tests", Label("core", "thvignore", "e2e"), func() {
 	var (
 		config     *e2e.TestConfig
 		serverName string

--- a/test/e2e/unhealthy_workload_test.go
+++ b/test/e2e/unhealthy_workload_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stacklok/toolhive/test/e2e"
 )
 
-var _ = Describe("Unhealthy Workload Detection", func() {
+var _ = Describe("Unhealthy Workload Detection", Label("stability", "unhealthy", "e2e"), func() {
 	var (
 		config     *e2e.TestConfig
 		serverName string


### PR DESCRIPTION
This PR improves E2E test organization and CI execution.

What changed
- Added Ginkgo labels to all test/e2e suites to classify tests into broad categories:
  - core – CLI, groups, listings, restart, thvignore
  - mcp – server bring-up and protocol coverage (SSE, streamable-http, protocol builds, inspector)
  - proxy | middleware | stability – proxy oauth/stdio/tunnel, audit middleware, telemetry middleware, unhealthy detection
- Updated E2E runners to support label-driven subsets:
  - test/e2e/run_tests.sh and test/e2e/run_tests.bat accept LABEL_FILTER (or E2E_LABEL_FILTER) and pass --label-filter to Ginkgo
- Split the E2E workflow into a 3-entry matrix running in parallel:
  - core → LABEL_FILTER=core
  - mcp → LABEL_FILTER=mcp
  - proxy/middleware/stability → LABEL_FILTER='proxy || middleware || stability'

Why
- Faster CI via parallel execution of categorized suites
- Easier local workflows by running only the relevant subset
- Clearer ownership and readability by grouping tests by concern

Local examples
- LABEL_FILTER=core ./test/e2e/run_tests.sh
- LABEL_FILTER=mcp ./test/e2e/run_tests.sh
- LABEL_FILTER='proxy || middleware || stability' ./test/e2e/run_tests.sh

Notes
- Only E2E test files, test runners, and the E2E workflow were updated. No production code paths were changed.