### PR TITLE
fix: fail fast on missing volume source paths

### DIFF
--- a/pkg/runner/config_builder.go
+++ b/pkg/runner/config_builder.go
@@ -9,6 +9,8 @@ import (
 	"log/slog"
 	"maps"
 	"net/url"
+	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 
@@ -1065,6 +1067,10 @@ func (b *runConfigBuilder) processVolumeMounts() error {
 			continue
 		}
 
+		if err := b.validateVolumeSourcePath(source); err != nil {
+			return err
+		}
+
 		// Add the mount to the appropriate permission list
 		if readOnly {
 			b.config.PermissionProfile.Read = append(b.config.PermissionProfile.Read, mount)
@@ -1077,6 +1083,30 @@ func (b *runConfigBuilder) processVolumeMounts() error {
 
 		slog.Debug("Adding volume mount", "source", source, "target", target,
 			"mode", map[bool]string{true: "read-only", false: "read-write"}[readOnly])
+	}
+
+	return nil
+}
+
+func (b *runConfigBuilder) validateVolumeSourcePath(source string) error {
+	if b.buildContext == BuildContextOperator || strings.HasPrefix(source, "resource://") {
+		return nil
+	}
+
+	resolved := source
+	if !filepath.IsAbs(resolved) {
+		absPath, err := filepath.Abs(resolved)
+		if err != nil {
+			return fmt.Errorf("failed to resolve volume source path %q: %w", source, err)
+		}
+		resolved = absPath
+	}
+
+	if _, err := os.Stat(resolved); err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("volume source path does not exist: %s", resolved)
+		}
+		return fmt.Errorf("failed to access volume source path %s: %w", resolved, err)
 	}
 
 	return nil

