### PR TITLE
Refactor health status to separate status from reason

### DIFF
--- a/pkg/vmcp/health/helpers.go
+++ b/pkg/vmcp/health/helpers.go
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package health
+
+import (
+	"strings"
+
+	"github.com/stacklok/toolhive/pkg/vmcp"
+)
+
+// containsAuthError checks if a lowercase error string contains authentication-related patterns.
+// This consolidates authentication error detection to avoid repeated string.Contains checks.
+func containsAuthError(errLower string) bool {
+	return strings.Contains(errLower, "authentication failed") ||
+		strings.Contains(errLower, "authentication error") ||
+		strings.Contains(errLower, "401 unauthorized") ||
+		strings.Contains(errLower, "403 forbidden") ||
+		strings.Contains(errLower, "http 401") ||
+		strings.Contains(errLower, "http 403") ||
+		strings.Contains(errLower, "status code 401") ||
+		strings.Contains(errLower, "status code 403") ||
+		strings.Contains(errLower, "request unauthenticated") ||
+		strings.Contains(errLower, "request unauthorized") ||
+		strings.Contains(errLower, "access denied")
+}
+
+// containsTimeoutError checks if a lowercase error string contains timeout-related patterns.
+func containsTimeoutError(errLower string) bool {
+	return strings.Contains(errLower, "timeout") ||
+		strings.Contains(errLower, "deadline exceeded")
+}
+
+// containsConnectionError checks if a lowercase error string contains connection-related patterns.
+func containsConnectionError(errLower string) bool {
+	return strings.Contains(errLower, "connection refused") ||
+		strings.Contains(errLower, "connection reset") ||
+		strings.Contains(errLower, "no route to host") ||
+		strings.Contains(errLower, "network is unreachable")
+}
+
+// categorizeConnectionErrorByString determines the specific connection error reason
+// based on error string patterns. This provides more granular categorization than
+// the generic "connection error" classification.
+//
+// Returns:
+//   - ReasonConnectionRefused: For "connection refused" errors
+//   - ReasonNetworkUnreachable: For network routing issues
+//   - ReasonHealthCheckFailed: For other connection errors (reset, broken pipe, etc.)
+func categorizeConnectionErrorByString(errLower string) vmcp.BackendHealthReason {
+	if strings.Contains(errLower, "connection refused") {
+		return vmcp.ReasonConnectionRefused
+	}
+
+	// Fix: Add explicit parentheses to avoid boolean precedence confusion
+	// This checks: (network AND unreachable) OR (no route to host)
+	if (strings.Contains(errLower, "network") && strings.Contains(errLower, "unreachable")) ||
+		strings.Contains(errLower, "no route to host") {
+		return vmcp.ReasonNetworkUnreachable
+	}
+
+	// Other connection errors (reset, broken pipe, etc.)
+	return vmcp.ReasonHealthCheckFailed
+}

