### PR TITLE
Don't try to install mockgen if it's already available

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -21,6 +21,8 @@ tasks:
 
   mock-install:
     desc: Install the mockgen tool for mock generation
+    status:
+      - which mockgen
     cmds:
       - go install go.uber.org/mock/mockgen@latest
 


### PR DESCRIPTION
This sets a conditional in the Taskfile target to allow us to not
reinstall mockgen if it's already in the system

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>
