### PR TITLE
Fix flaky api-workloads E2E test timeout

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -161,10 +161,12 @@ func (b *ServerBuilder) Build(ctx context.Context) (*chi.Mux, error) {
 	r.Use(recovery.Middleware)
 
 	// Apply default middleware
+	// NOTE: Timeout is NOT applied globally because workload create/update routes
+	// pull container images, which can take minutes. Instead, timeouts are applied
+	// per-route group in setupDefaultRoutes and within WorkloadRouter.
 	r.Use(
 		middleware.RequestID,
 		// TODO: Figure out logging middleware. We may want to use a different logger.
-		middleware.Timeout(middlewareTimeout),
 		requestBodySizeLimitMiddleware(maxRequestBodySize),
 		headersMiddleware,
 	)
@@ -192,7 +194,7 @@ func (b *ServerBuilder) Build(ctx context.Context) (*chi.Mux, error) {
 	// Setup default routes
 	b.setupDefaultRoutes(r)
 
-	// Add custom routes
+	// Add custom routes (callers of WithRoute are responsible for their own timeout management)
 	for prefix, handler := range b.customRoutes {
 		r.Mount(prefix, handler)
 	}
@@ -271,15 +273,20 @@ func (b *ServerBuilder) createDefaultManagers(ctx context.Context) error {
 
 // setupDefaultRoutes sets up the default API routes
 func (b *ServerBuilder) setupDefaultRoutes(r *chi.Mux) {
-	routers := map[string]http.Handler{
-		"/health":             v1.HealthcheckRouter(b.containerRuntime),
-		"/api/v1beta/version": v1.VersionRouter(),
-		"/api/v1beta/workloads": v1.WorkloadRouter(
-			b.workloadManager,
-			b.containerRuntime,
-			b.groupManager,
-			b.debugMode,
-		),
+	standardTimeout := middleware.Timeout(middlewareTimeout)
+
+	// Workload router manages its own per-route timeouts (image pulls can take minutes)
+	r.Mount("/api/v1beta/workloads", v1.WorkloadRouter(
+		b.workloadManager,
+		b.containerRuntime,
+		b.groupManager,
+		b.debugMode,
+	))
+
+	// All other routes get standard timeout
+	standardRouters := map[string]http.Handler{
+		"/health":               v1.HealthcheckRouter(b.containerRuntime),
+		"/api/v1beta/version":   v1.VersionRouter(),
 		"/api/v1beta/registry":  v1.RegistryRouter(),
 		"/api/v1beta/discovery": v1.DiscoveryRouter(),
 		"/api/v1beta/clients":   v1.ClientRouter(b.clientManager, b.workloadManager, b.groupManager),
@@ -287,14 +294,13 @@ func (b *ServerBuilder) setupDefaultRoutes(r *chi.Mux) {
 		"/api/v1beta/groups":    v1.GroupsRouter(b.groupManager, b.workloadManager, b.clientManager),
 		"/api/v1beta/skills":    v1.SkillsRouter(b.skillManager),
 	}
+	for prefix, router := range standardRouters {
+		r.Mount(prefix, standardTimeout(router))
+	}
 
 	// Only mount docs router if enabled
 	if b.enableDocs {
-		routers["/api/"] = DocsRouter()
-	}
-
-	for prefix, router := range routers {
-		r.Mount(prefix, router)
+		r.Mount("/api/", standardTimeout(DocsRouter()))
 	}
 }
 

--- a/pkg/api/v1/workloads.go
+++ b/pkg/api/v1/workloads.go
@@ -8,8 +8,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
 
 	"github.com/stacklok/toolhive-core/httperr"
 	groupval "github.com/stacklok/toolhive-core/validation/group"
@@ -24,6 +26,12 @@ import (
 const (
 	// maxAPILogLines is the maximum number of log lines returned by API endpoints
 	maxAPILogLines = 1000
+
+	// standardRouteTimeout is the timeout for quick read/action routes.
+	standardRouteTimeout = 60 * time.Second
+	// longRunningRouteTimeout is the timeout for routes that may pull container images.
+	// Slightly longer than imageRetrievalTimeout to let the specific error surface first.
+	longRunningRouteTimeout = imageRetrievalTimeout + 1*time.Minute
 )
 
 // WorkloadRoutes defines the routes for workload management.
@@ -64,20 +72,23 @@ func WorkloadRouter(
 	}
 
 	r := chi.NewRouter()
-	r.Get("/", apierrors.ErrorHandler(routes.listWorkloads))
-	r.Post("/", apierrors.ErrorHandler(routes.createWorkload))
-	r.Post("/stop", apierrors.ErrorHandler(routes.stopWorkloadsBulk))
-	r.Post("/restart", apierrors.ErrorHandler(routes.restartWorkloadsBulk))
-	r.Post("/delete", apierrors.ErrorHandler(routes.deleteWorkloadsBulk))
-	r.Get("/{name}", apierrors.ErrorHandler(routes.getWorkload))
-	r.Post("/{name}/edit", apierrors.ErrorHandler(routes.updateWorkload))
-	r.Post("/{name}/stop", apierrors.ErrorHandler(routes.stopWorkload))
-	r.Post("/{name}/restart", apierrors.ErrorHandler(routes.restartWorkload))
-	r.Get("/{name}/status", apierrors.ErrorHandler(routes.getWorkloadStatus))
-	r.Get("/{name}/logs", apierrors.ErrorHandler(routes.getLogsForWorkload))
-	r.Get("/{name}/proxy-logs", apierrors.ErrorHandler(routes.getProxyLogsForWorkload))
-	r.Get("/{name}/export", apierrors.ErrorHandler(routes.exportWorkload))
-	r.Delete("/{name}", apierrors.ErrorHandler(routes.deleteWorkload))
+	stdTimeout := middleware.Timeout(standardRouteTimeout)
+	longTimeout := middleware.Timeout(longRunningRouteTimeout)
+
+	r.With(stdTimeout).Get("/", apierrors.ErrorHandler(routes.listWorkloads))
+	r.With(longTimeout).Post("/", apierrors.ErrorHandler(routes.createWorkload))
+	r.With(stdTimeout).Post("/stop", apierrors.ErrorHandler(routes.stopWorkloadsBulk))
+	r.With(stdTimeout).Post("/restart", apierrors.ErrorHandler(routes.restartWorkloadsBulk))
+	r.With(stdTimeout).Post("/delete", apierrors.ErrorHandler(routes.deleteWorkloadsBulk))
+	r.With(stdTimeout).Get("/{name}", apierrors.ErrorHandler(routes.getWorkload))
+	r.With(longTimeout).Post("/{name}/edit", apierrors.ErrorHandler(routes.updateWorkload))
+	r.With(stdTimeout).Post("/{name}/stop", apierrors.ErrorHandler(routes.stopWorkload))
+	r.With(stdTimeout).Post("/{name}/restart", apierrors.ErrorHandler(routes.restartWorkload))
+	r.With(stdTimeout).Get("/{name}/status", apierrors.ErrorHandler(routes.getWorkloadStatus))
+	r.With(stdTimeout).Get("/{name}/logs", apierrors.ErrorHandler(routes.getLogsForWorkload))
+	r.With(stdTimeout).Get("/{name}/proxy-logs", apierrors.ErrorHandler(routes.getProxyLogsForWorkload))
+	r.With(stdTimeout).Get("/{name}/export", apierrors.ErrorHandler(routes.exportWorkload))
+	r.With(stdTimeout).Delete("/{name}", apierrors.ErrorHandler(routes.deleteWorkload))
 
 	return r
 }


### PR DESCRIPTION
## Summary

- The "E2E Tests Core (api-workloads)" CI job fails intermittently because Chi's global `middleware.Timeout(60s)` cancels the request context before container image pulls can complete. When images are cached the pull finishes in <60s (pass); when uncached it takes >60s (HTTP 500).
- Replace the global timeout with per-route timeouts: workload create and edit routes get an 11-minute timeout (slightly longer than the 10-minute `imageRetrievalTimeout`), while all other routes keep the standard 60-second timeout.

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)

## Changes

| File | Change |
|------|--------|
| `pkg/api/server.go` | Remove global `middleware.Timeout` from `r.Use()` block; apply standard timeout per-mount in `setupDefaultRoutes` for all non-workload routers |
| `pkg/api/v1/workloads.go` | Add per-route timeouts via `r.With()`: 11min for create/edit (image pulls), 60s for all other routes |

## Special notes for reviewers

- `longRunningRouteTimeout` is derived from `imageRetrievalTimeout + 1*time.Minute` (same package) so the invariant is maintained if the image timeout changes.
- Custom routes added via `WithRoute` are not currently used anywhere, but now have a comment noting callers are responsible for their own timeout management.
- The two pre-existing flaky test failures in `pkg/secrets` and `pkg/transport/proxy/transparent` are unrelated to this change.

Generated with [Claude Code](https://claude.com/claude-code)