### PR TITLE
installs golang to github runner for helm docs

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,6 +32,10 @@ jobs:
         with:
           fetch-depth: 1
 
+      - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6
+        with:
+          go-version-file: 'go.mod'
+
       - name: Setup helm-docs
         run: go install github.com/norwoodj/helm-docs/cmd/helm-docs@latest
 


### PR DESCRIPTION
Claude tries to run helm docs but has issues, it maybe because of some misalignments with go paths of installed binaries. 