### PR TITLE
authserver: Add OAuth session management for JWT claims and IDP linking

### DIFF
--- a/pkg/authserver/server/session/session.go
+++ b/pkg/authserver/server/session/session.go
@@ -1,0 +1,161 @@
+// Copyright 2025 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package session provides OAuth session management for the authorization server.
+// Sessions link issued access tokens to upstream identity provider tokens,
+// enabling token exchange and refresh operations.
+package session
+
+import (
+	"github.com/ory/fosite"
+	"github.com/ory/fosite/handler/oauth2"
+	"github.com/ory/fosite/token/jwt"
+)
+
+// Factory is a function that creates a new session given subject, IDP session ID, and client ID.
+// This allows storage implementations to create sessions without importing this package directly.
+//
+// The factory is primarily used during deserialization where the clientID may be empty
+// because the client_id claim is preserved in the JWT claims Extra map from the original
+// serialized session data.
+type Factory func(subject, idpSessionID, clientID string) fosite.Session
+
+// UpstreamSession is an interface for sessions that support IDP linking and JWT claims.
+// It embeds oauth2.JWTSessionContainer (which includes fosite.Session, GetJWTClaims,
+// and GetJWTHeader) and adds IDP session tracking.
+// This interface is used by the storage layer for serialization/deserialization.
+type UpstreamSession interface {
+	oauth2.JWTSessionContainer
+	GetIDPSessionID() string
+}
+
+// TokenSessionIDClaimKey is the JWT claim key for the token session ID.
+// This links JWT access tokens to stored upstream IDP tokens.
+// We use "tsid" instead of "sid" to avoid confusion with OIDC session management
+// which defines "sid" for different purposes (RFC 7519, OIDC Session Management).
+const TokenSessionIDClaimKey = "tsid"
+
+// ClientIDClaimKey is the JWT claim key for the OAuth client ID.
+// This identifies which client was issued the token.
+const ClientIDClaimKey = "client_id"
+
+// Session extends fosite's JWT session with an IDP session reference.
+// This allows the authorization server to link issued tokens to
+// upstream IDP tokens stored separately.
+//
+// Most methods are provided by the embedded *oauth2.JWTSession. This type
+// only adds IDP session tracking and overrides Clone() to include the
+// UpstreamSessionID field.
+//
+// Concurrency: Sessions are designed to be request-scoped and are not
+// safe for concurrent access from multiple goroutines. This follows
+// Fosite's design pattern where sessions are created per-request,
+// populated by handlers, and then persisted to storage. The storage
+// layer is responsible for thread-safe access to stored sessions.
+type Session struct {
+	*oauth2.JWTSession
+
+	// UpstreamSessionID links this session to stored upstream IDP tokens.
+	// This ID is used to retrieve the IDP tokens from storage.
+	UpstreamSessionID string
+}
+
+// New creates a new Session with the given subject, IDP session ID, and client ID.
+//
+// Parameters:
+//   - subject: The OAuth subject (user identifier). May be empty for placeholder sessions.
+//   - idpSessionID: Links to upstream IDP tokens in storage. If provided, it will be
+//     included in the JWT claims as "tsid" to allow proxy middleware to look up
+//     upstream IDP tokens.
+//   - clientID: The OAuth client ID. When provided, it will be included in the JWT
+//     claims as "client_id" for binding verification per RFC 9068.
+//
+// ClientID handling:
+//   - For token issuance (authorize handler): Pass the client ID to ensure RFC 9068
+//     compliance. The client_id claim will be embedded in the JWT.
+//   - For token exchange (token handler): May be empty - Fosite copies claims from
+//     the stored authorize session, preserving the original client_id.
+//   - For deserialization: May be empty - the client_id claim is preserved in the
+//     JWT claims Extra map from the serialized session data.
+//
+// Note: The remaining RFC 9068 required claims (iss, aud, exp, iat, jti) are
+// populated by Fosite during token generation. This session only initializes
+// custom claims that are not part of Fosite's standard JWT handling.
+func New(subject, idpSessionID, clientID string) *Session {
+	// Initialize the Extra map for JWT claims
+	claimsExtra := make(map[string]any)
+
+	// Add tsid claim if idpSessionID is provided
+	if idpSessionID != "" {
+		claimsExtra[TokenSessionIDClaimKey] = idpSessionID
+	}
+
+	// Add client_id claim for binding verification per RFC 9068
+	// This may be empty for placeholder sessions or deserialization;
+	// in those cases the claim is preserved from the original session.
+	if clientID != "" {
+		claimsExtra[ClientIDClaimKey] = clientID
+	}
+
+	return &Session{
+		JWTSession: &oauth2.JWTSession{
+			JWTClaims: &jwt.JWTClaims{
+				Subject: subject,
+				Extra:   claimsExtra,
+			},
+			JWTHeader: &jwt.Headers{
+				Extra: make(map[string]any),
+			},
+			Subject: subject, // Also set on JWTSession for fosite compatibility
+		},
+		UpstreamSessionID: idpSessionID,
+	}
+}
+
+// Clone creates a deep copy of the session.
+// This overrides the embedded JWTSession.Clone() to also copy UpstreamSessionID.
+func (s *Session) Clone() fosite.Session {
+	if s == nil {
+		return nil
+	}
+
+	var jwtSession *oauth2.JWTSession
+	if s.JWTSession != nil {
+		jwtSession = s.JWTSession.Clone().(*oauth2.JWTSession)
+	}
+
+	return &Session{
+		JWTSession:        jwtSession,
+		UpstreamSessionID: s.UpstreamSessionID,
+	}
+}
+
+// GetIDPSessionID returns the IDP session ID.
+func (s *Session) GetIDPSessionID() string {
+	if s == nil {
+		return ""
+	}
+	return s.UpstreamSessionID
+}
+
+// SetIDPSessionID sets the IDP session ID.
+func (s *Session) SetIDPSessionID(id string) {
+	if s == nil {
+		return
+	}
+	s.UpstreamSessionID = id
+}
+
+// Compile-time interface compliance check.
+var _ UpstreamSession = (*Session)(nil)

