### PR TITLE
Increase timeout and add debug logging in lifecycle E2E test

### DIFF
--- a/test/e2e/api_workloads_test.go
+++ b/test/e2e/api_workloads_test.go
@@ -553,11 +553,16 @@ var _ = Describe("Workloads API", Label("api", "api-workloads", "workloads", "e2
 				workloads := listWorkloads(apiServer, true)
 				for _, w := range workloads {
 					if w.Name == workloadName {
+						if w.Status == runtime.WorkloadStatusRemoving {
+							GinkgoWriter.Printf("Workload %q still present with status 'removing', waiting for cleanup...\n", workloadName)
+							return true
+						}
+						GinkgoWriter.Printf("Workload %q still present with status %q\n", workloadName, w.Status)
 						return true
 					}
 				}
 				return false
-			}, 60*time.Second, 2*time.Second).Should(BeFalse(),
+			}, 120*time.Second, 2*time.Second).Should(BeFalse(),
 				"Deleted workload should not appear in list")
 		})
 	})


### PR DESCRIPTION
## Summary

- The workload lifecycle E2E test (`should track workload through create-list-delete lifecycle`) has been flaking in CI because the async container removal via Docker can take longer than 60s under load. The test polls `listWorkloads(all=true)` waiting for the deleted workload to disappear, but the merge logic in `ListWorkloads` includes containers still present in the Docker runtime even after the status file is deleted.
- Doubled the polling timeout from 60s to 120s and added `GinkgoWriter` debug output on each iteration showing the workload's current status, so future failures will clearly indicate whether the workload is stuck in "removing", or some other unexpected state.

Relates to #4077

## Type of change

- [x] Bug fix

## Test plan

- [x] Linting (`task lint-fix`)
- [x] Manual testing (describe below)

Verified the change compiles with `go vet ./test/e2e/...`. The fix targets a CI-only flake in the `api-workloads` E2E test shard — the test logic is unchanged, only the timeout and observability are improved.

## Does this introduce a user-facing change?

No

## Special notes for reviewers

The root cause is a race between async container removal and `ListWorkloads`'s merge logic, which includes runtime containers even after status files are deleted. A deeper fix would involve either increasing `removeContainer()`'s 3s polling timeout or filtering "removing" workloads from the runtime merge. This PR is the quick fix to stop the flake; #4077 tracks broader E2E debuggability improvements.

Generated with [Claude Code](https://claude.com/claude-code)