### PR TITLE
DRAFT: Add network/client span attributes and fix span status per OTEL semconv

### DIFF
--- a/docs/telemetry-migration.md
+++ b/docs/telemetry-migration.md
@@ -140,6 +140,25 @@ affected and remain unchanged.
 | `mcp.protocol.version` | MCP protocol version (e.g., `2025-06-18`) |
 | `jsonrpc.protocol.version` | JSON-RPC protocol version (always `2.0`) |
 | `gen_ai.operation.name` | Operation type (e.g., `execute_tool`) |
+| `network.protocol.name` | Protocol name (e.g., `http`) |
+| `network.protocol.version` | HTTP protocol version (e.g., `1.1`, `2`) |
+| `client.address` | Client IP address |
+| `client.port` | Client port number |
+| `mcp.session.id` | MCP session ID from `Mcp-Session-Id` header |
+| `error.type` | HTTP status code string on 5xx errors |
+
+## Span Status Changes
+
+The span status behavior has been updated to follow OTEL semantic conventions:
+
+| HTTP Status | Old Behavior | New Behavior |
+|-------------|-------------|-------------|
+| 2xx/3xx | `Ok` | `Ok` |
+| 4xx | `Error` | `Unset` (not a server error) |
+| 5xx | `Error` | `Error` with `error.type` attribute |
+
+Per the OTEL spec, 4xx responses are client errors and should not set the span
+status to Error, as they are not indicative of server-side issues.
 
 ## Span Name Changes
 


### PR DESCRIPTION
## Summary

- Adds new additive span attributes: `network.protocol.name`, `network.protocol.version`, `client.address`, `client.port`, `mcp.session.id`
- Fixes span status to follow OTEL semconv: 4xx → Unset (client errors), 5xx → Error with `error.type`
- Adds `httpProtocolVersion` and `parseRemoteAddr` helper functions

These are new attributes that have no legacy equivalents — they are always emitted regardless of the `UseLegacyAttributes` setting.

Stacked on #3734 (attribute rename + dual emission).

## Test plan

- [x] Unit tests for `httpProtocolVersion` helper (HTTP/1.0, 1.1, 2.0, 3.0, zero)
- [x] Unit tests for `parseRemoteAddr` helper (host:port, IPv6, empty, no port)
- [x] Updated `TestHTTPMiddleware_FinalizeSpan_Logic` for 4xx → Unset, 5xx → Error behavior
- [x] Migration doc updated with span status changes and new attributes
- [x] `task lint` passes
- [x] `task test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)