### PR TITLE
Refactor proxy implementations to share code

### DIFF
--- a/pkg/transport/proxy/common/headers.go
+++ b/pkg/transport/proxy/common/headers.go
@@ -1,0 +1,50 @@
+package common
+
+import (
+	"net"
+	"net/http"
+)
+
+// ForwardedHeaders contains extracted X-Forwarded-* header values.
+type ForwardedHeaders struct {
+	Proto  string // X-Forwarded-Proto
+	Host   string // X-Forwarded-Host (may include port)
+	Port   string // X-Forwarded-Port
+	Prefix string // X-Forwarded-Prefix
+}
+
+// ExtractForwardedHeaders extracts X-Forwarded-* headers from the request.
+// Only extracts headers if trustProxyHeaders is true.
+// Always extracts X-Forwarded-Proto regardless of trustProxyHeaders setting.
+func ExtractForwardedHeaders(r *http.Request, trustProxyHeaders bool) ForwardedHeaders {
+	headers := ForwardedHeaders{}
+
+	// Always extract X-Forwarded-Proto (used for scheme detection)
+	headers.Proto = r.Header.Get("X-Forwarded-Proto")
+
+	if !trustProxyHeaders {
+		return headers
+	}
+
+	// Extract other headers only if trust is enabled
+	headers.Host = r.Header.Get("X-Forwarded-Host")
+	headers.Port = r.Header.Get("X-Forwarded-Port")
+	headers.Prefix = r.Header.Get("X-Forwarded-Prefix")
+
+	return headers
+}
+
+// JoinHostPort combines host and port, handling existing ports in host.
+// If host already contains a port, it's stripped before adding the new port.
+func JoinHostPort(host, port string) string {
+	if port == "" {
+		return host
+	}
+
+	// Strip any existing port from host
+	if hostOnly, _, err := net.SplitHostPort(host); err == nil {
+		host = hostOnly
+	}
+
+	return net.JoinHostPort(host, port)
+}

--- a/pkg/transport/proxy/common/headers_test.go
+++ b/pkg/transport/proxy/common/headers_test.go
@@ -1,0 +1,168 @@
+package common
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+const testSchemeHTTPS = "https"
+
+func TestExtractForwardedHeaders(t *testing.T) {
+	t.Parallel()
+
+	t.Run("trust enabled extracts all headers", func(t *testing.T) {
+		t.Parallel()
+
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.Header.Set("X-Forwarded-Proto", testSchemeHTTPS)
+		req.Header.Set("X-Forwarded-Host", "example.com")
+		req.Header.Set("X-Forwarded-Port", "8080")
+		req.Header.Set("X-Forwarded-Prefix", "/api")
+
+		headers := ExtractForwardedHeaders(req, true)
+
+		if headers.Proto != testSchemeHTTPS {
+			t.Errorf("Expected Proto to be https, got %s", headers.Proto)
+		}
+		if headers.Host != "example.com" {
+			t.Errorf("Expected Host to be example.com, got %s", headers.Host)
+		}
+		if headers.Port != "8080" {
+			t.Errorf("Expected Port to be 8080, got %s", headers.Port)
+		}
+		if headers.Prefix != "/api" {
+			t.Errorf("Expected Prefix to be /api, got %s", headers.Prefix)
+		}
+	})
+
+	t.Run("trust disabled only extracts Proto", func(t *testing.T) {
+		t.Parallel()
+
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.Header.Set("X-Forwarded-Proto", testSchemeHTTPS)
+		req.Header.Set("X-Forwarded-Host", "example.com")
+		req.Header.Set("X-Forwarded-Port", "8080")
+		req.Header.Set("X-Forwarded-Prefix", "/api")
+
+		headers := ExtractForwardedHeaders(req, false)
+
+		if headers.Proto != testSchemeHTTPS {
+			t.Errorf("Expected Proto to be https, got %s", headers.Proto)
+		}
+		if headers.Host != "" {
+			t.Errorf("Expected Host to be empty, got %s", headers.Host)
+		}
+		if headers.Port != "" {
+			t.Errorf("Expected Port to be empty, got %s", headers.Port)
+		}
+		if headers.Prefix != "" {
+			t.Errorf("Expected Prefix to be empty, got %s", headers.Prefix)
+		}
+	})
+
+	t.Run("missing headers return empty strings", func(t *testing.T) {
+		t.Parallel()
+
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+
+		headers := ExtractForwardedHeaders(req, true)
+
+		if headers.Proto != "" {
+			t.Errorf("Expected Proto to be empty, got %s", headers.Proto)
+		}
+		if headers.Host != "" {
+			t.Errorf("Expected Host to be empty, got %s", headers.Host)
+		}
+		if headers.Port != "" {
+			t.Errorf("Expected Port to be empty, got %s", headers.Port)
+		}
+		if headers.Prefix != "" {
+			t.Errorf("Expected Prefix to be empty, got %s", headers.Prefix)
+		}
+	})
+
+	t.Run("Proto always extracted regardless of trust", func(t *testing.T) {
+		t.Parallel()
+
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.Header.Set("X-Forwarded-Proto", testSchemeHTTPS)
+
+		// Test with trust disabled
+		headers := ExtractForwardedHeaders(req, false)
+		if headers.Proto != testSchemeHTTPS {
+			t.Errorf("Expected Proto to be https with trust disabled, got %s", headers.Proto)
+		}
+
+		// Test with trust enabled
+		headers = ExtractForwardedHeaders(req, true)
+		if headers.Proto != testSchemeHTTPS {
+			t.Errorf("Expected Proto to be https with trust enabled, got %s", headers.Proto)
+		}
+	})
+}
+
+func TestJoinHostPort(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		host     string
+		port     string
+		expected string
+	}{
+		{
+			name:     "empty port returns host unchanged",
+			host:     "example.com",
+			port:     "",
+			expected: "example.com",
+		},
+		{
+			name:     "host without port adds port",
+			host:     "example.com",
+			port:     "8080",
+			expected: "example.com:8080",
+		},
+		{
+			name:     "host with existing port strips and adds new port",
+			host:     "example.com:9090",
+			port:     "8080",
+			expected: "example.com:8080",
+		},
+		{
+			name:     "IPv6 host without port adds port",
+			host:     "::1",
+			port:     "8080",
+			expected: "[::1]:8080",
+		},
+		{
+			name:     "IPv6 host with existing port strips and adds new port",
+			host:     "[::1]:9090",
+			port:     "8080",
+			expected: "[::1]:8080",
+		},
+		{
+			name:     "localhost without port adds port",
+			host:     "localhost",
+			port:     "3000",
+			expected: "localhost:3000",
+		},
+		{
+			name:     "localhost with existing port strips and adds new port",
+			host:     "localhost:9090",
+			port:     "3000",
+			expected: "localhost:3000",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := JoinHostPort(tt.host, tt.port)
+			if result != tt.expected {
+				t.Errorf("Expected %s, got %s", tt.expected, result)
+			}
+		})
+	}
+}

