### PR TITLE
Set audience on DCR clients for refresh token support

### DIFF
--- a/pkg/authserver/server/handlers/dcr.go
+++ b/pkg/authserver/server/handlers/dcr.go
@@ -69,6 +69,7 @@ func (h *Handler) RegisterClientHandler(w http.ResponseWriter, req *http.Request
 		GrantTypes:    validated.GrantTypes,
 		ResponseTypes: validated.ResponseTypes,
 		Scopes:        h.config.ScopesSupported,
+		Audience:      h.config.AllowedAudiences,
 	})
 	if err != nil {
 		logger.Errorw("failed to create client", "error", err)

--- a/pkg/authserver/server/handlers/dcr_test.go
+++ b/pkg/authserver/server/handlers/dcr_test.go
@@ -130,7 +130,10 @@ func TestRegisterClientHandler_ClientIsStored(t *testing.T) {
 			return nil
 		})
 
-	handler := &Handler{storage: stor, config: &server.AuthorizationServerConfig{}}
+	allowedAudiences := []string{"https://mcp.example.com"}
+	handler := &Handler{storage: stor, config: &server.AuthorizationServerConfig{
+		AllowedAudiences: allowedAudiences,
+	}}
 
 	reqBody, err := json.Marshal(registration.DCRRequest{
 		RedirectURIs: []string{"http://127.0.0.1:8080/callback"},
@@ -155,4 +158,6 @@ func TestRegisterClientHandler_ClientIsStored(t *testing.T) {
 	assert.Equal(t, resp.ClientID, loopbackClient.GetID())
 	assert.True(t, loopbackClient.IsPublic())
 	assert.Equal(t, []string{"http://127.0.0.1:8080/callback"}, loopbackClient.GetRedirectURIs())
+	assert.Equal(t, fosite.Arguments(allowedAudiences), loopbackClient.GetAudience(),
+		"DCR client must inherit server's AllowedAudiences so refresh token requests with resource= succeed")
 }

--- a/pkg/authserver/server/registration/client.go
+++ b/pkg/authserver/server/registration/client.go
@@ -112,6 +112,11 @@ type Config struct {
 	// Scopes overrides the default scopes.
 	// If nil or empty, DefaultScopes is used.
 	Scopes []string
+
+	// Audience is the list of allowed audience values for this client.
+	// Per RFC 8707, the "resource" parameter in token requests is validated
+	// against this list. If nil, audience validation will reject all values.
+	Audience []string
 }
 
 // New creates a fosite.Client from the given configuration.
@@ -143,6 +148,7 @@ func New(cfg Config) (fosite.Client, error) {
 		ResponseTypes: responseTypes,
 		GrantTypes:    grantTypes,
 		Scopes:        scopes,
+		Audience:      cfg.Audience,
 		Public:        cfg.Public,
 	}
 


### PR DESCRIPTION
DCR-registered clients had no Audience field set on the fosite DefaultClient. During refresh token requests with resource= (RFC 8707), Fosite validates the original session's granted audience against the client's registered audience whitelist. With an empty whitelist, all refresh token requests failed with "has not been whitelisted".

Pass AllowedAudiences from the server config to registration.New() so DCR clients inherit the server's allowed audiences.

Fixes: #3777