### PR TITLE
Strengthen session hijacking prevention types and tests

### DIFF
--- a/pkg/vmcp/server/session_management_v2_integration_test.go
+++ b/pkg/vmcp/server/session_management_v2_integration_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/stacklok/toolhive/pkg/vmcp/router"
 	"github.com/stacklok/toolhive/pkg/vmcp/server"
 	vmcpsession "github.com/stacklok/toolhive/pkg/vmcp/session"
+	sessiontypes "github.com/stacklok/toolhive/pkg/vmcp/session/types"
 )
 
 // ---------------------------------------------------------------------------
@@ -114,7 +115,7 @@ func (f *v2FakeMultiSessionFactory) MakeSession(
 
 	// Set basic metadata to indicate whether this is an anonymous session.
 	// Integration tests don't need to verify crypto implementation details.
-	allowAnonymous := vmcpsession.ShouldAllowAnonymous(identity)
+	allowAnonymous := sessiontypes.ShouldAllowAnonymous(identity)
 	if !allowAnonymous {
 		// Authenticated session - set non-empty hash placeholder
 		baseSession.SetMetadata(vmcpsession.MetadataKeyTokenHash, "fake-hash-for-testing")

--- a/pkg/vmcp/server/sessionmanager/session_manager.go
+++ b/pkg/vmcp/server/sessionmanager/session_manager.go
@@ -165,7 +165,7 @@ func (sm *Manager) CreateSession(
 	// Build the fully-formed MultiSession using the SDK-assigned session ID.
 	// Sessions created with an identity are bound to that identity (allowAnonymous=false).
 	// Sessions created without an identity allow anonymous access (allowAnonymous=true).
-	allowAnonymous := vmcpsession.ShouldAllowAnonymous(identity)
+	allowAnonymous := sessiontypes.ShouldAllowAnonymous(identity)
 	sess, err := sm.factory.MakeSessionWithID(ctx, sessionID, identity, allowAnonymous, backends)
 	if err != nil {
 		return nil, fmt.Errorf("Manager.CreateSession: failed to create multi-session: %w", err)

--- a/pkg/vmcp/session/internal/security/hijack_prevention_test.go
+++ b/pkg/vmcp/session/internal/security/hijack_prevention_test.go
@@ -43,15 +43,15 @@ func (m *mockSession) GetMetadata() map[string]string {
 }
 
 func (*mockSession) CallTool(_ context.Context, _ *auth.Identity, _ string, _ map[string]any, _ map[string]any) (*vmcp.ToolCallResult, error) {
-	return nil, nil
+	return &vmcp.ToolCallResult{}, nil
 }
 
 func (*mockSession) ReadResource(_ context.Context, _ *auth.Identity, _ string) (*vmcp.ResourceReadResult, error) {
-	return nil, nil
+	return &vmcp.ResourceReadResult{}, nil
 }
 
 func (*mockSession) GetPrompt(_ context.Context, _ *auth.Identity, _ string, _ map[string]any) (*vmcp.PromptGetResult, error) {
-	return nil, nil
+	return &vmcp.PromptGetResult{}, nil
 }
 
 func (*mockSession) Close() error { return nil }
@@ -148,51 +148,39 @@ func TestValidateCaller_EdgeCases(t *testing.T) {
 				hmacSecret:     testSecret,
 			}
 
-			// Test validateCaller directly on the decorator
-			err := decorator.validateCaller(tt.caller)
+			ctx := context.Background()
+
+			// Test all three decorated methods to verify validation is integrated correctly
+			toolResult, errCallTool := decorator.CallTool(ctx, tt.caller, "test-tool", nil, nil)
+			resourceResult, errReadResource := decorator.ReadResource(ctx, tt.caller, "test://uri")
+			promptResult, errGetPrompt := decorator.GetPrompt(ctx, tt.caller, "test-prompt", nil)
 
 			if tt.wantErr != nil {
-				require.Error(t, err)
-				assert.ErrorIs(t, err, tt.wantErr)
+				require.ErrorIs(t, errCallTool, tt.wantErr)
+				require.ErrorIs(t, errReadResource, tt.wantErr)
+				require.ErrorIs(t, errGetPrompt, tt.wantErr)
+				assert.Nil(t, toolResult)
+				assert.Nil(t, resourceResult)
+				assert.Nil(t, promptResult)
 			} else {
-				require.NoError(t, err)
+				require.NoError(t, errCallTool)
+				require.NoError(t, errReadResource)
+				require.NoError(t, errGetPrompt)
+				assert.NotNil(t, toolResult)
+				assert.NotNil(t, resourceResult)
+				assert.NotNil(t, promptResult)
 			}
 		})
 	}
 }
 
