### PR TITLE
Auto-chunk TEI embedding requests to respect server batch size limit

### DIFF
--- a/pkg/vmcp/optimizer/internal/similarity/tei_client.go
+++ b/pkg/vmcp/optimizer/internal/similarity/tei_client.go
@@ -22,13 +22,20 @@ const (
 
 	// embedPath is the TEI endpoint path for generating embeddings.
 	embedPath = "/embed"
+
+	// infoPath is the TEI endpoint that returns server metadata including max batch size.
+	infoPath = "/info"
+
+	// defaultMaxBatchSize is used when the TEI /info endpoint does not report a max batch size.
+	defaultMaxBatchSize = 32
 )
 
 // teiClient implements types.EmbeddingClient by calling the HuggingFace
 // Text Embeddings Inference (TEI) HTTP API.
 type teiClient struct {
-	baseURL    string
-	httpClient *http.Client
+	baseURL      string
+	httpClient   *http.Client
+	maxBatchSize int
 }
 
 // NewEmbeddingClient creates an EmbeddingClient from the given optimizer
@@ -42,6 +49,7 @@ func NewEmbeddingClient(cfg *types.OptimizerConfig) (types.EmbeddingClient, erro
 }
 
 // newTEIClient creates a new TEI embedding client that calls the specified endpoint.
+// It queries the TEI /info endpoint to discover the server's maximum batch size.
 func newTEIClient(baseURL string, timeout time.Duration) (*teiClient, error) {
 	if baseURL == "" {
 		return nil, fmt.Errorf("TEI BaseURL is required")
@@ -51,14 +59,52 @@ func newTEIClient(baseURL string, timeout time.Duration) (*teiClient, error) {
 		timeout = defaultTimeout
 	}
 
-	slog.Debug("TEI embedding client created", "base_url", baseURL, "timeout", timeout)
+	httpClient := &http.Client{Timeout: timeout}
+
+	maxBatch, err := fetchMaxBatchSize(baseURL, httpClient)
+	if err != nil {
+		slog.Warn("failed to query TEI /info, using default max batch size",
+			"error", err, "default", defaultMaxBatchSize)
+		maxBatch = defaultMaxBatchSize
+	}
+
+	slog.Debug("TEI embedding client created",
+		"base_url", baseURL, "timeout", timeout, "max_batch_size", maxBatch)
 
 	return &teiClient{
-		baseURL: baseURL,
-		httpClient: &http.Client{
-			Timeout: timeout,
-		},
+		baseURL:      baseURL,
+		httpClient:   httpClient,
+		maxBatchSize: maxBatch,
 	}, nil
+}
+
+// teiInfoResponse is a subset of the TEI /info endpoint response.
+type teiInfoResponse struct {
+	MaxClientBatchSize int `json:"max_client_batch_size"`
+}
+
+// fetchMaxBatchSize queries the TEI /info endpoint and returns the max client batch size.
+func fetchMaxBatchSize(baseURL string, httpClient *http.Client) (int, error) {
+	resp, err := httpClient.Get(baseURL + infoPath) // #nosec G107 -- URL is built from the configured TEI base URL
+	if err != nil {
+		return 0, fmt.Errorf("TEI /info request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return 0, fmt.Errorf("TEI /info returned status %d", resp.StatusCode)
+	}
+
+	var info teiInfoResponse
+	if err := json.NewDecoder(resp.Body).Decode(&info); err != nil {
+		return 0, fmt.Errorf("failed to decode TEI /info response: %w", err)
+	}
+
+	if info.MaxClientBatchSize <= 0 {
+		return defaultMaxBatchSize, nil
+	}
+
+	return info.MaxClientBatchSize, nil
 }
 
 // embedRequest is the JSON body sent to the TEI /embed endpoint.
@@ -83,12 +129,35 @@ func (c *teiClient) Embed(ctx context.Context, text string) ([]float32, error) {
 	return results[0], nil
 }
 
-// EmbedBatch returns vector embeddings for multiple texts in a single request.
+// EmbedBatch returns vector embeddings for multiple texts, automatically
+// chunking requests to respect the TEI server's maximum batch size.
 func (c *teiClient) EmbedBatch(ctx context.Context, texts []string) ([][]float32, error) {
 	if len(texts) == 0 {
 		return nil, nil
 	}
 
+	allEmbeddings := make([][]float32, 0, len(texts))
+
+	for start := 0; start < len(texts); start += c.maxBatchSize {
+		end := min(start+c.maxBatchSize, len(texts))
+		chunk := texts[start:end]
+
+		embeddings, err := c.embedChunk(ctx, chunk)
+		if err != nil {
+			return nil, err
+		}
+		allEmbeddings = append(allEmbeddings, embeddings...)
+	}
+
+	slog.Debug("TEI embedding batch completed",
+		"inputs", len(texts), "chunks", (len(texts)+c.maxBatchSize-1)/c.maxBatchSize,
+		"dimensions", len(allEmbeddings[0]))
+
+	return allEmbeddings, nil
+}
+
+// embedChunk sends a single batch of texts to the TEI /embed endpoint.
+func (c *teiClient) embedChunk(ctx context.Context, texts []string) ([][]float32, error) {
 	reqBody := embedRequest{
 		Inputs:   texts,
 		Truncate: true,
@@ -124,8 +193,6 @@ func (c *teiClient) EmbedBatch(ctx context.Context, texts []string) ([][]float32
 	if len(embeddings) != len(texts) {
 		return nil, fmt.Errorf("TEI returned %d embeddings for %d inputs", len(embeddings), len(texts))
 	}
-
-	slog.Debug("TEI embedding batch completed", "inputs", len(texts), "dimensions", len(embeddings[0]))
 
 	return embeddings, nil
 }

--- a/pkg/vmcp/optimizer/internal/similarity/tei_client_test.go
+++ b/pkg/vmcp/optimizer/internal/similarity/tei_client_test.go
@@ -6,6 +6,7 @@ package similarity
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -17,45 +18,55 @@ import (
 func Test_newTEIClient(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct {
-		name    string
-		baseURL string
-		timeout time.Duration
-		wantErr string
-	}{
-		{
-			name:    "empty URL returns error",
-			baseURL: "",
-			wantErr: "TEI BaseURL is required",
-		},
-		{
-			name:    "valid URL creates client",
-			baseURL: "http://my-embedding:8080",
-		},
-		{
-			name:    "URL with namespace",
-			baseURL: "http://my-embedding.ml.svc.cluster.local:8080",
-		},
-		{
-			name:    "custom timeout",
-			baseURL: "http://my-embedding:8080",
-			timeout: 5 * time.Second,
-		},
-	}
+	infoHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == infoPath {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"max_client_batch_size": 16}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			client, err := newTEIClient(tt.baseURL, tt.timeout)
-			if tt.wantErr != "" {
-				require.ErrorContains(t, err, tt.wantErr)
-				require.Nil(t, client)
-			} else {
-				require.NoError(t, err)
-				require.NotNil(t, client)
-			}
-		})
-	}
+	t.Run("empty URL returns error", func(t *testing.T) {
+		t.Parallel()
+		client, err := newTEIClient("", 0)
+		require.ErrorContains(t, err, "TEI BaseURL is required")
+		require.Nil(t, client)
+	})
+
+	t.Run("valid URL creates client with batch size from info", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(infoHandler)
+		defer srv.Close()
+
+		client, err := newTEIClient(srv.URL, 0)
+		require.NoError(t, err)
+		require.NotNil(t, client)
+		require.Equal(t, 16, client.maxBatchSize)
+	})
+
+	t.Run("custom timeout", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(infoHandler)
+		defer srv.Close()
+
+		client, err := newTEIClient(srv.URL, 5*time.Second)
+		require.NoError(t, err)
+		require.NotNil(t, client)
+	})
+
+	t.Run("unreachable info endpoint uses default batch size", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer srv.Close()
+
+		client, err := newTEIClient(srv.URL, 0)
+		require.NoError(t, err)
+		require.NotNil(t, client)
+		require.Equal(t, defaultMaxBatchSize, client.maxBatchSize)
+	})
 }
 
 func TestTEIClient_Embed(t *testing.T) {
@@ -175,21 +186,201 @@ func TestTEIClient_EmbedBatch(t *testing.T) {
 	}
 }
 
