### PR TITLE
Fix SSE gauge leak, config bool handling, and metric error logging

### DIFF
--- a/cmd/thv/app/run_flags.go
+++ b/cmd/thv/app/run_flags.go
@@ -948,13 +948,12 @@ func getTelemetryFromFlags(cmd *cobra.Command, config *cfg.Config, otelEndpoint 
 	}
 
 	// UseLegacyAttributes defaults to true for this release to avoid breaking existing
-	// dashboards and alerts. Unlike other bool flags, we only override from config when
-	// the config value is true, because Go's zero-value false is indistinguishable from
-	// "not set". Users can disable via --otel-use-legacy-attributes=false.
+	// dashboards and alerts. When the config file explicitly sets this field (non-nil),
+	// use the config value. Otherwise, use the CLI flag value (which defaults to true).
 	// This default will change to false in a future release.
 	finalOtelUseLegacyAttributes := otelUseLegacyAttributes
-	if !cmd.Flags().Changed("otel-use-legacy-attributes") && config.OTEL.UseLegacyAttributes {
-		finalOtelUseLegacyAttributes = config.OTEL.UseLegacyAttributes
+	if !cmd.Flags().Changed("otel-use-legacy-attributes") && config.OTEL.UseLegacyAttributes != nil {
+		finalOtelUseLegacyAttributes = *config.OTEL.UseLegacyAttributes
 	}
 
 	return finalOtelEndpoint, finalOtelSamplingRate, finalOtelEnvironmentVariables,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -368,7 +368,7 @@ type OpenTelemetryConfig struct {
 	TracingEnabled              bool     `yaml:"tracing-enabled,omitempty"`
 	Insecure                    bool     `yaml:"insecure,omitempty"`
 	EnablePrometheusMetricsPath bool     `yaml:"enable-prometheus-metrics-path,omitempty"`
-	UseLegacyAttributes         bool     `yaml:"use-legacy-attributes"`
+	UseLegacyAttributes         *bool    `yaml:"use-legacy-attributes"`
 }
 
 // getRuntimeConfig returns the runtime configuration for a given transport type


### PR DESCRIPTION
## Summary

Three small telemetry bug fixes identified during OTEL MCP semantic conventions review ([#3399](https://github.com/stacklok/toolhive/issues/3399)):

- **SSE active connections gauge leak**: The `toolhive_mcp_active_connections` gauge with `connection_type=sse` was incremented in `recordSSEConnection` but never decremented, growing monotonically. Moved the increment into `Handler` with a `defer` decrement so the gauge correctly tracks SSE connection lifecycle.

- **Config file `use-legacy-attributes: false` silently ignored**: Go's zero-value `false` was indistinguishable from "not set", so setting `use-legacy-attributes: false` in YAML had no effect — the CLI default `true` always won. Changed `UseLegacyAttributes` from `bool` to `*bool` in the app config struct so `nil` (not set) is distinguishable from explicit `false`.

- **Metric creation errors silently discarded**: All four metric instruments in `NewHTTPMiddleware` used `_ :=` for errors. Now logged at debug level. The OTEL SDK returns no-op instruments on error so there is no runtime risk, but logging aids troubleshooting.

## Test plan

- [x] Existing telemetry middleware tests pass
- [x] Two new test cases added for `UseLegacyAttributes` config handling:
  - Config explicitly sets `false` → correctly applied
  - Config not set (`nil`) → CLI default `true` used
- [x] Linter passes with zero issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)