### PR TITLE
Refactor OIDC resolver to use generic OIDCConfigurable interface

### DIFF
--- a/cmd/thv-operator/api/v1alpha1/mcpserver_types.go
+++ b/cmd/thv-operator/api/v1alpha1/mcpserver_types.go
@@ -659,6 +659,26 @@ type MCPServerList struct {
 	Items           []MCPServer `json:"items"`
 }
 
+// GetName returns the name of the MCPServer
+func (m *MCPServer) GetName() string {
+	return m.Name
+}
+
+// GetNamespace returns the namespace of the MCPServer
+func (m *MCPServer) GetNamespace() string {
+	return m.Namespace
+}
+
+// GetOIDCConfig returns the OIDC configuration reference
+func (m *MCPServer) GetOIDCConfig() *OIDCConfigRef {
+	return m.Spec.OIDCConfig
+}
+
+// GetPort returns the port of the MCPServer
+func (m *MCPServer) GetPort() int32 {
+	return m.Spec.Port
+}
+
 func init() {
 	SchemeBuilder.Register(&MCPServer{}, &MCPServerList{})
 }


### PR DESCRIPTION
## Summary

This PR refactors the OIDC resolver to use a generic `OIDCConfigurable` interface instead of being tied to `MCPServer` specifically. This makes the resolver more flexible and enables code reuse across different resource types.

This refactoring extracts the generic OIDC resolution logic from PR #2226, making it available for both MCPServer and the future MCPRemoteProxy resource.

## Changes

- **Add `OIDCConfigurable` interface**: Defines methods `GetName()`, `GetNamespace()`, `GetOIDCConfig()`, and `GetPort()` that any resource with OIDC configuration can implement
- **Refactor `Resolve()` method**: Now accepts any `OIDCConfigurable` resource instead of `MCPServer` directly
- **Update helper methods**: `resolveKubernetesConfig()` and `resolveConfigMapConfig()` now accept namespace string parameter instead of full `MCPServer` object
- **Implement interface for MCPServer**: MCPServer now implements `OIDCConfigurable` interface
- **Remove code duplication**: Eliminated duplicate MCPServer-specific resolution methods

## Benefits

1. **Code reuse**: Future resource types (like MCPRemoteProxy from PR #2226) can implement the same interface and use the same resolution logic
2. **Cleaner design**: Separation of concerns - resolver only needs the interface methods, not the full resource object
3. **Backward compatible**: MCPServer controller continues to work unchanged, simply calling `resolver.Resolve(ctx, mcpServer)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)