### PR TITLE
Fix flaky vMCP E2E tests with proper readiness checks

### DIFF
--- a/test/e2e/thv-operator/virtualmcp/virtualmcp_aggregation_filtering_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcp_aggregation_filtering_test.go
@@ -75,11 +75,8 @@ var _ = Describe("VirtualMCPServer Aggregation Filtering", Ordered, func() {
 		}
 		Expect(k8sClient.Create(ctx, vmcpServer)).To(Succeed())
 
-		By("Waiting for VirtualMCPServer to be ready")
-		WaitForVirtualMCPServerReady(ctx, k8sClient, vmcpServerName, testNamespace, timeout)
-
-		By("Getting NodePort for VirtualMCPServer")
-		vmcpNodePort = GetVMCPNodePort(ctx, k8sClient, vmcpServerName, testNamespace, timeout, pollingInterval)
+		By("Waiting for VirtualMCPServer to be fully ready (CR, pods, and health)")
+		vmcpNodePort = WaitForVMCPFullyReady(ctx, k8sClient, vmcpServerName, testNamespace, timeout, pollingInterval)
 
 		By(fmt.Sprintf("VirtualMCPServer accessible at http://localhost:%d", vmcpNodePort))
 	})

--- a/test/e2e/thv-operator/virtualmcp/virtualmcp_aggregation_overrides_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcp_aggregation_overrides_test.go
@@ -75,11 +75,8 @@ var _ = Describe("VirtualMCPServer Tool Overrides", Ordered, func() {
 		}
 		Expect(k8sClient.Create(ctx, vmcpServer)).To(Succeed())
 
-		By("Waiting for VirtualMCPServer to be ready")
-		WaitForVirtualMCPServerReady(ctx, k8sClient, vmcpServerName, testNamespace, timeout)
-
-		By("Getting NodePort for VirtualMCPServer")
-		vmcpNodePort = GetVMCPNodePort(ctx, k8sClient, vmcpServerName, testNamespace, timeout, pollingInterval)
+		By("Waiting for VirtualMCPServer to be fully ready (CR, pods, and health)")
+		vmcpNodePort = WaitForVMCPFullyReady(ctx, k8sClient, vmcpServerName, testNamespace, timeout, pollingInterval)
 
 		By(fmt.Sprintf("VirtualMCPServer accessible at http://localhost:%d", vmcpNodePort))
 	})

--- a/test/e2e/thv-operator/virtualmcp/virtualmcp_composite_parallel_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcp_composite_parallel_test.go
@@ -122,11 +122,8 @@ var _ = Describe("VirtualMCPServer Composite Parallel Workflow", Ordered, func()
 		}
 		Expect(k8sClient.Create(ctx, vmcpServer)).To(Succeed())
 
-		By("Waiting for VirtualMCPServer to be ready")
-		WaitForVirtualMCPServerReady(ctx, k8sClient, vmcpServerName, testNamespace, timeout)
-
-		By("Getting NodePort for VirtualMCPServer")
-		vmcpNodePort = GetVMCPNodePort(ctx, k8sClient, vmcpServerName, testNamespace, timeout, pollingInterval)
+		By("Waiting for VirtualMCPServer to be fully ready (CR, pods, and health)")
+		vmcpNodePort = WaitForVMCPFullyReady(ctx, k8sClient, vmcpServerName, testNamespace, timeout, pollingInterval)
 
 		By(fmt.Sprintf("VirtualMCPServer accessible at http://localhost:%d", vmcpNodePort))
 	})

--- a/test/e2e/thv-operator/virtualmcp/virtualmcp_composite_sequential_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcp_composite_sequential_test.go
@@ -107,11 +107,8 @@ var _ = Describe("VirtualMCPServer Composite Sequential Workflow", Ordered, func
 		}
 		Expect(k8sClient.Create(ctx, vmcpServer)).To(Succeed())
 
-		By("Waiting for VirtualMCPServer to be ready")
-		WaitForVirtualMCPServerReady(ctx, k8sClient, vmcpServerName, testNamespace, timeout)
-
-		By("Getting NodePort for VirtualMCPServer")
-		vmcpNodePort = GetVMCPNodePort(ctx, k8sClient, vmcpServerName, testNamespace, timeout, pollingInterval)
+		By("Waiting for VirtualMCPServer to be fully ready (CR, pods, and health)")
+		vmcpNodePort = WaitForVMCPFullyReady(ctx, k8sClient, vmcpServerName, testNamespace, timeout, pollingInterval)
 
 		By(fmt.Sprintf("VirtualMCPServer accessible at http://localhost:%d", vmcpNodePort))
 	})

--- a/test/e2e/thv-operator/virtualmcp/virtualmcp_conflict_resolution_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcp_conflict_resolution_test.go
@@ -60,11 +60,8 @@ func setupConflictResolutionTest(setup conflictResolutionTestSetup) int32 {
 	}
 	Expect(k8sClient.Create(ctx, vmcpServer)).To(Succeed())
 
-	By("Waiting for VirtualMCPServer to be ready")
-	WaitForVirtualMCPServerReady(ctx, k8sClient, setup.vmcpName, setup.namespace, setup.timeout)
-
-	By("Getting NodePort for VirtualMCPServer")
-	vmcpNodePort := GetVMCPNodePort(ctx, k8sClient, setup.vmcpName, setup.namespace, setup.timeout, setup.pollingInterval)
+	By("Waiting for VirtualMCPServer to be fully ready (CR, pods, and health)")
+	vmcpNodePort := WaitForVMCPFullyReady(ctx, k8sClient, setup.vmcpName, setup.namespace, setup.timeout, setup.pollingInterval)
 
 	By(fmt.Sprintf("VirtualMCPServer accessible at http://localhost:%d", vmcpNodePort))
 	return vmcpNodePort

