### PR TITLE
Remove NewUpstreamRegistryFromUpstreamServers

### DIFF
--- a/pkg/registry/converters/registry_converters.go
+++ b/pkg/registry/converters/registry_converters.go
@@ -2,28 +2,11 @@ package converters
 
 import (
 	"fmt"
-	"time"
 
 	upstreamv0 "github.com/modelcontextprotocol/registry/pkg/api/v0"
 
 	types "github.com/stacklok/toolhive/pkg/registry/registry"
 )
-
-// NewUpstreamRegistryFromUpstreamServers creates a UpstreamRegistry from upstream ServerJSON array.
-// This is used when ingesting data from upstream MCP Registry API endpoints.
-func NewUpstreamRegistryFromUpstreamServers(servers []upstreamv0.ServerJSON) *types.UpstreamRegistry {
-	return &types.UpstreamRegistry{
-		Schema:  "https://raw.githubusercontent.com/stacklok/toolhive/main/pkg/registry/data/upstream-registry.schema.json",
-		Version: "1.0.0",
-		Meta: types.UpstreamMeta{
-			LastUpdated: time.Now().Format(time.RFC3339),
-		},
-		Data: types.UpstreamData{
-			Servers: servers,
-			Groups:  []types.UpstreamGroup{},
-		},
-	}
-}
 
 // NewUpstreamRegistryFromToolhiveRegistry creates a UpstreamRegistry from ToolHive Registry.
 // This converts ToolHive format to upstream ServerJSON using the converters package.

--- a/pkg/registry/converters/registry_converters_test.go
+++ b/pkg/registry/converters/registry_converters_test.go
@@ -2,12 +2,8 @@ package converters
 
 import (
 	"testing"
-	"time"
 
-	upstreamv0 "github.com/modelcontextprotocol/registry/pkg/api/v0"
-	"github.com/modelcontextprotocol/registry/pkg/model"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	types "github.com/stacklok/toolhive/pkg/registry/registry"
 )
@@ -112,85 +108,4 @@ func TestNewUpstreamRegistryFromToolhiveRegistry(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestNewUpstreamRegistryFromUpstreamServers(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name     string
-		servers  []upstreamv0.ServerJSON
-		validate func(*testing.T, *types.UpstreamRegistry)
-	}{
-		{
-			name: "create from upstream servers",
-			servers: []upstreamv0.ServerJSON{
-				{
-					Schema:      "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
-					Name:        "io.test/server1",
-					Description: "Test server 1",
-					Version:     "1.0.0",
-					Packages: []model.Package{
-						{
-							RegistryType: "oci",
-							Identifier:   "test/image:latest",
-							Transport:    model.Transport{Type: "stdio"},
-						},
-					},
-				},
-			},
-			validate: func(t *testing.T, sr *types.UpstreamRegistry) {
-				t.Helper()
-				assert.Equal(t, "1.0.0", sr.Version)
-				assert.NotEmpty(t, sr.Meta.LastUpdated)
-				assert.Len(t, sr.Data.Servers, 1)
-				assert.Equal(t, "io.test/server1", sr.Data.Servers[0].Name)
-			},
-		},
-		{
-			name:    "create from empty slice",
-			servers: []upstreamv0.ServerJSON{},
-			validate: func(t *testing.T, sr *types.UpstreamRegistry) {
-				t.Helper()
-				assert.Empty(t, sr.Data.Servers)
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			result := NewUpstreamRegistryFromUpstreamServers(tt.servers)
-
-			assert.NotNil(t, result)
-			if tt.validate != nil {
-				tt.validate(t, result)
-			}
-		})
-	}
-}
-
-func TestNewServerRegistryFromUpstream_DefaultValues(t *testing.T) {
-	t.Parallel()
-
-	servers := []upstreamv0.ServerJSON{
-		{
-			Schema:      "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
-			Name:        "io.test/server1",
-			Description: "Test server",
-			Version:     "1.0.0",
-		},
-	}
-
-	result := NewUpstreamRegistryFromUpstreamServers(servers)
-
-	// Verify defaults
-	assert.Equal(t, "1.0.0", result.Version)
-	assert.NotEmpty(t, result.Meta.LastUpdated)
-
-	// Verify timestamp is recent (within last minute)
-	parsedTime, err := time.Parse(time.RFC3339, result.Meta.LastUpdated)
-	require.NoError(t, err)
-	assert.WithinDuration(t, time.Now(), parsedTime, time.Minute)
 }


### PR DESCRIPTION
This is no longer needed on the registry side after https://github.com/stacklok/toolhive-registry-server/pull/201. 