### PR TITLE
Fix CI failures from typecheck error and flaky keyctl test

### DIFF
--- a/pkg/secrets/keyring/keyctl_linux.go
+++ b/pkg/secrets/keyring/keyctl_linux.go
@@ -6,6 +6,7 @@
 package keyring
 
 import (
+	"errors"
 	"fmt"
 	"sync"
 
@@ -71,6 +72,11 @@ func (k *keyctlProvider) Get(service, key string) (string, error) {
 	buf := make([]byte, bufSize)
 	readBytes, err := unix.KeyctlBuffer(unix.KEYCTL_READ, keyID, buf, bufSize)
 	if err != nil {
+		// If the key was revoked or expired (e.g. after DeleteAll), treat it as not found.
+		// The kernel may still return the key in a search briefly after KEYCTL_UNLINK + KEYCTL_REVOKE.
+		if errors.Is(err, unix.EKEYREVOKED) || errors.Is(err, unix.EKEYEXPIRED) {
+			return "", ErrNotFound
+		}
 		return "", fmt.Errorf("read of key '%s' failed: %w", keyName, err)
 	}
 

--- a/pkg/vmcp/session/sessionv2_integration_test.go
+++ b/pkg/vmcp/session/sessionv2_integration_test.go
@@ -488,7 +488,7 @@ func TestSessionManagementV2_MetadataEncoding(t *testing.T) {
 	assert.Len(t, hashBytes, 32, "decoded token hash should be 32 bytes (SHA256)")
 
 	// Get token salt from session metadata
-	tokenSalt := sess.GetMetadata()[MetadataKeyTokenSalt]
+	tokenSalt := sess.GetMetadata()[sessiontypes.MetadataKeyTokenSalt]
 	require.NotEmpty(t, tokenSalt)
 
 	// Verify salt is valid hex encoding


### PR DESCRIPTION
## Summary

CI on main is broken after the HMAC secret management merge (e783bf54). This PR fixes two issues causing the lint and test jobs to fail:

1. **Typecheck error**: `sessionv2_integration_test.go` referenced `MetadataKeyTokenSalt` without the `sessiontypes.` package qualifier, failing golangci-lint's typecheck and preventing the session package tests from compiling. The compilation failure also cascaded into a test reporter panic (`BUG: Empty package name encountered`), causing false-positive test failures.

2. **Flaky keyctl test**: After `DeleteAll` unlinks and revokes a kernel keyring key, `KeyctlSearch` may still briefly return the key. The `Get` method now returns `ErrNotFound` for `EKEYREVOKED`/`EKEYEXPIRED` read errors instead of a generic failure, making the delete-then-get pattern reliable.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test plan

- [x] Verified session package compiles with `go vet ./pkg/vmcp/session/...`
- [x] Verified session tests compile with `go test -run=^$ -count=0 ./pkg/vmcp/session/...`
- [ ] CI lint job passes
- [ ] CI test job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)