### PR TITLE
Add HTTP header validation to prevent injection

### DIFF
--- a/pkg/validation/validation_test.go
+++ b/pkg/validation/validation_test.go
@@ -1,6 +1,7 @@
 package validation_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -53,6 +54,89 @@ func TestValidateGroupName(t *testing.T) {
 				assert.Error(t, err, "Expected error for input: %q", tc.input)
 			} else {
 				assert.NoError(t, err, "Did not expect error for input: %q", tc.input)
+			}
+		})
+	}
+}
+
+func TestValidateHTTPHeaderName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		input     string
+		expectErr bool
+	}{
+		// Valid cases
+		{"valid simple", "X-API-Key", false},
+		{"valid authorization", "Authorization", false},
+		{"valid with numbers", "X-API-Key-123", false},
+		{"valid with dots", "X.Custom.Header", false},
+
+		// CRLF injection attacks
+		{"crlf injection", "X-API-Key\r\nX-Injected: malicious", true},
+		{"newline injection", "X-API-Key\nInjected", true},
+		{"carriage return", "X-API-Key\r", true},
+
+		// Other invalid characters
+		{"null byte", "X-API-Key\x00", true},
+		{"contains space", "X API Key", true},
+		{"empty string", "", true},
+
+		// Length limits
+		{"too long", strings.Repeat("A", 300), true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := validation.ValidateHTTPHeaderName(tt.input)
+			if tt.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateHTTPHeaderValue(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		input     string
+		expectErr bool
+	}{
+		// Valid cases
+		{"valid simple", "my-api-key-12345", false},
+		{"valid with spaces", "Bearer token123", false},
+		{"valid special chars", "key!@#$%^&*()", false},
+
+		// CRLF injection attacks
+		{"crlf injection", "key\r\nX-Injected: malicious", true},
+		{"newline injection", "key\ninjected", true},
+		{"carriage return", "key\r", true},
+
+		// Control characters
+		{"null byte", "key\x00value", true},
+		{"control char", "key\x01value", true},
+		{"delete char", "key\x7Fvalue", true},
+		{"tab allowed", "key\tvalue", false}, // Tab is allowed in values
+
+		// Length limits
+		{"too long", strings.Repeat("A", 10000), true},
+		{"empty string", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := validation.ValidateHTTPHeaderValue(tt.input)
+			if tt.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
 			}
 		})
 	}


### PR DESCRIPTION
Add ValidateHTTPHeaderName and ValidateHTTPHeaderValue functions to the validation package to prevent CRLF injection and other header-based attacks. These functions use golang.org/x/net/http/httpguts for RFC 7230 compliant validation, matching Go's own HTTP/2 implementation.

The validation checks for:
- CRLF injection attempts (\r\n)
- Control characters (null bytes, etc.)
- RFC 7230 token compliance for header names
- Length limits (256 bytes for names, 8KB for values)