### PR TITLE
Add Roddie and Daniele as ToolHive Maintainers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -69,6 +69,8 @@ The current list of ToolHive maintainers:
 <!-- This section will be updated as maintainers are added -->
 
 * [@stacklok/stackers](https://github.com/orgs/stacklok/teams/stackers)
+* [@dmartinol (RedHat)](https://github.com/dmartinol)
+* [@RoddieKieley (RedHat)](https://github.com/RoddieKieley)
 
 ## Becoming a Maintainer
 


### PR DESCRIPTION
We’re excited to officially welcome @RoddieKieley and @dmartinol as new maintainers of ToolHive! 🎉

Both have consistently gone above and beyond with their contributions, reviews, and community support. Their dedication and expertise have already made a huge impact and we’re thrilled to have them join the maintainer team!

Please join us in congratulating them and giving them a warm welcome to their new roles! 👋 