### PR TITLE
Fix GoReleaser archive formats

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -26,9 +26,11 @@ builds:
     binary: thv
 # This section defines the release format.
 archives:
-  - name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+  - formats: [ 'tar.gz' ]
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     format_overrides:
       - goos: windows
+        formats: [ 'zip' ]
 # This section defines how to release to winget.
 winget:
  - name: thv


### PR DESCRIPTION
The `archives.format` and `archives.format_overrides.format` fields were removed in #1969 to clear deprecation warnings, but they should have beenrenamed from `format` to `formats` instead of being removed, per the deprecation notices:

https://goreleaser.com/deprecations/#archivesformat
https://goreleaser.com/deprecations/#archivesformat_overridesformat

This broke the release process because the expected archives were not generated.

Signed-off-by: Dan Barr <6922515+danbarr@users.noreply.github.com>