### PR TITLE
Automate HMAC secret management

### DIFF
--- a/cmd/thv-operator/controllers/virtualmcpserver_controller.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_controller.go
@@ -7,6 +7,8 @@ package controllers
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/base64"
 	"fmt"
 	"maps"
 	"reflect"
@@ -23,6 +25,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -100,7 +103,7 @@ type VirtualMCPServerReconciler struct {
 // +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=roles,verbs=create;delete;get;list;patch;update;watch
 // +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=rolebindings,verbs=create;delete;get;list;patch;update;watch
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
-// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=create;get;list;watch
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=create;delete;get;list;patch;update;watch
 // +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=create;delete;get;list;patch;update;watch
 // +kubebuilder:rbac:groups=toolhive.stacklok.dev,resources=embeddingservers,verbs=get;list;watch
@@ -592,6 +595,12 @@ func (r *VirtualMCPServerReconciler) ensureAllResources(
 		return ctrl.Result{}, err
 	}
 
+	// Ensure HMAC secret for session token binding (Session Management V2)
+	if err := r.ensureHMACSecret(ctx, vmcp); err != nil {
+		ctxLogger.Error(err, "Failed to ensure HMAC secret")
+		return ctrl.Result{}, err
+	}
+
 	// Ensure vmcp Config ConfigMap
 	if err := r.ensureVmcpConfigConfigMap(ctx, vmcp, workloadNames, statusManager); err != nil {
 		ctxLogger.Error(err, "Failed to ensure vmcp Config ConfigMap")
@@ -658,6 +667,161 @@ func (r *VirtualMCPServerReconciler) ensureRBACResources(
 		Owner:     vmcp,
 	})
 	return err
+}
+
+// ensureHMACSecret ensures the HMAC secret exists for session token binding.
+// This secret is required when Session Management V2 is enabled.
+// The secret is automatically generated with a cryptographically secure random value.
+//
+// The secret follows this naming pattern: {vmcp-name}-hmac-secret
+// and contains a single key: hmac-secret with a 32-byte base64-encoded random value.
+func (r *VirtualMCPServerReconciler) ensureHMACSecret(
+	ctx context.Context,
+	vmcp *mcpv1alpha1.VirtualMCPServer,
+) error {
+	ctxLogger := log.FromContext(ctx)
+
+	// Only ensure HMAC secret if Session Management V2 is enabled
+	if vmcp.Spec.Config.Operational == nil || !vmcp.Spec.Config.Operational.SessionManagementV2 {
+		return nil
+	}
+
+	secretName := fmt.Sprintf("%s-hmac-secret", vmcp.Name)
+	secret := &corev1.Secret{}
+	err := r.Get(ctx, types.NamespacedName{Name: secretName, Namespace: vmcp.Namespace}, secret)
+
+	if errors.IsNotFound(err) {
+		// Generate a cryptographically secure 32-byte HMAC secret
+		hmacSecret, err := generateHMACSecret()
+		if err != nil {
+			ctxLogger.Error(err, "Failed to generate HMAC secret")
+			if r.Recorder != nil {
+				r.Recorder.Eventf(vmcp, corev1.EventTypeWarning, "HMACSecretGenerationFailed",
+					"Failed to generate HMAC secret: %v", err)
+			}
+			return fmt.Errorf("failed to generate HMAC secret: %w", err)
+		}
+
+		newSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretName,
+				Namespace: vmcp.Namespace,
+				Labels: map[string]string{
+					"app.kubernetes.io/name":       "virtualmcpserver",
+					"app.kubernetes.io/instance":   vmcp.Name,
+					"app.kubernetes.io/component":  "session-security",
+					"app.kubernetes.io/managed-by": "toolhive-operator",
+				},
+				Annotations: map[string]string{
+					"toolhive.stacklok.dev/purpose": "hmac-secret-for-session-token-binding",
+				},
+			},
+			Type: corev1.SecretTypeOpaque,
+			Data: map[string][]byte{
+				"hmac-secret": []byte(hmacSecret),
+			},
+		}
+
+		// Set VirtualMCPServer as owner so secret is automatically deleted when VMCP is deleted
+		if err := controllerutil.SetControllerReference(vmcp, newSecret, r.Scheme); err != nil {
+			ctxLogger.Error(err, "Failed to set controller reference for HMAC secret")
+			return fmt.Errorf("failed to set controller reference: %w", err)
+		}
+
+		ctxLogger.Info("Creating HMAC secret for session token binding", "Secret.Name", secretName)
+		if err := r.Create(ctx, newSecret); err != nil {
+			ctxLogger.Error(err, "Failed to create HMAC secret")
+			if r.Recorder != nil {
+				r.Recorder.Eventf(vmcp, corev1.EventTypeWarning, "HMACSecretCreationFailed",
+					"Failed to create HMAC secret: %v", err)
+			}
+			return fmt.Errorf("failed to create HMAC secret: %w", err)
+		}
+
+		// Record success event
+		if r.Recorder != nil {
+			r.Recorder.Event(vmcp, corev1.EventTypeNormal, "HMACSecretCreated",
+				"HMAC secret created for session token binding")
+		}
+		return nil
+	} else if err != nil {
+		ctxLogger.Error(err, "Failed to get HMAC secret")
+		return fmt.Errorf("failed to get HMAC secret: %w", err)
+	}
+
+	// Secret exists - validate ownership and structure before accepting it
+	if err := r.validateHMACSecret(ctx, vmcp, secret); err != nil {
+		ctxLogger.Error(err, "Existing HMAC secret is invalid", "Secret.Name", secretName)
+		if r.Recorder != nil {
+			r.Recorder.Eventf(vmcp, corev1.EventTypeWarning, "HMACSecretValidationFailed",
+				"Existing HMAC secret validation failed: %v", err)
+		}
+		return fmt.Errorf("existing HMAC secret validation failed: %w", err)
+	}
+
+	return nil
+}
+
+// validateHMACSecret validates that an existing HMAC secret has the correct ownership,
+// structure, and content. This prevents accepting stale, malformed, or attacker-controlled
+// secrets that could weaken session token signing or cause pod startup failures.
+func (*VirtualMCPServerReconciler) validateHMACSecret(
+	ctx context.Context,
+	vmcp *mcpv1alpha1.VirtualMCPServer,
+	secret *corev1.Secret,
+) error {
+	ctxLogger := log.FromContext(ctx)
+
+	// Verify the secret is owned by this VirtualMCPServer
+	// This prevents accepting secrets created by other actors
+	isOwned := false
+	for _, ownerRef := range secret.OwnerReferences {
+		if ownerRef.UID == vmcp.UID &&
+			ownerRef.Kind == "VirtualMCPServer" &&
+			ownerRef.Name == vmcp.Name {
+			isOwned = true
+			break
+		}
+	}
+	if !isOwned {
+		return fmt.Errorf("secret is not owned by VirtualMCPServer %s/%s", vmcp.Namespace, vmcp.Name)
+	}
+
+	// Verify the hmac-secret key exists
+	hmacSecretData, exists := secret.Data["hmac-secret"]
+	if !exists {
+		return fmt.Errorf("secret missing required 'hmac-secret' key")
+	}
+
+	// Verify it's valid base64 and decodes to exactly 32 bytes
+	hmacSecretBase64 := string(hmacSecretData)
+	if hmacSecretBase64 == "" {
+		return fmt.Errorf("hmac-secret is empty")
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(hmacSecretBase64)
+	if err != nil {
+		return fmt.Errorf("hmac-secret is not valid base64: %w", err)
+	}
+
+	if len(decoded) != 32 {
+		return fmt.Errorf("hmac-secret must be exactly 32 bytes, got %d bytes", len(decoded))
+	}
+
+	// Verify it's not all zeros (would indicate a weak/predictable key)
+	allZeros := true
+	for _, b := range decoded {
+		if b != 0 {
+			allZeros = false
+			break
+		}
+	}
+	if allZeros {
+		return fmt.Errorf("hmac-secret is all zeros (weak key)")
+	}
+
+	ctxLogger.V(1).Info("HMAC secret validation passed", "Secret.Name", secret.Name)
+	return nil
 }
 
 // getVmcpConfigChecksum fetches the vmcp Config ConfigMap checksum annotation.
@@ -2367,4 +2531,19 @@ func setAuthConfigConditions(
 	// Note: We don't modify the overall AuthConfigured condition here because
 	// auth config errors are non-fatal. The system can continue operating with
 	// the auth configs that are valid.
+}
+
+// generateHMACSecret generates a cryptographically secure 32-byte HMAC secret
+// encoded as base64. This secret is used for session token binding in Session Management V2.
+//
+// Returns a base64-encoded string suitable for use as VMCP_SESSION_HMAC_SECRET.
+func generateHMACSecret() (string, error) {
+	// Generate 32 bytes of cryptographically secure random data
+	secret := make([]byte, 32)
+	if _, err := rand.Read(secret); err != nil {
+		return "", fmt.Errorf("failed to generate random bytes: %w", err)
+	}
+
+	// Encode as base64 for safe storage and environment variable use
+	return base64.StdEncoding.EncodeToString(secret), nil
 }

--- a/cmd/thv-operator/controllers/virtualmcpserver_deployment.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_deployment.go
@@ -277,6 +277,11 @@ func (r *VirtualMCPServerReconciler) buildEnvVarsForVmcp(
 	// Mount outgoing auth secrets
 	env = append(env, r.buildOutgoingAuthEnvVars(ctx, vmcp, typedWorkloads)...)
 
+	// Mount HMAC secret for session token binding (Session Management V2)
+	if vmcp.Spec.Config.Operational != nil && vmcp.Spec.Config.Operational.SessionManagementV2 {
+		env = append(env, r.buildHMACSecretEnvVar(vmcp))
+	}
+
 	// Note: Other secrets (Redis passwords, service account credentials) may be added here in the future
 	// following the same pattern of mounting from Kubernetes Secrets as environment variables.
 
@@ -323,6 +328,25 @@ func (*VirtualMCPServerReconciler) buildOIDCEnvVars(vmcp *mcpv1alpha1.VirtualMCP
 	}
 
 	return env
+}
+
+// buildHMACSecretEnvVar builds environment variable for HMAC secret mounting.
+// This secret is used for session token binding in Session Management V2.
+// The operator automatically generates and manages this secret if it doesn't exist.
+func (*VirtualMCPServerReconciler) buildHMACSecretEnvVar(vmcp *mcpv1alpha1.VirtualMCPServer) corev1.EnvVar {
+	secretName := fmt.Sprintf("%s-hmac-secret", vmcp.Name)
+
+	return corev1.EnvVar{
+		Name: "VMCP_SESSION_HMAC_SECRET",
+		ValueFrom: &corev1.EnvVarSource{
+			SecretKeyRef: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: secretName,
+				},
+				Key: "hmac-secret",
+			},
+		},
+	}
 }
 
 // buildOutgoingAuthEnvVars builds environment variables for outgoing auth secrets.

