### PR TITLE
fix(fileutils): handle EBUSY when replacing bind-mounted files

### DIFF
--- a/pkg/fileutils/atomic.go
+++ b/pkg/fileutils/atomic.go
@@ -5,15 +5,24 @@
 package fileutils
 
 import (
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
+	"syscall"
 )
 
 // AtomicWriteFile writes data to a file atomically by writing to a temporary file
 // and then renaming it. This ensures that readers either see the complete old file
 // or the complete new file, never a partially written file.
 func AtomicWriteFile(targetPath string, data []byte, perm os.FileMode) error {
+	return atomicWriteFile(targetPath, data, perm, os.Rename)
+}
+
+type renameFunc func(oldPath, newPath string) error
+
+func atomicWriteFile(targetPath string, data []byte, perm os.FileMode, rename renameFunc) error {
 	// Create a temporary file in the same directory as the target file
 	// This ensures the temp file is on the same filesystem for atomic rename
 	dir := filepath.Dir(targetPath)
@@ -53,13 +62,56 @@ func AtomicWriteFile(targetPath string, data []byte, perm os.FileMode) error {
 		return fmt.Errorf("failed to set permissions on temp file: %w", err)
 	}
 
-	// Atomically rename temp file to target file
-	// This is atomic on POSIX systems (Linux, macOS, etc.)
+	// Atomically rename temp file to target file.
 	// #nosec G703 -- tmpPath is from os.CreateTemp, targetPath is caller-controlled
-	if err := os.Rename(tmpPath, targetPath); err != nil {
-		return fmt.Errorf("failed to rename temp file: %w", err)
+	if renameErr := rename(tmpPath, targetPath); renameErr != nil {
+		if !errors.Is(renameErr, syscall.EBUSY) {
+			return fmt.Errorf("failed to rename temp file: %w", renameErr)
+		}
+
+		// Some sandbox setups bind-mount individual files (for example Flatpak
+		// --filesystem=~/file). Renaming over that mountpoint fails with EBUSY.
+		// Fallback to in-place overwrite to preserve functionality.
+		if overwriteErr := overwriteFileInPlace(tmpPath, targetPath, perm); overwriteErr != nil {
+			return fmt.Errorf("failed to rename temp file: %w (fallback overwrite failed: %v)", renameErr, overwriteErr)
+		}
+	} else {
+		// Rename succeeded, no temp file remains.
+		success = true
+		return nil
+	}
+
+	// Fallback path: remove temporary source file now that data has been copied.
+	if err := os.Remove(tmpPath); err != nil {
+		return fmt.Errorf("failed to clean up temp file after fallback overwrite: %w", err)
 	}
 
 	success = true
+	return nil
+}
+
+func overwriteFileInPlace(srcPath, dstPath string, perm os.FileMode) error {
+	src, err := os.Open(srcPath)
+	if err != nil {
+		return fmt.Errorf("open temp file: %w", err)
+	}
+	defer src.Close() //nolint:errcheck,gosec // best effort cleanup
+
+	// #nosec G304 -- dstPath is caller-controlled target path.
+	dst, err := os.OpenFile(dstPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, perm)
+	if err != nil {
+		return fmt.Errorf("open target file: %w", err)
+	}
+	defer dst.Close() //nolint:errcheck,gosec // best effort cleanup
+
+	if _, err := io.Copy(dst, src); err != nil {
+		return fmt.Errorf("copy data: %w", err)
+	}
+	if err := dst.Sync(); err != nil {
+		return fmt.Errorf("sync target file: %w", err)
+	}
+	if err := dst.Chmod(perm); err != nil {
+		return fmt.Errorf("set target permissions: %w", err)
+	}
 	return nil
 }

--- a/pkg/fileutils/atomic_test.go
+++ b/pkg/fileutils/atomic_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -116,6 +117,39 @@ func TestAtomicWriteFile_NoTempFileLeftBehind(t *testing.T) {
 	for _, entry := range entries {
 		assert.False(t, strings.HasPrefix(entry.Name(), ".tmp-"),
 			"temp file should not remain: %s", entry.Name())
+	}
+}
+
+func TestAtomicWriteFile_EBUSYFallback(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	targetPath := filepath.Join(tempDir, "bind-mounted-target.json")
+	require.NoError(t, os.WriteFile(targetPath, []byte(`{"before":true}`), 0o600))
+
+	renameCalled := 0
+	renameAlwaysEBUSY := func(oldPath, newPath string) error {
+		renameCalled++
+		return &os.LinkError{Op: "rename", Old: oldPath, New: newPath, Err: syscall.EBUSY}
+	}
+
+	newData := []byte(`{"after":true}`)
+	err := atomicWriteFile(targetPath, newData, 0o640, renameAlwaysEBUSY)
+	require.NoError(t, err)
+	assert.Equal(t, 1, renameCalled)
+
+	content, err := os.ReadFile(targetPath)
+	require.NoError(t, err)
+	assert.Equal(t, newData, content)
+
+	info, err := os.Stat(targetPath)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o640), info.Mode().Perm())
+
+	entries, err := os.ReadDir(tempDir)
+	require.NoError(t, err)
+	for _, entry := range entries {
+		assert.False(t, strings.HasPrefix(entry.Name(), ".tmp-"), "temp file should not remain: %s", entry.Name())
 	}
 }
 


### PR DESCRIPTION
## Summary

`AtomicWriteFile` currently relies on temp-file + rename only. In bind-mounted single-file environments (for example Flatpak `--filesystem=~/.claude.json`), `rename()` to the mounted target can fail with `EBUSY`, which breaks client registration workflows that write directly to root-level files.

This PR adds a targeted fallback for that case:

- Keep the existing atomic rename path as the default behavior
- If rename fails specifically with `EBUSY`, fall back to an in-place overwrite (`O_TRUNC` + copy + sync + chmod)
- Add a focused unit test that injects an `EBUSY` rename failure and verifies overwrite + temp-file cleanup

Fixes #3979

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [ ] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [ ] Linting (`task lint-fix`)
- [x] Manual testing (describe below)

Validation details:

- Attempted: `go test ./pkg/fileutils`
- Result: blocked in this environment because the repo requires Go 1.26 and the toolchain is not available on this host (`go: download go1.26 for windows/amd64: toolchain not available`)
- Additional check run: `git diff --check` (clean)

## Changes

| File | Change |
|------|--------|
| `pkg/fileutils/atomic.go` | Added `EBUSY` fallback path from rename to in-place overwrite + cleanup helper |
| `pkg/fileutils/atomic_test.go` | Added test that simulates `rename` returning `EBUSY` and verifies correct overwrite behavior |

## Does this introduce a user-facing change?

Yes. In sandboxed environments that bind-mount an individual file path, writes to that file now succeed even when atomic rename is rejected with `EBUSY`.

## Special notes for reviewers

The fallback is intentionally narrow: it only triggers on `EBUSY`, preserving current atomic semantics for all normal rename-success paths.
