### PR TITLE
Update MCP protocol expert agent with 2025-11-25 spec

### DIFF
--- a/.claude/agents/mcp-protocol-expert.md
+++ b/.claude/agents/mcp-protocol-expert.md
@@ -148,16 +148,16 @@ All messages MUST follow JSON-RPC 2.0 specification.
 Tasks enable durable state machines for tracking long-running operations. Both clients and servers can create tasks.
 
 **Terminology**:
-- **Requestor**: Sender of a task-augmented request (can be client or server)
+- **Requester**: Sender of a task-augmented request (can be client or server)
 - **Receiver**: Receiver/executor of the task (can be client or server)
 
 **Methods**:
 - `tasks/list`: List all tasks (paginated)
-- `tasks/get`: Get task status (requestor SHOULD poll respecting `pollInterval`)
+- `tasks/get`: Get task status (requester SHOULD poll respecting `pollInterval`)
 - `tasks/cancel`: Cancel a non-terminal task
 - `tasks/result`: Retrieve result (blocks until terminal status)
 
-**Notification**: `notifications/tasks/status` (optional, requestors MUST NOT rely on it)
+**Notification**: `notifications/tasks/status` (optional, requesters MUST NOT rely on it)
 
 **Status Lifecycle**:
 ```


### PR DESCRIPTION
## Summary

- Update the mcp-protocol-expert agent with comprehensive information from the MCP 2025-11-25 specification
- Apply AI agent writing best practices for better invocation and clarity

### Spec Updates
- Expanded transport documentation (stdio, Streamable HTTP with security details)
- Detailed Tasks specification (requestor/receiver model, tool-level negotiation, capability declarations)
- Comprehensive Elicitation coverage (Form and URL modes, security requirements)
- Updated Authorization section (Client ID Metadata Documents as preferred method, PKCE, resource indicators)
- Added Security Best Practices section (confused deputy, token passthrough, session hijacking, scope minimization)
- Enhanced lifecycle documentation (version negotiation, timeouts)

### Agent Best Practices Applied
- Improved description for better "Tool SEO" (PROACTIVELY keyword for automatic invocation)
- Added context explaining WHY dynamic spec fetching matters
- Positive framing for delegation to other agents
- Clearer invocation triggers with specific directories (`pkg/transport/`, `pkg/mcp/`, `pkg/vmcp/`)
- More action-oriented workflow guidance
- XML tags for critical behavior section

## Test plan
- [ ] Verify agent file is valid markdown
- [ ] Test agent invocation in Claude Code for MCP-related questions

🤖 Generated with [Claude Code](https://claude.com/claude-code)