### PR TITLE
Add group support to skills API

### DIFF
--- a/docs/server/docs.go
+++ b/docs/server/docs.go
@@ -1826,6 +1826,10 @@ const docTemplate = `{
                         "description": "Force allows overwriting unmanaged skill directories",
                         "type": "boolean"
                     },
+                    "group": {
+                        "description": "Group is the group name to add the skill to after installation",
+                        "type": "string"
+                    },
                     "name": {
                         "description": "Name or OCI reference of the skill to install",
                         "type": "string"
@@ -3547,6 +3551,14 @@ const docTemplate = `{
                         "description": "Filter by project root path",
                         "in": "query",
                         "name": "project_root",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Filter by group name",
+                        "in": "query",
+                        "name": "group",
                         "schema": {
                             "type": "string"
                         }

--- a/docs/server/swagger.json
+++ b/docs/server/swagger.json
@@ -1819,6 +1819,10 @@
                         "description": "Force allows overwriting unmanaged skill directories",
                         "type": "boolean"
                     },
+                    "group": {
+                        "description": "Group is the group name to add the skill to after installation",
+                        "type": "string"
+                    },
                     "name": {
                         "description": "Name or OCI reference of the skill to install",
                         "type": "string"
@@ -3540,6 +3544,14 @@
                         "description": "Filter by project root path",
                         "in": "query",
                         "name": "project_root",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Filter by group name",
+                        "in": "query",
+                        "name": "group",
                         "schema": {
                             "type": "string"
                         }

--- a/docs/server/swagger.yaml
+++ b/docs/server/swagger.yaml
@@ -1619,6 +1619,9 @@ components:
         force:
           description: Force allows overwriting unmanaged skill directories
           type: boolean
+        group:
+          description: Group is the group name to add the skill to after installation
+          type: string
         name:
           description: Name or OCI reference of the skill to install
           type: string
@@ -2731,6 +2734,11 @@ paths:
       - description: Filter by project root path
         in: query
         name: project_root
+        schema:
+          type: string
+      - description: Filter by group name
+        in: query
+        name: group
         schema:
           type: string
       responses:

--- a/pkg/api/v1/skills.go
+++ b/pkg/api/v1/skills.go
@@ -47,19 +47,21 @@ func SkillsRouter(skillService skills.SkillService) http.Handler {
 //	@Param			scope	query		string	false	"Filter by scope (user or project)"	Enums(user, project)
 //	@Param			client	query		string	false	"Filter by client app"
 //	@Param			project_root	query	string	false	"Filter by project root path"
+//	@Param			group	query		string	false	"Filter by group name"
 //	@Success		200		{object}	skillListResponse
 //	@Failure		500		{string}	string	"Internal Server Error"
 //	@Router			/api/v1beta/skills [get]
 func (s *SkillsRoutes) listSkills(w http.ResponseWriter, r *http.Request) error {
 	scope := skills.Scope(r.URL.Query().Get("scope"))
 	projectRoot := r.URL.Query().Get("project_root")
-
 	client := r.URL.Query().Get("client")
+	group := r.URL.Query().Get("group")
 
 	result, err := s.skillService.List(r.Context(), skills.ListOptions{
 		Scope:       scope,
 		ClientApp:   client,
 		ProjectRoot: projectRoot,
+		Group:       group,
 	})
 	if err != nil {
 		return err
@@ -99,6 +101,7 @@ func (s *SkillsRoutes) installSkill(w http.ResponseWriter, r *http.Request) erro
 		ProjectRoot: req.ProjectRoot,
 		Client:      req.Client,
 		Force:       req.Force,
+		Group:       req.Group,
 	})
 	if err != nil {
 		return err

--- a/pkg/api/v1/skills_types.go
+++ b/pkg/api/v1/skills_types.go
@@ -29,6 +29,8 @@ type installSkillRequest struct {
 	Client string `json:"client,omitempty"`
 	// Force allows overwriting unmanaged skill directories
 	Force bool `json:"force,omitempty"`
+	// Group is the group name to add the skill to after installation
+	Group string `json:"group,omitempty"`
 }
 
 // installSkillResponse represents the response after installing a skill.

--- a/test/e2e/api_skills_test.go
+++ b/test/e2e/api_skills_test.go
@@ -51,6 +51,7 @@ type installSkillRequest struct {
 	ProjectRoot string `json:"project_root,omitempty"`
 	Client      string `json:"client,omitempty"`
 	Force       bool   `json:"force,omitempty"`
+	Group       string `json:"group,omitempty"`
 }
 
 type installSkillResponse struct {
@@ -85,6 +86,12 @@ type skillInfoResponse struct {
 
 func listSkills(server *e2e.Server) *http.Response {
 	resp, err := server.Get("/api/v1beta/skills")
+	ExpectWithOffset(1, err).ToNot(HaveOccurred())
+	return resp
+}
+
+func listSkillsInGroup(server *e2e.Server, group string) *http.Response {
+	resp, err := server.Get("/api/v1beta/skills?group=" + group)
 	ExpectWithOffset(1, err).ToNot(HaveOccurred())
 	return resp
 }
@@ -560,6 +567,113 @@ var _ = Describe("Skills API", Label("api", "skills", "e2e"), func() {
 
 			By("Verifying response status is 400 Bad Request")
 			Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
+		})
+	})
+
+	Describe("Group integration", func() {
+		var groupName string
+
+		BeforeEach(func() {
+			groupName = fmt.Sprintf("skill-group-%d", GinkgoRandomSeed())
+			By("Creating a group for skill tests")
+			resp := createGroup(apiServer, map[string]interface{}{"name": groupName})
+			defer resp.Body.Close()
+			Expect(resp.StatusCode).To(Equal(http.StatusCreated))
+		})
+
+		AfterEach(func() {
+			deleteGroup(apiServer, groupName)
+		})
+
+		It("should register the skill in the group on install", func() {
+			skillName := "group-install-skill"
+
+			By("Installing a skill into the group")
+			resp := installSkill(apiServer, installSkillRequest{Name: skillName, Group: groupName})
+			defer resp.Body.Close()
+			Expect(resp.StatusCode).To(Equal(http.StatusCreated))
+
+			By("Verifying the group lists the skill")
+			getResp, err := apiServer.Get(fmt.Sprintf("/api/v1beta/groups/%s", groupName))
+			Expect(err).ToNot(HaveOccurred())
+			defer getResp.Body.Close()
+			Expect(getResp.StatusCode).To(Equal(http.StatusOK))
+
+			var grp struct {
+				Name   string   `json:"name"`
+				Skills []string `json:"skills"`
+			}
+			Expect(json.NewDecoder(getResp.Body).Decode(&grp)).To(Succeed())
+			Expect(grp.Skills).To(ContainElement(skillName))
+		})
+
+		It("should filter list by group", func() {
+			skillInGroup := "group-filter-in"
+			skillOutGroup := "group-filter-out"
+
+			By("Installing a skill into the group")
+			r1 := installSkill(apiServer, installSkillRequest{Name: skillInGroup, Group: groupName})
+			defer r1.Body.Close()
+			Expect(r1.StatusCode).To(Equal(http.StatusCreated))
+
+			By("Installing a skill without a group")
+			r2 := installSkill(apiServer, installSkillRequest{Name: skillOutGroup})
+			defer r2.Body.Close()
+			Expect(r2.StatusCode).To(Equal(http.StatusCreated))
+
+			By("Listing skills filtered by group")
+			resp := listSkillsInGroup(apiServer, groupName)
+			defer resp.Body.Close()
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+			var result skillListResponse
+			Expect(json.NewDecoder(resp.Body).Decode(&result)).To(Succeed())
+
+			names := make([]string, 0, len(result.Skills))
+			for _, s := range result.Skills {
+				names = append(names, s.Metadata.Name)
+			}
+			Expect(names).To(ContainElement(skillInGroup))
+			Expect(names).NotTo(ContainElement(skillOutGroup))
+		})
+
+		It("should remove the skill from the group on uninstall", func() {
+			skillName := "group-uninstall-skill"
+
+			By("Installing a skill into the group")
+			r1 := installSkill(apiServer, installSkillRequest{Name: skillName, Group: groupName})
+			defer r1.Body.Close()
+			Expect(r1.StatusCode).To(Equal(http.StatusCreated))
+
+			By("Uninstalling the skill")
+			r2 := uninstallSkill(apiServer, skillName)
+			defer r2.Body.Close()
+			Expect(r2.StatusCode).To(Equal(http.StatusNoContent))
+
+			By("Verifying the group no longer lists the skill")
+			getResp, err := apiServer.Get(fmt.Sprintf("/api/v1beta/groups/%s", groupName))
+			Expect(err).ToNot(HaveOccurred())
+			defer getResp.Body.Close()
+			Expect(getResp.StatusCode).To(Equal(http.StatusOK))
+
+			var grp struct {
+				Name   string   `json:"name"`
+				Skills []string `json:"skills"`
+			}
+			Expect(json.NewDecoder(getResp.Body).Decode(&grp)).To(Succeed())
+			Expect(grp.Skills).NotTo(ContainElement(skillName))
+		})
+
+		It("should return error when installing into a non-existent group", func() {
+			By("Attempting to install a skill into a non-existent group")
+			resp := installSkill(apiServer, installSkillRequest{
+				Name:  "group-noexist-skill",
+				Group: "no-such-group-xyz",
+			})
+			defer resp.Body.Close()
+
+			By("Verifying the response indicates failure")
+			Expect(resp.StatusCode).To(BeNumerically(">=", http.StatusBadRequest))
 		})
 	})
 


### PR DESCRIPTION
## Summary

- Expose `group` field in `POST /api/v1beta/skills` install request — the skill is registered in the named group after installation
- Add `?group=` query parameter to `GET /api/v1beta/skills` to filter results to skills belonging to a specific group
- Add E2E tests covering install-into-group, list-by-group filter, uninstall-removes-from-group, and error on non-existent group
- Regenerate Swagger docs to include the new field and query parameter

## Test plan

- [ ] `task test` — unit tests pass
- [ ] `task test-e2e` — new `Group integration` E2E tests in `api_skills_test.go` pass
- [ ] Verify `GET /api/v1beta/skills?group=<name>` returns only skills in the group
- [ ] Verify `POST /api/v1beta/skills` with `"group": "<name>"` registers the skill in the group (check via `GET /api/v1beta/groups/<name>`)
- [ ] Verify `DELETE /api/v1beta/skills/<name>` removes the skill from all groups

🤖 Generated with [Claude Code](https://claude.com/claude-code)