+func TestTEIClient_EmbedBatch_Chunking(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		maxBatchSize int
+		numInputs    int
+		wantChunks   int
+	}{
+		{
+			name:         "inputs fit in single batch",
+			maxBatchSize: 5,
+			numInputs:    3,
+			wantChunks:   1,
+		},
+		{
+			name:         "inputs exactly fill one batch",
+			maxBatchSize: 4,
+			numInputs:    4,
+			wantChunks:   1,
+		},
+		{
+			name:         "inputs split into two batches",
+			maxBatchSize: 3,
+			numInputs:    5,
+			wantChunks:   2,
+		},
+		{
+			name:         "inputs split into many batches",
+			maxBatchSize: 2,
+			numInputs:    7,
+			wantChunks:   4,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var chunkCount int
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var req embedRequest
+				require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+				require.LessOrEqual(t, len(req.Inputs), tt.maxBatchSize,
+					"chunk size should not exceed maxBatchSize")
+				chunkCount++
+
+				embeddings := make([][]float32, len(req.Inputs))
+				for i := range embeddings {
+					embeddings[i] = []float32{float32(i) * 0.1}
+				}
+				w.Header().Set("Content-Type", "application/json")
+				require.NoError(t, json.NewEncoder(w).Encode(embeddings))
+			}))
+			defer srv.Close()
+
+			texts := make([]string, tt.numInputs)
+			for i := range texts {
+				texts[i] = fmt.Sprintf("text-%d", i)
+			}
+
+			client := newTestTEIClientWithBatch(t, srv.URL, tt.maxBatchSize)
+			results, err := client.EmbedBatch(context.Background(), texts)
+			require.NoError(t, err)
+			require.Len(t, results, tt.numInputs)
+			require.Equal(t, tt.wantChunks, chunkCount)
+		})
+	}
+}
+
+func TestTEIClient_EmbedBatch_ChunkErrorStopsEarly(t *testing.T) {
+	t.Parallel()
+
+	var callCount int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		callCount++
+		if callCount == 2 {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte("server overloaded"))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([][]float32{{0.1}, {0.2}})
+	}))
+	defer srv.Close()
+
+	texts := make([]string, 6) // 3 chunks of 2
+	for i := range texts {
+		texts[i] = fmt.Sprintf("text-%d", i)
+	}
+
+	client := newTestTEIClientWithBatch(t, srv.URL, 2)
+	_, err := client.EmbedBatch(context.Background(), texts)
+	require.ErrorContains(t, err, "TEI returned status 500")
+	require.Equal(t, 2, callCount, "should stop after the failing chunk")
+}
+
+func Test_fetchMaxBatchSize(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		handler  http.HandlerFunc
+		wantSize int
+		wantErr  string
+	}{
+		{
+			name: "returns reported batch size",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"max_client_batch_size": 64, "model_type": "bert"}`))
+			},
+			wantSize: 64,
+		},
+		{
+			name: "zero batch size returns default",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"max_client_batch_size": 0}`))
+			},
+			wantSize: defaultMaxBatchSize,
+		},
+		{
+			name: "missing field returns default",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"model_type": "bert"}`))
+			},
+			wantSize: defaultMaxBatchSize,
+		},
+		{
+			name: "server error returns error",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+			},
+			wantErr: "TEI /info returned status 500",
+		},
+		{
+			name: "invalid JSON returns error",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`not json`))
+			},
+			wantErr: "failed to decode TEI /info response",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := httptest.NewServer(tt.handler)
+			defer srv.Close()
+
+			size, err := fetchMaxBatchSize(srv.URL, srv.Client())
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.wantSize, size)
+		})
+	}
+}
+
+func Test_fetchMaxBatchSize_ConnectionRefused(t *testing.T) {
+	t.Parallel()
+
+	_, err := fetchMaxBatchSize("http://localhost:1", &http.Client{Timeout: time.Second})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "TEI /info request failed")
+}
+
 func TestTEIClient_Close(t *testing.T) {
 	t.Parallel()
 
-	client, err := newTEIClient("http://my-embedding:8080", 0)
-	require.NoError(t, err)
+	client := newTestTEIClient(t, "http://my-embedding:8080")
 	require.NoError(t, client.Close())
 }
 
 // newTestTEIClient creates a teiClient pointing at the given URL for testing.
 // This bypasses newTEIClient since test servers have dynamic URLs that don't
-// map to a Kubernetes service name.
+// map to a Kubernetes service name. It defaults to a large batch size so
+// existing tests behave as single-chunk requests.
 func newTestTEIClient(t *testing.T, baseURL string) *teiClient {
 	t.Helper()
+	return newTestTEIClientWithBatch(t, baseURL, 1000)
+}
+
+// newTestTEIClientWithBatch creates a teiClient with a specific max batch size for testing.
+func newTestTEIClientWithBatch(t *testing.T, baseURL string, maxBatchSize int) *teiClient {
+	t.Helper()
 	return &teiClient{
-		baseURL:    baseURL,
-		httpClient: &http.Client{Timeout: defaultTimeout},
+		baseURL:      baseURL,
+		httpClient:   &http.Client{Timeout: defaultTimeout},
+		maxBatchSize: maxBatchSize,
 	}
 }


### PR DESCRIPTION
## Summary

TEI (Text Embeddings Inference), which the Optimizer uses for embeddings, does not automatically batch requests that exceed its `max_client_batch_size` — it simply rejects them with a 422 error. This bug hadn't surfaced because we were indexing fewer than 32 tools (the default server limit). Once that threshold was exceeded, upserts started failing.

This PR fixes the issue by:
- Querying the TEI `/info` endpoint at client creation to discover `max_client_batch_size`
- Splitting `EmbedBatch` requests into chunks that respect the server limit
- Falling back gracefully to a default of 32 when `/info` is unavailable

## Test plan

- [x] All existing TEI client tests pass
- [x] New tests for batch chunking (single batch, exact fit, multi-chunk, many chunks)
- [x] New test verifying early stop on chunk error
- [x] New tests for `/info` endpoint fetching (success, zero value, missing field, server error, invalid JSON, connection refused)
- [x] New test for `newTEIClient` with `/info` integration and fallback behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)