### PR TITLE
Fix flaky TestMemoryStorage_CleanupLoop timing test

### DIFF
--- a/pkg/authserver/storage/memory_test.go
+++ b/pkg/authserver/storage/memory_test.go
@@ -133,7 +133,7 @@ func withStorage(t *testing.T, fn func(context.Context, *MemoryStorage)) {
 	t.Parallel()
 	storage := NewMemoryStorage()
 	defer storage.Close()
-	fn(context.Background(), storage)
+	fn(t.Context(), storage)
 }
 
 func requireNotFoundError(t *testing.T, err error) {
@@ -715,7 +715,7 @@ func TestMemoryStorage_CleanupLoop(t *testing.T) {
 
 	t.Run("cleanup runs periodically", func(t *testing.T) {
 		t.Parallel()
-		ctx := context.Background()
+		ctx := t.Context()
 		storage := NewMemoryStorage(WithCleanupInterval(50 * time.Millisecond))
 		defer storage.Close()
 
@@ -724,8 +724,9 @@ func TestMemoryStorage_CleanupLoop(t *testing.T) {
 		require.NoError(t, storage.CreateAuthorizeCodeSession(ctx, "expired", expiredRequest))
 		assert.Equal(t, 1, storage.Stats().AuthCodes)
 
-		time.Sleep(100 * time.Millisecond)
-		assert.Equal(t, 0, storage.Stats().AuthCodes)
+		require.Eventually(t, func() bool {
+			return storage.Stats().AuthCodes == 0
+		}, 2*time.Second, 25*time.Millisecond, "expired auth code should be cleaned up")
 	})
 
 	t.Run("close stops cleanup goroutine", func(t *testing.T) {


### PR DESCRIPTION
## Summary

- `TestMemoryStorage_CleanupLoop/cleanup_runs_periodically` was flaky because it used a fixed 100ms `time.Sleep` to wait for a 50ms cleanup goroutine. Under load (especially with `-race` and many parallel tests), the goroutine wouldn't always fire within that window, causing intermittent `expected: 0, actual: 1` failures.
- Replace the sleep with `require.Eventually` polling (25ms interval, 2s timeout), making the test deterministic regardless of system load. Also switch `context.Background()` to `t.Context()` per project conventions.

Fixes #4096

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test`)
- Ran the specific test 5 times with `-race -count=5` — all passed consistently.
- Ran the full `pkg/authserver/storage/` test suite with `-race` — all passed.

Generated with [Claude Code](https://claude.com/claude-code)