### PR TITLE
Fix renovate config to properly restrict kindest/node to patch updates only

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,15 +16,16 @@
       "matchFileNames": ["deploy/charts/operator/**"]
     },
     {
-      "groupName": "dockerfile template base images",
-      "matchDatasources": ["docker"],
-      "matchManagers": ["custom.regex"]
-    },
-    {
       "groupName": "kindest/node versions",
       "matchManagers": ["custom.regex"],
       "matchPackageNames": ["kindest/node"],
       "matchUpdateTypes": ["patch"]
+    },
+    {
+      "groupName": "dockerfile template base images",
+      "matchDatasources": ["docker"],
+      "matchManagers": ["custom.regex"],
+      "matchPackageNames": ["!kindest/node"]
     }
   ],
   "customManagers": [


### PR DESCRIPTION
The issue was that we had two package rules that both matched custom.regex managers:
1. A broad "dockerfile template base images" rule that matched all docker custom.regex managers
2. A specific "kindest/node versions" rule with patch-only restriction

The broad rule was overriding the specific rule, causing kindest/node to get minor updates (v1.34.0).

Fixed by:
- Reordering rules so kindest/node rule comes first (higher priority)
- Adding negative match (!kindest/node) to the dockerfile template rule to exclude kindest/node
- This ensures kindest/node only gets patch updates while other docker images get all updates

Validated with renovate-config-validator.
