### PR TITLE
fix(recovery): re-panic http.ErrAbortHandler in middleware

### DIFF
--- a/pkg/recovery/recovery.go
+++ b/pkg/recovery/recovery.go
@@ -23,6 +23,10 @@ func Middleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		defer func() {
 			if rec := recover(); rec != nil {
+				if rec == http.ErrAbortHandler {
+					panic(rec)
+				}
+
 				stack := debug.Stack()
 				slog.Error(fmt.Sprintf("Panic recovered: %v\nStack trace:\n%s", rec, stack))
 				http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/pkg/recovery/recovery_test.go
+++ b/pkg/recovery/recovery_test.go
@@ -59,6 +59,22 @@ func TestRecoveryMiddleware_RecoverFromPanic(t *testing.T) {
 	assert.Contains(t, rec.Body.String(), "Internal Server Error")
 }
 
+func TestRecoveryMiddleware_RepanicErrAbortHandler(t *testing.T) {
+	t.Parallel()
+
+	testHandler := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		panic(http.ErrAbortHandler)
+	})
+
+	wrappedHandler := Middleware(testHandler)
+	req := httptest.NewRequest("GET", "/test", nil)
+	rec := httptest.NewRecorder()
+
+	assert.PanicsWithValue(t, http.ErrAbortHandler, func() {
+		wrappedHandler.ServeHTTP(rec, req)
+	})
+}
+
 func TestRecoveryMiddleware_PreservesRequestContext(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary\n- let http.ErrAbortHandler panic propagate through the recovery middleware\n- keep recovery behavior unchanged for all other panics\n- add a focused middleware test that asserts ErrAbortHandler is re-panicked\n\n## Why\nhttputil.ReverseProxy intentionally panics with http.ErrAbortHandler when a streaming copy is aborted. Recovering it in middleware causes noisy error logs and can try to write a 500 into an in-flight response.\n\nFixes #4064\n\n## Testing\n- go test ./pkg/recovery *(blocked locally: repo requires Go 1.26 toolchain, unavailable in this runner)*