### PR TITLE
Isolate PID file logic into statuses package

### DIFF
--- a/pkg/process/detached.go
+++ b/pkg/process/detached.go
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+// Package process provides low level operations on OS processes
 package process
 
 import (

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -420,10 +420,6 @@ func (r *Runner) Run(ctx context.Context) error {
 		}
 
 		// Remove the PID file if it exists
-		// TODO: Stop writing to PID file once we migrate over to statuses.
-		if err := process.RemovePIDFile(r.Config.BaseName); err != nil {
-			logger.Warnf("Warning: Failed to remove PID file: %v", err)
-		}
 		if err := r.statusManager.ResetWorkloadPID(cleanupCtx, r.Config.BaseName); err != nil {
 			logger.Warnf("Warning: Failed to reset workload %s PID: %v", r.Config.ContainerName, err)
 		}
@@ -502,11 +498,7 @@ func (r *Runner) Run(ctx context.Context) error {
 		stopMCPServer("Context cancelled")
 	case <-doneCh:
 		// The transport has already been stopped (likely by the container exit)
-		// Clean up the PID file and state
-		// TODO: Stop writing to PID file once we migrate over to statuses.
-		if err := process.RemovePIDFile(r.Config.BaseName); err != nil {
-			logger.Warnf("Warning: Failed to remove PID file: %v", err)
-		}
+		// Remove the old PID from the state file
 		if err := r.statusManager.ResetWorkloadPID(ctx, r.Config.BaseName); err != nil {
 			logger.Warnf("Warning: Failed to reset workload %s PID: %v", r.Config.BaseName, err)
 		}

--- a/pkg/workloads/manager.go
+++ b/pkg/workloads/manager.go
@@ -841,11 +841,11 @@ func (d *DefaultManager) stopProcess(ctx context.Context, name string) {
 	// Try to read the PID and kill the process
 	pid, err := d.statuses.GetWorkloadPID(ctx, name)
 	if err != nil {
-		logger.Debugf("No PID file found for %s, proxy may not be running in detached mode", name)
+		logger.Debugf("No PID found for %s, proxy may not be running in detached mode", name)
 		return
 	}
 
-	// PID file found, try to kill the process
+	// PID found, try to kill the process
 	logger.Debugf("Stopping proxy process (PID: %d)...", pid)
 	if err := process.KillProcess(pid); err != nil {
 		logger.Debugf("Warning: Failed to kill proxy process: %v", err)
@@ -853,9 +853,9 @@ func (d *DefaultManager) stopProcess(ctx context.Context, name string) {
 		logger.Debugf("Proxy process stopped")
 	}
 
-	// Clean up PID file after successful kill
-	if err := process.RemovePIDFile(name); err != nil {
-		logger.Debugf("Warning: Failed to remove PID file: %v", err)
+	// Remove old PID from
+	if err := d.statuses.ResetWorkloadPID(ctx, name); err != nil {
+		logger.Warnf("Warning: Failed to reset workload %s PID: %v", name, err)
 	}
 }
 
@@ -1366,12 +1366,6 @@ func (d *DefaultManager) stopSingleContainerWorkload(ctx context.Context, worklo
 		logger.Debugf("Skipping proxy stop for auxiliary workload %s", name)
 	} else {
 		d.stopProcess(ctx, name)
-	}
-
-	// TODO: refactor the StopProcess function to stop dealing explicitly with PID files.
-	// Note that this is not a blocker for k8s since this code path is not called there.
-	if err := d.statuses.ResetWorkloadPID(ctx, name); err != nil {
-		logger.Warnf("Warning: Failed to reset workload %s PID: %v", name, err)
 	}
 
 	logger.Debugf("Stopping containers for %s...", name)

--- a/pkg/workloads/statuses/file_status_test.go
+++ b/pkg/workloads/statuses/file_status_test.go
@@ -23,7 +23,6 @@ import (
 	rtmocks "github.com/stacklok/toolhive/pkg/container/runtime/mocks"
 	"github.com/stacklok/toolhive/pkg/core"
 	"github.com/stacklok/toolhive/pkg/logger"
-	"github.com/stacklok/toolhive/pkg/process"
 	stateMocks "github.com/stacklok/toolhive/pkg/state/mocks"
 )
 
@@ -1831,8 +1830,8 @@ func TestFileStatusManager_ListWorkloads_PIDMigration(t *testing.T) {
 	require.NoError(t, err)
 
 	// Clean up PID files after test completes
-	require.NoError(t, process.RemovePIDFile(workloadMigrate))
-	require.NoError(t, process.RemovePIDFile(workloadNoMigrate))
+	require.NoError(t, removePIDFile(workloadMigrate))
+	require.NoError(t, removePIDFile(workloadNoMigrate))
 
 	// Should have 2 workloads
 	require.Len(t, workloads, 2)

--- a/pkg/workloads/statuses/pid.go
+++ b/pkg/workloads/statuses/pid.go
@@ -1,9 +1,7 @@
 // SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-// Package process provides utilities for managing process-related operations,
-// such as PID file handling and process management.
-package process
+package statuses
 
 import (
 	"fmt"
@@ -16,6 +14,10 @@ import (
 
 	"github.com/stacklok/toolhive/pkg/container/runtime"
 )
+
+/*
+ * NOTE: PID file functionality is deprecated. It should only be used by code which migrates PIDs to status files.
+ */
 
 // getOldPIDFilePath returns the legacy path to the PID file for a container (for backward compatibility)
 // Note: containerBaseName is pre-sanitized by the caller
@@ -73,10 +75,10 @@ func getPIDFilePathWithFallback(containerBaseName string) (string, error) {
 	return newPath, nil
 }
 
-// ReadPIDFile reads the process ID from a file
+// readPIDFile reads the process ID from a file
 // It checks both the new XDG location and the old temp directory location
 // Note: containerBaseName is pre-sanitized by the caller
-func ReadPIDFile(containerBaseName string) (int, error) {
+func readPIDFile(containerBaseName string) (int, error) {
 	// Skip PID file operations in Kubernetes runtime
 	if runtime.IsKubernetesRuntime() {
 		return 0, fmt.Errorf("PID file operations are not supported in Kubernetes runtime")
@@ -117,9 +119,9 @@ func ReadPIDFile(containerBaseName string) (int, error) {
 	return pid, nil
 }
 
-// RemovePIDFile removes the PID file
+// removePIDFile removes the PID file
 // It attempts to remove from both the new XDG location and the old temp directory location
-func RemovePIDFile(containerBaseName string) error {
+func removePIDFile(containerBaseName string) error {
 	// Skip PID file operations in Kubernetes runtime
 	if runtime.IsKubernetesRuntime() {
 		return nil

--- a/pkg/workloads/statuses/pid_test.go
+++ b/pkg/workloads/statuses/pid_test.go
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-package process
+package statuses
 
 import (
 	"fmt"
@@ -43,7 +43,7 @@ func TestPIDFileBackwardCompatibility(t *testing.T) {
 			"Failed to write PID file to old location")
 
 		// Read PID file (should find it in old location)
-		pid, err := ReadPIDFile(containerName)
+		pid, err := readPIDFile(containerName)
 		require.NoError(t, err, "Failed to read PID file from old location")
 		assert.Equal(t, testPID, pid, "PID mismatch")
 	})
@@ -81,7 +81,7 @@ func TestPIDFileBackwardCompatibility(t *testing.T) {
 			"Failed to write PID file to new location")
 
 		// Read PID file (should prefer new location)
-		pid, err := ReadPIDFile(containerName)
+		pid, err := readPIDFile(containerName)
 		require.NoError(t, err, "Failed to read PID file")
 		assert.Equal(t, newPID, pid, "Should read from new location when both exist")
 	})
@@ -120,7 +120,7 @@ func TestPIDFileBackwardCompatibility(t *testing.T) {
 			"Failed to write PID file to new location")
 
 		// Remove PID files
-		require.NoError(t, RemovePIDFile(containerName), "Failed to remove PID files")
+		require.NoError(t, removePIDFile(containerName), "Failed to remove PID files")
 
 		// Verify both locations are cleaned up
 		_, err = os.Stat(oldPath)
@@ -155,7 +155,7 @@ func TestPIDFileBackwardCompatibility(t *testing.T) {
 		require.NoError(t, os.WriteFile(oldPath, []byte(fmt.Sprintf("%d", testPID)), 0600),
 			"Failed to write PID file to old location")
 
-		err := RemovePIDFile(containerName)
+		err := removePIDFile(containerName)
 		assert.NoError(t, err, "Should handle removing only old file")
 
 		_, err = os.Stat(oldPath)
@@ -217,11 +217,11 @@ func TestPIDFileOperations(t *testing.T) {
 
 		// Clean up to ensure file doesn't exist
 		t.Cleanup(func() {
-			require.NoError(t, RemovePIDFile(containerName))
+			require.NoError(t, removePIDFile(containerName))
 		})
 
 		// Try to read non-existent file
-		_, err := ReadPIDFile(containerName)
+		_, err := readPIDFile(containerName)
 		assert.Error(t, err, "Should error when reading non-existent PID file")
 	})
 
@@ -233,12 +233,12 @@ func TestPIDFileOperations(t *testing.T) {
 
 		// Clean up to ensure file doesn't exist
 		t.Cleanup(func() {
-			require.NoError(t, RemovePIDFile(containerName))
+			require.NoError(t, removePIDFile(containerName))
 		})
 
 		// Removing non-existent file may or may not error (implementation dependent)
 		// Just ensure it doesn't panic
-		_ = RemovePIDFile(containerName)
+		_ = removePIDFile(containerName)
 	})
 }
 


### PR DESCRIPTION
Recently, a PR was created which called the PID file logic. The PID file logic is deprecated, and only used to handle workloads created by old versions of ToolHive.

As a precaution, move the PID file logic into the statuses package, and make it private, so that the PID file handling occurs inside the status file logic.