### PR TITLE
Webhook Middleware Phase 2: Validating webhook middleware

### DIFF
--- a/docs/server/docs.go
+++ b/docs/server/docs.go
@@ -1111,6 +1111,14 @@ const docTemplate = `{
                     "upstream_swap_config": {
                         "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_auth_upstreamswap.Config"
                     },
+                    "validating_webhooks": {
+                        "description": "ValidatingWebhooks contains the configuration for validating webhook middleware.",
+                        "items": {
+                            "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_webhook.Config"
+                        },
+                        "type": "array",
+                        "uniqueItems": false
+                    },
                     "volumes": {
                         "description": "Volumes are the directory mounts to pass to the container\nFormat: \"host-path:container-path[:ro]\"",
                         "items": {
@@ -1385,6 +1393,67 @@ const docTemplate = `{
                     },
                     "useLegacyAttributes": {
                         "description": "UseLegacyAttributes controls whether legacy (pre-MCP OTEL semconv) attribute names\nare emitted alongside the new standard attribute names. When true, spans include both\nold and new attribute names for backward compatibility with existing dashboards.\nCurrently defaults to true; this will change to false in a future release.\n+kubebuilder:default=true\n+optional",
+                        "type": "boolean"
+                    }
+                },
+                "type": "object"
+            },
+            "github_com_stacklok_toolhive_pkg_webhook.Config": {
+                "properties": {
+                    "failure_policy": {
+                        "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_webhook.FailurePolicy"
+                    },
+                    "hmac_secret_ref": {
+                        "description": "HMACSecretRef is an optional reference to an HMAC secret for payload signing.",
+                        "type": "string"
+                    },
+                    "name": {
+                        "description": "Name is a unique identifier for this webhook.",
+                        "type": "string"
+                    },
+                    "timeout": {
+                        "description": "Timeout is the maximum time to wait for a webhook response.",
+                        "type": "integer"
+                    },
+                    "tls_config": {
+                        "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_webhook.TLSConfig"
+                    },
+                    "url": {
+                        "description": "URL is the HTTPS endpoint to call.",
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "github_com_stacklok_toolhive_pkg_webhook.FailurePolicy": {
+                "description": "FailurePolicy determines behavior when the webhook call fails.",
+                "enum": [
+                    "fail",
+                    "ignore"
+                ],
+                "type": "string",
+                "x-enum-varnames": [
+                    "FailurePolicyFail",
+                    "FailurePolicyIgnore"
+                ]
+            },
+            "github_com_stacklok_toolhive_pkg_webhook.TLSConfig": {
+                "description": "TLSConfig holds optional TLS configuration (CA bundles, client certs).",
+                "properties": {
+                    "ca_bundle_path": {
+                        "description": "CABundlePath is the path to a CA certificate bundle for server verification.",
+                        "type": "string"
+                    },
+                    "client_cert_path": {
+                        "description": "ClientCertPath is the path to a client certificate for mTLS.",
+                        "type": "string"
+                    },
+                    "client_key_path": {
+                        "description": "ClientKeyPath is the path to a client key for mTLS.",
+                        "type": "string"
+                    },
+                    "insecure_skip_verify": {
+                        "description": "InsecureSkipVerify disables server certificate verification.\nWARNING: This should only be used for development/testing.",
                         "type": "boolean"
                     }
                 },

--- a/docs/server/swagger.json
+++ b/docs/server/swagger.json
@@ -1104,6 +1104,14 @@
                     "upstream_swap_config": {
                         "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_auth_upstreamswap.Config"
                     },
+                    "validating_webhooks": {
+                        "description": "ValidatingWebhooks contains the configuration for validating webhook middleware.",
+                        "items": {
+                            "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_webhook.Config"
+                        },
+                        "type": "array",
+                        "uniqueItems": false
+                    },
                     "volumes": {
                         "description": "Volumes are the directory mounts to pass to the container\nFormat: \"host-path:container-path[:ro]\"",
                         "items": {
@@ -1378,6 +1386,67 @@
                     },
                     "useLegacyAttributes": {
                         "description": "UseLegacyAttributes controls whether legacy (pre-MCP OTEL semconv) attribute names\nare emitted alongside the new standard attribute names. When true, spans include both\nold and new attribute names for backward compatibility with existing dashboards.\nCurrently defaults to true; this will change to false in a future release.\n+kubebuilder:default=true\n+optional",
+                        "type": "boolean"
+                    }
+                },
+                "type": "object"
+            },
+            "github_com_stacklok_toolhive_pkg_webhook.Config": {
+                "properties": {
+                    "failure_policy": {
+                        "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_webhook.FailurePolicy"
+                    },
+                    "hmac_secret_ref": {
+                        "description": "HMACSecretRef is an optional reference to an HMAC secret for payload signing.",
+                        "type": "string"
+                    },
+                    "name": {
+                        "description": "Name is a unique identifier for this webhook.",
+                        "type": "string"
+                    },
+                    "timeout": {
+                        "description": "Timeout is the maximum time to wait for a webhook response.",
+                        "type": "integer"
+                    },
+                    "tls_config": {
+                        "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_webhook.TLSConfig"
+                    },
+                    "url": {
+                        "description": "URL is the HTTPS endpoint to call.",
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "github_com_stacklok_toolhive_pkg_webhook.FailurePolicy": {
+                "description": "FailurePolicy determines behavior when the webhook call fails.",
+                "enum": [
+                    "fail",
+                    "ignore"
+                ],
+                "type": "string",
+                "x-enum-varnames": [
+                    "FailurePolicyFail",
+                    "FailurePolicyIgnore"
+                ]
+            },
+            "github_com_stacklok_toolhive_pkg_webhook.TLSConfig": {
+                "description": "TLSConfig holds optional TLS configuration (CA bundles, client certs).",
+                "properties": {
+                    "ca_bundle_path": {
+                        "description": "CABundlePath is the path to a CA certificate bundle for server verification.",
+                        "type": "string"
+                    },
+                    "client_cert_path": {
+                        "description": "ClientCertPath is the path to a client certificate for mTLS.",
+                        "type": "string"
+                    },
+                    "client_key_path": {
+                        "description": "ClientKeyPath is the path to a client key for mTLS.",
+                        "type": "string"
+                    },
+                    "insecure_skip_verify": {
+                        "description": "InsecureSkipVerify disables server certificate verification.\nWARNING: This should only be used for development/testing.",
                         "type": "boolean"
                     }
                 },

--- a/docs/server/swagger.yaml
+++ b/docs/server/swagger.yaml
@@ -1050,6 +1050,13 @@ components:
           type: boolean
         upstream_swap_config:
           $ref: '#/components/schemas/github_com_stacklok_toolhive_pkg_auth_upstreamswap.Config'
+        validating_webhooks:
+          description: ValidatingWebhooks contains the configuration for validating
+            webhook middleware.
+          items:
+            $ref: '#/components/schemas/github_com_stacklok_toolhive_pkg_webhook.Config'
+          type: array
+          uniqueItems: false
         volumes:
           description: |-
             Volumes are the directory mounts to pass to the container
@@ -1309,6 +1316,55 @@ components:
             Currently defaults to true; this will change to false in a future release.
             +kubebuilder:default=true
             +optional
+          type: boolean
+      type: object
+    github_com_stacklok_toolhive_pkg_webhook.Config:
+      properties:
+        failure_policy:
+          $ref: '#/components/schemas/github_com_stacklok_toolhive_pkg_webhook.FailurePolicy'
+        hmac_secret_ref:
+          description: HMACSecretRef is an optional reference to an HMAC secret for
+            payload signing.
+          type: string
+        name:
+          description: Name is a unique identifier for this webhook.
+          type: string
+        timeout:
+          description: Timeout is the maximum time to wait for a webhook response.
+          type: integer
+        tls_config:
+          $ref: '#/components/schemas/github_com_stacklok_toolhive_pkg_webhook.TLSConfig'
+        url:
+          description: URL is the HTTPS endpoint to call.
+          type: string
+      type: object
+    github_com_stacklok_toolhive_pkg_webhook.FailurePolicy:
+      description: FailurePolicy determines behavior when the webhook call fails.
+      enum:
+      - fail
+      - ignore
+      type: string
+      x-enum-varnames:
+      - FailurePolicyFail
+      - FailurePolicyIgnore
+    github_com_stacklok_toolhive_pkg_webhook.TLSConfig:
+      description: TLSConfig holds optional TLS configuration (CA bundles, client
+        certs).
+      properties:
+        ca_bundle_path:
+          description: CABundlePath is the path to a CA certificate bundle for server
+            verification.
+          type: string
+        client_cert_path:
+          description: ClientCertPath is the path to a client certificate for mTLS.
+          type: string
+        client_key_path:
+          description: ClientKeyPath is the path to a client key for mTLS.
+          type: string
+        insecure_skip_verify:
+          description: |-
+            InsecureSkipVerify disables server certificate verification.
+            WARNING: This should only be used for development/testing.
           type: boolean
       type: object
     ignore.Config:

--- a/pkg/runner/config.go
+++ b/pkg/runner/config.go
@@ -32,6 +32,7 @@ import (
 	"github.com/stacklok/toolhive/pkg/state"
 	"github.com/stacklok/toolhive/pkg/telemetry"
 	"github.com/stacklok/toolhive/pkg/transport/types"
+	"github.com/stacklok/toolhive/pkg/webhook"
 	workloadtypes "github.com/stacklok/toolhive/pkg/workloads/types"
 )
 
@@ -193,6 +194,9 @@ type RunConfig struct {
 	// MiddlewareConfigs contains the list of middleware to apply to the transport
 	// and the configuration for each middleware.
 	MiddlewareConfigs []types.MiddlewareConfig `json:"middleware_configs,omitempty" yaml:"middleware_configs,omitempty"`
+
+	// ValidatingWebhooks contains the configuration for validating webhook middleware.
+	ValidatingWebhooks []webhook.Config `json:"validating_webhooks,omitempty" yaml:"validating_webhooks,omitempty"`
 
 	// existingPort is the port from an existing workload being updated (not serialized)
 	// Used during port validation to allow reusing the same port

--- a/pkg/runner/middleware.go
+++ b/pkg/runner/middleware.go
@@ -19,6 +19,7 @@ import (
 	headerfwd "github.com/stacklok/toolhive/pkg/transport/middleware"
 	"github.com/stacklok/toolhive/pkg/transport/types"
 	"github.com/stacklok/toolhive/pkg/usagemetrics"
+	"github.com/stacklok/toolhive/pkg/webhook/validating"
 )
 
 // GetSupportedMiddlewareFactories returns a map of supported middleware types to their factory functions
@@ -37,6 +38,7 @@ func GetSupportedMiddlewareFactories() map[string]types.MiddlewareFactory {
 		audit.MiddlewareType:                  audit.CreateMiddleware,
 		recovery.MiddlewareType:               recovery.CreateMiddleware,
 		headerfwd.HeaderForwardMiddlewareName: headerfwd.CreateMiddleware,
+		validating.MiddlewareType:             validating.CreateMiddleware,
 	}
 }
 
@@ -112,6 +114,12 @@ func PopulateMiddlewareConfigs(config *RunConfig) error {
 		return fmt.Errorf("failed to create MCP parser middleware config: %w", err)
 	}
 	middlewareConfigs = append(middlewareConfigs, *mcpParserConfig)
+
+	// Validating Webhooks middleware (if configured)
+	middlewareConfigs, err = addValidatingWebhookMiddleware(middlewareConfigs, config)
+	if err != nil {
+		return err
+	}
 
 	// Load application config for global settings
 	configProvider := cfg.NewDefaultProvider()
@@ -195,6 +203,28 @@ func PopulateMiddlewareConfigs(config *RunConfig) error {
 	// Set the populated middleware configs
 	config.MiddlewareConfigs = middlewareConfigs
 	return nil
+}
+
+// addValidatingWebhookMiddleware configures the validating webhook middleware if any webhooks are defined
+func addValidatingWebhookMiddleware(configs []types.MiddlewareConfig, runConfig *RunConfig) ([]types.MiddlewareConfig, error) {
+	if len(runConfig.ValidatingWebhooks) == 0 {
+		return configs, nil
+	}
+
+	params := validating.FactoryMiddlewareParams{
+		MiddlewareParams: validating.MiddlewareParams{
+			Webhooks: runConfig.ValidatingWebhooks,
+		},
+		ServerName: runConfig.Name,
+		Transport:  runConfig.Transport.String(),
+	}
+
+	config, err := types.NewMiddlewareConfig(validating.MiddlewareType, params)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create validating webhook middleware config: %w", err)
+	}
+
+	return append(configs, *config), nil
 }
 
 // addTokenExchangeMiddleware adds token exchange middleware if configured

--- a/pkg/webhook/types.go
+++ b/pkg/webhook/types.go
@@ -62,17 +62,17 @@ type TLSConfig struct {
 // Config holds the configuration for a single webhook.
 type Config struct {
 	// Name is a unique identifier for this webhook.
-	Name string `json:"name"`
+	Name string `json:"name" yaml:"name"`
 	// URL is the HTTPS endpoint to call.
-	URL string `json:"url"`
+	URL string `json:"url" yaml:"url"`
 	// Timeout is the maximum time to wait for a webhook response.
-	Timeout time.Duration `json:"timeout"`
+	Timeout time.Duration `json:"timeout" yaml:"timeout" swaggertype:"primitive,integer"`
 	// FailurePolicy determines behavior when the webhook call fails.
-	FailurePolicy FailurePolicy `json:"failure_policy"`
+	FailurePolicy FailurePolicy `json:"failure_policy" yaml:"failure_policy"`
 	// TLSConfig holds optional TLS configuration (CA bundles, client certs).
-	TLSConfig *TLSConfig `json:"tls_config,omitempty"`
+	TLSConfig *TLSConfig `json:"tls_config,omitempty" yaml:"tls_config,omitempty"`
 	// HMACSecretRef is an optional reference to an HMAC secret for payload signing.
-	HMACSecretRef string `json:"hmac_secret_ref,omitempty"`
+	HMACSecretRef string `json:"hmac_secret_ref,omitempty" yaml:"hmac_secret_ref,omitempty"`
 }
 
 // Validate checks that the WebhookConfig has valid required fields.

--- a/pkg/webhook/validating/config.go
+++ b/pkg/webhook/validating/config.go
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package validating implements a validating webhook middleware for ToolHive.
+// It calls external HTTP services to approve or deny MCP requests.
+package validating
+
+import (
+	"fmt"
+
+	"github.com/stacklok/toolhive/pkg/webhook"
+)
+
+// MiddlewareParams holds the configuration parameters for the validating webhook middleware.
+type MiddlewareParams struct {
+	// Webhooks is the list of validating webhook configurations to call.
+	// Webhooks are called in configuration order; if any webhook denies the request,
+	// the request is rejected. All webhooks must allow the request for it to proceed.
+	Webhooks []webhook.Config `json:"webhooks"`
+}
+
+// Validate checks that the MiddlewareParams are valid.
+func (p *MiddlewareParams) Validate() error {
+	if len(p.Webhooks) == 0 {
+		return fmt.Errorf("validating webhook middleware requires at least one webhook")
+	}
+	for i, wh := range p.Webhooks {
+		if err := wh.Validate(); err != nil {
+			return fmt.Errorf("webhook[%d] (%q): %w", i, wh.Name, err)
+		}
+	}
+	return nil
+}

--- a/pkg/webhook/validating/middleware.go
+++ b/pkg/webhook/validating/middleware.go
@@ -1,0 +1,202 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package validating
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/google/uuid"
+	"golang.org/x/exp/jsonrpc2"
+
+	"github.com/stacklok/toolhive/pkg/auth"
+	"github.com/stacklok/toolhive/pkg/mcp"
+	"github.com/stacklok/toolhive/pkg/transport/types"
+	"github.com/stacklok/toolhive/pkg/webhook"
+)
+
+// MiddlewareType is the type constant for the validating webhook middleware.
+const MiddlewareType = "validating-webhook"
+
+// FactoryMiddlewareParams extends MiddlewareParams with context for the factory.
+type FactoryMiddlewareParams struct {
+	MiddlewareParams
+	// ServerName is the name of the ToolHive instance.
+	ServerName string `json:"server_name"`
+	// Transport is the transport type (e.g., sse, stdio).
+	Transport string `json:"transport"`
+}
+
+// Middleware wraps validating webhook functionality for the factory pattern.
+type Middleware struct {
+	handler types.MiddlewareFunction
+}
+
+// Handler returns the middleware function used by the proxy.
+func (m *Middleware) Handler() types.MiddlewareFunction {
+	return m.handler
+}
+
+// Close cleans up any resources used by the middleware.
+func (*Middleware) Close() error {
+	return nil
+}
+
+type clientExecutor struct {
+	client *webhook.Client
+	config webhook.Config
+}
+
+// CreateMiddleware is the factory function for validating webhook middleware.
+func CreateMiddleware(config *types.MiddlewareConfig, runner types.MiddlewareRunner) error {
+	var params FactoryMiddlewareParams
+	if err := json.Unmarshal(config.Parameters, &params); err != nil {
+		return fmt.Errorf("failed to unmarshal validating webhook middleware parameters: %w", err)
+	}
+
+	if err := params.Validate(); err != nil {
+		return fmt.Errorf("invalid validating webhook configuration: %w", err)
+	}
+
+	// Create clients for each webhook
+	var executors []clientExecutor
+	for i, whCfg := range params.Webhooks {
+		client, err := webhook.NewClient(whCfg, webhook.TypeValidating, nil) // HMAC secret not yet plumbed
+		if err != nil {
+			return fmt.Errorf("failed to create client for webhook[%d] (%q): %w", i, whCfg.Name, err)
+		}
+		executors = append(executors, clientExecutor{client: client, config: whCfg})
+	}
+
+	mw := &Middleware{
+		handler: createValidatingHandler(executors, params.ServerName, params.Transport),
+	}
+	runner.AddMiddleware(MiddlewareType, mw)
+	return nil
+}
+
+func createValidatingHandler(executors []clientExecutor, serverName, transport string) types.MiddlewareFunction {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Skip if it's not a parsed MCP request (middleware runs after mcp parser)
+			parsedMCP := mcp.GetParsedMCPRequest(r.Context())
+			if parsedMCP == nil {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			// Read the request body to get the raw MCP request
+			bodyBytes, err := io.ReadAll(r.Body)
+			if err != nil {
+				sendErrorResponse(w, http.StatusInternalServerError, "Failed to read request body", parsedMCP.ID)
+				return
+			}
+			// Restore the request body for downstream handlers
+			r.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+
+			// Build the webhook request payload
+			reqUID := uuid.New().String()
+			whReq := &webhook.Request{
+				Version:    webhook.APIVersion,
+				UID:        reqUID,
+				Timestamp:  time.Now().UTC(),
+				MCPRequest: json.RawMessage(bodyBytes),
+				Context: &webhook.RequestContext{
+					ServerName: serverName,
+					SourceIP:   readSourceIP(r),
+					Transport:  transport,
+				},
+			}
+
+			// Add Principal if authenticated
+			if identity, ok := auth.IdentityFromContext(r.Context()); ok {
+				whReq.Principal = identity.GetPrincipalInfo()
+			}
+
+			// Call each webhook in order
+			for _, exec := range executors {
+				whName := exec.config.Name
+
+				resp, err := exec.client.Call(r.Context(), whReq)
+				if err != nil {
+					// Handle error based on failure policy
+					if exec.config.FailurePolicy == webhook.FailurePolicyIgnore {
+						slog.Warn("Validating webhook error ignored due to fail-open policy",
+							"webhook", whName, "error", err)
+						continue
+					}
+
+					slog.Error("Validating webhook error caused request denial",
+						"webhook", whName, "error", err)
+					sendErrorResponse(w, http.StatusForbidden, "Request denied by policy", parsedMCP.ID)
+					return
+				}
+
+				if !resp.Allowed {
+					slog.Info("Validating webhook denied request", "webhook", whName, "reason", resp.Reason, "message", resp.Message)
+
+					// Prevent information leaks by ignoring the webhook's message
+					msg := "Request denied by policy"
+
+					code := http.StatusForbidden
+
+					sendErrorResponse(w, code, msg, parsedMCP.ID)
+					return
+				}
+			}
+
+			// All webhooks allowed or ignored errors
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+func readSourceIP(r *http.Request) string {
+	// Let runner handle X-Forwarded-For if TrustProxyHeaders is set.
+	// For now, simple RemoteAddr.
+	return r.RemoteAddr
+}
+
+func convertToJSONRPC2ID(id interface{}) (jsonrpc2.ID, error) {
+	if id == nil {
+		return jsonrpc2.ID{}, nil
+	}
+
+	switch v := id.(type) {
+	case string:
+		return jsonrpc2.StringID(v), nil
+	case int:
+		return jsonrpc2.Int64ID(int64(v)), nil
+	case int64:
+		return jsonrpc2.Int64ID(v), nil
+	case float64:
+		// JSON numbers are often unmarshaled as float64
+		return jsonrpc2.Int64ID(int64(v)), nil
+	default:
+		return jsonrpc2.ID{}, fmt.Errorf("unsupported ID type: %T", id)
+	}
+}
+
+func sendErrorResponse(w http.ResponseWriter, statusCode int, message string, msgID interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(statusCode)
+
+	id, err := convertToJSONRPC2ID(msgID)
+	if err != nil {
+		id = jsonrpc2.ID{} // Use empty ID if conversion fails
+	}
+
+	// Return a JSON-RPC 2.0 error so MCP clients can parse the denial.
+	// The HTTP status code signals the error at the transport level; the JSON-RPC body carries the detail.
+	errResp := &jsonrpc2.Response{
+		ID:    id,
+		Error: jsonrpc2.NewError(int64(statusCode), message),
+	}
+	_ = json.NewEncoder(w).Encode(errResp)
+}

--- a/pkg/webhook/validating/middleware_test.go
+++ b/pkg/webhook/validating/middleware_test.go
@@ -1,0 +1,510 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package validating
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stacklok/toolhive/pkg/auth"
+	"github.com/stacklok/toolhive/pkg/mcp"
+	"github.com/stacklok/toolhive/pkg/transport/types"
+	"github.com/stacklok/toolhive/pkg/webhook"
+)
+
+// closedServerURL is a URL that will always fail to connect (port 0 is reserved/closed).
+const closedServerURL = "http://127.0.0.1:0"
+
+//nolint:paralleltest // Shares a mock HTTP server and lastRequest state
+func TestValidatingMiddleware(t *testing.T) {
+	// Setup a mock webhook server
+	var lastRequest webhook.Request
+	mockResponse := webhook.Response{
+		Version: webhook.APIVersion,
+		UID:     "resp-uid",
+		Allowed: true,
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+		err := json.NewDecoder(r.Body).Decode(&lastRequest)
+		require.NoError(t, err)
+
+		w.Header().Set("Content-Type", "application/json")
+		err = json.NewEncoder(w).Encode(mockResponse)
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	// Create middleware handler
+	config := []webhook.Config{
+		{
+			Name:          "test-webhook",
+			URL:           server.URL,
+			Timeout:       webhook.DefaultTimeout,
+			FailurePolicy: webhook.FailurePolicyFail,
+			TLSConfig: &webhook.TLSConfig{
+				InsecureSkipVerify: true, // Need this for httptest server
+			},
+		},
+	}
+
+	var executors []clientExecutor
+	for _, cfg := range config {
+		client, err := webhook.NewClient(cfg, webhook.TypeValidating, nil)
+		require.NoError(t, err)
+		executors = append(executors, clientExecutor{client: client, config: cfg})
+	}
+
+	mw := createValidatingHandler(executors, "test-server", "stdio")
+
+	t.Run("Allowed Request", func(t *testing.T) {
+		mockResponse.Allowed = true // Server will return allowed
+
+		reqBody := []byte(`{"jsonrpc":"2.0","method":"tools/call","id":1}`)
+		req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(reqBody))
+
+		// Add parsed MCP request and auth identity to context
+		parsedMCP := &mcp.ParsedMCPRequest{
+			Method: "tools/call",
+			ID:     1,
+		}
+		ctx := context.WithValue(req.Context(), mcp.MCPRequestContextKey, parsedMCP)
+
+		identity := &auth.Identity{
+			PrincipalInfo: auth.PrincipalInfo{
+				Subject: "user-1",
+				Email:   "user@example.com",
+				Groups:  []string{"admin"},
+			},
+		}
+		ctx = auth.WithIdentity(ctx, identity)
+
+		req = req.WithContext(ctx)
+		req.RemoteAddr = "192.168.1.1:1234"
+
+		var nextCalled bool
+		nextHandler := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+			nextCalled = true
+		})
+
+		rr := httptest.NewRecorder()
+		mw(nextHandler).ServeHTTP(rr, req)
+
+		assert.True(t, nextCalled, "Next handler should be called for allowed request")
+		assert.Equal(t, http.StatusOK, rr.Code)
+
+		// Verify the payload sent to webhook
+		assert.Equal(t, webhook.APIVersion, lastRequest.Version)
+		assert.NotEmpty(t, lastRequest.UID)
+		assert.NotZero(t, lastRequest.Timestamp)
+		assert.JSONEq(t, string(reqBody), string(lastRequest.MCPRequest))
+
+		require.NotNil(t, lastRequest.Context)
+		assert.Equal(t, "test-server", lastRequest.Context.ServerName)
+		assert.Equal(t, "stdio", lastRequest.Context.Transport)
+		assert.Equal(t, "192.168.1.1:1234", lastRequest.Context.SourceIP)
+
+		require.NotNil(t, lastRequest.Principal)
+		assert.Equal(t, "user-1", lastRequest.Principal.Subject)
+		assert.Equal(t, "user@example.com", lastRequest.Principal.Email)
+		assert.Equal(t, []string{"admin"}, lastRequest.Principal.Groups)
+	})
+
+	t.Run("Allowed Request - No Identity", func(t *testing.T) {
+		mockResponse.Allowed = true
+
+		reqBody := []byte(`{"jsonrpc":"2.0","method":"tools/call","id":1}`)
+		req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(reqBody))
+		ctx := context.WithValue(req.Context(), mcp.MCPRequestContextKey, &mcp.ParsedMCPRequest{})
+		req = req.WithContext(ctx)
+
+		var nextCalled bool
+		nextHandler := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+			nextCalled = true
+		})
+
+		rr := httptest.NewRecorder()
+		mw(nextHandler).ServeHTTP(rr, req)
+
+		assert.True(t, nextCalled)
+		assert.Equal(t, http.StatusOK, rr.Code)
+		assert.Nil(t, lastRequest.Principal, "Principal should be nil")
+	})
+
+	t.Run("Denied Request", func(t *testing.T) {
+		mockResponse.Allowed = false
+		mockResponse.Message = "Custom deny message"
+		mockResponse.Code = http.StatusForbidden
+
+		reqBody := []byte(`{"jsonrpc":"2.0","method":"tools/call","id":1}`)
+		req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(reqBody))
+
+		ctx := context.WithValue(req.Context(), mcp.MCPRequestContextKey, &mcp.ParsedMCPRequest{})
+		req = req.WithContext(ctx)
+
+		var nextCalled bool
+		nextHandler := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+			nextCalled = true
+		})
+
+		rr := httptest.NewRecorder()
+		mw(nextHandler).ServeHTTP(rr, req)
+
+		assert.False(t, nextCalled, "Next handler should not be called for denied request")
+		assert.Equal(t, http.StatusForbidden, rr.Code)
+
+		// The error response is a JSON-RPC format
+		var errResp map[string]interface{}
+		err := json.Unmarshal(rr.Body.Bytes(), &errResp)
+		require.NoError(t, err)
+
+		errObj, ok := errResp["Error"].(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, float64(http.StatusForbidden), errObj["code"])
+		assert.Equal(t, "Request denied by policy", errObj["message"])
+	})
+
+	t.Run("Denied Request - Out-of-Range Code Defaults to 403", func(t *testing.T) {
+		mockResponse.Allowed = false
+		mockResponse.Message = "blocked"
+		mockResponse.Code = 200 // out-of-range (not 4xx-5xx) should default to 403
+
+		reqBody := []byte(`{"jsonrpc":"2.0","method":"tools/call","id":1}`)
+		req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(reqBody))
+		ctx := context.WithValue(req.Context(), mcp.MCPRequestContextKey, &mcp.ParsedMCPRequest{})
+		req = req.WithContext(ctx)
+
+		var nextCalled bool
+		nextHandler := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+			nextCalled = true
+		})
+
+		rr := httptest.NewRecorder()
+		mw(nextHandler).ServeHTTP(rr, req)
+
+		assert.False(t, nextCalled)
+		assert.Equal(t, http.StatusForbidden, rr.Code, "Out-of-range webhook code should be normalized to 403")
+	})
+
+	t.Run("Webhook Error - Fail Policy", func(t *testing.T) {
+		// Create a client pointing to a closed port to generate connection error
+		cfg := config[0]
+		cfg.URL = closedServerURL
+		cfg.FailurePolicy = webhook.FailurePolicyFail
+
+		failClient, err := webhook.NewClient(cfg, webhook.TypeValidating, nil)
+		require.NoError(t, err)
+
+		failMw := createValidatingHandler([]clientExecutor{{client: failClient, config: cfg}}, "test", "stdio")
+
+		reqBody := []byte(`{"jsonrpc":"2.0","method":"tools/call","id":1}`)
+		req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(reqBody))
+		ctx := context.WithValue(req.Context(), mcp.MCPRequestContextKey, &mcp.ParsedMCPRequest{})
+		req = req.WithContext(ctx)
+
+		var nextCalled bool
+		nextHandler := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+			nextCalled = true
+		})
+
+		rr := httptest.NewRecorder()
+		failMw(nextHandler).ServeHTTP(rr, req)
+
+		assert.False(t, nextCalled, "Next handler should not be called on evaluation error with fail policy")
+		assert.Equal(t, http.StatusForbidden, rr.Code)
+	})
+
+	t.Run("Webhook Error - Ignore Policy", func(t *testing.T) {
+		// Create a client pointing to a closed port to generate connection error
+		cfg := config[0]
+		cfg.URL = closedServerURL
+		cfg.FailurePolicy = webhook.FailurePolicyIgnore
+
+		ignoreClient, err := webhook.NewClient(cfg, webhook.TypeValidating, nil)
+		require.NoError(t, err)
+
+		ignoreMw := createValidatingHandler([]clientExecutor{{client: ignoreClient, config: cfg}}, "test", "stdio")
+
+		reqBody := []byte(`{"jsonrpc":"2.0","method":"tools/call","id":1}`)
+		req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(reqBody))
+		ctx := context.WithValue(req.Context(), mcp.MCPRequestContextKey, &mcp.ParsedMCPRequest{})
+		req = req.WithContext(ctx)
+
+		var nextCalled bool
+		nextHandler := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+			nextCalled = true
+		})
+
+		rr := httptest.NewRecorder()
+		ignoreMw(nextHandler).ServeHTTP(rr, req)
+
+		assert.True(t, nextCalled, "Next handler should be called on evaluation error with ignore policy")
+		assert.Equal(t, http.StatusOK, rr.Code)
+	})
+
+	t.Run("Skip Non-MCP Requests", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/health", nil)
+		// Missing parsed MCP request in context
+
+		var nextCalled bool
+		nextHandler := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+			nextCalled = true
+		})
+
+		rr := httptest.NewRecorder()
+		mw(nextHandler).ServeHTTP(rr, req)
+
+		assert.True(t, nextCalled, "Next handler should be called for non-MCP requests")
+		assert.Equal(t, http.StatusOK, rr.Code)
+	})
+}
+
+func TestMiddlewareParams_Validate(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		params  MiddlewareParams
+		wantErr bool
+	}{
+		{
+			name:    "valid",
+			params:  MiddlewareParams{Webhooks: []webhook.Config{{Name: "a", URL: "https://a", Timeout: webhook.DefaultTimeout, FailurePolicy: webhook.FailurePolicyFail}}},
+			wantErr: false,
+		},
+		{
+			name:    "empty webhooks",
+			params:  MiddlewareParams{},
+			wantErr: true,
+		},
+		{
+			name:    "invalid webhook config",
+			params:  MiddlewareParams{Webhooks: []webhook.Config{{Name: ""}}}, // Missing name
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := tt.params.Validate()
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+type mockRunner struct {
+	types.MiddlewareRunner
+	middlewares map[string]types.Middleware
+}
+
+func (m *mockRunner) AddMiddleware(name string, mw types.Middleware) {
+	if m.middlewares == nil {
+		m.middlewares = make(map[string]types.Middleware)
+	}
+	m.middlewares[name] = mw
+}
+
+func TestCreateMiddleware(t *testing.T) {
+	t.Parallel()
+	runner := &mockRunner{}
+
+	// Create valid config JSON
+	params := FactoryMiddlewareParams{
+		MiddlewareParams: MiddlewareParams{
+			Webhooks: []webhook.Config{
+				{
+					Name:          "test",
+					URL:           "https://test.com/hook",
+					Timeout:       webhook.DefaultTimeout,
+					FailurePolicy: webhook.FailurePolicyIgnore,
+				},
+			},
+		},
+		ServerName: "test-server",
+		Transport:  "stdio",
+	}
+	paramsJSON, err := json.Marshal(params)
+	require.NoError(t, err)
+
+	mwConfig := &types.MiddlewareConfig{
+		Type:       MiddlewareType,
+		Parameters: paramsJSON,
+	}
+
+	err = CreateMiddleware(mwConfig, runner)
+	require.NoError(t, err)
+
+	require.Contains(t, runner.middlewares, MiddlewareType)
+	mw := runner.middlewares[MiddlewareType]
+
+	// Test Handler/Close methods to get 100% coverage
+	require.NotNil(t, mw.Handler())
+	require.NoError(t, mw.Close())
+}
+
+//nolint:paralleltest // Shares a mock HTTP server and lastRequest state
+func TestMultiWebhookChain(t *testing.T) {
+	// Setup mock webhook servers
+	var lastRequest1, lastRequest2 webhook.Request
+	mockResponse1 := webhook.Response{Version: webhook.APIVersion, UID: "resp-uid-1", Allowed: true}
+	mockResponse2 := webhook.Response{Version: webhook.APIVersion, UID: "resp-uid-2", Allowed: true}
+
+	server1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&lastRequest1)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(mockResponse1)
+	}))
+	defer server1.Close()
+
+	server2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&lastRequest2)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(mockResponse2)
+	}))
+	defer server2.Close()
+
+	// Create middleware handler with two webhooks
+	config := []webhook.Config{
+		{
+			Name:          "hook-1",
+			URL:           server1.URL,
+			Timeout:       webhook.DefaultTimeout,
+			FailurePolicy: webhook.FailurePolicyFail,
+			TLSConfig:     &webhook.TLSConfig{InsecureSkipVerify: true},
+		},
+		{
+			Name:          "hook-2",
+			URL:           server2.URL,
+			Timeout:       webhook.DefaultTimeout,
+			FailurePolicy: webhook.FailurePolicyFail,
+			TLSConfig:     &webhook.TLSConfig{InsecureSkipVerify: true},
+		},
+	}
+
+	var executors []clientExecutor
+	for _, cfg := range config {
+		client, err := webhook.NewClient(cfg, webhook.TypeValidating, nil)
+		require.NoError(t, err)
+		executors = append(executors, clientExecutor{client: client, config: cfg})
+	}
+	mw := createValidatingHandler(executors, "test-server", "stdio")
+
+	createReq := func() *http.Request {
+		reqBody := []byte(`{"jsonrpc":"2.0","method":"tools/call","id":1}`)
+		req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(reqBody))
+		ctx := context.WithValue(req.Context(), mcp.MCPRequestContextKey, &mcp.ParsedMCPRequest{})
+		return req.WithContext(ctx)
+	}
+
+	t.Run("Both Allow", func(t *testing.T) {
+		mockResponse1.Allowed = true
+		mockResponse2.Allowed = true
+		lastRequest1 = webhook.Request{}
+		lastRequest2 = webhook.Request{}
+
+		var nextCalled bool
+		nextHandler := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) { nextCalled = true })
+
+		rr := httptest.NewRecorder()
+		mw(nextHandler).ServeHTTP(rr, createReq())
+
+		assert.True(t, nextCalled, "Next handler should be called when both webhooks allow")
+		assert.Equal(t, http.StatusOK, rr.Code)
+		assert.NotEmpty(t, lastRequest1.UID, "First webhook should be called")
+		assert.NotEmpty(t, lastRequest2.UID, "Second webhook should be called")
+	})
+
+	t.Run("First Denies, Second Skipped", func(t *testing.T) {
+		mockResponse1.Allowed = false
+		mockResponse1.Message = "Denied by hook-1"
+		mockResponse2.Allowed = true // shouldn't matter
+		lastRequest1 = webhook.Request{}
+		lastRequest2 = webhook.Request{} // reset
+
+		var nextCalled bool
+		nextHandler := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) { nextCalled = true })
+
+		rr := httptest.NewRecorder()
+		mw(nextHandler).ServeHTTP(rr, createReq())
+
+		assert.False(t, nextCalled, "Next handler should not be called")
+		assert.Equal(t, http.StatusForbidden, rr.Code)
+		assert.NotEmpty(t, lastRequest1.UID, "First webhook should be called")
+		assert.Empty(t, lastRequest2.UID, "Second webhook should NOT be called")
+
+		// Verify error response
+		var errResp map[string]interface{}
+		_ = json.Unmarshal(rr.Body.Bytes(), &errResp)
+		errObj := errResp["Error"].(map[string]interface{})
+		assert.Equal(t, "Request denied by policy", errObj["message"])
+	})
+
+	t.Run("First Allows, Second Denies", func(t *testing.T) {
+		mockResponse1.Allowed = true
+		mockResponse2.Allowed = false
+		mockResponse2.Message = "Denied by hook-2"
+		lastRequest1 = webhook.Request{}
+		lastRequest2 = webhook.Request{}
+
+		var nextCalled bool
+		nextHandler := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) { nextCalled = true })
+
+		rr := httptest.NewRecorder()
+		mw(nextHandler).ServeHTTP(rr, createReq())
+
+		assert.False(t, nextCalled, "Next handler should not be called")
+		assert.Equal(t, http.StatusForbidden, rr.Code)
+		assert.NotEmpty(t, lastRequest1.UID, "First webhook should be called")
+		assert.NotEmpty(t, lastRequest2.UID, "Second webhook should be called")
+
+		// Verify error response
+		var errResp map[string]interface{}
+		_ = json.Unmarshal(rr.Body.Bytes(), &errResp)
+		errObj := errResp["Error"].(map[string]interface{})
+		assert.Equal(t, "Request denied by policy", errObj["message"])
+	})
+
+	t.Run("Mixed Failure Policies: Err Ignore -> Allow", func(t *testing.T) {
+		// Clone configs, set hook-1 to fail-open (ignore) and use bad URL
+		cfg1 := config[0]
+		cfg1.FailurePolicy = webhook.FailurePolicyIgnore
+		cfg1.URL = closedServerURL // Force connection error
+		client1, _ := webhook.NewClient(cfg1, webhook.TypeValidating, nil)
+
+		cfg2 := config[1]
+		client2, _ := webhook.NewClient(cfg2, webhook.TypeValidating, nil)
+
+		mixedExecutors := []clientExecutor{
+			{client: client1, config: cfg1},
+			{client: client2, config: cfg2},
+		}
+		mixedMw := createValidatingHandler(mixedExecutors, "test-server", "stdio")
+
+		mockResponse2.Allowed = true
+		lastRequest2 = webhook.Request{}
+
+		var nextCalled bool
+		nextHandler := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) { nextCalled = true })
+
+		rr := httptest.NewRecorder()
+		mixedMw(nextHandler).ServeHTTP(rr, createReq())
+
+		assert.True(t, nextCalled, "Next handler should be called because error on first is ignored, and second allows")
+		assert.Equal(t, http.StatusOK, rr.Code)
+		assert.NotEmpty(t, lastRequest2.UID, "Second webhook should be called")
+	})
+}


