### PR TITLE
Update issue triage workflow

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -80,6 +80,7 @@ jobs:
              - Consider platform labels (kubernetes) if applicable
              - If you find similar issues using mcp__github__search_issues, consider using a "duplicate" label if appropriate. Only do so if the issue is a duplicate of another OPEN issue.
              - DO NOT add labels that pertain to priority, such as p0, p1, p2, etc.
+             - DO NOT add the "good-first-issue" label ever
 
           5. Apply the selected labels:
              - Use mcp__github__update_issue to apply your selected labels


### PR DESCRIPTION
Do not allow Claude to add the "good-first-issue" label. It's been adding this to issues that are not appropriate for community members to pick up.