### PR TITLE
Guard PID reset against replacement process

### DIFF
--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -459,8 +459,10 @@ func (r *Runner) Run(ctx context.Context) error {
 			slog.Warn("failed to cleanup telemetry", "error", err)
 		}
 
-		// Remove the PID file if it exists
-		if err := r.statusManager.ResetWorkloadPID(cleanupCtx, r.Config.BaseName); err != nil {
+		// Remove the PID file if it exists. Use PID-guarded reset so that a
+		// dying process does not clobber the PID of a replacement process that
+		// started in the meantime (e.g. during thv rm + thv run).
+		if err := r.statusManager.ResetWorkloadPIDIfMatch(cleanupCtx, r.Config.BaseName, os.Getpid()); err != nil {
 			slog.Warn("failed to reset workload PID", "container", r.Config.ContainerName, "error", err)
 		}
 
@@ -538,8 +540,9 @@ func (r *Runner) Run(ctx context.Context) error {
 		stopMCPServer("Context cancelled")
 	case <-doneCh:
 		// The transport has already been stopped (likely by the container exit)
-		// Remove the old PID from the state file
-		if err := r.statusManager.ResetWorkloadPID(ctx, r.Config.BaseName); err != nil {
+		// Remove the old PID from the state file. Use PID-guarded reset to
+		// avoid clobbering a replacement process's PID.
+		if err := r.statusManager.ResetWorkloadPIDIfMatch(ctx, r.Config.BaseName, os.Getpid()); err != nil {
 			slog.Warn("failed to reset workload PID", "workload", r.Config.BaseName, "error", err)
 		}
 

--- a/pkg/workloads/statuses/file_status.go
+++ b/pkg/workloads/statuses/file_status.go
@@ -464,6 +464,45 @@ func (f *fileStatusManager) ResetWorkloadPID(ctx context.Context, workloadName s
 	return f.SetWorkloadPID(ctx, workloadName, 0)
 }
 
+// ResetWorkloadPIDIfMatch resets the PID of a workload to 0 only if the
+// current PID in the status file matches expectedPID. This prevents a dying
+// process from clobbering a PID written by a replacement process.
+func (f *fileStatusManager) ResetWorkloadPIDIfMatch(ctx context.Context, workloadName string, expectedPID int) error {
+	// As a side effect, get rid of the PID file if any exists
+	if err := removePIDFile(workloadName); err != nil {
+		slog.Debug("no PID for workload was removed", "workload", workloadName)
+	}
+
+	err := f.withFileLock(ctx, workloadName, func(statusFilePath string) error {
+		if _, err := os.Stat(statusFilePath); os.IsNotExist(err) {
+			return nil
+		} else if err != nil {
+			return fmt.Errorf("failed to check status file for workload %s: %w", workloadName, err)
+		}
+
+		statusFile, err := f.readStatusFile(statusFilePath)
+		if err != nil {
+			return fmt.Errorf("failed to read status for workload %s: %w", workloadName, err)
+		}
+
+		if statusFile.ProcessID != expectedPID {
+			slog.Debug("skipping PID reset: current PID does not match",
+				"workload", workloadName,
+				"current_pid", statusFile.ProcessID,
+				"expected_pid", expectedPID)
+			return nil
+		}
+
+		statusFile.ProcessID = 0
+		statusFile.UpdatedAt = time.Now()
+		return f.writeStatusFile(statusFilePath, *statusFile)
+	})
+	if err != nil {
+		slog.Error("error resetting workload PID", "workload", workloadName, "error", err)
+	}
+	return err
+}
+
 // GetWorkloadPID retrieves the PID of a workload from its status file.
 func (f *fileStatusManager) GetWorkloadPID(ctx context.Context, workloadName string) (int, error) {
 	var pid int

--- a/pkg/workloads/statuses/file_status_test.go
+++ b/pkg/workloads/statuses/file_status_test.go
@@ -1682,6 +1682,76 @@ func TestFileStatusManager_ResetWorkloadPID_WithSlashes(t *testing.T) {
 	assert.Equal(t, 0, statusFileData.ProcessID) // PID should be reset to 0
 }
 
+func TestFileStatusManager_ResetWorkloadPIDIfMatch_MatchingPID(t *testing.T) {
+	t.Parallel()
+	tempDir := t.TempDir()
+	manager := &fileStatusManager{baseDir: tempDir}
+	ctx := context.Background()
+
+	// Create a workload and set its PID
+	err := manager.SetWorkloadStatus(ctx, "test-workload", rt.WorkloadStatusRunning, "started")
+	require.NoError(t, err)
+
+	err = manager.SetWorkloadPID(ctx, "test-workload", 12345)
+	require.NoError(t, err)
+
+	// Reset with matching PID — should reset to 0
+	err = manager.ResetWorkloadPIDIfMatch(ctx, "test-workload", 12345)
+	require.NoError(t, err)
+
+	statusFile := filepath.Join(tempDir, "test-workload.json")
+	data, err := os.ReadFile(statusFile)
+	require.NoError(t, err)
+
+	var statusFileData workloadStatusFile
+	err = json.Unmarshal(data, &statusFileData)
+	require.NoError(t, err)
+	assert.Equal(t, 0, statusFileData.ProcessID)
+	assert.Equal(t, rt.WorkloadStatusRunning, statusFileData.Status)
+}
+
+func TestFileStatusManager_ResetWorkloadPIDIfMatch_NonMatchingPID(t *testing.T) {
+	t.Parallel()
+	tempDir := t.TempDir()
+	manager := &fileStatusManager{baseDir: tempDir}
+	ctx := context.Background()
+
+	// Create a workload and set its PID to simulate the new process
+	err := manager.SetWorkloadStatus(ctx, "test-workload", rt.WorkloadStatusRunning, "started")
+	require.NoError(t, err)
+
+	err = manager.SetWorkloadPID(ctx, "test-workload", 99999)
+	require.NoError(t, err)
+
+	// Reset with a different (old) PID — should be a no-op
+	err = manager.ResetWorkloadPIDIfMatch(ctx, "test-workload", 12345)
+	require.NoError(t, err)
+
+	statusFile := filepath.Join(tempDir, "test-workload.json")
+	data, err := os.ReadFile(statusFile)
+	require.NoError(t, err)
+
+	var statusFileData workloadStatusFile
+	err = json.Unmarshal(data, &statusFileData)
+	require.NoError(t, err)
+	assert.Equal(t, 99999, statusFileData.ProcessID) // PID unchanged
+	assert.Equal(t, rt.WorkloadStatusRunning, statusFileData.Status)
+}
+
+func TestFileStatusManager_ResetWorkloadPIDIfMatch_NonExistentWorkload(t *testing.T) {
+	t.Parallel()
+	tempDir := t.TempDir()
+	manager := &fileStatusManager{baseDir: tempDir}
+	ctx := context.Background()
+
+	// Reset for non-existent workload — should be a no-op
+	err := manager.ResetWorkloadPIDIfMatch(ctx, "test-workload", 12345)
+	require.NoError(t, err)
+
+	statusFile := filepath.Join(tempDir, "test-workload.json")
+	require.NoFileExists(t, statusFile)
+}
+
 // TestFileStatusManager_GetWorkload_PIDMigration tests PID migration from legacy PID files to status files
 func TestFileStatusManager_GetWorkload_PIDMigration(t *testing.T) {
 	t.Parallel()

--- a/pkg/workloads/statuses/mocks/mock_status_manager.go
+++ b/pkg/workloads/statuses/mocks/mock_status_manager.go
@@ -115,6 +115,20 @@ func (mr *MockStatusManagerMockRecorder) ResetWorkloadPID(ctx, workloadName any)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetWorkloadPID", reflect.TypeOf((*MockStatusManager)(nil).ResetWorkloadPID), ctx, workloadName)
 }
 
+// ResetWorkloadPIDIfMatch mocks base method.
+func (m *MockStatusManager) ResetWorkloadPIDIfMatch(ctx context.Context, workloadName string, expectedPID int) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ResetWorkloadPIDIfMatch", ctx, workloadName, expectedPID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ResetWorkloadPIDIfMatch indicates an expected call of ResetWorkloadPIDIfMatch.
+func (mr *MockStatusManagerMockRecorder) ResetWorkloadPIDIfMatch(ctx, workloadName, expectedPID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetWorkloadPIDIfMatch", reflect.TypeOf((*MockStatusManager)(nil).ResetWorkloadPIDIfMatch), ctx, workloadName, expectedPID)
+}
+
 // SetWorkloadPID mocks base method.
 func (m *MockStatusManager) SetWorkloadPID(ctx context.Context, workloadName string, pid int) error {
 	m.ctrl.T.Helper()

--- a/pkg/workloads/statuses/noop.go
+++ b/pkg/workloads/statuses/noop.go
@@ -49,6 +49,11 @@ func (*NoopStatusManager) ResetWorkloadPID(_ context.Context, _ string) error {
 	return nil
 }
 
+// ResetWorkloadPIDIfMatch does nothing and returns nil.
+func (*NoopStatusManager) ResetWorkloadPIDIfMatch(_ context.Context, _ string, _ int) error {
+	return nil
+}
+
 // GetWorkloadPID returns 0 and nil error.
 func (*NoopStatusManager) GetWorkloadPID(_ context.Context, _ string) (int, error) {
 	return 0, nil

--- a/pkg/workloads/statuses/status.go
+++ b/pkg/workloads/statuses/status.go
@@ -36,6 +36,11 @@ type StatusManager interface {
 	// ResetWorkloadPID resets the PID of a workload to 0.
 	// This method will do nothing if the workload does not exist.
 	ResetWorkloadPID(ctx context.Context, workloadName string) error
+	// ResetWorkloadPIDIfMatch resets the PID of a workload to 0 only if the
+	// current PID in the status file matches expectedPID. This prevents a
+	// dying process from clobbering the PID written by a replacement process
+	// that started in the meantime.
+	ResetWorkloadPIDIfMatch(ctx context.Context, workloadName string, expectedPID int) error
 	// GetWorkloadPID retrieves the PID of a workload by its name.
 	// Returns 0 if the workload does not exist or if PID is not available.
 	GetWorkloadPID(ctx context.Context, workloadName string) (int, error)
@@ -143,6 +148,13 @@ func (*runtimeStatusManager) SetWorkloadPID(_ context.Context, workloadName stri
 func (*runtimeStatusManager) ResetWorkloadPID(_ context.Context, workloadName string) error {
 	// Noop for runtime status manager
 	slog.Debug("workload PID reset (noop for runtime status manager)", "workload", workloadName)
+	return nil
+}
+
+func (*runtimeStatusManager) ResetWorkloadPIDIfMatch(_ context.Context, workloadName string, expectedPID int) error {
+	// Noop for runtime status manager
+	slog.Debug("workload PID conditional reset (noop for runtime status manager)",
+		"workload", workloadName, "expected_pid", expectedPID)
 	return nil
 }
 


### PR DESCRIPTION
## Summary

- When replacing a server (`thv rm` + `thv run`), the old process's cleanup unconditionally writes `process_id: 0` to the status file after a shutdown timeout (up to 30s). By then, the new process has already written its own PID, so the old process clobbers it. This causes false "desync" reports in monitoring tools.
- Add `ResetWorkloadPIDIfMatch` to `StatusManager` that reads the current PID under the existing file lock and only resets to 0 if it matches the caller's PID. Both cleanup paths in `runner.go` now use this guarded reset.

Fixes #4324

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)
- [x] Manual testing (describe below)

Reproduced the bug with Glean (the only server whose backend holds SSE streams open long enough to trigger the race). Verified that after the fix, the status file PID remains correct after `thv rm` + `thv run` + 35s wait.

## Changes

| File | Change |
|------|--------|
| `pkg/workloads/statuses/status.go` | Add `ResetWorkloadPIDIfMatch` to interface + `runtimeStatusManager` no-op |
| `pkg/workloads/statuses/file_status.go` | Implement PID-guarded reset: read PID under file lock, compare, skip if mismatched |
| `pkg/workloads/statuses/noop.go` | No-op implementation |
| `pkg/workloads/statuses/mocks/mock_status_manager.go` | Regenerated mock |
| `pkg/runner/runner.go` | Both `ResetWorkloadPID` call sites → `ResetWorkloadPIDIfMatch(ctx, name, os.Getpid())` |
| `pkg/workloads/statuses/file_status_test.go` | 3 new tests: matching PID resets, non-matching skips, non-existent is no-op |

## Special notes for reviewers

The existing `ResetWorkloadPID` (unconditional) is kept for backward compatibility. It's still correct for the `stopProcess` path in `manager.go` where the manager just killed the process and wants an unconditional reset. Only the runner's self-cleanup paths need the guarded version.

The file lock (`withFileLock`) ensures the read-compare-write is atomic with respect to other status file operations, preventing TOCTOU races.

Generated with [Claude Code](https://claude.com/claude-code)