### PR TITLE
Preserve tool annotations and output schema through vmcp

### DIFF
--- a/pkg/vmcp/aggregator/aggregator.go
+++ b/pkg/vmcp/aggregator/aggregator.go
@@ -118,6 +118,12 @@ type ResolvedTool struct {
 	// InputSchema is the JSON Schema for parameters.
 	InputSchema map[string]any
 
+	// OutputSchema is the JSON Schema for tool output (optional).
+	OutputSchema map[string]any
+
+	// Annotations describes behavioral hints for the tool (optional).
+	Annotations *vmcp.ToolAnnotations
+
 	// BackendID identifies the backend providing this tool.
 	BackendID string
 

--- a/pkg/vmcp/aggregator/default_aggregator.go
+++ b/pkg/vmcp/aggregator/default_aggregator.go
@@ -244,6 +244,8 @@ func (a *defaultAggregator) ResolveConflicts(
 					OriginalName: tool.Name,
 					Description:  tool.Description,
 					InputSchema:  tool.InputSchema,
+					OutputSchema: tool.OutputSchema,
+					Annotations:  tool.Annotations,
 					BackendID:    backendID,
 				}
 			}
@@ -321,10 +323,12 @@ func (a *defaultAggregator) MergeCapabilities(
 
 		if shouldAdvertise {
 			tools = append(tools, vmcp.Tool{
-				Name:        resolvedTool.ResolvedName,
-				Description: resolvedTool.Description,
-				InputSchema: resolvedTool.InputSchema,
-				BackendID:   resolvedTool.BackendID,
+				Name:         resolvedTool.ResolvedName,
+				Description:  resolvedTool.Description,
+				InputSchema:  resolvedTool.InputSchema,
+				OutputSchema: resolvedTool.OutputSchema,
+				Annotations:  resolvedTool.Annotations,
+				BackendID:    resolvedTool.BackendID,
 			})
 		}
 

--- a/pkg/vmcp/aggregator/manual_resolver.go
+++ b/pkg/vmcp/aggregator/manual_resolver.go
@@ -143,6 +143,8 @@ func (r *ManualConflictResolver) resolveToolWithOverride(backendID string, tool 
 		OriginalName:              tool.Name,
 		Description:               description,
 		InputSchema:               tool.InputSchema,
+		OutputSchema:              tool.OutputSchema,
+		Annotations:               tool.Annotations,
 		BackendID:                 backendID,
 		ConflictResolutionApplied: vmcp.ConflictStrategyManual,
 	}

--- a/pkg/vmcp/aggregator/prefix_resolver.go
+++ b/pkg/vmcp/aggregator/prefix_resolver.go
@@ -64,6 +64,8 @@ func (r *PrefixConflictResolver) ResolveToolConflicts(
 				OriginalName:              tool.Name,
 				Description:               tool.Description,
 				InputSchema:               tool.InputSchema,
+				OutputSchema:              tool.OutputSchema,
+				Annotations:               tool.Annotations,
 				BackendID:                 backendID,
 				ConflictResolutionApplied: vmcp.ConflictStrategyPrefix,
 			}

--- a/pkg/vmcp/aggregator/priority_resolver.go
+++ b/pkg/vmcp/aggregator/priority_resolver.go
@@ -74,6 +74,8 @@ func (r *PriorityConflictResolver) ResolveToolConflicts(
 				OriginalName:              toolName,
 				Description:               candidate.Tool.Description,
 				InputSchema:               candidate.Tool.InputSchema,
+				OutputSchema:              candidate.Tool.OutputSchema,
+				Annotations:               candidate.Tool.Annotations,
 				BackendID:                 candidate.BackendID,
 				ConflictResolutionApplied: vmcp.ConflictStrategyPriority,
 			}
@@ -100,6 +102,8 @@ func (r *PriorityConflictResolver) ResolveToolConflicts(
 					OriginalName:              toolName,
 					Description:               candidate.Tool.Description,
 					InputSchema:               candidate.Tool.InputSchema,
+					OutputSchema:              candidate.Tool.OutputSchema,
+					Annotations:               candidate.Tool.Annotations,
 					BackendID:                 candidate.BackendID,
 					ConflictResolutionApplied: vmcp.ConflictStrategyPrefix, // Fallback used prefix
 				}
@@ -112,6 +116,8 @@ func (r *PriorityConflictResolver) ResolveToolConflicts(
 			OriginalName:              toolName,
 			Description:               winner.Tool.Description,
 			InputSchema:               winner.Tool.InputSchema,
+			OutputSchema:              winner.Tool.OutputSchema,
+			Annotations:               winner.Tool.Annotations,
 			BackendID:                 winner.BackendID,
 			ConflictResolutionApplied: vmcp.ConflictStrategyPriority,
 		}

--- a/pkg/vmcp/aggregator/testhelpers_annotations_test.go
+++ b/pkg/vmcp/aggregator/testhelpers_annotations_test.go
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package aggregator
+
+import (
+	"github.com/stacklok/toolhive/pkg/vmcp"
+)
+
+func boolPtr(b bool) *bool { return &b }
+
+func newTestToolWithAnnotations(name, backendID string, annotations *vmcp.ToolAnnotations) vmcp.Tool {
+	return vmcp.Tool{
+		Name:        name,
+		Description: name + " description",
+		InputSchema: map[string]any{"type": "object"},
+		OutputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"result": map[string]any{"type": "string"},
+			},
+		},
+		Annotations: annotations,
+		BackendID:   backendID,
+	}
+}

