### PR TITLE
Handle async methods in workload manager in a more idiomatic way

### DIFF
--- a/cmd/thv/app/group.go
+++ b/cmd/thv/app/group.go
@@ -273,13 +273,13 @@ func deleteWorkloadsInGroup(
 	}
 
 	// Delete all workloads in the group
-	group, err := workloadManager.DeleteWorkloads(ctx, workloadNames)
+	complete, err := workloadManager.DeleteWorkloads(ctx, workloadNames)
 	if err != nil {
 		return fmt.Errorf("failed to delete workloads in group: %w", err)
 	}
 
 	// Wait for the deletion to complete
-	if err := group.Wait(); err != nil {
+	if err := complete(); err != nil {
 		return fmt.Errorf("failed to delete workloads in group: %w", err)
 	}
 

--- a/cmd/thv/app/restart.go
+++ b/cmd/thv/app/restart.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"golang.org/x/sync/errgroup"
 
 	"github.com/stacklok/toolhive/pkg/groups"
 	"github.com/stacklok/toolhive/pkg/workloads"
@@ -70,13 +69,13 @@ func restartCmdFunc(cmd *cobra.Command, args []string) error {
 
 	// Restart single workload
 	workloadName := args[0]
-	restartGroup, err := workloadManager.RestartWorkloads(ctx, []string{workloadName}, restartForeground)
+	complete, err := workloadManager.RestartWorkloads(ctx, []string{workloadName}, restartForeground)
 	if err != nil {
 		return err
 	}
 
-	// Wait for the restart group to complete
-	if err := restartGroup.Wait(); err != nil {
+	// Wait for the restart to complete
+	if err := complete(); err != nil {
 		return fmt.Errorf("failed to restart workload %s: %w", workloadName, err)
 	}
 
@@ -148,11 +147,11 @@ func restartMultipleWorkloads(
 
 	fmt.Printf("Restarting %d workload(s)...\n", len(workloadNames))
 
-	var restartRequests []*errgroup.Group
+	var restartRequests []workloads.CompletionFunc
 	// First, trigger the restarts concurrently.
 	for _, workloadName := range workloadNames {
 		fmt.Printf("Restarting %s...", workloadName)
-		restart, err := workloadManager.RestartWorkloads(ctx, []string{workloadName}, foreground)
+		complete, err := workloadManager.RestartWorkloads(ctx, []string{workloadName}, foreground)
 		if err != nil {
 			fmt.Printf(" failed: %v\n", err)
 			failedCount++
@@ -160,13 +159,13 @@ func restartMultipleWorkloads(
 		} else {
 			// If it didn't fail during the synchronous part of the operation,
 			// append to the list of restart requests in flight.
-			restartRequests = append(restartRequests, restart)
+			restartRequests = append(restartRequests, complete)
 		}
 	}
 
 	// Wait for all restarts to complete.
-	for _, restart := range restartRequests {
-		err := restart.Wait()
+	for _, complete := range restartRequests {
+		err := complete()
 		if err != nil {
 			fmt.Printf(" failed: %v\n", err)
 			failedCount++

--- a/cmd/thv/app/rm.go
+++ b/cmd/thv/app/rm.go
@@ -88,13 +88,13 @@ func rmCmdFunc(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to create workload manager: %w", err)
 	}
 	// Delete workloads.
-	group, err := manager.DeleteWorkloads(ctx, workloadNames)
+	complete, err := manager.DeleteWorkloads(ctx, workloadNames)
 	if err != nil {
 		return fmt.Errorf("failed to delete workloads: %w", err)
 	}
 
-	// Wait for the deletion to complete.
-	if err := group.Wait(); err != nil {
+	// Wait for the deletion to complete
+	if err := complete(); err != nil {
 		return fmt.Errorf("failed to delete workloads: %w", err)
 	}
 
@@ -132,13 +132,13 @@ func deleteAllWorkloads(ctx context.Context) error {
 	}
 
 	// Delete all workloads
-	group, err := workloadManager.DeleteWorkloads(ctx, workloadNames)
+	complete, err := workloadManager.DeleteWorkloads(ctx, workloadNames)
 	if err != nil {
 		return fmt.Errorf("failed to delete all workloads: %w", err)
 	}
 
 	// Wait for the deletion to complete
-	if err := group.Wait(); err != nil {
+	if err := complete(); err != nil {
 		return fmt.Errorf("failed to delete all workloads: %w", err)
 	}
 
@@ -180,13 +180,13 @@ func deleteAllWorkloadsInGroup(ctx context.Context, groupName string) error {
 	}
 
 	// Delete all workloads in the group
-	group, err := workloadManager.DeleteWorkloads(ctx, groupWorkloads)
+	complete, err := workloadManager.DeleteWorkloads(ctx, groupWorkloads)
 	if err != nil {
 		return fmt.Errorf("failed to delete workloads in group: %w", err)
 	}
 
 	// Wait for the deletion to complete
-	if err := group.Wait(); err != nil {
+	if err := complete(); err != nil {
 		return fmt.Errorf("failed to delete workloads in group: %w", err)
 	}
 

--- a/cmd/thv/app/run.go
+++ b/cmd/thv/app/run.go
@@ -152,12 +152,12 @@ func cleanupAndWait(workloadManager workloads.Manager, name string) {
 	cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cleanupCancel()
 
-	group, err := workloadManager.DeleteWorkloads(cleanupCtx, []string{name})
+	complete, err := workloadManager.DeleteWorkloads(cleanupCtx, []string{name})
 	if err != nil {
 		logger.Warnf("Failed to delete workload %q: %v", name, err)
-	} else if group != nil {
-		if err := group.Wait(); err != nil {
-			logger.Warnf("DeleteWorkloads group error for %q: %v", name, err)
+	} else if complete != nil {
+		if err := complete(); err != nil {
+			logger.Warnf("DeleteWorkloads error for %q: %v", name, err)
 		}
 	}
 }

--- a/pkg/api/v1/groups.go
+++ b/pkg/api/v1/groups.go
@@ -258,13 +258,13 @@ func (s *GroupsRoutes) handleWorkloadsForGroupDeletion(
 
 	if withWorkloads {
 		// Delete all workloads in the group
-		group, err := s.workloadManager.DeleteWorkloads(ctx, workloadNames)
+		complete, err := s.workloadManager.DeleteWorkloads(ctx, workloadNames)
 		if err != nil {
 			return fmt.Errorf("failed to delete workloads in group %s: %w", groupName, err)
 		}
 
 		// Wait for the deletion to complete
-		if err := group.Wait(); err != nil {
+		if err := complete(); err != nil {
 			return fmt.Errorf("failed to delete workloads in group %s: %w", groupName, err)
 		}
 

--- a/pkg/mcp/server/handler_mock_test.go
+++ b/pkg/mcp/server/handler_mock_test.go
@@ -7,12 +7,12 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
-	"golang.org/x/sync/errgroup"
 
 	runtime "github.com/stacklok/toolhive/pkg/container/runtime"
 	"github.com/stacklok/toolhive/pkg/core"
 	registrymocks "github.com/stacklok/toolhive/pkg/registry/mocks"
 	regtypes "github.com/stacklok/toolhive/pkg/registry/registry"
+	"github.com/stacklok/toolhive/pkg/workloads"
 	workloadsmocks "github.com/stacklok/toolhive/pkg/workloads/mocks"
 )
 
@@ -290,10 +290,10 @@ func TestHandler_StopServer_WithMocks(t *testing.T) {
 			name:       "successful stop",
 			serverName: "test-server",
 			setupMocks: func(m *workloadsmocks.MockManager) {
-				group := &errgroup.Group{}
+				complete := func() error { return nil }
 				m.EXPECT().
 					StopWorkloads(gomock.Any(), []string{"test-server"}).
-					Return(group, nil)
+					Return(workloads.CompletionFunc(complete), nil)
 			},
 			wantErr: false,
 			checkResult: func(t *testing.T, result *mcp.CallToolResult) {
@@ -374,10 +374,10 @@ func TestHandler_RemoveServer_WithMocks(t *testing.T) {
 			name:       "successful remove",
 			serverName: "test-server",
 			setupMocks: func(m *workloadsmocks.MockManager) {
-				group := &errgroup.Group{}
+				complete := func() error { return nil }
 				m.EXPECT().
 					DeleteWorkloads(gomock.Any(), []string{"test-server"}).
-					Return(group, nil)
+					Return(workloads.CompletionFunc(complete), nil)
 			},
 			wantErr: false,
 			checkResult: func(t *testing.T, result *mcp.CallToolResult) {

--- a/pkg/mcp/server/remove_server.go
+++ b/pkg/mcp/server/remove_server.go
@@ -21,13 +21,13 @@ func (h *Handler) RemoveServer(ctx context.Context, request mcp.CallToolRequest)
 	}
 
 	// Delete the workload
-	group, err := h.workloadManager.DeleteWorkloads(ctx, []string{args.Name})
+	complete, err := h.workloadManager.DeleteWorkloads(ctx, []string{args.Name})
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("Failed to remove server: %v", err)), nil
 	}
 
 	// Wait for the delete operation to complete
-	if err := group.Wait(); err != nil {
+	if err := complete(); err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("Failed to remove server: %v", err)), nil
 	}
 

--- a/pkg/mcp/server/stop_server.go
+++ b/pkg/mcp/server/stop_server.go
@@ -21,13 +21,13 @@ func (h *Handler) StopServer(ctx context.Context, request mcp.CallToolRequest) (
 	}
 
 	// Stop the workload
-	group, err := h.workloadManager.StopWorkloads(ctx, []string{args.Name})
+	complete, err := h.workloadManager.StopWorkloads(ctx, []string{args.Name})
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("Failed to stop server: %v", err)), nil
 	}
 
 	// Wait for the stop operation to complete
-	if err := group.Wait(); err != nil {
+	if err := complete(); err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("Failed to stop server: %v", err)), nil
 	}
 

--- a/pkg/workloads/manager.go
+++ b/pkg/workloads/manager.go
@@ -32,6 +32,11 @@ import (
 	"github.com/stacklok/toolhive/pkg/workloads/types"
 )
 
+// CompletionFunc is a function that can be called to wait for an async operation to complete.
+// Call this function to block until the operation finishes and get the final error result.
+// If you don't call it, the operation continues in the background.
+type CompletionFunc func() error
+
 // Manager is responsible for managing the state of ToolHive-managed containers.
 // NOTE: This interface may be split up in future PRs, in particular, operations
 // which are only relevant to the CLI/API use case will be split out.
@@ -45,21 +50,25 @@ type Manager interface {
 	// The optional `labelFilters` parameter allows filtering workloads by labels (format: key=value).
 	ListWorkloads(ctx context.Context, listAll bool, labelFilters ...string) ([]core.Workload, error)
 	// DeleteWorkloads deletes the specified workloads by name.
-	// It is implemented as an asynchronous operation which returns an errgroup.Group
-	DeleteWorkloads(ctx context.Context, names []string) (*errgroup.Group, error)
+	// Returns a CompletionFunc that can be called to wait for the operation to complete.
+	// The operation runs asynchronously unless the CompletionFunc is called.
+	DeleteWorkloads(ctx context.Context, names []string) (CompletionFunc, error)
 	// StopWorkloads stops the specified workloads by name.
-	// It is implemented as an asynchronous operation which returns an errgroup.Group
-	StopWorkloads(ctx context.Context, names []string) (*errgroup.Group, error)
+	// Returns a CompletionFunc that can be called to wait for the operation to complete.
+	// The operation runs asynchronously unless the CompletionFunc is called.
+	StopWorkloads(ctx context.Context, names []string) (CompletionFunc, error)
 	// RunWorkload runs a container in the foreground.
 	RunWorkload(ctx context.Context, runConfig *runner.RunConfig) error
 	// RunWorkloadDetached runs a container in the background.
 	RunWorkloadDetached(ctx context.Context, runConfig *runner.RunConfig) error
 	// RestartWorkloads restarts the specified workloads by name.
-	// It is implemented as an asynchronous operation which returns an errgroup.Group
-	RestartWorkloads(ctx context.Context, names []string, foreground bool) (*errgroup.Group, error)
+	// Returns a CompletionFunc that can be called to wait for the operation to complete.
+	// The operation runs asynchronously unless the CompletionFunc is called.
+	RestartWorkloads(ctx context.Context, names []string, foreground bool) (CompletionFunc, error)
 	// UpdateWorkload updates a workload by stopping, deleting, and recreating it.
-	// It is implemented as an asynchronous operation which returns an errgroup.Group
-	UpdateWorkload(ctx context.Context, workloadName string, newConfig *runner.RunConfig) (*errgroup.Group, error)
+	// Returns a CompletionFunc that can be called to wait for the operation to complete.
+	// The operation runs asynchronously unless the CompletionFunc is called.
+	UpdateWorkload(ctx context.Context, workloadName string, newConfig *runner.RunConfig) (CompletionFunc, error)
 	// GetLogs retrieves the logs of a container.
 	GetLogs(ctx context.Context, containerName string, follow bool) (string, error)
 	// GetProxyLogs retrieves the proxy logs from the filesystem.
@@ -272,7 +281,7 @@ func (d *DefaultManager) ListWorkloads(ctx context.Context, listAll bool, labelF
 }
 
 // StopWorkloads stops the specified workloads by name.
-func (d *DefaultManager) StopWorkloads(_ context.Context, names []string) (*errgroup.Group, error) {
+func (d *DefaultManager) StopWorkloads(ctx context.Context, names []string) (CompletionFunc, error) {
 	// Validate all workload names to prevent path traversal attacks
 	for _, name := range names {
 		if err := types.ValidateWorkloadName(name); err != nil {
@@ -284,21 +293,21 @@ func (d *DefaultManager) StopWorkloads(_ context.Context, names []string) (*errg
 		}
 	}
 
-	group := &errgroup.Group{}
+	group, gctx := errgroup.WithContext(ctx)
 	// Process each workload
 	for _, name := range names {
 		group.Go(func() error {
-			return d.stopSingleWorkload(name)
+			return d.stopSingleWorkload(gctx, name)
 		})
 	}
 
-	return group, nil
+	return group.Wait, nil
 }
 
 // stopSingleWorkload stops a single workload (container or remote)
-func (d *DefaultManager) stopSingleWorkload(name string) error {
+func (d *DefaultManager) stopSingleWorkload(ctx context.Context, name string) error {
 	// Create a child context with a longer timeout
-	childCtx, cancel := context.WithTimeout(context.Background(), AsyncOperationTimeout)
+	childCtx, cancel := context.WithTimeout(ctx, AsyncOperationTimeout)
 	defer cancel()
 
 	// First, try to load the run configuration to check if it's a remote workload
@@ -648,9 +657,9 @@ func (*DefaultManager) GetProxyLogs(_ context.Context, workloadName string) (str
 }
 
 // deleteWorkload handles deletion of a single workload
-func (d *DefaultManager) deleteWorkload(name string) error {
+func (d *DefaultManager) deleteWorkload(ctx context.Context, name string) error {
 	// Create a child context with a longer timeout
-	childCtx, cancel := context.WithTimeout(context.Background(), AsyncOperationTimeout)
+	childCtx, cancel := context.WithTimeout(ctx, AsyncOperationTimeout)
 	defer cancel()
 
 	// First, check if this is a remote workload by trying to load its run configuration
@@ -862,7 +871,7 @@ func (d *DefaultManager) cleanupWorkloadResources(ctx context.Context, name, bas
 }
 
 // DeleteWorkloads deletes the specified workloads by name.
-func (d *DefaultManager) DeleteWorkloads(_ context.Context, names []string) (*errgroup.Group, error) {
+func (d *DefaultManager) DeleteWorkloads(ctx context.Context, names []string) (CompletionFunc, error) {
 	// Validate all workload names to prevent path traversal attacks
 	for _, name := range names {
 		if err := types.ValidateWorkloadName(name); err != nil {
@@ -870,19 +879,19 @@ func (d *DefaultManager) DeleteWorkloads(_ context.Context, names []string) (*er
 		}
 	}
 
-	group := &errgroup.Group{}
+	group, gctx := errgroup.WithContext(ctx)
 
 	for _, name := range names {
 		group.Go(func() error {
-			return d.deleteWorkload(name)
+			return d.deleteWorkload(gctx, name)
 		})
 	}
 
-	return group, nil
+	return group.Wait, nil
 }
 
 // RestartWorkloads restarts the specified workloads by name.
-func (d *DefaultManager) RestartWorkloads(ctx context.Context, names []string, foreground bool) (*errgroup.Group, error) {
+func (d *DefaultManager) RestartWorkloads(ctx context.Context, names []string, foreground bool) (CompletionFunc, error) {
 	// Validate all workload names to prevent path traversal attacks
 	for _, name := range names {
 		if err := types.ValidateWorkloadName(name); err != nil {
@@ -890,47 +899,47 @@ func (d *DefaultManager) RestartWorkloads(ctx context.Context, names []string, f
 		}
 	}
 
-	group := &errgroup.Group{}
+	group, gctx := errgroup.WithContext(ctx)
 
 	for _, name := range names {
 		group.Go(func() error {
-			return d.restartSingleWorkload(ctx, name, foreground)
+			return d.restartSingleWorkload(gctx, name, foreground)
 		})
 	}
 
-	return group, nil
+	return group.Wait, nil
 }
 
 // UpdateWorkload updates a workload by stopping, deleting, and recreating it
-func (d *DefaultManager) UpdateWorkload(_ context.Context, workloadName string, newConfig *runner.RunConfig) (*errgroup.Group, error) { //nolint:lll
+func (d *DefaultManager) UpdateWorkload(ctx context.Context, workloadName string, newConfig *runner.RunConfig) (CompletionFunc, error) { //nolint:lll
 	// Validate workload name
 	if err := types.ValidateWorkloadName(workloadName); err != nil {
 		return nil, fmt.Errorf("invalid workload name '%s': %w", workloadName, err)
 	}
 
-	group := &errgroup.Group{}
+	group, gctx := errgroup.WithContext(ctx)
 	group.Go(func() error {
-		return d.updateSingleWorkload(workloadName, newConfig)
+		return d.updateSingleWorkload(gctx, workloadName, newConfig)
 	})
-	return group, nil
+	return group.Wait, nil
 }
 
 // updateSingleWorkload handles the update logic for a single workload
-func (d *DefaultManager) updateSingleWorkload(workloadName string, newConfig *runner.RunConfig) error {
+func (d *DefaultManager) updateSingleWorkload(ctx context.Context, workloadName string, newConfig *runner.RunConfig) error {
 	// Create a child context with a longer timeout
-	childCtx, cancel := context.WithTimeout(context.Background(), AsyncOperationTimeout)
+	childCtx, cancel := context.WithTimeout(ctx, AsyncOperationTimeout)
 	defer cancel()
 
 	logger.Infof("Starting update for workload %s", workloadName)
 
 	// Stop the existing workload
-	if err := d.stopSingleWorkload(workloadName); err != nil {
+	if err := d.stopSingleWorkload(childCtx, workloadName); err != nil {
 		return fmt.Errorf("failed to stop workload: %w", err)
 	}
 	logger.Infof("Successfully stopped workload %s", workloadName)
 
 	// Delete the existing workload
-	if err := d.deleteWorkload(workloadName); err != nil {
+	if err := d.deleteWorkload(childCtx, workloadName); err != nil {
 		return fmt.Errorf("failed to delete workload: %w", err)
 	}
 	logger.Infof("Successfully deleted workload %s", workloadName)

--- a/pkg/workloads/mocks/mock_manager.go
+++ b/pkg/workloads/mocks/mock_manager.go
@@ -15,8 +15,8 @@ import (
 
 	core "github.com/stacklok/toolhive/pkg/core"
 	runner "github.com/stacklok/toolhive/pkg/runner"
+	workloads "github.com/stacklok/toolhive/pkg/workloads"
 	gomock "go.uber.org/mock/gomock"
-	errgroup "golang.org/x/sync/errgroup"
 )
 
 // MockManager is a mock of Manager interface.
@@ -44,10 +44,10 @@ func (m *MockManager) EXPECT() *MockManagerMockRecorder {
 }
 
 // DeleteWorkloads mocks base method.
-func (m *MockManager) DeleteWorkloads(ctx context.Context, names []string) (*errgroup.Group, error) {
+func (m *MockManager) DeleteWorkloads(ctx context.Context, names []string) (workloads.CompletionFunc, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteWorkloads", ctx, names)
-	ret0, _ := ret[0].(*errgroup.Group)
+	ret0, _ := ret[0].(workloads.CompletionFunc)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -183,10 +183,10 @@ func (mr *MockManagerMockRecorder) MoveToGroup(ctx, workloadNames, groupFrom, gr
 }
 
 // RestartWorkloads mocks base method.
-func (m *MockManager) RestartWorkloads(ctx context.Context, names []string, foreground bool) (*errgroup.Group, error) {
+func (m *MockManager) RestartWorkloads(ctx context.Context, names []string, foreground bool) (workloads.CompletionFunc, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RestartWorkloads", ctx, names, foreground)
-	ret0, _ := ret[0].(*errgroup.Group)
+	ret0, _ := ret[0].(workloads.CompletionFunc)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -226,10 +226,10 @@ func (mr *MockManagerMockRecorder) RunWorkloadDetached(ctx, runConfig any) *gomo
 }
 
 // StopWorkloads mocks base method.
-func (m *MockManager) StopWorkloads(ctx context.Context, names []string) (*errgroup.Group, error) {
+func (m *MockManager) StopWorkloads(ctx context.Context, names []string) (workloads.CompletionFunc, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StopWorkloads", ctx, names)
-	ret0, _ := ret[0].(*errgroup.Group)
+	ret0, _ := ret[0].(workloads.CompletionFunc)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -241,10 +241,10 @@ func (mr *MockManagerMockRecorder) StopWorkloads(ctx, names any) *gomock.Call {
 }
 
 // UpdateWorkload mocks base method.
-func (m *MockManager) UpdateWorkload(ctx context.Context, workloadName string, newConfig *runner.RunConfig) (*errgroup.Group, error) {
+func (m *MockManager) UpdateWorkload(ctx context.Context, workloadName string, newConfig *runner.RunConfig) (workloads.CompletionFunc, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateWorkload", ctx, workloadName, newConfig)
-	ret0, _ := ret[0].(*errgroup.Group)
+	ret0, _ := ret[0].(workloads.CompletionFunc)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }


### PR DESCRIPTION
Some of the methods in the workload manager are asynchronous. It is intended that the API will return a 202 response before they are finished, but the CLI will block until completion.

Previously, this was modelled by returning an error group, which is not a particularly idiomatic way of modelling this in Go. Change it to return a completion function. If a caller wishes to block on completion, they call the function which forces the operation to complete.