### PR TITLE
Add `pkg/testkit` package

### DIFF
--- a/pkg/testkit/sse_server.go
+++ b/pkg/testkit/sse_server.go
@@ -1,0 +1,184 @@
+package testkit
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
+)
+
+// sseServer provides a test server with /command and /sse endpoints
+type sseServer struct {
+	commandChannel chan string
+
+	middlewares       []func(http.Handler) http.Handler
+	toolsListResponse string
+	tools             map[string]tooldef
+}
+
+var _ TestMCPServer = (*sseServer)(nil)
+
+func (s *sseServer) SetMiddlewares(middlewares ...func(http.Handler) http.Handler) error {
+	if len(s.middlewares) > 0 {
+		return fmt.Errorf("middlewares already set")
+	}
+	s.middlewares = middlewares
+	return nil
+}
+
+func (s *sseServer) AddTool(tool tooldef) error {
+	if _, ok := s.tools[tool.Name]; ok {
+		return fmt.Errorf("tool %s already exists", tool.Name)
+	}
+	if s.tools == nil {
+		s.tools = make(map[string]tooldef)
+	}
+	s.tools[tool.Name] = tool
+	return nil
+}
+
+// NewSSETestServer creates a new SSE server, wraps it
+// in an `httptest.Server`, and returns it.
+func NewSSETestServer(
+	options ...TestMCPServerOption,
+) (*httptest.Server, error) {
+	commandChannel := make(chan string, 10)
+
+	server := &sseServer{
+		commandChannel: commandChannel,
+	}
+
+	for _, option := range options {
+		if err := option(server); err != nil {
+			return nil, fmt.Errorf("failed to apply option: %w", err)
+		}
+	}
+
+	if server.tools != nil {
+		// This precompiles the tools list response based on the provided tools
+		server.toolsListResponse = makeToolsList(server.tools)
+	}
+
+	router := chi.NewRouter()
+
+	// Apply middleware
+	allMiddlewares := append(
+		[]func(http.Handler) http.Handler{
+			middleware.RequestID,
+			middleware.Recoverer,
+		},
+		server.middlewares...,
+	)
+	router.Use(allMiddlewares...)
+
+	router.Post("/command", server.commandHandler)
+	router.Get("/sse", server.sseHandler)
+
+	return httptest.NewServer(router), nil
+}
+
+func (s *sseServer) commandHandler(w http.ResponseWriter, r *http.Request) {
+	// Read the request body
+	body := make([]byte, r.ContentLength)
+	_, err := r.Body.Read(body)
+	if err != nil {
+		http.Error(w, "Error reading request body", http.StatusInternalServerError)
+		return
+	}
+
+	// Parse the MCP request to validate it's either tools/list or tools/call
+	var mcpRequest map[string]any
+	if err := json.Unmarshal(body, &mcpRequest); err != nil {
+		http.Error(w, "Invalid JSON", http.StatusBadRequest)
+		return
+	}
+
+	// Check if it's a valid MCP request with method
+	method, ok := mcpRequest["method"].(string)
+	if !ok {
+		http.Error(w, "Missing or invalid method", http.StatusBadRequest)
+		return
+	}
+
+	// Validate that it's either tools/list or tools/call
+	if method != toolsListMethod && method != toolsCallMethod {
+		http.Error(w, "Unsupported method: "+method, http.StatusBadRequest)
+		return
+	}
+
+	// Send the command to the channel for /sse endpoint
+	s.commandChannel <- string(body)
+
+	// Reply with "Accepted"
+	w.WriteHeader(http.StatusAccepted)
+	if _, err := w.Write([]byte("Accepted")); err != nil {
+		http.Error(w, "Error writing response", http.StatusInternalServerError)
+		return
+	}
+
+	// Flush if available
+	if flusher, ok := w.(http.Flusher); ok {
+		flusher.Flush()
+	}
+
+	// Note: it is paramount to close the channel as it starts a chain reaction
+	// that causes the whole connection to be closed, allowing the test to finish.
+	close(s.commandChannel)
+}
+
+func (s *sseServer) sseHandler(w http.ResponseWriter, _ *http.Request) {
+	// Set SSE headers
+	w.Header().Set("Content-Type", "text/event-stream")
+
+	// Get flusher for streaming responses
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "Streaming unsupported", http.StatusInternalServerError)
+		return
+	}
+
+	// Loop over commands from the channel
+	for command := range s.commandChannel {
+		// Parse the MCP request to determine the response
+		var mcpRequest map[string]any
+		if err := json.Unmarshal([]byte(command), &mcpRequest); err != nil {
+			// If parsing fails, send the raw command as before
+			if _, err := w.Write([]byte("data: " + command + "\n\n")); err != nil {
+				http.Error(w, "Error writing response", http.StatusInternalServerError)
+				return
+			}
+		} else {
+			// Generate appropriate response based on method
+			method, ok := mcpRequest["method"].(string)
+			if !ok {
+				// If no method, send the raw command as before
+				if _, err := w.Write([]byte("data: " + command + "\n\n")); err != nil {
+					http.Error(w, "Error writing response", http.StatusInternalServerError)
+					return
+				}
+			} else {
+				var response string
+				switch method {
+				case toolsListMethod:
+					response = s.toolsListResponse
+				case toolsCallMethod:
+					response = runToolCall(s.tools, mcpRequest)
+				default:
+					//nolint:goconst
+					response = "failed to generate response"
+				}
+
+				if _, err := w.Write([]byte("data: " + response + "\n\n")); err != nil {
+					http.Error(w, "Error writing response", http.StatusInternalServerError)
+					return
+				}
+			}
+
+			// Flush the response immediately
+			flusher.Flush()
+		}
+	}
+}

