### PR TITLE
Decouple transport from runtime

### DIFF
--- a/cmd/thv/app/proxy.go
+++ b/cmd/thv/app/proxy.go
@@ -253,8 +253,11 @@ func proxyCmdFunc(cmd *cobra.Command, args []string) error {
 
 	// Create the transparent proxy with middlewares
 	proxy := transparent.NewTransparentProxy(
-		proxyHost, port, serverName, proxyTargetURI,
-		nil, authInfoHandler,
+		proxyHost,
+		port,
+		proxyTargetURI,
+		nil,
+		authInfoHandler,
 		false,
 		false, // isRemote
 		"",

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stacklok/toolhive/pkg/labels"
 	"github.com/stacklok/toolhive/pkg/logger"
 	"github.com/stacklok/toolhive/pkg/process"
+	"github.com/stacklok/toolhive/pkg/runtime"
 	"github.com/stacklok/toolhive/pkg/secrets"
 	"github.com/stacklok/toolhive/pkg/telemetry"
 	"github.com/stacklok/toolhive/pkg/transport"
@@ -137,11 +138,6 @@ func (r *Runner) Run(ctx context.Context) error {
 	// Set proxy mode for stdio transport
 	transportConfig.ProxyMode = r.Config.ProxyMode
 
-	transportHandler, err := transport.NewFactory().Create(transportConfig)
-	if err != nil {
-		return fmt.Errorf("failed to create transport: %v", err)
-	}
-
 	// Process secrets if provided (regular secrets or RemoteAuthConfig.ClientSecret in CLI format)
 	hasRegularSecrets := len(r.Config.Secrets) > 0
 	hasRemoteAuthSecret := r.Config.RemoteAuthConfig != nil && r.Config.RemoteAuthConfig.ClientSecret != ""
@@ -175,7 +171,48 @@ func (r *Runner) Run(ctx context.Context) error {
 	// Set up the transport
 	logger.Infof("Setting up %s transport...", r.Config.Transport)
 
-	// For remote MCP servers, set the remote URL on HTTP transports before setup
+	// Prepare transport options based on workload type
+	var transportOpts []transport.Option
+	var setupResult *runtime.SetupResult
+
+	if r.Config.RemoteURL == "" {
+		// For local workloads, deploy the container using runtime.Setup first
+		result, err := runtime.Setup(
+			ctx,
+			r.Config.Transport,
+			r.Config.Deployer,
+			r.Config.ContainerName,
+			r.Config.Image,
+			r.Config.CmdArgs,
+			r.Config.EnvVars,
+			r.Config.ContainerLabels,
+			r.Config.PermissionProfile,
+			r.Config.K8sPodTemplatePatch,
+			r.Config.IsolateNetwork,
+			r.Config.IgnoreConfig,
+			r.Config.Host,
+			r.Config.TargetPort,
+			r.Config.TargetHost,
+		)
+		if err != nil {
+			return fmt.Errorf("failed to set up workload: %v", err)
+		}
+		setupResult = result
+
+		// Configure the transport with the setup results using options
+		transportOpts = append(transportOpts, transport.WithContainerName(setupResult.ContainerName))
+		if setupResult.TargetURI != "" {
+			transportOpts = append(transportOpts, transport.WithTargetURI(setupResult.TargetURI))
+		}
+	}
+
+	// Create transport with options
+	transportHandler, err := transport.NewFactory().Create(transportConfig, transportOpts...)
+	if err != nil {
+		return fmt.Errorf("failed to create transport: %v", err)
+	}
+
+	// For remote MCP servers, set the remote URL on HTTP transports
 	if r.Config.RemoteURL != "" {
 		if httpTransport, ok := transportHandler.(interface{ SetRemoteURL(string) }); ok {
 			httpTransport.SetRemoteURL(r.Config.RemoteURL)
@@ -191,17 +228,6 @@ func (r *Runner) Run(ctx context.Context) error {
 		if httpTransport, ok := transportHandler.(interface{ SetTokenSource(oauth2.TokenSource) }); ok {
 			httpTransport.SetTokenSource(tokenSource)
 		}
-
-		// For remote workloads, we don't need a deployer
-		r.Config.Deployer = nil
-	}
-
-	if err := transportHandler.Setup(
-		ctx, r.Config.Deployer, r.Config.ContainerName, r.Config.Image, r.Config.CmdArgs,
-		r.Config.EnvVars, r.Config.ContainerLabels, r.Config.PermissionProfile, r.Config.K8sPodTemplatePatch,
-		r.Config.IsolateNetwork, r.Config.IgnoreConfig,
-	); err != nil {
-		return fmt.Errorf("failed to set up transport: %v", err)
 	}
 
 	// Start the transport (which also starts the container and monitoring)

--- a/pkg/runtime/setup.go
+++ b/pkg/runtime/setup.go
@@ -1,0 +1,145 @@
+// Package runtime provides workload deployment setup functionality
+// that was previously part of the transport package.
+package runtime
+
+import (
+	"context"
+	"fmt"
+
+	rt "github.com/stacklok/toolhive/pkg/container/runtime"
+	"github.com/stacklok/toolhive/pkg/ignore"
+	"github.com/stacklok/toolhive/pkg/logger"
+	"github.com/stacklok/toolhive/pkg/permissions"
+	"github.com/stacklok/toolhive/pkg/transport/types"
+)
+
+var transportEnvMap = map[types.TransportType]string{
+	types.TransportTypeSSE:            "sse",
+	types.TransportTypeStreamableHTTP: "streamable-http",
+	types.TransportTypeStdio:          "stdio",
+}
+
+// SetupResult contains the results of setting up a workload
+type SetupResult struct {
+	ContainerName string
+	TargetURI     string
+	TargetPort    int
+	TargetHost    string
+}
+
+// Setup prepares and deploys a workload for use with a transport.
+// The runtime parameter provides access to container operations.
+// The permissionProfile is used to configure container permissions (including network mode).
+// The k8sPodTemplatePatch is a JSON string to patch the Kubernetes pod template.
+// Returns the container name and target URI for configuring the transport.
+func Setup(
+	ctx context.Context,
+	transportType types.TransportType,
+	runtime rt.Deployer,
+	containerName string,
+	image string,
+	cmdArgs []string,
+	envVars, labels map[string]string,
+	permissionProfile *permissions.Profile,
+	k8sPodTemplatePatch string,
+	isolateNetwork bool,
+	ignoreConfig *ignore.Config,
+	host string,
+	targetPort int,
+	targetHost string,
+) (*SetupResult, error) {
+	// Add transport-specific environment variables
+	env, ok := transportEnvMap[transportType]
+	if !ok && transportType != types.TransportTypeStdio {
+		return nil, fmt.Errorf("unsupported transport type: %s", transportType)
+	}
+
+	// For stdio transport, env is already set above
+	if transportType == types.TransportTypeStdio {
+		envVars["MCP_TRANSPORT"] = "stdio"
+	} else {
+		envVars["MCP_TRANSPORT"] = env
+
+		// Use the target port for the container's environment variables
+		envVars["MCP_PORT"] = fmt.Sprintf("%d", targetPort)
+		envVars["FASTMCP_PORT"] = fmt.Sprintf("%d", targetPort)
+		envVars["MCP_HOST"] = targetHost
+	}
+
+	// Create workload options
+	containerOptions := rt.NewDeployWorkloadOptions()
+	containerOptions.K8sPodTemplatePatch = k8sPodTemplatePatch
+	containerOptions.IgnoreConfig = ignoreConfig
+
+	if transportType == types.TransportTypeStdio {
+		containerOptions.AttachStdio = true
+	} else {
+		// Expose the target port in the container
+		containerPortStr := fmt.Sprintf("%d/tcp", targetPort)
+		containerOptions.ExposedPorts[containerPortStr] = struct{}{}
+
+		// Create host port bindings (configurable through the --host flag)
+		portBindings := []rt.PortBinding{
+			{
+				HostIP:   host,
+				HostPort: fmt.Sprintf("%d", targetPort),
+			},
+		}
+
+		// Set the port bindings
+		containerOptions.PortBindings[containerPortStr] = portBindings
+	}
+
+	// Create the container
+	logger.Infof("Deploying workload %s from image %s...", containerName, image)
+	exposedPort, err := runtime.DeployWorkload(
+		ctx,
+		image,
+		containerName,
+		cmdArgs,
+		envVars,
+		labels,
+		permissionProfile,
+		transportType.String(),
+		containerOptions,
+		isolateNetwork,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create container: %v", err)
+	}
+	logger.Infof("Container created: %s", containerName)
+
+	result := &SetupResult{
+		ContainerName: containerName,
+		TargetHost:    targetHost,
+		TargetPort:    targetPort,
+	}
+
+	// For stdio transport, there's no target URI
+	if transportType == types.TransportTypeStdio {
+		result.TargetURI = ""
+	} else {
+		// Update target host and port if needed (for Kubernetes)
+		if (transportType == types.TransportTypeSSE || transportType == types.TransportTypeStreamableHTTP) && rt.IsKubernetesRuntime() {
+			// If the SSEHeadlessServiceName is set, use it as the target host
+			if containerOptions.SSEHeadlessServiceName != "" {
+				result.TargetHost = containerOptions.SSEHeadlessServiceName
+			}
+		}
+
+		// we don't want to override the targetPort in a Kubernetes deployment. Because
+		// by default the Kubernetes container deployer returns `0` for the exposedPort
+		// therefore causing the "target port not set" error when it is assigned to the targetPort.
+		// Issues:
+		// - https://github.com/stacklok/toolhive/issues/902
+		// - https://github.com/stacklok/toolhive/issues/924
+		if !rt.IsKubernetesRuntime() {
+			result.TargetPort = exposedPort
+		}
+
+		// Construct target URI
+		result.TargetURI = fmt.Sprintf("http://%s:%d", result.TargetHost, result.TargetPort)
+	}
+
+	return result, nil
+}

--- a/pkg/transport/proxy/httpsse/http_proxy.go
+++ b/pkg/transport/proxy/httpsse/http_proxy.go
@@ -56,7 +56,6 @@ type HTTPSSEProxy struct {
 	// Basic configuration
 	host              string
 	port              int
-	containerName     string
 	middlewares       []types.NamedMiddleware
 	trustProxyHeaders bool
 
@@ -89,7 +88,6 @@ type HTTPSSEProxy struct {
 func NewHTTPSSEProxy(
 	host string,
 	port int,
-	containerName string,
 	trustProxyHeaders bool,
 	prometheusHandler http.Handler,
 	middlewares ...types.NamedMiddleware,
@@ -103,7 +101,6 @@ func NewHTTPSSEProxy(
 		middlewares:       middlewares,
 		host:              host,
 		port:              port,
-		containerName:     containerName,
 		trustProxyHeaders: trustProxyHeaders,
 		shutdownCh:        make(chan struct{}),
 		messageCh:         make(chan jsonrpc2.Message, 100),
@@ -184,7 +181,7 @@ func (p *HTTPSSEProxy) Start(_ context.Context) error {
 		_, portStr, _ := net.SplitHostPort(actualAddr)
 		actualPort, _ := strconv.Atoi(portStr)
 
-		logger.Infof("HTTP proxy started for container %s on port %d", p.containerName, actualPort)
+		logger.Infof("HTTP proxy started on port %d", actualPort)
 		logger.Infof("SSE endpoint: http://%s%s", actualAddr, ssecommon.HTTPSSEEndpoint)
 		logger.Infof("JSON-RPC endpoint: http://%s%s", actualAddr, ssecommon.HTTPMessagesEndpoint)
 

--- a/pkg/transport/proxy/httpsse/http_proxy_integration_test.go
+++ b/pkg/transport/proxy/httpsse/http_proxy_integration_test.go
@@ -28,7 +28,7 @@ func TestIntegrationSSEProxyStressTest(t *testing.T) {
 	t.Parallel()
 
 	// Create proxy with a random port
-	proxy := NewHTTPSSEProxy("localhost", 0, "test-container", false, nil)
+	proxy := NewHTTPSSEProxy("localhost", 0, false, nil)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -175,7 +175,7 @@ func TestIntegrationConcurrentClientsWithLongRunning(t *testing.T) {
 	t.Parallel()
 
 	// Create and start proxy
-	proxy := NewHTTPSSEProxy("localhost", 0, "test-container", false, nil)
+	proxy := NewHTTPSSEProxy("localhost", 0, false, nil)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -320,7 +320,7 @@ func TestIntegrationConcurrentClientsWithLongRunning(t *testing.T) {
 // TestIntegrationMemoryLeakPrevention tests that the closedClients map doesn't grow unbounded
 func TestIntegrationMemoryLeakPrevention(t *testing.T) {
 	t.Parallel()
-	proxy := NewHTTPSSEProxy("localhost", 0, "test-container", false, nil)
+	proxy := NewHTTPSSEProxy("localhost", 0, false, nil)
 	ctx := context.Background()
 
 	err := proxy.Start(ctx)

--- a/pkg/transport/proxy/httpsse/http_proxy_test.go
+++ b/pkg/transport/proxy/httpsse/http_proxy_test.go
@@ -24,12 +24,11 @@ const testClientID = "test-client"
 //
 //nolint:paralleltest // Test modifies shared proxy state
 func TestNewHTTPSSEProxy(t *testing.T) {
-	proxy := NewHTTPSSEProxy("localhost", 8080, "test-container", false, nil)
+	proxy := NewHTTPSSEProxy("localhost", 8080, false, nil)
 
 	assert.NotNil(t, proxy)
 	assert.Equal(t, "localhost", proxy.host)
 	assert.Equal(t, 8080, proxy.port)
-	assert.Equal(t, "test-container", proxy.containerName)
 	assert.NotNil(t, proxy.messageCh)
 	assert.NotNil(t, proxy.sessionManager)
 	assert.NotNil(t, proxy.closedClients)
@@ -40,7 +39,7 @@ func TestNewHTTPSSEProxy(t *testing.T) {
 //
 //nolint:paralleltest // Test modifies shared proxy state
 func TestGetMessageChannel(t *testing.T) {
-	proxy := NewHTTPSSEProxy("localhost", 8080, "test-container", false, nil)
+	proxy := NewHTTPSSEProxy("localhost", 8080, false, nil)
 
 	ch := proxy.GetMessageChannel()
 	assert.NotNil(t, ch)
@@ -51,7 +50,7 @@ func TestGetMessageChannel(t *testing.T) {
 //
 //nolint:paralleltest // Test modifies shared proxy state
 func TestSendMessageToDestination(t *testing.T) {
-	proxy := NewHTTPSSEProxy("localhost", 8080, "test-container", false, nil)
+	proxy := NewHTTPSSEProxy("localhost", 8080, false, nil)
 
 	// Create a test message
 	msg, err := jsonrpc2.NewCall(jsonrpc2.StringID("test"), "test.method", nil)
@@ -74,7 +73,7 @@ func TestSendMessageToDestination(t *testing.T) {
 //
 //nolint:paralleltest // Test modifies shared proxy state
 func TestSendMessageToDestination_ChannelFull(t *testing.T) {
-	proxy := NewHTTPSSEProxy("localhost", 8080, "test-container", false, nil)
+	proxy := NewHTTPSSEProxy("localhost", 8080, false, nil)
 
 	// Fill the channel
 	for i := 0; i < 100; i++ {
@@ -93,7 +92,7 @@ func TestSendMessageToDestination_ChannelFull(t *testing.T) {
 //
 //nolint:paralleltest // Test modifies shared proxy state
 func TestRemoveClient(t *testing.T) {
-	proxy := NewHTTPSSEProxy("localhost", 8080, "test-container", false, nil)
+	proxy := NewHTTPSSEProxy("localhost", 8080, false, nil)
 
 	// Create a client session
 	clientID := "test-client-1"
@@ -130,7 +129,7 @@ func TestRemoveClient(t *testing.T) {
 //
 //nolint:paralleltest // Test modifies shared proxy state
 func TestConcurrentClientRemoval(t *testing.T) {
-	proxy := NewHTTPSSEProxy("localhost", 8080, "test-container", false, nil)
+	proxy := NewHTTPSSEProxy("localhost", 8080, false, nil)
 
 	// Create multiple client sessions
 	numClients := 100
@@ -178,7 +177,7 @@ func TestConcurrentClientRemoval(t *testing.T) {
 //
 //nolint:paralleltest // Test modifies shared proxy state
 func TestForwardResponseToClients(t *testing.T) {
-	proxy := NewHTTPSSEProxy("localhost", 8080, "test-container", false, nil)
+	proxy := NewHTTPSSEProxy("localhost", 8080, false, nil)
 	ctx := context.Background()
 
 	// Create a client session
@@ -216,7 +215,7 @@ func TestForwardResponseToClients(t *testing.T) {
 //
 //nolint:paralleltest // Test modifies shared proxy state
 func TestForwardResponseToClients_NoClients(t *testing.T) {
-	proxy := NewHTTPSSEProxy("localhost", 8080, "test-container", false, nil)
+	proxy := NewHTTPSSEProxy("localhost", 8080, false, nil)
 	ctx := context.Background()
 
 	// Create a test response
@@ -237,7 +236,7 @@ func TestForwardResponseToClients_NoClients(t *testing.T) {
 //
 //nolint:paralleltest // Test modifies shared proxy state
 func TestSendSSEEvent_ChannelFull(t *testing.T) {
-	proxy := NewHTTPSSEProxy("localhost", 8080, "test-container", false, nil)
+	proxy := NewHTTPSSEProxy("localhost", 8080, false, nil)
 
 	// Create a client session with a small buffer
 	clientID := testClientID
@@ -273,7 +272,7 @@ func TestSendSSEEvent_ChannelFull(t *testing.T) {
 //
 //nolint:paralleltest // Test modifies shared proxy state
 func TestProcessPendingMessages(t *testing.T) {
-	proxy := NewHTTPSSEProxy("localhost", 8080, "test-container", false, nil)
+	proxy := NewHTTPSSEProxy("localhost", 8080, false, nil)
 
 	// Add pending messages
 	for i := 0; i < 5; i++ {
@@ -303,7 +302,7 @@ func TestProcessPendingMessages(t *testing.T) {
 //
 //nolint:paralleltest // Test uses HTTP test server
 func TestHandleSSEConnection(t *testing.T) {
-	proxy := NewHTTPSSEProxy("localhost", 8080, "test-container", false, nil)
+	proxy := NewHTTPSSEProxy("localhost", 8080, false, nil)
 
 	// Create a test server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -330,7 +329,7 @@ func TestHandleSSEConnection(t *testing.T) {
 //
 //nolint:paralleltest // Test uses HTTP test server
 func TestHandleSSEConnection_WithTrustProxyHeaders(t *testing.T) {
-	proxy := NewHTTPSSEProxy("localhost", 8080, "test-container", true, nil)
+	proxy := NewHTTPSSEProxy("localhost", 8080, true, nil)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		proxy.handleSSEConnection(w, r)
@@ -366,7 +365,7 @@ func TestHandleSSEConnection_WithTrustProxyHeaders(t *testing.T) {
 //
 //nolint:paralleltest // Test uses HTTP test server
 func TestHandleSSEConnection_WithoutTrustProxyHeaders(t *testing.T) {
-	proxy := NewHTTPSSEProxy("localhost", 8080, "test-container", false, nil)
+	proxy := NewHTTPSSEProxy("localhost", 8080, false, nil)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		proxy.handleSSEConnection(w, r)
@@ -402,7 +401,7 @@ func TestHandleSSEConnection_WithoutTrustProxyHeaders(t *testing.T) {
 //
 //nolint:paralleltest // Test modifies shared proxy state
 func TestHandlePostRequest(t *testing.T) {
-	proxy := NewHTTPSSEProxy("localhost", 8080, "test-container", false, nil)
+	proxy := NewHTTPSSEProxy("localhost", 8080, false, nil)
 
 	// Create a client session
 	sessionID := "test-session"
@@ -446,7 +445,7 @@ func TestHandlePostRequest(t *testing.T) {
 //
 //nolint:paralleltest // Test modifies shared proxy state
 func TestHandlePostRequest_NoSessionID(t *testing.T) {
-	proxy := NewHTTPSSEProxy("localhost", 8080, "test-container", false, nil)
+	proxy := NewHTTPSSEProxy("localhost", 8080, false, nil)
 
 	// Create a test request without session_id
 	req := httptest.NewRequest("POST", "/messages", nil)
@@ -464,7 +463,7 @@ func TestHandlePostRequest_NoSessionID(t *testing.T) {
 //
 //nolint:paralleltest // Test modifies shared proxy state
 func TestHandlePostRequest_InvalidSession(t *testing.T) {
-	proxy := NewHTTPSSEProxy("localhost", 8080, "test-container", false, nil)
+	proxy := NewHTTPSSEProxy("localhost", 8080, false, nil)
 
 	// Create a test request with non-existent session_id
 	req := httptest.NewRequest("POST", "/messages?session_id=invalid", nil)
@@ -482,7 +481,7 @@ func TestHandlePostRequest_InvalidSession(t *testing.T) {
 //
 //nolint:paralleltest // Test modifies shared proxy state
 func TestRWMutexUsage(t *testing.T) {
-	proxy := NewHTTPSSEProxy("localhost", 8080, "test-container", false, nil)
+	proxy := NewHTTPSSEProxy("localhost", 8080, false, nil)
 
 	// Add multiple client sessions
 	for i := 0; i < 10; i++ {
@@ -523,7 +522,7 @@ func TestRWMutexUsage(t *testing.T) {
 //
 //nolint:paralleltest // Test modifies shared proxy state
 func TestClosedClientsCleanup(t *testing.T) {
-	proxy := NewHTTPSSEProxy("localhost", 8080, "test-container", false, nil)
+	proxy := NewHTTPSSEProxy("localhost", 8080, false, nil)
 
 	// Add many closed client sessions to trigger cleanup
 	for i := 0; i < 1100; i++ {
@@ -555,7 +554,7 @@ func TestClosedClientsCleanup(t *testing.T) {
 //
 //nolint:paralleltest // Test starts/stops HTTP server
 func TestStartStop(t *testing.T) {
-	proxy := NewHTTPSSEProxy("localhost", 0, "test-container", false, nil) // Use port 0 for auto-assignment
+	proxy := NewHTTPSSEProxy("localhost", 0, false, nil) // Use port 0 for auto-assignment
 	ctx := context.Background()
 
 	// Start the proxy

--- a/pkg/transport/proxy/streamable/streamable_proxy.go
+++ b/pkg/transport/proxy/streamable/streamable_proxy.go
@@ -34,7 +34,6 @@ const (
 type HTTPProxy struct {
 	host              string
 	port              int
-	containerName     string
 	shutdownCh        chan struct{}
 	prometheusHandler http.Handler
 	middlewares       []types.NamedMiddleware
@@ -63,7 +62,6 @@ type HTTPProxy struct {
 func NewHTTPProxy(
 	host string,
 	port int,
-	containerName string,
 	prometheusHandler http.Handler,
 	middlewares ...types.NamedMiddleware,
 ) *HTTPProxy {
@@ -73,7 +71,6 @@ func NewHTTPProxy(
 	proxy := &HTTPProxy{
 		host:              host,
 		port:              port,
-		containerName:     containerName,
 		shutdownCh:        make(chan struct{}),
 		prometheusHandler: prometheusHandler,
 		middlewares:       middlewares,
@@ -113,7 +110,7 @@ func (p *HTTPProxy) Start(_ context.Context) error {
 	go p.dispatchResponses()
 
 	go func() {
-		logger.Infof("Streamable HTTP proxy started for container %s on port %d", p.containerName, p.port)
+		logger.Infof("Streamable HTTP proxy started on port %d", p.port)
 		logger.Infof("Streamable HTTP endpoint: http://%s:%d%s", p.host, p.port, StreamableHTTPEndpoint)
 		if err := p.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			logger.Errorf("Streamable HTTP server error: %v", err)

--- a/pkg/transport/proxy/streamable/streamable_proxy_integration_test.go
+++ b/pkg/transport/proxy/streamable/streamable_proxy_integration_test.go
@@ -31,7 +31,7 @@ func getFreePort(t *testing.T) int {
 func TestHTTPRequestIgnoresNotifications(t *testing.T) {
 	// Get an available port dynamically
 	port := getFreePort(t)
-	proxy := NewHTTPProxy("localhost", port, "test-container", nil)
+	proxy := NewHTTPProxy("localhost", port, nil)
 	ctx := context.Background()
 
 	// Start the proxy server

--- a/pkg/transport/proxy/streamable/streamable_proxy_mcp_client_integration_test.go
+++ b/pkg/transport/proxy/streamable/streamable_proxy_mcp_client_integration_test.go
@@ -34,7 +34,7 @@ func TestMCPGoClientInitializeAndPing(t *testing.T) {
 
 	// Use a dedicated port to avoid clashes with other tests
 	const port = 8096
-	proxy := NewHTTPProxy("127.0.0.1", port, "test-container", http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+	proxy := NewHTTPProxy("127.0.0.1", port, http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
 		// no-op prometheus handler, safe for tests
 	}))
 
@@ -160,7 +160,7 @@ func TestMCPGoConcurrentClientsAndPings(t *testing.T) {
 	t.Parallel()
 
 	const port = 8097
-	proxy := NewHTTPProxy("127.0.0.1", port, "test-container", nil)
+	proxy := NewHTTPProxy("127.0.0.1", port, nil)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
@@ -310,7 +310,7 @@ func TestMCPGoManySequentialPingsSingleClient(t *testing.T) {
 	t.Parallel()
 
 	const port = 8098
-	proxy := NewHTTPProxy("127.0.0.1", port, "test-container", nil)
+	proxy := NewHTTPProxy("127.0.0.1", port, nil)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)

--- a/pkg/transport/proxy/streamable/streamable_proxy_spec_test.go
+++ b/pkg/transport/proxy/streamable/streamable_proxy_spec_test.go
@@ -19,7 +19,7 @@ import (
 func startProxyWithBackend(t *testing.T, port int) (*HTTPProxy, context.Context, context.CancelFunc) {
 	t.Helper()
 
-	proxy := NewHTTPProxy("127.0.0.1", port, "test-container", nil)
+	proxy := NewHTTPProxy("127.0.0.1", port, nil)
 	ctx, cancel := context.WithCancel(context.Background())
 
 	require.NoError(t, proxy.Start(ctx), "proxy start")
@@ -53,7 +53,7 @@ func TestGETReturns405(t *testing.T) {
 	t.Parallel()
 
 	const port = 8101
-	proxy := NewHTTPProxy("127.0.0.1", port, "test-container", nil)
+	proxy := NewHTTPProxy("127.0.0.1", port, nil)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -140,7 +140,7 @@ func TestPOSTNotificationOnlyAccepted(t *testing.T) {
 
 	const port = 8104
 	// No backend needed for notification-only submission, but starting is fine.
-	proxy := NewHTTPProxy("127.0.0.1", port, "test-container", nil)
+	proxy := NewHTTPProxy("127.0.0.1", port, nil)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	require.NoError(t, proxy.Start(ctx), "proxy start")
@@ -168,7 +168,7 @@ func TestBatchOnlyNotificationsAccepted(t *testing.T) {
 	t.Parallel()
 
 	const port = 8105
-	proxy := NewHTTPProxy("127.0.0.1", port, "test-container", nil)
+	proxy := NewHTTPProxy("127.0.0.1", port, nil)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	require.NoError(t, proxy.Start(ctx), "proxy start")

--- a/pkg/transport/proxy/streamable/streamable_proxy_test.go
+++ b/pkg/transport/proxy/streamable/streamable_proxy_test.go
@@ -15,12 +15,11 @@ import (
 //
 //nolint:paralleltest // Test modifies shared proxy state
 func TestNewHTTPProxy(t *testing.T) {
-	proxy := NewHTTPProxy("localhost", 8080, "test-container", nil)
+	proxy := NewHTTPProxy("localhost", 8080, nil)
 
 	assert.NotNil(t, proxy)
 	assert.Equal(t, "localhost", proxy.host)
 	assert.Equal(t, 8080, proxy.port)
-	assert.Equal(t, "test-container", proxy.containerName)
 	assert.NotNil(t, proxy.messageCh)
 	assert.NotNil(t, proxy.responseCh)
 }
@@ -29,7 +28,7 @@ func TestNewHTTPProxy(t *testing.T) {
 //
 //nolint:paralleltest // Test modifies shared proxy state
 func TestProxyChannelCommunication(t *testing.T) {
-	proxy := NewHTTPProxy("localhost", 8080, "test-container", nil)
+	proxy := NewHTTPProxy("localhost", 8080, nil)
 	ctx := context.Background()
 
 	// Test that we can send a message to the destination
@@ -67,7 +66,7 @@ func TestProxyChannelCommunication(t *testing.T) {
 //
 //nolint:paralleltest // Test modifies shared proxy state
 func TestSendMessageToDestination(t *testing.T) {
-	proxy := NewHTTPProxy("localhost", 8080, "test-container", nil)
+	proxy := NewHTTPProxy("localhost", 8080, nil)
 
 	// Create a test message
 	msg, err := jsonrpc2.NewCall(jsonrpc2.StringID("test"), "test.method", nil)
@@ -90,7 +89,7 @@ func TestSendMessageToDestination(t *testing.T) {
 //
 //nolint:paralleltest // Test modifies shared proxy state
 func TestSendMessageToDestination_ChannelFull(t *testing.T) {
-	proxy := NewHTTPProxy("localhost", 8080, "test-container", nil)
+	proxy := NewHTTPProxy("localhost", 8080, nil)
 
 	// Fill the channel
 	for i := 0; i < 100; i++ {
@@ -109,7 +108,7 @@ func TestSendMessageToDestination_ChannelFull(t *testing.T) {
 //
 //nolint:paralleltest // Test starts/stops HTTP server
 func TestStartStop(t *testing.T) {
-	proxy := NewHTTPProxy("localhost", 0, "test-container", nil) // Use port 0 for auto-assignment
+	proxy := NewHTTPProxy("localhost", 0, nil) // Use port 0 for auto-assignment
 	ctx := context.Background()
 
 	// Start the proxy

--- a/pkg/transport/proxy/transparent/transparent_test.go
+++ b/pkg/transport/proxy/transparent/transparent_test.go
@@ -25,7 +25,7 @@ func init() {
 
 func TestStreamingSessionIDDetection(t *testing.T) {
 	t.Parallel()
-	proxy := NewTransparentProxy("127.0.0.1", 0, "test", "", nil, nil, true, false, "streamable-http")
+	proxy := NewTransparentProxy("127.0.0.1", 0, "", nil, nil, true, false, "streamable-http")
 	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream; charset=utf-8")
 		w.WriteHeader(200)
@@ -82,7 +82,7 @@ func createBasicProxy(p *TransparentProxy, targetURL *url.URL) *httputil.Reverse
 func TestNoSessionIDInNonSSE(t *testing.T) {
 	t.Parallel()
 
-	p := NewTransparentProxy("127.0.0.1", 0, "test", "", nil, nil, false, false, "streamable-http")
+	p := NewTransparentProxy("127.0.0.1", 0, "", nil, nil, false, false, "streamable-http")
 
 	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		// Set both content-type and also optionally MCP header to test behavior
@@ -108,7 +108,7 @@ func TestNoSessionIDInNonSSE(t *testing.T) {
 func TestHeaderBasedSessionInitialization(t *testing.T) {
 	t.Parallel()
 
-	p := NewTransparentProxy("127.0.0.1", 0, "test", "", nil, nil, false, false, "streamable-http")
+	p := NewTransparentProxy("127.0.0.1", 0, "", nil, nil, false, false, "streamable-http")
 
 	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		// Set both content-type and also optionally MCP header to test behavior
@@ -148,7 +148,7 @@ func TestTracePropagationHeaders(t *testing.T) {
 	defer downstream.Close()
 
 	// Create transparent proxy pointing to mock server
-	proxy := NewTransparentProxy("localhost", 0, "test-server", downstream.URL, nil, nil, false, false, "")
+	proxy := NewTransparentProxy("localhost", 0, downstream.URL, nil, nil, false, false, "")
 
 	// Parse downstream URL
 	targetURL, err := url.Parse(downstream.URL)

--- a/pkg/transport/types/mocks/mock_transport.go
+++ b/pkg/transport/types/mocks/mock_transport.go
@@ -14,9 +14,6 @@ import (
 	http "net/http"
 	reflect "reflect"
 
-	runtime "github.com/stacklok/toolhive/pkg/container/runtime"
-	ignore "github.com/stacklok/toolhive/pkg/ignore"
-	permissions "github.com/stacklok/toolhive/pkg/permissions"
 	types "github.com/stacklok/toolhive/pkg/transport/types"
 	gomock "go.uber.org/mock/gomock"
 	jsonrpc2 "golang.org/x/exp/jsonrpc2"
@@ -251,20 +248,6 @@ func (m *MockTransport) ProxyPort() int {
 func (mr *MockTransportMockRecorder) ProxyPort() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProxyPort", reflect.TypeOf((*MockTransport)(nil).ProxyPort))
-}
-
-// Setup mocks base method.
-func (m *MockTransport) Setup(ctx context.Context, arg1 runtime.Deployer, containerName, image string, cmdArgs []string, envVars, labels map[string]string, permissionProfile *permissions.Profile, k8sPodTemplatePatch string, isolateNetwork bool, ignoreConfig *ignore.Config) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Setup", ctx, arg1, containerName, image, cmdArgs, envVars, labels, permissionProfile, k8sPodTemplatePatch, isolateNetwork, ignoreConfig)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Setup indicates an expected call of Setup.
-func (mr *MockTransportMockRecorder) Setup(ctx, arg1, containerName, image, cmdArgs, envVars, labels, permissionProfile, k8sPodTemplatePatch, isolateNetwork, ignoreConfig any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Setup", reflect.TypeOf((*MockTransport)(nil).Setup), ctx, arg1, containerName, image, cmdArgs, envVars, labels, permissionProfile, k8sPodTemplatePatch, isolateNetwork, ignoreConfig)
 }
 
 // Start mocks base method.

--- a/pkg/transport/types/transport.go
+++ b/pkg/transport/types/transport.go
@@ -12,8 +12,6 @@ import (
 	"golang.org/x/exp/jsonrpc2"
 
 	rt "github.com/stacklok/toolhive/pkg/container/runtime"
-	"github.com/stacklok/toolhive/pkg/ignore"
-	"github.com/stacklok/toolhive/pkg/permissions"
 	"github.com/stacklok/toolhive/pkg/transport/errors"
 )
 
@@ -92,14 +90,6 @@ type Transport interface {
 
 	// ProxyPort returns the port used by the transport.
 	ProxyPort() int
-
-	// Setup prepares the transport for use.
-	// The runtime parameter provides access to container operations.
-	// The permissionProfile is used to configure container permissions (including network mode).
-	// The k8sPodTemplatePatch is a JSON string to patch the Kubernetes pod template.
-	Setup(ctx context.Context, runtime rt.Deployer, containerName string, image string, cmdArgs []string,
-		envVars, labels map[string]string, permissionProfile *permissions.Profile, k8sPodTemplatePatch string,
-		isolateNetwork bool, ignoreConfig *ignore.Config) error
 
 	// Start initializes the transport and begins processing messages.
 	// The transport is responsible for container operations like attaching to stdin/stdout if needed.


### PR DESCRIPTION
As currently implemented, `pkg/transport` is tightly coupled with the underlying runtime. Specifically, transport implementations are aware of the fact that they're wrapping a container workload and even use `rt.Deployer` to stop and restart the workload. This coupling makes it hard to test the transport layer.

This is the first of a series of patches that aim to decouple the transport layer from the underlying workload.

First of a series of PRs addressing #2429