### PR TITLE
Validate RuntimeConfig fields at all entry points

### DIFF
--- a/cmd/thv/app/run_flags.go
+++ b/cmd/thv/app/run_flags.go
@@ -407,12 +407,17 @@ func handleImageRetrieval(
 	error,
 ) {
 
-	// Build runtime config override from flags (if any)
+	// Build runtime config override from flags (if any).
+	// Validation here is intentionally duplicated with configureRuntimeOptions
+	// so that invalid input is caught early before registry lookups.
 	var runtimeOverride *templates.RuntimeConfig
 	if runFlags.RuntimeImage != "" || len(runFlags.RuntimeAddPackages) > 0 {
 		runtimeOverride = &templates.RuntimeConfig{
 			BuilderImage:       runFlags.RuntimeImage,
 			AdditionalPackages: runFlags.RuntimeAddPackages,
+		}
+		if err := runtimeOverride.Validate(); err != nil {
+			return "", nil, fmt.Errorf("invalid runtime configuration: %w", err)
 		}
 	}
 
@@ -521,17 +526,22 @@ func configureRemoteHeaderOptions(runFlags *RunFlags) ([]runner.RunConfigBuilder
 	return opts, nil
 }
 
-// configureRuntimeOptions configures runtime image and package options
-func configureRuntimeOptions(runFlags *RunFlags) []runner.RunConfigBuilderOption {
+// configureRuntimeOptions configures runtime image and package options.
+// It validates the configuration to prevent shell injection when values
+// are interpolated into Dockerfile templates.
+func configureRuntimeOptions(runFlags *RunFlags) ([]runner.RunConfigBuilderOption, error) {
 	if runFlags.RuntimeImage == "" && len(runFlags.RuntimeAddPackages) == 0 {
-		return nil
+		return nil, nil
 	}
 
 	runtimeConfig := &templates.RuntimeConfig{
 		BuilderImage:       runFlags.RuntimeImage,
 		AdditionalPackages: runFlags.RuntimeAddPackages,
 	}
-	return []runner.RunConfigBuilderOption{runner.WithRuntimeConfig(runtimeConfig)}
+	if err := runtimeConfig.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid runtime configuration: %w", err)
+	}
+	return []runner.RunConfigBuilderOption{runner.WithRuntimeConfig(runtimeConfig)}, nil
 }
 
 // buildRunnerConfig creates the final RunnerConfig using the builder pattern
@@ -617,7 +627,10 @@ func buildRunnerConfig(
 	}
 
 	// Configure runtime options
-	runtimeOpts := configureRuntimeOptions(runFlags)
+	runtimeOpts, err := configureRuntimeOptions(runFlags)
+	if err != nil {
+		return nil, err
+	}
 	opts = append(opts, runtimeOpts...)
 
 	// Configure middleware and additional options

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -413,8 +413,16 @@ func getRuntimeConfig(provider Provider, transportType string) (*templates.Runti
 	return runtimeConfig, nil
 }
 
-// setRuntimeConfig sets the runtime configuration for a given transport type
+// setRuntimeConfig sets the runtime configuration for a given transport type.
+// It validates the configuration before storing to prevent shell injection
+// when values are interpolated into Dockerfile templates.
 func setRuntimeConfig(provider Provider, transportType string, runtimeConfig *templates.RuntimeConfig) error {
+	if runtimeConfig != nil {
+		if err := runtimeConfig.Validate(); err != nil {
+			return fmt.Errorf("invalid runtime config: %w", err)
+		}
+	}
+
 	return provider.UpdateConfig(func(c *Config) {
 		if c.RuntimeConfigs == nil {
 			c.RuntimeConfigs = make(map[string]*templates.RuntimeConfig)

--- a/pkg/container/templates/runtime_config.go
+++ b/pkg/container/templates/runtime_config.go
@@ -3,6 +3,23 @@
 
 package templates
 
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+
+	nameref "github.com/google/go-containerregistry/pkg/name"
+)
+
+// maxPackageNameLength is the maximum allowed length for a package name.
+const maxPackageNameLength = 128
+
+// packageNamePattern matches valid Alpine/Debian package names.
+// Must start with an alphanumeric character, followed by alphanumeric characters,
+// dots, underscores, plus signs, or hyphens.
+var packageNamePattern = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._+\-]*$`)
+
 // RuntimeConfig defines the base images and versions for a specific runtime
 type RuntimeConfig struct {
 	// BuilderImage is the full image reference for the builder stage
@@ -13,6 +30,44 @@ type RuntimeConfig struct {
 	// Examples for Alpine: ["git", "make", "gcc"]
 	// Examples for Debian: ["git", "build-essential"]
 	AdditionalPackages []string `json:"additional_packages,omitempty" yaml:"additional_packages,omitempty"`
+}
+
+// Validate checks that all RuntimeConfig fields contain safe values that cannot
+// cause unexpected behavior when interpolated into Dockerfile templates.
+// An empty BuilderImage is allowed because it signals "use the default for
+// this transport type" during config merging.
+// It returns a combined error listing all invalid fields.
+func (rc *RuntimeConfig) Validate() error {
+	var errs []error
+
+	// Validate BuilderImage using go-containerregistry's ParseReference,
+	// which rejects newlines, shell metacharacters, and malformed refs.
+	if rc.BuilderImage != "" {
+		trimmed := strings.TrimSpace(rc.BuilderImage)
+		if trimmed == "" {
+			errs = append(errs, fmt.Errorf("builder_image is blank after trimming whitespace"))
+		} else if _, err := nameref.ParseReference(trimmed); err != nil {
+			errs = append(errs, fmt.Errorf("invalid builder_image %q: %w", rc.BuilderImage, err))
+		}
+	}
+
+	// Validate each AdditionalPackages entry against a strict allowlist regex
+	// and a maximum length bound.
+	for _, pkg := range rc.AdditionalPackages {
+		if len(pkg) > maxPackageNameLength {
+			errs = append(errs, fmt.Errorf(
+				"package name %q exceeds maximum length of %d characters",
+				pkg, maxPackageNameLength,
+			))
+		} else if !packageNamePattern.MatchString(pkg) {
+			errs = append(errs, fmt.Errorf(
+				"invalid package name %q: must match %s",
+				pkg, packageNamePattern.String(),
+			))
+		}
+	}
+
+	return errors.Join(errs...)
 }
 
 // RuntimeDefaults provides default configurations for each runtime type

--- a/pkg/container/templates/runtime_config_test.go
+++ b/pkg/container/templates/runtime_config_test.go
@@ -6,6 +6,9 @@ package templates
 import (
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetDefaultRuntimeConfig(t *testing.T) {
@@ -135,5 +138,195 @@ func TestGetDockerfileTemplateUsesDefaultWhenNil(t *testing.T) {
 	// Should use default Go version
 	if !strings.Contains(result, "FROM golang:1.25-alpine AS builder") {
 		t.Error("Dockerfile does not contain default Go version")
+	}
+}
+
+func TestRuntimeConfigValidate_ValidPackageNames(t *testing.T) {
+	t.Parallel()
+
+	validPackages := []string{
+		"git",
+		"ca-certificates",
+		"libssl1.1",
+		"g++",
+		"python3.11",
+		"build-essential",
+		"gcc",
+		"make",
+		"libc6-dev",
+		"curl",
+	}
+
+	for _, pkg := range validPackages {
+		t.Run(pkg, func(t *testing.T) {
+			t.Parallel()
+
+			rc := &RuntimeConfig{
+				BuilderImage:       "golang:1.25-alpine",
+				AdditionalPackages: []string{pkg},
+			}
+			assert.NoError(t, rc.Validate())
+		})
+	}
+}
+
+func TestRuntimeConfigValidate_InvalidPackageNames(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		pkg  string
+	}{
+		{name: "command chaining with &&", pkg: "git && rm -rf /"},
+		{name: "command substitution", pkg: "$(curl evil)"},
+		{name: "semicolon separator", pkg: "pkg;ls"},
+		{name: "pipe operator", pkg: "pkg|cat"},
+		{name: "backtick substitution", pkg: "pkg`id`"},
+		{name: "newline injection", pkg: "pkg\nRUN evil"},
+		{name: "space in name", pkg: "pkg name"},
+		{name: "empty string", pkg: ""},
+		{name: "starts with hyphen", pkg: "-pkg"},
+		{name: "redirect operator", pkg: "pkg>file"},
+		{name: "shell variable", pkg: "${HOME}"},
+		{name: "wildcard", pkg: "pkg*"},
+		{name: "question mark glob", pkg: "pkg?"},
+		{name: "parentheses", pkg: "pkg(test)"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			rc := &RuntimeConfig{
+				BuilderImage:       "golang:1.25-alpine",
+				AdditionalPackages: []string{tt.pkg},
+			}
+			err := rc.Validate()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "invalid package name")
+		})
+	}
+}
+
+func TestRuntimeConfigValidate_ValidBuilderImages(t *testing.T) {
+	t.Parallel()
+
+	validImages := []string{
+		"golang:1.24-alpine",
+		"docker.io/library/node:20-alpine",
+		"ghcr.io/stacklok/builder:latest",
+		"python:3.13-slim",
+		"node:22-alpine",
+		"mcr.microsoft.com/dotnet/sdk:8.0",
+		"registry.example.com/myimage:v1.2.3",
+	}
+
+	for _, img := range validImages {
+		t.Run(img, func(t *testing.T) {
+			t.Parallel()
+
+			rc := &RuntimeConfig{
+				BuilderImage:       img,
+				AdditionalPackages: []string{"git"},
+			}
+			assert.NoError(t, rc.Validate())
+		})
+	}
+}
+
+func TestRuntimeConfigValidate_InvalidBuilderImages(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		image string
+	}{
+		{name: "newline injection", image: "alpine\nRUN curl evil"},
+		{name: "space in image", image: "alpine invalid"},
+		{name: "blank after trim", image: "   "},
+		{name: "shell metachar semicolon", image: "alpine;echo pwned"},
+		{name: "shell metachar pipe", image: "alpine|cat /etc/passwd"},
+		{name: "shell metachar ampersand", image: "alpine&&curl evil"},
+		{name: "backtick injection", image: "alpine`id`"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			rc := &RuntimeConfig{
+				BuilderImage:       tt.image,
+				AdditionalPackages: []string{"git"},
+			}
+			err := rc.Validate()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "builder_image")
+		})
+	}
+}
+
+func TestRuntimeConfigValidate_EmptyBuilderImageIsAllowed(t *testing.T) {
+	t.Parallel()
+
+	rc := &RuntimeConfig{
+		BuilderImage:       "",
+		AdditionalPackages: []string{"git"},
+	}
+	assert.NoError(t, rc.Validate())
+}
+
+func TestRuntimeConfigValidate_EmptyConfig(t *testing.T) {
+	t.Parallel()
+
+	rc := &RuntimeConfig{}
+	assert.NoError(t, rc.Validate())
+}
+
+func TestRuntimeConfigValidate_MultipleErrors(t *testing.T) {
+	t.Parallel()
+
+	rc := &RuntimeConfig{
+		BuilderImage:       "alpine\nRUN evil",
+		AdditionalPackages: []string{"git", "pkg;ls", "curl", "$(evil)"},
+	}
+	err := rc.Validate()
+	require.Error(t, err)
+	// Should report both the builder image and the invalid packages
+	assert.Contains(t, err.Error(), "builder_image")
+	assert.Contains(t, err.Error(), "pkg;ls")
+	assert.Contains(t, err.Error(), "$(evil)")
+}
+
+func TestRuntimeConfigValidate_PackageNameTooLong(t *testing.T) {
+	t.Parallel()
+
+	longName := strings.Repeat("a", maxPackageNameLength+1)
+	rc := &RuntimeConfig{
+		AdditionalPackages: []string{longName},
+	}
+	err := rc.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds maximum length")
+}
+
+func TestRuntimeConfigValidate_PackageNameAtMaxLength(t *testing.T) {
+	t.Parallel()
+
+	exactName := strings.Repeat("a", maxPackageNameLength)
+	rc := &RuntimeConfig{
+		AdditionalPackages: []string{exactName},
+	}
+	assert.NoError(t, rc.Validate())
+}
+
+func TestRuntimeConfigValidate_DefaultConfigsAreValid(t *testing.T) {
+	t.Parallel()
+
+	for transportType, config := range RuntimeDefaults {
+		t.Run(string(transportType), func(t *testing.T) {
+			t.Parallel()
+
+			assert.NoError(t, config.Validate())
+		})
 	}
 }

--- a/pkg/runner/protocol.go
+++ b/pkg/runner/protocol.go
@@ -142,7 +142,10 @@ func createTemplateData(
 	}
 
 	// Load runtime configuration (base images and packages)
-	runtimeConfig := loadRuntimeConfig(transportType, runtimeOverride)
+	runtimeConfig, err := loadRuntimeConfig(transportType, runtimeOverride)
+	if err != nil {
+		return templateData, err
+	}
 	templateData.RuntimeConfig = runtimeConfig
 
 	return templateData, nil
@@ -150,27 +153,33 @@ func createTemplateData(
 
 // loadRuntimeConfig loads the runtime configuration for a given transport type.
 // Priority order:
-// 1. Override provided as parameter
+// 1. Override provided as parameter (validated before use)
 // 2. User configuration from config file
 // 3. Default configuration for the transport type
 func loadRuntimeConfig(
 	transportType templates.TransportType,
 	override *templates.RuntimeConfig,
-) *templates.RuntimeConfig {
-	// If override is provided, use it
+) (*templates.RuntimeConfig, error) {
+	// If override is provided, validate and use it
 	if override != nil {
-		return override
+		if err := override.Validate(); err != nil {
+			return nil, fmt.Errorf("invalid runtime config override: %w", err)
+		}
+		return override, nil
 	}
 
-	// Try loading from user config
+	// Try loading from user config (validate on read since config.yaml is hand-editable)
 	provider := config.NewProvider()
 	if userConfig, err := provider.GetRuntimeConfig(string(transportType)); err == nil && userConfig != nil {
-		return userConfig
+		if err := userConfig.Validate(); err != nil {
+			return nil, fmt.Errorf("invalid runtime config in config file for %s: %w", transportType, err)
+		}
+		return userConfig, nil
 	}
 
 	// Fall back to defaults
 	defaultConfig := templates.GetDefaultRuntimeConfig(transportType)
-	return &defaultConfig
+	return &defaultConfig, nil
 }
 
 // addBuildEnvToTemplate loads build environment variables from config and adds them to template data.


### PR DESCRIPTION
## Summary

- RuntimeConfig values (`AdditionalPackages` and `BuilderImage`) are interpolated into Dockerfile templates via `text/template`. To harden these inputs, add strict validation at all entry points before values reach template rendering.
- Add a `Validate()` method on `RuntimeConfig` that enforces a strict allowlist regex for package names and uses `go-containerregistry/pkg/name.ParseReference()` for builder image references. Call it at every path where RuntimeConfig is accepted: CLI flags, API requests, config file storage, and the runner's runtime config loader.

## Type of change

- [x] New feature

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)

## Changes

| File | Change |
|------|--------|
| `pkg/container/templates/runtime_config.go` | Add `Validate()` method with package name regex and image ref validation |
| `pkg/container/templates/runtime_config_test.go` | Add 8 test functions covering valid/invalid packages, images, empty configs, multiple errors, defaults |
| `cmd/thv/app/run_flags.go` | Call `Validate()` in `configureRuntimeOptions()` and `handleImageRetrieval()` |
| `pkg/runner/protocol.go` | Call `Validate()` in `loadRuntimeConfig()` before returning overrides |
| `pkg/config/config.go` | Call `Validate()` in `setRuntimeConfig()` before persisting |

## Does this introduce a user-facing change?

Users will now get a clear error message if they pass an invalid package name (e.g., containing shell metacharacters) via `--runtime-add-package` or an invalid image reference via `--runtime-image`. Previously these would be silently passed through to the Dockerfile template.

Generated with [Claude Code](https://claude.com/claude-code)
