### PR TITLE
Change Renovate commit messages

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
-    "helpers:pinGitHubActionDigests"
+    "helpers:pinGitHubActionDigests",
+    ":semanticCommitsDisabled"
   ],
   "labels": ["dependencies"],
   "packageRules": [


### PR DESCRIPTION
This configuration change gets rid of `chore(deps):` prefix used by Renovate in its PRs. This should make it adhere to our commit message guidelines.