### PR TITLE
fix: Standardize CLI output messages to use 'Workload' terminology

### DIFF
--- a/cmd/thv/app/rm.go
+++ b/cmd/thv/app/rm.go
@@ -99,10 +99,10 @@ func rmCmdFunc(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(workloadNames) == 1 {
-		fmt.Printf("Container %s removed successfully\n", workloadNames[0])
+		fmt.Printf("Workload %s removed successfully\n", workloadNames[0])
 	} else {
 		formattedNames := strings.Join(workloadNames, ", ")
-		fmt.Printf("Containers %s removed successfully\n", formattedNames)
+		fmt.Printf("Workloads %s removed successfully\n", formattedNames)
 	}
 	return nil
 }

--- a/cmd/thv/app/stop.go
+++ b/cmd/thv/app/stop.go
@@ -110,10 +110,10 @@ func stopCmdFunc(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to stop workloads %v: %w", workloadNames, err)
 	}
 	if len(workloadNames) == 1 {
-		fmt.Printf("workload %s stopped successfully\n", workloadNames[0])
+		fmt.Printf("Workload %s stopped successfully\n", workloadNames[0])
 	} else {
 		formattedNames := strings.Join(workloadNames, ", ")
-		fmt.Printf("workloads %v stopped successfully\n", formattedNames)
+		fmt.Printf("Workloads %s stopped successfully\n", formattedNames)
 	}
 
 	return nil


### PR DESCRIPTION
## Summary
This PR fixes #3044

## Changes
- `cmd/thv/app/rm.go`
- `cmd/thv/app/stop.go`
