### PR TITLE
Migrate pkg/auth and pkg/authz from logger shim to slog

### DIFF
--- a/pkg/auth/awssts/exchange.go
+++ b/pkg/auth/awssts/exchange.go
@@ -6,13 +6,12 @@ package awssts
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"regexp"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
-
-	"github.com/stacklok/toolhive/pkg/logger"
 )
 
 // STSClient defines the interface for STS operations, enabling mock injection for testing.
@@ -77,7 +76,7 @@ func (e *Exchanger) ExchangeToken(
 
 	output, err := e.client.AssumeRoleWithWebIdentity(ctx, input)
 	if err != nil {
-		logger.Debugf("STS AssumeRoleWithWebIdentity failed: %v", err)
+		slog.Debug("STS AssumeRoleWithWebIdentity failed", "error", err)
 		return nil, ErrSTSExchangeFailed
 	}
 

--- a/pkg/auth/awssts/role_mapper.go
+++ b/pkg/auth/awssts/role_mapper.go
@@ -6,6 +6,7 @@ package awssts
 import (
 	"cmp"
 	"fmt"
+	"log/slog"
 	"math"
 	"slices"
 	"strings"
@@ -14,7 +15,6 @@ import (
 	celgo "github.com/google/cel-go/cel"
 
 	"github.com/stacklok/toolhive-core/cel"
-	"github.com/stacklok/toolhive/pkg/logger"
 )
 
 // claimBindingExpression is the generic CEL expression used for claim-based role mappings.
@@ -182,7 +182,8 @@ func (rm *RoleMapper) SelectRole(claims map[string]any) (string, error) {
 	for _, mapping := range rm.mappings {
 		match, err := mapping.expr.EvaluateBool(mapping.evalContext(claims, roleClaim))
 		if err != nil {
-			logger.Debugw("CEL expression evaluation failed, skipping mapping",
+			//nolint:gosec // G706: role ARN is from server configuration
+			slog.Debug("CEL expression evaluation failed, skipping mapping",
 				"role_arn", mapping.roleArn, "error", err)
 			continue
 		}

--- a/pkg/auth/discovery/discovery.go
+++ b/pkg/auth/discovery/discovery.go
@@ -17,6 +17,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"path"
@@ -27,7 +28,6 @@ import (
 
 	"github.com/stacklok/toolhive/pkg/auth"
 	"github.com/stacklok/toolhive/pkg/auth/oauth"
-	"github.com/stacklok/toolhive/pkg/logger"
 	"github.com/stacklok/toolhive/pkg/networking"
 	oauthproto "github.com/stacklok/toolhive/pkg/oauth"
 )
@@ -120,16 +120,16 @@ func DetectAuthenticationFromServer(ctx context.Context, targetURI string, confi
 
 	// NEW: Well-known URI fallback per MCP specification
 	// When no WWW-Authenticate header found, try well-known URIs
-	logger.Debugf("No WWW-Authenticate header found, attempting well-known URI discovery")
+	slog.Debug("No WWW-Authenticate header found, attempting well-known URI discovery")
 
 	wellKnownAuthInfo, err := tryWellKnownDiscovery(detectCtx, client, targetURI)
 	if err != nil {
-		logger.Debugf("Well-known URI discovery failed: %v", err)
+		slog.Debug("Well-known URI discovery failed", "error", err)
 		return nil, nil // Not an error, just no auth detected
 	}
 
 	if wellKnownAuthInfo != nil {
-		logger.Debugf("Discovered authentication via well-known URI")
+		slog.Debug("Discovered authentication via well-known URI")
 		return wellKnownAuthInfo, nil
 	}
 
@@ -166,7 +166,7 @@ func detectAuthWithRequest(
 	}
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
-			logger.Debugf("Failed to close response body: %v", err)
+			slog.Debug("Failed to close response body", "error", err)
 		}
 	}()
 
@@ -207,7 +207,8 @@ func buildWellKnownURI(parsedURL *url.URL, endpointSpecific bool) string {
 func checkWellKnownURIExists(ctx context.Context, client *http.Client, uri string) bool {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, uri, nil)
 	if err != nil {
-		logger.Debugf("Failed to create GET request for %s: %v", uri, err)
+		//nolint:gosec // G706: uri is from server endpoint discovery
+		slog.Debug("Failed to create GET request", "uri", uri, "error", err)
 		return false
 	}
 
@@ -215,7 +216,8 @@ func checkWellKnownURIExists(ctx context.Context, client *http.Client, uri strin
 
 	resp, err := client.Do(req) // #nosec G704 -- uri is built from the MCP server endpoint for auth discovery
 	if err != nil {
-		logger.Debugf("Failed to check %s: %v", uri, err)
+		//nolint:gosec // G706: uri is from server endpoint discovery
+		slog.Debug("Failed to check well-known URI", "uri", uri, "error", err)
 		return false
 	}
 	defer func() {
@@ -233,7 +235,9 @@ func checkWellKnownURIExists(ctx context.Context, client *http.Client, uri strin
 	// RFC 9728 requires Content-Type to be application/json
 	contentType := strings.ToLower(resp.Header.Get("Content-Type"))
 	if !strings.Contains(contentType, "application/json") {
-		logger.Debugf("Well-known URI %s returned unexpected content type: %s", uri, contentType)
+		//nolint:gosec // G706: content type from server response is safe to log
+		slog.Debug("Well-known URI returned unexpected content type",
+			"uri", uri, "content_type", contentType)
 		return false
 	}
 
@@ -259,17 +263,20 @@ func tryWellKnownDiscovery(ctx context.Context, client *http.Client, targetURI s
 
 	// Try each well-known URI in order
 	for _, wellKnownURI := range wellKnownURIs {
-		logger.Debugf("Trying well-known URI: %s", wellKnownURI)
+		//nolint:gosec // G706: well-known URIs are built from server endpoint
+		slog.Debug("Trying well-known URI", "uri", wellKnownURI)
 
 		// Check if the URI exists before attempting to fetch
 		if !checkWellKnownURIExists(ctx, client, wellKnownURI) {
-			logger.Debugf("Well-known URI not found: %s", wellKnownURI)
+			//nolint:gosec // G706: well-known URIs are built from server endpoint
+			slog.Debug("Well-known URI not found", "uri", wellKnownURI)
 			continue
 		}
 
 		// URI exists - return AuthInfo with ResourceMetadata set
 		// Downstream handler will use FetchResourceMetadata to get the actual metadata
-		logger.Debugf("Found well-known URI: %s", wellKnownURI)
+		//nolint:gosec // G706: well-known URIs are built from server endpoint
+		slog.Debug("Found well-known URI", "uri", wellKnownURI)
 		return &AuthInfo{
 			Type:             "OAuth",
 			ResourceMetadata: wellKnownURI,
@@ -349,7 +356,8 @@ func ParseWWWAuthenticate(header string) (*AuthInfo, error) {
 	// Currently only OAuth-based authentication is supported
 	// Basic and Digest authentication are not implemented
 	if strings.HasPrefix(header, "Basic") || strings.HasPrefix(header, "Digest") {
-		logger.Debugf("Unsupported authentication scheme: %s", header)
+		//nolint:gosec // G706: auth scheme name (Basic/Digest) is safe to log
+		slog.Debug("Unsupported authentication scheme", "header", header)
 		return nil, fmt.Errorf("unsupported authentication scheme: %s", strings.Split(header, " ")[0])
 	}
 
@@ -361,7 +369,7 @@ func DeriveIssuerFromURL(remoteURL string) string {
 	// Parse the URL to extract the domain
 	parsedURL, err := url.Parse(remoteURL)
 	if err != nil {
-		logger.Debugf("Failed to parse remote URL: %v", err)
+		slog.Debug("Failed to parse remote URL", "error", err)
 		return ""
 	}
 
@@ -387,7 +395,8 @@ func DeriveIssuerFromURL(remoteURL string) string {
 	// This works for most OAuth providers that use their domain as the issuer
 	issuer := fmt.Sprintf("%s://%s", scheme, host)
 
-	logger.Debugf("Derived issuer from URL - remoteURL: %s, issuer: %s", remoteURL, issuer)
+	//nolint:gosec // G706: derived issuer URL is from server configuration
+	slog.Debug("Derived issuer from URL", "remote_url", remoteURL, "issuer", issuer)
 	return issuer
 }
 
@@ -452,14 +461,14 @@ func DeriveIssuerFromRealm(realm string) string {
 	// Check if realm is already a valid HTTPS URL
 	parsedURL, err := url.Parse(realm)
 	if err != nil {
-		logger.Debugf("Realm is not a valid URL: %v", err)
+		slog.Debug("Realm is not a valid URL", "error", err)
 		return ""
 	}
 
 	// RFC 8414: The issuer identifier MUST be a URL using the "https" scheme
 	// with no query or fragment components
 	if parsedURL.Scheme != "https" && !networking.IsLocalhost(parsedURL.Host) {
-		logger.Debugf("Realm is not using HTTPS scheme: %s", realm)
+		slog.Debug("Realm is not using HTTPS scheme", "realm", realm)
 		return ""
 	}
 
@@ -475,14 +484,15 @@ func DeriveIssuerFromRealm(realm string) string {
 	}
 
 	if parsedURL.RawQuery != "" || parsedURL.Fragment != "" {
-		logger.Debugf("Realm contains query or fragment components: %s", realm)
+		slog.Debug("Realm contains query or fragment components", "realm", realm)
 		// Remove query and fragment to make it a valid issuer
 		parsedURL.RawQuery = ""
 		parsedURL.Fragment = ""
 	}
 
 	issuer := parsedURL.String()
-	logger.Debugf("Derived issuer from realm - realm: %s, issuer: %s", realm, issuer)
+	//nolint:gosec // G706: realm is from WWW-Authenticate header of configured remote
+	slog.Debug("Derived issuer from realm", "realm", realm, "issuer", issuer)
 	return issuer
 }
 
@@ -522,7 +532,7 @@ func shouldDynamicallyRegisterClient(config *OAuthFlowConfig) bool {
 
 // PerformOAuthFlow performs an OAuth authentication flow with the given configuration
 func PerformOAuthFlow(ctx context.Context, issuer string, config *OAuthFlowConfig) (*OAuthFlowResult, error) {
-	logger.Debugf("Starting OAuth authentication flow for issuer: %s", issuer)
+	slog.Debug("Starting OAuth authentication flow", "issuer", issuer)
 
 	if config == nil {
 		return nil, fmt.Errorf("OAuth flow config cannot be nil")
@@ -540,7 +550,7 @@ func PerformOAuthFlow(ctx context.Context, issuer string, config *OAuthFlowConfi
 		}
 
 		if port != config.CallbackPort {
-			logger.Warnf("Specified auth callback port %d is unavailable, using port %d instead", config.CallbackPort, port)
+			slog.Warn("Specified auth callback port is unavailable", "requested_port", config.CallbackPort, "actual_port", port)
 		}
 		config.CallbackPort = port
 	} else {
@@ -603,7 +613,7 @@ func getDiscoveryDocument(
 ) (*oauthproto.OIDCDiscoveryDocument, error) {
 	// If we already have the registration endpoint from earlier discovery, use it
 	if config.RegistrationEndpoint != "" && config.AuthorizeURL != "" && config.TokenURL != "" {
-		logger.Debugf("Using pre-discovered OAuth endpoints for dynamic registration")
+		slog.Debug("Using pre-discovered OAuth endpoints for dynamic registration")
 		return &oauthproto.OIDCDiscoveryDocument{
 			AuthorizationServerMetadata: oauthproto.AuthorizationServerMetadata{
 				Issuer:                issuer,
@@ -622,8 +632,8 @@ func getDiscoveryDocument(
 func createOAuthConfig(ctx context.Context, issuer string, config *OAuthFlowConfig) (*oauth.Config, error) {
 	// Check if we have OAuth endpoints configured
 	if config.AuthorizeURL != "" && config.TokenURL != "" {
-		logger.Debugf("Using OAuth endpoints - authorize_url: %s, token_url: %s",
-			config.AuthorizeURL, config.TokenURL)
+		slog.Debug("Using OAuth endpoints",
+			"authorize_url", config.AuthorizeURL, "token_url", config.TokenURL)
 
 		return oauth.CreateOAuthConfigManual(
 			config.ClientID,
@@ -639,7 +649,7 @@ func createOAuthConfig(ctx context.Context, issuer string, config *OAuthFlowConf
 	}
 
 	// Fall back to OIDC discovery
-	logger.Debug("Using OIDC discovery")
+	slog.Debug("Using OIDC discovery")
 	return oauth.CreateOAuthConfigFromOIDC(
 		ctx,
 		issuer,
@@ -676,15 +686,15 @@ func newOAuthFlow(ctx context.Context, oauthConfig *oauth.Config, config *OAuthF
 		return nil, fmt.Errorf("OAuth flow failed: %w", err)
 	}
 
-	logger.Debug("OAuth authentication successful")
+	slog.Debug("OAuth authentication successful")
 
 	// Log token info (without exposing the actual token)
 	if tokenResult.Claims != nil {
 		if sub, ok := tokenResult.Claims["sub"].(string); ok {
-			logger.Debugf("Authenticated as subject: %s", sub)
+			slog.Debug("Authenticated as subject", "sub", sub)
 		}
 		if email, ok := tokenResult.Claims["email"].(string); ok {
-			logger.Debugf("Authenticated email: %s", email)
+			slog.Debug("Authenticated with email", "email", email)
 		}
 	}
 
@@ -764,7 +774,7 @@ func FetchResourceMetadata(ctx context.Context, metadataURL string) (*auth.RFC97
 	}
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
-			logger.Debugf("Failed to close response body: %v", err)
+			slog.Debug("Failed to close response body", "error", err)
 		}
 	}()
 
@@ -805,9 +815,9 @@ func ValidateAndDiscoverAuthServer(ctx context.Context, potentialIssuer string) 
 	if err == nil && doc != nil && doc.Issuer != "" {
 		// Found valid authorization server metadata, return the actual issuer and endpoints
 		if doc.Issuer != potentialIssuer {
-			logger.Debugf("Discovered actual issuer: %s (from metadata URL: %s)", doc.Issuer, potentialIssuer)
+			slog.Debug("Discovered actual issuer", "issuer", doc.Issuer, "metadata_url", potentialIssuer)
 		} else {
-			logger.Debugf("Validated authorization server: %s", potentialIssuer)
+			slog.Debug("Validated authorization server", "issuer", potentialIssuer)
 		}
 
 		return &AuthServerInfo{

--- a/pkg/auth/discovery/discovery_test.go
+++ b/pkg/auth/discovery/discovery_test.go
@@ -17,17 +17,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/stacklok/toolhive/pkg/logger"
 	"github.com/stacklok/toolhive/pkg/networking"
 	oauthproto "github.com/stacklok/toolhive/pkg/oauth"
 )
 
 const wellKnownOAuthPath = "/.well-known/oauth-protected-resource"
-
-func init() {
-	// Initialize logger for tests
-	logger.Initialize()
-}
 
 func TestParseWWWAuthenticate(t *testing.T) {
 	t.Parallel()

--- a/pkg/auth/github_provider.go
+++ b/pkg/auth/github_provider.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"strings"
@@ -19,7 +20,6 @@ import (
 	"golang.org/x/time/rate"
 
 	"github.com/stacklok/toolhive/pkg/auth/oauth"
-	"github.com/stacklok/toolhive/pkg/logger"
 	"github.com/stacklok/toolhive/pkg/networking"
 )
 
@@ -127,7 +127,7 @@ func (*GitHubProvider) CanHandle(introspectURL string) bool {
 // IntrospectToken introspects a GitHub OAuth token and returns JWT claims
 // This calls GitHub's token validation API to verify the token and extract user information
 func (g *GitHubProvider) IntrospectToken(ctx context.Context, token string) (jwt.MapClaims, error) {
-	logger.Debugf("Using GitHub token validation provider: %s", g.baseURL)
+	slog.Debug("Using GitHub token validation provider", "url", g.baseURL)
 
 	// Apply rate limiting to prevent DoS and respect GitHub API limits
 	if err := g.rateLimiter.Wait(ctx); err != nil {
@@ -162,7 +162,7 @@ func (g *GitHubProvider) IntrospectToken(ctx context.Context, token string) (jwt
 	}
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
-			logger.Debugf("Failed to close response body: %v", err)
+			slog.Debug("Failed to close response body", "error", err)
 		}
 	}()
 
@@ -184,8 +184,9 @@ func (g *GitHubProvider) IntrospectToken(ctx context.Context, token string) (jwt
 		retryAfter := resp.Header.Get("Retry-After")
 		remaining := resp.Header.Get("X-RateLimit-Remaining")
 		reset := resp.Header.Get("X-RateLimit-Reset")
-		logger.Warnf("GitHub rate limit exceeded - Retry-After: %s, Remaining: %s, Reset: %s",
-			retryAfter, remaining, reset)
+		//nolint:gosec // G706: rate limit headers are public HTTP metadata
+		slog.Warn("GitHub rate limit exceeded",
+			"retry_after", retryAfter, "remaining", remaining, "reset", reset)
 		return nil, fmt.Errorf("github rate limit exceeded, retry after: %s", retryAfter)
 	}
 	if resp.StatusCode != http.StatusOK {
@@ -193,7 +194,8 @@ func (g *GitHubProvider) IntrospectToken(ctx context.Context, token string) (jwt
 	}
 
 	// Parse the GitHub response and convert to JWT claims
-	logger.Debugf("Successfully validated GitHub token (status: %d)", resp.StatusCode)
+	//nolint:gosec // G706: HTTP status code is not sensitive
+	slog.Debug("Successfully validated GitHub token", "status", resp.StatusCode)
 	return g.parseGitHubResponse(body)
 }
 

--- a/pkg/auth/middleware_test.go
+++ b/pkg/auth/middleware_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
-	"github.com/stacklok/toolhive/pkg/logger"
 	"github.com/stacklok/toolhive/pkg/transport/types"
 	"github.com/stacklok/toolhive/pkg/transport/types/mocks"
 )
@@ -96,9 +95,6 @@ func TestMiddleware_AuthInfoHandler(t *testing.T) {
 
 func TestCreateMiddleware_WithoutOIDCConfig(t *testing.T) {
 	t.Parallel()
-
-	// Initialize logger for testing
-	logger.Initialize()
 
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -208,9 +204,6 @@ func TestCreateMiddleware_NilParameters(t *testing.T) {
 
 func TestCreateMiddleware_EmptyParameters(t *testing.T) {
 	t.Parallel()
-
-	// Initialize logger for testing
-	logger.Initialize()
 
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/pkg/auth/oauth/dynamic_registration.go
+++ b/pkg/auth/oauth/dynamic_registration.go
@@ -9,12 +9,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"strings"
 	"time"
 
-	"github.com/stacklok/toolhive/pkg/logger"
 	"github.com/stacklok/toolhive/pkg/networking"
 	oauthproto "github.com/stacklok/toolhive/pkg/oauth"
 )
@@ -84,7 +84,7 @@ func (s ScopeList) MarshalJSON() ([]byte, error) {
 	scopeString := strings.Join(s, " ")
 	result, err := json.Marshal(scopeString)
 	if err == nil {
-		logger.Debugf("RFC 7591: Marshaled ScopeList %v -> %q (space-delimited string)", []string(s), scopeString)
+		slog.Debug("RFC 7591: Marshaled ScopeList", "scopes", []string(s), "result", scopeString)
 	}
 	return result, err
 }
@@ -255,7 +255,7 @@ func getHTTPClient(client networking.HTTPClient) networking.HTTPClient {
 func handleHTTPResponse(resp *http.Response) (*DynamicClientRegistrationResponse, error) {
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
-			logger.Debugf("Failed to close response body: %v", err)
+			slog.Debug("Failed to close response body", "error", err)
 		}
 	}()
 
@@ -344,6 +344,8 @@ func registerClientDynamicallyWithClient(
 		return nil, err
 	}
 
-	logger.Debugf("Successfully registered OAuth client dynamically - client_id: %s", response.ClientID)
+	//nolint:gosec // G706: client_id is public metadata from DCR response
+	slog.Debug("Successfully registered OAuth client dynamically",
+		"client_id", response.ClientID)
 	return response, nil
 }

--- a/pkg/auth/oauth/flow.go
+++ b/pkg/auth/oauth/flow.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"html"
+	"log/slog"
 	"net/http"
 	"os"
 	"os/signal"
@@ -21,7 +22,6 @@ import (
 	"github.com/pkg/browser"
 	"golang.org/x/oauth2"
 
-	"github.com/stacklok/toolhive/pkg/logger"
 	"github.com/stacklok/toolhive/pkg/networking"
 	oauthproto "github.com/stacklok/toolhive/pkg/oauth"
 )
@@ -187,7 +187,7 @@ func (f *Flow) Start(ctx context.Context, skipBrowser bool) (*TokenResult, error
 
 	// Start the server in a goroutine
 	go func() {
-		logger.Debugf("Starting OAuth callback server on port %d", f.port)
+		slog.Debug("Starting OAuth callback server", "port", f.port)
 		if err := f.server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			errorChan <- fmt.Errorf("failed to start callback server: %w", err)
 		}
@@ -202,7 +202,7 @@ func (f *Flow) Start(ctx context.Context, skipBrowser bool) (*TokenResult, error
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 		if err := f.server.Shutdown(shutdownCtx); err != nil {
-			logger.Warnf("Failed to shutdown OAuth callback server: %v", err)
+			slog.Warn("Failed to shutdown OAuth callback server", "error", err)
 		}
 	}()
 
@@ -211,16 +211,16 @@ func (f *Flow) Start(ctx context.Context, skipBrowser bool) (*TokenResult, error
 
 	// Open browser or display URL
 	if !skipBrowser {
-		logger.Infof("Opening browser to: %s", authURL)
+		fmt.Fprintf(os.Stderr, "Opening browser: %s\n", authURL)
 		if err := browser.OpenURL(authURL); err != nil {
-			logger.Warnf("Failed to open browser: %v", err)
-			logger.Infof("Please manually open this URL in your browser: %s", authURL)
+			slog.Warn("Failed to open browser", "error", err)
+			fmt.Fprintf(os.Stderr, "Please manually open this URL in your browser: %s\n", authURL)
 		}
 	} else {
-		logger.Infof("Please open this URL in your browser: %s", authURL)
+		fmt.Fprintf(os.Stderr, "Please open this URL in your browser: %s\n", authURL)
 	}
 
-	logger.Info("Waiting for OAuth callback...")
+	fmt.Fprintln(os.Stderr, "Waiting for OAuth callback")
 
 	// Set up signal handling for graceful shutdown
 	sigChan := make(chan os.Signal, 1)
@@ -229,7 +229,7 @@ func (f *Flow) Start(ctx context.Context, skipBrowser bool) (*TokenResult, error
 	// Wait for token, error, or cancellation
 	select {
 	case token := <-tokenChan:
-		logger.Debug("OAuth flow completed successfully")
+		slog.Debug("OAuth flow completed successfully")
 		return f.processToken(ctx, token), nil
 	case err := <-errorChan:
 		return nil, fmt.Errorf("OAuth flow failed: %w", err)
@@ -373,7 +373,7 @@ func (f *Flow) handleRoot() http.HandlerFunc {
 </body>
 </html>`
 		if _, err := w.Write([]byte(htmlContent)); err != nil {
-			logger.Warnf("Failed to write HTML content: %v", err)
+			slog.Warn("Failed to write HTML content", "error", err)
 		}
 	}
 }
@@ -405,7 +405,7 @@ func (f *Flow) writeSuccessPage(w http.ResponseWriter) {
 </body>
 </html>`
 	if _, err := w.Write([]byte(htmlContent)); err != nil {
-		logger.Warnf("Failed to write HTML content: %v", err)
+		slog.Warn("Failed to write HTML content", "error", err)
 	}
 }
 
@@ -444,7 +444,7 @@ func (*Flow) writeErrorPage(w http.ResponseWriter, err error) {
 </body>
 </html>`, escapedError)
 	if _, err := w.Write([]byte(htmlContent)); err != nil {
-		logger.Warnf("Failed to write HTML content: %v", err)
+		slog.Warn("Failed to write HTML content", "error", err)
 	}
 }
 
@@ -480,17 +480,17 @@ func (f *Flow) processToken(_ context.Context, token *oauth2.Token) *TokenResult
 		result.IDToken = idToken
 		if claims, err := f.extractJWTClaims(idToken); err == nil {
 			result.Claims = claims
-			logger.Debugf("Successfully extracted JWT claims from ID token")
+			slog.Debug("Successfully extracted JWT claims from ID token")
 		} else {
-			logger.Debugf("Could not extract JWT claims from ID token: %v", err)
+			slog.Debug("Could not extract JWT claims from ID token", "error", err)
 		}
 	} else {
 		// Fallback: try to extract claims from the access token (e.g., Keycloak)
 		if claims, err := f.extractJWTClaims(token.AccessToken); err == nil {
 			result.Claims = claims
-			logger.Debugf("Successfully extracted JWT claims from access token")
+			slog.Debug("Successfully extracted JWT claims from access token")
 		} else {
-			logger.Debugf("Could not extract JWT claims from access token (may be opaque token): %v", err)
+			slog.Debug("Could not extract JWT claims from access token (may be opaque token)", "error", err)
 		}
 	}
 

--- a/pkg/auth/oauth/flow_test.go
+++ b/pkg/auth/oauth/flow_test.go
@@ -20,14 +20,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2"
-
-	"github.com/stacklok/toolhive/pkg/logger"
 )
 
 func TestMain(m *testing.M) {
-	// Initialize logger for tests
-	logger.Initialize()
-
 	// Run tests
 	code := m.Run()
 

--- a/pkg/auth/oauth/resource_token_source.go
+++ b/pkg/auth/oauth/resource_token_source.go
@@ -6,12 +6,11 @@ package oauth
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"time"
 
 	"golang.org/x/oauth2"
-
-	"github.com/stacklok/toolhive/pkg/logger"
 )
 
 // resourceTokenSource wraps an oauth2.TokenSource and adds the resource parameter
@@ -89,7 +88,7 @@ func (r *resourceTokenSource) refreshWithResource(ctx context.Context) (*oauth2.
 		token.RefreshToken = refreshToken
 	}
 
-	logger.Debugw("token refreshed with resource parameter",
+	slog.Debug("Token refreshed with resource parameter",
 		"resource", r.resource,
 	)
 

--- a/pkg/auth/remote/config.go
+++ b/pkg/auth/remote/config.go
@@ -6,12 +6,12 @@ package remote
 import (
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/url"
 	"strings"
 	"time"
 
 	httpval "github.com/stacklok/toolhive-core/validation/http"
-	"github.com/stacklok/toolhive/pkg/logger"
 	"github.com/stacklok/toolhive/pkg/registry/registry"
 )
 
@@ -175,14 +175,14 @@ func DefaultResourceIndicator(remoteServerURL string) string {
 	normalized, err := normalizeResourceURI(remoteServerURL)
 	if err != nil {
 		// Normalization failed - log warning and leave resource empty
-		logger.Warnf("Failed to normalize resource indicator from remote server URL %s: %v", remoteServerURL, err)
+		slog.Warn("Failed to normalize resource indicator from remote server URL", "url", remoteServerURL, "error", err)
 		return ""
 	}
 
 	// Validate the normalized result
 	if err := httpval.ValidateResourceURI(normalized); err != nil {
 		// Validation failed - log warning and leave resource empty
-		logger.Warnf("Normalized resource indicator is invalid %s: %v", normalized, err)
+		slog.Warn("Normalized resource indicator is invalid", "resource", normalized, "error", err)
 		return ""
 	}
 

--- a/pkg/auth/remote/config_test.go
+++ b/pkg/auth/remote/config_test.go
@@ -9,13 +9,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/stacklok/toolhive/pkg/logger"
 )
 
 func TestDeriveResourceIndicator(t *testing.T) {
 	t.Parallel()
-	logger.Initialize()
 
 	tests := []struct {
 		name             string

--- a/pkg/auth/remote/handler_test.go
+++ b/pkg/auth/remote/handler_test.go
@@ -16,17 +16,11 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/stacklok/toolhive/pkg/auth/discovery"
-	"github.com/stacklok/toolhive/pkg/logger"
 )
 
 const (
 	resourceMetadataPath = "/.well-known/resource-metadata"
 )
-
-func init() {
-	// Initialize logger for tests
-	logger.Initialize()
-}
 
 func TestDiscoverIssuerAndScopes(t *testing.T) {
 	t.Parallel()

--- a/pkg/auth/remote/persisting_token_source.go
+++ b/pkg/auth/remote/persisting_token_source.go
@@ -5,12 +5,11 @@ package remote
 
 import (
 	"context"
+	"log/slog"
 	"sync"
 	"time"
 
 	"golang.org/x/oauth2"
-
-	"github.com/stacklok/toolhive/pkg/logger"
 )
 
 // TokenPersister is a callback function that persists OAuth refresh tokens.
@@ -61,9 +60,9 @@ func (p *PersistingTokenSource) Token() (*oauth2.Token, error) {
 		// Refresh token changed, persist it
 		if err := p.persister(token.RefreshToken, token.Expiry); err != nil {
 			// Log the error but don't fail the token retrieval
-			logger.Warnf("Failed to persist refreshed OAuth token: %v", err)
+			slog.Warn("Failed to persist refreshed OAuth token", "error", err)
 		} else {
-			logger.Debugf("Successfully persisted refreshed OAuth token")
+			slog.Debug("Successfully persisted refreshed OAuth token")
 		}
 		p.lastToken = token
 	}

--- a/pkg/auth/token.go
+++ b/pkg/auth/token.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -24,7 +25,6 @@ import (
 
 	"github.com/stacklok/toolhive-core/env"
 	"github.com/stacklok/toolhive/pkg/auth/oauth"
-	"github.com/stacklok/toolhive/pkg/logger"
 	"github.com/stacklok/toolhive/pkg/networking"
 	oauthproto "github.com/stacklok/toolhive/pkg/oauth"
 )
@@ -57,12 +57,13 @@ func NewRegistry() *Registry {
 func (r *Registry) GetIntrospector(introspectURL string) TokenIntrospector {
 	for _, provider := range r.providers {
 		if provider.CanHandle(introspectURL) {
-			logger.Debugf("Selected provider for introspection: %s (url: %s)", provider.Name(), introspectURL)
+			//nolint:gosec // G706: provider name and URL are from server configuration
+			slog.Debug("Selected provider for introspection", "provider", provider.Name(), "url", introspectURL)
 			return provider
 		}
 	}
 	// Create a new fallback provider instance with the specific URL
-	logger.Debugf("Using RFC7662 fallback provider for introspection: %s", introspectURL)
+	slog.Debug("Using RFC7662 fallback provider for introspection", "url", introspectURL)
 	return NewRFC7662Provider(introspectURL)
 }
 
@@ -100,7 +101,7 @@ func (g *GoogleProvider) CanHandle(introspectURL string) bool {
 
 // IntrospectToken introspects a Google opaque token and returns JWT claims
 func (g *GoogleProvider) IntrospectToken(ctx context.Context, token string) (jwt.MapClaims, error) {
-	logger.Debugf("Using Google tokeninfo provider for token introspection: %s", g.url)
+	slog.Debug("Using Google tokeninfo provider for token introspection", "url", g.url)
 
 	// Parse the URL and add query parameters
 	u, err := url.Parse(g.url)
@@ -129,7 +130,7 @@ func (g *GoogleProvider) IntrospectToken(ctx context.Context, token string) (jwt
 	}
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
-			logger.Debugf("Failed to close response body: %v", err)
+			slog.Debug("Failed to close response body", "error", err)
 		}
 	}()
 
@@ -147,7 +148,8 @@ func (g *GoogleProvider) IntrospectToken(ctx context.Context, token string) (jwt
 	}
 
 	// Parse the Google response and convert to JWT claims
-	logger.Debugf("Successfully received Google tokeninfo response (status: %d)", resp.StatusCode)
+	//nolint:gosec // G706: HTTP status code is not sensitive
+	slog.Debug("Successfully received Google tokeninfo response", "status", resp.StatusCode)
 	return g.parseGoogleResponse(body)
 }
 
@@ -310,7 +312,7 @@ func (r *RFC7662Provider) IntrospectToken(ctx context.Context, token string) (jw
 	}
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
-			logger.Debugf("Failed to close response body: %v", err)
+			slog.Debug("Failed to close response body", "error", err)
 		}
 	}()
 
@@ -453,7 +455,7 @@ func discoverOIDCConfiguration(
 	}
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
-			logger.Debugf("Failed to close response body: %v", err)
+			slog.Debug("Failed to close response body", "error", err)
 		}
 	}()
 
@@ -499,13 +501,13 @@ func registerIntrospectionProviders(config TokenValidatorConfig, clientSecret st
 
 	// Add Google provider if the introspection URL matches
 	if config.IntrospectionURL == GoogleTokeninfoURL {
-		logger.Debugf("Registering Google tokeninfo provider: %s", config.IntrospectionURL)
+		slog.Debug("Registering Google tokeninfo provider", "url", config.IntrospectionURL)
 		registry.AddProvider(NewGoogleProvider(config.IntrospectionURL))
 	}
 
 	// Add GitHub provider if the introspection URL matches GitHub's API pattern
 	if strings.Contains(config.IntrospectionURL, GitHubTokenCheckURL) {
-		logger.Debugf("Registering GitHub token validation provider: %s", config.IntrospectionURL)
+		slog.Debug("Registering GitHub token validation provider", "url", config.IntrospectionURL)
 		githubProvider, err := NewGitHubProvider(
 			config.IntrospectionURL,
 			config.ClientID,
@@ -560,10 +562,10 @@ func NewTokenValidator(ctx context.Context, config TokenValidatorConfig, opts ..
 
 	// Log warning if insecure HTTP is enabled
 	if config.InsecureAllowHTTP {
-		logger.Warnf(
-			"WARNING: InsecureAllowHTTP is enabled for issuer '%s' - "+
+		slog.Warn(
+			"InsecureAllowHTTP is enabled - "+
 				"HTTP OIDC URLs are allowed. This is INSECURE and should NEVER be used in production!",
-			config.Issuer,
+			"issuer", config.Issuer,
 		)
 	}
 
@@ -583,12 +585,12 @@ func NewTokenValidator(ctx context.Context, config TokenValidatorConfig, opts ..
 					"This env var is for testing only and cannot guess provider-specific JWKS URLs",
 			)
 		}
-		logger.Warnf(
-			"OIDC discovery skipped for issuer '%s' (TOOLHIVE_SKIP_OIDC_DISCOVERY=true)",
-			config.Issuer,
+		slog.Warn(
+			"OIDC discovery skipped (TOOLHIVE_SKIP_OIDC_DISCOVERY=true)",
+			"issuer", config.Issuer,
 		)
 	} else if jwksURL == "" && config.Issuer != "" {
-		logger.Debugf("OIDC discovery deferred for issuer '%s' - will discover on first validation request", config.Issuer)
+		slog.Debug("OIDC discovery deferred - will discover on first validation request", "issuer", config.Issuer)
 	}
 
 	// Ensure we have either an explicit JWKS URL or an issuer to discover from
@@ -744,18 +746,18 @@ func (v *TokenValidator) ensureOIDCDiscovered(ctx context.Context) error {
 		backoff.WithBackOff(expBackoff),
 		backoff.WithMaxTries(oidcDiscoveryMaxAttempts),
 		backoff.WithNotify(func(err error, duration time.Duration) {
-			logger.Debugf(
-				"OIDC discovery for issuer '%s' failed, retrying in %v: %v",
-				v.issuer, duration, err,
+			slog.Debug(
+				"OIDC discovery failed, retrying",
+				"issuer", v.issuer, "retry_in", duration, "error", err,
 			)
 		}),
 	)
 
 	if err != nil {
 		v.oidcDiscoveryErr = fmt.Errorf("%w: %w", ErrFailedToDiscoverOIDC, err)
-		logger.Errorf(
-			"OIDC discovery failed for issuer '%s' after %d attempts: %v",
-			v.issuer, oidcDiscoveryMaxAttempts, err,
+		slog.Error(
+			"OIDC discovery failed after retries",
+			"issuer", v.issuer, "attempts", oidcDiscoveryMaxAttempts, "error", err,
 		)
 		// Do NOT set oidcDiscovered = true -- allow retry on next ValidateToken call
 		return v.oidcDiscoveryErr
@@ -771,9 +773,9 @@ func (v *TokenValidator) ensureOIDCDiscovered(ctx context.Context) error {
 	v.jwksRegistrationMu.Lock()
 	v.jwksRegistered = false
 	v.jwksRegistrationMu.Unlock()
-	logger.Debugf(
-		"OIDC discovery succeeded for issuer '%s': JWKS URL is '%s'",
-		v.issuer, doc.JWKSURI,
+	slog.Debug(
+		"OIDC discovery succeeded",
+		"issuer", v.issuer, "jwks_url", doc.JWKSURI,
 	)
 
 	return nil
@@ -1051,7 +1053,7 @@ func (v *TokenValidator) Middleware(next http.Handler) http.Handler {
 		// Convert claims to Identity
 		identity, err := claimsToIdentity(claims, tokenString)
 		if err != nil {
-			logger.Errorf("Failed to convert claims to identity: %v", err)
+			slog.Error("Failed to convert claims to identity", "error", err)
 			w.Header().Set("WWW-Authenticate", v.buildWWWAuthenticate(true, err.Error()))
 			http.Error(w, "Invalid authentication claims", http.StatusUnauthorized)
 			return
@@ -1120,7 +1122,7 @@ func NewAuthInfoHandler(issuer, jwksURL, resourceURL string, scopes []string) ht
 
 		// Encode and send the response
 		if err := json.NewEncoder(w).Encode(authInfo); err != nil {
-			logger.Errorf("Failed to encode OAuth discovery response: %v", err)
+			slog.Error("Failed to encode OAuth discovery response", "error", err)
 			http.Error(w, "Internal server error", http.StatusInternalServerError)
 			return
 		}

--- a/pkg/auth/utils.go
+++ b/pkg/auth/utils.go
@@ -7,11 +7,10 @@ package auth
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"net/http"
 	"os/user"
 	"strings"
-
-	"github.com/stacklok/toolhive/pkg/logger"
 )
 
 // bearerTokenType defines the expected token type for Bearer authentication.
@@ -65,7 +64,7 @@ func ExtractBearerToken(r *http.Request) (string, error) {
 func GetAuthenticationMiddleware(ctx context.Context, oidcConfig *TokenValidatorConfig,
 ) (func(http.Handler) http.Handler, http.Handler, error) {
 	if oidcConfig != nil {
-		logger.Debug("OIDC validation enabled")
+		slog.Debug("OIDC validation enabled")
 
 		// Create JWT validator
 		jwtValidator, err := NewTokenValidator(ctx, *oidcConfig)
@@ -77,16 +76,16 @@ func GetAuthenticationMiddleware(ctx context.Context, oidcConfig *TokenValidator
 		return jwtValidator.Middleware, authInfoHandler, nil
 	}
 
-	logger.Debug("OIDC validation disabled, using local user authentication")
+	slog.Debug("OIDC validation disabled, using local user authentication")
 
 	// Get current OS user
 	currentUser, err := user.Current()
 	if err != nil {
-		logger.Warnf("Failed to get current user, using 'local' as default: %v", err)
+		slog.Warn("Failed to get current user, using 'local' as default", "error", err)
 		return LocalUserMiddleware("local"), nil, nil
 	}
 
-	logger.Debugf("Using local user authentication for user: %s", currentUser.Username)
+	slog.Debug("Using local user authentication", "user", currentUser.Username)
 	return LocalUserMiddleware(currentUser.Username), nil, nil
 }
 

--- a/pkg/auth/utils_test.go
+++ b/pkg/auth/utils_test.go
@@ -12,8 +12,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/stacklok/toolhive/pkg/logger"
 )
 
 func TestExtractBearerToken(t *testing.T) {
@@ -109,8 +107,6 @@ func TestExtractBearerToken(t *testing.T) {
 
 func TestGetAuthenticationMiddleware(t *testing.T) {
 	t.Parallel()
-	// Initialize logger for testing
-	logger.Initialize()
 
 	ctx := context.Background()
 

--- a/pkg/authz/authorizers/cedar/core.go
+++ b/pkg/authz/authorizers/cedar/core.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
 	"sync"
 
@@ -17,7 +18,6 @@ import (
 
 	"github.com/stacklok/toolhive/pkg/auth"
 	"github.com/stacklok/toolhive/pkg/authz/authorizers"
-	"github.com/stacklok/toolhive/pkg/logger"
 )
 
 // ConfigType is the configuration type identifier for Cedar authorization.
@@ -308,15 +308,15 @@ func (a *Authorizer) IsAuthorized(
 	}
 
 	// Debug logging for authorization
-	logger.Debugf("Cedar authorization check - Principal: %s, Action: %s, Resource: %s",
-		req.Principal, req.Action, req.Resource)
-	logger.Debugf("Cedar context: %+v", req.Context)
+	slog.Debug("Cedar authorization check",
+		"principal", req.Principal, "action", req.Action, "resource", req.Resource)
+	slog.Debug("Cedar context", "context", req.Context)
 
 	// Check authorization
 	decision, diagnostic := cedar.Authorize(a.policySet, entityMap, req)
 
 	// Log the decision
-	logger.Debugf("Cedar decision: %v, diagnostic: %+v", decision, diagnostic)
+	slog.Debug("Cedar decision", "decision", decision, "diagnostic", diagnostic)
 
 	// Cedar's Authorize returns a Decision and a Diagnostic
 	// Check if the Diagnostic contains any errors

--- a/pkg/authz/authorizers/cedar/core_test.go
+++ b/pkg/authz/authorizers/cedar/core_test.go
@@ -13,15 +13,12 @@ import (
 
 	"github.com/stacklok/toolhive/pkg/auth"
 	"github.com/stacklok/toolhive/pkg/authz/authorizers"
-	"github.com/stacklok/toolhive/pkg/logger"
 )
 
 // TestNewCedarAuthorizer tests the creation of a new Cedar authorizer with different configurations.
 func TestNewCedarAuthorizer(t *testing.T) {
 	t.Parallel()
 
-	// Initialize logger for tests
-	logger.Initialize()
 	// Test cases
 	testCases := []struct {
 		name         string

--- a/pkg/authz/authorizers/http/core.go
+++ b/pkg/authz/authorizers/http/core.go
@@ -7,10 +7,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 
 	"github.com/stacklok/toolhive/pkg/auth"
 	"github.com/stacklok/toolhive/pkg/authz/authorizers"
-	"github.com/stacklok/toolhive/pkg/logger"
 )
 
 func init() {
@@ -76,7 +76,7 @@ func NewAuthorizer(config ConfigOptions, serverName string) (*Authorizer, error)
 		return nil, err
 	}
 
-	logger.Debugf("creating new HTTP PDP authorizer: %v", config)
+	slog.Debug("Creating new HTTP PDP authorizer", "config", config)
 	p, err := NewClient(config.HTTP)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create HTTP client: %w", err)
@@ -115,17 +115,17 @@ func (a *Authorizer) AuthorizeWithJWTClaims(
 	porc := a.porcBuilder.Build(feature, operation, resourceID, identity.Claims, arguments)
 
 	// Log the authorization request
-	logger.Debugf("HTTP PDP authorization check - Operation: %s, Resource: %s",
-		porc["operation"], porc["resource"])
+	slog.Debug("HTTP PDP authorization check",
+		"operation", porc["operation"], "resource", porc["resource"])
 
 	// Delegate to PDP (not in probe mode for actual authorization)
 	allowed, err := a.pdp.Authorize(ctx, porc, false)
 	if err != nil {
-		logger.Debugf("HTTP PDP authorization check - Failed to authorize: %v", err)
+		slog.Debug("HTTP PDP authorization check failed", "error", err)
 		return false, fmt.Errorf("authorization failed: %w", err)
 	}
 
-	logger.Debugf("HTTP PDP authorization result: %t", allowed)
+	slog.Debug("HTTP PDP authorization result", "allowed", allowed)
 
 	return allowed, nil
 }

--- a/pkg/authz/authorizers/http/http_client.go
+++ b/pkg/authz/authorizers/http/http_client.go
@@ -10,11 +10,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	nethttp "net/http"
 	"net/url"
 	"time"
-
-	"github.com/stacklok/toolhive/pkg/logger"
 )
 
 const (
@@ -38,7 +37,7 @@ type Client struct {
 
 // NewClient creates a new HTTP client for PDP communication.
 func NewClient(config *ConnectionConfig) (*Client, error) {
-	logger.Debugf("creating new HTTP client: %v", config)
+	slog.Debug("Creating new HTTP client", "config", config)
 
 	if config == nil {
 		return nil, fmt.Errorf("HTTP configuration is required")
@@ -116,8 +115,10 @@ func (c *Client) Authorize(ctx context.Context, porc PORC, probe bool) (bool, er
 			logSubject = sub
 		}
 	}
-	logger.Debugf("HTTP PDP authorization - URL: %s, Subject: %s, Operation: %v, Resource: %v",
-		decisionURL, logSubject, porc["operation"], porc["resource"])
+	//nolint:gosec // G706: authorization metadata is safe for debug logging
+	slog.Debug("HTTP PDP authorization",
+		"url", decisionURL, "subject", logSubject,
+		"operation", porc["operation"], "resource", porc["resource"])
 
 	// Marshal PORC to JSON
 	body, err := json.Marshal(porc)

--- a/pkg/authz/integration_test.go
+++ b/pkg/authz/integration_test.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/stacklok/toolhive/pkg/auth"
 	"github.com/stacklok/toolhive/pkg/authz/authorizers/cedar"
-	"github.com/stacklok/toolhive/pkg/logger"
 	mcpparser "github.com/stacklok/toolhive/pkg/mcp"
 )
 
@@ -27,8 +26,6 @@ import (
 func TestIntegrationListFiltering(t *testing.T) {
 	t.Parallel()
 
-	// Initialize logger for tests
-	logger.Initialize()
 	// Create a realistic Cedar authorizer with role-based policies
 	authorizer, err := cedar.NewCedarAuthorizer(cedar.ConfigOptions{
 		Policies: []string{

--- a/pkg/authz/middleware.go
+++ b/pkg/authz/middleware.go
@@ -9,13 +9,13 @@ package authz
 import (
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"strings"
 
 	"golang.org/x/exp/jsonrpc2"
 
 	"github.com/stacklok/toolhive/pkg/authz/authorizers"
-	"github.com/stacklok/toolhive/pkg/logger"
 	"github.com/stacklok/toolhive/pkg/mcp"
 	"github.com/stacklok/toolhive/pkg/transport/ssecommon"
 	"github.com/stacklok/toolhive/pkg/transport/types"
@@ -220,7 +220,7 @@ func Middleware(a authorizers.Authorizer, next http.Handler) http.Handler {
 			if err := filteringWriter.FlushAndFilter(); err != nil {
 				// If flushing fails, we've already started writing the response,
 				// so we can't return an error response. Just log it.
-				logger.Warnf("Error flushing filtered response: %v", err)
+				slog.Warn("Error flushing filtered response", "error", err)
 			}
 			return
 		}

--- a/pkg/authz/middleware_test.go
+++ b/pkg/authz/middleware_test.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/stacklok/toolhive/pkg/auth"
 	"github.com/stacklok/toolhive/pkg/authz/authorizers/cedar"
-	"github.com/stacklok/toolhive/pkg/logger"
 	mcpparser "github.com/stacklok/toolhive/pkg/mcp"
 	"github.com/stacklok/toolhive/pkg/transport/types"
 	"github.com/stacklok/toolhive/pkg/transport/types/mocks"
@@ -29,9 +28,6 @@ import (
 
 func TestMiddleware(t *testing.T) {
 	t.Parallel()
-
-	// Initialize logger for tests
-	logger.Initialize()
 
 	// Create a Cedar authorizer
 	authorizer, err := cedar.NewCedarAuthorizer(cedar.ConfigOptions{
@@ -453,9 +449,6 @@ func TestMiddlewareWithGETRequest(t *testing.T) {
 
 func TestFactoryCreateMiddleware(t *testing.T) {
 	t.Parallel()
-
-	// Initialize logger for tests
-	logger.Initialize()
 
 	t.Run("create middleware with config data", func(t *testing.T) {
 		t.Parallel()

--- a/pkg/authz/response_filter_test.go
+++ b/pkg/authz/response_filter_test.go
@@ -17,14 +17,10 @@ import (
 
 	"github.com/stacklok/toolhive/pkg/auth"
 	"github.com/stacklok/toolhive/pkg/authz/authorizers/cedar"
-	"github.com/stacklok/toolhive/pkg/logger"
 )
 
 func TestResponseFilteringWriter(t *testing.T) {
 	t.Parallel()
-
-	// Initialize logger for tests
-	logger.Initialize()
 
 	// Create a Cedar authorizer with specific tool permissions
 	authorizer, err := cedar.NewCedarAuthorizer(cedar.ConfigOptions{


### PR DESCRIPTION
The following PR:                                                                                                                                                                                                                                      
- Migrate `pkg/auth/` and `pkg/authz/` packages from `pkg/logger` shim to `log/slog`                                                                                                                                                                  
- Convert all `logger.Xxxf` format-style calls to structured `slog.Xxx` key-value calls                                                                                                                                                                 
- Remove `logger.Initialize()` calls and `pkg/logger` imports from test files                                                                                                                                                                           
- Preserve all `MiddlewareFactory` signatures unchanged