### PR TITLE
Add TOML client config support for Mistral Vibe and Codex

### DIFF
--- a/cmd/thv/app/client.go
+++ b/cmd/thv/app/client.go
@@ -58,12 +58,14 @@ Valid clients:
   - antigravity: Google Antigravity IDE
   - claude-code: Claude Code CLI
   - cline: Cline extension for VS Code
+  - codex: OpenAI Codex
   - continue: Continue.dev extensions for VS Code and JetBrains
   - cursor: Cursor editor
   - gemini-cli: Google Gemini CLI
   - goose: Goose AI agent
   - kiro: Kiro AI IDE
   - lm-studio: LM Studio application
+  - mistral-vibe: Mistral Vibe IDE
   - opencode: OpenCode editor
   - roo-code: Roo Code extension for VS Code
   - trae: Trae IDE
@@ -90,12 +92,14 @@ Valid clients:
   - antigravity: Google Antigravity IDE
   - claude-code: Claude Code CLI
   - cline: Cline extension for VS Code
+  - codex: OpenAI Codex
   - continue: Continue.dev extensions for VS Code and JetBrains
   - cursor: Cursor editor
   - gemini-cli: Google Gemini CLI
   - goose: Goose AI agent
   - kiro: Kiro AI IDE
   - lm-studio: LM Studio application
+  - mistral-vibe: Mistral Vibe IDE
   - opencode: OpenCode editor
   - roo-code: Roo Code extension for VS Code
   - trae: Trae IDE
