### PR TITLE
Fix: Align OpenAPI Type for Auth Timeout

### DIFF
--- a/docs/server/docs.go
+++ b/docs/server/docs.go
@@ -279,8 +279,7 @@ const docTemplate = `{
                         "type": "boolean"
                     },
                     "timeout": {
-                        "example": "5m",
-                        "type": "string"
+                        "type": "integer"
                     },
                     "token_url": {
                         "type": "string"

--- a/docs/server/swagger.json
+++ b/docs/server/swagger.json
@@ -272,8 +272,7 @@
                         "type": "boolean"
                     },
                     "timeout": {
-                        "example": "5m",
-                        "type": "string"
+                        "type": "integer"
                     },
                     "token_url": {
                         "type": "string"

--- a/docs/server/swagger.yaml
+++ b/docs/server/swagger.yaml
@@ -267,8 +267,7 @@ components:
         skip_browser:
           type: boolean
         timeout:
-          example: 5m
-          type: string
+          type: integer
         token_url:
           type: string
         use_pkce:

--- a/pkg/auth/remote/config.go
+++ b/pkg/auth/remote/config.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/stacklok/toolhive-core/registry/types"
+	registry "github.com/stacklok/toolhive-core/registry/types"
 	httpval "github.com/stacklok/toolhive-core/validation/http"
 )
 
@@ -23,7 +23,7 @@ type Config struct {
 	ClientSecretFile string        `json:"client_secret_file,omitempty" yaml:"client_secret_file,omitempty"`
 	Scopes           []string      `json:"scopes,omitempty" yaml:"scopes,omitempty"`
 	SkipBrowser      bool          `json:"skip_browser,omitempty" yaml:"skip_browser,omitempty"`
-	Timeout          time.Duration `json:"timeout,omitempty" yaml:"timeout,omitempty" swaggertype:"string" example:"5m"`
+	Timeout          time.Duration `json:"timeout,omitempty" yaml:"timeout,omitempty" swaggertype:"primitive,integer"`
 	CallbackPort     int           `json:"callback_port,omitempty" yaml:"callback_port,omitempty"`
 	UsePKCE          bool          `json:"use_pkce" yaml:"use_pkce"`
 


### PR DESCRIPTION
This PR updates the `swaggertype` tag for the `Timeout` field in `pkg/auth/remote/config.go`. 

This change was originally part of PR #4314 but was requested to be split into its own PR to keep the main feature PR focused on the validating webhook middleware.

Fix: #4353 

### Changes Included
- Modified `pkg/auth/remote/config.go` to use `swaggertype:"primitive,integer"` for the `Timeout` field.
- Updated `docs/server/docs.go`, `docs/server/swagger.json`, and `docs/server/swagger.yaml` accordingly.

### Verification
- Ran `task docs` to confirm no unwanted schema bloat for `time.Duration`.
- Verified documentation synchronization with `./cmd/help/verify.sh`.
