### PR TITLE
Add extensible container runtime registry

### DIFF
--- a/pkg/container/docker/register.go
+++ b/pkg/container/docker/register.go
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package docker
+
+import (
+	"context"
+
+	"github.com/stacklok/toolhive/pkg/container/runtime"
+)
+
+func init() {
+	runtime.RegisterRuntime(&runtime.Info{
+		Name:     RuntimeName,
+		Priority: 100,
+		Initializer: func(ctx context.Context) (runtime.Runtime, error) {
+			return NewClient(ctx)
+		},
+		AutoDetector: func() bool {
+			return IsAvailable()
+		},
+	})
+}

--- a/pkg/container/factory.go
+++ b/pkg/container/factory.go
@@ -9,81 +9,43 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 	"sync"
 
 	"github.com/stacklok/toolhive/pkg/container/docker"
-	"github.com/stacklok/toolhive/pkg/container/kubernetes"
 	"github.com/stacklok/toolhive/pkg/container/runtime"
 )
-
-// RuntimeInitializer is a function that creates a new runtime instance
-type RuntimeInitializer func(ctx context.Context) (runtime.Runtime, error)
-
-// RuntimeInfo contains metadata about a runtime
-type RuntimeInfo struct {
-	// Name is the runtime name (e.g., "docker", "kubernetes")
-	Name string
-	// Initializer is the function to create the runtime instance
-	Initializer RuntimeInitializer
-	// AutoDetector is an optional function to detect if this runtime is available
-	// If nil, the runtime is always considered available
-	AutoDetector func() bool
-}
 
 // Factory creates container runtimes with pluggable runtime support
 type Factory struct {
 	mu       sync.RWMutex
-	runtimes map[string]*RuntimeInfo
+	runtimes map[string]*runtime.Info
 }
 
-// NewFactory creates a new container factory with default runtimes registered
+// NewFactory creates a new container factory seeded from the DefaultRegistry.
+// Runtimes register themselves via init() in their respective packages;
+// the container/runtimes.go collector file ensures all built-in runtimes are imported.
 func NewFactory() *Factory {
+	return NewFactoryFromRegistry(runtime.DefaultRegistry)
+}
+
+// NewFactoryFromRegistry creates a new container factory seeded from the given registry.
+// This is useful for testing with isolated registry instances.
+func NewFactoryFromRegistry(reg *runtime.Registry) *Factory {
 	f := &Factory{
-		runtimes: make(map[string]*RuntimeInfo),
+		runtimes: make(map[string]*runtime.Info),
 	}
 
-	// Register default runtimes
-	f.registerDefaultRuntimes()
+	for _, info := range reg.All() {
+		f.runtimes[info.Name] = info
+	}
 
 	return f
 }
 
-// registerDefaultRuntimes registers the built-in docker and kubernetes runtimes
-func (f *Factory) registerDefaultRuntimes() {
-	// Register Docker runtime
-	if err := f.Register(&RuntimeInfo{
-		Name: docker.RuntimeName,
-		Initializer: func(ctx context.Context) (runtime.Runtime, error) {
-			return docker.NewClient(ctx)
-		},
-		AutoDetector: func() bool {
-			// Check if Docker daemon is actually available
-			return docker.IsAvailable()
-		},
-	}); err != nil {
-		// This should never happen for built-in runtimes
-		panic(fmt.Sprintf("failed to register built-in runtime: %v", err))
-	}
-
-	// Register Kubernetes runtime
-	if err := f.Register(&RuntimeInfo{
-		Name: kubernetes.RuntimeName,
-		Initializer: func(ctx context.Context) (runtime.Runtime, error) {
-			return kubernetes.NewClient(ctx)
-		},
-		AutoDetector: func() bool {
-			// Kubernetes is available if we're in a Kubernetes environment
-			return runtime.IsKubernetesRuntime()
-		},
-	}); err != nil {
-		// This should never happen for built-in runtimes
-		panic(fmt.Sprintf("failed to register built-in runtime: %v", err))
-	}
-}
-
 // Register registers a new runtime with the factory
