### PR TITLE
Return JSON 404 for OAuth discovery when auth is off

### DIFF
--- a/pkg/auth/well_known.go
+++ b/pkg/auth/well_known.go
@@ -18,38 +18,36 @@ import (
 // under it must be accessible without authentication. This handler ensures proper
 // routing of discovery requests while returning 404 for unknown paths.
 //
-// If authInfoHandler is nil, this function returns nil (no handler registration needed).
+// If authInfoHandler is nil, the returned handler responds with HTTP 404 and a
+// JSON body for all /.well-known/ paths. This ensures OAuth discovery clients
+// (e.g., Claude Code) receive a clean, parseable "not found" instead of falling
+// through to the MCP handler, which would reject the GET with an HTTP 406
+// JSON-RPC error that breaks OAuth error parsing.
 //
 // Usage:
 //
 //	authInfoHandler := auth.NewAuthInfoHandler(issuer, resourceURL, scopes)
 //	wellKnownHandler := auth.NewWellKnownHandler(authInfoHandler)
-//	if wellKnownHandler != nil {
-//	    mux.Handle("/.well-known/", wellKnownHandler)
-//	}
+//	mux.Handle("/.well-known/", wellKnownHandler)
 //
 // This handler matches:
 //   - /.well-known/oauth-protected-resource (exact)
 //   - /.well-known/oauth-protected-resource/* (subpaths)
 //
-// Returns 404 for other /.well-known/* paths.
+// Returns 404 for other /.well-known/* paths or when auth is not configured.
 func NewWellKnownHandler(authInfoHandler http.Handler) http.Handler {
-	if authInfoHandler == nil {
-		return nil
-	}
-
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// RFC 9728: Match /.well-known/oauth-protected-resource and any subpaths
-		// Examples:
-		//   ✓ /.well-known/oauth-protected-resource
-		//   ✓ /.well-known/oauth-protected-resource/mcp
-		//   ✗ /.well-known/other-endpoint
-		if strings.HasPrefix(r.URL.Path, oauthproto.WellKnownOAuthResourcePath) {
+		// When auth is configured, route discovery requests to the auth handler.
+		if authInfoHandler != nil &&
+			strings.HasPrefix(r.URL.Path, oauthproto.WellKnownOAuthResourcePath) {
 			authInfoHandler.ServeHTTP(w, r)
 			return
 		}
 
-		// Unknown .well-known path
-		http.NotFound(w, r)
+		// No auth configured, or unknown .well-known path — return JSON 404
+		// so OAuth discovery clients can parse the response cleanly.
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":"not_found"}`))
 	})
 }

--- a/pkg/auth/well_known_test.go
+++ b/pkg/auth/well_known_test.go
@@ -22,9 +22,21 @@ func TestNewWellKnownHandler(t *testing.T) {
 		testRequests    []testRequest
 	}{
 		{
-			name:            "nil authInfoHandler returns nil",
+			name:            "nil authInfoHandler returns 404 JSON for discovery path",
 			authInfoHandler: nil,
-			expectedNil:     true,
+			expectedNil:     false,
+			testRequests: []testRequest{
+				{
+					path:           "/.well-known/oauth-protected-resource",
+					expectedStatus: http.StatusNotFound,
+					expectedBody:   `{"error":"not_found"}`,
+				},
+				{
+					path:           "/.well-known/other",
+					expectedStatus: http.StatusNotFound,
+					expectedBody:   `{"error":"not_found"}`,
+				},
+			},
 		},
 		{
 			name: "exact path /.well-known/oauth-protected-resource routes to authInfoHandler",
@@ -82,12 +94,12 @@ func TestNewWellKnownHandler(t *testing.T) {
 				{
 					path:           "/.well-known/openid-configuration",
 					expectedStatus: http.StatusNotFound,
-					expectedBody:   "404 page not found\n",
+					expectedBody:   `{"error":"not_found"}`,
 				},
 				{
 					path:           "/.well-known/other",
 					expectedStatus: http.StatusNotFound,
-					expectedBody:   "404 page not found\n",
+					expectedBody:   `{"error":"not_found"}`,
 				},
 			},
 		},
@@ -249,13 +261,13 @@ func TestWellKnownHandler_EdgeCases(t *testing.T) {
 			name:           "different .well-known path returns 404",
 			path:           "/.well-known/jwks.json", // Different endpoint
 			expectedStatus: http.StatusNotFound,
-			expectedBody:   "404 page not found\n",
+			expectedBody:   `{"error":"not_found"}`,
 		},
 		{
 			name:           "path prefix match is not sufficient",
 			path:           "/.well-known/oauth", // Prefix but not full path
 			expectedStatus: http.StatusNotFound,
-			expectedBody:   "404 page not found\n",
+			expectedBody:   `{"error":"not_found"}`,
 		},
 	}
 

