### PR TITLE
Change pinging logic for remote workloads

### DIFF
--- a/pkg/transport/http.go
+++ b/pkg/transport/http.go
@@ -205,7 +205,7 @@ func (t *HTTPTransport) Start(ctx context.Context) error {
 		targetURI,
 		t.prometheusHandler,
 		t.authInfoHandler,
-		t.remoteURL == "",
+		true,
 		t.remoteURL != "",
 		string(t.transportType),
 		middlewares...)

--- a/pkg/transport/proxy/transparent/pinger.go
+++ b/pkg/transport/proxy/transparent/pinger.go
@@ -51,10 +51,12 @@ func (p *MCPPinger) Ping(ctx context.Context) (time.Duration, error) {
 
 	duration := time.Since(start)
 
-	// For SSE servers, we expect various responses:
+	// For Streamable HTTP servers, we expect various responses:
 	// - 200 OK for root endpoints
 	// - 404 for non-existent endpoints (but server is still alive)
+	// - 401 for remote workloads (we may not be able to authenticate, but this response indicates the server is alive).
 	// - Other 4xx/5xx may indicate server issues
+	// For now, we accept any non 50x response for both local and remote.
 	if resp.StatusCode >= 200 && resp.StatusCode < 500 {
 		logger.Debugf("SSE server health check successful in %v (status: %d)", duration, resp.StatusCode)
 		return duration, nil

--- a/pkg/transport/proxy/transparent/transparent_proxy.go
+++ b/pkg/transport/proxy/transparent/transparent_proxy.go
@@ -108,8 +108,6 @@ func NewTransparentProxy(
 	}
 
 	// Create health checker always for Kubernetes probes
-	// For remote proxies, pass nil pinger since we can't ping authenticated servers
-	// For local proxies, create pinger to check MCP server status
 	var mcpPinger healthcheck.MCPPinger
 	if enableHealthCheck {
 		mcpPinger = NewMCPPinger(targetURI)


### PR DESCRIPTION
Previously, we did not include the pinger for remote workloads. The assumption was that we may not be able to authenticate while pinging the remote, so we would not get the expected status. There were two issues which arose:

- It turns out the pinger accepts any non 50x, so we do not need to worry about 401.
- By excluding the pinger from the remote workload, we lack the ability to test basic connectivity to the remote workload. This has led to some reported issues where network connectivity is lost, and ToolHive is not aware that there is a problem.

This PR adds the pinger to the remote workload. In future, we may want to be more selective - for example, only allow 401s for remote workloads.