### PR TITLE
Add optimizer composite tool E2E test with fake embedding server

### DIFF
--- a/test/e2e/thv-operator/virtualmcp/helpers.go
+++ b/test/e2e/thv-operator/virtualmcp/helpers.go
@@ -1290,3 +1290,142 @@ func CleanupMockHTTPServer(ctx context.Context, c client.Client, name, namespace
 		ObjectMeta: metav1.ObjectMeta{Name: configMapName, Namespace: namespace},
 	})
 }
+
+// fakeEmbeddingServerScript is a minimal Python HTTP server that mimics the
+// text-embeddings-inference (TEI) API. It provides:
+//   - GET /info  → {"max_client_batch_size": 32}
+//   - POST /embed → 384-dim constant vectors (one per input)
+//
+// This is sufficient for the optimizer because FTS5 keyword search works
+// without real embeddings, and the SQLite store stores the dummy embeddings
+// without errors.
+const fakeEmbeddingServerScript = `
+python3 -c '
+import json
+from http.server import HTTPServer, BaseHTTPRequestHandler
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path == "/info":
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(json.dumps({"max_client_batch_size": 32}).encode())
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def do_POST(self):
+        if self.path == "/embed":
+            length = int(self.headers.get("Content-Length", 0))
+            body = json.loads(self.rfile.read(length)) if length else {}
+            inputs = body.get("inputs", [])
+            n = len(inputs) if isinstance(inputs, list) else 1
+            embeddings = [[0.1] * 384 for _ in range(n)]
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(json.dumps(embeddings).encode())
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def log_message(self, format, *args):
+        pass  # suppress request logs
+
+HTTPServer(("0.0.0.0", 8080), Handler).serve_forever()
+'
+`
+
+// DeployFakeEmbeddingServer deploys a lightweight fake embedding server that
+// mimics the TEI API. This avoids pulling the heavyweight TEI container image
+// while satisfying the optimizer's embedding service requirement.
+// Returns the in-cluster service URL (http://<name>.<namespace>.svc.cluster.local:8080).
+func DeployFakeEmbeddingServer(
+	ctx context.Context,
+	c client.Client,
+	name, namespace string,
+	timeout, pollingInterval time.Duration,
+) string {
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    map[string]string{"app": name},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: int32Ptr(1),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": name},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app": name},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:    "fake-embedding",
+							Image:   images.PythonImage,
+							Command: []string{"sh", "-c"},
+							Args:    []string{fakeEmbeddingServerScript},
+							Ports: []corev1.ContainerPort{
+								{ContainerPort: 8080, Name: "http"},
+							},
+							ReadinessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									TCPSocket: &corev1.TCPSocketAction{
+										Port: intstr.FromInt(8080),
+									},
+								},
+								InitialDelaySeconds: 2,
+								PeriodSeconds:       2,
+								TimeoutSeconds:      5,
+								SuccessThreshold:    1,
+								FailureThreshold:    15,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	gomega.Expect(c.Create(ctx, deployment)).To(gomega.Succeed())
+
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{"app": name},
+			Ports: []corev1.ServicePort{
+				{
+					Port:       8080,
+					TargetPort: intstr.FromInt(8080),
+					Protocol:   corev1.ProtocolTCP,
+				},
+			},
+		},
+	}
+	gomega.Expect(c.Create(ctx, service)).To(gomega.Succeed())
+
+	ginkgo.By("Waiting for fake embedding server to be ready")
+	gomega.Eventually(func() bool {
+		dep := &appsv1.Deployment{}
+		err := c.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, dep)
+		return err == nil && dep.Status.ReadyReplicas > 0
+	}, timeout, pollingInterval).Should(gomega.BeTrue(), "Fake embedding server should be ready")
+
+	return fmt.Sprintf("http://%s.%s.svc.cluster.local:8080", name, namespace)
+}
+
+// CleanupFakeEmbeddingServer removes the fake embedding server Deployment and Service.
+func CleanupFakeEmbeddingServer(ctx context.Context, c client.Client, name, namespace string) {
+	_ = c.Delete(ctx, &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+	})
+	_ = c.Delete(ctx, &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+	})
+}

