### PR TITLE
Fix flaky E2E lifecycle tests: tool discovery race

### DIFF
--- a/test/e2e/thv-operator/virtualmcp/virtualmcp_auth_discovery_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcp_auth_discovery_test.go
@@ -1195,39 +1195,27 @@ with socketserver.TCPServer(("", PORT), OIDCHandler) as httpd:
 			By("Getting OIDC token from mock OIDC server")
 			oidcToken := getOIDCToken()
 
-			By("Starting transport and initializing connection with retries")
-			// Retry MCP initialization to handle timing issues where the VirtualMCPServer's
-			// auth middleware (OIDC validation and auth discovery) may not be fully ready
-			serverURL := fmt.Sprintf("http://localhost:%d/mcp", vmcpNodePort)
+			By("Starting transport and initializing connection with retries, waiting for expected tools")
+			// Retry MCP initialization AND tool discovery to handle timing issues where
+			// the VirtualMCPServer's auth middleware or backends may not be fully ready.
+			// Each retry creates a new session to trigger fresh backend discovery.
 			authenticatedHTTPClient := createAuthenticatedHTTPClient(oidcToken)
 
-			testCtx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
-			defer cancel()
-			mcpClient := InitializeMCPClientWithRetries(serverURL, 2*time.Minute, WithHttpLoggerOption(), transport.WithHTTPBasicClient(authenticatedHTTPClient))
+			toolsToTest := []string{"backend-with-token-exchange_fetch", "backend-no-auth_fetch"}
+			tools, mcpClient := WaitForExpectedToolsWithAuth(
+				vmcpNodePort, 2*time.Minute,
+				func(tools []mcp.Tool) error {
+					return ToolsContainAll(tools, toolsToTest...)
+				},
+				WithHttpLoggerOption(), transport.WithHTTPBasicClient(authenticatedHTTPClient),
+			)
 			defer mcpClient.Close()
 
-			By("Listing tools from VirtualMCPServer")
-			listRequest := mcp.ListToolsRequest{}
-			tools, err := mcpClient.ListTools(testCtx, listRequest)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(tools.Tools).ToNot(BeEmpty())
 			Expect(len(tools.Tools)).To(BeNumerically(">=", 2), "Should aggregate tools from multiple backends")
-
 			GinkgoWriter.Printf("VirtualMCPServer aggregates %d tools with discovered auth\n", len(tools.Tools))
 
 			By("Calling fetch tools from backends with different auth configurations")
-			toolsToTest := []string{"backend-with-token-exchange_fetch", "backend-no-auth_fetch"}
-
 			for _, targetToolName := range toolsToTest {
-				var toolFound bool
-				for _, tool := range tools.Tools {
-					if tool.Name == targetToolName {
-						toolFound = true
-						break
-					}
-				}
-				Expect(toolFound).To(BeTrue(), "Expected tool %s should be available", targetToolName)
-
 				toolCallCtx, toolCallCancel := context.WithTimeout(context.Background(), 30*time.Second)
 				defer toolCallCancel()
 
@@ -1238,7 +1226,7 @@ with socketserver.TCPServer(("", PORT), OIDCHandler) as httpd:
 				result, err := mcpClient.CallTool(toolCallCtx, callRequest)
 				Expect(err).ToNot(HaveOccurred(), "Tool call should succeed: %s", targetToolName)
 				Expect(result).ToNot(BeNil())
-				GinkgoWriter.Printf("✓ Successfully called tool: %s\n", targetToolName)
+				GinkgoWriter.Printf("Successfully called tool: %s\n", targetToolName)
 			}
 		})
 

