### PR TITLE
Fix recovery middleware to not catch http.ErrAbortHandler

### DIFF
--- a/pkg/recovery/recovery.go
+++ b/pkg/recovery/recovery.go
@@ -23,6 +23,12 @@ func Middleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		defer func() {
 			if rec := recover(); rec != nil {
+				// Re-panic http.ErrAbortHandler to let Go's HTTP server handle it natively.
+				// This is a sentinel panic value used by httputil.ReverseProxy to cleanly
+				// abort streaming responses without logging or sending error responses.
+				if rec == http.ErrAbortHandler {
+					panic(rec)
+				}
 				stack := debug.Stack()
 				slog.Error(fmt.Sprintf("Panic recovered: %v\nStack trace:\n%s", rec, stack))
 				http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/pkg/recovery/recovery_test.go
+++ b/pkg/recovery/recovery_test.go
@@ -92,3 +92,30 @@ func TestRecoveryMiddleware_PreservesRequestContext(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.Equal(t, value, receivedValue)
 }
+
+func TestRecoveryMiddleware_RePanicsErrAbortHandler(t *testing.T) {
+	t.Parallel()
+
+	// Create a test handler that panics with http.ErrAbortHandler
+	testHandler := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		panic(http.ErrAbortHandler)
+	})
+
+	// Wrap with recovery middleware
+	wrappedHandler := Middleware(testHandler)
+
+	// Create test request
+	req := httptest.NewRequest("GET", "/test", nil)
+	rec := httptest.NewRecorder()
+
+	// Execute request - should re-panic http.ErrAbortHandler
+	defer func() {
+		recovered := recover()
+		assert.Equal(t, http.ErrAbortHandler, recovered, "http.ErrAbortHandler should be re-panicked")
+	}()
+
+	wrappedHandler.ServeHTTP(rec, req)
+
+	// If we reach here without re-panicking, the test should fail
+	t.Fatal("Expected http.ErrAbortHandler to be re-panicked, but it was not")
+}


### PR DESCRIPTION
## Summary

Fixes #4064

The recovery middleware (`pkg/recovery/recovery.go`) catches all panics indiscriminately, including `http.ErrAbortHandler`. This is a sentinel panic value that Go's `httputil.ReverseProxy` uses intentionally when a streaming response breaks mid-copy. By intercepting it, the middleware:

1. Logs noisy stack traces for something that isn't a bug
2. Tries to write `http.Error(w, "Internal Server Error", 500)` to an already-in-flight response, corrupting it
3. Prevents Go's HTTP server from cleanly aborting the connection

## Changes

- **`pkg/recovery/recovery.go`**: Added a check immediately after `recover()` to detect `http.ErrAbortHandler` and re-panic it before any logging or error response handling
- **`pkg/recovery/recovery_test.go`**: Added `TestRecoveryMiddleware_RePanicsErrAbortHandler` to verify the panic propagates correctly

## How it works

\`\`\`go
if rec == http.ErrAbortHandler {
    panic(rec) // re-panic to let Go's HTTP server handle it
}
\`\`\`

When `httputil.ReverseProxy` panics with `http.ErrAbortHandler` (to abort broken streaming responses), the recovery middleware now re-panics the value so Go's HTTP server can handle it natively by silently closing the connection.

## Testing

- Added unit test that verifies `http.ErrAbortHandler` panics propagate through the recovery middleware
- Regular panics continue to be caught and handled as before

## AI Disclosure

This contribution was developed with the assistance of Claude (AI by Anthropic). The implementation approach, code, and PR description were AI-assisted. All changes are focused on resolving the specific issue described above.

Co-Authored-By: AI Assistant (Claude) <ai-assistant@contributor-bot.dev>
Signed-off-by: ndpvt-web <ndpvt-web@users.noreply.github.com>