### PR TITLE
Add workflow metadata to output template context

### DIFF
--- a/pkg/vmcp/composer/composer.go
+++ b/pkg/vmcp/composer/composer.go
@@ -337,8 +337,31 @@ type WorkflowContext struct {
 	// and does not require synchronization. Steps should not modify this map during execution.
 	Variables map[string]any
 
-	// mu protects concurrent access to Steps map during parallel execution.
+	// Workflow contains workflow-level metadata (ID, start time, step count, status).
+	// Access must be synchronized using mu.
+	Workflow *WorkflowMetadata
+
+	// mu protects concurrent access to Steps map and Workflow metadata during parallel execution.
 	mu sync.RWMutex
+}
+
+// WorkflowMetadata contains workflow-level metadata available in templates.
+type WorkflowMetadata struct {
+	// ID is the unique workflow execution ID.
+	ID string
+
+	// StartTime is when the workflow started execution.
+	StartTime time.Time
+
+	// StepCount is the number of steps executed so far.
+	StepCount int
+
+	// Status is the current workflow status.
+	Status WorkflowStatusType
+
+	// DurationMs is the workflow duration in milliseconds.
+	// This is calculated dynamically at template expansion time.
+	DurationMs int64
 }
 
 // WorkflowStateStore manages workflow execution state.

--- a/pkg/vmcp/composer/template_expander.go
+++ b/pkg/vmcp/composer/template_expander.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"text/template"
+	"time"
 )
 
 const (
@@ -131,11 +132,12 @@ func (e *defaultTemplateExpander) expandString(
 		return "", fmt.Errorf("context cancelled before template expansion: %w", err)
 	}
 
-	// Create template context with params and steps
+	// Create template context with params, steps, vars, and workflow metadata
 	tmplCtx := map[string]any{
-		"params": workflowCtx.Params,
-		"steps":  e.buildStepsContext(workflowCtx),
-		"vars":   workflowCtx.Variables,
+		"params":   workflowCtx.Params,
+		"steps":    e.buildStepsContext(workflowCtx),
+		"vars":     workflowCtx.Variables,
+		"workflow": e.buildWorkflowContext(workflowCtx),
 	}
 
 	// Parse and execute template
@@ -185,6 +187,26 @@ func (*defaultTemplateExpander) buildStepsContext(workflowCtx *WorkflowContext) 
 	}
 
 	return stepsCtx
+}
+
+// buildWorkflowContext converts WorkflowMetadata to a template-friendly structure.
+// This provides access to workflow metadata via {{.workflow.id}}, {{.workflow.duration_ms}}, etc.
+func (*defaultTemplateExpander) buildWorkflowContext(workflowCtx *WorkflowContext) map[string]any {
+	// Acquire read lock to safely access Workflow metadata during concurrent execution
+	workflowCtx.mu.RLock()
+	defer workflowCtx.mu.RUnlock()
+
+	if workflowCtx.Workflow == nil {
+		return map[string]any{}
+	}
+
+	return map[string]any{
+		"id":          workflowCtx.Workflow.ID,
+		"duration_ms": workflowCtx.Workflow.DurationMs,
+		"step_count":  workflowCtx.Workflow.StepCount,
+		"status":      string(workflowCtx.Workflow.Status),
+		"start_time":  workflowCtx.Workflow.StartTime.Format(time.RFC3339),
+	}
 }
 
 // EvaluateCondition evaluates a condition template to a boolean.

--- a/pkg/vmcp/composer/template_expander_test.go
+++ b/pkg/vmcp/composer/template_expander_test.go
@@ -218,3 +218,184 @@ func TestWorkflowContext_Clone(t *testing.T) {
 	assert.NotEqual(t, original.Params, clone.Params)
 	assert.NotEqual(t, len(original.Steps), len(clone.Steps))
 }
