### PR TITLE
Clarify file name format for `docs/proposals`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,7 @@ get started. You can find some hints for starting development in ToolHive's
   - [Not sure how to start contributing?](#not-sure-how-to-start-contributing)
   - [Pull request process](#pull-request-process)
   - [Contributing to docs](#contributing-to-docs)
+  - [Contributing to design proposals](#contributing-to-design-proposals)
   - [Commit message guidelines](#commit-message-guidelines)
 
 ## Code of conduct
@@ -78,6 +79,38 @@ Please review the README and
 [STYLE-GUIDE](https://github.com/stacklok/docs-website/blob/main/STYLE-GUIDE.md)
 in the docs-website repository for more information on how to contribute to the
 documentation.
+
+### Contributing to design proposals
+
+Design proposals for ToolHive should be placed in the `docs/proposals/` directory
+and follow a specific naming convention to ensure proper organization and tracking.
+
+#### Proposal file naming format
+
+All proposal files must follow this naming pattern:
+```
+THV-{PR_NUMBER}-{descriptive-name}.md
+```
+
+Where:
+- `THV-` is the required prefix
+- `{PR_NUMBER}` is the pull request number (4 digits)
+- `{descriptive-name}` is a descriptive name in kebab-case
+
+#### Examples of valid proposal names:
+- `THV-1234-new-feature-proposal.md`
+- `THV-5678-api-improvements.md`
+- `THV-9012-authentication-enhancement.md`
+
+#### Proposal content guidelines:
+- Use clear, descriptive titles
+- Include a problem statement at the beginning
+- Add examples where applicable
+- Consider backward compatibility
+- Include migration strategies if needed
+
+The CI system will automatically validate that proposal files follow the correct
+naming convention when they are added or modified in pull requests.
 
 ### Commit message guidelines
 


### PR DESCRIPTION
This adds a short section specifying the file name format for documents under `docs/proposals`.