### PR TITLE
Add ginkgolinter to golangci-lint configuration

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,6 +12,7 @@ linters:
   enable:
     - depguard
     - exhaustive
+    - ginkgolinter
     - goconst
     - gocyclo
     - gosec
@@ -37,6 +38,29 @@ linters:
           deny:
             - pkg: io/ioutil
               desc: this is deprecated
+    ginkgolinter:
+      # Suppress the wrong length assertion warning
+      suppress-len-assertion: false
+      # Suppress the wrong nil assertion warning
+      suppress-nil-assertion: false
+      # Suppress the wrong error assertion warning
+      suppress-err-assertion: false
+      # Suppress the wrong comparison assertion warning
+      suppress-compare-assertion: false
+      # Suppress the wrong async assertion warning
+      suppress-async-assertion: false
+      # Suppress warning for comparing values from different types
+      suppress-type-compare-assertion: false
+      # Forbid focus containers (FIt, FDescribe, etc.)
+      forbid-focus-container: true
+      # Force using Expect with To/ToNot instead of Should/ShouldNot
+      force-expect-to: false
+      # Validate async intervals (timeout vs polling)
+      validate-async-intervals: true
+      # Forbid spec pollution (variable initialization in container nodes)
+      forbid-spec-pollution: false
+      # Force using Succeed() for functions and HaveOccurred() for errors
+      force-succeed: false
     gocyclo:
       min-complexity: 15
     gosec:

--- a/test/e2e/group_list_e2e_test.go
+++ b/test/e2e/group_list_e2e_test.go
@@ -119,7 +119,7 @@ var _ = Describe("Group List E2E", Label("core", "groups", "e2e"), func() {
 			}
 
 			By("Verifying test groups are in alphanumeric order")
-			Expect(len(testGroups)).To(Equal(len(mixedGroupNames)), "All test groups should be found")
+			Expect(testGroups).To(HaveLen(len(mixedGroupNames)), "All test groups should be found")
 
 			// Check that our test groups are sorted correctly
 			for i := 1; i < len(testGroups); i++ {

--- a/test/e2e/stdio_proxy_over_streamable_http_mcp_server_test.go
+++ b/test/e2e/stdio_proxy_over_streamable_http_mcp_server_test.go
@@ -118,7 +118,7 @@ var _ = Describe("TimeStreamableHttpMcpServer", Label("proxy", "streamable-http"
 			decoder := json.NewDecoder(resp.Body)
 			err = decoder.Decode(&responses)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(len(responses)).To(Equal(2))
+			Expect(responses).To(HaveLen(2))
 
 			ids := map[float64]bool{4: false, 5: false}
 			for _, r := range responses {


### PR DESCRIPTION
## Summary

This PR adds the [ginkgolinter](https://github.com/nunnatsa/ginkgolinter) to our golangci-lint configuration to ensure better code quality and consistency in our Ginkgo test suites.

## Changes

### Configuration Updates
- Added `ginkgolinter` to the enabled linters list in `.golangci.yml`
- Configured ginkgolinter with appropriate settings:
  - Enabled focus container detection to prevent accidentally committed focused tests
  - Enabled async interval validation for proper timeout/polling configuration
  - Kept default settings for assertion style checks

### Code Fixes
- Fixed existing ginkgolinter issues in e2e tests:
  - `test/e2e/group_list_e2e_test.go`: Changed `Expect(len(testGroups)).To(Equal(len(mixedGroupNames)))` to `Expect(testGroups).To(HaveLen(len(mixedGroupNames)))`
  - `test/e2e/stdio_proxy_over_streamable_http_mcp_server_test.go`: Changed `Expect(len(responses)).To(Equal(2))` to `Expect(responses).To(HaveLen(2))`

## Benefits

The ginkgolinter helps us:
- Catch common mistakes in Ginkgo tests (e.g., function calls in async assertions)
- Enforce consistent assertion styles (e.g., using `HaveLen()` instead of checking `len()` with `Equal()`)
- Prevent focus containers from being accidentally committed
- Ensure proper error handling patterns in tests
- Validate async assertion intervals

## Testing

- [x] Ran `task lint` - all checks pass
- [x] Verified ginkgolinter is properly configured and working
- [x] Fixed all existing ginkgolinter issues in the codebase