### PR TITLE
Fix proxy shutdown follow-ups from #3970

### DIFF
--- a/pkg/transport/proxy/transparent/transparent_proxy.go
+++ b/pkg/transport/proxy/transparent/transparent_proxy.go
@@ -184,8 +184,6 @@ func withShutdownTimeout(timeout time.Duration) Option {
 	}
 }
 
-// NewTransparentProxy creates a new transparent proxy with optional middlewares and configuration options.
-
 // NewTransparentProxy creates a new transparent proxy with optional middlewares.
 // The endpointPrefix parameter specifies an explicit prefix to prepend to SSE endpoint URLs.
 // The trustProxyHeaders parameter indicates whether to trust X-Forwarded-* headers from reverse proxies.
@@ -440,6 +438,11 @@ func (p *TransparentProxy) modifyResponse(resp *http.Response) error {
 func (p *TransparentProxy) Start(ctx context.Context) error {
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
+
+	// Guard against calling Start() after Stop()
+	if p.stopped {
+		return fmt.Errorf("proxy has been stopped")
+	}
 
 	// Parse the target URI
 	targetURL, err := url.Parse(p.targetURI)

--- a/pkg/transport/proxy/transparent/transparent_test.go
+++ b/pkg/transport/proxy/transparent/transparent_test.go
@@ -1789,7 +1789,7 @@ func TestTransparentProxy_IsRunningDoesNotBlockDuringStop(t *testing.T) {
 		withShutdownTimeout(10*time.Second),
 	)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	err := proxy.Start(ctx)
 	require.NoError(t, err)
 
@@ -1872,7 +1872,7 @@ func TestTransparentProxy_StopForcesCloseAfterTimeout(t *testing.T) {
 		withShutdownTimeout(500*time.Millisecond),
 	)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	err := proxy.Start(ctx)
 	require.NoError(t, err)
 
@@ -1910,7 +1910,7 @@ func TestTransparentProxy_ServerHasIdleTimeout(t *testing.T) {
 		false, false, "sse", nil, nil, "", false, nil,
 	)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	err := proxy.Start(ctx)
 	require.NoError(t, err)
 	defer func() { _ = proxy.Stop(ctx) }()


### PR DESCRIPTION
## Summary

- Use `t.Context()` instead of `context.Background()` in new shutdown tests per project conventions
- Add `Start()` guard against calling after `Stop()` to prevent a leaked server if the lifecycle is violated
- Remove duplicate godoc comment on `NewTransparentProxy`

## Test plan

- [x] All 3 new tests from #3970 pass with `-race`
- [x] Full transparent proxy test suite passes (30+ tests)
- [x] `golangci-lint` clean

Fixes follow-ups from #3970

🤖 Generated with [Claude Code](https://claude.com/claude-code)