### PR TITLE
Fix race condition in operator git tests

### DIFF
--- a/cmd/thv-operator/pkg/git/client_test.go
+++ b/cmd/thv-operator/pkg/git/client_test.go
@@ -1,8 +1,10 @@
 package git
 
 import (
-	"context"
 	"testing"
+
+	"github.com/go-logr/logr"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 func TestNewDefaultGitClient(t *testing.T) {
@@ -21,7 +23,7 @@ func TestNewDefaultGitClient(t *testing.T) {
 func TestDefaultGitClient_Clone_InvalidURL(t *testing.T) {
 	t.Parallel()
 	client := NewDefaultGitClient()
-	ctx := context.Background()
+	ctx := log.IntoContext(t.Context(), logr.Discard())
 
 	config := &CloneConfig{
 		URL: "invalid-url",
@@ -39,7 +41,7 @@ func TestDefaultGitClient_Clone_InvalidURL(t *testing.T) {
 func TestDefaultGitClient_Clone_NonExistentRepo(t *testing.T) {
 	t.Parallel()
 	client := NewDefaultGitClient()
-	ctx := context.Background()
+	ctx := log.IntoContext(t.Context(), logr.Discard())
 
 	config := &CloneConfig{
 		URL: "https://github.com/nonexistent/nonexistent.git",
@@ -58,7 +60,7 @@ func TestDefaultGitClient_Cleanup_NilRepoInfo(t *testing.T) {
 	t.Parallel()
 	client := NewDefaultGitClient()
 
-	err := client.Cleanup(context.Background(), nil)
+	err := client.Cleanup(log.IntoContext(t.Context(), logr.Discard()), nil)
 	if err == nil {
 		t.Errorf("Expected error for nil repoInfo, got nil")
 	}
@@ -71,7 +73,7 @@ func TestDefaultGitClient_Cleanup_NilRepository(t *testing.T) {
 		Repository: nil,
 	}
 
-	err := client.Cleanup(context.Background(), repoInfo)
+	err := client.Cleanup(log.IntoContext(t.Context(), logr.Discard()), repoInfo)
 	if err == nil {
 		t.Errorf("Expected error for nil repository, got nil")
 	}

--- a/cmd/thv-operator/pkg/git/commit_test.go
+++ b/cmd/thv-operator/pkg/git/commit_test.go
@@ -1,8 +1,10 @@
 package git
 
 import (
-	"context"
 	"testing"
+
+	"github.com/go-logr/logr"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // TestDefaultGitClient_CloneSpecificCommit_RealRepo tests cloning a specific commit from a real repository
@@ -13,7 +15,7 @@ func TestDefaultGitClient_CloneSpecificCommit_RealRepo(t *testing.T) {
 	}
 
 	client := NewDefaultGitClient()
-	ctx := context.Background()
+	ctx := log.IntoContext(t.Context(), logr.Discard())
 
 	// Test with a known commit from a public repository
 	config := &CloneConfig{
@@ -37,7 +39,7 @@ func TestDefaultGitClient_CloneSpecificCommit_RealRepo(t *testing.T) {
 	}
 
 	// Clean up
-	err = client.Cleanup(context.Background(), repoInfo)
+	err = client.Cleanup(ctx, repoInfo)
 	if err != nil {
 		t.Fatalf("Failed to cleanup: %v", err)
 	}
@@ -51,7 +53,7 @@ func TestDefaultGitClient_CloneInvalidCommit(t *testing.T) {
 	}
 
 	client := NewDefaultGitClient()
-	ctx := context.Background()
+	ctx := log.IntoContext(t.Context(), logr.Discard())
 
 	// Test with an invalid commit hash
 	config := &CloneConfig{
@@ -63,7 +65,7 @@ func TestDefaultGitClient_CloneInvalidCommit(t *testing.T) {
 	if err == nil {
 		t.Error("Expected error for invalid commit hash, got nil")
 		if repoInfo != nil {
-			client.Cleanup(context.Background(), repoInfo)
+			client.Cleanup(ctx, repoInfo)
 		}
 	}
 

--- a/cmd/thv-operator/pkg/git/integration_test.go
+++ b/cmd/thv-operator/pkg/git/integration_test.go
@@ -1,7 +1,6 @@
 package git
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -9,6 +8,8 @@ import (
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/go-logr/logr"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 const (
@@ -62,13 +63,14 @@ func TestDefaultGitClient_FullWorkflow(t *testing.T) {
 
 	// Test the full workflow
 	client := NewDefaultGitClient()
+	ctx := log.IntoContext(t.Context(), logr.Discard())
 
 	// Clone the repository
 	config := &CloneConfig{
 		URL: sourceRepoDir, // Use local path for testing
 	}
 
-	repoInfo, err := client.Clone(context.Background(), config)
+	repoInfo, err := client.Clone(ctx, config)
 	if err != nil {
 		t.Fatalf("Failed to clone repository: %v", err)
 	}
@@ -97,7 +99,7 @@ func TestDefaultGitClient_FullWorkflow(t *testing.T) {
 	}
 
 	// Test Cleanup
-	err = client.Cleanup(context.Background(), repoInfo)
+	err = client.Cleanup(ctx, repoInfo)
 	if err != nil {
 		t.Fatalf("Failed to cleanup: %v", err)
 	}
@@ -180,12 +182,13 @@ func TestDefaultGitClient_CloneWithBranch(t *testing.T) {
 
 	// Clone the feature branch
 	client := NewDefaultGitClient()
+	ctx := log.IntoContext(t.Context(), logr.Discard())
 	config := &CloneConfig{
 		URL:    sourceRepoDir,
 		Branch: "feature",
 	}
 
-	repoInfo, err := client.Clone(context.Background(), config)
+	repoInfo, err := client.Clone(ctx, config)
 	if err != nil {
 		t.Fatalf("Failed to clone feature branch: %v", err)
 	}
@@ -209,7 +212,7 @@ func TestDefaultGitClient_CloneWithBranch(t *testing.T) {
 	}
 
 	// Clean up
-	err = client.Cleanup(context.Background(), repoInfo)
+	err = client.Cleanup(ctx, repoInfo)
 	if err != nil {
 		t.Fatalf("Failed to cleanup: %v", err)
 	}
@@ -282,12 +285,13 @@ func TestDefaultGitClient_CloneWithCommit(t *testing.T) {
 
 	// Clone at the first commit
 	client := NewDefaultGitClient()
+	ctx := log.IntoContext(t.Context(), logr.Discard())
 	config := &CloneConfig{
 		URL:    sourceRepoDir,
 		Commit: firstCommit.String(),
 	}
 
-	repoInfo, err := client.Clone(context.Background(), config)
+	repoInfo, err := client.Clone(ctx, config)
 	if err != nil {
 		t.Fatalf("Failed to clone at specific commit: %v", err)
 	}
@@ -308,7 +312,7 @@ func TestDefaultGitClient_CloneWithCommit(t *testing.T) {
 	}
 
 	// Clean up
-	err = client.Cleanup(context.Background(), repoInfo)
+	err = client.Cleanup(ctx, repoInfo)
 	if err != nil {
 		t.Fatalf("Failed to cleanup: %v", err)
 	}


### PR DESCRIPTION
## Summary
Fixes a race condition detected in operator git tests when running with `t.Parallel()` and the race detector.

## Root Cause
Parallel tests were calling `log.FromContext(ctx)` in the `Cleanup` method with contexts created by `context.Background()` that lacked loggers. This caused controller-runtime to attempt initializing a global root logger from multiple goroutines simultaneously, triggering race conditions.

## Solution
Replaced all `context.Background()` calls in parallel tests with properly initialized contexts containing a test logger:
- `log.IntoContext(t.Context(), logr.Discard())`

This ensures each test has its own logger in the context, preventing concurrent access to global logger initialization.

## Files Modified
- `pkg/git/commit_test.go` - Fixed 2 test functions
- `pkg/git/client_test.go` - Fixed 4 test functions
- `pkg/git/integration_test.go` - Fixed 3 test functions

## Testing
All 26 tests now pass with `-race` flag enabled and `t.Parallel()` working correctly:
```bash
go test -v -race ./pkg/git/...
```

No warnings, no race conditions detected.

## Test plan
- [x] All existing tests pass with race detector
- [x] Tests continue to run in parallel (`t.Parallel()`)
- [x] No logger initialization warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)