### PR TITLE
authserver: Add RFC 7591 Dynamic Client Registration validation

### DIFF
--- a/pkg/authserver/server/registration/dcr.go
+++ b/pkg/authserver/server/registration/dcr.go
@@ -1,0 +1,227 @@
+// Copyright 2025 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package registration provides OAuth 2.0 Dynamic Client Registration (DCR)
+// functionality per RFC 7591, including request validation and secure redirect
+// URI handling for public native clients.
+package registration
+
+import (
+	"context"
+	"net/url"
+	"slices"
+
+	"github.com/ory/fosite"
+)
+
+// DCR error codes per RFC 7591 Section 3.2.2
+const (
+	// DCRErrorInvalidRedirectURI indicates that the value of one or more
+	// redirect_uris is invalid.
+	DCRErrorInvalidRedirectURI = "invalid_redirect_uri"
+
+	// DCRErrorInvalidClientMetadata indicates that the value of one of the
+	// client metadata fields is invalid and the server has rejected this request.
+	DCRErrorInvalidClientMetadata = "invalid_client_metadata"
+)
+
+// Validation limits to prevent DoS attacks via excessively large requests.
+const (
+	// MaxRedirectURILength is the maximum allowed length for a single redirect URI.
+	MaxRedirectURILength = 2048
+
+	// MaxRedirectURICount is the maximum number of redirect URIs allowed per client.
+	MaxRedirectURICount = 10
+)
+
+// DCRRequest represents an OAuth 2.0 Dynamic Client Registration request
+// per RFC 7591 Section 2.
+type DCRRequest struct {
+	// RedirectURIs is an array of redirection URIs for the client.
+	// Required for public clients.
+	RedirectURIs []string `json:"redirect_uris"`
+
+	// ClientName is a human-readable name for the client.
+	ClientName string `json:"client_name,omitempty"`
+
+	// TokenEndpointAuthMethod is the requested authentication method for the token endpoint.
+	// For public clients, this must be "none".
+	TokenEndpointAuthMethod string `json:"token_endpoint_auth_method,omitempty"`
+
+	// GrantTypes is an array of OAuth 2.0 grant types the client may use.
+	// Defaults to ["authorization_code"] if not specified.
+	GrantTypes []string `json:"grant_types,omitempty"`
+
+	// ResponseTypes is an array of OAuth 2.0 response types the client may use.
+	// Defaults to ["code"] if not specified.
+	ResponseTypes []string `json:"response_types,omitempty"`
+}
+
+// DCRResponse represents a successful OAuth 2.0 Dynamic Client Registration
+// response per RFC 7591 Section 3.2.1.
+type DCRResponse struct {
+	// ClientID is the unique identifier for the client.
+	ClientID string `json:"client_id"`
+
+	// ClientIDIssuedAt is the time at which the client identifier was issued,
+	// as a Unix timestamp.
+	ClientIDIssuedAt int64 `json:"client_id_issued_at,omitempty"`
+
+	// RedirectURIs is an array of redirection URIs for the client.
+	RedirectURIs []string `json:"redirect_uris"`
+
+	// ClientName is a human-readable name for the client.
+	ClientName string `json:"client_name,omitempty"`
+
+	// TokenEndpointAuthMethod is the authentication method for the token endpoint.
+	TokenEndpointAuthMethod string `json:"token_endpoint_auth_method"`
+
+	// GrantTypes is an array of OAuth 2.0 grant types the client may use.
+	GrantTypes []string `json:"grant_types"`
+
+	// ResponseTypes is an array of OAuth 2.0 response types the client may use.
+	ResponseTypes []string `json:"response_types"`
+}
+
+// DCRError represents an OAuth 2.0 Dynamic Client Registration error
+// response per RFC 7591 Section 3.2.2.
+type DCRError struct {
+	// Error is a single ASCII error code from the defined set.
+	Error string `json:"error"`
+
+	// ErrorDescription is a human-readable text providing additional information.
+	ErrorDescription string `json:"error_description,omitempty"`
+}
+
+// DefaultGrantTypes are the default grant types for registered clients.
+var DefaultGrantTypes = []string{"authorization_code", "refresh_token"}
+
+// DefaultResponseTypes are the default response types for registered clients.
+var DefaultResponseTypes = []string{"code"}
+
+// ValidateDCRRequest validates a DCR request according to RFC 7591
+// and the server's security policy (loopback-only public clients).
+// Returns the validated request with defaults applied, or an error.
+func ValidateDCRRequest(req *DCRRequest) (*DCRRequest, *DCRError) {
+	// 1. Validate redirect_uris - required
+	if len(req.RedirectURIs) == 0 {
+		return nil, &DCRError{
+			Error:            DCRErrorInvalidRedirectURI,
+			ErrorDescription: "redirect_uris is required",
+		}
+	}
+
+	// 2. Validate redirect_uris count limit
+	if len(req.RedirectURIs) > MaxRedirectURICount {
+		return nil, &DCRError{
+			Error:            DCRErrorInvalidRedirectURI,
+			ErrorDescription: "too many redirect_uris (maximum 10)",
+		}
+	}
+
+	// 3. Validate all redirect_uris per RFC 8252
+	for _, uri := range req.RedirectURIs {
+		if err := ValidateRedirectURI(uri); err != nil {
+			return nil, err
+		}
+	}
+
+	// 4. Validate/default token_endpoint_auth_method
+	authMethod := req.TokenEndpointAuthMethod
+	if authMethod == "" {
+		authMethod = "none"
+	}
+	if authMethod != "none" {
+		return nil, &DCRError{
+			Error:            DCRErrorInvalidClientMetadata,
+			ErrorDescription: "token_endpoint_auth_method must be 'none' for public clients",
+		}
+	}
+
+	// 5. Validate/default grant_types
+	grantTypes := req.GrantTypes
+	if len(grantTypes) == 0 {
+		grantTypes = DefaultGrantTypes
+	}
+	if !slices.Contains(grantTypes, "authorization_code") {
+		return nil, &DCRError{
+			Error:            DCRErrorInvalidClientMetadata,
+			ErrorDescription: "grant_types must include 'authorization_code'",
+		}
+	}
+
+	// 6. Validate/default response_types
+	responseTypes := req.ResponseTypes
+	if len(responseTypes) == 0 {
+		responseTypes = DefaultResponseTypes
+	}
+	if !slices.Contains(responseTypes, "code") {
+		return nil, &DCRError{
+			Error:            DCRErrorInvalidClientMetadata,
+			ErrorDescription: "response_types must include 'code'",
+		}
+	}
+
+	// Return validated request with defaults applied
+	return &DCRRequest{
+		RedirectURIs:            req.RedirectURIs,
+		ClientName:              req.ClientName,
+		TokenEndpointAuthMethod: authMethod,
+		GrantTypes:              grantTypes,
+		ResponseTypes:           responseTypes,
+	}, nil
+}
+
+// ValidateRedirectURI validates a redirect URI per RFC 8252:
+// - HTTPS is allowed for any address (web-based redirects)
+// - HTTP is only allowed for loopback addresses (127.0.0.1, [::1], localhost)
+func ValidateRedirectURI(uri string) *DCRError {
+	// Check length limit before parsing (DoS protection - fosite doesn't have this)
+	if len(uri) > MaxRedirectURILength {
+		return &DCRError{
+			Error:            DCRErrorInvalidRedirectURI,
+			ErrorDescription: "redirect_uri too long (maximum 2048 characters)",
+		}
+	}
+
+	parsed, err := url.Parse(uri)
+	if err != nil {
+		return &DCRError{
+			Error:            DCRErrorInvalidRedirectURI,
+			ErrorDescription: "invalid redirect_uri format",
+		}
+	}
+
+	// Delegate to fosite for RFC 6749 Section 3.1.2 validation:
+	// - URI must be absolute (have a scheme)
+	// - URI must not have a fragment component
+	if !fosite.IsValidRedirectURI(parsed) {
+		return &DCRError{
+			Error:            DCRErrorInvalidRedirectURI,
+			ErrorDescription: "redirect_uri must be an absolute URI without a fragment",
+		}
+	}
+
+	// Delegate to fosite for scheme security check per RFC 8252:
+	// - HTTPS is allowed for any address
+	// - HTTP is only allowed for loopback addresses (127.0.0.1, [::1], localhost, *.localhost)
+	if !fosite.IsRedirectURISecureStrict(context.Background(), parsed) {
+		return &DCRError{
+			Error:            DCRErrorInvalidRedirectURI,
+			ErrorDescription: "redirect_uri must use http (for loopback) or https scheme",
+		}
+	}
+
+	return nil
+}

