### PR TITLE
Make private IP error message context-agnostic

### DIFF
--- a/pkg/networking/utilities.go
+++ b/pkg/networking/utilities.go
@@ -14,8 +14,7 @@ import (
 
 const (
 	// ErrPrivateIpAddress is the error returned when the provided URL redirects to a private IP address
-	ErrPrivateIpAddress = "the provided registry URL redirects to a private IP address, which is not allowed; " +
-		"to override this, reset the registry URL using the --allow-private-ip (-p) flag"
+	ErrPrivateIpAddress = "the provided URL redirects to a private IP address, which is not allowed"
 )
 
 func init() {


### PR DESCRIPTION
Remove command-line flag reference from ErrPrivateIpAddress error message to avoid confusing third-party consumers like the registry server that may not expose the same flags. The error now provides a generic message that can be used across different contexts (CLI, API, registry).

Fixes #3018