### PR TITLE
Fix args handling for protocol builds

### DIFF
--- a/pkg/container/templates/go.tmpl
+++ b/pkg/container/templates/go.tmpl
@@ -99,4 +99,4 @@ COPY --from=builder --chown=appuser:appgroup /build/ /app/
 USER appuser
 
 # Run the pre-built MCP server binary
-ENTRYPOINT ["/app/mcp-server"{{range .MCPArgs}}, "{{.}}"{{end}}]
+ENTRYPOINT ["/app/mcp-server"]

--- a/pkg/container/templates/npx.tmpl
+++ b/pkg/container/templates/npx.tmpl
@@ -98,7 +98,7 @@ USER appuser
 # `MCPPackage` may include a version suffix (e.g., `package@1.2.3`), which we cannot use here.
 # Create a small wrapper script to handle this.
 RUN echo "#!/bin/sh" >> entrypoint.sh && \
-    echo "exec npx $(echo {{.MCPPackage}} | sed 's/@[^@/]*$//'){{range .MCPArgs}}, "{{.}}"{{end}}" >> entrypoint.sh && \
+    echo "exec npx {{.MCPPackage}} \"\$@\"" >> entrypoint.sh && \
     chmod +x entrypoint.sh
 
 # Run the preinstalled MCP package directly using npx.

