### PR TITLE
Fix already used OAuth callback port handling to prevent "Invalid redirect URI" errors

### DIFF
--- a/pkg/auth/discovery/discovery.go
+++ b/pkg/auth/discovery/discovery.go
@@ -395,6 +395,30 @@ func PerformOAuthFlow(ctx context.Context, issuer string, config *OAuthFlowConfi
 		return nil, fmt.Errorf("OAuth flow config cannot be nil")
 	}
 
+	// Resolve port availability BEFORE dynamic registration
+	// This ensures we register the OAuth client with the same port we'll actually use
+
+	if shouldDynamicallyRegisterClient(config) {
+		// For dynamic registration, we can allow fallback to alternative ports
+		// since we can register the client with the actual port we'll use
+		port, err := networking.FindOrUsePort(config.CallbackPort)
+		if err != nil {
+			return nil, fmt.Errorf("failed to find available port: %w", err)
+		}
+
+		if port != config.CallbackPort {
+			logger.Warnf("Specified auth callback port %d is unavailable, using port %d instead", config.CallbackPort, port)
+		}
+		config.CallbackPort = port
+	} else {
+		// For pre-registered clients, use strict port checking
+		// The user likely configured this port in their IdP/app
+		if !networking.IsAvailable(config.CallbackPort) {
+			return nil, fmt.Errorf(`specified auth callback port %d is not available
+			- please choose a different port or ensure it's not in use`, config.CallbackPort)
+		}
+	}
+
 	// Handle dynamic client registration if needed
 	if shouldDynamicallyRegisterClient(config) {
 		if err := handleDynamicRegistration(ctx, issuer, config); err != nil {

--- a/pkg/auth/discovery/discovery_test.go
+++ b/pkg/auth/discovery/discovery_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/stacklok/toolhive/pkg/logger"
+	"github.com/stacklok/toolhive/pkg/networking"
 )
 
 func init() {
@@ -430,111 +431,206 @@ func TestDeriveIssuerFromURL(t *testing.T) {
 func TestPerformOAuthFlow_PortBehavior(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct {
-		name               string
-		config             *OAuthFlowConfig
-		expectError        bool
-		errorContains      string
-		expectPortFallback bool
-	}{
-		{
-			name: "dynamic registration with available port",
-			config: &OAuthFlowConfig{
-				ClientID:     "", // No client ID triggers dynamic registration
-				ClientSecret: "",
-				CallbackPort: 0, // Use 0 to find an available port
-				Scopes:       []string{"openid"},
-			},
-			expectError: false,
-		},
-		{
-			name: "dynamic registration with unavailable port - should fallback",
-			config: &OAuthFlowConfig{
-				ClientID:     "", // No client ID triggers dynamic registration
-				ClientSecret: "",
-				CallbackPort: 80, // Port 80 is likely in use
-				Scopes:       []string{"openid"},
-			},
-			expectError:        false,
-			expectPortFallback: true,
-		},
-		{
-			name: "pre-registered client with available port",
-			config: &OAuthFlowConfig{
-				ClientID:     "test-client",
-				ClientSecret: "test-secret",
-				CallbackPort: 0, // Use 0 to find an available port
-				Scopes:       []string{"openid"},
-			},
-			expectError: false,
-		},
-		{
-			name: "pre-registered client with unavailable port - should fail",
-			config: &OAuthFlowConfig{
-				ClientID:     "test-client",
-				ClientSecret: "test-secret",
-				CallbackPort: 80, // Port 80 is likely in use
-				Scopes:       []string{"openid"},
-			},
-			expectError:   true,
-			errorContains: "not available",
-		},
-	}
+	// Test dynamic registration with available port
+	t.Run("dynamic registration with available port", func(t *testing.T) {
+		t.Parallel()
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
+		config := &OAuthFlowConfig{
+			ClientID:     "", // No client ID triggers dynamic registration
+			ClientSecret: "",
+			CallbackPort: 0, // Use 0 to find an available port
+			Scopes:       []string{"openid"},
+		}
 
-			// Create a mock OIDC discovery server
-			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if strings.HasSuffix(r.URL.Path, "/.well-known/openid_configuration") {
-					// Return OIDC discovery document
-					w.Header().Set("Content-Type", "application/json")
-					w.WriteHeader(http.StatusOK)
-					w.Write([]byte(`{
-						"issuer": "https://example.com",
-						"authorization_endpoint": "https://example.com/auth",
-						"token_endpoint": "https://example.com/token",
-						"registration_endpoint": "https://example.com/register"
-					}`))
-					return
-				}
-				if strings.HasSuffix(r.URL.Path, "/register") {
-					// Return dynamic registration response
-					w.Header().Set("Content-Type", "application/json")
-					w.WriteHeader(http.StatusCreated)
-					w.Write([]byte(`{
-						"client_id": "dynamic-client-id",
-						"client_secret": "dynamic-client-secret"
-					}`))
-					return
-				}
-				w.WriteHeader(http.StatusNotFound)
-			}))
-			defer server.Close()
-
-			ctx := context.Background()
-			result, err := PerformOAuthFlow(ctx, server.URL, tt.config)
-
-			if tt.expectError {
-				require.Error(t, err)
-				if tt.errorContains != "" {
-					assert.Contains(t, err.Error(), tt.errorContains)
-				}
-				assert.Nil(t, result)
-			} else {
-				// For successful cases, we expect the OAuth flow to fail later
-				// (since we're not actually completing the full flow), but the
-				// port resolution should work correctly
-				if err != nil {
-					// Check if it's a port-related error (which we don't want)
-					if strings.Contains(err.Error(), "not available") && !tt.expectPortFallback {
-						t.Errorf("Unexpected port availability error: %v", err)
-					}
-				}
+		// Create a mock OIDC discovery server
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if strings.HasSuffix(r.URL.Path, "/.well-known/openid_configuration") {
+				// Return OIDC discovery document
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte(`{
+					"issuer": "https://example.com",
+					"authorization_endpoint": "https://example.com/auth",
+					"token_endpoint": "https://example.com/token",
+					"registration_endpoint": "https://example.com/register"
+				}`))
+				return
 			}
-		})
-	}
+			if strings.HasSuffix(r.URL.Path, "/register") {
+				// Return dynamic registration response
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusCreated)
+				w.Write([]byte(`{
+					"client_id": "dynamic-client-id",
+					"client_secret": "dynamic-client-secret"
+				}`))
+				return
+			}
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		defer server.Close()
+
+		ctx := context.Background()
+		_, err := PerformOAuthFlow(ctx, server.URL, config)
+
+		// For successful cases, we expect the OAuth flow to fail later
+		// (since we're not actually completing the full flow), but the
+		// port resolution should work correctly
+		if err != nil {
+			// Check if it's a port-related error (which we don't want)
+			if strings.Contains(err.Error(), "not available") {
+				t.Errorf("Unexpected port availability error: %v", err)
+			}
+		}
+	})
+
+	// Test dynamic registration with unavailable port - should fallback
+	t.Run("dynamic registration with unavailable port - should fallback", func(t *testing.T) {
+		t.Parallel()
+
+		// Create a listener to make a port unavailable
+		listener, err := net.Listen("tcp", "127.0.0.1:0")
+		require.NoError(t, err)
+		defer listener.Close()
+		unavailablePort := listener.Addr().(*net.TCPAddr).Port
+
+		config := &OAuthFlowConfig{
+			ClientID:     "", // No client ID triggers dynamic registration
+			ClientSecret: "",
+			CallbackPort: unavailablePort, // Use the unavailable port
+			Scopes:       []string{"openid"},
+		}
+
+		// Create a mock OIDC discovery server
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if strings.HasSuffix(r.URL.Path, "/.well-known/openid_configuration") {
+				// Return OIDC discovery document
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte(`{
+					"issuer": "https://example.com",
+					"authorization_endpoint": "https://example.com/auth",
+					"token_endpoint": "https://example.com/token",
+					"registration_endpoint": "https://example.com/register"
+				}`))
+				return
+			}
+			if strings.HasSuffix(r.URL.Path, "/register") {
+				// Return dynamic registration response
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusCreated)
+				w.Write([]byte(`{
+					"client_id": "dynamic-client-id",
+					"client_secret": "dynamic-client-secret"
+				}`))
+				return
+			}
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		defer server.Close()
+
+		ctx := context.Background()
+		_, err = PerformOAuthFlow(ctx, server.URL, config)
+
+		// Should not fail due to port unavailability (should fallback)
+		if err != nil {
+			// Check if it's a port-related error (which we don't want for dynamic registration)
+			if strings.Contains(err.Error(), "not available") {
+				t.Errorf("Dynamic registration should allow port fallback, but got port error: %v", err)
+			}
+		}
+	})
+
+	// Test pre-registered client with available port
+	t.Run("pre-registered client with available port", func(t *testing.T) {
+		t.Parallel()
+
+		config := &OAuthFlowConfig{
+			ClientID:     "test-client",
+			ClientSecret: "test-secret",
+			CallbackPort: 0, // Use 0 to find an available port
+			Scopes:       []string{"openid"},
+		}
+
+		// Create a mock OIDC discovery server
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if strings.HasSuffix(r.URL.Path, "/.well-known/openid_configuration") {
+				// Return OIDC discovery document
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte(`{
+					"issuer": "https://example.com",
+					"authorization_endpoint": "https://example.com/auth",
+					"token_endpoint": "https://example.com/token",
+					"registration_endpoint": "https://example.com/register"
+				}`))
+				return
+			}
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		defer server.Close()
+
+		ctx := context.Background()
+		_, err := PerformOAuthFlow(ctx, server.URL, config)
+
+		// For successful cases, we expect the OAuth flow to fail later
+		// (since we're not actually completing the full flow), but the
+		// port resolution should work correctly
+		if err != nil {
+			// Check if it's a port-related error (which we don't want)
+			if strings.Contains(err.Error(), "not available") {
+				t.Errorf("Unexpected port availability error: %v", err)
+			}
+		}
+	})
+
+	// Test pre-registered client with unavailable port - should fail
+	t.Run("pre-registered client with unavailable port - should fail", func(t *testing.T) {
+		t.Parallel()
+
+		// Create a listener to make a port unavailable
+		listener, err := net.Listen("tcp", "127.0.0.1:0")
+		require.NoError(t, err)
+		defer listener.Close()
+		unavailablePort := listener.Addr().(*net.TCPAddr).Port
+
+		config := &OAuthFlowConfig{
+			ClientID:     "test-client",
+			ClientSecret: "test-secret",
+			CallbackPort: unavailablePort, // Use the unavailable port
+			Scopes:       []string{"openid"},
+		}
+
+		// Create a mock OIDC discovery server
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if strings.HasSuffix(r.URL.Path, "/.well-known/openid_configuration") {
+				// Return OIDC discovery document
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte(`{
+					"issuer": "https://example.com",
+					"authorization_endpoint": "https://example.com/auth",
+					"token_endpoint": "https://example.com/token",
+					"registration_endpoint": "https://example.com/register"
+				}`))
+				return
+			}
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		defer server.Close()
+
+		// Verify the port is actually unavailable
+		if networking.IsAvailable(config.CallbackPort) {
+			t.Fatalf("Test setup error: Expected port %d to be unavailable, but it's available", config.CallbackPort)
+		}
+
+		ctx := context.Background()
+		_, err = PerformOAuthFlow(ctx, server.URL, config)
+
+		// Should fail due to port unavailability
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not available")
+	})
 }
 
 func TestPerformOAuthFlow_PortFallbackBehavior(t *testing.T) {
@@ -544,11 +640,10 @@ func TestPerformOAuthFlow_PortFallbackBehavior(t *testing.T) {
 	t.Run("dynamic registration port fallback", func(t *testing.T) {
 		t.Parallel()
 
-		// Create a listener on a specific port to make it unavailable
+		// Create a listener to make a port unavailable
 		listener, err := net.Listen("tcp", "127.0.0.1:0")
 		require.NoError(t, err)
 		defer listener.Close()
-
 		unavailablePort := listener.Addr().(*net.TCPAddr).Port
 
 		config := &OAuthFlowConfig{
@@ -598,11 +693,10 @@ func TestPerformOAuthFlow_PortFallbackBehavior(t *testing.T) {
 	t.Run("pre-registered client strict port checking", func(t *testing.T) {
 		t.Parallel()
 
-		// Create a listener on a specific port to make it unavailable
+		// Create a listener to make a port unavailable
 		listener, err := net.Listen("tcp", "127.0.0.1:0")
 		require.NoError(t, err)
 		defer listener.Close()
-
 		unavailablePort := listener.Addr().(*net.TCPAddr).Port
 
 		config := &OAuthFlowConfig{
@@ -618,5 +712,40 @@ func TestPerformOAuthFlow_PortFallbackBehavior(t *testing.T) {
 		// Should fail due to port unavailability
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "not available")
+	})
+}
+
+// TestPerformOAuthFlow_PortCheckingOnly tests just the port checking logic
+// without going through the full OAuth flow
+func TestPerformOAuthFlow_PortCheckingOnly(t *testing.T) {
+	t.Parallel()
+
+	// Test that pre-registered clients fail on unavailable ports
+	t.Run("pre-registered client strict port checking", func(t *testing.T) {
+		t.Parallel()
+
+		// Create a listener to make a port unavailable
+		listener, err := net.Listen("tcp", "127.0.0.1:0")
+		require.NoError(t, err)
+		defer listener.Close()
+
+		unavailablePort := listener.Addr().(*net.TCPAddr).Port
+
+		config := &OAuthFlowConfig{
+			ClientID:     "test-client",
+			ClientSecret: "test-secret",
+			CallbackPort: unavailablePort,
+			Scopes:       []string{"openid"},
+		}
+
+		// Test the port checking logic directly
+		if shouldDynamicallyRegisterClient(config) {
+			t.Error("Expected shouldDynamicallyRegisterClient to return false for pre-registered client")
+		}
+
+		// This should fail because the port is unavailable
+		if networking.IsAvailable(config.CallbackPort) {
+			t.Errorf("Expected port %d to be unavailable, but IsAvailable returned true", config.CallbackPort)
+		}
 	})
 }


### PR DESCRIPTION
## Problem

Users were experiencing "Invalid redirect URI" errors during OAuth authentication when the specified callback port was unavailable. The issue occurred because:

1. **Port Resolution Timing**: Dynamic client registration happened before port availability was checked, causing a mismatch between the registered callback URL and the actual port used
2. **Inconsistent Behavior**: The system would silently pick a random port without clear indication to users
3. **Unpredictable Failures**: Pre-registered clients would fail unexpectedly when ports were unavailable

## Solution

This PR implements a comprehensive fix for OAuth callback port handling:

### 🔧 **Core Changes**

- **Port Resolution Before Registration**: Moved port availability checking before dynamic client registration to ensure the OAuth provider is registered with the correct callback URL
- **Intelligent Port Behavior**: 
  - **Dynamic Registration**: Allows port fallback with clear warning messages
  - **Pre-registered Clients**: Uses strict port checking (fails if port unavailable)
- **Consistent Logging**: Added informative messages when ports change

### 🧪 **Testing**

- Added comprehensive tests for `PerformOAuthFlow` covering all port scenarios
- Tests validate both success and failure cases
- Mock OIDC discovery servers for reliable testing
- Removed unused `FindOrUsePortStrict` function and related tests

### 📋 **Behavior Summary**

| Scenario | Port Specified | Registration Type | Behavior |
|----------|---------------|-------------------|----------|
| No port specified | 0 | Dynamic | ✅ Find available port |
| Port specified | 8080 (available) | Dynamic | ✅ Use specified port |
| Port specified | 8080 (unavailable) | Dynamic | ⚠️ Use alternative port with warning |
| Port specified | 8080 (available) | Pre-registered | ✅ Use specified port |
| Port specified | 8080 (unavailable) | Pre-registered | ❌ Fail with clear error |

### 🎯 **Benefits**

- **Predictable**: Explicitly specified ports are respected for pre-registered clients
- **Flexible**: Dynamic registration allows port fallback when needed  
- **Clear**: Users get informative messages about port changes
- **Consistent**: Same behavior across `thv proxy` and `thv run` commands
- **Robust**: Comprehensive test coverage ensures reliability

## Testing

- ✅ All existing tests pass
- ✅ New comprehensive test suite for port behavior
- ✅ Manual testing with various port scenarios
- ✅ Verified behavior with both dynamic and pre-registered OAuth clients

## Breaking Changes

None. This is a bug fix that improves existing behavior without changing APIs.

## Related Issues

Fixes the "Invalid redirect URI" error reported by users during OAuth authentication flows.