### PR TITLE
Add default port fallback to GetMcpPort() for HTTP-based transports

### DIFF
--- a/cmd/thv-operator/api/v1alpha1/mcpserver_types.go
+++ b/cmd/thv-operator/api/v1alpha1/mcpserver_types.go
@@ -763,7 +763,13 @@ func (m *MCPServer) GetMcpPort() int32 {
 
 	// the below is deprecated and will be removed in a future version
 	// we need to keep it here to avoid breaking changes
-	return m.Spec.TargetPort
+	if m.Spec.TargetPort > 0 {
+		return m.Spec.TargetPort
+	}
+
+	// Default to 8080 if no port is specified (matches GetProxyPort behavior)
+	// This is needed for HTTP-based transports (SSE, streamable-http) which require a target port
+	return 8080
 }
 
 func init() {


### PR DESCRIPTION
## Summary

This PR adds a default port fallback (8080) to the `GetMcpPort()` method when both `McpPort` and `TargetPort` are not specified. This ensures HTTP-based transports (SSE, streamable-http) always have a valid target port to work with.

## Changes

- Added default return value of `8080` in `GetMcpPort()` when both `McpPort` and `TargetPort` are unset
- Matches the behavior of `GetProxyPort()` for consistency
- Includes explanatory comment about the requirement for HTTP-based transports

## Rationale

HTTP-based transports (SSE, streamable-http) require a target port to be specified. Previously, if neither `McpPort` nor the deprecated `TargetPort` were set, the function would return `0`, which could cause issues during deployment. By defaulting to `8080` (matching the proxy port default), we ensure these transports can function correctly even when no explicit port is configured.

## Testing

- [ ] Verified that `GetMcpPort()` returns 8080 when both fields are unset
- [ ] Confirmed existing behavior is preserved when `McpPort` or `TargetPort` are set
- [ ] Tested HTTP-based transport deployments with default port