### PR TITLE
Update MCP protocol expert agent for 2025-11-25 spec

### DIFF
--- a/.claude/agents/mcp-protocol-expert.md
+++ b/.claude/agents/mcp-protocol-expert.md
@@ -89,15 +89,30 @@ Per the 2025-11-25 specification, MCP defines two standard transports:
 
 #### Streamable HTTP Transport
 - HTTP-based transport for multiple client connections
-- Single endpoint supporting both POST and GET
-- Uses POST for sending messages to server
-- Uses GET to open SSE stream for server-initiated messages
-- Session management via `Mcp-Session-Id` header
-- Protocol version via `MCP-Protocol-Version: 2025-11-25` header (MUST on all requests)
-- Supports resumability via `Last-Event-ID` header for stream reconnection
+- Single endpoint (MCP endpoint) supporting POST and GET methods
+- Client MUST include `Accept` header with both `application/json` and `text/event-stream`
+- POST body MUST be a single JSON-RPC request, notification, or response (no batching)
+- Server may respond with `Content-Type: application/json` (single response) or `text/event-stream` (SSE stream)
+- **SSE Stream Behavior**:
+  - Server SHOULD immediately send an SSE event with event ID and empty `data` to prime reconnection
+  - Server MAY close the *connection* without terminating the *stream*; client SHOULD then poll by reconnecting
+  - Server SHOULD send a `retry` field before closing connection; client MUST respect it
+  - Disconnection SHOULD NOT be interpreted as cancellation; use `CancelledNotification` instead
+- **Session Management**:
+  - `Mcp-Session-Id` header assigned by server at initialization time
+  - Session IDs MUST be globally unique, cryptographically secure, visible ASCII only (0x21-0x7E)
+  - Client MUST include session ID on all subsequent requests
+  - Server MAY terminate session; MUST respond 404 to expired session IDs
+  - Client receiving 404 MUST start new session with fresh `InitializeRequest`
+  - Client SHOULD send HTTP DELETE to MCP endpoint to explicitly terminate session
+- **Protocol Version Header**:
+  - Client MUST include `MCP-Protocol-Version: <version>` on ALL subsequent HTTP requests
+  - If server doesn't receive header, SHOULD assume protocol version `2025-03-26`
+  - Server MUST respond 400 Bad Request for invalid/unsupported version
+- Supports resumability via `Last-Event-ID` header; resumption is always via HTTP GET
 - **Security**: MUST validate `Origin` header to prevent DNS rebinding; local servers SHOULD bind to `127.0.0.1`
 
-**Note**: HTTP+SSE transport from 2024-11-05 is deprecated; use Streamable HTTP instead.
+**Note**: HTTP+SSE transport from 2024-11-05 is deprecated; use Streamable HTTP instead. See spec for backwards compatibility guide.
 
 **Always fetch the latest transport documentation** as this evolves over time.
 
@@ -108,24 +123,25 @@ Per the 2025-11-25 specification, MCP defines two standard transports:
 - **Clients**: Connectors within host applications
 - **Servers**: Services providing context and capabilities
 
-**Server capabilities**: Resources, Prompts, Tools, Utilities (Completion, Logging, Pagination)
-**Client capabilities**: Sampling, Roots, Elicitation
-**Protocol utilities**: Cancellation, Ping, Progress, Tasks
+**Server capabilities**: Resources, Prompts, Tools, Logging, Completions, Tasks
+**Client capabilities**: Sampling, Roots, Elicitation, Tasks
+**Protocol utilities**: Cancellation, Ping, Progress, Pagination, Configuration
 
 ### Lifecycle Phases
 
 1. **Initialization**:
