### PR TITLE
Release proxy mutex before draining connections in Stop()

### DIFF
--- a/pkg/transport/proxy/transparent/transparent_proxy.go
+++ b/pkg/transport/proxy/transparent/transparent_proxy.go
@@ -112,6 +112,9 @@ type TransparentProxy struct {
 
 	// Health check ping timeout (default: 5 seconds)
 	healthCheckPingTimeout time.Duration
+
+	// Shutdown timeout for graceful HTTP server shutdown (default: 30 seconds)
+	shutdownTimeout time.Duration
 }
 
 const (
@@ -120,6 +123,14 @@ const (
 
 	// DefaultHealthCheckRetryDelay is the default delay between retry attempts
 	DefaultHealthCheckRetryDelay = 5 * time.Second
+
+	// defaultShutdownTimeout is the maximum time to wait for graceful HTTP server
+	// shutdown before force-closing connections.
+	defaultShutdownTimeout = 30 * time.Second
+
+	// defaultIdleTimeout is the maximum time to wait for the next request on a
+	// keep-alive connection. Matches the value used by the vMCP server.
+	defaultIdleTimeout = 120 * time.Second
 
 	// HealthCheckIntervalEnvVar is the environment variable name for configuring health check interval.
 	// This is primarily useful for testing with shorter intervals.
@@ -158,6 +169,17 @@ func withHealthCheckPingTimeout(timeout time.Duration) Option {
 	return func(p *TransparentProxy) {
 		if timeout > 0 {
 			p.healthCheckPingTimeout = timeout
+		}
+	}
+}
+
+// withShutdownTimeout sets the graceful shutdown timeout for the HTTP server.
+// This is primarily useful for testing with shorter timeouts.
+// Ignores non-positive timeouts; default will be used.
+func withShutdownTimeout(timeout time.Duration) Option {
+	return func(p *TransparentProxy) {
+		if timeout > 0 {
+			p.shutdownTimeout = timeout
 		}
 	}
 }
@@ -251,6 +273,7 @@ func newTransparentProxyWithOptions(
 		healthCheckInterval:    getHealthCheckInterval(),
 		healthCheckRetryDelay:  DefaultHealthCheckRetryDelay,
 		healthCheckPingTimeout: DefaultPingerTimeout,
+		shutdownTimeout:        defaultShutdownTimeout,
 	}
 
 	// Apply options
@@ -510,7 +533,8 @@ func (p *TransparentProxy) Start(ctx context.Context) error {
 	p.server = &http.Server{
 		Addr:              fmt.Sprintf("%s:%d", p.host, p.port),
 		Handler:           mux,
-		ReadHeaderTimeout: 10 * time.Second, // Prevent Slowloris attacks
+		ReadHeaderTimeout: 10 * time.Second,   // Prevent Slowloris attacks
+		IdleTimeout:       defaultIdleTimeout, // Prevent idle keep-alive connections from blocking Shutdown()
 	}
 
 	// Capture server in local variable to avoid race with Stop()
@@ -666,31 +690,55 @@ func (p *TransparentProxy) monitorHealth(parentCtx context.Context) {
 // Stop stops the transparent proxy.
 func (p *TransparentProxy) Stop(ctx context.Context) error {
 	p.mutex.Lock()
-	defer p.mutex.Unlock()
 
 	// Check if already stopped
 	if p.stopped {
+		p.mutex.Unlock()
 		//nolint:gosec // G706: logging target URI from config
 		slog.Debug("proxy is already stopped, skipping", "target", p.targetURI)
 		return nil
 	}
 
-	// Mark as stopped before closing channel
+	// Mark as stopped and signal shutdown under the lock
 	p.stopped = true
-
-	// Signal shutdown
 	close(p.shutdownCh)
 
-	// Stop the HTTP server
-	if p.server != nil {
-		err := p.server.Shutdown(ctx)
-		if err != nil && !errors.Is(err, http.ErrServerClosed) && !errors.Is(err, context.DeadlineExceeded) {
-			slog.Warn("error during proxy shutdown", "error", err)
-			return err
+	// Capture server reference and nil it out under the lock so no other
+	// goroutine can race on p.server after we release the mutex.
+	server := p.server
+	p.server = nil
+
+	// Release the lock before server.Shutdown() so IsRunning() is not blocked
+	// while long-lived connections drain.
+	p.mutex.Unlock()
+
+	if server != nil {
+		// Use the caller's context if still valid; fall back to a fresh one
+		// when the caller's context is already cancelled (e.g. the health
+		// monitor calls Stop() after its parent context is done).
+		base := ctx
+		if base.Err() != nil {
+			base = context.Background()
+		}
+		shutdownCtx, cancel := context.WithTimeout(base, p.shutdownTimeout)
+		defer cancel()
+
+		err := server.Shutdown(shutdownCtx)
+		if err != nil {
+			if errors.Is(err, context.DeadlineExceeded) {
+				// Graceful shutdown timed out — force-close remaining connections
+				slog.Warn("graceful shutdown timed out, force-closing connections",
+					"target", p.targetURI, "timeout", p.shutdownTimeout)
+				if closeErr := server.Close(); closeErr != nil {
+					slog.Warn("error during forced server close", "error", closeErr)
+				}
+			} else if !errors.Is(err, http.ErrServerClosed) {
+				slog.Warn("error during proxy shutdown", "error", err)
+				return err
+			}
 		}
 		//nolint:gosec // G706: logging target URI from config
 		slog.Debug("server stopped successfully", "target", p.targetURI)
-		p.server = nil
 	}
 
 	return nil
@@ -698,10 +746,8 @@ func (p *TransparentProxy) Stop(ctx context.Context) error {
 
 // IsRunning checks if the proxy is running.
 func (p *TransparentProxy) IsRunning() (bool, error) {
-	p.mutex.Lock()
-	defer p.mutex.Unlock()
-
-	// Check if the shutdown channel is closed
+	// No mutex needed: shutdownCh is closed under the lock in Stop(),
+	// and a select on a closed channel is goroutine-safe by design.
 	select {
 	case <-p.shutdownCh:
 		return false, nil

--- a/pkg/transport/proxy/transparent/transparent_test.go
+++ b/pkg/transport/proxy/transparent/transparent_test.go
@@ -1760,3 +1760,163 @@ func TestPrefixHandlers_WellKnownNamespaceCoexistence(t *testing.T) {
 		})
 	}
 }
+
+// TestTransparentProxy_IsRunningDoesNotBlockDuringStop verifies that IsRunning()
+// returns immediately even while Stop() is blocked draining long-lived connections.
+// This is the core regression test for the mutex contention fix.
+func TestTransparentProxy_IsRunningDoesNotBlockDuringStop(t *testing.T) {
+	t.Parallel()
+
+	// Create a backend that holds SSE connections open until we signal
+	releaseConn := make(chan struct{})
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+		// Hold the connection open until released
+		<-releaseConn
+	}))
+	defer backend.Close()
+
+	proxy := newTransparentProxyWithOptions(
+		"127.0.0.1", 0, backend.URL,
+		nil, nil, nil,
+		false, // no health check
+		false, "sse", nil, nil, "", false, nil,
+		// Use a long shutdown timeout so Stop() blocks on the SSE connection
+		withShutdownTimeout(10*time.Second),
+	)
+
+	ctx := context.Background()
+	err := proxy.Start(ctx)
+	require.NoError(t, err)
+
+	actualPort := proxy.listener.Addr().(*net.TCPAddr).Port
+
+	// Establish an SSE connection through the proxy
+	client := &http.Client{Timeout: 0} // no client timeout
+	resp, err := client.Get(fmt.Sprintf("http://127.0.0.1:%d/", actualPort))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	// Call Stop() in a goroutine — it will block on server.Shutdown()
+	// waiting for the SSE connection to close
+	stopDone := make(chan error, 1)
+	go func() {
+		stopDone <- proxy.Stop(ctx)
+	}()
+
+	// Give Stop() a moment to acquire the lock and begin shutdown
+	time.Sleep(100 * time.Millisecond)
+
+	// IsRunning() must return false within 2 seconds — not blocked by mutex
+	isRunningDone := make(chan bool, 1)
+	go func() {
+		running, _ := proxy.IsRunning()
+		isRunningDone <- running
+	}()
+
+	select {
+	case running := <-isRunningDone:
+		assert.False(t, running, "IsRunning() should return false after Stop() signals shutdown")
+	case <-time.After(2 * time.Second):
+		t.Fatal("IsRunning() blocked for >2s — mutex contention not fixed")
+	}
+
+	// Release the backend connection so Stop() can complete
+	close(releaseConn)
+
+	select {
+	case err := <-stopDone:
+		assert.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Stop() did not complete after releasing connection")
+	}
+}
+
+// TestTransparentProxy_StopForcesCloseAfterTimeout verifies that Stop()
+// force-closes connections after the shutdown timeout expires, preventing
+// indefinite blocking on long-lived connections.
+func TestTransparentProxy_StopForcesCloseAfterTimeout(t *testing.T) {
+	t.Parallel()
+
+	// Channel to unblock the backend handler when the test is done,
+	// so httptest.Server.Close() doesn't hang.
+	testDone := make(chan struct{})
+
+	// Create a backend that holds SSE connections open until testDone
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+		// Hold the connection open — simulates a long-lived SSE stream.
+		// Released by testDone so httptest.Server.Close() can complete.
+		<-testDone
+	}))
+	// Release handler BEFORE closing backend (Close waits for handlers to finish)
+	defer func() {
+		close(testDone)
+		backend.Close()
+	}()
+
+	proxy := newTransparentProxyWithOptions(
+		"127.0.0.1", 0, backend.URL,
+		nil, nil, nil,
+		false, // no health check
+		false, "sse", nil, nil, "", false, nil,
+		// Use a very short timeout to test the force-close path
+		withShutdownTimeout(500*time.Millisecond),
+	)
+
+	ctx := context.Background()
+	err := proxy.Start(ctx)
+	require.NoError(t, err)
+
+	actualPort := proxy.listener.Addr().(*net.TCPAddr).Port
+
+	// Establish an SSE connection through the proxy
+	client := &http.Client{Timeout: 0}
+	resp, err := client.Get(fmt.Sprintf("http://127.0.0.1:%d/", actualPort))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	// Stop() should complete within shutdownTimeout + margin, not block forever
+	stopDone := make(chan error, 1)
+	go func() {
+		stopDone <- proxy.Stop(ctx)
+	}()
+
+	select {
+	case err := <-stopDone:
+		assert.NoError(t, err, "Stop() should not return an error after force-close")
+	case <-time.After(3 * time.Second):
+		t.Fatal("Stop() blocked for >3s — shutdown timeout safety net not working")
+	}
+}
+
+// TestTransparentProxy_ServerHasIdleTimeout verifies that the HTTP server
+// is configured with an IdleTimeout to prevent idle keep-alive connections
+// from blocking server.Shutdown() indefinitely.
+func TestTransparentProxy_ServerHasIdleTimeout(t *testing.T) {
+	t.Parallel()
+
+	proxy := newTransparentProxyWithOptions(
+		"127.0.0.1", 0, "http://localhost:9999",
+		nil, nil, nil,
+		false, false, "sse", nil, nil, "", false, nil,
+	)
+
+	ctx := context.Background()
+	err := proxy.Start(ctx)
+	require.NoError(t, err)
+	defer func() { _ = proxy.Stop(ctx) }()
+
+	// Access the server directly (we're in the same package)
+	require.NotNil(t, proxy.server)
+	assert.Equal(t, 120*time.Second, proxy.server.IdleTimeout,
+		"HTTP server should have IdleTimeout set to 120s")
+}


### PR DESCRIPTION
## Summary

- Release `p.mutex` before calling `server.Shutdown()` in `TransparentProxy.Stop()` so that `IsRunning()` is not blocked while long-lived connections drain
- Remove the mutex from `IsRunning()` — it only does a channel select, which is goroutine-safe by design
- Add a 30-second shutdown timeout with force-close fallback to bound the drain
- Set `IdleTimeout` (120s) on the HTTP server to prevent idle keep-alive connections from blocking `Shutdown()` indefinitely

## Test plan

- [x] New test: `TestTransparentProxy_IsRunningDoesNotBlockDuringStop` — establishes a real SSE connection, calls `Stop()` (blocks on drain), asserts `IsRunning()` returns `false` within 2 seconds
- [x] New test: `TestTransparentProxy_StopForcesCloseAfterTimeout` — verifies force-close after 500ms timeout
- [x] New test: `TestTransparentProxy_ServerHasIdleTimeout` — verifies `IdleTimeout` is set to 120s
- [x] All 30 existing tests pass with `-race`
- [x] `golangci-lint` clean

Fixes #3969