### PR TITLE
test(authserver): deflake cleanup loop periodic assertion

### DIFF
--- a/pkg/authserver/storage/memory_test.go
+++ b/pkg/authserver/storage/memory_test.go
@@ -724,8 +724,9 @@ func TestMemoryStorage_CleanupLoop(t *testing.T) {
 		require.NoError(t, storage.CreateAuthorizeCodeSession(ctx, "expired", expiredRequest))
 		assert.Equal(t, 1, storage.Stats().AuthCodes)
 
-		time.Sleep(100 * time.Millisecond)
-		assert.Equal(t, 0, storage.Stats().AuthCodes)
+		require.Eventually(t, func() bool {
+			return storage.Stats().AuthCodes == 0
+		}, 2*time.Second, 25*time.Millisecond, "expired auth code should be cleaned up")
 	})
 
 	t.Run("close stops cleanup goroutine", func(t *testing.T) {


### PR DESCRIPTION
## Summary

- `TestMemoryStorage_CleanupLoop/cleanup runs periodically` was flaky because it relied on a fixed `time.Sleep(100ms)` and could miss cleanup execution under load.
- Replaced the fixed sleep with `require.Eventually(..., 2*time.Second, 25*time.Millisecond)` so the assertion waits deterministically until the cleanup loop removes expired auth codes.

Fixes #4096

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [ ] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [ ] Linting (`task lint-fix`)
- [x] Manual testing (describe below)

Manual testing:
- Verified the updated test logic now polls for cleanup completion instead of assuming cleanup has run at a fixed time boundary.
- Ran `git diff --check` to confirm no whitespace or patch formatting issues.
- Attempted to run targeted unit tests, but local Go attempted to download toolchain `go1.26` and failed with `toolchain not available` in this environment.

## Does this introduce a user-facing change?

No.