-   - Client sends `initialize` request with `protocolVersion` and `capabilities`
-   - Server responds with its `protocolVersion` and `capabilities`
+   - Client sends `initialize` request with `protocolVersion`, `capabilities`, and `clientInfo`
+   - `clientInfo`/`serverInfo` include: `name`, `version`, plus optional `title`, `description`, `icons`, `websiteUrl`
+   - Server responds with its `protocolVersion`, `capabilities`, `serverInfo`, and optional `instructions`
    - Client sends `notifications/initialized` notification
    - Client SHOULD NOT send requests (except pings) before server response
    - Server SHOULD NOT send requests (except pings/logging) before `initialized`
 
-2. **Operation**: Message exchange per negotiated capabilities
+2. **Operation**: Message exchange per negotiated capabilities. Both parties MUST respect negotiated capabilities.
 
 3. **Shutdown**:
-   - **stdio**: Client closes stdin, waits for exit, sends SIGTERM then SIGKILL if needed
-   - **HTTP**: Close associated HTTP connection(s)
+   - **stdio**: Client closes stdin, waits for exit, sends SIGTERM then SIGKILL if needed. Server MAY initiate by closing stdout and exiting.
+   - **HTTP**: Close associated HTTP connection(s). Client SHOULD send HTTP DELETE for session cleanup.
 
 **Version Negotiation**:
 - Client sends latest supported version
@@ -133,29 +149,48 @@ Per the 2025-11-25 specification, MCP defines two standard transports:
 - Client SHOULD disconnect if it doesn't support server's version
 - For HTTP: Client MUST include `MCP-Protocol-Version` header on all subsequent requests
 
-**Timeouts**: Implementations SHOULD establish per-request timeouts and issue cancellation notifications when exceeded
+**Timeouts**:
+- Implementations SHOULD establish per-request timeouts and issue cancellation notifications when exceeded
+- SDKs and middleware SHOULD allow per-request timeout configuration
+- Implementations MAY reset timeout clock on progress notifications, but SHOULD enforce a maximum timeout regardless
 
 ### Message Types
 
-- **Requests**: Operations with required IDs (string or number)
-- **Responses**: Results or errors, never both
-- **Notifications**: One-way messages without IDs
+- **Requests**: Operations with required IDs (string or number, MUST NOT be null, MUST be unique per session)
+- **Responses**: Results or errors, never both; MUST include same ID as request
+- **Notifications**: One-way messages without IDs; receiver MUST NOT send a response
 
-All messages MUST follow JSON-RPC 2.0 specification.
+All messages MUST follow JSON-RPC 2.0 specification (UTF-8 encoded).
 
-### Tasks (New in 2025-11-25)
+**`_meta` Field**: Reserved for protocol-level metadata on requests/responses/notifications.
+- Key format: optional prefix (reverse DNS with `/` separator) + name
+- Prefixes where second label is `modelcontextprotocol` or `mcp` are reserved (e.g., `io.modelcontextprotocol/`)
 
-Tasks enable durable state machines for tracking long-running operations. Both clients and servers can create tasks.
+**JSON Schema Usage**: MCP defaults to JSON Schema 2020-12 when no `$schema` field is present. Implementations MUST support 2020-12.
+
+**Content Types**: `TextContent`, `ImageContent`, `AudioContent` (new), `ResourceLink`, `EmbeddedResource`
+- All content types support optional `annotations` (audience, priority, lastModified)
+
+**Icons**: Standardized `icons` field (array of `Icon` objects with `src`, `mimeType`, `sizes`, `theme`) on tools, prompts, resources, and implementations. Clients MUST support PNG and JPEG; SHOULD support SVG and WebP. Must treat icon data as untrusted.
+
+### Tasks (New in 2025-11-25, Experimental)
+
+Tasks enable durable state machines for tracking long-running operations. Both clients and servers can create tasks. **Note: Tasks are currently experimental and may evolve in future protocol versions.**
 
 **Terminology**:
 - **Requester**: Sender of a task-augmented request (can be client or server)
 - **Receiver**: Receiver/executor of the task (can be client or server)
 
+**Two-Phase Response Pattern**:
+- Normal requests: Server processes and returns result directly
+- Task-augmented requests: Server returns `CreateTaskResult` immediately with task data; actual result available later via `tasks/result`
+- To create a task, requester includes `task` field (with optional `ttl`) in request params
+
 **Methods**:
