### PR TITLE
Remove duplicate pull_request trigger from operator-ci workflow

### DIFF
--- a/.github/workflows/operator-ci.yml
+++ b/.github/workflows/operator-ci.yml
@@ -3,9 +3,6 @@ name: Operator CI
 on:
   workflow_call:
   workflow_dispatch:
-  pull_request:
-    paths:
-      - 'deploy/charts/operator-crds/**'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Fixes duplicate operator e2e test runs by removing conflicting workflow triggers.

## Problem

The operator e2e tests were running multiple times on PRs because:
- The `operator-ci.yml` workflow had a direct `pull_request` trigger for `deploy/charts/operator-crds/**`
- The same workflow was also called via `workflow_call` from `run-on-pr.yml`
- This caused the entire operator e2e test suite (including the 3-version Kubernetes matrix) to run twice

## Solution

Removed the direct `pull_request` trigger from `operator-ci.yml`. The workflow now only runs via:
- `workflow_call` (from `run-on-pr.yml` and `run-on-main.yml`)
- `workflow_dispatch` (for manual triggering)

This ensures the operator CI runs exactly once per PR while maintaining coverage for all changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)