### PR TITLE
Add gosec #nosec annotations to fix lint errors

### DIFF
--- a/cmd/regup/app/update.go
+++ b/cmd/regup/app/update.go
@@ -374,7 +374,7 @@ func getGitHubRepoInfo(owner, repo, serverName string, currentPulls int) (stars 
 	}
 
 	// Send request
-	resp, err := client.Do(req)
+	resp, err := client.Do(req) //nolint:gosec // G704: URL is from hardcoded GitHub API endpoint
 	if err != nil {
 		return 0, 0, fmt.Errorf("failed to send request: %w", err)
 	}

--- a/cmd/thv-operator/api/v1alpha1/mcpserver_types.go
+++ b/cmd/thv-operator/api/v1alpha1/mcpserver_types.go
@@ -530,7 +530,7 @@ type InlineOIDCConfig struct {
 	// ClientSecret is the client secret for introspection (optional)
 	// Deprecated: Use ClientSecretRef instead for better security
 	// +optional
-	ClientSecret string `json:"clientSecret,omitempty"`
+	ClientSecret string `json:"clientSecret,omitempty"` //nolint:gosec // G117: field legitimately holds sensitive data
 
 	// ClientSecretRef is a reference to a Kubernetes Secret containing the client secret
 	// If both ClientSecret and ClientSecretRef are provided, ClientSecretRef takes precedence

--- a/cmd/thv-operator/pkg/httpclient/client.go
+++ b/cmd/thv-operator/pkg/httpclient/client.go
@@ -65,7 +65,7 @@ func (c *DefaultClient) Get(ctx context.Context, url string) ([]byte, error) {
 	req.Header.Set("Accept", "application/json")
 
 	// Execute request
-	resp, err := c.client.Do(req)
+	resp, err := c.client.Do(req) //nolint:gosec // G704: URL is from operator-configured endpoints
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute request: %w", err)
 	}

--- a/cmd/thv-operator/pkg/oidc/resolver.go
+++ b/cmd/thv-operator/pkg/oidc/resolver.go
@@ -34,7 +34,7 @@ type OIDCConfig struct { //nolint:revive // Keeping OIDCConfig name for backward
 	JWKSURL            string
 	IntrospectionURL   string
 	ClientID           string
-	ClientSecret       string
+	ClientSecret       string // #nosec G117 -- not a hardcoded credential, populated at runtime from config
 	ThvCABundlePath    string
 	JWKSAuthTokenPath  string
 	ResourceURL        string

--- a/cmd/thv/app/build.go
+++ b/cmd/thv/app/build.go
@@ -105,6 +105,7 @@ func buildCmdFunc(cmd *cobra.Command, args []string) error {
 
 		// Write to output file if specified
 		if buildFlags.Output != "" {
+			// #nosec G703 -- buildFlags.Output is a user-provided CLI flag for output path
 			if err := os.WriteFile(buildFlags.Output, []byte(dockerfileContent), 0600); err != nil {
 				return fmt.Errorf("failed to write Dockerfile to %s: %w", buildFlags.Output, err)
 			}

--- a/cmd/thv/app/ui/clients_setup.go
+++ b/cmd/thv/app/ui/clients_setup.go
@@ -118,7 +118,7 @@ func (m *setupModel) View() string {
 			for i := range m.SelectedGroups {
 				selectedGroupNames = append(selectedGroupNames, m.Groups[i].Name)
 			}
-			b.WriteString(fmt.Sprintf("Selected groups: %s\n\n", strings.Join(selectedGroupNames, ", ")))
+			fmt.Fprintf(&b, "Selected groups: %s\n\n", strings.Join(selectedGroupNames, ", "))
 		}
 		b.WriteString("Select clients to register:\n\n")
 		for i, cli := range m.Clients {

--- a/pkg/api/v1/secrets.go
+++ b/pkg/api/v1/secrets.go
@@ -533,7 +533,7 @@ type setupSecretsRequest struct {
 	ProviderType string `json:"provider_type"`
 	// Password for encrypted provider (optional, can be set via environment variable)
 	// TODO Review environment variable for this
-	Password string `json:"password,omitempty"`
+	Password string `json:"password,omitempty"` //nolint:gosec // G117: field legitimately holds sensitive data
 }
 
 // setupSecretsResponse represents the response for initializing a secrets provider

--- a/pkg/api/v1/workload_types.go
+++ b/pkg/api/v1/workload_types.go
@@ -164,7 +164,7 @@ type oidcOptions struct {
 	// OAuth2 client ID
 	ClientID string `json:"client_id"`
 	// OAuth2 client secret
-	ClientSecret string `json:"client_secret"`
+	ClientSecret string `json:"client_secret"` //nolint:gosec // G117
 	// OAuth scopes to advertise in well-known endpoint (RFC 9728)
 	Scopes []string `json:"scopes,omitempty"`
 }

--- a/pkg/api/v1/workloads.go
+++ b/pkg/api/v1/workloads.go
@@ -533,7 +533,7 @@ func (s *WorkloadRoutes) getLogsForWorkload(w http.ResponseWriter, r *http.Reque
 	}
 
 	w.Header().Set("Content-Type", "text/plain")
-	if _, err = w.Write([]byte(logs)); err != nil {
+	if _, err = w.Write([]byte(logs)); err != nil { //nolint:gosec // G705: logs from internal container runtime
 		return fmt.Errorf("failed to write logs response: %w", err)
 	}
 	return nil
@@ -568,6 +568,7 @@ func (s *WorkloadRoutes) getProxyLogsForWorkload(w http.ResponseWriter, r *http.
 	}
 
 	w.Header().Set("Content-Type", "text/plain")
+	// #nosec G705 -- logs is read from internal proxy log storage, not user input
 	if _, err = w.Write([]byte(logs)); err != nil {
 		return fmt.Errorf("failed to write proxy logs response: %w", err)
 	}

--- a/pkg/auth/discovery/discovery.go
+++ b/pkg/auth/discovery/discovery.go
@@ -160,7 +160,7 @@ func detectAuthWithRequest(
 		}
 	}
 
-	resp, err := client.Do(req)
+	resp, err := client.Do(req) // #nosec G704 -- targetURI is the MCP server endpoint URL from internal config
 	if err != nil {
 		return nil, fmt.Errorf("failed to make %s request: %w", method, err)
 	}
@@ -213,7 +213,7 @@ func checkWellKnownURIExists(ctx context.Context, client *http.Client, uri strin
 
 	req.Header.Set("Accept", "application/json")
 
-	resp, err := client.Do(req)
+	resp, err := client.Do(req) // #nosec G704 -- uri is built from the MCP server endpoint for auth discovery
 	if err != nil {
 		logger.Debugf("Failed to check %s: %v", uri, err)
 		return false
@@ -489,7 +489,7 @@ func DeriveIssuerFromRealm(realm string) string {
 // OAuthFlowConfig contains configuration for performing OAuth flows
 type OAuthFlowConfig struct {
 	ClientID             string
-	ClientSecret         string
+	ClientSecret         string //nolint:gosec // G117: field legitimately holds sensitive data
 	AuthorizeURL         string // Manual OAuth endpoint (optional)
 	TokenURL             string // Manual OAuth endpoint (optional)
 	RegistrationEndpoint string // Manual registration endpoint (optional)
@@ -507,13 +507,13 @@ type OAuthFlowResult struct {
 	Config      *oauth.Config
 
 	// Token details for persistence across restarts
-	AccessToken  string
-	RefreshToken string
+	AccessToken  string //nolint:gosec // G117: field legitimately holds sensitive data
+	RefreshToken string //nolint:gosec // G117: field legitimately holds sensitive data
 	Expiry       time.Time
 
 	// DCR client credentials for persistence (obtained during Dynamic Client Registration)
 	ClientID     string
-	ClientSecret string
+	ClientSecret string //nolint:gosec // G117: field legitimately holds sensitive data
 }
 
 func shouldDynamicallyRegisterClient(config *OAuthFlowConfig) bool {
@@ -758,7 +758,7 @@ func FetchResourceMetadata(ctx context.Context, metadataURL string) (*auth.RFC97
 
 	req.Header.Set("Accept", "application/json")
 
-	resp, err := client.Do(req)
+	resp, err := client.Do(req) // #nosec G704 -- URL is the OIDC well-known metadata endpoint
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch metadata: %w", err)
 	}

--- a/pkg/auth/github_provider.go
+++ b/pkg/auth/github_provider.go
@@ -156,7 +156,7 @@ func (g *GitHubProvider) IntrospectToken(ctx context.Context, token string) (jwt
 	req.SetBasicAuth(g.clientID, g.clientSecret)
 
 	// Make the request
-	resp, err := g.client.Do(req)
+	resp, err := g.client.Do(req) // #nosec G704 -- URL is the configured GitHub API endpoint
 	if err != nil {
 		return nil, fmt.Errorf("github validation request failed: %w", err)
 	}

--- a/pkg/auth/oauth/dynamic_registration.go
+++ b/pkg/auth/oauth/dynamic_registration.go
@@ -135,7 +135,7 @@ func (s *ScopeList) UnmarshalJSON(data []byte) error {
 type DynamicClientRegistrationResponse struct {
 	// Required fields
 	ClientID     string `json:"client_id"`
-	ClientSecret string `json:"client_secret,omitempty"`
+	ClientSecret string `json:"client_secret,omitempty"` //nolint:gosec // G117: field legitimately holds sensitive data
 
 	// Optional fields that may be returned
 	ClientIDIssuedAt        int64  `json:"client_id_issued_at,omitempty"`

--- a/pkg/auth/oauth/flow.go
+++ b/pkg/auth/oauth/flow.go
@@ -32,7 +32,7 @@ type Config struct {
 	ClientID string
 
 	// ClientSecret is the OAuth client secret (optional for PKCE flow)
-	ClientSecret string
+	ClientSecret string //nolint:gosec // G117: field legitimately holds sensitive data
 
 	// RedirectURL is the redirect URL for the OAuth flow
 	RedirectURL string
@@ -79,8 +79,8 @@ type Flow struct {
 
 // TokenResult contains the result of the OAuth flow
 type TokenResult struct {
-	AccessToken  string
-	RefreshToken string
+	AccessToken  string //nolint:gosec // G117: field legitimately holds sensitive data
+	RefreshToken string //nolint:gosec // G117: field legitimately holds sensitive data
 	TokenType    string
 	Expiry       time.Time
 	Claims       jwt.MapClaims

--- a/pkg/auth/remote/config.go
+++ b/pkg/auth/remote/config.go
@@ -19,7 +19,7 @@ import (
 // Supports OAuth/OIDC-based authentication with automatic discovery.
 type Config struct {
 	ClientID         string        `json:"client_id,omitempty" yaml:"client_id,omitempty"`
-	ClientSecret     string        `json:"client_secret,omitempty" yaml:"client_secret,omitempty"`
+	ClientSecret     string        `json:"client_secret,omitempty" yaml:"client_secret,omitempty"` //nolint:gosec // G117
 	ClientSecretFile string        `json:"client_secret_file,omitempty" yaml:"client_secret_file,omitempty"`
 	Scopes           []string      `json:"scopes,omitempty" yaml:"scopes,omitempty"`
 	SkipBrowser      bool          `json:"skip_browser,omitempty" yaml:"skip_browser,omitempty"`
@@ -45,7 +45,7 @@ type Config struct {
 	OAuthParams map[string]string `json:"oauth_params,omitempty" yaml:"oauth_params,omitempty"`
 
 	// Bearer token configuration (alternative to OAuth)
-	BearerToken     string `json:"bearer_token,omitempty" yaml:"bearer_token,omitempty"`
+	BearerToken     string `json:"bearer_token,omitempty" yaml:"bearer_token,omitempty"` //nolint:gosec // G117
 	BearerTokenFile string `json:"bearer_token_file,omitempty" yaml:"bearer_token_file,omitempty"`
 
 	// Cached OAuth token reference for persistence across restarts.
@@ -88,7 +88,7 @@ func (r *Config) UnmarshalJSON(data []byte) error {
 		// Unmarshal using old PascalCase format
 		var oldFormat struct {
 			ClientID         string             `json:"ClientID,omitempty"`
-			ClientSecret     string             `json:"ClientSecret,omitempty"`
+			ClientSecret     string             `json:"ClientSecret,omitempty"` //nolint:gosec // G117
 			ClientSecretFile string             `json:"ClientSecretFile,omitempty"`
 			Scopes           []string           `json:"Scopes,omitempty"`
 			SkipBrowser      bool               `json:"SkipBrowser,omitempty"`
@@ -101,7 +101,7 @@ func (r *Config) UnmarshalJSON(data []byte) error {
 			Headers          []*registry.Header `json:"Headers,omitempty"`
 			EnvVars          []*registry.EnvVar `json:"EnvVars,omitempty"`
 			OAuthParams      map[string]string  `json:"OAuthParams,omitempty"`
-			BearerToken      string             `json:"BearerToken,omitempty"`
+			BearerToken      string             `json:"BearerToken,omitempty"` //nolint:gosec // G117
 			BearerTokenFile  string             `json:"BearerTokenFile,omitempty"`
 		}
 

--- a/pkg/auth/token.go
+++ b/pkg/auth/token.go
@@ -123,7 +123,7 @@ func (g *GoogleProvider) IntrospectToken(ctx context.Context, token string) (jwt
 	req.Header.Set("User-Agent", oauth.UserAgent)
 
 	// Make the request
-	resp, err := g.client.Do(req)
+	resp, err := g.client.Do(req) // #nosec G704 -- URL is the configured OIDC introspection endpoint
 	if err != nil {
 		return nil, fmt.Errorf("google tokeninfo request failed: %w", err)
 	}
@@ -304,7 +304,7 @@ func (r *RFC7662Provider) IntrospectToken(ctx context.Context, token string) (jw
 	}
 
 	// Make the request
-	resp, err := r.client.Do(req)
+	resp, err := r.client.Do(req) // #nosec G704 -- URL is the configured OIDC introspection endpoint
 	if err != nil {
 		return nil, fmt.Errorf("introspection request failed: %w", err)
 	}
@@ -393,7 +393,7 @@ type TokenValidatorConfig struct {
 	ClientID string
 
 	// ClientSecret is the optional OIDC client secret for introspection
-	ClientSecret string
+	ClientSecret string // #nosec G117 -- not a hardcoded credential, populated at runtime from config
 
 	// CACertPath is the path to the CA certificate bundle for HTTPS requests
 	CACertPath string
@@ -447,7 +447,7 @@ func discoverOIDCConfiguration(
 	req.Header.Set("User-Agent", oauth.UserAgent)
 	req.Header.Set("Accept", "application/json")
 
-	resp, err := client.Do(req)
+	resp, err := client.Do(req) // #nosec G704 -- URL is the configured OIDC issuer discovery endpoint
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch OIDC configuration: %w", err)
 	}

--- a/pkg/auth/tokenexchange/exchange.go
+++ b/pkg/auth/tokenexchange/exchange.go
@@ -159,12 +159,12 @@ func (r exchangeRequest) String() string {
 
 // response is used to decode the remote server response during an OAuth 2.0 token exchange.
 type response struct {
-	AccessToken     string `json:"access_token"`
+	AccessToken     string `json:"access_token"` //nolint:gosec // G117: field legitimately holds sensitive data
 	IssuedTokenType string `json:"issued_token_type"`
 	TokenType       string `json:"token_type"`
 	ExpiresIn       int    `json:"expires_in"`
 	Scope           string `json:"scope"`
-	RefreshToken    string `json:"refresh_token"`
+	RefreshToken    string `json:"refresh_token"` //nolint:gosec // G117: field legitimately holds sensitive data
 }
 
 // String implements fmt.Stringer for response, redacting sensitive tokens.
@@ -186,7 +186,7 @@ func (r response) String() string {
 // clientAuthentication represents OAuth client credentials for token exchange.
 type clientAuthentication struct {
 	ClientID     string
-	ClientSecret string
+	ClientSecret string //nolint:gosec // G117
 }
 
 // String implements fmt.Stringer for clientAuthentication, redacting the client secret.
@@ -209,7 +209,7 @@ type ExchangeConfig struct {
 	ClientID string
 
 	// ClientSecret is the OAuth 2.0 client secret
-	ClientSecret string
+	ClientSecret string //nolint:gosec // G117
 
 	// Audience is the target audience for the exchanged token (optional per RFC 8693)
 	Audience string
@@ -470,7 +470,7 @@ func createTokenExchangeRequest(
 
 // executeTokenExchangeRequest sends the HTTP request and returns the response body.
 func executeTokenExchangeRequest(client *http.Client, req *http.Request) ([]byte, error) {
-	resp, err := client.Do(req)
+	resp, err := client.Do(req) // #nosec G704 -- URL is the configured token exchange endpoint
 	if err != nil {
 		return nil, fmt.Errorf("token exchange request failed: %w", err)
 	}

--- a/pkg/auth/tokenexchange/middleware.go
+++ b/pkg/auth/tokenexchange/middleware.go
@@ -62,7 +62,7 @@ type Config struct {
 	ClientID string `json:"client_id"`
 
 	// ClientSecret is the OAuth 2.0 client secret
-	ClientSecret string `json:"client_secret"`
+	ClientSecret string `json:"client_secret"` //nolint:gosec // G117: field legitimately holds sensitive data
 
 	// Audience is the target audience for the exchanged token
 	Audience string `json:"audience"`

--- a/pkg/authserver/server/handlers/discovery.go
+++ b/pkg/authserver/server/handlers/discovery.go
@@ -87,7 +87,7 @@ func (h *Handler) JWKSHandler(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Cache-Control", fmt.Sprintf("public, max-age=%d", DefaultJWKSCacheMaxAge))
 	w.Header().Set("X-Content-Type-Options", "nosniff")
-	_, _ = w.Write(data)
+	_, _ = w.Write(data) //nolint:gosec // G705: data is JSON-marshaled from internal metadata, not user input
 }
 
 // buildOAuthMetadata constructs the base OAuth 2.0 Authorization Server Metadata (RFC 8414).
@@ -135,7 +135,7 @@ func (h *Handler) OAuthDiscoveryHandler(w http.ResponseWriter, _ *http.Request) 
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Cache-Control", fmt.Sprintf("public, max-age=%d", DefaultDiscoveryCacheMaxAge))
 	w.Header().Set("X-Content-Type-Options", "nosniff")
-	_, _ = w.Write(data)
+	_, _ = w.Write(data) //nolint:gosec // G705: data is JSON-marshaled from internal metadata, not user input
 }
 
 // OIDCDiscoveryHandler handles GET /.well-known/openid-configuration requests.

--- a/pkg/authserver/server/registration/client.go
+++ b/pkg/authserver/server/registration/client.go
@@ -92,7 +92,7 @@ type Config struct {
 
 	// Secret is the client secret for confidential clients.
 	// Empty for public clients.
-	Secret string
+	Secret string //nolint:gosec // G117: field legitimately holds sensitive data
 
 	// RedirectURIs is the list of allowed redirect URIs.
 	RedirectURIs []string

--- a/pkg/authserver/storage/redis.go
+++ b/pkg/authserver/storage/redis.go
@@ -74,7 +74,7 @@ type SentinelConfig struct {
 // ACLUserConfig contains Redis ACL user authentication configuration.
 type ACLUserConfig struct {
 	Username string
-	Password string
+	Password string //nolint:gosec // G117: field legitimately holds sensitive data
 }
 
 // RedisStorage implements the Storage interface with Redis Sentinel backend.
@@ -200,7 +200,7 @@ func (s *RedisStorage) Close() error {
 // storedClient is a serializable wrapper for OAuth clients.
 type storedClient struct {
 	ID            string   `json:"id"`
-	Secret        []byte   `json:"secret,omitempty"`
+	Secret        []byte   `json:"secret,omitempty"` //nolint:gosec // G117: field legitimately holds sensitive data
 	RedirectURIs  []string `json:"redirect_uris"`
 	GrantTypes    []string `json:"grant_types"`
 	ResponseTypes []string `json:"response_types"`
@@ -685,8 +685,8 @@ func (s *RedisStorage) DeletePKCERequestSession(ctx context.Context, signature s
 // storedUpstreamTokens is a serializable wrapper for UpstreamTokens.
 type storedUpstreamTokens struct {
 	ProviderID      string `json:"provider_id"`
-	AccessToken     string `json:"access_token"`
-	RefreshToken    string `json:"refresh_token"`
+	AccessToken     string `json:"access_token"`  //nolint:gosec // G117: field legitimately holds sensitive data
+	RefreshToken    string `json:"refresh_token"` //nolint:gosec // G117: field legitimately holds sensitive data
 	IDToken         string `json:"id_token"`
 	ExpiresAt       int64  `json:"expires_at"`
 	UserID          string `json:"user_id"`

--- a/pkg/authserver/storage/types.go
+++ b/pkg/authserver/storage/types.go
@@ -57,8 +57,8 @@ type UpstreamTokens struct {
 	ProviderID string
 
 	// Token values from the upstream IDP
-	AccessToken  string
-	RefreshToken string
+	AccessToken  string //nolint:gosec // G117: field legitimately holds sensitive data
+	RefreshToken string //nolint:gosec // G117: field legitimately holds sensitive data
 	IDToken      string
 	ExpiresAt    time.Time
 

--- a/pkg/authserver/upstream/oauth2.go
+++ b/pkg/authserver/upstream/oauth2.go
@@ -100,6 +100,7 @@ type CommonOAuthConfig struct {
 	// ClientSecret is the OAuth client secret registered with the upstream IDP.
 	// Optional for public clients (RFC 6749 Section 2.1) which authenticate using
 	// PKCE instead of a client secret. Required for confidential clients.
+	//nolint:gosec // G117: field legitimately holds sensitive data
 	ClientSecret string `json:"client_secret,omitempty" yaml:"client_secret,omitempty"`
 
 	// Scopes are the OAuth scopes to request from the upstream IDP.
@@ -508,7 +509,7 @@ func (p *BaseOAuth2Provider) fetchUserInfo(ctx context.Context, accessToken stri
 		req.Header.Set(k, v)
 	}
 
-	resp, err := p.httpClient.Do(req)
+	resp, err := p.httpClient.Do(req) //nolint:gosec // G704: URL is from OIDC discovery, not user input
 	if err != nil {
 		return nil, fmt.Errorf("userinfo request failed: %w", err)
 	}

--- a/pkg/authserver/upstream/tokens.go
+++ b/pkg/authserver/upstream/tokens.go
@@ -27,10 +27,10 @@ const tokenExpirationBuffer = 30 * time.Second
 // (see storage.IDPTokens for the storage representation).
 type Tokens struct {
 	// AccessToken is the access token from the upstream IDP.
-	AccessToken string
+	AccessToken string //nolint:gosec // G117: field legitimately holds sensitive data
 
 	// RefreshToken is the refresh token from the upstream IDP (if provided).
-	RefreshToken string
+	RefreshToken string //nolint:gosec // G117: field legitimately holds sensitive data
 
 	// IDToken is the ID token from the upstream IDP (for OIDC).
 	IDToken string

--- a/pkg/authz/authorizers/http/http_client.go
+++ b/pkg/authz/authorizers/http/http_client.go
@@ -135,7 +135,7 @@ func (c *Client) Authorize(ctx context.Context, porc PORC, probe bool) (bool, er
 	req.Header.Set("Accept", "application/json")
 
 	// Send request
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.httpClient.Do(req) //nolint:gosec // G704: URL is from server configuration, not user input
 	if err != nil {
 		return false, fmt.Errorf("HTTP request failed: %w", err)
 	}

--- a/pkg/cli/tools_override.go
+++ b/pkg/cli/tools_override.go
@@ -22,7 +22,7 @@ type toolsOverrideJSON struct {
 
 // LoadToolsOverride loads the tools override JSON file from the given path.
 func LoadToolsOverride(path string) (*map[string]runner.ToolOverride, error) {
-	jsonFile, err := os.Open(filepath.Clean(path))
+	jsonFile, err := os.Open(filepath.Clean(path)) // #nosec G703 -- path is a user-provided CLI flag for tools override
 	if err != nil {
 		return nil, fmt.Errorf("failed to open tools override file: %w", err)
 	}

--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -794,7 +794,7 @@ func GetClientListFormatted() string {
 
 	var sb strings.Builder
 	for _, config := range configs {
-		sb.WriteString(fmt.Sprintf("  - %s: %s\n", config.ClientType, config.Description))
+		fmt.Fprintf(&sb, "  - %s: %s\n", config.ClientType, config.Description)
 	}
 	return strings.TrimSuffix(sb.String(), "\n")
 }

--- a/pkg/container/docker/sdk/client_unix.go
+++ b/pkg/container/docker/sdk/client_unix.go
@@ -49,7 +49,7 @@ func findPlatformContainerSocket(rt runtime.Type) (string, runtime.Type, error) 
 	if customSocketPath := os.Getenv(PodmanSocketEnv); customSocketPath != "" {
 		logger.Debugf("Using Podman socket from env: %s", customSocketPath)
 		// validate the socket path
-		if _, err := os.Stat(customSocketPath); err != nil {
+		if _, err := os.Stat(customSocketPath); err != nil { //nolint:gosec // G703: socket path from trusted environment variable
 			return "", runtime.TypePodman, fmt.Errorf("invalid Podman socket path: %w", err)
 		}
 		return customSocketPath, runtime.TypePodman, nil
@@ -58,7 +58,7 @@ func findPlatformContainerSocket(rt runtime.Type) (string, runtime.Type, error) 
 	if customSocketPath := os.Getenv(DockerSocketEnv); customSocketPath != "" {
 		logger.Debugf("Using Docker socket from env: %s", customSocketPath)
 		// validate the socket path
-		if _, err := os.Stat(customSocketPath); err != nil {
+		if _, err := os.Stat(customSocketPath); err != nil { //nolint:gosec // G703: socket path from trusted environment variable
 			return "", runtime.TypeDocker, fmt.Errorf("invalid Docker socket path: %w", err)
 		}
 		return customSocketPath, runtime.TypeDocker, nil
@@ -67,7 +67,7 @@ func findPlatformContainerSocket(rt runtime.Type) (string, runtime.Type, error) 
 	if customSocketPath := os.Getenv(ColimaSocketEnv); customSocketPath != "" {
 		logger.Debugf("Using Colima socket from env: %s", customSocketPath)
 		// validate the socket path
-		if _, err := os.Stat(customSocketPath); err != nil {
+		if _, err := os.Stat(customSocketPath); err != nil { //nolint:gosec // G703: socket path from trusted environment variable
 			return "", runtime.TypeDocker, fmt.Errorf("invalid Colima socket path: %w", err)
 		}
 		return customSocketPath, runtime.TypeDocker, nil
@@ -111,7 +111,7 @@ func findPodmanSocket() (string, error) {
 	// Check XDG_RUNTIME_DIR location for Podman
 	if xdgRuntimeDir := os.Getenv("XDG_RUNTIME_DIR"); xdgRuntimeDir != "" {
 		xdgSocketPath := filepath.Join(xdgRuntimeDir, PodmanXDGRuntimeSocketPath)
-		_, err := os.Stat(xdgSocketPath)
+		_, err := os.Stat(xdgSocketPath) //nolint:gosec // G703: path from trusted env + constant
 
 		if err == nil {
 			logger.Debugf("Found Podman socket at %s", xdgSocketPath)
@@ -124,7 +124,7 @@ func findPodmanSocket() (string, error) {
 	// Check user-specific location for Podman
 	if home := os.Getenv("HOME"); home != "" {
 		userSocketPath := filepath.Join(home, ".local/share/containers/podman/machine/podman.sock")
-		_, err := os.Stat(userSocketPath)
+		_, err := os.Stat(userSocketPath) //nolint:gosec // G703: path from trusted env + constant
 
 		if err == nil {
 			logger.Debugf("Found Podman socket at %s", userSocketPath)
@@ -138,7 +138,7 @@ func findPodmanSocket() (string, error) {
 	// The socket path follows the pattern: $TMPDIR/podman/<machine-name>-api.sock
 	if tmpDir := os.Getenv("TMPDIR"); tmpDir != "" {
 		podmanTmpDir := filepath.Join(tmpDir, "podman")
-		if _, err := os.Stat(podmanTmpDir); err == nil {
+		if _, err := os.Stat(podmanTmpDir); err == nil { //nolint:gosec // G703: path from trusted env
 			// Look for any -api.sock files (there may be multiple machines)
 			matches, err := filepath.Glob(filepath.Join(podmanTmpDir, "*-api.sock"))
 			if err == nil && len(matches) > 0 {
@@ -171,7 +171,7 @@ func findDockerSocket() (string, error) {
 	// Try Docker Desktop socket path on macOS
 	if home := os.Getenv("HOME"); home != "" {
 		dockerDesktopPath := filepath.Join(home, DockerDesktopMacSocketPath)
-		_, err := os.Stat(dockerDesktopPath)
+		_, err := os.Stat(dockerDesktopPath) // #nosec G703 -- path is built from HOME + constant socket path
 
 		if err == nil {
 			logger.Debugf("Found Docker Desktop socket at %s", dockerDesktopPath)
@@ -184,7 +184,7 @@ func findDockerSocket() (string, error) {
 	// Try Rancher Desktop socket path on macOS
 	if home := os.Getenv("HOME"); home != "" {
 		rancherDesktopPath := filepath.Join(home, RancherDesktopMacSocketPath)
-		_, err := os.Stat(rancherDesktopPath)
+		_, err := os.Stat(rancherDesktopPath) // #nosec G703 -- path is built from HOME + constant socket path
 
 		if err == nil {
 			logger.Debugf("Found Rancher Desktop socket at %s", rancherDesktopPath)
@@ -197,7 +197,7 @@ func findDockerSocket() (string, error) {
 	// Try OrbStack socket path on macOS
 	if home := os.Getenv("HOME"); home != "" {
 		orbStackPath := filepath.Join(home, OrbStackMacSocketPath)
-		_, err := os.Stat(orbStackPath)
+		_, err := os.Stat(orbStackPath) // #nosec G703 -- path is built from HOME + constant socket path
 
 		if err == nil {
 			logger.Debugf("Found OrbStack socket at %s", orbStackPath)
@@ -224,7 +224,7 @@ func findColimaSocket() (string, error) {
 	// Check user-specific location for Colima
 	if home := os.Getenv("HOME"); home != "" {
 		userSocketPath := filepath.Join(home, ColimaDesktopMacSocketPath)
-		_, err := os.Stat(userSocketPath)
+		_, err := os.Stat(userSocketPath) // #nosec G703 -- path is built from HOME + constant socket path
 
 		if err == nil {
 			logger.Debugf("Found Colima socket at %s", userSocketPath)

--- a/pkg/container/images/registry.go
+++ b/pkg/container/images/registry.go
@@ -147,6 +147,7 @@ func buildDockerImage(ctx context.Context, dockerClient *client.Client, contextD
 		return fmt.Errorf("failed to create temporary tar file: %w", err)
 	}
 	defer func() {
+		// #nosec G703 -- tarFile.Name() is from os.CreateTemp, not user input
 		if err := os.Remove(tarFile.Name()); err != nil {
 			// Non-fatal: temp file cleanup failure
 			logger.Debugf("Failed to remove temporary file %s: %v", tarFile.Name(), err)

--- a/pkg/container/kubernetes/configmap_test.go
+++ b/pkg/container/kubernetes/configmap_test.go
@@ -412,7 +412,7 @@ func generateLargeJSON() string {
 		if i > 0 {
 			sb.WriteString(",")
 		}
-		sb.WriteString(fmt.Sprintf(`{"id":%d,"value":"item-%d"}`, i, i))
+		fmt.Fprintf(&sb, `{"id":%d,"value":"item-%d"}`, i, i)
 	}
 	sb.WriteString(`],`)
 	sb.WriteString(`"metadata":{`)

--- a/pkg/desktop/validation.go
+++ b/pkg/desktop/validation.go
@@ -196,10 +196,10 @@ func buildConflictMessage(desktopPath, currentPath string, marker *cliSourceMark
 	var sb strings.Builder
 
 	sb.WriteString("The ToolHive Desktop application manages a CLI installation at:\n")
-	sb.WriteString(fmt.Sprintf("  %s\n\n", desktopPath))
+	fmt.Fprintf(&sb, "  %s\n\n", desktopPath)
 
 	sb.WriteString("You are running a different CLI binary at:\n")
-	sb.WriteString(fmt.Sprintf("  %s\n\n", currentPath))
+	fmt.Fprintf(&sb, "  %s\n\n", currentPath)
 
 	sb.WriteString("To avoid conflicts, please use the desktop-managed CLI or uninstall\n")
 	sb.WriteString("the ToolHive Desktop application.\n\n")
@@ -208,13 +208,13 @@ func buildConflictMessage(desktopPath, currentPath string, marker *cliSourceMark
 	binPath, exeName := getDesktopBinPath()
 
 	sb.WriteString("To use the desktop-managed CLI, ensure your PATH includes:\n")
-	sb.WriteString(fmt.Sprintf("  %s\n\n", binPath))
+	fmt.Fprintf(&sb, "  %s\n\n", binPath)
 
 	sb.WriteString("Or run the desktop CLI directly:\n")
-	sb.WriteString(fmt.Sprintf("  %s [command]\n", filepath.Join(binPath, exeName)))
+	fmt.Fprintf(&sb, "  %s [command]\n", filepath.Join(binPath, exeName))
 
 	if marker.DesktopVersion != "" {
-		sb.WriteString(fmt.Sprintf("\nDesktop version: %s\n", marker.DesktopVersion))
+		fmt.Fprintf(&sb, "\nDesktop version: %s\n", marker.DesktopVersion)
 	}
 
 	return sb.String()

--- a/pkg/fileutils/atomic.go
+++ b/pkg/fileutils/atomic.go
@@ -48,12 +48,14 @@ func AtomicWriteFile(targetPath string, data []byte, perm os.FileMode) error {
 	}
 
 	// Set the correct permissions on the temp file
+	// #nosec G703 -- tmpPath is from os.CreateTemp in the same directory as targetPath
 	if err := os.Chmod(tmpPath, perm); err != nil {
 		return fmt.Errorf("failed to set permissions on temp file: %w", err)
 	}
 
 	// Atomically rename temp file to target file
 	// This is atomic on POSIX systems (Linux, macOS, etc.)
+	// #nosec G703 -- tmpPath is from os.CreateTemp, targetPath is caller-controlled
 	if err := os.Rename(tmpPath, targetPath); err != nil {
 		return fmt.Errorf("failed to rename temp file: %w", err)
 	}

--- a/pkg/registry/api/client.go
+++ b/pkg/registry/api/client.go
@@ -95,7 +95,7 @@ func (c *mcpRegistryClient) GetServer(ctx context.Context, name string) (*v0.Ser
 	}
 	req.Header.Set("User-Agent", c.userAgent)
 
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.httpClient.Do(req) //nolint:gosec // G704: URL from configured registry
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch server %s: %w", name, err)
 	}
@@ -190,7 +190,7 @@ func (c *mcpRegistryClient) fetchServersPage(
 	}
 	req.Header.Set("User-Agent", c.userAgent)
 
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.httpClient.Do(req) //nolint:gosec // G704: URL from configured registry
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to fetch servers: %w", err)
 	}
@@ -235,7 +235,7 @@ func (c *mcpRegistryClient) SearchServers(ctx context.Context, query string) ([]
 	}
 	req.Header.Set("User-Agent", c.userAgent)
 
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.httpClient.Do(req) // #nosec G704 -- URL is built from the configured registry base URL
 	if err != nil {
 		return nil, fmt.Errorf("failed to search servers: %w", err)
 	}
@@ -275,7 +275,7 @@ func (c *mcpRegistryClient) ValidateEndpoint(ctx context.Context) error {
 	}
 	req.Header.Set("User-Agent", c.userAgent)
 
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.httpClient.Do(req) // #nosec G704 -- URL is built from the configured registry base URL
 	if err != nil {
 		return fmt.Errorf("failed to fetch /openapi.yaml: %w", err)
 	}

--- a/pkg/runner/env.go
+++ b/pkg/runner/env.go
@@ -161,8 +161,8 @@ func promptForEnvironmentVariable(envVar *registry.EnvVar) (string, error) {
 	if envVar.Secret {
 		fmt.Printf("Required secret environment variable: %s (%s)", envVar.Name, envVar.Description)
 		fmt.Printf("Enter value for %s (input will be hidden): ", envVar.Name)
-		byteValue, err = term.ReadPassword(int(os.Stdin.Fd()))
-		fmt.Println() // Move to the next line after hidden input
+		byteValue, err = term.ReadPassword(int(os.Stdin.Fd())) //nolint:gosec // G115: stdin fd is always small
+		fmt.Println()                                          // Move to the next line after hidden input
 	} else {
 		fmt.Printf("Required environment variable: %s (%s)", envVar.Name, envVar.Description)
 		fmt.Printf("Enter value for %s: ", envVar.Name)

--- a/pkg/runner/permissions.go
+++ b/pkg/runner/permissions.go
@@ -62,12 +62,14 @@ func CleanupTempPermissionProfile(permissionProfilePath string) error {
 	}
 
 	// Check if the file exists
+	// #nosec G703 -- permissionProfilePath is validated by isTempPermissionProfile above
 	if _, err := os.Stat(permissionProfilePath); os.IsNotExist(err) {
 		logger.Debugf("Temporary permission profile file %s does not exist, skipping cleanup", permissionProfilePath)
 		return nil
 	}
 
 	// Remove the temporary file
+	// #nosec G703 -- permissionProfilePath is validated by isTempPermissionProfile above
 	if err := os.Remove(permissionProfilePath); err != nil {
 		return fmt.Errorf("failed to remove temporary permission profile file %s: %w", permissionProfilePath, err)
 	}

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -816,7 +816,7 @@ func waitForInitializeSuccess(ctx context.Context, serverURL, transportType stri
 				req.Header.Set("MCP-Protocol-Version", "2024-11-05")
 			}
 
-			resp, err := httpClient.Do(req)
+			resp, err := httpClient.Do(req) // #nosec G704 -- endpoint is the local MCP server readiness URL
 			if err == nil {
 				//nolint:errcheck // Ignoring close error on response body in error path
 				defer resp.Body.Close()

--- a/pkg/secrets/factory.go
+++ b/pkg/secrets/factory.go
@@ -342,7 +342,7 @@ func StoreSecretsPassword(password []byte) error {
 
 func readPasswordStdin() ([]byte, error) {
 	printPasswordPrompt()
-	password, err := term.ReadPassword(int(os.Stdin.Fd()))
+	password, err := term.ReadPassword(int(os.Stdin.Fd())) //nolint:gosec // G115: stdin fd is always small
 	// Start new line after receiving password to ensure errors are printed correctly.
 	fmt.Println()
 	if err != nil {

--- a/pkg/transport/proxy/httpsse/http_proxy.go
+++ b/pkg/transport/proxy/httpsse/http_proxy.go
@@ -332,7 +332,7 @@ func (p *HTTPSSEProxy) handleSSEConnection(w http.ResponseWriter, r *http.Reques
 	endpointMsg := ssecommon.NewSSEMessage("endpoint", endpointURL)
 
 	// Send the initial event
-	if _, err := fmt.Fprint(w, endpointMsg.ToSSEString()); err != nil {
+	if _, err := fmt.Fprint(w, endpointMsg.ToSSEString()); err != nil { //nolint:gosec // G705: SSE data from internal MCP protocol
 		logger.Debugf("Failed to write endpoint message: %v", err)
 		return
 	}

--- a/pkg/transport/proxy/socket/socket_unix.go
+++ b/pkg/transport/proxy/socket/socket_unix.go
@@ -21,6 +21,7 @@ func ListenConfig() net.ListenConfig {
 		Control: func(_, _ string, c syscall.RawConn) error {
 			var opErr error
 			if err := c.Control(func(fd uintptr) {
+				//nolint:gosec // G115: fd is a valid file descriptor
 				opErr = unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_REUSEADDR, 1)
 			}); err != nil {
 				return err

--- a/pkg/transport/proxy/streamable/streamable_proxy.go
+++ b/pkg/transport/proxy/streamable/streamable_proxy.go
@@ -419,7 +419,7 @@ func (p *HTTPProxy) handleSingleRequestSSE(
 		return
 	}
 	// Write SSE event with the JSON-RPC response and flush
-	if _, err := fmt.Fprintf(w, "data: %s\n\n", data); err != nil {
+	if _, err := fmt.Fprintf(w, "data: %s\n\n", data); err != nil { //nolint:gosec // G705: SSE data from MCP protocol
 		logger.Debugf("Failed to write response: %v", err)
 		return
 	}

--- a/pkg/transport/proxy/streamable/utils.go
+++ b/pkg/transport/proxy/streamable/utils.go
@@ -31,7 +31,7 @@ func writeJSONRPC(w http.ResponseWriter, msg jsonrpc2.Message) error {
 	if err != nil {
 		return err
 	}
-	_, err = w.Write(data)
+	_, err = w.Write(data) //nolint:gosec // G705: data is JSON-RPC from MCP protocol
 	return err
 }
 

--- a/pkg/transport/proxy/transparent/pinger.go
+++ b/pkg/transport/proxy/transparent/pinger.go
@@ -59,7 +59,7 @@ func (p *MCPPinger) Ping(ctx context.Context) (time.Duration, error) {
 	logger.Debugf("Checking SSE server health at %s", p.targetURL)
 
 	// Send the request
-	resp, err := p.client.Do(req)
+	resp, err := p.client.Do(req) // #nosec G704 -- targetURL is the local MCP server health endpoint
 	if err != nil {
 		return time.Since(start), fmt.Errorf("failed to connect to SSE server: %w", err)
 	}

--- a/pkg/transport/proxy/transparent/transparent_proxy.go
+++ b/pkg/transport/proxy/transparent/transparent_proxy.go
@@ -441,7 +441,7 @@ func (p *TransparentProxy) Start(ctx context.Context) error {
 	}
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		proxy.ServeHTTP(w, r)
+		proxy.ServeHTTP(w, r) // #nosec G704 -- target URL is the configured backend MCP server
 	})
 
 	// Create a mux to handle both proxy and health endpoints

--- a/pkg/transport/ssecommon/sse_common.go
+++ b/pkg/transport/ssecommon/sse_common.go
@@ -50,11 +50,11 @@ func (m *SSEMessage) ToSSEString() string {
 	var sb strings.Builder
 
 	// Add event type
-	sb.WriteString(fmt.Sprintf("event: %s\n", m.EventType))
+	fmt.Fprintf(&sb, "event: %s\n", m.EventType)
 
 	// Add data (split by newlines to ensure proper formatting)
 	for _, line := range strings.Split(m.Data, "\n") {
-		sb.WriteString(fmt.Sprintf("data: %s\n", line))
+		fmt.Fprintf(&sb, "data: %s\n", line)
 	}
 
 	// End the message with a blank line

--- a/pkg/transport/tunnel/ngrok/tunnel_provider.go
+++ b/pkg/transport/tunnel/ngrok/tunnel_provider.go
@@ -24,7 +24,7 @@ type TunnelProvider struct {
 
 // TunnelConfig holds configuration options for the ngrok tunnel provider.
 type TunnelConfig struct {
-	AuthToken      string
+	AuthToken      string //nolint:gosec // G117: field legitimately holds sensitive data
 	URL            string // Optional: specify custom URL
 	TrafficPolicy  string // Optional: specify traffic policy
 	PoolingEnabled bool   // Optional: enable pooling

--- a/pkg/updates/client.go
+++ b/pkg/updates/client.go
@@ -115,7 +115,7 @@ func (d *defaultVersionClient) GetLatestVersion(instanceID string, currentVersio
 	client := &http.Client{
 		Timeout: defaultTimeout,
 	}
-	resp, err := client.Do(req)
+	resp, err := client.Do(req) // #nosec G704 -- URL is constructed from hardcoded update API base URL
 	if err != nil {
 		return "", fmt.Errorf("failed to send request to update API: %w", err)
 	}

--- a/pkg/usagemetrics/client.go
+++ b/pkg/usagemetrics/client.go
@@ -85,7 +85,7 @@ func (c *Client) SendMetrics(instanceID string, record MetricRecord) error {
 	req.Header.Set(anonymousIDHeader, anonymousID) // User anonymous ID (or default for operator)
 	req.Header.Set(userAgentHeader, generateUserAgent())
 
-	resp, err := c.client.Do(req)
+	resp, err := c.client.Do(req) // #nosec G704 -- URL is the hardcoded usage metrics endpoint
 	if err != nil {
 		return fmt.Errorf("failed to send request: %w", err)
 	}

--- a/pkg/vmcp/aggregator/manual_resolver.go
+++ b/pkg/vmcp/aggregator/manual_resolver.go
@@ -154,7 +154,7 @@ func (*ManualConflictResolver) formatConflictError(conflicts map[string][]string
 	sb.WriteString("unresolved tool name conflicts detected:\n")
 
 	for toolName, backendIDs := range conflicts {
-		sb.WriteString(fmt.Sprintf("  - %s: [%s]\n", toolName, strings.Join(backendIDs, ", ")))
+		fmt.Fprintf(&sb, "  - %s: [%s]\n", toolName, strings.Join(backendIDs, ", "))
 	}
 
 	sb.WriteString("\nUse 'overrides' in aggregation config to resolve these conflicts when using conflict_resolution: manual")

--- a/pkg/vmcp/auth/strategies/tokenexchange.go
+++ b/pkg/vmcp/auth/strategies/tokenexchange.go
@@ -149,7 +149,7 @@ func (s *TokenExchangeStrategy) Validate(strategy *authtypes.BackendAuthStrategy
 type tokenExchangeConfig struct {
 	TokenURL         string
 	ClientID         string
-	ClientSecret     string
+	ClientSecret     string //nolint:gosec // G117: field legitimately holds sensitive data
 	Audience         string
 	Scopes           []string
 	SubjectTokenType string

--- a/pkg/vmcp/auth/types/types.go
+++ b/pkg/vmcp/auth/types/types.go
@@ -78,6 +78,7 @@ type TokenExchangeConfig struct {
 	ClientID string `json:"clientId,omitempty" yaml:"clientId,omitempty"`
 
 	// ClientSecret is the OAuth client secret (use ClientSecretEnv for security).
+	//nolint:gosec // G117: field legitimately holds sensitive data
 	ClientSecret string `json:"clientSecret,omitempty" yaml:"clientSecret,omitempty"`
 
 	// ClientSecretEnv is the environment variable name containing the client secret.

--- a/pkg/vmcp/cache/cache.go
+++ b/pkg/vmcp/cache/cache.go
@@ -48,7 +48,7 @@ type CachedToken struct {
 	ExpiresAt time.Time
 
 	// RefreshToken is the refresh token (if available).
-	RefreshToken string
+	RefreshToken string //nolint:gosec // G117: field legitimately holds sensitive data
 
 	// Scopes are the token scopes.
 	Scopes []string

--- a/test/e2e/api_helpers.go
+++ b/test/e2e/api_helpers.go
@@ -152,7 +152,7 @@ func (s *Server) WaitForReady() error {
 				continue
 			}
 
-			resp, err := s.httpClient.Do(req)
+			resp, err := s.httpClient.Do(req) // #nosec G704 -- baseURL is the local test server URL
 			if err != nil {
 				continue
 			}
@@ -186,7 +186,7 @@ func (s *Server) Get(path string) (*http.Response, error) {
 	if err != nil {
 		return nil, err
 	}
-	return s.httpClient.Do(req)
+	return s.httpClient.Do(req) // #nosec G704 -- baseURL is the local test server URL
 }
 
 // GetWithHeaders performs a GET request with custom headers.
@@ -200,7 +200,7 @@ func (s *Server) GetWithHeaders(path string, headers map[string]string) (*http.R
 		req.Header.Set(key, value)
 	}
 
-	return s.httpClient.Do(req)
+	return s.httpClient.Do(req) // #nosec G704 -- baseURL is the local test server URL
 }
 
 // BaseURL returns the base URL of the API server.

--- a/test/e2e/oidc_mock.go
+++ b/test/e2e/oidc_mock.go
@@ -320,10 +320,10 @@ func (m *OIDCMockServer) handleJWKS(w http.ResponseWriter, _ *http.Request) {
 	// Convert to base64url format
 	nBytes := n.Bytes()
 	eBytes := make([]byte, 4)
-	eBytes[0] = byte(e >> 24)
-	eBytes[1] = byte(e >> 16)
-	eBytes[2] = byte(e >> 8)
-	eBytes[3] = byte(e)
+	eBytes[0] = byte(e >> 24) //nolint:gosec // G115: RSA exponent fits in 4 bytes
+	eBytes[1] = byte(e >> 16) //nolint:gosec // G115: RSA exponent fits in 4 bytes
+	eBytes[2] = byte(e >> 8)  //nolint:gosec // G115: RSA exponent fits in 4 bytes
+	eBytes[3] = byte(e)       //nolint:gosec // G115: RSA exponent fits in 4 bytes
 
 	// Trim leading zeros from exponent
 	eStart := 0

--- a/test/testkit/testkit.go
+++ b/test/testkit/testkit.go
@@ -260,7 +260,7 @@ func wrapBackendWithProxy(
 	proxy := httputil.NewSingleHostReverseProxy(backendURL)
 	proxy.FlushInterval = -1
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		proxy.ServeHTTP(w, r)
+		proxy.ServeHTTP(w, r) //nolint:gosec // G704: reverse proxy to test backend
 	})
 
 	// Apply middleware chain in reverse order (last middleware is applied first)


### PR DESCRIPTION
Suppress gosec false positives across the codebase by adding #nosec annotations with explanatory comments following the existing codebase pattern. The annotations cover SSRF (G704), path traversal (G703), XSS (G705), and secret pattern (G117) warnings where the flagged code is safe by design.

`golangci-lint` updated its version to latest (2.10.0) and started causing this issues