### PR TITLE
do not execute migration or proxy checks for auxiliary workloads

### DIFF
--- a/cmd/thv/app/inspector.go
+++ b/cmd/thv/app/inspector.go
@@ -131,7 +131,7 @@ func inspectorCmdFunc(cmd *cobra.Command, args []string) error {
 
 	labelsMap := map[string]string{}
 	labels.AddStandardLabels(labelsMap, "inspector", "inspector", string(types.TransportTypeInspector), inspectorUIPort)
-	labelsMap["toolhive-auxiliary"] = "true"
+	labelsMap[labels.LabelAuxiliary] = labels.LabelToolHiveValue
 	_, err = rt.DeployWorkload(
 		ctx,
 		processedImage,

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -36,6 +36,9 @@ const (
 	// LabelGroup is the label that contains the group name
 	LabelGroup = "toolhive-group"
 
+	// LabelAuxiliary is the label that indicates this is an auxiliary workload (like inspector)
+	LabelAuxiliary = "toolhive-auxiliary"
+
 	// LabelToolHiveValue is the value for the LabelToolHive label
 	LabelToolHiveValue = "true"
 )
@@ -126,6 +129,13 @@ func GetGroup(labels map[string]string) string {
 // SetGroup sets the group name in labels
 func SetGroup(labels map[string]string, groupName string) {
 	labels[LabelGroup] = groupName
+}
+
+// IsAuxiliaryWorkload checks if a workload is an auxiliary workload (like inspector)
+// Auxiliary workloads don't follow standard workload management patterns and don't use proxy processes
+func IsAuxiliaryWorkload(labels map[string]string) bool {
+	value, ok := labels[LabelAuxiliary]
+	return ok && strings.ToLower(value) == LabelToolHiveValue
 }
 
 // IsStandardToolHiveLabel checks if a label key is a standard ToolHive label

--- a/pkg/workloads/manager.go
+++ b/pkg/workloads/manager.go
@@ -271,7 +271,7 @@ func (d *defaultManager) stopRemoteWorkload(ctx context.Context, name string, ru
 
 	// For remote workloads, we only need to clean up client configurations
 	// The saved state should be preserved for restart capability
-	if err := removeClientConfigurations(name); err != nil {
+	if err := removeClientConfigurations(name, false); err != nil {
 		logger.Warnf("Warning: Failed to remove client configurations: %v", err)
 	} else {
 		logger.Infof("Client configurations for %s removed", name)
@@ -500,8 +500,8 @@ func (d *defaultManager) deleteRemoteWorkload(ctx context.Context, name string, 
 		d.stopProxyIfNeeded(ctx, name, runConfig.BaseName)
 	}
 
-	// Clean up associated resources
-	d.cleanupWorkloadResources(ctx, name, runConfig.BaseName)
+	// Clean up associated resources (remote workloads are not auxiliary)
+	d.cleanupWorkloadResources(ctx, name, runConfig.BaseName, false)
 
 	// Remove the workload status from the status store
 	if err := d.statuses.DeleteWorkloadStatus(ctx, name); err != nil {
@@ -530,9 +530,14 @@ func (d *defaultManager) deleteContainerWorkload(ctx context.Context, name strin
 		containerLabels := container.Labels
 		baseName := labels.GetContainerBaseName(containerLabels)
 
-		// Stop proxy if running
+		// Stop proxy if running (skip for auxiliary workloads like inspector)
 		if container.IsRunning() {
-			d.stopProxyIfNeeded(ctx, name, baseName)
+			// Skip proxy stopping for auxiliary workloads that don't use proxy processes
+			if labels.IsAuxiliaryWorkload(containerLabels) {
+				logger.Debugf("Skipping proxy stop for auxiliary workload %s", name)
+			} else {
+				d.stopProxyIfNeeded(ctx, name, baseName)
+			}
 		}
 
 		// Remove the container
@@ -541,7 +546,7 @@ func (d *defaultManager) deleteContainerWorkload(ctx context.Context, name strin
 		}
 
 		// Clean up associated resources
-		d.cleanupWorkloadResources(ctx, name, baseName)
+		d.cleanupWorkloadResources(ctx, name, baseName, labels.IsAuxiliaryWorkload(containerLabels))
 	}
 
 	// Remove the workload status from the status store
@@ -595,7 +600,7 @@ func (d *defaultManager) removeContainer(ctx context.Context, name string) error
 }
 
 // cleanupWorkloadResources cleans up all resources associated with a workload
-func (d *defaultManager) cleanupWorkloadResources(ctx context.Context, name, baseName string) {
+func (d *defaultManager) cleanupWorkloadResources(ctx context.Context, name, baseName string, isAuxiliary bool) {
 	if baseName == "" {
 		return
 	}
@@ -606,17 +611,21 @@ func (d *defaultManager) cleanupWorkloadResources(ctx context.Context, name, bas
 	}
 
 	// Remove client configurations
-	if err := removeClientConfigurations(name); err != nil {
+	if err := removeClientConfigurations(name, isAuxiliary); err != nil {
 		logger.Warnf("Warning: Failed to remove client configurations: %v", err)
 	} else {
 		logger.Infof("Client configurations for %s removed", name)
 	}
 
-	// Delete the saved state last
-	if err := state.DeleteSavedRunConfig(ctx, baseName); err != nil {
-		logger.Warnf("Warning: Failed to delete saved state: %v", err)
+	// Delete the saved state last (skip for auxiliary workloads that don't have run configs)
+	if !isAuxiliary {
+		if err := state.DeleteSavedRunConfig(ctx, baseName); err != nil {
+			logger.Warnf("Warning: Failed to delete saved state: %v", err)
+		} else {
+			logger.Infof("Saved state for %s removed", baseName)
+		}
 	} else {
-		logger.Infof("Saved state for %s removed", baseName)
+		logger.Debugf("Skipping saved state deletion for auxiliary workload %s", name)
 	}
 
 	logger.Infof("Container %s removed", name)
@@ -938,12 +947,15 @@ func (d *defaultManager) startWorkload(ctx context.Context, name string, mcpRunn
 
 // TODO: Move to dedicated config management interface.
 // updateClientConfigurations updates client configuration files with the MCP server URL
-func removeClientConfigurations(containerName string) error {
+func removeClientConfigurations(containerName string, isAuxiliary bool) error {
 	// Get the workload's group by loading its run config
 	runConfig, err := runner.LoadState(context.Background(), containerName)
 	var group string
 	if err != nil {
-		logger.Warnf("Warning: Failed to load run config for %s, will use backward compatible behavior: %v", containerName, err)
+		// Only warn for non-auxiliary workloads since auxiliary workloads don't have run configs
+		if !isAuxiliary {
+			logger.Warnf("Warning: Failed to load run config for %s, will use backward compatible behavior: %v", containerName, err)
+		}
 		// Continue with empty group (backward compatibility)
 	} else {
 		group = runConfig.Group
@@ -1015,8 +1027,12 @@ func (d *defaultManager) stopSingleContainerWorkload(ctx context.Context, worklo
 	defer cancel()
 
 	name := labels.GetContainerBaseName(workload.Labels)
-	// Stop the proxy process
-	proxy.StopProcess(name)
+	// Stop the proxy process (skip for auxiliary workloads like inspector)
+	if labels.IsAuxiliaryWorkload(workload.Labels) {
+		logger.Debugf("Skipping proxy stop for auxiliary workload %s", name)
+	} else {
+		proxy.StopProcess(name)
+	}
 	// TODO: refactor the StopProcess function to stop dealing explicitly with PID files.
 	// Note that this is not a blocker for k8s since this code path is not called there.
 	if err := d.statuses.ResetWorkloadPID(ctx, name); err != nil {
@@ -1032,7 +1048,7 @@ func (d *defaultManager) stopSingleContainerWorkload(ctx context.Context, worklo
 		return fmt.Errorf("failed to stop container: %w", err)
 	}
 
-	if err := removeClientConfigurations(name); err != nil {
+	if err := removeClientConfigurations(name, labels.IsAuxiliaryWorkload(workload.Labels)); err != nil {
 		logger.Warnf("Warning: Failed to remove client configurations: %v", err)
 	} else {
 		logger.Infof("Client configurations for %s removed", name)


### PR DESCRIPTION
We were seeing some warnings about migration processes, errors checking proxy, etc... on inspector
But this was caused because those processes didn't need to run for auxiliary workloads. So add a check to prevent this

Closes: #1696