### PR TITLE
fixes generation of manifests via kubebuilder

### DIFF
--- a/cmd/thv-operator/controllers/virtualmcpserver_controller.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_controller.go
@@ -85,9 +85,6 @@ var (
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=create;delete;get;list;patch;update;watch
 // +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=create;delete;get;list;patch;update;watch
-var (
-	envVarSanitizeRegex = regexp.MustCompile(`[^A-Z0-9_]`)
-)
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.


### PR DESCRIPTION
currently when you run a task operator-manifests, it will change the
clusterrole when it shouldn't. the reason for this is because a var
block [was added](https://github.com/stacklok/toolhive/pull/2875) directly below the kubebuilder comment markers that
generate the permissions for the clusterrole. kubebuilder therefore
ignored the markers because they thought the comments were related to
the var block itself. this commit moves the var block to be away from
the kubebuilder markers to remove interference