### PR TITLE
Fix flaky E2E tests caused by port allocation race condition

### DIFF
--- a/pkg/api/v1/workload_service.go
+++ b/pkg/api/v1/workload_service.go
@@ -8,8 +8,10 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"time"
 
+	"github.com/stacklok/toolhive-core/httperr"
 	regtypes "github.com/stacklok/toolhive-core/registry/types"
 	groupval "github.com/stacklok/toolhive-core/validation/group"
 	httpval "github.com/stacklok/toolhive-core/validation/http"
@@ -74,13 +76,19 @@ func (s *WorkloadService) CreateWorkloadFromRequest(ctx context.Context, req *cr
 	// Save the workload state
 	if err := runConfig.SaveState(ctx); err != nil {
 		slog.Error("failed to save workload config", "error", err)
-		return nil, fmt.Errorf("failed to save workload config: %w", err)
+		return nil, httperr.WithCode(
+			fmt.Errorf("failed to save workload config: %w", err),
+			http.StatusInternalServerError,
+		)
 	}
 
 	// Start workload
 	if err := s.workloadManager.RunWorkloadDetached(ctx, runConfig); err != nil {
 		slog.Error("failed to start workload", "error", err)
-		return nil, fmt.Errorf("failed to start workload: %w", err)
+		return nil, httperr.WithCode(
+			fmt.Errorf("failed to start workload: %w", err),
+			http.StatusInternalServerError,
+		)
 	}
 
 	return runConfig, nil
@@ -331,6 +339,13 @@ func (s *WorkloadService) BuildFullRunConfig(
 	runConfig, err := runner.NewRunConfigBuilder(ctx, imageMetadata, req.EnvVars, &runner.DetachedEnvVarValidator{}, options...)
 	if err != nil {
 		slog.Error("failed to build run config", "error", err)
+		// Map domain errors to HTTP status codes
+		if errors.Is(err, runner.ErrPortUnavailable) {
+			return nil, httperr.WithCode(
+				fmt.Errorf("%w: %w", retriever.ErrInvalidRunConfig, err),
+				http.StatusServiceUnavailable,
+			)
+		}
 		return nil, fmt.Errorf("%w: Failed to build run config: %w", retriever.ErrInvalidRunConfig, err)
 	}
 

--- a/pkg/networking/port.go
+++ b/pkg/networking/port.go
@@ -11,8 +11,20 @@ import (
 	"log/slog"
 	"math/big"
 	"net"
+	"sync"
+	"time"
 
 	gopsutilnet "github.com/shirou/gopsutil/v4/net"
+)
+
+var (
+	// portMu protects recentlyAllocated from concurrent access
+	portMu sync.Mutex
+	// recentlyAllocated tracks ports returned by FindAvailable/FindOrUsePort
+	// to prevent TOCTOU races when multiple goroutines allocate ports concurrently.
+	recentlyAllocated = map[int]time.Time{}
+	// portReservationTTL is how long a port stays reserved in recentlyAllocated
+	portReservationTTL = 30 * time.Second
 )
 
 const (
@@ -94,8 +106,15 @@ func IsIPv6Available() bool {
 	return false
 }
 
-// FindAvailable finds an available port
+// FindAvailable finds an available port.
+// It holds a process-level lock while checking availability and records the
+// port so that concurrent callers cannot receive the same port.
 func FindAvailable() int {
+	portMu.Lock()
+	defer portMu.Unlock()
+
+	purgeExpiredReservations()
+
 	for i := 0; i < MaxAttempts; i++ {
 		// Generate a cryptographically secure random number
 		n, err := rand.Int(rand.Reader, big.NewInt(int64(MaxPort-MinPort)))
@@ -104,14 +123,22 @@ func FindAvailable() int {
 			break
 		}
 		port := int(n.Int64()) + MinPort
+		if _, reserved := recentlyAllocated[port]; reserved {
+			continue
+		}
 		if IsAvailable(port) {
+			recentlyAllocated[port] = time.Now()
 			return port
 		}
 	}
 
 	// If we can't find a random port, try sequential ports
 	for port := MinPort; port <= MaxPort; port++ {
+		if _, reserved := recentlyAllocated[port]; reserved {
+			continue
+		}
 		if IsAvailable(port) {
+			recentlyAllocated[port] = time.Now()
 			return port
 		}
 	}
@@ -126,7 +153,7 @@ func FindAvailable() int {
 // Returns the selected port and an error if any.
 func FindOrUsePort(port int) (int, error) {
 	if port == 0 {
-		// Find an available port
+		// Find an available port (FindAvailable handles its own locking)
 		port = FindAvailable()
 		if port == 0 {
 			return 0, fmt.Errorf("could not find an available port")
@@ -134,16 +161,44 @@ func FindOrUsePort(port int) (int, error) {
 		return port, nil
 	}
 
-	if IsAvailable(port) {
+	portMu.Lock()
+	defer portMu.Unlock()
+	purgeExpiredReservations()
+
+	if _, reserved := recentlyAllocated[port]; !reserved && IsAvailable(port) {
+		recentlyAllocated[port] = time.Now()
 		return port, nil
 	}
 
-	// Requested port is busy — find an alternative
-	alt := FindAvailable()
-	if alt == 0 {
-		return 0, fmt.Errorf("failed to find an alternative port after requested port %d was unavailable", port)
+	// Requested port is busy — find an alternative without holding lock twice.
+	// We inline the search here since FindAvailable also takes the lock.
+	for i := 0; i < MaxAttempts; i++ {
+		n, err := rand.Int(rand.Reader, big.NewInt(int64(MaxPort-MinPort)))
+		if err != nil {
+			break
+		}
+		alt := int(n.Int64()) + MinPort
+		if _, reserved := recentlyAllocated[alt]; reserved {
+			continue
+		}
+		if IsAvailable(alt) {
+			recentlyAllocated[alt] = time.Now()
+			return alt, nil
+		}
 	}
-	return alt, nil
+
+	return 0, fmt.Errorf("failed to find an alternative port after requested port %d was unavailable", port)
+}
+
+// purgeExpiredReservations removes entries older than portReservationTTL.
+// Must be called with portMu held.
+func purgeExpiredReservations() {
+	cutoff := time.Now().Add(-portReservationTTL)
+	for p, t := range recentlyAllocated {
+		if t.Before(cutoff) {
+			delete(recentlyAllocated, p)
+		}
+	}
 }
 
 // ValidateCallbackPort validates that the specified callback port is valid and available.

--- a/pkg/runner/config.go
+++ b/pkg/runner/config.go
@@ -7,6 +7,7 @@ package runner
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -38,6 +39,9 @@ import (
 // CurrentSchemaVersion is the current version of the RunConfig schema
 // TODO: Set to "v1.0.0" when we clean up the middleware configuration.
 const CurrentSchemaVersion = "v0.1.0"
+
+// ErrPortUnavailable indicates that a requested or required port is not available.
+var ErrPortUnavailable = errors.New("port unavailable")
 
 // RunConfig contains all the configuration needed to run an MCP server
 // It is serializable to JSON and YAML
@@ -403,7 +407,7 @@ func (c *RunConfig) WithPorts(proxyPort, targetPort int) (*RunConfig, error) {
 			slog.Debug("reusing existing port", "port", proxyPort)
 			selectedPort = proxyPort
 		} else if !networking.IsAvailable(proxyPort) {
-			return c, fmt.Errorf("requested proxy port %d is not available", proxyPort)
+			return c, fmt.Errorf("%w: requested proxy port %d is not available", ErrPortUnavailable, proxyPort)
 		} else {
 			slog.Debug("using requested port", "port", proxyPort)
 			selectedPort = proxyPort
@@ -412,7 +416,7 @@ func (c *RunConfig) WithPorts(proxyPort, targetPort int) (*RunConfig, error) {
 		// Otherwise - pick a random available port.
 		selectedPort, err = networking.FindOrUsePort(proxyPort)
 		if err != nil {
-			return c, err
+			return c, fmt.Errorf("%w: %w", ErrPortUnavailable, err)
 		}
 	}
 	c.Port = selectedPort
@@ -421,7 +425,7 @@ func (c *RunConfig) WithPorts(proxyPort, targetPort int) (*RunConfig, error) {
 	if c.Transport == types.TransportTypeSSE || c.Transport == types.TransportTypeStreamableHTTP {
 		selectedTargetPort, err := networking.FindOrUsePort(targetPort)
 		if err != nil {
-			return c, fmt.Errorf("target port error: %w", err)
+			return c, fmt.Errorf("%w: target port error: %w", ErrPortUnavailable, err)
 		}
 		slog.Debug("using target port", "port", selectedTargetPort)
 		c.TargetPort = selectedTargetPort

--- a/test/e2e/api_workload_lifecycle_test.go
+++ b/test/e2e/api_workload_lifecycle_test.go
@@ -754,7 +754,7 @@ var _ = Describe("Workload Lifecycle API", Label("api", "api-workloads", "worklo
 				deleteGroup(apiServer, groupName)
 			})
 
-			It("should stop all workloads in a group", func() {
+			It("should stop all workloads in a group", NodeTimeout(5*time.Minute), func(_ SpecContext) {
 				By("Creating a test group")
 				createReq := map[string]interface{}{"name": groupName}
 				groupResp := createGroup(apiServer, createReq)
@@ -779,7 +779,7 @@ var _ = Describe("Workload Lifecycle API", Label("api", "api-workloads", "worklo
 						"image": "osv",
 						"group": groupName,
 					}
-					resp := createWorkload(apiServer, createReq)
+					resp := createWorkloadWithRetry(apiServer, createReq)
 					resp.Body.Close()
 					Expect(resp.StatusCode).To(Equal(http.StatusCreated))
 				}
@@ -1047,7 +1047,7 @@ var _ = Describe("Workload Lifecycle API", Label("api", "api-workloads", "worklo
 				}, 60*time.Second, 2*time.Second).Should(Equal(len(workloadNames)))
 			})
 
-			It("should restart stopped workloads in a group", func() {
+			It("should restart stopped workloads in a group", NodeTimeout(5*time.Minute), func(_ SpecContext) {
 				By("Creating a test group")
 				createReq := map[string]interface{}{"name": groupName}
 				groupResp := createGroup(apiServer, createReq)
@@ -1071,7 +1071,7 @@ var _ = Describe("Workload Lifecycle API", Label("api", "api-workloads", "worklo
 						"image": "osv",
 						"group": groupName,
 					}
-					resp := createWorkload(apiServer, createReq)
+					resp := createWorkloadWithRetry(apiServer, createReq)
 					resp.Body.Close()
 					Expect(resp.StatusCode).To(Equal(http.StatusCreated))
 				}
@@ -1196,14 +1196,14 @@ var _ = Describe("Workload Lifecycle API", Label("api", "api-workloads", "worklo
 		// Note: Workload cleanup handled by suite-level CLI cleanup
 
 		Context("when deleting workloads in bulk", func() {
-			It("should delete multiple workloads", func() {
+			It("should delete multiple workloads", NodeTimeout(5*time.Minute), func(_ SpecContext) {
 				By("Creating multiple workloads")
 				for _, name := range workloadNames {
 					createReq := map[string]interface{}{
 						"name":  name,
 						"image": "osv",
 					}
-					resp := createWorkload(apiServer, createReq)
+					resp := createWorkloadWithRetry(apiServer, createReq)
 					resp.Body.Close()
 					Expect(resp.StatusCode).To(Equal(http.StatusCreated))
 				}

--- a/test/e2e/api_workloads_test.go
+++ b/test/e2e/api_workloads_test.go
@@ -19,6 +19,11 @@ import (
 	"github.com/stacklok/toolhive/test/e2e"
 )
 
+const (
+	createWorkloadRetryAttempts = 3
+	createWorkloadRetryBackoff  = 2 * time.Second
+)
+
 var _ = Describe("Workloads API", Label("api", "api-workloads", "workloads", "e2e"), func() {
 	var (
 		config    *e2e.ServerConfig
@@ -576,6 +581,35 @@ func createWorkload(server *e2e.Server, request map[string]interface{}) *http.Re
 	resp, err := http.DefaultClient.Do(req)
 	ExpectWithOffset(1, err).ToNot(HaveOccurred(), "Should be able to send HTTP request")
 
+	// Log response body on unexpected status for CI debugging
+	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusBadRequest &&
+		resp.StatusCode != http.StatusConflict && resp.StatusCode != http.StatusNotFound {
+		bodyBytes, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		GinkgoWriter.Printf("createWorkload: unexpected status %d, body: %s\n", resp.StatusCode, string(bodyBytes))
+		// Re-wrap body so callers can still read it
+		resp.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+	}
+
+	return resp
+}
+
+// createWorkloadWithRetry retries workload creation on 5xx responses.
+// This handles transient failures like port allocation races during bulk operations.
+func createWorkloadWithRetry(server *e2e.Server, request map[string]interface{}) *http.Response {
+	var resp *http.Response
+	for attempt := 1; attempt <= createWorkloadRetryAttempts; attempt++ {
+		resp = createWorkload(server, request)
+		if resp.StatusCode < 500 {
+			return resp
+		}
+		GinkgoWriter.Printf("createWorkloadWithRetry: attempt %d/%d got %d, retrying after backoff\n",
+			attempt, createWorkloadRetryAttempts, resp.StatusCode)
+		resp.Body.Close()
+		if attempt < createWorkloadRetryAttempts {
+			time.Sleep(createWorkloadRetryBackoff)
+		}
+	}
 	return resp
 }
 


### PR DESCRIPTION
## Summary

- E2E Tests Core jobs are flaky on main, failing across consecutive CI runs with HTTP 500 on workload creation during bulk operations, followed by suite timeout cascades
- Root cause: port allocation in `pkg/networking/port.go` has a TOCTOU race — `IsAvailable()` opens/closes listeners, creating a window where concurrent goroutines allocate the same port
- Fix adds process-level mutex and recently-allocated port tracking to prevent concurrent goroutines from receiving the same port
- Port allocation errors now surface as HTTP 503 (Service Unavailable) instead of generic 500, and bulk E2E tests use retry + NodeTimeout for resilience

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)

## Changes

| File | Change |
|------|--------|
| `pkg/networking/port.go` | Add `sync.Mutex` + `recentlyAllocated` map with 30s TTL to prevent TOCTOU races in `FindAvailable()` and `FindOrUsePort()` |
| `pkg/runner/config.go` | Add `ErrPortUnavailable` sentinel error; wrap all port allocation failures with it |
| `pkg/api/v1/workload_service.go` | Map `ErrPortUnavailable` to HTTP 503; wrap `SaveState`/`RunWorkloadDetached` errors with explicit `httperr` codes |
| `test/e2e/api_workloads_test.go` | Add response body logging on unexpected status; add `createWorkloadWithRetry` helper (3 attempts, 2s backoff on 5xx) |
| `test/e2e/api_workload_lifecycle_test.go` | Use `createWorkloadWithRetry` in bulk stop/restart/delete tests; add `NodeTimeout(5m)` to prevent cascade failures |

## Does this introduce a user-facing change?

Port allocation errors during workload creation now return HTTP 503 (Service Unavailable) instead of a generic 500 (Internal Server Error), giving clients a clearer signal to retry.

## Special notes for reviewers

- The `recentlyAllocated` map uses a 30s TTL with lazy purging — entries are cleaned up on the next `FindAvailable()`/`FindOrUsePort()` call, not via a background goroutine
- `FindOrUsePort` inlines the fallback port search rather than calling `FindAvailable()` to avoid double-locking the mutex
- The retry helper is intentionally only used in bulk operation tests where the race was observed; single-workload tests keep strict assertions

Generated with [Claude Code](https://claude.com/claude-code)