### PR TITLE
Return tools_override in workload GET endpoint

### DIFF
--- a/pkg/api/v1/workload_types.go
+++ b/pkg/api/v1/workload_types.go
@@ -228,6 +228,18 @@ func runConfigToCreateRequest(runConfig *runner.RunConfig) *createRequest {
 
 	authzConfigPath := ""
 
+	// Convert ToolsOverride from runner.ToolOverride to API toolOverride
+	var toolsOverride map[string]toolOverride
+	if runConfig.ToolsOverride != nil {
+		toolsOverride = make(map[string]toolOverride, len(runConfig.ToolsOverride))
+		for key, override := range runConfig.ToolsOverride {
+			toolsOverride[key] = toolOverride{
+				Name:        override.Name,
+				Description: override.Description,
+			}
+		}
+	}
+
 	return &createRequest{
 		updateRequest: updateRequest{
 			Image:             runConfig.Image,
@@ -246,6 +258,7 @@ func runConfigToCreateRequest(runConfig *runner.RunConfig) *createRequest {
 			NetworkIsolation:  runConfig.IsolateNetwork,
 			TrustProxyHeaders: runConfig.TrustProxyHeaders,
 			ToolsFilter:       runConfig.ToolsFilter,
+			ToolsOverride:     toolsOverride,
 			Group:             runConfig.Group,
 			URL:               runConfig.RemoteURL,
 			OAuthConfig:       oAuthConfig,

--- a/pkg/api/v1/workloads_types_test.go
+++ b/pkg/api/v1/workloads_types_test.go
@@ -246,6 +246,33 @@ func TestRunConfigToCreateRequest(t *testing.T) {
 		assert.Empty(t, result.Secrets)
 	})
 
+	t.Run("with tools override", func(t *testing.T) {
+		t.Parallel()
+
+		runConfig := &runner.RunConfig{
+			Name: "test-workload",
+			ToolsOverride: map[string]runner.ToolOverride{
+				"fetch": {
+					Name:        "fetch_custom",
+					Description: "Custom fetch description",
+				},
+				"read": {
+					Name: "read_file",
+				},
+			},
+		}
+
+		result := runConfigToCreateRequest(runConfig)
+
+		require.NotNil(t, result)
+		require.NotNil(t, result.ToolsOverride)
+		assert.Len(t, result.ToolsOverride, 2)
+		assert.Equal(t, "fetch_custom", result.ToolsOverride["fetch"].Name)
+		assert.Equal(t, "Custom fetch description", result.ToolsOverride["fetch"].Description)
+		assert.Equal(t, "read_file", result.ToolsOverride["read"].Name)
+		assert.Empty(t, result.ToolsOverride["read"].Description)
+	})
+
 	t.Run("nil runConfig", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
The GET endpoint for workloads was not returning the tools_override field even though it was being stored and applied correctly. This was because the runConfigToCreateRequest function was missing the logic to copy the ToolsOverride field from RunConfig to the API response.

Added conversion logic to map runConfig.ToolsOverride to the API's toolsOverride format in the runConfigToCreateRequest function, along with a test case to ensure it works correctly.

Fixes #2385