### PR TITLE
Enable OIDC provider support in the embedded auth server

### DIFF
--- a/pkg/authserver/runner/embeddedauthserver_test.go
+++ b/pkg/authserver/runner/embeddedauthserver_test.go
@@ -9,10 +9,7 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/x509"
-	"encoding/json"
 	"encoding/pem"
-	"net/http"
-	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -647,15 +644,107 @@ func TestNewEmbeddedAuthServer(t *testing.T) {
 	})
 }
 
-func TestBuildOIDCConfig(t *testing.T) {
+func TestBuildUpstreamConfig(t *testing.T) {
 	t.Parallel()
 
-	// Constants for OIDC well-known paths used in test mocks
-	const (
-		wellKnownOIDCPath  = "/.well-known/openid-configuration"
-		wellKnownOAuthPath = "/.well-known/oauth-authorization-server"
-		httpScheme         = "http"
-	)
+	t.Run("OIDC type returns UpstreamConfig with OIDCConfig", func(t *testing.T) {
+		t.Parallel()
+
+		rc := &authserver.UpstreamRunConfig{
+			Name: "google",
+			Type: authserver.UpstreamProviderTypeOIDC,
+			OIDCConfig: &authserver.OIDCUpstreamRunConfig{
+				IssuerURL:   "https://accounts.google.com",
+				ClientID:    "my-client-id",
+				RedirectURI: "http://localhost:8080/callback",
+				Scopes:      []string{"openid", "email"},
+			},
+		}
+
+		cfg, err := buildUpstreamConfig(rc)
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+
+		assert.Equal(t, "google", cfg.Name)
+		assert.Equal(t, authserver.UpstreamProviderTypeOIDC, cfg.Type)
+		require.NotNil(t, cfg.OIDCConfig, "OIDCConfig should be set for OIDC type")
+		assert.Nil(t, cfg.OAuth2Config, "OAuth2Config should be nil for OIDC type")
+		assert.Equal(t, "https://accounts.google.com", cfg.OIDCConfig.Issuer)
+		assert.Equal(t, "my-client-id", cfg.OIDCConfig.ClientID)
+		assert.Equal(t, []string{"openid", "email"}, cfg.OIDCConfig.Scopes)
+	})
+
+	t.Run("OAuth2 type returns UpstreamConfig with OAuth2Config", func(t *testing.T) {
+		t.Parallel()
+
+		rc := &authserver.UpstreamRunConfig{
+			Name: "github",
+			Type: authserver.UpstreamProviderTypeOAuth2,
+			OAuth2Config: &authserver.OAuth2UpstreamRunConfig{
+				AuthorizationEndpoint: "https://github.com/login/oauth/authorize",
+				TokenEndpoint:         "https://github.com/login/oauth/access_token",
+				ClientID:              "gh-client-id",
+				RedirectURI:           "http://localhost:8080/callback",
+			},
+		}
+
+		cfg, err := buildUpstreamConfig(rc)
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+
+		assert.Equal(t, "github", cfg.Name)
+		assert.Equal(t, authserver.UpstreamProviderTypeOAuth2, cfg.Type)
+		require.NotNil(t, cfg.OAuth2Config, "OAuth2Config should be set for OAuth2 type")
+		assert.Nil(t, cfg.OIDCConfig, "OIDCConfig should be nil for OAuth2 type")
+		assert.Equal(t, "gh-client-id", cfg.OAuth2Config.ClientID)
+		assert.Equal(t, "https://github.com/login/oauth/authorize", cfg.OAuth2Config.AuthorizationEndpoint)
+	})
+
+	t.Run("unknown type returns error", func(t *testing.T) {
+		t.Parallel()
+
+		rc := &authserver.UpstreamRunConfig{
+			Name: "unknown-provider",
+			Type: authserver.UpstreamProviderType("saml"),
+		}
+
+		_, err := buildUpstreamConfig(rc)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unsupported upstream type")
+		assert.Contains(t, err.Error(), "saml")
+	})
+
+	t.Run("OIDC type with nil OIDCConfig returns error", func(t *testing.T) {
+		t.Parallel()
+
+		rc := &authserver.UpstreamRunConfig{
+			Name:       "broken",
+			Type:       authserver.UpstreamProviderTypeOIDC,
+			OIDCConfig: nil,
+		}
+
+		_, err := buildUpstreamConfig(rc)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "oidc_config required")
+	})
+
+	t.Run("OAuth2 type with nil OAuth2Config returns error", func(t *testing.T) {
+		t.Parallel()
+
+		rc := &authserver.UpstreamRunConfig{
+			Name:         "broken",
+			Type:         authserver.UpstreamProviderTypeOAuth2,
+			OAuth2Config: nil,
+		}
+
+		_, err := buildUpstreamConfig(rc)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "oauth2_config required")
+	})
+}
+
+func TestBuildOIDCConfig(t *testing.T) {
+	t.Parallel()
 
 	t.Run("nil OIDCConfig returns error", func(t *testing.T) {
 		t.Parallel()
@@ -665,205 +754,60 @@ func TestBuildOIDCConfig(t *testing.T) {
 			OIDCConfig: nil,
 		}
 
-		_, err := buildOIDCConfig(context.Background(), rc)
+		_, err := buildOIDCConfig(rc)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "oidc_config required")
 	})
 
