### PR TITLE
Optimize E2E workflow: build ToolHive binary only once

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -7,9 +7,42 @@ permissions:
   contents: read
 
 jobs:
+  build-binary:
+    name: Build ToolHive Binary
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+
+      - name: Set up Go
+        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
+      - name: Install Task
+        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2
+        with:
+          version: 3.44.1
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build ToolHive binary
+        run: |
+          task build
+          # Verify the binary was created and is executable
+          ls -la ./bin/
+          chmod +x ./bin/thv
+
+      - name: Upload ToolHive binary
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: toolhive-binary
+          path: ./bin/thv
+          retention-days: 1
+
   e2e-tests:
     name: E2E Tests (${{ matrix.title }})
     runs-on: ubuntu-latest
+    needs: build-binary
     strategy:
       fail-fast: false
       matrix:
@@ -32,21 +65,23 @@ jobs:
           go-version-file: 'go.mod'
           cache: true
 
-      - name: Install Task
-        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2
-        with:
-          version: 3.44.1
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Install Ginkgo CLI
-        run: go install github.com/onsi/ginkgo/v2/ginkgo@latest
-
-      - name: Build ToolHive binary
+      - name: Install dependencies
         run: |
-          task build
-          # Verify the binary was created and is executable
-          ls -la ./bin/
+          go mod download
+      - name: Install Ginkgo CLI
+        run: |
+          go install github.com/onsi/ginkgo/v2/ginkgo@latest
+
+      - name: Download ToolHive binary
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
+        with:
+          name: toolhive-binary
+          path: ./bin/
+
+      - name: Set binary permissions
+        run: |
           chmod +x ./bin/thv
+          ls -la ./bin/
 
       - name: Set up container runtime (Docker)
         run: |


### PR DESCRIPTION
## Summary

Optimizes the E2E tests workflow by building the ToolHive binary only once and reusing it across all matrix jobs, significantly reducing CI execution time.

## Changes

- **Added `build-binary` job**: Creates a separate job that builds the ToolHive binary once using the existing build process
- **Binary artifact management**: Uploads the built binary as an artifact with 1-day retention
- **Job dependency**: Modified `e2e-tests` job to depend on `build-binary` via `needs: build-binary`
- **Eliminated redundant builds**: Removed the "Build ToolHive binary" step from each matrix job and replaced with artifact download
- **Maintained necessary dependencies**: Kept Go setup and Ginkgo CLI installation in test jobs since they're still needed

## Benefits

- **Reduced build time**: Instead of building the binary 3 times (once per matrix job), it's now built only once
- **Parallel execution**: All three matrix jobs (`core`, `mcp`, `proxy-mw`) can now run in parallel after the single build completes
- **Resource optimization**: Less CPU and memory usage in the CI pipeline
- **Maintained test coverage**: No changes to actual test execution or coverage

## Workflow Structure

**Before**: `e2e-tests` (3 parallel jobs, each building binary) 
**After**: `build-binary` → `e2e-tests` (3 parallel jobs using shared binary)

## Testing

The workflow maintains the same test execution pattern and environment variables. The only change is how the binary is obtained (artifact download vs. local build).