### PR TITLE
Fix authz behavior on `tools/list`

### DIFF
--- a/pkg/mcp/tool_middleware_test.go
+++ b/pkg/mcp/tool_middleware_test.go
@@ -1,13 +1,10 @@
 package mcp
 
 import (
-	"bufio"
 	"bytes"
 	"encoding/json"
-	"io"
+	"fmt"
 	"net/http"
-	"strings"
-	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -15,52 +12,6 @@ import (
 
 	"github.com/stacklok/toolhive/pkg/testkit"
 )
-
-// Helper function to make a tools list request
-func makeToolsListRequest(t *testing.T, url string) *toolsListResponse {
-	t.Helper()
-
-	req := map[string]any{
-		"jsonrpc": "2.0",
-		"id":      1,
-		"method":  "tools/list",
-	}
-
-	body, err := json.Marshal(req)
-	require.NoError(t, err)
-
-	resp, err := http.Post(url, "application/json", bytes.NewBuffer(body))
-	require.NoError(t, err)
-	defer resp.Body.Close()
-
-	var response toolsListResponse
-	err = json.NewDecoder(resp.Body).Decode(&response)
-	require.NoError(t, err)
-
-	return &response
-}
-
-// Helper function to make a tool call request
-func makeToolCallRequest(t *testing.T, url string, toolName string) (*http.Response, error) {
-	t.Helper()
-
-	req := toolCallRequest{
-		JSONRPC: "2.0",
-		ID:      1,
-		Method:  "tools/call",
-		Params: &map[string]any{
-			"name": toolName,
-			"arguments": map[string]any{
-				"arg1": "value1",
-			},
-		},
-	}
-
-	body, err := json.Marshal(req)
-	require.NoError(t, err)
-
-	return http.Post(url, "application/json", bytes.NewBuffer(body))
-}
 
 func TestNewListToolsMappingMiddleware_Scenarios(t *testing.T) {
 	t.Parallel()
@@ -186,15 +137,45 @@ func TestNewListToolsMappingMiddleware_Scenarios(t *testing.T) {
 
 			// Create test server
 			serverOpts := append(tt.serverOpts, testkit.WithMiddlewares(middlewares...))
-			server, err := testkit.NewStreamableTestServer(
+			serverOpts = append(serverOpts, testkit.WithJSONClientType())
+			server, client, err := testkit.NewStreamableTestServer(
 				serverOpts...,
 			)
 			require.NoError(t, err)
 			defer server.Close()
 
 			// Make request
-			response := makeToolsListRequest(t, server.URL+"/mcp-json")
-			assert.Equal(t, tt.expected, response.Result.Tools)
+			respBody, err := client.ToolsList()
+			require.NoError(t, err)
+
+			var response toolsListResponse
+			err = json.NewDecoder(bytes.NewReader(respBody)).Decode(&response)
+			require.NoError(t, err)
+			require.NotNil(t, response.Result)
+			require.NotNil(t, response.Result.Tools)
+
+			fmt.Println(response.Result.Tools)
+			fmt.Println(tt.expected)
+
+			if tt.expected != nil {
+				for _, expected := range *tt.expected {
+					found := false
+
+					for _, tool := range *response.Result.Tools {
+						// NOTE: here I switched from name to description because to ensure that redundant tool overrides
+						// are covered (i.e. two tools "Foo" and "Bar" exist, the User renames "Foo" into "Bar" or vice versa).
+						// I'm not sure we want to support this, but cannot prevent this from happening or prevent the
+						// User from doing it.
+						if tool["description"] == expected["description"] {
+							found = true
+							assert.Equal(t, expected["description"], tool["description"])
+							assert.Equal(t, expected["name"], tool["name"])
+						}
+					}
+
+					require.True(t, found, "Tool %s not found", expected["name"])
+				}
+			}
 		})
 	}
 }
