### PR TITLE
Move defaultAuthzKey constant to common_helpers.go

### DIFF
--- a/cmd/thv-operator/controllers/common_helpers.go
+++ b/cmd/thv-operator/controllers/common_helpers.go
@@ -25,6 +25,10 @@ import (
 	"github.com/stacklok/toolhive/pkg/runner"
 )
 
+const (
+	defaultAuthzKey = "authz.json"
+)
+
 // PlatformDetectorInterface provides platform detection capabilities
 type PlatformDetectorInterface interface {
 	DetectPlatform(ctx context.Context) (kubernetes.Platform, error)

--- a/cmd/thv-operator/controllers/mcpserver_runconfig.go
+++ b/cmd/thv-operator/controllers/mcpserver_runconfig.go
@@ -29,9 +29,6 @@ const defaultProxyHost = "0.0.0.0"
 // defaultAPITimeout is the default timeout for Kubernetes API calls made during reconciliation
 const defaultAPITimeout = 15 * time.Second
 
-// defaultAuthzKey is the default key in the ConfigMap for authorization configuration
-const defaultAuthzKey = "authz.json"
-
 // ensureRunConfigConfigMap ensures the RunConfig ConfigMap exists and is up to date
 func (r *MCPServerReconciler) ensureRunConfigConfigMap(ctx context.Context, m *mcpv1alpha1.MCPServer) error {
 	runConfig, err := r.createRunConfigFromMCPServer(m)


### PR DESCRIPTION
## Summary

Relocates the `defaultAuthzKey` constant from `mcpserver_runconfig.go` to `common_helpers.go` where other shared authorization helpers reside.

This is a pure refactoring change that prepares for code sharing with the upcoming MCPRemoteProxy controller implementation.

## Changes

- Move `defaultAuthzKey` constant to `common_helpers.go`
- Remove duplicate constant from `mcpserver_runconfig.go`

## Test Plan

- [x] Existing tests continue to pass
- [x] No behavioral changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)