### PR TITLE
Add UserInfo fetching support to authserver's upstream OAuth2 provider

### DIFF
--- a/pkg/authserver/upstream/oauth2.go
+++ b/pkg/authserver/upstream/oauth2.go
@@ -16,8 +16,10 @@ package upstream
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"maps"
 	"net/http"
 	"net/url"
@@ -34,6 +36,10 @@ import (
 const (
 	// ProviderTypeOAuth2 is for pure OAuth 2.0 providers with explicit endpoints.
 	ProviderTypeOAuth2 ProviderType = "oauth2"
+
+	// maxResponseSize is the maximum allowed UserInfo response size (1MB).
+	// This prevents memory exhaustion from malicious or malformed responses.
+	maxResponseSize = 1 << 20
 )
 
 // AuthorizationOption configures authorization URL generation.
@@ -70,6 +76,15 @@ type OAuth2Provider interface {
 
 	// RefreshTokens refreshes the upstream IDP tokens.
 	RefreshTokens(ctx context.Context, refreshToken string) (*Tokens, error)
+
+	// ResolveIdentity validates tokens and returns the canonical subject.
+	// For OIDC providers with ID tokens, it validates the token and nonce.
+	// For OAuth2 providers or as fallback, it fetches UserInfo.
+	ResolveIdentity(ctx context.Context, tokens *Tokens, nonce string) (subject string, err error)
+
+	// FetchUserInfo retrieves user information using the provided access token.
+	// Returns an error if the provider is not configured for UserInfo fetching.
+	FetchUserInfo(ctx context.Context, accessToken string) (*UserInfo, error)
 }
 
 // defaultTokenExpiration is the default token lifetime when expires_in is not specified.
@@ -133,6 +148,11 @@ func (c *OAuth2Config) Validate() error {
 	}
 	if err := networking.ValidateEndpointURL(c.TokenEndpoint); err != nil {
 		return fmt.Errorf("invalid token_endpoint: %w", err)
+	}
+	if c.UserInfo != nil {
+		if err := c.UserInfo.Validate(); err != nil {
+			return fmt.Errorf("invalid userinfo config: %w", err)
+		}
 	}
 	return c.CommonOAuthConfig.Validate()
 }
@@ -422,6 +442,111 @@ func (p *BaseOAuth2Provider) RefreshTokens(ctx context.Context, refreshToken str
 	)
 
 	return tokens, nil
+}
+
+// FetchUserInfo fetches user information from the configured UserInfo endpoint.
+// Returns an error if no UserInfo endpoint is configured.
+// The field mapping from UserInfoConfig.FieldMapping is used to extract claims
+// from non-standard provider responses.
+func (p *BaseOAuth2Provider) FetchUserInfo(ctx context.Context, accessToken string) (*UserInfo, error) {
+	if p.config.UserInfo == nil {
+		return nil, errors.New("userinfo endpoint not configured")
+	}
+
+	cfg := p.config.UserInfo
+
+	if accessToken == "" {
+		return nil, errors.New("access token is required")
+	}
+
+	logger.Debugw("fetching user info",
+		"userinfo_endpoint", cfg.EndpointURL,
+	)
+
+	// Determine HTTP method (default GET per OIDC Core Section 5.3.1)
+	method := cfg.HTTPMethod
+	if method == "" {
+		method = http.MethodGet
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, cfg.EndpointURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	// Set authorization header per RFC 6750 (Bearer Token Usage)
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	req.Header.Set("Accept", "application/json")
+
+	// Add any additional headers (useful for non-standard providers like GitHub)
+	for k, v := range cfg.AdditionalHeaders {
+		req.Header.Set(k, v)
+	}
+
+	resp, err := p.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("userinfo request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		// Drain response body for connection reuse, but don't log it to avoid
+		// potentially exposing sensitive information from the upstream provider.
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1024))
+		logger.Debugw("userinfo request failed",
+			"status", resp.StatusCode)
+		return nil, fmt.Errorf("userinfo request failed with status %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseSize))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read userinfo response: %w", err)
+	}
+
+	var claims map[string]any
+	if err := json.Unmarshal(body, &claims); err != nil {
+		return nil, fmt.Errorf("failed to parse userinfo response: %w", err)
+	}
+
+	// Use configured field mapping for subject extraction
+	mapping := cfg.FieldMapping
+
+	// Extract and validate required subject claim
+	sub, err := mapping.ResolveSubject(claims)
+	if err != nil {
+		return nil, fmt.Errorf("userinfo response missing required subject claim: %w", err)
+	}
+
+	userInfo := &UserInfo{
+		Subject: sub,
+		Claims:  claims,
+	}
+
+	logger.Debugw("user info retrieved",
+		"subject", userInfo.Subject,
+	)
+
+	return userInfo, nil
+}
+
+// ResolveIdentity resolves the user's identity by fetching UserInfo.
+// For pure OAuth2 providers, this fetches user information from the configured endpoint.
+// OIDC-specific validation (ID token nonce, subject matching) will be added when
+// OIDCProvider is implemented.
+func (p *BaseOAuth2Provider) ResolveIdentity(ctx context.Context, tokens *Tokens, _ string) (string, error) {
+	if tokens == nil {
+		return "", ErrIdentityResolutionFailed
+	}
+
+	userInfo, err := p.FetchUserInfo(ctx, tokens.AccessToken)
+	if err != nil {
+		return "", fmt.Errorf("%w: %w", ErrIdentityResolutionFailed, err)
+	}
+	if userInfo == nil || userInfo.Subject == "" {
+		return "", ErrIdentityResolutionFailed
+	}
+
+	return userInfo.Subject, nil
 }
 
 // formatOAuth2Error extracts error details from oauth2.RetrieveError for better error messages.

