### PR TITLE
downgrade go to 1.24 for alignment with UBI

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stacklok/toolhive
 
-go 1.25.2
+go 1.24.6
 
 require (
 	github.com/1password/onepassword-sdk-go v0.3.1


### PR DESCRIPTION
Following our slack discussion, downgrading to 1.24 to better align with UBI 10.