### PR TITLE
Add E2E tests for secrets management

### DIFF
--- a/test/e2e/api_secrets_test.go
+++ b/test/e2e/api_secrets_test.go
@@ -389,11 +389,8 @@ var _ = Describe("Secrets API", Label("api", "secrets", "e2e"), func() {
 				resp := updateSecret(apiServer, "test-key", "")
 				defer resp.Body.Close()
 
-				By("Verifying response status is 400 or 405")
-				Expect(resp.StatusCode).To(SatisfyAny(
-					Equal(http.StatusBadRequest),
-					Equal(http.StatusMethodNotAllowed),
-				))
+				By("Verifying response status is 400")
+				Expect(resp.StatusCode).To(SatisfyAny(Equal(http.StatusBadRequest)))
 			})
 
 			It("should reject malformed JSON", func() {


### PR DESCRIPTION
Due to dependency issues (keychain for encrypted, or 1password), these tests only test the environment type. This does not cover all secrets management functionality, but verifies basic correctness of the secrets endpoints.