### PR TITLE
Refactor auth resolution logic to config struct

### DIFF
--- a/pkg/vmcp/aggregator/cli_discoverer.go
+++ b/pkg/vmcp/aggregator/cli_discoverer.go
@@ -103,13 +103,11 @@ func (d *cliBackendDiscoverer) Discover(ctx context.Context, groupRef string) ([
 		}
 
 		// Apply authentication configuration if provided
-		if d.authConfig != nil {
-			authStrategy, authMetadata := d.resolveAuthConfig(name)
-			backend.AuthStrategy = authStrategy
-			backend.AuthMetadata = authMetadata
-			if authStrategy != "" {
-				logger.Debugf("Backend %s configured with auth strategy: %s", name, authStrategy)
-			}
+		authStrategy, authMetadata := d.authConfig.ResolveForBackend(name)
+		backend.AuthStrategy = authStrategy
+		backend.AuthMetadata = authMetadata
+		if authStrategy != "" {
+			logger.Debugf("Backend %s configured with auth strategy: %s", name, authStrategy)
 		}
 
 		// Copy user labels to metadata first
@@ -134,29 +132,6 @@ func (d *cliBackendDiscoverer) Discover(ctx context.Context, groupRef string) ([
 
 	logger.Infof("Discovered %d backends in group %s", len(backends), groupRef)
 	return backends, nil
-}
-
-// resolveAuthConfig determines the authentication strategy and metadata for a backend.
-// It checks for backend-specific configuration first, then falls back to default.
-func (d *cliBackendDiscoverer) resolveAuthConfig(backendID string) (string, map[string]any) {
-	if d.authConfig == nil {
-		return "", nil
-	}
-
-	// Check for backend-specific configuration
-	if strategy, exists := d.authConfig.Backends[backendID]; exists && strategy != nil {
-		logger.Debugf("Using backend-specific auth strategy for %s: %s", backendID, strategy.Type)
-		return strategy.Type, strategy.Metadata
-	}
-
-	// Fall back to default configuration
-	if d.authConfig.Default != nil {
-		logger.Debugf("Using default auth strategy for %s: %s", backendID, d.authConfig.Default.Type)
-		return d.authConfig.Default.Type, d.authConfig.Default.Metadata
-	}
-
-	// No authentication configured
-	return "", nil
 }
 
 // mapWorkloadStatusToHealth converts a workload status to a backend health status.

--- a/pkg/vmcp/config/config.go
+++ b/pkg/vmcp/config/config.go
@@ -125,6 +125,28 @@ type BackendAuthStrategy struct {
 	Metadata map[string]any
 }
 
+// ResolveForBackend returns the auth strategy and metadata for a given backend ID.
+// It checks for backend-specific config first, then falls back to default.
+// Returns empty string and nil if no authentication is configured.
+func (c *OutgoingAuthConfig) ResolveForBackend(backendID string) (string, map[string]any) {
+	if c == nil {
+		return "", nil
+	}
+
+	// Check for backend-specific configuration
+	if strategy, exists := c.Backends[backendID]; exists && strategy != nil {
+		return strategy.Type, strategy.Metadata
+	}
+
+	// Fall back to default configuration
+	if c.Default != nil {
+		return c.Default.Type, c.Default.Metadata
+	}
+
+	// No authentication configured
+	return "", nil
+}
+
 // AggregationConfig configures capability aggregation.
 type AggregationConfig struct {
 	// ConflictResolution is the strategy: "prefix", "priority", "manual"

--- a/pkg/vmcp/config/config_test.go
+++ b/pkg/vmcp/config/config_test.go
@@ -1,0 +1,146 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOutgoingAuthConfig_ResolveForBackend(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		config       *OutgoingAuthConfig
+		backendID    string
+		wantStrategy string
+		wantMetadata map[string]any
+		description  string
+	}{
+		{
+			name:         "nil config returns empty",
+			config:       nil,
+			backendID:    "backend1",
+			wantStrategy: "",
+			wantMetadata: nil,
+			description:  "When config is nil, should return empty values",
+		},
+		{
+			name: "backend-specific config takes precedence",
+			config: &OutgoingAuthConfig{
+				Default: &BackendAuthStrategy{
+					Type:     "default-strategy",
+					Metadata: map[string]any{"key": "default-value"},
+				},
+				Backends: map[string]*BackendAuthStrategy{
+					"backend1": {
+						Type:     "backend-specific-strategy",
+						Metadata: map[string]any{"key": "backend-value"},
+					},
+				},
+			},
+			backendID:    "backend1",
+			wantStrategy: "backend-specific-strategy",
+			wantMetadata: map[string]any{"key": "backend-value"},
+			description:  "Backend-specific config should override default",
+		},
+		{
+			name: "falls back to default when backend not configured",
+			config: &OutgoingAuthConfig{
+				Default: &BackendAuthStrategy{
+					Type:     "default-strategy",
+					Metadata: map[string]any{"key": "default-value"},
+				},
+				Backends: map[string]*BackendAuthStrategy{
+					"backend1": {
+						Type:     "backend-specific-strategy",
+						Metadata: map[string]any{"key": "backend-value"},
+					},
+				},
+			},
+			backendID:    "backend2",
+			wantStrategy: "default-strategy",
+			wantMetadata: map[string]any{"key": "default-value"},
+			description:  "Should use default when specific backend not configured",
+		},
+		{
+			name: "returns empty when no default and backend not configured",
+			config: &OutgoingAuthConfig{
+				Backends: map[string]*BackendAuthStrategy{
+					"backend1": {
+						Type:     "backend-specific-strategy",
+						Metadata: map[string]any{"key": "backend-value"},
+					},
+				},
+			},
+			backendID:    "backend2",
+			wantStrategy: "",
+			wantMetadata: nil,
+			description:  "Should return empty when no default and backend not in map",
+		},
+		{
+			name: "handles nil backend strategy in map",
+			config: &OutgoingAuthConfig{
+				Default: &BackendAuthStrategy{
+					Type:     "default-strategy",
+					Metadata: map[string]any{"key": "default-value"},
+				},
+				Backends: map[string]*BackendAuthStrategy{
+					"backend1": nil,
+				},
+			},
+			backendID:    "backend1",
+			wantStrategy: "default-strategy",
+			wantMetadata: map[string]any{"key": "default-value"},
+			description:  "Should fall back to default when backend strategy is nil",
+		},
+		{
+			name: "returns empty when only default is nil",
+			config: &OutgoingAuthConfig{
+				Default:  nil,
+				Backends: map[string]*BackendAuthStrategy{},
+			},
+			backendID:    "backend1",
+			wantStrategy: "",
+			wantMetadata: nil,
+			description:  "Should return empty when default is nil and backend not found",
+		},
+		{
+			name: "handles strategy with nil metadata",
+			config: &OutgoingAuthConfig{
+				Default: &BackendAuthStrategy{
+					Type:     "default-strategy",
+					Metadata: nil,
+				},
+			},
+			backendID:    "backend1",
+			wantStrategy: "default-strategy",
+			wantMetadata: nil,
+			description:  "Should handle nil metadata correctly",
+		},
+		{
+			name: "handles strategy with empty metadata",
+			config: &OutgoingAuthConfig{
+				Default: &BackendAuthStrategy{
+					Type:     "default-strategy",
+					Metadata: map[string]any{},
+				},
+			},
+			backendID:    "backend1",
+			wantStrategy: "default-strategy",
+			wantMetadata: map[string]any{},
+			description:  "Should return empty map when metadata is empty",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotStrategy, gotMetadata := tt.config.ResolveForBackend(tt.backendID)
+
+			assert.Equal(t, tt.wantStrategy, gotStrategy, "Strategy mismatch: %s", tt.description)
+			assert.Equal(t, tt.wantMetadata, gotMetadata, "Metadata mismatch: %s", tt.description)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Refactors authentication resolution logic from the CLI backend discoverer to the `OutgoingAuthConfig` struct for better separation of concerns and reusability.

## Changes

- **Added** `ResolveForBackend()` method to `OutgoingAuthConfig` in `pkg/vmcp/config/config.go`
- **Updated** CLI discoverer in `pkg/vmcp/aggregator/cli_discoverer.go` to use the new method
- **Removed** duplicate `resolveAuthConfig()` method from CLI discoverer
- **Added** comprehensive test coverage in `pkg/vmcp/config/config_test.go` with 8 test cases

## Benefits

- **Better separation of concerns**: Auth resolution logic now belongs in the config struct where it logically fits
- **Improved reusability**: The method can be used by any component that needs to resolve backend authentication
- **Better testability**: Logic can be tested independently without mocking the entire discoverer
- **Code reduction**: Removed 30 lines from CLI discoverer by moving logic to its proper home

## Test Coverage

All tests pass, including:
- ✅ Nil config handling
- ✅ Backend-specific config precedence  
- ✅ Default fallback behavior
- ✅ Edge cases (nil strategies, empty metadata, etc.)

## Related

Fixes #2465