--- a/pkg/vmcp/aggregator/tool_adapter.go
+++ b/pkg/vmcp/aggregator/tool_adapter.go
@@ -104,10 +104,12 @@ func processBackendTools(
 
 		// Construct the result tool with processed name/description but original schema
 		result = append(result, vmcp.Tool{
-			Name:        simpleTool.Name,        // Use the processed (potentially overridden) name
-			Description: simpleTool.Description, // Use the processed (potentially overridden) description
-			InputSchema: originalTool.InputSchema,
-			BackendID:   backendID, // Use the backendID parameter (source of truth)
+			Name:         simpleTool.Name,        // Use the processed (potentially overridden) name
+			Description:  simpleTool.Description, // Use the processed (potentially overridden) description
+			InputSchema:  originalTool.InputSchema,
+			OutputSchema: originalTool.OutputSchema,
+			Annotations:  originalTool.Annotations,
+			BackendID:    backendID, // Use the backendID parameter (source of truth)
 		})
 	}
 

--- a/pkg/vmcp/aggregator/tool_adapter_annotations_test.go
+++ b/pkg/vmcp/aggregator/tool_adapter_annotations_test.go
@@ -1,0 +1,155 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package aggregator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stacklok/toolhive/pkg/vmcp"
+	"github.com/stacklok/toolhive/pkg/vmcp/config"
+)
+
+func TestProcessBackendTools_AnnotationsAndOutputSchema(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		backendID        string
+		tools            []vmcp.Tool
+		workloadConfig   *config.WorkloadToolConfig
+		wantCount        int
+		wantNames        []string
+		wantAnnotations  *vmcp.ToolAnnotations
+		wantOutputSchema map[string]any
+	}{
+		{
+			name:      "preserves Annotations and OutputSchema through overrides",
+			backendID: "backend1",
+			tools: []vmcp.Tool{
+				{
+					Name:        "tool1",
+					Description: "Tool 1",
+					InputSchema: map[string]any{"type": "object"},
+					OutputSchema: map[string]any{
+						"type": "object",
+						"properties": map[string]any{
+							"result": map[string]any{"type": "string"},
+						},
+					},
+					Annotations: &vmcp.ToolAnnotations{
+						ReadOnlyHint: boolPtr(true),
+						Title:        "My Tool",
+					},
+					BackendID: "backend1",
+				},
+			},
+			workloadConfig: &config.WorkloadToolConfig{
+				Workload: "backend1",
+				Overrides: map[string]*config.ToolOverride{
+					"tool1": {Name: "renamed_tool1"},
+				},
+			},
+			wantCount: 1,
+			wantNames: []string{"renamed_tool1"},
+			wantAnnotations: &vmcp.ToolAnnotations{
+				ReadOnlyHint: boolPtr(true),
+				Title:        "My Tool",
+			},
+			wantOutputSchema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"result": map[string]any{"type": "string"},
+				},
+			},
+		},
+		{
+			name:      "preserves Annotations without overrides",
+			backendID: "backend1",
+			tools: []vmcp.Tool{
+				newTestToolWithAnnotations("annotated_tool", "backend1", &vmcp.ToolAnnotations{
+					Title:           "Annotated",
+					DestructiveHint: boolPtr(true),
+					IdempotentHint:  boolPtr(false),
+				}),
+			},
+			workloadConfig: nil,
+			wantCount:      1,
+			wantNames:      []string{"annotated_tool"},
+			wantAnnotations: &vmcp.ToolAnnotations{
+				Title:           "Annotated",
+				DestructiveHint: boolPtr(true),
+				IdempotentHint:  boolPtr(false),
+			},
+			wantOutputSchema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"result": map[string]any{"type": "string"},
+				},
+			},
+		},
+		{
+			name:      "nil Annotations preserved as nil",
+			backendID: "backend1",
+			tools: []vmcp.Tool{
+				{
+					Name:        "simple_tool",
+					Description: "Simple tool",
+					InputSchema: map[string]any{"type": "object"},
+					BackendID:   "backend1",
+				},
+			},
+			workloadConfig:   nil,
+			wantCount:        1,
+			wantNames:        []string{"simple_tool"},
+			wantAnnotations:  nil,
+			wantOutputSchema: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := processBackendTools(context.Background(), tt.backendID, tt.tools, tt.workloadConfig)
+
+			require.Len(t, result, tt.wantCount)
+
+			// Check expected tool names are present
+			resultNames := make(map[string]bool)
+			for _, tool := range result {
+				resultNames[tool.Name] = true
+			}
+			for _, wantName := range tt.wantNames {
+				assert.True(t, resultNames[wantName], "expected tool %q not found in results", wantName)
+			}
+
+			// Verify Annotations and OutputSchema on the first result tool
+			if tt.wantCount > 0 {
+				tool := result[0]
+
+				if tt.wantAnnotations == nil {
+					assert.Nil(t, tool.Annotations, "expected nil Annotations")
+				} else {
+					require.NotNil(t, tool.Annotations, "expected non-nil Annotations")
+					assert.Equal(t, tt.wantAnnotations.Title, tool.Annotations.Title)
+					assert.Equal(t, tt.wantAnnotations.ReadOnlyHint, tool.Annotations.ReadOnlyHint)
+					assert.Equal(t, tt.wantAnnotations.DestructiveHint, tool.Annotations.DestructiveHint)
+					assert.Equal(t, tt.wantAnnotations.IdempotentHint, tool.Annotations.IdempotentHint)
+					assert.Equal(t, tt.wantAnnotations.OpenWorldHint, tool.Annotations.OpenWorldHint)
+				}
+
+				if tt.wantOutputSchema == nil {
+					assert.Nil(t, tool.OutputSchema, "expected nil OutputSchema")
+				} else {
+					require.NotNil(t, tool.OutputSchema, "expected non-nil OutputSchema")
+					assert.Equal(t, tt.wantOutputSchema["type"], tool.OutputSchema["type"])
+				}
+			}
+		})
+	}
+}

