### PR TITLE
chore: migrate from Trivy to Grype for vulnerability scanning

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -16,49 +16,27 @@ permissions:
   security-events: write
 
 jobs:
-  trivy-repo-scan:
-    name: Trivy Repository Scan
+  grype-repo-scan:
+    name: Grype Repository Scan
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Run Trivy vulnerability scanner in repo mode
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
+      - name: Run Grype vulnerability scanner
+        id: grype-scan
+        uses: anchore/scan-action@7037fa011853d5a11690026fb85feee79f4c946c # v7.3.2
         with:
-          version: 'v0.69.3'
-          scan-type: 'fs'
-          scan-ref: '.'
-          format: 'sarif'
-          output: 'trivy-results.sarif'
+          path: "."
+          output-format: "sarif"
+          fail-build: false
 
-      - name: Upload Trivy scan results to GitHub Security tab
+      - name: Upload Grype scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@b1bff81932f5cdfc8695c7752dcee935dcd061c8 # v4
         if: always()
         with:
-          sarif_file: 'trivy-results.sarif'
-
-  trivy-config-scan:
-    name: Trivy Configuration Scan
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - name: Run Trivy configuration scanner
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
-        with:
-          version: 'v0.69.3'
-          scan-type: 'config'
-          scan-ref: './deploy/charts'
-          format: 'sarif'
-          output: 'trivy-config-results.sarif'
-
-      - name: Upload Trivy config scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@b1bff81932f5cdfc8695c7752dcee935dcd061c8 # v4
-        if: always()
-        with:
-          sarif_file: 'trivy-config-results.sarif'
+          sarif_file: ${{ steps.grype-scan.outputs.sarif }}
+          category: "grype"
 
   govulncheck:
     name: Go Vulnerability Check


### PR DESCRIPTION
## Summary
- Replace `aquasecurity/trivy-action` with `anchore/scan-action` (Grype) v7.3.2 for vulnerability scanning
- Remove config scanning job (not supported by Grype)
- Preserve govulncheck job unchanged

## Test plan
- [ ] Verify Grype scan runs successfully in CI
- [ ] Check that SARIF results appear in Security tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)