### PR TITLE
adds slack alert for failed toolhive releases

### DIFF
--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -206,3 +206,62 @@ jobs:
 #                                            --source-tag "$GITHUB_REF_NAME" \
 #                                            "$fn"
 #          done <<<"$checksums"
+
+  notify-release-failure:
+    name: Notify Release Failure
+    needs:
+      - compute-build-flags
+      - release-binaries
+      - image-build-and-push
+      - update-docs-website-binaries
+    if: ${{ failure() }}
+    runs-on: ubuntu-slim
+    permissions: {}
+    steps:
+      - name: Send Slack Notification
+        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
+        with:
+          webhook: ${{ secrets.SLACK_TOOLHIVE_RELEASE_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "🚨 ToolHive Release Failed",
+                    "emoji": true
+                  }
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Version:*\n${{ github.ref_name }}"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Triggered by:*\n${{ github.actor }}"
+                    }
+                  ]
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*Workflow Run:*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Failed Run>"
+                  }
+                },
+                {
+                  "type": "context",
+                  "elements": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "Repository: ${{ github.repository }} | Commit: ${{ github.sha }}"
+                    }
+                  ]
+                }
+              ]
+            }


### PR DESCRIPTION
ToolHive release builds fail often enough to the point we want to know exactly when they happen so we can stop making assumptions that they succeeded.

Example:
```
  ┌─────────────────────────────────────────────────────────┐
  │  🚨 ToolHive Release Failed                             │
  ├─────────────────────────────────────────────────────────┤
  │  Version:              Triggered by:                    │
  │  v0.5.0                chrisburns                       │
  ├─────────────────────────────────────────────────────────┤
  │  Workflow Run:                                          │
  │  View Failed Run  ← (clickable link)                    │
  ├─────────────────────────────────────────────────────────┤
  │  Repository: stacklok/toolhive | Commit: abc123def...   │
  └─────────────────────────────────────────────────────────┘

  The "View Failed Run" link would take you directly to the GitHub Actions run page (e.g., https://github.com/stacklok/toolhive/actions/runs/12345678) where you can investigate which job failed and view the logs.
```