### PR TITLE
feat(session): add NewManagerWithRedis constructor (RC-7)

### DIFF
--- a/pkg/transport/proxy/httpsse/http_proxy_test.go
+++ b/pkg/transport/proxy/httpsse/http_proxy_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/jsonrpc2"
@@ -21,7 +22,7 @@ import (
 	"github.com/stacklok/toolhive/pkg/transport/ssecommon"
 )
 
-const testClientID = "test-client"
+const testClientID = "eeeeeeee-0001-0001-0001-000000000001"
 
 // TestNewHTTPSSEProxy tests the creation of a new HTTP SSE proxy
 //
@@ -98,7 +99,7 @@ func TestRemoveClient(t *testing.T) {
 	proxy := NewHTTPSSEProxy("localhost", 8080, false, nil)
 
 	// Create a client session
-	clientID := "test-client-1"
+	clientID := "eeeeeeee-0002-0002-0002-000000000002"
 	clientInfo := &ssecommon.SSEClient{
 		MessageCh: make(chan string, 10),
 		CreatedAt: time.Now(),
@@ -136,15 +137,16 @@ func TestConcurrentClientRemoval(t *testing.T) {
 
 	// Create multiple client sessions
 	numClients := 100
+	clientIDs := make([]string, numClients)
 	for i := 0; i < numClients; i++ {
-		clientID := fmt.Sprintf("client-%d", i)
+		clientIDs[i] = uuid.New().String()
 		clientInfo := &ssecommon.SSEClient{
 			MessageCh: make(chan string, 10),
 			CreatedAt: time.Now(),
 		}
 
 		// Add session to manager
-		sseSession := session.NewSSESessionWithClient(clientID, clientInfo)
+		sseSession := session.NewSSESessionWithClient(clientIDs[i], clientInfo)
 		err := proxy.sessionManager.AddSession(sseSession)
 		require.NoError(t, err)
 	}
@@ -153,7 +155,7 @@ func TestConcurrentClientRemoval(t *testing.T) {
 	var wg sync.WaitGroup
 	for i := 0; i < numClients; i++ {
 		wg.Add(2) // Two goroutines trying to remove the same client
-		clientID := fmt.Sprintf("client-%d", i)
+		clientID := clientIDs[i]
 
 		go func(id string) {
 			defer wg.Done()
@@ -447,7 +449,7 @@ func TestHandlePostRequest(t *testing.T) {
 	proxy := NewHTTPSSEProxy("localhost", 8080, false, nil)
 
 	// Create a client session
-	sessionID := "test-session"
+	sessionID := "eeeeeeee-0003-0003-0003-000000000003"
 	clientInfo := &ssecommon.SSEClient{
 		MessageCh: make(chan string, 10),
 		CreatedAt: time.Now(),
@@ -528,14 +530,13 @@ func TestRWMutexUsage(t *testing.T) {
 
 	// Add multiple client sessions
 	for i := 0; i < 10; i++ {
-		clientID := fmt.Sprintf("client-%d", i)
 		clientInfo := &ssecommon.SSEClient{
 			MessageCh: make(chan string, 10),
 			CreatedAt: time.Now(),
 		}
 
 		// Add session to manager
-		sseSession := session.NewSSESessionWithClient(clientID, clientInfo)
+		sseSession := session.NewSSESessionWithClient(uuid.New().String(), clientInfo)
 		err := proxy.sessionManager.AddSession(sseSession)
 		require.NoError(t, err)
 	}
@@ -569,7 +570,7 @@ func TestClosedClientsCleanup(t *testing.T) {
 
 	// Add many closed client sessions to trigger cleanup
 	for i := 0; i < 1100; i++ {
-		clientID := fmt.Sprintf("client-%d", i)
+		clientID := uuid.New().String()
 		clientInfo := &ssecommon.SSEClient{
 			MessageCh: make(chan string, 1),
 			CreatedAt: time.Now(),

--- a/pkg/transport/proxy/transparent/delete_session_test.go
+++ b/pkg/transport/proxy/transparent/delete_session_test.go
@@ -19,7 +19,7 @@ func TestDeleteSessionCleanup(t *testing.T) {
 	tests := []struct {
 		name             string
 		seedSession      bool   // whether to pre-populate a session in the manager
-		sessionID        string // the session ID to seed and/or reference
+		sessionID        string // the session ID to seed and/or reference (must be a valid UUID)
 		deleteHeader     string // value of Mcp-Session-Id header on the DELETE request ("" = omit header)
 		deleteStatusCode int    // status code the upstream returns for the DELETE
 		expectSession    bool   // whether the session should exist after the DELETE
@@ -27,31 +27,31 @@ func TestDeleteSessionCleanup(t *testing.T) {
 		{
 			name:             "DELETE with 200 removes session",
 			seedSession:      true,
-			sessionID:        "sess-delete-200",
-			deleteHeader:     "sess-delete-200",
+			sessionID:        "cccccccc-0001-0001-0001-000000000001",
+			deleteHeader:     "cccccccc-0001-0001-0001-000000000001",
 			deleteStatusCode: http.StatusOK,
 			expectSession:    false,
 		},
 		{
 			name:             "DELETE with 404 removes session",
 			seedSession:      true,
-			sessionID:        "sess-delete-404",
-			deleteHeader:     "sess-delete-404",
+			sessionID:        "cccccccc-0002-0002-0002-000000000002",
+			deleteHeader:     "cccccccc-0002-0002-0002-000000000002",
 			deleteStatusCode: http.StatusNotFound,
 			expectSession:    false,
 		},
 		{
 			name:             "DELETE with 500 does not remove session",
 			seedSession:      true,
-			sessionID:        "sess-delete-500",
-			deleteHeader:     "sess-delete-500",
+			sessionID:        "cccccccc-0003-0003-0003-000000000003",
+			deleteHeader:     "cccccccc-0003-0003-0003-000000000003",
 			deleteStatusCode: http.StatusInternalServerError,
 			expectSession:    true,
 		},
 		{
 			name:             "DELETE without Mcp-Session-Id header does nothing",
 			seedSession:      true,
-			sessionID:        "sess-no-header",
+			sessionID:        "cccccccc-0004-0004-0004-000000000004",
 			deleteHeader:     "",
 			deleteStatusCode: http.StatusOK,
 			expectSession:    true,
@@ -59,8 +59,8 @@ func TestDeleteSessionCleanup(t *testing.T) {
 		{
 			name:             "DELETE for non-existent session does not error",
 			seedSession:      false,
-			sessionID:        "sess-nonexistent",
-			deleteHeader:     "sess-nonexistent",
+			sessionID:        "cccccccc-0005-0005-0005-000000000005",
+			deleteHeader:     "cccccccc-0005-0005-0005-000000000005",
 			deleteStatusCode: http.StatusOK,
 			expectSession:    false,
 		},

--- a/pkg/transport/proxy/transparent/session_id.go
+++ b/pkg/transport/proxy/transparent/session_id.go
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package transparent
+
+import "github.com/google/uuid"
+
+// mcpSessionNamespace is the UUID v5 namespace used when normalizing non-UUID
+// Mcp-Session-Id values received from upstream MCP servers.
+var mcpSessionNamespace = uuid.MustParse("6ba7b810-9dad-11d1-80b4-00c04fd430c8") // RFC 4122 URL namespace
+
+// normalizeSessionID returns id unchanged if it is already a valid UUID.
+// Otherwise it returns a deterministic UUID v5 derived from id, ensuring that
+// the session manager (which requires UUID-format IDs) can store sessions whose
+// Mcp-Session-Id was issued by an upstream server in a non-UUID format.
+//
+// The mapping is stable: the same external id always produces the same UUID,
+// so the proxy can look up and delete sessions without maintaining a separate
+// reverse-mapping table.
+func normalizeSessionID(id string) string {
+	if _, err := uuid.Parse(id); err == nil {
+		return id
+	}
+	return uuid.NewSHA1(mcpSessionNamespace, []byte(id)).String()
+}

--- a/pkg/transport/proxy/transparent/session_id_test.go
+++ b/pkg/transport/proxy/transparent/session_id_test.go
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package transparent
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNormalizeSessionID(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid UUID passes through unchanged", func(t *testing.T) {
+		t.Parallel()
+		id := "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+		assert.Equal(t, id, normalizeSessionID(id))
+	})
+
+	t.Run("non-UUID is normalized to a valid UUID", func(t *testing.T) {
+		t.Parallel()
+		result := normalizeSessionID("some-opaque-session-token")
+		_, err := uuid.Parse(result)
+		assert.NoError(t, err, "normalized result should be a valid UUID")
+	})
+
+	t.Run("normalization is deterministic", func(t *testing.T) {
+		t.Parallel()
+		const externalID = "some-opaque-session-token"
+		assert.Equal(t, normalizeSessionID(externalID), normalizeSessionID(externalID))
+	})
+
+	t.Run("different inputs produce different UUIDs", func(t *testing.T) {
+		t.Parallel()
+		a := normalizeSessionID("token-a")
+		b := normalizeSessionID("token-b")
+		assert.NotEqual(t, a, b)
+	})
+}

--- a/pkg/transport/proxy/transparent/sse_response_processor.go
+++ b/pkg/transport/proxy/transparent/sse_response_processor.go
@@ -262,7 +262,7 @@ func (s *sseLineProcessor) extractSessionID(line string) {
 			sid = m[2]
 		}
 		s.proxy.setServerInitialized()
-		if err := s.proxy.sessionManager.AddWithID(sid); err != nil {
+		if err := s.proxy.sessionManager.AddWithID(normalizeSessionID(sid)); err != nil {
 			slog.Error("failed to create session from SSE line", "error", err)
 		}
 		s.sessionFound = true

--- a/pkg/transport/proxy/transparent/transparent_proxy.go
+++ b/pkg/transport/proxy/transparent/transparent_proxy.go
@@ -413,7 +413,7 @@ func (t *tracingTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 	if req.Method == http.MethodDelete &&
 		(resp.StatusCode >= 200 && resp.StatusCode < 300 || resp.StatusCode == http.StatusNotFound) {
 		if sid := req.Header.Get("Mcp-Session-Id"); sid != "" {
-			if err := t.p.sessionManager.Delete(sid); err != nil {
+			if err := t.p.sessionManager.Delete(normalizeSessionID(sid)); err != nil {
 				slog.Debug("failed to delete session from transparent proxy",
 					"session_id", sid, "error", err)
 			}
@@ -426,8 +426,9 @@ func (t *tracingTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 		if ct != "" {
 			//nolint:gosec // G706: logging session ID from HTTP response header
 			slog.Debug("detected Mcp-Session-Id header", "session_id", ct)
-			if _, ok := t.p.sessionManager.Get(ct); !ok {
-				if err := t.p.sessionManager.AddWithID(ct); err != nil {
+			internalID := normalizeSessionID(ct)
+			if _, ok := t.p.sessionManager.Get(internalID); !ok {
+				if err := t.p.sessionManager.AddWithID(internalID); err != nil {
 					//nolint:gosec // G706: session ID from HTTP response header
 					slog.Error("failed to create session from header",
 						"session_id", ct, "error", err)

--- a/pkg/transport/proxy/transparent/transparent_test.go
+++ b/pkg/transport/proxy/transparent/transparent_test.go
@@ -65,7 +65,7 @@ func TestStreamingSessionIDDetection(t *testing.T) {
 
 	// side-effect: proxy should have seen session
 	assert.True(t, proxy.serverInitialized(), "server should have been initialized")
-	_, ok := proxy.sessionManager.Get("ABC123")
+	_, ok := proxy.sessionManager.Get(normalizeSessionID("ABC123"))
 	assert.True(t, ok, "sessionManager should have stored ABC123")
 }
 
@@ -130,7 +130,7 @@ func TestHeaderBasedSessionInitialization(t *testing.T) {
 	proxy.ServeHTTP(rec, req)
 
 	assert.True(t, p.serverInitialized(), "server should not be initialized for application/json")
-	_, ok := p.sessionManager.Get("XYZ789")
+	_, ok := p.sessionManager.Get(normalizeSessionID("XYZ789"))
 	assert.True(t, ok, "no session should be added")
 }
 
@@ -869,7 +869,7 @@ func TestSSEEndpointRewriting(t *testing.T) {
 	assert.Contains(t, bodyLines, "event: endpoint")
 
 	// Session should still be tracked
-	_, ok := proxy.sessionManager.Get("ABC123")
+	_, ok := proxy.sessionManager.Get(normalizeSessionID("ABC123"))
 	assert.True(t, ok, "sessionManager should have stored ABC123")
 }
 

--- a/pkg/transport/session/manager.go
+++ b/pkg/transport/session/manager.go
@@ -9,6 +9,8 @@ import (
 	"fmt"
 	"log/slog"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 const (
@@ -114,19 +116,14 @@ func NewManagerWithStorage(ttl time.Duration, factory Factory, storage Storage) 
 }
 
 // NewManagerWithRedis creates a session manager backed by Redis.
+// ctx is used for the initial Ping during construction and should carry any
+// deadline appropriate for the connection attempt (e.g. a startup timeout).
 // cfg supplies the Redis connection configuration; ttl is applied as both the
 // manager's cleanup interval and the Redis key TTL.
 // Returns an error if the Redis client cannot be constructed (e.g. invalid config or TLS error).
-// Callers that do not require Redis should continue to use NewManager or NewTypedManager.
-//
-// cfg is intentionally passed by value (not *RedisConfig): NewManagerWithRedis is a dedicated
-// Redis constructor. Callers that want LocalStorage should use NewManager or NewTypedManager
-// directly; there is no "nil config falls back to local" path by design.
-//
-// context.Background() is passed to NewRedisStorage because the Ping timeout is already bounded
-// by cfg.DialTimeout (default 5 s). A redundant context deadline at this layer would add no value.
-func NewManagerWithRedis(ttl time.Duration, factory Factory, cfg RedisConfig) (*Manager, error) {
-	storage, err := NewRedisStorage(context.Background(), cfg, ttl)
+// Callers that do not require Redis should use NewManager or NewTypedManager instead.
+func NewManagerWithRedis(ctx context.Context, ttl time.Duration, factory Factory, cfg RedisConfig) (*Manager, error) {
+	storage, err := NewRedisStorage(ctx, cfg, ttl)
 	if err != nil {
 		return nil, fmt.Errorf("creating redis storage: %w", err)
 	}
@@ -151,11 +148,23 @@ func (m *Manager) cleanupRoutine() {
 	}
 }
 
-// AddWithID creates (and adds) a new session with the provided ID.
-// Returns error if ID is empty or already exists.
-func (m *Manager) AddWithID(id string) error {
+// validateSessionID returns an error if id is empty or not a valid UUID.
+// UUID format is enforced across all storage backends to keep ID semantics consistent.
+func validateSessionID(id string) error {
 	if id == "" {
 		return fmt.Errorf("session ID cannot be empty")
+	}
+	if _, err := uuid.Parse(id); err != nil {
+		return fmt.Errorf("invalid session ID format: %w", err)
+	}
+	return nil
+}
+
+// AddWithID creates (and adds) a new session with the provided ID.
+// Returns error if ID is empty, not a valid UUID, or already exists.
+func (m *Manager) AddWithID(id string) error {
+	if err := validateSessionID(id); err != nil {
+		return err
 	}
 	// Check if session already exists
 	ctx, cancel := context.WithTimeout(context.Background(), defaultOperationTimeout)
@@ -176,8 +185,8 @@ func (m *Manager) AddSession(session Session) error {
 	if session == nil {
 		return fmt.Errorf("session cannot be nil")
 	}
-	if session.ID() == "" {
-		return fmt.Errorf("session ID cannot be empty")
+	if err := validateSessionID(session.ID()); err != nil {
+		return err
 	}
 
 	// Check if session already exists
@@ -213,8 +222,8 @@ func (m *Manager) UpsertSession(session Session) error {
 	if session == nil {
 		return fmt.Errorf("session cannot be nil")
 	}
-	if session.ID() == "" {
-		return fmt.Errorf("session ID cannot be empty")
+	if err := validateSessionID(session.ID()); err != nil {
+		return err
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), defaultOperationTimeout)
 	defer cancel()
@@ -222,8 +231,11 @@ func (m *Manager) UpsertSession(session Session) error {
 }
 
 // Delete removes a session by ID.
-// Returns an error if the deletion fails.
+// Returns an error if the ID is invalid or the deletion fails.
 func (m *Manager) Delete(id string) error {
+	if err := validateSessionID(id); err != nil {
+		return err
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), defaultOperationTimeout)
 	defer cancel()
 	return m.storage.Delete(ctx, id)

--- a/pkg/transport/session/manager_redis_test.go
+++ b/pkg/transport/session/manager_redis_test.go
@@ -4,6 +4,7 @@
 package session
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -22,7 +23,7 @@ func TestNewManagerWithRedis(t *testing.T) {
 		mr := miniredis.RunT(t)
 		defer mr.Close()
 
-		m, err := NewManagerWithRedis(time.Hour, proxyFactory, RedisConfig{
+		m, err := NewManagerWithRedis(context.Background(), time.Hour, proxyFactory, RedisConfig{
 			Addr:      mr.Addr(),
 			KeyPrefix: "test:mgr:",
 		})
@@ -37,7 +38,7 @@ func TestNewManagerWithRedis(t *testing.T) {
 	t.Run("invalid config returns error", func(t *testing.T) {
 		t.Parallel()
 		// Missing KeyPrefix → validateRedisConfig fails before Ping
-		m, err := NewManagerWithRedis(time.Hour, proxyFactory, RedisConfig{
+		m, err := NewManagerWithRedis(context.Background(), time.Hour, proxyFactory, RedisConfig{
 			Addr: "localhost:6379",
 		})
 		require.Error(t, err)
@@ -46,7 +47,7 @@ func TestNewManagerWithRedis(t *testing.T) {
 
 	t.Run("invalid TLS CA cert returns error", func(t *testing.T) {
 		t.Parallel()
-		m, err := NewManagerWithRedis(time.Hour, proxyFactory, RedisConfig{
+		m, err := NewManagerWithRedis(context.Background(), time.Hour, proxyFactory, RedisConfig{
 			Addr:      "localhost:6379",
 			KeyPrefix: "test:mgr:",
 			TLS:       &RedisTLSConfig{CACert: []byte("not-valid-pem")},
@@ -60,18 +61,19 @@ func TestNewManagerWithRedis(t *testing.T) {
 		mr := miniredis.RunT(t)
 		defer mr.Close()
 
-		m, err := NewManagerWithRedis(time.Hour, proxyFactory, RedisConfig{
+		m, err := NewManagerWithRedis(context.Background(), time.Hour, proxyFactory, RedisConfig{
 			Addr:      mr.Addr(),
 			KeyPrefix: "test:mgr:",
 		})
 		require.NoError(t, err)
 		defer m.Stop()
 
-		require.NoError(t, m.AddWithID("rt-session"))
+		const rtSessionID = "bbbbbbbb-0001-0001-0001-000000000001"
+		require.NoError(t, m.AddWithID(rtSessionID))
 
-		sess, ok := m.Get("rt-session")
+		sess, ok := m.Get(rtSessionID)
 		require.True(t, ok)
-		assert.Equal(t, "rt-session", sess.ID())
+		assert.Equal(t, rtSessionID, sess.ID())
 	})
 
 	t.Run("Stop closes Redis client", func(t *testing.T) {
@@ -79,17 +81,17 @@ func TestNewManagerWithRedis(t *testing.T) {
 		mr := miniredis.RunT(t)
 		defer mr.Close()
 
-		m, err := NewManagerWithRedis(time.Hour, proxyFactory, RedisConfig{
+		m, err := NewManagerWithRedis(context.Background(), time.Hour, proxyFactory, RedisConfig{
 			Addr:      mr.Addr(),
 			KeyPrefix: "test:mgr:",
 		})
 		require.NoError(t, err)
 
-		require.NoError(t, m.AddWithID("pre-stop"))
+		require.NoError(t, m.AddWithID("bbbbbbbb-0002-0001-0001-000000000002"))
 		require.NoError(t, m.Stop())
 
-		// After Stop, storage is closed; further operations should fail
-		err = m.AddWithID("post-stop")
+		// After Stop, storage is closed; further operations should fail with a Redis error.
+		err = m.AddWithID("bbbbbbbb-0003-0001-0001-000000000003")
 		assert.Error(t, err)
 	})
 }

--- a/pkg/transport/session/manager_test.go
+++ b/pkg/transport/session/manager_test.go
@@ -12,6 +12,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	uuidFoo       = "11111111-1111-1111-1111-111111111111"
+	uuidDup       = "22222222-2222-2222-2222-222222222222"
+	uuidDel       = "33333333-3333-3333-3333-333333333333"
+	uuidTouchme   = "44444444-4444-4444-4444-444444444444"
+	uuidOld       = "55555555-5555-5555-5555-555555555555"
+	uuidNew       = "66666666-6666-6666-6666-666666666666"
+	uuidStay      = "77777777-7777-7777-7777-777777777777"
+	uuidBrandNew  = "88888888-8888-8888-8888-888888888888"
+	uuidReplaceMe = "99999999-9999-9999-9999-999999999999"
+)
+
 // stubFactory returns ProxySessions with fixed timestamps and records IDs.
 type stubFactory struct {
 	mu         sync.Mutex
@@ -38,12 +50,47 @@ func TestAddAndGetWithStubSession(t *testing.T) {
 	m := NewManager(time.Hour, factory.New)
 	defer m.Stop()
 
-	require.NoError(t, m.AddWithID("foo"))
+	require.NoError(t, m.AddWithID(uuidFoo))
 
-	sess, ok := m.Get("foo")
+	sess, ok := m.Get(uuidFoo)
 	require.True(t, ok, "session foo should exist")
-	assert.Equal(t, "foo", sess.ID())
-	assert.Contains(t, factory.createdIDs, "foo")
+	assert.Equal(t, uuidFoo, sess.ID())
+	assert.Contains(t, factory.createdIDs, uuidFoo)
+}
+
+func TestInvalidSessionID(t *testing.T) {
+	t.Parallel()
+	factory := &stubFactory{fixedTime: time.Now()}
+	m := NewManager(time.Hour, factory.New)
+	t.Cleanup(func() { m.Stop() })
+
+	t.Run("AddWithID rejects non-UUID", func(t *testing.T) {
+		t.Parallel()
+		err := m.AddWithID("not-a-uuid")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid session ID format")
+	})
+
+	t.Run("AddSession rejects non-UUID", func(t *testing.T) {
+		t.Parallel()
+		err := m.AddSession(&ProxySession{id: "not-a-uuid"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid session ID format")
+	})
+
+	t.Run("UpsertSession rejects non-UUID", func(t *testing.T) {
+		t.Parallel()
+		err := m.UpsertSession(&ProxySession{id: "not-a-uuid"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid session ID format")
+	})
+
+	t.Run("Delete rejects non-UUID", func(t *testing.T) {
+		t.Parallel()
+		err := m.Delete("not-a-uuid")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid session ID format")
+	})
 }
 
 func TestAddDuplicate(t *testing.T) {
@@ -53,9 +100,9 @@ func TestAddDuplicate(t *testing.T) {
 	m := NewManager(time.Hour, factory.New)
 	defer m.Stop()
 
-	require.NoError(t, m.AddWithID("dup"))
+	require.NoError(t, m.AddWithID(uuidDup))
 
-	err := m.AddWithID("dup")
+	err := m.AddWithID(uuidDup)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "already exists")
 }
@@ -67,10 +114,10 @@ func TestDeleteSession(t *testing.T) {
 	m := NewManager(time.Hour, factory.New)
 	defer m.Stop()
 
-	require.NoError(t, m.AddWithID("del"))
-	require.NoError(t, m.Delete("del"))
+	require.NoError(t, m.AddWithID(uuidDel))
+	require.NoError(t, m.Delete(uuidDel))
 
-	_, ok := m.Get("del")
+	_, ok := m.Get(uuidDel)
 	assert.False(t, ok, "deleted session should not be found")
 }
 
@@ -82,13 +129,13 @@ func TestGetUpdatesTimestamp(t *testing.T) {
 	m := NewManager(time.Hour, factory.New)
 	defer m.Stop()
 
-	require.NoError(t, m.AddWithID("touchme"))
-	s1, ok := m.Get("touchme")
+	require.NoError(t, m.AddWithID(uuidTouchme))
+	s1, ok := m.Get(uuidTouchme)
 	require.True(t, ok)
 	t0 := s1.UpdatedAt()
 
 	time.Sleep(10 * time.Millisecond)
-	s2, ok2 := m.Get("touchme")
+	s2, ok2 := m.Get(uuidTouchme)
 	require.True(t, ok2)
 	t1 := s2.UpdatedAt()
 
@@ -105,10 +152,10 @@ func TestCleanupExpired_ManualTrigger(t *testing.T) {
 	m := NewManager(ttl, factory.New)
 	defer m.Stop()
 
-	require.NoError(t, m.AddWithID("old"))
+	require.NoError(t, m.AddWithID(uuidOld))
 
 	// Retrieve and expire session manually
-	sess, ok := m.Get("old")
+	sess, ok := m.Get(uuidOld)
 	require.True(t, ok)
 	ps := sess.(*ProxySession)
 	ps.updated = now.Add(-ttl * 2)
@@ -117,13 +164,13 @@ func TestCleanupExpired_ManualTrigger(t *testing.T) {
 	m.cleanupExpiredOnce()
 
 	// Now it should be gone
-	_, okOld := m.Get("old")
+	_, okOld := m.Get(uuidOld)
 	assert.False(t, okOld, "expired session should have been cleaned")
 
 	// Add fresh session and assert it remains after cleanup
-	require.NoError(t, m.AddWithID("new"))
+	require.NoError(t, m.AddWithID(uuidNew))
 	m.cleanupExpiredOnce()
-	_, okNew := m.Get("new")
+	_, okNew := m.Get(uuidNew)
 	assert.True(t, okNew, "new session should still exist after cleanup")
 }
 
@@ -135,10 +182,10 @@ func TestStopDisablesCleanup(t *testing.T) {
 	m := NewManager(ttl, factory.New)
 	m.Stop() // disable cleanup before any session expires
 
-	require.NoError(t, m.AddWithID("stay"))
+	require.NoError(t, m.AddWithID(uuidStay))
 	time.Sleep(ttl * 2)
 
-	_, ok := m.Get("stay")
+	_, ok := m.Get(uuidStay)
 	assert.True(t, ok, "session should still be present even after Stop() and TTL elapsed")
 }
 
@@ -176,13 +223,13 @@ func TestUpsertSession_UpsertNewSession(t *testing.T) {
 	defer m.Stop()
 
 	// UpsertSession on an ID that does not exist yet should store it.
-	newSess := NewStreamableSession("brand-new-id")
+	newSess := NewStreamableSession(uuidBrandNew)
 	err := m.UpsertSession(newSess)
 	require.NoError(t, err)
 
-	got, ok := m.Get("brand-new-id")
+	got, ok := m.Get(uuidBrandNew)
 	require.True(t, ok, "session should exist after UpsertSession upsert")
-	assert.Equal(t, "brand-new-id", got.ID())
+	assert.Equal(t, uuidBrandNew, got.ID())
 }
 
 func TestUpsertSession_ReplacesExistingSession(t *testing.T) {
@@ -192,7 +239,7 @@ func TestUpsertSession_ReplacesExistingSession(t *testing.T) {
 	m := NewManager(time.Hour, factory.New)
 	defer m.Stop()
 
-	const sessionID = "replace-me"
+	const sessionID = uuidReplaceMe
 
 	// Phase 1: store a placeholder via AddWithID (creates a ProxySession via factory).
 	require.NoError(t, m.AddWithID(sessionID))

--- a/pkg/transport/session/redis_config.go
+++ b/pkg/transport/session/redis_config.go
@@ -21,8 +21,14 @@ type RedisConfig struct {
 	// SentinelConfig, when non-nil, activates Sentinel mode. Mutually exclusive with Addr.
 	SentinelConfig *SentinelConfig
 
-	// Password is the Redis AUTH password.
-	Password string
+	// Username is the Redis ACL username (Redis 6.0+). When non-empty, both
+	// Username and Password are sent as ACL credentials (AUTH username password).
+	// Leave empty to authenticate as the default user (legacy AUTH password).
+	Username string
+
+	// Password is the Redis AUTH password. Used with Username for ACL auth,
+	// or alone for legacy AUTH with the default user.
+	Password string //nolint:gosec // G101: not a hardcoded credential
 
 	// DB is the Redis database index.
 	DB int

--- a/pkg/transport/session/storage_redis.go
+++ b/pkg/transport/session/storage_redis.go
@@ -39,11 +39,16 @@ func validateRedisConfig(cfg *RedisConfig) error {
 	if cfg.KeyPrefix == "" {
 		return errors.New("KeyPrefix is required")
 	}
+	if cfg.KeyPrefix[len(cfg.KeyPrefix)-1] != ':' {
+		return errors.New("KeyPrefix must end with ':' to avoid key collisions (e.g. \"thv:vmcp:session:\")")
+	}
 	return nil
 }
 
 // NewRedisStorage constructs a RedisStorage from a RedisConfig.
-// ttl is the expiry applied to every key on Store.
+// ttl is the expiry applied to every key on Store and refreshed on every Load (sliding window).
+// Because TTL is sliding, sessions remain valid indefinitely while actively used; revocation
+// requires an explicit Delete call. There is no absolute maximum session lifetime.
 func NewRedisStorage(ctx context.Context, cfg RedisConfig, ttl time.Duration) (*RedisStorage, error) {
 	if err := validateRedisConfig(&cfg); err != nil {
 		return nil, fmt.Errorf("invalid redis configuration: %w", err)
@@ -73,6 +78,7 @@ func NewRedisStorage(ctx context.Context, cfg RedisConfig, ttl time.Duration) (*
 		opts := &redis.FailoverOptions{
 			MasterName:    cfg.SentinelConfig.MasterName,
 			SentinelAddrs: cfg.SentinelConfig.SentinelAddrs,
+			Username:      cfg.Username,
 			Password:      cfg.Password,
 			DB:            cfg.DB,
 			DialTimeout:   cfg.DialTimeout,
@@ -84,6 +90,7 @@ func NewRedisStorage(ctx context.Context, cfg RedisConfig, ttl time.Duration) (*
 	} else {
 		opts := &redis.Options{
 			Addr:         cfg.Addr,
+			Username:     cfg.Username,
 			Password:     cfg.Password,
 			DB:           cfg.DB,
 			DialTimeout:  cfg.DialTimeout,
@@ -160,6 +167,13 @@ func (s *RedisStorage) Store(ctx context.Context, session Session) error {
 // Load retrieves a session by ID. Returns ErrSessionNotFound when the key does not exist.
 // The Redis eviction TTL is refreshed atomically via GETEX on every read so that active
 // sessions are not evicted between accesses. The session's UpdatedAt timestamp is not modified.
+//
+// Lifetime note: this implements a sliding-window TTL. A session accessed at least once per
+// TTL window will never expire and can live indefinitely while the client keeps making requests.
+// Session revocation therefore depends entirely on explicit Delete calls (e.g. on logout or
+// token invalidation); there is no absolute maximum session lifetime enforced here. If a hard
+// cap is required in future, a MaxLifetime field checked against the session's CreatedAt would
+// be the path forward.
 func (s *RedisStorage) Load(ctx context.Context, id string) (Session, error) {
 	if id == "" {
 		return nil, fmt.Errorf("cannot load session with empty ID")

--- a/pkg/transport/session/storage_redis_test.go
+++ b/pkg/transport/session/storage_redis_test.go
@@ -79,6 +79,11 @@ func TestValidateRedisConfig(t *testing.T) {
 			wantErr: "KeyPrefix",
 		},
 		{
+			name:    "KeyPrefix without trailing colon",
+			cfg:     RedisConfig{Addr: "localhost:6379", KeyPrefix: "thvsession"},
+			wantErr: "must end with ':'",
+		},
+		{
 			name: "valid standalone",
 			cfg:  RedisConfig{Addr: "localhost:6379", KeyPrefix: "thv:vmcp:session:"},
 		},
@@ -102,6 +107,49 @@ func TestValidateRedisConfig(t *testing.T) {
 	}
 }
 
+func TestNewRedisStorageACLAuth(t *testing.T) {
+	t.Parallel()
+
+	t.Run("connects with valid ACL username and password", func(t *testing.T) {
+		t.Parallel()
+		mr := miniredis.RunT(t)
+		defer mr.Close()
+		mr.RequireUserAuth("alice", "secret")
+
+		storage, err := NewRedisStorage(context.Background(), RedisConfig{
+			Addr:      mr.Addr(),
+			KeyPrefix: "test:acl:",
+			Username:  "alice",
+			Password:  "secret",
+		}, time.Minute)
+		require.NoError(t, err)
+		defer storage.Close()
+
+		// Verify a round-trip works under ACL auth.
+		sess := NewProxySession("cccccccc-0001-0001-0001-000000000001")
+		require.NoError(t, storage.Store(context.Background(), sess))
+		loaded, err := storage.Load(context.Background(), sess.ID())
+		require.NoError(t, err)
+		assert.Equal(t, sess.ID(), loaded.ID())
+	})
+
+	t.Run("fails to connect with wrong password", func(t *testing.T) {
+		t.Parallel()
+		mr := miniredis.RunT(t)
+		defer mr.Close()
+		mr.RequireUserAuth("alice", "secret")
+
+		_, err := NewRedisStorage(context.Background(), RedisConfig{
+			Addr:      mr.Addr(),
+			KeyPrefix: "test:acl:",
+			Username:  "alice",
+			Password:  "wrong",
+		}, time.Minute)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to connect to redis")
+	})
+}
+
 func TestNewRedisStorageTTLValidation(t *testing.T) {
 	t.Parallel()
 	mr := miniredis.RunT(t)
@@ -117,6 +165,25 @@ func TestNewRedisStorageTTLValidation(t *testing.T) {
 	assert.Contains(t, err.Error(), "ttl")
 }
 
+// redisTestIDs holds fixed UUIDs for use across Redis storage tests.
+// Each test uses a distinct UUID to prevent cross-test key collisions.
+const (
+	rtID           = "aaaaaaaa-0001-0001-0001-000000000001"
+	deleteID       = "aaaaaaaa-0002-0001-0001-000000000002"
+	notFoundID     = "aaaaaaaa-0003-0001-0001-000000000003"
+	noOpID         = "aaaaaaaa-0004-0001-0001-000000000004"
+	ttlID          = "aaaaaaaa-0005-0001-0001-000000000005"
+	loadRefreshID  = "aaaaaaaa-0006-0001-0001-000000000006"
+	expiringID     = "aaaaaaaa-0007-0001-0001-000000000007"
+	upsertID       = "aaaaaaaa-0008-0001-0001-000000000008"
+	keyFormatID    = "aaaaaaaa-0009-0001-0001-000000000009"
+	beforeCloseID  = "aaaaaaaa-000a-0001-0001-00000000000a"
+	sseRtID        = "aaaaaaaa-000b-0001-0001-00000000000b"
+	streamRtID     = "aaaaaaaa-000c-0001-0001-00000000000c"
+	mcpRtID        = "aaaaaaaa-000d-0001-0001-00000000000d"
+	deleteNonExist = "aaaaaaaa-000e-0001-0001-00000000000e"
+)
+
 // --- Unit Tests ---
 
 func TestRedisStorage(t *testing.T) {
@@ -124,12 +191,12 @@ func TestRedisStorage(t *testing.T) {
 
 	t.Run("Store and Load round-trip", func(t *testing.T) {
 		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, _ *miniredis.Miniredis) {
-			session := NewProxySession("round-trip-1")
+			session := NewProxySession(rtID)
 			session.SetMetadata("key1", "value1")
 
 			require.NoError(t, s.Store(ctx, session))
 
-			loaded, err := s.Load(ctx, "round-trip-1")
+			loaded, err := s.Load(ctx, rtID)
 			require.NoError(t, err)
 			assert.Equal(t, session.ID(), loaded.ID())
 			assert.Equal(t, session.Type(), loaded.Type())
@@ -156,7 +223,7 @@ func TestRedisStorage(t *testing.T) {
 
 	t.Run("Load non-existent key returns ErrSessionNotFound", func(t *testing.T) {
 		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, _ *miniredis.Miniredis) {
-			loaded, err := s.Load(ctx, "does-not-exist")
+			loaded, err := s.Load(ctx, notFoundID)
 			assert.Equal(t, ErrSessionNotFound, err)
 			assert.Nil(t, loaded)
 		})
@@ -173,19 +240,19 @@ func TestRedisStorage(t *testing.T) {
 
 	t.Run("Delete removes key; subsequent Load returns ErrSessionNotFound", func(t *testing.T) {
 		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, _ *miniredis.Miniredis) {
-			session := NewProxySession("delete-me")
+			session := NewProxySession(deleteID)
 			require.NoError(t, s.Store(ctx, session))
 
-			require.NoError(t, s.Delete(ctx, "delete-me"))
+			require.NoError(t, s.Delete(ctx, deleteID))
 
-			_, err := s.Load(ctx, "delete-me")
+			_, err := s.Load(ctx, deleteID)
 			assert.Equal(t, ErrSessionNotFound, err)
 		})
 	})
 
 	t.Run("Delete non-existent key returns nil", func(t *testing.T) {
 		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, _ *miniredis.Miniredis) {
-			err := s.Delete(ctx, "non-existent")
+			err := s.Delete(ctx, deleteNonExist)
 			assert.NoError(t, err)
 		})
 	})
@@ -200,21 +267,21 @@ func TestRedisStorage(t *testing.T) {
 
 	t.Run("DeleteExpired is a no-op", func(t *testing.T) {
 		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, _ *miniredis.Miniredis) {
-			session := NewProxySession("no-op-session")
+			session := NewProxySession(noOpID)
 			require.NoError(t, s.Store(ctx, session))
 
 			err := s.DeleteExpired(ctx, time.Now().Add(1*time.Hour))
 			assert.NoError(t, err)
 
 			// Key should still exist — DeleteExpired is a no-op
-			_, err = s.Load(ctx, "no-op-session")
+			_, err = s.Load(ctx, noOpID)
 			assert.NoError(t, err)
 		})
 	})
 
 	t.Run("TTL is refreshed on Store", func(t *testing.T) {
 		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, mr *miniredis.Miniredis) {
-			session := NewProxySession("ttl-session")
+			session := NewProxySession(ttlID)
 			require.NoError(t, s.Store(ctx, session))
 
 			// Advance time by almost the full TTL
@@ -227,54 +294,54 @@ func TestRedisStorage(t *testing.T) {
 			mr.FastForward(2 * time.Minute)
 
 			// Key should still be alive because TTL was refreshed
-			_, err := s.Load(ctx, "ttl-session")
+			_, err := s.Load(ctx, ttlID)
 			assert.NoError(t, err)
 		})
 	})
 
 	t.Run("Load refreshes TTL via GETEX", func(t *testing.T) {
 		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, mr *miniredis.Miniredis) {
-			session := NewProxySession("load-refresh-ttl")
+			session := NewProxySession(loadRefreshID)
 			require.NoError(t, s.Store(ctx, session))
 
 			// Advance time by almost the full TTL
 			mr.FastForward(29 * time.Minute)
 
 			// Load refreshes the TTL (GETEX)
-			_, err := s.Load(ctx, "load-refresh-ttl")
+			_, err := s.Load(ctx, loadRefreshID)
 			require.NoError(t, err)
 
 			// Advance past the original expiry; key should still be alive
 			mr.FastForward(2 * time.Minute)
 
-			_, err = s.Load(ctx, "load-refresh-ttl")
+			_, err = s.Load(ctx, loadRefreshID)
 			assert.NoError(t, err)
 		})
 	})
 
 	t.Run("Key expires after TTL when not refreshed", func(t *testing.T) {
 		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, mr *miniredis.Miniredis) {
-			session := NewProxySession("expiring-session")
+			session := NewProxySession(expiringID)
 			require.NoError(t, s.Store(ctx, session))
 
 			// Advance past TTL without refreshing
 			mr.FastForward(31 * time.Minute)
 
-			_, err := s.Load(ctx, "expiring-session")
+			_, err := s.Load(ctx, expiringID)
 			assert.Equal(t, ErrSessionNotFound, err)
 		})
 	})
 
 	t.Run("Store is idempotent upsert", func(t *testing.T) {
 		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, _ *miniredis.Miniredis) {
-			session := NewProxySession("upsert-session")
+			session := NewProxySession(upsertID)
 			session.SetMetadata("v", "1")
 			require.NoError(t, s.Store(ctx, session))
 
 			session.SetMetadata("v", "2")
 			require.NoError(t, s.Store(ctx, session))
 
-			loaded, err := s.Load(ctx, "upsert-session")
+			loaded, err := s.Load(ctx, upsertID)
 			require.NoError(t, err)
 			assert.Equal(t, "2", loaded.GetMetadata()["v"])
 		})
@@ -282,10 +349,10 @@ func TestRedisStorage(t *testing.T) {
 
 	t.Run("Key format is {KeyPrefix}{sessionID}", func(t *testing.T) {
 		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, mr *miniredis.Miniredis) {
-			session := NewProxySession("key-format-test")
+			session := NewProxySession(keyFormatID)
 			require.NoError(t, s.Store(ctx, session))
 
-			val, err := mr.Get("test:session:key-format-test")
+			val, err := mr.Get("test:session:" + keyFormatID)
 			require.NoError(t, err)
 			assert.NotEmpty(t, val)
 		})
@@ -299,7 +366,7 @@ func TestRedisStorage(t *testing.T) {
 
 		// Store something to confirm it works before close
 		ctx := context.Background()
-		session := NewProxySession("before-close")
+		session := NewProxySession(beforeCloseID)
 		require.NoError(t, storage.Store(ctx, session))
 
 		require.NoError(t, storage.Close())
@@ -311,11 +378,11 @@ func TestRedisStorage(t *testing.T) {
 
 	t.Run("SSESession round-trip", func(t *testing.T) {
 		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, _ *miniredis.Miniredis) {
-			session := NewSSESession("sse-rt-1")
+			session := NewSSESession(sseRtID)
 			session.SetMetadata("client", "browser")
 			require.NoError(t, s.Store(ctx, session))
 
-			loaded, err := s.Load(ctx, "sse-rt-1")
+			loaded, err := s.Load(ctx, sseRtID)
 			require.NoError(t, err)
 			assert.Equal(t, SessionTypeSSE, loaded.Type())
 			assert.Equal(t, "browser", loaded.GetMetadata()["client"])
@@ -324,11 +391,11 @@ func TestRedisStorage(t *testing.T) {
 
 	t.Run("StreamableSession round-trip", func(t *testing.T) {
 		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, _ *miniredis.Miniredis) {
-			session := NewStreamableSession("stream-rt-1")
+			session := NewStreamableSession(streamRtID)
 			session.SetMetadata("protocol", "http")
 			require.NoError(t, s.Store(ctx, session))
 
-			loaded, err := s.Load(ctx, "stream-rt-1")
+			loaded, err := s.Load(ctx, streamRtID)
 			require.NoError(t, err)
 			assert.Equal(t, SessionTypeStreamable, loaded.Type())
 			assert.Equal(t, "http", loaded.GetMetadata()["protocol"])
@@ -337,11 +404,11 @@ func TestRedisStorage(t *testing.T) {
 
 	t.Run("MCPSession round-trip", func(t *testing.T) {
 		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, _ *miniredis.Miniredis) {
-			session := NewTypedProxySession("mcp-rt-1", SessionTypeMCP)
+			session := NewTypedProxySession(mcpRtID, SessionTypeMCP)
 			session.SetMetadata("env", "prod")
 			require.NoError(t, s.Store(ctx, session))
 
-			loaded, err := s.Load(ctx, "mcp-rt-1")
+			loaded, err := s.Load(ctx, mcpRtID)
 			require.NoError(t, err)
 			assert.Equal(t, SessionTypeMCP, loaded.Type())
 			assert.Equal(t, "prod", loaded.GetMetadata()["env"])

--- a/pkg/transport/session/storage_test.go
+++ b/pkg/transport/session/storage_test.go
@@ -619,21 +619,23 @@ func TestManagerWithStorage(t *testing.T) {
 		manager := NewManagerWithStorage(30*time.Minute, factory, storage)
 		defer manager.Stop()
 
+		const localMgrID = "aaaaaaaa-1001-1001-1001-000000000001"
+
 		// Add a session
-		err := manager.AddWithID("test-session-1")
+		err := manager.AddWithID(localMgrID)
 		require.NoError(t, err)
 
 		// Get the session
-		session, found := manager.Get("test-session-1")
+		session, found := manager.Get(localMgrID)
 		assert.True(t, found)
 		assert.NotNil(t, session)
-		assert.Equal(t, "test-session-1", session.ID())
+		assert.Equal(t, localMgrID, session.ID())
 
 		// Delete the session
-		manager.Delete("test-session-1")
+		manager.Delete(localMgrID)
 
 		// Should not be found
-		session, found = manager.Get("test-session-1")
+		session, found = manager.Get(localMgrID)
 		assert.False(t, found)
 		assert.Nil(t, session)
 	})
@@ -649,12 +651,14 @@ func TestManagerWithStorage(t *testing.T) {
 		manager := NewManagerWithStorage(30*time.Minute, factory, storage)
 		defer manager.Stop()
 
+		const sseMgrID = "aaaaaaaa-1002-1002-1002-000000000002"
+
 		// Add a session
-		err := manager.AddWithID("sse-session-1")
+		err := manager.AddWithID(sseMgrID)
 		require.NoError(t, err)
 
 		// Get the session
-		session, found := manager.Get("sse-session-1")
+		session, found := manager.Get(sseMgrID)
 		assert.True(t, found)
 		assert.NotNil(t, session)
 		assert.Equal(t, SessionTypeSSE, session.Type())
@@ -670,8 +674,10 @@ func TestManagerWithStorage(t *testing.T) {
 		manager := NewManagerWithStorage(30*time.Minute, factory, storage)
 		defer manager.Stop()
 
+		const customMgrID = "aaaaaaaa-1003-1003-1003-000000000003"
+
 		// Create a custom session
-		customSession := NewTypedProxySession("custom-1", SessionTypeStreamable)
+		customSession := NewTypedProxySession(customMgrID, SessionTypeStreamable)
 		customSession.SetMetadata("custom", "metadata")
 
 		// Add the custom session
@@ -679,7 +685,7 @@ func TestManagerWithStorage(t *testing.T) {
 		require.NoError(t, err)
 
 		// Get the session
-		session, found := manager.Get("custom-1")
+		session, found := manager.Get(customMgrID)
 		assert.True(t, found)
 		assert.NotNil(t, session)
 		assert.Equal(t, SessionTypeStreamable, session.Type())
@@ -701,9 +707,15 @@ func TestManagerWithStorage(t *testing.T) {
 		// Initially empty
 		assert.Equal(t, 0, manager.Count())
 
+		countIDs := []string{
+			"aaaaaaaa-1004-1004-1004-000000000001",
+			"aaaaaaaa-1004-1004-1004-000000000002",
+			"aaaaaaaa-1004-1004-1004-000000000003",
+		}
+
 		// Add sessions
-		for i := 0; i < 3; i++ {
-			err := manager.AddWithID(fmt.Sprintf("session-%d", i))
+		for _, id := range countIDs {
+			err := manager.AddWithID(id)
 			require.NoError(t, err)
 		}
 
@@ -722,7 +734,11 @@ func TestManagerWithStorage(t *testing.T) {
 		defer manager.Stop()
 
 		// Add sessions
-		ids := []string{"one", "two", "three"}
+		ids := []string{
+			"aaaaaaaa-1005-1005-1005-000000000001",
+			"aaaaaaaa-1005-1005-1005-000000000002",
+			"aaaaaaaa-1005-1005-1005-000000000003",
+		}
 		for _, id := range ids {
 			err := manager.AddWithID(id)
 			require.NoError(t, err)

--- a/pkg/vmcp/discovery/middleware_test.go
+++ b/pkg/vmcp/discovery/middleware_test.go
@@ -198,7 +198,7 @@ func TestMiddleware_SubsequentRequest_SkipsDiscovery(t *testing.T) {
 
 	// Add a MockMultiSession with the routing table
 	mockSess := sessionmocks.NewMockMultiSession(ctrl)
-	mockSess.EXPECT().ID().Return("test-session-123").AnyTimes()
+	mockSess.EXPECT().ID().Return("dddddddd-1001-1001-1001-000000000001").AnyTimes()
 	mockSess.EXPECT().GetRoutingTable().Return(routingTable).AnyTimes()
 	mockSess.EXPECT().Tools().Return(nil).AnyTimes()
 	mockSess.EXPECT().Touch().AnyTimes()
@@ -219,7 +219,7 @@ func TestMiddleware_SubsequentRequest_SkipsDiscovery(t *testing.T) {
 
 	// Create subsequent request (with session ID header)
 	req := httptest.NewRequest(http.MethodPost, "/mcp/v1/tools/list", nil)
-	req.Header.Set("Mcp-Session-Id", "test-session-123")
+	req.Header.Set("Mcp-Session-Id", "dddddddd-1001-1001-1001-000000000001")
 	rec := httptest.NewRecorder()
 
 	// Execute request


### PR DESCRIPTION
## Summary

Wires the Redis storage backend into the session manager lifecycle (RC-7), and establishes UUID as the canonical session ID format across all storage backends and proxy transports.

**NewManagerWithRedis constructor (RC-7)**
- `NewManagerWithRedis(ctx, ttl, factory, cfg)` accepts a `RedisConfig` and constructs a Redis-backed `*Manager` via `NewRedisStorage` + `NewManagerWithStorage`
- `ctx` is used for the initial Ping during construction (improvement over the original issue spec, which did not thread context through)
- Existing `NewManager`, `NewTypedManager`, and `NewManagerWithStorage` signatures are unchanged

**UUID enforcement (breaking API change — see compatibility notes below)**
- `Manager` now validates that all session IDs are UUID-format on `AddWithID`, `AddSession`, `UpsertSession`, and `Delete`
- `validateSessionID` is an unexported helper that enforces this consistently across all storage backends (previously `RedisStorage` alone had per-operation UUID checks, creating a store-then-can't-load inconsistency)
- `RedisStorage` no longer does its own UUID checks; validation lives exclusively in `Manager`

**Non-UUID Mcp-Session-Id normalization in transparent proxy**
- The MCP spec does not mandate UUID format for `Mcp-Session-Id`; upstream servers may issue arbitrary strings
- `normalizeSessionID` (new, in `pkg/transport/proxy/transparent`) maps any non-UUID external session ID to a deterministic UUID v5 (RFC 4122 URL namespace), so the transparent proxy can store upstream-issued IDs in the UUID-only session manager without a reverse-mapping table
- Applied at all three callsites where the transparent proxy reads `Mcp-Session-Id` from upstream responses or SSE stream data

Fixes #4208

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [x] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [x] Linting (`task lint-fix`)
- [ ] Manual testing (describe below)

## Changes

| File | Change |
|------|--------|
| `pkg/transport/session/manager.go` | Add `NewManagerWithRedis`, `validateSessionID`; wire UUID validation into all manager methods |
| `pkg/transport/session/storage_redis.go` | Remove per-operation UUID checks (moved to Manager); add `Username` ACL field wiring; add `KeyPrefix` trailing-colon validation; sliding-window TTL godoc |
| `pkg/transport/session/redis_config.go` | Add `Username` field for Redis 6+ ACL auth |
| `pkg/transport/proxy/transparent/session_id.go` | New: `normalizeSessionID` — UUID pass-through or deterministic UUID v5 derivation |
| `pkg/transport/proxy/transparent/transparent_proxy.go` | Apply `normalizeSessionID` at all `Mcp-Session-Id` callsites |
| `pkg/transport/proxy/transparent/sse_response_processor.go` | Apply `normalizeSessionID` before `AddWithID` |
| Tests | Updated throughout to use UUID-format session IDs; new tests for Redis round-trips, ACL auth, UUID validation, and `normalizeSessionID` |

## Does this introduce a user-facing change?

No direct user-facing change. Internal plumbing for Redis-backed horizontal scaling (THV-0047). The Redis constructor is not yet wired into the vMCP server (deferred to RC-8).

## Special notes for reviewers

**Compatibility**: `Manager.AddWithID`, `AddSession`, `UpsertSession`, and `Delete` now reject non-UUID IDs with `"invalid session ID format"`. All existing toolhive call sites generate UUIDs internally, so there is no runtime regression. The transparent proxy is the only place that ingests externally-sourced session IDs; `normalizeSessionID` handles that path.

**Sliding-window TTL**: `RedisStorage` uses `GETEX` on every `Load` to refresh the TTL, meaning sessions remain alive indefinitely while actively used. Revocation requires an explicit `Delete`. No absolute max lifetime is enforced; a `MaxLifetime`/`CreatedAt` check is the noted path forward if a hard cap is needed.