-- `tasks/list`: List all tasks (paginated)
+- `tasks/list`: List all tasks (paginated with cursor)
 - `tasks/get`: Get task status (requester SHOULD poll respecting `pollInterval`)
-- `tasks/cancel`: Cancel a non-terminal task
-- `tasks/result`: Retrieve result (blocks until terminal status)
+- `tasks/cancel`: Cancel a non-terminal task (error `-32602` if already terminal)
+- `tasks/result`: Retrieve result (blocks until terminal status); returns same result as underlying request would have
 
 **Notification**: `notifications/tasks/status` (optional, requesters MUST NOT rely on it)
 
@@ -164,8 +199,10 @@ Tasks enable durable state machines for tracking long-running operations. Both c
 working → input_required → working (loop)
        → completed | failed | cancelled (terminal)
 ```
+- `input_required`: Receiver needs input; requester SHOULD preemptively call `tasks/result`
+- `failed`: Includes cases where tool call result has `isError: true`
 
-**Key Fields**: taskId, status, statusMessage, createdAt, lastUpdatedAt, ttl, pollInterval
+**Key Fields**: taskId, status, statusMessage, createdAt (ISO 8601), lastUpdatedAt (ISO 8601), ttl (ms from creation), pollInterval (ms)
 
 **Capability Declaration**:
 ```json
@@ -187,12 +224,29 @@ working → input_required → working (loop)
 **Tool-Level Negotiation**: Tools declare `execution.taskSupport`:
 - `"forbidden"` (default): MUST NOT use task augmentation
 - `"optional"`: MAY use task augmentation
-- `"required"`: MUST use task augmentation (server returns -32601 if not)
+- `"required"`: MUST use task augmentation (server returns `-32601` if not)
+- Only applies if server capabilities include `tasks.requests.tools.call`
 
 **Task Metadata**: All related messages MUST include `io.modelcontextprotocol/related-task` in `_meta`:
 ```json
 { "_meta": { "io.modelcontextprotocol/related-task": { "taskId": "..." } } }
 ```
+- Exception: `tasks/get`, `tasks/list`, `tasks/cancel` use the `taskId` parameter directly; SHOULD NOT include related-task metadata
+- `tasks/result` MUST include related-task metadata in response (result structure lacks taskId)
+
+**Error Codes**:
+- `-32602` (Invalid params): Invalid/nonexistent taskId, invalid cursor, cancel of terminal task
+- `-32600` (Invalid request): Non-task-augmented request when receiver requires task augmentation
+- `-32601` (Method not found): Task augmentation attempted on `forbidden` tool, or not used on `required` tool
+- `-32603` (Internal error): Server-side errors
+
+**Task Security**:
+- When authorization context exists, receivers MUST bind tasks to that context
+- Receivers MUST reject cross-context access to tasks
+- Without auth context: MUST use cryptographically secure task IDs, SHOULD use shorter TTLs, SHOULD NOT declare `tasks.list`
+- Receivers SHOULD implement rate limiting on task operations
+
+**Optional**: `io.modelcontextprotocol/model-immediate-response` in `_meta` of `CreateTaskResult` — string for host apps to return to the model while task executes
 
 ToolHive implementation: Parser support in `pkg/mcp/parser.go`
 
@@ -207,16 +261,19 @@ Elicitation enables servers to request information from users during interaction
 1. **Form Mode** (`mode: "form"` or omitted for backwards compatibility):
    - In-band structured data collection
    - Uses JSON Schema for validation (restricted subset: flat objects with primitives only)
-   - Supported types: string, number, integer, boolean, enum (single/multi-select)
+   - Supported types: string (with `format`: email/uri/date/date-time), number, integer, boolean
+   - Enum: single-select via `enum` or `oneOf` with `const`/`title`; multi-select via `type: "array"` with `items`
+   - All types support optional `default` values; clients SHOULD pre-populate
    - **MUST NOT** be used for sensitive information (passwords, API keys, etc.)
 
