### PR TITLE
Fix skill names to comply with Agent Skills specification

### DIFF
--- a/.claude/skills/commit-message/SKILL.md
+++ b/.claude/skills/commit-message/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: Generating Commit Messages
+name: commit-message
 description: Generates clear commit messages from git diffs. Use when writing commit messages or reviewing staged changes.
 ---
 

--- a/.claude/skills/doc-review/SKILL.md
+++ b/.claude/skills/doc-review/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: Documentation review
+name: doc-review
 description: Reviews documentation for factual accuracy
 ---
 

--- a/.claude/skills/helm-chart-bump/SKILL.md
+++ b/.claude/skills/helm-chart-bump/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: Bumping Helm Chart
+name: helm-chart-bump
 description: Ensures that all necessary tasks have been performed for a Helm Chart bump.
 ---
 

--- a/.claude/skills/pr-inline-review/SKILL.md
+++ b/.claude/skills/pr-inline-review/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: PR Inline Review
+name: pr-inline-review
 description: Submit inline review comments to GitHub Pull Requests using the GitHub CLI, with support for inline code suggestions.
 ---
 

--- a/.claude/skills/pr-review-reply/SKILL.md
+++ b/.claude/skills/pr-review-reply/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: PR Review Reply
+name: pr-review-reply
 description: Reply to and resolve GitHub PR review comments using the GitHub CLI and GraphQL API.
 ---
 


### PR DESCRIPTION
## Summary
- Updates all skill `name` fields in SKILL.md frontmatter to match their parent directory names
- Renames `pr-inline-review/skill.md` to `SKILL.md` as required by the spec
- Ensures compliance with [Agent Skills specification](https://agentskills.io/specification)

The specification requires the `name` field to:
- Use only lowercase letters, numbers, and hyphens (`a-z`, `0-9`, `-`)
- Match the parent directory name exactly
- Not contain spaces or uppercase characters

### Changes

| Skill Directory | Before | After |
|-----------------|--------|-------|
| `commit-message` | `Generating Commit Messages` | `commit-message` |
| `doc-review` | `Documentation review` | `doc-review` |
| `pr-inline-review` | `PR Inline Review` | `pr-inline-review` |
| `pr-review-reply` | `PR Review Reply` | `pr-review-reply` |
| `helm-chart-bump` | `Bumping Helm Chart` | `helm-chart-bump` |

## Test plan
- [ ] Verify skills are still recognized and function correctly
- [ ] Confirm frontmatter parses without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)