### PR TITLE
Fix egress proxy ARM64 build by using Alpine edge repository

### DIFF
--- a/containers/egress-proxy/Dockerfile
+++ b/containers/egress-proxy/Dockerfile
@@ -1,8 +1,9 @@
 # Use Alpine Linux 3.22.0 for minimal footprint
 FROM alpine:3.22.1
 
-# Install squid and create necessary directories
-RUN apk add --no-cache squid \
+# Install squid from edge repository and create necessary directories
+RUN echo "https://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories \
+    && apk add --no-cache squid \
     && mkdir -p /var/cache/squid /var/log/squid \
     && chown -R squid:squid /var/cache/squid /var/log/squid /var/run/squid \
     && chmod 750 /var/cache/squid /var/log/squid


### PR DESCRIPTION
## Problem

The egress proxy Docker image build is failing for ARM64 architecture because the \`squid\` package is not available in Alpine Linux 3.22.1 repositories for the \`aarch64\` architecture.

## Changes

This PR adds the Alpine edge community repository to the Dockerfile to access the squid package for both AMD64 and ARM64 architectures.

**Modified Files:**
- \`containers/egress-proxy/Dockerfile\`: Added Alpine edge repository before installing squid

## Testing

- ✅ Local build test for \`linux/amd64\` - **PASSED**
- ✅ Local build test for \`linux/arm64\` - **PASSED**

Both architectures now successfully build the egress proxy image.

## Impact

- **Fixes:** Multi-architecture Docker image builds for egress proxy
- **Severity:** High - Previously blocked all ARM64 builds
- **Risk:** Low - Uses official Alpine edge repository

Fixes #1994