### PR TITLE
Limit RBAC permissions for inline mode VirtualMCPServers

### DIFF
--- a/cmd/thv-operator/controllers/virtualmcpserver_controller_test.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_controller_test.go
@@ -369,7 +369,7 @@ func TestVirtualMCPServerEnsureRBACResources_Update(t *testing.T) {
 		Namespace: vmcp.Namespace,
 	}, role)
 	assert.NoError(t, err)
-	assert.Equal(t, vmcpRBACRules, role.Rules, "Role should be updated with correct rules")
+	assert.Equal(t, vmcpDiscoveredRBACRules, role.Rules, "Role should be updated with correct rules")
 }
 
 func TestVirtualMCPServerEnsureRBACResources_Idempotency(t *testing.T) {
@@ -422,7 +422,7 @@ func TestVirtualMCPServerEnsureRBACResources_Idempotency(t *testing.T) {
 		Namespace: vmcp.Namespace,
 	}, role)
 	assert.NoError(t, err)
-	assert.Equal(t, vmcpRBACRules, role.Rules)
+	assert.Equal(t, vmcpDiscoveredRBACRules, role.Rules)
 
 	rb := &rbacv1.RoleBinding{}
 	err = fakeClient.Get(context.Background(), types.NamespacedName{
@@ -432,21 +432,19 @@ func TestVirtualMCPServerEnsureRBACResources_Idempotency(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestVirtualMCPServerEnsureRBACResources_StaticMode(t *testing.T) {
+// TestVirtualMCPServerEnsureRBACResources_InlineMode tests that inline mode uses
+// minimal RBAC permissions (no secret/configmap access) for security
+func TestVirtualMCPServerEnsureRBACResources_InlineMode(t *testing.T) {
 	t.Parallel()
 
-	// Static mode: OutgoingAuth.Source set to "inline"
-	// RBAC resources should still be created for status reporting
 	vmcp := &mcpv1alpha1.VirtualMCPServer{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "static-vmcp",
+			Name:      "inline-mode-vmcp",
 			Namespace: "default",
 			UID:       "test-uid",
 		},
 		Spec: mcpv1alpha1.VirtualMCPServerSpec{
-			Config: vmcpconfig.Config{
-				Group: "test-group",
-			},
+			Config: vmcpconfig.Config{Group: "test-group"},
 			OutgoingAuth: &mcpv1alpha1.OutgoingAuthConfig{
 				Source: "inline",
 			},
@@ -468,34 +466,107 @@ func TestVirtualMCPServerEnsureRBACResources_StaticMode(t *testing.T) {
 		Scheme: scheme,
 	}
 
-	// Call ensureRBACResources in static mode - should create RBAC for status reporting
+	// Call ensureRBACResources in inline mode
 	err := r.ensureRBACResources(context.Background(), vmcp)
 	require.NoError(t, err)
 
+	// Verify Role was created with minimal permissions (inline mode)
 	saName := vmcpServiceAccountName(vmcp.Name)
-
-	// Verify RBAC resources were created even in static mode (for status reporting)
-	sa := &corev1.ServiceAccount{}
-	err = fakeClient.Get(context.Background(), types.NamespacedName{
-		Name:      saName,
-		Namespace: vmcp.Namespace,
-	}, sa)
-	assert.NoError(t, err, "ServiceAccount should be created in static mode for status reporting")
-
 	role := &rbacv1.Role{}
 	err = fakeClient.Get(context.Background(), types.NamespacedName{
 		Name:      saName,
 		Namespace: vmcp.Namespace,
 	}, role)
-	assert.NoError(t, err, "Role should be created in static mode for status reporting")
-	assert.Equal(t, vmcpRBACRules, role.Rules)
+	assert.NoError(t, err, "Role should be created in inline mode")
+	assert.Equal(t, vmcpInlineRBACRules, role.Rules, "Role should use minimal rules in inline mode")
 
-	rb := &rbacv1.RoleBinding{}
+	// Verify inline mode doesn't have secret/configmap access
+	for _, rule := range role.Rules {
+		for _, resource := range rule.Resources {
+			assert.NotContains(t, resource, "secrets", "Inline mode should not have secret access")
+			assert.NotContains(t, resource, "configmaps", "Inline mode should not have configmap access")
+		}
+	}
+
+	// Verify inline mode still has status update permissions
+	hasStatusPermission := false
+	for _, rule := range role.Rules {
+		for _, resource := range rule.Resources {
+			if resource == "virtualmcpservers/status" {
+				hasStatusPermission = true
+				assert.Contains(t, rule.Verbs, "update", "Should have update permission for status")
+				assert.Contains(t, rule.Verbs, "patch", "Should have patch permission for status")
+			}
+		}
+	}
+	assert.True(t, hasStatusPermission, "Inline mode should have status update permissions")
+}
+
+// TestVirtualMCPServerEnsureRBACResources_DiscoveredMode tests that discovered mode uses
+// full RBAC permissions (including secret/configmap access) for backend discovery
+func TestVirtualMCPServerEnsureRBACResources_DiscoveredMode(t *testing.T) {
+	t.Parallel()
+
+	vmcp := &mcpv1alpha1.VirtualMCPServer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "discovered-mode-vmcp",
+			Namespace: "default",
+			UID:       "test-uid",
+		},
+		Spec: mcpv1alpha1.VirtualMCPServerSpec{
+			Config: vmcpconfig.Config{Group: "test-group"},
+			OutgoingAuth: &mcpv1alpha1.OutgoingAuthConfig{
+				Source: "discovered",
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	_ = mcpv1alpha1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+	_ = rbacv1.AddToScheme(scheme)
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(vmcp).
+		Build()
+
+	r := &VirtualMCPServerReconciler{
+		Client: fakeClient,
+		Scheme: scheme,
+	}
+
+	// Call ensureRBACResources in discovered mode
+	err := r.ensureRBACResources(context.Background(), vmcp)
+	require.NoError(t, err)
+
+	// Verify Role was created with full permissions (discovered mode)
+	saName := vmcpServiceAccountName(vmcp.Name)
+	role := &rbacv1.Role{}
 	err = fakeClient.Get(context.Background(), types.NamespacedName{
 		Name:      saName,
 		Namespace: vmcp.Namespace,
-	}, rb)
-	assert.NoError(t, err, "RoleBinding should be created in static mode for status reporting")
+	}, role)
+	assert.NoError(t, err, "Role should be created in discovered mode")
+	assert.Equal(t, vmcpDiscoveredRBACRules, role.Rules, "Role should use full rules in discovered mode")
+
+	// Verify discovered mode has secret/configmap access
+	hasSecretAccess := false
+	hasConfigMapAccess := false
+	for _, rule := range role.Rules {
+		for _, resource := range rule.Resources {
+			if resource == "secrets" {
+				hasSecretAccess = true
+				assert.Contains(t, rule.Verbs, "get", "Should have get permission for secrets")
+			}
+			if resource == "configmaps" {
+				hasConfigMapAccess = true
+				assert.Contains(t, rule.Verbs, "get", "Should have get permission for configmaps")
+			}
+		}
+	}
+	assert.True(t, hasSecretAccess, "Discovered mode should have secret access")
+	assert.True(t, hasConfigMapAccess, "Discovered mode should have configmap access")
 }
 
 // TestVirtualMCPServerEnsureRBACResources_CustomServiceAccount tests that RBAC resources

--- a/cmd/thv-operator/controllers/virtualmcpserver_deployment.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_deployment.go
@@ -52,11 +52,29 @@ const (
 	vmcpReadinessFailures     = int32(3)  // consecutive failures before removing from service
 )
 
-// RBAC rules for VirtualMCPServer service account
+// RBAC rules for VirtualMCPServer service account in inline mode
+// These minimal rules only allow vMCP to:
+// - Read its own VirtualMCPServer spec
+// - Update VirtualMCPServer status (via K8sReporter)
+// No access to secrets or other Kubernetes resources since config is provided inline
+var vmcpInlineRBACRules = []rbacv1.PolicyRule{
+	{
+		APIGroups: []string{"toolhive.stacklok.dev"},
+		Resources: []string{"virtualmcpservers"},
+		Verbs:     []string{"get"},
+	},
+	{
+		APIGroups: []string{"toolhive.stacklok.dev"},
+		Resources: []string{"virtualmcpservers/status"},
+		Verbs:     []string{"update", "patch"},
+	},
+}
+
+// RBAC rules for VirtualMCPServer service account in discovered mode
 // These rules allow vMCP to:
-// - Discover backends and configurations at runtime (in discovered mode)
-// - Update VirtualMCPServer status (in all modes via K8sReporter)
-var vmcpRBACRules = []rbacv1.PolicyRule{
+// - Discover backends and configurations at runtime (read secrets, configmaps, and MCP resources)
+// - Update VirtualMCPServer status (via K8sReporter)
+var vmcpDiscoveredRBACRules = []rbacv1.PolicyRule{
 	{
 		APIGroups: []string{""},
 		Resources: []string{"configmaps", "secrets"},


### PR DESCRIPTION
In inline mode, VirtualMCPServer pods receive all backend configuration through the VirtualMCPServer spec and don't need to discover backends from Kubernetes resources. However, they were still granted full RBAC permissions including access to secrets and configmaps.

Since vMCP is exposed to the outside world via HTTP, granting unnecessary Kubernetes API permissions increases the security risk. This change implements conditional RBAC based on the outgoing auth source mode:

  - Inline mode: Minimal permissions (read own spec + update status)
  - Discovered mode: Full permissions (read secrets, configmaps, MCP resources)

The implementation creates two separate RBAC rule sets and selects the appropriate one based on spec.outgoingAuth.source. Existing resources default to discovered mode for backward compatibility.

Added comprehensive tests to verify correct permissions are granted for each mode, including validation that inline mode has no secret or configmap access while still maintaining status update capabilities.

Also removed orphaned comment and nolint directive for deleted discoverBackends function.

Related-to: #3149