### PR TITLE
Add telemetry instrumentation for optimizer

### DIFF
--- a/pkg/vmcp/server/server.go
+++ b/pkg/vmcp/server/server.go
@@ -587,6 +587,17 @@ func (s *Server) Start(ctx context.Context) error {
 		}
 		s.shutdownFuncs = append(s.shutdownFuncs, cleanup)
 		s.config.OptimizerFactory = factory
+
+		if s.config.TelemetryProvider != nil {
+			s.config.OptimizerFactory, err = monitorOptimizer(
+				s.config.TelemetryProvider.MeterProvider(),
+				s.config.TelemetryProvider.TracerProvider(),
+				s.config.OptimizerFactory,
+			)
+			if err != nil {
+				return fmt.Errorf("failed to monitor optimizer: %w", err)
+			}
+		}
 	}
 
 	// Build the HTTP handler (middleware chain, routes, mux)

--- a/pkg/vmcp/server/telemetry.go
+++ b/pkg/vmcp/server/telemetry.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/mark3labs/mcp-go/mcp"
+	mcpserver "github.com/mark3labs/mcp-go/server"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
@@ -16,6 +18,7 @@ import (
 	"github.com/stacklok/toolhive/pkg/telemetry"
 	transporttypes "github.com/stacklok/toolhive/pkg/transport/types"
 	"github.com/stacklok/toolhive/pkg/vmcp"
+	"github.com/stacklok/toolhive/pkg/vmcp/optimizer"
 	"github.com/stacklok/toolhive/pkg/vmcp/server/adapter"
 )
 
@@ -331,4 +334,199 @@ func (t *telemetryWorkflowExecutor) ExecuteWorkflow(ctx context.Context, params 
 	}
 
 	return result, err
