### PR TITLE
Refactor session timeouts and add V2 feature warnings

### DIFF
--- a/pkg/transport/session/manager.go
+++ b/pkg/transport/session/manager.go
@@ -11,6 +11,13 @@ import (
 	"time"
 )
 
+const (
+	// defaultOperationTimeout is the timeout for standard storage operations
+	defaultOperationTimeout = 5 * time.Second
+	// cleanupOperationTimeout is the timeout for cleanup operations which may take longer
+	cleanupOperationTimeout = 30 * time.Second
+)
+
 // Session interface defines the contract for all session types
 type Session interface {
 	ID() string
@@ -113,7 +120,7 @@ func (m *Manager) cleanupRoutine() {
 		select {
 		case <-ticker.C:
 			cutoff := time.Now().Add(-m.ttl)
-			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), cleanupOperationTimeout)
 			if err := m.storage.DeleteExpired(ctx, cutoff); err != nil {
 				slog.Error("failed to delete expired sessions", "error", err)
 			}
@@ -131,7 +138,7 @@ func (m *Manager) AddWithID(id string) error {
 		return fmt.Errorf("session ID cannot be empty")
 	}
 	// Check if session already exists
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), defaultOperationTimeout)
 	defer cancel()
 
 	if _, err := m.storage.Load(ctx, id); err == nil {
@@ -154,7 +161,7 @@ func (m *Manager) AddSession(session Session) error {
 	}
 
 	// Check if session already exists
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), defaultOperationTimeout)
 	defer cancel()
 
 	if _, err := m.storage.Load(ctx, session.ID()); err == nil {
@@ -167,7 +174,7 @@ func (m *Manager) AddSession(session Session) error {
 // Get retrieves a session by ID. Returns (session, true) if found,
 // and also updates its UpdatedAt timestamp.
 func (m *Manager) Get(id string) (Session, bool) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), defaultOperationTimeout)
 	defer cancel()
 
 	sess, err := m.storage.Load(ctx, id)
@@ -189,7 +196,7 @@ func (m *Manager) UpsertSession(session Session) error {
 	if session.ID() == "" {
 		return fmt.Errorf("session ID cannot be empty")
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), defaultOperationTimeout)
 	defer cancel()
 	return m.storage.Store(ctx, session)
 }
@@ -197,7 +204,7 @@ func (m *Manager) UpsertSession(session Session) error {
 // Delete removes a session by ID.
 // Returns an error if the deletion fails.
 func (m *Manager) Delete(id string) error {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), defaultOperationTimeout)
 	defer cancel()
 	return m.storage.Delete(ctx, id)
 }
@@ -246,7 +253,7 @@ func (m *Manager) Count() int {
 
 func (m *Manager) cleanupExpiredOnce() error {
 	cutoff := time.Now().Add(-m.ttl)
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), cleanupOperationTimeout)
 	defer cancel()
 	return m.storage.DeleteExpired(ctx, cutoff)
 }

--- a/pkg/vmcp/server/server.go
+++ b/pkg/vmcp/server/server.go
@@ -337,21 +337,32 @@ func New(
 	stateStore := composer.NewInMemoryStateStore(5*time.Minute, 1*time.Hour)
 	workflowComposer := composer.NewWorkflowEngine(rt, backendClient, elicitationHandler, stateStore, workflowAuditor)
 
-	// Validate workflows and create executors (fail fast on invalid workflows)
-	workflowDefs, workflowExecutors, err := validateAndCreateExecutors(workflowComposer, workflowDefs)
-	if err != nil {
-		return nil, fmt.Errorf("workflow validation failed: %w", err)
-	}
-
-	// Decorate workflow executors with telemetry if provider is configured
-	if cfg.TelemetryProvider != nil {
-		workflowExecutors, err = monitorWorkflowExecutors(
-			cfg.TelemetryProvider.MeterProvider(),
-			cfg.TelemetryProvider.TracerProvider(),
-			workflowExecutors,
-		)
+	// Skip workflow validation and executor creation when SessionManagementV2 is enabled
+	// (composite tools are not supported in V2 path)
+	var workflowExecutors map[string]adapter.WorkflowExecutor
+	var err error
+	if cfg.SessionManagementV2 && len(workflowDefs) > 0 {
+		slog.Warn("SessionManagementV2 does not support composite tools; skipping workflow validation",
+			"workflow_count", len(workflowDefs))
+		workflowDefs = nil
+		workflowExecutors = nil
+	} else {
+		// Validate workflows and create executors (fail fast on invalid workflows)
+		workflowDefs, workflowExecutors, err = validateAndCreateExecutors(workflowComposer, workflowDefs)
 		if err != nil {
-			return nil, fmt.Errorf("failed to monitor workflow executors: %w", err)
+			return nil, fmt.Errorf("workflow validation failed: %w", err)
+		}
+
+		// Decorate workflow executors with telemetry if provider is configured
+		if cfg.TelemetryProvider != nil && len(workflowExecutors) > 0 {
+			workflowExecutors, err = monitorWorkflowExecutors(
+				cfg.TelemetryProvider.MeterProvider(),
+				cfg.TelemetryProvider.TracerProvider(),
+				workflowExecutors,
+			)
+			if err != nil {
+				return nil, fmt.Errorf("failed to monitor workflow executors: %w", err)
+			}
 		}
 	}
 
@@ -391,6 +402,13 @@ func New(
 		}
 		vmcpSessMgr = sessionmanager.New(sessionManager, cfg.SessionFactory, backendRegistry)
 		slog.Info("session-scoped backend lifecycle enabled")
+
+		// Warn about incompatible optimizer configuration and disable it
+		if cfg.OptimizerConfig != nil {
+			slog.Warn("SessionManagementV2 does not support optimizer mode; optimizer configuration will be ignored")
+			cfg.OptimizerConfig = nil // Prevent optimizer initialization in Start()
+		}
+		// Note: Composite tools warning and disabling happens earlier before validation
 	}
 
 	// Create Server instance


### PR DESCRIPTION
Extract hardcoded timeout values in session manager into package-level constants for better maintainability. Add startup warnings when SessionManagementV2 is configured with incompatible features.

Changes:
- pkg/transport/session: Extract 5s and 30s timeouts to named constants (defaultOperationTimeout and cleanupOperationTimeout) to improve readability and make adjustments easier
- pkg/vmcp/server: Warn operators at startup when SessionManagementV2 is enabled alongside unsupported features (optimizer mode, composite tools) to provide early feedback instead of silent feature loss

Addresses PR review feedback from @aponcedeleonch.

Closes: #3866