### PR TITLE
Skip token injection when token exchange active

### DIFF
--- a/cmd/thv/app/proxy.go
+++ b/cmd/thv/app/proxy.go
@@ -416,7 +416,7 @@ func addExternalTokenMiddleware(middlewares *[]types.NamedMiddleware, tokenSourc
 			}
 		}
 		*middlewares = append(*middlewares, types.NamedMiddleware{
-			Name:     "token-exchange",
+			Name:     tokenexchange.MiddlewareType,
 			Function: tokenExchangeMiddleware,
 		})
 	} else if tokenSource != nil {

--- a/pkg/transport/http.go
+++ b/pkg/transport/http.go
@@ -13,6 +13,7 @@ import (
 
 	"golang.org/x/oauth2"
 
+	"github.com/stacklok/toolhive/pkg/auth/tokenexchange"
 	"github.com/stacklok/toolhive/pkg/container"
 	"github.com/stacklok/toolhive/pkg/container/docker"
 	rt "github.com/stacklok/toolhive/pkg/container/runtime"
@@ -176,6 +177,18 @@ func (t *HTTPTransport) createTokenInjectionMiddleware() types.MiddlewareFunctio
 	return middleware.CreateTokenInjectionMiddleware(t.tokenSource)
 }
 
+// hasTokenExchangeMiddleware checks if any middleware in the slice is a token exchange middleware.
+// When token exchange is configured, it handles its own Authorization header injection,
+// so the oauth-token-injection middleware should be skipped to avoid overwriting the exchanged token.
+func hasTokenExchangeMiddleware(middlewares []types.NamedMiddleware) bool {
+	for _, mw := range middlewares {
+		if mw.Name == tokenexchange.MiddlewareType {
+			return true
+		}
+	}
+	return false
+}
+
 // Mode returns the transport mode.
 func (t *HTTPTransport) Mode() types.TransportType {
 	return t.transportType
@@ -249,8 +262,9 @@ func (t *HTTPTransport) Start(ctx context.Context) error {
 
 	isRemote := t.remoteURL != ""
 
-	// Add OAuth token injection middleware for remote authentication if we have a token source
-	if isRemote && t.tokenSource != nil {
+	// Add OAuth token injection middleware for remote authentication if we have a token source.
+	// Skip if token exchange is configured (it handles its own Authorization header injection).
+	if isRemote && t.tokenSource != nil && !hasTokenExchangeMiddleware(t.middlewares) {
 		tokenMiddleware := t.createTokenInjectionMiddleware()
 		middlewares = append(middlewares, types.NamedMiddleware{
 			Name:     "oauth-token-injection",


### PR DESCRIPTION
When token exchange middleware is configured, it handles its own Authorization header injection. The oauth-token-injection middleware was being added anyway, potentially overwriting the exchanged token with the original OAuth token.

Add hasTokenExchangeMiddleware() to detect when token exchange is present and skip adding the redundant token injection middleware. Also fix the middleware name in proxy.go to use the MiddlewareType constant for consistent detection.

In practical terms what this enables is easier testing with:
```
  thv run \
    --token-exchange-audience 'backend' \
    --token-exchange-client-id blablabla \
    --token-exchange-client-secret foobar \
    --token-exchange-scopes 'backend-api:read' \
    --token-exchange-url https://blah \
    --remote-auth-bearer-token-file $(pwd)/token.auth \
```

What the fix enables is to read the token using the remote-auth