### PR TITLE
Address PR review feedback on vmcp/session

### DIFF
--- a/pkg/vmcp/session/admission.go
+++ b/pkg/vmcp/session/admission.go
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package session
+
+import "sync"
+
+// AdmissionQueue controls admission of concurrent requests to a shared
+// resource that can be closed. Once closed, no further requests are admitted
+// and CloseAndDrain blocks until all previously-admitted requests complete.
+type AdmissionQueue interface {
+	// TryAdmit attempts to admit a request. If the queue is open, it returns
+	// (true, done) where done must be called when the request completes.
+	// If the queue is already closed, it returns (false, nil).
+	TryAdmit() (bool, func())
+
+	// CloseAndDrain closes the queue so that subsequent TryAdmit calls return
+	// false, then blocks until all currently-admitted requests have called
+	// their done function. Idempotent.
+	CloseAndDrain()
+}
+
+// admissionQueue is the production AdmissionQueue implementation.
+// It uses a read-write mutex to protect the closed flag and an
+// atomic-counter wait group to track in-flight requests.
+//
+// Invariant: wg.Add(1) is always called while mu is read-locked,
+// so CloseAndDrain() cannot observe a zero wait-group count between
+// a caller's closed-check and its wg.Add.
+type admissionQueue struct {
+	mu     sync.RWMutex
+	wg     sync.WaitGroup
+	closed bool
+}
+
+// Compile-time assertion: admissionQueue must implement AdmissionQueue.
+var _ AdmissionQueue = (*admissionQueue)(nil)
+
+func newAdmissionQueue() AdmissionQueue {
+	return &admissionQueue{}
+}
+
+func (q *admissionQueue) TryAdmit() (bool, func()) {
+	q.mu.RLock()
+	if q.closed {
+		q.mu.RUnlock()
+		return false, nil
+	}
+	q.wg.Add(1)
+	q.mu.RUnlock()
+	return true, q.wg.Done
+}
+
+func (q *admissionQueue) CloseAndDrain() {
+	q.mu.Lock()
+	if q.closed {
+		q.mu.Unlock()
+		return
+	}
+	q.closed = true
+	q.mu.Unlock()
+	q.wg.Wait()
+}

