### PR TITLE
Fix CI build failures on main

### DIFF
--- a/pkg/vmcp/discovery/middleware.go
+++ b/pkg/vmcp/discovery/middleware.go
@@ -45,6 +45,7 @@ const (
 // middlewareConfig holds optional configuration for Middleware.
 type middlewareConfig struct {
 	sessionScopedRouting bool
+	timeout              time.Duration
 }
 
 // MiddlewareOption configures Middleware behaviour.
@@ -57,6 +58,13 @@ type MiddlewareOption func(*middlewareConfig)
 func WithSessionScopedRouting() MiddlewareOption {
 	return func(c *middlewareConfig) {
 		c.sessionScopedRouting = true
+	}
+}
+
+// WithDiscoveryTimeout overrides the default discovery timeout.
+func WithDiscoveryTimeout(timeout time.Duration) MiddlewareOption {
+	return func(c *middlewareConfig) {
+		c.timeout = timeout
 	}
 }
 
@@ -84,7 +92,9 @@ func Middleware(
 	healthStatusProvider health.StatusProvider,
 	opts ...MiddlewareOption,
 ) func(http.Handler) http.Handler {
-	cfg := middlewareConfig{}
+	cfg := middlewareConfig{
+		timeout: discoveryTimeout,
+	}
 	for _, o := range opts {
 		o(&cfg)
 	}
@@ -102,7 +112,7 @@ func Middleware(
 					return
 				}
 				// Initialize request: discover and cache capabilities in session.
-				ctx, err = handleInitializeRequest(ctx, r, manager, registry, healthStatusProvider)
+				ctx, err = handleInitializeRequest(ctx, r, manager, registry, healthStatusProvider, cfg.timeout)
 			} else {
 				// Subsequent request: retrieve cached capabilities from session.
 				ctx, err = handleSubsequentRequest(ctx, r, sessionID, sessionManager)
@@ -207,8 +217,9 @@ func handleInitializeRequest(
 	manager Manager,
 	registry vmcp.BackendRegistry,
 	healthStatusProvider health.StatusProvider,
+	timeout time.Duration,
 ) (context.Context, error) {
-	discoveryCtx, cancel := context.WithTimeout(ctx, discoveryTimeout)
+	discoveryCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	// Get current backend list from registry (supports dynamic backend changes)

--- a/pkg/vmcp/discovery/middleware_test.go
+++ b/pkg/vmcp/discovery/middleware_test.go
@@ -479,6 +479,8 @@ func TestMiddleware_ContextTimeoutHandling(t *testing.T) {
 		{ID: "backend1", Name: "Backend 1", HealthStatus: vmcp.BackendHealthy},
 	}
 
+	testTimeout := 100 * time.Millisecond
+
 	// Simulate slow discovery that takes longer than timeout
 	mockMgr.EXPECT().
 		Discover(gomock.Any(), backends).
@@ -486,16 +488,13 @@ func TestMiddleware_ContextTimeoutHandling(t *testing.T) {
 			// Verify timeout context is set
 			deadline, ok := ctx.Deadline()
 			assert.True(t, ok, "context should have a deadline")
-			assert.True(t, time.Until(deadline) <= discoveryTimeout, "timeout should be set correctly")
+			assert.True(t, time.Until(deadline) <= testTimeout, "timeout should be set correctly")
 
 			// Simulate slow operation that exceeds the timeout
-			// The 15-second timeout will expire before this 20-second sleep completes
 			select {
 			case <-ctx.Done():
-				// Context was cancelled (either timeout or cancellation)
 				return nil, ctx.Err()
-			case <-time.After(20 * time.Second):
-				// This should never be reached because context times out first
+			case <-time.After(5 * time.Second):
 				return nil, errors.New("operation completed without timeout")
 			}
 		})
@@ -505,7 +504,7 @@ func TestMiddleware_ContextTimeoutHandling(t *testing.T) {
 	})
 
 	backendRegistry := vmcp.NewImmutableRegistry(backends)
-	middleware := Middleware(mockMgr, backendRegistry, createTestSessionManager(t), nil)
+	middleware := Middleware(mockMgr, backendRegistry, createTestSessionManager(t), nil, WithDiscoveryTimeout(testTimeout))
 	wrappedHandler := middleware(testHandler)
 
 	// Initialize request (no session ID) - discovery should happen

--- a/pkg/vmcp/session/sessionv2_integration_test.go
+++ b/pkg/vmcp/session/sessionv2_integration_test.go
@@ -488,7 +488,7 @@ func TestSessionManagementV2_MetadataEncoding(t *testing.T) {
 	assert.Len(t, hashBytes, 32, "decoded token hash should be 32 bytes (SHA256)")
 
 	// Get token salt from session metadata
-	tokenSalt := sess.GetMetadata()[MetadataKeyTokenSalt]
+	tokenSalt := sess.GetMetadata()[sessiontypes.MetadataKeyTokenSalt]
 	require.NotEmpty(t, tokenSalt)
 
 	// Verify salt is valid hex encoding


### PR DESCRIPTION
## Summary

- The main build broke after e783bf54 ("Automate HMAC secret management") due to a missing package prefix on `MetadataKeyTokenSalt` in `sessionv2_integration_test.go`, causing a typecheck lint failure that cascaded into test compilation failures for dependent packages.
- `TestMiddleware_ContextTimeoutHandling` hard-coded a 15-second wait for the `discoveryTimeout` constant, making it slow and fragile. Made the timeout injectable via `WithDiscoveryTimeout` middleware option so the test uses 100ms instead.

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)

## Does this introduce a user-facing change?

No

Generated with [Claude Code](https://claude.com/claude-code)
