### PR TITLE
Gate legacy span attributes behind UseLegacyAttributes flag

### DIFF
--- a/pkg/telemetry/integration_test.go
+++ b/pkg/telemetry/integration_test.go
@@ -186,8 +186,9 @@ func TestTelemetryIntegration_WithRealProviders(t *testing.T) {
 	)
 
 	config := Config{
-		ServiceName:    "test-service",
-		ServiceVersion: "1.0.0",
+		ServiceName:         "test-service",
+		ServiceVersion:      "1.0.0",
+		UseLegacyAttributes: true,
 	}
 
 	// Create middleware directly with real providers


### PR DESCRIPTION
## Summary

- Wraps all existing span attribute emissions in `if m.config.UseLegacyAttributes` conditionals
- This is a behavioral no-op since `UseLegacyAttributes` defaults to `true`
- Prepares the codebase for adding new OTEL semantic convention attribute names alongside legacy ones
- Adds test coverage for both `UseLegacyAttributes=true` and `UseLegacyAttributes=false` paths

This is a structural change only — no attributes are renamed or added. When `UseLegacyAttributes=true` (the default), all existing attributes are emitted exactly as before.

Stacked on #3729 (adds the `UseLegacyAttributes` config flag).

## Test plan

- [x] New unit test: `TestHTTPMiddleware_LegacyAttributes_Enabled` — verifies all legacy attributes emitted when flag is true
- [x] New unit test: `TestHTTPMiddleware_LegacyAttributes_Disabled` — verifies no legacy attributes emitted when flag is false
- [x] Integration test updated with `UseLegacyAttributes: true`
- [x] `task lint` passes
- [x] `task test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)