### PR TITLE
Add environment variable support for OIDC client secret

### DIFF
--- a/pkg/auth/token.go
+++ b/pkg/auth/token.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -539,6 +540,14 @@ func NewTokenValidator(ctx context.Context, config TokenValidatorConfig) (*Token
 	if config.IntrospectionURL == GoogleTokeninfoURL {
 		logger.Debugf("Registering Google tokeninfo provider: %s", config.IntrospectionURL)
 		registry.AddProvider(NewGoogleProvider(config.IntrospectionURL))
+	}
+
+	// Load client secret from environment variable if not provided in config
+	// This allows secrets to be injected via Kubernetes Secret references
+	if config.ClientSecret == "" {
+		if envSecret := os.Getenv("TOOLHIVE_OIDC_CLIENT_SECRET"); envSecret != "" {
+			config.ClientSecret = envSecret
+		}
 	}
 
 	// Add RFC7662 provider with auth if configured


### PR DESCRIPTION
## Summary

Add support for loading OIDC client secret from `TOOLHIVE_OIDC_CLIENT_SECRET` environment variable in the token validator. This is preparatory work for Kubernetes-native secret injection via SecretKeyRef.

## Changes

- ✅ Added `os` import to `pkg/auth/token.go`
- ✅ Added environment variable fallback in `NewTokenValidator()`
- ✅ Loads from `TOOLHIVE_OIDC_CLIENT_SECRET` when `config.ClientSecret` is empty

## Behavior

**Backward Compatible:**
- If environment variable is not set → uses `config.ClientSecret` as before
- If `config.ClientSecret` is set → uses that value (no change)
- If `config.ClientSecret` is empty AND env var is set → uses env var value

**Use Case:**
This enables Kubernetes operators to inject OIDC client secrets via environment variables sourced from Kubernetes Secrets, without embedding secrets in ConfigMaps or YAML manifests.

## Testing

- ✅ No functional change when environment variable is not set
- ✅ All existing tests pass
- ✅ Linter passes

## Follow-up Work

This is **Part 1 of 2** for implementing #2321:
- **Part 1** (this PR): Runtime support for environment variable
- **Part 2** (#2324): CRD changes, controller integration, and full SecretKeyRef support

Part 2 will add:
- `ClientSecretRef` field to `InlineOIDCConfig` CRD
- Controller logic to inject secrets via environment variables
- Examples and documentation

## Related

Related to #2321

🤖 Generated with [Claude Code](https://claude.com/claude-code)