### PR TITLE
Fix slog key names, remove secret logging, and clean up messages (follow up to 3864)

### DIFF
--- a/pkg/runner/config.go
+++ b/pkg/runner/config.go
@@ -299,7 +299,7 @@ func migrateOAuthClientSecret(config *RunConfig) error {
 	// Save the migrated RunConfig back to disk so migration only happens once
 	if err := config.SaveState(context.Background()); err != nil {
 		// Log error without potentially sensitive details - only log error type and message
-		slog.Warn("Failed to save migrated RunConfig for workload", "name", config.Name, "s", err.Error())
+		slog.Warn("Failed to save migrated RunConfig for workload", "name", config.Name, "error", err)
 		// Don't fail the migration - the secret is already stored and the config is updated in memory
 	}
 
@@ -338,7 +338,7 @@ func migrateBearerToken(config *RunConfig) error {
 	// Save the migrated RunConfig back to disk so migration only happens once
 	if err := config.SaveState(context.Background()); err != nil {
 		// Log error without potentially sensitive details - only log error type and message
-		slog.Warn("Failed to save migrated RunConfig for workload", "name", config.Name, "s", err.Error())
+		slog.Warn("Failed to save migrated RunConfig for workload", "name", config.Name, "error", err)
 		// Don't fail the migration - the secret is already stored and the config is updated in memory
 	}
 
@@ -400,7 +400,7 @@ func (c *RunConfig) WithPorts(proxyPort, targetPort int) (*RunConfig, error) {
 	if proxyPort != 0 {
 		// Skip validation if reusing the same port from existing workload (during update)
 		if proxyPort == c.existingPort && c.existingPort > 0 {
-			slog.Debug("Reusing existing port", "reusing_existing_port", proxyPort)
+			slog.Debug("Reusing existing port", "port", proxyPort)
 			selectedPort = proxyPort
 		} else if !networking.IsAvailable(proxyPort) {
 			return c, fmt.Errorf("requested proxy port %d is not available", proxyPort)

--- a/pkg/runner/config_builder.go
+++ b/pkg/runner/config_builder.go
@@ -305,7 +305,7 @@ func WithLabels(labelStrings []string) RunConfigBuilderOption {
 		for _, labelString := range labelStrings {
 			key, value, err := labels.ParseLabel(labelString)
 			if err != nil {
-				slog.Warn("Skipping invalid label: ()", "skipping_invalid_label", labelString, "error", err)
+				slog.Warn("Skipping invalid label", "label", labelString, "error", err)
 				continue
 			}
 			b.config.ContainerLabels[key] = value

--- a/pkg/runner/config_builder_test.go
+++ b/pkg/runner/config_builder_test.go
@@ -28,8 +28,6 @@ const testPort = math.MaxInt16
 func TestRunConfigBuilder_Build_WithPermissionProfile(t *testing.T) {
 	t.Parallel()
 
-	// Needed to prevent a nil pointer dereference in the logger.
-
 	// Create a mock environment variable validator
 	mockValidator := &mockEnvVarValidator{}
 
@@ -243,8 +241,6 @@ func TestRunConfigBuilder_Build_WithPermissionProfile(t *testing.T) {
 func TestRunConfigBuilder_Build_WithVolumeMounts(t *testing.T) {
 	t.Parallel()
 
-	// Initialize logger to prevent nil pointer dereference when processing volume mounts
-
 	// Create a mock environment variable validator
 	mockValidator := &mockEnvVarValidator{}
 
@@ -378,8 +374,6 @@ func createTempProfileFile(t *testing.T, content string) (string, func()) {
 func TestAddCoreMiddlewares_TokenExchangeIntegration(t *testing.T) {
 	t.Parallel()
 
-	// Prevent nil pointer dereference in the logger.
-
 	t.Run("token-exchange NOT added when config is nil", func(t *testing.T) {
 		t.Parallel()
 
@@ -441,8 +435,6 @@ func TestAddCoreMiddlewares_TokenExchangeIntegration(t *testing.T) {
 
 func TestRunConfigBuilder_WithToolOverride(t *testing.T) {
 	t.Parallel()
-
-	// Needed to prevent a nil pointer dereference in the logger.
 
 	// Create a mock environment variable validator
 	mockValidator := &mockEnvVarValidator{}
@@ -552,8 +544,6 @@ func TestRunConfigBuilder_WithToolOverride(t *testing.T) {
 func TestRunConfigBuilder_ToolOverrideMutualExclusivity(t *testing.T) {
 	t.Parallel()
 
-	// Needed to prevent a nil pointer dereference in the logger.
-
 	// Create a mock environment variable validator
 	mockValidator := &mockEnvVarValidator{}
 
@@ -629,8 +619,6 @@ func TestRunConfigBuilder_ToolOverrideMutualExclusivity(t *testing.T) {
 
 func TestRunConfigBuilder_ToolOverrideWithToolsFilter(t *testing.T) {
 	t.Parallel()
-
-	// Needed to prevent a nil pointer dereference in the logger.
 
 	// Create a mock environment variable validator
 	mockValidator := &mockEnvVarValidator{}
@@ -839,8 +827,6 @@ func TestWithEnvVarsOverwrite(t *testing.T) {
 func TestBuildForOperator(t *testing.T) {
 	t.Parallel()
 
-	// Initialize logger to prevent nil pointer dereference
-
 	testCases := []struct {
 		name           string
 		builderOptions []RunConfigBuilderOption
@@ -910,8 +896,6 @@ func TestBuildForOperator(t *testing.T) {
 
 func TestWithEnvFileDir(t *testing.T) {
 	t.Parallel()
-
-	// Needed to prevent a nil pointer dereference in the logger.
 
 	testCases := []struct {
 		name        string

--- a/pkg/runner/config_env_files_test.go
+++ b/pkg/runner/config_env_files_test.go
@@ -15,8 +15,6 @@ import (
 func TestRunConfig_WithEnvFile(t *testing.T) {
 	t.Parallel()
 
-	// Initialize logger to prevent nil pointer dereference
-
 	tests := []struct {
 		name            string
 		initialEnvVars  map[string]string
@@ -95,8 +93,6 @@ func TestRunConfig_WithEnvFile(t *testing.T) {
 
 func TestRunConfig_WithEnvFilesFromDirectory(t *testing.T) {
 	t.Parallel()
-
-	// Initialize logger to prevent nil pointer dereference
 
 	tests := []struct {
 		name            string
@@ -191,8 +187,6 @@ func TestRunConfig_WithEnvFilesFromDirectory(t *testing.T) {
 
 func TestRunConfig_WithEnvFile_ErrorHandling(t *testing.T) {
 	t.Parallel()
-
-	// Initialize logger to prevent nil pointer dereference
 
 	config := &RunConfig{}
 

--- a/pkg/runner/config_test.go
+++ b/pkg/runner/config_test.go
@@ -738,7 +738,6 @@ func (*mockEnvVarValidator) Validate(_ context.Context, _ *regtypes.ImageMetadat
 func TestRunConfigBuilder(t *testing.T) {
 	t.Parallel()
 
-	// Needed to prevent a nil pointer dereference in the logger.
 	runtime := &runtimemocks.MockRuntime{}
 	cmdArgs := []string{"arg1", "arg2"}
 	name := "test-server"
@@ -1050,8 +1049,6 @@ func TestCommaSeparatedEnvVars(t *testing.T) {
 func TestRunConfigBuilder_MetadataOverrides(t *testing.T) {
 	t.Parallel()
 
-	// Needed to prevent a nil pointer dereference in the logger.
-
 	tests := []struct {
 		name               string
 		userTransport      string
@@ -1158,7 +1155,6 @@ func TestRunConfigBuilder_MetadataOverrides(t *testing.T) {
 func TestRunConfigBuilder_EnvironmentVariableTransportDependency(t *testing.T) {
 	t.Parallel()
 
-	// Needed to prevent a nil pointer dereference in the logger.
 	runtime := &runtimemocks.MockRuntime{}
 	validator := &mockEnvVarValidator{}
 
@@ -1203,8 +1199,6 @@ func TestRunConfigBuilder_EnvironmentVariableTransportDependency(t *testing.T) {
 // TestRunConfigBuilder_CmdArgsMetadataOverride tests that user args override registry defaults
 func TestRunConfigBuilder_CmdArgsMetadataOverride(t *testing.T) {
 	t.Parallel()
-
-	// Needed to prevent a nil pointer dereference in the logger.
 
 	runtime := &runtimemocks.MockRuntime{}
 	validator := &mockEnvVarValidator{}
@@ -1257,8 +1251,6 @@ func TestRunConfigBuilder_CmdArgsMetadataOverride(t *testing.T) {
 func TestRunConfigBuilder_CmdArgsMetadataDefaults(t *testing.T) {
 	t.Parallel()
 
-	// Needed to prevent a nil pointer dereference in the logger.
-
 	runtime := &runtimemocks.MockRuntime{}
 	validator := &mockEnvVarValidator{}
 
@@ -1309,7 +1301,6 @@ func TestRunConfigBuilder_CmdArgsMetadataDefaults(t *testing.T) {
 func TestRunConfigBuilder_VolumeProcessing(t *testing.T) {
 	t.Parallel()
 
-	// Needed to prevent a nil pointer dereference in the logger.
 	runtime := &runtimemocks.MockRuntime{}
 	validator := &mockEnvVarValidator{}
 
@@ -1376,8 +1367,6 @@ func TestRunConfigBuilder_VolumeProcessing(t *testing.T) {
 // TestRunConfigBuilder_FilesystemMCPScenario tests the specific scenario from the bug report
 func TestRunConfigBuilder_FilesystemMCPScenario(t *testing.T) {
 	t.Parallel()
-
-	// Needed to prevent a nil pointer dereference in the logger.
 
 	runtime := &runtimemocks.MockRuntime{}
 	validator := &mockEnvVarValidator{}

--- a/pkg/runner/env.go
+++ b/pkg/runner/env.go
@@ -137,7 +137,7 @@ func (v *CLIEnvVarValidator) Validate(
 
 				value, err := promptForEnvironmentVariable(envVar)
 				if err != nil {
-					slog.Warn("Warning: Failed to read input for", "name", envVar.Name, "s", err)
+					slog.Warn("failed to read input", "name", envVar.Name, "error", err)
 					continue
 				}
 				if value != "" {
@@ -215,8 +215,8 @@ func addAsSecret(
 	}
 
 	if err := secretsManager.SetSecret(ctx, secretName, value); err != nil {
-		slog.Warn("Warning: Failed to store secret", "secretname", secretName, "s", err)
-		slog.Warn("Falling back to environment variable for", "name", envVar.Name)
+		slog.Warn("failed to store secret", "secret_name", secretName, "error", err)
+		slog.Warn("Falling back to environment variable", "name", envVar.Name)
 		(*envVars)[envVar.Name] = value
 		slog.Debug("Added environment variable (secret fallback)", "name", envVar.Name)
 	} else {
@@ -224,9 +224,9 @@ func addAsSecret(
 		secretEntry := fmt.Sprintf("%s,target=%s", secretName, envVar.Name)
 		*secretsList = append(*secretsList, secretEntry)
 		if envVar.Required {
-			slog.Debug("Created secret for", "name", envVar.Name, "s", secretName)
+			slog.Debug("Created secret", "name", envVar.Name, "secret_name", secretName)
 		} else {
-			slog.Debug("Created secret with default value for", "name", envVar.Name, "s", secretName)
+			slog.Debug("Created secret with default value", "name", envVar.Name, "secret_name", secretName)
 		}
 	}
 }
@@ -248,7 +248,7 @@ func (v *CLIEnvVarValidator) initializeSecretsManagerIfNeeded(registryEnvVars []
 
 	secretsManager, err := v.getSecretsManager()
 	if err != nil {
-		slog.Warn("Warning: Failed to initialize secrets manager", "error", err)
+		slog.Warn("failed to initialize secrets manager", "error", err)
 		slog.Warn("Secret environment variables will be stored as regular environment variables")
 		return nil
 	}
@@ -336,9 +336,9 @@ func addAsEnvironmentVariable(
 		}
 	} else {
 		if envVar.Required {
-			slog.Debug("Added environment variable", "added_environment_variable", envVar.Name)
+			slog.Debug("Added environment variable", "name", envVar.Name)
 		} else {
-			slog.Debug("Using default value for", "name", envVar.Name, "s", value)
+			slog.Debug("Using default value", "name", envVar.Name, "default_value", value)
 		}
 	}
 }

--- a/pkg/runner/env_files.go
+++ b/pkg/runner/env_files.go
@@ -20,13 +20,13 @@ func processEnvFilesDirectory(dirPath string) (map[string]string, error) {
 	entries, err := os.ReadDir(dirPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			slog.Debug("Env files directory does not exist", "dirpath", dirPath)
+			slog.Debug("Env files directory does not exist", "dir", dirPath)
 			return make(map[string]string), nil // Return empty map, not an error
 		}
 		return nil, fmt.Errorf("failed to read env files directory %s: %w", dirPath, err)
 	}
 
-	slog.Debug("Env files directory detected, processing environment files", "dirpath", dirPath)
+	slog.Debug("Env files directory detected, processing environment files", "dir", dirPath)
 
 	allEnvVars := make(map[string]string)
 	processedCount := 0
@@ -45,7 +45,7 @@ func processEnvFilesDirectory(dirPath string) (map[string]string, error) {
 		filePath := filepath.Join(dirPath, entry.Name())
 		fileEnvVars, err := processEnvFile(filePath)
 		if err != nil {
-			slog.Warn("Failed to process env file", "name", entry.Name(), "s", err)
+			slog.Warn("Failed to process env file", "name", entry.Name(), "error", err)
 			continue
 		}
 
@@ -56,7 +56,7 @@ func processEnvFilesDirectory(dirPath string) (map[string]string, error) {
 		processedCount++
 	}
 
-	slog.Debug("Processed env files, environment variables extracted", "processedcount", processedCount, "value2", len(allEnvVars))
+	slog.Debug("Processed env files", "files_processed", processedCount, "vars_extracted", len(allEnvVars))
 	return allEnvVars, nil
 }
 
@@ -90,7 +90,7 @@ func processEnvFile(path string) (map[string]string, error) {
 	}
 
 	if len(envLines) == 0 {
-		slog.Debug("No environment variables found in", "value", filepath.Base(path))
+		slog.Debug("No environment variables found", "file", filepath.Base(path))
 		return make(map[string]string), nil
 	}
 
@@ -100,6 +100,6 @@ func processEnvFile(path string) (map[string]string, error) {
 		return nil, fmt.Errorf("failed to parse environment variables in %s: %w", filepath.Base(path), err)
 	}
 
-	slog.Debug("Extracted environment variables from", "value1", len(envVars), "value2", filepath.Base(path))
+	slog.Debug("Extracted environment variables", "count", len(envVars), "file", filepath.Base(path))
 	return envVars, nil
 }

--- a/pkg/runner/env_files_test.go
+++ b/pkg/runner/env_files_test.go
@@ -15,8 +15,6 @@ import (
 func TestProcessEnvFile(t *testing.T) {
 	t.Parallel()
 
-	// Needed to prevent a nil pointer dereference in the logger.
-
 	tests := []struct {
 		name     string
 		content  string
@@ -112,8 +110,6 @@ func TestProcessEnvFile(t *testing.T) {
 func TestProcessEnvFilesDirectory_FileFiltering(t *testing.T) {
 	t.Parallel()
 
-	// Needed to prevent a nil pointer dereference in the logger.
-
 	// Create temporary directory structure
 	tmpDir := t.TempDir()
 	envDir := filepath.Join(tmpDir, "env")
@@ -160,8 +156,6 @@ func TestProcessEnvFilesDirectory_FileFiltering(t *testing.T) {
 
 func TestProcessEnvFilesDirectory_Integration(t *testing.T) {
 	t.Parallel()
-
-	// Needed to prevent a nil pointer dereference in the logger.
 
 	tests := []struct {
 		name         string
@@ -248,8 +242,6 @@ DATABASE_URL=postgres://user:complex_password_with_symbols_!@#$@db.example.com:5
 
 func TestProcessEnvFilesDirectory_NonExistentDirectory(t *testing.T) {
 	t.Parallel()
-
-	// Needed to prevent a nil pointer dereference in the logger.
 
 	result, err := processEnvFilesDirectory("/path/that/does/not/exist")
 	assert.NoError(t, err)

--- a/pkg/runner/protocol.go
+++ b/pkg/runner/protocol.go
@@ -213,7 +213,7 @@ func addBuildEnvToTemplate(templateData *templates.TemplateData) error {
 
 	if len(resolvedEnv) > 0 {
 		templateData.BuildEnv = resolvedEnv
-		slog.Debug("Loaded build environment variable(s) (redacted for security)", "value", len(resolvedEnv))
+		slog.Debug("Loaded build environment variable(s) (redacted for security)", "count", len(resolvedEnv))
 	}
 
 	return nil
@@ -236,7 +236,7 @@ func addBuildAuthFilesToTemplate(templateData *templates.TemplateData) error {
 
 	if len(authFiles) > 0 {
 		templateData.BuildAuthFiles = authFiles
-		slog.Debug("Loaded build auth file(s)", "value", len(authFiles))
+		slog.Debug("Loaded build auth file(s)", "count", len(authFiles))
 	}
 
 	return nil
@@ -317,7 +317,7 @@ func resolveSecretsForBuildEnv(secretRefs map[string]string) (map[string]string,
 
 // addCACertToTemplate reads and validates a CA certificate, adding it to the template data.
 func addCACertToTemplate(caCertPath string, templateData *templates.TemplateData) error {
-	slog.Debug("Using custom CA certificate from", "path", caCertPath)
+	slog.Debug("Using custom CA certificate", "path", caCertPath)
 
 	// Read the CA certificate file
 	// #nosec G304 -- This is a user-provided file path that we need to read
@@ -424,7 +424,7 @@ func writeDockerfile(dockerfilePath, dockerfileContent string, isLocalPath bool)
 	if isLocalPath {
 		// Check if a Dockerfile already exists
 		if _, err := os.Stat(dockerfilePath); err == nil {
-			slog.Debug("Dockerfile already exists at , using existing Dockerfile", "dockerfilepath", dockerfilePath)
+			slog.Debug("Dockerfile already exists, using existing Dockerfile", "path", dockerfilePath)
 			return nil // Use the existing Dockerfile
 		}
 	}
@@ -437,7 +437,7 @@ func writeDockerfile(dockerfilePath, dockerfileContent string, isLocalPath bool)
 	}
 
 	if isLocalPath {
-		slog.Debug("Created temporary Dockerfile at", "dockerfilepath", dockerfilePath)
+		slog.Debug("Created temporary Dockerfile", "path", dockerfilePath)
 	}
 
 	return nil
@@ -510,7 +510,7 @@ func writeAuthFiles(buildContextDir string, authFiles map[string]string, isLocal
 		cleanupFunc = func() {
 			for _, f := range writtenFiles {
 				if err := os.Remove(f); err != nil {
-					slog.Debug("Failed to remove temporary auth file", "f", f, "s", err)
+					slog.Debug("Failed to remove temporary auth file", "path", f, "error", err)
 				}
 			}
 		}
@@ -589,8 +589,8 @@ func buildImageFromTemplateWithName(
 	}
 
 	// Log the build process
-	slog.Debug("Building Docker image for package", "transporttype", transportType, "s_package", packageName)
-	slog.Debug("Using Dockerfile:\n", "dockerfilecontent", dockerfileContent)
+	slog.Debug("Building Docker image for package", "transport_type", transportType, "package", packageName)
+	slog.Debug("Using Dockerfile", "dockerfile_content", dockerfileContent)
 
 	if err := imageManager.BuildImage(ctx, buildCtx.Dir, finalImageName); err != nil {
 		return "", fmt.Errorf("failed to build Docker image: %w", err)

--- a/pkg/runner/retriever/retriever.go
+++ b/pkg/runner/retriever/retriever.go
@@ -381,7 +381,7 @@ func hasLatestTag(imageRef string) bool {
 	ref, err := nameref.ParseReference(imageRef)
 	if err != nil {
 		// If we can't parse the reference, assume it's not "latest"
-		slog.Warn("Warning: Failed to parse image reference", "error", err)
+		slog.Warn("failed to parse image reference", "error", err)
 		return false
 	}
 


### PR DESCRIPTION
I was reviewing PR #3864 but it got merged before I could reply - a follow up PR it is then.

The initial slog migration had mechanical conversion artifacts: meaningless key names from format-string positional args, plaintext secret values logged at debug level, stale format-string remnants in messages, redundant "Warning:" prefixes on slog.Warn calls, and orphaned test comments referencing the removed logger.Initialize().