### PR TITLE
Fix Content-Length mismatch in authz response filter with remote proxies

### DIFF
--- a/pkg/authz/response_filter.go
+++ b/pkg/authz/response_filter.go
@@ -85,8 +85,15 @@ func (rfw *ResponseFilteringWriter) FlushAndFilter() error {
 
 	switch mimeType {
 	case "application/json":
+		// Remove the upstream Content-Length header. The reverse proxy copies it
+		// from the backend response via Header() (which we don't override), but
+		// filtering changes the body size. Without this, Go's HTTP server detects
+		// the mismatch and tears down the connection.
+		rfw.ResponseWriter.Header().Del("Content-Length")
 		return rfw.processJSONResponse(rawResponse)
 	case "text/event-stream":
+		// Same issue: filtering changes the SSE payload size.
+		rfw.ResponseWriter.Header().Del("Content-Length")
 		return rfw.processSSEResponse(rawResponse)
 	default:
 		rfw.ResponseWriter.WriteHeader(rfw.statusCode)
@@ -97,8 +104,16 @@ func (rfw *ResponseFilteringWriter) FlushAndFilter() error {
 
 // Flush implements http.Flusher if the underlying ResponseWriter supports it.
 // This method is required for streaming support (SSE, streamable-http).
+//
+// We must delete the Content-Length header before flushing because
+// httputil.ReverseProxy (with FlushInterval: -1) calls Flush() after copying
+// the backend response. The first Flush() on the underlying writer triggers an
+// implicit WriteHeader(200), sending headers to the wire. If the stale
+// Content-Length is still present at that point, it's too late to remove it in
+// FlushAndFilter().
 func (rfw *ResponseFilteringWriter) Flush() {
 	if flusher, ok := rfw.ResponseWriter.(http.Flusher); ok {
+		rfw.ResponseWriter.Header().Del("Content-Length")
 		flusher.Flush()
 	}
 }

--- a/pkg/authz/response_filter_test.go
+++ b/pkg/authz/response_filter_test.go
@@ -4,9 +4,15 @@
 package authz
 
 import (
+	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/http/httputil"
+	"net/url"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/golang-jwt/jwt/v5"
@@ -17,6 +23,7 @@ import (
 
 	"github.com/stacklok/toolhive/pkg/auth"
 	"github.com/stacklok/toolhive/pkg/authz/authorizers/cedar"
+	mcpparser "github.com/stacklok/toolhive/pkg/mcp"
 )
 
 func TestResponseFilteringWriter(t *testing.T) {
@@ -304,4 +311,190 @@ func TestResponseFilteringWriter_ErrorResponse(t *testing.T) {
 
 	// Verify the error response passed through unchanged
 	assert.Equal(t, responseBytes, rr.Body.Bytes(), "Error response should pass through unchanged")
+}
+
+// TestResponseFilteringWriter_ContentLengthMismatch reproduces a bug where
+// httputil.ReverseProxy copies the backend's Content-Length header to the
+// underlying ResponseWriter via Header() (which ResponseFilteringWriter does
+// NOT override). When FlushAndFilter later writes a filtered (shorter) body,
+// the Content-Length no longer matches the actual body, causing Go's HTTP
+// server to produce a truncated or corrupt response.
+//
+// The bug requires a real HTTP server to manifest because httptest.NewRecorder
+// does not enforce Content-Length consistency the way net/http.Server does.
+func TestResponseFilteringWriter_ContentLengthMismatch(t *testing.T) {
+	t.Parallel()
+
+	// Create a Cedar authorizer that only permits the "weather" tool.
+	// The backend will return 3 tools, so filtering will shrink the response.
+	authorizer, err := cedar.NewCedarAuthorizer(cedar.ConfigOptions{
+		Policies: []string{
+			`permit(principal, action == Action::"call_tool", resource == Tool::"weather");`,
+		},
+		EntitiesJSON: `[]`,
+	})
+	require.NoError(t, err, "Failed to create Cedar authorizer")
+
+	// Build the backend response: a tools/list result with 3 tools.
+	backendResult := mcp.ListToolsResult{
+		Tools: []mcp.Tool{
+			{Name: "weather", Description: "Get weather information"},
+			{Name: "calculator", Description: "Perform calculations"},
+			{Name: "translator", Description: "Translate text between languages"},
+		},
+	}
+	resultData, err := json.Marshal(backendResult)
+	require.NoError(t, err)
+
+	backendRPCResponse := &jsonrpc2.Response{
+		ID:     jsonrpc2.Int64ID(1),
+		Result: json.RawMessage(resultData),
+	}
+	backendBody, err := jsonrpc2.EncodeMessage(backendRPCResponse)
+	require.NoError(t, err)
+
+	// Create the backend server that returns the full tools/list response
+	// with an accurate Content-Length header (as a real MCP server would).
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Content-Length", strconv.Itoa(len(backendBody)))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(backendBody)
+	}))
+	defer backend.Close()
+
+	backendURL, err := url.Parse(backend.URL)
+	require.NoError(t, err)
+
+	// Create the frontend server that:
+	// 1. Injects identity + parsed MCP request into context (normally done by
+	//    auth and parser middleware).
+	// 2. Wraps the ResponseWriter with ResponseFilteringWriter (as the authz
+	//    middleware does).
+	// 3. Proxies to the backend via httputil.ReverseProxy.
+	// 4. Calls FlushAndFilter after the proxy returns.
+	frontend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Inject identity into context (Cedar authorizer reads claims from it).
+		identity := &auth.Identity{
+			Subject: "user123",
+			Name:    "Test User",
+			Claims: jwt.MapClaims{
+				"sub":  "user123",
+				"name": "Test User",
+			},
+		}
+		ctx := auth.WithIdentity(r.Context(), identity)
+
+		// Inject parsed MCP request into context (authz middleware reads method from it).
+		parsed := &mcpparser.ParsedMCPRequest{
+			Method: string(mcp.MethodToolsList),
+			ID:     float64(1),
+		}
+		ctx = context.WithValue(ctx, mcpparser.MCPRequestContextKey, parsed)
+		r = r.WithContext(ctx)
+
+		// Wrap the real ResponseWriter with ResponseFilteringWriter,
+		// exactly as the authz middleware does in middleware.go.
+		filteringWriter := NewResponseFilteringWriter(w, authorizer, r, string(mcp.MethodToolsList))
+
+		// Proxy to the backend. ReverseProxy will call w.Header() to copy
+		// the backend's Content-Length into the response header map. Since
+		// ResponseFilteringWriter does not override Header(), this goes
+		// directly to the real http.ResponseWriter.
+		//
+		// FlushInterval: -1 matches the production transparent proxy
+		// (transparent_proxy.go), which flushes after every write. This is
+		// critical: the flush triggers an implicit WriteHeader on the real
+		// writer, sending headers (including any stale Content-Length) to
+		// the wire before FlushAndFilter() runs.
+		proxy := httputil.NewSingleHostReverseProxy(backendURL)
+		proxy.FlushInterval = -1
+		proxy.ServeHTTP(filteringWriter, r)
+
+		// Flush the filtered (shorter) response to the real writer.
+		if flushErr := filteringWriter.FlushAndFilter(); flushErr != nil {
+			t.Errorf("FlushAndFilter returned error: %v", flushErr)
+		}
+	}))
+	defer frontend.Close()
+
+	// Build a JSON-RPC tools/list request.
+	rpcRequest := map[string]interface{}{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "tools/list",
+	}
+	reqBody, err := json.Marshal(rpcRequest)
+	require.NoError(t, err)
+
+	// Send the request to the frontend.
+	resp, err := http.Post(
+		frontend.URL+"/mcp",
+		"application/json",
+		strings.NewReader(string(reqBody)),
+	)
+	require.NoError(t, err, "HTTP request to frontend should succeed")
+	defer resp.Body.Close()
+
+	// Read the full response body. Because of the Content-Length mismatch bug,
+	// Go's HTTP server may tear down the connection, causing an unexpected EOF
+	// on the client side. We tolerate read errors here so we can inspect
+	// whichever failure mode manifests.
+	body, readErr := io.ReadAll(resp.Body)
+
+	// ---- Bug assertion ----
+	// The bug manifests in one of two ways:
+	//
+	// 1. The client gets an "unexpected EOF" because Go's HTTP server detects
+	//    that the handler wrote fewer bytes than the declared Content-Length
+	//    and aborts the connection.
+	//
+	// 2. The Content-Length header (copied from the backend's unfiltered
+	//    response) does not match the actual body length.
+	//
+	// Either condition proves the bug exists. A correct implementation would
+	// let the client read the complete filtered body with a matching
+	// Content-Length (or no Content-Length at all, letting chunked encoding
+	// handle it).
+
+	if readErr != nil {
+		// Failure mode 1: connection was torn down due to Content-Length mismatch.
+		// The client could not even read the full response.
+		t.Fatalf("BUG: client received read error due to Content-Length mismatch: %v\n"+
+			"The backend's Content-Length header leaked through ResponseFilteringWriter.\n"+
+			"The filtered body is shorter than the declared Content-Length, so Go's HTTP\n"+
+			"server aborted the connection.", readErr)
+	}
+
+	// If we got here, the body was readable. Check Content-Length consistency.
+	clHeader := resp.Header.Get("Content-Length")
+	if clHeader != "" {
+		declaredLength, convErr := strconv.Atoi(clHeader)
+		require.NoError(t, convErr, "Content-Length should be a valid integer")
+
+		// Failure mode 2: Content-Length does not match actual body length.
+		require.Equal(t, len(body), declaredLength,
+			"BUG: Content-Length header (%d) does not match actual body length (%d).\n"+
+				"The backend's unfiltered Content-Length leaked through ResponseFilteringWriter.\n"+
+				"After filtering removed 2 of 3 tools, the body shrank but the header was not updated.",
+			declaredLength, len(body))
+	}
+
+	// If we somehow got past both checks, verify the response is valid and
+	// correctly filtered.
+	message, err := jsonrpc2.DecodeMessage(body)
+	require.NoError(t, err, "Response body should be valid JSON-RPC")
+
+	rpcResp, ok := message.(*jsonrpc2.Response)
+	require.True(t, ok, "Should be a JSON-RPC response")
+	require.Nil(t, rpcResp.Error, "Response should not contain an error")
+
+	var toolsResult mcp.ListToolsResult
+	err = json.Unmarshal(rpcResp.Result, &toolsResult)
+	require.NoError(t, err, "Should unmarshal tools list result")
+
+	assert.Len(t, toolsResult.Tools, 1, "Only the permitted 'weather' tool should remain")
+	if len(toolsResult.Tools) > 0 {
+		assert.Equal(t, "weather", toolsResult.Tools[0].Name)
+	}
 }


### PR DESCRIPTION
When httputil.ReverseProxy forwards a response from a remote MCP server, it copies the backend's Content-Length header to the ResponseWriter via Header(). ResponseFilteringWriter does not override Header(), so the original Content-Length leaks to the real writer. After Cedar policy filtering changes the response body size, Go's HTTP server detects the mismatch and tears down the connection.

Delete the stale Content-Length header before writing filtered responses for both JSON and SSE content types. Go's HTTP library will handle correct framing automatically.

Fixes: #4044