### PR TITLE
Fix YAML parsing and workflow conversion for composite tool output configuration

### DIFF
--- a/pkg/vmcp/server/workflow_converter.go
+++ b/pkg/vmcp/server/workflow_converter.go
@@ -80,6 +80,7 @@ func ConvertConfigToWorkflowDefinitions(
 			Parameters:  params,
 			Steps:       steps,
 			Timeout:     timeout,
+			Output:      ct.Output,
 			Metadata:    make(map[string]string),
 		}
 

--- a/pkg/vmcp/server/workflow_converter_test.go
+++ b/pkg/vmcp/server/workflow_converter_test.go
@@ -264,3 +264,122 @@ func TestConvertSteps_ComplexWorkflow(t *testing.T) {
 	assert.NotEmpty(t, result[2].Condition)
 	assert.Equal(t, []string{"confirm"}, result[2].DependsOn)
 }
+
+// TestConvertConfigToWorkflowDefinitions_WithOutputConfig tests that output configuration
+// is correctly copied from CompositeToolConfig to WorkflowDefinition.
+func TestConvertConfigToWorkflowDefinitions_WithOutputConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		input  []*config.CompositeToolConfig
+		verify func(t *testing.T, defs map[string]*composer.WorkflowDefinition)
+	}{
+		{
+			name: "composite tool with output config",
+			input: []*config.CompositeToolConfig{
+				{
+					Name:        "data_processor",
+					Description: "Process data with typed output",
+					Steps: []*config.WorkflowStepConfig{
+						{ID: "fetch", Type: "tool", Tool: "data.fetch"},
+					},
+					Output: &config.OutputConfig{
+						Properties: map[string]config.OutputProperty{
+							"message": {
+								Type:        "string",
+								Description: "Result message",
+								Value:       "{{.steps.fetch.output.text}}",
+							},
+							"count": {
+								Type:        "integer",
+								Description: "Item count",
+								Value:       "{{.steps.fetch.output.count}}",
+							},
+						},
+						Required: []string{"message"},
+					},
+				},
+			},
+			verify: func(t *testing.T, defs map[string]*composer.WorkflowDefinition) {
+				t.Helper()
+				require.Len(t, defs, 1)
+
+				def, exists := defs["data_processor"]
+				require.True(t, exists)
+				require.NotNil(t, def.Output, "Output should be set on WorkflowDefinition")
+
+				assert.Len(t, def.Output.Properties, 2)
+				assert.Equal(t, []string{"message"}, def.Output.Required)
+
+				msgProp, exists := def.Output.Properties["message"]
+				require.True(t, exists)
+				assert.Equal(t, "string", msgProp.Type)
+				assert.Equal(t, "Result message", msgProp.Description)
+			},
+		},
+		{
+			name: "composite tool without output config (backward compatible)",
+			input: []*config.CompositeToolConfig{
+				{
+					Name:   "simple_tool",
+					Steps:  []*config.WorkflowStepConfig{{ID: "step1", Type: "tool", Tool: "tool"}},
+					Output: nil,
+				},
+			},
+			verify: func(t *testing.T, defs map[string]*composer.WorkflowDefinition) {
+				t.Helper()
+				require.Len(t, defs, 1)
+
+				def, exists := defs["simple_tool"]
+				require.True(t, exists)
+				assert.Nil(t, def.Output, "Output should be nil for backward compatibility")
+			},
+		},
+		{
+			name: "multiple tools with mixed output configs",
+			input: []*config.CompositeToolConfig{
+				{
+					Name:  "with_output",
+					Steps: []*config.WorkflowStepConfig{{ID: "s1", Type: "tool", Tool: "t1"}},
+					Output: &config.OutputConfig{
+						Properties: map[string]config.OutputProperty{
+							"result": {Type: "string", Value: "{{.steps.s1.output.text}}"},
+						},
+					},
+				},
+				{
+					Name:   "without_output",
+					Steps:  []*config.WorkflowStepConfig{{ID: "s2", Type: "tool", Tool: "t2"}},
+					Output: nil,
+				},
+			},
+			verify: func(t *testing.T, defs map[string]*composer.WorkflowDefinition) {
+				t.Helper()
+				require.Len(t, defs, 2)
+
+				withOutput := defs["with_output"]
+				require.NotNil(t, withOutput)
+				assert.NotNil(t, withOutput.Output)
+
+				withoutOutput := defs["without_output"]
+				require.NotNil(t, withoutOutput)
+				assert.Nil(t, withoutOutput.Output)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := ConvertConfigToWorkflowDefinitions(tt.input)
+			require.NoError(t, err)
+			require.NotNil(t, result)
+
+			if tt.verify != nil {
+				tt.verify(t, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Fix YAML parsing and workflow conversion for composite tool output configuration

**Fixes:** #2713  
**Related:** #2714 (workflow metadata enhancement)

## Summary

Fixes structured output schemas returning only `{text: "..."}` instead of properly defined structures. The issue had **two root causes** that both needed to be fixed:

1. **YAML parser wasn't reading the `output:` section** from YAML config files
2. **Workflow converter wasn't copying the parsed output** to `WorkflowDefinition`

Both pieces were missing, causing `def.Output` to always be `nil` in the workflow engine, which triggered backward compatibility mode returning raw last-step output.

## Changes

### 1. YAML Parser (`pkg/vmcp/config/yaml_loader.go`)

**Added output config parsing:**
- Added `Output *rawOutputConfig` field to `rawCompositeTool` struct
- Added `rawOutputConfig` and `rawOutputProperty` structs for YAML unmarshaling
- Implemented `transformOutputConfig()` function (recursive transformation)
- Implemented `transformOutputProperty()` helper function
- Updated `transformCompositeTools()` to call output transformation

**Before:**
```go
type rawCompositeTool struct {
    Name        string
    Description string
    Parameters  map[string]map[string]any
    Steps       []*rawWorkflowStep
    // Output field was MISSING
}
```

**After:**
```go
type rawCompositeTool struct {
    Name        string
    Description string
    Parameters  map[string]map[string]any
    Steps       []*rawWorkflowStep
    Output      *rawOutputConfig  // NOW PARSED
}
```

### 2. Workflow Converter (`pkg/vmcp/server/workflow_converter.go`)

**Added output field assignment:**
```go
def := &composer.WorkflowDefinition{
    Name:        ct.Name,
    Description: ct.Description,
    Parameters:  params,
    Steps:       steps,
    Timeout:     timeout,
    Output:      ct.Output,  // THIS LINE WAS MISSING
    Metadata:    make(map[string]string),
}
```

Without this line, even though the YAML was parsed correctly, the output config was never copied to the `WorkflowDefinition`, so it remained `nil`.

## Testing

### New Tests Added

**`pkg/vmcp/config/yaml_loader_transform_test.go`** (+272 lines):
- `TestYAMLLoader_transformOutputConfig` - 4 test cases
  - Nil config handling
  - Simple properties with all fields
  - Multiple properties with different types (string, integer, boolean, number)
  - Nested object properties (2 levels deep)
- `TestYAMLLoader_transformCompositeTools_WithOutputConfig` - 3 test cases
  - Composite tool with output config
  - Composite tool without output config (backward compatibility)
  - Multiple tools with mixed configurations

**`pkg/vmcp/server/workflow_converter_test.go`** (+119 lines):
- `TestConvertConfigToWorkflowDefinitions_WithOutputConfig` - 3 test cases
  - Verifies output is correctly copied to WorkflowDefinition
  - Verifies backward compatibility (nil output)
  - Verifies mixed scenarios (some with, some without output)

### Test Results

```bash
# New tests pass
✅ TestYAMLLoader_transformOutputConfig (4 subtests)
✅ TestYAMLLoader_transformCompositeTools_WithOutputConfig (3 subtests)
✅ TestConvertConfigToWorkflowDefinitions_WithOutputConfig (3 subtests)

# All existing tests pass
✅ pkg/vmcp/config tests: PASS
✅ pkg/vmcp/server tests: PASS
✅ pkg/vmcp/composer tests: PASS

# Code quality
✅ golangci-lint: 0 issues
```

## Example

**YAML Config:**
```yaml
composite_tools:
  - name: data_processor
    description: Process data with typed output
    steps:
      - id: fetch
        type: tool
        tool: data.fetch
    
    output:
      properties:
        message:
          type: string
          description: Result message
          value: "{{.steps.fetch.output.text}}"
        count:
          type: integer
          description: Item count
          value: "{{.steps.fetch.output.count}}"
      required: [message]
```

**Before this PR:**
```json
{
  "text": "raw output from last step..."
}
```

**After this PR:**
```json
{
  "message": "Data fetched successfully",
  "count": 42
}
```

## Backward Compatibility

✅ **Fully backward compatible** - Composite tools without `output:` configuration continue to return the last step's output as before.

## Known Limitations

The workflow metadata fields (`{{.workflow.id}}`, `{{.workflow.duration_ms}}`, `{{.workflow.step_count}}`) shown in #2713's example are **not yet implemented**. These require additional work tracked in #2714:

- Adding workflow metadata to `WorkflowContext` struct
- Updating template context to include `workflow` object  
- Refactoring workflow engine to calculate duration/step_count before output construction

Currently only `{{.params.*}}` and `{{.steps.*}}` template variables work in output schemas.

## Review Checklist

- [x] Tests added and passing
- [x] Linting passes (0 issues)
- [x] Backward compatibility maintained
- [x] Documentation updated (commit message explains changes)
- [x] Related issue created for workflow metadata enhancement (#2714)
- [x] No TODOs or technical debt introduced

## Files Changed

```
pkg/vmcp/config/yaml_loader.go              | +54 lines
pkg/vmcp/config/yaml_loader_transform_test.go | +272 lines
pkg/vmcp/server/workflow_converter.go       | +1 line
pkg/vmcp/server/workflow_converter_test.go  | +119 lines
```

**Total:** +446 lines (mostly comprehensive tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>