### PR TITLE
fix(proxy): make streamable response timeout configurable

### DIFF
--- a/pkg/transport/proxy/streamable/streamable_proxy.go
+++ b/pkg/transport/proxy/streamable/streamable_proxy.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -29,8 +30,11 @@ const (
 	// StreamableHTTPEndpoint is the endpoint for streamable HTTP.
 	StreamableHTTPEndpoint = "/mcp"
 
+	// ResponseTimeoutEnvVar overrides the default response timeout for streamable HTTP proxy requests.
+	ResponseTimeoutEnvVar = "TOOLHIVE_PROXY_RESPONSE_TIMEOUT"
+
 	// Default timeouts and buffer sizes
-	defaultResponseTimeout = 30 * time.Second
+	defaultResponseTimeout = 5 * time.Minute
 )
 
 // HTTPProxy implements a proxy for streamable HTTP transport.
@@ -40,6 +44,7 @@ type HTTPProxy struct {
 	shutdownCh        chan struct{}
 	prometheusHandler http.Handler
 	middlewares       []types.NamedMiddleware
+	responseTimeout   time.Duration
 
 	// Message channel for sending JSON-RPC to the container (from HTTP -> runner)
 	messageCh chan jsonrpc2.Message
@@ -61,6 +66,17 @@ type HTTPProxy struct {
 	stopOnce sync.Once
 }
 
+// getResponseTimeout returns the response timeout for streamable HTTP requests.
+// Uses TOOLHIVE_PROXY_RESPONSE_TIMEOUT when set to a valid positive duration.
+func getResponseTimeout() time.Duration {
+	if val := os.Getenv(ResponseTimeoutEnvVar); val != "" {
+		if d, err := time.ParseDuration(val); err == nil && d > 0 {
+			return d
+		}
+	}
+	return defaultResponseTimeout
+}
+
 // NewHTTPProxy creates a new HTTPProxy for streamable HTTP transport.
 func NewHTTPProxy(
 	host string,
@@ -77,6 +93,7 @@ func NewHTTPProxy(
 		shutdownCh:        make(chan struct{}),
 		prometheusHandler: prometheusHandler,
 		middlewares:       middlewares,
+		responseTimeout:   getResponseTimeout(),
 		messageCh:         make(chan jsonrpc2.Message, 100),
 		responseCh:        make(chan jsonrpc2.Message, 100),
 		sessionManager:    session.NewManager(session.DefaultSessionTTL, sFactory),
@@ -341,7 +358,7 @@ func (p *HTTPProxy) handleSingleRequest(
 	req *jsonrpc2.Request,
 	setSessionHeader bool,
 ) {
-	ctx, cancel := context.WithTimeout(ctx, defaultResponseTimeout)
+	ctx, cancel := context.WithTimeout(ctx, p.responseTimeout)
 	defer cancel()
 
 	msg, err := p.doRequest(ctx, sessID, req)
@@ -373,7 +390,7 @@ func (p *HTTPProxy) handleSingleRequestSSE(
 	req *jsonrpc2.Request,
 	setSessionHeader bool,
 ) {
-	ctx, cancel := context.WithTimeout(ctx, defaultResponseTimeout)
+	ctx, cancel := context.WithTimeout(ctx, p.responseTimeout)
 	defer cancel()
 
 	// Prepare SSE response headers
@@ -480,7 +497,7 @@ func (p *HTTPProxy) processSingleMessage(sessID string, raw json.RawMessage) jso
 		return nil
 	}
 
-	response := p.waitForResponse(waitCh, defaultResponseTimeout)
+	response := p.waitForResponse(waitCh, p.responseTimeout)
 	if response == nil {
 		slog.Warn("streamableHTTP: batch timeout waiting for key", "key", bkey)
 		return nil

--- a/pkg/transport/proxy/streamable/streamable_proxy_test.go
+++ b/pkg/transport/proxy/streamable/streamable_proxy_test.go
@@ -25,6 +25,26 @@ func TestNewHTTPProxy(t *testing.T) {
 	assert.Equal(t, 8080, proxy.port)
 	assert.NotNil(t, proxy.messageCh)
 	assert.NotNil(t, proxy.responseCh)
+	assert.Equal(t, defaultResponseTimeout, proxy.responseTimeout)
+}
+
+func TestGetResponseTimeout(t *testing.T) {
+	t.Run("valid env override", func(t *testing.T) {
+		t.Setenv(ResponseTimeoutEnvVar, "90s")
+		assert.Equal(t, 90*time.Second, getResponseTimeout())
+	})
+
+	t.Run("invalid env falls back", func(t *testing.T) {
+		t.Setenv(ResponseTimeoutEnvVar, "nope")
+		assert.Equal(t, defaultResponseTimeout, getResponseTimeout())
+	})
+
+	t.Run("zero and negative values fall back", func(t *testing.T) {
+		t.Setenv(ResponseTimeoutEnvVar, "0s")
+		assert.Equal(t, defaultResponseTimeout, getResponseTimeout())
+		t.Setenv(ResponseTimeoutEnvVar, "-5s")
+		assert.Equal(t, defaultResponseTimeout, getResponseTimeout())
+	})
 }
 
 // TestProxyChannelCommunication tests basic proxy channel communication


### PR DESCRIPTION
## Summary

- The streamable HTTP proxy used a hardcoded `30s` response timeout, which can trigger premature 504s for long-running stdio-backed MCP tools.
- This change raises the default timeout to `5m` and adds `TOOLHIVE_PROXY_RESPONSE_TIMEOUT` as an env-based override for operators who need custom behavior.
- The timeout is now stored on `HTTPProxy` and applied consistently across single JSON, SSE, and batch request paths.
- Added focused unit coverage for timeout env parsing and fallback behavior.

Fixes #4061

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [ ] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [ ] Linting (`task lint-fix`)
- [x] Manual testing (describe below)

Manual checks performed:
- Attempted to run targeted package tests:
  - `go test ./pkg/transport/proxy/streamable -count=1`
- Local environment cannot execute this repository's Go tests because `go.mod` now requires Go 1.26, while the available local toolchain is 1.21.3 (`go: go.mod requires go >= 1.26`).
- Verified diff scope and logic manually to ensure all streamable response wait paths now use the same configurable timeout.

## Changes

| File | Change |
|------|--------|
| `pkg/transport/proxy/streamable/streamable_proxy.go` | Increased default response timeout to 5m, added `TOOLHIVE_PROXY_RESPONSE_TIMEOUT`, and applied proxy-level timeout across single/SSE/batch paths |
| `pkg/transport/proxy/streamable/streamable_proxy_test.go` | Added tests for env override parsing and fallback behavior; asserted proxy timeout initialization |

## Does this introduce a user-facing change?

Yes. Long-running streamable HTTP MCP requests now default to a 5-minute timeout instead of 30 seconds, and users can override via `TOOLHIVE_PROXY_RESPONSE_TIMEOUT`.

## Special notes for reviewers

- The change is intentionally scoped to streamable proxy timeout behavior only.
- Invalid/zero/negative timeout env values safely fall back to the default.