### PR TITLE
Add shared pkg/oauth for OAuth/OIDC types and constants

### DIFF
--- a/pkg/auth/discovery/discovery_test.go
+++ b/pkg/auth/discovery/discovery_test.go
@@ -14,9 +14,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/stacklok/toolhive/pkg/auth/oauth"
 	"github.com/stacklok/toolhive/pkg/logger"
 	"github.com/stacklok/toolhive/pkg/networking"
+	oauthproto "github.com/stacklok/toolhive/pkg/oauth"
 )
 
 const wellKnownOAuthPath = "/.well-known/oauth-protected-resource"
@@ -1298,13 +1298,15 @@ func TestRegisterDynamicClient_MissingRegistrationEndpoint(t *testing.T) {
 	ctx := context.Background()
 
 	// Create a discovery document without registration_endpoint
-	discoveredDoc := &oauth.OIDCDiscoveryDocument{
-		Issuer:                "https://auth.example.com",
-		AuthorizationEndpoint: "https://auth.example.com/oauth/authorize",
-		TokenEndpoint:         "https://auth.example.com/oauth/token",
-		JWKSURI:               "https://auth.example.com/oauth/jwks",
-		// Note: RegistrationEndpoint is intentionally omitted (empty string)
-		RegistrationEndpoint: "",
+	discoveredDoc := &oauthproto.OIDCDiscoveryDocument{
+		AuthorizationServerMetadata: oauthproto.AuthorizationServerMetadata{
+			Issuer:                "https://auth.example.com",
+			AuthorizationEndpoint: "https://auth.example.com/oauth/authorize",
+			TokenEndpoint:         "https://auth.example.com/oauth/token",
+			JWKSURI:               "https://auth.example.com/oauth/jwks",
+			// Note: RegistrationEndpoint is intentionally omitted (empty string)
+			RegistrationEndpoint: "",
+		},
 	}
 
 	config := &OAuthFlowConfig{

--- a/pkg/auth/oauth/dynamic_registration.go
+++ b/pkg/auth/oauth/dynamic_registration.go
@@ -13,22 +13,11 @@ import (
 
 	"github.com/stacklok/toolhive/pkg/logger"
 	"github.com/stacklok/toolhive/pkg/networking"
+	oauthproto "github.com/stacklok/toolhive/pkg/oauth"
 )
 
 // ToolHiveMCPClientName is the name of the ToolHive MCP client
 const ToolHiveMCPClientName = "ToolHive MCP Client"
-
-// AuthorizationCode is the grant type for authorization code
-const AuthorizationCode = "authorization_code"
-
-// RefreshToken is the grant type for refresh token
-const RefreshToken = "refresh_token"
-
-// ResponseTypeCode is the response type for code
-const ResponseTypeCode = "code"
-
-// TokenEndpointAuthMethodNone is the token endpoint auth method for none
-const TokenEndpointAuthMethodNone = "none"
 
 // DynamicClientRegistrationRequest represents the request for dynamic client registration (RFC 7591)
 type DynamicClientRegistrationRequest struct {
@@ -52,9 +41,9 @@ func NewDynamicClientRegistrationRequest(scopes []string, callbackPort int) *Dyn
 	registrationRequest := &DynamicClientRegistrationRequest{
 		ClientName:              ToolHiveMCPClientName,
 		RedirectURIs:            redirectURIs,
-		TokenEndpointAuthMethod: "none", // For PKCE flow
-		GrantTypes:              []string{AuthorizationCode, RefreshToken},
-		ResponseTypes:           []string{ResponseTypeCode},
+		TokenEndpointAuthMethod: oauthproto.TokenEndpointAuthMethodNone, // For PKCE flow
+		GrantTypes:              []string{oauthproto.GrantTypeAuthorizationCode, oauthproto.GrantTypeRefreshToken},
+		ResponseTypes:           []string{oauthproto.ResponseTypeCode},
 		Scopes:                  scopes,
 	}
 	return registrationRequest
@@ -206,13 +195,13 @@ func validateAndSetDefaults(request *DynamicClientRegistrationRequest) error {
 		request.ClientName = ToolHiveMCPClientName
 	}
 	if len(request.GrantTypes) == 0 {
-		request.GrantTypes = []string{AuthorizationCode, RefreshToken}
+		request.GrantTypes = []string{oauthproto.GrantTypeAuthorizationCode, oauthproto.GrantTypeRefreshToken}
 	}
 	if len(request.ResponseTypes) == 0 {
-		request.ResponseTypes = []string{ResponseTypeCode}
+		request.ResponseTypes = []string{oauthproto.ResponseTypeCode}
 	}
 	if request.TokenEndpointAuthMethod == "" {
-		request.TokenEndpointAuthMethod = TokenEndpointAuthMethodNone // For PKCE flow
+		request.TokenEndpointAuthMethod = oauthproto.TokenEndpointAuthMethodNone // For PKCE flow
 	}
 
 	return nil

--- a/pkg/auth/oauth/dynamic_registration_test.go
+++ b/pkg/auth/oauth/dynamic_registration_test.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	oauthproto "github.com/stacklok/toolhive/pkg/oauth"
 )
 
 func TestDiscoverOIDCEndpointsWithRegistration(t *testing.T) {
@@ -19,7 +21,7 @@ func TestDiscoverOIDCEndpointsWithRegistration(t *testing.T) {
 		issuer         string
 		response       string
 		expectedError  bool
-		expectedResult *OIDCDiscoveryDocument
+		expectedResult *oauthproto.OIDCDiscoveryDocument
 	}{
 		{
 			name:   "valid OIDC discovery with registration endpoint",
@@ -33,13 +35,15 @@ func TestDiscoverOIDCEndpointsWithRegistration(t *testing.T) {
 				"registration_endpoint": "{{SERVER_URL}}/oauth/register"
 			}`,
 			expectedError: false,
-			expectedResult: &OIDCDiscoveryDocument{
-				Issuer:                "https://example.com",
-				AuthorizationEndpoint: "https://example.com/oauth/authorize",
-				TokenEndpoint:         "https://example.com/oauth/token",
-				UserinfoEndpoint:      "https://example.com/oauth/userinfo",
-				JWKSURI:               "https://example.com/oauth/jwks",
-				RegistrationEndpoint:  "https://example.com/oauth/register",
+			expectedResult: &oauthproto.OIDCDiscoveryDocument{
+				AuthorizationServerMetadata: oauthproto.AuthorizationServerMetadata{
+					Issuer:                "https://example.com",
+					AuthorizationEndpoint: "https://example.com/oauth/authorize",
+					TokenEndpoint:         "https://example.com/oauth/token",
+					UserinfoEndpoint:      "https://example.com/oauth/userinfo",
+					JWKSURI:               "https://example.com/oauth/jwks",
+					RegistrationEndpoint:  "https://example.com/oauth/register",
+				},
 			},
 		},
 		{
@@ -53,13 +57,15 @@ func TestDiscoverOIDCEndpointsWithRegistration(t *testing.T) {
 				"jwks_uri": "{{SERVER_URL}}/oauth/jwks"
 			}`,
 			expectedError: false,
-			expectedResult: &OIDCDiscoveryDocument{
-				Issuer:                "https://example.com",
-				AuthorizationEndpoint: "https://example.com/oauth/authorize",
-				TokenEndpoint:         "https://example.com/oauth/token",
-				UserinfoEndpoint:      "https://example.com/oauth/userinfo",
-				JWKSURI:               "https://example.com/oauth/jwks",
-				RegistrationEndpoint:  "",
+			expectedResult: &oauthproto.OIDCDiscoveryDocument{
+				AuthorizationServerMetadata: oauthproto.AuthorizationServerMetadata{
+					Issuer:                "https://example.com",
+					AuthorizationEndpoint: "https://example.com/oauth/authorize",
+					TokenEndpoint:         "https://example.com/oauth/token",
+					UserinfoEndpoint:      "https://example.com/oauth/userinfo",
+					JWKSURI:               "https://example.com/oauth/jwks",
+					RegistrationEndpoint:  "",
+				},
 			},
 		},
 		{
@@ -84,13 +90,15 @@ func TestDiscoverOIDCEndpointsWithRegistration(t *testing.T) {
 				"registration_endpoint": "{{SERVER_URL}}/oauth/register"
 			}`,
 			expectedError: false,
-			expectedResult: &OIDCDiscoveryDocument{
-				Issuer:                "http://localhost:8080",
-				AuthorizationEndpoint: "http://localhost:8080/oauth/authorize",
-				TokenEndpoint:         "http://localhost:8080/oauth/token",
-				UserinfoEndpoint:      "http://localhost:8080/oauth/userinfo",
-				JWKSURI:               "http://localhost:8080/oauth/jwks",
-				RegistrationEndpoint:  "http://localhost:8080/oauth/register",
+			expectedResult: &oauthproto.OIDCDiscoveryDocument{
+				AuthorizationServerMetadata: oauthproto.AuthorizationServerMetadata{
+					Issuer:                "http://localhost:8080",
+					AuthorizationEndpoint: "http://localhost:8080/oauth/authorize",
+					TokenEndpoint:         "http://localhost:8080/oauth/token",
+					UserinfoEndpoint:      "http://localhost:8080/oauth/userinfo",
+					JWKSURI:               "http://localhost:8080/oauth/jwks",
+					RegistrationEndpoint:  "http://localhost:8080/oauth/register",
+				},
 			},
 		},
 	}
@@ -105,8 +113,8 @@ func TestDiscoverOIDCEndpointsWithRegistration(t *testing.T) {
 				responseTemplate = tt.response
 				server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					// Handle both OIDC and OAuth discovery endpoints
-					if r.URL.Path == WellKnownOIDCPath ||
-						r.URL.Path == WellKnownOAuthServerPath {
+					if r.URL.Path == oauthproto.WellKnownOIDCPath ||
+						r.URL.Path == oauthproto.WellKnownOAuthServerPath {
 						w.Header().Set("Content-Type", "application/json")
 						w.WriteHeader(http.StatusOK)
 						// Replace placeholder with actual server URL
@@ -503,7 +511,7 @@ func TestDiscoverOIDCEndpointsWithRegistrationFallback(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		baseURL := "http://" + r.Host
 		switch r.URL.Path {
-		case WellKnownOIDCPath:
+		case oauthproto.WellKnownOIDCPath:
 			// OIDC discovery - no registration_endpoint
 			response := `{
 				"issuer": "` + baseURL + `",
@@ -514,7 +522,7 @@ func TestDiscoverOIDCEndpointsWithRegistrationFallback(t *testing.T) {
 			}`
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(response))
-		case WellKnownOAuthServerPath:
+		case oauthproto.WellKnownOAuthServerPath:
 			// OAuth authorization server - has registration_endpoint
 			response := `{
 				"issuer": "` + baseURL + `",
@@ -551,7 +559,7 @@ func TestDiscoverOIDCEndpointsWithRegistrationFallbackIssuerMismatch(t *testing.
 		w.Header().Set("Content-Type", "application/json")
 		baseURL := "http://" + r.Host
 		switch r.URL.Path {
-		case WellKnownOIDCPath:
+		case oauthproto.WellKnownOIDCPath:
 			// OIDC discovery - no registration_endpoint, different issuer
 			response := `{
 				"issuer": "https://oidc.example.com",
@@ -562,7 +570,7 @@ func TestDiscoverOIDCEndpointsWithRegistrationFallbackIssuerMismatch(t *testing.
 			}`
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(response))
-		case WellKnownOAuthServerPath:
+		case oauthproto.WellKnownOAuthServerPath:
 			// OAuth authorization server - has registration_endpoint but different issuer
 			response := `{
 				"issuer": "https://oauth.example.com",

--- a/pkg/auth/oauth/flow.go
+++ b/pkg/auth/oauth/flow.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/stacklok/toolhive/pkg/logger"
 	"github.com/stacklok/toolhive/pkg/networking"
+	oauthproto "github.com/stacklok/toolhive/pkg/oauth"
 )
 
 // Config contains configuration for OAuth authentication
@@ -265,7 +266,7 @@ func (f *Flow) buildAuthURL() string {
 	if f.config.UsePKCE {
 		opts = append(opts,
 			oauth2.SetAuthURLParam("code_challenge", f.codeChallenge),
-			oauth2.SetAuthURLParam("code_challenge_method", "S256"),
+			oauth2.SetAuthURLParam("code_challenge_method", oauthproto.PKCEMethodS256),
 		)
 	}
 

--- a/pkg/auth/oauth/oidc.go
+++ b/pkg/auth/oauth/oidc.go
@@ -14,43 +14,21 @@ import (
 
 	"github.com/stacklok/toolhive/pkg/logger"
 	"github.com/stacklok/toolhive/pkg/networking"
+	oauthproto "github.com/stacklok/toolhive/pkg/oauth"
 )
 
 // UserAgent is the user agent for the ToolHive MCP client
 const UserAgent = "ToolHive/1.0"
 
-// Well-known endpoint paths for OIDC and OAuth discovery
-const (
-	// WellKnownOIDCPath is the standard OIDC discovery endpoint path
-	// per OpenID Connect Discovery 1.0 specification
-	WellKnownOIDCPath = "/.well-known/openid-configuration"
-	// WellKnownOAuthServerPath is the standard OAuth authorization server metadata endpoint path
-	// per RFC 8414 (OAuth 2.0 Authorization Server Metadata)
-	WellKnownOAuthServerPath = "/.well-known/oauth-authorization-server"
-)
-
-// OIDCDiscoveryDocument represents the OIDC discovery document structure
-// This is a simplified wrapper around the Zitadel OIDC discovery
-type OIDCDiscoveryDocument struct {
-	Issuer                        string   `json:"issuer"`
-	AuthorizationEndpoint         string   `json:"authorization_endpoint"`
-	IntrospectionEndpoint         string   `json:"introspection_endpoint,omitempty"`
-	TokenEndpoint                 string   `json:"token_endpoint"`
-	UserinfoEndpoint              string   `json:"userinfo_endpoint"`
-	JWKSURI                       string   `json:"jwks_uri"`
-	RegistrationEndpoint          string   `json:"registration_endpoint,omitempty"`
-	CodeChallengeMethodsSupported []string `json:"code_challenge_methods_supported,omitempty"`
-}
-
 // DiscoverOIDCEndpoints discovers OAuth endpoints from an OIDC issuer
-func DiscoverOIDCEndpoints(ctx context.Context, issuer string) (*OIDCDiscoveryDocument, error) {
+func DiscoverOIDCEndpoints(ctx context.Context, issuer string) (*oauthproto.OIDCDiscoveryDocument, error) {
 	return discoverOIDCEndpointsWithClient(ctx, issuer, nil, false)
 }
 
 // DiscoverActualIssuer discovers the actual issuer from a URL that might be different from the issuer itself
 // This is useful when the resource metadata points to a URL that hosts the authorization server metadata
 // but the actual issuer identifier is different (e.g., Stripe's case)
-func DiscoverActualIssuer(ctx context.Context, metadataURL string) (*OIDCDiscoveryDocument, error) {
+func DiscoverActualIssuer(ctx context.Context, metadataURL string) (*oauthproto.OIDCDiscoveryDocument, error) {
 	return discoverOIDCEndpointsWithClientAndValidation(ctx, metadataURL, nil, false, false)
 }
 
@@ -60,7 +38,7 @@ func discoverOIDCEndpointsWithClient(
 	issuer string,
 	client networking.HTTPClient,
 	insecureAllowHTTP bool,
-) (*OIDCDiscoveryDocument, error) {
+) (*oauthproto.OIDCDiscoveryDocument, error) {
 	return discoverOIDCEndpointsWithClientAndValidation(ctx, issuer, client, true, insecureAllowHTTP)
 }
 
@@ -73,7 +51,7 @@ func discoverOIDCEndpointsWithClientAndValidation(
 	client networking.HTTPClient,
 	validateIssuer bool,
 	insecureAllowHTTP bool,
-) (*OIDCDiscoveryDocument, error) {
+) (*oauthproto.OIDCDiscoveryDocument, error) {
 
 	oidcURL, oauthURL, err := buildWellKnownURLs(issuer, insecureAllowHTTP)
 	if err != nil {
@@ -90,7 +68,7 @@ func discoverOIDCEndpointsWithClientAndValidation(
 		}
 	}
 
-	try := func(urlStr string, oidc bool) (*OIDCDiscoveryDocument, error) {
+	try := func(urlStr string, oidc bool) (*oauthproto.OIDCDiscoveryDocument, error) {
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, urlStr, nil)
 		if err != nil {
 			return nil, fmt.Errorf("build request: %w", err)
@@ -118,7 +96,7 @@ func discoverOIDCEndpointsWithClientAndValidation(
 
 		// Limit response size to prevent DoS
 		const maxResponseSize = 1024 * 1024 // 1MB
-		var doc OIDCDiscoveryDocument
+		var doc oauthproto.OIDCDiscoveryDocument
 		if err := json.NewDecoder(io.LimitReader(resp.Body, maxResponseSize)).Decode(&doc); err != nil {
 			return nil, fmt.Errorf("%s: unexpected response: %w", urlStr, err)
 		}
@@ -165,30 +143,34 @@ func discoverOIDCEndpointsWithClientAndValidation(
 		oidcURL, oauthURL, oidcErr, oauthErr)
 }
 
-// validateOIDCDocument validates the OIDC discovery document
-func validateOIDCDocument(doc *OIDCDiscoveryDocument, expectedIssuer string, oidc bool, insecureAllowHTTP bool) error {
-	if doc.Issuer == "" {
-		return fmt.Errorf("missing issuer")
+// validateOIDCDocument validates the OIDC discovery document.
+// It delegates basic field presence validation to the shared doc.Validate() method,
+// then performs additional security checks (issuer mismatch, URL HTTPS validation).
+func validateOIDCDocument(
+	doc *oauthproto.OIDCDiscoveryDocument,
+	expectedIssuer string,
+	oidc bool,
+	insecureAllowHTTP bool,
+) error {
+	// Delegate basic field presence validation to the shared method.
+	// Note: We pass oidc=false here because we handle jwks_uri separately below
+	// with a more specific error message, and response_types_supported validation
+	// is not enforced in this legacy code path to maintain backward compatibility.
+	if err := doc.Validate(false); err != nil {
+		return err
 	}
 
-	if doc.Issuer != expectedIssuer {
-		return fmt.Errorf("issuer mismatch: expected %s, got %s", expectedIssuer, doc.Issuer)
-	}
-
-	if doc.AuthorizationEndpoint == "" {
-		return fmt.Errorf("missing authorization_endpoint")
-	}
-
-	if doc.TokenEndpoint == "" {
-		return fmt.Errorf("missing token_endpoint")
-	}
-
-	// Require jwks_uri for OIDC
+	// Require jwks_uri for OIDC (with specific error message)
 	if oidc && doc.JWKSURI == "" {
 		return fmt.Errorf("missing jwks_uri (OIDC requires it)")
 	}
 
-	// Validate URLs (skip HTTPS validation if insecureAllowHTTP is enabled)
+	// Security check: issuer must match expected value
+	if doc.Issuer != expectedIssuer {
+		return fmt.Errorf("issuer mismatch: expected %s, got %s", expectedIssuer, doc.Issuer)
+	}
+
+	// Security check: validate endpoint URLs (HTTPS required unless insecureAllowHTTP)
 	endpoints := map[string]string{
 		"authorization_endpoint": doc.AuthorizationEndpoint,
 		"token_endpoint":         doc.TokenEndpoint,
@@ -245,7 +227,7 @@ func createOAuthConfigFromOIDCWithClient(
 	// Enable PKCE by default if supported
 	if !usePKCE && len(doc.CodeChallengeMethodsSupported) > 0 {
 		for _, method := range doc.CodeChallengeMethodsSupported {
-			if method == "S256" {
+			if method == oauthproto.PKCEMethodS256 {
 				usePKCE = true
 				break
 			}
@@ -293,7 +275,7 @@ func buildWellKnownURLs(issuer string, insecureAllowHTTP bool) (oidcURL, oauthUR
 	//   /{tenant}/.well-known/openid-configuration
 	//
 	oidc := *base
-	oidc.Path = path.Join("/", tenant, WellKnownOIDCPath)
+	oidc.Path = path.Join("/", tenant, oauthproto.WellKnownOIDCPath)
 	oidcURL = oidc.String()
 
 	//
@@ -301,7 +283,7 @@ func buildWellKnownURLs(issuer string, insecureAllowHTTP bool) (oidcURL, oauthUR
 	//   /.well-known/oauth-authorization-server/{tenant}
 	//
 	oauth := *base
-	oauth.Path = path.Join(WellKnownOAuthServerPath, tenant)
+	oauth.Path = path.Join(oauthproto.WellKnownOAuthServerPath, tenant)
 	oauthURL = oauth.String()
 
 	return oidcURL, oauthURL, nil

--- a/pkg/auth/token_test.go
+++ b/pkg/auth/token_test.go
@@ -17,6 +17,8 @@ import (
 
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/lestrrat-go/jwx/v3/jwk"
+
+	oauthproto "github.com/stacklok/toolhive/pkg/oauth"
 )
 
 const (
@@ -377,12 +379,14 @@ func createTestOIDCServer(_ *testing.T, jwksURL string) *httptest.Server {
 		}
 		issuerURL := fmt.Sprintf("%s://%s", scheme, r.Host)
 
-		doc := OIDCDiscoveryDocument{
-			Issuer:                issuerURL,
-			AuthorizationEndpoint: issuerURL + "/auth",
-			TokenEndpoint:         issuerURL + "/token",
-			UserinfoEndpoint:      issuerURL + "/userinfo",
-			JWKSURI:               jwksURL,
+		doc := oauthproto.OIDCDiscoveryDocument{
+			AuthorizationServerMetadata: oauthproto.AuthorizationServerMetadata{
+				Issuer:                issuerURL,
+				AuthorizationEndpoint: issuerURL + "/auth",
+				TokenEndpoint:         issuerURL + "/token",
+				UserinfoEndpoint:      issuerURL + "/userinfo",
+				JWKSURI:               jwksURL,
+			},
 		}
 
 		w.Header().Set("Content-Type", "application/json")

--- a/pkg/auth/well_known.go
+++ b/pkg/auth/well_known.go
@@ -4,17 +4,9 @@ package auth
 import (
 	"net/http"
 	"strings"
-)
 
-// WellKnownOAuthResourcePath is the RFC 9728 standard path for OAuth Protected Resource metadata.
-// Per RFC 9728 Section 3, this endpoint and any subpaths under it should be accessible
-// without authentication to enable OIDC/OAuth discovery.
-//
-// Example valid paths:
-//   - /.well-known/oauth-protected-resource
-//   - /.well-known/oauth-protected-resource/mcp
-//   - /.well-known/oauth-protected-resource/v1/metadata
-const WellKnownOAuthResourcePath = "/.well-known/oauth-protected-resource"
+	oauthproto "github.com/stacklok/toolhive/pkg/oauth"
+)
 
 // NewWellKnownHandler creates an HTTP handler that routes requests under the
 // /.well-known/ path space to the appropriate handler.
@@ -49,7 +41,7 @@ func NewWellKnownHandler(authInfoHandler http.Handler) http.Handler {
 		//   ✓ /.well-known/oauth-protected-resource
 		//   ✓ /.well-known/oauth-protected-resource/mcp
 		//   ✗ /.well-known/other-endpoint
-		if strings.HasPrefix(r.URL.Path, WellKnownOAuthResourcePath) {
+		if strings.HasPrefix(r.URL.Path, oauthproto.WellKnownOAuthResourcePath) {
 			authInfoHandler.ServeHTTP(w, r)
 			return
 		}

--- a/pkg/authserver/upstream/oauth2.go
+++ b/pkg/authserver/upstream/oauth2.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/stacklok/toolhive/pkg/logger"
 	"github.com/stacklok/toolhive/pkg/networking"
+	oauthproto "github.com/stacklok/toolhive/pkg/oauth"
 )
 
 const (
@@ -335,7 +336,7 @@ func (p *BaseOAuth2Provider) buildAuthorizationURL(
 	if codeChallenge != "" {
 		oauth2Opts = append(oauth2Opts,
 			oauth2.SetAuthURLParam("code_challenge", codeChallenge),
-			oauth2.SetAuthURLParam("code_challenge_method", "S256"),
+			oauth2.SetAuthURLParam("code_challenge_method", oauthproto.PKCEMethodS256),
 		)
 	}
 

--- a/pkg/oauth/constants.go
+++ b/pkg/oauth/constants.go
@@ -1,0 +1,62 @@
+// Copyright 2025 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package oauth provides RFC-defined types and constants for OAuth 2.0 and OpenID Connect.
+// This package contains ONLY protocol-level definitions with no business logic.
+// It serves as a shared foundation for both OAuth clients (consumers) and servers (producers).
+package oauth
+
+// Well-known endpoint paths as defined by RFC 8414, OpenID Connect Discovery 1.0, and RFC 9728.
+const (
+	// WellKnownOIDCPath is the standard OIDC discovery endpoint path
+	// per OpenID Connect Discovery 1.0 specification.
+	WellKnownOIDCPath = "/.well-known/openid-configuration"
+
+	// WellKnownOAuthServerPath is the standard OAuth authorization server metadata endpoint path
+	// per RFC 8414 (OAuth 2.0 Authorization Server Metadata).
+	WellKnownOAuthServerPath = "/.well-known/oauth-authorization-server"
+
+	// WellKnownOAuthResourcePath is the RFC 9728 standard path for OAuth Protected Resource metadata.
+	// Per RFC 9728 Section 3, this endpoint and any subpaths under it should be accessible
+	// without authentication to enable OIDC/OAuth discovery.
+	WellKnownOAuthResourcePath = "/.well-known/oauth-protected-resource"
+)
+
+// Grant types as defined by RFC 6749.
+const (
+	// GrantTypeAuthorizationCode is the authorization code grant type (RFC 6749 Section 4.1).
+	GrantTypeAuthorizationCode = "authorization_code"
+
+	// GrantTypeRefreshToken is the refresh token grant type (RFC 6749 Section 6).
+	GrantTypeRefreshToken = "refresh_token"
+)
+
+// Response types as defined by RFC 6749.
+const (
+	// ResponseTypeCode is the authorization code response type (RFC 6749 Section 4.1.1).
+	ResponseTypeCode = "code"
+)
+
+// Token endpoint authentication methods as defined by RFC 7591.
+const (
+	// TokenEndpointAuthMethodNone indicates no client authentication (public clients).
+	// Typically used with PKCE for native/mobile applications.
+	TokenEndpointAuthMethodNone = "none"
+)
+
+// PKCE (Proof Key for Code Exchange) methods as defined by RFC 7636.
+const (
+	// PKCEMethodS256 uses SHA-256 hash of the code verifier (recommended).
+	PKCEMethodS256 = "S256"
+)

--- a/pkg/oauth/discovery.go
+++ b/pkg/oauth/discovery.go
@@ -1,0 +1,117 @@
+// Copyright 2025 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oauth
+
+// AuthorizationServerMetadata represents the OAuth 2.0 Authorization Server Metadata
+// per RFC 8414. This is the base structure that OIDC Discovery extends.
+type AuthorizationServerMetadata struct {
+	// Issuer is the authorization server's issuer identifier (REQUIRED per RFC 8414).
+	Issuer string `json:"issuer"`
+
+	// AuthorizationEndpoint is the URL of the authorization endpoint (RECOMMENDED).
+	// Note: No omitempty to maintain backward compatibility with existing JSON serialization.
+	AuthorizationEndpoint string `json:"authorization_endpoint"`
+
+	// TokenEndpoint is the URL of the token endpoint (RECOMMENDED).
+	// Note: No omitempty to maintain backward compatibility with existing JSON serialization.
+	TokenEndpoint string `json:"token_endpoint"`
+
+	// JWKSURI is the URL of the JSON Web Key Set document (RECOMMENDED).
+	// Note: No omitempty to maintain backward compatibility with existing JSON serialization.
+	JWKSURI string `json:"jwks_uri"`
+
+	// RegistrationEndpoint is the URL of the Dynamic Client Registration endpoint (OPTIONAL).
+	RegistrationEndpoint string `json:"registration_endpoint,omitempty"`
+
+	// IntrospectionEndpoint is the URL of the token introspection endpoint (OPTIONAL, RFC 7662).
+	IntrospectionEndpoint string `json:"introspection_endpoint,omitempty"`
+
+	// UserinfoEndpoint is the URL of the UserInfo endpoint (OPTIONAL, OIDC specific).
+	// Note: No omitempty to maintain backward compatibility with existing JSON serialization.
+	UserinfoEndpoint string `json:"userinfo_endpoint"`
+
+	// ResponseTypesSupported lists the response types supported (RECOMMENDED).
+	ResponseTypesSupported []string `json:"response_types_supported,omitempty"`
+
+	// GrantTypesSupported lists the grant types supported (OPTIONAL).
+	GrantTypesSupported []string `json:"grant_types_supported,omitempty"`
+
+	// CodeChallengeMethodsSupported lists the PKCE code challenge methods supported (OPTIONAL).
+	CodeChallengeMethodsSupported []string `json:"code_challenge_methods_supported,omitempty"`
+
+	// TokenEndpointAuthMethodsSupported lists the authentication methods supported at the token endpoint (OPTIONAL).
+	TokenEndpointAuthMethodsSupported []string `json:"token_endpoint_auth_methods_supported,omitempty"`
+}
+
+// OIDCDiscoveryDocument represents the OpenID Connect Discovery 1.0 document.
+// It extends OAuth 2.0 Authorization Server Metadata (RFC 8414) with OIDC-specific fields.
+// This unified type supports both producer (server) and consumer (client) use cases.
+type OIDCDiscoveryDocument struct {
+	// Embed OAuth 2.0 AS Metadata (RFC 8414) as the base
+	AuthorizationServerMetadata
+
+	// SubjectTypesSupported lists the subject identifier types supported (REQUIRED for OIDC).
+	SubjectTypesSupported []string `json:"subject_types_supported,omitempty"`
+
+	// IDTokenSigningAlgValuesSupported lists the JWS algorithms supported for ID tokens (REQUIRED for OIDC).
+	IDTokenSigningAlgValuesSupported []string `json:"id_token_signing_alg_values_supported,omitempty"`
+
+	// ScopesSupported lists the OAuth 2.0 scope values supported (RECOMMENDED for OIDC).
+	ScopesSupported []string `json:"scopes_supported,omitempty"`
+
+	// ClaimsSupported lists the claims that can be returned (RECOMMENDED for OIDC).
+	ClaimsSupported []string `json:"claims_supported,omitempty"`
+}
+
+// Validate performs basic validation on the discovery document.
+// It checks for required fields based on whether this is an OIDC or pure OAuth document.
+func (d *OIDCDiscoveryDocument) Validate(isOIDC bool) error {
+	if d.Issuer == "" {
+		return ErrMissingIssuer
+	}
+	if d.AuthorizationEndpoint == "" {
+		return ErrMissingAuthorizationEndpoint
+	}
+	if d.TokenEndpoint == "" {
+		return ErrMissingTokenEndpoint
+	}
+	if isOIDC && d.JWKSURI == "" {
+		return ErrMissingJWKSURI
+	}
+	if isOIDC && len(d.ResponseTypesSupported) == 0 {
+		return ErrMissingResponseTypesSupported
+	}
+	return nil
+}
+
+// SupportsPKCE returns true if the authorization server supports PKCE with S256.
+func (d *OIDCDiscoveryDocument) SupportsPKCE() bool {
+	for _, method := range d.CodeChallengeMethodsSupported {
+		if method == PKCEMethodS256 {
+			return true
+		}
+	}
+	return false
+}
+
+// SupportsGrantType returns true if the authorization server supports the given grant type.
+func (d *OIDCDiscoveryDocument) SupportsGrantType(grantType string) bool {
+	for _, gt := range d.GrantTypesSupported {
+		if gt == grantType {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/oauth/discovery_test.go
+++ b/pkg/oauth/discovery_test.go
@@ -1,0 +1,127 @@
+// Copyright 2025 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oauth
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestOIDCDiscoveryDocument_Validate(t *testing.T) {
+	t.Parallel()
+
+	validDoc := func() OIDCDiscoveryDocument {
+		return OIDCDiscoveryDocument{
+			AuthorizationServerMetadata: AuthorizationServerMetadata{
+				Issuer:                 "https://example.com",
+				AuthorizationEndpoint:  "https://example.com/authorize",
+				TokenEndpoint:          "https://example.com/token",
+				JWKSURI:                "https://example.com/jwks",
+				ResponseTypesSupported: []string{"code"},
+			},
+		}
+	}
+
+	tests := []struct {
+		name    string
+		modify  func(*OIDCDiscoveryDocument)
+		isOIDC  bool
+		wantErr error
+	}{
+		{"valid OAuth document", nil, false, nil},
+		{"valid OIDC document", nil, true, nil},
+		{"missing issuer", func(d *OIDCDiscoveryDocument) { d.Issuer = "" }, false, ErrMissingIssuer},
+		{"missing authorization_endpoint", func(d *OIDCDiscoveryDocument) { d.AuthorizationEndpoint = "" }, false, ErrMissingAuthorizationEndpoint},
+		{"missing token_endpoint", func(d *OIDCDiscoveryDocument) { d.TokenEndpoint = "" }, false, ErrMissingTokenEndpoint},
+		{"missing jwks_uri for OIDC", func(d *OIDCDiscoveryDocument) { d.JWKSURI = "" }, true, ErrMissingJWKSURI},
+		{"missing jwks_uri for OAuth is OK", func(d *OIDCDiscoveryDocument) { d.JWKSURI = "" }, false, nil},
+		{"missing response_types_supported for OIDC", func(d *OIDCDiscoveryDocument) { d.ResponseTypesSupported = nil }, true, ErrMissingResponseTypesSupported},
+		{"missing response_types_supported for OAuth is OK", func(d *OIDCDiscoveryDocument) { d.ResponseTypesSupported = nil }, false, nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			doc := validDoc()
+			if tt.modify != nil {
+				tt.modify(&doc)
+			}
+			err := doc.Validate(tt.isOIDC)
+			if !errors.Is(err, tt.wantErr) {
+				t.Errorf("Validate() = %v, want %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestOIDCDiscoveryDocument_SupportsPKCE(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		methods []string
+		want    bool
+	}{
+		{"nil slice", nil, false},
+		{"empty slice", []string{}, false},
+		{"only plain", []string{"plain"}, false},
+		{"S256 present", []string{"S256"}, true},
+		{"both plain and S256", []string{"plain", "S256"}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			doc := OIDCDiscoveryDocument{
+				AuthorizationServerMetadata: AuthorizationServerMetadata{
+					CodeChallengeMethodsSupported: tt.methods,
+				},
+			}
+			if got := doc.SupportsPKCE(); got != tt.want {
+				t.Errorf("SupportsPKCE() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOIDCDiscoveryDocument_SupportsGrantType(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		grants    []string
+		grantType string
+		want      bool
+	}{
+		{"nil slice", nil, GrantTypeAuthorizationCode, false},
+		{"empty slice", []string{}, GrantTypeAuthorizationCode, false},
+		{"grant type present", []string{GrantTypeAuthorizationCode}, GrantTypeAuthorizationCode, true},
+		{"grant type absent", []string{GrantTypeRefreshToken}, GrantTypeAuthorizationCode, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			doc := OIDCDiscoveryDocument{
+				AuthorizationServerMetadata: AuthorizationServerMetadata{
+					GrantTypesSupported: tt.grants,
+				},
+			}
+			if got := doc.SupportsGrantType(tt.grantType); got != tt.want {
+				t.Errorf("SupportsGrantType(%q) = %v, want %v", tt.grantType, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/oauth/doc.go
+++ b/pkg/oauth/doc.go
@@ -1,0 +1,18 @@
+// Copyright 2025 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package oauth provides shared RFC-defined types and constants for OAuth 2.0 and OpenID Connect.
+// It contains only protocol-level definitions with no business logic, serving as a shared
+// foundation for both OAuth clients and servers.
+package oauth

--- a/pkg/oauth/errors.go
+++ b/pkg/oauth/errors.go
@@ -1,0 +1,35 @@
+// Copyright 2025 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oauth
+
+import "errors"
+
+// Validation errors for discovery documents.
+var (
+	// ErrMissingIssuer indicates the issuer field is missing from the discovery document.
+	ErrMissingIssuer = errors.New("missing issuer")
+
+	// ErrMissingAuthorizationEndpoint indicates the authorization_endpoint field is missing.
+	ErrMissingAuthorizationEndpoint = errors.New("missing authorization_endpoint")
+
+	// ErrMissingTokenEndpoint indicates the token_endpoint field is missing.
+	ErrMissingTokenEndpoint = errors.New("missing token_endpoint")
+
+	// ErrMissingJWKSURI indicates the jwks_uri field is missing (required for OIDC).
+	ErrMissingJWKSURI = errors.New("missing jwks_uri")
+
+	// ErrMissingResponseTypesSupported indicates the response_types_supported field is missing (required for OIDC).
+	ErrMissingResponseTypesSupported = errors.New("missing response_types_supported")
+)


### PR DESCRIPTION
This PR introduces a new shared package at `pkg/oauth` that consolidates OAuth 2.0 and OpenID Connect protocol-level types and constants. Previously, the codebase had three separate `OIDCDiscoveryDocument` definitions scattered across `pkg/auth` packages, along with duplicated constants for well-known paths, grant types, and PKCE methods. And the upcoming authserver would have added another one.

This commit adds a new top-level package `pkg/oauth` that should implement the relevat RFC structures and I imagine in the future would also add wrappers around libraries like `x/oauth` or `fosite` to add reusable OAuth logic - but without tying it to toolhive-specific functionality.

The new package provides a single source of truth following the relevant RFCs:

- `AuthorizationServerMetadata` models **RFC 8414**
- `OIDCDiscoveryDocument` extends it with OIDC-specific fields per **OpenID Connect Discovery 1.0**

The embedded struct approach correctly represents the RFC hierarchy  Fields that were previously serialized without `omitempty` retain that behavior to avoid breaking existing JSON consumers.