### PR TITLE
Call audit config validation in vMCP server

### DIFF
--- a/pkg/vmcp/server/server.go
+++ b/pkg/vmcp/server/server.go
@@ -266,6 +266,9 @@ func New(
 	// Create workflow auditor if audit config is provided
 	var workflowAuditor *audit.WorkflowAuditor
 	if cfg.AuditConfig != nil {
+		if err := cfg.AuditConfig.Validate(); err != nil {
+			return nil, fmt.Errorf("invalid audit configuration: %w", err)
+		}
 		var err error
 		workflowAuditor, err = audit.NewWorkflowAuditor(cfg.AuditConfig)
 		if err != nil {
@@ -501,6 +504,9 @@ func (s *Server) Start(ctx context.Context) error {
 
 	// Apply audit middleware if configured (runs after auth, before discovery)
 	if s.config.AuditConfig != nil {
+		if err := s.config.AuditConfig.Validate(); err != nil {
+			return fmt.Errorf("invalid audit configuration: %w", err)
+		}
 		auditor, err := audit.NewAuditorWithTransport(
 			s.config.AuditConfig,
 			"streamable-http", // vMCP uses streamable HTTP transport


### PR DESCRIPTION
The audit.Config.Validate() method existed and was tested, but was never called in production code for the vMCP server. This allowed invalid audit configurations (negative MaxDataSize, typos in event types) to be silently accepted, potentially causing users to believe auditing was working when it was misconfigured.

Closes: #2985