### PR TITLE
Add shortNames to MCPServer CRD for consistency

### DIFF
--- a/cmd/thv-operator/api/v1alpha1/mcpserver_types.go
+++ b/cmd/thv-operator/api/v1alpha1/mcpserver_types.go
@@ -768,6 +768,7 @@ const (
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:resource:shortName=mcpserver;mcpservers
 //+kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.phase"
 //+kubebuilder:printcolumn:name="URL",type="string",JSONPath=".status.url"
 //+kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"

--- a/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpservers.yaml
+++ b/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpservers.yaml
@@ -11,6 +11,9 @@ spec:
     kind: MCPServer
     listKind: MCPServerList
     plural: mcpservers
+    shortNames:
+    - mcpserver
+    - mcpservers
     singular: mcpserver
   scope: Namespaced
   versions:

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpservers.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpservers.yaml
@@ -14,6 +14,9 @@ spec:
     kind: MCPServer
     listKind: MCPServerList
     plural: mcpservers
+    shortNames:
+    - mcpserver
+    - mcpservers
     singular: mcpserver
   scope: Namespaced
   versions:


### PR DESCRIPTION
## Summary
- Adds `shortNames` (`mcpserver`, `mcpservers`) to the MCPServer CRD
- Ensures consistency with other CRDs in the project (MCPGroup, VirtualMCPServer, MCPToolConfig, MCPExternalAuthConfig) which already have shortNames defined
