### PR TITLE
Add generic CEL expression engine package (Mediator strikes back!)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/go-jose/go-jose/v4 v4.1.3
 	github.com/go-logr/zapr v1.3.0
 	github.com/gofrs/flock v0.13.0
+	github.com/google/cel-go v0.27.0
 	github.com/google/go-cmp v0.7.0
 	github.com/google/go-containerregistry v0.20.7
 	github.com/google/uuid v1.6.0
@@ -54,7 +55,6 @@ require (
 	golang.ngrok.com/ngrok/v2 v2.1.1
 	golang.org/x/exp/jsonrpc2 v0.0.0-20260112195511-716be5621a96
 	golang.org/x/mod v0.32.0
-	golang.org/x/net v0.49.0
 	golang.org/x/oauth2 v0.34.0
 	golang.org/x/sync v0.19.0
 	golang.org/x/term v0.39.0
@@ -69,9 +69,11 @@ require (
 
 require (
 	al.essio.dev/pkg/shellescape v1.6.0 // indirect
+	cel.dev/expr v0.25.1 // indirect
 	github.com/KyleBanks/depth v1.2.1 // indirect
 	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/ProtonMail/go-crypto v1.1.6 // indirect
+	github.com/antlr4-go/antlr/v4 v4.13.1 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
@@ -239,6 +241,7 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.ngrok.com/muxado/v2 v2.0.1 // indirect
 	golang.org/x/exp/event v0.0.0-20251219203646-944ab1f22d93 // indirect
+	golang.org/x/net v0.49.0 // indirect
 	golang.org/x/text v0.33.0 // indirect
 	golang.org/x/tools v0.41.0 // indirect
 	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 al.essio.dev/pkg/shellescape v1.6.0 h1:NxFcEqzFSEVCGN2yq7Huv/9hyCEGVa/TncnOOBBeXHA=
 al.essio.dev/pkg/shellescape v1.6.0/go.mod h1:6sIqp7X2P6mThCQ7twERpZTuigpr6KbZWtls1U8I890=
+cel.dev/expr v0.25.1 h1:1KrZg61W6TWSxuNZ37Xy49ps13NUovb66QLprthtwi4=
+cel.dev/expr v0.25.1/go.mod h1:hrXvqGP6G6gyx8UAHSHJ5RGk//1Oj5nXQ2NI02Nrsg4=
 cloud.google.com/go v0.121.6 h1:waZiuajrI28iAf40cWgycWNgaXPO06dupuS+sgibK6c=
 cloud.google.com/go v0.121.6/go.mod h1:coChdst4Ea5vUpiALcYKXEpR1S9ZgXbhEzzMcMR66vI=
 cloud.google.com/go/auth v0.18.0 h1:wnqy5hrv7p3k7cShwAU/Br3nzod7fxoqG+k0VZ+/Pk0=
@@ -51,6 +53,8 @@ github.com/adrg/xdg v0.5.3 h1:xRnxJXne7+oWDatRhR1JLnvuccuIeCoBu2rtuLqQB78=
 github.com/adrg/xdg v0.5.3/go.mod h1:nlTsY+NNiCBGCK2tpm09vRqfVzrc2fLmXGpBLF0zlTQ=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
+github.com/antlr4-go/antlr/v4 v4.13.1 h1:SqQKkuVZ+zWkMMNkjy5FZe5mr5WURWnlpmOuzYWrPrQ=
+github.com/antlr4-go/antlr/v4 v4.13.1/go.mod h1:GKmUxMtwp6ZgGwZSva4eWPC5mS6vUAmOABFgjdkM7Nw=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=
@@ -343,6 +347,8 @@ github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/google/btree v1.1.3 h1:CVpQJjYgC4VbzxeGVHfvZrv1ctoYCAI8vbl07Fcxlyg=
 github.com/google/btree v1.1.3/go.mod h1:qOPhT0dTNdNzV6Z/lhRX0YXUafgPLFUh+gZMl761Gm4=
+github.com/google/cel-go v0.27.0 h1:e7ih85+4qVrBuqQWTW4FKSqZYokVuc3HnhH5keboFTo=
+github.com/google/cel-go v0.27.0/go.mod h1:tTJ11FWqnhw5KKpnWpvW9CJC3Y9GK4EIS0WXnBbebzw=
 github.com/google/certificate-transparency-go v1.3.2 h1:9ahSNZF2o7SYMaKaXhAumVEzXB2QaayzII9C8rv7v+A=
 github.com/google/certificate-transparency-go v1.3.2/go.mod h1:H5FpMUaGa5Ab2+KCYsxg6sELw3Flkl7pGZzWdBoYLXs=
 github.com/google/gnostic-models v0.7.0 h1:qwTtogB15McXDaNqTZdzPJRHvaVJlAl+HVQnLmJEJxo=

--- a/pkg/cel/engine.go
+++ b/pkg/cel/engine.go
@@ -1,0 +1,204 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package cel provides a generic CEL expression engine for evaluating
+// expressions against arbitrary data contexts.
+package cel
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/google/cel-go/cel"
+)
+
+const (
+	// DefaultMaxExpressionLength is the maximum allowed length for a CEL expression.
+	// This limit prevents DoS attacks via excessively long expressions.
+	DefaultMaxExpressionLength = 10000
+
+	// DefaultCostLimit is the default runtime cost limit for CEL program evaluation.
+	// This prevents DoS attacks via expensive operations in expressions.
+	DefaultCostLimit = 1000000
+)
+
+// Engine provides CEL expression compilation and evaluation capabilities.
+// It is safe for concurrent use from multiple goroutines.
+type Engine struct {
+	envCache            *envCache
+	factory             envFactory
+	maxExpressionLength int
+	costLimit           uint64
+}
+
+// envFactory is a function that creates a CEL environment.
+type envFactory func() (*cel.Env, error)
+
+// envCache holds a lazily-initialized CEL environment.
+type envCache struct {
+	once sync.Once
+	env  *cel.Env
+	err  error
+}
+
+// CompiledExpression represents a pre-compiled CEL program ready for evaluation.
+type CompiledExpression struct {
+	source  string
+	program cel.Program
+}
+
+// Source returns the original expression source string.
+func (ce *CompiledExpression) Source() string {
+	return ce.source
+}
+
+// NewEngine creates a new CEL engine with the specified variable declarations.
+// The options are passed to cel.NewEnv to configure the CEL environment.
+//
+// The engine is created with default limits for expression length and evaluation cost
+// to prevent denial-of-service attacks. Use WithMaxExpressionLength and WithCostLimit
+// to customize these limits if needed.
+//
+// Example usage:
+//
+//	engine := cel.NewEngine(
+//	    cel.Variable("claims", cel.MapType(cel.StringType, cel.DynType)),
+//	)
+func NewEngine(options ...cel.EnvOption) *Engine {
+	return &Engine{
+		envCache:            &envCache{},
+		maxExpressionLength: DefaultMaxExpressionLength,
+		costLimit:           DefaultCostLimit,
+		factory: func() (*cel.Env, error) {
+			return cel.NewEnv(options...)
+		},
+	}
+}
+
+// WithMaxExpressionLength sets the maximum allowed length for CEL expressions.
+// Expressions exceeding this length will be rejected during compilation.
+func (e *Engine) WithMaxExpressionLength(maxLen int) *Engine {
+	e.maxExpressionLength = maxLen
+	return e
+}
+
+// WithCostLimit sets the runtime cost limit for CEL program evaluation.
+// Programs that exceed this cost during evaluation will return an error.
+func (e *Engine) WithCostLimit(limit uint64) *Engine {
+	e.costLimit = limit
+	return e
+}
+
+// getEnv returns the CEL environment, creating it lazily on first access.
+func (e *Engine) getEnv() (*cel.Env, error) {
+	e.envCache.once.Do(func() {
+		e.envCache.env, e.envCache.err = e.factory()
+	})
+	return e.envCache.env, e.envCache.err
+}
+
+// Compile parses and compiles a CEL expression, returning a CompiledExpression
+// that can be evaluated multiple times against different contexts.
+//
+// Returns an error if the expression exceeds the maximum length, a ParseError
+// if the expression has syntax errors, or a CheckError if the expression has
+// type checking errors.
+func (e *Engine) Compile(expr string) (*CompiledExpression, error) {
+	// Check expression length to prevent DoS via excessively long expressions
+	if len(expr) > e.maxExpressionLength {
+		return nil, fmt.Errorf("%w: expression length %d exceeds maximum of %d",
+			ErrExpressionCheck, len(expr), e.maxExpressionLength)
+	}
+
+	env, err := e.getEnv()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get CEL environment: %w", err)
+	}
+
+	// Parse the expression
+	parsedAst, issues := env.Parse(expr)
+	if issues.Err() != nil {
+		return nil, newParseError(expr, issues)
+	}
+
+	// Type check the expression
+	checkedAst, issues := env.Check(parsedAst)
+	if issues.Err() != nil {
+		return nil, newCheckError(expr, issues)
+	}
+
+	// Compile to a program with cost limit to prevent DoS via expensive operations
+	program, err := env.Program(checkedAst, cel.CostLimit(e.costLimit))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create CEL program for %q: %w", expr, err)
+	}
+
+	return &CompiledExpression{
+		source:  expr,
+		program: program,
+	}, nil
+}
+
+// Check verifies that a CEL expression is syntactically and semantically valid
+// without creating a compiled program. This is useful for configuration validation.
+//
+// Returns an error if the expression exceeds the maximum length, a ParseError
+// if the expression has syntax errors, or a CheckError if the expression has
+// type checking errors.
+func (e *Engine) Check(expr string) error {
+	// Check expression length to prevent DoS via excessively long expressions
+	if len(expr) > e.maxExpressionLength {
+		return fmt.Errorf("%w: expression length %d exceeds maximum of %d",
+			ErrExpressionCheck, len(expr), e.maxExpressionLength)
+	}
+
+	env, err := e.getEnv()
+	if err != nil {
+		return fmt.Errorf("failed to get CEL environment: %w", err)
+	}
+
+	// Parse the expression
+	parsedAst, issues := env.Parse(expr)
+	if issues.Err() != nil {
+		return newParseError(expr, issues)
+	}
+
+	// Type check the expression
+	_, issues = env.Check(parsedAst)
+	if issues.Err() != nil {
+		return newCheckError(expr, issues)
+	}
+
+	return nil
+}
+
+// Evaluate executes the compiled expression against the provided context
+// and returns the result. The context should contain values for all variables
+// declared when creating the Engine.
+//
+// Example:
+//
+//	ctx := map[string]any{"myVar": someValue}
+func (ce *CompiledExpression) Evaluate(ctx map[string]any) (any, error) {
+	out, _, err := ce.program.Eval(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %s", ErrEvaluation, err)
+	}
+	return out.Value(), nil
+}
+
+// EvaluateBool executes the compiled expression and returns the result as a bool.
+// Returns an error if the expression does not evaluate to a boolean.
+func (ce *CompiledExpression) EvaluateBool(ctx map[string]any) (bool, error) {
+	result, err := ce.Evaluate(ctx)
+	if err != nil {
+		return false, err
+	}
+
+	boolResult, ok := result.(bool)
+	if !ok {
+		return false, fmt.Errorf("%w: expected bool, got %T", ErrInvalidResult, result)
+	}
+
+	return boolResult, nil
+}

