### PR TITLE
Use very high port numbers in unit tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -312,6 +312,10 @@ For the complete documentation structure and navigation, see `docs/arch/README.m
     conventions.
   - Do not use "Conventional Commits", e.g. starting with `feat`, `fix`, `chore`, etc.
   - Use mockgen for creating mocks instead of generating mocks by hand.
+- Use very large numbers for unit tests which need port numbers.
+  - Using common port ranges leads to a likelihood that you will clash with a
+    port which is already in use. Pick math.MaxInt16 as a sample port to reduce
+    the changes of hitting this problem.
 
 ### Go Coding Style
 

--- a/pkg/runner/config_builder_test.go
+++ b/pkg/runner/config_builder_test.go
@@ -6,6 +6,7 @@ package runner
 import (
 	"context"
 	"encoding/json"
+	"math"
 	"os"
 	"testing"
 
@@ -20,6 +21,8 @@ import (
 	regtypes "github.com/stacklok/toolhive/pkg/registry/registry"
 	"github.com/stacklok/toolhive/pkg/transport/types"
 )
+
+const testPort = math.MaxInt16
 
 func TestRunConfigBuilder_Build_WithPermissionProfile(t *testing.T) {
 	t.Parallel()
@@ -1059,11 +1062,11 @@ func TestRunConfigBuilder_WithRegistryProxyPort(t *testing.T) {
 					Transport: "streamable-http",
 				},
 				Image:      "test-image:latest",
-				ProxyPort:  8976,
-				TargetPort: 8976,
+				ProxyPort:  testPort,
+				TargetPort: testPort,
 			},
 			cliProxyPort:      0,
-			expectedProxyPort: 8976,
+			expectedProxyPort: testPort,
 		},
 		{
 			name: "CLI proxy_port overrides registry",
@@ -1073,8 +1076,8 @@ func TestRunConfigBuilder_WithRegistryProxyPort(t *testing.T) {
 					Transport: "streamable-http",
 				},
 				Image:      "test-image:latest",
-				ProxyPort:  8976,
-				TargetPort: 8976,
+				ProxyPort:  testPort,
+				TargetPort: testPort,
 			},
 			cliProxyPort:      9000,
 			expectedProxyPort: 9000,


### PR DESCRIPTION
This test suite has a transient problem where failures happen if the specified port is in use. Pick a very high port number to minimize the odds of this happening. Add a note to CLAUDE.md about this.