### PR TITLE
Rename MCPClient type to ClientApp

### DIFF
--- a/cmd/thv/app/client.go
+++ b/cmd/thv/app/client.go
@@ -142,8 +142,8 @@ func clientSetupCmdFunc(cmd *cobra.Command, _ []string) error {
 }
 
 // Helper to get available (installed) clients
-func getAvailableClients(statuses []client.MCPClientStatus) []client.MCPClientStatus {
-	var available []client.MCPClientStatus
+func getAvailableClients(statuses []client.ClientAppStatus) []client.ClientAppStatus {
+	var available []client.ClientAppStatus
 	for _, s := range statuses {
 		if s.Installed {
 			available = append(available, s)
@@ -153,7 +153,7 @@ func getAvailableClients(statuses []client.MCPClientStatus) []client.MCPClientSt
 }
 
 // Helper to register selected clients
-func registerSelectedClients(cmd *cobra.Command, clientsToRegister []client.MCPClientStatus, selectedGroups []string) error {
+func registerSelectedClients(cmd *cobra.Command, clientsToRegister []client.ClientAppStatus, selectedGroups []string) error {
 	clients := make([]client.Client, len(clientsToRegister))
 	for i, cli := range clientsToRegister {
 		clients[i] = client.Client{Name: cli.ClientType}
@@ -170,7 +170,7 @@ func clientRegisterCmdFunc(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("invalid client type: %s (valid types: %s)", clientType, client.GetClientListCSV())
 	}
 
-	return performClientRegistration(cmd.Context(), []client.Client{{Name: client.MCPClient(clientType)}}, groupAddNames)
+	return performClientRegistration(cmd.Context(), []client.Client{{Name: client.ClientApp(clientType)}}, groupAddNames)
 }
 
 func clientRemoveCmdFunc(cmd *cobra.Command, args []string) error {
@@ -181,7 +181,7 @@ func clientRemoveCmdFunc(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("invalid client type: %s (valid types: %s)", clientType, client.GetClientListCSV())
 	}
 
-	return performClientRemoval(cmd.Context(), client.Client{Name: client.MCPClient(clientType)}, groupRmNames)
+	return performClientRemoval(cmd.Context(), client.Client{Name: client.ClientApp(clientType)}, groupRmNames)
 }
 
 func listRegisteredClientsCmdFunc(cmd *cobra.Command, _ []string) error {

--- a/cmd/thv/app/ui/clients_setup.go
+++ b/cmd/thv/app/ui/clients_setup.go
@@ -29,7 +29,7 @@ const (
 )
 
 type setupModel struct {
-	Clients         []client.MCPClientStatus
+	Clients         []client.ClientAppStatus
 	Groups          []*groups.Group
 	Cursor          int
 	SelectedClients map[int]struct{}
@@ -146,7 +146,7 @@ func renderGroupRow(m *setupModel, i int, group *groups.Group) string {
 	return itemStyle.Render(row) + "\n"
 }
 
-func renderClientRow(m *setupModel, i int, cli client.MCPClientStatus) string {
+func renderClientRow(m *setupModel, i int, cli client.ClientAppStatus) string {
 	cursor := "  "
 	if m.Cursor == i {
 		cursor = "> "
@@ -164,9 +164,9 @@ func renderClientRow(m *setupModel, i int, cli client.MCPClientStatus) string {
 
 // RunClientSetup runs the interactive client setup and returns the selected clients, groups, and whether the user confirmed.
 func RunClientSetup(
-	clients []client.MCPClientStatus,
+	clients []client.ClientAppStatus,
 	availableGroups []*groups.Group,
-) ([]client.MCPClientStatus, []string, bool, error) {
+) ([]client.ClientAppStatus, []string, bool, error) {
 
 	var selectedGroupsMap = make(map[int]struct{})
 	var currentStep = stepClientSelection
@@ -197,7 +197,7 @@ func RunClientSetup(
 	}
 
 	m := finalModel.(*setupModel)
-	var selectedClients []client.MCPClientStatus
+	var selectedClients []client.ClientAppStatus
 	for i := range m.SelectedClients {
 		selectedClients = append(selectedClients, clients[i])
 	}

--- a/cmd/thv/app/ui/clients_status.go
+++ b/cmd/thv/app/ui/clients_status.go
@@ -16,7 +16,7 @@ import (
 )
 
 // RenderClientStatusTable renders the client status table to stdout.
-func RenderClientStatusTable(clientStatuses []client.MCPClientStatus) error {
+func RenderClientStatusTable(clientStatuses []client.ClientAppStatus) error {
 	if len(clientStatuses) == 0 {
 		fmt.Println("No supported clients found.")
 		return nil

--- a/docs/server/docs.go
+++ b/docs/server/docs.go
@@ -379,7 +379,7 @@ const docTemplate = `{
                 },
                 "type": "object"
             },
-            "client.MCPClient": {
+            "client.ClientApp": {
                 "description": "ClientType is the type of MCP client",
                 "enum": [
                     "roo-code",
@@ -437,10 +437,10 @@ const docTemplate = `{
                     "Codex"
                 ]
             },
-            "client.MCPClientStatus": {
+            "client.ClientAppStatus": {
                 "properties": {
                     "client_type": {
-                        "$ref": "#/components/schemas/client.MCPClient"
+                        "$ref": "#/components/schemas/client.ClientApp"
                     },
                     "installed": {
                         "description": "Installed indicates whether the client is installed on the system",
@@ -463,7 +463,7 @@ const docTemplate = `{
                         "uniqueItems": false
                     },
                     "name": {
-                        "$ref": "#/components/schemas/client.MCPClient"
+                        "$ref": "#/components/schemas/client.ClientApp"
                     }
                 },
                 "type": "object"
@@ -1477,7 +1477,7 @@ const docTemplate = `{
                 "description": "InstalledSkill is set if the skill is installed.",
                 "properties": {
                     "clients": {
-                        "description": "Clients is the list of client identifiers the skill is installed for.\nTODO: Refactor client.MCPClient to a shared package so it can be used here instead of []string.",
+                        "description": "Clients is the list of client identifiers the skill is installed for.\nTODO: Refactor client.ClientApp to a shared package so it can be used here instead of []string.",
                         "items": {
                             "type": "string"
                         },
@@ -1824,7 +1824,7 @@ const docTemplate = `{
                     "names": {
                         "description": "Names is the list of client names to operate on.",
                         "items": {
-                            "$ref": "#/components/schemas/client.MCPClient"
+                            "$ref": "#/components/schemas/client.ClientApp"
                         },
                         "type": "array",
                         "uniqueItems": false
@@ -1853,7 +1853,7 @@ const docTemplate = `{
                 "properties": {
                     "clients": {
                         "items": {
-                            "$ref": "#/components/schemas/client.MCPClientStatus"
+                            "$ref": "#/components/schemas/client.ClientAppStatus"
                         },
                         "type": "array",
                         "uniqueItems": false
@@ -1872,7 +1872,7 @@ const docTemplate = `{
                         "uniqueItems": false
                     },
                     "name": {
-                        "$ref": "#/components/schemas/client.MCPClient"
+                        "$ref": "#/components/schemas/client.ClientApp"
                     }
                 },
                 "type": "object"
@@ -1888,7 +1888,7 @@ const docTemplate = `{
                         "uniqueItems": false
                     },
                     "name": {
-                        "$ref": "#/components/schemas/client.MCPClient"
+                        "$ref": "#/components/schemas/client.ClientApp"
                     }
                 },
                 "type": "object"

--- a/docs/server/swagger.json
+++ b/docs/server/swagger.json
@@ -372,7 +372,7 @@
                 },
                 "type": "object"
             },
-            "client.MCPClient": {
+            "client.ClientApp": {
                 "description": "ClientType is the type of MCP client",
                 "enum": [
                     "roo-code",
@@ -430,10 +430,10 @@
                     "Codex"
                 ]
             },
-            "client.MCPClientStatus": {
+            "client.ClientAppStatus": {
                 "properties": {
                     "client_type": {
-                        "$ref": "#/components/schemas/client.MCPClient"
+                        "$ref": "#/components/schemas/client.ClientApp"
                     },
                     "installed": {
                         "description": "Installed indicates whether the client is installed on the system",
@@ -456,7 +456,7 @@
                         "uniqueItems": false
                     },
                     "name": {
-                        "$ref": "#/components/schemas/client.MCPClient"
+                        "$ref": "#/components/schemas/client.ClientApp"
                     }
                 },
                 "type": "object"
@@ -1470,7 +1470,7 @@
                 "description": "InstalledSkill is set if the skill is installed.",
                 "properties": {
                     "clients": {
-                        "description": "Clients is the list of client identifiers the skill is installed for.\nTODO: Refactor client.MCPClient to a shared package so it can be used here instead of []string.",
+                        "description": "Clients is the list of client identifiers the skill is installed for.\nTODO: Refactor client.ClientApp to a shared package so it can be used here instead of []string.",
                         "items": {
                             "type": "string"
                         },
@@ -1817,7 +1817,7 @@
                     "names": {
                         "description": "Names is the list of client names to operate on.",
                         "items": {
-                            "$ref": "#/components/schemas/client.MCPClient"
+                            "$ref": "#/components/schemas/client.ClientApp"
                         },
                         "type": "array",
                         "uniqueItems": false
@@ -1846,7 +1846,7 @@
                 "properties": {
                     "clients": {
                         "items": {
-                            "$ref": "#/components/schemas/client.MCPClientStatus"
+                            "$ref": "#/components/schemas/client.ClientAppStatus"
                         },
                         "type": "array",
                         "uniqueItems": false
@@ -1865,7 +1865,7 @@
                         "uniqueItems": false
                     },
                     "name": {
-                        "$ref": "#/components/schemas/client.MCPClient"
+                        "$ref": "#/components/schemas/client.ClientApp"
                     }
                 },
                 "type": "object"
@@ -1881,7 +1881,7 @@
                         "uniqueItems": false
                     },
                     "name": {
-                        "$ref": "#/components/schemas/client.MCPClient"
+                        "$ref": "#/components/schemas/client.ClientApp"
                     }
                 },
                 "type": "object"

--- a/docs/server/swagger.yaml
+++ b/docs/server/swagger.yaml
@@ -385,7 +385,7 @@ components:
           description: Version is the version of the configuration format.
           type: string
       type: object
-    client.MCPClient:
+    client.ClientApp:
       description: ClientType is the type of MCP client
       enum:
       - roo-code
@@ -440,10 +440,10 @@ components:
       - VSCodeServer
       - MistralVibe
       - Codex
-    client.MCPClientStatus:
+    client.ClientAppStatus:
       properties:
         client_type:
-          $ref: '#/components/schemas/client.MCPClient'
+          $ref: '#/components/schemas/client.ClientApp'
         installed:
           description: Installed indicates whether the client is installed on the
             system
@@ -461,7 +461,7 @@ components:
           type: array
           uniqueItems: false
         name:
-          $ref: '#/components/schemas/client.MCPClient'
+          $ref: '#/components/schemas/client.ClientApp'
       type: object
     core.Workload:
       properties:
@@ -1356,7 +1356,7 @@ components:
         clients:
           description: |-
             Clients is the list of client identifiers the skill is installed for.
-            TODO: Refactor client.MCPClient to a shared package so it can be used here instead of []string.
+            TODO: Refactor client.ClientApp to a shared package so it can be used here instead of []string.
           items:
             type: string
           type: array
@@ -1676,7 +1676,7 @@ components:
         names:
           description: Names is the list of client names to operate on.
           items:
-            $ref: '#/components/schemas/client.MCPClient'
+            $ref: '#/components/schemas/client.ClientApp'
           type: array
           uniqueItems: false
       type: object
@@ -1696,7 +1696,7 @@ components:
       properties:
         clients:
           items:
-            $ref: '#/components/schemas/client.MCPClientStatus'
+            $ref: '#/components/schemas/client.ClientAppStatus'
           type: array
           uniqueItems: false
       type: object
@@ -1709,7 +1709,7 @@ components:
           type: array
           uniqueItems: false
         name:
-          $ref: '#/components/schemas/client.MCPClient'
+          $ref: '#/components/schemas/client.ClientApp'
       type: object
     v1.createClientResponse:
       properties:
@@ -1720,7 +1720,7 @@ components:
           type: array
           uniqueItems: false
         name:
-          $ref: '#/components/schemas/client.MCPClient'
+          $ref: '#/components/schemas/client.ClientApp'
       type: object
     v1.createGroupRequest:
       properties:

--- a/pkg/api/v1/clients.go
+++ b/pkg/api/v1/clients.go
@@ -139,7 +139,7 @@ func (c *ClientRoutes) unregisterClient(w http.ResponseWriter, r *http.Request) 
 		)
 	}
 
-	if err := c.removeClient(r.Context(), []client.Client{{Name: client.MCPClient(clientName)}}, nil); err != nil {
+	if err := c.removeClient(r.Context(), []client.Client{{Name: client.ClientApp(clientName)}}, nil); err != nil {
 		if errors.Is(err, client.ErrUnsupportedClientType) {
 			return httperr.WithCode(
 				fmt.Errorf("failed to unregister client: %w", err),
@@ -182,7 +182,7 @@ func (c *ClientRoutes) unregisterClientFromGroup(w http.ResponseWriter, r *http.
 	}
 
 	// Remove client from the specific group
-	if err := c.removeClient(r.Context(), []client.Client{{Name: client.MCPClient(clientName)}}, []string{groupName}); err != nil {
+	if err := c.removeClient(r.Context(), []client.Client{{Name: client.ClientApp(clientName)}}, []string{groupName}); err != nil {
 		if errors.Is(err, client.ErrUnsupportedClientType) {
 			return httperr.WithCode(
 				fmt.Errorf("failed to unregister client from group: %w", err),
@@ -298,21 +298,21 @@ func (c *ClientRoutes) unregisterClientsBulk(w http.ResponseWriter, r *http.Requ
 
 type createClientRequest struct {
 	// Name is the type of the client to register.
-	Name client.MCPClient `json:"name"`
+	Name client.ClientApp `json:"name"`
 	// Groups is the list of groups configured on the client.
 	Groups []string `json:"groups,omitempty"`
 }
 
 type createClientResponse struct {
 	// Name is the type of the client that was registered.
-	Name client.MCPClient `json:"name"`
+	Name client.ClientApp `json:"name"`
 	// Groups is the list of groups configured on the client.
 	Groups []string `json:"groups,omitempty"`
 }
 
 type bulkClientRequest struct {
 	// Names is the list of client names to operate on.
-	Names []client.MCPClient `json:"names"`
+	Names []client.ClientApp `json:"names"`
 	// Groups is the list of groups configured on the client.
 	Groups []string `json:"groups,omitempty"`
 }

--- a/pkg/api/v1/discovery.go
+++ b/pkg/api/v1/discovery.go
@@ -50,5 +50,5 @@ func (*DiscoveryRoutes) discoverClients(w http.ResponseWriter, r *http.Request) 
 
 // clientStatusResponse represents the response for the client discovery
 type clientStatusResponse struct {
-	Clients []client.MCPClientStatus `json:"clients"`
+	Clients []client.ClientAppStatus `json:"clients"`
 }

--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -30,60 +30,62 @@ const lockTimeout = 1 * time.Second
 // defaultURLFieldName is the default URL field name used when no specific mapping exists
 const defaultURLFieldName = "url"
 
-// MCPClient is an enum of supported MCP clients.
-type MCPClient string
+// ClientApp is an enum of supported AI clients (IDEs, editors, and coding tools).
+//
+//nolint:revive // ClientApp is intentionally named for clarity across packages
+type ClientApp string
 
 const (
 	// RooCode represents the Roo Code extension for VS Code.
-	RooCode MCPClient = "roo-code"
+	RooCode ClientApp = "roo-code"
 	// Cline represents the Cline extension for VS Code.
-	Cline MCPClient = "cline"
+	Cline ClientApp = "cline"
 	// Cursor represents the Cursor editor.
-	Cursor MCPClient = "cursor"
+	Cursor ClientApp = "cursor"
 	// VSCodeInsider represents the VS Code Insiders editor.
-	VSCodeInsider MCPClient = "vscode-insider"
+	VSCodeInsider ClientApp = "vscode-insider"
 	// VSCode represents the standard VS Code editor.
-	VSCode MCPClient = "vscode"
+	VSCode ClientApp = "vscode"
 	// ClaudeCode represents the Claude Code CLI.
-	ClaudeCode MCPClient = "claude-code"
+	ClaudeCode ClientApp = "claude-code"
 	// Windsurf represents the Windsurf IDE.
-	Windsurf MCPClient = "windsurf"
+	Windsurf ClientApp = "windsurf"
 	// WindsurfJetBrains represents the Windsurf plugin for JetBrains.
-	WindsurfJetBrains MCPClient = "windsurf-jetbrains"
+	WindsurfJetBrains ClientApp = "windsurf-jetbrains"
 	// AmpCli represents the Sourcegraph Amp CLI.
-	AmpCli MCPClient = "amp-cli"
+	AmpCli ClientApp = "amp-cli"
 	// AmpVSCode represents the Sourcegraph Amp extension for VS Code.
-	AmpVSCode MCPClient = "amp-vscode"
+	AmpVSCode ClientApp = "amp-vscode"
 	// AmpCursor represents the Sourcegraph Amp extension for Cursor.
-	AmpCursor MCPClient = "amp-cursor"
+	AmpCursor ClientApp = "amp-cursor"
 	// AmpVSCodeInsider represents the Sourcegraph Amp extension for VS Code Insiders.
-	AmpVSCodeInsider MCPClient = "amp-vscode-insider"
+	AmpVSCodeInsider ClientApp = "amp-vscode-insider"
 	// AmpWindsurf represents the Sourcegraph Amp extension for Windsurf.
-	AmpWindsurf MCPClient = "amp-windsurf"
+	AmpWindsurf ClientApp = "amp-windsurf"
 	// LMStudio represents the LM Studio application.
-	LMStudio MCPClient = "lm-studio"
+	LMStudio ClientApp = "lm-studio"
 	// Goose represents the Goose AI agent.
-	Goose MCPClient = "goose"
+	Goose ClientApp = "goose"
 	// Trae represents the Trae IDE.
-	Trae MCPClient = "trae"
+	Trae ClientApp = "trae"
 	// Continue represents the Continue.dev IDE plugins.
-	Continue MCPClient = "continue"
+	Continue ClientApp = "continue"
 	// OpenCode represents the OpenCode editor.
-	OpenCode MCPClient = "opencode"
+	OpenCode ClientApp = "opencode"
 	// Kiro represents the Kiro AI IDE.
-	Kiro MCPClient = "kiro"
+	Kiro ClientApp = "kiro"
 	// Antigravity represents the Google Antigravity IDE.
-	Antigravity MCPClient = "antigravity"
+	Antigravity ClientApp = "antigravity"
 	// Zed represents the Zed editor.
-	Zed MCPClient = "zed"
+	Zed ClientApp = "zed"
 	// GeminiCli represents the Google Gemini CLI.
-	GeminiCli MCPClient = "gemini-cli"
+	GeminiCli ClientApp = "gemini-cli"
 	// VSCodeServer represents Microsoft's VS Code Server (remote development).
-	VSCodeServer MCPClient = "vscode-server"
+	VSCodeServer ClientApp = "vscode-server"
 	// MistralVibe represents the Mistral Vibe IDE.
-	MistralVibe MCPClient = "mistral-vibe"
+	MistralVibe ClientApp = "mistral-vibe"
 	// Codex represents the OpenAI Codex CLI.
-	Codex MCPClient = "codex"
+	Codex ClientApp = "codex"
 )
 
 // Extension is extension of the client config file.
@@ -122,7 +124,7 @@ const (
 
 // mcpClientConfig represents a configuration path for a supported MCP client.
 type mcpClientConfig struct {
-	ClientType                    MCPClient
+	ClientType                    ClientApp
 	Description                   string
 	RelPath                       []string
 	SettingsFile                  string
@@ -713,8 +715,8 @@ var supportedClientIntegrations = []mcpClientConfig{
 
 // GetAllClients returns a slice of all supported MCP client types, sorted alphabetically.
 // This is the single source of truth for valid client types.
-func GetAllClients() []MCPClient {
-	clients := make([]MCPClient, 0, len(supportedClientIntegrations))
+func GetAllClients() []ClientApp {
+	clients := make([]ClientApp, 0, len(supportedClientIntegrations))
 	for _, config := range supportedClientIntegrations {
 		clients = append(clients, config.ClientType)
 	}
@@ -737,7 +739,7 @@ func IsValidClient(clientType string) bool {
 
 // GetClientDescription returns the description for a given client type.
 // Returns an empty string if the client type is not found.
-func GetClientDescription(clientType MCPClient) string {
+func GetClientDescription(clientType ClientApp) string {
 	for _, config := range supportedClientIntegrations {
 		if config.ClientType == clientType {
 			return config.Description
@@ -777,7 +779,7 @@ func GetClientListCSV() string {
 // ConfigFile represents a client configuration file
 type ConfigFile struct {
 	Path          string
-	ClientType    MCPClient
+	ClientType    ClientApp
 	ConfigUpdater ConfigUpdater
 	Extension     Extension
 }
@@ -788,7 +790,7 @@ type MCPServerConfig struct {
 }
 
 // FindClientConfig returns the client configuration file for a given client type.
-func FindClientConfig(clientType MCPClient) (*ConfigFile, error) {
+func FindClientConfig(clientType ClientApp) (*ConfigFile, error) {
 	manager, err := NewClientManager()
 	if err != nil {
 		return nil, err
@@ -797,7 +799,7 @@ func FindClientConfig(clientType MCPClient) (*ConfigFile, error) {
 }
 
 // FindClientConfig returns the client configuration file for a given client type using this manager's dependencies.
-func (cm *ClientManager) FindClientConfig(clientType MCPClient) (*ConfigFile, error) {
+func (cm *ClientManager) FindClientConfig(clientType ClientApp) (*ConfigFile, error) {
 	// retrieve the metadata of the config files
 	configFile, err := cm.retrieveConfigFileMetadata(clientType)
 	if err != nil {
@@ -859,7 +861,7 @@ func (cm *ClientManager) FindRegisteredClientConfigs(ctx context.Context) ([]Con
 }
 
 // CreateClientConfig creates a new client configuration file for a given client type.
-func CreateClientConfig(clientType MCPClient) (*ConfigFile, error) {
+func CreateClientConfig(clientType ClientApp) (*ConfigFile, error) {
 	manager, err := NewClientManager()
 	if err != nil {
 		return nil, err
@@ -868,7 +870,7 @@ func CreateClientConfig(clientType MCPClient) (*ConfigFile, error) {
 }
 
 // CreateClientConfig creates a new client configuration file for a given client type using this manager's dependencies.
-func (cm *ClientManager) CreateClientConfig(clientType MCPClient) (*ConfigFile, error) {
+func (cm *ClientManager) CreateClientConfig(clientType ClientApp) (*ConfigFile, error) {
 	// Find the configuration for the requested client type
 	var clientCfg *mcpClientConfig
 	for _, cfg := range cm.clientIntegrations {
@@ -983,7 +985,7 @@ func buildMCPServer(url, transportType string, clientCfg *mcpClientConfig) MCPSe
 }
 
 // retrieveConfigFileMetadata retrieves the metadata for client configuration files using this manager's dependencies.
-func (cm *ClientManager) retrieveConfigFileMetadata(clientType MCPClient) (*ConfigFile, error) {
+func (cm *ClientManager) retrieveConfigFileMetadata(clientType ClientApp) (*ConfigFile, error) {
 	// Find the configuration for the requested client type
 	var clientCfg *mcpClientConfig
 	for _, cfg := range cm.clientIntegrations {

--- a/pkg/client/config_test.go
+++ b/pkg/client/config_test.go
@@ -424,7 +424,7 @@ func TestSuccessfulClientConfigOperations(t *testing.T) {
 		assert.Len(t, configs, len(mockClientConfigs), "Should find all mock client configs")
 
 		// Verify each client type is found
-		foundTypes := make(map[MCPClient]bool)
+		foundTypes := make(map[ClientApp]bool)
 		for _, cf := range configs {
 			foundTypes[cf.ClientType] = true
 		}
@@ -1294,13 +1294,13 @@ func TestGetAllClients(t *testing.T) {
 	}
 
 	// Verify some known clients are in the list
-	expectedClients := []MCPClient{
+	expectedClients := []ClientApp{
 		RooCode, Cline, Cursor, VSCode, VSCodeInsider, ClaudeCode,
 		Windsurf, WindsurfJetBrains, AmpCli, LMStudio, Goose,
 		Continue, Zed, Codex, MistralVibe,
 	}
 
-	clientMap := make(map[MCPClient]bool)
+	clientMap := make(map[ClientApp]bool)
 	for _, client := range clients {
 		clientMap[client] = true
 	}
@@ -1369,7 +1369,7 @@ func TestGetClientDescription(t *testing.T) {
 
 	tests := []struct {
 		name        string
-		client      MCPClient
+		client      ClientApp
 		expectFound bool
 	}{
 		{
@@ -1389,7 +1389,7 @@ func TestGetClientDescription(t *testing.T) {
 		},
 		{
 			name:        "Invalid client",
-			client:      MCPClient("invalid"),
+			client:      ClientApp("invalid"),
 			expectFound: false,
 		},
 	}

--- a/pkg/client/discovery.go
+++ b/pkg/client/discovery.go
@@ -60,10 +60,12 @@ func NewTestClientManager(
 	}
 }
 
-// MCPClientStatus represents the status of a supported MCP client
-type MCPClientStatus struct {
+// ClientAppStatus represents the status of a supported client application
+//
+//nolint:revive // ClientAppStatus is intentionally named for clarity across packages
+type ClientAppStatus struct {
 	// ClientType is the type of MCP client
-	ClientType MCPClient `json:"client_type"`
+	ClientType ClientApp `json:"client_type"`
 
 	// Installed indicates whether the client is installed on the system
 	Installed bool `json:"installed"`
@@ -73,8 +75,8 @@ type MCPClientStatus struct {
 }
 
 // GetClientStatus returns the status of all supported MCP clients using this manager's dependencies
-func (cm *ClientManager) GetClientStatus(ctx context.Context) ([]MCPClientStatus, error) {
-	var statuses []MCPClientStatus
+func (cm *ClientManager) GetClientStatus(ctx context.Context) ([]ClientAppStatus, error) {
+	var statuses []ClientAppStatus
 
 	// Get app configuration to check for registered clients
 	appConfig := cm.configProvider.GetConfig()
@@ -99,7 +101,7 @@ func (cm *ClientManager) GetClientStatus(ctx context.Context) ([]MCPClientStatus
 	}
 
 	for _, cfg := range cm.clientIntegrations {
-		status := MCPClientStatus{
+		status := ClientAppStatus{
 			ClientType: cfg.ClientType,
 			Installed:  false, // start with assuming client is not installed
 			Registered: registeredClients[string(cfg.ClientType)],
@@ -127,7 +129,7 @@ func (cm *ClientManager) GetClientStatus(ctx context.Context) ([]MCPClientStatus
 }
 
 // GetClientStatus returns the status of all supported MCP clients using the default config provider
-func GetClientStatus(ctx context.Context) ([]MCPClientStatus, error) {
+func GetClientStatus(ctx context.Context) ([]ClientAppStatus, error) {
 	manager, err := NewClientManager()
 	if err != nil {
 		return nil, err

--- a/pkg/client/discovery_test.go
+++ b/pkg/client/discovery_test.go
@@ -133,7 +133,7 @@ func TestGetClientStatus(t *testing.T) {
 	require.NotNil(t, statuses)
 
 	// Create a map for easier testing
-	statusMap := make(map[MCPClient]MCPClientStatus)
+	statusMap := make(map[ClientApp]ClientAppStatus)
 	for _, status := range statuses {
 		statusMap[status.ClientType] = status
 	}
@@ -257,7 +257,7 @@ func TestGetClientStatus_WithGroups(t *testing.T) {
 	require.NotNil(t, statuses)
 
 	// Create a map for easier testing
-	statusMap := make(map[MCPClient]MCPClientStatus)
+	statusMap := make(map[ClientApp]ClientAppStatus)
 	for _, status := range statuses {
 		statusMap[status.ClientType] = status
 	}

--- a/pkg/client/manager.go
+++ b/pkg/client/manager.go
@@ -18,12 +18,12 @@ import (
 
 // Client represents a registered ToolHive client.
 type Client struct {
-	Name MCPClient `json:"name"`
+	Name ClientApp `json:"name"`
 }
 
 // RegisteredClient represents a registered client with its associated groups.
 type RegisteredClient struct {
-	Name   MCPClient `json:"name"`
+	Name   ClientApp `json:"name"`
 	Groups []string  `json:"groups"`
 }
 
@@ -131,7 +131,7 @@ func (m *defaultManager) ListClients(ctx context.Context) ([]RegisteredClient, e
 	registeredClients := make([]RegisteredClient, 0)
 	for clientName := range allRegisteredClients {
 		registered := RegisteredClient{
-			Name:   MCPClient(clientName),
+			Name:   ClientApp(clientName),
 			Groups: clientGroups[clientName],
 		}
 		registeredClients = append(registeredClients, registered)
@@ -197,7 +197,7 @@ func (m *defaultManager) RemoveServerFromClients(ctx context.Context, serverName
 
 	// Remove the server from each target client
 	for _, clientName := range targetClients {
-		if err := m.removeServerFromClient(MCPClient(clientName), serverName); err != nil && !errors.Is(err, ErrConfigFileNotFound) {
+		if err := m.removeServerFromClient(ClientApp(clientName), serverName); err != nil && !errors.Is(err, ErrConfigFileNotFound) {
 			logger.Warnf("Warning: Failed to remove server from client %s: %v", clientName, err)
 		}
 	}
@@ -206,7 +206,7 @@ func (m *defaultManager) RemoveServerFromClients(ctx context.Context, serverName
 }
 
 // addWorkloadsToClient adds the specified workloads to the client's configuration
-func (m *defaultManager) addWorkloadsToClient(clientType MCPClient, workloads []core.Workload) error {
+func (m *defaultManager) addWorkloadsToClient(clientType ClientApp, workloads []core.Workload) error {
 	if len(workloads) == 0 {
 		// No workloads to add, nothing more to do
 		return nil
@@ -229,7 +229,7 @@ func (m *defaultManager) addWorkloadsToClient(clientType MCPClient, workloads []
 }
 
 // removeWorkloadsFromClient removes the specified workloads from the client's configuration
-func (m *defaultManager) removeWorkloadsFromClient(clientType MCPClient, workloads []core.Workload) error {
+func (m *defaultManager) removeWorkloadsFromClient(clientType ClientApp, workloads []core.Workload) error {
 	if len(workloads) == 0 {
 		// No workloads to remove, nothing to do
 		return nil
@@ -247,7 +247,7 @@ func (m *defaultManager) removeWorkloadsFromClient(clientType MCPClient, workloa
 }
 
 // removeServerFromClient removes an MCP server from a single client configuration
-func (*defaultManager) removeServerFromClient(clientName MCPClient, serverName string) error {
+func (*defaultManager) removeServerFromClient(clientName ClientApp, serverName string) error {
 	clientConfig, err := FindClientConfig(clientName)
 	if err != nil {
 		return fmt.Errorf("failed to find client configurations: %w", err)
@@ -264,11 +264,11 @@ func (*defaultManager) removeServerFromClient(clientName MCPClient, serverName s
 
 // updateClientWithServer updates a single client with an MCP server configuration, creating config if needed
 func (*defaultManager) updateClientWithServer(clientName, serverName, serverURL, transportType string) error {
-	clientConfig, err := FindClientConfig(MCPClient(clientName))
+	clientConfig, err := FindClientConfig(ClientApp(clientName))
 	if err != nil {
 		if errors.Is(err, ErrConfigFileNotFound) {
 			// Create a new client configuration if it doesn't exist
-			clientConfig, err = CreateClientConfig(MCPClient(clientName))
+			clientConfig, err = CreateClientConfig(ClientApp(clientName))
 			if err != nil {
 				return fmt.Errorf("failed to create client configuration for %s: %w", clientName, err)
 			}

--- a/pkg/skills/types.go
+++ b/pkg/skills/types.go
@@ -53,7 +53,7 @@ type InstalledSkill struct {
 	// InstalledAt is the timestamp when the skill was installed.
 	InstalledAt time.Time `json:"installed_at"`
 	// Clients is the list of client identifiers the skill is installed for.
-	// TODO: Refactor client.MCPClient to a shared package so it can be used here instead of []string.
+	// TODO: Refactor client.ClientApp to a shared package so it can be used here instead of []string.
 	Clients []string `json:"clients,omitempty"`
 }
 

--- a/test/e2e/api_clients_test.go
+++ b/test/e2e/api_clients_test.go
@@ -44,7 +44,7 @@ var _ = Describe("Clients API", Label("api", "clients", "e2e"), func() {
 	})
 
 	Describe("POST /api/v1beta/clients - Register client with workloads", func() {
-		var testClientName client.MCPClient
+		var testClientName client.ClientApp
 		var groupName string
 		var workloadName string
 
@@ -219,7 +219,7 @@ var _ = Describe("Clients API", Label("api", "clients", "e2e"), func() {
 	})
 
 	Describe("DELETE /api/v1beta/clients/{name}/groups/{group} - Unregister client from group", func() {
-		var testClientName client.MCPClient
+		var testClientName client.ClientApp
 		var groupName string
 		var workloadName string
 
@@ -307,12 +307,12 @@ var _ = Describe("Clients API", Label("api", "clients", "e2e"), func() {
 	})
 
 	Describe("POST /api/v1beta/clients/register - Bulk register clients", func() {
-		var testClientNames []client.MCPClient
+		var testClientNames []client.ClientApp
 		var groupName string
 		var workloadName string
 
 		BeforeEach(func() {
-			testClientNames = []client.MCPClient{
+			testClientNames = []client.ClientApp{
 				client.VSCode, // Use valid client types for bulk tests
 				client.Cline,
 			}
@@ -416,12 +416,12 @@ var _ = Describe("Clients API", Label("api", "clients", "e2e"), func() {
 	})
 
 	Describe("POST /api/v1beta/clients/unregister - Bulk unregister clients", func() {
-		var testClientNames []client.MCPClient
+		var testClientNames []client.ClientApp
 		var groupName string
 		var workloadName string
 
 		BeforeEach(func() {
-			testClientNames = []client.MCPClient{
+			testClientNames = []client.ClientApp{
 				client.Windsurf, // Use different valid client types for bulk unregister tests
 				client.LMStudio,
 			}

--- a/test/e2e/api_discovery_test.go
+++ b/test/e2e/api_discovery_test.go
@@ -75,13 +75,13 @@ var _ = Describe("Discovery API", Label("api", "discovery", "e2e"), func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				// Create a map of returned client types
-				clientTypes := make(map[client.MCPClient]bool)
+				clientTypes := make(map[client.ClientApp]bool)
 				for _, status := range result.Clients {
 					clientTypes[status.ClientType] = true
 				}
 
 				// Verify some well-known client types are included
-				expectedClients := []client.MCPClient{
+				expectedClients := []client.ClientApp{
 					client.RooCode,
 					client.Cline,
 					client.Cursor,
@@ -146,12 +146,12 @@ var _ = Describe("Discovery API", Label("api", "discovery", "e2e"), func() {
 				Expect(result1.Clients).To(HaveLen(len(result2.Clients)))
 
 				// Create maps for comparison
-				clients1 := make(map[client.MCPClient]client.MCPClientStatus)
+				clients1 := make(map[client.ClientApp]client.ClientAppStatus)
 				for _, status := range result1.Clients {
 					clients1[status.ClientType] = status
 				}
 
-				clients2 := make(map[client.MCPClient]client.MCPClientStatus)
+				clients2 := make(map[client.ClientApp]client.ClientAppStatus)
 				for _, status := range result2.Clients {
 					clients2[status.ClientType] = status
 				}
@@ -330,7 +330,7 @@ var _ = Describe("Discovery API", Label("api", "discovery", "e2e"), func() {
 // -----------------------------------------------------------------------------
 
 type clientStatusResponse struct {
-	Clients []client.MCPClientStatus `json:"clients"`
+	Clients []client.ClientAppStatus `json:"clients"`
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Renames the `MCPClient` type to `ClientApp` across the codebase — these represent AI coding tools (Claude Code, Cursor, Codex, etc.), not MCP-specific clients
- `MCPClientStatus` becomes `ClientAppStatus` as a consequence
- MCP-specific types and fields (`MCPServer`, `MCPServersPathPrefix`, etc.) are intentionally unchanged since they genuinely describe MCP concepts
- Regenerated mocks and swagger docs

## Motivation

With skills support coming (#3647), the client config struct will hold both MCP server settings and skill paths. Having the type called `MCPClient` would be misleading since skills have nothing to do with MCP. This rename prepares clean naming for that work.

## Test plan

- [x] `go build ./...` passes
- [x] `task test` (pkg/client, pkg/api, pkg/skills) — all pass
- [x] `task docs` regenerated
- [x] `task gen` regenerated mocks
- [x] Verified vmcp test helper `MCPClient` (different type) is untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)