### PR TITLE
Remove NewManagerWithRegistry in favor of NewManager

### DIFF
--- a/cmd/vmcp/app/commands.go
+++ b/cmd/vmcp/app/commands.go
@@ -399,15 +399,13 @@ func runServe(cmd *cobra.Command, _ []string) error {
 	}
 	agg := aggregator.NewDefaultAggregator(backendClient, conflictResolver, cfg.Aggregation, tracerProvider)
 
-	// Use DynamicRegistry for version-based cache invalidation
-	// Works in both standalone (CLI with YAML config) and Kubernetes (operator-deployed) modes
-	// In standalone mode: backends from config file, no dynamic updates
-	// In K8s mode with discovered auth: backends watched dynamically via BackendWatcher
+	// DynamicRegistry tracks backends for dynamic discovery in Kubernetes mode.
+	// In standalone mode: backends from config file, no dynamic updates.
+	// In K8s mode with discovered auth: backends watched dynamically via BackendWatcher.
 	dynamicRegistry := vmcp.NewDynamicRegistry(backends)
 	backendRegistry := vmcp.BackendRegistry(dynamicRegistry)
 
-	// Use NewManagerWithRegistry to enable version-based cache invalidation
-	discoveryMgr, err := discovery.NewManagerWithRegistry(agg, dynamicRegistry)
+	discoveryMgr, err := discovery.NewManager(agg)
 	if err != nil {
 		return fmt.Errorf("failed to create discovery manager: %w", err)
 	}

--- a/pkg/vmcp/discovery/manager.go
+++ b/pkg/vmcp/discovery/manager.go
@@ -54,13 +54,6 @@ func NewManager(agg aggregator.Aggregator) (Manager, error) {
 	}, nil
 }
 
-// NewManagerWithRegistry creates a new discovery manager.
-// The registry parameter is accepted for API compatibility but is no longer used
-// for caching. Discovery results are computed fresh on each request.
-func NewManagerWithRegistry(agg aggregator.Aggregator, _ vmcp.DynamicRegistry) (Manager, error) {
-	return NewManager(agg)
-}
-
 // Discover performs capability aggregation for the given backends.
 //
 // Results are computed fresh on each call — no caching is performed. New MCP

--- a/pkg/vmcp/discovery/manager_test.go
+++ b/pkg/vmcp/discovery/manager_test.go
@@ -45,50 +45,6 @@ func TestNewManager(t *testing.T) {
 	})
 }
 
-func TestNewManagerWithRegistry(t *testing.T) {
-	t.Parallel()
-
-	t.Run("success - registry parameter is ignored", func(t *testing.T) {
-		t.Parallel()
-		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
-
-		mockAgg := aggmocks.NewMockAggregator(ctrl)
-		registry := vmcp.NewDynamicRegistry(nil)
-
-		mgr, err := NewManagerWithRegistry(mockAgg, registry)
-
-		require.NoError(t, err)
-		assert.NotNil(t, mgr)
-		assert.IsType(t, &DefaultManager{}, mgr)
-	})
-
-	t.Run("success with nil registry", func(t *testing.T) {
-		t.Parallel()
-		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
-
-		mockAgg := aggmocks.NewMockAggregator(ctrl)
-
-		mgr, err := NewManagerWithRegistry(mockAgg, nil)
-
-		require.NoError(t, err)
-		assert.NotNil(t, mgr)
-	})
-
-	t.Run("error with nil aggregator", func(t *testing.T) {
-		t.Parallel()
-
-		registry := vmcp.NewDynamicRegistry(nil)
-
-		mgr, err := NewManagerWithRegistry(nil, registry)
-
-		require.Error(t, err)
-		assert.Nil(t, mgr)
-		assert.ErrorIs(t, err, ErrAggregatorNil)
-	})
-}
-
 func TestDefaultManager_Discover(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- `NewManagerWithRegistry` was left over from the cache removal in #4110 — it accepted a `DynamicRegistry` parameter but silently ignored it, making the API misleading. This removes the function entirely and updates the single call site to use `NewManager` directly.

## Type of change

- [x] Refactoring (no behavior change)

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)

## Changes

| File | Change |
|------|--------|
| `pkg/vmcp/discovery/manager.go` | Remove `NewManagerWithRegistry` function |
| `pkg/vmcp/discovery/manager_test.go` | Remove `TestNewManagerWithRegistry` test |
| `cmd/vmcp/app/commands.go` | Replace `discovery.NewManagerWithRegistry(agg, dynamicRegistry)` with `discovery.NewManager(agg)`, update stale comment |

## Does this introduce a user-facing change?

No

Generated with [Claude Code](https://claude.com/claude-code)