### PR TITLE
Implement OCI Build and Push for skill service

### DIFF
--- a/docs/server/docs.go
+++ b/docs/server/docs.go
@@ -4177,7 +4177,7 @@ const docTemplate = `{
                         },
                         "description": "OK"
                     },
-                    "501": {
+                    "400": {
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -4185,7 +4185,17 @@ const docTemplate = `{
                                 }
                             }
                         },
-                        "description": "Not Implemented"
+                        "description": "Bad Request"
+                    },
+                    "500": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Internal Server Error"
                     }
                 },
                 "summary": "Build a skill",
@@ -4228,7 +4238,7 @@ const docTemplate = `{
                         },
                         "description": "No Content"
                     },
-                    "501": {
+                    "400": {
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -4236,7 +4246,27 @@ const docTemplate = `{
                                 }
                             }
                         },
-                        "description": "Not Implemented"
+                        "description": "Bad Request"
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Not Found"
+                    },
+                    "500": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Internal Server Error"
                     }
                 },
                 "summary": "Push a skill",
@@ -4279,7 +4309,7 @@ const docTemplate = `{
                         },
                         "description": "OK"
                     },
-                    "501": {
+                    "400": {
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -4287,7 +4317,17 @@ const docTemplate = `{
                                 }
                             }
                         },
-                        "description": "Not Implemented"
+                        "description": "Bad Request"
+                    },
+                    "500": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Internal Server Error"
                     }
                 },
                 "summary": "Validate a skill",

--- a/docs/server/swagger.json
+++ b/docs/server/swagger.json
@@ -4170,7 +4170,7 @@
                         },
                         "description": "OK"
                     },
-                    "501": {
+                    "400": {
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -4178,7 +4178,17 @@
                                 }
                             }
                         },
-                        "description": "Not Implemented"
+                        "description": "Bad Request"
+                    },
+                    "500": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Internal Server Error"
                     }
                 },
                 "summary": "Build a skill",
@@ -4221,7 +4231,7 @@
                         },
                         "description": "No Content"
                     },
-                    "501": {
+                    "400": {
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -4229,7 +4239,27 @@
                                 }
                             }
                         },
-                        "description": "Not Implemented"
+                        "description": "Bad Request"
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Not Found"
+                    },
+                    "500": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Internal Server Error"
                     }
                 },
                 "summary": "Push a skill",
@@ -4272,7 +4302,7 @@
                         },
                         "description": "OK"
                     },
-                    "501": {
+                    "400": {
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -4280,7 +4310,17 @@
                                 }
                             }
                         },
-                        "description": "Not Implemented"
+                        "description": "Bad Request"
+                    },
+                    "500": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Internal Server Error"
                     }
                 },
                 "summary": "Validate a skill",

--- a/docs/server/swagger.yaml
+++ b/docs/server/swagger.yaml
@@ -3360,12 +3360,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/skills.BuildResult'
           description: OK
-        "501":
+        "400":
           content:
             application/json:
               schema:
                 type: string
-          description: Not Implemented
+          description: Bad Request
+        "500":
+          content:
+            application/json:
+              schema:
+                type: string
+          description: Internal Server Error
       summary: Build a skill
       tags:
       - skills
@@ -3390,12 +3396,24 @@ paths:
               schema:
                 type: string
           description: No Content
-        "501":
+        "400":
           content:
             application/json:
               schema:
                 type: string
-          description: Not Implemented
+          description: Bad Request
+        "404":
+          content:
+            application/json:
+              schema:
+                type: string
+          description: Not Found
+        "500":
+          content:
+            application/json:
+              schema:
+                type: string
+          description: Internal Server Error
       summary: Push a skill
       tags:
       - skills
@@ -3420,12 +3438,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/skills.ValidationResult'
           description: OK
-        "501":
+        "400":
           content:
             application/json:
               schema:
                 type: string
-          description: Not Implemented
+          description: Bad Request
+        "500":
+          content:
+            application/json:
+              schema:
+                type: string
+          description: Internal Server Error
       summary: Validate a skill
       tags:
       - skills

--- a/pkg/api/v1/skills_test.go
+++ b/pkg/api/v1/skills_test.go
@@ -287,35 +287,106 @@ func TestSkillsRouter(t *testing.T) {
 			},
 			expectedStatus: http.StatusNoContent,
 		},
