### PR TITLE
adds base from creation of the registry server config

### DIFF
--- a/cmd/thv-operator/pkg/registryapi/config.go
+++ b/cmd/thv-operator/pkg/registryapi/config.go
@@ -1,0 +1,247 @@
+package registryapi
+
+import (
+	"fmt"
+
+	mcpv1alpha1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1alpha1"
+)
+
+// ConfigManager provides methods to build registry server configuration from MCPRegistry resources
+type ConfigManager interface {
+	BuildConfig(mcpRegistry *mcpv1alpha1.MCPRegistry) (*Config, error)
+}
+
+// NewConfigManager creates a new instance of ConfigManager
+func NewConfigManager() ConfigManager {
+	return &configManager{}
+}
+
+type configManager struct{}
+
+const (
+	// RegistryJSONFilePath is the file path where the registry JSON file will be mounted
+	RegistryJSONFilePath = "/etc/registry/registry.json"
+)
+
+// Config represents the root configuration structure
+type Config struct {
+	// RegistryName is the name/identifier for this registry instance
+	// Defaults to "default" if not specified
+	RegistryName string            `yaml:"registryName,omitempty"`
+	Source       *SourceConfig     `yaml:"source"`
+	SyncPolicy   *SyncPolicyConfig `yaml:"syncPolicy,omitempty"`
+	Filter       *FilterConfig     `yaml:"filter,omitempty"`
+}
+
+// SourceConfig defines the data source configuration
+type SourceConfig struct {
+	Type   string      `yaml:"type"`
+	Format string      `yaml:"format"`
+	Git    *GitConfig  `yaml:"git,omitempty"`
+	API    *APIConfig  `yaml:"api,omitempty"`
+	File   *FileConfig `yaml:"file,omitempty"`
+}
+
+// GitConfig defines Git source settings
+type GitConfig struct {
+	// Repository is the Git repository URL (HTTP/HTTPS/SSH)
+	Repository string `yaml:"repository"`
+
+	// Branch is the Git branch to use (mutually exclusive with Tag and Commit)
+	Branch string `yaml:"branch,omitempty"`
+
+	// Tag is the Git tag to use (mutually exclusive with Branch and Commit)
+	Tag string `yaml:"tag,omitempty"`
+
+	// Commit is the Git commit SHA to use (mutually exclusive with Branch and Tag)
+	Commit string `yaml:"commit,omitempty"`
+
+	// Path is the path to the registry file within the repository
+	Path string `yaml:"path,omitempty"`
+}
+
+// APIConfig defines API source configuration for ToolHive Registry APIs
+type APIConfig struct {
+	// Endpoint is the base API URL (without path)
+	// The source handler will append the appropriate paths, for instance:
+	//   - /v0/servers - List all servers (single response, no pagination)
+	//   - /v0/servers/{name} - Get specific server (future)
+	//   - /v0/info - Get registry metadata (future)
+	// Example: "http://my-registry-api.default.svc.cluster.local/api"
+	Endpoint string `yaml:"endpoint"`
+}
+
+// FileConfig defines local file source configuration
+type FileConfig struct {
+	// Path is the path to the registry.json file on the local filesystem
+	// Can be absolute or relative to the working directory
+	Path string `yaml:"path"`
+}
+
+// SyncPolicyConfig defines synchronization settings
+type SyncPolicyConfig struct {
+	Interval string `yaml:"interval"`
+}
+
+// FilterConfig defines filtering rules for registry entries
+type FilterConfig struct {
+	Names *NameFilterConfig `yaml:"names,omitempty"`
+	Tags  *TagFilterConfig  `yaml:"tags,omitempty"`
+}
+
+// NameFilterConfig defines name-based filtering
+type NameFilterConfig struct {
+	Include []string `yaml:"include,omitempty"`
+	Exclude []string `yaml:"exclude,omitempty"`
+}
+
+// TagFilterConfig defines tag-based filtering
+type TagFilterConfig struct {
+	Include []string `yaml:"include,omitempty"`
+	Exclude []string `yaml:"exclude,omitempty"`
+}
+
+func (*configManager) BuildConfig(mcpRegistry *mcpv1alpha1.MCPRegistry) (*Config, error) {
+	config := Config{}
+
+	if mcpRegistry.Name == "" {
+		return nil, fmt.Errorf("registry name is required")
+	}
+
+	config.RegistryName = mcpRegistry.Name
+
+	if err := buildSourceConfig(&mcpRegistry.Spec.Source, &config); err != nil {
+		return nil, fmt.Errorf("failed to build source configuration: %w", err)
+	}
+
+	if err := buildSyncPolicyConfig(mcpRegistry.Spec.SyncPolicy, &config); err != nil {
+		return nil, fmt.Errorf("failed to build sync policy configuration: %w", err)
+	}
+
+	buildFilterConfig(mcpRegistry.Spec.Filter, &config)
+
+	return &config, nil
+}
+
+func buildFilterConfig(filter *mcpv1alpha1.RegistryFilter, config *Config) {
+	if filter == nil {
+		return
+	}
+
+	// Initialize Filter if needed
+	if config.Filter == nil {
+		config.Filter = &FilterConfig{}
+	}
+
+	if filter.NameFilters != nil {
+		config.Filter.Names = &NameFilterConfig{
+			Include: filter.NameFilters.Include,
+			Exclude: filter.NameFilters.Exclude,
+		}
+	}
+
+	if filter.Tags != nil {
+		config.Filter.Tags = &TagFilterConfig{
+			Include: filter.Tags.Include,
+			Exclude: filter.Tags.Exclude,
+		}
+	}
+}
+
+func buildSyncPolicyConfig(syncPolicy *mcpv1alpha1.SyncPolicy, config *Config) error {
+	if syncPolicy == nil {
+		return fmt.Errorf("sync policy configuration is required")
+	}
+
+	if syncPolicy.Interval == "" {
+		return fmt.Errorf("sync policy interval is required")
+	}
+
+	config.SyncPolicy = &SyncPolicyConfig{
+		Interval: syncPolicy.Interval,
+	}
+
+	return nil
+}
+
+func buildSourceConfig(source *mcpv1alpha1.MCPRegistrySource, config *Config) error {
+	if source == nil || source.Type == "" {
+		return fmt.Errorf("source type is required")
+	}
+
+	sourceConfig := SourceConfig{}
+
+	if source.Format == "" {
+		return fmt.Errorf("source format is required")
+	}
+	sourceConfig.Format = source.Format
+
+	switch source.Type {
+	case mcpv1alpha1.RegistrySourceTypeConfigMap:
+		// we use the file source config for configmap sources
+		// because the configmap will be mounted as a file in the registry server container.
+		// this stops the registry server worrying about configmap sources when all it has to do
+		// is read the file on startup
+		sourceConfig.File = &FileConfig{
+			Path: RegistryJSONFilePath,
+		}
+	case mcpv1alpha1.RegistrySourceTypeGit:
+		gitConfig, err := buildGitSourceConfig(source.Git)
+		if err != nil {
+			return fmt.Errorf("failed to build Git source configuration: %w", err)
+		}
+		sourceConfig.Git = gitConfig
+	case mcpv1alpha1.RegistrySourceTypeAPI:
+		apiConfig, err := buildAPISourceConfig(source.API)
+		if err != nil {
+			return fmt.Errorf("failed to build API source configuration: %w", err)
+		}
+		sourceConfig.API = apiConfig
+	default:
+		return fmt.Errorf("unsupported source type: %s", source.Type)
+	}
+
+	config.Source = &sourceConfig
+	return nil
+}
+
+func buildGitSourceConfig(git *mcpv1alpha1.GitSource) (*GitConfig, error) {
+	if git == nil {
+		return nil, fmt.Errorf("git source configuration is required")
+	}
+
+	if git.Repository == "" {
+		return nil, fmt.Errorf("git repository is required")
+	}
+
+	serverGitConfig := GitConfig{
+		Repository: git.Repository,
+	}
+
+	switch {
+	case git.Branch != "":
+		serverGitConfig.Branch = git.Branch
+	case git.Tag != "":
+		serverGitConfig.Tag = git.Tag
+	case git.Commit != "":
+		serverGitConfig.Commit = git.Commit
+	default:
+		return nil, fmt.Errorf("git branch, tag, and commit are mutually exclusive, please provide only one of them")
+	}
+
+	return &serverGitConfig, nil
+}
+
+func buildAPISourceConfig(api *mcpv1alpha1.APISource) (*APIConfig, error) {
+	if api == nil {
+		return nil, fmt.Errorf("api source configuration is required")
+	}
+
+	if api.Endpoint == "" {
+		return nil, fmt.Errorf("api endpoint is required")
+	}
+
+	return &APIConfig{
+		Endpoint: api.Endpoint,
+	}, nil
+}