--- a/pkg/testkit/streamable_server.go
+++ b/pkg/testkit/streamable_server.go
@@ -1,0 +1,182 @@
+package testkit
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
+)
+
+// streamableServer provides a test server with /mcp-json and /mcp-sse endpoints
+type streamableServer struct {
+	middlewares       []func(http.Handler) http.Handler
+	toolsListResponse string
+	tools             map[string]tooldef
+}
+
+var _ TestMCPServer = (*streamableServer)(nil)
+
+func (s *streamableServer) SetMiddlewares(middlewares ...func(http.Handler) http.Handler) error {
+	if len(s.middlewares) > 0 {
+		return fmt.Errorf("middlewares already set")
+	}
+	s.middlewares = middlewares
+	return nil
+}
+
+func (s *streamableServer) AddTool(tool tooldef) error {
+	if _, ok := s.tools[tool.Name]; ok {
+		return fmt.Errorf("tool %s already exists", tool.Name)
+	}
+	if s.tools == nil {
+		s.tools = make(map[string]tooldef)
+	}
+	s.tools[tool.Name] = tool
+	return nil
+}
+
+// NewStreamableTestServer creates a new Streamable-HTTP server,
+// wraps it in an `httptest.Server`, and returns it.
+func NewStreamableTestServer(
+	options ...TestMCPServerOption,
+) (*httptest.Server, error) {
+	server := &streamableServer{}
+
+	for _, option := range options {
+		if err := option(server); err != nil {
+			return nil, fmt.Errorf("failed to apply option: %w", err)
+		}
+	}
+
+	// This precompiles the tools list response based on the provided tools
+	server.toolsListResponse = makeToolsList(server.tools)
+
+	router := chi.NewRouter()
+
+	// Apply middleware
+	allMiddlewares := append(
+		[]func(http.Handler) http.Handler{
+			middleware.RequestID,
+			middleware.Recoverer,
+		},
+		server.middlewares...,
+	)
+	router.Use(allMiddlewares...)
+
+	router.Post("/mcp-json", server.mcpJSONHandler)
+	router.Post("/mcp-sse", server.mcpEventStreamHandler)
+
+	return httptest.NewServer(router), nil
+}
+
+func (s *streamableServer) mcpJSONHandler(w http.ResponseWriter, r *http.Request) {
+	// Read the request body
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Error reading request body: %v", err), http.StatusBadRequest)
+		return
+	}
+
+	// Parse the MCP request to validate it's either tools/list or tools/call
+	var mcpRequest map[string]any
+	if err := json.Unmarshal(body, &mcpRequest); err != nil {
+		http.Error(w, fmt.Sprintf("Invalid JSON: %v", err), http.StatusBadRequest)
+		return
+	}
+
+	// Check if it's a valid MCP request with method
+	method, ok := mcpRequest["method"].(string)
+	if !ok {
+		http.Error(w, "Missing or invalid method", http.StatusBadRequest)
+		return
+	}
+
+	// Validate that it's either tools/list or tools/call
+	if method != "tools/list" && method != "tools/call" {
+		http.Error(w, "Unsupported method: "+method, http.StatusBadRequest)
+		return
+	}
+
+	// Generate appropriate response based on method
+	var response string
+	switch method {
+	case toolsListMethod:
+		response = s.toolsListResponse
+	case toolsCallMethod:
+		response = runToolCall(s.tools, mcpRequest)
+	default:
+		//nolint:goconst
+		response = "failed to generate response"
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if _, err := w.Write([]byte(response)); err != nil {
+		http.Error(w, "Error writing response", http.StatusInternalServerError)
+		return
+	}
+
+	// Flush if available
+	if flusher, ok := w.(http.Flusher); ok {
+		flusher.Flush()
+	}
+}
+
+func (s *streamableServer) mcpEventStreamHandler(w http.ResponseWriter, r *http.Request) {
+	// Read the request body
+	body := make([]byte, r.ContentLength)
+	_, err := r.Body.Read(body)
+	if err != nil {
+		http.Error(w, "Error reading request body", http.StatusInternalServerError)
+		return
+	}
+
+	// Parse the MCP request to validate it's either tools/list or tools/call
+	var mcpRequest map[string]any
+	if err := json.Unmarshal(body, &mcpRequest); err != nil {
+		http.Error(w, "Invalid JSON", http.StatusBadRequest)
+		return
+	}
+
+	// Check if it's a valid MCP request with method
+	method, ok := mcpRequest["method"].(string)
+	if !ok {
+		http.Error(w, "Missing or invalid method", http.StatusBadRequest)
+		return
+	}
+
+	// Validate that it's either tools/list or tools/call
+	if method != "tools/list" && method != "tools/call" {
+		http.Error(w, "Unsupported method: "+method, http.StatusBadRequest)
+		return
+	}
+
+	// Set SSE headers
+	w.Header().Set("Content-Type", "text/event-stream")
+
+	// Generate appropriate SSE response based on method
+	var response string
+	switch method {
+	case toolsListMethod:
+		response = s.toolsListResponse
+	case toolsCallMethod:
+		response = runToolCall(s.tools, mcpRequest)
+	default:
+		//nolint:goconst
+		response = "failed to generate response"
+	}
+
+	if _, err := w.Write([]byte("data: " + response + "\n\n")); err != nil {
+		http.Error(w, "Error writing response", http.StatusInternalServerError)
+		return
+	}
+
+	// Flush if available
+	if flusher, ok := w.(http.Flusher); ok {
+		flusher.Flush()
+	}
+}

