### PR TITLE
Add cryptographic utilities for OAuth authorization server

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/go-chi/chi/v5 v5.2.3
 	github.com/go-git/go-billy/v5 v5.7.0
 	github.com/go-git/go-git/v5 v5.16.4
+	github.com/go-jose/go-jose/v4 v4.1.3
 	github.com/go-logr/zapr v1.3.0
 	github.com/gofrs/flock v0.13.0
 	github.com/google/go-cmp v0.7.0

--- a/pkg/authserver/server/crypto/keys.go
+++ b/pkg/authserver/server/crypto/keys.go
@@ -1,0 +1,279 @@
+// Copyright 2025 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package crypto provides cryptographic utilities for the OAuth authorization server.
+package crypto
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/go-jose/go-jose/v4"
+)
+
+// MinSecretLength is the minimum required length for the HMAC secret in bytes.
+// Using 256 bits (32 bytes) provides adequate security for HMAC-SHA256.
+const MinSecretLength = 32
+
+// MinRSAKeyBits is the minimum required RSA key size in bits.
+// NIST recommends at least 2048 bits for RSA keys.
+const MinRSAKeyBits = 2048
+
+// LoadSigningKey loads a private key from a PEM file.
+// Supports both RSA (PKCS1 and PKCS8) and ECDSA (PKCS8) formats.
+// Returns a crypto.Signer that can be used for JWT signing.
+func LoadSigningKey(keyPath string) (crypto.Signer, error) {
+	keyPEM, err := os.ReadFile(keyPath) // #nosec G304 - keyPath is provided by user via CLI flag or config
+	if err != nil {
+		return nil, fmt.Errorf("failed to read signing key: %w", err)
+	}
+
+	block, _ := pem.Decode(keyPEM)
+	if block == nil {
+		return nil, fmt.Errorf("failed to decode PEM block from signing key")
+	}
+
+	// Try PKCS1 first (RSA only)
+	if rsaKey, err := x509.ParsePKCS1PrivateKey(block.Bytes); err == nil {
+		if keyBits := rsaKey.N.BitLen(); keyBits < MinRSAKeyBits {
+			return nil, fmt.Errorf("RSA key size %d bits is below minimum required %d bits", keyBits, MinRSAKeyBits)
+		}
+		return rsaKey, nil
+	}
+
+	// Try EC private key (SEC 1, ASN.1 DER form)
+	if ecKey, err := x509.ParseECPrivateKey(block.Bytes); err == nil {
+		return ecKey, nil
+	}
+
+	// Try PKCS8 (supports both RSA and EC)
+	key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse signing key: %w", err)
+	}
+
+	// Validate RSA key size if parsed key is RSA
+	if rsaKey, ok := key.(*rsa.PrivateKey); ok {
+		if keyBits := rsaKey.N.BitLen(); keyBits < MinRSAKeyBits {
+			return nil, fmt.Errorf("RSA key size %d bits is below minimum required %d bits", keyBits, MinRSAKeyBits)
+		}
+	}
+
+	signer, ok := key.(crypto.Signer)
+	if !ok {
+		return nil, fmt.Errorf("signing key does not implement crypto.Signer")
+	}
+
+	return signer, nil
+}
+
+// DeriveKeyID computes a key ID from the public key using RFC 7638 JWK Thumbprint.
+// The thumbprint is computed as base64url(SHA-256(JWK canonical form)).
+func DeriveKeyID(key crypto.Signer) (string, error) {
+	// Create a JWK from the public key
+	jwk := jose.JSONWebKey{
+		Key: key.Public(),
+	}
+
+	// Compute the thumbprint using go-jose's built-in RFC 7638 implementation
+	thumbprint, err := jwk.Thumbprint(crypto.SHA256)
+	if err != nil {
+		return "", fmt.Errorf("failed to compute key thumbprint: %w", err)
+	}
+
+	// Base64url encode without padding (RFC 7638 standard)
+	return base64.RawURLEncoding.EncodeToString(thumbprint), nil
+}
+
+// DeriveAlgorithm determines the appropriate JWT signing algorithm for the given key.
+// Returns the algorithm string (e.g., "RS256", "ES256", "EdDSA") based on key type and parameters.
+func DeriveAlgorithm(key crypto.Signer) (string, error) {
+	switch k := key.(type) {
+	case *rsa.PrivateKey:
+		return "RS256", nil
+	case *ecdsa.PrivateKey:
+		return deriveECAlgorithm(k.Curve)
+	case ed25519.PrivateKey:
+		return "EdDSA", nil
+	default:
+		return "", fmt.Errorf("unsupported key type: %T", key)
+	}
+}
+
+// deriveECAlgorithm determines the ECDSA algorithm based on the curve.
+func deriveECAlgorithm(curve elliptic.Curve) (string, error) {
+	switch curve {
+	case elliptic.P256():
+		return "ES256", nil
+	case elliptic.P384():
+		return "ES384", nil
+	case elliptic.P521():
+		return "ES512", nil
+	default:
+		return "", fmt.Errorf("unsupported EC curve: %s", curve.Params().Name)
+	}
+}
+
+// ValidateAlgorithmForKey checks if the provided algorithm is compatible with the key type.
+// Returns an error if the algorithm doesn't match the key type.
+func ValidateAlgorithmForKey(alg string, key crypto.Signer) error {
+	switch k := key.(type) {
+	case *rsa.PrivateKey:
+		switch alg {
+		case "RS256", "RS384", "RS512":
+			return nil
+		default:
+			return fmt.Errorf("algorithm %s is not compatible with RSA key", alg)
+		}
+	case *ecdsa.PrivateKey:
+		expectedAlg, err := deriveECAlgorithm(k.Curve)
+		if err != nil {
+			return err
+		}
+		if alg != expectedAlg {
+			return fmt.Errorf("algorithm %s is not compatible with EC key using curve %s (expected %s)",
+				alg, k.Curve.Params().Name, expectedAlg)
+		}
+		return nil
+	case ed25519.PrivateKey:
+		if alg != "EdDSA" {
+			return fmt.Errorf("algorithm %s is not compatible with Ed25519 key (expected EdDSA)", alg)
+		}
+		return nil
+	default:
+		return fmt.Errorf("unsupported key type: %T", key)
+	}
+}
+
+// SigningKeyParams contains the derived or configured parameters for a signing key.
+type SigningKeyParams struct {
+	// Key is the private key used for signing.
+	Key crypto.Signer
+	// KeyID is the key identifier (either derived from thumbprint or configured).
+	KeyID string
+	// Algorithm is the signing algorithm (either derived from key type or configured).
+	Algorithm string
+}
+
+// HMACSecrets holds the current secret and any rotated (previous) secrets.
+// This supports zero-downtime secret rotation for OAuth token signing.
+type HMACSecrets struct {
+	// Current is the active secret used for signing new tokens.
+	Current []byte
+	// Rotated contains previously-used secrets for verifying existing tokens.
+	Rotated [][]byte
+}
+
+// DeriveSigningKeyParams derives or validates signing key parameters.
+// If keyID or algorithm are empty, they are derived from the key.
+// If they are provided, they are validated against the key type.
+func DeriveSigningKeyParams(key crypto.Signer, keyID, algorithm string) (*SigningKeyParams, error) {
+	params := &SigningKeyParams{Key: key}
+
+	// Derive or use provided KeyID
+	if keyID == "" {
+		derivedID, err := DeriveKeyID(key)
+		if err != nil {
+			return nil, fmt.Errorf("failed to derive key ID: %w", err)
+		}
+		params.KeyID = derivedID
+	} else {
+		params.KeyID = keyID
+	}
+
+	// Derive or validate Algorithm
+	if algorithm == "" {
+		derivedAlg, err := DeriveAlgorithm(key)
+		if err != nil {
+			return nil, fmt.Errorf("failed to derive algorithm: %w", err)
+		}
+		params.Algorithm = derivedAlg
+	} else {
+		// Validate that provided algorithm matches key type
+		if err := ValidateAlgorithmForKey(algorithm, key); err != nil {
+			return nil, err
+		}
+		params.Algorithm = algorithm
+	}
+
+	return params, nil
+}
+
+// loadHMACSecretFile loads an HMAC secret from a file (internal helper).
+// Returns nil if path is empty (triggers random generation in toInternalConfig).
+// The secret must be at least 32 bytes after trimming whitespace.
+func loadHMACSecretFile(secretPath string) ([]byte, error) {
+	if secretPath == "" {
+		return nil, nil
+	}
+
+	data, err := os.ReadFile(secretPath) // #nosec G304 - secretPath is provided by user via CLI flag or config
+	if err != nil {
+		return nil, fmt.Errorf("failed to read HMAC secret file: %w", err)
+	}
+
+	// Trim whitespace (common in Kubernetes Secret mounts which often add trailing newlines)
+	secret := []byte(strings.TrimSpace(string(data)))
+
+	if len(secret) < MinSecretLength {
+		return nil, fmt.Errorf("HMAC secret must be at least %d bytes", MinSecretLength)
+	}
+
+	return secret, nil
+}
+
+// LoadHMACSecrets loads HMAC secrets from file paths for rotation support.
+// paths[0] is the current (signing) secret; paths[1:] are rotated (verification) secrets.
+// Returns nil if paths is empty (caller should generate random secret).
+func LoadHMACSecrets(paths []string) (*HMACSecrets, error) {
+	if len(paths) == 0 {
+		return nil, nil
+	}
+
+	// Load current secret (required, cannot be empty path)
+	if paths[0] == "" {
+		return nil, fmt.Errorf("current HMAC secret path cannot be empty")
+	}
+	current, err := loadHMACSecretFile(paths[0])
+	if err != nil {
+		return nil, fmt.Errorf("failed to load current HMAC secret: %w", err)
+	}
+
+	// Load rotated secrets (optional, skip empty paths)
+	var rotated [][]byte
+	for i, path := range paths[1:] {
+		if path == "" {
+			continue
+		}
+		secret, err := loadHMACSecretFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load rotated HMAC secret [%d]: %w", i+1, err)
+		}
+		rotated = append(rotated, secret)
+	}
+
+	return &HMACSecrets{
+		Current: current,
+		Rotated: rotated,
+	}, nil
+}

