### PR TITLE
Adds caching to make CI actions faster when downloading dependencies

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,10 +17,27 @@ jobs:
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6
         with:
           go-version-file: 'go.mod'
-          cache: true
+          cache: true  # Caches go modules
+          cache-dependency-path: go.sum
+
+      # Download all dependencies upfront (will be cached)
+      - name: Download Go dependencies
+        run: |
+          go mod download
+          go mod verify
+
+      # Cache Go build cache for faster compilation during linting
+      - name: Cache Go build cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/go-build
+          key: ${{ runner.os }}-go-build-lint-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-build-lint-
+            ${{ runner.os }}-go-build-
 
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@0a35821d5c230e903fcfe077583637dea1b27b47 # v9.0.0
         with:
-          skip-cache: true
+          # Enable golangci-lint's built-in caching (removes skip-cache: true)
           args: --timeout=5m

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,13 +17,39 @@ jobs:
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6
         with:
           go-version-file: 'go.mod'
-          cache: true
+          cache: true  # This caches go modules based on go.sum
+          cache-dependency-path: go.sum
 
-      - name: Set up gotestfmt
-        uses: gotesttools/gotestfmt-action@v2
+      # Download all dependencies upfront (will be cached)
+      - name: Download Go dependencies
+        run: |
+          go mod download
+          go mod verify
+
+      # Cache Go build cache for faster compilation
+      # Note: ~/go/pkg/mod is already cached by actions/setup-go with cache: true
+      - name: Cache Go build cache
+        uses: actions/cache@v4
         with:
-          # avoid rate limiting
-          token: ${{ secrets.GITHUB_TOKEN }}
+          path: ~/.cache/go-build
+          key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-build-
+
+      # Cache Go tools (gotestfmt only for tests)
+      - name: Cache Go tools
+        id: cache-go-tools
+        uses: actions/cache@v4
+        with:
+          path: ~/go/bin
+          key: ${{ runner.os }}-go-tools-${{ hashFiles('go.mod') }}-gotestfmt-v2
+          restore-keys: |
+            ${{ runner.os }}-go-tools-
+
+      # Only install gotestfmt if not cached
+      - name: Install gotestfmt (if not cached)
+        if: steps.cache-go-tools.outputs.cache-hit != 'true'
+        run: go install github.com/gotesttools/gotestfmt/v2/cmd/gotestfmt@latest
 
       - name: Install Task
         uses: arduino/setup-task@v2
@@ -31,6 +57,7 @@ jobs:
           version: 3.44.1
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
+      # Run tests with all dependencies already cached
       - name: Run tests with coverage
         run: task test-coverage
 

--- a/.github/workflows/verify-gen.yml
+++ b/.github/workflows/verify-gen.yml
@@ -16,20 +16,37 @@ jobs:
       - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6
         with:
           go-version-file: go.mod
+          cache: true  # Cache go modules
+      # Cache Go tools (mockgen)
+      - name: Cache Go tools
+        id: cache-go-tools
+        uses: actions/cache@v4
+        with:
+          path: ~/go/bin
+          key: ${{ runner.os }}-go-codegen-tools-${{ hashFiles('go.mod') }}-mockgen
+          restore-keys: |
+            ${{ runner.os }}-go-codegen-tools-
+
       - name: Install Task
         uses: arduino/setup-task@v2
         with:
           version: 3.44.1
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Install mockgen
+
+      # Only install mockgen if not cached
+      - name: Install mockgen (if not cached)
+        if: steps.cache-go-tools.outputs.cache-hit != 'true'
         run: task mock-install
+
       - name: Generate code files
         run: task gen
       - name: Check for changes
         run: |
-          if ! git diff --exit-code docs/server/; then
+          if ! git diff --exit-code; then
             echo "❌ Generated code files are not up to date!"
             echo "Please run 'task gen' and commit the changes."
+            echo "Files changed:"
+            git diff --name-only
             exit 1
           else
             echo "✅ Generated code files are up to date!"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -48,8 +48,10 @@ tasks:
     platforms: [linux, darwin]
     internal: true
     cmds:
-      - go install github.com/gotesttools/gotestfmt/v2/cmd/gotestfmt@latest
-      # we have to use ldflags to avoid the LC_DYSYMTAB linker error. 
+      # Only install gotestfmt if not already installed
+      - cmd: which gotestfmt > /dev/null 2>&1 || go install github.com/gotesttools/gotestfmt/v2/cmd/gotestfmt@latest
+        platforms: [linux, darwin]
+      # we have to use ldflags to avoid the LC_DYSYMTAB linker error.
       # https://github.com/stacklok/toolhive/issues/1687
       - go test -ldflags=-extldflags=-Wl,-w -v -json -race $(go list ./... | grep -v '/test/e2e' | grep -v '/cmd/thv-operator/test-integration') | gotestfmt -hide "all"
 
@@ -79,8 +81,10 @@ tasks:
     cmds:
       - cmd: mkdir -p coverage
         platforms: [linux, darwin]
-      - go install github.com/gotesttools/gotestfmt/v2/cmd/gotestfmt@latest
-      # we have to use ldflags to avoid the LC_DYSYMTAB linker error. 
+      # Only install gotestfmt if not already installed
+      - cmd: which gotestfmt > /dev/null 2>&1 || go install github.com/gotesttools/gotestfmt/v2/cmd/gotestfmt@latest
+        platforms: [linux, darwin]
+      # we have to use ldflags to avoid the LC_DYSYMTAB linker error.
       # https://github.com/stacklok/toolhive/issues/1687
       - go test -ldflags=-extldflags=-Wl,-w -json -race -coverprofile=coverage/coverage.out $(go list ./... | grep -v '/test/e2e' | grep -v '/cmd/thv-operator/test-integration') | gotestfmt -hide "all"
       - go tool cover -func=coverage/coverage.out


### PR DESCRIPTION
# Description
Implements some caching for some of our CI actions to make them run faster. 

# Affects following tasks
- lint
- test (unit tests)
- mockgen

# Changes 
- Added explicit dependency downloads - go mod download runs upfront to ensure all deps are cached
- Cached Go tools - Tools like `gotestfmt` and `mockgen` are installed once and cached
-  Enabled `golangci-lint` caching - Removed skip-cache: true to use built-in caching
- Added Go build cache - Caches compiled packages for faster builds

# Outcome


<html><head></head><body>

Stage | Before | After | Time saved | % time reduced | ≈ Speedup
-- | -- | -- | -- | -- | --
Lint | 3:47 | 1:05 | 2:42 | 71.4% | 3.49×
Test | 5:26 | 2:23 | 3:03 | 56.1% | 2.28×
Docs | 2:23 | 0:49 | 1:34 | 65.7% | 2.92×
Total | 11:36 | 4:17 | 7:19 | 63.1% | 2.71×

<p>(Percentages are reductions relative to the original times.)</p></body></html>


# Future
In future, we can speed up other tasks but wanted to start off with these. `docs` take over 2 minutes and can be cut down