### PR TITLE
Rename mcpClientConfig to clientAppConfig

### DIFF
--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -122,8 +122,8 @@ const (
 	TOMLStorageTypeArray TOMLStorageType = "array"
 )
 
-// mcpClientConfig represents a configuration path for a supported MCP client.
-type mcpClientConfig struct {
+// clientAppConfig represents a configuration path for a supported MCP client.
+type clientAppConfig struct {
 	ClientType                    ClientApp
 	Description                   string
 	RelPath                       []string
@@ -145,14 +145,14 @@ type mcpClientConfig struct {
 
 // extractServersKeyFromConfig extracts the servers key from MCPServersPathPrefix
 // by removing the leading "/" (e.g., "/mcpServers" -> "mcpServers").
-func extractServersKeyFromConfig(cfg *mcpClientConfig) string {
+func extractServersKeyFromConfig(cfg *clientAppConfig) string {
 	return strings.TrimPrefix(cfg.MCPServersPathPrefix, "/")
 }
 
 // extractURLLabelFromConfig extracts the URL field label from MCPServersUrlLabelMap.
 // It checks transport types in priority order: StreamableHTTP, then Stdio.
 // Returns defaultURLFieldName if no mapping is found.
-func extractURLLabelFromConfig(cfg *mcpClientConfig) string {
+func extractURLLabelFromConfig(cfg *clientAppConfig) string {
 	if cfg.MCPServersUrlLabelMap != nil {
 		if label, ok := cfg.MCPServersUrlLabelMap[types.TransportTypeStreamableHTTP]; ok {
 			return label
@@ -171,7 +171,7 @@ var (
 	ErrUnsupportedClientType = fmt.Errorf("unsupported client type")
 )
 
-var supportedClientIntegrations = []mcpClientConfig{
+var supportedClientIntegrations = []clientAppConfig{
 	{
 		ClientType:   RooCode,
 		Description:  "VS Code Roo Code extension",
@@ -752,7 +752,7 @@ func GetClientDescription(clientType ClientApp) string {
 // with their descriptions, sorted alphabetically. This is suitable for use in CLI help text.
 func GetClientListFormatted() string {
 	// Create a sorted copy of the configurations
-	configs := make([]mcpClientConfig, len(supportedClientIntegrations))
+	configs := make([]clientAppConfig, len(supportedClientIntegrations))
 	copy(configs, supportedClientIntegrations)
 	sort.Slice(configs, func(i, j int) bool {
 		return configs[i].ClientType < configs[j].ClientType
@@ -867,7 +867,7 @@ func CreateClientConfig(clientType ClientApp) (*ConfigFile, error) {
 // CreateClientConfig creates a new client configuration file for a given client type using this manager's dependencies.
 func (cm *ClientManager) CreateClientConfig(clientType ClientApp) (*ConfigFile, error) {
 	// Find the configuration for the requested client type
-	var clientCfg *mcpClientConfig
+	var clientCfg *clientAppConfig
 	for _, cfg := range cm.clientIntegrations {
 		if cfg.ClientType == clientType {
 			clientCfg = &cfg
@@ -946,7 +946,7 @@ func (cm *ClientManager) Upsert(cf ConfigFile, name string, url string, transpor
 // If the map is nil or the transport type is not found, it falls back to "url" as the default.
 // For most clients, all transport types map to the same URL field (e.g., "url"), but some clients
 // like Gemini CLI use different URL fields per transport type (e.g., "url" for SSE, "httpUrl" for streamable HTTP).
-func buildMCPServer(url, transportType string, clientCfg *mcpClientConfig) MCPServer {
+func buildMCPServer(url, transportType string, clientCfg *clientAppConfig) MCPServer {
 	server := MCPServer{}
 
 	// Determine the URL field name from the transport type using MCPServersUrlLabelMap
@@ -982,7 +982,7 @@ func buildMCPServer(url, transportType string, clientCfg *mcpClientConfig) MCPSe
 // retrieveConfigFileMetadata retrieves the metadata for client configuration files using this manager's dependencies.
 func (cm *ClientManager) retrieveConfigFileMetadata(clientType ClientApp) (*ConfigFile, error) {
 	// Find the configuration for the requested client type
-	var clientCfg *mcpClientConfig
+	var clientCfg *clientAppConfig
 	for _, cfg := range cm.clientIntegrations {
 		if cfg.ClientType == clientType {
 			clientCfg = &cfg
@@ -1006,7 +1006,7 @@ func (cm *ClientManager) retrieveConfigFileMetadata(clientType ClientApp) (*Conf
 	var configUpdater ConfigUpdater
 	switch clientCfg.Extension {
 	case YAML:
-		// Use the generic YAML converter with configuration from mcpClientConfig
+		// Use the generic YAML converter with configuration from clientAppConfig
 		converter := NewGenericYAMLConverter(clientCfg)
 		configUpdater = &YAMLConfigUpdater{
 			Path:      path,

--- a/pkg/client/config_test.go
+++ b/pkg/client/config_test.go
@@ -29,8 +29,8 @@ const testValidYAML = `extensions: {}`
 const testValidTOML = ``
 
 // createMockClientConfigs creates a set of mock client configurations for testing
-func createMockClientConfigs() []mcpClientConfig {
-	return []mcpClientConfig{
+func createMockClientConfigs() []clientAppConfig {
+	return []clientAppConfig{
 		{
 			ClientType:           VSCode,
 			Description:          "Visual Studio Code (Mock)",
@@ -261,7 +261,7 @@ func TestFindClientConfigs(t *testing.T) { // Can't run in parallel because it u
 
 		// Create fake test client integrations with Cursor pointing to invalid JSON
 		// This tests the JSON validation error path
-		testClientIntegrations := []mcpClientConfig{
+		testClientIntegrations := []clientAppConfig{
 			{
 				ClientType:   VSCode,
 				Description:  "VS Code (Test)",
@@ -356,7 +356,7 @@ func TestSuccessfulClientConfigOperations(t *testing.T) {
 	logger.Initialize()
 
 	// Helper function to create isolated test setup for each subtest
-	setupSubtest := func(t *testing.T) (string, []mcpClientConfig, config.Provider) {
+	setupSubtest := func(t *testing.T) (string, []clientAppConfig, config.Provider) {
 		t.Helper()
 
 		// Create isolated temporary home directory for this subtest
@@ -560,7 +560,7 @@ func TestSuccessfulClientConfigOperations(t *testing.T) {
 }
 
 // Helper function to create test config files for specific client configurations
-func createTestConfigFilesWithConfigs(t *testing.T, homeDir string, clientConfigs []mcpClientConfig) {
+func createTestConfigFilesWithConfigs(t *testing.T, homeDir string, clientConfigs []clientAppConfig) {
 	t.Helper()
 	// Create test config files for each provided client configuration
 	for _, cfg := range clientConfigs {
@@ -612,7 +612,7 @@ func TestCreateClientConfig(t *testing.T) {
 		defer cleanup()
 
 		// Create mock client config for JSON client (VSCode)
-		mockClientConfigs := []mcpClientConfig{
+		mockClientConfigs := []clientAppConfig{
 			{
 				ClientType:           VSCode,
 				Description:          "Visual Studio Code (Mock)",
@@ -659,7 +659,7 @@ func TestCreateClientConfig(t *testing.T) {
 		defer cleanup()
 
 		// Create mock client config for YAML client (Goose)
-		mockClientConfigs := []mcpClientConfig{
+		mockClientConfigs := []clientAppConfig{
 			{
 				ClientType:           Goose,
 				Description:          "Goose AI agent (Mock)",
@@ -706,7 +706,7 @@ func TestCreateClientConfig(t *testing.T) {
 		defer cleanup()
 
 		// Create mock client config
-		mockClientConfigs := []mcpClientConfig{
+		mockClientConfigs := []clientAppConfig{
 			{
 				ClientType:           VSCode,
 				Description:          "Visual Studio Code (Mock)",
@@ -743,7 +743,7 @@ func TestCreateClientConfig(t *testing.T) {
 		defer cleanup()
 
 		// Create empty mock client configs (no supported clients)
-		mockClientConfigs := []mcpClientConfig{}
+		mockClientConfigs := []clientAppConfig{}
 
 		manager := NewTestClientManager(tempHome, nil, mockClientConfigs, configProvider)
 
@@ -763,7 +763,7 @@ func TestCreateClientConfig(t *testing.T) {
 		defer cleanup()
 
 		// Create empty mock client configs (no supported clients)
-		mockClientConfigs := []mcpClientConfig{}
+		mockClientConfigs := []clientAppConfig{}
 
 		manager := NewTestClientManager(tempHome, nil, mockClientConfigs, configProvider)
 
@@ -786,7 +786,7 @@ func TestCreateClientConfig(t *testing.T) {
 		defer cleanup()
 
 		// Create mock client config with a path that will cause write error
-		mockClientConfigs := []mcpClientConfig{
+		mockClientConfigs := []clientAppConfig{
 			{
 				ClientType:           VSCode,
 				Description:          "Visual Studio Code (Mock)",
@@ -846,7 +846,7 @@ func TestCreateTOMLClientConfig(t *testing.T) {
 		defer cleanup()
 
 		// Create mock client config for TOML client with array storage (MistralVibe)
-		mockClientConfigs := []mcpClientConfig{
+		mockClientConfigs := []clientAppConfig{
 			{
 				ClientType:           MistralVibe,
 				Description:          "Mistral Vibe IDE (Mock)",
@@ -894,7 +894,7 @@ func TestCreateTOMLClientConfig(t *testing.T) {
 		defer cleanup()
 
 		// Create mock client config for TOML client with map storage (Codex)
-		mockClientConfigs := []mcpClientConfig{
+		mockClientConfigs := []clientAppConfig{
 			{
 				ClientType:           Codex,
 				Description:          "OpenAI Codex CLI (Mock)",
@@ -944,7 +944,7 @@ func TestUpsertWithDynamicUrlFieldMapping(t *testing.T) {
 		tempHome := t.TempDir()
 
 		// Create mock client config for Gemini CLI with MCPServersUrlLabelMap
-		mockClientConfigs := []mcpClientConfig{
+		mockClientConfigs := []clientAppConfig{
 			{
 				ClientType:                    GeminiCli,
 				Description:                   "Google Gemini CLI (Mock)",
@@ -994,7 +994,7 @@ func TestUpsertWithDynamicUrlFieldMapping(t *testing.T) {
 		tempHome := t.TempDir()
 
 		// Create mock client config for Gemini CLI with MCPServersUrlLabelMap
-		mockClientConfigs := []mcpClientConfig{
+		mockClientConfigs := []clientAppConfig{
 			{
 				ClientType:                    GeminiCli,
 				Description:                   "Google Gemini CLI (Mock)",
@@ -1044,7 +1044,7 @@ func TestUpsertWithDynamicUrlFieldMapping(t *testing.T) {
 		tempHome := t.TempDir()
 
 		// Create mock client config with limited URL label map (no entry for "unknown")
-		mockClientConfigs := []mcpClientConfig{
+		mockClientConfigs := []clientAppConfig{
 			{
 				ClientType:                    GeminiCli,
 				Description:                   "Google Gemini CLI (Mock)",
@@ -1091,7 +1091,7 @@ func TestUpsertWithDynamicUrlFieldMapping(t *testing.T) {
 		tempHome := t.TempDir()
 
 		// Create mock client config for Windsurf (uses serverUrl for all transport types)
-		mockClientConfigs := []mcpClientConfig{
+		mockClientConfigs := []clientAppConfig{
 			{
 				ClientType:           Windsurf,
 				Description:          "Windsurf IDE (Mock)",
@@ -1149,7 +1149,7 @@ func TestBuildMCPServer(t *testing.T) {
 		name          string
 		url           string
 		transportType string
-		clientCfg     *mcpClientConfig
+		clientCfg     *clientAppConfig
 		expectUrl     string
 		expectSrvUrl  string
 		expectHttpUrl string
@@ -1159,7 +1159,7 @@ func TestBuildMCPServer(t *testing.T) {
 			name:          "url field without type",
 			url:           "http://localhost:8080",
 			transportType: types.TransportTypeSSE.String(),
-			clientCfg: &mcpClientConfig{
+			clientCfg: &clientAppConfig{
 				IsTransportTypeFieldSupported: false,
 				MCPServersUrlLabelMap: map[types.TransportType]string{
 					types.TransportTypeSSE: "url",
@@ -1174,7 +1174,7 @@ func TestBuildMCPServer(t *testing.T) {
 			name:          "serverUrl field without type",
 			url:           "http://localhost:8080",
 			transportType: types.TransportTypeSSE.String(),
-			clientCfg: &mcpClientConfig{
+			clientCfg: &clientAppConfig{
 				IsTransportTypeFieldSupported: false,
 				MCPServersUrlLabelMap: map[types.TransportType]string{
 					types.TransportTypeSSE: "serverUrl",
@@ -1189,7 +1189,7 @@ func TestBuildMCPServer(t *testing.T) {
 			name:          "httpUrl field without type",
 			url:           "http://localhost:8080",
 			transportType: types.TransportTypeStreamableHTTP.String(),
-			clientCfg: &mcpClientConfig{
+			clientCfg: &clientAppConfig{
 				IsTransportTypeFieldSupported: false,
 				MCPServersUrlLabelMap: map[types.TransportType]string{
 					types.TransportTypeStreamableHTTP: "httpUrl",
@@ -1204,7 +1204,7 @@ func TestBuildMCPServer(t *testing.T) {
 			name:          "url field with type support",
 			url:           "http://localhost:8080",
 			transportType: types.TransportTypeSSE.String(),
-			clientCfg: &mcpClientConfig{
+			clientCfg: &clientAppConfig{
 				IsTransportTypeFieldSupported: true,
 				MCPServersUrlLabelMap: map[types.TransportType]string{
 					types.TransportTypeSSE: "url",
@@ -1222,7 +1222,7 @@ func TestBuildMCPServer(t *testing.T) {
 			name:          "MCPServersUrlLabelMap uses transport map for URL field",
 			url:           "http://localhost:8080",
 			transportType: types.TransportTypeStreamableHTTP.String(),
-			clientCfg: &mcpClientConfig{
+			clientCfg: &clientAppConfig{
 				IsTransportTypeFieldSupported: false,
 				MCPServersUrlLabelMap: map[types.TransportType]string{
 					types.TransportTypeStreamableHTTP: "httpUrl",
@@ -1237,7 +1237,7 @@ func TestBuildMCPServer(t *testing.T) {
 			name:          "Unknown transport falls back to default url field",
 			url:           "http://localhost:8080",
 			transportType: "unknown-transport",
-			clientCfg: &mcpClientConfig{
+			clientCfg: &clientAppConfig{
 				IsTransportTypeFieldSupported: false,
 				MCPServersUrlLabelMap: map[types.TransportType]string{
 					types.TransportTypeSSE: "httpUrl",
@@ -1252,7 +1252,7 @@ func TestBuildMCPServer(t *testing.T) {
 			name:          "MCPServersUrlLabelMap with SSE uses url field",
 			url:           "http://localhost:8080",
 			transportType: types.TransportTypeSSE.String(),
-			clientCfg: &mcpClientConfig{
+			clientCfg: &clientAppConfig{
 				IsTransportTypeFieldSupported: false,
 				MCPServersUrlLabelMap: map[types.TransportType]string{
 					types.TransportTypeSSE:            "url",

--- a/pkg/client/converter.go
+++ b/pkg/client/converter.go
@@ -14,7 +14,7 @@ type YAMLConverter interface {
 	RemoveEntry(config interface{}, serverName string) error
 }
 
-// GenericYAMLConverter implements YAMLConverter using configuration from mcpClientConfig
+// GenericYAMLConverter implements YAMLConverter using configuration from clientAppConfig
 type GenericYAMLConverter struct {
 	storageType     YAMLStorageType        // How servers are stored in YAML (map or array)
 	serversPath     string                 // path to servers section (e.g., "extensions" or "mcpServers")
@@ -23,8 +23,8 @@ type GenericYAMLConverter struct {
 	urlLabel        string                 // label for URL field (e.g., "url", "uri", "serverUrl")
 }
 
-// NewGenericYAMLConverter creates a converter from mcpClientConfig
-func NewGenericYAMLConverter(cfg *mcpClientConfig) *GenericYAMLConverter {
+// NewGenericYAMLConverter creates a converter from clientAppConfig
+func NewGenericYAMLConverter(cfg *clientAppConfig) *GenericYAMLConverter {
 	return &GenericYAMLConverter{
 		storageType:     cfg.YAMLStorageType,
 		serversPath:     extractServersKeyFromConfig(cfg),

--- a/pkg/client/converter_test.go
+++ b/pkg/client/converter_test.go
@@ -17,8 +17,8 @@ const (
 )
 
 // Helper function to create a Goose-style config
-func createGooseConfig() *mcpClientConfig {
-	return &mcpClientConfig{
+func createGooseConfig() *clientAppConfig {
+	return &clientAppConfig{
 		ClientType:           Goose,
 		MCPServersPathPrefix: "/extensions",
 		MCPServersUrlLabelMap: map[types.TransportType]string{
@@ -36,8 +36,8 @@ func createGooseConfig() *mcpClientConfig {
 }
 
 // Helper function to create a Continue-style config
-func createContinueConfig() *mcpClientConfig {
-	return &mcpClientConfig{
+func createContinueConfig() *clientAppConfig {
+	return &clientAppConfig{
 		ClientType:           Continue,
 		MCPServersPathPrefix: "/mcpServers",
 		MCPServersUrlLabelMap: map[types.TransportType]string{

--- a/pkg/client/discovery.go
+++ b/pkg/client/discovery.go
@@ -20,7 +20,7 @@ import (
 type ClientManager struct {
 	homeDir            string
 	groupManager       groups.Manager
-	clientIntegrations []mcpClientConfig
+	clientIntegrations []clientAppConfig
 	configProvider     config.Provider
 }
 
@@ -49,7 +49,7 @@ func NewClientManager() (*ClientManager, error) {
 func NewTestClientManager(
 	homeDir string,
 	groupManager groups.Manager,
-	clientIntegrations []mcpClientConfig,
+	clientIntegrations []clientAppConfig,
 	configProvider config.Provider,
 ) *ClientManager {
 	return &ClientManager{

--- a/pkg/client/discovery_test.go
+++ b/pkg/client/discovery_test.go
@@ -21,8 +21,8 @@ import (
 
 // createTestClientIntegrations creates fake client integrations for testing
 // These match the file structure that the tests create
-func createTestClientIntegrations() []mcpClientConfig {
-	return []mcpClientConfig{
+func createTestClientIntegrations() []clientAppConfig {
+	return []clientAppConfig{
 		{
 			ClientType:   ClaudeCode,
 			Description:  "Claude Code CLI (Test)",
@@ -102,7 +102,7 @@ func TestGetClientStatus(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create explicit client integrations for this test to avoid race conditions with global variable
-	clientIntegrations := []mcpClientConfig{
+	clientIntegrations := []clientAppConfig{
 		{
 			ClientType:   ClaudeCode,
 			Description:  "Claude Code CLI (Test)",
@@ -225,7 +225,7 @@ func TestGetClientStatus_WithGroups(t *testing.T) {
 
 	// Now test GetClientStatus using ClientManager with dependency injection
 	// Use explicit client integrations for this test to avoid race conditions with global variable
-	clientIntegrations := []mcpClientConfig{
+	clientIntegrations := []clientAppConfig{
 		{
 			ClientType:   ClaudeCode,
 			Description:  "Claude Code CLI (Test)",


### PR DESCRIPTION
## Summary

- Renames the unexported `mcpClientConfig` struct to `clientAppConfig` in `pkg/client/`
- This struct holds per-client configuration (paths, file format, MCP server settings) and will soon include skill-specific fields (#3647)
- The `mcp` prefix was misleading since the struct describes a client application's overall config, not just its MCP aspects
- MCP-specific fields inside the struct (`MCPServersPathPrefix`, `MCPServersUrlLabelMap`, etc.) are intentionally unchanged

## Context

This is the second preparatory refactoring PR for skills support (#3647). The first was #3700 (rename `MCPClient` → `ClientApp`).

Since `clientAppConfig` is unexported, all changes are internal to `pkg/client/` (6 files, pure rename).

## Test plan

- [x] `go build ./...` passes
- [x] `pkg/client` tests pass
- [x] `task lint` passes (0 issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)