### PR TITLE
Ensure API E2E tests clean up after themselves

### DIFF
--- a/docs/server/docs.go
+++ b/docs/server/docs.go
@@ -3765,7 +3765,7 @@ const docTemplate = `{
         },
         "/api/v1beta/workloads/delete": {
             "post": {
-                "description": "Delete multiple workloads by name or by group",
+                "description": "Delete multiple workloads by name or by group asynchronously.\nReturns 202 Accepted immediately. Deletion happens in the background.",
                 "requestBody": {
                     "content": {
                         "application/json": {
@@ -3795,7 +3795,7 @@ const docTemplate = `{
                                 }
                             }
                         },
-                        "description": "Accepted"
+                        "description": "Accepted - deletion started"
                     },
                     "400": {
                         "content": {
@@ -3918,7 +3918,7 @@ const docTemplate = `{
         },
         "/api/v1beta/workloads/{name}": {
             "delete": {
-                "description": "Delete a workload",
+                "description": "Delete a workload asynchronously. Returns 202 Accepted immediately.\nThe deletion happens in the background. Poll the workload list to confirm deletion.",
                 "parameters": [
                     {
                         "description": "Workload name",
@@ -3939,7 +3939,7 @@ const docTemplate = `{
                                 }
                             }
                         },
-                        "description": "Accepted"
+                        "description": "Accepted - deletion started"
                     },
                     "400": {
                         "content": {

--- a/docs/server/swagger.json
+++ b/docs/server/swagger.json
@@ -3758,7 +3758,7 @@
         },
         "/api/v1beta/workloads/delete": {
             "post": {
-                "description": "Delete multiple workloads by name or by group",
+                "description": "Delete multiple workloads by name or by group asynchronously.\nReturns 202 Accepted immediately. Deletion happens in the background.",
                 "requestBody": {
                     "content": {
                         "application/json": {
@@ -3788,7 +3788,7 @@
                                 }
                             }
                         },
-                        "description": "Accepted"
+                        "description": "Accepted - deletion started"
                     },
                     "400": {
                         "content": {
@@ -3911,7 +3911,7 @@
         },
         "/api/v1beta/workloads/{name}": {
             "delete": {
-                "description": "Delete a workload",
+                "description": "Delete a workload asynchronously. Returns 202 Accepted immediately.\nThe deletion happens in the background. Poll the workload list to confirm deletion.",
                 "parameters": [
                     {
                         "description": "Workload name",
@@ -3932,7 +3932,7 @@
                                 }
                             }
                         },
-                        "description": "Accepted"
+                        "description": "Accepted - deletion started"
                     },
                     "400": {
                         "content": {

--- a/docs/server/swagger.yaml
+++ b/docs/server/swagger.yaml
@@ -2919,7 +2919,9 @@ paths:
       - workloads
   /api/v1beta/workloads/{name}:
     delete:
-      description: Delete a workload
+      description: |-
+        Delete a workload asynchronously. Returns 202 Accepted immediately.
+        The deletion happens in the background. Poll the workload list to confirm deletion.
       parameters:
       - description: Workload name
         in: path
@@ -2933,7 +2935,7 @@ paths:
             application/json:
               schema:
                 type: string
-          description: Accepted
+          description: Accepted - deletion started
         "400":
           content:
             application/json:
@@ -3201,7 +3203,9 @@ paths:
       - workloads
   /api/v1beta/workloads/delete:
     post:
-      description: Delete multiple workloads by name or by group
+      description: |-
+        Delete multiple workloads by name or by group asynchronously.
+        Returns 202 Accepted immediately. Deletion happens in the background.
       requestBody:
         content:
           application/json:
@@ -3219,7 +3223,7 @@ paths:
             application/json:
               schema:
                 type: string
-          description: Accepted
+          description: Accepted - deletion started
         "400":
           content:
             application/json:

--- a/pkg/api/v1/groups.go
+++ b/pkg/api/v1/groups.go
@@ -199,7 +199,7 @@ func (s *GroupsRoutes) deleteGroup(w http.ResponseWriter, r *http.Request) error
 	}
 
 	// Get the with-workloads flag from query parameter
-	withWorkloads := r.URL.Query().Get("with-workloads") == "true"
+	withWorkloads := r.URL.Query().Get("with-workloads") == "true" //nolint:goconst // Query parameter check
 
 	// Get all workloads and filter for the group
 	allWorkloads, err := s.workloadManager.ListWorkloads(ctx, true) // listAll=true to include stopped workloads

--- a/pkg/api/v1/workloads.go
+++ b/pkg/api/v1/workloads.go
@@ -225,10 +225,11 @@ func (s *WorkloadRoutes) restartWorkload(w http.ResponseWriter, r *http.Request)
 // deleteWorkload
 //
 //	@Summary		Delete a workload
-//	@Description	Delete a workload
+//	@Description	Delete a workload asynchronously. Returns 202 Accepted immediately.
+//	@Description	The deletion happens in the background. Poll the workload list to confirm deletion.
 //	@Tags			workloads
 //	@Param			name	path		string	true	"Workload name"
-//	@Success		202		{string}	string	"Accepted"
+//	@Success		202		{string}	string	"Accepted - deletion started"
 //	@Failure		400		{string}	string	"Bad Request"
 //	@Failure		404		{string}	string	"Not Found"
 //	@Router			/api/v1beta/workloads/{name} [delete]
@@ -248,6 +249,7 @@ func (s *WorkloadRoutes) deleteWorkload(w http.ResponseWriter, r *http.Request) 
 	if err != nil {
 		return err // ErrInvalidWorkloadName already has 400 status code
 	}
+
 	w.WriteHeader(http.StatusAccepted)
 	return nil
 }
@@ -466,11 +468,12 @@ func (s *WorkloadRoutes) restartWorkloadsBulk(w http.ResponseWriter, r *http.Req
 // deleteWorkloadsBulk
 //
 //	@Summary		Delete workloads in bulk
-//	@Description	Delete multiple workloads by name or by group
+//	@Description	Delete multiple workloads by name or by group asynchronously.
+//	@Description	Returns 202 Accepted immediately. Deletion happens in the background.
 //	@Tags			workloads
 //	@Accept			json
 //	@Param			request	body		bulkOperationRequest	true	"Bulk delete request (names or group)"
-//	@Success		202		{string}	string	"Accepted"
+//	@Success		202		{string}	string	"Accepted - deletion started"
 //	@Failure		400		{string}	string	"Bad Request"
 //	@Router			/api/v1beta/workloads/delete [post]
 func (s *WorkloadRoutes) deleteWorkloadsBulk(w http.ResponseWriter, r *http.Request) error {
@@ -499,6 +502,7 @@ func (s *WorkloadRoutes) deleteWorkloadsBulk(w http.ResponseWriter, r *http.Requ
 	if err != nil {
 		return err // ErrInvalidWorkloadName already has 400 status code
 	}
+
 	w.WriteHeader(http.StatusAccepted)
 	return nil
 }

--- a/pkg/workloads/manager.go
+++ b/pkg/workloads/manager.go
@@ -732,7 +732,7 @@ func (d *DefaultManager) deleteRemoteWorkload(ctx context.Context, name string, 
 
 	// Remove the workload status from the status store
 	if err := d.statuses.DeleteWorkloadStatus(ctx, name); err != nil {
-		logger.Warnf("Failed to delete workload status for %s: %v", name, err)
+		return fmt.Errorf("failed to delete workload status for %s: %v", name, err)
 	}
 
 	logger.Debugf("Remote workload %s removed", name)
@@ -787,7 +787,7 @@ func (d *DefaultManager) deleteContainerWorkload(ctx context.Context, name strin
 
 	// Remove the workload status from the status store
 	if err := d.statuses.DeleteWorkloadStatus(ctx, name); err != nil {
-		logger.Warnf("Failed to delete workload status for %s: %v", name, err)
+		return fmt.Errorf("failed to delete workload status for %s: %v", name, err)
 	}
 
 	return nil
@@ -854,7 +854,7 @@ func (d *DefaultManager) stopProcess(ctx context.Context, name string) {
 		logger.Debugf("Proxy process stopped")
 	}
 
-	// Remove old PID from
+	// Remove the PID of the terminated process
 	if err := d.statuses.ResetWorkloadPID(ctx, name); err != nil {
 		logger.Warnf("Failed to reset workload %s PID: %v", name, err)
 	}

--- a/test/e2e/api_clients_test.go
+++ b/test/e2e/api_clients_test.go
@@ -56,7 +56,7 @@ var _ = Describe("Clients API", Label("api", "clients", "e2e"), func() {
 
 		AfterEach(func() {
 			// Clean up in reverse order
-			deleteWorkload(apiServer, workloadName)
+			// Note: Workload cleanup handled by suite-level CLI cleanup
 			unregisterClientFromGroup(apiServer, string(testClientName), groupName)
 			deleteGroup(apiServer, groupName)
 		})
@@ -230,7 +230,7 @@ var _ = Describe("Clients API", Label("api", "clients", "e2e"), func() {
 		})
 
 		AfterEach(func() {
-			deleteWorkload(apiServer, workloadName)
+			// Note: Workload cleanup handled by suite-level CLI cleanup
 			deleteGroup(apiServer, groupName)
 		})
 
@@ -321,7 +321,7 @@ var _ = Describe("Clients API", Label("api", "clients", "e2e"), func() {
 		})
 
 		AfterEach(func() {
-			deleteWorkload(apiServer, workloadName)
+			// Note: Workload cleanup handled by suite-level CLI cleanup
 			// Unregister clients from group
 			for _, name := range testClientNames {
 				unregisterClientFromGroup(apiServer, string(name), groupName)
@@ -430,7 +430,7 @@ var _ = Describe("Clients API", Label("api", "clients", "e2e"), func() {
 		})
 
 		AfterEach(func() {
-			deleteWorkload(apiServer, workloadName)
+			// Note: Workload cleanup handled by suite-level CLI cleanup
 			deleteGroup(apiServer, groupName)
 		})
 

--- a/test/e2e/api_clients_validation_test.go
+++ b/test/e2e/api_clients_validation_test.go
@@ -32,7 +32,7 @@ var _ = Describe("Clients API Validation", Label("api", "clients", "validation",
 	Describe("Invalid client type validation", func() {
 		It("should return 400 Bad Request for unsupported client type", func() {
 			workloadName := e2e.GenerateUniqueServerName("validation-workload")
-			defer deleteWorkload(apiServer, workloadName)
+			// Note: Workload cleanup handled by suite-level CLI cleanup
 
 			By("Creating a workload in the default group")
 			workloadReq := map[string]interface{}{
@@ -86,7 +86,7 @@ var _ = Describe("Clients API Validation", Label("api", "clients", "validation",
 		It("should return 400 Bad Request for bulk registration with invalid client type", func() {
 			workloadName := e2e.GenerateUniqueServerName("bulk-validation-workload")
 			groupName := fmt.Sprintf("bulk-validation-group-%d", time.Now().UnixNano())
-			defer deleteWorkload(apiServer, workloadName)
+			// Note: Workload cleanup handled by suite-level CLI cleanup
 			defer deleteGroup(apiServer, groupName)
 
 			By("Creating a test group")

--- a/test/e2e/api_groups_test.go
+++ b/test/e2e/api_groups_test.go
@@ -439,8 +439,7 @@ var _ = Describe("Groups API", Label("api", "groups", "e2e"), func() {
 				}, 10*time.Second, 1*time.Second).Should(BeTrue(),
 					"Workload should still exist after group deletion")
 
-				By("Cleaning up workload")
-				deleteWorkload(apiServer, workloadName)
+				// Note: Workload cleanup handled by suite-level CLI cleanup
 			})
 
 			It("should return 404 when deleting non-existent group", func() {

--- a/test/e2e/api_workload_lifecycle_test.go
+++ b/test/e2e/api_workload_lifecycle_test.go
@@ -35,9 +35,7 @@ var _ = Describe("Workload Lifecycle API", Label("api", "workloads", "lifecycle"
 			workloadName = e2e.GenerateUniqueServerName("api-stop-test")
 		})
 
-		AfterEach(func() {
-			deleteWorkload(apiServer, workloadName)
-		})
+		// Note: Workload cleanup handled by suite-level CLI cleanup
 
 		Context("when stopping a workload", func() {
 			It("should successfully stop a running workload", func() {
@@ -147,9 +145,7 @@ var _ = Describe("Workload Lifecycle API", Label("api", "workloads", "lifecycle"
 			workloadName = e2e.GenerateUniqueServerName("api-restart-test")
 		})
 
-		AfterEach(func() {
-			deleteWorkload(apiServer, workloadName)
-		})
+		// Note: Workload cleanup handled by suite-level CLI cleanup
 
 		Context("when restarting a workload", func() {
 			It("should successfully restart a running workload and keep same URL", func() {
@@ -274,9 +270,7 @@ var _ = Describe("Workload Lifecycle API", Label("api", "workloads", "lifecycle"
 			workloadName = e2e.GenerateUniqueServerName("api-status-test")
 		})
 
-		AfterEach(func() {
-			deleteWorkload(apiServer, workloadName)
-		})
+		// Note: Workload cleanup handled by suite-level CLI cleanup
 
 		Context("when getting workload status", func() {
 			It("should return status of a running workload", func() {
@@ -391,9 +385,7 @@ var _ = Describe("Workload Lifecycle API", Label("api", "workloads", "lifecycle"
 			workloadName = e2e.GenerateUniqueServerName("api-update-test")
 		})
 
-		AfterEach(func() {
-			deleteWorkload(apiServer, workloadName)
-		})
+		// Note: Workload cleanup handled by suite-level CLI cleanup
 
 		Context("when updating a workload", func() {
 			It("should successfully update workload environment variables", func() {
@@ -490,9 +482,7 @@ var _ = Describe("Workload Lifecycle API", Label("api", "workloads", "lifecycle"
 			workloadName = e2e.GenerateUniqueServerName("api-logs-test")
 		})
 
-		AfterEach(func() {
-			deleteWorkload(apiServer, workloadName)
-		})
+		// Note: Workload cleanup handled by suite-level CLI cleanup
 
 		Context("when getting workload logs", func() {
 			It("should return logs for running workload", func() {
@@ -547,9 +537,7 @@ var _ = Describe("Workload Lifecycle API", Label("api", "workloads", "lifecycle"
 			workloadName = e2e.GenerateUniqueServerName("api-proxy-logs-test")
 		})
 
-		AfterEach(func() {
-			deleteWorkload(apiServer, workloadName)
-		})
+		// Note: Workload cleanup handled by suite-level CLI cleanup
 
 		Context("when getting proxy logs", func() {
 			It("should return 404 when workload has no proxy", func() {
@@ -602,9 +590,7 @@ var _ = Describe("Workload Lifecycle API", Label("api", "workloads", "lifecycle"
 			workloadName = e2e.GenerateUniqueServerName("api-export-test")
 		})
 
-		AfterEach(func() {
-			deleteWorkload(apiServer, workloadName)
-		})
+		// Note: Workload cleanup handled by suite-level CLI cleanup
 
 		Context("when exporting workload configuration", func() {
 			It("should export workload as RunConfig JSON", func() {
@@ -669,11 +655,7 @@ var _ = Describe("Workload Lifecycle API", Label("api", "workloads", "lifecycle"
 			}
 		})
 
-		AfterEach(func() {
-			for _, name := range workloadNames {
-				deleteWorkload(apiServer, name)
-			}
-		})
+		// Note: Workload cleanup handled by suite-level CLI cleanup
 
 		Context("when stopping workloads in bulk by names", func() {
 			It("should stop multiple workloads", func() {
@@ -768,9 +750,7 @@ var _ = Describe("Workload Lifecycle API", Label("api", "workloads", "lifecycle"
 			})
 
 			AfterEach(func() {
-				for _, name := range workloadNames {
-					deleteWorkload(apiServer, name)
-				}
+				// Note: Workload cleanup handled by suite-level CLI cleanup
 				deleteGroup(apiServer, groupName)
 			})
 
@@ -900,11 +880,7 @@ var _ = Describe("Workload Lifecycle API", Label("api", "workloads", "lifecycle"
 			}
 		})
 
-		AfterEach(func() {
-			for _, name := range workloadNames {
-				deleteWorkload(apiServer, name)
-			}
-		})
+		// Note: Workload cleanup handled by suite-level CLI cleanup
 
 		Context("when restarting workloads in bulk", func() {
 			It("should restart multiple workloads", func() {
@@ -998,9 +974,7 @@ var _ = Describe("Workload Lifecycle API", Label("api", "workloads", "lifecycle"
 			})
 
 			AfterEach(func() {
-				for _, name := range workloadNames {
-					deleteWorkload(apiServer, name)
-				}
+				// Note: Workload cleanup handled by suite-level CLI cleanup
 				deleteGroup(apiServer, groupName)
 			})
 
@@ -1219,11 +1193,7 @@ var _ = Describe("Workload Lifecycle API", Label("api", "workloads", "lifecycle"
 			}
 		})
 
-		AfterEach(func() {
-			for _, name := range workloadNames {
-				deleteWorkload(apiServer, name)
-			}
-		})
+		// Note: Workload cleanup handled by suite-level CLI cleanup
 
 		Context("when deleting workloads in bulk", func() {
 			It("should delete multiple workloads", func() {
@@ -1327,10 +1297,7 @@ var _ = Describe("Workload Lifecycle API", Label("api", "workloads", "lifecycle"
 			})
 
 			AfterEach(func() {
-				// Cleanup any remaining workloads
-				for _, name := range workloadNames {
-					deleteWorkload(apiServer, name)
-				}
+				// Note: Workload cleanup handled by suite-level CLI cleanup
 				deleteGroup(apiServer, groupName)
 			})
 

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -4,11 +4,18 @@
 package e2e_test
 
 import (
+	"context"
 	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"github.com/stacklok/toolhive/test/e2e"
 )
 
 // sharedConfigDir is created once for the entire test suite
@@ -32,8 +39,109 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = AfterSuite(func() {
-	// Clean up the shared config directory after all tests complete
+	// Clean up the shared config directory
+	// This is safe because it's an isolated temp directory created by BeforeSuite
 	if sharedConfigDir != "" {
-		_ = os.RemoveAll(sharedConfigDir)
+		// Clean up any remaining test workloads by name (surgical approach)
+		cleanupTestWorkloadsByName()
+
+		// Remove the entire temp directory
+		GinkgoWriter.Printf("Removing test config directory: %s\n", sharedConfigDir)
+		if err := os.RemoveAll(sharedConfigDir); err != nil {
+			GinkgoWriter.Printf("Warning: Failed to remove test config directory: %v\n", err)
+		}
+		GinkgoWriter.Printf("Test cleanup complete\n")
 	}
 })
+
+// cleanupTestWorkloadsByName discovers test workloads from the isolated config directory
+// and deletes them specifically by name. This is safe because:
+// 1. We only delete workloads that exist in the isolated test config
+// 2. We delete them by explicit name (not --all)
+// 3. Real workloads are unaffected because they're not in the test config
+func cleanupTestWorkloadsByName() {
+	testConfig := e2e.NewTestConfig()
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	defer cancel()
+
+	// SAFETY CHECK: Verify we're using a temp directory
+	if !strings.Contains(sharedConfigDir, "toolhive-e2e-shared-") {
+		GinkgoWriter.Printf("ERROR: Config directory does not look like a test directory: %s\n", sharedConfigDir)
+		GinkgoWriter.Printf("Skipping cleanup to avoid affecting real workloads!\n")
+		return
+	}
+
+	// List workloads from the isolated test config
+	workloadNames := listTestWorkloadNames()
+	if len(workloadNames) == 0 {
+		GinkgoWriter.Printf("No test workloads found to clean up\n")
+		return
+	}
+
+	GinkgoWriter.Printf("Cleaning up %d test workload(s): %v\n", len(workloadNames), workloadNames)
+
+	// Set up environment to use the ISOLATED test config directory
+	env := []string{
+		"XDG_CONFIG_HOME=" + sharedConfigDir,
+		"XDG_DATA_HOME=" + sharedConfigDir,
+		"HOME=" + sharedConfigDir,
+		"TOOLHIVE_DEV=true",
+	}
+
+	// Delete each test workload specifically by name
+	for _, name := range workloadNames {
+		//nolint:gosec // Intentional for cleanup with specific workload names
+		rmCmd := exec.CommandContext(ctx, testConfig.THVBinary, "rm", name)
+		rmCmd.Env = env
+		if err := rmCmd.Run(); err != nil {
+			GinkgoWriter.Printf("Warning: Failed to delete test workload %s: %v\n", name, err)
+		}
+	}
+
+	GinkgoWriter.Printf("Test workload cleanup complete\n")
+}
+
+// listTestWorkloadNames reads the isolated test config directory to find workload names.
+// It checks both run configs and status files to catch all workloads.
+func listTestWorkloadNames() []string {
+	namesMap := make(map[string]bool)
+
+	// Check run configs: XDG_DATA_HOME/toolhive/run_configs/
+	runConfigsDir := filepath.Join(sharedConfigDir, "toolhive", "run_configs")
+	if entries, err := os.ReadDir(runConfigsDir); err == nil {
+		for _, entry := range entries {
+			if entry.IsDir() {
+				continue
+			}
+			// Run config files are named <workload-name>.json
+			name := strings.TrimSuffix(entry.Name(), ".json")
+			if name != "" && name != entry.Name() { // Valid JSON file
+				namesMap[name] = true
+			}
+		}
+	}
+
+	// Check status files: XDG_DATA_HOME/toolhive/statuses/
+	// This catches workloads that have orphaned containers but lost their run configs
+	statusesDir := filepath.Join(sharedConfigDir, "toolhive", "statuses")
+	if entries, err := os.ReadDir(statusesDir); err == nil {
+		for _, entry := range entries {
+			if entry.IsDir() {
+				continue
+			}
+			// Status files are named <workload-name>.json
+			name := strings.TrimSuffix(entry.Name(), ".json")
+			if name != "" && name != entry.Name() { // Valid JSON file
+				namesMap[name] = true
+			}
+		}
+	}
+
+	// Convert map to slice
+	names := make([]string, 0, len(namesMap))
+	for name := range namesMap {
+		names = append(names, name)
+	}
+
+	return names
+}


### PR DESCRIPTION
The code previously relied on API calls to clean up local test state. However, since the APIs are async, and the servers get spun up and down during the tests, a lot of workloads would end up in a partially deleted state. This change uses the CLI for final cleanup, ensuring that the cleanup is complete. In tests where delete endpoints are tested, it introduces some logic to wait for the deletion to finish.

This mostly affects local runs of the E2E tests.