### PR TITLE
Update inspector to use upstream image

### DIFF
--- a/cmd/thv/app/inspector.go
+++ b/cmd/thv/app/inspector.go
@@ -18,7 +18,6 @@ import (
 	"github.com/stacklok/toolhive/pkg/labels"
 	"github.com/stacklok/toolhive/pkg/logger"
 	"github.com/stacklok/toolhive/pkg/permissions"
-	"github.com/stacklok/toolhive/pkg/runner"
 	"github.com/stacklok/toolhive/pkg/transport/types"
 	"github.com/stacklok/toolhive/pkg/workloads"
 )
@@ -112,10 +111,11 @@ func inspectorCmdFunc(cmd *cobra.Command, args []string) error {
 	}
 
 	imageManager := images.NewImageManager(ctx)
-	processedImage, err := runner.HandleProtocolScheme(ctx, imageManager, inspector.Image, "")
+	err = imageManager.PullImage(ctx, inspector.Image)
 	if err != nil {
-		return fmt.Errorf("failed to handle protocol scheme: %v", err)
+		return fmt.Errorf("failed to pull inspector image: %v", err)
 	}
+	processedImage := inspector.Image
 
 	// Setup workload options with the required port configuration
 	uiPortStr := strconv.Itoa(inspectorUIPort)

--- a/cmd/thv/app/inspector/version.go
+++ b/cmd/thv/app/inspector/version.go
@@ -3,9 +3,5 @@ package inspector
 
 // Image specifies the image to use for the inspector command.
 // TODO: This could probably be a flag with a sensible default
-// TODO: Additionally, when the inspector image has been published
-// TODO: to docker.io, we can use that instead of npx
-// TODO: https://github.com/modelcontextprotocol/inspector/issues/237
-// Pinning to a specific version for stability. The latest version
-// as of 2025-07-09 broke the inspector command.
-var Image = "npx://@modelcontextprotocol/inspector@0.16.6"
+// Pinning to a specific version for stability.
+var Image = "ghcr.io/modelcontextprotocol/inspector:0.17.0"


### PR DESCRIPTION
The MCP Inspector project has been quietly publishing a container image for a few months.

This switches the `thv inspect` command to use it instead of building on-the-fly from the npx package. Also bumps to the latest v0.17.0.

Tested with streamable-http, see, and  stdio->sse servers.

Signed-off-by: Dan Barr <6922515+danbarr@users.noreply.github.com>