### PR TITLE
fix(3383): loss of pod causes stdio transport to stop

### DIFF
--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -352,3 +352,218 @@ func (m *mockMiddlewareImpl) Handler() types.MiddlewareFunction {
 func (m *mockMiddlewareImpl) Close() error {
 	return m.closeErr
 }
+
+// Test_monitorTransport tests the monitorTransport helper function that is used by
+// Runner.Run() to detect when a transport stops running.
+//
+// This test verifies the contract between Runner and Transport:
+// 1. monitorTransport polls the isRunning function periodically
+// 2. When isRunning() returns false, it closes the returned channel
+// 3. This triggers the restart flow ("container exited, restart needed")
+func Test_monitorTransport(t *testing.T) {
+	t.Parallel()
+
+	t.Run("detects transport stopped and closes channel", func(t *testing.T) {
+		t.Parallel()
+
+		callCount := 0
+		isRunning := func(_ context.Context) (bool, error) {
+			callCount++
+			if callCount <= 2 {
+				return true, nil // First two calls: still running
+			}
+			return false, nil // Third call: stopped
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		// Use the actual monitorTransport function
+		transportStoppedCh := monitorTransport(ctx, isRunning, 10*time.Millisecond)
+
+		// Wait for the monitoring loop to detect the transport stopped
+		select {
+		case <-transportStoppedCh:
+			// Success - monitoring loop detected transport stopped
+			assert.GreaterOrEqual(t, callCount, 3, "Should have polled IsRunning at least 3 times")
+		case <-time.After(1 * time.Second):
+			t.Fatal("monitorTransport should have detected transport stopped")
+		}
+	})
+
+	t.Run("continues polling on IsRunning error", func(t *testing.T) {
+		t.Parallel()
+
+		callCount := 0
+		isRunning := func(_ context.Context) (bool, error) {
+			callCount++
+			if callCount <= 2 {
+				return false, assert.AnError // First two calls: error
+			}
+			return false, nil // Third call: actually stopped
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		// Use the actual monitorTransport function
+		transportStoppedCh := monitorTransport(ctx, isRunning, 10*time.Millisecond)
+
+		select {
+		case <-transportStoppedCh:
+			// Success - continued polling despite errors
+			assert.GreaterOrEqual(t, callCount, 3, "Should have continued polling after errors")
+		case <-time.After(1 * time.Second):
+			t.Fatal("monitorTransport should have continued after errors and detected stopped")
+		}
+	})
+
+	t.Run("respects context cancellation", func(t *testing.T) {
+		t.Parallel()
+
+		isRunning := func(_ context.Context) (bool, error) {
+			return true, nil // Always running
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+
+		transportStoppedCh := monitorTransport(ctx, isRunning, 10*time.Millisecond)
+
+		// Cancel the context
+		cancel()
+
+		// The channel should NOT be closed (transport is still running)
+		// Give it a moment to process
+		time.Sleep(50 * time.Millisecond)
+
+		select {
+		case <-transportStoppedCh:
+			t.Fatal("monitorTransport should not close channel when context is cancelled (transport still running)")
+		default:
+			// Expected - channel is not closed
+		}
+	})
+}
+
+// TestHandleTransportStopped tests the handleTransportStopped function which handles
+// the entire transport stopped event, including cleanup and restart decision.
+func TestHandleTransportStopped(t *testing.T) {
+	t.Parallel()
+
+	// noopDeps returns deps with no-op functions for fields we don't care about in a test
+	noopDeps := func() transportStoppedDeps {
+		return transportStoppedDeps{
+			removePIDFile:     func() error { return nil },
+			resetWorkloadPID:  func(_ context.Context) error { return nil },
+			workloadExists:    func(_ context.Context) (bool, error) { return true, nil },
+			removeFromClients: func(_ context.Context) error { return nil },
+		}
+	}
+
+	t.Run("returns restart error when workload exists", func(t *testing.T) {
+		t.Parallel()
+
+		deps := noopDeps()
+		deps.workloadExists = func(_ context.Context) (bool, error) {
+			return true, nil
+		}
+
+		err := handleTransportStopped(context.Background(), deps)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "container exited, restart needed")
+	})
+
+	t.Run("returns nil when workload does not exist", func(t *testing.T) {
+		t.Parallel()
+
+		deps := noopDeps()
+		deps.workloadExists = func(_ context.Context) (bool, error) {
+			return false, nil
+		}
+
+		err := handleTransportStopped(context.Background(), deps)
+
+		assert.NoError(t, err, "Should return nil when workload was removed")
+	})
+
+	t.Run("returns restart error when existence check fails", func(t *testing.T) {
+		t.Parallel()
+
+		deps := noopDeps()
+		deps.workloadExists = func(_ context.Context) (bool, error) {
+			return false, assert.AnError
+		}
+
+		err := handleTransportStopped(context.Background(), deps)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "container exited, restart needed")
+	})
+
+	t.Run("calls removePIDFile", func(t *testing.T) {
+		t.Parallel()
+
+		called := false
+		deps := noopDeps()
+		deps.removePIDFile = func() error {
+			called = true
+			return nil
+		}
+
+		_ = handleTransportStopped(context.Background(), deps)
+
+		assert.True(t, called, "Should call removePIDFile")
+	})
+
+	t.Run("calls resetWorkloadPID", func(t *testing.T) {
+		t.Parallel()
+
+		called := false
+		deps := noopDeps()
+		deps.resetWorkloadPID = func(_ context.Context) error {
+			called = true
+			return nil
+		}
+
+		_ = handleTransportStopped(context.Background(), deps)
+
+		assert.True(t, called, "Should call resetWorkloadPID")
+	})
+
+	t.Run("calls removeFromClients when workload does not exist", func(t *testing.T) {
+		t.Parallel()
+
+		called := false
+		deps := noopDeps()
+		deps.workloadExists = func(_ context.Context) (bool, error) {
+			return false, nil
+		}
+		deps.removeFromClients = func(_ context.Context) error {
+			called = true
+			return nil
+		}
+
+		_ = handleTransportStopped(context.Background(), deps)
+
+		assert.True(t, called, "Should call removeFromClients when workload does not exist")
+	})
+
+	t.Run("does not call removeFromClients when workload exists", func(t *testing.T) {
+		t.Parallel()
+
+		called := false
+		deps := noopDeps()
+		deps.workloadExists = func(_ context.Context) (bool, error) {
+			return true, nil
+		}
+		deps.removeFromClients = func(_ context.Context) error {
+			called = true
+			return nil
+		}
+
+		_ = handleTransportStopped(context.Background(), deps)
+
+		assert.False(t, called, "Should not call removeFromClients when workload exists")
+	})
+}

--- a/pkg/transport/stdio.go
+++ b/pkg/transport/stdio.go
@@ -514,6 +514,10 @@ func (t *StdioTransport) processStdout(ctx context.Context, stdout io.ReadCloser
 					}
 
 					logger.Info("Container stdout closed - exiting read loop")
+
+					if err := t.Stop(ctx); err != nil {
+						logger.Errorf("Error stopping transport: %v", err)
+					}
 				} else {
 					logger.Errorf("Error reading from container stdout: %v", err)
 				}


### PR DESCRIPTION
## Summary

Fixes #3383

When the Docker daemon becomes unavailable while a stdio transport proxy is running, the transport would enter a "zombie" state where `IsRunning()` returns `true` but it cannot communicate with the container. This prevented the automatic restart mechanism from triggering. The fix ensures the transport properly shuts down when re-attachment fails.

## Changes

The fix here is actually quite small, but I found the existing recovery code hard to understand. Consequently, I made slight refactors to backfill unit tests to document the actual relationship between the transport and the runner's monitoring behavior.

### Fix: Call `Stop()` after failed re-attachment (`pkg/transport/stdio.go`)

Added a call to `t.Stop(ctx)` in `processStdout` after re-attachment fails. Previously, the function would log "Container stdout closed - exiting read loop" and return without shutting down the transport, leaving it in a zombie state where:
- `processMessages` continued running
- The HTTP proxy continued accepting requests
- `IsRunning()` returned `true`
- The monitoring loop never detected the failure

### Refactor: Extract monitoring loop into `monitorTransport` (`pkg/runner/runner.go`)

Extracted the transport monitoring goroutine from `Run()` into a standalone `monitorTransport` function with a `transportChecker` function type alias. This improves testability and reduces code in the main `Run()` method.

### Refactor: Extract transport stopped handling into `handleTransportStopped` (`pkg/runner/runner.go`)

Extracted the `case <-doneCh` handling logic into a testable `handleTransportStopped` function with a `transportStoppedDeps` struct for dependency injection. This allows unit testing the restart decision logic without complex integration setup.

### Test updates (`pkg/transport/stdio_test.go`)

- Added `TestTransport_ZombieStateWhenDockerUnavailable` to verify the fix
- Updated `TestProcessStdout_EOFWithFailedReattachment`, `TestConcurrentReattachment`, and `TestStdinRaceCondition` with additional mock expectations for `Stop()` and `StopWorkload()` calls
- Updated test assertions to reflect the new behavior where stdin/stdout are nil after `Stop()` is called

## Testing

- [x] `TestTransport_ZombieStateWhenDockerUnavailable` - verifies transport shuts down properly when Docker is unavailable during re-attachment
- [x] `Test_monitorTransport` - verifies monitoring loop detects stopped transport, continues polling on errors, and respects context cancellation
- [x] `TestHandleTransportStopped` - verifies restart decision logic (restart when workload exists, no restart when removed, restart on check failure)
- [x] All existing transport and runner tests pass
- [ ] Manual e2e test with real docker outage 