### PR TITLE
Adopt MCPRegistry RBAC pattern for VirtualMCPServer

### DIFF
--- a/cmd/thv-operator/controllers/virtualmcpserver_rbac.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_rbac.go
@@ -1,0 +1,176 @@
+package controllers
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	mcpv1alpha1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1alpha1"
+)
+
+// ensureRBACResourcesForVirtualMCPServer ensures that RBAC resources (ServiceAccount, Role, RoleBinding)
+// are in place for the VirtualMCPServer in dynamic mode.
+//
+// This implementation follows the MCPRegistry pattern using CreateOrUpdate with RetryOnConflict,
+// which automatically updates RBAC rules during operator upgrades. This is an improvement over
+// the previous EnsureRBACResource helper which only created resources but never updated them.
+//
+// All resources are namespace-scoped and use owner references for automatic cleanup
+// when the VirtualMCPServer is deleted.
+func (r *VirtualMCPServerReconciler) ensureRBACResourcesForVirtualMCPServer(
+	ctx context.Context,
+	vmcp *mcpv1alpha1.VirtualMCPServer,
+) error {
+	ctxLogger := log.FromContext(ctx).WithValues("virtualmcpserver", vmcp.Name)
+	ctxLogger.Info("Ensuring RBAC resources for VirtualMCPServer")
+
+	resourceName := vmcpServiceAccountName(vmcp.Name)
+
+	if err := r.ensureServiceAccountForVirtualMCPServer(ctx, vmcp, resourceName); err != nil {
+		return fmt.Errorf("failed to ensure service account: %w", err)
+	}
+
+	if err := r.ensureRoleForVirtualMCPServer(ctx, vmcp, resourceName); err != nil {
+		return fmt.Errorf("failed to ensure role: %w", err)
+	}
+
+	if err := r.ensureRoleBindingForVirtualMCPServer(ctx, vmcp, resourceName); err != nil {
+		return fmt.Errorf("failed to ensure role binding: %w", err)
+	}
+
+	ctxLogger.Info("Successfully ensured RBAC resources for VirtualMCPServer")
+	return nil
+}
+
+// ensureServiceAccountForVirtualMCPServer ensures the ServiceAccount exists for the VirtualMCPServer.
+func (r *VirtualMCPServerReconciler) ensureServiceAccountForVirtualMCPServer(
+	ctx context.Context,
+	vmcp *mcpv1alpha1.VirtualMCPServer,
+	resourceName string,
+) error {
+	ctxLogger := log.FromContext(ctx)
+
+	serviceAccount := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      resourceName,
+			Namespace: vmcp.Namespace,
+		},
+	}
+
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		result, err := controllerutil.CreateOrUpdate(ctx, r.Client, serviceAccount, func() error {
+			serviceAccount.Labels = labelsForVirtualMCPServerRBAC(vmcp, resourceName)
+			return controllerutil.SetControllerReference(vmcp, serviceAccount, r.Scheme)
+		})
+		if err != nil {
+			return err
+		}
+		ctxLogger.Info("ServiceAccount reconciled", "name", resourceName, "namespace", vmcp.Namespace, "result", result)
+		return nil
+	})
+
+	if err != nil {
+		return fmt.Errorf("failed to ensure ServiceAccount: %w", err)
+	}
+	return nil
+}
+
+// ensureRoleForVirtualMCPServer ensures the Role exists for the VirtualMCPServer.
+func (r *VirtualMCPServerReconciler) ensureRoleForVirtualMCPServer(
+	ctx context.Context,
+	vmcp *mcpv1alpha1.VirtualMCPServer,
+	resourceName string,
+) error {
+	ctxLogger := log.FromContext(ctx)
+
+	role := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      resourceName,
+			Namespace: vmcp.Namespace,
+		},
+	}
+
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		result, err := controllerutil.CreateOrUpdate(ctx, r.Client, role, func() error {
+			role.Labels = labelsForVirtualMCPServerRBAC(vmcp, resourceName)
+			role.Rules = vmcpRBACRules
+			return controllerutil.SetControllerReference(vmcp, role, r.Scheme)
+		})
+		if err != nil {
+			return err
+		}
+		ctxLogger.Info("Role reconciled", "name", resourceName, "namespace", vmcp.Namespace, "result", result)
+		return nil
+	})
+
+	if err != nil {
+		return fmt.Errorf("failed to ensure Role: %w", err)
+	}
+	return nil
+}
+
+// ensureRoleBindingForVirtualMCPServer ensures the RoleBinding exists for the VirtualMCPServer.
+func (r *VirtualMCPServerReconciler) ensureRoleBindingForVirtualMCPServer(
+	ctx context.Context,
+	vmcp *mcpv1alpha1.VirtualMCPServer,
+	resourceName string,
+) error {
+	ctxLogger := log.FromContext(ctx)
+
+	roleBinding := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      resourceName,
+			Namespace: vmcp.Namespace,
+		},
+	}
+
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		result, err := controllerutil.CreateOrUpdate(ctx, r.Client, roleBinding, func() error {
+			roleBinding.Labels = labelsForVirtualMCPServerRBAC(vmcp, resourceName)
+			// RoleRef is immutable after creation, but CreateOrUpdate handles this
+			if roleBinding.CreationTimestamp.IsZero() {
+				roleBinding.RoleRef = rbacv1.RoleRef{
+					APIGroup: "rbac.authorization.k8s.io",
+					Kind:     "Role",
+					Name:     resourceName,
+				}
+			}
+			roleBinding.Subjects = []rbacv1.Subject{
+				{
+					Kind:      "ServiceAccount",
+					Name:      resourceName,
+					Namespace: vmcp.Namespace,
+				},
+			}
+			return controllerutil.SetControllerReference(vmcp, roleBinding, r.Scheme)
+		})
+		if err != nil {
+			return err
+		}
+		ctxLogger.Info("RoleBinding reconciled", "name", resourceName, "namespace", vmcp.Namespace, "result", result)
+		return nil
+	})
+
+	if err != nil {
+		return fmt.Errorf("failed to ensure RoleBinding: %w", err)
+	}
+	return nil
+}
+
+// labelsForVirtualMCPServerRBAC returns the labels for VirtualMCPServer RBAC resources.
+func labelsForVirtualMCPServerRBAC(vmcp *mcpv1alpha1.VirtualMCPServer, resourceName string) map[string]string {
+	return map[string]string{
+		"app.kubernetes.io/name":       "virtualmcpserver-rbac",
+		"app.kubernetes.io/instance":   resourceName,
+		"app.kubernetes.io/component":  "rbac",
+		"app.kubernetes.io/part-of":    "toolhive",
+		"app.kubernetes.io/managed-by": "toolhive-operator",
+		"toolhive.stacklok.dev/vmcp":   vmcp.Name,
+	}
+}

