### PR TITLE
Change default proxy mode from SSE to streamable-http

### DIFF
--- a/cmd/thv/app/mcp.go
+++ b/cmd/thv/app/mcp.go
@@ -302,9 +302,9 @@ func determineTransportType(serverURL, transportFlag string) types.TransportType
 	// Auto-detect based on URL path
 	parsedURL, err := url.Parse(serverURL)
 	if err != nil {
-		// If we can't parse the URL, default to SSE for backward compatibility
-		logger.Warnf("Failed to parse server URL %s, defaulting to SSE transport: %v", serverURL, err)
-		return types.TransportTypeSSE
+		// If we can't parse the URL, default to streamable-http (SSE is deprecated)
+		logger.Warnf("Failed to parse server URL %s, defaulting to streamable-http transport: %v", serverURL, err)
+		return types.TransportTypeStreamableHTTP
 	}
 
 	path := parsedURL.Path
@@ -320,8 +320,8 @@ func determineTransportType(serverURL, transportFlag string) types.TransportType
 		return types.TransportTypeSSE
 	}
 
-	// Default to SSE for backward compatibility
-	return types.TransportTypeSSE
+	// Default to streamable-http (SSE is deprecated)
+	return types.TransportTypeStreamableHTTP
 }
 
 // initializeMCPClient initializes the MCP client connection

