### PR TITLE
Add Virtual MCP Server architecture documentation

### DIFF
--- a/docs/arch/00-overview.md
+++ b/docs/arch/00-overview.md
@@ -87,7 +87,7 @@ thv run go://package-name
 
 Manages MCP servers in Kubernetes clusters using custom resources.
 
-The operator watches for `MCPServer`, `MCPRegistry`, `MCPToolConfig`, and `MCPExternalAuthConfig` CRDs, reconciling them into Kubernetes resources (Deployments, StatefulSets, Services).
+The operator watches for `MCPServer`, `MCPRegistry`, `MCPToolConfig`, `MCPExternalAuthConfig`, `MCPGroup`, and `VirtualMCPServer` CRDs, reconciling them into Kubernetes resources (Deployments, StatefulSets, Services).
 
 **For details**, see:
 - [`cmd/thv-operator/README.md`](../../cmd/thv-operator/README.md) - Operator overview and usage
@@ -122,6 +122,18 @@ A registry API server for hosting custom MCP server registries. Located in `cmd/
 - Future support for upstream MCP registry format
 - Provide file-based and Kubernetes ConfigMap storage
 
+### 5. Virtual MCP Server (vmcp)
+
+An MCP Gateway that aggregates multiple backend MCP servers into a single unified interface. Located in `cmd/vmcp/`.
+
+**Key responsibilities:**
+- Aggregate tools, resources, and prompts from multiple backends
+- Resolve naming conflicts when backends expose duplicate tool names
+- Execute composite workflows across multiple backends
+- Handle two-boundary authentication (incoming clients and outgoing backends)
+
+**For details**, see [Virtual MCP Server Architecture](10-virtual-mcp-architecture.md).
+
 ## Core Concepts
 
 For detailed definitions and relationships, see [Core Concepts](02-core-concepts.md).
@@ -134,6 +146,7 @@ For detailed definitions and relationships, see [Core Concepts](02-core-concepts
 - **Permission Profiles** - Security policies
 - **Groups** - Logical server collections
 - **Registry** - Catalog of trusted MCP servers
+- **Virtual MCP Server** - Aggregates multiple backends into unified interface
 
 ## Deployment Modes
 
@@ -246,6 +259,7 @@ These are automatically converted to container images at runtime.
 - [Groups](07-groups.md) - Groups and organization
 - [Workloads Lifecycle](08-workloads-lifecycle.md) - Workload management
 - [Operator Architecture](09-operator-architecture.md) - Kubernetes operator design
+- [Virtual MCP Server Architecture](10-virtual-mcp-architecture.md) - MCP Gateway and aggregation
 
 ## Getting Started
 

--- a/docs/arch/02-core-concepts.md
+++ b/docs/arch/02-core-concepts.md
@@ -286,6 +286,8 @@ spec:
 - Controller: `cmd/thv-operator/controllers/virtualmcpserver_controller.go`
 - Binary: `cmd/vmcp/` (virtual MCP server runtime)
 
+**For architecture details**, see [Virtual MCP Server Architecture](10-virtual-mcp-architecture.md).
+
 **Related concepts:** Group, MCPServer (Kubernetes), Workload, Client
 
 ### Registry
@@ -777,3 +779,4 @@ Registry
 - [Transport Architecture](03-transport-architecture.md) - Transport and proxy details
 - [RunConfig and Permissions](05-runconfig-and-permissions.md) - Configuration schema
 - [Middleware](../middleware.md) - Middleware system
+- [Virtual MCP Server Architecture](10-virtual-mcp-architecture.md) - vMCP aggregation details

--- a/docs/arch/07-groups.md
+++ b/docs/arch/07-groups.md
@@ -117,11 +117,19 @@ Groups provide a logical boundary for client configuration. The client manager c
 - `frontend-team` - Frontend development tools
 - `data-team` - Data analysis tools
 
+## Virtual MCP Integration
+
+Groups are the foundation for **Virtual MCP Servers**. A VirtualMCPServer references an MCPGroup and aggregates all backends in that group into a single unified interface.
+
+See [Virtual MCP Server Architecture](10-virtual-mcp-architecture.md) for details on:
+- Backend discovery from groups
+- Tool aggregation and conflict resolution
+- Composite tool workflows
+
 ## Future Features
 
-Groups serve as the foundation for upcoming features:
+Groups may serve as the foundation for additional features:
 
-- **Virtual MCP Servers**: Aggregate multiple servers in a group into a single unified interface (proposed, under consideration)
 - **Group-level policies**: Apply authorization at group level
 - **Group metrics**: Aggregate telemetry from all group members
 - **Group health**: Overall health status of group
@@ -131,3 +139,4 @@ Groups serve as the foundation for upcoming features:
 - [Core Concepts](02-core-concepts.md) - Group concept definition
 - [Registry System](06-registry-system.md) - Groups in registry
 - [Workloads Lifecycle](08-workloads-lifecycle.md) - Group operations
+- [Virtual MCP Server Architecture](10-virtual-mcp-architecture.md) - Group-based aggregation

--- a/docs/arch/09-operator-architecture.md
+++ b/docs/arch/09-operator-architecture.md
@@ -187,6 +187,18 @@ VirtualMCPServer creates a virtual MCP server that aggregates tools, resources, 
 
 5. **Backend Health Monitoring**: Periodic health checks with configurable intervals and automatic status updates
 
+### VirtualMCPCompositeToolDefinition
+
+Defines reusable composite tool workflows that can be shared across multiple VirtualMCPServers.
+
+**Implementation**: `cmd/thv-operator/api/v1alpha1/virtualmcpcompositetooldefinition_types.go`
+
+Composite tools orchestrate calls to multiple backend tools in sequence or parallel, enabling complex workflows without client awareness of the underlying backends. Workflow steps form a DAG (Directed Acyclic Graph) with support for conditional execution and error handling.
+
+**Referenced by**: VirtualMCPServer (via `spec.compositeToolRefs`)
+
+**Status fields** track validation status and which VirtualMCPServers reference the definition.
+
 For examples, see the [`examples/operator/`](../../examples/operator/) directory.
 
 For complete examples of all CRDs, see the [`examples/operator/mcp-servers/`](../../examples/operator/mcp-servers/) directory.
@@ -471,4 +483,5 @@ spec:
 - [Deployment Modes](01-deployment-modes.md) - Kubernetes mode details
 - [Core Concepts](02-core-concepts.md) - Operator concepts
 - [Registry System](06-registry-system.md) - MCPRegistry CRD
+- [Virtual MCP Server Architecture](10-virtual-mcp-architecture.md) - VirtualMCPServer details
 - Operator Design: `cmd/thv-operator/DESIGN.md`

--- a/docs/arch/10-virtual-mcp-architecture.md
+++ b/docs/arch/10-virtual-mcp-architecture.md
@@ -1,0 +1,239 @@
+# Virtual MCP Server Architecture
+
+The Virtual MCP Server (vMCP) aggregates multiple MCP servers from a ToolHive group into a single unified interface. This document explains the architecture and design of vMCP.
+
+## Overview
+
+vMCP solves the problem of **MCP server sprawl**. As organizations deploy more specialized MCP servers, clients need to connect to multiple endpoints. vMCP provides:
+
+- **Unified endpoint** - One URL for clients to access many backends
+- **Tool aggregation** - Combine tools from multiple servers
+- **Conflict resolution** - Handle duplicate tool names automatically
+- **Composite workflows** - Create new tools that orchestrate multiple backends
+- **Centralized security** - Single authentication and authorization point
+- **Token management** - Exchange and cache tokens for backend access
+
+## Architecture
+
+The vmcp package follows Domain-Driven Design principles with clear separation into bounded contexts:
+
+```mermaid
+graph TB
+    subgraph "Virtual MCP Server"
+        Server[Server<br/>HTTP + MCP Protocol]
+        Discovery[Discovery Manager]
+        Router[Router]
+        BackendClient[Backend Client]
+        Health[Health Monitor]
+    end
+
+    subgraph "Aggregation"
+        Aggregator[Aggregator]
+        Conflict[Conflict Resolver]
+    end
+
+    subgraph "Authentication"
+        InAuth[Incoming Auth<br/>OIDC / Anonymous]
+        OutAuth[Outgoing Auth<br/>Token Exchange / Headers]
+    end
+
+    subgraph "MCPGroup"
+        B1[MCPServer]
+        B2[MCPServer]
+        B3[MCPRemoteProxy]
+    end
+
+    Client[MCP Client] --> Server
+    Server --> InAuth
+    InAuth --> Discovery
+    Discovery --> Aggregator
+    Aggregator --> Conflict
+    Discovery --> Router
+    Router --> OutAuth
+    OutAuth --> BackendClient
+    BackendClient --> B1
+    BackendClient --> B2
+    BackendClient --> B3
+    Health --> B1
+    Health --> B2
+    Health --> B3
+
+    style Server fill:#90caf9
+    style Aggregator fill:#81c784
+    style Router fill:#fff59d
+```
+
+### Core Concepts
+
+| Concept | Purpose |
+|---------|---------|
+| **Routing** | Forward MCP requests (tools, resources, prompts) to appropriate backends |
+| **Aggregation** | Discover capabilities, resolve conflicts, merge into unified view |
+| **Authentication** | Two-boundary model: incoming (client → vMCP) and outgoing (vMCP → backend) |
+| **Composition** | Execute multi-step workflows across multiple backends |
+| **Caching** | Reduce auth overhead by caching exchanged tokens |
+
+**Implementation**: `pkg/vmcp/`
+
+## Backend Discovery
+
+vMCP discovers backends from an **MCPGroup**. The group acts as a container for related MCP servers that should be exposed together.
+
+```mermaid
+graph LR
+    vMCP[VirtualMCPServer] -->|references| Group[MCPGroup]
+    Group -->|contains| S1[MCPServer]
+    Group -->|contains| S2[MCPServer]
+    Group -->|contains| R1[MCPRemoteProxy]
+
+    style vMCP fill:#90caf9
+    style Group fill:#ba68c8
+```
+
+**Discovery process:**
+1. VirtualMCPServer references an MCPGroup by name
+2. All MCPServers and MCPRemoteProxies in that group are discovered
+3. For each backend, URL, transport type, and auth config are extracted
+4. vMCP queries each backend for available tools, resources, and prompts
+
+**Implementation**: `pkg/vmcp/aggregator/`
+
+## Aggregation Pipeline
+
+Aggregation happens in three stages:
+
+```mermaid
+graph LR
+    A[1. Discovery<br/>Find backends] --> B[2. Query<br/>Get capabilities]
+    B --> C[3. Resolve<br/>Handle conflicts]
+    C --> D[4. Merge<br/>Create routing table]
+
+    style A fill:#e3f2fd
+    style B fill:#e8f5e9
+    style C fill:#fff3e0
+    style D fill:#fce4ec
+```
+
+1. **Discovery** - Find all backends in the MCPGroup
+2. **Query** - Ask each backend for its tools, resources, and prompts (parallel)
+3. **Resolve** - Handle naming conflicts using configured strategy
+4. **Merge** - Create unified routing table mapping names to backends
+
+### Conflict Resolution
+
+When backends expose tools with the same name, vMCP resolves the conflict using one of three strategies:
+
+| Strategy | Behavior |
+|----------|----------|
+| **prefix** | Prepend backend name to all tools (e.g., `github.create_issue`) |
+| **priority** | First backend in priority order wins, others hidden |
+| **manual** | Explicit mapping for each conflict |
+
+### Tool Filtering
+
+Beyond conflict resolution, vMCP can filter which tools are exposed through allow/deny lists, renaming, and description overrides.
+
+**Implementation**: `pkg/vmcp/aggregator/`
+
+## Composite Tools
+
+Composite tools are new tools defined in vMCP that orchestrate calls to multiple backend tools. They enable complex workflows without client awareness of the underlying backends.
+
+```mermaid
+graph LR
+    subgraph "Composite Tool"
+        Step1[Step 1]
+        Step2[Step 2]
+        Step3[Step 3]
+    end
+
+    Step1 --> Step2
+    Step1 --> Step3
+
+    style Step1 fill:#90caf9
+    style Step2 fill:#81c784
+    style Step3 fill:#81c784
+```
+
+Step dependencies form a DAG (Directed Acyclic Graph). Steps without dependencies execute in parallel, while dependent steps wait for prerequisites.
+
+**Implementation**: `pkg/vmcp/composer/`
+
+## Two-Boundary Authentication
+
+vMCP uses separate authentication for incoming clients and outgoing backend calls:
+
+```mermaid
+graph LR
+    subgraph "Boundary 1: Incoming"
+        Client[Client] -->|JWT| vMCP[vMCP]
+    end
+
+    subgraph "Boundary 2: Outgoing"
+        vMCP -->|Exchanged Token| Backend[Backend]
+    end
+
+    style Client fill:#e3f2fd
+    style vMCP fill:#90caf9
+    style Backend fill:#ffb74d
+```
+
+### Incoming Authentication
+
+Validates clients connecting to vMCP using OIDC token validation or anonymous access.
+
+### Outgoing Authentication
+
+Authenticates vMCP to backend MCP servers using:
+- **Token exchange** - RFC 8693 exchange of client token for backend-specific token
+- **Header injection** - Static API key or header injection
+- **Unauthenticated** - For internal/trusted backends
+
+Exchanged tokens are cached to avoid repeated exchange calls.
+
+**Implementation**: `pkg/vmcp/auth/`, `pkg/vmcp/cache/`
+
+## Request Flow
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Server as vMCP Server
+    participant Router
+    participant Backend
+
+    Client->>Server: tools/call (tool_name)
+    Server->>Server: Validate client auth
+    Server->>Router: Route tool_name
+    Router->>Server: BackendTarget
+    Server->>Server: Apply outgoing auth
+    Server->>Backend: tools/call (original_name)
+    Backend->>Server: Tool result
+    Server->>Client: Tool result
+```
+
+**Key insight**: If a tool was renamed during conflict resolution (e.g., `github.create_issue`), vMCP translates it back to the original name (`create_issue`) when calling the backend.
+
+## Health Monitoring
+
+vMCP monitors backend health with configurable intervals. Health status (healthy, degraded, unhealthy, unknown) affects routing decisions and is reported in VirtualMCPServer status.
+
+**Implementation**: `pkg/vmcp/health/`
+
+## Deployment
+
+vMCP can be deployed two ways:
+
+- **Kubernetes** - Via the VirtualMCPServer CRD managed by the operator
+- **CLI** - Standalone via the `vmcp` binary for development or non-Kubernetes environments
+
+**Implementation**:
+- Kubernetes: `cmd/thv-operator/controllers/virtualmcpserver_controller.go`
+- CLI: `cmd/vmcp/`
+
+## Related Documentation
+
+- [Core Concepts](02-core-concepts.md) - Virtual MCP Server concept
+- [Groups](07-groups.md) - MCPGroup for backend organization
+- [Operator Architecture](09-operator-architecture.md) - CRD details
+- [Transport Architecture](03-transport-architecture.md) - Transport types used by backends

