### PR TITLE
Add MistralVibe and Codex client configurations

### DIFF
--- a/cmd/thv/app/client.go
+++ b/cmd/thv/app/client.go
@@ -58,12 +58,14 @@ Valid clients:
   - antigravity: Google Antigravity IDE
   - claude-code: Claude Code CLI
   - cline: Cline extension for VS Code
+  - codex: OpenAI Codex CLI
   - continue: Continue.dev extensions for VS Code and JetBrains
   - cursor: Cursor editor
   - gemini-cli: Google Gemini CLI
   - goose: Goose AI agent
   - kiro: Kiro AI IDE
   - lm-studio: LM Studio application
+  - mistral-vibe: Mistral Vibe IDE
   - opencode: OpenCode editor
   - roo-code: Roo Code extension for VS Code
   - trae: Trae IDE
@@ -91,12 +93,14 @@ Valid clients:
   - antigravity: Google Antigravity IDE
   - claude-code: Claude Code CLI
   - cline: Cline extension for VS Code
+  - codex: OpenAI Codex CLI
   - continue: Continue.dev extensions for VS Code and JetBrains
   - cursor: Cursor editor
   - gemini-cli: Google Gemini CLI
   - goose: Goose AI agent
   - kiro: Kiro AI IDE
   - lm-studio: LM Studio application
+  - mistral-vibe: Mistral Vibe IDE
   - opencode: OpenCode editor
   - roo-code: Roo Code extension for VS Code
   - trae: Trae IDE
