### PR TITLE
includes vmcp in the images to update for toolhive

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,7 +12,8 @@
       "matchDatasources": ["docker"],
       "matchPackageNames": [
         "ghcr.io/stacklok/toolhive/proxyrunner",
-        "ghcr.io/stacklok/toolhive/operator"
+        "ghcr.io/stacklok/toolhive/operator",
+        "ghcr.io/stacklok/toolhive/vmcp"
       ],
       "matchFileNames": ["deploy/charts/operator/**"]
     },


### PR DESCRIPTION
renovate doesn't bump vmcp when bumping the rest of toolhive images. this pr configures it so it does