+}
+
+// monitorOptimizer wraps an optimizer factory so that every Optimizer instance
+// produced by the factory is decorated with telemetry (metrics + traces).
+func monitorOptimizer(
+	meterProvider metric.MeterProvider,
+	tracerProvider trace.TracerProvider,
+	factory func(context.Context, []mcpserver.ServerTool) (optimizer.Optimizer, error),
+) (func(context.Context, []mcpserver.ServerTool) (optimizer.Optimizer, error), error) {
+	meter := meterProvider.Meter(instrumentationName)
+
+	findToolRequests, err := meter.Int64Counter(
+		"toolhive_vmcp_optimizer_find_tool_requests",
+		metric.WithDescription("Total number of FindTool calls"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create find_tool requests counter: %w", err)
+	}
+
+	findToolErrors, err := meter.Int64Counter(
+		"toolhive_vmcp_optimizer_find_tool_errors",
+		metric.WithDescription("Total number of FindTool errors"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create find_tool errors counter: %w", err)
+	}
+
+	findToolDuration, err := meter.Float64Histogram(
+		"toolhive_vmcp_optimizer_find_tool_duration",
+		metric.WithDescription("Duration of FindTool calls in seconds"),
+		metric.WithUnit("s"),
+		metric.WithExplicitBucketBoundaries(telemetry.MCPHistogramBuckets...),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create find_tool duration histogram: %w", err)
+	}
+
+	findToolResults, err := meter.Float64Histogram(
+		"toolhive_vmcp_optimizer_find_tool_results",
+		metric.WithDescription("Number of tools returned per FindTool call"),
+		metric.WithUnit("{tools}"),
+		metric.WithExplicitBucketBoundaries(0, 1, 2, 3, 5, 10, 20, 50),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create find_tool results histogram: %w", err)
+	}
+
+	tokenSavingsPercent, err := meter.Float64Histogram(
+		"toolhive_vmcp_optimizer_token_savings_percent",
+		metric.WithDescription("Token savings percentage per FindTool call"),
+		metric.WithUnit("%"),
+		metric.WithExplicitBucketBoundaries(0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 95, 99, 100),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create token savings histogram: %w", err)
+	}
+
+	callToolRequests, err := meter.Int64Counter(
+		"toolhive_vmcp_optimizer_call_tool_requests",
+		metric.WithDescription("Total number of CallTool calls"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create call_tool requests counter: %w", err)
+	}
+
+	callToolErrors, err := meter.Int64Counter(
+		"toolhive_vmcp_optimizer_call_tool_errors",
+		metric.WithDescription("Total number of CallTool Go errors"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create call_tool errors counter: %w", err)
+	}
+
+	callToolNotFound, err := meter.Int64Counter(
+		"toolhive_vmcp_optimizer_call_tool_not_found",
+		metric.WithDescription("Total number of CallTool calls where result.IsError is true"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create call_tool not_found counter: %w", err)
+	}
+
+	callToolDuration, err := meter.Float64Histogram(
+		"toolhive_vmcp_optimizer_call_tool_duration",
+		metric.WithDescription("Duration of CallTool calls in seconds"),
+		metric.WithUnit("s"),
+		metric.WithExplicitBucketBoundaries(telemetry.MCPHistogramBuckets...),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create call_tool duration histogram: %w", err)
+	}
+
+	tracer := tracerProvider.Tracer(instrumentationName)
+
+	wrapped := func(ctx context.Context, tools []mcpserver.ServerTool) (optimizer.Optimizer, error) {
+		opt, err := factory(ctx, tools)
+		if err != nil {
+			return nil, err
+		}
+		return &telemetryOptimizer{
+			optimizer:           opt,
+			tracer:              tracer,
+			findToolRequests:    findToolRequests,
+			findToolErrors:      findToolErrors,
+			findToolDuration:    findToolDuration,
+			findToolResults:     findToolResults,
+			tokenSavingsPercent: tokenSavingsPercent,
+			callToolRequests:    callToolRequests,
+			callToolErrors:      callToolErrors,
+			callToolNotFound:    callToolNotFound,
+			callToolDuration:    callToolDuration,
+		}, nil
+	}
+
+	return wrapped, nil
+}
+
+// telemetryOptimizer wraps an optimizer.Optimizer with telemetry recording.
+type telemetryOptimizer struct {
+	optimizer optimizer.Optimizer
+	tracer    trace.Tracer
+
+	findToolRequests    metric.Int64Counter
+	findToolErrors      metric.Int64Counter
+	findToolDuration    metric.Float64Histogram
+	findToolResults     metric.Float64Histogram
+	tokenSavingsPercent metric.Float64Histogram
+
+	callToolRequests metric.Int64Counter
+	callToolErrors   metric.Int64Counter
+	callToolNotFound metric.Int64Counter
+	callToolDuration metric.Float64Histogram
+}
+
+var _ optimizer.Optimizer = (*telemetryOptimizer)(nil)
+
+// FindTool delegates to the wrapped optimizer and records metrics and traces.
+func (t *telemetryOptimizer) FindTool(ctx context.Context, input optimizer.FindToolInput) (*optimizer.FindToolOutput, error) {
+	ctx, span := t.tracer.Start(ctx, "optimizer.FindTool",
+		trace.WithAttributes(
+			attribute.String("tool_description", input.ToolDescription),
+		),
+	)
+	defer span.End()
+
+	start := time.Now()
+	t.findToolRequests.Add(ctx, 1)
+
+	result, err := t.optimizer.FindTool(ctx, input)
+
+	duration := time.Since(start)
+	t.findToolDuration.Record(ctx, duration.Seconds())
+
+	if err != nil {
+		t.findToolErrors.Add(ctx, 1)
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return nil, err
+	}
+
+	t.findToolResults.Record(ctx, float64(len(result.Tools)))
+	t.tokenSavingsPercent.Record(ctx, result.TokenMetrics.SavingsPercent)
+
+	return result, nil
+}
+
+// CallTool delegates to the wrapped optimizer and records metrics and traces.
+func (t *telemetryOptimizer) CallTool(ctx context.Context, input optimizer.CallToolInput) (*mcp.CallToolResult, error) {
+	toolAttr := attribute.String("tool_name", input.ToolName)
+
+	ctx, span := t.tracer.Start(ctx, "optimizer.CallTool",
+		trace.WithAttributes(toolAttr),
+	)
+	defer span.End()
+
+	metricAttrs := metric.WithAttributes(toolAttr)
+	start := time.Now()
+	t.callToolRequests.Add(ctx, 1, metricAttrs)
+
+	result, err := t.optimizer.CallTool(ctx, input)
+
+	duration := time.Since(start)
+	t.callToolDuration.Record(ctx, duration.Seconds(), metricAttrs)
+
+	if err != nil {
+		t.callToolErrors.Add(ctx, 1, metricAttrs)
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return nil, err
+	}
+
+	if result != nil && result.IsError {
+		t.callToolNotFound.Add(ctx, 1, metricAttrs)
+	}
+
+	return result, nil
 }

--- a/pkg/vmcp/server/telemetry_test.go
+++ b/pkg/vmcp/server/telemetry_test.go
@@ -4,7 +4,19 @@
 package server
 
 import (
+	"context"
+	"fmt"
 	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	mcpserver "github.com/mark3labs/mcp-go/server"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	tracenoop "go.opentelemetry.io/otel/trace/noop"
+
+	"github.com/stacklok/toolhive/pkg/vmcp/optimizer"
 )
 
 func TestMapActionToMCPMethod(t *testing.T) {
@@ -55,6 +67,300 @@ func TestMapTransportTypeToNetworkTransport(t *testing.T) {
 			if got != tt.expected {
 				t.Errorf("mapTransportTypeToNetworkTransport(%q) = %q, want %q", tt.transportType, got, tt.expected)
 			}
+		})
+	}
+}
+
+// fakeOptimizer implements optimizer.Optimizer for testing.
+type fakeOptimizer struct {
+	findToolFn func(ctx context.Context, input optimizer.FindToolInput) (*optimizer.FindToolOutput, error)
+	callToolFn func(ctx context.Context, input optimizer.CallToolInput) (*mcp.CallToolResult, error)
+}
+
+func (f *fakeOptimizer) FindTool(ctx context.Context, input optimizer.FindToolInput) (*optimizer.FindToolOutput, error) {
+	return f.findToolFn(ctx, input)
+}
+
+func (f *fakeOptimizer) CallTool(ctx context.Context, input optimizer.CallToolInput) (*mcp.CallToolResult, error) {
+	return f.callToolFn(ctx, input)
+}
+
+// findMetric returns the first metric matching the given name from the collected resource metrics.
+func findMetric(rm metricdata.ResourceMetrics, name string) *metricdata.Metrics {
+	for _, sm := range rm.ScopeMetrics {
+		for i := range sm.Metrics {
+			if sm.Metrics[i].Name == name {
+				return &sm.Metrics[i]
+			}
+		}
+	}
+	return nil
+}
+
+// counterValue returns the sum of all data points for an Int64 counter metric.
+// Returns 0 if m is nil (metric not reported because it was never incremented).
+func counterValue(m *metricdata.Metrics) int64 {
+	if m == nil {
+		return 0
+	}
+	sum, ok := m.Data.(metricdata.Sum[int64])
+	if !ok {
+		return 0
+	}
+	var total int64
+	for _, dp := range sum.DataPoints {
+		total += dp.Value
+	}
+	return total
+}
+
+// histogramCount returns the total count across all data points for a Float64 histogram metric.
+// Returns 0 if m is nil (metric not reported because it was never recorded).
+func histogramCount(m *metricdata.Metrics) uint64 {
+	if m == nil {
+		return 0
+	}
+	hist, ok := m.Data.(metricdata.Histogram[float64])
+	if !ok {
+		return 0
+	}
+	var total uint64
+	for _, dp := range hist.DataPoints {
+		total += dp.Count
+	}
+	return total
+}
+
+func TestTelemetryOptimizer(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		setup      func() *fakeOptimizer
+		action     func(t *testing.T, opt optimizer.Optimizer)
+		assertFunc func(t *testing.T, rm metricdata.ResourceMetrics)
+	}{
+		{
+			name: "FindTool success records requests counter, duration, results, and savings",
+			setup: func() *fakeOptimizer {
+				return &fakeOptimizer{
+					findToolFn: func(_ context.Context, _ optimizer.FindToolInput) (*optimizer.FindToolOutput, error) {
+						return &optimizer.FindToolOutput{
+							Tools: []optimizer.ToolMatch{
+								{Name: "tool_a", Description: "Tool A"},
+								{Name: "tool_b", Description: "Tool B"},
+							},
+							TokenMetrics: optimizer.TokenMetrics{
+								BaselineTokens: 1000,
+								ReturnedTokens: 200,
+								SavingsPercent: 80.0,
+							},
+						}, nil
+					},
+				}
+			},
+			action: func(t *testing.T, opt optimizer.Optimizer) {
+				t.Helper()
+				result, err := opt.FindTool(context.Background(), optimizer.FindToolInput{
+					ToolDescription: "search tools",
+				})
+				require.NoError(t, err)
+				require.Len(t, result.Tools, 2)
+			},
+			assertFunc: func(t *testing.T, rm metricdata.ResourceMetrics) {
+				t.Helper()
+				// Requests counter
+				m := findMetric(rm, "toolhive_vmcp_optimizer_find_tool_requests")
+				require.NotNil(t, m, "find_tool_requests metric should exist")
+				assert.Equal(t, int64(1), counterValue(m))
+
+				// No errors (counter not reported when never incremented)
+				assert.Equal(t, int64(0), counterValue(findMetric(rm, "toolhive_vmcp_optimizer_find_tool_errors")))
+
+				// Duration histogram
+				m = findMetric(rm, "toolhive_vmcp_optimizer_find_tool_duration")
+				require.NotNil(t, m, "find_tool_duration metric should exist")
+				assert.Equal(t, uint64(1), histogramCount(m))
+
+				// Results histogram (2 tools returned)
+				m = findMetric(rm, "toolhive_vmcp_optimizer_find_tool_results")
+				require.NotNil(t, m, "find_tool_results metric should exist")
+				assert.Equal(t, uint64(1), histogramCount(m))
+
+				// Token savings histogram
+				m = findMetric(rm, "toolhive_vmcp_optimizer_token_savings_percent")
+				require.NotNil(t, m, "token_savings_percent metric should exist")
+				assert.Equal(t, uint64(1), histogramCount(m))
+			},
+		},
+		{
+			name: "FindTool error increments error counter",
+			setup: func() *fakeOptimizer {
+				return &fakeOptimizer{
+					findToolFn: func(_ context.Context, _ optimizer.FindToolInput) (*optimizer.FindToolOutput, error) {
+						return nil, fmt.Errorf("search failed")
+					},
+				}
+			},
+			action: func(t *testing.T, opt optimizer.Optimizer) {
+				t.Helper()
+				_, err := opt.FindTool(context.Background(), optimizer.FindToolInput{
+					ToolDescription: "search tools",
+				})
+				require.Error(t, err)
+			},
+			assertFunc: func(t *testing.T, rm metricdata.ResourceMetrics) {
+				t.Helper()
+				m := findMetric(rm, "toolhive_vmcp_optimizer_find_tool_requests")
+				require.NotNil(t, m)
+				assert.Equal(t, int64(1), counterValue(m))
+
+				m = findMetric(rm, "toolhive_vmcp_optimizer_find_tool_errors")
+				require.NotNil(t, m)
+				assert.Equal(t, int64(1), counterValue(m))
+
+				// Duration should still be recorded
+				m = findMetric(rm, "toolhive_vmcp_optimizer_find_tool_duration")
+				require.NotNil(t, m)
+				assert.Equal(t, uint64(1), histogramCount(m))
+
+				// Results and savings should not be recorded on error
+				assert.Equal(t, uint64(0), histogramCount(findMetric(rm, "toolhive_vmcp_optimizer_find_tool_results")))
+			},
+		},
+		{
+			name: "CallTool success records requests counter and duration with tool_name attribute",
+			setup: func() *fakeOptimizer {
+				return &fakeOptimizer{
+					callToolFn: func(_ context.Context, _ optimizer.CallToolInput) (*mcp.CallToolResult, error) {
+						return &mcp.CallToolResult{
+							Content: []mcp.Content{mcp.NewTextContent("result")},
+						}, nil
+					},
+				}
+			},
+			action: func(t *testing.T, opt optimizer.Optimizer) {
+				t.Helper()
+				result, err := opt.CallTool(context.Background(), optimizer.CallToolInput{
+					ToolName: "my_tool",
+				})
+				require.NoError(t, err)
+				require.False(t, result.IsError)
+			},
+			assertFunc: func(t *testing.T, rm metricdata.ResourceMetrics) {
+				t.Helper()
+				m := findMetric(rm, "toolhive_vmcp_optimizer_call_tool_requests")
+				require.NotNil(t, m, "call_tool_requests metric should exist")
+				assert.Equal(t, int64(1), counterValue(m))
+
+				// Error counters should not be reported (never incremented)
+				assert.Equal(t, int64(0), counterValue(findMetric(rm, "toolhive_vmcp_optimizer_call_tool_errors")))
+				assert.Equal(t, int64(0), counterValue(findMetric(rm, "toolhive_vmcp_optimizer_call_tool_not_found")))
+
+				m = findMetric(rm, "toolhive_vmcp_optimizer_call_tool_duration")
+				require.NotNil(t, m)
+				assert.Equal(t, uint64(1), histogramCount(m))
+			},
+		},
+		{
+			name: "CallTool not found increments call_tool_not_found counter when IsError is true",
+			setup: func() *fakeOptimizer {
+				return &fakeOptimizer{
+					callToolFn: func(_ context.Context, _ optimizer.CallToolInput) (*mcp.CallToolResult, error) {
+						return mcp.NewToolResultError("tool not found: missing_tool"), nil
+					},
+				}
+			},
+			action: func(t *testing.T, opt optimizer.Optimizer) {
+				t.Helper()
+				result, err := opt.CallTool(context.Background(), optimizer.CallToolInput{
+					ToolName: "missing_tool",
+				})
+				require.NoError(t, err)
+				require.True(t, result.IsError)
+			},
+			assertFunc: func(t *testing.T, rm metricdata.ResourceMetrics) {
+				t.Helper()
+				m := findMetric(rm, "toolhive_vmcp_optimizer_call_tool_requests")
+				require.NotNil(t, m)
+				assert.Equal(t, int64(1), counterValue(m))
+
+				// Go error counter should not be reported (never incremented)
+				assert.Equal(t, int64(0), counterValue(findMetric(rm, "toolhive_vmcp_optimizer_call_tool_errors")))
+
+				m = findMetric(rm, "toolhive_vmcp_optimizer_call_tool_not_found")
+				require.NotNil(t, m, "not_found counter should exist")
+				assert.Equal(t, int64(1), counterValue(m))
+
+				m = findMetric(rm, "toolhive_vmcp_optimizer_call_tool_duration")
+				require.NotNil(t, m)
+				assert.Equal(t, uint64(1), histogramCount(m))
+			},
+		},
+		{
+			name: "CallTool Go error increments error counter",
+			setup: func() *fakeOptimizer {
+				return &fakeOptimizer{
+					callToolFn: func(_ context.Context, _ optimizer.CallToolInput) (*mcp.CallToolResult, error) {
+						return nil, fmt.Errorf("handler panic")
+					},
+				}
+			},
+			action: func(t *testing.T, opt optimizer.Optimizer) {
+				t.Helper()
+				_, err := opt.CallTool(context.Background(), optimizer.CallToolInput{
+					ToolName: "broken_tool",
+				})
+				require.Error(t, err)
+			},
+			assertFunc: func(t *testing.T, rm metricdata.ResourceMetrics) {
+				t.Helper()
+				m := findMetric(rm, "toolhive_vmcp_optimizer_call_tool_requests")
+				require.NotNil(t, m)
+				assert.Equal(t, int64(1), counterValue(m))
+
+				m = findMetric(rm, "toolhive_vmcp_optimizer_call_tool_errors")
+				require.NotNil(t, m)
+				assert.Equal(t, int64(1), counterValue(m))
+
+				// not_found counter should not be reported (never incremented)
+				assert.Equal(t, int64(0), counterValue(findMetric(rm, "toolhive_vmcp_optimizer_call_tool_not_found")))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			reader := sdkmetric.NewManualReader()
+			meterProvider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+			tracerProvider := tracenoop.NewTracerProvider()
+
+			fake := tt.setup()
+
+			// Create a factory that returns the fake optimizer
+			factory := func(_ context.Context, _ []mcpserver.ServerTool) (optimizer.Optimizer, error) {
+				return fake, nil
+			}
+
+			// Wrap with telemetry
+			wrappedFactory, err := monitorOptimizer(meterProvider, tracerProvider, factory)
+			require.NoError(t, err)
+
+			// Create the telemetry-decorated optimizer
+			opt, err := wrappedFactory(context.Background(), nil)
+			require.NoError(t, err)
+
+			// Execute the action
+			tt.action(t, opt)
+
+			// Collect and verify metrics
+			var rm metricdata.ResourceMetrics
+			err = reader.Collect(context.Background(), &rm)
+			require.NoError(t, err)
+
+			tt.assertFunc(t, rm)
 		})
 	}
 }


### PR DESCRIPTION
## Summary
- Wrap the optimizer factory with a telemetry decorator (`telemetryOptimizer`) that records OTel metrics and traces for `FindTool` and `CallTool` operations
- Metrics include request/error counters, duration histograms, result-set size, and token-savings percentages
- The decorator is applied in `Server.Start` when a `TelemetryProvider` is configured
- Add comprehensive table-driven unit tests covering success, error, and not-found scenarios

## Test plan
- [x] Unit tests pass (`go test ./pkg/vmcp/server/... -count=1`)
- [x] `go vet` clean
- [x] `gofmt` clean
- [ ] Deploy with OTel stack and verify metrics appear in Prometheus/Grafana

🤖 Generated with [Claude Code](https://claude.com/claude-code)