### PR TITLE
Re-panic http.ErrAbortHandler in recovery middleware

### DIFF
--- a/pkg/recovery/recovery.go
+++ b/pkg/recovery/recovery.go
@@ -23,6 +23,14 @@ func Middleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		defer func() {
 			if rec := recover(); rec != nil {
+				// Re-panic http.ErrAbortHandler so Go's HTTP server can
+				// handle it as designed (silently close the connection).
+				// ReverseProxy panics with this sentinel when a streaming
+				// response breaks mid-copy; catching it would log noisy
+				// stack traces and corrupt the already-in-flight response.
+				if rec == http.ErrAbortHandler {
+					panic(http.ErrAbortHandler)
+				}
 				stack := debug.Stack()
 				slog.Error(fmt.Sprintf("Panic recovered: %v\nStack trace:\n%s", rec, stack))
 				http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/pkg/recovery/recovery_test.go
+++ b/pkg/recovery/recovery_test.go
@@ -59,6 +59,27 @@ func TestRecoveryMiddleware_RecoverFromPanic(t *testing.T) {
 	assert.Contains(t, rec.Body.String(), "Internal Server Error")
 }
 
+func TestRecoveryMiddleware_RePanicsErrAbortHandler(t *testing.T) {
+	t.Parallel()
+
+	// Create a handler that panics with http.ErrAbortHandler, as
+	// httputil.ReverseProxy does when a streaming response breaks.
+	testHandler := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		panic(http.ErrAbortHandler)
+	})
+
+	wrappedHandler := Middleware(testHandler)
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	rec := httptest.NewRecorder()
+
+	// The middleware must re-panic http.ErrAbortHandler so Go's HTTP
+	// server can handle it (silently close the connection).
+	assert.PanicsWithValue(t, http.ErrAbortHandler, func() {
+		wrappedHandler.ServeHTTP(rec, req)
+	})
+}
+
 func TestRecoveryMiddleware_PreservesRequestContext(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- The recovery middleware catches all panics indiscriminately, including
  `http.ErrAbortHandler`. This is a sentinel that Go's `httputil.ReverseProxy`
  panics with intentionally when a streaming response breaks mid-copy
  (`reverseproxy.go:612`). Go's HTTP server has built-in handling for it:
  catch it silently, close the connection, move on.
- By intercepting this sentinel, the middleware logs noisy stack traces for
  normal proxy behavior, attempts to write a 500 to an already-in-flight
  response, and prevents Go's HTTP server from cleanly aborting the connection.
- Check for `http.ErrAbortHandler` and re-panic it, letting Go's HTTP server
  handle it as designed.

Fixes #4064

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)
- [x] Manual testing (describe below)

Deployed a local ToolHive build with this fix and tested with mcp-optimizer
traffic. Before the fix: 150 `abort Handler` panic stack traces in the log
over ~5 hours. After: zero.