--- a/pkg/vmcp/client/client.go
+++ b/pkg/vmcp/client/client.go
@@ -467,10 +467,12 @@ func (h *httpBackendClient) ListCapabilities(ctx context.Context, target *vmcp.B
 	// Convert tools
 	for i, tool := range toolsResp.Tools {
 		capabilities.Tools[i] = vmcp.Tool{
-			Name:        tool.Name,
-			Description: tool.Description,
-			InputSchema: conversion.ConvertToolInputSchema(tool.InputSchema),
-			BackendID:   target.WorkloadID,
+			Name:         tool.Name,
+			Description:  tool.Description,
+			InputSchema:  conversion.ConvertToolInputSchema(tool.InputSchema),
+			OutputSchema: conversion.ConvertToolOutputSchema(tool.OutputSchema),
+			Annotations:  conversion.ConvertToolAnnotations(tool.Annotations),
+			BackendID:    target.WorkloadID,
 		}
 	}
 

--- a/pkg/vmcp/conversion/content.go
+++ b/pkg/vmcp/conversion/content.go
@@ -186,6 +186,61 @@ func ConvertPromptArguments(arguments map[string]any) map[string]string {
 	return result
 }
 
+// ConvertToolAnnotations converts mcp.ToolAnnotation to *vmcp.ToolAnnotations.
+// Returns nil if all fields are zero-valued (empty Title, all hint pointers nil).
+func ConvertToolAnnotations(ann mcp.ToolAnnotation) *vmcp.ToolAnnotations {
+	if ann.Title == "" && ann.ReadOnlyHint == nil && ann.DestructiveHint == nil &&
+		ann.IdempotentHint == nil && ann.OpenWorldHint == nil {
+		return nil
+	}
+	return &vmcp.ToolAnnotations{
+		Title:           ann.Title,
+		ReadOnlyHint:    ann.ReadOnlyHint,
+		DestructiveHint: ann.DestructiveHint,
+		IdempotentHint:  ann.IdempotentHint,
+		OpenWorldHint:   ann.OpenWorldHint,
+	}
+}
+
+// ConvertToolOutputSchema converts a mcp.ToolOutputSchema to map[string]any via a
+// JSON round-trip, same pattern as ConvertToolInputSchema.
+// Returns nil if the schema has no meaningful type (empty Type field).
+func ConvertToolOutputSchema(schema mcp.ToolOutputSchema) map[string]any {
+	// A zero-valued ToolOutputSchema has Type="" — this means the backend
+	// did not provide an output schema. Return nil to distinguish from a
+	// schema that was explicitly set.
+	if schema.Type == "" {
+		return nil
+	}
+	b, err := json.Marshal(schema)
+	if err != nil {
+		return nil
+	}
+	result := make(map[string]any)
+	if err := json.Unmarshal(b, &result); err != nil {
+		return nil
+	}
+	if len(result) == 0 {
+		return nil
+	}
+	return result
+}
+
+// ToMCPToolAnnotations converts *vmcp.ToolAnnotations back to mcp.ToolAnnotation.
+// Returns a zero-valued mcp.ToolAnnotation if annotations is nil.
+func ToMCPToolAnnotations(annotations *vmcp.ToolAnnotations) mcp.ToolAnnotation {
+	if annotations == nil {
+		return mcp.ToolAnnotation{}
+	}
+	return mcp.ToolAnnotation{
+		Title:           annotations.Title,
+		ReadOnlyHint:    annotations.ReadOnlyHint,
+		DestructiveHint: annotations.DestructiveHint,
+		IdempotentHint:  annotations.IdempotentHint,
+		OpenWorldHint:   annotations.OpenWorldHint,
+	}
+}
+
 // ContentArrayToMap converts a vmcp.Content array to a map for template variable substitution.
 // This is used by composite tool workflows and backend result handling.
 //

--- a/pkg/vmcp/conversion/content_test.go
+++ b/pkg/vmcp/conversion/content_test.go
@@ -1,0 +1,285 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package conversion
+
+import (
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stacklok/toolhive/pkg/vmcp"
+)
+
+func boolPtr(b bool) *bool { return &b }
+
+func TestConvertToolAnnotations(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input mcp.ToolAnnotation
+		want  *vmcp.ToolAnnotations
+	}{
+		{
+			name: "all fields populated",
+			input: mcp.ToolAnnotation{
+				Title:           "My Tool",
+				ReadOnlyHint:    boolPtr(true),
+				DestructiveHint: boolPtr(false),
+				IdempotentHint:  boolPtr(true),
+				OpenWorldHint:   boolPtr(false),
+			},
+			want: &vmcp.ToolAnnotations{
+				Title:           "My Tool",
+				ReadOnlyHint:    boolPtr(true),
+				DestructiveHint: boolPtr(false),
+				IdempotentHint:  boolPtr(true),
+				OpenWorldHint:   boolPtr(false),
+			},
+		},
+		{
+			name:  "all zero-valued returns nil",
+			input: mcp.ToolAnnotation{},
+			want:  nil,
+		},
+		{
+			name: "only Title set",
+			input: mcp.ToolAnnotation{
+				Title: "Just a Title",
+			},
+			want: &vmcp.ToolAnnotations{
+				Title: "Just a Title",
+			},
+		},
+		{
+			name: "only ReadOnlyHint set",
+			input: mcp.ToolAnnotation{
+				ReadOnlyHint: boolPtr(true),
+			},
+			want: &vmcp.ToolAnnotations{
+				ReadOnlyHint: boolPtr(true),
+			},
+		},
+		{
+			name: "mixed hints with some nil",
+			input: mcp.ToolAnnotation{
+				Title:           "Mixed",
+				ReadOnlyHint:    boolPtr(false),
+				DestructiveHint: nil,
+				IdempotentHint:  boolPtr(true),
+				OpenWorldHint:   nil,
+			},
+			want: &vmcp.ToolAnnotations{
+				Title:          "Mixed",
+				ReadOnlyHint:   boolPtr(false),
+				IdempotentHint: boolPtr(true),
+			},
+		},
+		{
+			name: "only DestructiveHint set to false",
+			input: mcp.ToolAnnotation{
+				DestructiveHint: boolPtr(false),
+			},
+			want: &vmcp.ToolAnnotations{
+				DestructiveHint: boolPtr(false),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := ConvertToolAnnotations(tt.input)
+			if tt.want == nil {
+				assert.Nil(t, got)
+			} else {
+				require.NotNil(t, got)
+				assert.Equal(t, tt.want.Title, got.Title)
+				assert.Equal(t, tt.want.ReadOnlyHint, got.ReadOnlyHint)
+				assert.Equal(t, tt.want.DestructiveHint, got.DestructiveHint)
+				assert.Equal(t, tt.want.IdempotentHint, got.IdempotentHint)
+				assert.Equal(t, tt.want.OpenWorldHint, got.OpenWorldHint)
+			}
+		})
+	}
+}
+
+func TestConvertToolOutputSchema(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input mcp.ToolOutputSchema
+		want  map[string]any
+	}{
+		{
+			name: "schema with type and properties",
+			input: mcp.ToolOutputSchema{
+				Type: "object",
+				Properties: map[string]any{
+					"result": map[string]any{"type": "string"},
+					"count":  map[string]any{"type": "integer"},
+				},
+			},
+			want: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"result": map[string]any{"type": "string"},
+					"count":  map[string]any{"type": "integer"},
+				},
+			},
+		},
+		{
+			name:  "empty schema returns nil",
+			input: mcp.ToolOutputSchema{},
+			want:  nil,
+		},
+		{
+			name:  "schema with only type field",
+			input: mcp.ToolOutputSchema{Type: "string"},
+			want:  map[string]any{"type": "string"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := ConvertToolOutputSchema(tt.input)
+			if tt.want == nil {
+				assert.Nil(t, got)
+			} else {
+				require.NotNil(t, got)
+				// Check type field
+				assert.Equal(t, tt.want["type"], got["type"])
+				// Check properties if expected
+				if expectedProps, ok := tt.want["properties"]; ok {
+					assert.Equal(t, expectedProps, got["properties"])
+				}
+			}
+		})
+	}
+}
+
+func TestToMCPToolAnnotations(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input *vmcp.ToolAnnotations
+		check func(t *testing.T, got mcp.ToolAnnotation)
+	}{
+		{
+			name:  "nil input returns zero-valued ToolAnnotation",
+			input: nil,
+			check: func(t *testing.T, got mcp.ToolAnnotation) {
+				t.Helper()
+				assert.Empty(t, got.Title)
+				assert.Nil(t, got.ReadOnlyHint)
+				assert.Nil(t, got.DestructiveHint)
+				assert.Nil(t, got.IdempotentHint)
+				assert.Nil(t, got.OpenWorldHint)
+			},
+		},
+		{
+			name: "fully populated input",
+			input: &vmcp.ToolAnnotations{
+				Title:           "Full Tool",
+				ReadOnlyHint:    boolPtr(true),
+				DestructiveHint: boolPtr(false),
+				IdempotentHint:  boolPtr(true),
+				OpenWorldHint:   boolPtr(false),
+			},
+			check: func(t *testing.T, got mcp.ToolAnnotation) {
+				t.Helper()
+				assert.Equal(t, "Full Tool", got.Title)
+				require.NotNil(t, got.ReadOnlyHint)
+				assert.True(t, *got.ReadOnlyHint)
+				require.NotNil(t, got.DestructiveHint)
+				assert.False(t, *got.DestructiveHint)
+				require.NotNil(t, got.IdempotentHint)
+				assert.True(t, *got.IdempotentHint)
+				require.NotNil(t, got.OpenWorldHint)
+				assert.False(t, *got.OpenWorldHint)
+			},
+		},
+		{
+			name: "partial fields",
+			input: &vmcp.ToolAnnotations{
+				Title:        "Partial",
+				ReadOnlyHint: boolPtr(true),
+			},
+			check: func(t *testing.T, got mcp.ToolAnnotation) {
+				t.Helper()
+				assert.Equal(t, "Partial", got.Title)
+				require.NotNil(t, got.ReadOnlyHint)
+				assert.True(t, *got.ReadOnlyHint)
+				assert.Nil(t, got.DestructiveHint)
+				assert.Nil(t, got.IdempotentHint)
+				assert.Nil(t, got.OpenWorldHint)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := ToMCPToolAnnotations(tt.input)
+			tt.check(t, got)
+		})
+	}
+}
+
+func TestAnnotationsRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input mcp.ToolAnnotation
+	}{
+		{
+			name: "fully populated round-trips",
+			input: mcp.ToolAnnotation{
+				Title:           "Round Trip Tool",
+				ReadOnlyHint:    boolPtr(true),
+				DestructiveHint: boolPtr(false),
+				IdempotentHint:  boolPtr(true),
+				OpenWorldHint:   boolPtr(false),
+			},
+		},
+		{
+			name: "partial fields round-trip",
+			input: mcp.ToolAnnotation{
+				Title:        "Partial Round Trip",
+				ReadOnlyHint: boolPtr(false),
+			},
+		},
+		{
+			name: "only hints round-trip",
+			input: mcp.ToolAnnotation{
+				DestructiveHint: boolPtr(true),
+				OpenWorldHint:   boolPtr(true),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// mcp.ToolAnnotation -> vmcp.ToolAnnotations -> mcp.ToolAnnotation
+			intermediate := ConvertToolAnnotations(tt.input)
+			require.NotNil(t, intermediate, "intermediate should not be nil for non-empty input")
+
+			result := ToMCPToolAnnotations(intermediate)
+
+			assert.Equal(t, tt.input.Title, result.Title)
+			assert.Equal(t, tt.input.ReadOnlyHint, result.ReadOnlyHint)
+			assert.Equal(t, tt.input.DestructiveHint, result.DestructiveHint)
+			assert.Equal(t, tt.input.IdempotentHint, result.IdempotentHint)
+			assert.Equal(t, tt.input.OpenWorldHint, result.OpenWorldHint)
+		})
+	}
+}

