### PR TITLE
Clean up client filtering after PR #3889

### DIFF
--- a/cmd/thv/app/client.go
+++ b/cmd/thv/app/client.go
@@ -125,7 +125,7 @@ func clientSetupCmdFunc(cmd *cobra.Command, _ []string) error {
 
 	selectedClients, selectedGroups, confirmed, err := ui.RunClientSetup(availableClients, availableGroups)
 	if err != nil {
-		if errors.Is(err, ui.ErrAllClientsRegistered) {
+		if errors.Is(err, client.ErrAllClientsRegistered) {
 			fmt.Println("All installed clients are already registered for the selected groups.")
 			return nil
 		}

--- a/cmd/thv/app/ui/clients_setup.go
+++ b/cmd/thv/app/ui/clients_setup.go
@@ -5,7 +5,6 @@
 package ui
 
 import (
-	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -16,10 +15,6 @@ import (
 	"github.com/stacklok/toolhive/pkg/client"
 	"github.com/stacklok/toolhive/pkg/groups"
 )
-
-// ErrAllClientsRegistered is returned when all available clients are already
-// registered for the selected groups.
-var ErrAllClientsRegistered = errors.New("all installed clients are already registered for the selected groups")
 
 var (
 	docStyle          = lipgloss.NewStyle().Margin(1, 2)
@@ -143,6 +138,19 @@ func (m *setupModel) View() string {
 	return docStyle.Render(b.String())
 }
 
+// selectedGroups returns the groups corresponding to SelectedGroups indices,
+// skipping any index that is out of bounds.
+func (m *setupModel) selectedGroups() []*groups.Group {
+	selected := make([]*groups.Group, 0, len(m.SelectedGroups))
+	for i := range m.SelectedGroups {
+		if i < 0 || i >= len(m.Groups) {
+			continue
+		}
+		selected = append(selected, m.Groups[i])
+	}
+	return selected
+}
+
 // filterClientsBySelectedGroups replaces Clients with a filtered subset
 // that excludes clients already registered in all selected groups, and
 // resets SelectedClients since the indices would no longer be valid.
@@ -151,20 +159,16 @@ func (m *setupModel) filterClientsBySelectedGroups() {
 		return
 	}
 
-	var selectedGroups []*groups.Group
-	for i := range m.SelectedGroups {
-		selectedGroups = append(selectedGroups, m.Groups[i])
-	}
-
-	m.Clients = client.FilterClientsAlreadyRegistered(m.UnfilteredClients, selectedGroups)
+	m.Clients = client.FilterClientsAlreadyRegistered(m.UnfilteredClients, m.selectedGroups())
 	m.SelectedClients = make(map[int]struct{})
 }
 
 // sortedSelectedGroupNames returns selected group names in sorted order.
 func (m *setupModel) sortedSelectedGroupNames() []string {
-	names := make([]string, 0, len(m.SelectedGroups))
-	for i := range m.SelectedGroups {
-		names = append(names, m.Groups[i].Name)
+	sg := m.selectedGroups()
+	names := make([]string, 0, len(sg))
+	for _, g := range sg {
+		names = append(names, g.Name)
 	}
 	sort.Strings(names)
 	return names
@@ -222,31 +226,23 @@ func RunClientSetup(
 		currentStep = stepGroupSelection
 	}
 
-	// When skipping group selection, filter out already-registered clients
-	displayClients := clients
-	if currentStep == stepClientSelection && len(selectedGroupsMap) > 0 {
-		var selectedGroups []*groups.Group
-		for i := range selectedGroupsMap {
-			selectedGroups = append(selectedGroups, availableGroups[i])
-		}
-		displayClients = client.FilterClientsAlreadyRegistered(clients, selectedGroups)
-		if len(displayClients) == 0 {
-			groupNames := make([]string, 0, len(selectedGroupsMap))
-			for i := range selectedGroupsMap {
-				groupNames = append(groupNames, availableGroups[i].Name)
-			}
-			sort.Strings(groupNames)
-			return nil, groupNames, false, ErrAllClientsRegistered
-		}
-	}
-
 	model := &setupModel{
 		UnfilteredClients: clients,
-		Clients:           displayClients,
+		Clients:           clients,
 		Groups:            availableGroups,
 		SelectedClients:   make(map[int]struct{}),
 		SelectedGroups:    selectedGroupsMap,
 		CurrentStep:       currentStep,
+	}
+
+	// When skipping group selection, filter out already-registered clients
+	if currentStep == stepClientSelection && len(selectedGroupsMap) > 0 {
+		sg := model.selectedGroups()
+		model.Clients = client.FilterClientsAlreadyRegistered(clients, sg)
+		if len(model.Clients) == 0 {
+			groupNames := model.sortedSelectedGroupNames()
+			return nil, groupNames, false, client.ErrAllClientsRegistered
+		}
 	}
 
 	p := tea.NewProgram(model)
@@ -259,7 +255,7 @@ func RunClientSetup(
 
 	if m.AllFiltered {
 		groupNames := m.sortedSelectedGroupNames()
-		return nil, groupNames, false, ErrAllClientsRegistered
+		return nil, groupNames, false, client.ErrAllClientsRegistered
 	}
 
 	var selectedClients []client.ClientAppStatus

--- a/cmd/thv/app/ui/selected_groups_test.go
+++ b/cmd/thv/app/ui/selected_groups_test.go
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package ui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/stacklok/toolhive/pkg/client"
+	"github.com/stacklok/toolhive/pkg/groups"
+)
+
+func TestSelectedGroups_BoundsCheck(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		grps           []*groups.Group
+		selectedGroups map[int]struct{}
+		wantNames      []string
+	}{
+		{
+			name: "all indices out of bounds returns empty",
+			grps: []*groups.Group{
+				{Name: "only-group"},
+			},
+			selectedGroups: map[int]struct{}{99: {}, -1: {}},
+			wantNames:      nil,
+		},
+		{
+			name: "mix of valid and out-of-bounds indices",
+			grps: []*groups.Group{
+				{Name: "alpha"},
+				{Name: "beta"},
+			},
+			selectedGroups: map[int]struct{}{0: {}, 50: {}, 1: {}},
+			wantNames:      []string{"alpha", "beta"},
+		},
+		{
+			name:           "empty selection returns empty",
+			grps:           []*groups.Group{{Name: "g1"}},
+			selectedGroups: map[int]struct{}{},
+			wantNames:      nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			m := &setupModel{
+				Groups:         tt.grps,
+				SelectedGroups: tt.selectedGroups,
+			}
+
+			got := m.selectedGroups()
+
+			var gotNames []string
+			for _, g := range got {
+				gotNames = append(gotNames, g.Name)
+			}
+			assert.ElementsMatch(t, tt.wantNames, gotNames)
+		})
+	}
+}
+
+func TestFilterClientsBySelectedGroups_OutOfBoundsIndices(t *testing.T) {
+	t.Parallel()
+
+	allClients := []client.ClientAppStatus{
+		{ClientType: client.VSCode, Installed: true},
+		{ClientType: client.Cursor, Installed: true},
+	}
+
+	m := &setupModel{
+		UnfilteredClients: allClients,
+		Clients:           allClients,
+		Groups: []*groups.Group{
+			{Name: "group1", RegisteredClients: []string{"vscode"}},
+		},
+		SelectedClients: make(map[int]struct{}),
+		SelectedGroups:  map[int]struct{}{0: {}, 99: {}}, // 99 is out of bounds
+		CurrentStep:     stepGroupSelection,
+	}
+
+	// Press enter to trigger transition which calls filterClientsBySelectedGroups
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	result := updated.(*setupModel)
+
+	assert.Equal(t, stepClientSelection, result.CurrentStep)
+	assert.False(t, result.Quitting)
+	assert.False(t, result.AllFiltered)
+	// Only cursor remains; vscode was filtered by group1, OOB index 99 safely ignored
+	assert.Len(t, result.Clients, 1)
+	assert.Equal(t, client.Cursor, result.Clients[0].ClientType)
+}

--- a/pkg/client/filter.go
+++ b/pkg/client/filter.go
@@ -4,8 +4,15 @@
 package client
 
 import (
+	"errors"
+	"slices"
+
 	"github.com/stacklok/toolhive/pkg/groups"
 )
+
+// ErrAllClientsRegistered is returned when all available clients are already
+// registered for the selected groups.
+var ErrAllClientsRegistered = errors.New("all installed clients are already registered for the selected groups")
 
 // FilterClientsAlreadyRegistered returns only clients that are NOT already
 // registered in all of the provided groups. A client is excluded only when
@@ -29,14 +36,7 @@ func FilterClientsAlreadyRegistered(
 
 func isClientRegisteredInAllGroups(clientName string, selectedGroups []*groups.Group) bool {
 	for _, group := range selectedGroups {
-		found := false
-		for _, registered := range group.RegisteredClients {
-			if registered == clientName {
-				found = true
-				break
-			}
-		}
-		if !found {
+		if !slices.Contains(group.RegisteredClients, clientName) {
 			return false
 		}
 	}


### PR DESCRIPTION
## Summary

PR #3889 added client filtering in `thv client setup`. Code review identified four mechanical cleanup items — no behavior changes, just improved consistency and safety.

- Move `ErrAllClientsRegistered` sentinel from `cmd/thv/app/ui/` to `pkg/client/` to match project convention (sentinel errors live in `pkg/`)
- Replace hand-rolled inner loop with `slices.Contains` in `isClientRegisteredInAllGroups`, matching the pattern used in `pkg/groups/skills.go`
- Extract `selectedGroups()` helper to deduplicate the map-to-groups-slice logic shared by `filterClientsBySelectedGroups()` and `RunClientSetup()`
- Add bounds check on group indices before indexing `m.Groups` to guard against out-of-bounds panics

## Type of change

- [x] Refactoring (no behavior change)

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)

## Changes

| File | Change |
|------|--------|
| `pkg/client/filter.go` | Add `ErrAllClientsRegistered` sentinel, use `slices.Contains` |
| `cmd/thv/app/ui/clients_setup.go` | Remove local sentinel, extract `selectedGroups()` with bounds check, use it in `filterClientsBySelectedGroups`, `sortedSelectedGroupNames`, and `RunClientSetup` |
| `cmd/thv/app/client.go` | Update `ui.ErrAllClientsRegistered` → `client.ErrAllClientsRegistered` |
| `cmd/thv/app/ui/selected_groups_test.go` | New tests for bounds check and out-of-bounds filtering |

## Does this introduce a user-facing change?

No

Generated with [Claude Code](https://claude.com/claude-code)