### PR TITLE
feat(session): implement Redis storage backend (RC-6)

### DIFF
--- a/pkg/transport/session/redis_config.go
+++ b/pkg/transport/session/redis_config.go
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package session
+
+import "time"
+
+// Default timeouts for Redis operations.
+const (
+	DefaultDialTimeout  = 5 * time.Second
+	DefaultReadTimeout  = 3 * time.Second
+	DefaultWriteTimeout = 3 * time.Second
+)
+
+// RedisConfig configures the Redis storage backend for session storage.
+// Addr is used for standalone; SentinelConfig activates Sentinel mode (mutually exclusive).
+type RedisConfig struct {
+	// Addr is the Redis server address for standalone mode (e.g., "host:port").
+	Addr string
+
+	// SentinelConfig, when non-nil, activates Sentinel mode. Mutually exclusive with Addr.
+	SentinelConfig *SentinelConfig
+
+	// Password is the Redis AUTH password.
+	Password string
+
+	// DB is the Redis database index.
+	DB int
+
+	// KeyPrefix namespaces all session keys (e.g., "thv:vmcp:session:").
+	KeyPrefix string
+
+	// DialTimeout is the timeout for establishing a connection. Defaults to 5s.
+	DialTimeout time.Duration
+
+	// ReadTimeout is the timeout for read operations. Defaults to 3s.
+	ReadTimeout time.Duration
+
+	// WriteTimeout is the timeout for write operations. Defaults to 3s.
+	WriteTimeout time.Duration
+
+	// TLS configures TLS for Redis connections. nil means plaintext.
+	TLS *RedisTLSConfig
+}
+
+// SentinelConfig contains Redis Sentinel configuration.
+type SentinelConfig struct {
+	MasterName    string
+	SentinelAddrs []string
+}
+
+// RedisTLSConfig holds TLS configuration for Redis connections.
+// Presence of this struct enables TLS for the connection.
+type RedisTLSConfig struct {
+	// InsecureSkipVerify skips TLS certificate verification.
+	InsecureSkipVerify bool
+
+	// CACert is the PEM-encoded CA certificate for verifying the server.
+	// When nil, the system root CAs are used.
+	CACert []byte
+}

--- a/pkg/transport/session/serialization.go
+++ b/pkg/transport/session/serialization.go
@@ -9,12 +9,8 @@ import (
 	"time"
 )
 
-// The following serialization functions are prepared for Phase 4 (Redis/Valkey implementation)
-// They are currently unused but will be needed when implementing distributed storage backends.
-
 // sessionData is the JSON representation of a session.
 // This structure is used for serializing sessions to/from storage backends.
