### PR TITLE
Add bearer token support for remote auth proxy

### DIFF
--- a/cmd/thv/app/proxy.go
+++ b/cmd/thv/app/proxy.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"os"
 	"os/signal"
 	"syscall"
 	"time"
@@ -17,6 +18,7 @@ import (
 	"github.com/stacklok/toolhive/pkg/auth"
 	"github.com/stacklok/toolhive/pkg/auth/discovery"
 	"github.com/stacklok/toolhive/pkg/auth/oauth"
+	"github.com/stacklok/toolhive/pkg/auth/remote"
 	"github.com/stacklok/toolhive/pkg/auth/tokenexchange"
 	"github.com/stacklok/toolhive/pkg/logger"
 	"github.com/stacklok/toolhive/pkg/networking"
@@ -202,7 +204,7 @@ func proxyCmdFunc(cmd *cobra.Command, args []string) error {
 	var oauthConfig *oauth.Config
 	var introspectionURL string
 
-	if remoteAuthFlags.EnableRemoteAuth || shouldDetectAuth() {
+	if shouldHandleOutgoingAuth() {
 		var result *discovery.OAuthFlowResult
 		result, err = handleOutgoingAuthentication(ctx)
 		if err != nil {
@@ -306,15 +308,36 @@ func getProxyOIDCConfig(cmd *cobra.Command) *auth.TokenValidatorConfig {
 	}
 }
 
-// shouldDetectAuth determines if we should try to detect authentication requirements
-func shouldDetectAuth() bool {
-	// Only try to detect auth if OAuth client ID is provided
-	// This prevents unnecessary requests when no OAuth config is available
-	return remoteAuthFlags.RemoteAuthClientID != ""
+// shouldHandleOutgoingAuth determines if outgoing authentication should be attempted.
+// This is true when:
+// - Remote auth is explicitly enabled via --remote-auth flag
+// - OAuth client ID is provided (allows auto-detection of auth requirements)
+// - Bearer token is configured via flag, file, or environment variable
+func shouldHandleOutgoingAuth() bool {
+	return remoteAuthFlags.EnableRemoteAuth ||
+		remoteAuthFlags.RemoteAuthClientID != "" ||
+		remoteAuthFlags.RemoteAuthBearerToken != "" ||
+		remoteAuthFlags.RemoteAuthBearerTokenFile != "" ||
+		os.Getenv(remote.BearerTokenEnvVarName) != ""
 }
 
 // handleOutgoingAuthentication handles authentication to the remote MCP server
 func handleOutgoingAuthentication(ctx context.Context) (*discovery.OAuthFlowResult, error) {
+	bearerToken, err := resolveSecret(
+		remoteAuthFlags.RemoteAuthBearerToken,
+		remoteAuthFlags.RemoteAuthBearerTokenFile,
+		remote.BearerTokenEnvVarName,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve bearer token: %w", err)
+	}
+	if bearerToken != "" {
+		logger.Debug("Using bearer token authentication for remote server")
+		return &discovery.OAuthFlowResult{
+			TokenSource: remote.NewBearerTokenSource(bearerToken),
+		}, nil
+	}
+
 	// Resolve client secret from multiple sources
 	clientSecret, err := resolveClientSecret()
 	if err != nil {


### PR DESCRIPTION
Previously, specifying --remote-auth-bearer-token without also setting --remote-auth or --remote-auth-client-id would silently ignore the bearer token. The authentication flow was never triggered.

Add shouldHandleOutgoingAuth() that also checks for bearer token configuration via flag, file, or environment variable. When a bearer token is configured, it is now used as Priority 1 in the authentication flow, before OAuth discovery.

This enables using a pre-obtained bearer token for token exchange without requiring a full OAuth configuration.