### PR TITLE
Simplify authserver's upstream provider interface

### DIFF
--- a/pkg/authserver/server/handlers/callback_test.go
+++ b/pkg/authserver/server/handlers/callback_test.go
@@ -94,7 +94,7 @@ func TestCallbackHandler_ExchangeCodeFailure(t *testing.T) {
 
 	// Configure upstream to fail code exchange
 	mockUpstream.exchangeErr = assert.AnError
-	mockUpstream.exchangeTokens = nil
+	mockUpstream.exchangeResult = nil
 
 	// Store a pending authorization
 	internalState := testInternalState
@@ -203,8 +203,9 @@ func TestCallbackHandler_IdentityResolutionFailure(t *testing.T) {
 	t.Parallel()
 	handler, storState, mockUpstream := handlerTestSetup(t)
 
-	// Configure upstream to fail identity resolution
-	mockUpstream.resolveIdentityErr = assert.AnError
+	// Configure upstream to fail identity resolution (now part of ExchangeCodeForIdentity)
+	mockUpstream.exchangeErr = assert.AnError
+	mockUpstream.exchangeResult = nil
 
 	// Store a pending authorization
 	internalState := testInternalState
@@ -225,11 +226,11 @@ func TestCallbackHandler_IdentityResolutionFailure(t *testing.T) {
 
 	handler.CallbackHandler(rec, req)
 
-	// Should fail because identity resolution failed
+	// Should fail because exchange/identity resolution failed
 	assert.Equal(t, http.StatusSeeOther, rec.Code)
 	location := rec.Header().Get("Location")
 	assert.Contains(t, location, "error=")
-	assert.Contains(t, location, "failed+to+verify+user+identity")
+	assert.Contains(t, location, "failed+to+exchange+authorization+code")
 }
 
 func TestRoutesIncludeAuthorizeAndCallback(t *testing.T) {

--- a/pkg/authserver/upstream/doc.go
+++ b/pkg/authserver/upstream/doc.go
@@ -23,21 +23,19 @@
 //
 //   - Type: Returns the provider type identifier
 //   - AuthorizationURL: Build redirect URL for user authentication
-//   - ExchangeCode: Exchange authorization code for tokens
+//   - ExchangeCodeForIdentity: Exchange authorization code and resolve identity atomically
 //   - RefreshTokens: Refresh expired tokens (with subject validation for OIDC)
-//   - ResolveIdentity: Resolve user identity from tokens
-//   - FetchUserInfo: Fetch user claims
 //
 // # Type Hierarchy
 //
 //	OAuth2Provider (interface)
-//	    ├── BaseOAuth2Provider (concrete - pure OAuth 2.0, uses UserInfo for identity)
+//	    ├── BaseOAuth2Provider (concrete - pure OAuth 2.0, uses userinfo endpoint for identity)
 //	    └── OIDCProviderImpl (concrete - OIDC with discovery, validates ID tokens for identity)
 //
 // # Value Objects
 //
 //   - Tokens: Token response from upstream IDP
-//   - UserInfo: User claims from UserInfo endpoint
+//   - Identity: Combined tokens + subject from code exchange
 //   - OAuth2Config: Configuration for OAuth 2.0 providers
 //
 // # Usage
@@ -64,11 +62,10 @@
 //	// Build authorization URL
 //	authURL, err := provider.AuthorizationURL(state, pkceChallenge)
 //
-//	// After callback, exchange code for tokens
-//	tokens, err := provider.ExchangeCode(ctx, code, pkceVerifier)
-//
-//	// Resolve user identity
-//	subject, err := provider.ResolveIdentity(ctx, tokens, "")
+//	// After callback, exchange code and resolve identity atomically
+//	result, err := provider.ExchangeCodeForIdentity(ctx, code, pkceVerifier, nonce)
+//	// result.Tokens contains the upstream tokens
+//	// result.Subject contains the canonical user identifier
 //
 // # Extensibility
 //
@@ -76,15 +73,11 @@
 //
 // # UserInfo Extensibility
 //
-// The package supports flexible UserInfo fetching through the OAuth2Provider
-// interface's FetchUserInfo method and UserInfoConfig. This enables:
+// The package supports flexible userinfo fetching through UserInfoConfig.
+// This enables:
 //
 //   - Custom field mapping for non-standard provider responses
 //   - Additional headers for provider-specific requirements
-//
-// All OAuth2Provider implementations support FetchUserInfo directly:
-//
-//	userInfo, err := provider.FetchUserInfo(ctx, accessToken)
 //
 // For custom provider configuration, use UserInfoConfig:
 //

--- a/pkg/authserver/upstream/mocks/mock_provider.go
+++ b/pkg/authserver/upstream/mocks/mock_provider.go
@@ -61,34 +61,19 @@ func (mr *MockOAuth2ProviderMockRecorder) AuthorizationURL(state, codeChallenge 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AuthorizationURL", reflect.TypeOf((*MockOAuth2Provider)(nil).AuthorizationURL), varargs...)
 }
 
-// ExchangeCode mocks base method.
-func (m *MockOAuth2Provider) ExchangeCode(ctx context.Context, code, codeVerifier string) (*upstream.Tokens, error) {
+// ExchangeCodeForIdentity mocks base method.
+func (m *MockOAuth2Provider) ExchangeCodeForIdentity(ctx context.Context, code, codeVerifier, nonce string) (*upstream.Identity, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ExchangeCode", ctx, code, codeVerifier)
-	ret0, _ := ret[0].(*upstream.Tokens)
+	ret := m.ctrl.Call(m, "ExchangeCodeForIdentity", ctx, code, codeVerifier, nonce)
+	ret0, _ := ret[0].(*upstream.Identity)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ExchangeCode indicates an expected call of ExchangeCode.
-func (mr *MockOAuth2ProviderMockRecorder) ExchangeCode(ctx, code, codeVerifier any) *gomock.Call {
+// ExchangeCodeForIdentity indicates an expected call of ExchangeCodeForIdentity.
+func (mr *MockOAuth2ProviderMockRecorder) ExchangeCodeForIdentity(ctx, code, codeVerifier, nonce any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExchangeCode", reflect.TypeOf((*MockOAuth2Provider)(nil).ExchangeCode), ctx, code, codeVerifier)
-}
-
-// FetchUserInfo mocks base method.
-func (m *MockOAuth2Provider) FetchUserInfo(ctx context.Context, accessToken string) (*upstream.UserInfo, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FetchUserInfo", ctx, accessToken)
-	ret0, _ := ret[0].(*upstream.UserInfo)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// FetchUserInfo indicates an expected call of FetchUserInfo.
-func (mr *MockOAuth2ProviderMockRecorder) FetchUserInfo(ctx, accessToken any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchUserInfo", reflect.TypeOf((*MockOAuth2Provider)(nil).FetchUserInfo), ctx, accessToken)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExchangeCodeForIdentity", reflect.TypeOf((*MockOAuth2Provider)(nil).ExchangeCodeForIdentity), ctx, code, codeVerifier, nonce)
 }
 
 // RefreshTokens mocks base method.
@@ -104,21 +89,6 @@ func (m *MockOAuth2Provider) RefreshTokens(ctx context.Context, refreshToken, ex
 func (mr *MockOAuth2ProviderMockRecorder) RefreshTokens(ctx, refreshToken, expectedSubject any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RefreshTokens", reflect.TypeOf((*MockOAuth2Provider)(nil).RefreshTokens), ctx, refreshToken, expectedSubject)
-}
-
-// ResolveIdentity mocks base method.
-func (m *MockOAuth2Provider) ResolveIdentity(ctx context.Context, tokens *upstream.Tokens, nonce string) (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ResolveIdentity", ctx, tokens, nonce)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ResolveIdentity indicates an expected call of ResolveIdentity.
-func (mr *MockOAuth2ProviderMockRecorder) ResolveIdentity(ctx, tokens, nonce any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveIdentity", reflect.TypeOf((*MockOAuth2Provider)(nil).ResolveIdentity), ctx, tokens, nonce)
 }
 
 // Type mocks base method.

--- a/pkg/authserver/upstream/types.go
+++ b/pkg/authserver/upstream/types.go
@@ -21,19 +21,15 @@ import (
 // ProviderType identifies the type of upstream Identity Provider.
 type ProviderType string
 
-// UserInfo contains user information retrieved from the upstream IDP.
-type UserInfo struct {
-	// Subject is the unique identifier for the user (sub claim).
-	Subject string `json:"sub"`
+// Identity holds the identity resolved from an upstream IDP after
+// exchanging an authorization code. It combines the tokens (for storage and
+// refresh) with the subject identifier (for internal user resolution).
+type Identity struct {
+	// Tokens contains the tokens obtained from the upstream IDP.
+	Tokens *Tokens
 
-	// Email is the user's email address.
-	Email string `json:"email,omitempty"`
-
-	// Name is the user's full name.
-	Name string `json:"name,omitempty"`
-
-	// Claims contains all claims returned by the userinfo endpoint.
-	Claims map[string]any `json:"-"`
+	// Subject is the canonical user identifier from the upstream IDP (the "sub" claim).
+	Subject string
 }
 
 // ErrIdentityResolutionFailed indicates identity could not be determined.


### PR DESCRIPTION
Follow-up to an earlier discussion in a previous PR: https://github.com/stacklok/toolhive/pull/3580#discussion_r2762417865

Combine ExchangeCode and ResolveIdentity into atomic ExchangeCodeForIdentity

Merge the two-step exchange+identity flow into a single interface method to prevent OIDC nonce validation from being accidentally skipped. This ensures replay protection is always enforced when exchanging authorization codes with OIDC providers.

The OAuth2Provider interface shrinks from 6 to 4 methods by removing ExchangeCode, ResolveIdentity, and FetchUserInfo (now package-private). The UserInfo struct is also made private and moved to oauth2.go.

## Large PR Justification

- renames and simplifies an interface implemented by 2 modules along with tests and mocks. There are no logical changes here.