--- a/pkg/authserver/server/crypto/keys_test.go
+++ b/pkg/authserver/server/crypto/keys_test.go
@@ -1,0 +1,435 @@
+// Copyright 2025 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package crypto
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadSigningKey(t *testing.T) {
+	t.Parallel()
+
+	// Generate test keys once for the table
+	rsaKey, _ := rsa.GenerateKey(rand.Reader, 2048)
+	smallRSAKey, _ := rsa.GenerateKey(rand.Reader, 1024)
+	ecKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	_, ed25519Key, _ := ed25519.GenerateKey(rand.Reader)
+
+	tests := []struct {
+		name      string
+		setup     func(t *testing.T, dir string) string // returns key path
+		wantErr   string
+		checkType func(t *testing.T, key any) // optional type check
+	}{
+		{
+			name: "RSA PKCS1",
+			setup: func(_ *testing.T, dir string) string {
+				return writePEM(t, dir, "RSA PRIVATE KEY", x509.MarshalPKCS1PrivateKey(rsaKey))
+			},
+			checkType: func(t *testing.T, key any) { t.Helper(); assert.IsType(t, &rsa.PrivateKey{}, key) },
+		},
+		{
+			name: "RSA PKCS8",
+			setup: func(_ *testing.T, dir string) string {
+				der, _ := x509.MarshalPKCS8PrivateKey(rsaKey)
+				return writePEM(t, dir, "PRIVATE KEY", der)
+			},
+			checkType: func(t *testing.T, key any) { t.Helper(); assert.IsType(t, &rsa.PrivateKey{}, key) },
+		},
+		{
+			name: "EC SEC1",
+			setup: func(_ *testing.T, dir string) string {
+				der, _ := x509.MarshalECPrivateKey(ecKey)
+				return writePEM(t, dir, "EC PRIVATE KEY", der)
+			},
+			checkType: func(t *testing.T, key any) { t.Helper(); assert.IsType(t, &ecdsa.PrivateKey{}, key) },
+		},
+		{
+			name: "EC PKCS8",
+			setup: func(_ *testing.T, dir string) string {
+				der, _ := x509.MarshalPKCS8PrivateKey(ecKey)
+				return writePEM(t, dir, "PRIVATE KEY", der)
+			},
+			checkType: func(t *testing.T, key any) { t.Helper(); assert.IsType(t, &ecdsa.PrivateKey{}, key) },
+		},
+		{
+			name: "Ed25519 PKCS8",
+			setup: func(_ *testing.T, dir string) string {
+				der, _ := x509.MarshalPKCS8PrivateKey(ed25519Key)
+				return writePEM(t, dir, "PRIVATE KEY", der)
+			},
+			checkType: func(t *testing.T, key any) { t.Helper(); assert.IsType(t, ed25519.PrivateKey{}, key) },
+		},
+		{
+			name: "RSA below minimum size PKCS1",
+			setup: func(_ *testing.T, dir string) string {
+				return writePEM(t, dir, "RSA PRIVATE KEY", x509.MarshalPKCS1PrivateKey(smallRSAKey))
+			},
+			wantErr: "below minimum required",
+		},
+		{
+			name: "RSA below minimum size PKCS8",
+			setup: func(_ *testing.T, dir string) string {
+				der, _ := x509.MarshalPKCS8PrivateKey(smallRSAKey)
+				return writePEM(t, dir, "PRIVATE KEY", der)
+			},
+			wantErr: "below minimum required",
+		},
+		{
+			name: "invalid PEM",
+			setup: func(_ *testing.T, dir string) string {
+				path := filepath.Join(dir, "key.pem")
+				require.NoError(t, os.WriteFile(path, []byte("not valid PEM"), 0600))
+				return path
+			},
+			wantErr: "failed to decode PEM block",
+		},
+		{
+			name: "non-existent file",
+			setup: func(_ *testing.T, _ string) string {
+				return "/nonexistent/key.pem"
+			},
+			wantErr: "failed to read signing key",
+		},
+		{
+			name: "invalid key data in PEM",
+			setup: func(_ *testing.T, dir string) string {
+				return writePEM(t, dir, "PRIVATE KEY", []byte("garbage"))
+			},
+			wantErr: "failed to parse signing key",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			keyPath := tt.setup(t, t.TempDir())
+
+			signer, err := LoadSigningKey(keyPath)
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				assert.Nil(t, signer)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, signer)
+				if tt.checkType != nil {
+					tt.checkType(t, signer)
+				}
+			}
+		})
+	}
+}
+
+func TestDeriveAlgorithm(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		key     func() crypto.Signer
+		wantAlg string
+		wantErr bool
+	}{
+		{"RSA", func() crypto.Signer { k, _ := rsa.GenerateKey(rand.Reader, 2048); return k }, "RS256", false},
+		{"EC P-256", func() crypto.Signer { k, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader); return k }, "ES256", false},
+		{"EC P-384", func() crypto.Signer { k, _ := ecdsa.GenerateKey(elliptic.P384(), rand.Reader); return k }, "ES384", false},
+		{"EC P-521", func() crypto.Signer { k, _ := ecdsa.GenerateKey(elliptic.P521(), rand.Reader); return k }, "ES512", false},
+		{"Ed25519", func() crypto.Signer { _, k, _ := ed25519.GenerateKey(rand.Reader); return k }, "EdDSA", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			alg, err := DeriveAlgorithm(tt.key())
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.wantAlg, alg)
+			}
+		})
+	}
+}
+
+func TestValidateAlgorithmForKey(t *testing.T) {
+	t.Parallel()
+
+	rsaKey, _ := rsa.GenerateKey(rand.Reader, 2048)
+	ecP256, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	ecP384, _ := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	_, ed25519Key, _ := ed25519.GenerateKey(rand.Reader)
+
+	tests := []struct {
+		name    string
+		alg     string
+		key     crypto.Signer
+		wantErr string
+	}{
+		// Valid combinations
+		{"RS256 with RSA", "RS256", rsaKey, ""},
+		{"RS384 with RSA", "RS384", rsaKey, ""},
+		{"RS512 with RSA", "RS512", rsaKey, ""},
+		{"ES256 with P-256", "ES256", ecP256, ""},
+		{"ES384 with P-384", "ES384", ecP384, ""},
+		{"EdDSA with Ed25519", "EdDSA", ed25519Key, ""},
+		// Invalid combinations
+		{"ES256 with RSA", "ES256", rsaKey, "not compatible with RSA"},
+		{"RS256 with EC", "RS256", ecP256, "not compatible with EC"},
+		{"ES256 with P-384", "ES256", ecP384, "not compatible with EC key"},
+		{"RS256 with Ed25519", "RS256", ed25519Key, "not compatible with Ed25519"},
+		{"ES256 with Ed25519", "ES256", ed25519Key, "not compatible with Ed25519"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := ValidateAlgorithmForKey(tt.alg, tt.key)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestDeriveSigningKeyParams(t *testing.T) {
+	t.Parallel()
+
+	rsaKey, _ := rsa.GenerateKey(rand.Reader, 2048)
+	ecKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	_, ed25519Key, _ := ed25519.GenerateKey(rand.Reader)
+
+	tests := []struct {
+		name      string
+		key       crypto.Signer
+		keyID     string
+		algorithm string
+		wantAlg   string
+		wantErr   string
+	}{
+		{"derive both for RSA", rsaKey, "", "", "RS256", ""},
+		{"derive both for EC", ecKey, "", "", "ES256", ""},
+		{"derive both for Ed25519", ed25519Key, "", "", "EdDSA", ""},
+		{"use provided values", rsaKey, "my-key", "RS384", "RS384", ""},
+		{"derive alg only", ecKey, "my-key", "", "ES256", ""},
+		{"invalid alg for RSA", rsaKey, "key", "ES256", "", "not compatible with RSA"},
+		{"invalid alg for EC curve", ecKey, "key", "ES384", "", "not compatible with EC"},
+		{"invalid alg for Ed25519", ed25519Key, "key", "RS256", "", "not compatible with Ed25519"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			params, err := DeriveSigningKeyParams(tt.key, tt.keyID, tt.algorithm)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.wantAlg, params.Algorithm)
+				if tt.keyID != "" {
+					assert.Equal(t, tt.keyID, params.KeyID)
+				} else {
+					assert.NotEmpty(t, params.KeyID)
+				}
+			}
+		})
+	}
+}
+
+func TestDeriveKeyID(t *testing.T) {
+	t.Parallel()
+
+	rsaKey, _ := rsa.GenerateKey(rand.Reader, 2048)
+
+	// Test consistency
+	id1, err := DeriveKeyID(rsaKey)
+	require.NoError(t, err)
+	assert.NotEmpty(t, id1)
+
+	id2, err := DeriveKeyID(rsaKey)
+	require.NoError(t, err)
+	assert.Equal(t, id1, id2, "same key should produce same ID")
+
+	// Test uniqueness
+	rsaKey2, _ := rsa.GenerateKey(rand.Reader, 2048)
+	id3, _ := DeriveKeyID(rsaKey2)
+	assert.NotEqual(t, id1, id3, "different keys should produce different IDs")
+}
+
+func TestLoadHMACSecrets(t *testing.T) {
+	t.Parallel()
+
+	validSecret := strings.Repeat("a", 32)
+	validSecret2 := strings.Repeat("b", 32)
+	tooShortSecret := strings.Repeat("a", 31)
+
+	tests := []struct {
+		name        string
+		setup       func(t *testing.T, dir string) []string
+		wantCurrent []byte
+		wantRotated [][]byte
+		wantErr     string
+	}{
+		{
+			name:        "empty paths",
+			setup:       func(_ *testing.T, _ string) []string { return []string{} },
+			wantCurrent: nil,
+			wantRotated: nil,
+		},
+		{
+			name: "single secret",
+			setup: func(_ *testing.T, dir string) []string {
+				return []string{writeFileNamed(t, dir, "current", validSecret)}
+			},
+			wantCurrent: []byte(validSecret),
+			wantRotated: nil,
+		},
+		{
+			name: "with rotated secrets",
+			setup: func(_ *testing.T, dir string) []string {
+				return []string{
+					writeFileNamed(t, dir, "current", validSecret),
+					writeFileNamed(t, dir, "rotated1", validSecret2),
+				}
+			},
+			wantCurrent: []byte(validSecret),
+			wantRotated: [][]byte{[]byte(validSecret2)},
+		},
+		{
+			name: "empty current path",
+			setup: func(_ *testing.T, _ string) []string {
+				return []string{""}
+			},
+			wantErr: "current HMAC secret path cannot be empty",
+		},
+		{
+			name: "invalid current secret file",
+			setup: func(_ *testing.T, _ string) []string {
+				return []string{"/nonexistent/secret"}
+			},
+			wantErr: "failed to load current",
+		},
+		{
+			name: "invalid rotated secret",
+			setup: func(_ *testing.T, dir string) []string {
+				return []string{
+					writeFileNamed(t, dir, "current", validSecret),
+					"/nonexistent/rotated",
+				}
+			},
+			wantErr: "failed to load rotated HMAC secret [1]",
+		},
+		{
+			name: "skip empty rotated paths",
+			setup: func(_ *testing.T, dir string) []string {
+				return []string{
+					writeFileNamed(t, dir, "current", validSecret),
+					"",
+					writeFileNamed(t, dir, "rotated2", validSecret2),
+				}
+			},
+			wantCurrent: []byte(validSecret),
+			wantRotated: [][]byte{[]byte(validSecret2)},
+		},
+		{
+			name: "whitespace trimmed",
+			setup: func(_ *testing.T, dir string) []string {
+				return []string{
+					writeFileNamed(t, dir, "current", "  "+validSecret+"  \n\n"),
+					writeFileNamed(t, dir, "rotated", "\t"+validSecret2+"\n"),
+				}
+			},
+			wantCurrent: []byte(validSecret),
+			wantRotated: [][]byte{[]byte(validSecret2)},
+		},
+		{
+			name: "current too short",
+			setup: func(_ *testing.T, dir string) []string {
+				return []string{writeFileNamed(t, dir, "current", tooShortSecret)}
+			},
+			wantErr: "HMAC secret must be at least",
+		},
+		{
+			name: "rotated too short",
+			setup: func(_ *testing.T, dir string) []string {
+				return []string{
+					writeFileNamed(t, dir, "current", validSecret),
+					writeFileNamed(t, dir, "rotated", tooShortSecret),
+				}
+			},
+			wantErr: "failed to load rotated HMAC secret [1]",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			paths := tt.setup(t, dir)
+
+			secrets, err := LoadHMACSecrets(paths)
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				assert.Nil(t, secrets)
+			} else {
+				require.NoError(t, err)
+				if tt.wantCurrent == nil {
+					assert.Nil(t, secrets)
+				} else {
+					require.NotNil(t, secrets)
+					assert.Equal(t, tt.wantCurrent, secrets.Current)
+					assert.Equal(t, tt.wantRotated, secrets.Rotated)
+				}
+			}
+		})
+	}
+}
+
+// Helpers
+
+func writePEM(t *testing.T, dir, pemType string, der []byte) string {
+	t.Helper()
+	path := filepath.Join(dir, "key.pem")
+	data := pem.EncodeToMemory(&pem.Block{Type: pemType, Bytes: der})
+	require.NoError(t, os.WriteFile(path, data, 0600))
+	return path
+}
+
+func writeFileNamed(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(path, []byte(content), 0600))
+	return path
+}