-	t.Run("successful discovery populates endpoints", func(t *testing.T) {
+	t.Run("builds config with issuer and client credentials", func(t *testing.T) {
 		t.Parallel()
-
-		// Create mock OIDC server with userinfo endpoint
-		mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.Path == wellKnownOIDCPath ||
-				r.URL.Path == wellKnownOAuthPath {
-				issuerURL := httpScheme + "://" + r.Host
-
-				doc := map[string]interface{}{
-					"issuer":                 issuerURL,
-					"authorization_endpoint": issuerURL + "/authorize",
-					"token_endpoint":         issuerURL + "/token",
-					"jwks_uri":               issuerURL + "/.well-known/jwks.json",
-					"userinfo_endpoint":      issuerURL + "/userinfo",
-				}
-
-				w.Header().Set("Content-Type", "application/json")
-				err := json.NewEncoder(w).Encode(doc)
-				require.NoError(t, err)
-				return
-			}
-			http.NotFound(w, r)
-		}))
-		defer mockServer.Close()
 
 		rc := &authserver.UpstreamRunConfig{
 			Type: authserver.UpstreamProviderTypeOIDC,
 			OIDCConfig: &authserver.OIDCUpstreamRunConfig{
-				IssuerURL:   mockServer.URL,
+				IssuerURL:   "https://example.com",
 				ClientID:    "test-client-id",
 				RedirectURI: "http://localhost:8080/callback",
 				Scopes:      []string{"openid", "profile"},
 			},
 		}
 
-		cfg, err := buildOIDCConfig(context.Background(), rc)
+		cfg, err := buildOIDCConfig(rc)
 		require.NoError(t, err)
 		require.NotNil(t, cfg)
 
-		// Verify endpoints from discovery
-		assert.Equal(t, mockServer.URL+"/authorize", cfg.AuthorizationEndpoint)
-		assert.Equal(t, mockServer.URL+"/token", cfg.TokenEndpoint)
+		// Verify issuer is set (discovery happens in factory)
+		assert.Equal(t, "https://example.com", cfg.Issuer)
 
 		// Verify client config is passed through
 		assert.Equal(t, "test-client-id", cfg.ClientID)
 		assert.Equal(t, "http://localhost:8080/callback", cfg.RedirectURI)
 		assert.Equal(t, []string{"openid", "profile"}, cfg.Scopes)
-
-		// Verify userinfo endpoint is populated from discovery
-		require.NotNil(t, cfg.UserInfo)
-		assert.Equal(t, mockServer.URL+"/userinfo", cfg.UserInfo.EndpointURL)
 	})
 