@@ -383,28 +364,22 @@ func TestNewToolCallMappingMiddleware_Scenarios(t *testing.T) {
 
 			// Create test server
 			serverOpts := append(tt.serverOpts, testkit.WithMiddlewares(middlewares...))
-			server, err := testkit.NewStreamableTestServer(
+			serverOpts = append(serverOpts, testkit.WithJSONClientType())
+			server, client, err := testkit.NewStreamableTestServer(
 				serverOpts...,
 			)
 			require.NoError(t, err)
 			defer server.Close()
 
 			// Make request
-			resp, err := makeToolCallRequest(t, server.URL+"/mcp-json", tt.callToolName)
-			require.NoError(t, err)
-			defer resp.Body.Close()
-
-			assert.Equal(t, tt.expectedStatus, resp.StatusCode)
-
-			// Read response body
-			bodyBytes, err := io.ReadAll(resp.Body)
+			bodyBytes, err := client.ToolsCall(tt.callToolName)
 			require.NoError(t, err)
 
 			if tt.expected != nil {
 				var response map[string]any
 				err = json.Unmarshal(bodyBytes, &response)
 				require.NoError(t, err)
-				require.NotNil(t, response["result"])
+				require.NotNil(t, response["result"], "Result is nil: %+v", string(bodyBytes))
 
 				result, ok := response["result"].(map[string]any)
 				require.True(t, ok)
@@ -494,86 +469,27 @@ func TestNewListToolsMappingMiddleware_SSE_Scenarios(t *testing.T) {
 
 			// Create test server
 			serverOpts := append(tt.serverOpts, testkit.WithMiddlewares(middlewares...))
-			server, err := testkit.NewSSETestServer(
+			serverOpts = append(serverOpts, testkit.WithSSEClientType())
+			server, client, err := testkit.NewSSETestServer(
 				serverOpts...,
 			)
 			require.NoError(t, err)
 			defer server.Close()
 
-			var wg sync.WaitGroup
+			// Make request
+			respBody, err := client.ToolsList()
+			require.NoError(t, err)
 
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
+			var response toolsListResponse
+			err = json.Unmarshal(respBody, &response)
+			require.NoError(t, err)
 
-				// Make request
-				resp, err := http.Get(server.URL + "/sse")
-				require.NoError(t, err)
-				defer resp.Body.Close()
-				require.Equal(t, http.StatusOK, resp.StatusCode)
-				require.Equal(t, "text/event-stream", resp.Header.Get("Content-Type"))
-
-				// Read SSE response
-				if tt.expected != nil {
-					bodyBytes, err := io.ReadAll(resp.Body)
-					require.NoError(t, err)
-
-					// Parse SSE response
-					dataLine := sseParser(t, bodyBytes)
-					require.NotEmpty(t, dataLine, "No data line found in SSE response: '%+v'", bodyBytes)
-
-					// Parse JSON response
-					var response toolsListResponse
-					err = json.Unmarshal(dataLine, &response)
-					require.NoError(t, err)
-
-					// Verify results
-					assert.Equal(t, "2.0", response.JSONRPC)
-					assert.Equal(t, float64(1), response.ID)
-					assert.Equal(t, tt.expected, response.Result.Tools)
-				}
-			}()
-
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-
-				commandResp, err := http.Post(server.URL+"/command", "application/json", bytes.NewBufferString(`{"jsonrpc": "2.0", "id": 1, "method": "tools/list"}`))
-				require.NoError(t, err)
-				defer commandResp.Body.Close()
-
-				respBody, err := io.ReadAll(commandResp.Body)
-				require.NoError(t, err)
-				require.Equal(t, http.StatusAccepted, commandResp.StatusCode)
-				require.Equal(t, "Accepted", string(respBody))
-			}()
-
-			wg.Wait()
+			// Verify results
+			assert.Equal(t, "2.0", response.JSONRPC)
+			assert.Equal(t, float64(1), response.ID)
+			assert.Equal(t, tt.expected, response.Result.Tools)
 		})
 	}