+
+func TestTemplateExpander_WorkflowMetadata(t *testing.T) {
+	t.Parallel()
+
+	startTime := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name     string
+		data     map[string]any
+		workflow *WorkflowMetadata
+		expected map[string]any
+		wantErr  bool
+	}{
+		{
+			name: "workflow ID",
+			data: map[string]any{"id": "{{.workflow.id}}"},
+			workflow: &WorkflowMetadata{
+				ID:         "wf-123",
+				StartTime:  startTime,
+				StepCount:  3,
+				Status:     WorkflowStatusCompleted,
+				DurationMs: 1500,
+			},
+			expected: map[string]any{"id": "wf-123"},
+		},
+		{
+			name: "workflow duration_ms",
+			data: map[string]any{"duration": "{{.workflow.duration_ms}}"},
+			workflow: &WorkflowMetadata{
+				ID:         "wf-123",
+				StartTime:  startTime,
+				StepCount:  3,
+				Status:     WorkflowStatusCompleted,
+				DurationMs: 2500,
+			},
+			expected: map[string]any{"duration": "2500"},
+		},
+		{
+			name: "workflow step_count",
+			data: map[string]any{"steps": "{{.workflow.step_count}}"},
+			workflow: &WorkflowMetadata{
+				ID:         "wf-123",
+				StartTime:  startTime,
+				StepCount:  5,
+				Status:     WorkflowStatusCompleted,
+				DurationMs: 1000,
+			},
+			expected: map[string]any{"steps": "5"},
+		},
+		{
+			name: "workflow status",
+			data: map[string]any{"status": "{{.workflow.status}}"},
+			workflow: &WorkflowMetadata{
+				ID:         "wf-123",
+				StartTime:  startTime,
+				StepCount:  3,
+				Status:     WorkflowStatusCompleted,
+				DurationMs: 1000,
+			},
+			expected: map[string]any{"status": "completed"},
+		},
+		{
+			name: "workflow start_time",
+			data: map[string]any{"started": "{{.workflow.start_time}}"},
+			workflow: &WorkflowMetadata{
+				ID:         "wf-123",
+				StartTime:  startTime,
+				StepCount:  3,
+				Status:     WorkflowStatusCompleted,
+				DurationMs: 1000,
+			},
+			expected: map[string]any{"started": "2024-01-01T12:00:00Z"},
+		},
+		{
+			name: "combined workflow metadata",
+			data: map[string]any{
+				"summary": map[string]any{
+					"workflow_id": "{{.workflow.id}}",
+					"duration_ms": "{{.workflow.duration_ms}}",
+					"step_count":  "{{.workflow.step_count}}",
+					"status":      "{{.workflow.status}}",
+					"started_at":  "{{.workflow.start_time}}",
+				},
+			},
+			workflow: &WorkflowMetadata{
+				ID:         "wf-abc",
+				StartTime:  startTime,
+				StepCount:  7,
+				Status:     WorkflowStatusCompleted,
+				DurationMs: 3250,
+			},
+			expected: map[string]any{
+				"summary": map[string]any{
+					"workflow_id": "wf-abc",
+					"duration_ms": "3250",
+					"step_count":  "7",
+					"status":      "completed",
+					"started_at":  "2024-01-01T12:00:00Z",
+				},
+			},
+		},
+		{
+			name: "workflow metadata with step outputs",
+			data: map[string]any{
+				"result":      "{{.steps.fetch.output.data}}",
+				"workflow_id": "{{.workflow.id}}",
+				"step_count":  "{{.workflow.step_count}}",
+			},
+			workflow: &WorkflowMetadata{
+				ID:         "wf-456",
+				StartTime:  startTime,
+				StepCount:  2,
+				Status:     WorkflowStatusCompleted,
+				DurationMs: 800,
+			},
+			expected: map[string]any{
+				"result":      "test-data",
+				"workflow_id": "wf-456",
+				"step_count":  "2",
+			},
+		},
+	}
+
+	expander := NewTemplateExpander()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := &WorkflowContext{
+				WorkflowID: tt.workflow.ID,
+				Params:     map[string]any{},
+				Steps:      map[string]*StepResult{},
+				Variables:  map[string]any{},
+				Workflow:   tt.workflow,
+			}
+
+			// Add test step data for the combined test
+			if tt.name == "workflow metadata with step outputs" {
+				ctx.Steps = map[string]*StepResult{
+					"fetch": {
+						StepID: "fetch",
+						Status: StepStatusCompleted,
+						Output: map[string]any{"data": "test-data"},
+					},
+				}
+			}
+
+			result, err := expander.Expand(context.Background(), tt.data, ctx)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestTemplateExpander_WorkflowMetadataEmpty(t *testing.T) {
+	t.Parallel()
+
+	expander := NewTemplateExpander()
+
+	// Test with nil workflow metadata
+	ctx := &WorkflowContext{
+		WorkflowID: "test",
+		Params:     map[string]any{},
+		Steps:      map[string]*StepResult{},
+		Variables:  map[string]any{},
+		Workflow:   nil,
+	}
+
+	data := map[string]any{"id": "{{.workflow.id}}"}
+
+	// Should not panic, should return empty/zero value
+	result, err := expander.Expand(context.Background(), data, ctx)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]any{"id": "<no value>"}, result)
+}

