### PR TITLE
Fix kind load failures with Docker 29+ containerd image store

### DIFF
--- a/.github/workflows/test-e2e-lifecycle.yml
+++ b/.github/workflows/test-e2e-lifecycle.yml
@@ -36,6 +36,19 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+    - name: Disable containerd image store
+      # Workaround for https://github.com/kubernetes-sigs/kind/issues/3795
+      # Docker 29+ defaults to containerd image store, which causes
+      # `kind load docker-image` to fail for multi-arch images because
+      # `docker save` preserves the OCI index referencing all platforms
+      # even when only the host platform layers were pulled.
+      # --platform on docker pull is not sufficient; the image store
+      # itself must be switched back to the classic overlay2 driver.
+      run: |
+        sudo mkdir -p /etc/docker
+        echo '{"features":{"containerd-snapshotter": false}}' | sudo tee /etc/docker/daemon.json
+        sudo systemctl restart docker
+
     - name: Set up Helm
       uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
 


### PR DESCRIPTION
 Work around kind load failure with Docker 29+ containerd image store

Docker 29+ defaults to the containerd image store, which causes `kind load docker-image` to fail for multi-arch images.  With the containerd snapshotter, `docker save` preserves the full OCI index (referencing all platforms) even when only the host-platform layers were pulled.  kind then calls `ctr images import --all-platforms`, which fails because the non-host-platform layers are missing.

Disable the containerd snapshotter before pulling any images so that Docker falls back to the classic overlay2 store, which only exports the single-platform manifest.

Ref: https://github.com/kubernetes-sigs/kind/issues/3795