### PR TITLE
Validate volume mount source paths before detached process

### DIFF
--- a/pkg/runner/config_builder.go
+++ b/pkg/runner/config_builder.go
@@ -1063,13 +1063,9 @@ func (b *runConfigBuilder) processVolumeMounts() error {
 
 		// Validate source path exists on host filesystem (CLI context only)
 		if b.buildContext == BuildContextCLI && !mount.IsResourceURI() {
-			absSource := source
-			if !filepath.IsAbs(source) {
-				cwd, err := os.Getwd()
-				if err != nil {
-					return fmt.Errorf("failed to resolve relative path %s: %w", source, err)
-				}
-				absSource = filepath.Join(cwd, source)
+			absSource, err := filepath.Abs(source)
+			if err != nil {
+				return fmt.Errorf("failed to resolve path %s: %w", source, err)
 			}
 			if _, err := os.Stat(absSource); err != nil {
 				if os.IsNotExist(err) {

--- a/pkg/runner/config_builder.go
+++ b/pkg/runner/config_builder.go
@@ -9,6 +9,8 @@ import (
 	"log/slog"
 	"maps"
 	"net/url"
+	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 
@@ -1057,6 +1059,24 @@ func (b *runConfigBuilder) processVolumeMounts() error {
 		source, target, err := mount.Parse()
 		if err != nil {
 			return fmt.Errorf("invalid volume format: %s (%w)", volume, err)
+		}
+
+		// Validate source path exists on host filesystem (CLI context only)
+		if b.buildContext == BuildContextCLI && !mount.IsResourceURI() {
+			absSource := source
+			if !filepath.IsAbs(source) {
+				cwd, err := os.Getwd()
+				if err != nil {
+					return fmt.Errorf("failed to resolve relative path %s: %w", source, err)
+				}
+				absSource = filepath.Join(cwd, source)
+			}
+			if _, err := os.Stat(absSource); err != nil {
+				if os.IsNotExist(err) {
+					return fmt.Errorf("volume source path does not exist: %s", absSource)
+				}
+				return fmt.Errorf("cannot access volume source path %s: %w", absSource, err)
+			}
 		}
 
 		// Check for duplicate mount target

--- a/pkg/runner/config_builder_test.go
+++ b/pkg/runner/config_builder_test.go
@@ -713,6 +713,32 @@ func TestNewOperatorRunConfigBuilder(t *testing.T) {
 	assert.NotNil(t, config.ContainerLabels, "ContainerLabels should be initialized")
 }
 
+// TestOperatorContextSkipsVolumeValidation verifies that operator context does not
+// validate volume source paths on the host filesystem, since paths reference
+// Kubernetes node paths rather than the operator pod's filesystem.
+func TestOperatorContextSkipsVolumeValidation(t *testing.T) {
+	t.Parallel()
+
+	mockValidator := &mockEnvVarValidator{}
+	imageMetadata := &regtypes.ImageMetadata{
+		BaseServerMetadata: regtypes.BaseServerMetadata{
+			Name:  "test-image",
+			Tools: []string{"tool1"},
+		},
+	}
+
+	config, err := NewOperatorRunConfigBuilder(
+		context.Background(),
+		imageMetadata,
+		nil,
+		mockValidator,
+		WithVolumes([]string{"/nonexistent/node/path:/container"}),
+		WithPermissionProfile(permissions.BuiltinNoneProfile()),
+	)
+	require.NoError(t, err, "Operator context should not validate source paths")
+	assert.NotNil(t, config)
+}
+
 // TestWithEnvVars tests the WithEnvVars method
 func TestWithEnvVars(t *testing.T) {
 	t.Parallel()

--- a/pkg/runner/config_builder_test.go
+++ b/pkg/runner/config_builder_test.go
@@ -242,6 +242,12 @@ func TestRunConfigBuilder_Build_WithVolumeMounts(t *testing.T) {
 	// Create a mock environment variable validator
 	mockValidator := &mockEnvVarValidator{}
 
+	// Create real temp directories so volume mount source path validation passes
+	hostDir := t.TempDir()
+	hostDir1 := t.TempDir()
+	hostDir2 := t.TempDir()
+	hostDir3 := t.TempDir()
+
 	testCases := []struct {
 		name                string
 		builderOptions      []RunConfigBuilderOption
@@ -261,7 +267,7 @@ func TestRunConfigBuilder_Build_WithVolumeMounts(t *testing.T) {
 		{
 			name: "Volumes without permission profile but with profile name",
 			builderOptions: []RunConfigBuilderOption{
-				WithVolumes([]string{"/host:/container"}),
+				WithVolumes([]string{hostDir + ":/container"}),
 				WithPermissionProfileNameOrPath(permissions.ProfileNone),
 			},
 			expectError:         false,
@@ -271,7 +277,7 @@ func TestRunConfigBuilder_Build_WithVolumeMounts(t *testing.T) {
 		{
 			name: "Read-only volume with existing profile",
 			builderOptions: []RunConfigBuilderOption{
-				WithVolumes([]string{"/host:/container:ro"}),
+				WithVolumes([]string{hostDir + ":/container:ro"}),
 				WithPermissionProfile(permissions.BuiltinNoneProfile()),
 			},
 			expectError:         false,
@@ -281,7 +287,7 @@ func TestRunConfigBuilder_Build_WithVolumeMounts(t *testing.T) {
 		{
 			name: "Read-write volume with existing profile",
 			builderOptions: []RunConfigBuilderOption{
-				WithVolumes([]string{"/host:/container"}),
+				WithVolumes([]string{hostDir + ":/container"}),
 				WithPermissionProfile(permissions.BuiltinNoneProfile()),
 			},
 			expectError:         false,
@@ -292,9 +298,9 @@ func TestRunConfigBuilder_Build_WithVolumeMounts(t *testing.T) {
 			name: "Multiple volumes with existing profile",
 			builderOptions: []RunConfigBuilderOption{
 				WithVolumes([]string{
-					"/host1:/container1:ro",
-					"/host2:/container2",
-					"/host3:/container3:ro",
+					hostDir1 + ":/container1:ro",
+					hostDir2 + ":/container2",
+					hostDir3 + ":/container3:ro",
 				}),
 				WithPermissionProfile(permissions.BuiltinNoneProfile()),
 			},
@@ -306,6 +312,14 @@ func TestRunConfigBuilder_Build_WithVolumeMounts(t *testing.T) {
 			name: "Invalid volume format",
 			builderOptions: []RunConfigBuilderOption{
 				WithVolumes([]string{"invalid:format:with:too:many:colons"}),
+				WithPermissionProfile(permissions.BuiltinNoneProfile()),
+			},
+			expectError: true,
+		},
+		{
+			name: "Non-existent source path",
+			builderOptions: []RunConfigBuilderOption{
+				WithVolumes([]string{"/nonexistent/path:/container"}),
 				WithPermissionProfile(permissions.BuiltinNoneProfile()),
 			},
 			expectError: true,

--- a/pkg/runner/config_test.go
+++ b/pkg/runner/config_test.go
@@ -754,7 +754,8 @@ func TestRunConfigBuilder(t *testing.T) {
 	}
 	host := localhostStr
 	debug := true
-	volumes := []string{"/host:/container"}
+	hostDir := t.TempDir()
+	volumes := []string{hostDir + ":/container"}
 	secretsList := []string{"secret1,target=ENV_VAR1"}
 	authzConfigPath := "" // Empty to skip loading the authorization configuration
 	permissionProfile := permissions.ProfileNone
@@ -1310,9 +1311,13 @@ func TestRunConfigBuilder_VolumeProcessing(t *testing.T) {
 	runtime := &runtimemocks.MockRuntime{}
 	validator := &mockEnvVarValidator{}
 
+	// Use real temp directories so volume mount source path validation passes
+	hostRead := t.TempDir()
+	hostWrite := t.TempDir()
+
 	volumes := []string{
-		"/host/read:/container/read:ro",
-		"/host/write:/container/write",
+		hostRead + ":/container/read:ro",
+		hostWrite + ":/container/write",
 	}
 
 	config, err := NewRunConfigBuilder(context.Background(), nil, nil, validator,


### PR DESCRIPTION
## Summary

Volume mount errors were silently buried in proxy log files when the source path didn't exist. Users saw a success message but the server immediately entered error state. This adds pre-flight validation in `processVolumeMounts()` so path errors surface immediately in the terminal.

This picks up where #3932 left off, addressing the two must-fix items from @JAORMX's review:
1. Uses `mount.IsResourceURI()` instead of `strings.HasPrefix` for resource URI detection
2. Uses `os.IsNotExist(err)` to distinguish "not exists" from "permission denied"

Fixes #2485

## Type of change

- [x] Bug fix

## Test plan

- [x] Ran `go build ./...` - passes
- [x] Ran `go test ./pkg/runner/... -count=1` - all tests pass
- [x] Added test case for non-existent source path error
- [x] Updated existing volume mount tests to use real temp directories
- [x] Verified resource URIs skip validation (via `mount.IsResourceURI()`)
- [x] Verified operator context skips validation (via `BuildContextCLI` check)

## Changes

| File | Change |
|------|--------|
| `pkg/runner/config_builder.go` | Add source path validation after `mount.Parse()`, before duplicate check |
| `pkg/runner/config_builder_test.go` | Use real temp dirs, add non-existent path test case |
| `pkg/runner/config_test.go` | Use real temp dirs for volume processing test |

Generated with [Claude Code](https://claude.com/claude-code)