--- a/cmd/thv/app/run_flags.go
+++ b/cmd/thv/app/run_flags.go
@@ -123,7 +123,7 @@ type RunFlags struct {
 // AddRunFlags adds all the run flags to a command
 func AddRunFlags(cmd *cobra.Command, config *RunFlags) {
 	cmd.Flags().StringVar(&config.Transport, "transport", "", "Transport mode (sse, streamable-http or stdio)")
-	cmd.Flags().StringVar(&config.ProxyMode, "proxy-mode", "sse", "Proxy mode for stdio transport (sse or streamable-http)")
+	cmd.Flags().StringVar(&config.ProxyMode, "proxy-mode", "streamable-http", "Proxy mode for stdio (streamable-http or sse)")
 	cmd.Flags().StringVar(&config.Name, "name", "", "Name of the MCP server (auto-generated from image if not provided)")
 	cmd.Flags().StringVar(&config.Group, "group", "default",
 		"Name of the group this workload belongs to (defaults to 'default' if not specified)")
@@ -392,7 +392,7 @@ func handleImageRetrieval(
 func validateAndSetupProxyMode(runFlags *RunFlags) error {
 	if !types.IsValidProxyMode(runFlags.ProxyMode) {
 		if runFlags.ProxyMode == "" {
-			runFlags.ProxyMode = types.ProxyModeSSE.String() // default to SSE for backward compatibility
+			runFlags.ProxyMode = types.ProxyModeStreamableHTTP.String() // default to streamable-http (SSE is deprecated)
 		} else {
 			return fmt.Errorf("invalid value for --proxy-mode: %s", runFlags.ProxyMode)
 		}

--- a/docs/arch/03-transport-architecture.md
+++ b/docs/arch/03-transport-architecture.md
@@ -190,8 +190,8 @@ ToolHive uses two different proxy implementations:
 
 When stdio transport is selected, the proxy mode determines which HTTP protocol clients use to communicate:
 
-- **SSE Mode**: Default for backward compatibility, provides SSE endpoints for clients
-- **Streamable HTTP Mode**: Modern streaming protocol following MCP specification
+- **Streamable HTTP Mode**: Default mode, modern streaming protocol following MCP specification
+- **SSE Mode**: Legacy mode (deprecated), provides SSE endpoints for clients
 
 **Implementation:**
 - `pkg/runner/config.go` - ProxyMode configuration

--- a/docs/cli/thv_run.md
+++ b/docs/cli/thv_run.md
@@ -126,7 +126,7 @@ thv run [flags] SERVER_OR_IMAGE_OR_PROTOCOL [-- ARGS...]
       --otel-tracing-enabled                       Enable distributed tracing (when OTLP endpoint is configured) (default true)
       --permission-profile string                  Permission profile to use (none, network, or path to JSON file)
       --print-resolved-overlays                    Debug: show resolved container paths for tmpfs overlays
-      --proxy-mode string                          Proxy mode for stdio transport (sse or streamable-http) (default "sse")
+      --proxy-mode string                          Proxy mode for stdio (streamable-http or sse) (default "streamable-http")
       --proxy-port int                             Port for the HTTP proxy to listen on (host port)
       --remote-auth                                Enable OAuth/OIDC authentication to remote MCP server
       --remote-auth-authorize-url string           OAuth authorization endpoint URL (alternative to --remote-auth-issuer for non-OIDC OAuth)

--- a/pkg/api/v1/workload_service.go
+++ b/pkg/api/v1/workload_service.go
@@ -93,10 +93,10 @@ func (s *WorkloadService) UpdateWorkloadFromRequest(ctx context.Context, name st
 //
 //nolint:gocyclo // TODO: refactor this into shorter functions
 func (s *WorkloadService) BuildFullRunConfig(ctx context.Context, req *createRequest) (*runner.RunConfig, error) {
-	// Default proxy mode to SSE if not specified
+	// Default proxy mode to streamable-http if not specified (SSE is deprecated)
 	if !types.IsValidProxyMode(req.ProxyMode) {
 		if req.ProxyMode == "" {
-			req.ProxyMode = types.ProxyModeSSE.String()
+			req.ProxyMode = types.ProxyModeStreamableHTTP.String()
 		} else {
 			return nil, fmt.Errorf("%w: %s", retriever.ErrInvalidRunConfig, fmt.Sprintf("Invalid proxy_mode: %s", req.ProxyMode))
 		}

--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -90,7 +90,7 @@ type mcpClientConfig struct {
 	PlatformPrefix                map[string][]string
 	MCPServersPathPrefix          string
 	Extension                     Extension
-	SupportedTransportTypesMap    map[types.TransportType]string // stdio should be mapped to sse
+	SupportedTransportTypesMap    map[types.TransportType]string // stdio mapped to streamable-http (SSE deprecated)
 	IsTransportTypeFieldSupported bool
 	MCPServersUrlLabel            string
 	// YAML-specific configuration (only used when Extension == YAML)
@@ -120,7 +120,7 @@ var supportedClientIntegrations = []mcpClientConfig{
 		MCPServersPathPrefix: "/mcpServers",
 		Extension:            JSON,
 		SupportedTransportTypesMap: map[types.TransportType]string{
-			types.TransportTypeStdio:          "sse",
+			types.TransportTypeStdio:          "streamable-http",
 			types.TransportTypeSSE:            "sse",
 			types.TransportTypeStreamableHTTP: "streamable-http",
 		},
@@ -142,7 +142,7 @@ var supportedClientIntegrations = []mcpClientConfig{
 		MCPServersPathPrefix: "/mcpServers",
 		Extension:            JSON,
 		SupportedTransportTypesMap: map[types.TransportType]string{
-			types.TransportTypeStdio:          "sse",
+			types.TransportTypeStdio:          "streamableHttp",
 			types.TransportTypeSSE:            "sse",
 			types.TransportTypeStreamableHTTP: "streamableHttp",
 		},
@@ -164,7 +164,7 @@ var supportedClientIntegrations = []mcpClientConfig{
 		MCPServersPathPrefix: "/servers",
 		Extension:            JSON,
 		SupportedTransportTypesMap: map[types.TransportType]string{
-			types.TransportTypeStdio:          "sse",
+			types.TransportTypeStdio:          "http",
 			types.TransportTypeSSE:            "sse",
 			types.TransportTypeStreamableHTTP: "http",
 		},
@@ -186,7 +186,7 @@ var supportedClientIntegrations = []mcpClientConfig{
 		},
 		Extension: JSON,
 		SupportedTransportTypesMap: map[types.TransportType]string{
-			types.TransportTypeStdio:          "sse",
+			types.TransportTypeStdio:          "http",
 			types.TransportTypeSSE:            "sse",
 			types.TransportTypeStreamableHTTP: "http",
 		},
@@ -201,7 +201,7 @@ var supportedClientIntegrations = []mcpClientConfig{
 		RelPath:              []string{".cursor"},
 		Extension:            JSON,
 		SupportedTransportTypesMap: map[types.TransportType]string{
-			types.TransportTypeStdio:          "sse",
+			types.TransportTypeStdio:          "http",
 			types.TransportTypeSSE:            "sse",
 			types.TransportTypeStreamableHTTP: "http",
 		},
@@ -218,7 +218,7 @@ var supportedClientIntegrations = []mcpClientConfig{
 		RelPath:              []string{},
 		Extension:            JSON,
 		SupportedTransportTypesMap: map[types.TransportType]string{
-			types.TransportTypeStdio:          "sse",
+			types.TransportTypeStdio:          "http",
 			types.TransportTypeSSE:            "sse",
 			types.TransportTypeStreamableHTTP: "http",
 		},
@@ -233,7 +233,7 @@ var supportedClientIntegrations = []mcpClientConfig{
 		RelPath:              []string{".codeium", "windsurf"},
 		Extension:            JSON,
 		SupportedTransportTypesMap: map[types.TransportType]string{
-			types.TransportTypeStdio:          "sse",
+			types.TransportTypeStdio:          "http",
 			types.TransportTypeSSE:            "sse",
 			types.TransportTypeStreamableHTTP: "http",
 		},
@@ -248,7 +248,7 @@ var supportedClientIntegrations = []mcpClientConfig{
 		RelPath:              []string{".codeium"},
 		Extension:            JSON,
 		SupportedTransportTypesMap: map[types.TransportType]string{
-			types.TransportTypeStdio:          "sse",
+			types.TransportTypeStdio:          "http",
 			types.TransportTypeSSE:            "sse",
 			types.TransportTypeStreamableHTTP: "http",
 		},
@@ -268,7 +268,7 @@ var supportedClientIntegrations = []mcpClientConfig{
 		},
 		Extension: JSON,
 		SupportedTransportTypesMap: map[types.TransportType]string{
-			types.TransportTypeStdio:          "sse",
+			types.TransportTypeStdio:          "http",
 			types.TransportTypeSSE:            "sse",
 			types.TransportTypeStreamableHTTP: "http",
 		},
@@ -287,7 +287,7 @@ var supportedClientIntegrations = []mcpClientConfig{
 		},
 		Extension: JSON,
 		SupportedTransportTypesMap: map[types.TransportType]string{
-			types.TransportTypeStdio:          "sse",
+			types.TransportTypeStdio:          "http",
 			types.TransportTypeSSE:            "sse",
 			types.TransportTypeStreamableHTTP: "http",
 		},
@@ -306,7 +306,7 @@ var supportedClientIntegrations = []mcpClientConfig{
 		},
 		Extension: JSON,
 		SupportedTransportTypesMap: map[types.TransportType]string{
-			types.TransportTypeStdio:          "sse",
+			types.TransportTypeStdio:          "http",
 			types.TransportTypeSSE:            "sse",
 			types.TransportTypeStreamableHTTP: "http",
 		},
@@ -325,7 +325,7 @@ var supportedClientIntegrations = []mcpClientConfig{
 		},
 		Extension: JSON,
 		SupportedTransportTypesMap: map[types.TransportType]string{
-			types.TransportTypeStdio:          "sse",
+			types.TransportTypeStdio:          "http",
 			types.TransportTypeSSE:            "sse",
 			types.TransportTypeStreamableHTTP: "http",
 		},
@@ -344,7 +344,7 @@ var supportedClientIntegrations = []mcpClientConfig{
 		},
 		Extension: JSON,
 		SupportedTransportTypesMap: map[types.TransportType]string{
-			types.TransportTypeStdio:          "sse",
+			types.TransportTypeStdio:          "http",
 			types.TransportTypeSSE:            "sse",
 			types.TransportTypeStreamableHTTP: "http",
 		},
@@ -358,7 +358,7 @@ var supportedClientIntegrations = []mcpClientConfig{
 		RelPath:              []string{".lmstudio"},
 		Extension:            JSON,
 		SupportedTransportTypesMap: map[types.TransportType]string{
-			types.TransportTypeStdio:          "sse",
+			types.TransportTypeStdio:          "http",
 			types.TransportTypeSSE:            "sse",
 			types.TransportTypeStreamableHTTP: "http",
 		},
@@ -378,7 +378,7 @@ var supportedClientIntegrations = []mcpClientConfig{
 		},
 		Extension: YAML,
 		SupportedTransportTypesMap: map[types.TransportType]string{
-			types.TransportTypeStdio:          "sse",
+			types.TransportTypeStdio:          "streamable_http",
 			types.TransportTypeSSE:            "sse",
 			types.TransportTypeStreamableHTTP: "streamable_http",
 		},
@@ -404,7 +404,7 @@ var supportedClientIntegrations = []mcpClientConfig{
 		},
 		Extension: JSON,
 		SupportedTransportTypesMap: map[types.TransportType]string{
-			types.TransportTypeStdio:          "sse",
+			types.TransportTypeStdio:          "http",
 			types.TransportTypeSSE:            "sse",
 			types.TransportTypeStreamableHTTP: "http",
 		},
@@ -419,7 +419,7 @@ var supportedClientIntegrations = []mcpClientConfig{
 		RelPath:              []string{".continue"},
 		Extension:            YAML,
 		SupportedTransportTypesMap: map[types.TransportType]string{
-			types.TransportTypeStdio:          "sse",
+			types.TransportTypeStdio:          "streamable-http",
 			types.TransportTypeSSE:            "sse",
 			types.TransportTypeStreamableHTTP: "streamable-http",
 		},

--- a/test/e2e/audit_middleware_e2e_test.go
+++ b/test/e2e/audit_middleware_e2e_test.go
@@ -20,7 +20,7 @@ func generateUniqueAuditServerName(prefix string) string {
 	return fmt.Sprintf("%s-%d-%d-%d", prefix, os.Getpid(), time.Now().UnixNano(), GinkgoRandomSeed())
 }
 
-var _ = Describe("Audit Middleware E2E", Label("middleware", "audit", "sse", "e2e"), Serial, func() {
+var _ = Describe("Audit Middleware E2E", Label("middleware", "audit", "streamable-http", "e2e"), Serial, func() {
 	var (
 		config          *e2e.TestConfig
 		mcpServerName   string
@@ -402,7 +402,7 @@ func startMCPServerWithAuditConfig(config *e2e.TestConfig, workloadName, mcpServ
 	args := []string{
 		"run",
 		"--name", workloadName,
-		"--transport", "sse", // Use SSE transport for HTTP-based testing
+		"--transport", "streamable-http", // Use streamable-http transport (default)
 		"--audit-config", auditConfigPath,
 		mcpServerName,
 	}
@@ -428,7 +428,7 @@ func startMCPServerWithEnableAuditFlag(config *e2e.TestConfig, workloadName, mcp
 	args := []string{
 		"run",
 		"--name", workloadName,
-		"--transport", "sse", // Use SSE transport for HTTP-based testing
+		"--transport", "streamable-http", // Use streamable-http transport (default)
 		"--enable-audit",
 		mcpServerName,
 	}
@@ -454,8 +454,8 @@ func makeHTTPMCPRequest(serverURL string, request map[string]any) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	// Create MCP client for SSE transport
-	mcpClient, err := e2e.NewMCPClientForSSE(&e2e.TestConfig{}, serverURL)
+	// Create MCP client for streamable-http transport
+	mcpClient, err := e2e.NewMCPClientForStreamableHTTP(&e2e.TestConfig{}, serverURL)
 	Expect(err).ToNot(HaveOccurred())
 	defer mcpClient.Close()
 

--- a/test/e2e/proxy_oauth_test.go
+++ b/test/e2e/proxy_oauth_test.go
@@ -88,7 +88,7 @@ var _ = Describe("Proxy OAuth Authentication E2E", Label("proxy", "oauth", "e2e"
 		By("Starting OSV MCP server as target")
 		e2e.NewTHVCommand(config, "run",
 			"--name", osvServerName,
-			"--transport", "sse",
+			"--transport", "streamable-http",
 			"osv").ExpectSuccess()
 
 		// Wait for OSV server to be ready
@@ -154,7 +154,7 @@ var _ = Describe("Proxy OAuth Authentication E2E", Label("proxy", "oauth", "e2e"
 			By("Testing proxy endpoint accessibility")
 			// Try to access the proxy endpoint
 			client := &http.Client{Timeout: 10 * time.Second}
-			resp, err := client.Get(fmt.Sprintf("http://localhost:%d/sse", proxyPort))
+			resp, err := client.Get(fmt.Sprintf("http://localhost:%d/mcp", proxyPort))
 			if err == nil {
 				defer resp.Body.Close()
 				// We expect some response, even if it's not a successful MCP connection
@@ -320,9 +320,9 @@ var _ = Describe("Proxy OAuth Authentication E2E", Label("proxy", "oauth", "e2e"
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Extracting base URL for transparent proxy")
-			// The URL from thv list is like: http://127.0.0.1:21929/sse#container-name
+			// With streamable-http: http://127.0.0.1:21929/mcp (no fragment)
 			// But the transparent proxy needs the base URL: http://127.0.0.1:21929
-			baseURL := strings.TrimSuffix(strings.Split(osvServerURL, "#")[0], "/sse")
+			baseURL := strings.TrimSuffix(osvServerURL, "/mcp")
 			GinkgoWriter.Printf("Original server URL: %s\n", osvServerURL)
 			GinkgoWriter.Printf("Base URL for proxy: %s\n", baseURL)
 
@@ -373,17 +373,17 @@ var _ = Describe("Proxy OAuth Authentication E2E", Label("proxy", "oauth", "e2e"
 			time.Sleep(5 * time.Second)
 
 			By("Testing MCP connection through proxy")
-			proxyURL := fmt.Sprintf("http://localhost:%d/sse", proxyPort)
+			proxyURL := fmt.Sprintf("http://localhost:%d/mcp", proxyPort)
 
 			// Wait for proxy to be ready for MCP connections
-			err = e2e.WaitForMCPServerReady(config, proxyURL, "sse", 60*time.Second)
+			err = e2e.WaitForMCPServerReady(config, proxyURL, "streamable-http", 60*time.Second)
 			if err != nil {
 				GinkgoWriter.Printf("MCP connection through proxy failed: %v\n", err)
 				Skip("Skipping MCP test due to proxy not being ready")
 			}
 
 			By("Creating MCP client through proxy")
-			mcpClient, err := e2e.NewMCPClientForSSE(config, proxyURL)
+			mcpClient, err := e2e.NewMCPClientForStreamableHTTP(config, proxyURL)
 			Expect(err).ToNot(HaveOccurred())
 			defer mcpClient.Close()
 
@@ -410,7 +410,7 @@ var _ = Describe("Proxy OAuth Authentication E2E", Label("proxy", "oauth", "e2e"
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Extracting base URL for transparent proxy")
-			baseURL := strings.TrimSuffix(strings.Split(osvServerURL, "#")[0], "/sse")
+			baseURL := strings.TrimSuffix(osvServerURL, "/mcp")
 			GinkgoWriter.Printf("Base URL for proxy: %s\n", baseURL)
 
 			By("Starting the proxy with OAuth-enabled MCP support")
@@ -442,11 +442,11 @@ var _ = Describe("Proxy OAuth Authentication E2E", Label("proxy", "oauth", "e2e"
 			time.Sleep(3 * time.Second) // longer than the 2s lifespan
 
 			By("Reconnecting via MCP to trigger token refresh")
-			proxyURL := fmt.Sprintf("http://localhost:%d/sse", proxyPort)
-			err = e2e.WaitForMCPServerReady(config, proxyURL, "sse", 10*time.Second)
+			proxyURL := fmt.Sprintf("http://localhost:%d/mcp", proxyPort)
+			err = e2e.WaitForMCPServerReady(config, proxyURL, "streamable-http", 10*time.Second)
 			Expect(err).ToNot(HaveOccurred(), "MCP server not ready after token expiry")
 
-			mcpClient, err := e2e.NewMCPClientForSSE(config, proxyURL)
+			mcpClient, err := e2e.NewMCPClientForStreamableHTTP(config, proxyURL)
 			Expect(err).ToNot(HaveOccurred())
 			defer mcpClient.Close()
 

--- a/test/e2e/proxy_tunnel_e2e_test.go
+++ b/test/e2e/proxy_tunnel_e2e_test.go
@@ -33,7 +33,7 @@ var _ = Describe("Proxy Tunnel E2E", Label("proxy", "tunnel", "e2e"), Serial, fu
 		By("Starting OSV MCP server as target workload")
 		e2e.NewTHVCommand(config, "run",
 			"--name", osvServerName,
-			"--transport", "sse",
+			"--transport", "streamable-http",
 			"osv").ExpectSuccess()
 
 		By("Waiting for OSV server to be ready")

--- a/test/e2e/telemetry_middleware_e2e_test.go
+++ b/test/e2e/telemetry_middleware_e2e_test.go
@@ -38,7 +38,7 @@ var _ = Describe("Telemetry Middleware E2E", Label("middleware", "telemetry", "e
 		Expect(err).ToNot(HaveOccurred())
 		workloadName = generateUniqueTelemetryServerName("telemetry-test")
 		mcpServerName = "osv" // Use OSV server as a reliable test server
-		transportType = types.TransportTypeSSE
+		transportType = types.TransportTypeStreamableHTTP
 	})
 
 	JustBeforeEach(func() {
@@ -309,7 +309,8 @@ func startProxyStdioForTelemetryTest(config *e2e.TestConfig, workloadName string
 	Expect(err).ToNot(HaveOccurred())
 
 	// Extract base URL for transparent proxy
-	baseURL := strings.TrimSuffix(strings.Split(serverURL, "#")[0], "/sse")
+	// With streamable-http: http://127.0.0.1:PORT/mcp (no fragment)
+	baseURL := strings.TrimSuffix(serverURL, "/mcp")
 	GinkgoWriter.Printf("Base URL for telemetry proxy: %s\n", baseURL)
 
 	// Start the proxy command


### PR DESCRIPTION
Fixes #2210

## Summary

Changes the default proxy mode from the deprecated SSE transport to `streamable-http` to align with the MCP specification recommendations.

## Changes Made

### Core Application
- **CLI (`cmd/thv/app/run_flags.go`)**: Changed `--proxy-mode` flag default to `streamable-http` and updated validation function
- **API (`pkg/api/v1/workload_service.go`)**: Changed default proxy mode to `streamable-http`
- **MCP Client (`cmd/thv/app/mcp.go`)**: Updated transport auto-detection to default to `streamable-http`
- **Client Configs (`pkg/client/config.go`)**: Updated all 17 client integration mappings to map `stdio` transport to `streamable-http` variants
- **Documentation**: Updated architecture docs and regenerated CLI documentation

### E2E Tests
Updated 4 middleware/proxy e2e tests to use the new default transport:
- `audit_middleware_e2e_test.go`: Changed transport, client type, and labels
- `telemetry_middleware_e2e_test.go`: Changed transport and URL extraction
- `proxy_oauth_test.go`: Changed transport, URLs (`/mcp` instead of `/sse`), and client type
- `proxy_tunnel_e2e_test.go`: Changed transport

Tests that explicitly validate SSE behavior remain unchanged (`osv_mcp_server_test.go`, `proxy_stdio_test.go` SSE contexts).

## Breaking Change

This is a **breaking change** for users relying on the default SSE behavior. They will need to explicitly specify:
- CLI: `--proxy-mode sse`
- API: `"proxyMode": "sse"`

## Testing

- ✅ All linting checks pass
- ✅ Unit tests pass for modified packages
- ✅ E2E tests updated to reflect new defaults
- ✅ Backward compatibility maintained through explicit SSE options