### PR TITLE
Make MCPServer controller hands-off on replicas

### DIFF
--- a/cmd/thv-operator/api/v1alpha1/mcpserver_types.go
+++ b/cmd/thv-operator/api/v1alpha1/mcpserver_types.go
@@ -758,10 +758,14 @@ type MCPServerStatus struct {
 	// Message provides additional information about the current phase
 	// +optional
 	Message string `json:"message,omitempty"`
+
+	// ReadyReplicas is the number of ready proxy replicas
+	// +optional
+	ReadyReplicas int32 `json:"readyReplicas,omitempty"`
 }
 
 // MCPServerPhase is the phase of the MCPServer
-// +kubebuilder:validation:Enum=Pending;Running;Failed;Terminating
+// +kubebuilder:validation:Enum=Pending;Running;Failed;Terminating;Stopped
 type MCPServerPhase string
 
 const (
@@ -776,12 +780,16 @@ const (
 
 	// MCPServerPhaseTerminating means the MCPServer is being deleted
 	MCPServerPhaseTerminating MCPServerPhase = "Terminating"
+
+	// MCPServerPhaseStopped means the MCPServer is scaled to zero
+	MCPServerPhaseStopped MCPServerPhase = "Stopped"
 )
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 //+kubebuilder:resource:shortName=mcpserver;mcpservers
 //+kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.phase"
+//+kubebuilder:printcolumn:name="Ready",type="integer",JSONPath=".status.readyReplicas"
 //+kubebuilder:printcolumn:name="URL",type="string",JSONPath=".status.url"
 //+kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 

--- a/cmd/thv-operator/controllers/mcpserver_replicas_test.go
+++ b/cmd/thv-operator/controllers/mcpserver_replicas_test.go
@@ -1,0 +1,506 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package controllers
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	mcpv1alpha1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1alpha1"
+	"github.com/stacklok/toolhive/pkg/container/kubernetes"
+)
+
+func TestReplicaBehavior(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		transport        string
+		currentReplicas  int32
+		expectedReplicas int32
+		expectRequeue    bool
+		description      string
+	}{
+		{
+			name:             "SSE transport allows scaling to 3",
+			transport:        "sse",
+			currentReplicas:  3,
+			expectedReplicas: 3,
+			expectRequeue:    false,
+			description:      "Non-stdio transports should not have replicas reverted",
+		},
+		{
+			name:             "streamable-http transport allows scaling to 5",
+			transport:        "streamable-http",
+			currentReplicas:  5,
+			expectedReplicas: 5,
+			expectRequeue:    false,
+			description:      "Non-stdio transports should not have replicas reverted",
+		},
+		{
+			name:             "stdio transport caps at 1 when scaled to 3",
+			transport:        "stdio",
+			currentReplicas:  3,
+			expectedReplicas: 1,
+			expectRequeue:    true,
+			description:      "stdio requires 1:1 proxy-to-backend connections",
+		},
+		{
+			name:             "stdio transport stays at 1",
+			transport:        "stdio",
+			currentReplicas:  1,
+			expectedReplicas: 1,
+			expectRequeue:    false,
+			description:      "stdio at 1 replica should not trigger an update",
+		},
+		{
+			name:             "SSE transport allows scale to 0",
+			transport:        "sse",
+			currentReplicas:  0,
+			expectedReplicas: 0,
+			expectRequeue:    false,
+			description:      "Scale-to-zero should be allowed for any transport",
+		},
+		{
+			name:             "stdio transport allows scale to 0",
+			transport:        "stdio",
+			currentReplicas:  0,
+			expectedReplicas: 0,
+			expectRequeue:    false,
+			description:      "Scale-to-zero should be allowed even for stdio",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			name := "replica-test"
+			namespace := testNamespaceDefault
+
+			mcpServer := &mcpv1alpha1.MCPServer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: namespace,
+				},
+				Spec: mcpv1alpha1.MCPServerSpec{
+					Image:     "test-image:latest",
+					Transport: tt.transport,
+					ProxyPort: 8080,
+				},
+			}
+
+			testScheme := createTestScheme()
+
+			// Create a deployment with the desired replica count
+			deployment := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: namespace,
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: int32Ptr(tt.currentReplicas),
+					Selector: &metav1.LabelSelector{
+						MatchLabels: labelsForMCPServer(name),
+					},
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: labelsForMCPServer(name),
+						},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:  "mcp",
+									Image: "test-image:latest",
+								},
+							},
+						},
+					},
+				},
+			}
+
+			// Create a service so reconcile doesn't bail early
+			service := &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("mcp-%s-proxy", name),
+					Namespace: namespace,
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{Port: 8080},
+					},
+				},
+			}
+
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(testScheme).
+				WithObjects(mcpServer, deployment, service).
+				WithStatusSubresource(&mcpv1alpha1.MCPServer{}).
+				Build()
+
+			reconciler := newTestMCPServerReconciler(fakeClient, testScheme, kubernetes.PlatformKubernetes)
+
+			result, err := reconciler.Reconcile(t.Context(), ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      name,
+					Namespace: namespace,
+				},
+			})
+			require.NoError(t, err)
+
+			if tt.expectRequeue {
+				//nolint:staticcheck // Requeue is what the controller actually returns
+				assert.True(t, result.Requeue, tt.description)
+			}
+
+			// Verify the deployment replicas
+			updatedDeployment := &appsv1.Deployment{}
+			err = fakeClient.Get(t.Context(), types.NamespacedName{
+				Name:      name,
+				Namespace: namespace,
+			}, updatedDeployment)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedReplicas, *updatedDeployment.Spec.Replicas, tt.description)
+		})
+	}
+}
+
+func TestConfigUpdatePreservesReplicas(t *testing.T) {
+	t.Parallel()
+
+	name := "config-update-test"
+	namespace := testNamespaceDefault
+
+	mcpServer := &mcpv1alpha1.MCPServer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: mcpv1alpha1.MCPServerSpec{
+			Image:     "new-image:v2", // Changed image triggers deployment update
+			Transport: "sse",
+			ProxyPort: 8080,
+		},
+	}
+
+	testScheme := createTestScheme()
+
+	// Create deployment with 3 replicas and an old image
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: int32Ptr(3),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: labelsForMCPServer(name),
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: labelsForMCPServer(name),
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "mcp",
+							Image: "old-runner-image:v1", // Different from current runner image
+						},
+					},
+				},
+			},
+		},
+	}
+
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("mcp-%s-proxy", name),
+			Namespace: namespace,
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{Port: 8080},
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(testScheme).
+		WithObjects(mcpServer, deployment, service).
+		WithStatusSubresource(&mcpv1alpha1.MCPServer{}).
+		Build()
+
+	reconciler := newTestMCPServerReconciler(fakeClient, testScheme, kubernetes.PlatformKubernetes)
+
+	_, err := reconciler.Reconcile(t.Context(), ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      name,
+			Namespace: namespace,
+		},
+	})
+	require.NoError(t, err)
+
+	// Verify the deployment replicas are preserved
+	updatedDeployment := &appsv1.Deployment{}
+	err = fakeClient.Get(t.Context(), types.NamespacedName{
+		Name:      name,
+		Namespace: namespace,
+	}, updatedDeployment)
+	require.NoError(t, err)
+	assert.Equal(t, int32(3), *updatedDeployment.Spec.Replicas,
+		"Config update should preserve replicas set by external tools")
+}
+
+func TestUpdateMCPServerStatusScaledToZero(t *testing.T) {
+	t.Parallel()
+
+	name := "stopped-test"
+	namespace := testNamespaceDefault
+
+	mcpServer := &mcpv1alpha1.MCPServer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: mcpv1alpha1.MCPServerSpec{
+			Image:     "test-image:latest",
+			Transport: "sse",
+			ProxyPort: 8080,
+		},
+	}
+
+	testScheme := createTestScheme()
+
+	// Create deployment scaled to zero
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: int32Ptr(0),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: labelsForMCPServer(name),
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: labelsForMCPServer(name),
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "mcp",
+							Image: "test-image:latest",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(testScheme).
+		WithObjects(mcpServer, deployment).
+		WithStatusSubresource(&mcpv1alpha1.MCPServer{}).
+		Build()
+
+	reconciler := newTestMCPServerReconciler(fakeClient, testScheme, kubernetes.PlatformKubernetes)
+
+	err := reconciler.updateMCPServerStatus(t.Context(), mcpServer)
+	require.NoError(t, err)
+
+	// Fetch the updated MCPServer
+	updatedMCPServer := &mcpv1alpha1.MCPServer{}
+	err = fakeClient.Get(t.Context(), types.NamespacedName{
+		Name:      name,
+		Namespace: namespace,
+	}, updatedMCPServer)
+	require.NoError(t, err)
+
+	assert.Equal(t, mcpv1alpha1.MCPServerPhaseStopped, updatedMCPServer.Status.Phase)
+	assert.Equal(t, "MCP server is stopped (scaled to zero)", updatedMCPServer.Status.Message)
+	assert.Equal(t, int32(0), updatedMCPServer.Status.ReadyReplicas)
+}
+
+func TestUpdateMCPServerStatusReadyReplicas(t *testing.T) {
+	t.Parallel()
+
+	name := "ready-replicas-test"
+	namespace := testNamespaceDefault
+
+	mcpServer := &mcpv1alpha1.MCPServer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: mcpv1alpha1.MCPServerSpec{
+			Image:     "test-image:latest",
+			Transport: "sse",
+			ProxyPort: 8080,
+		},
+	}
+
+	testScheme := createTestScheme()
+
+	// Create deployment with 3 replicas
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: int32Ptr(3),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: labelsForMCPServer(name),
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: labelsForMCPServer(name),
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "mcp",
+							Image: "test-image:latest",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Create 2 running pods and 1 pending
+	runningPod1 := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-pod-0", name),
+			Namespace: namespace,
+			Labels:    labelsForMCPServer(name),
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "mcp", Image: "test-image:latest"},
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{
+				{Ready: true, State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}},
+			},
+		},
+	}
+	runningPod2 := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-pod-1", name),
+			Namespace: namespace,
+			Labels:    labelsForMCPServer(name),
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "mcp", Image: "test-image:latest"},
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{
+				{Ready: true, State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}},
+			},
+		},
+	}
+	pendingPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-pod-2", name),
+			Namespace: namespace,
+			Labels:    labelsForMCPServer(name),
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "mcp", Image: "test-image:latest"},
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodPending,
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(testScheme).
+		WithObjects(mcpServer, deployment, runningPod1, runningPod2, pendingPod).
+		WithStatusSubresource(&mcpv1alpha1.MCPServer{}).
+		Build()
+
+	reconciler := newTestMCPServerReconciler(fakeClient, testScheme, kubernetes.PlatformKubernetes)
+
+	err := reconciler.updateMCPServerStatus(t.Context(), mcpServer)
+	require.NoError(t, err)
+
+	// Fetch the updated MCPServer
+	updatedMCPServer := &mcpv1alpha1.MCPServer{}
+	err = fakeClient.Get(t.Context(), types.NamespacedName{
+		Name:      name,
+		Namespace: namespace,
+	}, updatedMCPServer)
+	require.NoError(t, err)
+
+	assert.Equal(t, mcpv1alpha1.MCPServerPhaseRunning, updatedMCPServer.Status.Phase)
+	assert.Equal(t, int32(2), updatedMCPServer.Status.ReadyReplicas,
+		"ReadyReplicas should match the number of running pods")
+}
+
+func TestDefaultCreationHasOneReplica(t *testing.T) {
+	t.Parallel()
+
+	name := "default-creation"
+	namespace := testNamespaceDefault
+
+	mcpServer := &mcpv1alpha1.MCPServer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: mcpv1alpha1.MCPServerSpec{
+			Image:     "test-image:latest",
+			Transport: "sse",
+			ProxyPort: 8080,
+		},
+	}
+
+	testScheme := createTestScheme()
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(testScheme).
+		WithObjects(mcpServer).
+		WithStatusSubresource(&mcpv1alpha1.MCPServer{}).
+		Build()
+
+	reconciler := newTestMCPServerReconciler(fakeClient, testScheme, kubernetes.PlatformKubernetes)
+
+	// First reconcile creates the deployment
+	result, err := reconciler.Reconcile(t.Context(), ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      name,
+			Namespace: namespace,
+		},
+	})
+	require.NoError(t, err)
+	//nolint:staticcheck // Requeue is what the controller actually returns
+	assert.True(t, result.Requeue, "First reconcile should requeue after creating deployment")
+
+	// Verify the deployment was created with 1 replica
+	deployment := &appsv1.Deployment{}
+	err = fakeClient.Get(t.Context(), types.NamespacedName{
+		Name:      name,
+		Namespace: namespace,
+	}, deployment)
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), *deployment.Spec.Replicas,
+		"Default deployment should start with 1 replica")
+}