--- a/cmd/thv-operator/controllers/virtualmcpserver_hmac_secret_test.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_hmac_secret_test.go
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package controllers
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGenerateHMACSecret tests the HMAC secret generation function.
+func TestGenerateHMACSecret(t *testing.T) {
+	t.Parallel()
+
+	t.Run("generates valid base64 encoded secret", func(t *testing.T) {
+		t.Parallel()
+
+		secret, err := generateHMACSecret()
+		require.NoError(t, err)
+		require.NotEmpty(t, secret)
+
+		// Verify it's valid base64
+		decoded, err := base64.StdEncoding.DecodeString(secret)
+		require.NoError(t, err)
+		assert.Len(t, decoded, 32, "decoded secret should be exactly 32 bytes")
+	})
+
+	t.Run("generates unique secrets", func(t *testing.T) {
+		t.Parallel()
+
+		secret1, err := generateHMACSecret()
+		require.NoError(t, err)
+
+		secret2, err := generateHMACSecret()
+		require.NoError(t, err)
+
+		// Two generated secrets should be different
+		assert.NotEqual(t, secret1, secret2, "consecutive secrets should be unique")
+	})
+
+	t.Run("generates cryptographically secure random data", func(t *testing.T) {
+		t.Parallel()
+
+		secret, err := generateHMACSecret()
+		require.NoError(t, err)
+
+		decoded, err := base64.StdEncoding.DecodeString(secret)
+		require.NoError(t, err)
+
+		// Check that it's not all zeros (would indicate failure of crypto/rand)
+		allZeros := make([]byte, 32)
+		assert.NotEqual(t, allZeros, decoded, "secret should not be all zeros")
+	})
+
+	t.Run("generates multiple valid secrets", func(t *testing.T) {
+		t.Parallel()
+
+		// Generate 100 secrets to ensure consistency
+		secrets := make(map[string]bool)
+		for i := 0; i < 100; i++ {
+			secret, err := generateHMACSecret()
+			require.NoError(t, err)
+
+			// Verify base64 decoding
+			decoded, err := base64.StdEncoding.DecodeString(secret)
+			require.NoError(t, err)
+			assert.Len(t, decoded, 32)
+
+			// Track uniqueness
+			secrets[secret] = true
+		}
+
+		// All secrets should be unique
+		assert.Len(t, secrets, 100, "all generated secrets should be unique")
+	})
+}

