### PR TITLE
Remove registry-related labels from the example config

### DIFF
--- a/examples/operator/mcp-servers/mcpserver_fetch.yaml
+++ b/examples/operator/mcp-servers/mcpserver_fetch.yaml
@@ -3,10 +3,6 @@ kind: MCPServer
 metadata:
   name: fetch
   namespace: toolhive-system
-  labels:
-    toolhive.stacklok.io/registry-name: example-registry-data
-    toolhive.stacklok.io/registry-namespace: toolhive-system
-    toolhive.stacklok.io/server-registry-name: fetch
 spec:
   image: ghcr.io/stackloklabs/gofetch/server
   transport: streamable-http


### PR DESCRIPTION
I must have modified the example fetch server when working on the registry feature with enforcing registry labels and commited the diff by mistake.

Once we promoted the registry enforcement feature out of experimental, this started hitting us because the MCPServer suddendly started requiring that a registry exists.

Let's remove the labels.