### PR TITLE
Fix validateOCITag to accept full OCI references

### DIFF
--- a/pkg/skills/skillsvc/skillsvc.go
+++ b/pkg/skills/skillsvc/skillsvc.go
@@ -357,7 +357,7 @@ func (s *service) Build(ctx context.Context, opts skills.BuildOptions) (*skills.
 	}()
 
 	if tag != "" {
-		if err := validateOCITag(tag); err != nil {
+		if err := validateOCITagOrReference(tag); err != nil {
 			return nil, err
 		}
 	}
@@ -840,14 +840,25 @@ func validateLocalPath(path string) error {
 	return nil
 }
 
-// validateOCITag checks that a tag conforms to the OCI distribution spec format
-// using go-containerregistry's reference parser rather than a hand-rolled regex.
-func validateOCITag(tag string) error {
-	// Construct a minimal valid reference with the tag so the library
-	// validates the tag portion per the distribution spec.
-	if _, err := nameref.NewTag("dummy.invalid/repo:"+tag, nameref.StrictValidation); err != nil {
+// validateOCITagOrReference accepts either a bare OCI tag ("v1.0.0") or a full
+// OCI reference ("ghcr.io/org/repo:v1.0.0"). The --tag flag in `thv skill build`
+// supports both forms (matching `docker build -t` semantics), so we route to
+// the appropriate parser based on the presence of '/', ':', or '@'.
+func validateOCITagOrReference(value string) error {
+	if strings.ContainsAny(value, "/:@") {
+		// Looks like a full OCI reference — validate as such.
+		if _, err := nameref.ParseReference(value, nameref.StrictValidation); err != nil {
+			return httperr.WithCode(
+				fmt.Errorf("invalid OCI reference or tag %q: %w", value, err),
+				http.StatusBadRequest,
+			)
+		}
+		return nil
+	}
+	// Bare tag — construct a dummy reference to validate the tag portion.
+	if _, err := nameref.NewTag("dummy.invalid/repo:"+value, nameref.StrictValidation); err != nil {
 		return httperr.WithCode(
-			fmt.Errorf("invalid OCI tag %q: %w", tag, err),
+			fmt.Errorf("invalid OCI reference or tag %q: %w", value, err),
 			http.StatusBadRequest,
 		)
 	}

--- a/pkg/skills/skillsvc/skillsvc_test.go
+++ b/pkg/skills/skillsvc/skillsvc_test.go
@@ -1942,7 +1942,7 @@ func TestUninstallRemovesSkillFromGroups(t *testing.T) {
 	}
 }
 
-func TestValidateOCITag(t *testing.T) {
+func TestValidateOCITagOrReference(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -1950,7 +1950,7 @@ func TestValidateOCITag(t *testing.T) {
 		tag     string
 		wantErr bool
 	}{
-		// Valid tags
+		// Valid bare tags
 		{name: "simple version", tag: "v1.0.0", wantErr: false},
 		{name: "latest", tag: "latest", wantErr: false},
 		{name: "numeric", tag: "123", wantErr: false},
@@ -1963,23 +1963,32 @@ func TestValidateOCITag(t *testing.T) {
 		{name: "max length 128 chars", tag: strings.Repeat("a", 128), wantErr: false},
 		{name: "exceeds max length 129 chars", tag: strings.Repeat("a", 129), wantErr: true},
 
-		// Invalid tags
+		// Valid full OCI references
+		{name: "ghcr tagged reference", tag: "ghcr.io/stacklok/toolhive-skills/my-skill:v1.0.0", wantErr: false},
+		{name: "CI format tag", tag: "ghcr.io/stacklok/toolhive-skills/my-skill:0.0.1-dev.123_abc1234", wantErr: false},
+		{name: "docker hub reference", tag: "docker.io/library/nginx:1.25", wantErr: false},
+		{name: "localhost with port", tag: "localhost:5000/my-skill:v1", wantErr: false},
+		{name: "digest reference", tag: "ghcr.io/org/repo@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", wantErr: false},
+
+		// Invalid bare tags
 		{name: "empty string", tag: "", wantErr: true},
 		{name: "contains space", tag: "invalid tag", wantErr: true},
 		{name: "contains exclamation", tag: "invalid!", wantErr: true},
-		{name: "contains at", tag: "invalid@tag", wantErr: true},
 		{name: "contains hash", tag: "invalid#tag", wantErr: true},
-		{name: "contains slash", tag: "invalid/tag", wantErr: true},
+
+		// Invalid full references
+		{name: "space in tag of reference", tag: "ghcr.io/org/repo:invalid tag", wantErr: true},
+		{name: "empty tag after colon", tag: "ghcr.io/org/repo:", wantErr: true},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			err := validateOCITag(tt.tag)
+			err := validateOCITagOrReference(tt.tag)
 			if tt.wantErr {
 				require.Error(t, err)
-				assert.Contains(t, err.Error(), "invalid OCI tag")
+				assert.Contains(t, err.Error(), "invalid OCI reference or tag")
 				// Verify it returns a proper HTTP status code.
 				var coded *httperr.CodedError
 				require.ErrorAs(t, err, &coded)


### PR DESCRIPTION
## Summary

- The `--tag` flag in `thv skill build` accepts both bare tags (`v1.0`) and full OCI references (`ghcr.io/org/repo:v1.0`) to match `docker build -t` semantics. The CI skills workflow passes full references, but `validateOCITag()` rejected them because it prepended a dummy host, producing an invalid double-reference like `dummy.invalid/repo:ghcr.io/org/repo:v1.0`.
- Rename `validateOCITag` → `validateOCITagOrReference` with two-branch validation: if the input contains `/:@` characters, validate as a full OCI reference via `ParseReference`; otherwise validate as a bare tag via `NewTag` with a dummy prefix. This reuses the same heuristic already used in `parseOCIReference()`.

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)

## Changes

| File | Change |
|------|--------|
| `pkg/skills/skillsvc/skillsvc.go` | Rename + rewrite validator to accept full OCI refs; update call site |
| `pkg/skills/skillsvc/skillsvc_test.go` | Rename test, add valid/invalid full-reference cases, update error string |

## Does this introduce a user-facing change?

`thv skill build --tag ghcr.io/org/repo:v1.0.0` no longer fails validation. Previously only bare tags like `v1.0.0` were accepted.

Generated with [Claude Code](https://claude.com/claude-code)