### PR TITLE
Remove SessionCacheSize from ScalingConfig

### DIFF
--- a/docs/server/docs.go
+++ b/docs/server/docs.go
@@ -1120,10 +1120,6 @@ const docTemplate = `{
                     "backend_replicas": {
                         "description": "BackendReplicas is the desired StatefulSet replica count for the proxy runner backend.\nWhen nil, replicas are unmanaged (preserving HPA or manual kubectl control).\nWhen set (including 0), the value is an explicit replica count.",
                         "type": "integer"
-                    },
-                    "session_cache_size": {
-                        "description": "SessionCacheSize is the maximum number of sessions held in the local LRU cache.\nWhen nil, consuming code applies a sensible default (e.g. 1000).",
-                        "type": "integer"
                     }
                 },
                 "type": "object"

--- a/docs/server/swagger.json
+++ b/docs/server/swagger.json
@@ -1113,10 +1113,6 @@
                     "backend_replicas": {
                         "description": "BackendReplicas is the desired StatefulSet replica count for the proxy runner backend.\nWhen nil, replicas are unmanaged (preserving HPA or manual kubectl control).\nWhen set (including 0), the value is an explicit replica count.",
                         "type": "integer"
-                    },
-                    "session_cache_size": {
-                        "description": "SessionCacheSize is the maximum number of sessions held in the local LRU cache.\nWhen nil, consuming code applies a sensible default (e.g. 1000).",
-                        "type": "integer"
                     }
                 },
                 "type": "object"

--- a/docs/server/swagger.yaml
+++ b/docs/server/swagger.yaml
@@ -1063,11 +1063,6 @@ components:
             When nil, replicas are unmanaged (preserving HPA or manual kubectl control).
             When set (including 0), the value is an explicit replica count.
           type: integer
-        session_cache_size:
-          description: |-
-            SessionCacheSize is the maximum number of sessions held in the local LRU cache.
-            When nil, consuming code applies a sensible default (e.g. 1000).
-          type: integer
       type: object
     github_com_stacklok_toolhive_pkg_runner.ToolOverride:
       properties:

--- a/pkg/runner/config.go
+++ b/pkg/runner/config.go
@@ -226,10 +226,6 @@ type ScalingConfig struct {
 	// When nil, replicas are unmanaged (preserving HPA or manual kubectl control).
 	// When set (including 0), the value is an explicit replica count.
 	BackendReplicas *int32 `json:"backend_replicas,omitempty" yaml:"backend_replicas,omitempty"`
-
-	// SessionCacheSize is the maximum number of sessions held in the local LRU cache.
-	// When nil, consuming code applies a sensible default (e.g. 1000).
-	SessionCacheSize *int32 `json:"session_cache_size,omitempty" yaml:"session_cache_size,omitempty"`
 }
 
 // WriteJSON serializes the RunConfig to JSON and writes it to the provided writer

--- a/pkg/runner/config_test.go
+++ b/pkg/runner/config_test.go
@@ -2242,19 +2242,18 @@ func TestRunConfig_WriteJSON_ReadJSON_EmbeddedAuthServer(t *testing.T) {
 	})
 }
 
-func TestRunConfig_BackendReplicasAndSessionCacheSize(t *testing.T) {
+func TestRunConfig_BackendReplicas(t *testing.T) {
 	t.Parallel()
 
 	const testServerName = "srv"
 	int32ptr := func(v int32) *int32 { return &v }
 
-	t.Run("round-trip with both fields set", func(t *testing.T) {
+	t.Run("round-trip with backend_replicas set", func(t *testing.T) {
 		t.Parallel()
 		original := NewRunConfig()
 		original.Name = "test-server"
 		original.ScalingConfig = &ScalingConfig{
-			BackendReplicas:  int32ptr(3),
-			SessionCacheSize: int32ptr(500),
+			BackendReplicas: int32ptr(3),
 		}
 
 		var buf bytes.Buffer
@@ -2265,8 +2264,6 @@ func TestRunConfig_BackendReplicasAndSessionCacheSize(t *testing.T) {
 		require.NotNil(t, got.ScalingConfig)
 		require.NotNil(t, got.ScalingConfig.BackendReplicas)
 		assert.Equal(t, int32(3), *got.ScalingConfig.BackendReplicas)
-		require.NotNil(t, got.ScalingConfig.SessionCacheSize)
-		assert.Equal(t, int32(500), *got.ScalingConfig.SessionCacheSize)
 	})
 
 	t.Run("round-trip without scaling config preserves nil", func(t *testing.T) {
@@ -2289,7 +2286,6 @@ func TestRunConfig_BackendReplicasAndSessionCacheSize(t *testing.T) {
 		require.NoError(t, cfg.WriteJSON(&buf))
 		assert.NotContains(t, buf.String(), "scaling_config")
 		assert.NotContains(t, buf.String(), "backend_replicas")
-		assert.NotContains(t, buf.String(), "session_cache_size")
 	})
 
 	t.Run("explicit backend_replicas 2 in JSON deserializes to pointer with value 2", func(t *testing.T) {
@@ -2304,7 +2300,6 @@ func TestRunConfig_BackendReplicasAndSessionCacheSize(t *testing.T) {
 		require.NotNil(t, got.ScalingConfig)
 		require.NotNil(t, got.ScalingConfig.BackendReplicas, "BackendReplicas should be non-nil when present in JSON")
 		assert.Equal(t, int32(2), *got.ScalingConfig.BackendReplicas)
-		assert.Nil(t, got.ScalingConfig.SessionCacheSize, "SessionCacheSize should be nil when omitted from JSON")
 	})
 
 	t.Run("backend_replicas 0 in JSON deserializes to pointer-to-zero, not nil", func(t *testing.T) {
@@ -2323,30 +2318,12 @@ func TestRunConfig_BackendReplicasAndSessionCacheSize(t *testing.T) {
 		assert.Equal(t, int32(0), *got.ScalingConfig.BackendReplicas)
 	})
 
-	t.Run("session_cache_size 0 in JSON deserializes to pointer-to-zero, not nil", func(t *testing.T) {
-		t.Parallel()
-		// omitempty only omits when the pointer is nil; pointer-to-zero is a meaningful
-		// "set to 0" and must survive a round-trip.
-		cfg := NewRunConfig()
-		cfg.Name = testServerName
-		cfg.ScalingConfig = &ScalingConfig{SessionCacheSize: int32ptr(0)}
-		var buf bytes.Buffer
-		require.NoError(t, cfg.WriteJSON(&buf))
-		got, err := ReadJSON(&buf)
-		require.NoError(t, err)
-		require.NotNil(t, got.ScalingConfig)
-		require.NotNil(t, got.ScalingConfig.SessionCacheSize, "SessionCacheSize should be non-nil when explicitly set to 0 in JSON")
-		assert.Equal(t, int32(0), *got.ScalingConfig.SessionCacheSize)
-		assert.Nil(t, got.ScalingConfig.BackendReplicas, "BackendReplicas should be nil when omitted from JSON")
-	})
-
-	t.Run("YAML round-trip with both fields set", func(t *testing.T) {
+	t.Run("YAML round-trip with backend_replicas set", func(t *testing.T) {
 		t.Parallel()
 		original := NewRunConfig()
 		original.Name = "yaml-server"
 		original.ScalingConfig = &ScalingConfig{
-			BackendReplicas:  int32ptr(5),
-			SessionCacheSize: int32ptr(250),
+			BackendReplicas: int32ptr(5),
 		}
 
 		data, err := yaml.Marshal(original)
@@ -2357,7 +2334,5 @@ func TestRunConfig_BackendReplicasAndSessionCacheSize(t *testing.T) {
 		require.NotNil(t, got.ScalingConfig)
 		require.NotNil(t, got.ScalingConfig.BackendReplicas)
 		assert.Equal(t, int32(5), *got.ScalingConfig.BackendReplicas)
-		require.NotNil(t, got.ScalingConfig.SessionCacheSize)
-		assert.Equal(t, int32(250), *got.ScalingConfig.SessionCacheSize)
 	})
 }


### PR DESCRIPTION


## Summary

<!--
REQUIRED. You MUST explain:
1. WHY this change is needed (the problem or motivation)
2. WHAT changed (concise bullet points)

The diff shows the code — your summary must provide the context a reviewer
needs to understand the purpose without reading the diff first.
-->

The local LRU session cache layer was dropped in favour of going directly to Redis for session storage, making SessionCacheSize meaningless. Remove the field from ScalingConfig, clean up its tests, and update the generated Swagger docs.

<!--
Link related issues. Use "Closes" or "Fixes" to auto-close on merge.
Remove this line if there is no related issue.
-->


## Type of change

<!-- REQUIRED. Check exactly one. -->

- [ ] Bug fix
- [ ] New feature
- [x] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

<!--
REQUIRED. Check every verification step you actually ran.
You MUST check at least one item. If you only did manual testing,
describe exactly what you tested below the checkbox.
-->

- [x] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [x] Linting (`task lint-fix`)
- [ ] Manual testing (describe below)

## Changes

<!--
Optional — include for PRs touching more than a few files to help
reviewers navigate the diff. Remove this entire section for small PRs.
-->

| File | Change |
|------|--------|
|      |        |

## Does this introduce a user-facing change?

<!--
If yes, describe the change from the user's perspective. This helps with release notes.
If no, write "No".
Remove this section entirely if not applicable.
-->

## Special notes for reviewers

<!--
Optional — call out anything non-obvious: tricky logic, known limitations,
areas where you'd like extra scrutiny, or follow-up work planned.
Remove this section if not needed.
-->
