### PR TITLE
Add configurable UserInfo field mapping and UserInfo support for authserver's OAuth provider

### DIFF
--- a/pkg/authserver/upstream/doc.go
+++ b/pkg/authserver/upstream/doc.go
@@ -95,7 +95,7 @@
 //	    EndpointURL: "https://api.example.com/user",
 //	    HTTPMethod:  "GET",  // or "POST" per OIDC Core Section 5.3.1
 //	    FieldMapping: &upstream.UserInfoFieldMapping{
-//	        SubjectField: "user_id",  // custom field for non-OIDC providers
+//	        SubjectFields: []string{"user_id"},  // custom field for non-OIDC providers
 //	    },
 //	}
 package upstream


### PR DESCRIPTION
Enhance UserInfoFieldMapping to support ordered fallback field chains, enabling compatibility with non-standard OAuth providers like GitHub that use different claim names (e.g., "id" instead of "sub").

Changes:
- Replace single field names with ordered lists (SubjectFields, NameFields, EmailFields)
- Add ResolveField() helper with support for numeric ID conversion
- Add ResolveSubject/ResolveName/ResolveEmail methods with defaults
- Implement UserInfoProvider interface on BaseOAuth2Provider
- Support additional headers for provider-specific requirements (e.g., GitHub API versioning)
- Add JSON/YAML struct tags for file-based configuration support

Example YAML configuration for GitHub:
```
upstream:
  client_id: "my-app"
  client_secret: "secret"
  redirect_uri: "http://localhost:8080/callback"
  authorization_endpoint: "https://github.com/login/oauth/authorize"
  token_endpoint: "https://github.com/login/oauth/access_token"
  scopes:
    - user:email
  userinfo:
    endpoint_url: "https://api.github.com/user"
    additional_headers:
      X-GitHub-Api-Version: "2022-11-28"
    field_mapping:
      subject_fields: ["id", "login"]
      name_fields: ["name", "login"]
      email_fields: ["email"]
```