### PR TITLE
Add authserver configuration with validation and auto-generation

### DIFF
--- a/pkg/authserver/config_test.go
+++ b/pkg/authserver/config_test.go
@@ -78,11 +78,13 @@ func TestConfigValidate(t *testing.T) {
 		{name: "nil upstream config", config: Config{Issuer: "https://example.com", KeyProvider: validKeyProvider, HMACSecrets: validHMAC, Upstreams: []UpstreamConfig{{Name: "test"}}}, wantErr: true, errMsg: "config is required"},
 		{name: "multiple upstreams", config: Config{Issuer: "https://example.com", KeyProvider: validKeyProvider, HMACSecrets: validHMAC, Upstreams: []UpstreamConfig{{Name: "first", Config: validUpstream}, {Name: "second", Config: validUpstream}}}, wantErr: true, errMsg: "multiple upstreams not yet supported (found 2)"},
 		{name: "duplicate upstream names", config: Config{Issuer: "https://example.com", KeyProvider: validKeyProvider, HMACSecrets: validHMAC, Upstreams: []UpstreamConfig{{Name: "same", Config: validUpstream}, {Name: "same", Config: validUpstream}}}, wantErr: true, errMsg: "multiple upstreams not yet supported"},
+		{name: "missing allowed audiences", config: Config{Issuer: "https://example.com", KeyProvider: validKeyProvider, HMACSecrets: validHMAC, Upstreams: validUpstreams}, wantErr: true, errMsg: "at least one allowed audience is required"},
+		{name: "empty allowed audiences slice", config: Config{Issuer: "https://example.com", KeyProvider: validKeyProvider, HMACSecrets: validHMAC, Upstreams: validUpstreams, AllowedAudiences: []string{}}, wantErr: true, errMsg: "at least one allowed audience is required"},
 
 		// Valid configs
-		{name: "valid minimal", config: Config{Issuer: "https://example.com", KeyProvider: validKeyProvider, HMACSecrets: validHMAC, Upstreams: validUpstreams}},
-		{name: "valid nil key provider", config: Config{Issuer: "https://example.com", HMACSecrets: validHMAC, Upstreams: validUpstreams}},
-		{name: "valid empty upstream name defaults", config: Config{Issuer: "https://example.com", KeyProvider: validKeyProvider, HMACSecrets: validHMAC, Upstreams: []UpstreamConfig{{Config: validUpstream}}}},
+		{name: "valid minimal", config: Config{Issuer: "https://example.com", KeyProvider: validKeyProvider, HMACSecrets: validHMAC, Upstreams: validUpstreams, AllowedAudiences: []string{"https://mcp.example.com"}}},
+		{name: "valid nil key provider", config: Config{Issuer: "https://example.com", HMACSecrets: validHMAC, Upstreams: validUpstreams, AllowedAudiences: []string{"https://mcp.example.com"}}},
+		{name: "valid empty upstream name defaults", config: Config{Issuer: "https://example.com", KeyProvider: validKeyProvider, HMACSecrets: validHMAC, Upstreams: []UpstreamConfig{{Config: validUpstream}}, AllowedAudiences: []string{"https://mcp.example.com"}}},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This PR introduces the `Config` type for the OAuth authorization server, providing a pure configuration interface with full validation. The config supports signing keys via a `KeyProvider` interface (with auto-generation for development), HMAC secrets for opaque tokens (authorization codes and refresh tokens), sensible token lifespan defaults (1h access, 7d refresh, 10m auth code), and pre-registered OAuth client definitions supporting both public and confidential client types. Issuer URL validation enforces HTTPS per OIDC Core Section 3.1.2.1 and RFC 8414, with a localhost exception for development workflows.

This configuration layer is consumed by the upcoming `newServer()` implementation which creates the fosite-based OAuth 2.0 authorization server. The server calls `applyDefaults()` to fill in missing values and `Validate()` to ensure correctness before constructing the `AuthorizationServerParams` that configure the OAuth2 provider, handlers, and endpoints. The "just works" philosophy enables quick development startup with ephemeral secrets while warning about their limitations, and the config cleanly separates concerns: this layer handles what the server needs, while the server implementation handles how it delivers OAuth/OIDC functionality.