### PR TITLE
DO NOT MERGE: add stdio e2e debug dumps

### DIFF
--- a/test/e2e/chainsaw/operator/multi-tenancy/test-scenarios/stdio-streamable-http/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/operator/multi-tenancy/test-scenarios/stdio-streamable-http/chainsaw-test.yaml
@@ -29,8 +29,27 @@ spec:
         file: assert-mcpserver-running.yaml
     - assert:
         file: assert-mcpserver-pod-running.yaml
-    - assert:
-        file: assert-mcpserver-proxy-runner-running.yaml
+    - script:
+        content: |
+          #!/bin/sh
+          set -u
+
+          echo "Waiting for proxy runner deployment to become available..."
+          if kubectl wait --for=condition=Available deployment/yardstick -n test-namespace --timeout=60s; then
+            echo "✓ Deployment is available"
+            exit 0
+          fi
+
+          echo "! Deployment did not become available, dumping debug info"
+          kubectl get deployment yardstick -n test-namespace -o yaml || true
+          kubectl describe deployment yardstick -n test-namespace || true
+          kubectl get rs -n test-namespace -o wide || true
+          kubectl describe rs -n test-namespace || true
+          kubectl get pods -n test-namespace -o wide || true
+          kubectl describe pods -n test-namespace || true
+          kubectl logs deployment/yardstick -n test-namespace --all-containers=true --tail=200 || true
+          kubectl get events -n test-namespace --sort-by=.lastTimestamp || true
+          exit 1
     - assert:
         file: assert-mcpserver-proxy-runner-svc.yaml
     - assert:

--- a/test/e2e/chainsaw/operator/multi-tenancy/test-scenarios/stdio/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/operator/multi-tenancy/test-scenarios/stdio/chainsaw-test.yaml
@@ -29,8 +29,27 @@ spec:
         file: assert-mcpserver-running.yaml
     - assert:
         file: assert-mcpserver-pod-running.yaml
-    - assert:
-        file: assert-mcpserver-proxy-runner-running.yaml
+    - script:
+        content: |
+          #!/bin/sh
+          set -u
+
+          echo "Waiting for proxy runner deployment to become available..."
+          if kubectl wait --for=condition=Available deployment/yardstick -n test-namespace --timeout=60s; then
+            echo "✓ Deployment is available"
+            exit 0
+          fi
+
+          echo "! Deployment did not become available, dumping debug info"
+          kubectl get deployment yardstick -n test-namespace -o yaml || true
+          kubectl describe deployment yardstick -n test-namespace || true
+          kubectl get rs -n test-namespace -o wide || true
+          kubectl describe rs -n test-namespace || true
+          kubectl get pods -n test-namespace -o wide || true
+          kubectl describe pods -n test-namespace || true
+          kubectl logs deployment/yardstick -n test-namespace --all-containers=true --tail=200 || true
+          kubectl get events -n test-namespace --sort-by=.lastTimestamp || true
+          exit 1
     - assert:
         file: assert-mcpserver-proxy-runner-svc.yaml
     - assert:


### PR DESCRIPTION
## Summary
- replace stdio deployment readiness assertion with a wait script that dumps deployment/pod/rs logs on failure
- add the same debug dump for the stdio+streamable-http scenario

## Testing
- not run (debug-only change for CI diagnostics)