### PR TITLE
Add automated PR size labeling workflow

### DIFF
--- a/.github/workflows/pr-size-labeler.yml
+++ b/.github/workflows/pr-size-labeler.yml
@@ -1,0 +1,100 @@
+name: PR Size Labeler
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label-pr-size:
+    name: Label PR Size
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get PR details
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number
+            });
+
+            const additions = pr.data.additions;
+            const deletions = pr.data.deletions;
+            const totalChanges = additions + deletions;
+
+            console.log(`PR #${context.issue.number}: +${additions} -${deletions} (${totalChanges} total)`);
+
+            return {
+              additions: additions,
+              deletions: deletions,
+              total: totalChanges
+            };
+
+      - name: Determine size label
+        id: size
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const changes = ${{ steps.pr.outputs.result }};
+            const total = changes.total;
+
+            let sizeLabel = '';
+
+            if (total < 100) {
+              sizeLabel = 'size/XS';
+            } else if (total < 300) {
+              sizeLabel = 'size/S';
+            } else if (total < 600) {
+              sizeLabel = 'size/M';
+            } else if (total < 1000) {
+              sizeLabel = 'size/L';
+            } else {
+              sizeLabel = 'size/XL';
+            }
+
+            console.log(`PR size: ${total} lines -> ${sizeLabel}`);
+            return sizeLabel;
+
+      - name: Remove old size labels
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const sizeLabels = ['size/XS', 'size/S', 'size/M', 'size/L', 'size/XL'];
+
+            const currentLabels = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number
+            });
+
+            for (const label of currentLabels.data) {
+              if (sizeLabels.includes(label.name)) {
+                console.log(`Removing old size label: ${label.name}`);
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  name: label.name
+                });
+              }
+            }
+
+      - name: Add new size label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const sizeLabel = ${{ steps.size.outputs.result }};
+
+            console.log(`Adding size label: ${sizeLabel}`);
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: [sizeLabel]
+            });


### PR DESCRIPTION
Add GitHub Action to automatically label PRs with t-shirt sizes based on lines changed. Labels are: XS (<100), S (100-299), M (300-599), L (600-999), XL (1000+). Labels update automatically when PR is opened or updated to help identify PRs that may need splitting per contribution guidelines.