### PR TITLE
fixes job name reference

### DIFF
--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -88,10 +88,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           WINGET_GITHUB_TOKEN: ${{ secrets.WINGET_GITHUB_TOKEN }}
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
-          VERSION: ${{ needs.ldflags_args.outputs.version }}
-          COMMIT: ${{ needs.ldflags_args.outputs.commit }}
-          COMMIT_DATE: ${{ needs.ldflags_args.outputs.commit-date }}
-          TREE_STATE: ${{ needs.ldflags_args.outputs.tree-state }}
+          VERSION: ${{ needs.compute-build-flags.outputs.version }}
+          COMMIT: ${{ needs.compute-build-flags.outputs.commit }}
+          COMMIT_DATE: ${{ needs.compute-build-flags.outputs.commit-date }}
+          TREE_STATE: ${{ needs.compute-build-flags.outputs.tree-state }}
 
       - name: Generate subject
         id: hash


### PR DESCRIPTION
There were some things missed from https://github.com/stacklok/toolhive/pull/1955/files, this PRs makes sure to reference the new job names so that the version information is being set properly.

Ref: https://github.com/stacklok/toolhive/issues/1964