### PR TITLE
fix: set ObservedGeneration in all validateCOmpositeToolsRefs paths

### DIFF
--- a/cmd/thv-operator/controllers/virtualmcpserver_controller.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_controller.go
@@ -299,6 +299,7 @@ func (r *VirtualMCPServerReconciler) validateCompositeToolRefs(
 	// If no composite tool refs, nothing to validate
 	if len(vmcp.Spec.CompositeToolRefs) == 0 {
 		// Set condition to indicate validation passed (no refs to validate)
+		statusManager.SetObservedGeneration(vmcp.Generation)
 		statusManager.SetCompositeToolRefsValidatedCondition(
 			mcpv1alpha1.ConditionReasonCompositeToolRefsValid,
 			"No composite tool references to validate",
@@ -317,6 +318,7 @@ func (r *VirtualMCPServerReconciler) validateCompositeToolRefs(
 
 		if errors.IsNotFound(err) {
 			message := fmt.Sprintf("Referenced VirtualMCPCompositeToolDefinition %s not found", ref.Name)
+			statusManager.SetObservedGeneration(vmcp.Generation)
 			statusManager.SetPhase(mcpv1alpha1.VirtualMCPServerPhaseFailed)
 			statusManager.SetMessage(message)
 			statusManager.SetCompositeToolRefsValidatedCondition(
@@ -336,6 +338,7 @@ func (r *VirtualMCPServerReconciler) validateCompositeToolRefs(
 			if len(compositeToolDef.Status.ValidationErrors) > 0 {
 				message = fmt.Sprintf("%s: %s", message, strings.Join(compositeToolDef.Status.ValidationErrors, "; "))
 			}
+			statusManager.SetObservedGeneration(vmcp.Generation)
 			statusManager.SetPhase(mcpv1alpha1.VirtualMCPServerPhaseFailed)
 			statusManager.SetMessage(message)
 			statusManager.SetCompositeToolRefsValidatedCondition(
@@ -355,6 +358,7 @@ func (r *VirtualMCPServerReconciler) validateCompositeToolRefs(
 	}
 
 	// All composite tool refs are valid
+	statusManager.SetObservedGeneration(vmcp.Generation)
 	statusManager.SetCompositeToolRefsValidatedCondition(
 		mcpv1alpha1.ConditionReasonCompositeToolRefsValid,
 		fmt.Sprintf("All %d composite tool references are valid", len(vmcp.Spec.CompositeToolRefs)),


### PR DESCRIPTION
## Summary
Fixes missing `ObservedGeneration` calls in the `validateCompositeToolRefs` function.

Fixes #2948

## Problem
`validateCompositeToolRefs` was the only validation function in the VirtualMCPServer controller that didn't set `ObservedGeneration` in any of its exit paths. All other validation functions consistently set this field.

## Solution
Added `statusManager.SetObservedGeneration(vmcp.Generation)` to all 4 exit paths:
1. Empty refs (success)
2. Not found error
3. Invalid status error
4. All refs valid (success)

## Impact
Users can now properly track whether the controller has processed the current resource spec version when debugging composite tool reference reconciliation issues.