### PR TITLE
Remove unimplemented StepTypeConditional

### DIFF
--- a/pkg/vmcp/composer/composer.go
+++ b/pkg/vmcp/composer/composer.go
@@ -68,7 +68,7 @@ type WorkflowStep struct {
 	// ID uniquely identifies this step within the workflow.
 	ID string
 
-	// Type is the step type: "tool", "elicitation", "conditional"
+	// Type is the step type: "tool", "elicitation"
 	Type StepType
 
 	// Tool is the tool to call (for tool steps).
@@ -114,9 +114,6 @@ const (
 
 	// StepTypeElicitation requests user input via MCP elicitation protocol.
 	StepTypeElicitation StepType = "elicitation"
-
-	// StepTypeConditional executes based on a condition (future).
-	StepTypeConditional StepType = "conditional"
 )
 
 // ErrorHandler defines how to handle step failures.

--- a/pkg/vmcp/composer/workflow_engine.go
+++ b/pkg/vmcp/composer/workflow_engine.go
@@ -269,11 +269,6 @@ func (e *workflowEngine) executeStep(
 		return e.executeToolStep(stepCtx, step, workflowCtx)
 	case StepTypeElicitation:
 		return e.executeElicitationStep(stepCtx, step, workflowCtx)
-	case StepTypeConditional:
-		// Conditional steps are not implemented in Phase 2
-		err := fmt.Errorf("conditional steps are not yet supported")
-		workflowCtx.RecordStepFailure(step.ID, err)
-		return err
 	default:
 		err := fmt.Errorf("unsupported step type: %s", step.Type)
 		workflowCtx.RecordStepFailure(step.ID, err)
@@ -776,11 +771,6 @@ func (*workflowEngine) validateStep(step *WorkflowStep, validStepIDs map[string]
 				fmt.Sprintf("elicitation message is required for step %s", step.ID),
 				nil)
 		}
-	case StepTypeConditional:
-		// Future: validate conditional step
-		return NewValidationError("step.type",
-			fmt.Sprintf("conditional steps are not yet supported (step %s)", step.ID),
-			nil)
 	default:
 		return NewValidationError("step.type",
 			fmt.Sprintf("invalid step type %q for step %s", step.Type, step.ID),

--- a/pkg/vmcp/server/workflow_converter.go
+++ b/pkg/vmcp/server/workflow_converter.go
@@ -170,8 +170,6 @@ func parseStepType(cs *config.WorkflowStepConfig) (composer.StepType, error) {
 		}
 	case "elicitation":
 		stepType = composer.StepTypeElicitation
-	case "conditional":
-		stepType = composer.StepTypeConditional
 	default:
 		return "", fmt.Errorf("step %s: invalid step type %s", cs.ID, cs.Type)
 	}


### PR DESCRIPTION
## Summary

Removes the `StepTypeConditional` constant and all related code that was added as a placeholder but never designed or implemented in the proposal.

## Background

The constant was added in #2439 alongside the `condition` field implementation, but:
- It was never documented in the THV-2106 proposal
- No design exists for how it would work
- It's been marked "not yet supported" since day one
- It causes confusion by suggesting a feature that doesn't exist

## What Changed

- ✅ Removed `StepTypeConditional` constant from composer package
- ✅ Removed conditional case from workflow execution switch
- ✅ Removed conditional validation case  
- ✅ Removed conditional parsing from workflow converter
- ✅ Updated step type documentation comment

## What Stays the Same

The **`condition` field** on workflow steps remains unchanged and fully functional. This field enables conditional execution via template evaluation (e.g., `condition: "{{.steps.confirm.output.action == 'accept'}}"`).

## Testing

- ✅ All composer tests pass
- ✅ All vmcp tests pass
- ✅ Linter passes with 0 issues
- ✅ K8s CRD already has correct enum (`tool;elicitation`)
- ✅ No e2e test changes needed

## Notes

One test (`TestDAGExecutor_ComplexWorkflow`) shows intermittent flakiness with the race detector (timing-sensitive parallel execution test), but passes consistently without it. This is unrelated to these changes.