### PR TITLE
Align authserver DCR client scopes with discovery scopes_supported

### DIFF
--- a/pkg/authserver/config.go
+++ b/pkg/authserver/config.go
@@ -13,6 +13,7 @@ import (
 
 	servercrypto "github.com/stacklok/toolhive/pkg/authserver/server/crypto"
 	"github.com/stacklok/toolhive/pkg/authserver/server/keys"
+	"github.com/stacklok/toolhive/pkg/authserver/server/registration"
 	"github.com/stacklok/toolhive/pkg/authserver/upstream"
 	"github.com/stacklok/toolhive/pkg/logger"
 	"github.com/stacklok/toolhive/pkg/networking"
@@ -416,9 +417,7 @@ func (c *Config) applyDefaults() error {
 			"warning", "JWTs will be invalid after restart")
 	}
 	if len(c.ScopesSupported) == 0 {
-		// Default to minimal OIDC scopes per MCP specification best practices.
-		// "openid" is required for OIDC, "offline_access" enables refresh tokens.
-		c.ScopesSupported = []string{"openid", "offline_access"}
+		c.ScopesSupported = registration.DefaultScopes
 		logger.Debugw("applied default scopes_supported", "scopes", c.ScopesSupported)
 	}
 	return nil

--- a/pkg/authserver/server/handlers/dcr.go
+++ b/pkg/authserver/server/handlers/dcr.go
@@ -59,13 +59,16 @@ func (h *Handler) RegisterClientHandler(w http.ResponseWriter, req *http.Request
 	// Generate client ID
 	clientID := uuid.NewString()
 
-	// Create fosite client using factory
+	// Create fosite client using factory.
+	// Use the server's advertised scopes so DCR clients can request any scope
+	// listed in scopes_supported. This keeps discovery and DCR consistent.
 	fositeClient, err := registration.New(registration.Config{
 		ID:            clientID,
 		RedirectURIs:  validated.RedirectURIs,
 		Public:        true,
 		GrantTypes:    validated.GrantTypes,
 		ResponseTypes: validated.ResponseTypes,
+		Scopes:        h.config.ScopesSupported,
 	})
 	if err != nil {
 		logger.Errorw("failed to create client", "error", err)

--- a/pkg/authserver/server/handlers/dcr_test.go
+++ b/pkg/authserver/server/handlers/dcr_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	"github.com/stacklok/toolhive/pkg/authserver/server"
 	"github.com/stacklok/toolhive/pkg/authserver/server/registration"
 	"github.com/stacklok/toolhive/pkg/authserver/storage/mocks"
 )
@@ -80,7 +81,7 @@ func TestRegisterClientHandler(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			stor := mocks.NewMockStorage(ctrl)
 			stor.EXPECT().RegisterClient(gomock.Any(), gomock.Any()).Return(tc.storageErr).AnyTimes()
-			handler := &Handler{storage: stor}
+			handler := &Handler{storage: stor, config: &server.AuthorizationServerConfig{}}
 
 			var body []byte
 			if s, ok := tc.requestBody.(string); ok {
@@ -129,7 +130,7 @@ func TestRegisterClientHandler_ClientIsStored(t *testing.T) {
 			return nil
 		})
 
-	handler := &Handler{storage: stor}
+	handler := &Handler{storage: stor, config: &server.AuthorizationServerConfig{}}
 
 	reqBody, err := json.Marshal(registration.DCRRequest{
 		RedirectURIs: []string{"http://127.0.0.1:8080/callback"},

--- a/pkg/authserver/server/registration/client.go
+++ b/pkg/authserver/server/registration/client.go
@@ -82,6 +82,8 @@ func (c *LoopbackClient) GetMatchingRedirectURI(requestedURI string) string {
 }
 
 // DefaultScopes are the default OIDC scopes for registered clients.
+// Also used as the default for ScopesSupported in config.go when no
+// scopes are explicitly configured.
 var DefaultScopes = []string{"openid", "profile", "email"}
 
 // Config holds configuration for creating a new OAuth client.


### PR DESCRIPTION
DCR was assigning hardcoded DefaultScopes ["openid", "profile", "email"] to registered clients, while the discovery document advertised whatever was configured in oidcConfig.inline.scopes. When those differed, clients would read scopes_supported from discovery, request those scopes, and get rejected by fosite because the client wasn't allowed them.

For example, with this MCPServer config:

```
    oidcConfig:
      inline:
        scopes: [user:email, read:user, repo]
```

the discovery document would advertise scopes_supported: ["user:email", "read:user", "repo"], but a DCR client would only be allowed ["openid", "profile", "email"]. Requesting "user:email" would fail with invalid_scope.

The fix: DCR now reads h.config.ScopesSupported so clients are allowed to request exactly the scopes the server advertises. The config default for ScopesSupported references registration.DefaultScopes directly, giving a single source of truth instead of two arrays to keep in sync.