### PR TITLE
Revert "Update dependency python to 3.14 (#2109)"

### DIFF
--- a/.github/workflows/lint-helm-charts.yml
+++ b/.github/workflows/lint-helm-charts.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6
         with:
-          python-version: 3.14
+          python-version: 3.13
 
       - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6
         with:

--- a/.github/workflows/test-helm-charts.yml
+++ b/.github/workflows/test-helm-charts.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6
         with:
-          python-version: 3.14
+          python-version: 3.13
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@0d28d3144d3a25ea2cc349d6e59901c4ff469b3b # v2.7.0


### PR DESCRIPTION
This reverts commit fb7ad3092ab1691d827ec393847fb4ff97cb3b1d.

Rationale: [Yamale](https://pypi.org/project/yamale/) does not support python 3.14 yet
