### PR TITLE
Address review feedback for MCP backend session affinity

### DIFF
--- a/cmd/thv-operator/controllers/mcpserver_controller.go
+++ b/cmd/thv-operator/controllers/mcpserver_controller.go
@@ -1458,11 +1458,13 @@ func (r *MCPServerReconciler) updateMCPServerStatus(ctx context.Context, m *mcpv
 // deleteIfExists fetches a Kubernetes object by name and namespace, and deletes it if it exists.
 // Returns nil if the object was not found or was successfully deleted.
 func (r *MCPServerReconciler) deleteIfExists(ctx context.Context, obj client.Object, name, namespace, kind string) error {
+	ctxLogger := log.FromContext(ctx)
 	err := r.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, obj)
 	if err == nil {
 		if delErr := r.Delete(ctx, obj); delErr != nil && !errors.IsNotFound(delErr) {
 			return fmt.Errorf("failed to delete %s %s: %w", kind, name, delErr)
 		}
+		ctxLogger.V(1).Info("deleted resource", "kind", kind, "name", name, "namespace", namespace)
 		return nil
 	}
 	if !errors.IsNotFound(err) {

--- a/pkg/container/kubernetes/client.go
+++ b/pkg/container/kubernetes/client.go
@@ -331,8 +331,6 @@ func (c *Client) GetWorkloadLogs(ctx context.Context, workloadName string, follo
 }
 
 // DeployWorkload implements runtime.Runtime.
-//
-//nolint:gocyclo
 func (c *Client) DeployWorkload(ctx context.Context,
 	image string,
 	containerName string,
@@ -412,40 +410,21 @@ func (c *Client) DeployWorkload(ctx context.Context,
 			WithTemplate(podTemplateSpec))
 
 	// Apply the statefulset using server-side apply
-	fieldManager := serviceFieldManager
 	createdStatefulSet, err := c.client.AppsV1().StatefulSets(namespace).
 		Apply(ctx, statefulSetApply, metav1.ApplyOptions{
-			FieldManager: fieldManager,
+			FieldManager: serviceFieldManager,
 			Force:        true,
 		})
 	if err != nil {
 		return 0, fmt.Errorf("failed to apply statefulset: %w", err)
 	}
 
-	//nolint:gosec // G706: statefulset name from Kubernetes API response
-	slog.Info("applied statefulset", "name", createdStatefulSet.Name)
+	slog.Debug("applied statefulset", "name", createdStatefulSet.Name)
 
-	if transportTypeRequiresBackendServices(transportType) && options != nil {
-		stsOwner := &metav1.OwnerReference{
-			APIVersion:         appsv1.SchemeGroupVersion.String(),
-			Kind:               "StatefulSet",
-			Name:               createdStatefulSet.Name,
-			UID:                createdStatefulSet.UID,
-			BlockOwnerDeletion: ptr.To(true),
-			Controller:         ptr.To(true),
-		}
-
-		// Create a headless service for DNS discovery
-		err := c.createHeadlessService(ctx, containerName, namespace, containerLabels, options, stsOwner)
-		if err != nil {
-			return 0, fmt.Errorf("failed to create headless service: %w", err)
-		}
-
-		// Create a regular ClusterIP service with session affinity for the proxy-runner target
-		err = c.createMCPService(ctx, containerName, namespace, containerLabels, options, stsOwner)
-		if err != nil {
-			return 0, fmt.Errorf("failed to create MCP service: %w", err)
-		}
+	err = c.ensureBackendServices(
+		ctx, containerName, namespace, containerLabels, transportType, options, createdStatefulSet)
+	if err != nil {
+		return 0, err
 	}
 
 	// Wait for the statefulset to be ready
@@ -461,6 +440,43 @@ func (c *Client) DeployWorkload(ctx context.Context,
 	}
 
 	return 0, nil
+}
+
+// ensureBackendServices creates the headless and ClusterIP services needed by
+// HTTP-based transports (SSE, streamable-http). Both services are owned by the
+// StatefulSet so Kubernetes GC can clean them up automatically.
+func (c *Client) ensureBackendServices(
+	ctx context.Context,
+	containerName, namespace string,
+	containerLabels map[string]string,
+	transportType string,
+	options *runtime.DeployWorkloadOptions,
+	sts *appsv1.StatefulSet,
+) error {
+	if !transportTypeRequiresBackendServices(transportType) || options == nil {
+		return nil
+	}
+
+	stsOwner := &metav1.OwnerReference{
+		APIVersion:         appsv1.SchemeGroupVersion.String(),
+		Kind:               "StatefulSet",
+		Name:               sts.Name,
+		UID:                sts.UID,
+		BlockOwnerDeletion: ptr.To(true),
+		Controller:         ptr.To(true),
+	}
+
+	// Create a headless service for DNS discovery
+	if err := c.createHeadlessService(ctx, containerName, namespace, containerLabels, options, stsOwner); err != nil {
+		return fmt.Errorf("failed to create headless service: %w", err)
+	}
+
+	// Create a regular ClusterIP service with session affinity for the proxy-runner target
+	if err := c.createMCPService(ctx, containerName, namespace, containerLabels, options, stsOwner); err != nil {
+		return fmt.Errorf("failed to create MCP service: %w", err)
+	}
+
+	return nil
 }
 
 // GetWorkloadInfo implements runtime.Runtime.

--- a/pkg/container/kubernetes/client_test.go
+++ b/pkg/container/kubernetes/client_test.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/rest"
+	"k8s.io/utils/ptr"
 
 	"github.com/stacklok/toolhive/pkg/container/runtime"
 )
@@ -810,7 +811,7 @@ func TestDeployWorkloadCreatesBackendServices(t *testing.T) {
 					UID:       "test-uid-123",
 				},
 				Spec: appsv1.StatefulSetSpec{
-					Replicas: func() *int32 { i := int32(1); return &i }(),
+					Replicas: ptr.To(int32(1)),
 					Template: corev1.PodTemplateSpec{
 						Spec: corev1.PodSpec{
 							Containers: []corev1.Container{},
@@ -835,7 +836,7 @@ func TestDeployWorkloadCreatesBackendServices(t *testing.T) {
 			}
 
 			_, err := client.DeployWorkload(
-				context.Background(),
+				t.Context(),
 				"test-image",
 				containerName,
 				[]string{"serve"},
@@ -850,7 +851,7 @@ func TestDeployWorkloadCreatesBackendServices(t *testing.T) {
 
 			// Verify the headless service was created
 			headlessSvc, err := clientset.CoreV1().Services("default").Get(
-				context.Background(), "mcp-"+containerName+"-headless", metav1.GetOptions{})
+				t.Context(), "mcp-"+containerName+"-headless", metav1.GetOptions{})
 			require.NoError(t, err)
 			assert.Equal(t, corev1.ClusterIPNone, headlessSvc.Spec.ClusterIP)
 			assert.NotEqual(t, corev1.ServiceAffinityClientIP, headlessSvc.Spec.SessionAffinity)
@@ -868,7 +869,7 @@ func TestDeployWorkloadCreatesBackendServices(t *testing.T) {
 
 			// Verify the MCP ClusterIP service was created
 			mcpSvc, err := clientset.CoreV1().Services("default").Get(
-				context.Background(), "mcp-"+containerName, metav1.GetOptions{})
+				t.Context(), "mcp-"+containerName, metav1.GetOptions{})
 			require.NoError(t, err)
 			assert.Equal(t, corev1.ServiceAffinityClientIP, mcpSvc.Spec.SessionAffinity)
 			require.NotNil(t, mcpSvc.Spec.SessionAffinityConfig)


### PR DESCRIPTION
## Summary

Follow-up to #3992, addressing review feedback from @yrobla and code review findings:

- Extract `ensureBackendServices` from `DeployWorkload` to reduce cyclomatic complexity and drop `//nolint:gocyclo`
- Add debug-level logging to `deleteIfExists` so finalization is observable for troubleshooting
- Downgrade `slog.Info("applied statefulset")` to `slog.Debug` per logging guidelines (silent success)
- Remove stale `//nolint:gosec` comment
- Fix test conventions: `context.Background()` → `t.Context()`, inline `func() *int32` → `ptr.To(int32(1))`

## Test plan

- [x] `task lint-fix` passes (0 issues)
- [x] `task test` passes (unit tests for changed packages)
- [x] No behavioral changes, only code quality improvements

🤖 Generated with [Claude Code](https://claude.com/claude-code)