### PR TITLE
Fix flaky TestWorkflowEngine_ParallelExecution on CI

### DIFF
--- a/pkg/vmcp/composer/workflow_engine_test.go
+++ b/pkg/vmcp/composer/workflow_engine_test.go
@@ -525,16 +525,17 @@ func TestWorkflowEngine_ParallelExecution(t *testing.T) {
 	// Verify all steps executed
 	assert.Len(t, result.Steps, 3, "all 3 steps should have results")
 
-	// Verify parallel execution performance
-	// Sequential would be: 50+50+30 = 130ms
-	// Parallel should be: max(50,50)+30 = 80ms expected
-	// Use 200ms timeout (2.5x expected time) to account for race detector instrumentation overhead
-	assert.Less(t, totalDuration, 200*time.Millisecond,
-		"parallel execution should be faster than sequential")
-
-	// Verify concurrency - at least 2 steps should run concurrently
+	// Verify parallel execution via concurrency tracking rather than wall-clock
+	// thresholds, which are inherently flaky on CI runners with variable load.
+	// The maxConcurrent counter directly proves that steps ran in parallel.
 	assert.GreaterOrEqual(t, int(maxConcurrent), 2,
 		"at least 2 steps should run concurrently")
+
+	// Sanity-check: total time should be well under the sequential sum
+	// (50+50+30 = 130ms). Use a generous 2s ceiling so this only catches
+	// a broken scheduler, not slow CI.
+	assert.Less(t, totalDuration, 2*time.Second,
+		"workflow took unreasonably long (%v), parallelism may be broken", totalDuration)
 
 	// Verify both fetch steps completed before report using sequence numbers
 	require.Len(t, startSeq, 3, "all steps should have start sequences")


### PR DESCRIPTION
## Summary

- `TestWorkflowEngine_ParallelExecution` intermittently fails on CI because it asserts parallel workflow execution completes within 200ms. CI runners (especially with `-race`) have variable scheduling overhead, causing spurious failures (e.g. 218ms on [this run](https://github.com/stacklok/toolhive/actions/runs/23480587013/job/68323114303?pr=4332)).
- Replace the tight wall-clock threshold with the `maxConcurrent` atomic counter as the primary parallelism proof, which directly measures whether steps ran concurrently regardless of machine speed. Keep a generous 2s sanity ceiling and the existing sequence-number ordering assertions for dependency-graph correctness.

## Type of change

- [x] Bug fix

## Test plan

- [x] Manual testing (describe below)

Verified the package compiles cleanly with `go build` and `go vet`. The `-race` test runner is unavailable in the sandbox (no GCC), but the change is a test-only assertion adjustment — no production code affected.

## Does this introduce a user-facing change?

No

Generated with [Claude Code](https://claude.com/claude-code)