### PR TITLE
Ensure error types are checked with errors.Is()

### DIFF
--- a/cmd/thv/app/runtime.go
+++ b/cmd/thv/app/runtime.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -43,7 +44,7 @@ func runtimeCheckCmdFunc(cmd *cobra.Command, _ []string) error {
 	defer cancelCreate()
 	rt, err := createWithTimeout(createCtx)
 	if err != nil {
-		if createCtx.Err() == context.DeadlineExceeded {
+		if errors.Is(createCtx.Err(), context.DeadlineExceeded) {
 			return fmt.Errorf("creating container runtime timed out after %d seconds", runtimeCheckTimeout)
 		}
 		return fmt.Errorf("failed to create container runtime: %w", err)
@@ -53,7 +54,7 @@ func runtimeCheckCmdFunc(cmd *cobra.Command, _ []string) error {
 	pingCtx, cancelPing := context.WithTimeout(ctx, time.Duration(runtimeCheckTimeout)*time.Second)
 	defer cancelPing()
 	if err := pingRuntime(pingCtx, rt); err != nil {
-		if pingCtx.Err() == context.DeadlineExceeded {
+		if errors.Is(pingCtx.Err(), context.DeadlineExceeded) {
 			return fmt.Errorf("runtime ping timed out after %d seconds", runtimeCheckTimeout)
 		}
 		return fmt.Errorf("runtime ping failed: %w", err)

--- a/pkg/api/v1/workload_service.go
+++ b/pkg/api/v1/workload_service.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -165,7 +166,7 @@ func (s *WorkloadService) BuildFullRunConfig(ctx context.Context, req *createReq
 		)
 		if err != nil {
 			// Check if the error is due to context timeout
-			if imageCtx.Err() == context.DeadlineExceeded {
+			if errors.Is(imageCtx.Err(), context.DeadlineExceeded) {
 				return nil, fmt.Errorf("image retrieval timed out after %v - image may be too large or connection too slow",
 					imageRetrievalTimeout)
 			}

--- a/pkg/auth/discovery/discovery.go
+++ b/pkg/auth/discovery/discovery.go
@@ -11,6 +11,7 @@ package discovery
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -646,7 +647,7 @@ func newOAuthFlow(ctx context.Context, oauthConfig *oauth.Config, config *OAuthF
 	// Start OAuth flow
 	tokenResult, err := flow.Start(oauthCtx, config.SkipBrowser)
 	if err != nil {
-		if oauthCtx.Err() == context.DeadlineExceeded {
+		if errors.Is(oauthCtx.Err(), context.DeadlineExceeded) {
 			return nil, fmt.Errorf("OAuth flow timed out after %v - user did not complete authentication", oauthTimeout)
 		}
 		return nil, fmt.Errorf("OAuth flow failed: %w", err)

--- a/pkg/auth/token_test.go
+++ b/pkg/auth/token_test.go
@@ -161,7 +161,7 @@ func TestTokenValidator(t *testing.T) {
 			if tc.expectErr {
 				if err == nil {
 					t.Errorf("Expected error but got nil")
-				} else if tc.errType != nil && err != tc.errType {
+				} else if tc.errType != nil && !errors.Is(err, tc.errType) {
 					t.Errorf("Expected error %v but got %v", tc.errType, err)
 				}
 			} else {
@@ -680,7 +680,7 @@ func TestNewTokenValidatorWithOIDCDiscovery(t *testing.T) {
 		}
 
 		validator, err := NewTokenValidator(ctx, config)
-		if err != ErrMissingIssuerAndJWKSURL {
+		if !errors.Is(err, ErrMissingIssuerAndJWKSURL) {
 			t.Errorf("Expected error %v but got %v", ErrMissingIssuerAndJWKSURL, err)
 		}
 		if validator != nil {

--- a/pkg/errors/errors_test.go
+++ b/pkg/errors/errors_test.go
@@ -52,7 +52,7 @@ func TestError_Unwrap(t *testing.T) {
 		Cause:   cause,
 	}
 
-	if got := err.Unwrap(); got != cause {
+	if got := err.Unwrap(); !errors.Is(got, cause) {
 		t.Errorf("Error.Unwrap() = %v, want %v", got, cause)
 	}
 
@@ -78,7 +78,7 @@ func TestNewError(t *testing.T) {
 	if err.Message != "test message" {
 		t.Errorf("NewError().Message = %v, want %v", err.Message, "test message")
 	}
-	if err.Cause != cause {
+	if !errors.Is(cause, err.Cause) {
 		t.Errorf("NewError().Cause = %v, want %v", err.Cause, cause)
 	}
 }
@@ -164,7 +164,7 @@ func TestNewErrorConstructors(t *testing.T) {
 			if err.Message != "test message" {
 				t.Errorf("%s().Message = %v, want %v", tt.name, err.Message, "test message")
 			}
-			if err.Cause != cause {
+			if !errors.Is(err.Cause, cause) {
 				t.Errorf("%s().Cause = %v, want %v", tt.name, err.Cause, cause)
 			}
 		})

--- a/pkg/mcp/server/server.go
+++ b/pkg/mcp/server/server.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -81,7 +82,7 @@ func New(ctx context.Context, config *Config) (*Server, error) {
 // Start starts the MCP server
 func (s *Server) Start() error {
 	logger.Infof("Starting ToolHive MCP server on http://%s:%s/mcp", s.config.Host, s.config.Port)
-	if err := s.httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+	if err := s.httpServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		return fmt.Errorf("MCP server error: %w", err)
 	}
 	return nil

--- a/pkg/mcp/server/server_test.go
+++ b/pkg/mcp/server/server_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"testing"
 	"time"
@@ -132,7 +133,7 @@ func TestServer_StartAndShutdown(t *testing.T) {
 	serverErr := make(chan error, 1)
 	go func() {
 		err := server.Start()
-		if err != nil && err != http.ErrServerClosed {
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
 			serverErr <- err
 		}
 		close(serverErr)

--- a/pkg/runner/retriever/retriever.go
+++ b/pkg/runner/retriever/retriever.go
@@ -95,10 +95,10 @@ func GetMCPServer(
 	// Pull the image if necessary
 	if err := pullImage(ctx, imageToUse, imageManager); err != nil {
 		// Check if the error is due to context cancellation/timeout
-		if ctx.Err() == context.DeadlineExceeded {
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 			return "", nil, fmt.Errorf("image pull timed out - the image may be too large or the connection too slow")
 		}
-		if ctx.Err() == context.Canceled {
+		if errors.Is(ctx.Err(), context.Canceled) {
 			return "", nil, fmt.Errorf("image pull was canceled")
 		}
 		return "", nil, fmt.Errorf("failed to retrieve or pull image: %w", err)
@@ -244,10 +244,10 @@ func pullImage(ctx context.Context, image string, imageManager images.ImageManag
 		err := imageManager.PullImage(ctx, image)
 		if err != nil {
 			// Check if the error is due to context cancellation/timeout
-			if ctx.Err() == context.DeadlineExceeded {
+			if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 				return fmt.Errorf("image pull timed out for %s - the image may be too large or the connection too slow", image)
 			}
-			if ctx.Err() == context.Canceled {
+			if errors.Is(ctx.Err(), context.Canceled) {
 				return fmt.Errorf("image pull was canceled for %s", image)
 			}
 
@@ -282,10 +282,10 @@ func pullImage(ctx context.Context, image string, imageManager images.ImageManag
 			logger.Infof("Image %s not found locally, pulling...", image)
 			if err := imageManager.PullImage(ctx, image); err != nil {
 				// Check if the error is due to context cancellation/timeout
-				if ctx.Err() == context.DeadlineExceeded {
+				if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 					return fmt.Errorf("image pull timed out for %s - the image may be too large or the connection too slow", image)
 				}
-				if ctx.Err() == context.Canceled {
+				if errors.Is(ctx.Err(), context.Canceled) {
 					return fmt.Errorf("image pull was canceled for %s", image)
 				}
 				// TODO: need more fine grained error handling here.

--- a/pkg/transport/proxy/streamable/streamable_proxy.go
+++ b/pkg/transport/proxy/streamable/streamable_proxy.go
@@ -112,7 +112,7 @@ func (p *HTTPProxy) Start(_ context.Context) error {
 	go func() {
 		logger.Infof("Streamable HTTP proxy started on port %d", p.port)
 		logger.Infof("Streamable HTTP endpoint: http://%s:%d%s", p.host, p.port, StreamableHTTPEndpoint)
-		if err := p.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		if err := p.server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			logger.Errorf("Streamable HTTP server error: %v", err)
 		}
 	}()

--- a/pkg/transport/proxy/transparent/transparent_proxy.go
+++ b/pkg/transport/proxy/transparent/transparent_proxy.go
@@ -383,7 +383,7 @@ func (p *TransparentProxy) Start(ctx context.Context) error {
 	server := p.server
 	go func() {
 		err := server.Serve(ln)
-		if err != nil && err != http.ErrServerClosed {
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
 			var opErr *net.OpError
 			if errors.As(err, &opErr) && opErr.Op == "accept" {
 				// Expected when listener is closed—silently return
@@ -462,7 +462,7 @@ func (p *TransparentProxy) Stop(ctx context.Context) error {
 	// Stop the HTTP server
 	if p.server != nil {
 		err := p.server.Shutdown(ctx)
-		if err != nil && err != http.ErrServerClosed && err != context.DeadlineExceeded {
+		if err != nil && !errors.Is(err, http.ErrServerClosed) && !errors.Is(err, context.DeadlineExceeded) {
 			logger.Warnf("Error during proxy shutdown: %v", err)
 			return err
 		}

--- a/pkg/vmcp/composer/workflow_engine.go
+++ b/pkg/vmcp/composer/workflow_engine.go
@@ -177,7 +177,7 @@ func (e *workflowEngine) ExecuteWorkflow(
 		logger.Errorf("Workflow %s failed: %v", def.Name, dagErr)
 
 		// Check if it was a timeout
-		if execCtx.Err() == context.DeadlineExceeded {
+		if errors.Is(execCtx.Err(), context.DeadlineExceeded) {
 			result.Status = WorkflowStatusTimedOut
 			result.Error = ErrWorkflowTimeout
 			result.EndTime = time.Now()

--- a/pkg/vmcp/server/integration_test.go
+++ b/pkg/vmcp/server/integration_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -213,7 +214,7 @@ func TestIntegration_AggregatorToRouterToServer(t *testing.T) {
 	// Start server in background
 	serverErrCh := make(chan error, 1)
 	go func() {
-		if err := srv.Start(serverCtx); err != nil && err != context.Canceled {
+		if err := srv.Start(serverCtx); err != nil && !errors.Is(err, context.Canceled) {
 			serverErrCh <- err
 		}
 	}()
@@ -340,7 +341,7 @@ func TestIntegration_HTTPRequestFlowWithRoutingTable(t *testing.T) {
 
 	serverErrCh := make(chan error, 1)
 	go func() {
-		if err := srv.Start(serverCtx); err != nil && err != context.Canceled {
+		if err := srv.Start(serverCtx); err != nil && !errors.Is(err, context.Canceled) {
 			serverErrCh <- err
 		}
 	}()
@@ -675,7 +676,7 @@ func TestIntegration_AuditLogging(t *testing.T) {
 
 	serverErrCh := make(chan error, 1)
 	go func() {
-		if err := srv.Start(serverCtx); err != nil && err != context.Canceled {
+		if err := srv.Start(serverCtx); err != nil && !errors.Is(err, context.Canceled) {
 			serverErrCh <- err
 		}
 	}()
@@ -950,7 +951,7 @@ func TestIntegration_AuditLoggingWithAuth(t *testing.T) {
 
 	serverErrCh := make(chan error, 1)
 	go func() {
-		if err := srv.Start(serverCtx); err != nil && err != context.Canceled {
+		if err := srv.Start(serverCtx); err != nil && !errors.Is(err, context.Canceled) {
 			serverErrCh <- err
 		}
 	}()

--- a/pkg/vmcp/server/server.go
+++ b/pkg/vmcp/server/server.go
@@ -520,7 +520,7 @@ func (s *Server) Start(ctx context.Context) error {
 	// Start server in background
 	errCh := make(chan error, 1)
 	go func() {
-		if err := s.httpServer.Serve(listener); err != nil && err != http.ErrServerClosed {
+		if err := s.httpServer.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			errCh <- fmt.Errorf("HTTP server error: %w", err)
 		}
 	}()

--- a/test/e2e/oidc_mock.go
+++ b/test/e2e/oidc_mock.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rsa"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -351,7 +352,7 @@ func (m *OIDCMockServer) handleJWKS(w http.ResponseWriter, _ *http.Request) {
 // Start starts the OIDC mock server
 func (m *OIDCMockServer) Start() error {
 	go func() {
-		if err := m.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		if err := m.server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			fmt.Printf("OIDC mock server error: %v\n", err)
 		}
 	}()


### PR DESCRIPTION
Ensures that error handling works as expected in the case that an error gets wrapped.

This matches the advice given in CLAUDE.md