### PR TITLE
Centralize container image references in e2e tests

### DIFF
--- a/test/e2e/images/images.go
+++ b/test/e2e/images/images.go
@@ -1,0 +1,42 @@
+// Package images provides centralized container image references for e2e tests.
+// This package serves as a single source of truth for all container images used
+// in end-to-end testing, making it easier to maintain versions and enabling
+// automated dependency updates through tools like Renovate.
+//
+// Each image is composed of an imageURL (base path) and imageTag (version).
+// The complete Image constant combines the URL and tag for use in tests.
+package images
+
+const (
+	yardstickServerImageURL = "ghcr.io/stackloklabs/yardstick/yardstick-server"
+	yardstickServerImageTag = "0.0.2"
+	// YardstickServerImage is used in operator tests across multiple transport protocols
+	// (stdio, SSE, streamable-http) and tenancy modes.
+	// Note: This image is also referenced in 8 YAML fixture files under
+	// test/e2e/chainsaw/operator/. Those files are declarative Kubernetes manifests
+	// and cannot import Go constants directly.
+	YardstickServerImage = yardstickServerImageURL + ":" + yardstickServerImageTag
+
+	gofetchServerImageURL = "ghcr.io/stackloklabs/gofetch/server"
+	gofetchServerImageTag = "1.0.1"
+	// GofetchServerImage is used for testing virtual MCP server features, including
+	// authentication flows and backend aggregation.
+	GofetchServerImage = gofetchServerImageURL + ":" + gofetchServerImageTag
+
+	osvmcpServerImageURL = "ghcr.io/stackloklabs/osv-mcp/server"
+	osvmcpServerImageTag = "0.0.7"
+	// OSVMCPServerImage is used for testing discovered mode aggregation and telemetry
+	// metrics validation.
+	OSVMCPServerImage = osvmcpServerImageURL + ":" + osvmcpServerImageTag
+
+	pythonImageURL = "python"
+	pythonImageTag = "3.9-slim"
+	// PythonImage is used for deploying mock OIDC servers and instrumented backend servers
+	// in Kubernetes tests. These run Flask-based Python services for testing authentication flows.
+	PythonImage = pythonImageURL + ":" + pythonImageTag
+
+	curlImageURL = "curlimages/curl"
+	curlImageTag = "8.17.0"
+	// CurlImage is used to query service endpoints and gather statistics during Kubernetes tests.
+	CurlImage = curlImageURL + ":" + curlImageTag
+)

--- a/test/e2e/telemetry_metrics_validation_e2e_test.go
+++ b/test/e2e/telemetry_metrics_validation_e2e_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/stacklok/toolhive/pkg/transport/types"
 	"github.com/stacklok/toolhive/test/e2e"
