### PR TITLE
Add SPDX license headers to all Go files

### DIFF
--- a/.github/license-header.txt
+++ b/.github/license-header.txt
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+SPDX-License-Identifier: Apache-2.0

--- a/.github/workflows/license-headers.yml
+++ b/.github/workflows/license-headers.yml
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+name: License Headers
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  check-license-headers:
+    name: Check License Headers
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+
+      - name: Set up Go
+        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6
+        with:
+          go-version-file: 'go.mod'
+          cache: false
+
+      - name: Install addlicense
+        run: go install github.com/google/addlicense@latest
+
+      - name: Check license headers
+        run: |
+          # Check all Go files for SPDX license headers
+          # Using -check flag to only verify, not modify files
+          addlicense -check \
+            -f .github/license-header.txt \
+            -ignore '**/mocks/**' \
+            -ignore '**/testdata/**' \
+            -ignore 'vendor/**' \
+            -ignore '**/*.pb.go' \
+            -ignore '**/zz_generated*.go' \
+            $(find . -name '*.go' -type f)

--- a/.github/workflows/run-on-pr.yml
+++ b/.github/workflows/run-on-pr.yml
@@ -14,6 +14,9 @@ jobs:
   spellcheck:
     name: Spellcheck
     uses: ./.github/workflows/spellcheck.yml
+  license-headers:
+    name: License Headers
+    uses: ./.github/workflows/license-headers.yml
   linting:
     name: Linting
     uses: ./.github/workflows/lint.yml

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -38,6 +38,25 @@ tasks:
     cmds:
       - go generate ./...
 
+  addlicense-install:
+    desc: Install the addlicense tool for license header management
+    status:
+      - which addlicense
+    cmds:
+      - go install github.com/google/addlicense@latest
+
+  license-check:
+    desc: Check that all Go files have proper SPDX license headers
+    deps: [addlicense-install]
+    cmds:
+      - addlicense -check -f .github/license-header.txt -ignore '**/mocks/**' -ignore '**/testdata/**' -ignore 'vendor/**' -ignore '**/*.pb.go' -ignore '**/zz_generated*.go' $(find . -name '*.go' -type f)
+
+  license-fix:
+    desc: Add SPDX license headers to Go files that are missing them
+    deps: [addlicense-install]
+    cmds:
+      - addlicense -f .github/license-header.txt -ignore '**/mocks/**' -ignore '**/testdata/**' -ignore 'vendor/**' -ignore '**/*.pb.go' -ignore '**/zz_generated*.go' $(find . -name '*.go' -type f)
+
   lint:
     desc: Run linting tools
     cmds:

--- a/cmd/help/main.go
+++ b/cmd/help/main.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package main is the entry point for the ToolHive CLI Doc Generator.
 package main
 

--- a/cmd/regup/app/root.go
+++ b/cmd/regup/app/root.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package app provides the entry point for the regup command-line application.
 package app
 