-2. **URL Mode** (`mode: "url"`):
+2. **URL Mode** (`mode: "url"`, new in 2025-11-25):
    - Out-of-band interaction via URL navigation
    - For sensitive data, OAuth flows, payment processing
    - Requires `elicitationId` for tracking
    - Data does NOT pass through MCP client
-   - Notification: `notifications/elicitation/complete` (optional)
-   - Error: `URLElicitationRequiredError` (-32042) when elicitation needed
+   - Notification: `notifications/elicitation/complete` (optional, server MAY send when interaction done)
+   - Error: `URLElicitationRequiredError` (`-32042`) when elicitation needed; MUST include list of required elicitations
+   - Servers can use URL mode to act as OAuth clients to third-party services (separate from MCP authorization)
 
 **Capability Declaration**:
 ```json
@@ -229,46 +286,92 @@ Elicitation enables servers to request information from users during interaction
   }
 }
 ```
+- Backwards compat: empty `"elicitation": {}` is equivalent to `{ "form": {} }`
+- Clients MUST support at least one mode; servers MUST NOT send unsupported modes
+- Error `-32602` (Invalid params) if server sends mode not in client capabilities
 
-**Response Actions**: `accept`, `decline`, `cancel`
+**Response Actions**: `accept` (with `content` for form mode), `decline`, `cancel`
+
+**Statefulness**: Servers implementing elicitation MUST securely associate state with individual users:
+- State MUST NOT be associated with session IDs alone
+- User identity SHOULD be derived from MCP authorization credentials (e.g., `sub` claim)
 
 **Security for URL Mode**:
-- Servers MUST verify user identity before accepting information (prevent phishing)
+- Servers MUST verify user identity before accepting information (prevent phishing attacks)
 - Servers MUST NOT include sensitive info or pre-authenticated URLs
-- Clients MUST show full URL to user before opening
+- Servers SHOULD use HTTPS URLs for non-development environments
+- Clients MUST show full URL to user before opening; SHOULD highlight domain
 - Clients MUST NOT auto-fetch or open without explicit consent
+- Clients MUST open URL in secure manner (e.g., SFSafariViewController, NOT WkWebView)
+- Clients SHOULD have warnings for suspicious URIs (Punycode, etc.)
 
 ToolHive implementation: Full support in `pkg/vmcp/composer/elicitation_handler.go`
 
+### Tools (Enhanced in 2025-11-25)
+
+**Tool Definition Fields**:
+- `name`: Unique identifier (1-128 chars, case-sensitive, alphanumeric + `_` `-` `.`)
+- `title`: Optional human-readable display name (NEW)
+- `description`: Human-readable description
+- `icons`: Optional array of Icon objects for UI display (NEW)
+- `inputSchema`: JSON Schema for parameters (MUST be valid object, defaults to 2020-12)
+- `outputSchema`: Optional JSON Schema for structured output validation (NEW)
+- `annotations`: Optional behavior hints (audience, priority) — treat as untrusted from untrusted servers
+- `execution`: Optional object with `taskSupport` field (see Tasks)
+
+**Structured Content** (NEW):
+- `structuredContent`: JSON object in response matching `outputSchema`
+- For backwards compat, tools returning structured content SHOULD also return serialized JSON in a `TextContent` block
+- Clients SHOULD validate structured results against `outputSchema` if provided
+
+**Content Types in Tool Results**: text, image, audio (NEW), resource_link, embedded resource
+
+**Error Handling**: Two mechanisms:
+- Protocol errors (JSON-RPC): unknown tools, malformed requests → clients MAY show to LLM
+- Tool execution errors (`isError: true`): API failures, validation errors → clients SHOULD show to LLM for self-correction
+
 ### Authorization (Updated in 2025-11-25)
 
