### PR TITLE
Add assignee to the docs update workflows

### DIFF
--- a/.github/workflows/releaser-helm-charts.yml
+++ b/.github/workflows/releaser-helm-charts.yml
@@ -87,5 +87,6 @@ jobs:
         version: ${{ fromJSON(needs.release-helm-charts.outputs.released_charts) }}
     with:
       version: ${{ matrix.version }}
+      assign_to: ${{ github.actor }}
     secrets:
       DOCS_REPO_DISPATCH_TOKEN: ${{ secrets.DOCS_REPO_DISPATCH_TOKEN }}

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -151,6 +151,7 @@ jobs:
     uses: ./.github/workflows/update-docs-website.yml
     with:
       version: ${{ github.ref_name }}
+      assign_to: ${{ github.actor }}
     secrets:
       DOCS_REPO_DISPATCH_TOKEN: ${{ secrets.DOCS_REPO_DISPATCH_TOKEN }}
 

--- a/.github/workflows/update-docs-website.yml
+++ b/.github/workflows/update-docs-website.yml
@@ -9,6 +9,10 @@ on:
         description: 'Version tag for the release'
         required: true
         type: string
+      assign_to:
+        description: 'GitHub username to assign the PR to'
+        required: false
+        type: string
     secrets:
       DOCS_REPO_DISPATCH_TOKEN:
         required: true
@@ -24,13 +28,24 @@ jobs:
           repo="stacklok/docs-website"
           event_type="published-release"
           version="${{ inputs.version }}"
+          assign_to="${{ inputs.assign_to }}"
 
           echo "Triggering docs update for $repo with version $version"
-  
+          if [ -n "$assign_to" ]; then
+            echo "Will assign PR to: $assign_to"
+          fi
+
+          # Build client_payload JSON
+          payload="{\"version\": \"$version\""
+          if [ -n "$assign_to" ]; then
+            payload="$payload, \"assign_to\": \"$assign_to\""
+          fi
+          payload="$payload}"
+
           curl --fail -L \
             -X POST \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${{ secrets.DOCS_REPO_DISPATCH_TOKEN }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/$repo/dispatches \
-            -d "{\"event_type\": \"$event_type\", \"client_payload\": {\"version\": \"$version\"}}"
+            -d "{\"event_type\": \"$event_type\", \"client_payload\": $payload}"


### PR DESCRIPTION
Depends on stacklok/docs-website#443

Passes the username of the person whose push/tag triggered the CLI or Operator release along to the docs auto-update workflow, so it can assign the related docs PR.

Signed-off-by: Dan Barr <6922515+danbarr@users.noreply.github.com>