### PR TITLE
Revert "Force reload of config singleton after writing config changes… (#1923)"

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -241,10 +241,6 @@ func (c *Config) saveToPath(configPath string) error {
 	if err != nil {
 		return fmt.Errorf("error writing config file: %w", err)
 	}
-
-	// Important: Need to reset config singleton or else it won't pick up changes.
-	ResetSingleton()
-
 	return nil
 }
 


### PR DESCRIPTION
Merged before e2e test failures were understood.

This reverts commit 766f6085f60a7db3a570ab5aa0299eff0fc39e8f.