### PR TITLE
Add validation in create workloads endpoint

### DIFF
--- a/pkg/api/v1/workloads.go
+++ b/pkg/api/v1/workloads.go
@@ -249,6 +249,20 @@ func (s *WorkloadRoutes) createWorkload(w http.ResponseWriter, r *http.Request) 
 		)
 	}
 
+	// Validate that image or URL is provided
+	if req.Image == "" && req.URL == "" {
+		return thverrors.WithCode(
+			fmt.Errorf("either 'image' or 'url' field is required"),
+			http.StatusBadRequest,
+		)
+	}
+
+	// Validate workload name (strict validation, no sanitization)
+	// The JSON decoder sets req.Name to "" by default, so we need to validate it
+	if err := wt.ValidateWorkloadName(req.Name); err != nil {
+		return err // ErrInvalidWorkloadName already has 400 status code
+	}
+
 	// check if the workload already exists
 	if req.Name != "" {
 		exists, err := s.workloadManager.DoesWorkloadExist(ctx, req.Name)


### PR DESCRIPTION
This came up during E2E testing - provide more robust handling of validation errors during workload creation.