--- a/pkg/vmcp/server/adapter/capability_adapter.go
+++ b/pkg/vmcp/server/adapter/capability_adapter.go
@@ -12,6 +12,7 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 
 	"github.com/stacklok/toolhive/pkg/vmcp"
+	"github.com/stacklok/toolhive/pkg/vmcp/conversion"
 )
 
 // CapabilityAdapter converts aggregator domain models to SDK types.
@@ -64,13 +65,25 @@ func (a *CapabilityAdapter) ToSDKTools(tools []vmcp.Tool) ([]server.ServerTool, 
 		// Create handler via factory
 		handler := a.handlerFactory.CreateToolHandler(tool.Name)
 
-		// Create SDK tool
+		// Create SDK tool with annotations and output schema
+		sdkTool := mcp.Tool{
+			Name:           tool.Name,
+			Description:    tool.Description,
+			RawInputSchema: schemaJSON,
+			Annotations:    conversion.ToMCPToolAnnotations(tool.Annotations),
+		}
+		if tool.OutputSchema != nil {
+			outputSchemaJSON, marshalErr := json.Marshal(tool.OutputSchema)
+			if marshalErr != nil {
+				slog.Warn("failed to marshal tool output schema",
+					"tool", tool.Name, "error", marshalErr)
+			} else {
+				sdkTool.RawOutputSchema = outputSchemaJSON
+			}
+		}
+
 		sdkTools = append(sdkTools, server.ServerTool{
-			Tool: mcp.Tool{
-				Name:           tool.Name,
-				Description:    tool.Description,
-				RawInputSchema: schemaJSON,
-			},
+			Tool:    sdkTool,
 			Handler: handler,
 		})
 	}