-}
-
-// Note: we might want to move some variation of this to testkit.
-func sseParser(t *testing.T, body []byte) []byte {
-	t.Helper()
-
-	var result []byte
-
-	scanner := bufio.NewScanner(bytes.NewReader(body))
-	scanner.Split(testkit.NewSplitSSE(testkit.LFSep))
-	for scanner.Scan() {
-		require.NoError(t, scanner.Err())
-		for line := range strings.SplitSeq(scanner.Text(), "\n") {
-			dataLine, ok := strings.CutPrefix(line, "data:")
-			if !ok {
-				continue
-			}
-
-			result = []byte(dataLine)
-		}
-	}
-
-	return result
 }
 
 func TestNewListToolsMappingMiddleware_ErrorCases(t *testing.T) {

--- a/pkg/mcp/tool_middleware_test.go
+++ b/pkg/mcp/tool_middleware_test.go
@@ -3,7 +3,6 @@ package mcp
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"testing"
 
@@ -153,9 +152,6 @@ func TestNewListToolsMappingMiddleware_Scenarios(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, response.Result)
 			require.NotNil(t, response.Result.Tools)
-
-			fmt.Println(response.Result.Tools)
-			fmt.Println(tt.expected)
 
 			if tt.expected != nil {
 				for _, expected := range *tt.expected {

--- a/pkg/testkit/sse_server.go
+++ b/pkg/testkit/sse_server.go
@@ -134,12 +134,7 @@ func (s *sseEventStreamClient) ToolsCall(name string) ([]byte, error) {
 			}
 
 			if data, ok := bytes.CutPrefix(lineScanner.Bytes(), []byte("data:")); ok {
-				var result map[string]any
-				err := json.Unmarshal([]byte(data), &result)
-				if err != nil {
-					return nil, err
-				}
-				return []byte(data), nil
+				return data, nil
 			}
 		}
 	}

--- a/pkg/testkit/streamable_server.go
+++ b/pkg/testkit/streamable_server.go
@@ -16,7 +16,6 @@ import (
 
 const (
 	toolsListRequest = `{"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}}`
-	// toolsCallRequest = `{"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {"name": "test"}}`
 )
 
 // streamableServer provides a test server with /mcp-json and /mcp-sse endpoints
@@ -125,12 +124,7 @@ func (s *streamableEventStreamClient) ToolsList() ([]byte, error) {
 			}
 
 			if data, ok := bytes.CutPrefix(lineScanner.Bytes(), []byte("data:")); ok {
-				var result map[string]any
-				err := json.Unmarshal([]byte(data), &result)
-				if err != nil {
-					return nil, err
-				}
-				return []byte(data), nil
+				return data, nil
 			}
 		}
 	}

