### PR TITLE
Support MCP servers with partial capabilities in vmcp

### DIFF
--- a/pkg/vmcp/client/client_test.go
+++ b/pkg/vmcp/client/client_test.go
@@ -43,6 +43,37 @@ func TestHTTPBackendClient_ListCapabilities_WithMockFactory(t *testing.T) {
 	})
 }
 
+func TestQueryHelpers_PartialCapabilities(t *testing.T) {
+	t.Parallel()
+
+	t.Run("queryTools with unsupported capability returns empty slice", func(t *testing.T) {
+		t.Parallel()
+
+		result, err := queryTools(context.Background(), nil, false, "test-backend")
+		require.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.Empty(t, result.Tools)
+	})
+
+	t.Run("queryResources with unsupported capability returns empty slice", func(t *testing.T) {
+		t.Parallel()
+
+		result, err := queryResources(context.Background(), nil, false, "test-backend")
+		require.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.Empty(t, result.Resources)
+	})
+
+	t.Run("queryPrompts with unsupported capability returns empty slice", func(t *testing.T) {
+		t.Parallel()
+
+		result, err := queryPrompts(context.Background(), nil, false, "test-backend")
+		require.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.Empty(t, result.Prompts)
+	})
+}
+
 func TestDefaultClientFactory_UnsupportedTransport(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Fix vmcp to support MCP servers that implement only a subset of capabilities (tools, resources, prompts), per the MCP specification.

Previously, vmcp unconditionally queried all three capabilities from every backend, causing it to reject backends like oci-registry that only implement tools.

## Changes

- Query `ServerCapabilities` during MCP initialization handshake
- Conditionally query only capabilities advertised by the backend
- Return empty results for unsupported capabilities instead of errors
- Add test coverage for backends with partial capability support

## Impact

- oci-registry (tools-only) now successfully aggregates: **105 tools** (was 101)
- All 3 backends in the demo group now connect successfully (was 2/3)
- Complies with MCP spec that makes all capabilities optional

## Test Results

```
✓ All tests pass (pkg/vmcp/client)
✓ Linting clean
✓ Verified with live oci-registry, fetch, and github backends
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)