### PR TITLE
Inject BackendReplicas and Redis session config into MCPServer RunConfig

### DIFF
--- a/cmd/thv-operator/controllers/mcpserver_runconfig.go
+++ b/cmd/thv-operator/controllers/mcpserver_runconfig.go
@@ -242,7 +242,39 @@ func (r *MCPServerReconciler) createRunConfigFromMCPServer(m *mcpv1alpha1.MCPSer
 		return nil, fmt.Errorf("failed to populate middleware configs: %w", err)
 	}
 
+	// Populate scaling config (BackendReplicas and Redis session storage).
+	// Both fields use nil-passthrough: only set when explicitly configured in the spec.
+	populateScalingConfig(runConfig, m)
+
 	return runConfig, nil
+}
+
+// populateScalingConfig sets BackendReplicas and SessionRedis on the RunConfig from the MCPServer spec.
+// Fields are only set when present in the spec; nil means "not configured" and is left as-is.
+func populateScalingConfig(runConfig *runner.RunConfig, m *mcpv1alpha1.MCPServer) {
+	hasBackendReplicas := m.Spec.BackendReplicas != nil
+	hasRedis := m.Spec.SessionStorage != nil && m.Spec.SessionStorage.Provider == mcpv1alpha1.SessionStorageProviderRedis
+
+	if !hasBackendReplicas && !hasRedis {
+		return
+	}
+
+	if runConfig.ScalingConfig == nil {
+		runConfig.ScalingConfig = &runner.ScalingConfig{}
+	}
+
+	if hasBackendReplicas {
+		val := *m.Spec.BackendReplicas
+		runConfig.ScalingConfig.BackendReplicas = &val
+	}
+
+	if hasRedis {
+		runConfig.ScalingConfig.SessionRedis = &runner.SessionRedisConfig{
+			Address:   m.Spec.SessionStorage.Address,
+			DB:        m.Spec.SessionStorage.DB,
+			KeyPrefix: m.Spec.SessionStorage.KeyPrefix,
+		}
+	}
 }
 
 // labelsForRunConfig returns labels for run config ConfigMap

--- a/cmd/thv-operator/controllers/mcpserver_runconfig_test.go
+++ b/cmd/thv-operator/controllers/mcpserver_runconfig_test.go
@@ -1703,3 +1703,160 @@ func TestEnsureRunConfigConfigMap_WithVaultInjection(t *testing.T) {
 		})
 	}
 }
