### PR TITLE
docs: update developer guide to use Go 1.25

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -32,7 +32,7 @@ install Go and set up your development environment.
 
 ### Prerequisites
 
-- **Go**: ToolHive requires Go 1.24. You can download and install Go from the
+- **Go**: ToolHive requires Go 1.25. You can download and install Go from the
   [official Go website](https://go.dev/doc/install).
 
 - **Task** (Recommended): Install the [Task](https://taskfile.dev/) tool to run


### PR DESCRIPTION
### Summary
Updated the developer guide to reference Go 1.25 instead of Go 1.24 for consistency with the current ToolHive version.

### Changes
- Updated Go version in `docs/README.md` (1.24 → 1.25)

### Why
Keeps documentation consistent with the Go version currently used by ToolHive.

Signed-off-by: Mohamed Fawas <fawastmh@gmail.com>
