### PR TITLE
[#2660] Fix issue with MCPServer.Spec.ResourceOverrides.ProxyDeployme…

### DIFF
--- a/cmd/thv-operator/controllers/mcpserver_controller.go
+++ b/cmd/thv-operator/controllers/mcpserver_controller.go
@@ -1097,7 +1097,8 @@ func (r *MCPServerReconciler) deploymentForMCPServer(
 
 		if m.Spec.ResourceOverrides.ProxyDeployment.PodTemplateMetadataOverrides != nil {
 			if m.Spec.ResourceOverrides.ProxyDeployment.PodTemplateMetadataOverrides.Labels != nil {
-				deploymentLabels = ctrlutil.MergeLabels(ls, m.Spec.ResourceOverrides.ProxyDeployment.PodTemplateMetadataOverrides.Labels)
+				deploymentTemplateLabels = ctrlutil.MergeLabels(ls,
+					m.Spec.ResourceOverrides.ProxyDeployment.PodTemplateMetadataOverrides.Labels)
 			}
 			if m.Spec.ResourceOverrides.ProxyDeployment.PodTemplateMetadataOverrides.Annotations != nil {
 				deploymentTemplateAnnotations = ctrlutil.MergeAnnotations(deploymentAnnotations,

--- a/cmd/thv-operator/controllers/mcpserver_pod_template_test.go
+++ b/cmd/thv-operator/controllers/mcpserver_pod_template_test.go
@@ -76,6 +76,15 @@ func TestDeploymentForMCPServerWithPodTemplateSpec(t *testing.T) {
 			Transport:       "stdio",
 			ProxyPort:       8080,
 			PodTemplateSpec: podTemplateSpecToRawExtension(t, podTemplateSpec),
+			ResourceOverrides: &mcpv1alpha1.ResourceOverrides{
+				ProxyDeployment: &mcpv1alpha1.ProxyDeploymentOverrides{
+					PodTemplateMetadataOverrides: &mcpv1alpha1.ResourceMetadataOverrides{
+						Labels: map[string]string{
+							"podspec-testlabel": "true",
+						},
+					},
+				},
+			},
 		},
 	}
 
@@ -92,6 +101,10 @@ func TestDeploymentForMCPServerWithPodTemplateSpec(t *testing.T) {
 	ctx := context.Background()
 	deployment := r.deploymentForMCPServer(ctx, mcpServer, "test-checksum")
 	require.NotNil(t, deployment, "Deployment should not be nil")
+
+	// Check that the pod template metadata overrides labels are merged with Spec.Template.Labels
+	proxyLabels := deployment.Spec.Template.Labels
+	assert.Equal(t, "true", proxyLabels["podspec-testlabel"], "podTemplateMetadataOverrides labels should be merged with Spec.Template.Labels")
 
 	// Check if the pod template patch is included in the args
 	podTemplatePatchFound := false

--- a/cmd/thv-operator/test-integration/mcp-server/mcpserver_controller_integration_test.go
+++ b/cmd/thv-operator/test-integration/mcp-server/mcpserver_controller_integration_test.go
@@ -79,6 +79,15 @@ var _ = Describe("MCPServer Controller Integration Tests", func() {
 							Memory: "128Mi",
 						},
 					},
+					ResourceOverrides: &mcpv1alpha1.ResourceOverrides{
+						ProxyDeployment: &mcpv1alpha1.ProxyDeploymentOverrides{
+							PodTemplateMetadataOverrides: &mcpv1alpha1.ResourceMetadataOverrides{
+								Labels: map[string]string{
+									"podspec-testlabel": "true",
+								},
+							},
+						},
+					},
 				},
 			}
 
@@ -116,14 +125,14 @@ var _ = Describe("MCPServer Controller Integration Tests", func() {
 			verifyOwnerReference(deployment.OwnerReferences, createdMCPServer, "Deployment")
 
 			// Verify Deployment labels
-			expectedLabels := map[string]string{
+			baseExpectedLabels := map[string]string{
 				"app":                        "mcpserver",
 				"app.kubernetes.io/name":     "mcpserver",
 				"app.kubernetes.io/instance": mcpServerName,
 				"toolhive":                   "true",
 				"toolhive-name":              mcpServerName,
 			}
-			for key, value := range expectedLabels {
+			for key, value := range baseExpectedLabels {
 				Expect(deployment.Labels).To(HaveKeyWithValue(key, value))
 			}
 
@@ -131,10 +140,12 @@ var _ = Describe("MCPServer Controller Integration Tests", func() {
 			Expect(deployment.Spec.Replicas).To(Equal(ptr.To(int32(1))))
 
 			// Verify selector
-			Expect(deployment.Spec.Selector.MatchLabels).To(Equal(expectedLabels))
+			Expect(deployment.Spec.Selector.MatchLabels).To(Equal(baseExpectedLabels))
 
 			// Verify pod template labels
-			for key, value := range expectedLabels {
+			podTemplateExepectedLabels := baseExpectedLabels
+			podTemplateExepectedLabels["podspec-testlabel"] = "true"
+			for key, value := range podTemplateExepectedLabels {
 				Expect(deployment.Spec.Template.Labels).To(HaveKeyWithValue(key, value))
 			}
 


### PR DESCRIPTION
…nt.PodTemplateMetadataOverrides.Labels

This assigns the CRD labels to the correct aree of the emitted Deployment object

Fixes #2660