### PR TITLE
Fix server port when network mode is `host`

### DIFF
--- a/pkg/container/docker/client_final_port_linux.go
+++ b/pkg/container/docker/client_final_port_linux.go
@@ -1,0 +1,10 @@
+//go:build linux
+
+package docker
+
+func calculateFinalPort(hostPort int, firstPortInt int, networkName string) int {
+	if networkName == "host" {
+		return firstPortInt
+	}
+	return hostPort
+}

--- a/pkg/container/docker/client_final_port_other.go
+++ b/pkg/container/docker/client_final_port_other.go
@@ -1,0 +1,7 @@
+//go:build !linux
+
+package docker
+
+func calculateFinalPort(hostPort int, _ int, _ string) int {
+	return hostPort
+}

--- a/pkg/transport/http.go
+++ b/pkg/transport/http.go
@@ -321,8 +321,12 @@ func (t *HTTPTransport) Start(ctx context.Context) error {
 
 	// Create the transparent proxy
 	t.proxy = transparent.NewTransparentProxy(
-		t.host, t.proxyPort, t.containerName, targetURI,
-		t.prometheusHandler, t.authInfoHandler,
+		t.host,
+		t.proxyPort,
+		t.containerName,
+		targetURI,
+		t.prometheusHandler,
+		t.authInfoHandler,
 		t.remoteURL == "",
 		t.remoteURL != "",
 		string(t.transportType),


### PR DESCRIPTION
Docker networking works differently depending on whether it's running inside a VM or on the (linux) host itself, with VM-based installations like Docker Desktop not supporting `host` network. What happens is that the port is exposed on the VM rather than the actual host. Note that this is the case for linux running Docker Desktop.

On the other hand, Docker Engine installations work just fine on linux, but we were still configuring the Proxy to try to connect to the wrong port.

This is PR assumes that
* all linux installations run docker engine
* all non-linux installations run on VMs

Fixes #2317 