### PR TITLE
Remove GetClaimsFromContext backward compatibility helper

### DIFF
--- a/pkg/auth/anonymous_test.go
+++ b/pkg/auth/anonymous_test.go
@@ -12,25 +12,32 @@ import (
 
 func TestAnonymousMiddleware(t *testing.T) {
 	t.Parallel()
-	// Create a test handler that checks for claims in the context
+	// Create a test handler that checks for identity in the context
 	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		claims, ok := GetClaimsFromContext(r.Context())
-		require.True(t, ok, "Expected claims to be present in context")
+		identity, ok := IdentityFromContext(r.Context())
+		require.True(t, ok, "Expected identity to be present in context")
+		require.NotNil(t, identity, "Expected identity to be non-nil")
+
+		// Verify the identity fields
+		assert.Equal(t, "anonymous", identity.Subject)
+		assert.Equal(t, "Anonymous User", identity.Name)
+		assert.Equal(t, "anonymous@localhost", identity.Email)
 
 		// Verify the anonymous claims
-		assert.Equal(t, "anonymous", claims["sub"])
-		assert.Equal(t, "toolhive-local", claims["iss"])
-		assert.Equal(t, "toolhive", claims["aud"])
-		assert.Equal(t, "anonymous@localhost", claims["email"])
-		assert.Equal(t, "Anonymous User", claims["name"])
+		require.NotNil(t, identity.Claims)
+		assert.Equal(t, "anonymous", identity.Claims["sub"])
+		assert.Equal(t, "toolhive-local", identity.Claims["iss"])
+		assert.Equal(t, "toolhive", identity.Claims["aud"])
+		assert.Equal(t, "anonymous@localhost", identity.Claims["email"])
+		assert.Equal(t, "Anonymous User", identity.Claims["name"])
 
 		// Verify timestamps are reasonable
 		now := time.Now().Unix()
-		exp, ok := claims["exp"].(int64)
+		exp, ok := identity.Claims["exp"].(int64)
 		require.True(t, ok, "Expected exp to be present and be an int64")
 		assert.Greater(t, exp, now, "Expected exp to be in the future")
 
-		iat, ok := claims["iat"].(int64)
+		iat, ok := identity.Claims["iat"].(int64)
 		require.True(t, ok, "Expected iat to be present and be an int64")
 		assert.LessOrEqual(t, iat, now+1, "Expected iat to be current time or earlier (with 1 second tolerance)")
 

--- a/pkg/auth/context.go
+++ b/pkg/auth/context.go
@@ -50,24 +50,6 @@ func IdentityFromContext(ctx context.Context) (*Identity, bool) {
 	return identity, ok
 }
 
-// GetClaimsFromContext retrieves the claims from Identity in the request context.
-// This is a helper function for backward compatibility with code that expects MapClaims.
-// New code should use IdentityFromContext and access the Claims field directly.
-func GetClaimsFromContext(ctx context.Context) (jwt.MapClaims, bool) {
-	if ctx == nil {
-		return nil, false
-	}
-
-	// Get Identity and return its Claims
-	if identity, ok := IdentityFromContext(ctx); ok && identity != nil {
-		if identity.Claims != nil {
-			return jwt.MapClaims(identity.Claims), true
-		}
-	}
-
-	return nil, false
-}
-
 // claimsToIdentity converts JWT claims to Identity struct.
 // It requires the 'sub' claim per OIDC Core 1.0 spec § 5.1.
 // The original token can be provided for passthrough scenarios.

--- a/pkg/auth/local_test.go
+++ b/pkg/auth/local_test.go
@@ -14,25 +14,32 @@ func TestLocalUserMiddleware(t *testing.T) {
 	t.Parallel()
 	username := "testuser"
 
-	// Create a test handler that checks for claims in the context
+	// Create a test handler that checks for identity in the context
 	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		claims, ok := GetClaimsFromContext(r.Context())
-		require.True(t, ok, "Expected claims to be present in context")
+		identity, ok := IdentityFromContext(r.Context())
+		require.True(t, ok, "Expected identity to be present in context")
+		require.NotNil(t, identity, "Expected identity to be non-nil")
+
+		// Verify the identity fields
+		assert.Equal(t, username, identity.Subject)
+		assert.Equal(t, "Local User: "+username, identity.Name)
+		assert.Equal(t, username+"@localhost", identity.Email)
 
 		// Verify the local user claims
-		assert.Equal(t, username, claims["sub"])
-		assert.Equal(t, "toolhive-local", claims["iss"])
-		assert.Equal(t, "toolhive", claims["aud"])
-		assert.Equal(t, username+"@localhost", claims["email"])
-		assert.Equal(t, "Local User: "+username, claims["name"])
+		require.NotNil(t, identity.Claims)
+		assert.Equal(t, username, identity.Claims["sub"])
+		assert.Equal(t, "toolhive-local", identity.Claims["iss"])
+		assert.Equal(t, "toolhive", identity.Claims["aud"])
+		assert.Equal(t, username+"@localhost", identity.Claims["email"])
+		assert.Equal(t, "Local User: "+username, identity.Claims["name"])
 
 		// Verify timestamps are reasonable
 		now := time.Now().Unix()
-		exp, ok := claims["exp"].(int64)
+		exp, ok := identity.Claims["exp"].(int64)
 		require.True(t, ok, "Expected exp to be present and be an int64")
 		assert.Greater(t, exp, now, "Expected exp to be in the future")
 
-		iat, ok := claims["iat"].(int64)
+		iat, ok := identity.Claims["iat"].(int64)
 		require.True(t, ok, "Expected iat to be present and be an int64")
 		assert.LessOrEqual(t, iat, now+1, "Expected iat to be current time or earlier (with 1 second tolerance)")
 
@@ -63,11 +70,12 @@ func TestLocalUserMiddlewareWithDifferentUsernames(t *testing.T) {
 		t.Run("username_"+username, func(t *testing.T) {
 			t.Parallel()
 			testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				claims, ok := GetClaimsFromContext(r.Context())
-				require.True(t, ok, "Expected claims to be present in context")
+				identity, ok := IdentityFromContext(r.Context())
+				require.True(t, ok, "Expected identity to be present in context")
+				require.NotNil(t, identity, "Expected identity to be non-nil")
 
-				assert.Equal(t, username, claims["sub"])
-				assert.Equal(t, username+"@localhost", claims["email"])
+				assert.Equal(t, username, identity.Subject)
+				assert.Equal(t, username+"@localhost", identity.Email)
 
 				w.WriteHeader(http.StatusOK)
 			})

--- a/pkg/auth/token_test.go
+++ b/pkg/auth/token_test.go
@@ -242,17 +242,17 @@ func TestTokenValidatorMiddleware(t *testing.T) {
 
 	// Create a test handler
 	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Get the claims from the context using the helper function
-		claims, ok := GetClaimsFromContext(r.Context())
-		if !ok {
-			t.Errorf("Failed to get claims from context")
-			http.Error(w, "Failed to get claims from context", http.StatusInternalServerError)
+		// Get the identity from the context
+		identity, ok := IdentityFromContext(r.Context())
+		if !ok || identity == nil {
+			t.Errorf("Failed to get identity from context")
+			http.Error(w, "Failed to get identity from context", http.StatusInternalServerError)
 			return
 		}
 
 		// Write the claims as the response
 		w.Header().Set("Content-Type", "application/json")
-		if err := json.NewEncoder(w).Encode(claims); err != nil {
+		if err := json.NewEncoder(w).Encode(identity.Claims); err != nil {
 			t.Errorf("Failed to encode claims: %v", err)
 			http.Error(w, fmt.Sprintf("Failed to encode claims: %v", err), http.StatusInternalServerError)
 			return


### PR DESCRIPTION
## Summary

Remove `GetClaimsFromContext` function and migrate all usages to `IdentityFromContext` pattern following the authentication unification completed in #2437.

## Changes

- Remove `GetClaimsFromContext()` from `pkg/auth/context.go`
- Update all test files to use `IdentityFromContext()` and access `identity.Claims` directly when needed
- Remove dedicated `GetClaimsFromContext` test functions
- Remove unused jwt imports from test files

## Rationale

`GetClaimsFromContext` was added as a backward-compatibility helper during the Identity struct unification in #2437. All production code has migrated to using `IdentityFromContext` directly, with **zero production usages remaining**. Tests should verify the actual production API contract.

The function's comment even stated: _"This is a helper function for backward compatibility with code that expects MapClaims. New code should use IdentityFromContext and access the Claims field directly."_

Since all code is now "new code" using `IdentityFromContext`, the backward compatibility layer is no longer needed.

## Impact

- **Removes ~130 lines of code** (function + tests)
- **Simplifies the auth API** to a single consistent pattern
- **Improves test clarity** by testing the actual production contract
- **All tests pass** - no functional changes to production code

## Production Usage Analysis

Verified that `GetClaimsFromContext` had **zero production usages**:
- `pkg/audit/auditor.go` uses `IdentityFromContext()` 
- `pkg/authz/cedar.go` uses `IdentityFromContext()`
- `pkg/auth/tokenexchange/middleware.go` uses `IdentityFromContext()`

The only usages were in test files, which have been updated to use the production pattern.

## Testing

All tests pass:
```bash
go test ./pkg/auth/...
go test ./pkg/audit/...
go test ./pkg/authz/...
```

Linting clean:
```bash
task lint-fix
```