### PR TITLE
Fix workload update API by using background context for async operation

### DIFF
--- a/pkg/api/v1/workload_service.go
+++ b/pkg/api/v1/workload_service.go
@@ -97,7 +97,8 @@ func (s *WorkloadService) UpdateWorkloadFromRequest(ctx context.Context, name st
 	}
 
 	// Use the manager's UpdateWorkload method to handle the lifecycle
-	if _, err := s.workloadManager.UpdateWorkload(ctx, name, runConfig); err != nil {
+	// Use background context since this is async operation
+	if _, err := s.workloadManager.UpdateWorkload(context.Background(), name, runConfig); err != nil {
 		return nil, fmt.Errorf("failed to update workload: %w", err)
 	}
 


### PR DESCRIPTION
## Problem
The `updateWorkload` endpoint was using the HTTP request context (`r.Context()`) for async operations. When the handler returns, the request context gets cancelled, which can cause failures in async operations like lock acquisition.

## Solution
Changed `updateWorkload` to use `context.Background()` instead of the request context, matching the pattern used by `deleteWorkload`, `restartWorkload`, and `stopWorkload` endpoints.