### PR TITLE
Fix vmcp tool schema double-nesting bug

### DIFF
--- a/pkg/vmcp/server/server.go
+++ b/pkg/vmcp/server/server.go
@@ -366,13 +366,18 @@ func (s *Server) Address() string {
 //nolint:unparam // Error return kept for future extensibility
 func (s *Server) registerTool(tool vmcp.Tool) error {
 	// Convert vmcp.Tool to mcp.Tool
+	// Note: tool.InputSchema is already a complete JSON Schema (map[string]any)
+	// containing type, properties, required, etc. We marshal it to JSON and
+	// use RawInputSchema to avoid double-nesting the schema structure.
+	schemaJSON, err := json.Marshal(tool.InputSchema)
+	if err != nil {
+		return fmt.Errorf("failed to marshal input schema for tool %s: %w", tool.Name, err)
+	}
+
 	mcpTool := mcp.Tool{
-		Name:        tool.Name,
-		Description: tool.Description,
-		InputSchema: mcp.ToolInputSchema{
-			Type:       "object",
-			Properties: tool.InputSchema,
-		},
+		Name:           tool.Name,
+		Description:    tool.Description,
+		RawInputSchema: schemaJSON,
 	}
 
 	// Create handler that routes to backend


### PR DESCRIPTION
## Summary

Fixes a critical bug where vmcp tool schemas were incorrectly double-nested, causing validation failures in strict MCP clients like VSCode.

## Problem

The `registerTool` function in `pkg/vmcp/server/server.go` was incorrectly wrapping the complete JSON Schema in an additional layer. The `tool.InputSchema` (a `map[string]any`) already contains a complete JSON Schema with `type`, `properties`, and `required` fields, but the code treated it as just properties and wrapped it in a new schema structure.

**Before (buggy)**:
```json
{
  "type": "object",
  "properties": {
    "properties": { "url": {...}, ... },
    "required": ["url"],
    "type": "object"
  }
}
```

**After (correct)**:
```json
{
  "type": "object",
  "properties": { "url": {...}, ... },
  "required": ["url"]
}
```

## Solution

Changed `pkg/vmcp/server/server.go` to use `RawInputSchema` instead of `InputSchema`, which marshals the complete schema as-is without double-nesting.

## Testing

- Added comprehensive unit tests in `pkg/vmcp/server/server_test.go`
- Verified fix with `thv mcp list --transport streamable-http --server http://127.0.0.1:4483/mcp --format json`
- All existing tests pass
- Linter passes

## Impact

This fix resolves VSCode MCP validation errors like:
```
Tool 'fetch_fetch' has invalid JSON parameters:
  - Incorrect type. Expected one of object, boolean. (at /properties/required)
  - Incorrect type. Expected one of object, boolean. (at /properties/type)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)