### PR TITLE
Apply default MaxDataSize when config value is zero

### DIFF
--- a/pkg/audit/config.go
+++ b/pkg/audit/config.go
@@ -128,6 +128,11 @@ func GetMiddlewareFromFile(path string, transportType string) (func(http.Handler
 
 // Validate validates the audit configuration.
 func (c *Config) Validate() error {
+	// Apply default for MaxDataSize if not set (0 means use default)
+	if c.MaxDataSize == 0 {
+		c.MaxDataSize = DefaultConfig().MaxDataSize
+	}
+
 	if c.MaxDataSize < 0 {
 		return fmt.Errorf("max_data_size cannot be negative")
 	}

--- a/pkg/audit/config_test.go
+++ b/pkg/audit/config_test.go
@@ -129,6 +129,7 @@ func TestValidateValidConfig(t *testing.T) {
 
 	err := config.Validate()
 	assert.NoError(t, err)
+	assert.Equal(t, 2048, config.MaxDataSize, "MaxDataSize should be preserved when explicitly set")
 }
 
 func TestValidateNegativeMaxDataSize(t *testing.T) {
@@ -140,6 +141,18 @@ func TestValidateNegativeMaxDataSize(t *testing.T) {
 	err := config.Validate()
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "max_data_size cannot be negative")
+}
+
+func TestValidateAppliesDefaultMaxDataSize(t *testing.T) {
+	t.Parallel()
+	config := &Config{
+		MaxDataSize: 0, // Not set - should become default (1024) after validation
+	}
+
+	err := config.Validate()
+	assert.NoError(t, err)
+	assert.Equal(t, DefaultConfig().MaxDataSize, config.MaxDataSize,
+		"Validate() should apply default MaxDataSize when 0")
 }
 
 func TestValidateInvalidEventType(t *testing.T) {

--- a/pkg/audit/middleware.go
+++ b/pkg/audit/middleware.go
@@ -67,6 +67,11 @@ func CreateMiddleware(config *types.MiddlewareConfig, runner types.MiddlewareRun
 		auditConfig.Component = params.Component
 	}
 
+	// Validate and apply defaults to the config
+	if err := auditConfig.Validate(); err != nil {
+		return fmt.Errorf("invalid audit configuration: %w", err)
+	}
+
 	// Always use the transport-aware constructor
 	middleware, err := auditConfig.CreateMiddlewareWithTransport(params.TransportType)
 	if err != nil {


### PR DESCRIPTION
Related to PR #3060 where I forgot to set the audit max size, let's default to a sane value rather than the Go default value for the audit max size.

When max_data_size is not specified in the audit config, Go's zero value (0) was used directly. This caused the size check len(body) <= 0 to always fail for non-empty bodies, preventing data capture.

Changes:
- Validate() now applies the default value (1024) when MaxDataSize is 0
- CreateMiddleware() now calls Validate() to ensure defaults are applied
- Added test coverage for default application and value preservation