### PR TITLE
fix(recovery): pass through http.ErrAbortHandler panics

### DIFF
--- a/pkg/recovery/recovery.go
+++ b/pkg/recovery/recovery.go
@@ -23,6 +23,9 @@ func Middleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		defer func() {
 			if rec := recover(); rec != nil {
+				if rec == http.ErrAbortHandler {
+					panic(rec)
+				}
 				stack := debug.Stack()
 				slog.Error(fmt.Sprintf("Panic recovered: %v\nStack trace:\n%s", rec, stack))
 				http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/pkg/recovery/recovery_test.go
+++ b/pkg/recovery/recovery_test.go
@@ -59,6 +59,23 @@ func TestRecoveryMiddleware_RecoverFromPanic(t *testing.T) {
 	assert.Contains(t, rec.Body.String(), "Internal Server Error")
 }
 
+func TestRecoveryMiddleware_ErrAbortHandlerPanicsThrough(t *testing.T) {
+	t.Parallel()
+
+	testHandler := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		panic(http.ErrAbortHandler)
+	})
+
+	wrappedHandler := Middleware(testHandler)
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	rec := httptest.NewRecorder()
+
+	assert.PanicsWithValue(t, http.ErrAbortHandler, func() {
+		wrappedHandler.ServeHTTP(rec, req)
+	})
+}
+
 func TestRecoveryMiddleware_PreservesRequestContext(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- `pkg/recovery` currently catches every panic, including `http.ErrAbortHandler`, which `httputil.ReverseProxy` uses intentionally for aborted streaming responses. Catching it logs noisy stack traces and attempts to write a 500 into an already-in-flight response.
- Update recovery middleware to immediately re-panic `http.ErrAbortHandler` so Go's HTTP server can handle it natively.
- Add a regression test that asserts `http.ErrAbortHandler` is propagated instead of converted into an internal-server-error response.

Fixes #4064

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [ ] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [ ] Linting (`task lint-fix`)
- [x] Manual testing (describe below)

Manual verification performed:
- Confirmed no formatting/hunk issues with `git diff --check`.
- Attempted targeted unit tests with `go test ./pkg/recovery -run TestRecoveryMiddleware`, but local execution is blocked in this environment because the required Go 1.26 toolchain cannot be downloaded (`toolchain not available`).

## Does this introduce a user-facing change?

Yes. Aborted proxy streams now follow Go's native `http.ErrAbortHandler` handling path (silent connection abort) instead of emitting recovery error logs and attempted 500 writes.