--- a/pkg/runner/config_builder_test.go
+++ b/pkg/runner/config_builder_test.go
@@ -6,7 +6,9 @@ package runner
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -242,6 +244,22 @@ func TestRunConfigBuilder_Build_WithVolumeMounts(t *testing.T) {
 	// Create a mock environment variable validator
 	mockValidator := &mockEnvVarValidator{}
 
+	createVolumeSource := func(t *testing.T, prefix string) string {
+		t.Helper()
+
+		dir, err := os.MkdirTemp(".", prefix)
+		require.NoError(t, err, "failed to create temporary volume source")
+		t.Cleanup(func() { _ = os.RemoveAll(dir) })
+
+		return filepath.ToSlash(dir)
+	}
+
+	sourceA := createVolumeSource(t, "volume-src-a-")
+	sourceB := createVolumeSource(t, "volume-src-b-")
+	sourceC := createVolumeSource(t, "volume-src-c-")
+	sourceD := createVolumeSource(t, "volume-src-d-")
+	missingSource := filepath.ToSlash(filepath.Join(sourceA, "does-not-exist"))
+
 	testCases := []struct {
 		name                string
 		builderOptions      []RunConfigBuilderOption
@@ -261,7 +279,7 @@ func TestRunConfigBuilder_Build_WithVolumeMounts(t *testing.T) {
 		{
 			name: "Volumes without permission profile but with profile name",
 			builderOptions: []RunConfigBuilderOption{
-				WithVolumes([]string{"/host:/container"}),
+				WithVolumes([]string{fmt.Sprintf("%s:/container", sourceA)}),
 				WithPermissionProfileNameOrPath(permissions.ProfileNone),
 			},
 			expectError:         false,
@@ -271,7 +289,7 @@ func TestRunConfigBuilder_Build_WithVolumeMounts(t *testing.T) {
 		{
 			name: "Read-only volume with existing profile",
 			builderOptions: []RunConfigBuilderOption{
-				WithVolumes([]string{"/host:/container:ro"}),
+				WithVolumes([]string{fmt.Sprintf("%s:/container:ro", sourceB)}),
 				WithPermissionProfile(permissions.BuiltinNoneProfile()),
 			},
 			expectError:         false,
@@ -281,7 +299,7 @@ func TestRunConfigBuilder_Build_WithVolumeMounts(t *testing.T) {
 		{
 			name: "Read-write volume with existing profile",
 			builderOptions: []RunConfigBuilderOption{
-				WithVolumes([]string{"/host:/container"}),
+				WithVolumes([]string{fmt.Sprintf("%s:/container", sourceC)}),
 				WithPermissionProfile(permissions.BuiltinNoneProfile()),
 			},
 			expectError:         false,
@@ -292,15 +310,23 @@ func TestRunConfigBuilder_Build_WithVolumeMounts(t *testing.T) {
 			name: "Multiple volumes with existing profile",
 			builderOptions: []RunConfigBuilderOption{
 				WithVolumes([]string{
-					"/host1:/container1:ro",
-					"/host2:/container2",
-					"/host3:/container3:ro",
+					fmt.Sprintf("%s:/container1:ro", sourceA),
+					fmt.Sprintf("%s:/container2", sourceB),
+					fmt.Sprintf("%s:/container3:ro", sourceD),
 				}),
 				WithPermissionProfile(permissions.BuiltinNoneProfile()),
 			},
 			expectError:         false,
 			expectedReadMounts:  2,
 			expectedWriteMounts: 1,
+		},
+		{
+			name: "Invalid volume source path",
+			builderOptions: []RunConfigBuilderOption{
+				WithVolumes([]string{fmt.Sprintf("%s:/container", missingSource)}),
+				WithPermissionProfile(permissions.BuiltinNoneProfile()),
+			},
+			expectError: true,
 		},
 		{
 			name: "Invalid volume format",
@@ -346,6 +372,28 @@ func TestRunConfigBuilder_Build_WithVolumeMounts(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRunConfigBuilder_BuildForOperator_WithNonexistentVolumeSource(t *testing.T) {
+	t.Parallel()
+
+	mockValidator := &mockEnvVarValidator{}
+	missingSource := filepath.ToSlash(filepath.Join("does-not-exist", "source"))
+
+	config, err := NewOperatorRunConfigBuilder(
+		context.Background(),
+		nil,
+		nil,
+		mockValidator,
+		WithName("test-server"),
+		WithImage("test-image:latest"),
+		WithVolumes([]string{fmt.Sprintf("%s:/container", missingSource)}),
+		WithPermissionProfile(permissions.BuiltinNoneProfile()),
+	)
+	require.NoError(t, err, "operator build should skip local host path validation")
+	require.NotNil(t, config)
+	require.NotNil(t, config.PermissionProfile)
+	assert.Len(t, config.PermissionProfile.Write, 1)
 }
 
 // createTempProfileFile creates a temporary JSON profile file with the provided content


### PR DESCRIPTION
## Summary

- `thv run --volume` currently accepts missing host source paths and reports success before detached startup fails, forcing users to inspect logs to find the root cause.
- Added pre-flight volume source validation in `runConfigBuilder.processVolumeMounts` for CLI builds so missing or inaccessible source paths fail fast with actionable errors.
- Added coverage for valid existing mounts, missing-source rejection, and operator-build behavior that intentionally skips local filesystem validation.

Fixes #2485

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [ ] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [ ] Linting (`task lint-fix`)
- [x] Manual testing (describe below)

Manual verification performed:
- `git diff --check`
- Attempted: `go test ./pkg/runner -run "TestRunConfigBuilder_Build_WithVolumeMounts|TestRunConfigBuilder_BuildForOperator_WithNonexistentVolumeSource" -count=1`
  - Could not execute because this environment cannot provision the required Go 1.26 toolchain (`toolchain not available`).

## Changes

| File | Change |
|------|--------|
| `pkg/runner/config_builder.go` | Added CLI pre-flight validation for volume source path existence/accessibility; skips validation for operator context and `resource://` mounts. |
| `pkg/runner/config_builder_test.go` | Updated volume mount tests to use real temporary source paths, added missing-source failure case, and added operator-context regression test. |

## Does this introduce a user-facing change?

Yes. Invalid `--volume` source paths now fail immediately with a clear error instead of reporting detached-start success and failing later in logs.

## Special notes for reviewers

- Validation intentionally remains disabled in operator context because those mount paths are evaluated in cluster runtime, not on the local CLI host.
