### PR TITLE
Fix proposal naming validation to only check new files

### DIFF
--- a/.github/workflows/validate-proposal-naming.yml
+++ b/.github/workflows/validate-proposal-naming.yml
@@ -37,12 +37,13 @@ jobs:
 
       - name: Validate proposal naming
         run: |
-          # Get the list of changed files in docs/proposals
-          CHANGED_FILES=$(git diff --name-only --diff-filter A origin/${{ github.base_ref }}...HEAD | grep '^docs/proposals/')
+          # Get the list of NEW files added in docs/proposals (not modifications to existing files)
+          CHANGED_FILES=$(git diff --name-only --diff-filter=A origin/${{ github.base_ref }}...HEAD | grep '^docs/proposals/' || true)
 
-          # This is here to avoid errors when running this workflow manually without a PR
+          # Skip validation if no new proposal files are being added
+          # (modifications to existing proposals don't need naming validation)
           if [ -z "$CHANGED_FILES" ]; then
-            echo "ℹ️ No proposal files changed in this PR"
+            echo "ℹ️ No new proposal files added in this PR (only modifications to existing proposals or manual trigger)"
             exit 0
           fi
 


### PR DESCRIPTION
## Summary

- Fixed the `--diff-filter` syntax from `--diff-filter A` to `--diff-filter=A` in the proposal naming validation workflow
- Without the equals sign, git could misinterpret `A` as a path argument instead of the "Added files only" filter
- This caused the validation to incorrectly fail when updating existing proposal files

## Test plan

- [ ] Verify CI passes on this PR
- [ ] Test by creating a PR that modifies an existing proposal file (e.g., `THV-0597-otel-integration-proposal.md`) - validation should pass
- [ ] Test by creating a PR that adds a new proposal file with incorrect naming - validation should fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)