### PR TITLE
fix(session): close streamable session resources on delete

### DIFF
--- a/pkg/transport/session/manager.go
+++ b/pkg/transport/session/manager.go
@@ -7,6 +7,7 @@ package session
 import (
 	"context"
 	"fmt"
+	"io"
 	"log/slog"
 	"time"
 )
@@ -206,6 +207,15 @@ func (m *Manager) UpsertSession(session Session) error {
 func (m *Manager) Delete(id string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultOperationTimeout)
 	defer cancel()
+
+	if sess, err := m.storage.Load(ctx, id); err == nil {
+		if closer, ok := sess.(io.Closer); ok {
+			if closeErr := closer.Close(); closeErr != nil {
+				slog.Warn("failed to close session during delete", "session_id", id, "error", closeErr)
+			}
+		}
+	}
+
 	return m.storage.Delete(ctx, id)
 }
 

--- a/pkg/transport/session/manager_test.go
+++ b/pkg/transport/session/manager_test.go
@@ -74,6 +74,26 @@ func TestDeleteSession(t *testing.T) {
 	assert.False(t, ok, "deleted session should not be found")
 }
 
+func TestDeleteSession_ClosesStreamableSession(t *testing.T) {
+	t.Parallel()
+
+	factory := &stubFactory{fixedTime: time.Now()}
+	m := NewManager(time.Hour, factory.New)
+	defer m.Stop()
+
+	session := NewStreamableSession("stream-del").(*StreamableSession)
+	require.NoError(t, m.AddSession(session))
+	require.NoError(t, m.Delete("stream-del"))
+
+	assert.True(t, session.disconnected, "streamable session should be disconnected on delete")
+
+	_, ok := <-session.MessageCh
+	assert.False(t, ok, "message channel should be closed")
+
+	_, ok = <-session.ResponseCh
+	assert.False(t, ok, "response channel should be closed")
+}
+
 func TestGetUpdatesTimestamp(t *testing.T) {
 	t.Parallel()
 	oldTime := time.Now().Add(-1 * time.Minute)

--- a/pkg/transport/session/streamable_session.go
+++ b/pkg/transport/session/streamable_session.go
@@ -5,6 +5,7 @@ package session
 
 import (
 	"errors"
+	"sync"
 
 	"golang.org/x/exp/jsonrpc2"
 )
@@ -12,9 +13,10 @@ import (
 // StreamableSession represents a Streamable HTTP session
 type StreamableSession struct {
 	*ProxySession
-	MessageCh    chan jsonrpc2.Message
-	ResponseCh   chan jsonrpc2.Message
-	disconnected bool
+	MessageCh      chan jsonrpc2.Message
+	ResponseCh     chan jsonrpc2.Message
+	disconnected   bool
+	disconnectOnce sync.Once
 }
 
 // NewStreamableSession constructs a new streamable session with buffered channels
@@ -42,14 +44,19 @@ func (s *StreamableSession) GetData() interface{} {
 // SetData is a no-op for StreamableSession; channel stats are exposed via GetData.
 func (*StreamableSession) SetData(interface{}) {}
 
-// Disconnect closes channels and marks session as disconnected
+// Disconnect closes channels and marks session as disconnected.
 func (s *StreamableSession) Disconnect() {
-	if s.disconnected {
-		return
-	}
-	close(s.MessageCh)
-	close(s.ResponseCh)
-	s.disconnected = true
+	s.disconnectOnce.Do(func() {
+		close(s.MessageCh)
+		close(s.ResponseCh)
+		s.disconnected = true
+	})
+}
+
+// Close allows StreamableSession to satisfy io.Closer so storage cleanup can eagerly release resources.
+func (s *StreamableSession) Close() error {
+	s.Disconnect()
+	return nil
 }
 
 // SendMessage pushes message to MessageCh


### PR DESCRIPTION
## Summary

- `DELETE` on a streamable session removed storage state but did not explicitly disconnect/close the session channels first.
- `Manager.Delete` now loads the session and calls `Close()` when available before deleting from storage.
- `StreamableSession` now implements `io.Closer` via `Close()` and makes `Disconnect()` idempotent with `sync.Once`.
- Added a regression test to verify deleting a streamable session closes channels and marks the session disconnected.

Fixes #4062

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [ ] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [ ] Linting (`task lint-fix`)
- [x] Manual testing (describe below)

Manual testing performed:
- `git diff --check upstream/main...HEAD`
- Attempted targeted unit test: `go test ./pkg/transport/session -run TestDeleteSession_ClosesStreamableSession -count=1`
  - Not runnable in this environment because required Go 1.26 toolchain is unavailable.

## Changes

| File | Change |
|------|--------|
| `pkg/transport/session/manager.go` | Call `Close()` on loaded session (when implemented) before deleting from storage. |
| `pkg/transport/session/streamable_session.go` | Add idempotent disconnect with `sync.Once` and implement `Close() error`. |
| `pkg/transport/session/manager_test.go` | Add `TestDeleteSession_ClosesStreamableSession` regression coverage. |

## Does this introduce a user-facing change?

No.

## Special notes for reviewers

- This PR intentionally scopes to streamable session teardown during delete.
- It does not include the large-loop memory benchmark from the issue; this is a targeted fix plus regression test around channel/resource cleanup.
