### PR TITLE
Add environment variable support to header_injection auth

### DIFF
--- a/examples/vmcp-config.yaml
+++ b/examples/vmcp-config.yaml
@@ -43,12 +43,19 @@ outgoing_auth:
   # NOT for authenticating Virtual MCP to backend MCP servers.
   # Backend MCP servers receive properly scoped tokens and use them to call upstream APIs.
   backends:
-    # Example: API key authentication using header_injection
+    # Example 1: API key from environment variable (recommended for secrets)
     github:
       type: header_injection
       header_injection:
         header_name: "Authorization"
-        header_value: "your-github-api-token-here"
+        header_value_env: "GITHUB_API_TOKEN"  # Read from environment variable
+
+    # Example 2: Static header value (for non-secret values only)
+    # api-service:
+    #   type: header_injection
+    #   header_injection:
+    #     header_name: "X-API-Version"
+    #     header_value: "v1"  # Literal value
 
     # Example: OAuth 2.0 Token Exchange (RFC 8693) for GitHub API access
     # github:

--- a/pkg/vmcp/auth/strategies/header_injection.go
+++ b/pkg/vmcp/auth/strategies/header_injection.go
@@ -19,6 +19,8 @@ import (
 // Required metadata fields:
 //   - header_name: The HTTP header name to use (e.g., "X-API-Key", "Authorization")
 //   - header_value: The header value to inject (can be an API key, token, or any value)
+//     Note: In YAML configuration, use either header_value (literal) or header_value_env (from environment).
+//     The value is resolved at config load time and passed here as header_value.
 //
 // This strategy is appropriate when:
 //   - The backend requires a static header value for authentication
@@ -26,7 +28,6 @@ import (
 //   - No dynamic token exchange or user-specific authentication is required
 //
 // Future enhancements may include:
-//   - Secret reference resolution (e.g., ${SECRET_REF:...})
 //   - Support for multiple header formats (e.g., "Bearer <key>")
 //   - Value rotation and refresh mechanisms
 type HeaderInjectionStrategy struct{}
@@ -65,14 +66,6 @@ func (*HeaderInjectionStrategy) Authenticate(_ context.Context, req *http.Reques
 	if !ok || headerValue == "" {
 		return fmt.Errorf("header_value required in metadata")
 	}
-
-	// TODO: Future enhancement - resolve secret references
-	// if strings.HasPrefix(headerValue, "${SECRET_REF:") {
-	//     headerValue, err = s.secretResolver.Resolve(ctx, headerValue)
-	//     if err != nil {
-	//         return fmt.Errorf("failed to resolve secret reference: %w", err)
-	//     }
-	// }
 
 	req.Header.Set(headerName, headerValue)
 	return nil


### PR DESCRIPTION
Adds header_value_env field to header_injection authentication strategy, enabling secrets to be resolved from environment variables at config load time instead of hardcoded in YAML files.

Changes:
- Add header_value_env field to rawHeaderInjectionAuth struct
- Implement validation: exactly one of header_value or header_value_env required
- Update token_exchange and service_account to use env.Reader consistently
- Add 6 comprehensive test cases covering all edge cases
- Update documentation and examples to show both usage patterns

This follows the same pattern as token_exchange (client_secret_env) and service_account (credentials_env) strategies. Environment variables are resolved at config load time with fail-fast validation.

Backward compatible: existing header_value (literal) configurations continue to work unchanged.

Example usage:
  outgoing_auth:
    backends:
      github:
        type: header_injection
        header_injection:
          header_name: "Authorization"
          header_value_env: "GITHUB_API_TOKEN"

Fixes: #2573