### PR TITLE
Accept ECDSA signing keys in JWKS token validation

### DIFF
--- a/pkg/auth/token.go
+++ b/pkg/auth/token.go
@@ -791,7 +791,10 @@ func (v *TokenValidator) getKeyFromJWKS(ctx context.Context, token *jwt.Token) (
 	}
 
 	// Validate the signing method
-	if _, ok := token.Method.(*jwt.SigningMethodRSA); !ok {
+	switch token.Method.(type) {
+	case *jwt.SigningMethodRSA, *jwt.SigningMethodECDSA:
+		// Supported RSA signing methods
+	default:
 		return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
 	}
 


### PR DESCRIPTION
The JWKS token validator only accepted RSA signing methods, rejecting ECDSA keys generated by the auth server for ephemeral signing. Expand the signing method check to also accept ECDSA, matching the key types the auth server produces.

Validated E2E with Claude Code + Github MCP server.