### PR TITLE
Propagate serviceAccount to StatefulSet in ConfigMap mode

### DIFF
--- a/cmd/thv-operator/controllers/mcpserver_controller.go
+++ b/cmd/thv-operator/controllers/mcpserver_controller.go
@@ -754,8 +754,15 @@ func (r *MCPServerReconciler) deploymentForMCPServer(ctx context.Context, m *mcp
 	// Check if global ConfigMap mode is enabled via environment variable
 	useConfigMap := os.Getenv("TOOLHIVE_USE_CONFIGMAP") == trueValue
 	if useConfigMap {
-		// Also add pod template patch for secrets (same as regular flags approach)
+		// Also add pod template patch for secrets and service account (same as regular flags approach)
+		// If service account is not specified, use the default MCP server service account
+		serviceAccount := m.Spec.ServiceAccount
+		if serviceAccount == nil {
+			defaultSA := mcpServerServiceAccountName(m.Name)
+			serviceAccount = &defaultSA
+		}
 		finalPodTemplateSpec := NewMCPServerPodTemplateSpecBuilder(m.Spec.PodTemplateSpec).
+			WithServiceAccount(serviceAccount).
 			WithSecrets(m.Spec.Secrets).
 			Build()
 		// Add pod template patch if we have one

--- a/test/e2e/chainsaw/operator/single-tenancy/test-scenarios/configmap-mode/assert-statefulset-serviceaccount.yaml
+++ b/test/e2e/chainsaw/operator/single-tenancy/test-scenarios/configmap-mode/assert-statefulset-serviceaccount.yaml
@@ -1,0 +1,9 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: yardstick
+  namespace: toolhive-system
+spec:
+  template:
+    spec:
+      serviceAccountName: yardstick-custom-sa

--- a/test/e2e/chainsaw/operator/single-tenancy/test-scenarios/configmap-mode/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/operator/single-tenancy/test-scenarios/configmap-mode/chainsaw-test.yaml
@@ -62,6 +62,8 @@ spec:
         file: assert-mcpserver-pod-running.yaml
     - assert:
         file: assert-deployment-uses-volume-mounting.yaml
+    - assert:
+        file: assert-statefulset-serviceaccount.yaml
 
   - name: verify-configmap-functionality
     description: Verify ConfigMap is created with proper content and deployment works
@@ -208,12 +210,22 @@ spec:
               exit 1
             fi
 
+            # Validate serviceAccountName in pod patch
+            if echo "$POD_PATCH_ARG" | jq -e '.spec.serviceAccountName == "yardstick-custom-sa"' > /dev/null 2>&1; then
+              echo "✓ Pod patch contains correct serviceAccountName"
+            else
+              echo "✗ Pod patch missing or has incorrect serviceAccountName"
+              echo "Expected: yardstick-custom-sa"
+              echo "Actual: $(echo "$POD_PATCH_ARG" | jq -r '.spec.serviceAccountName // "not set"')"
+              exit 1
+            fi
+
           else
             echo "✗ No pod patch argument found"
             exit 1
           fi
 
-          echo "✅ ConfigMap mode functionality with secrets verified successfully!"
+          echo "✅ ConfigMap mode functionality with secrets and serviceAccount verified successfully!"
 
   - name: cleanup-configmap-mode
     description: Disable ConfigMap mode to avoid affecting subsequent tests

--- a/test/e2e/chainsaw/operator/single-tenancy/test-scenarios/configmap-mode/mcpserver.yaml
+++ b/test/e2e/chainsaw/operator/single-tenancy/test-scenarios/configmap-mode/mcpserver.yaml
@@ -1,3 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: yardstick-custom-sa
+  namespace: toolhive-system
+---
 apiVersion: toolhive.stacklok.dev/v1alpha1
 kind: MCPServer
 metadata:
@@ -7,6 +13,7 @@ spec:
   image: ghcr.io/stackloklabs/yardstick/yardstick-server:0.0.2
   transport: stdio
   port: 8080
+  serviceAccount: yardstick-custom-sa
   env:
   - name: TEST_ENV_VAR
     value: "configmap_test_value"


### PR DESCRIPTION
## Description

Fixes #2048

The `serviceAccount` field from MCPServer spec was not being included in the pod template patch when `TOOLHIVE_USE_CONFIGMAP` mode was enabled. This caused MCP server pods to use the default service account instead of the custom one specified in the MCPServer resource.

## Changes

- Add serviceAccount to pod template patch in ConfigMap mode
- Enhance existing unit test to verify serviceAccount propagation
- Add e2e test assertion for StatefulSet serviceAccountName
- Add serviceAccount field to configmap-mode test MCPServer

## Testing

- ✅ All unit tests pass
- ✅ Enhanced `TestDeploymentForMCPServerWithSecrets` to verify serviceAccount in pod template patch
- ✅ Added e2e chainsaw test assertion for StatefulSet serviceAccountName
- ✅ Linting passes

## Impact

The fix ensures that both ConfigMap and non-ConfigMap modes properly propagate the serviceAccount field to the underlying StatefulSet pods, allowing MCP servers to use custom service accounts with specific RBAC permissions.