### PR TITLE
Implement skill install and uninstall CLI commands

### DIFF
--- a/cmd/thv/app/skill_build.go
+++ b/cmd/thv/app/skill_build.go
@@ -3,18 +3,52 @@
 
 package app
 
-import "github.com/spf13/cobra"
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"github.com/stacklok/toolhive/pkg/skills"
+)
+
+var skillBuildTag string
 
 var skillBuildCmd = &cobra.Command{
 	Use:   "build [path]",
 	Short: "Build a skill",
-	Long:  `Build a skill from a local directory into an OCI artifact that can be pushed to a registry.`,
-	Args:  cobra.ExactArgs(1),
-	RunE: func(_ *cobra.Command, _ []string) error {
-		return nil
+	Long: `Build a skill from a local directory into an OCI artifact that can be pushed to a registry.
+
+On success, prints the OCI reference of the built artifact to stdout.`,
+	Args: cobra.ExactArgs(1),
+	ValidArgsFunction: func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return nil, cobra.ShellCompDirectiveFilterDirs
 	},
+	RunE: skillBuildCmdFunc,
 }
 
 func init() {
 	skillCmd.AddCommand(skillBuildCmd)
+
+	skillBuildCmd.Flags().StringVarP(&skillBuildTag, "tag", "t", "", "OCI tag for the built artifact")
+}
+
+func skillBuildCmdFunc(cmd *cobra.Command, args []string) error {
+	absPath, err := filepath.Abs(args[0])
+	if err != nil {
+		return fmt.Errorf("failed to resolve path: %w", err)
+	}
+
+	c := newSkillClient()
+
+	result, err := c.Build(cmd.Context(), skills.BuildOptions{
+		Path: absPath,
+		Tag:  skillBuildTag,
+	})
+	if err != nil {
+		return formatSkillError("build skill", err)
+	}
+
+	fmt.Println(result.Reference)
+	return nil
 }

--- a/cmd/thv/app/skill_helpers.go
+++ b/cmd/thv/app/skill_helpers.go
@@ -52,3 +52,14 @@ func validateSkillScope(scopeVar *string) func(*cobra.Command, []string) error {
 		return skills.ValidateScope(skills.Scope(*scopeVar))
 	}
 }
+
+// validateProjectRootForScope returns a PreRunE that ensures --project-root is
+// provided when --scope is "project".
+func validateProjectRootForScope(scopeVar, projectRootVar *string) func(*cobra.Command, []string) error {
+	return func(_ *cobra.Command, _ []string) error {
+		if skills.Scope(*scopeVar) == skills.ScopeProject && *projectRootVar == "" {
+			return fmt.Errorf("--project-root is required when --scope is %q", skills.ScopeProject)
+		}
+		return nil
+	}
+}

--- a/cmd/thv/app/skill_install.go
+++ b/cmd/thv/app/skill_install.go
@@ -4,8 +4,6 @@
 package app
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 
 	"github.com/stacklok/toolhive/pkg/skills"
@@ -55,15 +53,4 @@ func skillInstallCmdFunc(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
-}
-
-// validateProjectRootForScope returns a PreRunE that ensures --project-root is
-// provided when --scope is "project".
-func validateProjectRootForScope(scopeVar, projectRootVar *string) func(*cobra.Command, []string) error {
-	return func(_ *cobra.Command, _ []string) error {
-		if skills.Scope(*scopeVar) == skills.ScopeProject && *projectRootVar == "" {
-			return fmt.Errorf("--project-root is required when --scope is %q", skills.ScopeProject)
-		}
-		return nil
-	}
 }

--- a/cmd/thv/app/skill_push.go
+++ b/cmd/thv/app/skill_push.go
@@ -3,18 +3,33 @@
 
 package app
 
-import "github.com/spf13/cobra"
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/stacklok/toolhive/pkg/skills"
+)
 
 var skillPushCmd = &cobra.Command{
 	Use:   "push [reference]",
 	Short: "Push a built skill",
 	Long:  `Push a previously built skill artifact to a remote OCI registry.`,
 	Args:  cobra.ExactArgs(1),
-	RunE: func(_ *cobra.Command, _ []string) error {
-		return nil
-	},
+	RunE:  skillPushCmdFunc,
 }
 
 func init() {
 	skillCmd.AddCommand(skillPushCmd)
+}
+
+func skillPushCmdFunc(cmd *cobra.Command, args []string) error {
+	c := newSkillClient()
+
+	err := c.Push(cmd.Context(), skills.PushOptions{
+		Reference: args[0],
+	})
+	if err != nil {
+		return formatSkillError("push skill", err)
+	}
+
+	return nil
 }

