### PR TITLE
Mark fields in the runconfig as deprecated

### DIFF
--- a/docs/server/docs.go
+++ b/docs/server/docs.go
@@ -9,7 +9,7 @@ const docTemplate = `{
     "components": {
         "schemas": {
             "audit.Config": {
-                "description": "AuditConfig contains the audit logging configuration",
+                "description": "DEPRECATED: Middleware configuration.\nAuditConfig contains the audit logging configuration",
                 "properties": {
                     "component": {
                         "description": "Component is the component name to use in audit events.\n+optional",
@@ -55,7 +55,7 @@ const docTemplate = `{
                 "type": "object"
             },
             "auth.TokenValidatorConfig": {
-                "description": "OIDCConfig contains OIDC configuration",
+                "description": "DEPRECATED: Middleware configuration.\nOIDCConfig contains OIDC configuration",
                 "properties": {
                     "allowPrivateIP": {
                         "description": "AllowPrivateIP allows JWKS/OIDC endpoints on private IP addresses",
@@ -112,7 +112,7 @@ const docTemplate = `{
                 "type": "object"
             },
             "authz.Config": {
-                "description": "AuthzConfig contains the authorization configuration",
+                "description": "DEPRECATED: Middleware configuration.\nAuthzConfig contains the authorization configuration",
                 "properties": {
                     "type": {
                         "description": "Type is the type of authorization configuration (e.g., \"cedarv1\").",
@@ -750,14 +750,14 @@ const docTemplate = `{
                         "$ref": "#/components/schemas/audit.Config"
                     },
                     "audit_config_path": {
-                        "description": "AuditConfigPath is the path to the audit configuration file",
+                        "description": "DEPRECATED: Middleware configuration.\nAuditConfigPath is the path to the audit configuration file",
                         "type": "string"
                     },
                     "authz_config": {
                         "$ref": "#/components/schemas/authz.Config"
                     },
                     "authz_config_path": {
-                        "description": "AuthzConfigPath is the path to the authorization configuration file",
+                        "description": "DEPRECATED: Middleware configuration.\nAuthzConfigPath is the path to the authorization configuration file",
                         "type": "string"
                     },
                     "base_name": {
@@ -792,7 +792,7 @@ const docTemplate = `{
                         "type": "string"
                     },
                     "env_file_dir": {
-                        "description": "EnvFileDir is the directory path to load environment files from",
+                        "description": "DEPRECATED: No longer appears to be used.\nEnvFileDir is the directory path to load environment files from",
                         "type": "string"
                     },
                     "env_vars": {
@@ -822,7 +822,7 @@ const docTemplate = `{
                         "type": "boolean"
                     },
                     "jwks_auth_token_file": {
-                        "description": "JWKSAuthTokenFile is the path to file containing auth token for JWKS/OIDC requests",
+                        "description": "DEPRECATED: No longer appears to be used.\nJWKSAuthTokenFile is the path to file containing auth token for JWKS/OIDC requests",
                         "type": "string"
                     },
                     "k8s_pod_template_patch": {
@@ -889,14 +889,14 @@ const docTemplate = `{
                         "$ref": "#/components/schemas/telemetry.Config"
                     },
                     "thv_ca_bundle": {
-                        "description": "ThvCABundle is the path to the CA certificate bundle for ToolHive HTTP operations",
+                        "description": "DEPRECATED: No longer appears to be used.\nThvCABundle is the path to the CA certificate bundle for ToolHive HTTP operations",
                         "type": "string"
                     },
                     "token_exchange_config": {
                         "$ref": "#/components/schemas/tokenexchange.Config"
                     },
                     "tools_filter": {
-                        "description": "ToolsFilter is the list of tools to filter",
+                        "description": "DEPRECATED: Middleware configuration.\nToolsFilter is the list of tools to filter",
                         "items": {
                             "type": "string"
                         },
@@ -907,7 +907,7 @@ const docTemplate = `{
                         "additionalProperties": {
                             "$ref": "#/components/schemas/runner.ToolOverride"
                         },
-                        "description": "ToolsOverride is a map from an actual tool to its overridden name and/or description",
+                        "description": "DEPRECATED: Middleware configuration.\nToolsOverride is a map from an actual tool to its overridden name and/or description",
                         "type": "object"
                     },
                     "transport": {
@@ -980,7 +980,7 @@ const docTemplate = `{
                 "type": "object"
             },
             "telemetry.Config": {
-                "description": "TelemetryConfig contains the OpenTelemetry configuration",
+                "description": "DEPRECATED: Middleware configuration.\nTelemetryConfig contains the OpenTelemetry configuration",
                 "properties": {
                     "customAttributes": {
                         "additionalProperties": {

--- a/docs/server/swagger.json
+++ b/docs/server/swagger.json
@@ -2,7 +2,7 @@
     "components": {
         "schemas": {
             "audit.Config": {
-                "description": "AuditConfig contains the audit logging configuration",
+                "description": "DEPRECATED: Middleware configuration.\nAuditConfig contains the audit logging configuration",
                 "properties": {
                     "component": {
                         "description": "Component is the component name to use in audit events.\n+optional",
@@ -48,7 +48,7 @@
                 "type": "object"
             },
             "auth.TokenValidatorConfig": {
-                "description": "OIDCConfig contains OIDC configuration",
+                "description": "DEPRECATED: Middleware configuration.\nOIDCConfig contains OIDC configuration",
                 "properties": {
                     "allowPrivateIP": {
                         "description": "AllowPrivateIP allows JWKS/OIDC endpoints on private IP addresses",
@@ -105,7 +105,7 @@
                 "type": "object"
             },
             "authz.Config": {
-                "description": "AuthzConfig contains the authorization configuration",
+                "description": "DEPRECATED: Middleware configuration.\nAuthzConfig contains the authorization configuration",
                 "properties": {
                     "type": {
                         "description": "Type is the type of authorization configuration (e.g., \"cedarv1\").",
@@ -743,14 +743,14 @@
                         "$ref": "#/components/schemas/audit.Config"
                     },
                     "audit_config_path": {
-                        "description": "AuditConfigPath is the path to the audit configuration file",
+                        "description": "DEPRECATED: Middleware configuration.\nAuditConfigPath is the path to the audit configuration file",
                         "type": "string"
                     },
                     "authz_config": {
                         "$ref": "#/components/schemas/authz.Config"
                     },
                     "authz_config_path": {
-                        "description": "AuthzConfigPath is the path to the authorization configuration file",
+                        "description": "DEPRECATED: Middleware configuration.\nAuthzConfigPath is the path to the authorization configuration file",
                         "type": "string"
                     },
                     "base_name": {
@@ -785,7 +785,7 @@
                         "type": "string"
                     },
                     "env_file_dir": {
-                        "description": "EnvFileDir is the directory path to load environment files from",
+                        "description": "DEPRECATED: No longer appears to be used.\nEnvFileDir is the directory path to load environment files from",
                         "type": "string"
                     },
                     "env_vars": {
@@ -815,7 +815,7 @@
                         "type": "boolean"
                     },
                     "jwks_auth_token_file": {
-                        "description": "JWKSAuthTokenFile is the path to file containing auth token for JWKS/OIDC requests",
+                        "description": "DEPRECATED: No longer appears to be used.\nJWKSAuthTokenFile is the path to file containing auth token for JWKS/OIDC requests",
                         "type": "string"
                     },
                     "k8s_pod_template_patch": {
@@ -882,14 +882,14 @@
                         "$ref": "#/components/schemas/telemetry.Config"
                     },
                     "thv_ca_bundle": {
-                        "description": "ThvCABundle is the path to the CA certificate bundle for ToolHive HTTP operations",
+                        "description": "DEPRECATED: No longer appears to be used.\nThvCABundle is the path to the CA certificate bundle for ToolHive HTTP operations",
                         "type": "string"
                     },
                     "token_exchange_config": {
                         "$ref": "#/components/schemas/tokenexchange.Config"
                     },
                     "tools_filter": {
-                        "description": "ToolsFilter is the list of tools to filter",
+                        "description": "DEPRECATED: Middleware configuration.\nToolsFilter is the list of tools to filter",
                         "items": {
                             "type": "string"
                         },
@@ -900,7 +900,7 @@
                         "additionalProperties": {
                             "$ref": "#/components/schemas/runner.ToolOverride"
                         },
-                        "description": "ToolsOverride is a map from an actual tool to its overridden name and/or description",
+                        "description": "DEPRECATED: Middleware configuration.\nToolsOverride is a map from an actual tool to its overridden name and/or description",
                         "type": "object"
                     },
                     "transport": {
@@ -973,7 +973,7 @@
                 "type": "object"
             },
             "telemetry.Config": {
-                "description": "TelemetryConfig contains the OpenTelemetry configuration",
+                "description": "DEPRECATED: Middleware configuration.\nTelemetryConfig contains the OpenTelemetry configuration",
                 "properties": {
                     "customAttributes": {
                         "additionalProperties": {

--- a/docs/server/swagger.yaml
+++ b/docs/server/swagger.yaml
@@ -1,7 +1,9 @@
 components:
   schemas:
     audit.Config:
-      description: AuditConfig contains the audit logging configuration
+      description: |-
+        DEPRECATED: Middleware configuration.
+        AuditConfig contains the audit logging configuration
       properties:
         component:
           description: |-
@@ -57,7 +59,9 @@ components:
           type: integer
       type: object
     auth.TokenValidatorConfig:
-      description: OIDCConfig contains OIDC configuration
+      description: |-
+        DEPRECATED: Middleware configuration.
+        OIDCConfig contains OIDC configuration
       properties:
         allowPrivateIP:
           description: AllowPrivateIP allows JWKS/OIDC endpoints on private IP addresses
@@ -107,7 +111,9 @@ components:
           type: array
       type: object
     authz.Config:
-      description: AuthzConfig contains the authorization configuration
+      description: |-
+        DEPRECATED: Middleware configuration.
+        AuthzConfig contains the authorization configuration
       properties:
         type:
           description: Type is the type of authorization configuration (e.g., "cedarv1").
@@ -650,13 +656,16 @@ components:
         audit_config:
           $ref: '#/components/schemas/audit.Config'
         audit_config_path:
-          description: AuditConfigPath is the path to the audit configuration file
+          description: |-
+            DEPRECATED: Middleware configuration.
+            AuditConfigPath is the path to the audit configuration file
           type: string
         authz_config:
           $ref: '#/components/schemas/authz.Config'
         authz_config_path:
-          description: AuthzConfigPath is the path to the authorization configuration
-            file
+          description: |-
+            DEPRECATED: Middleware configuration.
+            AuthzConfigPath is the path to the authorization configuration file
           type: string
         base_name:
           description: BaseName is the base name used for the container (without prefixes)
@@ -684,8 +693,9 @@ components:
             This is used to handle path-based ingress routing scenarios.
           type: string
         env_file_dir:
-          description: EnvFileDir is the directory path to load environment files
-            from
+          description: |-
+            DEPRECATED: No longer appears to be used.
+            EnvFileDir is the directory path to load environment files from
           type: string
         env_vars:
           additionalProperties:
@@ -709,8 +719,9 @@ components:
             the container
           type: boolean
         jwks_auth_token_file:
-          description: JWKSAuthTokenFile is the path to file containing auth token
-            for JWKS/OIDC requests
+          description: |-
+            DEPRECATED: No longer appears to be used.
+            JWKSAuthTokenFile is the path to file containing auth token for JWKS/OIDC requests
           type: string
         k8s_pod_template_patch:
           description: |-
@@ -768,13 +779,16 @@ components:
         telemetry_config:
           $ref: '#/components/schemas/telemetry.Config'
         thv_ca_bundle:
-          description: ThvCABundle is the path to the CA certificate bundle for ToolHive
-            HTTP operations
+          description: |-
+            DEPRECATED: No longer appears to be used.
+            ThvCABundle is the path to the CA certificate bundle for ToolHive HTTP operations
           type: string
         token_exchange_config:
           $ref: '#/components/schemas/tokenexchange.Config'
         tools_filter:
-          description: ToolsFilter is the list of tools to filter
+          description: |-
+            DEPRECATED: Middleware configuration.
+            ToolsFilter is the list of tools to filter
           items:
             type: string
           type: array
@@ -782,8 +796,9 @@ components:
         tools_override:
           additionalProperties:
             $ref: '#/components/schemas/runner.ToolOverride'
-          description: ToolsOverride is a map from an actual tool to its overridden
-            name and/or description
+          description: |-
+            DEPRECATED: Middleware configuration.
+            ToolsOverride is a map from an actual tool to its overridden name and/or description
           type: object
         transport:
           $ref: '#/components/schemas/types.TransportType'
@@ -841,7 +856,9 @@ components:
           type: string
       type: object
     telemetry.Config:
-      description: TelemetryConfig contains the OpenTelemetry configuration
+      description: |-
+        DEPRECATED: Middleware configuration.
+        TelemetryConfig contains the OpenTelemetry configuration
       properties:
         customAttributes:
           additionalProperties:

--- a/pkg/runner/config.go
+++ b/pkg/runner/config.go
@@ -85,6 +85,7 @@ type RunConfig struct {
 	// EnvVars are the parsed environment variables as key-value pairs
 	EnvVars map[string]string `json:"env_vars,omitempty" yaml:"env_vars,omitempty"`
 
+	// DEPRECATED: No longer appears to be used.
 	// EnvFileDir is the directory path to load environment files from
 	EnvFileDir string `json:"env_file_dir,omitempty" yaml:"env_file_dir,omitempty"`
 
@@ -98,24 +99,30 @@ type RunConfig struct {
 	// ContainerLabels are the labels to apply to the container
 	ContainerLabels map[string]string `json:"container_labels,omitempty" yaml:"container_labels,omitempty"`
 
+	// DEPRECATED: Middleware configuration.
 	// OIDCConfig contains OIDC configuration
 	OIDCConfig *auth.TokenValidatorConfig `json:"oidc_config,omitempty" yaml:"oidc_config,omitempty"`
 
 	// TokenExchangeConfig contains token exchange configuration for external authentication
 	TokenExchangeConfig *tokenexchange.Config `json:"token_exchange_config,omitempty" yaml:"token_exchange_config,omitempty"`
 
+	// DEPRECATED: Middleware configuration.
 	// AuthzConfig contains the authorization configuration
 	AuthzConfig *authz.Config `json:"authz_config,omitempty" yaml:"authz_config,omitempty"`
 
+	// DEPRECATED: Middleware configuration.
 	// AuthzConfigPath is the path to the authorization configuration file
 	AuthzConfigPath string `json:"authz_config_path,omitempty" yaml:"authz_config_path,omitempty"`
 
+	// DEPRECATED: Middleware configuration.
 	// AuditConfig contains the audit logging configuration
 	AuditConfig *audit.Config `json:"audit_config,omitempty" yaml:"audit_config,omitempty"`
 
+	// DEPRECATED: Middleware configuration.
 	// AuditConfigPath is the path to the audit configuration file
 	AuditConfigPath string `json:"audit_config_path,omitempty" yaml:"audit_config_path,omitempty"`
 
+	// DEPRECATED: Middleware configuration.
 	// TelemetryConfig contains the OpenTelemetry configuration
 	TelemetryConfig *telemetry.Config `json:"telemetry_config,omitempty" yaml:"telemetry_config,omitempty"`
 
@@ -143,18 +150,22 @@ type RunConfig struct {
 	// Note: "sse" is deprecated; use "streamable-http" instead.
 	ProxyMode types.ProxyMode `json:"proxy_mode,omitempty" yaml:"proxy_mode,omitempty"`
 
+	// DEPRECATED: No longer appears to be used.
 	// ThvCABundle is the path to the CA certificate bundle for ToolHive HTTP operations
 	ThvCABundle string `json:"thv_ca_bundle,omitempty" yaml:"thv_ca_bundle,omitempty"`
 
+	// DEPRECATED: No longer appears to be used.
 	// JWKSAuthTokenFile is the path to file containing auth token for JWKS/OIDC requests
 	JWKSAuthTokenFile string `json:"jwks_auth_token_file,omitempty" yaml:"jwks_auth_token_file,omitempty"`
 
 	// Group is the name of the group this workload belongs to, if any
 	Group string `json:"group,omitempty" yaml:"group,omitempty"`
 
+	// DEPRECATED: Middleware configuration.
 	// ToolsFilter is the list of tools to filter
 	ToolsFilter []string `json:"tools_filter,omitempty" yaml:"tools_filter,omitempty"`
 
+	// DEPRECATED: Middleware configuration.
 	// ToolsOverride is a map from an actual tool to its overridden name and/or description
 	ToolsOverride map[string]ToolOverride `json:"tools_override,omitempty" yaml:"tools_override,omitempty"`
 


### PR DESCRIPTION
This applies to fields which either:

- Do not appear to be used any more.
- Are replaced by the telemetry middleware.

We need to modify k8s to use the telemetry middleware object.