### PR TITLE
Add automatic patch updates for kindest/node versions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,6 +19,12 @@
       "groupName": "dockerfile template base images",
       "matchDatasources": ["docker"],
       "matchManagers": ["custom.regex"]
+    },
+    {
+      "groupName": "kindest/node versions",
+      "matchManagers": ["custom.regex"],
+      "matchPackageNames": ["kindest/node"],
+      "matchUpdateTypes": ["patch"]
     }
   ],
   "customManagers": [
@@ -30,6 +36,16 @@
         "FROM (?<depName>[a-z0-9.-]+):(?<currentValue>[a-z0-9.-]+)"
       ],
       "datasourceTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "description": "Update kindest/node versions in GitHub workflows",
+      "managerFilePatterns": [".github/workflows/*.yml", ".github/workflows/*.yaml"],
+      "matchStrings": [
+        "\"(?<depName>kindest/node):v(?<currentValue>\\d+\\.\\d+\\.\\d+)\""
+      ],
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "semver"
     }
   ],
   "postUpdateOptions": ["gomodTidy"]


### PR DESCRIPTION
## Summary

Adds renovate configuration to automatically update kindest/node versions in `.github/workflows/operator-ci.yml` with patch-only updates.

## Changes

- **Custom regex manager**: Detects kindest/node versions in GitHub workflow files
- **Package rule**: Restricts updates to patch versions only using `matchUpdateTypes: ["patch"]`
- **Grouping**: All kindest/node updates are grouped together for easier management
- **Validation**: Configuration validated with `renovate-config-validator`

## Current versions and available updates

- `v1.31.9` → `v1.31.12` (patch update available)
- `v1.32.5` → `v1.32.8` (patch update available)
- `v1.33.1` → `v1.33.4` (patch update available)

## Benefits

- ✅ Automatic patch updates keep Kubernetes test matrix current
- ✅ Patch-only updates maintain version stability
- ✅ Grouped updates reduce PR noise
- ✅ No manual intervention required for patch releases

## Testing

- [x] Configuration validated with `renovate-config-validator`
- [x] Regex pattern tested against current workflow file
- [x] Verified newer patch versions are available in Docker registry

This configuration will automatically create pull requests when new patch versions of kindest/node are released, keeping the E2E test matrix up to date while maintaining compatibility.