### PR TITLE
Add atomic writes and file locking for secrets file

### DIFF
--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -15,7 +15,6 @@ import (
 	"runtime"
 	"sort"
 	"strings"
-	"time"
 
 	"github.com/pelletier/go-toml/v2"
 	"github.com/tailscale/hujson"
@@ -23,9 +22,6 @@ import (
 
 	"github.com/stacklok/toolhive/pkg/transport/types"
 )
-
-// lockTimeout is the maximum time to wait for a file lock
-const lockTimeout = 1 * time.Second
 
 // defaultURLFieldName is the default URL field name used when no specific mapping exists
 const defaultURLFieldName = "url"

--- a/pkg/client/config_editor.go
+++ b/pkg/client/config_editor.go
@@ -28,20 +28,18 @@
 //
 // # File Locking
 //
-// All operations use file-based locking via withFileLock() to ensure safe concurrent
+// All operations use file-based locking via fileutils.WithFileLock() to ensure safe concurrent
 // access. Each config file has a corresponding ".lock" file that is acquired before
 // any read-modify-write operation.
 
 package client
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"log/slog"
 	"os"
 	"strings"
-	"time"
 
 	"github.com/pelletier/go-toml/v2"
 	"github.com/tailscale/hujson"
@@ -49,7 +47,6 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/stacklok/toolhive/pkg/fileutils"
-	"github.com/stacklok/toolhive/pkg/lockfile"
 )
 
 // ConfigUpdater defines the interface for types which can edit MCP client config files.
