### PR TITLE
Fix staticcheck SA5011 nil pointer dereference in retriever test

### DIFF
--- a/pkg/runner/retriever/retriever_test.go
+++ b/pkg/runner/retriever/retriever_test.go
@@ -33,11 +33,8 @@ func TestGetMCPServer_WithGroup(t *testing.T) {
 		}
 	}
 
-	if testGroupName == "" {
+	if testGroupName == "" || group == nil {
 		t.Skip("No groups found in registry, skipping group tests")
-	}
-	if group == nil {
-		t.Skip("Test group is nil, skipping")
 	}
 
 	// Find a server in the group to test with


### PR DESCRIPTION
This PR fixes the staticcheck linter errors that were blocking CI:

```
Error: pkg/runner/retriever/retriever_test.go:39:5: SA5011(related information): this check suggests that the pointer can be nil (staticcheck)
Error: pkg/runner/retriever/retriever_test.go:45:15: SA5011: possible nil pointer dereference (staticcheck)
```

## What was the problem?

The test had two separate if statements checking for nil conditions:
1. First checking if `testGroupName` is empty
2. Then checking if `group` is nil

Both checks call `t.Skip()` to exit the test early. However, the staticcheck linter couldn't understand that `t.Skip()` terminates execution, so it thought the code could continue and potentially dereference a nil `group` pointer later in the test.

## How did we fix it?

We combined both checks into a single if statement using the OR operator (`||`). This makes it crystal clear to the linter that if `group` is nil, the test will skip before any code tries to access `group.Servers`.

The test behavior is exactly the same - it still skips when there are no groups or when the group is nil. We just made the logic clearer for the static analyzer.

## Verification

- ✅ Staticcheck now passes with zero SA5011 errors
- ✅ The test still works correctly and skips appropriately
- ✅ No functional changes to the test logic