### PR TITLE
Update headless service log message to reference HTTP transport

### DIFF
--- a/pkg/container/kubernetes/client.go
+++ b/pkg/container/kubernetes/client.go
@@ -861,7 +861,7 @@ func (c *Client) createHeadlessService(
 		return fmt.Errorf("failed to apply service: %v", err)
 	}
 
-	logger.Infof("Created headless service %s for SSE transport", containerName)
+	logger.Infof("Created headless service %s for HTTP transport", containerName)
 
 	options.SSEHeadlessServiceName = svcName
 	return nil


### PR DESCRIPTION
Changed log message from 'SSE transport' to 'HTTP transport' since the headless service is used for both SSE and Streamable HTTP transports.

Fixes #2507

Generated with [Claude Code](https://claude.ai/code)