--- a/pkg/container/templates/templates.go
+++ b/pkg/container/templates/templates.go
@@ -16,8 +16,6 @@ var templateFS embed.FS
 type TemplateData struct {
 	// MCPPackage is the name of the MCP package to run.
 	MCPPackage string
-	// MCPArgs are the arguments to pass to the MCP package.
-	MCPArgs []string
 	// CACertContent is the content of the custom CA certificate to include in the image.
 	CACertContent string
 	// IsLocalPath indicates if the MCPPackage is a local path that should be copied into the container.

--- a/pkg/container/templates/templates_test.go
+++ b/pkg/container/templates/templates_test.go
@@ -22,7 +22,6 @@ func TestGetDockerfileTemplate(t *testing.T) {
 			transportType: TransportTypeUVX,
 			data: TemplateData{
 				MCPPackage: "example-package",
-				MCPArgs:    []string{"--arg1", "--arg2", "value"},
 			},
 			wantContains: []string{
 				"FROM python:",
@@ -31,7 +30,7 @@ func TestGetDockerfileTemplate(t *testing.T) {
 				"package_spec=$(echo \"$package\" | sed 's/@/==/')",
 				"uv tool install \"$package_spec\"",
 				"COPY --from=builder --chown=appuser:appgroup /opt/uv-tools /opt/uv-tools",
-				"ENTRYPOINT [\"sh\", \"-c\", \"package='example-package'; exec \\\"${package%%@*}\\\" \\\"--arg1\\\" \\\"--arg2\\\" \\\"value\\\" \\\"$@\\\"\", \"--\"]",
+				"ENTRYPOINT [\"sh\", \"-c\", \"package='example-package'; exec \\\"${package%%@*}\\\"\", \"--\"]",
 			},
 			wantMatches: []string{
 				`FROM python:\d+\.\d+-slim AS builder`, // Match builder stage
@@ -48,7 +47,6 @@ func TestGetDockerfileTemplate(t *testing.T) {
 			transportType: TransportTypeUVX,
 			data: TemplateData{
 				MCPPackage:    "example-package",
-				MCPArgs:       []string{"--arg1", "--arg2", "value"},
 				CACertContent: "-----BEGIN CERTIFICATE-----\nMIICertificateContent\n-----END CERTIFICATE-----",
 			},
 			wantContains: []string{
@@ -58,7 +56,7 @@ func TestGetDockerfileTemplate(t *testing.T) {
 				"package_spec=$(echo \"$package\" | sed 's/@/==/')",
 				"uv tool install \"$package_spec\"",
 				"COPY --from=builder --chown=appuser:appgroup /opt/uv-tools /opt/uv-tools",
-				"ENTRYPOINT [\"sh\", \"-c\", \"package='example-package'; exec \\\"${package%%@*}\\\" \\\"--arg1\\\" \\\"--arg2\\\" \\\"value\\\" \\\"$@\\\"\", \"--\"]",
+				"ENTRYPOINT [\"sh\", \"-c\", \"package='example-package'; exec \\\"${package%%@*}\\\"\", \"--\"]",
 				"Add custom CA certificate BEFORE any network operations",
 				"COPY ca-cert.crt /tmp/custom-ca.crt",
 				"cat /tmp/custom-ca.crt >> /etc/ssl/certs/ca-certificates.crt",
@@ -76,13 +74,12 @@ func TestGetDockerfileTemplate(t *testing.T) {
 			transportType: TransportTypeNPX,
 			data: TemplateData{
 				MCPPackage: "example-package",
-				MCPArgs:    []string{"--arg1", "--arg2", "value"},
 			},
 			wantContains: []string{
 				"FROM node:",
 				"npm install --save example-package",
 				"COPY --from=builder --chown=appuser:appgroup /build/node_modules /app/node_modules",
-				"echo \"exec npx $(echo example-package | sed 's/@[^@/]*$//'), \"--arg1\", \"--arg2\", \"value\"\" >> entrypoint.sh",
+				"echo \"exec npx example-package \\\"\\$@\\\"\" >> entrypoint.sh",
 				"ENTRYPOINT [\"./entrypoint.sh\"]",
 			},
 			wantMatches: []string{
@@ -100,13 +97,12 @@ func TestGetDockerfileTemplate(t *testing.T) {
 			transportType: TransportTypeNPX,
 			data: TemplateData{
 				MCPPackage:    "example-package",
-				MCPArgs:       []string{"--arg1", "--arg2", "value"},
 				CACertContent: "-----BEGIN CERTIFICATE-----\nMIICertificateContent\n-----END CERTIFICATE-----",
 			},
 			wantContains: []string{
 				"FROM node:",
 				"npm install --save example-package",
-				"echo \"exec npx $(echo example-package | sed 's/@[^@/]*$//'), \"--arg1\", \"--arg2\", \"value\"\" >> entrypoint.sh",
+				"echo \"exec npx example-package \\\"\\$@\\\"\" >> entrypoint.sh",
 				"ENTRYPOINT [\"./entrypoint.sh\"]",
 				"Add custom CA certificate BEFORE any network operations",
 				"COPY ca-cert.crt /tmp/custom-ca.crt",
@@ -125,7 +121,6 @@ func TestGetDockerfileTemplate(t *testing.T) {
 			transportType: TransportTypeGO,
 			data: TemplateData{
 				MCPPackage: "example-package",
-				MCPArgs:    []string{"--arg1", "--arg2", "value"},
 			},
 			wantContains: []string{
 				"FROM golang:",
@@ -134,7 +129,7 @@ func TestGetDockerfileTemplate(t *testing.T) {
 				"go install \"$package\"",
 				"FROM alpine:",
 				"COPY --from=builder --chown=appuser:appgroup /app/mcp-server /app/mcp-server",
-				"ENTRYPOINT [\"/app/mcp-server\", \"--arg1\", \"--arg2\", \"value\"]",
+				"ENTRYPOINT [\"/app/mcp-server\"]",
 			},
 			wantMatches: []string{
 				`FROM golang:\d+\.\d+-alpine AS builder`, // Match builder stage
@@ -151,7 +146,6 @@ func TestGetDockerfileTemplate(t *testing.T) {
 			transportType: TransportTypeGO,
 			data: TemplateData{
 				MCPPackage:    "example-package",
-				MCPArgs:       []string{"--arg1", "--arg2", "value"},
 				CACertContent: "-----BEGIN CERTIFICATE-----\nMIICertificateContent\n-----END CERTIFICATE-----",
 			},
 			wantContains: []string{
@@ -160,7 +154,7 @@ func TestGetDockerfileTemplate(t *testing.T) {
 				"package=\"${package}@latest\"",
 				"go install \"$package\"",
 				"FROM alpine:",
-				"ENTRYPOINT [\"/app/mcp-server\", \"--arg1\", \"--arg2\", \"value\"]",
+				"ENTRYPOINT [\"/app/mcp-server\"]",
 				"Add custom CA certificate BEFORE any network operations",
 				"COPY ca-cert.crt /tmp/custom-ca.crt",
 				"cat /tmp/custom-ca.crt >> /etc/ssl/certs/ca-certificates.crt",
@@ -178,7 +172,6 @@ func TestGetDockerfileTemplate(t *testing.T) {
 			transportType: TransportTypeGO,
 			data: TemplateData{
 				MCPPackage:  "./cmd/server",
-				MCPArgs:     []string{"--arg1", "value"},
 				IsLocalPath: true,
 			},
 			wantContains: []string{
@@ -188,7 +181,7 @@ func TestGetDockerfileTemplate(t *testing.T) {
 				"FROM alpine:",
 				"COPY --from=builder --chown=appuser:appgroup /app/mcp-server /app/mcp-server",
 				"COPY --from=builder --chown=appuser:appgroup /build/ /app/",
-				"ENTRYPOINT [\"/app/mcp-server\", \"--arg1\", \"value\"]",
+				"ENTRYPOINT [\"/app/mcp-server\"]",
 			},
 			wantMatches: []string{
 				`FROM golang:\d+\.\d+-alpine AS builder`, // Match builder stage
@@ -204,7 +197,6 @@ func TestGetDockerfileTemplate(t *testing.T) {
 			transportType: TransportTypeGO,
 			data: TemplateData{
 				MCPPackage:  ".",
-				MCPArgs:     []string{},
 				IsLocalPath: true,
 			},
 			wantContains: []string{
@@ -229,7 +221,6 @@ func TestGetDockerfileTemplate(t *testing.T) {
 			transportType: "unsupported",
 			data: TemplateData{
 				MCPPackage: "example-package",
-				MCPArgs:    []string{"--arg1", "--arg2", "value"},
 			},
 			wantContains:    nil,
 			wantNotContains: nil,

--- a/pkg/container/templates/uvx.tmpl
+++ b/pkg/container/templates/uvx.tmpl
@@ -118,4 +118,4 @@ USER appuser
 # We use sh -c to allow the package name to be resolved from PATH
 # Strip version specifier (if present) from package name for execution
 # Handles format like package@version
-ENTRYPOINT ["sh", "-c", "package='{{.MCPPackage}}'; exec \"${package%%@*}\" {{range .MCPArgs}}\"{{.}}\" {{end}}\"$@\"", "--"]
+ENTRYPOINT ["sh", "-c", "package='{{.MCPPackage}}'; exec \"${package%%@*}\"", "--"]

--- a/pkg/runner/protocol.go
+++ b/pkg/runner/protocol.go
@@ -91,7 +91,6 @@ func createTemplateData(transportType templates.TransportType, packageName, caCe
 
 	templateData := templates.TemplateData{
 		MCPPackage:  packageName,
-		MCPArgs:     []string{}, // No additional arguments for now
 		IsLocalPath: isLocalPath,
 	}
 

--- a/pkg/runner/protocol_test.go
+++ b/pkg/runner/protocol_test.go
@@ -188,7 +188,6 @@ func TestTemplateDataWithLocalPath(t *testing.T) {
 			packageName: "github.com/example/package",
 			expected: templates.TemplateData{
 				MCPPackage:  "github.com/example/package",
-				MCPArgs:     []string{},
 				IsLocalPath: false,
 			},
 		},
@@ -197,7 +196,6 @@ func TestTemplateDataWithLocalPath(t *testing.T) {
 			packageName: "./cmd/server",
 			expected: templates.TemplateData{
 				MCPPackage:  "./cmd/server",
-				MCPArgs:     []string{},
 				IsLocalPath: true,
 			},
 		},
@@ -206,7 +204,6 @@ func TestTemplateDataWithLocalPath(t *testing.T) {
 			packageName: ".",
 			expected: templates.TemplateData{
 				MCPPackage:  ".",
-				MCPArgs:     []string{},
 				IsLocalPath: true,
 			},
 		},
@@ -220,7 +217,6 @@ func TestTemplateDataWithLocalPath(t *testing.T) {
 
 			templateData := templates.TemplateData{
 				MCPPackage:  tt.packageName,
-				MCPArgs:     []string{},
 				IsLocalPath: isLocalPath,
 			}
 


### PR DESCRIPTION
Fixes #2623

Abandons the unimplemented MCPArgs build-time expansion in favor of simpler runtime args handling. This also eliminates potential
duplication of args.


Root cause: command args were working for Go and uvx protocol builds because their Dockerfile templates implemented direct ENTRYPOINT execution, while npx has an interim shell script that was not handling runtime args. An alternate approach to the fix (#2627) led to duplication of args.

Changes:
- Remove unused MCPArgs field from TemplateData struct
- Update go.tmpl, npx.tmpl, and uvx.tmpl to use runtime args ($@)
- Update all test expectations in templates_test.go and protocol_test.go

All Dockerfile templates now accept arguments at runtime instead of baking them in at build time, making the containers more flexible.

Testing:

I tested with Go, uvx, and npx and confirmed the resulting Docker command was as expected for all three:

```bash
./bin/thv run go://github.com/aantti/mcp-netbird/cmd/mcp-netbird@latest -- --some-arg true
./bin/thv run uvx://awslabs.aws-diagram-mcp-server@1.0.12 -- --some-arg true
./bin/thv run npx://@launchdarkly/mcp-server@latest -- start

docker ps --no-trunc --format "table {{.Names}}\t{{.Command}}"
```

Output:

```
NAMES                                                  COMMAND
awslabs-aws-diagram-mcp-server-1-0-12                  "sh -c 'package='awslabs.aws-diagram-mcp-server@1.0.12'; exec \"${package%%@*}\"' -- --some-arg true"
launchdarkly-mcp-server-latest                         "./entrypoint.sh start"
github-com-aantti-mcp-netbird-cmd-mcp-netbird-latest   "/app/mcp-server --some-arg true"
```

Signed-off-by: Dan Barr <6922515+danbarr@users.noreply.github.com>