### PR TITLE
Fix VirtualMCPServer controller to check PodReady condition

### DIFF
--- a/cmd/thv-operator/controllers/virtualmcpserver_controller.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_controller.go
@@ -1019,14 +1019,17 @@ func (*VirtualMCPServerReconciler) determineStatusFromBackends(
 	}
 }
 
-// determineStatusFromPods determines the appropriate status based on pod states
+// determineStatusFromPods determines the appropriate status based on pod states.
+// The 'ready' parameter counts pods that have passed their readiness probes (PodReady condition is True),
+// not just pods in Running phase. This ensures the VirtualMCPServer is only marked Ready when
+// the underlying pods are actually ready to serve traffic.
 func (r *VirtualMCPServerReconciler) determineStatusFromPods(
 	ctx context.Context,
 	vmcp *mcpv1alpha1.VirtualMCPServer,
-	running, pending, failed int,
+	ready, pending, failed int,
 ) statusDecision {
-	// Handle non-running states first (early returns reduce nesting)
-	if running == 0 {
+	// Handle non-ready states first (early returns reduce nesting)
+	if ready == 0 {
 		if failed > 0 {
 			return statusDecision{
 				phase:          mcpv1alpha1.VirtualMCPServerPhaseFailed,
@@ -1050,9 +1053,9 @@ func (r *VirtualMCPServerReconciler) determineStatusFromPods(
 		}
 	}
 
-	// Pods are running - check backend health if backends exist
+	// Pods are ready (passed readiness probes) - check backend health if backends exist
 	if len(vmcp.Status.DiscoveredBackends) == 0 {
-		// No backends discovered yet - pods running is sufficient for Ready
+		// No backends discovered yet - pods ready is sufficient for Ready
 		return statusDecision{
 			phase:          mcpv1alpha1.VirtualMCPServerPhaseReady,
 			message:        "Virtual MCP server is running",
@@ -1081,25 +1084,37 @@ func (r *VirtualMCPServerReconciler) updateVirtualMCPServerStatus(
 		return err
 	}
 
-	// Count pod states
-	var running, pending, failed int
+	// Count pod states based on actual readiness, not just phase.
+	// A pod in Running phase may not be ready to serve traffic if it hasn't
+	// passed its readiness probe yet. We must check the PodReady condition.
+	var ready, pending, failed int
 	for _, pod := range podList.Items {
-		switch pod.Status.Phase {
-		case corev1.PodRunning:
-			running++
-		case corev1.PodPending:
-			pending++
-		case corev1.PodFailed:
+		// Check for terminal failure states first
+		if pod.Status.Phase == corev1.PodFailed {
 			failed++
-		case corev1.PodSucceeded:
-			running++
-		case corev1.PodUnknown:
+			continue
+		}
+
+		// Check if pod is actually ready to serve traffic (passed readiness probes)
+		// This is the authoritative signal that the pod can handle requests
+		isPodReady := false
+		for _, condition := range pod.Status.Conditions {
+			if condition.Type == corev1.PodReady && condition.Status == corev1.ConditionTrue {
+				isPodReady = true
+				break
+			}
+		}
+
+		if isPodReady {
+			ready++
+		} else {
+			// Pod exists but isn't ready yet (still starting, or readiness probe failing)
 			pending++
 		}
 	}
 
 	// Determine status in one place (no branching/repetition)
-	decision := r.determineStatusFromPods(ctx, vmcp, running, pending, failed)
+	decision := r.determineStatusFromPods(ctx, vmcp, ready, pending, failed)
 
 	// Apply all status updates at once
 	statusManager.SetPhase(decision.phase)


### PR DESCRIPTION
## Summary

- Fix VirtualMCPServer controller to check `PodReady` condition instead of `PodRunning` phase
- This ensures the CR is only marked Ready when pods have actually passed their readiness probes
- Fixes flaky E2E tests caused by race condition between CR status and actual server readiness

## Problem

The VirtualMCPServer controller was marking the CR as Ready based on `pod.Status.Phase == PodRunning`, but this doesn't guarantee the pod is actually ready to serve traffic. A pod can be in Running phase while still waiting for its readiness probe to pass.

This caused flaky E2E tests where:
1. Pod starts → Phase becomes `Running`
2. Controller sees `Running` → marks CR as `Ready`  
3. Test sees CR `Ready` → tries to connect
4. Pod hasn't passed readiness probe yet → EOF error

## Solution

Now the controller checks the `PodReady` condition in `pod.Status.Conditions`, which is the authoritative signal that a pod can receive traffic. This aligns with Kubernetes semantics.

| Pod State | Counted As | Result |
|-----------|------------|--------|
| `PodReady` condition = `True` | ready | Ready |
| `PodFailed` phase | failed | Failed |
| Everything else | pending | Pending |

## Test plan

- [x] Unit tests pass (`go test ./cmd/thv-operator/controllers/... -run VirtualMCPServer`)
- [x] Linting passes (`task lint`)
- [ ] E2E tests pass (CI will verify)

🤖 Generated with [Claude Code](https://claude.com/claude-code)