### PR TITLE
Handle partial flushes in tool config middleware

### DIFF
--- a/pkg/mcp/tool_middleware_test.go
+++ b/pkg/mcp/tool_middleware_test.go
@@ -3,8 +3,11 @@ package mcp
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -105,6 +108,23 @@ func TestNewListToolsMappingMiddleware_Scenarios(t *testing.T) {
 				testkit.WithTool("Foo", "Foo tool", func() string { return "Foo" }),
 				//nolint:goconst
 				testkit.WithTool("Bar", "Bar tool", func() string { return "Bar" }),
+			},
+			opts: &[]ToolMiddlewareOption{
+				WithToolsFilter("MyFoo"),
+				WithToolsOverride("Foo", "MyFoo", ""),
+			},
+			expected: &[]map[string]any{
+				{"name": "MyFoo", "description": "Foo tool"},
+			},
+		},
+		{
+			name: "Filter MyFoo, Override Foo -> MyFoo with connection hang",
+			serverOpts: []testkit.TestMCPServerOption{
+				//nolint:goconst
+				testkit.WithTool("Foo", "Foo tool", func() string { return "Foo" }),
+				//nolint:goconst
+				testkit.WithTool("Bar", "Bar tool", func() string { return "Bar" }),
+				testkit.WithConnectionHang(10 * time.Second),
 			},
 			opts: &[]ToolMiddlewareOption{
 				WithToolsFilter("MyFoo"),
@@ -609,4 +629,59 @@ func TestNewToolCallMappingMiddleware_ErrorCases(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNewListToolsMappingMiddleware_ConnectionHang(t *testing.T) {
+	t.Parallel()
+	middlewares := []func(http.Handler) http.Handler{}
+
+	opts := []ToolMiddlewareOption{
+		WithToolsFilter("MyFoo"),
+		WithToolsOverride("Foo", "MyFoo", ""),
+	}
+
+	// Create the middleware
+	toolsListmiddleware, err := NewListToolsMappingMiddleware(opts...)
+	assert.NoError(t, err)
+	toolsCallMiddleware, err := NewToolCallMappingMiddleware(opts...)
+	assert.NoError(t, err)
+
+	middlewares = append(middlewares,
+		toolsCallMiddleware,
+		toolsListmiddleware,
+	)
+
+	// Create test server
+	serverOpts := []testkit.TestMCPServerOption{
+		testkit.WithSSEClientType(),
+		testkit.WithConnectionHang(10 * time.Second),
+		testkit.WithMiddlewares(middlewares...),
+		testkit.WithWithProxy(),
+		testkit.WithTool("Foo", "Foo tool", func() string { return "Foo" }),
+	}
+
+	for i := 0; i < 100; i++ {
+		opt := testkit.WithTool(
+			fmt.Sprintf("Foo%d", i),
+			strings.Repeat("A", 10*1024),
+			func() string { return fmt.Sprintf("Foo%d", i) },
+		)
+		serverOpts = append(serverOpts, opt)
+	}
+
+	server, client, err := testkit.NewStreamableTestServer(
+		serverOpts...,
+	)
+	require.NoError(t, err)
+	defer server.Close()
+
+	// Make request
+	respBody, err := client.ToolsList()
+	require.NoError(t, err)
+
+	var response toolsListResponse
+	err = json.NewDecoder(bytes.NewReader(respBody)).Decode(&response)
+	require.NoError(t, err)
+	require.NotNil(t, response.Result)
+	require.NotNil(t, response.Result.Tools)
 }

--- a/test/testkit/testkit.go
+++ b/test/testkit/testkit.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"time"
 )
 
 const (
@@ -57,6 +58,8 @@ type TestMCPServer interface {
 	SetMiddlewares(middlewares ...func(http.Handler) http.Handler) error
 	AddTool(tool tooldef) error
 	SetClientType(clientType clientType) error
+	SetWithProxy() error
+	SetConnectionHang(duration time.Duration) error
 }
 
 // TestMCPServerOption is a function that can be used to configure a test MCP server.
@@ -105,6 +108,22 @@ func WithJSONClientType() TestMCPServerOption {
 func WithSSEClientType() TestMCPServerOption {
 	return func(s TestMCPServer) error {
 		return s.SetClientType(clientTypeSSE)
+	}
+}
+
+// WithWithProxy configures the test MCP server to stay behind a reverse proxy.
+func WithWithProxy() TestMCPServerOption {
+	return func(s TestMCPServer) error {
+		return s.SetWithProxy()
+	}
+}
+
+// WithConnectionHang configures the test MCP server to hang the connection
+// after sending the tools list response. This is useful to test the client's
+// ability to handle a hanging connection.
+func WithConnectionHang(duration time.Duration) TestMCPServerOption {
+	return func(s TestMCPServer) error {
+		return s.SetConnectionHang(duration)
 	}
 }
 


### PR DESCRIPTION
Tool config middleware implicitly assumed that `Flush()` was only called once a full SSE event was received by the proxy. While testing remote servers we encountered a scenario in which a very long `tools/list` (~80kb) caused golang reverse proxy implementation to run `Flush()` more than once on partial SSE payloads.

Golang standard library code that triggered the bug is here https://github.com/golang/go/blob/go1.25.0/src/net/http/httputil/reverseproxy.go#L708-L711

This change checks whether the SSE event is fully buffered, and keeps buffering otherwise. It also ships an `testkit` enhancement that lets the test developer wrap the test MCP server in a reverse proxy. Ideally, we would use the same reverse proxy used by ToolHive itself, but it's tightly coupled with container orchestrator and requires refactoring.

Fixes #2403