### PR TITLE
Add CRD overview diagram to operator architecture docs

### DIFF
--- a/docs/arch/09-operator-architecture.md
+++ b/docs/arch/09-operator-architecture.md
@@ -38,6 +38,95 @@ graph TB
 
 ## Custom Resource Definitions
 
+### CRD Overview
+
+MCPServer is the fundamental building block. All other CRDs either **organize**, **aggregate**, **configure**, or help **discover** MCP servers.
+
+```
+                    ┌─────────────────────────────────────┐
+                    │           DISCOVERY                 │
+                    │          MCPRegistry                │
+                    │  ┌───────────────────────────────┐  │
+                    │  │       AGGREGATION             │  │
+                    │  │    VirtualMCPServer           │  │
+                    │  │    + CompositeToolDef         │  │
+                    │  │  ┌─────────────────────────┐  │  │
+                    │  │  │     ORGANIZATION        │  │  │
+                    │  │  │       MCPGroup          │  │  │
+                    │  │  │  ┌───────────────────┐  │  │  │
+                    │  │  │  │      CORE         │  │  │  │
+                    │  │  │  │    MCPServer      │  │  │  │
+                    │  │  │  │  MCPRemoteProxy   │  │  │  │
+                    │  │  │  └───────────────────┘  │  │  │
+                    │  │  └─────────────────────────┘  │  │
+                    │  └───────────────────────────────┘  │
+                    └─────────────────────────────────────┘
+
+        ┌──────────────────────────────────────────────────┐
+        │              CONFIGURATION (attaches to any)     │
+        │         ToolConfig    MCPExternalAuthConfig      │
+        └──────────────────────────────────────────────────┘
+```
+
+| Layer | CRDs | Purpose |
+|-------|------|---------|
+| **Core** | MCPServer, MCPRemoteProxy | Run or proxy MCP servers |
+| **Organization** | MCPGroup | Group related servers together |
+| **Aggregation** | VirtualMCPServer, VirtualMCPCompositeToolDefinition | Combine multiple servers into one endpoint |
+| **Discovery** | MCPRegistry | Help clients find available servers |
+| **Configuration** | ToolConfig, MCPExternalAuthConfig | Shared config that attaches to any layer |
+
+#### Workload CRDs (Deploy Running Pods)
+
+| CRD | Deploys | Purpose |
+|-----|---------|---------|
+| **MCPServer** | Deployment + StatefulSet | Container-based MCP server with proxy |
+| **MCPRemoteProxy** | Deployment | Proxy to external/remote MCP servers |
+| **VirtualMCPServer** | Deployment | Aggregates multiple backends into one endpoint |
+| **MCPRegistry** | Deployment | Registry API server for MCP discovery |
+
+#### Logical/Configuration CRDs (No Pods)
+
+| CRD | Purpose |
+|-----|---------|
+| **MCPGroup** | Logical grouping of workloads (status tracking only) |
+| **ToolConfig** | Tool filtering and renaming configuration |
+| **MCPExternalAuthConfig** | Token exchange / header injection configuration |
+| **VirtualMCPCompositeToolDefinition** | Workflow definitions (webhook validation only) |
+
+### CRD Relationships
+
+```mermaid
+graph TB
+    subgraph "Deploys Workloads"
+        VMCP[VirtualMCPServer<br/>Deployment: aggregator]
+        Server[MCPServer<br/>Deployment + StatefulSet]
+        Proxy[MCPRemoteProxy<br/>Deployment: proxy]
+        Registry[MCPRegistry<br/>Deployment: API server]
+    end
+
+    subgraph "Logical Grouping"
+        Group[MCPGroup<br/>No resources]
+    end
+
+    subgraph "Configuration Only"
+        CTD[VirtualMCPCompositeToolDefinition<br/>Webhook validation]
+        ExtAuth[MCPExternalAuthConfig<br/>No resources]
+        ToolCfg[ToolConfig<br/>No resources]
+    end
+
+    VMCP -->|groupRef| Group
+    VMCP -->|compositeToolRefs| CTD
+
+    Server -->|groupRef| Group
+    Server -.->|externalAuthConfigRef| ExtAuth
+    Server -.->|toolConfigRef| ToolCfg
+
+    Proxy -->|groupRef| Group
+    Proxy -.->|externalAuthConfigRef| ExtAuth
+    Proxy -.->|toolConfigRef| ToolCfg
+```
+
 ### MCPServer
 
 Defines an MCP server deployment, including container images, transports, middleware, and authentication configuration.


### PR DESCRIPTION
## Summary

- Adds a concentric circles diagram showing how CRDs relate conceptually
- MCPServer is the core building block; other CRDs provide organization, aggregation, discovery, and configuration
- Adds layer table explaining the purpose of each CRD category
- Adds detailed tables showing which CRDs deploy workloads vs configuration-only
- Adds mermaid diagram showing reference relationships between CRDs

## Test plan

- [ ] Verify the ASCII diagram renders correctly in GitHub markdown
- [ ] Review that the layer categorization makes sense

🤖 Generated with [Claude Code](https://claude.com/claude-code)