### PR TITLE
Fix concurrency bug with groups

### DIFF
--- a/pkg/groups/cli_manager.go
+++ b/pkg/groups/cli_manager.go
@@ -9,9 +9,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"sort"
 	"strings"
 
+	thverrors "github.com/stacklok/toolhive/pkg/errors"
 	"github.com/stacklok/toolhive/pkg/logger"
 	"github.com/stacklok/toolhive/pkg/state"
 	"github.com/stacklok/toolhive/pkg/validation"
@@ -38,20 +40,43 @@ func (m *cliManager) Create(ctx context.Context, name string) error {
 	if err := validation.ValidateGroupName(name); err != nil {
 		return fmt.Errorf("%w: %s - %w", ErrInvalidGroupName, name, err)
 	}
-	// Check if group already exists
-	exists, err := m.groupStore.Exists(ctx, name)
-	if err != nil {
-		return fmt.Errorf("failed to check if group exists: %w", err)
-	}
-	if exists {
-		return fmt.Errorf("%w: %s", ErrGroupAlreadyExists, name)
-	}
 
 	group := &Group{
 		Name:              name,
 		RegisteredClients: []string{},
 	}
-	return m.saveGroup(ctx, group)
+
+	// Use CreateExclusive for atomic check-and-create to prevent race conditions
+	writer, err := m.groupStore.CreateExclusive(ctx, name)
+	if err != nil {
+		// Check if the error is a conflict (group already exists)
+		if thverrors.Code(err) == http.StatusConflict {
+			return fmt.Errorf("%w: %s", ErrGroupAlreadyExists, name)
+		}
+		return fmt.Errorf("failed to create group: %w", err)
+	}
+	defer func() {
+		if err := writer.Close(); err != nil {
+			// Non-fatal: writer cleanup failure
+			logger.Warnf("Failed to close writer: %v", err)
+		}
+	}()
+
+	// Write the group data
+	encoder := json.NewEncoder(writer)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(group); err != nil {
+		return fmt.Errorf("failed to write group: %w", err)
+	}
+
+	// Ensure the writer is flushed
+	if syncer, ok := writer.(interface{ Sync() error }); ok {
+		if err := syncer.Sync(); err != nil {
+			return fmt.Errorf("failed to sync group file: %w", err)
+		}
+	}
+
+	return nil
 }
 
 // Get retrieves a group by name

--- a/pkg/groups/cli_manager_test.go
+++ b/pkg/groups/cli_manager_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"net/http"
 	"os"
 	"strings"
 	"testing"
@@ -14,6 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 
+	thverrors "github.com/stacklok/toolhive/pkg/errors"
 	"github.com/stacklok/toolhive/pkg/logger"
 	"github.com/stacklok/toolhive/pkg/state/mocks"
 )
