### PR TITLE
Update the Claude Code action to v1

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -11,7 +11,7 @@ on:
     types: [submitted]
 
 jobs:
-  claude-code-action:
+  claude:
     name: Claude Code Action
     if: |
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
@@ -19,31 +19,21 @@ jobs:
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && contains(github.event.issue.body, '@claude'))
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
       pull-requests: read
       issues: read
       id-token: write
+      actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
         with:
           fetch-depth: 1
 
-      - name: Run Claude PR Action
-        uses: anthropics/claude-code-action@beta
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@426380f01bad0a17200865605a85cb28926dccbf # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          # Or use OAuth token instead:
-          # claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          timeout_minutes: "20"
-          # mode: tag  # Default: responds to @claude mentions
-          # Optional: Restrict network access to specific domains only
-          # experimental_allowed_domains: |
-          #   .anthropic.com
-          #   .github.com
-          #   api.github.com
-          #   .githubusercontent.com
-          #   bun.sh
-          #   registry.npmjs.org
-          #   .blob.core.windows.net


### PR DESCRIPTION
Now that the Claude Code action has [reached v1](https://github.com/anthropics/claude-code-action/releases/tag/v1), Anthropic has stopped bumping the `beta` tag.

Updating per the [migration guide](https://github.com/anthropics/claude-code-action/blob/main/docs/migration-guide.md) and the [example](https://github.com/anthropics/claude-code-action/blob/main/examples/claude.yml).

Signed-off-by: Dan Barr <6922515+danbarr@users.noreply.github.com>