### PR TITLE
Use mcp.LATEST_PROTOCOL_VERSION in E2E tests

### DIFF
--- a/test/e2e/thv-operator/virtualmcp/suite_test.go
+++ b/test/e2e/thv-operator/virtualmcp/suite_test.go
@@ -28,8 +28,6 @@ import (
 const (
 	// fetchToolName is the name of the fetch tool used in tests
 	fetchToolName = "fetch"
-	// mcpProtocolVersion is the MCP protocol version used in tests
-	mcpProtocolVersion = "2024-11-05"
 )
 
 var (

--- a/test/e2e/thv-operator/virtualmcp/virtualmcp_aggregation_filtering_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcp_aggregation_filtering_test.go
@@ -223,7 +223,7 @@ var _ = Describe("VirtualMCPServer Aggregation Filtering", Ordered, func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			initRequest := mcp.InitializeRequest{}
-			initRequest.Params.ProtocolVersion = mcpProtocolVersion
+			initRequest.Params.ProtocolVersion = mcp.LATEST_PROTOCOL_VERSION
 			initRequest.Params.ClientInfo = mcp.Implementation{
 				Name:    "toolhive-filtering-test",
 				Version: "1.0.0",
@@ -283,7 +283,7 @@ var _ = Describe("VirtualMCPServer Aggregation Filtering", Ordered, func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			initRequest := mcp.InitializeRequest{}
-			initRequest.Params.ProtocolVersion = mcpProtocolVersion
+			initRequest.Params.ProtocolVersion = mcp.LATEST_PROTOCOL_VERSION
 			initRequest.Params.ClientInfo = mcp.Implementation{
 				Name:    "toolhive-filtering-test",
 				Version: "1.0.0",

--- a/test/e2e/thv-operator/virtualmcp/virtualmcp_auth_discovery_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcp_auth_discovery_test.go
@@ -520,7 +520,7 @@ var _ = Describe("VirtualMCPServer Auth Discovery", Ordered, func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			initRequest := mcp.InitializeRequest{}
-			initRequest.Params.ProtocolVersion = mcpProtocolVersion
+			initRequest.Params.ProtocolVersion = mcp.LATEST_PROTOCOL_VERSION
 			initRequest.Params.ClientInfo = mcp.Implementation{
 				Name:    "toolhive-auth-discovery-test",
 				Version: "1.0.0",
@@ -560,7 +560,7 @@ var _ = Describe("VirtualMCPServer Auth Discovery", Ordered, func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			initRequest := mcp.InitializeRequest{}
-			initRequest.Params.ProtocolVersion = mcpProtocolVersion
+			initRequest.Params.ProtocolVersion = mcp.LATEST_PROTOCOL_VERSION
 			initRequest.Params.ClientInfo = mcp.Implementation{
 				Name:    "toolhive-auth-discovery-test",
 				Version: "1.0.0",

--- a/test/e2e/thv-operator/virtualmcp/virtualmcp_discovered_mode_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcp_discovered_mode_test.go
@@ -258,7 +258,7 @@ var _ = Describe("VirtualMCPServer Discovered Mode", Ordered, func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			initRequest := mcp.InitializeRequest{}
-			initRequest.Params.ProtocolVersion = "2024-11-05"
+			initRequest.Params.ProtocolVersion = mcp.LATEST_PROTOCOL_VERSION
 			initRequest.Params.ClientInfo = mcp.Implementation{
 				Name:    "toolhive-e2e-test",
 				Version: "1.0.0",
@@ -307,7 +307,7 @@ var _ = Describe("VirtualMCPServer Discovered Mode", Ordered, func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			initRequest := mcp.InitializeRequest{}
-			initRequest.Params.ProtocolVersion = "2024-11-05"
+			initRequest.Params.ProtocolVersion = mcp.LATEST_PROTOCOL_VERSION
 			initRequest.Params.ClientInfo = mcp.Implementation{
 				Name:    "toolhive-e2e-test",
 				Version: "1.0.0",

--- a/test/e2e/thv-operator/virtualmcp/virtualmcp_inline_auth_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcp_inline_auth_test.go
@@ -173,7 +173,7 @@ var _ = Describe("VirtualMCPServer Inline Auth with Anonymous Incoming", Ordered
 			Expect(err).ToNot(HaveOccurred())
 
 			initRequest := mcp.InitializeRequest{}
-			initRequest.Params.ProtocolVersion = mcpProtocolVersion
+			initRequest.Params.ProtocolVersion = mcp.LATEST_PROTOCOL_VERSION
 			initRequest.Params.ClientInfo = mcp.Implementation{
 				Name:    "toolhive-e2e-test",
 				Version: "1.0.0",
@@ -430,7 +430,7 @@ var _ = Describe("VirtualMCPServer Inline Auth with OIDC Incoming", Ordered, fun
 			err = mcpClient.Start(ctx)
 			if err == nil {
 				initRequest := mcp.InitializeRequest{}
-				initRequest.Params.ProtocolVersion = mcpProtocolVersion
+				initRequest.Params.ProtocolVersion = mcp.LATEST_PROTOCOL_VERSION
 				initRequest.Params.ClientInfo = mcp.Implementation{
 					Name:    "toolhive-e2e-test",
 					Version: "1.0.0",

--- a/test/e2e/thv-operator/virtualmcp/virtualmcp_tokenexchange_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcp_tokenexchange_test.go
@@ -287,7 +287,7 @@ var _ = Describe("VirtualMCPServer Token Exchange Auth", Ordered, func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			initRequest := mcp.InitializeRequest{}
-			initRequest.Params.ProtocolVersion = mcpProtocolVersion
+			initRequest.Params.ProtocolVersion = mcp.LATEST_PROTOCOL_VERSION
 			initRequest.Params.ClientInfo = mcp.Implementation{
 				Name:    "toolhive-e2e-test",
 				Version: "1.0.0",

--- a/test/e2e/thv-operator/virtualmcp/virtualmcp_yardstick_base_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcp_yardstick_base_test.go
@@ -231,7 +231,7 @@ var _ = Describe("VirtualMCPServer Yardstick Base", Ordered, func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			initRequest := mcp.InitializeRequest{}
-			initRequest.Params.ProtocolVersion = mcpProtocolVersion
+			initRequest.Params.ProtocolVersion = mcp.LATEST_PROTOCOL_VERSION
 			initRequest.Params.ClientInfo = mcp.Implementation{
 				Name:    "toolhive-yardstick-test",
 				Version: "1.0.0",
@@ -293,7 +293,7 @@ var _ = Describe("VirtualMCPServer Yardstick Base", Ordered, func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			initRequest := mcp.InitializeRequest{}
-			initRequest.Params.ProtocolVersion = mcpProtocolVersion
+			initRequest.Params.ProtocolVersion = mcp.LATEST_PROTOCOL_VERSION
 			initRequest.Params.ClientInfo = mcp.Implementation{
 				Name:    "toolhive-yardstick-test",
 				Version: "1.0.0",


### PR DESCRIPTION
Replace hardcoded MCP protocol version ("2024-11-05") with mcp.LATEST_PROTOCOL_VERSION from the mcp-go SDK across all VirtualMCP E2E tests.