### PR TITLE
Integrate AWS STS token exchange with SigV4 signing middleware

### DIFF
--- a/docs/server/docs.go
+++ b/docs/server/docs.go
@@ -379,6 +379,65 @@ const docTemplate = `{
                 },
                 "type": "object"
             },
+            "awssts.Config": {
+                "description": "AWSStsConfig contains AWS STS token exchange configuration for accessing AWS services",
+                "properties": {
+                    "fallback_role_arn": {
+                        "description": "FallbackRoleArn is the IAM role ARN to assume when no role mapping matches.",
+                        "type": "string"
+                    },
+                    "region": {
+                        "description": "Region is the AWS region for STS and SigV4 signing.",
+                        "type": "string"
+                    },
+                    "role_claim": {
+                        "description": "RoleClaim is the JWT claim to use for role mapping (default: \"groups\").",
+                        "type": "string"
+                    },
+                    "role_mappings": {
+                        "description": "RoleMappings maps JWT claim values to IAM roles with priority.",
+                        "items": {
+                            "$ref": "#/components/schemas/awssts.RoleMapping"
+                        },
+                        "type": "array",
+                        "uniqueItems": false
+                    },
+                    "service": {
+                        "description": "Service is the AWS service name for SigV4 signing (default: \"aws-mcp\").",
+                        "type": "string"
+                    },
+                    "session_duration": {
+                        "description": "SessionDuration is the duration in seconds for assumed role credentials.",
+                        "type": "integer"
+                    },
+                    "session_name_claim": {
+                        "description": "SessionNameClaim is the JWT claim to use for role session name (default: \"sub\").",
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "awssts.RoleMapping": {
+                "properties": {
+                    "claim": {
+                        "description": "Claim is the simple claim value to match (e.g., group name).\nInternally compiles to a CEL expression: \"\u003cclaim_value\u003e\" in claims[\"\u003crole_claim\u003e\"]\nMutually exclusive with Matcher.",
+                        "type": "string"
+                    },
+                    "matcher": {
+                        "description": "Matcher is a CEL expression for complex matching against JWT claims.\nThe expression has access to a \"claims\" variable containing all JWT claims.\nExamples:\n  - \"admins\" in claims[\"groups\"]\n  - claims[\"sub\"] == \"user123\" \u0026\u0026 !(\"act\" in claims)\nMutually exclusive with Claim.",
+                        "type": "string"
+                    },
+                    "priority": {
+                        "description": "Priority determines selection order (lower number = higher priority).\nWhen multiple mappings match, the one with the lowest priority is selected.\nWhen nil (omitted), the mapping has the lowest possible priority, and\nconfiguration order acts as tie-breaker via stable sort.",
+                        "type": "integer"
+                    },
+                    "role_arn": {
+                        "description": "RoleArn is the IAM role ARN to assume when this mapping matches.",
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
             "client.ClientApp": {
                 "description": "ClientType is the type of MCP client",
                 "enum": [
@@ -1218,6 +1277,9 @@ const docTemplate = `{
                     "authz_config_path": {
                         "description": "DEPRECATED: Middleware configuration.\nAuthzConfigPath is the path to the authorization configuration file",
                         "type": "string"
+                    },
+                    "aws_sts_config": {
+                        "$ref": "#/components/schemas/awssts.Config"
                     },
                     "base_name": {
                         "description": "BaseName is the base name used for the container (without prefixes)",

--- a/docs/server/swagger.json
+++ b/docs/server/swagger.json
@@ -372,6 +372,65 @@
                 },
                 "type": "object"
             },
