### PR TITLE
docs(operator): add E2E test instructions, clarify task usage, and automate Chainsaw install

### DIFF
--- a/cmd/thv-operator/README.md
+++ b/cmd/thv-operator/README.md
@@ -53,6 +53,45 @@ flowchart LR
 
 ## Installation
 
+
+## Running Operator Unit & Integration Tests
+
+To run the basic operator-only tests (unit and integration), use the following command from the root of the project:
+
+```bash
+task operator:operator-test
+```
+
+This will run all Go tests in the operator codebase.
+
+## Running Operator E2E Tests
+
+The `task` commands for the operator are designed to be run from the root of the project.
+
+### E2E Test Prerequisites
+
+To run the Operator end-to-end (E2E) tests locally, ensure you have the following installed:
+
+- [Go](https://golang.org/doc/install)
+- [Kind](https://kind.sigs.k8s.io/)
+- [Kind Load Balancer](https://kind.sigs.k8s.io/docs/user/loadbalancer/)
+- [Task](https://taskfile.dev/#/installation)
+- [Chainsaw](https://github.com/kubernetes-sigs/chainsaw) (automatically installed by the Taskfile for local runs)
+
+### Steps
+
+1. **Set up the Kind cluster:**
+  ```bash
+  task operator:kind-setup
+  ```
+
+2. **Run the Operator E2E tests:**
+  ```bash
+  task operator:operator-e2e-test
+  ```
+
+Note: The Taskfile will ensure Chainsaw is installed locally if not present. In CI, Chainsaw is installed via the GitHub Action.
+
 ### Prerequisites
 
 - Kubernetes cluster (v1.19+)

--- a/cmd/thv-operator/README.md
+++ b/cmd/thv-operator/README.md
@@ -53,7 +53,6 @@ flowchart LR
 
 ## Installation
 
-
 ## Running Operator Unit & Integration Tests
 
 To run the basic operator-only tests (unit and integration), use the following command from the root of the project:

--- a/cmd/thv-operator/Taskfile.yml
+++ b/cmd/thv-operator/Taskfile.yml
@@ -182,6 +182,13 @@ tasks:
   operator-e2e-test:
     desc: Run E2E tests for the operator
     cmds:
+      - |
+        if [ -z "$CI" ]; then
+          if ! command -v chainsaw >/dev/null 2>&1; then
+            echo "Chainsaw not found, installing..."
+            go install github.com/kubernetes-sigs/chainsaw/cmd/chainsaw@latest
+          fi
+        fi
       - chainsaw test --test-dir test/e2e/chainsaw/operator/multi-tenancy/setup
       - chainsaw test --test-dir test/e2e/chainsaw/operator/multi-tenancy/test-scenarios
       - chainsaw test --test-dir test/e2e/chainsaw/operator/multi-tenancy/cleanup


### PR DESCRIPTION
- Added clear instructions for running Operator E2E and unit/integration tests in README
- Clarified that all operator task commands should be run from the project root
- Updated Taskfile to auto-install Chainsaw for local runs, skipping in CI

Ref: #1843