### PR TITLE
Remove Score field from optimizer tool responses

### DIFF
--- a/pkg/vmcp/optimizer/internal/toolstore/sqlite_store.go
+++ b/pkg/vmcp/optimizer/internal/toolstore/sqlite_store.go
@@ -96,13 +96,15 @@ func newSQLiteToolStore(
 		}
 	}
 
-	return sqliteToolStore{
+	store := sqliteToolStore{
 		db:                        db,
 		embeddingClient:           embeddingClient,
 		maxToolsToReturn:          maxTools,
 		hybridSemanticRatio:       hybridRatio,
 		semanticDistanceThreshold: semanticThreshold,
-	}, nil
+	}
+
+	return store, nil
 }
 
 // UpsertTools adds or updates tools in the store.
@@ -180,7 +182,11 @@ func (s sqliteToolStore) Search(ctx context.Context, query string, allowedTools 
 		if ftsExpr == "" {
 			return nil, nil
 		}
-		return s.searchFTS5(ctx, ftsExpr, allowedTools, s.maxToolsToReturn)
+		results, err := s.searchFTS5(ctx, ftsExpr, allowedTools, s.maxToolsToReturn)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
 	}
 
 	// Hybrid search: derive per-method limits from the ratio.
@@ -210,7 +216,9 @@ func (s sqliteToolStore) Search(ctx context.Context, query string, allowedTools 
 		return nil, err
 	}
 
-	return mergeResults(ftsResults, semanticResults, s.maxToolsToReturn), nil
+	merged := mergeResults(ftsResults, semanticResults, s.maxToolsToReturn)
+
+	return merged, nil
 }
 
 // Close releases the underlying database connection.
@@ -267,11 +275,14 @@ func (s sqliteToolStore) searchFTS5(
 		matches = append(matches, types.ToolMatch{
 			Name:        name,
 			Description: description,
-			Score:       normalizeBM25(rank),
 		})
 	}
 
-	return matches, rows.Err()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return matches, nil
 }
 
 // searchSemantic performs embedding-based semantic search.
@@ -310,7 +321,14 @@ func (s sqliteToolStore) searchSemantic(
 	}
 	defer func() { _ = rows.Close() }()
 
