### PR TITLE
Add TOML config file format support

### DIFF
--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -12,8 +12,10 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"time"
 
+	"github.com/pelletier/go-toml/v2"
 	"github.com/tailscale/hujson"
 	"gopkg.in/yaml.v3"
 
@@ -23,6 +25,9 @@ import (
 
 // lockTimeout is the maximum time to wait for a file lock
 const lockTimeout = 1 * time.Second
+
+// defaultURLFieldName is the default URL field name used when no specific mapping exists
+const defaultURLFieldName = "url"
 
 // MCPClient is an enum of supported MCP clients.
 type MCPClient string
@@ -82,6 +87,8 @@ const (
 	JSON Extension = "json"
 	// YAML represents a YAML extension.
 	YAML Extension = "yaml"
+	// TOML represents a TOML extension.
+	TOML Extension = "toml"
 )
 
 // YAMLStorageType represents how servers are stored in YAML configuration files.
@@ -92,6 +99,18 @@ const (
 	YAMLStorageTypeMap YAMLStorageType = "map"
 	// YAMLStorageTypeArray represents servers stored as an array of objects.
 	YAMLStorageTypeArray YAMLStorageType = "array"
+)
+
+// TOMLStorageType represents how servers are stored in TOML configuration files.
+type TOMLStorageType string
+
+const (
+	// TOMLStorageTypeMap represents servers stored as nested tables [section.servername].
+	// Example: [mcp_servers.myserver]
+	TOMLStorageTypeMap TOMLStorageType = "map"
+	// TOMLStorageTypeArray represents servers stored as array of tables [[section]].
+	// Example: [[mcp_servers]]
+	TOMLStorageTypeArray TOMLStorageType = "array"
 )
 
 // mcpClientConfig represents a configuration path for a supported MCP client.
@@ -108,9 +127,32 @@ type mcpClientConfig struct {
 	// MCPServersUrlLabelMap maps transport type to URL field name (e.g., "url", "serverUrl", "httpUrl")
 	MCPServersUrlLabelMap map[types.TransportType]string
 	// YAML-specific configuration (only used when Extension == YAML)
-	YAMLStorageType     YAMLStorageType        // How servers are stored in YAML (map or array)
-	YAMLIdentifierField string                 // For array type: field name that identifies the server
-	YAMLDefaults        map[string]interface{} // Default values to add to entries
+	YAMLStorageType     YAMLStorageType // How servers are stored in YAML (map or array)
+	YAMLIdentifierField string          // For array type: field name that identifies the server
+	YAMLDefaults        map[string]any  // Default values to add to entries
+	// TOML-specific configuration (only used when Extension == TOML)
+	TOMLStorageType TOMLStorageType // How servers are stored in TOML (map or array)
+}
+
+// extractServersKeyFromConfig extracts the servers key from MCPServersPathPrefix
+// by removing the leading "/" (e.g., "/mcpServers" -> "mcpServers").
+func extractServersKeyFromConfig(cfg *mcpClientConfig) string {
+	return strings.TrimPrefix(cfg.MCPServersPathPrefix, "/")
+}
+
+// extractURLLabelFromConfig extracts the URL field label from MCPServersUrlLabelMap.
+// It checks transport types in priority order: StreamableHTTP, then Stdio.
+// Returns defaultURLFieldName if no mapping is found.
+func extractURLLabelFromConfig(cfg *mcpClientConfig) string {
+	if cfg.MCPServersUrlLabelMap != nil {
+		if label, ok := cfg.MCPServersUrlLabelMap[types.TransportTypeStreamableHTTP]; ok {
+			return label
+		}
+		if label, ok := cfg.MCPServersUrlLabelMap[types.TransportTypeStdio]; ok {
+			return label
+		}
+	}
+	return defaultURLFieldName
 }
 
 var (
@@ -735,10 +777,11 @@ func (cm *ClientManager) CreateClientConfig(clientType MCPClient) (*ConfigFile, 
 	}
 
 	var initialContent []byte
-	if clientCfg.Extension == YAML {
-		// For YAML files, create an empty file - the updater will initialize structure as needed
+	switch clientCfg.Extension {
+	case YAML, TOML:
+		// For YAML and TOML files, create an empty file - the updater will initialize structure as needed
 		initialContent = []byte("")
-	} else {
+	case JSON:
 		// JSON files get empty object
 		initialContent = []byte("{}")
 	}
@@ -787,7 +830,7 @@ func buildMCPServer(url, transportType string, clientCfg *mcpClientConfig) MCPSe
 	server := MCPServer{}
 
 	// Determine the URL field name from the transport type using MCPServersUrlLabelMap
-	urlFieldName := "url" // default fallback
+	urlFieldName := defaultURLFieldName // default fallback
 	if clientCfg.MCPServersUrlLabelMap != nil {
 		if mappedUrlField, ok := clientCfg.MCPServersUrlLabelMap[types.TransportType(transportType)]; ok {
 			urlFieldName = mappedUrlField
@@ -849,6 +892,27 @@ func (cm *ClientManager) retrieveConfigFileMetadata(clientType MCPClient) (*Conf
 			Path:      path,
 			Converter: converter,
 		}
+	case TOML:
+		serversKey := extractServersKeyFromConfig(clientCfg)
+		urlLabel := extractURLLabelFromConfig(clientCfg)
+
+		// Choose TOML updater based on storage type
+		if clientCfg.TOMLStorageType == TOMLStorageTypeMap {
+			// Use map-based format [section.servername] (e.g., Codex)
+			configUpdater = &TOMLMapConfigUpdater{
+				Path:       path,
+				ServersKey: serversKey,
+				URLField:   urlLabel,
+			}
+		} else {
+			// Default to array-of-tables format [[section]] (e.g., Mistral Vibe)
+			configUpdater = &TOMLConfigUpdater{
+				Path:            path,
+				ServersKey:      serversKey,
+				IdentifierField: "name", // TOML configs use "name" as the identifier
+				URLField:        urlLabel,
+			}
+		}
 	case JSON:
 		configUpdater = &JSONConfigUpdater{
 			Path:                 path,
@@ -888,16 +952,29 @@ func validateConfigFileFormat(cf *ConfigFile) error {
 		return fmt.Errorf("failed to read file %s: %w", cf.Path, err)
 	}
 
+	// For YAML and TOML files, empty content is valid
+	// For JSON files, default to empty object if the file is empty
 	if len(data) == 0 {
-		data = []byte("{}") // Default to an empty JSON object if the file is empty
+		switch cf.Extension {
+		case YAML, TOML:
+			return nil // Empty YAML/TOML files are valid
+		case JSON:
+			data = []byte("{}") // Default to an empty JSON object
+		}
 	}
 
 	switch cf.Extension {
 	case YAML:
-		var temp interface{}
+		var temp any
 		err = yaml.Unmarshal(data, &temp)
 		if err != nil {
 			return fmt.Errorf("failed to parse YAML for file %s: %w", cf.Path, err)
+		}
+	case TOML:
+		var temp any
+		err = toml.Unmarshal(data, &temp)
+		if err != nil {
+			return fmt.Errorf("failed to parse TOML for file %s: %w", cf.Path, err)
 		}
 	case JSON:
 		_, err = hujson.Parse(data)

--- a/pkg/client/config_editor_test.go
+++ b/pkg/client/config_editor_test.go
@@ -595,3 +595,752 @@ func setupExistingTestYAMLConfig(t *testing.T, testName string) (string, string)
 
 	return tempDir, configPath
 }
+
+const testServerName = "testServer"
+
+func TestTOMLConfigUpdaterUpsert(t *testing.T) {
+	t.Parallel()
+
+	logger.Initialize()
+
+	t.Run("AddNewMCPServerToEmptyTOML", func(t *testing.T) {
+		t.Parallel()
+
+		uniqueId := uuid.New().String()
+		tempDir, configPath := setupEmptyTestTOMLConfig(t, uniqueId)
+
+		tcu := TOMLConfigUpdater{
+			Path:            configPath,
+			ServersKey:      "mcp_servers",
+			IdentifierField: "name",
+			URLField:        "url",
+		}
+
+		mcpServer := MCPServer{
+			Url:  fmt.Sprintf("http://localhost:%s", uniqueId),
+			Type: "http",
+		}
+
+		err := tcu.Upsert(testServerName, mcpServer)
+		if err != nil {
+			t.Fatalf("Failed to update TOML config: %v", err)
+		}
+
+		// Verify the TOML content
+		content, err := os.ReadFile(configPath)
+		if err != nil {
+			t.Fatalf("Failed to read TOML file: %v", err)
+		}
+
+		// Verify content contains expected values
+		// Note: go-toml/v2 uses single quotes for string values
+		contentStr := string(content)
+		assert.Contains(t, contentStr, "[[mcp_servers]]", "Should contain array-of-tables syntax")
+		assert.Contains(t, contentStr, fmt.Sprintf("name = '%s'", testServerName), "Should contain server name")
+		assert.Contains(t, contentStr, fmt.Sprintf("url = '%s'", mcpServer.Url), "Should contain URL")
+		assert.Contains(t, contentStr, fmt.Sprintf("transport = '%s'", mcpServer.Type), "Should contain transport type")
+
+		t.Cleanup(func() {
+			if err := os.RemoveAll(tempDir); err != nil {
+				t.Logf("Failed to remove temp dir: %v", err)
+			}
+		})
+	})
+
+	t.Run("UpdateExistingServerInTOML", func(t *testing.T) {
+		t.Parallel()
+
+		uniqueId := uuid.New().String()
+		tempDir, configPath := setupExistingTestTOMLConfig(t, uniqueId)
+
+		tcu := TOMLConfigUpdater{
+			Path:            configPath,
+			ServersKey:      "mcp_servers",
+			IdentifierField: "name",
+			URLField:        "url",
+		}
+
+		// Update the existing server
+		updatedServer := MCPServer{
+			Url:  "http://localhost:9999/updated",
+			Type: "http",
+		}
+
+		err := tcu.Upsert("existingServer", updatedServer)
+		if err != nil {
+			t.Fatalf("Failed to update TOML config: %v", err)
+		}
+
+		// Verify the TOML content was updated
+		content, err := os.ReadFile(configPath)
+		if err != nil {
+			t.Fatalf("Failed to read TOML file: %v", err)
+		}
+
+		// Note: go-toml/v2 uses single quotes for string values
+		contentStr := string(content)
+		assert.Contains(t, contentStr, "url = 'http://localhost:9999/updated'", "Should contain updated URL")
+		// Ensure there's only one mcp_servers entry (updated, not appended)
+		assert.Equal(t, 1, countOccurrences(contentStr, "[[mcp_servers]]"), "Should have only one server entry")
+
+		t.Cleanup(func() {
+			if err := os.RemoveAll(tempDir); err != nil {
+				t.Logf("Failed to remove temp dir: %v", err)
+			}
+		})
+	})
+
+	t.Run("AddSecondServerToExistingTOML", func(t *testing.T) {
+		t.Parallel()
+
+		uniqueId := uuid.New().String()
+		tempDir, configPath := setupExistingTestTOMLConfig(t, uniqueId)
+
+		tcu := TOMLConfigUpdater{
+			Path:            configPath,
+			ServersKey:      "mcp_servers",
+			IdentifierField: "name",
+			URLField:        "url",
+		}
+
+		// Add a new server
+		newServer := MCPServer{
+			Url:  "http://localhost:8888/new",
+			Type: "http",
+		}
+
+		err := tcu.Upsert("newServer", newServer)
+		if err != nil {
+			t.Fatalf("Failed to add new server to TOML config: %v", err)
+		}
+
+		// Verify both servers exist
+		content, err := os.ReadFile(configPath)
+		if err != nil {
+			t.Fatalf("Failed to read TOML file: %v", err)
+		}
+
+		// Note: go-toml/v2 uses single quotes for string values
+		contentStr := string(content)
+		assert.Equal(t, 2, countOccurrences(contentStr, "[[mcp_servers]]"), "Should have two server entries")
+		assert.Contains(t, contentStr, "name = 'existingServer'", "Should contain existing server")
+		assert.Contains(t, contentStr, "name = 'newServer'", "Should contain new server")
+
+		t.Cleanup(func() {
+			if err := os.RemoveAll(tempDir); err != nil {
+				t.Logf("Failed to remove temp dir: %v", err)
+			}
+		})
+	})
+
+	t.Run("PreserveOtherFieldsWhenUpserting", func(t *testing.T) {
+		t.Parallel()
+
+		uniqueId := uuid.New().String()
+		tempDir := t.TempDir()
+		configPath := filepath.Join(tempDir, fmt.Sprintf("config-%s.toml", uniqueId))
+
+		// Create a TOML file with extra top-level fields
+		initialConfig := `# Some comment
+version = "1.0"
+
+[settings]
+debug = true
+
+[[mcp_servers]]
+name = "existingServer"
+url = "http://localhost:8080"
+transport = "http"
+`
+		if err := os.WriteFile(configPath, []byte(initialConfig), 0600); err != nil {
+			t.Fatalf("Failed to write test TOML file: %v", err)
+		}
+
+		tcu := TOMLConfigUpdater{
+			Path:            configPath,
+			ServersKey:      "mcp_servers",
+			IdentifierField: "name",
+			URLField:        "url",
+		}
+
+		// Add a new server
+		newServer := MCPServer{
+			Url:  "http://localhost:9090/new",
+			Type: "http",
+		}
+
+		err := tcu.Upsert("newServer", newServer)
+		if err != nil {
+			t.Fatalf("Failed to add new server: %v", err)
+		}
+
+		// Verify other fields are preserved
+		content, err := os.ReadFile(configPath)
+		if err != nil {
+			t.Fatalf("Failed to read TOML file: %v", err)
+		}
+
+		// Note: go-toml/v2 uses single quotes for string values
+		contentStr := string(content)
+		assert.Contains(t, contentStr, "version =", "Should preserve version field")
+		assert.Contains(t, contentStr, "[settings]", "Should preserve settings section")
+		assert.Contains(t, contentStr, "debug =", "Should preserve debug setting")
+		assert.Contains(t, contentStr, "name = 'newServer'", "Should contain new server")
+
+		t.Cleanup(func() {
+			if err := os.RemoveAll(tempDir); err != nil {
+				t.Logf("Failed to remove temp dir: %v", err)
+			}
+		})
+	})
+}
+
+func TestTOMLConfigUpdaterRemove(t *testing.T) {
+	t.Parallel()
+
+	logger.Initialize()
+
+	t.Run("RemoveExistingServerFromTOML", func(t *testing.T) {
+		t.Parallel()
+
+		uniqueId := uuid.New().String()
+		tempDir, configPath := setupExistingTestTOMLConfig(t, uniqueId)
+
+		tcu := TOMLConfigUpdater{
+			Path:            configPath,
+			ServersKey:      "mcp_servers",
+			IdentifierField: "name",
+			URLField:        "url",
+		}
+
+		err := tcu.Remove("existingServer")
+		if err != nil {
+			t.Fatalf("Failed to remove server from TOML config: %v", err)
+		}
+
+		// Verify removal
+		content, err := os.ReadFile(configPath)
+		if err != nil {
+			t.Fatalf("Failed to read TOML file: %v", err)
+		}
+
+		contentStr := string(content)
+		assert.NotContains(t, contentStr, "existingServer", "Should not contain removed server")
+
+		t.Cleanup(func() {
+			if err := os.RemoveAll(tempDir); err != nil {
+				t.Logf("Failed to remove temp dir: %v", err)
+			}
+		})
+	})
+
+	t.Run("RemoveNonExistentServerFromTOML", func(t *testing.T) {
+		t.Parallel()
+
+		uniqueId := uuid.New().String()
+		tempDir, configPath := setupExistingTestTOMLConfig(t, uniqueId)
+
+		tcu := TOMLConfigUpdater{
+			Path:            configPath,
+			ServersKey:      "mcp_servers",
+			IdentifierField: "name",
+			URLField:        "url",
+		}
+
+		// Try to remove non-existent server
+		err := tcu.Remove("nonExistentServer")
+		if err != nil {
+			t.Fatalf("Should not error when removing non-existent server: %v", err)
+		}
+
+		// Verify existing server is still there
+		content, err := os.ReadFile(configPath)
+		if err != nil {
+			t.Fatalf("Failed to read TOML file: %v", err)
+		}
+
+		contentStr := string(content)
+		assert.Contains(t, contentStr, "existingServer", "Existing server should still exist")
+
+		t.Cleanup(func() {
+			if err := os.RemoveAll(tempDir); err != nil {
+				t.Logf("Failed to remove temp dir: %v", err)
+			}
+		})
+	})
+
+	t.Run("RemoveFromEmptyTOMLFile", func(t *testing.T) {
+		t.Parallel()
+
+		uniqueId := uuid.New().String()
+		tempDir, configPath := setupEmptyTestTOMLConfig(t, uniqueId)
+
+		tcu := TOMLConfigUpdater{
+			Path:            configPath,
+			ServersKey:      "mcp_servers",
+			IdentifierField: "name",
+			URLField:        "url",
+		}
+
+		// Try to remove from empty file
+		err := tcu.Remove("anyServer")
+		if err != nil {
+			t.Fatalf("Should not error when removing from empty file: %v", err)
+		}
+
+		t.Cleanup(func() {
+			if err := os.RemoveAll(tempDir); err != nil {
+				t.Logf("Failed to remove temp dir: %v", err)
+			}
+		})
+	})
+
+	t.Run("RemoveFromNonExistentFile", func(t *testing.T) {
+		t.Parallel()
+
+		tempDir := t.TempDir()
+		configPath := filepath.Join(tempDir, "nonexistent.toml")
+
+		tcu := TOMLConfigUpdater{
+			Path:            configPath,
+			ServersKey:      "mcp_servers",
+			IdentifierField: "name",
+			URLField:        "url",
+		}
+
+		// Try to remove from non-existent file
+		err := tcu.Remove("anyServer")
+		if err != nil {
+			t.Fatalf("Should not error when file doesn't exist: %v", err)
+		}
+	})
+}
+
+// setupEmptyTestTOMLConfig creates a temporary directory and an empty TOML config file for testing
+func setupEmptyTestTOMLConfig(t *testing.T, testName string) (string, string) {
+	t.Helper()
+
+	tempDir, err := os.MkdirTemp("", "toolhive-toml-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+
+	configPath := filepath.Join(tempDir, fmt.Sprintf("config-%s.toml", testName))
+
+	// Create an empty TOML file
+	if err := os.WriteFile(configPath, []byte(""), 0600); err != nil {
+		t.Fatalf("Failed to write empty TOML file: %v", err)
+	}
+
+	return tempDir, configPath
+}
+
+// setupExistingTestTOMLConfig creates a temporary directory and a TOML config file with existing data
+func setupExistingTestTOMLConfig(t *testing.T, testName string) (string, string) {
+	t.Helper()
+
+	tempDir, err := os.MkdirTemp("", "toolhive-toml-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+
+	configPath := filepath.Join(tempDir, fmt.Sprintf("config-%s.toml", testName))
+
+	// Create a TOML config with existing server using array-of-tables syntax
+	testConfig := fmt.Sprintf(`[[mcp_servers]]
+name = "existingServer"
+url = "http://localhost:8080/existing-%s"
+transport = "http"
+`, testName)
+
+	if err := os.WriteFile(configPath, []byte(testConfig), 0600); err != nil {
+		t.Fatalf("Failed to write test TOML file: %v", err)
+	}
+
+	return tempDir, configPath
+}
+
+// countOccurrences counts how many times substr appears in s
+func countOccurrences(s, substr string) int {
+	count := 0
+	idx := 0
+	for {
+		i := indexOf(s[idx:], substr)
+		if i == -1 {
+			break
+		}
+		count++
+		idx += i + len(substr)
+	}
+	return count
+}
+
+// indexOf returns the index of substr in s, or -1 if not found
+func indexOf(s, substr string) int {
+	for i := 0; i+len(substr) <= len(s); i++ {
+		if s[i:i+len(substr)] == substr {
+			return i
+		}
+	}
+	return -1
+}
+
+func TestTOMLMapConfigUpdaterUpsert(t *testing.T) {
+	t.Parallel()
+
+	logger.Initialize()
+
+	t.Run("AddNewMCPServerToEmptyTOML", func(t *testing.T) {
+		t.Parallel()
+
+		uniqueId := uuid.New().String()
+		tempDir, configPath := setupEmptyTestTOMLConfig(t, uniqueId)
+
+		tmu := TOMLMapConfigUpdater{
+			Path:       configPath,
+			ServersKey: "mcp_servers",
+			URLField:   "url",
+		}
+
+		mcpServer := MCPServer{
+			Url: fmt.Sprintf("http://localhost:%s", uniqueId),
+		}
+
+		err := tmu.Upsert(testServerName, mcpServer)
+		if err != nil {
+			t.Fatalf("Failed to update TOML config: %v", err)
+		}
+
+		// Verify the TOML content
+		content, err := os.ReadFile(configPath)
+		if err != nil {
+			t.Fatalf("Failed to read TOML file: %v", err)
+		}
+
+		// Verify content contains expected nested table format
+		contentStr := string(content)
+		assert.Contains(t, contentStr, "[mcp_servers."+testServerName+"]", "Should contain nested table syntax")
+		assert.Contains(t, contentStr, fmt.Sprintf("url = '%s'", mcpServer.Url), "Should contain URL")
+		// Should NOT contain array-of-tables format
+		assert.NotContains(t, contentStr, "[[mcp_servers]]", "Should NOT contain array-of-tables syntax")
+
+		t.Cleanup(func() {
+			if err := os.RemoveAll(tempDir); err != nil {
+				t.Logf("Failed to remove temp dir: %v", err)
+			}
+		})
+	})
+
+	t.Run("UpdateExistingServerInTOMLMap", func(t *testing.T) {
+		t.Parallel()
+
+		uniqueId := uuid.New().String()
+		tempDir, configPath := setupExistingTestTOMLMapConfig(t, uniqueId)
+
+		tmu := TOMLMapConfigUpdater{
+			Path:       configPath,
+			ServersKey: "mcp_servers",
+			URLField:   "url",
+		}
+
+		// Update the existing server
+		updatedServer := MCPServer{
+			Url: "http://localhost:9999/updated",
+		}
+
+		err := tmu.Upsert("existingServer", updatedServer)
+		if err != nil {
+			t.Fatalf("Failed to update TOML config: %v", err)
+		}
+
+		// Verify the TOML content was updated
+		content, err := os.ReadFile(configPath)
+		if err != nil {
+			t.Fatalf("Failed to read TOML file: %v", err)
+		}
+
+		contentStr := string(content)
+		assert.Contains(t, contentStr, "url = 'http://localhost:9999/updated'", "Should contain updated URL")
+		// Ensure there's still only one server section
+		assert.Equal(t, 1, countOccurrences(contentStr, "[mcp_servers."), "Should have only one server entry")
+
+		t.Cleanup(func() {
+			if err := os.RemoveAll(tempDir); err != nil {
+				t.Logf("Failed to remove temp dir: %v", err)
+			}
+		})
+	})
+
+	t.Run("AddSecondServerToExistingTOMLMap", func(t *testing.T) {
+		t.Parallel()
+
+		uniqueId := uuid.New().String()
+		tempDir, configPath := setupExistingTestTOMLMapConfig(t, uniqueId)
+
+		tmu := TOMLMapConfigUpdater{
+			Path:       configPath,
+			ServersKey: "mcp_servers",
+			URLField:   "url",
+		}
+
+		// Add a new server
+		newServer := MCPServer{
+			Url: "http://localhost:8888/new",
+		}
+
+		err := tmu.Upsert("newServer", newServer)
+		if err != nil {
+			t.Fatalf("Failed to add new server to TOML config: %v", err)
+		}
+
+		// Verify both servers exist
+		content, err := os.ReadFile(configPath)
+		if err != nil {
+			t.Fatalf("Failed to read TOML file: %v", err)
+		}
+
+		contentStr := string(content)
+		assert.Contains(t, contentStr, "[mcp_servers.existingServer]", "Should contain existing server")
+		assert.Contains(t, contentStr, "[mcp_servers.newServer]", "Should contain new server")
+
+		t.Cleanup(func() {
+			if err := os.RemoveAll(tempDir); err != nil {
+				t.Logf("Failed to remove temp dir: %v", err)
+			}
+		})
+	})
+
+	t.Run("PreserveOtherFieldsWhenUpserting", func(t *testing.T) {
+		t.Parallel()
+
+		uniqueId := uuid.New().String()
+		tempDir := t.TempDir()
+		configPath := filepath.Join(tempDir, fmt.Sprintf("config-%s.toml", uniqueId))
+
+		// Create a TOML file with extra top-level fields
+		initialConfig := `# Codex config
+model = "gpt-4"
+
+[settings]
+debug = true
+
+[mcp_servers.existingServer]
+url = "http://localhost:8080"
+`
+		if err := os.WriteFile(configPath, []byte(initialConfig), 0600); err != nil {
+			t.Fatalf("Failed to write test TOML file: %v", err)
+		}
+
+		tmu := TOMLMapConfigUpdater{
+			Path:       configPath,
+			ServersKey: "mcp_servers",
+			URLField:   "url",
+		}
+
+		// Add a new server
+		newServer := MCPServer{
+			Url: "http://localhost:9090/new",
+		}
+
+		err := tmu.Upsert("newServer", newServer)
+		if err != nil {
+			t.Fatalf("Failed to add new server: %v", err)
+		}
+
+		// Verify other fields are preserved
+		content, err := os.ReadFile(configPath)
+		if err != nil {
+			t.Fatalf("Failed to read TOML file: %v", err)
+		}
+
+		contentStr := string(content)
+		assert.Contains(t, contentStr, "model =", "Should preserve model field")
+		assert.Contains(t, contentStr, "[settings]", "Should preserve settings section")
+		assert.Contains(t, contentStr, "debug =", "Should preserve debug setting")
+		assert.Contains(t, contentStr, "[mcp_servers.newServer]", "Should contain new server")
+
+		t.Cleanup(func() {
+			if err := os.RemoveAll(tempDir); err != nil {
+				t.Logf("Failed to remove temp dir: %v", err)
+			}
+		})
+	})
+
+	t.Run("AddServerWithTransportType", func(t *testing.T) {
+		t.Parallel()
+
+		uniqueId := uuid.New().String()
+		tempDir, configPath := setupEmptyTestTOMLConfig(t, uniqueId)
+
+		tmu := TOMLMapConfigUpdater{
+			Path:       configPath,
+			ServersKey: "mcp_servers",
+			URLField:   "url",
+		}
+
+		mcpServer := MCPServer{
+			Url:  "http://localhost:8080",
+			Type: "http",
+		}
+
+		err := tmu.Upsert(testServerName, mcpServer)
+		if err != nil {
+			t.Fatalf("Failed to update TOML config: %v", err)
+		}
+
+		content, err := os.ReadFile(configPath)
+		if err != nil {
+			t.Fatalf("Failed to read TOML file: %v", err)
+		}
+
+		contentStr := string(content)
+		assert.Contains(t, contentStr, "transport = 'http'", "Should contain transport type")
+
+		t.Cleanup(func() {
+			if err := os.RemoveAll(tempDir); err != nil {
+				t.Logf("Failed to remove temp dir: %v", err)
+			}
+		})
+	})
+}
+
+func TestTOMLMapConfigUpdaterRemove(t *testing.T) {
+	t.Parallel()
+
+	logger.Initialize()
+
+	t.Run("RemoveExistingServerFromTOMLMap", func(t *testing.T) {
+		t.Parallel()
+
+		uniqueId := uuid.New().String()
+		tempDir, configPath := setupExistingTestTOMLMapConfig(t, uniqueId)
+
+		tmu := TOMLMapConfigUpdater{
+			Path:       configPath,
+			ServersKey: "mcp_servers",
+			URLField:   "url",
+		}
+
+		err := tmu.Remove("existingServer")
+		if err != nil {
+			t.Fatalf("Failed to remove server from TOML config: %v", err)
+		}
+
+		// Verify removal
+		content, err := os.ReadFile(configPath)
+		if err != nil {
+			t.Fatalf("Failed to read TOML file: %v", err)
+		}
+
+		contentStr := string(content)
+		assert.NotContains(t, contentStr, "existingServer", "Should not contain removed server")
+
+		t.Cleanup(func() {
+			if err := os.RemoveAll(tempDir); err != nil {
+				t.Logf("Failed to remove temp dir: %v", err)
+			}
+		})
+	})
+
+	t.Run("RemoveNonExistentServerFromTOMLMap", func(t *testing.T) {
+		t.Parallel()
+
+		uniqueId := uuid.New().String()
+		tempDir, configPath := setupExistingTestTOMLMapConfig(t, uniqueId)
+
+		tmu := TOMLMapConfigUpdater{
+			Path:       configPath,
+			ServersKey: "mcp_servers",
+			URLField:   "url",
+		}
+
+		// Try to remove non-existent server
+		err := tmu.Remove("nonExistentServer")
+		if err != nil {
+			t.Fatalf("Should not error when removing non-existent server: %v", err)
+		}
+
+		// Verify existing server is still there
+		content, err := os.ReadFile(configPath)
+		if err != nil {
+			t.Fatalf("Failed to read TOML file: %v", err)
+		}
+
+		contentStr := string(content)
+		assert.Contains(t, contentStr, "existingServer", "Existing server should still exist")
+
+		t.Cleanup(func() {
+			if err := os.RemoveAll(tempDir); err != nil {
+				t.Logf("Failed to remove temp dir: %v", err)
+			}
+		})
+	})
+
+	t.Run("RemoveFromEmptyTOMLMapFile", func(t *testing.T) {
+		t.Parallel()
+
+		uniqueId := uuid.New().String()
+		tempDir, configPath := setupEmptyTestTOMLConfig(t, uniqueId)
+
+		tmu := TOMLMapConfigUpdater{
+			Path:       configPath,
+			ServersKey: "mcp_servers",
+			URLField:   "url",
+		}
+
+		// Try to remove from empty file
+		err := tmu.Remove("anyServer")
+		if err != nil {
+			t.Fatalf("Should not error when removing from empty file: %v", err)
+		}
+
+		t.Cleanup(func() {
+			if err := os.RemoveAll(tempDir); err != nil {
+				t.Logf("Failed to remove temp dir: %v", err)
+			}
+		})
+	})
+
+	t.Run("RemoveFromNonExistentFile", func(t *testing.T) {
+		t.Parallel()
+
+		tempDir := t.TempDir()
+		configPath := filepath.Join(tempDir, "nonexistent.toml")
+
+		tmu := TOMLMapConfigUpdater{
+			Path:       configPath,
+			ServersKey: "mcp_servers",
+			URLField:   "url",
+		}
+
+		// Try to remove from non-existent file
+		err := tmu.Remove("anyServer")
+		if err != nil {
+			t.Fatalf("Should not error when file doesn't exist: %v", err)
+		}
+	})
+}
+
+// setupExistingTestTOMLMapConfig creates a temporary directory and a TOML config file with existing data
+// using the map-based format [section.servername]
+func setupExistingTestTOMLMapConfig(t *testing.T, testName string) (string, string) {
+	t.Helper()
+
+	tempDir, err := os.MkdirTemp("", "toolhive-toml-map-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+
+	configPath := filepath.Join(tempDir, fmt.Sprintf("config-%s.toml", testName))
+
+	// Create a TOML config with existing server using nested table syntax
+	testConfig := fmt.Sprintf(`[mcp_servers.existingServer]
+url = "http://localhost:8080/existing-%s"
+`, testName)
+
+	if err := os.WriteFile(configPath, []byte(testConfig), 0600); err != nil {
+		t.Fatalf("Failed to write test TOML file: %v", err)
+	}
+
+	return tempDir, configPath
+}

--- a/pkg/client/config_test.go
+++ b/pkg/client/config_test.go
@@ -26,6 +26,7 @@ import (
 
 const testValidJSON = `{"mcpServers": {}, "mcp": {"servers": {}}}`
 const testValidYAML = `extensions: {}`
+const testValidTOML = ``
 
 // createMockClientConfigs creates a set of mock client configurations for testing
 func createMockClientConfigs() []mcpClientConfig {
@@ -534,9 +535,12 @@ func createTestConfigFilesWithConfigs(t *testing.T, homeDir string, clientConfig
 
 			// Choose the appropriate content based on the file extension
 			var content []byte
-			if cfg.Extension == YAML {
+			switch cfg.Extension {
+			case YAML:
 				content = []byte(testValidYAML)
-			} else {
+			case TOML:
+				content = []byte(testValidTOML)
+			case JSON:
 				content = []byte(testValidJSON)
 			}
 


### PR DESCRIPTION
## Summary

- Adds infrastructure for reading/writing TOML configuration files
- Supports two storage formats: array-of-tables (`[[section]]`) and nested tables (`[section.name]`)
- Uses go-toml/v2 library for parsing and writing
- Enables future clients using TOML configs to be supported

## Note

This is PR 1 of 2 for adding new client support. PR 2 (which depends on this) will add MistralVibe and Codex client configurations that use this TOML infrastructure.

🤖 Generated with [Claude Code](https://claude.ai/code)