### PR TITLE
Align skills REST API contract with RESTful conventions

### DIFF
--- a/docs/server/docs.go
+++ b/docs/server/docs.go
@@ -1604,7 +1604,7 @@ const docTemplate = `{
                 "type": "object"
             },
             "skills.Scope": {
-                "description": "Scope from which to uninstall",
+                "description": "Scope for the installation",
                 "enum": [
                     "user",
                     "project"
@@ -2589,19 +2589,6 @@ const docTemplate = `{
                     "name": {
                         "description": "Name of the tool",
                         "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "v1.uninstallSkillRequest": {
-                "description": "Request to uninstall a skill",
-                "properties": {
-                    "name": {
-                        "description": "Name of the skill to uninstall",
-                        "type": "string"
-                    },
-                    "scope": {
-                        "$ref": "#/components/schemas/skills.Scope"
                     }
                 },
                 "type": "object"
@@ -4021,6 +4008,20 @@ const docTemplate = `{
         "/api/v1beta/skills": {
             "get": {
                 "description": "Get a list of all installed skills",
+                "parameters": [
+                    {
+                        "description": "Filter by scope (user or project)",
+                        "in": "query",
+                        "name": "scope",
+                        "schema": {
+                            "enum": [
+                                "user",
+                                "project"
+                            ],
+                            "type": "string"
+                        }
+                    }
+                ],
                 "responses": {
                     "200": {
                         "content": {
@@ -4044,6 +4045,83 @@ const docTemplate = `{
                     }
                 },
                 "summary": "List all installed skills",
+                "tags": [
+                    "skills"
+                ]
+            },
+            "post": {
+                "description": "Install a skill from a remote source",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "oneOf": [
+                                    {
+                                        "type": "object"
+                                    },
+                                    {
+                                        "$ref": "#/components/schemas/v1.installSkillRequest",
+                                        "summary": "request",
+                                        "description": "Install request"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "description": "Install request",
+                    "required": true
+                },
+                "responses": {
+                    "201": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/v1.installSkillResponse"
+                                }
+                            }
+                        },
+                        "description": "Created",
+                        "headers": {
+                            "Location": {
+                                "description": "URI of the installed skill resource",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Bad Request"
+                    },
+                    "409": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Conflict"
+                    },
+                    "501": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Not Implemented"
+                    }
+                },
+                "summary": "Install a skill",
                 "tags": [
                     "skills"
                 ]
@@ -4100,57 +4178,6 @@ const docTemplate = `{
                 ]
             }
         },
-        "/api/v1beta/skills/install": {
-            "post": {
-                "description": "Install a skill from a remote source",
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "oneOf": [
-                                    {
-                                        "type": "object"
-                                    },
-                                    {
-                                        "$ref": "#/components/schemas/v1.installSkillRequest",
-                                        "summary": "request",
-                                        "description": "Install request"
-                                    }
-                                ]
-                            }
-                        }
-                    },
-                    "description": "Install request",
-                    "required": true
-                },
-                "responses": {
-                    "201": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/v1.installSkillResponse"
-                                }
-                            }
-                        },
-                        "description": "Created"
-                    },
-                    "501": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "description": "Not Implemented"
-                    }
-                },
-                "summary": "Install a skill",
-                "tags": [
-                    "skills"
-                ]
-            }
-        },
         "/api/v1beta/skills/push": {
             "post": {
                 "description": "Push a built skill artifact to a remote registry",
@@ -4197,57 +4224,6 @@ const docTemplate = `{
                     }
                 },
                 "summary": "Push a skill",
-                "tags": [
-                    "skills"
-                ]
-            }
-        },
-        "/api/v1beta/skills/uninstall": {
-            "post": {
-                "description": "Remove an installed skill",
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "oneOf": [
-                                    {
-                                        "type": "object"
-                                    },
-                                    {
-                                        "$ref": "#/components/schemas/v1.uninstallSkillRequest",
-                                        "summary": "request",
-                                        "description": "Uninstall request"
-                                    }
-                                ]
-                            }
-                        }
-                    },
-                    "description": "Uninstall request",
-                    "required": true
-                },
-                "responses": {
-                    "204": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "description": "No Content"
-                    },
-                    "501": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "description": "Not Implemented"
-                    }
-                },
-                "summary": "Uninstall a skill",
                 "tags": [
                     "skills"
                 ]
