### PR TITLE
Add offline_access to default scopes and fix PRM scope discovery

### DIFF
--- a/docs/server/docs.go
+++ b/docs/server/docs.go
@@ -217,7 +217,7 @@ const docTemplate = `{
                         "type": "string"
                     },
                     "scopes_supported": {
-                        "description": "ScopesSupported lists the OAuth 2.0 scope values advertised in discovery documents.\nIf empty, defaults to [\"openid\", \"offline_access\"].",
+                        "description": "ScopesSupported lists the OAuth 2.0 scope values advertised in discovery documents.\nIf empty, defaults to [\"openid\", \"profile\", \"email\", \"offline_access\"].",
                         "items": {
                             "type": "string"
                         },

--- a/docs/server/swagger.json
+++ b/docs/server/swagger.json
@@ -210,7 +210,7 @@
                         "type": "string"
                     },
                     "scopes_supported": {
-                        "description": "ScopesSupported lists the OAuth 2.0 scope values advertised in discovery documents.\nIf empty, defaults to [\"openid\", \"offline_access\"].",
+                        "description": "ScopesSupported lists the OAuth 2.0 scope values advertised in discovery documents.\nIf empty, defaults to [\"openid\", \"profile\", \"email\", \"offline_access\"].",
                         "items": {
                             "type": "string"
                         },

--- a/docs/server/swagger.yaml
+++ b/docs/server/swagger.yaml
@@ -228,7 +228,7 @@ components:
         scopes_supported:
           description: |-
             ScopesSupported lists the OAuth 2.0 scope values advertised in discovery documents.
-            If empty, defaults to ["openid", "offline_access"].
+            If empty, defaults to ["openid", "profile", "email", "offline_access"].
           items:
             type: string
           type: array

--- a/pkg/auth/token.go
+++ b/pkg/auth/token.go
@@ -1092,7 +1092,9 @@ func NewAuthInfoHandler(issuer, jwksURL, resourceURL string, scopes []string) ht
 			return
 		}
 
-		// Use provided scopes or default to 'openid'
+		// Use provided scopes or fall back to a minimal default.
+		// When the embedded auth server is used, the caller provides
+		// the AS's ScopesSupported explicitly (see config_builder.go).
 		supportedScopes := scopes
 		if len(supportedScopes) == 0 {
 			supportedScopes = []string{"openid"}

--- a/pkg/auth/token_test.go
+++ b/pkg/auth/token_test.go
@@ -1128,7 +1128,7 @@ func TestNewAuthInfoHandler(t *testing.T) {
 			issuer:       "https://auth.example.com",
 			jwksURL:      "https://auth.example.com/.well-known/jwks.json",
 			resourceURL:  "https://api.example.com",
-			scopes:       nil, // Test default scopes
+			scopes:       nil, // Test default scopes (should default to ["openid"])
 			method:       "GET",
 			origin:       "",
 			expectStatus: http.StatusOK,
@@ -1164,7 +1164,7 @@ func TestNewAuthInfoHandler(t *testing.T) {
 			issuer:       "",
 			jwksURL:      "",
 			resourceURL:  "https://api.example.com",
-			scopes:       []string{}, // Test empty scopes (should default to openid)
+			scopes:       []string{}, // Test empty scopes (should default to ["openid"])
 			method:       "GET",
 			origin:       "https://client.example.com",
 			expectStatus: http.StatusOK,

--- a/pkg/authserver/config.go
+++ b/pkg/authserver/config.go
@@ -59,7 +59,7 @@ type RunConfig struct {
 	Upstreams []UpstreamRunConfig `json:"upstreams" yaml:"upstreams"`
 
 	// ScopesSupported lists the OAuth 2.0 scope values advertised in discovery documents.
-	// If empty, defaults to ["openid", "offline_access"].
+	// If empty, defaults to ["openid", "profile", "email", "offline_access"].
 	ScopesSupported []string `json:"scopes_supported,omitempty" yaml:"scopes_supported,omitempty"`
 
 	// AllowedAudiences is the list of valid resource URIs that tokens can be issued for.
@@ -295,7 +295,7 @@ type Config struct {
 	Upstreams []UpstreamConfig
 
 	// ScopesSupported lists the OAuth 2.0 scope values advertised in discovery documents.
-	// If nil or empty, defaults to ["openid", "offline_access"].
+	// If nil or empty, defaults to ["openid", "profile", "email", "offline_access"].
 	// This is advertised in /.well-known/openid-configuration and
 	// /.well-known/oauth-authorization-server discovery endpoints.
 	ScopesSupported []string

--- a/pkg/authserver/server/registration/client.go
+++ b/pkg/authserver/server/registration/client.go
@@ -81,10 +81,9 @@ func (c *LoopbackClient) GetMatchingRedirectURI(requestedURI string) string {
 	return ""
 }
 
-// DefaultScopes are the default OIDC scopes for registered clients.
-// Also used as the default for ScopesSupported in config.go when no
-// scopes are explicitly configured.
-var DefaultScopes = []string{"openid", "profile", "email"}
+// DefaultScopes are the default OAuth 2.0 scopes for registered clients.
+// Includes offline_access to enable refresh token issuance.
+var DefaultScopes = []string{"openid", "profile", "email", "offline_access"}
 
 // Config holds configuration for creating a new OAuth client.
 type Config struct {


### PR DESCRIPTION
MCP clients like VS Code resolve OAuth scopes from the Protected Resource Metadata (RFC 9728) scopes_supported field. When no explicit scopes were configured, the PRM handler defaulted to ["openid"], causing clients to never request offline_access and therefore never receive refresh tokens.

Separate the PRM and auth server default scopes. Per RFC 9728, PRM scopes_supported describes what the resource server needs (minimal: ["openid"]), while auth server scopes describe what the AS supports (["openid", "profile", "email", "offline_access"]). These are distinct concerns that should not share a single constant.

When the embedded auth server is configured, the config builder now propagates the AS's ScopesSupported to the PRM so clients discover the full set of supported scopes including offline_access. When using an external OIDC provider without explicit scopes, the PRM safely defaults to ["openid"].

Add integration tests verifying refresh token issuance with offline_access and its absence without it.

Fixes: #3776