### PR TITLE
Fix RFC 7591 scope serialization format

### DIFF
--- a/pkg/auth/oauth/dynamic_registration_test.go
+++ b/pkg/auth/oauth/dynamic_registration_test.go
@@ -466,14 +466,14 @@ func TestDynamicClientRegistrationResponse_Validation(t *testing.T) {
 
 // TestIsLocalhost is already defined in oidc_test.go
 
-// TestRequestScopeList_MarshalJSON tests that the RequestScopeList marshaling works correctly
+// TestScopeList_MarshalJSON tests that the ScopeList marshaling works correctly
 // and produces RFC 7591 compliant space-delimited strings.
-func TestRequestScopeList_MarshalJSON(t *testing.T) {
+func TestScopeList_MarshalJSON(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
 		name     string
-		scopes   RequestScopeList
+		scopes   ScopeList
 		wantJSON string
 		wantOmit bool // If true, expect omitempty to hide the field
 	}{
@@ -485,28 +485,28 @@ func TestRequestScopeList_MarshalJSON(t *testing.T) {
 		},
 		{
 			name:     "empty slice => empty string (omitempty will hide at struct level)",
-			scopes:   RequestScopeList{},
+			scopes:   ScopeList{},
 			wantJSON: `""`,
 			wantOmit: true,
 		},
 		{
 			name:     "single scope => string",
-			scopes:   RequestScopeList{"openid"},
+			scopes:   ScopeList{"openid"},
 			wantJSON: `"openid"`,
 		},
 		{
 			name:     "two scopes => space-delimited string",
-			scopes:   RequestScopeList{"openid", "profile"},
+			scopes:   ScopeList{"openid", "profile"},
 			wantJSON: `"openid profile"`,
 		},
 		{
 			name:     "three scopes => space-delimited string",
-			scopes:   RequestScopeList{"openid", "profile", "email"},
+			scopes:   ScopeList{"openid", "profile", "email"},
 			wantJSON: `"openid profile email"`,
 		},
 		{
 			name:     "scopes with special characters",
-			scopes:   RequestScopeList{"read:user", "write:repo"},
+			scopes:   ScopeList{"read:user", "write:repo"},
 			wantJSON: `"read:user write:repo"`,
 		},
 	}
@@ -526,7 +526,7 @@ func TestRequestScopeList_MarshalJSON(t *testing.T) {
 			// so empty slices are omitted regardless of what MarshalJSON returns.
 			if tt.wantOmit {
 				type testStruct struct {
-					Scope RequestScopeList `json:"scope,omitempty"`
+					Scope ScopeList `json:"scope,omitempty"`
 				}
 				s := testStruct{Scope: tt.scopes}
 				structJSON, err := json.Marshal(s)


### PR DESCRIPTION
## Problem

ToolHive's dynamic client registration was sending the `scope` parameter as a JSON array instead of a space-delimited string, violating RFC 7591 Section 2.

This caused registration failures with OAuth providers that strictly validate RFC 7591 compliance.

## Changes

- Added `RequestScopeList` type with custom `MarshalJSON` method to serialize scopes as space-delimited strings
- Updated `DynamicClientRegistrationRequest.Scopes` field to use `RequestScopeList`
- Enhanced test coverage with `TestRequestScopeList_MarshalJSON` to verify RFC compliance
- Updated existing tests to validate space-delimited string format
- Removed NOTE/TODO comments about the format violation
- Added INFO logging to demonstrate RFC 7591 scope marshaling in production

## RFC 7591 Compliance

Per RFC 7591 Section 2:
> "scope: String containing a **space-separated list** of scope values"

**Before:**
```json
{
  "scope": ["openid", "profile", "email"]
}
```

**After (RFC 7591 compliant):**
```json
{
  "scope": "openid profile email"
}
```

## Real-World Testing

Tested successfully against [Atlassian's Rovo MCP Server](https://support.atlassian.com/)](https://support.atlassian.com/atlassian-rovo-mcp-server/docs/using-with-other-supported-mcp-clients/) and its OAuth server (`https://cf.mcp.atlassian.com`):

### RFC 7591 Scope Marshaling Proof

```
RFC 7591: Marshaled RequestScopeList [openid profile email] -> "openid profile email" (space-delimited string)
Successfully registered OAuth client dynamically
```

This proves the fix correctly:
1. Transforms Go slice `[openid profile email]` to JSON string `"openid profile email"`
2. Sends space-delimited string per RFC 7591 Section 2 (not JSON array)
3. Successfully registers with a real third-party OAuth server

The authorization URL also confirms correct format: `scope=openid+profile+email` (URL-encoded space-delimited).

## Testing

- All existing OAuth tests pass
- New test `TestRequestScopeList_MarshalJSON` validates marshaling behavior
- Updated test `TestDynamicClientRegistrationRequest_ScopeSerialization` verifies RFC compliance
- Linting passes with 0 issues
- Real-world validation against Atlassian MCP OAuth server

## Compatibility

The response handling (`ScopeList` type) already supports both formats for maximum compatibility with various OAuth providers.

### Question
Do any mainstream mcp servers only support non-spec / array of strings behavior?  If so, does toolhive customers need a config control over the format to allow customers to force non-spec behavior?

Fixes #2596

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
