### PR TITLE
Resolve OTel serviceVersion at runtime instead of persisting it

### DIFF
--- a/cmd/thv-operator/pkg/spectoconfig/telemetry.go
+++ b/cmd/thv-operator/pkg/spectoconfig/telemetry.go
@@ -105,7 +105,10 @@ func ConvertTelemetryConfig(
 // This includes:
 // - Stripping http:// or https:// prefixes from the endpoint (OTLP clients expect host:port format)
 // - Defaulting ServiceName to the provided default name if not specified
-// - Defaulting ServiceVersion to the build version if not specified
+//
+// Note: ServiceVersion is intentionally NOT defaulted here. It is resolved at
+// runtime in telemetry.NewProvider() to always reflect the running binary version,
+// avoiding stale versions persisted in configs. See #2296.
 //
 // This function is used by both the VirtualMCPServer converter (for spec.config.telemetry)
 // and indirectly by ConvertTelemetryConfig (for CRD-style configs).
@@ -125,11 +128,6 @@ func NormalizeTelemetryConfig(config *telemetry.Config, defaultServiceName strin
 	// Default service name if not specified
 	if normalized.ServiceName == "" {
 		normalized.ServiceName = defaultServiceName
-	}
-
-	// Default service version to build version if not specified
-	if normalized.ServiceVersion == "" {
-		normalized.ServiceVersion = telemetry.DefaultConfig().ServiceVersion
 	}
 
 	return &normalized

--- a/cmd/thv-operator/pkg/spectoconfig/telemetry_test.go
+++ b/cmd/thv-operator/pkg/spectoconfig/telemetry_test.go
@@ -17,9 +17,6 @@ import (
 func TestNormalizeTelemetryConfig(t *testing.T) {
 	t.Parallel()
 
-	// Get the expected build version for tests
-	buildVersion := telemetry.DefaultConfig().ServiceVersion
-
 	tests := []struct {
 		name        string
 		input       *telemetry.Config
@@ -40,9 +37,8 @@ func TestNormalizeTelemetryConfig(t *testing.T) {
 			},
 			defaultName: "default-service",
 			expected: &telemetry.Config{
-				Endpoint:       "otlp-collector:4317",
-				ServiceName:    "my-service",
-				ServiceVersion: buildVersion,
+				Endpoint:    "otlp-collector:4317",
+				ServiceName: "my-service",
 			},
 		},
 		{
@@ -53,9 +49,8 @@ func TestNormalizeTelemetryConfig(t *testing.T) {
 			},
 			defaultName: "default-service",
 			expected: &telemetry.Config{
-				Endpoint:       "localhost:4317",
-				ServiceName:    "my-service",
-				ServiceVersion: buildVersion,
+				Endpoint:    "localhost:4317",
+				ServiceName: "my-service",
 			},
 		},
 		{
@@ -66,9 +61,8 @@ func TestNormalizeTelemetryConfig(t *testing.T) {
 			},
 			defaultName: "default-service",
 			expected: &telemetry.Config{
-				Endpoint:       "otlp-collector:4317",
-				ServiceName:    "my-service",
-				ServiceVersion: buildVersion,
+				Endpoint:    "otlp-collector:4317",
+				ServiceName: "my-service",
 			},
 		},
 		{
@@ -79,13 +73,12 @@ func TestNormalizeTelemetryConfig(t *testing.T) {
 			},
 			defaultName: "default-service",
 			expected: &telemetry.Config{
-				Endpoint:       "localhost:4317",
-				ServiceName:    "default-service",
-				ServiceVersion: buildVersion,
+				Endpoint:    "localhost:4317",
+				ServiceName: "default-service",
 			},
 		},
 		{
-			name: "defaults ServiceVersion to build version when empty",
+			name: "ServiceVersion left empty for runtime resolution",
 			input: &telemetry.Config{
 				Endpoint:       "localhost:4317",
 				ServiceName:    "my-service",
@@ -93,9 +86,8 @@ func TestNormalizeTelemetryConfig(t *testing.T) {
 			},
 			defaultName: "default-service",
 			expected: &telemetry.Config{
-				Endpoint:       "localhost:4317",
-				ServiceName:    "my-service",
-				ServiceVersion: buildVersion,
+				Endpoint:    "localhost:4317",
+				ServiceName: "my-service",
 			},
 		},
 		{
@@ -193,11 +185,10 @@ func TestNormalizeTelemetryConfig_DoesNotModifyInput(t *testing.T) {
 func TestConvertTelemetryConfig_UsesNormalization(t *testing.T) {
 	t.Parallel()
 
-	// Get the expected build version for tests
-	buildVersion := telemetry.DefaultConfig().ServiceVersion
-
 	// This test verifies that ConvertTelemetryConfig uses NormalizeTelemetryConfig
-	// to apply endpoint prefix stripping and service name/version defaults
+	// to apply endpoint prefix stripping and service name defaults.
+	// ServiceVersion is intentionally left empty — it is resolved at runtime
+	// in telemetry.NewProvider() to always reflect the running binary version.
 	tests := []struct {
 		name       string
 		input      *v1alpha1.TelemetryConfig
@@ -221,7 +212,6 @@ func TestConvertTelemetryConfig_UsesNormalization(t *testing.T) {
 			expected: &telemetry.Config{
 				Endpoint:       "otlp-collector:4317", // Prefix stripped
 				ServiceName:    "my-mcp-server",       // Defaulted
-				ServiceVersion: buildVersion,          // Defaulted to build version
 				TracingEnabled: true,
 				SamplingRate:   "0.1",
 			},
@@ -237,9 +227,8 @@ func TestConvertTelemetryConfig_UsesNormalization(t *testing.T) {
 			},
 			serverName: "default-server",
 			expected: &telemetry.Config{
-				Endpoint:       "localhost:4317", // Prefix stripped
-				ServiceName:    "custom-service", // Preserved
-				ServiceVersion: buildVersion,     // Defaulted to build version
+				Endpoint:    "localhost:4317", // Prefix stripped
+				ServiceName: "custom-service", // Preserved
 			},
 		},
 		{
@@ -253,7 +242,6 @@ func TestConvertTelemetryConfig_UsesNormalization(t *testing.T) {
 			expected: &telemetry.Config{
 				EnablePrometheusMetricsPath: true,
 				ServiceName:                 "prom-server", // Defaulted
-				ServiceVersion:              buildVersion,  // Defaulted to build version
 				UseLegacyAttributes:         true,          // Default when OTEL block absent
 			},
 		},
@@ -273,7 +261,6 @@ func TestConvertTelemetryConfig_UsesNormalization(t *testing.T) {
 			expected: &telemetry.Config{
 				Endpoint:            "otlp:4317",
 				ServiceName:         "legacy-test",
-				ServiceVersion:      buildVersion,
 				TracingEnabled:      true,
 				UseLegacyAttributes: false,
 			},

--- a/cmd/thv-operator/pkg/vmcpconfig/converter_test.go
+++ b/cmd/thv-operator/pkg/vmcpconfig/converter_test.go
@@ -1346,16 +1346,13 @@ func TestConverter_TelemetryConfigPreserved(t *testing.T) {
 func TestConverter_TelemetryDefaults(t *testing.T) {
 	t.Parallel()
 
-	// Get the expected build version for tests
-	buildVersion := telemetry.DefaultConfig().ServiceVersion
-
 	tests := []struct {
 		name              string
 		inputTelemetry    *telemetry.Config
 		expectedTelemetry *telemetry.Config
 	}{
 		{
-			name: "defaults ServiceName to vmcp name and ServiceVersion to build version",
+			name: "defaults ServiceName to vmcp name, ServiceVersion left for runtime",
 			inputTelemetry: &telemetry.Config{
 				Endpoint:                    "localhost:4317",
 				EnablePrometheusMetricsPath: true,
@@ -1366,11 +1363,10 @@ func TestConverter_TelemetryDefaults(t *testing.T) {
 				Endpoint:                    "localhost:4317",
 				EnablePrometheusMetricsPath: true,
 				ServiceName:                 "my-vmcp-server",
-				ServiceVersion:              buildVersion,
 			},
 		},
 		{
-			name: "defaults ServiceVersion to build version when ServiceName is specified",
+			name: "ServiceVersion left for runtime when ServiceName is specified",
 			inputTelemetry: &telemetry.Config{
 				Endpoint:                    "localhost:4317",
 				EnablePrometheusMetricsPath: true,
@@ -1381,7 +1377,6 @@ func TestConverter_TelemetryDefaults(t *testing.T) {
 				Endpoint:                    "localhost:4317",
 				EnablePrometheusMetricsPath: true,
 				ServiceName:                 "custom-service",
-				ServiceVersion:              buildVersion,
 			},
 		},
 		{

--- a/cmd/thv/app/run_flags.go
+++ b/cmd/thv/app/run_flags.go
@@ -1025,7 +1025,7 @@ func createTelemetryConfig(otelEndpoint string, otelEnablePrometheusMetricsPath 
 	telemetryCfg := &telemetry.Config{
 		Endpoint:                    otelEndpoint,
 		ServiceName:                 otelServiceName,
-		ServiceVersion:              telemetry.DefaultConfig().ServiceVersion,
+		ServiceVersion:              "", // resolved at runtime in NewProvider()
 		TracingEnabled:              otelTracingEnabled,
 		MetricsEnabled:              otelMetricsEnabled,
 		Headers:                     headers,

--- a/pkg/telemetry/config_test.go
+++ b/pkg/telemetry/config_test.go
@@ -186,7 +186,7 @@ func TestDefaultConfig(t *testing.T) {
 	config := DefaultConfig()
 
 	assert.Empty(t, config.ServiceName, "ServiceName should be empty by default (resolved at runtime from workload name)")
-	assert.NotEmpty(t, config.ServiceVersion)
+	assert.Empty(t, config.ServiceVersion, "ServiceVersion should be empty by default (resolved at runtime in NewProvider)")
 	assert.Equal(t, "0.05", config.SamplingRate)
 	assert.NotNil(t, config.Headers)
 	assert.Empty(t, config.Headers)


### PR DESCRIPTION
## Summary

- Moves `serviceVersion` resolution from config creation time to runtime in `NewProvider()`, so it always reflects the running binary version
- Stops persisting the version in `DefaultConfig()`, `MaybeMakeConfig()`, `createTelemetryConfig()`, and operator's `NormalizeTelemetryConfig()`
- Existing configs with an explicit `serviceVersion` (e.g., from the K8s operator CRD) are still honored
- Previously, restarting a workload after upgrading ToolHive would report the old version in traces/metrics; `thv export` would also capture the stale version

Closes #2296

## Test plan

- [x] `go test ./pkg/telemetry/...` passes
- [x] `go test ./cmd/thv-operator/pkg/spectoconfig/...` passes
- [x] `go test ./cmd/thv-operator/pkg/vmcpconfig/...` passes
- [x] Lint passes
- [ ] Manual: start server with otel, check version in traces, upgrade binary, restart, verify version updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)