### PR TITLE
adds claude helm chart bump skill and removes pre-commit

### DIFF
--- a/.claude/skills/helm-chart-bump/SKILL.md
+++ b/.claude/skills/helm-chart-bump/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: Bumping Helm Chart
+description: Ensures that all necessary tasks have been performed for a Helm Chart bump.
+---
+
+# Bumping Helm Chart
+
+## Instructions
+
+1. Ensure the chart version in [deploy/charts/operator/Chart.yaml](deploy/charts/operator/Chart.yaml) is updated based on what you're told
+2. Ensure the same version change to the badge [deploy/charts/operator/README.md](deploy/charts/operator/README.md)
+3. Ensure the appVersion in [deploy/charts/operator/Chart.yaml](deploy/charts/operator/Chart.yaml) matches the version of the image that is being bumped to
+4. Go to the `.pre-commit-config.yaml` in the root of this repo and run the `helm-docs` hook command specifically with the args found in the file, nothing else. Do not run the `pre-commit` command as you will not have access to the binary. You do have access to the `helm-docs` binary so only run the `helm-docs` command with the args found in the `./pre-commit.yaml` file.
+
+## Best practices
+
+- Use present tense
+- Explain what and why, not how

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,9 +35,6 @@ jobs:
       - name: Setup helm-docs
         run: go install github.com/norwoodj/helm-docs/cmd/helm-docs@latest
 
-      - name: Run pre-commit
-        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
-
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@8a1c4371755898f67cd97006ba7c97702d5fc4bf # v1


### PR DESCRIPTION
Skills seems more effective that just adding some words in claude md files around helm chart bumping. This PR adds a claude skill for helm chart bumping that seems to work nicely locally. Given the pre-commit action runs pre-commit and doesn't ONLY install it, we shall remove as we don't want it to be run on every claude interaction. We already install helm docs anyways so we should be able to just run the commands thats most important