### PR TITLE
Prevent permanent backend unhealthy marking after startup race

### DIFF
--- a/pkg/vmcp/client/client.go
+++ b/pkg/vmcp/client/client.go
@@ -82,6 +82,32 @@ func NewHTTPBackendClient(registry vmcpauth.OutgoingAuthRegistry) (vmcp.BackendC
 	return c, nil
 }
 
+// newBackendTransport creates a *http.Transport with the same defaults as http.DefaultTransport.
+// If http.DefaultTransport is a *http.Transport, it is cloned directly (preserving any
+// environment-specific settings like TLS config or proxy overrides). Otherwise a transport
+// with the standard Go defaults is constructed, preserving proxy, dial timeout, HTTP/2, and
+// idle-connection settings that a zero-value &http.Transport{} would drop.
+func newBackendTransport() *http.Transport {
+	if dt, ok := http.DefaultTransport.(*http.Transport); ok {
+		return dt.Clone()
+	}
+	// http.DefaultTransport has been replaced (e.g. in tests or by a third-party library).
+	// Construct a transport with the same defaults as the Go standard library uses for
+	// http.DefaultTransport so we don't silently drop proxy, timeout, or HTTP/2 settings.
+	return &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+}
+
 // roundTripperFunc is a function adapter for http.RoundTripper.
 type roundTripperFunc func(*http.Request) (*http.Response, error)
 
@@ -173,7 +199,10 @@ func (h *httpBackendClient) resolveAuthStrategy(target *vmcp.BackendTarget) (vmc
 func (h *httpBackendClient) defaultClientFactory(ctx context.Context, target *vmcp.BackendTarget) (*client.Client, error) {
 	// Build transport chain (outermost to innermost, request execution order):
 	// size limit (response body) → trace propagation → identity propagation → authentication → HTTP
-	var baseTransport = http.DefaultTransport
+	//
+	// Clone DefaultTransport per call so each client gets an isolated connection pool,
+	// preventing stale keep-alive connections from one backend affecting others.
+	var baseTransport http.RoundTripper = newBackendTransport()
 
 	// Resolve authentication strategy ONCE at client creation time
 	authStrategy, err := h.resolveAuthStrategy(target)

--- a/pkg/vmcp/client/client_test.go
+++ b/pkg/vmcp/client/client_test.go
@@ -89,6 +89,21 @@ func TestQueryHelpers_PartialCapabilities(t *testing.T) {
 	})
 }
 
+// TestNewBackendTransport_IsolatesFromDefault verifies that newBackendTransport never
+// returns http.DefaultTransport itself, preventing stale keep-alive connections on one
+// backend from affecting requests to other backends or future calls.
+func TestNewBackendTransport_IsolatesFromDefault(t *testing.T) {
+	t.Parallel()
+
+	t1 := newBackendTransport()
+	t2 := newBackendTransport()
+
+	// Each call must return a distinct transport — not the shared DefaultTransport.
+	assert.NotSame(t, http.DefaultTransport, t1, "newBackendTransport must not return http.DefaultTransport")
+	assert.NotSame(t, http.DefaultTransport, t2, "newBackendTransport must not return http.DefaultTransport")
+	assert.NotSame(t, t1, t2, "each call must return a distinct *http.Transport")
+}
+
 func TestDefaultClientFactory_UnsupportedTransport(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Health checks could permanently mark backends as unhealthy due to a race condition: `http.DefaultTransport` was shared across all backend clients, causing stale keep-alive connections to replaced K8s pods to persist and return 4xx indefinitely.

- Replace the shared `http.DefaultTransport` reference with `newBackendTransport()`, which clones `DefaultTransport` (or constructs an equivalent) per `defaultClientFactory` call. Each client gets its own isolated connection pool, so a replaced pod's stale connections cannot affect requests to other backends or future calls.


Fixes #4278

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [x] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [x] Linting (`task lint-fix`)
- [ ] Manual testing (describe below)