### PR TITLE
Fix goreleaser warnings

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -26,11 +26,9 @@ builds:
     binary: thv
 # This section defines the release format.
 archives:
-  - format: tar.gz # we can use binary, but it seems there's an issue where goreleaser skips the sboms
-    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+  - name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     format_overrides:
       - goos: windows
-        format: zip
 # This section defines how to release to winget.
 winget:
  - name: thv


### PR DESCRIPTION
The following PR should fix: 
```bash
    • DEPRECATED: archives.format should not be used anymore, check https://goreleaser.com/deprecations#archivesformat for more info
    • DEPRECATED: archives.format_overrides.format should not be used anymore, check https://goreleaser.com/deprecations#archivesformat_overridesformat for more info
```