### PR TITLE
Bump Kubernetes e2e test tool versions and add Renovate managers

### DIFF
--- a/.github/workflows/helm-charts-test.yml
+++ b/.github/workflows/helm-charts-test.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
         with:
-          version: v3.14.0
+          version: v3.20.0 # helm
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f # v2.8.0

--- a/.github/workflows/operator-ci.yml
+++ b/.github/workflows/operator-ci.yml
@@ -185,7 +185,7 @@ jobs:
     - name: Install Chainsaw
       uses: kyverno/action-install-chainsaw@06560d18422209e9c1e08e931d477d04bf2674c1 # v0.2.14
       with:
-        release: v0.2.12
+        release: v0.2.14 # chainsaw
 
     - name: Disable containerd image store
       # Workaround for https://github.com/kubernetes-sigs/kind/issues/3795
@@ -204,7 +204,7 @@ jobs:
       uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # pin@v1.12.0
       with:
         cluster_name: toolhive
-        version: v0.29.0
+        version: v0.31.0 # kind
         cloud_provider: true
         node_image: ${{ matrix.version }}
 

--- a/.github/workflows/test-e2e-lifecycle.yml
+++ b/.github/workflows/test-e2e-lifecycle.yml
@@ -71,7 +71,7 @@ jobs:
       uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # pin@v1.12.0
       with:
         cluster_name: toolhive
-        version: v0.29.0
+        version: v0.31.0 # kind
         config: test/e2e/thv-operator/kind-config.yaml
         node_image: ${{ matrix.version }}
 

--- a/renovate.json
+++ b/renovate.json
@@ -180,6 +180,13 @@
         "github.com/mark3labs/mcp-go",
         "github.com/modelcontextprotocol/registry"
       ]
+    },
+    {
+      "description": "Only allow minor and patch updates for Helm CLI (avoid v4.x)",
+      "matchManagers": ["custom.regex"],
+      "matchPackageNames": ["helm/helm"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
     }
   ],
   "customManagers": [
@@ -228,6 +235,31 @@
       "depNameTemplate": "golang",
       "datasourceTemplate": "golang-version",
       "versioningTemplate": "loose"
+    },
+    {
+      "customType": "regex",
+      "description": "Update Kind CLI version in GitHub workflows",
+      "managerFilePatterns": [".github/workflows/*.yml"],
+      "matchStrings": ["version:\\s+v(?<currentValue>\\d+\\.\\d+\\.\\d+)\\s+#\\s+kind"],
+      "depNameTemplate": "kubernetes-sigs/kind",
+      "datasourceTemplate": "github-releases"
+    },
+    {
+      "customType": "regex",
+      "description": "Update Chainsaw release version in GitHub workflows",
+      "managerFilePatterns": [".github/workflows/*.yml"],
+      "matchStrings": ["release:\\s+v(?<currentValue>\\d+\\.\\d+\\.\\d+)\\s+#\\s+chainsaw"],
+      "depNameTemplate": "kyverno/chainsaw",
+      "datasourceTemplate": "github-releases"
+    },
+    {
+      "customType": "regex",
+      "description": "Update Helm CLI version in GitHub workflows",
+      "managerFilePatterns": [".github/workflows/*.yml"],
+      "matchStrings": ["version:\\s+v(?<currentValue>\\d+\\.\\d+\\.\\d+)\\s+#\\s+helm"],
+      "depNameTemplate": "helm/helm",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v(?<version>.*)$"
     }
   ],
   "postUpdateOptions": ["gomodTidy"]


### PR DESCRIPTION
## Summary

Several CI tools used in Kubernetes e2e workflows were behind their latest versions, and Renovate had no custom managers to auto-bump them. This updates the tools and adds Renovate coverage so they stay current.

- Bump Kind CLI v0.29.0 → v0.31.0 (compatible with current kindest/node images)
- Bump Chainsaw release param v0.2.12 → v0.2.14 (action tag was already at v0.2.14 but the `release:` param lagged)
- Bump Helm CLI v3.14.0 → v3.20.0 (pinned to v3.x to avoid Helm 4 compatibility issues)
- Add Renovate custom regex managers for Kind CLI, Chainsaw release, and Helm CLI versions
- Add Renovate package rule to block Helm v4.x major upgrades

## Type of change

- [x] Dependency update

## Test plan

- [x] Manual testing (describe below)

Verified kindest/node image compatibility: Kind v0.31.0 supports v1.33.7, v1.34.3, and v1.35.x which are the images in the workflow matrix. CI workflows will validate end-to-end on push.

## Changes

| File | Change |
|------|--------|
| `.github/workflows/operator-ci.yml` | Kind CLI v0.29.0 → v0.31.0, Chainsaw release v0.2.12 → v0.2.14, added `# kind` and `# chainsaw` comments for Renovate |
| `.github/workflows/test-e2e-lifecycle.yml` | Kind CLI v0.29.0 → v0.31.0, added `# kind` comment for Renovate |
| `.github/workflows/helm-charts-test.yml` | Helm CLI v3.14.0 → v3.20.0, added `# helm` comment for Renovate |
| `renovate.json` | Added 3 custom regex managers (Kind CLI, Chainsaw, Helm CLI) and package rule to pin Helm to v3.x |

## Special notes for reviewers

The `# kind`, `# chainsaw`, and `# helm` inline comments are required for the Renovate custom regex managers to disambiguate `version:` fields in the workflow YAML. Without them, Renovate would match unrelated `version:` parameters.

The Helm package rule blocks major version bumps (v4.x) since chart-testing compatibility with Helm 4 hasn't been verified.

Generated with [Claude Code](https://claude.com/claude-code)