### PR TITLE
feat(vmcp): add optional backend keepalive

### DIFF
--- a/pkg/vmcp/session/default_session.go
+++ b/pkg/vmcp/session/default_session.go
@@ -66,7 +66,8 @@ type defaultMultiSession struct {
 	prompts         []vmcp.Prompt
 	backendSessions map[string]string
 
-	queue AdmissionQueue
+	queue     AdmissionQueue
+	keepalive *KeepaliveManager // may be nil in tests that bypass the factory
 }
 
 // Tools returns a snapshot copy of the tools available in this session.
@@ -179,6 +180,12 @@ func (s *defaultMultiSession) GetPrompt(
 // operations complete; subsequent calls are no-ops (idempotent).
 func (s *defaultMultiSession) Close() error {
 	s.queue.CloseAndDrain()
+
+	// Stop keepalive goroutines before closing backend connections so they
+	// don't attempt probes on already-closed sessions.
+	if s.keepalive != nil {
+		s.keepalive.Stop()
+	}
 
 	var errs []error
 	for id, conn := range s.connections {

--- a/pkg/vmcp/session/default_session_test.go
+++ b/pkg/vmcp/session/default_session_test.go
@@ -56,7 +56,8 @@ func (m *mockConnectedBackend) GetPrompt(ctx context.Context, name string, argum
 	return &vmcp.PromptGetResult{Messages: "hello"}, nil
 }
 
-func (m *mockConnectedBackend) SessionID() string { return m.sessID }
+func (*mockConnectedBackend) Ping(_ context.Context) error { return nil }
+func (m *mockConnectedBackend) SessionID() string          { return m.sessID }
 func (m *mockConnectedBackend) Close() error {
 	m.closeCalled.Store(true)
 	return m.closeErr

--- a/pkg/vmcp/session/factory.go
+++ b/pkg/vmcp/session/factory.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"go.opentelemetry.io/otel/metric"
 
 	"github.com/stacklok/toolhive/pkg/auth"
 	transportsession "github.com/stacklok/toolhive/pkg/transport/session"
@@ -112,6 +113,8 @@ type defaultMultiSessionFactory struct {
 	maxConcurrency     int
 	backendInitTimeout time.Duration
 	hmacSecret         []byte // Server-managed secret for HMAC-SHA256 token hashing
+	keepaliveCfg       KeepaliveConfig
+	keepaliveMetrics   *keepaliveMetrics
 }
 
 // MultiSessionFactoryOption configures a defaultMultiSessionFactory.
@@ -135,6 +138,43 @@ func WithBackendInitTimeout(d time.Duration) MultiSessionFactoryOption {
 			f.backendInitTimeout = d
 		}
 	}
+}
+
+// WithKeepaliveConfig sets the server-level keepalive configuration applied to
+// every session created by this factory. Per-backend overrides live in
+// BackendTarget.KeepaliveMethod. Keepalive is disabled when Method is
+// KeepaliveMethodNone on the target.
+func WithKeepaliveConfig(cfg KeepaliveConfig) MultiSessionFactoryOption {
+	return func(f *defaultMultiSessionFactory) {
+		f.keepaliveCfg = cfg
+	}
+}
+
+// WithMeterProvider sets the OTel MeterProvider used to emit keepalive metrics.
+// If not provided (or nil), a no-op provider is used so keepalive still works
+// without metrics infrastructure.
+func WithMeterProvider(mp metric.MeterProvider) MultiSessionFactoryOption {
+	return func(f *defaultMultiSessionFactory) {
+		if mp == nil {
+			return
+		}
+		km, err := newKeepaliveMetrics(mp)
+		if err != nil {
+			slog.Warn("failed to initialise keepalive metrics; metrics will be no-ops", "error", err)
+			return
+		}
+		f.keepaliveMetrics = km
+	}
+}
+
+// ensureKeepaliveMetrics returns the factory's keepalive metrics, initialising
+// a no-op set if none were configured via WithMeterProvider.
+func (f *defaultMultiSessionFactory) ensureKeepaliveMetrics() *keepaliveMetrics {
+	if f.keepaliveMetrics != nil {
+		return f.keepaliveMetrics
+	}
+	km, _ := newKeepaliveMetrics(nil) // nil → noop provider, error is impossible
+	return km
 }
 
 // WithHMACSecret sets the server-managed secret used for HMAC-SHA256 token hashing.
@@ -404,7 +444,18 @@ func (f *defaultMultiSessionFactory) makeSession(
 
 	populateBackendMetadata(transportSess, results)
 
-	// Create the base session
+	// Build the target map needed by the keepalive manager (workloadID → target).
+	targetsByID := make(map[string]*vmcp.BackendTarget, len(results))
+	for i := range results {
+		targetsByID[results[i].target.WorkloadID] = results[i].target
+	}
+
+	// Create and start the keepalive manager. This factory is only constructed
+	// when SessionManagementV2 is enabled, so keepalive is gated by that flag.
+	km := newKeepaliveManager(connections, targetsByID, f.keepaliveCfg, f.ensureKeepaliveMetrics())
+	km.Start(context.Background())
+
+	// Create the base session without token binding
 	baseSession := &defaultMultiSession{
 		Session:         transportSess,
 		connections:     connections,
@@ -414,6 +465,7 @@ func (f *defaultMultiSessionFactory) makeSession(
 		prompts:         allPrompts,
 		backendSessions: backendSessions,
 		queue:           newAdmissionQueue(),
+		keepalive:       km,
 	}
 
 	// Apply hijack prevention: computes token binding, stores metadata, and wraps

--- a/pkg/vmcp/session/internal/backend/mcp_session.go
+++ b/pkg/vmcp/session/internal/backend/mcp_session.go
@@ -91,6 +91,10 @@ type mcpSession struct {
 // SessionID returns the backend-assigned session ID.
 func (c *mcpSession) SessionID() string { return c.backendSessionID }
 
+// Ping sends an MCP protocol ping to the backend. It is side-effect-free and
+// used by the keepalive mechanism to verify the connection is still alive.
+func (c *mcpSession) Ping(ctx context.Context) error { return c.client.Ping(ctx) }
+
 // Close closes the underlying MCP client transport.
 func (c *mcpSession) Close() error { return c.client.Close() }
 

--- a/pkg/vmcp/session/internal/backend/session.go
+++ b/pkg/vmcp/session/internal/backend/session.go
@@ -45,6 +45,11 @@ type Session interface {
 		arguments map[string]any,
 	) (*vmcp.PromptGetResult, error)
 
+	// Ping sends a protocol-level ping to the backend and returns an error if
+	// the backend is unreachable or does not respond. It is side-effect-free
+	// and is used exclusively by the keepalive mechanism.
+	Ping(ctx context.Context) error
+
 	// Close releases all resources held by this session. Implementations must
 	// be idempotent: calling Close multiple times returns nil.
 	Close() error

--- a/pkg/vmcp/session/keepalive.go
+++ b/pkg/vmcp/session/keepalive.go
@@ -1,0 +1,340 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package session
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"math/rand/v2"
+	"sync"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/noop"
+
+	"github.com/stacklok/toolhive/pkg/vmcp"
+	"github.com/stacklok/toolhive/pkg/vmcp/session/internal/backend"
+)
+
+const (
+	// DefaultKeepaliveInterval is the default interval between keepalive probes.
+	DefaultKeepaliveInterval = 5 * time.Minute
+
+	// DefaultKeepaliveMaxFailures is the number of consecutive probe failures
+	// before keepalive is disabled for a backend (circuit breaker threshold).
+	DefaultKeepaliveMaxFailures = 3
+
+	// DefaultKeepaliveProbeAfter is how long to wait before re-probing a
+	// backend after the circuit breaker disables its keepalive.
+	DefaultKeepaliveProbeAfter = 30 * time.Minute
+
+	// pingTimeout is the per-ping deadline. Short to avoid tying up goroutines.
+	pingTimeout = 10 * time.Second
+
+	// keepaliveInstrumentationScope is the OTel meter name for keepalive metrics.
+	keepaliveInstrumentationScope = "github.com/stacklok/toolhive/pkg/vmcp/session/keepalive"
+)
+
+// KeepaliveConfig holds server-level keepalive settings applied to every
+// backend in a session. Per-backend method overrides live in BackendTarget.
+type KeepaliveConfig struct {
+	// DefaultMethod is the keepalive method used when a backend's
+	// BackendTarget.KeepaliveMethod is empty. Defaults to KeepaliveMethodNone,
+	// so keepalive is disabled unless explicitly configured.
+	DefaultMethod vmcp.KeepaliveMethod
+
+	// Interval is the time between successive keepalive probes.
+	// Defaults to DefaultKeepaliveInterval when zero.
+	Interval time.Duration
+
+	// MaxFailures is the consecutive-failure threshold for the circuit breaker.
+	// After this many failures keepalive is disabled for the backend and a
+	// warning is logged. Defaults to DefaultKeepaliveMaxFailures when zero.
+	MaxFailures int
+
+	// ProbeAfter is how long to wait before re-enabling keepalive after the
+	// circuit breaker fires. Defaults to DefaultKeepaliveProbeAfter when zero.
+	ProbeAfter time.Duration
+}
+
+func (c *KeepaliveConfig) intervalOrDefault() time.Duration {
+	if c.Interval > 0 {
+		return c.Interval
+	}
+	return DefaultKeepaliveInterval
+}
+
+func (c *KeepaliveConfig) maxFailuresOrDefault() int {
+	if c.MaxFailures > 0 {
+		return c.MaxFailures
+	}
+	return DefaultKeepaliveMaxFailures
+}
+
+func (c *KeepaliveConfig) probeAfterOrDefault() time.Duration {
+	if c.ProbeAfter > 0 {
+		return c.ProbeAfter
+	}
+	return DefaultKeepaliveProbeAfter
+}
+
+// keepaliveMetrics holds the OTel instruments for the keepalive subsystem.
+type keepaliveMetrics struct {
+	attempts    metric.Int64Counter
+	successes   metric.Int64Counter
+	failures    metric.Int64Counter
+	latency     metric.Float64Histogram
+	autoDisable metric.Int64Counter
+}
+
+func newKeepaliveMetrics(mp metric.MeterProvider) (*keepaliveMetrics, error) {
+	if mp == nil {
+		mp = noop.NewMeterProvider()
+	}
+	m := mp.Meter(keepaliveInstrumentationScope)
+
+	attempts, err := m.Int64Counter("vmcp_keepalive_attempt_total",
+		metric.WithDescription("Total keepalive probes sent, by backend"))
+	if err != nil {
+		return nil, fmt.Errorf("keepalive attempts counter: %w", err)
+	}
+	successes, err := m.Int64Counter("vmcp_keepalive_success_total",
+		metric.WithDescription("Keepalive probes that succeeded, by backend"))
+	if err != nil {
+		return nil, fmt.Errorf("keepalive successes counter: %w", err)
+	}
+	failures, err := m.Int64Counter("vmcp_keepalive_failure_total",
+		metric.WithDescription("Keepalive probes that failed, by backend and reason"))
+	if err != nil {
+		return nil, fmt.Errorf("keepalive failures counter: %w", err)
+	}
+	latency, err := m.Float64Histogram("vmcp_keepalive_latency_seconds",
+		metric.WithDescription("Duration of successful keepalive probes, in seconds"),
+		metric.WithUnit("s"))
+	if err != nil {
+		return nil, fmt.Errorf("keepalive latency histogram: %w", err)
+	}
+	autoDisable, err := m.Int64Counter("vmcp_keepalive_auto_disabled_total",
+		metric.WithDescription("Number of times keepalive was automatically disabled for a backend"))
+	if err != nil {
+		return nil, fmt.Errorf("keepalive auto-disable counter: %w", err)
+	}
+	return &keepaliveMetrics{
+		attempts:    attempts,
+		successes:   successes,
+		failures:    failures,
+		latency:     latency,
+		autoDisable: autoDisable,
+	}, nil
+}
+
+// circuitBreakerState tracks per-backend keepalive health.
+type circuitBreakerState struct {
+	consecutiveFailures int
+	disabled            bool
+	disabledAt          time.Time
+}
+
+// backendKeepalive manages keepalive probes for a single backend connection.
+type backendKeepalive struct {
+	backendID string
+	conn      backend.Session
+	target    *vmcp.BackendTarget
+	cfg       KeepaliveConfig
+	metrics   *keepaliveMetrics
+
+	mu    sync.Mutex
+	state circuitBreakerState
+}
+
+// probe executes one keepalive probe according to the configured method.
+// It returns (success bool, reason string). reason is non-empty on failure.
+func (b *backendKeepalive) probe(ctx context.Context) (bool, string) {
+	method := b.target.KeepaliveMethod
+	if method == "" {
+		method = b.cfg.DefaultMethod
+	}
+	if method == "" {
+		method = vmcp.KeepaliveMethodNone
+	}
+
+	pCtx, cancel := context.WithTimeout(ctx, pingTimeout)
+	defer cancel()
+
+	switch method {
+	case vmcp.KeepaliveMethodNone:
+		return true, "" // keepalive disabled for this backend
+	case vmcp.KeepaliveMethodTool:
+		toolName := b.target.KeepaliveToolName
+		if toolName == "" {
+			return false, "keepalive_tool_name_not_configured"
+		}
+		_, err := b.conn.CallTool(pCtx, toolName, nil, nil)
+		if err != nil {
+			return false, "tool_call_failed"
+		}
+		return true, ""
+	case vmcp.KeepaliveMethodPing:
+		fallthrough
+	default: // unknown values also fall back to ping
+		if err := b.conn.Ping(pCtx); err != nil {
+			return false, "ping_failed"
+		}
+		return true, ""
+	}
+}
+
+// tick runs a single keepalive iteration: probe and update circuit breaker state.
+func (b *backendKeepalive) tick(ctx context.Context) {
+	b.mu.Lock()
+	state := b.state
+	cfg := b.cfg
+	b.mu.Unlock()
+
+	// Circuit breaker: if disabled, check whether the probe window has elapsed.
+	if state.disabled {
+		if time.Since(state.disabledAt) < cfg.probeAfterOrDefault() {
+			return // still within the quiet window; skip this tick
+		}
+		slog.Info("keepalive: re-enabling probe after quiet window",
+			"backend_id", b.backendID,
+			"quiet_window", cfg.probeAfterOrDefault())
+		b.mu.Lock()
+		b.state.disabled = false
+		b.state.consecutiveFailures = 0
+		b.mu.Unlock()
+	}
+
+	attrs := attribute.NewSet(attribute.String("backend_id", b.backendID))
+	b.metrics.attempts.Add(ctx, 1, metric.WithAttributeSet(attrs))
+
+	start := time.Now()
+	ok, reason := b.probe(ctx)
+	elapsed := time.Since(start)
+
+	if ok {
+		b.metrics.successes.Add(ctx, 1, metric.WithAttributeSet(attrs))
+		b.metrics.latency.Record(ctx, elapsed.Seconds(), metric.WithAttributeSet(attrs))
+		b.mu.Lock()
+		b.state.consecutiveFailures = 0
+		b.mu.Unlock()
+		slog.Debug("keepalive: probe succeeded", "backend_id", b.backendID)
+		return
+	}
+
+	// Probe failed.
+	failAttrs := attribute.NewSet(
+		attribute.String("backend_id", b.backendID),
+		attribute.String("reason", reason),
+	)
+	b.metrics.failures.Add(ctx, 1, metric.WithAttributeSet(failAttrs))
+	slog.Warn("keepalive: probe failed",
+		"backend_id", b.backendID, "reason", reason,
+		"consecutive_failures", state.consecutiveFailures+1)
+
+	b.mu.Lock()
+	b.state.consecutiveFailures++
+	if b.state.consecutiveFailures >= cfg.maxFailuresOrDefault() {
+		b.state.disabled = true
+		b.state.disabledAt = time.Now()
+		b.mu.Unlock()
+		b.metrics.autoDisable.Add(ctx, 1, metric.WithAttributeSet(failAttrs))
+		slog.Warn("keepalive: circuit breaker tripped, disabling keepalive for backend",
+			"backend_id", b.backendID,
+			"consecutive_failures", cfg.maxFailuresOrDefault(),
+			"probe_after", cfg.probeAfterOrDefault())
+	} else {
+		b.mu.Unlock()
+	}
+}
+
+// run is the keepalive goroutine body. It adds per-backend jitter to the
+// initial sleep to spread load across sessions, then probes on each tick.
+func (b *backendKeepalive) run(ctx context.Context) {
+	interval := b.cfg.intervalOrDefault()
+
+	// Jitter: random initial delay in [0, interval/4) to spread probes.
+	// Skip when the upper bound is less than 1 to avoid rand.Int64N(0) panic.
+	if jitterBound := int64(interval / 4); jitterBound > 0 {
+		jitter := time.Duration(rand.Int64N(jitterBound)) //nolint:gosec // non-crypto jitter for probe spread
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(jitter):
+		}
+	}
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			b.tick(ctx)
+		}
+	}
+}
+
+// KeepaliveManager starts and stops per-backend keepalive goroutines for a
+// single MultiSession. It is created by the session factory and embedded in
+// defaultMultiSession.
+type KeepaliveManager struct {
+	backends []*backendKeepalive
+	cancel   context.CancelFunc
+	wg       sync.WaitGroup
+}
+
+// newKeepaliveManager creates a KeepaliveManager but does not start goroutines.
+// Call Start() after construction.
+func newKeepaliveManager(
+	connections map[string]backend.Session,
+	targets map[string]*vmcp.BackendTarget, // workloadID → target
+	cfg KeepaliveConfig,
+	metrics *keepaliveMetrics,
+) *KeepaliveManager {
+	km := &KeepaliveManager{}
+	for id, conn := range connections {
+		target, ok := targets[id]
+		if !ok {
+			continue
+		}
+		// Skip backends that explicitly opt out of keepalive.
+		if target.KeepaliveMethod == vmcp.KeepaliveMethodNone {
+			slog.Debug("keepalive: disabled for backend", "backend_id", id)
+			continue
+		}
+		km.backends = append(km.backends, &backendKeepalive{
+			backendID: id,
+			conn:      conn,
+			target:    target,
+			cfg:       cfg,
+			metrics:   metrics,
+		})
+	}
+	return km
+}
+
+// Start launches background goroutines. ctx should be the session lifetime context.
+func (km *KeepaliveManager) Start(ctx context.Context) {
+	ctx, km.cancel = context.WithCancel(ctx)
+	for _, b := range km.backends {
+		km.wg.Add(1)
+		go func(bk *backendKeepalive) {
+			defer km.wg.Done()
+			bk.run(ctx)
+		}(b)
+	}
+}
+
+// Stop cancels all keepalive goroutines and waits for them to exit.
+func (km *KeepaliveManager) Stop() {
+	if km.cancel != nil {
+		km.cancel()
+	}
+	km.wg.Wait()
+}

--- a/pkg/vmcp/session/keepalive_test.go
+++ b/pkg/vmcp/session/keepalive_test.go
@@ -1,0 +1,294 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package session
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/metric/noop"
+
+	"github.com/stacklok/toolhive/pkg/vmcp"
+	internalbk "github.com/stacklok/toolhive/pkg/vmcp/session/internal/backend"
+)
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// fakeBackend is a minimal backend.Session that records Ping calls and can
+// be configured to fail.
+type fakeBackend struct {
+	pingCalls atomic.Int64
+	pingErr   error
+	pingErrFn func(n int) error // called with call number if non-nil
+	mockConnectedBackend
+}
+
+func (f *fakeBackend) Ping(_ context.Context) error {
+	n := int(f.pingCalls.Add(1))
+	if f.pingErrFn != nil {
+		return f.pingErrFn(n)
+	}
+	return f.pingErr
+}
+
+func testTarget(method vmcp.KeepaliveMethod) *vmcp.BackendTarget {
+	return &vmcp.BackendTarget{
+		WorkloadID:      "b1",
+		WorkloadName:    "b1",
+		BaseURL:         "http://localhost",
+		KeepaliveMethod: method,
+	}
+}
+
+func testMetrics(t *testing.T) *keepaliveMetrics {
+	t.Helper()
+	mp := noop.NewMeterProvider()
+	m, err := newKeepaliveMetrics(mp)
+	require.NoError(t, err)
+	return m
+}
+
+func buildBackendKeepalive(
+	conn internalbk.Session,
+	target *vmcp.BackendTarget,
+	cfg KeepaliveConfig,
+) *backendKeepalive {
+	return &backendKeepalive{
+		backendID: "b1",
+		conn:      conn,
+		target:    target,
+		cfg:       cfg,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tests: probe method dispatch
+// ---------------------------------------------------------------------------
+
+func TestKeepalive_PingUsedByDefault(t *testing.T) {
+	t.Parallel()
+
+	fb := &fakeBackend{}
+	bk := buildBackendKeepalive(fb, testTarget(""), KeepaliveConfig{})
+	bk.metrics = testMetrics(t)
+
+	ok, reason := bk.probe(context.Background())
+	assert.True(t, ok)
+	assert.Empty(t, reason)
+	assert.Equal(t, int64(1), fb.pingCalls.Load(), "ping should be called when method is empty (default)")
+}
+
+func TestKeepalive_ExplicitPing(t *testing.T) {
+	t.Parallel()
+
+	fb := &fakeBackend{}
+	bk := buildBackendKeepalive(fb, testTarget(vmcp.KeepaliveMethodPing), KeepaliveConfig{})
+	bk.metrics = testMetrics(t)
+
+	ok, _ := bk.probe(context.Background())
+	assert.True(t, ok)
+	assert.Equal(t, int64(1), fb.pingCalls.Load())
+}
+
+func TestKeepalive_NoneSkipsProbe(t *testing.T) {
+	t.Parallel()
+
+	fb := &fakeBackend{}
+	bk := buildBackendKeepalive(fb, testTarget(vmcp.KeepaliveMethodNone), KeepaliveConfig{})
+	bk.metrics = testMetrics(t)
+
+	ok, reason := bk.probe(context.Background())
+	assert.True(t, ok, "none should always return success (no-op)")
+	assert.Empty(t, reason)
+	assert.Equal(t, int64(0), fb.pingCalls.Load(), "no ping should be sent when method is none")
+}
+
+func TestKeepalive_FallbackToTool(t *testing.T) {
+	t.Parallel()
+
+	var callToolCalled atomic.Bool
+	fb := &fakeBackend{
+		mockConnectedBackend: mockConnectedBackend{
+			callToolFunc: func(_ context.Context, _ string, _, _ map[string]any) (*vmcp.ToolCallResult, error) {
+				callToolCalled.Store(true)
+				return &vmcp.ToolCallResult{}, nil
+			},
+		},
+	}
+	target := testTarget(vmcp.KeepaliveMethodTool)
+	target.KeepaliveToolName = "health-check"
+	bk := buildBackendKeepalive(fb, target, KeepaliveConfig{})
+	bk.metrics = testMetrics(t)
+
+	ok, reason := bk.probe(context.Background())
+	assert.True(t, ok)
+	assert.Empty(t, reason)
+	assert.True(t, callToolCalled.Load(), "CallTool should be used when method is tool")
+	assert.Equal(t, int64(0), fb.pingCalls.Load(), "ping must not be called when method is tool")
+}
+
+func TestKeepalive_ToolFallback_MissingToolName(t *testing.T) {
+	t.Parallel()
+
+	fb := &fakeBackend{}
+	target := testTarget(vmcp.KeepaliveMethodTool)
+	// KeepaliveToolName intentionally not set
+	bk := buildBackendKeepalive(fb, target, KeepaliveConfig{})
+	bk.metrics = testMetrics(t)
+
+	ok, reason := bk.probe(context.Background())
+	assert.False(t, ok)
+	assert.Equal(t, "keepalive_tool_name_not_configured", reason)
+}
+
+// ---------------------------------------------------------------------------
+// Tests: circuit breaker
+// ---------------------------------------------------------------------------
+
+func TestKeepalive_CircuitBreaker_TripsAfterNFailures(t *testing.T) {
+	t.Parallel()
+
+	pingErr := errors.New("backend gone")
+	fb := &fakeBackend{pingErr: pingErr}
+	cfg := KeepaliveConfig{MaxFailures: 3, ProbeAfter: time.Hour}
+	bk := buildBackendKeepalive(fb, testTarget(vmcp.KeepaliveMethodPing), cfg)
+	bk.metrics = testMetrics(t)
+
+	// First two ticks: failures but circuit still open.
+	bk.tick(context.Background())
+	bk.mu.Lock()
+	assert.False(t, bk.state.disabled, "circuit should not trip after 1 failure")
+	bk.mu.Unlock()
+
+	bk.tick(context.Background())
+	bk.mu.Lock()
+	assert.False(t, bk.state.disabled, "circuit should not trip after 2 failures")
+	bk.mu.Unlock()
+
+	// Third tick: trips the circuit.
+	bk.tick(context.Background())
+	bk.mu.Lock()
+	disabled := bk.state.disabled
+	bk.mu.Unlock()
+	assert.True(t, disabled, "circuit should trip after MaxFailures consecutive failures")
+}
+
+func TestKeepalive_CircuitBreaker_SkipsDuringQuietWindow(t *testing.T) {
+	t.Parallel()
+
+	fb := &fakeBackend{pingErr: errors.New("down")}
+	cfg := KeepaliveConfig{MaxFailures: 1, ProbeAfter: time.Hour}
+	bk := buildBackendKeepalive(fb, testTarget(vmcp.KeepaliveMethodPing), cfg)
+	bk.metrics = testMetrics(t)
+
+	// Trip the circuit.
+	bk.tick(context.Background())
+	bk.mu.Lock()
+	require.True(t, bk.state.disabled)
+	bk.mu.Unlock()
+
+	beforeCalls := fb.pingCalls.Load()
+
+	// Another tick while inside the quiet window — must not call probe.
+	bk.tick(context.Background())
+	assert.Equal(t, beforeCalls, fb.pingCalls.Load(), "ping must not be sent during quiet window")
+}
+
+func TestKeepalive_CircuitBreaker_ReEnablesAfterProbeWindow(t *testing.T) {
+	t.Parallel()
+
+	// Backend starts down, then recovers on the re-probe.
+	fb := &fakeBackend{
+		pingErrFn: func(n int) error {
+			if n == 1 {
+				return errors.New("down")
+			}
+			return nil // recovered
+		},
+	}
+	// Set ProbeAfter to a tiny value so we can advance state without real sleep.
+	cfg := KeepaliveConfig{MaxFailures: 1, ProbeAfter: time.Millisecond}
+	bk := buildBackendKeepalive(fb, testTarget(vmcp.KeepaliveMethodPing), cfg)
+	bk.metrics = testMetrics(t)
+
+	// Trip the circuit on first tick.
+	bk.tick(context.Background())
+	bk.mu.Lock()
+	require.True(t, bk.state.disabled)
+	// Back-date disabledAt so the probe window appears elapsed.
+	bk.state.disabledAt = time.Now().Add(-(cfg.ProbeAfter + time.Second))
+	bk.mu.Unlock()
+
+	// Second tick: probe window elapsed → re-enable and probe.
+	bk.tick(context.Background())
+	bk.mu.Lock()
+	disabled := bk.state.disabled
+	failures := bk.state.consecutiveFailures
+	bk.mu.Unlock()
+
+	assert.False(t, disabled, "circuit should re-enable after probe window")
+	assert.Equal(t, 0, failures, "consecutive failures should reset after successful probe")
+	assert.Equal(t, int64(2), fb.pingCalls.Load(), "exactly two pings should have been sent")
+}
+
+// ---------------------------------------------------------------------------
+// Tests: KeepaliveManager
+// ---------------------------------------------------------------------------
+
+func TestKeepaliveManager_NoneMethodExcludesBackend(t *testing.T) {
+	t.Parallel()
+
+	fb := &fakeBackend{}
+	target := testTarget(vmcp.KeepaliveMethodNone)
+	connections := map[string]internalbk.Session{"b1": fb}
+	targets := map[string]*vmcp.BackendTarget{"b1": target}
+
+	km := newKeepaliveManager(connections, targets, KeepaliveConfig{}, testMetrics(t))
+	assert.Empty(t, km.backends, "backend with method=none must be excluded from keepalive")
+}
+
+func TestKeepaliveManager_StartStop(t *testing.T) {
+	t.Parallel()
+
+	fb := &fakeBackend{}
+	target := testTarget(vmcp.KeepaliveMethodPing)
+	connections := map[string]internalbk.Session{"b1": fb}
+	targets := map[string]*vmcp.BackendTarget{"b1": target}
+
+	km := newKeepaliveManager(connections, targets, KeepaliveConfig{Interval: time.Hour}, testMetrics(t))
+	km.Start(context.Background())
+	km.Stop() // must not hang
+}
+
+func TestKeepaliveManager_StopCancelsGoroutines(t *testing.T) {
+	t.Parallel()
+
+	fb := &fakeBackend{}
+	target := testTarget(vmcp.KeepaliveMethodPing)
+	connections := map[string]internalbk.Session{"b1": fb}
+	targets := map[string]*vmcp.BackendTarget{"b1": target}
+
+	km := newKeepaliveManager(connections, targets, KeepaliveConfig{Interval: time.Hour}, testMetrics(t))
+	km.Start(context.Background())
+
+	done := make(chan struct{})
+	go func() {
+		km.Stop()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// passed
+	case <-time.After(2 * time.Second):
+		t.Fatal("KeepaliveManager.Stop() did not return within 2s")
+	}
+}

--- a/pkg/vmcp/types.go
+++ b/pkg/vmcp/types.go
@@ -67,9 +67,35 @@ type BackendTarget struct {
 	// HealthStatus indicates the current health of the backend.
 	HealthStatus BackendHealthStatus
 
+	// KeepaliveMethod sets the keepalive probe method for this backend.
+	// When empty, KeepaliveConfig.DefaultMethod is used; if that is also
+	// empty, keepalive is disabled for this backend.
+	KeepaliveMethod KeepaliveMethod
+
+	// KeepaliveToolName is the tool name to call when KeepaliveMethod is
+	// KeepaliveMethodTool. Ignored for other methods.
+	KeepaliveToolName string
+
 	// Metadata stores additional backend-specific information.
 	Metadata map[string]string
 }
+
+// KeepaliveMethod defines how keepalive probes are sent to a backend.
+type KeepaliveMethod string
+
+const (
+	// KeepaliveMethodPing uses the MCP protocol-level ping request. This is
+	// the default: it is side-effect-free and supported by all compliant servers.
+	KeepaliveMethodPing KeepaliveMethod = "ping"
+
+	// KeepaliveMethodTool invokes a low-cost tool specified in
+	// BackendTarget.KeepaliveToolName. Use this only when the backend does not
+	// support ping.
+	KeepaliveMethodTool KeepaliveMethod = "tool"
+
+	// KeepaliveMethodNone disables keepalive for this backend.
+	KeepaliveMethodNone KeepaliveMethod = "none"
+)
 
 // GetBackendCapabilityName returns the name to use when forwarding a request to the backend.
 // If conflict resolution renamed the capability, this returns the original name that the backend expects.


### PR DESCRIPTION

Closes: #3870

## Summary

Introduce per-backend keepalive probing with a circuit breaker to detect
and survive backend connection failures without terminating the vMCP session.

Fixes #3870 

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [x] Unit tests (\`task test\`)
- [ ] E2E tests (\`task test-e2e\`)
- [x] Linting (\`task lint-fix\`)
- [ ] Manual testing (describe below)

## Changes

pkg/vmcp/types.go — adds KeepaliveMethod type (ping, tool, none) and KeepaliveToolName field to BackendTarget
pkg/vmcp/session/keepalive.go — new KeepaliveManager with per-backend goroutines, configurable interval/jitter, circuit breaker (disable after N failures, re-probe after quiet window), and OTel metrics (vmcp_keepalive_attempt_total, vmcp_keepalive_success_total, vmcp_keepalive_failure_total, vmcp_keepalive_latency_seconds, vmcp_keepalive_auto_disabled_total)
pkg/vmcp/session/factory.go — wires KeepaliveManager into session creation via WithKeepaliveConfig and WithMeterProvider options; keepalive starts automatically when the factory is used (which itself is only constructed when SessionManagementV2 is enabled)
pkg/vmcp/session/default_session.go — stops keepalive goroutines in Close() before closing backend connections
pkg/vmcp/session/internal/backend/session.go and mcp_session.go — adds Ping(ctx) to the Session interface, delegating to client.Ping
pkg/vmcp/session/keepalive_test.go — 11 new unit tests covering probe dispatch, circuit breaker lifecycle, and manager start/stop

## Does this introduce a user-facing change?

Yes. When \`SessionManagementV2\` is enabled, the vMCP server now sends periodic keepalive probes to each connected backend. This is transparent to clients but affects backend traffic patterns and exposes new OTel metrics (\`vmcp_keepalive_*\`). The feature is inactive when \`SessionManagementV2\` is disabled.