### PR TITLE
Log middleware names instead of numeric indices

### DIFF
--- a/pkg/audit/middleware.go
+++ b/pkg/audit/middleware.go
@@ -74,6 +74,6 @@ func CreateMiddleware(config *types.MiddlewareConfig, runner types.MiddlewareRun
 	}
 
 	auditMw := &Middleware{middleware: middleware}
-	runner.AddMiddleware(auditMw)
+	runner.AddMiddleware(config.Type, auditMw)
 	return nil
 }

--- a/pkg/audit/middleware_test.go
+++ b/pkg/audit/middleware_test.go
@@ -106,7 +106,7 @@ func TestCreateMiddlewareWithConfigData(t *testing.T) {
 		defer ctrl.Finish()
 
 		mockRunner := mocks.NewMockMiddlewareRunner(ctrl)
-		mockRunner.EXPECT().AddMiddleware(gomock.Any()).Times(1)
+		mockRunner.EXPECT().AddMiddleware(gomock.Any(), gomock.Any()).Times(1)
 
 		config := &Config{
 			Component:           "test-component",
@@ -159,7 +159,7 @@ func TestCreateMiddlewareWithConfigData(t *testing.T) {
 		defer ctrl.Finish()
 
 		mockRunner := mocks.NewMockMiddlewareRunner(ctrl)
-		mockRunner.EXPECT().AddMiddleware(gomock.Any()).Times(1)
+		mockRunner.EXPECT().AddMiddleware(gomock.Any(), gomock.Any()).Times(1)
 
 		err = CreateMiddleware(middlewareConfig, mockRunner)
 		assert.NoError(t, err)
@@ -178,7 +178,7 @@ func TestCreateMiddlewareWithConfigData(t *testing.T) {
 		defer ctrl.Finish()
 
 		mockRunner := mocks.NewMockMiddlewareRunner(ctrl)
-		mockRunner.EXPECT().AddMiddleware(gomock.Any()).Times(1)
+		mockRunner.EXPECT().AddMiddleware(gomock.Any(), gomock.Any()).Times(1)
 
 		err = CreateMiddleware(middlewareConfig, mockRunner)
 		assert.NoError(t, err)
@@ -224,7 +224,7 @@ func TestCreateMiddlewareWithConfigData(t *testing.T) {
 		defer ctrl.Finish()
 
 		mockRunner := mocks.NewMockMiddlewareRunner(ctrl)
-		mockRunner.EXPECT().AddMiddleware(gomock.Any()).Times(1)
+		mockRunner.EXPECT().AddMiddleware(gomock.Any(), gomock.Any()).Times(1)
 
 		err = CreateMiddleware(middlewareConfig, mockRunner)
 		assert.NoError(t, err)
@@ -295,7 +295,7 @@ func TestCreateMiddlewareWithConfigData(t *testing.T) {
 		defer ctrl.Finish()
 
 		mockRunner := mocks.NewMockMiddlewareRunner(ctrl)
-		mockRunner.EXPECT().AddMiddleware(gomock.Any()).Times(1)
+		mockRunner.EXPECT().AddMiddleware(gomock.Any(), gomock.Any()).Times(1)
 
 		err = CreateMiddleware(middlewareConfig, mockRunner)
 		assert.NoError(t, err)
@@ -437,7 +437,7 @@ func TestBackwardsCompatibility(t *testing.T) {
 		defer ctrl.Finish()
 
 		mockRunner := mocks.NewMockMiddlewareRunner(ctrl)
-		mockRunner.EXPECT().AddMiddleware(gomock.Any()).Times(1)
+		mockRunner.EXPECT().AddMiddleware(gomock.Any(), gomock.Any()).Times(1)
 
 		err = CreateMiddleware(middlewareConfig, mockRunner)
 		assert.NoError(t, err)
@@ -483,7 +483,7 @@ func TestBackwardsCompatibility(t *testing.T) {
 		defer ctrl.Finish()
 
 		mockRunner := mocks.NewMockMiddlewareRunner(ctrl)
-		mockRunner.EXPECT().AddMiddleware(gomock.Any()).Times(1)
+		mockRunner.EXPECT().AddMiddleware(gomock.Any(), gomock.Any()).Times(1)
 
 		err = CreateMiddleware(middlewareConfig, mockRunner)
 		assert.NoError(t, err)

--- a/pkg/auth/middleware.go
+++ b/pkg/auth/middleware.go
@@ -60,7 +60,7 @@ func CreateMiddleware(config *types.MiddlewareConfig, runner types.MiddlewareRun
 	}
 
 	// Add middleware to runner
-	runner.AddMiddleware(authMw)
+	runner.AddMiddleware(config.Type, authMw)
 
 	// Set auth info handler if present
 	if authInfoHandler != nil {

--- a/pkg/auth/middleware_test.go
+++ b/pkg/auth/middleware_test.go
@@ -104,10 +104,11 @@ func TestCreateMiddleware_WithoutOIDCConfig(t *testing.T) {
 	mockRunner := mocks.NewMockMiddlewareRunner(ctrl)
 
 	// Expect AddMiddleware to be called with a middleware instance
-	mockRunner.EXPECT().AddMiddleware(gomock.Any()).Do(func(mw types.Middleware) {
+	mockRunner.EXPECT().AddMiddleware(gomock.Any(), gomock.Any()).Do(func(name string, mw types.Middleware) {
 		// Verify it's our auth middleware
 		_, ok := mw.(*Middleware)
 		assert.True(t, ok, "Expected middleware to be of type *auth.Middleware")
+		assert.Equal(t, MiddlewareType, name, "Expected middleware name to be 'auth'")
 	})
 
 	// Create parameters without OIDC config (local auth)
@@ -214,7 +215,7 @@ func TestCreateMiddleware_EmptyParameters(t *testing.T) {
 	mockRunner := mocks.NewMockMiddlewareRunner(ctrl)
 
 	// Expect AddMiddleware to be called
-	mockRunner.EXPECT().AddMiddleware(gomock.Any())
+	mockRunner.EXPECT().AddMiddleware(gomock.Any(), gomock.Any())
 
 	// Create config with empty JSON parameters
 	config := &types.MiddlewareConfig{

--- a/pkg/auth/tokenexchange/middleware.go
+++ b/pkg/auth/tokenexchange/middleware.go
@@ -124,7 +124,7 @@ func CreateMiddleware(config *types.MiddlewareConfig, runner types.MiddlewareRun
 	}
 
 	// Add middleware to runner
-	runner.AddMiddleware(tokenExchangeMw)
+	runner.AddMiddleware(config.Type, tokenExchangeMw)
 
 	return nil
 }

--- a/pkg/auth/tokenexchange/middleware_test.go
+++ b/pkg/auth/tokenexchange/middleware_test.go
@@ -552,7 +552,7 @@ func TestCreateMiddleware(t *testing.T) {
 			mockRunner := mocks.NewMockMiddlewareRunner(ctrl)
 
 			if tt.expectAddMiddleware {
-				mockRunner.EXPECT().AddMiddleware(gomock.Any()).Do(func(mw types.Middleware) {
+				mockRunner.EXPECT().AddMiddleware(gomock.Any(), gomock.Any()).Do(func(_ string, mw types.Middleware) {
 					_, ok := mw.(*Middleware)
 					assert.True(t, ok, "Expected middleware to be of type *tokenexchange.Middleware")
 				})

--- a/pkg/authz/middleware.go
+++ b/pkg/authz/middleware.go
@@ -263,6 +263,6 @@ func CreateMiddleware(config *types.MiddlewareConfig, runner types.MiddlewareRun
 	}
 
 	authzMw := &FactoryMiddleware{middleware: middleware}
-	runner.AddMiddleware(authzMw)
+	runner.AddMiddleware(config.Type, authzMw)
 	return nil
 }

--- a/pkg/authz/middleware_test.go
+++ b/pkg/authz/middleware_test.go
@@ -322,7 +322,7 @@ func TestFactoryCreateMiddleware(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 		mockRunner := mocks.NewMockMiddlewareRunner(ctrl)
-		mockRunner.EXPECT().AddMiddleware(gomock.Any()).Times(1)
+		mockRunner.EXPECT().AddMiddleware(gomock.Any(), gomock.Any()).Times(1)
 
 		// Test CreateMiddleware
 		err = CreateMiddleware(middlewareConfig, mockRunner)
@@ -368,7 +368,7 @@ func TestFactoryCreateMiddleware(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 		mockRunner := mocks.NewMockMiddlewareRunner(ctrl)
-		mockRunner.EXPECT().AddMiddleware(gomock.Any()).Times(1)
+		mockRunner.EXPECT().AddMiddleware(gomock.Any(), gomock.Any()).Times(1)
 
 		// Test CreateMiddleware
 		err = CreateMiddleware(middlewareConfig, mockRunner)
@@ -405,7 +405,7 @@ func TestFactoryCreateMiddleware(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 		mockRunner := mocks.NewMockMiddlewareRunner(ctrl)
-		mockRunner.EXPECT().AddMiddleware(gomock.Any()).Times(1)
+		mockRunner.EXPECT().AddMiddleware(gomock.Any(), gomock.Any()).Times(1)
 
 		// Test CreateMiddleware - should succeed even with invalid path because ConfigData takes precedence
 		err = CreateMiddleware(middlewareConfig, mockRunner)

--- a/pkg/mcp/middleware.go
+++ b/pkg/mcp/middleware.go
@@ -62,10 +62,10 @@ func (*ToolFilterMiddleware) Close() error {
 }
 
 // CreateParserMiddleware factory function for MCP parser middleware
-func CreateParserMiddleware(_ *types.MiddlewareConfig, runner types.MiddlewareRunner) error {
+func CreateParserMiddleware(config *types.MiddlewareConfig, runner types.MiddlewareRunner) error {
 
 	mcpMw := &ParserMiddleware{}
-	runner.AddMiddleware(mcpMw)
+	runner.AddMiddleware(config.Type, mcpMw)
 	return nil
 }
 
@@ -89,7 +89,7 @@ func CreateToolFilterMiddleware(config *types.MiddlewareConfig, runner types.Mid
 	}
 
 	toolFilterMw := &ToolFilterMiddleware{middleware: middleware}
-	runner.AddMiddleware(toolFilterMw)
+	runner.AddMiddleware(config.Type, toolFilterMw)
 	return nil
 }
 
@@ -113,6 +113,6 @@ func CreateToolCallFilterMiddleware(config *types.MiddlewareConfig, runner types
 	}
 
 	toolCallFilterMw := &ToolFilterMiddleware{middleware: middleware}
-	runner.AddMiddleware(toolCallFilterMw)
+	runner.AddMiddleware(config.Type, toolCallFilterMw)
 	return nil
 }

--- a/pkg/mcp/middleware_test.go
+++ b/pkg/mcp/middleware_test.go
@@ -78,7 +78,7 @@ func TestCreateToolFilterMiddleware(t *testing.T) {
 				}
 			}(),
 			setupMock: func(mockRunner *mocks.MockMiddlewareRunner) {
-				mockRunner.EXPECT().AddMiddleware(gomock.Any()).Do(func(mw types.Middleware) {
+				mockRunner.EXPECT().AddMiddleware(gomock.Any(), gomock.Any()).Do(func(_ string, mw types.Middleware) {
 					_, ok := mw.(*ToolFilterMiddleware)
 					assert.True(t, ok, "Expected middleware to be of type *ToolFilterMiddleware")
 				})
@@ -98,7 +98,7 @@ func TestCreateToolFilterMiddleware(t *testing.T) {
 				}
 			}(),
 			setupMock: func(mockRunner *mocks.MockMiddlewareRunner) {
-				mockRunner.EXPECT().AddMiddleware(gomock.Any()).Do(func(mw types.Middleware) {
+				mockRunner.EXPECT().AddMiddleware(gomock.Any(), gomock.Any()).Do(func(_ string, mw types.Middleware) {
 					_, ok := mw.(*ToolFilterMiddleware)
 					assert.True(t, ok, "Expected middleware to be of type *ToolFilterMiddleware")
 				})
@@ -182,7 +182,7 @@ func TestCreateToolCallFilterMiddleware(t *testing.T) {
 				}
 			}(),
 			setupMock: func(mockRunner *mocks.MockMiddlewareRunner) {
-				mockRunner.EXPECT().AddMiddleware(gomock.Any()).Do(func(mw types.Middleware) {
+				mockRunner.EXPECT().AddMiddleware(gomock.Any(), gomock.Any()).Do(func(_ string, mw types.Middleware) {
 					_, ok := mw.(*ToolFilterMiddleware)
 					assert.True(t, ok, "Expected middleware to be of type *ToolFilterMiddleware")
 				})
@@ -202,7 +202,7 @@ func TestCreateToolCallFilterMiddleware(t *testing.T) {
 				}
 			}(),
 			setupMock: func(mockRunner *mocks.MockMiddlewareRunner) {
-				mockRunner.EXPECT().AddMiddleware(gomock.Any()).Do(func(mw types.Middleware) {
+				mockRunner.EXPECT().AddMiddleware(gomock.Any(), gomock.Any()).Do(func(_ string, mw types.Middleware) {
 					_, ok := mw.(*ToolFilterMiddleware)
 					assert.True(t, ok, "Expected middleware to be of type *ToolFilterMiddleware")
 				})

--- a/pkg/telemetry/middleware.go
+++ b/pkg/telemetry/middleware.go
@@ -608,7 +608,7 @@ func CreateMiddleware(config *types.MiddlewareConfig, runner types.MiddlewareRun
 	}
 
 	// Add middleware to runner
-	runner.AddMiddleware(telemetryMw)
+	runner.AddMiddleware(config.Type, telemetryMw)
 
 	// Set Prometheus handler if enabled
 	if prometheusHandler != nil {

--- a/pkg/telemetry/middleware_test.go
+++ b/pkg/telemetry/middleware_test.go
@@ -840,7 +840,7 @@ func TestCreateMiddleware_ValidConfig(t *testing.T) {
 			},
 			expectError: false,
 			expectedCalls: func(runner *mocks.MockMiddlewareRunner, _ *mocks.MockRunnerConfig) {
-				runner.EXPECT().AddMiddleware(gomock.Any()).Times(1)
+				runner.EXPECT().AddMiddleware(gomock.Any(), gomock.Any()).Times(1)
 			},
 		},
 		{
@@ -860,7 +860,7 @@ func TestCreateMiddleware_ValidConfig(t *testing.T) {
 			},
 			expectError: false,
 			expectedCalls: func(runner *mocks.MockMiddlewareRunner, config *mocks.MockRunnerConfig) {
-				runner.EXPECT().AddMiddleware(gomock.Any()).Times(1)
+				runner.EXPECT().AddMiddleware(gomock.Any(), gomock.Any()).Times(1)
 				runner.EXPECT().SetPrometheusHandler(gomock.Any()).Times(1)
 				config.EXPECT().GetPort().Return(8080).Times(1)
 			},
@@ -883,7 +883,7 @@ func TestCreateMiddleware_ValidConfig(t *testing.T) {
 			},
 			expectError: false,
 			expectedCalls: func(runner *mocks.MockMiddlewareRunner, config *mocks.MockRunnerConfig) {
-				runner.EXPECT().AddMiddleware(gomock.Any()).Times(1)
+				runner.EXPECT().AddMiddleware(gomock.Any(), gomock.Any()).Times(1)
 				runner.EXPECT().SetPrometheusHandler(gomock.Any()).Times(1)
 				config.EXPECT().GetPort().Return(8080).Times(1)
 			},
@@ -906,7 +906,7 @@ func TestCreateMiddleware_ValidConfig(t *testing.T) {
 			},
 			expectError: false,
 			expectedCalls: func(runner *mocks.MockMiddlewareRunner, _ *mocks.MockRunnerConfig) {
-				runner.EXPECT().AddMiddleware(gomock.Any()).Times(1)
+				runner.EXPECT().AddMiddleware(gomock.Any(), gomock.Any()).Times(1)
 				// No SetPrometheusHandler call expected for no-op provider
 			},
 		},
@@ -999,7 +999,7 @@ func TestCreateMiddleware_InvalidConfig(t *testing.T) {
 			},
 			expectedError: "", // This should not error - empty server name is allowed
 			expectedCalls: func(runner *mocks.MockMiddlewareRunner) {
-				runner.EXPECT().AddMiddleware(gomock.Any()).Times(1)
+				runner.EXPECT().AddMiddleware(gomock.Any(), gomock.Any()).Times(1)
 			},
 		},
 		{
@@ -1017,7 +1017,7 @@ func TestCreateMiddleware_InvalidConfig(t *testing.T) {
 			},
 			expectedError: "", // This should not error - empty transport is allowed
 			expectedCalls: func(runner *mocks.MockMiddlewareRunner) {
-				runner.EXPECT().AddMiddleware(gomock.Any()).Times(1)
+				runner.EXPECT().AddMiddleware(gomock.Any(), gomock.Any()).Times(1)
 			},
 		},
 	}
@@ -1387,7 +1387,7 @@ func TestFactoryMiddleware_Integration(t *testing.T) {
 
 		// Expect middleware to be added and Prometheus handler to be set
 		var capturedMiddleware types.Middleware
-		mockRunner.EXPECT().AddMiddleware(gomock.Any()).Times(1).Do(func(mw types.Middleware) {
+		mockRunner.EXPECT().AddMiddleware(gomock.Any(), gomock.Any()).Times(1).Do(func(_ string, mw types.Middleware) {
 			capturedMiddleware = mw
 		})
 		mockRunner.EXPECT().SetPrometheusHandler(gomock.Any()).Times(1)
@@ -1444,7 +1444,7 @@ func TestFactoryMiddleware_Integration(t *testing.T) {
 
 		// Expect only middleware to be added (no Prometheus)
 		var capturedMiddleware types.Middleware
-		mockRunner.EXPECT().AddMiddleware(gomock.Any()).Times(1).Do(func(mw types.Middleware) {
+		mockRunner.EXPECT().AddMiddleware(gomock.Any(), gomock.Any()).Times(1).Do(func(_ string, mw types.Middleware) {
 			capturedMiddleware = mw
 		})
 

--- a/pkg/transport/proxy/httpsse/http_proxy.go
+++ b/pkg/transport/proxy/httpsse/http_proxy.go
@@ -57,7 +57,7 @@ type HTTPSSEProxy struct {
 	host              string
 	port              int
 	containerName     string
-	middlewares       []types.MiddlewareFunction
+	middlewares       []types.NamedMiddleware
 	trustProxyHeaders bool
 
 	// HTTP server
@@ -92,7 +92,7 @@ func NewHTTPSSEProxy(
 	containerName string,
 	trustProxyHeaders bool,
 	prometheusHandler http.Handler,
-	middlewares ...types.MiddlewareFunction,
+	middlewares ...types.NamedMiddleware,
 ) *HTTPSSEProxy {
 	// Create a factory for SSE sessions
 	sseFactory := func(id string) session.Session {
@@ -121,10 +121,10 @@ func NewHTTPSSEProxy(
 }
 
 // applyMiddlewares applies a chain of middlewares to a handler
-func applyMiddlewares(handler http.Handler, middlewares ...types.MiddlewareFunction) http.Handler {
+func applyMiddlewares(handler http.Handler, middlewares ...types.NamedMiddleware) http.Handler {
 	// Apply middleware chain in reverse order (last middleware is applied first)
 	for i := len(middlewares) - 1; i >= 0; i-- {
-		handler = middlewares[i](handler)
+		handler = middlewares[i].Function(handler)
 	}
 	return handler
 }

--- a/pkg/transport/proxy/streamable/streamable_proxy.go
+++ b/pkg/transport/proxy/streamable/streamable_proxy.go
@@ -36,7 +36,7 @@ type HTTPProxy struct {
 	containerName     string
 	shutdownCh        chan struct{}
 	prometheusHandler http.Handler
-	middlewares       []types.MiddlewareFunction
+	middlewares       []types.NamedMiddleware
 
 	// Message channel for sending JSON-RPC to the container (from HTTP -> runner)
 	messageCh chan jsonrpc2.Message
@@ -61,7 +61,7 @@ func NewHTTPProxy(
 	port int,
 	containerName string,
 	prometheusHandler http.Handler,
-	middlewares ...types.MiddlewareFunction,
+	middlewares ...types.NamedMiddleware,
 ) *HTTPProxy {
 	// Use typed Streamable sessions
 	sFactory := func(id string) session.Session { return session.NewStreamableSession(id) }
@@ -543,7 +543,7 @@ func (p *HTTPProxy) doRequest(ctx context.Context, sessID string, req *jsonrpc2.
 
 func (p *HTTPProxy) applyMiddlewares(handler http.Handler) http.Handler {
 	for i := len(p.middlewares) - 1; i >= 0; i-- {
-		handler = p.middlewares[i](handler)
+		handler = p.middlewares[i].Function(handler)
 	}
 	return handler
 }

--- a/pkg/transport/proxy/transparent/transparent_test.go
+++ b/pkg/transport/proxy/transparent/transparent_test.go
@@ -148,7 +148,7 @@ func TestTracePropagationHeaders(t *testing.T) {
 	defer downstream.Close()
 
 	// Create transparent proxy pointing to mock server
-	proxy := NewTransparentProxy("localhost", 0, "test-server", downstream.URL, nil, nil, false, false, "", nil)
+	proxy := NewTransparentProxy("localhost", 0, "test-server", downstream.URL, nil, nil, false, false, "")
 
 	// Parse downstream URL
 	targetURL, err := url.Parse(downstream.URL)

--- a/pkg/transport/stdio.go
+++ b/pkg/transport/stdio.go
@@ -32,7 +32,7 @@ type StdioTransport struct {
 	containerName     string
 	deployer          rt.Deployer
 	debug             bool
-	middlewares       []types.MiddlewareFunction
+	middlewares       []types.NamedMiddleware
 	prometheusHandler http.Handler
 	trustProxyHeaders bool
 
@@ -63,7 +63,7 @@ func NewStdioTransport(
 	debug bool,
 	trustProxyHeaders bool,
 	prometheusHandler http.Handler,
-	middlewares ...types.MiddlewareFunction,
+	middlewares ...types.NamedMiddleware,
 ) *StdioTransport {
 	return &StdioTransport{
 		host:              host,

--- a/pkg/transport/types/mocks/mock_transport.go
+++ b/pkg/transport/types/mocks/mock_transport.go
@@ -99,15 +99,15 @@ func (m *MockMiddlewareRunner) EXPECT() *MockMiddlewareRunnerMockRecorder {
 }
 
 // AddMiddleware mocks base method.
-func (m *MockMiddlewareRunner) AddMiddleware(middleware types.Middleware) {
+func (m *MockMiddlewareRunner) AddMiddleware(name string, middleware types.Middleware) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "AddMiddleware", middleware)
+	m.ctrl.Call(m, "AddMiddleware", name, middleware)
 }
 
 // AddMiddleware indicates an expected call of AddMiddleware.
-func (mr *MockMiddlewareRunnerMockRecorder) AddMiddleware(middleware any) *gomock.Call {
+func (mr *MockMiddlewareRunnerMockRecorder) AddMiddleware(name, middleware any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddMiddleware", reflect.TypeOf((*MockMiddlewareRunner)(nil).AddMiddleware), middleware)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddMiddleware", reflect.TypeOf((*MockMiddlewareRunner)(nil).AddMiddleware), name, middleware)
 }
 
 // GetConfig mocks base method.

--- a/pkg/transport/types/transport.go
+++ b/pkg/transport/types/transport.go
@@ -20,6 +20,12 @@ import (
 // MiddlewareFunction is a function that wraps an http.Handler with additional functionality.
 type MiddlewareFunction func(http.Handler) http.Handler
 
+// NamedMiddleware pairs a middleware function with its name for logging purposes.
+type NamedMiddleware struct {
+	Name     string
+	Function MiddlewareFunction
+}
+
 // Middleware defines a middleware interceptor and a close method.
 type Middleware interface {
 	// Handler returns the middleware function used by the proxy.
@@ -56,8 +62,8 @@ func NewMiddlewareConfig(middlewareType string, parameters any) (*MiddlewareConf
 // MiddlewareRunner defines the interface that middleware can use to interact with the runner.
 // This unified interface replaces the ad-hoc interfaces defined in each middleware package.
 type MiddlewareRunner interface {
-	// AddMiddleware adds a middleware instance to the runner's middleware chain
-	AddMiddleware(middleware Middleware)
+	// AddMiddleware adds a middleware instance to the runner's middleware chain with a name for logging
+	AddMiddleware(name string, middleware Middleware)
 
 	// SetAuthInfoHandler sets the authentication info handler (used by auth middleware)
 	SetAuthInfoHandler(handler http.Handler)
@@ -191,9 +197,9 @@ type Config struct {
 	// If debug mode is enabled, containers will not be removed when stopped.
 	Debug bool
 
-	// Middlewares is a list of middleware functions to apply to the transport.
+	// Middlewares is a list of named middleware to apply to the transport.
 	// These are applied in order, with the first middleware being the outermost wrapper.
-	Middlewares []MiddlewareFunction
+	Middlewares []NamedMiddleware
 
 	// PrometheusHandler is an optional HTTP handler for Prometheus metrics endpoint.
 	// If provided, it will be exposed at /metrics on the transport's HTTP server.


### PR DESCRIPTION
## Summary

Improves middleware logging by displaying actual middleware names instead of generic numeric indices. This makes it much easier to debug which specific middleware are enabled from the logs.

**Before:**
```
Applied middleware 1
Applied middleware 2
Applied middleware 3
```

**After:**
```
Applied middleware: auth
Applied middleware: mcp-parser
Applied middleware: authorization
Applied middleware: telemetry
```

## Implementation

The solution leverages the existing middleware factory architecture by:

1. Creating a `NamedMiddleware` struct that pairs middleware functions with their names
2. Updating the `MiddlewareRunner.AddMiddleware()` interface to accept a name parameter
3. Having all middleware factories pass `config.Type` (which contains the middleware name) when calling `AddMiddleware()`
4. Propagating `NamedMiddleware` through the transport layer to the `TransparentProxy`
5. Using the name in the log statement instead of the numeric index

This approach is clean because it reuses the existing `config.Type` from middleware configurations rather than requiring a new `Name()` method on the `Middleware` interface.

## Key Files Changed

- `pkg/transport/types/transport.go` - Added `NamedMiddleware` struct and updated interface
- `pkg/transport/proxy/transparent/transparent_proxy.go` - Updated logging to use middleware names
- `pkg/runner/runner.go` - Tracks `NamedMiddleware` instead of plain functions
- All middleware factories - Pass `config.Type` to `AddMiddleware()`
- All transport implementations - Use `NamedMiddleware` throughout

Fixes #1630

🤖 Generated with [Claude Code](https://claude.com/claude-code)