### PR TITLE
Add Swagger annotations for registry auth endpoints

### DIFF
--- a/docs/server/docs.go
+++ b/docs/server/docs.go
@@ -3553,6 +3553,94 @@ const docTemplate = `{
                 ]
             }
         },
+        "/api/v1beta/registry/auth/login": {
+            "post": {
+                "description": "Trigger an interactive OAuth flow to authenticate with the configured registry. Only available in serve mode.",
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "additionalProperties": {
+                                        "type": "string"
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Authenticated successfully"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Bad Request - Registry OAuth not configured"
+                    },
+                    "500": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Internal Server Error"
+                    }
+                },
+                "summary": "Registry login",
+                "tags": [
+                    "registry"
+                ]
+            }
+        },
+        "/api/v1beta/registry/auth/logout": {
+            "post": {
+                "description": "Clear cached OAuth tokens for the configured registry. Only available in serve mode.",
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "additionalProperties": {
+                                        "type": "string"
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Logged out successfully"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Bad Request - Registry OAuth not configured"
+                    },
+                    "500": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Internal Server Error"
+                    }
+                },
+                "summary": "Registry logout",
+                "tags": [
+                    "registry"
+                ]
+            }
+        },
         "/api/v1beta/registry/{name}": {
             "delete": {
                 "description": "Remove a specific registry",

--- a/docs/server/swagger.json
+++ b/docs/server/swagger.json
@@ -3546,6 +3546,94 @@
                 ]
             }
         },
+        "/api/v1beta/registry/auth/login": {
+            "post": {
+                "description": "Trigger an interactive OAuth flow to authenticate with the configured registry. Only available in serve mode.",
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "additionalProperties": {
+                                        "type": "string"
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Authenticated successfully"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Bad Request - Registry OAuth not configured"
+                    },
+                    "500": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Internal Server Error"
+                    }
+                },
+                "summary": "Registry login",
+                "tags": [
+                    "registry"
+                ]
+            }
+        },
+        "/api/v1beta/registry/auth/logout": {
+            "post": {
+                "description": "Clear cached OAuth tokens for the configured registry. Only available in serve mode.",
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "additionalProperties": {
+                                        "type": "string"
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Logged out successfully"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Bad Request - Registry OAuth not configured"
+                    },
+                    "500": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Internal Server Error"
+                    }
+                },
+                "summary": "Registry logout",
+                "tags": [
+                    "registry"
+                ]
+            }
+        },
         "/api/v1beta/registry/{name}": {
             "delete": {
                 "description": "Remove a specific registry",

--- a/docs/server/swagger.yaml
+++ b/docs/server/swagger.yaml
@@ -3101,6 +3101,62 @@ paths:
       summary: Get a server from a registry
       tags:
       - registry
+  /api/v1beta/registry/auth/login:
+    post:
+      description: Trigger an interactive OAuth flow to authenticate with the configured
+        registry. Only available in serve mode.
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                additionalProperties:
+                  type: string
+                type: object
+          description: Authenticated successfully
+        "400":
+          content:
+            application/json:
+              schema:
+                type: string
+          description: Bad Request - Registry OAuth not configured
+        "500":
+          content:
+            application/json:
+              schema:
+                type: string
+          description: Internal Server Error
+      summary: Registry login
+      tags:
+      - registry
+  /api/v1beta/registry/auth/logout:
+    post:
+      description: Clear cached OAuth tokens for the configured registry. Only available
+        in serve mode.
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                additionalProperties:
+                  type: string
+                type: object
+          description: Logged out successfully
+        "400":
+          content:
+            application/json:
+              schema:
+                type: string
+          description: Bad Request - Registry OAuth not configured
+        "500":
+          content:
+            application/json:
+              schema:
+                type: string
+          description: Internal Server Error
+      summary: Registry logout
+      tags:
+      - registry
   /api/v1beta/secrets:
     post:
       description: Setup the secrets provider with the specified type and configuration.

--- a/pkg/api/v1/registry.go
+++ b/pkg/api/v1/registry.go
@@ -84,6 +84,15 @@ func newSecretsProvider(configProvider config.Provider) (secrets.Provider, error
 // This endpoint is only available in serve mode and is designed for desktop
 // clients (e.g. Studio) where the user has a local browser. Headless or
 // remote deployments should pre-configure credentials via the CLI instead.
+//
+//	@Summary		Registry login
+//	@Description	Trigger an interactive OAuth flow to authenticate with the configured registry. Only available in serve mode.
+//	@Tags			registry
+//	@Produce		json
+//	@Success		200	{object}	map[string]string	"Authenticated successfully"
+//	@Failure		400	{string}	string				"Bad Request - Registry OAuth not configured"
+//	@Failure		500	{string}	string				"Internal Server Error"
+//	@Router			/api/v1beta/registry/auth/login [post]
 func (rr *RegistryRoutes) registryAuthLogin(w http.ResponseWriter, r *http.Request) {
 	secretsProvider, err := newSecretsProvider(rr.configProvider)
 	if err != nil {
@@ -112,6 +121,15 @@ func (rr *RegistryRoutes) registryAuthLogin(w http.ResponseWriter, r *http.Reque
 // registryAuthLogout handles POST /registry/auth/logout.
 // It clears cached OAuth tokens for the configured registry.
 // This endpoint is only available in serve mode.
+//
+//	@Summary		Registry logout
+//	@Description	Clear cached OAuth tokens for the configured registry. Only available in serve mode.
+//	@Tags			registry
+//	@Produce		json
+//	@Success		200	{object}	map[string]string	"Logged out successfully"
+//	@Failure		400	{string}	string				"Bad Request - Registry OAuth not configured"
+//	@Failure		500	{string}	string				"Internal Server Error"
+//	@Router			/api/v1beta/registry/auth/logout [post]
 func (rr *RegistryRoutes) registryAuthLogout(w http.ResponseWriter, r *http.Request) {
 	secretsProvider, err := newSecretsProvider(rr.configProvider)
 	if err != nil {


### PR DESCRIPTION
## Summary

- The `registryAuthLogin` and `registryAuthLogout` handlers were missing swag annotations, so they did not appear in the generated OpenAPI spec. This adds the standard `@Summary`, `@Description`, `@Tags`, `@Router`, etc. comment blocks and regenerates the swagger docs.

## Type of change

- [x] Documentation

## Test plan

- [x] Linting (`task lint-fix`)
- [x] Manual testing (describe below)

Verified `task docs` regenerates successfully and the new endpoints appear in `docs/server/swagger.json` and `docs/server/swagger.yaml` under `/api/v1beta/registry/auth/login` and `/api/v1beta/registry/auth/logout`.

## Does this introduce a user-facing change?

No code behavior change. The login/logout endpoints now appear in the Swagger/OpenAPI documentation.

Generated with [Claude Code](https://claude.com/claude-code)