### PR TITLE
Add BackendReplicas and SessionCacheSize to RunConfig

### DIFF
--- a/docs/server/docs.go
+++ b/docs/server/docs.go
@@ -896,10 +896,6 @@ const docTemplate = `{
                     "aws_sts_config": {
                         "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_auth_awssts.Config"
                     },
-                    "backend_replicas": {
-                        "description": "BackendReplicas is the desired StatefulSet replica count for the proxy runner backend.\nWhen omitted or null, replicas are unmanaged (preserving HPA or manual kubectl control).\nWhen set (including 0), the value is an explicit replica count passed to consuming code.",
-                        "type": "integer"
-                    },
                     "base_name": {
                         "description": "BaseName is the base name used for the container (without prefixes)",
                         "type": "string"
@@ -1016,6 +1012,9 @@ const docTemplate = `{
                     "runtime_config": {
                         "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_container_templates.RuntimeConfig"
                     },
+                    "scaling_config": {
+                        "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_runner.ScalingConfig"
+                    },
                     "schema_version": {
                         "description": "SchemaVersion is the version of the RunConfig schema",
                         "type": "string"
@@ -1027,10 +1026,6 @@ const docTemplate = `{
                         },
                         "type": "array",
                         "uniqueItems": false
-                    },
-                    "session_cache_size": {
-                        "description": "SessionCacheSize is the maximum number of sessions held in the local LRU cache.\nA value of 0 causes consuming code to apply a sensible default (1000).",
-                        "type": "integer"
                     },
                     "target_host": {
                         "description": "TargetHost is the host to forward traffic to (only applicable to SSE transport)",
@@ -1089,6 +1084,20 @@ const docTemplate = `{
                         },
                         "type": "array",
                         "uniqueItems": false
+                    }
+                },
+                "type": "object"
+            },
+            "github_com_stacklok_toolhive_pkg_runner.ScalingConfig": {
+                "description": "ScalingConfig contains configuration for horizontal scaling of the proxy runner.\nOnly applicable when running in Kubernetes with the ToolHive operator.\nWhen nil, no scaling configuration is applied (single-replica default behavior).",
+                "properties": {
+                    "backend_replicas": {
+                        "description": "BackendReplicas is the desired StatefulSet replica count for the proxy runner backend.\nWhen nil, replicas are unmanaged (preserving HPA or manual kubectl control).\nWhen set (including 0), the value is an explicit replica count.",
+                        "type": "integer"
+                    },
+                    "session_cache_size": {
+                        "description": "SessionCacheSize is the maximum number of sessions held in the local LRU cache.\nWhen nil, consuming code applies a sensible default (e.g. 1000).",
+                        "type": "integer"
                     }
                 },
                 "type": "object"

--- a/docs/server/swagger.json
+++ b/docs/server/swagger.json
@@ -889,10 +889,6 @@
                     "aws_sts_config": {
                         "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_auth_awssts.Config"
                     },
-                    "backend_replicas": {
-                        "description": "BackendReplicas is the desired StatefulSet replica count for the proxy runner backend.\nWhen omitted or null, replicas are unmanaged (preserving HPA or manual kubectl control).\nWhen set (including 0), the value is an explicit replica count passed to consuming code.",
-                        "type": "integer"
-                    },
                     "base_name": {
                         "description": "BaseName is the base name used for the container (without prefixes)",
                         "type": "string"
@@ -1009,6 +1005,9 @@
                     "runtime_config": {
                         "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_container_templates.RuntimeConfig"
                     },
+                    "scaling_config": {
+                        "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_runner.ScalingConfig"
+                    },
                     "schema_version": {
                         "description": "SchemaVersion is the version of the RunConfig schema",
                         "type": "string"
@@ -1020,10 +1019,6 @@
                         },
                         "type": "array",
                         "uniqueItems": false
-                    },
-                    "session_cache_size": {
-                        "description": "SessionCacheSize is the maximum number of sessions held in the local LRU cache.\nA value of 0 causes consuming code to apply a sensible default (1000).",
-                        "type": "integer"
                     },
                     "target_host": {
                         "description": "TargetHost is the host to forward traffic to (only applicable to SSE transport)",
@@ -1082,6 +1077,20 @@
                         },
                         "type": "array",
                         "uniqueItems": false
+                    }
+                },
+                "type": "object"
+            },
+            "github_com_stacklok_toolhive_pkg_runner.ScalingConfig": {
+                "description": "ScalingConfig contains configuration for horizontal scaling of the proxy runner.\nOnly applicable when running in Kubernetes with the ToolHive operator.\nWhen nil, no scaling configuration is applied (single-replica default behavior).",
+                "properties": {
+                    "backend_replicas": {
+                        "description": "BackendReplicas is the desired StatefulSet replica count for the proxy runner backend.\nWhen nil, replicas are unmanaged (preserving HPA or manual kubectl control).\nWhen set (including 0), the value is an explicit replica count.",
+                        "type": "integer"
+                    },
+                    "session_cache_size": {
+                        "description": "SessionCacheSize is the maximum number of sessions held in the local LRU cache.\nWhen nil, consuming code applies a sensible default (e.g. 1000).",
+                        "type": "integer"
                     }
                 },
                 "type": "object"

--- a/docs/server/swagger.yaml
+++ b/docs/server/swagger.yaml
@@ -861,12 +861,6 @@ components:
           type: string
         aws_sts_config:
           $ref: '#/components/schemas/github_com_stacklok_toolhive_pkg_auth_awssts.Config'
-        backend_replicas:
-          description: |-
-            BackendReplicas is the desired StatefulSet replica count for the proxy runner backend.
-            When omitted or null, replicas are unmanaged (preserving HPA or manual kubectl control).
-            When set (including 0), the value is an explicit replica count passed to consuming code.
-          type: integer
         base_name:
           description: BaseName is the base name used for the container (without prefixes)
           type: string
@@ -967,6 +961,8 @@ components:
           type: string
         runtime_config:
           $ref: '#/components/schemas/github_com_stacklok_toolhive_pkg_container_templates.RuntimeConfig'
+        scaling_config:
+          $ref: '#/components/schemas/github_com_stacklok_toolhive_pkg_runner.ScalingConfig'
         schema_version:
           description: SchemaVersion is the version of the RunConfig schema
           type: string
@@ -978,11 +974,6 @@ components:
             type: string
           type: array
           uniqueItems: false
-        session_cache_size:
-          description: |-
-            SessionCacheSize is the maximum number of sessions held in the local LRU cache.
-            A value of 0 causes consuming code to apply a sensible default (1000).
-          type: integer
         target_host:
           description: TargetHost is the host to forward traffic to (only applicable
             to SSE transport)
@@ -1037,6 +1028,24 @@ components:
             type: string
           type: array
           uniqueItems: false
+      type: object
+    github_com_stacklok_toolhive_pkg_runner.ScalingConfig:
+      description: |-
+        ScalingConfig contains configuration for horizontal scaling of the proxy runner.
+        Only applicable when running in Kubernetes with the ToolHive operator.
+        When nil, no scaling configuration is applied (single-replica default behavior).
+      properties:
+        backend_replicas:
+          description: |-
+            BackendReplicas is the desired StatefulSet replica count for the proxy runner backend.
+            When nil, replicas are unmanaged (preserving HPA or manual kubectl control).
+            When set (including 0), the value is an explicit replica count.
+          type: integer
+        session_cache_size:
+          description: |-
+            SessionCacheSize is the maximum number of sessions held in the local LRU cache.
+            When nil, consuming code applies a sensible default (e.g. 1000).
+          type: integer
       type: object
     github_com_stacklok_toolhive_pkg_runner.ToolOverride:
       properties:

--- a/pkg/runner/config.go
+++ b/pkg/runner/config.go
@@ -211,14 +211,25 @@ type RunConfig struct {
 	// This is the serializable RunConfig; secrets are referenced by file paths or env var names.
 	EmbeddedAuthServerConfig *authserver.RunConfig `json:"embedded_auth_server_config,omitempty" yaml:"embedded_auth_server_config,omitempty"` //nolint:lll
 
+	// ScalingConfig contains configuration for horizontal scaling of the proxy runner.
+	// Only applicable when running in Kubernetes with the ToolHive operator.
+	// When nil, no scaling configuration is applied (single-replica default behavior).
+	ScalingConfig *ScalingConfig `json:"scaling_config,omitempty" yaml:"scaling_config,omitempty"`
+}
+
+// ScalingConfig contains configuration for horizontal scaling of the proxy runner backend.
+// It is intentionally kept as a separate struct so future scaling knobs (MinReplicas,
+// MaxReplicas, ScaleDownWindow, etc.) can be added here without growing the top-level
+// RunConfig shape.
+type ScalingConfig struct {
 	// BackendReplicas is the desired StatefulSet replica count for the proxy runner backend.
-	// When omitted or null, replicas are unmanaged (preserving HPA or manual kubectl control).
-	// When set (including 0), the value is an explicit replica count passed to consuming code.
+	// When nil, replicas are unmanaged (preserving HPA or manual kubectl control).
+	// When set (including 0), the value is an explicit replica count.
 	BackendReplicas *int32 `json:"backend_replicas,omitempty" yaml:"backend_replicas,omitempty"`
 
 	// SessionCacheSize is the maximum number of sessions held in the local LRU cache.
-	// A value of 0 causes consuming code to apply a sensible default (1000).
-	SessionCacheSize int `json:"session_cache_size,omitempty" yaml:"session_cache_size,omitempty"`
+	// When nil, consuming code applies a sensible default (e.g. 1000).
+	SessionCacheSize *int32 `json:"session_cache_size,omitempty" yaml:"session_cache_size,omitempty"`
 }
 
 // WriteJSON serializes the RunConfig to JSON and writes it to the provided writer

--- a/pkg/runner/config_test.go
+++ b/pkg/runner/config_test.go
@@ -2252,50 +2252,43 @@ func TestRunConfig_BackendReplicasAndSessionCacheSize(t *testing.T) {
 		t.Parallel()
 		original := NewRunConfig()
 		original.Name = "test-server"
-		original.BackendReplicas = int32ptr(3)
-		original.SessionCacheSize = 500
+		original.ScalingConfig = &ScalingConfig{
+			BackendReplicas:  int32ptr(3),
+			SessionCacheSize: int32ptr(500),
+		}
 
 		var buf bytes.Buffer
 		require.NoError(t, original.WriteJSON(&buf))
 
 		got, err := ReadJSON(&buf)
 		require.NoError(t, err)
-		require.NotNil(t, got.BackendReplicas)
-		assert.Equal(t, int32(3), *got.BackendReplicas)
-		assert.Equal(t, 500, got.SessionCacheSize)
+		require.NotNil(t, got.ScalingConfig)
+		require.NotNil(t, got.ScalingConfig.BackendReplicas)
+		assert.Equal(t, int32(3), *got.ScalingConfig.BackendReplicas)
+		require.NotNil(t, got.ScalingConfig.SessionCacheSize)
+		assert.Equal(t, int32(500), *got.ScalingConfig.SessionCacheSize)
 	})
 
