### PR TITLE
Fix MCPServer and MCPRemoteProxy operator spec change reconciliation

### DIFF
--- a/cmd/thv-operator/controllers/mcpremoteproxy_deployment.go
+++ b/cmd/thv-operator/controllers/mcpremoteproxy_deployment.go
@@ -13,12 +13,13 @@ import (
 
 	mcpv1alpha1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1alpha1"
 	ctrlutil "github.com/stacklok/toolhive/cmd/thv-operator/pkg/controllerutil"
+	"github.com/stacklok/toolhive/cmd/thv-operator/pkg/runconfig/configmap/checksum"
 	"github.com/stacklok/toolhive/pkg/container/kubernetes"
 )
 
 // deploymentForMCPRemoteProxy returns a MCPRemoteProxy Deployment object
 func (r *MCPRemoteProxyReconciler) deploymentForMCPRemoteProxy(
-	ctx context.Context, proxy *mcpv1alpha1.MCPRemoteProxy,
+	ctx context.Context, proxy *mcpv1alpha1.MCPRemoteProxy, runConfigChecksum string,
 ) *appsv1.Deployment {
 	ls := labelsForMCPRemoteProxy(proxy.Name)
 	replicas := int32(1)
@@ -29,7 +30,7 @@ func (r *MCPRemoteProxyReconciler) deploymentForMCPRemoteProxy(
 	env := r.buildEnvVarsForProxy(ctx, proxy)
 	resources := ctrlutil.BuildResourceRequirements(proxy.Spec.Resources)
 	deploymentLabels, deploymentAnnotations := r.buildDeploymentMetadata(ls, proxy)
-	deploymentTemplateLabels, deploymentTemplateAnnotations := r.buildPodTemplateMetadata(ls, proxy)
+	deploymentTemplateLabels, deploymentTemplateAnnotations := r.buildPodTemplateMetadata(ls, proxy, runConfigChecksum)
 	podSecurityContext, containerSecurityContext := r.buildSecurityContexts(ctx, proxy)
 
 	dep := &appsv1.Deployment{
@@ -184,12 +185,23 @@ func (*MCPRemoteProxyReconciler) buildDeploymentMetadata(
 	return deploymentLabels, deploymentAnnotations
 }
 
-// buildPodTemplateMetadata builds pod template labels and annotations
+// buildPodTemplateMetadata builds pod template labels and annotations.
+//
+// The runConfigChecksum parameter must be a non-empty SHA256 hash of the RunConfig.
+// This checksum is added as an annotation to the pod template, which triggers
+// Kubernetes to perform a rolling update when the configuration changes.
+//
+// User-specified overrides from ResourceOverrides.PodTemplateMetadataOverrides
+// are merged after the checksum annotation is set.
 func (*MCPRemoteProxyReconciler) buildPodTemplateMetadata(
-	baseLabels map[string]string, proxy *mcpv1alpha1.MCPRemoteProxy,
+	baseLabels map[string]string, proxy *mcpv1alpha1.MCPRemoteProxy, runConfigChecksum string,
 ) (map[string]string, map[string]string) {
 	templateLabels := baseLabels
 	templateAnnotations := make(map[string]string)
+
+	// Add RunConfig checksum annotation to trigger pod rollout when config changes
+	// This is critical for ensuring pods restart with updated configuration
+	templateAnnotations = checksum.AddRunConfigChecksumToPodTemplate(templateAnnotations, runConfigChecksum)
 
 	if proxy.Spec.ResourceOverrides != nil &&
 		proxy.Spec.ResourceOverrides.ProxyDeployment != nil &&

--- a/cmd/thv-operator/controllers/mcpserver_invalid_podtemplate_reconcile_test.go
+++ b/cmd/thv-operator/controllers/mcpserver_invalid_podtemplate_reconcile_test.go
@@ -216,7 +216,7 @@ func TestDeploymentArgsWithInvalidPodTemplateSpec(t *testing.T) {
 	ctx = log.IntoContext(ctx, log.Log)
 
 	// Call deploymentForMCPServer to check that it handles invalid PodTemplateSpec gracefully
-	deployment := r.deploymentForMCPServer(ctx, mcpServer)
+	deployment := r.deploymentForMCPServer(ctx, mcpServer, "test-checksum")
 
 	// Check that the deployment was created successfully
 	require.NotNil(t, deployment)

--- a/cmd/thv-operator/controllers/mcpserver_platform_test.go
+++ b/cmd/thv-operator/controllers/mcpserver_platform_test.go
@@ -114,7 +114,7 @@ func TestMCPServerReconciler_DeploymentForMCPServer_Kubernetes(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	deployment := reconciler.deploymentForMCPServer(ctx, mcpServer)
+	deployment := reconciler.deploymentForMCPServer(ctx, mcpServer, "test-checksum")
 
 	require.NotNil(t, deployment, "Deployment should not be nil")
 
@@ -186,7 +186,7 @@ func TestMCPServerReconciler_DeploymentForMCPServer_OpenShift(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	deployment := reconciler.deploymentForMCPServer(ctx, mcpServer)
+	deployment := reconciler.deploymentForMCPServer(ctx, mcpServer, "test-checksum")
 
 	require.NotNil(t, deployment, "Deployment should not be nil")
 
@@ -264,7 +264,7 @@ func TestMCPServerReconciler_DeploymentForMCPServer_PlatformDetectionError(t *te
 	}
 
 	ctx := context.Background()
-	deployment := reconciler.deploymentForMCPServer(ctx, mcpServer)
+	deployment := reconciler.deploymentForMCPServer(ctx, mcpServer, "test-checksum")
 
 	require.NotNil(t, deployment, "Deployment should not be nil")
 

--- a/cmd/thv-operator/controllers/mcpserver_pod_template_test.go
+++ b/cmd/thv-operator/controllers/mcpserver_pod_template_test.go
@@ -90,7 +90,7 @@ func TestDeploymentForMCPServerWithPodTemplateSpec(t *testing.T) {
 
 	// Call deploymentForMCPServer
 	ctx := context.Background()
-	deployment := r.deploymentForMCPServer(ctx, mcpServer)
+	deployment := r.deploymentForMCPServer(ctx, mcpServer, "test-checksum")
 	require.NotNil(t, deployment, "Deployment should not be nil")
 
 	// Check if the pod template patch is included in the args
@@ -177,7 +177,7 @@ func TestDeploymentForMCPServerSecretsProviderEnv(t *testing.T) {
 
 	// Call deploymentForMCPServer
 	ctx := context.Background()
-	deployment := r.deploymentForMCPServer(ctx, mcpServer)
+	deployment := r.deploymentForMCPServer(ctx, mcpServer, "test-checksum")
 	require.NotNil(t, deployment, "Deployment should not be nil")
 }
 
@@ -221,7 +221,7 @@ func TestDeploymentForMCPServerWithSecrets(t *testing.T) {
 
 	// Call deploymentForMCPServer
 	ctx := context.Background()
-	deployment := r.deploymentForMCPServer(ctx, mcpServer)
+	deployment := r.deploymentForMCPServer(ctx, mcpServer, "test-checksum")
 	require.NotNil(t, deployment, "Deployment should not be nil")
 
 	// Check that secrets are injected via pod template patch
@@ -317,7 +317,7 @@ func TestProxyRunnerSecurityContext(t *testing.T) {
 
 	// Generate the deployment
 	ctx := context.Background()
-	deployment := r.deploymentForMCPServer(ctx, mcpServer)
+	deployment := r.deploymentForMCPServer(ctx, mcpServer, "test-checksum")
 	require.NotNil(t, deployment, "Deployment should not be nil")
 
 	// Check that the ProxyRunner's pod and container security context are set
@@ -364,7 +364,7 @@ func TestProxyRunnerStructuredLogsEnvVar(t *testing.T) {
 
 	// Create the deployment
 	ctx := context.Background()
-	deployment := r.deploymentForMCPServer(ctx, mcpServer)
+	deployment := r.deploymentForMCPServer(ctx, mcpServer, "test-checksum")
 	require.NotNil(t, deployment, "Deployment should not be nil")
 
 	// Check that the proxy runner container has the UNSTRUCTURED_LOGS environment variable set to false

--- a/cmd/thv-operator/controllers/mcpserver_resource_overrides_test.go
+++ b/cmd/thv-operator/controllers/mcpserver_resource_overrides_test.go
@@ -306,7 +306,7 @@ func TestResourceOverrides(t *testing.T) {
 
 			// Test deployment creation
 			ctx := context.Background()
-			deployment := r.deploymentForMCPServer(ctx, tt.mcpServer)
+			deployment := r.deploymentForMCPServer(ctx, tt.mcpServer, "test-checksum")
 			require.NotNil(t, deployment)
 
 			assert.Equal(t, tt.expectedDeploymentLabels, deployment.Labels)
@@ -564,7 +564,7 @@ func TestDeploymentNeedsUpdateProxyEnv(t *testing.T) {
 
 			// Create a deployment and manually set up its state to isolate proxy env testing
 			ctx := context.Background()
-			deployment := r.deploymentForMCPServer(ctx, tt.mcpServer)
+			deployment := r.deploymentForMCPServer(ctx, tt.mcpServer, "test-checksum")
 			require.NotNil(t, deployment)
 			require.Len(t, deployment.Spec.Template.Spec.Containers, 1)
 
@@ -575,7 +575,7 @@ func TestDeploymentNeedsUpdateProxyEnv(t *testing.T) {
 			deployment.Spec.Template.Spec.Containers[0].Image = getToolhiveRunnerImage()
 
 			// Test if deployment needs update - should correlate with env change expectation
-			needsUpdate := r.deploymentNeedsUpdate(context.Background(), deployment, tt.mcpServer)
+			needsUpdate := r.deploymentNeedsUpdate(context.Background(), deployment, tt.mcpServer, "test-checksum")
 
 			if tt.expectEnvChange {
 				assert.True(t, needsUpdate, "Expected deployment update due to proxy env change")

--- a/cmd/thv-operator/pkg/runconfig/configmap/checksum/checksum.go
+++ b/cmd/thv-operator/pkg/runconfig/configmap/checksum/checksum.go
@@ -2,16 +2,24 @@
 package checksum
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"fmt"
 	"sort"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
 	// ContentChecksumAnnotation is the annotation key used to store the ConfigMap content checksum
 	ContentChecksumAnnotation = "toolhive.stacklok.dev/content-checksum"
+
+	// RunConfigChecksumAnnotation is the annotation key used to store the RunConfig checksum
+	// in pod template annotations to trigger pod restarts when configuration changes
+	RunConfigChecksumAnnotation = "toolhive.stacklok.dev/runconfig-checksum"
 )
 
 // RunConfigConfigMapChecksum provides methods for computing and comparing ConfigMap checksums
@@ -89,4 +97,83 @@ func (r *runConfigConfigMapChecksum) ConfigMapChecksumHasChanged(current, desire
 	}
 
 	return currentChecksum != desiredChecksum
+}
+
+// RunConfigChecksumFetcher provides methods for fetching RunConfig ConfigMap checksums.
+// This is used to detect configuration changes and trigger pod restarts.
+type RunConfigChecksumFetcher struct {
+	client client.Client
+}
+
+// NewRunConfigChecksumFetcher creates a new RunConfigChecksumFetcher
+func NewRunConfigChecksumFetcher(c client.Client) *RunConfigChecksumFetcher {
+	return &RunConfigChecksumFetcher{client: c}
+}
+
+// GetRunConfigChecksum fetches the RunConfig ConfigMap checksum annotation for a resource.
+//
+// This checksum is used to trigger pod restarts when the RunConfig content changes.
+// The function retrieves the checksum from the ConfigMap's annotations and validates
+// that it is non-empty.
+//
+// Parameters:
+//   - ctx: Context for the operation
+//   - namespace: Namespace of the ConfigMap
+//   - resourceName: Name of the resource (used to construct ConfigMap name as "<resourceName>-runconfig")
+//
+// Returns:
+//   - (checksum, nil) on success - checksum is a non-empty SHA256 hex string
+//   - ("", error) on failure - error indicates the specific failure reason
+//
+// The returned error preserves the error type, allowing callers to check for
+// errors.IsNotFound() to handle missing ConfigMaps gracefully during initial creation.
+func (f *RunConfigChecksumFetcher) GetRunConfigChecksum(
+	ctx context.Context,
+	namespace string,
+	resourceName string,
+) (string, error) {
+	if resourceName == "" {
+		return "", fmt.Errorf("resourceName cannot be empty")
+	}
+
+	configMapName := fmt.Sprintf("%s-runconfig", resourceName)
+	configMap := &corev1.ConfigMap{}
+	err := f.client.Get(ctx, types.NamespacedName{Name: configMapName, Namespace: namespace}, configMap)
+	if err != nil {
+		// Return the specific error type so caller can check for IsNotFound
+		return "", fmt.Errorf("failed to get RunConfig ConfigMap %s/%s: %w", namespace, configMapName, err)
+	}
+
+	checksum, ok := configMap.Annotations[ContentChecksumAnnotation]
+	if !ok {
+		return "", fmt.Errorf("RunConfig ConfigMap %s/%s missing %s annotation",
+			namespace, configMapName, ContentChecksumAnnotation)
+	}
+
+	if checksum == "" {
+		return "", fmt.Errorf("RunConfig ConfigMap %s/%s has empty %s annotation",
+			namespace, configMapName, ContentChecksumAnnotation)
+	}
+
+	return checksum, nil
+}
+
+// AddRunConfigChecksumToPodTemplate adds the RunConfig checksum as an annotation
+// to the provided annotations map. This triggers Kubernetes to perform a rolling
+// update when the checksum changes.
+//
+// If the checksum is empty, no annotation is added. This allows callers to
+// gracefully handle cases where the checksum is not yet available.
+//
+// Returns the updated annotations map.
+func AddRunConfigChecksumToPodTemplate(annotations map[string]string, checksum string) map[string]string {
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+
+	if checksum != "" {
+		annotations[RunConfigChecksumAnnotation] = checksum
+	}
+
+	return annotations
 }


### PR DESCRIPTION
## Summary

Fixes #2314 - Both MCPServer and MCPRemoteProxy operators were not properly reconciling spec changes, requiring users to delete and recreate resources to apply configuration updates. This PR adds ConfigMap checksum tracking to pod template annotations to trigger automatic rolling updates when configuration changes.

## Changes

- Created shared `RunConfigChecksumFetcher` in `pkg/controllerutil` for consistent checksum handling
- Add RunConfig ConfigMap checksum to pod template annotations for both operators
- Trigger automatic pod restarts when configuration changes via Kubernetes rolling updates
- Add constants for checksum annotation keys (`toolhive.stacklok.dev/runconfig-checksum`, `toolhive.stacklok.dev/content-checksum`)
- Refactor `deploymentNeedsUpdate()` in both controllers to properly check pod template annotations
- Add comprehensive error handling and nil guards
- Handle ConfigMap not found during initial creation gracefully with 5-second requeue
- Update all tests to pass checksum parameter

## How It Works

1. **ConfigMap Checksum**: When RunConfig ConfigMap is created/updated, a SHA256 checksum is computed and stored as an annotation
2. **Pod Template Annotation**: The checksum is fetched and added to the pod template annotations
3. **Kubernetes Rolling Update**: When the checksum changes, Kubernetes detects the pod template change and performs a rolling update
4. **Declarative Updates**: Users can now update the spec and changes will propagate automatically

## Impact

- Enables declarative GitOps workflows for MCP resources
- Configuration changes (OIDC config, authz policies, telemetry, tool filters, image, etc.) now properly propagate to running pods
- Eliminates need to delete/recreate resources for config updates
- Follows standard Kubernetes operator patterns

## Test Plan

- [x] Unit tests pass
- [x] Linter passes with 0 issues
- [x] Reviewed by kubernetes-expert agent
- [x] Reviewed by toolhive-expert agent  
- [x] Reviewed by code-reviewer agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)