### PR TITLE
Add proposal for custom package mirror support

### DIFF
--- a/docs/proposals/THV-2732-custom-package-registries.md
+++ b/docs/proposals/THV-2732-custom-package-registries.md
@@ -181,6 +181,19 @@ Build environment variable names should be validated:
 - Must match pattern `^[A-Z][A-Z0-9_]*$` (uppercase letters, numbers, underscores)
 - Cannot override critical Docker variables (e.g., `PATH`, `HOME`)
 
+### Value Escaping and Injection Safety
+
+Environment variable values are injected into Dockerfiles using Go template syntax with double quotes:
+```dockerfile
+ENV {{$key}}="{{$value}}"
+```
+
+To prevent shell escape vulnerabilities:
+- Values containing double quotes (`"`) should be escaped or rejected
+- Validation should check for potentially dangerous characters like backticks, `$()`, and other shell metacharacters
+- The template rendering should use proper escaping mechanisms to prevent injection attacks
+- Consider restricting characters to alphanumeric, hyphens, underscores, forward slashes, colons, and dots for URL-like values
+
 ### No Credential Storage
 
 This proposal does not include credential storage. If a mirror requires authentication, users should use URL-embedded credentials (not recommended) or configure credentials through other mechanisms. Future work may address secure credential injection.


### PR DESCRIPTION
## Summary

This proposal introduces a general mechanism for injecting build environment variables into protocol builds (`npx://`, `uvx://`, `go://`). The primary use case is configuring custom package mirrors for organizations operating in restricted network environments, but the solution is flexible enough to handle other build-time configuration needs.

## Problem

Many organizations require packages to be downloaded through internal mirrors that:
- Scan and verify packages for security vulnerabilities
- Maintain curated lists of approved packages
- Provide an audit trail of package usage
- Operate behind corporate firewalls with TLS interception

Currently, ToolHive protocol builds always use public registries, preventing adoption in these environments. Beyond package mirrors, there are other build-time configurations that organizations may need to customize.

## Proposed Solution

- New configuration section: `build_env` storing key-value pairs of environment variables
- CLI commands: `thv config set/get/unset build-env <KEY> <value>`
- Templates modified to iterate and inject all configured environment variables
- Integration with existing CA certificate configuration

Example usage:
```bash
thv config set build-env NPM_CONFIG_REGISTRY https://npm.corp.example.com
thv config set build-env PIP_INDEX_URL https://pypi.corp.example.com/simple
thv config set build-env UV_DEFAULT_INDEX https://pypi.corp.example.com/simple
thv config set build-env GOPROXY https://goproxy.corp.example.com
```

## Key Design Decisions

- General mechanism (`build-env`) instead of specific package-mirror commands for flexibility
- Handles unforeseen use cases (e.g., `GOPRIVATE`, `NODE_OPTIONS`, `PIP_TRUSTED_HOST`)
- Global configuration to enforce organizational policies
- Includes security validation for variable names and value escaping
- Maintains backward compatibility