### PR TITLE
Remove non-spec progress/update method from MCP parser

### DIFF
--- a/pkg/authz/middleware.go
+++ b/pkg/authz/middleware.go
@@ -29,10 +29,8 @@ var MCPMethodToFeatureOperation = map[string]struct {
 	Operation authorizers.MCPOperation
 }{
 	// Core protocol methods - always allowed
-	"initialize":      {Feature: "", Operation: ""}, // Protocol initialization
-	"ping":            {Feature: "", Operation: ""}, // Health check
-	"progress/update": {Feature: "", Operation: ""}, // Progress reporting
-
+	"initialize": {Feature: "", Operation: ""}, // Protocol initialization
+	"ping":       {Feature: "", Operation: ""}, // Health check
 	// Tool operations - require authorization
 	"tools/call": {Feature: authorizers.MCPFeatureTool, Operation: authorizers.MCPOperationCall},
 	"tools/list": {Feature: authorizers.MCPFeatureTool, Operation: authorizers.MCPOperationList},
@@ -99,7 +97,7 @@ func shouldSkipInitialAuthorization(r *http.Request) bool {
 // after parsing the JSON-RPC message.
 func shouldSkipSubsequentAuthorization(method string) bool {
 	// Skip authorization for methods that don't require it
-	if method == "ping" || method == "progress/update" || method == "initialize" {
+	if method == "ping" || method == "initialize" {
 		return true
 	}
 

--- a/pkg/mcp/parser.go
+++ b/pkg/mcp/parser.go
@@ -191,7 +191,6 @@ var methodHandlers = map[string]methodHandler{
 	"resources/list":                     handleListMethod,
 	"tools/list":                         handleListMethod,
 	"prompts/list":                       handleListMethod,
-	"progress/update":                    handleProgressMethod,
 	"notifications/message":              handleNotificationMethod,
 	"logging/setLevel":                   handleLoggingMethod,
 	"completion/complete":                handleCompletionMethod,
@@ -298,14 +297,6 @@ func handleResourceReadMethod(paramsMap map[string]interface{}) (string, map[str
 func handleListMethod(paramsMap map[string]interface{}) (string, map[string]interface{}) {
 	if cursor, ok := paramsMap["cursor"].(string); ok && cursor != "" {
 		return cursor, nil
-	}
-	return "", nil
-}
-
-// handleProgressMethod extracts resource ID for progress updates
-func handleProgressMethod(paramsMap map[string]interface{}) (string, map[string]interface{}) {
-	if token, ok := paramsMap["progressToken"].(string); ok {
-		return token, nil
 	}
 	return "", nil
 }

--- a/pkg/mcp/parser_test.go
+++ b/pkg/mcp/parser_test.go
@@ -288,13 +288,6 @@ func TestExtractResourceAndArguments(t *testing.T) {
 			expectedArguments:  nil,
 		},
 		{
-			name:               "progress/update with token",
-			method:             "progress/update",
-			params:             `{"progressToken":"task-123","progress":50}`,
-			expectedResourceID: "task-123",
-			expectedArguments:  nil,
-		},
-		{
 			name:               "unknown method",
 			method:             "unknown/method",
 			params:             `{"someParam":"value"}`,
@@ -583,13 +576,6 @@ func TestExtractResourceAndArguments(t *testing.T) {
 			name:               "resources/read with missing uri",
 			method:             "resources/read",
 			params:             `{"other":"value"}`,
-			expectedResourceID: "",
-			expectedArguments:  nil,
-		},
-		{
-			name:               "progress/update with missing token",
-			method:             "progress/update",
-			params:             `{"progress":50}`,
 			expectedResourceID: "",
 			expectedArguments:  nil,
 		},


### PR DESCRIPTION
## Summary

The MCP parser included a `progress/update` method handler that is not part of the MCP specification. This conflicts with the spec-compliant `notifications/progress` handler that already exists and works correctly. Removing the non-spec method to align with the protocol specification.

- Remove `progress/update` map entry and dead `handleProgressMethod` function from parser
- Remove two related test cases from parser tests
- Remove `progress/update` from authorization middleware (method map and skip-auth condition)

Fixes #4170

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)

Ran `go test ./pkg/mcp/... ./pkg/authz/...` — all tests pass. Verified `go build ./...` compiles cleanly.