--- a/pkg/transport/proxy/common/middleware.go
+++ b/pkg/transport/proxy/common/middleware.go
@@ -1,0 +1,18 @@
+// Package common provides shared utilities for proxy implementations.
+package common
+
+import (
+	"net/http"
+
+	"github.com/stacklok/toolhive/pkg/transport/types"
+)
+
+// ApplyMiddlewares applies a chain of middlewares to an HTTP handler.
+// Middlewares are applied in reverse order (last middleware is applied first)
+// so that the first middleware in the slice is the outermost handler.
+func ApplyMiddlewares(handler http.Handler, middlewares ...types.NamedMiddleware) http.Handler {
+	for i := len(middlewares) - 1; i >= 0; i-- {
+		handler = middlewares[i].Function(handler)
+	}
+	return handler
+}

--- a/pkg/transport/proxy/common/middleware_test.go
+++ b/pkg/transport/proxy/common/middleware_test.go
@@ -1,0 +1,167 @@
+package common
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stacklok/toolhive/pkg/transport/types"
+)
+
+func TestApplyMiddlewares(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty middleware slice", func(t *testing.T) {
+		t.Parallel()
+
+		handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			if _, err := w.Write([]byte("handler")); err != nil {
+				t.Fatal(err)
+			}
+		})
+
+		result := ApplyMiddlewares(handler)
+
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		result.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Errorf("Expected status 200, got %d", rec.Code)
+		}
+		if rec.Body.String() != "handler" {
+			t.Errorf("Expected body 'handler', got %s", rec.Body.String())
+		}
+	})
+
+	t.Run("single middleware", func(t *testing.T) {
+		t.Parallel()
+
+		handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			if _, err := w.Write([]byte("handler")); err != nil {
+				t.Fatal(err)
+			}
+		})
+
+		middleware := types.NamedMiddleware{
+			Name: "test",
+			Function: func(next http.Handler) http.Handler {
+				return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if _, err := w.Write([]byte("before-")); err != nil {
+						t.Fatal(err)
+					}
+					next.ServeHTTP(w, r)
+					if _, err := w.Write([]byte("-after")); err != nil {
+						t.Fatal(err)
+					}
+				})
+			},
+		}
+
+		result := ApplyMiddlewares(handler, middleware)
+
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		result.ServeHTTP(rec, req)
+
+		expected := "before-handler-after"
+		if rec.Body.String() != expected {
+			t.Errorf("Expected body %q, got %q", expected, rec.Body.String())
+		}
+	})
+
+	t.Run("multiple middlewares applied in correct order", func(t *testing.T) {
+		t.Parallel()
+
+		handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			if _, err := w.Write([]byte("handler")); err != nil {
+				t.Fatal(err)
+			}
+		})
+
+		middleware1 := types.NamedMiddleware{
+			Name: "first",
+			Function: func(next http.Handler) http.Handler {
+				return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if _, err := w.Write([]byte("1-")); err != nil {
+						t.Fatal(err)
+					}
+					next.ServeHTTP(w, r)
+				})
+			},
+		}
+
+		middleware2 := types.NamedMiddleware{
+			Name: "second",
+			Function: func(next http.Handler) http.Handler {
+				return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if _, err := w.Write([]byte("2-")); err != nil {
+						t.Fatal(err)
+					}
+					next.ServeHTTP(w, r)
+				})
+			},
+		}
+
+		middleware3 := types.NamedMiddleware{
+			Name: "third",
+			Function: func(next http.Handler) http.Handler {
+				return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if _, err := w.Write([]byte("3-")); err != nil {
+						t.Fatal(err)
+					}
+					next.ServeHTTP(w, r)
+				})
+			},
+		}
+
+		result := ApplyMiddlewares(handler, middleware1, middleware2, middleware3)
+
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		result.ServeHTTP(rec, req)
+
+		// First middleware should be applied first (outermost)
+		expected := "1-2-3-handler"
+		if rec.Body.String() != expected {
+			t.Errorf("Expected body %q, got %q", expected, rec.Body.String())
+		}
+	})
+
+	t.Run("middleware with state", func(t *testing.T) {
+		t.Parallel()
+
+		handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			if _, err := w.Write([]byte("handler")); err != nil {
+				t.Fatal(err)
+			}
+		})
+
+		counter := 0
+		middleware := types.NamedMiddleware{
+			Name: "counter",
+			Function: func(next http.Handler) http.Handler {
+				return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					counter++
+					next.ServeHTTP(w, r)
+				})
+			},
+		}
+
+		result := ApplyMiddlewares(handler, middleware)
+
+		// Call handler twice
+		rec1 := httptest.NewRecorder()
+		req1 := httptest.NewRequest(http.MethodGet, "/", nil)
+		result.ServeHTTP(rec1, req1)
+
+		rec2 := httptest.NewRecorder()
+		req2 := httptest.NewRequest(http.MethodGet, "/", nil)
+		result.ServeHTTP(rec2, req2)
+
+		if counter != 2 {
+			t.Errorf("Expected counter to be 2, got %d", counter)
+		}
+	})
+}

