### PR TITLE
Inject tool annotations into context during list filtering

### DIFF
--- a/pkg/authz/response_filter.go
+++ b/pkg/authz/response_filter.go
@@ -286,10 +286,20 @@ func (rfw *ResponseFilteringWriter) filterToolsResponse(response *jsonrpc2.Respo
 	// Note: instantiating the list ensures that no null value is sent over the wire.
 	// This is basically defensive programming, but for clients.
 	filteredTools := []mcp.Tool{}
-	for _, tool := range listResult.Tools {
+	for i, tool := range listResult.Tools {
+		// Inject this tool's annotations into the context so Cedar policies
+		// that use when clauses on resource attributes (e.g. resource.readOnlyHint)
+		// can evaluate correctly. Without this, the authorization check runs
+		// against a context with no annotations and all when clauses fail.
+		ctx := rfw.request.Context()
+		ann := &listResult.Tools[i].Annotations
+		if hasAnyHint(ann) {
+			ctx = authorizers.WithToolAnnotations(ctx, convertMCPAnnotation(ann))
+		}
+
 		// Check if the user is authorized to call this tool
 		authorized, err := rfw.authorizer.AuthorizeWithJWTClaims(
-			rfw.request.Context(),
+			ctx,
 			authorizers.MCPFeatureTool,
 			authorizers.MCPOperationCall,
 			tool.Name,


### PR DESCRIPTION
## Summary

- **Why**: When the authz middleware filters a `tools/list` response, it calls `AuthorizeWithJWTClaims` per tool to decide visibility. It was passing the original `tools/list` request context, which contains no tool annotations. Cedar policies with `when` clauses on resource attributes (e.g. `resource.readOnlyHint == true`) always evaluated to an error (attribute not found), causing **all tools to be filtered out** regardless of their annotations.
- **What**: For each tool in the list response, inject its annotations into the context before the authorization check — matching what `AnnotationEnrichmentMiddleware` already does for `tools/call` requests. Uses existing `hasAnyHint` and `convertMCPAnnotation` helpers from the same package.

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test`)
- [x] Manual testing (describe below)

Verified with brood-box using a local `go.mod` replace directive pointing to this branch. With `--mcp-authz-profile safe-tools`:
- **Before**: zero tools visible (only Slack resources appeared)
- **After**: tools with matching annotations (`readOnlyHint: true` from github, context7) correctly appear; destructive/open-world tools (slack) correctly remain blocked

## Does this introduce a user-facing change?

Yes. Cedar authz policies that use annotation-based `when` clauses (e.g. `resource.readOnlyHint == true`) now work correctly during `tools/list` filtering. Previously, all tools were incorrectly filtered out.

## Special notes for reviewers

The fix is minimal — 10 lines added in `filterToolsResponse()`. The root issue is that `AnnotationEnrichmentMiddleware` only enriches `tools/call` requests (by design), but the list filter was making `call_tool` authorization decisions without the same enrichment. The helpers `hasAnyHint` and `convertMCPAnnotation` are already in `annotation_cache.go` in the same package.

Generated with [Claude Code](https://claude.com/claude-code)