+	"github.com/stacklok/toolhive/test/e2e/images"
 )
 
 var _ = Describe("Telemetry Metrics Validation E2E", Label("telemetry", "metrics", "validation", "e2e"), Serial, func() {
@@ -88,7 +89,7 @@ var _ = Describe("Telemetry Metrics Validation E2E", Label("telemetry", "metrics
 				"--transport", types.TransportTypeSSE.String(),
 				"--otel-enable-prometheus-metrics-path",
 				"--name", inferredName, // Still need explicit name for cleanup
-				"ghcr.io/stackloklabs/osv-mcp/server:0.0.7",
+				images.OSVMCPServerImage,
 			).ExpectSuccess()
 
 			// Update workloadName for cleanup

--- a/test/e2e/thv-operator/virtualmcp/helpers.go
+++ b/test/e2e/thv-operator/virtualmcp/helpers.go
@@ -21,6 +21,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	mcpv1alpha1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1alpha1"
+	"github.com/stacklok/toolhive/test/e2e/images"
 )
 
 // WaitForVirtualMCPServerReady waits for a VirtualMCPServer to reach Ready status
@@ -294,7 +295,7 @@ func DeployMockOIDCServerHTTP(ctx context.Context, c client.Client, namespace, s
 					Containers: []corev1.Container{
 						{
 							Name:    "mock-oidc",
-							Image:   "python:3.9-slim",
+							Image:   images.PythonImage,
 							Command: []string{"sh", "-c"},
 							Args:    []string{MockOIDCServerHTTPScript},
 							Ports: []corev1.ContainerPort{
@@ -353,7 +354,7 @@ func DeployInstrumentedBackendServer(ctx context.Context, c client.Client, names
 					Containers: []corev1.Container{
 						{
 							Name:    "instrumented-backend",
-							Image:   "python:3.9-slim",
+							Image:   images.PythonImage,
 							Command: []string{"sh", "-c"},
 							Args:    []string{InstrumentedBackendScript},
 							Ports: []corev1.ContainerPort{
@@ -461,7 +462,7 @@ func GetServiceStats(ctx context.Context, c client.Client, namespace, serviceNam
 			Containers: []corev1.Container{
 				{
 					Name:    "curl",
-					Image:   "curlimages/curl:latest",
+					Image:   images.CurlImage,
 					Command: []string{"curl", "-s", fmt.Sprintf("http://%s.%s.svc.cluster.local:%d/stats", serviceName, namespace, port)},
 				},
 			},

--- a/test/e2e/thv-operator/virtualmcp/virtualmcp_aggregation_filtering_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcp_aggregation_filtering_test.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	mcpv1alpha1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1alpha1"
+	"github.com/stacklok/toolhive/test/e2e/images"
 )
 
 // Compile-time check to ensure corev1 is used (for Service type)
@@ -67,7 +68,7 @@ var _ = Describe("VirtualMCPServer Aggregation Filtering", Ordered, func() {
 			},
 			Spec: mcpv1alpha1.MCPServerSpec{
 				GroupRef:  mcpGroupName,
-				Image:     YardstickImage,
+				Image:     images.YardstickServerImage,
 				Transport: "streamable-http",
 				ProxyPort: 8080,
 				McpPort:   8080,
@@ -86,7 +87,7 @@ var _ = Describe("VirtualMCPServer Aggregation Filtering", Ordered, func() {
 			},
 			Spec: mcpv1alpha1.MCPServerSpec{
 				GroupRef:  mcpGroupName,
-				Image:     YardstickImage,
+				Image:     images.YardstickServerImage,
 				Transport: "streamable-http",
 				ProxyPort: 8080,
 				McpPort:   8080,

--- a/test/e2e/thv-operator/virtualmcp/virtualmcp_auth_discovery_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcp_auth_discovery_test.go
@@ -22,6 +22,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	mcpv1alpha1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1alpha1"
+	"github.com/stacklok/toolhive/test/e2e/images"
 )
 
 // authRoundTripper is an HTTP RoundTripper that adds Bearer token authentication
@@ -718,7 +719,7 @@ with socketserver.TCPServer(("", PORT), OIDCHandler) as httpd:
 			},
 			Spec: mcpv1alpha1.MCPServerSpec{
 				GroupRef:  mcpGroupName,
-				Image:     "ghcr.io/stackloklabs/gofetch/server:1.0.1",
+				Image:     images.GofetchServerImage,
 				Transport: "streamable-http",
 				ProxyPort: 8080,
 				McpPort:   8080,
@@ -739,7 +740,7 @@ with socketserver.TCPServer(("", PORT), OIDCHandler) as httpd:
 			},
 			Spec: mcpv1alpha1.MCPServerSpec{
 				GroupRef:  mcpGroupName,
-				Image:     "ghcr.io/stackloklabs/osv-mcp/server:0.0.7",
+				Image:     images.OSVMCPServerImage,
 				Transport: "streamable-http",
 				ProxyPort: 8080,
 				McpPort:   8080,
@@ -758,7 +759,7 @@ with socketserver.TCPServer(("", PORT), OIDCHandler) as httpd:
 			},
 			Spec: mcpv1alpha1.MCPServerSpec{
 				GroupRef:  mcpGroupName,
-				Image:     "ghcr.io/stackloklabs/gofetch/server:1.0.1",
+				Image:     images.GofetchServerImage,
 				Transport: "streamable-http",
 				ProxyPort: 8080,
 				McpPort:   8080,

--- a/test/e2e/thv-operator/virtualmcp/virtualmcp_conflict_resolution_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcp_conflict_resolution_test.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	mcpv1alpha1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1alpha1"
+	"github.com/stacklok/toolhive/test/e2e/images"
 )
 
 // Compile-time check to ensure corev1 is used (for Service type)
@@ -68,7 +69,7 @@ func setupConflictResolutionTest(setup conflictResolutionTestSetup) int32 {
 			},
 			Spec: mcpv1alpha1.MCPServerSpec{
 				GroupRef:  setup.groupName,
-				Image:     YardstickImage,
+				Image:     images.YardstickServerImage,
 				Transport: "streamable-http",
 				ProxyPort: 8080,
 				McpPort:   8080,

--- a/test/e2e/thv-operator/virtualmcp/virtualmcp_discovered_mode_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcp_discovered_mode_test.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	mcpv1alpha1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1alpha1"
+	"github.com/stacklok/toolhive/test/e2e/images"
 )
 
 var _ = Describe("VirtualMCPServer Discovered Mode", Ordered, func() {
@@ -67,7 +68,7 @@ var _ = Describe("VirtualMCPServer Discovered Mode", Ordered, func() {
 			},
 			Spec: mcpv1alpha1.MCPServerSpec{
 				GroupRef:  mcpGroupName,
-				Image:     "ghcr.io/stackloklabs/gofetch/server:1.0.1",
+				Image:     images.GofetchServerImage,
 				Transport: "streamable-http",
 				ProxyPort: 8080,
 				McpPort:   8080,
@@ -83,7 +84,7 @@ var _ = Describe("VirtualMCPServer Discovered Mode", Ordered, func() {
 			},
 			Spec: mcpv1alpha1.MCPServerSpec{
 				GroupRef:  mcpGroupName,
-				Image:     "ghcr.io/stackloklabs/osv-mcp/server:0.0.7",
+				Image:     images.OSVMCPServerImage,
 				Transport: "streamable-http",
 				ProxyPort: 8080,
 				McpPort:   8080,

--- a/test/e2e/thv-operator/virtualmcp/virtualmcp_inline_auth_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcp_inline_auth_test.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	mcpv1alpha1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1alpha1"
+	"github.com/stacklok/toolhive/test/e2e/images"
 )
 
 var _ = Describe("VirtualMCPServer Inline Auth with Anonymous Incoming", Ordered, func() {
@@ -65,7 +66,7 @@ var _ = Describe("VirtualMCPServer Inline Auth with Anonymous Incoming", Ordered
 			},
 			Spec: mcpv1alpha1.MCPServerSpec{
 				GroupRef:  mcpGroupName,
-				Image:     "ghcr.io/stackloklabs/gofetch/server:1.0.1",
+				Image:     images.GofetchServerImage,
 				Transport: "streamable-http",
 				ProxyPort: 8080,
 				McpPort:   8080,
@@ -285,7 +286,7 @@ var _ = Describe("VirtualMCPServer Inline Auth with OIDC Incoming", Ordered, fun
 			},
 			Spec: mcpv1alpha1.MCPServerSpec{
 				GroupRef:  mcpGroupName,
-				Image:     "ghcr.io/stackloklabs/gofetch/server:1.0.1",
+				Image:     images.GofetchServerImage,
 				Transport: "streamable-http",
 				ProxyPort: 8080,
 				McpPort:   8080,

--- a/test/e2e/thv-operator/virtualmcp/virtualmcp_yardstick_base_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcp_yardstick_base_test.go
@@ -14,13 +14,11 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	mcpv1alpha1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1alpha1"
+	"github.com/stacklok/toolhive/test/e2e/images"
 )
 
 // Compile-time check to ensure corev1 is used (for Service type)
 var _ = corev1.ServiceSpec{}
-
-// YardstickImage is the container image for the yardstick MCP server
-const YardstickImage = "ghcr.io/stackloklabs/yardstick/yardstick-server:0.0.2"
 
 var _ = Describe("VirtualMCPServer Yardstick Base", Ordered, func() {
 	var (
@@ -71,7 +69,7 @@ var _ = Describe("VirtualMCPServer Yardstick Base", Ordered, func() {
 			},
 			Spec: mcpv1alpha1.MCPServerSpec{
 				GroupRef:  mcpGroupName,
-				Image:     YardstickImage,
+				Image:     images.YardstickServerImage,
 				Transport: "streamable-http",
 				ProxyPort: 8080,
 				McpPort:   8080,
@@ -90,7 +88,7 @@ var _ = Describe("VirtualMCPServer Yardstick Base", Ordered, func() {
 			},
 			Spec: mcpv1alpha1.MCPServerSpec{
 				GroupRef:  mcpGroupName,
-				Image:     YardstickImage,
+				Image:     images.YardstickServerImage,
 				Transport: "streamable-http",
 				ProxyPort: 8080,
 				McpPort:   8080,


### PR DESCRIPTION
Create a dedicated package for container image constants used across e2e tests to provide a single source of truth for image versions.

Each image is now defined with three constants:
- imageURL: base image path (unexported)
- imageTag: version tag (unexported)
- Image: combined reference (exported)

This structure makes version updates simpler by allowing changes to only the tag constant while keeping the base URL unchanged.

Updated test files:
- test/e2e/telemetry_metrics_validation_e2e_test.go
- test/e2e/thv-operator/virtualmcp/helpers.go
- test/e2e/thv-operator/virtualmcp/virtualmcp_aggregation_filtering_test.go
- test/e2e/thv-operator/virtualmcp/virtualmcp_auth_discovery_test.go
- test/e2e/thv-operator/virtualmcp/virtualmcp_conflict_resolution_test.go
- test/e2e/thv-operator/virtualmcp/virtualmcp_discovered_mode_test.go
- test/e2e/thv-operator/virtualmcp/virtualmcp_inline_auth_test.go
- test/e2e/thv-operator/virtualmcp/virtualmcp_yardstick_base_test.go

Fixes #2786