### PR TITLE
Implement skill validate, build, and push CLI commands

### DIFF
--- a/cmd/thv/app/skill_build.go
+++ b/cmd/thv/app/skill_build.go
@@ -3,18 +3,50 @@
 
 package app
 
-import "github.com/spf13/cobra"
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"github.com/stacklok/toolhive/pkg/skills"
+)
+
+var skillBuildTag string
 
 var skillBuildCmd = &cobra.Command{
 	Use:   "build [path]",
 	Short: "Build a skill",
 	Long:  `Build a skill from a local directory into an OCI artifact that can be pushed to a registry.`,
 	Args:  cobra.ExactArgs(1),
-	RunE: func(_ *cobra.Command, _ []string) error {
-		return nil
+	ValidArgsFunction: func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return nil, cobra.ShellCompDirectiveFilterDirs
 	},
+	RunE: skillBuildCmdFunc,
 }
 
 func init() {
 	skillCmd.AddCommand(skillBuildCmd)
+
+	skillBuildCmd.Flags().StringVarP(&skillBuildTag, "tag", "t", "", "OCI tag for the built artifact")
+}
+
+func skillBuildCmdFunc(cmd *cobra.Command, args []string) error {
+	absPath, err := filepath.Abs(args[0])
+	if err != nil {
+		return fmt.Errorf("failed to resolve path: %w", err)
+	}
+
+	c := newSkillClient()
+
+	result, err := c.Build(cmd.Context(), skills.BuildOptions{
+		Path: absPath,
+		Tag:  skillBuildTag,
+	})
+	if err != nil {
+		return formatSkillError("build skill", err)
+	}
+
+	fmt.Println(result.Reference)
+	return nil
 }

--- a/cmd/thv/app/skill_push.go
+++ b/cmd/thv/app/skill_push.go
@@ -3,18 +3,33 @@
 
 package app
 
-import "github.com/spf13/cobra"
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/stacklok/toolhive/pkg/skills"
+)
 
 var skillPushCmd = &cobra.Command{
 	Use:   "push [reference]",
 	Short: "Push a built skill",
 	Long:  `Push a previously built skill artifact to a remote OCI registry.`,
 	Args:  cobra.ExactArgs(1),
-	RunE: func(_ *cobra.Command, _ []string) error {
-		return nil
-	},
+	RunE:  skillPushCmdFunc,
 }
 
 func init() {
 	skillCmd.AddCommand(skillPushCmd)
+}
+
+func skillPushCmdFunc(cmd *cobra.Command, args []string) error {
+	c := newSkillClient()
+
+	err := c.Push(cmd.Context(), skills.PushOptions{
+		Reference: args[0],
+	})
+	if err != nil {
+		return formatSkillError("push skill", err)
+	}
+
+	return nil
 }

--- a/cmd/thv/app/skill_validate.go
+++ b/cmd/thv/app/skill_validate.go
@@ -3,18 +3,69 @@
 
 package app
 
-import "github.com/spf13/cobra"
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+)
+
+var skillValidateFormat string
 
 var skillValidateCmd = &cobra.Command{
 	Use:   "validate [path]",
 	Short: "Validate a skill definition",
 	Long:  `Check that a skill definition in the given directory is valid and well-formed.`,
 	Args:  cobra.ExactArgs(1),
-	RunE: func(_ *cobra.Command, _ []string) error {
-		return nil
+	ValidArgsFunction: func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return nil, cobra.ShellCompDirectiveFilterDirs
 	},
+	PreRunE: ValidateFormat(&skillValidateFormat),
+	RunE:    skillValidateCmdFunc,
 }
 
 func init() {
 	skillCmd.AddCommand(skillValidateCmd)
+
+	AddFormatFlag(skillValidateCmd, &skillValidateFormat)
+}
+
+func skillValidateCmdFunc(cmd *cobra.Command, args []string) error {
+	absPath, err := filepath.Abs(args[0])
+	if err != nil {
+		return fmt.Errorf("failed to resolve path: %w", err)
+	}
+
+	c := newSkillClient()
+
+	result, err := c.Validate(cmd.Context(), absPath)
+	if err != nil {
+		return formatSkillError("validate skill", err)
+	}
+
+	switch skillValidateFormat {
+	case FormatJSON:
+		data, err := json.MarshalIndent(result, "", "  ")
+		if err != nil {
+			return fmt.Errorf("failed to marshal JSON: %w", err)
+		}
+		fmt.Println(string(data))
+	default:
+		if result.Valid {
+			fmt.Println("Valid")
+		}
+		for _, e := range result.Errors {
+			fmt.Printf("Error: %s\n", e)
+		}
+		for _, w := range result.Warnings {
+			fmt.Printf("Warning: %s\n", w)
+		}
+	}
+
+	if !result.Valid {
+		return fmt.Errorf("skill validation failed")
+	}
+
+	return nil
 }


### PR DESCRIPTION
## Summary
- Replace empty `skill validate` stub with real implementation supporting `--format` flag, absolute path resolution, error/warning output in text mode, and non-zero exit on invalid
- Replace empty `skill build` stub with real implementation supporting `--tag`/`-t` flag, printing the built OCI reference on success
- Replace empty `skill push` stub with real implementation following silent-success convention
- All path-based commands include directory-based shell completion

Part 3 of 3 for stacklok/toolhive#3653 (CLI Skills Commands). Stacked on #3988.

## Test plan
- [ ] `task lint` passes with no new warnings
- [ ] `task test` passes (existing unit tests)
- [ ] `task license-check` passes (SPDX headers correct)
- [ ] `thv skill validate --help` shows correct flags (--format)
- [ ] `thv skill build --help` shows correct flags (--tag/-t)
- [ ] `thv skill push --help` shows correct usage


🤖 Generated with [Claude Code](https://claude.com/claude-code)