### PR TITLE
Increase session management E2E test timeout to 3 minutes

### DIFF
--- a/test/e2e/thv-operator/virtualmcp/virtualmcp_session_management_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcp_session_management_test.go
@@ -31,7 +31,7 @@ import (
 
 var _ = ginkgo.Describe("VirtualMCPServer Session Management", func() {
 	const (
-		timeout           = time.Minute * 2
+		timeout           = time.Minute * 3
 		pollInterval      = time.Second * 2
 		defaultNamespace  = "default"
 		vmcpContainerName = "vmcp"


### PR DESCRIPTION
## Summary

The session management E2E tests were the only VirtualMCPServer tests using a 2-minute timeout for `WaitForVirtualMCPServerReady` — all other tests use 3 minutes. Under CI load (this test runs as spec ~120/121), backend pod startup can be slow enough that the health monitor accumulates 3 failures (at 30-second default intervals) before the backend is reachable. Recovery from unhealthy state requires 2 additional successful checks (another 60 seconds), pushing the total past the 2-minute window and causing a timeout with "All backends are unhealthy".

- Increase `timeout` from 2 minutes to 3 minutes, matching all other VirtualMCPServer E2E tests
- This fixes flaky failures in both session management contexts: "Session token storage and retrieval" and "Session token binding prevents session hijacking"

## Type of change

- [x] Bug fix

## Test plan

- [x] Verified all other VirtualMCPServer E2E tests already use 3-minute timeout
- [x] Confirmed the session management test was the only test file using 2-minute timeout

## Special notes for reviewers

The worst-case health monitor timeline with default settings (30s interval, threshold 3):
- T=0-60s: 3 failed checks → backend marked unhealthy
- T=90s: first successful check → status transitions to degraded (still counted as "unhealthy" by `countBackendHealth`)
- T=120s: second successful check → status transitions to healthy → VirtualMCPServer ready

With 2-minute timeout, the test races against this 150-second worst case. With 3 minutes, there is comfortable headroom. A deeper fix could configure shorter health check intervals on the test's VirtualMCPServer (like the circuit breaker and external auth tests do with 5s intervals), but the timeout alignment is the minimal safe change.

Generated with [Claude Code](https://claude.com/claude-code)