--- a/cmd/thv-operator/controllers/virtualmcpserver_rbac_test.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_rbac_test.go
@@ -1,0 +1,270 @@
+package controllers
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	mcpv1alpha1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1alpha1"
+)
+
+func createTestVirtualMCPServer() *mcpv1alpha1.VirtualMCPServer {
+	return &mcpv1alpha1.VirtualMCPServer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-vmcp",
+			Namespace: "test-namespace",
+			UID:       types.UID("test-uid"),
+		},
+		Spec: mcpv1alpha1.VirtualMCPServerSpec{
+			IncomingAuth: &mcpv1alpha1.IncomingAuthConfig{
+				Type: "anonymous",
+			},
+		},
+	}
+}
+
+func createTestSchemeForVMCP() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	_ = mcpv1alpha1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+	_ = rbacv1.AddToScheme(scheme)
+	return scheme
+}
+
+func TestEnsureRBACResourcesForVirtualMCPServer(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		vmcp          *mcpv1alpha1.VirtualMCPServer
+		setupClient   func(*testing.T) client.Client
+		expectedError string
+		validate      func(*testing.T, client.Client, *mcpv1alpha1.VirtualMCPServer)
+	}{
+		{
+			name: "creates all RBAC resources when none exist",
+			vmcp: createTestVirtualMCPServer(),
+			setupClient: func(t *testing.T) client.Client {
+				t.Helper()
+				return fake.NewClientBuilder().WithScheme(createTestSchemeForVMCP()).Build()
+			},
+			validate: func(t *testing.T, c client.Client, vmcp *mcpv1alpha1.VirtualMCPServer) {
+				t.Helper()
+				ctx := context.Background()
+				resourceName := vmcpServiceAccountName(vmcp.Name)
+
+				// Verify ServiceAccount
+				sa := &corev1.ServiceAccount{}
+				err := c.Get(ctx, types.NamespacedName{Name: resourceName, Namespace: vmcp.Namespace}, sa)
+				require.NoError(t, err)
+				require.Len(t, sa.OwnerReferences, 1)
+				assert.Equal(t, vmcp.Name, sa.OwnerReferences[0].Name)
+				assert.Equal(t, labelsForVirtualMCPServerRBAC(vmcp, resourceName), sa.Labels)
+
+				// Verify Role
+				role := &rbacv1.Role{}
+				err = c.Get(ctx, types.NamespacedName{Name: resourceName, Namespace: vmcp.Namespace}, role)
+				require.NoError(t, err)
+				assert.Equal(t, vmcpRBACRules, role.Rules)
+				require.Len(t, role.OwnerReferences, 1)
+				assert.Equal(t, vmcp.Name, role.OwnerReferences[0].Name)
+				assert.Equal(t, labelsForVirtualMCPServerRBAC(vmcp, resourceName), role.Labels)
+
+				// Verify RoleBinding
+				rb := &rbacv1.RoleBinding{}
+				err = c.Get(ctx, types.NamespacedName{Name: resourceName, Namespace: vmcp.Namespace}, rb)
+				require.NoError(t, err)
+				assert.Equal(t, resourceName, rb.RoleRef.Name)
+				assert.Equal(t, "Role", rb.RoleRef.Kind)
+				require.Len(t, rb.Subjects, 1)
+				assert.Equal(t, resourceName, rb.Subjects[0].Name)
+				require.Len(t, rb.OwnerReferences, 1)
+				assert.Equal(t, vmcp.Name, rb.OwnerReferences[0].Name)
+				assert.Equal(t, labelsForVirtualMCPServerRBAC(vmcp, resourceName), rb.Labels)
+			},
+		},
+		{
+			name: "is idempotent with existing resources",
+			vmcp: createTestVirtualMCPServer(),
+			setupClient: func(t *testing.T) client.Client {
+				t.Helper()
+				vmcp := createTestVirtualMCPServer()
+				resourceName := vmcpServiceAccountName(vmcp.Name)
+				return fake.NewClientBuilder().
+					WithScheme(createTestSchemeForVMCP()).
+					WithObjects(
+						&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: resourceName, Namespace: vmcp.Namespace}},
+						&rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: resourceName, Namespace: vmcp.Namespace}, Rules: vmcpRBACRules},
+						&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: resourceName, Namespace: vmcp.Namespace}, RoleRef: rbacv1.RoleRef{APIGroup: "rbac.authorization.k8s.io", Kind: "Role", Name: resourceName}},
+					).Build()
+			},
+			validate: func(t *testing.T, c client.Client, vmcp *mcpv1alpha1.VirtualMCPServer) {
+				t.Helper()
+				ctx := context.Background()
+				resourceName := vmcpServiceAccountName(vmcp.Name)
+				role := &rbacv1.Role{}
+				require.NoError(t, c.Get(ctx, types.NamespacedName{Name: resourceName, Namespace: vmcp.Namespace}, role))
+			},
+		},
+		{
+			name: "updates RBAC rules when they change",
+			vmcp: createTestVirtualMCPServer(),
+			setupClient: func(t *testing.T) client.Client {
+				t.Helper()
+				vmcp := createTestVirtualMCPServer()
+				resourceName := vmcpServiceAccountName(vmcp.Name)
+				oldRules := []rbacv1.PolicyRule{
+					{
+						APIGroups: []string{""},
+						Resources: []string{"configmaps"},
+						Verbs:     []string{"get"},
+					},
+				}
+				return fake.NewClientBuilder().
+					WithScheme(createTestSchemeForVMCP()).
+					WithObjects(
+						&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: resourceName, Namespace: vmcp.Namespace}},
+						&rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: resourceName, Namespace: vmcp.Namespace}, Rules: oldRules},
+						&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: resourceName, Namespace: vmcp.Namespace}, RoleRef: rbacv1.RoleRef{APIGroup: "rbac.authorization.k8s.io", Kind: "Role", Name: resourceName}},
+					).Build()
+			},
+			validate: func(t *testing.T, c client.Client, vmcp *mcpv1alpha1.VirtualMCPServer) {
+				t.Helper()
+				ctx := context.Background()
+				resourceName := vmcpServiceAccountName(vmcp.Name)
+				role := &rbacv1.Role{}
+				require.NoError(t, c.Get(ctx, types.NamespacedName{Name: resourceName, Namespace: vmcp.Namespace}, role))
+				// Verify that the rules have been updated to match vmcpRBACRules
+				assert.Equal(t, vmcpRBACRules, role.Rules)
+			},
+		},
+		{
+			name: "returns error when ServiceAccount creation fails",
+			vmcp: createTestVirtualMCPServer(),
+			setupClient: func(t *testing.T) client.Client {
+				t.Helper()
+				return fake.NewClientBuilder().
+					WithScheme(createTestSchemeForVMCP()).
+					WithInterceptorFuncs(interceptor.Funcs{
+						Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+							if _, ok := obj.(*corev1.ServiceAccount); ok {
+								return errors.New("simulated failure")
+							}
+							return c.Create(ctx, obj, opts...)
+						},
+					}).Build()
+			},
+			expectedError: "failed to ensure service account",
+		},
+		{
+			name: "returns error when Role creation fails",
+			vmcp: createTestVirtualMCPServer(),
+			setupClient: func(t *testing.T) client.Client {
+				t.Helper()
+				return fake.NewClientBuilder().
+					WithScheme(createTestSchemeForVMCP()).
+					WithInterceptorFuncs(interceptor.Funcs{
+						Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+							if _, ok := obj.(*rbacv1.Role); ok {
+								return errors.New("simulated failure")
+							}
+							return c.Create(ctx, obj, opts...)
+						},
+					}).Build()
+			},
+			expectedError: "failed to ensure role",
+		},
+		{
+			name: "returns error when RoleBinding creation fails",
+			vmcp: createTestVirtualMCPServer(),
+			setupClient: func(t *testing.T) client.Client {
+				t.Helper()
+				return fake.NewClientBuilder().
+					WithScheme(createTestSchemeForVMCP()).
+					WithInterceptorFuncs(interceptor.Funcs{
+						Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+							if _, ok := obj.(*rbacv1.RoleBinding); ok {
+								return errors.New("simulated failure")
+							}
+							return c.Create(ctx, obj, opts...)
+						},
+					}).Build()
+			},
+			expectedError: "failed to ensure role binding",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			c := tt.setupClient(t)
+			r := &VirtualMCPServerReconciler{
+				Client: c,
+				Scheme: createTestSchemeForVMCP(),
+			}
+
+			err := r.ensureRBACResourcesForVirtualMCPServer(context.Background(), tt.vmcp)
+
+			if tt.expectedError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedError)
+			} else {
+				require.NoError(t, err)
+				if tt.validate != nil {
+					tt.validate(t, c, tt.vmcp)
+				}
+			}
+		})
+	}
+}
+
+func TestVmcpRBACRules(t *testing.T) {
+	t.Parallel()
+
+	require.Len(t, vmcpRBACRules, 3)
+
+	// Core resources (ConfigMaps and Secrets)
+	assert.ElementsMatch(t, []string{""}, vmcpRBACRules[0].APIGroups)
+	assert.ElementsMatch(t, []string{"configmaps", "secrets"}, vmcpRBACRules[0].Resources)
+	assert.ElementsMatch(t, []string{"get", "list", "watch"}, vmcpRBACRules[0].Verbs)
+
+	// ToolHive resources for backend discovery
+	assert.ElementsMatch(t, []string{"toolhive.stacklok.dev"}, vmcpRBACRules[1].APIGroups)
+	assert.ElementsMatch(t, []string{"mcpgroups", "mcpservers", "mcpremoteproxies", "mcpexternalauthconfigs", "mcptoolconfigs"}, vmcpRBACRules[1].Resources)
+	assert.ElementsMatch(t, []string{"get", "list", "watch"}, vmcpRBACRules[1].Verbs)
+
+	// Status update permissions
+	assert.ElementsMatch(t, []string{"toolhive.stacklok.dev"}, vmcpRBACRules[2].APIGroups)
+	assert.ElementsMatch(t, []string{"virtualmcpservers/status"}, vmcpRBACRules[2].Resources)
+	assert.ElementsMatch(t, []string{"update", "patch"}, vmcpRBACRules[2].Verbs)
+}
+
+func TestLabelsForVirtualMCPServerRBAC(t *testing.T) {
+	t.Parallel()
+
+	vmcp := createTestVirtualMCPServer()
+	resourceName := vmcpServiceAccountName(vmcp.Name)
+	labels := labelsForVirtualMCPServerRBAC(vmcp, resourceName)
+
+	expectedLabels := map[string]string{
+		"app.kubernetes.io/name":       "virtualmcpserver-rbac",
+		"app.kubernetes.io/instance":   resourceName,
+		"app.kubernetes.io/component":  "rbac",
+		"app.kubernetes.io/part-of":    "toolhive",
+		"app.kubernetes.io/managed-by": "toolhive-operator",
+		"toolhive.stacklok.dev/vmcp":   vmcp.Name,
+	}
+
+	assert.Equal(t, expectedLabels, labels)
+}


### PR DESCRIPTION
Replace EnsureRBACResource helper with CreateOrUpdate + RetryOnConflict pattern for VirtualMCPServer RBAC management. This addresses the limitation where RBAC resources were only created but never updated during operator upgrades.

Related-to: #3003