@@ -213,13 +217,13 @@ func clientRegisterCmdFunc(cmd *cobra.Command, args []string) error {
 	switch clientType {
 	case "roo-code", "cline", "cursor", "claude-code", "vscode-insider", "vscode", "vscode-server", "windsurf", "windsurf-jetbrains",
 		"amp-cli", "amp-vscode", "amp-vscode-insider", "amp-cursor", "amp-windsurf", "lm-studio", "goose", "trae",
-		"continue", "opencode", "kiro", "antigravity", "zed", "gemini-cli":
+		"continue", "opencode", "kiro", "antigravity", "zed", "gemini-cli", "mistral-vibe", "codex":
 		// Valid client type
 	default:
 		return fmt.Errorf(
 			"invalid client type: %s (valid types: roo-code, cline, cursor, claude-code, vscode, vscode-insider, vscode-server, "+
 				"windsurf, windsurf-jetbrains, amp-cli, amp-vscode, amp-vscode-insider, amp-cursor, amp-windsurf, lm-studio, "+
-				"goose, trae, continue, opencode, kiro, antigravity, zed, gemini-cli)",
+				"goose, trae, continue, opencode, kiro, antigravity, zed, gemini-cli, mistral-vibe, codex)",
 			clientType)
 	}
 
@@ -233,13 +237,13 @@ func clientRemoveCmdFunc(cmd *cobra.Command, args []string) error {
 	switch clientType {
 	case "roo-code", "cline", "cursor", "claude-code", "vscode-insider", "vscode", "vscode-server", "windsurf", "windsurf-jetbrains",
 		"amp-cli", "amp-vscode", "amp-vscode-insider", "amp-cursor", "amp-windsurf", "lm-studio", "goose", "trae",
-		"continue", "opencode", "kiro", "antigravity", "zed", "gemini-cli":
+		"continue", "opencode", "kiro", "antigravity", "zed", "gemini-cli", "mistral-vibe", "codex":
 		// Valid client type
 	default:
 		return fmt.Errorf(
 			"invalid client type: %s (valid types: roo-code, cline, cursor, claude-code, vscode, vscode-insider, vscode-server, "+
 				"windsurf, windsurf-jetbrains, amp-cli, amp-vscode, amp-vscode-insider, amp-cursor, amp-windsurf, lm-studio, "+
-				"goose, trae, continue, opencode, kiro, antigravity, zed, gemini-cli)",
+				"goose, trae, continue, opencode, kiro, antigravity, zed, gemini-cli, mistral-vibe, codex)",
 			clientType)
 	}
 

--- a/docs/cli/thv_client_register.md
+++ b/docs/cli/thv_client_register.md
@@ -26,12 +26,14 @@ Valid clients:
   - antigravity: Google Antigravity IDE
   - claude-code: Claude Code CLI
   - cline: Cline extension for VS Code
+  - codex: OpenAI Codex CLI
   - continue: Continue.dev extensions for VS Code and JetBrains
   - cursor: Cursor editor
   - gemini-cli: Google Gemini CLI
   - goose: Goose AI agent
   - kiro: Kiro AI IDE
   - lm-studio: LM Studio application
+  - mistral-vibe: Mistral Vibe IDE
   - opencode: OpenCode editor
   - roo-code: Roo Code extension for VS Code
   - trae: Trae IDE

--- a/docs/cli/thv_client_remove.md
+++ b/docs/cli/thv_client_remove.md
@@ -26,12 +26,14 @@ Valid clients:
   - antigravity: Google Antigravity IDE
   - claude-code: Claude Code CLI
   - cline: Cline extension for VS Code
+  - codex: OpenAI Codex CLI
   - continue: Continue.dev extensions for VS Code and JetBrains
   - cursor: Cursor editor
   - gemini-cli: Google Gemini CLI
   - goose: Goose AI agent
   - kiro: Kiro AI IDE
   - lm-studio: LM Studio application
+  - mistral-vibe: Mistral Vibe IDE
   - opencode: OpenCode editor
   - roo-code: Roo Code extension for VS Code
   - trae: Trae IDE

--- a/docs/server/docs.go
+++ b/docs/server/docs.go
@@ -404,7 +404,9 @@ const docTemplate = `{
                     "antigravity",
                     "zed",
                     "gemini-cli",
-                    "vscode-server"
+                    "vscode-server",
+                    "mistral-vibe",
+                    "codex"
                 ],
                 "type": "string",
                 "x-enum-varnames": [
@@ -430,7 +432,9 @@ const docTemplate = `{
                     "Antigravity",
                     "Zed",
                     "GeminiCli",
-                    "VSCodeServer"
+                    "VSCodeServer",
+                    "MistralVibe",
+                    "Codex"
                 ]
             },
             "client.MCPClientStatus": {

--- a/docs/server/swagger.json
+++ b/docs/server/swagger.json
@@ -397,7 +397,9 @@
                     "antigravity",
                     "zed",
                     "gemini-cli",
-                    "vscode-server"
+                    "vscode-server",
+                    "mistral-vibe",
+                    "codex"
                 ],
                 "type": "string",
                 "x-enum-varnames": [
@@ -423,7 +425,9 @@
                     "Antigravity",
                     "Zed",
                     "GeminiCli",
-                    "VSCodeServer"
+                    "VSCodeServer",
+                    "MistralVibe",
+                    "Codex"
                 ]
             },
             "client.MCPClientStatus": {

--- a/docs/server/swagger.yaml
+++ b/docs/server/swagger.yaml
@@ -411,6 +411,8 @@ components:
       - zed
       - gemini-cli
       - vscode-server
+      - mistral-vibe
+      - codex
       type: string
       x-enum-varnames:
       - RooCode
@@ -436,6 +438,8 @@ components:
       - Zed
       - GeminiCli
       - VSCodeServer
+      - MistralVibe
+      - Codex
     client.MCPClientStatus:
       properties:
         client_type:

--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -79,6 +79,10 @@ const (
 	GeminiCli MCPClient = "gemini-cli"
 	// VSCodeServer represents Microsoft's VS Code Server (remote development).
 	VSCodeServer MCPClient = "vscode-server"
+	// MistralVibe represents the Mistral Vibe IDE.
+	MistralVibe MCPClient = "mistral-vibe"
+	// Codex represents the OpenAI Codex CLI.
+	Codex MCPClient = "codex"
 )
 
 // Extension is extension of the client config file.
@@ -665,12 +669,44 @@ var supportedClientIntegrations = []mcpClientConfig{
 			types.TransportTypeSSE:            "sse",
 			types.TransportTypeStreamableHTTP: "http",
 		},
+	},
+	{
+		ClientType:           MistralVibe,
+		Description:          "Mistral Vibe IDE",
+		SettingsFile:         "config.toml",
+		MCPServersPathPrefix: "/mcp_servers",
+		RelPath:              []string{".vibe"},
+		Extension:            TOML,
+		SupportedTransportTypesMap: map[types.TransportType]string{
+			types.TransportTypeStdio:          "streamable-http",
+			types.TransportTypeSSE:            "http",
+			types.TransportTypeStreamableHTTP: "streamable-http",
+		},
 		IsTransportTypeFieldSupported: true,
 		MCPServersUrlLabelMap: map[types.TransportType]string{
 			types.TransportTypeStdio:          "url",
 			types.TransportTypeSSE:            "url",
 			types.TransportTypeStreamableHTTP: "url",
 		},
+		// TOML configuration: uses array-of-tables format [[mcp_servers]]
+		TOMLStorageType: TOMLStorageTypeArray,
+	},
+	{
+		ClientType:           Codex,
+		Description:          "OpenAI Codex CLI",
+		SettingsFile:         "config.toml",
+		MCPServersPathPrefix: "/mcp_servers",
+		RelPath:              []string{".codex"},
+		Extension:            TOML,
+		// Codex doesn't support a transport type field - it auto-detects
+		IsTransportTypeFieldSupported: false,
+		MCPServersUrlLabelMap: map[types.TransportType]string{
+			types.TransportTypeStdio:          "url",
+			types.TransportTypeSSE:            "url",
+			types.TransportTypeStreamableHTTP: "url",
+		},
+		// TOML configuration: uses nested tables format [mcp_servers.servername]
+		TOMLStorageType: TOMLStorageTypeMap,
 	},
 }
 


### PR DESCRIPTION
Closes: #3586 , #3553 

## Summary

- Add support for MistralVibe (Mistral Vibe IDE) client configuration
- Add support for Codex (OpenAI Codex CLI) client configuration
- Both clients use TOML configuration format with different storage patterns

## Details

### MistralVibe (`mistral-vibe`)
- Uses TOML array-of-tables format: `[[mcp_servers]]`
- Config location: `~/.vibe/config.toml`
- Supports transport type field with `streamable-http` mapping

### Codex (`codex`)
- Uses TOML nested tables format: `[mcp_servers.servername]`
- Config location: `~/.codex/config.toml`
- No transport type field (auto-detects)

## Dependencies

This PR depends on #3596 and #3597 (TOML support infrastructure) and should be merged after those PRs land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)