### PR TITLE
Fix SSE endpoint rewrite E2E tests using nonexistent flags

### DIFF
--- a/test/e2e/sse_endpoint_rewrite_test.go
+++ b/test/e2e/sse_endpoint_rewrite_test.go
@@ -95,7 +95,7 @@ var _ = Describe("SSE Endpoint URL Rewriting", Label("proxy", "sse", "endpoint-r
 					"--name", serverName,
 					"--transport", "sse",
 					"--endpoint-prefix", endpointPrefix,
-					"--remote-url", mockSSEServer.URL,
+					mockSSEServer.URL,
 				).ExpectSuccess()
 
 				Expect(stdout+stderr).To(ContainSubstring(serverName), "Output should mention the server name")
@@ -224,7 +224,7 @@ var _ = Describe("SSE Endpoint URL Rewriting", Label("proxy", "sse", "endpoint-r
 					"--name", serverName,
 					"--transport", "sse",
 					"--trust-proxy-headers",
-					"--remote-url", mockSSEServer.URL,
+					mockSSEServer.URL,
 				).ExpectSuccess()
 
 				Expect(stdout + stderr).To(ContainSubstring(serverName))
@@ -334,7 +334,7 @@ var _ = Describe("SSE Endpoint URL Rewriting", Label("proxy", "sse", "endpoint-r
 					"--transport", "sse",
 					"--endpoint-prefix", explicitPrefix,
 					"--trust-proxy-headers",
-					"--remote-url", mockSSEServer.URL,
+					mockSSEServer.URL,
 				).ExpectSuccess()
 
 				Expect(stdout + stderr).To(ContainSubstring(serverName))
@@ -419,7 +419,7 @@ var _ = Describe("SSE Endpoint URL Rewriting", Label("proxy", "sse", "endpoint-r
 				endpointPrefix := "/api/mcp"
 
 				// Check if osv server is available in registry
-				stdout, _ := e2e.NewTHVCommand(config, "list", "--registry").ExpectSuccess()
+				stdout, _ := e2e.NewTHVCommand(config, "registry", "list").ExpectSuccess()
 				if !strings.Contains(stdout, "osv") {
 					Skip("OSV server not available in registry")
 				}


### PR DESCRIPTION
## Summary

- The SSE endpoint rewrite E2E tests were orphaned from CI until #4074 rebalanced the E2E test buckets into the `proxy` bucket. Now that they run, all 4 tests fail because they invoke `thv` with flags that don't exist.
- 3 tests passed `--remote-url <url>` (not a real flag) instead of passing the URL as the positional argument. The `run` command auto-detects URLs and treats them as remote servers. Because Cobra's `UnknownFlags` whitelist is enabled, the flag was silently ignored, leaving no positional arg and causing "requires at least 1 arg(s)".
- 1 test used `thv list --registry` instead of the correct `thv registry list` subcommand.

## Type of change

- [x] Bug fix

## Test plan

- [x] Linting (`task lint-fix`)
- [x] Manual testing (describe below)

Verified `go vet ./test/e2e/...` passes. The actual E2E tests require CI infrastructure (Docker) to run fully, but the fix is straightforward: replacing nonexistent flags with correct CLI invocations.

Generated with [Claude Code](https://claude.com/claude-code)