### PR TITLE
pin Trivy version to avoid broken v0.69.1 install in CI

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -26,6 +26,7 @@ jobs:
       - name: Run Trivy vulnerability scanner in repo mode
         uses: aquasecurity/trivy-action@e368e328979b113139d6f9068e03accaed98a518 # 0.34.1
         with:
+          version: 'v0.69.3'
           scan-type: 'fs'
           scan-ref: '.'
           format: 'sarif'
@@ -47,6 +48,7 @@ jobs:
       - name: Run Trivy configuration scanner
         uses: aquasecurity/trivy-action@e368e328979b113139d6f9068e03accaed98a518 # 0.34.1
         with:
+          version: 'v0.69.3'
           scan-type: 'config'
           scan-ref: './deploy/charts'
           format: 'sarif'


### PR DESCRIPTION
## Summary

Fix CI failures in the security workflow by explicitly pinning the Trivy version used by `aquasecurity/trivy-action`.

## Problem

The workflow was failing during the Trivy installation step:

```
installing Trivy binary
aquasecurity/trivy info found version: 0.69.1 for v0.69.1/Linux/64bit
Error: Process completed with exit code 1
```

`trivy-action` defaults to installing **v0.69.1**, whose GitHub release assets were temporarily unavailable following the Aqua Security March 2026 incident. This caused the installation step in CI to fail before scans could run.

## Fix

Explicitly pin Trivy to a working release:

```yaml
trivy-version: '0.69.3'
```

This ensures the binary can be downloaded and allows the repository and configuration scans to complete successfully.

## Changes

* Added `trivy-version: '0.69.3'` to:

  * repository filesystem scan
  * configuration scan

## Impact

* Restores CI security scan workflow
* No changes to scan coverage or policies
* No runtime or application impact

## Verification

* CI workflow runs successfully
* Trivy scans complete and upload SARIF results to GitHub Security tab