+
+// TestPopulateScalingConfig tests BackendReplicas and SessionRedis injection into RunConfig.
+func TestPopulateScalingConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		spec     mcpv1alpha1.MCPServerSpec
+		expected func(t *testing.T, sc *runner.ScalingConfig)
+	}{
+		{
+			name: "nil backendReplicas and nil sessionStorage — ScalingConfig stays nil",
+			spec: mcpv1alpha1.MCPServerSpec{
+				Image:     testImage,
+				Transport: stdioTransport,
+				ProxyPort: 8080,
+			},
+			expected: func(t *testing.T, sc *runner.ScalingConfig) {
+				t.Helper()
+				assert.Nil(t, sc)
+			},
+		},
+		{
+			name: "backendReplicas set — written to ScalingConfig",
+			spec: mcpv1alpha1.MCPServerSpec{
+				Image:           testImage,
+				Transport:       stdioTransport,
+				ProxyPort:       8080,
+				BackendReplicas: int32Ptr(3),
+			},
+			expected: func(t *testing.T, sc *runner.ScalingConfig) {
+				t.Helper()
+				require.NotNil(t, sc)
+				require.NotNil(t, sc.BackendReplicas)
+				assert.Equal(t, int32(3), *sc.BackendReplicas)
+			},
+		},
+		{
+			name: "backendReplicas zero — written (not nil) to ScalingConfig",
+			spec: mcpv1alpha1.MCPServerSpec{
+				Image:           testImage,
+				Transport:       stdioTransport,
+				ProxyPort:       8080,
+				BackendReplicas: int32Ptr(0),
+			},
+			expected: func(t *testing.T, sc *runner.ScalingConfig) {
+				t.Helper()
+				require.NotNil(t, sc)
+				require.NotNil(t, sc.BackendReplicas)
+				assert.Equal(t, int32(0), *sc.BackendReplicas)
+			},
+		},
+		{
+			name: "sessionStorage nil — SessionRedis stays nil",
+			spec: mcpv1alpha1.MCPServerSpec{
+				Image:           testImage,
+				Transport:       stdioTransport,
+				ProxyPort:       8080,
+				BackendReplicas: int32Ptr(2),
+			},
+			expected: func(t *testing.T, sc *runner.ScalingConfig) {
+				t.Helper()
+				require.NotNil(t, sc)
+				assert.Nil(t, sc.SessionRedis)
+			},
+		},
+		{
+			name: "sessionStorage memory — SessionRedis stays nil",
+			spec: mcpv1alpha1.MCPServerSpec{
+				Image:     testImage,
+				Transport: stdioTransport,
+				ProxyPort: 8080,
+				SessionStorage: &mcpv1alpha1.SessionStorageConfig{
+					Provider: "memory",
+				},
+			},
+			expected: func(t *testing.T, sc *runner.ScalingConfig) {
+				t.Helper()
+				assert.Nil(t, sc)
+			},
+		},
+		{
+			name: "sessionStorage redis — address/db/keyPrefix written to SessionRedis",
+			spec: mcpv1alpha1.MCPServerSpec{
+				Image:     testImage,
+				Transport: stdioTransport,
+				ProxyPort: 8080,
+				SessionStorage: &mcpv1alpha1.SessionStorageConfig{
+					Provider:  "redis",
+					Address:   "redis.default.svc:6379",
+					DB:        2,
+					KeyPrefix: "thv:",
+				},
+			},
+			expected: func(t *testing.T, sc *runner.ScalingConfig) {
+				t.Helper()
+				require.NotNil(t, sc)
+				require.NotNil(t, sc.SessionRedis)
+				assert.Equal(t, "redis.default.svc:6379", sc.SessionRedis.Address)
+				assert.Equal(t, int32(2), sc.SessionRedis.DB)
+				assert.Equal(t, "thv:", sc.SessionRedis.KeyPrefix)
+			},
+		},
+		{
+			name: "sessionStorage redis with passwordRef — password NOT in SessionRedis",
+			spec: mcpv1alpha1.MCPServerSpec{
+				Image:     testImage,
+				Transport: stdioTransport,
+				ProxyPort: 8080,
+				SessionStorage: &mcpv1alpha1.SessionStorageConfig{
+					Provider: "redis",
+					Address:  "redis:6379",
+					PasswordRef: &mcpv1alpha1.SecretKeyRef{
+						Name: "redis-secret",
+						Key:  "password",
+					},
+				},
+			},
+			expected: func(t *testing.T, sc *runner.ScalingConfig) {
+				t.Helper()
+				require.NotNil(t, sc)
+				require.NotNil(t, sc.SessionRedis)
+				assert.Equal(t, "redis:6379", sc.SessionRedis.Address)
+				assert.Equal(t, int32(0), sc.SessionRedis.DB)
+				assert.Empty(t, sc.SessionRedis.KeyPrefix)
+				// Password must NOT be stored in the RunConfig (it's injected as pod env var).
+				// Verify neither the secret name nor the key leaks into the serialized config.
+				data, err := json.Marshal(sc)
+				require.NoError(t, err)
+				assert.NotContains(t, string(data), "redis-secret")
+				assert.NotContains(t, string(data), "password")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			m := &mcpv1alpha1.MCPServer{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+				Spec:       tt.spec,
+			}
+
+			r := &MCPServerReconciler{
+				Client: fake.NewClientBuilder().
+					WithScheme(createRunConfigTestScheme()).
+					WithObjects(m).
+					Build(),
+			}
+
+			runConfig, err := r.createRunConfigFromMCPServer(m)
+			require.NoError(t, err)
+			tt.expected(t, runConfig.ScalingConfig)
+		})
+	}
+}

