### PR TITLE
feat: Add tool annotations for improved LLM tool understanding

### DIFF
--- a/pkg/mcp/server/server.go
+++ b/pkg/mcp/server/server.go
@@ -98,6 +98,11 @@ func (s *Server) GetAddress() string {
 	return fmt.Sprintf("http://%s:%s/mcp", s.config.Host, s.config.Port)
 }
 
+// boolPtr returns a pointer to a bool value
+func boolPtr(b bool) *bool {
+	return &b
+}
+
 // registerTools registers all MCP tools with the server
 func registerTools(mcpServer *server.MCPServer, handler *Handler) {
 	mcpServer.AddTool(mcp.Tool{
@@ -112,6 +117,10 @@ func registerTools(mcpServer *server.MCPServer, handler *Handler) {
 				},
 			},
 			Required: []string{"query"},
+		},
+		Annotations: mcp.ToolAnnotation{
+			Title:        "Search Registry",
+			ReadOnlyHint: boolPtr(true),
 		},
 	}, handler.SearchRegistry)
 
@@ -157,6 +166,10 @@ func registerTools(mcpServer *server.MCPServer, handler *Handler) {
 			},
 			Required: []string{"server"},
 		},
+		Annotations: mcp.ToolAnnotation{
+			Title:           "Run Server",
+			DestructiveHint: boolPtr(true),
+		},
 	}, handler.RunServer)
 
 	mcpServer.AddTool(mcp.Tool{
@@ -165,6 +178,10 @@ func registerTools(mcpServer *server.MCPServer, handler *Handler) {
 		InputSchema: mcp.ToolInputSchema{
 			Type:       "object",
 			Properties: map[string]interface{}{},
+		},
+		Annotations: mcp.ToolAnnotation{
+			Title:        "List Servers",
+			ReadOnlyHint: boolPtr(true),
 		},
 	}, handler.ListServers)
 
@@ -181,6 +198,10 @@ func registerTools(mcpServer *server.MCPServer, handler *Handler) {
 			},
 			Required: []string{"name"},
 		},
+		Annotations: mcp.ToolAnnotation{
+			Title:           "Stop Server",
+			DestructiveHint: boolPtr(true),
+		},
 	}, handler.StopServer)
 
 	mcpServer.AddTool(mcp.Tool{
@@ -195,6 +216,10 @@ func registerTools(mcpServer *server.MCPServer, handler *Handler) {
 				},
 			},
 			Required: []string{"name"},
+		},
+		Annotations: mcp.ToolAnnotation{
+			Title:           "Remove Server",
+			DestructiveHint: boolPtr(true),
 		},
 	}, handler.RemoveServer)
 
@@ -211,6 +236,10 @@ func registerTools(mcpServer *server.MCPServer, handler *Handler) {
 			},
 			Required: []string{"name"},
 		},
+		Annotations: mcp.ToolAnnotation{
+			Title:        "Get Server Logs",
+			ReadOnlyHint: boolPtr(true),
+		},
 	}, handler.GetServerLogs)
 
 	mcpServer.AddTool(mcp.Tool{
@@ -219,6 +248,10 @@ func registerTools(mcpServer *server.MCPServer, handler *Handler) {
 		InputSchema: mcp.ToolInputSchema{
 			Type:       "object",
 			Properties: map[string]interface{}{},
+		},
+		Annotations: mcp.ToolAnnotation{
+			Title:        "List Secrets",
+			ReadOnlyHint: boolPtr(true),
 		},
 	}, handler.ListSecrets)
 
@@ -238,6 +271,10 @@ func registerTools(mcpServer *server.MCPServer, handler *Handler) {
 				},
 			},
 			Required: []string{"name", "file_path"},
+		},
+		Annotations: mcp.ToolAnnotation{
+			Title:           "Set Secret",
+			DestructiveHint: boolPtr(true),
 		},
 	}, handler.SetSecret)
 }


### PR DESCRIPTION
## Summary

Adds MCP tool annotations (`readOnlyHint`, `destructiveHint`, `title`) to all 8 tools to help LLMs better understand tool behavior and make safer decisions about tool execution.

## Changes

| Tool | Annotation |
|------|------------|
| `search_registry` | `readOnlyHint: true` |
| `run_server` | `destructiveHint: true` |
| `list_servers` | `readOnlyHint: true` |
| `stop_server` | `destructiveHint: true` |
| `remove_server` | `destructiveHint: true` |
| `get_server_logs` | `readOnlyHint: true` |
| `list_secrets` | `readOnlyHint: true` |
| `set_secret` | `destructiveHint: true` |

**Summary:** 4 read-only, 4 destructive

## Why This Matters

- Annotations provide semantic metadata that helps LLMs understand tool behavior
- LLMs can make better decisions about when to use tools and in what order
- Enables safer tool execution by distinguishing read-only from destructive operations
- MCP clients like Claude Code can auto-approve read-only tools while prompting for destructive ones

## Testing

- [x] Server builds successfully (`go build ./pkg/mcp/server/...`)
- [x] Tests pass (`go test ./pkg/mcp/server/...`)
- [x] Annotation values match actual tool behavior

## Before/After

**Before:**
```go
mcpServer.AddTool(mcp.Tool{
    Name:        "search_registry",
    Description: "Search the ToolHive registry for MCP servers",
    InputSchema: mcp.ToolInputSchema{...},
}, handler.SearchRegistry)
```

**After:**
```go
mcpServer.AddTool(mcp.Tool{
    Name:        "search_registry",
    Description: "Search the ToolHive registry for MCP servers",
    InputSchema: mcp.ToolInputSchema{...},
    Annotations: mcp.ToolAnnotation{
        Title:        "Search Registry",
        ReadOnlyHint: boolPtr(true),
    },
}, handler.SearchRegistry)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)