--- a/docs/arch/README.md
+++ b/docs/arch/README.md
@@ -54,7 +54,6 @@ Welcome to the ToolHive architecture documentation. This directory contains comp
    - Group concept and use cases
    - Registry groups
    - Client configuration
-   - Future: Virtual MCP aggregation (proposal pending)
 
 9. **[Workloads Lifecycle Management](08-workloads-lifecycle.md)**
    - Workloads API interface
@@ -64,11 +63,18 @@ Welcome to the ToolHive architecture documentation. This directory contains comp
    - Async operations
 
 10. **[Kubernetes Operator Architecture](09-operator-architecture.md)**
-    - CRD design (MCPServer, MCPRegistry, MCPToolConfig, MCPExternalAuthConfig)
+    - CRD design (MCPServer, MCPRegistry, MCPToolConfig, MCPExternalAuthConfig, VirtualMCPServer)
     - Two-binary architecture (operator + proxy-runner)
     - Deployment pattern
     - Status management
     - Design principles
+
+11. **[Virtual MCP Server Architecture](10-virtual-mcp-architecture.md)**
+    - MCP Gateway for aggregating multiple backends
+    - Backend discovery and capability aggregation
+    - Conflict resolution strategies
+    - Two-boundary authentication model
+    - Composite tool workflows
 
 ### Existing Documentation
 
