### PR TITLE
Fix chainsaw install for e2e tests task

### DIFF
--- a/cmd/thv-operator/Taskfile.yml
+++ b/cmd/thv-operator/Taskfile.yml
@@ -211,7 +211,7 @@ tasks:
         if [ -z "$CI" ]; then
           if ! command -v chainsaw >/dev/null 2>&1; then
             echo "Chainsaw not found, installing..."
-            go install github.com/kubernetes-sigs/chainsaw/cmd/chainsaw@latest
+            go install github.com/kyverno/chainsaw@latest
           fi
         fi
       - chainsaw test --test-dir test/e2e/chainsaw/operator/multi-tenancy/setup


### PR DESCRIPTION
Fixes the `go install` for chainsaw when running `task operator-e2e-test`. It was pointed to an outdated repo.