### PR TITLE
Always use `thv run` in example command

### DIFF
--- a/cmd/thv/app/registry.go
+++ b/cmd/thv/app/registry.go
@@ -318,11 +318,7 @@ func printTextServerInfo(name string, server registry.ServerMetadata) {
 
 	// Print example command
 	fmt.Println("\nExample Command:")
-	if server.IsRemote() {
-		fmt.Printf("  thv proxy %s\n", name)
-	} else {
-		fmt.Printf("  thv run %s\n", name)
-	}
+	fmt.Printf("  thv run %s\n", name)
 }
 
 // truncateString truncates a string to the specified length and adds "..." if truncated


### PR DESCRIPTION
Fixes the `thv registry info` output to always use `thv run` instead of `thv proxy` for remote MCPs.

Signed-off-by: Dan Barr <6922515+danbarr@users.noreply.github.com>