### PR DESCRIPTION
## Overview
This PR implements **Phase 2** of the Dynamic Webhook Middleware feature by introducing the **Validating Webhook Middleware**. Validating webhooks allow ToolHive to call external HTTP services (such as policy engines, bespoke approval workflows, or rate limiters) to strictly evaluate, approve, or deny MCP requests before they reach backend tools.

Fixes #3397 

## Key Changes

### 1. `pkg/webhook/validating` Package
- **Configuration (`config.go`)**: Added `MiddlewareParams` struct supporting a chain of `webhook.Config` elements. Includes setup validation requiring >0 webhooks to be explicitly declared.
- **Middleware Handler (`middleware.go`)**: 
  - Implementation of the ToolHive `types.Middleware` interface factory.
  - Automatically intercepts MCP POST requests (post-parsing).
  - Composes the HTTP evaluation payload, embedding the original raw JSON-RPC `MCPRequest`, extracting User Principal attributes directly from the `auth.Identity` context, and recording the request Origin Context (`SourceIP`, `Transport`, `ServerName`).
  - **Evaluation Engine**: Invokes all configured webhooks sequentially. It eagerly denies the entire request (HTTP 403) providing an optional custom error message as soon as any webhook responds with `allowed: false`.
  - **Failure Policies**: Accurately respects `FailurePolicyFail` (fail-closed, blocks request on network/server errors) and `FailurePolicyIgnore` (fail-open, logs a warning on exception but continues pipeline).
