### PR TITLE
Force reload of config singleton on secret provider setup

### DIFF
--- a/pkg/api/v1/secrets.go
+++ b/pkg/api/v1/secrets.go
@@ -186,6 +186,9 @@ func (s *SecretsRoutes) setupSecretsProvider(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
+	// Need to force the singleton to be reloaded so that SetupComplete is updated.
+	config.ResetSingleton()
+
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
 


### PR DESCRIPTION
I previously did this in a more general way (see #1927) but I ran into strange e2e issues which I could not replicate locally. I decided to do it more surgically to avoid those problems.