### PR TITLE
Add CLI flags for bearer token authentication

### DIFF
--- a/cmd/thv/app/auth_flags.go
+++ b/cmd/thv/app/auth_flags.go
@@ -77,6 +77,10 @@ type RemoteAuthFlags struct {
 	RemoteAuthTokenURL         string
 	RemoteAuthResource         string
 
+	// Bearer Token Configuration (alternative to OAuth)
+	RemoteAuthBearerToken     string
+	RemoteAuthBearerTokenFile string
+
 	// Token Exchange Configuration
 	TokenExchangeURL              string
 	TokenExchangeClientID         string
@@ -165,6 +169,10 @@ func AddRemoteAuthFlags(cmd *cobra.Command, config *RemoteAuthFlags) {
 		"OAuth token endpoint URL (alternative to --remote-auth-issuer for non-OIDC OAuth)")
 	cmd.Flags().StringVar(&config.RemoteAuthResource, "remote-auth-resource", "",
 		"OAuth 2.0 resource indicator (RFC 8707)")
+	cmd.Flags().StringVar(&config.RemoteAuthBearerToken, "remote-auth-bearer-token", "",
+		"Bearer token for remote server authentication (alternative to OAuth)")
+	cmd.Flags().StringVar(&config.RemoteAuthBearerTokenFile, "remote-auth-bearer-token-file", "",
+		"Path to file containing bearer token (alternative to --remote-auth-bearer-token)")
 
 	// Token Exchange flags
 	cmd.Flags().StringVar(&config.TokenExchangeURL, "token-exchange-url", "",

--- a/docs/cli/thv_proxy.md
+++ b/docs/cli/thv_proxy.md
@@ -109,6 +109,8 @@ thv proxy [flags] SERVER_NAME
       --port int                                   Port for the HTTP proxy to listen on (host port)
       --remote-auth                                Enable OAuth/OIDC authentication to remote MCP server
       --remote-auth-authorize-url string           OAuth authorization endpoint URL (alternative to --remote-auth-issuer for non-OIDC OAuth)
+      --remote-auth-bearer-token string            Bearer token for remote server authentication (alternative to OAuth)
+      --remote-auth-bearer-token-file string       Path to file containing bearer token (alternative to --remote-auth-bearer-token)
       --remote-auth-callback-port int              Port for OAuth callback server during remote authentication (default 8666)
       --remote-auth-client-id string               OAuth client ID for remote server authentication
       --remote-auth-client-secret string           OAuth client secret for remote server authentication (optional for PKCE)

--- a/docs/cli/thv_run.md
+++ b/docs/cli/thv_run.md
@@ -155,6 +155,8 @@ thv run [flags] SERVER_OR_IMAGE_OR_PROTOCOL [-- ARGS...]
       --proxy-port int                             Port for the HTTP proxy to listen on (host port)
       --remote-auth                                Enable OAuth/OIDC authentication to remote MCP server
       --remote-auth-authorize-url string           OAuth authorization endpoint URL (alternative to --remote-auth-issuer for non-OIDC OAuth)
+      --remote-auth-bearer-token string            Bearer token for remote server authentication (alternative to OAuth)
+      --remote-auth-bearer-token-file string       Path to file containing bearer token (alternative to --remote-auth-bearer-token)
       --remote-auth-callback-port int              Port for OAuth callback server during remote authentication (default 8666)
       --remote-auth-client-id string               OAuth client ID for remote server authentication
       --remote-auth-client-secret string           OAuth client secret for remote server authentication (optional for PKCE)


### PR DESCRIPTION
## Summary

Adds CLI flags for bearer token authentication, allowing users to provide bearer tokens via command-line flags, files, or the hardcoded environment variable. This completes the CLI implementation for bearer token authentication in Phase 1.

## Changes

**CLI Flags (`cmd/thv/app/auth_flags.go`):**
- Added `RemoteAuthBearerToken` and `RemoteAuthBearerTokenFile` fields to `RemoteAuthFlags` struct
- Added `--remote-auth-bearer-token` flag for direct bearer token input
- Added `--remote-auth-bearer-token-file` flag for bearer token from file

**Config Building (`cmd/thv/app/run_flags.go`):**
- Updated `getRemoteAuthFromRunFlags()` to resolve bearer token from multiple sources:
  - Priority: CLI flag → file → environment variable (`TOOLHIVE_REMOTE_AUTH_BEARER_TOKEN`)
  - Processes bearer token using `authsecrets.ProcessSecret()` for secret management
  - Sets `BearerToken` and `BearerTokenFile` in `remote.Config`
- Updated `getRemoteAuthFromRemoteServerMetadata()` to handle bearer token from CLI flags when registry metadata is present
  - CLI flags take priority over registry configuration

## Behavior

- **Flag Priority**: CLI flags override registry configuration (if present)
- **Resolution Order**: Flag → File → Environment Variable (hardcoded `TOOLHIVE_REMOTE_AUTH_BEARER_TOKEN`)
- **Secret Processing**: Plain text tokens are automatically converted to CLI format secret references
- **Backward Compatibility**: Works alongside existing OAuth authentication flags

## Usage Examples
ash
# Using bearer token flag
thv run --remote-url https://example.com/mcp --remote-auth-bearer-token my-token-123

# Using bearer token file
thv run https://example.com/mcp --remote-auth-bearer-token-file /path/to/token.txt

# Using environment variable (hardcoded)
export TOOLHIVE_REMOTE_AUTH_BEARER_TOKEN=my-token-123
thv run https://example.com/mcp

# CLI flags override registry configuration
thv run server-name --remote-auth-bearer-token override-token