--- a/pkg/authserver/upstream/types.go
+++ b/pkg/authserver/upstream/types.go
@@ -15,8 +15,7 @@
 package upstream
 
 import (
-	"context"
-	"fmt"
+	"errors"
 )
 
 // ProviderType identifies the type of upstream Identity Provider.
@@ -58,37 +57,5 @@ type OIDCEndpoints struct {
 	CodeChallengeMethodsSupported []string `json:"code_challenge_methods_supported,omitempty"`
 }
 
-// IDTokenNonceValidator is implemented by providers that support OIDC nonce validation.
-// This is used to validate the nonce claim in ID tokens to prevent replay attacks.
-type IDTokenNonceValidator interface {
-	// ValidateIDTokenWithNonce validates an ID token with nonce verification.
-	// Returns the parsed claims if validation succeeds, or an error if validation fails.
-	ValidateIDTokenWithNonce(idToken, expectedNonce string) (*IDTokenClaims, error)
-}
-
-// UserInfoSubjectValidator is implemented by providers that support UserInfo subject validation
-// per OIDC Core Section 5.3.4. This validation ensures the UserInfo response's subject matches
-// the ID Token's subject to prevent user impersonation attacks.
-type UserInfoSubjectValidator interface {
-	// UserInfoWithSubjectValidation fetches user info and validates the subject matches expected.
-	// Returns ErrUserInfoSubjectMismatch if the subjects do not match.
-	UserInfoWithSubjectValidation(ctx context.Context, accessToken, expectedSubject string) (*UserInfo, error)
-}
-
-// ErrUserInfoSubjectMismatch is returned when the UserInfo endpoint returns a subject
-// that does not match the expected subject from the ID Token.
-// This validation is required per OIDC Core Section 5.3.4 to prevent user impersonation.
-var ErrUserInfoSubjectMismatch = fmt.Errorf("userinfo subject does not match expected subject")
-
-// UserInfoFetcher is implemented by providers that support fetching user information.
-// This interface enables extensible UserInfo retrieval from various endpoint types,
-// including standard OIDC UserInfo endpoints and custom provider-specific APIs.
-//
-// Implementations may use different authentication methods, field mappings, and
-// response formats as configured via UserInfoConfig.
-type UserInfoFetcher interface {
-	// FetchUserInfo retrieves user information using the provided access token.
-	// Returns the parsed UserInfo on success, or an error if the request fails
-	// or the response cannot be parsed.
-	FetchUserInfo(ctx context.Context, accessToken string) (*UserInfo, error)
-}
+// ErrIdentityResolutionFailed indicates identity could not be determined.
+var ErrIdentityResolutionFailed = errors.New("failed to resolve user identity")

