### PR TITLE
Fix SSE proxy mode transport label mapping for stdio servers

### DIFF
--- a/pkg/runner/config.go
+++ b/pkg/runner/config.go
@@ -469,6 +469,8 @@ func (c *RunConfig) WithStandardLabels() *RunConfig {
 	transportLabel := c.Transport.String()
 	if c.Transport == types.TransportTypeStdio && c.ProxyMode == types.ProxyModeStreamableHTTP {
 		transportLabel = types.TransportTypeStreamableHTTP.String()
+	} else if c.Transport == types.TransportTypeStdio && c.ProxyMode == types.ProxyModeSSE {
+		transportLabel = types.TransportTypeSSE.String()
 	}
 	// Use the Group field from the RunConfig
 	labels.AddStandardLabels(c.ContainerLabels, containerName, c.BaseName, transportLabel, c.Port)

--- a/pkg/runner/config_test.go
+++ b/pkg/runner/config_test.go
@@ -481,6 +481,42 @@ func TestRunConfig_WithStandardLabels(t *testing.T) {
 				"existing-label":     "existing-value",
 			},
 		},
+		{
+			name: "Stdio transport with SSE proxy mode",
+			config: &RunConfig{
+				Name:            "test-server",
+				Image:           "test-image",
+				Transport:       types.TransportTypeStdio,
+				ProxyMode:       types.ProxyModeSSE,
+				Port:            60000,
+				ContainerLabels: map[string]string{},
+			},
+			expected: map[string]string{
+				"toolhive":           "true",
+				"toolhive-name":      "test-server",
+				"toolhive-transport": "sse", // Should be "sse" not "stdio"
+				"toolhive-port":      "60000",
+				"toolhive-tool-type": "mcp",
+			},
+		},
+		{
+			name: "Stdio transport with streamable-http proxy mode",
+			config: &RunConfig{
+				Name:            "test-server",
+				Image:           "test-image",
+				Transport:       types.TransportTypeStdio,
+				ProxyMode:       types.ProxyModeStreamableHTTP,
+				Port:            60000,
+				ContainerLabels: map[string]string{},
+			},
+			expected: map[string]string{
+				"toolhive":           "true",
+				"toolhive-name":      "test-server",
+				"toolhive-transport": "streamable-http", // Should be "streamable-http" not "stdio"
+				"toolhive-port":      "60000",
+				"toolhive-tool-type": "mcp",
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
## Summary

Fixes a bug where `--proxy-mode sse` was incorrectly setting client configuration `type` to `streamable-http` instead of `sse`.

## Changes

- **pkg/runner/config.go**: Added handling for stdio transport with SSE proxy mode in `WithStandardLabels()`
- **pkg/runner/config_test.go**: Added test coverage for both SSE and streamable-http proxy mode scenarios

## Root Cause

The `WithStandardLabels()` function computes the transport label stored in container labels, which is later used to determine the transport type for client configurations. The function handled the `streamable-http` proxy mode case but was missing the `sse` case.

## Testing

- ✅ Added test cases to verify correct transport label for both SSE and streamable-http proxy modes
- ✅ All existing tests pass
- ✅ No linting issues

## Related

Fixes #2475

🤖 Generated with [Claude Code](https://claude.com/claude-code)