### PR TITLE
Add CLI flags for header forward configuration

### DIFF
--- a/cmd/thv/app/header_flags.go
+++ b/cmd/thv/app/header_flags.go
@@ -1,0 +1,139 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package app
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/stacklok/toolhive/pkg/config"
+	"github.com/stacklok/toolhive/pkg/secrets"
+	"github.com/stacklok/toolhive/pkg/transport/middleware"
+	"github.com/stacklok/toolhive/pkg/validation"
+)
+
+// validateHeaderNames checks that no header names are in the restricted set.
+// This provides early CLI-level validation before middleware creation.
+func validateHeaderNames(headers map[string]string) error {
+	for name := range headers {
+		canonical := http.CanonicalHeaderKey(name)
+		if _, blocked := middleware.RestrictedHeaders[canonical]; blocked {
+			return fmt.Errorf("header %q is restricted and cannot be configured for forwarding", name)
+		}
+	}
+	return nil
+}
+
+// parseHeaderForwardFlags parses the slice of headers,
+// validates the format (Name=Value), and returns a map of headers.
+func parseHeaderForwardFlags(headers []string) (map[string]string, error) {
+	result := make(map[string]string, len(headers))
+
+	for _, header := range headers {
+		name, value, err := parseHeaderString(header)
+		if err != nil {
+			return nil, err
+		}
+		result[name] = value
+	}
+
+	if err := validateHeaderNames(result); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+// parseHeaderString parses a single header string in the format Name=Value.
+// The name must not be empty; the value may be empty.
+// Validates header name and value for RFC 7230 compliance (rejects CRLF injection).
+func parseHeaderString(header string) (string, string, error) {
+	// Find the first equals sign
+	idx := strings.Index(header, "=")
+	if idx == -1 {
+		return "", "", fmt.Errorf("invalid header format %q: expected Name=Value", header)
+	}
+
+	name := strings.TrimSpace(header[:idx])
+	value := header[idx+1:] // Value keeps leading/trailing whitespace intentionally
+
+	// Validate header name for RFC 7230 compliance (rejects CRLF, control chars)
+	if err := validation.ValidateHTTPHeaderName(name); err != nil {
+		return "", "", fmt.Errorf("invalid header name in %q: %w", header, err)
+	}
+
+	// Validate header value for RFC 7230 compliance (rejects CRLF, control chars)
+	// Only validate non-empty values since empty header values are allowed
+	if value != "" {
+		if err := validation.ValidateHTTPHeaderValue(value); err != nil {
+			return "", "", fmt.Errorf("invalid header value in %q: %w", header, err)
+		}
+	}
+
+	return name, value, nil
+}
+
+// parseHeaderSecretFlags parses --remote-forward-headers-secret flags.
+// Format: "HeaderName=secret-name" where secret-name is a key in the secrets manager.
+// Returns a map of header name → secret name.
+func parseHeaderSecretFlags(secretHeaders []string) (map[string]string, error) {
+	result := make(map[string]string, len(secretHeaders))
+	for _, entry := range secretHeaders {
+		headerName, secretName, err := parseHeaderString(entry)
+		if err != nil {
+			return nil, fmt.Errorf("invalid secret header format: %w", err)
+		}
+		if secretName == "" {
+			return nil, fmt.Errorf("invalid secret header %q: secret name cannot be empty", entry)
+		}
+		result[headerName] = secretName
+	}
+
+	if err := validateHeaderNames(result); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+// resolveHeaderSecrets resolves header secret references immediately using the secrets manager.
+// This is used by thv proxy which does not persist RunConfig, so secrets must be resolved
+// at startup rather than deferred to WithSecrets() as in thv run.
+// Returns a map of header name → resolved secret value.
+func resolveHeaderSecrets(secretHeaders map[string]string) (map[string]string, error) {
+	if len(secretHeaders) == 0 {
+		return nil, nil
+	}
+
+	cfgProvider := config.NewDefaultProvider()
+	cfg := cfgProvider.GetConfig()
+
+	providerType, err := cfg.Secrets.GetProviderType()
+	if err != nil {
+		return nil, fmt.Errorf("failed to determine secrets provider type: %w", err)
+	}
+
+	secretManager, err := secrets.CreateSecretProvider(providerType)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create secret provider: %w", err)
+	}
+
+	result := make(map[string]string, len(secretHeaders))
+	for headerName, secretName := range secretHeaders {
+		value, err := secretManager.GetSecret(context.Background(), secretName)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve secret %q for header %q: %w", secretName, headerName, err)
+		}
+		// Validate resolved secret value for RFC 7230 compliance (rejects CRLF, control chars)
+		if value != "" {
+			if err := validation.ValidateHTTPHeaderValue(value); err != nil {
+				return nil, fmt.Errorf("secret %q for header %q contains invalid value: %w", secretName, headerName, err)
+			}
+		}
+		result[headerName] = value
+	}
+	return result, nil
+}

