### PR TITLE
Set correct content length when mutating calls

### DIFF
--- a/pkg/mcp/tool_filter.go
+++ b/pkg/mcp/tool_filter.go
@@ -245,7 +245,10 @@ func NewToolCallMappingMiddleware(opts ...ToolMiddlewareOption) (types.Middlewar
 						next.ServeHTTP(w, r)
 						return
 					}
+
 					r.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+					// TODO: find a reasonable way to test this
+					r.ContentLength = int64(len(bodyBytes))
 
 				// According to the current version of the MCP spec at
 				// https://modelcontextprotocol.io/specification/2025-06-18/schema#calltoolrequest


### PR DESCRIPTION
This sets content length correctly when `tool/call` requests are modified by the Tool Config middleware. The issue manifests only when `pkg/transport/proxy/transparent` is used, which makes it a bit trickier to test.

I manually tested the fix, but I've yet to find a decent way to test it.

Fixes #2056