### PR TITLE
Add testing and code quality guidelines to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,25 @@ are a great place to start!
 - Once approved, all of your commits will be squashed into a single commit with
   your PR title.
 
+### Testing requirements
+
+- Add end-to-end tests for new features covering both API and CLI flows.
+- Write unit tests for new code alongside the source files.
+
+### Code quality expectations
+
+Pull request authors are responsible for:
+
+- Keeping PRs small and focused. PRs exceeding 1000 lines may be blocked and
+  require splitting into multiple PRs or logical commits before review. If a
+  large PR is unavoidable, include an explanation in the PR description
+  justifying the size and describing how the changes are organized for review.
+- Reviewing all submitted code, regardless of whether it's AI-generated or
+  hand-written.
+- Manually testing changes to verify new or existing features work correctly.
+- Ensuring coding style guidelines are followed.
+- Respecting architecture boundaries and design patterns.
+
 ### Contributing to docs
 
 The ToolHive user documentation website is maintained in the


### PR DESCRIPTION
Add testing requirements section covering E2E and unit tests. Add code quality expectations section with clear PR size limits and responsibilities. Clarify that PRs over 1000 lines may be blocked and require justification.