### PR TITLE
Preserve prompt message structure through vMCP relay

### DIFF
--- a/pkg/vmcp/client/client.go
+++ b/pkg/vmcp/client/client.go
@@ -772,7 +772,7 @@ func (h *httpBackendClient) GetPrompt(
 	}
 
 	return &vmcp.PromptGetResult{
-		Messages:    conversion.ConvertPromptMessages(result.Messages),
+		Messages:    conversion.ConvertMCPPromptMessages(result.Messages),
 		Description: result.Description,
 		Meta:        conversion.FromMCPMeta(result.Meta),
 	}, nil

--- a/pkg/vmcp/client/meta_integration_test.go
+++ b/pkg/vmcp/client/meta_integration_test.go
@@ -204,8 +204,10 @@ func TestMetaPreservation_GetPrompt(t *testing.T) {
 	assert.Equal(t, "prompt-token-456", result.Meta["progressToken"])
 	assert.Equal(t, "prompt-trace-id", result.Meta["traceId"])
 
-	// Verify prompt content
-	assert.Contains(t, result.Messages, "Hello, World!")
+	// Verify prompt content preserves message structure
+	require.Len(t, result.Messages, 1)
+	assert.Equal(t, "user", result.Messages[0].Role)
+	assert.Equal(t, "Hello, World!", result.Messages[0].Content.Text)
 }
 
 // TestMetaPreservation_ReadResource documents the SDK limitation for resource _meta.

--- a/pkg/vmcp/conversion/content.go
+++ b/pkg/vmcp/conversion/content.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
-	"strings"
 
 	"github.com/mark3labs/mcp-go/mcp"
 
@@ -162,22 +161,29 @@ func ConvertToolInputSchema(schema mcp.ToolInputSchema) map[string]any {
 	return result
 }
 
-// ConvertPromptMessages flattens MCP prompt messages into a single string with
-// the format "[role] text\n". Messages without a role omit the prefix. Only
-// text content is included; non-text content is silently discarded (Phase 1
-// limitation — vmcp.PromptGetResult carries a flat string, not structured messages).
-func ConvertPromptMessages(messages []mcp.PromptMessage) string {
-	var sb strings.Builder
+// ConvertMCPPromptMessages converts []mcp.PromptMessage to []vmcp.PromptMessage,
+// preserving individual message roles and content types.
+func ConvertMCPPromptMessages(messages []mcp.PromptMessage) []vmcp.PromptMessage {
+	result := make([]vmcp.PromptMessage, 0, len(messages))
 	for _, msg := range messages {
-		if msg.Role != "" {
-			fmt.Fprintf(&sb, "[%s] ", msg.Role)
-		}
-		if textContent, ok := mcp.AsTextContent(msg.Content); ok {
-			sb.WriteString(textContent.Text)
-			sb.WriteByte('\n')
-		}
+		result = append(result, vmcp.PromptMessage{
+			Role:    string(msg.Role),
+			Content: ConvertMCPContent(msg.Content),
+		})
 	}
-	return sb.String()
+	return result
+}
+
+// ToMCPPromptMessages converts []vmcp.PromptMessage to []mcp.PromptMessage.
+func ToMCPPromptMessages(messages []vmcp.PromptMessage) []mcp.PromptMessage {
+	result := make([]mcp.PromptMessage, 0, len(messages))
+	for _, msg := range messages {
+		result = append(result, mcp.PromptMessage{
+			Role:    mcp.Role(msg.Role),
+			Content: ToMCPContent(msg.Content),
+		})
+	}
+	return result
 }
 
 // ConvertPromptArguments converts map[string]any to map[string]string by

--- a/pkg/vmcp/conversion/conversion_test.go
+++ b/pkg/vmcp/conversion/conversion_test.go
@@ -73,50 +73,175 @@ func TestConvertToolInputSchema(t *testing.T) {
 	}
 }
 