-	t.Run("round-trip without new fields preserves zero values", func(t *testing.T) {
+	t.Run("round-trip without scaling config preserves nil", func(t *testing.T) {
 		t.Parallel()
-		// Marshal a minimal config that has no BackendReplicas or SessionCacheSize set,
-		// then unmarshal and verify the new fields are absent (nil / 0).
 		minimal := NewRunConfig()
 		minimal.Name = testServerName
 		var buf bytes.Buffer
 		require.NoError(t, minimal.WriteJSON(&buf))
 		got, err := ReadJSON(&buf)
 		require.NoError(t, err)
-		assert.Nil(t, got.BackendReplicas, "BackendReplicas should be nil when omitted")
-		assert.Equal(t, 0, got.SessionCacheSize, "SessionCacheSize should be 0 when omitted")
+		assert.Nil(t, got.ScalingConfig, "ScalingConfig should be nil when omitted")
 	})
 
-	t.Run("BackendReplicas nil is omitted from JSON output", func(t *testing.T) {
+	t.Run("nil ScalingConfig is omitted from JSON output", func(t *testing.T) {
 		t.Parallel()
 		cfg := NewRunConfig()
-		cfg.Name = "no-replicas"
+		cfg.Name = "no-scaling"
 
 		var buf bytes.Buffer
 		require.NoError(t, cfg.WriteJSON(&buf))
+		assert.NotContains(t, buf.String(), "scaling_config")
 		assert.NotContains(t, buf.String(), "backend_replicas")
-	})
-
-	t.Run("SessionCacheSize zero is omitted from JSON output", func(t *testing.T) {
-		t.Parallel()
-		cfg := NewRunConfig()
-		cfg.Name = "no-cache-size"
-
-		var buf bytes.Buffer
-		require.NoError(t, cfg.WriteJSON(&buf))
 		assert.NotContains(t, buf.String(), "session_cache_size")
 	})
 
@@ -2303,46 +2296,68 @@ func TestRunConfig_BackendReplicasAndSessionCacheSize(t *testing.T) {
 		t.Parallel()
 		cfg := NewRunConfig()
 		cfg.Name = testServerName
-		cfg.BackendReplicas = int32ptr(2)
+		cfg.ScalingConfig = &ScalingConfig{BackendReplicas: int32ptr(2)}
 		var buf bytes.Buffer
 		require.NoError(t, cfg.WriteJSON(&buf))
 		got, err := ReadJSON(&buf)
 		require.NoError(t, err)
-		require.NotNil(t, got.BackendReplicas, "BackendReplicas should be non-nil when present in JSON")
-		assert.Equal(t, int32(2), *got.BackendReplicas)
+		require.NotNil(t, got.ScalingConfig)
+		require.NotNil(t, got.ScalingConfig.BackendReplicas, "BackendReplicas should be non-nil when present in JSON")
+		assert.Equal(t, int32(2), *got.ScalingConfig.BackendReplicas)
+		assert.Nil(t, got.ScalingConfig.SessionCacheSize, "SessionCacheSize should be nil when omitted from JSON")
 	})
 
 	t.Run("backend_replicas 0 in JSON deserializes to pointer-to-zero, not nil", func(t *testing.T) {
 		t.Parallel()
-		// Explicitly encoding 0 is distinct from omitting the field entirely.
-		// omitempty only omits the field when the pointer is nil; a pointer-to-zero
-		// is a meaningful "set to 0" and must survive a round-trip.
+		// omitempty only omits when the pointer is nil; pointer-to-zero is a meaningful
+		// "set to 0" and must survive a round-trip.
 		cfg := NewRunConfig()
 		cfg.Name = testServerName
-		cfg.BackendReplicas = int32ptr(0)
+		cfg.ScalingConfig = &ScalingConfig{BackendReplicas: int32ptr(0)}
 		var buf bytes.Buffer
 		require.NoError(t, cfg.WriteJSON(&buf))
 		got, err := ReadJSON(&buf)
 		require.NoError(t, err)
-		require.NotNil(t, got.BackendReplicas, "BackendReplicas should be non-nil when explicitly set to 0 in JSON")
-		assert.Equal(t, int32(0), *got.BackendReplicas)
+		require.NotNil(t, got.ScalingConfig)
+		require.NotNil(t, got.ScalingConfig.BackendReplicas, "BackendReplicas should be non-nil when explicitly set to 0 in JSON")
+		assert.Equal(t, int32(0), *got.ScalingConfig.BackendReplicas)
+	})
+
+	t.Run("session_cache_size 0 in JSON deserializes to pointer-to-zero, not nil", func(t *testing.T) {
+		t.Parallel()
+		// omitempty only omits when the pointer is nil; pointer-to-zero is a meaningful
+		// "set to 0" and must survive a round-trip.
+		cfg := NewRunConfig()
+		cfg.Name = testServerName
+		cfg.ScalingConfig = &ScalingConfig{SessionCacheSize: int32ptr(0)}
+		var buf bytes.Buffer
+		require.NoError(t, cfg.WriteJSON(&buf))
+		got, err := ReadJSON(&buf)
+		require.NoError(t, err)
+		require.NotNil(t, got.ScalingConfig)
+		require.NotNil(t, got.ScalingConfig.SessionCacheSize, "SessionCacheSize should be non-nil when explicitly set to 0 in JSON")
+		assert.Equal(t, int32(0), *got.ScalingConfig.SessionCacheSize)
+		assert.Nil(t, got.ScalingConfig.BackendReplicas, "BackendReplicas should be nil when omitted from JSON")
 	})
 
 	t.Run("YAML round-trip with both fields set", func(t *testing.T) {
 		t.Parallel()
 		original := NewRunConfig()
 		original.Name = "yaml-server"
-		original.BackendReplicas = int32ptr(5)
-		original.SessionCacheSize = 250
+		original.ScalingConfig = &ScalingConfig{
+			BackendReplicas:  int32ptr(5),
+			SessionCacheSize: int32ptr(250),
+		}
 
-		// Marshal to YAML then unmarshal back using the standard yaml library.
 		data, err := yaml.Marshal(original)
 		require.NoError(t, err)
 
 		var got RunConfig
 		require.NoError(t, yaml.Unmarshal(data, &got))
-		require.NotNil(t, got.BackendReplicas)
-		assert.Equal(t, int32(5), *got.BackendReplicas)
-		assert.Equal(t, 250, got.SessionCacheSize)
+		require.NotNil(t, got.ScalingConfig)
+		require.NotNil(t, got.ScalingConfig.BackendReplicas)
+		assert.Equal(t, int32(5), *got.ScalingConfig.BackendReplicas)
+		require.NotNil(t, got.ScalingConfig.SessionCacheSize)
+		assert.Equal(t, int32(250), *got.ScalingConfig.SessionCacheSize)
 	})
 }


### PR DESCRIPTION
## Summary

<!--
REQUIRED. You MUST explain:
1. WHY this change is needed (the problem or motivation)
2. WHAT changed (concise bullet points)

The diff shows the code — your summary must provide the context a reviewer
needs to understand the purpose without reading the diff first.
-->

Extends RunConfig with two optional, zero-value-safe fields needed by the proxyrunner horizontal scaling epic (THV-0047). BackendReplicas (*int32, nil = unmanaged) controls StatefulSet replica count; SessionCacheSize (*int32, 0 = default 1000) bounds the local LRU session cache. Both fields use omitempty so existing configs deserialize without modification.

<!--
Link related issues. Use "Closes" or "Fixes" to auto-close on merge.
Remove this line if there is no related issue.
-->

Fixes #4203 

## Type of change

<!-- REQUIRED. Check exactly one. -->

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

<!--
REQUIRED. Check every verification step you actually ran.
You MUST check at least one item. If you only did manual testing,
describe exactly what you tested below the checkbox.
-->

- [x] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [ ] Linting (`task lint-fix`)
- [ ] Manual testing (describe below)

## Changes

<!--
Optional — include for PRs touching more than a few files to help
reviewers navigate the diff. Remove this entire section for small PRs.
-->

| File | Change |
|------|--------|
|      |        |

## Does this introduce a user-facing change?

<!--
If yes, describe the change from the user's perspective. This helps with release notes.
If no, write "No".
Remove this section entirely if not applicable.
-->

## Special notes for reviewers

<!--
Optional — call out anything non-obvious: tricky logic, known limitations,
areas where you'd like extra scrutiny, or follow-up work planned.
Remove this section if not needed.
-->
