### PR TITLE
Add token exchange authentication strategy

### DIFF
--- a/cmd/vmcp/example-config.yaml
+++ b/cmd/vmcp/example-config.yaml
@@ -34,13 +34,13 @@ incoming_auth:
   #   scopes: ["openid", "profile", "email"]
 
 # ===== OUTGOING AUTHENTICATION (Virtual MCP → Backends) =====
-# Implemented strategies: unauthenticated, header_injection
+# Implemented strategies: unauthenticated, header_injection, token_exchange
 outgoing_auth:
   source: inline  # Options: inline | discovered
 
   # Default behavior for backends without explicit config
   default:
-    type: unauthenticated  # Options: unauthenticated | header_injection
+    type: unauthenticated  # Options: unauthenticated | header_injection | token_exchange
     # TODO: Uncomment when pass_through is implemented
     # type: pass_through
 
@@ -51,17 +51,18 @@ outgoing_auth:
   #     type: header_injection
   #     header_injection:
   #       header_name: "Authorization"
-  #       header_value: "${GITHUB_API_TOKEN}"
+  #       header_value: "your-github-api-token-here"
   #
-  #   # TODO: Uncomment when token_exchange is implemented
-  #   # jira:
-  #   #   type: token_exchange
-  #   #   metadata:
-  #   #     token_url: "https://keycloak.example.com/realms/myrealm/protocol/openid-connect/token"
-  #   #     client_id: "vmcp-github-exchange"
-  #   #     client_secret_env: "GITHUB_EXCHANGE_SECRET"
-  #   #     audience: "github-api"
-  #   #     scopes: ["repo", "read:org"]
+  #   # Example: OAuth 2.0 Token Exchange (RFC 8693)
+  #   jira:
+  #     type: token_exchange
+  #     token_exchange:
+  #       token_url: "https://keycloak.example.com/realms/myrealm/protocol/openid-connect/token"
+  #       client_id: "vmcp-jira-exchange"
+  #       client_secret_env: "JIRA_EXCHANGE_SECRET"
+  #       audience: "jira-api"
+  #       scopes: ["read:jira-work", "write:jira-work"]
+  #       subject_token_type: "access_token"  # Optional: access_token | id_token | jwt
 
 # ===== TOOL AGGREGATION =====
 aggregation:

--- a/examples/vmcp-config.yaml
+++ b/examples/vmcp-config.yaml
@@ -34,7 +34,7 @@ outgoing_auth:
 
   # Default behavior for backends without explicit config
   default:
-    type: unauthenticated  # unauthenticated | header_injection
+    type: unauthenticated  # unauthenticated | header_injection | token_exchange
     # TODO: Uncomment when pass_through is implemented
     # type: pass_through  # Forward client token unchanged
 
@@ -48,24 +48,24 @@ outgoing_auth:
       type: header_injection
       header_injection:
         header_name: "Authorization"
-        header_value: "${GITHUB_API_TOKEN}"  # Read from environment variable
+        header_value: "your-github-api-token-here"
 
-    # TODO: Uncomment when token_exchange strategy is implemented
+    # Example: OAuth 2.0 Token Exchange (RFC 8693) for GitHub API access
     # github:
     #   type: token_exchange
-    #   metadata:
+    #   token_exchange:
     #     # RFC 8693 token exchange for GitHub API access
     #     token_url: "https://keycloak.example.com/realms/myrealm/protocol/openid-connect/token"
     #     client_id: "vmcp-github-exchange"
     #     client_secret_env: "GITHUB_EXCHANGE_SECRET"
     #     audience: "github-api"  # Token audience for GitHub API
     #     scopes: ["repo", "read:org"]  # GitHub API scopes
-    #     subject_token_type: "access_token"  # access_token | id_token
+    #     subject_token_type: "access_token"  # Optional: access_token | id_token | jwt
 
-    # TODO: Uncomment when token_exchange strategy is implemented
+    # Example: Token Exchange for Jira API access
     # jira:
     #   type: token_exchange
-    #   metadata:
+    #   token_exchange:
     #     token_url: "https://keycloak.example.com/realms/myrealm/protocol/openid-connect/token"
     #     client_id: "vmcp-jira-exchange"
     #     client_secret_env: "JIRA_EXCHANGE_SECRET"