--- a/pkg/vmcp/health/helpers_test.go
+++ b/pkg/vmcp/health/helpers_test.go
@@ -1,0 +1,200 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package health
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/stacklok/toolhive/pkg/vmcp"
+)
+
+func TestContainsAuthError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		errLower string
+		expected bool
+	}{
+		// Positive cases
+		{name: "authentication failed", errLower: "authentication failed", expected: true},
+		{name: "authentication error", errLower: "authentication error: bad token", expected: true},
+		{name: "401 unauthorized", errLower: "401 unauthorized", expected: true},
+		{name: "403 forbidden", errLower: "403 forbidden", expected: true},
+		{name: "http 401", errLower: "http 401", expected: true},
+		{name: "http 403", errLower: "http 403", expected: true},
+		{name: "status code 401", errLower: "status code 401", expected: true},
+		{name: "status code 403", errLower: "status code 403", expected: true},
+		{name: "request unauthenticated", errLower: "request unauthenticated", expected: true},
+		{name: "request unauthorized", errLower: "request unauthorized", expected: true},
+		{name: "access denied", errLower: "access denied", expected: true},
+
+		// Negative cases
+		{name: "connection refused", errLower: "connection refused", expected: false},
+		{name: "timeout", errLower: "request timeout", expected: false},
+		{name: "generic error", errLower: "something went wrong", expected: false},
+		{name: "404 not found", errLower: "404 not found", expected: false},
+		{name: "500 error", errLower: "500 internal server error", expected: false},
+		{name: "hostname with 401", errLower: "http://backend401.example.com", expected: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := containsAuthError(tt.errLower)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestContainsTimeoutError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		errLower string
+		expected bool
+	}{
+		// Positive cases
+		{name: "timeout", errLower: "request timeout", expected: true},
+		{name: "deadline exceeded", errLower: "deadline exceeded", expected: true},
+		{name: "context deadline exceeded", errLower: "context deadline exceeded", expected: true},
+
+		// Negative cases
+		{name: "connection refused", errLower: "connection refused", expected: false},
+		{name: "authentication failed", errLower: "authentication failed", expected: false},
+		{name: "generic error", errLower: "something went wrong", expected: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := containsTimeoutError(tt.errLower)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestContainsConnectionError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		errLower string
+		expected bool
+	}{
+		// Positive cases
+		{name: "connection refused", errLower: "connection refused", expected: true},
+		{name: "connection reset", errLower: "connection reset by peer", expected: true},
+		{name: "no route to host", errLower: "no route to host", expected: true},
+		{name: "network is unreachable", errLower: "network is unreachable", expected: true},
+
+		// Negative cases
+		{name: "timeout", errLower: "request timeout", expected: false},
+		{name: "authentication failed", errLower: "authentication failed", expected: false},
+		{name: "generic error", errLower: "something went wrong", expected: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := containsConnectionError(tt.errLower)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestCategorizeConnectionErrorByString(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		errLower       string
+		expectedReason vmcp.BackendHealthReason
+	}{
+		{
+			name:           "connection refused",
+			errLower:       "connection refused",
+			expectedReason: vmcp.ReasonConnectionRefused,
+		},
+		{
+			name:           "network is unreachable",
+			errLower:       "network is unreachable",
+			expectedReason: vmcp.ReasonNetworkUnreachable,
+		},
+		{
+			name:           "no route to host",
+			errLower:       "no route to host",
+			expectedReason: vmcp.ReasonNetworkUnreachable,
+		},
+		{
+			name:           "connection reset",
+			errLower:       "connection reset by peer",
+			expectedReason: vmcp.ReasonHealthCheckFailed,
+		},
+		{
+			name:           "broken pipe",
+			errLower:       "broken pipe",
+			expectedReason: vmcp.ReasonHealthCheckFailed,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			reason := categorizeConnectionErrorByString(tt.errLower)
+			assert.Equal(t, tt.expectedReason, reason)
+		})
+	}
+}
+
+func TestCategorizeConnectionErrorByString_BooleanPrecedence(t *testing.T) {
+	t.Parallel()
+
+	// This test verifies the fix for the boolean precedence bug
+	// Without parentheses: A && B || C evaluates as (A && B) || C
+	// With fix: (A && B) || C is explicit
+
+	tests := []struct {
+		name           string
+		errLower       string
+		expectedReason vmcp.BackendHealthReason
+		description    string
+	}{
+		{
+			name:           "network unreachable (both keywords)",
+			errLower:       "network is unreachable",
+			expectedReason: vmcp.ReasonNetworkUnreachable,
+			description:    "Should match: network AND unreachable",
+		},
+		{
+			name:           "no route to host",
+			errLower:       "no route to host",
+			expectedReason: vmcp.ReasonNetworkUnreachable,
+			description:    "Should match: no route to host (OR condition)",
+		},
+		{
+			name:           "just network (not unreachable)",
+			errLower:       "network error occurred",
+			expectedReason: vmcp.ReasonHealthCheckFailed,
+			description:    "Should NOT match: network without unreachable",
+		},
+		{
+			name:           "just unreachable (not network)",
+			errLower:       "service unreachable",
+			expectedReason: vmcp.ReasonHealthCheckFailed,
+			description:    "Should NOT match: unreachable without network",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			reason := categorizeConnectionErrorByString(tt.errLower)
+			assert.Equal(t, tt.expectedReason, reason, tt.description)
+		})
+	}
+}

--- a/pkg/vmcp/health/monitor_test.go
+++ b/pkg/vmcp/health/monitor_test.go
@@ -517,21 +517,19 @@ func TestSummary_String(t *testing.T) {
 	t.Parallel()
 
 	summary := Summary{
-		Total:           10,
-		Healthy:         5,
-		Degraded:        1,
-		Unhealthy:       2,
-		Unknown:         1,
-		Unauthenticated: 1,
+		Total:     9,
+		Healthy:   5,
+		Degraded:  1,
+		Unhealthy: 2,
+		Unknown:   1,
 	}
 
 	str := summary.String()
-	assert.Contains(t, str, "total=10")
+	assert.Contains(t, str, "total=9")
 	assert.Contains(t, str, "healthy=5")
 	assert.Contains(t, str, "degraded=1")
 	assert.Contains(t, str, "unhealthy=2")
 	assert.Contains(t, str, "unknown=1")
-	assert.Contains(t, str, "unauthenticated=1")
 }
 
 // testContextKey is a custom type for context keys in tests

--- a/pkg/vmcp/registry_test.go
+++ b/pkg/vmcp/registry_test.go
@@ -58,7 +58,7 @@ func TestNewImmutableRegistry(t *testing.T) {
 				{ID: "degraded", HealthStatus: BackendDegraded},
 				{ID: "unhealthy", HealthStatus: BackendUnhealthy},
 				{ID: "unknown", HealthStatus: BackendUnknown},
-				{ID: "unauthenticated", HealthStatus: BackendUnauthenticated},
+				{ID: "auth_failed", HealthStatus: BackendUnhealthy, HealthReason: ReasonAuthenticationFailed},
 			},
 			expectedCount: 5,
 		},
