### PR TITLE
Add default resource limits to VirtualMCPServer vmcp container

### DIFF
--- a/cmd/thv-operator/controllers/virtualmcpserver_deployment.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_deployment.go
@@ -12,6 +12,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -50,6 +51,13 @@ const (
 	vmcpReadinessPeriod       = int32(5)  // seconds - check more frequently for quick detection
 	vmcpReadinessTimeout      = int32(3)  // seconds - shorter timeout for faster detection
 	vmcpReadinessFailures     = int32(3)  // consecutive failures before removing from service
+
+	// Default resource requirements for VirtualMCPServer vmcp container
+	// These provide sensible defaults that can be overridden via PodTemplateSpec
+	vmcpDefaultCPURequest    = "100m"
+	vmcpDefaultMemoryRequest = "128Mi"
+	vmcpDefaultCPULimit      = "500m"
+	vmcpDefaultMemoryLimit   = "512Mi"
 )
 
 // RBAC rules for VirtualMCPServer service account in inline mode
@@ -152,6 +160,16 @@ func (r *VirtualMCPServerReconciler) deploymentForVirtualMCPServer(
 							vmcpReadinessInitialDelay, vmcpReadinessPeriod, vmcpReadinessTimeout, vmcpReadinessFailures,
 						),
 						SecurityContext: containerSecurityContext,
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse(vmcpDefaultCPURequest),
+								corev1.ResourceMemory: resource.MustParse(vmcpDefaultMemoryRequest),
+							},
+							Limits: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse(vmcpDefaultCPULimit),
+								corev1.ResourceMemory: resource.MustParse(vmcpDefaultMemoryLimit),
+							},
+						},
 					}},
 					Volumes:         volumes,
 					SecurityContext: podSecurityContext,

--- a/cmd/thv-operator/controllers/virtualmcpserver_deployment_test.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_deployment_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
@@ -73,6 +74,14 @@ func TestDeploymentForVirtualMCPServer(t *testing.T) {
 	// Verify checksum annotation using standard annotation key
 	assert.Equal(t, "test-checksum",
 		deployment.Spec.Template.Annotations[checksum.RunConfigChecksumAnnotation])
+
+	// Verify default resource requirements
+	require.Len(t, deployment.Spec.Template.Spec.Containers, 1)
+	container := deployment.Spec.Template.Spec.Containers[0]
+	assert.Equal(t, resource.MustParse("100m"), container.Resources.Requests[corev1.ResourceCPU])
+	assert.Equal(t, resource.MustParse("128Mi"), container.Resources.Requests[corev1.ResourceMemory])
+	assert.Equal(t, resource.MustParse("500m"), container.Resources.Limits[corev1.ResourceCPU])
+	assert.Equal(t, resource.MustParse("512Mi"), container.Resources.Limits[corev1.ResourceMemory])
 }
 
 // TestBuildContainerArgsForVmcp tests container argument generation


### PR DESCRIPTION
## Summary
- Adds default CPU/memory resource limits (100m/128Mi requests, 500m/512Mi limits) to the vmcp container in VirtualMCPServer deployments
- Prevents unbounded resource consumption by misbehaving containers
- Users can override defaults via PodTemplateSpec (existing strategic merge patch mechanism)

Closes #2873

## Test plan
- [x] Unit test verifies default resources are applied to the vmcp container
- [x] Unit test verifies user-provided resources via PodTemplateSpec override defaults
- [x] All existing PodTemplateSpec tests continue to pass
- [x] Linting passes with zero issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)