--- a/pkg/authserver/upstream/userinfo_config.go
+++ b/pkg/authserver/upstream/userinfo_config.go
@@ -16,22 +16,60 @@ package upstream
 
 import (
 	"errors"
+	"fmt"
+	"net/http"
 	"net/url"
+	"strconv"
 
 	"github.com/stacklok/toolhive/pkg/networking"
 )
 
 // UserInfoFieldMapping maps provider-specific field names to standard UserInfo fields.
 // This allows adapting non-standard provider responses to the canonical UserInfo structure.
+//
+// Example for GitHub:
+//
+//	mapping := &UserInfoFieldMapping{
+//	    SubjectField: "id",
+//	}
 type UserInfoFieldMapping struct {
-	// SubjectField is the field name for the user ID (default: "sub").
+	// SubjectField is the field name for the user ID (e.g., "sub" for OIDC, "id" for GitHub).
+	// Default: "sub"
 	SubjectField string
+}
 
-	// NameField is the field name for the display name (default: "name").
-	NameField string
+// DefaultSubjectField is the default field name for subject resolution.
+const DefaultSubjectField = "sub"
 
-	// EmailField is the field name for the email address (default: "email").
-	EmailField string
+// GetSubjectField returns the configured subject field or the default.
+func (m *UserInfoFieldMapping) GetSubjectField() string {
+	if m != nil && m.SubjectField != "" {
+		return m.SubjectField
+	}
+	return DefaultSubjectField
+}
+
+// ResolveSubject extracts the subject (user ID) from claims using the configured mapping.
+// Returns an error if no subject can be resolved (subject is required).
+func (m *UserInfoFieldMapping) ResolveSubject(claims map[string]any) (string, error) {
+	field := m.GetSubjectField()
+	val, ok := claims[field]
+	if !ok {
+		return "", fmt.Errorf("subject claim not found (tried field: %q)", field)
+	}
+
+	switch v := val.(type) {
+	case string:
+		if v == "" {
+			return "", fmt.Errorf("subject claim %q is empty", field)
+		}
+		return v, nil
+	case float64:
+		// JSON numbers are always float64; format as integer for user IDs
+		return strconv.FormatFloat(v, 'f', 0, 64), nil
+	default:
+		return "", fmt.Errorf("subject claim %q has unsupported type %T", field, val)
+	}
 }
 
 // UserInfoConfig contains configuration for fetching user information from an upstream provider.
@@ -74,6 +112,11 @@ func (c *UserInfoConfig) Validate() error {
 	// HTTP scheme is only allowed for loopback addresses (consistent with validateRedirectURI)
 	if parsed.Scheme == networking.HttpScheme && !networking.IsLocalhost(parsed.Host) {
 		return errors.New("endpoint_url with http scheme requires loopback address (127.0.0.1, ::1, or localhost)")
+	}
+
+	// Validate HTTP method if specified (OIDC Core Section 5.3.1 allows GET and POST)
+	if c.HTTPMethod != "" && c.HTTPMethod != http.MethodGet && c.HTTPMethod != http.MethodPost {
+		return errors.New("http_method must be GET or POST")
 	}
 
 	return nil

--- a/pkg/authserver/upstream/userinfo_config_test.go
+++ b/pkg/authserver/upstream/userinfo_config_test.go
@@ -45,8 +45,6 @@ func TestUserInfoConfig_Validate(t *testing.T) {
 				},
 				FieldMapping: &UserInfoFieldMapping{
 					SubjectField: "user_id",
-					NameField:    "display_name",
-					EmailField:   "email_address",
 				},
 			},
 			wantErr: "",
@@ -107,6 +105,40 @@ func TestUserInfoConfig_Validate(t *testing.T) {
 			},
 			wantErr: "",
 		},
