### PR TITLE
Handle scope field as string or array in DynamicClientRegistrationResponse

### DIFF
--- a/pkg/auth/oauth/dynamic_registration.go
+++ b/pkg/auth/oauth/dynamic_registration.go
@@ -57,35 +57,53 @@ func NewDynamicClientRegistrationRequest(scopes []string, callbackPort int) *Dyn
 	return registrationRequest
 }
 
+// ScopeList represents the "scope" field in a dynamic client registration response.
+// Some servers return this as a space-delimited string per RFC 7591, while others
+// return it as a JSON array of strings. This type normalizes both into a []string.
+//
+// Examples of supported inputs:
+//
+//	"openid profile email"        → []string{"openid", "profile", "email"}
+//	["openid","profile","email"]  → []string{"openid", "profile", "email"}
+//	null                          → nil
+//	"" or ["", "  "]              → nil
 type ScopeList []string
 
+// UnmarshalJSON implements custom decoding for ScopeList. It supports both
+// string and array encodings of the "scope" field, trimming whitespace and
+// normalizing empty values to nil for consistent semantics.
 func (s *ScopeList) UnmarshalJSON(data []byte) error {
 	// Handle explicit null
-	if string(data) == "null" {
+	if strings.TrimSpace(string(data)) == "null" {
 		*s = nil
 		return nil
 	}
 
-	// Try to decode as string first: "openid profile email"
+	// Case 1: space-delimited string
 	var str string
 	if err := json.Unmarshal(data, &str); err == nil {
-		str = strings.TrimSpace(str)
-		if str == "" {
+		if strings.TrimSpace(str) == "" {
 			*s = nil
 			return nil
 		}
-		*s = strings.Fields(str) // split by spaces
+		*s = strings.Fields(str)
 		return nil
 	}
 
-	// Try to decode as []string: ["openid","profile","email"]
+	// Case 2: JSON array
 	var arr []string
 	if err := json.Unmarshal(data, &arr); err == nil {
-		*s = make([]string, 0, len(arr))
+		cleaned := make([]string, 0, len(arr))
 		for _, v := range arr {
 			if v = strings.TrimSpace(v); v != "" {
-				*s = append(*s, v)
+				cleaned = append(cleaned, v)
 			}
+		}
+		// Normalize: treat all-empty/whitespace arrays the same as ""
+		if len(cleaned) == 0 {
+			*s = nil
+		} else {
+			*s = cleaned
 		}
 		return nil
 	}

--- a/pkg/auth/oauth/dynamic_registration_test.go
+++ b/pkg/auth/oauth/dynamic_registration_test.go
@@ -368,6 +368,7 @@ func TestDynamicClientRegistrationResponse_Validation(t *testing.T) {
 
 // TestScopeList_UnmarshalJSON tests that the ScopeList unmarshaling works correctly
 func TestScopeList_UnmarshalJSON(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		jsonIn  string
@@ -424,6 +425,7 @@ func TestScopeList_UnmarshalJSON(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			var s ScopeList
 			err := json.Unmarshal([]byte(tt.jsonIn), &s)
 

--- a/pkg/auth/oauth/dynamic_registration_test.go
+++ b/pkg/auth/oauth/dynamic_registration_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"reflect"
 	"strings"
 	"testing"
 
@@ -366,14 +365,14 @@ func TestDynamicClientRegistrationResponse_Validation(t *testing.T) {
 
 // TestIsLocalhost is already defined in oidc_test.go
 
-// TestScopeList_UnmarshalJSON tests that the ScopeList unmarshaling works correctly
+// TestScopeList_UnmarshalJSON tests that the ScopeList unmarshaling works correctly.
 func TestScopeList_UnmarshalJSON(t *testing.T) {
 	t.Parallel()
+
 	tests := []struct {
 		name    string
 		jsonIn  string
 		want    []string
-		wantNil bool
 		wantErr bool
 	}{
 		{
@@ -382,9 +381,9 @@ func TestScopeList_UnmarshalJSON(t *testing.T) {
 			want:   []string{"openid", "profile", "email"},
 		},
 		{
-			name:    "empty string => nil",
-			jsonIn:  `""`,
-			wantNil: true,
+			name:   "empty string => nil",
+			jsonIn: `""`,
+			want:   nil,
 		},
 		{
 			name:   "string with extra spaces",
@@ -402,14 +401,14 @@ func TestScopeList_UnmarshalJSON(t *testing.T) {
 			want:   []string{"openid", "profile"},
 		},
 		{
-			name:    "all-empty array => nil",
-			jsonIn:  `["","  "]`,
-			wantNil: true,
+			name:   "all-empty array => nil",
+			jsonIn: `["","  "]`,
+			want:   nil,
 		},
 		{
-			name:    "explicit null => nil",
-			jsonIn:  `null`,
-			wantNil: true,
+			name:   "explicit null => nil",
+			jsonIn: `null`,
+			want:   nil,
 		},
 		{
 			name:    "invalid type (number)",
@@ -424,31 +423,20 @@ func TestScopeList_UnmarshalJSON(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt // capture loop variable
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+
 			var s ScopeList
 			err := json.Unmarshal([]byte(tt.jsonIn), &s)
 
 			if tt.wantErr {
-				if err == nil {
-					t.Fatalf("expected error but got none (value: %v)", s)
-				}
-				return
-			}
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-
-			if tt.wantNil {
-				if s != nil {
-					t.Fatalf("expected nil, got %v", []string(s))
-				}
+				assert.Error(t, err, "expected error but got none")
 				return
 			}
 
-			if !reflect.DeepEqual([]string(s), tt.want) {
-				t.Fatalf("got %v, want %v", []string(s), tt.want)
-			}
+			assert.NoError(t, err, "unexpected unmarshal error")
+			assert.Equal(t, tt.want, []string(s))
 		})
 	}
 }


### PR DESCRIPTION
Some authorization servers return the `scope` field as a space-delimited
string (per RFC 7591), while others return it as a JSON array of strings.
This caused decoding errors when the format didn’t match expectations.

This change introduces a custom `ScopeList` type with a flexible
UnmarshalJSON implementation that correctly handles:
- space-delimited strings (e.g. "openid profile email")
- JSON arrays (e.g. ["openid","profile","email"])
- explicit null values
- empty string values

This ensures consistent behavior and provides a unified []string
representation in Go, regardless of how the server encodes scopes.