### PR TITLE
Ignore operator tags when releasing thv CLI

### DIFF
--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -47,7 +47,7 @@ jobs:
         run: |
           echo "commit=$GITHUB_SHA" >> $GITHUB_OUTPUT
           echo "commit-date=$(git log --date=iso8601-strict -1 --pretty=%ct)" >> $GITHUB_OUTPUT
-          echo "version=$(git describe --tags --always --dirty)" >> $GITHUB_OUTPUT
+          echo "version=$(git describe --tags --always --dirty --match 'v*')" >> $GITHUB_OUTPUT
           echo "tree-state=$(if git diff --quiet; then echo "clean"; else echo "dirty"; fi)" >> $GITHUB_OUTPUT
   release-binaries:
     needs:


### PR DESCRIPTION
When looking for the `thv` version, only consider tags that start with `v`.