### PR TITLE
Sort clients in the client setup command

### DIFF
--- a/cmd/thv/app/client.go
+++ b/cmd/thv/app/client.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"fmt"
+	"sort"
 
 	"github.com/spf13/cobra"
 
@@ -134,6 +135,11 @@ func clientSetupCmdFunc(cmd *cobra.Command, _ []string) error {
 		fmt.Println("No new clients found.")
 		return nil
 	}
+
+	// Sort clients alphabetically by ClientType
+	sort.Slice(availableClients, func(i, j int) bool {
+		return availableClients[i].ClientType < availableClients[j].ClientType
+	})
 	// Get available groups for the UI
 	groupManager, err := groups.NewManager()
 	if err != nil {


### PR DESCRIPTION
Sorts the list of clients in the `thv client setup` menu.

Before:
<img width="281" height="315" alt="image" src="https://github.com/user-attachments/assets/c29da9c5-ed8c-4f23-aa2a-ad39d152c5d4" />

After:
<img width="281" height="315" alt="image" src="https://github.com/user-attachments/assets/2783e8de-7d2b-4b56-adda-6e95dc494fb8" />


Signed-off-by: Dan Barr <6922515+danbarr@users.noreply.github.com>