--- a/cmd/thv/app/header_flags_test.go
+++ b/cmd/thv/app/header_flags_test.go
@@ -1,0 +1,263 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseHeaderString(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		input         string
+		expectedName  string
+		expectedValue string
+		expectError   bool
+	}{
+		{
+			name:          "simple header",
+			input:         "X-Custom-Header=some-value",
+			expectedName:  "X-Custom-Header",
+			expectedValue: "some-value",
+			expectError:   false,
+		},
+		{
+			name:          "header with empty value",
+			input:         "X-Empty=",
+			expectedName:  "X-Empty",
+			expectedValue: "",
+			expectError:   false,
+		},
+		{
+			name:          "header with equals in value",
+			input:         "X-Complex=value=with=equals",
+			expectedName:  "X-Complex",
+			expectedValue: "value=with=equals",
+			expectError:   false,
+		},
+		{
+			name:          "header with spaces in value",
+			input:         "X-Spaced=value with spaces",
+			expectedName:  "X-Spaced",
+			expectedValue: "value with spaces",
+			expectError:   false,
+		},
+		{
+			name:          "header name with whitespace trimmed",
+			input:         "  X-Trimmed  =value",
+			expectedName:  "X-Trimmed",
+			expectedValue: "value",
+			expectError:   false,
+		},
+		{
+			name:        "missing equals sign",
+			input:       "InvalidHeader",
+			expectError: true,
+		},
+		{
+			name:        "empty name",
+			input:       "=value-only",
+			expectError: true,
+		},
+		{
+			name:        "whitespace only name",
+			input:       "   =value-only",
+			expectError: true,
+		},
+		{
+			name:        "CRLF injection in value rejected",
+			input:       "X-Header=value\r\nEvil: injected",
+			expectError: true,
+		},
+		{
+			name:        "newline in value rejected",
+			input:       "X-Header=value\nEvil",
+			expectError: true,
+		},
+		{
+			name:        "carriage return in value rejected",
+			input:       "X-Header=value\rEvil",
+			expectError: true,
+		},
+		{
+			name:        "control character in name rejected",
+			input:       "X-Header\x00=value",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			name, value, err := parseHeaderString(tt.input)
+
+			if tt.expectError {
+				assert.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedName, name)
+			assert.Equal(t, tt.expectedValue, value)
+		})
+	}
+}
+
+func TestParseHeaderForwardFlags(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		headers     []string
+		expected    map[string]string
+		expectError bool
+	}{
+		{
+			name:        "multiple headers",
+			headers:     []string{"X-Header1=value1", "X-Header2=value2"},
+			expected:    map[string]string{"X-Header1": "value1", "X-Header2": "value2"},
+			expectError: false,
+		},
+		{
+			name:        "empty inputs",
+			headers:     []string{},
+			expected:    map[string]string{},
+			expectError: false,
+		},
+		{
+			name:        "invalid header",
+			headers:     []string{"InvalidHeader"},
+			expectError: true,
+		},
+		{
+			name:        "restricted header Host rejected",
+			headers:     []string{"Host=evil.example.com"},
+			expectError: true,
+		},
+		{
+			name:        "restricted header case insensitive",
+			headers:     []string{"transfer-encoding=chunked"},
+			expectError: true,
+		},
+		{
+			name:        "restricted header among valid headers",
+			headers:     []string{"X-Good=ok", "X-Forwarded-For=1.2.3.4"},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := parseHeaderForwardFlags(tt.headers)
+
+			if tt.expectError {
+				assert.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestValidateHeaderNames(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		headers     map[string]string
+		expectError bool
+	}{
+		{
+			name:        "allowed headers pass",
+			headers:     map[string]string{"X-Custom": "value", "Authorization": "Bearer tok"},
+			expectError: false,
+		},
+		{
+			name:        "empty map passes",
+			headers:     map[string]string{},
+			expectError: false,
+		},
+		{
+			name:        "Host is blocked",
+			headers:     map[string]string{"Host": "evil.example.com"},
+			expectError: true,
+		},
+		{
+			name:        "Connection is blocked",
+			headers:     map[string]string{"connection": "keep-alive"},
+			expectError: true,
+		},
+		{
+			name:        "X-Forwarded-For is blocked",
+			headers:     map[string]string{"x-forwarded-for": "1.2.3.4"},
+			expectError: true,
+		},
+		{
+			name:        "Content-Length is blocked",
+			headers:     map[string]string{"content-length": "42"},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateHeaderNames(tt.headers)
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "restricted")
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestParseHeaderSecretFlagsRestrictedHeaders(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		inputs      []string
+		expectError bool
+	}{
+		{
+			name:        "allowed secret header",
+			inputs:      []string{"X-Api-Key=my-secret"},
+			expectError: false,
+		},
+		{
+			name:        "restricted secret header Host",
+			inputs:      []string{"Host=some-secret"},
+			expectError: true,
+		},
+		{
+			name:        "restricted secret header Transfer-Encoding",
+			inputs:      []string{"Transfer-Encoding=some-secret"},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := parseHeaderSecretFlags(tt.inputs)
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "restricted")
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/cmd/thv/app/proxy.go
+++ b/cmd/thv/app/proxy.go
@@ -116,6 +116,10 @@ var (
 
 	// Remote server authentication flags
 	remoteAuthFlags RemoteAuthFlags
+
+	// Header forwarding flags
+	remoteForwardHeaders       []string
+	remoteForwardHeadersSecret []string
 )
 
 // Environment variable names
@@ -142,6 +146,13 @@ func init() {
 
 	// Add remote server authentication flags
 	AddRemoteAuthFlags(proxyCmd, &remoteAuthFlags)
+
+	// Add header forwarding flags
+	// Using StringArrayVar (not StringSliceVar) to avoid comma-splitting in header values
+	proxyCmd.Flags().StringArrayVar(&remoteForwardHeaders, "remote-forward-headers", []string{},
+		"Headers to inject into requests to remote server (format: Name=Value, can be repeated)")
+	proxyCmd.Flags().StringArrayVar(&remoteForwardHeadersSecret, "remote-forward-headers-secret", []string{},
+		"Headers with secret values from ToolHive secrets manager (format: Name=secret-name, can be repeated)")
 
 	// Mark target-uri as required
 	if err := proxyCmd.MarkFlagRequired("target-uri"); err != nil {
@@ -214,26 +225,7 @@ func proxyCmdFunc(cmd *cobra.Command, args []string) error {
 	var middlewares []types.NamedMiddleware
 
 	// Get OIDC configuration if enabled (for protecting the proxy endpoint)
-	var oidcConfig *auth.TokenValidatorConfig
-	if IsOIDCEnabled(cmd) {
-		// Get OIDC flag values
-		issuer := GetStringFlagOrEmpty(cmd, "oidc-issuer")
-		audience := GetStringFlagOrEmpty(cmd, "oidc-audience")
-		jwksURL := GetStringFlagOrEmpty(cmd, "oidc-jwks-url")
-		introspectionURL := GetStringFlagOrEmpty(cmd, "oidc-introspection-url")
-		clientID := GetStringFlagOrEmpty(cmd, "oidc-client-id")
-		clientSecret := GetStringFlagOrEmpty(cmd, "oidc-client-secret")
-
-		oidcConfig = &auth.TokenValidatorConfig{
-			Issuer:           issuer,
-			Audience:         audience,
-			JWKSURL:          jwksURL,
-			IntrospectionURL: introspectionURL,
-			ClientID:         clientID,
-			ClientSecret:     clientSecret,
-			ResourceURL:      resourceURL,
-		}
-	}
+	oidcConfig := getProxyOIDCConfig(cmd)
 
 	// Get authentication middleware for incoming requests
 	authMiddleware, authInfoHandler, err := auth.GetAuthenticationMiddleware(ctx, oidcConfig)
@@ -247,6 +239,13 @@ func proxyCmdFunc(cmd *cobra.Command, args []string) error {
 
 	// Add OAuth token injection or token exchange middleware for outgoing requests
 	if err := addExternalTokenMiddleware(&middlewares, tokenSource); err != nil {
+		return err
+	}
+
+	// Add header forward middleware if headers are configured
+	if err := addHeaderForwardMiddleware(
+		&middlewares, remoteForwardHeaders, remoteForwardHeadersSecret,
+	); err != nil {
 		return err
 	}
 
@@ -289,6 +288,22 @@ func proxyCmdFunc(cmd *cobra.Command, args []string) error {
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	return proxy.Stop(shutdownCtx)
+}
+
+// getProxyOIDCConfig returns the OIDC token validator config from CLI flags, or nil if OIDC is not enabled.
+func getProxyOIDCConfig(cmd *cobra.Command) *auth.TokenValidatorConfig {
+	if !IsOIDCEnabled(cmd) {
+		return nil
+	}
+	return &auth.TokenValidatorConfig{
+		Issuer:           GetStringFlagOrEmpty(cmd, "oidc-issuer"),
+		Audience:         GetStringFlagOrEmpty(cmd, "oidc-audience"),
+		JWKSURL:          GetStringFlagOrEmpty(cmd, "oidc-jwks-url"),
+		IntrospectionURL: GetStringFlagOrEmpty(cmd, "oidc-introspection-url"),
+		ClientID:         GetStringFlagOrEmpty(cmd, "oidc-client-id"),
+		ClientSecret:     GetStringFlagOrEmpty(cmd, "oidc-client-secret"),
+		ResourceURL:      resourceURL,
+	}
 }
 
 // shouldDetectAuth determines if we should try to detect authentication requirements
@@ -427,6 +442,50 @@ func addExternalTokenMiddleware(middlewares *[]types.NamedMiddleware, tokenSourc
 			Function: tokenMiddleware,
 		})
 	}
+	return nil
+}
+
+// addHeaderForwardMiddleware adds header forward middleware to the middleware chain if headers are configured.
+// Secret references are resolved immediately via the secrets manager.
+func addHeaderForwardMiddleware(
+	middlewares *[]types.NamedMiddleware, headers []string, secretHeaders []string,
+) error {
+	// Parse plaintext headers from flags
+	addHeaders, err := parseHeaderForwardFlags(headers)
+	if err != nil {
+		return fmt.Errorf("failed to parse header forward flags: %w", err)
+	}
+
+	// Resolve secret-backed headers
+	if len(secretHeaders) > 0 {
+		secretMap, err := parseHeaderSecretFlags(secretHeaders)
+		if err != nil {
+			return err
+		}
+		resolved, err := resolveHeaderSecrets(secretMap)
+		if err != nil {
+			return err
+		}
+		for name, value := range resolved {
+			addHeaders[name] = value
+		}
+	}
+
+	// Skip if no headers configured
+	if len(addHeaders) == 0 {
+		return nil
+	}
+
+	// Create the header forward middleware
+	mwFunc, err := middleware.CreateHeaderForwardMiddleware(addHeaders)
+	if err != nil {
+		return fmt.Errorf("failed to create header forward middleware: %w", err)
+	}
+	*middlewares = append(*middlewares, types.NamedMiddleware{
+		Name:     middleware.HeaderForwardMiddlewareName,
+		Function: mwFunc,
+	})
+
 	return nil
 }
 

--- a/cmd/thv/app/run_flags.go
+++ b/cmd/thv/app/run_flags.go
@@ -124,6 +124,10 @@ type RunFlags struct {
 	// Remote authentication
 	RemoteAuthFlags RemoteAuthFlags
 	OAuthParams     map[string]string
+
+	// Remote header forwarding
+	RemoteForwardHeaders       []string
+	RemoteForwardHeadersSecret []string
 }
 
 // AddRunFlags adds all the run flags to a command
@@ -192,6 +196,13 @@ func AddRunFlags(cmd *cobra.Command, config *RunFlags) {
 
 	// Remote authentication flags
 	AddRemoteAuthFlags(cmd, &config.RemoteAuthFlags)
+
+	// Remote header forwarding flags
+	// Using StringArrayVar (not StringSliceVar) to avoid comma-splitting in header values
+	cmd.Flags().StringArrayVar(&config.RemoteForwardHeaders, "remote-forward-headers", []string{},
+		"Headers to inject into requests to remote MCP server (format: Name=Value, can be repeated)")
+	cmd.Flags().StringArrayVar(&config.RemoteForwardHeadersSecret, "remote-forward-headers-secret", []string{},
+		"Headers with secret values from ToolHive secrets manager (format: Name=secret-name, can be repeated)")
 
 	// OAuth discovery configuration
 	cmd.Flags().StringVar(&config.ResourceURL, "resource-url", "",
@@ -489,6 +500,28 @@ func buildRunnerConfig(
 			return nil, fmt.Errorf("failed to load tools override: %w", err)
 		}
 		toolsOverride = *loadedToolsOverride
+	}
+
+	// Configure header forwarding for remote servers
+	if runFlags.RemoteURL != "" {
+		addHeaders, err := parseHeaderForwardFlags(runFlags.RemoteForwardHeaders)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse header forward flags: %w", err)
+		}
+		if len(addHeaders) > 0 {
+			opts = append(opts, runner.WithHeaderForward(addHeaders))
+		}
+
+		// Parse secret header references (stored in RunConfig, resolved at runtime by WithSecrets)
+		if len(runFlags.RemoteForwardHeadersSecret) > 0 {
+			secretHeaders, err := parseHeaderSecretFlags(runFlags.RemoteForwardHeadersSecret)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse header secret flags: %w", err)
+			}
+			if len(secretHeaders) > 0 {
+				opts = append(opts, runner.WithHeaderForwardSecrets(secretHeaders))
+			}
+		}
 	}
 
 	// Configure middleware and additional options

--- a/docs/cli/thv_proxy.md
+++ b/docs/cli/thv_proxy.md
@@ -97,40 +97,42 @@ thv proxy [flags] SERVER_NAME
 ### Options
 
 ```
-  -h, --help                                       help for proxy
-      --host string                                Host for the HTTP proxy to listen on (IP or hostname) (default "127.0.0.1")
-      --oidc-audience string                       Expected audience for the token
-      --oidc-client-id string                      OIDC client ID
-      --oidc-client-secret string                  OIDC client secret (optional, for introspection)
-      --oidc-introspection-url string              URL for token introspection endpoint
-      --oidc-issuer string                         OIDC issuer URL (e.g., https://accounts.google.com)
-      --oidc-jwks-url string                       URL to fetch the JWKS from
-      --oidc-scopes strings                        OAuth scopes to advertise in the well-known endpoint (RFC 9728, defaults to 'openid' if not specified)
-      --port int                                   Port for the HTTP proxy to listen on (host port)
-      --remote-auth                                Enable OAuth/OIDC authentication to remote MCP server (default false)
-      --remote-auth-authorize-url string           OAuth authorization endpoint URL (alternative to --remote-auth-issuer for non-OIDC OAuth)
-      --remote-auth-bearer-token string            Bearer token for remote server authentication (alternative to OAuth)
-      --remote-auth-bearer-token-file string       Path to file containing bearer token (alternative to --remote-auth-bearer-token)
-      --remote-auth-callback-port int              Port for OAuth callback server during remote authentication (default 8666)
-      --remote-auth-client-id string               OAuth client ID for remote server authentication (optional if the authorization server supports dynamic client registration (RFC 7591))
-      --remote-auth-client-secret string           OAuth client secret for remote server authentication (optional if the authorization server supports dynamic client registration (RFC 7591) or if using PKCE)
-      --remote-auth-client-secret-file string      Path to file containing OAuth client secret (alternative to --remote-auth-client-secret) (optional if the authorization server supports dynamic client registration (RFC 7591) or if using PKCE)
-      --remote-auth-issuer string                  OAuth/OIDC issuer URL for remote server authentication (e.g., https://accounts.google.com)
-      --remote-auth-resource string                OAuth 2.0 resource indicator (RFC 8707)
-      --remote-auth-scopes strings                 OAuth scopes to request for remote server authentication (defaults: OIDC uses 'openid,profile,email')
-      --remote-auth-skip-browser                   Skip opening browser for remote server OAuth flow (default false)
-      --remote-auth-timeout duration               Timeout for OAuth authentication flow (e.g., 30s, 1m, 2m30s) (default 30s)
-      --remote-auth-token-url string               OAuth token endpoint URL (alternative to --remote-auth-issuer for non-OIDC OAuth)
-      --resource-url string                        Explicit resource URL for OAuth discovery endpoint (RFC 9728)
-      --target-uri string                          URI for the target MCP server (e.g., http://localhost:8080) (required)
-      --token-exchange-audience string             Target audience for exchanged tokens
-      --token-exchange-client-id string            OAuth client ID for token exchange operations
-      --token-exchange-client-secret string        OAuth client secret for token exchange operations
-      --token-exchange-client-secret-file string   Path to file containing OAuth client secret for token exchange (alternative to --token-exchange-client-secret)
-      --token-exchange-header-name string          Custom header name for injecting exchanged token (default: replaces Authorization header)
-      --token-exchange-scopes strings              Scopes to request for exchanged tokens
-      --token-exchange-subject-token-type string   Type of subject token to exchange. Accepts: access_token (default), id_token (required for Google STS)
-      --token-exchange-url string                  OAuth 2.0 token exchange endpoint URL (enables token exchange when provided)
+  -h, --help                                        help for proxy
+      --host string                                 Host for the HTTP proxy to listen on (IP or hostname) (default "127.0.0.1")
+      --oidc-audience string                        Expected audience for the token
+      --oidc-client-id string                       OIDC client ID
+      --oidc-client-secret string                   OIDC client secret (optional, for introspection)
+      --oidc-introspection-url string               URL for token introspection endpoint
+      --oidc-issuer string                          OIDC issuer URL (e.g., https://accounts.google.com)
+      --oidc-jwks-url string                        URL to fetch the JWKS from
+      --oidc-scopes strings                         OAuth scopes to advertise in the well-known endpoint (RFC 9728, defaults to 'openid' if not specified)
+      --port int                                    Port for the HTTP proxy to listen on (host port)
+      --remote-auth                                 Enable OAuth/OIDC authentication to remote MCP server (default false)
+      --remote-auth-authorize-url string            OAuth authorization endpoint URL (alternative to --remote-auth-issuer for non-OIDC OAuth)
+      --remote-auth-bearer-token string             Bearer token for remote server authentication (alternative to OAuth)
+      --remote-auth-bearer-token-file string        Path to file containing bearer token (alternative to --remote-auth-bearer-token)
+      --remote-auth-callback-port int               Port for OAuth callback server during remote authentication (default 8666)
+      --remote-auth-client-id string                OAuth client ID for remote server authentication (optional if the authorization server supports dynamic client registration (RFC 7591))
+      --remote-auth-client-secret string            OAuth client secret for remote server authentication (optional if the authorization server supports dynamic client registration (RFC 7591) or if using PKCE)
+      --remote-auth-client-secret-file string       Path to file containing OAuth client secret (alternative to --remote-auth-client-secret) (optional if the authorization server supports dynamic client registration (RFC 7591) or if using PKCE)
+      --remote-auth-issuer string                   OAuth/OIDC issuer URL for remote server authentication (e.g., https://accounts.google.com)
+      --remote-auth-resource string                 OAuth 2.0 resource indicator (RFC 8707)
+      --remote-auth-scopes strings                  OAuth scopes to request for remote server authentication (defaults: OIDC uses 'openid,profile,email')
+      --remote-auth-skip-browser                    Skip opening browser for remote server OAuth flow (default false)
+      --remote-auth-timeout duration                Timeout for OAuth authentication flow (e.g., 30s, 1m, 2m30s) (default 30s)
+      --remote-auth-token-url string                OAuth token endpoint URL (alternative to --remote-auth-issuer for non-OIDC OAuth)
+      --remote-forward-headers stringArray          Headers to inject into requests to remote server (format: Name=Value, can be repeated)
+      --remote-forward-headers-secret stringArray   Headers with secret values from ToolHive secrets manager (format: Name=secret-name, can be repeated)
+      --resource-url string                         Explicit resource URL for OAuth discovery endpoint (RFC 9728)
+      --target-uri string                           URI for the target MCP server (e.g., http://localhost:8080) (required)
+      --token-exchange-audience string              Target audience for exchanged tokens
+      --token-exchange-client-id string             OAuth client ID for token exchange operations
+      --token-exchange-client-secret string         OAuth client secret for token exchange operations
+      --token-exchange-client-secret-file string    Path to file containing OAuth client secret for token exchange (alternative to --token-exchange-client-secret)
+      --token-exchange-header-name string           Custom header name for injecting exchanged token (default: replaces Authorization header)
+      --token-exchange-scopes strings               Scopes to request for exchanged tokens
+      --token-exchange-subject-token-type string    Type of subject token to exchange. Accepts: access_token (default), id_token (required for Google STS)
+      --token-exchange-url string                   OAuth 2.0 token exchange endpoint URL (enables token exchange when provided)
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli/thv_run.md
+++ b/docs/cli/thv_run.md
@@ -111,81 +111,83 @@ thv run [flags] SERVER_OR_IMAGE_OR_PROTOCOL [-- ARGS...]
 ### Options
 
 ```
-      --audit-config string                        Path to the audit configuration file
-      --authz-config string                        Path to the authorization configuration file
-      --ca-cert string                             Path to a custom CA certificate file to use for container builds
-      --enable-audit                               Enable audit logging with default configuration (default false)
-      --endpoint-prefix string                     Path prefix to prepend to SSE endpoint URLs (e.g., /playwright)
-  -e, --env stringArray                            Environment variables to pass to the MCP server (format: KEY=VALUE)
-      --env-file string                            Load environment variables from a single file
-      --env-file-dir string                        Load environment variables from all files in a directory
-  -f, --foreground                                 Run in foreground mode (block until container exits) (default false)
-      --from-config string                         Load configuration from exported file
-      --group string                               Name of the group this workload should belong to (default "default")
-  -h, --help                                       help for run
-      --host string                                Host for the HTTP proxy to listen on (IP or hostname) (default "127.0.0.1")
-      --ignore-globally                            Load global ignore patterns from ~/.config/toolhive/thvignore (default true)
-      --image-verification string                  Set image verification mode (warn, enabled, disabled) (default "warn")
-      --isolate-network                            Isolate the container network from the host (default false)
-      --jwks-allow-private-ip                      Allow JWKS/OIDC endpoints on private IP addresses (use with caution) (default false)
-      --jwks-auth-token-file string                Path to file containing bearer token for authenticating JWKS/OIDC requests
-  -l, --label stringArray                          Set labels on the container (format: key=value)
-      --name string                                Name of the MCP server (default to auto-generated from image)
-      --network string                             Connect the container to a network (e.g., 'host' for host networking)
-      --oidc-audience string                       Expected audience for the token
-      --oidc-client-id string                      OIDC client ID
-      --oidc-client-secret string                  OIDC client secret (optional, for introspection)
-      --oidc-insecure-allow-http                   Allow HTTP (non-HTTPS) OIDC issuers for local development/testing (WARNING: Insecure!) (default false)
-      --oidc-introspection-url string              URL for token introspection endpoint
-      --oidc-issuer string                         OIDC issuer URL (e.g., https://accounts.google.com)
-      --oidc-jwks-url string                       URL to fetch the JWKS from
-      --oidc-scopes strings                        OAuth scopes to advertise in the well-known endpoint (RFC 9728, defaults to 'openid' if not specified)
-      --otel-custom-attributes string              Custom resource attributes for OpenTelemetry in key=value format (e.g., server_type=prod,region=us-east-1,team=platform)
-      --otel-enable-prometheus-metrics-path        Enable Prometheus-style /metrics endpoint on the main transport port (default false)
-      --otel-endpoint string                       OpenTelemetry OTLP endpoint URL (e.g., https://api.honeycomb.io)
-      --otel-env-vars stringArray                  Environment variable names to include in OpenTelemetry spans (comma-separated: ENV1,ENV2)
-      --otel-headers stringArray                   OpenTelemetry OTLP headers in key=value format (e.g., x-honeycomb-team=your-api-key)
-      --otel-insecure                              Connect to the OpenTelemetry endpoint using HTTP instead of HTTPS (default false)
-      --otel-metrics-enabled                       Enable OTLP metrics export (when OTLP endpoint is configured) (default true)
-      --otel-sampling-rate float                   OpenTelemetry trace sampling rate (0.0-1.0) (default 0.1)
-      --otel-service-name string                   OpenTelemetry service name (defaults to toolhive-mcp-proxy)
-      --otel-tracing-enabled                       Enable distributed tracing (when OTLP endpoint is configured) (default true)
-      --permission-profile string                  Permission profile to use (none, network, or path to JSON file) (default is to use the permission profile from the registry or "network" if not part of the registry)
-      --print-resolved-overlays                    Debug: show resolved container paths for tmpfs overlays (default false)
-      --proxy-mode string                          Proxy mode for stdio (streamable-http or sse (deprecated, will be removed)) (default "streamable-http")
-      --proxy-port int                             Port for the HTTP proxy to listen on (host port)
-      --remote-auth                                Enable OAuth/OIDC authentication to remote MCP server (default false)
-      --remote-auth-authorize-url string           OAuth authorization endpoint URL (alternative to --remote-auth-issuer for non-OIDC OAuth)
-      --remote-auth-bearer-token string            Bearer token for remote server authentication (alternative to OAuth)
-      --remote-auth-bearer-token-file string       Path to file containing bearer token (alternative to --remote-auth-bearer-token)
-      --remote-auth-callback-port int              Port for OAuth callback server during remote authentication (default 8666)
-      --remote-auth-client-id string               OAuth client ID for remote server authentication (optional if the authorization server supports dynamic client registration (RFC 7591))
-      --remote-auth-client-secret string           OAuth client secret for remote server authentication (optional if the authorization server supports dynamic client registration (RFC 7591) or if using PKCE)
-      --remote-auth-client-secret-file string      Path to file containing OAuth client secret (alternative to --remote-auth-client-secret) (optional if the authorization server supports dynamic client registration (RFC 7591) or if using PKCE)
-      --remote-auth-issuer string                  OAuth/OIDC issuer URL for remote server authentication (e.g., https://accounts.google.com)
-      --remote-auth-resource string                OAuth 2.0 resource indicator (RFC 8707)
-      --remote-auth-scopes strings                 OAuth scopes to request for remote server authentication (defaults: OIDC uses 'openid,profile,email')
-      --remote-auth-skip-browser                   Skip opening browser for remote server OAuth flow (default false)
-      --remote-auth-timeout duration               Timeout for OAuth authentication flow (e.g., 30s, 1m, 2m30s) (default 30s)
-      --remote-auth-token-url string               OAuth token endpoint URL (alternative to --remote-auth-issuer for non-OIDC OAuth)
-      --resource-url string                        Explicit resource URL for OAuth discovery endpoint (RFC 9728)
-      --secret stringArray                         Specify a secret to be fetched from the secrets manager and set as an environment variable (format: NAME,target=TARGET)
-      --target-host string                         Host to forward traffic to (only applicable to SSE or Streamable HTTP transport) (default "127.0.0.1")
-      --target-port int                            Port for the container to expose (only applicable to SSE or Streamable HTTP transport)
-      --thv-ca-bundle string                       Path to CA certificate bundle for ToolHive HTTP operations (JWKS, OIDC discovery, etc.)
-      --token-exchange-audience string             Target audience for exchanged tokens
-      --token-exchange-client-id string            OAuth client ID for token exchange operations
-      --token-exchange-client-secret string        OAuth client secret for token exchange operations
-      --token-exchange-client-secret-file string   Path to file containing OAuth client secret for token exchange (alternative to --token-exchange-client-secret)
-      --token-exchange-header-name string          Custom header name for injecting exchanged token (default: replaces Authorization header)
-      --token-exchange-scopes strings              Scopes to request for exchanged tokens
-      --token-exchange-subject-token-type string   Type of subject token to exchange. Accepts: access_token (default), id_token (required for Google STS)
-      --token-exchange-url string                  OAuth 2.0 token exchange endpoint URL (enables token exchange when provided)
-      --tools stringArray                          Filter MCP server tools (comma-separated list of tool names)
-      --tools-override string                      Path to a JSON file containing overrides for MCP server tools names and descriptions
-      --transport string                           Transport mode (sse, streamable-http or stdio)
-      --trust-proxy-headers                        Trust X-Forwarded-* headers from reverse proxies (X-Forwarded-Proto, X-Forwarded-Host, X-Forwarded-Port, X-Forwarded-Prefix) (default false)
-  -v, --volume stringArray                         Mount a volume into the container (format: host-path:container-path[:ro])
+      --audit-config string                         Path to the audit configuration file
+      --authz-config string                         Path to the authorization configuration file
+      --ca-cert string                              Path to a custom CA certificate file to use for container builds
+      --enable-audit                                Enable audit logging with default configuration (default false)
+      --endpoint-prefix string                      Path prefix to prepend to SSE endpoint URLs (e.g., /playwright)
+  -e, --env stringArray                             Environment variables to pass to the MCP server (format: KEY=VALUE)
+      --env-file string                             Load environment variables from a single file
+      --env-file-dir string                         Load environment variables from all files in a directory
+  -f, --foreground                                  Run in foreground mode (block until container exits) (default false)
+      --from-config string                          Load configuration from exported file
+      --group string                                Name of the group this workload should belong to (default "default")
+  -h, --help                                        help for run
+      --host string                                 Host for the HTTP proxy to listen on (IP or hostname) (default "127.0.0.1")
+      --ignore-globally                             Load global ignore patterns from ~/.config/toolhive/thvignore (default true)
+      --image-verification string                   Set image verification mode (warn, enabled, disabled) (default "warn")
+      --isolate-network                             Isolate the container network from the host (default false)
+      --jwks-allow-private-ip                       Allow JWKS/OIDC endpoints on private IP addresses (use with caution) (default false)
+      --jwks-auth-token-file string                 Path to file containing bearer token for authenticating JWKS/OIDC requests
+  -l, --label stringArray                           Set labels on the container (format: key=value)
+      --name string                                 Name of the MCP server (default to auto-generated from image)
+      --network string                              Connect the container to a network (e.g., 'host' for host networking)
+      --oidc-audience string                        Expected audience for the token
+      --oidc-client-id string                       OIDC client ID
+      --oidc-client-secret string                   OIDC client secret (optional, for introspection)
+      --oidc-insecure-allow-http                    Allow HTTP (non-HTTPS) OIDC issuers for local development/testing (WARNING: Insecure!) (default false)
+      --oidc-introspection-url string               URL for token introspection endpoint
+      --oidc-issuer string                          OIDC issuer URL (e.g., https://accounts.google.com)
+      --oidc-jwks-url string                        URL to fetch the JWKS from
+      --oidc-scopes strings                         OAuth scopes to advertise in the well-known endpoint (RFC 9728, defaults to 'openid' if not specified)
+      --otel-custom-attributes string               Custom resource attributes for OpenTelemetry in key=value format (e.g., server_type=prod,region=us-east-1,team=platform)
+      --otel-enable-prometheus-metrics-path         Enable Prometheus-style /metrics endpoint on the main transport port (default false)
+      --otel-endpoint string                        OpenTelemetry OTLP endpoint URL (e.g., https://api.honeycomb.io)
+      --otel-env-vars stringArray                   Environment variable names to include in OpenTelemetry spans (comma-separated: ENV1,ENV2)
+      --otel-headers stringArray                    OpenTelemetry OTLP headers in key=value format (e.g., x-honeycomb-team=your-api-key)
+      --otel-insecure                               Connect to the OpenTelemetry endpoint using HTTP instead of HTTPS (default false)
+      --otel-metrics-enabled                        Enable OTLP metrics export (when OTLP endpoint is configured) (default true)
+      --otel-sampling-rate float                    OpenTelemetry trace sampling rate (0.0-1.0) (default 0.1)
+      --otel-service-name string                    OpenTelemetry service name (defaults to toolhive-mcp-proxy)
+      --otel-tracing-enabled                        Enable distributed tracing (when OTLP endpoint is configured) (default true)
+      --permission-profile string                   Permission profile to use (none, network, or path to JSON file) (default is to use the permission profile from the registry or "network" if not part of the registry)
+      --print-resolved-overlays                     Debug: show resolved container paths for tmpfs overlays (default false)
+      --proxy-mode string                           Proxy mode for stdio (streamable-http or sse (deprecated, will be removed)) (default "streamable-http")
+      --proxy-port int                              Port for the HTTP proxy to listen on (host port)
+      --remote-auth                                 Enable OAuth/OIDC authentication to remote MCP server (default false)
+      --remote-auth-authorize-url string            OAuth authorization endpoint URL (alternative to --remote-auth-issuer for non-OIDC OAuth)
+      --remote-auth-bearer-token string             Bearer token for remote server authentication (alternative to OAuth)
+      --remote-auth-bearer-token-file string        Path to file containing bearer token (alternative to --remote-auth-bearer-token)
+      --remote-auth-callback-port int               Port for OAuth callback server during remote authentication (default 8666)
+      --remote-auth-client-id string                OAuth client ID for remote server authentication (optional if the authorization server supports dynamic client registration (RFC 7591))
+      --remote-auth-client-secret string            OAuth client secret for remote server authentication (optional if the authorization server supports dynamic client registration (RFC 7591) or if using PKCE)
+      --remote-auth-client-secret-file string       Path to file containing OAuth client secret (alternative to --remote-auth-client-secret) (optional if the authorization server supports dynamic client registration (RFC 7591) or if using PKCE)
+      --remote-auth-issuer string                   OAuth/OIDC issuer URL for remote server authentication (e.g., https://accounts.google.com)
+      --remote-auth-resource string                 OAuth 2.0 resource indicator (RFC 8707)
+      --remote-auth-scopes strings                  OAuth scopes to request for remote server authentication (defaults: OIDC uses 'openid,profile,email')
+      --remote-auth-skip-browser                    Skip opening browser for remote server OAuth flow (default false)
+      --remote-auth-timeout duration                Timeout for OAuth authentication flow (e.g., 30s, 1m, 2m30s) (default 30s)
+      --remote-auth-token-url string                OAuth token endpoint URL (alternative to --remote-auth-issuer for non-OIDC OAuth)
+      --remote-forward-headers stringArray          Headers to inject into requests to remote MCP server (format: Name=Value, can be repeated)
+      --remote-forward-headers-secret stringArray   Headers with secret values from ToolHive secrets manager (format: Name=secret-name, can be repeated)
+      --resource-url string                         Explicit resource URL for OAuth discovery endpoint (RFC 9728)
+      --secret stringArray                          Specify a secret to be fetched from the secrets manager and set as an environment variable (format: NAME,target=TARGET)
+      --target-host string                          Host to forward traffic to (only applicable to SSE or Streamable HTTP transport) (default "127.0.0.1")
+      --target-port int                             Port for the container to expose (only applicable to SSE or Streamable HTTP transport)
+      --thv-ca-bundle string                        Path to CA certificate bundle for ToolHive HTTP operations (JWKS, OIDC discovery, etc.)
+      --token-exchange-audience string              Target audience for exchanged tokens
+      --token-exchange-client-id string             OAuth client ID for token exchange operations
+      --token-exchange-client-secret string         OAuth client secret for token exchange operations
+      --token-exchange-client-secret-file string    Path to file containing OAuth client secret for token exchange (alternative to --token-exchange-client-secret)
+      --token-exchange-header-name string           Custom header name for injecting exchanged token (default: replaces Authorization header)
+      --token-exchange-scopes strings               Scopes to request for exchanged tokens
+      --token-exchange-subject-token-type string    Type of subject token to exchange. Accepts: access_token (default), id_token (required for Google STS)
+      --token-exchange-url string                   OAuth 2.0 token exchange endpoint URL (enables token exchange when provided)
+      --tools stringArray                           Filter MCP server tools (comma-separated list of tool names)
+      --tools-override string                       Path to a JSON file containing overrides for MCP server tools names and descriptions
+      --transport string                            Transport mode (sse, streamable-http or stdio)
+      --trust-proxy-headers                         Trust X-Forwarded-* headers from reverse proxies (X-Forwarded-Proto, X-Forwarded-Host, X-Forwarded-Port, X-Forwarded-Prefix) (default false)
+  -v, --volume stringArray                          Mount a volume into the container (format: host-path:container-path[:ro])
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
Add --remote-forward-headers and --remote-forward-headers-secret flags to both thv proxy and thv run commands for configuring header injection to remote MCP servers.

Changes:
- header_flags.go: Shared parsing logic for header flags and secrets
- proxy.go: Add flags and wire middleware into proxy command
- run_flags.go: Add flags to RunFlags struct and builder options
- header_forward.go: Add HeaderForwardMiddlewareName constant

The --remote-forward-headers-secret option resolves values from the ToolHive secrets manager, keeping sensitive data out of process listings and RunConfig persistence.

Related: #3316 