--- a/pkg/testkit/streamable_server.go
+++ b/pkg/testkit/streamable_server.go
@@ -1,7 +1,10 @@
 package testkit
 
 import (
+	"bufio"
+	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -11,11 +14,17 @@ import (
 	"github.com/go-chi/chi/v5/middleware"
 )
 
+const (
+	toolsListRequest = `{"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}}`
+	// toolsCallRequest = `{"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {"name": "test"}}`
+)
+
 // streamableServer provides a test server with /mcp-json and /mcp-sse endpoints
 type streamableServer struct {
 	middlewares       []func(http.Handler) http.Handler
 	toolsListResponse string
 	tools             map[string]tooldef
+	clientType        clientType
 }
 
 var _ TestMCPServer = (*streamableServer)(nil)
@@ -39,16 +48,144 @@ func (s *streamableServer) AddTool(tool tooldef) error {
 	return nil
 }
 
+func (s *streamableServer) SetClientType(clientType clientType) error {
+	if s.clientType != "" {
+		return fmt.Errorf("client type already set")
+	}
+	s.clientType = clientType
+	return nil
+}
+
+type streamableJSONClient struct {
+	server *httptest.Server
+}
+
+var _ TestMCPClient = (*streamableJSONClient)(nil)
+
+func (s *streamableJSONClient) ToolsList() ([]byte, error) {
+	client := s.server.Client()
+	resp, err := client.Post(s.server.URL+"/mcp-json", "application/json", bytes.NewBufferString(toolsListRequest))
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	return body, nil
+}
+
+func (s *streamableJSONClient) ToolsCall(name string) ([]byte, error) {
+	client := s.server.Client()
+
+	toolsCallRequest := fmt.Sprintf(`{"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {"name": "%s"}}`, name)
+	resp, err := client.Post(s.server.URL+"/mcp-json", "application/json", bytes.NewBufferString(toolsCallRequest))
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	return body, nil
+}
+
+type streamableEventStreamClient struct {
+	server *httptest.Server
+}
+
+var _ TestMCPClient = (*streamableEventStreamClient)(nil)
+
+func (s *streamableEventStreamClient) ToolsList() ([]byte, error) {
+	client := s.server.Client()
+	resp, err := client.Post(s.server.URL+"/mcp-sse", "application/json", bytes.NewBufferString(toolsListRequest))
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	scanner := bufio.NewScanner(resp.Body)
+	scanner.Split(NewSplitSSE(LFSep))
+
+	for scanner.Scan() {
+		if scanner.Err() != nil {
+			return nil, scanner.Err()
+		}
+
+		lineScanner := bufio.NewScanner(bytes.NewReader(scanner.Bytes()))
+		for lineScanner.Scan() {
+			if lineScanner.Err() != nil {
+				return nil, lineScanner.Err()
+			}
+
+			if data, ok := bytes.CutPrefix(lineScanner.Bytes(), []byte("data:")); ok {
+				var result map[string]any
+				err := json.Unmarshal([]byte(data), &result)
+				if err != nil {
+					return nil, err
+				}
+				return []byte(data), nil
+			}
+		}
+	}
+
+	return nil, errors.New("no data found")
+}
+
+func (s *streamableEventStreamClient) ToolsCall(name string) ([]byte, error) {
+	client := s.server.Client()
+
+	toolsCallRequest := fmt.Sprintf(`{"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {"name": "%s"}}`, name)
+	resp, err := client.Post(s.server.URL+"/mcp-sse", "application/json", bytes.NewBufferString(toolsCallRequest))
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	scanner := bufio.NewScanner(resp.Body)
+	scanner.Split(NewSplitSSE(LFSep))
+
+	for scanner.Scan() {
+		if scanner.Err() != nil {
+			return nil, scanner.Err()
+		}
+
+		lineScanner := bufio.NewScanner(bytes.NewReader(scanner.Bytes()))
+		for lineScanner.Scan() {
+			if lineScanner.Err() != nil {
+				return nil, lineScanner.Err()
+			}
+
+			if data, ok := bytes.CutPrefix(lineScanner.Bytes(), []byte("data:")); ok {
+				var result map[string]any
+				err := json.Unmarshal([]byte(data), &result)
+				if err != nil {
+					return nil, err
+				}
+				return []byte(data), nil
+			}
+		}
+	}
+
+	return nil, errors.New("no data found")
+}
+
 // NewStreamableTestServer creates a new Streamable-HTTP server,
 // wraps it in an `httptest.Server`, and returns it.
 func NewStreamableTestServer(
 	options ...TestMCPServerOption,
-) (*httptest.Server, error) {
+) (*httptest.Server, TestMCPClient, error) {
 	server := &streamableServer{}
 
 	for _, option := range options {
 		if err := option(server); err != nil {
-			return nil, fmt.Errorf("failed to apply option: %w", err)
+			return nil, nil, fmt.Errorf("failed to apply option: %w", err)
 		}
 	}
 
@@ -70,7 +207,22 @@ func NewStreamableTestServer(
 	router.Post("/mcp-json", server.mcpJSONHandler)
 	router.Post("/mcp-sse", server.mcpEventStreamHandler)
 
-	return httptest.NewServer(router), nil
+	httpServer := httptest.NewServer(router)
+
+	switch server.clientType {
+	case clientTypeJSON:
+		return httpServer, &streamableJSONClient{
+			server: httpServer,
+		}, nil
+	case clientTypeSSE:
+		return httpServer, &streamableEventStreamClient{
+			server: httpServer,
+		}, nil
+	default:
+		return httpServer, &streamableJSONClient{
+			server: httpServer,
+		}, nil
+	}
 }
 
 func (s *streamableServer) mcpJSONHandler(w http.ResponseWriter, r *http.Request) {

--- a/pkg/testkit/testkit_test.go
+++ b/pkg/testkit/testkit_test.go
@@ -4,19 +4,11 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/json"
-	"io"
-	"net/http"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-)
-
-const (
-	toolsListRequest = `{"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}}`
-	toolsCallRequest = `{"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {"name": "test"}}`
 )
 
 // TestSSEServerEndpoints tests a simple MCP server with three endpoints
@@ -25,81 +17,39 @@ func TestSSEServerEndpoints(t *testing.T) {
 
 	opts := []TestMCPServerOption{
 		WithTool("test", "A test tool", func() string { return "Tool call executed successfully" }),
+		WithSSEClientType(),
 	}
 
 	t.Run("sse text/event-stream tools/list", func(t *testing.T) {
 		t.Parallel()
 
 		// Create SSE server for /command and /sse endpoints
-		server, err := NewSSETestServer(opts...)
+		server, client, err := NewSSETestServer(opts...)
 		require.NoError(t, err)
 		defer server.Close()
 
-		// Channel to receive SSE response
-		sseResponseChan := make(chan string, 1)
-
-		// Start SSE connection in a goroutine
-		go func() {
-			t.Helper()
-			defer close(sseResponseChan)
-
-			resp, err := http.Get(server.URL + "/sse")
-			require.NoError(t, err)
-			defer resp.Body.Close()
-
-			require.Equal(t, http.StatusOK, resp.StatusCode)
-			require.Equal(t, "text/event-stream", resp.Header.Get("Content-Type"))
-
-			scanner := bufio.NewScanner(resp.Body)
-			scanner.Split(NewSplitSSE(LFSep))
-
-			for scanner.Scan() {
-				require.NoError(t, scanner.Err())
-				event := scanner.Text()
-				sseResponseChan <- event
-			}
-		}()
-
-		// Give the SSE goroutine a moment to start
-		time.Sleep(10 * time.Millisecond)
-
-		// Now send a command to /command endpoint
-		commandResp, err := http.Post(server.URL+"/command", "application/json", bytes.NewBufferString(toolsListRequest))
+		sseBody, err := client.ToolsList()
 		require.NoError(t, err)
-		defer commandResp.Body.Close()
+		scanner := bufio.NewScanner(bytes.NewReader([]byte(sseBody)))
 
-		assert.Equal(t, http.StatusAccepted, commandResp.StatusCode)
+		for scanner.Scan() {
+			require.NoError(t, scanner.Err())
 
-		commandBody, err := io.ReadAll(commandResp.Body)
-		require.NoError(t, err)
-		assert.Equal(t, "Accepted", string(commandBody))
+			// Check that the SSE response contains the tools/list response
+			data, ok := strings.CutPrefix(scanner.Text(), "data:")
+			if ok {
+				var result map[string]any
+				err = json.Unmarshal([]byte(data), &result)
+				require.NoError(t, err)
+				assert.Equal(t, "2.0", result["jsonrpc"])
+				assert.Equal(t, float64(1), result["id"])
 
-		// Wait for SSE response
-		select {
-		case sseBody := <-sseResponseChan:
-			scanner := bufio.NewScanner(bytes.NewReader([]byte(sseBody)))
-
-			for scanner.Scan() {
-				require.NoError(t, scanner.Err())
-
-				// Check that the SSE response contains the tools/list response
-				data, ok := strings.CutPrefix(scanner.Text(), "data:")
-				if ok {
-					var result map[string]any
-					err = json.Unmarshal([]byte(data), &result)
-					require.NoError(t, err)
-					assert.Equal(t, "2.0", result["jsonrpc"])
-					assert.Equal(t, float64(1), result["id"])
-
-					// Check that it's a tools/list response
-					toolCall, ok := result["result"].(map[string]any)
-					require.True(t, ok, "Result should contain result array")
-					assert.Len(t, toolCall["tools"], 1, "Should have one tool")
-					return
-				}
+				// Check that it's a tools/list response
+				toolCall, ok := result["result"].(map[string]any)
+				require.True(t, ok, "Result should contain result array")
+				assert.Len(t, toolCall["tools"], 1, "Should have one tool")
+				return
 			}
-		case <-time.After(1 * time.Second):
-			t.Fatal("Timeout waiting for SSE response")
 		}
 	})
 
@@ -107,79 +57,26 @@ func TestSSEServerEndpoints(t *testing.T) {
 		t.Parallel()
 
 		// Create SSE server for /command and /sse endpoints
-		server, err := NewSSETestServer(opts...)
+		server, client, err := NewSSETestServer(opts...)
 		require.NoError(t, err)
 		defer server.Close()
 
-		// Channel to receive SSE response
-		sseResponseChan := make(chan string, 1)
-
-		// Start SSE connection in a goroutine
-		go func() {
-			t.Helper()
-			defer close(sseResponseChan)
-
-			resp, err := http.Get(server.URL + "/sse")
-			require.NoError(t, err)
-			defer resp.Body.Close()
-
-			require.Equal(t, http.StatusOK, resp.StatusCode)
-			require.Equal(t, "text/event-stream", resp.Header.Get("Content-Type"))
-
-			scanner := bufio.NewScanner(resp.Body)
-			scanner.Split(NewSplitSSE(LFSep))
-
-			for scanner.Scan() {
-				require.NoError(t, scanner.Err())
-				event := scanner.Text()
-				sseResponseChan <- event
-			}
-		}()
-
-		// Give the SSE goroutine a moment to start
-		time.Sleep(10 * time.Millisecond)
-
-		// Now send a command to /command endpoint
-		commandResp, err := http.Post(server.URL+"/command", "application/json", bytes.NewBufferString(toolsCallRequest))
+		data, err := client.ToolsCall("test")
 		require.NoError(t, err)
-		defer commandResp.Body.Close()
 
-		assert.Equal(t, http.StatusAccepted, commandResp.StatusCode)
-
-		commandBody, err := io.ReadAll(commandResp.Body)
+		var result map[string]any
+		err = json.Unmarshal([]byte(data), &result)
 		require.NoError(t, err)
-		assert.Equal(t, "Accepted", string(commandBody))
+		assert.Equal(t, "2.0", result["jsonrpc"])
+		assert.Equal(t, float64(1), result["id"])
 
-		// Wait for SSE response
-		select {
-		case sseBody := <-sseResponseChan:
-			scanner := bufio.NewScanner(bytes.NewReader([]byte(sseBody)))
+		// Check that it's a tools/call response
+		resultData, ok := result["result"].(map[string]any)
+		require.True(t, ok, "Result should contain a result object")
 
-			for scanner.Scan() {
-				require.NoError(t, scanner.Err())
-
-				// Check that the SSE response contains the tools/call response
-				data, ok := strings.CutPrefix(scanner.Text(), "data:")
-				if ok {
-					var result map[string]any
-					err = json.Unmarshal([]byte(data), &result)
-					require.NoError(t, err)
-					assert.Equal(t, "2.0", result["jsonrpc"])
-					assert.Equal(t, float64(1), result["id"])
-
-					// Check that it's a tools/call response
-					resultData, ok := result["result"].(map[string]any)
-					require.True(t, ok, "Result should contain a result object")
-
-					toolCall, ok := resultData["content"].([]any)
-					require.True(t, ok, "Result should contain content array")
-					assert.Len(t, toolCall, 1, "Should have one result")
-					return
-				}
-			}
-		case <-time.After(1 * time.Second):
-			t.Fatal("Timeout waiting for SSE response")
-		}
+		toolCall, ok := resultData["content"].([]any)
+		require.True(t, ok, "Result should contain content array")
+		assert.Len(t, toolCall, 1, "Should have one result")
 	})
 }
 
@@ -193,19 +90,14 @@ func TestStreamableServerEndpoints(t *testing.T) {
 	t.Run("streamable application/json tools/list", func(t *testing.T) {
 		t.Parallel()
 
-		// Create streamable server for /mcp-json and /mcp-sse endpoints
-		server, err := NewStreamableTestServer(opts...)
+		opts := append(opts, WithJSONClientType())
+		server, client, err := NewStreamableTestServer(opts...)
 		require.NoError(t, err)
 		defer server.Close()
 
-		resp, err := http.Post(server.URL+"/mcp-json", "application/json", bytes.NewBufferString(toolsListRequest))
-		require.NoError(t, err)
-		defer resp.Body.Close()
+		require.IsType(t, &streamableJSONClient{}, client)
 
-		assert.Equal(t, http.StatusOK, resp.StatusCode)
-		assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
-
-		body, err := io.ReadAll(resp.Body)
+		body, err := client.ToolsList()
 		require.NoError(t, err)
 
 		var result map[string]any
@@ -226,64 +118,42 @@ func TestStreamableServerEndpoints(t *testing.T) {
 	t.Run("streamable text/event-stream tools/list", func(t *testing.T) {
 		t.Parallel()
 
-		// Create streamable server for /mcp-json and /mcp-sse endpoints
-		server, err := NewStreamableTestServer(opts...)
+		opts := append(opts, WithSSEClientType())
+		server, client, err := NewStreamableTestServer(opts...)
 		require.NoError(t, err)
 		defer server.Close()
 
-		resp, err := http.Post(server.URL+"/mcp-sse", "application/json", bytes.NewBufferString(toolsListRequest))
+		require.IsType(t, &streamableEventStreamClient{}, client)
+
+		body, err := client.ToolsList()
 		require.NoError(t, err)
-		defer resp.Body.Close()
 
-		assert.Equal(t, http.StatusOK, resp.StatusCode)
-		assert.Equal(t, "text/event-stream", resp.Header.Get("Content-Type"))
+		var result map[string]any
+		err = json.Unmarshal(body, &result)
+		require.NoError(t, err)
+		assert.Equal(t, "2.0", result["jsonrpc"])
+		assert.Equal(t, float64(1), result["id"])
 
-		scanner := bufio.NewScanner(resp.Body)
-		scanner.Split(NewSplitSSE(LFSep))
+		// Check that it's a tools/list response
+		resultData, ok := result["result"].(map[string]any)
+		require.True(t, ok, "Result should contain a result object")
 
-		for scanner.Scan() {
-			require.NoError(t, scanner.Err())
-
-			lineScanner := bufio.NewScanner(bytes.NewReader([]byte(scanner.Text())))
-			for lineScanner.Scan() {
-				require.NoError(t, lineScanner.Err())
-
-				if data, ok := strings.CutPrefix(lineScanner.Text(), "data:"); ok {
-					var result map[string]any
-					err = json.Unmarshal([]byte(data), &result)
-					require.NoError(t, err)
-					assert.Equal(t, "2.0", result["jsonrpc"])
-					assert.Equal(t, float64(1), result["id"])
-
-					// Check that it's a tools/list response
-					resultData, ok := result["result"].(map[string]any)
-					require.True(t, ok, "Result should contain a result object")
-
-					tools, ok := resultData["tools"].([]any)
-					require.True(t, ok, "Result should contain tools array")
-					assert.Len(t, tools, 1, "Should have one tool")
-					return
-				}
-			}
-		}
+		tools, ok := resultData["tools"].([]any)
+		require.True(t, ok, "Result should contain tools array")
+		assert.Len(t, tools, 1, "Should have one tool")
 	})
 
 	t.Run("streamable application/json tools/call", func(t *testing.T) {
 		t.Parallel()
 
-		// Create streamable server for /mcp-json and /mcp-sse endpoints
-		server, err := NewStreamableTestServer(opts...)
+		opts := append(opts, WithJSONClientType())
+		server, client, err := NewStreamableTestServer(opts...)
 		require.NoError(t, err)
 		defer server.Close()
 
-		resp, err := http.Post(server.URL+"/mcp-json", "application/json", bytes.NewBufferString(toolsCallRequest))
-		require.NoError(t, err)
-		defer resp.Body.Close()
+		require.IsType(t, &streamableJSONClient{}, client)
 
-		assert.Equal(t, http.StatusOK, resp.StatusCode)
-		assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
-
-		body, err := io.ReadAll(resp.Body)
+		body, err := client.ToolsCall("test")
 		require.NoError(t, err)
 
 		var result map[string]any
@@ -304,45 +174,28 @@ func TestStreamableServerEndpoints(t *testing.T) {
 	t.Run("streamable text/event-stream tools/call", func(t *testing.T) {
 		t.Parallel()
 
-		// Create streamable server for /mcp-json and /mcp-sse endpoints
-		server, err := NewStreamableTestServer(opts...)
+		opts := append(opts, WithSSEClientType())
+		server, client, err := NewStreamableTestServer(opts...)
 		require.NoError(t, err)
 		defer server.Close()
 
-		resp, err := http.Post(server.URL+"/mcp-sse", "application/json", bytes.NewBufferString(toolsCallRequest))
+		require.IsType(t, &streamableEventStreamClient{}, client)
+
+		body, err := client.ToolsCall("test")
 		require.NoError(t, err)
-		defer resp.Body.Close()
 
-		assert.Equal(t, http.StatusOK, resp.StatusCode)
-		assert.Equal(t, "text/event-stream", resp.Header.Get("Content-Type"))
+		var result map[string]any
+		err = json.Unmarshal(body, &result)
+		require.NoError(t, err)
+		assert.Equal(t, "2.0", result["jsonrpc"])
+		assert.Equal(t, float64(1), result["id"])
 
-		scanner := bufio.NewScanner(resp.Body)
-		scanner.Split(NewSplitSSE(LFSep))
+		// Check that it's a tools/call response
+		resultData, ok := result["result"].(map[string]any)
+		require.True(t, ok, "Result should contain a result object")
 
-		for scanner.Scan() {
-			require.NoError(t, scanner.Err())
-
-			lineScanner := bufio.NewScanner(bytes.NewReader([]byte(scanner.Text())))
-			for lineScanner.Scan() {
-				require.NoError(t, lineScanner.Err())
-
-				if data, ok := strings.CutPrefix(lineScanner.Text(), "data:"); ok {
-					var result map[string]any
-					err = json.Unmarshal([]byte(data), &result)
-					require.NoError(t, err)
-					assert.Equal(t, "2.0", result["jsonrpc"])
-					assert.Equal(t, float64(1), result["id"])
-
-					// Check that it's a tools/call response
-					resultData, ok := result["result"].(map[string]any)
-					require.True(t, ok, "Result should contain a result object")
-
-					toolCall, ok := resultData["content"].([]any)
-					require.True(t, ok, "Result should contain content array")
-					assert.Len(t, toolCall, 1, "Should have one result")
-					return
-				}
-			}
-		}
+		toolCall, ok := resultData["content"].([]any)
+		require.True(t, ok, "Result should contain content array")
+		assert.Len(t, toolCall, 1, "Should have one result")
 	})
 }


### PR DESCRIPTION
This is a follow up of #1189 specifically targeted to SSE streams from different request, i.e. handling of the SSE transport.

This doesn't modify or add any conde under `pkg/authz`, but does add a test pinning the current behavior.

In order to write the test more easily, I added clients to `pkg/testkit` so that when a specific test server is initialized, a pre-configured client exposing `ToolsList()` and `ToolsCall()` routines is returned along.

The returned client masks any transport specific behavior so that developers writing new tests don't have to bother anymore handling SSE streams, goroutines, or channel closure anymore.

Fixes #1188