### PR TITLE
Remove redundant best_effort failure mode from composer

### DIFF
--- a/cmd/thv-operator/api/v1alpha1/virtualmcpcompositetooldefinition_types.go
+++ b/cmd/thv-operator/api/v1alpha1/virtualmcpcompositetooldefinition_types.go
@@ -41,8 +41,7 @@ type VirtualMCPCompositeToolDefinitionSpec struct {
 	// FailureMode defines the failure handling strategy
 	// - abort: Stop execution on first failure (default)
 	// - continue: Continue executing remaining steps
-	// - best_effort: Try all steps, report partial success
-	// +kubebuilder:validation:Enum=abort;continue;best_effort
+	// +kubebuilder:validation:Enum=abort;continue
 	// +kubebuilder:default=abort
 	// +optional
 	FailureMode string `json:"failureMode,omitempty"`

--- a/cmd/thv-operator/api/v1alpha1/virtualmcpcompositetooldefinition_webhook.go
+++ b/cmd/thv-operator/api/v1alpha1/virtualmcpcompositetooldefinition_webhook.go
@@ -84,12 +84,11 @@ func (r *VirtualMCPCompositeToolDefinition) Validate() error {
 	// Validate failure mode
 	if r.Spec.FailureMode != "" {
 		validModes := map[string]bool{
-			"abort":       true,
-			"continue":    true,
-			"best_effort": true,
+			"abort":    true,
+			"continue": true,
 		}
 		if !validModes[r.Spec.FailureMode] {
-			errors = append(errors, "spec.failureMode must be one of: abort, continue, best_effort")
+			errors = append(errors, "spec.failureMode must be one of: abort, continue")
 		}
 	}
 

--- a/cmd/thv-operator/api/v1alpha1/virtualmcpcompositetooldefinition_webhook_test.go
+++ b/cmd/thv-operator/api/v1alpha1/virtualmcpcompositetooldefinition_webhook_test.go
@@ -443,9 +443,9 @@ func TestVirtualMCPCompositeToolDefinitionValidate(t *testing.T) {
 			name: "valid failure mode configuration",
 			ctd: &VirtualMCPCompositeToolDefinition{
 				Spec: VirtualMCPCompositeToolDefinitionSpec{
-					Name:        "best_effort_deploy",
-					Description: "Deploy with best effort",
-					FailureMode: "best_effort",
+					Name:        "continue_deploy",
+					Description: "Deploy with continue mode",
+					FailureMode: "continue",
 					Steps: []WorkflowStep{
 						{
 							ID:   "deploy1",
@@ -476,7 +476,7 @@ func TestVirtualMCPCompositeToolDefinitionValidate(t *testing.T) {
 				},
 			},
 			wantErr: true,
-			errMsg:  "spec.failureMode must be one of: abort, continue, best_effort",
+			errMsg:  "spec.failureMode must be one of: abort, continue",
 		},
 		{
 			name: "valid conditional step",

--- a/deploy/charts/operator-crds/Chart.yaml
+++ b/deploy/charts/operator-crds/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: toolhive-operator-crds
 description: A Helm chart for installing the ToolHive Operator CRDs into Kubernetes.
 type: application
-version: 0.0.63
+version: 0.0.64
 appVersion: "0.0.1"

--- a/deploy/charts/operator-crds/README.md
+++ b/deploy/charts/operator-crds/README.md
@@ -1,6 +1,6 @@
 # ToolHive Operator CRDs Helm Chart
 
-![Version: 0.0.63](https://img.shields.io/badge/Version-0.0.63-informational?style=flat-square)
+![Version: 0.0.64](https://img.shields.io/badge/Version-0.0.64-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for installing the ToolHive Operator CRDs into Kubernetes.

--- a/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_virtualmcpcompositetooldefinitions.yaml
+++ b/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_virtualmcpcompositetooldefinitions.yaml
@@ -80,11 +80,9 @@ spec:
                   FailureMode defines the failure handling strategy
                   - abort: Stop execution on first failure (default)
                   - continue: Continue executing remaining steps
-                  - best_effort: Try all steps, report partial success
                 enum:
                 - abort
                 - continue
-                - best_effort
                 type: string
               name:
                 description: Name is the workflow name exposed as a composite tool

--- a/docs/operator/advanced-workflow-patterns.md
+++ b/docs/operator/advanced-workflow-patterns.md
@@ -213,7 +213,7 @@ Set the workflow's `failureMode` to control global error behavior:
 ```yaml
 spec:
   name: resilient_workflow
-  failureMode: continue  # Options: abort, continue, best_effort
+  failureMode: continue  # Options: abort, continue
   steps:
     # ...
 ```
@@ -224,7 +224,6 @@ spec:
 |------|----------|----------|
 | `abort` | Stop immediately on first error (default) | Critical workflows where partial completion is dangerous |
 | `continue` | Log errors but continue executing remaining steps | Data collection where some failures are acceptable |
-| `best_effort` | Try all steps, aggregate errors at end | Monitoring/reporting where you want maximum data |
 
 ### Step-Level Error Handling
 

--- a/docs/operator/composite-tools-quick-reference.md
+++ b/docs/operator/composite-tools-quick-reference.md
@@ -14,7 +14,7 @@ spec:
   name: my_workflow_name        # Tool name exposed to clients
   description: What it does      # Required description
   timeout: 30m                   # Optional: workflow timeout (default: 30m)
-  failureMode: abort             # Optional: abort|continue|best_effort (default: abort)
+  failureMode: abort             # Optional: abort|continue (default: abort)
 
   parameters:                    # Optional: input parameters
     param_name:
@@ -116,7 +116,6 @@ All Go template built-ins are available: `index`, `len`, `range`, `with`, `print
 spec:
   failureMode: abort             # Stop on first error (default)
   failureMode: continue          # Log errors, continue workflow
-  failureMode: best_effort       # Try all steps, aggregate errors
 ```
 
 ### Step-Level (Overrides Workflow)

--- a/docs/operator/crd-api.md
+++ b/docs/operator/crd-api.md
@@ -1855,7 +1855,7 @@ _Appears in:_
 | `parameters` _object (keys:string, values:[ParameterSpec](#parameterspec))_ | Parameters defines the input parameter schema for the workflow<br />Each key is a parameter name, each value is the parameter specification |  |  |
 | `steps` _[WorkflowStep](#workflowstep) array_ | Steps defines the workflow step definitions<br />Steps are executed sequentially in Phase 1<br />Phase 2 will support DAG execution via dependsOn |  | MinItems: 1 <br />Required: \{\} <br /> |
 | `timeout` _string_ | Timeout is the overall workflow timeout<br />Defaults to 30m if not specified | 30m | Pattern: `^([0-9]+(\.[0-9]+)?(ms\|s\|m\|h))+$` <br /> |
-| `failureMode` _string_ | FailureMode defines the failure handling strategy<br />- abort: Stop execution on first failure (default)<br />- continue: Continue executing remaining steps<br />- best_effort: Try all steps, report partial success | abort | Enum: [abort continue best_effort] <br /> |
+| `failureMode` _string_ | FailureMode defines the failure handling strategy<br />- abort: Stop execution on first failure (default)<br />- continue: Continue executing remaining steps | abort | Enum: [abort continue] <br /> |
 
 
 #### VirtualMCPCompositeToolDefinitionStatus

--- a/docs/operator/virtualmcpcompositetooldefinition-guide.md
+++ b/docs/operator/virtualmcpcompositetooldefinition-guide.md
@@ -236,7 +236,7 @@ spec:
   description: Deploy with multiple retries
 
   # Failure handling strategy
-  failureMode: best_effort
+  failureMode: continue
 
   steps:
     - id: deploy_primary
@@ -253,7 +253,6 @@ spec:
 **Failure Modes**:
 - `abort`: Stop on first failure (default)
 - `continue`: Execute all steps regardless of failures
-- `best_effort`: Try all steps, report partial success
 
 ### Template Syntax
 
@@ -455,7 +454,7 @@ spec:
         action: continue
 
   timeout: 15m
-  failureMode: best_effort
+  failureMode: continue
 ```
 
 ### Example 4: Multi-Stage Deployment

--- a/pkg/vmcp/composer/dag_executor.go
+++ b/pkg/vmcp/composer/dag_executor.go
@@ -15,7 +15,6 @@ const (
 	// defaultMaxParallelSteps is the default maximum number of steps to execute in parallel.
 	defaultMaxParallelSteps = 10
 	failureModeContinue     = "continue"
-	failureModeBestEffort   = "best_effort"
 )
 
 // dagExecutor executes workflow steps using a Directed Acyclic Graph (DAG) approach.
@@ -157,7 +156,7 @@ func (*dagExecutor) shouldContinueOnError(step *WorkflowStep, failureMode string
 	}
 
 	// Check workflow-level failure mode
-	return failureMode == failureModeContinue || failureMode == failureModeBestEffort
+	return failureMode == failureModeContinue
 }
 
 // buildExecutionLevels performs topological sort to build execution levels.

--- a/pkg/vmcp/composer/dag_executor_test.go
+++ b/pkg/vmcp/composer/dag_executor_test.go
@@ -250,13 +250,6 @@ func TestDAGExecutor_ErrorHandling(t *testing.T) {
 			wantErr:     false,
 			wantAllRun:  true,
 		},
-		{
-			name:        "best_effort on error",
-			failureMode: "best_effort",
-			failAt:      "step2",
-			wantErr:     false,
-			wantAllRun:  true,
-		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
The best_effort and continue failure modes were functionally identical in the vMCP composer implementation. Both modes executed all workflow steps regardless of failures and suppressed errors. This simplifies the API by keeping only abort (default) and continue modes.