### PR TITLE
removes pulling and loading of registry api image in operator deploy task

### DIFF
--- a/cmd/thv-operator/Taskfile.yml
+++ b/cmd/thv-operator/Taskfile.yml
@@ -141,9 +141,6 @@ tasks:
       - kind load docker-image --name toolhive {{.OPERATOR_IMAGE}}
       - echo "Loading toolhive image {{.TOOLHIVE_IMAGE}} into kind..."
       - kind load docker-image --name toolhive {{.TOOLHIVE_IMAGE}}
-      - echo "Pulling and loading registry API image {{.REGISTRY_API_IMAGE}} into kind..."
-      - docker pull {{.REGISTRY_API_IMAGE}}
-      - kind load docker-image --name toolhive {{.REGISTRY_API_IMAGE}}
       - |
         helm upgrade --install toolhive-operator deploy/charts/operator \
         --set operator.image={{.OPERATOR_IMAGE}} \


### PR DESCRIPTION
This was likely a leftover from when the registry API lived in this repository. At that time, it made sense to load the image into the kind node because it’s common to load locally built images into a kind cluster for testing. Now that the registry server lives in its own repository and the image is publicly available, the operator simply pulls it when creating the registry deployment inside the cluster. This means we no longer need to pull the image ourselves or load it into kind.

There were also complications with pulling and loading remote images. Docker only pulls images for the host architecture, while `kind load` (by default) expects all platforms via `--all-platforms`. This mismatch causes errors because Docker never downloaded the multi-arch manifests that kind tries to load. We *could* instruct kind to load only the host platform, but since the image is public and no longer part of the local build process, that would be unnecessary.

The operator and proxyrunner images loaded without issues because we build them with `ko`, which produces multi-arch images by default, so kind can successfully load them.
