### PR TITLE
Implement skill list and info CLI commands with shared helpers

### DIFF
--- a/cmd/thv/app/commands.go
+++ b/cmd/thv/app/commands.go
@@ -107,6 +107,7 @@ func IsInformationalCommand(args []string) bool {
 		"completion": true,
 		"registry":   true,
 		"mcp":        true,
+		"skill":      true,
 	}
 
 	return informationalCommands[command]

--- a/cmd/thv/app/skill_helpers.go
+++ b/cmd/thv/app/skill_helpers.go
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package app
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/stacklok/toolhive/pkg/skills"
+	skillclient "github.com/stacklok/toolhive/pkg/skills/client"
+)
+
+// newSkillClient creates a new Skills API HTTP client using default settings.
+func newSkillClient() *skillclient.Client {
+	return skillclient.NewDefaultClient()
+}
+
+// completeSkillNames provides shell completion for installed skill names.
+func completeSkillNames(cmd *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
+	if len(args) > 0 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	c := newSkillClient()
+	installed, err := c.List(cmd.Context(), skills.ListOptions{})
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	names := make([]string, 0, len(installed))
+	for _, s := range installed {
+		names = append(names, s.Metadata.Name)
+	}
+	return names, cobra.ShellCompDirectiveNoFileComp
+}
+
+// formatSkillError wraps an error with contextual information. If the
+// underlying cause is ErrServerUnreachable it appends a helpful hint.
+func formatSkillError(action string, err error) error {
+	if errors.Is(err, skillclient.ErrServerUnreachable) {
+		return fmt.Errorf("failed to %s: %w\nHint: ensure 'thv serve' is running", action, err)
+	}
+	return fmt.Errorf("failed to %s: %w", action, err)
+}
+
+// validateSkillScope returns a PreRunE that validates the --scope flag.
+func validateSkillScope(scopeVar *string) func(*cobra.Command, []string) error {
+	return func(_ *cobra.Command, _ []string) error {
+		return skills.ValidateScope(skills.Scope(*scopeVar))
+	}
+}

--- a/cmd/thv/app/skill_info.go
+++ b/cmd/thv/app/skill_info.go
@@ -3,18 +3,87 @@
 
 package app
 
-import "github.com/spf13/cobra"
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+
+	"github.com/stacklok/toolhive/pkg/skills"
+)
+
+var (
+	skillInfoScope       string
+	skillInfoFormat      string
+	skillInfoProjectRoot string
+)
 
 var skillInfoCmd = &cobra.Command{
-	Use:   "info [skill-name]",
-	Short: "Show skill details",
-	Long:  `Display detailed information about a skill, including metadata, version, and installation status.`,
-	Args:  cobra.ExactArgs(1),
-	RunE: func(_ *cobra.Command, _ []string) error {
-		return nil
-	},
+	Use:               "info [skill-name]",
+	Short:             "Show skill details",
+	Long:              `Display detailed information about a skill, including metadata, version, and installation status.`,
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: completeSkillNames,
+	PreRunE: chainPreRunE(
+		validateSkillScope(&skillInfoScope),
+		ValidateFormat(&skillInfoFormat),
+	),
+	RunE: skillInfoCmdFunc,
 }
 
 func init() {
 	skillCmd.AddCommand(skillInfoCmd)
+
+	skillInfoCmd.Flags().StringVar(&skillInfoScope, "scope", "", "Filter by scope (user, project)")
+	AddFormatFlag(skillInfoCmd, &skillInfoFormat)
+	skillInfoCmd.Flags().StringVar(&skillInfoProjectRoot, "project-root", "", "Project root path for project-scoped skills")
+}
+
+func skillInfoCmdFunc(cmd *cobra.Command, args []string) error {
+	c := newSkillClient()
+
+	info, err := c.Info(cmd.Context(), skills.InfoOptions{
+		Name:        args[0],
+		Scope:       skills.Scope(skillInfoScope),
+		ProjectRoot: skillInfoProjectRoot,
+	})
+	if err != nil {
+		return formatSkillError("get skill info", err)
+	}
+
+	switch skillInfoFormat {
+	case FormatJSON:
+		data, err := json.MarshalIndent(info, "", "  ")
+		if err != nil {
+			return fmt.Errorf("failed to marshal JSON: %w", err)
+		}
+		fmt.Println(string(data))
+	default:
+		printSkillInfoText(info)
+	}
+
+	return nil
+}
+
+func printSkillInfoText(info *skills.SkillInfo) {
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+
+	_, _ = fmt.Fprintf(w, "Name:\t%s\n", info.Metadata.Name)
+	_, _ = fmt.Fprintf(w, "Version:\t%s\n", info.Metadata.Version)
+	_, _ = fmt.Fprintf(w, "Description:\t%s\n", info.Metadata.Description)
+
+	if s := info.InstalledSkill; s != nil {
+		_, _ = fmt.Fprintf(w, "Scope:\t%s\n", s.Scope)
+		_, _ = fmt.Fprintf(w, "Status:\t%s\n", s.Status)
+		_, _ = fmt.Fprintf(w, "Reference:\t%s\n", s.Reference)
+		_, _ = fmt.Fprintf(w, "Installed At:\t%s\n", s.InstalledAt.Format("2006-01-02 15:04:05"))
+		if len(s.Clients) > 0 {
+			_, _ = fmt.Fprintf(w, "Clients:\t%s\n", strings.Join(s.Clients, ", "))
+		}
+	}
+
+	_ = w.Flush()
 }

