### PR TITLE
Ignore GO-2026-4514 in govulncheck to unblock CI

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -86,7 +86,11 @@ jobs:
           #   ToolHive only uses sigstore-go as a client to verify signatures, it does not
           #   expose any timestamp-authority server endpoints. Fix requires sigstore-go to
           #   upgrade to timestamp-authority/v2 which hasn't been released yet.
-          IGNORED_VULNS="GO-2025-4192"
+          # GO-2026-4514: buger/jsonparser Delete function DoS via malformed JSON (CVE-2025-54410)
+          #   Indirect dependency via mcp-go, invopop/jsonschema, wk8/go-ordered-map.
+          #   The vulnerability is in the Delete function which is not called by ToolHive
+          #   or any of its dependencies. No fixed version exists yet (all versions affected).
+          IGNORED_VULNS="GO-2025-4192 GO-2026-4514"
 
           # Show the raw output for debugging
           echo "::group::govulncheck raw output"


### PR DESCRIPTION
## Summary

- A new vulnerability GO-2026-4514 was published on 2026-03-16 for `github.com/buger/jsonparser` (CVE-2025-54410), causing the govulncheck CI job to fail on all PRs.
- The vuln is a DoS in the `Delete` function via malformed JSON. Neither ToolHive nor any of its dependencies call this function — govulncheck only flags it at the package import level.
- No fixed version exists (all versions affected: v1.0.0, v1.1.0, v1.1.1), and `buger/jsonparser` is a transitive dep pulled in by mcp-go, invopop/jsonschema, and wk8/go-ordered-map.
- Added GO-2026-4514 to the `IGNORED_VULNS` allowlist with a justification comment, following the same pattern as the existing GO-2025-4192 entry.

## Type of change

- [x] Other (describe): CI fix — allowlist unreachable vulnerability

## Test plan

- [x] Manual testing (describe below)

Verified the vuln is not reachable: `jsonparser.Delete` is not called anywhere in ToolHive's code or its dependency chain. CI will pass once this ignore is in place.

## Does this introduce a user-facing change?

No

🤖 Generated with [Claude Code](https://claude.com/claude-code)