### PR TITLE
Increase MCPRemoteProxy readiness probe initial delay to 15 seconds

### DIFF
--- a/cmd/thv-operator/controllers/mcpremoteproxy_deployment.go
+++ b/cmd/thv-operator/controllers/mcpremoteproxy_deployment.go
@@ -60,7 +60,7 @@ func (r *MCPRemoteProxyReconciler) deploymentForMCPRemoteProxy(
 						Resources:       resources,
 						Ports:           r.buildContainerPorts(proxy),
 						LivenessProbe:   ctrlutil.BuildHealthProbe("/health", "http", 30, 10, 5, 3),
-						ReadinessProbe:  ctrlutil.BuildHealthProbe("/health", "http", 5, 5, 3, 3),
+						ReadinessProbe:  ctrlutil.BuildHealthProbe("/health", "http", 15, 5, 3, 3),
 						SecurityContext: containerSecurityContext,
 					}},
 					Volumes:         volumes,


### PR DESCRIPTION
## Summary
Fixes the MCPRemoteProxy CrashLoopBackOff issue by increasing the readiness probe initial delay from 5 seconds to 15 seconds.

## Problem
The MCPRemoteProxy operator was creating deployments with a readiness probe that had an initial delay of only 5 seconds. This was insufficient for the proxy runner to fully initialize, causing health probes to fail with 404 errors and pods to enter CrashLoopBackOff.

## Root Cause
The initialization process requires multiple steps:
- Kubernetes client initialization: 3-5 seconds
- HTTP server startup: 1-2 seconds
- Configuration loading: 1-2 seconds
- Buffer for slower environments: 5-7 seconds

Total initialization time is approximately 10-16 seconds, making the original 5-second delay too short.

## Solution (Phase 1)
This PR implements the immediate Phase 1 fix as recommended in issue #2312 by changing the `InitialDelaySeconds` parameter from 5 to 15 seconds in the readiness probe configuration.

**Changed line:** `cmd/thv-operator/controllers/mcpremoteproxy_deployment.go:63`

```diff
-ReadinessProbe:  ctrlutil.BuildHealthProbe("/health", "http", 5, 5, 3, 3),
+ReadinessProbe:  ctrlutil.BuildHealthProbe("/health", "http", 15, 5, 3, 3),
```

## Benefits
- ✅ Minimal code change (one number)
- ✅ Quick to implement and test
- ✅ Low risk
- ✅ Fixes immediate CrashLoopBackOff issue
- ✅ Safe for backporting to patch releases

## Trade-offs
- Pods take 10 seconds longer to be marked ready
- Doesn't address semantic issue (still checks K8s API unnecessarily for remote proxies)
- Future technical debt

## Future Work (Phase 2)
A more comprehensive solution with separate `/health` (liveness) and `/ready` (readiness) endpoints can be implemented in a future enhancement. This would:
- Check only what actually matters for each probe type
- Enable faster startup for remote proxies (<5s, no K8s API check)
- Be more robust (remote proxies work even if K8s API is degraded)
- Follow Kubernetes best practices

## Testing
- ✅ Linting passed
- ✅ All operator tests passed

## Related
Related-to #2312

🤖 Generated with [Claude Code](https://claude.com/claude-code)