### PR TITLE
Add client capacity enforcement to authserver storage layer

### DIFF
--- a/pkg/authserver/storage/config.go
+++ b/pkg/authserver/storage/config.go
@@ -40,6 +40,10 @@ const (
 
 	// DefaultPKCETTL is the default TTL for PKCE requests (same as auth codes).
 	DefaultPKCETTL = 10 * time.Minute
+
+	// DefaultMaxClients is the default maximum number of registered clients.
+	// 0 means unlimited.
+	DefaultMaxClients = 100
 )
 
 // Config configures the storage backend.

--- a/pkg/authserver/storage/types.go
+++ b/pkg/authserver/storage/types.go
@@ -43,6 +43,10 @@ var (
 	// ErrInvalidBinding is returned when token binding validation fails
 	// (e.g., subject or client ID mismatch).
 	ErrInvalidBinding = errors.New("storage: token binding validation failed")
+
+	// ErrCapacityExceeded is returned when a storage limit has been reached
+	// (e.g., maximum number of registered clients).
+	ErrCapacityExceeded = errors.New("storage: capacity exceeded")
 )
 
 // DefaultPendingAuthorizationTTL is the default TTL for pending authorization requests.


### PR DESCRIPTION
Introduce a configurable maximum client limit (DefaultMaxClients=100) with ErrCapacityExceeded sentinel error. MemoryStorage enforces the limit in RegisterClient and exposes WithMaxClients option.