### PR TITLE
Fix GoReleaser CLI docs tarball upload path

### DIFF
--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -141,7 +141,9 @@ jobs:
           rm ./thv-test
 
       - name: Bundle CLI docs
-        run: tar -czf /tmp/thv-cli-docs.tar.gz -C docs/cli .
+        run: |
+          mkdir -p build
+          tar -czf build/thv-cli-docs.tar.gz -C docs/cli .
 
       - name: Run GoReleaser
         id: run-goreleaser

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ go.work
 
 # Build output
 /bin/
+/build/
 /dist/
 /coverage/
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -100,7 +100,7 @@ release:
     owner: stacklok
     name: toolhive
   extra_files:
-    - glob: /tmp/thv-cli-docs.tar.gz
+    - glob: build/thv-cli-docs.tar.gz
     - glob: docs/server/swagger.yaml
     - glob: docs/server/swagger.json
     - glob: docs/operator/crd-api.md


### PR DESCRIPTION
## Summary
- GoReleaser v2 doesn't support absolute paths in `extra_files` glob patterns. The `/tmp/thv-cli-docs.tar.gz` path was internally prefixed with `./`, producing `.//tmp/thv-cli-docs.tar.gz` which fails with `stat: invalid argument`
- Moves the CLI docs tarball to a relative `build/` directory, which survives GoReleaser's `--clean` flag (only wipes `dist/`)
- Adds `build/` to `.gitignore`

Fixes the failure in: https://github.com/stacklok/toolhive/actions/runs/22589401671/job/65445484908

## Test plan
- [ ] Trigger a release and verify the CLI docs tarball is included in the GitHub release artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)