--- a/pkg/authserver/server/session/session_test.go
+++ b/pkg/authserver/server/session/session_test.go
@@ -1,0 +1,284 @@
+// Copyright 2025 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package session
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ory/fosite"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFactory(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		subject      string
+		idpSessionID string
+		clientID     string
+	}{
+		{
+			name:         "creates session with all parameters",
+			subject:      "user@example.com",
+			idpSessionID: "idp-session-123",
+			clientID:     "client-456",
+		},
+		{
+			name:         "creates session for deserialization (empty clientID)",
+			subject:      "deserialized-user",
+			idpSessionID: "deserialized-idp-session",
+			clientID:     "",
+		},
+		{
+			name:         "creates mock session for testing",
+			subject:      "test-subject",
+			idpSessionID: "",
+			clientID:     "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			factory := Factory(func(subject, idpSessionID, clientID string) fosite.Session {
+				return New(subject, idpSessionID, clientID)
+			})
+
+			session := factory(tt.subject, tt.idpSessionID, tt.clientID)
+
+			require.NotNil(t, session)
+			assert.Equal(t, tt.subject, session.GetSubject())
+
+			concreteSession, ok := session.(*Session)
+			require.True(t, ok, "factory should return *Session")
+			assert.Equal(t, tt.idpSessionID, concreteSession.UpstreamSessionID)
+
+			// Verify UpstreamSession interface works for storage serialization
+			idpSession, ok := session.(UpstreamSession)
+			require.True(t, ok, "session should implement UpstreamSession")
+			assert.Equal(t, tt.idpSessionID, idpSession.GetIDPSessionID())
+		})
+	}
+}
+
+func TestNew(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		subject        string
+		idpSessionID   string
+		clientID       string
+		expectTsid     bool
+		expectClientID bool
+	}{
+		{
+			name:           "with all parameters",
+			subject:        "user@example.com",
+			idpSessionID:   "upstream-session-123",
+			clientID:       "test-client-id",
+			expectTsid:     true,
+			expectClientID: true,
+		},
+		{
+			name:           "with subject and IDP session ID only",
+			subject:        "user@example.com",
+			idpSessionID:   "upstream-session-123",
+			clientID:       "",
+			expectTsid:     true,
+			expectClientID: false,
+		},
+		{
+			name:           "with empty subject",
+			subject:        "",
+			idpSessionID:   "upstream-session-456",
+			clientID:       "",
+			expectTsid:     true,
+			expectClientID: false,
+		},
+		{
+			name:           "with empty IDP session ID",
+			subject:        "user@example.com",
+			idpSessionID:   "",
+			clientID:       "",
+			expectTsid:     false,
+			expectClientID: false,
+		},
+		{
+			name:           "with all empty (placeholder session)",
+			subject:        "",
+			idpSessionID:   "",
+			clientID:       "",
+			expectTsid:     false,
+			expectClientID: false,
+		},
+		{
+			name:           "with only clientID",
+			subject:        "",
+			idpSessionID:   "",
+			clientID:       "my-client",
+			expectTsid:     false,
+			expectClientID: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			session := New(tt.subject, tt.idpSessionID, tt.clientID)
+
+			require.NotNil(t, session)
+			require.NotNil(t, session.JWTSession)
+			require.NotNil(t, session.JWTClaims)
+			require.NotNil(t, session.JWTHeader)
+
+			assert.Equal(t, tt.subject, session.GetSubject())
+			assert.Equal(t, tt.idpSessionID, session.UpstreamSessionID)
+
+			claimsMap := session.GetJWTClaims().ToMapClaims()
+
+			if tt.expectTsid {
+				assert.Equal(t, tt.idpSessionID, claimsMap[TokenSessionIDClaimKey])
+			} else {
+				_, ok := claimsMap[TokenSessionIDClaimKey]
+				assert.False(t, ok, "tsid claim should not be present when idpSessionID is empty")
+			}
+
+			if tt.expectClientID {
+				assert.Equal(t, tt.clientID, claimsMap[ClientIDClaimKey])
+			} else {
+				_, ok := claimsMap[ClientIDClaimKey]
+				assert.False(t, ok, "client_id claim should not be present when clientID is empty")
+			}
+		})
+	}
+}
+
+func TestSession_Clone(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		session       func() *Session
+		expectNil     bool
+		checkDeepCopy bool
+	}{
+		{
+			name:      "nil session returns nil",
+			session:   func() *Session { return nil },
+			expectNil: true,
+		},
+		{
+			name: "session with nil JWTSession",
+			session: func() *Session {
+				return &Session{UpstreamSessionID: "upstream-123"}
+			},
+			expectNil: false,
+		},
+		{
+			name: "fully populated session creates deep copy",
+			session: func() *Session {
+				s := New("user@example.com", "upstream-session-789", "client-123")
+				s.Username = "original-username"
+				s.SetExpiresAt(fosite.AccessToken, time.Now().Add(time.Hour))
+				return s
+			},
+			expectNil:     false,
+			checkDeepCopy: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			original := tt.session()
+			cloned := original.Clone()
+
+			if tt.expectNil {
+				assert.Nil(t, cloned)
+				return
+			}
+
+			require.NotNil(t, cloned)
+			clonedSession, ok := cloned.(*Session)
+			require.True(t, ok)
+			assert.Equal(t, original.UpstreamSessionID, clonedSession.UpstreamSessionID)
+
+			if tt.checkDeepCopy {
+				// Verify modifying clone doesn't affect original
+				clonedSession.UpstreamSessionID = "modified"
+				clonedSession.SetSubject("modified-subject")
+				clonedSession.Username = "modified-username"
+
+				assert.Equal(t, "upstream-session-789", original.UpstreamSessionID)
+				assert.Equal(t, "user@example.com", original.GetSubject())
+				assert.Equal(t, "original-username", original.GetUsername())
+			}
+		})
+	}
+}
+
+func TestSession_UpstreamSessionID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		session   *Session
+		setID     string
+		wantGet   string
+		wantPanic bool
+	}{
+		{
+			name:    "get and set on new session",
+			session: New("subject", "initial-upstream", "client"),
+			setID:   "updated-upstream",
+			wantGet: "initial-upstream",
+		},
+		{
+			name:    "get on nil session returns empty",
+			session: nil,
+			wantGet: "",
+		},
+		{
+			name:      "set on nil session does not panic",
+			session:   nil,
+			setID:     "test-id",
+			wantPanic: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.wantGet, tt.session.GetIDPSessionID())
+
+			if tt.setID != "" {
+				assert.NotPanics(t, func() {
+					tt.session.SetIDPSessionID(tt.setID)
+				})
+				if tt.session != nil {
+					assert.Equal(t, tt.setID, tt.session.GetIDPSessionID())
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
This package provides custom session handling for the authorization server, extending fosite's JWTSession with upstream IDP session tracking. It links issued OAuth tokens to upstream identity provider sessions, enabling token exchange by storing references to IDP tokens and adding custom JWT claims (tsid, client_id) for token binding.

The Session type embeds *oauth2.JWTSession to reuse fosite's JWT handling methods rather than reimplementing them. The UpstreamSession interface embeds oauth2.JWTSessionContainer for compatibility with fosite's type assertions. Only Clone() is overridden to copy the UpstreamSessionID field; all other methods are inherited from fosite's JWTSession.

When the authserver will be done, the authorize handler will create sessions with the subject, IDP session ID, and client ID when completing OAuth authorization flows. The token handler creates placeholder sessions for token exchange requests where fosite populates claims from the stored authorize session. The storage layer uses the UpstreamSession interface and Factory type for session serialization/deserialization without direct package coupling.