@@ -195,13 +208,25 @@ func (a *CapabilityAdapter) ToCompositeToolSDKTools(
 		// Create handler via factory (uses composite tool handler instead of backend router)
 		handler := a.handlerFactory.CreateCompositeToolHandler(tool.Name, executor)
 
-		// Create SDK tool
+		// Create SDK tool with annotations and output schema
+		sdkTool := mcp.Tool{
+			Name:           tool.Name,
+			Description:    tool.Description,
+			RawInputSchema: schemaJSON,
+			Annotations:    conversion.ToMCPToolAnnotations(tool.Annotations),
+		}
+		if tool.OutputSchema != nil {
+			outputSchemaJSON, marshalErr := json.Marshal(tool.OutputSchema)
+			if marshalErr != nil {
+				slog.Warn("failed to marshal composite tool output schema",
+					"tool", tool.Name, "error", marshalErr)
+			} else {
+				sdkTool.RawOutputSchema = outputSchemaJSON
+			}
+		}
+
 		sdkTools = append(sdkTools, server.ServerTool{
-			Tool: mcp.Tool{
-				Name:           tool.Name,
-				Description:    tool.Description,
-				RawInputSchema: schemaJSON,
-			},
+			Tool:    sdkTool,
 			Handler: handler,
 		})
 	}

