### PR TITLE
Update Kubernetes test versions to latest supported releases

### DIFF
--- a/.github/workflows/operator-ci.yml
+++ b/.github/workflows/operator-ci.yml
@@ -151,9 +151,9 @@ jobs:
         # but we want to make sure renovate bumps the versions when new ones are released. Doing that with
         # just the number is a bit more difficult and i like simple things.
         version: [
-          "kindest/node:v1.31.9",
-          "kindest/node:v1.32.5",
-          "kindest/node:v1.33.1"
+          "kindest/node:v1.32.8",
+          "kindest/node:v1.33.4",
+          "kindest/node:v1.34.0"
         ]
     
     steps:


### PR DESCRIPTION
## Summary

- Update operator E2E tests to use the three currently supported Kubernetes versions
- Upgrade all versions to their latest patch releases
- Remove v1.31 which reaches EOL on October 28, 2025

## Changes

- **v1.31.9 → v1.32.8**: Upgraded to v1.32 (latest patch) as v1.31 reaches EOL in 14 days
- **v1.32.5 → v1.33.4**: Updated to latest v1.33 patch release
- **v1.33.1 → v1.34.0**: Upgraded to v1.34 (newest K8s release from Aug 2025)

This aligns with the Kubernetes project's support policy of maintaining the most recent three minor releases (1.32, 1.33, 1.34).

🤖 Generated with [Claude Code](https://claude.com/claude-code)