-	t.Run("UserInfoOverride takes precedence over discovered endpoint", func(t *testing.T) {
+	t.Run("applies default scopes when not specified", func(t *testing.T) {
 		t.Parallel()
-
-		// Create mock OIDC server with a userinfo endpoint
-		mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.Path == wellKnownOIDCPath ||
-				r.URL.Path == wellKnownOAuthPath {
-				issuerURL := httpScheme + "://" + r.Host
-
-				doc := map[string]interface{}{
-					"issuer":                 issuerURL,
-					"authorization_endpoint": issuerURL + "/authorize",
-					"token_endpoint":         issuerURL + "/token",
-					"jwks_uri":               issuerURL + "/.well-known/jwks.json",
-					"userinfo_endpoint":      issuerURL + "/discovered-userinfo",
-				}
-
-				w.Header().Set("Content-Type", "application/json")
-				err := json.NewEncoder(w).Encode(doc)
-				require.NoError(t, err)
-				return
-			}
-			http.NotFound(w, r)
-		}))
-		defer mockServer.Close()
 
 		rc := &authserver.UpstreamRunConfig{
 			Type: authserver.UpstreamProviderTypeOIDC,
 			OIDCConfig: &authserver.OIDCUpstreamRunConfig{
-				IssuerURL:   mockServer.URL,
+				IssuerURL:   "https://example.com",
 				ClientID:    "test-client-id",
 				RedirectURI: "http://localhost:8080/callback",
-				UserInfoOverride: &authserver.UserInfoRunConfig{
-					EndpointURL: "https://custom.example.com/userinfo",
-					HTTPMethod:  "POST",
-				},
+				// No scopes specified
 			},
 		}
 
-		cfg, err := buildOIDCConfig(context.Background(), rc)
+		cfg, err := buildOIDCConfig(rc)
 		require.NoError(t, err)
 		require.NotNil(t, cfg)
 
-		// UserInfoOverride should take precedence over discovered endpoint
-		require.NotNil(t, cfg.UserInfo)
-		assert.Equal(t, "https://custom.example.com/userinfo", cfg.UserInfo.EndpointURL)
-		assert.Equal(t, "POST", cfg.UserInfo.HTTPMethod)
-	})
-
-	t.Run("no userinfo when not discovered and no override", func(t *testing.T) {
-		t.Parallel()
-
-		// Create mock OIDC server without userinfo endpoint
-		mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.Path == wellKnownOIDCPath ||
-				r.URL.Path == wellKnownOAuthPath {
-				issuerURL := httpScheme + "://" + r.Host
-
-				doc := map[string]interface{}{
-					"issuer":                 issuerURL,
-					"authorization_endpoint": issuerURL + "/authorize",
-					"token_endpoint":         issuerURL + "/token",
-					"jwks_uri":               issuerURL + "/.well-known/jwks.json",
-					// No userinfo_endpoint
-				}
-
-				w.Header().Set("Content-Type", "application/json")
-				err := json.NewEncoder(w).Encode(doc)
-				require.NoError(t, err)
-				return
-			}
-			http.NotFound(w, r)
-		}))
-		defer mockServer.Close()
-
-		rc := &authserver.UpstreamRunConfig{
-			Type: authserver.UpstreamProviderTypeOIDC,
-			OIDCConfig: &authserver.OIDCUpstreamRunConfig{
-				IssuerURL:   mockServer.URL,
-				ClientID:    "test-client-id",
-				RedirectURI: "http://localhost:8080/callback",
-				// No UserInfoOverride
-			},
-		}
-
-		cfg, err := buildOIDCConfig(context.Background(), rc)
-		require.NoError(t, err)
-		require.NotNil(t, cfg)
-
-		// UserInfo should be nil when not discovered and no override
-		assert.Nil(t, cfg.UserInfo)
-	})
-
-	t.Run("discovery failure returns error", func(t *testing.T) {
-		t.Parallel()
-
-		// Create mock server that returns 404
-		mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			http.Error(w, "not found", http.StatusNotFound)
-		}))
-		defer mockServer.Close()
-
-		rc := &authserver.UpstreamRunConfig{
-			Type: authserver.UpstreamProviderTypeOIDC,
-			OIDCConfig: &authserver.OIDCUpstreamRunConfig{
-				IssuerURL:   mockServer.URL,
-				ClientID:    "test-client-id",
-				RedirectURI: "http://localhost:8080/callback",
-			},
-		}
-
-		_, err := buildOIDCConfig(context.Background(), rc)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "OIDC discovery failed")
+		// Verify default scopes are applied
+		assert.Equal(t, []string{"openid", "offline_access"}, cfg.Scopes)
 	})
 
 	t.Run("resolves client secret from file", func(t *testing.T) {
 		t.Parallel()
-
-		// Create mock OIDC server
-		mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.Path == wellKnownOIDCPath ||
-				r.URL.Path == wellKnownOAuthPath {
-				issuerURL := httpScheme + "://" + r.Host
-
-				doc := map[string]interface{}{
-					"issuer":                 issuerURL,
-					"authorization_endpoint": issuerURL + "/authorize",
-					"token_endpoint":         issuerURL + "/token",
-					"jwks_uri":               issuerURL + "/.well-known/jwks.json",
-				}
-
-				w.Header().Set("Content-Type", "application/json")
-				err := json.NewEncoder(w).Encode(doc)
-				require.NoError(t, err)
-				return
-			}
-			http.NotFound(w, r)
-		}))
-		defer mockServer.Close()
 
 		// Create secret file
 		tmpDir := t.TempDir()
