### PR TITLE
Add contributor guidelines for issue claiming and expectations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,7 @@ in the description so we know you're planning to submit a PR.
 
 Reviews of external contributions are on a best effort basis. ToolHive moves
 fast, so priorities can shift. We may occasionally
-need to pick up urgent issues ourselves, but we'll always try to coordinate
+need to pick up urgent issues ourselves, but we'll always coordinate
 with active contributors first.
 
 ### Pull request process


### PR DESCRIPTION
## Summary

- Add "Claiming an issue" section explaining contributors should comment and wait for assignment before starting work
- Add "What to expect" section setting expectations that reviews are on a best effort basis

These additions help set clear expectations for external contributors and reduce the chance of duplicate work.

## Test plan

- [ ] Review the new sections in CONTRIBUTING.md for clarity
- [ ] Verify table of contents links work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)