### PR TITLE
Replace ToolMatch with mcp.Tool in optimizer pipeline

### DIFF
--- a/pkg/vmcp/optimizer/internal/toolstore/sqlite_store.go
+++ b/pkg/vmcp/optimizer/internal/toolstore/sqlite_store.go
@@ -19,6 +19,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 	"golang.org/x/sync/errgroup"
 	_ "modernc.org/sqlite" // registers the "sqlite" database/sql driver
@@ -180,7 +181,7 @@ func (s sqliteToolStore) generateEmbeddings(ctx context.Context, tools []server.
 // The allowedTools parameter limits results to only tools with names in the given set.
 // If allowedTools is empty, no results are returned (empty = no access).
 // Returns matches ranked by relevance.
-func (s sqliteToolStore) Search(ctx context.Context, query string, allowedTools []string) ([]types.ToolMatch, error) {
+func (s sqliteToolStore) Search(ctx context.Context, query string, allowedTools []string) ([]mcp.Tool, error) {
 	if len(allowedTools) == 0 {
 		slog.Debug("search skipped, no allowed tools")
 		return nil, nil
@@ -207,7 +208,7 @@ func (s sqliteToolStore) Search(ctx context.Context, query string, allowedTools 
 
 	g, gCtx := errgroup.WithContext(ctx)
 
-	var ftsResults []types.ToolMatch
+	var ftsResults []mcp.Tool
 	if ftsExpr != "" && ftsLimit > 0 {
 		g.Go(func() error {
 			var err error
@@ -216,7 +217,7 @@ func (s sqliteToolStore) Search(ctx context.Context, query string, allowedTools 
 		})
 	}
 
-	var semanticResults []types.ToolMatch
+	var semanticResults []mcp.Tool
 	if semanticLimit > 0 {
 		g.Go(func() error {
 			var err error
@@ -266,7 +267,7 @@ func (s sqliteToolStore) Close() error {
 // parameterized ? value, never interpolated into SQL.
 func (s sqliteToolStore) searchFTS5(
 	ctx context.Context, ftsExpr string, allowedTools []string, limit int,
-) ([]types.ToolMatch, error) {
+) ([]mcp.Tool, error) {
 	allowedJSON, err := json.Marshal(allowedTools)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal allowed tools: %w", err)
@@ -286,14 +287,14 @@ func (s sqliteToolStore) searchFTS5(
 	}
 	defer func() { _ = rows.Close() }()
 
-	var matches []types.ToolMatch
+	var matches []mcp.Tool
 	for rows.Next() {
 		var name, description string
 		var rank float64
 		if err := rows.Scan(&name, &description, &rank); err != nil {
 			return nil, fmt.Errorf("failed to scan row: %w", err)
 		}
-		matches = append(matches, types.ToolMatch{
+		matches = append(matches, mcp.Tool{
 			Name:        name,
 			Description: description,
 		})
@@ -328,7 +329,7 @@ func (s sqliteToolStore) searchFTS5(
 //nolint:unparam // limit kept for API consistency with searchFTS5
 func (s sqliteToolStore) searchSemantic(
 	ctx context.Context, query string, allowedTools []string, limit int,
-) ([]types.ToolMatch, error) {
+) ([]mcp.Tool, error) {
 	queryVec, err := s.embeddingClient.Embed(ctx, query)
 	if err != nil {
 		return nil, fmt.Errorf("failed to embed query: %w", err)
@@ -396,9 +397,9 @@ func (s sqliteToolStore) searchSemantic(
 		ranked = ranked[:limit]
 	}
 
-	matches := make([]types.ToolMatch, len(ranked))
+	matches := make([]mcp.Tool, len(ranked))
 	for i, r := range ranked {
-		matches[i] = types.ToolMatch{
+		matches[i] = mcp.Tool{
 			Name:        r.name,
 			Description: r.description,
 		}
@@ -418,9 +419,9 @@ func (s sqliteToolStore) searchSemantic(
 // mergeResults combines semantic and FTS5 results, deduplicating by name.
 // Semantic results are listed first (preserving their distance-based order),
 // followed by FTS5 results not already present, and truncated to maxResults.
-func mergeResults(fts, semantic []types.ToolMatch, maxResults int) []types.ToolMatch {
+func mergeResults(fts, semantic []mcp.Tool, maxResults int) []mcp.Tool {
 	seen := make(map[string]struct{}, len(fts)+len(semantic))
-	merged := make([]types.ToolMatch, 0, len(fts)+len(semantic))
+	merged := make([]mcp.Tool, 0, len(fts)+len(semantic))
 
 	// Semantic results first.
 	for _, m := range semantic {
@@ -448,7 +449,7 @@ func mergeResults(fts, semantic []types.ToolMatch, maxResults int) []types.ToolM
 }
 
 // matchNames extracts tool names from a slice of ToolMatch results for logging.
-func matchNames(matches []types.ToolMatch) []string {
+func matchNames(matches []mcp.Tool) []string {
 	names := make([]string, len(matches))
 	for i, m := range matches {
 		names[i] = m.Name

--- a/pkg/vmcp/optimizer/internal/toolstore/sqlite_store_test.go
+++ b/pkg/vmcp/optimizer/internal/toolstore/sqlite_store_test.go
@@ -535,17 +535,17 @@ func TestMergeResults(t *testing.T) {
 
 	tests := []struct {
 		name       string
-		fts        []types.ToolMatch
-		semantic   []types.ToolMatch
+		fts        []mcp.Tool
+		semantic   []mcp.Tool
 		maxResults int
 		wantNames  []string // expected names in order (semantic first, then FTS5)
 	}{
 		{
 			name: "deduplicates keeping semantic entry",
-			fts: []types.ToolMatch{
+			fts: []mcp.Tool{
 				{Name: "tool_a", Description: "A"},
 			},
-			semantic: []types.ToolMatch{
+			semantic: []mcp.Tool{
 				{Name: "tool_a", Description: "A"},
 			},
 			maxResults: 10,
@@ -553,10 +553,10 @@ func TestMergeResults(t *testing.T) {
 		},
 		{
 			name: "semantic results come first",
-			fts: []types.ToolMatch{
+			fts: []mcp.Tool{
 				{Name: "tool_a", Description: "A"},
 			},
-			semantic: []types.ToolMatch{
+			semantic: []mcp.Tool{
 				{Name: "tool_b", Description: "B"},
 			},
 			maxResults: 10,
@@ -564,11 +564,11 @@ func TestMergeResults(t *testing.T) {
 		},
 		{
 			name: "preserves order within each group",
-			fts: []types.ToolMatch{
+			fts: []mcp.Tool{
 				{Name: "tool_c", Description: "C"},
 				{Name: "tool_a", Description: "A"},
 			},
-			semantic: []types.ToolMatch{
+			semantic: []mcp.Tool{
 				{Name: "tool_b", Description: "B"},
 			},
 			maxResults: 10,
@@ -576,12 +576,12 @@ func TestMergeResults(t *testing.T) {
 		},
 		{
 			name: "truncates to maxResults",
-			fts: []types.ToolMatch{
+			fts: []mcp.Tool{
 				{Name: "tool_a", Description: "A"},
 				{Name: "tool_b", Description: "B"},
 				{Name: "tool_c", Description: "C"},
 			},
-			semantic: []types.ToolMatch{
+			semantic: []mcp.Tool{
 				{Name: "tool_d", Description: "D"},
 				{Name: "tool_e", Description: "E"},
 			},
@@ -597,12 +597,12 @@ func TestMergeResults(t *testing.T) {
 		},
 		{
 			name: "dedup with truncate combined",
-			fts: []types.ToolMatch{
+			fts: []mcp.Tool{
 				{Name: "dup", Description: "D"},
 				{Name: "best", Description: "B"},
 				{Name: "worst", Description: "W"},
 			},
-			semantic: []types.ToolMatch{
+			semantic: []mcp.Tool{
 				{Name: "dup", Description: "D"},
 				{Name: "mid", Description: "M"},
 			},

--- a/pkg/vmcp/optimizer/internal/types/mocks/mock_types.go
+++ b/pkg/vmcp/optimizer/internal/types/mocks/mock_types.go
@@ -13,8 +13,8 @@ import (
 	context "context"
 	reflect "reflect"
 
+	mcp "github.com/mark3labs/mcp-go/mcp"
 	server "github.com/mark3labs/mcp-go/server"
-	types "github.com/stacklok/toolhive/pkg/vmcp/optimizer/internal/types"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -57,10 +57,10 @@ func (mr *MockToolStoreMockRecorder) Close() *gomock.Call {
 }
 
 // Search mocks base method.
-func (m *MockToolStore) Search(ctx context.Context, query string, allowedTools []string) ([]types.ToolMatch, error) {
+func (m *MockToolStore) Search(ctx context.Context, query string, allowedTools []string) ([]mcp.Tool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Search", ctx, query, allowedTools)
-	ret0, _ := ret[0].([]types.ToolMatch)
+	ret0, _ := ret[0].([]mcp.Tool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/pkg/vmcp/optimizer/internal/types/types.go
+++ b/pkg/vmcp/optimizer/internal/types/types.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 )
 
@@ -26,22 +27,14 @@ type ToolStore interface {
 	// Search finds tools matching the query string.
 	// The allowedTools parameter limits results to only tools with names in the given set.
 	// If allowedTools is empty, no results are returned (empty = no access).
-	// Returns matches ranked by relevance.
-	Search(ctx context.Context, query string, allowedTools []string) ([]ToolMatch, error)
+	// Returns matches ranked by relevance. The returned mcp.Tool values contain
+	// only Name and Description; the caller is responsible for enriching with schemas.
+	Search(ctx context.Context, query string, allowedTools []string) ([]mcp.Tool, error)
 
 	// Close releases any resources held by the store (e.g., database connections).
 	// For in-memory stores this is a no-op.
 	// It is safe to call Close multiple times.
 	Close() error
-}
-
-// ToolMatch represents a tool that matched the search criteria.
-type ToolMatch struct {
-	// Name is the unique identifier of the tool.
-	Name string `json:"name"`
-
-	// Description is the human-readable description of the tool.
-	Description string `json:"description"`
 }
 
 // EmbeddingClient generates vector embeddings from text.

--- a/pkg/vmcp/optimizer/optimizer.go
+++ b/pkg/vmcp/optimizer/optimizer.go
@@ -113,16 +113,11 @@ type FindToolInput struct {
 // FindToolOutput contains the results of a tool search.
 type FindToolOutput struct {
 	// Tools contains the matching tools, ranked by relevance.
-	Tools []ToolMatch `json:"tools"`
+	Tools []mcp.Tool `json:"tools"`
 
 	// TokenMetrics provides information about token savings from using the optimizer.
 	TokenMetrics TokenMetrics `json:"token_metrics"`
 }
-
-// ToolMatch represents a tool that matched the search criteria.
-// It is defined in the internal/types package and aliased here so that
-// external consumers continue to use optimizer.ToolMatch.
-type ToolMatch = types.ToolMatch
 
 // TokenMetrics provides information about token usage optimization.
 // It is defined in the internal/tokencounter package and aliased here so that
@@ -248,6 +243,15 @@ func (d *toolOptimizer) FindTool(ctx context.Context, input FindToolInput) (*Fin
 	matches, err := d.store.Search(ctx, input.ToolDescription, d.toolNames)
 	if err != nil {
 		return nil, fmt.Errorf("tool search failed: %w", err)
+	}
+
+	// Enrich each match with the full tool from the in-memory map.
+	// The store only returns Name and Description; replacing with the full
+	// mcp.Tool gives us InputSchema, OutputSchema, Annotations, etc.
+	for i, m := range matches {
+		if tool, ok := d.tools[m.Name]; ok {
+			matches[i] = tool.Tool
+		}
 	}
 
 	matchedNames := make([]string, len(matches))

--- a/pkg/vmcp/optimizer/optimizer_test.go
+++ b/pkg/vmcp/optimizer/optimizer_test.go
@@ -5,6 +5,7 @@ package optimizer
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"testing"
@@ -249,7 +250,7 @@ func newMockStoreWithSubstringSearch(ctrl *gomock.Controller) *mocks.MockToolSto
 	).AnyTimes()
 
 	store.EXPECT().Search(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, query string, allowedTools []string) ([]ToolMatch, error) {
+		func(_ context.Context, query string, allowedTools []string) ([]mcp.Tool, error) {
 			if len(allowedTools) == 0 {
 				return nil, nil
 			}
@@ -258,7 +259,7 @@ func newMockStoreWithSubstringSearch(ctrl *gomock.Controller) *mocks.MockToolSto
 			for _, name := range allowedTools {
 				allowedSet[name] = struct{}{}
 			}
-			var matches []ToolMatch
+			var matches []mcp.Tool
 			for _, tool := range tools {
 				if _, ok := allowedSet[tool.Tool.Name]; !ok {
 					continue
@@ -266,7 +267,7 @@ func newMockStoreWithSubstringSearch(ctrl *gomock.Controller) *mocks.MockToolSto
 				nameLower := strings.ToLower(tool.Tool.Name)
 				descLower := strings.ToLower(tool.Tool.Description)
 				if strings.Contains(nameLower, searchTerm) || strings.Contains(descLower, searchTerm) {
-					matches = append(matches, ToolMatch{
+					matches = append(matches, mcp.Tool{
 						Name:        tool.Tool.Name,
 						Description: tool.Tool.Description,
 					})
@@ -296,9 +297,9 @@ func TestOptimizer_SearchDelegation(t *testing.T) {
 
 	store.EXPECT().UpsertTools(gomock.Any(), gomock.Any()).Return(nil)
 	store.EXPECT().Search(gomock.Any(), "query", gomock.Any()).DoAndReturn(
-		func(_ context.Context, _ string, allowedTools []string) ([]ToolMatch, error) {
+		func(_ context.Context, _ string, allowedTools []string) ([]mcp.Tool, error) {
 			require.ElementsMatch(t, []string{"tool_a", "tool_b"}, allowedTools)
-			return []ToolMatch{
+			return []mcp.Tool{
 				{Name: "tool_a", Description: "Tool A"},
 			}, nil
 		},
@@ -319,6 +320,45 @@ func TestOptimizer_SearchDelegation(t *testing.T) {
 	require.Greater(t, result.TokenMetrics.BaselineTokens, 0)
 	require.Greater(t, result.TokenMetrics.ReturnedTokens, 0)
 	require.Greater(t, result.TokenMetrics.SavingsPercent, 0.0)
+}
+
+// TestOptimizer_FindToolEnrichesSchema verifies that FindTool populates
+// InputSchema and OutputSchema from the in-memory tool definitions.
+func TestOptimizer_FindToolEnrichesSchema(t *testing.T) {
+	t.Parallel()
+
+	rawInput := json.RawMessage(`{"type":"object","properties":{"url":{"type":"string"}},"required":["url"]}`)
+	tools := []server.ServerTool{
+		{Tool: mcp.NewToolWithRawSchema("fetch_url", "Fetch content from a URL", rawInput)},
+		{Tool: mcp.NewTool("typed_tool",
+			mcp.WithDescription("Tool with typed schema"),
+			mcp.WithString("name", mcp.Description("The name"), mcp.Required()),
+		)},
+	}
+
+	ctrl := gomock.NewController(t)
+	store := newMockStoreWithSubstringSearch(ctrl)
+	opt, err := newToolOptimizer(context.Background(), store, tokencounter.NewJSONByteCounter(), tools)
+	require.NoError(t, err)
+
+	result, err := opt.FindTool(context.Background(), FindToolInput{ToolDescription: "fetch"})
+	require.NoError(t, err)
+	require.Len(t, result.Tools, 1)
+
+	m := result.Tools[0]
+	require.Equal(t, "fetch_url", m.Name)
+	require.NotEmpty(t, m.RawInputSchema, "RawInputSchema should be populated for raw-schema tools")
+	require.JSONEq(t, string(rawInput), string(m.RawInputSchema))
+
+	// Test typed schema fallback
+	result2, err := opt.FindTool(context.Background(), FindToolInput{ToolDescription: "typed"})
+	require.NoError(t, err)
+	require.Len(t, result2.Tools, 1)
+
+	m2 := result2.Tools[0]
+	require.Equal(t, "typed_tool", m2.Name)
+	require.Equal(t, "object", m2.InputSchema.Type)
+	require.NotEmpty(t, m2.InputSchema.Properties)
 }
 
 // TestOptimizer_SearchError verifies that store search errors are propagated.

--- a/pkg/vmcp/server/adapter/optimizer_adapter_test.go
+++ b/pkg/vmcp/server/adapter/optimizer_adapter_test.go
@@ -51,7 +51,7 @@ func TestFindToolHandler(t *testing.T) {
 		findToolFunc: func(_ context.Context, input optimizer.FindToolInput) (*optimizer.FindToolOutput, error) {
 			require.Equal(t, "read files", input.ToolDescription)
 			return &optimizer.FindToolOutput{
-				Tools: []optimizer.ToolMatch{
+				Tools: []mcp.Tool{
 					{
 						Name:        "read_file",
 						Description: "Read a file",

--- a/pkg/vmcp/server/telemetry_test.go
+++ b/pkg/vmcp/server/telemetry_test.go
@@ -146,7 +146,7 @@ func TestTelemetryOptimizer(t *testing.T) {
 				return &fakeOptimizer{
 					findToolFn: func(_ context.Context, _ optimizer.FindToolInput) (*optimizer.FindToolOutput, error) {
 						return &optimizer.FindToolOutput{
-							Tools: []optimizer.ToolMatch{
+							Tools: []mcp.Tool{
 								{Name: "tool_a", Description: "Tool A"},
 								{Name: "tool_b", Description: "Tool B"},
 							},


### PR DESCRIPTION
## Summary

- Removes the `ToolMatch` struct from the optimizer's internal types, replacing it with `mcp.Tool` throughout the pipeline
- The store's `Search` method now returns `[]mcp.Tool` (with only Name and Description populated)
- `FindTool` enriches results by swapping in the full `mcp.Tool` from the in-memory map, giving callers all fields (InputSchema, OutputSchema, RawInputSchema, Annotations, etc.) for free
- Regenerates mocks to match the updated `ToolStore` interface

## Test plan

- [x] `go test ./pkg/vmcp/optimizer/...` — all pass
- [x] `go test ./pkg/vmcp/server/...` — all pass
- [x] `task test` — full unit suite passes
- [x] `task lint-fix` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)