### PR TITLE
Return 400 for bad clients instead of 500s

### DIFF
--- a/docs/server/docs.go
+++ b/docs/server/docs.go
@@ -2161,7 +2161,7 @@ const docTemplate = `{
                                 }
                             }
                         },
-                        "description": "Invalid request"
+                        "description": "Invalid request or unsupported client type"
                     }
                 },
                 "summary": "Register a new client",
@@ -2215,7 +2215,7 @@ const docTemplate = `{
                                 }
                             }
                         },
-                        "description": "Invalid request"
+                        "description": "Invalid request or unsupported client type"
                     }
                 },
                 "summary": "Register multiple clients",
@@ -2259,7 +2259,7 @@ const docTemplate = `{
                                 }
                             }
                         },
-                        "description": "Invalid request"
+                        "description": "Invalid request or unsupported client type"
                     }
                 },
                 "summary": "Unregister multiple clients",
@@ -2294,7 +2294,7 @@ const docTemplate = `{
                                 }
                             }
                         },
-                        "description": "Invalid request"
+                        "description": "Invalid request or unsupported client type"
                     }
                 },
                 "summary": "Unregister a client",
@@ -2338,7 +2338,7 @@ const docTemplate = `{
                                 }
                             }
                         },
-                        "description": "Invalid request"
+                        "description": "Invalid request or unsupported client type"
                     },
                     "404": {
                         "content": {

--- a/docs/server/swagger.json
+++ b/docs/server/swagger.json
@@ -2154,7 +2154,7 @@
                                 }
                             }
                         },
-                        "description": "Invalid request"
+                        "description": "Invalid request or unsupported client type"
                     }
                 },
                 "summary": "Register a new client",
@@ -2208,7 +2208,7 @@
                                 }
                             }
                         },
-                        "description": "Invalid request"
+                        "description": "Invalid request or unsupported client type"
                     }
                 },
                 "summary": "Register multiple clients",
@@ -2252,7 +2252,7 @@
                                 }
                             }
                         },
-                        "description": "Invalid request"
+                        "description": "Invalid request or unsupported client type"
                     }
                 },
                 "summary": "Unregister multiple clients",
@@ -2287,7 +2287,7 @@
                                 }
                             }
                         },
-                        "description": "Invalid request"
+                        "description": "Invalid request or unsupported client type"
                     }
                 },
                 "summary": "Unregister a client",
@@ -2331,7 +2331,7 @@
                                 }
                             }
                         },
-                        "description": "Invalid request"
+                        "description": "Invalid request or unsupported client type"
                     },
                     "404": {
                         "content": {

--- a/docs/server/swagger.yaml
+++ b/docs/server/swagger.yaml
@@ -1797,7 +1797,7 @@ paths:
             application/json:
               schema:
                 type: string
-          description: Invalid request
+          description: Invalid request or unsupported client type
       summary: Register a new client
       tags:
       - clients
@@ -1819,7 +1819,7 @@ paths:
             application/json:
               schema:
                 type: string
-          description: Invalid request
+          description: Invalid request or unsupported client type
       summary: Unregister a client
       tags:
       - clients
@@ -1847,7 +1847,7 @@ paths:
             application/json:
               schema:
                 type: string
-          description: Invalid request
+          description: Invalid request or unsupported client type
         "404":
           content:
             application/json:
@@ -1885,7 +1885,7 @@ paths:
             application/json:
               schema:
                 type: string
-          description: Invalid request
+          description: Invalid request or unsupported client type
       summary: Register multiple clients
       tags:
       - clients
@@ -1911,7 +1911,7 @@ paths:
             application/json:
               schema:
                 type: string
-          description: Invalid request
+          description: Invalid request or unsupported client type
       summary: Unregister multiple clients
       tags:
       - clients

--- a/pkg/api/v1/clients.go
+++ b/pkg/api/v1/clients.go
@@ -6,6 +6,7 @@ package v1
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -80,7 +81,7 @@ func (c *ClientRoutes) listClients(w http.ResponseWriter, r *http.Request) error
 //	@Produce		json
 //	@Param			client	body	createClientRequest	true	"Client to register"
 //	@Success		200	{object}	createClientResponse
-//	@Failure		400	{string}	string	"Invalid request"
+//	@Failure		400	{string}	string	"Invalid request or unsupported client type"
 //	@Router			/api/v1beta/clients [post]
 func (c *ClientRoutes) registerClient(w http.ResponseWriter, r *http.Request) error {
 	var newClient createClientRequest
@@ -103,6 +104,12 @@ func (c *ClientRoutes) registerClient(w http.ResponseWriter, r *http.Request) er
 	}
 
 	if err := c.performClientRegistration(r.Context(), []client.Client{{Name: newClient.Name}}, newClient.Groups); err != nil {
+		if errors.Is(err, client.ErrUnsupportedClientType) {
+			return thverrors.WithCode(
+				fmt.Errorf("failed to register client: %w", err),
+				http.StatusBadRequest,
+			)
+		}
 		return fmt.Errorf("failed to register client: %w", err)
 	}
 
@@ -121,7 +128,7 @@ func (c *ClientRoutes) registerClient(w http.ResponseWriter, r *http.Request) er
 //	@Tags			clients
 //	@Param			name	path	string	true	"Client name to unregister"
 //	@Success		204
-//	@Failure		400	{string}	string	"Invalid request"
+//	@Failure		400	{string}	string	"Invalid request or unsupported client type"
 //	@Router			/api/v1beta/clients/{name} [delete]
 func (c *ClientRoutes) unregisterClient(w http.ResponseWriter, r *http.Request) error {
 	clientName := chi.URLParam(r, "name")
@@ -133,6 +140,12 @@ func (c *ClientRoutes) unregisterClient(w http.ResponseWriter, r *http.Request) 
 	}
 
 	if err := c.removeClient(r.Context(), []client.Client{{Name: client.MCPClient(clientName)}}, nil); err != nil {
+		if errors.Is(err, client.ErrUnsupportedClientType) {
+			return thverrors.WithCode(
+				fmt.Errorf("failed to unregister client: %w", err),
+				http.StatusBadRequest,
+			)
+		}
 		return fmt.Errorf("failed to unregister client: %w", err)
 	}
 
@@ -148,7 +161,7 @@ func (c *ClientRoutes) unregisterClient(w http.ResponseWriter, r *http.Request) 
 //	@Param			name	path	string	true	"Client name to unregister"
 //	@Param			group	path	string	true	"Group name to remove client from"
 //	@Success		204
-//	@Failure		400	{string}	string	"Invalid request"
+//	@Failure		400	{string}	string	"Invalid request or unsupported client type"
 //	@Failure		404	{string}	string	"Client or group not found"
 //	@Router			/api/v1beta/clients/{name}/groups/{group} [delete]
 func (c *ClientRoutes) unregisterClientFromGroup(w http.ResponseWriter, r *http.Request) error {
@@ -170,6 +183,12 @@ func (c *ClientRoutes) unregisterClientFromGroup(w http.ResponseWriter, r *http.
 
 	// Remove client from the specific group
 	if err := c.removeClient(r.Context(), []client.Client{{Name: client.MCPClient(clientName)}}, []string{groupName}); err != nil {
+		if errors.Is(err, client.ErrUnsupportedClientType) {
+			return thverrors.WithCode(
+				fmt.Errorf("failed to unregister client from group: %w", err),
+				http.StatusBadRequest,
+			)
+		}
 		return fmt.Errorf("failed to unregister client from group: %w", err)
 	}
 
@@ -186,7 +205,7 @@ func (c *ClientRoutes) unregisterClientFromGroup(w http.ResponseWriter, r *http.
 //	@Produce		json
 //	@Param			clients	body	bulkClientRequest	true	"Clients to register"
 //	@Success		200	{array}	createClientResponse
-//	@Failure		400	{string}	string	"Invalid request"
+//	@Failure		400	{string}	string	"Invalid request or unsupported client type"
 //	@Router			/api/v1beta/clients/register [post]
 func (c *ClientRoutes) registerClientsBulk(w http.ResponseWriter, r *http.Request) error {
 	var req bulkClientRequest
@@ -210,6 +229,12 @@ func (c *ClientRoutes) registerClientsBulk(w http.ResponseWriter, r *http.Reques
 	}
 
 	if err := c.performClientRegistration(r.Context(), clients, req.Groups); err != nil {
+		if errors.Is(err, client.ErrUnsupportedClientType) {
+			return thverrors.WithCode(
+				fmt.Errorf("failed to register clients: %w", err),
+				http.StatusBadRequest,
+			)
+		}
 		return fmt.Errorf("failed to register clients: %w", err)
 	}
 
@@ -233,7 +258,7 @@ func (c *ClientRoutes) registerClientsBulk(w http.ResponseWriter, r *http.Reques
 //	@Accept			json
 //	@Param			clients	body	bulkClientRequest	true	"Clients to unregister"
 //	@Success		204
-//	@Failure		400	{string}	string	"Invalid request"
+//	@Failure		400	{string}	string	"Invalid request or unsupported client type"
 //	@Router			/api/v1beta/clients/unregister [post]
 func (c *ClientRoutes) unregisterClientsBulk(w http.ResponseWriter, r *http.Request) error {
 	var req bulkClientRequest
@@ -258,6 +283,12 @@ func (c *ClientRoutes) unregisterClientsBulk(w http.ResponseWriter, r *http.Requ
 	}
 
 	if err := c.removeClient(r.Context(), clients, req.Groups); err != nil {
+		if errors.Is(err, client.ErrUnsupportedClientType) {
+			return thverrors.WithCode(
+				fmt.Errorf("failed to unregister clients: %w", err),
+				http.StatusBadRequest,
+			)
+		}
 		return fmt.Errorf("failed to unregister clients: %w", err)
 	}
 

--- a/pkg/client/config_test.go
+++ b/pkg/client/config_test.go
@@ -7,6 +7,7 @@ package client
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -691,6 +692,29 @@ func TestCreateClientConfig(t *testing.T) {
 		assert.Error(t, err, "Should return error for unsupported client type")
 		assert.Nil(t, cf, "Should not return a config file on error")
 		assert.Contains(t, err.Error(), "unsupported client type", "Error should mention unsupported client type")
+	})
+
+	t.Run("CreateClientConfigUnsupportedClientTypeIsSentinelError", func(t *testing.T) {
+		t.Parallel()
+		// Setup a temporary home directory for testing
+		tempHome := t.TempDir()
+
+		configProvider, cleanup := CreateTestConfigProvider(t, testConfig)
+		defer cleanup()
+
+		// Create empty mock client configs (no supported clients)
+		mockClientConfigs := []mcpClientConfig{}
+
+		manager := NewTestClientManager(tempHome, nil, mockClientConfigs, configProvider)
+
+		// Call CreateClientConfig with unsupported client type
+		_, err := manager.CreateClientConfig(VSCode)
+		require.Error(t, err)
+
+		// Verify the error can be matched using errors.Is with the sentinel error
+		// This is important for API handlers to return appropriate HTTP status codes
+		assert.True(t, errors.Is(err, ErrUnsupportedClientType),
+			"Error should be matchable with ErrUnsupportedClientType sentinel error")
 	})
 
 	t.Run("CreateClientConfigWriteError", func(t *testing.T) {

--- a/pkg/client/manager.go
+++ b/pkg/client/manager.go
@@ -127,7 +127,8 @@ func (m *defaultManager) ListClients(ctx context.Context) ([]RegisteredClient, e
 	}
 
 	// Convert to slice for return
-	var registeredClients []RegisteredClient
+	// Initialize as empty slice to ensure JSON encodes as [] instead of null when empty
+	registeredClients := make([]RegisteredClient, 0)
 	for clientName := range allRegisteredClients {
 		registered := RegisteredClient{
 			Name:   MCPClient(clientName),


### PR DESCRIPTION
Previously, if an invalid client type was specified, the API would return a 500. Return a 400 with a more useful error.