### PR TITLE
Add notifications/elicitation/complete to MCP parser

### DIFF
--- a/pkg/mcp/parser.go
+++ b/pkg/mcp/parser.go
@@ -184,30 +184,31 @@ type methodHandler func(map[string]interface{}) (string, map[string]interface{})
 
 // methodHandlers maps MCP methods to their respective handlers
 var methodHandlers = map[string]methodHandler{
-	"initialize":                 handleInitializeMethod,
-	"tools/call":                 handleNamedResourceMethod,
-	"prompts/get":                handleNamedResourceMethod,
-	"resources/read":             handleResourceReadMethod,
-	"resources/list":             handleListMethod,
-	"tools/list":                 handleListMethod,
-	"prompts/list":               handleListMethod,
-	"progress/update":            handleProgressMethod,
-	"notifications/message":      handleNotificationMethod,
-	"logging/setLevel":           handleLoggingMethod,
-	"completion/complete":        handleCompletionMethod,
-	"elicitation/create":         handleElicitationMethod,
-	"sampling/createMessage":     handleSamplingMethod,
-	"resources/subscribe":        handleResourceSubscribeMethod,
-	"resources/unsubscribe":      handleResourceUnsubscribeMethod,
-	"resources/templates/list":   handleListMethod,
-	"roots/list":                 handleListMethod,
-	"notifications/progress":     handleProgressNotificationMethod,
-	"notifications/cancelled":    handleCancelledNotificationMethod,
-	"tasks/list":                 handleListMethod,
-	"tasks/get":                  handleTaskIDMethod,
-	"tasks/cancel":               handleTaskIDMethod,
-	"tasks/result":               handleTaskIDMethod,
-	"notifications/tasks/status": handleTaskStatusNotificationMethod,
+	"initialize":                         handleInitializeMethod,
+	"tools/call":                         handleNamedResourceMethod,
+	"prompts/get":                        handleNamedResourceMethod,
+	"resources/read":                     handleResourceReadMethod,
+	"resources/list":                     handleListMethod,
+	"tools/list":                         handleListMethod,
+	"prompts/list":                       handleListMethod,
+	"progress/update":                    handleProgressMethod,
+	"notifications/message":              handleNotificationMethod,
+	"logging/setLevel":                   handleLoggingMethod,
+	"completion/complete":                handleCompletionMethod,
+	"elicitation/create":                 handleElicitationMethod,
+	"sampling/createMessage":             handleSamplingMethod,
+	"resources/subscribe":                handleResourceSubscribeMethod,
+	"resources/unsubscribe":              handleResourceUnsubscribeMethod,
+	"resources/templates/list":           handleListMethod,
+	"roots/list":                         handleListMethod,
+	"notifications/progress":             handleProgressNotificationMethod,
+	"notifications/cancelled":            handleCancelledNotificationMethod,
+	"tasks/list":                         handleListMethod,
+	"tasks/get":                          handleTaskIDMethod,
+	"tasks/cancel":                       handleTaskIDMethod,
+	"tasks/result":                       handleTaskIDMethod,
+	"notifications/tasks/status":         handleTaskStatusNotificationMethod,
+	"notifications/elicitation/complete": handleElicitationCompleteNotificationMethod,
 }
 
 // staticResourceIDs maps methods to their static resource IDs
@@ -355,6 +356,16 @@ func handleElicitationMethod(paramsMap map[string]interface{}) (string, map[stri
 	// The message field could be used as a resource identifier
 	if message, ok := paramsMap["message"].(string); ok {
 		return message, paramsMap
+	}
+	return "", paramsMap
+}
+
+// handleElicitationCompleteNotificationMethod extracts resource ID for elicitation complete notifications.
+// This notification is sent by the server when an out-of-band URL-mode elicitation is completed.
+// Returns the elicitationId as the resource identifier.
+func handleElicitationCompleteNotificationMethod(paramsMap map[string]interface{}) (string, map[string]interface{}) {
+	if elicitationId, ok := paramsMap["elicitationId"].(string); ok {
+		return elicitationId, paramsMap
 	}
 	return "", paramsMap
 }

--- a/pkg/mcp/parser_test.go
+++ b/pkg/mcp/parser_test.go
@@ -174,6 +174,17 @@ func TestParsingMiddleware(t *testing.T) {
 			expectedID:     int64(6),
 			expectedResID:  "debug",
 		},
+		{
+			name:           "notifications/elicitation/complete notification",
+			method:         "POST",
+			path:           "/messages",
+			contentType:    "application/json",
+			body:           `{"jsonrpc":"2.0","method":"notifications/elicitation/complete","params":{"elicitationId":"550e8400-e29b-41d4-a716-446655440000"}}`,
+			expectParsed:   true,
+			expectedMethod: "notifications/elicitation/complete",
+			expectedID:     nil,
+			expectedResID:  "550e8400-e29b-41d4-a716-446655440000",
+		},
 	}
 
 	for _, tt := range tests {
@@ -769,6 +780,22 @@ func TestExtractResourceAndArguments(t *testing.T) {
 			params:             `{"cursor":"page-2"}`,
 			expectedResourceID: "page-2",
 			expectedArguments:  nil,
+		},
+		{
+			name:               "notifications/elicitation/complete with elicitationId",
+			method:             "notifications/elicitation/complete",
+			params:             `{"elicitationId":"550e8400-e29b-41d4-a716-446655440000"}`,
+			expectedResourceID: "550e8400-e29b-41d4-a716-446655440000",
+			expectedArguments: map[string]interface{}{
+				"elicitationId": "550e8400-e29b-41d4-a716-446655440000",
+			},
+		},
+		{
+			name:               "notifications/elicitation/complete with missing elicitationId",
+			method:             "notifications/elicitation/complete",
+			params:             `{}`,
+			expectedResourceID: "",
+			expectedArguments:  map[string]interface{}{},
 		},
 	}
 


### PR DESCRIPTION
## Summary

- The MCP 2025-11-25 spec defines `notifications/elicitation/complete` as a server-to-client notification sent when an out-of-band URL-mode elicitation completes. This was the only spec-defined method not yet handled by the parser (30 of 31 covered).
- Adds a handler that extracts `elicitationId` as the resource identifier, plus tests for the middleware round-trip and extraction logic.

## Type of change

- [x] New feature

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)

Generated with [Claude Code](https://claude.com/claude-code)