### PR TITLE
Fall through to well-known discovery when resource metadata auth fails

### DIFF
--- a/pkg/auth/remote/handler.go
+++ b/pkg/auth/remote/handler.go
@@ -333,7 +333,11 @@ func (h *Handler) discoverIssuerAndScopes(
 
 	// Priority 3: Fetch from resource metadata (RFC 9728)
 	if authInfo.ResourceMetadata != "" {
-		return h.tryDiscoverFromResourceMetadata(ctx, authInfo.ResourceMetadata)
+		issuer, scopes, authServerInfo, err := h.tryDiscoverFromResourceMetadata(ctx, authInfo.ResourceMetadata)
+		if err == nil {
+			return issuer, scopes, authServerInfo, nil
+		}
+		slog.Debug("Resource metadata discovery failed, falling through to well-known discovery", "error", err)
 	}
 
 	// Priority 4: Try to discover actual issuer from the server's well-known endpoint

--- a/pkg/auth/remote/handler_test.go
+++ b/pkg/auth/remote/handler_test.go
@@ -169,15 +169,15 @@ func TestDiscoverIssuerAndScopes(t *testing.T) {
 			expectError:    false,
 		},
 		{
-			name:   "malformed resource metadata URL",
+			name:   "malformed resource metadata URL falls through to URL-derived issuer",
 			config: &Config{},
 			authInfo: &discovery.AuthInfo{
 				Type:             "OAuth",
 				ResourceMetadata: "not-a-url",
 			},
-			remoteURL:     "https://server.example.com",
-			expectError:   true,
-			errorContains: "could not determine OAuth issuer",
+			remoteURL:      "https://server.example.com",
+			expectError:    false,
+			expectedIssuer: "https://server.example.com",
 		},
 
 		// Edge cases
@@ -442,10 +442,11 @@ func TestDiscoverIssuerAndScopes_Security(t *testing.T) {
 		ctx, cancel := context.WithTimeout(t.Context(), 1*time.Second)
 		defer cancel()
 
-		_, _, _, err := handler.discoverIssuerAndScopes(ctx, authInfo, "https://server.example.com")
+		issuer, _, _, err := handler.discoverIssuerAndScopes(ctx, authInfo, "https://server.example.com")
 
-		// Should timeout or fail gracefully, not hang or crash
-		assert.Error(t, err)
+		// Should not hang or crash; Priority 3 fails gracefully and falls through to URL-derived issuer
+		require.NoError(t, err)
+		assert.Equal(t, "https://server.example.com", issuer)
 	})
 }
 


### PR DESCRIPTION
## Summary

- Servers like Sourcegraph and Deepsearch include `resource_metadata` in their `WWW-Authenticate` header but list path-based URLs in their `authorization_servers` field (e.g. `https://sourcegraph.com/.api/mcp/sourcegraph`). Per RFC 8414, ToolHive extracts the path as a tenant and builds a discovery URL like `/.well-known/oauth-authorization-server/.api/mcp/sourcegraph` — an endpoint those servers don't serve. Validation fails and auth breaks.
- Before https://github.com/stacklok/toolhive/commit/6cad0b59, `DeriveIssuerFromURL` always stripped the path and returned the root domain issuer, which worked. That commit introduced the RFC 9728 resource metadata flow with a hard `return` at Priority 3, so when validation fails Priorities 4 and 5 (including `DeriveIssuerFromURL`) are never reached.
- Fix: capture the error from `tryDiscoverFromResourceMetadata` and only return on success. Failures log at DEBUG and fall through to Priority 4 (well-known probing) and Priority 5 (URL-derived issuer), restoring the previous working behaviour.

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test`)

## Does this introduce a user-facing change?

Yes — MCP servers that use path-based `authorization_servers` URLs in their resource metadata (e.g. Sourcegraph, Deepsearch) will successfully authenticate again instead of failing with a malformed discovery URL error.

## Special notes for reviewers

The regression was introduced in `6cad0b59` and first shipped in v0.3.0. Two test cases were updated: `malformed resource metadata URL` and `handles malicious resource metadata response`. Both previously expected an error that can no longer be returned — the function now falls through to Priority 5 and returns a URL-derived issuer. The DoS protection property of the second test is unchanged (response body draining is still capped by `MaxResponseBodyDrain`; the test just now asserts the derived issuer rather than an error).

Generated with [Claude Code](https://claude.com/claude-code)