### PR TITLE
Add headerForward to workloads REST API

### DIFF
--- a/docs/server/docs.go
+++ b/docs/server/docs.go
@@ -1452,6 +1452,9 @@ const docTemplate = `{
                         "description": "Group name this workload belongs to",
                         "type": "string"
                     },
+                    "header_forward": {
+                        "$ref": "#/components/schemas/v1.headerForwardConfig"
+                    },
                     "headers": {
                         "items": {
                             "$ref": "#/components/schemas/registry.Header"
@@ -1658,6 +1661,26 @@ const docTemplate = `{
                         },
                         "type": "array",
                         "uniqueItems": false
+                    }
+                },
+                "type": "object"
+            },
+            "v1.headerForwardConfig": {
+                "description": "HeaderForward configures headers to inject into requests to remote MCP servers.\nUse this to add custom headers like X-Tenant-ID or correlation IDs.",
+                "properties": {
+                    "add_headers_from_secret": {
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "AddHeadersFromSecret maps header names to secret names in ToolHive's secrets manager.\nKey: HTTP header name, Value: secret name in the secrets manager",
+                        "type": "object"
+                    },
+                    "add_plaintext_headers": {
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "AddPlaintextHeaders contains literal header values to inject.\nWARNING: These values are stored and transmitted in plaintext.\nUse AddHeadersFromSecret for sensitive data like API keys.",
+                        "type": "object"
                     }
                 },
                 "type": "object"
@@ -1945,6 +1968,9 @@ const docTemplate = `{
                     "group": {
                         "description": "Group name this workload belongs to",
                         "type": "string"
+                    },
+                    "header_forward": {
+                        "$ref": "#/components/schemas/v1.headerForwardConfig"
                     },
                     "headers": {
                         "items": {

--- a/docs/server/swagger.json
+++ b/docs/server/swagger.json
@@ -1445,6 +1445,9 @@
                         "description": "Group name this workload belongs to",
                         "type": "string"
                     },
+                    "header_forward": {
+                        "$ref": "#/components/schemas/v1.headerForwardConfig"
+                    },
                     "headers": {
                         "items": {
                             "$ref": "#/components/schemas/registry.Header"
@@ -1651,6 +1654,26 @@
                         },
                         "type": "array",
                         "uniqueItems": false
+                    }
+                },
+                "type": "object"
+            },
+            "v1.headerForwardConfig": {
+                "description": "HeaderForward configures headers to inject into requests to remote MCP servers.\nUse this to add custom headers like X-Tenant-ID or correlation IDs.",
+                "properties": {
+                    "add_headers_from_secret": {
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "AddHeadersFromSecret maps header names to secret names in ToolHive's secrets manager.\nKey: HTTP header name, Value: secret name in the secrets manager",
+                        "type": "object"
+                    },
+                    "add_plaintext_headers": {
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "AddPlaintextHeaders contains literal header values to inject.\nWARNING: These values are stored and transmitted in plaintext.\nUse AddHeadersFromSecret for sensitive data like API keys.",
+                        "type": "object"
                     }
                 },
                 "type": "object"
@@ -1938,6 +1961,9 @@
                     "group": {
                         "description": "Group name this workload belongs to",
                         "type": "string"
+                    },
+                    "header_forward": {
+                        "$ref": "#/components/schemas/v1.headerForwardConfig"
                     },
                     "headers": {
                         "items": {

--- a/docs/server/swagger.yaml
+++ b/docs/server/swagger.yaml
@@ -1293,6 +1293,8 @@ components:
         group:
           description: Group name this workload belongs to
           type: string
+        header_forward:
+          $ref: '#/components/schemas/v1.headerForwardConfig'
         headers:
           items:
             $ref: '#/components/schemas/registry.Header'
@@ -1444,6 +1446,27 @@ components:
             $ref: '#/components/schemas/groups.Group'
           type: array
           uniqueItems: false
+      type: object
+    v1.headerForwardConfig:
+      description: |-
+        HeaderForward configures headers to inject into requests to remote MCP servers.
+        Use this to add custom headers like X-Tenant-ID or correlation IDs.
+      properties:
+        add_headers_from_secret:
+          additionalProperties:
+            type: string
+          description: |-
+            AddHeadersFromSecret maps header names to secret names in ToolHive's secrets manager.
+            Key: HTTP header name, Value: secret name in the secrets manager
+          type: object
+        add_plaintext_headers:
+          additionalProperties:
+            type: string
+          description: |-
+            AddPlaintextHeaders contains literal header values to inject.
+            WARNING: These values are stored and transmitted in plaintext.
+            Use AddHeadersFromSecret for sensitive data like API keys.
+          type: object
       type: object
     v1.listSecretsResponse:
       description: Response containing a list of secret keys
@@ -1658,6 +1681,8 @@ components:
         group:
           description: Group name this workload belongs to
           type: string
+        header_forward:
+          $ref: '#/components/schemas/v1.headerForwardConfig'
         headers:
           items:
             $ref: '#/components/schemas/registry.Header'

--- a/pkg/api/v1/workload_service.go
+++ b/pkg/api/v1/workload_service.go
@@ -137,6 +137,11 @@ func (s *WorkloadService) BuildFullRunConfig(
 		}
 	}
 
+	// Validate header forward configuration
+	if err := validateHeaderForwardConfig(req.HeaderForward); err != nil {
+		return nil, fmt.Errorf("%w: %w", retriever.ErrInvalidRunConfig, err)
+	}
+
 	// Default group if not specified
 	groupName := req.Group
 	if groupName == "" {
@@ -263,6 +268,16 @@ func (s *WorkloadService) BuildFullRunConfig(
 		runner.WithToolsFilter(req.ToolsFilter),
 		runner.WithToolsOverride(toolsOverride),
 		runner.WithTelemetryConfigFromFlags("", false, false, false, "", 0.0, nil, false, nil),
+	}
+
+	// Add header forward configuration if specified
+	if req.HeaderForward != nil {
+		if len(req.HeaderForward.AddPlaintextHeaders) > 0 {
+			options = append(options, runner.WithHeaderForward(req.HeaderForward.AddPlaintextHeaders))
+		}
+		if len(req.HeaderForward.AddHeadersFromSecret) > 0 {
+			options = append(options, runner.WithHeaderForwardSecrets(req.HeaderForward.AddHeadersFromSecret))
+		}
 	}
 
 	// Add existing port if provided (for update operations)

--- a/pkg/api/v1/workload_types.go
+++ b/pkg/api/v1/workload_types.go
@@ -5,6 +5,7 @@ package v1
 
 import (
 	"fmt"
+	"net/http"
 
 	"github.com/stacklok/toolhive/pkg/container/runtime"
 	"github.com/stacklok/toolhive/pkg/core"
@@ -12,6 +13,8 @@ import (
 	"github.com/stacklok/toolhive/pkg/registry/registry"
 	"github.com/stacklok/toolhive/pkg/runner"
 	"github.com/stacklok/toolhive/pkg/secrets"
+	"github.com/stacklok/toolhive/pkg/transport/middleware"
+	"github.com/stacklok/toolhive/pkg/validation"
 )
 
 // workloadListResponse represents the response for listing workloads
@@ -75,6 +78,10 @@ type updateRequest struct {
 	URL         string             `json:"url,omitempty"`
 	OAuthConfig remoteOAuthConfig  `json:"oauth_config,omitempty"`
 	Headers     []*registry.Header `json:"headers,omitempty"`
+
+	// HeaderForward configures headers to inject into requests to remote MCP servers.
+	// Use this to add custom headers like X-Tenant-ID or correlation IDs.
+	HeaderForward *headerForwardConfig `json:"header_forward,omitempty"`
 }
 
 // toolOverride represents a tool override
@@ -85,6 +92,20 @@ type toolOverride struct {
 	Name string `json:"name,omitempty"`
 	// Description of the tool
 	Description string `json:"description,omitempty"`
+}
+
+// headerForwardConfig represents header forward configuration for API requests/responses
+//
+//	@Description	Configuration for injecting headers into requests to remote MCP servers
+type headerForwardConfig struct {
+	// AddPlaintextHeaders contains literal header values to inject.
+	// WARNING: These values are stored and transmitted in plaintext.
+	// Use AddHeadersFromSecret for sensitive data like API keys.
+	AddPlaintextHeaders map[string]string `json:"add_plaintext_headers,omitempty"`
+
+	// AddHeadersFromSecret maps header names to secret names in ToolHive's secrets manager.
+	// Key: HTTP header name, Value: secret name in the secrets manager
+	AddHeadersFromSecret map[string]string `json:"add_headers_from_secret,omitempty"`
 }
 
 // remoteOAuthConfig represents OAuth configuration for remote servers
@@ -262,6 +283,15 @@ func runConfigToCreateRequest(runConfig *runner.RunConfig) *createRequest {
 		}
 	}
 
+	// Convert HeaderForward from RunConfig
+	var headerForward *headerForwardConfig
+	if runConfig.HeaderForward != nil {
+		headerForward = &headerForwardConfig{
+			AddPlaintextHeaders:  runConfig.HeaderForward.AddPlaintextHeaders,
+			AddHeadersFromSecret: runConfig.HeaderForward.AddHeadersFromSecret,
+		}
+	}
+
 	return &createRequest{
 		updateRequest: updateRequest{
 			Image:             runConfig.Image,
@@ -285,7 +315,58 @@ func runConfigToCreateRequest(runConfig *runner.RunConfig) *createRequest {
 			URL:               runConfig.RemoteURL,
 			OAuthConfig:       oAuthConfig,
 			Headers:           headers,
+			HeaderForward:     headerForward,
 		},
 		Name: runConfig.Name,
 	}
+}
+
+// validateHeaderForwardConfig validates the header forward configuration.
+// Returns an error if any header name is restricted/invalid or any value contains control characters.
+func validateHeaderForwardConfig(config *headerForwardConfig) error {
+	if config == nil {
+		return nil
+	}
+
+	// Validate plaintext headers (both name and value)
+	for name, value := range config.AddPlaintextHeaders {
+		if err := validateHeaderName(name); err != nil {
+			return err
+		}
+		// Validate value for CRLF injection and control characters per RFC 7230
+		if value != "" {
+			if err := validation.ValidateHTTPHeaderValue(value); err != nil {
+				return fmt.Errorf("invalid header value for %q: %w", name, err)
+			}
+		}
+	}
+
+	// Validate secret-backed header names (values are validated at resolution time)
+	for name := range config.AddHeadersFromSecret {
+		if err := validateHeaderName(name); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// validateHeaderName checks if a header name is valid per RFC 7230 and not restricted.
+func validateHeaderName(name string) error {
+	if name == "" {
+		return fmt.Errorf("header name cannot be empty")
+	}
+
+	// Validate header name format per RFC 7230
+	if err := validation.ValidateHTTPHeaderName(name); err != nil {
+		return fmt.Errorf("invalid header name %q: %w", name, err)
+	}
+
+	// Check for restricted headers using canonical form
+	canonical := http.CanonicalHeaderKey(name)
+	if middleware.RestrictedHeaders[canonical] {
+		return fmt.Errorf("header %q is restricted and cannot be configured for forwarding", name)
+	}
+
+	return nil
 }

--- a/pkg/api/v1/workloads_types_test.go
+++ b/pkg/api/v1/workloads_types_test.go
@@ -127,6 +127,77 @@ func TestRunConfigToCreateRequest(t *testing.T) {
 		assert.Equal(t, []string{"tool1", "tool2"}, result.ToolsFilter)
 	})
 
+	t.Run("with plaintext header forward", func(t *testing.T) {
+		t.Parallel()
+
+		runConfig := &runner.RunConfig{
+			Name: "test-workload",
+			HeaderForward: &runner.HeaderForwardConfig{
+				AddPlaintextHeaders: map[string]string{
+					"X-Custom-Header": "custom-value",
+					"X-Tenant-ID":     "tenant-123",
+				},
+			},
+		}
+
+		result := runConfigToCreateRequest(runConfig)
+
+		require.NotNil(t, result)
+		require.NotNil(t, result.HeaderForward)
+		assert.Equal(t, map[string]string{
+			"X-Custom-Header": "custom-value",
+			"X-Tenant-ID":     "tenant-123",
+		}, result.HeaderForward.AddPlaintextHeaders)
+		assert.Nil(t, result.HeaderForward.AddHeadersFromSecret)
+	})
+
+	t.Run("with secret-backed header forward", func(t *testing.T) {
+		t.Parallel()
+
+		runConfig := &runner.RunConfig{
+			Name: "test-workload",
+			HeaderForward: &runner.HeaderForwardConfig{
+				AddHeadersFromSecret: map[string]string{
+					"Authorization": "api-key-secret",
+					"X-API-Key":     "another-secret",
+				},
+			},
+		}
+
+		result := runConfigToCreateRequest(runConfig)
+
+		require.NotNil(t, result)
+		require.NotNil(t, result.HeaderForward)
+		assert.Nil(t, result.HeaderForward.AddPlaintextHeaders)
+		assert.Equal(t, map[string]string{
+			"Authorization": "api-key-secret",
+			"X-API-Key":     "another-secret",
+		}, result.HeaderForward.AddHeadersFromSecret)
+	})
+
+	t.Run("with both plaintext and secret header forward", func(t *testing.T) {
+		t.Parallel()
+
+		runConfig := &runner.RunConfig{
+			Name: "test-workload",
+			HeaderForward: &runner.HeaderForwardConfig{
+				AddPlaintextHeaders: map[string]string{
+					"X-Tenant-ID": "tenant-123",
+				},
+				AddHeadersFromSecret: map[string]string{
+					"Authorization": "api-key-secret",
+				},
+			},
+		}
+
+		result := runConfigToCreateRequest(runConfig)
+
+		require.NotNil(t, result)
+		require.NotNil(t, result.HeaderForward)
+		assert.Equal(t, "tenant-123", result.HeaderForward.AddPlaintextHeaders["X-Tenant-ID"])
+		assert.Equal(t, "api-key-secret", result.HeaderForward.AddHeadersFromSecret["Authorization"])
+	})
+
 	t.Run("with OIDC config", func(t *testing.T) {
 		t.Parallel()
 
@@ -340,85 +411,193 @@ func TestRunConfigToCreateRequest(t *testing.T) {
 func TestCreateRequestToRemoteAuthConfig(t *testing.T) {
 	t.Parallel()
 
-	t.Run("with bearer token", func(t *testing.T) {
-		t.Parallel()
+	tests := []struct {
+		name                 string
+		clientSecret         *secrets.SecretParameter
+		bearerToken          *secrets.SecretParameter
+		expectedClientSecret string
+		expectedBearerToken  string
+	}{
+		{
+			name: "with bearer token only",
+			bearerToken: &secrets.SecretParameter{
+				Name:   "bearer-token-secret",
+				Target: "bearer_token",
+			},
+			expectedClientSecret: "",
+			expectedBearerToken:  "bearer-token-secret,target=bearer_token",
+		},
+		{
+			name: "with bearer token and client secret",
+			clientSecret: &secrets.SecretParameter{
+				Name:   "oauth-client-secret",
+				Target: "oauth_secret",
+			},
+			bearerToken: &secrets.SecretParameter{
+				Name:   "bearer-token-secret",
+				Target: "bearer_token",
+			},
+			expectedClientSecret: "oauth-client-secret,target=oauth_secret",
+			expectedBearerToken:  "bearer-token-secret,target=bearer_token",
+		},
+		{
+			name:                 "without bearer token or client secret",
+			clientSecret:         nil,
+			bearerToken:          nil,
+			expectedClientSecret: "",
+			expectedBearerToken:  "",
+		},
+	}
 
-		bearerTokenParam := &secrets.SecretParameter{
-			Name:   "bearer-token-secret",
-			Target: "bearer_token",
-		}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-		req := &createRequest{
-			updateRequest: updateRequest{
-				URL: "https://example.com/mcp",
-				OAuthConfig: remoteOAuthConfig{
-					ClientID:    "test-client",
-					BearerToken: bearerTokenParam,
-					Scopes:      []string{"read", "write"},
+			req := &createRequest{
+				updateRequest: updateRequest{
+					URL: "https://example.com/mcp",
+					OAuthConfig: remoteOAuthConfig{
+						ClientID:     "test-client",
+						ClientSecret: tt.clientSecret,
+						BearerToken:  tt.bearerToken,
+						Scopes:       []string{"read", "write"},
+					},
+				},
+			}
+
+			result := createRequestToRemoteAuthConfig(context.Background(), req)
+
+			require.NotNil(t, result)
+			assert.Equal(t, "test-client", result.ClientID)
+			assert.Equal(t, []string{"read", "write"}, result.Scopes)
+			assert.Equal(t, tt.expectedClientSecret, result.ClientSecret)
+			assert.Equal(t, tt.expectedBearerToken, result.BearerToken)
+		})
+	}
+}
+
+func TestValidateHeaderForwardConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		config    *headerForwardConfig
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name: "valid config with plaintext headers",
+			config: &headerForwardConfig{
+				AddPlaintextHeaders: map[string]string{
+					"X-Custom-Header": "value",
+					"X-Tenant-ID":     "tenant-123",
 				},
 			},
-		}
-
-		result := createRequestToRemoteAuthConfig(context.Background(), req)
-
-		require.NotNil(t, result)
-		assert.Equal(t, "test-client", result.ClientID)
-		assert.Equal(t, []string{"read", "write"}, result.Scopes)
-		// Verify bearer token is converted to CLI format
-		assert.Equal(t, "bearer-token-secret,target=bearer_token", result.BearerToken)
-	})
-
-	t.Run("with bearer token and client secret", func(t *testing.T) {
-		t.Parallel()
-
-		clientSecretParam := &secrets.SecretParameter{
-			Name:   "oauth-client-secret",
-			Target: "oauth_secret",
-		}
-		bearerTokenParam := &secrets.SecretParameter{
-			Name:   "bearer-token-secret",
-			Target: "bearer_token",
-		}
-
-		req := &createRequest{
-			updateRequest: updateRequest{
-				URL: "https://example.com/mcp",
-				OAuthConfig: remoteOAuthConfig{
-					ClientID:     "test-client",
-					ClientSecret: clientSecretParam,
-					BearerToken:  bearerTokenParam,
-					Scopes:       []string{"read", "write"},
+			wantErr: false,
+		},
+		{
+			name: "valid config with secret headers",
+			config: &headerForwardConfig{
+				AddHeadersFromSecret: map[string]string{
+					"X-API-Key":     "api-key-secret",
+					"Authorization": "auth-secret",
 				},
 			},
-		}
-
-		result := createRequestToRemoteAuthConfig(context.Background(), req)
-
-		require.NotNil(t, result)
-		assert.Equal(t, "test-client", result.ClientID)
-		// Verify both secrets are converted to CLI format
-		assert.Equal(t, "oauth-client-secret,target=oauth_secret", result.ClientSecret)
-		assert.Equal(t, "bearer-token-secret,target=bearer_token", result.BearerToken)
-	})
-
-	t.Run("without bearer token", func(t *testing.T) {
-		t.Parallel()
-
-		req := &createRequest{
-			updateRequest: updateRequest{
-				URL: "https://example.com/mcp",
-				OAuthConfig: remoteOAuthConfig{
-					ClientID: "test-client",
-					Scopes:   []string{"read", "write"},
+			wantErr: false,
+		},
+		{
+			name:    "nil config is valid",
+			config:  nil,
+			wantErr: false,
+		},
+		{
+			name:    "empty config is valid",
+			config:  &headerForwardConfig{},
+			wantErr: false,
+		},
+		{
+			name: "restricted header Host rejected in plaintext",
+			config: &headerForwardConfig{
+				AddPlaintextHeaders: map[string]string{
+					"Host": "evil.com",
 				},
 			},
-		}
+			wantErr:   true,
+			errSubstr: "restricted",
+		},
+		{
+			name: "restricted header Host rejected in secrets",
+			config: &headerForwardConfig{
+				AddHeadersFromSecret: map[string]string{
+					"Host": "host-secret",
+				},
+			},
+			wantErr:   true,
+			errSubstr: "restricted",
+		},
+		{
+			name: "restricted header Content-Length rejected",
+			config: &headerForwardConfig{
+				AddPlaintextHeaders: map[string]string{
+					"Content-Length": "100",
+				},
+			},
+			wantErr:   true,
+			errSubstr: "restricted",
+		},
+		{
+			name: "empty header name rejected in plaintext",
+			config: &headerForwardConfig{
+				AddPlaintextHeaders: map[string]string{
+					"": "value",
+				},
+			},
+			wantErr:   true,
+			errSubstr: "empty",
+		},
+		{
+			name: "empty header name rejected in secrets",
+			config: &headerForwardConfig{
+				AddHeadersFromSecret: map[string]string{
+					"": "secret-name",
+				},
+			},
+			wantErr:   true,
+			errSubstr: "empty",
+		},
+		{
+			name: "CRLF injection in header value rejected",
+			config: &headerForwardConfig{
+				AddPlaintextHeaders: map[string]string{
+					"X-Custom": "value\r\nX-Injected: malicious",
+				},
+			},
+			wantErr:   true,
+			errSubstr: "invalid header value",
+		},
+		{
+			name: "control character in header value rejected",
+			config: &headerForwardConfig{
+				AddPlaintextHeaders: map[string]string{
+					"X-Custom": "value\x00with-null",
+				},
+			},
+			wantErr:   true,
+			errSubstr: "invalid header value",
+		},
+	}
 
-		result := createRequestToRemoteAuthConfig(context.Background(), req)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-		require.NotNil(t, result)
-		assert.Equal(t, "test-client", result.ClientID)
-		// Bearer token should be empty when not provided
-		assert.Empty(t, result.BearerToken)
-	})
+			err := validateHeaderForwardConfig(tt.config)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errSubstr)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Enable API clients to configure headers that are injected into requests to remote MCP servers. This mirrors the functionality available via CLI flags (--remote-forward-headers) and Kubernetes CRDs.

API structure:
  header_forward:
    add_plaintext_headers:     # Static headers (non-sensitive)
      X-Tenant-ID: "tenant-123"
    add_headers_from_secret:   # Headers from secrets manager
      X-API-Key: "api-key-secret"

Also simplify workloads_types_test.go:
- Convert TestValidateHeaderForwardConfig to table-driven
- Convert TestCreateRequestToRemoteAuthConfig to table-driven
- Merge HeaderForward tests into TestRunConfigToCreateRequest
- Remove redundant tests covering same code paths

Relates: #3316