### PR TITLE
Add CEL-based AWS STS role mapper for claim-based IAM role selection

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.6
 require (
 	dario.cat/mergo v1.0.2
 	github.com/1password/onepassword-sdk-go v0.3.1
+	github.com/aws/aws-sdk-go-v2 v1.41.0
 	github.com/cedar-policy/cedar-go v1.4.1
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/charmbracelet/bubbletea v1.3.10
@@ -20,6 +21,7 @@ require (
 	github.com/go-jose/go-jose/v4 v4.1.3
 	github.com/go-logr/zapr v1.3.0
 	github.com/gofrs/flock v0.13.0
+	github.com/google/cel-go v0.27.0
 	github.com/google/go-cmp v0.7.0
 	github.com/google/go-containerregistry v0.20.7
 	github.com/google/uuid v1.6.0
@@ -68,9 +70,11 @@ require (
 
 require (
 	al.essio.dev/pkg/shellescape v1.6.0 // indirect
+	cel.dev/expr v0.25.1 // indirect
 	github.com/KyleBanks/depth v1.2.1 // indirect
 	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/ProtonMail/go-crypto v1.1.6 // indirect
+	github.com/antlr4-go/antlr/v4 v4.13.1 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/bahlo/generic-list-go v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 al.essio.dev/pkg/shellescape v1.6.0 h1:NxFcEqzFSEVCGN2yq7Huv/9hyCEGVa/TncnOOBBeXHA=
 al.essio.dev/pkg/shellescape v1.6.0/go.mod h1:6sIqp7X2P6mThCQ7twERpZTuigpr6KbZWtls1U8I890=
+cel.dev/expr v0.25.1 h1:1KrZg61W6TWSxuNZ37Xy49ps13NUovb66QLprthtwi4=
+cel.dev/expr v0.25.1/go.mod h1:hrXvqGP6G6gyx8UAHSHJ5RGk//1Oj5nXQ2NI02Nrsg4=
 cloud.google.com/go v0.121.6 h1:waZiuajrI28iAf40cWgycWNgaXPO06dupuS+sgibK6c=
 cloud.google.com/go v0.121.6/go.mod h1:coChdst4Ea5vUpiALcYKXEpR1S9ZgXbhEzzMcMR66vI=
 cloud.google.com/go/auth v0.18.0 h1:wnqy5hrv7p3k7cShwAU/Br3nzod7fxoqG+k0VZ+/Pk0=
@@ -51,6 +53,8 @@ github.com/adrg/xdg v0.5.3 h1:xRnxJXne7+oWDatRhR1JLnvuccuIeCoBu2rtuLqQB78=
 github.com/adrg/xdg v0.5.3/go.mod h1:nlTsY+NNiCBGCK2tpm09vRqfVzrc2fLmXGpBLF0zlTQ=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
+github.com/antlr4-go/antlr/v4 v4.13.1 h1:SqQKkuVZ+zWkMMNkjy5FZe5mr5WURWnlpmOuzYWrPrQ=
+github.com/antlr4-go/antlr/v4 v4.13.1/go.mod h1:GKmUxMtwp6ZgGwZSva4eWPC5mS6vUAmOABFgjdkM7Nw=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=
@@ -343,6 +347,8 @@ github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/google/btree v1.1.3 h1:CVpQJjYgC4VbzxeGVHfvZrv1ctoYCAI8vbl07Fcxlyg=
 github.com/google/btree v1.1.3/go.mod h1:qOPhT0dTNdNzV6Z/lhRX0YXUafgPLFUh+gZMl761Gm4=
+github.com/google/cel-go v0.27.0 h1:e7ih85+4qVrBuqQWTW4FKSqZYokVuc3HnhH5keboFTo=
+github.com/google/cel-go v0.27.0/go.mod h1:tTJ11FWqnhw5KKpnWpvW9CJC3Y9GK4EIS0WXnBbebzw=
 github.com/google/certificate-transparency-go v1.3.2 h1:9ahSNZF2o7SYMaKaXhAumVEzXB2QaayzII9C8rv7v+A=
 github.com/google/certificate-transparency-go v1.3.2/go.mod h1:H5FpMUaGa5Ab2+KCYsxg6sELw3Flkl7pGZzWdBoYLXs=
 github.com/google/gnostic-models v0.7.0 h1:qwTtogB15McXDaNqTZdzPJRHvaVJlAl+HVQnLmJEJxo=

--- a/pkg/auth/awssts/config.go
+++ b/pkg/auth/awssts/config.go
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package awssts provides AWS STS token exchange with SigV4 signing support.
+package awssts
+
+// MinSessionDuration is the minimum allowed session duration (AWS limit).
+const MinSessionDuration int32 = 900
+
+// MaxSessionDuration is the maximum allowed session duration (12 hours).
+const MaxSessionDuration int32 = 43200
+
+// defaultRoleClaim is the default JWT claim to use for role mapping.
+const defaultRoleClaim = "groups"
+
+// Config holds configuration for AWS STS token exchange.
+type Config struct {
+	// Region is the AWS region for STS and SigV4 signing.
+	Region string `json:"region" yaml:"region"`
+
+	// Service is the AWS service name for SigV4 signing (default: "aws-mcp").
+	Service string `json:"service" yaml:"service"`
+
+	// FallbackRoleArn is the IAM role ARN to assume when no role mapping matches.
+	FallbackRoleArn string `json:"fallback_role_arn,omitempty" yaml:"fallback_role_arn,omitempty"`
+
+	// RoleMappings maps JWT claim values to IAM roles with priority.
+	RoleMappings []RoleMapping `json:"role_mappings,omitempty" yaml:"role_mappings,omitempty"`
+
+	// RoleClaim is the JWT claim to use for role mapping (default: "groups").
+	RoleClaim string `json:"role_claim,omitempty" yaml:"role_claim,omitempty"`
+
+	// SessionDuration is the duration in seconds for assumed role credentials.
+	SessionDuration int32 `json:"session_duration,omitempty" yaml:"session_duration,omitempty"`
+
+	// SessionNameClaim is the JWT claim to use for role session name (default: "sub").
+	SessionNameClaim string `json:"session_name_claim,omitempty" yaml:"session_name_claim,omitempty"`
+}
+
+// GetRoleClaim returns the configured role claim or the default.
+func (c *Config) GetRoleClaim() string {
+	if c.RoleClaim != "" {
+		return c.RoleClaim
+	}
+	return defaultRoleClaim
+}
+
+// RoleMapping maps a JWT claim value or CEL expression to an IAM role with explicit priority.
+type RoleMapping struct {
+	// Claim is the simple claim value to match (e.g., group name).
+	// Internally compiles to a CEL expression: "<claim_value>" in claims["<role_claim>"]
+	// Mutually exclusive with Matcher.
+	Claim string `json:"claim,omitempty" yaml:"claim,omitempty"`
+
+	// Matcher is a CEL expression for complex matching against JWT claims.
+	// The expression has access to a "claims" variable containing all JWT claims.
+	// Examples:
+	//   - "admins" in claims["groups"]
+	//   - claims["sub"] == "user123" && !("act" in claims)
+	// Mutually exclusive with Claim.
+	Matcher string `json:"matcher,omitempty" yaml:"matcher,omitempty"`
+
+	// RoleArn is the IAM role ARN to assume when this mapping matches.
+	RoleArn string `json:"role_arn" yaml:"role_arn"`
+
+	// Priority determines selection order (lower number = higher priority).
+	// When multiple mappings match, the one with the lowest priority is selected.
+	Priority int `json:"priority" yaml:"priority"`
+}

--- a/pkg/auth/awssts/errors.go
+++ b/pkg/auth/awssts/errors.go
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package awssts
+
+import "errors"
+
+// Sentinel errors for AWS STS operations.
+var (
+	// ErrNoRoleMapping is returned when no role mapping matches the JWT claims.
+	ErrNoRoleMapping = errors.New("no role mapping found for JWT claims")
+
+	// ErrInvalidRoleArn is returned when the role ARN format is invalid.
+	ErrInvalidRoleArn = errors.New("invalid IAM role ARN format")
+
+	// ErrMissingRegion is returned when region is not configured.
+	ErrMissingRegion = errors.New("AWS region is required")
+
+	// ErrMissingRoleConfig is returned when neither role_arn nor role_mappings is configured.
+	ErrMissingRoleConfig = errors.New("either role_arn or role_mappings must be configured")
+
+	// ErrInvalidRoleMapping is returned when a role mapping has invalid configuration.
+	ErrInvalidRoleMapping = errors.New("invalid role mapping configuration")
+
+	// ErrInvalidMatcher is returned when a CEL matcher expression is invalid.
+	ErrInvalidMatcher = errors.New("invalid CEL matcher expression")
+)

--- a/pkg/auth/awssts/role_mapper.go
+++ b/pkg/auth/awssts/role_mapper.go
@@ -1,0 +1,284 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package awssts
+
+import (
+	"cmp"
+	"fmt"
+	"regexp"
+	"slices"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
+	celgo "github.com/google/cel-go/cel"
+
+	"github.com/stacklok/toolhive-core/cel"
+	"github.com/stacklok/toolhive/pkg/logger"
+)
+
+// safeClaimValueRegex defines the whitelist of characters allowed in JWT claim values
+// used for CEL expression interpolation. This prevents CEL injection while covering
+// legitimate group/role claim values from major identity providers (Azure AD, Okta,
+// Auth0, Google Workspace, Keycloak, LDAP).
+//
+// Blocked characters that enable CEL injection: " \ ( ) | & ` $ { } [ ] < > ^ %
+var safeClaimValueRegex = regexp.MustCompile(`^[a-zA-Z0-9@.:,;/\-_=+*#!?'~ ]+$`)
+
+// newClaimsEngine creates a CEL engine configured for evaluating JWT claims expressions.
+// The claims are accessible via the "claims" variable as a map[string]any.
+func newClaimsEngine() *cel.Engine {
+	return cel.NewEngine(
+		celgo.Variable("claims", celgo.MapType(celgo.StringType, celgo.DynType)),
+	)
+}
+
+// ValidateRoleArn validates that the given string is a valid IAM role ARN.
+// It accepts ARNs from all AWS partitions (aws, aws-cn, aws-us-gov) and
+// supports role paths (e.g., arn:aws:iam::123456789012:role/service-role/MyRole).
+func ValidateRoleArn(roleArn string) error {
+	if roleArn == "" {
+		return fmt.Errorf("%w: ARN is empty", ErrInvalidRoleArn)
+	}
+
+	// Use AWS SDK to parse the ARN
+	parsed, err := arn.Parse(roleArn)
+	if err != nil {
+		return fmt.Errorf("%w: %s", ErrInvalidRoleArn, roleArn)
+	}
+
+	// Verify it's an IAM role
+	if parsed.Service != "iam" {
+		return fmt.Errorf("%w: not an IAM ARN: %s", ErrInvalidRoleArn, roleArn)
+	}
+
+	// Resource should start with "role/"
+	if !strings.HasPrefix(parsed.Resource, "role/") {
+		return fmt.Errorf("%w: not a role ARN: %s", ErrInvalidRoleArn, roleArn)
+	}
+
+	// Verify account ID is present and valid (12 digits)
+	if len(parsed.AccountID) != 12 {
+		return fmt.Errorf("%w: invalid account ID: %s", ErrInvalidRoleArn, roleArn)
+	}
+
+	return nil
+}
+
+// compiledMapping holds a role mapping with its compiled CEL expression.
+type compiledMapping struct {
+	roleArn  string
+	priority int
+	expr     *cel.CompiledExpression
+}
+
+// RoleMapper handles mapping JWT claims to IAM roles with priority-based selection.
+// It uses CEL expressions for flexible claim matching.
+type RoleMapper struct {
+	config   *Config
+	mappings []compiledMapping
+}
+
+// NewRoleMapper creates a new RoleMapper with the provided configuration.
+// It validates the configuration and compiles all CEL expressions during construction.
+// Returns an error if the configuration is invalid or any expression fails to compile.
+//
+// ValidateConfig is called internally, so callers do not need to call both.
+func NewRoleMapper(cfg *Config) (*RoleMapper, error) {
+	if err := ValidateConfig(cfg); err != nil {
+		return nil, fmt.Errorf("invalid config: %w", err)
+	}
+
+	engine := newClaimsEngine()
+	rm := &RoleMapper{
+		config:   cfg,
+		mappings: make([]compiledMapping, 0, len(cfg.RoleMappings)),
+	}
+
+	// Compile all role mappings
+	for i, mapping := range cfg.RoleMappings {
+		expr, err := compileMapping(engine, cfg.GetRoleClaim(), mapping)
+		if err != nil {
+			return nil, fmt.Errorf("role mapping at index %d: %w", i, err)
+		}
+
+		rm.mappings = append(rm.mappings, compiledMapping{
+			roleArn:  mapping.RoleArn,
+			priority: mapping.Priority,
+			expr:     expr,
+		})
+	}
+
+	return rm, nil
+}
+
+// compileMapping converts a RoleMapping to a compiled CEL expression.
+func compileMapping(engine *cel.Engine, roleClaim string, mapping RoleMapping) (*cel.CompiledExpression, error) {
+	celExpr := buildCELExpression(mapping, roleClaim)
+
+	expr, err := engine.Compile(celExpr)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrInvalidMatcher, err)
+	}
+
+	return expr, nil
+}
+
+// SelectRole selects the appropriate IAM role based on JWT claims.
+// It returns the role ARN to assume based on the following logic:
+//  1. If no role mappings are configured, return the FallbackRoleArn
+//  2. Evaluate each mapping's CEL expression against the claims
+//  3. Collect all matching mappings
+//  4. Sort matches by priority (lower number = higher priority)
+//  5. Return the highest priority match
+//  6. If no matches found, fall back to the FallbackRoleArn
+func (rm *RoleMapper) SelectRole(claims map[string]any) (string, error) {
+	// If no role mappings configured, use default role
+	if len(rm.mappings) == 0 {
+		if rm.config.FallbackRoleArn == "" {
+			return "", ErrMissingRoleConfig
+		}
+		return rm.config.FallbackRoleArn, nil
+	}
+
+	// Build CEL evaluation context
+	ctx := map[string]any{"claims": claims}
+
+	// Find all matching mappings
+	var matches []compiledMapping
+	for _, mapping := range rm.mappings {
+		match, err := mapping.expr.EvaluateBool(ctx)
+		if err != nil {
+			logger.Debugw("CEL expression evaluation failed, skipping mapping",
+				"role_arn", mapping.roleArn, "error", err)
+			continue
+		}
+
+		if match {
+			matches = append(matches, mapping)
+		}
+	}
+
+	// If no matches, fall back to default role
+	if len(matches) == 0 {
+		if rm.config.FallbackRoleArn == "" {
+			return "", fmt.Errorf("%w: no mapping matched for the provided claims", ErrNoRoleMapping)
+		}
+		return rm.config.FallbackRoleArn, nil
+	}
+
+	// Sort by priority (lower number = higher priority).
+	// SortStableFunc preserves configuration order as a tie-breaker
+	// when priorities are equal.
+	slices.SortStableFunc(matches, func(a, b compiledMapping) int {
+		return cmp.Compare(a.priority, b.priority)
+	})
+
+	// Return the highest priority match (lowest priority number)
+	return matches[0].roleArn, nil
+}
+
+// ValidateConfig validates the AWS STS configuration structure.
+// It checks that required fields are present, ARNs are well-formed, claim values
+// are safe for CEL interpolation, and session duration is within bounds.
+//
+// This performs structural validation only — CEL expression compilation is handled
+// by NewRoleMapper. It is safe to call standalone for early validation at config
+// load time. NewRoleMapper calls this internally, so callers do not need to call both.
+func ValidateConfig(cfg *Config) error {
+	if cfg == nil {
+		return fmt.Errorf("config is nil")
+	}
+
+	// Region is required
+	if cfg.Region == "" {
+		return ErrMissingRegion
+	}
+
+	// Either FallbackRoleArn or RoleMappings must be configured
+	if cfg.FallbackRoleArn == "" && len(cfg.RoleMappings) == 0 {
+		return ErrMissingRoleConfig
+	}
+
+	// Validate FallbackRoleArn if provided
+	if cfg.FallbackRoleArn != "" {
+		if err := ValidateRoleArn(cfg.FallbackRoleArn); err != nil {
+			return err
+		}
+	}
+
+	// Validate RoleClaim if provided (it's interpolated into CEL expressions)
+	if cfg.RoleClaim != "" {
+		if err := validateClaimValue(cfg.RoleClaim); err != nil {
+			return fmt.Errorf("role_claim: %w", err)
+		}
+	}
+
+	// Validate all role mappings (structural checks only)
+	for i, mapping := range cfg.RoleMappings {
+		if err := validateRoleMapping(i, mapping); err != nil {
+			return err
+		}
+	}
+
+	// Validate session duration if specified
+	if cfg.SessionDuration != 0 {
+		if cfg.SessionDuration < MinSessionDuration {
+			return fmt.Errorf("session duration %d is below minimum %d seconds", cfg.SessionDuration, MinSessionDuration)
+		}
+		if cfg.SessionDuration > MaxSessionDuration {
+			return fmt.Errorf("session duration %d exceeds maximum %d seconds", cfg.SessionDuration, MaxSessionDuration)
+		}
+	}
+
+	return nil
+}
+
+// validateRoleMapping validates the structural properties of a single role mapping.
+func validateRoleMapping(index int, mapping RoleMapping) error {
+	// Exactly one of Claim or Matcher must be set
+	if mapping.Claim == "" && mapping.Matcher == "" {
+		return fmt.Errorf("%w at index %d: either claim or matcher must be set", ErrInvalidRoleMapping, index)
+	}
+	if mapping.Claim != "" && mapping.Matcher != "" {
+		return fmt.Errorf("%w at index %d: claim and matcher are mutually exclusive", ErrInvalidRoleMapping, index)
+	}
+
+	// Validate claim value for safe CEL interpolation
+	if mapping.Claim != "" {
+		if err := validateClaimValue(mapping.Claim); err != nil {
+			return fmt.Errorf("role mapping at index %d: %w", index, err)
+		}
+	}
+
+	// RoleArn is required
+	if mapping.RoleArn == "" {
+		return fmt.Errorf("role mapping at index %d has empty role ARN", index)
+	}
+
+	// Validate the role ARN
+	if err := ValidateRoleArn(mapping.RoleArn); err != nil {
+		return fmt.Errorf("role mapping at index %d: %w", index, err)
+	}
+
+	return nil
+}
+
+// buildCELExpression returns the CEL expression for a role mapping.
+// If the mapping has a Matcher, it is used directly. Otherwise, a CEL expression
+// is built from the Claim value: "claim_value" in claims["role_claim"].
+func buildCELExpression(mapping RoleMapping, roleClaim string) string {
+	if mapping.Matcher != "" {
+		return mapping.Matcher
+	}
+	return fmt.Sprintf(`"%s" in claims["%s"]`, mapping.Claim, roleClaim)
+}
+
+// validateClaimValue checks that a claim value is safe for CEL expression interpolation.
+// It rejects values containing characters that could alter CEL expression semantics.
+func validateClaimValue(value string) error {
+	if !safeClaimValueRegex.MatchString(value) {
+		return fmt.Errorf("%w: claim value %q contains characters unsafe for CEL interpolation", ErrInvalidRoleMapping, value)
+	}
+	return nil
+}

--- a/pkg/auth/awssts/role_mapper_test.go
+++ b/pkg/auth/awssts/role_mapper_test.go
@@ -1,0 +1,595 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package awssts_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stacklok/toolhive/pkg/auth/awssts"
+)
+
+func TestValidateRoleArn(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		roleArn string
+		wantErr bool
+	}{
+		// Valid ARNs
+		{
+			name:    "valid standard role",
+			roleArn: "arn:aws:iam::123456789012:role/MyRole",
+			wantErr: false,
+		},
+		{
+			name:    "valid role with path",
+			roleArn: "arn:aws:iam::123456789012:role/service-role/MyRole",
+			wantErr: false,
+		},
+		{
+			name:    "valid china partition",
+			roleArn: "arn:aws-cn:iam::123456789012:role/MyRole",
+			wantErr: false,
+		},
+		// Invalid ARNs
+		{
+			name:    "empty string",
+			roleArn: "",
+			wantErr: true,
+		},
+		{
+			name:    "invalid format",
+			roleArn: "not-an-arn",
+			wantErr: true,
+		},
+		{
+			name:    "non-IAM service",
+			roleArn: "arn:aws:s3:::my-bucket",
+			wantErr: true,
+		},
+		{
+			name:    "IAM user instead of role",
+			roleArn: "arn:aws:iam::123456789012:user/MyUser",
+			wantErr: true,
+		},
+		{
+			name:    "invalid account ID length",
+			roleArn: "arn:aws:iam::12345:role/MyRole",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := awssts.ValidateRoleArn(tt.roleArn)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, awssts.ErrInvalidRoleArn)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestNewRoleMapper(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		cfg       *awssts.Config
+		wantErr   bool
+		wantErrIs error
+	}{
+		{
+			name:    "nil config returns error",
+			cfg:     nil,
+			wantErr: true,
+		},
+		{
+			name: "simple claim mapping",
+			cfg: &awssts.Config{
+				Region:    "us-east-1",
+				RoleClaim: "groups",
+				RoleMappings: []awssts.RoleMapping{
+					{
+						Claim:    "admins",
+						RoleArn:  "arn:aws:iam::123456789012:role/AdminRole",
+						Priority: 1,
+					},
+				},
+			},
+		},
+		{
+			name: "invalid CEL matcher",
+			cfg: &awssts.Config{
+				Region: "us-east-1",
+				RoleMappings: []awssts.RoleMapping{
+					{
+						Matcher:  `invalid syntax here`,
+						RoleArn:  "arn:aws:iam::123456789012:role/AdminRole",
+						Priority: 1,
+					},
+				},
+			},
+			wantErr:   true,
+			wantErrIs: awssts.ErrInvalidMatcher,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			rm, err := awssts.NewRoleMapper(tt.cfg)
+			if !tt.wantErr {
+				require.NoError(t, err)
+				assert.NotNil(t, rm)
+				return
+			}
+			require.Error(t, err)
+			if tt.wantErrIs != nil {
+				assert.ErrorIs(t, err, tt.wantErrIs)
+			}
+			assert.Nil(t, rm)
+		})
+	}
+}
+
+func TestRoleMapper_SelectRole(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		cfg      *awssts.Config
+		claims   map[string]any
+		expected string
+		wantErr  error
+	}{
+		// Simple claim matching with default fallback
+		{
+			name: "match admins group",
+			cfg: &awssts.Config{
+				Region:          "us-east-1",
+				RoleClaim:       "groups",
+				FallbackRoleArn: "arn:aws:iam::123456789012:role/DefaultRole",
+				RoleMappings: []awssts.RoleMapping{
+					{Claim: "admins", RoleArn: "arn:aws:iam::123456789012:role/AdminRole", Priority: 1},
+					{Claim: "developers", RoleArn: "arn:aws:iam::123456789012:role/DevRole", Priority: 2},
+				},
+			},
+			claims:   map[string]any{"sub": "user123", "groups": []any{"users", "admins"}},
+			expected: "arn:aws:iam::123456789012:role/AdminRole",
+		},
+		{
+			name: "priority selection when multiple match",
+			cfg: &awssts.Config{
+				Region:          "us-east-1",
+				RoleClaim:       "groups",
+				FallbackRoleArn: "arn:aws:iam::123456789012:role/DefaultRole",
+				RoleMappings: []awssts.RoleMapping{
+					{Claim: "admins", RoleArn: "arn:aws:iam::123456789012:role/AdminRole", Priority: 1},
+					{Claim: "developers", RoleArn: "arn:aws:iam::123456789012:role/DevRole", Priority: 2},
+				},
+			},
+			claims:   map[string]any{"sub": "user123", "groups": []any{"admins", "developers"}},
+			expected: "arn:aws:iam::123456789012:role/AdminRole",
+		},
+		{
+			name: "fallback to default when no match",
+			cfg: &awssts.Config{
+				Region:          "us-east-1",
+				RoleClaim:       "groups",
+				FallbackRoleArn: "arn:aws:iam::123456789012:role/DefaultRole",
+				RoleMappings: []awssts.RoleMapping{
+					{Claim: "admins", RoleArn: "arn:aws:iam::123456789012:role/AdminRole", Priority: 1},
+				},
+			},
+			claims:   map[string]any{"sub": "user123", "groups": []any{"users"}},
+			expected: "arn:aws:iam::123456789012:role/DefaultRole",
+		},
+		{
+			name: "missing claim falls back to default",
+			cfg: &awssts.Config{
+				Region:          "us-east-1",
+				RoleClaim:       "groups",
+				FallbackRoleArn: "arn:aws:iam::123456789012:role/DefaultRole",
+				RoleMappings: []awssts.RoleMapping{
+					{Claim: "admins", RoleArn: "arn:aws:iam::123456789012:role/AdminRole", Priority: 1},
+				},
+			},
+			claims:   map[string]any{"sub": "user123"},
+			expected: "arn:aws:iam::123456789012:role/DefaultRole",
+		},
+		{
+			name: "no default role without match returns error",
+			cfg: &awssts.Config{
+				Region:    "us-east-1",
+				RoleClaim: "groups",
+				RoleMappings: []awssts.RoleMapping{
+					{Claim: "admins", RoleArn: "arn:aws:iam::123456789012:role/AdminRole", Priority: 1},
+				},
+			},
+			claims:  map[string]any{"sub": "user123", "groups": []any{"users"}},
+			wantErr: awssts.ErrNoRoleMapping,
+		},
+		// No mappings configured
+		{
+			name: "no mappings returns default role",
+			cfg: &awssts.Config{
+				Region:          "us-east-1",
+				FallbackRoleArn: "arn:aws:iam::123456789012:role/DefaultRole",
+			},
+			claims:   map[string]any{"sub": "user123"},
+			expected: "arn:aws:iam::123456789012:role/DefaultRole",
+		},
+		// Equal priority preserves config order
+		{
+			name: "equal priority preserves config order",
+			cfg: &awssts.Config{
+				Region:    "us-east-1",
+				RoleClaim: "groups",
+				RoleMappings: []awssts.RoleMapping{
+					{Claim: "group-a", RoleArn: "arn:aws:iam::123456789012:role/RoleA", Priority: 1},
+					{Claim: "group-b", RoleArn: "arn:aws:iam::123456789012:role/RoleB", Priority: 1},
+				},
+			},
+			claims:   map[string]any{"groups": []any{"group-a", "group-b"}},
+			expected: "arn:aws:iam::123456789012:role/RoleA",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			rm, err := awssts.NewRoleMapper(tt.cfg)
+			require.NoError(t, err)
+
+			role, err := rm.SelectRole(tt.claims)
+			if tt.wantErr != nil {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expected, role)
+			}
+		})
+	}
+}
+
+func TestRoleMapper_SelectRole_CELMatcher(t *testing.T) {
+	t.Parallel()
+
+	cfg := &awssts.Config{
+		Region:          "us-east-1",
+		FallbackRoleArn: "arn:aws:iam::123456789012:role/DefaultRole",
+		RoleMappings: []awssts.RoleMapping{
+			{
+				Matcher:  `"admins" in claims["groups"] && !("act" in claims)`,
+				RoleArn:  "arn:aws:iam::123456789012:role/AdminDirectRole",
+				Priority: 1,
+			},
+			{
+				Matcher:  `"admins" in claims["groups"]`,
+				RoleArn:  "arn:aws:iam::123456789012:role/AdminRole",
+				Priority: 2,
+			},
+			{
+				Matcher:  `claims["sub"].startsWith("service-")`,
+				RoleArn:  "arn:aws:iam::123456789012:role/ServiceRole",
+				Priority: 3,
+			},
+		},
+	}
+
+	rm, err := awssts.NewRoleMapper(cfg)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name     string
+		claims   map[string]any
+		expected string
+	}{
+		{
+			name: "admin direct access (no agent delegation)",
+			claims: map[string]any{
+				"sub":    "user123",
+				"groups": []any{"admins"},
+			},
+			expected: "arn:aws:iam::123456789012:role/AdminDirectRole",
+		},
+		{
+			name: "admin with agent delegation falls back",
+			claims: map[string]any{
+				"sub":    "user123",
+				"groups": []any{"admins"},
+				"act": map[string]any{
+					"sub": "agent456",
+				},
+			},
+			expected: "arn:aws:iam::123456789012:role/AdminRole",
+		},
+		{
+			name: "service account",
+			claims: map[string]any{
+				"sub":    "service-worker",
+				"groups": []any{"services"},
+			},
+			expected: "arn:aws:iam::123456789012:role/ServiceRole",
+		},
+		{
+			name: "no match falls back to default",
+			claims: map[string]any{
+				"sub":    "user123",
+				"groups": []any{"users"},
+			},
+			expected: "arn:aws:iam::123456789012:role/DefaultRole",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			role, err := rm.SelectRole(tt.claims)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, role)
+		})
+	}
+}
+
+func TestValidateConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		cfg       *awssts.Config
+		wantErr   bool
+		wantErrIs error
+	}{
+		{
+			name:    "nil config",
+			cfg:     nil,
+			wantErr: true,
+		},
+		{
+			name: "missing region",
+			cfg: &awssts.Config{
+				FallbackRoleArn: "arn:aws:iam::123456789012:role/MyRole",
+			},
+			wantErr:   true,
+			wantErrIs: awssts.ErrMissingRegion,
+		},
+		{
+			name: "missing both role_arn and role_mappings",
+			cfg: &awssts.Config{
+				Region: "us-east-1",
+			},
+			wantErr:   true,
+			wantErrIs: awssts.ErrMissingRoleConfig,
+		},
+		{
+			name: "invalid default role ARN",
+			cfg: &awssts.Config{
+				Region:          "us-east-1",
+				FallbackRoleArn: "invalid-arn",
+			},
+			wantErr:   true,
+			wantErrIs: awssts.ErrInvalidRoleArn,
+		},
+		{
+			name: "valid with default role only",
+			cfg: &awssts.Config{
+				Region:          "us-east-1",
+				FallbackRoleArn: "arn:aws:iam::123456789012:role/DefaultRole",
+			},
+		},
+		{
+			name: "valid with simple claim mapping",
+			cfg: &awssts.Config{
+				Region: "us-east-1",
+				RoleMappings: []awssts.RoleMapping{
+					{
+						Claim:    "admins",
+						RoleArn:  "arn:aws:iam::123456789012:role/AdminRole",
+						Priority: 1,
+					},
+				},
+			},
+		},
+		{
+			name: "mapping with both claim and matcher",
+			cfg: &awssts.Config{
+				Region: "us-east-1",
+				RoleMappings: []awssts.RoleMapping{
+					{
+						Claim:    "admins",
+						Matcher:  `"admins" in claims["groups"]`,
+						RoleArn:  "arn:aws:iam::123456789012:role/AdminRole",
+						Priority: 1,
+					},
+				},
+			},
+			wantErr:   true,
+			wantErrIs: awssts.ErrInvalidRoleMapping,
+		},
+		{
+			name: "mapping with neither claim nor matcher",
+			cfg: &awssts.Config{
+				Region: "us-east-1",
+				RoleMappings: []awssts.RoleMapping{
+					{
+						RoleArn:  "arn:aws:iam::123456789012:role/AdminRole",
+						Priority: 1,
+					},
+				},
+			},
+			wantErr:   true,
+			wantErrIs: awssts.ErrInvalidRoleMapping,
+		},
+		{
+			name: "mapping with empty role ARN",
+			cfg: &awssts.Config{
+				Region: "us-east-1",
+				RoleMappings: []awssts.RoleMapping{
+					{
+						Claim:    "admins",
+						RoleArn:  "",
+						Priority: 1,
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "mapping with invalid role ARN",
+			cfg: &awssts.Config{
+				Region: "us-east-1",
+				RoleMappings: []awssts.RoleMapping{
+					{
+						Claim:    "admins",
+						RoleArn:  "invalid-arn",
+						Priority: 1,
+					},
+				},
+			},
+			wantErr:   true,
+			wantErrIs: awssts.ErrInvalidRoleArn,
+		},
+		{
+			name: "session duration below minimum",
+			cfg: &awssts.Config{
+				Region:          "us-east-1",
+				FallbackRoleArn: "arn:aws:iam::123456789012:role/DefaultRole",
+				SessionDuration: 100,
+			},
+			wantErr: true,
+		},
+		{
+			name: "session duration above maximum",
+			cfg: &awssts.Config{
+				Region:          "us-east-1",
+				FallbackRoleArn: "arn:aws:iam::123456789012:role/DefaultRole",
+				SessionDuration: 50000,
+			},
+			wantErr: true,
+		},
+		{
+			name: "claim with CEL injection characters rejected",
+			cfg: &awssts.Config{
+				Region: "us-east-1",
+				RoleMappings: []awssts.RoleMapping{
+					{
+						Claim:    `") || true || ("`,
+						RoleArn:  "arn:aws:iam::123456789012:role/AdminRole",
+						Priority: 1,
+					},
+				},
+			},
+			wantErr:   true,
+			wantErrIs: awssts.ErrInvalidRoleMapping,
+		},
+		{
+			name: "role_claim with unsafe characters rejected",
+			cfg: &awssts.Config{
+				Region:    "us-east-1",
+				RoleClaim: `groups"])||true`,
+				RoleMappings: []awssts.RoleMapping{
+					{Claim: "admins", RoleArn: "arn:aws:iam::123456789012:role/AdminRole", Priority: 1},
+				},
+			},
+			wantErr:   true,
+			wantErrIs: awssts.ErrInvalidRoleMapping,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := awssts.ValidateConfig(tt.cfg)
+			if !tt.wantErr {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			if tt.wantErrIs != nil {
+				assert.ErrorIs(t, err, tt.wantErrIs)
+			}
+		})
+	}
+}
+
+func TestRoleMapper_Concurrency(t *testing.T) {
+	t.Parallel()
+
+	cfg := &awssts.Config{
+		Region:          "us-east-1",
+		RoleClaim:       "groups",
+		FallbackRoleArn: "arn:aws:iam::123456789012:role/DefaultRole",
+		RoleMappings: []awssts.RoleMapping{
+			{
+				Claim:    "admins",
+				RoleArn:  "arn:aws:iam::123456789012:role/AdminRole",
+				Priority: 1,
+			},
+			{
+				Claim:    "developers",
+				RoleArn:  "arn:aws:iam::123456789012:role/DevRole",
+				Priority: 2,
+			},
+		},
+	}
+
+	rm, err := awssts.NewRoleMapper(cfg)
+	require.NoError(t, err)
+
+	// Run concurrent role selections
+	const numGoroutines = 100
+	results := make(chan string, numGoroutines)
+	errs := make(chan error, numGoroutines)
+
+	for i := 0; i < numGoroutines; i++ {
+		go func(i int) {
+			var groups []any
+			switch i % 3 {
+			case 0:
+				groups = []any{"admins"}
+			case 1:
+				groups = []any{"developers"}
+			case 2:
+				groups = []any{"users"}
+			}
+
+			claims := map[string]any{
+				"sub":    "user" + string(rune('0'+i%10)),
+				"groups": groups,
+			}
+
+			role, err := rm.SelectRole(claims)
+			if err != nil {
+				errs <- err
+				return
+			}
+			results <- role
+		}(i)
+	}
+
+	// Collect results - all should succeed
+	for i := 0; i < numGoroutines; i++ {
+		select {
+		case err := <-errs:
+			t.Fatalf("unexpected error: %v", err)
+		case role := <-results:
+			// Verify role is one of the expected values
+			assert.Contains(t, []string{
+				"arn:aws:iam::123456789012:role/AdminRole",
+				"arn:aws:iam::123456789012:role/DevRole",
+				"arn:aws:iam::123456789012:role/DefaultRole",
+			}, role)
+		}
+	}
+}


### PR DESCRIPTION
Implement a role mapper that selects IAM roles based on JWT claims using CEL expressions with priority-based selection. The mapper supports two configuration modes: a simple claim syntax where a value like "admins" is checked for membership in a configurable claim (defaulting to "groups"), and a full CEL matcher syntax for complex expressions such as agent delegation checks using the RFC 7519 "act" claim. All CEL expressions are compiled at configuration load time for fail-fast validation, claim values are validated against a safe-character regex to prevent CEL injection, and role ARNs are validated using the AWS SDK. When multiple mappings match, the one with the lowest priority number wins, with configuration order as a tie-breaker. A fallback role ARN can be configured for when no mapping matches.

This is the first in a series of PRs that add AWS STS authentication to ToolHive, enabling MCP servers to authenticate with AWS services by exchanging incoming OIDC tokens for temporary AWS credentials via STS AssumeRoleWithWebIdentity. Subsequent PRs then add token exchange with SigV4 request signing, credential caching, HTTP middleware integration for the CLI runner, operator CRD support via MCPExternalAuthConfig, and user-facing documentation. This PR provides the claim-to-role mapping foundation that all subsequent layers depend on.

Fixes: #3567