@@ -211,13 +215,13 @@ func clientRegisterCmdFunc(cmd *cobra.Command, args []string) error {
 	switch clientType {
 	case "roo-code", "cline", "cursor", "claude-code", "vscode-insider", "vscode", "windsurf", "windsurf-jetbrains",
 		"amp-cli", "amp-vscode", "amp-vscode-insider", "amp-cursor", "amp-windsurf", "lm-studio", "goose", "trae",
-		"continue", "opencode", "kiro", "antigravity", "zed", "gemini-cli":
+		"continue", "opencode", "kiro", "antigravity", "zed", "gemini-cli", "mistral-vibe", "codex":
 		// Valid client type
 	default:
 		return fmt.Errorf(
 			"invalid client type: %s (valid types: roo-code, cline, cursor, claude-code, vscode, vscode-insider, "+
 				"windsurf, windsurf-jetbrains, amp-cli, amp-vscode, amp-vscode-insider, amp-cursor, amp-windsurf, lm-studio, "+
-				"goose, trae, continue, opencode, kiro, antigravity, zed, gemini-cli)",
+				"goose, trae, continue, opencode, kiro, antigravity, zed, gemini-cli, mistral-vibe, codex)",
 			clientType)
 	}
 
@@ -231,13 +235,13 @@ func clientRemoveCmdFunc(cmd *cobra.Command, args []string) error {
 	switch clientType {
 	case "roo-code", "cline", "cursor", "claude-code", "vscode-insider", "vscode", "windsurf", "windsurf-jetbrains",
 		"amp-cli", "amp-vscode", "amp-vscode-insider", "amp-cursor", "amp-windsurf", "lm-studio", "goose", "trae",
-		"continue", "opencode", "kiro", "antigravity", "zed", "gemini-cli":
+		"continue", "opencode", "kiro", "antigravity", "zed", "gemini-cli", "mistral-vibe", "codex":
 		// Valid client type
 	default:
 		return fmt.Errorf(
 			"invalid client type: %s (valid types: roo-code, cline, cursor, claude-code, vscode, vscode-insider, "+
 				"windsurf, windsurf-jetbrains, amp-cli, amp-vscode, amp-vscode-insider, amp-cursor, amp-windsurf, lm-studio, "+
-				"goose, trae, continue, opencode, kiro, antigravity, zed, gemini-cli)",
+				"goose, trae, continue, opencode, kiro, antigravity, zed, gemini-cli, mistral-vibe, codex)",
 			clientType)
 	}
 

--- a/docs/cli/thv_client_register.md
+++ b/docs/cli/thv_client_register.md
@@ -26,12 +26,14 @@ Valid clients:
   - antigravity: Google Antigravity IDE
   - claude-code: Claude Code CLI
   - cline: Cline extension for VS Code
+  - codex: OpenAI Codex
   - continue: Continue.dev extensions for VS Code and JetBrains
   - cursor: Cursor editor
   - gemini-cli: Google Gemini CLI
   - goose: Goose AI agent
   - kiro: Kiro AI IDE
   - lm-studio: LM Studio application
+  - mistral-vibe: Mistral Vibe IDE
   - opencode: OpenCode editor
   - roo-code: Roo Code extension for VS Code
   - trae: Trae IDE

--- a/docs/cli/thv_client_remove.md
+++ b/docs/cli/thv_client_remove.md
@@ -26,12 +26,14 @@ Valid clients:
   - antigravity: Google Antigravity IDE
   - claude-code: Claude Code CLI
   - cline: Cline extension for VS Code
+  - codex: OpenAI Codex
   - continue: Continue.dev extensions for VS Code and JetBrains
   - cursor: Cursor editor
   - gemini-cli: Google Gemini CLI
   - goose: Goose AI agent
   - kiro: Kiro AI IDE
   - lm-studio: LM Studio application
+  - mistral-vibe: Mistral Vibe IDE
   - opencode: OpenCode editor
   - roo-code: Roo Code extension for VS Code
   - trae: Trae IDE

--- a/docs/server/docs.go
+++ b/docs/server/docs.go
@@ -403,7 +403,9 @@ const docTemplate = `{
                     "kiro",
                     "antigravity",
                     "zed",
-                    "gemini-cli"
+                    "gemini-cli",
+                    "mistral-vibe",
+                    "codex"
                 ],
                 "type": "string",
                 "x-enum-varnames": [
@@ -428,7 +430,9 @@ const docTemplate = `{
                     "Kiro",
                     "Antigravity",
                     "Zed",
-                    "GeminiCli"
+                    "GeminiCli",
+                    "MistralVibe",
+                    "Codex"
                 ]
             },
             "client.MCPClientStatus": {

--- a/docs/server/swagger.json
+++ b/docs/server/swagger.json
@@ -396,7 +396,9 @@
                     "kiro",
                     "antigravity",
                     "zed",
-                    "gemini-cli"
+                    "gemini-cli",
+                    "mistral-vibe",
+                    "codex"
                 ],
                 "type": "string",
                 "x-enum-varnames": [
@@ -421,7 +423,9 @@
                     "Kiro",
                     "Antigravity",
                     "Zed",
-                    "GeminiCli"
+                    "GeminiCli",
+                    "MistralVibe",
+                    "Codex"
                 ]
             },
             "client.MCPClientStatus": {

--- a/docs/server/swagger.yaml
+++ b/docs/server/swagger.yaml
@@ -410,6 +410,8 @@ components:
       - antigravity
       - zed
       - gemini-cli
+      - mistral-vibe
+      - codex
       type: string
       x-enum-varnames:
       - RooCode
@@ -434,6 +436,8 @@ components:
       - Antigravity
       - Zed
       - GeminiCli
+      - MistralVibe
+      - Codex
     client.MCPClientStatus:
       properties:
         client_type:


### PR DESCRIPTION
Closes: #3586 , #3553 

Extends the client configuration system to support TOML-based config files with two different formats:
- Array-of-tables format `[[section]]` for Mistral Vibe IDE
- Nested tables format `[section.servername]` for Codex CLI

Key changes:
- Add TOMLConfigUpdater for array-of-tables format (Mistral Vibe)
- Add TOMLMapConfigUpdater for nested tables format (Codex)
- Add MistralVibe and Codex client types with transport mappings
- Add TOMLStorageType enum to distinguish between TOML formats
- Support TOML extension alongside JSON and YAML
- Add comprehensive tests for both TOML updater implementations
- Extract defaultURLFieldName constant to reduce duplication
- Improve validation to handle empty YAML/TOML files correctly