--- a/test/e2e/thv-operator/virtualmcp/virtualmcp_conflict_resolution_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcp_conflict_resolution_test.go
@@ -147,15 +147,10 @@ var _ = Describe("VirtualMCPServer Conflict Resolution", Ordered, func() {
 
 		Context("when tools from multiple backends have the same name", func() {
 			It("should prefix tool names with workload identifier", func() {
-				By("Creating and initializing MCP client for VirtualMCPServer")
-				mcpClient, err := CreateInitializedMCPClient(vmcpNodePort, "toolhive-prefix-test", 30*time.Second)
-				Expect(err).ToNot(HaveOccurred())
-				defer mcpClient.Close()
-
-				By("Listing tools from VirtualMCPServer")
-				listRequest := mcp.ListToolsRequest{}
-				tools, err := mcpClient.Client.ListTools(mcpClient.Ctx, listRequest)
-				Expect(err).ToNot(HaveOccurred())
+				By("Waiting for tools from both backends to be discovered")
+				tools := WaitForExpectedTools(vmcpNodePort, "toolhive-prefix-test", func(tools []mcp.Tool) error {
+					return ToolsHavePrefix(tools, backend1Name+"_", backend2Name+"_")
+				})
 
 				By(fmt.Sprintf("VirtualMCPServer exposes %d tools", len(tools.Tools)))
 				for _, tool := range tools.Tools {
@@ -186,15 +181,10 @@ var _ = Describe("VirtualMCPServer Conflict Resolution", Ordered, func() {
 			})
 
 			It("should expose tools from both backends with different prefixes", func() {
-				By("Creating and initializing MCP client for VirtualMCPServer")
-				mcpClient, err := CreateInitializedMCPClient(vmcpNodePort, "toolhive-prefix-test", 30*time.Second)
-				Expect(err).ToNot(HaveOccurred())
-				defer mcpClient.Close()
-
-				By("Listing tools from VirtualMCPServer")
-				listRequest := mcp.ListToolsRequest{}
-				tools, err := mcpClient.Client.ListTools(mcpClient.Ctx, listRequest)
-				Expect(err).ToNot(HaveOccurred())
+				By("Waiting for tools from both backends to be discovered")
+				tools := WaitForExpectedTools(vmcpNodePort, "toolhive-prefix-test", func(tools []mcp.Tool) error {
+					return ToolsHavePrefix(tools, backend1Name+"_", backend2Name+"_")
+				})
 
 				// Count tools by prefix
 				backend1Count := 0
@@ -230,15 +220,10 @@ var _ = Describe("VirtualMCPServer Conflict Resolution", Ordered, func() {
 			})
 
 			It("should handle conflicting tool names by prefixing both", func() {
-				By("Creating and initializing MCP client for VirtualMCPServer")
-				mcpClient, err := CreateInitializedMCPClient(vmcpNodePort, "toolhive-prefix-test", 30*time.Second)
-				Expect(err).ToNot(HaveOccurred())
-				defer mcpClient.Close()
-
-				By("Listing tools from VirtualMCPServer")
-				listRequest := mcp.ListToolsRequest{}
-				tools, err := mcpClient.Client.ListTools(mcpClient.Ctx, listRequest)
-				Expect(err).ToNot(HaveOccurred())
+				By("Waiting for tools from both backends to be discovered")
+				tools := WaitForExpectedTools(vmcpNodePort, "toolhive-prefix-test", func(tools []mcp.Tool) error {
+					return ToolsHavePrefix(tools, backend1Name+"_", backend2Name+"_")
+				})
 
 				// Look for the same tool name with different prefixes (e.g., echo)
 				// Since both backends are identical yardstick, they'll have the same tools
@@ -305,15 +290,19 @@ var _ = Describe("VirtualMCPServer Conflict Resolution", Ordered, func() {
 
 		Context("when tools from multiple backends have the same name", func() {
 			It("should expose tools from highest priority backend without prefix", func() {
-				By("Creating and initializing MCP client for VirtualMCPServer")
-				mcpClient, err := CreateInitializedMCPClient(vmcpNodePort, "toolhive-priority-test", 30*time.Second)
-				Expect(err).ToNot(HaveOccurred())
-				defer mcpClient.Close()
-
-				By("Listing tools from VirtualMCPServer")
-				listRequest := mcp.ListToolsRequest{}
-				tools, err := mcpClient.Client.ListTools(mcpClient.Ctx, listRequest)
-				Expect(err).ToNot(HaveOccurred())
+				By("Waiting for tools to be discovered (priority strategy should expose unprefixed tools)")
+				tools := WaitForExpectedTools(vmcpNodePort, "toolhive-priority-test", func(tools []mcp.Tool) error {
+					if len(tools) == 0 {
+						return fmt.Errorf("no tools available yet")
+					}
+					// Priority strategy should have at least one unprefixed tool
+					for _, tool := range tools {
+						if !strings.HasPrefix(tool.Name, backend1Name+"_") && !strings.HasPrefix(tool.Name, backend2Name+"_") {
+							return nil
+						}
+					}
+					return fmt.Errorf("expected unprefixed tools from priority resolution, got %d tools all prefixed", len(tools))
+				})
 
 				By(fmt.Sprintf("VirtualMCPServer exposes %d tools with priority strategy", len(tools.Tools)))
 				for _, tool := range tools.Tools {
@@ -321,10 +310,8 @@ var _ = Describe("VirtualMCPServer Conflict Resolution", Ordered, func() {
 				}
 
 				// Verify that tools are NOT prefixed (priority strategy doesn't prefix)
-				// Both backends should have tools, but conflicting tools should come from backend1 (higher priority)
 				hasToolsWithoutPrefix := false
 				for _, tool := range tools.Tools {
-					// Tools should not have workload prefixes
 					if !strings.HasPrefix(tool.Name, backend1Name+"_") && !strings.HasPrefix(tool.Name, backend2Name+"_") {
 						hasToolsWithoutPrefix = true
 						By(fmt.Sprintf("Found tool without prefix: %s", tool.Name))
@@ -340,15 +327,13 @@ var _ = Describe("VirtualMCPServer Conflict Resolution", Ordered, func() {
 			})
 
 			It("should resolve conflicts by using highest priority backend", func() {
-				By("Creating and initializing MCP client for VirtualMCPServer")
-				mcpClient, err := CreateInitializedMCPClient(vmcpNodePort, "toolhive-priority-test", 30*time.Second)
-				Expect(err).ToNot(HaveOccurred())
-				defer mcpClient.Close()
-
-				By("Listing tools from VirtualMCPServer")
-				listRequest := mcp.ListToolsRequest{}
-				tools, err := mcpClient.Client.ListTools(mcpClient.Ctx, listRequest)
-				Expect(err).ToNot(HaveOccurred())
+				By("Waiting for tools to be discovered")
+				tools := WaitForExpectedTools(vmcpNodePort, "toolhive-priority-test", func(tools []mcp.Tool) error {
+					if len(tools) == 0 {
+						return fmt.Errorf("no tools available yet")
+					}
+					return nil
+				})
 
 				By(fmt.Sprintf("VirtualMCPServer exposes %d tools total", len(tools.Tools)))
 
@@ -375,15 +360,13 @@ var _ = Describe("VirtualMCPServer Conflict Resolution", Ordered, func() {
 			})
 
 			It("should expose non-conflicting tools from all backends", func() {
-				By("Creating and initializing MCP client for VirtualMCPServer")
-				mcpClient, err := CreateInitializedMCPClient(vmcpNodePort, "toolhive-priority-test", 30*time.Second)
-				Expect(err).ToNot(HaveOccurred())
-				defer mcpClient.Close()
-
-				By("Listing tools from VirtualMCPServer")
-				listRequest := mcp.ListToolsRequest{}
-				tools, err := mcpClient.Client.ListTools(mcpClient.Ctx, listRequest)
-				Expect(err).ToNot(HaveOccurred())
+				By("Waiting for tools to be discovered")
+				tools := WaitForExpectedTools(vmcpNodePort, "toolhive-priority-test", func(tools []mcp.Tool) error {
+					if len(tools) == 0 {
+						return fmt.Errorf("no tools available yet")
+					}
+					return nil
+				})
 
 				// Since both backends have identical tools (same yardstick image),
 				// we should have exactly the same number of tools as a single backend would expose
@@ -455,15 +438,10 @@ var _ = Describe("VirtualMCPServer Conflict Resolution", Ordered, func() {
 
 		Context("when tools from multiple backends have explicit overrides", func() {
 			It("should expose tools with manually specified names", func() {
-				By("Creating and initializing MCP client for VirtualMCPServer")
-				mcpClient, err := CreateInitializedMCPClient(vmcpNodePort, "toolhive-manual-test", 30*time.Second)
-				Expect(err).ToNot(HaveOccurred())
-				defer mcpClient.Close()
-
-				By("Listing tools from VirtualMCPServer")
-				listRequest := mcp.ListToolsRequest{}
-				tools, err := mcpClient.Client.ListTools(mcpClient.Ctx, listRequest)
-				Expect(err).ToNot(HaveOccurred())
+				By("Waiting for tools with manually overridden names to be discovered")
+				tools := WaitForExpectedTools(vmcpNodePort, "toolhive-manual-test", func(tools []mcp.Tool) error {
+					return ToolsContainAll(tools, "echo_backend1", "echo_backend2")
+				})
 
 				By(fmt.Sprintf("VirtualMCPServer exposes %d tools with manual strategy", len(tools.Tools)))
 				for _, tool := range tools.Tools {

--- a/test/e2e/thv-operator/virtualmcp/virtualmcp_optimizer_circuit_breaker_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcp_optimizer_circuit_breaker_test.go
@@ -151,41 +151,52 @@ var _ = Describe("VirtualMCPServer Optimizer with Circuit Breaker", Ordered, fun
 	})
 
 	It("should find tools from all healthy backends via optimizer", func() {
-		By("Creating MCP client and finding echo tool from unstable backend")
-		mcpClient, err := CreateInitializedMCPClient(vmcpNodePort, "opt-cb-test-all-healthy", 30*time.Second)
-		Expect(err).ToNot(HaveOccurred())
-		defer mcpClient.Close()
-
-		findResult, err := callFindTool(mcpClient, "echo back a message")
-		Expect(err).ToNot(HaveOccurred())
-		foundTools := getToolNames(findResult)
-		Expect(foundTools).ToNot(BeEmpty(), "find_tool should return results for echo")
-
-		hasEchoTool := false
-		for _, name := range foundTools {
-			if strings.Contains(name, "echo") {
-				hasEchoTool = true
-				break
+		By("Waiting for both echo and fetch tools to be discoverable via optimizer")
+		Eventually(func() error {
+			mcpClient, err := CreateInitializedMCPClient(vmcpNodePort, "opt-cb-test-all-healthy", 30*time.Second)
+			if err != nil {
+				return fmt.Errorf("failed to create MCP client: %w", err)
 			}
-		}
-		Expect(hasEchoTool).To(BeTrue(), "Should find echo tool from unstable backend, got tools: %v", foundTools)
+			defer mcpClient.Close()
 
-		By("Finding fetch tool from stable backend")
-		findResult, err = callFindTool(mcpClient, "fetch content from a URL")
-		Expect(err).ToNot(HaveOccurred())
-		foundTools = getToolNames(findResult)
-		Expect(foundTools).ToNot(BeEmpty(), "find_tool should return results for fetch")
-
-		hasFetchTool := false
-		for _, name := range foundTools {
-			if strings.Contains(name, "fetch") {
-				hasFetchTool = true
-				break
+			// Check for echo tool from unstable backend
+			findResult, err := callFindTool(mcpClient, "echo back a message")
+			if err != nil {
+				return fmt.Errorf("find_tool for echo failed: %w", err)
 			}
-		}
-		Expect(hasFetchTool).To(BeTrue(), "Should find fetch tool from stable backend, got tools: %v", foundTools)
+			foundTools := getToolNames(findResult)
+			hasEcho := false
+			for _, name := range foundTools {
+				if strings.Contains(name, "echo") {
+					hasEcho = true
+					break
+				}
+			}
+			if !hasEcho {
+				return fmt.Errorf("echo tool not found yet, got tools: %v", foundTools)
+			}
 
-		_, _ = fmt.Fprintf(GinkgoWriter, "✓ Both backends' tools found via optimizer: echo and fetch\n")
+			// Check for fetch tool from stable backend
+			findResult, err = callFindTool(mcpClient, "fetch content from a URL")
+			if err != nil {
+				return fmt.Errorf("find_tool for fetch failed: %w", err)
+			}
+			foundTools = getToolNames(findResult)
+			hasFetch := false
+			for _, name := range foundTools {
+				if strings.Contains(name, "fetch") {
+					hasFetch = true
+					break
+				}
+			}
+			if !hasFetch {
+				return fmt.Errorf("fetch tool not found yet, got tools: %v", foundTools)
+			}
+
+			return nil
+		}, 2*time.Minute, 5*time.Second).Should(Succeed(), "Both backends' tools should be discoverable via optimizer")
+
+		_, _ = fmt.Fprintf(GinkgoWriter, "Both backends' tools found via optimizer: echo and fetch\n")
 	})
 
 	It("should exclude unhealthy backend tools from optimizer after circuit breaker opens", func() {
@@ -231,7 +242,7 @@ var _ = Describe("VirtualMCPServer Optimizer with Circuit Breaker", Ordered, fun
 				if vmcpServer.Status.DiscoveredBackends[i].Name == unstableName {
 					backend := &vmcpServer.Status.DiscoveredBackends[i]
 					if backend.CircuitBreakerState == "open" {
-						GinkgoWriter.Printf("✓ Circuit breaker opened (failures: %d)\n",
+						GinkgoWriter.Printf("Circuit breaker opened (failures: %d)\n",
 							backend.ConsecutiveFailures)
 						return nil
 					}
@@ -271,7 +282,7 @@ var _ = Describe("VirtualMCPServer Optimizer with Circuit Breaker", Ordered, fun
 				"Tools from unhealthy backend %s should be excluded, but found tool: %s", unstableName, name)
 		}
 
-		_, _ = fmt.Fprintf(GinkgoWriter, "✓ Unhealthy backend tools excluded from optimizer results\n")
+		_, _ = fmt.Fprintf(GinkgoWriter, "Unhealthy backend tools excluded from optimizer results\n")
 	})
 
 	It("should restore backend tools in optimizer after circuit breaker recovers", func() {
@@ -330,7 +341,7 @@ var _ = Describe("VirtualMCPServer Optimizer with Circuit Breaker", Ordered, fun
 					if backend.CircuitBreakerState == "closed" &&
 						(backend.Status == mcpv1alpha1.BackendStatusReady ||
 							backend.Status == mcpv1alpha1.BackendStatusDegraded) {
-						GinkgoWriter.Printf("✓ Backend recovered: status=%s, circuitState=%s\n",
+						GinkgoWriter.Printf("Backend recovered: status=%s, circuitState=%s\n",
 							backend.Status, backend.CircuitBreakerState)
 						return nil
 					}
@@ -375,7 +386,7 @@ var _ = Describe("VirtualMCPServer Optimizer with Circuit Breaker", Ordered, fun
 		}
 		Expect(hasFetchTool).To(BeTrue(), "Fetch tool should still be available, got tools: %v", foundTools)
 
-		_, _ = fmt.Fprintf(GinkgoWriter, "✓ Both backends' tools available after recovery\n")
+		_, _ = fmt.Fprintf(GinkgoWriter, "Both backends' tools available after recovery\n")
 	})
 
 	It("should not affect stable backend throughout circuit breaker lifecycle", func() {
@@ -405,7 +416,7 @@ var _ = Describe("VirtualMCPServer Optimizer with Circuit Breaker", Ordered, fun
 		Expect(strings.ToLower(stableBackend.Message)).NotTo(ContainSubstring("circuit breaker open"),
 			"stable backend should not have circuit breaker open, message: %s", stableBackend.Message)
 
-		GinkgoWriter.Printf("✓ Stable backend remained healthy: status=%s, circuitState=%s\n",
+		GinkgoWriter.Printf("Stable backend remained healthy: status=%s, circuitState=%s\n",
 			stableBackend.Status, stableBackend.CircuitBreakerState)
 	})
 })

--- a/test/e2e/thv-operator/virtualmcp/virtualmcp_toolconfig_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcp_toolconfig_test.go
@@ -150,25 +150,20 @@ var _ = Describe("VirtualMCPServer Tool Filtering via MCPToolConfig", Ordered, f
 
 	Context("when MCPToolConfig is used for filtering", func() {
 		It("should only expose filtered tools from backend1", func() {
-			By("Waiting for VirtualMCPServer to discover backends and expose tools")
-			var tools *mcp.ListToolsResult
-			Eventually(func() error {
-				mcpClient, err := CreateInitializedMCPClient(vmcpNodePort, "toolhive-toolconfig-test", 30*time.Second)
-				if err != nil {
-					return fmt.Errorf("failed to create MCP client: %w", err)
+			By("Waiting for VirtualMCPServer to discover backends and expose the renamed tool")
+			tools := WaitForExpectedTools(vmcpNodePort, "toolhive-toolconfig-test", func(tools []mcp.Tool) error {
+				// Must have at least one tool with both backend1Name and "renamed_fetch" in its name
+				for _, tool := range tools {
+					if strings.Contains(tool.Name, backend1Name) && strings.Contains(tool.Name, "renamed_fetch") {
+						return nil
+					}
 				}
-				defer mcpClient.Close()
-
-				listRequest := mcp.ListToolsRequest{}
-				tools, err = mcpClient.Client.ListTools(mcpClient.Ctx, listRequest)
-				if err != nil {
-					return fmt.Errorf("failed to list tools: %w", err)
+				toolNames := make([]string, len(tools))
+				for i, t := range tools {
+					toolNames[i] = t.Name
 				}
-				if len(tools.Tools) == 0 {
-					return fmt.Errorf("no tools available yet (backends may still be connecting)")
-				}
-				return nil
-			}, 2*time.Minute, 5*time.Second).Should(Succeed(), "VirtualMCPServer should expose tools once backends are connected")
+				return fmt.Errorf("expected tool containing %q and %q, got tools: %v", backend1Name, "renamed_fetch", toolNames)
+			})
 
 			By(fmt.Sprintf("VirtualMCPServer exposes %d tools after MCPToolConfig filtering", len(tools.Tools)))
 			for _, tool := range tools.Tools {
@@ -180,15 +175,6 @@ var _ = Describe("VirtualMCPServer Tool Filtering via MCPToolConfig", Ordered, f
 			for i, tool := range tools.Tools {
 				toolNames[i] = tool.Name
 			}
-
-			// Should have tool from backend1 with renamed name
-			hasBackend1Tool := false
-			for _, name := range toolNames {
-				if strings.Contains(name, backend1Name) && strings.Contains(name, "renamed_fetch") {
-					hasBackend1Tool = true
-				}
-			}
-			Expect(hasBackend1Tool).To(BeTrue(), "Should have renamed_fetch tool from backend1")
 
 			// Should NOT have the original 'fetch' name
 			hasOriginalFetch := false
@@ -220,25 +206,15 @@ var _ = Describe("VirtualMCPServer Tool Filtering via MCPToolConfig", Ordered, f
 		})
 
 		It("should apply tool overrides from MCPToolConfig", func() {
-			By("Waiting for tools to be available")
-			var tools *mcp.ListToolsResult
-			Eventually(func() error {
-				mcpClient, err := CreateInitializedMCPClient(vmcpNodePort, "toolhive-toolconfig-test", 30*time.Second)
-				if err != nil {
-					return fmt.Errorf("failed to create MCP client: %w", err)
+			By("Waiting for tools to be available with the renamed tool")
+			tools := WaitForExpectedTools(vmcpNodePort, "toolhive-toolconfig-test", func(tools []mcp.Tool) error {
+				for _, tool := range tools {
+					if strings.Contains(tool.Name, backend1Name) && strings.Contains(tool.Name, "renamed_fetch") {
+						return nil
+					}
 				}
-				defer mcpClient.Close()
-
-				listRequest := mcp.ListToolsRequest{}
-				tools, err = mcpClient.Client.ListTools(mcpClient.Ctx, listRequest)
-				if err != nil {
-					return fmt.Errorf("failed to list tools: %w", err)
-				}
-				if len(tools.Tools) == 0 {
-					return fmt.Errorf("no tools available yet")
-				}
-				return nil
-			}, 2*time.Minute, 5*time.Second).Should(Succeed(), "Should have tools available")
+				return fmt.Errorf("renamed_fetch tool from %s not found yet (got %d tools)", backend1Name, len(tools))
+			})
 
 			// Find the renamed tool
 			var renamedTool *mcp.Tool
@@ -255,25 +231,15 @@ var _ = Describe("VirtualMCPServer Tool Filtering via MCPToolConfig", Ordered, f
 		})
 
 		It("should still allow calling the renamed tool", func() {
-			By("Waiting for tools to be available")
-			var tools *mcp.ListToolsResult
-			Eventually(func() error {
-				mcpClient, err := CreateInitializedMCPClient(vmcpNodePort, "toolhive-toolconfig-test", 30*time.Second)
-				if err != nil {
-					return fmt.Errorf("failed to create MCP client: %w", err)
+			By("Waiting for tools to be available with the renamed tool")
+			tools := WaitForExpectedTools(vmcpNodePort, "toolhive-toolconfig-test", func(tools []mcp.Tool) error {
+				for _, tool := range tools {
+					if strings.Contains(tool.Name, backend1Name) && strings.Contains(tool.Name, "renamed_fetch") {
+						return nil
+					}
 				}
-				defer mcpClient.Close()
-
-				listRequest := mcp.ListToolsRequest{}
-				tools, err = mcpClient.Client.ListTools(mcpClient.Ctx, listRequest)
-				if err != nil {
-					return fmt.Errorf("failed to list tools: %w", err)
-				}
-				if len(tools.Tools) == 0 {
-					return fmt.Errorf("no tools available yet")
-				}
-				return nil
-			}, 2*time.Minute, 5*time.Second).Should(Succeed(), "Should have tools available")
+				return fmt.Errorf("renamed_fetch tool from %s not found yet (got %d tools)", backend1Name, len(tools))
+			})
 
 			// Find the renamed tool
 			var targetToolName string
@@ -466,18 +432,24 @@ var _ = Describe("VirtualMCPServer MCPToolConfig Dynamic Updates", Ordered, func
 
 	Context("when MCPToolConfig is updated", func() {
 		It("should initially only expose the fetch tool", func() {
-			By("Creating and initializing MCP client for VirtualMCPServer")
-			mcpClient, err := CreateInitializedMCPClient(vmcpNodePort, "toolhive-toolconfig-update-test", 30*time.Second)
-			Expect(err).ToNot(HaveOccurred())
-			defer mcpClient.Close()
-
-			By("Listing tools from VirtualMCPServer")
-			listRequest := mcp.ListToolsRequest{}
-			tools, err := mcpClient.Client.ListTools(mcpClient.Ctx, listRequest)
-			Expect(err).ToNot(HaveOccurred())
+			By("Waiting for VirtualMCPServer to discover backends and expose the fetch tool")
+			tools := WaitForExpectedTools(vmcpNodePort, "toolhive-toolconfig-update-test", func(tools []mcp.Tool) error {
+				if len(tools) == 0 {
+					return fmt.Errorf("no tools available yet (backends may still be connecting)")
+				}
+				for _, tool := range tools {
+					if strings.Contains(tool.Name, "fetch") {
+						return nil
+					}
+				}
+				toolNames := make([]string, len(tools))
+				for i, t := range tools {
+					toolNames[i] = t.Name
+				}
+				return fmt.Errorf("expected a tool containing 'fetch', got tools: %v", toolNames)
+			})
 
 			// Should only have fetch tool
-			Expect(tools.Tools).ToNot(BeEmpty())
 			for _, tool := range tools.Tools {
 				Expect(tool.Name).To(ContainSubstring("fetch"), "Should only have fetch tool")
 			}

--- a/test/e2e/thv-operator/virtualmcp/wait_for_tools_helpers.go
+++ b/test/e2e/thv-operator/virtualmcp/wait_for_tools_helpers.go
@@ -1,0 +1,193 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package virtualmcp
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	mcpclient "github.com/mark3labs/mcp-go/client"
+	"github.com/mark3labs/mcp-go/client/transport"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+)
+
+// WaitForExpectedTools creates MCP sessions with retry until the validateTools
+// function returns nil (all expected tools are present). Returns the final tool list.
+// This is essential for avoiding flaky tests caused by session-scoped tool discovery
+// race conditions: when a backend isn't fully ready, it's silently skipped, producing
+// incomplete tool lists. Each retry creates a new MCP session to trigger fresh discovery.
+func WaitForExpectedTools(
+	vmcpNodePort int32,
+	clientName string,
+	validateTools func([]mcp.Tool) error,
+	timeout ...time.Duration,
+) *mcp.ListToolsResult {
+	eventuallyTimeout := 2 * time.Minute
+	if len(timeout) > 0 {
+		eventuallyTimeout = timeout[0]
+	}
+
+	var tools *mcp.ListToolsResult
+	gomega.Eventually(func() error {
+		mcpClient, err := CreateInitializedMCPClient(vmcpNodePort, clientName, 30*time.Second)
+		if err != nil {
+			return fmt.Errorf("failed to create MCP client: %w", err)
+		}
+		defer mcpClient.Close()
+
+		listRequest := mcp.ListToolsRequest{}
+		tools, err = mcpClient.Client.ListTools(mcpClient.Ctx, listRequest)
+		if err != nil {
+			return fmt.Errorf("failed to list tools: %w", err)
+		}
+		return validateTools(tools.Tools)
+	}, eventuallyTimeout, 5*time.Second).Should(gomega.Succeed())
+	return tools
+}
+
+// WaitForExpectedToolsWithAuth creates authenticated MCP sessions with retry until the
+// validateTools function returns nil (all expected tools are present). Returns the final
+// tool list. This variant accepts StreamableHTTPCOptions for authenticated clients.
+// The returned *mcpclient.Client is still open and must be closed by the caller so
+// that subsequent tool calls can reuse the same session.
+func WaitForExpectedToolsWithAuth(
+	vmcpNodePort int32,
+	timeout time.Duration,
+	validateTools func([]mcp.Tool) error,
+	opts ...transport.StreamableHTTPCOption,
+) (*mcp.ListToolsResult, *mcpclient.Client) {
+	var tools *mcp.ListToolsResult
+	var mcpClient *mcpclient.Client
+
+	// Ensure the last client is cleaned up if Eventually exhausts retries and
+	// Ginkgo panics before the caller can defer Close().
+	ginkgo.DeferCleanup(func() {
+		if mcpClient != nil {
+			_ = mcpClient.Close()
+		}
+	})
+
+	serverURL := fmt.Sprintf("http://localhost:%d/mcp", vmcpNodePort)
+
+	gomega.Eventually(func() error {
+		// Close any previous client to avoid stale session state
+		if mcpClient != nil {
+			_ = mcpClient.Close()
+		}
+
+		var err error
+		mcpClient, err = mcpclient.NewStreamableHttpClient(serverURL, opts...)
+		if err != nil {
+			return fmt.Errorf("failed to create client: %w", err)
+		}
+
+		initCtx, initCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer initCancel()
+
+		if err := mcpClient.Start(initCtx); err != nil {
+			return fmt.Errorf("failed to start transport: %w", err)
+		}
+
+		initRequest := mcp.InitializeRequest{}
+		initRequest.Params.ProtocolVersion = mcp.LATEST_PROTOCOL_VERSION
+		initRequest.Params.ClientInfo = mcp.Implementation{
+			Name:    "toolhive-e2e-test",
+			Version: "1.0.0",
+		}
+
+		_, err = mcpClient.Initialize(initCtx, initRequest)
+		if err != nil {
+			return fmt.Errorf("failed to initialize: %w", err)
+		}
+
+		listCtx, listCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer listCancel()
+
+		listRequest := mcp.ListToolsRequest{}
+		tools, err = mcpClient.ListTools(listCtx, listRequest)
+		if err != nil {
+			return fmt.Errorf("failed to list tools: %w", err)
+		}
+		return validateTools(tools.Tools)
+	}, timeout, 5*time.Second).Should(gomega.Succeed())
+
+	return tools, mcpClient
+}
+
+// ToolsContainAll checks if the tool list contains all expected tool names (exact match).
+// Returns an error listing missing tools, or nil if all are found.
+func ToolsContainAll(tools []mcp.Tool, expectedNames ...string) error {
+	nameSet := make(map[string]bool, len(tools))
+	for _, t := range tools {
+		nameSet[t.Name] = true
+	}
+	var missing []string
+	for _, name := range expectedNames {
+		if !nameSet[name] {
+			missing = append(missing, name)
+		}
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("missing expected tools %v; got %v", missing, toolNames(tools))
+	}
+	return nil
+}
+
+// ToolsContainSubstring checks if the tool list contains at least one tool whose
+// name contains each of the given substrings. Returns an error if any substring
+// has no matching tool.
+func ToolsContainSubstring(tools []mcp.Tool, substrings ...string) error {
+	var missing []string
+	for _, sub := range substrings {
+		found := false
+		for _, t := range tools {
+			if strings.Contains(t.Name, sub) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			missing = append(missing, sub)
+		}
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("no tools matching substrings %v; got %v", missing, toolNames(tools))
+	}
+	return nil
+}
+
+// ToolsHavePrefix checks if there is at least one tool with each of the given prefixes.
+// Returns an error listing missing prefixes, or nil if all are found.
+func ToolsHavePrefix(tools []mcp.Tool, prefixes ...string) error {
+	var missing []string
+	for _, prefix := range prefixes {
+		found := false
+		for _, t := range tools {
+			if strings.HasPrefix(t.Name, prefix) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			missing = append(missing, prefix)
+		}
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("no tools with prefixes %v; got %v", missing, toolNames(tools))
+	}
+	return nil
+}
+
+// toolNames extracts tool names from a slice of mcp.Tool for error messages.
+func toolNames(tools []mcp.Tool) []string {
+	names := make([]string, len(tools))
+	for i, t := range tools {
+		names[i] = t.Name
+	}
+	return names
+}


### PR DESCRIPTION
## Summary

- The "E2E Tests Lifecycle" workflow is flaky because tool discovery is session-scoped: when a backend isn't fully ready at session creation time, it's silently skipped, producing incomplete tool lists. Tests then fail because they assert on specific tool names **outside** the `Eventually` retry loop (or have no retry at all).
- Move all tool-name assertions inside `Eventually` loops so each retry creates a fresh MCP session, triggering fresh backend discovery. Add reusable helper functions to reduce boilerplate across tests.

## Type of change

- [x] Bug fix

## Test plan

- [x] Linting (`task lint-fix`)
- [ ] Manual testing (describe below)

These are E2E operator tests that require a KIND cluster. The fix is structural (moving assertions inside retry loops) and does not change test semantics — only retry behavior. Full verification requires the "E2E Tests Lifecycle" CI workflow to pass across all K8s versions.

## Changes

| File | Change |
|------|--------|
| `test/e2e/thv-operator/virtualmcp/wait_for_tools_helpers.go` | New file: `WaitForExpectedTools`, `WaitForExpectedToolsWithAuth`, `ToolsContainAll`, `ToolsContainSubstring`, `ToolsHavePrefix` helpers |
| `test/e2e/thv-operator/virtualmcp/virtualmcp_toolconfig_test.go` | 4 `It` blocks: move tool-name assertions inside `WaitForExpectedTools` |
| `test/e2e/thv-operator/virtualmcp/virtualmcp_conflict_resolution_test.go` | 7 `It` blocks: wrap with `WaitForExpectedTools` (previously had NO retry) |
| `test/e2e/thv-operator/virtualmcp/virtualmcp_optimizer_circuit_breaker_test.go` | 1 `It` block: wrap `callFindTool` for echo + fetch inside `Eventually` |
| `test/e2e/thv-operator/virtualmcp/virtualmcp_auth_discovery_test.go` | 1 `It` block: replace `InitializeMCPClientWithRetries` + immediate assert with `WaitForExpectedToolsWithAuth` |

## Does this introduce a user-facing change?

No

## Special notes for reviewers

- `WaitForExpectedToolsWithAuth` uses `ginkgo.DeferCleanup` to ensure the last MCP client is closed even if `Eventually` exhausts retries and Ginkgo panics before the caller can `defer Close()`.
- `TestToolListingAndCall` (in `helpers.go`) has the same single-shot pattern but is partially mitigated by `Ordered` suites where preceding `It` blocks warm up backends. Worth tracking as follow-up but not blocking for this PR.
- Other test files (`virtualmcp_aggregation_*.go`, `virtualmcp_optimizer_test.go`, etc.) also use single-shot client creation. These haven't been observed to flake and can be addressed in a follow-up.

Generated with [Claude Code](https://claude.com/claude-code)