### PR TITLE
Add unit tests for MCPRegistryReconciler

### DIFF
--- a/cmd/thv-operator/controllers/mcpregistry_controller_test.go
+++ b/cmd/thv-operator/controllers/mcpregistry_controller_test.go
@@ -39,7 +39,7 @@ func newMCPRegistryTestScheme(t *testing.T) *runtime.Scheme {
 }
 
 // newMCPRegistryWithFinalizer creates an MCPRegistry with the controller finalizer already set.
-func newMCPRegistryWithFinalizer(name, namespace string) *mcpv1alpha1.MCPRegistry {
+func newMCPRegistryWithFinalizer(name, namespace string) *mcpv1alpha1.MCPRegistry { //nolint:unparam
 	return &mcpv1alpha1.MCPRegistry{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       name,
@@ -420,4 +420,3 @@ func TestMCPRegistryReconciler_Reconcile(t *testing.T) {
 		})
 	}
 }
-


### PR DESCRIPTION
## Summary

- Add table-driven unit tests for `MCPRegistryReconciler.Reconcile` using a fake Kubernetes client and gomock
- Cover reconcile paths: resource not found, finalizer addition, deletion with/without controller finalizer, invalid/valid `PodTemplateSpec`, and API reconcile outcomes (error, deploying, ready)
- Assert status phase transitions (`Pending`, `Ready`, `Failed`, `Terminating`) and condition updates (`PodTemplateValid`, `APIReady`)

## Test plan

- [ ] `go test ./cmd/thv-operator/controllers/...` passes
- [ ] All 10 table-driven cases exercise distinct reconcile branches
- [ ] No external dependencies — uses `controller-runtime/pkg/client/fake` and mocked `registryapi.Manager`

🤖 Generated with [Claude Code](https://claude.com/claude-code)