-MCP 2025-11-25 significantly updated the authorization model for HTTP transports. Authorization is **optional** but follows strict requirements when implemented.
+MCP 2025-11-25 significantly updated the authorization model for HTTP transports. Authorization is **optional** but follows strict requirements when implemented. STDIO transport SHOULD NOT use this spec (retrieve credentials from environment instead).
 
 **Standards Compliance**:
 - OAuth 2.1 (draft-ietf-oauth-v2-1-13)
 - RFC 8414 (Authorization Server Metadata)
-- RFC 9728 (Protected Resource Metadata)
-- RFC 8707 (Resource Indicators)
+- RFC 9728 (Protected Resource Metadata) — MCP servers MUST implement this
+- RFC 8707 (Resource Indicators) — clients MUST include `resource` parameter
 - RFC 7591 (Dynamic Client Registration - for backwards compatibility)
-- Client ID Metadata Documents (NEW preferred method)
+- Client ID Metadata Documents (draft-ietf-oauth-client-id-metadata-document-00) — NEW preferred method
+- OpenID Connect Discovery 1.0 — clients MUST support alongside RFC 8414
 
 **Discovery Flow**:
-1. Server returns 401 with `WWW-Authenticate: Bearer resource_metadata="..."`
-2. Client fetches Protected Resource Metadata from `/.well-known/oauth-protected-resource`
-3. Client discovers Authorization Server from issuer metadata
+1. Server returns 401 with `WWW-Authenticate: Bearer resource_metadata="..."` (may include `scope` hint)
+2. Client fetches Protected Resource Metadata:
+   - First try `resource_metadata` URL from header
+   - Fallback: `/.well-known/oauth-protected-resource/<mcp-path>`, then `/.well-known/oauth-protected-resource`
+3. Client discovers Authorization Server from `authorization_servers` field in metadata
+4. Client fetches AS metadata (try in order for path-based issuers):
+   - `/.well-known/oauth-authorization-server/<path>`
+   - `/.well-known/openid-configuration/<path>`
+   - `<path>/.well-known/openid-configuration`
 
 **Client Registration Priority** (try in order):
 1. Pre-registered credentials (if available)
-2. Client ID Metadata Documents (if `client_id_metadata_document_supported: true`)
-3. Dynamic Client Registration (if supported)
+2. Client ID Metadata Documents (if `client_id_metadata_document_supported: true` in AS metadata)
+3. Dynamic Client Registration (if `registration_endpoint` in AS metadata)
 4. Prompt user for credentials
 
+**Scope Selection Strategy** (priority order):
+1. Use `scope` from initial `WWW-Authenticate` header if provided
+2. Otherwise use all `scopes_supported` from Protected Resource Metadata
+3. Step-up authorization: on `403 insufficient_scope`, re-authorize with expanded scopes
+
 **REQUIRED Security Measures**:
-- **PKCE**: MUST use with `S256` code challenge method
-- **Resource Parameter**: MUST include RFC 8707 resource indicator in auth/token requests
+- **PKCE**: MUST use with `S256` code challenge method; MUST verify PKCE support via AS metadata before proceeding
+- **Resource Parameter**: MUST include RFC 8707 resource indicator in auth/token requests (canonical MCP server URI)
 - **Audience Validation**: Servers MUST verify tokens were issued for them
-- **Token Handling**: MUST use Bearer token in Authorization header, MUST NOT in query strings
+- **Token Handling**: MUST use Bearer token in Authorization header on every HTTP request, MUST NOT in query strings
 - **Scope Minimization**: Start with minimal scopes, use step-up authorization
+- **SSRF Protection**: Clients MUST consider SSRF risks when fetching OAuth URLs (see Security Best Practices)
 
 **For OAuth/auth implementation details, defer to the oauth-expert agent.**
 
@@ -340,10 +443,17 @@ When working on MCP-related code, follow this approach:
 - Session IDs MUST be globally unique, cryptographically secure, visible ASCII only (0x21-0x7E)
 
 **Key 2025-11-25 Features**:
