### PR TITLE
Fix nil pointer panic in resolveTransportType for protocol scheme images

### DIFF
--- a/cmd/thv/app/run_flags.go
+++ b/cmd/thv/app/run_flags.go
@@ -439,7 +439,7 @@ func handleImageRetrieval(
 			return imageURL, serverMetadata, nil
 		}
 	}
-	return serverOrImage, nil, nil
+	return imageURL, nil, nil
 }
 
 // validateAndSetupProxyMode validates and sets default proxy mode if needed
@@ -454,13 +454,17 @@ func validateAndSetupProxyMode(runFlags *RunFlags) error {
 	return nil
 }
 
-// resolveTransportType selects the appropriate transport type based on flags and metadata
+// resolveTransportType selects the appropriate transport type based on flags and metadata.
+// Uses a type assertion with nil check to guard against typed nil pointers wrapped
+// in a non-nil interface (e.g., nil *ImageMetadata returned as ServerMetadata).
 func resolveTransportType(runFlags *RunFlags, serverMetadata regtypes.ServerMetadata) string {
 	if runFlags.Transport != "" {
 		return runFlags.Transport
 	}
-	if serverMetadata != nil {
-		return serverMetadata.GetTransport()
+	if imageMetadata, ok := serverMetadata.(*regtypes.ImageMetadata); ok && imageMetadata != nil {
+		if t := imageMetadata.GetTransport(); t != "" {
+			return t
+		}
 	}
 	return defaultTransportType
 }
@@ -547,7 +551,13 @@ func buildRunnerConfig(
 ) (*runner.RunConfig, error) {
 	transportType := resolveTransportType(runFlags, serverMetadata)
 	serverName := resolveServerName(runFlags, serverMetadata)
-	imageMetadata, _ := serverMetadata.(*regtypes.ImageMetadata)
+
+	// Use type assertion with nil check to guard against typed nil pointers
+	// wrapped in a non-nil interface (e.g., protocol scheme images).
+	var imageMetadata *regtypes.ImageMetadata
+	if md, ok := serverMetadata.(*regtypes.ImageMetadata); ok && md != nil {
+		imageMetadata = md
+	}
 
 	// Build default options
 	opts := []runner.RunConfigBuilderOption{
@@ -701,7 +711,7 @@ func configureMiddlewareAndOptions(
 func configureRemoteAuth(runFlags *RunFlags, serverMetadata regtypes.ServerMetadata) ([]runner.RunConfigBuilderOption, error) {
 	var opts []runner.RunConfigBuilderOption
 
-	if remoteServerMetadata, ok := serverMetadata.(*regtypes.RemoteServerMetadata); ok {
+	if remoteServerMetadata, ok := serverMetadata.(*regtypes.RemoteServerMetadata); ok && remoteServerMetadata != nil {
 		remoteAuthConfig, err := getRemoteAuthFromRemoteServerMetadata(remoteServerMetadata, runFlags)
 		if err != nil {
 			return nil, err

--- a/pkg/mcp/server/run_server.go
+++ b/pkg/mcp/server/run_server.go
@@ -50,8 +50,12 @@ func (h *Handler) RunServer(ctx context.Context, request mcp.CallToolRequest) (*
 		return mcp.NewToolResultError(fmt.Sprintf("Failed to get MCP server: %v", err)), nil
 	}
 
-	// Build run configuration
-	imageMetadata, _ := serverMetadata.(*types.ImageMetadata)
+	// Build run configuration.
+	// Use type assertion with nil check to guard against typed nil pointers.
+	var imageMetadata *types.ImageMetadata
+	if md, ok := serverMetadata.(*types.ImageMetadata); ok && md != nil {
+		imageMetadata = md
+	}
 
 	runConfig, err := buildServerConfig(ctx, args, imageURL, imageMetadata)
 	if err != nil {


### PR DESCRIPTION
## Summary

- Fix a nil pointer panic when running protocol scheme images (`npx://`, `uvx://`, `go://`) without an explicit `--transport` flag. The panic was caused by a classic Go "typed nil in interface" bug where `handleProtocolScheme` returned a nil `*ImageMetadata` that was wrapped as a non-nil `ServerMetadata` interface.
- Guard against typed nil pointers at the source (`GetMCPServer`) and defensively at all call sites across CLI, API, and MCP server packages.
- Add unit tests for `resolveTransportType` and `resolveServerName` covering nil interface, typed-nil-in-interface, and valid metadata scenarios.

### Root cause

`handleProtocolScheme` declared `var imageMetadata *types.ImageMetadata` (nil) and returned it without assignment. `GetMCPServer` returned this nil `*ImageMetadata` as a `types.ServerMetadata` interface, creating a non-nil interface wrapping a nil pointer. `resolveTransportType` checked `serverMetadata != nil` (true), then called `serverMetadata.GetTransport()` which panicked because the promoted method from `BaseServerMetadata` requires dereferencing the nil outer struct.

### Why e2e tests didn't catch it

Every protocol scheme e2e test passes `--transport` explicitly (`"--transport", "stdio"` or `"--transport", "streamable-http"`), causing `resolveTransportType` to return early without ever calling `serverMetadata.GetTransport()`.

### Changes

| File | Change |
|------|--------|
| `pkg/runner/retriever/retriever.go` | Nil guard before returning `imageMetadata` as `ServerMetadata` interface; cleaned up `handleProtocolScheme` to return `nil` directly |
| `cmd/thv/app/run_flags.go` | Safe type assertion in `resolveTransportType`, `buildRunConfig`, and `configureRemoteAuth` |
| `pkg/api/v1/workload_service.go` | Safe type assertions for both `ImageMetadata` and `RemoteServerMetadata`; safe transport resolution |
| `pkg/mcp/server/run_server.go` | Safe type assertion for `ImageMetadata` |
| `cmd/thv/app/run_flags_test.go` | Unit tests for `resolveTransportType` and `resolveServerName` with typed-nil cases |

## Test plan

- [x] `go build ./...` passes
- [x] `task lint` passes (0 issues)
- [x] Unit tests pass for all changed packages
- [ ] Verify `thv run npx://@zereight/mcp-gitlab --name gitlab` no longer panics (manual)

Fixes #3940

🤖 Generated with [Claude Code](https://claude.com/claude-code)