### PR TITLE
Fix: Added path configuration to registry server

### DIFF
--- a/cmd/thv-operator/pkg/registryapi/config/config.go
+++ b/cmd/thv-operator/pkg/registryapi/config/config.go
@@ -340,8 +340,13 @@ func buildGitSourceConfig(git *mcpv1alpha1.GitSource) (*GitConfig, error) {
 		return nil, fmt.Errorf("git repository is required")
 	}
 
+	if git.Path == "" {
+		return nil, fmt.Errorf("git path is required")
+	}
+
 	serverGitConfig := GitConfig{
 		Repository: git.Repository,
+		Path:       git.Path,
 	}
 
 	switch {

--- a/cmd/thv-operator/pkg/registryapi/config/config_test.go
+++ b/cmd/thv-operator/pkg/registryapi/config/config_test.go
@@ -277,6 +277,7 @@ func TestBuildConfig_GitSource(t *testing.T) {
 						Format: mcpv1alpha1.RegistryFormatToolHive,
 						Git: &mcpv1alpha1.GitSource{
 							Repository: "https://github.com/example/repo.git",
+							Path:       "registry.json",
 							// No branch, tag, or commit specified - should cause an error
 						},
 					},
@@ -289,6 +290,33 @@ func TestBuildConfig_GitSource(t *testing.T) {
 
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "git branch, tag, and commit are mutually exclusive")
+		assert.Nil(t, config)
+	})
+
+	t.Run("no git path specified", func(t *testing.T) {
+		t.Parallel()
+		mcpRegistry := &mcpv1alpha1.MCPRegistry{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-registry",
+			},
+			Spec: mcpv1alpha1.MCPRegistrySpec{
+				Registries: []mcpv1alpha1.MCPRegistryConfig{
+					{
+						Name:   "default",
+						Format: mcpv1alpha1.RegistryFormatToolHive,
+						Git: &mcpv1alpha1.GitSource{
+							Repository: "https://github.com/example/repo.git",
+						},
+					},
+				},
+			},
+		}
+
+		manager := NewConfigManagerForTesting(mcpRegistry)
+		config, err := manager.BuildConfig()
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "path is required")
 		assert.Nil(t, config)
 	})
 
@@ -306,6 +334,7 @@ func TestBuildConfig_GitSource(t *testing.T) {
 						Git: &mcpv1alpha1.GitSource{
 							Repository: "https://github.com/example/repo.git",
 							Branch:     "main",
+							Path:       "registry.json",
 						},
 						SyncPolicy: &mcpv1alpha1.SyncPolicy{
 							Interval: "1h",
@@ -347,6 +376,7 @@ func TestBuildConfig_GitSource(t *testing.T) {
 						Git: &mcpv1alpha1.GitSource{
 							Repository: "git@github.com:example/repo.git",
 							Tag:        "v1.2.3",
+							Path:       "registry.json",
 						},
 						SyncPolicy: &mcpv1alpha1.SyncPolicy{
 							Interval: "1h",
@@ -388,6 +418,7 @@ func TestBuildConfig_GitSource(t *testing.T) {
 						Git: &mcpv1alpha1.GitSource{
 							Repository: "https://github.com/example/repo.git",
 							Commit:     "abc123def456",
+							Path:       "registry.json",
 						},
 						SyncPolicy: &mcpv1alpha1.SyncPolicy{
 							Interval: "1h",
@@ -722,6 +753,7 @@ func TestBuildConfig_Filter(t *testing.T) {
 						Git: &mcpv1alpha1.GitSource{
 							Repository: "https://github.com/example/repo.git",
 							Branch:     "main",
+							Path:       "registry.json",
 						},
 						SyncPolicy: &mcpv1alpha1.SyncPolicy{
 							Interval: "30m",
@@ -866,6 +898,7 @@ func TestToConfigMapWithContentChecksum(t *testing.T) {
 				Git: &GitConfig{
 					Repository: "https://github.com/example/mcp-servers.git",
 					Branch:     "main",
+					Path:       "registry.json",
 				},
 				SyncPolicy: &SyncPolicyConfig{
 					Interval: "15m",
@@ -960,6 +993,7 @@ func TestBuildConfig_MultipleRegistries(t *testing.T) {
 					Git: &mcpv1alpha1.GitSource{
 						Repository: "https://github.com/example/repo.git",
 						Branch:     "main",
+						Path:       "registry.json",
 					},
 					SyncPolicy: &mcpv1alpha1.SyncPolicy{
 						Interval: "30m",


### PR DESCRIPTION
Git configuration was losing the `path` definition when passed to the registry server.