### PR TITLE
Update ubi golang builder to 1.25.z via epel10 copr repo.

### DIFF
--- a/containers/operator/Dockerfile
+++ b/containers/operator/Dockerfile
@@ -1,7 +1,13 @@
 # Build the binary
-FROM registry.access.redhat.com/ubi10/go-toolset:1.24 as builder
+FROM registry.access.redhat.com/ubi10/ubi:10.0 as builder
 
 USER root
+
+# As per https://discussion.fedoraproject.org/t/fedora-doesnt-provide-latest-version-of-go/146930/9
+WORKDIR /etc/yum.repos.d
+RUN dnf install -y wget
+RUN wget https://copr.fedorainfracloud.org/coprs/g/go-sig/golang-rawhide/repo/epel-10/group_go-sig-golang-rawhide-epel-10.repo
+RUN dnf install -y golang
 
 WORKDIR /workspace
 


### PR DESCRIPTION
As per yesterdays 'Go Vulnerability Check' job during this [ToolHive github action](https://github.com/stacklok/toolhive/actions/runs/18936006564/job/54062921437) run there are a number of golang vulnerabilities impacting 1.24.6 through 1.24.8 and resolved in >= 1.24.9 / >= 1.25.3.

As ubi has a slow golang update cadence as per the [Fedora doesn’t provide latest version of Go](https://discussion.fedoraproject.org/t/fedora-doesnt-provide-latest-version-of-go/146930/9) discussion, updating directly from the [Fedora go-sig copr](https://copr.fedorainfracloud.org/coprs/g/go-sig/golang-rawhide) for now as a workaround until the ubi go-toolset is updated.