### PR TITLE
Add RegisterProviderFactory extension point to pkg/config

### DIFF
--- a/pkg/config/factory.go
+++ b/pkg/config/factory.go
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+// ProviderFactory is a function that optionally creates a Provider.
+// Returning nil signals that the caller should fall back to the default provider.
+type ProviderFactory func() Provider
+
+// registeredFactory is the package-level factory, nil by default.
+var registeredFactory ProviderFactory
+
+// RegisterProviderFactory sets a custom factory to be used by NewProvider.
+// It must be called before the first call to NewProvider (typically in main or init).
+// Calling it a second time replaces the previously registered factory.
+func RegisterProviderFactory(f ProviderFactory) {
+	registeredFactory = f
+}

--- a/pkg/config/factory_test.go
+++ b/pkg/config/factory_test.go
@@ -1,0 +1,104 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubProvider is a minimal Provider implementation used in factory tests.
+type stubProvider struct {
+	KubernetesProvider // embed no-op implementation to satisfy the interface
+	label              string
+}
+
+func TestRegisterProviderFactory_NoFactoryRegistered(t *testing.T) {
+	// Ensure clean state.
+	registeredFactory = nil
+	t.Cleanup(func() { registeredFactory = nil })
+
+	// Ensure we are not detected as running in Kubernetes.
+	t.Setenv("KUBERNETES_SERVICE_HOST", "")
+	t.Setenv("KUBERNETES_SERVICE_PORT", "")
+
+	provider := NewProvider()
+	require.NotNil(t, provider)
+	assert.IsType(t, &DefaultProvider{}, provider)
+}
+
+func TestRegisterProviderFactory_ReturnsNonNilProvider(t *testing.T) {
+	registeredFactory = nil
+	t.Cleanup(func() { registeredFactory = nil })
+
+	t.Setenv("KUBERNETES_SERVICE_HOST", "")
+	t.Setenv("KUBERNETES_SERVICE_PORT", "")
+
+	custom := &stubProvider{label: "custom"}
+	RegisterProviderFactory(func() Provider {
+		return custom
+	})
+
+	provider := NewProvider()
+	require.NotNil(t, provider)
+	assert.Same(t, custom, provider, "NewProvider should return the factory-provided provider")
+}
+
+func TestRegisterProviderFactory_ReturnsNil_FallsThrough(t *testing.T) {
+	registeredFactory = nil
+	t.Cleanup(func() { registeredFactory = nil })
+
+	t.Setenv("KUBERNETES_SERVICE_HOST", "")
+	t.Setenv("KUBERNETES_SERVICE_PORT", "")
+
+	RegisterProviderFactory(func() Provider {
+		return nil
+	})
+
+	provider := NewProvider()
+	require.NotNil(t, provider)
+	assert.IsType(t, &DefaultProvider{}, provider, "NewProvider should fall back to DefaultProvider when factory returns nil")
+}
+
+func TestRegisterProviderFactory_SecondCallWins(t *testing.T) {
+	registeredFactory = nil
+	t.Cleanup(func() { registeredFactory = nil })
+
+	t.Setenv("KUBERNETES_SERVICE_HOST", "")
+	t.Setenv("KUBERNETES_SERVICE_PORT", "")
+
+	first := &stubProvider{label: "first"}
+	second := &stubProvider{label: "second"}
+
+	RegisterProviderFactory(func() Provider {
+		return first
+	})
+	RegisterProviderFactory(func() Provider {
+		return second
+	})
+
+	provider := NewProvider()
+	require.NotNil(t, provider)
+	assert.Same(t, second, provider, "The second registered factory should replace the first")
+}
+
+func TestRegisterProviderFactory_FactoryOverridesKubernetesDetection(t *testing.T) {
+	registeredFactory = nil
+	t.Cleanup(func() { registeredFactory = nil })
+
+	// Simulate a Kubernetes environment.
+	t.Setenv("KUBERNETES_SERVICE_HOST", "10.96.0.1")
+	t.Setenv("KUBERNETES_SERVICE_PORT", "443")
+
+	custom := &stubProvider{label: "custom-in-k8s"}
+	RegisterProviderFactory(func() Provider {
+		return custom
+	})
+
+	provider := NewProvider()
+	require.NotNil(t, provider)
+	assert.Same(t, custom, provider, "Factory provider should take precedence over KubernetesProvider")
+}

--- a/pkg/config/interface.go
+++ b/pkg/config/interface.go
@@ -559,8 +559,16 @@ func (*KubernetesProvider) SetRuntimeConfig(_ string, _ *templates.RuntimeConfig
 	return nil
 }
 
-// NewProvider creates the appropriate config provider based on the runtime environment
+// NewProvider creates the appropriate config provider based on the runtime environment.
+// If a custom ProviderFactory has been registered via RegisterProviderFactory and it
+// returns a non-nil Provider, that provider is used. Otherwise, the built-in selection
+// logic applies.
 func NewProvider() Provider {
+	if registeredFactory != nil {
+		if p := registeredFactory(); p != nil {
+			return p
+		}
+	}
 	if runtime.IsKubernetesRuntime() {
 		return NewKubernetesProvider()
 	}


### PR DESCRIPTION
## Summary

- `NewProvider()` currently hard-codes the selection between `KubernetesProvider` and `DefaultProvider` with no way for downstream consumers to inject a custom `Provider` implementation without forking
- This adds a `ProviderFactory` registration hook (`RegisterProviderFactory`) so that callers can register a custom factory at startup, and `NewProvider()` will consult it before falling back to the built-in logic
- The two-step nil check ensures a factory that intentionally returns `nil` triggers the fallback rather than a nil-pointer dereference

## Type of change

- [x] Enhancement (non-breaking change that adds functionality)

## Changes

| File | Change |
|---|---|
| `pkg/config/factory.go` | New file — `ProviderFactory` type, `registeredFactory` var, `RegisterProviderFactory` func |
| `pkg/config/interface.go` | Updated `NewProvider()` to consult `registeredFactory` before built-in logic |
| `pkg/config/factory_test.go` | New file — unit tests for factory registration and fallback behaviour |

## Test plan

- [x] Unit tests pass (`go test ./pkg/config/`)
- [x] Linter passes (`task lint`)
- [x] Tests cover: no factory registered, factory returns non-nil, factory returns nil (fallback), second registration overwrites first, factory overrides Kubernetes detection

Generated with [Claude Code](https://claude.com/claude-code)