### PR TITLE
fix(proxy): Rewrite Host header for backends with strict host validation

### DIFF
--- a/pkg/transport/proxy/transparent/transparent_proxy.go
+++ b/pkg/transport/proxy/transparent/transparent_proxy.go
@@ -674,15 +674,6 @@ func (p *TransparentProxy) Stop(ctx context.Context) error {
 	return nil
 }
 
-// Address returns the address the proxy is listening on.
-// Returns an empty string if the proxy is not running.
-func (p *TransparentProxy) Address() string {
-	if p.listener == nil {
-		return ""
-	}
-	return p.listener.Addr().String()
-}
-
 // IsRunning checks if the proxy is running.
 func (p *TransparentProxy) IsRunning() (bool, error) {
 	p.mutex.Lock()


### PR DESCRIPTION
## Summary

- Always rewrite the `Host` header to match the target URL in the transparent proxy's `RoundTrip` method
- Previously, this was only done for `isRemote=true` deployments, causing Kubernetes deployments to forward the proxy's Host header to backends
- Backends with strict host validation (e.g., Django `ALLOWED_HOSTS`, FastAPI `TrustedHostMiddleware`) rejected these requests with "Invalid Host" errors

Closes https://github.com/stacklok/stacklok-epics/issues/231

## Test Plan
This was tested manually, because it's quite a contrived setup for a small change. If someone really wants this committed as an e2e test, I can oblige. 
### Backend Configuration

A custom MCP server (`strict-host-mcp`) was deployed to reproduce the issue. The server enforces strict host validation:

```go
// Strict host validation - simulates Django ALLOWED_HOSTS or FastAPI TrustedHostMiddleware
var allowedHosts = map[string]bool{
    "mcp-strict-host-mcp-headless:3000": true, // Headless service (correct - what fix provides)
    "localhost:3000":                    true, // Local testing
}

// Explicitly rejected hosts (proxy service name - should never reach backend)
var rejectedHostPrefix = "mcp-strict-host-mcp-proxy"

func handleMCP(w http.ResponseWriter, r *http.Request) {
    if strings.HasPrefix(r.Host, rejectedHostPrefix) {
        // Reject proxy service hostname - this is the BUG
        errResp := JSONRPCResponse{
            Error: &JSONRPCError{
                Code:    -1,
                Message: fmt.Sprintf("Invalid Host: %s", r.Host),
            },
        }
        // ...
    }
    // ...
}
```

### Error WITHOUT Fix (proxy leaks its hostname to backend)

```json
{"level":"warn","msg":"Backend strict-host-mcp initialized with failure (1/3 failures, status: unknown): health check failed: backend unavailable: failed to initialize client for backend strict-host-mcp: Invalid Host: mcp-strict-host-mcp-proxy.mcp-servers.svc.cluster.local:8080"}
```

The backend received `Host: mcp-strict-host-mcp-proxy.mcp-servers.svc.cluster.local:8080` (the proxy's service name) instead of the backend's actual hostname.

### Success WITH Fix (proxy rewrites Host to target URL)

Backend logs after applying fix:

```
2026/02/06 23:48:13 Received request: Host=mcp-strict-host-mcp-headless:3000, Method=POST
2026/02/06 23:48:13 ACCEPTED: Host validation passed: mcp-strict-host-mcp-headless:3000
2026/02/06 23:48:13 RPC Method: initialize
2026/02/06 23:48:13 Received request: Host=mcp-strict-host-mcp-headless:3000, Method=POST  
2026/02/06 23:48:13 ACCEPTED: Host validation passed: mcp-strict-host-mcp-headless:3000
2026/02/06 23:48:13 RPC Method: tools/list
```

The fix correctly rewrites the Host header to `mcp-strict-host-mcp-headless:3000` (the backend's target URL), which the backend accepts.
