### PR TITLE
Replace global logger with context-aware logging in operator

### DIFF
--- a/cmd/thv-operator/controllers/mcpserver_oidc_test.go
+++ b/cmd/thv-operator/controllers/mcpserver_oidc_test.go
@@ -359,7 +359,7 @@ func TestGenerateKubernetesOIDCArgs(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			args := reconciler.generateKubernetesOIDCArgs(tt.mcpServer)
+			args := reconciler.generateKubernetesOIDCArgs(context.Background(), tt.mcpServer)
 			assert.Equal(t, tt.expectedArgs, args)
 		})
 	}

--- a/cmd/thv-operator/controllers/mcpserver_resource_overrides_test.go
+++ b/cmd/thv-operator/controllers/mcpserver_resource_overrides_test.go
@@ -314,7 +314,7 @@ func TestResourceOverrides(t *testing.T) {
 			assert.Equal(t, tt.expectedDeploymentAnns, deployment.Annotations)
 
 			// Test service creation
-			service := r.serviceForMCPServer(tt.mcpServer)
+			service := r.serviceForMCPServer(context.Background(), tt.mcpServer)
 			require.NotNil(t, service)
 
 			assert.Equal(t, tt.expectedServiceLabels, service.Labels)
@@ -457,7 +457,7 @@ func TestDeploymentNeedsUpdateServiceAccount(t *testing.T) {
 	require.NotNil(t, deployment)
 
 	// Test with the current deployment - this should NOT need update
-	needsUpdate := r.deploymentNeedsUpdate(deployment, mcpServer)
+	needsUpdate := r.deploymentNeedsUpdate(context.Background(), deployment, mcpServer)
 
 	// With the service account bug fixed, this should now return false
 	assert.False(t, needsUpdate, "deploymentNeedsUpdate should return false when deployment matches MCPServer spec")
@@ -637,7 +637,7 @@ func TestDeploymentNeedsUpdateProxyEnv(t *testing.T) {
 			deployment.Spec.Template.Spec.Containers[0].Image = getToolhiveRunnerImage()
 
 			// Test if deployment needs update - should correlate with env change expectation
-			needsUpdate := r.deploymentNeedsUpdate(deployment, tt.mcpServer)
+			needsUpdate := r.deploymentNeedsUpdate(context.Background(), deployment, tt.mcpServer)
 
 			if tt.expectEnvChange {
 				assert.True(t, needsUpdate, "Expected deployment update due to proxy env change")
@@ -718,7 +718,7 @@ func TestDeploymentNeedsUpdateToolsFilter(t *testing.T) {
 
 			mcpServer.Spec.ToolsFilter = tt.newToolsFilter
 
-			needsUpdate := r.deploymentNeedsUpdate(deployment, mcpServer)
+			needsUpdate := r.deploymentNeedsUpdate(context.Background(), deployment, mcpServer)
 			assert.Equal(t, tt.expectEnvChange, needsUpdate)
 		})
 	}

--- a/cmd/thv-operator/controllers/mcpserver_runconfig.go
+++ b/cmd/thv-operator/controllers/mcpserver_runconfig.go
@@ -22,7 +22,6 @@ import (
 
 	mcpv1alpha1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1alpha1"
 	"github.com/stacklok/toolhive/pkg/authz"
-	"github.com/stacklok/toolhive/pkg/logger"
 	"github.com/stacklok/toolhive/pkg/operator/accessors"
 	"github.com/stacklok/toolhive/pkg/runner"
 	transporttypes "github.com/stacklok/toolhive/pkg/transport/types"
@@ -92,7 +91,7 @@ func (r *MCPServerReconciler) ensureRunConfigConfigMap(ctx context.Context, m *m
 	}
 
 	// Validate the RunConfig before creating the ConfigMap
-	if err := r.validateRunConfig(runConfig); err != nil {
+	if err := r.validateRunConfig(ctx, runConfig); err != nil {
 		return fmt.Errorf("invalid RunConfig: %w", err)
 	}
 
@@ -354,7 +353,7 @@ func labelsForRunConfig(mcpServerName string) map[string]string {
 }
 
 // validateRunConfig validates a RunConfig for operator-managed deployments
-func (r *MCPServerReconciler) validateRunConfig(config *runner.RunConfig) error {
+func (r *MCPServerReconciler) validateRunConfig(ctx context.Context, config *runner.RunConfig) error {
 	if config == nil {
 		return fmt.Errorf("RunConfig cannot be nil")
 	}
@@ -387,7 +386,8 @@ func (r *MCPServerReconciler) validateRunConfig(config *runner.RunConfig) error 
 		return err
 	}
 
-	logger.Debugf("RunConfig validation passed for %s", config.Name)
+	ctxLogger := log.FromContext(ctx)
+	ctxLogger.V(1).Info("RunConfig validation passed", "name", config.Name)
 	return nil
 }
 

--- a/cmd/thv-operator/controllers/mcpserver_runconfig_test.go
+++ b/cmd/thv-operator/controllers/mcpserver_runconfig_test.go
@@ -1441,7 +1441,7 @@ func TestValidateRunConfig(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			r := &MCPServerReconciler{}
-			err := r.validateRunConfig(tt.config)
+			err := r.validateRunConfig(t.Context(), tt.config)
 
 			if tt.expectErr {
 				assert.Error(t, err)


### PR DESCRIPTION
Resolves #1830

This change replaces all instances of global logger usage in the ToolHive operator with context-aware logging to preserve trace context for better observability.

## Changes

- Updated `validateRunConfig()` to accept context and use `log.FromContext()`
- Updated helper functions in `mcpserver_controller.go` to use context-aware logging:
  - `ensureRequiredEnvVars()`
  - `serviceForMCPServer()`
  - `deploymentNeedsUpdate()`
  - `generateKubernetesOIDCArgs()`
  - `generateConfigMapOIDCArgs()`
- Removed unused global logger imports
- Updated function signatures to accept `context.Context` parameters
- Fixed all calling sites to pass context
- Updated test files to accommodate new function signatures
- Fixed linting issues (line length violations)

## Testing

- All unit tests pass
- All integration tests pass
- Linting passes with no issues
- No regressions introduced

## Impact

This change improves observability by ensuring that trace context is properly preserved throughout the operator's logging, making it easier to correlate logs with distributed traces in production environments.