### PR TITLE
Update Go version to 1.25.6 to fix security vulnerabilities

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stacklok/toolhive
 
-go 1.25.5
+go 1.25.6
 
 require (
 	dario.cat/mergo v1.0.2


### PR DESCRIPTION
## Summary

Updates Go from 1.25.5 to 1.25.6 to address three stdlib vulnerabilities that are causing the govulncheck CI check to fail:

- **GO-2026-4340** (CVE-2025-61730): TLS 1.3 handshake issue in `crypto/tls` - minor information disclosure
- **GO-2026-4341** (CVE-2025-61726): No limit on query parameters in `net/url` - memory exhaustion DoS
- **GO-2026-4342** (CVE-2025-61728): Super-linear indexing in `archive/zip` - CPU exhaustion DoS

All three vulnerabilities are fixed in Go 1.25.6.

## Test plan

- [x] Build passes
- [x] Linting passes
- [x] Unit tests pass
- [ ] CI govulncheck should pass with the updated Go version

🤖 Generated with [Claude Code](https://claude.com/claude-code)