### PR TITLE
Make client_secret_env optional in vMCP OIDC config

### DIFF
--- a/pkg/vmcp/config/validator.go
+++ b/pkg/vmcp/config/validator.go
@@ -102,10 +102,10 @@ func (v *DefaultValidator) validateIncomingAuth(auth *IncomingAuthConfig) error 
 			return fmt.Errorf("incoming_auth.oidc.audience is required")
 		}
 
-		// Client secret env var should be set (references a Kubernetes Secret mounted as env var)
-		if auth.OIDC.ClientSecretEnv == "" {
-			return fmt.Errorf("incoming_auth.oidc.client_secret_env is required")
-		}
+		// ClientSecretEnv is optional - some OIDC flows don't require client secrets:
+		// - PKCE flows (public clients)
+		// - Token validation without introspection
+		// - Kubernetes service account token validation
 	}
 
 	// Validate authorization configuration

--- a/pkg/vmcp/config/validator_test.go
+++ b/pkg/vmcp/config/validator_test.go
@@ -128,6 +128,18 @@ func TestValidator_ValidateIncomingAuth(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "valid OIDC auth without client secret (public client)",
+			auth: &IncomingAuthConfig{
+				Type: "oidc",
+				OIDC: &OIDCConfig{
+					Issuer:   "https://example.com",
+					ClientID: "public-client",
+					Audience: "vmcp",
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name: "invalid auth type",
 			auth: &IncomingAuthConfig{
 				Type: "invalid",


### PR DESCRIPTION
Remove the requirement for client_secret_env in the vMCP config
validator. This field is now optional to support OIDC flows that
don't require client secrets:
- PKCE flows (public clients)
- OIDC Token validation without introspection
- Kubernetes service account token validation

This aligns with the Kubernetes CRD behavior where clientSecretRef
is already optional.
