### PR TITLE
Wire AWS STS middleware into the runner middleware chain

### DIFF
--- a/docs/server/docs.go
+++ b/docs/server/docs.go
@@ -379,6 +379,65 @@ const docTemplate = `{
                 },
                 "type": "object"
             },
+            "awssts.Config": {
+                "description": "AWSStsConfig contains AWS STS token exchange configuration for accessing AWS services",
+                "properties": {
+                    "fallback_role_arn": {
+                        "description": "FallbackRoleArn is the IAM role ARN to assume when no role mapping matches.",
+                        "type": "string"
+                    },
+                    "region": {
+                        "description": "Region is the AWS region for STS and SigV4 signing.",
+                        "type": "string"
+                    },
+                    "role_claim": {
+                        "description": "RoleClaim is the JWT claim to use for role mapping (default: \"groups\").",
+                        "type": "string"
+                    },
+                    "role_mappings": {
+                        "description": "RoleMappings maps JWT claim values to IAM roles with priority.",
+                        "items": {
+                            "$ref": "#/components/schemas/awssts.RoleMapping"
+                        },
+                        "type": "array",
+                        "uniqueItems": false
+                    },
+                    "service": {
+                        "description": "Service is the AWS service name for SigV4 signing (default: \"aws-mcp\").",
+                        "type": "string"
+                    },
+                    "session_duration": {
+                        "description": "SessionDuration is the duration in seconds for assumed role credentials (default: 3600).",
+                        "type": "integer"
+                    },
+                    "session_name_claim": {
+                        "description": "SessionNameClaim is the JWT claim to use for role session name (default: \"sub\").",
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "awssts.RoleMapping": {
+                "properties": {
+                    "claim": {
+                        "description": "Claim is the simple claim value to match (e.g., group name).\nInternally compiles to a CEL expression: \"\u003cclaim_value\u003e\" in claims[\"\u003crole_claim\u003e\"]\nMutually exclusive with Matcher.",
+                        "type": "string"
+                    },
+                    "matcher": {
+                        "description": "Matcher is a CEL expression for complex matching against JWT claims.\nThe expression has access to a \"claims\" variable containing all JWT claims.\nExamples:\n  - \"admins\" in claims[\"groups\"]\n  - claims[\"sub\"] == \"user123\" \u0026\u0026 !(\"act\" in claims)\nMutually exclusive with Claim.",
+                        "type": "string"
+                    },
+                    "priority": {
+                        "description": "Priority determines selection order (lower number = higher priority).\nWhen multiple mappings match, the one with the lowest priority is selected.\nWhen nil (omitted), the mapping has the lowest possible priority, and\nconfiguration order acts as tie-breaker via stable sort.",
+                        "type": "integer"
+                    },
+                    "role_arn": {
+                        "description": "RoleArn is the IAM role ARN to assume when this mapping matches.",
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
             "client.ClientApp": {
                 "description": "ClientType is the type of MCP client",
                 "enum": [
@@ -1218,6 +1277,9 @@ const docTemplate = `{
                     "authz_config_path": {
                         "description": "DEPRECATED: Middleware configuration.\nAuthzConfigPath is the path to the authorization configuration file",
                         "type": "string"
+                    },
+                    "aws_sts_config": {
+                        "$ref": "#/components/schemas/awssts.Config"
                     },
                     "base_name": {
                         "description": "BaseName is the base name used for the container (without prefixes)",

--- a/docs/server/swagger.json
+++ b/docs/server/swagger.json
@@ -372,6 +372,65 @@
                 },
                 "type": "object"
             },