+            "awssts.Config": {
+                "description": "AWSStsConfig contains AWS STS token exchange configuration for accessing AWS services",
+                "properties": {
+                    "fallback_role_arn": {
+                        "description": "FallbackRoleArn is the IAM role ARN to assume when no role mapping matches.",
+                        "type": "string"
+                    },
+                    "region": {
+                        "description": "Region is the AWS region for STS and SigV4 signing.",
+                        "type": "string"
+                    },
+                    "role_claim": {
+                        "description": "RoleClaim is the JWT claim to use for role mapping (default: \"groups\").",
+                        "type": "string"
+                    },
+                    "role_mappings": {
+                        "description": "RoleMappings maps JWT claim values to IAM roles with priority.",
+                        "items": {
+                            "$ref": "#/components/schemas/awssts.RoleMapping"
+                        },
+                        "type": "array",
+                        "uniqueItems": false
+                    },
+                    "service": {
+                        "description": "Service is the AWS service name for SigV4 signing (default: \"aws-mcp\").",
+                        "type": "string"
+                    },
+                    "session_duration": {
+                        "description": "SessionDuration is the duration in seconds for assumed role credentials.",
+                        "type": "integer"
+                    },
+                    "session_name_claim": {
+                        "description": "SessionNameClaim is the JWT claim to use for role session name (default: \"sub\").",
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "awssts.RoleMapping": {
+                "properties": {
+                    "claim": {
+                        "description": "Claim is the simple claim value to match (e.g., group name).\nInternally compiles to a CEL expression: \"\u003cclaim_value\u003e\" in claims[\"\u003crole_claim\u003e\"]\nMutually exclusive with Matcher.",
+                        "type": "string"
+                    },
+                    "matcher": {
+                        "description": "Matcher is a CEL expression for complex matching against JWT claims.\nThe expression has access to a \"claims\" variable containing all JWT claims.\nExamples:\n  - \"admins\" in claims[\"groups\"]\n  - claims[\"sub\"] == \"user123\" \u0026\u0026 !(\"act\" in claims)\nMutually exclusive with Claim.",
+                        "type": "string"
+                    },
+                    "priority": {
+                        "description": "Priority determines selection order (lower number = higher priority).\nWhen multiple mappings match, the one with the lowest priority is selected.\nWhen nil (omitted), the mapping has the lowest possible priority, and\nconfiguration order acts as tie-breaker via stable sort.",
+                        "type": "integer"
+                    },
+                    "role_arn": {
+                        "description": "RoleArn is the IAM role ARN to assume when this mapping matches.",
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
             "client.ClientApp": {
                 "description": "ClientType is the type of MCP client",
                 "enum": [
@@ -1211,6 +1270,9 @@
                     "authz_config_path": {
                         "description": "DEPRECATED: Middleware configuration.\nAuthzConfigPath is the path to the authorization configuration file",
                         "type": "string"
+                    },
+                    "aws_sts_config": {
+                        "$ref": "#/components/schemas/awssts.Config"
                     },
                     "base_name": {
                         "description": "BaseName is the base name used for the container (without prefixes)",

--- a/docs/server/swagger.yaml
+++ b/docs/server/swagger.yaml
@@ -385,6 +385,68 @@ components:
           description: Version is the version of the configuration format.
           type: string
       type: object
+    awssts.Config:
+      description: AWSStsConfig contains AWS STS token exchange configuration for
+        accessing AWS services
+      properties:
+        fallback_role_arn:
+          description: FallbackRoleArn is the IAM role ARN to assume when no role
+            mapping matches.
+          type: string
+        region:
+          description: Region is the AWS region for STS and SigV4 signing.
+          type: string
+        role_claim:
+          description: 'RoleClaim is the JWT claim to use for role mapping (default:
+            "groups").'
+          type: string
+        role_mappings:
+          description: RoleMappings maps JWT claim values to IAM roles with priority.
+          items:
+            $ref: '#/components/schemas/awssts.RoleMapping'
+          type: array
+          uniqueItems: false
+        service:
+          description: 'Service is the AWS service name for SigV4 signing (default:
+            "aws-mcp").'
+          type: string
+        session_duration:
+          description: SessionDuration is the duration in seconds for assumed role
+            credentials.
+          type: integer
+        session_name_claim:
+          description: 'SessionNameClaim is the JWT claim to use for role session
+            name (default: "sub").'
+          type: string
+      type: object
+    awssts.RoleMapping:
+      properties:
+        claim:
+          description: |-
+            Claim is the simple claim value to match (e.g., group name).
+            Internally compiles to a CEL expression: "<claim_value>" in claims["<role_claim>"]
+            Mutually exclusive with Matcher.
+          type: string
+        matcher:
+          description: |-
+            Matcher is a CEL expression for complex matching against JWT claims.
+            The expression has access to a "claims" variable containing all JWT claims.
+            Examples:
+              - "admins" in claims["groups"]
+              - claims["sub"] == "user123" && !("act" in claims)
+            Mutually exclusive with Claim.
+          type: string
+        priority:
+          description: |-
+            Priority determines selection order (lower number = higher priority).
+            When multiple mappings match, the one with the lowest priority is selected.
+            When nil (omitted), the mapping has the lowest possible priority, and
+            configuration order acts as tie-breaker via stable sort.
+          type: integer
+        role_arn:
+          description: RoleArn is the IAM role ARN to assume when this mapping matches.
+          type: string
+      type: object
     client.ClientApp:
       description: ClientType is the type of MCP client
       enum:
@@ -1137,6 +1199,8 @@ components:
             DEPRECATED: Middleware configuration.
             AuthzConfigPath is the path to the authorization configuration file
           type: string
+        aws_sts_config:
+          $ref: '#/components/schemas/awssts.Config'
         base_name:
           description: BaseName is the base name used for the container (without prefixes)
           type: string

--- a/pkg/auth/awssts/config.go
+++ b/pkg/auth/awssts/config.go
@@ -37,12 +37,31 @@ type Config struct {
 	SessionNameClaim string `json:"session_name_claim,omitempty" yaml:"session_name_claim,omitempty"`
 }
 
+// defaultSessionDuration is the default session duration in seconds (1 hour).
+const defaultSessionDuration int32 = 3600
+
 // GetRoleClaim returns the configured role claim or the default.
 func (c *Config) GetRoleClaim() string {
 	if c.RoleClaim != "" {
 		return c.RoleClaim
 	}
 	return defaultRoleClaim
+}
+
+// GetService returns the configured service name or the default ("aws-mcp").
+func (c *Config) GetService() string {
+	if c.Service != "" {
+		return c.Service
+	}
+	return defaultService
+}
+
+// GetSessionDuration returns the configured session duration or the default (3600s).
+func (c *Config) GetSessionDuration() int32 {
+	if c.SessionDuration != 0 {
+		return c.SessionDuration
+	}
+	return defaultSessionDuration
 }
 
 // RoleMapping maps a JWT claim value or CEL expression to an IAM role with explicit priority.

--- a/pkg/auth/awssts/errors.go
+++ b/pkg/auth/awssts/errors.go
@@ -39,4 +39,7 @@ var (
 
 	// ErrSTSNilCredentials is returned when STS returns a response without credentials.
 	ErrSTSNilCredentials = errors.New("STS returned nil credentials")
+
+	// ErrAccessDenied is returned when AWS STS denies access.
+	ErrAccessDenied = errors.New("access denied")
 )

--- a/pkg/auth/awssts/middleware.go
+++ b/pkg/auth/awssts/middleware.go
@@ -1,0 +1,302 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package awssts provides AWS STS token exchange with SigV4 signing support.
+package awssts
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+
+	"github.com/stacklok/toolhive/pkg/auth"
+	"github.com/stacklok/toolhive/pkg/logger"
+	"github.com/stacklok/toolhive/pkg/transport/types"
+)
+
+// Middleware type constant
+const (
+	MiddlewareType = "awssts"
+)
+
+// Default session name claim when not specified in config.
+const defaultSessionNameClaim = "sub"
+
+// MiddlewareParams represents the parameters for AWS STS middleware.
+type MiddlewareParams struct {
+	AWSStsConfig *Config `json:"aws_sts_config,omitempty"`
+	// TargetURL is the remote MCP server URL for SigV4 signing.
+	// The request must be signed with the target host, not the proxy host.
+	TargetURL string `json:"target_url,omitempty"`
+}
+
+// Middleware wraps AWS STS middleware functionality.
+type Middleware struct {
+	middleware types.MiddlewareFunction
+	exchanger  *Exchanger
+}
+
+// Handler returns the middleware function used by the proxy.
+func (m *Middleware) Handler() types.MiddlewareFunction {
+	return m.middleware
+}
+
+// Close cleans up any resources used by the middleware.
+func (*Middleware) Close() error {
+	return nil
+}
+
+// CreateMiddleware is the factory function for AWS STS middleware.
+func CreateMiddleware(config *types.MiddlewareConfig, runner types.MiddlewareRunner) error {
+	var params MiddlewareParams
+	if err := json.Unmarshal(config.Parameters, &params); err != nil {
+		return fmt.Errorf("failed to unmarshal AWS STS middleware parameters: %w", err)
+	}
+
+	// AWS STS config is required when this middleware type is specified
+	if params.AWSStsConfig == nil {
+		return fmt.Errorf("AWS STS configuration is required but not provided")
+	}
+
+	// Validate configuration at startup
+	if err := ValidateConfig(params.AWSStsConfig); err != nil {
+		return fmt.Errorf("invalid AWS STS configuration: %w", err)
+	}
+
+	// Parse and validate target URL if provided
+	var targetURL *url.URL
+	if params.TargetURL != "" {
+		var err error
+		targetURL, err = url.Parse(params.TargetURL)
+		if err != nil {
+			return fmt.Errorf("invalid target URL: %w", err)
+		}
+		if targetURL.Scheme == "" || targetURL.Host == "" {
+			return fmt.Errorf("target URL must include scheme and host (e.g., https://example.com)")
+		}
+	}
+
+	// Create the middleware
+	// TODO(jakub): MiddlewareFactory interface does not accept a context; pass context.TODO
+	// because we don't really have a better option here.
+	mw, err := newAWSStsMiddleware(context.TODO(), params.AWSStsConfig, targetURL)
+	if err != nil {
+		return fmt.Errorf("failed to create AWS STS middleware: %w", err)
+	}
+
+	// Add middleware to runner
+	runner.AddMiddleware(config.Type, mw)
+
+	return nil
+}
+
+// newAWSStsMiddleware creates a new AWS STS middleware with all required components.
+// targetURL is the remote MCP server URL used for SigV4 signing (can be nil if not proxying).
+func newAWSStsMiddleware(ctx context.Context, cfg *Config, targetURL *url.URL) (*Middleware, error) {
+	// Create the STS exchanger with regional endpoint
+	exchanger, err := NewExchanger(ctx, cfg.Region)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create STS exchanger: %w", err)
+	}
+
+	// Create the role mapper
+	roleMapper, err := NewRoleMapper(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create role mapper: %w", err)
+	}
+
+	// Create the SigV4 signer
+	signer, err := newRequestSigner(cfg.Region, withService(cfg.GetService()))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create SigV4 signer: %w", err)
+	}
+
+	// Determine session name claim
+	sessionNameClaim := cfg.SessionNameClaim
+	if sessionNameClaim == "" {
+		sessionNameClaim = defaultSessionNameClaim
+	}
+
+	// Get session duration
+	sessionDuration := cfg.GetSessionDuration()
+
+	// Create the middleware function
+	middlewareFunc := createAWSStsMiddlewareFunc(exchanger, roleMapper, signer, sessionNameClaim, sessionDuration, targetURL)
+
+	return &Middleware{
+		middleware: middlewareFunc,
+		exchanger:  exchanger,
+	}, nil
+}
+
+// createAWSStsMiddlewareFunc creates the HTTP middleware function.
+// targetURL is the remote MCP server URL used for SigV4 signing.
+// SigV4 requires signing with the actual target host, not the proxy host.
+func createAWSStsMiddlewareFunc(
+	exchanger *Exchanger,
+	roleMapper *RoleMapper,
+	signer *requestSigner,
+	sessionNameClaim string,
+	sessionDuration int32,
+	targetURL *url.URL,
+) types.MiddlewareFunction {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Get identity from the auth middleware.
+			// Unlike token exchange/upstream swap middleware, AWS STS requires valid
+			// credentials and cannot fall through — every request must be signed.
+			identity, ok := auth.IdentityFromContext(r.Context())
+			if !ok {
+				logger.Warn("No identity found in context, rejecting request")
+				http.Error(w, "Authentication required", http.StatusUnauthorized)
+				return
+			}
+
+			// Extract JWT claims from identity
+			claims := identity.Claims
+			if claims == nil {
+				logger.Warn("No claims in identity, rejecting request")
+				http.Error(w, "Authentication required", http.StatusUnauthorized)
+				return
+			}
+
+			// Use RoleMapper to select the appropriate IAM role based on claims
+			roleArn, err := roleMapper.SelectRole(claims)
+			if err != nil {
+				logger.Warnf("Failed to select IAM role: %v", err)
+				http.Error(w, "Failed to determine IAM role", http.StatusForbidden)
+				return
+			}
+
+			logger.Debugf("Selected IAM role: %s", roleArn)
+
+			// Extract bearer token from request
+			bearerToken, err := auth.ExtractBearerToken(r)
+			if err != nil {
+				logger.Warnf("No valid Bearer token found: %v", err)
+				http.Error(w, "Bearer token required", http.StatusUnauthorized)
+				return
+			}
+
+			// Extract session name from claims
+			sessionName, err := extractSessionName(claims, sessionNameClaim)
+			if err != nil {
+				logger.Warnf("Failed to extract session name: %v", err)
+				http.Error(w, "Missing session name claim", http.StatusUnauthorized)
+				return
+			}
+
+			logger.Debugf("Exchanging token for AWS credentials (session: %s)", sessionName)
+
+			// Exchange token for AWS credentials via STS
+			creds, err := exchanger.ExchangeToken(r.Context(), bearerToken, roleArn, sessionName, sessionDuration)
+			if err != nil {
+				logger.Warnf("STS token exchange failed: %v", err)
+				http.Error(w, "AWS credential exchange failed", http.StatusUnauthorized)
+				return
+			}
+
+			// Sign the request with SigV4 using a clone so we don't permanently
+			// overwrite r.Host / r.URL.Host — that rewriting is the reverse
+			// proxy's responsibility, not ours. We only add the SigV4 headers.
+			if err := signRequestForTarget(r, signer, creds, targetURL); err != nil {
+				logger.Warnf("Failed to sign request with SigV4: %v", err)
+				http.Error(w, "Request signing failed", http.StatusInternalServerError)
+				return
+			}
+
+			logger.Debug("Request signed with AWS SigV4")
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// signRequestForTarget signs the request with SigV4 for the given target host
+// without permanently modifying r.Host or r.URL. When targetURL is non-nil, a
+// clone is used for signing so that only the SigV4 headers are copied back to
+// the original request; the reverse proxy's Director is left to handle host
+// rewriting. When targetURL is nil the request is signed in-place.
+func signRequestForTarget(r *http.Request, signer *requestSigner, creds *aws.Credentials, targetURL *url.URL) error {
+	if targetURL == nil {
+		return signer.SignRequest(r.Context(), r, creds)
+	}
+
+	// Buffer the body so both the signing clone and the original request
+	// can read it. The SigV4 signer consumes the body to compute the
+	// payload hash and then replaces it on the request it receives.
+	// Because Clone() shares the same Body reader, we must buffer once
+	// and provide fresh readers to each side.
+	var bodyBytes []byte
+	if r.Body != nil && r.Body != http.NoBody {
+		var err error
+		bodyBytes, err = io.ReadAll(io.LimitReader(r.Body, maxPayloadSize+1))
+		if err != nil {
+			return fmt.Errorf("failed to read request body for signing: %w", err)
+		}
+		if len(bodyBytes) > maxPayloadSize {
+			return fmt.Errorf("request body exceeds maximum size of %d bytes", maxPayloadSize)
+		}
+		_ = r.Body.Close()
+	}
+
+	// Build a signing-only clone with the target host.
+	signingReq := r.Clone(r.Context())
+	signingReq.URL.Scheme = targetURL.Scheme
+	signingReq.URL.Host = targetURL.Host
+	signingReq.Host = targetURL.Host
+	if bodyBytes != nil {
+		signingReq.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+		signingReq.ContentLength = int64(len(bodyBytes))
+	}
+
+	logger.Debugf("Signing request for target host: %s", targetURL.Host)
+
+	if err := signer.SignRequest(r.Context(), signingReq, creds); err != nil {
+		return err
+	}
+
+	// Copy only the SigV4 headers back — these are the only headers the
+	// AWS SDK v4 signer sets during SignHTTP.
+	r.Header.Set("Authorization", signingReq.Header.Get("Authorization"))
+	r.Header.Set("X-Amz-Date", signingReq.Header.Get("X-Amz-Date"))
+	if tok := signingReq.Header.Get("X-Amz-Security-Token"); tok != "" {
+		r.Header.Set("X-Amz-Security-Token", tok)
+	}
+
+	// Restore the body on the original request for downstream handlers
+	// (the reverse proxy and tracingTransport both read it again).
+	if bodyBytes != nil {
+		r.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+		r.ContentLength = int64(len(bodyBytes))
+	}
+
+	return nil
+}
+
+// extractSessionName extracts the session name from JWT claims.
+// Returns an error if the configured claim is missing or empty, since a missing
+// claim likely indicates a misconfiguration and would produce untraceable
+// CloudTrail entries.
+//
+// The returned value is passed directly to AWS STS as RoleSessionName.
+// and returns a clear error if the value doesn't conform.
+//
+// See: https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRoleWithWebIdentity.html
+func extractSessionName(claims map[string]interface{}, claimName string) (string, error) {
+	value, ok := claims[claimName]
+	if !ok {
+		return "", fmt.Errorf("claim %q not found in token", claimName)
+	}
+	strValue, ok := value.(string)
+	if !ok || strValue == "" {
+		return "", fmt.Errorf("claim %q is not a non-empty string", claimName)
+	}
+	return strValue, nil
+}

--- a/pkg/auth/awssts/middleware_test.go
+++ b/pkg/auth/awssts/middleware_test.go
@@ -1,0 +1,396 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package awssts
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	ststypes "github.com/aws/aws-sdk-go-v2/service/sts/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/stacklok/toolhive/pkg/auth"
+	"github.com/stacklok/toolhive/pkg/transport/types"
+	"github.com/stacklok/toolhive/pkg/transport/types/mocks"
+)
+
+// TestCreateMiddleware tests the factory function validation.
+func TestCreateMiddleware(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		params   MiddlewareParams
+		errorMsg string
+	}{
+		{
+			name:     "nil config returns error",
+			params:   MiddlewareParams{AWSStsConfig: nil},
+			errorMsg: "AWS STS configuration is required",
+		},
+		{
+			name: "missing region returns error",
+			params: MiddlewareParams{
+				AWSStsConfig: &Config{FallbackRoleArn: "arn:aws:iam::123456789012:role/TestRole"},
+			},
+			errorMsg: "AWS region is required",
+		},
+		{
+			name: "invalid role ARN format returns error",
+			params: MiddlewareParams{
+				AWSStsConfig: &Config{Region: "us-east-1", FallbackRoleArn: "invalid-arn"},
+			},
+			errorMsg: "invalid IAM role ARN format",
+		},
+		{
+			name: "target URL missing scheme and host returns error",
+			params: MiddlewareParams{
+				AWSStsConfig: &Config{Region: "us-east-1", FallbackRoleArn: "arn:aws:iam::123456789012:role/TestRole"},
+				TargetURL:    "example.com/path",
+			},
+			errorMsg: "target URL must include scheme and host",
+		},
+		{
+			name: "target URL missing host returns error",
+			params: MiddlewareParams{
+				AWSStsConfig: &Config{Region: "us-east-1", FallbackRoleArn: "arn:aws:iam::123456789012:role/TestRole"},
+				TargetURL:    "/just-a-path",
+			},
+			errorMsg: "target URL must include scheme and host",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockRunner := mocks.NewMockMiddlewareRunner(ctrl)
+
+			paramsJSON, err := json.Marshal(tt.params)
+			require.NoError(t, err)
+
+			config := &types.MiddlewareConfig{Type: MiddlewareType, Parameters: paramsJSON}
+			err = CreateMiddleware(config, mockRunner)
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.errorMsg)
+		})
+	}
+}
+
+// TestCreateMiddleware_Success tests the factory function happy path.
+func TestCreateMiddleware_Success(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockRunner := mocks.NewMockMiddlewareRunner(ctrl)
+	mockRunner.EXPECT().AddMiddleware(MiddlewareType, gomock.Any()).Times(1)
+
+	params := MiddlewareParams{
+		AWSStsConfig: &Config{
+			Region:          "us-east-1",
+			FallbackRoleArn: "arn:aws:iam::123456789012:role/TestRole",
+		},
+	}
+
+	paramsJSON, err := json.Marshal(params)
+	require.NoError(t, err)
+
+	config := &types.MiddlewareConfig{Type: MiddlewareType, Parameters: paramsJSON}
+	err = CreateMiddleware(config, mockRunner)
+
+	require.NoError(t, err)
+}
+
+// TestMiddlewareFunc_RejectsUnauthenticated tests that requests without proper
+// authentication are rejected when the middleware is configured.
+func TestMiddlewareFunc_RejectsUnauthenticated(t *testing.T) {
+	t.Parallel()
+
+	exchanger := &Exchanger{client: &mockSTSClient{}}
+	roleMapper, _ := NewRoleMapper(&Config{Region: "us-east-1", FallbackRoleArn: "arn:aws:iam::123456789012:role/TestRole"})
+	signer, _ := newRequestSigner("us-east-1")
+
+	middlewareFunc := createAWSStsMiddlewareFunc(exchanger, roleMapper, signer, "sub", 3600, nil)
+
+	tests := []struct {
+		name    string
+		setupFn func(*http.Request) *http.Request
+	}{
+		{
+			name:    "no identity in context",
+			setupFn: func(r *http.Request) *http.Request { return r },
+		},
+		{
+			name: "identity with nil claims",
+			setupFn: func(r *http.Request) *http.Request {
+				identity := &auth.Identity{Subject: "user123", Claims: nil}
+				return r.WithContext(auth.WithIdentity(r.Context(), identity))
+			},
+		},
+		{
+			name: "no bearer token",
+			setupFn: func(r *http.Request) *http.Request {
+				identity := &auth.Identity{Subject: "user123", Claims: map[string]interface{}{"sub": "user123"}}
+				return r.WithContext(auth.WithIdentity(r.Context(), identity))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			handlerCalled := false
+			testHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				handlerCalled = true
+				w.WriteHeader(http.StatusOK)
+			})
+
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+			req = tt.setupFn(req)
+
+			rec := httptest.NewRecorder()
+			middlewareFunc(testHandler).ServeHTTP(rec, req)
+
+			assert.Equal(t, http.StatusUnauthorized, rec.Code)
+			assert.False(t, handlerCalled)
+		})
+	}
+}
+
+// TestMiddlewareFunc_EndToEnd tests the full middleware flow: STS exchange,
+// SigV4 signing, target URL rewriting, and STS failure handling.
+func TestMiddlewareFunc_EndToEnd(t *testing.T) {
+	t.Parallel()
+
+	expiration := time.Now().Add(time.Hour)
+	successResponse := &sts.AssumeRoleWithWebIdentityOutput{
+		Credentials: &ststypes.Credentials{
+			AccessKeyId: aws.String("AKIATEST"), SecretAccessKey: aws.String("secret"),
+			SessionToken: aws.String("session"), Expiration: &expiration,
+		},
+	}
+
+	targetURL, err := url.Parse("https://aws-mcp.us-east-1.api.aws")
+	require.NoError(t, err)
+
+	tests := []struct {
+		name           string
+		mockClient     *mockSTSClient
+		targetURL      *url.URL
+		requestURL     string
+		requestBody    string // optional body to send with the request
+		wantStatus     int
+		wantAuthPrefix string
+		// wantOrigHost/Scheme assert that the middleware does NOT overwrite
+		// the original request's Host and URL fields — that is the reverse
+		// proxy's responsibility.
+		wantOrigHost   string
+		wantOrigScheme string
+		// wantBodyPreserved, if non-empty, asserts that the next handler
+		// can still read the request body after signing.
+		wantBodyPreserved string
+	}{
+		{
+			name:           "signs request successfully",
+			mockClient:     &mockSTSClient{response: successResponse},
+			requestURL:     "http://example.com/test",
+			wantStatus:     http.StatusOK,
+			wantAuthPrefix: "AWS4-HMAC-SHA256",
+		},
+		{
+			name:       "returns 401 on STS failure",
+			mockClient: &mockSTSClient{err: ErrAccessDenied},
+			requestURL: "/test",
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name:           "signs for target without rewriting host",
+			mockClient:     &mockSTSClient{response: successResponse},
+			targetURL:      targetURL,
+			requestURL:     "http://localhost:8080/mcp/v1",
+			wantStatus:     http.StatusOK,
+			wantAuthPrefix: "AWS4-HMAC-SHA256",
+			wantOrigHost:   "localhost:8080",
+			wantOrigScheme: "http",
+		},
+		{
+			name:              "signs for target with body preserving it for downstream",
+			mockClient:        &mockSTSClient{response: successResponse},
+			targetURL:         targetURL,
+			requestURL:        "http://localhost:8080/mcp/v1",
+			requestBody:       `{"method":"tools/list","params":{}}`,
+			wantStatus:        http.StatusOK,
+			wantAuthPrefix:    "AWS4-HMAC-SHA256",
+			wantOrigHost:      "localhost:8080",
+			wantOrigScheme:    "http",
+			wantBodyPreserved: `{"method":"tools/list","params":{}}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			exchanger := &Exchanger{client: tt.mockClient}
+			roleMapper, _ := NewRoleMapper(&Config{Region: "us-east-1", FallbackRoleArn: "arn:aws:iam::123456789012:role/TestRole"})
+			signer, _ := newRequestSigner("us-east-1")
+
+			middlewareFunc := createAWSStsMiddlewareFunc(exchanger, roleMapper, signer, "sub", 3600, tt.targetURL)
+
+			var capturedAuth, capturedHost, capturedURLHost, capturedScheme, capturedBody string
+			testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				capturedAuth = r.Header.Get("Authorization")
+				capturedHost = r.Host
+				capturedURLHost = r.URL.Host
+				capturedScheme = r.URL.Scheme
+				if r.Body != nil {
+					b, _ := io.ReadAll(r.Body)
+					capturedBody = string(b)
+				}
+				w.WriteHeader(http.StatusOK)
+			})
+
+			var bodyReader io.Reader
+			if tt.requestBody != "" {
+				bodyReader = strings.NewReader(tt.requestBody)
+			}
+			req := httptest.NewRequest(http.MethodPost, tt.requestURL, bodyReader)
+			req.Header.Set("Authorization", "Bearer test-jwt-token")
+			identity := &auth.Identity{Subject: "user123", Claims: map[string]interface{}{"sub": "user123"}}
+			req = req.WithContext(auth.WithIdentity(req.Context(), identity))
+
+			rec := httptest.NewRecorder()
+			middlewareFunc(testHandler).ServeHTTP(rec, req)
+
+			assert.Equal(t, tt.wantStatus, rec.Code)
+
+			if tt.wantAuthPrefix != "" {
+				assert.Contains(t, capturedAuth, tt.wantAuthPrefix)
+			}
+			if tt.wantOrigHost != "" {
+				assert.Equal(t, tt.wantOrigHost, capturedHost, "Host should not be overwritten by middleware")
+				assert.Equal(t, tt.wantOrigHost, capturedURLHost, "URL.Host should not be overwritten by middleware")
+			}
+			if tt.wantOrigScheme != "" {
+				assert.Equal(t, tt.wantOrigScheme, capturedScheme, "URL.Scheme should not be overwritten by middleware")
+			}
+			if tt.wantBodyPreserved != "" {
+				assert.Equal(t, tt.wantBodyPreserved, capturedBody, "Request body should be preserved after signing")
+			}
+		})
+	}
+}
+
+// TestMiddlewareFunc_RoleMapperFailure tests that the middleware returns 403
+// when the role mapper cannot determine an IAM role for the request.
+func TestMiddlewareFunc_RoleMapperFailure(t *testing.T) {
+	t.Parallel()
+
+	exchanger := &Exchanger{client: &mockSTSClient{}}
+	// No fallback role, only a mapping for "admins" group — claims won't match.
+	roleMapper, err := NewRoleMapper(&Config{
+		Region:    "us-east-1",
+		RoleClaim: "groups",
+		RoleMappings: []RoleMapping{
+			{Claim: "admins", RoleArn: "arn:aws:iam::123456789012:role/AdminRole"},
+		},
+	})
+	require.NoError(t, err)
+
+	signer, err := newRequestSigner("us-east-1")
+	require.NoError(t, err)
+
+	middlewareFunc := createAWSStsMiddlewareFunc(exchanger, roleMapper, signer, "sub", 3600, nil)
+
+	handlerCalled := false
+	testHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		handlerCalled = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/test", nil)
+	req.Header.Set("Authorization", "Bearer test-jwt-token")
+	identity := &auth.Identity{
+		Subject: "user123",
+		Claims: map[string]interface{}{
+			"sub":    "user123",
+			"groups": []interface{}{"developers"}, // Does not match "admins"
+		},
+	}
+	req = req.WithContext(auth.WithIdentity(req.Context(), identity))
+
+	rec := httptest.NewRecorder()
+	middlewareFunc(testHandler).ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.False(t, handlerCalled)
+}
+
+// TestExtractSessionName tests session name extraction from JWT claims.
+func TestExtractSessionName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		claims    map[string]interface{}
+		claimName string
+		want      string
+		wantErr   bool
+	}{
+		{
+			name:      "returns claim value",
+			claims:    map[string]interface{}{"sub": "user@example.com"},
+			claimName: "sub",
+			want:      "user@example.com",
+		},
+		{
+			name:      "missing claim returns error",
+			claims:    map[string]interface{}{"email": "user@example.com"},
+			claimName: "sub",
+			wantErr:   true,
+		},
+		{
+			name:      "empty string claim returns error",
+			claims:    map[string]interface{}{"sub": ""},
+			claimName: "sub",
+			wantErr:   true,
+		},
+		{
+			name:      "non-string claim returns error",
+			claims:    map[string]interface{}{"sub": 12345},
+			claimName: "sub",
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := extractSessionName(tt.claims, tt.claimName)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/auth/awssts/signer_test.go
+++ b/pkg/auth/awssts/signer_test.go
@@ -25,7 +25,7 @@ func TestEmptySHA256IsCorrect(t *testing.T) {
 	assert.Equal(t, hex.EncodeToString(h[:]), emptySHA256)
 }
 
-func Test_newRequestSigner(t *testing.T) {
+func TestNewRequestSigner(t *testing.T) {
 	t.Parallel()
 
 	t.Run("succeeds with valid region", func(t *testing.T) {
@@ -50,8 +50,9 @@ func Test_newRequestSigner(t *testing.T) {
 	})
 }
 
-//nolint:paralleltest // Tests share signer and credentials state
 func TestSigner_SignRequest(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	signer, err := newRequestSigner("us-east-1")
 	require.NoError(t, err)
@@ -65,6 +66,7 @@ func TestSigner_SignRequest(t *testing.T) {
 	}
 
 	t.Run("signs request with body", func(t *testing.T) {
+		t.Parallel()
 		body := `{"method": "tools/list"}`
 		req, _ := http.NewRequestWithContext(ctx, "POST", "https://aws-mcp.us-east-1.api.aws/mcp", strings.NewReader(body))
 		req.Header.Set("Content-Type", "application/json")
@@ -87,6 +89,8 @@ func TestSigner_SignRequest(t *testing.T) {
 	})
 
 	t.Run("signs request without body", func(t *testing.T) {
+		t.Parallel()
+
 		req, _ := http.NewRequestWithContext(ctx, "GET", "https://aws-mcp.us-east-1.api.aws/mcp", nil)
 
 		err := signer.SignRequest(ctx, req, validCreds)
@@ -95,6 +99,8 @@ func TestSigner_SignRequest(t *testing.T) {
 	})
 
 	t.Run("signs request with empty body", func(t *testing.T) {
+		t.Parallel()
+
 		req, _ := http.NewRequestWithContext(ctx, "POST", "https://aws-mcp.us-east-1.api.aws/mcp", http.NoBody)
 
 		err := signer.SignRequest(ctx, req, validCreds)
@@ -103,6 +109,8 @@ func TestSigner_SignRequest(t *testing.T) {
 	})
 
 	t.Run("errors with nil credentials", func(t *testing.T) {
+		t.Parallel()
+
 		req, _ := http.NewRequestWithContext(ctx, "POST", "https://aws-mcp.us-east-1.api.aws/mcp", nil)
 
 		err := signer.SignRequest(ctx, req, nil)
@@ -110,12 +118,13 @@ func TestSigner_SignRequest(t *testing.T) {
 	})
 }
 
-//nolint:paralleltest // Tests share signer state
 func TestSigner_HashPayload(t *testing.T) {
+	t.Parallel()
 	signer, err := newRequestSigner("us-east-1")
 	require.NoError(t, err)
 
 	t.Run("hashes body correctly", func(t *testing.T) {
+		t.Parallel()
 		body := "test body content"
 		req, _ := http.NewRequest("POST", "http://example.com", strings.NewReader(body))
 
@@ -132,6 +141,7 @@ func TestSigner_HashPayload(t *testing.T) {
 	})
 
 	t.Run("handles nil body", func(t *testing.T) {
+		t.Parallel()
 		req, _ := http.NewRequest("GET", "http://example.com", nil)
 
 		hash, bodyBytes, err := signer.hashPayload(req)
@@ -141,6 +151,7 @@ func TestSigner_HashPayload(t *testing.T) {
 	})
 
 	t.Run("handles http.NoBody", func(t *testing.T) {
+		t.Parallel()
 		req, _ := http.NewRequest("GET", "http://example.com", http.NoBody)
 
 		hash, bodyBytes, err := signer.hashPayload(req)
@@ -150,6 +161,7 @@ func TestSigner_HashPayload(t *testing.T) {
 	})
 
 	t.Run("handles large body within limit", func(t *testing.T) {
+		t.Parallel()
 		// 1MB body (well within 10MB limit)
 		largeBody := bytes.Repeat([]byte("x"), 1024*1024)
 		req, _ := http.NewRequest("POST", "http://example.com", bytes.NewReader(largeBody))
@@ -161,6 +173,7 @@ func TestSigner_HashPayload(t *testing.T) {
 	})
 
 	t.Run("rejects body exceeding size limit", func(t *testing.T) {
+		t.Parallel()
 		oversizedBody := bytes.Repeat([]byte("x"), maxPayloadSize+1)
 		req, _ := http.NewRequest("POST", "http://example.com", bytes.NewReader(oversizedBody))
 

--- a/pkg/runner/config.go
+++ b/pkg/runner/config.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/stacklok/toolhive/pkg/audit"
 	"github.com/stacklok/toolhive/pkg/auth"
+	"github.com/stacklok/toolhive/pkg/auth/awssts"
 	"github.com/stacklok/toolhive/pkg/auth/remote"
 	authsecrets "github.com/stacklok/toolhive/pkg/auth/secrets"
 	"github.com/stacklok/toolhive/pkg/auth/tokenexchange"
@@ -116,6 +117,9 @@ type RunConfig struct {
 	// When set along with EmbeddedAuthServerConfig, this middleware exchanges ToolHive JWTs
 	// for upstream IdP tokens before forwarding requests to the MCP server.
 	UpstreamSwapConfig *upstreamswap.Config `json:"upstream_swap_config,omitempty" yaml:"upstream_swap_config,omitempty"`
+
+	// AWSStsConfig contains AWS STS token exchange configuration for accessing AWS services
+	AWSStsConfig *awssts.Config `json:"aws_sts_config,omitempty" yaml:"aws_sts_config,omitempty"`
 
 	// DEPRECATED: Middleware configuration.
 	// AuthzConfig contains the authorization configuration

--- a/pkg/runner/config_builder.go
+++ b/pkg/runner/config_builder.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/stacklok/toolhive/pkg/audit"
 	"github.com/stacklok/toolhive/pkg/auth"
+	"github.com/stacklok/toolhive/pkg/auth/awssts"
 	"github.com/stacklok/toolhive/pkg/auth/remote"
 	"github.com/stacklok/toolhive/pkg/auth/tokenexchange"
 	"github.com/stacklok/toolhive/pkg/authserver"
@@ -397,6 +398,14 @@ func WithOIDCConfig(
 func WithTokenExchangeConfig(config *tokenexchange.Config) RunConfigBuilderOption {
 	return func(b *runConfigBuilder) error {
 		b.config.TokenExchangeConfig = config
+		return nil
+	}
+}
+
+// WithAWSStsConfig sets the AWS STS token exchange configuration
+func WithAWSStsConfig(config *awssts.Config) RunConfigBuilderOption {
+	return func(b *runConfigBuilder) error {
+		b.config.AWSStsConfig = config
 		return nil
 	}
 }

--- a/pkg/runner/middleware_test.go
+++ b/pkg/runner/middleware_test.go
@@ -10,11 +10,33 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/stacklok/toolhive/pkg/auth/awssts"
 	"github.com/stacklok/toolhive/pkg/auth/upstreamswap"
 	"github.com/stacklok/toolhive/pkg/authserver"
 	headerfwd "github.com/stacklok/toolhive/pkg/transport/middleware"
 	"github.com/stacklok/toolhive/pkg/transport/types"
 )
+
+// createMinimalAuthServerConfig creates a minimal valid EmbeddedAuthServerConfig for testing.
+func createMinimalAuthServerConfig() *authserver.RunConfig {
+	return &authserver.RunConfig{
+		SchemaVersion: authserver.CurrentSchemaVersion,
+		Issuer:        "http://localhost:8080",
+		Upstreams: []authserver.UpstreamRunConfig{
+			{
+				Name: "test-upstream",
+				Type: authserver.UpstreamProviderTypeOAuth2,
+				OAuth2Config: &authserver.OAuth2UpstreamRunConfig{
+					AuthorizationEndpoint: "https://example.com/authorize",
+					TokenEndpoint:         "https://example.com/token",
+					ClientID:              "test-client-id",
+					RedirectURI:           "http://localhost:8080/oauth/callback",
+				},
+			},
+		},
+		AllowedAudiences: []string{"https://mcp.example.com"},
+	}
+}
 
 func TestAddHeaderForwardMiddleware(t *testing.T) {
 	t.Parallel()
@@ -170,12 +192,18 @@ func TestWithMiddlewareFromFlags_ExcludesHeaderForward(t *testing.T) {
 	assert.Equal(t, map[string]string{"X-Key": "val"}, cfg.HeaderForward.AddPlaintextHeaders)
 }
 
-func TestGetSupportedMiddlewareFactories_IncludesHeaderForward(t *testing.T) {
+func TestGetSupportedMiddlewareFactories(t *testing.T) {
 	t.Parallel()
 
 	factories := GetSupportedMiddlewareFactories()
-	_, ok := factories[headerfwd.HeaderForwardMiddlewareName]
-	assert.True(t, ok, "factory map should contain %q", headerfwd.HeaderForwardMiddlewareName)
+	for _, key := range []string{
+		headerfwd.HeaderForwardMiddlewareName,
+		upstreamswap.MiddlewareType,
+		awssts.MiddlewareType,
+	} {
+		_, ok := factories[key]
+		assert.True(t, ok, "factory map should contain %q", key)
+	}
 }
 
 func TestWithHeaderForwardSecretsBuilderOption(t *testing.T) {
@@ -221,27 +249,6 @@ func TestWithHeaderForwardSecretsBuilderOption(t *testing.T) {
 
 func TestAddUpstreamSwapMiddleware(t *testing.T) {
 	t.Parallel()
-
-	// createMinimalAuthServerConfig creates a minimal valid EmbeddedAuthServerConfig for testing.
-	createMinimalAuthServerConfig := func() *authserver.RunConfig {
-		return &authserver.RunConfig{
-			SchemaVersion: authserver.CurrentSchemaVersion,
-			Issuer:        "http://localhost:8080",
-			Upstreams: []authserver.UpstreamRunConfig{
-				{
-					Name: "test-upstream",
-					Type: authserver.UpstreamProviderTypeOAuth2,
-					OAuth2Config: &authserver.OAuth2UpstreamRunConfig{
-						AuthorizationEndpoint: "https://example.com/authorize",
-						TokenEndpoint:         "https://example.com/token",
-						ClientID:              "test-client-id",
-						RedirectURI:           "http://localhost:8080/oauth/callback",
-					},
-				},
-			},
-			AllowedAudiences: []string{"https://mcp.example.com"},
-		}
-	}
 
 	tests := []struct {
 		name         string
@@ -322,27 +329,6 @@ func TestAddUpstreamSwapMiddleware(t *testing.T) {
 func TestPopulateMiddlewareConfigs_UpstreamSwap(t *testing.T) {
 	t.Parallel()
 
-	// createMinimalAuthServerConfig creates a minimal valid EmbeddedAuthServerConfig for testing.
-	createMinimalAuthServerConfig := func() *authserver.RunConfig {
-		return &authserver.RunConfig{
-			SchemaVersion: authserver.CurrentSchemaVersion,
-			Issuer:        "http://localhost:8080",
-			Upstreams: []authserver.UpstreamRunConfig{
-				{
-					Name: "test-upstream",
-					Type: authserver.UpstreamProviderTypeOAuth2,
-					OAuth2Config: &authserver.OAuth2UpstreamRunConfig{
-						AuthorizationEndpoint: "https://example.com/authorize",
-						TokenEndpoint:         "https://example.com/token",
-						ClientID:              "test-client-id",
-						RedirectURI:           "http://localhost:8080/oauth/callback",
-					},
-				},
-			},
-			AllowedAudiences: []string{"https://mcp.example.com"},
-		}
-	}
-
 	tests := []struct {
 		name               string
 		config             *RunConfig
@@ -402,10 +388,110 @@ func TestPopulateMiddlewareConfigs_UpstreamSwap(t *testing.T) {
 	}
 }
 
-func TestGetSupportedMiddlewareFactories_IncludesUpstreamSwap(t *testing.T) {
+func TestAddAWSStsMiddleware(t *testing.T) {
 	t.Parallel()
 
-	factories := GetSupportedMiddlewareFactories()
-	_, ok := factories[upstreamswap.MiddlewareType]
-	assert.True(t, ok, "factory map should contain %q", upstreamswap.MiddlewareType)
+	tests := []struct {
+		name         string
+		config       *RunConfig
+		wantAppended bool
+	}{
+		{
+			name:         "nil AWSStsConfig returns input unchanged",
+			config:       &RunConfig{AWSStsConfig: nil},
+			wantAppended: false,
+		},
+		{
+			name: "valid AWSStsConfig appends middleware with correct type and params",
+			config: &RunConfig{
+				AWSStsConfig: &awssts.Config{
+					Region:          "us-east-1",
+					FallbackRoleArn: "arn:aws:iam::123456789012:role/TestRole",
+				},
+				RemoteURL: "https://aws-mcp.us-east-1.api.aws",
+			},
+			wantAppended: true,
+		},
+		{
+			name: "AWSStsConfig without RemoteURL appends middleware with empty target URL",
+			config: &RunConfig{
+				AWSStsConfig: &awssts.Config{
+					Region:          "us-east-1",
+					FallbackRoleArn: "arn:aws:iam::123456789012:role/TestRole",
+				},
+			},
+			wantAppended: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			initial := []types.MiddlewareConfig{{Type: "existing"}}
+			got, err := addAWSStsMiddleware(initial, tt.config)
+			require.NoError(t, err)
+
+			if !tt.wantAppended {
+				assert.Equal(t, initial, got, "middleware slice should be unchanged")
+				return
+			}
+
+			require.Len(t, got, len(initial)+1)
+			added := got[len(got)-1]
+			assert.Equal(t, awssts.MiddlewareType, added.Type)
+
+			// Verify serialized params contain the config and target URL.
+			var params awssts.MiddlewareParams
+			require.NoError(t, json.Unmarshal(added.Parameters, &params))
+			require.NotNil(t, params.AWSStsConfig)
+			assert.Equal(t, tt.config.AWSStsConfig.Region, params.AWSStsConfig.Region)
+			assert.Equal(t, tt.config.RemoteURL, params.TargetURL)
+		})
+	}
+}
+
+func TestPopulateMiddlewareConfigs_AWSSts(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		config     *RunConfig
+		wantAWSSts bool
+	}{
+		{
+			name: "AWSStsConfig set includes awssts middleware",
+			config: &RunConfig{
+				AWSStsConfig: &awssts.Config{
+					Region:          "us-east-1",
+					FallbackRoleArn: "arn:aws:iam::123456789012:role/TestRole",
+				},
+			},
+			wantAWSSts: true,
+		},
+		{
+			name:       "nil AWSStsConfig omits awssts middleware",
+			config:     &RunConfig{AWSStsConfig: nil},
+			wantAWSSts: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := PopulateMiddlewareConfigs(tt.config)
+			require.NoError(t, err)
+
+			found := false
+			for _, mw := range tt.config.MiddlewareConfigs {
+				if mw.Type == awssts.MiddlewareType {
+					found = true
+					break
+				}
+			}
+			assert.Equal(t, tt.wantAWSSts, found,
+				"awssts middleware presence mismatch")
+		})
+	}
 }


### PR DESCRIPTION
Add an HTTP middleware that converts incoming OIDC bearer tokens into SigV4-signed AWS requests. The pipeline extracts JWT claims from the auth context, selects an IAM role via the RoleMapper, calls STS AssumeRoleWithWebIdentity for temporary credentials, and signs the outbound request with SigV4.

When a target URL is configured, the middleware clones the request with the target host for signing purposes but copies only the SigV4 headers (Authorization, X-Amz-Date, X-Amz-Security-Token) back to the original request, leaving host rewriting to the reverse proxy. Request bodies are buffered with a 10 MB size limit and restored for downstream handlers.

Wire the middleware into the runner: add AWSStsConfig to RunConfig, a WithAWSStsConfig builder option, factory registration in GetSupportedMiddlewareFactories, and placement in
PopulateMiddlewareConfigs after audit/authz but before header forwarding.

Also add GetService() and GetSessionDuration() config helpers, an ErrAccessDenied sentinel, and clean up the signer's body-close handling to use defer.

Fixes: #3569