-// TestConcurrentValidation tests that validateCaller is safe for concurrent use.
-func TestConcurrentValidation(t *testing.T) {
+// TestPreventSessionHijacking_NilSession tests that a nil session is rejected before any method call.
+func TestPreventSessionHijacking_NilSession(t *testing.T) {
 	t.Parallel()
 
-	baseSession := newMockSession("test-session")
-
-	decorator := &hijackPreventionDecorator{
-		MultiSession:   baseSession,
-		allowAnonymous: false,
-		boundTokenHash: hashToken("test-token", testSecret, testTokenSalt),
-		tokenSalt:      testTokenSalt,
-		hmacSecret:     testSecret,
-	}
-
-	// Run validation concurrently from multiple goroutines
-	// Collect errors in channel to avoid race conditions with testify assertions
-	const numGoroutines = 10
-	errChan := make(chan error, numGoroutines)
-
-	for i := 0; i < numGoroutines; i++ {
-		go func() {
-			caller := &auth.Identity{Subject: "user", Token: "test-token"}
-			err := decorator.validateCaller(caller)
-			errChan <- err
-		}()
-	}
-
-	// Wait for all goroutines and assert in main goroutine (thread-safe)
-	for i := 0; i < numGoroutines; i++ {
-		err := <-errChan
-		assert.NoError(t, err, "concurrent validation should succeed")
-	}
+	decorated, err := PreventSessionHijacking(nil, testSecret, &auth.Identity{Subject: "user", Token: "test-token"})
+	require.Error(t, err)
+	assert.Nil(t, decorated)
 }
 
 // TestPreventSessionHijacking_BasicFunctionality tests the main entry point.

--- a/pkg/vmcp/session/internal/security/security.go
+++ b/pkg/vmcp/session/internal/security/security.go
@@ -222,21 +222,17 @@ func (d hijackPreventionDecorator) GetPrompt(
 //   - Raw tokens are never stored, only HMAC-SHA256 hashes
 //
 // Returns an error if:
-//   - session doesn't implement sessiontypes.MultiSession interface
+//   - session is nil
 //   - salt generation fails
 func PreventSessionHijacking(
-	session interface{},
+	session sessiontypes.MultiSession,
 	hmacSecret []byte,
 	identity *auth.Identity,
 ) (sessiontypes.MultiSession, error) {
-	allowAnonymous := identity == nil || identity.Token == ""
-	// Validate upfront that session implements the MultiSession interface.
-	// This provides fail-fast behavior for security-critical operations
-	// instead of panics at runtime.
-	multiSession, ok := session.(sessiontypes.MultiSession)
-	if !ok {
-		return nil, fmt.Errorf("session must implement sessiontypes.MultiSession interface, got %T", session)
+	if session == nil {
+		return nil, fmt.Errorf("session must not be nil")
 	}
+	allowAnonymous := sessiontypes.ShouldAllowAnonymous(identity)
 
 	// Note: Pass-through methods (ID, Type, CreatedAt, etc.) are validated by the
 	// type system when the decorator is used. We don't validate them here to keep
@@ -259,9 +255,9 @@ func PreventSessionHijacking(
 
 	// Store hash and salt in session metadata for persistence, auditing,
 	// and backward compatibility
-	multiSession.SetMetadata(metadataKeyTokenHash, boundTokenHash)
+	session.SetMetadata(metadataKeyTokenHash, boundTokenHash)
 	if len(tokenSalt) > 0 {
-		multiSession.SetMetadata(metadataKeyTokenSalt, hex.EncodeToString(tokenSalt))
+		session.SetMetadata(metadataKeyTokenSalt, hex.EncodeToString(tokenSalt))
 	}
 
 	// Make defensive copies of slices to prevent external mutation
@@ -277,7 +273,7 @@ func PreventSessionHijacking(
 	// The decorator embeds the MultiSession interface, so all methods are automatically
 	// delegated except for the three we override (CallTool, ReadResource, GetPrompt).
 	return &hijackPreventionDecorator{
-		MultiSession:   multiSession,
+		MultiSession:   session,
 		allowAnonymous: allowAnonymous,
 		hmacSecret:     hmacSecretCopy,
 		boundTokenHash: boundTokenHash,

--- a/pkg/vmcp/session/internal/security/security_test.go
+++ b/pkg/vmcp/session/internal/security/security_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/stacklok/toolhive/pkg/auth"
-	"github.com/stacklok/toolhive/pkg/vmcp/session"
+	sessiontypes "github.com/stacklok/toolhive/pkg/vmcp/session/types"
 )
 
 // TestShouldAllowAnonymous_EdgeCases tests the ShouldAllowAnonymous helper.
@@ -46,7 +46,7 @@ func TestShouldAllowAnonymous_EdgeCases(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got := session.ShouldAllowAnonymous(tt.identity)
+			got := sessiontypes.ShouldAllowAnonymous(tt.identity)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/vmcp/session/session.go
+++ b/pkg/vmcp/session/session.go
@@ -4,7 +4,6 @@
 package session
 
 import (
-	"github.com/stacklok/toolhive/pkg/auth"
 	sessiontypes "github.com/stacklok/toolhive/pkg/vmcp/session/types"
 )
 
@@ -20,21 +19,10 @@ const (
 	//
 	// Re-exported from types package for convenience.
 	MetadataKeyTokenHash = sessiontypes.MetadataKeyTokenHash
-)
 
-// ShouldAllowAnonymous determines if a session should allow anonymous access
-// based on the creator's identity. This is session business logic that decides
-// whether a session is bound to a specific identity or allows anonymous access.
-//
-// Sessions without an identity (nil) or with an empty token are treated as
-// anonymous and will only accept nil callers or callers with an empty token;
-// callers presenting a non-empty token are rejected to prevent session-upgrade
-// attacks. Sessions with a non-empty bearer token are bound to that token and
-// will reject requests from callers with a different token.
-//
-// This function is used by both the session factory (to determine how to create
-// the session) and the security layer (to validate requests against the session's
-// access policy).
-func ShouldAllowAnonymous(identity *auth.Identity) bool {
-	return identity == nil || identity.Token == ""
-}
+	// MetadataKeyTokenSalt is the session metadata key that holds the hex-encoded
+	// random salt used for HMAC-SHA256 token hashing. Omitted for anonymous sessions.
+	//
+	// Re-exported from types package for convenience.
+	MetadataKeyTokenSalt = sessiontypes.MetadataKeyTokenSalt
+)

--- a/pkg/vmcp/session/types/session.go
+++ b/pkg/vmcp/session/types/session.go
@@ -146,6 +146,13 @@ const (
 	MetadataKeyTokenSalt = "vmcp.token.salt" //nolint:gosec // This is a metadata key name, not a credential.
 )
 
+// ShouldAllowAnonymous determines if a session should allow anonymous access
+// based on the creator's identity. Sessions without an identity (nil) or with
+// an empty token are treated as anonymous.
+func ShouldAllowAnonymous(identity *auth.Identity) bool {
+	return identity == nil || identity.Token == ""
+}
+
 // Token binding errors returned by Caller methods when caller identity
 // validation fails.
 var (


### PR DESCRIPTION
## Summary

- Change PreventSessionHijacking to accept sessiontypes.MultiSession directly instead of interface{}, enforcing the contract at compile time and removing the runtime type assertion
- Update tests to call the decorated methods (CallTool, ReadResource, GetPrompt) rather than the internal validateCaller, verifying that validation is correctly integrated end-to-end
- Remove TestConcurrentValidation as the decorator holds no mutable state, making a concurrency test unnecessary

<!--
REQUIRED. You MUST explain:
1. WHY this change is needed (the problem or motivation)
2. WHAT changed (concise bullet points)

The diff shows the code — your summary must provide the context a reviewer
needs to understand the purpose without reading the diff first.
-->

-

<!--
Link related issues. Use "Closes" or "Fixes" to auto-close on merge.
Remove this line if there is no related issue.
-->

Fixes #3867 

## Type of change

<!-- REQUIRED. Check exactly one. -->

- [ ] Bug fix
- [ ] New feature
- [x] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

<!--
REQUIRED. Check every verification step you actually ran.
You MUST check at least one item. If you only did manual testing,
describe exactly what you tested below the checkbox.
-->

- [ ] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [ ] Linting (`task lint-fix`)
- [ ] Manual testing (describe below)

## Changes

Affected: pkg/vmcp/session/internal/security
<!--
Optional — include for PRs touching more than a few files to help
reviewers navigate the diff. Remove this entire section for small PRs.
-->

| File | Change |
|------|--------|
|      |        |

## Does this introduce a user-facing change?

<!--
If yes, describe the change from the user's perspective. This helps with release notes.
If no, write "No".
Remove this section entirely if not applicable.
-->

## Special notes for reviewers

<!--
Optional — call out anything non-obvious: tricky logic, known limitations,
areas where you'd like extra scrutiny, or follow-up work planned.
Remove this section if not needed.
-->