--- a/cmd/vmcp/README.md
+++ b/cmd/vmcp/README.md
@@ -237,7 +237,35 @@ spec:
               key: hmac-secret
 ```
 
-**Note**: Kubernetes deployments **require** `VMCP_SESSION_HMAC_SECRET` to be set (the server will fail to start without it). For non-Kubernetes environments (local development/testing), a default insecure secret is used as a fallback, but this is **NOT recommended for production**.
+**Note**: When **Session Management V2 is enabled**, Kubernetes deployments **require** `VMCP_SESSION_HMAC_SECRET` to be set (the server will fail to start without it). For non-Kubernetes environments (local development/testing), a default insecure secret is used as a fallback, but this is **NOT recommended for production**. If Session Management V2 is disabled, this environment variable is not required.
+
+### Automatic Secret Management (ToolHive Operator)
+
+When deploying vMCP via the **ToolHive operator** with Session Management V2 enabled, the HMAC secret is **automatically generated and managed** for you:
+
+```yaml
+apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: VirtualMCPServer
+metadata:
+  name: my-vmcp
+spec:
+  config:
+    operational:
+      sessionManagementV2: true  # Enables automatic HMAC secret creation
+    group: my-group
+```
+
+The operator will:
+
+- ✅ Automatically generate a cryptographically secure 32-byte HMAC secret
+- ✅ Store it in a Kubernetes Secret named `{vmcp-name}-hmac-secret`
+- ✅ Inject it into the vMCP deployment as `VMCP_SESSION_HMAC_SECRET`
+- ✅ Validate existing secrets (ownership, structure, and content)
+- ✅ Automatically delete the secret when the VirtualMCPServer is removed
+
+**No manual secret generation or management required!** The operator handles all of this automatically when you enable Session Management V2.
+
+> **Note**: The secret is generated once at creation time and persists for the lifetime of the VirtualMCPServer. Secret rotation is not currently supported but may be added in a future release.
 
 ## Tool Aggregation & Conflict Resolution
 

--- a/pkg/vmcp/session/sessionv2_integration_test.go
+++ b/pkg/vmcp/session/sessionv2_integration_test.go
@@ -1,0 +1,498 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package session
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stacklok/toolhive/pkg/auth"
+	"github.com/stacklok/toolhive/pkg/vmcp"
+	sessiontypes "github.com/stacklok/toolhive/pkg/vmcp/session/types"
+)
+
+// TestSessionManagementV2_Integration tests end-to-end Session Management V2
+// functionality including HMAC token binding and session hijacking prevention.
+func TestSessionManagementV2_Integration(t *testing.T) {
+	t.Parallel()
+
+	// Generate a proper 32-byte HMAC secret for these tests
+	hmacSecret := generateTestHMACSecret(t)
+
+	// Start a real in-process MCP server
+	baseURL := startInProcessMCPServer(t)
+
+	// Create backend
+	backend := &vmcp.Backend{
+		ID:            "test-backend",
+		Name:          "test-backend",
+		BaseURL:       baseURL,
+		TransportType: "streamable-http",
+	}
+
+	t.Run("bound session with valid token can call tools", func(t *testing.T) {
+		t.Parallel()
+
+		// Create session factory with HMAC secret
+		factory := NewSessionFactory(newUnauthenticatedRegistry(t), WithHMACSecret(hmacSecret))
+
+		// Create an authenticated identity
+		identity := &auth.Identity{
+			Subject: "test-user",
+			Token:   "valid-bearer-token-123",
+		}
+
+		// Create a bound session (allowAnonymous=false)
+		sess, err := factory.MakeSessionWithID(
+			context.Background(),
+			"test-session-1",
+			identity,
+			false, // bound session
+			[]*vmcp.Backend{backend},
+		)
+		require.NoError(t, err)
+		require.NotNil(t, sess)
+		t.Cleanup(func() { require.NoError(t, sess.Close()) })
+
+		// Verify session metadata
+		tokenHash := sess.GetMetadata()[MetadataKeyTokenHash]
+		require.NotEmpty(t, tokenHash, "token hash should be stored in session metadata")
+
+		// Call a tool with the SAME identity (should succeed)
+		result, err := sess.CallTool(context.Background(), identity, "echo", map[string]any{
+			"input": "hello world",
+		}, nil)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+
+		// Verify the result contains echoed text
+		assert.NotEmpty(t, result.Content)
+	})
+
+	t.Run("bound session rejects different token (session hijacking prevention)", func(t *testing.T) {
+		t.Parallel()
+
+		factory := NewSessionFactory(newUnauthenticatedRegistry(t), WithHMACSecret(hmacSecret))
+
+		// Create session with original identity
+		originalIdentity := &auth.Identity{
+			Subject: "alice",
+			Token:   "alice-token",
+		}
+
+		sess, err := factory.MakeSessionWithID(
+			context.Background(),
+			"test-session-2",
+			originalIdentity,
+			false, // bound session
+			[]*vmcp.Backend{backend},
+		)
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, sess.Close()) })
+
+		// Attempt to call tool with DIFFERENT identity (hijacking attempt)
+		attackerIdentity := &auth.Identity{
+			Subject: "bob",
+			Token:   "bob-token", // Different token!
+		}
+
+		_, err = sess.CallTool(context.Background(), attackerIdentity, "echo", map[string]any{
+			"input": "hijacked",
+		}, nil)
+
+		// Should be rejected
+		require.Error(t, err)
+		assert.ErrorIs(t, err, sessiontypes.ErrUnauthorizedCaller)
+	})
+
+	t.Run("bound session rejects nil caller", func(t *testing.T) {
+		t.Parallel()
+
+		factory := NewSessionFactory(newUnauthenticatedRegistry(t), WithHMACSecret(hmacSecret))
+
+		identity := &auth.Identity{
+			Subject: "user",
+			Token:   "user-token",
+		}
+
+		sess, err := factory.MakeSessionWithID(
+			context.Background(),
+			"test-session-3",
+			identity,
+			false, // bound session
+			[]*vmcp.Backend{backend},
+		)
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, sess.Close()) })
+
+		// Attempt to call tool with nil caller
+		_, err = sess.CallTool(context.Background(), nil, "echo", map[string]any{
+			"input": "test",
+		}, nil)
+
+		// Should be rejected
+		require.Error(t, err)
+		assert.ErrorIs(t, err, sessiontypes.ErrNilCaller)
+	})
+
+	t.Run("anonymous session allows nil caller", func(t *testing.T) {
+		t.Parallel()
+
+		factory := NewSessionFactory(newUnauthenticatedRegistry(t), WithHMACSecret(hmacSecret))
+
+		// Create anonymous session (allowAnonymous=true, no identity)
+		sess, err := factory.MakeSessionWithID(
+			context.Background(),
+			"test-session-4",
+			nil,  // no identity
+			true, // anonymous session
+			[]*vmcp.Backend{backend},
+		)
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, sess.Close()) })
+
+		// Verify anonymous session metadata
+		tokenHash := sess.GetMetadata()[MetadataKeyTokenHash]
+		assert.Empty(t, tokenHash, "anonymous session should have empty token hash sentinel")
+
+		// Call tool with nil caller (should succeed for anonymous session)
+		result, err := sess.CallTool(context.Background(), nil, "echo", map[string]any{
+			"input": "anonymous call",
+		}, nil)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+	})
+
+	t.Run("anonymous session rejects caller with token (upgrade attack prevention)", func(t *testing.T) {
+		t.Parallel()
+
+		factory := NewSessionFactory(newUnauthenticatedRegistry(t), WithHMACSecret(hmacSecret))
+
+		// Create anonymous session
+		sess, err := factory.MakeSessionWithID(
+			context.Background(),
+			"test-session-5",
+			nil,  // no identity
+			true, // anonymous
+			[]*vmcp.Backend{backend},
+		)
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, sess.Close()) })
+
+		// Attempt to call tool with an identity (upgrade attack)
+		attackerIdentity := &auth.Identity{
+			Subject: "attacker",
+			Token:   "attacker-token",
+		}
+
+		_, err = sess.CallTool(context.Background(), attackerIdentity, "echo", map[string]any{
+			"input": "upgraded",
+		}, nil)
+
+		// Should be rejected to prevent session upgrade attacks
+		require.Error(t, err)
+		assert.ErrorIs(t, err, sessiontypes.ErrUnauthorizedCaller)
+	})
+
+	t.Run("bound session can read resources", func(t *testing.T) {
+		t.Parallel()
+
+		factory := NewSessionFactory(newUnauthenticatedRegistry(t), WithHMACSecret(hmacSecret))
+
+		identity := &auth.Identity{
+			Subject: "user",
+			Token:   "user-token",
+		}
+
+		sess, err := factory.MakeSessionWithID(
+			context.Background(),
+			"test-session-6",
+			identity,
+			false, // bound
+			[]*vmcp.Backend{backend},
+		)
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, sess.Close()) })
+
+		// Read resource with correct identity
+		result, err := sess.ReadResource(context.Background(), identity, "test://data")
+		require.NoError(t, err)
+		require.NotNil(t, result)
+
+		// Verify resource content (Contents is []byte)
+		assert.NotEmpty(t, result.Contents)
+		assert.Contains(t, string(result.Contents), "hello")
+	})
+
+	t.Run("bound session rejects resource read with wrong token", func(t *testing.T) {
+		t.Parallel()
+
+		factory := NewSessionFactory(newUnauthenticatedRegistry(t), WithHMACSecret(hmacSecret))
+
+		originalIdentity := &auth.Identity{
+			Subject: "alice",
+			Token:   "alice-token",
+		}
+
+		sess, err := factory.MakeSessionWithID(
+			context.Background(),
+			"test-session-7",
+			originalIdentity,
+			false,
+			[]*vmcp.Backend{backend},
+		)
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, sess.Close()) })
+
+		// Attempt to read resource with different token
+		attackerIdentity := &auth.Identity{
+			Subject: "bob",
+			Token:   "bob-token",
+		}
+
+		_, err = sess.ReadResource(context.Background(), attackerIdentity, "test://data")
+		require.Error(t, err)
+		assert.ErrorIs(t, err, sessiontypes.ErrUnauthorizedCaller)
+	})
+
+	t.Run("bound session can get prompts", func(t *testing.T) {
+		t.Parallel()
+
+		factory := NewSessionFactory(newUnauthenticatedRegistry(t), WithHMACSecret(hmacSecret))
+
+		identity := &auth.Identity{
+			Subject: "user",
+			Token:   "user-token",
+		}
+
+		sess, err := factory.MakeSessionWithID(
+			context.Background(),
+			"test-session-8",
+			identity,
+			false,
+			[]*vmcp.Backend{backend},
+		)
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, sess.Close()) })
+
+		// Get prompt with correct identity
+		result, err := sess.GetPrompt(context.Background(), identity, "greet", nil)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.NotEmpty(t, result.Messages)
+	})
+
+	t.Run("bound session rejects prompt with wrong token", func(t *testing.T) {
+		t.Parallel()
+
+		factory := NewSessionFactory(newUnauthenticatedRegistry(t), WithHMACSecret(hmacSecret))
+
+		originalIdentity := &auth.Identity{
+			Subject: "alice",
+			Token:   "alice-token",
+		}
+
+		sess, err := factory.MakeSessionWithID(
+			context.Background(),
+			"test-session-9",
+			originalIdentity,
+			false,
+			[]*vmcp.Backend{backend},
+		)
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, sess.Close()) })
+
+		// Attempt to get prompt with different token
+		attackerIdentity := &auth.Identity{
+			Subject: "bob",
+			Token:   "bob-token",
+		}
+
+		_, err = sess.GetPrompt(context.Background(), attackerIdentity, "greet", nil)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, sessiontypes.ErrUnauthorizedCaller)
+	})
+
+	t.Run("different HMAC secrets produce different token hashes", func(t *testing.T) {
+		t.Parallel()
+
+		// Create two factories with different HMAC secrets
+		secret1 := generateTestHMACSecret(t)
+		secret2 := generateTestHMACSecret(t)
+
+		factory1 := NewSessionFactory(newUnauthenticatedRegistry(t), WithHMACSecret(secret1))
+		factory2 := NewSessionFactory(newUnauthenticatedRegistry(t), WithHMACSecret(secret2))
+
+		identity := &auth.Identity{
+			Subject: "user",
+			Token:   "same-token",
+		}
+
+		// Create sessions with same identity but different secrets
+		sess1, err := factory1.MakeSessionWithID(context.Background(), "session-1", identity, false, nil)
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, sess1.Close()) })
+
+		sess2, err := factory2.MakeSessionWithID(context.Background(), "session-2", identity, false, nil)
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, sess2.Close()) })
+
+		// Token hashes should be different due to different HMAC secrets
+		hash1 := sess1.GetMetadata()[MetadataKeyTokenHash]
+		hash2 := sess2.GetMetadata()[MetadataKeyTokenHash]
+
+		assert.NotEqual(t, hash1, hash2, "different HMAC secrets should produce different token hashes")
+	})
+
+	t.Run("session validates token consistently across multiple calls", func(t *testing.T) {
+		t.Parallel()
+
+		factory := NewSessionFactory(newUnauthenticatedRegistry(t), WithHMACSecret(hmacSecret))
+
+		identity := &auth.Identity{
+			Subject: "user",
+			Token:   "consistent-token",
+		}
+
+		sess, err := factory.MakeSessionWithID(
+			context.Background(),
+			"test-session-10",
+			identity,
+			false,
+			[]*vmcp.Backend{backend},
+		)
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, sess.Close()) })
+
+		// Make multiple calls with the same identity - all should succeed
+		for i := 0; i < 5; i++ {
+			result, err := sess.CallTool(context.Background(), identity, "echo", map[string]any{
+				"input": "test",
+			}, nil)
+			require.NoError(t, err)
+			require.NotNil(t, result)
+		}
+	})
+}
+
+// generateTestHMACSecret generates a cryptographically secure 32-byte secret
+// for testing, similar to what the operator generates in production.
+func generateTestHMACSecret(t *testing.T) []byte {
+	t.Helper()
+
+	secret := make([]byte, 32)
+	_, err := rand.Read(secret)
+	require.NoError(t, err, "failed to generate test HMAC secret")
+
+	// Verify it's not all zeros
+	allZeros := true
+	for _, b := range secret {
+		if b != 0 {
+			allZeros = false
+			break
+		}
+	}
+	require.False(t, allZeros, "generated secret should not be all zeros")
+
+	return secret
+}
+
+// TestSessionManagementV2_SecretRotation tests that sessions created with
+// different secrets cannot be used interchangeably (validates secret isolation).
+func TestSessionManagementV2_SecretRotation(t *testing.T) {
+	t.Parallel()
+
+	baseURL := startInProcessMCPServer(t)
+	backend := &vmcp.Backend{
+		ID:            "test-backend",
+		Name:          "test-backend",
+		BaseURL:       baseURL,
+		TransportType: "streamable-http",
+	}
+
+	t.Run("session created with old secret cannot be validated with new secret", func(t *testing.T) {
+		t.Parallel()
+
+		oldSecret := generateTestHMACSecret(t)
+		newSecret := generateTestHMACSecret(t)
+
+		// Create factory with old secret
+		oldFactory := NewSessionFactory(newUnauthenticatedRegistry(t), WithHMACSecret(oldSecret))
+
+		identity := &auth.Identity{
+			Subject: "user",
+			Token:   "rotation-token",
+		}
+
+		// Create session with old secret
+		oldSess, err := oldFactory.MakeSessionWithID(context.Background(), "old-session", identity, false, []*vmcp.Backend{backend})
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, oldSess.Close()) })
+
+		// Session should work with old secret
+		_, err = oldSess.CallTool(context.Background(), identity, "echo", map[string]any{"input": "test"}, nil)
+		require.NoError(t, err)
+
+		// Create a new factory with new secret (simulating secret rotation)
+		newFactory := NewSessionFactory(newUnauthenticatedRegistry(t), WithHMACSecret(newSecret))
+
+		// Create a new session with new secret
+		newSess, err := newFactory.MakeSessionWithID(context.Background(), "new-session", identity, false, []*vmcp.Backend{backend})
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, newSess.Close()) })
+
+		// New session should have different token hash
+		oldHash := oldSess.GetMetadata()[MetadataKeyTokenHash]
+		newHash := newSess.GetMetadata()[MetadataKeyTokenHash]
+		assert.NotEqual(t, oldHash, newHash, "rotated secret should produce different token hash")
+
+		// Both sessions should work independently with same identity
+		_, err = newSess.CallTool(context.Background(), identity, "echo", map[string]any{"input": "test"}, nil)
+		require.NoError(t, err)
+	})
+}
+
+// TestSessionManagementV2_MetadataEncoding verifies that token hashes and salts
+// are properly hex-encoded in session metadata for transmission and storage.
+func TestSessionManagementV2_MetadataEncoding(t *testing.T) {
+	t.Parallel()
+
+	hmacSecret := generateTestHMACSecret(t)
+	factory := NewSessionFactory(newUnauthenticatedRegistry(t), WithHMACSecret(hmacSecret))
+
+	identity := &auth.Identity{
+		Subject: "user",
+		Token:   "test-token-123",
+	}
+
+	sess, err := factory.MakeSessionWithID(context.Background(), "test-session", identity, false, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, sess.Close()) })
+
+	// Get token hash from session metadata
+	tokenHash := sess.GetMetadata()[MetadataKeyTokenHash]
+	require.NotEmpty(t, tokenHash)
+
+	// Verify it's valid hex encoding (HMAC-SHA256 is 64 hex chars)
+	assert.Len(t, tokenHash, 64, "HMAC-SHA256 hex-encoded hash should be 64 characters")
+
+	// Verify token hash decodes as valid hex
+	hashBytes, err := hex.DecodeString(tokenHash)
+	require.NoError(t, err, "token hash should be valid hex")
+	assert.Len(t, hashBytes, 32, "decoded token hash should be 32 bytes (SHA256)")
+
+	// Get token salt from session metadata
+	tokenSalt := sess.GetMetadata()[MetadataKeyTokenSalt]
+	require.NotEmpty(t, tokenSalt)
+
+	// Verify salt is valid hex encoding
+	saltBytes, err := hex.DecodeString(tokenSalt)
+	require.NoError(t, err, "token salt should be valid hex")
+	assert.Len(t, saltBytes, 16, "decoded token salt should be 16 bytes")
+}

--- a/test/e2e/thv-operator/virtualmcp/virtualmcp_hmac_secret_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcp_hmac_secret_test.go
@@ -1,0 +1,318 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package virtualmcp contains e2e tests for VirtualMCPServer against a real Kubernetes cluster
+package virtualmcp
+
+import (
+	"encoding/base64"
+	"fmt"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	mcpv1alpha1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1alpha1"
+	vmcpconfig "github.com/stacklok/toolhive/pkg/vmcp/config"
+)
+
+var _ = ginkgo.Describe("VirtualMCPServer HMAC Secret E2E Tests", func() {
+	const (
+		timeout          = time.Minute * 2
+		pollInterval     = time.Second * 2
+		defaultNamespace = "default"
+	)
+
+	ginkgo.Context("When creating VirtualMCPServer with SessionManagementV2 enabled", ginkgo.Ordered, func() {
+		var (
+			mcpGroupName       string
+			virtualMCPName     string
+			expectedSecretName string
+		)
+
+		ginkgo.BeforeAll(func() {
+			// Use nanosecond timestamp to ensure unique names and avoid collisions with parallel runs
+			timestamp := time.Now().UnixNano()
+			mcpGroupName = fmt.Sprintf("e2e-test-group-hmac-%d", timestamp)
+			virtualMCPName = fmt.Sprintf("e2e-test-vmcp-hmac-%d", timestamp)
+			expectedSecretName = virtualMCPName + "-hmac-secret"
+
+			ginkgo.By("Creating MCPGroup")
+			mcpGroup := &mcpv1alpha1.MCPGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      mcpGroupName,
+					Namespace: defaultNamespace,
+				},
+				Spec: mcpv1alpha1.MCPGroupSpec{
+					Description: "E2E test group for HMAC secret validation",
+				},
+			}
+			gomega.Expect(k8sClient.Create(ctx, mcpGroup)).Should(gomega.Succeed())
+
+			ginkgo.By("Creating VirtualMCPServer with SessionManagementV2 enabled")
+			virtualMCPServer := &mcpv1alpha1.VirtualMCPServer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      virtualMCPName,
+					Namespace: defaultNamespace,
+				},
+				Spec: mcpv1alpha1.VirtualMCPServerSpec{
+					Config: vmcpconfig.Config{
+						Group: mcpGroupName,
+						Operational: &vmcpconfig.OperationalConfig{
+							SessionManagementV2: true, // Enable Session Management V2
+						},
+					},
+					IncomingAuth: &mcpv1alpha1.IncomingAuthConfig{
+						Type: "anonymous",
+					},
+				},
+			}
+			gomega.Expect(k8sClient.Create(ctx, virtualMCPServer)).Should(gomega.Succeed())
+		})
+
+		ginkgo.AfterAll(func() {
+			ginkgo.By("Cleaning up VirtualMCPServer")
+			virtualMCPServer := &mcpv1alpha1.VirtualMCPServer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      virtualMCPName,
+					Namespace: defaultNamespace,
+				},
+			}
+			_ = k8sClient.Delete(ctx, virtualMCPServer)
+
+			ginkgo.By("Cleaning up MCPGroup")
+			mcpGroup := &mcpv1alpha1.MCPGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      mcpGroupName,
+					Namespace: defaultNamespace,
+				},
+			}
+			_ = k8sClient.Delete(ctx, mcpGroup)
+
+			ginkgo.By("Waiting for resources to be deleted")
+			gomega.Eventually(func() bool {
+				err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      virtualMCPName,
+					Namespace: defaultNamespace,
+				}, &mcpv1alpha1.VirtualMCPServer{})
+				return apierrors.IsNotFound(err)
+			}, timeout, pollInterval).Should(gomega.BeTrue())
+		})
+
+		ginkgo.It("Should automatically create HMAC secret", func() {
+			ginkgo.By("Waiting for HMAC secret to be created by operator")
+			secret := &corev1.Secret{}
+			gomega.Eventually(func() error {
+				return k8sClient.Get(ctx, types.NamespacedName{
+					Name:      expectedSecretName,
+					Namespace: defaultNamespace,
+				}, secret)
+			}, timeout, pollInterval).Should(gomega.Succeed())
+
+			ginkgo.By("Verifying secret was created")
+			gomega.Expect(secret.Name).To(gomega.Equal(expectedSecretName))
+		})
+
+		ginkgo.It("Should have correct secret structure and metadata", func() {
+			secret := &corev1.Secret{}
+			gomega.Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      expectedSecretName,
+				Namespace: defaultNamespace,
+			}, secret)).Should(gomega.Succeed())
+
+			ginkgo.By("Verifying secret type")
+			gomega.Expect(secret.Type).To(gomega.Equal(corev1.SecretTypeOpaque))
+
+			ginkgo.By("Verifying labels")
+			gomega.Expect(secret.Labels).To(gomega.HaveKeyWithValue("app.kubernetes.io/name", "virtualmcpserver"))
+			gomega.Expect(secret.Labels).To(gomega.HaveKeyWithValue("app.kubernetes.io/instance", virtualMCPName))
+			gomega.Expect(secret.Labels).To(gomega.HaveKeyWithValue("app.kubernetes.io/component", "session-security"))
+			gomega.Expect(secret.Labels).To(gomega.HaveKeyWithValue("app.kubernetes.io/managed-by", "toolhive-operator"))
+
+			ginkgo.By("Verifying annotations")
+			gomega.Expect(secret.Annotations).To(gomega.HaveKeyWithValue("toolhive.stacklok.dev/purpose", "hmac-secret-for-session-token-binding"))
+
+			ginkgo.By("Verifying owner reference for cascade deletion")
+			gomega.Expect(secret.OwnerReferences).To(gomega.HaveLen(1))
+			gomega.Expect(secret.OwnerReferences[0].Name).To(gomega.Equal(virtualMCPName))
+			gomega.Expect(secret.OwnerReferences[0].Kind).To(gomega.Equal("VirtualMCPServer"))
+		})
+
+		ginkgo.It("Should contain a valid 32-byte base64-encoded HMAC secret", func() {
+			secret := &corev1.Secret{}
+			gomega.Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      expectedSecretName,
+				Namespace: defaultNamespace,
+			}, secret)).Should(gomega.Succeed())
+
+			ginkgo.By("Verifying secret has hmac-secret key")
+			gomega.Expect(secret.Data).To(gomega.HaveKey("hmac-secret"))
+
+			hmacSecretBase64 := string(secret.Data["hmac-secret"])
+			gomega.Expect(hmacSecretBase64).NotTo(gomega.BeEmpty())
+
+			ginkgo.By("Verifying secret is valid base64")
+			decoded, err := base64.StdEncoding.DecodeString(hmacSecretBase64)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By("Verifying decoded secret is exactly 32 bytes")
+			gomega.Expect(decoded).To(gomega.HaveLen(32))
+
+			ginkgo.By("Verifying secret is not all zeros (proper random generation)")
+			allZeros := make([]byte, 32)
+			gomega.Expect(decoded).NotTo(gomega.Equal(allZeros))
+		})
+
+		ginkgo.It("Should inject HMAC secret into deployment as environment variable", func() {
+			deployment := &appsv1.Deployment{}
+
+			ginkgo.By("Waiting for deployment to be created")
+			gomega.Eventually(func() error {
+				return k8sClient.Get(ctx, types.NamespacedName{
+					Name:      virtualMCPName,
+					Namespace: defaultNamespace,
+				}, deployment)
+			}, timeout, pollInterval).Should(gomega.Succeed())
+
+			ginkgo.By("Finding vmcp container in deployment")
+			gomega.Expect(deployment.Spec.Template.Spec.Containers).NotTo(gomega.BeEmpty())
+
+			var vmcpContainer *corev1.Container
+			for i, container := range deployment.Spec.Template.Spec.Containers {
+				if container.Name == "vmcp" {
+					vmcpContainer = &deployment.Spec.Template.Spec.Containers[i]
+					break
+				}
+			}
+			gomega.Expect(vmcpContainer).NotTo(gomega.BeNil())
+
+			ginkgo.By("Verifying VMCP_SESSION_HMAC_SECRET environment variable exists")
+			var hmacSecretEnvVar *corev1.EnvVar
+			for i, env := range vmcpContainer.Env {
+				if env.Name == "VMCP_SESSION_HMAC_SECRET" {
+					hmacSecretEnvVar = &vmcpContainer.Env[i]
+					break
+				}
+			}
+			gomega.Expect(hmacSecretEnvVar).NotTo(gomega.BeNil())
+
+			ginkgo.By("Verifying env var is sourced from the secret")
+			gomega.Expect(hmacSecretEnvVar.ValueFrom).NotTo(gomega.BeNil())
+			gomega.Expect(hmacSecretEnvVar.ValueFrom.SecretKeyRef).NotTo(gomega.BeNil())
+			gomega.Expect(hmacSecretEnvVar.ValueFrom.SecretKeyRef.Name).To(gomega.Equal(expectedSecretName))
+			gomega.Expect(hmacSecretEnvVar.ValueFrom.SecretKeyRef.Key).To(gomega.Equal("hmac-secret"))
+		})
+	})
+
+	ginkgo.Context("When creating VirtualMCPServer WITHOUT SessionManagementV2", ginkgo.Ordered, func() {
+		var (
+			mcpGroupName       string
+			virtualMCPName     string
+			expectedSecretName string
+		)
+
+		ginkgo.BeforeAll(func() {
+			// Use nanosecond timestamp to ensure unique names and avoid collisions with parallel runs
+			timestamp := time.Now().UnixNano()
+			mcpGroupName = fmt.Sprintf("e2e-test-group-no-hmac-%d", timestamp)
+			virtualMCPName = fmt.Sprintf("e2e-test-vmcp-no-hmac-%d", timestamp)
+			expectedSecretName = virtualMCPName + "-hmac-secret"
+
+			ginkgo.By("Creating MCPGroup")
+			mcpGroup := &mcpv1alpha1.MCPGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      mcpGroupName,
+					Namespace: defaultNamespace,
+				},
+				Spec: mcpv1alpha1.MCPGroupSpec{
+					Description: "E2E test group for no HMAC secret validation",
+				},
+			}
+			gomega.Expect(k8sClient.Create(ctx, mcpGroup)).Should(gomega.Succeed())
+
+			ginkgo.By("Creating VirtualMCPServer WITHOUT SessionManagementV2")
+			virtualMCPServer := &mcpv1alpha1.VirtualMCPServer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      virtualMCPName,
+					Namespace: defaultNamespace,
+				},
+				Spec: mcpv1alpha1.VirtualMCPServerSpec{
+					Config: vmcpconfig.Config{
+						Group: mcpGroupName,
+						// No Operational config - SessionManagementV2 defaults to false
+					},
+					IncomingAuth: &mcpv1alpha1.IncomingAuthConfig{
+						Type: "anonymous",
+					},
+				},
+			}
+			gomega.Expect(k8sClient.Create(ctx, virtualMCPServer)).Should(gomega.Succeed())
+		})
+
+		ginkgo.AfterAll(func() {
+			ginkgo.By("Cleaning up VirtualMCPServer")
+			virtualMCPServer := &mcpv1alpha1.VirtualMCPServer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      virtualMCPName,
+					Namespace: defaultNamespace,
+				},
+			}
+			_ = k8sClient.Delete(ctx, virtualMCPServer)
+
+			ginkgo.By("Cleaning up MCPGroup")
+			mcpGroup := &mcpv1alpha1.MCPGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      mcpGroupName,
+					Namespace: defaultNamespace,
+				},
+			}
+			_ = k8sClient.Delete(ctx, mcpGroup)
+		})
+
+		ginkgo.It("Should NOT create HMAC secret when SessionManagementV2 is disabled", func() {
+			ginkgo.By("Verifying secret consistently does not exist over time")
+			// Use Consistently to verify the secret is NOT created over a sustained period
+			// This is more robust than a fixed sleep + single check
+			gomega.Consistently(func() bool {
+				secret := &corev1.Secret{}
+				err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      expectedSecretName,
+					Namespace: defaultNamespace,
+				}, secret)
+				return apierrors.IsNotFound(err)
+			}, time.Second*15, pollInterval).Should(gomega.BeTrue(), "HMAC secret should NOT be created when SessionManagementV2 is disabled")
+		})
+
+		ginkgo.It("Should NOT inject HMAC secret env var when SessionManagementV2 is disabled", func() {
+			deployment := &appsv1.Deployment{}
+
+			ginkgo.By("Waiting for deployment to be created")
+			gomega.Eventually(func() error {
+				return k8sClient.Get(ctx, types.NamespacedName{
+					Name:      virtualMCPName,
+					Namespace: defaultNamespace,
+				}, deployment)
+			}, timeout, pollInterval).Should(gomega.Succeed())
+
+			ginkgo.By("Finding vmcp container")
+			var vmcpContainer *corev1.Container
+			for i, container := range deployment.Spec.Template.Spec.Containers {
+				if container.Name == "vmcp" {
+					vmcpContainer = &deployment.Spec.Template.Spec.Containers[i]
+					break
+				}
+			}
+			gomega.Expect(vmcpContainer).NotTo(gomega.BeNil())
+
+			ginkgo.By("Verifying VMCP_SESSION_HMAC_SECRET env var does NOT exist")
+			for _, env := range vmcpContainer.Env {
+				gomega.Expect(env.Name).NotTo(gomega.Equal("VMCP_SESSION_HMAC_SECRET"))
+			}
+		})
+	})
+})


### PR DESCRIPTION
Automatically generate and manage HMAC secrets when SessionManagementV2 is enabled in VirtualMCPServer resources, eliminating manual secret creation.

## Large PR Justification

This is an atomic PR that implements a single functionality and it's adding comprehensive tests. Cannot be split.

Related-to: #3867