### PR TITLE
Fix workload deletion API by using background context

### DIFF
--- a/pkg/api/v1/workloads.go
+++ b/pkg/api/v1/workloads.go
@@ -210,11 +210,11 @@ func (s *WorkloadRoutes) restartWorkload(w http.ResponseWriter, r *http.Request)
 //	@Failure		404		{string}	string	"Not Found"
 //	@Router			/api/v1beta/workloads/{name} [delete]
 func (s *WorkloadRoutes) deleteWorkload(w http.ResponseWriter, r *http.Request) error {
-	ctx := r.Context()
 	name := chi.URLParam(r, "name")
 
 	// Use the bulk method with a single workload
-	_, err := s.workloadManager.DeleteWorkloads(ctx, []string{name})
+	// Note: In the API, we always assume that the delete is a background operation
+	_, err := s.workloadManager.DeleteWorkloads(context.Background(), []string{name})
 	if err != nil {
 		return err // ErrInvalidWorkloadName already has 400 status code
 	}
@@ -445,7 +445,8 @@ func (s *WorkloadRoutes) deleteWorkloadsBulk(w http.ResponseWriter, r *http.Requ
 
 	// Note that this is an asynchronous operation.
 	// The request is not blocked on completion.
-	_, err = s.workloadManager.DeleteWorkloads(ctx, workloadNames)
+	// Note: In the API, we always assume that the delete is a background operation.
+	_, err = s.workloadManager.DeleteWorkloads(context.Background(), workloadNames)
 	if err != nil {
 		return err // ErrInvalidWorkloadName already has 400 status code
 	}


### PR DESCRIPTION
## Problem
When deleting workloads through the API, we're getting errors:
```
 failed to acquire lock for workload <name>: context canceled 
```

This happens in `setWorkloadStatusInternal` when trying to acquire a file lock.

## Root Cause
The `deleteWorkload` and `deleteWorkloadsBulk` endpoints were using the HTTP request context (`r.Context()`) for async operations. When the HTTP handler returns (after sending `202 Accepted`), the request context gets cancelled. The async deletion operation then tries to acquire locks using this cancelled context, causing the error.

## Solution
Changed both delete endpoints to use `context.Background()` instead of the request context, matching the pattern used by `restartWorkload` and `restartWorkloadsBulk` (fixed in #3034).

## Why This is Safe
- The timeout is still preserved: `deleteWorkload` creates a child context with `AsyncOperationTimeout` (5 minutes) via `context.WithTimeout(ctx, AsyncOperationTimeout)`
- This matches the established pattern for async operations that should continue after HTTP request completion
- The bug was present from the start (June 2025) but manifests intermittently based on timing and lock contention

## Testing
- [ ] Tested delete operation works without errors
- [ ] Verified timeout is still enforced (5 minutes)
- [ ] Confirmed behavior matches restart operations
## Files Changed:
pkg/api/v1/workloads.go (2 functions: deleteWorkload, deleteWorkloadsBulk)
Related:
Fixes the same issue pattern as #3034 (restart operations)