### PR TITLE
Map mcp-go sentinel errors and poll registry version for timely status reports

### DIFF
--- a/pkg/vmcp/client/client.go
+++ b/pkg/vmcp/client/client.go
@@ -321,7 +321,23 @@ func wrapBackendError(err error, backendID string, operation string) error {
 			vmcp.ErrTimeout, operation, backendID, err)
 	}
 
-	// 4. String-based detection: Fall back to pattern matching for cases where
+	// 4. mcp-go transport sentinel errors: check before string-based fallbacks
+	// to ensure accurate classification of protocol-level errors.
+	if errors.Is(err, transport.ErrUnauthorized) {
+		return fmt.Errorf("%w: failed to %s for backend %s: %v",
+			vmcp.ErrAuthenticationFailed, operation, backendID, err)
+	}
+	// ErrLegacySSEServer is returned for any 4xx (except 401) on initialize POST.
+	// This includes 403 (auth rejection) and 404/405 (endpoint not found/method not allowed).
+	// We cannot distinguish auth failures from routing errors without the raw status code,
+	// so we surface a clear message and classify as backend unavailable to allow recovery.
+	if errors.Is(err, transport.ErrLegacySSEServer) {
+		const legacyMsg = "server rejected MCP initialize — possible auth rejection or legacy SSE-only server"
+		return fmt.Errorf("%w: failed to %s for backend %s (%s): %v",
+			vmcp.ErrBackendUnavailable, operation, backendID, legacyMsg, err)
+	}
+
+	// 5. String-based detection: Fall back to pattern matching for cases where
 	// we don't have structured error types (MCP SDK, HTTP libraries with embedded status codes)
 	// Authentication errors (401, 403, auth failures)
 	if vmcp.IsAuthenticationError(err) {

--- a/pkg/vmcp/client/client_test.go
+++ b/pkg/vmcp/client/client_test.go
@@ -8,11 +8,13 @@ package client
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/mark3labs/mcp-go/client"
+	"github.com/mark3labs/mcp-go/client/transport"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/propagation"
@@ -767,6 +769,73 @@ func TestResolveAuthStrategy(t *testing.T) {
 				if tt.checkStrategy != nil {
 					tt.checkStrategy(t, strategy)
 				}
+			}
+		})
+	}
+}
+
+// TestWrapBackendError verifies that wrapBackendError maps mcp-go transport sentinel
+// errors to the correct vmcp sentinel errors for downstream health monitoring.
+func TestWrapBackendError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		err             error
+		wantSentinel    error
+		wantMsgContains string
+	}{
+		{
+			name:         "nil error returns nil",
+			err:          nil,
+			wantSentinel: nil,
+		},
+		{
+			// mcp-go returns ErrUnauthorized for 401 on initialize POST.
+			// Must map to ErrAuthenticationFailed so health monitors classify
+			// the backend as BackendUnauthenticated, not BackendUnhealthy.
+			name:         "ErrUnauthorized maps to ErrAuthenticationFailed",
+			err:          transport.ErrUnauthorized,
+			wantSentinel: vmcp.ErrAuthenticationFailed,
+		},
+		{
+			// errors.Is traverses the error chain, so wrapping ErrUnauthorized
+			// in another error must still produce ErrAuthenticationFailed.
+			name:         "wrapped ErrUnauthorized maps to ErrAuthenticationFailed",
+			err:          fmt.Errorf("transport layer: %w", transport.ErrUnauthorized),
+			wantSentinel: vmcp.ErrAuthenticationFailed,
+		},
+		{
+			// mcp-go returns ErrLegacySSEServer for non-401 4xx on initialize POST
+			// (e.g. 403, 404, 405). Classified as backend unavailable so the health
+			// monitor can recover if the backend is later corrected.
+			name:            "ErrLegacySSEServer maps to ErrBackendUnavailable",
+			err:             transport.ErrLegacySSEServer,
+			wantSentinel:    vmcp.ErrBackendUnavailable,
+			wantMsgContains: "legacy SSE",
+		},
+		{
+			name:         "context.DeadlineExceeded maps to ErrTimeout",
+			err:          context.DeadlineExceeded,
+			wantSentinel: vmcp.ErrTimeout,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := wrapBackendError(tt.err, "test-backend", "initialize")
+
+			if tt.err == nil {
+				assert.NoError(t, result)
+				return
+			}
+
+			require.Error(t, result)
+			assert.ErrorIs(t, result, tt.wantSentinel)
+			if tt.wantMsgContains != "" {
+				assert.Contains(t, result.Error(), tt.wantMsgContains)
 			}
 		})
 	}

--- a/pkg/vmcp/errors.go
+++ b/pkg/vmcp/errors.go
@@ -98,9 +98,12 @@ func IsAuthenticationError(err error) bool {
 		return true
 	}
 
