### PR TITLE
Add hidden skill CLI command stubs

### DIFF
--- a/cmd/thv/app/commands.go
+++ b/cmd/thv/app/commands.go
@@ -62,6 +62,7 @@ func NewRootCmd(enableUpdates bool) *cobra.Command {
 	rootCmd.AddCommand(inspectorCommand())
 	rootCmd.AddCommand(newMCPCommand())
 	rootCmd.AddCommand(groupCmd)
+	rootCmd.AddCommand(skillCmd)
 	rootCmd.AddCommand(statusCmd)
 
 	// Silence printing the usage on error

--- a/cmd/thv/app/skill.go
+++ b/cmd/thv/app/skill.go
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package app
+
+import "github.com/spf13/cobra"
+
+// TODO: Remove Hidden flag when skills feature is ready for release.
+var skillCmd = &cobra.Command{
+	Use:    "skill",
+	Short:  "Manage skills",
+	Long:   `The skill command provides subcommands to manage skills.`,
+	Hidden: true,
+}

--- a/cmd/thv/app/skill_build.go
+++ b/cmd/thv/app/skill_build.go
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package app
+
+import "github.com/spf13/cobra"
+
+var skillBuildCmd = &cobra.Command{
+	Use:   "build [path]",
+	Short: "Build a skill",
+	Long:  `Build a skill from a local directory into an OCI artifact that can be pushed to a registry.`,
+	Args:  cobra.ExactArgs(1),
+	RunE: func(_ *cobra.Command, _ []string) error {
+		return nil
+	},
+}
+
+func init() {
+	skillCmd.AddCommand(skillBuildCmd)
+}

--- a/cmd/thv/app/skill_info.go
+++ b/cmd/thv/app/skill_info.go
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package app
+
+import "github.com/spf13/cobra"
+
+var skillInfoCmd = &cobra.Command{
+	Use:   "info [skill-name]",
+	Short: "Show skill details",
+	Long:  `Display detailed information about a skill, including metadata, version, and installation status.`,
+	Args:  cobra.ExactArgs(1),
+	RunE: func(_ *cobra.Command, _ []string) error {
+		return nil
+	},
+}
+
+func init() {
+	skillCmd.AddCommand(skillInfoCmd)
+}

--- a/cmd/thv/app/skill_install.go
+++ b/cmd/thv/app/skill_install.go
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package app
+
+import "github.com/spf13/cobra"
+
+var skillInstallCmd = &cobra.Command{
+	Use:   "install [skill-name]",
+	Short: "Install a skill",
+	Long: `Install a skill by name or OCI reference.
+The skill will be fetched from a remote registry and installed locally.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(_ *cobra.Command, _ []string) error {
+		return nil
+	},
+}
+
+func init() {
+	skillCmd.AddCommand(skillInstallCmd)
+}

--- a/cmd/thv/app/skill_list.go
+++ b/cmd/thv/app/skill_list.go
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package app
+
+import "github.com/spf13/cobra"
+
+var skillListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List installed skills",
+	Long:  `List all currently installed skills and their status.`,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		return nil
+	},
+}
+
+func init() {
+	skillCmd.AddCommand(skillListCmd)
+}

--- a/cmd/thv/app/skill_push.go
+++ b/cmd/thv/app/skill_push.go
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package app
+
+import "github.com/spf13/cobra"
+
+var skillPushCmd = &cobra.Command{
+	Use:   "push [reference]",
+	Short: "Push a built skill",
+	Long:  `Push a previously built skill artifact to a remote OCI registry.`,
+	Args:  cobra.ExactArgs(1),
+	RunE: func(_ *cobra.Command, _ []string) error {
+		return nil
+	},
+}
+
+func init() {
+	skillCmd.AddCommand(skillPushCmd)
+}

--- a/cmd/thv/app/skill_uninstall.go
+++ b/cmd/thv/app/skill_uninstall.go
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package app
+
+import "github.com/spf13/cobra"
+
+var skillUninstallCmd = &cobra.Command{
+	Use:   "uninstall [skill-name]",
+	Short: "Uninstall a skill",
+	Long:  `Remove a previously installed skill by name.`,
+	Args:  cobra.ExactArgs(1),
+	RunE: func(_ *cobra.Command, _ []string) error {
+		return nil
+	},
+}
+
+func init() {
+	skillCmd.AddCommand(skillUninstallCmd)
+}

--- a/cmd/thv/app/skill_validate.go
+++ b/cmd/thv/app/skill_validate.go
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package app
+
+import "github.com/spf13/cobra"
+
+var skillValidateCmd = &cobra.Command{
+	Use:   "validate [path]",
+	Short: "Validate a skill definition",
+	Long:  `Check that a skill definition in the given directory is valid and well-formed.`,
+	Args:  cobra.ExactArgs(1),
+	RunE: func(_ *cobra.Command, _ []string) error {
+		return nil
+	},
+}
+
+func init() {
+	skillCmd.AddCommand(skillValidateCmd)
+}


### PR DESCRIPTION
## Summary

- Adds hidden `thv skill` parent command with `Hidden: true` (not shown in `--help` until feature is ready)
- Adds 7 subcommand stubs, each in its own file for future growth:
  - `skill list` — List installed skills
  - `skill install [skill-name]` — Install a skill
  - `skill uninstall [skill-name]` — Uninstall a skill
  - `skill info [skill-name]` — Show skill details
  - `skill validate [path]` — Validate a skill definition
  - `skill build [path]` — Build a skill into an OCI artifact
  - `skill push [reference]` — Push a built skill to a registry
- All stubs return `nil` (silent success per CLI guidelines)
- Registers `skillCmd` in `NewRootCmd()` in `commands.go`

This is PR 3/3 for the Skills Lifecycle Management stubs (stacklok-epics#239). Independent of #3666 (API stubs).

Ref: #3645

## Test plan

- [x] `task build` passes
- [x] `task lint` passes (0 issues)
- [x] `thv skill --help` shows all 7 subcommands
- [x] `thv skill list` exits 0 silently
- [x] `thv --help` does NOT show `skill` (hidden)

🤖 Generated with [Claude Code](https://claude.com/claude-code)