### PR TITLE
Rotate K8s versions to add 1.35 for tests

### DIFF
--- a/.github/workflows/operator-ci.yml
+++ b/.github/workflows/operator-ci.yml
@@ -151,9 +151,9 @@ jobs:
         # but we want to make sure renovate bumps the versions when new ones are released. Doing that with
         # just the number is a bit more difficult and i like simple things.
         version: [
-          "kindest/node:v1.32.8",
-          "kindest/node:v1.33.4",
-          "kindest/node:v1.34.2"
+          "kindest/node:v1.33.7",
+          "kindest/node:v1.34.3",
+          "kindest/node:v1.35.0"
         ]
     
     steps:

--- a/.github/workflows/test-e2e-lifecycle.yml
+++ b/.github/workflows/test-e2e-lifecycle.yml
@@ -27,9 +27,9 @@ jobs:
       fail-fast: false
       matrix:
         version: [
-          "kindest/node:v1.32.8",
-          "kindest/node:v1.33.4",
-          "kindest/node:v1.34.2"
+          "kindest/node:v1.33.7",
+          "kindest/node:v1.34.3",
+          "kindest/node:v1.35.0"
         ]
 
     steps:


### PR DESCRIPTION
1.35.0 shipped this week; rolling it in and rolling out 1.32 per our "3 most current versions" policy.

Also bumped patch versions on 1.33 and 1.34 kindest images.

Signed-off-by: Dan Barr <6922515+danbarr@users.noreply.github.com>