### PR TITLE
fix(vmcp): apply outgoing auth credentials during health checks (#4101)

### DIFF
--- a/pkg/vmcp/auth/strategies/header_injection.go
+++ b/pkg/vmcp/auth/strategies/header_injection.go
@@ -11,7 +11,6 @@ import (
 
 	httpval "github.com/stacklok/toolhive-core/validation/http"
 	authtypes "github.com/stacklok/toolhive/pkg/vmcp/auth/types"
-	"github.com/stacklok/toolhive/pkg/vmcp/health"
 )
 
 // HeaderInjectionStrategy injects a static header value into request headers.
@@ -50,12 +49,14 @@ func (*HeaderInjectionStrategy) Name() string {
 // Authenticate injects the header value from the strategy config into the request header.
 //
 // This method:
-//  1. Skips authentication if this is a health check request
-//  2. Validates that HeaderName and HeaderValue are present in the strategy config
-//  3. Sets the specified header with the provided value
+//  1. Validates that HeaderName and HeaderValue are present in the strategy config
+//  2. Sets the specified header with the provided value
+//
+// This strategy applies to all requests including health checks, since the header
+// value is static and does not depend on user identity.
 //
 // Parameters:
-//   - ctx: Request context (used to check for health check marker)
+//   - ctx: Request context
 //   - req: The HTTP request to authenticate
 //   - strategy: The backend auth strategy configuration containing HeaderInjection
 //
@@ -63,13 +64,8 @@ func (*HeaderInjectionStrategy) Name() string {
 //   - HeaderName is missing or empty
 //   - HeaderValue is missing or empty
 func (*HeaderInjectionStrategy) Authenticate(
-	ctx context.Context, req *http.Request, strategy *authtypes.BackendAuthStrategy,
+	_ context.Context, req *http.Request, strategy *authtypes.BackendAuthStrategy,
 ) error {
-	// Skip authentication for health checks
-	if health.IsHealthCheck(ctx) {
-		return nil
-	}
-
 	if strategy == nil || strategy.HeaderInjection == nil {
 		return fmt.Errorf("header_injection configuration required")
 	}

--- a/pkg/vmcp/auth/strategies/header_injection_test.go
+++ b/pkg/vmcp/auth/strategies/header_injection_test.go
@@ -35,7 +35,7 @@ func TestHeaderInjectionStrategy_Authenticate(t *testing.T) {
 		checkHeader   func(t *testing.T, req *http.Request)
 	}{
 		{
-			name: "skips authentication for health checks",
+			name: "injects header for health checks",
 			strategy: &authtypes.BackendAuthStrategy{
 				Type: authtypes.StrategyTypeHeaderInjection,
 				HeaderInjection: &authtypes.HeaderInjectionConfig{
@@ -47,7 +47,7 @@ func TestHeaderInjectionStrategy_Authenticate(t *testing.T) {
 			expectError: false,
 			checkHeader: func(t *testing.T, req *http.Request) {
 				t.Helper()
-				assert.Empty(t, req.Header.Get("X-API-Key"), "X-API-Key header should not be set for health checks")
+				assert.Equal(t, "secret-key-123", req.Header.Get("X-API-Key"), "static header must be injected for health checks")
 			},
 		},
 		{

--- a/pkg/vmcp/auth/strategies/tokenexchange.go
+++ b/pkg/vmcp/auth/strategies/tokenexchange.go
@@ -7,9 +7,12 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 	"sort"
 	"strings"
 	"sync"
+
+	"golang.org/x/oauth2/clientcredentials"
 
 	"github.com/stacklok/toolhive-core/env"
 	"github.com/stacklok/toolhive/pkg/auth"
@@ -73,13 +76,12 @@ func (*TokenExchangeStrategy) Name() string {
 // Authenticate exchanges the client's token for a backend token and injects it.
 //
 // This method:
-//  1. Skips authentication if this is a health check request
-//  2. Retrieves the client's identity and token from the context
-//  3. Parses and validates the token exchange configuration from strategy
-//  4. Gets or creates a cached ExchangeConfig for this backend configuration
-//  5. Creates a TokenSource with the current identity token
-//  6. Obtains an access token by performing the exchange
-//  7. Injects the token into the backend request's Authorization header
+//  1. Parses and validates the token exchange configuration from strategy
+//  2. For health check requests: uses a client credentials grant if client_id and
+//     client_secret are configured; otherwise skips authentication
+//  3. For regular requests: retrieves the client's identity and token from the context,
+//     gets or creates a cached ExchangeConfig, performs the token exchange, and injects
+//     the token into the backend request's Authorization header
 //
 // Token caching per user is handled by the upper vMCP TokenCache layer.
 // This strategy only caches the ExchangeConfig template per backend.
@@ -90,15 +92,25 @@ func (*TokenExchangeStrategy) Name() string {
 //   - strategy: Backend auth strategy containing token exchange configuration
 //
 // Returns an error if:
-//   - No identity is found in the context
-//   - The identity has no token
 //   - Strategy configuration is invalid or incomplete
-//   - Token exchange fails
+//   - No identity is found in the context (regular requests only)
+//   - The identity has no token (regular requests only)
+//   - Token exchange or client credentials grant fails
 func (s *TokenExchangeStrategy) Authenticate(
 	ctx context.Context, req *http.Request, strategy *authtypes.BackendAuthStrategy,
 ) error {
-	// Skip authentication for health checks
+	config, err := s.parseTokenExchangeConfig(strategy)
+	if err != nil {
+		return fmt.Errorf("invalid strategy configuration: %w", err)
+	}
+
+	// For health checks there is no user identity to exchange. If client credentials
+	// are configured, use a client credentials grant to authenticate the probe request.
+	// Otherwise skip authentication — the backend will be probed unauthenticated.
 	if health.IsHealthCheck(ctx) {
+		if config.ClientID != "" && config.ClientSecret != "" {
+			return s.authenticateWithClientCredentials(ctx, req, config)
+		}
 		return nil
 	}
 
@@ -109,11 +121,6 @@ func (s *TokenExchangeStrategy) Authenticate(
 
 	if identity.Token == "" {
 		return fmt.Errorf("identity has no token")
-	}
-
-	config, err := s.parseTokenExchangeConfig(strategy)
-	if err != nil {
-		return fmt.Errorf("invalid strategy configuration: %w", err)
 	}
 
 	// Get user-specific exchange config. This creates a fresh config instance
@@ -127,6 +134,31 @@ func (s *TokenExchangeStrategy) Authenticate(
 	}
 
 	// Inject exchanged token into request
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token.AccessToken))
+	return nil
+}
+
+// authenticateWithClientCredentials performs an OAuth2 client credentials grant and
+// injects the resulting token into the request. Used for health check probes when
+// client_id and client_secret are configured.
+func (*TokenExchangeStrategy) authenticateWithClientCredentials(
+	ctx context.Context, req *http.Request, config *tokenExchangeConfig,
+) error {
+	ccConfig := clientcredentials.Config{
+		ClientID:     config.ClientID,
+		ClientSecret: config.ClientSecret,
+		TokenURL:     config.TokenURL,
+		Scopes:       config.Scopes,
+	}
+	if config.Audience != "" {
+		ccConfig.EndpointParams = url.Values{"audience": {config.Audience}}
+	}
+
+	token, err := ccConfig.Token(ctx)
+	if err != nil {
+		return fmt.Errorf("client credentials grant failed: %w", err)
+	}
+
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token.AccessToken))
 	return nil
 }

--- a/pkg/vmcp/auth/strategies/tokenexchange_test.go
+++ b/pkg/vmcp/auth/strategies/tokenexchange_test.go
@@ -96,11 +96,11 @@ func TestTokenExchangeStrategy_Authenticate(t *testing.T) {
 		checkAuthHeader func(t *testing.T, req *http.Request)
 	}{
 		{
-			name:     "skips authentication for health checks",
+			name:     "health check without client credentials skips authentication",
 			setupCtx: func() context.Context { return health.WithHealthCheckMarker(context.Background()) },
 			setupServer: func() *httptest.Server {
 				return httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
-					t.Error("Server should not be called for health checks")
+					t.Error("token endpoint should not be called when no client credentials are configured")
 				}))
 			},
 			strategy: func(server *httptest.Server) *authtypes.BackendAuthStrategy {
@@ -109,7 +109,39 @@ func TestTokenExchangeStrategy_Authenticate(t *testing.T) {
 			expectError: false,
 			checkAuthHeader: func(t *testing.T, req *http.Request) {
 				t.Helper()
-				assert.Empty(t, req.Header.Get("Authorization"), "Authorization header should not be set for health checks")
+				assert.Empty(t, req.Header.Get("Authorization"), "Authorization header should not be set when no client credentials are available")
+			},
+		},
+		{
+			name:     "health check with client credentials uses client credentials grant",
+			setupCtx: func() context.Context { return health.WithHealthCheckMarker(context.Background()) },
+			setupServer: func() *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					t.Helper()
+					require.NoError(t, r.ParseForm())
+					assert.Equal(t, "client_credentials", r.Form.Get("grant_type"))
+					clientID, clientSecret, ok := r.BasicAuth()
+					assert.True(t, ok, "expected Basic Auth credentials")
+					assert.Equal(t, "health-client-id", clientID)
+					assert.Equal(t, "health-client-secret", clientSecret)
+
+					w.Header().Set("Content-Type", "application/json")
+					json.NewEncoder(w).Encode(map[string]any{
+						"access_token": "health-check-token",
+						"token_type":   "Bearer",
+					})
+				}))
+			},
+			strategy: func(server *httptest.Server) *authtypes.BackendAuthStrategy {
+				return createTokenExchangeStrategy(server.URL, func(cfg *authtypes.TokenExchangeConfig) {
+					cfg.ClientID = "health-client-id"
+					cfg.ClientSecret = "health-client-secret"
+				})
+			},
+			expectError: false,
+			checkAuthHeader: func(t *testing.T, req *http.Request) {
+				t.Helper()
+				assert.Equal(t, "Bearer health-check-token", req.Header.Get("Authorization"))
 			},
 		},
 		{

--- a/pkg/vmcp/health/checker_test.go
+++ b/pkg/vmcp/health/checker_test.go
@@ -442,6 +442,109 @@ func TestHealthChecker_CheckHealth_Timeout(t *testing.T) {
 	assert.Equal(t, vmcp.BackendUnhealthy, status)
 }
 
+// TestHealthChecker_CheckHealth_ContextCarriesHealthCheckMarker verifies that CheckHealth
+// passes a context with the health check marker to ListCapabilities.
+// This is critical because the auth strategies (header_injection, token_exchange) read
+// this marker to decide how to authenticate probe requests.
+func TestHealthChecker_CheckHealth_ContextCarriesHealthCheckMarker(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	var capturedCtx context.Context
+	mockClient := mocks.NewMockBackendClient(ctrl)
+	mockClient.EXPECT().
+		ListCapabilities(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, _ *vmcp.BackendTarget) (*vmcp.CapabilityList, error) {
+			capturedCtx = ctx
+			return &vmcp.CapabilityList{}, nil
+		}).
+		Times(1)
+
+	checker := NewHealthChecker(mockClient, 5*time.Second, 0)
+	target := &vmcp.BackendTarget{
+		WorkloadID:   "backend-1",
+		WorkloadName: "test-backend",
+		BaseURL:      "http://localhost:8080",
+	}
+
+	status, err := checker.CheckHealth(context.Background(), target)
+	require.NoError(t, err)
+	assert.Equal(t, vmcp.BackendHealthy, status)
+
+	// The context passed to ListCapabilities must carry the health check marker so
+	// that auth strategies (header_injection, token_exchange) apply the correct
+	// authentication path for probe requests.
+	require.NotNil(t, capturedCtx, "context must have been captured")
+	assert.True(t, IsHealthCheck(capturedCtx),
+		"ListCapabilities must receive a context with the health check marker; "+
+			"without it, header_injection and token_exchange strategies cannot "+
+			"apply outgoing auth to health check probes")
+}
+
+// TestHealthChecker_CheckHealth_AuthErrorsCategorizesAsUnauthenticated verifies that auth
+// errors from health checks are correctly categorised as BackendUnauthenticated, not
+// BackendUnhealthy. This distinguishes a backend that is reachable-but-needs-auth
+// from one that is down, which is important for health check probes that apply
+// outgoing auth credentials (header_injection or token_exchange).
+func TestHealthChecker_CheckHealth_AuthErrorsCategorizesAsUnauthenticated(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{
+			name: "header injection auth failure - http 401",
+			err:  fmt.Errorf("transport error: http 401"),
+		},
+		{
+			name: "token exchange auth failure - status code 401",
+			err:  fmt.Errorf("backend unavailable: failed to initialize client for backend my-backend: status code 401"),
+		},
+		{
+			name: "sentinel auth error",
+			err:  vmcp.ErrAuthenticationFailed,
+		},
+		{
+			name: "sentinel authz error",
+			err:  vmcp.ErrAuthorizationFailed,
+		},
+		{
+			name: "wrapped sentinel auth error",
+			err:  fmt.Errorf("client credentials grant failed: %w", vmcp.ErrAuthenticationFailed),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockClient := mocks.NewMockBackendClient(ctrl)
+			mockClient.EXPECT().
+				ListCapabilities(gomock.Any(), gomock.Any()).
+				Return(nil, tt.err).
+				Times(1)
+
+			checker := NewHealthChecker(mockClient, 5*time.Second, 0)
+			target := &vmcp.BackendTarget{
+				WorkloadID:   "backend-1",
+				WorkloadName: "test-backend",
+				BaseURL:      "http://localhost:8080",
+			}
+
+			status, err := checker.CheckHealth(context.Background(), target)
+			assert.Error(t, err)
+			assert.Equal(t, vmcp.BackendUnauthenticated, status,
+				"auth failure from a health probe should be BackendUnauthenticated, not BackendUnhealthy")
+		})
+	}
+}
+
 func TestHealthChecker_CheckHealth_MultipleBackends(t *testing.T) {
 	t.Parallel()
 

--- a/test/e2e/thv-operator/virtualmcp/helpers.go
+++ b/test/e2e/thv-operator/virtualmcp/helpers.go
@@ -7,6 +7,7 @@ package virtualmcp
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -636,6 +637,22 @@ func GetInstrumentedBackendStats(ctx context.Context, c client.Client, namespace
 		stats["bearer_token_requests"] = 1 // Simplified - just check if field exists and > 0
 	}
 	return stats, nil
+}
+
+// GetMockOAuth2Stats queries the /stats endpoint of the mock OAuth2 server (port 8080)
+// and returns the number of client_credentials grant requests recorded so far.
+func GetMockOAuth2Stats(ctx context.Context, c client.Client, namespace, serviceName string) (int, error) {
+	logs, err := GetServiceStats(ctx, c, namespace, serviceName, 8080)
+	if err != nil {
+		return 0, err
+	}
+	var stats struct {
+		ClientCredentialsRequests int `json:"client_credentials_requests"`
+	}
+	if err := json.Unmarshal([]byte(logs), &stats); err != nil {
+		return 0, fmt.Errorf("failed to parse OAuth2 stats JSON %q: %w", logs, err)
+	}
+	return stats.ClientCredentialsRequests, nil
 }
 
 // MockOIDCServerHTTPScript is a mock OIDC server script with HTTP (for testing with private IPs)
@@ -1613,4 +1630,175 @@ func CleanupFakeEmbeddingServer(ctx context.Context, c client.Client, name, name
 	_ = c.Delete(ctx, &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
 	})
+}
+
+// MockOAuth2ServerScript is a minimal OAuth2 server that accepts token requests and
+// tracks token request statistics. Designed to be used as the token endpoint for
+// TokenExchange health-check tests.
+//
+// Endpoints:
+//
+//	POST /token  – accepts grant_type=client_credentials (Basic Auth or form body)
+//	              returns {"access_token": "mock-health-check-token", ...}
+//	            – accepts grant_type=urn:ietf:params:oauth:grant-type:token-exchange
+//	              returns {"access_token": "mock-exchanged-token", ..., "issued_token_type": "...access_token"}
+//	GET  /stats  – returns {"token_requests": N, "client_credentials_requests": N, "last_client_id": "..."}
+const MockOAuth2ServerScript = `
+pip install --quiet flask && python3 - <<'PYTHON_SCRIPT'
+from flask import Flask, jsonify, request
+import base64
+import sys
+
+app = Flask(__name__)
+
+stats = {
+    "token_requests": 0,
+    "client_credentials_requests": 0,
+    "last_client_id": None,
+}
+
+@app.route('/token', methods=['POST'])
+def token():
+    grant_type = request.form.get('grant_type', '')
+
+    # Extract client credentials from Basic Auth header first
+    client_id = None
+    auth_header = request.headers.get('Authorization', '')
+    if auth_header.startswith('Basic '):
+        try:
+            decoded = base64.b64decode(auth_header[6:]).decode('utf-8')
+            parts = decoded.split(':', 1)
+            if len(parts) == 2:
+                client_id = parts[0]
+        except Exception:
+            pass
+
+    # Fall back to form body
+    if not client_id:
+        client_id = request.form.get('client_id', '')
+
+    stats['token_requests'] += 1
+    stats['last_client_id'] = client_id
+
+    print(f"Token request #{stats['token_requests']}: grant_type={grant_type} client_id={client_id}", flush=True)
+    sys.stdout.flush()
+
+    if grant_type == 'client_credentials':
+        stats['client_credentials_requests'] += 1
+        return jsonify({
+            "access_token": "mock-health-check-token",
+            "token_type": "Bearer",
+            "expires_in": 3600,
+        })
+
+    if grant_type == 'urn:ietf:params:oauth:grant-type:token-exchange':
+        return jsonify({
+            "access_token": "mock-exchanged-token",
+            "token_type": "Bearer",
+            "expires_in": 3600,
+            "issued_token_type": "urn:ietf:params:oauth:token-type:access_token",
+        })
+
+    return jsonify({"error": "unsupported_grant_type"}), 400
+
+@app.route('/stats')
+def get_stats():
+    print(f"Stats request: {stats}", flush=True)
+    sys.stdout.flush()
+    return jsonify(stats)
+
+if __name__ == '__main__':
+    print("Mock OAuth2 server starting on port 8080", flush=True)
+    sys.stdout.flush()
+    app.run(host='0.0.0.0', port=8080)
+PYTHON_SCRIPT
+`
+
+// DeployMockOAuth2Server deploys a minimal OAuth2 server in-cluster that accepts
+// client_credentials and token-exchange grant requests, and exposes a /stats endpoint.
+// The service is ClusterIP — use GetMockOAuth2Stats to query /stats via a curl pod
+// rather than relying on NodePort reachability from the test process.
+//
+// Returns:
+//   - inClusterTokenURL: the /token URL reachable from inside the cluster
+//   - cleanup:           function that removes all created resources
+func DeployMockOAuth2Server(
+	ctx context.Context,
+	c client.Client,
+	name, namespace string,
+	timeout, pollingInterval time.Duration,
+) (inClusterTokenURL string, cleanup func()) {
+	inClusterTokenURL = fmt.Sprintf("http://%s.%s.svc.cluster.local:8080/token", name, namespace)
+
+	ginkgo.By("Creating mock OAuth2 server pod: " + name)
+	gomega.Expect(c.Create(ctx, &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    map[string]string{"app": name},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name:    "mock-oauth2",
+				Image:   images.PythonImage,
+				Command: []string{"sh", "-c"},
+				Args:    []string{MockOAuth2ServerScript},
+				Ports:   []corev1.ContainerPort{{ContainerPort: 8080, Name: "http"}},
+				ReadinessProbe: &corev1.Probe{
+					ProbeHandler: corev1.ProbeHandler{
+						HTTPGet: &corev1.HTTPGetAction{
+							Path: "/stats",
+							Port: intstr.FromInt(8080),
+						},
+					},
+					InitialDelaySeconds: 5,
+					PeriodSeconds:       2,
+					FailureThreshold:    30,
+				},
+			}},
+		},
+	})).To(gomega.Succeed())
+
+	ginkgo.By("Creating mock OAuth2 server ClusterIP service: " + name)
+	gomega.Expect(c.Create(ctx, &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{"app": name},
+			Ports: []corev1.ServicePort{{
+				Port:       8080,
+				TargetPort: intstr.FromInt(8080),
+				Protocol:   corev1.ProtocolTCP,
+			}},
+		},
+	})).To(gomega.Succeed())
+
+	ginkgo.By("Waiting for mock OAuth2 server to be ready")
+	gomega.Eventually(func() bool {
+		pod := &corev1.Pod{}
+		if err := c.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, pod); err != nil {
+			return false
+		}
+		if pod.Status.Phase != corev1.PodRunning {
+			return false
+		}
+		for _, cond := range pod.Status.Conditions {
+			if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
+				return true
+			}
+		}
+		return false
+	}, timeout, pollingInterval).Should(gomega.BeTrue(), "mock OAuth2 server should be ready")
+
+	cleanup = func() {
+		_ = c.Delete(ctx, &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace}})
+		_ = c.Delete(ctx, &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace}})
+		gomega.Eventually(func() bool {
+			pod := &corev1.Pod{}
+			svcObj := &corev1.Service{}
+			podGone := apierrors.IsNotFound(c.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, pod))
+			svcGone := apierrors.IsNotFound(c.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, svcObj))
+			return podGone && svcGone
+		}, timeout, pollingInterval).Should(gomega.BeTrue(), "mock OAuth2 pod and service should be fully deleted")
+	}
+	return inClusterTokenURL, cleanup
 }

