### PR TITLE
fix(#3411) - waitForStatefulSet waits for the latest generation

### DIFF
--- a/pkg/container/kubernetes/client.go
+++ b/pkg/container/kubernetes/client.go
@@ -631,7 +631,7 @@ func (c *Client) IsRunning(ctx context.Context) error {
 // 2. UpdatedReplicas == Replicas (all pods are on the new spec)
 // 3. ReadyReplicas == Replicas (all pods are ready)
 func isStatefulSetReady(desiredGeneration int64, currentSts *appsv1.StatefulSet) bool {
-	if currentSts.Spec.Replicas == nil {
+	if currentSts == nil || currentSts.Spec.Replicas == nil {
 		return false
 	}
 

--- a/pkg/container/kubernetes/client_test.go
+++ b/pkg/container/kubernetes/client_test.go
@@ -1109,4 +1109,46 @@ func Test_isStatefulSetReady(t *testing.T) {
 			assert.Equal(t, tc.expectedReady, result)
 		})
 	}
+
+	// Test nil/zero value edge cases - all should return false
+	nilTests := []struct {
+		name  string
+		input *appsv1.StatefulSet
+	}{
+		{
+			name:  "nil_statefulset",
+			input: nil,
+		},
+		{
+			name:  "empty_statefulset",
+			input: &appsv1.StatefulSet{},
+		},
+		{
+			name: "spec_replicas_nil",
+			input: &appsv1.StatefulSet{
+				Status: appsv1.StatefulSetStatus{
+					ObservedGeneration: 1,
+					UpdatedReplicas:    1,
+					ReadyReplicas:      1,
+				},
+			},
+		},
+		{
+			name: "status_all_zero",
+			input: &appsv1.StatefulSet{
+				Spec: appsv1.StatefulSetSpec{
+					Replicas: func() *int32 { v := int32(1); return &v }(),
+				},
+			},
+		},
+	}
+
+	for _, tc := range nilTests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := isStatefulSetReady(1, tc.input)
+			assert.False(t, result)
+		})
+	}
 }


### PR DESCRIPTION
## Summary

Fixes a race condition in `waitForStatefulSetReady` that causes the proxy to start before the new MCP pod is ready during rolling updates, leading to DNS lookup failures and restart loops.

Closes #3411

## Problem

During a StatefulSet rolling update, `waitForStatefulSetReady` only checked `ReadyReplicas == Replicas`. This could return "ready" when:
- The OLD pod was still ready (`ReadyReplicas = 1`)
- The controller hadn't processed our spec yet (`ObservedGeneration < desiredGeneration`)
- No pods were updated to the new spec (`UpdatedReplicas = 0`)

The proxy would start, attempt to connect to the headless service, but the backing pod was being rolled. DNS lookups failed with `no such host`, the health monitor detected the failure, and both pods entered a restart loop.

## Solution

Update `isStatefulSetReady` to check all three conditions before considering the StatefulSet ready:

1. `ObservedGeneration >= desiredGeneration` (controller processed our spec)
2. `UpdatedReplicas == Replicas` (all pods on new spec)
3. `ReadyReplicas == Replicas` (all pods ready)

## Changes

The commit history incrementally introduces changes for easy reading:
1. Extract `isStatefulSetReady` as a private, unit-testable function. Add unit tests demonstrating the bug.
2. Add `desiredGeneration` parameter to `waitForStatefulSetReady` to track the generation from the Apply call.
3. Fix the bug by waiting until the statefulset is on the `desiredGeneration`.

## Testing

- Added 11 unit tests covering:
  - Controller not caught up (old pod ready)
  - Controller caught up but no new pods
  - New pod starting but not ready
  - Rolling update complete
  - Steady state
  - Multi-replica rolling update scenarios (0/3, 1/3, 2/3, 3/3 updated)

All tests pass.