--- a/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpservers.yaml
+++ b/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpservers.yaml
@@ -21,6 +21,9 @@ spec:
     - jsonPath: .status.phase
       name: Status
       type: string
+    - jsonPath: .status.readyReplicas
+      name: Ready
+      type: integer
     - jsonPath: .status.url
       name: URL
       type: string
@@ -824,7 +827,12 @@ spec:
                 - Running
                 - Failed
                 - Terminating
+                - Stopped
                 type: string
+              readyReplicas:
+                description: ReadyReplicas is the number of ready proxy replicas
+                format: int32
+                type: integer
               toolConfigHash:
                 description: ToolConfigHash stores the hash of the referenced ToolConfig
                   for change detection

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpservers.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpservers.yaml
@@ -24,6 +24,9 @@ spec:
     - jsonPath: .status.phase
       name: Status
       type: string
+    - jsonPath: .status.readyReplicas
+      name: Ready
+      type: integer
     - jsonPath: .status.url
       name: URL
       type: string
@@ -827,7 +830,12 @@ spec:
                 - Running
                 - Failed
                 - Terminating
+                - Stopped
                 type: string
+              readyReplicas:
+                description: ReadyReplicas is the number of ready proxy replicas
+                format: int32
+                type: integer
               toolConfigHash:
                 description: ToolConfigHash stores the hash of the referenced ToolConfig
                   for change detection