--- a/cmd/thv-operator/pkg/registryapi/config_test.go
+++ b/cmd/thv-operator/pkg/registryapi/config_test.go
@@ -1,0 +1,737 @@
+package registryapi
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	mcpv1alpha1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1alpha1"
+)
+
+func TestBuildConfig_EmptyRegistryName(t *testing.T) {
+	t.Parallel()
+	// Test that an empty registry name returns the correct error
+	mcpRegistry := &mcpv1alpha1.MCPRegistry{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "", // Empty name should cause an error
+		},
+		Spec: mcpv1alpha1.MCPRegistrySpec{
+			Source: mcpv1alpha1.MCPRegistrySource{
+				Type:   mcpv1alpha1.RegistrySourceTypeConfigMap,
+				Format: mcpv1alpha1.RegistryFormatToolHive,
+			},
+		},
+	}
+
+	manager := NewConfigManager()
+	config, err := manager.BuildConfig(mcpRegistry)
+
+	require.Error(t, err)
+	assert.Equal(t, "registry name is required", err.Error())
+	assert.Nil(t, config)
+}
+
+func TestBuildConfig_MissingSource(t *testing.T) {
+	t.Parallel()
+	// Test that a nil/empty source returns the correct error
+	mcpRegistry := &mcpv1alpha1.MCPRegistry{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-registry",
+		},
+		Spec: mcpv1alpha1.MCPRegistrySpec{
+			Source: mcpv1alpha1.MCPRegistrySource{
+				Type: "", // Empty type should cause an error
+			},
+		},
+	}
+
+	manager := NewConfigManager()
+	config, err := manager.BuildConfig(mcpRegistry)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "source type is required")
+	assert.Nil(t, config)
+}
+
+func TestBuildConfig_EmptyFormat(t *testing.T) {
+	t.Parallel()
+	// Test that an empty source format returns the correct error
+	mcpRegistry := &mcpv1alpha1.MCPRegistry{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-registry",
+		},
+		Spec: mcpv1alpha1.MCPRegistrySpec{
+			Source: mcpv1alpha1.MCPRegistrySource{
+				Type:   mcpv1alpha1.RegistrySourceTypeConfigMap,
+				Format: "", // Empty format should cause an error
+			},
+		},
+	}
+
+	manager := NewConfigManager()
+	config, err := manager.BuildConfig(mcpRegistry)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "source format is required")
+	assert.Nil(t, config)
+}
+
+func TestBuildConfig_UnsupportedSourceType(t *testing.T) {
+	t.Parallel()
+	// Test that an unsupported source type returns the correct error
+	mcpRegistry := &mcpv1alpha1.MCPRegistry{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-registry",
+		},
+		Spec: mcpv1alpha1.MCPRegistrySpec{
+			Source: mcpv1alpha1.MCPRegistrySource{
+				Type:   "unsupported-type", // This should trigger the default case
+				Format: mcpv1alpha1.RegistryFormatToolHive,
+			},
+		},
+	}
+
+	manager := NewConfigManager()
+	config, err := manager.BuildConfig(mcpRegistry)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported source type: unsupported-type")
+	assert.Nil(t, config)
+}
+
+func TestBuildConfig_ConfigMapSource(t *testing.T) {
+	t.Parallel()
+	// Test suite for ConfigMap source validation
+
+	t.Run("nil configmap source object", func(t *testing.T) {
+		t.Parallel()
+		// Note: Currently, nil ConfigMap doesn't cause an error since the code
+		// directly creates a FileConfig without checking if ConfigMap is nil.
+		// This test documents the current behavior.
+		mcpRegistry := &mcpv1alpha1.MCPRegistry{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-registry",
+			},
+			Spec: mcpv1alpha1.MCPRegistrySpec{
+				Source: mcpv1alpha1.MCPRegistrySource{
+					Type:      mcpv1alpha1.RegistrySourceTypeConfigMap,
+					Format:    mcpv1alpha1.RegistryFormatToolHive,
+					ConfigMap: nil, // Currently doesn't cause an error
+				},
+				SyncPolicy: &mcpv1alpha1.SyncPolicy{
+					Interval: "1h",
+				},
+			},
+		}
+
+		manager := NewConfigManager()
+		config, err := manager.BuildConfig(mcpRegistry)
+
+		// Currently this succeeds even with nil ConfigMap
+		require.NoError(t, err)
+		require.NotNil(t, config)
+		assert.Equal(t, "test-registry", config.RegistryName)
+		assert.Equal(t, mcpv1alpha1.RegistryFormatToolHive, config.Source.Format)
+		require.NotNil(t, config.Source.File)
+		assert.Equal(t, RegistryJSONFilePath, config.Source.File.Path)
+	})
+
+	t.Run("valid configmap source", func(t *testing.T) {
+		t.Parallel()
+		mcpRegistry := &mcpv1alpha1.MCPRegistry{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-registry",
+			},
+			Spec: mcpv1alpha1.MCPRegistrySpec{
+				Source: mcpv1alpha1.MCPRegistrySource{
+					Type:   mcpv1alpha1.RegistrySourceTypeConfigMap,
+					Format: mcpv1alpha1.RegistryFormatToolHive,
+					ConfigMap: &mcpv1alpha1.ConfigMapSource{
+						Name: "registry-configmap",
+					},
+				},
+				SyncPolicy: &mcpv1alpha1.SyncPolicy{
+					Interval: "1h",
+				},
+			},
+		}
+
+		manager := NewConfigManager()
+		config, err := manager.BuildConfig(mcpRegistry)
+
+		require.NoError(t, err)
+		require.NotNil(t, config)
+		assert.Equal(t, "test-registry", config.RegistryName)
+		assert.Equal(t, mcpv1alpha1.RegistryFormatToolHive, config.Source.Format)
+		require.NotNil(t, config.Source.File)
+		assert.Equal(t, RegistryJSONFilePath, config.Source.File.Path)
+	})
+}
+
+func TestBuildConfig_GitSource(t *testing.T) {
+	t.Parallel()
+	// Test suite for Git source validation
+
+	t.Run("nil git source object", func(t *testing.T) {
+		t.Parallel()
+		mcpRegistry := &mcpv1alpha1.MCPRegistry{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-registry",
+			},
+			Spec: mcpv1alpha1.MCPRegistrySpec{
+				Source: mcpv1alpha1.MCPRegistrySource{
+					Type:   mcpv1alpha1.RegistrySourceTypeGit,
+					Format: mcpv1alpha1.RegistryFormatToolHive,
+					Git:    nil, // Nil Git source should cause an error
+				},
+			},
+		}
+
+		manager := NewConfigManager()
+		config, err := manager.BuildConfig(mcpRegistry)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "git source configuration is required")
+		assert.Nil(t, config)
+	})
+
+	t.Run("empty git repository", func(t *testing.T) {
+		t.Parallel()
+		mcpRegistry := &mcpv1alpha1.MCPRegistry{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-registry",
+			},
+			Spec: mcpv1alpha1.MCPRegistrySpec{
+				Source: mcpv1alpha1.MCPRegistrySource{
+					Type:   mcpv1alpha1.RegistrySourceTypeGit,
+					Format: mcpv1alpha1.RegistryFormatToolHive,
+					Git: &mcpv1alpha1.GitSource{
+						Repository: "", // Empty repository should cause an error
+					},
+				},
+			},
+		}
+
+		manager := NewConfigManager()
+		config, err := manager.BuildConfig(mcpRegistry)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "git repository is required")
+		assert.Nil(t, config)
+	})
+
+	t.Run("no git reference specified", func(t *testing.T) {
+		t.Parallel()
+		mcpRegistry := &mcpv1alpha1.MCPRegistry{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-registry",
+			},
+			Spec: mcpv1alpha1.MCPRegistrySpec{
+				Source: mcpv1alpha1.MCPRegistrySource{
+					Type:   mcpv1alpha1.RegistrySourceTypeGit,
+					Format: mcpv1alpha1.RegistryFormatToolHive,
+					Git: &mcpv1alpha1.GitSource{
+						Repository: "https://github.com/example/repo.git",
+						// No branch, tag, or commit specified - should cause an error
+					},
+				},
+			},
+		}
+
+		manager := NewConfigManager()
+		config, err := manager.BuildConfig(mcpRegistry)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "git branch, tag, and commit are mutually exclusive")
+		assert.Nil(t, config)
+	})
+
+	t.Run("valid git source with branch", func(t *testing.T) {
+		t.Parallel()
+		mcpRegistry := &mcpv1alpha1.MCPRegistry{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-registry",
+			},
+			Spec: mcpv1alpha1.MCPRegistrySpec{
+				Source: mcpv1alpha1.MCPRegistrySource{
+					Type:   mcpv1alpha1.RegistrySourceTypeGit,
+					Format: mcpv1alpha1.RegistryFormatUpstream,
+					Git: &mcpv1alpha1.GitSource{
+						Repository: "https://github.com/example/repo.git",
+						Branch:     "main",
+					},
+				},
+				SyncPolicy: &mcpv1alpha1.SyncPolicy{
+					Interval: "1h",
+				},
+			},
+		}
+
+		manager := NewConfigManager()
+		config, err := manager.BuildConfig(mcpRegistry)
+
+		require.NoError(t, err)
+		require.NotNil(t, config)
+		assert.Equal(t, "test-registry", config.RegistryName)
+		assert.Equal(t, mcpv1alpha1.RegistryFormatUpstream, config.Source.Format)
+		require.NotNil(t, config.Source.Git)
+		assert.Equal(t, "https://github.com/example/repo.git", config.Source.Git.Repository)
+		assert.Equal(t, "main", config.Source.Git.Branch)
+		assert.Empty(t, config.Source.Git.Tag)
+		assert.Empty(t, config.Source.Git.Commit)
+	})
+
+	t.Run("valid git source with tag", func(t *testing.T) {
+		t.Parallel()
+		mcpRegistry := &mcpv1alpha1.MCPRegistry{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-registry",
+			},
+			Spec: mcpv1alpha1.MCPRegistrySpec{
+				Source: mcpv1alpha1.MCPRegistrySource{
+					Type:   mcpv1alpha1.RegistrySourceTypeGit,
+					Format: mcpv1alpha1.RegistryFormatToolHive,
+					Git: &mcpv1alpha1.GitSource{
+						Repository: "git@github.com:example/repo.git",
+						Tag:        "v1.2.3",
+					},
+				},
+				SyncPolicy: &mcpv1alpha1.SyncPolicy{
+					Interval: "1h",
+				},
+			},
+		}
+
+		manager := NewConfigManager()
+		config, err := manager.BuildConfig(mcpRegistry)
+
+		require.NoError(t, err)
+		require.NotNil(t, config)
+		assert.Equal(t, "test-registry", config.RegistryName)
+		assert.Equal(t, mcpv1alpha1.RegistryFormatToolHive, config.Source.Format)
+		require.NotNil(t, config.Source.Git)
+		assert.Equal(t, "git@github.com:example/repo.git", config.Source.Git.Repository)
+		assert.Empty(t, config.Source.Git.Branch)
+		assert.Equal(t, "v1.2.3", config.Source.Git.Tag)
+		assert.Empty(t, config.Source.Git.Commit)
+	})
+
+	t.Run("valid git source with commit", func(t *testing.T) {
+		t.Parallel()
+		mcpRegistry := &mcpv1alpha1.MCPRegistry{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-registry",
+			},
+			Spec: mcpv1alpha1.MCPRegistrySpec{
+				Source: mcpv1alpha1.MCPRegistrySource{
+					Type:   mcpv1alpha1.RegistrySourceTypeGit,
+					Format: mcpv1alpha1.RegistryFormatUpstream,
+					Git: &mcpv1alpha1.GitSource{
+						Repository: "https://github.com/example/repo.git",
+						Commit:     "abc123def456",
+					},
+				},
+				SyncPolicy: &mcpv1alpha1.SyncPolicy{
+					Interval: "1h",
+				},
+			},
+		}
+
+		manager := NewConfigManager()
+		config, err := manager.BuildConfig(mcpRegistry)
+
+		require.NoError(t, err)
+		require.NotNil(t, config)
+		assert.Equal(t, "test-registry", config.RegistryName)
+		assert.Equal(t, mcpv1alpha1.RegistryFormatUpstream, config.Source.Format)
+		require.NotNil(t, config.Source.Git)
+		assert.Equal(t, "https://github.com/example/repo.git", config.Source.Git.Repository)
+		assert.Empty(t, config.Source.Git.Branch)
+		assert.Empty(t, config.Source.Git.Tag)
+		assert.Equal(t, "abc123def456", config.Source.Git.Commit)
+	})
+}
+
+func TestBuildConfig_APISource(t *testing.T) {
+	t.Parallel()
+	// Test suite for API source validation
+
+	t.Run("nil api source object", func(t *testing.T) {
+		t.Parallel()
+		mcpRegistry := &mcpv1alpha1.MCPRegistry{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-registry",
+			},
+			Spec: mcpv1alpha1.MCPRegistrySpec{
+				Source: mcpv1alpha1.MCPRegistrySource{
+					Type:   mcpv1alpha1.RegistrySourceTypeAPI,
+					Format: mcpv1alpha1.RegistryFormatToolHive,
+					API:    nil, // Nil API source should cause an error
+				},
+			},
+		}
+
+		manager := NewConfigManager()
+		config, err := manager.BuildConfig(mcpRegistry)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "api source configuration is required")
+		assert.Nil(t, config)
+	})
+
+	t.Run("empty api endpoint", func(t *testing.T) {
+		t.Parallel()
+		mcpRegistry := &mcpv1alpha1.MCPRegistry{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-registry",
+			},
+			Spec: mcpv1alpha1.MCPRegistrySpec{
+				Source: mcpv1alpha1.MCPRegistrySource{
+					Type:   mcpv1alpha1.RegistrySourceTypeAPI,
+					Format: mcpv1alpha1.RegistryFormatToolHive,
+					API: &mcpv1alpha1.APISource{
+						Endpoint: "", // Empty endpoint should cause an error
+					},
+				},
+			},
+		}
+
+		manager := NewConfigManager()
+		config, err := manager.BuildConfig(mcpRegistry)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "api endpoint is required")
+		assert.Nil(t, config)
+	})
+
+	t.Run("valid api source with endpoint", func(t *testing.T) {
+		t.Parallel()
+		mcpRegistry := &mcpv1alpha1.MCPRegistry{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-registry",
+			},
+			Spec: mcpv1alpha1.MCPRegistrySpec{
+				Source: mcpv1alpha1.MCPRegistrySource{
+					Type:   mcpv1alpha1.RegistrySourceTypeAPI,
+					Format: mcpv1alpha1.RegistryFormatUpstream,
+					API: &mcpv1alpha1.APISource{
+						Endpoint: "https://api.example.com/registry",
+					},
+				},
+				SyncPolicy: &mcpv1alpha1.SyncPolicy{
+					Interval: "1h",
+				},
+			},
+		}
+
+		manager := NewConfigManager()
+		config, err := manager.BuildConfig(mcpRegistry)
+
+		require.NoError(t, err)
+		require.NotNil(t, config)
+		assert.Equal(t, "test-registry", config.RegistryName)
+		assert.Equal(t, mcpv1alpha1.RegistryFormatUpstream, config.Source.Format)
+		require.NotNil(t, config.Source.API)
+		assert.Equal(t, "https://api.example.com/registry", config.Source.API.Endpoint)
+		// Verify that other source types are nil
+		assert.Nil(t, config.Source.File)
+		assert.Nil(t, config.Source.Git)
+	})
+}
+
+func TestBuildConfig_SyncPolicy(t *testing.T) {
+	t.Parallel()
+	// Test suite for SyncPolicy validation
+
+	t.Run("nil sync policy", func(t *testing.T) {
+		t.Parallel()
+		mcpRegistry := &mcpv1alpha1.MCPRegistry{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-registry",
+			},
+			Spec: mcpv1alpha1.MCPRegistrySpec{
+				Source: mcpv1alpha1.MCPRegistrySource{
+					Type:   mcpv1alpha1.RegistrySourceTypeConfigMap,
+					Format: mcpv1alpha1.RegistryFormatToolHive,
+					ConfigMap: &mcpv1alpha1.ConfigMapSource{
+						Name: "test-configmap",
+					},
+				},
+				SyncPolicy: nil, // Nil SyncPolicy should cause an error
+			},
+		}
+
+		manager := NewConfigManager()
+		config, err := manager.BuildConfig(mcpRegistry)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "sync policy configuration is required")
+		assert.Nil(t, config)
+	})
+
+	t.Run("empty interval", func(t *testing.T) {
+		t.Parallel()
+		mcpRegistry := &mcpv1alpha1.MCPRegistry{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-registry",
+			},
+			Spec: mcpv1alpha1.MCPRegistrySpec{
+				Source: mcpv1alpha1.MCPRegistrySource{
+					Type:   mcpv1alpha1.RegistrySourceTypeConfigMap,
+					Format: mcpv1alpha1.RegistryFormatToolHive,
+					ConfigMap: &mcpv1alpha1.ConfigMapSource{
+						Name: "test-configmap",
+					},
+				},
+				SyncPolicy: &mcpv1alpha1.SyncPolicy{
+					Interval: "", // Empty interval should cause an error
+				},
+			},
+		}
+
+		manager := NewConfigManager()
+		config, err := manager.BuildConfig(mcpRegistry)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "sync policy interval is required")
+		assert.Nil(t, config)
+	})
+
+	t.Run("valid sync policy with interval", func(t *testing.T) {
+		t.Parallel()
+		mcpRegistry := &mcpv1alpha1.MCPRegistry{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-registry",
+			},
+			Spec: mcpv1alpha1.MCPRegistrySpec{
+				Source: mcpv1alpha1.MCPRegistrySource{
+					Type:   mcpv1alpha1.RegistrySourceTypeConfigMap,
+					Format: mcpv1alpha1.RegistryFormatToolHive,
+					ConfigMap: &mcpv1alpha1.ConfigMapSource{
+						Name: "test-configmap",
+					},
+				},
+				SyncPolicy: &mcpv1alpha1.SyncPolicy{
+					Interval: "30m", // Valid interval
+				},
+			},
+		}
+
+		manager := NewConfigManager()
+		config, err := manager.BuildConfig(mcpRegistry)
+
+		require.NoError(t, err)
+		require.NotNil(t, config)
+		assert.Equal(t, "test-registry", config.RegistryName)
+		require.NotNil(t, config.SyncPolicy)
+		assert.Equal(t, "30m", config.SyncPolicy.Interval)
+	})
+}
+
+func TestBuildConfig_Filter(t *testing.T) {
+	t.Parallel()
+	// Test suite for Filter validation
+
+	t.Run("nil filter", func(t *testing.T) {
+		t.Parallel()
+		// Nil filter should not cause an error
+		mcpRegistry := &mcpv1alpha1.MCPRegistry{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-registry",
+			},
+			Spec: mcpv1alpha1.MCPRegistrySpec{
+				Source: mcpv1alpha1.MCPRegistrySource{
+					Type:   mcpv1alpha1.RegistrySourceTypeConfigMap,
+					Format: mcpv1alpha1.RegistryFormatToolHive,
+					ConfigMap: &mcpv1alpha1.ConfigMapSource{
+						Name: "test-configmap",
+					},
+				},
+				SyncPolicy: &mcpv1alpha1.SyncPolicy{
+					Interval: "1h",
+				},
+				Filter: nil, // Nil filter is optional
+			},
+		}
+
+		manager := NewConfigManager()
+		config, err := manager.BuildConfig(mcpRegistry)
+
+		require.NoError(t, err)
+		require.NotNil(t, config)
+		assert.Equal(t, "test-registry", config.RegistryName)
+		// Filter should be nil when not provided
+		assert.Nil(t, config.Filter)
+	})
+
+	t.Run("filter with name filters", func(t *testing.T) {
+		t.Parallel()
+		mcpRegistry := &mcpv1alpha1.MCPRegistry{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-registry",
+			},
+			Spec: mcpv1alpha1.MCPRegistrySpec{
+				Source: mcpv1alpha1.MCPRegistrySource{
+					Type:   mcpv1alpha1.RegistrySourceTypeConfigMap,
+					Format: mcpv1alpha1.RegistryFormatToolHive,
+					ConfigMap: &mcpv1alpha1.ConfigMapSource{
+						Name: "test-configmap",
+					},
+				},
+				SyncPolicy: &mcpv1alpha1.SyncPolicy{
+					Interval: "1h",
+				},
+				Filter: &mcpv1alpha1.RegistryFilter{
+					NameFilters: &mcpv1alpha1.NameFilter{
+						Include: []string{"server-*", "tool-*"},
+						Exclude: []string{"*-deprecated", "*-test"},
+					},
+				},
+			},
+		}
+
+		manager := NewConfigManager()
+		config, err := manager.BuildConfig(mcpRegistry)
+
+		require.NoError(t, err)
+		require.NotNil(t, config)
+		require.NotNil(t, config.Filter)
+		require.NotNil(t, config.Filter.Names)
+		assert.Equal(t, []string{"server-*", "tool-*"}, config.Filter.Names.Include)
+		assert.Equal(t, []string{"*-deprecated", "*-test"}, config.Filter.Names.Exclude)
+		// Tags should be nil when not provided
+		assert.Nil(t, config.Filter.Tags)
+	})
+
+	t.Run("filter with tags", func(t *testing.T) {
+		t.Parallel()
+		mcpRegistry := &mcpv1alpha1.MCPRegistry{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-registry",
+			},
+			Spec: mcpv1alpha1.MCPRegistrySpec{
+				Source: mcpv1alpha1.MCPRegistrySource{
+					Type:   mcpv1alpha1.RegistrySourceTypeGit,
+					Format: mcpv1alpha1.RegistryFormatUpstream,
+					Git: &mcpv1alpha1.GitSource{
+						Repository: "https://github.com/example/repo.git",
+						Branch:     "main",
+					},
+				},
+				SyncPolicy: &mcpv1alpha1.SyncPolicy{
+					Interval: "30m",
+				},
+				Filter: &mcpv1alpha1.RegistryFilter{
+					Tags: &mcpv1alpha1.TagFilter{
+						Include: []string{"stable", "production", "v1.*"},
+						Exclude: []string{"beta", "alpha", "experimental"},
+					},
+				},
+			},
+		}
+
+		manager := NewConfigManager()
+		config, err := manager.BuildConfig(mcpRegistry)
+
+		require.NoError(t, err)
+		require.NotNil(t, config)
+		require.NotNil(t, config.Filter)
+		require.NotNil(t, config.Filter.Tags)
+		assert.Equal(t, []string{"stable", "production", "v1.*"}, config.Filter.Tags.Include)
+		assert.Equal(t, []string{"beta", "alpha", "experimental"}, config.Filter.Tags.Exclude)
+		// Names should be nil when not provided
+		assert.Nil(t, config.Filter.Names)
+	})
+
+	t.Run("filter with both name filters and tags", func(t *testing.T) {
+		t.Parallel()
+		mcpRegistry := &mcpv1alpha1.MCPRegistry{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-registry",
+			},
+			Spec: mcpv1alpha1.MCPRegistrySpec{
+				Source: mcpv1alpha1.MCPRegistrySource{
+					Type:   mcpv1alpha1.RegistrySourceTypeAPI,
+					Format: mcpv1alpha1.RegistryFormatToolHive,
+					API: &mcpv1alpha1.APISource{
+						Endpoint: "https://api.example.com/registry",
+					},
+				},
+				SyncPolicy: &mcpv1alpha1.SyncPolicy{
+					Interval: "2h",
+				},
+				Filter: &mcpv1alpha1.RegistryFilter{
+					NameFilters: &mcpv1alpha1.NameFilter{
+						Include: []string{"mcp-*"},
+						Exclude: []string{"*-internal"},
+					},
+					Tags: &mcpv1alpha1.TagFilter{
+						Include: []string{"latest", "stable"},
+						Exclude: []string{"dev", "test"},
+					},
+				},
+			},
+		}
+
+		manager := NewConfigManager()
+		config, err := manager.BuildConfig(mcpRegistry)
+
+		require.NoError(t, err)
+		require.NotNil(t, config)
+		require.NotNil(t, config.Filter)
+		// Both name filters and tags should be present
+		require.NotNil(t, config.Filter.Names)
+		assert.Equal(t, []string{"mcp-*"}, config.Filter.Names.Include)
+		assert.Equal(t, []string{"*-internal"}, config.Filter.Names.Exclude)
+		require.NotNil(t, config.Filter.Tags)
+		assert.Equal(t, []string{"latest", "stable"}, config.Filter.Tags.Include)
+		assert.Equal(t, []string{"dev", "test"}, config.Filter.Tags.Exclude)
+	})
+
+	t.Run("filter with empty include and exclude lists", func(t *testing.T) {
+		t.Parallel()
+		mcpRegistry := &mcpv1alpha1.MCPRegistry{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-registry",
+			},
+			Spec: mcpv1alpha1.MCPRegistrySpec{
+				Source: mcpv1alpha1.MCPRegistrySource{
+					Type:   mcpv1alpha1.RegistrySourceTypeConfigMap,
+					Format: mcpv1alpha1.RegistryFormatToolHive,
+					ConfigMap: &mcpv1alpha1.ConfigMapSource{
+						Name: "test-configmap",
+					},
+				},
+				SyncPolicy: &mcpv1alpha1.SyncPolicy{
+					Interval: "1h",
+				},
+				Filter: &mcpv1alpha1.RegistryFilter{
+					NameFilters: &mcpv1alpha1.NameFilter{
+						Include: []string{},
+						Exclude: []string{},
+					},
+					Tags: &mcpv1alpha1.TagFilter{
+						Include: []string{},
+						Exclude: []string{},
+					},
+				},
+			},
+		}
+
+		manager := NewConfigManager()
+		config, err := manager.BuildConfig(mcpRegistry)
+
+		require.NoError(t, err)
+		require.NotNil(t, config)
+		require.NotNil(t, config.Filter)
+		// Empty lists should still be set
+		require.NotNil(t, config.Filter.Names)
+		assert.Empty(t, config.Filter.Names.Include)
+		assert.Empty(t, config.Filter.Names.Exclude)
+		require.NotNil(t, config.Filter.Tags)
+		assert.Empty(t, config.Filter.Tags.Include)
+		assert.Empty(t, config.Filter.Tags.Exclude)
+	})
+}


### PR DESCRIPTION
The operator will eventually create the config file for the registry server, but it first needs to be able to create the structure that is needed. This PR adds the registry server config structs  (unfortunately is a copy and paste).

All code in this PR is currently unused by the Operator but subsequent PRs will start to use it in order to mount the config file into the registry server container.