### PR TITLE
Use gopkg.in/yaml.v3 not v2

### DIFF
--- a/cmd/thv-operator/pkg/registryapi/config/config.go
+++ b/cmd/thv-operator/pkg/registryapi/config/config.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/go.mod
+++ b/go.mod
@@ -54,7 +54,6 @@ require (
 	golang.org/x/sync v0.18.0
 	golang.org/x/term v0.37.0
 	golang.org/x/time v0.14.0
-	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.34.2
 	k8s.io/apimachinery v0.34.2
@@ -289,6 +288,7 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gotest.tools/v3 v3.5.2 // indirect
 	k8s.io/apiextensions-apiserver v0.34.1 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect


### PR DESCRIPTION
A change slipped using the older version. This fixes that.

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>
