### PR TITLE
Remove support for managing mcp with partial names

### DIFF
--- a/pkg/container/docker/client.go
+++ b/pkg/container/docker/client.go
@@ -779,7 +779,9 @@ func (c *Client) getPermissionConfigFromProfile(
 }
 
 // findExistingContainer finds a container with the exact name
+// Uses container runtime's name filter for efficiency but then verifies exact match to prevent partial matching
 func (c *Client) findExistingContainer(ctx context.Context, name string) (string, error) {
+	// Use name filter to narrow results, then verify exact match
 	containers, err := c.api.ContainerList(ctx, container.ListOptions{
 		All: true, // Include stopped containers
 		Filters: filters.NewArgs(
@@ -790,7 +792,7 @@ func (c *Client) findExistingContainer(ctx context.Context, name string) (string
 		return "", NewContainerError(err, "", fmt.Sprintf("failed to list containers: %v", err))
 	}
 
-	// Find exact name match (filter can return partial matches)
+	// Verify exact name match from the filtered results (name filter does partial matching)
 	for _, cont := range containers {
 		for _, containerName := range cont.Names {
 			// Container names in the API have a leading slash
@@ -1063,15 +1065,19 @@ func (c *Client) createNetwork(
 	internal bool,
 ) error {
 	// Check if the network already exists
+	// Use name filter for efficiency but verify exact match to avoid partial matching
 	networks, err := c.client.NetworkList(ctx, network.ListOptions{
 		Filters: filters.NewArgs(filters.Arg("name", name)),
 	})
 	if err != nil {
 		return fmt.Errorf("failed to list networks: %w", err)
 	}
-	if len(networks) > 0 {
-		// Network already exists, return its ID
-		return nil
+	// Verify exact name match from filtered results
+	for _, n := range networks {
+		if n.Name == name {
+			// Network already exists
+			return nil
+		}
 	}
 
 	networkCreate := network.CreateOptions{
@@ -1089,7 +1095,7 @@ func (c *Client) createNetwork(
 
 // DeleteNetwork deletes a network by name.
 func (c *Client) deleteNetwork(ctx context.Context, name string) error {
-	// find the network by name
+	// find the network by name using filter for efficiency but verify exact match
 	networks, err := c.client.NetworkList(ctx, network.ListOptions{
 		Filters: filters.NewArgs(filters.Arg("name", name)),
 	})
@@ -1097,13 +1103,22 @@ func (c *Client) deleteNetwork(ctx context.Context, name string) error {
 		return err
 	}
 
+	// Verify exact name match from filtered results
+	var networkToRemove *network.Summary
+	for _, n := range networks {
+		if n.Name == name {
+			networkToRemove = &n
+			break
+		}
+	}
+
 	// If the network does not exist, there is nothing to do here.
-	if len(networks) == 0 {
+	if networkToRemove == nil {
 		logger.Debugf("network %s not found, nothing to delete", name)
 		return nil
 	}
 
-	if err := c.client.NetworkRemove(ctx, networks[0].ID); err != nil {
+	if err := c.client.NetworkRemove(ctx, networkToRemove.ID); err != nil {
 		return fmt.Errorf("failed to remove network %s: %w", name, err)
 	}
 	return nil
@@ -1633,10 +1648,11 @@ func (c *Client) findContainerByLabel(ctx context.Context, workloadName string) 
 
 // findContainerByExactName finds a container by exact name matching.
 // Returns the container ID if found, empty string otherwise.
+// Uses container runtime's name filter for efficiency but then verifies exact match to prevent partial matching
 func (c *Client) findContainerByExactName(ctx context.Context, workloadName string) (string, error) {
 	filterArgs := filters.NewArgs()
 	filterArgs.Add("label", "toolhive=true")
-	filterArgs.Add("name", workloadName)
+	filterArgs.Add("name", workloadName) // Use name filter for efficiency
 
 	containers, err := c.api.ContainerList(ctx, container.ListOptions{
 		All:     true,
@@ -1650,28 +1666,17 @@ func (c *Client) findContainerByExactName(ctx context.Context, workloadName stri
 		return "", nil
 	}
 
-	// Docker does a prefix match on the name. If we find multiple containers,
-	// we need to filter down to the exact name requested.
-	var containerID string
-	if len(containers) > 1 {
-		// The name in the API has a leading slash, so we need to search for that.
-		prefixedName := "/" + workloadName
-		// The name in the API response is a list of names, so we need to check
-		// if the prefixed name is in the list.
-		// The extra names are used for docker network functionality which is
-		// not relevant for us.
-		idx := slices.IndexFunc(containers, func(c container.Summary) bool {
-			return slices.Contains(c.Names, prefixedName)
-		})
-		if idx == -1 {
-			return "", nil
+	// Verify exact name match from the filtered results (name filter does partial matching)
+	// The name in the API has a leading slash, so we need to search for that.
+	prefixedName := "/" + workloadName
+	for _, cont := range containers {
+		// Check if any of the container names match exactly
+		if slices.Contains(cont.Names, prefixedName) || slices.Contains(cont.Names, workloadName) {
+			return cont.ID, nil
 		}
-		containerID = containers[idx].ID
-	} else {
-		containerID = containers[0].ID
 	}
 
-	return containerID, nil
+	return "", nil
 }
 
 // inspectContainerByName finds a container by the workload name and inspects it.

--- a/pkg/container/docker/client_partial_match_test.go
+++ b/pkg/container/docker/client_partial_match_test.go
@@ -1,0 +1,280 @@
+package docker
+
+import (
+	"context"
+	"testing"
+
+	"github.com/docker/docker/api/types/container"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFindExistingContainer_RejectsPartialMatches tests that findExistingContainer
+// only returns exact matches and rejects partial matches that might be returned
+// by the container runtime's name filter
+func TestFindExistingContainer_RejectsPartialMatches(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	tests := []struct {
+		name           string
+		searchName     string
+		mockContainers []container.Summary
+		expectedID     string
+		expectFound    bool
+	}{
+		{
+			name:       "exact match found",
+			searchName: "myapp",
+			mockContainers: []container.Summary{
+				{ID: "exact-match-id", Names: []string{"/myapp"}},
+				{ID: "partial-match-id", Names: []string{"/myapp-test"}}, // partial match that should be ignored
+			},
+			expectedID:  "exact-match-id",
+			expectFound: true,
+		},
+		{
+			name:       "no exact match with partial matches present",
+			searchName: "app",
+			mockContainers: []container.Summary{
+				{ID: "partial-1", Names: []string{"/myapp"}},    // contains "app" but not exact
+				{ID: "partial-2", Names: []string{"/webapp"}},   // contains "app" but not exact
+				{ID: "partial-3", Names: []string{"/app-test"}}, // starts with "app" but not exact
+			},
+			expectedID:  "",
+			expectFound: false,
+		},
+		{
+			name:       "exact match among multiple partial matches",
+			searchName: "service",
+			mockContainers: []container.Summary{
+				{ID: "partial-1", Names: []string{"/service-web"}},
+				{ID: "partial-2", Names: []string{"/microservice"}},
+				{ID: "exact-match", Names: []string{"/service"}}, // exact match
+				{ID: "partial-3", Names: []string{"/service-db"}},
+			},
+			expectedID:  "exact-match",
+			expectFound: true,
+		},
+		{
+			name:       "exact match with leading slash",
+			searchName: "worker",
+			mockContainers: []container.Summary{
+				{ID: "slash-match", Names: []string{"/worker"}},
+				{ID: "partial", Names: []string{"/background-worker"}},
+			},
+			expectedID:  "slash-match",
+			expectFound: true,
+		},
+		{
+			name:       "exact match without leading slash",
+			searchName: "task",
+			mockContainers: []container.Summary{
+				{ID: "no-slash-match", Names: []string{"task"}}, // without leading slash
+				{ID: "partial", Names: []string{"/task-runner"}},
+			},
+			expectedID:  "no-slash-match",
+			expectFound: true,
+		},
+		{
+			name:           "no containers found",
+			searchName:     "nonexistent",
+			mockContainers: []container.Summary{},
+			expectedID:     "",
+			expectFound:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			api := &fakeDockerAPI{
+				listFunc: func(_ context.Context, opts container.ListOptions) ([]container.Summary, error) {
+					// Verify that the name filter is being used
+					nameFilters := opts.Filters.Get("name")
+					if len(nameFilters) > 0 {
+						assert.Equal(t, tt.searchName, nameFilters[0], "Expected name filter to be set correctly")
+					}
+
+					// Return mock containers that simulate runtime's partial matching behavior
+					return tt.mockContainers, nil
+				},
+			}
+
+			client := &Client{api: api}
+			containerID, err := client.findExistingContainer(ctx, tt.searchName)
+
+			require.NoError(t, err)
+			if tt.expectFound {
+				assert.Equal(t, tt.expectedID, containerID)
+				assert.NotEmpty(t, containerID)
+			} else {
+				assert.Empty(t, containerID)
+			}
+		})
+	}
+}
+
+// TestFindContainerByExactName_RejectsPartialMatches tests that findContainerByExactName
+// only returns exact matches and rejects partial matches, even when using both label
+// and name filters
+func TestFindContainerByExactName_RejectsPartialMatches(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	tests := []struct {
+		name           string
+		searchName     string
+		mockContainers []container.Summary
+		expectedID     string
+		expectFound    bool
+	}{
+		{
+			name:       "exact match with toolhive label",
+			searchName: "mcp-server",
+			mockContainers: []container.Summary{
+				{
+					ID:     "exact-match-id",
+					Names:  []string{"/mcp-server"},
+					Labels: map[string]string{"toolhive": "true"},
+				},
+				{
+					ID:     "partial-match-id",
+					Names:  []string{"/mcp-server-backup"},
+					Labels: map[string]string{"toolhive": "true"},
+				},
+			},
+			expectedID:  "exact-match-id",
+			expectFound: true,
+		},
+		{
+			name:       "no exact match despite partial matches",
+			searchName: "web",
+			mockContainers: []container.Summary{
+				{
+					ID:     "partial-1",
+					Names:  []string{"/webapp"},
+					Labels: map[string]string{"toolhive": "true"},
+				},
+				{
+					ID:     "partial-2",
+					Names:  []string{"/web-frontend"},
+					Labels: map[string]string{"toolhive": "true"},
+				},
+			},
+			expectedID:  "",
+			expectFound: false,
+		},
+		{
+			name:       "exact match among toolhive containers only",
+			searchName: "api",
+			mockContainers: []container.Summary{
+				{
+					ID:     "toolhive-exact",
+					Names:  []string{"/api"},
+					Labels: map[string]string{"toolhive": "true"},
+				},
+				{
+					ID:     "toolhive-partial",
+					Names:  []string{"/api-gateway"},
+					Labels: map[string]string{"toolhive": "true"},
+				},
+			},
+			expectedID:  "toolhive-exact",
+			expectFound: true,
+		},
+		{
+			name:       "multiple exact name matches - returns first toolhive one",
+			searchName: "duplicated",
+			mockContainers: []container.Summary{
+				{
+					ID:     "first-toolhive",
+					Names:  []string{"/duplicated"},
+					Labels: map[string]string{"toolhive": "true"},
+				},
+				{
+					ID:     "second-toolhive",
+					Names:  []string{"/duplicated"},
+					Labels: map[string]string{"toolhive": "true"},
+				},
+			},
+			expectedID:  "first-toolhive",
+			expectFound: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			api := &fakeDockerAPI{
+				listFunc: func(_ context.Context, opts container.ListOptions) ([]container.Summary, error) {
+					// Verify that both toolhive label filter and name filter are being used
+					toolhiveFilter := opts.Filters.Get("label")
+					nameFilter := opts.Filters.Get("name")
+
+					assert.Contains(t, toolhiveFilter, "toolhive=true", "Expected toolhive label filter")
+					assert.Contains(t, nameFilter, tt.searchName, "Expected name filter to be set")
+
+					// Return mock containers that simulate runtime's partial matching behavior
+					return tt.mockContainers, nil
+				},
+			}
+
+			client := &Client{api: api}
+			containerID, err := client.findContainerByExactName(ctx, tt.searchName)
+
+			require.NoError(t, err)
+			if tt.expectFound {
+				assert.Equal(t, tt.expectedID, containerID)
+				assert.NotEmpty(t, containerID)
+			} else {
+				assert.Empty(t, containerID)
+			}
+		})
+	}
+}
+
+// TestPartialMatchingPrevention_IntegrationScenarios tests real-world scenarios
+// where partial matching could cause problems
+func TestPartialMatchingPrevention_IntegrationScenarios(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	// Scenario: User has containers "app", "app-web", "app-db"
+	// When looking for "app", should only find exact match, not the others
+	mockContainers := []container.Summary{
+		{ID: "app-main", Names: []string{"/app"}, Labels: map[string]string{"toolhive": "true"}},
+		{ID: "app-web-id", Names: []string{"/app-web"}, Labels: map[string]string{"toolhive": "true"}},
+		{ID: "app-db-id", Names: []string{"/app-db"}, Labels: map[string]string{"toolhive": "true"}},
+		{ID: "webapp-id", Names: []string{"/webapp"}, Labels: map[string]string{"toolhive": "true"}},
+	}
+
+	api := &fakeDockerAPI{
+		listFunc: func(_ context.Context, _ container.ListOptions) ([]container.Summary, error) {
+			// Simulate that container runtime returned all containers due to partial matching
+			return mockContainers, nil
+		},
+	}
+
+	client := &Client{api: api}
+
+	// Test findExistingContainer with exact match
+	containerID, err := client.findExistingContainer(ctx, "app")
+	require.NoError(t, err)
+	assert.Equal(t, "app-main", containerID, "Should find exact match 'app', not partial matches")
+
+	// Test findContainerByExactName with exact match
+	containerID, err = client.findContainerByExactName(ctx, "app")
+	require.NoError(t, err)
+	assert.Equal(t, "app-main", containerID, "Should find exact match 'app', not partial matches")
+
+	// Test that partial match requests don't return wrong containers
+	containerID, err = client.findExistingContainer(ctx, "nonexistent")
+	require.NoError(t, err)
+	assert.Empty(t, containerID, "Should not find anything for non-existent exact name")
+}

--- a/pkg/workloads/manager.go
+++ b/pkg/workloads/manager.go
@@ -847,17 +847,9 @@ func (d *defaultManager) getWorkloadState(ctx context.Context, name string) (*wo
 			return nil, fmt.Errorf("failed to find workload %s: %v", name, err)
 		}
 	} else {
-		// Verify exact name match to prevent Docker prefix matching false positives
-		if container.Name != name {
-			logger.Warnf("Warning: Found container %s but requested %s (prefix match)", container.Name, name)
-			// Treat as if container not found
-			workloadSt.BaseName = name
-			workloadSt.Running = false
-		} else {
-			// Container found with exact name, check if it's running and get the base name
-			workloadSt.Running = container.IsRunning()
-			workloadSt.BaseName = labels.GetContainerBaseName(container.Labels)
-		}
+		// Container found, check if it's running and get the base name
+		workloadSt.Running = container.IsRunning()
+		workloadSt.BaseName = labels.GetContainerBaseName(container.Labels)
 	}
 
 	// Check if the proxy process is running

--- a/pkg/workloads/statuses/file_status.go
+++ b/pkg/workloads/statuses/file_status.go
@@ -550,11 +550,6 @@ func (f *fileStatusManager) getWorkloadFromRuntime(ctx context.Context, workload
 		return core.Workload{}, fmt.Errorf("failed to get workload info from runtime: %w", err)
 	}
 
-	// Verify exact name match to prevent Docker prefix matching false positives
-	if info.Name != workloadName {
-		return core.Workload{}, rt.ErrWorkloadNotFound
-	}
-
 	return types.WorkloadFromContainerInfo(&info)
 }
 


### PR DESCRIPTION
Docker has a feature, that allows to manage containers by looking at their partial names. When we use docker runtime, this is propagated to our thv client, and has caused many problems for us. Should be better to always manage mcp servers by referencing their complete names, removing that support for partials

Closes: #1941