### PR TITLE
Add MAINTAINERS file

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,83 @@
+# ToolHive Contribution and Maintainership
+
+We welcome additional contributors to ToolHive, including maintainers. ToolHive
+currently has a two-tier contributor structure:
+
+| Role        | Description                                                      | Privileges                          |
+| ----------- | ---------------------------------------------------------------- | ----------------------------------- |
+| Contributor | Anyone who participates in the project!                          | Send / update PRs                   |
+| Maintainer  | Consistent contributors who have shown commitment to the project | Review and merge PRs, manage issues |
+
+## Contributors
+
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for a description of how to get started
+contributing to ToolHive.
+
+## Requirements for Becoming a Maintainer
+
+To become a maintainer, you must meet the following criteria:
+
+1. **Account Security**
+
+- Must have enabled
+  [two factor authentication](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/about-two-factor-authentication)
+  on their GitHub account
+
+2. **Demonstrated Contribution**:
+
+   - Have made multiple significant contributions to ToolHive's GitHub
+     repositories. This can include:
+     - PR contributions to at least one ToolHive subsystem (CLI, Operator, or related components)
+     - PR reviews of at least one ToolHive subsystem
+     - Documentation and issue triage
+     - Community engagement and support
+
+3. **Sponsorship**:
+
+   - Sponsored by at least one existing maintainer.
+
+## Responsibilities of a Maintainer
+
+As a maintainer, you will have the following responsibilities:
+
+1. **Code Review and Merging**:
+
+   - Review pull requests for quality, correctness, and alignment with the
+     project direction.
+     - When in doubt, assign pull requests to subject matter experts in the
+       relevant subsystem.
+   - Merge reviewed pull requests when satisfactory.
+
+2. **Set Technical Direction**:
+
+   - Where appropriate, participate in authoring and reviewing technical design
+     documents and proposals in the [`docs/proposals/`](./docs/proposals/) directory.
+   - Contribute to architectural decisions for ToolHive's CLI, Kubernetes Operator,
+     and MCP server management capabilities.
+
+3. **Community Engagement**:
+
+   - Help maintain a welcoming and inclusive community environment.
+   - Participate in discussions on GitHub issues and in the
+     [ToolHive Discord](https://discord.gg/stacklok).
+   - Assist with triaging issues and providing guidance to new contributors.
+
+## Maintainers List
+
+The current list of ToolHive maintainers:
+
+<!-- This section will be updated as maintainers are added -->
+
+*To be populated as the project grows and maintainers are appointed.*
+
+## Becoming a Maintainer
+
+If you're interested in becoming a maintainer and meet the requirements above:
+
+1. Reach out to an existing maintainer or the core team
+2. Provide examples of your contributions to ToolHive
+3. Get sponsorship from an existing maintainer
+4. The maintainer team will review your application and make a decision
+
+For questions about maintainership, please reach out in our
+[Discord community](https://discord.gg/stacklok) or open an issue in this repository.


### PR DESCRIPTION
This designates the different roles in ToolHive as a project and a path
towards maintainership.