--- a/test/e2e/thv-operator/virtualmcp/virtualmcp_discovered_mode_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcp_discovered_mode_test.go
@@ -128,11 +128,8 @@ var _ = Describe("VirtualMCPServer Discovered Mode", Ordered, func() {
 		}
 		Expect(k8sClient.Create(ctx, vmcpServer)).To(Succeed())
 
-		By("Waiting for VirtualMCPServer to be ready")
-		WaitForVirtualMCPServerReady(ctx, k8sClient, vmcpServerName, testNamespace, timeout)
-
-		By("Getting NodePort for VirtualMCPServer")
-		vmcpNodePort = GetVMCPNodePort(ctx, k8sClient, vmcpServerName, testNamespace, timeout, pollingInterval)
+		By("Waiting for VirtualMCPServer to be fully ready (CR, pods, and health)")
+		vmcpNodePort = WaitForVMCPFullyReady(ctx, k8sClient, vmcpServerName, testNamespace, timeout, pollingInterval)
 
 		By(fmt.Sprintf("VirtualMCPServer accessible at http://localhost:%d", vmcpNodePort))
 		By("Backend servers use ClusterIP and are accessed through VirtualMCPServer")

--- a/test/e2e/thv-operator/virtualmcp/virtualmcp_inline_auth_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcp_inline_auth_test.go
@@ -88,11 +88,8 @@ var _ = Describe("VirtualMCPServer Inline Auth with Anonymous Incoming", Ordered
 		}
 		Expect(k8sClient.Create(ctx, vmcpServer)).To(Succeed())
 
-		By("Waiting for VirtualMCPServer to be ready")
-		WaitForVirtualMCPServerReady(ctx, k8sClient, vmcpServerName, testNamespace, timeout)
-
-		By("Getting NodePort for VirtualMCPServer")
-		vmcpNodePort = GetVMCPNodePort(ctx, k8sClient, vmcpServerName, testNamespace, timeout, pollingInterval)
+		By("Waiting for VirtualMCPServer to be fully ready (CR, pods, and health)")
+		vmcpNodePort = WaitForVMCPFullyReady(ctx, k8sClient, vmcpServerName, testNamespace, timeout, pollingInterval)
 	})
 
 	AfterAll(func() {
@@ -283,11 +280,8 @@ var _ = Describe("VirtualMCPServer Inline Auth with OIDC Incoming", Ordered, fun
 		}
 		Expect(k8sClient.Create(ctx, vmcpServer)).To(Succeed())
 
-		By("Waiting for VirtualMCPServer to be ready")
-		WaitForVirtualMCPServerReady(ctx, k8sClient, vmcpServerName, testNamespace, timeout)
-
-		By("Getting NodePort for VirtualMCPServer")
-		vmcpNodePort = GetVMCPNodePort(ctx, k8sClient, vmcpServerName, testNamespace, timeout, pollingInterval)
+		By("Waiting for VirtualMCPServer to be fully ready (CR, pods, and health)")
+		vmcpNodePort = WaitForVMCPFullyReady(ctx, k8sClient, vmcpServerName, testNamespace, timeout, pollingInterval)
 	})
 
 	AfterAll(func() {

--- a/test/e2e/thv-operator/virtualmcp/virtualmcp_yardstick_base_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcp_yardstick_base_test.go
@@ -62,11 +62,8 @@ var _ = Describe("VirtualMCPServer Yardstick Base", Ordered, func() {
 		}
 		Expect(k8sClient.Create(ctx, vmcpServer)).To(Succeed())
 
-		By("Waiting for VirtualMCPServer to be ready")
-		WaitForVirtualMCPServerReady(ctx, k8sClient, vmcpServerName, testNamespace, timeout)
-
-		By("Getting NodePort for VirtualMCPServer")
-		vmcpNodePort = GetVMCPNodePort(ctx, k8sClient, vmcpServerName, testNamespace, timeout, pollingInterval)
+		By("Waiting for VirtualMCPServer to be fully ready (CR, pods, and health)")
+		vmcpNodePort = WaitForVMCPFullyReady(ctx, k8sClient, vmcpServerName, testNamespace, timeout, pollingInterval)
 
 		By(fmt.Sprintf("VirtualMCPServer accessible at http://localhost:%d", vmcpNodePort))
 	})


### PR DESCRIPTION
## Summary
- Fix intermittent EOF errors in VirtualMCPServer E2E tests by adding proper readiness checks
- Add `WaitForVMCPHealthy` helper to poll `/health` endpoint until server responds
- Add `WaitForVMCPFullyReady` helper that combines all readiness checks (CR ready + pods ready + health check)
- Update 8 test files to use the new comprehensive readiness helper

## Problem
The `VirtualMCPServer Inline Auth with Anonymous Incoming` test (and potentially others) was failing intermittently with:
```
transport error: failed to send request: Post "http://localhost:30016/mcp": EOF
```

This happened because there's a timing gap between when the Kubernetes operator marks the VirtualMCPServer CR as Ready and when the actual HTTP server inside the pod is fully initialized and ready to handle requests.

## Solution
Added a comprehensive readiness check sequence:
1. Wait for VirtualMCPServer CRD to reach Ready status
2. Wait for all vMCP pods to be running and containers ready  
3. Poll the `/health` endpoint until the server responds successfully

This ensures the vMCP server is truly ready before tests attempt to make MCP requests.

## Test plan
- [x] Code compiles successfully
- [x] Linting passes with 0 issues
- [ ] CI E2E tests pass (this PR should fix the flaky failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)