### PR TITLE
Fix flaky MCPRemoteProxy integration test

### DIFF
--- a/cmd/thv-operator/test-integration/mcp-remote-proxy/mcpremoteproxy_controller_integration_test.go
+++ b/cmd/thv-operator/test-integration/mcp-remote-proxy/mcpremoteproxy_controller_integration_test.go
@@ -264,10 +264,8 @@ var _ = Describe("MCPRemoteProxy Controller", Label("k8s", "remoteproxy"), func(
 			}, MediumTimeout)
 
 			By("verifying the phase is Pending (since deployment is not ready in envtest)")
-			phase, err := proxyHelper.GetRemoteProxyPhase(proxy.Name)
-			Expect(err).NotTo(HaveOccurred())
 			// In envtest, pods don't actually run so phase will be Pending
-			Expect(phase).To(Equal(mcpv1alpha1.MCPRemoteProxyPhasePending))
+			statusHelper.WaitForPhase(proxy.Name, mcpv1alpha1.MCPRemoteProxyPhasePending, MediumTimeout)
 		})
 
 		It("should update ObservedGeneration in status", func() {
@@ -420,9 +418,7 @@ var _ = Describe("MCPRemoteProxy Controller", Label("k8s", "remoteproxy"), func(
 				hash := proxyHelper.WaitForExternalAuthConfigHash(proxy.Name, MediumTimeout)
 
 				By("verifying phase is Pending (not Failed)")
-				phase, err := proxyHelper.GetRemoteProxyPhase(proxy.Name)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(phase).To(Equal(mcpv1alpha1.MCPRemoteProxyPhasePending))
+				statusHelper.WaitForPhase(proxy.Name, mcpv1alpha1.MCPRemoteProxyPhasePending, MediumTimeout)
 
 				By("verifying the ExternalAuthConfigHash is tracked in status")
 				Expect(hash).NotTo(BeEmpty())
@@ -581,9 +577,7 @@ var _ = Describe("MCPRemoteProxy Controller", Label("k8s", "remoteproxy"), func(
 				hash := proxyHelper.WaitForToolConfigHash(proxy.Name, MediumTimeout)
 
 				By("verifying phase is Pending (not Failed)")
-				phase, err := proxyHelper.GetRemoteProxyPhase(proxy.Name)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(phase).To(Equal(mcpv1alpha1.MCPRemoteProxyPhasePending))
+				statusHelper.WaitForPhase(proxy.Name, mcpv1alpha1.MCPRemoteProxyPhasePending, MediumTimeout)
 
 				By("verifying the ToolConfigHash is tracked in status")
 				Expect(hash).NotTo(BeEmpty())


### PR DESCRIPTION
## Summary
- Replace 3 point-in-time `GetRemoteProxyPhase()` assertions with `statusHelper.WaitForPhase()` which uses `Eventually` with polling
- Fixes intermittent failure where Phase is `""` instead of `"Pending"` due to a timing gap between two separate status updates in the controller's reconciliation

## Root cause
The controller performs two sequential status updates: `ToolConfigHash` first, then `Phase`. The test waited for `ToolConfigHash` (using `Eventually`), then did a single-shot read of Phase — which could see the object after update #1 but before update #2 completed.

## Test plan
- [x] `task lint` passes
- [x] `task operator-test-integration` passes (all 7 suites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)