### PR TITLE
Add skill domain types, service interface, and HTTP client stub

### DIFF
--- a/pkg/skills/client/client.go
+++ b/pkg/skills/client/client.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package client provides an HTTP client for the ToolHive Skills API.
+package client
+
+// Client is an HTTP client for the ToolHive Skills API.
+type Client struct {
+	baseURL string
+}
+
+// NewClient creates a new Skills API client with the given base URL.
+func NewClient(baseURL string) *Client {
+	return &Client{
+		baseURL: baseURL,
+	}
+}

--- a/pkg/skills/options.go
+++ b/pkg/skills/options.go
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package skills
+
+// ListOptions configures the behavior of the List operation.
+type ListOptions struct {
+	// Scope filters results by installation scope.
+	Scope Scope `json:"scope,omitempty"`
+}
+
+// InstallOptions configures the behavior of the Install operation.
+type InstallOptions struct {
+	// Name is the skill name or OCI reference to install.
+	Name string `json:"name"`
+	// Version is the specific version to install. Empty means latest.
+	Version string `json:"version,omitempty"`
+	// Scope is the installation scope.
+	Scope Scope `json:"scope,omitempty"`
+}
+
+// InstallResult contains the outcome of an Install operation.
+type InstallResult struct {
+	// Skill is the installed skill.
+	Skill InstalledSkill `json:"skill"`
+}
+
+// UninstallOptions configures the behavior of the Uninstall operation.
+type UninstallOptions struct {
+	// Name is the skill name to uninstall.
+	Name string `json:"name"`
+	// Scope is the scope from which to uninstall.
+	Scope Scope `json:"scope,omitempty"`
+}
+
+// InfoOptions configures the behavior of the Info operation.
+type InfoOptions struct {
+	// Name is the skill name to look up.
+	Name string `json:"name"`
+}
+
+// SkillInfo contains detailed information about a skill.
+type SkillInfo struct {
+	// Metadata contains the skill's metadata.
+	Metadata SkillMetadata `json:"metadata"`
+	// Installed indicates whether the skill is currently installed.
+	Installed bool `json:"installed"`
+	// InstalledSkill is set if the skill is installed.
+	InstalledSkill *InstalledSkill `json:"installed_skill,omitempty"`
+}
+
+// ValidationResult contains the outcome of a Validate operation.
+type ValidationResult struct {
+	// Valid indicates whether the skill definition is valid.
+	Valid bool `json:"valid"`
+	// Errors is a list of validation errors, if any.
+	Errors []string `json:"errors,omitempty"`
+}
+
+// BuildOptions configures the behavior of the Build operation.
+type BuildOptions struct {
+	// Path is the local directory path containing the skill definition.
+	Path string `json:"path"`
+	// Tag is the OCI tag to use for the built artifact.
+	Tag string `json:"tag,omitempty"`
+}
+
+// BuildResult contains the outcome of a Build operation.
+type BuildResult struct {
+	// Reference is the OCI reference of the built skill artifact.
+	Reference string `json:"reference"`
+}
+
+// PushOptions configures the behavior of the Push operation.
+type PushOptions struct {
+	// Reference is the OCI reference to push.
+	Reference string `json:"reference"`
+}

--- a/pkg/skills/service.go
+++ b/pkg/skills/service.go
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package skills
+
+import "context"
+
+//go:generate mockgen -destination=mocks/mock_service.go -package=mocks -source=service.go SkillService
+
+// SkillService defines the interface for managing skills.
+type SkillService interface {
+	// List returns all installed skills matching the given options.
+	List(ctx context.Context, opts ListOptions) ([]InstalledSkill, error)
+	// Install installs a skill from a remote source.
+	Install(ctx context.Context, opts InstallOptions) (*InstallResult, error)
+	// Uninstall removes an installed skill.
+	Uninstall(ctx context.Context, opts UninstallOptions) error
+	// Info returns detailed information about a skill.
+	Info(ctx context.Context, opts InfoOptions) (*SkillInfo, error)
+	// Validate checks whether a skill definition is valid.
+	Validate(ctx context.Context, path string) (*ValidationResult, error)
+	// Build builds a skill from a local directory into an OCI artifact.
+	Build(ctx context.Context, opts BuildOptions) (*BuildResult, error)
+	// Push pushes a built skill artifact to a remote registry.
+	Push(ctx context.Context, opts PushOptions) error
+}

