### PR TITLE
installs helm-docs and precommit for claude chart tasks

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,6 +32,12 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Setup helm-docs
+        run: go install github.com/norwoodj/helm-docs/cmd/helm-docs@latest
+
+      - name: Run pre-commit
+        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
+
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@8a1c4371755898f67cd97006ba7c97702d5fc4bf # v1


### PR DESCRIPTION
We want claude to be able to run pre-commit commands in PRs for bumping of helm chart, but it currently needs it installed. rather than allowing it to run pip install, we'll just install it into the GH runner like we do with the helm lint task