### PR TITLE
Make role mapping Priority in AWS STS config optional with *int

### DIFF
--- a/pkg/auth/awssts/config.go
+++ b/pkg/auth/awssts/config.go
@@ -65,5 +65,7 @@ type RoleMapping struct {
 
 	// Priority determines selection order (lower number = higher priority).
 	// When multiple mappings match, the one with the lowest priority is selected.
-	Priority int `json:"priority" yaml:"priority"`
+	// When nil (omitted), the mapping has the lowest possible priority, and
+	// configuration order acts as tie-breaker via stable sort.
+	Priority *int `json:"priority,omitempty" yaml:"priority,omitempty"`
 }


### PR DESCRIPTION
Change Priority from int to *int so users can omit it when they don't care about ordering. Nil defaults to math.MaxInt (lowest priority), and stable sort preserves config order as the natural tie-breaker.