### PR TITLE
Replace utilruntime.Must with proper error handling in vMCP code

### DIFF
--- a/pkg/groups/manager.go
+++ b/pkg/groups/manager.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/runtime"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 
 	mcpv1alpha1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1alpha1"
@@ -32,8 +31,12 @@ func NewManager() (Manager, error) {
 func newCRDManager() (Manager, error) {
 	// Create a scheme for controller-runtime client
 	scheme := runtime.NewScheme()
-	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
-	utilruntime.Must(mcpv1alpha1.AddToScheme(scheme))
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		return nil, fmt.Errorf("failed to add client-go scheme: %w", err)
+	}
+	if err := mcpv1alpha1.AddToScheme(scheme); err != nil {
+		return nil, fmt.Errorf("failed to add MCP v1alpha1 scheme: %w", err)
+	}
 
 	// Create controller-runtime client with custom scheme
 	k8sClient, err := k8s.NewControllerRuntimeClient(scheme)

--- a/pkg/vmcp/workloads/k8s.go
+++ b/pkg/vmcp/workloads/k8s.go
@@ -7,7 +7,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -33,8 +32,12 @@ type k8sDiscoverer struct {
 func NewK8SDiscoverer(namespace ...string) (Discoverer, error) {
 	// Create a scheme for controller-runtime client
 	scheme := runtime.NewScheme()
-	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
-	utilruntime.Must(mcpv1alpha1.AddToScheme(scheme))
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		return nil, fmt.Errorf("failed to add client-go scheme: %w", err)
+	}
+	if err := mcpv1alpha1.AddToScheme(scheme); err != nil {
+		return nil, fmt.Errorf("failed to add MCP v1alpha1 scheme: %w", err)
+	}
 
 	// Create controller-runtime client
 	k8sClient, err := k8s.NewControllerRuntimeClient(scheme)


### PR DESCRIPTION
## Summary
- Replace `utilruntime.Must` with proper error handling in `pkg/vmcp/workloads/k8s.go` and `pkg/groups/manager.go`
- `utilruntime.Must` panics on error, which is inappropriate for library code that should gracefully handle initialization failures
- Both functions already return errors, so propagating these errors is straightforward

## Test plan
- [x] Ran `task lint` - passes
- [x] Ran `task test` - passes
- [x] Verified tests for modified packages pass: `go test -v ./pkg/vmcp/workloads/... ./pkg/groups/...`

Closes #2782

🤖 Generated with [Claude Code](https://claude.com/claude-code)