### PR TITLE
Fix proxy hang on kubectl attach EOF

### DIFF
--- a/pkg/container/kubernetes/client_test.go
+++ b/pkg/container/kubernetes/client_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -859,6 +860,25 @@ func TestAttachToWorkloadNoPodFound(t *testing.T) {
 	// Should return error immediately (no pods found)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no pods found")
+}
+
+// TestAttachRetryConstants verifies the retry configuration constants are set
+// to reasonable values for handling pod restarts.
+func TestAttachRetryConstants(t *testing.T) {
+	t.Parallel()
+
+	// The retry timeout should be long enough to accommodate pod restarts
+	// (including image pulls) but not so long that failures take forever to detect
+	assert.Equal(t, 90*time.Second, attachRetryTimeout,
+		"attachRetryTimeout should be 90 seconds to accommodate pod restarts")
+
+	// Initial retry interval should be short for quick recovery from transient errors
+	assert.Equal(t, 1*time.Second, attachInitialRetryInterval,
+		"attachInitialRetryInterval should be 1 second for quick recovery")
+
+	// Max retry interval caps the backoff to prevent excessive delays
+	assert.Equal(t, 15*time.Second, attachMaxRetryInterval,
+		"attachMaxRetryInterval should be 15 seconds to cap backoff")
 }
 
 // TestApplyPodTemplatePatchAnnotations tests that annotations are correctly applied


### PR DESCRIPTION
## Summary

Fixes #3583 - Proxy does not exit on EOF from kubectl attach SPDY connection.

PR #3183 added exit-on-failure logic for retry exhaustion, but EOF errors from `k8s.io/client-go` SPDY code bypassed this logic, leaving the proxy in a zombie state where HTTP health checks pass but MCP communication fails.

## Changes

1. **Fresh SPDY executor per retry** - The executor was created once and reused across retries. When the SPDY connection fails with EOF, the executor enters a corrupted state. Now each retry creates a fresh executor.

2. **Pipe closure on goroutine exit** - Added deferred close of stdout/stdin pipes when the attach goroutine exits, ensuring the transport layer sees EOF and can trigger re-attachment or exit.

## Validation

Deployed to production cluster and verified:
- Proxy recovered from zombie state (104 consecutive failures → healthy)
- MCP tool calls successful after fix
- No unnecessary restarts during idle periods
- Clean attachment in logs

## Related

- Issue #3179 - Original bug report
- PR #3183 - Partial fix (exit on retry exhaustion)