### PR TITLE
Fix the name mapping between the 2 formats

### DIFF
--- a/cmd/thv/app/registry.go
+++ b/cmd/thv/app/registry.go
@@ -346,7 +346,21 @@ func printTextServerInfo(name string, server types.ServerMetadata) {
 }
 
 // truncateString truncates a string to the specified length and adds "..." if truncated
+// It also sanitizes the string by replacing newlines and multiple spaces with single spaces
 func truncateString(s string, maxLen int) string {
+	// Replace newlines and tabs with spaces
+	s = strings.ReplaceAll(s, "\n", " ")
+	s = strings.ReplaceAll(s, "\r", " ")
+	s = strings.ReplaceAll(s, "\t", " ")
+
+	// Replace multiple consecutive spaces with a single space
+	for strings.Contains(s, "  ") {
+		s = strings.ReplaceAll(s, "  ", " ")
+	}
+
+	// Trim leading/trailing spaces
+	s = strings.TrimSpace(s)
+
 	if len(s) <= maxLen {
 		return s
 	}

--- a/pkg/registry/converters/converters_test.go
+++ b/pkg/registry/converters/converters_test.go
@@ -984,8 +984,8 @@ func TestRealWorld_GitHubServer(t *testing.T) {
 	require.NoError(t, err, "Should convert ImageMetadata back to ServerJSON")
 	require.NotNil(t, resultServerJSON)
 
-	// Verify round-trip preserved core data
-	assert.Equal(t, "io.github.stacklok/github-mcp-server", resultServerJSON.Name)
+	// Verify round-trip preserved core data (including original canonical name)
+	assert.Equal(t, "io.github.github/github-mcp-server", resultServerJSON.Name)
 	assert.Equal(t, officialFormat.Description, resultServerJSON.Description)
 	assert.Equal(t, officialFormat.Repository.URL, resultServerJSON.Repository.URL)
 

--- a/pkg/registry/converters/toolhive_to_upstream.go
+++ b/pkg/registry/converters/toolhive_to_upstream.go
@@ -20,7 +20,7 @@ import (
 )
 
 // ImageMetadataToServerJSON converts toolhive ImageMetadata to an upstream ServerJSON
-// The name parameter should be the simple server name (e.g., "fetch")
+// The name parameter is deprecated and should match imageMetadata.Name. It's kept for backward compatibility.
 func ImageMetadataToServerJSON(name string, imageMetadata *types.ImageMetadata) (*upstream.ServerJSON, error) {
 	if imageMetadata == nil {
 		return nil, fmt.Errorf("imageMetadata cannot be nil")
@@ -29,10 +29,16 @@ func ImageMetadataToServerJSON(name string, imageMetadata *types.ImageMetadata) 
 		return nil, fmt.Errorf("name cannot be empty")
 	}
 
+	// Use imageMetadata.Name if available (contains canonical identifier), otherwise fall back to parameter
+	canonicalName := imageMetadata.Name
+	if canonicalName == "" {
+		canonicalName = BuildReverseDNSName(name)
+	}
+
 	// Create ServerJSON with basic fields
 	serverJSON := &upstream.ServerJSON{
 		Schema:      model.CurrentSchemaURL,
-		Name:        BuildReverseDNSName(name),
+		Name:        canonicalName,
 		Title:       imageMetadata.Name,
 		Description: imageMetadata.Description,
 		Version:     "1.0.0", // TODO: Extract from image tag or metadata
@@ -58,7 +64,7 @@ func ImageMetadataToServerJSON(name string, imageMetadata *types.ImageMetadata) 
 }
 
 // RemoteServerMetadataToServerJSON converts toolhive RemoteServerMetadata to an upstream ServerJSON
-// The name parameter should be the simple server name (e.g., "github-remote")
+// The name parameter is deprecated and should match remoteMetadata.Name. It's kept for backward compatibility.
 func RemoteServerMetadataToServerJSON(name string, remoteMetadata *types.RemoteServerMetadata) (*upstream.ServerJSON, error) {
 	if remoteMetadata == nil {
 		return nil, fmt.Errorf("remoteMetadata cannot be nil")
@@ -67,10 +73,16 @@ func RemoteServerMetadataToServerJSON(name string, remoteMetadata *types.RemoteS
 		return nil, fmt.Errorf("name cannot be empty")
 	}
 
+	// Use remoteMetadata.Name if available (contains canonical identifier), otherwise fall back to parameter
+	canonicalName := remoteMetadata.Name
+	if canonicalName == "" {
+		canonicalName = BuildReverseDNSName(name)
+	}
+
 	// Create ServerJSON with basic fields
 	serverJSON := &upstream.ServerJSON{
 		Schema:      model.CurrentSchemaURL,
-		Name:        BuildReverseDNSName(name),
+		Name:        canonicalName,
 		Title:       remoteMetadata.Name,
 		Description: remoteMetadata.Description,
 		Version:     "1.0.0", // TODO: Version management

--- a/pkg/registry/converters/upstream_to_toolhive.go
+++ b/pkg/registry/converters/upstream_to_toolhive.go
@@ -27,15 +27,9 @@ func ServerJSONToImageMetadata(serverJSON *upstream.ServerJSON) (*types.ImageMet
 		return nil, err
 	}
 
-	// Use Title if available, otherwise use full reverse-DNS Name to avoid conflicts
-	displayName := serverJSON.Title
-	if displayName == "" {
-		displayName = serverJSON.Name
-	}
-
 	imageMetadata := &types.ImageMetadata{
 		BaseServerMetadata: types.BaseServerMetadata{
-			Name:        displayName,
+			Name:        serverJSON.Name,
 			Description: serverJSON.Description,
 			Transport:   pkg.Transport.Type,
 		},
@@ -237,15 +231,9 @@ func ServerJSONToRemoteServerMetadata(serverJSON *upstream.ServerJSON) (*types.R
 
 	remote := serverJSON.Remotes[0] // Use first remote
 
-	// Use Title if available, otherwise use full reverse-DNS Name to avoid conflicts
-	displayName := serverJSON.Title
-	if displayName == "" {
-		displayName = serverJSON.Name
-	}
-
 	remoteMetadata := &types.RemoteServerMetadata{
 		BaseServerMetadata: types.BaseServerMetadata{
-			Name:        displayName,
+			Name:        serverJSON.Name,
 			Description: serverJSON.Description,
 			Transport:   remote.Type,
 		},


### PR DESCRIPTION
The following PR:
* fixes the name mapping between the 2 formats, i.e. do not use the title (nicely formatted name) as the name in the toolhive format
* normalises new lines and other formatters so they don't break the table view