-		// validateSkill stub
+		// validateSkill
 		{
-			name:           "validate skill returns 501",
+			name:   "validate skill success",
+			method: "POST",
+			path:   "/validate",
+			body:   `{"path":"/tmp/skill"}`,
+			setupMock: func(svc *skillsmocks.MockSkillService) {
+				svc.EXPECT().Validate(gomock.Any(), "/tmp/skill").
+					Return(&skills.ValidationResult{Valid: true}, nil)
+			},
+			expectedStatus: http.StatusOK,
+			expectedBody:   `"valid":true`,
+		},
+		{
+			name:           "validate skill bad request",
 			method:         "POST",
 			path:           "/validate",
-			body:           `{"path":"/tmp"}`,
+			body:           `{invalid`,
 			setupMock:      func(_ *skillsmocks.MockSkillService) {},
-			expectedStatus: http.StatusNotImplemented,
-			expectedBody:   "Not Implemented",
+			expectedStatus: http.StatusBadRequest,
+			expectedBody:   "invalid request body",
 		},
-		// buildSkill stub
 		{
-			name:           "build skill returns 501",
+			name:   "validate skill service error",
+			method: "POST",
+			path:   "/validate",
+			body:   `{"path":"/tmp/skill"}`,
+			setupMock: func(svc *skillsmocks.MockSkillService) {
+				svc.EXPECT().Validate(gomock.Any(), "/tmp/skill").
+					Return(nil, fmt.Errorf("validation failed"))
+			},
+			expectedStatus: http.StatusInternalServerError,
+			expectedBody:   "Internal Server Error",
+		},
+		// buildSkill
+		{
+			name:   "build skill success",
+			method: "POST",
+			path:   "/build",
+			body:   `{"path":"/tmp/skill","tag":"v1.0.0"}`,
+			setupMock: func(svc *skillsmocks.MockSkillService) {
+				svc.EXPECT().Build(gomock.Any(), skills.BuildOptions{Path: "/tmp/skill", Tag: "v1.0.0"}).
+					Return(&skills.BuildResult{Reference: "v1.0.0"}, nil)
+			},
+			expectedStatus: http.StatusOK,
+			expectedBody:   `"reference":"v1.0.0"`,
+		},
+		{
+			name:           "build skill bad request",
 			method:         "POST",
 			path:           "/build",
-			body:           `{"path":"/tmp"}`,
+			body:           `{invalid`,
 			setupMock:      func(_ *skillsmocks.MockSkillService) {},
-			expectedStatus: http.StatusNotImplemented,
-			expectedBody:   "Not Implemented",
+			expectedStatus: http.StatusBadRequest,
+			expectedBody:   "invalid request body",
 		},
-		// pushSkill stub
 		{
-			name:           "push skill returns 501",
+			name:   "build skill service error",
+			method: "POST",
+			path:   "/build",
+			body:   `{"path":"/tmp/skill"}`,
+			setupMock: func(svc *skillsmocks.MockSkillService) {
+				svc.EXPECT().Build(gomock.Any(), skills.BuildOptions{Path: "/tmp/skill"}).
+					Return(nil, httperr.WithCode(fmt.Errorf("path is required"), http.StatusBadRequest))
+			},
+			expectedStatus: http.StatusBadRequest,
+			expectedBody:   "path is required",
+		},
+		// pushSkill
+		{
+			name:   "push skill success",
+			method: "POST",
+			path:   "/push",
+			body:   `{"reference":"ghcr.io/test/skill:v1"}`,
+			setupMock: func(svc *skillsmocks.MockSkillService) {
+				svc.EXPECT().Push(gomock.Any(), skills.PushOptions{Reference: "ghcr.io/test/skill:v1"}).
+					Return(nil)
+			},
+			expectedStatus: http.StatusNoContent,
+		},
+		{
+			name:           "push skill bad request",
 			method:         "POST",
 			path:           "/push",
-			body:           `{"reference":"ghcr.io/test/skill:v1"}`,
+			body:           `{invalid`,
 			setupMock:      func(_ *skillsmocks.MockSkillService) {},
-			expectedStatus: http.StatusNotImplemented,
-			expectedBody:   "Not Implemented",
+			expectedStatus: http.StatusBadRequest,
+			expectedBody:   "invalid request body",
+		},
+		{
+			name:   "push skill service error",
+			method: "POST",
+			path:   "/push",
+			body:   `{"reference":"ghcr.io/test/skill:v1"}`,
+			setupMock: func(svc *skillsmocks.MockSkillService) {
+				svc.EXPECT().Push(gomock.Any(), skills.PushOptions{Reference: "ghcr.io/test/skill:v1"}).
+					Return(fmt.Errorf("push failed"))
+			},
+			expectedStatus: http.StatusInternalServerError,
+			expectedBody:   "Internal Server Error",
 		},
 	}
 