--- a/pkg/vmcp/session/admission_test.go
+++ b/pkg/vmcp/session/admission_test.go
@@ -1,0 +1,174 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package session
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAdmissionQueue_TryAdmit_Open(t *testing.T) {
+	t.Parallel()
+
+	q := newAdmissionQueue()
+	admitted, done := q.TryAdmit()
+	require.True(t, admitted, "TryAdmit should return true when queue is open")
+	require.NotNil(t, done, "done func must not be nil when admitted")
+	done() // must not panic
+}
+
+func TestAdmissionQueue_TryAdmit_AfterClose(t *testing.T) {
+	t.Parallel()
+
+	q := newAdmissionQueue()
+	q.CloseAndDrain()
+
+	admitted, done := q.TryAdmit()
+	assert.False(t, admitted, "TryAdmit should return false after CloseAndDrain")
+	assert.Nil(t, done, "done func must be nil when not admitted")
+}
+
+func TestAdmissionQueue_CloseAndDrain_Idempotent(t *testing.T) {
+	t.Parallel()
+
+	q := newAdmissionQueue()
+	// Multiple calls must not panic or deadlock.
+	q.CloseAndDrain()
+	q.CloseAndDrain()
+	q.CloseAndDrain()
+}
+
+func TestAdmissionQueue_CloseAndDrain_BlocksUntilDone(t *testing.T) {
+	t.Parallel()
+
+	q := newAdmissionQueue()
+
+	admitted, done := q.TryAdmit()
+	require.True(t, admitted)
+	require.NotNil(t, done)
+
+	drainDone := make(chan struct{})
+	go func() {
+		q.CloseAndDrain()
+		close(drainDone)
+	}()
+
+	// CloseAndDrain must not return before done is called.
+	select {
+	case <-drainDone:
+		t.Fatal("CloseAndDrain returned before in-flight request completed")
+	case <-time.After(50 * time.Millisecond):
+		// Expected: drain is blocking.
+	}
+
+	done() // release the in-flight request
+	select {
+	case <-drainDone:
+		// Expected: drain unblocked after done().
+	case <-time.After(time.Second):
+		t.Fatal("CloseAndDrain did not return after done() was called")
+	}
+}
+
+func TestAdmissionQueue_MultipleRequests_AllMustComplete(t *testing.T) {
+	t.Parallel()
+
+	const numRequests = 10
+	q := newAdmissionQueue()
+
+	doneFuncs := make([]func(), 0, numRequests)
+	for i := range numRequests {
+		admitted, done := q.TryAdmit()
+		require.Truef(t, admitted, "request %d should be admitted", i)
+		require.NotNilf(t, done, "done func for request %d must not be nil", i)
+		doneFuncs = append(doneFuncs, done)
+	}
+
+	drainDone := make(chan struct{})
+	go func() {
+		q.CloseAndDrain()
+		close(drainDone)
+	}()
+
+	// CloseAndDrain must not return until all done funcs are called.
+	select {
+	case <-drainDone:
+		t.Fatal("CloseAndDrain returned before all in-flight requests completed")
+	case <-time.After(50 * time.Millisecond):
+		// Expected: drain is still blocking.
+	}
+
+	// Release all in-flight requests one by one.
+	for _, done := range doneFuncs {
+		done()
+	}
+
+	select {
+	case <-drainDone:
+		// Expected.
+	case <-time.After(time.Second):
+		t.Fatal("CloseAndDrain did not return after all done() calls")
+	}
+}
+
+func TestAdmissionQueue_ConcurrentTryAdmitAndClose_NoRaces(t *testing.T) {
+	t.Parallel()
+
+	const goroutines = 50
+	q := newAdmissionQueue()
+
+	var wg sync.WaitGroup
+	var admitted atomic.Int64
+
+	// Start goroutines that call TryAdmit concurrently.
+	wg.Add(goroutines)
+	for range goroutines {
+		go func() {
+			defer wg.Done()
+			ok, done := q.TryAdmit()
+			if ok {
+				admitted.Add(1)
+				// Simulate a brief in-flight operation.
+				time.Sleep(time.Millisecond)
+				done()
+			}
+		}()
+	}
+
+	// Let some goroutines get admitted before closing.
+	time.Sleep(5 * time.Millisecond)
+	q.CloseAndDrain()
+
+	// All goroutines must have finished (drain waited for them).
+	wg.Wait()
+
+	// Calls after close must always return false.
+	ok, done := q.TryAdmit()
+	assert.False(t, ok)
+	assert.Nil(t, done)
+}
+
+func TestAdmissionQueue_DoneCalledAfterDrainReturns_NoPanic(t *testing.T) {
+	t.Parallel()
+
+	// Admit a request, then let done() be called before CloseAndDrain runs so
+	// that drain sees a zero wait-group and returns immediately — no panic, no block.
+	q := newAdmissionQueue()
+	admitted, done := q.TryAdmit()
+	require.True(t, admitted)
+
+	doneReleased := make(chan struct{})
+	go func() {
+		done() // release before drain starts
+		close(doneReleased)
+	}()
+
+	<-doneReleased    // ensure done() has been called
+	q.CloseAndDrain() // wg is already zero — must return immediately without panic
+}

--- a/pkg/vmcp/session/default_session_test.go
+++ b/pkg/vmcp/session/default_session_test.go
@@ -104,6 +104,7 @@ func buildTestSession(
 		resources:       resources,
 		prompts:         prompts,
 		backendSessions: map[string]string{backendID: "backend-session-abc"},
+		queue:           newAdmissionQueue(),
 	}
 }
 
@@ -451,6 +452,7 @@ func TestDefaultSession_ErrNoBackendClient(t *testing.T) {
 		resources:       []vmcp.Resource{{URI: "file://readme", BackendID: "b1"}},
 		prompts:         []vmcp.Prompt{{Name: "greet", BackendID: "b1"}},
 		backendSessions: map[string]string{},
+		queue:           newAdmissionQueue(),
 	}
 	defer func() { _ = sess.Close() }()
 
@@ -484,6 +486,7 @@ func TestDefaultSession_Close_AllBackendsAttemptedOnError(t *testing.T) {
 			Prompts:   map[string]*vmcp.BackendTarget{},
 		},
 		backendSessions: map[string]string{},
+		queue:           newAdmissionQueue(),
 	}
 
 	err := sess.Close()

--- a/pkg/vmcp/session/factory.go
+++ b/pkg/vmcp/session/factory.go
@@ -292,5 +292,6 @@ func (f *defaultMultiSessionFactory) MakeSession(
 		resources:       allResources,
 		prompts:         allPrompts,
 		backendSessions: backendSessions,
+		queue:           newAdmissionQueue(),
 	}, nil
 }

