### PR TITLE
Add native OrbStack Docker socket support on macOS

### DIFF
--- a/docs/arch/01-deployment-modes.md
+++ b/docs/arch/01-deployment-modes.md
@@ -97,11 +97,12 @@ The CLI automatically detects container runtimes in this order:
    - `$TOOLHIVE_COLIMA_SOCKET` (if set)
    - `~/.colima/default/docker.sock`
 
-3. **Docker** (including Docker Desktop and Rancher Desktop) - Checks for Docker socket at:
+3. **Docker** (including Docker Desktop, Rancher Desktop, and OrbStack) - Checks for Docker socket at:
    - `$TOOLHIVE_DOCKER_SOCKET` (if set)
    - `/var/run/docker.sock`
    - `~/.docker/run/docker.sock` (Docker Desktop on macOS)
    - `~/.rd/docker.sock` (Rancher Desktop on macOS)
+   - `~/.orbstack/run/docker.sock` (OrbStack on macOS)
 
 ### Detached Process Model
 

--- a/pkg/container/docker/sdk/client_unix.go
+++ b/pkg/container/docker/sdk/client_unix.go
@@ -191,6 +191,19 @@ func findDockerSocket() (string, error) {
 		logger.Debugf("Failed to check Rancher Desktop socket at %s: %v", rancherDesktopPath, err)
 	}
 
+	// Try OrbStack socket path on macOS
+	if home := os.Getenv("HOME"); home != "" {
+		orbStackPath := filepath.Join(home, OrbStackMacSocketPath)
+		_, err := os.Stat(orbStackPath)
+
+		if err == nil {
+			logger.Debugf("Found OrbStack socket at %s", orbStackPath)
+			return orbStackPath, nil
+		}
+
+		logger.Debugf("Failed to check OrbStack socket at %s: %v", orbStackPath, err)
+	}
+
 	return "", fmt.Errorf("docker socket not found in standard locations")
 }
 

--- a/pkg/container/docker/sdk/factory.go
+++ b/pkg/container/docker/sdk/factory.go
@@ -38,6 +38,8 @@ const (
 	DockerDesktopMacSocketPath = ".docker/run/docker.sock"
 	// RancherDesktopMacSocketPath is the Docker socket path for Rancher Desktop on macOS
 	RancherDesktopMacSocketPath = ".rd/docker.sock"
+	// OrbStackMacSocketPath is the Docker socket path for OrbStack on macOS
+	OrbStackMacSocketPath = ".orbstack/run/docker.sock"
 	// ColimaDesktopMacSocketPath is the Docker socket path for Colima on macOS
 	ColimaDesktopMacSocketPath = ".colima/default/docker.sock"
 )


### PR DESCRIPTION
## Summary

This PR adds native support for OrbStack on macOS by detecting its Docker socket directly. ToolHive previously relied solely on `/var/run/docker.sock`, which does not cover all local Docker runtime configurations on macOS. By including OrbStack’s socket path, ToolHive gains broader and more reliable Docker runtime detection.

## What Changed

ToolHive now checks the following socket paths:

1. `/var/run/docker.sock` (existing behavior)  
2. `$HOME/.orbstack/run/docker.sock` (OrbStack’s native socket)

If the OrbStack socket exists, ToolHive will use it automatically.

## Why This Matters

- Expands ToolHive’s compatibility with Docker environments on macOS.
- Provides first-class support for OrbStack’s native socket location.
- Improves detection robustness without requiring any system-level symlinks.

## Impact

- No behavioral changes for Docker Desktop, Linux, or environments where `/var/run/docker.sock` is available.
- Only enhances macOS compatibility by supporting an additional local socket path.
