### PR TITLE
authserver DCR hardening: Add grant_types and response_types allowlis…

### DIFF
--- a/pkg/authserver/server/registration/client.go
+++ b/pkg/authserver/server/registration/client.go
@@ -100,11 +100,11 @@ type Config struct {
 	Public bool
 
 	// GrantTypes overrides the default grant types.
-	// If nil or empty, DefaultGrantTypes is used.
+	// If nil or empty, defaultGrantTypes is used.
 	GrantTypes []string
 
 	// ResponseTypes overrides the default response types.
-	// If nil or empty, DefaultResponseTypes is used.
+	// If nil or empty, defaultResponseTypes is used.
 	ResponseTypes []string
 
 	// Scopes overrides the default scopes.
@@ -121,12 +121,12 @@ func New(cfg Config) (fosite.Client, error) {
 	// Apply defaults for empty slices
 	grantTypes := cfg.GrantTypes
 	if len(grantTypes) == 0 {
-		grantTypes = DefaultGrantTypes
+		grantTypes = defaultGrantTypes
 	}
 
 	responseTypes := cfg.ResponseTypes
 	if len(responseTypes) == 0 {
-		responseTypes = DefaultResponseTypes
+		responseTypes = defaultResponseTypes
 	}
 
 	scopes := cfg.Scopes

--- a/pkg/authserver/server/registration/client_test.go
+++ b/pkg/authserver/server/registration/client_test.go
@@ -281,8 +281,8 @@ func TestNewClient_PublicClient(t *testing.T) {
 	assert.Equal(t, []string{"http://127.0.0.1:8080/callback"}, client.GetRedirectURIs())
 
 	// Check defaults are applied (use ElementsMatch since fosite returns fosite.Arguments type)
-	assert.ElementsMatch(t, DefaultGrantTypes, client.GetGrantTypes())
-	assert.ElementsMatch(t, DefaultResponseTypes, client.GetResponseTypes())
+	assert.ElementsMatch(t, defaultGrantTypes, client.GetGrantTypes())
+	assert.ElementsMatch(t, defaultResponseTypes, client.GetResponseTypes())
 	assert.ElementsMatch(t, DefaultScopes, client.GetScopes())
 }
 
@@ -313,8 +313,8 @@ func TestNewClient_ConfidentialClient(t *testing.T) {
 	assert.NoError(t, err, "stored secret should be bcrypt hash of plaintext")
 
 	// Check defaults are applied (use ElementsMatch since fosite returns fosite.Arguments type)
-	assert.ElementsMatch(t, DefaultGrantTypes, client.GetGrantTypes())
-	assert.ElementsMatch(t, DefaultResponseTypes, client.GetResponseTypes())
+	assert.ElementsMatch(t, defaultGrantTypes, client.GetGrantTypes())
+	assert.ElementsMatch(t, defaultResponseTypes, client.GetResponseTypes())
 	assert.ElementsMatch(t, DefaultScopes, client.GetScopes())
 }
 
@@ -375,7 +375,7 @@ func TestNewClient_EmptySlicesUseDefaults(t *testing.T) {
 	require.NoError(t, err)
 
 	// Use ElementsMatch since fosite returns fosite.Arguments type
-	assert.ElementsMatch(t, DefaultGrantTypes, client.GetGrantTypes())
-	assert.ElementsMatch(t, DefaultResponseTypes, client.GetResponseTypes())
+	assert.ElementsMatch(t, defaultGrantTypes, client.GetGrantTypes())
+	assert.ElementsMatch(t, defaultResponseTypes, client.GetResponseTypes())
 	assert.ElementsMatch(t, DefaultScopes, client.GetScopes())
 }

--- a/pkg/authserver/server/registration/dcr_test.go
+++ b/pkg/authserver/server/registration/dcr_test.go
@@ -158,8 +158,8 @@ func TestValidateDCRRequest(t *testing.T) {
 			},
 			expectError:        false,
 			expectedAuthMethod: "none",
-			expectedGrants:     DefaultGrantTypes,
-			expectedResponses:  DefaultResponseTypes,
+			expectedGrants:     defaultGrantTypes,
+			expectedResponses:  defaultResponseTypes,
 		},
 		{
 			name: "valid request with all fields specified",
@@ -182,8 +182,8 @@ func TestValidateDCRRequest(t *testing.T) {
 			},
 			expectError:        false,
 			expectedAuthMethod: "none",
-			expectedGrants:     DefaultGrantTypes,
-			expectedResponses:  DefaultResponseTypes,
+			expectedGrants:     defaultGrantTypes,
+			expectedResponses:  defaultResponseTypes,
 		},
 
 		// Empty redirect_uris
@@ -290,7 +290,7 @@ func TestValidateDCRRequest(t *testing.T) {
 				GrantTypes:   []string{},
 			},
 			expectError:    false,
-			expectedGrants: DefaultGrantTypes,
+			expectedGrants: defaultGrantTypes,
 		},
 		{
 			name: "grant_types defaults when nil",
@@ -299,7 +299,7 @@ func TestValidateDCRRequest(t *testing.T) {
 				GrantTypes:   nil,
 			},
 			expectError:    false,
-			expectedGrants: DefaultGrantTypes,
+			expectedGrants: defaultGrantTypes,
 		},
 		{
 			name: "grant_types without authorization_code fails",
@@ -328,6 +328,15 @@ func TestValidateDCRRequest(t *testing.T) {
 			expectError:    false,
 			expectedGrants: []string{"authorization_code"},
 		},
+		{
+			name: "grant_types with unsupported type rejected",
+			request: &DCRRequest{
+				RedirectURIs: []string{"http://127.0.0.1/callback"},
+				GrantTypes:   []string{"authorization_code", "client_credentials"},
+			},
+			expectError: true,
+			errorCode:   DCRErrorInvalidClientMetadata,
+		},
 
 		// response_types validation
 		{
@@ -337,7 +346,7 @@ func TestValidateDCRRequest(t *testing.T) {
 				ResponseTypes: []string{},
 			},
 			expectError:       false,
-			expectedResponses: DefaultResponseTypes,
+			expectedResponses: defaultResponseTypes,
 		},
 		{
 			name: "response_types defaults when nil",
@@ -346,7 +355,7 @@ func TestValidateDCRRequest(t *testing.T) {
 				ResponseTypes: nil,
 			},
 			expectError:       false,
-			expectedResponses: DefaultResponseTypes,
+			expectedResponses: defaultResponseTypes,
 		},
 		{
 			name: "response_types without code fails",
@@ -376,21 +385,38 @@ func TestValidateDCRRequest(t *testing.T) {
 			expectedResponses: []string{"code"},
 		},
 		{
-			name: "response_types with code and others passes",
+			name: "response_types with unsupported type rejected",
 			request: &DCRRequest{
 				RedirectURIs:  []string{"http://127.0.0.1/callback"},
 				ResponseTypes: []string{"code", "token"},
 			},
-			expectError:       false,
-			expectedResponses: []string{"code", "token"},
+			expectError: true,
+			errorCode:   DCRErrorInvalidClientMetadata,
 		},
 
-		// ClientName preservation
+		// ClientName validation
 		{
 			name: "client_name is preserved",
 			request: &DCRRequest{
 				RedirectURIs: []string{"http://127.0.0.1/callback"},
 				ClientName:   "My Application",
+			},
+			expectError: false,
+		},
+		{
+			name: "client_name exceeding max length is rejected",
+			request: &DCRRequest{
+				RedirectURIs: []string{"http://127.0.0.1/callback"},
+				ClientName:   strings.Repeat("a", MaxClientNameLength+1),
+			},
+			expectError: true,
+			errorCode:   DCRErrorInvalidClientMetadata,
+		},
+		{
+			name: "client_name at max length is accepted",
+			request: &DCRRequest{
+				RedirectURIs: []string{"http://127.0.0.1/callback"},
+				ClientName:   strings.Repeat("a", MaxClientNameLength),
 			},
 			expectError: false,
 		},
@@ -443,9 +469,9 @@ func TestDefaultGrantTypesAndResponseTypes(t *testing.T) {
 	t.Parallel()
 
 	// Verify default grant types include authorization_code
-	assert.Contains(t, DefaultGrantTypes, "authorization_code")
-	assert.Contains(t, DefaultGrantTypes, "refresh_token")
+	assert.Contains(t, defaultGrantTypes, "authorization_code")
+	assert.Contains(t, defaultGrantTypes, "refresh_token")
 
 	// Verify default response types include code
-	assert.Contains(t, DefaultResponseTypes, "code")
+	assert.Contains(t, defaultResponseTypes, "code")
 }


### PR DESCRIPTION
…t validation

Reject unsupported grant types and response types in DCR validation to prevent clients from requesting capabilities the server cannot fulfill (e.g. client_credentials, implicit token).