--- a/pkg/authserver/server/registration/dcr_test.go
+++ b/pkg/authserver/server/registration/dcr_test.go
@@ -1,0 +1,451 @@
+// Copyright 2025 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registration
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateRedirectURI(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		uri         string
+		expectError bool
+		errorCode   string
+	}{
+		// HTTPS - allowed for any host
+		{
+			name:        "https with any host",
+			uri:         "https://example.com/callback",
+			expectError: false,
+		},
+		{
+			name:        "https with custom domain",
+			uri:         "https://myapp.example.org:8443/oauth/callback",
+			expectError: false,
+		},
+
+		// HTTP loopback addresses - allowed per RFC 8252
+		{
+			name:        "http with 127.0.0.1",
+			uri:         "http://127.0.0.1/callback",
+			expectError: false,
+		},
+		{
+			name:        "http with 127.0.0.1 and port",
+			uri:         "http://127.0.0.1:8080/callback",
+			expectError: false,
+		},
+		{
+			name:        "http with localhost",
+			uri:         "http://localhost/callback",
+			expectError: false,
+		},
+		{
+			name:        "http with localhost and port",
+			uri:         "http://localhost:9000/callback",
+			expectError: false,
+		},
+
+		// HTTP non-loopback - not allowed
+		{
+			name:        "http with non-loopback host",
+			uri:         "http://example.com/callback",
+			expectError: true,
+			errorCode:   DCRErrorInvalidRedirectURI,
+		},
+		{
+			name:        "http with IP address that is not loopback",
+			uri:         "http://192.168.1.1/callback",
+			expectError: true,
+			errorCode:   DCRErrorInvalidRedirectURI,
+		},
+
+		// Invalid URI format
+		{
+			name:        "invalid URI format - missing scheme",
+			uri:         "://invalid",
+			expectError: true,
+			errorCode:   DCRErrorInvalidRedirectURI,
+		},
+		{
+			name:        "invalid URI format - malformed",
+			uri:         "not a valid uri",
+			expectError: true,
+			errorCode:   DCRErrorInvalidRedirectURI,
+		},
+
+		// Other schemes - not allowed
+		{
+			name:        "ftp scheme not allowed",
+			uri:         "ftp://example.com/callback",
+			expectError: true,
+			errorCode:   DCRErrorInvalidRedirectURI,
+		},
+		{
+			name:        "file scheme not allowed",
+			uri:         "file:///callback",
+			expectError: true,
+			errorCode:   DCRErrorInvalidRedirectURI,
+		},
+		{
+			name:        "custom scheme not allowed",
+			uri:         "myapp://callback",
+			expectError: true,
+			errorCode:   DCRErrorInvalidRedirectURI,
+		},
+
+		// Length validation
+		{
+			name:        "redirect URI exceeding max length is rejected",
+			uri:         "https://example.com/" + strings.Repeat("a", MaxRedirectURILength),
+			expectError: true,
+			errorCode:   DCRErrorInvalidRedirectURI,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := ValidateRedirectURI(tt.uri)
+
+			if tt.expectError {
+				require.NotNil(t, err, "expected error for URI %q", tt.uri)
+				assert.Equal(t, tt.errorCode, err.Error)
+			} else {
+				assert.Nil(t, err, "unexpected error for URI %q: %v", tt.uri, err)
+			}
+		})
+	}
+}
+
+func TestValidateDCRRequest(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name               string
+		request            *DCRRequest
+		expectError        bool
+		errorCode          string
+		expectedAuthMethod string
+		expectedGrants     []string
+		expectedResponses  []string
+	}{
+		// Valid requests
+		{
+			name: "valid minimal request with loopback redirect URI",
+			request: &DCRRequest{
+				RedirectURIs: []string{"http://127.0.0.1/callback"},
+			},
+			expectError:        false,
+			expectedAuthMethod: "none",
+			expectedGrants:     DefaultGrantTypes,
+			expectedResponses:  DefaultResponseTypes,
+		},
+		{
+			name: "valid request with all fields specified",
+			request: &DCRRequest{
+				RedirectURIs:            []string{"http://localhost:8080/callback", "https://example.com/callback"},
+				ClientName:              "My Test Client",
+				TokenEndpointAuthMethod: "none",
+				GrantTypes:              []string{"authorization_code", "refresh_token"},
+				ResponseTypes:           []string{"code"},
+			},
+			expectError:        false,
+			expectedAuthMethod: "none",
+			expectedGrants:     []string{"authorization_code", "refresh_token"},
+			expectedResponses:  []string{"code"},
+		},
+		{
+			name: "valid request with https redirect URI",
+			request: &DCRRequest{
+				RedirectURIs: []string{"https://example.com/oauth/callback"},
+			},
+			expectError:        false,
+			expectedAuthMethod: "none",
+			expectedGrants:     DefaultGrantTypes,
+			expectedResponses:  DefaultResponseTypes,
+		},
+
+		// Empty redirect_uris
+		{
+			name: "empty redirect_uris",
+			request: &DCRRequest{
+				RedirectURIs: []string{},
+			},
+			expectError: true,
+			errorCode:   DCRErrorInvalidRedirectURI,
+		},
+		{
+			name: "nil redirect_uris",
+			request: &DCRRequest{
+				RedirectURIs: nil,
+			},
+			expectError: true,
+			errorCode:   DCRErrorInvalidRedirectURI,
+		},
+
+		// Too many redirect URIs
+		{
+			name: "too many redirect URIs",
+			request: &DCRRequest{
+				RedirectURIs: []string{
+					"http://127.0.0.1:1/callback",
+					"http://127.0.0.1:2/callback",
+					"http://127.0.0.1:3/callback",
+					"http://127.0.0.1:4/callback",
+					"http://127.0.0.1:5/callback",
+					"http://127.0.0.1:6/callback",
+					"http://127.0.0.1:7/callback",
+					"http://127.0.0.1:8/callback",
+					"http://127.0.0.1:9/callback",
+					"http://127.0.0.1:10/callback",
+					"http://127.0.0.1:11/callback", // 11th - exceeds limit
+				},
+			},
+			expectError: true,
+			errorCode:   DCRErrorInvalidRedirectURI,
+		},
+
+		// Invalid redirect URI in list
+		{
+			name: "invalid redirect URI in list",
+			request: &DCRRequest{
+				RedirectURIs: []string{"http://127.0.0.1/callback", "http://example.com/callback"},
+			},
+			expectError: true,
+			errorCode:   DCRErrorInvalidRedirectURI,
+		},
+		{
+			name: "malformed redirect URI in list",
+			request: &DCRRequest{
+				RedirectURIs: []string{"://invalid"},
+			},
+			expectError: true,
+			errorCode:   DCRErrorInvalidRedirectURI,
+		},
+
+		// token_endpoint_auth_method validation
+		{
+			name: "token_endpoint_auth_method = none",
+			request: &DCRRequest{
+				RedirectURIs:            []string{"http://127.0.0.1/callback"},
+				TokenEndpointAuthMethod: "none",
+			},
+			expectError:        false,
+			expectedAuthMethod: "none",
+		},
+		{
+			name: "token_endpoint_auth_method empty defaults to none",
+			request: &DCRRequest{
+				RedirectURIs:            []string{"http://127.0.0.1/callback"},
+				TokenEndpointAuthMethod: "",
+			},
+			expectError:        false,
+			expectedAuthMethod: "none",
+		},
+		{
+			name: "token_endpoint_auth_method = client_secret_basic fails",
+			request: &DCRRequest{
+				RedirectURIs:            []string{"http://127.0.0.1/callback"},
+				TokenEndpointAuthMethod: "client_secret_basic",
+			},
+			expectError: true,
+			errorCode:   DCRErrorInvalidClientMetadata,
+		},
+		{
+			name: "token_endpoint_auth_method = client_secret_post fails",
+			request: &DCRRequest{
+				RedirectURIs:            []string{"http://127.0.0.1/callback"},
+				TokenEndpointAuthMethod: "client_secret_post",
+			},
+			expectError: true,
+			errorCode:   DCRErrorInvalidClientMetadata,
+		},
+
+		// grant_types validation
+		{
+			name: "grant_types defaults when empty",
+			request: &DCRRequest{
+				RedirectURIs: []string{"http://127.0.0.1/callback"},
+				GrantTypes:   []string{},
+			},
+			expectError:    false,
+			expectedGrants: DefaultGrantTypes,
+		},
+		{
+			name: "grant_types defaults when nil",
+			request: &DCRRequest{
+				RedirectURIs: []string{"http://127.0.0.1/callback"},
+				GrantTypes:   nil,
+			},
+			expectError:    false,
+			expectedGrants: DefaultGrantTypes,
+		},
+		{
+			name: "grant_types without authorization_code fails",
+			request: &DCRRequest{
+				RedirectURIs: []string{"http://127.0.0.1/callback"},
+				GrantTypes:   []string{"refresh_token"},
+			},
+			expectError: true,
+			errorCode:   DCRErrorInvalidClientMetadata,
+		},
+		{
+			name: "grant_types with only client_credentials fails",
+			request: &DCRRequest{
+				RedirectURIs: []string{"http://127.0.0.1/callback"},
+				GrantTypes:   []string{"client_credentials"},
+			},
+			expectError: true,
+			errorCode:   DCRErrorInvalidClientMetadata,
+		},
+		{
+			name: "grant_types with authorization_code passes",
+			request: &DCRRequest{
+				RedirectURIs: []string{"http://127.0.0.1/callback"},
+				GrantTypes:   []string{"authorization_code"},
+			},
+			expectError:    false,
+			expectedGrants: []string{"authorization_code"},
+		},
+
+		// response_types validation
+		{
+			name: "response_types defaults when empty",
+			request: &DCRRequest{
+				RedirectURIs:  []string{"http://127.0.0.1/callback"},
+				ResponseTypes: []string{},
+			},
+			expectError:       false,
+			expectedResponses: DefaultResponseTypes,
+		},
+		{
+			name: "response_types defaults when nil",
+			request: &DCRRequest{
+				RedirectURIs:  []string{"http://127.0.0.1/callback"},
+				ResponseTypes: nil,
+			},
+			expectError:       false,
+			expectedResponses: DefaultResponseTypes,
+		},
+		{
+			name: "response_types without code fails",
+			request: &DCRRequest{
+				RedirectURIs:  []string{"http://127.0.0.1/callback"},
+				ResponseTypes: []string{"token"},
+			},
+			expectError: true,
+			errorCode:   DCRErrorInvalidClientMetadata,
+		},
+		{
+			name: "response_types with only id_token fails",
+			request: &DCRRequest{
+				RedirectURIs:  []string{"http://127.0.0.1/callback"},
+				ResponseTypes: []string{"id_token"},
+			},
+			expectError: true,
+			errorCode:   DCRErrorInvalidClientMetadata,
+		},
+		{
+			name: "response_types with code passes",
+			request: &DCRRequest{
+				RedirectURIs:  []string{"http://127.0.0.1/callback"},
+				ResponseTypes: []string{"code"},
+			},
+			expectError:       false,
+			expectedResponses: []string{"code"},
+		},
+		{
+			name: "response_types with code and others passes",
+			request: &DCRRequest{
+				RedirectURIs:  []string{"http://127.0.0.1/callback"},
+				ResponseTypes: []string{"code", "token"},
+			},
+			expectError:       false,
+			expectedResponses: []string{"code", "token"},
+		},
+
+		// ClientName preservation
+		{
+			name: "client_name is preserved",
+			request: &DCRRequest{
+				RedirectURIs: []string{"http://127.0.0.1/callback"},
+				ClientName:   "My Application",
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := ValidateDCRRequest(tt.request)
+
+			if tt.expectError {
+				require.NotNil(t, err, "expected error")
+				assert.Nil(t, result, "result should be nil on error")
+				assert.Equal(t, tt.errorCode, err.Error)
+			} else {
+				require.Nil(t, err, "unexpected error: %v", err)
+				require.NotNil(t, result, "result should not be nil on success")
+
+				// Verify defaults/values were applied correctly
+				if tt.expectedAuthMethod != "" {
+					assert.Equal(t, tt.expectedAuthMethod, result.TokenEndpointAuthMethod)
+				}
+				if tt.expectedGrants != nil {
+					assert.ElementsMatch(t, tt.expectedGrants, result.GrantTypes)
+				}
+				if tt.expectedResponses != nil {
+					assert.ElementsMatch(t, tt.expectedResponses, result.ResponseTypes)
+				}
+
+				// Verify redirect_uris are preserved
+				assert.Equal(t, tt.request.RedirectURIs, result.RedirectURIs)
+
+				// Verify client_name is preserved
+				assert.Equal(t, tt.request.ClientName, result.ClientName)
+			}
+		})
+	}
+}
+
+func TestDCRErrorConstants(t *testing.T) {
+	t.Parallel()
+
+	// Verify error code constants match RFC 7591 Section 3.2.2
+	assert.Equal(t, "invalid_redirect_uri", DCRErrorInvalidRedirectURI)
+	assert.Equal(t, "invalid_client_metadata", DCRErrorInvalidClientMetadata)
+}
+
+func TestDefaultGrantTypesAndResponseTypes(t *testing.T) {
+	t.Parallel()
+
+	// Verify default grant types include authorization_code
+	assert.Contains(t, DefaultGrantTypes, "authorization_code")
+	assert.Contains(t, DefaultGrantTypes, "refresh_token")
+
+	// Verify default response types include code
+	assert.Contains(t, DefaultResponseTypes, "code")
+}


### PR DESCRIPTION
Add DCR request validation for OAuth public clients. Validates redirect URIs, grant types, response types, and token endpoint auth method per RFC 7591.

Delegates to fosite where possible:
- fosite.IsValidRedirectURI for absolute URI and fragment checks
- fosite.IsRedirectURISecureStrict for scheme security (HTTPS or HTTP loopback per RFC 8252)

Adds DoS protection not provided by fosite:
- MaxRedirectURILength (2048 chars)
- MaxRedirectURICount (10 URIs)

Enforces public client requirements:
- token_endpoint_auth_method must be "none"
- grant_types must include "authorization_code"
- response_types must include "code"