### PR TITLE
fixes test assertion that fails intermittently if not exact order match

### DIFF
--- a/pkg/mcp/tool_middleware_test.go
+++ b/pkg/mcp/tool_middleware_test.go
@@ -483,7 +483,12 @@ func TestNewListToolsMappingMiddleware_SSE_Scenarios(t *testing.T) {
 			// Verify results
 			assert.Equal(t, "2.0", response.JSONRPC)
 			assert.Equal(t, float64(1), response.ID)
-			assert.Equal(t, tt.expected, response.Result.Tools)
+			// Use ElementsMatch for order-independent comparison of tools
+			if tt.expected != nil && response.Result.Tools != nil {
+				assert.ElementsMatch(t, *tt.expected, *response.Result.Tools, "Tools should match regardless of order")
+			} else {
+				assert.Equal(t, tt.expected, response.Result.Tools)
+			}
 		})
 	}
 }


### PR DESCRIPTION
The test is using `assert.Equal()` to directly compare tool slices, which requires exact order matching. However, the tools in the response can come in any order (likely from map iteration), causing intermittent failures.

Using an `assert.ElementsMatch()` should allow us to match regardless of order