@@ -78,27 +75,6 @@ type MCPServer struct {
 
 // --- Shared helper functions ---
 
-// withFileLock executes the given function while holding a file lock for the specified path.
-// This is used by all config updaters (JSON, YAML, TOML) to ensure safe concurrent access.
-func withFileLock(path string, fn func() error) error {
-	lockPath := path + ".lock"
-	fileLock := lockfile.NewTrackedLock(lockPath)
-
-	ctx, cancel := context.WithTimeout(context.Background(), lockTimeout)
-	defer cancel()
-
-	locked, err := fileLock.TryLockContext(ctx, 100*time.Millisecond)
-	if err != nil {
-		return fmt.Errorf("failed to acquire lock: %w", err)
-	}
-	if !locked {
-		return fmt.Errorf("failed to acquire lock: timeout after %v", lockTimeout)
-	}
-	defer lockfile.ReleaseTrackedLock(lockPath, fileLock)
-
-	return fn()
-}
-
 // JSONConfigUpdater is a ConfigUpdater that is responsible for updating
 // JSON config files.
 type JSONConfigUpdater struct {
@@ -108,7 +84,7 @@ type JSONConfigUpdater struct {
 
 // Upsert inserts or updates an MCP server in the MCP client config file
 func (jcu *JSONConfigUpdater) Upsert(serverName string, data MCPServer) error {
-	return withFileLock(jcu.Path, func() error {
+	return fileutils.WithFileLock(jcu.Path, func() error {
 		content, err := os.ReadFile(jcu.Path)
 		if err != nil && !os.IsNotExist(err) {
 			return fmt.Errorf("failed to read file: %w", err)
@@ -154,7 +130,7 @@ func (jcu *JSONConfigUpdater) Upsert(serverName string, data MCPServer) error {
 
 // Remove removes an MCP server from the MCP client config file
 func (jcu *JSONConfigUpdater) Remove(serverName string) error {
-	return withFileLock(jcu.Path, func() error {
+	return fileutils.WithFileLock(jcu.Path, func() error {
 		content, err := os.ReadFile(jcu.Path)
 		if err != nil {
 			if os.IsNotExist(err) {
@@ -211,7 +187,7 @@ type YAMLConfigUpdater struct {
 
 // Upsert inserts or updates an MCP server in the config.yaml file using the converter
 func (ycu *YAMLConfigUpdater) Upsert(serverName string, data MCPServer) error {
-	return withFileLock(ycu.Path, func() error {
+	return fileutils.WithFileLock(ycu.Path, func() error {
 		content, err := os.ReadFile(ycu.Path)
 		if err != nil && !os.IsNotExist(err) {
 			return fmt.Errorf("failed to read file: %w", err)
@@ -260,7 +236,7 @@ func (ycu *YAMLConfigUpdater) Upsert(serverName string, data MCPServer) error {
 
 // Remove removes an entry from the config.yaml file using the converter
 func (ycu *YAMLConfigUpdater) Remove(serverName string) error {
-	return withFileLock(ycu.Path, func() error {
+	return fileutils.WithFileLock(ycu.Path, func() error {
 		// Read existing config
 		content, err := os.ReadFile(ycu.Path)
 		if err != nil {
@@ -383,7 +359,7 @@ type TOMLConfigUpdater struct {
 
 // Upsert inserts or updates an MCP server in the TOML config file
 func (tcu *TOMLConfigUpdater) Upsert(serverName string, data MCPServer) error {
-	return withFileLock(tcu.Path, func() error {
+	return fileutils.WithFileLock(tcu.Path, func() error {
 		config, err := readTOMLConfig(tcu.Path)
 		if err != nil {
 			return err
@@ -405,7 +381,7 @@ func (tcu *TOMLConfigUpdater) Upsert(serverName string, data MCPServer) error {
 
 // Remove removes an MCP server from the TOML config file
 func (tcu *TOMLConfigUpdater) Remove(serverName string) error {
-	return withFileLock(tcu.Path, func() error {
+	return fileutils.WithFileLock(tcu.Path, func() error {
 		config, err := readTOMLConfig(tcu.Path)
 		if err != nil {
 			return err
@@ -510,7 +486,7 @@ type TOMLMapConfigUpdater struct {
 
 // Upsert inserts or updates an MCP server in the TOML config file using map format
 func (tmu *TOMLMapConfigUpdater) Upsert(serverName string, data MCPServer) error {
-	return withFileLock(tmu.Path, func() error {
+	return fileutils.WithFileLock(tmu.Path, func() error {
 		config, err := readTOMLConfig(tmu.Path)
 		if err != nil {
 			return err
@@ -537,7 +513,7 @@ func (tmu *TOMLMapConfigUpdater) Upsert(serverName string, data MCPServer) error
 
 // Remove removes an MCP server from the TOML config file
 func (tmu *TOMLMapConfigUpdater) Remove(serverName string) error {
-	return withFileLock(tmu.Path, func() error {
+	return fileutils.WithFileLock(tmu.Path, func() error {
 		config, err := readTOMLConfig(tmu.Path)
 		if err != nil {
 			return err

--- a/pkg/fileutils/lock.go
+++ b/pkg/fileutils/lock.go
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package fileutils
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/stacklok/toolhive/pkg/lockfile"
+)
+
+const (
+	// DefaultLockTimeout is the maximum time to wait for a file lock.
+	DefaultLockTimeout = 1 * time.Second
+
+	// defaultLockRetryInterval is the interval between lock acquisition attempts.
+	defaultLockRetryInterval = 100 * time.Millisecond
+)
+
+// WithFileLock executes fn while holding an OS-level advisory file lock on path + ".lock".
+// It uses a 1-second timeout with 100ms retry interval.
+func WithFileLock(path string, fn func() error) error {
+	lockPath := path + ".lock"
+	fileLock := lockfile.NewTrackedLock(lockPath)
+
+	ctx, cancel := context.WithTimeout(context.Background(), DefaultLockTimeout)
+	defer cancel()
+
+	locked, err := fileLock.TryLockContext(ctx, defaultLockRetryInterval)
+	if err != nil {
+		return fmt.Errorf("failed to acquire lock: %w", err)
+	}
+	if !locked {
+		return fmt.Errorf("failed to acquire lock: timeout after %v", DefaultLockTimeout)
+	}
+	defer lockfile.ReleaseTrackedLock(lockPath, fileLock)
+
+	return fn()
+}

--- a/pkg/secrets/encrypted.go
+++ b/pkg/secrets/encrypted.go
@@ -15,6 +15,7 @@ import (
 
 	"golang.org/x/sync/syncmap"
 
+	"github.com/stacklok/toolhive/pkg/fileutils"
 	"github.com/stacklok/toolhive/pkg/secrets/aes"
 )
 
@@ -51,8 +52,10 @@ func (e *EncryptedManager) SetSecret(_ context.Context, name, value string) erro
 		return errors.New("secret name cannot be empty")
 	}
 
-	e.secrets.Store(name, value)
-	return e.updateFile()
+	return fileutils.WithFileLock(e.filePath, func() error {
+		e.secrets.Store(name, value)
+		return e.updateFile()
+	})
 }
 
 // DeleteSecret removes a secret from the secret store.
@@ -67,8 +70,10 @@ func (e *EncryptedManager) DeleteSecret(_ context.Context, name string) error {
 		return fmt.Errorf("cannot delete non-existent secret: %s", name)
 	}
 
-	e.secrets.Delete(name)
-	return e.updateFile()
+	return fileutils.WithFileLock(e.filePath, func() error {
+		e.secrets.Delete(name)
+		return e.updateFile()
+	})
 }
 
 // ListSecrets returns a list of all secret names stored in the manager.
@@ -85,11 +90,13 @@ func (e *EncryptedManager) ListSecrets(_ context.Context) ([]SecretDescription, 
 
 // Cleanup removes all secrets managed by this manager.
 func (e *EncryptedManager) Cleanup() error {
-	// Create a new empty syncmap.Map
-	e.secrets = syncmap.Map{}
+	return fileutils.WithFileLock(e.filePath, func() error {
+		// Create a new empty syncmap.Map
+		e.secrets = syncmap.Map{}
 
-	// Update the file to reflect the empty state
-	return e.updateFile()
+		// Update the file to reflect the empty state
+		return e.updateFile()
+	})
 }
 
 // Capabilities returns the capabilities of the encrypted provider.
@@ -121,8 +128,7 @@ func (e *EncryptedManager) updateFile() error {
 		return fmt.Errorf("failed to encrypt secrets: %w", err)
 	}
 
-	err = os.WriteFile(e.filePath, encryptedContents, 0600)
-	if err != nil {
+	if err := fileutils.AtomicWriteFile(e.filePath, encryptedContents, 0600); err != nil {
 		return fmt.Errorf("failed to write secrets to file: %w", err)
 	}
 	return nil

--- a/pkg/secrets/encrypted_test.go
+++ b/pkg/secrets/encrypted_test.go
@@ -333,14 +333,14 @@ func TestEncryptedManager_Concurrency(t *testing.T) {
 		<-done
 	}
 
-	// Verify all secrets were set
+	// Verify all secrets were set in memory
 	secrets, err := manager.ListSecrets(ctx)
 	assert.NoError(t, err, "Listing secrets should not return an error")
 	assert.Len(t, secrets, numGoroutines+1, "There should be numGoroutines+1 secrets")
 
 	// Helper function to check if a key exists in the secrets list
-	containsKey := func(key string) bool {
-		for _, secret := range secrets {
+	containsKey := func(list []SecretDescription, key string) bool {
+		for _, secret := range list {
 			if secret.Key == key {
 				return true
 			}
@@ -349,12 +349,24 @@ func TestEncryptedManager_Concurrency(t *testing.T) {
 	}
 
 	// Check if the original key exists
-	assert.True(t, containsKey("test-key"), "The list should contain the original key")
+	assert.True(t, containsKey(secrets, "test-key"), "The list should contain the original key")
 
 	// Check if all the keys created in the goroutines exist
 	for i := 0; i < numGoroutines; i++ {
 		keyName := fmt.Sprintf("key-%d", i)
-		assert.True(t, containsKey(keyName), "The list should contain %s", keyName)
+		assert.True(t, containsKey(secrets, keyName), "The list should contain %s", keyName)
+	}
+
+	// Verify file-level consistency: reload from disk and confirm all secrets are present
+	reloaded := createEncryptedManager(t, tempFile, key)
+	reloadedSecrets, err := reloaded.ListSecrets(ctx)
+	require.NoError(t, err, "Listing secrets from reloaded manager should not return an error")
+	assert.Len(t, reloadedSecrets, numGoroutines+1, "Reloaded manager should have numGoroutines+1 secrets")
+
+	assert.True(t, containsKey(reloadedSecrets, "test-key"), "Reloaded list should contain the original key")
+	for i := 0; i < numGoroutines; i++ {
+		keyName := fmt.Sprintf("key-%d", i)
+		assert.True(t, containsKey(reloadedSecrets, keyName), "Reloaded list should contain %s", keyName)
 	}
 }
 


### PR DESCRIPTION
The secrets file used os.WriteFile directly, which is non-atomic — a crash mid-write could leave a corrupted file. It also had no file locking, so concurrent processes could race on writes.

- Replace os.WriteFile with fileutils.AtomicWriteFile (temp file + fsync + rename) in the encrypted secrets manager
- Wrap SetSecret, DeleteSecret, and Cleanup with file locking using lockfile.NewTrackedLock to prevent cross-process races
- Extract shared WithFileLock helper into pkg/fileutils/lock.go and reuse it from both pkg/secrets and pkg/client
- Update concurrency test to verify file-level consistency by reloading from disk after concurrent writes