### PR TITLE
Add omitempty to UserinfoEndpoint JSON tag

### DIFF
--- a/pkg/oauth/discovery.go
+++ b/pkg/oauth/discovery.go
@@ -38,9 +38,9 @@ type AuthorizationServerMetadata struct {
 	// IntrospectionEndpoint is the URL of the token introspection endpoint (OPTIONAL, RFC 7662).
 	IntrospectionEndpoint string `json:"introspection_endpoint,omitempty"`
 
-	// UserinfoEndpoint is the URL of the UserInfo endpoint (OPTIONAL, OIDC specific).
-	// Note: No omitempty to maintain backward compatibility with existing JSON serialization.
-	UserinfoEndpoint string `json:"userinfo_endpoint"`
+	// UserinfoEndpoint is the URL of the UserInfo endpoint (RECOMMENDED per OIDC Discovery, not in RFC 8414).
+	// Omitted from JSON when empty to avoid serializing an invalid URL value.
+	UserinfoEndpoint string `json:"userinfo_endpoint,omitempty"`
 
 	// ResponseTypesSupported lists the response types supported (RECOMMENDED).
 	ResponseTypesSupported []string `json:"response_types_supported,omitempty"`


### PR DESCRIPTION
The authserver does not implement a UserInfo endpoint: no /userinfo handler is registered and buildOAuthMetadata() never populates the field. Without omitempty the empty string was serialized into discovery documents, which is misleading and could cause clients to attempt requests against a non-existent endpoint.

Omitting the field is standards-compliant: userinfo_endpoint is not defined in RFC 8414 (OAuth 2.0 AS Metadata) and is only RECOMMENDED (not REQUIRED) by OIDC Discovery 1.0. Consumers in the codebase already guard with `if doc.UserinfoEndpoint != ""` before use.