### PR TITLE
Harden scope handling in DCR and callback handler

### DIFF
--- a/docs/server/docs.go
+++ b/docs/server/docs.go
@@ -217,7 +217,7 @@ const docTemplate = `{
                         "type": "string"
                     },
                     "scopes_supported": {
-                        "description": "ScopesSupported lists the OAuth 2.0 scope values advertised in discovery documents.\nIf empty, defaults to [\"openid\", \"profile\", \"email\", \"offline_access\"].",
+                        "description": "ScopesSupported lists the OAuth 2.0 scope values advertised in discovery documents.\nIf empty, defaults to registration.DefaultScopes ([\"openid\", \"profile\", \"email\", \"offline_access\"]).",
                         "items": {
                             "type": "string"
                         },

--- a/docs/server/swagger.json
+++ b/docs/server/swagger.json
@@ -210,7 +210,7 @@
                         "type": "string"
                     },
                     "scopes_supported": {
-                        "description": "ScopesSupported lists the OAuth 2.0 scope values advertised in discovery documents.\nIf empty, defaults to [\"openid\", \"profile\", \"email\", \"offline_access\"].",
+                        "description": "ScopesSupported lists the OAuth 2.0 scope values advertised in discovery documents.\nIf empty, defaults to registration.DefaultScopes ([\"openid\", \"profile\", \"email\", \"offline_access\"]).",
                         "items": {
                             "type": "string"
                         },

--- a/docs/server/swagger.yaml
+++ b/docs/server/swagger.yaml
@@ -228,7 +228,7 @@ components:
         scopes_supported:
           description: |-
             ScopesSupported lists the OAuth 2.0 scope values advertised in discovery documents.
-            If empty, defaults to ["openid", "profile", "email", "offline_access"].
+            If empty, defaults to registration.DefaultScopes (["openid", "profile", "email", "offline_access"]).
           items:
             type: string
           type: array

--- a/pkg/authserver/config.go
+++ b/pkg/authserver/config.go
@@ -59,7 +59,7 @@ type RunConfig struct {
 	Upstreams []UpstreamRunConfig `json:"upstreams" yaml:"upstreams"`
 
 	// ScopesSupported lists the OAuth 2.0 scope values advertised in discovery documents.
-	// If empty, defaults to ["openid", "profile", "email", "offline_access"].
+	// If empty, defaults to registration.DefaultScopes (["openid", "profile", "email", "offline_access"]).
 	ScopesSupported []string `json:"scopes_supported,omitempty" yaml:"scopes_supported,omitempty"`
 
 	// AllowedAudiences is the list of valid resource URIs that tokens can be issued for.
@@ -295,7 +295,7 @@ type Config struct {
 	Upstreams []UpstreamConfig
 
 	// ScopesSupported lists the OAuth 2.0 scope values advertised in discovery documents.
-	// If nil or empty, defaults to ["openid", "profile", "email", "offline_access"].
+	// If nil or empty, defaults to registration.DefaultScopes (["openid", "profile", "email", "offline_access"]).
 	// This is advertised in /.well-known/openid-configuration and
 	// /.well-known/oauth-authorization-server discovery endpoints.
 	ScopesSupported []string

--- a/pkg/authserver/server/provider.go
+++ b/pkg/authserver/server/provider.go
@@ -201,6 +201,10 @@ func NewAuthorizationServerConfig(cfg *AuthorizationServerParams) (*Authorizatio
 		TokenURL:                       cfg.Issuer + "/oauth/token",
 		EnforcePKCE:                    true,
 		EnablePKCEPlainChallengeMethod: false, // Only allow S256 per MCP specification
+		// ScopeStrategy validates requested scopes against client's registered scopes.
+		// ExactScopeStrategy requires exact matches (no wildcards) for security.
+		// This prevents clients from requesting scopes beyond what they registered with.
+		ScopeStrategy: fosite.ExactScopeStrategy,
 	}
 
 	return &AuthorizationServerConfig{

--- a/pkg/authserver/server/registration/dcr.go
+++ b/pkg/authserver/server/registration/dcr.go
@@ -19,6 +19,7 @@ package registration
 
 import (
 	"slices"
+	"strings"
 
 	"github.com/stacklok/toolhive/pkg/oauth"
 )
@@ -64,6 +65,11 @@ type DCRRequest struct {
 	// ResponseTypes is an array of OAuth 2.0 response types the client may use.
 	// Defaults to ["code"] if not specified.
 	ResponseTypes []string `json:"response_types,omitempty"`
+
+	// Scope is a space-separated list of OAuth 2.0 scope values the client may use.
+	// If not specified, defaults to the server's default scopes.
+	// All requested scopes must be supported by the server.
+	Scope string `json:"scope,omitempty"`
 }
 
 // DCRResponse represents a successful OAuth 2.0 Dynamic Client Registration
@@ -250,4 +256,55 @@ func ValidateRedirectURI(uri string) *DCRError {
 		}
 	}
 	return nil
+}
+
+// ValidateScopes validates that all requested scopes are in the allowed set.
+// Returns the validated scopes (or defaults if empty) and any error.
+// This enforces server-side scope restrictions per RFC 7591 Section 2.
+func ValidateScopes(requestedScope string, allowedScopes []string) ([]string, *DCRError) {
+	// Build allowed scope set for O(1) lookup
+	allowed := make(map[string]bool, len(allowedScopes))
+	for _, s := range allowedScopes {
+		allowed[s] = true
+	}
+
+	// Parse space-separated scope string per RFC 6749 Section 3.3.
+	// Deduplicate to ensure each scope appears at most once (RFC 6749
+	// defines scope as a set of case-sensitive strings).
+	var scopes []string
+	if requestedScope != "" {
+		seen := make(map[string]bool)
+		for _, s := range strings.Fields(requestedScope) {
+			if !allowed[s] {
+				return nil, &DCRError{
+					Error:            DCRErrorInvalidClientMetadata,
+					ErrorDescription: "unsupported scope: " + s,
+				}
+			}
+			if !seen[s] {
+				seen[s] = true
+				scopes = append(scopes, s)
+			}
+		}
+	}
+
+	// If no scopes requested, use defaults validated against allowed scopes
+	if len(scopes) == 0 {
+		for _, s := range DefaultScopes {
+			if !allowed[s] {
+				return nil, &DCRError{
+					Error:            DCRErrorInvalidClientMetadata,
+					ErrorDescription: "default scope not supported by server: " + s,
+				}
+			}
+		}
+		return DefaultScopes, nil
+	}
+
+	return scopes, nil
+}
+
+// FormatScopes formats a scope slice as a space-separated string.
+func FormatScopes(scopes []string) string {
+	return strings.Join(scopes, " ")
 }


### PR DESCRIPTION
The embedded auth server had three scope-handling gaps that weakened least-privilege enforcement. These are not directly exploitable under the current default configuration, but reduce defense-in-depth:

1. DCR registered every client with all ScopesSupported scopes unconditionally, ignoring what the client actually needs.

2. The callback handler copied all stored scopes from PendingAuthorization into GrantedScope without filtering against the client's registration.

3. No explicit ScopeStrategy was configured — fosite's default WildcardScopeStrategy works for current scope names but is less strict than necessary.

Changes:
- Set fosite ScopeStrategy to ExactScopeStrategy explicitly
- Add scope field to DCR requests; validate against ScopesSupported; default to DefaultScopes when omitted
- Filter callback scopes against client registration and log when scopes are dropped
- Deduplicate scope values
- Add integration test for scope elevation rejection
- Add prefix/substring scope validation tests
- Replace hardcoded scope slices with registration.DefaultScopes
- Fix stale ScopesSupported comments in config.go

Fixes #3745