--- a/pkg/testkit/testkit.go
+++ b/pkg/testkit/testkit.go
@@ -1,0 +1,191 @@
+// Package testkit provides testing utilities for ToolHive.
+//
+// Its sole purpose is
+//
+//   - providing utilities to quickly spin-up an HTTP test server exposing
+//     either a Streamable-HTTP or (legacy) SSE MCP server
+//   - providing utilities to ease the parsing of `text/event-stream` response
+//     bodies
+//
+// The file `pkg/testkit/testkit_test.go` contains a few tests that
+// exemplify how to use the framework. Ideally, it should allow the
+// developer to add assertions in the test server as well, but for
+// now it only allows configuring the returned JSON payloads.
+package testkit
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// Implementation note: this framework is work in progress, and in order to
+// make it easier to write tests using this framework we really need to provide
+// the developer not just with servers, but with clients as well.
+//
+// Ideally, clients would expose high-level functions that reflect protocol
+// operations, like `Initialize()`, `ListTools()`, `CallTool("foo")`, and so on.
+//
+// The reason clients were not added on the first iteration is because
+// SSE transport and Streamable-HTTP transport are very different, and
+// SSE clients need to first issue an HTTP GET on the SSE endpoint _before_
+// issuing the first command, while Streamable-HTTP can just fire off the command.
+
+const (
+	toolsListMethod = "tools/list"
+	toolsCallMethod = "tools/call"
+)
+
+// TestMCPServer is the common interface that test MCP servers must implement.
+// This allows having a single set of options for all test MCP servers,
+// regardless of the underlying implementation.
+type TestMCPServer interface {
+	SetMiddlewares(middlewares ...func(http.Handler) http.Handler) error
+	AddTool(tool tooldef) error
+}
+
+// TestMCPServerOption is a function that can be used to configure a test MCP server.
+// It uses the TestMCPServer interface to configure the server.
+type TestMCPServerOption func(TestMCPServer) error
+
+// WithMiddlewares is a function that can be used to configure a test MCP server with middlewares.
+// The actual order of application of the middleware functions is determined by the server
+// implementation, but is generally expected to be the same as the one provided.
+func WithMiddlewares(middlewares ...func(http.Handler) http.Handler) TestMCPServerOption {
+	return func(s TestMCPServer) error {
+		return s.SetMiddlewares(middlewares...)
+	}
+}
+
+type tooldef struct {
+	Name        string
+	Description string
+	Handler     func() string
+}
+
+// WithTool is a function that can be used to configure a test MCP server with a tool.
+// The underlying implementation is expected to honor this and return the tool
+// as part of the tools list response, as well as handle tool call requests using the given
+// handler function.
+func WithTool(name string, description string, handler func() string) TestMCPServerOption {
+	return func(s TestMCPServer) error {
+		return s.AddTool(tooldef{
+			Name:        name,
+			Description: description,
+			Handler:     handler,
+		})
+	}
+}
+
+// SSESep is a type that represents the separator for SSE responses.
+type SSESep int
+
+const (
+	// LFSep is the line feed separator for SSE responses.
+	LFSep = iota
+	// CRSep is the carriage return separator for SSE responses.
+	CRSep
+	// CRLFSep is the carriage return line feed separator for SSE responses.
+	CRLFSep
+)
+
+// NewSplitSSE is a function that can be used to create a new SSE split function.
+// It's just a helper function to be used with bufio.Scanner.Split.
+func NewSplitSSE(sep SSESep) bufio.SplitFunc {
+	var separator []byte
+
+	switch sep {
+	case LFSep:
+		separator = []byte("\n\n")
+	case CRSep:
+		separator = []byte("\r\r")
+	case CRLFSep:
+		separator = []byte("\r\n\r\n")
+	}
+
+	return func(data []byte, atEOF bool) (advance int, token []byte, err error) {
+		if atEOF && len(data) == 0 {
+			return 0, nil, nil
+		}
+
+		if i := bytes.Index(data, separator); i >= 0 {
+			return i + 2, data[0:i], nil
+		}
+
+		return 0, nil, nil
+	}
+}
+
+func makeToolsList(tools map[string]tooldef) string {
+	toolsList := make([]map[string]any, 0, len(tools))
+	for _, tool := range tools {
+		toolsList = append(toolsList, map[string]any{
+			"name":        tool.Name,
+			"description": tool.Description,
+		})
+	}
+
+	res := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"result": map[string]any{
+			"tools": toolsList,
+		},
+	}
+
+	response, err := json.Marshal(res)
+	if err != nil {
+		return fmt.Sprintf("failed to marshal tools list: %v", err)
+	}
+
+	return string(response)
+}
+
+func runToolCall(tools map[string]tooldef, mcpRequest map[string]any) string {
+	params, ok := mcpRequest["params"].(map[string]any)
+	if !ok {
+		return simpleError(fmt.Sprintf("failed to get tool params: %v", mcpRequest))
+	}
+
+	toolName, ok := params["name"].(string)
+	if !ok {
+		return simpleError(fmt.Sprintf("failed to get tool name: %v", mcpRequest))
+	}
+
+	if _, ok := tools[toolName]; !ok {
+		return simpleError(fmt.Sprintf("tool %s not found", toolName))
+	}
+
+	text := tools[toolName].Handler()
+	res := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"result": map[string]any{
+			"content": []map[string]any{{"type": "text", "text": text}},
+		},
+	}
+
+	payload, err := json.Marshal(res)
+	if err != nil {
+		return simpleError(fmt.Sprintf("failed to marshal tool call: %v", err))
+	}
+
+	return string(payload)
+}
+
+func simpleError(message string) string {
+	res := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"error":   map[string]any{"message": message},
+	}
+
+	payload, err := json.Marshal(res)
+	if err != nil {
+		return fmt.Sprintf("failed to marshal simple error: %v", err)
+	}
+
+	return string(payload)
+}