--- a/pkg/vmcp/composer/testhelpers_test.go
+++ b/pkg/vmcp/composer/testhelpers_test.go
@@ -3,6 +3,7 @@ package composer
 import (
 	"context"
 	"testing"
+	"time"
 
 	"go.uber.org/mock/gomock"
 
@@ -80,11 +81,19 @@ func (te *testEngine) expectToolCallWithAnyArgs(toolName string, output map[stri
 
 // newWorkflowContext creates a test workflow context.
 func newWorkflowContext(params map[string]any) *WorkflowContext {
+	startTime := time.Now()
 	return &WorkflowContext{
 		WorkflowID: "test-workflow",
 		Params:     params,
 		Steps:      make(map[string]*StepResult),
 		Variables:  make(map[string]any),
+		Workflow: &WorkflowMetadata{
+			ID:         "test-workflow",
+			StartTime:  startTime,
+			StepCount:  0,
+			Status:     WorkflowStatusPending,
+			DurationMs: 0,
+		},
 	}
 }
 

--- a/pkg/vmcp/composer/workflow_context.go
+++ b/pkg/vmcp/composer/workflow_context.go
@@ -27,11 +27,21 @@ func (m *workflowContextManager) CreateContext(params map[string]any) *WorkflowC
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
+	workflowID := uuid.New().String()
+	startTime := time.Now()
+
 	ctx := &WorkflowContext{
-		WorkflowID: uuid.New().String(),
+		WorkflowID: workflowID,
 		Params:     params,
 		Steps:      make(map[string]*StepResult),
 		Variables:  make(map[string]any),
+		Workflow: &WorkflowMetadata{
+			ID:         workflowID,
+			StartTime:  startTime,
+			StepCount:  0,
+			Status:     WorkflowStatusPending,
+			DurationMs: 0,
+		},
 	}
 
 	m.contexts[ctx.WorkflowID] = ctx
@@ -177,6 +187,17 @@ func (ctx *WorkflowContext) Clone() *WorkflowContext {
 		Params:     cloneMap(ctx.Params),
 		Steps:      make(map[string]*StepResult, len(ctx.Steps)),
 		Variables:  cloneMap(ctx.Variables),
+	}
+
+	// Clone workflow metadata
+	if ctx.Workflow != nil {
+		clone.Workflow = &WorkflowMetadata{
+			ID:         ctx.Workflow.ID,
+			StartTime:  ctx.Workflow.StartTime,
+			StepCount:  ctx.Workflow.StepCount,
+			Status:     ctx.Workflow.Status,
+			DurationMs: ctx.Workflow.DurationMs,
+		}
 	}
 
 	// Clone step results

--- a/pkg/vmcp/composer/workflow_engine.go
+++ b/pkg/vmcp/composer/workflow_engine.go
@@ -206,6 +206,10 @@ func (e *workflowEngine) ExecuteWorkflow(
 	// Workflow completed successfully
 	result.Status = WorkflowStatusCompleted
 
+	// Update workflow metadata before output construction
+	// This ensures {{.workflow.*}} template variables are available with accurate values
+	e.updateWorkflowMetadata(workflowCtx, result.StartTime, WorkflowStatusCompleted)
+
 	// Construct output based on configuration
 	if def.Output == nil {
 		// Backward compatible: return last step output
@@ -879,6 +883,34 @@ func (e *workflowEngine) CancelWorkflow(ctx context.Context, workflowID string) 
 
 	logger.Infof("Workflow %s marked as cancelled", workflowID)
 	return nil
+}
+
+// updateWorkflowMetadata updates the workflow metadata with current execution state.
+// This should be called before output construction to ensure template variables
+// like {{.workflow.duration_ms}} and {{.workflow.step_count}} have accurate values.
+func (*workflowEngine) updateWorkflowMetadata(
+	workflowCtx *WorkflowContext,
+	startTime time.Time,
+	status WorkflowStatusType,
+) {
+	workflowCtx.mu.Lock()
+	defer workflowCtx.mu.Unlock()
+
+	if workflowCtx.Workflow == nil {
+		return
+	}
+
+	// Count completed steps
+	completedSteps := 0
+	for _, step := range workflowCtx.Steps {
+		if step.Status == StepStatusCompleted {
+			completedSteps++
+		}
+	}
+
+	workflowCtx.Workflow.StepCount = completedSteps
+	workflowCtx.Workflow.Status = status
+	workflowCtx.Workflow.DurationMs = time.Since(startTime).Milliseconds()
 }
 
 // applyParameterDefaults applies default values from JSON Schema to workflow parameters.

--- a/pkg/vmcp/composer/workflow_engine_test.go
+++ b/pkg/vmcp/composer/workflow_engine_test.go
@@ -13,6 +13,7 @@ import (
 	"go.uber.org/mock/gomock"
 
 	"github.com/stacklok/toolhive/pkg/vmcp"
+	"github.com/stacklok/toolhive/pkg/vmcp/config"
 	"github.com/stacklok/toolhive/pkg/vmcp/mocks"
 	routermocks "github.com/stacklok/toolhive/pkg/vmcp/router/mocks"
 )
@@ -428,4 +429,193 @@ func TestWorkflowEngine_ParallelExecution(t *testing.T) {
 	assert.Less(t, endSeq["fetch_metrics"], startSeq["create_report"],
 		"fetch_metrics (seq %d) should complete before create_report starts (seq %d)",
 		endSeq["fetch_metrics"], startSeq["create_report"])
+}
+
+func TestWorkflowEngine_ExecuteWorkflow_WithWorkflowMetadata(t *testing.T) {
+	t.Parallel()
+
+	te := newTestEngine(t)
+
+	// Workflow that uses workflow metadata in output
+	workflow := &WorkflowDefinition{
+		Name:        "metadata_test",
+		Description: "Test workflow metadata in output templates",
+		Steps: []WorkflowStep{
+			toolStep("fetch_data", "data.fetch", map[string]any{
+				"source": "{{.params.source}}",
+			}),
+			toolStepWithDeps("process", "data.process", map[string]any{
+				"data": "{{.steps.fetch_data.output.result}}",
+			}, []string{"fetch_data"}),
+		},
+		Output: &config.OutputConfig{
+			Properties: map[string]config.OutputProperty{
+				"summary": {
+					Type:        "object",
+					Description: "Workflow execution summary",
+					Properties: map[string]config.OutputProperty{
+						"workflow_id": {
+							Type:        "string",
+							Description: "Workflow execution ID",
+							Value:       "{{.workflow.id}}",
+						},
+						"duration_ms": {
+							Type:        "integer",
+							Description: "Workflow duration in milliseconds",
+							Value:       "{{.workflow.duration_ms}}",
+						},
+						"step_count": {
+							Type:        "integer",
+							Description: "Number of completed steps",
+							Value:       "{{.workflow.step_count}}",
+						},
+						"status": {
+							Type:        "string",
+							Description: "Workflow status",
+							Value:       "{{.workflow.status}}",
+						},
+						"start_time": {
+							Type:        "string",
+							Description: "Workflow start time",
+							Value:       "{{.workflow.start_time}}",
+						},
+					},
+				},
+				"data_result": {
+					Type:        "string",
+					Description: "Processed data result",
+					Value:       "{{.steps.process.output.value}}",
+				},
+			},
+		},
+	}
+
+	// Setup expectations with delays to ensure duration > 0
+	target := &vmcp.BackendTarget{
+		WorkloadID:   "test-backend",
+		WorkloadName: "test",
+		BaseURL:      "http://test:8080",
+	}
+
+	te.Router.EXPECT().RouteTool(gomock.Any(), "data.fetch").Return(target, nil)
+	te.Backend.EXPECT().CallTool(gomock.Any(), target, "data.fetch", map[string]any{"source": "test-source"}).
+		DoAndReturn(func(_ context.Context, _ *vmcp.BackendTarget, _ string, _ map[string]any) (map[string]any, error) {
+			time.Sleep(10 * time.Millisecond)
+			return map[string]any{"result": "raw-data"}, nil
+		})
+
+	te.Router.EXPECT().RouteTool(gomock.Any(), "data.process").Return(target, nil)
+	te.Backend.EXPECT().CallTool(gomock.Any(), target, "data.process", gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ *vmcp.BackendTarget, _ string, _ map[string]any) (map[string]any, error) {
+			time.Sleep(10 * time.Millisecond)
+			return map[string]any{"value": "processed-data"}, nil
+		})
+
+	// Execute workflow
+	startTime := time.Now()
+	result, err := execute(t, te.Engine, workflow, map[string]any{"source": "test-source"})
+	executionTime := time.Since(startTime)
+
+	// Verify execution success
+	require.NoError(t, err)
+	assert.Equal(t, WorkflowStatusCompleted, result.Status)
+	assert.Len(t, result.Steps, 2)
+
+	// Verify output structure
+	require.NotNil(t, result.Output)
+	require.Contains(t, result.Output, "summary")
+	require.Contains(t, result.Output, "data_result")
+
+	// Verify data result
+	assert.Equal(t, "processed-data", result.Output["data_result"])
+
+	// Verify workflow metadata in output
+	summary, ok := result.Output["summary"].(map[string]any)
+	require.True(t, ok, "summary should be a map")
+
+	// Check workflow_id
+	workflowID, ok := summary["workflow_id"].(string)
+	require.True(t, ok, "workflow_id should be a string")
+	assert.NotEmpty(t, workflowID)
+	assert.Equal(t, result.WorkflowID, workflowID)
+
+	// Check duration_ms
+	durationMs, ok := summary["duration_ms"].(int64)
+	require.True(t, ok, "duration_ms should be an int64")
+	// With 20ms of artificial delays (10ms per step), duration should be at least a few ms
+	assert.Greater(t, durationMs, int64(0), "duration should be positive")
+	// Duration should be reasonable (less than total execution time in ms + buffer)
+	assert.Less(t, durationMs, executionTime.Milliseconds()+100, "duration should be less than total execution time")
+
+	// Check step_count
+	stepCount, ok := summary["step_count"].(int64)
+	require.True(t, ok, "step_count should be an int64")
+	assert.Equal(t, int64(2), stepCount, "should have 2 completed steps")
+
+	// Check status
+	status, ok := summary["status"].(string)
+	require.True(t, ok, "status should be a string")
+	assert.Equal(t, "completed", status)
+
+	// Check start_time (RFC3339 format)
+	startTimeStr, ok := summary["start_time"].(string)
+	require.True(t, ok, "start_time should be a string")
+	assert.NotEmpty(t, startTimeStr)
+	// Verify it's valid RFC3339 format
+	parsedTime, err := time.Parse(time.RFC3339, startTimeStr)
+	require.NoError(t, err, "start_time should be valid RFC3339 format")
+	assert.WithinDuration(t, startTime, parsedTime, 5*time.Second, "start_time should be close to actual start")
+}
+
+func TestWorkflowEngine_WorkflowMetadataAvailableInTemplates(t *testing.T) {
+	t.Parallel()
+
+	te := newTestEngine(t)
+
+	// Workflow that uses workflow metadata in step arguments
+	// Note: workflow.id and workflow.start_time are available, but workflow.step_count and
+	// workflow.duration_ms are only updated before output construction, not during step execution.
+	workflow := &WorkflowDefinition{
+		Name: "metadata_in_args",
+		Steps: []WorkflowStep{
+			toolStep("first", "tool.first", nil),
+			toolStepWithDeps("second", "tool.second", map[string]any{
+				"workflow_id": "{{.workflow.id}}",
+				"status":      "{{.workflow.status}}",
+			}, []string{"first"}),
+		},
+	}
+
+	// Setup expectations
+	te.expectToolCall("tool.first", nil, map[string]any{"ok": true})
+
+	// For the second tool, verify it receives basic workflow metadata
+	target := &vmcp.BackendTarget{
+		WorkloadID:   "test-backend",
+		WorkloadName: "test",
+		BaseURL:      "http://test:8080",
+	}
+	te.Router.EXPECT().RouteTool(gomock.Any(), "tool.second").Return(target, nil)
+	te.Backend.EXPECT().CallTool(gomock.Any(), target, "tool.second", gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ *vmcp.BackendTarget, _ string, args map[string]any) (map[string]any, error) {
+			// Verify workflow metadata was expanded in arguments
+			workflowID, ok := args["workflow_id"].(string)
+			assert.True(t, ok, "workflow_id should be a string")
+			assert.NotEmpty(t, workflowID, "workflow_id should not be empty")
+
+			// Status should be available (though not yet "completed" since workflow is still running)
+			status, ok := args["status"].(string)
+			assert.True(t, ok, "status should be a string")
+			assert.Contains(t, []string{"pending", "running"}, status, "status should be pending or running during execution")
+
+			return map[string]any{"done": true}, nil
+		})
+
+	// Execute workflow
+	result, err := execute(t, te.Engine, workflow, nil)
+
+	// Verify
+	require.NoError(t, err)
+	assert.Equal(t, WorkflowStatusCompleted, result.Status)
+	assert.Len(t, result.Steps, 2)
 }


### PR DESCRIPTION
# Add workflow metadata to output template context

**Issue:** #2714
**Branch:** `issue_2714_2025-11-25`
**Status:** Ready for Review

## Summary

This PR adds workflow-level metadata to composite tool output templates, enabling users to access workflow execution details via `{{.workflow.*}}` template variables. This addresses a gap where **output templates** could reference parameters, steps, and variables, but not workflow-level metadata like execution ID, duration, and step count.

## Problem Statement

Previously, composite tool output templates only had access to:
- `{{.params.*}}` - workflow input parameters
- `{{.steps.*}}` - step results
- `{{.vars.*}}` - workflow variables

Users needed access to workflow-level metadata for creating structured outputs with execution context, particularly:
- Workflow execution ID for tracking and debugging
- Duration metrics for performance monitoring
- Step count for execution summaries
- Status and timing information

Additionally, there was an architectural issue where workflow metadata was calculated **after** output construction, making it impossible to include in templates even if the context existed.

## Changes Made

### Core Implementation

1. **Added `WorkflowMetadata` struct** ([pkg/vmcp/composer/composer.go](pkg/vmcp/composer/composer.go#L348-L365))
   - `ID` - unique workflow execution ID
   - `StartTime` - workflow start timestamp
   - `StepCount` - number of completed steps
   - `Status` - current workflow status (using `WorkflowStatusType` constants)
   - `DurationMs` - execution duration in milliseconds

2. **Extended `WorkflowContext`** ([pkg/vmcp/composer/composer.go](pkg/vmcp/composer/composer.go#L340-L342))
   - Added `Workflow *WorkflowMetadata` field
   - Protected by existing `mu sync.RWMutex` for thread-safe concurrent access
   - Properly documented synchronization requirements

3. **Updated template context** ([pkg/vmcp/composer/template_expander.go](pkg/vmcp/composer/template_expander.go#L132-L140))
   - Added `buildWorkflowContext()` method to convert metadata to template-friendly structure
   - Included `workflow` field in template context alongside `params`, `steps`, and `vars`
   - Implements proper read-locking for concurrent template expansion

4. **Fixed timing issue** ([pkg/vmcp/composer/workflow_engine.go](pkg/vmcp/composer/workflow_engine.go#L206-L210))
   - Added `updateWorkflowMetadata()` method to calculate metadata
   - Called **before** output construction (not after)
   - Ensures template variables have accurate, up-to-date values

5. **Updated workflow context management** ([pkg/vmcp/composer/workflow_context.go](pkg/vmcp/composer/workflow_context.go#L30-L45))
   - Initialize `WorkflowMetadata` in `CreateContext()`
   - Clone metadata properly in `Clone()` method for parallel execution safety

### Testing

Comprehensive test coverage added:

- **Unit tests** ([pkg/vmcp/composer/template_expander_test.go](pkg/vmcp/composer/template_expander_test.go)) - 181 lines
  - Individual workflow metadata field expansion
  - Combined metadata usage in templates
  - Nil workflow metadata edge cases
  - Integration with step outputs

- **Integration tests** ([pkg/vmcp/composer/workflow_engine_test.go](pkg/vmcp/composer/workflow_engine_test.go)) - 190 lines
  - End-to-end workflow execution with metadata
  - Metadata availability in output templates
  - Metadata availability during step execution
  - Duration calculation with timing verification

- **Test helpers** ([pkg/vmcp/composer/testhelpers_test.go](pkg/vmcp/composer/testhelpers_test.go))
  - Updated to initialize workflow metadata in test contexts

## Usage Example

Users can now use workflow metadata in composite tool output configurations:

```yaml
composite_tools:
  - name: aggregate_docs
    steps:
      - id: fetch_source_1
        type: tool
        tool: fetch_fetch
      - id: fetch_source_2
        type: tool
        tool: fetch_fetch
      - id: fetch_source_3
        type: tool
        tool: fetch_fetch

    output:
      properties:
        summary:
          type: object
          properties:
            workflow_id:
              type: string
              value: "{{.workflow.id}}"
            duration_ms:
              type: integer
              value: "{{.workflow.duration_ms}}"
            step_count:
              type: integer
              value: "{{.workflow.step_count}}"
            status:
              type: string
              value: "{{.workflow.status}}"
            started_at:
              type: string
              value: "{{.workflow.start_time}}"
        results:
          type: array
          value: "{{.steps.fetch_source_1.output.data}}"
```

## Available Template Variables

| Variable | Type | Description |
|----------|------|-------------|
| `{{.workflow.id}}` | string | Unique workflow execution ID |
| `{{.workflow.duration_ms}}` | integer | Workflow duration in milliseconds |
| `{{.workflow.step_count}}` | integer | Number of completed steps |
| `{{.workflow.status}}` | string | Current status (pending, running, completed, etc.) |
| `{{.workflow.start_time}}` | string | Start timestamp in RFC3339 format |

## Technical Highlights

### Thread Safety
- **Read lock** in `buildWorkflowContext()` for concurrent template expansion
- **Write lock** in `updateWorkflowMetadata()` for metadata updates
- Existing `WorkflowContext.mu` protects both Steps map and Workflow metadata
- Proper nil checking prevents panics

### Backward Compatibility
- No breaking changes - existing templates continue to work
- New template variables are optional
- Nil workflow metadata returns empty map (templates gracefully handle `<no value>`)

### Architecture
- Follows clean separation of concerns
- Metadata calculation before output construction (fixes timing issue)
- Immutable after update (single calculation point)
- Clone support for parallel workflow scenarios

## Related Issues

- Issue #2714 - Add workflow metadata to output template context (this PR)
- Issue #2713 - Structured output schema bug (referenced in #2714 for context)
- PR #2677 - Added output configuration support (foundation for this feature)

## Checklist

- [x] Implementation follows specification from issue #2714
- [x] All requested template variables implemented
- [x] Thread-safety verified with mutex protection
- [x] Comprehensive unit tests added
- [x] Integration tests added
- [x] Test helpers updated
- [x] Backward compatibility maintained
- [x] Documentation in code comments
- [x] No breaking changes
- [x] Follows Go conventions and ToolHive patterns

## Deployment Notes

This is a backward-compatible feature addition. No migration or configuration changes required. Users can immediately start using `{{.workflow.*}}` variables in their composite tool output templates after deployment.
