### PR TITLE
Add debug logging to optimizer

### DIFF
--- a/pkg/vmcp/optimizer/internal/similarity/tei_client.go
+++ b/pkg/vmcp/optimizer/internal/similarity/tei_client.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"time"
 
@@ -49,6 +50,8 @@ func newTEIClient(baseURL string, timeout time.Duration) (*teiClient, error) {
 	if timeout == 0 {
 		timeout = defaultTimeout
 	}
+
+	slog.Debug("TEI embedding client created", "base_url", baseURL, "timeout", timeout)
 
 	return &teiClient{
 		baseURL: baseURL,
@@ -121,6 +124,8 @@ func (c *teiClient) EmbedBatch(ctx context.Context, texts []string) ([][]float32
 	if len(embeddings) != len(texts) {
 		return nil, fmt.Errorf("TEI returned %d embeddings for %d inputs", len(embeddings), len(texts))
 	}
+
+	slog.Debug("TEI embedding batch completed", "inputs", len(texts), "dimensions", len(embeddings[0]))
 
 	return embeddings, nil
 }

--- a/pkg/vmcp/optimizer/internal/toolstore/sqlite_store.go
+++ b/pkg/vmcp/optimizer/internal/toolstore/sqlite_store.go
@@ -14,6 +14,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"math"
 	"sort"
 	"strings"
@@ -104,6 +105,13 @@ func newSQLiteToolStore(
 		semanticDistanceThreshold: semanticThreshold,
 	}
 
+	slog.Debug("optimizer tool store created",
+		"max_tools_to_return", maxTools,
+		"hybrid_semantic_ratio", hybridRatio,
+		"semantic_distance_threshold", semanticThreshold,
+		"semantic_search_enabled", embeddingClient != nil,
+	)
+
 	return store, nil
 }
 
@@ -135,6 +143,8 @@ func (s sqliteToolStore) UpsertTools(ctx context.Context, tools []server.ServerT
 			return fmt.Errorf("failed to upsert tool %s: %w", tool.Tool.Name, err)
 		}
 	}
+
+	slog.Debug("upserted tools into store", "count", len(tools))
 
 	return tx.Commit()
 }
@@ -172,6 +182,7 @@ func (s sqliteToolStore) generateEmbeddings(ctx context.Context, tools []server.
 // Returns matches ranked by relevance.
 func (s sqliteToolStore) Search(ctx context.Context, query string, allowedTools []string) ([]types.ToolMatch, error) {
 	if len(allowedTools) == 0 {
+		slog.Debug("search skipped, no allowed tools")
 		return nil, nil
 	}
 
@@ -180,12 +191,14 @@ func (s sqliteToolStore) Search(ctx context.Context, query string, allowedTools 
 	// FTS5-only path (no embedding client)
 	if s.embeddingClient == nil {
 		if ftsExpr == "" {
+			slog.Debug("search skipped, empty FTS5 expression", "query", query)
 			return nil, nil
 		}
 		results, err := s.searchFTS5(ctx, ftsExpr, allowedTools, s.maxToolsToReturn)
 		if err != nil {
 			return nil, err
 		}
+		slog.Debug("search completed (FTS5-only)", "query", query, "results", len(results), "matched_tools", matchNames(results))
 		return results, nil
 	}
 
@@ -217,6 +230,14 @@ func (s sqliteToolStore) Search(ctx context.Context, query string, allowedTools 
 	}
 
 	merged := mergeResults(ftsResults, semanticResults, s.maxToolsToReturn)
+
+	slog.Debug("search completed (hybrid)",
+		"query", query,
+		"fts5_results", len(ftsResults),
+		"semantic_results", len(semanticResults),
+		"merged_results", len(merged),
+		"matched_tools", matchNames(merged),
+	)
 
 	return merged, nil
 }
@@ -281,6 +302,14 @@ func (s sqliteToolStore) searchFTS5(
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
+
+	slog.Debug("FTS5 search completed",
+		"fts_expression", ftsExpr,
+		"allowed_tools", len(allowedTools),
+		"limit", limit,
+		"results", len(matches),
+		"matched_tools", matchNames(matches),
+	)
 
 	return matches, nil
 }
@@ -375,6 +404,14 @@ func (s sqliteToolStore) searchSemantic(
 		}
 	}
 
+	slog.Debug("semantic search completed",
+		"allowed_tools", len(allowedTools),
+		"limit", limit,
+		"candidates_evaluated", candidatesEvaluated,
+		"results", len(matches),
+		"matched_tools", matchNames(matches),
+	)
+
 	return matches, nil
 }
 
@@ -408,6 +445,15 @@ func mergeResults(fts, semantic []types.ToolMatch, maxResults int) []types.ToolM
 	}
 
 	return merged
+}
+
+// matchNames extracts tool names from a slice of ToolMatch results for logging.
+func matchNames(matches []types.ToolMatch) []string {
+	names := make([]string, len(matches))
+	for i, m := range matches {
+		names[i] = m.Name
+	}
+	return names
 }
 
 // problematicWords contains words that FTS5 interprets as operators or that

--- a/pkg/vmcp/optimizer/optimizer.go
+++ b/pkg/vmcp/optimizer/optimizer.go
@@ -15,6 +15,7 @@ package optimizer
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"strconv"
 	"time"
 
@@ -161,6 +162,11 @@ func NewOptimizerFactory(cfg *Config) (
 		return store.Close()
 	}
 
+	slog.Debug("optimizer factory created",
+		"embedding_service", cfg.EmbeddingService,
+		"semantic_search_enabled", embClient != nil,
+	)
+
 	return factory, cleanup, nil
 }
 
@@ -216,6 +222,11 @@ func newToolOptimizer(
 		return nil, fmt.Errorf("failed to upsert tools into store: %w", err)
 	}
 
+	slog.Debug("optimizer session created",
+		"tools", len(tools),
+		"baseline_tokens", baselineTokens,
+	)
+
 	return &toolOptimizer{
 		store:          store,
 		tools:          toolMap,
@@ -245,6 +256,15 @@ func (d *toolOptimizer) FindTool(ctx context.Context, input FindToolInput) (*Fin
 	}
 	metrics := tokencounter.ComputeTokenMetrics(d.baselineTokens, d.tokenCounts, matchedNames)
 
+	slog.Debug("find_tool completed",
+		"query", input.ToolDescription,
+		"keywords", input.ToolKeywords,
+		"results", len(matches),
+		"baseline_tokens", metrics.BaselineTokens,
+		"returned_tokens", metrics.ReturnedTokens,
+		"savings_percent", metrics.SavingsPercent,
+	)
+
 	return &FindToolOutput{
 		Tools:        matches,
 		TokenMetrics: metrics,
@@ -263,8 +283,11 @@ func (d *toolOptimizer) CallTool(ctx context.Context, input CallToolInput) (*mcp
 	// Verify the tool exists
 	tool, exists := d.tools[input.ToolName]
 	if !exists {
+		slog.Debug("call_tool failed, tool not found", "tool", input.ToolName)
 		return mcp.NewToolResultError(fmt.Sprintf("tool not found: %s", input.ToolName)), nil
 	}
+
+	slog.Debug("call_tool invoking backend tool", "tool", input.ToolName)
 
 	// Build the MCP request
 	request := mcp.CallToolRequest{}


### PR DESCRIPTION
Add slog.Debug calls throughout the optimizer package to aid troubleshooting:
- Factory and session creation with config details
- Tool store creation with search parameters
- Tool upsert operations with count
- Search operations (FTS5-only, hybrid, semantic) with results
- TEI embedding batch completion with dimensions