### PR TITLE
Add Debug Logs for thv run Server Location

### DIFF
--- a/cmd/thv/app/run_flags.go
+++ b/cmd/thv/app/run_flags.go
@@ -284,10 +284,6 @@ func BuildRunnerConfig(
 		return nil, err
 	}
 
-	if serverMetadata != nil && serverMetadata.IsRemote() {
-		logger.Debugf("Attemtpting to run remote MCP server: %s", serverMetadata.GetName())
-	}
-
 	// Validate and setup proxy mode
 	if err := validateAndSetupProxyMode(runFlags); err != nil {
 		return nil, err

--- a/pkg/runner/retriever/retriever.go
+++ b/pkg/runner/retriever/retriever.go
@@ -59,7 +59,7 @@ func GetMCPServer(
 			return "", nil, err
 		}
 	} else {
-		logger.Debugf("No protocol scheme detected, attempting to retrieve remote server or registry server: %s", serverOrImage)
+		logger.Debugf("No protocol scheme detected, attempting to retrieve image or registry server: %s", serverOrImage)
 
 		// If group name is provided, look up server in the group first
 		if groupName != "" {


### PR DESCRIPTION
### Summary

Add debug logs that differentiate which type of MCP server we're attempting to run.

Fixes #2761 


### Implementation Details
The linked issue gestures towards an ideal solution where we have one log per type of MCP server. The existing code branches in quite a few places (e.g. there are two different paths for differentiating between remote and registry MCP servers). Instead of adding logging to these cases exhaustively, I opted to make an incremental improvement in the debug logs. 

I'd prefer to consolidate the existing code into fewer branches before adding more logs, but if someone feels strongly LMK and I can accommodate.

### Testing 

I verified the new logs appear locally by running `task build` and then a series of `bin/thv run --debug` commands. Output pictured below:
<img width="763" height="16" alt="Screenshot 2025-12-01 at 5 21 47 PM" src="https://github.com/user-attachments/assets/5270c47f-892f-4ed6-8ec7-22b5911488a5" />
<img width="549" height="15" alt="Screenshot 2025-12-01 at 5 24 22 PM" src="https://github.com/user-attachments/assets/6240dd17-195d-49b6-a202-e5a176433080" />
