### PR TITLE
Add Flusher interface to audit and authz middlewares

### DIFF
--- a/pkg/audit/auditor.go
+++ b/pkg/audit/auditor.go
@@ -91,6 +91,13 @@ func (rw *responseWriter) Write(data []byte) (int, error) {
 	return rw.ResponseWriter.Write(data)
 }
 
+// Flush implements http.Flusher if the underlying ResponseWriter supports it.
+func (rw *responseWriter) Flush() {
+	if flusher, ok := rw.ResponseWriter.(http.Flusher); ok {
+		flusher.Flush()
+	}
+}
+
 // isMCPStreamOpenRequest returns true only for MCP "stream" opens:
 // - SSE transport's SSE endpoint (GET + Accept: text/event-stream)
 // - Streamable HTTP's GET stream (same header pattern)

--- a/pkg/authz/middleware.go
+++ b/pkg/authz/middleware.go
@@ -177,7 +177,7 @@ func (a *CedarAuthorizer) Middleware(next http.Handler) http.Handler {
 			next.ServeHTTP(filteringWriter, r)
 
 			// Flush the filtered response
-			if err := filteringWriter.Flush(); err != nil {
+			if err := filteringWriter.FlushAndFilter(); err != nil {
 				// If flushing fails, we've already started writing the response,
 				// so we can't return an error response. Just log it.
 				logger.Warnf("Error flushing filtered response: %v", err)

--- a/pkg/authz/response_filter_test.go
+++ b/pkg/authz/response_filter_test.go
@@ -152,7 +152,7 @@ func TestResponseFilteringWriter(t *testing.T) {
 			require.NoError(t, err, "Failed to write response data")
 
 			// Flush the response
-			err = filteringWriter.Flush()
+			err = filteringWriter.FlushAndFilter()
 			require.NoError(t, err, "Failed to flush response")
 
 			// Parse the filtered response
@@ -257,7 +257,7 @@ func TestResponseFilteringWriter_NonListOperations(t *testing.T) {
 	require.NoError(t, err, "Failed to write response data")
 
 	// Flush the response
-	err = filteringWriter.Flush()
+	err = filteringWriter.FlushAndFilter()
 	require.NoError(t, err, "Failed to flush response")
 
 	// Verify the response passed through unchanged
@@ -299,7 +299,7 @@ func TestResponseFilteringWriter_ErrorResponse(t *testing.T) {
 	require.NoError(t, err, "Failed to write response data")
 
 	// Flush the response
-	err = filteringWriter.Flush()
+	err = filteringWriter.FlushAndFilter()
 	require.NoError(t, err, "Failed to flush response")
 
 	// Verify the error response passed through unchanged


### PR DESCRIPTION
## Summary

Fixes #2509 by implementing the `http.Flusher` interface in audit and authorization middleware responseWriter wrappers.

## Root Cause

The audit and authorization middlewares wrap `http.ResponseWriter` to capture response data, but their wrappers didn't implement the `http.Flusher` interface. When using streamable-http proxy mode, the proxy checks for `http.Flusher` support when handling requests with `Accept: text/event-stream` header (per-request streaming per MCP spec). Without this interface, the type assertion fails and returns "Streaming not supported" error.

## Changes

- **Audit middleware** (`pkg/audit/auditor.go`): Added `Flush()` method that delegates to underlying ResponseWriter
- **Authz middleware** (`pkg/authz/response_filter.go`): 
  - Added `Flush()` method for `http.Flusher` interface
  - Renamed existing `Flush() error` → `FlushAndFilter() error` to avoid confusion
  - Updated caller in `pkg/authz/middleware.go`
  - Updated tests in `pkg/authz/response_filter_test.go`

## Testing

- ✅ All audit package tests pass (61 tests)
- ✅ All authz package tests pass (97 tests)
- ✅ 0 linter issues

## Impact

This fix ensures streamable-http proxy mode works correctly when audit or authz middlewares are enabled. SSE mode continues to work as before.