### PR TITLE
Remove unused MCPServerConfig struct

### DIFF
--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -782,11 +782,6 @@ type ConfigFile struct {
 	Extension     Extension
 }
 
-// MCPServerConfig represents an MCP server configuration in a client config file
-type MCPServerConfig struct {
-	URL string `json:"url,omitempty"`
-}
-
 // FindClientConfig returns the client configuration file for a given client type.
 func FindClientConfig(clientType MCPClient) (*ConfigFile, error) {
 	manager, err := NewClientManager()

--- a/pkg/client/config_editor_test.go
+++ b/pkg/client/config_editor_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/stacklok/toolhive/pkg/logger"
 )
 
-func TestUpsertMCPServerConfig(t *testing.T) {
+func TestUpsertMCPServer(t *testing.T) {
 	t.Parallel()
 
 	logger.Initialize()
@@ -119,7 +119,7 @@ func TestUpsertMCPServerConfig(t *testing.T) {
 	}
 }
 
-func TestRemoveMCPServerConfigNew(t *testing.T) {
+func TestRemoveMCPServer(t *testing.T) {
 	t.Parallel()
 
 	logger.Initialize()


### PR DESCRIPTION
## Summary

- Removes the dead `MCPServerConfig` struct from `pkg/client/config.go`
- This struct was defined but never used anywhere in the codebase
- The actual struct used for MCP server entries is `MCPServer` (in `config_editor.go`)
- Renames test functions that referenced the deleted struct:
  - `TestUpsertMCPServerConfig` → `TestUpsertMCPServer`
  - `TestRemoveMCPServerConfigNew` → `TestRemoveMCPServer`

## Context

`MCPServerConfig` only had a single `URL` field, while the real `MCPServer` struct has multiple URL field variants (`Url`, `ServerUrl`, `HttpUrl`, `Uri`) plus a `Type` field. It appears to be legacy code that was superseded but never cleaned up.

## Test plan

- [x] `go build ./...` passes
- [x] `pkg/client` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)