### PR TITLE
Display custom metadata in registry info text output

### DIFF
--- a/cmd/thv/app/registry.go
+++ b/cmd/thv/app/registry.go
@@ -340,6 +340,14 @@ func printTextServerInfo(name string, server types.ServerMetadata) {
 		fmt.Printf("  %s\n", strings.Join(tags, ", "))
 	}
 
+	// Print custom metadata
+	if customMetadata := server.GetCustomMetadata(); len(customMetadata) > 0 {
+		fmt.Println("\nCustom Metadata:")
+		for key, value := range customMetadata {
+			fmt.Printf("  %s: %v\n", key, value)
+		}
+	}
+
 	// Print example command
 	fmt.Println("\nExample Command:")
 	fmt.Printf("  thv run %s\n", name)


### PR DESCRIPTION
## Summary
- Add display of `custom_metadata` field in text format output for `thv registry info <server>` command
- Custom metadata was previously only shown when using `--format json`
- Adds a "Custom Metadata:" section after Tags in the text output

## Test plan
- [x] Build passes
- [x] Lint passes
- [x] Unit tests pass
- [x] Manually tested with `thv registry info atlassian-remote` which shows custom metadata

## Example output
```
Tags:
  remote, atlassian, jira, confluence, compass, oauth, project-management, collaboration, documentation, beta

Custom Metadata:
  author: Atlassian
  homepage: https://www.atlassian.com/platform/remote-mcp-server

Example Command:
  thv run atlassian-remote
```

Fixes #1934

🤖 Generated with [Claude Code](https://claude.com/claude-code)