--- a/docs/operator/crd-api.md
+++ b/docs/operator/crd-api.md
@@ -1939,7 +1939,7 @@ _Underlying type:_ _string_
 MCPServerPhase is the phase of the MCPServer
 
 _Validation:_
-- Enum: [Pending Running Failed Terminating]
+- Enum: [Pending Running Failed Terminating Stopped]
 
 _Appears in:_
 - [api.v1alpha1.MCPServerStatus](#apiv1alpha1mcpserverstatus)
@@ -1950,6 +1950,7 @@ _Appears in:_
 | `Running` | MCPServerPhaseRunning means the MCPServer is running<br /> |
 | `Failed` | MCPServerPhaseFailed means the MCPServer failed to start<br /> |
 | `Terminating` | MCPServerPhaseTerminating means the MCPServer is being deleted<br /> |
+| `Stopped` | MCPServerPhaseStopped means the MCPServer is scaled to zero<br /> |
 
 
 #### api.v1alpha1.MCPServerSpec
@@ -2010,8 +2011,9 @@ _Appears in:_
 | `toolConfigHash` _string_ | ToolConfigHash stores the hash of the referenced ToolConfig for change detection |  | Optional: \{\} <br /> |
 | `externalAuthConfigHash` _string_ | ExternalAuthConfigHash is the hash of the referenced MCPExternalAuthConfig spec |  | Optional: \{\} <br /> |
 | `url` _string_ | URL is the URL where the MCP server can be accessed |  | Optional: \{\} <br /> |
-| `phase` _[api.v1alpha1.MCPServerPhase](#apiv1alpha1mcpserverphase)_ | Phase is the current phase of the MCPServer |  | Enum: [Pending Running Failed Terminating] <br />Optional: \{\} <br /> |
+| `phase` _[api.v1alpha1.MCPServerPhase](#apiv1alpha1mcpserverphase)_ | Phase is the current phase of the MCPServer |  | Enum: [Pending Running Failed Terminating Stopped] <br />Optional: \{\} <br /> |
 | `message` _string_ | Message provides additional information about the current phase |  | Optional: \{\} <br /> |
+| `readyReplicas` _integer_ | ReadyReplicas is the number of ready proxy replicas |  | Optional: \{\} <br /> |
 
 
 #### api.v1alpha1.MCPToolConfig

--- a/pkg/vmcp/workloads/k8s.go
+++ b/pkg/vmcp/workloads/k8s.go
@@ -356,6 +356,8 @@ func mapK8SWorkloadPhaseToHealth(phase mcpv1alpha1.MCPServerPhase) vmcp.BackendH
 		return vmcp.BackendUnhealthy
 	case mcpv1alpha1.MCPServerPhaseTerminating:
 		return vmcp.BackendUnhealthy
+	case mcpv1alpha1.MCPServerPhaseStopped:
+		return vmcp.BackendUnhealthy
 	case mcpv1alpha1.MCPServerPhasePending:
 		return vmcp.BackendUnknown
 	default:


### PR DESCRIPTION
## Summary

- **Remove hardcoded replica enforcement**: The controller no longer forces `replicas=1` on every reconcile, allowing `kubectl scale`, HPAs, KEDA, and other autoscalers to manage replicas freely
- **Add stdio transport cap**: stdio requires 1:1 proxy-to-backend connections, so the controller caps it at 1 replica while leaving SSE and streamable-http unconstrained
- **Template-only deployment updates**: Config changes (image, env, etc.) now update only `Spec.Template`, `Spec.Selector`, labels, and annotations — preserving `Spec.Replicas` set by external tools
- **New status fields**: `ReadyReplicas` reports actual running pod count; `Stopped` phase reports scale-to-zero state; `Ready` print column shows replica count in `kubectl get mcpservers`

Closes #3329

## Test plan

- [x] Unit tests for replica behavior across all transports (SSE, streamable-http, stdio)
- [x] Unit test: stdio transport scaled to 3 → capped back to 1
- [x] Unit test: SSE/streamable-http scaled to 3/5 → replicas preserved
- [x] Unit test: scale-to-zero → status shows `Stopped` phase
- [x] Unit test: config update preserves externally-set replicas
- [x] Unit test: `ReadyReplicas` matches running pod count
- [x] Unit test: default creation starts with 1 replica
- [x] `task operator-test` passes
- [x] `task lint` passes (also fixes pre-existing goconst issue)
- [x] CRD manifests, reference docs, and CLI docs regenerated
- [ ] Manual: deploy MCPServer, `kubectl scale --replicas=3` (SSE), verify controller doesn't revert
- [ ] Manual: `kubectl scale --replicas=0`, verify status shows `Stopped`
- [ ] Manual: stdio MCPServer, `kubectl scale --replicas=3`, verify controller caps to 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)