### PR TITLE
fix(ci): clear full build cache before coverage to prevent NumStmt mismatch

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -107,9 +107,13 @@ tasks:
     cmds:
       - cmd: mkdir -p coverage
         platforms: [linux, darwin]
-      # Clean test cache to prevent "inconsistent NumStmt" errors from stale instrumented binaries.
-      # Only the test cache needs clearing (not the full build cache), preserving compiled packages.
-      - cmd: go clean -testcache
+      # Clear both the test-result cache and the build cache before running coverage.
+      # The CI build cache is keyed on go.sum, so source-only changes don't bust it.
+      # With -coverpkg=./..., every test binary instruments all packages; if any binary
+      # was compiled from a stale cached artifact (different NumStmt than the current
+      # source), go tool cover -func will error with "inconsistent NumStmt". Clearing
+      # the full build cache guarantees every package is instrumented from fresh source.
+      - cmd: go clean -cache -testcache
         platforms: [linux, darwin]
       # Only install gotestfmt if not already installed
       - cmd: which gotestfmt > /dev/null 2>&1 || go install github.com/gotesttools/gotestfmt/v2/cmd/gotestfmt@latest
@@ -131,9 +135,9 @@ tasks:
     cmds:
       - cmd: cmd.exe /c mkdir coverage
         ignore_error: true   # Windows has no mkdir -p, so just ignore error if it exists
-      # Clean test cache to prevent "inconsistent NumStmt" errors from stale instrumented binaries.
-      # Only the test cache needs clearing (not the full build cache), preserving compiled packages.
-      - go clean -testcache
+      # Clear both the test-result cache and the build cache before running coverage.
+      # See the unix variant above for rationale.
+      - go clean -cache -testcache
       - go test -race -coverpkg=./... -coverprofile=coverage/coverage.out {{.DIR_LIST | catLines}}
       - go tool cover -func=coverage/coverage.out
       - echo "Generating HTML coverage report in coverage/coverage.html"


### PR DESCRIPTION

## Summary

The CI Go build cache is keyed on go.sum, so source-only changes do not bust it. With -coverpkg=./..., every test binary instruments all packages; if any binary was compiled from a stale cached artifact whose coverage statement count differs from the current source, go tool cover -func errors with "inconsistent NumStmt: changed from N to M".

Replace go clean -testcache with go clean -cache -testcache so that both the test-result cache and the compiled artifact cache are wiped before each coverage run, guaranteeing every package is instrumented from fresh source.

<!--
Link related issues. Use "Closes" or "Fixes" to auto-close on merge.
Remove this line if there is no related issue.
-->

Fixes #

## Type of change

<!-- REQUIRED. Check exactly one. -->

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

<!--
REQUIRED. Check every verification step you actually ran.
You MUST check at least one item. If you only did manual testing,
describe exactly what you tested below the checkbox.
-->

- [x] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [ ] Linting (`task lint-fix`)
- [ ] Manual testing (describe below)

## Changes

<!--
Optional — include for PRs touching more than a few files to help
reviewers navigate the diff. Remove this entire section for small PRs.
-->

| File | Change |
|------|--------|
|      |        |

## Does this introduce a user-facing change?

<!--
If yes, describe the change from the user's perspective. This helps with release notes.
If no, write "No".
Remove this section entirely if not applicable.
-->

## Special notes for reviewers

<!--
Optional — call out anything non-obvious: tricky logic, known limitations,
areas where you'd like extra scrutiny, or follow-up work planned.
Remove this section if not needed.
-->