--- a/pkg/authserver/server/crypto/pkce.go
+++ b/pkg/authserver/server/crypto/pkce.go
@@ -1,0 +1,51 @@
+// Copyright 2025 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package crypto
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+)
+
+// PKCEChallengeMethodS256 is the PKCE challenge method using SHA-256 (RFC 7636).
+const PKCEChallengeMethodS256 = "S256"
+
+// pkceVerifierLength is the length of the code verifier in bytes before encoding.
+// RFC 7636 requires the verifier to be 43-128 characters after base64url encoding.
+// 32 bytes = 43 characters after base64url encoding (without padding).
+const pkceVerifierLength = 32
+
+// GeneratePKCEVerifier generates a cryptographically random code_verifier
+// per RFC 7636 Section 4.1.
+// The verifier is 43 characters (32 bytes base64url encoded without padding),
+// using characters from the base64url alphabet: [A-Z], [a-z], [0-9], "-", "_".
+func GeneratePKCEVerifier() (string, error) {
+	b := make([]byte, pkceVerifierLength)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("failed to generate PKCE verifier: %w", err)
+	}
+	// base64url encoding without padding produces URL-safe characters
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+// ComputePKCEChallenge computes the code_challenge from a code_verifier
+// using the S256 method per RFC 7636 Section 4.2.
+// code_challenge = BASE64URL(SHA256(code_verifier))
+func ComputePKCEChallenge(verifier string) string {
+	hash := sha256.Sum256([]byte(verifier))
+	return base64.RawURLEncoding.EncodeToString(hash[:])
+}