--- a/pkg/transport/proxy/common/server.go
+++ b/pkg/transport/proxy/common/server.go
@@ -1,0 +1,51 @@
+package common
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/stacklok/toolhive/pkg/logger"
+)
+
+// ServerConfig holds configuration for creating an HTTP server.
+type ServerConfig struct {
+	Host              string
+	Port              int
+	Handler           http.Handler
+	ReadHeaderTimeout time.Duration
+}
+
+// DefaultReadHeaderTimeout is the default timeout for reading request headers.
+const DefaultReadHeaderTimeout = 10 * time.Second
+
+// NewHTTPServer creates a new HTTP server with standard security settings.
+func NewHTTPServer(config ServerConfig) *http.Server {
+	if config.ReadHeaderTimeout == 0 {
+		config.ReadHeaderTimeout = DefaultReadHeaderTimeout
+	}
+
+	return &http.Server{
+		Addr:              fmt.Sprintf("%s:%d", config.Host, config.Port),
+		Handler:           config.Handler,
+		ReadHeaderTimeout: config.ReadHeaderTimeout,
+	}
+}
+
+// MountHealthCheck adds a health check endpoint to the mux without middlewares.
+func MountHealthCheck(mux *http.ServeMux, healthChecker http.Handler) {
+	if healthChecker != nil {
+		mux.Handle("/health", healthChecker)
+	}
+}
+
+// MountMetrics adds a Prometheus metrics endpoint to the mux without middlewares.
+// Returns true if the handler was non-nil and mounted.
+func MountMetrics(mux *http.ServeMux, metricsHandler http.Handler) bool {
+	if metricsHandler != nil {
+		mux.Handle("/metrics", metricsHandler)
+		logger.Info("Prometheus metrics endpoint enabled at /metrics")
+		return true
+	}
+	return false
+}

