### PR TITLE
Add /health endpoint to all proxy types for Kubernetes health probes

### DIFF
--- a/pkg/transport/proxy/transparent/transparent_proxy.go
+++ b/pkg/transport/proxy/transparent/transparent_proxy.go
@@ -106,11 +106,14 @@ func NewTransparentProxy(
 		transportType:     transportType,
 	}
 
-	// Create MCP pinger and health checker only if enabled
+	// Create health checker always for Kubernetes probes
+	// For remote proxies, pass nil pinger since we can't ping authenticated servers
+	// For local proxies, create pinger to check MCP server status
+	var mcpPinger healthcheck.MCPPinger
 	if enableHealthCheck {
-		mcpPinger := NewMCPPinger(targetURI)
-		proxy.healthChecker = healthcheck.NewHealthChecker("sse", mcpPinger)
+		mcpPinger = NewMCPPinger(targetURI)
 	}
+	proxy.healthChecker = healthcheck.NewHealthChecker(transportType, mcpPinger)
 
 	return proxy
 }


### PR DESCRIPTION
## Summary

Ensures all proxy types (transparent, streamable) expose a `/health` endpoint for Kubernetes readiness and liveness probes. For remote proxies where MCP pinging isn't possible (authenticated servers require user tokens), the health checker is created without a pinger, making it a simple proxy liveness check.

## Changes

- **Transparent Proxy**: Always creates health checker, uses nil pinger for remote servers
- **Streamable Proxy**: Added health checker field and `/health` endpoint handler  
- Fixed hardcoded "sse" transport type to use actual `transportType` parameter

## Why This Matters

Before this change:
- Transparent proxy with remote servers: No `/health` endpoint → 404 errors
- Streamable proxy: No `/health` endpoint at all → 404 errors
- Result: MCPRemoteProxy pods failed health probes and entered CrashLoopBackOff

After this change:
- All proxy types expose `/health` endpoint
- Returns 200 OK if proxy is running
- For remote servers: No MCP ping (can't authenticate without user tokens)
- For local servers: Includes MCP ping status in response

## How It Works

The `HealthChecker` already safely handles nil pinger (`pkg/healthcheck/healthcheck.go:87`):
```go
if hc.mcpPinger != nil {
    mcpStatus := hc.checkMCPStatus(ctx)
    // ...
}
```

When pinger is nil:
- Health check returns 200 OK with `{"status": "healthy"}`
- No MCP status field included
- Simple liveness check for Kubernetes

## Testing

- ✅ Linter passes
- ✅ Unit tests pass
- Addresses issue #2312

## Related

- Fixes #2312
- Complements timing fix in earlier PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)