### PR TITLE
Add explicit histogram bucket boundaries to duration metrics

### DIFF
--- a/pkg/telemetry/middleware.go
+++ b/pkg/telemetry/middleware.go
@@ -85,6 +85,7 @@ func NewHTTPMiddleware(
 		"toolhive_mcp_request_duration", // The exporter adds the _seconds suffix automatically
 		metric.WithDescription("Duration of MCP requests in seconds"),
 		metric.WithUnit("s"),
+		metric.WithExplicitBucketBoundaries(MCPHistogramBuckets...),
 	)
 	if err != nil {
 		logger.Debugf("failed to create request duration metric: %v", err)

--- a/pkg/vmcp/server/telemetry.go
+++ b/pkg/vmcp/server/telemetry.go
@@ -59,6 +59,7 @@ func monitorBackends(
 		"toolhive_vmcp_backend_requests_duration",
 		metric.WithDescription("Duration of requests in seconds per backend"),
 		metric.WithUnit("s"),
+		metric.WithExplicitBucketBoundaries(telemetry.MCPHistogramBuckets...),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create requests duration histogram: %w", err)
@@ -267,6 +268,7 @@ func monitorWorkflowExecutors(
 		"toolhive_vmcp_workflow_duration",
 		metric.WithDescription("Duration of workflow executions in seconds"),
 		metric.WithUnit("s"),
+		metric.WithExplicitBucketBoundaries(telemetry.MCPHistogramBuckets...),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create workflow duration histogram: %w", err)


### PR DESCRIPTION
## Summary

- Adds `MCPHistogramBuckets` to three legacy duration histograms that were using default OTel SDK bucket boundaries (0, 5, 10, 25, ..., 10000), causing all sub-second observations to land in the first bucket and making `histogram_quantile` calculations meaningless
- Affected metrics: `toolhive_mcp_request_duration`, `toolhive_vmcp_backend_requests_duration`, `toolhive_vmcp_workflow_duration`
- Uses the same bucket boundaries already applied to the spec-aligned metrics (`mcp.server.operation.duration`, `mcp.client.operation.duration`)

Fixes #3680

## Test plan

- [x] `go build ./pkg/telemetry/... ./pkg/vmcp/server/...` compiles successfully
- [x] `go test ./pkg/telemetry/... ./pkg/vmcp/server/...` passes
- [ ] Deploy with OTEL stack and verify exported histograms have correct bucket boundaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)