### PR TITLE
Return scope in DCR response per RFC 7591 Section 3.2.1

### DIFF
--- a/pkg/authserver/server/handlers/dcr.go
+++ b/pkg/authserver/server/handlers/dcr.go
@@ -94,7 +94,8 @@ func (h *Handler) RegisterClientHandler(w http.ResponseWriter, req *http.Request
 		"client_name", validated.ClientName,
 	)
 
-	// Build response
+	// Build response per RFC 7591 Section 3.2.1.
+	// Include scope so the client knows what scopes it was granted.
 	response := registration.DCRResponse{
 		ClientID:                clientID,
 		ClientIDIssuedAt:        time.Now().Unix(),
@@ -103,6 +104,7 @@ func (h *Handler) RegisterClientHandler(w http.ResponseWriter, req *http.Request
 		TokenEndpointAuthMethod: validated.TokenEndpointAuthMethod,
 		GrantTypes:              validated.GrantTypes,
 		ResponseTypes:           validated.ResponseTypes,
+		Scope:                   strings.Join(h.config.ScopesSupported, " "),
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/pkg/authserver/server/handlers/dcr_test.go
+++ b/pkg/authserver/server/handlers/dcr_test.go
@@ -118,6 +118,38 @@ func TestRegisterClientHandler(t *testing.T) {
 	}
 }
 
+func TestRegisterClientHandler_ScopeInResponse(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	stor := mocks.NewMockStorage(ctrl)
+	stor.EXPECT().RegisterClient(gomock.Any(), gomock.Any()).Return(nil)
+
+	handler := &Handler{
+		storage: stor,
+		config: &server.AuthorizationServerConfig{
+			ScopesSupported: []string{"openid", "profile", "email", "offline_access"},
+		},
+	}
+
+	reqBody, err := json.Marshal(registration.DCRRequest{
+		RedirectURIs: []string{"http://127.0.0.1:8080/callback"},
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/oauth/register", bytes.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler.RegisterClientHandler(w, req)
+	require.Equal(t, http.StatusCreated, w.Code)
+
+	var resp registration.DCRResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "openid profile email offline_access", resp.Scope,
+		"DCR response should include granted scopes per RFC 7591 Section 3.2.1")
+}
+
 func TestRegisterClientHandler_ClientIsStored(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/authserver/server/registration/dcr.go
+++ b/pkg/authserver/server/registration/dcr.go
@@ -90,6 +90,10 @@ type DCRResponse struct {
 
 	// ResponseTypes is an array of OAuth 2.0 response types the client may use.
 	ResponseTypes []string `json:"response_types"`
+
+	// Scope is a space-separated list of OAuth 2.0 scope values the client may use.
+	// Per RFC 7591 Section 3.2, this tells the client what scopes it was granted.
+	Scope string `json:"scope,omitempty"`
 }
 
 // DCRError represents an OAuth 2.0 Dynamic Client Registration error


### PR DESCRIPTION
The Dynamic Client Registration response now includes a scope field containing the space-separated list of scopes the client was granted. This tells clients what scopes they may request in subsequent authorize calls, improving spec compliance for well-behaved OAuth clients.

Fixes: #3778