### PR TITLE
Fix authorization bypass for unknown MCP methods

### DIFF
--- a/pkg/authz/middleware.go
+++ b/pkg/authz/middleware.go
@@ -22,20 +22,61 @@ import (
 )
 
 // MCPMethodToFeatureOperation maps MCP method names to feature and operation pairs.
+// Methods with empty Feature and Operation are always allowed (protocol-level).
+// Methods not in this map are denied by default for security.
 var MCPMethodToFeatureOperation = map[string]struct {
 	Feature   authorizers.MCPFeature
 	Operation authorizers.MCPOperation
 }{
-	"tools/call":      {Feature: authorizers.MCPFeatureTool, Operation: authorizers.MCPOperationCall},
-	"tools/list":      {Feature: authorizers.MCPFeatureTool, Operation: authorizers.MCPOperationList},
-	"prompts/get":     {Feature: authorizers.MCPFeaturePrompt, Operation: authorizers.MCPOperationGet},
-	"prompts/list":    {Feature: authorizers.MCPFeaturePrompt, Operation: authorizers.MCPOperationList},
-	"resources/read":  {Feature: authorizers.MCPFeatureResource, Operation: authorizers.MCPOperationRead},
-	"resources/list":  {Feature: authorizers.MCPFeatureResource, Operation: authorizers.MCPOperationList},
-	"features/list":   {Feature: "", Operation: authorizers.MCPOperationList},
-	"ping":            {Feature: "", Operation: ""}, // Always allowed
-	"progress/update": {Feature: "", Operation: ""}, // Always allowed
-	"initialize":      {Feature: "", Operation: ""}, // Always allowed
+	// Core protocol methods - always allowed
+	"initialize":      {Feature: "", Operation: ""}, // Protocol initialization
+	"ping":            {Feature: "", Operation: ""}, // Health check
+	"progress/update": {Feature: "", Operation: ""}, // Progress reporting
+
+	// Tool operations - require authorization
+	"tools/call": {Feature: authorizers.MCPFeatureTool, Operation: authorizers.MCPOperationCall},
+	"tools/list": {Feature: authorizers.MCPFeatureTool, Operation: authorizers.MCPOperationList},
+
+	// Prompt operations - require authorization
+	"prompts/get":  {Feature: authorizers.MCPFeaturePrompt, Operation: authorizers.MCPOperationGet},
+	"prompts/list": {Feature: authorizers.MCPFeaturePrompt, Operation: authorizers.MCPOperationList},
+
+	// Resource operations - require authorization
+	"resources/read":           {Feature: authorizers.MCPFeatureResource, Operation: authorizers.MCPOperationRead},
+	"resources/list":           {Feature: authorizers.MCPFeatureResource, Operation: authorizers.MCPOperationList},
+	"resources/templates/list": {Feature: authorizers.MCPFeatureResource, Operation: authorizers.MCPOperationList},
+	"resources/subscribe":      {Feature: authorizers.MCPFeatureResource, Operation: authorizers.MCPOperationRead},
+	"resources/unsubscribe":    {Feature: authorizers.MCPFeatureResource, Operation: authorizers.MCPOperationRead},
+
+	// Discovery and capability methods - always allowed
+	"features/list": {Feature: "", Operation: authorizers.MCPOperationList}, // Capability discovery
+	"roots/list":    {Feature: "", Operation: ""},                           // Root directory discovery
+
+	// Logging and client preferences - always allowed
+	"logging/setLevel": {Feature: "", Operation: ""}, // Client preference for server logging
+
+	// Argument completion - always allowed (UX feature)
+	"completion/complete": {Feature: "", Operation: ""}, // Argument completion for prompts/resources
+
+	// Notifications (server-to-client, informational) - always allowed
+	"notifications/message":                {Feature: "", Operation: ""}, // General notifications
+	"notifications/initialized":            {Feature: "", Operation: ""}, // Initialization complete
+	"notifications/progress":               {Feature: "", Operation: ""}, // Progress updates
+	"notifications/cancelled":              {Feature: "", Operation: ""}, // Request cancellation
+	"notifications/roots/list_changed":     {Feature: "", Operation: ""}, // Roots changed
+	"notifications/tools/list_changed":     {Feature: "", Operation: ""}, // Tools changed
+	"notifications/prompts/list_changed":   {Feature: "", Operation: ""}, // Prompts changed
+	"notifications/resources/list_changed": {Feature: "", Operation: ""}, // Resources changed
+	"notifications/resources/updated":      {Feature: "", Operation: ""}, // Resource updated
+	"notifications/tasks/status":           {Feature: "", Operation: ""}, // Task status update
+
+	// NOTE: The following MCP methods are NOT included and will be DENIED by default:
+	// - elicitation/create: User input prompting (requires new authorization feature)
+	// - sampling/createMessage: LLM text generation (security-sensitive, requires new authorization feature)
+	// - tasks/list, tasks/get, tasks/cancel, tasks/result: Task management (requires new authorization feature)
+	//
+	// To enable these methods, add appropriate authorization features/operations or add them
+	// to the always-allowed list above after security review.
 }
 
 // shouldSkipInitialAuthorization checks if the request should skip authorization
