### PR TITLE
Inject env.Reader for testable token exchange auth

### DIFF
--- a/cmd/vmcp/app/commands.go
+++ b/cmd/vmcp/app/commands.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
+	"github.com/stacklok/toolhive/pkg/env"
 	"github.com/stacklok/toolhive/pkg/groups"
 	"github.com/stacklok/toolhive/pkg/logger"
 	"github.com/stacklok/toolhive/pkg/vmcp"
@@ -129,7 +130,8 @@ This command checks:
 			logger.Infof("Validating configuration: %s", configPath)
 
 			// Load configuration from YAML
-			loader := config.NewYAMLLoader(configPath)
+			envReader := &env.OSReader{}
+			loader := config.NewYAMLLoader(configPath, envReader)
 			cfg, err := loader.Load()
 			if err != nil {
 				logger.Errorf("Failed to load configuration: %v", err)
@@ -182,7 +184,8 @@ func getVersion() string {
 func loadAndValidateConfig(configPath string) (*config.Config, error) {
 	logger.Infof("Loading configuration from: %s", configPath)
 
-	loader := config.NewYAMLLoader(configPath)
+	envReader := &env.OSReader{}
+	loader := config.NewYAMLLoader(configPath, envReader)
 	cfg, err := loader.Load()
 	if err != nil {
 		logger.Errorf("Failed to load configuration: %v", err)
@@ -208,7 +211,8 @@ func loadAndValidateConfig(configPath string) (*config.Config, error) {
 func discoverBackends(ctx context.Context, cfg *config.Config) ([]vmcp.Backend, vmcp.BackendClient, error) {
 	// Create outgoing authentication registry from configuration
 	logger.Info("Initializing outgoing authentication")
-	outgoingRegistry, err := factory.NewOutgoingAuthRegistry(ctx, cfg.OutgoingAuth)
+	envReader := &env.OSReader{}
+	outgoingRegistry, err := factory.NewOutgoingAuthRegistry(ctx, cfg.OutgoingAuth, envReader)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create outgoing authentication registry: %w", err)
 	}

--- a/pkg/vmcp/auth/factory/outgoing.go
+++ b/pkg/vmcp/auth/factory/outgoing.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/stacklok/toolhive/pkg/env"
 	"github.com/stacklok/toolhive/pkg/vmcp/auth"
 	"github.com/stacklok/toolhive/pkg/vmcp/auth/strategies"
 	"github.com/stacklok/toolhive/pkg/vmcp/config"
@@ -42,11 +43,16 @@ import (
 // Parameters:
 //   - ctx: Context for any initialization that requires it
 //   - cfg: The outgoing authentication configuration (may be nil)
+//   - envReader: Environment variable reader for dependency injection
 //
 // Returns:
 //   - auth.OutgoingAuthRegistry: Configured registry with registered strategies
 //   - error: Any error during strategy initialization or registration
-func NewOutgoingAuthRegistry(_ context.Context, cfg *config.OutgoingAuthConfig) (auth.OutgoingAuthRegistry, error) {
+func NewOutgoingAuthRegistry(
+	_ context.Context,
+	cfg *config.OutgoingAuthConfig,
+	envReader env.Reader,
+) (auth.OutgoingAuthRegistry, error) {
 	registry := auth.NewDefaultOutgoingAuthRegistry()
 
 	// ALWAYS register the unauthenticated strategy as the default fallback.
@@ -66,7 +72,7 @@ func NewOutgoingAuthRegistry(_ context.Context, cfg *config.OutgoingAuthConfig) 
 
 	// Collect and register all unique strategy types from configuration
 	strategyTypes := collectStrategyTypes(cfg)
-	if err := registerStrategies(registry, strategyTypes); err != nil {
+	if err := registerStrategies(registry, strategyTypes, envReader); err != nil {
 		return nil, err
 	}
 
@@ -117,14 +123,14 @@ func collectStrategyTypes(cfg *config.OutgoingAuthConfig) map[string]struct{} {
 }
 
 // registerStrategies instantiates and registers each unique strategy type.
-func registerStrategies(registry auth.OutgoingAuthRegistry, strategyTypes map[string]struct{}) error {
+func registerStrategies(registry auth.OutgoingAuthRegistry, strategyTypes map[string]struct{}, envReader env.Reader) error {
 	for strategyType := range strategyTypes {
 		// Skip "unauthenticated" - already registered
 		if strategyType == strategies.StrategyTypeUnauthenticated {
 			continue
 		}
 
-		strategy, err := createStrategy(strategyType)
+		strategy, err := createStrategy(strategyType, envReader)
 		if err != nil {
 			return fmt.Errorf("failed to create strategy %q: %w", strategyType, err)
 		}
@@ -145,11 +151,12 @@ func registerStrategies(registry auth.OutgoingAuthRegistry, strategyTypes map[st
 //
 // Parameters:
 //   - strategyType: The type identifier of the strategy to create
+//   - envReader: Environment variable reader for dependency injection
 //
 // Returns:
 //   - auth.Strategy: The instantiated strategy
 //   - error: Any error during strategy creation or validation
-func createStrategy(strategyType string) (auth.Strategy, error) {
+func createStrategy(strategyType string, envReader env.Reader) (auth.Strategy, error) {
 	// Validate strategy type is not empty
 	if strings.TrimSpace(strategyType) == "" {
 		return nil, fmt.Errorf("strategy type cannot be empty")
@@ -159,7 +166,7 @@ func createStrategy(strategyType string) (auth.Strategy, error) {
 	case strategies.StrategyTypeHeaderInjection:
 		return strategies.NewHeaderInjectionStrategy(), nil
 	case strategies.StrategyTypeTokenExchange:
-		return strategies.NewTokenExchangeStrategy(), nil
+		return strategies.NewTokenExchangeStrategy(envReader), nil
 	case strategies.StrategyTypeUnauthenticated:
 		return strategies.NewUnauthenticatedStrategy(), nil
 	default:

--- a/pkg/vmcp/auth/factory/outgoing_test.go
+++ b/pkg/vmcp/auth/factory/outgoing_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/stacklok/toolhive/pkg/env"
 	"github.com/stacklok/toolhive/pkg/vmcp/auth"
 	"github.com/stacklok/toolhive/pkg/vmcp/config"
 )
@@ -343,7 +344,8 @@ func TestNewOutgoingAuthRegistry(t *testing.T) {
 			t.Parallel()
 
 			ctx := context.Background()
-			registry, err := NewOutgoingAuthRegistry(ctx, tt.cfg)
+			envReader := &env.OSReader{}
+			registry, err := NewOutgoingAuthRegistry(ctx, tt.cfg, envReader)
 
 			if tt.wantErr {
 				require.Error(t, err)
@@ -657,7 +659,8 @@ func TestCreateStrategy(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			strategy, err := createStrategy(tt.strategyType)
+			envReader := &env.OSReader{}
+			strategy, err := createStrategy(tt.strategyType, envReader)
 
 			if tt.wantErr {
 				require.Error(t, err)
@@ -683,7 +686,8 @@ func TestRegisterUnauthenticatedStrategy(t *testing.T) {
 		t.Parallel()
 
 		ctx := context.Background()
-		registry, err := NewOutgoingAuthRegistry(ctx, nil)
+		envReader := &env.OSReader{}
+		registry, err := NewOutgoingAuthRegistry(ctx, nil, envReader)
 		require.NoError(t, err)
 		require.NotNil(t, registry)
 
@@ -730,7 +734,8 @@ func TestErrorMessages(t *testing.T) {
 			t.Parallel()
 
 			ctx := context.Background()
-			_, err := NewOutgoingAuthRegistry(ctx, tt.cfg)
+			envReader := &env.OSReader{}
+			_, err := NewOutgoingAuthRegistry(ctx, tt.cfg, envReader)
 			require.Error(t, err)
 
 			errMsg := err.Error()


### PR DESCRIPTION
Refactors environment variable access in token exchange authentication to use dependency-injected env.Reader interface instead of direct os.Getenv calls.

This enables proper testing with mocked environment variables using gomock instead of t.Setenv, allowing parallel test execution. No functional changes - client_secret_env support was already present.

This patch will also make it easier to test adding support for environment variables for the `header_injection` strategy.