### PR TITLE
Disable failing vMCP test for k8s

### DIFF
--- a/test/e2e/thv-operator/virtualmcp/virtualmcp_inline_auth_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcp_inline_auth_test.go
@@ -3,7 +3,6 @@ package virtualmcp
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/mark3labs/mcp-go/client"
@@ -26,7 +25,7 @@ var _ = Describe("VirtualMCPServer Inline Auth with Anonymous Incoming", Ordered
 		backend1Name    = "backend-fetch-inline-anon"
 		timeout         = 5 * time.Minute
 		pollingInterval = 5 * time.Second
-		vmcpNodePort    int32
+		// vmcpNodePort    int32
 	)
 
 	BeforeAll(func() {
@@ -92,7 +91,7 @@ var _ = Describe("VirtualMCPServer Inline Auth with Anonymous Incoming", Ordered
 		WaitForVirtualMCPServerReady(ctx, k8sClient, vmcpServerName, testNamespace, timeout)
 
 		By("Getting NodePort for VirtualMCPServer")
-		vmcpNodePort = GetVMCPNodePort(ctx, k8sClient, vmcpServerName, testNamespace, timeout, pollingInterval)
+		// vmcpNodePort = GetVMCPNodePort(ctx, k8sClient, vmcpServerName, testNamespace, timeout, pollingInterval)
 	})
 
 	AfterAll(func() {
@@ -121,7 +120,8 @@ var _ = Describe("VirtualMCPServer Inline Auth with Anonymous Incoming", Ordered
 			Expect(vmcpServer.Spec.OutgoingAuth.Source).To(Equal("inline"))
 		})
 
-		It("should proxy tool calls with inline auth configuration", func() {
+		// Commented out due to failure. See https://github.com/stacklok/toolhive/issues/2918
+		/*It("should proxy tool calls with inline auth configuration", func() {
 			By("Creating MCP client with anonymous auth")
 			serverURL := fmt.Sprintf("http://localhost:%d/mcp", vmcpNodePort)
 			mcpClient, err := client.NewStreamableHttpClient(serverURL)
@@ -172,7 +172,7 @@ var _ = Describe("VirtualMCPServer Inline Auth with Anonymous Incoming", Ordered
 			Expect(result.Content).ToNot(BeEmpty())
 
 			GinkgoWriter.Printf("Anonymous auth with inline outgoing: tool call succeeded\n")
-		})
+		})*/
 	})
 })
 


### PR DESCRIPTION
Since this functionality is still under development, remove the test until either the test or the functionality is fixed.