@@ -41,10 +43,7 @@ func TestManager_Create(t *testing.T) {
 			groupName: testGroupName,
 			setupMock: func(mock *mocks.MockStore) {
 				mock.EXPECT().
-					Exists(gomock.Any(), testGroupName).
-					Return(false, nil)
-				mock.EXPECT().
-					GetWriter(gomock.Any(), testGroupName).
+					CreateExclusive(gomock.Any(), testGroupName).
 					Return(&mockWriteCloser{}, nil)
 			},
 			expectError: false,
@@ -54,36 +53,33 @@ func TestManager_Create(t *testing.T) {
 			groupName: "existinggroup",
 			setupMock: func(mock *mocks.MockStore) {
 				mock.EXPECT().
-					Exists(gomock.Any(), "existinggroup").
-					Return(true, nil)
+					CreateExclusive(gomock.Any(), "existinggroup").
+					Return(nil, thverrors.WithCode(errors.New("state 'existinggroup' already exists"), http.StatusConflict))
 			},
 			expectError: true,
 			errorMsg:    "already exists",
 		},
 		{
-			name:      "exists check fails",
+			name:      "create exclusive fails with other error",
 			groupName: testGroupName,
 			setupMock: func(mock *mocks.MockStore) {
 				mock.EXPECT().
-					Exists(gomock.Any(), testGroupName).
-					Return(false, errors.New("exists check failed"))
+					CreateExclusive(gomock.Any(), testGroupName).
+					Return(nil, errors.New("disk full"))
 			},
 			expectError: true,
-			errorMsg:    "failed to check if group exists",
+			errorMsg:    "failed to create group",
 		},
 		{
-			name:      "get writer fails",
+			name:      "writer encoding fails",
 			groupName: testGroupName,
 			setupMock: func(mock *mocks.MockStore) {
 				mock.EXPECT().
-					Exists(gomock.Any(), testGroupName).
-					Return(false, nil)
-				mock.EXPECT().
-					GetWriter(gomock.Any(), testGroupName).
-					Return(nil, errors.New("writer failed"))
+					CreateExclusive(gomock.Any(), testGroupName).
+					Return(&mockWriteCloser{writeError: errors.New("write failed")}, nil)
 			},
 			expectError: true,
-			errorMsg:    "failed to get writer for group",
+			errorMsg:    "failed to write group",
 		},
 		{
 			name:        "invalid name - uppercase",
@@ -641,14 +637,23 @@ func TestManager_UnregisterClients(t *testing.T) {
 
 // mockWriteCloser implements io.WriteCloser for testing
 type mockWriteCloser struct {
-	data []byte
+	data       []byte
+	writeError error
+	closeError error
 }
 
 func (m *mockWriteCloser) Write(p []byte) (n int, err error) {
+	if m.writeError != nil {
+		return 0, m.writeError
+	}
 	m.data = append(m.data, p...)
 	return len(p), nil
 }
 
-func (*mockWriteCloser) Close() error {
+func (m *mockWriteCloser) Close() error {
+	return m.closeError
+}
+
+func (*mockWriteCloser) Sync() error {
 	return nil
 }

--- a/pkg/state/interface.go
+++ b/pkg/state/interface.go
@@ -22,6 +22,11 @@ type Store interface {
 	// This is useful for streaming large state data
 	GetWriter(ctx context.Context, name string) (io.WriteCloser, error)
 
+	// CreateExclusive creates a new state entry exclusively, returning an error if it already exists.
+	// This provides atomic check-and-create semantics to prevent race conditions.
+	// Returns a writer for the new state data, or an error with http.StatusConflict if the entry exists.
+	CreateExclusive(ctx context.Context, name string) (io.WriteCloser, error)
+
 	// Delete removes the data for the given name
 	Delete(ctx context.Context, name string) error
 

--- a/pkg/state/kubernetes.go
+++ b/pkg/state/kubernetes.go
@@ -38,6 +38,12 @@ func (*KubernetesStore) GetWriter(_ context.Context, _ string) (io.WriteCloser, 
 	return &noopWriteCloser{}, nil
 }
 
+// CreateExclusive returns a no-op writer for Kubernetes stores.
+// In Kubernetes, state management is handled by the cluster, not local files.
+func (*KubernetesStore) CreateExclusive(_ context.Context, _ string) (io.WriteCloser, error) {
+	return &noopWriteCloser{}, nil
+}
+
 // Delete is a no-op for Kubernetes stores.
 func (*KubernetesStore) Delete(_ context.Context, _ string) error {
 	return nil

--- a/pkg/state/mocks/mock_store.go
+++ b/pkg/state/mocks/mock_store.go
@@ -41,6 +41,21 @@ func (m *MockStore) EXPECT() *MockStoreMockRecorder {
 	return m.recorder
 }
 
+// CreateExclusive mocks base method.
+func (m *MockStore) CreateExclusive(ctx context.Context, name string) (io.WriteCloser, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateExclusive", ctx, name)
+	ret0, _ := ret[0].(io.WriteCloser)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateExclusive indicates an expected call of CreateExclusive.
+func (mr *MockStoreMockRecorder) CreateExclusive(ctx, name any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateExclusive", reflect.TypeOf((*MockStore)(nil).CreateExclusive), ctx, name)
+}
+
 // Delete mocks base method.
 func (m *MockStore) Delete(ctx context.Context, name string) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
The E2E tests have exposed an issue where concurrent attempts to create a group would conflict with eachother:

1. Both would check if the group exists → both get false
2. Both would then create the file → both succeed (the second overwrites the first)
3. Both requests returned 201 Created instead of one returning 409 Conflict

Change the logic to make the creation atomic.