@@ -111,6 +117,7 @@ graph TB
     subgraph "Runtime Management"
         Workloads[08: Workloads Lifecycle<br/>Deploy, stop, restart, delete]
         Operator[09: Kubernetes Operator<br/>CRDs & reconciliation]
+        vMCP[10: Virtual MCP<br/>Aggregation & Gateway]
     end
 
     %% Navigation paths
@@ -133,8 +140,10 @@ graph TB
     Registry --> Workloads
 
     Groups --> Workloads
+    Groups --> vMCP
 
     Workloads --> Operator
+    vMCP --> Operator
 
     %% Styling
     style Overview fill:#e1f5fe,stroke:#01579b,stroke-width:3px
@@ -148,6 +157,7 @@ graph TB
     style Groups fill:#fce4ec,stroke:#880e4f,stroke-width:2px
     style Workloads fill:#e0f2f1,stroke:#004d40,stroke-width:2px
     style Operator fill:#e0f2f1,stroke:#004d40,stroke-width:2px
+    style vMCP fill:#e0f2f1,stroke:#004d40,stroke-width:2px
 ```
 
 **Color Legend:**
@@ -233,7 +243,7 @@ ToolHive is a **platform** for MCP server management, providing:
 - Middleware system for custom processing
 - Custom registries
 - Protocol builds (uvx://, npx://, go://)
-- Virtual MCP composition (upcoming)
+- [Virtual MCP composition](10-virtual-mcp-architecture.md)
 
 ### 5. Cloud Native
 


### PR DESCRIPTION
## Summary
- Add new `docs/arch/10-virtual-mcp-architecture.md` with comprehensive vMCP architecture documentation
- Update existing architecture docs to fix outdated "upcoming feature" references for vMCP
- Add VirtualMCPCompositeToolDefinition CRD documentation to operator architecture doc

## Details

The Virtual MCP Server (vMCP) was previously described as "proposed" or "upcoming" in the architecture documentation, but it is now fully implemented. This PR brings the documentation up to date.

**New document** (`10-virtual-mcp-architecture.md`) covers:
- Core concepts: routing, aggregation, authentication, composition, caching
- Backend discovery from MCPGroups
- Aggregation pipeline (discovery → query → resolve → merge)
- Conflict resolution strategies (prefix, priority, manual)
- Composite tools with DAG-based execution
- Two-boundary authentication model (incoming and outgoing)
- Health monitoring

**Updated documents:**
- `README.md` - Added vMCP to index and architecture map
- `07-groups.md` - Changed "Future Features" to "Virtual MCP Integration" 
- `00-overview.md` - Added vmcp binary as key component #5
- `09-operator-architecture.md` - Added VirtualMCPCompositeToolDefinition CRD
- `02-core-concepts.md` - Added cross-reference to new doc

## Test plan
- [ ] Verify all internal links work correctly
- [ ] Review diagrams render properly in GitHub markdown
- [ ] Confirm accuracy of implementation file paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)