-	// Check for HTTP 401/403 status codes with context
-	// Match patterns like "401 Unauthorized", "HTTP 401", "status code 401"
+	// Check for HTTP 401/403 status codes with context.
+	// Match patterns like "401 Unauthorized", "HTTP 401", "status code 401".
+	// Also match mcp-go's ErrUnauthorized = "unauthorized (401)" which uses
+	// reversed order compared to the "401 unauthorized" pattern above.
 	if strings.Contains(errLower, "401 unauthorized") ||
+		strings.Contains(errLower, "unauthorized (401)") ||
 		strings.Contains(errLower, "403 forbidden") ||
 		strings.Contains(errLower, "http 401") ||
 		strings.Contains(errLower, "http 403") ||

--- a/pkg/vmcp/health/checker_test.go
+++ b/pkg/vmcp/health/checker_test.go
@@ -334,6 +334,9 @@ func TestIsAuthenticationError(t *testing.T) {
 		{name: "request unauthorized", err: errors.New("request unauthorized"), expectErr: true},
 		{name: "access denied", err: errors.New("access denied"), expectErr: true},
 
+		// mcp-go ErrUnauthorized format: "unauthorized (401)" (reversed order vs "401 unauthorized")
+		{name: "unauthorized (401) - mcp-go ErrUnauthorized format", err: errors.New("unauthorized (401)"), expectErr: true},
+
 		// Negative cases - should NOT be detected as auth errors
 		{name: "connection refused", err: errors.New("connection refused"), expectErr: false},
 		{name: "timeout", err: errors.New("request timeout"), expectErr: false},
@@ -514,6 +517,13 @@ func TestHealthChecker_CheckHealth_AuthErrorsCategorizesAsUnauthenticated(t *tes
 		{
 			name: "wrapped sentinel auth error",
 			err:  fmt.Errorf("client credentials grant failed: %w", vmcp.ErrAuthenticationFailed),
+		},
+		{
+			// transport.ErrUnauthorized is wrapped with ErrAuthenticationFailed in wrapBackendError,
+			// so a 401 from the mcp-go transport layer reaches health monitoring as
+			// BackendUnauthenticated instead of BackendUnhealthy.
+			name: "mcp-go ErrUnauthorized wrapped as ErrAuthenticationFailed by wrapBackendError",
+			err:  fmt.Errorf("%w: failed to initialize for backend my-backend: unauthorized (401)", vmcp.ErrAuthenticationFailed),
 		},
 	}
 

--- a/pkg/vmcp/server/status_reporting.go
+++ b/pkg/vmcp/server/status_reporting.go
@@ -12,6 +12,10 @@ import (
 	vmcpstatus "github.com/stacklok/toolhive/pkg/vmcp/status"
 )
 
+// versionPollInterval is how often to check the registry version for changes.
+// Exposed as a package-level var so tests can set a shorter interval.
+var versionPollInterval = 2 * time.Second
+
 // StatusReportingConfig configures periodic status reporting.
 type StatusReportingConfig struct {
 	// Interval is how often to report status.
@@ -67,7 +71,24 @@ func (s *Server) periodicStatusReporting(ctx context.Context, config StatusRepor
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
-	// Report status immediately after initial health checks complete
+	// Only start the version-polling ticker when the registry supports dynamic
+	// discovery. For static registries the ticker would fire every 2s only to
+	// type-assert and continue, wasting wakeups in the steady state.
+	dynamicReg, isDynamic := s.backendRegistry.(vmcp.DynamicRegistry)
+	var versionTickerC <-chan time.Time
+	var lastRegistryVersion uint64
+	if isDynamic {
+		versionTicker := time.NewTicker(versionPollInterval)
+		defer versionTicker.Stop()
+		versionTickerC = versionTicker.C
+	}
+
+	// Snapshot the version before reporting so that any mutation that races with
+	// reportStatus is visible to the version ticker on the next poll cycle, rather
+	// than being silently absorbed by a post-report version update.
+	if isDynamic {
+		lastRegistryVersion = dynamicReg.Version()
+	}
 	s.reportStatus(ctx, config.Reporter)
 
 	for {
@@ -77,7 +98,18 @@ func (s *Server) periodicStatusReporting(ctx context.Context, config StatusRepor
 			return
 
 		case <-ticker.C:
+			if isDynamic {
+				lastRegistryVersion = dynamicReg.Version()
+			}
 			s.reportStatus(ctx, config.Reporter)
+
+		case <-versionTickerC:
+			if v := dynamicReg.Version(); v != lastRegistryVersion {
+				slog.Debug("backend registry changed, triggering immediate status report",
+					"old_version", lastRegistryVersion, "new_version", v)
+				lastRegistryVersion = v
+				s.reportStatus(ctx, config.Reporter)
+			}
 		}
 	}
 }

--- a/pkg/vmcp/server/status_reporting_test.go
+++ b/pkg/vmcp/server/status_reporting_test.go
@@ -132,6 +132,88 @@ func TestDefaultStatusReportingConfig(t *testing.T) {
 	assert.Nil(t, config.Reporter, "Default reporter should be nil")
 }
 
+// testDynamicRegistry is a minimal vmcp.DynamicRegistry for testing version-change detection.
+type testDynamicRegistry struct {
+	mu      sync.Mutex
+	version uint64
+}
+
+func (r *testDynamicRegistry) Version() uint64 {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.version
+}
+
+func (*testDynamicRegistry) List(_ context.Context) []vmcp.Backend         { return nil }
+func (*testDynamicRegistry) Get(_ context.Context, _ string) *vmcp.Backend { return nil }
+func (*testDynamicRegistry) Count() int                                    { return 0 }
+
+func (r *testDynamicRegistry) Upsert(_ vmcp.Backend) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.version++
+	return nil
+}
+
+func (r *testDynamicRegistry) Remove(_ string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.version++
+	return nil
+}
+
+// TestPeriodicStatusReporting_ReactsToVersionChange verifies that when the backend
+// registry version changes, an immediate status report is triggered via the version-polling
+// ticker rather than waiting for the full reporting interval.
+func TestPeriodicStatusReporting_ReactsToVersionChange(t *testing.T) {
+	t.Parallel()
+
+	// Speed up the version-polling ticker so the test completes in milliseconds.
+	orig := versionPollInterval
+	versionPollInterval = 10 * time.Millisecond
+	t.Cleanup(func() { versionPollInterval = orig })
+
+	reporter := &mockReporter{}
+	reg := &testDynamicRegistry{}
+	server := &Server{
+		backendRegistry: reg,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	// Use a long interval so the periodic tick never fires during the test.
+	config := StatusReportingConfig{
+		Interval: 30 * time.Second,
+		Reporter: reporter,
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		server.periodicStatusReporting(ctx, config)
+	}()
+
+	// Wait for the initial immediate report before triggering a version change.
+	require.Eventually(t, func() bool {
+		return reporter.getCallCount() >= 1
+	}, time.Second, 5*time.Millisecond, "expected initial immediate status report")
+
+	countAfterInit := reporter.getCallCount()
+
+	// Trigger a version bump to simulate a backend being removed from the registry.
+	require.NoError(t, reg.Remove("some-backend"))
+
+	// The version-polling ticker fires every 10ms in tests; allow up to 200ms.
+	require.Eventually(t, func() bool {
+		return reporter.getCallCount() > countAfterInit
+	}, 200*time.Millisecond, 5*time.Millisecond,
+		"version change should trigger an immediate status report without waiting for the 30s interval")
+
+	cancel()
+	<-done
+}
+
 // TestReportStatus tests the reportStatus method.
 func TestReportStatus(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION

## Summary

<!--
REQUIRED. You MUST explain:
1. WHY this change is needed (the problem or motivation)
2. WHAT changed (concise bullet points)

The diff shows the code — your summary must provide the context a reviewer
needs to understand the purpose without reading the diff first.
-->

- Map transport.ErrUnauthorized to ErrAuthenticationFailed and transport.ErrLegacySSEServer to ErrBackendUnavailable in wrapBackendError, before the string-based fallback. This ensures 401 responses from mcp-go reach health monitoring as BackendUnauthenticated rather than BackendUnhealthy.
- Add "unauthorized (401)" pattern to IsAuthenticationError to match mcp-go's ErrUnauthorized string format (reversed order vs "401 unauthorized").
- Poll DynamicRegistry.Version() every 2s in periodicStatusReporting and trigger an immediate status report when the version changes, so backend additions/removals are reflected without waiting for the full 30s interval.

<!--
Link related issues. Use "Closes" or "Fixes" to auto-close on merge.
Remove this line if there is no related issue.
-->

Fixes #4278 

## Type of change

<!-- REQUIRED. Check exactly one. -->

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

<!--
REQUIRED. Check every verification step you actually ran.
You MUST check at least one item. If you only did manual testing,
describe exactly what you tested below the checkbox.
-->

- [x] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [x] Linting (`task lint-fix`)
- [ ] Manual testing (describe below)

## Changes

<!--
Optional — include for PRs touching more than a few files to help
reviewers navigate the diff. Remove this entire section for small PRs.
-->

| File | Change |
|------|--------|
|      |        |

## Does this introduce a user-facing change?

<!--
If yes, describe the change from the user's perspective. This helps with release notes.
If no, write "No".
Remove this section entirely if not applicable.
-->

## Special notes for reviewers

<!--
Optional — call out anything non-obvious: tricky logic, known limitations,
areas where you'd like extra scrutiny, or follow-up work planned.
Remove this section if not needed.
-->
