### PR TITLE
Run operator tests only after other jobs pass

### DIFF
--- a/.github/workflows/run-on-main.yml
+++ b/.github/workflows/run-on-main.yml
@@ -23,22 +23,26 @@ jobs:
     name: Tests
     uses: ./.github/workflows/test.yml
     secrets: inherit
-  e2e-tests:
-    name: E2E Tests
-    uses: ./.github/workflows/e2e-tests.yml
   codegen:
     name: Codegen
     uses: ./.github/workflows/verify-gen.yml
+  # Tier 2: Expensive integration tests - only run after all fast checks pass
+  e2e-tests:
+    name: E2E Tests
+    needs: [linting, tests, codegen]
+    uses: ./.github/workflows/e2e-tests.yml
+  operator-ci:
+    name: Operator CI
+    needs: [linting, tests, codegen]
+    permissions:
+      contents: read
+    uses: ./.github/workflows/operator-ci.yml
+  # Tier 3: Build and publish images - only after all tests pass
   image-build-and-push:
     name: Build and Sign Image
-    needs: [ linting, security-scan, tests, e2e-tests, codegen ]
+    needs: [linting, security-scan, tests, e2e-tests, codegen, operator-ci]
     permissions:
       contents: write
       packages: write
       id-token: write
     uses: ./.github/workflows/image-build-and-publish.yml
-  operator-ci:
-    name: Operator CI
-    permissions:
-      contents: read
-    uses: ./.github/workflows/operator-ci.yml

--- a/.github/workflows/run-on-pr.yml
+++ b/.github/workflows/run-on-pr.yml
@@ -27,17 +27,20 @@ jobs:
     name: Tests
     uses: ./.github/workflows/test.yml
     secrets: inherit
-  e2e-tests:
-    name: E2E Tests
-    uses: ./.github/workflows/e2e-tests.yml
   docs:
     name: Docs
     uses: ./.github/workflows/verify-docgen.yml
   codegen:
     name: Codegen
     uses: ./.github/workflows/verify-gen.yml
+  # Tier 2: Expensive integration tests - only run after all fast checks pass
+  e2e-tests:
+    name: E2E Tests
+    needs: [linting, tests, docs, codegen]
+    uses: ./.github/workflows/e2e-tests.yml
   operator-ci:
     name: Operator CI
+    needs: [linting, tests, docs, codegen]
     permissions:
       contents: read
     uses: ./.github/workflows/operator-ci.yml


### PR DESCRIPTION
The following PR updates the order of CI jobs so we don't run the expensive operator tests if a lint job has failed for example.