--- a/test/e2e/thv-operator/virtualmcp/virtualmcp_external_auth_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcp_external_auth_test.go
@@ -20,6 +20,10 @@ import (
 	"github.com/stacklok/toolhive/test/e2e/images"
 )
 
+// healthCheckAuthInterval is a short interval used in health-check auth tests so
+// the monitor runs at least a few times within the test timeout.
+const healthCheckAuthInterval = 5 * time.Second
+
 var _ = Describe("VirtualMCPServer Unauthenticated Backend Auth", Ordered, func() {
 	var (
 		testNamespace          = "default"
@@ -751,5 +755,426 @@ var _ = Describe("VirtualMCPServer Inline HeaderInjection Backend Auth", Ordered
 			}
 			Expect(fetchTool).ToNot(BeNil(), "fetch tool should be available")
 		})
+	})
+})
+
+// VirtualMCPServer Health Check with HeaderInjection Auth
+//
+// This suite validates the fix for https://github.com/stacklok/toolhive/issues/4101:
+// health checks must apply outgoing auth credentials (header_injection) when probing
+// backend MCPServers, exactly as real requests do.
+//
+// Before the fix, HeaderInjectionStrategy.Authenticate() returned early for health-check
+// contexts, meaning the header was never injected. After the fix it always injects the
+// header because static headers do not depend on user identity.
+//
+// Because the standard test backends (yardstick) do not enforce API-key validation this
+// test validates the directly observable effects:
+//   - The backend is reported as BackendStatusReady (not BackendStatusUnavailable/Unknown)
+//     even while health monitoring is running continuously.
+//   - Tools remain accessible through the vMCP (proving health checks passed and the
+//     backend was not prematurely marked unhealthy).
+var _ = Describe("VirtualMCPServer Health Check with HeaderInjection Auth", Ordered, func() {
+	var (
+		testNamespace          = "default"
+		mcpGroupName           = "test-hc-headerinjection-group"
+		vmcpServerName         = "test-vmcp-hc-headerinjection"
+		backendName            = "backend-hc-headerinjection"
+		externalAuthConfigName = "test-hc-headerinjection-config"
+		secretName             = "test-hc-headerinjection-secret"
+		timeout                = 3 * time.Minute
+		pollingInterval        = 1 * time.Second
+		vmcpNodePort           int32
+	)
+
+	BeforeAll(func() {
+		By("Creating Secret for header injection")
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretName,
+				Namespace: testNamespace,
+			},
+			StringData: map[string]string{
+				"api-key": "test-hc-api-key-value",
+			},
+		}
+		Expect(k8sClient.Create(ctx, secret)).To(Succeed())
+
+		By("Creating MCPExternalAuthConfig with headerInjection type")
+		externalAuthConfig := &mcpv1alpha1.MCPExternalAuthConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      externalAuthConfigName,
+				Namespace: testNamespace,
+			},
+			Spec: mcpv1alpha1.MCPExternalAuthConfigSpec{
+				Type: mcpv1alpha1.ExternalAuthTypeHeaderInjection,
+				HeaderInjection: &mcpv1alpha1.HeaderInjectionConfig{
+					HeaderName: "X-API-Key",
+					ValueSecretRef: &mcpv1alpha1.SecretKeyRef{
+						Name: secretName,
+						Key:  "api-key",
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, externalAuthConfig)).To(Succeed())
+
+		By("Creating MCPGroup")
+		CreateMCPGroupAndWait(ctx, k8sClient, mcpGroupName, testNamespace,
+			"Test group for health check headerInjection auth", timeout, pollingInterval)
+
+		By("Creating backend MCPServer with headerInjection auth ref")
+		backend := &mcpv1alpha1.MCPServer{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      backendName,
+				Namespace: testNamespace,
+			},
+			Spec: mcpv1alpha1.MCPServerSpec{
+				GroupRef:  mcpGroupName,
+				Image:     images.YardstickServerImage,
+				Transport: "streamable-http",
+				ProxyPort: 8080,
+				McpPort:   8080,
+				Env: []mcpv1alpha1.EnvVar{
+					{Name: "TRANSPORT", Value: "streamable-http"},
+				},
+				ExternalAuthConfigRef: &mcpv1alpha1.ExternalAuthConfigRef{
+					Name: externalAuthConfigName,
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, backend)).To(Succeed())
+
+		By("Waiting for backend MCPServer to be ready")
+		Eventually(func() error {
+			server := &mcpv1alpha1.MCPServer{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{
+				Name:      backendName,
+				Namespace: testNamespace,
+			}, server); err != nil {
+				return fmt.Errorf("failed to get server: %w", err)
+			}
+			if server.Status.Phase == mcpv1alpha1.MCPServerPhaseRunning {
+				return nil
+			}
+			return fmt.Errorf("backend not ready yet, phase: %s", server.Status.Phase)
+		}, timeout, pollingInterval).Should(Succeed())
+
+		By("Creating VirtualMCPServer with discovered auth and health monitoring enabled")
+		vmcpServer := &mcpv1alpha1.VirtualMCPServer{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      vmcpServerName,
+				Namespace: testNamespace,
+			},
+			Spec: mcpv1alpha1.VirtualMCPServerSpec{
+				Config: vmcpconfig.Config{
+					Group: mcpGroupName,
+					Operational: &vmcpconfig.OperationalConfig{
+						FailureHandling: &vmcpconfig.FailureHandlingConfig{
+							// Short interval so several health checks run within the test timeout.
+							HealthCheckInterval: vmcpconfig.Duration(healthCheckAuthInterval),
+							HealthCheckTimeout:  vmcpconfig.Duration(2 * time.Second),
+							UnhealthyThreshold:  3,
+						},
+					},
+				},
+				IncomingAuth: &mcpv1alpha1.IncomingAuthConfig{
+					Type: "anonymous",
+				},
+				OutgoingAuth: &mcpv1alpha1.OutgoingAuthConfig{
+					Source: "discovered",
+				},
+				ServiceType: "NodePort",
+			},
+		}
+		Expect(k8sClient.Create(ctx, vmcpServer)).To(Succeed())
+
+		By("Waiting for VirtualMCPServer to be ready")
+		WaitForVirtualMCPServerReady(ctx, k8sClient, vmcpServerName, testNamespace, timeout, pollingInterval)
+
+		By("Waiting for VirtualMCPServer to discover backends")
+		WaitForCondition(ctx, k8sClient, vmcpServerName, testNamespace, "BackendsDiscovered", "True", timeout, pollingInterval)
+
+		By("Getting NodePort for VirtualMCPServer")
+		vmcpNodePort = GetVMCPNodePort(ctx, k8sClient, vmcpServerName, testNamespace, timeout, pollingInterval)
+	})
+
+	AfterAll(func() {
+		By("Cleaning up test resources")
+		_ = k8sClient.Delete(ctx, &mcpv1alpha1.VirtualMCPServer{
+			ObjectMeta: metav1.ObjectMeta{Name: vmcpServerName, Namespace: testNamespace},
+		})
+		_ = k8sClient.Delete(ctx, &mcpv1alpha1.MCPServer{
+			ObjectMeta: metav1.ObjectMeta{Name: backendName, Namespace: testNamespace},
+		})
+		_ = k8sClient.Delete(ctx, &mcpv1alpha1.MCPGroup{
+			ObjectMeta: metav1.ObjectMeta{Name: mcpGroupName, Namespace: testNamespace},
+		})
+		_ = k8sClient.Delete(ctx, &mcpv1alpha1.MCPExternalAuthConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: externalAuthConfigName, Namespace: testNamespace},
+		})
+		_ = k8sClient.Delete(ctx, &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: secretName, Namespace: testNamespace},
+		})
+	})
+
+	Context("when health monitoring is running alongside header injection auth", func() {
+		It("should keep the backend healthy — not mark it unauthenticated", func() {
+			// Core regression check for the fix in HeaderInjectionStrategy.Authenticate():
+			// health checks must inject the static header just like real requests do.
+			// We use Consistently to observe the backend status over several health check
+			// cycles: if the fix were absent and the backend enforced the header, it would
+			// accumulate probe failures and flip to BackendStatusUnavailable during
+			// this window.
+			By("Verifying backend status never becomes unavailable over several health check cycles")
+			Consistently(func() bool {
+				server := &mcpv1alpha1.VirtualMCPServer{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      vmcpServerName,
+					Namespace: testNamespace,
+				}, server); err != nil {
+					return false // cannot read status — treat as failure
+				}
+				for _, b := range server.Status.DiscoveredBackends {
+					if b.Name == backendName {
+						return b.Status == mcpv1alpha1.BackendStatusReady || b.Status == mcpv1alpha1.BackendStatusDegraded
+					}
+				}
+				// BackendsDiscovered=True was confirmed in BeforeAll, so the backend
+				// must appear in DiscoveredBackends — absence is unexpected.
+				return false
+			}, 3*healthCheckAuthInterval, pollingInterval).Should(BeTrue(),
+				"backend must remain ready/degraded during health check cycles; "+
+					"without the fix, health checks send unauthenticated probes which accumulate "+
+					"failures and flip the backend to unavailable/unknown")
+		})
+
+		It("should serve tools — proving health checks did not prematurely mark the backend unhealthy", func() {
+			By("Connecting to vMCP and listing tools")
+			serverURL := fmt.Sprintf("http://localhost:%d/mcp", vmcpNodePort)
+			mcpClient := InitializeMCPClientWithRetries(serverURL, 2*time.Minute)
+			defer mcpClient.Close()
+
+			testCtx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+			defer cancel()
+
+			Eventually(func() error {
+				listRequest := mcp.ListToolsRequest{}
+				tools, err := mcpClient.ListTools(testCtx, listRequest)
+				if err != nil {
+					return fmt.Errorf("failed to list tools: %w", err)
+				}
+				if len(tools.Tools) == 0 {
+					return fmt.Errorf("no tools returned — backend may have been excluded due to failed health checks")
+				}
+				return nil
+			}, 30*time.Second, 2*time.Second).Should(Succeed(),
+				"tools must be accessible; if the backend was marked unhealthy by the health monitor "+
+					"it would be excluded by the discovery middleware and no tools would be returned")
+		})
+	})
+})
+
+// VirtualMCPServer Health Check with TokenExchange Auth verifies that health checks
+// apply a client_credentials grant when TokenExchange auth is configured with
+// client_id + client_secret (fix for issue #4101 — token-exchange path).
+var _ = Describe("VirtualMCPServer Health Check with TokenExchange Auth", Ordered, func() {
+	const (
+		testNamespace          = "default"
+		mcpGroupName           = "hc-te-group"
+		vmcpServerName         = "hc-te-vmcp"
+		backendName            = "hc-te-backend"
+		externalAuthConfigName = "hc-te-auth-config"
+		secretName             = "hc-te-client-secret"
+		oauth2ServerName       = "hc-te-oauth2"
+		timeout                = 3 * time.Minute
+		pollingInterval        = 1 * time.Second
+	)
+
+	var (
+		oauth2TokenURL string
+		cleanupOAuth2  func()
+	)
+
+	BeforeAll(func() {
+		By("Deploying mock OAuth2 server")
+		oauth2TokenURL, cleanupOAuth2 = DeployMockOAuth2Server(
+			ctx, k8sClient, oauth2ServerName, testNamespace, timeout, pollingInterval,
+		)
+
+		By("Creating Secret with OAuth2 client secret")
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretName,
+				Namespace: testNamespace,
+			},
+			Data: map[string][]byte{
+				"client-secret": []byte("test-secret"),
+			},
+		}
+		Expect(k8sClient.Create(ctx, secret)).To(Succeed())
+
+		By("Creating MCPExternalAuthConfig with tokenExchange type")
+		externalAuthConfig := &mcpv1alpha1.MCPExternalAuthConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      externalAuthConfigName,
+				Namespace: testNamespace,
+			},
+			Spec: mcpv1alpha1.MCPExternalAuthConfigSpec{
+				Type: mcpv1alpha1.ExternalAuthTypeTokenExchange,
+				TokenExchange: &mcpv1alpha1.TokenExchangeConfig{
+					TokenURL: oauth2TokenURL,
+					ClientID: "test-client",
+					ClientSecretRef: &mcpv1alpha1.SecretKeyRef{
+						Name: secretName,
+						Key:  "client-secret",
+					},
+					Audience: "test-backend",
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, externalAuthConfig)).To(Succeed())
+
+		By("Creating MCPGroup")
+		CreateMCPGroupAndWait(ctx, k8sClient, mcpGroupName, testNamespace,
+			"Test group for health check tokenExchange auth", timeout, pollingInterval)
+
+		By("Creating backend MCPServer with tokenExchange auth ref")
+		backend := &mcpv1alpha1.MCPServer{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      backendName,
+				Namespace: testNamespace,
+			},
+			Spec: mcpv1alpha1.MCPServerSpec{
+				GroupRef:  mcpGroupName,
+				Image:     images.YardstickServerImage,
+				Transport: "streamable-http",
+				ProxyPort: 8080,
+				McpPort:   8080,
+				Env: []mcpv1alpha1.EnvVar{
+					{Name: "TRANSPORT", Value: "streamable-http"},
+				},
+				ExternalAuthConfigRef: &mcpv1alpha1.ExternalAuthConfigRef{
+					Name: externalAuthConfigName,
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, backend)).To(Succeed())
+
+		By("Waiting for backend MCPServer to be ready")
+		Eventually(func() error {
+			server := &mcpv1alpha1.MCPServer{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{
+				Name:      backendName,
+				Namespace: testNamespace,
+			}, server); err != nil {
+				return fmt.Errorf("failed to get server: %w", err)
+			}
+			if server.Status.Phase == mcpv1alpha1.MCPServerPhaseRunning {
+				return nil
+			}
+			return fmt.Errorf("backend not ready yet, phase: %s", server.Status.Phase)
+		}, timeout, pollingInterval).Should(Succeed())
+
+		By("Creating VirtualMCPServer with discovered auth and health monitoring enabled")
+		vmcpServer := &mcpv1alpha1.VirtualMCPServer{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      vmcpServerName,
+				Namespace: testNamespace,
+			},
+			Spec: mcpv1alpha1.VirtualMCPServerSpec{
+				Config: vmcpconfig.Config{
+					Group: mcpGroupName,
+					Operational: &vmcpconfig.OperationalConfig{
+						FailureHandling: &vmcpconfig.FailureHandlingConfig{
+							HealthCheckInterval: vmcpconfig.Duration(healthCheckAuthInterval),
+							HealthCheckTimeout:  vmcpconfig.Duration(2 * time.Second),
+							UnhealthyThreshold:  3,
+						},
+					},
+				},
+				IncomingAuth: &mcpv1alpha1.IncomingAuthConfig{
+					Type: "anonymous",
+				},
+				OutgoingAuth: &mcpv1alpha1.OutgoingAuthConfig{
+					Source: "discovered",
+				},
+				ServiceType: "NodePort",
+			},
+		}
+		Expect(k8sClient.Create(ctx, vmcpServer)).To(Succeed())
+
+		By("Waiting for VirtualMCPServer to be ready")
+		WaitForVirtualMCPServerReady(ctx, k8sClient, vmcpServerName, testNamespace, timeout, pollingInterval)
+
+		By("Waiting for VirtualMCPServer to discover backends")
+		WaitForCondition(ctx, k8sClient, vmcpServerName, testNamespace, "BackendsDiscovered", "True", timeout, pollingInterval)
+	})
+
+	AfterAll(func() {
+		By("Cleaning up test resources")
+		_ = k8sClient.Delete(ctx, &mcpv1alpha1.VirtualMCPServer{
+			ObjectMeta: metav1.ObjectMeta{Name: vmcpServerName, Namespace: testNamespace},
+		})
+		_ = k8sClient.Delete(ctx, &mcpv1alpha1.MCPServer{
+			ObjectMeta: metav1.ObjectMeta{Name: backendName, Namespace: testNamespace},
+		})
+		_ = k8sClient.Delete(ctx, &mcpv1alpha1.MCPGroup{
+			ObjectMeta: metav1.ObjectMeta{Name: mcpGroupName, Namespace: testNamespace},
+		})
+		_ = k8sClient.Delete(ctx, &mcpv1alpha1.MCPExternalAuthConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: externalAuthConfigName, Namespace: testNamespace},
+		})
+		_ = k8sClient.Delete(ctx, &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: secretName, Namespace: testNamespace},
+		})
+		if cleanupOAuth2 != nil {
+			cleanupOAuth2()
+		}
+	})
+
+	Context("when health monitoring is running alongside token exchange auth", func() {
+		It("should call the token endpoint with client_credentials during health checks", func() {
+			// Core regression check for the fix in TokenExchangeStrategy.Authenticate():
+			// health checks must perform a client_credentials grant when client_id +
+			// client_secret are configured, rather than skipping auth entirely.
+			// GetMockOAuth2Stats uses a curl pod to query /stats over in-cluster DNS,
+			// which works reliably in CI without requiring NodePort reachability.
+			By("Querying mock OAuth2 server /stats to verify health checks called the token endpoint")
+			Eventually(func() (int, error) {
+				return GetMockOAuth2Stats(ctx, k8sClient, testNamespace, oauth2ServerName)
+			}, 2*time.Minute, 15*time.Second).Should(BeNumerically(">", 0),
+				"mock OAuth2 server must record at least one client_credentials grant; "+
+					"without the fix, health checks skip auth and never call the token endpoint")
+		})
+
+		It("should keep the backend healthy — not mark it unavailable", func() {
+			// The first It spec (client_credentials stats check) already waits via
+			// Eventually until at least one token request has been made, so by the
+			// time this spec runs health checks have definitely fired. We then use
+			// Consistently to confirm the backend stays healthy over further cycles.
+			By("Verifying backend status never becomes unavailable over several health check cycles")
+			Consistently(func() bool {
+				server := &mcpv1alpha1.VirtualMCPServer{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      vmcpServerName,
+					Namespace: testNamespace,
+				}, server); err != nil {
+					return false // cannot read status — treat as failure
+				}
+				for _, b := range server.Status.DiscoveredBackends {
+					if b.Name == backendName {
+						return b.Status == mcpv1alpha1.BackendStatusReady || b.Status == mcpv1alpha1.BackendStatusDegraded
+					}
+				}
+				// BackendsDiscovered=True was confirmed in BeforeAll, so the backend
+				// must appear in DiscoveredBackends — absence is unexpected.
+				return false
+			}, 3*healthCheckAuthInterval, pollingInterval).Should(BeTrue(),
+				"backend must remain ready/degraded during health check cycles; "+
+					"without the fix, health checks skip auth, the backend accumulates "+
+					"probe failures, and its status flips to unavailable/unknown")
+		})
+
 	})
 })