--- a/pkg/vmcp/server/adapter/capability_adapter_annotations_test.go
+++ b/pkg/vmcp/server/adapter/capability_adapter_annotations_test.go
@@ -1,0 +1,199 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package adapter_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/stacklok/toolhive/pkg/vmcp"
+	"github.com/stacklok/toolhive/pkg/vmcp/server/adapter"
+	"github.com/stacklok/toolhive/pkg/vmcp/server/adapter/mocks"
+)
+
+func boolPtr(b bool) *bool { return &b }
+
+func TestCapabilityAdapter_ToSDKTools_Annotations(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		tools       []vmcp.Tool
+		setupMocks  func(*mocks.MockHandlerFactory)
+		checkResult func(*testing.T, []server.ServerTool)
+	}{
+		{
+			name: "preserves Annotations and OutputSchema in SDK output",
+			tools: []vmcp.Tool{
+				{
+					Name:        "annotated_tool",
+					Description: "Tool with annotations",
+					InputSchema: map[string]any{"type": "object"},
+					OutputSchema: map[string]any{
+						"type": "object",
+						"properties": map[string]any{
+							"result": map[string]any{"type": "string"},
+						},
+					},
+					Annotations: &vmcp.ToolAnnotations{
+						Title:           "Annotated Tool",
+						ReadOnlyHint:    boolPtr(true),
+						DestructiveHint: boolPtr(false),
+					},
+					BackendID: "backend1",
+				},
+			},
+			setupMocks: func(mf *mocks.MockHandlerFactory) {
+				mf.EXPECT().CreateToolHandler("annotated_tool").Return(func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+					return &mcp.CallToolResult{}, nil
+				})
+			},
+			checkResult: func(t *testing.T, result []server.ServerTool) {
+				t.Helper()
+				require.Len(t, result, 1)
+				tool := result[0].Tool
+				assert.Equal(t, "annotated_tool", tool.Name)
+
+				// Verify annotations are set
+				assert.Equal(t, "Annotated Tool", tool.Annotations.Title)
+				require.NotNil(t, tool.Annotations.ReadOnlyHint)
+				assert.True(t, *tool.Annotations.ReadOnlyHint)
+				require.NotNil(t, tool.Annotations.DestructiveHint)
+				assert.False(t, *tool.Annotations.DestructiveHint)
+				assert.Nil(t, tool.Annotations.IdempotentHint)
+				assert.Nil(t, tool.Annotations.OpenWorldHint)
+
+				// Verify output schema is set
+				assert.NotNil(t, tool.RawOutputSchema)
+				assert.Contains(t, string(tool.RawOutputSchema), `"result"`)
+			},
+		},
+		{
+			name: "nil Annotations produces zero-valued SDK Annotations",
+			tools: []vmcp.Tool{
+				{
+					Name:        "simple_tool",
+					Description: "Tool without annotations",
+					InputSchema: map[string]any{"type": "object"},
+					BackendID:   "backend1",
+				},
+			},
+			setupMocks: func(mf *mocks.MockHandlerFactory) {
+				mf.EXPECT().CreateToolHandler("simple_tool").Return(func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+					return &mcp.CallToolResult{}, nil
+				})
+			},
+			checkResult: func(t *testing.T, result []server.ServerTool) {
+				t.Helper()
+				require.Len(t, result, 1)
+				tool := result[0].Tool
+				// nil vmcp.ToolAnnotations -> zero-valued mcp.ToolAnnotation
+				assert.Empty(t, tool.Annotations.Title)
+				assert.Nil(t, tool.Annotations.ReadOnlyHint)
+				assert.Nil(t, tool.RawOutputSchema)
+			},
+		},
+		{
+			name: "all annotation hints populated",
+			tools: []vmcp.Tool{
+				{
+					Name:        "full_annotations_tool",
+					Description: "Tool with all annotation hints",
+					InputSchema: map[string]any{"type": "object"},
+					Annotations: &vmcp.ToolAnnotations{
+						Title:           "Full Hints",
+						ReadOnlyHint:    boolPtr(false),
+						DestructiveHint: boolPtr(true),
+						IdempotentHint:  boolPtr(true),
+						OpenWorldHint:   boolPtr(false),
+					},
+					BackendID: "backend1",
+				},
+			},
+			setupMocks: func(mf *mocks.MockHandlerFactory) {
+				mf.EXPECT().CreateToolHandler("full_annotations_tool").Return(func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+					return &mcp.CallToolResult{}, nil
+				})
+			},
+			checkResult: func(t *testing.T, result []server.ServerTool) {
+				t.Helper()
+				require.Len(t, result, 1)
+				tool := result[0].Tool
+
+				assert.Equal(t, "Full Hints", tool.Annotations.Title)
+				require.NotNil(t, tool.Annotations.ReadOnlyHint)
+				assert.False(t, *tool.Annotations.ReadOnlyHint)
+				require.NotNil(t, tool.Annotations.DestructiveHint)
+				assert.True(t, *tool.Annotations.DestructiveHint)
+				require.NotNil(t, tool.Annotations.IdempotentHint)
+				assert.True(t, *tool.Annotations.IdempotentHint)
+				require.NotNil(t, tool.Annotations.OpenWorldHint)
+				assert.False(t, *tool.Annotations.OpenWorldHint)
+			},
+		},
+		{
+			name: "OutputSchema without Annotations",
+			tools: []vmcp.Tool{
+				{
+					Name:        "schema_only_tool",
+					Description: "Tool with output schema but no annotations",
+					InputSchema: map[string]any{"type": "object"},
+					OutputSchema: map[string]any{
+						"type": "object",
+						"properties": map[string]any{
+							"status": map[string]any{"type": "string"},
+						},
+					},
+					BackendID: "backend1",
+				},
+			},
+			setupMocks: func(mf *mocks.MockHandlerFactory) {
+				mf.EXPECT().CreateToolHandler("schema_only_tool").Return(func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+					return &mcp.CallToolResult{}, nil
+				})
+			},
+			checkResult: func(t *testing.T, result []server.ServerTool) {
+				t.Helper()
+				require.Len(t, result, 1)
+				tool := result[0].Tool
+
+				// No annotations
+				assert.Empty(t, tool.Annotations.Title)
+				assert.Nil(t, tool.Annotations.ReadOnlyHint)
+
+				// Output schema should be set
+				assert.NotNil(t, tool.RawOutputSchema)
+				assert.Contains(t, string(tool.RawOutputSchema), `"status"`)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockFactory := mocks.NewMockHandlerFactory(ctrl)
+			if tt.setupMocks != nil {
+				tt.setupMocks(mockFactory)
+			}
+
+			a := adapter.NewCapabilityAdapter(mockFactory)
+			result, err := a.ToSDKTools(tt.tools)
+			require.NoError(t, err)
+
+			if tt.checkResult != nil {
+				tt.checkResult(t, result)
+			}
+		})
+	}
+}

