### PR TITLE
Fix remote proxy 401 by failing fast on upstream token errors

### DIFF
--- a/pkg/auth/upstreamswap/middleware.go
+++ b/pkg/auth/upstreamswap/middleware.go
@@ -172,33 +172,34 @@ func createMiddlewareFunc(cfg *Config, storageGetter StorageGetter) types.Middle
 			// 3. Get storage
 			stor := storageGetter()
 			if stor == nil {
-				slog.Warn("Storage unavailable, proceeding without swap",
+				slog.Error("Storage unavailable, cannot swap upstream token",
 					"middleware", "upstreamswap")
-				next.ServeHTTP(w, r)
+				http.Error(w, "upstream token storage unavailable", http.StatusServiceUnavailable)
 				return
 			}
 
 			// 4. Lookup upstream tokens
 			tokens, err := stor.GetUpstreamTokens(r.Context(), tsid)
 			if err != nil {
-				slog.Warn("Failed to get upstream tokens",
+				slog.Error("Failed to get upstream tokens",
 					"middleware", "upstreamswap", "error", err)
-				next.ServeHTTP(w, r)
+				http.Error(w, "upstream token unavailable", http.StatusServiceUnavailable)
 				return
 			}
 
-			// 5. Check if expired (MVP: just log warning, continue with token)
+			// 5. Check if expired
 			if tokens.IsExpired(time.Now()) {
-				slog.Warn("Upstream tokens expired",
+				slog.Error("Upstream tokens expired, cannot forward request",
 					"middleware", "upstreamswap")
-				// Continue with expired token - backend will reject if needed
+				http.Error(w, "upstream token expired", http.StatusServiceUnavailable)
+				return
 			}
 
 			// 6. Inject access token
 			if tokens.AccessToken == "" {
-				slog.Warn("Access token is empty",
+				slog.Error("Access token is empty, cannot swap upstream token",
 					"middleware", "upstreamswap")
-				next.ServeHTTP(w, r)
+				http.Error(w, "upstream access token empty", http.StatusServiceUnavailable)
 				return
 			}
 

--- a/pkg/auth/upstreamswap/middleware_bug_test.go
+++ b/pkg/auth/upstreamswap/middleware_bug_test.go
@@ -1,0 +1,328 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package upstreamswap
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/stacklok/toolhive/pkg/auth"
+	"github.com/stacklok/toolhive/pkg/authserver/server/session"
+	"github.com/stacklok/toolhive/pkg/authserver/storage"
+	storagemocks "github.com/stacklok/toolhive/pkg/authserver/storage/mocks"
+)
+
+// TestFix_StorageError_Returns503 verifies that when GetUpstreamTokens fails,
+// the middleware returns 503 Service Unavailable instead of silently
+// forwarding the original (wrong) Authorization header to the remote server.
+func TestFix_StorageError_Returns503(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStorage := storagemocks.NewMockUpstreamTokenStorage(ctrl)
+	mockStorage.EXPECT().
+		GetUpstreamTokens(gomock.Any(), "session-123").
+		Return(nil, errors.New("database error"))
+
+	storageGetter := func() storage.UpstreamTokenStorage {
+		return mockStorage
+	}
+
+	cfg := &Config{}
+	middleware := createMiddlewareFunc(cfg, storageGetter)
+
+	originalJWT := "Bearer toolhive-internal-jwt-token"
+	var nextCalled bool
+	nextHandler := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		nextCalled = true
+	})
+
+	handler := middleware(nextHandler)
+
+	req := httptest.NewRequest(http.MethodPost, "/v2/mcp", nil)
+	req.Header.Set("Authorization", originalJWT)
+	identity := &auth.Identity{
+		Subject: "user123",
+		Claims: map[string]any{
+			"sub":                          "user123",
+			session.TokenSessionIDClaimKey: "session-123",
+		},
+	}
+	ctx := auth.WithIdentity(req.Context(), identity)
+	req = req.WithContext(ctx)
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	// FIX VERIFIED: middleware returns 503 instead of forwarding the wrong credential
+	assert.False(t, nextCalled,
+		"next handler should NOT be called — request must not be forwarded with wrong token")
+	assert.Equal(t, http.StatusServiceUnavailable, rr.Code,
+		"should return 503 Service Unavailable when upstream tokens cannot be retrieved")
+}
+
+// TestFix_TokenNotFound_Returns503 verifies that when tokens are not found
+// in storage (race condition where OAuth callback hasn't completed), the
+// middleware returns 503 instead of forwarding the original JWT.
+func TestFix_TokenNotFound_Returns503(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStorage := storagemocks.NewMockUpstreamTokenStorage(ctrl)
+	mockStorage.EXPECT().
+		GetUpstreamTokens(gomock.Any(), "session-456").
+		Return(nil, storage.ErrNotFound)
+
+	storageGetter := func() storage.UpstreamTokenStorage {
+		return mockStorage
+	}
+
+	cfg := &Config{}
+	middleware := createMiddlewareFunc(cfg, storageGetter)
+
+	originalJWT := "Bearer toolhive-jwt-from-embedded-auth-server"
+	var nextCalled bool
+	nextHandler := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		nextCalled = true
+	})
+
+	handler := middleware(nextHandler)
+
+	req := httptest.NewRequest(http.MethodPost, "/v2/mcp", nil)
+	req.Header.Set("Authorization", originalJWT)
+	identity := &auth.Identity{
+		Subject: "user123",
+		Claims: map[string]any{
+			"sub":                          "user123",
+			session.TokenSessionIDClaimKey: "session-456",
+		},
+	}
+	ctx := auth.WithIdentity(req.Context(), identity)
+	req = req.WithContext(ctx)
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	// FIX VERIFIED: client gets a retryable 503 instead of a permanent 401 cascade
+	require.False(t, nextCalled, "next handler should NOT be called")
+	assert.Equal(t, http.StatusServiceUnavailable, rr.Code,
+		"should return 503 when tokens not yet available (race condition)")
+}
+
+// TestFix_ExpiredToken_Returns503 verifies that expired upstream tokens are
+// no longer forwarded to the backend. Instead, the middleware returns 503.
+func TestFix_ExpiredToken_Returns503(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	expiredTokens := &storage.UpstreamTokens{
+		AccessToken:  "expired-asana-oauth-token",
+		RefreshToken: "valid-refresh-token",
+		ExpiresAt:    time.Now().Add(-1 * time.Hour),
+	}
+
+	mockStorage := storagemocks.NewMockUpstreamTokenStorage(ctrl)
+	mockStorage.EXPECT().
+		GetUpstreamTokens(gomock.Any(), "session-789").
+		Return(expiredTokens, nil)
+
+	storageGetter := func() storage.UpstreamTokenStorage {
+		return mockStorage
+	}
+
+	cfg := &Config{}
+	middleware := createMiddlewareFunc(cfg, storageGetter)
+
+	var nextCalled bool
+	nextHandler := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		nextCalled = true
+	})
+
+	handler := middleware(nextHandler)
+
+	req := httptest.NewRequest(http.MethodPost, "/v2/mcp", nil)
+	req.Header.Set("Authorization", "Bearer toolhive-jwt")
+	identity := &auth.Identity{
+		Subject: "user123",
+		Claims: map[string]any{
+			"sub":                          "user123",
+			session.TokenSessionIDClaimKey: "session-789",
+		},
+	}
+	ctx := auth.WithIdentity(req.Context(), identity)
+	req = req.WithContext(ctx)
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	// FIX VERIFIED: expired tokens are not forwarded to the backend
+	assert.False(t, nextCalled, "next handler should NOT be called with expired token")
+	assert.Equal(t, http.StatusServiceUnavailable, rr.Code,
+		"should return 503 for expired tokens")
+}
+
+// TestFix_StorageUnavailable_Returns503 verifies that when the storage
+// backend is nil, the middleware returns 503 instead of forwarding the
+// original JWT.
+func TestFix_StorageUnavailable_Returns503(t *testing.T) {
+	t.Parallel()
+
+	storageGetter := func() storage.UpstreamTokenStorage {
+		return nil
+	}
+
+	cfg := &Config{}
+	middleware := createMiddlewareFunc(cfg, storageGetter)
+
+	var nextCalled bool
+	nextHandler := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		nextCalled = true
+	})
+
+	handler := middleware(nextHandler)
+
+	req := httptest.NewRequest(http.MethodPost, "/v2/mcp", nil)
+	req.Header.Set("Authorization", "Bearer toolhive-jwt")
+	identity := &auth.Identity{
+		Subject: "user123",
+		Claims: map[string]any{
+			"sub":                          "user123",
+			session.TokenSessionIDClaimKey: "session-abc",
+		},
+	}
+	ctx := auth.WithIdentity(req.Context(), identity)
+	req = req.WithContext(ctx)
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.False(t, nextCalled, "next handler should NOT be called")
+	assert.Equal(t, http.StatusServiceUnavailable, rr.Code,
+		"should return 503 when storage is unavailable")
+}
+
+// TestFix_AllFailureModes_Return503 verifies that every failure path in the
+// middleware now returns 503 Service Unavailable instead of silently
+// continuing with the wrong credential.
+func TestFix_AllFailureModes_Return503(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		setupStorage func(ctrl *gomock.Controller) StorageGetter
+		description  string
+	}{
+		{
+			name: "storage_error",
+			setupStorage: func(ctrl *gomock.Controller) StorageGetter {
+				mock := storagemocks.NewMockUpstreamTokenStorage(ctrl)
+				mock.EXPECT().
+					GetUpstreamTokens(gomock.Any(), "tsid-1").
+					Return(nil, errors.New("connection refused"))
+				return func() storage.UpstreamTokenStorage { return mock }
+			},
+			description: "storage connection error",
+		},
+		{
+			name: "token_not_found",
+			setupStorage: func(ctrl *gomock.Controller) StorageGetter {
+				mock := storagemocks.NewMockUpstreamTokenStorage(ctrl)
+				mock.EXPECT().
+					GetUpstreamTokens(gomock.Any(), "tsid-1").
+					Return(nil, storage.ErrNotFound)
+				return func() storage.UpstreamTokenStorage { return mock }
+			},
+			description: "token not found in storage",
+		},
+		{
+			name: "empty_access_token",
+			setupStorage: func(ctrl *gomock.Controller) StorageGetter {
+				mock := storagemocks.NewMockUpstreamTokenStorage(ctrl)
+				mock.EXPECT().
+					GetUpstreamTokens(gomock.Any(), "tsid-1").
+					Return(&storage.UpstreamTokens{
+						AccessToken: "",
+						ExpiresAt:   time.Now().Add(1 * time.Hour),
+					}, nil)
+				return func() storage.UpstreamTokenStorage { return mock }
+			},
+			description: "empty access token",
+		},
+		{
+			name: "storage_unavailable",
+			setupStorage: func(_ *gomock.Controller) StorageGetter {
+				return func() storage.UpstreamTokenStorage { return nil }
+			},
+			description: "nil storage backend",
+		},
+		{
+			name: "expired_token",
+			setupStorage: func(ctrl *gomock.Controller) StorageGetter {
+				mock := storagemocks.NewMockUpstreamTokenStorage(ctrl)
+				mock.EXPECT().
+					GetUpstreamTokens(gomock.Any(), "tsid-1").
+					Return(&storage.UpstreamTokens{
+						AccessToken: "expired-token",
+						ExpiresAt:   time.Now().Add(-1 * time.Hour),
+					}, nil)
+				return func() storage.UpstreamTokenStorage { return mock }
+			},
+			description: "expired upstream token",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			storageGetter := tt.setupStorage(ctrl)
+			middleware := createMiddlewareFunc(&Config{}, storageGetter)
+
+			nextCalled := false
+			nextHandler := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+				nextCalled = true
+			})
+
+			handler := middleware(nextHandler)
+
+			req := httptest.NewRequest(http.MethodPost, "/v2/mcp", nil)
+			req.Header.Set("Authorization", "Bearer toolhive-jwt")
+			identity := &auth.Identity{
+				Subject: "user123",
+				Claims: map[string]any{
+					"sub":                          "user123",
+					session.TokenSessionIDClaimKey: "tsid-1",
+				},
+			}
+			ctx := auth.WithIdentity(req.Context(), identity)
+			req = req.WithContext(ctx)
+
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+
+			// FIX VERIFIED: all failure modes now return 503
+			assert.False(t, nextCalled,
+				"FIX VERIFIED (%s): %s — middleware returns 503 instead of forwarding wrong token",
+				tt.name, tt.description)
+			assert.Equal(t, http.StatusServiceUnavailable, rr.Code,
+				"should return 503 for %s", tt.description)
+		})
+	}
+}

