### PR TITLE
Validate OCI tags from all sources in Build (follow up to 3894)

### DIFF
--- a/pkg/skills/skillsvc/skillsvc_test.go
+++ b/pkg/skills/skillsvc/skillsvc_test.go
@@ -787,7 +787,14 @@ func TestBuild(t *testing.T) {
 			setup: func(ctrl *gomock.Controller) (ociskills.SkillPackager, *ociskills.Store) {
 				ociStore, err := ociskills.NewStore(t.TempDir())
 				require.NoError(t, err)
-				return ocimocks.NewMockSkillPackager(ctrl), ociStore
+				d := putTestManifest(t, ociStore)
+				p := ocimocks.NewMockSkillPackager(ctrl)
+				p.EXPECT().Package(gomock.Any(), "/some/dir", gomock.Any()).
+					Return(&ociskills.PackageResult{
+						IndexDigest: d,
+						Config:      &ociskills.SkillConfig{},
+					}, nil)
+				return p, ociStore
 			},
 			wantCode: http.StatusBadRequest,
 		},
@@ -854,6 +861,23 @@ func TestBuild(t *testing.T) {
 				return p, ociStore
 			},
 			// wantRef is set dynamically below since the digest depends on store content
+		},
+		{
+			name: "invalid fallback config name returns 400",
+			opts: skills.BuildOptions{Path: "/some/dir"},
+			setup: func(ctrl *gomock.Controller) (ociskills.SkillPackager, *ociskills.Store) {
+				ociStore, err := ociskills.NewStore(t.TempDir())
+				require.NoError(t, err)
+				d := putTestManifest(t, ociStore)
+				p := ocimocks.NewMockSkillPackager(ctrl)
+				p.EXPECT().Package(gomock.Any(), "/some/dir", gomock.Any()).
+					Return(&ociskills.PackageResult{
+						IndexDigest: d,
+						Config:      &ociskills.SkillConfig{Name: "invalid name!@#"},
+					}, nil)
+				return p, ociStore
+			},
+			wantCode: http.StatusBadRequest,
 		},
 	}
 


### PR DESCRIPTION
I was Johnny-came-late again for #3894 so I'm sending my comments as a follow-up.

Move tag validation after tag computation so both explicit user-provided tags and config-name fallback tags are validated against the OCI distribution spec. Previously only the explicit opts.Tag was checked, leaving the config name path unvalidated.

Also add debug logging for Push Resolve failures to aid diagnostics without leaking internal paths to API clients.