--- a/pkg/authserver/server/crypto/pkce_test.go
+++ b/pkg/authserver/server/crypto/pkce_test.go
@@ -1,0 +1,43 @@
+// Copyright 2025 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package crypto
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGeneratePKCEVerifier(t *testing.T) {
+	t.Parallel()
+
+	verifier, err := GeneratePKCEVerifier()
+	require.NoError(t, err)
+
+	// RFC 7636: code_verifier must be 43-128 characters
+	assert.GreaterOrEqual(t, len(verifier), 43)
+	assert.LessOrEqual(t, len(verifier), 128)
+}
+
+func TestComputePKCEChallenge_RFC7636Example(t *testing.T) {
+	t.Parallel()
+
+	// RFC 7636 Appendix B example
+	verifier := "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+	expected := "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+
+	assert.Equal(t, expected, ComputePKCEChallenge(verifier))
+}


### PR DESCRIPTION
Add the crypto package with utilities for JWT signing key management, HMAC secret handling with rotation support, and PKCE implementation.

Heavily inspired by code in Ory Hydra. I considered using their code direclty, but being outside fosite it's not considered stable.

So far this code is unused, just tested, but these utilities will be consumed by:
- runconfig.BuildConfig() to load keys from CLI flags
- server.NewOAuth2Provider() to configure fosite with signing keys
- OAuth flow handlers for PKCE validation and upstream IDP redirects

Key loading (keys.go):
- LoadSigningKey: Load private keys from PEM files (RSA PKCS1/PKCS8, ECDSA SEC1/PKCS8, Ed25519 PKCS8) with RSA minimum 2048-bit validation
- DeriveKeyID: Compute RFC 7638 JWK Thumbprint for stable key identifiers
- DeriveAlgorithm: Auto-detect signing algorithm from key type (RS256, ES256/384/512, EdDSA)
- ValidateAlgorithmForKey: Validate algorithm compatibility with key type
- DeriveSigningKeyParams: Orchestrate key parameter derivation/validation

HMAC secret management (keys.go):
- LoadHMACSecrets: Load secrets with rotation support for zero-downtime rotation. paths[0] is the current signing secret, paths[1:] are rotated verification-only secrets. Integrates with fosite's GlobalSecret/RotatedGlobalSecrets interfaces.

PKCE (pkce.go):
- GeneratePKCEVerifier: Generate RFC 7636 code_verifier (32 bytes, base64url encoded)
- ComputePKCEChallenge: Compute S256 code_challenge from verifier