### PR TITLE
Align vMCP client telemetry with OTEL MCP semantic conventions

### DIFF
--- a/pkg/vmcp/server/telemetry_test.go
+++ b/pkg/vmcp/server/telemetry_test.go
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package server
+
+import (
+	"testing"
+)
+
+func TestMapActionToMCPMethod(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		action   string
+		expected string
+	}{
+		{name: "call_tool maps to tools/call", action: "call_tool", expected: "tools/call"},
+		{name: "read_resource maps to resources/read", action: "read_resource", expected: "resources/read"},
+		{name: "get_prompt maps to prompts/get", action: "get_prompt", expected: "prompts/get"},
+		{name: "unknown action passes through", action: "list_capabilities", expected: "list_capabilities"},
+		{name: "empty string passes through", action: "", expected: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := mapActionToMCPMethod(tt.action)
+			if got != tt.expected {
+				t.Errorf("mapActionToMCPMethod(%q) = %q, want %q", tt.action, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestMapTransportTypeToNetworkTransport(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		transportType string
+		expected      string
+	}{
+		{name: "stdio maps to pipe", transportType: "stdio", expected: "pipe"},
+		{name: "sse maps to tcp", transportType: "sse", expected: "tcp"},
+		{name: "streamable-http maps to tcp", transportType: "streamable-http", expected: "tcp"},
+		{name: "unknown defaults to tcp", transportType: "unknown", expected: "tcp"},
+		{name: "empty defaults to tcp", transportType: "", expected: "tcp"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := mapTransportTypeToNetworkTransport(tt.transportType)
+			if got != tt.expected {
+				t.Errorf("mapTransportTypeToNetworkTransport(%q) = %q, want %q", tt.transportType, got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Aligns vMCP backend client spans and metrics with the OTEL MCP semantic conventions
- Span names changed from internal format (`telemetryBackendClient.call_tool`) to spec format (`tools/call my-tool`)
- Adds `mcp.method.name` (Required) to all client spans
- Adds spec-required attributes to `mcp.client.operation.duration` metric: `mcp.method.name`, `network.transport`, and `error.type` on error
- Adds `gen_ai.tool.name`, `gen_ai.prompt.name`, `mcp.resource.uri` to appropriate method spans
- Keeps all existing ToolHive-specific attributes for backward compatibility
- Avoids unbounded cardinality in ReadResource span names by omitting the URI from the span name (captured in attributes instead)
- Adds `resource_uri` backward-compat attribute to ReadResource, matching the pattern used by CallTool (`tool_name`) and GetPrompt (`prompt_name`)
- Adds unit tests for `mapActionToMCPMethod` and `mapTransportTypeToNetworkTransport` mapping functions

Parent issue: #3399

## Test plan

- [x] `go build ./pkg/vmcp/server/...` compiles cleanly
- [x] `go test ./pkg/vmcp/server/...` passes (including new unit tests)
- [x] `task lint-fix` passes with 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)