### PR TITLE
Fix registry type transitions

### DIFF
--- a/pkg/config/registry.go
+++ b/pkg/config/registry.go
@@ -119,6 +119,7 @@ func setRegistryURL(provider Provider, registryURL string, allowPrivateRegistryI
 	// Update the configuration
 	err = provider.UpdateConfig(func(c *Config) {
 		c.RegistryUrl = registryURL
+		c.RegistryApiUrl = ""    // Clear API URL when setting static URL
 		c.LocalRegistryPath = "" // Clear local path when setting URL
 		c.AllowPrivateRegistryIp = allowPrivateRegistryIp
 	})
@@ -151,7 +152,8 @@ func setRegistryFile(provider Provider, registryPath string) error {
 	// Update the configuration
 	err = provider.UpdateConfig(func(c *Config) {
 		c.LocalRegistryPath = absPath
-		c.RegistryUrl = "" // Clear URL when setting local path
+		c.RegistryUrl = ""    // Clear URL when setting local path
+		c.RegistryApiUrl = "" // Clear API URL when setting local path
 	})
 	if err != nil {
 		return fmt.Errorf("failed to update configuration: %w", err)


### PR DESCRIPTION
The following PR fixes an issue where registry type transitions are not setting the config file correctly.

**Details:**
```bash
setRegistryAPI() correctly clears both RegistryUrl and LocalRegistryPath
setRegistryURL() only clears LocalRegistryPath - missing RegistryApiUrl
setRegistryFile() only clears RegistryUrl - missing RegistryApiUrl
```
instead it should be
```
Setting API URL clears RegistryUrl + LocalRegistryPath
Setting static URL clears RegistryApiUrl + LocalRegistryPath
Setting file path clears RegistryUrl + RegistryApiUrl
```