--- a/cmd/regup/app/update.go
+++ b/cmd/regup/app/update.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package app
 
 import (

--- a/cmd/regup/app/update_test.go
+++ b/cmd/regup/app/update_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package app
 
 import (

--- a/cmd/regup/main.go
+++ b/cmd/regup/main.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package main is the entry point for the regup command
 package main
 

--- a/cmd/thv-operator/api/v1alpha1/groupversion_info.go
+++ b/cmd/thv-operator/api/v1alpha1/groupversion_info.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package v1alpha1 contains API Schema definitions for the toolhive v1alpha1 API group
 // +kubebuilder:object:generate=true
 // +groupName=toolhive.stacklok.dev

--- a/cmd/thv-operator/api/v1alpha1/mcpexternalauthconfig_types.go
+++ b/cmd/thv-operator/api/v1alpha1/mcpexternalauthconfig_types.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package v1alpha1
 
 import (

--- a/cmd/thv-operator/api/v1alpha1/mcpexternalauthconfig_webhook.go
+++ b/cmd/thv-operator/api/v1alpha1/mcpexternalauthconfig_webhook.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package v1alpha1
 
 import (

--- a/cmd/thv-operator/api/v1alpha1/mcpexternalauthconfig_webhook_test.go
+++ b/cmd/thv-operator/api/v1alpha1/mcpexternalauthconfig_webhook_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package v1alpha1
 
 import (

--- a/cmd/thv-operator/api/v1alpha1/mcpgroup_types.go
+++ b/cmd/thv-operator/api/v1alpha1/mcpgroup_types.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package v1alpha1
 
 import (

--- a/cmd/thv-operator/api/v1alpha1/mcpregistry_types.go
+++ b/cmd/thv-operator/api/v1alpha1/mcpregistry_types.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package v1alpha1
 
 import (

--- a/cmd/thv-operator/api/v1alpha1/mcpregistry_types_test.go
+++ b/cmd/thv-operator/api/v1alpha1/mcpregistry_types_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package v1alpha1
 
 import (

--- a/cmd/thv-operator/api/v1alpha1/mcpremoteproxy_types.go
+++ b/cmd/thv-operator/api/v1alpha1/mcpremoteproxy_types.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package v1alpha1
 
 import (

--- a/cmd/thv-operator/api/v1alpha1/mcpserver_types.go
+++ b/cmd/thv-operator/api/v1alpha1/mcpserver_types.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package v1alpha1
 
 import (

--- a/cmd/thv-operator/api/v1alpha1/toolconfig_types.go
+++ b/cmd/thv-operator/api/v1alpha1/toolconfig_types.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package v1alpha1
 
 import (

--- a/cmd/thv-operator/api/v1alpha1/virtualmcpcompositetooldefinition_types.go
+++ b/cmd/thv-operator/api/v1alpha1/virtualmcpcompositetooldefinition_types.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package v1alpha1
 
 import (

--- a/cmd/thv-operator/api/v1alpha1/virtualmcpcompositetooldefinition_webhook.go
+++ b/cmd/thv-operator/api/v1alpha1/virtualmcpcompositetooldefinition_webhook.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package v1alpha1
 
 import (

--- a/cmd/thv-operator/api/v1alpha1/virtualmcpcompositetooldefinition_webhook_test.go
+++ b/cmd/thv-operator/api/v1alpha1/virtualmcpcompositetooldefinition_webhook_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package v1alpha1
 
 import (

--- a/cmd/thv-operator/api/v1alpha1/virtualmcpserver_types.go
+++ b/cmd/thv-operator/api/v1alpha1/virtualmcpserver_types.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package v1alpha1
 
 import (

--- a/cmd/thv-operator/api/v1alpha1/virtualmcpserver_types_test.go
+++ b/cmd/thv-operator/api/v1alpha1/virtualmcpserver_types_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package v1alpha1
 
 import (

--- a/cmd/thv-operator/api/v1alpha1/virtualmcpserver_webhook.go
+++ b/cmd/thv-operator/api/v1alpha1/virtualmcpserver_webhook.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package v1alpha1
 
 import (

--- a/cmd/thv-operator/api/v1alpha1/virtualmcpserver_webhook_test.go
+++ b/cmd/thv-operator/api/v1alpha1/virtualmcpserver_webhook_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package v1alpha1
 
 import (

--- a/cmd/thv-operator/controllers/helpers_test.go
+++ b/cmd/thv-operator/controllers/helpers_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package controllers
 
 import (

--- a/cmd/thv-operator/controllers/mcpexternalauthconfig_controller.go
+++ b/cmd/thv-operator/controllers/mcpexternalauthconfig_controller.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package controllers
 
 import (

--- a/cmd/thv-operator/controllers/mcpexternalauthconfig_controller_test.go
+++ b/cmd/thv-operator/controllers/mcpexternalauthconfig_controller_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package controllers
 
 import (

--- a/cmd/thv-operator/controllers/mcpgroup_controller.go
+++ b/cmd/thv-operator/controllers/mcpgroup_controller.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package controllers
 
 import (

--- a/cmd/thv-operator/controllers/mcpgroup_controller_test.go
+++ b/cmd/thv-operator/controllers/mcpgroup_controller_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package controllers
 
 import (

--- a/cmd/thv-operator/controllers/mcpregistry_controller.go
+++ b/cmd/thv-operator/controllers/mcpregistry_controller.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package controllers
 
 import (

--- a/cmd/thv-operator/controllers/mcpremoteproxy_controller.go
+++ b/cmd/thv-operator/controllers/mcpremoteproxy_controller.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package controllers contains the reconciliation logic for the MCPRemoteProxy custom resource.
 // It handles the creation, update, and deletion of remote MCP proxies in Kubernetes.
 package controllers

--- a/cmd/thv-operator/controllers/mcpremoteproxy_deployment.go
+++ b/cmd/thv-operator/controllers/mcpremoteproxy_deployment.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package controllers
 
 import (

--- a/cmd/thv-operator/controllers/mcpremoteproxy_runconfig.go
+++ b/cmd/thv-operator/controllers/mcpremoteproxy_runconfig.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package controllers
 
 import (

--- a/cmd/thv-operator/controllers/mcpserver_authz_test.go
+++ b/cmd/thv-operator/controllers/mcpserver_authz_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package controllers
 
 import (

--- a/cmd/thv-operator/controllers/mcpserver_controller.go
+++ b/cmd/thv-operator/controllers/mcpserver_controller.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package controllers contains the reconciliation logic for the MCPServer custom resource.
 // It handles the creation, update, and deletion of MCP servers in Kubernetes.
 package controllers

--- a/cmd/thv-operator/controllers/mcpserver_groupref_test.go
+++ b/cmd/thv-operator/controllers/mcpserver_groupref_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package controllers
 
 import (

--- a/cmd/thv-operator/controllers/mcpserver_invalid_podtemplate_reconcile_test.go
+++ b/cmd/thv-operator/controllers/mcpserver_invalid_podtemplate_reconcile_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package controllers
 
 import (

--- a/cmd/thv-operator/controllers/mcpserver_platform_test.go
+++ b/cmd/thv-operator/controllers/mcpserver_platform_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package controllers
 
 import (

--- a/cmd/thv-operator/controllers/mcpserver_pod_template_test.go
+++ b/cmd/thv-operator/controllers/mcpserver_pod_template_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package controllers
 
 import (

--- a/cmd/thv-operator/controllers/mcpserver_podtemplatespec_builder_test.go
+++ b/cmd/thv-operator/controllers/mcpserver_podtemplatespec_builder_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package controllers
 
 import (

--- a/cmd/thv-operator/controllers/mcpserver_rbac_test.go
+++ b/cmd/thv-operator/controllers/mcpserver_rbac_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package controllers
 
 import (

--- a/cmd/thv-operator/controllers/mcpserver_restart_test.go
+++ b/cmd/thv-operator/controllers/mcpserver_restart_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package controllers
 
 import (

--- a/cmd/thv-operator/controllers/mcpserver_runconfig.go
+++ b/cmd/thv-operator/controllers/mcpserver_runconfig.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package controllers
 
 import (

--- a/cmd/thv-operator/controllers/mcpserver_runconfig_test.go
+++ b/cmd/thv-operator/controllers/mcpserver_runconfig_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package controllers
 
 import (

--- a/cmd/thv-operator/controllers/mcpserver_test_helpers_test.go
+++ b/cmd/thv-operator/controllers/mcpserver_test_helpers_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package controllers
 
 import (

--- a/cmd/thv-operator/controllers/toolconfig_controller.go
+++ b/cmd/thv-operator/controllers/toolconfig_controller.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package controllers
 
 import (

--- a/cmd/thv-operator/controllers/toolconfig_controller_edge_cases_test.go
+++ b/cmd/thv-operator/controllers/toolconfig_controller_edge_cases_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package controllers
 
 import (

--- a/cmd/thv-operator/controllers/toolconfig_controller_test.go
+++ b/cmd/thv-operator/controllers/toolconfig_controller_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package controllers
 
 import (

--- a/cmd/thv-operator/controllers/virtualmcpserver_controller.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_controller.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package controllers contains the reconciliation logic for the VirtualMCPServer custom resource.
 // It handles the creation, update, and deletion of Virtual MCP Servers in Kubernetes.
 package controllers

--- a/cmd/thv-operator/controllers/virtualmcpserver_deployment.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_deployment.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package controllers
 
 import (

--- a/cmd/thv-operator/controllers/virtualmcpserver_podtemplatespec_reconcile_test.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_podtemplatespec_reconcile_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package controllers
 
 import (

--- a/cmd/thv-operator/controllers/virtualmcpserver_podtemplatespec_test.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_podtemplatespec_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package controllers
 
 import (

--- a/cmd/thv-operator/controllers/virtualmcpserver_vmcpconfig.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_vmcpconfig.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package controllers
 
 import (

--- a/cmd/thv-operator/main.go
+++ b/cmd/thv-operator/main.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package main is the entry point for the ToolHive Kubernetes Operator.
 // It sets up and runs the controller manager for the MCPServer custom resource.
 package main

--- a/cmd/thv-operator/main_test.go
+++ b/cmd/thv-operator/main_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package main
 
 import (

--- a/cmd/thv-operator/pkg/controllerutil/authz.go
+++ b/cmd/thv-operator/pkg/controllerutil/authz.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package controllerutil provides utility functions for the ToolHive Kubernetes operator controllers.
 package controllerutil
 

--- a/cmd/thv-operator/pkg/controllerutil/authz_test.go
+++ b/cmd/thv-operator/pkg/controllerutil/authz_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package controllerutil
 
 import (

--- a/cmd/thv-operator/pkg/controllerutil/config.go
+++ b/cmd/thv-operator/pkg/controllerutil/config.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package controllerutil
 
 import (

--- a/cmd/thv-operator/pkg/controllerutil/config_test.go
+++ b/cmd/thv-operator/pkg/controllerutil/config_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package controllerutil
 
 import (

--- a/cmd/thv-operator/pkg/controllerutil/doc.go
+++ b/cmd/thv-operator/pkg/controllerutil/doc.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package controllerutil provides shared utility functions for ToolHive Kubernetes controllers.
 //
 // This package contains helper functions extracted from the controllers package to improve

--- a/cmd/thv-operator/pkg/controllerutil/externalauth.go
+++ b/cmd/thv-operator/pkg/controllerutil/externalauth.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package controllerutil provides utility functions for Kubernetes controllers.
 package controllerutil
 

--- a/cmd/thv-operator/pkg/controllerutil/externalauth_test.go
+++ b/cmd/thv-operator/pkg/controllerutil/externalauth_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package controllerutil
 
 import (

--- a/cmd/thv-operator/pkg/controllerutil/oidc.go
+++ b/cmd/thv-operator/pkg/controllerutil/oidc.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package controllerutil
 
 import (

--- a/cmd/thv-operator/pkg/controllerutil/oidc_test.go
+++ b/cmd/thv-operator/pkg/controllerutil/oidc_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package controllerutil
 
 import (

--- a/cmd/thv-operator/pkg/controllerutil/platform.go
+++ b/cmd/thv-operator/pkg/controllerutil/platform.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package controllerutil
 
 import (

--- a/cmd/thv-operator/pkg/controllerutil/podtemplatespec_builder.go
+++ b/cmd/thv-operator/pkg/controllerutil/podtemplatespec_builder.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package controllerutil provides shared utilities for ToolHive Kubernetes controllers.
 package controllerutil
 

--- a/cmd/thv-operator/pkg/controllerutil/podtemplatespec_builder_test.go
+++ b/cmd/thv-operator/pkg/controllerutil/podtemplatespec_builder_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package controllerutil
 
 import (

--- a/cmd/thv-operator/pkg/controllerutil/rbac.go
+++ b/cmd/thv-operator/pkg/controllerutil/rbac.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package controllerutil
 
 import (

--- a/cmd/thv-operator/pkg/controllerutil/resources.go
+++ b/cmd/thv-operator/pkg/controllerutil/resources.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package controllerutil
 
 import (

--- a/cmd/thv-operator/pkg/controllerutil/tokenexchange.go
+++ b/cmd/thv-operator/pkg/controllerutil/tokenexchange.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package controllerutil
 
 import (

--- a/cmd/thv-operator/pkg/controllerutil/tools_config.go
+++ b/cmd/thv-operator/pkg/controllerutil/tools_config.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package controllerutil
 
 import (

--- a/cmd/thv-operator/pkg/controllerutil/tools_config_test.go
+++ b/cmd/thv-operator/pkg/controllerutil/tools_config_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package controllerutil
 
 import (

--- a/cmd/thv-operator/pkg/git/client.go
+++ b/cmd/thv-operator/pkg/git/client.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package git
 
 import (

--- a/cmd/thv-operator/pkg/git/client_test.go
+++ b/cmd/thv-operator/pkg/git/client_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package git
 
 import (

--- a/cmd/thv-operator/pkg/git/commit_test.go
+++ b/cmd/thv-operator/pkg/git/commit_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package git
 
 import (

--- a/cmd/thv-operator/pkg/git/doc.go
+++ b/cmd/thv-operator/pkg/git/doc.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package git provides Git repository operations for MCPRegistry sources.
 //
 // This package implements a thin wrapper around the go-git library to enable

--- a/cmd/thv-operator/pkg/git/integration_test.go
+++ b/cmd/thv-operator/pkg/git/integration_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package git
 
 import (

--- a/cmd/thv-operator/pkg/git/types.go
+++ b/cmd/thv-operator/pkg/git/types.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package git
 
 import (

--- a/cmd/thv-operator/pkg/git/types_test.go
+++ b/cmd/thv-operator/pkg/git/types_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package git
 
 import (

--- a/cmd/thv-operator/pkg/httpclient/client.go
+++ b/cmd/thv-operator/pkg/httpclient/client.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package httpclient provides HTTP client functionality for API operations
 package httpclient
 

--- a/cmd/thv-operator/pkg/httpclient/client_test.go
+++ b/cmd/thv-operator/pkg/httpclient/client_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package httpclient_test
 
 import (

--- a/cmd/thv-operator/pkg/kubernetes/client.go
+++ b/cmd/thv-operator/pkg/kubernetes/client.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package kubernetes
 
 import (

--- a/cmd/thv-operator/pkg/kubernetes/configmaps/configmaps.go
+++ b/cmd/thv-operator/pkg/kubernetes/configmaps/configmaps.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package configmaps
 
 import (

--- a/cmd/thv-operator/pkg/kubernetes/configmaps/configmaps_test.go
+++ b/cmd/thv-operator/pkg/kubernetes/configmaps/configmaps_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package configmaps
 
 import (

--- a/cmd/thv-operator/pkg/kubernetes/configmaps/doc.go
+++ b/cmd/thv-operator/pkg/kubernetes/configmaps/doc.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package configmaps provides convenience methods for working with Kubernetes ConfigMaps.
 //
 // This package provides a Client that wraps the controller-runtime client

--- a/cmd/thv-operator/pkg/kubernetes/doc.go
+++ b/cmd/thv-operator/pkg/kubernetes/doc.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package kubernetes provides utilities for working with Kubernetes resources.
 //
 // This package provides a unified Client that composes domain-specific clients

--- a/cmd/thv-operator/pkg/kubernetes/secrets/doc.go
+++ b/cmd/thv-operator/pkg/kubernetes/secrets/doc.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package secrets provides utilities for working with Kubernetes Secrets.
 //
 // This package offers a Client that wraps the controller-runtime client

--- a/cmd/thv-operator/pkg/kubernetes/secrets/secrets.go
+++ b/cmd/thv-operator/pkg/kubernetes/secrets/secrets.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package secrets
 
 import (

--- a/cmd/thv-operator/pkg/kubernetes/secrets/secrets_test.go
+++ b/cmd/thv-operator/pkg/kubernetes/secrets/secrets_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package secrets
 
 import (

--- a/cmd/thv-operator/pkg/mcpregistrystatus/collector.go
+++ b/cmd/thv-operator/pkg/mcpregistrystatus/collector.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package mcpregistrystatus provides status management and batched updates for MCPRegistry resources.
 package mcpregistrystatus
 

--- a/cmd/thv-operator/pkg/mcpregistrystatus/collector_test.go
+++ b/cmd/thv-operator/pkg/mcpregistrystatus/collector_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package mcpregistrystatus
 
 import (

--- a/cmd/thv-operator/pkg/mcpregistrystatus/deriver.go
+++ b/cmd/thv-operator/pkg/mcpregistrystatus/deriver.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package mcpregistrystatus provides status management for MCPRegistry resources.
 package mcpregistrystatus
 

--- a/cmd/thv-operator/pkg/mcpregistrystatus/deriver_test.go
+++ b/cmd/thv-operator/pkg/mcpregistrystatus/deriver_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package mcpregistrystatus
 
 import (

--- a/cmd/thv-operator/pkg/mcpregistrystatus/types.go
+++ b/cmd/thv-operator/pkg/mcpregistrystatus/types.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package mcpregistrystatus provides status management for MCPRegistry resources.
 package mcpregistrystatus
 

--- a/cmd/thv-operator/pkg/mcpregistrystatus/types_test.go
+++ b/cmd/thv-operator/pkg/mcpregistrystatus/types_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package mcpregistrystatus
 
 import (

--- a/cmd/thv-operator/pkg/oidc/resolver.go
+++ b/cmd/thv-operator/pkg/oidc/resolver.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package oidc provides utilities for resolving OIDC configuration from various sources
 // including Kubernetes service accounts, ConfigMaps, and inline configurations.
 package oidc

--- a/cmd/thv-operator/pkg/oidc/resolver_test.go
+++ b/cmd/thv-operator/pkg/oidc/resolver_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package oidc
 
 import (

--- a/cmd/thv-operator/pkg/registryapi/config/config.go
+++ b/cmd/thv-operator/pkg/registryapi/config/config.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package config provides management for the registry server configuration
 package config
 

--- a/cmd/thv-operator/pkg/registryapi/config/config_test.go
+++ b/cmd/thv-operator/pkg/registryapi/config/config_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package config
 
 import (

--- a/cmd/thv-operator/pkg/registryapi/deployment.go
+++ b/cmd/thv-operator/pkg/registryapi/deployment.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package registryapi provides deployment management for the registry API component.
 package registryapi
 

--- a/cmd/thv-operator/pkg/registryapi/deployment_test.go
+++ b/cmd/thv-operator/pkg/registryapi/deployment_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package registryapi
 
 import (

--- a/cmd/thv-operator/pkg/registryapi/manager.go
+++ b/cmd/thv-operator/pkg/registryapi/manager.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package registryapi
 
 import (

--- a/cmd/thv-operator/pkg/registryapi/manager_test.go
+++ b/cmd/thv-operator/pkg/registryapi/manager_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package registryapi
 
 import (

--- a/cmd/thv-operator/pkg/registryapi/pgpass.go
+++ b/cmd/thv-operator/pkg/registryapi/pgpass.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package registryapi
 
 import (

--- a/cmd/thv-operator/pkg/registryapi/pgpass_test.go
+++ b/cmd/thv-operator/pkg/registryapi/pgpass_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package registryapi
 
 import (

--- a/cmd/thv-operator/pkg/registryapi/podtemplatespec.go
+++ b/cmd/thv-operator/pkg/registryapi/podtemplatespec.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package registryapi provides deployment management for the registry API component.
 package registryapi
 

--- a/cmd/thv-operator/pkg/registryapi/podtemplatespec_test.go
+++ b/cmd/thv-operator/pkg/registryapi/podtemplatespec_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package registryapi
 
 import (

--- a/cmd/thv-operator/pkg/registryapi/rbac.go
+++ b/cmd/thv-operator/pkg/registryapi/rbac.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package registryapi
 
 import (

--- a/cmd/thv-operator/pkg/registryapi/rbac_test.go
+++ b/cmd/thv-operator/pkg/registryapi/rbac_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package registryapi
 
 import (

--- a/cmd/thv-operator/pkg/registryapi/service.go
+++ b/cmd/thv-operator/pkg/registryapi/service.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package registryapi
 
 import (

--- a/cmd/thv-operator/pkg/registryapi/service_test.go
+++ b/cmd/thv-operator/pkg/registryapi/service_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package registryapi
 
 import (

--- a/cmd/thv-operator/pkg/registryapi/types.go
+++ b/cmd/thv-operator/pkg/registryapi/types.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package registryapi
 
 import (

--- a/cmd/thv-operator/pkg/registryapi/types_test.go
+++ b/cmd/thv-operator/pkg/registryapi/types_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package registryapi
 
 import (

--- a/cmd/thv-operator/pkg/runconfig/audit.go
+++ b/cmd/thv-operator/pkg/runconfig/audit.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package runconfig provides functions to build RunConfigBuilder options for audit configuration.
 // Given the size of this file, it's probably better suited to merge with another. This can be
 // done when the runconfig has been fully moved into this package.

--- a/cmd/thv-operator/pkg/runconfig/audit_test.go
+++ b/cmd/thv-operator/pkg/runconfig/audit_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package runconfig provides functions to build RunConfigBuilder options for audit configuration.
 // Given the size of this file, it's probably better suited to merge with another. This can be
 // done when the runconfig has been fully moved into this package.

--- a/cmd/thv-operator/pkg/runconfig/configmap/checksum/checksum.go
+++ b/cmd/thv-operator/pkg/runconfig/configmap/checksum/checksum.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package checksum provides checksum computation and comparison for ConfigMaps
 package checksum
 

--- a/cmd/thv-operator/pkg/runconfig/configmap/checksum/checksum_test.go
+++ b/cmd/thv-operator/pkg/runconfig/configmap/checksum/checksum_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package checksum
 
 import (

--- a/cmd/thv-operator/pkg/runconfig/telemetry.go
+++ b/cmd/thv-operator/pkg/runconfig/telemetry.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package runconfig provides functions to build RunConfigBuilder options for telemetry configuration.
 package runconfig
 

--- a/cmd/thv-operator/pkg/runconfig/telemetry_test.go
+++ b/cmd/thv-operator/pkg/runconfig/telemetry_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package runconfig
 
 import (

--- a/cmd/thv-operator/pkg/spectoconfig/telemetry.go
+++ b/cmd/thv-operator/pkg/spectoconfig/telemetry.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package spectoconfig provides functionality to convert CRD Telemetry types into telemetry.Config.
 package spectoconfig
 

--- a/cmd/thv-operator/pkg/spectoconfig/telemetry_test.go
+++ b/cmd/thv-operator/pkg/spectoconfig/telemetry_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package spectoconfig
 
 import (

--- a/cmd/thv-operator/pkg/validation/image_validation.go
+++ b/cmd/thv-operator/pkg/validation/image_validation.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package validation provides image validation functionality for the ToolHive operator.
 package validation
 

--- a/cmd/thv-operator/pkg/validation/image_validation_test.go
+++ b/cmd/thv-operator/pkg/validation/image_validation_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package validation
 
 import (

--- a/cmd/thv-operator/pkg/virtualmcpserverstatus/collector.go
+++ b/cmd/thv-operator/pkg/virtualmcpserverstatus/collector.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package virtualmcpserverstatus provides status management and batched updates for VirtualMCPServer resources.
 package virtualmcpserverstatus
 

--- a/cmd/thv-operator/pkg/virtualmcpserverstatus/types.go
+++ b/cmd/thv-operator/pkg/virtualmcpserverstatus/types.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package virtualmcpserverstatus provides status management for VirtualMCPServer resources.
 package virtualmcpserverstatus
 

--- a/cmd/thv-operator/pkg/vmcpconfig/converter.go
+++ b/cmd/thv-operator/pkg/vmcpconfig/converter.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package vmcpconfig provides conversion logic from VirtualMCPServer CRD to vmcp Config
 package vmcpconfig
 

--- a/cmd/thv-operator/pkg/vmcpconfig/converter_test.go
+++ b/cmd/thv-operator/pkg/vmcpconfig/converter_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package vmcpconfig provides conversion logic from VirtualMCPServer CRD to vmcp Config
 package vmcpconfig
 

--- a/cmd/thv-operator/pkg/vmcpconfig/validator.go
+++ b/cmd/thv-operator/pkg/vmcpconfig/validator.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package vmcpconfig
 
 import (

--- a/cmd/thv-operator/test-integration/mcp-external-auth/mcpexternalauthconfig_controller_integration_test.go
+++ b/cmd/thv-operator/test-integration/mcp-external-auth/mcpexternalauthconfig_controller_integration_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package controllers contains integration tests for the MCPExternalAuthConfig controller
 package controllers
 

--- a/cmd/thv-operator/test-integration/mcp-external-auth/suite_test.go
+++ b/cmd/thv-operator/test-integration/mcp-external-auth/suite_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package controllers contains integration tests for the MCPExternalAuthConfig controller
 package controllers
 

--- a/cmd/thv-operator/test-integration/mcp-group/mcpgroup_controller_integration_test.go
+++ b/cmd/thv-operator/test-integration/mcp-group/mcpgroup_controller_integration_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package operator_test
 
 import (

--- a/cmd/thv-operator/test-integration/mcp-group/suite_test.go
+++ b/cmd/thv-operator/test-integration/mcp-group/suite_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package operator_test
 
 import (

--- a/cmd/thv-operator/test-integration/mcp-registry/configmap_helpers.go
+++ b/cmd/thv-operator/test-integration/mcp-registry/configmap_helpers.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package operator_test
 
 import (

--- a/cmd/thv-operator/test-integration/mcp-registry/doc.go
+++ b/cmd/thv-operator/test-integration/mcp-registry/doc.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package operator_test provides end-to-end tests for the ToolHive operator controllers.
 // This package tests MCPRegistry and other operator functionality using Ginkgo and Kubernetes APIs.
 package operator_test

--- a/cmd/thv-operator/test-integration/mcp-registry/k8s_helpers.go
+++ b/cmd/thv-operator/test-integration/mcp-registry/k8s_helpers.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package operator_test
 
 import (

--- a/cmd/thv-operator/test-integration/mcp-registry/pvc_source_test.go
+++ b/cmd/thv-operator/test-integration/mcp-registry/pvc_source_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package operator_test
 
 import (

--- a/cmd/thv-operator/test-integration/mcp-registry/registry_helpers.go
+++ b/cmd/thv-operator/test-integration/mcp-registry/registry_helpers.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package operator_test
 
 import (

--- a/cmd/thv-operator/test-integration/mcp-registry/registry_lifecycle_test.go
+++ b/cmd/thv-operator/test-integration/mcp-registry/registry_lifecycle_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package operator_test
 
 import (

--- a/cmd/thv-operator/test-integration/mcp-registry/registry_server_rbac_test.go
+++ b/cmd/thv-operator/test-integration/mcp-registry/registry_server_rbac_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package operator_test
 
 import (

--- a/cmd/thv-operator/test-integration/mcp-registry/registryserver_config_test.go
+++ b/cmd/thv-operator/test-integration/mcp-registry/registryserver_config_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package operator_test
 
 import (

--- a/cmd/thv-operator/test-integration/mcp-registry/status_helpers.go
+++ b/cmd/thv-operator/test-integration/mcp-registry/status_helpers.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package operator_test
 
 import (

--- a/cmd/thv-operator/test-integration/mcp-registry/suite_test.go
+++ b/cmd/thv-operator/test-integration/mcp-registry/suite_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package operator_test
 
 import (

--- a/cmd/thv-operator/test-integration/mcp-registry/timing_helpers.go
+++ b/cmd/thv-operator/test-integration/mcp-registry/timing_helpers.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package operator_test
 
 import (

--- a/cmd/thv-operator/test-integration/mcp-server/mcpserver_controller_integration_test.go
+++ b/cmd/thv-operator/test-integration/mcp-server/mcpserver_controller_integration_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package controllers contains integration tests for the MCPServer controller
 package controllers
 

--- a/cmd/thv-operator/test-integration/mcp-server/mcpserver_runconfig_integration_test.go
+++ b/cmd/thv-operator/test-integration/mcp-server/mcpserver_runconfig_integration_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package controllers contains integration tests for the RunConfig ConfigMap management
 package controllers
 

--- a/cmd/thv-operator/test-integration/mcp-server/suite_test.go
+++ b/cmd/thv-operator/test-integration/mcp-server/suite_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package controllers contains integration tests for the thv-operator controllers
 package controllers
 

--- a/cmd/thv-operator/test-integration/virtualmcp/suite_test.go
+++ b/cmd/thv-operator/test-integration/virtualmcp/suite_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package controllers contains integration tests for the VirtualMCPServer controller
 package controllers
 

--- a/cmd/thv-operator/test-integration/virtualmcp/virtualmcpserver_compositetool_watch_test.go
+++ b/cmd/thv-operator/test-integration/virtualmcp/virtualmcpserver_compositetool_watch_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package controllers contains integration tests for the VirtualMCPServer controller
 package controllers
 

--- a/cmd/thv-operator/test-integration/virtualmcp/virtualmcpserver_elicitation_integration_test.go
+++ b/cmd/thv-operator/test-integration/virtualmcp/virtualmcpserver_elicitation_integration_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package controllers contains integration tests for the VirtualMCPServer controller
 package controllers
 

--- a/cmd/thv-operator/test-integration/virtualmcp/virtualmcpserver_externalauth_watch_test.go
+++ b/cmd/thv-operator/test-integration/virtualmcp/virtualmcpserver_externalauth_watch_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package controllers contains integration tests for the VirtualMCPServer controller
 package controllers
 

--- a/cmd/thv-operator/test-integration/virtualmcp/virtualmcpserver_podtemplatespec_integration_test.go
+++ b/cmd/thv-operator/test-integration/virtualmcp/virtualmcpserver_podtemplatespec_integration_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package controllers contains integration tests for the VirtualMCPServer controller
 package controllers
 

--- a/cmd/thv-proxyrunner/app/commands.go
+++ b/cmd/thv-proxyrunner/app/commands.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package app provides the entry point for the toolhive command-line application.
 package app
 

--- a/cmd/thv-proxyrunner/app/run.go
+++ b/cmd/thv-proxyrunner/app/run.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package app
 
 import (

--- a/cmd/thv-proxyrunner/main.go
+++ b/cmd/thv-proxyrunner/main.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package main is the entry point for the ToolHive ProxyRunner.
 package main
 

--- a/cmd/thv/app/auth_flags.go
+++ b/cmd/thv/app/auth_flags.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package app
 
 import (

--- a/cmd/thv/app/build.go
+++ b/cmd/thv/app/build.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package app
 
 import (

--- a/cmd/thv/app/client.go
+++ b/cmd/thv/app/client.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package app
 
 import (

--- a/cmd/thv/app/commands.go
+++ b/cmd/thv/app/commands.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package app provides the entry point for the toolhive command-line application.
 package app
 

--- a/cmd/thv/app/common.go
+++ b/cmd/thv/app/common.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package app
 
 import (

--- a/cmd/thv/app/common_test.go
+++ b/cmd/thv/app/common_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package app
 
 import (

--- a/cmd/thv/app/config.go
+++ b/cmd/thv/app/config.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package app
 
 import (

--- a/cmd/thv/app/config_buildauthfile.go
+++ b/cmd/thv/app/config_buildauthfile.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package app
 
 import (

--- a/cmd/thv/app/config_buildenv.go
+++ b/cmd/thv/app/config_buildenv.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package app
 
 import (

--- a/cmd/thv/app/constants.go
+++ b/cmd/thv/app/constants.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package app
 
 // Output format constants

--- a/cmd/thv/app/export.go
+++ b/cmd/thv/app/export.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package app
 
 import (

--- a/cmd/thv/app/flag_helpers.go
+++ b/cmd/thv/app/flag_helpers.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package app
 
 import (

--- a/cmd/thv/app/group.go
+++ b/cmd/thv/app/group.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package app
 
 import (

--- a/cmd/thv/app/inspector.go
+++ b/cmd/thv/app/inspector.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package app
 
 import (

--- a/cmd/thv/app/inspector/version.go
+++ b/cmd/thv/app/inspector/version.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package inspector contains definitions for the inspector command.
 package inspector
 

--- a/cmd/thv/app/list.go
+++ b/cmd/thv/app/list.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package app
 
 import (

--- a/cmd/thv/app/logs.go
+++ b/cmd/thv/app/logs.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package app
 
 import (

--- a/cmd/thv/app/mcp.go
+++ b/cmd/thv/app/mcp.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package app
 
 import (

--- a/cmd/thv/app/mcp_serve.go
+++ b/cmd/thv/app/mcp_serve.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package app
 
 import (

--- a/cmd/thv/app/otel.go
+++ b/cmd/thv/app/otel.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package app
 
 import (

--- a/cmd/thv/app/proxy.go
+++ b/cmd/thv/app/proxy.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package app
 
 import (

--- a/cmd/thv/app/proxy_stdio.go
+++ b/cmd/thv/app/proxy_stdio.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package app
 
 import (

--- a/cmd/thv/app/proxy_tunnel.go
+++ b/cmd/thv/app/proxy_tunnel.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package app
 
 import (

--- a/cmd/thv/app/registry.go
+++ b/cmd/thv/app/registry.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package app
 
 import (

--- a/cmd/thv/app/restart.go
+++ b/cmd/thv/app/restart.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package app
 
 import (

--- a/cmd/thv/app/rm.go
+++ b/cmd/thv/app/rm.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package app
 
 import (

--- a/cmd/thv/app/run.go
+++ b/cmd/thv/app/run.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package app
 
 import (

--- a/cmd/thv/app/run_flags.go
+++ b/cmd/thv/app/run_flags.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package app
 
 import (

--- a/cmd/thv/app/run_flags_test.go
+++ b/cmd/thv/app/run_flags_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package app
 
 import (

--- a/cmd/thv/app/run_test.go
+++ b/cmd/thv/app/run_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package app
 
 import (

--- a/cmd/thv/app/runtime.go
+++ b/cmd/thv/app/runtime.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package app
 
 import (

--- a/cmd/thv/app/search.go
+++ b/cmd/thv/app/search.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package app
 
 import (

--- a/cmd/thv/app/secret.go
+++ b/cmd/thv/app/secret.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package app
 
 import (

--- a/cmd/thv/app/server.go
+++ b/cmd/thv/app/server.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package app
 
 import (

--- a/cmd/thv/app/status.go
+++ b/cmd/thv/app/status.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package app
 
 import (

--- a/cmd/thv/app/status_test.go
+++ b/cmd/thv/app/status_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package app
 
 import (

--- a/cmd/thv/app/stop.go
+++ b/cmd/thv/app/stop.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package app
 
 import (

--- a/cmd/thv/app/ui/clients_setup.go
+++ b/cmd/thv/app/ui/clients_setup.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package ui provides terminal UI helpers for the ToolHive CLI.
 package ui
 

--- a/cmd/thv/app/ui/clients_status.go
+++ b/cmd/thv/app/ui/clients_status.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package ui
 
 import (

--- a/cmd/thv/app/version.go
+++ b/cmd/thv/app/version.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package app
 
 import (

--- a/cmd/thv/main.go
+++ b/cmd/thv/main.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package main is the entry point for the ToolHive CLI.
 package main
 

--- a/cmd/vmcp/app/commands.go
+++ b/cmd/vmcp/app/commands.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package app provides the entry point for the vmcp command-line application.
 package app
 

--- a/cmd/vmcp/main.go
+++ b/cmd/vmcp/main.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package main is the entry point for the Virtual MCP Server (vmcp).
 package main
 

--- a/pkg/api/docs.go
+++ b/pkg/api/docs.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package api
 
 import (

--- a/pkg/api/errors/handler.go
+++ b/pkg/api/errors/handler.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package errors provides HTTP error handling utilities for the API.
 package errors
 

--- a/pkg/api/errors/handler_test.go
+++ b/pkg/api/errors/handler_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package errors
 
 import (

--- a/pkg/api/openapi.go
+++ b/pkg/api/openapi.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package api
 
 import (

--- a/pkg/api/request_size_test.go
+++ b/pkg/api/request_size_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package api
 
 import (

--- a/pkg/api/scalar.go
+++ b/pkg/api/scalar.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package api
 
 import (

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package api contains the REST API for ToolHive.
 package api
 

--- a/pkg/api/v1/clients.go
+++ b/pkg/api/v1/clients.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package v1
 
 import (

--- a/pkg/api/v1/discovery.go
+++ b/pkg/api/v1/discovery.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package v1
 
 import (

--- a/pkg/api/v1/groups.go
+++ b/pkg/api/v1/groups.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package v1
 
 import (

--- a/pkg/api/v1/groups_test.go
+++ b/pkg/api/v1/groups_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package v1
 
 import (

--- a/pkg/api/v1/healtcheck_test.go
+++ b/pkg/api/v1/healtcheck_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package v1
 
 import (

--- a/pkg/api/v1/healthcheck.go
+++ b/pkg/api/v1/healthcheck.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package v1
 
 import (

--- a/pkg/api/v1/registry.go
+++ b/pkg/api/v1/registry.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package v1
 
 import (

--- a/pkg/api/v1/registry_test.go
+++ b/pkg/api/v1/registry_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package v1
 
 import (

--- a/pkg/api/v1/secrets.go
+++ b/pkg/api/v1/secrets.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package v1
 
 import (

--- a/pkg/api/v1/secrets_test.go
+++ b/pkg/api/v1/secrets_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package v1
 
 import (

--- a/pkg/api/v1/version.go
+++ b/pkg/api/v1/version.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package v1 contains the V1 API for ToolHive.
 package v1
 

--- a/pkg/api/v1/version_test.go
+++ b/pkg/api/v1/version_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package v1
 
 import (

--- a/pkg/api/v1/workload_service.go
+++ b/pkg/api/v1/workload_service.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package v1
 
 import (

--- a/pkg/api/v1/workload_service_test.go
+++ b/pkg/api/v1/workload_service_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package v1
 
 import (

--- a/pkg/api/v1/workload_types.go
+++ b/pkg/api/v1/workload_types.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package v1
 
 import (

--- a/pkg/api/v1/workloads.go
+++ b/pkg/api/v1/workloads.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package v1
 
 import (

--- a/pkg/api/v1/workloads_test.go
+++ b/pkg/api/v1/workloads_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package v1
 
 import (

--- a/pkg/api/v1/workloads_types_test.go
+++ b/pkg/api/v1/workloads_types_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package v1
 
 import (

--- a/pkg/audit/auditor.go
+++ b/pkg/audit/auditor.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package audit provides audit logging functionality for ToolHive.
 package audit
 

--- a/pkg/audit/auditor_test.go
+++ b/pkg/audit/auditor_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package audit
 
 import (

--- a/pkg/audit/backend_info_test.go
+++ b/pkg/audit/backend_info_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package audit
 
 import (

--- a/pkg/audit/config.go
+++ b/pkg/audit/config.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package audit provides audit logging configuration for ToolHive.
 package audit
 

--- a/pkg/audit/config_test.go
+++ b/pkg/audit/config_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package audit
 
 import (

--- a/pkg/audit/doc.go
+++ b/pkg/audit/doc.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package audit provides audit logging configuration for ToolHive.
 //
 // +groupName=toolhive.stacklok.dev

--- a/pkg/audit/event_test.go
+++ b/pkg/audit/event_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package audit
 
 import (

--- a/pkg/audit/mcp_events.go
+++ b/pkg/audit/mcp_events.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package audit provides MCP-specific audit event types and constants.
 package audit
 

--- a/pkg/audit/middleware.go
+++ b/pkg/audit/middleware.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package audit
 
 import (

--- a/pkg/audit/middleware_test.go
+++ b/pkg/audit/middleware_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package audit
 
 import (

--- a/pkg/audit/workflow_auditor.go
+++ b/pkg/audit/workflow_auditor.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package audit provides audit logging functionality for ToolHive.
 package audit
 

--- a/pkg/audit/workflow_auditor_test.go
+++ b/pkg/audit/workflow_auditor_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package audit
 
 import (

--- a/pkg/auth/anonymous.go
+++ b/pkg/auth/anonymous.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package auth provides authentication and authorization utilities.
 package auth
 

--- a/pkg/auth/anonymous_test.go
+++ b/pkg/auth/anonymous_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package auth
 
 import (

--- a/pkg/auth/context.go
+++ b/pkg/auth/context.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package auth provides authentication and authorization utilities.
 package auth
 

--- a/pkg/auth/context_test.go
+++ b/pkg/auth/context_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package auth
 
 import (

--- a/pkg/auth/discovery/discovery.go
+++ b/pkg/auth/discovery/discovery.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package discovery provides authentication discovery utilities for detecting
 // authentication requirements from remote servers.
 //

--- a/pkg/auth/discovery/discovery_test.go
+++ b/pkg/auth/discovery/discovery_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package discovery
 
 import (

--- a/pkg/auth/discovery/resource_metadata_test.go
+++ b/pkg/auth/discovery/resource_metadata_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package discovery
 
 import (

--- a/pkg/auth/github_provider.go
+++ b/pkg/auth/github_provider.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package auth provides authentication and authorization utilities.
 package auth
 

--- a/pkg/auth/github_provider_test.go
+++ b/pkg/auth/github_provider_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package auth
 
 import (

--- a/pkg/auth/identity.go
+++ b/pkg/auth/identity.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package auth provides authentication and authorization utilities.
 package auth
 

--- a/pkg/auth/identity_test.go
+++ b/pkg/auth/identity_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package auth
 
 import (

--- a/pkg/auth/local.go
+++ b/pkg/auth/local.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package auth provides authentication and authorization utilities.
 package auth
 

--- a/pkg/auth/local_test.go
+++ b/pkg/auth/local_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package auth
 
 import (

--- a/pkg/auth/middleware.go
+++ b/pkg/auth/middleware.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package auth
 
 import (

--- a/pkg/auth/middleware_test.go
+++ b/pkg/auth/middleware_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package auth
 
 import (

--- a/pkg/auth/monitored_token_source.go
+++ b/pkg/auth/monitored_token_source.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package auth
 
 import (

--- a/pkg/auth/monitored_token_source_test.go
+++ b/pkg/auth/monitored_token_source_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package auth
 
 import (

--- a/pkg/auth/oauth/dynamic_registration.go
+++ b/pkg/auth/oauth/dynamic_registration.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package oauth provides OAuth 2.0 and OIDC authentication functionality.
 package oauth
 

--- a/pkg/auth/oauth/dynamic_registration_test.go
+++ b/pkg/auth/oauth/dynamic_registration_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package oauth
 
 import (

--- a/pkg/auth/oauth/flow.go
+++ b/pkg/auth/oauth/flow.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package oauth provides OAuth 2.0 and OIDC authentication functionality.
 package oauth
 

--- a/pkg/auth/oauth/flow_test.go
+++ b/pkg/auth/oauth/flow_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package oauth
 
 import (

--- a/pkg/auth/oauth/manual.go
+++ b/pkg/auth/oauth/manual.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package oauth provides OAuth 2.0 and OIDC authentication functionality.
 package oauth
 

--- a/pkg/auth/oauth/manual_test.go
+++ b/pkg/auth/oauth/manual_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package oauth
 
 import (

--- a/pkg/auth/oauth/oidc.go
+++ b/pkg/auth/oauth/oidc.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package oauth provides OAuth 2.0 and OIDC authentication functionality.
 package oauth
 

--- a/pkg/auth/oauth/oidc_test.go
+++ b/pkg/auth/oauth/oidc_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package oauth
 
 import (

--- a/pkg/auth/remote/bearer_token_source.go
+++ b/pkg/auth/remote/bearer_token_source.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package remote
 
 import (

--- a/pkg/auth/remote/bearer_token_source_test.go
+++ b/pkg/auth/remote/bearer_token_source_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package remote
 
 import (

--- a/pkg/auth/remote/config.go
+++ b/pkg/auth/remote/config.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package remote
 
 import (

--- a/pkg/auth/remote/config_test.go
+++ b/pkg/auth/remote/config_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package remote
 
 import (

--- a/pkg/auth/remote/doc.go
+++ b/pkg/auth/remote/doc.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package remote provides authentication handling for remote MCP servers.
 //
 // This package implements OAuth/OIDC-based authentication with automatic

--- a/pkg/auth/remote/handler.go
+++ b/pkg/auth/remote/handler.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package remote
 
 import (

--- a/pkg/auth/remote/handler_test.go
+++ b/pkg/auth/remote/handler_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package remote
 
 import (

--- a/pkg/auth/remote/handler_test_helpers_test.go
+++ b/pkg/auth/remote/handler_test_helpers_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package remote
 
 import (

--- a/pkg/auth/secrets/secrets.go
+++ b/pkg/auth/secrets/secrets.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package secrets provides generic secret management utilities for authentication.
 // This package contains functions that can be used by any authentication method
 // (OAuth, bearer tokens, etc.) to process secrets and store them in a secrets manager.

--- a/pkg/auth/secrets/secrets_test.go
+++ b/pkg/auth/secrets/secrets_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package secrets
 
 import (

--- a/pkg/auth/token.go
+++ b/pkg/auth/token.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package auth provides authentication and authorization utilities.
 package auth
 

--- a/pkg/auth/token_test.go
+++ b/pkg/auth/token_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package auth
 
 import (

--- a/pkg/auth/tokenexchange/exchange.go
+++ b/pkg/auth/tokenexchange/exchange.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package tokenexchange provides OAuth 2.0 Token Exchange (RFC 8693) support.
 package tokenexchange
 

--- a/pkg/auth/tokenexchange/exchange_test.go
+++ b/pkg/auth/tokenexchange/exchange_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package tokenexchange
 
 import (

--- a/pkg/auth/tokenexchange/middleware.go
+++ b/pkg/auth/tokenexchange/middleware.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package tokenexchange
 
 import (

--- a/pkg/auth/tokenexchange/middleware_test.go
+++ b/pkg/auth/tokenexchange/middleware_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package tokenexchange
 
 import (

--- a/pkg/auth/utils.go
+++ b/pkg/auth/utils.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package auth provides authentication and authorization utilities.
 package auth
 

--- a/pkg/auth/utils_test.go
+++ b/pkg/auth/utils_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package auth
 
 import (

--- a/pkg/auth/well_known.go
+++ b/pkg/auth/well_known.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package auth provides authentication and authorization utilities.
 package auth
 

--- a/pkg/auth/well_known_test.go
+++ b/pkg/auth/well_known_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package auth
 
 import (

--- a/pkg/authz/authorizers.go
+++ b/pkg/authz/authorizers.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package authz
 
 // This file imports all authorizer implementations to ensure their init()

--- a/pkg/authz/authorizers/cedar/core.go
+++ b/pkg/authz/authorizers/cedar/core.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package cedar provides authorization utilities using Cedar policies.
 package cedar
 

--- a/pkg/authz/authorizers/cedar/core_test.go
+++ b/pkg/authz/authorizers/cedar/core_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package cedar
 
 import (

--- a/pkg/authz/authorizers/cedar/entity.go
+++ b/pkg/authz/authorizers/cedar/entity.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package cedar provides authorization utilities using Cedar policies.
 package cedar
 

--- a/pkg/authz/authorizers/cedar/entity_test.go
+++ b/pkg/authz/authorizers/cedar/entity_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package cedar
 
 import (

--- a/pkg/authz/authorizers/cedar/record_test.go
+++ b/pkg/authz/authorizers/cedar/record_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package cedar
 
 import (

--- a/pkg/authz/authorizers/config.go
+++ b/pkg/authz/authorizers/config.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package authorizers provides the authorization framework and abstractions for ToolHive.
 // It defines interfaces for authorization decisions and configuration handling.
 package authorizers

--- a/pkg/authz/authorizers/config_test.go
+++ b/pkg/authz/authorizers/config_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package authorizers
 
 import (

--- a/pkg/authz/authorizers/core.go
+++ b/pkg/authz/authorizers/core.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package authorizers
 
 import (

--- a/pkg/authz/authorizers/registry.go
+++ b/pkg/authz/authorizers/registry.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package authorizers
 
 import (

--- a/pkg/authz/authorizers/registry_test.go
+++ b/pkg/authz/authorizers/registry_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package authorizers
 
 import (

--- a/pkg/authz/config.go
+++ b/pkg/authz/config.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package authz provides authorization utilities for MCP servers.
 // It supports a pluggable authorizer architecture where different authorization
 // backends (e.g., Cedar, OPA) can be registered and used based on configuration.

--- a/pkg/authz/config_test.go
+++ b/pkg/authz/config_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package authz
 
 import (

--- a/pkg/authz/integration_test.go
+++ b/pkg/authz/integration_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package authz
 
 import (

--- a/pkg/authz/middleware.go
+++ b/pkg/authz/middleware.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package authz provides authorization utilities for MCP servers.
 // It supports a pluggable authorizer architecture where different authorization
 // backends (e.g., Cedar, OPA) can be registered and used based on configuration.

--- a/pkg/authz/middleware_test.go
+++ b/pkg/authz/middleware_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package authz
 
 import (

--- a/pkg/authz/response_filter.go
+++ b/pkg/authz/response_filter.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package authz provides authorization utilities for MCP servers.
 package authz
 

--- a/pkg/authz/response_filter_test.go
+++ b/pkg/authz/response_filter_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package authz
 
 import (

--- a/pkg/certs/validation.go
+++ b/pkg/certs/validation.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package certs provides utilities for certificate validation and handling.
 package certs
 

--- a/pkg/certs/validation_test.go
+++ b/pkg/certs/validation_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package certs
 
 import (

--- a/pkg/cli/tools_override.go
+++ b/pkg/cli/tools_override.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package cli provides utility functions specific to the
 // CLI that we want to test more thoroughly.
 package cli

--- a/pkg/cli/tools_override_test.go
+++ b/pkg/cli/tools_override_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package cli
 
 import (

--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package client provides utilities for managing client configurations
 // and interacting with MCP servers.
 package client

--- a/pkg/client/config_editor.go
+++ b/pkg/client/config_editor.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package client
 
 import (

--- a/pkg/client/config_editor_test.go
+++ b/pkg/client/config_editor_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package client
 
 import (

--- a/pkg/client/config_test.go
+++ b/pkg/client/config_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package client provides utilities for managing client configurations
 // and interacting with MCP servers.
 package client

--- a/pkg/client/converter.go
+++ b/pkg/client/converter.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package client
 
 import (

--- a/pkg/client/converter_test.go
+++ b/pkg/client/converter_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package client
 
 import (

--- a/pkg/client/discovery.go
+++ b/pkg/client/discovery.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package client
 
 import (

--- a/pkg/client/discovery_test.go
+++ b/pkg/client/discovery_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package client
 
 import (

--- a/pkg/client/manager.go
+++ b/pkg/client/manager.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package client
 
 import (

--- a/pkg/client/migration.go
+++ b/pkg/client/migration.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package client
 
 import (

--- a/pkg/config/buildauthfile.go
+++ b/pkg/config/buildauthfile.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package config
 
 import (

--- a/pkg/config/buildauthfile_test.go
+++ b/pkg/config/buildauthfile_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package config
 
 import (

--- a/pkg/config/buildenv.go
+++ b/pkg/config/buildenv.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package config
 
 import (

--- a/pkg/config/buildenv_test.go
+++ b/pkg/config/buildenv_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package config
 
 import (

--- a/pkg/config/cacert.go
+++ b/pkg/config/cacert.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package config
 
 import (

--- a/pkg/config/cacert_test.go
+++ b/pkg/config/cacert_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package config
 
 import (

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package config contains the definition of the application config structure
 // and logic required to load and update it.
 package config

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package config
 
 import (

--- a/pkg/config/interface.go
+++ b/pkg/config/interface.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package config
 
 import (

--- a/pkg/config/interface_test.go
+++ b/pkg/config/interface_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package config
 
 import (

--- a/pkg/config/registry.go
+++ b/pkg/config/registry.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package config
 
 import (

--- a/pkg/config/registry_test.go
+++ b/pkg/config/registry_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package config
 
 import (

--- a/pkg/config/singleton.go
+++ b/pkg/config/singleton.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package config
 
 import (

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package config
 
 import (

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package config
 
 import (

--- a/pkg/container/docker/client.go
+++ b/pkg/container/docker/client.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package docker provides Docker-specific implementation of container runtime,
 // including creating, starting, stopping, and monitoring containers.
 package docker

--- a/pkg/container/docker/client_config_test.go
+++ b/pkg/container/docker/client_config_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package docker
 
 import (

--- a/pkg/container/docker/client_create_test.go
+++ b/pkg/container/docker/client_create_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package docker
 
 import (

--- a/pkg/container/docker/client_deploy_test.go
+++ b/pkg/container/docker/client_deploy_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package docker
 
 import (

--- a/pkg/container/docker/client_final_port_linux.go
+++ b/pkg/container/docker/client_final_port_linux.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build linux
 
 package docker

--- a/pkg/container/docker/client_final_port_other.go
+++ b/pkg/container/docker/client_final_port_other.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build !linux
 
 package docker

--- a/pkg/container/docker/client_helpers_test.go
+++ b/pkg/container/docker/client_helpers_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package docker
 
 import (

--- a/pkg/container/docker/client_info_test.go
+++ b/pkg/container/docker/client_info_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package docker
 
 import (

--- a/pkg/container/docker/client_list_test.go
+++ b/pkg/container/docker/client_list_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package docker
 
 import (

--- a/pkg/container/docker/client_partial_match_test.go
+++ b/pkg/container/docker/client_partial_match_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package docker
 
 import (

--- a/pkg/container/docker/client_stop_test.go
+++ b/pkg/container/docker/client_stop_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package docker
 
 import (

--- a/pkg/container/docker/errors.go
+++ b/pkg/container/docker/errors.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package docker
 
 import (

--- a/pkg/container/docker/mocks_test.go
+++ b/pkg/container/docker/mocks_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package docker
 
 import (

--- a/pkg/container/docker/monitor.go
+++ b/pkg/container/docker/monitor.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package docker
 
 import (

--- a/pkg/container/docker/monitor_test.go
+++ b/pkg/container/docker/monitor_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package docker
 
 import (

--- a/pkg/container/docker/sdk/client_unix.go
+++ b/pkg/container/docker/sdk/client_unix.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build !windows
 
 package sdk

--- a/pkg/container/docker/sdk/client_windows.go
+++ b/pkg/container/docker/sdk/client_windows.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build windows
 
 package sdk

--- a/pkg/container/docker/sdk/factory.go
+++ b/pkg/container/docker/sdk/factory.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package sdk provides a factory method for creating a Docker client.
 package sdk
 

--- a/pkg/container/docker/squid.go
+++ b/pkg/container/docker/squid.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package docker
 
 import (

--- a/pkg/container/docker/squid_test.go
+++ b/pkg/container/docker/squid_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package docker
 
 import (

--- a/pkg/container/factory.go
+++ b/pkg/container/factory.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package container provides utilities for managing containers,
 // including creating, starting, stopping, and monitoring containers.
 package container

--- a/pkg/container/images/docker.go
+++ b/pkg/container/images/docker.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package images
 
 import (

--- a/pkg/container/images/image.go
+++ b/pkg/container/images/image.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package images handles container image management operations.
 package images
 

--- a/pkg/container/images/keychain.go
+++ b/pkg/container/images/keychain.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package images
 
 import (

--- a/pkg/container/images/registry.go
+++ b/pkg/container/images/registry.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package images
 
 import (

--- a/pkg/container/kubernetes/client.go
+++ b/pkg/container/kubernetes/client.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package kubernetes provides a client for the Kubernetes runtime
 // including creating, starting, stopping, and retrieving container information.
 package kubernetes

--- a/pkg/container/kubernetes/client_test.go
+++ b/pkg/container/kubernetes/client_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package kubernetes
 
 import (

--- a/pkg/container/kubernetes/common.go
+++ b/pkg/container/kubernetes/common.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package kubernetes
 
 import (

--- a/pkg/container/kubernetes/common_test.go
+++ b/pkg/container/kubernetes/common_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package kubernetes
 
 import (

--- a/pkg/container/kubernetes/configmap.go
+++ b/pkg/container/kubernetes/configmap.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package kubernetes
 
 import (

--- a/pkg/container/kubernetes/configmap_test.go
+++ b/pkg/container/kubernetes/configmap_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package kubernetes
 
 import (

--- a/pkg/container/kubernetes/security.go
+++ b/pkg/container/kubernetes/security.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package kubernetes
 
 import (

--- a/pkg/container/kubernetes/security_test.go
+++ b/pkg/container/kubernetes/security_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package kubernetes
 
 import (

--- a/pkg/container/name.go
+++ b/pkg/container/name.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package container
 
 import (

--- a/pkg/container/name_test.go
+++ b/pkg/container/name_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package container
 
 import (

--- a/pkg/container/runtime/types.go
+++ b/pkg/container/runtime/types.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package runtime provides interfaces and types for container runtimes,
 // including creating, starting, stopping, and monitoring containers.
 package runtime

--- a/pkg/container/templates/templates.go
+++ b/pkg/container/templates/templates.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package templates provides utilities for generating Dockerfile templates
 // based on different transport types (uvx, npx).
 package templates

--- a/pkg/container/templates/templates_test.go
+++ b/pkg/container/templates/templates_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package templates
 
 import (

--- a/pkg/container/verifier/attestations.go
+++ b/pkg/container/verifier/attestations.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package verifier
 
 import (

--- a/pkg/container/verifier/sigstore.go
+++ b/pkg/container/verifier/sigstore.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package verifier provides a client for verifying artifacts using sigstore
 package verifier
 

--- a/pkg/container/verifier/utils.go
+++ b/pkg/container/verifier/utils.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package verifier
 
 import (

--- a/pkg/container/verifier/verifier.go
+++ b/pkg/container/verifier/verifier.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package verifier
 
 import (

--- a/pkg/core/workload.go
+++ b/pkg/core/workload.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package core provides the core domain model for the ToolHive system.
 package core
 

--- a/pkg/core/workload_test.go
+++ b/pkg/core/workload_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package core
 
 import (

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package env provides abstractions for environment variable access
 // to enable dependency injection and testing isolation.
 package env

--- a/pkg/env/env_test.go
+++ b/pkg/env/env_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package env
 
 import (

--- a/pkg/environment/environment.go
+++ b/pkg/environment/environment.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package environment provides utilities for handling environment variables
 // and environment-related operations for containers.
 package environment

--- a/pkg/environment/environment_test.go
+++ b/pkg/environment/environment_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package environment
 
 import (

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package errors provides error types with HTTP status codes for API error handling.
 package errors
 

--- a/pkg/errors/errors_test.go
+++ b/pkg/errors/errors_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package errors
 
 import (

--- a/pkg/export/k8s.go
+++ b/pkg/export/k8s.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package export provides functionality for exporting ToolHive configurations to various formats.
 package export
 

--- a/pkg/export/k8s_test.go
+++ b/pkg/export/k8s_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package export
 
 import (

--- a/pkg/groups/cli_manager.go
+++ b/pkg/groups/cli_manager.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package groups provides functionality for managing logical groupings of MCP servers.
 // This file contains the CLI/filesystem-based implementation for local environments.
 package groups

--- a/pkg/groups/cli_manager_test.go
+++ b/pkg/groups/cli_manager_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package groups
 
 import (

--- a/pkg/groups/crd_manager.go
+++ b/pkg/groups/crd_manager.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package groups provides functionality for managing logical groupings of MCP servers.
 // This file contains the CRD-based implementation for Kubernetes environments.
 package groups

--- a/pkg/groups/crd_manager_test.go
+++ b/pkg/groups/crd_manager_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package groups
 
 import (

--- a/pkg/groups/errors.go
+++ b/pkg/groups/errors.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package groups
 
 import (

--- a/pkg/groups/group.go
+++ b/pkg/groups/group.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package groups provides functionality for managing logical groupings of MCP servers.
 // It includes types and interfaces for creating, retrieving, listing, and deleting groups.
 package groups

--- a/pkg/groups/manager.go
+++ b/pkg/groups/manager.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package groups provides functionality for managing logical groupings of MCP servers.
 package groups
 

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package healthcheck provides common healthcheck functionality for ToolHive proxies.
 // It includes MCP server status information and standardized response formats.
 package healthcheck

--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package healthcheck
 
 import (

--- a/pkg/ignore/processor.go
+++ b/pkg/ignore/processor.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package ignore provides functionality for processing .thvignore files
 // to filter bind mount contents using tmpfs overlays.
 package ignore

--- a/pkg/ignore/processor_test.go
+++ b/pkg/ignore/processor_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package ignore
 
 import (

--- a/pkg/json/any.go
+++ b/pkg/json/any.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package json provides JSON-related utilities for ToolHive.
 //
 // This package extends Go's standard json package with types that work

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package k8s
 
 import (

--- a/pkg/k8s/client_test.go
+++ b/pkg/k8s/client_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package k8s
 
 import (

--- a/pkg/k8s/config.go
+++ b/pkg/k8s/config.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package k8s provides common Kubernetes utilities for creating clients,
 // configs, and namespace detection that can be shared across packages.
 package k8s

--- a/pkg/k8s/config_test.go
+++ b/pkg/k8s/config_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package k8s
 
 import (

--- a/pkg/k8s/doc.go
+++ b/pkg/k8s/doc.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package k8s provides common Kubernetes client utilities for ToolHive.
 //
 // This package centralizes Kubernetes client creation, configuration loading,

--- a/pkg/k8s/namespace.go
+++ b/pkg/k8s/namespace.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package k8s
 
 import (

--- a/pkg/k8s/namespace_test.go
+++ b/pkg/k8s/namespace_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package k8s
 
 import (

--- a/pkg/k8s/test_helpers.go
+++ b/pkg/k8s/test_helpers.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package k8s
 
 // Test helper constants and functions shared across test files

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package labels provides utilities for managing container labels
 // used by the toolhive application.
 package labels

--- a/pkg/labels/labels_test.go
+++ b/pkg/labels/labels_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package labels
 
 import (

--- a/pkg/lockfile/cleanup.go
+++ b/pkg/lockfile/cleanup.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package lockfile provides utilities for managing file locks and cleanup.
 package lockfile
 

--- a/pkg/lockfile/cleanup_test.go
+++ b/pkg/lockfile/cleanup_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package lockfile
 
 import (

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package logger provides a logging capability for toolhive for running locally as a CLI and in Kubernetes
 package logger
 

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package logger
 
 import (

--- a/pkg/mcp/middleware.go
+++ b/pkg/mcp/middleware.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package mcp
 
 import (

--- a/pkg/mcp/middleware_test.go
+++ b/pkg/mcp/middleware_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package mcp
 
 import (

--- a/pkg/mcp/parser.go
+++ b/pkg/mcp/parser.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package mcp provides MCP (Model Context Protocol) parsing utilities and middleware.
 package mcp
 

--- a/pkg/mcp/parser_integration_test.go
+++ b/pkg/mcp/parser_integration_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package mcp
 
 import (

--- a/pkg/mcp/parser_test.go
+++ b/pkg/mcp/parser_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package mcp
 
 import (

--- a/pkg/mcp/server/get_server_logs.go
+++ b/pkg/mcp/server/get_server_logs.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package server
 
 import (

--- a/pkg/mcp/server/handler.go
+++ b/pkg/mcp/server/handler.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package server provides the MCP (Model Context Protocol) server implementation for ToolHive.
 package server
 

--- a/pkg/mcp/server/handler_mock_test.go
+++ b/pkg/mcp/server/handler_mock_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package server
 
 import (

--- a/pkg/mcp/server/handler_test.go
+++ b/pkg/mcp/server/handler_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package server
 
 import (

--- a/pkg/mcp/server/list_secrets.go
+++ b/pkg/mcp/server/list_secrets.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package server
 
 import (

--- a/pkg/mcp/server/list_secrets_test.go
+++ b/pkg/mcp/server/list_secrets_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package server
 
 import (

--- a/pkg/mcp/server/list_servers.go
+++ b/pkg/mcp/server/list_servers.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package server
 
 import (

--- a/pkg/mcp/server/remove_server.go
+++ b/pkg/mcp/server/remove_server.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package server
 
 import (

--- a/pkg/mcp/server/run_server.go
+++ b/pkg/mcp/server/run_server.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package server
 
 import (

--- a/pkg/mcp/server/search_registry.go
+++ b/pkg/mcp/server/search_registry.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package server
 
 import (

--- a/pkg/mcp/server/server.go
+++ b/pkg/mcp/server/server.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package server
 
 import (

--- a/pkg/mcp/server/server_test.go
+++ b/pkg/mcp/server/server_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package server
 
 import (

--- a/pkg/mcp/server/set_secret.go
+++ b/pkg/mcp/server/set_secret.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package server
 
 import (

--- a/pkg/mcp/server/set_secret_test.go
+++ b/pkg/mcp/server/set_secret_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package server
 
 import (

--- a/pkg/mcp/server/stop_server.go
+++ b/pkg/mcp/server/stop_server.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package server
 
 import (

--- a/pkg/mcp/tool_filter.go
+++ b/pkg/mcp/tool_filter.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package mcp
 
 import (

--- a/pkg/mcp/tool_filter_test.go
+++ b/pkg/mcp/tool_filter_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package mcp
 
 import (

--- a/pkg/mcp/tool_middleware_test.go
+++ b/pkg/mcp/tool_middleware_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package mcp
 
 import (

--- a/pkg/migration/default_group.go
+++ b/pkg/migration/default_group.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package migration
 
 import (

--- a/pkg/migration/migration.go
+++ b/pkg/migration/migration.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package migration handles any migrations needed to maintain compatibility
 package migration
 

--- a/pkg/migration/telemetry_config.go
+++ b/pkg/migration/telemetry_config.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package migration
 
 import (

--- a/pkg/migration/telemetry_config_test.go
+++ b/pkg/migration/telemetry_config_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package migration
 
 import (

--- a/pkg/networking/http_client.go
+++ b/pkg/networking/http_client.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package networking
 
 import (

--- a/pkg/networking/http_client_test.go
+++ b/pkg/networking/http_client_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package networking
 
 import (

--- a/pkg/networking/port.go
+++ b/pkg/networking/port.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package networking provides utilities for network operations,
 // such as finding available ports and checking network connectivity.
 package networking

--- a/pkg/networking/port_test.go
+++ b/pkg/networking/port_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package networking_test
 
 import (

--- a/pkg/networking/utilities.go
+++ b/pkg/networking/utilities.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package networking
 
 import (

--- a/pkg/networking/utilities_test.go
+++ b/pkg/networking/utilities_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package networking
 
 import (

--- a/pkg/operator/accessors/mcpserver_accessor.go
+++ b/pkg/operator/accessors/mcpserver_accessor.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package accessors provides accessor functions for the ToolHive operator
 package accessors
 

--- a/pkg/operator/accessors/mcpserver_accessor_test.go
+++ b/pkg/operator/accessors/mcpserver_accessor_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package accessors
 
 import (

--- a/pkg/operator/telemetry/telemetry.go
+++ b/pkg/operator/telemetry/telemetry.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package telemetry provides telemetry functionality for the ToolHive operator.
 package telemetry
 

--- a/pkg/operator/telemetry/telemetry_test.go
+++ b/pkg/operator/telemetry/telemetry_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package telemetry
 
 import (

--- a/pkg/permissions/profile.go
+++ b/pkg/permissions/profile.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package permissions provides utilities for managing container permissions
 // and permission profiles for the toolhive application.
 package permissions

--- a/pkg/permissions/profile_privileged_test.go
+++ b/pkg/permissions/profile_privileged_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package permissions
 
 import (

--- a/pkg/permissions/profile_test.go
+++ b/pkg/permissions/profile_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package permissions
 
 import (

--- a/pkg/process/detached.go
+++ b/pkg/process/detached.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package process
 
 import (

--- a/pkg/process/find_unix.go
+++ b/pkg/process/find_unix.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build !windows
 
 package process

--- a/pkg/process/find_windows.go
+++ b/pkg/process/find_windows.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build windows
 
 package process

--- a/pkg/process/kill_unix.go
+++ b/pkg/process/kill_unix.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build !windows
 
 package process

--- a/pkg/process/kill_windows.go
+++ b/pkg/process/kill_windows.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build windows
 
 package process

--- a/pkg/process/pid.go
+++ b/pkg/process/pid.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package process provides utilities for managing process-related operations,
 // such as PID file handling and process management.
 package process

--- a/pkg/process/pid_test.go
+++ b/pkg/process/pid_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package process
 
 import (

--- a/pkg/recovery/recovery.go
+++ b/pkg/recovery/recovery.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package recovery provides panic recovery middleware for HTTP handlers.
 package recovery
 

--- a/pkg/recovery/recovery_test.go
+++ b/pkg/recovery/recovery_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package recovery
 
 import (

--- a/pkg/registry/api/client.go
+++ b/pkg/registry/api/client.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package api provides client functionality for interacting with MCP Registry API endpoints
 package api
 

--- a/pkg/registry/converters/converters_fixture_test.go
+++ b/pkg/registry/converters/converters_fixture_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package converters
 
 import (

--- a/pkg/registry/converters/converters_test.go
+++ b/pkg/registry/converters/converters_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package converters
 
 import (

--- a/pkg/registry/converters/envvar_extraction_test.go
+++ b/pkg/registry/converters/envvar_extraction_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package converters
 
 import (

--- a/pkg/registry/converters/integration_test.go
+++ b/pkg/registry/converters/integration_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package converters
 
 import (

--- a/pkg/registry/converters/registry_converters.go
+++ b/pkg/registry/converters/registry_converters.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package converters
 
 import (

--- a/pkg/registry/converters/registry_converters_test.go
+++ b/pkg/registry/converters/registry_converters_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package converters
 
 import (

--- a/pkg/registry/converters/toolhive_to_upstream.go
+++ b/pkg/registry/converters/toolhive_to_upstream.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package converters provides bidirectional conversion between toolhive registry formats
 // and the upstream MCP (Model Context Protocol) ServerJSON format.
 //

--- a/pkg/registry/converters/upstream_to_toolhive.go
+++ b/pkg/registry/converters/upstream_to_toolhive.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package converters provides conversion functions from upstream MCP ServerJSON format
 // to toolhive ImageMetadata/RemoteServerMetadata formats.
 package converters

--- a/pkg/registry/converters/utils.go
+++ b/pkg/registry/converters/utils.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package converters provides utility functions for conversion between upstream and toolhive formats.
 package converters
 

--- a/pkg/registry/factory.go
+++ b/pkg/registry/factory.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package registry provides MCP server registry management functionality.
 // It supports multiple registry sources including embedded data, local files,
 // remote URLs, and API endpoints, with optional caching and conversion capabilities.

--- a/pkg/registry/provider.go
+++ b/pkg/registry/provider.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package registry
 
 import types "github.com/stacklok/toolhive/pkg/registry/registry"

--- a/pkg/registry/provider_api.go
+++ b/pkg/registry/provider_api.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package registry
 
 import (

--- a/pkg/registry/provider_base.go
+++ b/pkg/registry/provider_base.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package registry
 
 import (

--- a/pkg/registry/provider_cached.go
+++ b/pkg/registry/provider_cached.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package registry
 
 import (

--- a/pkg/registry/provider_local.go
+++ b/pkg/registry/provider_local.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package registry
 
 import (

--- a/pkg/registry/provider_remote.go
+++ b/pkg/registry/provider_remote.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package registry
 
 import (

--- a/pkg/registry/provider_test.go
+++ b/pkg/registry/provider_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package registry
 
 import (

--- a/pkg/registry/registry/registry_types.go
+++ b/pkg/registry/registry/registry_types.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package registry contains the core type definitions for the MCP registry system.
 package registry
 

--- a/pkg/registry/registry/upstream_registry.go
+++ b/pkg/registry/registry/upstream_registry.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package registry
 
 import (

--- a/pkg/registry/registry/upstream_registry_test.go
+++ b/pkg/registry/registry/upstream_registry_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package registry
 
 import (

--- a/pkg/registry/schema_validation.go
+++ b/pkg/registry/schema_validation.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package registry
 
 import (

--- a/pkg/registry/schema_validation_test.go
+++ b/pkg/registry/schema_validation_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package registry
 
 import (

--- a/pkg/registry/types_test.go
+++ b/pkg/registry/types_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package registry
 
 import (

--- a/pkg/runner/config.go
+++ b/pkg/runner/config.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package runner provides functionality for running MCP servers
 package runner
 

--- a/pkg/runner/config_builder.go
+++ b/pkg/runner/config_builder.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package runner
 
 import (

--- a/pkg/runner/config_builder_test.go
+++ b/pkg/runner/config_builder_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package runner
 
 import (

--- a/pkg/runner/config_env_files_test.go
+++ b/pkg/runner/config_env_files_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package runner
 
 import (

--- a/pkg/runner/config_test.go
+++ b/pkg/runner/config_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package runner
 
 import (

--- a/pkg/runner/env.go
+++ b/pkg/runner/env.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package runner
 
 import (

--- a/pkg/runner/env_files.go
+++ b/pkg/runner/env_files.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package runner
 
 import (

--- a/pkg/runner/env_files_test.go
+++ b/pkg/runner/env_files_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package runner
 
 import (

--- a/pkg/runner/middleware.go
+++ b/pkg/runner/middleware.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package runner
 
 import (

--- a/pkg/runner/permissions.go
+++ b/pkg/runner/permissions.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package runner
 
 import (

--- a/pkg/runner/permissions_test.go
+++ b/pkg/runner/permissions_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package runner
 
 import (

--- a/pkg/runner/protocol.go
+++ b/pkg/runner/protocol.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package runner
 
 import (

--- a/pkg/runner/protocol_test.go
+++ b/pkg/runner/protocol_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package runner
 
 import (

--- a/pkg/runner/retriever/retriever.go
+++ b/pkg/runner/retriever/retriever.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package retriever contains logic for fetching or building MCP servers.
 package retriever
 

--- a/pkg/runner/retriever/retriever_test.go
+++ b/pkg/runner/retriever/retriever_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package retriever
 
 import (

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package runner provides functionality for running MCP servers
 package runner
 

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package runner
 
 import (

--- a/pkg/runtime/setup.go
+++ b/pkg/runtime/setup.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package runtime provides workload deployment setup functionality
 // that was previously part of the transport package.
 package runtime

--- a/pkg/secrets/1password.go
+++ b/pkg/secrets/1password.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package secrets
 
 import (

--- a/pkg/secrets/1password_test.go
+++ b/pkg/secrets/1password_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package secrets_test
 
 import (

--- a/pkg/secrets/aes/aes.go
+++ b/pkg/secrets/aes/aes.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package aes contains functions for encrypting and decrypting data using AES-GCM
 package aes
 

--- a/pkg/secrets/aes/aes_test.go
+++ b/pkg/secrets/aes/aes_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package aes_test
 
 import (

--- a/pkg/secrets/clients/1password.go
+++ b/pkg/secrets/clients/1password.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package clients contains code for connecting to secret provider APIs.
 package clients
 

--- a/pkg/secrets/concurrency_test.go
+++ b/pkg/secrets/concurrency_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package secrets_test
 
 import (

--- a/pkg/secrets/encrypted.go
+++ b/pkg/secrets/encrypted.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package secrets
 
 import (

--- a/pkg/secrets/encrypted_test.go
+++ b/pkg/secrets/encrypted_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package secrets
 
 import (

--- a/pkg/secrets/environment.go
+++ b/pkg/secrets/environment.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package secrets
 
 import (

--- a/pkg/secrets/environment_test.go
+++ b/pkg/secrets/environment_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package secrets_test
 
 import (

--- a/pkg/secrets/factory.go
+++ b/pkg/secrets/factory.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package secrets
 
 import (

--- a/pkg/secrets/factory_test.go
+++ b/pkg/secrets/factory_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package secrets_test
 
 import (

--- a/pkg/secrets/fallback.go
+++ b/pkg/secrets/fallback.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package secrets
 
 import (

--- a/pkg/secrets/fallback_test.go
+++ b/pkg/secrets/fallback_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package secrets_test
 
 import (

--- a/pkg/secrets/integration_test.go
+++ b/pkg/secrets/integration_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package secrets_test
 
 import (

--- a/pkg/secrets/keyring/composite.go
+++ b/pkg/secrets/keyring/composite.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package keyring provides a composite keyring provider that supports multiple backends.
 // It supports macOS Keychain, Windows Credential Manager, and Linux D-Bus Secret Service,
 // with keyctl as a fallback on Linux systems.

--- a/pkg/secrets/keyring/composite_test.go
+++ b/pkg/secrets/keyring/composite_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package keyring
 
 import (

--- a/pkg/secrets/keyring/dbus_wrapper.go
+++ b/pkg/secrets/keyring/dbus_wrapper.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package keyring
 
 import (

--- a/pkg/secrets/keyring/interface.go
+++ b/pkg/secrets/keyring/interface.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package keyring
 
 import "errors"

--- a/pkg/secrets/keyring/keyctl_linux.go
+++ b/pkg/secrets/keyring/keyctl_linux.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build linux
 
 package keyring

--- a/pkg/secrets/keyring/keyctl_linux_test.go
+++ b/pkg/secrets/keyring/keyctl_linux_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build linux
 
 package keyring

--- a/pkg/secrets/keyring/keyctl_other.go
+++ b/pkg/secrets/keyring/keyctl_other.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build !linux
 
 package keyring

--- a/pkg/secrets/keyring/utils.go
+++ b/pkg/secrets/keyring/utils.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package keyring
 
 import (

--- a/pkg/secrets/none.go
+++ b/pkg/secrets/none.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package secrets
 
 import (

--- a/pkg/secrets/none_test.go
+++ b/pkg/secrets/none_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package secrets
 
 import (

--- a/pkg/secrets/types.go
+++ b/pkg/secrets/types.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package secrets contains the secrets management logic for ToolHive.
 package secrets
 

--- a/pkg/secrets/types_test.go
+++ b/pkg/secrets/types_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package secrets
 
 import (

--- a/pkg/state/factory.go
+++ b/pkg/state/factory.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package state
 
 import (

--- a/pkg/state/factory_test.go
+++ b/pkg/state/factory_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package state
 
 import (

--- a/pkg/state/interface.go
+++ b/pkg/state/interface.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package state provides functionality for storing and retrieving runner state
 // across different environments (local filesystem, Kubernetes, etc.)
 package state

--- a/pkg/state/kubernetes.go
+++ b/pkg/state/kubernetes.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package state
 
 import (

--- a/pkg/state/kubernetes_test.go
+++ b/pkg/state/kubernetes_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package state
 
 import (

--- a/pkg/state/local.go
+++ b/pkg/state/local.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package state
 
 import (

--- a/pkg/state/runconfig.go
+++ b/pkg/state/runconfig.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package state
 
 import (

--- a/pkg/telemetry/attributes.go
+++ b/pkg/telemetry/attributes.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package telemetry provides OpenTelemetry instrumentation for ToolHive MCP server proxies.
 package telemetry
 

--- a/pkg/telemetry/attributes_test.go
+++ b/pkg/telemetry/attributes_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package telemetry
 
 import (

--- a/pkg/telemetry/config.go
+++ b/pkg/telemetry/config.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package telemetry provides OpenTelemetry instrumentation for ToolHive MCP server proxies.
 package telemetry
 

--- a/pkg/telemetry/config_test.go
+++ b/pkg/telemetry/config_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package telemetry
 
 import (

--- a/pkg/telemetry/doc.go
+++ b/pkg/telemetry/doc.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package telemetry provides OpenTelemetry instrumentation for ToolHive MCP server proxies.
 //
 // +groupName=toolhive.stacklok.dev

--- a/pkg/telemetry/integration_test.go
+++ b/pkg/telemetry/integration_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package telemetry
 
 import (

--- a/pkg/telemetry/middleware.go
+++ b/pkg/telemetry/middleware.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package telemetry
 
 import (

--- a/pkg/telemetry/middleware_sse_test.go
+++ b/pkg/telemetry/middleware_sse_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package telemetry
 
 import (

--- a/pkg/telemetry/middleware_test.go
+++ b/pkg/telemetry/middleware_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package telemetry
 
 import (

--- a/pkg/telemetry/providers/otlp/config.go
+++ b/pkg/telemetry/providers/otlp/config.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package otlp provides OpenTelemetry Protocol (OTLP) provider implementations
 package otlp
 

--- a/pkg/telemetry/providers/otlp/logging.go
+++ b/pkg/telemetry/providers/otlp/logging.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package otlp
 
 // This file is a placeholder for future OTLP logging support

--- a/pkg/telemetry/providers/otlp/metrics.go
+++ b/pkg/telemetry/providers/otlp/metrics.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package otlp provides OpenTelemetry Protocol (OTLP) provider implementations
 package otlp
 

--- a/pkg/telemetry/providers/otlp/metrics_test.go
+++ b/pkg/telemetry/providers/otlp/metrics_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package otlp
 
 import (

--- a/pkg/telemetry/providers/otlp/tracing.go
+++ b/pkg/telemetry/providers/otlp/tracing.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package otlp
 
 import (

--- a/pkg/telemetry/providers/otlp/tracing_test.go
+++ b/pkg/telemetry/providers/otlp/tracing_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package otlp
 
 import (

--- a/pkg/telemetry/providers/prometheus/prometheus.go
+++ b/pkg/telemetry/providers/prometheus/prometheus.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package prometheus provides Prometheus metric exporter implementation
 package prometheus
 

--- a/pkg/telemetry/providers/prometheus/prometheus_test.go
+++ b/pkg/telemetry/providers/prometheus/prometheus_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package prometheus
 
 import (

--- a/pkg/telemetry/providers/providers.go
+++ b/pkg/telemetry/providers/providers.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package providers contains telemetry provider implementations and builder logic
 package providers
 

--- a/pkg/telemetry/providers/providers_strategy.go
+++ b/pkg/telemetry/providers/providers_strategy.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package providers
 
 import (

--- a/pkg/telemetry/providers/providers_strategy_test.go
+++ b/pkg/telemetry/providers/providers_strategy_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package providers
 
 import (

--- a/pkg/telemetry/providers/providers_test.go
+++ b/pkg/telemetry/providers/providers_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package providers
 
 import (

--- a/pkg/telemetry/providers/unified_test.go
+++ b/pkg/telemetry/providers/unified_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package providers
 
 import (

--- a/pkg/templates/references.go
+++ b/pkg/templates/references.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package templates provides utilities for parsing and analyzing Go templates.
 package templates
 

--- a/pkg/templates/references_test.go
+++ b/pkg/templates/references_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package templates
 
 import (

--- a/pkg/transport/bridge.go
+++ b/pkg/transport/bridge.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package transport
 
 import (

--- a/pkg/transport/errors/errors.go
+++ b/pkg/transport/errors/errors.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package errors provides error types and constants for the transport package.
 package errors
 

--- a/pkg/transport/errors/errors_test.go
+++ b/pkg/transport/errors/errors_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package errors
 
 import (

--- a/pkg/transport/factory.go
+++ b/pkg/transport/factory.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package transport provides utilities for handling different transport modes
 // for communication between the client and MCP server.
 package transport

--- a/pkg/transport/http.go
+++ b/pkg/transport/http.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package transport
 
 import (

--- a/pkg/transport/http_test.go
+++ b/pkg/transport/http_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package transport
 
 import (

--- a/pkg/transport/middleware/token_injection.go
+++ b/pkg/transport/middleware/token_injection.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package middleware provides middleware functions for the transport package.
 package middleware
 

--- a/pkg/transport/proxy/httpsse/http_proxy.go
+++ b/pkg/transport/proxy/httpsse/http_proxy.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package httpsse provides an HTTP proxy implementation for Server-Sent Events (SSE)
 // used in communication between the client and MCP server.
 package httpsse

--- a/pkg/transport/proxy/httpsse/http_proxy_integration_test.go
+++ b/pkg/transport/proxy/httpsse/http_proxy_integration_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package httpsse
 
 import (

--- a/pkg/transport/proxy/httpsse/http_proxy_test.go
+++ b/pkg/transport/proxy/httpsse/http_proxy_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package httpsse
 
 import (

--- a/pkg/transport/proxy/httpsse/pinger.go
+++ b/pkg/transport/proxy/httpsse/pinger.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package httpsse provides MCP ping functionality for HTTP SSE proxies.
 package httpsse
 

--- a/pkg/transport/proxy/streamable/dispatcher.go
+++ b/pkg/transport/proxy/streamable/dispatcher.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package streamable
 
 import (

--- a/pkg/transport/proxy/streamable/streamable_proxy.go
+++ b/pkg/transport/proxy/streamable/streamable_proxy.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package streamable provides a streamable HTTP proxy for MCP servers.
 package streamable
 

--- a/pkg/transport/proxy/streamable/streamable_proxy_integration_test.go
+++ b/pkg/transport/proxy/streamable/streamable_proxy_integration_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package streamable
 
 import (

--- a/pkg/transport/proxy/streamable/streamable_proxy_mcp_client_integration_test.go
+++ b/pkg/transport/proxy/streamable/streamable_proxy_mcp_client_integration_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package streamable
 
 import (

--- a/pkg/transport/proxy/streamable/streamable_proxy_spec_test.go
+++ b/pkg/transport/proxy/streamable/streamable_proxy_spec_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package streamable
 
 import (

--- a/pkg/transport/proxy/streamable/streamable_proxy_test.go
+++ b/pkg/transport/proxy/streamable/streamable_proxy_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package streamable
 
 import (

--- a/pkg/transport/proxy/streamable/utils.go
+++ b/pkg/transport/proxy/streamable/utils.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package streamable
 
 import (

--- a/pkg/transport/proxy/transparent/pinger.go
+++ b/pkg/transport/proxy/transparent/pinger.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package transparent provides MCP ping functionality for transparent proxies.
 package transparent
 

--- a/pkg/transport/proxy/transparent/response_processor.go
+++ b/pkg/transport/proxy/transparent/response_processor.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package transparent provides a transparent HTTP proxy implementation
 // that forwards requests to a destination without modifying them.
 package transparent

--- a/pkg/transport/proxy/transparent/sse_response_processor.go
+++ b/pkg/transport/proxy/transparent/sse_response_processor.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package transparent provides a transparent HTTP proxy implementation
 // that forwards requests to a destination without modifying them.
 package transparent

--- a/pkg/transport/proxy/transparent/transparent_proxy.go
+++ b/pkg/transport/proxy/transparent/transparent_proxy.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package transparent provides a transparent HTTP proxy implementation
 // that forwards requests to a destination without modifying them.
 package transparent

--- a/pkg/transport/proxy/transparent/transparent_test.go
+++ b/pkg/transport/proxy/transparent/transparent_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package transparent
 
 import (

--- a/pkg/transport/session/errors.go
+++ b/pkg/transport/session/errors.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package session
 
 import (

--- a/pkg/transport/session/manager.go
+++ b/pkg/transport/session/manager.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package session provides a session manager with TTL cleanup.
 package session
 

--- a/pkg/transport/session/manager_test.go
+++ b/pkg/transport/session/manager_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package session
 
 import (

--- a/pkg/transport/session/proxy_session.go
+++ b/pkg/transport/session/proxy_session.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package session
 
 import (

--- a/pkg/transport/session/serialization.go
+++ b/pkg/transport/session/serialization.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package session
 
 import (

--- a/pkg/transport/session/serialization_test.go
+++ b/pkg/transport/session/serialization_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package session
 
 import (

--- a/pkg/transport/session/sse_session.go
+++ b/pkg/transport/session/sse_session.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package session
 
 import (

--- a/pkg/transport/session/storage.go
+++ b/pkg/transport/session/storage.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package session provides session management with pluggable storage backends.
 package session
 

--- a/pkg/transport/session/storage_local.go
+++ b/pkg/transport/session/storage_local.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package session
 
 import (

--- a/pkg/transport/session/storage_test.go
+++ b/pkg/transport/session/storage_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package session
 
 import (

--- a/pkg/transport/session/streamable_session.go
+++ b/pkg/transport/session/streamable_session.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package session
 
 import (

--- a/pkg/transport/ssecommon/sse_common.go
+++ b/pkg/transport/ssecommon/sse_common.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package ssecommon provides common types and utilities for Server-Sent Events (SSE)
 // used in communication between the client and MCP server.
 package ssecommon

--- a/pkg/transport/ssecommon/sse_common_test.go
+++ b/pkg/transport/ssecommon/sse_common_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package ssecommon
 
 import (

--- a/pkg/transport/stdio.go
+++ b/pkg/transport/stdio.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package transport provides utilities for handling different transport modes
 // for communication between the client and MCP server, including stdio transport
 // with automatic re-attachment on Docker/container restarts.

--- a/pkg/transport/stdio_test.go
+++ b/pkg/transport/stdio_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package transport
 
 import (

--- a/pkg/transport/streamable/streamable.go
+++ b/pkg/transport/streamable/streamable.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package streamable provides common types and utilities for
 // Streamable HTTP connections used in communication between the client and MCP server.
 package streamable

--- a/pkg/transport/tunnel/ngrok/tunnel_provider.go
+++ b/pkg/transport/tunnel/ngrok/tunnel_provider.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package ngrok provides an implementation of the TunnelProvider interface using ngrok.
 package ngrok
 

--- a/pkg/transport/types/transport.go
+++ b/pkg/transport/types/transport.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package types provides common types and interfaces for the transport package
 // used in communication between the client and MCP server.
 package types

--- a/pkg/transport/types/transport_test.go
+++ b/pkg/transport/types/transport_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package types
 
 import (

--- a/pkg/transport/types/tunnel.go
+++ b/pkg/transport/types/tunnel.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package types
 
 import (

--- a/pkg/transport/url.go
+++ b/pkg/transport/url.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package transport provides utilities for MCP transport operations
 package transport
 

--- a/pkg/transport/url_test.go
+++ b/pkg/transport/url_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package transport
 
 import (

--- a/pkg/updates/checker.go
+++ b/pkg/updates/checker.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package updates contains logic for checking if an update is available for ToolHive.
 package updates
 

--- a/pkg/updates/checker_test.go
+++ b/pkg/updates/checker_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package updates
 
 import (

--- a/pkg/updates/client.go
+++ b/pkg/updates/client.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package updates
 
 import (

--- a/pkg/updates/client_test.go
+++ b/pkg/updates/client_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package updates
 
 import (

--- a/pkg/usagemetrics/client.go
+++ b/pkg/usagemetrics/client.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package usagemetrics
 
 import (

--- a/pkg/usagemetrics/client_test.go
+++ b/pkg/usagemetrics/client_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package usagemetrics
 
 import (

--- a/pkg/usagemetrics/collector.go
+++ b/pkg/usagemetrics/collector.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package usagemetrics
 
 import (

--- a/pkg/usagemetrics/collector_test.go
+++ b/pkg/usagemetrics/collector_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package usagemetrics
 
 import (

--- a/pkg/usagemetrics/middleware.go
+++ b/pkg/usagemetrics/middleware.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package usagemetrics
 
 import (

--- a/pkg/usagemetrics/middleware_test.go
+++ b/pkg/usagemetrics/middleware_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package usagemetrics
 
 import (

--- a/pkg/usagemetrics/types.go
+++ b/pkg/usagemetrics/types.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package usagemetrics provides internal usage metrics for tracking usage and adoption.
 package usagemetrics
 

--- a/pkg/validation/validation.go
+++ b/pkg/validation/validation.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package validation provides functions for validating input data.
 package validation
 

--- a/pkg/validation/validation_test.go
+++ b/pkg/validation/validation_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package validation
 
 import (

--- a/pkg/versions/version.go
+++ b/pkg/versions/version.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package versions provides version information for the ToolHive application.
 package versions
 

--- a/pkg/versions/version_test.go
+++ b/pkg/versions/version_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package versions
 
 import (

--- a/pkg/vmcp/aggregator/aggregator.go
+++ b/pkg/vmcp/aggregator/aggregator.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package aggregator provides capability aggregation for Virtual MCP Server.
 //
 // This package discovers backend MCP servers, queries their capabilities,

--- a/pkg/vmcp/aggregator/conflict_resolver.go
+++ b/pkg/vmcp/aggregator/conflict_resolver.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package aggregator provides capability aggregation for Virtual MCP Server.
 //
 // This file contains the factory function for creating conflict resolvers

--- a/pkg/vmcp/aggregator/conflict_resolver_test.go
+++ b/pkg/vmcp/aggregator/conflict_resolver_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package aggregator
 
 import (

--- a/pkg/vmcp/aggregator/default_aggregator.go
+++ b/pkg/vmcp/aggregator/default_aggregator.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package aggregator
 
 import (

--- a/pkg/vmcp/aggregator/default_aggregator_test.go
+++ b/pkg/vmcp/aggregator/default_aggregator_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package aggregator
 
 import (

--- a/pkg/vmcp/aggregator/discoverer.go
+++ b/pkg/vmcp/aggregator/discoverer.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package aggregator provides platform-specific backend discovery implementations.
 //
 // This file contains:

--- a/pkg/vmcp/aggregator/discoverer_test.go
+++ b/pkg/vmcp/aggregator/discoverer_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package aggregator
 
 import (

--- a/pkg/vmcp/aggregator/manual_resolver.go
+++ b/pkg/vmcp/aggregator/manual_resolver.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package aggregator
 
 import (

--- a/pkg/vmcp/aggregator/prefix_resolver.go
+++ b/pkg/vmcp/aggregator/prefix_resolver.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package aggregator
 
 import (

--- a/pkg/vmcp/aggregator/priority_resolver.go
+++ b/pkg/vmcp/aggregator/priority_resolver.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package aggregator
 
 import (

--- a/pkg/vmcp/aggregator/testhelpers_test.go
+++ b/pkg/vmcp/aggregator/testhelpers_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package aggregator
 
 import (

--- a/pkg/vmcp/aggregator/tool_adapter.go
+++ b/pkg/vmcp/aggregator/tool_adapter.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package aggregator provides capability aggregation for Virtual MCP Server.
 package aggregator
 

--- a/pkg/vmcp/aggregator/tool_adapter_test.go
+++ b/pkg/vmcp/aggregator/tool_adapter_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package aggregator
 
 import (

--- a/pkg/vmcp/auth/auth.go
+++ b/pkg/vmcp/auth/auth.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package auth provides authentication for Virtual MCP Server.
 //
 // This package defines:

--- a/pkg/vmcp/auth/converters/external_auth_config.go
+++ b/pkg/vmcp/auth/converters/external_auth_config.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package converters provides functions to convert external authentication configurations
 // to typed vMCP BackendAuthStrategy configurations.
 package converters

--- a/pkg/vmcp/auth/converters/header_injection.go
+++ b/pkg/vmcp/auth/converters/header_injection.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package converters provides strategy-specific converters for external authentication configurations.
 package converters
 

--- a/pkg/vmcp/auth/converters/header_injection_test.go
+++ b/pkg/vmcp/auth/converters/header_injection_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package converters
 
 import (

--- a/pkg/vmcp/auth/converters/interface.go
+++ b/pkg/vmcp/auth/converters/interface.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package converters provides a registry for converting external authentication configurations
 // to vMCP auth strategy metadata.
 package converters

--- a/pkg/vmcp/auth/converters/registry_test.go
+++ b/pkg/vmcp/auth/converters/registry_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package converters
 
 import (

--- a/pkg/vmcp/auth/converters/token_exchange.go
+++ b/pkg/vmcp/auth/converters/token_exchange.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package converters provides strategy-specific converters for external authentication configurations.
 package converters
 

--- a/pkg/vmcp/auth/converters/token_exchange_test.go
+++ b/pkg/vmcp/auth/converters/token_exchange_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package converters
 
 import (

--- a/pkg/vmcp/auth/converters/unauthenticated.go
+++ b/pkg/vmcp/auth/converters/unauthenticated.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package converters
 
 import (

--- a/pkg/vmcp/auth/converters/unauthenticated_test.go
+++ b/pkg/vmcp/auth/converters/unauthenticated_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package converters
 
 import (

--- a/pkg/vmcp/auth/factory/incoming.go
+++ b/pkg/vmcp/auth/factory/incoming.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package factory
 
 import (

--- a/pkg/vmcp/auth/factory/incoming_test.go
+++ b/pkg/vmcp/auth/factory/incoming_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package factory
 
 import (

--- a/pkg/vmcp/auth/factory/integration_test.go
+++ b/pkg/vmcp/auth/factory/integration_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package factory
 
 import (

--- a/pkg/vmcp/auth/factory/outgoing_test.go
+++ b/pkg/vmcp/auth/factory/outgoing_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package factory
 
 import (

--- a/pkg/vmcp/auth/outgoing_registry.go
+++ b/pkg/vmcp/auth/outgoing_registry.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package auth
 
 import (

--- a/pkg/vmcp/auth/outgoing_registry_test.go
+++ b/pkg/vmcp/auth/outgoing_registry_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package auth
 
 import (

--- a/pkg/vmcp/auth/strategies/constants.go
+++ b/pkg/vmcp/auth/strategies/constants.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package strategies provides authentication strategy implementations for Virtual MCP Server.
 package strategies
 

--- a/pkg/vmcp/auth/strategies/header_injection.go
+++ b/pkg/vmcp/auth/strategies/header_injection.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package strategies provides authentication strategy implementations for Virtual MCP Server.
 package strategies
 

--- a/pkg/vmcp/auth/strategies/header_injection_test.go
+++ b/pkg/vmcp/auth/strategies/header_injection_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package strategies
 
 import (

--- a/pkg/vmcp/auth/strategies/tokenexchange.go
+++ b/pkg/vmcp/auth/strategies/tokenexchange.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package strategies
 
 import (

--- a/pkg/vmcp/auth/strategies/tokenexchange_test.go
+++ b/pkg/vmcp/auth/strategies/tokenexchange_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package strategies
 
 import (

--- a/pkg/vmcp/auth/strategies/unauthenticated.go
+++ b/pkg/vmcp/auth/strategies/unauthenticated.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package strategies
 
 import (

--- a/pkg/vmcp/auth/strategies/unauthenticated_test.go
+++ b/pkg/vmcp/auth/strategies/unauthenticated_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package strategies
 
 import (

--- a/pkg/vmcp/auth/types/doc.go
+++ b/pkg/vmcp/auth/types/doc.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package types provides shared auth-related types for Virtual MCP Server.
 //
 // +groupName=toolhive.stacklok.dev

--- a/pkg/vmcp/auth/types/types.go
+++ b/pkg/vmcp/auth/types/types.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package types provides shared auth-related types for Virtual MCP Server.
 //
 // This package is designed as a leaf package with no dependencies on other

--- a/pkg/vmcp/cache/cache.go
+++ b/pkg/vmcp/cache/cache.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package cache provides token caching interfaces for Virtual MCP Server.
 //
 // Token caching reduces authentication overhead by caching exchanged tokens

--- a/pkg/vmcp/cache/cache_test.go
+++ b/pkg/vmcp/cache/cache_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package cache
 
 import (

--- a/pkg/vmcp/client/client.go
+++ b/pkg/vmcp/client/client.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package client provides MCP protocol client implementation for communicating with backend servers.
 //
 // This package implements the BackendClient interface defined in the vmcp package,

--- a/pkg/vmcp/client/client_test.go
+++ b/pkg/vmcp/client/client_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package client
 
 //go:generate mockgen -destination=mocks/mock_outgoing_registry.go -package=mocks github.com/stacklok/toolhive/pkg/vmcp/auth OutgoingAuthRegistry

--- a/pkg/vmcp/client/conversions_test.go
+++ b/pkg/vmcp/client/conversions_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package client
 
 import (

--- a/pkg/vmcp/client/testhelpers_test.go
+++ b/pkg/vmcp/client/testhelpers_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package client
 
 import (

--- a/pkg/vmcp/composer/composer.go
+++ b/pkg/vmcp/composer/composer.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package composer provides composite tool workflow execution for Virtual MCP Server.
 //
 // Composite tools orchestrate multi-step workflows across multiple backend MCP servers.

--- a/pkg/vmcp/composer/composite_output_integration_test.go
+++ b/pkg/vmcp/composer/composite_output_integration_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package composer
 
 import (

--- a/pkg/vmcp/composer/dag_executor.go
+++ b/pkg/vmcp/composer/dag_executor.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package composer provides composite tool workflow execution for Virtual MCP Server.
 package composer
 

--- a/pkg/vmcp/composer/dag_executor_test.go
+++ b/pkg/vmcp/composer/dag_executor_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package composer
 
 import (

--- a/pkg/vmcp/composer/elicitation_handler.go
+++ b/pkg/vmcp/composer/elicitation_handler.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package composer provides composite tool workflow execution for Virtual MCP Server.
 package composer
 

--- a/pkg/vmcp/composer/elicitation_handler_test.go
+++ b/pkg/vmcp/composer/elicitation_handler_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package composer
 
 import (

--- a/pkg/vmcp/composer/elicitation_integration_test.go
+++ b/pkg/vmcp/composer/elicitation_integration_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package composer
 
 import (

--- a/pkg/vmcp/composer/output_constructor.go
+++ b/pkg/vmcp/composer/output_constructor.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package composer provides composite tool workflow execution for Virtual MCP Server.
 package composer
 

--- a/pkg/vmcp/composer/output_constructor_test.go
+++ b/pkg/vmcp/composer/output_constructor_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package composer
 
 import (

--- a/pkg/vmcp/composer/output_validator.go
+++ b/pkg/vmcp/composer/output_validator.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package composer provides composite tool workflow execution for Virtual MCP Server.
 package composer
 

--- a/pkg/vmcp/composer/output_validator_test.go
+++ b/pkg/vmcp/composer/output_validator_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package composer
 
 import (

--- a/pkg/vmcp/composer/security_test.go
+++ b/pkg/vmcp/composer/security_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package composer
 
 import (

--- a/pkg/vmcp/composer/state_store.go
+++ b/pkg/vmcp/composer/state_store.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package composer provides composite tool workflow execution for Virtual MCP Server.
 package composer
 

--- a/pkg/vmcp/composer/state_store_test.go
+++ b/pkg/vmcp/composer/state_store_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package composer
 
 import (

--- a/pkg/vmcp/composer/template_expander.go
+++ b/pkg/vmcp/composer/template_expander.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package composer provides composite tool workflow execution for Virtual MCP Server.
 package composer
 

--- a/pkg/vmcp/composer/template_expander_test.go
+++ b/pkg/vmcp/composer/template_expander_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package composer
 
 import (

--- a/pkg/vmcp/composer/testhelpers_test.go
+++ b/pkg/vmcp/composer/testhelpers_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package composer
 
 import (

--- a/pkg/vmcp/composer/workflow_audit_integration_test.go
+++ b/pkg/vmcp/composer/workflow_audit_integration_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package composer
 
 import (

--- a/pkg/vmcp/composer/workflow_context.go
+++ b/pkg/vmcp/composer/workflow_context.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package composer provides composite tool workflow execution for Virtual MCP Server.
 package composer
 

--- a/pkg/vmcp/composer/workflow_engine.go
+++ b/pkg/vmcp/composer/workflow_engine.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package composer provides composite tool workflow execution for Virtual MCP Server.
 package composer
 

--- a/pkg/vmcp/composer/workflow_engine_test.go
+++ b/pkg/vmcp/composer/workflow_engine_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package composer
 
 import (

--- a/pkg/vmcp/composer/workflow_errors.go
+++ b/pkg/vmcp/composer/workflow_errors.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package composer provides composite tool workflow execution for Virtual MCP Server.
 package composer
 

--- a/pkg/vmcp/composer/workflow_state_store.go
+++ b/pkg/vmcp/composer/workflow_state_store.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package composer provides composite tool workflow execution for Virtual MCP Server.
 package composer
 

--- a/pkg/vmcp/composer/workflow_state_store_test.go
+++ b/pkg/vmcp/composer/workflow_state_store_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package composer
 
 import (

--- a/pkg/vmcp/config/composite_validation.go
+++ b/pkg/vmcp/config/composite_validation.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package config provides configuration types and validation for VirtualMCP.
 package config
 

--- a/pkg/vmcp/config/composite_validation_test.go
+++ b/pkg/vmcp/config/composite_validation_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package config
 
 import (

--- a/pkg/vmcp/config/config.go
+++ b/pkg/vmcp/config/config.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package config provides the configuration model for Virtual MCP Server.
 //
 // This package defines a platform-agnostic configuration model that works

--- a/pkg/vmcp/config/config_test.go
+++ b/pkg/vmcp/config/config_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package config
 
 import (

--- a/pkg/vmcp/config/crd_cli_roundtrip_test.go
+++ b/pkg/vmcp/config/crd_cli_roundtrip_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package config
 
 import (

--- a/pkg/vmcp/config/defaults.go
+++ b/pkg/vmcp/config/defaults.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package config provides the configuration model for Virtual MCP Server.
 package config
 

--- a/pkg/vmcp/config/defaults_test.go
+++ b/pkg/vmcp/config/defaults_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package config
 
 import (

--- a/pkg/vmcp/config/doc.go
+++ b/pkg/vmcp/config/doc.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package config provides the configuration model for Virtual MCP Server.
 //
 // +groupName=toolhive.stacklok.dev

--- a/pkg/vmcp/config/validator.go
+++ b/pkg/vmcp/config/validator.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package config
 
 import (

--- a/pkg/vmcp/config/validator_test.go
+++ b/pkg/vmcp/config/validator_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package config
 
 import (

--- a/pkg/vmcp/config/yaml_loader.go
+++ b/pkg/vmcp/config/yaml_loader.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package config
 
 import (

--- a/pkg/vmcp/config/yaml_loader_test.go
+++ b/pkg/vmcp/config/yaml_loader_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package config
 
 import (

--- a/pkg/vmcp/config/yaml_loader_transform_test.go
+++ b/pkg/vmcp/config/yaml_loader_transform_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package config
 
 import (

--- a/pkg/vmcp/discovery/context.go
+++ b/pkg/vmcp/discovery/context.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package discovery provides lazy per-user capability discovery for vMCP servers.
 //
 // This package handles context-based storage and retrieval of discovered backend

--- a/pkg/vmcp/discovery/context_test.go
+++ b/pkg/vmcp/discovery/context_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package discovery
 
 import (

--- a/pkg/vmcp/discovery/manager.go
+++ b/pkg/vmcp/discovery/manager.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package discovery provides lazy per-user capability discovery for vMCP servers.
 //
 // This package implements per-request capability discovery with user-specific

--- a/pkg/vmcp/discovery/manager_test.go
+++ b/pkg/vmcp/discovery/manager_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package discovery
 
 import (

--- a/pkg/vmcp/discovery/middleware.go
+++ b/pkg/vmcp/discovery/middleware.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package discovery provides lazy per-user capability discovery for vMCP servers.
 //
 // Capabilities are discovered at session initialization and cached in the session for

--- a/pkg/vmcp/discovery/middleware_test.go
+++ b/pkg/vmcp/discovery/middleware_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package discovery
 
 import (

--- a/pkg/vmcp/doc.go
+++ b/pkg/vmcp/doc.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package vmcp provides the Virtual MCP Server implementation.
 //
 // Virtual MCP Server aggregates multiple MCP servers from a ToolHive group into a

--- a/pkg/vmcp/errors.go
+++ b/pkg/vmcp/errors.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package vmcp
 
 import (

--- a/pkg/vmcp/health/checker.go
+++ b/pkg/vmcp/health/checker.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package health provides health monitoring for vMCP backend MCP servers.
 //
 // This package implements the HealthChecker interface and provides periodic

--- a/pkg/vmcp/health/checker_test.go
+++ b/pkg/vmcp/health/checker_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package health
 
 import (

--- a/pkg/vmcp/health/monitor.go
+++ b/pkg/vmcp/health/monitor.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package health
 
 import (

--- a/pkg/vmcp/health/monitor_test.go
+++ b/pkg/vmcp/health/monitor_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package health
 
 import (

--- a/pkg/vmcp/health/status.go
+++ b/pkg/vmcp/health/status.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package health
 
 import (

--- a/pkg/vmcp/health/status_test.go
+++ b/pkg/vmcp/health/status_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package health
 
 import (

--- a/pkg/vmcp/k8s/backend_reconciler.go
+++ b/pkg/vmcp/k8s/backend_reconciler.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package k8s provides Kubernetes integration for Virtual MCP Server dynamic mode.
 package k8s
 

--- a/pkg/vmcp/k8s/backend_reconciler_integration_test.go
+++ b/pkg/vmcp/k8s/backend_reconciler_integration_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 
 package k8s_test

--- a/pkg/vmcp/k8s/backend_reconciler_test.go
+++ b/pkg/vmcp/k8s/backend_reconciler_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package k8s_test
 
 import (

--- a/pkg/vmcp/k8s/manager.go
+++ b/pkg/vmcp/k8s/manager.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package k8s provides Kubernetes integration for Virtual MCP Server dynamic mode.
 //
 // In dynamic mode (outgoingAuth.source: discovered), the vMCP server runs a

--- a/pkg/vmcp/k8s/manager_test.go
+++ b/pkg/vmcp/k8s/manager_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package k8s_test
 
 import (

--- a/pkg/vmcp/optimizer/dummy_optimizer.go
+++ b/pkg/vmcp/optimizer/dummy_optimizer.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package optimizer
 
 import (

--- a/pkg/vmcp/optimizer/dummy_optimizer_test.go
+++ b/pkg/vmcp/optimizer/dummy_optimizer_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package optimizer
 
 import (

--- a/pkg/vmcp/optimizer/optimizer.go
+++ b/pkg/vmcp/optimizer/optimizer.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package optimizer provides the Optimizer interface for intelligent tool discovery
 // and invocation in the Virtual MCP Server.
 //

--- a/pkg/vmcp/registry.go
+++ b/pkg/vmcp/registry.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package vmcp
 
 import (

--- a/pkg/vmcp/registry_test.go
+++ b/pkg/vmcp/registry_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package vmcp
 
 import (

--- a/pkg/vmcp/router/default_router.go
+++ b/pkg/vmcp/router/default_router.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package router
 
 import (

--- a/pkg/vmcp/router/default_router_test.go
+++ b/pkg/vmcp/router/default_router_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package router_test
 
 import (

--- a/pkg/vmcp/router/router.go
+++ b/pkg/vmcp/router/router.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package router provides request routing for Virtual MCP Server.
 //
 // This package routes MCP protocol requests (tools, resources, prompts) to

--- a/pkg/vmcp/schema/array.go
+++ b/pkg/vmcp/schema/array.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package schema
 
 // arraySchema represents an array type with item schema.

--- a/pkg/vmcp/schema/object.go
+++ b/pkg/vmcp/schema/object.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package schema
 
 // objectSchema represents a JSON Schema object type.

--- a/pkg/vmcp/schema/primitive.go
+++ b/pkg/vmcp/schema/primitive.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package schema
 
 import (

--- a/pkg/vmcp/schema/reflect.go
+++ b/pkg/vmcp/schema/reflect.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package schema
 
 import (

--- a/pkg/vmcp/schema/reflect_test.go
+++ b/pkg/vmcp/schema/reflect_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package schema
 
 import (

--- a/pkg/vmcp/schema/schema.go
+++ b/pkg/vmcp/schema/schema.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package schema provides typed JSON Schema structures for type coercion and defaults.
 //
 // This package wraps raw JSON Schema maps (map[string]any) into typed structures

--- a/pkg/vmcp/schema/schema_test.go
+++ b/pkg/vmcp/schema/schema_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package schema
 
 import (

--- a/pkg/vmcp/server/adapter/capability_adapter.go
+++ b/pkg/vmcp/server/adapter/capability_adapter.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package adapter
 
 import (

--- a/pkg/vmcp/server/adapter/capability_adapter_test.go
+++ b/pkg/vmcp/server/adapter/capability_adapter_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package adapter_test
 
 import (

--- a/pkg/vmcp/server/adapter/handler_factory.go
+++ b/pkg/vmcp/server/adapter/handler_factory.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package adapter provides a layer between aggregator and SDK.
 //
 // The HandlerFactory interface and its default implementation create MCP request

--- a/pkg/vmcp/server/adapter/handler_factory_test.go
+++ b/pkg/vmcp/server/adapter/handler_factory_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package adapter_test
 
 import (

--- a/pkg/vmcp/server/adapter/optimizer_adapter.go
+++ b/pkg/vmcp/server/adapter/optimizer_adapter.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package adapter
 
 import (

--- a/pkg/vmcp/server/adapter/optimizer_adapter_test.go
+++ b/pkg/vmcp/server/adapter/optimizer_adapter_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package adapter
 
 import (

--- a/pkg/vmcp/server/backend_enrichment.go
+++ b/pkg/vmcp/server/backend_enrichment.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package server
 
 import (

--- a/pkg/vmcp/server/backend_enrichment_test.go
+++ b/pkg/vmcp/server/backend_enrichment_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package server
 
 import (

--- a/pkg/vmcp/server/composite_tool_converter.go
+++ b/pkg/vmcp/server/composite_tool_converter.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package server implements the Virtual MCP Server that aggregates
 // multiple backend MCP servers into a unified interface.
 package server

--- a/pkg/vmcp/server/composite_tool_converter_test.go
+++ b/pkg/vmcp/server/composite_tool_converter_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package server
 
 import (

--- a/pkg/vmcp/server/health_monitoring_test.go
+++ b/pkg/vmcp/server/health_monitoring_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package server
 
 import (

--- a/pkg/vmcp/server/health_test.go
+++ b/pkg/vmcp/server/health_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package server_test
 
 import (

--- a/pkg/vmcp/server/integration_test.go
+++ b/pkg/vmcp/server/integration_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package server_test
 
 import (

--- a/pkg/vmcp/server/readiness_test.go
+++ b/pkg/vmcp/server/readiness_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package server_test
 
 import (

--- a/pkg/vmcp/server/sdk_elicitation_adapter.go
+++ b/pkg/vmcp/server/sdk_elicitation_adapter.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package server implements the Virtual MCP Server that aggregates
 // multiple backend MCP servers into a unified interface.
 package server

--- a/pkg/vmcp/server/sdk_elicitation_adapter_test.go
+++ b/pkg/vmcp/server/sdk_elicitation_adapter_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package server
 
 import (

--- a/pkg/vmcp/server/server.go
+++ b/pkg/vmcp/server/server.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package server implements the Virtual MCP Server that aggregates
 // multiple backend MCP servers into a unified interface.
 //

--- a/pkg/vmcp/server/server_test.go
+++ b/pkg/vmcp/server/server_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package server_test
 
 import (

--- a/pkg/vmcp/server/session_adapter.go
+++ b/pkg/vmcp/server/session_adapter.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package server
 
 import (

--- a/pkg/vmcp/server/session_adapter_test.go
+++ b/pkg/vmcp/server/session_adapter_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package server
 
 import (

--- a/pkg/vmcp/server/status.go
+++ b/pkg/vmcp/server/status.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package server
 
 import (

--- a/pkg/vmcp/server/status_test.go
+++ b/pkg/vmcp/server/status_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package server_test
 
 import (

--- a/pkg/vmcp/server/telemetry.go
+++ b/pkg/vmcp/server/telemetry.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package server
 
 import (

--- a/pkg/vmcp/server/workflow_converter.go
+++ b/pkg/vmcp/server/workflow_converter.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package server implements the Virtual MCP Server that aggregates
 // multiple backend MCP servers into a unified interface.
 package server

--- a/pkg/vmcp/server/workflow_converter_test.go
+++ b/pkg/vmcp/server/workflow_converter_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package server
 
 import (

--- a/pkg/vmcp/server/workflow_executor_adapter.go
+++ b/pkg/vmcp/server/workflow_executor_adapter.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package server implements the Virtual MCP Server that aggregates
 // multiple backend MCP servers into a unified interface.
 package server

--- a/pkg/vmcp/session/vmcp_session.go
+++ b/pkg/vmcp/session/vmcp_session.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package session provides vMCP-specific session types that extend transport sessions with domain logic.
 package session
 

--- a/pkg/vmcp/session/vmcp_session_test.go
+++ b/pkg/vmcp/session/vmcp_session_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package session
 
 import (

--- a/pkg/vmcp/types.go
+++ b/pkg/vmcp/types.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package vmcp
 
 import (

--- a/pkg/vmcp/workloads/discoverer.go
+++ b/pkg/vmcp/workloads/discoverer.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package workloads provides the WorkloadDiscoverer interface for discovering
 // backend workloads in both CLI and Kubernetes environments.
 package workloads

--- a/pkg/vmcp/workloads/k8s.go
+++ b/pkg/vmcp/workloads/k8s.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package workloads
 
 import (

--- a/pkg/vmcp/workloads/k8s_test.go
+++ b/pkg/vmcp/workloads/k8s_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package workloads
 
 import (

--- a/pkg/workloads/discoverer_adapter.go
+++ b/pkg/workloads/discoverer_adapter.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package workloads contains high-level logic for managing the lifecycle of
 // ToolHive-managed containers.
 package workloads

--- a/pkg/workloads/discoverer_adapter_test.go
+++ b/pkg/workloads/discoverer_adapter_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package workloads
 
 import (

--- a/pkg/workloads/filter.go
+++ b/pkg/workloads/filter.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package workloads
 
 import (

--- a/pkg/workloads/filter_test.go
+++ b/pkg/workloads/filter_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package workloads
 
 import (

--- a/pkg/workloads/manager.go
+++ b/pkg/workloads/manager.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package workloads contains high-level logic for managing the lifecycle of
 // ToolHive-managed containers.
 package workloads

--- a/pkg/workloads/manager_test.go
+++ b/pkg/workloads/manager_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package workloads
 
 import (

--- a/pkg/workloads/statuses/file_status.go
+++ b/pkg/workloads/statuses/file_status.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package statuses
 
 import (

--- a/pkg/workloads/statuses/file_status_test.go
+++ b/pkg/workloads/statuses/file_status_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package statuses
 
 import (

--- a/pkg/workloads/statuses/noop.go
+++ b/pkg/workloads/statuses/noop.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package statuses
 
 import (

--- a/pkg/workloads/statuses/status.go
+++ b/pkg/workloads/statuses/status.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package statuses provides an interface and implementation for managing workload statuses.
 package statuses
 

--- a/pkg/workloads/statuses/status_test.go
+++ b/pkg/workloads/statuses/status_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package statuses
 
 import (

--- a/pkg/workloads/sysproc_unix.go
+++ b/pkg/workloads/sysproc_unix.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build !windows
 
 package workloads

--- a/pkg/workloads/sysproc_windows.go
+++ b/pkg/workloads/sysproc_windows.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build windows
 
 package workloads

--- a/pkg/workloads/types/effective_transport_test.go
+++ b/pkg/workloads/types/effective_transport_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package types
 
 import (

--- a/pkg/workloads/types/errors/errors.go
+++ b/pkg/workloads/types/errors/errors.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package errors contains error definitions for workloads
 // It is located in a separate package to side-step an import cycle
 package errors

--- a/pkg/workloads/types/labels.go
+++ b/pkg/workloads/types/labels.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package types
 
 import (

--- a/pkg/workloads/types/labels_test.go
+++ b/pkg/workloads/types/labels_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package types
 
 import (

--- a/pkg/workloads/types/types.go
+++ b/pkg/workloads/types/types.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package types
 
 import (

--- a/pkg/workloads/types/validate.go
+++ b/pkg/workloads/types/validate.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package types contains types and validation functions for workloads in ToolHive.
 // This is separated to avoid circular dependencies with the core package.
 package types

--- a/pkg/workloads/types/validate_test.go
+++ b/pkg/workloads/types/validate_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package types_test
 
 import (

--- a/test/e2e/api_healthcheck_test.go
+++ b/test/e2e/api_healthcheck_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package e2e_test
 
 import (

--- a/test/e2e/api_helpers.go
+++ b/test/e2e/api_helpers.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package e2e provides end-to-end testing utilities for ToolHive HTTP API.
 package e2e
 

--- a/test/e2e/audit_middleware_e2e_test.go
+++ b/test/e2e/audit_middleware_e2e_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package e2e_test
 
 import (

--- a/test/e2e/client_test.go
+++ b/test/e2e/client_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package e2e_test
 
 import (

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package e2e_test
 
 import (

--- a/test/e2e/export_test.go
+++ b/test/e2e/export_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package e2e_test
 
 import (

--- a/test/e2e/fetch_mcp_server_test.go
+++ b/test/e2e/fetch_mcp_server_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package e2e_test
 
 import (

--- a/test/e2e/group_list_e2e_test.go
+++ b/test/e2e/group_list_e2e_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package e2e_test
 
 import (

--- a/test/e2e/group_rm_test.go
+++ b/test/e2e/group_rm_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package e2e_test
 
 import (

--- a/test/e2e/group_test.go
+++ b/test/e2e/group_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package e2e_test
 
 import (

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package e2e provides end-to-end testing utilities for ToolHive.
 package e2e
 

--- a/test/e2e/images/images.go
+++ b/test/e2e/images/images.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package images provides centralized container image references for e2e tests.
 // This package serves as a single source of truth for all container images used
 // in end-to-end testing, making it easier to maintain versions and enabling

--- a/test/e2e/inspector_test.go
+++ b/test/e2e/inspector_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package e2e_test
 
 import (

--- a/test/e2e/list_group_e2e_test.go
+++ b/test/e2e/list_group_e2e_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package e2e_test
 
 import (

--- a/test/e2e/mcp_client_helpers.go
+++ b/test/e2e/mcp_client_helpers.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package e2e
 
 import (

--- a/test/e2e/network_isolation_test.go
+++ b/test/e2e/network_isolation_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package e2e_test
 
 import (

--- a/test/e2e/oidc_mock.go
+++ b/test/e2e/oidc_mock.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package e2e
 
 import (

--- a/test/e2e/osv_authz_test.go
+++ b/test/e2e/osv_authz_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package e2e_test
 
 import (

--- a/test/e2e/osv_mcp_server_test.go
+++ b/test/e2e/osv_mcp_server_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package e2e_test
 
 import (

--- a/test/e2e/osv_streamable_http_mcp_server_test.go
+++ b/test/e2e/osv_streamable_http_mcp_server_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package e2e_test
 
 import (

--- a/test/e2e/protocol_builds_e2e_test.go
+++ b/test/e2e/protocol_builds_e2e_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package e2e_test
 
 import (

--- a/test/e2e/proxy_oauth_test.go
+++ b/test/e2e/proxy_oauth_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package e2e_test
 
 import (

--- a/test/e2e/proxy_stdio_test.go
+++ b/test/e2e/proxy_stdio_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package e2e_test
 
 import (

--- a/test/e2e/proxy_tunnel_e2e_test.go
+++ b/test/e2e/proxy_tunnel_e2e_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package e2e_test
 
 import (

--- a/test/e2e/remote_mcp_server_test.go
+++ b/test/e2e/remote_mcp_server_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package e2e_test
 
 import (

--- a/test/e2e/restart_test.go
+++ b/test/e2e/restart_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package e2e_test
 
 import (

--- a/test/e2e/restart_zombie_test.go
+++ b/test/e2e/restart_zombie_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package e2e_test
 
 import (

--- a/test/e2e/rm_group_test.go
+++ b/test/e2e/rm_group_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package e2e_test
 
 import (

--- a/test/e2e/sse_endpoint_rewrite_test.go
+++ b/test/e2e/sse_endpoint_rewrite_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package e2e_test
 
 import (

--- a/test/e2e/status_test.go
+++ b/test/e2e/status_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package e2e_test
 
 import (

--- a/test/e2e/stdio_proxy_over_streamable_http_mcp_server_test.go
+++ b/test/e2e/stdio_proxy_over_streamable_http_mcp_server_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package e2e_test
 
 import (

--- a/test/e2e/telemetry_metrics_validation_e2e_test.go
+++ b/test/e2e/telemetry_metrics_validation_e2e_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package e2e_test
 
 import (

--- a/test/e2e/telemetry_middleware_e2e_test.go
+++ b/test/e2e/telemetry_middleware_e2e_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package e2e_test
 
 import (

--- a/test/e2e/thv-operator/virtualmcp/helpers.go
+++ b/test/e2e/thv-operator/virtualmcp/helpers.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package virtualmcp provides helper functions for VirtualMCP E2E tests.
 package virtualmcp
 

--- a/test/e2e/thv-operator/virtualmcp/suite_test.go
+++ b/test/e2e/thv-operator/virtualmcp/suite_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package virtualmcp contains e2e tests for VirtualMCPServer against a real Kubernetes cluster
 package virtualmcp
 

--- a/test/e2e/thv-operator/virtualmcp/virtualmcp_aggregation_filtering_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcp_aggregation_filtering_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package virtualmcp
 
 import (

--- a/test/e2e/thv-operator/virtualmcp/virtualmcp_aggregation_overrides_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcp_aggregation_overrides_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package virtualmcp
 
 import (

--- a/test/e2e/thv-operator/virtualmcp/virtualmcp_auth_discovery_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcp_auth_discovery_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package virtualmcp
 
 import (

--- a/test/e2e/thv-operator/virtualmcp/virtualmcp_composite_defaultresults_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcp_composite_defaultresults_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package virtualmcp
 
 import (

--- a/test/e2e/thv-operator/virtualmcp/virtualmcp_composite_parallel_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcp_composite_parallel_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package virtualmcp
 
 import (

--- a/test/e2e/thv-operator/virtualmcp/virtualmcp_composite_referenced_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcp_composite_referenced_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package virtualmcp
 
 import (

--- a/test/e2e/thv-operator/virtualmcp/virtualmcp_composite_sequential_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcp_composite_sequential_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package virtualmcp
 
 import (

--- a/test/e2e/thv-operator/virtualmcp/virtualmcp_conflict_resolution_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcp_conflict_resolution_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package virtualmcp
 
 import (

--- a/test/e2e/thv-operator/virtualmcp/virtualmcp_discovered_mode_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcp_discovered_mode_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package virtualmcp
 
 import (

--- a/test/e2e/thv-operator/virtualmcp/virtualmcp_external_auth_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcp_external_auth_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package virtualmcp
 
 import (

--- a/test/e2e/thv-operator/virtualmcp/virtualmcp_optimizer_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcp_optimizer_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package virtualmcp
 
 import (

--- a/test/e2e/thv-operator/virtualmcp/virtualmcp_telemetry_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcp_telemetry_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package virtualmcp
 
 import (

--- a/test/e2e/thv-operator/virtualmcp/virtualmcp_toolconfig_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcp_toolconfig_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package virtualmcp
 
 import (

--- a/test/e2e/thv-operator/virtualmcp/virtualmcp_yardstick_base_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcp_yardstick_base_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package virtualmcp
 
 import (

--- a/test/e2e/thvignore_test.go
+++ b/test/e2e/thvignore_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package e2e_test
 
 import (

--- a/test/e2e/unhealthy_workload_test.go
+++ b/test/e2e/unhealthy_workload_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package e2e_test
 
 import (

--- a/test/integration/vmcp/helpers/backend.go
+++ b/test/integration/vmcp/helpers/backend.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package helpers provides test utilities for vMCP integration tests.
 package helpers
 

--- a/test/integration/vmcp/helpers/helpers_test.go
+++ b/test/integration/vmcp/helpers/helpers_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package helpers
 
 import (

--- a/test/integration/vmcp/helpers/mcp_client.go
+++ b/test/integration/vmcp/helpers/mcp_client.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package helpers
 
 import (

--- a/test/integration/vmcp/helpers/vmcp_server.go
+++ b/test/integration/vmcp/helpers/vmcp_server.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package helpers
 
 import (

--- a/test/integration/vmcp/vmcp_integration_test.go
+++ b/test/integration/vmcp/vmcp_integration_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package vmcp_test
 
 import (

--- a/test/integration/vmcp/vmcp_typing_integration_test.go
+++ b/test/integration/vmcp/vmcp_typing_integration_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package vmcp_test
 
 import (

--- a/test/testkit/sse_server.go
+++ b/test/testkit/sse_server.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package testkit
 
 import (

--- a/test/testkit/streamable_server.go
+++ b/test/testkit/streamable_server.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package testkit
 
 import (

--- a/test/testkit/testkit.go
+++ b/test/testkit/testkit.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package testkit provides testing utilities for ToolHive.
 //
 // Its sole purpose is

--- a/test/testkit/testkit_test.go
+++ b/test/testkit/testkit_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package testkit
 
 import (


### PR DESCRIPTION
## Summary
- Add SPDX-FileCopyrightText and SPDX-License-Identifier headers to all Go source files for Apache-2.0 license compliance
- Add CI workflow (`license-headers.yml`) to verify headers on every PR
- Add `task license-check` and `task license-fix` commands for local development

## Details
The license header format follows the SPDX specification:
```go
// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
// SPDX-License-Identifier: Apache-2.0
```

The check ignores generated files: `mocks/`, `testdata/`, `vendor/`, `*.pb.go`, `zz_generated*.go`

## PR Size Justification
This PR is intentionally large (843 files, ~2500 lines) because it adds a 3-line license header to every existing Go file in the codebase. Each file change is identical and mechanical - no logic changes. The alternative of splitting this across multiple PRs would create unnecessary merge complexity and leave the codebase in an inconsistent state between merges.

## Test plan
- [x] Verify `task license-check` passes locally
- [ ] CI license-headers workflow passes

Closes #606

🤖 Generated with [Claude Code](https://claude.ai/code)