--- a/pkg/vmcp/auth/factory/outgoing.go
+++ b/pkg/vmcp/auth/factory/outgoing.go
@@ -158,6 +158,8 @@ func createStrategy(strategyType string) (auth.Strategy, error) {
 	switch strategyType {
 	case strategies.StrategyTypeHeaderInjection:
 		return strategies.NewHeaderInjectionStrategy(), nil
+	case strategies.StrategyTypeTokenExchange:
+		return strategies.NewTokenExchangeStrategy(), nil
 	case strategies.StrategyTypeUnauthenticated:
 		return strategies.NewUnauthenticatedStrategy(), nil
 	default:

--- a/pkg/vmcp/auth/strategies/constants.go
+++ b/pkg/vmcp/auth/strategies/constants.go
@@ -11,6 +11,11 @@ const (
 	// StrategyTypeHeaderInjection identifies the header injection strategy.
 	// This strategy injects a static header value into request headers.
 	StrategyTypeHeaderInjection = "header_injection"
+
+	// StrategyTypeTokenExchange identifies the token exchange strategy.
+	// This strategy exchanges an incoming token for a new token to use
+	// when authenticating to the backend service.
+	StrategyTypeTokenExchange = "token_exchange"
 )
 
 // Metadata key names used in strategy configurations.

--- a/pkg/vmcp/auth/strategies/tokenexchange.go
+++ b/pkg/vmcp/auth/strategies/tokenexchange.go
@@ -1,0 +1,350 @@
+package strategies
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/stacklok/toolhive/pkg/auth"
+	"github.com/stacklok/toolhive/pkg/auth/tokenexchange"
+)
+
+const (
+	// nonePlaceholder is used to represent empty or missing values in cache keys
+	nonePlaceholder = "<none>"
+)
+
+// TokenExchangeStrategy exchanges the client's token for a backend-specific token
+// using RFC 8693 token exchange protocol.
+//
+// This strategy implements OAuth 2.0 Token Exchange (RFC 8693) to convert a client's
+// token into a backend-specific token that the backend MCP server can validate.
+//
+// The strategy caches ExchangeConfig instances per backend configuration to avoid
+// recreating configuration objects. Per-user token caching is handled by the upper
+// vMCP TokenCache layer.
+//
+// Required metadata fields:
+//   - token_url: The OAuth 2.0 token endpoint URL for token exchange
+//
+// Optional metadata fields:
+//   - client_id: OAuth 2.0 client identifier (required for some token endpoints)
+//   - client_secret: OAuth 2.0 client secret (directly provided, mutually exclusive with client_secret_env)
+//   - client_secret_env: Name of environment variable containing the client secret (mutually exclusive with client_secret)
+//   - audience: Target audience for the exchanged token
+//   - scopes: Array of scope strings to request
+//   - subject_token_type: Type of the subject token (default: "access_token")
+//
+// This strategy is appropriate when:
+//   - The backend uses a different identity provider than the vMCP server
+//   - Token exchange relationships are configured between the identity providers
+//   - Per-user token exchange is required (not static credentials)
+type TokenExchangeStrategy struct {
+	// exchangeConfigs caches server-level ExchangeConfig templates.
+	// Key: buildCacheKey(config) - one entry per backend server.
+	// Each template is shared across all users connecting to that server.
+	exchangeConfigs map[string]*tokenexchange.ExchangeConfig
+	mu              sync.RWMutex
+}
+
+// NewTokenExchangeStrategy creates a new TokenExchangeStrategy instance.
+func NewTokenExchangeStrategy() *TokenExchangeStrategy {
+	return &TokenExchangeStrategy{
+		exchangeConfigs: make(map[string]*tokenexchange.ExchangeConfig),
+	}
+}
+
+// Name returns the strategy identifier.
+func (*TokenExchangeStrategy) Name() string {
+	return "token_exchange"
+}
+
+// Authenticate exchanges the client's token for a backend token and injects it.
+//
+// This method:
+//  1. Retrieves the client's identity and token from the context
+//  2. Parses and validates the token exchange configuration from metadata
+//  3. Gets or creates a cached ExchangeConfig for this backend configuration
+//  4. Creates a TokenSource with the current identity token
+//  5. Obtains an access token by performing the exchange
+//  6. Injects the token into the backend request's Authorization header
+//
+// Token caching per user is handled by the upper vMCP TokenCache layer.
+// This strategy only caches the ExchangeConfig template per backend.
+//
+// Parameters:
+//   - ctx: Request context containing the authenticated identity
+//   - req: The HTTP request to authenticate
+//   - metadata: Strategy-specific configuration for token exchange
+//
+// Returns an error if:
+//   - No identity is found in the context
+//   - The identity has no token
+//   - Metadata is invalid or incomplete
+//   - Token exchange fails
+func (s *TokenExchangeStrategy) Authenticate(ctx context.Context, req *http.Request, metadata map[string]any) error {
+	identity, ok := auth.IdentityFromContext(ctx)
+	if !ok {
+		return fmt.Errorf("no identity found in context")
+	}
+
+	if identity.Token == "" {
+		return fmt.Errorf("identity has no token")
+	}
+
+	config, err := parseTokenExchangeMetadata(metadata)
+	if err != nil {
+		return fmt.Errorf("invalid metadata: %w", err)
+	}
+
+	// Get user-specific exchange config. This creates a fresh config instance
+	// with the current user's token. The underlying server config is cached.
+	exchangeConfig := s.createUserConfig(config, identity.Token)
+	tokenSource := exchangeConfig.TokenSource(ctx)
+
+	token, err := tokenSource.Token()
+	if err != nil {
+		return fmt.Errorf("token exchange failed: %w", err)
+	}
+
+	// Inject exchanged token into request
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token.AccessToken))
+	return nil
+}
+
+// Validate checks if the required metadata fields are present and valid.
+//
+// This method verifies that:
+//   - token_url is present and valid
+//   - Optional fields (if present) have correct types and values
+//   - client_secret is only provided when client_id is present
+//
+// This validation is typically called during configuration parsing to fail fast
+// if the strategy is misconfigured.
+func (*TokenExchangeStrategy) Validate(metadata map[string]any) error {
+	_, err := parseTokenExchangeMetadata(metadata)
+	return err
+}
+
+// tokenExchangeConfig holds the parsed token exchange configuration.
+type tokenExchangeConfig struct {
+	TokenURL         string
+	ClientID         string
+	ClientSecret     string
+	Audience         string
+	Scopes           []string
+	SubjectTokenType string
+}
+
+// parseClientSecret parses and validates client_secret or client_secret_env from metadata.
+// Returns the resolved client secret, or an error if validation fails.
+func parseClientSecret(metadata map[string]any, clientID string) (string, error) {
+	// Check for client_secret first (takes precedence)
+	if clientSecret, ok := metadata["client_secret"].(string); ok {
+		if clientID == "" {
+			return "", fmt.Errorf("client_secret cannot be provided without client_id")
+		}
+		return clientSecret, nil
+	}
+
+	// Check for client_secret_env
+	if clientSecretEnv, ok := metadata["client_secret_env"].(string); ok && clientSecretEnv != "" {
+		if clientID == "" {
+			return "", fmt.Errorf("client_secret_env cannot be provided without client_id")
+		}
+		// Resolve the environment variable
+		secret := os.Getenv(clientSecretEnv)
+		if secret == "" {
+			return "", fmt.Errorf("environment variable %s not set or empty", clientSecretEnv)
+		}
+		return secret, nil
+	}
+
+	// No client secret provided (which is valid)
+	return "", nil
+}
+
+// parseTokenExchangeMetadata parses and validates token exchange metadata.
+func parseTokenExchangeMetadata(metadata map[string]any) (*tokenExchangeConfig, error) {
+	config := &tokenExchangeConfig{}
+
+	// Required: token_url
+	tokenURL, ok := metadata["token_url"].(string)
+	if !ok || tokenURL == "" {
+		return nil, fmt.Errorf("token_url required in metadata")
+	}
+	config.TokenURL = tokenURL
+
+	// Optional: client_id
+	if clientID, ok := metadata["client_id"].(string); ok {
+		config.ClientID = clientID
+	}
+
+	// Optional: client_secret or client_secret_env
+	clientSecret, err := parseClientSecret(metadata, config.ClientID)
+	if err != nil {
+		return nil, err
+	}
+	config.ClientSecret = clientSecret
+
+	// Optional: audience
+	if audience, ok := metadata["audience"].(string); ok {
+		config.Audience = audience
+	}
+
+	// Optional: scopes (can be string array or single string)
+	if scopesRaw, ok := metadata["scopes"]; ok {
+		switch v := scopesRaw.(type) {
+		case []string:
+			config.Scopes = v
+		case []any:
+			// Handle case where JSON unmarshaling gives []any
+			scopes := make([]string, 0, len(v))
+			for i, s := range v {
+				str, ok := s.(string)
+				if !ok {
+					return nil, fmt.Errorf("scopes[%d] must be a string", i)
+				}
+				scopes = append(scopes, str)
+			}
+			config.Scopes = scopes
+		case string:
+			// Single scope as string
+			config.Scopes = []string{v}
+		default:
+			return nil, fmt.Errorf("scopes must be a string or array of strings")
+		}
+	}
+
+	// Optional: subject_token_type
+	if subjectTokenType, ok := metadata["subject_token_type"].(string); ok {
+		// Validate if provided
+		normalized, err := tokenexchange.NormalizeTokenType(subjectTokenType)
+		if err != nil {
+			return nil, fmt.Errorf("invalid subject_token_type: %w", err)
+		}
+		config.SubjectTokenType = normalized
+	}
+
+	return config, nil
+}
+
+// getOrCreateServerConfig retrieves or creates a cached server-level ExchangeConfig.
+//
+// Server configs are cached per backend and shared across all users. This prevents
+// redundant config parsing and validation. The cached config does NOT include
+// SubjectTokenProvider - that's set per-user in createUserConfig().
+//
+// Thread-safe: Uses double-checked locking pattern.
+func (s *TokenExchangeStrategy) getOrCreateServerConfig(
+	config *tokenExchangeConfig,
+) *tokenexchange.ExchangeConfig {
+	cacheKey := buildCacheKey(config)
+
+	// Fast path: read lock
+	s.mu.RLock()
+	if cached, exists := s.exchangeConfigs[cacheKey]; exists {
+		s.mu.RUnlock()
+		return cached
+	}
+	s.mu.RUnlock()
+
+	// Slow path: write lock
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Double-check in case another goroutine created it
+	if cached, exists := s.exchangeConfigs[cacheKey]; exists {
+		return cached
+	}
+
+	// Create template (without SubjectTokenProvider)
+	template := &tokenexchange.ExchangeConfig{
+		TokenURL:         config.TokenURL,
+		ClientID:         config.ClientID,
+		ClientSecret:     config.ClientSecret,
+		Audience:         config.Audience,
+		Scopes:           config.Scopes,
+		SubjectTokenType: config.SubjectTokenType,
+	}
+
+	s.exchangeConfigs[cacheKey] = template
+	return template
+}
+
+// createUserConfig creates a user-specific ExchangeConfig instance.
+//
+// This function:
+//  1. Gets the cached server config template
+//  2. Creates a copy for this user
+//  3. Sets SubjectTokenProvider to return the user's token
+//
+// The identityToken parameter is a string value (not reference) to ensure
+// the closure captures an immutable value, preventing bugs if the token
+// changes after this call.
+func (s *TokenExchangeStrategy) createUserConfig(
+	config *tokenExchangeConfig,
+	identityToken string,
+) *tokenexchange.ExchangeConfig {
+	// Get cached server template
+	serverTemplate := s.getOrCreateServerConfig(config)
+
+	// Create user-specific copy
+	userConfig := *serverTemplate
+	userConfig.SubjectTokenProvider = func() (string, error) {
+		return identityToken, nil
+	}
+
+	return &userConfig
+}
+
+// buildCacheKey creates a unique cache key for server-level configs.
+// The key includes all parameters that differentiate backend servers:
+//   - token_url: OAuth token endpoint
+//   - client_id: OAuth client identifier
+//   - audience: Target audience
+//   - scopes: Requested scopes (sorted for consistency)
+//   - subject_token_type: Type of subject token
+//
+// Note: No user identity is included - server configs are shared across users.
+func buildCacheKey(config *tokenExchangeConfig) string {
+	// Handle client_id (empty becomes nonePlaceholder)
+	clientID := config.ClientID
+	if clientID == "" {
+		clientID = nonePlaceholder
+	}
+
+	// Handle audience (empty becomes nonePlaceholder)
+	audience := config.Audience
+	if audience == "" {
+		audience = nonePlaceholder
+	}
+
+	// Handle scopes (sort and join, empty becomes nonePlaceholder)
+	scopesStr := nonePlaceholder
+	if len(config.Scopes) > 0 {
+		sortedScopes := make([]string, len(config.Scopes))
+		copy(sortedScopes, config.Scopes)
+		sort.Strings(sortedScopes)
+		scopesStr = strings.Join(sortedScopes, ",")
+	}
+
+	// Handle subject_token_type (empty becomes nonePlaceholder)
+	tokenType := config.SubjectTokenType
+	if tokenType == "" {
+		tokenType = nonePlaceholder
+	}
+
+	// Format: token_url:client_id:audience:scopes:subject_token_type
+	return fmt.Sprintf("%s:%s:%s:%s:%s",
+		config.TokenURL,
+		clientID,
+		audience,
+		scopesStr,
+		tokenType,
+	)
+}