- **Test Suite (`middleware_test.go`)**: Complete parallelized test-suite covering `Allowed=true` paths, denial paths, both failure policies, connection errors, and safe bypass for non-MCP calls. (Test Coverage sits above **75%**).

### 2. Runner Integration (`pkg/runner`)
- **`middleware.go`**: 
  - Registered `validating.CreateMiddleware` inside `GetSupportedMiddlewareFactories`.
  - Added dedicated configuration wiring (`addValidatingWebhookMiddleware`) securely positioning the validating evaluation block sequentially **after** `mcp-parser` but precisely **before** auditing (`telemetry`, `authz`). Thus blocking unverified telemetry pollution or unauthorized execution.
- **`config.go`**:
  - Expanded the global `RunConfig` exposing the `ValidatingWebhooks []webhook.Config` slice.

## Testing Performed
- Run `go test ./pkg/webhook/validating/... ./pkg/runner/...` (All unit tests passing).
- Run `task lint` / `task lint-fix` against the overall project (clean).

## Type of change

<!-- REQUIRED. Check exactly one. -->

- [ ] Bug fix
- [x] New feature
- [x] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

<!--
REQUIRED. Check every verification step you actually ran.
You MUST check at least one item. If you only did manual testing,
describe exactly what you tested below the checkbox.
-->

- [x] Unit tests (`task test`)
- [x] E2E tests (`task test-e2e`)
- [x] Linting (`task lint-fix`)
- [ ] Manual testing (describe below)