@@ -153,7 +194,15 @@ func Middleware(a authorizers.Authorizer, next http.Handler) http.Handler {
 		// Get the feature and operation from the method
 		featureOp, ok := MCPMethodToFeatureOperation[parsedRequest.Method]
 		if !ok {
-			// Unknown method, let the next handler deal with it
+			// Unknown method - deny by default for security
+			// Methods must be explicitly added to MCPMethodToFeatureOperation to be allowed
+			handleUnauthorized(w, parsedRequest.ID,
+				fmt.Errorf("unknown MCP method: %s (not configured for authorization)", parsedRequest.Method))
+			return
+		}
+
+		// Methods with empty feature and operation are always allowed (protocol-level)
+		if featureOp.Feature == "" && featureOp.Operation == "" {
 			next.ServeHTTP(w, r)
 			return
 		}

--- a/pkg/authz/middleware_test.go
+++ b/pkg/authz/middleware_test.go
@@ -206,6 +206,165 @@ func TestMiddleware(t *testing.T) {
 			expectStatus:     http.StatusOK,
 			expectAuthorized: true,
 		},
+		{
+			name:   "Resources subscribe requires authorization",
+			method: "resources/subscribe",
+			params: map[string]interface{}{
+				"uri": "data",
+			},
+			claims: jwt.MapClaims{
+				"sub":  "user123",
+				"name": "John Doe",
+			},
+			expectStatus:     http.StatusOK,
+			expectAuthorized: true,
+		},
+		{
+			name:   "Resources unsubscribe requires authorization",
+			method: "resources/unsubscribe",
+			params: map[string]interface{}{
+				"uri": "secret",
+			},
+			claims: jwt.MapClaims{
+				"sub":  "user123",
+				"name": "John Doe",
+			},
+			expectStatus:     http.StatusForbidden,
+			expectAuthorized: false,
+		},
+		{
+			name:   "Resources templates list is authorized and filtered",
+			method: "resources/templates/list",
+			params: map[string]interface{}{},
+			claims: jwt.MapClaims{
+				"sub":  "user123",
+				"name": "John Doe",
+			},
+			expectStatus:     http.StatusOK,
+			expectAuthorized: true,
+		},
+		{
+			name:   "Roots list is always allowed",
+			method: "roots/list",
+			params: map[string]interface{}{},
+			claims: jwt.MapClaims{
+				"sub":  "user123",
+				"name": "John Doe",
+			},
+			expectStatus:     http.StatusOK,
+			expectAuthorized: true,
+		},
+		{
+			name:   "Logging setLevel is always allowed",
+			method: "logging/setLevel",
+			params: map[string]interface{}{
+				"level": "debug",
+			},
+			claims: jwt.MapClaims{
+				"sub":  "user123",
+				"name": "John Doe",
+			},
+			expectStatus:     http.StatusOK,
+			expectAuthorized: true,
+		},
+		{
+			name:   "Completion complete is always allowed",
+			method: "completion/complete",
+			params: map[string]interface{}{
+				"ref": map[string]interface{}{
+					"name": "greeting",
+				},
+				"argument": map[string]interface{}{
+					"name":  "name",
+					"value": "Jo",
+				},
+			},
+			claims: jwt.MapClaims{
+				"sub":  "user123",
+				"name": "John Doe",
+			},
+			expectStatus:     http.StatusOK,
+			expectAuthorized: true,
+		},
+		{
+			name:   "Notifications are always allowed",
+			method: "notifications/message",
+			params: map[string]interface{}{
+				"method": "test",
+			},
+			claims: jwt.MapClaims{
+				"sub":  "user123",
+				"name": "John Doe",
+			},
+			expectStatus:     http.StatusOK,
+			expectAuthorized: true,
+		},
+		{
+			name:   "Unknown method is denied by default",
+			method: "unknown/method",
+			params: map[string]interface{}{},
+			claims: jwt.MapClaims{
+				"sub":  "user123",
+				"name": "John Doe",
+			},
+			expectStatus:     http.StatusForbidden,
+			expectAuthorized: false,
+		},
+		{
+			name:   "Sampling createMessage is denied by default (security-sensitive)",
+			method: "sampling/createMessage",
+			params: map[string]interface{}{
+				"messages": []interface{}{
+					map[string]interface{}{
+						"role":    "user",
+						"content": map[string]interface{}{"type": "text", "text": "Hello"},
+					},
+				},
+			},
+			claims: jwt.MapClaims{
+				"sub":  "user123",
+				"name": "John Doe",
+			},
+			expectStatus:     http.StatusForbidden,
+			expectAuthorized: false,
+		},
+		{
+			name:   "Elicitation create is denied by default",
+			method: "elicitation/create",
+			params: map[string]interface{}{
+				"message": "Enter your name",
+			},
+			claims: jwt.MapClaims{
+				"sub":  "user123",
+				"name": "John Doe",
+			},
+			expectStatus:     http.StatusForbidden,
+			expectAuthorized: false,
+		},
+		{
+			name:   "Tasks list is denied by default",
+			method: "tasks/list",
+			params: map[string]interface{}{},
+			claims: jwt.MapClaims{
+				"sub":  "user123",
+				"name": "John Doe",
+			},
+			expectStatus:     http.StatusForbidden,
+			expectAuthorized: false,
+		},
+		{
+			name:   "Tasks get is denied by default",
+			method: "tasks/get",
+			params: map[string]interface{}{
+				"taskId": "task-123",
+			},
+			claims: jwt.MapClaims{
+				"sub":  "user123",
+				"name": "John Doe",
+			},
+			expectStatus:     http.StatusForbidden,
+			expectAuthorized: false,
+		},
 	}
 
 	// Run test cases


### PR DESCRIPTION
Previously, MCP methods not in the MCPMethodToFeatureOperation map bypassed authorization checks entirely, allowing unauthenticated access to security-sensitive operations like sampling/createMessage (LLM text generation), elicitation/create, and task management methods.

This commit switches to a default-deny security model where:
  - Unknown methods are rejected with a clear error message
  - All methods must be explicitly configured in the authorization map
  - Protocol-level methods (ping, initialize, notifications) are explicitly marked as always-allowed
  - Security-sensitive methods are explicitly denied until proper authorization features are implemented

Closes: #3168