### PR TITLE
Process EnvFileDir in file-based config mode

### DIFF
--- a/cmd/thv-proxyrunner/app/execution.go
+++ b/cmd/thv-proxyrunner/app/execution.go
@@ -127,6 +127,15 @@ func runWithFileBasedConfig(
 		config.EnvVars = validatedEnvVars
 	}
 
+	// Process environment files from EnvFileDir if specified (e.g., for Vault secrets)
+	if config.EnvFileDir != "" {
+		updatedConfig, err := config.WithEnvFilesFromDirectory(config.EnvFileDir)
+		if err != nil {
+			return fmt.Errorf("failed to process environment files from directory %s: %v", config.EnvFileDir, err)
+		}
+		config = updatedConfig
+	}
+
 	// Apply image metadata overrides if needed (similar to what the builder does)
 	if imageMetadata != nil && config.Name == "" {
 		config.Name = imageMetadata.Name


### PR DESCRIPTION
Fixes vault secrets not being passed to workload pods when using file-based configuration in the proxy runner.

The runWithFileBasedConfig function was loading the RunConfig from the ConfigMap but never processing the EnvFileDir field. This caused Vault Agent injected secrets to remain in the proxy pod at /vault/secrets without being propagated to the workload StatefulSet.

The fix adds environment file processing when EnvFileDir is set, matching the behavior of the flags-based configuration path. When the operator detects Vault annotations, it sets EnvFileDir to /vault/secrets in the RunConfig. The proxy runner now reads files from that directory and merges them into config.EnvVars before deploying the workload.

Fixes #2460