### PR TITLE
Add MCPGroup CRD documentation to operator architecture

### DIFF
--- a/docs/arch/09-operator-architecture.md
+++ b/docs/arch/09-operator-architecture.md
@@ -104,6 +104,20 @@ Defines a proxy for remote MCP servers with authentication, authorization, audit
 
 **Controller**: `cmd/thv-operator/controllers/mcpremoteproxy_controller.go`
 
+### MCPGroup
+
+Logically groups MCPServer resources together for organizational purposes.
+
+**Implementation**: `cmd/thv-operator/api/v1alpha1/mcpgroup_types.go`
+
+MCPGroup resources allow grouping related MCP servers. Servers reference their group using the `groupRef` field in MCPServer spec. The group tracks member servers in its status.
+
+**Status fields** include phase (Ready, Pending, Failed), list of server names, and server count.
+
+**Referenced by MCPServer** using `spec.groupRef`.
+
+**Controller**: `cmd/thv-operator/controllers/mcpgroup_controller.go`
+
 For complete examples of all CRDs, see the [`examples/operator/mcp-servers/`](../../examples/operator/mcp-servers/) directory.
 
 ## Operator Components


### PR DESCRIPTION
## Summary
- Add missing MCPGroup CRD documentation to operator architecture doc
- Ensures all six operator CRDs are documented

## Details
The MCPGroup custom resource definition was missing from the operator architecture documentation. This PR adds comprehensive documentation for MCPGroup including:

- Purpose: Logically grouping MCPServer resources for organizational purposes
- Implementation references (`mcpgroup_types.go`, `mcpgroup_controller.go`)
- Status fields (phase, server names list, server count)
- How MCPServers reference groups via `spec.groupRef`

## Review checklist
- [x] Documentation accurately reflects implementation in `cmd/thv-operator/api/v1alpha1/mcpgroup_types.go`
- [x] Documentation matches pattern of other CRD sections
- [x] All six CRDs now documented (MCPServer, MCPRegistry, MCPToolConfig, MCPExternalAuthConfig, MCPRemoteProxy, MCPGroup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)