--- a/pkg/vmcp/auth/strategies/tokenexchange_test.go
+++ b/pkg/vmcp/auth/strategies/tokenexchange_test.go
@@ -1,0 +1,562 @@
+package strategies
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stacklok/toolhive/pkg/auth"
+)
+
+// Test helpers for reducing boilerplate
+
+func createTestIdentity(subject, token string) *auth.Identity {
+	return &auth.Identity{
+		Subject: subject,
+		Token:   token,
+	}
+}
+
+func createContextWithIdentity(subject, token string) context.Context {
+	return auth.WithIdentity(context.Background(), createTestIdentity(subject, token))
+}
+
+func createSuccessfulTokenServer(t *testing.T, tokenPrefix string, validateForm func(*testing.T, *http.Request)) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Helper()
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "application/x-www-form-urlencoded", r.Header.Get("Content-Type"))
+
+		err := r.ParseForm()
+		require.NoError(t, err)
+
+		if validateForm != nil {
+			validateForm(t, r)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"access_token":      tokenPrefix,
+			"token_type":        "Bearer",
+			"issued_token_type": "urn:ietf:params:oauth:token-type:access_token",
+			"expires_in":        3600,
+		})
+	}))
+}
+
+func TestTokenExchangeStrategy_Authenticate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		setupCtx        func() context.Context
+		metadata        map[string]any
+		setupServer     func() *httptest.Server
+		expectError     bool
+		errorContains   string
+		checkAuthHeader func(t *testing.T, req *http.Request)
+	}{
+		{
+			name:     "successfully exchanges token",
+			setupCtx: func() context.Context { return createContextWithIdentity("user123", "client-token") },
+			setupServer: func() *httptest.Server {
+				return createSuccessfulTokenServer(t, "backend-token-123", func(t *testing.T, r *http.Request) {
+					t.Helper()
+					assert.Equal(t, "urn:ietf:params:oauth:grant-type:token-exchange", r.Form.Get("grant_type"))
+					assert.Equal(t, "client-token", r.Form.Get("subject_token"))
+				})
+			},
+			expectError: false,
+			checkAuthHeader: func(t *testing.T, req *http.Request) {
+				t.Helper()
+				assert.Equal(t, "Bearer backend-token-123", req.Header.Get("Authorization"))
+			},
+		},
+		{
+			name:     "includes audience in token exchange",
+			setupCtx: func() context.Context { return createContextWithIdentity("user456", "client-token-2") },
+			setupServer: func() *httptest.Server {
+				return createSuccessfulTokenServer(t, "backend-token", func(t *testing.T, r *http.Request) {
+					t.Helper()
+					assert.Equal(t, "https://backend.example.com", r.Form.Get("audience"))
+				})
+			},
+			metadata: map[string]any{
+				"audience": "https://backend.example.com",
+			},
+			expectError: false,
+		},
+		{
+			name:     "includes scopes in token exchange",
+			setupCtx: func() context.Context { return createContextWithIdentity("user789", "client-token-3") },
+			setupServer: func() *httptest.Server {
+				return createSuccessfulTokenServer(t, "backend-token", func(t *testing.T, r *http.Request) {
+					t.Helper()
+					assert.Equal(t, "read write", r.Form.Get("scope"))
+				})
+			},
+			metadata: map[string]any{
+				"scopes": []string{"read", "write"},
+			},
+			expectError: false,
+		},
+		{
+			name:     "includes client credentials in token exchange",
+			setupCtx: func() context.Context { return createContextWithIdentity("admin-user", "admin-token") },
+			setupServer: func() *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					t.Helper()
+					username, password, ok := r.BasicAuth()
+					assert.True(t, ok)
+					assert.Equal(t, "client-id", username)
+					assert.Equal(t, "client-secret", password)
+
+					w.Header().Set("Content-Type", "application/json")
+					json.NewEncoder(w).Encode(map[string]any{
+						"access_token":      "backend-token",
+						"token_type":        "Bearer",
+						"issued_token_type": "urn:ietf:params:oauth:token-type:access_token",
+					})
+				}))
+			},
+			metadata: map[string]any{
+				"client_id":     "client-id",
+				"client_secret": "client-secret",
+			},
+			expectError: false,
+		},
+		{
+			name:     "returns error when no identity in context",
+			setupCtx: func() context.Context { return context.Background() },
+			setupServer: func() *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+					t.Error("Server should not be called")
+				}))
+			},
+			expectError:   true,
+			errorContains: "no identity",
+		},
+		{
+			name:     "returns error when identity has no token",
+			setupCtx: func() context.Context { return createContextWithIdentity("no-token-user", "") },
+			setupServer: func() *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+					t.Error("Server should not be called")
+				}))
+			},
+			expectError:   true,
+			errorContains: "no token",
+		},
+		{
+			name:          "returns error when metadata is invalid",
+			setupCtx:      func() context.Context { return createContextWithIdentity("metadata-test-user", "metadata-token") },
+			setupServer:   nil,              // No server needed for validation error
+			metadata:      map[string]any{}, // Missing token_url
+			expectError:   true,
+			errorContains: "invalid metadata",
+		},
+		{
+			name:     "returns error when token exchange fails",
+			setupCtx: func() context.Context { return createContextWithIdentity("fail-user", "invalid-token") },
+			setupServer: func() *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					w.WriteHeader(http.StatusUnauthorized)
+					json.NewEncoder(w).Encode(map[string]any{
+						"error":             "invalid_grant",
+						"error_description": "The subject token is invalid",
+					})
+				}))
+			},
+			expectError:   true,
+			errorContains: "token exchange failed",
+		},
+		{
+			name:     "returns error when response is missing access_token",
+			setupCtx: func() context.Context { return createContextWithIdentity("missing-token-user", "test-token") },
+			setupServer: func() *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					w.Header().Set("Content-Type", "application/json")
+					json.NewEncoder(w).Encode(map[string]any{
+						"token_type":        "Bearer",
+						"issued_token_type": "urn:ietf:params:oauth:token-type:access_token",
+					})
+				}))
+			},
+			expectError:   true,
+			errorContains: "empty access_token",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var server *httptest.Server
+			if tt.setupServer != nil {
+				server = tt.setupServer()
+				defer server.Close()
+			}
+
+			strategy := NewTokenExchangeStrategy()
+			ctx := tt.setupCtx()
+
+			metadata := tt.metadata
+			if metadata == nil {
+				metadata = map[string]any{}
+			}
+			if server != nil {
+				metadata["token_url"] = server.URL
+			}
+
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+			err := strategy.Authenticate(ctx, req, metadata)
+
+			if tt.expectError {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errorContains)
+				return
+			}
+
+			require.NoError(t, err)
+			if tt.checkAuthHeader != nil {
+				tt.checkAuthHeader(t, req)
+			}
+		})
+	}
+}
+
+func TestTokenExchangeStrategy_Validate(t *testing.T) {
+	t.Parallel()
+
+	validBaseMetadata := map[string]any{"token_url": "https://auth.example.com/token"}
+
+	tests := []struct {
+		name        string
+		metadata    map[string]any
+		expectError string // empty means no error expected
+	}{
+		{name: "valid with only token_url", metadata: validBaseMetadata},
+		{name: "valid with all fields", metadata: map[string]any{
+			"token_url": "https://auth.example.com/token", "client_id": "my-client",
+			"client_secret": "my-secret", "audience": "https://backend.example.com",
+			"scopes": []string{"read", "write"}, "subject_token_type": "access_token",
+		}},
+		{name: "valid with string scopes", metadata: map[string]any{"token_url": "https://auth.example.com/token", "scopes": "read"}},
+		{name: "valid with id_token type", metadata: map[string]any{"token_url": "https://auth.example.com/token", "subject_token_type": "id_token"}},
+		{name: "valid with client_id only", metadata: map[string]any{"token_url": "https://auth.example.com/token", "client_id": "my-client"}},
+		{name: "valid with extra fields", metadata: map[string]any{"token_url": "https://auth.example.com/token", "extra": "ignored"}},
+		{name: "error on missing token_url", metadata: map[string]any{}, expectError: "token_url required"},
+		{name: "error on nil metadata", metadata: nil, expectError: "token_url required"},
+		{name: "error on client_secret without client_id", metadata: map[string]any{"token_url": "https://auth.example.com/token", "client_secret": "secret"}, expectError: "client_secret cannot be provided without client_id"},
+		{name: "error on client_secret_env without client_id", metadata: map[string]any{"token_url": "https://auth.example.com/token", "client_secret_env": "TEST_SECRET"}, expectError: "client_secret_env cannot be provided without client_id"},
+		{name: "error on invalid scopes type", metadata: map[string]any{"token_url": "https://auth.example.com/token", "scopes": 123}, expectError: "scopes must be a string or array"},
+		{name: "error on non-string in scopes", metadata: map[string]any{"token_url": "https://auth.example.com/token", "scopes": []any{"read", 123}}, expectError: "scopes[1] must be a string"},
+		{name: "error on invalid token type", metadata: map[string]any{"token_url": "https://auth.example.com/token", "subject_token_type": "invalid"}, expectError: "invalid subject_token_type"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			strategy := NewTokenExchangeStrategy()
+			err := strategy.Validate(tt.metadata)
+
+			if tt.expectError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectError)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestTokenExchangeStrategy_CacheSeparation(t *testing.T) {
+	t.Parallel()
+
+	// This test verifies that different configurations result in separate cache entries
+	server1 := createSuccessfulTokenServer(t, "token-scope-read", nil)
+	defer server1.Close()
+
+	server2 := createSuccessfulTokenServer(t, "token-scope-write", nil)
+	defer server2.Close()
+
+	strategy := NewTokenExchangeStrategy()
+	ctx := createContextWithIdentity("cache-test-user", "test-token")
+
+	// First request with "read" scope
+	metadata1 := map[string]any{
+		"token_url": server1.URL,
+		"scopes":    []string{"read"},
+	}
+	req1 := httptest.NewRequest(http.MethodGet, "/test", nil)
+	err := strategy.Authenticate(ctx, req1, metadata1)
+	require.NoError(t, err)
+	assert.Equal(t, "Bearer token-scope-read", req1.Header.Get("Authorization"))
+
+	// Second request with "write" scope - should use different cache entry
+	metadata2 := map[string]any{
+		"token_url": server2.URL,
+		"scopes":    []string{"write"},
+	}
+	req2 := httptest.NewRequest(http.MethodGet, "/test", nil)
+	err = strategy.Authenticate(ctx, req2, metadata2)
+	require.NoError(t, err)
+	assert.Equal(t, "Bearer token-scope-write", req2.Header.Get("Authorization"))
+
+	// Verify we have two separate cache entries (config-level)
+	strategy.mu.RLock()
+	assert.Len(t, strategy.exchangeConfigs, 2, "Should have two separate cache entries")
+	strategy.mu.RUnlock()
+}
+
+func TestTokenExchangeStrategy_CacheHitWithDifferentScopeOrder(t *testing.T) {
+	t.Parallel()
+
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		callCount++
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"access_token":      "cached-token",
+			"token_type":        "Bearer",
+			"issued_token_type": "urn:ietf:params:oauth:token-type:access_token",
+			"expires_in":        3600,
+		})
+	}))
+	defer server.Close()
+
+	strategy := NewTokenExchangeStrategy()
+	ctx := createContextWithIdentity("scope-order-user", "test-token")
+
+	// First request with scopes in one order
+	metadata1 := map[string]any{
+		"token_url": server.URL,
+		"scopes":    []string{"write", "read", "admin"},
+	}
+	req1 := httptest.NewRequest(http.MethodGet, "/test", nil)
+	err := strategy.Authenticate(ctx, req1, metadata1)
+	require.NoError(t, err)
+
+	// Second request with same scopes in different order
+	metadata2 := map[string]any{
+		"token_url": server.URL,
+		"scopes":    []string{"admin", "read", "write"},
+	}
+	req2 := httptest.NewRequest(http.MethodGet, "/test", nil)
+	err = strategy.Authenticate(ctx, req2, metadata2)
+	require.NoError(t, err)
+
+	// Note: callCount will be 2 since we don't cache per-user tokens at this layer
+	// Upper vMCP layer handles token caching. We only cache ExchangeConfig.
+	assert.Equal(t, 2, callCount, "Each request performs a new exchange (no per-user token caching at this layer)")
+
+	// Verify only one ExchangeConfig cache entry exists (config-level caching)
+	strategy.mu.RLock()
+	assert.Len(t, strategy.exchangeConfigs, 1, "Should have only one ExchangeConfig cache entry")
+	strategy.mu.RUnlock()
+}
+
+// TestTokenExchangeStrategy_SharedConfigAcrossUsers verifies that different users
+// with the same backend configuration share the same cached ExchangeConfig.
+func TestTokenExchangeStrategy_SharedConfigAcrossUsers(t *testing.T) {
+	t.Parallel()
+
+	server := createSuccessfulTokenServer(t, "backend-token", nil)
+	defer server.Close()
+
+	strategy := NewTokenExchangeStrategy()
+	metadata := map[string]any{
+		"token_url": server.URL,
+		"scopes":    []string{"read", "write"},
+	}
+
+	// First user makes a request
+	ctx1 := createContextWithIdentity("user1", "user1-token")
+	req1 := httptest.NewRequest(http.MethodGet, "/test", nil)
+	err := strategy.Authenticate(ctx1, req1, metadata)
+	require.NoError(t, err)
+
+	// Second user makes a request with same config
+	ctx2 := createContextWithIdentity("user2", "user2-token")
+	req2 := httptest.NewRequest(http.MethodGet, "/test", nil)
+	err = strategy.Authenticate(ctx2, req2, metadata)
+	require.NoError(t, err)
+
+	// Verify only one ExchangeConfig cache entry exists (shared across users)
+	strategy.mu.RLock()
+	assert.Len(t, strategy.exchangeConfigs, 1, "Should have only one ExchangeConfig for both users")
+	strategy.mu.RUnlock()
+}
+
+// TestTokenExchangeStrategy_CurrentTokenUsed verifies that the current identity
+// token is used at exchange time, not a stale cached token.
+func TestTokenExchangeStrategy_CurrentTokenUsed(t *testing.T) {
+	t.Parallel()
+
+	var capturedToken string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		err := r.ParseForm()
+		require.NoError(t, err)
+		capturedToken = r.Form.Get("subject_token")
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"access_token":      "backend-token",
+			"token_type":        "Bearer",
+			"issued_token_type": "urn:ietf:params:oauth:token-type:access_token",
+			"expires_in":        3600,
+		})
+	}))
+	defer server.Close()
+
+	strategy := NewTokenExchangeStrategy()
+	metadata := map[string]any{
+		"token_url": server.URL,
+	}
+
+	// First request with initial token
+	ctx1 := createContextWithIdentity("user1", "initial-token")
+	req1 := httptest.NewRequest(http.MethodGet, "/test", nil)
+	err := strategy.Authenticate(ctx1, req1, metadata)
+	require.NoError(t, err)
+	assert.Equal(t, "initial-token", capturedToken, "Should use initial token")
+
+	// Second request with refreshed token (simulating token refresh)
+	ctx2 := createContextWithIdentity("user1", "refreshed-token")
+	req2 := httptest.NewRequest(http.MethodGet, "/test", nil)
+	err = strategy.Authenticate(ctx2, req2, metadata)
+	require.NoError(t, err)
+	assert.Equal(t, "refreshed-token", capturedToken, "Should use current refreshed token, not cached stale token")
+}
+
+//nolint:paralleltest // Cannot use t.Parallel() with t.Setenv()
+func TestTokenExchangeStrategy_ClientSecretEnv(t *testing.T) {
+	tests := []struct {
+		name          string
+		setupEnv      func(t *testing.T)
+		metadata      map[string]any
+		expectError   bool
+		errorContains string
+		validateAuth  func(t *testing.T, r *http.Request)
+	}{
+		{
+			name: "successfully resolves client_secret from environment variable",
+			setupEnv: func(t *testing.T) {
+				t.Helper()
+				t.Setenv("TEST_CLIENT_SECRET", "secret-from-env")
+			},
+			metadata: map[string]any{
+				"client_id":         "test-client",
+				"client_secret_env": "TEST_CLIENT_SECRET",
+			},
+			expectError: false,
+			validateAuth: func(t *testing.T, r *http.Request) {
+				t.Helper()
+				username, password, ok := r.BasicAuth()
+				assert.True(t, ok, "Basic auth should be present")
+				assert.Equal(t, "test-client", username)
+				assert.Equal(t, "secret-from-env", password)
+			},
+		},
+		{
+			name: "error when environment variable is not set",
+			setupEnv: func(t *testing.T) {
+				t.Helper()
+				// Don't set the environment variable
+			},
+			metadata: map[string]any{
+				"client_id":         "test-client",
+				"client_secret_env": "MISSING_ENV_VAR",
+			},
+			expectError:   true,
+			errorContains: "environment variable MISSING_ENV_VAR not set",
+		},
+		{
+			name: "error when environment variable is empty",
+			setupEnv: func(t *testing.T) {
+				t.Helper()
+				t.Setenv("EMPTY_SECRET", "")
+			},
+			metadata: map[string]any{
+				"client_id":         "test-client",
+				"client_secret_env": "EMPTY_SECRET",
+			},
+			expectError:   true,
+			errorContains: "environment variable EMPTY_SECRET not set or empty",
+		},
+		{
+			name: "client_secret takes precedence over client_secret_env",
+			setupEnv: func(t *testing.T) {
+				t.Helper()
+				t.Setenv("TEST_SECRET_ENV", "env-secret")
+			},
+			metadata: map[string]any{
+				"client_id":         "test-client",
+				"client_secret":     "direct-secret",
+				"client_secret_env": "TEST_SECRET_ENV",
+			},
+			expectError: false,
+			validateAuth: func(t *testing.T, r *http.Request) {
+				t.Helper()
+				username, password, ok := r.BasicAuth()
+				assert.True(t, ok)
+				assert.Equal(t, "test-client", username)
+				assert.Equal(t, "direct-secret", password, "client_secret should take precedence")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.setupEnv != nil {
+				tt.setupEnv(t)
+			}
+
+			strategy := NewTokenExchangeStrategy()
+
+			// Validation test
+			metadata := tt.metadata
+			if metadata == nil {
+				metadata = map[string]any{}
+			}
+			metadata["token_url"] = "https://auth.example.com/token"
+
+			err := strategy.Validate(metadata)
+
+			if tt.expectError {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errorContains)
+				return
+			}
+
+			require.NoError(t, err)
+
+			// If validation passes, test actual authentication
+			if tt.validateAuth != nil {
+				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					tt.validateAuth(t, r)
+					w.Header().Set("Content-Type", "application/json")
+					json.NewEncoder(w).Encode(map[string]any{
+						"access_token":      "backend-token",
+						"token_type":        "Bearer",
+						"issued_token_type": "urn:ietf:params:oauth:token-type:access_token",
+					})
+				}))
+				defer server.Close()
+
+				metadata["token_url"] = server.URL
+				ctx := createContextWithIdentity("test-user", "user-token")
+				req := httptest.NewRequest(http.MethodGet, "/test", nil)
+
+				err := strategy.Authenticate(ctx, req, metadata)
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/vmcp/config/validator.go
+++ b/pkg/vmcp/config/validator.go
@@ -170,9 +170,11 @@ func (*DefaultValidator) validateBackendAuthStrategy(_ string, strategy *Backend
 	}
 
 	validTypes := []string{
-		strategies.StrategyTypeUnauthenticated, strategies.StrategyTypeHeaderInjection,
+		strategies.StrategyTypeUnauthenticated,
+		strategies.StrategyTypeHeaderInjection,
+		strategies.StrategyTypeTokenExchange,
 		// TODO: Add more as strategies are implemented:
-		// "pass_through", "token_exchange", "client_credentials",
+		// "pass_through", "client_credentials",
 		// "service_account", "oauth_proxy",
 	}
 	if !contains(validTypes, strategy.Type) {
@@ -181,13 +183,10 @@ func (*DefaultValidator) validateBackendAuthStrategy(_ string, strategy *Backend
 
 	// Validate type-specific requirements
 	switch strategy.Type {
-	case "token_exchange":
-		// Token exchange requires specific metadata
-		required := []string{"token_url", "client_id", "audience"}
-		for _, field := range required {
-			if _, ok := strategy.Metadata[field]; !ok {
-				return fmt.Errorf("token_exchange requires metadata field: %s", field)
-			}
+	case strategies.StrategyTypeTokenExchange:
+		// Token exchange requires token_url (other fields are optional)
+		if _, ok := strategy.Metadata["token_url"]; !ok {
+			return fmt.Errorf("token_exchange requires metadata field: token_url")
 		}
 
 	case "service_account":

--- a/pkg/vmcp/config/yaml_loader.go
+++ b/pkg/vmcp/config/yaml_loader.go
@@ -324,16 +324,17 @@ func (*YAMLLoader) transformBackendAuthStrategy(raw *rawBackendAuthStrategy) (*B
 			return nil, fmt.Errorf("token_exchange configuration is required")
 		}
 
-		// Resolve client secret from environment
-		clientSecret := os.Getenv(raw.TokenExchange.ClientSecretEnv)
-		if clientSecret == "" && raw.TokenExchange.ClientSecretEnv != "" {
-			return nil, fmt.Errorf("environment variable %s not set", raw.TokenExchange.ClientSecretEnv)
+		// Validate that environment variable is set (but don't resolve it yet)
+		if raw.TokenExchange.ClientSecretEnv != "" {
+			if os.Getenv(raw.TokenExchange.ClientSecretEnv) == "" {
+				return nil, fmt.Errorf("environment variable %s not set", raw.TokenExchange.ClientSecretEnv)
+			}
 		}
 
 		strategy.Metadata = map[string]any{
 			"token_url":          raw.TokenExchange.TokenURL,
 			"client_id":          raw.TokenExchange.ClientID,
-			"client_secret":      clientSecret,
+			"client_secret_env":  raw.TokenExchange.ClientSecretEnv,
 			"audience":           raw.TokenExchange.Audience,
 			"scopes":             raw.TokenExchange.Scopes,
 			"subject_token_type": raw.TokenExchange.SubjectTokenType,


### PR DESCRIPTION
Implement OAuth 2.0 Token Exchange (RFC 8693) authentication strategy for Virtual MCP Server outgoing authentication. This enables exchanging client tokens from the vMCP server's identity provider for backend- specific tokens that backend MCP servers can validate.

Fixes: #2378