### PR TITLE
Address miscellanious post-merge review feedback for AWS STS role mapper

### DIFF
--- a/pkg/auth/awssts/role_mapper.go
+++ b/pkg/auth/awssts/role_mapper.go
@@ -61,6 +61,11 @@ func ValidateRoleArn(roleArn string) error {
 	if len(parsed.AccountID) != 12 {
 		return fmt.Errorf("%w: invalid account ID: %s", ErrInvalidRoleArn, roleArn)
 	}
+	for _, c := range parsed.AccountID {
+		if c < '0' || c > '9' {
+			return fmt.Errorf("%w: invalid account ID: %s", ErrInvalidRoleArn, roleArn)
+		}
+	}
 
 	return nil
 }


### PR DESCRIPTION
Apply small fixes from the post-merge review of #3609:

- Validate that AWS account ID contains only digits, not just that it is 12 characters long
- Strengthen concurrency test to verify the correct role is returned for each input rather than just checking membership in the set of valid roles
- Use fmt.Sprintf for user name generation in test instead of the less readable rune conversion

Related: #3567 