### PR TITLE
Consolidate PKCE to use golang.org/x/oauth2 stdlib functions

### DIFF
--- a/pkg/auth/oauth/flow.go
+++ b/pkg/auth/oauth/flow.go
@@ -4,7 +4,6 @@ package oauth
 import (
 	"context"
 	"crypto/rand"
-	"crypto/sha256"
 	"encoding/base64"
 	"errors"
 	"fmt"
@@ -134,9 +133,7 @@ func NewFlow(config *Config) (*Flow, error) {
 
 	// Generate PKCE parameters if enabled
 	if config.UsePKCE {
-		if err := flow.generatePKCEParams(); err != nil {
-			return nil, fmt.Errorf("failed to generate PKCE parameters: %w", err)
-		}
+		flow.generatePKCEParams()
 	}
 
 	// Generate state parameter
@@ -147,20 +144,14 @@ func NewFlow(config *Config) (*Flow, error) {
 	return flow, nil
 }
 
-// generatePKCEParams generates PKCE code verifier and challenge
-func (f *Flow) generatePKCEParams() error {
-	// Generate code verifier (43-128 characters, RFC 7636)
-	verifierBytes := make([]byte, 32)
-	if _, err := rand.Read(verifierBytes); err != nil {
-		return fmt.Errorf("failed to generate code verifier: %w", err)
-	}
-	f.codeVerifier = base64.RawURLEncoding.EncodeToString(verifierBytes)
+// generatePKCEParams generates PKCE code verifier and challenge using
+// the standard oauth2 library functions.
+func (f *Flow) generatePKCEParams() {
+	// Generate code verifier using oauth2 stdlib (43-128 characters, RFC 7636)
+	f.codeVerifier = oauth2.GenerateVerifier()
 
 	// Use S256 method for enhanced security (RFC 7636 recommendation)
-	hash := sha256.Sum256([]byte(f.codeVerifier))
-	f.codeChallenge = base64.RawURLEncoding.EncodeToString(hash[:])
-
-	return nil
+	f.codeChallenge = oauth2.S256ChallengeFromVerifier(f.codeVerifier)
 }
 
 // generateState generates a random state parameter

--- a/pkg/authserver/server/crypto/pkce.go
+++ b/pkg/authserver/server/crypto/pkce.go
@@ -15,37 +15,28 @@
 package crypto
 
 import (
-	"crypto/rand"
-	"crypto/sha256"
-	"encoding/base64"
-	"fmt"
+	"golang.org/x/oauth2"
 )
 
 // PKCEChallengeMethodS256 is the PKCE challenge method using SHA-256 (RFC 7636).
 const PKCEChallengeMethodS256 = "S256"
 
-// pkceVerifierLength is the length of the code verifier in bytes before encoding.
-// RFC 7636 requires the verifier to be 43-128 characters after base64url encoding.
-// 32 bytes = 43 characters after base64url encoding (without padding).
-const pkceVerifierLength = 32
-
 // GeneratePKCEVerifier generates a cryptographically random code_verifier
 // per RFC 7636 Section 4.1.
 // The verifier is 43 characters (32 bytes base64url encoded without padding),
 // using characters from the base64url alphabet: [A-Z], [a-z], [0-9], "-", "_".
-func GeneratePKCEVerifier() (string, error) {
-	b := make([]byte, pkceVerifierLength)
-	if _, err := rand.Read(b); err != nil {
-		return "", fmt.Errorf("failed to generate PKCE verifier: %w", err)
-	}
-	// base64url encoding without padding produces URL-safe characters
-	return base64.RawURLEncoding.EncodeToString(b), nil
+//
+// This function delegates to oauth2.GenerateVerifier() from golang.org/x/oauth2.
+// It will panic on crypto/rand read failure (which is appropriate for this case).
+func GeneratePKCEVerifier() string {
+	return oauth2.GenerateVerifier()
 }
 
 // ComputePKCEChallenge computes the code_challenge from a code_verifier
 // using the S256 method per RFC 7636 Section 4.2.
 // code_challenge = BASE64URL(SHA256(code_verifier))
+//
+// This function delegates to oauth2.S256ChallengeFromVerifier() from golang.org/x/oauth2.
 func ComputePKCEChallenge(verifier string) string {
-	hash := sha256.Sum256([]byte(verifier))
-	return base64.RawURLEncoding.EncodeToString(hash[:])
+	return oauth2.S256ChallengeFromVerifier(verifier)
 }

--- a/pkg/authserver/server/crypto/pkce_test.go
+++ b/pkg/authserver/server/crypto/pkce_test.go
@@ -18,14 +18,12 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestGeneratePKCEVerifier(t *testing.T) {
 	t.Parallel()
 
-	verifier, err := GeneratePKCEVerifier()
-	require.NoError(t, err)
+	verifier := GeneratePKCEVerifier()
 
 	// RFC 7636: code_verifier must be 43-128 characters
 	assert.GreaterOrEqual(t, len(verifier), 43)


### PR DESCRIPTION
Several reviewers rightfully pointed out that I should get better at avoiding code duplication between authserver and pkg/auth. This is a small PR, but also goes in that direction.

Replace manual PKCE implementations with standard library functions:
- GeneratePKCEVerifier() now uses oauth2.GenerateVerifier()
- ComputePKCEChallenge() now uses oauth2.S256ChallengeFromVerifier()

The stdlib GenerateVerifier() doesn't return an error (panics on crypto/rand failure), so function signatures were updated accordingly.