-// nolint:unused // Will be used in Phase 4 for Redis/Valkey storage
 type sessionData struct {
 	ID        string            `json:"id"`
 	Type      SessionType       `json:"type"`
@@ -25,7 +21,6 @@ type sessionData struct {
 }
 
 // serializeSession converts a Session to its JSON representation.
-// nolint:unused // Will be used in Phase 4 for Redis/Valkey storage
 func serializeSession(s Session) ([]byte, error) {
 	if s == nil {
 		return nil, fmt.Errorf("cannot serialize nil session")
@@ -53,7 +48,6 @@ func serializeSession(s Session) ([]byte, error) {
 
 // deserializeSession reconstructs a Session from its JSON representation.
 // It creates the appropriate session type based on the Type field.
-// nolint:unused // Will be used in Phase 4 for Redis/Valkey storage
 func deserializeSession(data []byte) (Session, error) {
 	if len(data) == 0 {
 		return nil, fmt.Errorf("cannot deserialize empty data")

--- a/pkg/transport/session/storage.go
+++ b/pkg/transport/session/storage.go
@@ -19,8 +19,12 @@ type Storage interface {
 
 	// Load retrieves a session by ID from the storage backend.
 	// Returns ErrSessionNotFound if the session doesn't exist.
-	// Note: This does not automatically touch the session. Callers should
-	// explicitly call Touch() on the returned session if they want to update its timestamp.
+	//
+	// Implementations may refresh the backend's eviction TTL on every Load (e.g. Redis
+	// GETEX) to prevent active sessions from expiring between reads, because Manager.Get
+	// calls Touch on the returned object but does not call Store. This TTL refresh is a
+	// backend-level eviction concern and is distinct from the session's application-level
+	// UpdatedAt timestamp, which Load must NOT update.
 	Load(ctx context.Context, id string) (Session, error)
 
 	// Delete removes a session from the storage backend.

--- a/pkg/transport/session/storage_redis.go
+++ b/pkg/transport/session/storage_redis.go
@@ -1,0 +1,205 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package session
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// RedisStorage implements the Storage interface backed by Redis.
+type RedisStorage struct {
+	client    redis.UniversalClient
+	keyPrefix string
+	ttl       time.Duration
+}
+
+func validateRedisConfig(cfg *RedisConfig) error {
+	if cfg.Addr != "" && cfg.SentinelConfig != nil {
+		return errors.New("addr and SentinelConfig are mutually exclusive")
+	}
+	if cfg.Addr == "" && cfg.SentinelConfig == nil {
+		return errors.New("one of Addr (standalone) or SentinelConfig (sentinel) must be set")
+	}
+	if cfg.SentinelConfig != nil {
+		if cfg.SentinelConfig.MasterName == "" {
+			return errors.New("SentinelConfig.MasterName is required")
+		}
+		if len(cfg.SentinelConfig.SentinelAddrs) == 0 {
+			return errors.New("SentinelConfig.SentinelAddrs must not be empty")
+		}
+	}
+	if cfg.KeyPrefix == "" {
+		return errors.New("KeyPrefix is required")
+	}
+	return nil
+}
+
+// NewRedisStorage constructs a RedisStorage from a RedisConfig.
+// ttl is the expiry applied to every key on Store.
+func NewRedisStorage(ctx context.Context, cfg RedisConfig, ttl time.Duration) (*RedisStorage, error) {
+	if err := validateRedisConfig(&cfg); err != nil {
+		return nil, fmt.Errorf("invalid redis configuration: %w", err)
+	}
+	if ttl <= 0 {
+		return nil, fmt.Errorf("ttl must be a positive duration")
+	}
+
+	// Apply timeout defaults
+	if cfg.DialTimeout == 0 {
+		cfg.DialTimeout = DefaultDialTimeout
+	}
+	if cfg.ReadTimeout == 0 {
+		cfg.ReadTimeout = DefaultReadTimeout
+	}
+	if cfg.WriteTimeout == 0 {
+		cfg.WriteTimeout = DefaultWriteTimeout
+	}
+
+	tlsCfg, err := buildRedisTLSConfig(cfg.TLS)
+	if err != nil {
+		return nil, fmt.Errorf("tls configuration error: %w", err)
+	}
+
+	var client redis.UniversalClient
+	if cfg.SentinelConfig != nil {
+		opts := &redis.FailoverOptions{
+			MasterName:    cfg.SentinelConfig.MasterName,
+			SentinelAddrs: cfg.SentinelConfig.SentinelAddrs,
+			Password:      cfg.Password,
+			DB:            cfg.DB,
+			DialTimeout:   cfg.DialTimeout,
+			ReadTimeout:   cfg.ReadTimeout,
+			WriteTimeout:  cfg.WriteTimeout,
+			TLSConfig:     tlsCfg,
+		}
+		client = redis.NewFailoverClient(opts)
+	} else {
+		opts := &redis.Options{
+			Addr:         cfg.Addr,
+			Password:     cfg.Password,
+			DB:           cfg.DB,
+			DialTimeout:  cfg.DialTimeout,
+			ReadTimeout:  cfg.ReadTimeout,
+			WriteTimeout: cfg.WriteTimeout,
+			TLSConfig:    tlsCfg,
+		}
+		client = redis.NewClient(opts)
+	}
+
+	if err := client.Ping(ctx).Err(); err != nil {
+		_ = client.Close()
+		return nil, fmt.Errorf("failed to connect to redis: %w", err)
+	}
+
+	return &RedisStorage{
+		client:    client,
+		keyPrefix: cfg.KeyPrefix,
+		ttl:       ttl,
+	}, nil
+}
+
+// newRedisStorageWithClient creates a RedisStorage with a pre-configured client.
+// Intended for tests only (bypasses config validation and Ping); production callers
+// must use NewRedisStorage.
+func newRedisStorageWithClient(client redis.UniversalClient, keyPrefix string, ttl time.Duration) *RedisStorage {
+	return &RedisStorage{
+		client:    client,
+		keyPrefix: keyPrefix,
+		ttl:       ttl,
+	}
+}
+
+// buildRedisTLSConfig creates a *tls.Config from a RedisTLSConfig.
+func buildRedisTLSConfig(cfg *RedisTLSConfig) (*tls.Config, error) {
+	if cfg == nil {
+		return nil, nil
+	}
+	tc := &tls.Config{
+		MinVersion:         tls.VersionTLS12,
+		InsecureSkipVerify: cfg.InsecureSkipVerify, //nolint:gosec // G402: configurable per-deployment
+	}
+	if len(cfg.CACert) > 0 {
+		pool := x509.NewCertPool()
+		if !pool.AppendCertsFromPEM(cfg.CACert) {
+			return nil, fmt.Errorf("failed to parse CA certificate PEM data")
+		}
+		tc.RootCAs = pool
+	}
+	return tc, nil
+}
+
+func (s *RedisStorage) key(id string) string {
+	return s.keyPrefix + id
+}
+
+// Store serializes the session and persists it with SET … EX, refreshing the TTL on every call.
+func (s *RedisStorage) Store(ctx context.Context, session Session) error {
+	if session == nil {
+		return fmt.Errorf("cannot store nil session")
+	}
+	if session.ID() == "" {
+		return fmt.Errorf("cannot store session with empty ID")
+	}
+
+	data, err := serializeSession(session)
+	if err != nil {
+		return fmt.Errorf("failed to serialize session: %w", err)
+	}
+
+	return s.client.Set(ctx, s.key(session.ID()), data, s.ttl).Err()
+}
+
+// Load retrieves a session by ID. Returns ErrSessionNotFound when the key does not exist.
+// The Redis eviction TTL is refreshed atomically via GETEX on every read so that active
+// sessions are not evicted between accesses. The session's UpdatedAt timestamp is not modified.
+func (s *RedisStorage) Load(ctx context.Context, id string) (Session, error) {
+	if id == "" {
+		return nil, fmt.Errorf("cannot load session with empty ID")
+	}
+
+	data, err := s.client.GetEx(ctx, s.key(id), s.ttl).Bytes()
+	if err != nil {
+		if errors.Is(err, redis.Nil) {
+			return nil, ErrSessionNotFound
+		}
+		return nil, fmt.Errorf("failed to load session: %w", err)
+	}
+
+	session, err := deserializeSession(data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to deserialize session: %w", err)
+	}
+
+	return session, nil
+}
+
+// Delete removes the Redis key. A missing key is not an error.
+func (s *RedisStorage) Delete(ctx context.Context, id string) error {
+	if id == "" {
+		return fmt.Errorf("cannot delete session with empty ID")
+	}
+
+	if err := s.client.Del(ctx, s.key(id)).Err(); err != nil {
+		return fmt.Errorf("failed to delete session: %w", err)
+	}
+
+	return nil
+}
+
+// DeleteExpired is a no-op. Redis TTL handles key expiry natively.
+func (*RedisStorage) DeleteExpired(_ context.Context, _ time.Time) error {
+	return nil
+}
+
+// Close closes the underlying Redis client connection.
+func (s *RedisStorage) Close() error {
+	return s.client.Close()
+}

--- a/pkg/transport/session/storage_redis_test.go
+++ b/pkg/transport/session/storage_redis_test.go
@@ -1,0 +1,350 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Tests use the withRedisStorage helper which calls t.Parallel() internally,
+// making all subtests parallel despite not having explicit t.Parallel() calls.
+//
+//nolint:paralleltest // parallel execution handled by withRedisStorage helper
+package session
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Test Helpers ---
+
+func newTestRedisStorage(t *testing.T) (*RedisStorage, *miniredis.Miniredis) {
+	t.Helper()
+	mr := miniredis.RunT(t)
+
+	client := redis.NewClient(&redis.Options{
+		Addr: mr.Addr(),
+	})
+
+	storage := newRedisStorageWithClient(client, "test:session:", 30*time.Minute)
+	return storage, mr
+}
+
+func withRedisStorage(t *testing.T, fn func(context.Context, *RedisStorage, *miniredis.Miniredis)) {
+	t.Helper()
+	t.Parallel()
+	storage, mr := newTestRedisStorage(t)
+	defer func() {
+		_ = storage.Close()
+		mr.Close()
+	}()
+	fn(context.Background(), storage, mr)
+}
+
+// --- Config Validation Tests ---
+
+func TestValidateRedisConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		cfg     RedisConfig
+		wantErr string
+	}{
+		{
+			name:    "both Addr and SentinelConfig set",
+			cfg:     RedisConfig{Addr: "localhost:6379", SentinelConfig: &SentinelConfig{MasterName: "m", SentinelAddrs: []string{"s:26379"}}, KeyPrefix: "p:"},
+			wantErr: "mutually exclusive",
+		},
+		{
+			name:    "neither Addr nor SentinelConfig set",
+			cfg:     RedisConfig{KeyPrefix: "p:"},
+			wantErr: "one of Addr",
+		},
+		{
+			name:    "Sentinel missing MasterName",
+			cfg:     RedisConfig{SentinelConfig: &SentinelConfig{SentinelAddrs: []string{"s:26379"}}, KeyPrefix: "p:"},
+			wantErr: "MasterName",
+		},
+		{
+			name:    "Sentinel missing SentinelAddrs",
+			cfg:     RedisConfig{SentinelConfig: &SentinelConfig{MasterName: "m"}, KeyPrefix: "p:"},
+			wantErr: "SentinelAddrs",
+		},
+		{
+			name:    "empty KeyPrefix",
+			cfg:     RedisConfig{Addr: "localhost:6379"},
+			wantErr: "KeyPrefix",
+		},
+		{
+			name: "valid standalone",
+			cfg:  RedisConfig{Addr: "localhost:6379", KeyPrefix: "thv:vmcp:session:"},
+		},
+		{
+			name: "valid sentinel",
+			cfg:  RedisConfig{SentinelConfig: &SentinelConfig{MasterName: "m", SentinelAddrs: []string{"s:26379"}}, KeyPrefix: "thv:vmcp:session:"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateRedisConfig(&tc.cfg)
+			if tc.wantErr == "" {
+				assert.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestNewRedisStorageTTLValidation(t *testing.T) {
+	t.Parallel()
+	mr := miniredis.RunT(t)
+	defer mr.Close()
+	cfg := RedisConfig{Addr: mr.Addr(), KeyPrefix: "test:"}
+
+	_, err := NewRedisStorage(context.Background(), cfg, 0)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ttl")
+
+	_, err = NewRedisStorage(context.Background(), cfg, -1*time.Second)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ttl")
+}
+
+// --- Unit Tests ---
+
+func TestRedisStorage(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Store and Load round-trip", func(t *testing.T) {
+		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, _ *miniredis.Miniredis) {
+			session := NewProxySession("round-trip-1")
+			session.SetMetadata("key1", "value1")
+
+			require.NoError(t, s.Store(ctx, session))
+
+			loaded, err := s.Load(ctx, "round-trip-1")
+			require.NoError(t, err)
+			assert.Equal(t, session.ID(), loaded.ID())
+			assert.Equal(t, session.Type(), loaded.Type())
+			assert.Equal(t, "value1", loaded.GetMetadata()["key1"])
+		})
+	})
+
+	t.Run("Store with nil session returns error", func(t *testing.T) {
+		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, _ *miniredis.Miniredis) {
+			err := s.Store(ctx, nil)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "nil session")
+		})
+	})
+
+	t.Run("Store with empty session ID returns error", func(t *testing.T) {
+		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, _ *miniredis.Miniredis) {
+			session := &ProxySession{} // empty ID
+			err := s.Store(ctx, session)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "empty ID")
+		})
+	})
+
+	t.Run("Load non-existent key returns ErrSessionNotFound", func(t *testing.T) {
+		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, _ *miniredis.Miniredis) {
+			loaded, err := s.Load(ctx, "does-not-exist")
+			assert.Equal(t, ErrSessionNotFound, err)
+			assert.Nil(t, loaded)
+		})
+	})
+
+	t.Run("Load with empty ID returns error", func(t *testing.T) {
+		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, _ *miniredis.Miniredis) {
+			loaded, err := s.Load(ctx, "")
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "empty ID")
+			assert.Nil(t, loaded)
+		})
+	})
+
+	t.Run("Delete removes key; subsequent Load returns ErrSessionNotFound", func(t *testing.T) {
+		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, _ *miniredis.Miniredis) {
+			session := NewProxySession("delete-me")
+			require.NoError(t, s.Store(ctx, session))
+
+			require.NoError(t, s.Delete(ctx, "delete-me"))
+
+			_, err := s.Load(ctx, "delete-me")
+			assert.Equal(t, ErrSessionNotFound, err)
+		})
+	})
+
+	t.Run("Delete non-existent key returns nil", func(t *testing.T) {
+		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, _ *miniredis.Miniredis) {
+			err := s.Delete(ctx, "non-existent")
+			assert.NoError(t, err)
+		})
+	})
+
+	t.Run("Delete with empty ID returns error", func(t *testing.T) {
+		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, _ *miniredis.Miniredis) {
+			err := s.Delete(ctx, "")
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "empty ID")
+		})
+	})
+
+	t.Run("DeleteExpired is a no-op", func(t *testing.T) {
+		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, _ *miniredis.Miniredis) {
+			session := NewProxySession("no-op-session")
+			require.NoError(t, s.Store(ctx, session))
+
+			err := s.DeleteExpired(ctx, time.Now().Add(1*time.Hour))
+			assert.NoError(t, err)
+
+			// Key should still exist — DeleteExpired is a no-op
+			_, err = s.Load(ctx, "no-op-session")
+			assert.NoError(t, err)
+		})
+	})
+
+	t.Run("TTL is refreshed on Store", func(t *testing.T) {
+		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, mr *miniredis.Miniredis) {
+			session := NewProxySession("ttl-session")
+			require.NoError(t, s.Store(ctx, session))
+
+			// Advance time by almost the full TTL
+			mr.FastForward(29 * time.Minute)
+
+			// Store again to refresh the TTL
+			require.NoError(t, s.Store(ctx, session))
+
+			// Advance past the original expiry
+			mr.FastForward(2 * time.Minute)
+
+			// Key should still be alive because TTL was refreshed
+			_, err := s.Load(ctx, "ttl-session")
+			assert.NoError(t, err)
+		})
+	})
+
+	t.Run("Load refreshes TTL via GETEX", func(t *testing.T) {
+		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, mr *miniredis.Miniredis) {
+			session := NewProxySession("load-refresh-ttl")
+			require.NoError(t, s.Store(ctx, session))
+
+			// Advance time by almost the full TTL
+			mr.FastForward(29 * time.Minute)
+
+			// Load refreshes the TTL (GETEX)
+			_, err := s.Load(ctx, "load-refresh-ttl")
+			require.NoError(t, err)
+
+			// Advance past the original expiry; key should still be alive
+			mr.FastForward(2 * time.Minute)
+
+			_, err = s.Load(ctx, "load-refresh-ttl")
+			assert.NoError(t, err)
+		})
+	})
+
+	t.Run("Key expires after TTL when not refreshed", func(t *testing.T) {
+		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, mr *miniredis.Miniredis) {
+			session := NewProxySession("expiring-session")
+			require.NoError(t, s.Store(ctx, session))
+
+			// Advance past TTL without refreshing
+			mr.FastForward(31 * time.Minute)
+
+			_, err := s.Load(ctx, "expiring-session")
+			assert.Equal(t, ErrSessionNotFound, err)
+		})
+	})
+
+	t.Run("Store is idempotent upsert", func(t *testing.T) {
+		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, _ *miniredis.Miniredis) {
+			session := NewProxySession("upsert-session")
+			session.SetMetadata("v", "1")
+			require.NoError(t, s.Store(ctx, session))
+
+			session.SetMetadata("v", "2")
+			require.NoError(t, s.Store(ctx, session))
+
+			loaded, err := s.Load(ctx, "upsert-session")
+			require.NoError(t, err)
+			assert.Equal(t, "2", loaded.GetMetadata()["v"])
+		})
+	})
+
+	t.Run("Key format is {KeyPrefix}{sessionID}", func(t *testing.T) {
+		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, mr *miniredis.Miniredis) {
+			session := NewProxySession("key-format-test")
+			require.NoError(t, s.Store(ctx, session))
+
+			val, err := mr.Get("test:session:key-format-test")
+			require.NoError(t, err)
+			assert.NotEmpty(t, val)
+		})
+	})
+
+	t.Run("Close closes client; subsequent operations return error", func(t *testing.T) {
+		// Not using withRedisStorage so we control Close timing
+		t.Parallel()
+		storage, mr := newTestRedisStorage(t)
+		defer mr.Close()
+
+		// Store something to confirm it works before close
+		ctx := context.Background()
+		session := NewProxySession("before-close")
+		require.NoError(t, storage.Store(ctx, session))
+
+		require.NoError(t, storage.Close())
+
+		// After close, operations should fail
+		err := storage.Store(ctx, session)
+		assert.Error(t, err)
+	})
+
+	t.Run("SSESession round-trip", func(t *testing.T) {
+		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, _ *miniredis.Miniredis) {
+			session := NewSSESession("sse-rt-1")
+			session.SetMetadata("client", "browser")
+			require.NoError(t, s.Store(ctx, session))
+
+			loaded, err := s.Load(ctx, "sse-rt-1")
+			require.NoError(t, err)
+			assert.Equal(t, SessionTypeSSE, loaded.Type())
+			assert.Equal(t, "browser", loaded.GetMetadata()["client"])
+		})
+	})
+
+	t.Run("StreamableSession round-trip", func(t *testing.T) {
+		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, _ *miniredis.Miniredis) {
+			session := NewStreamableSession("stream-rt-1")
+			session.SetMetadata("protocol", "http")
+			require.NoError(t, s.Store(ctx, session))
+
+			loaded, err := s.Load(ctx, "stream-rt-1")
+			require.NoError(t, err)
+			assert.Equal(t, SessionTypeStreamable, loaded.Type())
+			assert.Equal(t, "http", loaded.GetMetadata()["protocol"])
+		})
+	})
+
+	t.Run("MCPSession round-trip", func(t *testing.T) {
+		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, _ *miniredis.Miniredis) {
+			session := NewTypedProxySession("mcp-rt-1", SessionTypeMCP)
+			session.SetMetadata("env", "prod")
+			require.NoError(t, s.Store(ctx, session))
+
+			loaded, err := s.Load(ctx, "mcp-rt-1")
+			require.NoError(t, err)
+			assert.Equal(t, SessionTypeMCP, loaded.Type())
+			assert.Equal(t, "prod", loaded.GetMetadata()["env"])
+		})
+	})
+}