-- Tasks: Durable state machines for long-running operations (requestor-driven polling)
-- Elicitation URL mode: Out-of-band sensitive data collection
-- Client ID Metadata Documents: Preferred client registration method
+- Tasks (experimental): Durable state machines for long-running operations (requestor-driven polling)
+- Elicitation URL mode: Out-of-band sensitive data collection with phishing prevention
+- Client ID Metadata Documents (draft-ietf-oauth-client-id-metadata-document-00): Preferred client registration
 - Tool-level task negotiation via `execution.taskSupport`
+- Tool `outputSchema` + `structuredContent`: Typed structured tool results alongside unstructured content
+- `AudioContent` type: Base64-encoded audio alongside text and image content
+- `icons` field: Standardized icon metadata on tools, prompts, resources, and implementations
+- `title` field: Human-readable display name on tools, prompts, resources
+- Enhanced `_meta` key format: Reverse DNS prefix convention with reserved MCP namespaces
+- Scope Selection Strategy + Step-Up Authorization: Progressive scope elevation via `WWW-Authenticate` challenges
+- SSRF protections: Explicit mitigations for OAuth metadata discovery URLs
 
 **ToolHive-Specific**:
 - Container isolation is key to ToolHive's security model
@@ -361,44 +471,64 @@ When working on MCP-related code, follow this approach:
 ### Security Best Practices (2025-11-25)
 
 **1. Confused Deputy Problem**:
-- MCP proxies MUST implement per-client consent storage
+- MCP proxies MUST implement per-client consent storage (per `client_id` per user)
 - MUST verify consent before third-party authorization flows
 - MUST use secure cookies (`__Host-` prefix, Secure, HttpOnly, SameSite=Lax)
 - MUST validate `state` parameter and set tracking cookie only AFTER consent
+- Consent UI MUST identify requesting client, display scopes, show redirect_uri, implement CSRF protection
 
 **2. Token Passthrough (Anti-Pattern)**:
 - Servers MUST NOT accept tokens not explicitly issued for them
 - MUST NOT pass client tokens to downstream APIs without validation
+- If MCP server calls upstream APIs, it acts as separate OAuth client; MUST use its own tokens
 
 **3. Session Hijacking Prevention**:
 - Servers MUST verify all inbound requests when implementing authorization
 - Servers MUST NOT use sessions for authentication
-- MUST use cryptographically secure session IDs (UUIDs)
-- SHOULD bind session IDs to user identity
+- MUST use cryptographically secure session IDs (UUIDs with secure random generators)
+- SHOULD bind session IDs to user identity (key format: `<user_id>:<session_id>`)
+- Two attack vectors: prompt injection via shared queues, impersonation via guessed session IDs
 
 **4. Local Server Security**:
-- MUST show exact command to user before launching local MCP servers
-- SHOULD highlight dangerous patterns (sudo, rm -rf, network ops)
+- MUST show exact command to user before launching local MCP servers (no truncation)
+- SHOULD highlight dangerous patterns (sudo, rm -rf, network ops, sensitive directory access)
 - SHOULD execute in sandboxed environment with minimal privileges
+- Local servers SHOULD use stdio transport or restrict HTTP access (auth token, unix sockets)
 
 **5. Scope Minimization**:
