### PR TITLE
Pin the version of sigs.k8s.io/controller-runtime/tools/setup-envtest…

### DIFF
--- a/cmd/thv-operator/Taskfile.yml
+++ b/cmd/thv-operator/Taskfile.yml
@@ -187,13 +187,15 @@ tasks:
   operator-test:
     desc: Run tests for the operator
     cmds:
-      - go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+      # We pin to the latest commit not requiring Go 1.25
+      - go install sigs.k8s.io/controller-runtime/tools/setup-envtest@b9bccfd419149d26d14130887a5e5819e4a3b2be
       - KUBEBUILDER_ASSETS="$($(go env GOPATH)/bin/setup-envtest use 1.31.0 -p path)" go test ./cmd/thv-operator/... -coverprofile cover.out
 
   operator-test-integration:
     desc: Run integration tests for the operator using envtest
     cmds:
-      - go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+      # We pin to the latest commit not requiring Go 1.25
+      - go install sigs.k8s.io/controller-runtime/tools/setup-envtest@b9bccfd419149d26d14130887a5e5819e4a3b2be
       - go install github.com/onsi/ginkgo/v2/ginkgo@latest
       - KUBEBUILDER_ASSETS="$($(go env GOPATH)/bin/setup-envtest use 1.31.0 -p path)" $(go env GOPATH)/bin/ginkgo -v ./cmd/thv-operator/test-integration/...
 


### PR DESCRIPTION
… to not require Go 1.25

Until we make this switch, to avoid issues like:
```
go: downloading sigs.k8s.io/controller-runtime/tools/setup-envtest
v0.0.0-20251013122658-1ad089b0ee87
go: sigs.k8s.io/controller-runtime/tools/setup-envtest@latest:
sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20251013122658-1ad089b0ee87
requires go >= 1.25.0 (running go 1.24.4; GOTOOLCHAIN=local)
task: Failed to run task "operator-test": exit status 1
```