### PR TITLE
Increase file lock timeout to fix flaky CI test

### DIFF
--- a/pkg/fileutils/lock.go
+++ b/pkg/fileutils/lock.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	// DefaultLockTimeout is the maximum time to wait for a file lock.
-	DefaultLockTimeout = 1 * time.Second
+	DefaultLockTimeout = 5 * time.Second
 
 	// defaultLockRetryInterval is the interval between lock acquisition attempts.
 	defaultLockRetryInterval = 100 * time.Millisecond


### PR DESCRIPTION
## Summary

- Increases `DefaultLockTimeout` in `pkg/fileutils/lock.go` from 1s to 5s
- Fixes `TestEncryptedManager_Concurrency` failures on GitHub Actions where 10 concurrent goroutines acquiring the same file lock (each doing AES encryption + disk write) would time out on slow CI runners

## Test plan

- [ ] `TestEncryptedManager_Concurrency` passes on CI without flakiness
- [ ] Existing unit tests in `pkg/fileutils` and `pkg/secrets` continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)