### PR TITLE
adds type setting for registry source

### DIFF
--- a/cmd/thv-operator/pkg/registryapi/config.go
+++ b/cmd/thv-operator/pkg/registryapi/config.go
@@ -19,6 +19,15 @@ func NewConfigManager() ConfigManager {
 type configManager struct{}
 
 const (
+	// SourceTypeGit is the type for registry data stored in Git repositories
+	SourceTypeGit = "git"
+
+	// SourceTypeAPI is the type for registry data fetched from API endpoints
+	SourceTypeAPI = "api"
+
+	// SourceTypeFile is the type for registry data stored in local files
+	SourceTypeFile = "file"
+
 	// RegistryJSONFilePath is the file path where the registry JSON file will be mounted
 	RegistryJSONFilePath = "/etc/registry/registry.json"
 )
@@ -185,18 +194,21 @@ func buildSourceConfig(source *mcpv1alpha1.MCPRegistrySource, config *Config) er
 		sourceConfig.File = &FileConfig{
 			Path: RegistryJSONFilePath,
 		}
+		sourceConfig.Type = SourceTypeFile
 	case mcpv1alpha1.RegistrySourceTypeGit:
 		gitConfig, err := buildGitSourceConfig(source.Git)
 		if err != nil {
 			return fmt.Errorf("failed to build Git source configuration: %w", err)
 		}
 		sourceConfig.Git = gitConfig
+		sourceConfig.Type = SourceTypeGit
 	case mcpv1alpha1.RegistrySourceTypeAPI:
 		apiConfig, err := buildAPISourceConfig(source.API)
 		if err != nil {
 			return fmt.Errorf("failed to build API source configuration: %w", err)
 		}
 		sourceConfig.API = apiConfig
+		sourceConfig.Type = SourceTypeAPI
 	default:
 		return fmt.Errorf("unsupported source type: %s", source.Type)
 	}

--- a/cmd/thv-operator/pkg/registryapi/config_test.go
+++ b/cmd/thv-operator/pkg/registryapi/config_test.go
@@ -135,6 +135,7 @@ func TestBuildConfig_ConfigMapSource(t *testing.T) {
 		assert.Equal(t, "test-registry", config.RegistryName)
 		assert.Equal(t, mcpv1alpha1.RegistryFormatToolHive, config.Source.Format)
 		require.NotNil(t, config.Source.File)
+		assert.Equal(t, SourceTypeFile, config.Source.Type)
 		assert.Equal(t, RegistryJSONFilePath, config.Source.File.Path)
 	})
 
@@ -165,7 +166,7 @@ func TestBuildConfig_ConfigMapSource(t *testing.T) {
 		require.NotNil(t, config)
 		assert.Equal(t, "test-registry", config.RegistryName)
 		assert.Equal(t, mcpv1alpha1.RegistryFormatToolHive, config.Source.Format)
-		require.NotNil(t, config.Source.File)
+		assert.Equal(t, SourceTypeFile, config.Source.Type)
 		assert.Equal(t, RegistryJSONFilePath, config.Source.File.Path)
 	})
 }
@@ -276,6 +277,7 @@ func TestBuildConfig_GitSource(t *testing.T) {
 		require.NotNil(t, config)
 		assert.Equal(t, "test-registry", config.RegistryName)
 		assert.Equal(t, mcpv1alpha1.RegistryFormatUpstream, config.Source.Format)
+		assert.Equal(t, SourceTypeGit, config.Source.Type)
 		require.NotNil(t, config.Source.Git)
 		assert.Equal(t, "https://github.com/example/repo.git", config.Source.Git.Repository)
 		assert.Equal(t, "main", config.Source.Git.Branch)
@@ -311,6 +313,7 @@ func TestBuildConfig_GitSource(t *testing.T) {
 		require.NotNil(t, config)
 		assert.Equal(t, "test-registry", config.RegistryName)
 		assert.Equal(t, mcpv1alpha1.RegistryFormatToolHive, config.Source.Format)
+		assert.Equal(t, SourceTypeGit, config.Source.Type)
 		require.NotNil(t, config.Source.Git)
 		assert.Equal(t, "git@github.com:example/repo.git", config.Source.Git.Repository)
 		assert.Empty(t, config.Source.Git.Branch)
@@ -346,6 +349,7 @@ func TestBuildConfig_GitSource(t *testing.T) {
 		require.NotNil(t, config)
 		assert.Equal(t, "test-registry", config.RegistryName)
 		assert.Equal(t, mcpv1alpha1.RegistryFormatUpstream, config.Source.Format)
+		assert.Equal(t, SourceTypeGit, config.Source.Type)
 		require.NotNil(t, config.Source.Git)
 		assert.Equal(t, "https://github.com/example/repo.git", config.Source.Git.Repository)
 		assert.Empty(t, config.Source.Git.Branch)
@@ -433,6 +437,7 @@ func TestBuildConfig_APISource(t *testing.T) {
 		require.NotNil(t, config)
 		assert.Equal(t, "test-registry", config.RegistryName)
 		assert.Equal(t, mcpv1alpha1.RegistryFormatUpstream, config.Source.Format)
+		assert.Equal(t, SourceTypeAPI, config.Source.Type)
 		require.NotNil(t, config.Source.API)
 		assert.Equal(t, "https://api.example.com/registry", config.Source.API.Endpoint)
 		// Verify that other source types are nil


### PR DESCRIPTION
PR https://github.com/stacklok/toolhive/pull/2534 adds the config building for the registry server. This PR adds the missing source config type setting for `git`, `file`, `api`