--- a/pkg/transport/proxy/transparent/transparent_proxy.go
+++ b/pkg/transport/proxy/transparent/transparent_proxy.go
@@ -589,10 +589,11 @@ func (p *TransparentProxy) Start(ctx context.Context) error {
 
 	// 4. Mount RFC 9728 OAuth Protected Resource discovery endpoint (no middlewares)
 	// Note: This is DIFFERENT from the auth server's /.well-known/oauth-authorization-server
-	// We mount at specific paths to allow prefix handlers to register other well-known paths.
-	if wellKnownHandler := auth.NewWellKnownHandler(p.authInfoHandler); wellKnownHandler != nil {
-		mux.Handle("/.well-known/oauth-protected-resource", wellKnownHandler)
-		mux.Handle("/.well-known/oauth-protected-resource/", wellKnownHandler)
+	// Always register so OAuth discovery gets a clean 404 JSON when auth is off,
+	// instead of falling through to the proxy catch-all.
+	wellKnownHandler := auth.NewWellKnownHandler(p.authInfoHandler)
+	mux.Handle("/.well-known/", wellKnownHandler)
+	if p.authInfoHandler != nil {
 		slog.Debug("rfc 9728 OAuth discovery endpoint enabled at /.well-known/oauth-protected-resource")
 	}
 

--- a/pkg/vmcp/server/server.go
+++ b/pkg/vmcp/server/server.go
@@ -469,10 +469,14 @@ func (s *Server) Handler(_ context.Context) (http.Handler, error) {
 		}
 	}
 
-	// RFC 9728 protected resource metadata (explicit path, not catch-all)
-	if wellKnownHandler := auth.NewWellKnownHandler(s.config.AuthInfoHandler); wellKnownHandler != nil {
-		mux.Handle("/.well-known/oauth-protected-resource", wellKnownHandler)
-		mux.Handle("/.well-known/oauth-protected-resource/", wellKnownHandler)
+	// RFC 9728 protected resource metadata.
+	// Always register a .well-known handler so OAuth discovery requests get a
+	// clean response (404 JSON when auth is off) instead of falling through to
+	// the MCP handler, which rejects GETs with a 406 JSON-RPC error that
+	// breaks Claude Code's OAuth error parsing.
+	wellKnownHandler := auth.NewWellKnownHandler(s.config.AuthInfoHandler)
+	mux.Handle("/.well-known/", wellKnownHandler)
+	if s.config.AuthInfoHandler != nil {
 		slog.Debug("RFC 9728 OAuth protected resource metadata enabled")
 	}
 


### PR DESCRIPTION
## Summary

Claude Code v2.1.83 introduced mandatory OAuth discovery for all HTTP MCP servers — it sends `GET /.well-known/oauth-protected-resource` before connecting. When the vMCP server (or transparent proxy) has no auth configured, no `.well-known` handler was registered, so these requests fell through to the `/` catch-all MCP handler. There, `headerValidatingMiddleware` rejected the GET with HTTP 406 and a JSON-RPC error body where `"error"` is an object. Claude Code expects `"error"` as a string (OAuth error format), Zod validation fails, and it shows "needs authentication" even though no auth is needed.

- Always register a `.well-known/` prefix handler via `NewWellKnownHandler`, even when `AuthInfoHandler` is nil
- When auth is not configured, return HTTP 404 with `{"error":"not_found"}` JSON — a clean, parseable signal that no auth metadata exists
- Apply the same fix to both the vMCP server and the transparent proxy

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)
- [x] Manual testing (describe below)

Verified that brood-box (which uses the vMCP proxy without auth) builds with a local `replace` directive and Claude Code v2.1.83 connects without the spurious "needs authentication" prompt.

## Changes

| File | Change |
|------|--------|
| `pkg/auth/well_known.go` | `NewWellKnownHandler` always returns a handler; nil authInfoHandler → 404 JSON |
| `pkg/auth/well_known_test.go` | Updated nil case to expect non-nil handler with 404 JSON; updated all 404 body assertions |
| `pkg/vmcp/server/server.go` | Register `.well-known/` prefix unconditionally |
| `pkg/transport/proxy/transparent/transparent_proxy.go` | Same unconditional registration for transparent proxy |

## Special notes for reviewers

The root cause is that `headerValidatingMiddleware` (which guards the MCP handler) returns a JSON-RPC error with `"error"` as an object, but OAuth discovery clients expect `"error"` as a string per RFC 6749. Rather than changing the middleware's error format (which is correct for MCP), we prevent OAuth discovery from reaching it at all.

Generated with [Claude Code](https://claude.com/claude-code)