+		{
+			name: "valid config with custom subject field",
+			config: &UserInfoConfig{
+				EndpointURL: "https://api.github.com/user",
+				FieldMapping: &UserInfoFieldMapping{
+					SubjectField: "id",
+				},
+			},
+			wantErr: "",
+		},
+		{
+			name: "valid config with GET method",
+			config: &UserInfoConfig{
+				EndpointURL: "https://example.com/userinfo",
+				HTTPMethod:  "GET",
+			},
+			wantErr: "",
+		},
+		{
+			name: "valid config with POST method",
+			config: &UserInfoConfig{
+				EndpointURL: "https://example.com/userinfo",
+				HTTPMethod:  "POST",
+			},
+			wantErr: "",
+		},
+		{
+			name: "invalid http_method",
+			config: &UserInfoConfig{
+				EndpointURL: "https://example.com/userinfo",
+				HTTPMethod:  "DELETE",
+			},
+			wantErr: "http_method must be GET or POST",
+		},
 	}
 
 	for _, tt := range tests {
@@ -119,6 +151,112 @@ func TestUserInfoConfig_Validate(t *testing.T) {
 			} else {
 				assert.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestUserInfoFieldMapping_GetSubjectField(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil mapping returns default", func(t *testing.T) {
+		t.Parallel()
+		var m *UserInfoFieldMapping
+		assert.Equal(t, DefaultSubjectField, m.GetSubjectField())
+	})
+
+	t.Run("empty mapping returns default", func(t *testing.T) {
+		t.Parallel()
+		m := &UserInfoFieldMapping{}
+		assert.Equal(t, DefaultSubjectField, m.GetSubjectField())
+	})
+
+	t.Run("configured field overrides default", func(t *testing.T) {
+		t.Parallel()
+		m := &UserInfoFieldMapping{
+			SubjectField: "user_id",
+		}
+		assert.Equal(t, "user_id", m.GetSubjectField())
+	})
+}
+
+func TestUserInfoFieldMapping_ResolveSubject(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		mapping     *UserInfoFieldMapping
+		claims      map[string]any
+		expected    string
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name:     "nil mapping uses default sub field",
+			mapping:  nil,
+			claims:   map[string]any{"sub": "user123"},
+			expected: "user123",
+		},
+		{
+			name:     "empty mapping uses default sub field",
+			mapping:  &UserInfoFieldMapping{},
+			claims:   map[string]any{"sub": "user123"},
+			expected: "user123",
+		},
+		{
+			name: "custom subject field",
+			mapping: &UserInfoFieldMapping{
+				SubjectField: "user_id",
+			},
+			claims:   map[string]any{"user_id": "custom123"},
+			expected: "custom123",
+		},
+		{
+			name:        "missing subject returns error",
+			mapping:     &UserInfoFieldMapping{SubjectField: "user_id"},
+			claims:      map[string]any{"other": "value"},
+			expectError: true,
+			errorMsg:    "subject claim not found",
+		},
+		{
+			name:        "nil mapping with missing sub returns error",
+			mapping:     nil,
+			claims:      map[string]any{"id": "456"},
+			expectError: true,
+			errorMsg:    "subject claim not found",
+		},
+		{
+			name:        "empty string subject returns error",
+			mapping:     nil,
+			claims:      map[string]any{"sub": ""},
+			expectError: true,
+			errorMsg:    "subject claim \"sub\" is empty",
+		},
+		{
+			name:     "numeric float64 converted to string",
+			mapping:  &UserInfoFieldMapping{SubjectField: "id"},
+			claims:   map[string]any{"id": float64(12345)},
+			expected: "12345",
+		},
+		{
+			name:        "unsupported type returns error",
+			mapping:     nil,
+			claims:      map[string]any{"sub": true},
+			expectError: true,
+			errorMsg:    "unsupported type",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result, err := tt.mapping.ResolveSubject(tt.claims)
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errorMsg)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, result)
 			}
 		})
 	}


### PR DESCRIPTION
Implement FetchUserInfo and ResolveIdentity methods on BaseOAuth2Provider to retrieve user information from upstream OAuth2/OIDC providers. This enables downstream handlers to obtain the authenticated user's subject.

FetchUserInfo makes an HTTP request to the configured UserInfo endpoint with the access token as a Bearer credential. ResolveIdentity provides a higher-level abstraction that fetches UserInfo and returns the subject claim directly.

To support non-standard providers like GitHub that use "id" instead of the OIDC-standard "sub" field, UserInfoFieldMapping allows configuring a custom SubjectField. The ResolveSubject helper handles both string and numeric subject values, converting JSON numbers to strings as needed.

The implementation includes response size limiting (1MB max), HTTP method validation (GET/POST only per OIDC Core Section 5.3.1), and UserInfo config validation during provider creation. The separate UserInfoFetcher interface has been removed in favor of methods directly on OAuth2Provider.

Example usage for GitHub:
```
  UserInfo: &upstream.UserInfoConfig{
      EndpointURL: "https://api.github.com/user",
      FieldMapping: &upstream.UserInfoFieldMapping{
          SubjectField: "id",
      },
  }
```