### PR TITLE
Fix flaky TestGetRegistryAPIImage test by using dependency injection

### DIFF
--- a/cmd/thv-operator/pkg/registryapi/deployment.go
+++ b/cmd/thv-operator/pkg/registryapi/deployment.go
@@ -240,7 +240,13 @@ func (*manager) getSourceDataHash(
 
 // getRegistryAPIImage returns the registry API container image to use
 func getRegistryAPIImage() string {
-	if img := os.Getenv("TOOLHIVE_REGISTRY_API_IMAGE"); img != "" {
+	return getRegistryAPIImageWithEnvGetter(os.Getenv)
+}
+
+// getRegistryAPIImageWithEnvGetter returns the registry API container image to use
+// with a custom environment variable getter function for testing
+func getRegistryAPIImageWithEnvGetter(envGetter func(string) string) string {
+	if img := envGetter("TOOLHIVE_REGISTRY_API_IMAGE"); img != "" {
 		return img
 	}
 	return "ghcr.io/stacklok/toolhive/thv-registry-api:latest"

--- a/cmd/thv-operator/pkg/registryapi/deployment_test.go
+++ b/cmd/thv-operator/pkg/registryapi/deployment_test.go
@@ -2,7 +2,6 @@ package registryapi
 
 import (
 	"errors"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -199,16 +198,6 @@ func TestManagerBuildRegistryAPIDeployment(t *testing.T) {
 func TestGetRegistryAPIImage(t *testing.T) {
 	t.Parallel()
 
-	// Save original environment variable
-	originalImage := os.Getenv("TOOLHIVE_REGISTRY_API_IMAGE")
-	t.Cleanup(func() {
-		if originalImage != "" {
-			os.Setenv("TOOLHIVE_REGISTRY_API_IMAGE", originalImage)
-		} else {
-			os.Unsetenv("TOOLHIVE_REGISTRY_API_IMAGE")
-		}
-	})
-
 	tests := []struct {
 		name        string
 		envValue    string
@@ -249,14 +238,15 @@ func TestGetRegistryAPIImage(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			// Cleanup environment before each test
-			os.Unsetenv("TOOLHIVE_REGISTRY_API_IMAGE")
-
-			if tt.setEnv {
-				os.Setenv("TOOLHIVE_REGISTRY_API_IMAGE", tt.envValue)
+			// Create a mock environment getter function for this test case
+			envGetter := func(key string) string {
+				if key == "TOOLHIVE_REGISTRY_API_IMAGE" && tt.setEnv {
+					return tt.envValue
+				}
+				return ""
 			}
 
-			result := getRegistryAPIImage()
+			result := getRegistryAPIImageWithEnvGetter(envGetter)
 			assert.Equal(t, tt.expected, result, tt.description)
 		})
 	}


### PR DESCRIPTION
Fixes a flaky test that was failing due to race conditions when manipulating global environment variables in parallel tests.

The `TestGetRegistryAPIImage/custom_image_from_env` test was using `os.Setenv`/`os.Unsetenv` while running with `t.Parallel()`, causing test cases to interfere with each other.

**Solution:** Refactored to use dependency injection - added `getRegistryAPIImageWithEnvGetter()` that accepts an environment getter function, allowing tests to use isolated mock functions instead of global state.

**Changes:**
- Added `getRegistryAPIImageWithEnvGetter` function for testability
- Updated test to use mock environment getter
- Removed unused `os` import
- Maintains backward compatibility

Test now runs reliably in parallel without race conditions.