### PR TITLE
Remove permissionProfile from K8s examples

### DIFF
--- a/cmd/thv-operator/README.md
+++ b/cmd/thv-operator/README.md
@@ -145,9 +145,6 @@ spec:
   image: docker.io/mcp/fetch
   transport: stdio
   port: 8080
-  permissionProfile:
-    type: builtin
-    name: network
   resources:
     limits:
       cpu: "100m"
@@ -177,9 +174,6 @@ spec:
   image: ghcr.io/github/github-mcp-server
   transport: stdio
   port: 8080
-  permissionProfile:
-    type: builtin
-    name: network
   secrets:
     - name: github-token
       key: token
@@ -219,20 +213,21 @@ kubectl describe mcpserver <name>
 
 ### MCPServer Spec
 
-| Field               | Description                                      | Required | Default |
-|---------------------|--------------------------------------------------|----------|---------|
-| `image`             | Container image for the MCP server               | Yes      | -       |
-| `transport`         | Transport method (stdio, streamable-http or sse) | No       | stdio   |
-| `port`              | Port to expose the MCP server on                 | No       | 8080    |
-| `targetPort`        | Port that MCP server listens to                  | No       | -       |
-| `args`              | Additional arguments to pass to the MCP server   | No       | -       |
-| `env`               | Environment variables to set in the container    | No       | -       |
-| `volumes`           | Volumes to mount in the container                | No       | -       |
-| `resources`         | Resource requirements for the container          | No       | -       |
-| `secrets`           | References to secrets to mount in the container  | No       | -       |
-| `permissionProfile` | Permission profile configuration                 | No       | -       |
-| `tools`             | Allow-list filter on the list of tools           | No       | -       |
+| Field               | Description                                        | Required | Default |
+|---------------------|----------------------------------------------------|----------|---------|
+| `image`             | Container image for the MCP server                 | Yes      | -       |
+| `transport`         | Transport method (stdio, streamable-http or sse)   | No       | stdio   |
+| `port`              | Port to expose the MCP server on                   | No       | 8080    |
+| `targetPort`        | Port that MCP server listens to                    | No       | -       |
+| `args`              | Additional arguments to pass to the MCP server     | No       | -       |
+| `env`               | Environment variables to set in the container      | No       | -       |
+| `volumes`           | Volumes to mount in the container                  | No       | -       |
+| `resources`         | Resource requirements for the container            | No       | -       |
+| `secrets`           | References to secrets to mount in the container    | No       | -       |
+| `permissionProfile` | Permission profile configuration (not implemented) | No       | -       |
+| `tools`             | Allow-list filter on the list of tools             | No       | -       |
 
+<!-- not implemented; commenting out until a decision is made on removal
 ### Permission Profiles
 
 Permission profiles can be configured in two ways:
@@ -255,6 +250,7 @@ permissionProfile:
 ```
 
 The ConfigMap should contain a JSON permission profile.
+-->
 
 ### Creating an MCP Registry (Experimental)
 

--- a/examples/operator/mcp-servers/mcpserver_fetch.yaml
+++ b/examples/operator/mcp-servers/mcpserver_fetch.yaml
@@ -12,9 +12,6 @@ spec:
   transport: streamable-http
   port: 8080
   targetPort: 8080
-  permissionProfile:
-    type: builtin
-    name: network
   resources:
     limits:
       cpu: "100m"

--- a/examples/operator/mcp-servers/mcpserver_fetch_otel.yaml
+++ b/examples/operator/mcp-servers/mcpserver_fetch_otel.yaml
@@ -8,9 +8,6 @@ spec:
   transport: streamable-http
   port: 8080
   targetPort: 8080
-  permissionProfile:
-    type: builtin
-    name: network
   resources:
     limits:
       cpu: "100m"

--- a/examples/operator/mcp-servers/mcpserver_fetch_tools_filter.yaml
+++ b/examples/operator/mcp-servers/mcpserver_fetch_tools_filter.yaml
@@ -10,9 +10,6 @@ spec:
     - fetch
   port: 8080
   targetPort: 8080
-  permissionProfile:
-    type: builtin
-    name: network
   resources:
     limits:
       cpu: "100m"

--- a/examples/operator/mcp-servers/mcpserver_github.yaml
+++ b/examples/operator/mcp-servers/mcpserver_github.yaml
@@ -7,9 +7,6 @@ spec:
   image: ghcr.io/github/github-mcp-server
   transport: stdio
   port: 8080
-  permissionProfile:
-    type: builtin
-    name: network
   secrets:
     - name: github-token
       key: token

--- a/examples/operator/mcp-servers/mcpserver_mkp.yaml
+++ b/examples/operator/mcp-servers/mcpserver_mkp.yaml
@@ -11,9 +11,6 @@ spec:
   args:
     # Change to true for read-write access.
     - --read-write=false
-  permissionProfile:
-    type: builtin
-    name: network
   # We create this service account below with the desired permissions.
   serviceAccount: mkp-sa
   resources:

--- a/examples/operator/mcp-servers/mcpserver_with_configmap_oidc.yaml
+++ b/examples/operator/mcp-servers/mcpserver_with_configmap_oidc.yaml
@@ -18,9 +18,6 @@ spec:
   image: docker.io/mcp/fetch
   transport: stdio
   port: 8080
-  permissionProfile:
-    type: builtin
-    name: network
   oidcConfig:
     type: configmap
     configMap:

--- a/examples/operator/mcp-servers/mcpserver_with_inline_oidc.yaml
+++ b/examples/operator/mcp-servers/mcpserver_with_inline_oidc.yaml
@@ -7,9 +7,6 @@ spec:
   image: docker.io/mcp/fetch
   transport: stdio
   port: 8080
-  permissionProfile:
-    type: builtin
-    name: network
   oidcConfig:
     type: inline
     inline:

--- a/examples/operator/mcp-servers/mcpserver_with_kubernetes_oidc.yaml
+++ b/examples/operator/mcp-servers/mcpserver_with_kubernetes_oidc.yaml
@@ -7,9 +7,6 @@ spec:
   image: docker.io/mcp/fetch
   transport: stdio
   port: 8080
-  permissionProfile:
-    type: builtin
-    name: network
   oidcConfig:
     type: kubernetes
     kubernetes:

--- a/examples/operator/mcp-servers/mcpserver_with_resource_overrides.yaml
+++ b/examples/operator/mcp-servers/mcpserver_with_resource_overrides.yaml
@@ -7,9 +7,6 @@ spec:
   image: docker.io/mcp/github
   transport: stdio
   port: 8080
-  permissionProfile:
-    type: builtin
-    name: network
   secrets:
     - name: github-token
       key: GITHUB_PERSONAL_ACCESS_TOKEN

--- a/examples/operator/mcp-servers/mcpserver_yardstick_sse.yaml
+++ b/examples/operator/mcp-servers/mcpserver_yardstick_sse.yaml
@@ -11,9 +11,6 @@ spec:
     value: sse
   port: 8080
   targetPort: 8080
-  permissionProfile:
-    type: builtin
-    name: network
   resources:
     limits:
       cpu: "100m"

--- a/examples/operator/mcp-servers/mcpserver_yardstick_stdio.yaml
+++ b/examples/operator/mcp-servers/mcpserver_yardstick_stdio.yaml
@@ -7,9 +7,6 @@ spec:
   image: ghcr.io/stackloklabs/yardstick/yardstick-server:0.0.2
   transport: stdio
   port: 8080
-  permissionProfile:
-    type: builtin
-    name: network
   resources:
     limits:
       cpu: "100m"

--- a/examples/operator/mcp-servers/mcpserver_yardstick_streamablehttp.yaml
+++ b/examples/operator/mcp-servers/mcpserver_yardstick_streamablehttp.yaml
@@ -11,9 +11,6 @@ spec:
     value: streamable-http
   port: 8080
   targetPort: 8080
-  permissionProfile:
-    type: builtin
-    name: network
   resources:
     limits:
       cpu: "100m"

--- a/examples/operator/vault/mcpserver-github-with-vault.yaml
+++ b/examples/operator/vault/mcpserver-github-with-vault.yaml
@@ -7,9 +7,6 @@ spec:
   image: ghcr.io/github/github-mcp-server:latest
   transport: stdio
   port: 9095
-  permissionProfile:
-    type: builtin
-    name: network
   resources:
     limits:
       cpu: '100m'


### PR DESCRIPTION
It's not implemented, and since it's not required there's no need to have it in the example manifests.

Also commented the section out of the operator README for now until a decision is reached on deprecating it.

Signed-off-by: Dan Barr <6922515+danbarr@users.noreply.github.com>