### PR TITLE
Configure chart-testing to install all charts

### DIFF
--- a/ct-install.yaml
+++ b/ct-install.yaml
@@ -1,5 +1,16 @@
+# Configuration for chart-testing (ct) install command
+# See: https://github.com/helm/chart-testing
+
 chart-dirs:
   - deploy/charts
 validate-maintainers: false
 remote: origin
 target-branch: main
+
+# Install all charts, not just changed ones.
+# This is required because the operator chart depends on the operator-crds chart.
+# Without 'all: true', ct only installs charts that have changed in the PR.
+# If a PR only changes the operator chart (not operator-crds), the operator
+# will fail to start because the CRDs are not installed in the test cluster.
+# The operator requires CRDs at startup to create field indexes (e.g., spec.groupRef).
+all: true


### PR DESCRIPTION
## Problem

Helm chart tests are failing for PRs that only modify the operator chart without bumping the operator-crds chart version (e.g., PR #2176).

### Root Cause

By default, `ct install` only installs charts that have changed in a PR. The operator chart has an **implicit dependency** on the operator-crds chart:

1. The operator image contains code that requires CRDs to exist at startup
2. The operator tries to create field indexes for CRD fields (e.g., `MCPServer.Spec.GroupRef` in `cmd/thv-operator/main.go:82-96`)
3. When a PR only modifies the operator chart, `ct install` detects only that chart as changed
4. `ct install` installs ONLY the operator chart (not operator-crds)
5. The operator pod crashes immediately with:
   ```
   unable to retrieve the complete list of server APIs:
   toolhive.stacklok.dev/v1alpha1: no matches for toolhive.stacklok.dev/v1alpha1
   ```

### Why This Happens

The dependency between operator and operator-crds charts is **not declared in Chart.yaml**, so chart-testing doesn't know to install both charts together. This is a common pattern when charts need to be independently versioned but have runtime dependencies.

## Solution

Configure `ct install` to use `all: true`, which tells chart-testing to install **all charts** in the chart directories regardless of which ones changed. This ensures:

- CRDs are always installed before the operator
- Chart tests work for PRs that only modify the operator chart
- No need to manually bump both chart versions together

## Changes

- Added `all: true` to `ct-install.yaml`
- Added comprehensive inline documentation explaining why this is needed

## Testing

This will fix the failing Helm chart tests in PR #2176 and prevent similar issues in the future.

## Alternative Solutions Considered

1. **Declare dependency in Chart.yaml** - Would require setting up chart repositories and complicates local development
2. **Combine charts into one** - Would require significant restructuring
3. **Manual version bumps** (current approach) - Error-prone and not obvious to contributors

The `all: true` approach is the simplest and most maintainable solution for charts with implicit dependencies.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)