--- a/pkg/vmcp/session/internal/backend/roundtripper_test.go
+++ b/pkg/vmcp/session/internal/backend/roundtripper_test.go
@@ -1,0 +1,248 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package backend
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/stacklok/toolhive/pkg/auth"
+	"github.com/stacklok/toolhive/pkg/vmcp"
+	authmocks "github.com/stacklok/toolhive/pkg/vmcp/auth/mocks"
+	authtypes "github.com/stacklok/toolhive/pkg/vmcp/auth/types"
+)
+
+// okTransport is a minimal RoundTripper that records the received request and
+// returns a 200 OK with an empty body.
+type okTransport struct {
+	received *http.Request
+}
+
+func (t *okTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	t.received = req
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(nil),
+	}, nil
+}
+
+// newTestRequest creates a GET request to a fixed URL using the provided context.
+func newTestRequest(ctx context.Context, t *testing.T) *http.Request {
+	t.Helper()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://backend.example.com/mcp", nil)
+	require.NoError(t, err)
+	return req
+}
+
+// ---------------------------------------------------------------------------
+// httpRoundTripperFunc
+// ---------------------------------------------------------------------------
+
+func TestHTTPRoundTripperFunc_DelegatesToWrappedFunction(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	wantResp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(nil)}
+
+	rt := httpRoundTripperFunc(func(_ *http.Request) (*http.Response, error) {
+		called = true
+		return wantResp, nil
+	})
+
+	req := newTestRequest(context.Background(), t)
+	resp, err := rt.RoundTrip(req)
+
+	require.NoError(t, err)
+	assert.True(t, called, "wrapped function was not called")
+	assert.Same(t, wantResp, resp)
+}
+
+func TestHTTPRoundTripperFunc_PropagatesError(t *testing.T) {
+	t.Parallel()
+
+	wantErr := errors.New("transport error")
+	rt := httpRoundTripperFunc(func(_ *http.Request) (*http.Response, error) {
+		return nil, wantErr
+	})
+
+	req := newTestRequest(context.Background(), t)
+	resp, err := rt.RoundTrip(req)
+
+	require.ErrorIs(t, err, wantErr)
+	assert.Nil(t, resp)
+}
+
+// ---------------------------------------------------------------------------
+// authRoundTripper
+// ---------------------------------------------------------------------------
+
+func TestAuthRoundTripper_SuccessfulAuth_ForwardsRequestToBase(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	mockStrat := authmocks.NewMockStrategy(ctrl)
+
+	authConfig := &authtypes.BackendAuthStrategy{Type: authtypes.StrategyTypeUnauthenticated}
+	target := &vmcp.BackendTarget{WorkloadID: "backend-a"}
+
+	base := &okTransport{}
+	rt := &authRoundTripper{
+		base:         base,
+		authStrategy: mockStrat,
+		authConfig:   authConfig,
+		target:       target,
+	}
+
+	req := newTestRequest(context.Background(), t)
+	mockStrat.EXPECT().Authenticate(gomock.Any(), gomock.Any(), authConfig).Return(nil)
+
+	resp, err := rt.RoundTrip(req)
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// The request forwarded to base must be a clone, not the original.
+	require.NotNil(t, base.received)
+	assert.NotSame(t, req, base.received, "base received the original request, expected a clone")
+}
+
+func TestAuthRoundTripper_AuthFailure_ReturnsErrorAndSkipsBase(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	mockStrat := authmocks.NewMockStrategy(ctrl)
+
+	authConfig := &authtypes.BackendAuthStrategy{Type: authtypes.StrategyTypeUnauthenticated}
+	target := &vmcp.BackendTarget{WorkloadID: "backend-b"}
+
+	baseCalled := false
+	base := httpRoundTripperFunc(func(_ *http.Request) (*http.Response, error) {
+		baseCalled = true
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(nil)}, nil
+	})
+
+	authErr := errors.New("token expired")
+	mockStrat.EXPECT().Authenticate(gomock.Any(), gomock.Any(), authConfig).Return(authErr)
+
+	rt := &authRoundTripper{
+		base:         base,
+		authStrategy: mockStrat,
+		authConfig:   authConfig,
+		target:       target,
+	}
+
+	req := newTestRequest(context.Background(), t)
+	resp, err := rt.RoundTrip(req)
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.False(t, baseCalled, "base transport should not be called when auth fails")
+
+	// Error must mention the backend ID so operators can identify the failure.
+	assert.ErrorContains(t, err, "backend-b")
+	assert.ErrorContains(t, err, "token expired")
+}
+
+func TestAuthRoundTripper_AuthStrategyReceivesClonedRequest(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	mockStrat := authmocks.NewMockStrategy(ctrl)
+
+	target := &vmcp.BackendTarget{WorkloadID: "backend-c"}
+	authConfig := &authtypes.BackendAuthStrategy{Type: authtypes.StrategyTypeUnauthenticated}
+
+	var strategyReq *http.Request
+	mockStrat.EXPECT().
+		Authenticate(gomock.Any(), gomock.Any(), authConfig).
+		DoAndReturn(func(_ context.Context, req *http.Request, _ *authtypes.BackendAuthStrategy) error {
+			strategyReq = req
+			return nil
+		})
+
+	base := &okTransport{}
+	rt := &authRoundTripper{
+		base:         base,
+		authStrategy: mockStrat,
+		authConfig:   authConfig,
+		target:       target,
+	}
+
+	orig := newTestRequest(context.Background(), t)
+	_, err := rt.RoundTrip(orig)
+	require.NoError(t, err)
+
+	// Strategy must receive the cloned request, not the original.
+	require.NotNil(t, strategyReq)
+	assert.NotSame(t, orig, strategyReq, "strategy received the original request, expected a clone")
+}
+
+// ---------------------------------------------------------------------------
+// identityRoundTripper
+// ---------------------------------------------------------------------------
+
+func TestIdentityRoundTripper_WithIdentity_PropagatesIdentityInContext(t *testing.T) {
+	t.Parallel()
+
+	identity := &auth.Identity{Subject: "user-42"}
+	base := &okTransport{}
+	rt := &identityRoundTripper{base: base, identity: identity}
+
+	orig := newTestRequest(context.Background(), t)
+	resp, err := rt.RoundTrip(orig)
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Downstream request must carry the identity in its context.
+	require.NotNil(t, base.received)
+	got, ok := auth.IdentityFromContext(base.received.Context())
+	require.True(t, ok, "identity not found in downstream request context")
+	assert.Equal(t, "user-42", got.Subject)
+
+	// Original request context must be unmodified.
+	_, origOk := auth.IdentityFromContext(orig.Context())
+	assert.False(t, origOk, "original request context was mutated")
+}
+
+func TestIdentityRoundTripper_NilIdentity_ContextUnchanged(t *testing.T) {
+	t.Parallel()
+
+	base := &okTransport{}
+	rt := &identityRoundTripper{base: base, identity: nil}
+
+	orig := newTestRequest(context.Background(), t)
+	resp, err := rt.RoundTrip(orig)
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// No identity should be present in the downstream context.
+	require.NotNil(t, base.received)
+	_, ok := auth.IdentityFromContext(base.received.Context())
+	assert.False(t, ok, "identity unexpectedly found in context when nil identity was configured")
+}
+
+func TestIdentityRoundTripper_WithIdentity_ClonesRequest(t *testing.T) {
+	t.Parallel()
+
+	identity := &auth.Identity{Subject: "user-99"}
+	base := &okTransport{}
+	rt := &identityRoundTripper{base: base, identity: identity}
+
+	orig := newTestRequest(context.Background(), t)
+	_, err := rt.RoundTrip(orig)
+	require.NoError(t, err)
+
+	// A non-nil identity must cause the request to be cloned.
+	require.NotNil(t, base.received)
+	assert.NotSame(t, orig, base.received, "non-nil identity should clone the request")
+}

