### PR TITLE
Wire scopes through VirtualMCPServer to auth middleware

### DIFF
--- a/cmd/thv-operator/pkg/vmcpconfig/converter.go
+++ b/cmd/thv-operator/pkg/vmcpconfig/converter.go
@@ -204,7 +204,7 @@ func mapResolvedOIDCToVmcpConfig(
 		Resource:                        resolved.ResourceURL,
 		ProtectedResourceAllowPrivateIP: resolved.JWKSAllowPrivateIP,
 		InsecureAllowHTTP:               resolved.InsecureAllowHTTP,
-		// Scopes are not currently in oidc.OIDCConfig - should be added later
+		Scopes:                          resolved.Scopes,
 	}
 
 	// Handle client secret - the deployment controller mounts secrets as environment variables

--- a/cmd/thv-operator/pkg/vmcpconfig/converter_test.go
+++ b/cmd/thv-operator/pkg/vmcpconfig/converter_test.go
@@ -1315,6 +1315,29 @@ func TestConverter_IncomingAuthRequired(t *testing.T) {
 			},
 			description: "Should correctly convert OIDC auth config",
 		},
+		{
+			name: "oidc auth with scopes",
+			incomingAuth: &mcpv1alpha1.IncomingAuthConfig{
+				Type: "oidc",
+				OIDCConfig: &mcpv1alpha1.OIDCConfigRef{
+					Type: "inline",
+					Inline: &mcpv1alpha1.InlineOIDCConfig{
+						Issuer:   "https://accounts.google.com",
+						ClientID: "google-client",
+						Audience: "google-audience",
+						Scopes:   []string{"https://www.googleapis.com/auth/drive.readonly", "openid"},
+					},
+				},
+			},
+			expectedAuthType: "oidc",
+			expectedOIDCConfig: &vmcpconfig.OIDCConfig{
+				Issuer:   "https://accounts.google.com",
+				ClientID: "google-client",
+				Audience: "google-audience",
+				Scopes:   []string{"https://www.googleapis.com/auth/drive.readonly", "openid"},
+			},
+			description: "Should correctly convert OIDC auth config with scopes",
+		},
 	}
 
 	for _, tt := range tests {
@@ -1342,6 +1365,7 @@ func TestConverter_IncomingAuthRequired(t *testing.T) {
 					Issuer:   tt.expectedOIDCConfig.Issuer,
 					ClientID: tt.expectedOIDCConfig.ClientID,
 					Audience: tt.expectedOIDCConfig.Audience,
+					Scopes:   tt.expectedOIDCConfig.Scopes,
 				}, nil)
 			} else {
 				mockResolver.EXPECT().Resolve(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
@@ -1365,6 +1389,7 @@ func TestConverter_IncomingAuthRequired(t *testing.T) {
 					assert.Equal(t, tt.expectedOIDCConfig.Issuer, config.IncomingAuth.OIDC.Issuer, tt.description)
 					assert.Equal(t, tt.expectedOIDCConfig.ClientID, config.IncomingAuth.OIDC.ClientID, tt.description)
 					assert.Equal(t, tt.expectedOIDCConfig.Audience, config.IncomingAuth.OIDC.Audience, tt.description)
+					assert.Equal(t, tt.expectedOIDCConfig.Scopes, config.IncomingAuth.OIDC.Scopes, tt.description)
 				} else {
 					assert.Nil(t, config.IncomingAuth.OIDC, tt.description)
 				}

--- a/deploy/charts/operator-crds/Chart.yaml
+++ b/deploy/charts/operator-crds/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: toolhive-operator-crds
 description: A Helm chart for installing the ToolHive Operator CRDs into Kubernetes.
 type: application
-version: 0.0.81
+version: 0.0.82
 appVersion: "0.0.1"

--- a/deploy/charts/operator-crds/README.md
+++ b/deploy/charts/operator-crds/README.md
@@ -1,6 +1,6 @@
 # ToolHive Operator CRDs Helm Chart
 
-![Version: 0.0.81](https://img.shields.io/badge/Version-0.0.81-informational?style=flat-square)
+![Version: 0.0.82](https://img.shields.io/badge/Version-0.0.82-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for installing the ToolHive Operator CRDs into Kubernetes.

--- a/pkg/vmcp/auth/factory/incoming.go
+++ b/pkg/vmcp/auth/factory/incoming.go
@@ -80,6 +80,7 @@ func newOIDCAuthMiddleware(
 		ResourceURL:       oidcCfg.Resource,
 		AllowPrivateIP:    oidcCfg.ProtectedResourceAllowPrivateIP,
 		InsecureAllowHTTP: oidcCfg.InsecureAllowHTTP,
+		Scopes:            oidcCfg.Scopes,
 	}
 
 	// pkg/auth.GetAuthenticationMiddleware now returns middleware that creates Identity


### PR DESCRIPTION
Complete the scopes support for VirtualMCPServer by wiring the Scopes
field through the vmcpconfig converter and auth factory:

- Map Scopes from oidc.OIDCConfig to vmcpconfig.OIDCConfig in converter
- Pass Scopes to TokenValidatorConfig in incoming auth factory
- Add test coverage for scopes in converter tests

This ensures scopes configured in VirtualMCPServer CRD are properly
advertised in the RFC 9728 well-known endpoint.

Fixes: #2783