--- a/pkg/vmcp/session/internal/backend/mcp_session.go
+++ b/pkg/vmcp/session/internal/backend/mcp_session.go
@@ -370,10 +370,12 @@ func initAndQueryCapabilities(
 		}
 		for _, t := range toolsResult.Tools {
 			caps.Tools = append(caps.Tools, vmcp.Tool{
-				Name:        t.Name,
-				Description: t.Description,
-				InputSchema: conversion.ConvertToolInputSchema(t.InputSchema),
-				BackendID:   target.WorkloadID,
+				Name:         t.Name,
+				Description:  t.Description,
+				InputSchema:  conversion.ConvertToolInputSchema(t.InputSchema),
+				OutputSchema: conversion.ConvertToolOutputSchema(t.OutputSchema),
+				Annotations:  conversion.ConvertToolAnnotations(t.Annotations),
+				BackendID:    target.WorkloadID,
 			})
 		}
 	}

--- a/pkg/vmcp/types.go
+++ b/pkg/vmcp/types.go
@@ -295,8 +295,28 @@ type Tool struct {
 	// Per MCP specification, this describes the structure of the tool's response.
 	OutputSchema map[string]any
 
+	// Annotations describes behavioral hints for the tool (optional).
+	// Per MCP specification, these include readOnlyHint, destructiveHint, etc.
+	Annotations *ToolAnnotations
+
 	// BackendID identifies the backend that provides this tool.
 	BackendID string
+}
+
+// ToolAnnotations describes behavioral hints for a tool.
+// These are the vmcp-domain equivalents of mcp.ToolAnnotation, following the
+// Anti-Corruption Layer pattern (vmcp types are decoupled from mcp-go).
+type ToolAnnotations struct {
+	// Title is a human-readable title for the tool.
+	Title string `json:"title,omitempty"`
+	// ReadOnlyHint indicates whether the tool does not modify its environment.
+	ReadOnlyHint *bool `json:"readOnlyHint,omitempty"`
+	// DestructiveHint indicates whether the tool may perform destructive updates.
+	DestructiveHint *bool `json:"destructiveHint,omitempty"`
+	// IdempotentHint indicates whether repeated calls with same args have no additional effect.
+	IdempotentHint *bool `json:"idempotentHint,omitempty"`
+	// OpenWorldHint indicates whether the tool interacts with external entities.
+	OpenWorldHint *bool `json:"openWorldHint,omitempty"`
 }
 
 // Resource represents an MCP resource capability.


