### PR TITLE
add remote server configuration methods to Transport interface

### DIFF
--- a/pkg/transport/stdio.go
+++ b/pkg/transport/stdio.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/cenkalti/backoff/v5"
 	"golang.org/x/exp/jsonrpc2"
+	"golang.org/x/oauth2"
 
 	"github.com/stacklok/toolhive/pkg/container"
 	"github.com/stacklok/toolhive/pkg/container/docker"
@@ -300,6 +301,24 @@ func (t *StdioTransport) IsRunning(_ context.Context) (bool, error) {
 	default:
 		return true, nil
 	}
+}
+
+// SetRemoteURL sets the remote URL for the MCP server.
+// This is a no-op for stdio transport as it doesn't support remote servers.
+func (*StdioTransport) SetRemoteURL(_ string) {
+	// No-op: stdio transport doesn't support remote servers
+}
+
+// SetTokenSource sets the OAuth token source for remote authentication.
+// This is a no-op for stdio transport as it doesn't support remote authentication.
+func (*StdioTransport) SetTokenSource(_ oauth2.TokenSource) {
+	// No-op: stdio transport doesn't support remote authentication
+}
+
+// SetOnHealthCheckFailed sets the callback for health check failures.
+// This is a no-op for stdio transport as it doesn't support health checks.
+func (*StdioTransport) SetOnHealthCheckFailed(_ types.HealthCheckFailedCallback) {
+	// No-op: stdio transport doesn't support health checks
 }
 
 // isDockerSocketError checks if an error indicates Docker socket unavailability using typed error detection

--- a/pkg/transport/types/mocks/mock_transport.go
+++ b/pkg/transport/types/mocks/mock_transport.go
@@ -17,6 +17,7 @@ import (
 	types "github.com/stacklok/toolhive/pkg/transport/types"
 	gomock "go.uber.org/mock/gomock"
 	jsonrpc2 "golang.org/x/exp/jsonrpc2"
+	oauth2 "golang.org/x/oauth2"
 )
 
 // MockMiddleware is a mock of Middleware interface.
@@ -248,6 +249,42 @@ func (m *MockTransport) ProxyPort() int {
 func (mr *MockTransportMockRecorder) ProxyPort() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProxyPort", reflect.TypeOf((*MockTransport)(nil).ProxyPort))
+}
+
+// SetOnHealthCheckFailed mocks base method.
+func (m *MockTransport) SetOnHealthCheckFailed(callback types.HealthCheckFailedCallback) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetOnHealthCheckFailed", callback)
+}
+
+// SetOnHealthCheckFailed indicates an expected call of SetOnHealthCheckFailed.
+func (mr *MockTransportMockRecorder) SetOnHealthCheckFailed(callback any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetOnHealthCheckFailed", reflect.TypeOf((*MockTransport)(nil).SetOnHealthCheckFailed), callback)
+}
+
+// SetRemoteURL mocks base method.
+func (m *MockTransport) SetRemoteURL(remoteURL string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetRemoteURL", remoteURL)
+}
+
+// SetRemoteURL indicates an expected call of SetRemoteURL.
+func (mr *MockTransportMockRecorder) SetRemoteURL(remoteURL any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetRemoteURL", reflect.TypeOf((*MockTransport)(nil).SetRemoteURL), remoteURL)
+}
+
+// SetTokenSource mocks base method.
+func (m *MockTransport) SetTokenSource(tokenSource oauth2.TokenSource) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetTokenSource", tokenSource)
+}
+
+// SetTokenSource indicates an expected call of SetTokenSource.
+func (mr *MockTransportMockRecorder) SetTokenSource(tokenSource any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetTokenSource", reflect.TypeOf((*MockTransport)(nil).SetTokenSource), tokenSource)
 }
 
 // Start mocks base method.

--- a/pkg/transport/types/transport.go
+++ b/pkg/transport/types/transport.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 
 	"golang.org/x/exp/jsonrpc2"
+	"golang.org/x/oauth2"
 
 	rt "github.com/stacklok/toolhive/pkg/container/runtime"
 	"github.com/stacklok/toolhive/pkg/transport/errors"
@@ -100,6 +101,18 @@ type Transport interface {
 
 	// IsRunning checks if the transport is currently running.
 	IsRunning(ctx context.Context) (bool, error)
+
+	// SetRemoteURL sets the remote URL for the MCP server.
+	// For transports that don't support remote servers (e.g., stdio), this is a no-op.
+	SetRemoteURL(remoteURL string)
+
+	// SetTokenSource sets the OAuth token source for remote authentication.
+	// For transports that don't support remote authentication (e.g., stdio), this is a no-op.
+	SetTokenSource(tokenSource oauth2.TokenSource)
+
+	// SetOnHealthCheckFailed sets the callback for health check failures.
+	// For transports that don't support health checks (e.g., stdio), this is a no-op.
+	SetOnHealthCheckFailed(callback HealthCheckFailedCallback)
 }
 
 // TransportType represents the type of transport to use.


### PR DESCRIPTION
## Summary

This PR refactors the transport layer to replace anonymous interface type casts with explicit methods on the `Transport` interface. This improves type safety, code clarity, and maintainability.

## Changes

- **Added methods to `Transport` interface** (`pkg/transport/types/transport.go`):
  - `SetRemoteURL(remoteURL string)` - Sets the remote URL for MCP servers
  - `SetTokenSource(tokenSource oauth2.TokenSource)` - Sets OAuth token source for remote authentication
  - `SetOnHealthCheckFailed(callback HealthCheckFailedCallback)` - Sets callback for health check failures

- **Added no-op implementations to `StdioTransport`** (`pkg/transport/stdio.go`):
  - All three methods implemented as no-ops since stdio transport doesn't support remote servers

- **Updated `runner.go`** (`pkg/runner/runner.go`):
  - Removed anonymous interface type casts
  - Now calls methods directly on the `Transport` interface

- **Updated mock transport** (`pkg/transport/types/mocks/mock_transport.go`):
  - Added methods to satisfy the interface

## Benefits

- ✅ **Cleaner code**: No more anonymous interface type casts
- ✅ **Better type safety**: Methods are part of the interface contract
- ✅ **Easier to maintain**: Consistent interface across all transports
- ✅ **No-op implementations**: Transports that don't need these features can provide no-ops

## Testing

- All existing tests pass
- Code compiles successfully
- No breaking changes to existing functionality