+            "awssts.Config": {
+                "description": "AWSStsConfig contains AWS STS token exchange configuration for accessing AWS services",
+                "properties": {
+                    "fallback_role_arn": {
+                        "description": "FallbackRoleArn is the IAM role ARN to assume when no role mapping matches.",
+                        "type": "string"
+                    },
+                    "region": {
+                        "description": "Region is the AWS region for STS and SigV4 signing.",
+                        "type": "string"
+                    },
+                    "role_claim": {
+                        "description": "RoleClaim is the JWT claim to use for role mapping (default: \"groups\").",
+                        "type": "string"
+                    },
+                    "role_mappings": {
+                        "description": "RoleMappings maps JWT claim values to IAM roles with priority.",
+                        "items": {
+                            "$ref": "#/components/schemas/awssts.RoleMapping"
+                        },
+                        "type": "array",
+                        "uniqueItems": false
+                    },
+                    "service": {
+                        "description": "Service is the AWS service name for SigV4 signing (default: \"aws-mcp\").",
+                        "type": "string"
+                    },
+                    "session_duration": {
+                        "description": "SessionDuration is the duration in seconds for assumed role credentials (default: 3600).",
+                        "type": "integer"
+                    },
+                    "session_name_claim": {
+                        "description": "SessionNameClaim is the JWT claim to use for role session name (default: \"sub\").",
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "awssts.RoleMapping": {
+                "properties": {
+                    "claim": {
+                        "description": "Claim is the simple claim value to match (e.g., group name).\nInternally compiles to a CEL expression: \"\u003cclaim_value\u003e\" in claims[\"\u003crole_claim\u003e\"]\nMutually exclusive with Matcher.",
+                        "type": "string"
+                    },
+                    "matcher": {
+                        "description": "Matcher is a CEL expression for complex matching against JWT claims.\nThe expression has access to a \"claims\" variable containing all JWT claims.\nExamples:\n  - \"admins\" in claims[\"groups\"]\n  - claims[\"sub\"] == \"user123\" \u0026\u0026 !(\"act\" in claims)\nMutually exclusive with Claim.",
+                        "type": "string"
+                    },
+                    "priority": {
+                        "description": "Priority determines selection order (lower number = higher priority).\nWhen multiple mappings match, the one with the lowest priority is selected.\nWhen nil (omitted), the mapping has the lowest possible priority, and\nconfiguration order acts as tie-breaker via stable sort.",
+                        "type": "integer"
+                    },
+                    "role_arn": {
+                        "description": "RoleArn is the IAM role ARN to assume when this mapping matches.",
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
             "client.ClientApp": {
                 "description": "ClientType is the type of MCP client",
                 "enum": [
@@ -1211,6 +1270,9 @@
                     "authz_config_path": {
                         "description": "DEPRECATED: Middleware configuration.\nAuthzConfigPath is the path to the authorization configuration file",
                         "type": "string"
+                    },
+                    "aws_sts_config": {
+                        "$ref": "#/components/schemas/awssts.Config"
                     },
                     "base_name": {
                         "description": "BaseName is the base name used for the container (without prefixes)",

--- a/docs/server/swagger.yaml
+++ b/docs/server/swagger.yaml
@@ -385,6 +385,68 @@ components:
           description: Version is the version of the configuration format.
           type: string
       type: object
+    awssts.Config:
+      description: AWSStsConfig contains AWS STS token exchange configuration for
+        accessing AWS services
+      properties:
+        fallback_role_arn:
+          description: FallbackRoleArn is the IAM role ARN to assume when no role
+            mapping matches.
+          type: string
+        region:
+          description: Region is the AWS region for STS and SigV4 signing.
+          type: string
+        role_claim:
+          description: 'RoleClaim is the JWT claim to use for role mapping (default:
+            "groups").'
+          type: string
+        role_mappings:
+          description: RoleMappings maps JWT claim values to IAM roles with priority.
+          items:
+            $ref: '#/components/schemas/awssts.RoleMapping'
+          type: array
+          uniqueItems: false
+        service:
+          description: 'Service is the AWS service name for SigV4 signing (default:
+            "aws-mcp").'
+          type: string
+        session_duration:
+          description: 'SessionDuration is the duration in seconds for assumed role
+            credentials (default: 3600).'
+          type: integer
+        session_name_claim:
+          description: 'SessionNameClaim is the JWT claim to use for role session
+            name (default: "sub").'
+          type: string
+      type: object
+    awssts.RoleMapping:
+      properties:
+        claim:
+          description: |-
+            Claim is the simple claim value to match (e.g., group name).
+            Internally compiles to a CEL expression: "<claim_value>" in claims["<role_claim>"]
+            Mutually exclusive with Matcher.
+          type: string
+        matcher:
+          description: |-
+            Matcher is a CEL expression for complex matching against JWT claims.
+            The expression has access to a "claims" variable containing all JWT claims.
+            Examples:
+              - "admins" in claims["groups"]
+              - claims["sub"] == "user123" && !("act" in claims)
+            Mutually exclusive with Claim.
+          type: string
+        priority:
+          description: |-
+            Priority determines selection order (lower number = higher priority).
+            When multiple mappings match, the one with the lowest priority is selected.
+            When nil (omitted), the mapping has the lowest possible priority, and
+            configuration order acts as tie-breaker via stable sort.
+          type: integer
+        role_arn:
+          description: RoleArn is the IAM role ARN to assume when this mapping matches.
+          type: string
+      type: object
     client.ClientApp:
       description: ClientType is the type of MCP client
       enum:
@@ -1137,6 +1199,8 @@ components:
             DEPRECATED: Middleware configuration.
             AuthzConfigPath is the path to the authorization configuration file
           type: string
+        aws_sts_config:
+          $ref: '#/components/schemas/awssts.Config'
         base_name:
           description: BaseName is the base name used for the container (without prefixes)
           type: string

--- a/pkg/auth/awssts/config.go
+++ b/pkg/auth/awssts/config.go
@@ -30,7 +30,7 @@ type Config struct {
 	// RoleClaim is the JWT claim to use for role mapping (default: "groups").
 	RoleClaim string `json:"role_claim,omitempty" yaml:"role_claim,omitempty"`
 
-	// SessionDuration is the duration in seconds for assumed role credentials.
+	// SessionDuration is the duration in seconds for assumed role credentials (default: 3600).
 	SessionDuration int32 `json:"session_duration,omitempty" yaml:"session_duration,omitempty"`
 
 	// SessionNameClaim is the JWT claim to use for role session name (default: "sub").

--- a/pkg/runner/config.go
+++ b/pkg/runner/config.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/stacklok/toolhive/pkg/audit"
 	"github.com/stacklok/toolhive/pkg/auth"
+	"github.com/stacklok/toolhive/pkg/auth/awssts"
 	"github.com/stacklok/toolhive/pkg/auth/remote"
 	authsecrets "github.com/stacklok/toolhive/pkg/auth/secrets"
 	"github.com/stacklok/toolhive/pkg/auth/tokenexchange"
@@ -116,6 +117,9 @@ type RunConfig struct {
 	// When set along with EmbeddedAuthServerConfig, this middleware exchanges ToolHive JWTs
 	// for upstream IdP tokens before forwarding requests to the MCP server.
 	UpstreamSwapConfig *upstreamswap.Config `json:"upstream_swap_config,omitempty" yaml:"upstream_swap_config,omitempty"`
+
+	// AWSStsConfig contains AWS STS token exchange configuration for accessing AWS services
+	AWSStsConfig *awssts.Config `json:"aws_sts_config,omitempty" yaml:"aws_sts_config,omitempty"`
 
 	// DEPRECATED: Middleware configuration.
 	// AuthzConfig contains the authorization configuration

--- a/pkg/runner/config_builder.go
+++ b/pkg/runner/config_builder.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/stacklok/toolhive/pkg/audit"
 	"github.com/stacklok/toolhive/pkg/auth"
+	"github.com/stacklok/toolhive/pkg/auth/awssts"
 	"github.com/stacklok/toolhive/pkg/auth/remote"
 	"github.com/stacklok/toolhive/pkg/auth/tokenexchange"
 	"github.com/stacklok/toolhive/pkg/authserver"
@@ -397,6 +398,14 @@ func WithOIDCConfig(
 func WithTokenExchangeConfig(config *tokenexchange.Config) RunConfigBuilderOption {
 	return func(b *runConfigBuilder) error {
 		b.config.TokenExchangeConfig = config
+		return nil
+	}
+}
+
+// WithAWSStsConfig sets the AWS STS token exchange configuration
+func WithAWSStsConfig(config *awssts.Config) RunConfigBuilderOption {
+	return func(b *runConfigBuilder) error {
+		b.config.AWSStsConfig = config
 		return nil
 	}
 }

--- a/pkg/runner/middleware.go
+++ b/pkg/runner/middleware.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stacklok/toolhive/pkg/audit"
 	"github.com/stacklok/toolhive/pkg/auth"
+	"github.com/stacklok/toolhive/pkg/auth/awssts"
 	"github.com/stacklok/toolhive/pkg/auth/tokenexchange"
 	"github.com/stacklok/toolhive/pkg/auth/upstreamswap"
 	"github.com/stacklok/toolhive/pkg/authz"
@@ -26,6 +27,7 @@ func GetSupportedMiddlewareFactories() map[string]types.MiddlewareFactory {
 		auth.MiddlewareType:                   auth.CreateMiddleware,
 		tokenexchange.MiddlewareType:          tokenexchange.CreateMiddleware,
 		upstreamswap.MiddlewareType:           upstreamswap.CreateMiddleware,
+		awssts.MiddlewareType:                 awssts.CreateMiddleware,
 		mcp.ParserMiddlewareType:              mcp.CreateParserMiddleware,
 		mcp.ToolFilterMiddlewareType:          mcp.CreateToolFilterMiddleware,
 		mcp.ToolCallFilterMiddlewareType:      mcp.CreateToolCallFilterMiddleware,
@@ -163,6 +165,15 @@ func PopulateMiddlewareConfigs(config *RunConfig) error {
 		middlewareConfigs = append(middlewareConfigs, *auditConfig)
 	}
 
+	// AWS STS middleware (if configured)
+	// Placed after audit/authz so that authorization is checked before exchanging
+	// credentials, and close to the backend so SigV4 signing happens as late as
+	// possible — minimizing the chance of subsequent middleware invalidating the signature.
+	middlewareConfigs, err = addAWSStsMiddleware(middlewareConfigs, config)
+	if err != nil {
+		return err
+	}
+
 	// Header forward middleware (if configured for remote servers).
 	// Added near the end so it executes closest to the backend handler (innermost).
 	// By this point, WithSecrets() has resolved any secret-backed headers
@@ -268,4 +279,27 @@ func addUpstreamSwapMiddleware(
 		return nil, fmt.Errorf("failed to create upstream swap middleware config: %w", err)
 	}
 	return append(middlewares, *upstreamSwapMwConfig), nil
+}
+
+// addAWSStsMiddleware adds AWS STS middleware if configured.
+// Returns an error if AWSStsConfig is set but RemoteURL is empty, because
+// SigV4 signing is only meaningful for remote MCP servers.
+func addAWSStsMiddleware(middlewares []types.MiddlewareConfig, config *RunConfig) ([]types.MiddlewareConfig, error) {
+	if config.AWSStsConfig == nil {
+		return middlewares, nil
+	}
+
+	if config.RemoteURL == "" {
+		return nil, fmt.Errorf("AWS STS middleware requires a remote URL: SigV4 signing is only meaningful for remote MCP servers")
+	}
+
+	awsStsParams := awssts.MiddlewareParams{
+		AWSStsConfig: config.AWSStsConfig,
+		TargetURL:    config.RemoteURL, // Use remote URL as the target for SigV4 signing
+	}
+	awsStsMwConfig, err := types.NewMiddlewareConfig(awssts.MiddlewareType, awsStsParams)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create AWS STS middleware config: %w", err)
+	}
+	return append(middlewares, *awsStsMwConfig), nil
 }


### PR DESCRIPTION
Register the AWS STS middleware in the runner so it can be activated via RunConfig.

Add AWSStsConfig to RunConfig, a WithAWSStsConfig builder option, and factory registration in GetSupportedMiddlewareFactories. Place the middleware in PopulateMiddlewareConfigs after audit/authz but before header forwarding — only authorized requests trigger credential exchange and SigV4 signing happens as late as possible.

Regenerate Swagger docs to include the new awssts.Config and awssts.RoleMapping schemas.

Consolidate the three GetSupportedMiddlewareFactories tests into one table-driven test and extract the duplicated createMinimalAuthServerConfig helper to package level.

Related: #3569