### PR TITLE
Refactor buildRunnerConfig to reduce cyclomatic complexity

### DIFF
--- a/cmd/thv/app/run_flags.go
+++ b/cmd/thv/app/run_flags.go
@@ -548,7 +548,7 @@ func configureRemoteAuth(runFlags *RunFlags, serverMetadata registry.ServerMetad
 	var opts []runner.RunConfigBuilderOption
 
 	if remoteServerMetadata, ok := serverMetadata.(*registry.RemoteServerMetadata); ok {
-		remoteAuthConfig := getRemoteAuthFromRemoteServerMetadata(remoteServerMetadata)
+		remoteAuthConfig := getRemoteAuthFromRemoteServerMetadata(remoteServerMetadata, runFlags)
 
 		// Validate OAuth callback port availability upfront for better user experience
 		if err := networking.ValidateCallbackPort(remoteAuthConfig.CallbackPort, remoteAuthConfig.ClientID); err != nil {
@@ -590,9 +590,12 @@ func extractTelemetryValues(config *telemetry.Config) (string, float64, []string
 
 // getRemoteAuthFromRemoteServerMetadata creates RemoteAuthConfig from RemoteServerMetadata,
 // giving CLI flags priority. For OAuthParams: if CLI provides any, they REPLACE metadata entirely.
-func getRemoteAuthFromRemoteServerMetadata(remoteServerMetadata *registry.RemoteServerMetadata) *runner.RemoteAuthConfig {
+func getRemoteAuthFromRemoteServerMetadata(
+	remoteServerMetadata *registry.RemoteServerMetadata,
+	runFlags *RunFlags,
+) *runner.RemoteAuthConfig {
 	if remoteServerMetadata == nil || remoteServerMetadata.OAuthConfig == nil {
-		return getRemoteAuthFromRunFlags(&runFlags)
+		return getRemoteAuthFromRunFlags(runFlags)
 	}
 
 	oc := remoteServerMetadata.OAuthConfig


### PR DESCRIPTION
## Summary
Refactor the `buildRunnerConfig` function to reduce its cyclomatic complexity from 16 to below the gocyclo threshold of 15.

## Changes
- Extract middleware configuration logic into `configureMiddlewareAndOptions` helper function
- Extract remote authentication logic into `configureRemoteAuth` helper function
- Improve code organization and maintainability
- All existing functionality is preserved

## Test plan
- [x] Linter passes with 0 issues (`task lint-fix`)
- [x] Unit tests pass (`task test`)
- [x] No behavioral changes - purely refactoring for code quality

## Technical Details
The `buildRunnerConfig` function at `cmd/thv/app/run_flags.go:390` had a cyclomatic complexity of 16, which exceeded the configured threshold of 15. This was causing the gocyclo linter check to fail.

The refactoring extracts conditional logic into focused helper functions:
1. **`configureMiddlewareAndOptions`** - Handles middleware setup, authorization config loading, OIDC/telemetry configuration, and environment file processing
2. **`configureRemoteAuth`** - Handles remote server metadata authentication and direct remote URL authentication

This reduces complexity while maintaining clear separation of concerns and improving code readability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)