### PR TITLE
Fix CI: Add workflow_call trigger to security-scan workflow

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,6 +1,7 @@
 name: Security Scan
 
 on:
+  workflow_call:
   workflow_dispatch:
   push:
     branches: [ main ]


### PR DESCRIPTION
## Problem

The CI was broken due to the `security-scan.yml` workflow missing the `workflow_call` trigger needed to make it reusable. This was causing the `run-on-pr.yml` workflow to fail when trying to call it at line 25.

Error message:
```
.github/workflows/run-on-pr.yml#L25
error parsing called workflow
".github/workflows/run-on-pr.yml"
-> "./.github/workflows/security-scan.yml"
: workflow is not reusable as it is missing a `on.workflow_call` trigger
```

## Solution

Added the `workflow_call:` trigger to the `security-scan.yml` workflow while preserving all existing triggers:
- `workflow_dispatch`
- `push` (on main branch)
- `pull_request` (on main branch) 
- `schedule` (daily at 2 AM UTC)

This follows the same pattern used by other reusable workflows in the repository like `spellcheck.yml` and `lint.yml`.

## Testing

The fix can be verified by:
1. The workflow syntax being valid
2. The PR checks running successfully once this PR is created
3. The security scan job completing as part of the overall CI pipeline

## Changes

- Added `workflow_call:` trigger to `.github/workflows/security-scan.yml`