### PR TITLE
Remove local incoming auth type from operator CRDs

### DIFF
--- a/cmd/thv-operator/api/v1alpha1/virtualmcpserver_types.go
+++ b/cmd/thv-operator/api/v1alpha1/virtualmcpserver_types.go
@@ -68,8 +68,8 @@ type GroupRef struct {
 
 // IncomingAuthConfig configures authentication for clients connecting to the Virtual MCP server
 type IncomingAuthConfig struct {
-	// Type defines the authentication type: anonymous, local, or oidc
-	// +kubebuilder:validation:Enum=anonymous;local;oidc
+	// Type defines the authentication type: anonymous or oidc
+	// +kubebuilder:validation:Enum=anonymous;oidc
 	// +optional
 	Type string `json:"type,omitempty"`
 

--- a/deploy/charts/operator-crds/Chart.yaml
+++ b/deploy/charts/operator-crds/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: toolhive-operator-crds
 description: A Helm chart for installing the ToolHive Operator CRDs into Kubernetes.
 type: application
-version: 0.0.65
+version: 0.0.66
 appVersion: "0.0.1"

--- a/deploy/charts/operator-crds/README.md
+++ b/deploy/charts/operator-crds/README.md
@@ -1,6 +1,6 @@
 # ToolHive Operator CRDs Helm Chart
 
-![Version: 0.0.65](https://img.shields.io/badge/Version-0.0.65-informational?style=flat-square)
+![Version: 0.0.66](https://img.shields.io/badge/Version-0.0.66-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for installing the ToolHive Operator CRDs into Kubernetes.

--- a/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_virtualmcpservers.yaml
+++ b/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_virtualmcpservers.yaml
@@ -515,11 +515,10 @@ spec:
                     - type
                     type: object
                   type:
-                    description: 'Type defines the authentication type: anonymous,
-                      local, or oidc'
+                    description: 'Type defines the authentication type: anonymous
+                      or oidc'
                     enum:
                     - anonymous
-                    - local
                     - oidc
                     type: string
                 type: object

--- a/docs/operator/crd-api.md
+++ b/docs/operator/crd-api.md
@@ -447,7 +447,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `type` _string_ | Type defines the authentication type: anonymous, local, or oidc |  | Enum: [anonymous local oidc] <br /> |
+| `type` _string_ | Type defines the authentication type: anonymous or oidc |  | Enum: [anonymous oidc] <br /> |
 | `oidcConfig` _[OIDCConfigRef](#oidcconfigref)_ | OIDCConfig defines OIDC authentication configuration<br />Reuses MCPServer OIDC patterns |  |  |
 | `authzConfig` _[AuthzConfigRef](#authzconfigref)_ | AuthzConfig defines authorization policy configuration<br />Reuses MCPServer authz patterns |  |  |
 

--- a/examples/vmcp-config.yaml
+++ b/examples/vmcp-config.yaml
@@ -20,7 +20,7 @@ group: "engineering-team"  # Reference to ToolHive group
 
 # ===== INCOMING AUTHENTICATION (Client → Virtual MCP) =====
 incoming_auth:
-  type: oidc  # Options: oidc | anonymous | local
+  type: oidc  # Options: oidc | anonymous
   # OIDC configuration
   oidc:
     issuer: "https://keycloak.example.com/realms/myrealm"

--- a/test/e2e/thv-operator/virtualmcp/virtualmcp_inline_auth_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcp_inline_auth_test.go
@@ -17,12 +17,12 @@ import (
 	mcpv1alpha1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1alpha1"
 )
 
-var _ = Describe("VirtualMCPServer Inline Auth with Local Incoming", Ordered, func() {
+var _ = Describe("VirtualMCPServer Inline Auth with Anonymous Incoming", Ordered, func() {
 	var (
 		testNamespace   = "default"
-		mcpGroupName    = "test-inline-auth-local-group"
-		vmcpServerName  = "test-vmcp-inline-auth-local"
-		backend1Name    = "backend-fetch-inline-local"
+		mcpGroupName    = "test-inline-auth-anon-group"
+		vmcpServerName  = "test-vmcp-inline-auth-anon"
+		backend1Name    = "backend-fetch-inline-anon"
 		timeout         = 5 * time.Minute
 		pollingInterval = 5 * time.Second
 		vmcpNodePort    int32
@@ -40,7 +40,7 @@ var _ = Describe("VirtualMCPServer Inline Auth with Local Incoming", Ordered, fu
 				Namespace: testNamespace,
 			},
 			Spec: mcpv1alpha1.MCPGroupSpec{
-				Description: "Test MCP Group for VirtualMCP inline auth with local incoming",
+				Description: "Test MCP Group for VirtualMCP inline auth with anonymous incoming",
 			},
 		}
 		Expect(k8sClient.Create(ctx, mcpGroup)).To(Succeed())
@@ -89,7 +89,7 @@ var _ = Describe("VirtualMCPServer Inline Auth with Local Incoming", Ordered, fu
 			return fmt.Errorf("backend not ready yet, phase: %s", server.Status.Phase)
 		}, timeout, pollingInterval).Should(Succeed())
 
-		By("Creating VirtualMCPServer with local incoming and inline outgoing auth")
+		By("Creating VirtualMCPServer with anonymous incoming and inline outgoing auth")
 		vmcpServer := &mcpv1alpha1.VirtualMCPServer{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      vmcpServerName,
@@ -100,7 +100,7 @@ var _ = Describe("VirtualMCPServer Inline Auth with Local Incoming", Ordered, fu
 					Name: mcpGroupName,
 				},
 				IncomingAuth: &mcpv1alpha1.IncomingAuthConfig{
-					Type: "local",
+					Type: "anonymous",
 				},
 				OutgoingAuth: &mcpv1alpha1.OutgoingAuthConfig{
 					Source: "inline",
@@ -146,8 +146,8 @@ var _ = Describe("VirtualMCPServer Inline Auth with Local Incoming", Ordered, fu
 		})
 	})
 
-	Context("when using local incoming with inline outgoing auth", func() {
-		It("should configure inline outgoing auth with local incoming", func() {
+	Context("when using anonymous incoming with inline outgoing auth", func() {
+		It("should configure inline outgoing auth with anonymous incoming", func() {
 			By("Verifying VirtualMCPServer has inline auth configuration")
 			vmcpServer := &mcpv1alpha1.VirtualMCPServer{}
 			err := k8sClient.Get(ctx, types.NamespacedName{
@@ -155,12 +155,12 @@ var _ = Describe("VirtualMCPServer Inline Auth with Local Incoming", Ordered, fu
 				Namespace: testNamespace,
 			}, vmcpServer)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(vmcpServer.Spec.IncomingAuth.Type).To(Equal("local"))
+			Expect(vmcpServer.Spec.IncomingAuth.Type).To(Equal("anonymous"))
 			Expect(vmcpServer.Spec.OutgoingAuth.Source).To(Equal("inline"))
 		})
 
 		It("should proxy tool calls with inline auth configuration", func() {
-			By("Creating MCP client with local auth")
+			By("Creating MCP client with anonymous auth")
 			serverURL := fmt.Sprintf("http://localhost:%d/mcp", vmcpNodePort)
 			mcpClient, err := client.NewStreamableHttpClient(serverURL)
 			Expect(err).ToNot(HaveOccurred())
@@ -196,7 +196,7 @@ var _ = Describe("VirtualMCPServer Inline Auth with Local Incoming", Ordered, fu
 			}
 			Expect(targetToolName).ToNot(BeEmpty())
 
-			GinkgoWriter.Printf("Calling tool '%s' with local incoming and inline outgoing auth\n", targetToolName)
+			GinkgoWriter.Printf("Calling tool '%s' with anonymous incoming and inline outgoing auth\n", targetToolName)
 
 			callRequest := mcp.CallToolRequest{}
 			callRequest.Params.Name = targetToolName
@@ -209,7 +209,7 @@ var _ = Describe("VirtualMCPServer Inline Auth with Local Incoming", Ordered, fu
 			Expect(result).ToNot(BeNil())
 			Expect(result.Content).ToNot(BeEmpty())
 
-			GinkgoWriter.Printf("Local auth with inline outgoing: tool call succeeded\n")
+			GinkgoWriter.Printf("Anonymous auth with inline outgoing: tool call succeeded\n")
 		})
 	})
 })


### PR DESCRIPTION
The `local` authentication type uses `user.Current()` to get the OS username, which is meaningful for CLI usage but inappropriate in Kubernetes where the container user has no relation to connecting clients.

This removes `local` from the CRD layer only, preserving it in pkg/vmcp for CLI use cases.