### PR TITLE
Fix vMCP architecture documentation accuracy

### DIFF
--- a/docs/arch/02-core-concepts.md
+++ b/docs/arch/02-core-concepts.md
@@ -276,10 +276,11 @@ spec:
 ```
 
 **Deployment:**
-- Kubernetes only (operator-based deployment)
-- Creates Deployment, Service, and ConfigMap
-- Mounts vmcp configuration as ConfigMap
-- Uses `thv-proxyrunner` to run vmcp binary
+- Kubernetes: Via VirtualMCPServer CRD managed by the operator
+  - Creates Deployment, Service, and ConfigMap
+  - Mounts vmcp configuration as ConfigMap
+  - Uses `thv-proxyrunner` to run vmcp binary
+- CLI: Standalone via the `vmcp` binary for development or non-Kubernetes environments
 
 **Implementation:**
 - CRD: `cmd/thv-operator/api/v1alpha1/virtualmcpserver_types.go`

--- a/docs/arch/09-operator-architecture.md
+++ b/docs/arch/09-operator-architecture.md
@@ -165,10 +165,10 @@ VirtualMCPServer creates a virtual MCP server that aggregates tools, resources, 
 - Phase (Ready, Degraded, Pending, Failed)
 - URL for accessing the virtual server
 - Discovered backends with individual health status
-- Capabilities summary (tool/resource/prompt counts)
+- Backend count
 - Detailed conditions for validation, discovery, and readiness
 
-**Referenced by**: MCPGroup (via `spec.groupRef`)
+**References**: MCPGroup (via `spec.config.groupRef`)
 
 **Controller**: `cmd/thv-operator/controllers/virtualmcpserver_controller.go`
 

--- a/docs/arch/10-virtual-mcp-architecture.md
+++ b/docs/arch/10-virtual-mcp-architecture.md
@@ -73,7 +73,7 @@ graph TB
 | **Composition** | Execute multi-step workflows across multiple backends |
 | **Caching** | Reduce auth overhead by caching exchanged tokens |
 
-**Implementation**: `pkg/vmcp/`
+**Implementation**: `pkg/vmcp/` (discovery: `pkg/vmcp/discovery/`, routing: `pkg/vmcp/router/`)
 
 ## Backend Discovery
 
@@ -125,7 +125,7 @@ When backends expose tools with the same name, vMCP resolves the conflict using 
 
 | Strategy | Behavior |
 |----------|----------|
-| **prefix** | Prepend backend name to all tools (e.g., `github.create_issue`) |
+| **prefix** | Prepend backend name to all tools (e.g., `github_create_issue`) |
 | **priority** | First backend in priority order wins, others hidden |
 | **manual** | Explicit mapping for each conflict |
 
@@ -212,11 +212,11 @@ sequenceDiagram
     Server->>Client: Tool result
 ```
 
-**Key insight**: If a tool was renamed during conflict resolution (e.g., `github.create_issue`), vMCP translates it back to the original name (`create_issue`) when calling the backend.
+**Key insight**: If a tool was renamed during conflict resolution (e.g., `github_create_issue`), vMCP translates it back to the original name (`create_issue`) when calling the backend.
 
 ## Health Monitoring
 
-vMCP monitors backend health with configurable intervals. Health status (healthy, degraded, unhealthy, unknown) affects routing decisions and is reported in VirtualMCPServer status.
+vMCP monitors backend health with configurable intervals. Health status (healthy, degraded, unhealthy, unauthenticated, unknown) affects routing decisions and is reported in VirtualMCPServer status.
 
 **Implementation**: `pkg/vmcp/health/`
 


### PR DESCRIPTION
Address review findings from PR #3272 to align documentation with actual implementation.

docs/arch/10-virtual-mcp-architecture.md:
- Fix prefix format example to use underscore separator (github_create_issue) instead of dot, matching the default format in prefix_resolver.go
- Add 'unauthenticated' to health status list, which is tracked by the health monitor but was missing from documentation
- Add explicit references to pkg/vmcp/discovery/ and pkg/vmcp/router/ packages shown in architecture diagram but not referenced

docs/arch/02-core-concepts.md:
- Document CLI deployment mode alongside Kubernetes to resolve inconsistency with 10-virtual-mcp-architecture.md which mentioned both deployment options

docs/arch/09-operator-architecture.md:
- Replace non-existent "Capabilities summary" status field with actual "Backend count" field from VirtualMCPServerStatus struct
- Fix reference direction: VirtualMCPServer references MCPGroup (not the reverse), and correct field path to spec.config.groupRef