### PR TITLE
Add PR template and Claude Code rule for PR creation

### DIFF
--- a/.claude/rules/pr-creation.md
+++ b/.claude/rules/pr-creation.md
@@ -1,23 +1,24 @@
 # PR Creation Rules
 
-When creating a pull request, follow the template at `.github/pull_request_template.md`.
+You MUST follow the template at `.github/pull_request_template.md` when creating pull requests. Do NOT skip or leave placeholder text in required sections.
 
-## Required sections
+## Required sections — do NOT omit these
 
-- **Summary**: Concise bullet points explaining what changed and why. Focus on motivation — the diff shows the implementation. Include issue references (`Closes #NNN` or `Fixes #NNN`) when applicable.
-- **Type of change**: Check exactly one category (bug fix, feature, refactoring, dependency update, documentation, or other).
-- **Test plan**: Checkbox list of verification steps. Check off items that were actually run. Add specific details for manual testing.
+- **Summary**: You MUST explain (1) WHY the change is needed and (2) WHAT changed. Lead with the motivation — the diff shows the code. Include issue references (`Closes #NNN` or `Fixes #NNN`) when a related issue exists; remove the `Fixes #` line entirely if there is none.
+- **Type of change**: Check exactly one category. Do not leave all boxes unchecked.
+- **Test plan**: Check every verification step you actually ran. You MUST check at least one item. For manual testing, describe exactly what you tested.
 
-## Optional sections — remove if not needed
+## Optional sections — remove entirely if not needed
 
-- **Changes**: File-by-file table for PRs touching many files. Helps reviewers navigate the diff.
-- **Does this introduce a user-facing change?**: Describe the change from the user's perspective. Important for release notes. Write "No" if not applicable.
+Do NOT leave optional sections empty or with only placeholder/template text. Either fill them in or delete them.
+
+- **Changes**: File-by-file table for PRs touching more than a few files.
+- **Does this introduce a user-facing change?**: Describe the change from the user's perspective. Write "No" if not applicable.
 - **Special notes for reviewers**: Non-obvious design decisions, known limitations, areas wanting extra scrutiny, or planned follow-up work.
 
 ## Style guidelines
 
 - Keep the PR title under 70 characters, imperative mood, no trailing period.
 - PR titles must NOT use conventional commit prefixes (`feat:`, `fix:`, `chore:`, etc.).
-- Summary bullets should explain the "what and why", not implementation details.
-- Remove template sections that don't apply rather than leaving them empty or with only placeholder text.
+- Summary bullets MUST explain the "why" first, then the "what". Do not just list what files changed.
 - When the PR is generated with Claude Code, include `Generated with [Claude Code](https://claude.com/claude-code)` at the bottom of the body.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,16 +1,26 @@
 ## Summary
 
-<!-- Concise bullet points: what changed and why. Focus on the "why" — the diff shows the "what". -->
+<!--
+REQUIRED. You MUST explain:
+1. WHY this change is needed (the problem or motivation)
+2. WHAT changed (concise bullet points)
+
+The diff shows the code — your summary must provide the context a reviewer
+needs to understand the purpose without reading the diff first.
+-->
 
 -
 
-<!-- Link related issues. Use "Closes" or "Fixes" to auto-close on merge. Write "N/A" if none. -->
+<!--
+Link related issues. Use "Closes" or "Fixes" to auto-close on merge.
+Remove this line if there is no related issue.
+-->
 
 Fixes #
 
 ## Type of change
 
-<!-- Check the one that applies. -->
+<!-- REQUIRED. Check exactly one. -->
 
 - [ ] Bug fix
 - [ ] New feature
@@ -21,7 +31,11 @@ Fixes #
 
 ## Test plan
 
-<!-- How did you verify this works? Check all that apply and add details for manual testing. -->
+<!--
+REQUIRED. Check every verification step you actually ran.
+You MUST check at least one item. If you only did manual testing,
+describe exactly what you tested below the checkbox.
+-->
 
 - [ ] Unit tests (`task test`)
 - [ ] E2E tests (`task test-e2e`)
@@ -30,7 +44,10 @@ Fixes #
 
 ## Changes
 
-<!-- Optional — include for larger PRs to help reviewers navigate the diff. Remove for small PRs. -->
+<!--
+Optional — include for PRs touching more than a few files to help
+reviewers navigate the diff. Remove this entire section for small PRs.
+-->
 
 | File | Change |
 |------|--------|
@@ -40,7 +57,8 @@ Fixes #
 
 <!--
 If yes, describe the change from the user's perspective. This helps with release notes.
-If no, write "No" and remove the details line.
+If no, write "No".
+Remove this section entirely if not applicable.
 -->
 
 ## Special notes for reviewers


### PR DESCRIPTION
## Summary

- The project had no PR template, so PR descriptions were inconsistent and reviewers had to ask for missing context (testing details, type of change, user-facing impact)
- Adds a GitHub pull request template (`.github/pull_request_template.md`) to give contributors a consistent structure and reduce back-and-forth during review
- Adds a Claude Code rule (`.claude/rules/pr-creation.md`) so AI agents follow the same template when creating PRs on behalf of developers
- Template design based on research across Kubernetes, Grafana, Operator SDK, Microsoft Engineering Playbook, and Graphite best practices, adapted to match ToolHive's existing PR conventions

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [x] Other: Developer workflow improvement

## Test plan

- [ ] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [ ] Linting (`task lint-fix`)
- [x] Manual testing: Verified template renders correctly by inspecting the markdown

## Does this introduce a user-facing change?

All new PRs will be pre-populated with the template. Contributors fill in the sections and remove any that don't apply.

Generated with [Claude Code](https://claude.com/claude-code)