--- a/docs/server/docs.go
+++ b/docs/server/docs.go
@@ -1136,6 +1136,27 @@ const docTemplate = `{
                     "backend_replicas": {
                         "description": "BackendReplicas is the desired StatefulSet replica count for the proxy runner backend.\nWhen nil, replicas are unmanaged (preserving HPA or manual kubectl control).\nWhen set (including 0), the value is an explicit replica count.",
                         "type": "integer"
+                    },
+                    "session_redis": {
+                        "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_runner.SessionRedisConfig"
+                    }
+                },
+                "type": "object"
+            },
+            "github_com_stacklok_toolhive_pkg_runner.SessionRedisConfig": {
+                "description": "SessionRedis holds non-sensitive Redis connection parameters for distributed session storage.\nPopulated only when MCPServer.spec.sessionStorage.provider == \"redis\".\nThe Redis password is not included — it is injected as env var THV_SESSION_REDIS_PASSWORD.\n+optional",
+                "properties": {
+                    "address": {
+                        "description": "Address is the Redis server address (host:port).",
+                        "type": "string"
+                    },
+                    "db": {
+                        "description": "DB is the Redis database number.",
+                        "type": "integer"
+                    },
+                    "key_prefix": {
+                        "description": "KeyPrefix is an optional prefix applied to all Redis keys used by ToolHive.",
+                        "type": "string"
                     }
                 },
                 "type": "object"

--- a/docs/server/swagger.json
+++ b/docs/server/swagger.json
@@ -1129,6 +1129,27 @@
                     "backend_replicas": {
                         "description": "BackendReplicas is the desired StatefulSet replica count for the proxy runner backend.\nWhen nil, replicas are unmanaged (preserving HPA or manual kubectl control).\nWhen set (including 0), the value is an explicit replica count.",
                         "type": "integer"
+                    },
+                    "session_redis": {
+                        "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_runner.SessionRedisConfig"
+                    }
+                },
+                "type": "object"
+            },
+            "github_com_stacklok_toolhive_pkg_runner.SessionRedisConfig": {
+                "description": "SessionRedis holds non-sensitive Redis connection parameters for distributed session storage.\nPopulated only when MCPServer.spec.sessionStorage.provider == \"redis\".\nThe Redis password is not included — it is injected as env var THV_SESSION_REDIS_PASSWORD.\n+optional",
+                "properties": {
+                    "address": {
+                        "description": "Address is the Redis server address (host:port).",
+                        "type": "string"
+                    },
+                    "db": {
+                        "description": "DB is the Redis database number.",
+                        "type": "integer"
+                    },
+                    "key_prefix": {
+                        "description": "KeyPrefix is an optional prefix applied to all Redis keys used by ToolHive.",
+                        "type": "string"
                     }
                 },
                 "type": "object"

--- a/docs/server/swagger.yaml
+++ b/docs/server/swagger.yaml
@@ -1078,6 +1078,26 @@ components:
             When nil, replicas are unmanaged (preserving HPA or manual kubectl control).
             When set (including 0), the value is an explicit replica count.
           type: integer
+        session_redis:
+          $ref: '#/components/schemas/github_com_stacklok_toolhive_pkg_runner.SessionRedisConfig'
+      type: object
+    github_com_stacklok_toolhive_pkg_runner.SessionRedisConfig:
+      description: |-
+        SessionRedis holds non-sensitive Redis connection parameters for distributed session storage.
+        Populated only when MCPServer.spec.sessionStorage.provider == "redis".
+        The Redis password is not included — it is injected as env var THV_SESSION_REDIS_PASSWORD.
+        +optional
+      properties:
+        address:
+          description: Address is the Redis server address (host:port).
+          type: string
+        db:
+          description: DB is the Redis database number.
+          type: integer
+        key_prefix:
+          description: KeyPrefix is an optional prefix applied to all Redis keys used
+            by ToolHive.
+          type: string
       type: object
     github_com_stacklok_toolhive_pkg_runner.ToolOverride:
       properties:

--- a/pkg/runner/config.go
+++ b/pkg/runner/config.go
@@ -233,6 +233,26 @@ type ScalingConfig struct {
 	// When nil, replicas are unmanaged (preserving HPA or manual kubectl control).
 	// When set (including 0), the value is an explicit replica count.
 	BackendReplicas *int32 `json:"backend_replicas,omitempty" yaml:"backend_replicas,omitempty"`
+
+	// SessionRedis holds non-sensitive Redis connection parameters for distributed session storage.
+	// Populated only when MCPServer.spec.sessionStorage.provider == "redis".
+	// The Redis password is not included — it is injected as env var THV_SESSION_REDIS_PASSWORD.
+	// +optional
+	SessionRedis *SessionRedisConfig `json:"session_redis,omitempty" yaml:"session_redis,omitempty"`
+}
+
+// SessionRedisConfig contains non-sensitive Redis connection parameters used for distributed
+// session storage when the operator is configured with sessionStorage.provider == "redis".
+// The Redis password is excluded and injected separately as env var THV_SESSION_REDIS_PASSWORD.
+type SessionRedisConfig struct {
+	// Address is the Redis server address (host:port).
+	Address string `json:"address,omitempty" yaml:"address,omitempty"`
+
+	// DB is the Redis database number.
+	DB int32 `json:"db,omitempty" yaml:"db,omitempty"`
+
+	// KeyPrefix is an optional prefix applied to all Redis keys used by ToolHive.
+	KeyPrefix string `json:"key_prefix,omitempty" yaml:"key_prefix,omitempty"`
 }
 
 // WriteJSON serializes the RunConfig to JSON and writes it to the provided writer

--- a/pkg/runner/config_test.go
+++ b/pkg/runner/config_test.go
@@ -2336,3 +2336,120 @@ func TestRunConfig_BackendReplicas(t *testing.T) {
 		assert.Equal(t, int32(5), *got.ScalingConfig.BackendReplicas)
 	})
 }
+
+func TestRunConfig_SessionRedis(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil SessionRedis is omitted from JSON output", func(t *testing.T) {
+		t.Parallel()
+		cfg := NewRunConfig()
+		cfg.Name = "no-redis"
+
+		var buf bytes.Buffer
+		require.NoError(t, cfg.WriteJSON(&buf))
+		assert.NotContains(t, buf.String(), "session_redis")
+	})
+
+	t.Run("nil SessionRedis within non-nil ScalingConfig is omitted from JSON output", func(t *testing.T) {
+		t.Parallel()
+		cfg := NewRunConfig()
+		cfg.Name = "scaling-no-redis"
+		replicas := int32(2)
+		cfg.ScalingConfig = &ScalingConfig{
+			BackendReplicas: &replicas,
+			SessionRedis:    nil,
+		}
+
+		var buf bytes.Buffer
+		require.NoError(t, cfg.WriteJSON(&buf))
+		assert.NotContains(t, buf.String(), "session_redis")
+	})
+
+	t.Run("JSON round-trip with all SessionRedis fields set", func(t *testing.T) {
+		t.Parallel()
+		cfg := NewRunConfig()
+		cfg.Name = "redis-server"
+		cfg.ScalingConfig = &ScalingConfig{
+			SessionRedis: &SessionRedisConfig{
+				Address:   "redis.default.svc:6379",
+				DB:        2,
+				KeyPrefix: "thv:",
+			},
+		}
+
+		var buf bytes.Buffer
+		require.NoError(t, cfg.WriteJSON(&buf))
+
+		got, err := ReadJSON(&buf)
+		require.NoError(t, err)
+		require.NotNil(t, got.ScalingConfig)
+		require.NotNil(t, got.ScalingConfig.SessionRedis)
+		assert.Equal(t, "redis.default.svc:6379", got.ScalingConfig.SessionRedis.Address)
+		assert.Equal(t, int32(2), got.ScalingConfig.SessionRedis.DB)
+		assert.Equal(t, "thv:", got.ScalingConfig.SessionRedis.KeyPrefix)
+	})
+
+	t.Run("JSON round-trip with zero DB and empty KeyPrefix", func(t *testing.T) {
+		t.Parallel()
+		cfg := NewRunConfig()
+		cfg.Name = "redis-defaults"
+		cfg.ScalingConfig = &ScalingConfig{
+			SessionRedis: &SessionRedisConfig{
+				Address: "redis:6379",
+			},
+		}
+
+		var buf bytes.Buffer
+		require.NoError(t, cfg.WriteJSON(&buf))
+
+		got, err := ReadJSON(&buf)
+		require.NoError(t, err)
+		require.NotNil(t, got.ScalingConfig.SessionRedis)
+		assert.Equal(t, "redis:6379", got.ScalingConfig.SessionRedis.Address)
+		assert.Equal(t, int32(0), got.ScalingConfig.SessionRedis.DB)
+		assert.Empty(t, got.ScalingConfig.SessionRedis.KeyPrefix)
+	})
+
+	t.Run("YAML round-trip with SessionRedis set", func(t *testing.T) {
+		t.Parallel()
+		cfg := NewRunConfig()
+		cfg.Name = "yaml-redis"
+		cfg.ScalingConfig = &ScalingConfig{
+			SessionRedis: &SessionRedisConfig{
+				Address:   "redis:6379",
+				DB:        3,
+				KeyPrefix: "prefix:",
+			},
+		}
+
+		data, err := yaml.Marshal(cfg)
+		require.NoError(t, err)
+
+		var got RunConfig
+		require.NoError(t, yaml.Unmarshal(data, &got))
+		require.NotNil(t, got.ScalingConfig)
+		require.NotNil(t, got.ScalingConfig.SessionRedis)
+		assert.Equal(t, "redis:6379", got.ScalingConfig.SessionRedis.Address)
+		assert.Equal(t, int32(3), got.ScalingConfig.SessionRedis.DB)
+		assert.Equal(t, "prefix:", got.ScalingConfig.SessionRedis.KeyPrefix)
+	})
+
+	t.Run("SessionRedis with nil BackendReplicas preserves both in round-trip", func(t *testing.T) {
+		t.Parallel()
+		cfg := NewRunConfig()
+		cfg.Name = "redis-no-backend"
+		cfg.ScalingConfig = &ScalingConfig{
+			SessionRedis: &SessionRedisConfig{Address: "redis:6379"},
+		}
+
+		var buf bytes.Buffer
+		require.NoError(t, cfg.WriteJSON(&buf))
+
+		got, err := ReadJSON(&buf)
+		require.NoError(t, err)
+		require.NotNil(t, got.ScalingConfig)
+		assert.Nil(t, got.ScalingConfig.BackendReplicas)
+		require.NotNil(t, got.ScalingConfig.SessionRedis)
+		assert.Equal(t, "redis:6379", got.ScalingConfig.SessionRedis.Address)
+	})
+}


### PR DESCRIPTION

## Summary

<!--
REQUIRED. You MUST explain:
1. WHY this change is needed (the problem or motivation)
2. WHAT changed (concise bullet points)

The diff shows the code — your summary must provide the context a reviewer
needs to understand the purpose without reading the diff first.
-->

Populates ScalingConfig in the MCPServer RunConfig ConfigMap from spec.backendReplicas and spec.sessionStorage. Adds SessionRedisConfig (address, db, keyPrefix) to runner.ScalingConfig; the Redis password is intentionally excluded and injected as a pod env var instead. Both fields use nil-passthrough so unset specs leave the RunConfig fields absent (HPA/external controllers remain authoritative).

<!--
Link related issues. Use "Closes" or "Fixes" to auto-close on merge.
Remove this line if there is no related issue.
-->

Fixes #4218 

## Type of change

<!-- REQUIRED. Check exactly one. -->

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

<!--
REQUIRED. Check every verification step you actually ran.
You MUST check at least one item. If you only did manual testing,
describe exactly what you tested below the checkbox.
-->

- [x] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [x] Linting (`task lint-fix`)
- [ ] Manual testing (describe below)

## Changes

<!--
Optional — include for PRs touching more than a few files to help
reviewers navigate the diff. Remove this entire section for small PRs.
-->

| File | Change |
|------|--------|
|      |        |

## Does this introduce a user-facing change?

<!--
If yes, describe the change from the user's perspective. This helps with release notes.
If no, write "No".
Remove this section entirely if not applicable.
-->

## Special notes for reviewers

<!--
Optional — call out anything non-obvious: tricky logic, known limitations,
areas where you'd like extra scrutiny, or follow-up work planned.
Remove this section if not needed.
-->
