### PR TITLE
Respect INSECURE_DISABLE_URL_VALIDATION in upstream auth HTTP client

### DIFF
--- a/pkg/authserver/upstream/oauth2.go
+++ b/pkg/authserver/upstream/oauth2.go
@@ -26,6 +26,7 @@ import (
 	"maps"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 	"time"
 
@@ -577,11 +578,13 @@ func formatOAuth2Error(err error, prefix string) error {
 }
 
 // newHTTPClientForHost creates an HTTP client configured for the given host.
-// It enables HTTP and private IPs only for localhost (development/testing).
+// It enables HTTP and private IPs only for localhost (development/testing),
+// or when INSECURE_DISABLE_URL_VALIDATION is set (e.g. Kubernetes dev environments).
 func newHTTPClientForHost(host string) (*http.Client, error) {
-	isLocalhost := networking.IsLocalhost(host)
+	allowInsecure := networking.IsLocalhost(host) ||
+		strings.EqualFold(os.Getenv("INSECURE_DISABLE_URL_VALIDATION"), "true")
 	return networking.NewHttpClientBuilder().
-		WithInsecureAllowHTTP(isLocalhost).
-		WithPrivateIPs(isLocalhost).
+		WithInsecureAllowHTTP(allowInsecure).
+		WithPrivateIPs(allowInsecure).
 		Build()
 }

--- a/pkg/authserver/upstream/userinfo_config.go
+++ b/pkg/authserver/upstream/userinfo_config.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"os"
+	"strings"
 
 	"github.com/stacklok/toolhive/pkg/networking"
 )
@@ -174,9 +176,12 @@ func (c *UserInfoConfig) Validate() error {
 		return errors.New("endpoint_url must use http or https scheme")
 	}
 
-	// HTTP scheme is only allowed for loopback addresses (consistent with validateRedirectURI)
+	// HTTP scheme is only allowed for loopback addresses unless URL validation is disabled.
+	// This is consistent with networking.ValidateEndpointURL which checks the same env var.
 	if parsed.Scheme == networking.HttpScheme && !networking.IsLocalhost(parsed.Host) {
-		return errors.New("endpoint_url with http scheme requires loopback address (127.0.0.1, ::1, or localhost)")
+		if !strings.EqualFold(os.Getenv("INSECURE_DISABLE_URL_VALIDATION"), "true") {
+			return errors.New("endpoint_url with http scheme requires loopback address (127.0.0.1, ::1, or localhost)")
+		}
 	}
 
 	// Validate HTTP method if specified (OIDC Core Section 5.3.1 allows GET and POST)

--- a/pkg/authserver/upstream/userinfo_config_test.go
+++ b/pkg/authserver/upstream/userinfo_config_test.go
@@ -160,6 +160,35 @@ func TestUserInfoConfig_Validate(t *testing.T) {
 	}
 }
 
+// TestUserInfoConfig_Validate_InsecureDisableURLValidation verifies that
+// INSECURE_DISABLE_URL_VALIDATION=true bypasses the HTTP non-localhost check.
+// Not parallel because t.Setenv modifies process-global state.
+func TestUserInfoConfig_Validate_InsecureDisableURLValidation(t *testing.T) {
+	httpNonLocalhost := &UserInfoConfig{EndpointURL: "http://example.com/userinfo"}
+
+	t.Run("allowed when env var is true", func(t *testing.T) {
+		t.Setenv("INSECURE_DISABLE_URL_VALIDATION", "true")
+		assert.NoError(t, httpNonLocalhost.Validate())
+	})
+
+	t.Run("allowed when env var is TRUE (case insensitive)", func(t *testing.T) {
+		t.Setenv("INSECURE_DISABLE_URL_VALIDATION", "TRUE")
+		assert.NoError(t, httpNonLocalhost.Validate())
+	})
+
+	t.Run("rejected when env var is false", func(t *testing.T) {
+		t.Setenv("INSECURE_DISABLE_URL_VALIDATION", "false")
+		err := httpNonLocalhost.Validate()
+		assert.ErrorContains(t, err, "endpoint_url with http scheme requires loopback address")
+	})
+
+	t.Run("other validations still apply when env var is true", func(t *testing.T) {
+		t.Setenv("INSECURE_DISABLE_URL_VALIDATION", "true")
+		err := (&UserInfoConfig{EndpointURL: "ftp://example.com/userinfo"}).Validate()
+		assert.ErrorContains(t, err, "endpoint_url must use http or https scheme")
+	})
+}
+
 func TestResolveField(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
UserInfoConfig.Validate() and newHTTPClientForHost() did not check the INSECURE_DISABLE_URL_VALIDATION env var, unlike the rest of the networking validation code. This caused the embedded auth server to reject non-localhost HTTP userinfo URLs and block requests to in-cluster services on private IPs, even when the env var was explicitly set.