### PR TITLE
Default skills to the "default" group on install

### DIFF
--- a/pkg/skills/skillsvc/skillsvc.go
+++ b/pkg/skills/skillsvc/skillsvc.go
@@ -188,6 +188,12 @@ func (s *service) Install(ctx context.Context, opts skills.InstallOptions) (*ski
 	// the same lock key and DB record.
 	opts.ProjectRoot = projectRoot
 
+	// Default to the "default" group when none is specified, matching
+	// workload behavior (pkg/api/v1/workload_service.go).
+	if opts.Group == "" {
+		opts.Group = groups.DefaultGroup
+	}
+
 	ref, isOCI, err := parseOCIReference(opts.Name)
 	if err != nil {
 		return nil, httperr.WithCode(

--- a/pkg/skills/skillsvc/skillsvc_test.go
+++ b/pkg/skills/skillsvc/skillsvc_test.go
@@ -1823,13 +1823,15 @@ func TestInstallAddsSkillToGroup(t *testing.T) {
 			},
 		},
 		{
-			name: "install without group skips group registration",
+			name: "install without group defaults to default group",
 			opts: skills.InstallOptions{Name: "my-skill"},
 			setupStoreMock: func(s *storemocks.MockSkillStore) {
 				s.EXPECT().Create(gomock.Any(), gomock.Any()).Return(nil)
 			},
-			setupGroupMock: func(_ *groupmocks.MockManager) {
-				// No group calls expected.
+			setupGroupMock: func(gm *groupmocks.MockManager) {
+				gm.EXPECT().Get(gomock.Any(), groups.DefaultGroup).
+					Return(&groups.Group{Name: groups.DefaultGroup, Skills: []string{}}, nil)
+				gm.EXPECT().Update(gomock.Any(), gomock.Any()).Return(nil)
 			},
 		},
 		{


### PR DESCRIPTION
## Summary

Workloads already default to the "default" group when no group is specified
(`pkg/api/v1/workload_service.go`), but skills did not. When
`thv skill install <name>` was called without `--group`, the group field stayed
empty and `registerSkillInGroup` was a no-op, meaning skills were never added to
any group unless the user explicitly passed `--group`.

- Add the same defaulting logic in the skill service `Install` method so skills
  are automatically registered in the "default" group, matching workload behavior
- Update the existing test case to verify default group registration occurs

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)

## Does this introduce a user-facing change?

Skills installed without `--group` are now automatically added to the "default"
group, matching the existing behavior for workloads. Previously they were not
added to any group.

Generated with [Claude Code](https://claude.com/claude-code)