### PR TITLE
Fix SSE response processor rewrite logic

### DIFF
--- a/pkg/migration/middleware_telemetry.go
+++ b/pkg/migration/middleware_telemetry.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package migration
 
 import (

--- a/pkg/transport/proxy/transparent/sse_response_processor.go
+++ b/pkg/transport/proxy/transparent/sse_response_processor.go
@@ -159,14 +159,14 @@ func rewriteEndpointURL(originalURL string, config sseRewriteConfig) (string, er
 		parsed.Path = prefix + parsed.Path
 	}
 
-	// Override scheme if configured
-	if config.scheme != "" {
-		parsed.Scheme = config.scheme
-	}
-
 	// Override host if configured
 	if config.host != "" {
 		parsed.Host = config.host
+
+		// Override scheme if configured
+		if config.scheme != "" {
+			parsed.Scheme = config.scheme
+		}
 	}
 
 	return parsed.String(), nil

--- a/pkg/transport/proxy/transparent/transparent_test.go
+++ b/pkg/transport/proxy/transparent/transparent_test.go
@@ -656,6 +656,23 @@ func TestRewriteEndpointURL(t *testing.T) {
 			expected: "https://public.example.com/sse?sessionId=abc123",
 		},
 		{
+			name:        "scheme and host only - path-only URL remains relative",
+			originalURL: "/sse?sessionId=abc123",
+			config: sseRewriteConfig{
+				scheme: "http",
+			},
+			expected: "/sse?sessionId=abc123",
+		},
+		{
+			name:        "scheme and host only - path and prefix URL remains relative",
+			originalURL: "/sse?sessionId=abc123",
+			config: sseRewriteConfig{
+				prefix: "/playwright",
+				scheme: "http",
+			},
+			expected: "/playwright/sse?sessionId=abc123",
+		},
+		{
 			name:        "preserves complex query string",
 			originalURL: "/sse?sessionId=abc123&foo=bar&baz=qux",
 			config:      sseRewriteConfig{prefix: "/api/v1"},


### PR DESCRIPTION
Response processor can be configured to honor `X-Forwarded-*` headers, but proxies can occasionally send `X-Forwarded-Proto` without `X-Forwarded-Host`. In those cases, payloads like `/sse?sessionId=deadbeef` are rewritten as
`http:///sse?sessionId=deadbeef`, causing issues on the client side.

This change adds the scheme part if and only if the host part is also configured.