-func TestConvertPromptMessages(t *testing.T) {
+func TestConvertMCPPromptMessages(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
 		name     string
 		messages []mcp.PromptMessage
-		want     string
+		want     []vmcp.PromptMessage
 	}{
 		{
-			name:     "empty messages",
+			name:     "nil messages returns empty slice",
 			messages: nil,
-			want:     "",
+			want:     []vmcp.PromptMessage{},
 		},
 		{
-			name: "single message with role",
+			name:     "empty messages returns empty slice",
+			messages: []mcp.PromptMessage{},
+			want:     []vmcp.PromptMessage{},
+		},
+		{
+			name: "single text message preserves role and content",
 			messages: []mcp.PromptMessage{
 				{Role: "user", Content: mcp.NewTextContent("Hello")},
 			},
-			want: "[user] Hello\n",
-		},
-		{
-			name: "message without role omits prefix",
-			messages: []mcp.PromptMessage{
-				{Role: "", Content: mcp.NewTextContent("No role")},
+			want: []vmcp.PromptMessage{
+				{Role: "user", Content: vmcp.Content{Type: vmcp.ContentTypeText, Text: "Hello"}},
 			},
-			want: "No role\n",
 		},
 		{
-			name: "multiple messages concatenated",
+			name: "multiple messages with different roles",
 			messages: []mcp.PromptMessage{
 				{Role: "system", Content: mcp.NewTextContent("You are helpful")},
 				{Role: "user", Content: mcp.NewTextContent("Hi")},
 				{Role: "assistant", Content: mcp.NewTextContent("Hello!")},
 			},
-			want: "[system] You are helpful\n[user] Hi\n[assistant] Hello!\n",
+			want: []vmcp.PromptMessage{
+				{Role: "system", Content: vmcp.Content{Type: vmcp.ContentTypeText, Text: "You are helpful"}},
+				{Role: "user", Content: vmcp.Content{Type: vmcp.ContentTypeText, Text: "Hi"}},
+				{Role: "assistant", Content: vmcp.Content{Type: vmcp.ContentTypeText, Text: "Hello!"}},
+			},
+		},
+		{
+			name: "message with image content is preserved",
+			messages: []mcp.PromptMessage{
+				{Role: "user", Content: mcp.NewImageContent("base64imgdata", "image/png")},
+			},
+			want: []vmcp.PromptMessage{
+				{Role: "user", Content: vmcp.Content{Type: vmcp.ContentTypeImage, Data: "base64imgdata", MimeType: "image/png"}},
+			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			assert.Equal(t, tt.want, conversion.ConvertPromptMessages(tt.messages))
+			got := conversion.ConvertMCPPromptMessages(tt.messages)
+			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestToMCPPromptMessages(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		messages []vmcp.PromptMessage
+		wantLen  int
+		check    func(*testing.T, []mcp.PromptMessage)
+	}{
+		{
+			name:     "nil messages returns empty slice",
+			messages: nil,
+			wantLen:  0,
+		},
+		{
+			name:     "empty messages returns empty slice",
+			messages: []vmcp.PromptMessage{},
+			wantLen:  0,
+		},
+		{
+			name: "single text message preserves role and content",
+			messages: []vmcp.PromptMessage{
+				{Role: "user", Content: vmcp.Content{Type: vmcp.ContentTypeText, Text: "Hello"}},
+			},
+			wantLen: 1,
+			check: func(t *testing.T, result []mcp.PromptMessage) {
+				t.Helper()
+				assert.Equal(t, mcp.Role("user"), result[0].Role)
+				text, ok := mcp.AsTextContent(result[0].Content)
+				require.True(t, ok)
+				assert.Equal(t, "Hello", text.Text)
+			},
+		},
+		{
+			name: "multiple messages with different roles",
+			messages: []vmcp.PromptMessage{
+				{Role: "system", Content: vmcp.Content{Type: vmcp.ContentTypeText, Text: "Be helpful"}},
+				{Role: "user", Content: vmcp.Content{Type: vmcp.ContentTypeText, Text: "Hi"}},
+				{Role: "assistant", Content: vmcp.Content{Type: vmcp.ContentTypeText, Text: "Hello!"}},
+			},
+			wantLen: 3,
+			check: func(t *testing.T, result []mcp.PromptMessage) {
+				t.Helper()
+				assert.Equal(t, mcp.Role("system"), result[0].Role)
+				assert.Equal(t, mcp.Role("user"), result[1].Role)
+				assert.Equal(t, mcp.Role("assistant"), result[2].Role)
+			},
+		},
+		{
+			name: "image content is preserved",
+			messages: []vmcp.PromptMessage{
+				{Role: "user", Content: vmcp.Content{Type: vmcp.ContentTypeImage, Data: "imgdata", MimeType: "image/png"}},
+			},
+			wantLen: 1,
+			check: func(t *testing.T, result []mcp.PromptMessage) {
+				t.Helper()
+				img, ok := result[0].Content.(mcp.ImageContent)
+				require.True(t, ok)
+				assert.Equal(t, "imgdata", img.Data)
+				assert.Equal(t, "image/png", img.MIMEType)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := conversion.ToMCPPromptMessages(tt.messages)
+			assert.Len(t, got, tt.wantLen)
+			if tt.check != nil {
+				tt.check(t, got)
+			}
+		})
+	}
+}
+
+func TestPromptMessagesRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	original := []mcp.PromptMessage{
+		{Role: "system", Content: mcp.NewTextContent("You are helpful")},
+		{Role: "user", Content: mcp.NewImageContent("base64data", "image/png")},
+		{Role: "assistant", Content: mcp.NewTextContent("I see an image")},
+	}
+
+	// mcp -> vmcp -> mcp
+	intermediate := conversion.ConvertMCPPromptMessages(original)
+	roundTripped := conversion.ToMCPPromptMessages(intermediate)
+
+	require.Len(t, roundTripped, len(original))
+	for i, orig := range original {
+		assert.Equal(t, orig.Role, roundTripped[i].Role, "role at index %d", i)
+	}
+
+	// Verify text content preserved
+	text0, ok := mcp.AsTextContent(roundTripped[0].Content)
+	require.True(t, ok)
+	assert.Equal(t, "You are helpful", text0.Text)
+
+	// Verify image content preserved
+	img1, ok := roundTripped[1].Content.(mcp.ImageContent)
+	require.True(t, ok)
+	assert.Equal(t, "base64data", img1.Data)
+	assert.Equal(t, "image/png", img1.MIMEType)
+
+	// Verify second text content preserved
+	text2, ok := mcp.AsTextContent(roundTripped[2].Content)
+	require.True(t, ok)
+	assert.Equal(t, "I see an image", text2.Text)
 }
 
 func TestConvertPromptArguments(t *testing.T) {

--- a/pkg/vmcp/server/adapter/handler_factory.go
+++ b/pkg/vmcp/server/adapter/handler_factory.go
@@ -241,12 +241,7 @@ func (f *DefaultHandlerFactory) CreatePromptHandler(promptName string) func(
 				Meta: conversion.ToMCPMeta(result.Meta),
 			},
 			Description: description,
-			Messages: []mcp.PromptMessage{
-				{
-					Role:    "assistant",
-					Content: mcp.NewTextContent(result.Messages),
-				},
-			},
+			Messages:    conversion.ToMCPPromptMessages(result.Messages),
 		}
 
 		return mcpResult, nil

--- a/pkg/vmcp/server/adapter/handler_factory_test.go
+++ b/pkg/vmcp/server/adapter/handler_factory_test.go
@@ -743,7 +743,9 @@ func TestDefaultHandlerFactory_CreatePromptHandler(t *testing.T) {
 					WorkloadName: "Backend 1",
 				}
 
-				promptText := "Write tests for Go code about testing"
+				promptMessages := []vmcp.PromptMessage{
+					{Role: "user", Content: vmcp.Content{Type: vmcp.ContentTypeText, Text: "Write tests for Go code about testing"}},
+				}
 
 				expectedArgs := map[string]any{
 					"topic":    "testing",
@@ -756,7 +758,7 @@ func TestDefaultHandlerFactory_CreatePromptHandler(t *testing.T) {
 
 				mockClient.EXPECT().
 					GetPrompt(gomock.Any(), target, "test_prompt", expectedArgs).
-					Return(&vmcp.PromptGetResult{Messages: promptText, Description: ""}, nil)
+					Return(&vmcp.PromptGetResult{Messages: promptMessages, Description: ""}, nil)
 			},
 			request: mcp.GetPromptRequest{
 				Params: mcp.GetPromptParams{
@@ -774,7 +776,7 @@ func TestDefaultHandlerFactory_CreatePromptHandler(t *testing.T) {
 				require.NotNil(t, result)
 				assert.Contains(t, result.Description, "test_prompt")
 				require.Len(t, result.Messages, 1)
-				assert.Equal(t, "assistant", string(result.Messages[0].Role))
+				assert.Equal(t, "user", string(result.Messages[0].Role))
 				assert.Equal(t, "Write tests for Go code about testing", result.Messages[0].Content.(mcp.TextContent).Text)
 			},
 		},
@@ -896,7 +898,9 @@ func TestDefaultHandlerFactory_CreatePromptHandler(t *testing.T) {
 					OriginalCapabilityName: "summarize",
 				}
 
-				promptText := "Summary of test content"
+				promptMessages := []vmcp.PromptMessage{
+					{Role: "assistant", Content: vmcp.Content{Type: vmcp.ContentTypeText, Text: "Summary of test content"}},
+				}
 				expectedArgs := map[string]any{"text": "test content"}
 
 				mockRouter.EXPECT().
@@ -905,7 +909,7 @@ func TestDefaultHandlerFactory_CreatePromptHandler(t *testing.T) {
 
 				mockClient.EXPECT().
 					GetPrompt(gomock.Any(), target, "summarize", expectedArgs).
-					Return(&vmcp.PromptGetResult{Messages: promptText, Description: ""}, nil)
+					Return(&vmcp.PromptGetResult{Messages: promptMessages, Description: ""}, nil)
 			},
 			request: mcp.GetPromptRequest{
 				Params: mcp.GetPromptParams{
@@ -918,6 +922,8 @@ func TestDefaultHandlerFactory_CreatePromptHandler(t *testing.T) {
 				t.Helper()
 				require.NoError(t, err)
 				require.NotNil(t, result)
+				require.Len(t, result.Messages, 1)
+				assert.Equal(t, "assistant", string(result.Messages[0].Role))
 				assert.Equal(t, "Summary of test content", result.Messages[0].Content.(mcp.TextContent).Text)
 			},
 		},
@@ -929,7 +935,9 @@ func TestDefaultHandlerFactory_CreatePromptHandler(t *testing.T) {
 					WorkloadID: "backend1",
 				}
 
-				promptText := "Simple prompt response"
+				promptMessages := []vmcp.PromptMessage{
+					{Role: "assistant", Content: vmcp.Content{Type: vmcp.ContentTypeText, Text: "Simple prompt response"}},
+				}
 				emptyArgs := map[string]any{}
 
 				mockRouter.EXPECT().
@@ -938,7 +946,7 @@ func TestDefaultHandlerFactory_CreatePromptHandler(t *testing.T) {
 
 				mockClient.EXPECT().
 					GetPrompt(gomock.Any(), target, "simple_prompt", emptyArgs).
-					Return(&vmcp.PromptGetResult{Messages: promptText, Description: ""}, nil)
+					Return(&vmcp.PromptGetResult{Messages: promptMessages, Description: ""}, nil)
 			},
 			request: mcp.GetPromptRequest{
 				Params: mcp.GetPromptParams{

--- a/pkg/vmcp/session/connector_integration_test.go
+++ b/pkg/vmcp/session/connector_integration_test.go
@@ -194,8 +194,11 @@ func TestSessionFactory_Integration_GetPrompt(t *testing.T) {
 	result, err := sess.GetPrompt(context.Background(), nil, "greet", nil)
 	require.NoError(t, err)
 	require.NotNil(t, result)
-	// ConvertPromptMessages formats messages as "[role] text\n"
-	assert.Equal(t, "[user] Hello!\n", result.Messages)
+	// Messages preserve individual roles and content structure
+	require.Len(t, result.Messages, 1)
+	assert.Equal(t, "user", result.Messages[0].Role)
+	assert.Equal(t, vmcp.ContentTypeText, result.Messages[0].Content.Type)
+	assert.Equal(t, "Hello!", result.Messages[0].Content.Text)
 }
 
 func TestSessionFactory_Integration_MultipleBackends(t *testing.T) {
@@ -306,7 +309,9 @@ func TestTokenBinding_ReadResource_And_GetPrompt_WithRealBackend(t *testing.T) {
 		result, err := sess.GetPrompt(context.Background(), identity, "greet", nil)
 		require.NoError(t, err)
 		require.NotNil(t, result)
-		assert.Equal(t, "[user] Hello!\n", result.Messages)
+		require.Len(t, result.Messages, 1)
+		assert.Equal(t, "user", result.Messages[0].Role)
+		assert.Equal(t, "Hello!", result.Messages[0].Content.Text)
 	})
 }
 

--- a/pkg/vmcp/session/default_session_test.go
+++ b/pkg/vmcp/session/default_session_test.go
@@ -54,7 +54,9 @@ func (m *mockConnectedBackend) GetPrompt(ctx context.Context, name string, argum
 	if m.getPromptFunc != nil {
 		return m.getPromptFunc(ctx, name, arguments)
 	}
-	return &vmcp.PromptGetResult{Messages: "hello"}, nil
+	return &vmcp.PromptGetResult{Messages: []vmcp.PromptMessage{
+		{Role: "assistant", Content: vmcp.Content{Type: vmcp.ContentTypeText, Text: "hello"}},
+	}}, nil
 }
 
 func (m *mockConnectedBackend) SessionID() string { return m.sessID }
@@ -278,20 +280,24 @@ func TestDefaultSession_GetPrompt(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name      string
-		prompt    string
-		mockFn    func(ctx context.Context, name string, arguments map[string]any) (*vmcp.PromptGetResult, error)
-		wantErr   bool
-		wantErrIs error
-		wantMsg   string
+		name         string
+		prompt       string
+		mockFn       func(ctx context.Context, name string, arguments map[string]any) (*vmcp.PromptGetResult, error)
+		wantErr      bool
+		wantErrIs    error
+		wantMessages []vmcp.PromptMessage
 	}{
 		{
 			name:   "successful get",
 			prompt: "greet",
 			mockFn: func(_ context.Context, _ string, _ map[string]any) (*vmcp.PromptGetResult, error) {
-				return &vmcp.PromptGetResult{Messages: "hi there"}, nil
+				return &vmcp.PromptGetResult{Messages: []vmcp.PromptMessage{
+					{Role: "assistant", Content: vmcp.Content{Type: vmcp.ContentTypeText, Text: "hi there"}},
+				}}, nil
 			},
-			wantMsg: "hi there",
+			wantMessages: []vmcp.PromptMessage{
+				{Role: "assistant", Content: vmcp.Content{Type: vmcp.ContentTypeText, Text: "hi there"}},
+			},
 		},
 		{
 			name:      "prompt not in routing table",
@@ -328,7 +334,7 @@ func TestDefaultSession_GetPrompt(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
-			assert.Equal(t, tt.wantMsg, result.Messages)
+			assert.Equal(t, tt.wantMessages, result.Messages)
 		})
 	}
 }

--- a/pkg/vmcp/session/internal/backend/mcp_session.go
+++ b/pkg/vmcp/session/internal/backend/mcp_session.go
@@ -186,10 +186,8 @@ func (c *mcpSession) GetPrompt(
 		return nil, fmt.Errorf("prompt %q get failed on backend %s: %w", name, c.target.WorkloadID, err)
 	}
 
-	// NOTE: ConvertPromptMessages is lossy — non-text content (images, audio)
-	// is discarded. Phase 1 limitation; see vmcp.PromptGetResult.
 	return &vmcp.PromptGetResult{
-		Messages:    conversion.ConvertPromptMessages(result.Messages),
+		Messages:    conversion.ConvertMCPPromptMessages(result.Messages),
 		Description: result.Description,
 		Meta:        conversion.FromMCPMeta(result.Meta),
 	}, nil

--- a/pkg/vmcp/types.go
+++ b/pkg/vmcp/types.go
@@ -450,11 +450,22 @@ type ResourceReadResult struct {
 	Meta map[string]any
 }
 
+// PromptMessage represents a single message in a prompt response,
+// preserving the role and content structure from the backend.
+type PromptMessage struct {
+	// Role is the message role. The MCP spec defines "user" and "assistant";
+	// backends may also send other values which are relayed as-is.
+	Role string
+	// Content is the message content, supporting all MCP content types.
+	Content Content
+}
+
 // PromptGetResult wraps a prompt response with metadata.
 // This preserves both the prompt messages AND the _meta field from the backend MCP server.
 type PromptGetResult struct {
-	// Messages is the concatenated prompt text from all messages.
-	Messages string
+	// Messages preserves individual prompt messages with their roles
+	// and full content structure (text, images, audio, resources).
+	Messages []PromptMessage
 
 	// Description is an optional description of the prompt.
 	Description string


### PR DESCRIPTION
## Summary

The vMCP relay was flattening prompt messages into a single `"[role] text\n"` string, losing individual message roles, content types (images, audio), and multi-message structure. AI clients receiving prompts through the relay got a degraded single-string representation instead of the structured messages the backend MCP server returned.

This changes `PromptGetResult.Messages` from `string` to `[]PromptMessage`, preserving each message's role and full content structure through the entire relay path (backend → session → client → handler factory → MCP response).

- Add `PromptMessage` type with `Role` and `Content` fields to `vmcp.types`
- Replace lossy `ConvertPromptMessages` (string concatenation) with `ConvertMCPPromptMessages` / `ToMCPPromptMessages` round-trip converters
- Update handler factory to relay structured messages instead of wrapping a flat string in a synthetic "assistant" message
- Update all tests to assert on structured message content

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)

## Does this introduce a user-facing change?

Prompt responses from virtual MCP servers now preserve the original message structure (roles, content types) from backend servers, instead of flattening them into a single text string.

## Special notes for reviewers

This is one of three related PRs fixing vMCP relay fidelity:
- **This PR**: prompt message structure
- fix-resource-relay: resource text/blob distinction and per-item metadata
- fix-content-annotations: per-content annotations (audience, priority, lastModified)

Generated with [Claude Code](https://claude.com/claude-code)