### PR TITLE
Fix OAuth URL extraction in proxy E2E tests

### DIFF
--- a/test/e2e/proxy_oauth_test.go
+++ b/test/e2e/proxy_oauth_test.go
@@ -351,7 +351,7 @@ var _ = Describe("Proxy OAuth Authentication E2E", Label("proxy", "oauth", "e2e"
 
 			// Use regex to extract the OAuth URL
 			// Pattern: "Please open this URL in your browser: <URL>"
-			urlPattern := regexp.MustCompile(`Please open this URL in your browser: (https?://[^\s]+)`)
+			urlPattern := regexp.MustCompile(`Please open this URL in your browser: (https?://[^\s"]+)`)
 			matches := urlPattern.FindStringSubmatch(output)
 
 			var authURL string
@@ -432,7 +432,7 @@ var _ = Describe("Proxy OAuth Authentication E2E", Label("proxy", "oauth", "e2e"
 			Eventually(outputBuffer.String, 5*time.Second, 500*time.Millisecond).
 				Should(ContainSubstring("Please open this URL"))
 
-			matches := regexp.MustCompile(`Please open this URL in your browser: (https?://[^\s]+)`).
+			matches := regexp.MustCompile(`Please open this URL in your browser: (https?://[^\s"]+)`).
 				FindStringSubmatch(outputBuffer.String())
 			Expect(matches).To(HaveLen(2))
 			authURL := matches[1]


### PR DESCRIPTION
The zap-to-slog logger migration (9377e3c6) changed the log output format. slog's text handler quotes the msg value when it contains special characters, so the OAuth URL line changed from:

```
  INFO Please open this URL in your browser: http://...&state=abc
```
to:
```
  level=INFO msg="Please open this URL in your browser: http://...&state=abc"
```

The regex `(https?://[^\s]+)` captured the trailing `"` as part of the URL, corrupting the state parameter and causing "invalid state parameter" errors on every run.

Exclude `"` from the capture group to handle both formats.