### PR TITLE
Preserve tool annotations and output schema in GetAdaptedTools

### DIFF
--- a/pkg/vmcp/server/sessionmanager/session_manager.go
+++ b/pkg/vmcp/server/sessionmanager/session_manager.go
@@ -387,6 +387,16 @@ func (sm *Manager) GetAdaptedTools(sessionID string) ([]mcpserver.ServerTool, er
 			Name:           domainTool.Name,
 			Description:    domainTool.Description,
 			RawInputSchema: schemaJSON,
+			Annotations:    conversion.ToMCPToolAnnotations(domainTool.Annotations),
+		}
+		if domainTool.OutputSchema != nil {
+			outputSchemaJSON, marshalErr := json.Marshal(domainTool.OutputSchema)
+			if marshalErr != nil {
+				slog.Warn("failed to marshal tool output schema",
+					"tool", domainTool.Name, "error", marshalErr)
+			} else {
+				tool.RawOutputSchema = outputSchemaJSON
+			}
 		}
 
 		capturedSess := multiSess

--- a/pkg/vmcp/server/sessionmanager/session_manager_test.go
+++ b/pkg/vmcp/server/sessionmanager/session_manager_test.go
@@ -861,6 +861,78 @@ func TestSessionManager_GetAdaptedTools(t *testing.T) {
 		assert.Contains(t, string(byName["alpha"].RawInputSchema), `"type"`)
 	})
 
+	t.Run("preserves annotations and output schema", func(t *testing.T) {
+		t.Parallel()
+
+		boolPtr := func(b bool) *bool { return &b }
+		tools := []vmcp.Tool{
+			{
+				Name:        "annotated",
+				Description: "tool with annotations",
+				InputSchema: map[string]any{"type": "object"},
+				OutputSchema: map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"result": map[string]any{"type": "string"},
+					},
+				},
+				Annotations: &vmcp.ToolAnnotations{
+					Title:           "Annotated Tool",
+					ReadOnlyHint:    boolPtr(true),
+					DestructiveHint: boolPtr(false),
+				},
+			},
+			{
+				Name:        "plain",
+				Description: "tool without annotations or output schema",
+				InputSchema: map[string]any{"type": "object"},
+			},
+		}
+		ctrl := gomock.NewController(t)
+		factory := sessionfactorymocks.NewMockMultiSessionFactory(ctrl)
+		factory.EXPECT().
+			MakeSessionWithID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, id string, _ *auth.Identity, _ bool, _ []*vmcp.Backend) (vmcpsession.MultiSession, error) {
+				return newMockSession(t, ctrl, id, tools), nil
+			}).Times(1)
+
+		registry := newFakeRegistry()
+		sm, _ := newTestSessionManager(t, factory, registry)
+
+		sessionID := sm.Generate()
+		_, err := sm.CreateSession(context.Background(), sessionID)
+		require.NoError(t, err)
+
+		adaptedTools, err := sm.GetAdaptedTools(sessionID)
+		require.NoError(t, err)
+		require.Len(t, adaptedTools, 2)
+
+		byName := map[string]mcp.Tool{}
+		for _, st := range adaptedTools {
+			byName[st.Tool.Name] = st.Tool
+		}
+
+		// Verify annotations are preserved on the annotated tool.
+		annotated := byName["annotated"]
+		assert.Equal(t, "Annotated Tool", annotated.Annotations.Title)
+		require.NotNil(t, annotated.Annotations.ReadOnlyHint)
+		assert.True(t, *annotated.Annotations.ReadOnlyHint)
+		require.NotNil(t, annotated.Annotations.DestructiveHint)
+		assert.False(t, *annotated.Annotations.DestructiveHint)
+		assert.Nil(t, annotated.Annotations.IdempotentHint)
+		assert.Nil(t, annotated.Annotations.OpenWorldHint)
+
+		// Verify output schema is preserved.
+		assert.NotNil(t, annotated.RawOutputSchema)
+		assert.Contains(t, string(annotated.RawOutputSchema), `"result"`)
+
+		// Verify nil annotations produce zero-valued annotations and nil output schema.
+		plain := byName["plain"]
+		assert.Empty(t, plain.Annotations.Title)
+		assert.Nil(t, plain.Annotations.ReadOnlyHint)
+		assert.Nil(t, plain.RawOutputSchema)
+	})
+
 	t.Run("handlers delegate to session CallTool", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
## Summary

- Cedar authorization policies relying on tool annotations (e.g. `readOnlyHint`, `destructiveHint`) were failing because `SessionManager.GetAdaptedTools` constructed `mcp.Tool` structs without copying `Annotations` or `OutputSchema` from the domain tool — every tool appeared annotation-less, so policies denied all requests.
- Added the missing `Annotations` field (via `conversion.ToMCPToolAnnotations`) and `RawOutputSchema` marshalling to match what `capability_adapter.go` already does.
- Added a test case covering both annotated and plain tools to prevent regression.

Fixes #4235

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)

## Changes

| File | Change |
|------|--------|
| `pkg/vmcp/server/sessionmanager/session_manager.go` | Copy `Annotations` and `OutputSchema` when building `mcp.Tool` in `GetAdaptedTools` |
| `pkg/vmcp/server/sessionmanager/session_manager_test.go` | Add "preserves annotations and output schema" test case |

## Does this introduce a user-facing change?

Tools exposed through vMCP sessions now correctly carry their annotations and output schema, restoring Cedar policy evaluation and ensuring MCP clients see the full tool metadata.

Generated with [Claude Code](https://claude.com/claude-code)