--- a/pkg/testkit/testkit_test.go
+++ b/pkg/testkit/testkit_test.go
@@ -1,0 +1,323 @@
+package testkit
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	toolsListRequest = `{"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}}`
+	toolsCallRequest = `{"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {"name": "test"}}`
+)
+
+// TestSSEServerEndpoints tests a simple MCP server with three endpoints
+func TestSSEServerEndpoints(t *testing.T) {
+	t.Parallel()
+
+	opts := []TestMCPServerOption{
+		WithTool("test", "A test tool", func() string { return "Tool call executed successfully" }),
+	}
+
+	t.Run("sse text/event-stream tools/list", func(t *testing.T) {
+		t.Parallel()
+
+		// Create SSE server for /command and /sse endpoints
+		server, err := NewSSETestServer(opts...)
+		require.NoError(t, err)
+		defer server.Close()
+
+		// Channel to receive SSE response
+		sseResponseChan := make(chan string, 1)
+
+		// Start SSE connection in a goroutine
+		go func() {
+			t.Helper()
+			defer close(sseResponseChan)
+
+			resp, err := http.Get(server.URL + "/sse")
+			require.NoError(t, err)
+			defer resp.Body.Close()
+
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+			require.Equal(t, "text/event-stream", resp.Header.Get("Content-Type"))
+
+			splitFunc := NewSplitSSE(LFSep)
+			scanner := bufio.NewScanner(resp.Body)
+			scanner.Split(splitFunc)
+
+			for scanner.Scan() {
+				require.NoError(t, scanner.Err())
+				event := scanner.Text()
+				sseResponseChan <- event
+			}
+		}()
+
+		// Give the SSE goroutine a moment to start
+		time.Sleep(10 * time.Millisecond)
+
+		// Now send a command to /command endpoint
+		commandResp, err := http.Post(server.URL+"/command", "application/json", bytes.NewBufferString(toolsListRequest))
+		require.NoError(t, err)
+		defer commandResp.Body.Close()
+
+		assert.Equal(t, http.StatusAccepted, commandResp.StatusCode)
+
+		commandBody, err := io.ReadAll(commandResp.Body)
+		require.NoError(t, err)
+		assert.Equal(t, "Accepted", string(commandBody))
+
+		// Wait for SSE response
+		select {
+		case sseBody := <-sseResponseChan:
+			// Check that the SSE response contains the tools/list response
+			data, ok := strings.CutPrefix(sseBody, "data: ")
+			require.True(t, ok)
+
+			var result map[string]any
+			err = json.Unmarshal([]byte(data), &result)
+			require.NoError(t, err)
+			assert.Equal(t, "2.0", result["jsonrpc"])
+			assert.Equal(t, float64(1), result["id"])
+
+			// Check that it's a tools/list response
+			toolCall, ok := result["result"].(map[string]any)
+			require.True(t, ok, "Result should contain result array")
+			assert.Len(t, toolCall["tools"], 1, "Should have one tool")
+			return
+		case <-time.After(1 * time.Second):
+			t.Fatal("Timeout waiting for SSE response")
+		}
+	})
+
+	t.Run("sse text/event-stream tools/call", func(t *testing.T) {
+		t.Parallel()
+
+		// Create SSE server for /command and /sse endpoints
+		server, err := NewSSETestServer(opts...)
+		require.NoError(t, err)
+		defer server.Close()
+
+		// Channel to receive SSE response
+		sseResponseChan := make(chan string, 1)
+
+		// Start SSE connection in a goroutine
+		go func() {
+			t.Helper()
+			defer close(sseResponseChan)
+
+			resp, err := http.Get(server.URL + "/sse")
+			require.NoError(t, err)
+			defer resp.Body.Close()
+
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+			require.Equal(t, "text/event-stream", resp.Header.Get("Content-Type"))
+
+			splitFunc := NewSplitSSE(LFSep)
+			scanner := bufio.NewScanner(resp.Body)
+			scanner.Split(splitFunc)
+
+			for scanner.Scan() {
+				require.NoError(t, scanner.Err())
+				event := scanner.Text()
+				sseResponseChan <- event
+			}
+		}()
+
+		// Give the SSE goroutine a moment to start
+		time.Sleep(10 * time.Millisecond)
+
+		// Now send a command to /command endpoint
+		commandResp, err := http.Post(server.URL+"/command", "application/json", bytes.NewBufferString(toolsCallRequest))
+		require.NoError(t, err)
+		defer commandResp.Body.Close()
+
+		assert.Equal(t, http.StatusAccepted, commandResp.StatusCode)
+
+		commandBody, err := io.ReadAll(commandResp.Body)
+		require.NoError(t, err)
+		assert.Equal(t, "Accepted", string(commandBody))
+
+		// Wait for SSE response
+		select {
+		case sseBody := <-sseResponseChan:
+			// Check that the SSE response contains the tools/call response
+			data, ok := strings.CutPrefix(sseBody, "data: ")
+			require.True(t, ok)
+
+			var result map[string]any
+			err = json.Unmarshal([]byte(data), &result)
+			require.NoError(t, err)
+			assert.Equal(t, "2.0", result["jsonrpc"])
+			assert.Equal(t, float64(1), result["id"])
+
+			// Check that it's a tools/call response
+			resultData, ok := result["result"].(map[string]any)
+			require.True(t, ok, "Result should contain a result object")
+
+			toolCall, ok := resultData["content"].([]any)
+			require.True(t, ok, "Result should contain content array")
+			assert.Len(t, toolCall, 1, "Should have one result")
+
+			return
+		case <-time.After(1 * time.Second):
+			t.Fatal("Timeout waiting for SSE response")
+		}
+	})
+}
+
+func TestStreamableServerEndpoints(t *testing.T) {
+	t.Parallel()
+
+	opts := []TestMCPServerOption{
+		WithTool("test", "A test tool", func() string { return "Tool call executed successfully" }),
+	}
+
+	t.Run("streamable application/json tools/list", func(t *testing.T) {
+		t.Parallel()
+
+		// Create streamable server for /mcp-json and /mcp-sse endpoints
+		server, err := NewStreamableTestServer(opts...)
+		require.NoError(t, err)
+		defer server.Close()
+
+		resp, err := http.Post(server.URL+"/mcp-json", "application/json", bytes.NewBufferString(toolsListRequest))
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
+
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+
+		var result map[string]any
+		err = json.Unmarshal(body, &result)
+		require.NoError(t, err)
+		assert.Equal(t, "2.0", result["jsonrpc"])
+		assert.Equal(t, float64(1), result["id"])
+
+		// Check that it's a tools/list response
+		resultData, ok := result["result"].(map[string]any)
+		require.True(t, ok, "Result should contain a result object")
+
+		tools, ok := resultData["tools"].([]any)
+		require.True(t, ok, "Result should contain tools array")
+		assert.Len(t, tools, 1, "Should have one tool")
+	})
+
+	t.Run("streamable text/event-stream tools/list", func(t *testing.T) {
+		t.Parallel()
+
+		// Create streamable server for /mcp-json and /mcp-sse endpoints
+		server, err := NewStreamableTestServer(opts...)
+		require.NoError(t, err)
+		defer server.Close()
+
+		resp, err := http.Post(server.URL+"/mcp-sse", "application/json", bytes.NewBufferString(toolsListRequest))
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Equal(t, "text/event-stream", resp.Header.Get("Content-Type"))
+
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+
+		// Check that the response is in SSE format
+		data, ok := strings.CutPrefix(string(body), "data: ")
+		require.True(t, ok)
+
+		var result map[string]any
+		err = json.Unmarshal([]byte(data), &result)
+		require.NoError(t, err)
+		assert.Equal(t, "2.0", result["jsonrpc"])
+		assert.Equal(t, float64(1), result["id"])
+
+		// Check that it's a tools/list response
+		resultData, ok := result["result"].(map[string]any)
+		require.True(t, ok, "Result should contain a result object")
+
+		tools, ok := resultData["tools"].([]any)
+		require.True(t, ok, "Result should contain tools array")
+		assert.Len(t, tools, 1, "Should have one tool")
+	})
+
+	t.Run("streamable application/json tools/call", func(t *testing.T) {
+		t.Parallel()
+
+		// Create streamable server for /mcp-json and /mcp-sse endpoints
+		server, err := NewStreamableTestServer(opts...)
+		require.NoError(t, err)
+		defer server.Close()
+
+		resp, err := http.Post(server.URL+"/mcp-json", "application/json", bytes.NewBufferString(toolsCallRequest))
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
+
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+
+		var result map[string]any
+		err = json.Unmarshal(body, &result)
+		require.NoError(t, err)
+		assert.Equal(t, "2.0", result["jsonrpc"])
+		assert.Equal(t, float64(1), result["id"])
+
+		// Check that it's a tools/call response
+		resultData, ok := result["result"].(map[string]any)
+		require.True(t, ok, "Result should contain a result object")
+
+		toolCall, ok := resultData["content"].([]any)
+		require.True(t, ok, "Result should contain content array")
+		assert.Len(t, toolCall, 1, "Should have one result")
+	})
+
+	t.Run("streamable text/event-stream tools/call", func(t *testing.T) {
+		t.Parallel()
+
+		// Create streamable server for /mcp-json and /mcp-sse endpoints
+		server, err := NewStreamableTestServer(opts...)
+		require.NoError(t, err)
+		defer server.Close()
+
+		resp, err := http.Post(server.URL+"/mcp-sse", "application/json", bytes.NewBufferString(toolsCallRequest))
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Equal(t, "text/event-stream", resp.Header.Get("Content-Type"))
+
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+
+		// Check that the response is in SSE format
+		data, ok := strings.CutPrefix(string(body), "data: ")
+		require.True(t, ok)
+
+		var result map[string]any
+		err = json.Unmarshal([]byte(data), &result)
+		require.NoError(t, err)
+		assert.Equal(t, "2.0", result["jsonrpc"])
+		assert.Equal(t, float64(1), result["id"])
+
+		// Check that it's a tools/call response
+		resultData, ok := result["result"].(map[string]any)
+		require.True(t, ok, "Result should contain a result object")
+
+		toolCall, ok := resultData["content"].([]any)
+		require.True(t, ok, "Result should contain content array")
+		assert.Len(t, toolCall, 1, "Should have one result")
+	})
+}


### PR DESCRIPTION
This change adds a new `testkit` package that should help us write e2e in a simpler way. Its sole purpose is

* adding utilities to quickly spin-up an HTTP test server exposing either a Streamable-HTTP or (legacy) SSE MCP server
* adding utilities to ease the parsing of `text/event-stream` response bodies

The file `pkg/testkit/testkit_test.go` contains a few tests that exemplify how to use the framework, which is barebone at the moment. Ideally, it should allow the developer to add assertions in the test server as well, but for now it only allows configuring the returned JSON payloads.