--- a/pkg/vmcp/session/internal/backend/session.go
+++ b/pkg/vmcp/session/internal/backend/session.go
@@ -7,9 +7,7 @@
 package backend
 
 import (
-	"context"
-
-	"github.com/stacklok/toolhive/pkg/vmcp"
+	sessiontypes "github.com/stacklok/toolhive/pkg/vmcp/session/types"
 )
 
 // Session abstracts a persistent, initialised MCP connection to a single
@@ -21,28 +19,9 @@ import (
 //
 // Implementations must be safe for concurrent use.
 type Session interface {
-	// CallTool invokes a named tool on this backend.
-	CallTool(
-		ctx context.Context,
-		toolName string,
-		arguments map[string]any,
-		meta map[string]any,
-	) (*vmcp.ToolCallResult, error)
-
-	// ReadResource reads a resource from this backend.
-	ReadResource(ctx context.Context, uri string) (*vmcp.ResourceReadResult, error)
-
-	// GetPrompt retrieves a prompt from this backend.
-	GetPrompt(
-		ctx context.Context,
-		name string,
-		arguments map[string]any,
-	) (*vmcp.PromptGetResult, error)
+	sessiontypes.Caller
 
 	// SessionID returns the backend-assigned session ID (if any).
 	// Returns "" if the backend did not assign a session ID.
 	SessionID() string
-
-	// Close closes the underlying transport connection.
-	Close() error
 }

--- a/pkg/vmcp/session/session.go
+++ b/pkg/vmcp/session/session.go
@@ -4,10 +4,9 @@
 package session
 
 import (
-	"context"
-
 	transportsession "github.com/stacklok/toolhive/pkg/transport/session"
 	"github.com/stacklok/toolhive/pkg/vmcp"
+	sessiontypes "github.com/stacklok/toolhive/pkg/vmcp/session/types"
 )
 
 // MultiSession is the vMCP domain session interface. It extends the
@@ -41,6 +40,7 @@ import (
 // storage path is introduced.
 type MultiSession interface {
 	transportsession.Session
+	sessiontypes.Caller
 
 	// Tools returns the resolved tools available in this session.
 	// The list is built once at session creation and is read-only thereafter.
@@ -57,39 +57,4 @@ type MultiSession interface {
 	// backend MCP server and is used to correlate vMCP sessions with backend
 	// sessions for debugging and auditing.
 	BackendSessions() map[string]string
-
-	// CallTool invokes toolName on the appropriate backend for this session.
-	// The routing table is consulted to identify the backend; the
-	// session-scoped client for that backend is then used, avoiding
-	// per-request connection overhead.
-	//
-	// arguments contains the tool input parameters.
-	// meta contains protocol-level metadata (_meta) forwarded from the client.
-	CallTool(
-		ctx context.Context,
-		toolName string,
-		arguments map[string]any,
-		meta map[string]any,
-	) (*vmcp.ToolCallResult, error)
-
-	// ReadResource retrieves the resource identified by uri from the
-	// appropriate backend for this session.
-	ReadResource(ctx context.Context, uri string) (*vmcp.ResourceReadResult, error)
-
-	// GetPrompt retrieves the named prompt from the appropriate backend for
-	// this session.
-	//
-	// arguments contains the prompt input parameters.
-	GetPrompt(
-		ctx context.Context,
-		name string,
-		arguments map[string]any,
-	) (*vmcp.PromptGetResult, error)
-
-	// Close releases all resources held by this session, including all
-	// backend client connections. It waits for any in-flight operations to
-	// complete before tearing down clients.
-	//
-	// Close is idempotent: calling it multiple times returns nil.
-	Close() error
 }

--- a/pkg/vmcp/session/types/session.go
+++ b/pkg/vmcp/session/types/session.go
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package types defines shared session interfaces for the vmcp/session package
+// hierarchy. Placing the common types here allows both the internal backend
+// package and the top-level session package to share a definition without
+// introducing an import cycle.
+package types
+
+import (
+	"context"
+
+	"github.com/stacklok/toolhive/pkg/vmcp"
+)
+
+// Caller represents the ability to invoke MCP protocol operations against a
+// backend. It is the common subset shared by both a single-backend
+// [backend.Session] and the multi-backend [session.MultiSession].
+//
+// Implementations must be safe for concurrent use.
+type Caller interface {
+	// CallTool invokes toolName on the backend.
+	//
+	// arguments contains the tool input parameters.
+	// meta contains protocol-level metadata (_meta) forwarded from the client.
+	CallTool(
+		ctx context.Context,
+		toolName string,
+		arguments map[string]any,
+		meta map[string]any,
+	) (*vmcp.ToolCallResult, error)
+
+	// ReadResource retrieves the resource identified by uri from the backend.
+	ReadResource(ctx context.Context, uri string) (*vmcp.ResourceReadResult, error)
+
+	// GetPrompt retrieves the named prompt from the backend.
+	//
+	// arguments contains the prompt input parameters.
+	GetPrompt(
+		ctx context.Context,
+		name string,
+		arguments map[string]any,
+	) (*vmcp.PromptGetResult, error)
+
+	// Close releases all resources held by this caller. Implementations must
+	// be idempotent: calling Close multiple times returns nil.
+	Close() error
+}


### PR DESCRIPTION
Extract the shared MCP operation methods (CallTool, ReadResource, GetPrompt, Close) from backend.Session and MultiSession into a new types.Caller interface in pkg/vmcp/session/types, eliminating duplication between the two interfaces. This is a first step toward the future consolidation of the two session types.

Factor the in-flight request tracking logic (sync.RWMutex, sync.WaitGroup, closed bool) out of defaultMultiSession into a new AdmissionQueue interface with a concrete admissionQueue implementation. This makes the concurrency contract independently testable and removes synchronization noise from the session struct. Snapshot methods (Tools, Resources, Prompts, BackendSessions) no longer need locks since those fields are immutable after construction.

Add unit tests for the HTTP round trippers (httpRoundTripperFunc, authRoundTripper, identityRoundTripper) in the internal/backend package, covering request cloning, auth error propagation, and identity context propagation.