### PR TITLE
Add shared HTTPClient interface to networking package

### DIFF
--- a/pkg/auth/oauth/dynamic_registration.go
+++ b/pkg/auth/oauth/dynamic_registration.go
@@ -245,7 +245,7 @@ func createHTTPRequest(
 }
 
 // getHTTPClient returns the HTTP client to use for the request
-func getHTTPClient(client httpClient) httpClient {
+func getHTTPClient(client networking.HTTPClient) networking.HTTPClient {
 	if client != nil {
 		return client
 	}
@@ -319,7 +319,7 @@ func registerClientDynamicallyWithClient(
 	ctx context.Context,
 	registrationEndpoint string,
 	request *DynamicClientRegistrationRequest,
-	client httpClient,
+	client networking.HTTPClient,
 ) (*DynamicClientRegistrationResponse, error) {
 	// Validate registration endpoint URL
 	if _, err := validateRegistrationEndpoint(registrationEndpoint); err != nil {

--- a/pkg/auth/oauth/oidc.go
+++ b/pkg/auth/oauth/oidc.go
@@ -42,11 +42,6 @@ type OIDCDiscoveryDocument struct {
 	CodeChallengeMethodsSupported []string `json:"code_challenge_methods_supported,omitempty"`
 }
 
-// httpClient interface for dependency injection (private for testing)
-type httpClient interface {
-	Do(req *http.Request) (*http.Response, error)
-}
-
 // DiscoverOIDCEndpoints discovers OAuth endpoints from an OIDC issuer
 func DiscoverOIDCEndpoints(ctx context.Context, issuer string) (*OIDCDiscoveryDocument, error) {
 	return discoverOIDCEndpointsWithClient(ctx, issuer, nil, false)
@@ -63,7 +58,7 @@ func DiscoverActualIssuer(ctx context.Context, metadataURL string) (*OIDCDiscove
 func discoverOIDCEndpointsWithClient(
 	ctx context.Context,
 	issuer string,
-	client httpClient,
+	client networking.HTTPClient,
 	insecureAllowHTTP bool,
 ) (*OIDCDiscoveryDocument, error) {
 	return discoverOIDCEndpointsWithClientAndValidation(ctx, issuer, client, true, insecureAllowHTTP)
@@ -75,7 +70,7 @@ func discoverOIDCEndpointsWithClient(
 func discoverOIDCEndpointsWithClientAndValidation(
 	ctx context.Context,
 	issuer string,
-	client httpClient,
+	client networking.HTTPClient,
 	validateIssuer bool,
 	insecureAllowHTTP bool,
 ) (*OIDCDiscoveryDocument, error) {
@@ -234,7 +229,7 @@ func createOAuthConfigFromOIDCWithClient(
 	usePKCE bool,
 	callbackPort int,
 	resource string,
-	client httpClient,
+	client networking.HTTPClient,
 ) (*Config, error) {
 	// Discover OIDC endpoints (insecureAllowHTTP is false for OAuth config creation)
 	doc, err := discoverOIDCEndpointsWithClient(ctx, issuer, client, false)

--- a/pkg/auth/oauth/oidc_test.go
+++ b/pkg/auth/oauth/oidc_test.go
@@ -1067,7 +1067,7 @@ func TestDiscoverOIDCEndpoints_Production(t *testing.T) {
 			defer cancel()
 
 			// Test the production function with TLS-skipping client for test servers
-			var client httpClient
+			var client networking.HTTPClient
 			if tt.serverResponse != nil {
 				client = &http.Client{
 					Timeout: 30 * time.Second,
@@ -1190,7 +1190,7 @@ func TestCreateOAuthConfigFromOIDC_Production(t *testing.T) {
 			defer cancel()
 
 			// Test the production function with TLS-skipping client for test servers
-			var client httpClient
+			var client networking.HTTPClient
 			if tt.issuer == server.URL {
 				client = &http.Client{
 					Timeout: 30 * time.Second,

--- a/pkg/networking/http_client.go
+++ b/pkg/networking/http_client.go
@@ -15,6 +15,12 @@ import (
 	"golang.org/x/oauth2"
 )
 
+// HTTPClient is an interface for making HTTP requests.
+// This interface is satisfied by *http.Client and allows for dependency injection in testing.
+type HTTPClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
 var privateIPBlocks []*net.IPNet
 
 // HttpTimeout is the timeout for outgoing HTTP requests


### PR DESCRIPTION
Move the HTTP client interface to pkg/networking so it can be shared across packages. This consolidates the previously private httpClient interface from pkg/auth/oauth.