### PR TITLE
Add retry logic for health check failures

### DIFF
--- a/pkg/transport/proxy/transparent/transparent_test.go
+++ b/pkg/transport/proxy/transparent/transparent_test.go
@@ -567,3 +567,16 @@ func TestTransparentProxy_NilUnauthorizedCallback(t *testing.T) {
 	// Verify 401 was returned
 	assert.Equal(t, http.StatusUnauthorized, rec.Code)
 }
+
+// TestHealthCheckRetryConstants verifies the retry configuration constants
+func TestHealthCheckRetryConstants(t *testing.T) {
+	t.Parallel()
+
+	// Verify retry count is reasonable (not too low, not too high)
+	assert.GreaterOrEqual(t, healthCheckRetryCount, 2, "Should retry at least twice before giving up")
+	assert.LessOrEqual(t, healthCheckRetryCount, 10, "Should not retry too many times")
+
+	// Verify retry delay is reasonable
+	assert.GreaterOrEqual(t, healthCheckRetryDelay, 1*time.Second, "Retry delay should be at least 1 second")
+	assert.LessOrEqual(t, healthCheckRetryDelay, 30*time.Second, "Retry delay should not be too long")
+}


### PR DESCRIPTION
Fixes #3221

Previously, remote MCP servers would shut down on the first health check failure, requiring manual restart. This change adds:

- 3 retry attempts before marking a server unhealthy
- 5 second delay between retries
- Logging for retry attempts and recovery

This prevents transient network issues (like VPN/firewall idle connection resets) from immediately killing the proxy.