### PR DESCRIPTION
## Summary

<!--
REQUIRED. You MUST explain:
1. WHY this change is needed (the problem or motivation)
2. WHAT changed (concise bullet points)

The diff shows the code — your summary must provide the context a reviewer
needs to understand the purpose without reading the diff first.
-->

Health check probes were sent unauthenticated to backend MCPServers because both auth strategies short-circuited on the health-check context marker before injecting any credentials.

HeaderInjectionStrategy: remove the early return — static headers have no dependency on user identity and must be injected for all requests, including probes.

TokenExchangeStrategy: instead of a blanket skip, perform an OAuth2 client_credentials grant when client_id + client_secret are configured, so the health probe carries a valid Bearer token. When credentials are not configured the probe is still sent unauthenticated (unchanged behaviour for that case).

Unit tests are updated / added to cover both the fixed header-injection path and the two token-exchange health-check branches (with and without client credentials). E2E tests are added in
test/e2e/thv-operator/virtualmcp for both auth strategies, including a new DeployMockOAuth2ServerWithNodePort helper that lets the test assert client_credentials grants were actually made to the token endpoint.

<!--
Link related issues. Use "Closes" or "Fixes" to auto-close on merge.
Remove this line if there is no related issue.
-->

Fixes #4101 

## Type of change

<!-- REQUIRED. Check exactly one. -->

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

<!--
REQUIRED. Check every verification step you actually ran.
You MUST check at least one item. If you only did manual testing,
describe exactly what you tested below the checkbox.
-->

- [x] Unit tests (`task test`)
- [x] E2E tests (`task test-e2e`)
- [x] Linting (`task lint-fix`)
- [ ] Manual testing (describe below)

## Changes

<!--
Optional — include for PRs touching more than a few files to help
reviewers navigate the diff. Remove this entire section for small PRs.
-->

| File | Change |
|------|--------|
|      |        |

## Does this introduce a user-facing change?

<!--
If yes, describe the change from the user's perspective. This helps with release notes.
If no, write "No".
Remove this section entirely if not applicable.
-->

## Special notes for reviewers

<!--
Optional — call out anything non-obvious: tricky logic, known limitations,
areas where you'd like extra scrutiny, or follow-up work planned.
Remove this section if not needed.
-->
