### PR TITLE
Simplify redirect URI validation in autheserver upstream package to use fosite

### DIFF
--- a/pkg/authserver/upstream/oauth2_test.go
+++ b/pkg/authserver/upstream/oauth2_test.go
@@ -987,99 +987,29 @@ func Test_validateRedirectURI(t *testing.T) {
 		wantErr     bool
 		errContains string
 	}{
-		// Valid URIs
-		{
-			name:    "valid HTTPS URI with path",
-			uri:     "https://auth.example.com/oauth/callback",
-			wantErr: false,
-		},
-		{
-			name:    "valid HTTPS URI with port",
-			uri:     "https://auth.example.com:8443/oauth/callback",
-			wantErr: false,
-		},
-		{
-			name:    "valid HTTP URI with loopback IPv4",
-			uri:     "http://127.0.0.1:8080/oauth/callback",
-			wantErr: false,
-		},
-		{
-			name:    "valid HTTP URI with loopback IPv6",
-			uri:     "http://[::1]:8080/oauth/callback",
-			wantErr: false,
-		},
-		{
-			name:    "valid HTTP URI with localhost",
-			uri:     "http://localhost:8080/oauth/callback",
-			wantErr: false,
-		},
-		{
-			name:    "valid HTTPS URI without path",
-			uri:     "https://example.com",
-			wantErr: false,
-		},
+		// Valid HTTPS URIs
+		{"HTTPS with path", "https://auth.example.com/oauth/callback", false, ""},
+		{"HTTPS with port", "https://auth.example.com:8443/oauth/callback", false, ""},
+		{"HTTPS without path", "https://example.com", false, ""},
 
-		// Invalid URIs
-		{
-			name:        "HTTP to non-loopback address",
-			uri:         "http://example.com/callback",
-			wantErr:     true,
-			errContains: "redirect_uri with http scheme requires loopback address (127.0.0.1, ::1, or localhost)",
-		},
-		{
-			name:        "URI contains fragment",
-			uri:         "https://example.com/callback#section",
-			wantErr:     true,
-			errContains: "redirect_uri must not contain a fragment (#)",
-		},
-		{
-			name:        "URI contains userinfo",
-			uri:         "https://user:pass@example.com/callback",
-			wantErr:     true,
-			errContains: "redirect_uri must not contain user credentials",
-		},
-		{
-			name:        "invalid scheme (ftp)",
-			uri:         "ftp://example.com/callback",
-			wantErr:     true,
-			errContains: "redirect_uri must use http or https scheme",
-		},
-		{
-			name:        "relative URI",
-			uri:         "/oauth/callback",
-			wantErr:     true,
-			errContains: "redirect_uri must be an absolute URL with scheme and host",
-		},
-		{
-			name:        "wildcard hostname",
-			uri:         "https://*/callback",
-			wantErr:     true,
-			errContains: "redirect_uri must not contain wildcard hostname",
-		},
-		{
-			name:        "empty URI",
-			uri:         "",
-			wantErr:     true,
-			errContains: "redirect_uri must be an absolute URL with scheme and host",
-		},
-		{
-			name:        "scheme only",
-			uri:         "https://",
-			wantErr:     true,
-			errContains: "redirect_uri must be an absolute URL with scheme and host",
-		},
-		{
-			name:        "wildcard subdomain",
-			uri:         "https://*.example.com/callback",
-			wantErr:     true,
-			errContains: "redirect_uri must not contain wildcard hostname",
-		},
-		{
-			name:        "malformed URL with invalid percent encoding",
-			uri:         "https://example.com/path%ZZ",
-			wantErr:     true,
-			errContains: "redirect_uri must be an absolute URL with scheme and host",
-		},
+		// Valid HTTP loopback URIs
+		{"HTTP localhost", "http://localhost/callback", false, ""},
+		{"HTTP localhost with port", "http://localhost:8080/callback", false, ""},
+		{"HTTP 127.0.0.1", "http://127.0.0.1/callback", false, ""},
+		{"HTTP 127.0.0.1 with port", "http://127.0.0.1:8080/callback", false, ""},
+		{"HTTP IPv6 ::1", "http://[::1]/callback", false, ""},
+		{"HTTP IPv6 ::1 with port", "http://[::1]:8080/callback", false, ""},
+
+		// Invalid: HTTP to non-loopback
+		{"HTTP non-loopback hostname", "http://example.com/callback", true, "redirect_uri must use http (for loopback) or https scheme"},
+		{"HTTP non-loopback hostname with port", "http://example.com:8080/callback", true, "redirect_uri must use http (for loopback) or https scheme"},
+		{"HTTP non-loopback IP", "http://192.168.1.1/callback", true, "redirect_uri must use http (for loopback) or https scheme"},
+
+		// Invalid: fragment, scheme, relative, empty
+		{"URI with fragment", "https://example.com/callback#section", true, "redirect_uri must be an absolute URI without a fragment"},
+		{"FTP scheme", "ftp://example.com/callback", true, "redirect_uri must use http (for loopback) or https scheme"},
+		{"relative URI", "/oauth/callback", true, "redirect_uri must be an absolute URI without a fragment"},
+		{"empty URI", "", true, "redirect_uri must be an absolute URI without a fragment"},
 	}
 
 	for _, tt := range tests {
@@ -1090,83 +1020,6 @@ func Test_validateRedirectURI(t *testing.T) {
 			if tt.wantErr {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.errContains)
-			} else {
-				require.NoError(t, err)
-			}
-		})
-	}
-}
-
-func Test_validateRedirectURI_LoopbackAddresses(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name    string
-		uri     string
-		wantErr bool
-	}{
-		// Loopback addresses with HTTP should be allowed
-		{
-			name:    "HTTP with localhost",
-			uri:     "http://localhost/callback",
-			wantErr: false,
-		},
-		{
-			name:    "HTTP with localhost and port",
-			uri:     "http://localhost:8080/callback",
-			wantErr: false,
-		},
-		{
-			name:    "HTTP with 127.0.0.1",
-			uri:     "http://127.0.0.1/callback",
-			wantErr: false,
-		},
-		{
-			name:    "HTTP with 127.0.0.1 and port",
-			uri:     "http://127.0.0.1:8080/callback",
-			wantErr: false,
-		},
-		{
-			name:    "HTTP with IPv6 ::1",
-			uri:     "http://[::1]/callback",
-			wantErr: false,
-		},
-		{
-			name:    "HTTP with IPv6 ::1 and port",
-			uri:     "http://[::1]:8080/callback",
-			wantErr: false,
-		},
-		// Non-loopback addresses with HTTP should be rejected
-		{
-			name:    "HTTP with non-loopback hostname",
-			uri:     "http://example.com/callback",
-			wantErr: true,
-		},
-		{
-			name:    "HTTP with non-loopback hostname and port",
-			uri:     "http://example.com:8080/callback",
-			wantErr: true,
-		},
-		{
-			name:    "HTTP with non-loopback IP",
-			uri:     "http://192.168.1.1/callback",
-			wantErr: true,
-		},
-		{
-			name:    "HTTP with non-loopback IP and port",
-			uri:     "http://192.168.1.1:8080/callback",
-			wantErr: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			err := validateRedirectURI(tt.uri)
-			if tt.wantErr {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), "redirect_uri with http scheme requires loopback address")
 			} else {
 				require.NoError(t, err)
 			}


### PR DESCRIPTION
As I'm going through the motions of plugging in the upstream proxy providers into the authproxy "frontend", I'm noticing things in the upstream code that could be simplified. This is one of them.

Replace hand-rolled redirect URI validation with fosite functions. This is our own callback URL where upstream IDPs redirect back to us - the upstream IDP validates it against their registered URIs anyway.

This aligns with the DCR package which already uses fosite for the same purpose.