### PR TITLE
Fix Goose client support

### DIFF
--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -395,8 +395,9 @@ var supportedClientIntegrations = []mcpClientConfig{
 		// YAML configuration
 		YAMLStorageType: YAMLStorageTypeMap,
 		YAMLDefaults: map[string]interface{}{
-			"enabled": true,
-			"timeout": 60,
+			"enabled":     true,
+			"timeout":     60,
+			"description": "",
 		},
 	},
 	{

--- a/pkg/client/config_editor_test.go
+++ b/pkg/client/config_editor_test.go
@@ -362,6 +362,7 @@ extensions:
     type: mcp
     uri: existing-url
     timeout: 60
+    description: ""
 `
 
 		if err := os.WriteFile(configPath, []byte(initialConfig), 0600); err != nil {
@@ -570,11 +571,12 @@ func setupExistingTestYAMLConfig(t *testing.T, testName string) (string, string)
 	testConfig := map[string]interface{}{
 		"extensions": map[string]interface{}{
 			"existingServer": map[string]interface{}{
-				"name":    "existingServer",
-				"enabled": true,
-				"type":    "existing-type",
-				"timeout": 60,
-				"uri":     fmt.Sprintf("existing-url-%s", testName),
+				"name":        "existingServer",
+				"enabled":     true,
+				"type":        "existing-type",
+				"timeout":     60,
+				"description": "",
+				"uri":         fmt.Sprintf("existing-url-%s", testName),
 			},
 		},
 	}

--- a/pkg/client/converter_test.go
+++ b/pkg/client/converter_test.go
@@ -19,8 +19,9 @@ func createGooseConfig() *mcpClientConfig {
 		MCPServersUrlLabel:   "uri",
 		YAMLStorageType:      YAMLStorageTypeMap,
 		YAMLDefaults: map[string]interface{}{
-			"enabled": true,
-			"timeout": 60,
+			"enabled":     true,
+			"timeout":     60,
+			"description": "",
 		},
 	}
 }
@@ -54,11 +55,12 @@ func TestGenericYAMLConverter_ConvertFromMCPServer_Goose(t *testing.T) {
 				Url:  "http://example.com",
 			},
 			expected: map[string]interface{}{
-				"name":    "test-server",
-				"enabled": true,
-				"type":    "mcp",
-				"timeout": 60,
-				"uri":     "http://example.com",
+				"name":        "test-server",
+				"enabled":     true,
+				"type":        "mcp",
+				"timeout":     60,
+				"description": "",
+				"uri":         "http://example.com",
 			},
 		},
 		{
@@ -69,11 +71,12 @@ func TestGenericYAMLConverter_ConvertFromMCPServer_Goose(t *testing.T) {
 				ServerUrl: "https://api.example.com",
 			},
 			expected: map[string]interface{}{
-				"name":    "another-server",
-				"enabled": true,
-				"type":    "custom",
-				"timeout": 60,
-				"uri":     "https://api.example.com",
+				"name":        "another-server",
+				"enabled":     true,
+				"type":        "custom",
+				"timeout":     60,
+				"description": "",
+				"uri":         "https://api.example.com",
 			},
 		},
 	}
@@ -196,11 +199,12 @@ func TestGenericYAMLConverter_UpsertEntry_MapStorage(t *testing.T) {
 		}
 
 		entry := map[string]interface{}{
-			"name":    "new-server",
-			"enabled": true,
-			"type":    "mcp",
-			"timeout": 60,
-			"uri":     "https://new.example.com",
+			"name":        "new-server",
+			"enabled":     true,
+			"type":        "mcp",
+			"timeout":     60,
+			"description": "",
+			"uri":         "https://new.example.com",
 		}
 
 		err := converter.UpsertEntry(config, "new-server", entry)


### PR DESCRIPTION
## Summary

Fix Goose integration by adding required description field to MCP server config. Goose was not displaying MCP servers added by ToolHive because the description field is now required in Goose's configuration schema, even when empty.

## Changes

- Add empty `description` field to Goose YAML defaults
- Update tests to include description field

## Testing

- [x] Unit tests pass
- [x] Goose displays MCP servers added via ToolHive

Signed-off-by: Dan Barr <6922515+danbarr@users.noreply.github.com>