### PR TITLE
Update swagger docs for registry API

### DIFF
--- a/docs/server/docs.go
+++ b/docs/server/docs.go
@@ -2830,6 +2830,26 @@ const docTemplate = `{
                             }
                         },
                         "description": "Not Found"
+                    },
+                    "502": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Bad Gateway - Registry validation failed"
+                    },
+                    "504": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Gateway Timeout - Registry unreachable"
                     }
                 },
                 "summary": "Update registry configuration",

--- a/docs/server/swagger.json
+++ b/docs/server/swagger.json
@@ -2823,6 +2823,26 @@
                             }
                         },
                         "description": "Not Found"
+                    },
+                    "502": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Bad Gateway - Registry validation failed"
+                    },
+                    "504": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Gateway Timeout - Registry unreachable"
                     }
                 },
                 "summary": "Update registry configuration",

--- a/docs/server/swagger.yaml
+++ b/docs/server/swagger.yaml
@@ -2226,6 +2226,18 @@ paths:
               schema:
                 type: string
           description: Not Found
+        "502":
+          content:
+            application/json:
+              schema:
+                type: string
+          description: Bad Gateway - Registry validation failed
+        "504":
+          content:
+            application/json:
+              schema:
+                type: string
+          description: Gateway Timeout - Registry unreachable
       summary: Update registry configuration
       tags:
       - registry

--- a/pkg/api/v1/registry.go
+++ b/pkg/api/v1/registry.go
@@ -265,6 +265,8 @@ func (rr *RegistryRoutes) getRegistry(w http.ResponseWriter, r *http.Request) {
 //		@Success		200		{object}	UpdateRegistryResponse
 //		@Failure		400		{string}	string	"Bad Request"
 //		@Failure		404		{string}	string	"Not Found"
+//		@Failure		502		{string}	string	"Bad Gateway - Registry validation failed"
+//		@Failure		504		{string}	string	"Gateway Timeout - Registry unreachable"
 //		@Router			/api/v1beta/registry/{name} [put]
 func (rr *RegistryRoutes) updateRegistry(w http.ResponseWriter, r *http.Request) {
 	name := chi.URLParam(r, "name")


### PR DESCRIPTION
These now indicate that the API can return 502 and 504 for errors involving remote registries.