### PR TITLE
Return 404 for not-found errors in workload API endpoints

### DIFF
--- a/pkg/api/v1/workloads.go
+++ b/pkg/api/v1/workloads.go
@@ -172,11 +172,18 @@ func (s *WorkloadRoutes) getWorkload(w http.ResponseWriter, r *http.Request) err
 //	@Failure		404		{string}	string	"Not Found"
 //	@Router			/api/v1beta/workloads/{name}/stop [post]
 func (s *WorkloadRoutes) stopWorkload(w http.ResponseWriter, r *http.Request) error {
+	ctx := r.Context()
 	name := chi.URLParam(r, "name")
+
+	// Check if workload exists first
+	_, err := s.workloadManager.GetWorkload(ctx, name)
+	if err != nil {
+		return err // ErrWorkloadNotFound (404) or ErrInvalidWorkloadName (400) already have status codes
+	}
 
 	// Use the bulk method with a single workload
 	// Use background context since this is async operation
-	_, err := s.workloadManager.StopWorkloads(context.Background(), []string{name})
+	_, err = s.workloadManager.StopWorkloads(context.Background(), []string{name})
 	if err != nil {
 		return err // ErrInvalidWorkloadName already has 400 status code
 	}
@@ -195,11 +202,19 @@ func (s *WorkloadRoutes) stopWorkload(w http.ResponseWriter, r *http.Request) er
 //	@Failure		404		{string}	string	"Not Found"
 //	@Router			/api/v1beta/workloads/{name}/restart [post]
 func (s *WorkloadRoutes) restartWorkload(w http.ResponseWriter, r *http.Request) error {
+	ctx := r.Context()
 	name := chi.URLParam(r, "name")
+
+	// Check if workload exists first
+	_, err := s.workloadManager.GetWorkload(ctx, name)
+	if err != nil {
+		return err // ErrWorkloadNotFound (404) or ErrInvalidWorkloadName (400) already have status codes
+	}
 
 	// Use the bulk method with a single workload
 	// Note: In the API, we always assume that the restart is a background operation
-	_, err := s.workloadManager.RestartWorkloads(context.Background(), []string{name}, false)
+	// Use background context since this is async operation
+	_, err = s.workloadManager.RestartWorkloads(context.Background(), []string{name}, false)
 	if err != nil {
 		return err // ErrInvalidWorkloadName already has 400 status code
 	}
@@ -218,11 +233,18 @@ func (s *WorkloadRoutes) restartWorkload(w http.ResponseWriter, r *http.Request)
 //	@Failure		404		{string}	string	"Not Found"
 //	@Router			/api/v1beta/workloads/{name} [delete]
 func (s *WorkloadRoutes) deleteWorkload(w http.ResponseWriter, r *http.Request) error {
+	ctx := r.Context()
 	name := chi.URLParam(r, "name")
+
+	// Check if workload exists first
+	_, err := s.workloadManager.GetWorkload(ctx, name)
+	if err != nil {
+		return err // ErrWorkloadNotFound (404) or ErrInvalidWorkloadName (400) already have status codes
+	}
 
 	// Use the bulk method with a single workload
 	// Use background context since this is an async operation
-	_, err := s.workloadManager.DeleteWorkloads(context.Background(), []string{name})
+	_, err = s.workloadManager.DeleteWorkloads(context.Background(), []string{name})
 	if err != nil {
 		return err // ErrInvalidWorkloadName already has 400 status code
 	}
@@ -390,6 +412,7 @@ func (s *WorkloadRoutes) stopWorkloadsBulk(w http.ResponseWriter, r *http.Reques
 
 	// Note that this is an asynchronous operation.
 	// The request is not blocked on completion.
+	// Use background context since this is async operation (handles partial failures gracefully)
 	_, err = s.workloadManager.StopWorkloads(context.Background(), workloadNames)
 	if err != nil {
 		return err // ErrInvalidWorkloadName already has 400 status code
@@ -431,6 +454,7 @@ func (s *WorkloadRoutes) restartWorkloadsBulk(w http.ResponseWriter, r *http.Req
 	// Note that this is an asynchronous operation.
 	// The request is not blocked on completion.
 	// Note: In the API, we always assume that the restart is a background operation.
+	// Use background context since this is async operation (handles partial failures gracefully)
 	_, err = s.workloadManager.RestartWorkloads(context.Background(), workloadNames, false)
 	if err != nil {
 		return err // ErrInvalidWorkloadName already has 400 status code


### PR DESCRIPTION
While adding E2E tests for the workloads API, I discovered that the stop/restart/delete API endpoints return 202s when the specified workload does not exist. This is a side effect of the implementation - the endpoints for single stop/restart/delete use the same underlying logic which is used for the bulk endpoints. I addressed this by explicitly checking to see if the workload exists before calling the methods in the workload manager to do the work. This duplicates work slightly, but provides a better API experience.