-- Request minimal initial scopes
-- Use progressive elevation via WWW-Authenticate challenges
-- Avoid wildcard/omnibus scopes
+- Request minimal initial scopes (e.g., `mcp:tools-basic`)
+- Use progressive elevation via `WWW-Authenticate` `scope="..."` challenges
+- Avoid wildcard/omnibus scopes (`*`, `all`, `full-access`)
+- Server SHOULD emit precise scope challenges, not full catalog
+- Server SHOULD accept reduced-scope tokens; AS MAY issue subset of requested scopes
+
+**6. SSRF (Server-Side Request Forgery)**:
+- Malicious MCP servers can populate OAuth metadata URLs with internal resource targets
+- Attack vectors: private IPs, cloud metadata (169.254.169.254), localhost services, DNS rebinding
+- Clients SHOULD require HTTPS for all OAuth URLs in production
+- Clients SHOULD block private/reserved IP ranges (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, 169.254.0.0/16)
+- Clients SHOULD validate redirect targets (same restrictions apply)
+- Server-side clients SHOULD use egress proxies (e.g., Smokescreen)
+- Be aware of DNS TOCTOU issues; consider pinning DNS resolution
 
 ## Resources
 
 **Primary (Always Check First)**:
 - MCP Main Site: https://modelcontextprotocol.io
+- Full doc index: https://modelcontextprotocol.io/llms.txt
 - Latest Spec (2025-11-25): https://modelcontextprotocol.io/specification/2025-11-25
 - Schema Reference: https://modelcontextprotocol.io/specification/2025-11-25/schema
+- Architecture: https://modelcontextprotocol.io/specification/2025-11-25/architecture
+- Base Protocol: https://modelcontextprotocol.io/specification/2025-11-25/basic
 - Transports: https://modelcontextprotocol.io/specification/2025-11-25/basic/transports
 - Lifecycle: https://modelcontextprotocol.io/specification/2025-11-25/basic/lifecycle
 - Authorization: https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization
 - Security Best Practices: https://modelcontextprotocol.io/specification/2025-11-25/basic/security_best_practices
 - Tasks: https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/tasks
+- Tools: https://modelcontextprotocol.io/specification/2025-11-25/server/tools
 - Elicitation: https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation
 - MCP Auth Extensions: https://github.com/modelcontextprotocol/ext-auth
+- TypeScript Schema (source of truth): https://github.com/modelcontextprotocol/specification/blob/main/schema/2025-11-25/schema.ts
 
 **Previous Spec Versions** (for compatibility):
 - 2025-06-18, 2025-03-26, 2024-11-05


### PR DESCRIPTION
## Summary

The MCP protocol expert agent had several gaps compared to the actual 2025-11-25 specification. A full deep-dive review of every spec page (overview, transports, lifecycle, tasks, elicitation, tools, authorization, security best practices, schema) revealed missing protocol details that could lead the agent to give incomplete or incorrect guidance.

Key areas updated:
- **Transport**: SSE stream closure/polling behavior, `retry` field, session DELETE, `Accept` header requirement, protocol version fallback rules
- **Lifecycle**: Extended `clientInfo`/`serverInfo` fields (`title`, `description`, `icons`, `websiteUrl`), per-request timeout configuration
- **Tasks**: Experimental designation, two-phase response pattern, `input_required` handling, task security (context binding, access control), error codes, `tasks/result` semantics
- **Elicitation**: Statefulness requirements, backwards compatibility for empty capability, multi-select enum, phishing prevention, secure URL opening
- **Tools** (new section): `outputSchema`, `structuredContent`, `title`, `icons`, `execution.taskSupport`, `AudioContent`, tool name constraints
- **Authorization**: Scope selection strategy, step-up authorization, OIDC discovery requirement, detailed well-known URI fallback chain, SSRF protection
- **Security**: New SSRF section, expanded confused deputy/session hijacking/scope minimization details
- **Base protocol**: `_meta` key format (reverse DNS prefix), JSON Schema 2020-12 default, content types with `AudioContent`, icon specification
- **Resources**: Added architecture, base protocol, tools, schema URLs; added `llms.txt` index and TypeScript schema source of truth

## Type of change

- [x] Documentation

## Test plan

- [x] Manual testing (describe below)

Reviewed every section of the updated file against the fetched spec pages to verify accuracy. Cross-referenced all URLs. Verified the file parses correctly as a Claude Code agent definition.

## Does this introduce a user-facing change?

No. This only affects the MCP protocol expert AI subagent's knowledge base.

Generated with [Claude Code](https://claude.com/claude-code)