### PR TITLE
Make client_id optional in vMCP OIDC config

### DIFF
--- a/pkg/vmcp/config/validator.go
+++ b/pkg/vmcp/config/validator.go
@@ -94,13 +94,14 @@ func (v *DefaultValidator) validateIncomingAuth(auth *IncomingAuthConfig) error 
 			return fmt.Errorf("incoming_auth.oidc.issuer is required")
 		}
 
-		if auth.OIDC.ClientID == "" {
-			return fmt.Errorf("incoming_auth.oidc.client_id is required")
-		}
-
 		if auth.OIDC.Audience == "" {
 			return fmt.Errorf("incoming_auth.oidc.audience is required")
 		}
+
+		// ClientID is optional - only required for specific flows:
+		// - Token introspection with client credentials
+		// - Some OAuth flows requiring client identification
+		// Not required for standard JWT validation using JWKS
 
 		// ClientSecretEnv is optional - some OIDC flows don't require client secrets:
 		// - PKCE flows (public clients)

--- a/pkg/vmcp/config/validator_test.go
+++ b/pkg/vmcp/config/validator_test.go
@@ -141,6 +141,17 @@ func TestValidator_ValidateIncomingAuth(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "valid OIDC auth without client_id (JWT validation only)",
+			auth: &IncomingAuthConfig{
+				Type: "oidc",
+				OIDC: &OIDCConfig{
+					Issuer:   "https://example.com",
+					Audience: "vmcp",
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name: "invalid auth type",
 			auth: &IncomingAuthConfig{
 				Type: "invalid",


### PR DESCRIPTION
client_id is only required for specific flows like token introspection with client credentials. For standard JWT validation using JWKS, only issuer and audience are needed.

This follows the same pattern as the previous change that made client_secret_env optional (d543c842).