### PR TITLE
Modify API endpoints to only return last 1,000 lines of logs

### DIFF
--- a/cmd/thv/app/logs.go
+++ b/cmd/thv/app/logs.go
@@ -101,7 +101,8 @@ func logsCmdFunc(cmd *cobra.Command, args []string) error {
 			return getProxyLogs(workloadName)
 		}
 		// Use the shared manager method for non-follow proxy logs
-		logs, err := manager.GetProxyLogs(ctx, workloadName)
+		// CLI gets all logs (0 = unlimited)
+		logs, err := manager.GetProxyLogs(ctx, workloadName, 0)
 		if err != nil {
 			logger.Infof("Proxy logs not found for workload %s", workloadName)
 			return nil
@@ -110,7 +111,8 @@ func logsCmdFunc(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	logs, err := manager.GetLogs(ctx, workloadName, follow)
+	// CLI gets all logs (0 = unlimited)
+	logs, err := manager.GetLogs(ctx, workloadName, follow, 0)
 	if err != nil {
 		if errors.Is(err, rt.ErrWorkloadNotFound) {
 			logger.Infof("Workload %s not found", workloadName)

--- a/docs/server/docs.go
+++ b/docs/server/docs.go
@@ -3641,7 +3641,7 @@ const docTemplate = `{
         },
         "/api/v1beta/workloads/{name}/logs": {
             "get": {
-                "description": "Retrieve at most 100 lines of logs for a specific workload by name.",
+                "description": "Retrieve at most 1000 lines of logs for a specific workload by name.",
                 "parameters": [
                     {
                         "description": "Workload name",
@@ -3693,7 +3693,7 @@ const docTemplate = `{
         },
         "/api/v1beta/workloads/{name}/proxy-logs": {
             "get": {
-                "description": "Retrieve proxy logs for a specific workload by name from the file system.",
+                "description": "Retrieve at most 1000 lines of proxy logs for a specific workload by name from the file system.",
                 "parameters": [
                     {
                         "description": "Workload name",

--- a/docs/server/swagger.json
+++ b/docs/server/swagger.json
@@ -3634,7 +3634,7 @@
         },
         "/api/v1beta/workloads/{name}/logs": {
             "get": {
-                "description": "Retrieve at most 100 lines of logs for a specific workload by name.",
+                "description": "Retrieve at most 1000 lines of logs for a specific workload by name.",
                 "parameters": [
                     {
                         "description": "Workload name",
@@ -3686,7 +3686,7 @@
         },
         "/api/v1beta/workloads/{name}/proxy-logs": {
             "get": {
-                "description": "Retrieve proxy logs for a specific workload by name from the file system.",
+                "description": "Retrieve at most 1000 lines of proxy logs for a specific workload by name from the file system.",
                 "parameters": [
                     {
                         "description": "Workload name",

--- a/docs/server/swagger.yaml
+++ b/docs/server/swagger.yaml
@@ -2562,7 +2562,8 @@ paths:
       - workloads
   /api/v1beta/workloads/{name}/logs:
     get:
-      description: Retrieve at most 100 lines of logs for a specific workload by name.
+      description: Retrieve at most 1000 lines of logs for a specific workload by
+        name.
       parameters:
       - description: Workload name
         in: path
@@ -2594,8 +2595,8 @@ paths:
       - logs
   /api/v1beta/workloads/{name}/proxy-logs:
     get:
-      description: Retrieve proxy logs for a specific workload by name from the file
-        system.
+      description: Retrieve at most 1000 lines of proxy logs for a specific workload
+        by name from the file system.
       parameters:
       - description: Workload name
         in: path

--- a/pkg/api/v1/workloads.go
+++ b/pkg/api/v1/workloads.go
@@ -18,6 +18,11 @@ import (
 	wt "github.com/stacklok/toolhive/pkg/workloads/types"
 )
 
+const (
+	// maxAPILogLines is the maximum number of log lines returned by API endpoints
+	maxAPILogLines = 1000
+)
+
 // WorkloadRoutes defines the routes for workload management.
 type WorkloadRoutes struct {
 	workloadManager  workloads.Manager
@@ -456,7 +461,7 @@ func (s *WorkloadRoutes) deleteWorkloadsBulk(w http.ResponseWriter, r *http.Requ
 // getLogsForWorkload
 //
 // @Summary      Get logs for a specific workload
-// @Description  Retrieve at most 100 lines of logs for a specific workload by name.
+// @Description  Retrieve at most 1000 lines of logs for a specific workload by name.
 // @Tags         logs
 // @Produce      text/plain
 // @Param        name  path      string  true  "Workload name"
@@ -473,10 +478,11 @@ func (s *WorkloadRoutes) getLogsForWorkload(w http.ResponseWriter, r *http.Reque
 		return err // ErrInvalidWorkloadName already has 400 status code
 	}
 
-	logs, err := s.workloadManager.GetLogs(ctx, name, false)
+	logs, err := s.workloadManager.GetLogs(ctx, name, false, maxAPILogLines)
 	if err != nil {
 		return err // ErrWorkloadNotFound (404) already has status code
 	}
+
 	w.Header().Set("Content-Type", "text/plain")
 	if _, err = w.Write([]byte(logs)); err != nil {
 		return fmt.Errorf("failed to write logs response: %w", err)
@@ -487,7 +493,7 @@ func (s *WorkloadRoutes) getLogsForWorkload(w http.ResponseWriter, r *http.Reque
 // getProxyLogsForWorkload
 //
 // @Summary      Get proxy logs for a specific workload
-// @Description  Retrieve proxy logs for a specific workload by name from the file system.
+// @Description  Retrieve at most 1000 lines of proxy logs for a specific workload by name from the file system.
 // @Tags         logs
 // @Produce      text/plain
 // @Param        name  path      string  true  "Workload name"
@@ -504,7 +510,7 @@ func (s *WorkloadRoutes) getProxyLogsForWorkload(w http.ResponseWriter, r *http.
 		return err // ErrInvalidWorkloadName already has 400 status code
 	}
 
-	logs, err := s.workloadManager.GetProxyLogs(ctx, name)
+	logs, err := s.workloadManager.GetProxyLogs(ctx, name, maxAPILogLines)
 	if err != nil {
 		return thverrors.WithCode(
 			fmt.Errorf("proxy logs not found for workload: %w", err),

--- a/pkg/container/docker/monitor.go
+++ b/pkg/container/docker/monitor.go
@@ -125,7 +125,8 @@ func (m *ContainerMonitor) monitor(ctx context.Context) {
 				// Container has exited, get logs and info
 				// Create a short timeout context for these operations, derived from parent
 				infoCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-				logs, _ := m.runtime.GetWorkloadLogs(infoCtx, m.containerName, false)
+				// Get last 50 lines of logs for error reporting
+				logs, _ := m.runtime.GetWorkloadLogs(infoCtx, m.containerName, false, 50)
 				info, _ := m.runtime.GetWorkloadInfo(infoCtx, m.containerName)
 				cancel() // Always cancel the context to avoid leaks
 

--- a/pkg/container/runtime/mocks/mock_runtime.go
+++ b/pkg/container/runtime/mocks/mock_runtime.go
@@ -174,18 +174,18 @@ func (mr *MockRuntimeMockRecorder) GetWorkloadInfo(ctx, workloadName any) *gomoc
 }
 
 // GetWorkloadLogs mocks base method.
-func (m *MockRuntime) GetWorkloadLogs(ctx context.Context, workloadName string, follow bool) (string, error) {
+func (m *MockRuntime) GetWorkloadLogs(ctx context.Context, workloadName string, follow bool, lines int) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetWorkloadLogs", ctx, workloadName, follow)
+	ret := m.ctrl.Call(m, "GetWorkloadLogs", ctx, workloadName, follow, lines)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetWorkloadLogs indicates an expected call of GetWorkloadLogs.
-func (mr *MockRuntimeMockRecorder) GetWorkloadLogs(ctx, workloadName, follow any) *gomock.Call {
+func (mr *MockRuntimeMockRecorder) GetWorkloadLogs(ctx, workloadName, follow, lines any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkloadLogs", reflect.TypeOf((*MockRuntime)(nil).GetWorkloadLogs), ctx, workloadName, follow)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkloadLogs", reflect.TypeOf((*MockRuntime)(nil).GetWorkloadLogs), ctx, workloadName, follow, lines)
 }
 
 // IsRunning mocks base method.

--- a/pkg/container/runtime/types.go
+++ b/pkg/container/runtime/types.go
@@ -160,9 +160,11 @@ type Runtime interface {
 
 	// GetWorkloadLogs retrieves logs from the primary container of the workload.
 	// If follow is true, the logs will be streamed continuously.
+	// The lines parameter specifies the maximum number of lines to return from the end of the logs.
+	// If lines is 0, all logs are returned.
 	// For workloads with multiple containers, this returns logs from the
 	// main MCP server container.
-	GetWorkloadLogs(ctx context.Context, workloadName string, follow bool) (string, error)
+	GetWorkloadLogs(ctx context.Context, workloadName string, follow bool, lines int) (string, error)
 
 	// GetWorkloadInfo retrieves detailed information about a workload.
 	// This includes status, resource usage, network configuration,

--- a/pkg/mcp/server/get_server_logs.go
+++ b/pkg/mcp/server/get_server_logs.go
@@ -21,8 +21,8 @@ func (h *Handler) GetServerLogs(ctx context.Context, request mcp.CallToolRequest
 		return mcp.NewToolResultError(fmt.Sprintf("Failed to parse arguments: %v", err)), nil
 	}
 
-	// Get logs
-	logs, err := h.workloadManager.GetLogs(ctx, args.Name, false)
+	// Get logs (0 = unlimited for MCP tools)
+	logs, err := h.workloadManager.GetLogs(ctx, args.Name, false, 0)
 	if err != nil {
 		// Check if it's a not found error
 		if strings.Contains(err.Error(), "not found") {

--- a/pkg/mcp/server/handler_mock_test.go
+++ b/pkg/mcp/server/handler_mock_test.go
@@ -461,7 +461,7 @@ func TestHandler_GetServerLogs_WithMocks(t *testing.T) {
 			logs:       "2024-01-01 12:00:00 Server started\n2024-01-01 12:00:01 Listening on port 8080",
 			setupMocks: func(m *workloadsmocks.MockManager) {
 				m.EXPECT().
-					GetLogs(gomock.Any(), "test-server", false).
+					GetLogs(gomock.Any(), "test-server", false, 0).
 					Return("2024-01-01 12:00:00 Server started\n2024-01-01 12:00:01 Listening on port 8080", nil)
 			},
 			wantErr: false,
@@ -478,7 +478,7 @@ func TestHandler_GetServerLogs_WithMocks(t *testing.T) {
 			serverName: "nonexistent",
 			setupMocks: func(m *workloadsmocks.MockManager) {
 				m.EXPECT().
-					GetLogs(gomock.Any(), "nonexistent", false).
+					GetLogs(gomock.Any(), "nonexistent", false, 0).
 					Return("", assert.AnError)
 			},
 			wantErr: false,

--- a/pkg/workloads/manager_test.go
+++ b/pkg/workloads/manager_test.go
@@ -347,7 +347,7 @@ func TestDefaultManager_GetLogs(t *testing.T) {
 			workloadName: "test-workload",
 			follow:       false,
 			setupMocks: func(rt *runtimeMocks.MockRuntime) {
-				rt.EXPECT().GetWorkloadLogs(gomock.Any(), "test-workload", false).Return("test log content", nil)
+				rt.EXPECT().GetWorkloadLogs(gomock.Any(), "test-workload", false, 0).Return("test log content", nil)
 			},
 			expectedLogs: "test log content",
 			expectError:  false,
@@ -357,7 +357,7 @@ func TestDefaultManager_GetLogs(t *testing.T) {
 			workloadName: "missing-workload",
 			follow:       false,
 			setupMocks: func(rt *runtimeMocks.MockRuntime) {
-				rt.EXPECT().GetWorkloadLogs(gomock.Any(), "missing-workload", false).Return("", runtime.ErrWorkloadNotFound)
+				rt.EXPECT().GetWorkloadLogs(gomock.Any(), "missing-workload", false, 0).Return("", runtime.ErrWorkloadNotFound)
 			},
 			expectedLogs: "",
 			expectError:  true,
@@ -368,7 +368,7 @@ func TestDefaultManager_GetLogs(t *testing.T) {
 			workloadName: "error-workload",
 			follow:       true,
 			setupMocks: func(rt *runtimeMocks.MockRuntime) {
-				rt.EXPECT().GetWorkloadLogs(gomock.Any(), "error-workload", true).Return("", errors.New("runtime failure"))
+				rt.EXPECT().GetWorkloadLogs(gomock.Any(), "error-workload", true, 0).Return("", errors.New("runtime failure"))
 			},
 			expectedLogs: "",
 			expectError:  true,
@@ -391,7 +391,8 @@ func TestDefaultManager_GetLogs(t *testing.T) {
 			}
 
 			ctx := context.Background()
-			logs, err := manager.GetLogs(ctx, tt.workloadName, tt.follow)
+			// Pass 0 for unlimited logs in these tests
+			logs, err := manager.GetLogs(ctx, tt.workloadName, tt.follow, 0)
 
 			if tt.expectError {
 				require.Error(t, err)
@@ -402,6 +403,82 @@ func TestDefaultManager_GetLogs(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDefaultManager_GetLogs_WithLineLimit(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		workloadName string
+		lines        int
+		expectedLogs string
+	}{
+		{
+			name:         "limit to 3 lines",
+			workloadName: "test-workload",
+			lines:        3,
+			expectedLogs: "line3\nline4\nline5",
+		},
+		{
+			name:         "no limit (0)",
+			workloadName: "test-workload",
+			lines:        0,
+			expectedLogs: "line1\nline2\nline3",
+		},
+		{
+			name:         "fewer lines than limit",
+			workloadName: "test-workload",
+			lines:        10,
+			expectedLogs: "line1\nline2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockRuntime := runtimeMocks.NewMockRuntime(ctrl)
+			// Mock expects the lines parameter and returns already-limited logs
+			mockRuntime.EXPECT().GetWorkloadLogs(gomock.Any(), tt.workloadName, false, tt.lines).Return(tt.expectedLogs, nil)
+
+			manager := &DefaultManager{
+				runtime: mockRuntime,
+			}
+
+			ctx := context.Background()
+			logs, err := manager.GetLogs(ctx, tt.workloadName, false, tt.lines)
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedLogs, logs)
+		})
+	}
+}
+
+func TestDefaultManager_GetLogs_FollowWithLimitError(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockRuntime := runtimeMocks.NewMockRuntime(ctrl)
+	// Expect the runtime to return an error when both follow and lines are set
+	mockRuntime.EXPECT().GetWorkloadLogs(gomock.Any(), "test-workload", true, 100).
+		Return("", errors.New("cannot use both follow and line limit"))
+
+	manager := &DefaultManager{
+		runtime: mockRuntime,
+	}
+
+	ctx := context.Background()
+	logs, err := manager.GetLogs(ctx, "test-workload", true, 100)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot use both follow and line limit")
+	assert.Empty(t, logs)
 }
 
 func TestDefaultManager_StopWorkloads(t *testing.T) {

--- a/pkg/workloads/mocks/mock_manager.go
+++ b/pkg/workloads/mocks/mock_manager.go
@@ -74,33 +74,33 @@ func (mr *MockManagerMockRecorder) DoesWorkloadExist(ctx, workloadName any) *gom
 }
 
 // GetLogs mocks base method.
-func (m *MockManager) GetLogs(ctx context.Context, containerName string, follow bool) (string, error) {
+func (m *MockManager) GetLogs(ctx context.Context, containerName string, follow bool, lines int) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetLogs", ctx, containerName, follow)
+	ret := m.ctrl.Call(m, "GetLogs", ctx, containerName, follow, lines)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetLogs indicates an expected call of GetLogs.
-func (mr *MockManagerMockRecorder) GetLogs(ctx, containerName, follow any) *gomock.Call {
+func (mr *MockManagerMockRecorder) GetLogs(ctx, containerName, follow, lines any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLogs", reflect.TypeOf((*MockManager)(nil).GetLogs), ctx, containerName, follow)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLogs", reflect.TypeOf((*MockManager)(nil).GetLogs), ctx, containerName, follow, lines)
 }
 
 // GetProxyLogs mocks base method.
-func (m *MockManager) GetProxyLogs(ctx context.Context, workloadName string) (string, error) {
+func (m *MockManager) GetProxyLogs(ctx context.Context, workloadName string, lines int) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetProxyLogs", ctx, workloadName)
+	ret := m.ctrl.Call(m, "GetProxyLogs", ctx, workloadName, lines)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetProxyLogs indicates an expected call of GetProxyLogs.
-func (mr *MockManagerMockRecorder) GetProxyLogs(ctx, workloadName any) *gomock.Call {
+func (mr *MockManagerMockRecorder) GetProxyLogs(ctx, workloadName, lines any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProxyLogs", reflect.TypeOf((*MockManager)(nil).GetProxyLogs), ctx, workloadName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProxyLogs", reflect.TypeOf((*MockManager)(nil).GetProxyLogs), ctx, workloadName, lines)
 }
 
 // GetWorkload mocks base method.


### PR DESCRIPTION
This is intended to prevent the server and client from getting overloaded by an excessively-large log file.

Fixes: #2213 