### PR TITLE
makes int tests less verbose in logs by default

### DIFF
--- a/cmd/thv-operator/Taskfile.yml
+++ b/cmd/thv-operator/Taskfile.yml
@@ -198,7 +198,7 @@ tasks:
       - go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.22
       - go install github.com/onsi/ginkgo/v2/ginkgo@latest
       # Run tests in parallel using ginkgo -p flag (uses number of CPU cores by default)
-      - KUBEBUILDER_ASSETS="$($(go env GOPATH)/bin/setup-envtest use 1.31.0 -p path)" $(go env GOPATH)/bin/ginkgo -v -p ./cmd/thv-operator/test-integration/...
+      - KUBEBUILDER_ASSETS="$($(go env GOPATH)/bin/setup-envtest use 1.31.0 -p path)" $(go env GOPATH)/bin/ginkgo --succinct -v -p ./cmd/thv-operator/test-integration/...
 
   # Backwards compatibility
   operator-e2e-test:

--- a/cmd/thv-operator/test-integration/mcp-external-auth/suite_test.go
+++ b/cmd/thv-operator/test-integration/mcp-external-auth/suite_test.go
@@ -38,11 +38,20 @@ var (
 func TestControllers(t *testing.T) {
 	t.Parallel()
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "MCPExternalAuthConfig Controller Suite")
+
+	suiteConfig, reporterConfig := GinkgoConfiguration()
+	// Only show verbose output for failures
+	reporterConfig.Verbose = false
+	reporterConfig.VeryVerbose = false
+	reporterConfig.FullTrace = false
+
+	RunSpecs(t, "MCPExternalAuthConfig Controller Suite", suiteConfig, reporterConfig)
 }
 
 var _ = BeforeSuite(func() {
-	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true), zap.Level(zapcore.DebugLevel)))
+	// Only log errors unless a test fails
+	logLevel := zapcore.ErrorLevel
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true), zap.Level(logLevel)))
 
 	ctx, cancel = context.WithCancel(context.TODO())
 

--- a/cmd/thv-operator/test-integration/mcp-group/suite_test.go
+++ b/cmd/thv-operator/test-integration/mcp-group/suite_test.go
@@ -39,11 +39,20 @@ var (
 func TestControllers(t *testing.T) {
 	t.Parallel()
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "MCPGroup Controller Integration Suite")
+
+	suiteConfig, reporterConfig := GinkgoConfiguration()
+	// Only show verbose output for failures
+	reporterConfig.Verbose = false
+	reporterConfig.VeryVerbose = false
+	reporterConfig.FullTrace = false
+
+	RunSpecs(t, "MCPGroup Controller Integration Suite", suiteConfig, reporterConfig)
 }
 
 var _ = BeforeSuite(func() {
-	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true), zap.Level(zapcore.DebugLevel)))
+	// Only log errors unless a test fails
+	logLevel := zapcore.ErrorLevel
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true), zap.Level(logLevel)))
 
 	ctx, cancel = context.WithCancel(context.TODO())
 

--- a/cmd/thv-operator/test-integration/mcp-registry/suite_test.go
+++ b/cmd/thv-operator/test-integration/mcp-registry/suite_test.go
@@ -10,6 +10,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"go.uber.org/zap/zapcore"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -34,11 +35,20 @@ var (
 
 func TestOperatorE2E(t *testing.T) { //nolint:paralleltest // E2E tests should not run in parallel
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Operator E2E Suite")
+
+	suiteConfig, reporterConfig := GinkgoConfiguration()
+	// Only show verbose output for failures
+	reporterConfig.Verbose = false
+	reporterConfig.VeryVerbose = false
+	reporterConfig.FullTrace = false
+
+	RunSpecs(t, "Operator E2E Suite", suiteConfig, reporterConfig)
 }
 
 var _ = BeforeSuite(func() {
-	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+	// Only log errors unless a test fails
+	logLevel := zapcore.ErrorLevel
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true), zap.Level(logLevel)))
 
 	ctx, cancel = context.WithCancel(context.TODO())
 

--- a/cmd/thv-operator/test-integration/mcp-server/suite_test.go
+++ b/cmd/thv-operator/test-integration/mcp-server/suite_test.go
@@ -41,11 +41,21 @@ var (
 func TestControllers(t *testing.T) {
 	t.Parallel()
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Controller Suite")
+
+	suiteConfig, reporterConfig := GinkgoConfiguration()
+	// Only show verbose output for failures
+	reporterConfig.Verbose = false
+	reporterConfig.VeryVerbose = false
+	reporterConfig.FullTrace = false
+
+	RunSpecs(t, "Controller Suite", suiteConfig, reporterConfig)
 }
 
 var _ = BeforeSuite(func() {
-	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true), zap.Level(zapcore.DebugLevel)))
+	// Only log errors unless a test fails
+	logLevel := zapcore.ErrorLevel
+
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true), zap.Level(logLevel)))
 
 	ctx, cancel = context.WithCancel(context.TODO())
 


### PR DESCRIPTION
When running `task operator-test-integration` by default it will spit out a bunch of logs and specs. We want to reduce this by default to only show what failed. You can choose to go back to verbosity if you want by removing the `--succinct` flag in the `operator-test-integration` Task. There's probably something smarter we could do but Taskfile is less flexible than Make and I don't want to have to duplicate the Task for a verbose version, so will keep it simple for now