--- a/cmd/thv/app/skill_uninstall.go
+++ b/cmd/thv/app/skill_uninstall.go
@@ -20,14 +20,19 @@ var skillUninstallCmd = &cobra.Command{
 	Long:              `Remove a previously installed skill by name.`,
 	Args:              cobra.ExactArgs(1),
 	ValidArgsFunction: completeSkillNames,
-	PreRunE:           validateSkillScope(&skillUninstallScope),
-	RunE:              skillUninstallCmdFunc,
+	PreRunE: chainPreRunE(
+		validateSkillScope(&skillUninstallScope),
+		validateProjectRootForScope(&skillUninstallScope, &skillUninstallProjectRoot),
+	),
+	RunE: skillUninstallCmdFunc,
 }
 
 func init() {
 	skillCmd.AddCommand(skillUninstallCmd)
 
-	skillUninstallCmd.Flags().StringVar(&skillUninstallScope, "scope", "", "Scope to uninstall from (user, project)")
+	skillUninstallCmd.Flags().StringVar(
+		&skillUninstallScope, "scope", string(skills.ScopeUser), "Scope to uninstall from (user, project)",
+	)
 	skillUninstallCmd.Flags().StringVar(
 		&skillUninstallProjectRoot, "project-root", "", "Project root path for project-scoped skills",
 	)

--- a/cmd/thv/app/skill_validate.go
+++ b/cmd/thv/app/skill_validate.go
@@ -3,18 +3,66 @@
 
 package app
 
-import "github.com/spf13/cobra"
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+)
+
+var skillValidateFormat string
 
 var skillValidateCmd = &cobra.Command{
 	Use:   "validate [path]",
 	Short: "Validate a skill definition",
 	Long:  `Check that a skill definition in the given directory is valid and well-formed.`,
 	Args:  cobra.ExactArgs(1),
-	RunE: func(_ *cobra.Command, _ []string) error {
-		return nil
+	ValidArgsFunction: func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return nil, cobra.ShellCompDirectiveFilterDirs
 	},
+	PreRunE: ValidateFormat(&skillValidateFormat),
+	RunE:    skillValidateCmdFunc,
 }
 
 func init() {
 	skillCmd.AddCommand(skillValidateCmd)
+
+	AddFormatFlag(skillValidateCmd, &skillValidateFormat)
+}
+
+func skillValidateCmdFunc(cmd *cobra.Command, args []string) error {
+	absPath, err := filepath.Abs(args[0])
+	if err != nil {
+		return fmt.Errorf("failed to resolve path: %w", err)
+	}
+
+	c := newSkillClient()
+
+	result, err := c.Validate(cmd.Context(), absPath)
+	if err != nil {
+		return formatSkillError("validate skill", err)
+	}
+
+	switch skillValidateFormat {
+	case FormatJSON:
+		data, err := json.MarshalIndent(result, "", "  ")
+		if err != nil {
+			return fmt.Errorf("failed to marshal JSON: %w", err)
+		}
+		fmt.Println(string(data))
+	default:
+		for _, e := range result.Errors {
+			fmt.Printf("Error: %s\n", e)
+		}
+		for _, w := range result.Warnings {
+			fmt.Printf("Warning: %s\n", w)
+		}
+	}
+
+	if !result.Valid {
+		return fmt.Errorf("skill validation failed")
+	}
+
+	return nil
 }


### PR DESCRIPTION
## Summary
- Replace empty `skill install` stub with real implementation supporting `--client`, `--scope` (default "user"), `--force`, and `--project-root` flags
- Replace empty `skill uninstall` stub with real implementation supporting `--scope` (default "user"), `--project-root` flags with shell completion and `validateProjectRootForScope` validation
- Replace empty `skill validate` stub with real implementation supporting `--format` flag, absolute path resolution, error/warning output, and non-zero exit on invalid (silent on success per convention)
- Replace empty `skill build` stub with real implementation supporting `--tag`/`-t` flag, printing the built OCI reference on success (documented exception to silent-success)
- Replace empty `skill push` stub with real implementation following silent-success convention
- Move `validateProjectRootForScope` to `skill_helpers.go` for reuse across install/uninstall

Supersedes #3989 (now included here). Closes stacklok/toolhive#3653.

## Test plan
- [ ] `task lint` passes with no new warnings
- [ ] `task test` passes (existing unit tests)
- [ ] `thv skill install --help` shows correct flags (--client, --scope, --force, --project-root)
- [ ] `thv skill uninstall --help` shows correct flags (--scope defaults to "user", --project-root)
- [ ] `thv skill validate --help` shows correct flags (--format)
- [ ] `thv skill build --help` shows correct flags (--tag/-t)
- [ ] `thv skill push --help` shows correct usage


🤖 Generated with [Claude Code](https://claude.com/claude-code)