--- a/cmd/thv/app/skill_list.go
+++ b/cmd/thv/app/skill_list.go
@@ -3,17 +3,98 @@
 
 package app
 
-import "github.com/spf13/cobra"
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+
+	"github.com/stacklok/toolhive/pkg/skills"
+)
+
+var (
+	skillListScope       string
+	skillListClient      string
+	skillListFormat      string
+	skillListProjectRoot string
+)
 
 var skillListCmd = &cobra.Command{
-	Use:   "list",
-	Short: "List installed skills",
-	Long:  `List all currently installed skills and their status.`,
-	RunE: func(_ *cobra.Command, _ []string) error {
-		return nil
-	},
+	Use:     "list",
+	Aliases: []string{"ls"},
+	Short:   "List installed skills",
+	Long:    `List all currently installed skills and their status.`,
+	PreRunE: chainPreRunE(
+		validateSkillScope(&skillListScope),
+		ValidateFormat(&skillListFormat),
+	),
+	RunE: skillListCmdFunc,
 }
 
 func init() {
 	skillCmd.AddCommand(skillListCmd)
+
+	skillListCmd.Flags().StringVar(&skillListScope, "scope", "", "Filter by scope (user, project)")
+	skillListCmd.Flags().StringVar(&skillListClient, "client", "", "Filter by client application")
+	AddFormatFlag(skillListCmd, &skillListFormat)
+	skillListCmd.Flags().StringVar(&skillListProjectRoot, "project-root", "", "Project root path for project-scoped skills")
+}
+
+func skillListCmdFunc(cmd *cobra.Command, _ []string) error {
+	c := newSkillClient()
+
+	installed, err := c.List(cmd.Context(), skills.ListOptions{
+		Scope:       skills.Scope(skillListScope),
+		ClientApp:   skillListClient,
+		ProjectRoot: skillListProjectRoot,
+	})
+	if err != nil {
+		return formatSkillError("list skills", err)
+	}
+
+	switch skillListFormat {
+	case FormatJSON:
+		if installed == nil {
+			installed = []skills.InstalledSkill{}
+		}
+		data, err := json.MarshalIndent(installed, "", "  ")
+		if err != nil {
+			return fmt.Errorf("failed to marshal JSON: %w", err)
+		}
+		fmt.Println(string(data))
+	default:
+		if len(installed) == 0 {
+			if skillListScope != "" || skillListClient != "" {
+				fmt.Println("No skills found matching filters")
+			} else {
+				fmt.Println("No skills installed")
+			}
+			return nil
+		}
+		printSkillListText(installed)
+	}
+
+	return nil
+}
+
+func printSkillListText(installed []skills.InstalledSkill) {
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+	_, _ = fmt.Fprintln(w, "NAME\tVERSION\tSCOPE\tSTATUS\tCLIENTS\tREFERENCE")
+
+	for _, s := range installed {
+		clients := strings.Join(s.Clients, ", ")
+		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",
+			s.Metadata.Name,
+			s.Metadata.Version,
+			s.Scope,
+			s.Status,
+			clients,
+			s.Reference,
+		)
+	}
+
+	_ = w.Flush()
 }


### PR DESCRIPTION
## Summary
- Add `skill_helpers.go` with shared utilities (`newSkillClient`, `completeSkillNames`, `formatSkillError`, `validateSkillScope`) used across all skill commands
- Replace empty `skill list` and `skill info` stubs with real implementations that call the Skills HTTP client
- Add `"skill"` to the `informationalCommands` map since skill commands communicate via HTTP API, not container runtime
- `skill list` supports `--scope`, `--client`, `--format`, `--project-root` flags with text (tabwriter) and JSON output
- `skill info` supports `--scope`, `--format`, `--project-root` flags with detailed key-value text and JSON output, plus shell completion for skill names

Part 1 of 3 for stacklok/toolhive#3653 (CLI Skills Commands).

## Test plan
- [ ] `task lint` passes with no new warnings
- [ ] `task test` passes (existing unit tests)
- [ ] `task license-check` passes (SPDX headers correct)
- [ ] `thv skill --help` shows all subcommands
- [ ] `thv skill list --help` shows correct flags (--scope, --client, --format, --project-root)
- [ ] `thv skill info --help` shows correct flags (--scope, --format, --project-root)


🤖 Generated with [Claude Code](https://claude.com/claude-code)