### PR TITLE
Check if a secret is empty before migrating

### DIFF
--- a/pkg/runner/config.go
+++ b/pkg/runner/config.go
@@ -232,6 +232,10 @@ func migrateOAuthClientSecret(config *RunConfig) error {
 		return nil // No OAuth config to migrate
 	}
 
+	if config.RemoteAuthConfig.ClientSecret == "" {
+		return nil
+	}
+
 	// Check if the client secret is already in CLI format
 	if _, err := secrets.ParseSecretParameter(config.RemoteAuthConfig.ClientSecret); err == nil {
 		return nil // Already in CLI format, no migration needed
@@ -265,6 +269,10 @@ func migrateOAuthClientSecret(config *RunConfig) error {
 func migrateBearerToken(config *RunConfig) error {
 	if config.RemoteAuthConfig == nil {
 		return nil // No remote auth config to migrate
+	}
+
+	if config.RemoteAuthConfig.BearerToken == "" {
+		return nil
 	}
 
 	// Check if the bearer token is already in CLI format


### PR DESCRIPTION
## Change
Added a check for an empty secret value before running the migration.

## Reasoning
I was noticing the migration happening on every command:
```
$ thv list  --all                                                        
10:38AM	INFO	Saved run configuration for fetch123
10:38AM	INFO	Saved run configuration for fetch123
10:38AM	INFO	Saved run configuration for gh-remote-3
10:38AM	INFO	Saved run configuration for gr2
10:38AM	INFO	Saved run configuration for gr2
A new version of ToolHive is available: v0.6.16
Currently running: v0.6.15-76-gab329ce8
10:38AM	INFO	Saved run configuration for fetch123
10:38AM	INFO	Saved run configuration for fetch123
10:38AM	INFO	Saved run configuration for gh-remote-3
10:38AM	INFO	Saved run configuration for gr2
10:38AM	INFO	Saved run configuration for gr2
NAME          PACKAGE   STATUS    URL                          PORT    GROUP     CREATED
gh-remote-3   remote    running   http://127.0.0.1:58495/mcp   58495   default   2026-01-08 10:17:40.239077 +0100 CET

$ thv list --all
10:24AM	INFO	Saved run configuration for fetch123
10:24AM	INFO	Saved run configuration for fetch123
10:24AM	INFO	Saved run configuration for gh-remote-3
10:24AM	INFO	Saved run configuration for gr2
10:24AM	INFO	Saved run configuration for gr2
A new version of ToolHive is available: v0.6.16
Currently running: v0.6.15-76-gab329ce8
10:24AM	INFO	Saved run configuration for fetch123
10:24AM	INFO	Saved run configuration for fetch123
10:24AM	INFO	Saved run configuration for gh-remote-3
10:24AM	INFO	Saved run configuration for gr2
10:24AM	INFO	Saved run configuration for gr2
NAME          PACKAGE   STATUS    URL                          PORT    GROUP     CREATED
gh-remote-3   remote    running   http://127.0.0.1:58495/mcp   58495   default   2026-01-08 10:17:40.239077 +0100 CET
```