### PR TITLE
Improve E2E test debuggability in CI

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -133,6 +133,5 @@ jobs:
         with:
           name: ${{ matrix.artifact }}
           path: |
-            test/e2e/ginkgo-report.xml
             test/e2e/junit-report.xml
           retention-days: 7

--- a/test/e2e/api_helpers.go
+++ b/test/e2e/api_helpers.go
@@ -7,6 +7,7 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"os/exec"
@@ -224,10 +225,25 @@ func StartServer(config *ServerConfig) *Server {
 	server, err := NewServer(config)
 	ExpectWithOffset(1, err).ToNot(HaveOccurred(), "Failed to start API server")
 
-	// Register cleanup
+	// Dump server logs when a test fails for post-mortem debugging
 	DeferCleanup(func() {
+		if CurrentSpecReport().Failed() {
+			GinkgoWriter.Printf("\n=== thv serve stdout (port %d) ===\n%s\n", server.port, server.GetStdout())
+			GinkgoWriter.Printf("=== thv serve stderr (port %d) ===\n%s\n", server.port, server.GetStderr())
+		}
 		_ = server.Stop()
 	})
 
 	return server
+}
+
+// ExpectStatus reads the response body and asserts the status code,
+// including the response body in the failure message for debugging.
+// The response body is consumed and closed; callers must not read it again.
+func ExpectStatus(resp *http.Response, expected int) {
+	body, _ := io.ReadAll(resp.Body)
+	//nolint:errcheck,gosec // This is just a test
+	resp.Body.Close()
+	ExpectWithOffset(1, resp.StatusCode).To(Equal(expected),
+		fmt.Sprintf("Response body: %s", string(body)))
 }

--- a/test/e2e/run_tests.sh
+++ b/test/e2e/run_tests.sh
@@ -58,9 +58,10 @@ cd "$(dirname "$0")"
 
 # Build ginkgo command with conditional GitHub output flag
 GINKGO_CMD="ginkgo run --timeout=\"$TEST_TIMEOUT\""
+GINKGO_CMD="$GINKGO_CMD --junit-report=junit-report.xml --output-dir=."
 if [ -n "$GITHUB_ACTIONS" ]; then
     echo -e "${GREEN}✓${NC} GitHub Actions detected, enabling GitHub output format"
-    GINKGO_CMD="$GINKGO_CMD --github-output"
+    GINKGO_CMD="$GINKGO_CMD --github-output --vv"
 else
     GINKGO_CMD="$GINKGO_CMD --vv --show-node-events --trace"
 fi


### PR DESCRIPTION
## Summary

- E2E test failures in CI have been hard to diagnose because response bodies aren't logged, `thv serve` output isn't captured, and Ginkgo report files are never generated. This addresses all four improvements proposed in #4077.
- Enables JUnit XML report generation, adds verbose output in CI, dumps server logs on failure, and provides an `ExpectStatus` helper for response-body-aware assertions.

Closes #4077

## Type of change

- [x] Bug fix

## Test plan

- [x] Linting (`task lint-fix`)
- [x] Manual testing (describe below)

Verified all changes compile with `go vet ./test/e2e/...`. The JUnit report generation and server log dumping will be validated by the E2E tests in this PR's CI run — if a test fails, the JUnit XML artifact should now be uploaded and server logs should appear in the Ginkgo output.

## Changes

| File | Change |
|------|--------|
| `test/e2e/run_tests.sh` | Add `--junit-report` and `--vv` flags to ginkgo in CI |
| `test/e2e/api_helpers.go` | Dump `thv serve` stdout/stderr on test failure; add `ExpectStatus` helper |
| `.github/workflows/e2e-tests.yml` | Remove never-generated `ginkgo-report.xml` from artifact upload |

## Does this introduce a user-facing change?

No

## Special notes for reviewers

The `ExpectStatus` helper is available for adoption in test files incrementally — existing assertions continue to work. The server log dumping only fires when `CurrentSpecReport().Failed()` is true, so successful test runs produce no extra output.

Generated with [Claude Code](https://claude.com/claude-code)