### PR TITLE
Use workload name as default OTel service name

### DIFF
--- a/docs/cli/thv_run.md
+++ b/docs/cli/thv_run.md
@@ -148,7 +148,7 @@ thv run [flags] SERVER_OR_IMAGE_OR_PROTOCOL [-- ARGS...]
       --otel-insecure                               Connect to the OpenTelemetry endpoint using HTTP instead of HTTPS (default false)
       --otel-metrics-enabled                        Enable OTLP metrics export (when OTLP endpoint is configured) (default true)
       --otel-sampling-rate float                    OpenTelemetry trace sampling rate (0.0-1.0) (default 0.1)
-      --otel-service-name string                    OpenTelemetry service name (defaults to toolhive-mcp-proxy)
+      --otel-service-name string                    OpenTelemetry service name (defaults to thv-<workload-name>)
       --otel-tracing-enabled                        Enable distributed tracing (when OTLP endpoint is configured) (default true)
       --otel-use-legacy-attributes                  Emit legacy attribute names alongside new OTEL semantic convention names (default true) (default true)
       --permission-profile string                   Permission profile to use (none, network, or path to JSON file) (default is to use the permission profile from the registry or "network" if not part of the registry)

--- a/pkg/runner/config_builder.go
+++ b/pkg/runner/config_builder.go
@@ -751,6 +751,10 @@ func internalRunConfigBuilder(
 		}
 	}
 
+	// Resolve the OTel service name from the workload name when not explicitly set.
+	// This ensures the service name is always populated before persisting the config.
+	telemetry.ResolveServiceName(b.config.TelemetryConfig, b.config.Name)
+
 	// When using the CLI validation strategy, this is where the prompting for
 	// missing environment variables will happen.
 	processedEnvVars := envVars


### PR DESCRIPTION
## Summary

- Derives the OTel service name from the workload name with a `thv-` prefix (e.g. `thv-fetch`, `thv-github`) when `--otel-service-name` is not explicitly set
- Replaces the previous hardcoded default of `toolhive-mcp-proxy` which made all workloads indistinguishable in telemetry
- Service name resolution happens in `internalRunConfigBuilder` (covers all paths including restart from persisted state)

Closes #1985

## Test plan

- [x] Unit tests pass (`go test ./pkg/telemetry/...`)
- [x] New `TestResolveServiceName` covers: nil config, empty name derivation, explicit name preservation, empty server name
- [x] Lint passes
- [x] CLI docs regenerated
- [ ] Manual: `thv run fetch --otel-enable-prometheus-metrics-path` → verify `/metrics` shows `service_name="thv-fetch"`
- [ ] Manual: `thv run fetch --otel-service-name my-custom --otel-enable-prometheus-metrics-path` → verify explicit name is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)