### PR TITLE
fix: switch operator micro ubi variant to minimal variant for missing certs

### DIFF
--- a/containers/operator/Dockerfile
+++ b/containers/operator/Dockerfile
@@ -29,7 +29,7 @@ RUN CGO_ENABLED=0 LDFLAGS="-s -w \
 GOOS=linux GOARCH=amd64 go build -ldflags "${LDFLAGS}" -o main ./${CODEDIR}/main.go
 
 # Use micro base image to package the binary
-FROM  --platform=linux/amd64 registry.access.redhat.com/ubi10/ubi-micro:10.0
+FROM  --platform=linux/amd64 registry.access.redhat.com/ubi10/ubi-minimal:10.0
 
 COPY --from=builder /workspace/main /
 COPY LICENSE /licenses/LICENSE


### PR DESCRIPTION
The micro variant of UBI is missing the certs existing in the minimal variant, these certs are required for the telemetry service and produce the following error when missing:

```
{"level":"error","ts":1761771396.9468894,"caller":"telemetry/telemetry.go:231","msg":"Failed initial telemetry check","error":"failed to check for updates: failed to send request to update API: Get \"https://updates.stacklok.com/api/v1/version\": tls: failed to verify certificate: x509: certificate signed by unknown authority","stacktrace":"github.com/stacklok/toolhive/pkg/operator/telemetry.(*Service).StartTelemetryWorker\n\t/workspace/pkg/operator/telemetry/telemetry.go:231\ngithub.com/stacklok/toolhive/pkg/operator/telemetry.(*LeaderTelemetryRunnable).Start.func1\n\t/workspace/pkg/operator/telemetry/telemetry.go:58"}
```

I've confirmed the error is not logged when using the minimal variant of UBI.