--- a/pkg/auth/upstreamswap/middleware_test.go
+++ b/pkg/auth/upstreamswap/middleware_test.go
@@ -190,7 +190,8 @@ func TestMiddleware_StorageUnavailable(t *testing.T) {
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 
-	assert.True(t, nextCalled, "next handler should be called")
+	assert.False(t, nextCalled, "next handler should NOT be called when storage is unavailable")
+	assert.Equal(t, http.StatusServiceUnavailable, rr.Code, "should return 503")
 }
 
 func TestMiddleware_TokensNotFound(t *testing.T) {
@@ -232,7 +233,8 @@ func TestMiddleware_TokensNotFound(t *testing.T) {
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 
-	assert.True(t, nextCalled, "next handler should be called")
+	assert.False(t, nextCalled, "next handler should NOT be called when tokens not found")
+	assert.Equal(t, http.StatusServiceUnavailable, rr.Code, "should return 503")
 }
 
 func TestMiddleware_StorageError(t *testing.T) {
@@ -274,7 +276,8 @@ func TestMiddleware_StorageError(t *testing.T) {
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 
-	assert.True(t, nextCalled, "next handler should be called despite error")
+	assert.False(t, nextCalled, "next handler should NOT be called on storage error")
+	assert.Equal(t, http.StatusServiceUnavailable, rr.Code, "should return 503")
 }
 
 func TestMiddleware_SuccessfulSwap_AccessToken(t *testing.T) {
@@ -382,7 +385,7 @@ func TestMiddleware_CustomHeader(t *testing.T) {
 	assert.Equal(t, "Bearer original-token", capturedAuthHeader)
 }
 
-func TestMiddleware_ExpiredTokens_ContinuesWithWarning(t *testing.T) {
+func TestMiddleware_ExpiredTokens_Returns503(t *testing.T) {
 	t.Parallel()
 
 	ctrl := gomock.NewController(t)
@@ -406,9 +409,9 @@ func TestMiddleware_ExpiredTokens_ContinuesWithWarning(t *testing.T) {
 	cfg := &Config{}
 	middleware := createMiddlewareFunc(cfg, storageGetter)
 
-	var capturedAuthHeader string
-	nextHandler := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
-		capturedAuthHeader = r.Header.Get("Authorization")
+	var nextCalled bool
+	nextHandler := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		nextCalled = true
 	})
 
 	handler := middleware(nextHandler)
@@ -427,8 +430,8 @@ func TestMiddleware_ExpiredTokens_ContinuesWithWarning(t *testing.T) {
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 
-	// MVP: Should continue with expired token
-	assert.Equal(t, "Bearer expired-upstream-token", capturedAuthHeader)
+	assert.False(t, nextCalled, "next handler should NOT be called with expired token")
+	assert.Equal(t, http.StatusServiceUnavailable, rr.Code, "should return 503")
 }
 
 func TestMiddleware_EmptySelectedToken(t *testing.T) {
@@ -457,10 +460,8 @@ func TestMiddleware_EmptySelectedToken(t *testing.T) {
 	middleware := createMiddlewareFunc(cfg, storageGetter)
 
 	var nextCalled bool
-	var capturedAuthHeader string
-	nextHandler := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+	nextHandler := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
 		nextCalled = true
-		capturedAuthHeader = r.Header.Get("Authorization")
 	})
 
 	handler := middleware(nextHandler)
@@ -479,8 +480,8 @@ func TestMiddleware_EmptySelectedToken(t *testing.T) {
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 
-	assert.True(t, nextCalled, "next handler should be called")
-	assert.Empty(t, capturedAuthHeader, "should not inject empty token")
+	assert.False(t, nextCalled, "next handler should NOT be called with empty token")
+	assert.Equal(t, http.StatusServiceUnavailable, rr.Code, "should return 503")
 }
 
 func TestMiddleware_Close(t *testing.T) {

--- a/pkg/transport/proxy/transparent/transparent_proxy.go
+++ b/pkg/transport/proxy/transparent/transparent_proxy.go
@@ -94,6 +94,15 @@ type TransparentProxy struct {
 	// Callback when 401 Unauthorized response is received (for bearer token authentication)
 	onUnauthorizedResponse types.UnauthorizedResponseCallback
 
+	// consecutiveUnauthorized tracks consecutive 401 responses from the remote server.
+	// The onUnauthorizedResponse callback fires only after this reaches unauthorizedThreshold.
+	consecutiveUnauthorized atomic.Int32
+
+	// unauthorizedThreshold is the number of consecutive 401 responses required
+	// before firing onUnauthorizedResponse. Prevents transient 401s (e.g., token
+	// race conditions, clock skew) from permanently killing the workload.
+	unauthorizedThreshold int32
+
 	// Response processor for transport-specific logic
 	responseProcessor ResponseProcessor
 
@@ -135,6 +144,12 @@ const (
 	// HealthCheckIntervalEnvVar is the environment variable name for configuring health check interval.
 	// This is primarily useful for testing with shorter intervals.
 	HealthCheckIntervalEnvVar = "TOOLHIVE_HEALTH_CHECK_INTERVAL"
+
+	// defaultUnauthorizedThreshold is the number of consecutive 401 responses
+	// from the remote server required before marking the workload as permanently
+	// unauthenticated. This prevents transient auth failures (token races,
+	// clock skew, brief token propagation delays) from permanently killing workloads.
+	defaultUnauthorizedThreshold int32 = 3
 )
 
 // Option is a functional option for configuring TransparentProxy
@@ -158,6 +173,16 @@ func withHealthCheckRetryDelay(delay time.Duration) Option {
 	return func(p *TransparentProxy) {
 		if delay > 0 {
 			p.healthCheckRetryDelay = delay
+		}
+	}
+}
+
+// withUnauthorizedThreshold sets the consecutive 401 threshold.
+// This is primarily useful for testing with lower thresholds.
+func withUnauthorizedThreshold(threshold int32) Option {
+	return func(p *TransparentProxy) {
+		if threshold > 0 {
+			p.unauthorizedThreshold = threshold
 		}
 	}
 }
@@ -272,6 +297,7 @@ func newTransparentProxyWithOptions(
 		healthCheckRetryDelay:  DefaultHealthCheckRetryDelay,
 		healthCheckPingTimeout: DefaultPingerTimeout,
 		shutdownTimeout:        defaultShutdownTimeout,
+		unauthorizedThreshold:  defaultUnauthorizedThreshold,
 	}
 
 	// Apply options
@@ -361,14 +387,22 @@ func (t *tracingTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 		return nil, err
 	}
 
-	// Check for 401 Unauthorized response (bearer token authentication failure)
+	// Track consecutive 401 responses for bearer token authentication failure detection.
+	// A single 401 may be transient (token race, clock skew, brief propagation delay),
+	// so we only fire the unauthorized callback after multiple consecutive failures.
 	if resp.StatusCode == http.StatusUnauthorized {
+		count := t.p.consecutiveUnauthorized.Add(1)
 		//nolint:gosec // G706: logging target URI from config
-		slog.Debug("received 401 Unauthorized response, bearer token may be invalid",
-			"target", t.p.targetURI)
-		if t.p.onUnauthorizedResponse != nil {
+		slog.Warn("received 401 Unauthorized response from remote server",
+			"target", t.p.targetURI,
+			"consecutive_count", count,
+			"threshold", t.p.unauthorizedThreshold)
+		if count >= t.p.unauthorizedThreshold && t.p.onUnauthorizedResponse != nil {
 			t.p.onUnauthorizedResponse()
 		}
+	} else {
+		// Reset consecutive counter on any non-401 response
+		t.p.consecutiveUnauthorized.Store(0)
 	}
 
 	if resp.StatusCode == http.StatusOK {

--- a/pkg/transport/proxy/transparent/transparent_test.go
+++ b/pkg/transport/proxy/transparent/transparent_test.go
@@ -399,7 +399,8 @@ func TestTransparentProxy_StopWithoutStart(t *testing.T) {
 	_ = err
 }
 
-// TestTransparentProxy_UnauthorizedResponseCallback tests that 401 responses trigger the callback
+// TestTransparentProxy_UnauthorizedResponseCallback tests that consecutive 401 responses
+// trigger the callback only after reaching the threshold (default: 3).
 func TestTransparentProxy_UnauthorizedResponseCallback(t *testing.T) {
 	t.Parallel()
 
@@ -422,8 +423,10 @@ func TestTransparentProxy_UnauthorizedResponseCallback(t *testing.T) {
 	targetURL, err := url.Parse(target.URL)
 	assert.NoError(t, err)
 
-	// Create a proxy with unauthorized response callback and set targetURI
-	proxy := NewTransparentProxy("127.0.0.1", 0, target.URL, nil, nil, nil, true, false, "streamable-http", nil, callback, "", false)
+	// Create a proxy with threshold of 1 to test that the callback fires after threshold
+	proxy := newTransparentProxyWithOptions("127.0.0.1", 0, target.URL, nil, nil, nil, true, false, "streamable-http", nil, callback, "", false, nil,
+		withUnauthorizedThreshold(1),
+	)
 
 	// Verify callback is set
 	assert.NotNil(t, proxy.onUnauthorizedResponse, "Callback should be set on proxy")
@@ -442,11 +445,11 @@ func TestTransparentProxy_UnauthorizedResponseCallback(t *testing.T) {
 	// Verify 401 was returned
 	assert.Equal(t, http.StatusUnauthorized, rec.Code)
 
-	// Verify callback was called
+	// Verify callback was called (threshold=1, so first 401 triggers it)
 	mu.Lock()
 	actualCalled := callbackCalled
 	mu.Unlock()
-	assert.True(t, actualCalled, "Unauthorized response callback should have been called")
+	assert.True(t, actualCalled, "Unauthorized response callback should have been called after reaching threshold")
 }
 
 func TestTransparentProxy_UnauthorizedResponseCallback_Multiple401s(t *testing.T) {
@@ -471,15 +474,17 @@ func TestTransparentProxy_UnauthorizedResponseCallback_Multiple401s(t *testing.T
 	targetURL, err := url.Parse(target.URL)
 	assert.NoError(t, err)
 
-	// Create a proxy with unauthorized response callback and set targetURI
-	proxy := NewTransparentProxy("127.0.0.1", 0, target.URL, nil, nil, nil, true, false, "streamable-http", nil, callback, "", false)
+	// Create a proxy with threshold of 3
+	proxy := newTransparentProxyWithOptions("127.0.0.1", 0, target.URL, nil, nil, nil, true, false, "streamable-http", nil, callback, "", false, nil,
+		withUnauthorizedThreshold(3),
+	)
 
 	// Create reverse proxy with tracing transport
 	reverseProxy := httputil.NewSingleHostReverseProxy(targetURL)
 	reverseProxy.FlushInterval = -1
 	reverseProxy.Transport = &tracingTransport{base: http.DefaultTransport, p: proxy}
 
-	// Make multiple requests through the proxy
+	// Make 5 requests through the proxy
 	for i := 0; i < 5; i++ {
 		rec := httptest.NewRecorder()
 		req := httptest.NewRequest("GET", target.URL, nil)
@@ -487,11 +492,12 @@ func TestTransparentProxy_UnauthorizedResponseCallback_Multiple401s(t *testing.T
 		assert.Equal(t, http.StatusUnauthorized, rec.Code)
 	}
 
-	// Verify callback was called for each 401 response
+	// Callback fires once when threshold is reached (at request 3),
+	// then on each subsequent 401 (requests 4 and 5) = 3 total
 	mu.Lock()
 	actualCount := callbackCallCount
 	mu.Unlock()
-	assert.Equal(t, 5, actualCount, "Callback should be called for each 401 response")
+	assert.Equal(t, 3, actualCount, "Callback should fire once at threshold and on each subsequent 401")
 }
 
 func TestTransparentProxy_NoUnauthorizedCallbackOnSuccess(t *testing.T) {

--- a/pkg/transport/proxy/transparent/unauthorized_bug_test.go
+++ b/pkg/transport/proxy/transparent/unauthorized_bug_test.go
@@ -1,0 +1,236 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package transparent
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFix_Single401_DoesNotMarkUnauthenticated verifies that a single 401
+// from the remote server does NOT fire the onUnauthorizedResponse callback.
+// The workload should remain available for subsequent requests.
+func TestFix_Single401_DoesNotMarkUnauthenticated(t *testing.T) {
+	t.Parallel()
+
+	var requestCount atomic.Int32
+	remoteServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		count := requestCount.Add(1)
+		if count == 1 {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"jsonrpc":"2.0","id":"1","result":{}}`))
+	}))
+	defer remoteServer.Close()
+
+	targetURL, err := url.Parse(remoteServer.URL)
+	require.NoError(t, err)
+
+	var unauthorizedCallbackCount atomic.Int32
+	proxy := NewTransparentProxy(
+		"127.0.0.1", 0, remoteServer.URL,
+		nil, nil, nil,
+		false, true, "streamable-http",
+		nil,
+		func() { unauthorizedCallbackCount.Add(1) },
+		"", false,
+	)
+
+	reverseProxy := httputil.NewSingleHostReverseProxy(targetURL)
+	reverseProxy.FlushInterval = -1
+	reverseProxy.Transport = &tracingTransport{base: http.DefaultTransport, p: proxy}
+
+	// First request: gets 401 from remote
+	req1 := httptest.NewRequest("POST", "/v2/mcp",
+		strings.NewReader(`{"jsonrpc":"2.0","method":"initialize","id":"1","params":{}}`))
+	req1.Header.Set("Content-Type", "application/json")
+	rec1 := httptest.NewRecorder()
+	reverseProxy.ServeHTTP(rec1, req1)
+
+	assert.Equal(t, http.StatusUnauthorized, rec1.Code,
+		"first request should return 401 from remote")
+
+	// FIX VERIFIED: callback was NOT fired on a single 401
+	assert.Equal(t, int32(0), unauthorizedCallbackCount.Load(),
+		"callback should NOT fire on a single 401 — workload remains available")
+
+	// Second request: succeeds (proving workload is still alive)
+	req2 := httptest.NewRequest("POST", "/v2/mcp",
+		strings.NewReader(`{"jsonrpc":"2.0","method":"initialize","id":"2","params":{}}`))
+	req2.Header.Set("Content-Type", "application/json")
+	rec2 := httptest.NewRecorder()
+	reverseProxy.ServeHTTP(rec2, req2)
+
+	assert.Equal(t, http.StatusOK, rec2.Code,
+		"second request should succeed — workload was not permanently killed")
+
+	// Counter should have reset to 0 after the 200 response
+	assert.Equal(t, int32(0), proxy.consecutiveUnauthorized.Load(),
+		"consecutive counter should reset to 0 after successful response")
+}
+
+// TestFix_ConsecutiveThreshold_Required verifies that the callback only
+// fires after the configured number of consecutive 401 responses.
+func TestFix_ConsecutiveThreshold_Required(t *testing.T) {
+	t.Parallel()
+
+	// Remote server always returns 401
+	remoteServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer remoteServer.Close()
+
+	targetURL, err := url.Parse(remoteServer.URL)
+	require.NoError(t, err)
+
+	var callbackFired atomic.Bool
+	proxy := newTransparentProxyWithOptions(
+		"127.0.0.1", 0, remoteServer.URL,
+		nil, nil, nil,
+		false, true, "streamable-http",
+		nil,
+		func() { callbackFired.Store(true) },
+		"", false,
+		nil, // middlewares
+		withUnauthorizedThreshold(3),
+	)
+
+	reverseProxy := httputil.NewSingleHostReverseProxy(targetURL)
+	reverseProxy.FlushInterval = -1
+	reverseProxy.Transport = &tracingTransport{base: http.DefaultTransport, p: proxy}
+
+	sendRequest := func() {
+		req := httptest.NewRequest("POST", "/v2/mcp",
+			strings.NewReader(`{"jsonrpc":"2.0","method":"initialize","id":"1","params":{}}`))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		reverseProxy.ServeHTTP(rec, req)
+	}
+
+	// First 401 — callback should NOT fire
+	sendRequest()
+	assert.False(t, callbackFired.Load(), "callback should not fire after 1st consecutive 401")
+	assert.Equal(t, int32(1), proxy.consecutiveUnauthorized.Load())
+
+	// Second 401 — callback should NOT fire
+	sendRequest()
+	assert.False(t, callbackFired.Load(), "callback should not fire after 2nd consecutive 401")
+	assert.Equal(t, int32(2), proxy.consecutiveUnauthorized.Load())
+
+	// Third 401 — callback SHOULD fire (threshold = 3)
+	sendRequest()
+	assert.True(t, callbackFired.Load(),
+		"callback should fire after 3rd consecutive 401 (threshold reached)")
+	assert.Equal(t, int32(3), proxy.consecutiveUnauthorized.Load())
+}
+
+// TestFix_NonConsecutive401s_ResetCounter verifies that a successful response
+// between 401s resets the counter, preventing the callback from firing.
+func TestFix_NonConsecutive401s_ResetCounter(t *testing.T) {
+	t.Parallel()
+
+	// Pattern: 401, 200, 401, 200 — should never reach threshold
+	var requestCount atomic.Int32
+	remoteServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		count := requestCount.Add(1)
+		if count%2 == 1 {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"jsonrpc":"2.0","id":"1","result":{}}`))
+	}))
+	defer remoteServer.Close()
+
+	targetURL, err := url.Parse(remoteServer.URL)
+	require.NoError(t, err)
+
+	var callbackFired atomic.Bool
+	proxy := newTransparentProxyWithOptions(
+		"127.0.0.1", 0, remoteServer.URL,
+		nil, nil, nil,
+		false, true, "streamable-http",
+		nil,
+		func() { callbackFired.Store(true) },
+		"", false,
+		nil, // middlewares
+		withUnauthorizedThreshold(3),
+	)
+
+	reverseProxy := httputil.NewSingleHostReverseProxy(targetURL)
+	reverseProxy.FlushInterval = -1
+	reverseProxy.Transport = &tracingTransport{base: http.DefaultTransport, p: proxy}
+
+	sendRequest := func() {
+		req := httptest.NewRequest("POST", "/v2/mcp",
+			strings.NewReader(`{"jsonrpc":"2.0","method":"initialize","id":"1","params":{}}`))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		reverseProxy.ServeHTTP(rec, req)
+	}
+
+	// Send 6 requests (alternating 401/200) — counter never reaches threshold
+	for range 6 {
+		sendRequest()
+	}
+
+	assert.False(t, callbackFired.Load(),
+		"callback should never fire when 401s are non-consecutive (reset by 200 responses)")
+}
+
+// TestFix_401PassesThroughButDoesNotKill verifies that the 401 response from
+// the remote server is still passed through to the client (transparent proxy
+// behavior), but does NOT permanently mark the workload on a single failure.
+func TestFix_401PassesThroughButDoesNotKill(t *testing.T) {
+	t.Parallel()
+
+	remoteServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("WWW-Authenticate", `Bearer realm="asana"`)
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte(`{"error": "invalid_token"}`))
+	}))
+	defer remoteServer.Close()
+
+	targetURL, err := url.Parse(remoteServer.URL)
+	require.NoError(t, err)
+
+	var callbackFired bool
+	proxy := NewTransparentProxy(
+		"127.0.0.1", 0, remoteServer.URL,
+		nil, nil, nil,
+		false, true, "streamable-http",
+		nil,
+		func() { callbackFired = true },
+		"", false,
+	)
+
+	reverseProxy := httputil.NewSingleHostReverseProxy(targetURL)
+	reverseProxy.FlushInterval = -1
+	reverseProxy.Transport = &tracingTransport{base: http.DefaultTransport, p: proxy}
+
+	req := httptest.NewRequest("POST", "/v2/mcp",
+		strings.NewReader(`{"jsonrpc":"2.0","method":"initialize","id":"1","params":{}}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	reverseProxy.ServeHTTP(rec, req)
+
+	// The 401 from the remote server is still passed through to the client
+	assert.Equal(t, http.StatusUnauthorized, rec.Code,
+		"401 should still pass through to client (transparent proxy)")
+
+	// But the workload is NOT permanently killed
+	assert.False(t, callbackFired,
+		"FIX VERIFIED: single 401 does NOT permanently mark workload as unauthenticated")
+}

--- a/pkg/transport/proxy/transparent/upstream_swap_integration_bug_test.go
+++ b/pkg/transport/proxy/transparent/upstream_swap_integration_bug_test.go
@@ -1,0 +1,353 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package transparent
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stacklok/toolhive/pkg/auth"
+	"github.com/stacklok/toolhive/pkg/authserver/server/session"
+	"github.com/stacklok/toolhive/pkg/authserver/storage"
+	"github.com/stacklok/toolhive/pkg/transport/types"
+)
+
+// fakeUpstreamTokenStorage is a simple in-memory storage for testing the
+// full proxy chain without gomock.
+type fakeUpstreamTokenStorage struct {
+	tokens map[string]*storage.UpstreamTokens
+}
+
+func (f *fakeUpstreamTokenStorage) StoreUpstreamTokens(_ context.Context, sessionID string, tokens *storage.UpstreamTokens) error {
+	f.tokens[sessionID] = tokens
+	return nil
+}
+
+func (f *fakeUpstreamTokenStorage) GetUpstreamTokens(_ context.Context, sessionID string) (*storage.UpstreamTokens, error) {
+	t, ok := f.tokens[sessionID]
+	if !ok {
+		return nil, storage.ErrNotFound
+	}
+	return t, nil
+}
+
+func (f *fakeUpstreamTokenStorage) DeleteUpstreamTokens(_ context.Context, sessionID string) error {
+	delete(f.tokens, sessionID)
+	return nil
+}
+
+// fakeAuthMiddleware creates a middleware that injects a fixed identity into
+// the request context, simulating the auth middleware in the real proxy chain.
+func fakeAuthMiddleware(identity *auth.Identity) types.MiddlewareFunction {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ctx := auth.WithIdentity(r.Context(), identity)
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}
+
+// upstreamSwapMiddleware creates a version of the upstreamswap middleware
+// for integration testing that matches the FIXED behavior: returns 503 when
+// token retrieval fails instead of silently continuing.
+func upstreamSwapMiddleware(stor storage.UpstreamTokenStorage) types.MiddlewareFunction {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			identity, ok := auth.IdentityFromContext(r.Context())
+			if !ok {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			tsid, ok := identity.Claims[session.TokenSessionIDClaimKey].(string)
+			if !ok || tsid == "" {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			if stor == nil {
+				http.Error(w, "upstream token storage unavailable", http.StatusServiceUnavailable)
+				return
+			}
+
+			tokens, err := stor.GetUpstreamTokens(r.Context(), tsid)
+			if err != nil {
+				http.Error(w, "upstream token unavailable", http.StatusServiceUnavailable)
+				return
+			}
+
+			if tokens.IsExpired(time.Now()) {
+				http.Error(w, "upstream token expired", http.StatusServiceUnavailable)
+				return
+			}
+
+			if tokens.AccessToken == "" {
+				http.Error(w, "upstream access token empty", http.StatusServiceUnavailable)
+				return
+			}
+
+			r.Header.Set("Authorization", fmt.Sprintf("Bearer %s", tokens.AccessToken))
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// TestFix_EndToEnd_StorageFailure_Returns503_NotForwarded verifies the full
+// fix chain: when upstream tokens are missing from storage, the middleware
+// returns 503 to the client. The request is NEVER forwarded to the remote
+// server, so no 401 occurs, and the workload is NOT permanently killed.
+func TestFix_EndToEnd_StorageFailure_Returns503_NotForwarded(t *testing.T) {
+	t.Parallel()
+
+	// Remote MCP server that tracks requests
+	var remoteRequestCount atomic.Int32
+	remoteServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		remoteRequestCount.Add(1)
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer remoteServer.Close()
+
+	// Storage does NOT have the tokens (simulates race condition)
+	tokenStorage := &fakeUpstreamTokenStorage{tokens: make(map[string]*storage.UpstreamTokens)}
+
+	// Identity that the auth middleware will inject into every request
+	identity := &auth.Identity{
+		Subject: "user123",
+		Claims: map[string]any{
+			"sub":                          "user123",
+			session.TokenSessionIDClaimKey: "session-missing",
+		},
+	}
+
+	var unauthorizedCallbackFired atomic.Bool
+	proxy := NewTransparentProxy(
+		"127.0.0.1", 0, remoteServer.URL,
+		nil, nil, nil,
+		false, true, "streamable-http",
+		nil,
+		func() { unauthorizedCallbackFired.Store(true) },
+		"", false,
+		// Auth middleware runs first (injects identity), then upstreamswap
+		types.NamedMiddleware{
+			Name:     "auth",
+			Function: fakeAuthMiddleware(identity),
+		},
+		types.NamedMiddleware{
+			Name:     "upstreamswap",
+			Function: upstreamSwapMiddleware(tokenStorage),
+		},
+	)
+
+	ctx := context.Background()
+	err := proxy.Start(ctx)
+	require.NoError(t, err)
+	defer func() {
+		stopErr := proxy.Stop(context.Background())
+		assert.NoError(t, stopErr)
+	}()
+
+	addr := proxy.listener.Addr()
+	require.NotNil(t, addr)
+
+	proxyURL := fmt.Sprintf("http://%s/v2/mcp", addr.String())
+	body := `{"jsonrpc":"2.0","method":"initialize","id":"1","params":{}}`
+	req, err := http.NewRequest("POST", proxyURL, strings.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer toolhive-jwt-with-tsid")
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	// FIX VERIFIED: Client gets 503 (retryable), NOT 401
+	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode,
+		"client should get 503 Service Unavailable, not 401")
+
+	// FIX VERIFIED: Remote server was NEVER contacted with wrong credentials
+	assert.Equal(t, int32(0), remoteRequestCount.Load(),
+		"remote server should NOT have received any request — middleware blocked it")
+
+	// FIX VERIFIED: Workload is NOT permanently marked as unauthenticated
+	assert.False(t, unauthorizedCallbackFired.Load(),
+		"workload should NOT be marked unauthenticated — the 401 never happened")
+}
+
+// TestFix_EndToEnd_ExpiredToken_Returns503_NotForwarded verifies that
+// expired upstream tokens are no longer forwarded to the backend. The
+// middleware returns 503 and the workload stays alive.
+func TestFix_EndToEnd_ExpiredToken_Returns503_NotForwarded(t *testing.T) {
+	t.Parallel()
+
+	var remoteRequestCount atomic.Int32
+	remoteServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		remoteRequestCount.Add(1)
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer remoteServer.Close()
+
+	// Storage has tokens but they're expired
+	tokenStorage := &fakeUpstreamTokenStorage{
+		tokens: map[string]*storage.UpstreamTokens{
+			"session-expired": {
+				AccessToken:  "expired-upstream-token",
+				RefreshToken: "valid-refresh-token",
+				ExpiresAt:    time.Now().Add(-1 * time.Hour),
+			},
+		},
+	}
+
+	identity := &auth.Identity{
+		Subject: "user123",
+		Claims: map[string]any{
+			"sub":                          "user123",
+			session.TokenSessionIDClaimKey: "session-expired",
+		},
+	}
+
+	var unauthorizedCallbackFired atomic.Bool
+	proxy := NewTransparentProxy(
+		"127.0.0.1", 0, remoteServer.URL,
+		nil, nil, nil,
+		false, true, "streamable-http",
+		nil,
+		func() { unauthorizedCallbackFired.Store(true) },
+		"", false,
+		types.NamedMiddleware{
+			Name:     "auth",
+			Function: fakeAuthMiddleware(identity),
+		},
+		types.NamedMiddleware{
+			Name:     "upstreamswap",
+			Function: upstreamSwapMiddleware(tokenStorage),
+		},
+	)
+
+	ctx := context.Background()
+	err := proxy.Start(ctx)
+	require.NoError(t, err)
+	defer func() {
+		stopErr := proxy.Stop(context.Background())
+		assert.NoError(t, stopErr)
+	}()
+
+	addr := proxy.listener.Addr()
+	require.NotNil(t, addr)
+
+	proxyURL := fmt.Sprintf("http://%s/v2/mcp", addr.String())
+	body := `{"jsonrpc":"2.0","method":"initialize","id":"1","params":{}}`
+	req, err := http.NewRequest("POST", proxyURL, strings.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer toolhive-jwt")
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	// FIX VERIFIED: Client gets 503 (retryable), expired token NOT forwarded
+	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode,
+		"client should get 503 — expired token was not forwarded")
+
+	// FIX VERIFIED: Remote server was never contacted
+	assert.Equal(t, int32(0), remoteRequestCount.Load(),
+		"remote server should NOT have received expired token")
+
+	// FIX VERIFIED: Workload stays alive
+	assert.False(t, unauthorizedCallbackFired.Load(),
+		"workload should NOT be marked unauthenticated")
+}
+
+// TestFix_EndToEnd_ValidToken_ForwardedSuccessfully verifies that the fix
+// doesn't break the happy path: valid, non-expired upstream tokens are still
+// correctly injected and forwarded to the remote server.
+func TestFix_EndToEnd_ValidToken_ForwardedSuccessfully(t *testing.T) {
+	t.Parallel()
+
+	validToken := "valid-asana-oauth-token"
+	var capturedAuthHeader atomic.Value
+
+	remoteServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedAuthHeader.Store(r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"jsonrpc":"2.0","id":"1","result":{"protocolVersion":"2024-11-05"}}`))
+	}))
+	defer remoteServer.Close()
+
+	// Storage has valid, non-expired tokens
+	tokenStorage := &fakeUpstreamTokenStorage{
+		tokens: map[string]*storage.UpstreamTokens{
+			"session-valid": {
+				AccessToken: validToken,
+				ExpiresAt:   time.Now().Add(1 * time.Hour),
+			},
+		},
+	}
+
+	identity := &auth.Identity{
+		Subject: "user123",
+		Claims: map[string]any{
+			"sub":                          "user123",
+			session.TokenSessionIDClaimKey: "session-valid",
+		},
+	}
+
+	proxy := NewTransparentProxy(
+		"127.0.0.1", 0, remoteServer.URL,
+		nil, nil, nil,
+		false, true, "streamable-http",
+		nil, nil,
+		"", false,
+		types.NamedMiddleware{
+			Name:     "auth",
+			Function: fakeAuthMiddleware(identity),
+		},
+		types.NamedMiddleware{
+			Name:     "upstreamswap",
+			Function: upstreamSwapMiddleware(tokenStorage),
+		},
+	)
+
+	ctx := context.Background()
+	err := proxy.Start(ctx)
+	require.NoError(t, err)
+	defer func() {
+		stopErr := proxy.Stop(context.Background())
+		assert.NoError(t, stopErr)
+	}()
+
+	addr := proxy.listener.Addr()
+	require.NotNil(t, addr)
+
+	proxyURL := fmt.Sprintf("http://%s/v2/mcp", addr.String())
+	body := `{"jsonrpc":"2.0","method":"initialize","id":"1","params":{}}`
+	req, err := http.NewRequest("POST", proxyURL, strings.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer toolhive-jwt-should-be-replaced")
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode,
+		"request should succeed with valid upstream token")
+
+	receivedAuth, _ := capturedAuthHeader.Load().(string)
+	assert.Equal(t, "Bearer "+validToken, receivedAuth,
+		"remote server should receive the upstream Asana token, not the ToolHive JWT")
+}


### PR DESCRIPTION
The upstreamswap middleware silently continued when it couldn't retrieve upstream tokens, forwarding the ToolHive JWT to the remote MCP server instead. The remote server rejected this with 401, which permanently marked the workload as unauthenticated with no recovery path.

Two fixes applied:

1. Upstreamswap middleware now returns 503 Service Unavailable when it cannot swap the token (storage error, token not found, expired, or empty). This prevents the wrong credential from reaching the remote server and gives clients a retryable error.

2. The transparent proxy now requires 3 consecutive 401 responses before firing the permanent unauthenticated callback. Non-401 responses reset the counter. This prevents transient auth failures from permanently killing workloads.