--- a/pkg/api/v1/skills_types.go
+++ b/pkg/api/v1/skills_types.go
@@ -40,8 +40,6 @@ type installSkillResponse struct {
 // validateSkillRequest represents the request to validate a skill.
 //
 //	@Description	Request to validate a skill definition
-//
-//nolint:unused // stub type for swagger annotations, used when handlers are implemented
 type validateSkillRequest struct {
 	// Path to the skill definition directory
 	Path string `json:"path"`
@@ -50,8 +48,6 @@ type validateSkillRequest struct {
 // buildSkillRequest represents the request to build a skill.
 //
 //	@Description	Request to build a skill from a local directory
-//
-//nolint:unused // stub type for swagger annotations, used when handlers are implemented
 type buildSkillRequest struct {
 	// Path to the skill definition directory
 	Path string `json:"path"`
@@ -62,8 +58,6 @@ type buildSkillRequest struct {
 // pushSkillRequest represents the request to push a skill.
 //
 //	@Description	Request to push a built skill artifact
-//
-//nolint:unused // stub type for swagger annotations, used when handlers are implemented
 type pushSkillRequest struct {
 	// OCI reference to push
 	Reference string `json:"reference"`

--- a/pkg/skills/skillsvc/skillsvc_test.go
+++ b/pkg/skills/skillsvc/skillsvc_test.go
@@ -14,12 +14,14 @@ import (
 	"testing"
 	"time"
 
+	godigest "github.com/opencontainers/go-digest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
 	"github.com/stacklok/toolhive-core/httperr"
 	ociskills "github.com/stacklok/toolhive-core/oci/skills"
+	ocimocks "github.com/stacklok/toolhive-core/oci/skills/mocks"
 	"github.com/stacklok/toolhive/pkg/skills"
 	skillsmocks "github.com/stacklok/toolhive/pkg/skills/mocks"
 	"github.com/stacklok/toolhive/pkg/storage"
@@ -696,25 +698,296 @@ func TestValidate(t *testing.T) {
 		assert.False(t, result.Valid)
 		assert.Contains(t, result.Errors, "SKILL.md not found in skill directory")
 	})
+
+	t.Run("empty path returns 400", func(t *testing.T) {
+		t.Parallel()
+		svc := New(&storage.NoopSkillStore{})
+		_, err := svc.Validate(t.Context(), "")
+		require.Error(t, err)
+		assert.Equal(t, http.StatusBadRequest, httperr.Code(err))
+	})
+
+	t.Run("relative path returns 400", func(t *testing.T) {
+		t.Parallel()
+		svc := New(&storage.NoopSkillStore{})
+		_, err := svc.Validate(t.Context(), "relative/path")
+		require.Error(t, err)
+		assert.Equal(t, http.StatusBadRequest, httperr.Code(err))
+	})
+
+	t.Run("path traversal returns 400", func(t *testing.T) {
+		t.Parallel()
+		svc := New(&storage.NoopSkillStore{})
+		_, err := svc.Validate(t.Context(), "/foo/../../../etc")
+		require.Error(t, err)
+		assert.Equal(t, http.StatusBadRequest, httperr.Code(err))
+	})
 }
 
-func TestBuildAndPush_NotImplemented(t *testing.T) {
+// putTestManifest stores a minimal manifest in the OCI store and returns its digest.
+func putTestManifest(t *testing.T, store *ociskills.Store) godigest.Digest {
+	t.Helper()
+	d, err := store.PutManifest(t.Context(), []byte(`{"schemaVersion":2}`))
+	require.NoError(t, err)
+	return d
+}
+
+func TestBuild(t *testing.T) {
 	t.Parallel()
-	svc := New(&storage.NoopSkillStore{})
 
-	t.Run("build", func(t *testing.T) {
-		t.Parallel()
-		_, err := svc.Build(t.Context(), skills.BuildOptions{})
-		require.Error(t, err)
-		assert.Equal(t, http.StatusNotImplemented, httperr.Code(err))
-	})
+	tests := []struct {
+		name     string
+		opts     skills.BuildOptions
+		setup    func(*gomock.Controller) (ociskills.SkillPackager, *ociskills.Store)
+		wantCode int
+		wantRef  string
+		wantErr  string
+	}{
+		{
+			name: "nil packager returns 500",
+			opts: skills.BuildOptions{Path: "/some/dir"},
+			setup: func(_ *gomock.Controller) (ociskills.SkillPackager, *ociskills.Store) {
+				return nil, nil
+			},
+			wantCode: http.StatusInternalServerError,
+		},
+		{
+			name: "empty path returns 400",
+			opts: skills.BuildOptions{Path: ""},
+			setup: func(ctrl *gomock.Controller) (ociskills.SkillPackager, *ociskills.Store) {
+				ociStore, err := ociskills.NewStore(t.TempDir())
+				require.NoError(t, err)
+				return ocimocks.NewMockSkillPackager(ctrl), ociStore
+			},
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name: "relative path returns 400",
+			opts: skills.BuildOptions{Path: "relative/path"},
+			setup: func(ctrl *gomock.Controller) (ociskills.SkillPackager, *ociskills.Store) {
+				ociStore, err := ociskills.NewStore(t.TempDir())
+				require.NoError(t, err)
+				return ocimocks.NewMockSkillPackager(ctrl), ociStore
+			},
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name: "path traversal returns 400",
+			opts: skills.BuildOptions{Path: "/some/dir/../../../etc"},
+			setup: func(ctrl *gomock.Controller) (ociskills.SkillPackager, *ociskills.Store) {
+				ociStore, err := ociskills.NewStore(t.TempDir())
+				require.NoError(t, err)
+				return ocimocks.NewMockSkillPackager(ctrl), ociStore
+			},
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name: "invalid tag returns 400",
+			opts: skills.BuildOptions{Path: "/some/dir", Tag: "invalid tag!@#"},
+			setup: func(ctrl *gomock.Controller) (ociskills.SkillPackager, *ociskills.Store) {
+				ociStore, err := ociskills.NewStore(t.TempDir())
+				require.NoError(t, err)
+				return ocimocks.NewMockSkillPackager(ctrl), ociStore
+			},
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name: "packager error propagates",
+			opts: skills.BuildOptions{Path: "/some/dir"},
+			setup: func(ctrl *gomock.Controller) (ociskills.SkillPackager, *ociskills.Store) {
+				ociStore, err := ociskills.NewStore(t.TempDir())
+				require.NoError(t, err)
+				p := ocimocks.NewMockSkillPackager(ctrl)
+				p.EXPECT().Package(gomock.Any(), "/some/dir", gomock.Any()).
+					Return(nil, fmt.Errorf("packaging failed"))
+				return p, ociStore
+			},
+			wantErr: "packaging skill",
+		},
+		{
+			name: "successful build with explicit tag",
+			opts: skills.BuildOptions{Path: "/some/dir", Tag: "v1.0.0"},
+			setup: func(ctrl *gomock.Controller) (ociskills.SkillPackager, *ociskills.Store) {
+				ociStore, err := ociskills.NewStore(t.TempDir())
+				require.NoError(t, err)
+				d := putTestManifest(t, ociStore)
+				p := ocimocks.NewMockSkillPackager(ctrl)
+				p.EXPECT().Package(gomock.Any(), "/some/dir", gomock.Any()).
+					Return(&ociskills.PackageResult{
+						IndexDigest: d,
+						Config:      &ociskills.SkillConfig{Name: "my-skill"},
+					}, nil)
+				return p, ociStore
+			},
+			wantRef: "v1.0.0",
+		},
+		{
+			name: "build without tag uses config name",
+			opts: skills.BuildOptions{Path: "/some/dir"},
+			setup: func(ctrl *gomock.Controller) (ociskills.SkillPackager, *ociskills.Store) {
+				ociStore, err := ociskills.NewStore(t.TempDir())
+				require.NoError(t, err)
+				d := putTestManifest(t, ociStore)
+				p := ocimocks.NewMockSkillPackager(ctrl)
+				p.EXPECT().Package(gomock.Any(), "/some/dir", gomock.Any()).
+					Return(&ociskills.PackageResult{
+						IndexDigest: d,
+						Config:      &ociskills.SkillConfig{Name: "my-skill"},
+					}, nil)
+				return p, ociStore
+			},
+			wantRef: "my-skill",
+		},
+		{
+			name: "build without tag or config name returns digest",
+			opts: skills.BuildOptions{Path: "/some/dir"},
+			setup: func(ctrl *gomock.Controller) (ociskills.SkillPackager, *ociskills.Store) {
+				ociStore, err := ociskills.NewStore(t.TempDir())
+				require.NoError(t, err)
+				d := putTestManifest(t, ociStore)
+				p := ocimocks.NewMockSkillPackager(ctrl)
+				p.EXPECT().Package(gomock.Any(), "/some/dir", gomock.Any()).
+					Return(&ociskills.PackageResult{
+						IndexDigest: d,
+						Config:      &ociskills.SkillConfig{},
+					}, nil)
+				return p, ociStore
+			},
+			// wantRef is set dynamically below since the digest depends on store content
+		},
+	}
 
-	t.Run("push", func(t *testing.T) {
-		t.Parallel()
-		err := svc.Push(t.Context(), skills.PushOptions{})
-		require.Error(t, err)
-		assert.Equal(t, http.StatusNotImplemented, httperr.Code(err))
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			packager, ociStore := tt.setup(ctrl)
+
+			svc := New(&storage.NoopSkillStore{},
+				WithPackager(packager),
+				WithOCIStore(ociStore),
+			)
+
+			result, err := svc.Build(t.Context(), tt.opts)
+			if tt.wantCode != 0 {
+				require.Error(t, err)
+				assert.Equal(t, tt.wantCode, httperr.Code(err))
+				return
+			}
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			if tt.wantRef != "" {
+				assert.Equal(t, tt.wantRef, result.Reference)
+			} else {
+				// Fallback case returns a digest string
+				assert.Contains(t, result.Reference, "sha256:")
+			}
+		})
+	}
+}
+
+func TestPush(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		opts     skills.PushOptions
+		setup    func(*gomock.Controller) (ociskills.RegistryClient, *ociskills.Store)
+		wantCode int
+		wantErr  string
+	}{
+		{
+			name: "nil registry returns 500",
+			opts: skills.PushOptions{Reference: "ghcr.io/test/skill:v1"},
+			setup: func(_ *gomock.Controller) (ociskills.RegistryClient, *ociskills.Store) {
+				return nil, nil
+			},
+			wantCode: http.StatusInternalServerError,
+		},
+		{
+			name: "empty reference returns 400",
+			opts: skills.PushOptions{Reference: ""},
+			setup: func(ctrl *gomock.Controller) (ociskills.RegistryClient, *ociskills.Store) {
+				ociStore, err := ociskills.NewStore(t.TempDir())
+				require.NoError(t, err)
+				return ocimocks.NewMockRegistryClient(ctrl), ociStore
+			},
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name: "resolve not found returns 404",
+			opts: skills.PushOptions{Reference: "nonexistent"},
+			setup: func(ctrl *gomock.Controller) (ociskills.RegistryClient, *ociskills.Store) {
+				ociStore, err := ociskills.NewStore(t.TempDir())
+				require.NoError(t, err)
+				return ocimocks.NewMockRegistryClient(ctrl), ociStore
+			},
+			wantCode: http.StatusNotFound,
+		},
+		{
+			name: "registry push error propagates",
+			opts: skills.PushOptions{Reference: "my-tag"},
+			setup: func(ctrl *gomock.Controller) (ociskills.RegistryClient, *ociskills.Store) {
+				ociStore, err := ociskills.NewStore(t.TempDir())
+				require.NoError(t, err)
+				// Create a manifest so Resolve succeeds.
+				d, tagErr := ociStore.PutManifest(t.Context(), []byte(`{"schemaVersion":2}`))
+				require.NoError(t, tagErr)
+				require.NoError(t, ociStore.Tag(t.Context(), d, "my-tag"))
+
+				reg := ocimocks.NewMockRegistryClient(ctrl)
+				reg.EXPECT().Push(gomock.Any(), ociStore, d, "my-tag").
+					Return(fmt.Errorf("auth failed"))
+				return reg, ociStore
+			},
+			wantErr: "pushing to registry",
+		},
+		{
+			name: "successful push",
+			opts: skills.PushOptions{Reference: "my-tag"},
+			setup: func(ctrl *gomock.Controller) (ociskills.RegistryClient, *ociskills.Store) {
+				ociStore, err := ociskills.NewStore(t.TempDir())
+				require.NoError(t, err)
+				d, tagErr := ociStore.PutManifest(t.Context(), []byte(`{"schemaVersion":2}`))
+				require.NoError(t, tagErr)
+				require.NoError(t, ociStore.Tag(t.Context(), d, "my-tag"))
+
+				reg := ocimocks.NewMockRegistryClient(ctrl)
+				reg.EXPECT().Push(gomock.Any(), ociStore, d, "my-tag").Return(nil)
+				return reg, ociStore
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			registry, ociStore := tt.setup(ctrl)
+
+			svc := New(&storage.NoopSkillStore{},
+				WithRegistryClient(registry),
+				WithOCIStore(ociStore),
+			)
+
+			err := svc.Push(t.Context(), tt.opts)
+			if tt.wantCode != 0 {
+				require.Error(t, err)
+				assert.Equal(t, tt.wantCode, httperr.Code(err))
+				return
+			}
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
 }
 
 func TestNewWithZeroOptions(t *testing.T) {


### PR DESCRIPTION
## Summary

This is **Part 1 of #3650** (Complete Skill Service OCI Operations), which adds the ability to package skills into OCI artifacts and push them to registries via the `thv serve` REST API.

### Background

The skill service (`pkg/skills/skillsvc/`) already handles listing, installing (extraction-based), uninstalling, and querying skills. However, the `Build`, `Push`, and `Validate` operations were stubbed out as 501 Not Implemented. The OCI primitives needed to implement them — `Store`, `SkillPackager`, and `RegistryClient` — are already available in `toolhive-core` (v0.0.5), but were not wired into the service.

### What this PR does

**Service layer (`skillsvc.go`):** Adds three new functional options (`WithOCIStore`, `WithPackager`, `WithRegistryClient`) to inject OCI dependencies into the skill service. Implements `Build()` which validates the skill path, calls the packager to create a local OCI artifact, tags it in the local store, and returns a reference. Implements `Push()` which resolves a local reference and pushes the artifact to a remote registry. Updates `Validate()` to delegate to `ValidateSkillDir` after path validation.

**Server wiring (`server.go`):** In the default manager creation path, initializes the OCI store (at `DefaultStoreRoot()`), registry client, and packager, and passes them to the skill service constructor.

**HTTP handlers (`skills.go`):** Replaces the three 501 stub handlers with real implementations that decode JSON requests, delegate to the service, and encode responses. Updates Swagger annotations accordingly.

### Security hardening

A code review identified several issues that are addressed in this PR:

- **Path traversal (HIGH):** `Build` and `Validate` accept a filesystem path from the API. Added `validateLocalPath()` which rejects empty paths, relative paths, and paths containing `..` traversal segments. The check operates on the raw path before `filepath.Clean` to catch traversal attempts that Clean would silently resolve.
- **OCI tag injection (MEDIUM):** Added `validateOCITag()` which enforces the OCI distribution spec tag format (`^[\w][\w.-]{0,127}$`) before writing to the local store.
- **Error information leakage (MEDIUM):** The `Push` 404 path previously wrapped the internal store error, which could expose filesystem paths. Changed to return a generic "reference not found" message without wrapping the underlying error.

### What comes next (Part 2)

Part 2 will add OCI pull-based Install — when `Install()` receives a registry reference but no layer data, it will pull the artifact from the registry, extract the layer, and hand off to the existing extraction path. It builds on the `ociStore` and `registry` fields added here.

## Test plan

- [x] `TestBuild` — 10 table-driven cases covering nil packager, empty/relative/traversal paths, invalid tag, packager error, successful build with explicit tag, build falling back to config name, and build returning digest reference
- [x] `TestPush` — 5 table-driven cases covering nil registry, empty reference, resolve-not-found, registry push error, and successful push
- [x] `TestValidate` — extended with path validation cases (empty, relative, traversal)
- [x] Handler tests for validate/build/push — success, bad request, and service error for each
- [x] `task test` — all unit tests pass
- [x] `task lint` — 0 issues
- [x] `task docs` — swagger docs regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)