### PR DESCRIPTION
## Summary

<!--
REQUIRED. You MUST explain:
1. WHY this change is needed (the problem or motivation)
2. WHAT changed (concise bullet points)

The diff shows the code — your summary must provide the context a reviewer
needs to understand the purpose without reading the diff first.
-->

Add RedisStorage as a distributed Storage implementation for the transport/session package, enabling horizontal scaling of the vMCP component by externalising session state to a shared Redis/Sentinel backend.

- Add RedisConfig, SentinelConfig, and RedisTLSConfig structs with configurable timeouts (defaults: dial 5s, read 3s, write 3s)
- Implement RedisStorage with Store (SET+EX TTL refresh), Load (ErrSessionNotFound on miss), Delete (no-op on missing key), DeleteExpired (no-op; Redis TTL handles expiry), and Close
- Support standalone and Sentinel modes; optional TLS with system or custom CA roots
- Add unit tests using miniredis covering all methods, TTL refresh, idempotent upsert, key format, and all three session types
- Remove nolint:unused annotations from serializeSession/deserializeSession now that they are consumed by RedisStorage

<!--
Link related issues. Use "Closes" or "Fixes" to auto-close on merge.
Remove this line if there is no related issue.
-->

Fixes #4205 

## Type of change

<!-- REQUIRED. Check exactly one. -->

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

<!--
REQUIRED. Check every verification step you actually ran.
You MUST check at least one item. If you only did manual testing,
describe exactly what you tested below the checkbox.
-->

- [x] Unit tests (`task test`)
- [x] E2E tests (`task test-e2e`)
- [x] Linting (`task lint-fix`)
- [ ] Manual testing (describe below)

## Changes

<!--
Optional — include for PRs touching more than a few files to help
reviewers navigate the diff. Remove this entire section for small PRs.
-->

| File | Change |
|------|--------|
|      |        |

## Does this introduce a user-facing change?

<!--
If yes, describe the change from the user's perspective. This helps with release notes.
If no, write "No".
Remove this section entirely if not applicable.
-->

## Special notes for reviewers

<!--
Optional — call out anything non-obvious: tricky logic, known limitations,
areas where you'd like extra scrutiny, or follow-up work planned.
Remove this section if not needed.
-->
