### PR TITLE
Clean up stale release branch before Create Release PR retry

### DIFF
--- a/.claude/skills/toolhive-release/references/WORKFLOW-REFERENCE.md
+++ b/.claude/skills/toolhive-release/references/WORKFLOW-REFERENCE.md
@@ -148,6 +148,12 @@ Detailed documentation of the ToolHive release workflow chain.
 
 ## Troubleshooting
 
+### Reference already exists when creating release PR
+
+If a previous Create Release PR run failed after creating the branch but before opening the PR, the branch (e.g. `release/v0.11.1`) is left behind. The next run fails with "Reference already exists" because releaseo cannot create the same branch again.
+
+**Fix**: The workflow now includes a cleanup step that deletes the target release branch before running releaseo, allowing retries to succeed. Simply re-run the workflow.
+
 ### PR not triggering create-release-tag
 
 - Ensure commit message matches expected pattern: `Release vX.Y.Z`

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -40,6 +40,33 @@ jobs:
       - name: Setup helm-docs
         run: go install github.com/norwoodj/helm-docs/cmd/helm-docs@latest
 
+      # Remove stale release branch from a previous failed run to avoid
+      # "Reference already exists" when releaseo tries to create the branch.
+      # Only deletes if the branch exists with no open PR (stale from failed run).
+      - name: Clean up stale release branch from previous failed run
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BUMP_TYPE: ${{ inputs.bump_type }}
+        run: |
+          CURRENT=$(cat VERSION | tr -d 'v')
+          IFS='.' read -r x y z <<< "$CURRENT"
+          case "$BUMP_TYPE" in
+            patch) z=$((z+1));;
+            minor) y=$((y+1)); z=0;;
+            major) x=$((x+1)); y=0; z=0;;
+            *) echo "Unknown bump type: $BUMP_TYPE"; exit 1;;
+          esac
+          NEW_VERSION="${x}.${y}.${z}"
+          BRANCH="release/v${NEW_VERSION}"
+          OPEN_PR=$(gh pr list --head "$BRANCH" --state open --json number -q 'length' 2>/dev/null || echo "0")
+          if [ "$OPEN_PR" = "0" ] || [ -z "$OPEN_PR" ]; then
+            echo "Deleting stale branch $BRANCH if it exists (from previous failed run)..."
+            gh api -X DELETE "/repos/${{ github.repository }}/git/refs/heads/${BRANCH}" 2>/dev/null || true
+          else
+            echo "Branch $BRANCH has an open PR - skipping cleanup. Close or merge the existing PR first."
+            exit 1
+          fi
+
       - name: Create Release PR
         id: release
         uses: stacklok/releaseo@b7022753f832cac36a9e07769a679a7c1ca72fe2 # v0.0.3


### PR DESCRIPTION
## Summary

When the Create Release PR workflow fails after creating the `release/vX.Y.Z` branch but before opening the PR (e.g. helm-docs or file update failure), the branch remains. A retry fails with "Reference already exists" because releaseo cannot create the same branch again.

This change adds a pre-step that:
1. Computes the target release branch from the VERSION file and bump_type input
2. Checks whether there is an open PR for that branch
3. Deletes the branch only when there is no open PR (treats it as stale from a failed run)
4. Fails with an explanatory message when a release PR already exists, so the branch is not deleted


## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [ ] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [ ] Linting (`task lint-fix`)
- [x] Manual testing (describe below)

Manually verified the cleanup logic: branch name derivation matches releaseo (release/v{major}.{minor}.{patch}), and gh pr list/gh api usage is valid.

## Changes

| File | Change |
|------|--------|
| `.github/workflows/create-release-pr.yml` | Add "Clean up stale release branch" step before releaseo |
| `.claude/skills/toolhive-release/references/WORKFLOW-REFERENCE.md` | Document the fix in troubleshooting |

## Does this introduce a user-facing change?

No. Improves workflow robustness for release automation only.

## Special notes for reviewers

The cleanup step uses `secrets.GITHUB_TOKEN` (via GH_TOKEN) for gh CLI, separate from `secrets.RELEASE_TOKEN` used by releaseo. `contents: write` is sufficient for deleting refs.