-	var matches []types.ToolMatch
+	type rankedMatch struct {
+		name        string
+		description string
+		dist        float64
+	}
+
+	var ranked []rankedMatch
+	var candidatesEvaluated int
 	for rows.Next() {
 		var name, description string
 		var embBlob []byte
@@ -318,6 +336,7 @@ func (s sqliteToolStore) searchSemantic(
 			return nil, fmt.Errorf("failed to scan row: %w", err)
 		}
 
+		candidatesEvaluated++
 		emb := decodeEmbedding(embBlob)
 		dist := similarity.CosineDistance(queryVec, emb)
 
@@ -328,10 +347,10 @@ func (s sqliteToolStore) searchSemantic(
 			continue
 		}
 
-		matches = append(matches, types.ToolMatch{
-			Name:        name,
-			Description: description,
-			Score:       dist,
+		ranked = append(ranked, rankedMatch{
+			name:        name,
+			description: description,
+			dist:        dist,
 		})
 	}
 
@@ -340,40 +359,49 @@ func (s sqliteToolStore) searchSemantic(
 	}
 
 	// Sort by distance ascending (lower = better match)
-	sort.Slice(matches, func(i, j int) bool {
-		return matches[i].Score < matches[j].Score
+	sort.Slice(ranked, func(i, j int) bool {
+		return ranked[i].dist < ranked[j].dist
 	})
 
-	if len(matches) > limit {
-		matches = matches[:limit]
+	if len(ranked) > limit {
+		ranked = ranked[:limit]
+	}
+
+	matches := make([]types.ToolMatch, len(ranked))
+	for i, r := range ranked {
+		matches[i] = types.ToolMatch{
+			Name:        r.name,
+			Description: r.description,
+		}
 	}
 
 	return matches, nil
 }
 
-// mergeResults combines FTS5 and semantic results, deduplicating by name
-// (keeping the lower score for duplicates), sorting by score ascending
-// (lower = better match), and truncating to maxResults.
+// mergeResults combines semantic and FTS5 results, deduplicating by name.
+// Semantic results are listed first (preserving their distance-based order),
+// followed by FTS5 results not already present, and truncated to maxResults.
 func mergeResults(fts, semantic []types.ToolMatch, maxResults int) []types.ToolMatch {
-	seen := make(map[string]types.ToolMatch, len(fts)+len(semantic))
-	for _, m := range fts {
-		seen[m.Name] = m
-	}
-	for _, m := range semantic {
-		existing, ok := seen[m.Name]
-		if !ok || m.Score < existing.Score {
-			seen[m.Name] = m
-		}
-	}
+	seen := make(map[string]struct{}, len(fts)+len(semantic))
+	merged := make([]types.ToolMatch, 0, len(fts)+len(semantic))
 
-	merged := make([]types.ToolMatch, 0, len(seen))
-	for _, m := range seen {
+	// Semantic results first.
+	for _, m := range semantic {
+		if _, ok := seen[m.Name]; ok {
+			continue
+		}
+		seen[m.Name] = struct{}{}
 		merged = append(merged, m)
 	}
 
-	sort.Slice(merged, func(i, j int) bool {
-		return merged[i].Score < merged[j].Score
-	})
+	// Then FTS5 results not already seen.
+	for _, m := range fts {
+		if _, ok := seen[m.Name]; ok {
+			continue
+		}
+		seen[m.Name] = struct{}{}
+		merged = append(merged, m)
+	}
 
 	if len(merged) > maxResults {
 		merged = merged[:maxResults]
@@ -444,13 +472,6 @@ func hybridSearchLimits(total int, semanticRatio float64) (ftsLimit, semanticLim
 	semanticLimit = int(math.Round(float64(total) * semanticRatio))
 	ftsLimit = total - semanticLimit
 	return ftsLimit, semanticLimit
-}
-
-// normalizeBM25 converts an FTS5 bm25() rank to a [0, 2) distance score.
-// FTS5 bm25() returns negative values where more negative = better match.
-// The output is scaled to [0, 2) to align with cosine distance range.
-func normalizeBM25(rank float64) float64 {
-	return 2.0 / (1.0 - rank)
 }
 
 // encodeEmbedding serializes a float32 slice to a little-endian byte slice.

--- a/pkg/vmcp/optimizer/internal/toolstore/sqlite_store_test.go
+++ b/pkg/vmcp/optimizer/internal/toolstore/sqlite_store_test.go
@@ -152,7 +152,6 @@ func TestSQLiteToolStore_Search(t *testing.T) {
 		allowedTools []string
 		wantNames    []string
 		wantNonEmpty bool // just assert results are non-empty (when exact names vary)
-		checkScores  bool // assert all scores are in (0, 2)
 	}{
 		{
 			name: "search by name",
@@ -233,7 +232,7 @@ func TestSQLiteToolStore_Search(t *testing.T) {
 			wantNonEmpty: true,
 		},
 		{
-			name: "BM25 scores are normalized to (0, 2)",
+			name: "BM25 returns results for matching query",
 			tools: makeTools(
 				mcp.NewTool("generic_tool", mcp.WithDescription("A tool that does many things including search")),
 				mcp.NewTool("search_tool", mcp.WithDescription("Search for files, search documents, search everything")),
@@ -241,7 +240,6 @@ func TestSQLiteToolStore_Search(t *testing.T) {
 			query:        "search",
 			allowedTools: []string{"generic_tool", "search_tool"},
 			wantNonEmpty: true,
-			checkScores:  true,
 		},
 	}
 
@@ -266,12 +264,6 @@ func TestSQLiteToolStore_Search(t *testing.T) {
 				require.ElementsMatch(t, tc.wantNames, gotNames)
 			}
 
-			if tc.checkScores {
-				for _, r := range results {
-					require.Greater(t, r.Score, 0.0, "score should be positive for tool %s", r.Name)
-					require.Less(t, r.Score, 2.0, "score should be < 2 for tool %s", r.Name)
-				}
-			}
 		})
 	}
 }
@@ -407,12 +399,6 @@ func TestSQLiteToolStore_SemanticSearch(t *testing.T) {
 	results, err := store.searchSemantic(ctx, "read a file from disk", toolNames(tools), DefaultMaxToolsToReturn)
 	require.NoError(t, err)
 	require.NotEmpty(t, results)
-
-	// Results should be sorted by score ascending (lower = better)
-	for i := 1; i < len(results); i++ {
-		require.LessOrEqual(t, results[i-1].Score, results[i].Score,
-			"results should be sorted by score ascending")
-	}
 }
 
 func TestSQLiteToolStore_HybridSearch(t *testing.T) {
@@ -544,31 +530,6 @@ func TestHybridSearchLimits(t *testing.T) {
 	}
 }
 
-func TestNormalizeBM25(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name    string
-		rank    float64
-		wantMin float64
-		wantMax float64
-	}{
-		{name: "zero rank", rank: 0, wantMin: 1.9, wantMax: 2.1},
-		{name: "rank -1", rank: -1, wantMin: 0.9, wantMax: 1.1},
-		{name: "rank -9", rank: -9, wantMin: 0.19, wantMax: 0.21},
-		{name: "rank -0.5", rank: -0.5, wantMin: 1.3, wantMax: 1.4},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			score := normalizeBM25(tt.rank)
-			require.GreaterOrEqual(t, score, tt.wantMin, "normalizeBM25(%f) = %f", tt.rank, score)
-			require.LessOrEqual(t, score, tt.wantMax, "normalizeBM25(%f) = %f", tt.rank, score)
-		})
-	}
-}
-
 func TestMergeResults(t *testing.T) {
 	t.Parallel()
 
@@ -577,85 +538,55 @@ func TestMergeResults(t *testing.T) {
 		fts        []types.ToolMatch
 		semantic   []types.ToolMatch
 		maxResults int
-		wantNames  []string // expected names in order (sorted by score ascending)
-		wantScores []float64
+		wantNames  []string // expected names in order (semantic first, then FTS5)
 	}{
 		{
-			name: "deduplicates keeping lower score",
+			name: "deduplicates keeping semantic entry",
 			fts: []types.ToolMatch{
-				{Name: "tool_a", Description: "A", Score: 1.0},
+				{Name: "tool_a", Description: "A"},
 			},
 			semantic: []types.ToolMatch{
-				{Name: "tool_a", Description: "A", Score: 0.5},
+				{Name: "tool_a", Description: "A"},
 			},
 			maxResults: 10,
 			wantNames:  []string{"tool_a"},
-			wantScores: []float64{0.5},
 		},
 		{
-			name: "deduplicates keeping fts score when lower",
+			name: "semantic results come first",
 			fts: []types.ToolMatch{
-				{Name: "tool_a", Description: "A", Score: 0.3},
+				{Name: "tool_a", Description: "A"},
 			},
 			semantic: []types.ToolMatch{
-				{Name: "tool_a", Description: "A", Score: 0.8},
-			},
-			maxResults: 10,
-			wantNames:  []string{"tool_a"},
-			wantScores: []float64{0.3},
-		},
-		{
-			name: "combines unique results sorted by score",
-			fts: []types.ToolMatch{
-				{Name: "tool_a", Description: "A", Score: 0.5},
-			},
-			semantic: []types.ToolMatch{
-				{Name: "tool_b", Description: "B", Score: 0.3},
+				{Name: "tool_b", Description: "B"},
 			},
 			maxResults: 10,
 			wantNames:  []string{"tool_b", "tool_a"},
-			wantScores: []float64{0.3, 0.5},
 		},
 		{
-			name: "sorts by score ascending",
+			name: "preserves order within each group",
 			fts: []types.ToolMatch{
-				{Name: "tool_c", Description: "C", Score: 0.9},
-				{Name: "tool_a", Description: "A", Score: 0.1},
+				{Name: "tool_c", Description: "C"},
+				{Name: "tool_a", Description: "A"},
 			},
 			semantic: []types.ToolMatch{
-				{Name: "tool_b", Description: "B", Score: 0.5},
+				{Name: "tool_b", Description: "B"},
 			},
 			maxResults: 10,
-			wantNames:  []string{"tool_a", "tool_b", "tool_c"},
-			wantScores: []float64{0.1, 0.5, 0.9},
+			wantNames:  []string{"tool_b", "tool_c", "tool_a"},
 		},
 		{
 			name: "truncates to maxResults",
 			fts: []types.ToolMatch{
-				{Name: "tool_a", Description: "A", Score: 0.1},
-				{Name: "tool_b", Description: "B", Score: 0.2},
-				{Name: "tool_c", Description: "C", Score: 0.3},
+				{Name: "tool_a", Description: "A"},
+				{Name: "tool_b", Description: "B"},
+				{Name: "tool_c", Description: "C"},
 			},
 			semantic: []types.ToolMatch{
-				{Name: "tool_d", Description: "D", Score: 0.4},
-				{Name: "tool_e", Description: "E", Score: 0.5},
+				{Name: "tool_d", Description: "D"},
+				{Name: "tool_e", Description: "E"},
 			},
 			maxResults: 3,
-			wantNames:  []string{"tool_a", "tool_b", "tool_c"},
-			wantScores: []float64{0.1, 0.2, 0.3},
-		},
-		{
-			name: "truncation removes worst scores",
-			fts: []types.ToolMatch{
-				{Name: "tool_z", Description: "Z", Score: 1.5},
-				{Name: "tool_a", Description: "A", Score: 0.1},
-			},
-			semantic: []types.ToolMatch{
-				{Name: "tool_m", Description: "M", Score: 0.7},
-			},
-			maxResults: 2,
-			wantNames:  []string{"tool_a", "tool_m"},
-			wantScores: []float64{0.1, 0.7},
+			wantNames:  []string{"tool_d", "tool_e", "tool_a"},
 		},
 		{
 			name:       "both empty",
@@ -663,22 +594,20 @@ func TestMergeResults(t *testing.T) {
 			semantic:   nil,
 			maxResults: 10,
 			wantNames:  nil,
-			wantScores: nil,
 		},
 		{
-			name: "dedup with sort and truncate combined",
+			name: "dedup with truncate combined",
 			fts: []types.ToolMatch{
-				{Name: "dup", Description: "D", Score: 0.8},
-				{Name: "best", Description: "B", Score: 0.1},
-				{Name: "worst", Description: "W", Score: 1.9},
+				{Name: "dup", Description: "D"},
+				{Name: "best", Description: "B"},
+				{Name: "worst", Description: "W"},
 			},
 			semantic: []types.ToolMatch{
-				{Name: "dup", Description: "D", Score: 0.3},
-				{Name: "mid", Description: "M", Score: 0.5},
+				{Name: "dup", Description: "D"},
+				{Name: "mid", Description: "M"},
 			},
 			maxResults: 3,
-			wantNames:  []string{"best", "dup", "mid"},
-			wantScores: []float64{0.1, 0.3, 0.5},
+			wantNames:  []string{"dup", "mid", "best"},
 		},
 	}
 
@@ -688,13 +617,10 @@ func TestMergeResults(t *testing.T) {
 			merged := mergeResults(tc.fts, tc.semantic, tc.maxResults)
 
 			var gotNames []string
-			var gotScores []float64
 			for _, m := range merged {
 				gotNames = append(gotNames, m.Name)
-				gotScores = append(gotScores, m.Score)
 			}
 			require.Equal(t, tc.wantNames, gotNames)
-			require.Equal(t, tc.wantScores, gotScores)
 		})
 	}
 }
@@ -777,11 +703,9 @@ func TestSQLiteToolStore_SemanticDistanceThreshold(t *testing.T) {
 	// With a threshold of 0.001, most results should be filtered out in semantic search
 	results, err := store.searchSemantic(ctx, "some random query", toolNames(tools), DefaultMaxToolsToReturn)
 	require.NoError(t, err)
-	// All results should have distance <= 0.001
-	for _, r := range results {
-		require.LessOrEqual(t, r.Score, 0.001,
-			"semantic result %s should have distance <= threshold", r.Name)
-	}
+	// With such a tight threshold, very few (if any) results should pass
+	require.Less(t, len(results), len(tools),
+		"tight threshold should filter out some results")
 }
 
 // newFakeEmbeddingClient is a test helper that creates a deterministic embedding client.

--- a/pkg/vmcp/optimizer/internal/types/types.go
+++ b/pkg/vmcp/optimizer/internal/types/types.go
@@ -42,10 +42,6 @@ type ToolMatch struct {
 
 	// Description is the human-readable description of the tool.
 	Description string `json:"description"`
-
-	// Score is a distance metric indicating how well this tool matches.
-	// Lower values indicate better matches (0 = identical, 2 = opposite).
-	Score float64 `json:"score"`
 }
 
 // EmbeddingClient generates vector embeddings from text.

--- a/pkg/vmcp/optimizer/optimizer.go
+++ b/pkg/vmcp/optimizer/optimizer.go
@@ -91,7 +91,7 @@ func GetAndValidateConfig(cfg *vmcpconfig.OptimizerConfig) (*Config, error) {
 // registered for each session.
 type Optimizer interface {
 	// FindTool searches for tools matching the given description and keywords.
-	// Returns matching tools ranked by relevance score.
+	// Returns matching tools ranked by relevance.
 	FindTool(ctx context.Context, input FindToolInput) (*FindToolOutput, error)
 
 	// CallTool invokes a tool by name with the given parameters.

--- a/pkg/vmcp/server/adapter/optimizer_adapter_test.go
+++ b/pkg/vmcp/server/adapter/optimizer_adapter_test.go
@@ -55,7 +55,6 @@ func TestFindToolHandler(t *testing.T) {
 					{
 						Name:        "read_file",
 						Description: "Read a file",
-						Score:       1.0,
 					},
 				},
 			}, nil


### PR DESCRIPTION
## Summary

- Remove the `Score` field from `ToolMatch` to avoid exposing internal distance metrics (cosine distance + interpolated BM25) in tool search results
- Refactor `mergeResults` to prioritize semantic results first instead of sorting by score, since the two scoring methods are not directly comparable
- Clean up related test assertions and remove the `normalizeBM25` helper that is no longer needed
- Fix minor doc comment referencing "relevance score" in the `FindTool` interface method

## Test plan

- [ ] Run `task test` to verify all unit tests pass
- [ ] Verify `ToolMatch` struct no longer contains `Score` in any public API surface
- [ ] Confirm `mergeResults` correctly deduplicates and orders semantic-first

🤖 Generated with [Claude Code](https://claude.com/claude-code)