### PR TITLE
Return error when custom registry is unreachable

### DIFF
--- a/pkg/registry/provider_remote.go
+++ b/pkg/registry/provider_remote.go
@@ -17,8 +17,9 @@ type RemoteRegistryProvider struct {
 	allowPrivateIp bool
 }
 
-// NewRemoteRegistryProvider creates a new remote registry provider
-func NewRemoteRegistryProvider(registryURL string, allowPrivateIp bool) *RemoteRegistryProvider {
+// NewRemoteRegistryProvider creates a new remote registry provider.
+// Validates the registry is reachable before returning.
+func NewRemoteRegistryProvider(registryURL string, allowPrivateIp bool) (*RemoteRegistryProvider, error) {
 	p := &RemoteRegistryProvider{
 		registryURL:    registryURL,
 		allowPrivateIp: allowPrivateIp,
@@ -27,7 +28,12 @@ func NewRemoteRegistryProvider(registryURL string, allowPrivateIp bool) *RemoteR
 	// Initialize the base provider with the GetRegistry function
 	p.BaseProvider = NewBaseProvider(p.GetRegistry)
 
-	return p
+	// Validate the registry is reachable
+	if _, err := p.GetRegistry(); err != nil {
+		return nil, err
+	}
+
+	return p, nil
 }
 
 // GetRegistry returns the remote registry data


### PR DESCRIPTION
## Summary

- Return an error when a custom registry is configured but unreachable, instead of silently falling back to the default registry
- Add validation at creation time for `RemoteRegistryProvider` to ensure the registry is reachable
- Update tests to verify the new error behavior

Fixes #2764

## Test plan

- [x] Unit tests pass (`task test`)
- [x] Linting passes (`task lint`)
- [x] Manual testing: Set unreachable custom registry with `thv config set-registry https://non-existent.example.com/registry.json` and verify `thv registry list` and `thv run <server>` return errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)