### PR TITLE
Make transparent proxy health check parameters configurable

### DIFF
--- a/docs/arch/03-transport-architecture.md
+++ b/docs/arch/03-transport-architecture.md
@@ -370,7 +370,9 @@ The transparent proxy health check behavior can be tuned via environment variabl
 
 Duration values use Go's `time.ParseDuration` format (e.g., `10s`, `500ms`, `1m30s`). Invalid values are ignored with a warning log, and the default is used instead.
 
-**Failure window**: With the defaults, the proxy tolerates roughly `(threshold-1) × (interval + retryDelay)` plus the initial failure tick before shutting down — approximately 70 seconds with default values. This is designed to survive transient network disruptions without prematurely killing healthy backends.
+**Threshold of 1**: Setting `TOOLHIVE_HEALTH_CHECK_FAILURE_THRESHOLD=1` means the proxy shuts down on the first health check failure with no retries.
+
+**Failure window**: With the defaults, the proxy tolerates roughly `(threshold-1) × (interval + retryDelay)` before shutting down — approximately 60 seconds with default values. This is designed to survive transient network disruptions without prematurely killing healthy backends. If `TOOLHIVE_HEALTH_CHECK_PING_TIMEOUT` exceeds `TOOLHIVE_HEALTH_CHECK_INTERVAL`, each health check cycle takes longer than one interval tick, extending the failure window beyond what the formula predicts.
 
 **Usage example** (increase tolerance for a flaky network):
 ```bash

--- a/pkg/transport/proxy/transparent/transparent_proxy.go
+++ b/pkg/transport/proxy/transparent/transparent_proxy.go
@@ -1072,12 +1072,7 @@ func (p *TransparentProxy) CloseListener() error {
 // performHealthCheckRetry performs a retry health check after a delay
 // Returns true if the retry was successful (health check recovered), false otherwise
 func (p *TransparentProxy) performHealthCheckRetry(ctx context.Context) bool {
-	retryDelay := p.healthCheckRetryDelay
-	if retryDelay == 0 {
-		retryDelay = DefaultHealthCheckRetryDelay
-	}
-
-	retryTimer := time.NewTimer(retryDelay)
+	retryTimer := time.NewTimer(p.healthCheckRetryDelay)
 	defer retryTimer.Stop()
 
 	select {

--- a/pkg/transport/proxy/transparent/transparent_test.go
+++ b/pkg/transport/proxy/transparent/transparent_test.go
@@ -706,7 +706,7 @@ func TestWithHealthCheckFailureThresholdOption(t *testing.T) {
 }
 
 func TestWithHealthCheckFailureThresholdOption_IgnoresNonPositive(t *testing.T) {
-	t.Parallel()
+	t.Setenv(HealthCheckFailureThresholdEnvVar, "")
 
 	proxy := newMinimalProxy(withHealthCheckFailureThreshold(0))
 


### PR DESCRIPTION
## Summary

- The transparent proxy health check has mostly hardcoded parameters (ping timeout, retry delay, failure threshold), making it impossible to tune resilience for environments with transient network disruptions. When the proxy kills itself due to false positives, the client's MCP session is invalidated, requiring a full client restart to recover.
- Add three new environment variables (`TOOLHIVE_HEALTH_CHECK_PING_TIMEOUT`, `TOOLHIVE_HEALTH_CHECK_RETRY_DELAY`, `TOOLHIVE_HEALTH_CHECK_FAILURE_THRESHOLD`) following the existing `TOOLHIVE_HEALTH_CHECK_INTERVAL` pattern.
- Raise the default failure threshold from 3 to 5, extending the tolerance window from ~40s to ~60s out of the box.
- Add warning logs when invalid env var values are provided, and debug logs when custom values are successfully applied.

Fixes #4084

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [x] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [x] Linting (`task lint-fix`)
- [x] Manual testing (describe below)

Built a test binary and started an MCP server with invalid env vars (`TOOLHIVE_HEALTH_CHECK_FAILURE_THRESHOLD=banana`, `TOOLHIVE_HEALTH_CHECK_PING_TIMEOUT=not-a-duration`). Verified warning logs appeared in the server log file with the env var name, invalid value, and default fallback. Confirmed `default=5` in the threshold warning, showing the new default is active.

## Changes

| File | Change |
|------|--------|
| `pkg/transport/proxy/transparent/transparent_proxy.go` | Add env var constants, getter functions, struct field for failure threshold, wire getters in constructor, replace package-level `healthCheckRetryCount` constant with struct field |
| `pkg/transport/proxy/transparent/transparent_test.go` | Table-driven tests for all 4 getters, constructor wiring tests, option function tests, test helper `newMinimalProxy()` |
| `docs/arch/03-transport-architecture.md` | Add "Health Check Tuning Parameters" section documenting all 4 env vars |

## Does this introduce a user-facing change?

Yes. Three new environment variables for tuning health check behavior:

| Environment Variable | Description | Default | Type |
|---|---|---|---|
| `TOOLHIVE_HEALTH_CHECK_PING_TIMEOUT` | Timeout for each health check ping | `5s` | duration |
| `TOOLHIVE_HEALTH_CHECK_RETRY_DELAY` | Delay between retry attempts after a failure | `5s` | duration |
| `TOOLHIVE_HEALTH_CHECK_FAILURE_THRESHOLD` | Consecutive failures before proxy shutdown | `5` | integer |

**Behavioral change:** The default failure threshold increases from 3 to 5. This means the proxy tolerates approximately 60 seconds of consecutive health check failures before shutting down (previously ~40 seconds). This improves resilience to transient network disruptions without significantly delaying detection of genuinely dead servers.

## Special notes for reviewers

- The existing `getHealthCheckInterval()` was also updated to add `slog.Warn` on invalid values and `slog.Debug` on custom values, for consistency with the new getter functions.
- The `healthCheckRetryCount` package-level constant was replaced with a `healthCheckFailureThreshold` struct field to allow per-proxy configuration via the options pattern.
- Per-server flags (e.g., `--health-check-failure-threshold` on `thv run`) would be a natural follow-up, following the precedence pattern suggested in #4063. Happy to include that in this PR if you'd prefer it bundled, or as a separate follow-up.