--- a/pkg/transport/proxy/common/server_test.go
+++ b/pkg/transport/proxy/common/server_test.go
@@ -1,0 +1,188 @@
+package common
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestNewHTTPServer(t *testing.T) {
+	t.Parallel()
+
+	t.Run("creates server with default ReadHeaderTimeout", func(t *testing.T) {
+		t.Parallel()
+
+		handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+
+		config := ServerConfig{
+			Host:    "localhost",
+			Port:    8080,
+			Handler: handler,
+		}
+
+		server := NewHTTPServer(config)
+
+		if server.Addr != "localhost:8080" {
+			t.Errorf("Expected Addr to be localhost:8080, got %s", server.Addr)
+		}
+
+		if server.Handler == nil {
+			t.Error("Expected Handler to be non-nil")
+		}
+
+		if server.ReadHeaderTimeout != DefaultReadHeaderTimeout {
+			t.Errorf("Expected ReadHeaderTimeout to be %v, got %v", DefaultReadHeaderTimeout, server.ReadHeaderTimeout)
+		}
+	})
+
+	t.Run("creates server with custom ReadHeaderTimeout", func(t *testing.T) {
+		t.Parallel()
+
+		handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+
+		customTimeout := 30 * time.Second
+		config := ServerConfig{
+			Host:              "0.0.0.0",
+			Port:              9090,
+			Handler:           handler,
+			ReadHeaderTimeout: customTimeout,
+		}
+
+		server := NewHTTPServer(config)
+
+		if server.Addr != "0.0.0.0:9090" {
+			t.Errorf("Expected Addr to be 0.0.0.0:9090, got %s", server.Addr)
+		}
+
+		if server.ReadHeaderTimeout != customTimeout {
+			t.Errorf("Expected ReadHeaderTimeout to be %v, got %v", customTimeout, server.ReadHeaderTimeout)
+		}
+	})
+
+	t.Run("formats address correctly for IPv6", func(t *testing.T) {
+		t.Parallel()
+
+		handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+
+		config := ServerConfig{
+			Host:    "::1",
+			Port:    8080,
+			Handler: handler,
+		}
+
+		server := NewHTTPServer(config)
+
+		if server.Addr != "::1:8080" {
+			t.Errorf("Expected Addr to be ::1:8080, got %s", server.Addr)
+		}
+	})
+}
+
+func TestMountHealthCheck(t *testing.T) {
+	t.Parallel()
+
+	t.Run("mounts health check when handler is non-nil", func(t *testing.T) {
+		t.Parallel()
+
+		mux := http.NewServeMux()
+		healthHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			if _, err := w.Write([]byte("healthy")); err != nil {
+				t.Fatal(err)
+			}
+		})
+
+		MountHealthCheck(mux, healthHandler)
+
+		// Test that the health endpoint works
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/health", nil)
+		mux.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Errorf("Expected status 200, got %d", rec.Code)
+		}
+
+		if rec.Body.String() != "healthy" {
+			t.Errorf("Expected body 'healthy', got %s", rec.Body.String())
+		}
+	})
+
+	t.Run("does not mount when handler is nil", func(t *testing.T) {
+		t.Parallel()
+
+		mux := http.NewServeMux()
+		MountHealthCheck(mux, nil)
+
+		// Test that the health endpoint returns 404
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/health", nil)
+		mux.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusNotFound {
+			t.Errorf("Expected status 404, got %d", rec.Code)
+		}
+	})
+}
+
+func TestMountMetrics(t *testing.T) {
+	t.Parallel()
+
+	t.Run("mounts metrics and returns true when handler is non-nil", func(t *testing.T) {
+		t.Parallel()
+
+		mux := http.NewServeMux()
+		metricsHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			if _, err := w.Write([]byte("metrics")); err != nil {
+				t.Fatal(err)
+			}
+		})
+
+		mounted := MountMetrics(mux, metricsHandler)
+
+		if !mounted {
+			t.Error("Expected MountMetrics to return true")
+		}
+
+		// Test that the metrics endpoint works
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+		mux.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Errorf("Expected status 200, got %d", rec.Code)
+		}
+
+		if rec.Body.String() != "metrics" {
+			t.Errorf("Expected body 'metrics', got %s", rec.Body.String())
+		}
+	})
+
+	t.Run("does not mount and returns false when handler is nil", func(t *testing.T) {
+		t.Parallel()
+
+		mux := http.NewServeMux()
+		mounted := MountMetrics(mux, nil)
+
+		if mounted {
+			t.Error("Expected MountMetrics to return false")
+		}
+
+		// Test that the metrics endpoint returns 404
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+		mux.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusNotFound {
+			t.Errorf("Expected status 404, got %d", rec.Code)
+		}
+	})
+}