-func (f *Factory) Register(info *RuntimeInfo) error {
+func (f *Factory) Register(info *runtime.Info) error {
 	if info == nil {
 		return fmt.Errorf("runtime info cannot be nil")
 	}
@@ -109,7 +71,7 @@ func (f *Factory) Unregister(name string) {
 }
 
 // GetRuntime retrieves a runtime info by name
-func (f *Factory) GetRuntime(name string) (*RuntimeInfo, bool) {
+func (f *Factory) GetRuntime(name string) (*runtime.Info, bool) {
 	f.mu.RLock()
 	defer f.mu.RUnlock()
 	info, exists := f.runtimes[name]
@@ -117,11 +79,11 @@ func (f *Factory) GetRuntime(name string) (*RuntimeInfo, bool) {
 }
 
 // ListRuntimes returns all registered runtimes
-func (f *Factory) ListRuntimes() map[string]*RuntimeInfo {
+func (f *Factory) ListRuntimes() map[string]*runtime.Info {
 	f.mu.RLock()
 	defer f.mu.RUnlock()
 
-	result := make(map[string]*RuntimeInfo, len(f.runtimes))
+	result := make(map[string]*runtime.Info, len(f.runtimes))
 	for name, info := range f.runtimes {
 		result[name] = info
 	}
@@ -129,54 +91,17 @@ func (f *Factory) ListRuntimes() map[string]*RuntimeInfo {
 }
 
 // ListAvailableRuntimes returns all runtimes that are currently available
-func (f *Factory) ListAvailableRuntimes() map[string]*RuntimeInfo {
+func (f *Factory) ListAvailableRuntimes() map[string]*runtime.Info {
 	f.mu.RLock()
 	defer f.mu.RUnlock()
 
-	result := make(map[string]*RuntimeInfo)
+	result := make(map[string]*runtime.Info)
 	for name, info := range f.runtimes {
 		if info.AutoDetector == nil || info.AutoDetector() {
 			result[name] = info
 		}
 	}
 	return result
-}
-
-// autoDetectRuntime returns the first available runtime based on auto-detection
-// This checks runtimes in a predictable order: Docker first, then Kubernetes
-func (f *Factory) autoDetectRuntime() (string, *RuntimeInfo) {
-	available := f.ListAvailableRuntimes()
-
-	// Define the preferred order of runtime detection
-	preferredOrder := []string{
-		docker.RuntimeName,     // "docker"
-		kubernetes.RuntimeName, // "kubernetes"
-	}
-
-	// Check runtimes in the preferred order
-	for _, runtimeName := range preferredOrder {
-		if info, exists := available[runtimeName]; exists {
-			return runtimeName, info
-		}
-	}
-
-	// Fallback: if none of the preferred runtimes are available,
-	// return any other available runtime (for extensibility)
-	for name, info := range available {
-		return name, info
-	}
-
-	return "", nil
-}
-
-// Clear removes all registered runtimes
-// This is useful for testing or when you want to start with a clean slate
-func (f *Factory) Clear() {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-
-	// Clear all runtimes
-	f.runtimes = make(map[string]*RuntimeInfo)
 }
 
 // Create creates a container runtime
@@ -189,7 +114,7 @@ func (f *Factory) Create(ctx context.Context) (runtime.Runtime, error) {
 // CreateWithRuntimeName creates a container runtime with a specific runtime name
 // If runtimeName is empty, it falls back to auto-detection
 func (f *Factory) CreateWithRuntimeName(ctx context.Context, runtimeName string) (runtime.Runtime, error) {
-	var runtimeInfo *RuntimeInfo
+	var runtimeInfo *runtime.Info
 	var selectedRuntimeName string
 
 	if runtimeName != "" {
@@ -230,12 +155,6 @@ func (f *Factory) CreateWithRuntimeName(ctx context.Context, runtimeName string)
 	return rt, nil
 }
 
-// getRuntimeFromEnv gets the runtime name from the TOOLHIVE_RUNTIME environment variable
-// This is separated for easier testing
-func (*Factory) getRuntimeFromEnv() string {
-	return strings.TrimSpace(os.Getenv("TOOLHIVE_RUNTIME"))
-}
-
 // NewMonitor creates a new container monitor
 func NewMonitor(rt runtime.Runtime, containerName string) runtime.Monitor {
 	return docker.NewMonitor(rt, containerName)
@@ -248,9 +167,57 @@ func CheckRuntimeAvailable() error {
 	available := factory.ListAvailableRuntimes()
 
 	if len(available) == 0 {
-		return fmt.Errorf("no container runtime available. ToolHive requires Docker, Podman, Colima, " +
-			"or a Kubernetes environment to run MCP servers")
+		registered := runtime.RegisteredRuntimesByPriority()
+		names := make([]string, 0, len(registered))
+		for _, r := range registered {
+			names = append(names, r.Name)
+		}
+		return fmt.Errorf("no container runtime available. ToolHive requires a Docker-compatible container runtime "+
+			"(Docker, Podman, or Colima) or Kubernetes to run MCP servers. Registered runtimes: [%s]",
+			strings.Join(names, ", "))
 	}
 
 	return nil
+}
+
+// autoDetectRuntime returns the first available runtime based on auto-detection.
+// Runtimes are tried in priority order (lowest first); the first one whose
+// AutoDetector is nil or returns true is selected.
+func (f *Factory) autoDetectRuntime() (string, *runtime.Info) {
+	f.mu.RLock()
+	ordered := make([]*runtime.Info, 0, len(f.runtimes))
+	for _, info := range f.runtimes {
+		ordered = append(ordered, info)
+	}
+	f.mu.RUnlock()
+
+	sort.SliceStable(ordered, func(i, j int) bool {
+		if ordered[i].Priority != ordered[j].Priority {
+			return ordered[i].Priority < ordered[j].Priority
+		}
+		return ordered[i].Name < ordered[j].Name
+	})
+
+	for _, info := range ordered {
+		if info.AutoDetector == nil || info.AutoDetector() {
+			return info.Name, info
+		}
+	}
+
+	return "", nil
+}
+
+// Clear removes all registered runtimes
+// This is useful for testing or when you want to start with a clean slate
+func (f *Factory) Clear() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.runtimes = make(map[string]*runtime.Info)
+}
+
+// getRuntimeFromEnv gets the runtime name from the TOOLHIVE_RUNTIME environment variable
+// This is separated for easier testing
+func (*Factory) getRuntimeFromEnv() string {
+	return strings.TrimSpace(os.Getenv("TOOLHIVE_RUNTIME"))
 }

--- a/pkg/container/factory_test.go
+++ b/pkg/container/factory_test.go
@@ -1,0 +1,117 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package container
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stacklok/toolhive/pkg/container/runtime"
+)
+
+func noopInit(_ context.Context) (runtime.Runtime, error) {
+	return nil, nil
+}
+
+func TestNewFactoryFromRegistry_SeedsFromRegistry(t *testing.T) {
+	t.Parallel()
+
+	reg := runtime.NewRegistry()
+	reg.Register(&runtime.Info{Name: "test-a", Priority: 100, Initializer: noopInit})
+	reg.Register(&runtime.Info{Name: "test-b", Priority: 200, Initializer: noopInit})
+
+	f := NewFactoryFromRegistry(reg)
+	runtimes := f.ListRuntimes()
+
+	assert.Len(t, runtimes, 2)
+	assert.Contains(t, runtimes, "test-a")
+	assert.Contains(t, runtimes, "test-b")
+}
+
+func TestNewFactoryFromRegistry_EmptyRegistryYieldsEmptyFactory(t *testing.T) {
+	t.Parallel()
+
+	reg := runtime.NewRegistry()
+	f := NewFactoryFromRegistry(reg)
+	assert.Empty(t, f.ListRuntimes())
+}
+
+func TestAutoDetectRuntime_RespectsPriority(t *testing.T) {
+	t.Parallel()
+
+	reg := runtime.NewRegistry()
+	reg.Register(&runtime.Info{
+		Name: "high-prio", Priority: 300, Initializer: noopInit,
+		AutoDetector: func() bool { return true },
+	})
+	reg.Register(&runtime.Info{
+		Name: "low-prio", Priority: 50, Initializer: noopInit,
+		AutoDetector: func() bool { return true },
+	})
+	reg.Register(&runtime.Info{
+		Name: "mid-prio", Priority: 150, Initializer: noopInit,
+		AutoDetector: func() bool { return true },
+	})
+
+	f := NewFactoryFromRegistry(reg)
+	name, info := f.autoDetectRuntime()
+
+	require.NotNil(t, info)
+	assert.Equal(t, "low-prio", name)
+}
+
+func TestAutoDetectRuntime_SkipsUnavailable(t *testing.T) {
+	t.Parallel()
+
+	reg := runtime.NewRegistry()
+	reg.Register(&runtime.Info{
+		Name: "unavailable", Priority: 50, Initializer: noopInit,
+		AutoDetector: func() bool { return false },
+	})
+	reg.Register(&runtime.Info{
+		Name: "available", Priority: 100, Initializer: noopInit,
+		AutoDetector: func() bool { return true },
+	})
+
+	f := NewFactoryFromRegistry(reg)
+	name, info := f.autoDetectRuntime()
+
+	require.NotNil(t, info)
+	assert.Equal(t, "available", name)
+}
+
+func TestAutoDetectRuntime_NilDetectorMeansAvailable(t *testing.T) {
+	t.Parallel()
+
+	reg := runtime.NewRegistry()
+	reg.Register(&runtime.Info{
+		Name: "no-detector", Priority: 100, Initializer: noopInit,
+		AutoDetector: nil,
+	})
+
+	f := NewFactoryFromRegistry(reg)
+	name, info := f.autoDetectRuntime()
+
+	require.NotNil(t, info)
+	assert.Equal(t, "no-detector", name)
+}
+
+func TestAutoDetectRuntime_NoneAvailable(t *testing.T) {
+	t.Parallel()
+
+	reg := runtime.NewRegistry()
+	reg.Register(&runtime.Info{
+		Name: "unavailable", Priority: 100, Initializer: noopInit,
+		AutoDetector: func() bool { return false },
+	})
+
+	f := NewFactoryFromRegistry(reg)
+	name, info := f.autoDetectRuntime()
+
+	assert.Nil(t, info)
+	assert.Empty(t, name)
+}

--- a/pkg/container/kubernetes/register.go
+++ b/pkg/container/kubernetes/register.go
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package kubernetes
+
+import (
+	"context"
+
+	"github.com/stacklok/toolhive/pkg/container/runtime"
+)
+
+func init() {
+	runtime.RegisterRuntime(&runtime.Info{
+		Name:     RuntimeName,
+		Priority: 200,
+		Initializer: func(ctx context.Context) (runtime.Runtime, error) {
+			return NewClient(ctx)
+		},
+		AutoDetector: func() bool {
+			return runtime.IsKubernetesRuntime()
+		},
+	})
+}

--- a/pkg/container/runtime/registry.go
+++ b/pkg/container/runtime/registry.go
@@ -1,0 +1,132 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package runtime
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+)
+
+// Registry holds a set of registered runtimes. It is safe for concurrent use.
+// Tests should create isolated instances via NewRegistry() rather than using
+// the DefaultRegistry, so they can run fully in parallel.
+type Registry struct {
+	mu       sync.RWMutex
+	runtimes map[string]*Info
+}
+
+// NewRegistry creates a new, empty Registry.
+func NewRegistry() *Registry {
+	return &Registry{
+		runtimes: make(map[string]*Info),
+	}
+}
+
+// Register adds a runtime to the registry.
+// It panics if info is nil, has an empty name, has a nil initializer,
+// or if a runtime with the same name is already registered.
+func (r *Registry) Register(info *Info) {
+	if info == nil {
+		panic("runtime info cannot be nil")
+	}
+	if info.Name == "" {
+		panic("runtime name cannot be empty")
+	}
+	if info.Initializer == nil {
+		panic("runtime initializer cannot be nil")
+	}
+	if info.Priority < 0 {
+		panic("runtime priority must be non-negative")
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if _, exists := r.runtimes[info.Name]; exists {
+		panic(fmt.Sprintf("runtime already registered: %s", info.Name))
+	}
+	r.runtimes[info.Name] = info
+}
+
+// Get returns a copy of the Info for the given name, or nil if not found.
+func (r *Registry) Get(name string) *Info {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	info, ok := r.runtimes[name]
+	if !ok {
+		return nil
+	}
+	cp := *info
+	return &cp
+}
+
+// IsRegistered returns true if a runtime with the given name is registered.
+func (r *Registry) IsRegistered(name string) bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	_, exists := r.runtimes[name]
+	return exists
+}
+
+// All returns copies of all registered runtimes as a slice.
+func (r *Registry) All() []*Info {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	result := make([]*Info, 0, len(r.runtimes))
+	for _, info := range r.runtimes {
+		cp := *info
+		result = append(result, &cp)
+	}
+	return result
+}
+
+// ByPriority returns all registered runtimes sorted by priority (ascending).
+// When two runtimes share the same priority, they are sorted by name for
+// deterministic ordering.
+func (r *Registry) ByPriority() []*Info {
+	runtimes := r.All()
+	sort.SliceStable(runtimes, func(i, j int) bool {
+		if runtimes[i].Priority != runtimes[j].Priority {
+			return runtimes[i].Priority < runtimes[j].Priority
+		}
+		return runtimes[i].Name < runtimes[j].Name
+	})
+	return runtimes
+}
+
+// DefaultRegistry is the global registry used by init()-time self-registration.
+// Production code should use this (typically via the package-level convenience
+// functions). Tests should create isolated registries with NewRegistry().
+var DefaultRegistry = NewRegistry()
+
+// RegisterRuntime registers an Info in the DefaultRegistry.
+// This is typically called from an init() function in each runtime package.
+func RegisterRuntime(info *Info) {
+	DefaultRegistry.Register(info)
+}
+
+// GetRegisteredRuntime returns the Info from the DefaultRegistry for the given name.
+func GetRegisteredRuntime(name string) *Info {
+	return DefaultRegistry.Get(name)
+}
+
+// IsRuntimeRegistered returns true if a runtime is registered in the DefaultRegistry.
+func IsRuntimeRegistered(name string) bool {
+	return DefaultRegistry.IsRegistered(name)
+}
+
+// RegisteredRuntimes returns all runtimes from the DefaultRegistry.
+func RegisteredRuntimes() []*Info {
+	return DefaultRegistry.All()
+}
+
+// RegisteredRuntimesByPriority returns all runtimes from the DefaultRegistry
+// sorted by priority.
+func RegisteredRuntimesByPriority() []*Info {
+	return DefaultRegistry.ByPriority()
+}

--- a/pkg/container/runtime/registry_test.go
+++ b/pkg/container/runtime/registry_test.go
@@ -1,0 +1,186 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package runtime
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func noopInitializer(_ context.Context) (Runtime, error) {
+	return nil, nil
+}
+
+func TestRegistry_Register(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		info      *Info
+		panicMsg  string
+		wantPanic bool
+	}{
+		{
+			name:      "nil info panics",
+			info:      nil,
+			wantPanic: true,
+			panicMsg:  "runtime info cannot be nil",
+		},
+		{
+			name:      "empty name panics",
+			info:      &Info{Name: "", Initializer: noopInitializer},
+			wantPanic: true,
+			panicMsg:  "runtime name cannot be empty",
+		},
+		{
+			name:      "nil initializer panics",
+			info:      &Info{Name: "test", Initializer: nil},
+			wantPanic: true,
+			panicMsg:  "runtime initializer cannot be nil",
+		},
+		{
+			name:      "negative priority panics",
+			info:      &Info{Name: "test", Priority: -1, Initializer: noopInitializer},
+			wantPanic: true,
+			panicMsg:  "runtime priority must be non-negative",
+		},
+		{
+			name: "valid registration succeeds",
+			info: &Info{
+				Name:        "test-rt",
+				Priority:    100,
+				Initializer: noopInitializer,
+			},
+			wantPanic: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			reg := NewRegistry()
+
+			if tt.wantPanic {
+				assert.PanicsWithValue(t, tt.panicMsg, func() {
+					reg.Register(tt.info)
+				})
+			} else {
+				require.NotPanics(t, func() {
+					reg.Register(tt.info)
+				})
+				got := reg.Get(tt.info.Name)
+				require.NotNil(t, got)
+				assert.Equal(t, tt.info.Name, got.Name)
+				assert.Equal(t, tt.info.Priority, got.Priority)
+			}
+		})
+	}
+}
+
+func TestRegistry_DuplicatePanics(t *testing.T) {
+	t.Parallel()
+	reg := NewRegistry()
+
+	info := &Info{
+		Name:        "dup-rt",
+		Priority:    100,
+		Initializer: noopInitializer,
+	}
+	reg.Register(info)
+
+	assert.PanicsWithValue(t, "runtime already registered: dup-rt", func() {
+		reg.Register(info)
+	})
+}
+
+func TestRegistry_Get_NotFound(t *testing.T) {
+	t.Parallel()
+	reg := NewRegistry()
+
+	assert.Nil(t, reg.Get("nonexistent"))
+}
+
+func TestRegistry_IsRegistered(t *testing.T) {
+	t.Parallel()
+	reg := NewRegistry()
+
+	assert.False(t, reg.IsRegistered("check-rt"))
+
+	reg.Register(&Info{
+		Name:        "check-rt",
+		Priority:    100,
+		Initializer: noopInitializer,
+	})
+
+	assert.True(t, reg.IsRegistered("check-rt"))
+}
+
+func TestRegistry_All(t *testing.T) {
+	t.Parallel()
+	reg := NewRegistry()
+
+	assert.Empty(t, reg.All())
+
+	reg.Register(&Info{Name: "a", Priority: 200, Initializer: noopInitializer})
+	reg.Register(&Info{Name: "b", Priority: 100, Initializer: noopInitializer})
+
+	runtimes := reg.All()
+	assert.Len(t, runtimes, 2)
+
+	names := make(map[string]bool)
+	for _, r := range runtimes {
+		names[r.Name] = true
+	}
+	assert.True(t, names["a"])
+	assert.True(t, names["b"])
+}
+
+func TestRegistry_ByPriority(t *testing.T) {
+	t.Parallel()
+	reg := NewRegistry()
+
+	reg.Register(&Info{Name: "high", Priority: 300, Initializer: noopInitializer})
+	reg.Register(&Info{Name: "low", Priority: 50, Initializer: noopInitializer})
+	reg.Register(&Info{Name: "mid", Priority: 150, Initializer: noopInitializer})
+
+	ordered := reg.ByPriority()
+	require.Len(t, ordered, 3)
+	assert.Equal(t, "low", ordered[0].Name)
+	assert.Equal(t, "mid", ordered[1].Name)
+	assert.Equal(t, "high", ordered[2].Name)
+}
+
+func TestRegistry_ByPriority_SamePrioritySortedByName(t *testing.T) {
+	t.Parallel()
+	reg := NewRegistry()
+
+	reg.Register(&Info{Name: "charlie", Priority: 100, Initializer: noopInitializer})
+	reg.Register(&Info{Name: "alpha", Priority: 100, Initializer: noopInitializer})
+	reg.Register(&Info{Name: "bravo", Priority: 100, Initializer: noopInitializer})
+
+	ordered := reg.ByPriority()
+	require.Len(t, ordered, 3)
+	assert.Equal(t, "alpha", ordered[0].Name)
+	assert.Equal(t, "bravo", ordered[1].Name)
+	assert.Equal(t, "charlie", ordered[2].Name)
+}
+
+func TestRegistry_Isolation(t *testing.T) {
+	t.Parallel()
+
+	reg1 := NewRegistry()
+	reg2 := NewRegistry()
+
+	reg1.Register(&Info{Name: "only-in-reg1", Priority: 100, Initializer: noopInitializer})
+	reg2.Register(&Info{Name: "only-in-reg2", Priority: 100, Initializer: noopInitializer})
+
+	assert.True(t, reg1.IsRegistered("only-in-reg1"))
+	assert.False(t, reg1.IsRegistered("only-in-reg2"))
+
+	assert.True(t, reg2.IsRegistered("only-in-reg2"))
+	assert.False(t, reg2.IsRegistered("only-in-reg1"))
+}

--- a/pkg/container/runtimes.go
+++ b/pkg/container/runtimes.go
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package container
+
+// This file imports all container runtime implementations to ensure their init()
+// functions are called and they register themselves with the global runtime registry.
+//
+// When adding a new runtime implementation, add a blank import here.
+
+import (
+	// Import Docker runtime to register it
+	_ "github.com/stacklok/toolhive/pkg/container/docker"
+	// Import Kubernetes runtime to register it
+	_ "github.com/stacklok/toolhive/pkg/container/kubernetes"
+)


### PR DESCRIPTION
## Summary

- Introduces a global `runtime.Registry` struct so built-in runtimes self-register via `init()` and external runtimes can register by blank-importing their package
- Moves `RuntimeInfo`/`RuntimeInitializer` types from `container/factory.go` to `runtime/types.go` (renamed to `Info`/`Initializer` to avoid stutter)
- Factory seeds from the registry instead of hardcoding Docker and Kubernetes; auto-detection uses configurable priority ordering (lower = tried first)
- `NewFactoryFromRegistry()` enables fully isolated, parallel testing — no shared global state in tests

## Design

Follows the existing `pkg/authz/authorizers/registry.go` self-registration pattern:

```go
// External runtime in a separate repo:
func init() {
    runtime.RegisterRuntime(&runtime.Info{
        Name:     "myruntime",
        Priority: 150,
        Initializer: func(ctx context.Context) (runtime.Runtime, error) {
            return NewClient(ctx)
        },
    })
}
```

Priority convention: Docker=100, Kubernetes=200. External runtimes pick relative values.

## Test plan

- [x] `task build` — binary builds, no import cycles
- [x] `task test` — full unit test suite passes (with race detector)
- [x] `task lint-fix` — 0 lint issues
- [x] Registry tests: registration, dedup panic, priority ordering, same-priority name sort, isolation between instances
- [x] Factory tests: seeding from registry, auto-detection priority, skip unavailable, nil detector, none available
- [x] All tests run fully in parallel with isolated `NewRegistry()` instances
- [ ] Manual: `TOOLHIVE_RUNTIME=docker thv list` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)