### PR DESCRIPTION
## Summary

- MCP tool annotations (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`, `Title`) were silently dropped during vmcp aggregation, blocking downstream authorization profiles. This adds the `ToolAnnotations` vmcp domain type and propagates it through the full pipeline.
- `OutputSchema` existed on `vmcp.Tool` but was never populated from backend MCP servers. This populates it using the same JSON round-trip pattern as `InputSchema`.
- Both fields now flow end-to-end: backend query → tool adapter → all three conflict resolvers (prefix/priority/manual) → merge → SDK adapter output.

## Type of change

- [x] New feature

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)

22 new test cases across 4 test files:
- `pkg/vmcp/conversion/content_test.go` — conversion functions (15 cases including round-trip)
- `pkg/vmcp/aggregator/tool_adapter_annotations_test.go` — preservation through overrides (3 cases)
- `pkg/vmcp/server/adapter/capability_adapter_annotations_test.go` — SDK output (4 cases)

## Changes

| File | Change |
|------|--------|
| `pkg/vmcp/types.go` | Add `ToolAnnotations` struct and `Annotations` field to `Tool` |
| `pkg/vmcp/conversion/content.go` | Add `ConvertToolAnnotations`, `ConvertToolOutputSchema`, `ToMCPToolAnnotations` |
| `pkg/vmcp/client/client.go` | Populate `Annotations` + `OutputSchema` from backend |
| `pkg/vmcp/session/internal/backend/mcp_session.go` | Same for session-based client path |
| `pkg/vmcp/aggregator/aggregator.go` | Add fields to `ResolvedTool` |
| `pkg/vmcp/aggregator/prefix_resolver.go` | Propagate through prefix resolver |
| `pkg/vmcp/aggregator/priority_resolver.go` | Propagate through all 3 code paths |
| `pkg/vmcp/aggregator/manual_resolver.go` | Propagate through manual resolver |
| `pkg/vmcp/aggregator/default_aggregator.go` | Propagate through fallback + merge |
| `pkg/vmcp/aggregator/tool_adapter.go` | Preserve through filtering/renaming |
| `pkg/vmcp/server/adapter/capability_adapter.go` | Emit `Annotations` and `RawOutputSchema` to SDK types |

## Does this introduce a user-facing change?

No direct user-facing change. Backend MCP tool annotations and output schemas are now preserved through vmcp aggregation instead of being silently dropped. This enables downstream consumers (like authorization profiles) to use these fields.

## Special notes for reviewers

- **ACL pattern preserved**: `vmcp.ToolAnnotations` is a vmcp-owned type (not `mcp.ToolAnnotation` directly) to maintain the Anti-Corruption Layer — mcp-go is only used at ingestion and SDK adapter boundaries.
- **PR 2 follow-up**: `Icons`, `Execution`, Resource `Annotations`, and Prompt `Icons` are deferred to a follow-up PR per the split strategy.
- **`ConvertToolOutputSchema` nil check**: Uses `schema.Type == ""` rather than byte-length check because a zero-valued `ToolOutputSchema` marshals to `{"type":"","properties":{},"required":[]}` (non-empty JSON but semantically empty).

Generated with [Claude Code](https://claude.com/claude-code)