--- a/pkg/transport/proxy/common/sse.go
+++ b/pkg/transport/proxy/common/sse.go
@@ -1,0 +1,23 @@
+package common
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// SetSSEHeaders sets standard Server-Sent Events response headers.
+func SetSSEHeaders(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+}
+
+// GetFlusher returns a http.Flusher from the ResponseWriter.
+// Returns an error if the ResponseWriter doesn't support flushing.
+func GetFlusher(w http.ResponseWriter) (http.Flusher, error) {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		return nil, fmt.Errorf("response writer does not support flushing")
+	}
+	return flusher, nil
+}

--- a/pkg/transport/proxy/common/sse_test.go
+++ b/pkg/transport/proxy/common/sse_test.go
@@ -1,0 +1,100 @@
+package common
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestSetSSEHeaders(t *testing.T) {
+	t.Parallel()
+
+	t.Run("sets all required SSE headers", func(t *testing.T) {
+		t.Parallel()
+
+		rec := httptest.NewRecorder()
+		SetSSEHeaders(rec)
+
+		if ct := rec.Header().Get("Content-Type"); ct != "text/event-stream" {
+			t.Errorf("Expected Content-Type to be text/event-stream, got %s", ct)
+		}
+
+		if cc := rec.Header().Get("Cache-Control"); cc != "no-cache" {
+			t.Errorf("Expected Cache-Control to be no-cache, got %s", cc)
+		}
+
+		if conn := rec.Header().Get("Connection"); conn != "keep-alive" {
+			t.Errorf("Expected Connection to be keep-alive, got %s", conn)
+		}
+	})
+
+	t.Run("overwrites existing headers", func(t *testing.T) {
+		t.Parallel()
+
+		rec := httptest.NewRecorder()
+		rec.Header().Set("Content-Type", "application/json")
+		rec.Header().Set("Cache-Control", "max-age=3600")
+		rec.Header().Set("Connection", "close")
+
+		SetSSEHeaders(rec)
+
+		if ct := rec.Header().Get("Content-Type"); ct != "text/event-stream" {
+			t.Errorf("Expected Content-Type to be text/event-stream, got %s", ct)
+		}
+
+		if cc := rec.Header().Get("Cache-Control"); cc != "no-cache" {
+			t.Errorf("Expected Cache-Control to be no-cache, got %s", cc)
+		}
+
+		if conn := rec.Header().Get("Connection"); conn != "keep-alive" {
+			t.Errorf("Expected Connection to be keep-alive, got %s", conn)
+		}
+	})
+}
+
+func TestGetFlusher(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns flusher when ResponseWriter supports it", func(t *testing.T) {
+		t.Parallel()
+
+		rec := httptest.NewRecorder()
+		flusher, err := GetFlusher(rec)
+
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+
+		if flusher == nil {
+			t.Error("Expected flusher to be non-nil")
+		}
+	})
+
+	t.Run("returns error when ResponseWriter doesn't support flushing", func(t *testing.T) {
+		t.Parallel()
+
+		// Create a ResponseWriter that doesn't implement http.Flusher
+		type nonFlushableWriter struct {
+			http.ResponseWriter
+		}
+
+		w := &nonFlushableWriter{
+			ResponseWriter: httptest.NewRecorder(),
+		}
+
+		flusher, err := GetFlusher(w)
+
+		if err == nil {
+			t.Error("Expected error, got nil")
+		}
+
+		if flusher != nil {
+			t.Error("Expected flusher to be nil")
+		}
+
+		expectedErr := "response writer does not support flushing"
+		if err.Error() != expectedErr {
+			t.Errorf("Expected error message %q, got %q", expectedErr, err.Error())
+		}
+	})
+}


### PR DESCRIPTION
While reviewing other changes, I discovered that there is a lot of duplication across the different proxy implementations. This PR splits out the shared logic into a common package, and reuses them in the proxy implementations. This gets rid of the duplicated logic.