### PR TITLE
Skip OAuth secret processing when empty

### DIFF
--- a/cmd/thv/app/run_flags.go
+++ b/cmd/thv/app/run_flags.go
@@ -642,9 +642,13 @@ func getRemoteAuthFromRemoteServerMetadata(
 	}
 
 	// Process the resolved client secret (convert plain text to secret reference if needed)
-	clientSecret, err := processOAuthClientSecret(resolvedClientSecret, runFlags.Name)
-	if err != nil {
-		return nil, fmt.Errorf("failed to process OAuth client secret: %w", err)
+	// Only process if a secret was actually provided to avoid unnecessary secrets manager access
+	var clientSecret string
+	if resolvedClientSecret != "" {
+		clientSecret, err = processOAuthClientSecret(resolvedClientSecret, runFlags.Name)
+		if err != nil {
+			return nil, fmt.Errorf("failed to process OAuth client secret: %w", err)
+		}
 	}
 
 	authCfg := &runner.RemoteAuthConfig{
@@ -701,9 +705,13 @@ func getRemoteAuthFromRunFlags(runFlags *RunFlags) (*runner.RemoteAuthConfig, er
 	}
 
 	// Process the resolved client secret (convert plain text to secret reference if needed)
-	clientSecret, err := processOAuthClientSecret(resolvedClientSecret, runFlags.Name)
-	if err != nil {
-		return nil, fmt.Errorf("failed to process OAuth client secret: %w", err)
+	// Only process if a secret was actually provided to avoid unnecessary secrets manager access
+	var clientSecret string
+	if resolvedClientSecret != "" {
+		clientSecret, err = processOAuthClientSecret(resolvedClientSecret, runFlags.Name)
+		if err != nil {
+			return nil, fmt.Errorf("failed to process OAuth client secret: %w", err)
+		}
 	}
 
 	return &runner.RemoteAuthConfig{

--- a/pkg/oauth/client_secret.go
+++ b/pkg/oauth/client_secret.go
@@ -13,6 +13,11 @@ import (
 
 // ProcessOAuthClientSecret processes an OAuth client secret, converting plain text to CLI format if needed
 func ProcessOAuthClientSecret(workloadName, clientSecret string) (string, error) {
+	// Early return if no secret is provided - no need to access secrets manager
+	if clientSecret == "" {
+		return "", nil
+	}
+
 	secretManager, err := getSecretsManager()
 	if err != nil {
 		return "", fmt.Errorf("failed to get secrets manager: %w", err)

--- a/pkg/oauth/client_secret_test.go
+++ b/pkg/oauth/client_secret_test.go
@@ -307,6 +307,23 @@ func TestStoreSecretInManagerWithProvider(t *testing.T) {
 	}
 }
 
+// TestProcessOAuthClientSecret tests that empty secrets don't require secrets manager
+func TestProcessOAuthClientSecret(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty client secret returns empty without accessing secrets manager", func(t *testing.T) {
+		t.Parallel()
+
+		// This test verifies that when clientSecret is empty, ProcessOAuthClientSecret
+		// returns early without attempting to access the secrets manager.
+		// If it tried to access the secrets manager, it would fail because
+		// no secrets provider is configured in the test environment.
+		result, err := ProcessOAuthClientSecret("test-workload", "")
+		assert.NoError(t, err, "Should not error when client secret is empty")
+		assert.Equal(t, "", result, "Should return empty string when input is empty")
+	})
+}
+
 // TestProcessOAuthClientSecretWithProvider tests the testable version with dependency injection
 func TestProcessOAuthClientSecretWithProvider(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## What

Fixes OAuth client secret processing to skip secrets manager access when no client secret is provided.

## Why

When running remote MCP servers without authentication (like `mcp-spec`), the code was attempting to access the secrets manager even though no OAuth secret was provided. This caused failures in CI environments where no secrets provider is configured.

## Changes

- Added checks at call sites to skip `processOAuthClientSecret()` when secret is empty
- Added defensive check in `ProcessOAuthClientSecret()` itself
- Added test to verify empty secrets don't require secrets manager access

This enables remote MCP servers without authentication to work in environments without secrets configuration.