### PR TITLE
Use UTC for workflow metadata timestamps

### DIFF
--- a/pkg/vmcp/composer/testhelpers_test.go
+++ b/pkg/vmcp/composer/testhelpers_test.go
@@ -81,7 +81,7 @@ func (te *testEngine) expectToolCallWithAnyArgs(toolName string, output map[stri
 
 // newWorkflowContext creates a test workflow context.
 func newWorkflowContext(params map[string]any) *WorkflowContext {
-	startTime := time.Now()
+	startTime := time.Now().UTC()
 	return &WorkflowContext{
 		WorkflowID: "test-workflow",
 		Params:     params,

--- a/pkg/vmcp/composer/workflow_context.go
+++ b/pkg/vmcp/composer/workflow_context.go
@@ -28,7 +28,7 @@ func (m *workflowContextManager) CreateContext(params map[string]any) *WorkflowC
 	defer m.mu.Unlock()
 
 	workflowID := uuid.New().String()
-	startTime := time.Now()
+	startTime := time.Now().UTC()
 
 	ctx := &WorkflowContext{
 		WorkflowID: workflowID,


### PR DESCRIPTION
This ensures RFC3339 formatted timestamps in template output have consistent timezone  handling regardless of server location.