### PR TITLE
Reduce example Grafana dashboard uid lengths

### DIFF
--- a/examples/otel/grafana-dashboards/toolhive-mcp-grafana-dashboard-otel-remotewrite.json
+++ b/examples/otel/grafana-dashboards/toolhive-mcp-grafana-dashboard-otel-remotewrite.json
@@ -791,6 +791,6 @@
   "timepicker": {},
   "timezone": "",
   "title": "ToolHive MCP Server & Proxy Runner Dashboard - OTEL RemoteWrite to Prometheus (with kubestats)",
-  "uid": "toolhive-mcp-grafana-dashboard-otel-remotewrite",
+  "uid": "toolhive-mcp-otel-remotewrite",
   "version": 3
 }

--- a/examples/otel/grafana-dashboards/toolhive-mcp-grafana-dashboard-otel-scrape.json
+++ b/examples/otel/grafana-dashboards/toolhive-mcp-grafana-dashboard-otel-scrape.json
@@ -791,6 +791,6 @@
   "timepicker": {},
   "timezone": "",
   "title": "ToolHive MCP Server & Proxy Runner Dashboard - Scrape from OTEL (with kubestats)",
-  "uid": "toolhive-mcp-grafana-dashboard-otel-scrape",
+  "uid": "toolhive-mcp-otel-scrape",
   "version": 9
 }


### PR DESCRIPTION
The Grafana dashboard uid field has a max length of 40 characters. This PR reduces the length in the example dashboards so users don't have to fix it themselves when following the blog post / tutorial.

Signed-off-by: Dan Barr <6922515+danbarr@users.noreply.github.com>