### PR TITLE
Add TOML config file support with array-of-tables format

### DIFF
--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -12,8 +12,10 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"time"
 
+	"github.com/pelletier/go-toml/v2"
 	"github.com/tailscale/hujson"
 	"gopkg.in/yaml.v3"
 
@@ -23,6 +25,9 @@ import (
 
 // lockTimeout is the maximum time to wait for a file lock
 const lockTimeout = 1 * time.Second
+
+// defaultURLFieldName is the default URL field name used when no specific mapping exists
+const defaultURLFieldName = "url"
 
 // MCPClient is an enum of supported MCP clients.
 type MCPClient string
@@ -82,6 +87,8 @@ const (
 	JSON Extension = "json"
 	// YAML represents a YAML extension.
 	YAML Extension = "yaml"
+	// TOML represents a TOML extension.
+	TOML Extension = "toml"
 )
 
 // YAMLStorageType represents how servers are stored in YAML configuration files.
@@ -92,6 +99,15 @@ const (
 	YAMLStorageTypeMap YAMLStorageType = "map"
 	// YAMLStorageTypeArray represents servers stored as an array of objects.
 	YAMLStorageTypeArray YAMLStorageType = "array"
+)
+
+// TOMLStorageType represents how servers are stored in TOML configuration files.
+type TOMLStorageType string
+
+const (
+	// TOMLStorageTypeArray represents servers stored as array of tables [[section]].
+	// Example: [[mcp_servers]]
+	TOMLStorageTypeArray TOMLStorageType = "array"
 )
 
 // mcpClientConfig represents a configuration path for a supported MCP client.
@@ -108,9 +124,32 @@ type mcpClientConfig struct {
 	// MCPServersUrlLabelMap maps transport type to URL field name (e.g., "url", "serverUrl", "httpUrl")
 	MCPServersUrlLabelMap map[types.TransportType]string
 	// YAML-specific configuration (only used when Extension == YAML)
-	YAMLStorageType     YAMLStorageType        // How servers are stored in YAML (map or array)
-	YAMLIdentifierField string                 // For array type: field name that identifies the server
-	YAMLDefaults        map[string]interface{} // Default values to add to entries
+	YAMLStorageType     YAMLStorageType // How servers are stored in YAML (map or array)
+	YAMLIdentifierField string          // For array type: field name that identifies the server
+	YAMLDefaults        map[string]any  // Default values to add to entries
+	// TOML-specific configuration (only used when Extension == TOML)
+	TOMLStorageType TOMLStorageType // How servers are stored in TOML (map or array)
+}
+
+// extractServersKeyFromConfig extracts the servers key from MCPServersPathPrefix
+// by removing the leading "/" (e.g., "/mcpServers" -> "mcpServers").
+func extractServersKeyFromConfig(cfg *mcpClientConfig) string {
+	return strings.TrimPrefix(cfg.MCPServersPathPrefix, "/")
+}
+
+// extractURLLabelFromConfig extracts the URL field label from MCPServersUrlLabelMap.
+// It checks transport types in priority order: StreamableHTTP, then Stdio.
+// Returns defaultURLFieldName if no mapping is found.
+func extractURLLabelFromConfig(cfg *mcpClientConfig) string {
+	if cfg.MCPServersUrlLabelMap != nil {
+		if label, ok := cfg.MCPServersUrlLabelMap[types.TransportTypeStreamableHTTP]; ok {
+			return label
+		}
+		if label, ok := cfg.MCPServersUrlLabelMap[types.TransportTypeStdio]; ok {
+			return label
+		}
+	}
+	return defaultURLFieldName
 }
 
 var (
@@ -735,10 +774,11 @@ func (cm *ClientManager) CreateClientConfig(clientType MCPClient) (*ConfigFile, 
 	}
 
 	var initialContent []byte
-	if clientCfg.Extension == YAML {
-		// For YAML files, create an empty file - the updater will initialize structure as needed
+	switch clientCfg.Extension {
+	case YAML, TOML:
+		// For YAML and TOML files, create an empty file - the updater will initialize structure as needed
 		initialContent = []byte("")
-	} else {
+	case JSON:
 		// JSON files get empty object
 		initialContent = []byte("{}")
 	}
@@ -787,7 +827,7 @@ func buildMCPServer(url, transportType string, clientCfg *mcpClientConfig) MCPSe
 	server := MCPServer{}
 
 	// Determine the URL field name from the transport type using MCPServersUrlLabelMap
-	urlFieldName := "url" // default fallback
+	urlFieldName := defaultURLFieldName // default fallback
 	if clientCfg.MCPServersUrlLabelMap != nil {
 		if mappedUrlField, ok := clientCfg.MCPServersUrlLabelMap[types.TransportType(transportType)]; ok {
 			urlFieldName = mappedUrlField
@@ -849,6 +889,17 @@ func (cm *ClientManager) retrieveConfigFileMetadata(clientType MCPClient) (*Conf
 			Path:      path,
 			Converter: converter,
 		}
+	case TOML:
+		serversKey := extractServersKeyFromConfig(clientCfg)
+		urlLabel := extractURLLabelFromConfig(clientCfg)
+
+		// Use array-of-tables format [[section]] (e.g., Mistral Vibe)
+		configUpdater = &TOMLConfigUpdater{
+			Path:            path,
+			ServersKey:      serversKey,
+			IdentifierField: "name", // TOML configs use "name" as the identifier
+			URLField:        urlLabel,
+		}
 	case JSON:
 		configUpdater = &JSONConfigUpdater{
 			Path:                 path,
@@ -888,16 +939,29 @@ func validateConfigFileFormat(cf *ConfigFile) error {
 		return fmt.Errorf("failed to read file %s: %w", cf.Path, err)
 	}
 
+	// For YAML and TOML files, empty content is valid
+	// For JSON files, default to empty object if the file is empty
 	if len(data) == 0 {
-		data = []byte("{}") // Default to an empty JSON object if the file is empty
+		switch cf.Extension {
+		case YAML, TOML:
+			return nil // Empty YAML/TOML files are valid
+		case JSON:
+			data = []byte("{}") // Default to an empty JSON object
+		}
 	}
 
 	switch cf.Extension {
 	case YAML:
-		var temp interface{}
+		var temp any
 		err = yaml.Unmarshal(data, &temp)
 		if err != nil {
 			return fmt.Errorf("failed to parse YAML for file %s: %w", cf.Path, err)
+		}
+	case TOML:
+		var temp any
+		err = toml.Unmarshal(data, &temp)
+		if err != nil {
+			return fmt.Errorf("failed to parse TOML for file %s: %w", cf.Path, err)
 		}
 	case JSON:
 		_, err = hujson.Parse(data)

--- a/pkg/client/config_editor.go
+++ b/pkg/client/config_editor.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pelletier/go-toml/v2"
 	"github.com/tailscale/hujson"
 	"github.com/tidwall/gjson"
 	"gopkg.in/yaml.v3"
@@ -290,6 +291,221 @@ func (ycu *YAMLConfigUpdater) Remove(serverName string) error {
 
 	logger.Debugf("Successfully removed server %s from YAML config file", serverName)
 	return nil
+}
+
+// --- Shared TOML helper functions ---
+
+// tomlWithFileLock executes the given function while holding a file lock for the specified path.
+func tomlWithFileLock(path string, fn func() error) error {
+	lockPath := path + ".lock"
+	fileLock := lockfile.NewTrackedLock(lockPath)
+
+	ctx, cancel := context.WithTimeout(context.Background(), lockTimeout)
+	defer cancel()
+
+	locked, err := fileLock.TryLockContext(ctx, 100*time.Millisecond)
+	if err != nil {
+		return fmt.Errorf("failed to acquire lock: %w", err)
+	}
+	if !locked {
+		return fmt.Errorf("failed to acquire lock: timeout after %v", lockTimeout)
+	}
+	defer lockfile.ReleaseTrackedLock(lockPath, fileLock)
+
+	return fn()
+}
+
+// readTOMLConfig reads and parses a TOML config file from the specified path.
+func readTOMLConfig(path string) (map[string]any, error) {
+	// #nosec G304 -- path is controlled by internal code (TOMLConfigUpdater/TOMLMapConfigUpdater structs)
+	content, err := os.ReadFile(path)
+	if err != nil && !os.IsNotExist(err) {
+		return nil, fmt.Errorf("failed to read file: %w", err)
+	}
+
+	if len(content) == 0 {
+		return make(map[string]any), nil
+	}
+
+	var config map[string]any
+	if err := toml.Unmarshal(content, &config); err != nil {
+		return nil, fmt.Errorf("failed to parse existing TOML config: %w", err)
+	}
+	return config, nil
+}
+
+// writeTOMLConfig marshals and writes the config to the specified TOML file path.
+func writeTOMLConfig(path string, config map[string]any) error {
+	updatedContent, err := toml.Marshal(config)
+	if err != nil {
+		return fmt.Errorf("failed to marshal TOML: %w", err)
+	}
+	if err := os.WriteFile(path, updatedContent, 0600); err != nil {
+		return fmt.Errorf("failed to write file: %w", err)
+	}
+	return nil
+}
+
+// extractURLFromMCPServer extracts the URL value from an MCPServer struct,
+// checking fields in priority order based on client specificity:
+// Uri (Goose) → ServerUrl (Windsurf) → HttpUrl (Gemini) → Url (default/most common).
+func extractURLFromMCPServer(data MCPServer) string {
+	switch {
+	case data.Uri != "":
+		return data.Uri
+	case data.ServerUrl != "":
+		return data.ServerUrl
+	case data.HttpUrl != "":
+		return data.HttpUrl
+	case data.Url != "":
+		return data.Url
+	default:
+		return ""
+	}
+}
+
+// convertToAnySlice converts various slice types to []any.
+func convertToAnySlice(v any) []any {
+	switch s := v.(type) {
+	case []any:
+		return s
+	case []map[string]any:
+		result := make([]any, len(s))
+		for i, item := range s {
+			result[i] = item
+		}
+		return result
+	default:
+		return nil
+	}
+}
+
+// --- TOMLConfigUpdater (array-of-tables format) ---
+
+// TOMLConfigUpdater is a ConfigUpdater that is responsible for updating
+// TOML config files with array-of-tables format (used by Mistral Vibe).
+type TOMLConfigUpdater struct {
+	Path            string
+	ServersKey      string // The TOML array key (e.g., "mcp_servers")
+	IdentifierField string // The field name used to identify servers (e.g., "name")
+	URLField        string // The field name for URL (e.g., "url")
+}
+
+// Upsert inserts or updates an MCP server in the TOML config file
+func (tcu *TOMLConfigUpdater) Upsert(serverName string, data MCPServer) error {
+	return tomlWithFileLock(tcu.Path, func() error {
+		config, err := readTOMLConfig(tcu.Path)
+		if err != nil {
+			return err
+		}
+
+		servers := tcu.getServersArray(config)
+		newEntry := tcu.buildServerEntry(serverName, data)
+		servers = tcu.upsertServerEntry(servers, serverName, newEntry)
+		config[tcu.ServersKey] = servers
+
+		if err := writeTOMLConfig(tcu.Path, config); err != nil {
+			return err
+		}
+
+		logger.Debugf("Successfully updated TOML client config file for server %s", serverName)
+		return nil
+	})
+}
+
+// Remove removes an MCP server from the TOML config file
+func (tcu *TOMLConfigUpdater) Remove(serverName string) error {
+	return tomlWithFileLock(tcu.Path, func() error {
+		config, err := readTOMLConfig(tcu.Path)
+		if err != nil {
+			return err
+		}
+
+		// If config is empty (file didn't exist or was empty), nothing to remove
+		if len(config) == 0 {
+			return nil
+		}
+
+		existingServers, ok := config[tcu.ServersKey]
+		if !ok {
+			return nil // No servers section, nothing to remove
+		}
+
+		servers := convertToAnySlice(existingServers)
+		if servers == nil {
+			return nil // Unknown format, nothing to remove
+		}
+
+		config[tcu.ServersKey] = tcu.filterOutServer(servers, serverName)
+
+		if err := writeTOMLConfig(tcu.Path, config); err != nil {
+			return err
+		}
+
+		logger.Debugf("Successfully removed server %s from TOML config file", serverName)
+		return nil
+	})
+}
+
+// getServersArray extracts or initializes the servers array from config
+func (tcu *TOMLConfigUpdater) getServersArray(config map[string]any) []any {
+	existingServers, ok := config[tcu.ServersKey]
+	if !ok {
+		return []any{}
+	}
+	servers := convertToAnySlice(existingServers)
+	if servers == nil {
+		return []any{}
+	}
+	return servers
+}
+
+// upsertServerEntry updates an existing server or appends a new one
+func (tcu *TOMLConfigUpdater) upsertServerEntry(servers []any, serverName string, newEntry map[string]any) []any {
+	for i, s := range servers {
+		if serverEntry, ok := s.(map[string]any); ok {
+			if name, exists := serverEntry[tcu.IdentifierField]; exists && name == serverName {
+				servers[i] = newEntry
+				return servers
+			}
+		}
+	}
+	return append(servers, newEntry)
+}
+
+// filterOutServer removes the server with the given name from the slice
+func (tcu *TOMLConfigUpdater) filterOutServer(servers []any, serverName string) []any {
+	filtered := make([]any, 0, len(servers))
+	for _, s := range servers {
+		serverEntry, ok := s.(map[string]any)
+		if !ok {
+			filtered = append(filtered, s)
+			continue
+		}
+		name, exists := serverEntry[tcu.IdentifierField]
+		if !exists || name != serverName {
+			filtered = append(filtered, s)
+		}
+	}
+	return filtered
+}
+
+// buildServerEntry creates a server entry map from MCPServer data
+func (tcu *TOMLConfigUpdater) buildServerEntry(serverName string, data MCPServer) map[string]any {
+	entry := map[string]any{
+		tcu.IdentifierField: serverName,
+	}
+
+	if url := extractURLFromMCPServer(data); url != "" {
+		entry[tcu.URLField] = url
+	}
+
+	// Add transport type if specified
+	if data.Type != "" {
+		entry["transport"] = data.Type
+	}
+
+	return entry
 }
 
 // ensurePathExists ensures that the path exists in the JSON content

--- a/pkg/client/config_editor_test.go
+++ b/pkg/client/config_editor_test.go
@@ -595,3 +595,392 @@ func setupExistingTestYAMLConfig(t *testing.T, testName string) (string, string)
 
 	return tempDir, configPath
 }
+
+const testServerName = "testServer"
+
+func TestTOMLConfigUpdaterUpsert(t *testing.T) {
+	t.Parallel()
+
+	logger.Initialize()
+
+	t.Run("AddNewMCPServerToEmptyTOML", func(t *testing.T) {
+		t.Parallel()
+
+		uniqueId := uuid.New().String()
+		tempDir, configPath := setupEmptyTestTOMLConfig(t, uniqueId)
+
+		tcu := TOMLConfigUpdater{
+			Path:            configPath,
+			ServersKey:      "mcp_servers",
+			IdentifierField: "name",
+			URLField:        "url",
+		}
+
+		mcpServer := MCPServer{
+			Url:  fmt.Sprintf("http://localhost:%s", uniqueId),
+			Type: "http",
+		}
+
+		err := tcu.Upsert(testServerName, mcpServer)
+		if err != nil {
+			t.Fatalf("Failed to update TOML config: %v", err)
+		}
+
+		// Verify the TOML content
+		content, err := os.ReadFile(configPath)
+		if err != nil {
+			t.Fatalf("Failed to read TOML file: %v", err)
+		}
+
+		// Verify content contains expected values
+		// Note: go-toml/v2 uses single quotes for string values
+		contentStr := string(content)
+		assert.Contains(t, contentStr, "[[mcp_servers]]", "Should contain array-of-tables syntax")
+		assert.Contains(t, contentStr, fmt.Sprintf("name = '%s'", testServerName), "Should contain server name")
+		assert.Contains(t, contentStr, fmt.Sprintf("url = '%s'", mcpServer.Url), "Should contain URL")
+		assert.Contains(t, contentStr, fmt.Sprintf("transport = '%s'", mcpServer.Type), "Should contain transport type")
+
+		t.Cleanup(func() {
+			if err := os.RemoveAll(tempDir); err != nil {
+				t.Logf("Failed to remove temp dir: %v", err)
+			}
+		})
+	})
+
+	t.Run("UpdateExistingServerInTOML", func(t *testing.T) {
+		t.Parallel()
+
+		uniqueId := uuid.New().String()
+		tempDir, configPath := setupExistingTestTOMLConfig(t, uniqueId)
+
+		tcu := TOMLConfigUpdater{
+			Path:            configPath,
+			ServersKey:      "mcp_servers",
+			IdentifierField: "name",
+			URLField:        "url",
+		}
+
+		// Update the existing server
+		updatedServer := MCPServer{
+			Url:  "http://localhost:9999/updated",
+			Type: "http",
+		}
+
+		err := tcu.Upsert("existingServer", updatedServer)
+		if err != nil {
+			t.Fatalf("Failed to update TOML config: %v", err)
+		}
+
+		// Verify the TOML content was updated
+		content, err := os.ReadFile(configPath)
+		if err != nil {
+			t.Fatalf("Failed to read TOML file: %v", err)
+		}
+
+		// Note: go-toml/v2 uses single quotes for string values
+		contentStr := string(content)
+		assert.Contains(t, contentStr, "url = 'http://localhost:9999/updated'", "Should contain updated URL")
+		// Ensure there's only one mcp_servers entry (updated, not appended)
+		assert.Equal(t, 1, countOccurrences(contentStr, "[[mcp_servers]]"), "Should have only one server entry")
+
+		t.Cleanup(func() {
+			if err := os.RemoveAll(tempDir); err != nil {
+				t.Logf("Failed to remove temp dir: %v", err)
+			}
+		})
+	})
+
+	t.Run("AddSecondServerToExistingTOML", func(t *testing.T) {
+		t.Parallel()
+
+		uniqueId := uuid.New().String()
+		tempDir, configPath := setupExistingTestTOMLConfig(t, uniqueId)
+
+		tcu := TOMLConfigUpdater{
+			Path:            configPath,
+			ServersKey:      "mcp_servers",
+			IdentifierField: "name",
+			URLField:        "url",
+		}
+
+		// Add a new server
+		newServer := MCPServer{
+			Url:  "http://localhost:8888/new",
+			Type: "http",
+		}
+
+		err := tcu.Upsert("newServer", newServer)
+		if err != nil {
+			t.Fatalf("Failed to add new server to TOML config: %v", err)
+		}
+
+		// Verify both servers exist
+		content, err := os.ReadFile(configPath)
+		if err != nil {
+			t.Fatalf("Failed to read TOML file: %v", err)
+		}
+
+		// Note: go-toml/v2 uses single quotes for string values
+		contentStr := string(content)
+		assert.Equal(t, 2, countOccurrences(contentStr, "[[mcp_servers]]"), "Should have two server entries")
+		assert.Contains(t, contentStr, "name = 'existingServer'", "Should contain existing server")
+		assert.Contains(t, contentStr, "name = 'newServer'", "Should contain new server")
+
+		t.Cleanup(func() {
+			if err := os.RemoveAll(tempDir); err != nil {
+				t.Logf("Failed to remove temp dir: %v", err)
+			}
+		})
+	})
+
+	t.Run("PreserveOtherFieldsWhenUpserting", func(t *testing.T) {
+		t.Parallel()
+
+		uniqueId := uuid.New().String()
+		tempDir := t.TempDir()
+		configPath := filepath.Join(tempDir, fmt.Sprintf("config-%s.toml", uniqueId))
+
+		// Create a TOML file with extra top-level fields
+		initialConfig := `# Some comment
+version = "1.0"
+
+[settings]
+debug = true
+
+[[mcp_servers]]
+name = "existingServer"
+url = "http://localhost:8080"
+transport = "http"
+`
+		if err := os.WriteFile(configPath, []byte(initialConfig), 0600); err != nil {
+			t.Fatalf("Failed to write test TOML file: %v", err)
+		}
+
+		tcu := TOMLConfigUpdater{
+			Path:            configPath,
+			ServersKey:      "mcp_servers",
+			IdentifierField: "name",
+			URLField:        "url",
+		}
+
+		// Add a new server
+		newServer := MCPServer{
+			Url:  "http://localhost:9090/new",
+			Type: "http",
+		}
+
+		err := tcu.Upsert("newServer", newServer)
+		if err != nil {
+			t.Fatalf("Failed to add new server: %v", err)
+		}
+
+		// Verify other fields are preserved
+		content, err := os.ReadFile(configPath)
+		if err != nil {
+			t.Fatalf("Failed to read TOML file: %v", err)
+		}
+
+		// Note: go-toml/v2 uses single quotes for string values
+		contentStr := string(content)
+		assert.Contains(t, contentStr, "version =", "Should preserve version field")
+		assert.Contains(t, contentStr, "[settings]", "Should preserve settings section")
+		assert.Contains(t, contentStr, "debug =", "Should preserve debug setting")
+		assert.Contains(t, contentStr, "name = 'newServer'", "Should contain new server")
+
+		t.Cleanup(func() {
+			if err := os.RemoveAll(tempDir); err != nil {
+				t.Logf("Failed to remove temp dir: %v", err)
+			}
+		})
+	})
+}
+
+func TestTOMLConfigUpdaterRemove(t *testing.T) {
+	t.Parallel()
+
+	logger.Initialize()
+
+	t.Run("RemoveExistingServerFromTOML", func(t *testing.T) {
+		t.Parallel()
+
+		uniqueId := uuid.New().String()
+		tempDir, configPath := setupExistingTestTOMLConfig(t, uniqueId)
+
+		tcu := TOMLConfigUpdater{
+			Path:            configPath,
+			ServersKey:      "mcp_servers",
+			IdentifierField: "name",
+			URLField:        "url",
+		}
+
+		err := tcu.Remove("existingServer")
+		if err != nil {
+			t.Fatalf("Failed to remove server from TOML config: %v", err)
+		}
+
+		// Verify removal
+		content, err := os.ReadFile(configPath)
+		if err != nil {
+			t.Fatalf("Failed to read TOML file: %v", err)
+		}
+
+		contentStr := string(content)
+		assert.NotContains(t, contentStr, "existingServer", "Should not contain removed server")
+
+		t.Cleanup(func() {
+			if err := os.RemoveAll(tempDir); err != nil {
+				t.Logf("Failed to remove temp dir: %v", err)
+			}
+		})
+	})
+
+	t.Run("RemoveNonExistentServerFromTOML", func(t *testing.T) {
+		t.Parallel()
+
+		uniqueId := uuid.New().String()
+		tempDir, configPath := setupExistingTestTOMLConfig(t, uniqueId)
+
+		tcu := TOMLConfigUpdater{
+			Path:            configPath,
+			ServersKey:      "mcp_servers",
+			IdentifierField: "name",
+			URLField:        "url",
+		}
+
+		// Try to remove non-existent server
+		err := tcu.Remove("nonExistentServer")
+		if err != nil {
+			t.Fatalf("Should not error when removing non-existent server: %v", err)
+		}
+
+		// Verify existing server is still there
+		content, err := os.ReadFile(configPath)
+		if err != nil {
+			t.Fatalf("Failed to read TOML file: %v", err)
+		}
+
+		contentStr := string(content)
+		assert.Contains(t, contentStr, "existingServer", "Existing server should still exist")
+
+		t.Cleanup(func() {
+			if err := os.RemoveAll(tempDir); err != nil {
+				t.Logf("Failed to remove temp dir: %v", err)
+			}
+		})
+	})
+
+	t.Run("RemoveFromEmptyTOMLFile", func(t *testing.T) {
+		t.Parallel()
+
+		uniqueId := uuid.New().String()
+		tempDir, configPath := setupEmptyTestTOMLConfig(t, uniqueId)
+
+		tcu := TOMLConfigUpdater{
+			Path:            configPath,
+			ServersKey:      "mcp_servers",
+			IdentifierField: "name",
+			URLField:        "url",
+		}
+
+		// Try to remove from empty file
+		err := tcu.Remove("anyServer")
+		if err != nil {
+			t.Fatalf("Should not error when removing from empty file: %v", err)
+		}
+
+		t.Cleanup(func() {
+			if err := os.RemoveAll(tempDir); err != nil {
+				t.Logf("Failed to remove temp dir: %v", err)
+			}
+		})
+	})
+
+	t.Run("RemoveFromNonExistentFile", func(t *testing.T) {
+		t.Parallel()
+
+		tempDir := t.TempDir()
+		configPath := filepath.Join(tempDir, "nonexistent.toml")
+
+		tcu := TOMLConfigUpdater{
+			Path:            configPath,
+			ServersKey:      "mcp_servers",
+			IdentifierField: "name",
+			URLField:        "url",
+		}
+
+		// Try to remove from non-existent file
+		err := tcu.Remove("anyServer")
+		if err != nil {
+			t.Fatalf("Should not error when file doesn't exist: %v", err)
+		}
+	})
+}
+
+// setupEmptyTestTOMLConfig creates a temporary directory and an empty TOML config file for testing
+func setupEmptyTestTOMLConfig(t *testing.T, testName string) (string, string) {
+	t.Helper()
+
+	tempDir, err := os.MkdirTemp("", "toolhive-toml-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+
+	configPath := filepath.Join(tempDir, fmt.Sprintf("config-%s.toml", testName))
+
+	// Create an empty TOML file
+	if err := os.WriteFile(configPath, []byte(""), 0600); err != nil {
+		t.Fatalf("Failed to write empty TOML file: %v", err)
+	}
+
+	return tempDir, configPath
+}
+
+// setupExistingTestTOMLConfig creates a temporary directory and a TOML config file with existing data
+func setupExistingTestTOMLConfig(t *testing.T, testName string) (string, string) {
+	t.Helper()
+
+	tempDir, err := os.MkdirTemp("", "toolhive-toml-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+
+	configPath := filepath.Join(tempDir, fmt.Sprintf("config-%s.toml", testName))
+
+	// Create a TOML config with existing server using array-of-tables syntax
+	testConfig := fmt.Sprintf(`[[mcp_servers]]
+name = "existingServer"
+url = "http://localhost:8080/existing-%s"
+transport = "http"
+`, testName)
+
+	if err := os.WriteFile(configPath, []byte(testConfig), 0600); err != nil {
+		t.Fatalf("Failed to write test TOML file: %v", err)
+	}
+
+	return tempDir, configPath
+}
+
+// countOccurrences counts how many times substr appears in s
+func countOccurrences(s, substr string) int {
+	count := 0
+	idx := 0
+	for {
+		i := indexOf(s[idx:], substr)
+		if i == -1 {
+			break
+		}
+		count++
+		idx += i + len(substr)
+	}
+	return count
+}
+
+// indexOf returns the index of substr in s, or -1 if not found
+func indexOf(s, substr string) int {
+	for i := 0; i+len(substr) <= len(s); i++ {
+		if s[i:i+len(substr)] == substr {
+			return i
+		}
+	}
+	return -1
+}

--- a/pkg/client/config_test.go
+++ b/pkg/client/config_test.go
@@ -26,6 +26,7 @@ import (
 
 const testValidJSON = `{"mcpServers": {}, "mcp": {"servers": {}}}`
 const testValidYAML = `extensions: {}`
+const testValidTOML = ``
 
 // createMockClientConfigs creates a set of mock client configurations for testing
 func createMockClientConfigs() []mcpClientConfig {
@@ -534,9 +535,12 @@ func createTestConfigFilesWithConfigs(t *testing.T, homeDir string, clientConfig
 
 			// Choose the appropriate content based on the file extension
 			var content []byte
-			if cfg.Extension == YAML {
+			switch cfg.Extension {
+			case YAML:
 				content = []byte(testValidYAML)
-			} else {
+			case TOML:
+				content = []byte(testValidTOML)
+			case JSON:
 				content = []byte(testValidJSON)
 			}
 


### PR DESCRIPTION
## Summary
- Add TOML configuration file format support infrastructure with the array-of-tables (`[[section]]`) format
- This format is used by clients like Mistral Vibe
- Foundation PR for TOML support - nested tables format will follow in a separate PR

## Changes
- Added `TOML` extension constant and `TOMLStorageType` type with `TOMLStorageTypeArray` constant
- Added shared TOML helper functions: `tomlWithFileLock`, `readTOMLConfig`, `writeTOMLConfig`, `extractURLFromMCPServer`, `convertToAnySlice`
- Added `TOMLConfigUpdater` struct and methods for array-of-tables format
- Added helper functions `extractServersKeyFromConfig` and `extractURLLabelFromConfig`
- Updated `validateConfigFileFormat` to support TOML validation
- Updated `CreateClientConfig` to support TOML file creation
- Updated `retrieveConfigFileMetadata` to create TOML updaters
- Added comprehensive tests for `TOMLConfigUpdater`

🤖 Generated with [Claude Code](https://claude.com/claude-code)