### PR TITLE
fix: Add missing flag shorthands and use shared helpers

### DIFF
--- a/cmd/thv/app/list.go
+++ b/cmd/thv/app/list.go
@@ -47,11 +47,22 @@ var (
 
 func init() {
 	listCmd.Flags().BoolVarP(&listAll, "all", "a", false, "Show all workloads (default shows just running)")
-	listCmd.Flags().StringVar(&listFormat, "format", FormatText, "Output format (json, text, or mcpservers)")
+	AddFormatFlag(listCmd, &listFormat)
 	listCmd.Flags().StringArrayVarP(&listLabelFilter, "label", "l", []string{}, "Filter workloads by labels (format: key=value)")
 	listCmd.Flags().StringVar(&listGroupFilter, "group", "", "Filter workloads by group")
 
-	listCmd.PreRunE = validateGroupFlag()
+	listCmd.PreRunE = ChainPreRunE(validateGroupFlag(), validateListFormat)
+}
+
+// validateListFormat validates the format flag for the list command.
+// It accepts all standard formats plus "mcpservers".
+func validateListFormat(_ *cobra.Command, _ []string) error {
+	switch listFormat {
+	case FormatJSON, FormatText, "mcpservers":
+		return nil
+	default:
+		return fmt.Errorf("invalid format %q: must be one of [json text mcpservers]", listFormat)
+	}
 }
 
 func listCmdFunc(cmd *cobra.Command, _ []string) error {

--- a/cmd/thv/app/mcp.go
+++ b/cmd/thv/app/mcp.go
@@ -88,10 +88,11 @@ func newMCPCommand() *cobra.Command {
 
 func addMCPFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&mcpServerURL, "server", "", "MCP server URL or name from ToolHive registry (required)")
-	cmd.Flags().StringVar(&mcpFormat, "format", FormatText, "Output format (json or text)")
+	AddFormatFlag(cmd, &mcpFormat)
 	cmd.Flags().DurationVar(&mcpTimeout, "timeout", 30*time.Second, "Connection timeout")
 	cmd.Flags().StringVar(&mcpTransport, "transport", "auto", "Transport type (auto, sse, streamable-http)")
 	_ = cmd.MarkFlagRequired("server")
+	cmd.PreRunE = ValidateFormatFlag(&mcpFormat)
 }
 
 // mcpListCmdFunc lists all capabilities (tools, resources, prompts)

--- a/cmd/thv/app/registry.go
+++ b/cmd/thv/app/registry.go
@@ -50,10 +50,14 @@ func init() {
 	registryCmd.AddCommand(registryInfoCmd)
 
 	// Add flags for list and info commands
-	registryListCmd.Flags().StringVar(&registryFormat, "format", FormatText, "Output format (json or text)")
+	AddFormatFlag(registryListCmd, &registryFormat)
 	registryListCmd.Flags().BoolVar(&refreshRegistry, "refresh", false, "Force refresh registry cache")
-	registryInfoCmd.Flags().StringVar(&registryFormat, "format", FormatText, "Output format (json or text)")
+	AddFormatFlag(registryInfoCmd, &registryFormat)
 	registryInfoCmd.Flags().BoolVar(&refreshRegistry, "refresh", false, "Force refresh registry cache")
+
+	// Add format validation
+	registryListCmd.PreRunE = ValidateFormatFlag(&registryFormat)
+	registryInfoCmd.PreRunE = ValidateFormatFlag(&registryFormat)
 }
 
 func registryListCmdFunc(_ *cobra.Command, _ []string) error {

--- a/cmd/thv/app/rm.go
+++ b/cmd/thv/app/rm.go
@@ -38,8 +38,8 @@ var (
 )
 
 func init() {
-	rmCmd.Flags().BoolVar(&rmAll, "all", false, "Delete all workloads")
-	rmCmd.Flags().StringVarP(&rmGroup, "group", "", "", "Delete all workloads in the specified group")
+	rmCmd.Flags().BoolVarP(&rmAll, "all", "a", false, "Delete all workloads")
+	rmCmd.Flags().StringVarP(&rmGroup, "group", "g", "", "Delete all workloads in the specified group")
 
 	// Mark the flags as mutually exclusive
 	rmCmd.MarkFlagsMutuallyExclusive("all", "group")

--- a/cmd/thv/app/stop.go
+++ b/cmd/thv/app/stop.go
@@ -43,7 +43,7 @@ var (
 
 func init() {
 	stopCmd.Flags().IntVar(&stopTimeout, "timeout", 30, "Timeout in seconds before forcibly stopping the workload")
-	stopCmd.Flags().BoolVar(&stopAll, "all", false, "Stop all running MCP servers")
+	stopCmd.Flags().BoolVarP(&stopAll, "all", "a", false, "Stop all running MCP servers")
 	stopCmd.Flags().StringVarP(&stopGroup, "group", "g", "", "Stop all MCP servers in a specific group")
 
 	// Mark the flags as mutually exclusive


### PR DESCRIPTION
## Summary
This PR fixes #3042

## Changes
- `cmd/thv/app/common.go`
- `cmd/thv/app/list.go`
- `cmd/thv/app/mcp.go`
- `cmd/thv/app/registry.go`
- `cmd/thv/app/rm.go`
- `cmd/thv/app/stop.go`
