### PR TITLE
Add vulnerability exclusion support to govulncheck workflow

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -72,3 +72,50 @@ jobs:
           go-version-file: go.mod
           go-package: ./...
           repo-checkout: false
+          output-format: json
+          output-file: govulncheck-output.json
+
+      - name: Check for vulnerabilities (with exclusions)
+        run: |
+          # Ignored vulnerabilities with justification:
+          # GO-2025-4192: sigstore/timestamp-authority excessive memory allocation (CVE-2025-66564)
+          #   Indirect dependency via sigstore-go (used for container signature verification).
+          #   The vulnerability affects timestamp-authority server request parsing endpoints.
+          #   ToolHive only uses sigstore-go as a client to verify signatures, it does not
+          #   expose any timestamp-authority server endpoints. Fix requires sigstore-go to
+          #   upgrade to timestamp-authority/v2 which hasn't been released yet.
+          IGNORED_VULNS="GO-2025-4192"
+
+          # Show the raw output for debugging
+          echo "::group::govulncheck raw output"
+          cat govulncheck-output.json
+          echo "::endgroup::"
+
+          # Extract vulnerability IDs that have actual findings (called symbols)
+          # The JSON has "finding" objects with "osv" field only for vulnerabilities
+          # where vulnerable code paths are actually called
+          FOUND_VULNS=$(jq -r 'select(.finding != null) | .finding.osv' govulncheck-output.json | sort -u | grep -E '^GO-' || true)
+
+          if [ -z "$FOUND_VULNS" ]; then
+            echo "✅ No vulnerabilities found"
+            exit 0
+          fi
+
+          echo "Found vulnerabilities: $FOUND_VULNS"
+
+          # Check if all found vulnerabilities are in the ignore list
+          UNIGNORED=""
+          for vuln in $FOUND_VULNS; do
+            if ! echo "$IGNORED_VULNS" | grep -qw "$vuln"; then
+              UNIGNORED="$UNIGNORED $vuln"
+            fi
+          done
+          UNIGNORED=$(echo "$UNIGNORED" | xargs)
+
+          if [ -z "$UNIGNORED" ]; then
+            echo "⚠️  All vulnerabilities are ignored: $FOUND_VULNS"
+            exit 0
+          fi
+
+          echo "❌ Vulnerabilities need attention: $UNIGNORED"
+          exit 1


### PR DESCRIPTION
Add a post-processing step to the govulncheck GitHub Action that allows excluding specific vulnerabilities with documented justification.

The govulncheck tool does not currently support excluding vulnerabilities via config file or flag. This feature is tracked in golang/go#61211. Until that is implemented, we use a post-processing approach similar to GitLab's Gitaly project.

Exclude GO-2025-4192 (CVE-2025-66564): sigstore/timestamp-authority excessive memory allocation vulnerability. This is an indirect dependency via sigstore-go used for container signature verification. The vulnerability affects timestamp-authority server request parsing, but ToolHive only uses sigstore-go as a client - it does not expose any timestamp-authority server endpoints.