### PR TITLE
Fix wrong API group in MCPExternalAuthConfig webhook marker

### DIFF
--- a/cmd/thv-operator/api/v1alpha1/mcpexternalauthconfig_webhook.go
+++ b/cmd/thv-operator/api/v1alpha1/mcpexternalauthconfig_webhook.go
@@ -21,7 +21,7 @@ func (r *MCPExternalAuthConfig) SetupWebhookWithManager(mgr ctrl.Manager) error 
 }
 
 //nolint:lll // kubebuilder webhook marker cannot be split
-// +kubebuilder:webhook:path=/validate-toolhive-stacklok-com-v1alpha1-mcpexternalauthconfig,mutating=false,failurePolicy=fail,sideEffects=None,groups=toolhive.stacklok.com,resources=mcpexternalauthconfigs,verbs=create;update,versions=v1alpha1,name=vmcpexternalauthconfig.kb.io,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/validate-toolhive-stacklok-dev-v1alpha1-mcpexternalauthconfig,mutating=false,failurePolicy=fail,sideEffects=None,groups=toolhive.stacklok.dev,resources=mcpexternalauthconfigs,verbs=create;update,versions=v1alpha1,name=vmcpexternalauthconfig.kb.io,admissionReviewVersions=v1
 
 var _ webhook.CustomValidator = &MCPExternalAuthConfig{}
 

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -10,12 +10,12 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
-      path: /validate-toolhive-stacklok-com-v1alpha1-mcpexternalauthconfig
+      path: /validate-toolhive-stacklok-dev-v1alpha1-mcpexternalauthconfig
   failurePolicy: Fail
   name: vmcpexternalauthconfig.kb.io
   rules:
   - apiGroups:
-    - toolhive.stacklok.com
+    - toolhive.stacklok.dev
     apiVersions:
     - v1alpha1
     operations:


### PR DESCRIPTION
The kubebuilder webhook marker used toolhive.stacklok.com but the actual API group defined in groupversion_info.go is toolhive.stacklok.dev. This mismatch caused the generated webhook configuration to intercept requests for the wrong group, meaning validation never fired for MCPExternalAuthConfig resources.

Fix the marker and regenerate the webhook manifest.