@@ -873,17 +817,63 @@ func TestBuildOIDCConfig(t *testing.T) {
 		rc := &authserver.UpstreamRunConfig{
 			Type: authserver.UpstreamProviderTypeOIDC,
 			OIDCConfig: &authserver.OIDCUpstreamRunConfig{
-				IssuerURL:        mockServer.URL,
+				IssuerURL:        "https://example.com",
 				ClientID:         "test-client-id",
 				ClientSecretFile: secretFile,
 				RedirectURI:      "http://localhost:8080/callback",
 			},
 		}
 
-		cfg, err := buildOIDCConfig(context.Background(), rc)
+		cfg, err := buildOIDCConfig(rc)
 		require.NoError(t, err)
 		require.NotNil(t, cfg)
 
 		assert.Equal(t, "my-oidc-client-secret", cfg.ClientSecret)
+	})
+
+	t.Run("missing secret file returns error", func(t *testing.T) {
+		t.Parallel()
+
+		rc := &authserver.UpstreamRunConfig{
+			Type: authserver.UpstreamProviderTypeOIDC,
+			OIDCConfig: &authserver.OIDCUpstreamRunConfig{
+				IssuerURL:        "https://example.com",
+				ClientID:         "test-client-id",
+				ClientSecretFile: "/nonexistent/secret",
+				RedirectURI:      "http://localhost:8080/callback",
+			},
+		}
+
+		_, err := buildOIDCConfig(rc)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to resolve OIDC client secret")
+	})
+
+	t.Run("UserInfoOverride is ignored without error", func(t *testing.T) {
+		t.Parallel()
+
+		// UserInfoOverride is intentionally not propagated to upstream.OIDCConfig
+		// because OIDC providers resolve identity from ID tokens, not UserInfo.
+		// This test documents that behavior.
+		rc := &authserver.UpstreamRunConfig{
+			Name: "with-userinfo-override",
+			Type: authserver.UpstreamProviderTypeOIDC,
+			OIDCConfig: &authserver.OIDCUpstreamRunConfig{
+				IssuerURL:   "https://example.com",
+				ClientID:    "test-client-id",
+				RedirectURI: "http://localhost:8080/callback",
+				UserInfoOverride: &authserver.UserInfoRunConfig{
+					EndpointURL: "https://example.com/userinfo",
+				},
+			},
+		}
+
+		cfg, err := buildOIDCConfig(rc)
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+
+		// OIDCConfig has no UserInfo field - verify the config is otherwise valid
+		assert.Equal(t, "https://example.com", cfg.Issuer)
+		assert.Equal(t, "test-client-id", cfg.ClientID)
 	})
 }

--- a/pkg/authserver/server_test.go
+++ b/pkg/authserver/server_test.go
@@ -42,7 +42,7 @@ func TestNew(t *testing.T) {
 
 	validKeyProvider := keys.NewGeneratingProvider(keys.DefaultAlgorithm)
 	validHMAC := &servercrypto.HMACSecrets{Current: validHMACSecret()}
-	validUpstreams := []UpstreamConfig{{Name: "default", Config: validUpstreamConfig()}}
+	validUpstreams := []UpstreamConfig{{Name: "default", Type: UpstreamProviderTypeOAuth2, OAuth2Config: validUpstreamConfig()}}
 
 	tests := []struct {
 		name        string
@@ -154,12 +154,12 @@ func TestNewServer_Success(t *testing.T) {
 		Issuer:           "https://example.com",
 		KeyProvider:      keys.NewGeneratingProvider(keys.DefaultAlgorithm),
 		HMACSecrets:      &servercrypto.HMACSecrets{Current: validHMACSecret()},
-		Upstreams:        []UpstreamConfig{{Name: "default", Config: validUpstreamConfig()}},
+		Upstreams:        []UpstreamConfig{{Name: "default", Type: UpstreamProviderTypeOAuth2, OAuth2Config: validUpstreamConfig()}},
 		AllowedAudiences: []string{"https://mcp.example.com"},
 	}
 
 	// Create factory that returns our mock
-	mockFactory := func(_ *upstream.OAuth2Config) (upstream.OAuth2Provider, error) {
+	mockFactory := func(_ context.Context, _ *UpstreamConfig) (upstream.OAuth2Provider, error) {
 		return mockUpstream, nil
 	}
 


### PR DESCRIPTION
Previously, the embedded auth server converted all upstream configs to OAuth2Config, which meant OIDCProviderImpl was never instantiated even when the upstream was configured as type "oidc". This caused OIDC features like ID token validation and automatic discovery to be silently skipped.

Refactor UpstreamConfig to carry an explicit provider type ("oidc" or "oauth2") with separate OIDCConfig and OAuth2Config fields. The upstream factory now dispatches on type, creating OIDCProviderImpl (with OIDC discovery and ID token validation) for OIDC upstreams and BaseOAuth2Provider for OAuth2 upstreams. Config validation enforces mutual exclusivity between the two config fields.

Tested end-to-end with Google as the OIDC upstream:

```yaml
    upstreamProviders:
      - name: google
        type: oidc
        oidcConfig:
          issuerUrl: "https://accounts.google.com"
          clientId: "<google-client-id>"
          clientSecretRef:
            name: google-oauth-secret
            key: client-secret
          redirectUri: "https://example.com/oauth/callback"
          scopes:
            - openid
            - email
```

Fixes: https://github.com/stacklok/stacklok-epics/issues/235