### PR TITLE
Migrate leaf packages from logger shim to slog

### DIFF
--- a/pkg/certs/validation.go
+++ b/pkg/certs/validation.go
@@ -8,8 +8,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-
-	"github.com/stacklok/toolhive/pkg/logger"
+	"log/slog"
 )
 
 // ValidateCACertificate validates that the provided data contains a valid PEM-encoded certificate
@@ -34,7 +33,7 @@ func ValidateCACertificate(certData []byte) error {
 	// Basic validation - check if it's a CA certificate
 	if !cert.IsCA {
 		// Log a warning but don't fail - some corporate proxies use non-CA certificates
-		logger.Warnf("Certificate is not marked as a CA certificate, but proceeding anyway")
+		slog.Warn("Certificate is not marked as a CA certificate, but proceeding anyway")
 	}
 
 	return nil

--- a/pkg/certs/validation_test.go
+++ b/pkg/certs/validation_test.go
@@ -8,14 +8,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/stacklok/toolhive/pkg/logger"
 )
 
 func TestValidateCACertificate(t *testing.T) {
 	t.Parallel()
-	// Initialize logger for testing
-	logger.Initialize()
 
 	tests := []struct {
 		name        string

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -8,10 +8,10 @@ package healthcheck
 import (
 	"context"
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"time"
 
-	"github.com/stacklok/toolhive/pkg/logger"
 	"github.com/stacklok/toolhive/pkg/versions"
 )
 
@@ -115,12 +115,12 @@ func (hc *HealthChecker) checkMCPStatus(ctx context.Context) *MCPStatus {
 	if err != nil {
 		status.Available = false
 		status.Error = err.Error()
-		logger.Debugf("MCP ping failed: %v", err)
+		slog.Debug("MCP ping failed", "error", err)
 	} else {
 		status.Available = true
 		responseTimeMs := duration.Milliseconds()
 		status.ResponseTime = &responseTimeMs
-		logger.Debugf("MCP ping successful: %v", duration)
+		slog.Debug("MCP ping successful", "duration", duration)
 	}
 
 	return status
@@ -148,7 +148,7 @@ func (hc *HealthChecker) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := json.NewEncoder(w).Encode(health); err != nil {
-		logger.Warnf("Failed to encode health response: %v", err)
+		slog.Warn("Failed to encode health response", "error", err)
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
 	}
 }

--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/stacklok/toolhive/pkg/logger"
 	"github.com/stacklok/toolhive/pkg/versions"
 )
 
@@ -33,9 +32,6 @@ func (m *mockMCPPinger) Ping(_ context.Context) (time.Duration, error) {
 
 func TestHealthChecker_CheckHealth(t *testing.T) {
 	t.Parallel()
-
-	// Initialize logger for tests
-	logger.Initialize()
 
 	tests := []struct {
 		name              string
@@ -102,9 +98,6 @@ func TestHealthChecker_CheckHealth(t *testing.T) {
 
 func TestHealthChecker_ServeHTTP(t *testing.T) {
 	t.Parallel()
-
-	// Initialize logger for tests
-	logger.Initialize()
 
 	tests := []struct {
 		name           string
@@ -184,9 +177,6 @@ func TestHealthChecker_ServeHTTP(t *testing.T) {
 
 func TestHealthResponse_JSON(t *testing.T) {
 	t.Parallel()
-
-	// Initialize logger for tests
-	logger.Initialize()
 
 	response := &HealthResponse{
 		Status:    StatusHealthy,

--- a/pkg/ignore/processor_test.go
+++ b/pkg/ignore/processor_test.go
@@ -7,13 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-
-	"github.com/stacklok/toolhive/pkg/logger"
 )
-
-func init() {
-	logger.Initialize() // ensure logging doesn't panic
-}
 
 func TestNewProcessor(t *testing.T) {
 	t.Parallel()

--- a/pkg/lockfile/cleanup_test.go
+++ b/pkg/lockfile/cleanup_test.go
@@ -13,14 +13,7 @@ import (
 	"github.com/gofrs/flock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/stacklok/toolhive/pkg/logger"
 )
-
-func init() {
-	// Initialize logger for all tests
-	logger.Initialize()
-}
 
 func TestLockRegistry_RegisterLock(t *testing.T) {
 	t.Parallel()

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -28,7 +28,9 @@ var singleton atomic.Pointer[slog.Logger]
 
 func init() {
 	// Set a default logger so callers that skip Initialize() don't panic.
-	singleton.Store(logging.New())
+	l := logging.New()
+	singleton.Store(l)
+	slog.SetDefault(l)
 }
 
 // get returns the current singleton logger.
@@ -45,6 +47,7 @@ func Get() *slog.Logger {
 // capture log output; production code should use [Initialize] instead.
 func Set(l *slog.Logger) {
 	singleton.Store(l)
+	slog.SetDefault(l)
 }
 
 // Debug logs a message at debug level using the singleton logger.
@@ -186,7 +189,9 @@ func InitializeWithEnv(envReader env.Reader) {
 		opts = append(opts, logging.WithLevel(slog.LevelDebug))
 	}
 
-	singleton.Store(logging.New(opts...))
+	l := logging.New(opts...)
+	singleton.Store(l)
+	slog.SetDefault(l)
 }
 
 func unstructuredLogsWithEnv(envReader env.Reader) bool {

--- a/pkg/networking/port.go
+++ b/pkg/networking/port.go
@@ -8,10 +8,9 @@ package networking
 import (
 	"crypto/rand"
 	"fmt"
+	"log/slog"
 	"math/big"
 	"net"
-
-	"github.com/stacklok/toolhive/pkg/logger"
 )
 
 const (
@@ -37,7 +36,7 @@ func IsAvailable(port int) bool {
 	}
 	if err := tcpListener.Close(); err != nil {
 		// Log the error but continue, as we're just checking if the port is available
-		logger.Warnf("Warning: Failed to close TCP listener: %v", err)
+		slog.Warn("Failed to close TCP listener", "error", err)
 	}
 
 	// Check UDP
@@ -52,7 +51,7 @@ func IsAvailable(port int) bool {
 	}
 	if err := udpConn.Close(); err != nil {
 		// Log the error but continue, as we're just checking if the port is available
-		logger.Warnf("Warning: Failed to close UDP connection: %v", err)
+		slog.Warn("Failed to close UDP connection", "error", err)
 	}
 
 	return true

--- a/pkg/recovery/recovery.go
+++ b/pkg/recovery/recovery.go
@@ -5,10 +5,11 @@
 package recovery
 
 import (
+	"fmt"
+	"log/slog"
 	"net/http"
 	"runtime/debug"
 
-	"github.com/stacklok/toolhive/pkg/logger"
 	"github.com/stacklok/toolhive/pkg/transport/types"
 )
 
@@ -23,7 +24,7 @@ func Middleware(next http.Handler) http.Handler {
 		defer func() {
 			if rec := recover(); rec != nil {
 				stack := debug.Stack()
-				logger.Errorf("Panic recovered: %v\nStack trace:\n%s", rec, stack)
+				slog.Error(fmt.Sprintf("Panic recovered: %v\nStack trace:\n%s", rec, stack))
 				http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 			}
 		}()

--- a/pkg/state/runconfig.go
+++ b/pkg/state/runconfig.go
@@ -8,8 +8,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 
-	"github.com/stacklok/toolhive/pkg/logger"
 	"github.com/stacklok/toolhive/pkg/workloads/types/errors"
 )
 
@@ -61,7 +61,7 @@ func DeleteSavedRunConfig(ctx context.Context, name string) error {
 		return fmt.Errorf("failed to delete run configuration: %w", err)
 	}
 
-	logger.Debugf("Deleted run configuration for %s", name)
+	slog.Debug("Deleted run configuration", "name", name)
 	return nil
 }
 
@@ -91,7 +91,7 @@ func SaveRunConfig[T RunConfigPersister](ctx context.Context, config T) error {
 	}
 	defer func() {
 		if err := writer.Close(); err != nil {
-			logger.Warnf("Failed to close writer: %v", err)
+			slog.Warn("Failed to close writer", "error", err)
 		}
 	}()
 
@@ -100,7 +100,7 @@ func SaveRunConfig[T RunConfigPersister](ctx context.Context, config T) error {
 		return fmt.Errorf("failed to write run configuration: %w", err)
 	}
 
-	logger.Debugf("Saved run configuration for %s", config.GetBaseName())
+	slog.Debug("Saved run configuration", "name", config.GetBaseName())
 	return nil
 }
 
@@ -113,7 +113,7 @@ func LoadRunConfig[T any](ctx context.Context, name string, readJSONFunc ReadJSO
 	}
 	defer func() {
 		if err := reader.Close(); err != nil {
-			logger.Warnf("Failed to close reader: %v", err)
+			slog.Warn("Failed to close reader", "error", err)
 		}
 	}()
 
@@ -149,7 +149,7 @@ func LoadRunConfigWithFunc(ctx context.Context, name string, readFunc RunConfigR
 	}
 	defer func() {
 		if err := reader.Close(); err != nil {
-			logger.Warnf("Failed to close reader: %v", err)
+			slog.Warn("Failed to close reader", "error", err)
 		}
 	}()
 

--- a/pkg/updates/client.go
+++ b/pkg/updates/client.go
@@ -7,13 +7,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"os"
 	"runtime"
 	"strings"
 	"time"
 
-	"github.com/stacklok/toolhive/pkg/logger"
 	"github.com/stacklok/toolhive/pkg/versions"
 )
 
@@ -121,7 +121,7 @@ func (d *defaultVersionClient) GetLatestVersion(instanceID string, currentVersio
 	}
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
-			logger.Debugf("Failed to close response body: %v", err)
+			slog.Debug("Failed to close response body", "error", err)
 		}
 	}()
 


### PR DESCRIPTION
The following PR:
- Migrate 8 leaf packages from `pkg/logger` shim to top-level `slog` functions with structured key-value logging
- Add `slog.SetDefault()` to `pkg/logger` so migrated packages use the configured toolhive-core logger
- Packages: recovery, certs, updates, lockfile, ignore, healthcheck, state, networking
- All 8 packages build and pass tests
- Full project `go build ./...` passes
- No remaining `pkg/logger` imports in changed packages