--- a/pkg/cel/engine_test.go
+++ b/pkg/cel/engine_test.go
@@ -1,0 +1,464 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package cel_test
+
+import (
+	"errors"
+	"testing"
+
+	celgo "github.com/google/cel-go/cel"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stacklok/toolhive/pkg/cel"
+)
+
+// newTestClaimsEngine creates a CEL engine for testing claims-based expressions.
+// This demonstrates how consumers should configure the generic CEL engine.
+func newTestClaimsEngine() *cel.Engine {
+	return cel.NewEngine(
+		celgo.Variable("claims", celgo.MapType(celgo.StringType, celgo.DynType)),
+	)
+}
+
+func TestNewEngine(t *testing.T) {
+	t.Parallel()
+
+	engine := newTestClaimsEngine()
+	require.NotNil(t, engine)
+
+	// Should be able to compile a valid expression
+	expr, err := engine.Compile(`claims["sub"] == "user123"`)
+	require.NoError(t, err)
+	require.NotNil(t, expr)
+}
+
+func TestEngine_Compile_ValidExpressions(t *testing.T) {
+	t.Parallel()
+
+	engine := newTestClaimsEngine()
+
+	tests := []struct {
+		name string
+		expr string
+	}{
+		{
+			name: "string equality",
+			expr: `claims["sub"] == "user123"`,
+		},
+		{
+			name: "membership in array",
+			expr: `"admins" in claims["groups"]`,
+		},
+		{
+			name: "key exists in map",
+			expr: `"act" in claims`,
+		},
+		{
+			name: "nested access",
+			expr: `claims["act"]["sub"] == "agent123"`,
+		},
+		{
+			name: "boolean and",
+			expr: `"admins" in claims["groups"] && !("act" in claims)`,
+		},
+		{
+			name: "boolean or",
+			expr: `claims["sub"] == "user1" || claims["sub"] == "user2"`,
+		},
+		{
+			name: "exists function",
+			expr: `claims["groups"].exists(g, g in ["admin", "sre"])`,
+		},
+		{
+			name: "string starts with",
+			expr: `claims["sub"].startsWith("user-")`,
+		},
+		{
+			name: "ternary expression",
+			expr: `"act" in claims ? "delegated" : "direct"`,
+		},
+		{
+			name: "true literal",
+			expr: `true`,
+		},
+		{
+			name: "false literal",
+			expr: `false`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			expr, err := engine.Compile(tt.expr)
+			require.NoError(t, err)
+			require.NotNil(t, expr)
+			assert.Equal(t, tt.expr, expr.Source())
+		})
+	}
+}
+
+func TestEngine_Compile_ParseErrors(t *testing.T) {
+	t.Parallel()
+
+	engine := newTestClaimsEngine()
+
+	tests := []struct {
+		name string
+		expr string
+	}{
+		{
+			name: "unclosed bracket",
+			expr: `claims["sub"`,
+		},
+		{
+			name: "invalid operator",
+			expr: `claims["sub"] === "user123"`,
+		},
+		{
+			name: "unclosed string",
+			expr: `claims["sub] == "user123"`,
+		},
+		{
+			name: "missing operand",
+			expr: `claims["sub"] ==`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			expr, err := engine.Compile(tt.expr)
+			require.Error(t, err)
+			require.Nil(t, expr)
+
+			var parseErr *cel.ParseError
+			assert.True(t, errors.As(err, &parseErr), "expected ParseError, got %T", err)
+		})
+	}
+}
+
+func TestEngine_Compile_CheckErrors(t *testing.T) {
+	t.Parallel()
+
+	engine := newTestClaimsEngine()
+
+	tests := []struct {
+		name string
+		expr string
+	}{
+		{
+			name: "undefined variable",
+			expr: `undefined_var == "test"`,
+		},
+		{
+			name: "undefined function",
+			expr: `undefined_func(claims)`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			expr, err := engine.Compile(tt.expr)
+			require.Error(t, err)
+			require.Nil(t, expr)
+
+			var checkErr *cel.CheckError
+			assert.True(t, errors.As(err, &checkErr), "expected CheckError, got %T", err)
+		})
+	}
+}
+
+func TestEngine_Check(t *testing.T) {
+	t.Parallel()
+
+	engine := newTestClaimsEngine()
+
+	t.Run("valid expression", func(t *testing.T) {
+		t.Parallel()
+		err := engine.Check(`claims["sub"] == "user123"`)
+		require.NoError(t, err)
+	})
+
+	t.Run("invalid expression", func(t *testing.T) {
+		t.Parallel()
+		err := engine.Check(`claims["sub"`)
+		require.Error(t, err)
+
+		var parseErr *cel.ParseError
+		assert.True(t, errors.As(err, &parseErr))
+	})
+}
+
+func TestCompiledExpression_Evaluate(t *testing.T) {
+	t.Parallel()
+
+	engine := newTestClaimsEngine()
+
+	tests := []struct {
+		name     string
+		expr     string
+		claims   map[string]any
+		expected any
+	}{
+		{
+			name: "string equality true",
+			expr: `claims["sub"] == "user123"`,
+			claims: map[string]any{
+				"sub": "user123",
+			},
+			expected: true,
+		},
+		{
+			name: "string equality false",
+			expr: `claims["sub"] == "user123"`,
+			claims: map[string]any{
+				"sub": "other-user",
+			},
+			expected: false,
+		},
+		{
+			name: "membership in array true",
+			expr: `"admins" in claims["groups"]`,
+			claims: map[string]any{
+				"groups": []any{"users", "admins", "developers"},
+			},
+			expected: true,
+		},
+		{
+			name: "membership in array false",
+			expr: `"admins" in claims["groups"]`,
+			claims: map[string]any{
+				"groups": []any{"users", "developers"},
+			},
+			expected: false,
+		},
+		{
+			name: "key exists in map true",
+			expr: `"act" in claims`,
+			claims: map[string]any{
+				"sub": "user123",
+				"act": map[string]any{
+					"sub": "agent456",
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "key missing from map",
+			expr: `"act" in claims`,
+			claims: map[string]any{
+				"sub": "user123",
+			},
+			expected: false,
+		},
+		{
+			name: "complex boolean expression",
+			expr: `"admins" in claims["groups"] && !("act" in claims)`,
+			claims: map[string]any{
+				"sub":    "user123",
+				"groups": []any{"admins"},
+			},
+			expected: true,
+		},
+		{
+			name: "complex boolean with agent delegation",
+			expr: `"admins" in claims["groups"] && !("act" in claims)`,
+			claims: map[string]any{
+				"sub":    "user123",
+				"groups": []any{"admins"},
+				"act": map[string]any{
+					"sub": "agent456",
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "ternary expression",
+			expr: `"act" in claims ? "delegated" : "direct"`,
+			claims: map[string]any{
+				"sub": "user123",
+				"act": map[string]any{
+					"sub": "agent456",
+				},
+			},
+			expected: "delegated",
+		},
+		{
+			name: "ternary expression no delegation",
+			expr: `"act" in claims ? "delegated" : "direct"`,
+			claims: map[string]any{
+				"sub": "user123",
+			},
+			expected: "direct",
+		},
+		{
+			name:     "true literal",
+			expr:     `true`,
+			claims:   map[string]any{},
+			expected: true,
+		},
+		{
+			name:     "false literal",
+			expr:     `false`,
+			claims:   map[string]any{},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			expr, err := engine.Compile(tt.expr)
+			require.NoError(t, err)
+
+			ctx := map[string]any{"claims": tt.claims}
+			result, err := expr.Evaluate(ctx)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestCompiledExpression_EvaluateBool(t *testing.T) {
+	t.Parallel()
+
+	engine := newTestClaimsEngine()
+
+	t.Run("returns true", func(t *testing.T) {
+		t.Parallel()
+
+		expr, err := engine.Compile(`claims["sub"] == "user123"`)
+		require.NoError(t, err)
+
+		ctx := map[string]any{"claims": map[string]any{"sub": "user123"}}
+		result, err := expr.EvaluateBool(ctx)
+		require.NoError(t, err)
+		assert.True(t, result)
+	})
+
+	t.Run("returns false", func(t *testing.T) {
+		t.Parallel()
+
+		expr, err := engine.Compile(`claims["sub"] == "user123"`)
+		require.NoError(t, err)
+
+		ctx := map[string]any{"claims": map[string]any{"sub": "other"}}
+		result, err := expr.EvaluateBool(ctx)
+		require.NoError(t, err)
+		assert.False(t, result)
+	})
+
+	t.Run("error on non-bool result", func(t *testing.T) {
+		t.Parallel()
+
+		expr, err := engine.Compile(`claims["sub"]`)
+		require.NoError(t, err)
+
+		ctx := map[string]any{"claims": map[string]any{"sub": "user123"}}
+		_, err = expr.EvaluateBool(ctx)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, cel.ErrInvalidResult)
+	})
+
+	t.Run("evaluation error wraps ErrEvaluation", func(t *testing.T) {
+		t.Parallel()
+
+		// Compile an expression that accesses a nested key on a non-map value
+		expr, err := engine.Compile(`claims["missing"]["nested"]`)
+		require.NoError(t, err)
+
+		// Provide an empty claims map so the nested access fails at runtime
+		ctx := map[string]any{"claims": map[string]any{}}
+		_, err = expr.EvaluateBool(ctx)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, cel.ErrEvaluation)
+	})
+}
+
+func TestParseError_Details(t *testing.T) {
+	t.Parallel()
+
+	engine := newTestClaimsEngine()
+
+	_, err := engine.Compile(`claims["sub"`)
+	require.Error(t, err)
+
+	var parseErr *cel.ParseError
+	require.True(t, errors.As(err, &parseErr))
+
+	// Should contain source and error details
+	assert.Contains(t, parseErr.Error(), "parse")
+	assert.Contains(t, parseErr.Source, `claims["sub"`)
+	assert.NotEmpty(t, parseErr.Errors)
+}
+
+func TestCheckError_Details(t *testing.T) {
+	t.Parallel()
+
+	engine := newTestClaimsEngine()
+
+	_, err := engine.Compile(`undefined_var == "test"`)
+	require.Error(t, err)
+
+	var checkErr *cel.CheckError
+	require.True(t, errors.As(err, &checkErr))
+
+	// Should contain source and error details
+	assert.Contains(t, checkErr.Error(), "check")
+	assert.Contains(t, checkErr.Source, "undefined_var")
+	assert.NotEmpty(t, checkErr.Errors)
+}
+
+func TestEngine_Concurrency(t *testing.T) {
+	t.Parallel()
+
+	engine := newTestClaimsEngine()
+
+	// Compile the expression once
+	expr, err := engine.Compile(`"admins" in claims["groups"]`)
+	require.NoError(t, err)
+
+	// Evaluate concurrently
+	const numGoroutines = 100
+	results := make(chan bool, numGoroutines)
+	errs := make(chan error, numGoroutines)
+
+	for i := 0; i < numGoroutines; i++ {
+		go func(i int) {
+			groups := []any{"users"}
+			if i%2 == 0 {
+				groups = append(groups, "admins")
+			}
+
+			ctx := map[string]any{
+				"claims": map[string]any{
+					"groups": groups,
+				},
+			}
+
+			result, err := expr.EvaluateBool(ctx)
+			if err != nil {
+				errs <- err
+				return
+			}
+			results <- result
+		}(i)
+	}
+
+	// Collect results
+	for i := 0; i < numGoroutines; i++ {
+		select {
+		case err := <-errs:
+			t.Fatalf("unexpected error: %v", err)
+		case result := <-results:
+			// Even indices should have "admins" and return true
+			// We can't verify specific results without tracking indices
+			_ = result
+		}
+	}
+}

--- a/pkg/cel/errors.go
+++ b/pkg/cel/errors.go
@@ -1,0 +1,121 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package cel
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/google/cel-go/cel"
+)
+
+// Sentinel errors for CEL operations.
+var (
+	// ErrExpressionCheck is returned when a CEL expression fails syntax or type checking.
+	ErrExpressionCheck = errors.New("CEL expression check failed")
+
+	// ErrEvaluation is returned when CEL expression evaluation fails.
+	ErrEvaluation = errors.New("CEL expression evaluation failed")
+
+	// ErrInvalidResult is returned when the CEL expression returns an unexpected type.
+	ErrInvalidResult = errors.New("CEL expression returned invalid result type")
+)
+
+// ErrKind is a string identifying the type of CEL error.
+type ErrKind string
+
+const (
+	// ErrKindParse indicates a syntax error in the CEL expression.
+	ErrKindParse ErrKind = "parse"
+	// ErrKindCheck indicates a type checking error in the CEL expression.
+	ErrKindCheck ErrKind = "check"
+)
+
+// ErrInstance represents one occurrence of an error in a CEL expression.
+type ErrInstance struct {
+	Line int    `json:"line,omitempty"`
+	Col  int    `json:"col,omitempty"`
+	Msg  string `json:"msg,omitempty"`
+}
+
+// ErrDetails contains structured error information for CEL expressions.
+type ErrDetails struct {
+	Errors []ErrInstance `json:"errors,omitempty"`
+	Source string        `json:"source,omitempty"`
+}
+
+// AsJSON returns the ErrDetails as a JSON string.
+func (ed *ErrDetails) AsJSON() string {
+	edBytes, err := json.Marshal(ed)
+	if err != nil {
+		return fmt.Sprintf(`{"error": "failed to marshal JSON: %s"}`, err)
+	}
+	return string(edBytes)
+}
+
+// errDetailsFromCelIssues converts CEL issues to ErrDetails.
+func errDetailsFromCelIssues(source string, issues *cel.Issues) ErrDetails {
+	var ed ErrDetails
+
+	ed.Source = source
+	ed.Errors = make([]ErrInstance, 0, len(issues.Errors()))
+	for _, err := range issues.Errors() {
+		ed.Errors = append(ed.Errors, ErrInstance{
+			Line: err.Location.Line(),
+			Col:  err.Location.Column(),
+			Msg:  err.Message,
+		})
+	}
+
+	return ed
+}
+
+// ParseError represents a CEL syntax error with location information.
+type ParseError struct {
+	ErrDetails
+	original error
+}
+
+// Error implements the error interface for ParseError.
+func (pe *ParseError) Error() string {
+	return fmt.Sprintf("CEL %s error in expression %q: %s", ErrKindParse, pe.Source, pe.original)
+}
+
+// Unwrap returns the underlying error.
+func (pe *ParseError) Unwrap() error {
+	return pe.original
+}
+
+// CheckError represents a CEL type checking error with location information.
+type CheckError struct {
+	ErrDetails
+	original error
+}
+
+// Error implements the error interface for CheckError.
+func (ce *CheckError) Error() string {
+	return fmt.Sprintf("CEL %s error in expression %q: %s", ErrKindCheck, ce.Source, ce.original)
+}
+
+// Unwrap returns the underlying error.
+func (ce *CheckError) Unwrap() error {
+	return ce.original
+}
+
+// newParseError creates a ParseError from CEL issues.
+func newParseError(source string, issues *cel.Issues) error {
+	return &ParseError{
+		ErrDetails: errDetailsFromCelIssues(source, issues),
+		original:   fmt.Errorf("%w: %w", ErrExpressionCheck, issues.Err()),
+	}
+}
+
+// newCheckError creates a CheckError from CEL issues.
+func newCheckError(source string, issues *cel.Issues) error {
+	return &CheckError{
+		ErrDetails: errDetailsFromCelIssues(source, issues),
+		original:   fmt.Errorf("%w: %w", ErrExpressionCheck, issues.Err()),
+	}
+}


### PR DESCRIPTION
Most of this PR is adapted code from https://github.com/mindersec/minder/blob/main/pkg/engine/selectors/selectors.go (which I also wrote so don't hold back during the review you won't be screaming at yourself)

Introduce a reusable CEL (Common Expression Language) engine in pkg/cel/ for compiling and evaluating expressions against arbitrary data contexts. The engine provides lazy-initialized, thread-safe environment caching, expression compilation with structured parse and type-check error reporting, boolean and generic value evaluation helpers, and built-in safeguards against denial-of-service via configurable expression length and runtime cost limits.

This is the first PR in the AWS STS integration series. The CEL engine will be used by the role mapper component to evaluate OIDC token claims against configurable expressions, enabling
flexible mapping from identity claims to AWS STS roles without hardcoding authorization logic.

Fixes: #3566