### PR TITLE
Add /status HTTP endpoint to vMCP server (#2998)

### DIFF
--- a/pkg/vmcp/server/server.go
+++ b/pkg/vmcp/server/server.go
@@ -63,6 +63,10 @@ type Config struct {
 	// Version is the server version
 	Version string
 
+	// GroupRef is the name of the MCPGroup containing backend workloads.
+	// Used for operational visibility in status endpoint and logging.
+	GroupRef string
+
 	// Host is the bind address (default: "127.0.0.1")
 	Host string
 
@@ -374,6 +378,7 @@ func (s *Server) Start(ctx context.Context) error {
 	// Unauthenticated health endpoints
 	mux.HandleFunc("/health", s.handleHealth)
 	mux.HandleFunc("/ping", s.handleHealth)
+	mux.HandleFunc("/status", s.handleStatus)
 
 	// Optional Prometheus metrics endpoint (unauthenticated)
 	if s.config.TelemetryProvider != nil {
@@ -460,7 +465,7 @@ func (s *Server) Start(ctx context.Context) error {
 
 	actualAddr := listener.Addr().String()
 	logger.Infof("Starting Virtual MCP Server at %s%s", actualAddr, s.config.EndpointPath)
-	logger.Infof("Health endpoints available at %s/health and %s/ping", actualAddr, actualAddr)
+	logger.Infof("Health endpoints available at %s/health, %s/ping, and %s/status", actualAddr, actualAddr, actualAddr)
 
 	// Start server in background
 	errCh := make(chan error, 1)

--- a/pkg/vmcp/server/status.go
+++ b/pkg/vmcp/server/status.go
@@ -1,0 +1,92 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/stacklok/toolhive/pkg/logger"
+	"github.com/stacklok/toolhive/pkg/versions"
+	"github.com/stacklok/toolhive/pkg/vmcp"
+	authtypes "github.com/stacklok/toolhive/pkg/vmcp/auth/types"
+)
+
+// StatusResponse represents the vMCP server's operational status.
+type StatusResponse struct {
+	Backends []BackendStatus `json:"backends"`
+	Healthy  bool            `json:"healthy"`
+	Version  string          `json:"version"`
+	GroupRef string          `json:"group_ref"`
+}
+
+// BackendStatus represents the status of a single backend MCP server.
+type BackendStatus struct {
+	Name      string `json:"name"`
+	Health    string `json:"health"`              // "healthy", "degraded", "unhealthy", "unknown"
+	Transport string `json:"transport"`           // MCP transport protocol
+	AuthType  string `json:"auth_type,omitempty"` // "unauthenticated", "header_injection", "token_exchange"
+}
+
+// handleStatus handles /status HTTP requests for operational visibility.
+//
+// Security Note: This endpoint is unauthenticated to support operator consumption
+// and debugging. It exposes operational metadata (backend names, auth types)
+// but NOT secrets, tokens, internal URLs, or request data. In sensitive multi-tenant
+// deployments, restrict access to this endpoint via network policies.
+//
+// For minimal health checking (load balancers), use /health instead.
+func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet && r.Method != http.MethodHead {
+		http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	response := s.buildStatusResponse()
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.Header().Set("Cache-Control", "no-store")
+	w.WriteHeader(http.StatusOK)
+
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		logger.Errorf("Failed to encode status response: %v", err)
+	}
+}
+
+// buildStatusResponse builds the StatusResponse from server state.
+func (s *Server) buildStatusResponse() StatusResponse {
+	backendStatuses := make([]BackendStatus, 0, len(s.backends))
+
+	hasHealthyBackend := false
+	for _, backend := range s.backends {
+		status := BackendStatus{
+			Name:      backend.Name,
+			Health:    string(backend.HealthStatus),
+			Transport: backend.TransportType,
+			AuthType:  getAuthType(backend.AuthConfig),
+		}
+		backendStatuses = append(backendStatuses, status)
+
+		if backend.HealthStatus == vmcp.BackendHealthy {
+			hasHealthyBackend = true
+		}
+	}
+
+	// Healthy = true if at least one backend is healthy AND there's at least one backend
+	healthy := len(s.backends) > 0 && hasHealthyBackend
+
+	return StatusResponse{
+		Backends: backendStatuses,
+		Healthy:  healthy,
+		Version:  versions.GetVersionInfo().Version,
+		GroupRef: s.config.GroupRef,
+	}
+}
+
+// getAuthType returns the auth type string from the backend auth strategy.
+// Returns "unauthenticated" if the config is nil.
+func getAuthType(cfg *authtypes.BackendAuthStrategy) string {
+	if cfg == nil {
+		return authtypes.StrategyTypeUnauthenticated
+	}
+	return cfg.Type
+}

--- a/pkg/vmcp/server/status_test.go
+++ b/pkg/vmcp/server/status_test.go
@@ -1,0 +1,240 @@
+package server_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/stacklok/toolhive/pkg/networking"
+	"github.com/stacklok/toolhive/pkg/vmcp"
+	"github.com/stacklok/toolhive/pkg/vmcp/aggregator"
+	authtypes "github.com/stacklok/toolhive/pkg/vmcp/auth/types"
+	discoveryMocks "github.com/stacklok/toolhive/pkg/vmcp/discovery/mocks"
+	"github.com/stacklok/toolhive/pkg/vmcp/mocks"
+	"github.com/stacklok/toolhive/pkg/vmcp/router"
+	"github.com/stacklok/toolhive/pkg/vmcp/server"
+)
+
+// StatusResponse mirrors the server's status response structure for test deserialization.
+type StatusResponse struct {
+	Backends []BackendStatus `json:"backends"`
+	Healthy  bool            `json:"healthy"`
+	Version  string          `json:"version"`
+	GroupRef string          `json:"group_ref"`
+}
+
+// BackendStatus mirrors the server's backend status structure for test deserialization.
+type BackendStatus struct {
+	Name      string `json:"name"`
+	Health    string `json:"health"`
+	Transport string `json:"transport"`
+	AuthType  string `json:"auth_type,omitempty"`
+}
+
+// createTestServerWithBackends creates a test server instance with custom backends.
+func createTestServerWithBackends(t *testing.T, backends []vmcp.Backend, groupRef string) *server.Server {
+	t.Helper()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	mockBackendClient := mocks.NewMockBackendClient(ctrl)
+	mockDiscoveryMgr := discoveryMocks.NewMockManager(ctrl)
+	rt := router.NewDefaultRouter()
+
+	port := networking.FindAvailable()
+	require.NotZero(t, port, "Failed to find available port")
+
+	mockDiscoveryMgr.EXPECT().
+		Discover(gomock.Any(), gomock.Any()).
+		Return(&aggregator.AggregatedCapabilities{
+			Tools:     []vmcp.Tool{},
+			Resources: []vmcp.Resource{},
+			Prompts:   []vmcp.Prompt{},
+			RoutingTable: &vmcp.RoutingTable{
+				Tools:     make(map[string]*vmcp.BackendTarget),
+				Resources: make(map[string]*vmcp.BackendTarget),
+				Prompts:   make(map[string]*vmcp.BackendTarget),
+			},
+			Metadata: &aggregator.AggregationMetadata{},
+		}, nil).
+		AnyTimes()
+	mockDiscoveryMgr.EXPECT().Stop().AnyTimes()
+
+	ctx, cancel := context.WithCancel(t.Context())
+
+	srv, err := server.New(ctx, &server.Config{
+		Name:     "test-vmcp",
+		Version:  "1.0.0",
+		Host:     "127.0.0.1",
+		Port:     port,
+		GroupRef: groupRef,
+	}, rt, mockBackendClient, mockDiscoveryMgr, backends, nil)
+	require.NoError(t, err)
+
+	t.Cleanup(cancel)
+	errCh := make(chan error, 1)
+	go func() {
+		if err := srv.Start(ctx); err != nil {
+			errCh <- err
+		}
+	}()
+
+	select {
+	case <-srv.Ready():
+	case err := <-errCh:
+		t.Fatalf("Server failed to start: %v", err)
+	case <-time.After(5 * time.Second):
+		t.Fatalf("Server did not become ready within 5s (address: %s)", srv.Address())
+	}
+
+	time.Sleep(10 * time.Millisecond)
+	return srv
+}
+
+func TestStatusEndpoint_HTTPBehavior(t *testing.T) {
+	t.Parallel()
+
+	t.Run("POST returns 405", func(t *testing.T) {
+		t.Parallel()
+		srv := createTestServerWithBackends(t, []vmcp.Backend{}, "")
+
+		resp, err := http.Post("http://"+srv.Address()+"/status", "application/json", nil)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusMethodNotAllowed, resp.StatusCode)
+	})
+
+	t.Run("GET returns 200 with correct Content-Type", func(t *testing.T) {
+		t.Parallel()
+		srv := createTestServerWithBackends(t, []vmcp.Backend{}, "")
+
+		resp, err := http.Get("http://" + srv.Address() + "/status")
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
+	})
+}
+
+func TestStatusEndpoint_HealthLogic(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		backends        []vmcp.Backend
+		expectedHealthy bool
+	}{
+		{"no backends", []vmcp.Backend{}, false},
+		{"single healthy", []vmcp.Backend{{ID: "b1", Name: "h", HealthStatus: vmcp.BackendHealthy}}, true},
+		{"single unhealthy", []vmcp.Backend{{ID: "b1", Name: "u", HealthStatus: vmcp.BackendUnhealthy}}, false},
+		{"mixed health", []vmcp.Backend{
+			{ID: "b1", Name: "h", HealthStatus: vmcp.BackendHealthy},
+			{ID: "b2", Name: "u", HealthStatus: vmcp.BackendUnhealthy},
+		}, true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			srv := createTestServerWithBackends(t, tc.backends, "")
+
+			resp, err := http.Get("http://" + srv.Address() + "/status")
+			require.NoError(t, err)
+			defer resp.Body.Close()
+
+			var status StatusResponse
+			require.NoError(t, json.NewDecoder(resp.Body).Decode(&status))
+
+			assert.Equal(t, tc.expectedHealthy, status.Healthy)
+			assert.Len(t, status.Backends, len(tc.backends))
+		})
+	}
+}
+
+func TestStatusEndpoint_AuthTypeMapping(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		authConfig *authtypes.BackendAuthStrategy
+		expected   string
+	}{
+		{"nil config", nil, authtypes.StrategyTypeUnauthenticated},
+		{"non-nil config", &authtypes.BackendAuthStrategy{Type: authtypes.StrategyTypeTokenExchange}, authtypes.StrategyTypeTokenExchange},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			backends := []vmcp.Backend{{
+				ID: "b1", Name: "test", HealthStatus: vmcp.BackendHealthy,
+				AuthConfig: tc.authConfig,
+			}}
+			srv := createTestServerWithBackends(t, backends, "")
+
+			resp, err := http.Get("http://" + srv.Address() + "/status")
+			require.NoError(t, err)
+			defer resp.Body.Close()
+
+			var status StatusResponse
+			require.NoError(t, json.NewDecoder(resp.Body).Decode(&status))
+
+			require.Len(t, status.Backends, 1)
+			assert.Equal(t, tc.expected, status.Backends[0].AuthType)
+		})
+	}
+}
+
+func TestStatusEndpoint_GroupRef(t *testing.T) {
+	t.Parallel()
+
+	srv := createTestServerWithBackends(t, []vmcp.Backend{}, "namespace/my-group")
+
+	resp, err := http.Get("http://" + srv.Address() + "/status")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	var status StatusResponse
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&status))
+	assert.Equal(t, "namespace/my-group", status.GroupRef)
+}
+
+func TestStatusEndpoint_BackendFieldMapping(t *testing.T) {
+	t.Parallel()
+
+	backends := []vmcp.Backend{{
+		ID: "backend-id", Name: "my-backend", BaseURL: "https://api.example.com:9090/mcp",
+		TransportType: "streamable-http", HealthStatus: vmcp.BackendHealthy,
+		AuthConfig: &authtypes.BackendAuthStrategy{Type: authtypes.StrategyTypeTokenExchange},
+	}}
+	srv := createTestServerWithBackends(t, backends, "test-group")
+
+	resp, err := http.Get("http://" + srv.Address() + "/status")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	var status StatusResponse
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&status))
+
+	// Verify all response fields
+	assert.NotEmpty(t, status.Version)
+	assert.Equal(t, "test-group", status.GroupRef)
+	assert.True(t, status.Healthy)
+
+	// Verify backend field mapping
+	require.Len(t, status.Backends, 1)
+	b := status.Backends[0]
+	assert.Equal(t, "my-backend", b.Name)
+	assert.Equal(t, "healthy", b.Health)
+	assert.Equal(t, "streamable-http", b.Transport)
+	assert.Equal(t, authtypes.StrategyTypeTokenExchange, b.AuthType)
+}


### PR DESCRIPTION
Add a new /status endpoint to the Virtual MCP server that exposes runtime status information for debugging and operator consumption.

The endpoint returns:
- backends: List of backend servers with name, health, transport type, and auth type (internal URLs intentionally excluded for security)
- healthy: Overall health status (true if at least one backend healthy)
- version: Build-time version for operational debugging
- group_ref: MCPGroup reference for the backend workloads

Closes #2998