@@ -558,7 +558,6 @@ func TestBackendToTarget(t *testing.T) {
 			BackendDegraded,
 			BackendUnhealthy,
 			BackendUnknown,
-			BackendUnauthenticated,
 		}
 
 		for _, status := range statuses {
@@ -649,7 +648,6 @@ func TestDomainTypes_BackendHealthStatus(t *testing.T) {
 		{BackendDegraded, "degraded"},
 		{BackendUnhealthy, "unhealthy"},
 		{BackendUnknown, "unknown"},
-		{BackendUnauthenticated, "unauthenticated"},
 	}
 
 	for _, tt := range tests {

--- a/pkg/vmcp/types_test.go
+++ b/pkg/vmcp/types_test.go
@@ -37,11 +37,6 @@ func TestBackendHealthStatus_ToCRDStatus(t *testing.T) {
 			expected: testStatusUnavailable,
 		},
 		{
-			name:     "unauthenticated maps to unavailable",
-			status:   BackendUnauthenticated,
-			expected: testStatusUnavailable,
-		},
-		{
 			name:     "unknown maps to unknown",
 			status:   BackendUnknown,
 			expected: "unknown",
@@ -78,7 +73,6 @@ func TestBackendHealthStatus_ToCRDStatus_AllHealthStatusesCovered(t *testing.T) 
 		BackendDegraded,
 		BackendUnhealthy,
 		BackendUnknown,
-		BackendUnauthenticated,
 	}
 
 	// Verify each status maps to a valid CRD status

--- a/pkg/workloads/manager.go
+++ b/pkg/workloads/manager.go
@@ -241,7 +241,9 @@ func mapWorkloadStatusToVMCPHealth(status rt.WorkloadStatus) vmcp.BackendHealthS
 	case rt.WorkloadStatusStarting, rt.WorkloadStatusUnknown:
 		return vmcp.BackendUnknown
 	case rt.WorkloadStatusUnauthenticated:
-		return vmcp.BackendUnauthenticated
+		// Unauthenticated workloads are unhealthy (status) with authentication_failed (reason)
+		// The reason is handled separately by the health checker
+		return vmcp.BackendUnhealthy
 	default:
 		return vmcp.BackendUnknown
 	}


### PR DESCRIPTION
Previously, BackendHealthStatus conflated WHAT the status is with WHY the backend is in that state. For example, BackendUnauthenticated was both a status value and a reason, making it unclear whether a backend was unavailable due to authentication issues or other causes.

This improves observability by providing clear separation between the backend's availability state and the underlying cause of that state.

Related-to: #3147

This change introduces BackendHealthReason to explicitly capture WHY a backend is in its current state, while BackendHealthStatus describes WHAT the state is (healthy, degraded, unhealthy, unknown).