@@ -4305,6 +4281,78 @@ const docTemplate = `{
             }
         },
         "/api/v1beta/skills/{name}": {
+            "delete": {
+                "description": "Remove an installed skill",
+                "parameters": [
+                    {
+                        "description": "Skill name",
+                        "in": "path",
+                        "name": "name",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Scope to uninstall from (user or project)",
+                        "in": "query",
+                        "name": "scope",
+                        "schema": {
+                            "enum": [
+                                "user",
+                                "project"
+                            ],
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Bad Request"
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Not Found"
+                    },
+                    "501": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Not Implemented"
+                    }
+                },
+                "summary": "Uninstall a skill",
+                "tags": [
+                    "skills"
+                ]
+            },
             "get": {
                 "description": "Get detailed information about a specific skill",
                 "parameters": [
@@ -4314,6 +4362,18 @@ const docTemplate = `{
                         "name": "name",
                         "required": true,
                         "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Filter by scope (user or project)",
+                        "in": "query",
+                        "name": "scope",
+                        "schema": {
+                            "enum": [
+                                "user",
+                                "project"
+                            ],
                             "type": "string"
                         }
                     }
@@ -4328,6 +4388,26 @@ const docTemplate = `{
                             }
                         },
                         "description": "OK"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Bad Request"
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Not Found"
                     },
                     "501": {
                         "content": {

--- a/docs/server/swagger.json
+++ b/docs/server/swagger.json
@@ -1597,7 +1597,7 @@
                 "type": "object"
             },
             "skills.Scope": {
-                "description": "Scope from which to uninstall",
+                "description": "Scope for the installation",
                 "enum": [
                     "user",
                     "project"
@@ -2582,19 +2582,6 @@
                     "name": {
                         "description": "Name of the tool",
                         "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "v1.uninstallSkillRequest": {
-                "description": "Request to uninstall a skill",
-                "properties": {
-                    "name": {
-                        "description": "Name of the skill to uninstall",
-                        "type": "string"
-                    },
-                    "scope": {
-                        "$ref": "#/components/schemas/skills.Scope"
                     }
                 },
                 "type": "object"
@@ -4014,6 +4001,20 @@
         "/api/v1beta/skills": {
             "get": {
                 "description": "Get a list of all installed skills",
+                "parameters": [
+                    {
+                        "description": "Filter by scope (user or project)",
+                        "in": "query",
+                        "name": "scope",
+                        "schema": {
+                            "enum": [
+                                "user",
+                                "project"
+                            ],
+                            "type": "string"
+                        }
+                    }
+                ],
                 "responses": {
                     "200": {
                         "content": {
@@ -4037,6 +4038,83 @@
                     }
                 },
                 "summary": "List all installed skills",
+                "tags": [
+                    "skills"
+                ]
+            },
+            "post": {
+                "description": "Install a skill from a remote source",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "oneOf": [
+                                    {
+                                        "type": "object"
+                                    },
+                                    {
+                                        "$ref": "#/components/schemas/v1.installSkillRequest",
+                                        "summary": "request",
+                                        "description": "Install request"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "description": "Install request",
+                    "required": true
+                },
+                "responses": {
+                    "201": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/v1.installSkillResponse"
+                                }
+                            }
+                        },
+                        "description": "Created",
+                        "headers": {
+                            "Location": {
+                                "description": "URI of the installed skill resource",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Bad Request"
+                    },
+                    "409": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Conflict"
+                    },
+                    "501": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Not Implemented"
+                    }
+                },
+                "summary": "Install a skill",
                 "tags": [
                     "skills"
                 ]
@@ -4093,57 +4171,6 @@
                 ]
             }
         },
-        "/api/v1beta/skills/install": {
-            "post": {
-                "description": "Install a skill from a remote source",
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "oneOf": [
-                                    {
-                                        "type": "object"
-                                    },
-                                    {
-                                        "$ref": "#/components/schemas/v1.installSkillRequest",
-                                        "summary": "request",
-                                        "description": "Install request"
-                                    }
-                                ]
-                            }
-                        }
-                    },
-                    "description": "Install request",
-                    "required": true
-                },
-                "responses": {
-                    "201": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/v1.installSkillResponse"
-                                }
-                            }
-                        },
-                        "description": "Created"
-                    },
-                    "501": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "description": "Not Implemented"
-                    }
-                },
-                "summary": "Install a skill",
-                "tags": [
-                    "skills"
-                ]
-            }
-        },
         "/api/v1beta/skills/push": {
             "post": {
                 "description": "Push a built skill artifact to a remote registry",
@@ -4190,57 +4217,6 @@
                     }
                 },
                 "summary": "Push a skill",
-                "tags": [
-                    "skills"
-                ]
-            }
-        },
-        "/api/v1beta/skills/uninstall": {
-            "post": {
-                "description": "Remove an installed skill",
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "oneOf": [
-                                    {
-                                        "type": "object"
-                                    },
-                                    {
-                                        "$ref": "#/components/schemas/v1.uninstallSkillRequest",
-                                        "summary": "request",
-                                        "description": "Uninstall request"
-                                    }
-                                ]
-                            }
-                        }
-                    },
-                    "description": "Uninstall request",
-                    "required": true
-                },
-                "responses": {
-                    "204": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "description": "No Content"
-                    },
-                    "501": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "description": "Not Implemented"
-                    }
-                },
-                "summary": "Uninstall a skill",
                 "tags": [
                     "skills"
                 ]
@@ -4298,6 +4274,78 @@
             }
         },
         "/api/v1beta/skills/{name}": {
+            "delete": {
+                "description": "Remove an installed skill",
+                "parameters": [
+                    {
+                        "description": "Skill name",
+                        "in": "path",
+                        "name": "name",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Scope to uninstall from (user or project)",
+                        "in": "query",
+                        "name": "scope",
+                        "schema": {
+                            "enum": [
+                                "user",
+                                "project"
+                            ],
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Bad Request"
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Not Found"
+                    },
+                    "501": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Not Implemented"
+                    }
+                },
+                "summary": "Uninstall a skill",
+                "tags": [
+                    "skills"
+                ]
+            },
             "get": {
                 "description": "Get detailed information about a specific skill",
                 "parameters": [
@@ -4307,6 +4355,18 @@
                         "name": "name",
                         "required": true,
                         "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Filter by scope (user or project)",
+                        "in": "query",
+                        "name": "scope",
+                        "schema": {
+                            "enum": [
+                                "user",
+                                "project"
+                            ],
                             "type": "string"
                         }
                     }
@@ -4321,6 +4381,26 @@
                             }
                         },
                         "description": "OK"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Bad Request"
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Not Found"
                     },
                     "501": {
                         "content": {

--- a/docs/server/swagger.yaml
+++ b/docs/server/swagger.yaml
@@ -1467,7 +1467,7 @@ components:
           type: string
       type: object
     skills.Scope:
-      description: Scope from which to uninstall
+      description: Scope for the installation
       enum:
       - user
       - project
@@ -2267,15 +2267,6 @@ components:
         name:
           description: Name of the tool
           type: string
-      type: object
-    v1.uninstallSkillRequest:
-      description: Request to uninstall a skill
-      properties:
-        name:
-          description: Name of the skill to uninstall
-          type: string
-        scope:
-          $ref: '#/components/schemas/skills.Scope'
       type: object
     v1.updateRequest:
       description: Request to update an existing workload (name cannot be changed)
@@ -3164,6 +3155,15 @@ paths:
   /api/v1beta/skills:
     get:
       description: Get a list of all installed skills
+      parameters:
+      - description: Filter by scope (user or project)
+        in: query
+        name: scope
+        schema:
+          enum:
+          - user
+          - project
+          type: string
       responses:
         "200":
           content:
@@ -3180,7 +3180,98 @@ paths:
       summary: List all installed skills
       tags:
       - skills
+    post:
+      description: Install a skill from a remote source
+      requestBody:
+        content:
+          application/json:
+            schema:
+              oneOf:
+              - type: object
+              - $ref: '#/components/schemas/v1.installSkillRequest'
+                description: Install request
+                summary: request
+        description: Install request
+        required: true
+      responses:
+        "201":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/v1.installSkillResponse'
+          description: Created
+          headers:
+            Location:
+              description: URI of the installed skill resource
+              schema:
+                type: string
+        "400":
+          content:
+            application/json:
+              schema:
+                type: string
+          description: Bad Request
+        "409":
+          content:
+            application/json:
+              schema:
+                type: string
+          description: Conflict
+        "501":
+          content:
+            application/json:
+              schema:
+                type: string
+          description: Not Implemented
+      summary: Install a skill
+      tags:
+      - skills
   /api/v1beta/skills/{name}:
+    delete:
+      description: Remove an installed skill
+      parameters:
+      - description: Skill name
+        in: path
+        name: name
+        required: true
+        schema:
+          type: string
+      - description: Scope to uninstall from (user or project)
+        in: query
+        name: scope
+        schema:
+          enum:
+          - user
+          - project
+          type: string
+      responses:
+        "204":
+          content:
+            application/json:
+              schema:
+                type: string
+          description: No Content
+        "400":
+          content:
+            application/json:
+              schema:
+                type: string
+          description: Bad Request
+        "404":
+          content:
+            application/json:
+              schema:
+                type: string
+          description: Not Found
+        "501":
+          content:
+            application/json:
+              schema:
+                type: string
+          description: Not Implemented
+      summary: Uninstall a skill
+      tags:
+      - skills
     get:
       description: Get detailed information about a specific skill
       parameters:
@@ -3190,6 +3281,14 @@ paths:
         required: true
         schema:
           type: string
+      - description: Filter by scope (user or project)
+        in: query
+        name: scope
+        schema:
+          enum:
+          - user
+          - project
+          type: string
       responses:
         "200":
           content:
@@ -3197,6 +3296,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/skills.SkillInfo'
           description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                type: string
+          description: Bad Request
+        "404":
+          content:
+            application/json:
+              schema:
+                type: string
+          description: Not Found
         "501":
           content:
             application/json:
@@ -3236,36 +3347,6 @@ paths:
       summary: Build a skill
       tags:
       - skills
-  /api/v1beta/skills/install:
-    post:
-      description: Install a skill from a remote source
-      requestBody:
-        content:
-          application/json:
-            schema:
-              oneOf:
-              - type: object
-              - $ref: '#/components/schemas/v1.installSkillRequest'
-                description: Install request
-                summary: request
-        description: Install request
-        required: true
-      responses:
-        "201":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/v1.installSkillResponse'
-          description: Created
-        "501":
-          content:
-            application/json:
-              schema:
-                type: string
-          description: Not Implemented
-      summary: Install a skill
-      tags:
-      - skills
   /api/v1beta/skills/push:
     post:
       description: Push a built skill artifact to a remote registry
@@ -3294,36 +3375,6 @@ paths:
                 type: string
           description: Not Implemented
       summary: Push a skill
-      tags:
-      - skills
-  /api/v1beta/skills/uninstall:
-    post:
-      description: Remove an installed skill
-      requestBody:
-        content:
-          application/json:
-            schema:
-              oneOf:
-              - type: object
-              - $ref: '#/components/schemas/v1.uninstallSkillRequest'
-                description: Uninstall request
-                summary: request
-        description: Uninstall request
-        required: true
-      responses:
-        "204":
-          content:
-            application/json:
-              schema:
-                type: string
-          description: No Content
-        "501":
-          content:
-            application/json:
-              schema:
-                type: string
-          description: Not Implemented
-      summary: Uninstall a skill
       tags:
       - skills
   /api/v1beta/skills/validate:

--- a/pkg/api/v1/skills.go
+++ b/pkg/api/v1/skills.go
@@ -27,8 +27,8 @@ func SkillsRouter(skillService skills.SkillService) http.Handler {
 
 	r := chi.NewRouter()
 	r.Get("/", apierrors.ErrorHandler(routes.listSkills))
-	r.Post("/install", apierrors.ErrorHandler(routes.installSkill))
-	r.Post("/uninstall", apierrors.ErrorHandler(routes.uninstallSkill))
+	r.Post("/", apierrors.ErrorHandler(routes.installSkill))
+	r.Delete("/{name}", apierrors.ErrorHandler(routes.uninstallSkill))
 	r.Get("/{name}", apierrors.ErrorHandler(routes.getSkillInfo))
 	r.Post("/validate", apierrors.ErrorHandler(routes.validateSkill))
 	r.Post("/build", apierrors.ErrorHandler(routes.buildSkill))
@@ -43,8 +43,9 @@ func SkillsRouter(skillService skills.SkillService) http.Handler {
 //	@Description	Get a list of all installed skills
 //	@Tags			skills
 //	@Produce		json
-//	@Success		200	{object}	skillListResponse
-//	@Failure		501	{string}	string	"Not Implemented"
+//	@Param			scope	query		string	false	"Filter by scope (user or project)"	Enums(user, project)
+//	@Success		200		{object}	skillListResponse
+//	@Failure		501		{string}	string	"Not Implemented"
 //	@Router			/api/v1beta/skills [get]
 func (*SkillsRoutes) listSkills(_ http.ResponseWriter, _ *http.Request) error {
 	return httperr.WithCode(fmt.Errorf("not implemented"), http.StatusNotImplemented)
@@ -59,8 +60,11 @@ func (*SkillsRoutes) listSkills(_ http.ResponseWriter, _ *http.Request) error {
 //	@Produce		json
 //	@Param			request	body		installSkillRequest	true	"Install request"
 //	@Success		201		{object}	installSkillResponse
-//	@Failure		501		{string}	string	"Not Implemented"
-//	@Router			/api/v1beta/skills/install [post]
+//	@Header			201		{string}	Location	"URI of the installed skill resource"
+//	@Failure		400		{string}	string		"Bad Request"
+//	@Failure		409		{string}	string		"Conflict"
+//	@Failure		501		{string}	string		"Not Implemented"
+//	@Router			/api/v1beta/skills [post]
 func (*SkillsRoutes) installSkill(_ http.ResponseWriter, _ *http.Request) error {
 	return httperr.WithCode(fmt.Errorf("not implemented"), http.StatusNotImplemented)
 }
@@ -70,11 +74,13 @@ func (*SkillsRoutes) installSkill(_ http.ResponseWriter, _ *http.Request) error 
 //	@Summary		Uninstall a skill
 //	@Description	Remove an installed skill
 //	@Tags			skills
-//	@Accept			json
-//	@Param			request	body	uninstallSkillRequest	true	"Uninstall request"
+//	@Param			name	path		string	true	"Skill name"
+//	@Param			scope	query		string	false	"Scope to uninstall from (user or project)"	Enums(user, project)
 //	@Success		204		{string}	string	"No Content"
+//	@Failure		400		{string}	string	"Bad Request"
+//	@Failure		404		{string}	string	"Not Found"
 //	@Failure		501		{string}	string	"Not Implemented"
-//	@Router			/api/v1beta/skills/uninstall [post]
+//	@Router			/api/v1beta/skills/{name} [delete]
 func (*SkillsRoutes) uninstallSkill(_ http.ResponseWriter, _ *http.Request) error {
 	return httperr.WithCode(fmt.Errorf("not implemented"), http.StatusNotImplemented)
 }
@@ -86,7 +92,10 @@ func (*SkillsRoutes) uninstallSkill(_ http.ResponseWriter, _ *http.Request) erro
 //	@Tags			skills
 //	@Produce		json
 //	@Param			name	path		string	true	"Skill name"
+//	@Param			scope	query		string	false	"Filter by scope (user or project)"	Enums(user, project)
 //	@Success		200		{object}	skills.SkillInfo
+//	@Failure		400		{string}	string	"Bad Request"
+//	@Failure		404		{string}	string	"Not Found"
 //	@Failure		501		{string}	string	"Not Implemented"
 //	@Router			/api/v1beta/skills/{name} [get]
 func (*SkillsRoutes) getSkillInfo(_ http.ResponseWriter, _ *http.Request) error {

--- a/pkg/api/v1/skills_types.go
+++ b/pkg/api/v1/skills_types.go
@@ -39,18 +39,6 @@ type installSkillResponse struct {
 	Skill skills.InstalledSkill `json:"skill"`
 }
 
-// uninstallSkillRequest represents the request to uninstall a skill.
-//
-//	@Description	Request to uninstall a skill
-//
-//nolint:unused // stub type for swagger annotations, used when handlers are implemented
-type uninstallSkillRequest struct {
-	// Name of the skill to uninstall
-	Name string `json:"name"`
-	// Scope from which to uninstall
-	Scope skills.Scope `json:"scope,omitempty"`
-}
-
 // validateSkillRequest represents the request to validate a skill.
 //
 //	@Description	Request to validate a skill definition

--- a/pkg/skills/options.go
+++ b/pkg/skills/options.go
@@ -37,6 +37,8 @@ type UninstallOptions struct {
 type InfoOptions struct {
 	// Name is the skill name to look up.
 	Name string `json:"name"`
+	// Scope filters the lookup by installation scope.
+	Scope Scope `json:"scope,omitempty"`
 }
 
 // SkillInfo contains detailed information about a skill.

--- a/pkg/skills/types.go
+++ b/pkg/skills/types.go
@@ -22,6 +22,17 @@ const (
 	ScopeProject Scope = "project"
 )
 
+// ValidateScope checks that a scope value is valid. An empty scope is accepted
+// (meaning "unscoped" / "all"). Otherwise only "user" and "project" are allowed.
+func ValidateScope(s Scope) error {
+	switch s {
+	case "", ScopeUser, ScopeProject:
+		return nil
+	default:
+		return fmt.Errorf("invalid scope %q: must be empty, %q, or %q", s, ScopeUser, ScopeProject)
+	}
+}
+
 // InstallStatus represents the current status of a skill installation.
 type InstallStatus string
 

--- a/pkg/skills/validator_test.go
+++ b/pkg/skills/validator_test.go
@@ -316,6 +316,40 @@ func TestValidateSkillName(t *testing.T) {
 	}
 }
 
+func TestValidateScope(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		input      Scope
+		wantErr    bool
+		errContain string
+	}{
+		{name: "empty is valid", input: "", wantErr: false},
+		{name: "user is valid", input: ScopeUser, wantErr: false},
+		{name: "project is valid", input: ScopeProject, wantErr: false},
+		{name: "unknown scope is invalid", input: "global", wantErr: true, errContain: "global"},
+		{name: "uppercase user is invalid", input: "User", wantErr: true, errContain: "User"},
+		{name: "uppercase PROJECT is invalid", input: "PROJECT", wantErr: true, errContain: "PROJECT"},
+		{name: "whitespace only is invalid", input: " ", wantErr: true, errContain: "invalid scope"},
+		{name: "trailing space is invalid", input: "user ", wantErr: true, errContain: "user "},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := ValidateScope(tt.input)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errContain)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
 // containsSubstring checks if any string in the slice contains the given substring.
 func containsSubstring(strs []string, substr string) bool {
 	for _, s := range strs {


### PR DESCRIPTION
## Summary

The skills endpoints (merged as 501 stubs in #3801) used verb-based routes
(`POST /install`, `POST /uninstall`) that don't follow REST conventions. This
PR fixes the API contract **before** the service implementation lands, so #3804
can rebase onto clean routes.

- `POST /skills/install` → `POST /skills/` — standard resource creation
- `POST /skills/uninstall` → `DELETE /skills/{name}` — idiomatic resource deletion via path param + `?scope=` query param
- Removed `uninstallSkillRequest` body type (no longer needed)
- Added `Enums(user, project)` constraint to all three `scope` query params (list, info, uninstall) for machine-readable OpenAPI validation
- Documented `Location` header on 201 install response
- Added 400/404/409 failure codes to swagger annotations where appropriate
- Added `ValidateScope()` function for scope validation at API boundaries
- Added `Scope` field to `InfoOptions` so the info endpoint can accept scope filtering

### Route comparison

| Endpoint | Before | After |
|----------|--------|-------|
| Install | `POST /api/v1beta/skills/install` | `POST /api/v1beta/skills` |
| Uninstall | `POST /api/v1beta/skills/uninstall` (JSON body) | `DELETE /api/v1beta/skills/{name}?scope=` |
| List | `GET /api/v1beta/skills` | unchanged (added `?scope=` enum) |
| Info | `GET /api/v1beta/skills/{name}` | unchanged (added `?scope=` enum + 404) |

All handlers remain 501 stubs — zero service code is touched. #3804 will
rebase onto this and adapt its handlers to the new routes.

### Why now?

Changing routes after the service implementation lands means rewriting handler
code, tests, and client assumptions simultaneously. Doing it while everything
is still a stub makes the change trivial and reviewable.

Refs: #3648, #3741

## Test plan

- [x] `task lint` — 0 issues
- [x] `task test` — all passing
- [x] `task docs` — swagger regenerated with enum constraints
- [x] `TestValidateScope` — 8 cases: valid scopes, unknown values, case sensitivity, whitespace, trailing spaces, and error message content assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)