--- a/pkg/skills/types.go
+++ b/pkg/skills/types.go
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package skills provides types and interfaces for managing ToolHive skills.
+package skills
+
+import "time"
+
+// Scope represents the scope at which a skill is installed.
+type Scope string
+
+const (
+	// ScopeUser indicates a skill installed for the current user.
+	ScopeUser Scope = "user"
+	// ScopeSystem indicates a skill installed system-wide.
+	ScopeSystem Scope = "system"
+)
+
+// InstallStatus represents the current status of a skill installation.
+type InstallStatus string
+
+const (
+	// InstallStatusInstalled indicates a skill is fully installed and ready.
+	InstallStatusInstalled InstallStatus = "installed"
+	// InstallStatusPending indicates a skill installation is in progress.
+	InstallStatusPending InstallStatus = "pending"
+	// InstallStatusFailed indicates a skill installation has failed.
+	InstallStatusFailed InstallStatus = "failed"
+)
+
+// SkillMetadata contains metadata about a skill.
+type SkillMetadata struct {
+	// Name is the unique name of the skill.
+	Name string `json:"name"`
+	// Version is the semantic version of the skill.
+	Version string `json:"version"`
+	// Description is a human-readable description of the skill.
+	Description string `json:"description"`
+	// Author is the skill author or maintainer.
+	Author string `json:"author"`
+	// Tags is a list of tags for categorization.
+	Tags []string `json:"tags,omitempty"`
+}
+
+// InstalledSkill represents a skill that has been installed locally.
+type InstalledSkill struct {
+	// Metadata contains the skill's metadata.
+	Metadata SkillMetadata `json:"metadata"`
+	// Scope is the installation scope (user or system).
+	Scope Scope `json:"scope"`
+	// Status is the current installation status.
+	Status InstallStatus `json:"status"`
+	// InstalledAt is the timestamp when the skill was installed.
+	InstalledAt time.Time `json:"installed_at"`
+}
+
+// SkillIndexEntry represents a single skill entry in a remote skill index.
+type SkillIndexEntry struct {
+	// Metadata contains the skill's metadata.
+	Metadata SkillMetadata `json:"metadata"`
+	// Repository is the OCI repository reference for the skill.
+	Repository string `json:"repository"`
+}
+
+// SkillIndex represents a collection of available skills from a remote index.
+type SkillIndex struct {
+	// Skills is the list of available skills.
+	Skills []SkillIndexEntry `json:"skills"`
+}


### PR DESCRIPTION
## Summary

- Adds `pkg/skills/` package with foundational domain types (`InstalledSkill`, `SkillMetadata`, `SkillIndexEntry`, `SkillIndex`, `Scope` enum, `InstallStatus` enum)
- Adds option/result structs for all skill operations (`ListOptions`, `InstallOptions`, `InstallResult`, `UninstallOptions`, `InfoOptions`, `SkillInfo`, `ValidationResult`, `BuildOptions`, `BuildResult`, `PushOptions`)
- Adds `SkillService` interface with 7 methods (`List`, `Install`, `Uninstall`, `Info`, `Validate`, `Build`, `Push`)
- Adds minimal `pkg/skills/client/` HTTP client stub (`Client` struct + `NewClient` constructor)

This is PR 1/3 for the Skills Lifecycle Management stubs (stacklok-epics#239). Pure scaffolding — no business logic. Enables parallel development of parser, state management, client metadata, and API handlers.

Ref: #3645

## Test plan

- [x] `task build` passes
- [x] `task lint` passes (0 issues)
- [ ] `task test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)