--- a/test/e2e/thv-operator/virtualmcp/virtualmcp_optimizer_composite_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcp_optimizer_composite_test.go
@@ -1,0 +1,265 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package virtualmcp
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	mcpv1alpha1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1alpha1"
+	thvjson "github.com/stacklok/toolhive/pkg/json"
+	vmcpconfig "github.com/stacklok/toolhive/pkg/vmcp/config"
+	"github.com/stacklok/toolhive/test/e2e/images"
+)
+
+// This test exercises composite tool execution through the optimizer's call_tool.
+// Without the fix in injectOptimizerCapabilities, composite tools are registered
+// with backend routing handlers (ToSDKTools) instead of workflow execution handlers
+// (ToCompositeToolSDKTools), causing call_tool to fail with ErrToolNotFound.
+//
+// A lightweight fake embedding server replaces the heavyweight TEI image to keep
+// test setup fast while satisfying the optimizer's embedding service requirement.
+var _ = Describe("VirtualMCPServer Optimizer Composite Tools", Ordered, func() {
+	var (
+		testNamespace     = "default"
+		mcpGroupName      = "test-opt-composite-group"
+		vmcpServerName    = "test-vmcp-opt-composite"
+		fakeEmbeddingName = "fake-embed-opt-composite"
+		backendName       = "backend-opt-composite"
+		// vmcpFetchToolName is the renamed fetch tool exposed through aggregation.
+		// Renaming lets us verify the optimizer respects the aggregation config.
+		vmcpFetchToolName        = "opt_composite_fetch"
+		vmcpFetchToolDescription = "Fetches a URL for the optimizer composite test."
+		backendFetchToolName     = "fetch"
+		compositeToolName        = "double_fetch"
+		timeout                  = 5 * time.Minute
+		pollingInterval          = 1 * time.Second
+		vmcpNodePort             int32
+	)
+
+	BeforeAll(func() {
+		By("Deploying fake embedding server")
+		embeddingURL := DeployFakeEmbeddingServer(ctx, k8sClient,
+			fakeEmbeddingName, testNamespace, timeout, pollingInterval)
+		_, _ = fmt.Fprintf(GinkgoWriter, "Fake embedding server at: %s\n", embeddingURL)
+
+		By("Creating MCPGroup")
+		CreateMCPGroupAndWait(ctx, k8sClient, mcpGroupName, testNamespace,
+			"MCP Group for optimizer composite E2E tests", timeout, pollingInterval)
+
+		By("Creating backend MCPServer - gofetch")
+		CreateMCPServerAndWait(ctx, k8sClient, backendName, testNamespace,
+			mcpGroupName, images.GofetchServerImage, timeout, pollingInterval)
+
+		By("Creating VirtualMCPServer with optimizer + composite tool")
+
+		stepArgs := map[string]interface{}{
+			"url": "{{.params.url}}",
+		}
+
+		vmcpServer := &mcpv1alpha1.VirtualMCPServer{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      vmcpServerName,
+				Namespace: testNamespace,
+			},
+			Spec: mcpv1alpha1.VirtualMCPServerSpec{
+				ServiceType: "NodePort",
+				IncomingAuth: &mcpv1alpha1.IncomingAuthConfig{
+					Type: "anonymous",
+				},
+				OutgoingAuth: &mcpv1alpha1.OutgoingAuthConfig{
+					Source: "discovered",
+				},
+				// Use embeddingService directly instead of EmbeddingServerRef
+				// to avoid depending on the heavyweight TEI image.
+				Config: vmcpconfig.Config{
+					Group: mcpGroupName,
+					Optimizer: &vmcpconfig.OptimizerConfig{
+						EmbeddingService: embeddingURL,
+					},
+					CompositeTools: []vmcpconfig.CompositeToolConfig{
+						{
+							Name:        compositeToolName,
+							Description: "Fetches a URL twice in sequence for verification",
+							Parameters: thvjson.NewMap(map[string]interface{}{
+								"type": "object",
+								"properties": map[string]interface{}{
+									"url": map[string]interface{}{
+										"type":        "string",
+										"description": "URL to fetch twice",
+									},
+								},
+								"required": []string{"url"},
+							}),
+							Steps: []vmcpconfig.WorkflowStepConfig{
+								{
+									ID:        "first_fetch",
+									Type:      "tool",
+									Tool:      vmcpFetchToolName,
+									Arguments: thvjson.NewMap(stepArgs),
+								},
+								{
+									ID:        "second_fetch",
+									Type:      "tool",
+									Tool:      vmcpFetchToolName,
+									DependsOn: []string{"first_fetch"},
+									Arguments: thvjson.NewMap(stepArgs),
+								},
+							},
+						},
+					},
+					Aggregation: &vmcpconfig.AggregationConfig{
+						ConflictResolution: "prefix",
+						Tools: []*vmcpconfig.WorkloadToolConfig{
+							{
+								Workload: backendName,
+								Overrides: map[string]*vmcpconfig.ToolOverride{
+									backendFetchToolName: {
+										Name:        vmcpFetchToolName,
+										Description: vmcpFetchToolDescription,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, vmcpServer)).To(Succeed())
+
+		By("Waiting for VirtualMCPServer to be ready")
+		WaitForVirtualMCPServerReady(ctx, k8sClient, vmcpServerName, testNamespace, timeout, pollingInterval)
+
+		By("Getting VirtualMCPServer NodePort")
+		vmcpNodePort = GetVMCPNodePort(ctx, k8sClient, vmcpServerName, testNamespace, timeout, pollingInterval)
+		_, _ = fmt.Fprintf(GinkgoWriter, "VirtualMCPServer is accessible at NodePort: %d\n", vmcpNodePort)
+	})
+
+	AfterAll(func() {
+		By("Cleaning up VirtualMCPServer")
+		vmcpServer := &mcpv1alpha1.VirtualMCPServer{}
+		if err := k8sClient.Get(ctx, types.NamespacedName{
+			Name:      vmcpServerName,
+			Namespace: testNamespace,
+		}, vmcpServer); err == nil {
+			_ = k8sClient.Delete(ctx, vmcpServer)
+		}
+
+		By("Cleaning up backend MCPServer")
+		backend := &mcpv1alpha1.MCPServer{}
+		if err := k8sClient.Get(ctx, types.NamespacedName{
+			Name:      backendName,
+			Namespace: testNamespace,
+		}, backend); err == nil {
+			_ = k8sClient.Delete(ctx, backend)
+		}
+
+		By("Cleaning up MCPGroup")
+		mcpGroup := &mcpv1alpha1.MCPGroup{}
+		if err := k8sClient.Get(ctx, types.NamespacedName{
+			Name:      mcpGroupName,
+			Namespace: testNamespace,
+		}, mcpGroup); err == nil {
+			_ = k8sClient.Delete(ctx, mcpGroup)
+		}
+
+		By("Cleaning up fake embedding server")
+		CleanupFakeEmbeddingServer(ctx, k8sClient, fakeEmbeddingName, testNamespace)
+	})
+
+	It("should only expose find_tool and call_tool", func() {
+		mcpClient, err := CreateInitializedMCPClient(vmcpNodePort, "opt-composite-list", 30*time.Second)
+		Expect(err).ToNot(HaveOccurred())
+		defer mcpClient.Close()
+
+		tools, err := mcpClient.Client.ListTools(mcpClient.Ctx, mcp.ListToolsRequest{})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(tools.Tools).To(HaveLen(2), "Should only have find_tool and call_tool")
+
+		toolNames := make([]string, len(tools.Tools))
+		for i, tool := range tools.Tools {
+			toolNames[i] = tool.Name
+		}
+		Expect(toolNames).To(ConsistOf("find_tool", "call_tool"))
+	})
+
+	It("should discover backend tool via find_tool", func() {
+		mcpClient, err := CreateInitializedMCPClient(vmcpNodePort, "opt-composite-find-backend", 30*time.Second)
+		Expect(err).ToNot(HaveOccurred())
+		defer mcpClient.Close()
+
+		findResult, err := callFindTool(mcpClient, vmcpFetchToolName)
+		Expect(err).ToNot(HaveOccurred())
+
+		foundTools := getToolNames(findResult)
+		Expect(foundTools).ToNot(BeEmpty(), "find_tool should discover backend tools")
+
+		found := false
+		for _, name := range foundTools {
+			if strings.Contains(name, vmcpFetchToolName) {
+				found = true
+				break
+			}
+		}
+		Expect(found).To(BeTrue(), "Should find the renamed backend fetch tool")
+		_, _ = fmt.Fprintf(GinkgoWriter, "Found backend tool in: %v\n", foundTools)
+	})
+
+	It("should discover composite tool via find_tool", func() {
+		mcpClient, err := CreateInitializedMCPClient(vmcpNodePort, "opt-composite-find-composite", 30*time.Second)
+		Expect(err).ToNot(HaveOccurred())
+		defer mcpClient.Close()
+
+		findResult, err := callFindTool(mcpClient, compositeToolName)
+		Expect(err).ToNot(HaveOccurred())
+
+		foundTools := getToolNames(findResult)
+		Expect(foundTools).ToNot(BeEmpty(), "find_tool should discover composite tools")
+
+		found := false
+		for _, name := range foundTools {
+			if strings.Contains(name, compositeToolName) {
+				found = true
+				break
+			}
+		}
+		Expect(found).To(BeTrue(), "Should find the composite tool")
+		_, _ = fmt.Fprintf(GinkgoWriter, "Found composite tool in: %v\n", foundTools)
+	})
+
+	It("should invoke backend tool via call_tool", func() {
+		mcpClient, err := CreateInitializedMCPClient(vmcpNodePort, "opt-composite-call-backend", 30*time.Second)
+		Expect(err).ToNot(HaveOccurred())
+		defer mcpClient.Close()
+
+		result, err := callToolViaOptimizer(mcpClient, vmcpFetchToolName, map[string]any{
+			"url": "https://example.com",
+		})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).ToNot(BeNil())
+		Expect(result.Content).ToNot(BeEmpty(), "call_tool should return content from backend tool")
+		_, _ = fmt.Fprintf(GinkgoWriter, "Successfully called backend tool via call_tool\n")
+	})
+
+	It("should invoke composite tool via call_tool", func() {
+		mcpClient, err := CreateInitializedMCPClient(vmcpNodePort, "opt-composite-call-composite", 30*time.Second)
+		Expect(err).ToNot(HaveOccurred())
+		defer mcpClient.Close()
+
+		result, err := callToolViaOptimizer(mcpClient, compositeToolName, map[string]any{
+			"url": "https://example.com",
+		})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).ToNot(BeNil())
+		Expect(result.Content).ToNot(BeEmpty(), "call_tool should return content from composite tool")
+		_, _ = fmt.Fprintf(GinkgoWriter, "Successfully called composite tool via call_tool\n")
+	})
+})


### PR DESCRIPTION
## Summary

I was paranoid that the optimizer and composite tools is something that would break during the migration to session v2, since composite tools are handled differently than MCPServers. This PR adds an integration test that ensures the two components are wired up correctly.


- Adds a new Ginkgo test suite ("Optimizer Composite Tools") that exercises composite tool discovery and invocation through the optimizer's `find_tool` and `call_tool` meta-tools using the fake embedding server.
- Adds `DeployFakeEmbeddingServer` / `CleanupFakeEmbeddingServer` helpers to `helpers.go` — a Python HTTP server mimicking the TEI `/info` and `/embed` endpoints, reusable by any test needing optimizer mode without TEI.


## Type of change

- [x] New feature

## Test plan

- [x] Manual testing (describe below)

Ran the new test suite against a local Kind cluster with `task operator-deploy-local`:

```
KUBECONFIG="$(pwd)/kconfig.yaml" ginkgo -v --fail-fast \
  --focus "Optimizer Composite" ./test/e2e/thv-operator/...
```

All 5 specs passed:
- `should only expose find_tool and call_tool`
- `should discover backend tool via find_tool`
- `should discover composite tool via find_tool`
- `should invoke backend tool via call_tool`
- `should invoke composite tool via call_tool`

## Changes

| File | Change |
|------|--------|
| `test/e2e/thv-operator/virtualmcp/helpers.go` | Add `DeployFakeEmbeddingServer`, `CleanupFakeEmbeddingServer` helpers and `fakeEmbeddingServerScript` constant |
| `test/e2e/thv-operator/virtualmcp/virtualmcp_optimizer_composite_test.go` | New Ginkgo test suite for optimizer composite tool discovery and invocation |

## Does this introduce a user-facing change?

No
