### PR TITLE
Fix flaky TestGenerateUserAgent test using dependency injection

### DIFF
--- a/pkg/usagemetrics/client.go
+++ b/pkg/usagemetrics/client.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	rt "github.com/stacklok/toolhive/pkg/container/runtime"
+	"github.com/stacklok/toolhive/pkg/env"
 	"github.com/stacklok/toolhive/pkg/logger"
 	"github.com/stacklok/toolhive/pkg/updates"
 	"github.com/stacklok/toolhive/pkg/versions"
@@ -87,12 +88,18 @@ func (c *Client) SendMetrics(instanceID string, record MetricRecord) error {
 	return nil
 }
 
-// generateUserAgent creates the user agent string
+// generateUserAgent creates the user agent string using the OS environment
 // Format: toolhive/[local|operator] [version] [build_type] (os/arch)
 func generateUserAgent() string {
+	return generateUserAgentWithEnv(&env.OSReader{})
+}
+
+// generateUserAgentWithEnv creates the user agent string using the provided environment reader
+// Format: toolhive/[local|operator] [version] [build_type] (os/arch)
+func generateUserAgentWithEnv(envReader env.Reader) string {
 	// Determine component type
 	envType := "local"
-	if rt.IsKubernetesRuntime() {
+	if rt.IsKubernetesRuntimeWithEnv(envReader) {
 		envType = "operator"
 	}
 


### PR DESCRIPTION
## Summary

- Fixes a race condition in TestGenerateUserAgent that caused intermittent test failures
- Refactors code to use dependency injection with env.Reader interface for testability
- Tests now run reliably in parallel without shared global state

## Problem

The TestGenerateUserAgent test was flaky due to parallel subtests manipulating the shared global environment variable KUBERNETES_SERVICE_HOST. When two subtests ran concurrently:
- The "local environment" subtest would unset the variable
- The "operator environment" subtest would set the variable
- Whichever test modified the environment last would cause the other to fail intermittently

## Solution

Implemented dependency injection pattern following the existing codebase conventions:
- Created `generateUserAgentWithEnv(envReader env.Reader)` that accepts an environment reader
- Kept `generateUserAgent()` as a wrapper using `env.OSReader{}` for production code
- Updated `IsKubernetesRuntime()` to use `IsKubernetesRuntimeWithEnv(envReader)`
- Refactored tests to use gomock-based environment readers with isolated state
- Removed all `os.Setenv`/`os.Unsetenv` calls from tests

## Test Plan

- [x] Ran TestGenerateUserAgent 10 times with race detector - all passed
- [x] Ran entire pkg/usagemetrics test suite with race detector - all passed
- [x] Verified linter passes with no issues
- [x] Tests remain parallel for fast execution
- [x] No changes to production behavior, only internal refactoring

## Changes

**pkg/usagemetrics/client.go:**
- Added `env` package import
- Added `generateUserAgentWithEnv()` internal function
- Refactored `generateUserAgent()` to delegate to new function

**pkg/usagemetrics/client_test.go:**
- Removed `os` package (no longer manipulates global state)
- Added `gomock` and `envmocks` imports
- Updated TestGenerateUserAgent to use mock environment readers
- Tests remain parallel and isolated

🤖 Generated with [Claude Code](https://claude.com/claude-code)