### PR TITLE
Webhook Middleware Phase 3: Mutating webhook middleware with JSONPatch

### DIFF
--- a/docs/server/docs.go
+++ b/docs/server/docs.go
@@ -1195,6 +1195,14 @@ const docTemplate = `{
                         "type": "array",
                         "uniqueItems": false
                     },
+                    "mutating_webhooks": {
+                        "description": "MutatingWebhooks contains the configuration for mutating webhook middleware.\nMutating webhooks run before validating webhooks, per RFC THV-0017 ordering.",
+                        "items": {
+                            "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_webhook.Config"
+                        },
+                        "type": "array",
+                        "uniqueItems": false
+                    },
                     "name": {
                         "description": "Name is the name of the MCP server",
                         "type": "string"

--- a/docs/server/swagger.json
+++ b/docs/server/swagger.json
@@ -1188,6 +1188,14 @@
                         "type": "array",
                         "uniqueItems": false
                     },
+                    "mutating_webhooks": {
+                        "description": "MutatingWebhooks contains the configuration for mutating webhook middleware.\nMutating webhooks run before validating webhooks, per RFC THV-0017 ordering.",
+                        "items": {
+                            "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_webhook.Config"
+                        },
+                        "type": "array",
+                        "uniqueItems": false
+                    },
                     "name": {
                         "description": "Name is the name of the MCP server",
                         "type": "string"

--- a/docs/server/swagger.yaml
+++ b/docs/server/swagger.yaml
@@ -1133,6 +1133,14 @@ components:
             $ref: '#/components/schemas/github_com_stacklok_toolhive_pkg_transport_types.MiddlewareConfig'
           type: array
           uniqueItems: false
+        mutating_webhooks:
+          description: |-
+            MutatingWebhooks contains the configuration for mutating webhook middleware.
+            Mutating webhooks run before validating webhooks, per RFC THV-0017 ordering.
+          items:
+            $ref: '#/components/schemas/github_com_stacklok_toolhive_pkg_webhook.Config'
+          type: array
+          uniqueItems: false
         name:
           description: Name is the name of the MCP server
           type: string

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/coreos/go-oidc/v3 v3.17.0
 	github.com/docker/docker v28.5.2+incompatible
 	github.com/docker/go-connections v0.6.0
+	github.com/evanphx/json-patch/v5 v5.9.11
 	github.com/go-chi/chi/v5 v5.2.5
 	github.com/go-git/go-billy/v5 v5.8.0
 	github.com/go-git/go-git/v5 v5.17.2
@@ -132,7 +133,6 @@ require (
 	github.com/emicklei/go-restful/v3 v3.12.2 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
-	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
 	github.com/extism/go-sdk v1.7.0 // indirect
 	github.com/fatih/color v1.18.0 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect

--- a/pkg/authz/middleware.go
+++ b/pkg/authz/middleware.go
@@ -108,27 +108,6 @@ func shouldSkipSubsequentAuthorization(method string) bool {
 	return false
 }
 
-// convertToJSONRPC2ID converts an interface{} ID to jsonrpc2.ID
-func convertToJSONRPC2ID(id interface{}) (jsonrpc2.ID, error) {
-	if id == nil {
-		return jsonrpc2.ID{}, nil
-	}
-
-	switch v := id.(type) {
-	case string:
-		return jsonrpc2.StringID(v), nil
-	case int:
-		return jsonrpc2.Int64ID(int64(v)), nil
-	case int64:
-		return jsonrpc2.Int64ID(v), nil
-	case float64:
-		// JSON numbers are often unmarshaled as float64
-		return jsonrpc2.Int64ID(int64(v)), nil
-	default:
-		return jsonrpc2.ID{}, fmt.Errorf("unsupported ID type: %T", id)
-	}
-}
-
 // handleUnauthorized handles unauthorized requests.
 func handleUnauthorized(w http.ResponseWriter, msgID interface{}, err error) {
 	// Create an error response
@@ -138,7 +117,7 @@ func handleUnauthorized(w http.ResponseWriter, msgID interface{}, err error) {
 	}
 
 	// Create a JSON-RPC error response
-	id, err := convertToJSONRPC2ID(msgID)
+	id, err := mcp.ConvertToJSONRPC2ID(msgID)
 	if err != nil {
 		id = jsonrpc2.ID{} // Use empty ID if conversion fails
 	}

--- a/pkg/authz/middleware_test.go
+++ b/pkg/authz/middleware_test.go
@@ -1258,7 +1258,7 @@ func TestConvertToJSONRPC2ID(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			result, err := convertToJSONRPC2ID(tc.input)
+			result, err := mcpparser.ConvertToJSONRPC2ID(tc.input)
 
 			if tc.expectError {
 				assert.Error(t, err)

--- a/pkg/mcp/utils.go
+++ b/pkg/mcp/utils.go
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"fmt"
+
+	"golang.org/x/exp/jsonrpc2"
+)
+
+// ConvertToJSONRPC2ID converts an interface{} ID to jsonrpc2.ID
+func ConvertToJSONRPC2ID(id interface{}) (jsonrpc2.ID, error) {
+	if id == nil {
+		return jsonrpc2.ID{}, nil
+	}
+
+	switch v := id.(type) {
+	case string:
+		return jsonrpc2.StringID(v), nil
+	case int:
+		return jsonrpc2.Int64ID(int64(v)), nil
+	case int64:
+		return jsonrpc2.Int64ID(v), nil
+	case float64:
+		// JSON numbers are often unmarshaled as float64
+		return jsonrpc2.Int64ID(int64(v)), nil
+	default:
+		return jsonrpc2.ID{}, fmt.Errorf("unsupported ID type: %T", id)
+	}
+}

--- a/pkg/mcp/utils_test.go
+++ b/pkg/mcp/utils_test.go
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/exp/jsonrpc2"
+)
+
+// TestConvertToJSONRPC2ID tests the ConvertToJSONRPC2ID function with various ID types
+func TestConvertToJSONRPC2ID(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name        string
+		input       interface{}
+		expectError bool
+	}{
+		{
+			name:        "nil ID",
+			input:       nil,
+			expectError: false,
+		},
+		{
+			name:        "string ID",
+			input:       "test-id",
+			expectError: false,
+		},
+		{
+			name:        "int ID",
+			input:       42,
+			expectError: false,
+		},
+		{
+			name:        "int64 ID",
+			input:       int64(123456789),
+			expectError: false,
+		},
+		{
+			name:        "float64 ID (JSON number)",
+			input:       float64(99.0),
+			expectError: false,
+		},
+		{
+			name:        "unsupported type (slice)",
+			input:       []string{"invalid"},
+			expectError: true,
+		},
+		{
+			name:        "unsupported type (map)",
+			input:       map[string]string{"key": "value"},
+			expectError: true,
+		},
+		{
+			name:        "unsupported type (struct)",
+			input:       struct{ Name string }{Name: "test"},
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := ConvertToJSONRPC2ID(tc.input)
+
+			if tc.expectError {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "unsupported ID type")
+			} else {
+				assert.NoError(t, err)
+				// For nil input, we expect an empty ID
+				if tc.input == nil {
+					assert.Equal(t, jsonrpc2.ID{}, result)
+				} else {
+					// For other valid inputs, we just verify no error
+					assert.NotNil(t, result)
+				}
+			}
+		})
+	}
+}

--- a/pkg/runner/config.go
+++ b/pkg/runner/config.go
@@ -222,6 +222,10 @@ type RunConfig struct {
 	// ValidatingWebhooks contains the configuration for validating webhook middleware.
 	ValidatingWebhooks []webhook.Config `json:"validating_webhooks,omitempty" yaml:"validating_webhooks,omitempty"`
 
+	// MutatingWebhooks contains the configuration for mutating webhook middleware.
+	// Mutating webhooks run before validating webhooks, per RFC THV-0017 ordering.
+	MutatingWebhooks []webhook.Config `json:"mutating_webhooks,omitempty" yaml:"mutating_webhooks,omitempty"`
+
 	// existingPort is the port from an existing workload being updated (not serialized)
 	// Used during port validation to allow reusing the same port
 	existingPort int

--- a/pkg/runner/config_builder_test.go
+++ b/pkg/runner/config_builder_test.go
@@ -990,9 +990,8 @@ func TestRunConfigBuilder_WithIndividualTransportOptions(t *testing.T) {
 	}
 }
 
+//nolint:paralleltest // This test uses dynamically selected ports and must run serially to avoid port races.
 func TestRunConfigBuilder_WithRegistryProxyPort(t *testing.T) {
-	t.Parallel()
-
 	mockValidator := &mockEnvVarValidator{}
 
 	// Find available ports dynamically to avoid flaky failures when a
@@ -1052,9 +1051,9 @@ func TestRunConfigBuilder_WithRegistryProxyPort(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
+		//nolint:paralleltest // Keep the subtests serial for stable port validation.
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
 			ctx := context.Background()
 			envVars := make(map[string]string)
 

--- a/pkg/runner/config_test.go
+++ b/pkg/runner/config_test.go
@@ -665,7 +665,7 @@ func TestRunConfig_WithContainerName(t *testing.T) {
 			config: &RunConfig{
 				ContainerName: "",
 				Image:         "test-image",
-				Name:          "test-server",
+				Name:          testServerName,
 			},
 			expectedChange: true,
 		},
@@ -709,7 +709,7 @@ func TestRunConfig_WithStandardLabels(t *testing.T) {
 		{
 			name: "Basic configuration",
 			config: &RunConfig{
-				Name:            "test-server",
+				Name:            testServerName,
 				Image:           "test-image",
 				Transport:       types.TransportTypeSSE,
 				Port:            60000,
@@ -717,7 +717,7 @@ func TestRunConfig_WithStandardLabels(t *testing.T) {
 			},
 			expected: map[string]string{
 				"toolhive":           "true",
-				"toolhive-name":      "test-server",
+				"toolhive-name":      testServerName,
 				"toolhive-transport": "sse",
 				"toolhive-port":      "60000",
 			},
@@ -725,7 +725,7 @@ func TestRunConfig_WithStandardLabels(t *testing.T) {
 		{
 			name: "With existing labels",
 			config: &RunConfig{
-				Name:      "test-server",
+				Name:      testServerName,
 				Image:     "test-image",
 				Transport: types.TransportTypeStdio,
 				ContainerLabels: map[string]string{
@@ -734,7 +734,7 @@ func TestRunConfig_WithStandardLabels(t *testing.T) {
 			},
 			expected: map[string]string{
 				"toolhive":           "true",
-				"toolhive-name":      "test-server",
+				"toolhive-name":      testServerName,
 				"toolhive-transport": "stdio",
 				"existing-label":     "existing-value",
 			},
@@ -742,7 +742,7 @@ func TestRunConfig_WithStandardLabels(t *testing.T) {
 		{
 			name: "Stdio transport with SSE proxy mode",
 			config: &RunConfig{
-				Name:            "test-server",
+				Name:            testServerName,
 				Image:           "test-image",
 				Transport:       types.TransportTypeStdio,
 				ProxyMode:       types.ProxyModeSSE,
@@ -751,7 +751,7 @@ func TestRunConfig_WithStandardLabels(t *testing.T) {
 			},
 			expected: map[string]string{
 				"toolhive":           "true",
-				"toolhive-name":      "test-server",
+				"toolhive-name":      testServerName,
 				"toolhive-transport": "stdio", // Should be "stdio" even when proxied
 				"toolhive-port":      "60000",
 			},
@@ -759,7 +759,7 @@ func TestRunConfig_WithStandardLabels(t *testing.T) {
 		{
 			name: "Stdio transport with streamable-http proxy mode",
 			config: &RunConfig{
-				Name:            "test-server",
+				Name:            testServerName,
 				Image:           "test-image",
 				Transport:       types.TransportTypeStdio,
 				ProxyMode:       types.ProxyModeStreamableHTTP,
@@ -768,7 +768,7 @@ func TestRunConfig_WithStandardLabels(t *testing.T) {
 			},
 			expected: map[string]string{
 				"toolhive":           "true",
-				"toolhive-name":      "test-server",
+				"toolhive-name":      testServerName,
 				"toolhive-transport": "stdio", // Should be "stdio" even when proxied
 				"toolhive-port":      "60000",
 			},
@@ -817,7 +817,7 @@ func TestRunConfigBuilder(t *testing.T) {
 
 	runtime := &runtimemocks.MockRuntime{}
 	cmdArgs := []string{"arg1", "arg2"}
-	name := "test-server"
+	name := testServerName
 	imageURL := "test-image:latest"
 	imageMetadata := &regtypes.ImageMetadata{
 		BaseServerMetadata: regtypes.BaseServerMetadata{
@@ -963,7 +963,7 @@ func TestRunConfigBuilder_OIDCScopes(t *testing.T) {
 			config, err := NewRunConfigBuilder(context.Background(), nil, nil, validator,
 				WithRuntime(runtime),
 				WithCmdArgs(nil),
-				WithName("test-server"),
+				WithName(testServerName),
 				WithImage("test-image"),
 				WithHost(localhostStr),
 				WithTargetHost(localhostStr),
@@ -1015,7 +1015,7 @@ func TestRunConfig_WriteJSON_ReadJSON(t *testing.T) {
 	originalConfig := &RunConfig{
 		Image:         "test-image",
 		CmdArgs:       []string{"arg1", "arg2"},
-		Name:          "test-server",
+		Name:          testServerName,
 		ContainerName: "test-container",
 		BaseName:      "test-base",
 		Transport:     types.TransportTypeSSE,
@@ -1198,7 +1198,7 @@ func TestRunConfigBuilder_MetadataOverrides(t *testing.T) {
 			config, err := NewRunConfigBuilder(context.Background(), tt.metadata, nil, validator,
 				WithRuntime(runtime),
 				WithCmdArgs(nil),
-				WithName("test-server"),
+				WithName(testServerName),
 				WithImage("test-image"),
 				WithHost(localhostStr),
 				WithTargetHost(localhostStr),
@@ -1243,7 +1243,7 @@ func TestRunConfigBuilder_EnvironmentVariableTransportDependency(t *testing.T) {
 	config, err := NewRunConfigBuilder(context.Background(), nil, map[string]string{"USER_VAR": "value"}, validator,
 		WithRuntime(runtime),
 		WithCmdArgs(nil),
-		WithName("test-server"),
+		WithName(testServerName),
 		WithImage("test-image"),
 		WithHost(localhostStr),
 		WithTargetHost(localhostStr),
@@ -1293,7 +1293,7 @@ func TestRunConfigBuilder_CmdArgsMetadataOverride(t *testing.T) {
 	config, err := NewRunConfigBuilder(context.Background(), metadata, nil, validator,
 		WithRuntime(runtime),
 		WithCmdArgs(userArgs),
-		WithName("test-server"),
+		WithName(testServerName),
 		WithImage("test-image"),
 		WithHost(localhostStr),
 		WithTargetHost(localhostStr),
@@ -1345,7 +1345,7 @@ func TestRunConfigBuilder_CmdArgsMetadataDefaults(t *testing.T) {
 	config, err := NewRunConfigBuilder(context.Background(), metadata, nil, validator,
 		WithRuntime(runtime),
 		WithCmdArgs(userArgs),
-		WithName("test-server"),
+		WithName(testServerName),
 		WithImage("test-image"),
 		WithHost(localhostStr),
 		WithTargetHost(localhostStr),
@@ -1397,7 +1397,7 @@ func TestRunConfigBuilder_VolumeProcessing(t *testing.T) {
 	config, err := NewRunConfigBuilder(context.Background(), nil, nil, validator,
 		WithRuntime(runtime),
 		WithCmdArgs(nil),
-		WithName("test-server"),
+		WithName(testServerName),
 		WithImage("test-image"),
 		WithHost(localhostStr),
 		WithTargetHost(localhostStr),
@@ -1679,9 +1679,9 @@ func TestConfigFileLoading(t *testing.T) {
 		tmpDir := t.TempDir()
 		configPath := tmpDir + "/runconfig.json"
 
-		configContent := `{
+		configContent := fmt.Sprintf(`{
 			"schema_version": "v1",
-			"name": "test-server",
+			"name": "%s",
 			"image": "test:latest",
 			"transport": "sse",
 			"port": 9090,
@@ -1690,7 +1690,7 @@ func TestConfigFileLoading(t *testing.T) {
 				"TEST_VAR": "test_value",
 				"ANOTHER_VAR": "another_value"
 			}
-		}`
+		}`, testServerName)
 
 		err := os.WriteFile(configPath, []byte(configContent), 0644)
 		require.NoError(t, err, "Should be able to create config file")
@@ -1705,7 +1705,7 @@ func TestConfigFileLoading(t *testing.T) {
 		require.NotNil(t, config, "Should return config when file exists")
 
 		// Verify config was loaded correctly
-		assert.Equal(t, "test-server", config.Name)
+		assert.Equal(t, testServerName, config.Name)
 		assert.Equal(t, "test:latest", config.Image)
 		assert.Equal(t, "sse", string(config.Transport))
 		assert.Equal(t, 9090, config.Port)
@@ -2104,7 +2104,7 @@ func TestRunConfig_WriteJSON_ReadJSON_EmbeddedAuthServer(t *testing.T) {
 
 		originalConfig := &RunConfig{
 			SchemaVersion: CurrentSchemaVersion,
-			Name:          "test-server",
+			Name:          testServerName,
 			Image:         "test-image:latest",
 			Transport:     types.TransportTypeSSE,
 			Port:          60000,
@@ -2324,13 +2324,13 @@ func TestRunConfig_WriteJSON_ReadJSON_EmbeddedAuthServer(t *testing.T) {
 func TestRunConfig_BackendReplicas(t *testing.T) {
 	t.Parallel()
 
-	const testServerName = "srv"
+	const testSrvName = "srv"
 	int32ptr := func(v int32) *int32 { return &v }
 
 	t.Run("round-trip with backend_replicas set", func(t *testing.T) {
 		t.Parallel()
 		original := NewRunConfig()
-		original.Name = "test-server"
+		original.Name = testSrvName
 		original.ScalingConfig = &ScalingConfig{
 			BackendReplicas: int32ptr(3),
 		}
@@ -2348,7 +2348,7 @@ func TestRunConfig_BackendReplicas(t *testing.T) {
 	t.Run("round-trip without scaling config preserves nil", func(t *testing.T) {
 		t.Parallel()
 		minimal := NewRunConfig()
-		minimal.Name = testServerName
+		minimal.Name = testSrvName
 		var buf bytes.Buffer
 		require.NoError(t, minimal.WriteJSON(&buf))
 		got, err := ReadJSON(&buf)

--- a/pkg/runner/middleware.go
+++ b/pkg/runner/middleware.go
@@ -22,6 +22,7 @@ import (
 	headerfwd "github.com/stacklok/toolhive/pkg/transport/middleware"
 	"github.com/stacklok/toolhive/pkg/transport/types"
 	"github.com/stacklok/toolhive/pkg/usagemetrics"
+	"github.com/stacklok/toolhive/pkg/webhook/mutating"
 	"github.com/stacklok/toolhive/pkg/webhook/validating"
 )
 
@@ -43,6 +44,7 @@ func GetSupportedMiddlewareFactories() map[string]types.MiddlewareFactory {
 		recovery.MiddlewareType:               recovery.CreateMiddleware,
 		headerfwd.HeaderForwardMiddlewareName: headerfwd.CreateMiddleware,
 		validating.MiddlewareType:             validating.CreateMiddleware,
+		mutating.MiddlewareType:               mutating.CreateMiddleware,
 	}
 }
 
@@ -123,6 +125,14 @@ func PopulateMiddlewareConfigs(config *RunConfig) error {
 	// Positioned after MCP parser (needs tool name from context).
 	// Will also need user identity from auth when per-user limits are added (#4550).
 	middlewareConfigs, err = addRateLimitMiddleware(middlewareConfigs, config)
+	if err != nil {
+		return err
+	}
+
+	// Mutating Webhooks middleware (if configured).
+	// Must run BEFORE validating webhooks:
+	// MCP Parser -> [Mutating Webhooks] -> [Validating Webhooks] -> Authz -> Audit
+	middlewareConfigs, err = addMutatingWebhookMiddleware(middlewareConfigs, config)
 	if err != nil {
 		return err
 	}
@@ -219,6 +229,29 @@ func PopulateMiddlewareConfigs(config *RunConfig) error {
 	// Set the populated middleware configs
 	config.MiddlewareConfigs = middlewareConfigs
 	return nil
+}
+
+// addMutatingWebhookMiddleware configures the mutating webhook middleware if any webhooks are defined.
+// It must be called before addValidatingWebhookMiddleware to preserve the RFC-specified ordering.
+func addMutatingWebhookMiddleware(configs []types.MiddlewareConfig, runConfig *RunConfig) ([]types.MiddlewareConfig, error) {
+	if len(runConfig.MutatingWebhooks) == 0 {
+		return configs, nil
+	}
+
+	params := mutating.FactoryMiddlewareParams{
+		MiddlewareParams: mutating.MiddlewareParams{
+			Webhooks: runConfig.MutatingWebhooks,
+		},
+		ServerName: runConfig.Name,
+		Transport:  runConfig.Transport.String(),
+	}
+
+	config, err := types.NewMiddlewareConfig(mutating.MiddlewareType, params)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create mutating webhook middleware config: %w", err)
+	}
+
+	return append(configs, *config), nil
 }
 
 // addValidatingWebhookMiddleware configures the validating webhook middleware if any webhooks are defined

--- a/pkg/runner/middleware_test.go
+++ b/pkg/runner/middleware_test.go
@@ -15,6 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	v1alpha1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1alpha1"
+	"github.com/stacklok/toolhive/pkg/audit"
 	"github.com/stacklok/toolhive/pkg/auth"
 	"github.com/stacklok/toolhive/pkg/auth/awssts"
 	"github.com/stacklok/toolhive/pkg/auth/upstreamswap"
@@ -22,10 +23,15 @@ import (
 	"github.com/stacklok/toolhive/pkg/authz"
 	"github.com/stacklok/toolhive/pkg/authz/authorizers"
 	"github.com/stacklok/toolhive/pkg/authz/authorizers/cedar"
+	"github.com/stacklok/toolhive/pkg/mcp"
 	"github.com/stacklok/toolhive/pkg/ratelimit"
 	"github.com/stacklok/toolhive/pkg/recovery"
+	"github.com/stacklok/toolhive/pkg/telemetry"
 	headerfwd "github.com/stacklok/toolhive/pkg/transport/middleware"
 	"github.com/stacklok/toolhive/pkg/transport/types"
+	"github.com/stacklok/toolhive/pkg/webhook"
+	"github.com/stacklok/toolhive/pkg/webhook/mutating"
+	"github.com/stacklok/toolhive/pkg/webhook/validating"
 )
 
 // createMinimalAuthServerConfig creates a minimal valid EmbeddedAuthServerConfig for testing.
@@ -870,4 +876,41 @@ func TestPopulateMiddlewareConfigs_RateLimit(t *testing.T) {
 			assert.Equal(t, tt.wantRateLimit, found)
 		})
 	}
+}
+
+func TestPopulateMiddlewareConfigs_FullCoverage(t *testing.T) {
+	t.Parallel()
+
+	config := NewRunConfig()
+	config.Name = "test-server"
+	config.Transport = types.TransportTypeStdio
+
+	// Setup options to hit all branches
+	config.MutatingWebhooks = []webhook.Config{{Name: "m-hook", URL: "http://example.com/m"}}
+	config.ValidatingWebhooks = []webhook.Config{{Name: "v-hook", URL: "http://example.com/v"}}
+
+	config.ToolsFilter = []string{"tool1"}
+	config.ToolsOverride = map[string]ToolOverride{"tool1": {Name: "newtool1"}}
+
+	config.TelemetryConfig = &telemetry.Config{}
+	config.AuthzConfig = &authz.Config{}
+
+	config.AuditConfig = &audit.Config{Component: "test-component"}
+
+	err := PopulateMiddlewareConfigs(config)
+	require.NoError(t, err)
+
+	// Ensure they are populated
+	typeIndex := make(map[string]bool)
+	for _, mw := range config.MiddlewareConfigs {
+		typeIndex[mw.Type] = true
+	}
+
+	assert.True(t, typeIndex[mutating.MiddlewareType])
+	assert.True(t, typeIndex[validating.MiddlewareType])
+	assert.True(t, typeIndex[mcp.ToolFilterMiddlewareType])
+	assert.True(t, typeIndex[mcp.ToolCallFilterMiddlewareType])
+	assert.True(t, typeIndex[telemetry.MiddlewareType])
+	assert.True(t, typeIndex[authz.MiddlewareType])
+	assert.True(t, typeIndex[audit.MiddlewareType])
 }

--- a/pkg/runner/webhook_integration_test.go
+++ b/pkg/runner/webhook_integration_test.go
@@ -1,0 +1,161 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package runner
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/stacklok/toolhive/pkg/webhook"
+	statusesmocks "github.com/stacklok/toolhive/pkg/workloads/statuses/mocks"
+)
+
+// TestWebhookMiddlewareChainIntegration tests the full execution of the webhook middleware chain
+// populated by PopulateMiddlewareConfigs in the runner.
+func TestWebhookMiddlewareChainIntegration(t *testing.T) {
+	t.Parallel()
+
+	// 1. Set up a mutating webhook server that adds a new argument field
+	mutatingServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req webhook.Request
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+
+		// Apply a JSONPatch to add "dept" = "engineering"
+		patch := []map[string]interface{}{
+			{
+				"op":    "add",
+				"path":  "/mcp_request/params/arguments/dept",
+				"value": "engineering",
+			},
+		}
+		patchJSON, _ := json.Marshal(patch)
+
+		resp := webhook.MutatingResponse{
+			Response: webhook.Response{
+				Version: webhook.APIVersion,
+				UID:     req.UID,
+				Allowed: true,
+			},
+			PatchType: "json_patch",
+			Patch:     patchJSON,
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	t.Cleanup(mutatingServer.Close)
+
+	// 2. Set up a validating webhook server that asserts the field is present and allows the request
+	validatingServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req webhook.Request
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+
+		// Parse the incoming MCP Request (which should have been mutated)
+		var mcpReq map[string]interface{}
+		require.NoError(t, json.Unmarshal(req.MCPRequest, &mcpReq))
+
+		params, ok := mcpReq["params"].(map[string]interface{})
+		require.True(t, ok)
+		args, ok := params["arguments"].(map[string]interface{})
+		require.True(t, ok)
+
+		// Check if the mutating webhook successfully added the parameter
+		assert.Equal(t, "engineering", args["dept"])
+
+		resp := webhook.Response{
+			Version: webhook.APIVersion,
+			UID:     req.UID,
+			Allowed: true,
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	t.Cleanup(validatingServer.Close)
+
+	// 3. Configure the runner config
+	runConfig := NewRunConfig()
+	runConfig.Name = "test-server"
+	runConfig.MutatingWebhooks = []webhook.Config{
+		{
+			Name:          "test-mutating-webhook",
+			URL:           mutatingServer.URL,
+			Timeout:       webhook.DefaultTimeout,
+			FailurePolicy: webhook.FailurePolicyFail,
+			TLSConfig:     &webhook.TLSConfig{InsecureSkipVerify: true},
+		},
+	}
+	runConfig.ValidatingWebhooks = []webhook.Config{
+		{
+			Name:          "test-validating-webhook",
+			URL:           validatingServer.URL,
+			Timeout:       webhook.DefaultTimeout,
+			FailurePolicy: webhook.FailurePolicyFail,
+			TLSConfig:     &webhook.TLSConfig{InsecureSkipVerify: true},
+		},
+	}
+
+	// 4. Populate Middleware Configs
+	err := PopulateMiddlewareConfigs(runConfig)
+	require.NoError(t, err)
+
+	// 5. Initialize the Runner (this parses the configs into actual middlewares)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockStatusManager := statusesmocks.NewMockStatusManager(ctrl)
+
+	runner := NewRunner(runConfig, mockStatusManager)
+
+	for _, mwConfig := range runConfig.MiddlewareConfigs {
+		factory, ok := runner.supportedMiddleware[mwConfig.Type]
+		require.True(t, ok)
+		err := factory(&mwConfig, runner)
+		require.NoError(t, err)
+	}
+
+	// Ensure the middlewares were created
+	require.NotEmpty(t, runner.middlewares)
+
+	// 6. Build the HTTP handler chain. Middlewares are applied backwards to wrap the handler.
+	var finalBody []byte
+	var handler http.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		finalBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"jsonrpc":"2.0", "id": 1, "result": {}}`))
+	})
+
+	for i := len(runner.middlewares) - 1; i >= 0; i-- {
+		handler = runner.middlewares[i].Handler()(handler)
+	}
+
+	// 7. Make a test request through the middleware chain
+	reqBody := `{"jsonrpc":"2.0","method":"tools/call","id":1,"params":{"name":"db","arguments":{"query":"SELECT *"}}}`
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	// 8. Assertions
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	// Verify the final body received by the innermost handler (the mock MCP server) has the mutated structure
+	var parsedFinalBody map[string]interface{}
+	require.NoError(t, json.Unmarshal(finalBody, &parsedFinalBody))
+
+	params := parsedFinalBody["params"].(map[string]interface{})
+	args := params["arguments"].(map[string]interface{})
+
+	// Ensure the original field was kept and the mutated one was added
+	assert.Equal(t, "SELECT *", args["query"])
+	assert.Equal(t, "engineering", args["dept"])
+}

--- a/pkg/webhook/mutating/config.go
+++ b/pkg/webhook/mutating/config.go
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package mutating implements a mutating webhook middleware for ToolHive.
+// It calls external HTTP services to transform MCP requests using JSONPatch (RFC 6902).
+package mutating
+
+import (
+	"fmt"
+
+	"github.com/stacklok/toolhive/pkg/webhook"
+)
+
+// MiddlewareParams holds the configuration parameters for the mutating webhook middleware.
+type MiddlewareParams struct {
+	// Webhooks is the list of mutating webhook configurations to call.
+	// Webhooks are called in configuration order; each webhook receives the output
+	// of the previous mutation. All patches are applied sequentially.
+	Webhooks []webhook.Config `json:"webhooks"`
+}
+
+// Validate checks that the MiddlewareParams are valid.
+func (p *MiddlewareParams) Validate() error {
+	if len(p.Webhooks) == 0 {
+		return fmt.Errorf("mutating webhook middleware requires at least one webhook")
+	}
+	for i, wh := range p.Webhooks {
+		if err := wh.Validate(); err != nil {
+			return fmt.Errorf("webhook[%d] (%q): %w", i, wh.Name, err)
+		}
+	}
+	return nil
+}
+
+// FactoryMiddlewareParams extends MiddlewareParams with context for the factory.
+type FactoryMiddlewareParams struct {
+	MiddlewareParams
+	// ServerName is the name of the ToolHive instance.
+	ServerName string `json:"server_name"`
+	// Transport is the transport type (e.g., sse, stdio).
+	Transport string `json:"transport"`
+}

--- a/pkg/webhook/mutating/middleware.go
+++ b/pkg/webhook/mutating/middleware.go
@@ -1,0 +1,314 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package mutating
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/google/uuid"
+	"golang.org/x/exp/jsonrpc2"
+
+	"github.com/stacklok/toolhive/pkg/auth"
+	"github.com/stacklok/toolhive/pkg/mcp"
+	"github.com/stacklok/toolhive/pkg/transport/types"
+	"github.com/stacklok/toolhive/pkg/webhook"
+)
+
+// MiddlewareType is the type constant for the mutating webhook middleware.
+const MiddlewareType = "mutating-webhook"
+
+// Middleware wraps mutating webhook functionality for the factory pattern.
+type Middleware struct {
+	handler types.MiddlewareFunction
+}
+
+// Handler returns the middleware function used by the proxy.
+func (m *Middleware) Handler() types.MiddlewareFunction {
+	return m.handler
+}
+
+// Close cleans up any resources used by the middleware.
+func (*Middleware) Close() error {
+	return nil
+}
+
+type clientExecutor struct {
+	client *webhook.Client
+	config webhook.Config
+}
+
+// CreateMiddleware is the factory function for mutating webhook middleware.
+func CreateMiddleware(config *types.MiddlewareConfig, runner types.MiddlewareRunner) error {
+	var params FactoryMiddlewareParams
+	if err := json.Unmarshal(config.Parameters, &params); err != nil {
+		return fmt.Errorf("failed to unmarshal mutating webhook middleware parameters: %w", err)
+	}
+
+	if err := params.Validate(); err != nil {
+		return fmt.Errorf("invalid mutating webhook configuration: %w", err)
+	}
+
+	// Create clients for each webhook.
+	var executors []clientExecutor
+	for i, whCfg := range params.Webhooks {
+		client, err := webhook.NewClient(whCfg, webhook.TypeMutating, nil) // HMAC secret not yet plumbed
+		if err != nil {
+			return fmt.Errorf("failed to create client for webhook[%d] (%q): %w", i, whCfg.Name, err)
+		}
+		executors = append(executors, clientExecutor{client: client, config: whCfg})
+	}
+
+	mw := &Middleware{
+		handler: createMutatingHandler(executors, params.ServerName, params.Transport),
+	}
+	runner.AddMiddleware(MiddlewareType, mw)
+	return nil
+}
+
+func createMutatingHandler(executors []clientExecutor, serverName, transport string) types.MiddlewareFunction {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Skip if it's not a parsed MCP request (middleware runs after mcp parser).
+			parsedMCP := mcp.GetParsedMCPRequest(r.Context())
+			if parsedMCP == nil {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			// Read the request body to get the raw MCP request.
+			bodyBytes, err := io.ReadAll(r.Body)
+			if err != nil {
+				sendErrorResponse(w, http.StatusInternalServerError, "Failed to read request body", parsedMCP.ID)
+				return
+			}
+			// Restore the request body immediately; we will replace it after mutations.
+			r.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+
+			// currentMCPBody is the MCP JSON-RPC body we thread through the webhook chain.
+			// Each successful mutation replaces this with the patched version.
+			currentMCPBody := bodyBytes
+
+			// Build the base webhook request context (reused across all webhooks).
+			reqContext := &webhook.RequestContext{
+				ServerName: serverName,
+				SourceIP:   readSourceIP(r),
+				Transport:  transport,
+			}
+
+			// Resolve principal once (same for all webhooks in this chain).
+			var principal *auth.PrincipalInfo
+			if identity, ok := auth.IdentityFromContext(r.Context()); ok {
+				principal = identity.GetPrincipalInfo()
+			}
+
+			// Execute the webhook chain to apply mutations.
+			mutatedBody, err := executeMutations(r.Context(), executors, currentMCPBody, reqContext, principal, parsedMCP.ID, w)
+			if err != nil {
+				// executeMutations handles writing the error to the response implicitly when it returns an error.
+				return
+			}
+
+			// Replace the request body with the (potentially mutated) MCP body for downstream handlers.
+			r.Body = io.NopCloser(bytes.NewBuffer(mutatedBody))
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// executeMutations runs the chain of mutating webhooks sequentially.
+// It returns the final mutated body, or an error if the chain was aborted.
+// If an error occurs that should abort the request, this function writes the error response.
+func executeMutations(
+	ctx context.Context,
+	executors []clientExecutor,
+	initialBody []byte,
+	reqContext *webhook.RequestContext,
+	principal *auth.PrincipalInfo,
+	msgID interface{},
+	w http.ResponseWriter,
+) ([]byte, error) {
+	currentBody := initialBody
+
+	for _, exec := range executors {
+		mutatedBody, err := executeSingleMutation(ctx, exec, currentBody, reqContext, principal, msgID, w)
+		if err != nil {
+			return nil, err
+		}
+		currentBody = mutatedBody
+	}
+
+	return currentBody, nil
+}
+
+// executeSingleMutation applies a single mutating webhook.
+func executeSingleMutation(
+	ctx context.Context,
+	exec clientExecutor,
+	currentBody []byte,
+	reqContext *webhook.RequestContext,
+	principal *auth.PrincipalInfo,
+	msgID interface{},
+	w http.ResponseWriter,
+) ([]byte, error) {
+	whName := exec.config.Name
+
+	whReq := &webhook.Request{
+		Version:    webhook.APIVersion,
+		UID:        uuid.New().String(),
+		Timestamp:  time.Now().UTC(),
+		MCPRequest: json.RawMessage(currentBody),
+		Context:    reqContext,
+		Principal:  principal,
+	}
+
+	resp, err := exec.client.CallMutating(ctx, whReq)
+	if err != nil {
+		if exec.config.FailurePolicy == webhook.FailurePolicyIgnore {
+			slog.Warn("Mutating webhook error ignored due to fail-open policy", "webhook", whName, "error", err)
+			return currentBody, nil
+		}
+		slog.Error("Mutating webhook error caused request denial", "webhook", whName, "error", err)
+		sendErrorResponse(w, http.StatusInternalServerError, "Webhook error", msgID)
+		return nil, err
+	}
+
+	// Explicit denial from a mutating webhook is always honored, regardless of failure policy.
+	// This differs from operational errors (network, timeout) where the failure policy applies.
+	if !resp.Allowed {
+		slog.Info("Mutating webhook denied request", "webhook", whName, "reason", resp.Reason)
+		sendErrorResponse(w, http.StatusForbidden, "Request denied by webhook policy", msgID)
+		return nil, fmt.Errorf("webhook denied request")
+	}
+
+	if resp.PatchType == "" || len(resp.Patch) == 0 {
+		return currentBody, nil
+	}
+
+	if resp.PatchType != patchTypeJSONPatch {
+		slog.Error("Mutating webhook returned unsupported patch type", "webhook", whName, "patch_type", resp.PatchType)
+		if exec.config.FailurePolicy == webhook.FailurePolicyIgnore {
+			return currentBody, nil
+		}
+		sendErrorResponse(w, http.StatusInternalServerError, "Unsupported patch type from webhook", msgID)
+		return nil, fmt.Errorf("unsupported patch type")
+	}
+
+	return applyMutationPatch(resp, whName, exec.config.FailurePolicy, currentBody, msgID, w)
+}
+
+func applyMutationPatch(
+	resp *webhook.MutatingResponse,
+	whName string,
+	failurePolicy webhook.FailurePolicy,
+	currentBody []byte,
+	msgID interface{},
+	w http.ResponseWriter,
+) ([]byte, error) {
+	var patchOps []JSONPatchOp
+	if err := json.Unmarshal(resp.Patch, &patchOps); err != nil {
+		slog.Error("Mutating webhook returned malformed patch", "webhook", whName, "error", err)
+		if failurePolicy == webhook.FailurePolicyIgnore {
+			return currentBody, nil
+		}
+		sendErrorResponse(w, http.StatusInternalServerError, "Malformed patch from webhook", msgID)
+		return nil, err
+	}
+
+	if err := ValidatePatch(patchOps); err != nil {
+		slog.Error("Mutating webhook patch failed validation", "webhook", whName, "error", err)
+		if failurePolicy == webhook.FailurePolicyIgnore {
+			return currentBody, nil
+		}
+		sendErrorResponse(w, http.StatusInternalServerError, "Invalid patch from webhook", msgID)
+		return nil, err
+	}
+
+	if !IsPatchScopedToMCPRequest(patchOps) {
+		slog.Error("Mutating webhook patch targets fields outside mcp_request — rejected", "webhook", whName)
+		if failurePolicy == webhook.FailurePolicyIgnore {
+			return currentBody, nil
+		}
+		sendErrorResponse(w, http.StatusInternalServerError, "Patch must be scoped to mcp_request", msgID)
+		return nil, fmt.Errorf("patch scope violation")
+	}
+
+	envelopeJSON, err := json.Marshal(struct {
+		MCPRequest json.RawMessage `json:"mcp_request"`
+	}{
+		MCPRequest: json.RawMessage(currentBody),
+	})
+	if err != nil {
+		slog.Error("Failed to marshal webhook request envelope", "webhook", whName, "error", err)
+		if failurePolicy == webhook.FailurePolicyIgnore {
+			return currentBody, nil
+		}
+		sendErrorResponse(w, http.StatusInternalServerError, "Internal error applying patch", msgID)
+		return nil, err
+	}
+
+	patchedEnvelope, err := ApplyPatch(envelopeJSON, patchOps)
+	if err != nil {
+		slog.Error("Mutating webhook patch application failed", "webhook", whName, "error", err)
+		if failurePolicy == webhook.FailurePolicyIgnore {
+			return currentBody, nil
+		}
+		sendErrorResponse(w, http.StatusInternalServerError, "Failed to apply patch from webhook", msgID)
+		return nil, err
+	}
+
+	mutatedMCPBody, err := extractMCPRequest(patchedEnvelope)
+	if err != nil {
+		slog.Error("Failed to extract mcp_request", "webhook", whName, "error", err)
+		if failurePolicy == webhook.FailurePolicyIgnore {
+			return currentBody, nil
+		}
+		sendErrorResponse(w, http.StatusInternalServerError, "Internal error extracting patched request", msgID)
+		return nil, err
+	}
+
+	slog.Debug("Mutating webhook applied patch successfully", "webhook", whName)
+	return mutatedMCPBody, nil
+}
+
+// extractMCPRequest extracts the raw mcp_request bytes from a patched webhook envelope.
+func extractMCPRequest(envelope []byte) ([]byte, error) {
+	var env struct {
+		MCPRequest json.RawMessage `json:"mcp_request"`
+	}
+	if err := json.Unmarshal(envelope, &env); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal patched envelope: %w", err)
+	}
+	if len(env.MCPRequest) == 0 {
+		return nil, fmt.Errorf("mcp_request field missing or empty in patched envelope")
+	}
+	return env.MCPRequest, nil
+}
+
+func readSourceIP(r *http.Request) string {
+	return r.RemoteAddr
+}
+
+func sendErrorResponse(w http.ResponseWriter, statusCode int, message string, msgID interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(statusCode)
+
+	id, err := mcp.ConvertToJSONRPC2ID(msgID)
+	if err != nil {
+		id = jsonrpc2.ID{} // Use empty ID if conversion fails.
+	}
+
+	// Return a JSON-RPC 2.0 error so MCP clients can parse the denial.
+	errResp := &jsonrpc2.Response{
+		ID:    id,
+		Error: jsonrpc2.NewError(int64(statusCode), message),
+	}
+	_ = json.NewEncoder(w).Encode(errResp)
+}

--- a/pkg/webhook/mutating/middleware_test.go
+++ b/pkg/webhook/mutating/middleware_test.go
@@ -1,0 +1,818 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package mutating
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stacklok/toolhive/pkg/auth"
+	"github.com/stacklok/toolhive/pkg/mcp"
+	"github.com/stacklok/toolhive/pkg/transport/types"
+	"github.com/stacklok/toolhive/pkg/webhook"
+)
+
+// closedServerURL is a URL that will always fail to connect (port 0 is reserved/closed).
+const closedServerURL = "http://127.0.0.1:0"
+
+func makeConfig(url string, policy webhook.FailurePolicy) webhook.Config {
+	return webhook.Config{
+		Name:          "test-webhook",
+		URL:           url,
+		Timeout:       webhook.DefaultTimeout,
+		FailurePolicy: policy,
+		TLSConfig:     &webhook.TLSConfig{InsecureSkipVerify: true},
+	}
+}
+
+func makeExecutors(t *testing.T, configs []webhook.Config) []clientExecutor {
+	t.Helper()
+	var executors []clientExecutor
+	for _, cfg := range configs {
+		client, err := webhook.NewClient(cfg, webhook.TypeMutating, nil)
+		require.NoError(t, err)
+		executors = append(executors, clientExecutor{client: client, config: cfg})
+	}
+	return executors
+}
+
+func makeMCPRequest(tb testing.TB, body []byte) *http.Request {
+	tb.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(body))
+	parsedMCP := &mcp.ParsedMCPRequest{
+		Method: "tools/call",
+		ID:     float64(1),
+	}
+	ctx := context.WithValue(req.Context(), mcp.MCPRequestContextKey, parsedMCP)
+	req = req.WithContext(ctx)
+	req.RemoteAddr = "192.168.1.1:1234"
+	return req
+}
+
+//nolint:paralleltest // Shares mock server state
+func TestMutatingMiddleware_AllowedWithPatch(t *testing.T) {
+	const reqBody = `{"jsonrpc":"2.0","method":"tools/call","id":1,"params":{"name":"db","arguments":{"query":"SELECT *"}}}`
+
+	// Build the mock webhook server that returns a patch adding "audit_user".
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+
+		var req webhook.Request
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+
+		// Verify principal is forwarded.
+		require.NotNil(t, req.Principal)
+		assert.Equal(t, "user-1", req.Principal.Subject)
+
+		patch := []JSONPatchOp{
+			{Op: "add", Path: "/mcp_request/params/arguments/audit_user", Value: json.RawMessage(`"user@example.com"`)},
+		}
+		patchJSON, _ := json.Marshal(patch)
+
+		resp := webhook.MutatingResponse{
+			Response:  webhook.Response{Version: webhook.APIVersion, UID: req.UID, Allowed: true},
+			PatchType: patchTypeJSONPatch,
+			Patch:     patchJSON,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	mw := createMutatingHandler(makeExecutors(t, []webhook.Config{makeConfig(server.URL, webhook.FailurePolicyFail)}), "srv", "stdio")
+
+	req := makeMCPRequest(t, []byte(reqBody))
+	identity := &auth.Identity{PrincipalInfo: auth.PrincipalInfo{Subject: "user-1", Email: "user@example.com"}}
+	req = req.WithContext(auth.WithIdentity(req.Context(), identity))
+
+	var capturedBody []byte
+	nextHandler := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		capturedBody, _ = io.ReadAll(r.Body)
+	})
+
+	rr := httptest.NewRecorder()
+	mw(nextHandler).ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.NotNil(t, capturedBody)
+
+	// Verify the mutated body has the new field.
+	var mutated map[string]interface{}
+	require.NoError(t, json.Unmarshal(capturedBody, &mutated))
+	params := mutated["params"].(map[string]interface{})
+	args := params["arguments"].(map[string]interface{})
+	assert.Equal(t, "user@example.com", args["audit_user"])
+	assert.Equal(t, "SELECT *", args["query"])
+}
+
+//nolint:paralleltest
+func TestMutatingMiddleware_AllowedNoPatch(t *testing.T) {
+	const reqBody = `{"jsonrpc":"2.0","method":"tools/call","id":1}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		resp := webhook.MutatingResponse{
+			Response: webhook.Response{Version: webhook.APIVersion, UID: "uid", Allowed: true},
+			// No patch
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	mw := createMutatingHandler(makeExecutors(t, []webhook.Config{makeConfig(server.URL, webhook.FailurePolicyFail)}), "srv", "stdio")
+
+	var nextCalled bool
+	var capturedBody []byte
+	nextHandler := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+		capturedBody, _ = io.ReadAll(r.Body)
+	})
+
+	rr := httptest.NewRecorder()
+	mw(nextHandler).ServeHTTP(rr, makeMCPRequest(t, []byte(reqBody)))
+
+	assert.True(t, nextCalled)
+	assert.Equal(t, http.StatusOK, rr.Code)
+	// Body should equal original since no patch was applied.
+	assert.JSONEq(t, reqBody, string(capturedBody))
+}
+
+//nolint:paralleltest
+func TestMutatingMiddleware_AllowedFalse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		resp := webhook.MutatingResponse{
+			Response: webhook.Response{Version: webhook.APIVersion, UID: "uid", Allowed: false},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	cfg := makeConfig(server.URL, webhook.FailurePolicyIgnore)
+	mw := createMutatingHandler(makeExecutors(t, []webhook.Config{cfg}), "srv", "stdio")
+
+	var nextCalled bool
+	nextHandler := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) { nextCalled = true })
+
+	rr := httptest.NewRecorder()
+	mw(nextHandler).ServeHTTP(rr, makeMCPRequest(t, []byte(`{"jsonrpc":"2.0","id":1}`)))
+
+	assert.False(t, nextCalled)
+	assert.Equal(t, http.StatusForbidden, rr.Code)
+	assert.Contains(t, rr.Body.String(), "Request denied by webhook policy")
+}
+
+func TestMutatingMiddleware_WebhookError_FailPolicy(t *testing.T) {
+	t.Parallel()
+	cfg := makeConfig(closedServerURL, webhook.FailurePolicyFail)
+	mw := createMutatingHandler(makeExecutors(t, []webhook.Config{cfg}), "srv", "stdio")
+
+	var nextCalled bool
+	nextHandler := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) { nextCalled = true })
+
+	rr := httptest.NewRecorder()
+	mw(nextHandler).ServeHTTP(rr, makeMCPRequest(t, []byte(`{"jsonrpc":"2.0","id":1}`)))
+
+	assert.False(t, nextCalled)
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+}
+
+func TestMutatingMiddleware_WebhookError_IgnorePolicy(t *testing.T) {
+	t.Parallel()
+	cfg := makeConfig(closedServerURL, webhook.FailurePolicyIgnore)
+	mw := createMutatingHandler(makeExecutors(t, []webhook.Config{cfg}), "srv", "stdio")
+
+	const reqBody = `{"jsonrpc":"2.0","method":"tools/call","id":1}`
+	var nextCalled bool
+	var capturedBody []byte
+	nextHandler := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+		capturedBody, _ = io.ReadAll(r.Body)
+	})
+
+	rr := httptest.NewRecorder()
+	mw(nextHandler).ServeHTTP(rr, makeMCPRequest(t, []byte(reqBody)))
+
+	assert.True(t, nextCalled, "next should be called; error ignored per fail-open policy")
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.JSONEq(t, reqBody, string(capturedBody))
+}
+
+func TestMutatingMiddleware_ScopeViolation_FailPolicy(t *testing.T) {
+	t.Parallel()
+	// Webhook tries to patch /principal/email — security violation.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		patch := []JSONPatchOp{
+			{Op: "replace", Path: "/principal/email", Value: json.RawMessage(`"hacked@evil.com"`)},
+		}
+		patchJSON, _ := json.Marshal(patch)
+		resp := webhook.MutatingResponse{
+			Response:  webhook.Response{Version: webhook.APIVersion, UID: "uid", Allowed: true},
+			PatchType: patchTypeJSONPatch,
+			Patch:     patchJSON,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	cfg := makeConfig(server.URL, webhook.FailurePolicyFail)
+	mw := createMutatingHandler(makeExecutors(t, []webhook.Config{cfg}), "srv", "stdio")
+
+	var nextCalled bool
+	nextHandler := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) { nextCalled = true })
+
+	rr := httptest.NewRecorder()
+	mw(nextHandler).ServeHTTP(rr, makeMCPRequest(t, []byte(`{"jsonrpc":"2.0","id":1}`)))
+
+	assert.False(t, nextCalled)
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+}
+
+func TestMutatingMiddleware_ScopeViolation_IgnorePolicy(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		patch := []JSONPatchOp{
+			{Op: "replace", Path: "/principal/email", Value: json.RawMessage(`"hacked@evil.com"`)},
+		}
+		patchJSON, _ := json.Marshal(patch)
+		resp := webhook.MutatingResponse{
+			Response:  webhook.Response{Version: webhook.APIVersion, UID: "uid", Allowed: true},
+			PatchType: patchTypeJSONPatch,
+			Patch:     patchJSON,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	const reqBody = `{"jsonrpc":"2.0","id":1}`
+	cfg := makeConfig(server.URL, webhook.FailurePolicyIgnore)
+	mw := createMutatingHandler(makeExecutors(t, []webhook.Config{cfg}), "srv", "stdio")
+
+	var nextCalled bool
+	nextHandler := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) { nextCalled = true })
+
+	rr := httptest.NewRecorder()
+	mw(nextHandler).ServeHTTP(rr, makeMCPRequest(t, []byte(reqBody)))
+
+	// fail-open: scope violation ignored, original body forwarded
+	assert.True(t, nextCalled)
+	assert.Equal(t, http.StatusOK, rr.Code)
+}
+
+//nolint:paralleltest
+func TestMutatingMiddleware_ChainedMutations(t *testing.T) {
+	const reqBody = `{"jsonrpc":"2.0","method":"tools/call","id":1,"params":{"name":"db","arguments":{"query":"SELECT *"}}}`
+
+	// First webhook: adds "user" field.
+	server1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req webhook.Request
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		// Verify we received the original body.
+		assert.JSONEq(t, reqBody, string(req.MCPRequest))
+
+		patch := []JSONPatchOp{
+			{Op: "add", Path: "/mcp_request/params/arguments/user", Value: json.RawMessage(`"alice"`)},
+		}
+		patchJSON, _ := json.Marshal(patch)
+		resp := webhook.MutatingResponse{
+			Response:  webhook.Response{Version: webhook.APIVersion, UID: req.UID, Allowed: true},
+			PatchType: patchTypeJSONPatch,
+			Patch:     patchJSON,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server1.Close()
+
+	// Second webhook: adds "dept" field. Receives the output of webhook 1.
+	server2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req webhook.Request
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+
+		// Verify "user" field from webhook 1 is present.
+		var mcpBody map[string]interface{}
+		require.NoError(t, json.Unmarshal(req.MCPRequest, &mcpBody))
+		params := mcpBody["params"].(map[string]interface{})
+		args := params["arguments"].(map[string]interface{})
+		assert.Equal(t, "alice", args["user"], "webhook 2 should receive output of webhook 1")
+
+		patch := []JSONPatchOp{
+			{Op: "add", Path: "/mcp_request/params/arguments/dept", Value: json.RawMessage(`"engineering"`)},
+		}
+		patchJSON, _ := json.Marshal(patch)
+		resp := webhook.MutatingResponse{
+			Response:  webhook.Response{Version: webhook.APIVersion, UID: req.UID, Allowed: true},
+			PatchType: patchTypeJSONPatch,
+			Patch:     patchJSON,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server2.Close()
+
+	cfg1 := makeConfig(server1.URL, webhook.FailurePolicyFail)
+	cfg1.Name = "hook-1"
+	cfg2 := makeConfig(server2.URL, webhook.FailurePolicyFail)
+	cfg2.Name = "hook-2"
+
+	mw := createMutatingHandler(makeExecutors(t, []webhook.Config{cfg1, cfg2}), "srv", "stdio")
+
+	var capturedBody []byte
+	nextHandler := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		capturedBody, _ = io.ReadAll(r.Body)
+	})
+
+	rr := httptest.NewRecorder()
+	mw(nextHandler).ServeHTTP(rr, makeMCPRequest(t, []byte(reqBody)))
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.NotNil(t, capturedBody)
+
+	var finalBody map[string]interface{}
+	require.NoError(t, json.Unmarshal(capturedBody, &finalBody))
+	params := finalBody["params"].(map[string]interface{})
+	args := params["arguments"].(map[string]interface{})
+	assert.Equal(t, "alice", args["user"], "user from webhook 1 should be present")
+	assert.Equal(t, "engineering", args["dept"], "dept from webhook 2 should be present")
+	assert.Equal(t, "SELECT *", args["query"], "original query should be preserved")
+}
+
+func TestMutatingMiddleware_SkipNonMCPRequests(t *testing.T) {
+	t.Parallel()
+	mw := createMutatingHandler(nil, "srv", "stdio")
+
+	var nextCalled bool
+	nextHandler := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) { nextCalled = true })
+
+	// No parsedMCP in context.
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	rr := httptest.NewRecorder()
+	mw(nextHandler).ServeHTTP(rr, req)
+
+	assert.True(t, nextCalled, "non-MCP requests should pass through")
+	assert.Equal(t, http.StatusOK, rr.Code)
+}
+
+func TestMiddlewareParams_Validate(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		params  MiddlewareParams
+		wantErr bool
+	}{
+		{
+			name: "valid",
+			params: MiddlewareParams{Webhooks: []webhook.Config{
+				{Name: "a", URL: "https://a.com/hook", Timeout: webhook.DefaultTimeout, FailurePolicy: webhook.FailurePolicyIgnore},
+			}},
+			wantErr: false,
+		},
+		{
+			name:    "empty webhooks",
+			params:  MiddlewareParams{},
+			wantErr: true,
+		},
+		{
+			name:    "invalid webhook config",
+			params:  MiddlewareParams{Webhooks: []webhook.Config{{Name: ""}}},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := tt.params.Validate()
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+type mockRunner struct {
+	types.MiddlewareRunner
+	middlewares map[string]types.Middleware
+}
+
+func (m *mockRunner) AddMiddleware(name string, mw types.Middleware) {
+	if m.middlewares == nil {
+		m.middlewares = make(map[string]types.Middleware)
+	}
+	m.middlewares[name] = mw
+}
+
+func TestCreateMiddleware(t *testing.T) {
+	t.Parallel()
+	runner := &mockRunner{}
+
+	params := FactoryMiddlewareParams{
+		MiddlewareParams: MiddlewareParams{
+			Webhooks: []webhook.Config{
+				{
+					Name:          "test",
+					URL:           "https://test.example.com/hook",
+					Timeout:       webhook.DefaultTimeout,
+					FailurePolicy: webhook.FailurePolicyIgnore,
+				},
+			},
+		},
+		ServerName: "test-server",
+		Transport:  "stdio",
+	}
+	paramsJSON, err := json.Marshal(params)
+	require.NoError(t, err)
+
+	mwConfig := &types.MiddlewareConfig{
+		Type:       MiddlewareType,
+		Parameters: paramsJSON,
+	}
+
+	err = CreateMiddleware(mwConfig, runner)
+	require.NoError(t, err)
+
+	require.Contains(t, runner.middlewares, MiddlewareType)
+	mw := runner.middlewares[MiddlewareType]
+	require.NotNil(t, mw.Handler())
+	require.NoError(t, mw.Close())
+}
+
+func TestCreateMiddleware_InvalidParams(t *testing.T) {
+	t.Parallel()
+	runner := &mockRunner{}
+	mwConfig := &types.MiddlewareConfig{
+		Type:       MiddlewareType,
+		Parameters: []byte(`not-valid-json`),
+	}
+	err := CreateMiddleware(mwConfig, runner)
+	require.Error(t, err)
+}
+
+func TestCreateMiddleware_ValidationError(t *testing.T) {
+	t.Parallel()
+	runner := &mockRunner{}
+	// Empty webhooks fails validation.
+	params := FactoryMiddlewareParams{
+		MiddlewareParams: MiddlewareParams{Webhooks: []webhook.Config{}},
+		ServerName:       "srv",
+		Transport:        "stdio",
+	}
+	paramsJSON, _ := json.Marshal(params)
+	mwConfig := &types.MiddlewareConfig{Type: MiddlewareType, Parameters: paramsJSON}
+	err := CreateMiddleware(mwConfig, runner)
+	require.Error(t, err)
+}
+
+//nolint:paralleltest
+func TestMutatingMiddleware_UnsupportedPatchType(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		resp := webhook.MutatingResponse{
+			Response:  webhook.Response{Version: webhook.APIVersion, UID: "uid", Allowed: true},
+			PatchType: "strategic_merge", // unsupported type
+			Patch:     json.RawMessage(`[{"op":"add","path":"/mcp_request/x","value":"y"}]`),
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	// FailurePolicyFail → 500
+	cfg := makeConfig(server.URL, webhook.FailurePolicyFail)
+	mw := createMutatingHandler(makeExecutors(t, []webhook.Config{cfg}), "srv", "stdio")
+
+	var nextCalled bool
+	nextHandler := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) { nextCalled = true })
+	rr := httptest.NewRecorder()
+	mw(nextHandler).ServeHTTP(rr, makeMCPRequest(t, []byte(`{"jsonrpc":"2.0","id":1}`)))
+
+	assert.False(t, nextCalled)
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+}
+
+//nolint:paralleltest
+func TestMutatingMiddleware_UnsupportedPatchType_IgnorePolicy(t *testing.T) {
+	const reqBody = `{"jsonrpc":"2.0","id":1}`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		resp := webhook.MutatingResponse{
+			Response:  webhook.Response{Version: webhook.APIVersion, UID: "uid", Allowed: true},
+			PatchType: "strategic_merge",
+			Patch:     json.RawMessage(`[{"op":"add","path":"/mcp_request/x","value":"y"}]`),
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	// FailurePolicyIgnore: unsupported patch type is ignored, original body forwarded.
+	cfg := makeConfig(server.URL, webhook.FailurePolicyIgnore)
+	mw := createMutatingHandler(makeExecutors(t, []webhook.Config{cfg}), "srv", "stdio")
+
+	var nextCalled bool
+	nextHandler := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) { nextCalled = true })
+	rr := httptest.NewRecorder()
+	mw(nextHandler).ServeHTTP(rr, makeMCPRequest(t, []byte(reqBody)))
+
+	assert.True(t, nextCalled)
+	assert.Equal(t, http.StatusOK, rr.Code)
+}
+
+//nolint:paralleltest
+func TestMutatingMiddleware_MalformedPatchJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		resp := webhook.MutatingResponse{
+			Response:  webhook.Response{Version: webhook.APIVersion, UID: "uid", Allowed: true},
+			PatchType: patchTypeJSONPatch,
+			Patch:     json.RawMessage(`not-valid-json`),
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	cfg := makeConfig(server.URL, webhook.FailurePolicyFail)
+	mw := createMutatingHandler(makeExecutors(t, []webhook.Config{cfg}), "srv", "stdio")
+
+	var nextCalled bool
+	nextHandler := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) { nextCalled = true })
+	rr := httptest.NewRecorder()
+	mw(nextHandler).ServeHTTP(rr, makeMCPRequest(t, []byte(`{"jsonrpc":"2.0","id":1}`)))
+
+	assert.False(t, nextCalled)
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+}
+
+//nolint:paralleltest
+func TestMutatingMiddleware_StringRequestID(t *testing.T) {
+	// Tests that the middleware correctly handles a string JSON-RPC ID.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		resp := webhook.MutatingResponse{
+			Response: webhook.Response{Version: webhook.APIVersion, UID: "uid", Allowed: false},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	cfg := makeConfig(server.URL, webhook.FailurePolicyFail)
+	mw := createMutatingHandler(makeExecutors(t, []webhook.Config{cfg}), "srv", "stdio")
+
+	reqBody := []byte(`{"jsonrpc":"2.0","method":"tools/call","id":"string-id"}`)
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(reqBody))
+	// Use string ID in parsedMCP.
+	parsedMCP := &mcp.ParsedMCPRequest{Method: "tools/call", ID: "string-id"}
+	ctx := context.WithValue(req.Context(), mcp.MCPRequestContextKey, parsedMCP)
+	req = req.WithContext(ctx)
+
+	rr := httptest.NewRecorder()
+	mw(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {})).ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusForbidden, rr.Code)
+	assert.Contains(t, rr.Body.String(), "Request denied by webhook policy")
+
+	// Confirm JSON-RPC error has the string ID.
+	var errResp map[string]interface{}
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &errResp))
+	require.NotNil(t, errResp["ID"])
+}
+
+//nolint:paralleltest
+func TestMutatingMiddleware_InvalidPatchOp_FailPolicy(t *testing.T) {
+	// Returns a well-formed JSON array but with an invalid op type, so
+	// ValidatePatch returns an error inside the middleware handler.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// "delete" is not a valid RFC 6902 op, but the JSON is syntactically valid.
+		patch := []map[string]interface{}{
+			{"op": "delete", "path": "/mcp_request/params/key"},
+		}
+		patchJSON, _ := json.Marshal(patch)
+		resp := webhook.MutatingResponse{
+			Response:  webhook.Response{Version: webhook.APIVersion, UID: "uid", Allowed: true},
+			PatchType: patchTypeJSONPatch,
+			Patch:     patchJSON,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	cfg := makeConfig(server.URL, webhook.FailurePolicyFail)
+	mw := createMutatingHandler(makeExecutors(t, []webhook.Config{cfg}), "srv", "stdio")
+
+	var nextCalled bool
+	nextHandler := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) { nextCalled = true })
+	rr := httptest.NewRecorder()
+	mw(nextHandler).ServeHTTP(rr, makeMCPRequest(t, []byte(`{"jsonrpc":"2.0","id":1}`)))
+
+	assert.False(t, nextCalled)
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+}
+
+//nolint:paralleltest
+func TestMutatingMiddleware_InvalidPatchOp_IgnorePolicy(t *testing.T) {
+	const reqBody = `{"jsonrpc":"2.0","id":1}`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		patch := []map[string]interface{}{
+			{"op": "delete", "path": "/mcp_request/params/key"},
+		}
+		patchJSON, _ := json.Marshal(patch)
+		resp := webhook.MutatingResponse{
+			Response:  webhook.Response{Version: webhook.APIVersion, UID: "uid", Allowed: true},
+			PatchType: patchTypeJSONPatch,
+			Patch:     patchJSON,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	cfg := makeConfig(server.URL, webhook.FailurePolicyIgnore)
+	mw := createMutatingHandler(makeExecutors(t, []webhook.Config{cfg}), "srv", "stdio")
+
+	var nextCalled bool
+	nextHandler := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) { nextCalled = true })
+	rr := httptest.NewRecorder()
+	mw(nextHandler).ServeHTTP(rr, makeMCPRequest(t, []byte(reqBody)))
+
+	assert.True(t, nextCalled)
+	assert.Equal(t, http.StatusOK, rr.Code)
+}
+
+func TestExtractMCPRequest(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		input    string
+		wantErr  bool
+		wantBody string
+	}{
+		{
+			name:     "valid envelope",
+			input:    `{"mcp_request":{"jsonrpc":"2.0","id":1}}`,
+			wantErr:  false,
+			wantBody: `{"jsonrpc":"2.0","id":1}`,
+		},
+		{
+			name:    "invalid JSON",
+			input:   `{not-json`,
+			wantErr: true,
+		},
+		{
+			name:    "empty mcp_request field",
+			input:   `{"other_field":"value"}`,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result, err := extractMCPRequest([]byte(tt.input))
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.JSONEq(t, tt.wantBody, string(result))
+		})
+	}
+}
+
+//nolint:paralleltest
+func TestMutatingMiddleware_ApplyPatchFailure_FailPolicy(t *testing.T) {
+	// Patch fails to apply because it removes a non-existent path
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		patch := []map[string]interface{}{{"op": "remove", "path": "/mcp_request/doesnotexist"}}
+		patchJSON, _ := json.Marshal(patch)
+		resp := webhook.MutatingResponse{
+			Response:  webhook.Response{Version: webhook.APIVersion, UID: "uid", Allowed: true},
+			PatchType: patchTypeJSONPatch,
+			Patch:     patchJSON,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	cfg := makeConfig(server.URL, webhook.FailurePolicyFail)
+	mw := createMutatingHandler(makeExecutors(t, []webhook.Config{cfg}), "srv", "stdio")
+
+	var nextCalled bool
+	nextHandler := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) { nextCalled = true })
+	rr := httptest.NewRecorder()
+	mw(nextHandler).ServeHTTP(rr, makeMCPRequest(t, []byte(`{"jsonrpc":"2.0","id":1}`)))
+
+	assert.False(t, nextCalled)
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+}
+
+//nolint:paralleltest
+func TestMutatingMiddleware_ApplyPatchFailure_IgnorePolicy(t *testing.T) {
+	const reqBody = `{"jsonrpc":"2.0","id":1}`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		patch := []map[string]interface{}{{"op": "remove", "path": "/mcp_request/doesnotexist"}}
+		patchJSON, _ := json.Marshal(patch)
+		resp := webhook.MutatingResponse{
+			Response:  webhook.Response{Version: webhook.APIVersion, UID: "uid", Allowed: true},
+			PatchType: patchTypeJSONPatch,
+			Patch:     patchJSON,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	cfg := makeConfig(server.URL, webhook.FailurePolicyIgnore)
+	mw := createMutatingHandler(makeExecutors(t, []webhook.Config{cfg}), "srv", "stdio")
+
+	var nextCalled bool
+	nextHandler := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) { nextCalled = true })
+	rr := httptest.NewRecorder()
+	mw(nextHandler).ServeHTTP(rr, makeMCPRequest(t, []byte(reqBody)))
+
+	assert.True(t, nextCalled)
+	assert.Equal(t, http.StatusOK, rr.Code)
+}
+
+//nolint:paralleltest
+func TestMutatingMiddleware_ExtractFailure_FailPolicy(t *testing.T) {
+	// Patch removes /mcp_request, making extraction fail
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		patch := []map[string]interface{}{{"op": "remove", "path": "/mcp_request"}}
+		patchJSON, _ := json.Marshal(patch)
+		resp := webhook.MutatingResponse{
+			Response:  webhook.Response{Version: webhook.APIVersion, UID: "uid", Allowed: true},
+			PatchType: patchTypeJSONPatch,
+			Patch:     patchJSON,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	cfg := makeConfig(server.URL, webhook.FailurePolicyFail)
+	mw := createMutatingHandler(makeExecutors(t, []webhook.Config{cfg}), "srv", "stdio")
+
+	var nextCalled bool
+	nextHandler := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) { nextCalled = true })
+	rr := httptest.NewRecorder()
+	mw(nextHandler).ServeHTTP(rr, makeMCPRequest(t, []byte(`{"jsonrpc":"2.0","id":1}`)))
+
+	assert.False(t, nextCalled)
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+}
+
+//nolint:paralleltest
+func TestMutatingMiddleware_ExtractFailure_IgnorePolicy(t *testing.T) {
+	const reqBody = `{"jsonrpc":"2.0","id":1}`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		patch := []map[string]interface{}{{"op": "remove", "path": "/mcp_request"}}
+		patchJSON, _ := json.Marshal(patch)
+		resp := webhook.MutatingResponse{
+			Response:  webhook.Response{Version: webhook.APIVersion, UID: "uid", Allowed: true},
+			PatchType: patchTypeJSONPatch,
+			Patch:     patchJSON,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	cfg := makeConfig(server.URL, webhook.FailurePolicyIgnore)
+	mw := createMutatingHandler(makeExecutors(t, []webhook.Config{cfg}), "srv", "stdio")
+
+	var nextCalled bool
+	var capturedBody []byte
+	nextHandler := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+		capturedBody, _ = io.ReadAll(r.Body)
+	})
+	rr := httptest.NewRecorder()
+	mw(nextHandler).ServeHTTP(rr, makeMCPRequest(t, []byte(reqBody)))
+
+	assert.True(t, nextCalled)
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.JSONEq(t, reqBody, string(capturedBody))
+}
+
+func TestValidatePatchErrors(t *testing.T) {
+	t.Parallel()
+	invalidOps := []JSONPatchOp{
+		{Op: "copy", Path: "/mcp_request/a"}, // missing From
+		{Op: "move", Path: "/mcp_request/b"}, // missing From
+		{Op: "invalid_op", Path: "/mcp_request/c"},
+		{Op: "add", Path: ""}, // missing Path
+	}
+	err := ValidatePatch(invalidOps)
+	require.Error(t, err)
+}

--- a/pkg/webhook/mutating/patch.go
+++ b/pkg/webhook/mutating/patch.go
@@ -1,0 +1,101 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package mutating
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	jsonpatch "github.com/evanphx/json-patch/v5"
+)
+
+// patchTypeJSONPatch is the patch_type value for RFC 6902 JSON Patch.
+const patchTypeJSONPatch = "json_patch"
+
+// mcpRequestPathPrefix is the required prefix for all patch paths.
+// Patches are scoped to the mcp_request container only.
+const mcpRequestPathPrefix = "/mcp_request/"
+
+// validOps is the set of valid RFC 6902 operations.
+var validOps = map[string]bool{
+	"add":     true,
+	"remove":  true,
+	"replace": true,
+	"copy":    true,
+	"move":    true,
+	"test":    true,
+}
+
+// JSONPatchOp represents a single RFC 6902 JSON Patch operation.
+type JSONPatchOp struct {
+	// Op is the patch operation type (add, remove, replace, copy, move, test).
+	Op string `json:"op"`
+	// Path is the JSON Pointer (RFC 6901) path to apply the operation to.
+	Path string `json:"path"`
+	// Value is the value to use for add, replace, and test operations.
+	Value json.RawMessage `json:"value,omitempty"`
+	// From is the source path for copy and move operations.
+	From string `json:"from,omitempty"`
+}
+
+// ValidatePatch checks that all operations in the patch are well-formed.
+// It validates that all operations are supported RFC 6902 types and paths are non-empty.
+func ValidatePatch(patch []JSONPatchOp) error {
+	for i, op := range patch {
+		if !validOps[op.Op] {
+			return fmt.Errorf("patch[%d]: unsupported operation %q (valid ops: add, remove, replace, copy, move, test)", i, op.Op)
+		}
+		if op.Path == "" {
+			return fmt.Errorf("patch[%d]: path is required", i)
+		}
+		// copy and move also require a From field.
+		if (op.Op == "copy" || op.Op == "move") && op.From == "" {
+			return fmt.Errorf("patch[%d]: %q operation requires a 'from' field", i, op.Op)
+		}
+	}
+	return nil
+}
+
+// IsPatchScopedToMCPRequest returns true if all patch operations target paths
+// within the mcp_request container. This prevents webhooks from accidentally
+// or maliciously modifying principal, context, or other immutable envelope fields.
+// The root "/mcp_request" path is intentionally rejected so webhooks must make
+// granular changes beneath the MCP request instead of replacing it wholesale.
+func IsPatchScopedToMCPRequest(patch []JSONPatchOp) bool {
+	for _, op := range patch {
+		if !strings.HasPrefix(op.Path, mcpRequestPathPrefix) {
+			return false
+		}
+		// For copy/move, also check the From path.
+		if (op.Op == "copy" || op.Op == "move") && op.From != "" {
+			if !strings.HasPrefix(op.From, mcpRequestPathPrefix) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// ApplyPatch applies a set of RFC 6902 JSON Patch operations to the original JSON document.
+// Returns the patched JSON document. The patch operations are applied in order.
+func ApplyPatch(original []byte, patch []JSONPatchOp) ([]byte, error) {
+	// Marshal the patch ops to JSON so the library can parse them.
+	patchJSON, err := json.Marshal(patch)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal patch operations: %w", err)
+	}
+
+	jp, err := jsonpatch.DecodePatch(patchJSON)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode JSON patch: %w", err)
+	}
+
+	patched, err := jp.Apply(original)
+	if err != nil {
+		return nil, fmt.Errorf("failed to apply JSON patch: %w", err)
+	}
+
+	return patched, nil
+}

--- a/pkg/webhook/mutating/patch_test.go
+++ b/pkg/webhook/mutating/patch_test.go
@@ -1,0 +1,266 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package mutating
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidatePatch(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		patch   []JSONPatchOp
+		wantErr bool
+	}{
+		{
+			name:    "valid add op",
+			patch:   []JSONPatchOp{{Op: "add", Path: "/mcp_request/params/arguments/key", Value: json.RawMessage(`"value"`)}},
+			wantErr: false,
+		},
+		{
+			name:    "valid remove op",
+			patch:   []JSONPatchOp{{Op: "remove", Path: "/mcp_request/params/arguments/key"}},
+			wantErr: false,
+		},
+		{
+			name:    "valid replace op",
+			patch:   []JSONPatchOp{{Op: "replace", Path: "/mcp_request/params/arguments/key", Value: json.RawMessage(`"new"`)}},
+			wantErr: false,
+		},
+		{
+			name:    "valid copy op",
+			patch:   []JSONPatchOp{{Op: "copy", Path: "/mcp_request/params/dest", From: "/mcp_request/params/src"}},
+			wantErr: false,
+		},
+		{
+			name:    "valid move op",
+			patch:   []JSONPatchOp{{Op: "move", Path: "/mcp_request/params/dest", From: "/mcp_request/params/src"}},
+			wantErr: false,
+		},
+		{
+			name:    "valid test op",
+			patch:   []JSONPatchOp{{Op: "test", Path: "/mcp_request/params/key", Value: json.RawMessage(`"expected"`)}},
+			wantErr: false,
+		},
+		{
+			name:    "invalid op name",
+			patch:   []JSONPatchOp{{Op: "delete", Path: "/mcp_request/params/key"}},
+			wantErr: true,
+		},
+		{
+			name:    "missing path",
+			patch:   []JSONPatchOp{{Op: "add", Value: json.RawMessage(`"value"`)}},
+			wantErr: true,
+		},
+		{
+			name:    "copy missing from",
+			patch:   []JSONPatchOp{{Op: "copy", Path: "/mcp_request/params/dest"}},
+			wantErr: true,
+		},
+		{
+			name:    "move missing from",
+			patch:   []JSONPatchOp{{Op: "move", Path: "/mcp_request/params/dest"}},
+			wantErr: true,
+		},
+		{
+			name:    "empty patch",
+			patch:   []JSONPatchOp{},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := ValidatePatch(tt.patch)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestIsPatchScopedToMCPRequest(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		patch []JSONPatchOp
+		want  bool
+	}{
+		{
+			name:  "scoped path",
+			patch: []JSONPatchOp{{Op: "add", Path: "/mcp_request/params/key", Value: json.RawMessage(`"v"`)}},
+			want:  true,
+		},
+		{
+			name: "multiple scoped paths",
+			patch: []JSONPatchOp{
+				{Op: "add", Path: "/mcp_request/params/key1", Value: json.RawMessage(`"v1"`)},
+				{Op: "add", Path: "/mcp_request/params/key2", Value: json.RawMessage(`"v2"`)},
+			},
+			want: true,
+		},
+		{
+			name:  "path outside mcp_request (principal)",
+			patch: []JSONPatchOp{{Op: "replace", Path: "/principal/email", Value: json.RawMessage(`"hacked@evil.com"`)}},
+			want:  false,
+		},
+		{
+			name:  "path outside mcp_request (context)",
+			patch: []JSONPatchOp{{Op: "add", Path: "/context/extra", Value: json.RawMessage(`"x"`)}},
+			want:  false,
+		},
+		{
+			name: "mixed: some scoped, some not",
+			patch: []JSONPatchOp{
+				{Op: "add", Path: "/mcp_request/params/key", Value: json.RawMessage(`"v"`)},
+				{Op: "replace", Path: "/principal/sub", Value: json.RawMessage(`"attacker"`)},
+			},
+			want: false,
+		},
+		{
+			name:  "reject exact mcp_request root replacement",
+			patch: []JSONPatchOp{{Op: "replace", Path: "/mcp_request", Value: json.RawMessage(`{"method":"tools/call"}`)}},
+			want:  false,
+		},
+		{
+			name:  "copy from outside mcp_request",
+			patch: []JSONPatchOp{{Op: "copy", Path: "/mcp_request/params/dest", From: "/principal/email"}},
+			want:  false,
+		},
+		{
+			name:  "copy both scoped",
+			patch: []JSONPatchOp{{Op: "copy", Path: "/mcp_request/params/dest", From: "/mcp_request/params/src"}},
+			want:  true,
+		},
+		{
+			name:  "empty patch",
+			patch: []JSONPatchOp{},
+			want:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := IsPatchScopedToMCPRequest(tt.patch)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestApplyPatch(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		original string
+		patch    []JSONPatchOp
+		check    func(t *testing.T, result []byte)
+		wantErr  bool
+	}{
+		{
+			name:     "add field",
+			original: `{"mcp_request":{"params":{"arguments":{"query":"SELECT *"}}}}`,
+			patch: []JSONPatchOp{
+				{Op: "add", Path: "/mcp_request/params/arguments/audit_user", Value: json.RawMessage(`"user@example.com"`)},
+			},
+			check: func(t *testing.T, result []byte) {
+				t.Helper()
+				var doc map[string]interface{}
+				require.NoError(t, json.Unmarshal(result, &doc))
+				mcpReq := doc["mcp_request"].(map[string]interface{})
+				params := mcpReq["params"].(map[string]interface{})
+				args := params["arguments"].(map[string]interface{})
+				assert.Equal(t, "user@example.com", args["audit_user"])
+				assert.Equal(t, "SELECT *", args["query"])
+			},
+		},
+		{
+			name:     "remove field",
+			original: `{"mcp_request":{"params":{"arguments":{"query":"SELECT *","secret":"pass"}}}}`,
+			patch: []JSONPatchOp{
+				{Op: "remove", Path: "/mcp_request/params/arguments/secret"},
+			},
+			check: func(t *testing.T, result []byte) {
+				t.Helper()
+				var doc map[string]interface{}
+				require.NoError(t, json.Unmarshal(result, &doc))
+				mcpReq := doc["mcp_request"].(map[string]interface{})
+				params := mcpReq["params"].(map[string]interface{})
+				args := params["arguments"].(map[string]interface{})
+				_, hasSecret := args["secret"]
+				assert.False(t, hasSecret)
+				assert.Equal(t, "SELECT *", args["query"])
+			},
+		},
+		{
+			name:     "replace field",
+			original: `{"mcp_request":{"params":{"arguments":{"env":"staging"}}}}`,
+			patch: []JSONPatchOp{
+				{Op: "replace", Path: "/mcp_request/params/arguments/env", Value: json.RawMessage(`"production"`)},
+			},
+			check: func(t *testing.T, result []byte) {
+				t.Helper()
+				var doc map[string]interface{}
+				require.NoError(t, json.Unmarshal(result, &doc))
+				mcpReq := doc["mcp_request"].(map[string]interface{})
+				params := mcpReq["params"].(map[string]interface{})
+				args := params["arguments"].(map[string]interface{})
+				assert.Equal(t, "production", args["env"])
+			},
+		},
+		{
+			name:     "multiple ops",
+			original: `{"mcp_request":{"params":{"arguments":{"query":"SELECT *"}}}}`,
+			patch: []JSONPatchOp{
+				{Op: "add", Path: "/mcp_request/params/arguments/user", Value: json.RawMessage(`"alice"`)},
+				{Op: "add", Path: "/mcp_request/params/arguments/dept", Value: json.RawMessage(`"eng"`)},
+			},
+			check: func(t *testing.T, result []byte) {
+				t.Helper()
+				var doc map[string]interface{}
+				require.NoError(t, json.Unmarshal(result, &doc))
+				mcpReq := doc["mcp_request"].(map[string]interface{})
+				params := mcpReq["params"].(map[string]interface{})
+				args := params["arguments"].(map[string]interface{})
+				assert.Equal(t, "alice", args["user"])
+				assert.Equal(t, "eng", args["dept"])
+			},
+		},
+		{
+			name:     "invalid JSON original",
+			original: `{not valid json`,
+			patch:    []JSONPatchOp{{Op: "add", Path: "/mcp_request/key", Value: json.RawMessage(`"v"`)}},
+			wantErr:  true,
+		},
+		{
+			name:     "patch to nonexistent path",
+			original: `{"mcp_request":{}}`,
+			patch:    []JSONPatchOp{{Op: "remove", Path: "/mcp_request/nonexistent"}},
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result, err := ApplyPatch([]byte(tt.original), tt.patch)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			if tt.check != nil {
+				tt.check(t, result)
+			}
+		})
+	}
+}

--- a/pkg/webhook/validating/middleware.go
+++ b/pkg/webhook/validating/middleware.go
@@ -142,11 +142,7 @@ func createValidatingHandler(executors []clientExecutor, serverName, transport s
 					slog.Info("Validating webhook denied request", "webhook", whName, "reason", resp.Reason, "message", resp.Message)
 
 					// Prevent information leaks by ignoring the webhook's message
-					msg := "Request denied by policy"
-
-					code := http.StatusForbidden
-
-					sendErrorResponse(w, code, msg, parsedMCP.ID)
+					sendErrorResponse(w, http.StatusForbidden, "Request denied by policy", parsedMCP.ID)
 					return
 				}
 			}
@@ -163,31 +159,11 @@ func readSourceIP(r *http.Request) string {
 	return r.RemoteAddr
 }
 
-func convertToJSONRPC2ID(id interface{}) (jsonrpc2.ID, error) {
-	if id == nil {
-		return jsonrpc2.ID{}, nil
-	}
-
-	switch v := id.(type) {
-	case string:
-		return jsonrpc2.StringID(v), nil
-	case int:
-		return jsonrpc2.Int64ID(int64(v)), nil
-	case int64:
-		return jsonrpc2.Int64ID(v), nil
-	case float64:
-		// JSON numbers are often unmarshaled as float64
-		return jsonrpc2.Int64ID(int64(v)), nil
-	default:
-		return jsonrpc2.ID{}, fmt.Errorf("unsupported ID type: %T", id)
-	}
-}
-
 func sendErrorResponse(w http.ResponseWriter, statusCode int, message string, msgID interface{}) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(statusCode)
 
-	id, err := convertToJSONRPC2ID(msgID)
+	id, err := mcp.ConvertToJSONRPC2ID(msgID)
 	if err != nil {
 		id = jsonrpc2.ID{} // Use empty ID if conversion fails
 	}

--- a/pkg/webhook/validating/middleware_test.go
+++ b/pkg/webhook/validating/middleware_test.go
@@ -175,7 +175,7 @@ func TestValidatingMiddleware(t *testing.T) {
 		assert.Equal(t, "Request denied by policy", errObj["message"])
 	})
 
-	t.Run("Denied Request - Out-of-Range Code Defaults to 403", func(t *testing.T) {
+	t.Run("Denied Request - Ignores Webhook Code Field", func(t *testing.T) {
 		mockResponse.Allowed = false
 		mockResponse.Message = "blocked"
 		mockResponse.Code = 200 // out-of-range (not 4xx-5xx) should default to 403
@@ -194,7 +194,7 @@ func TestValidatingMiddleware(t *testing.T) {
 		mw(nextHandler).ServeHTTP(rr, req)
 
 		assert.False(t, nextCalled)
-		assert.Equal(t, http.StatusForbidden, rr.Code, "Out-of-range webhook code should be normalized to 403")
+		assert.Equal(t, http.StatusForbidden, rr.Code, "Webhook code should be ignored and default to 403")
 	})
 
 	t.Run("Webhook Error - Fail Policy", func(t *testing.T) {


### PR DESCRIPTION
## Summary
Implements **Phase 3** of the Dynamic Webhook Middleware system: **Mutating Webhook Middleware**, as outlined in RFC THV-0017.

This PR adds support for mutating webhooks that allow external HTTP services to transform incoming MCP requests dynamically using RFC 6902 JSON Patch operations. Mutating webhooks are executed after the MCP parser but before validating webhooks, allowing organizations to cleanly intercept and rewrite requests (e.g., adding default parameters, applying transformations, or injecting audit trails) before validation or authorization logic runs.

---

## Large PR Justification

This is a new feature package with a large test suite, and it needs to land as one coherent phase so the middleware wiring, patch handling, and coverage stay consistent.

---


Fixes #3398 

## Changes

### 1. `pkg/webhook/mutating/` Package
Introduces the core logic for mutating webhooks:
- **`config.go`**: Defines configuration parameter types (`MiddlewareParams`, `FactoryMiddlewareParams`) mirroring the validating package.
- **`patch.go`**: Implements RFC 6902 JSONPatch parsing and application using `github.com/evanphx/json-patch/v5`.
  - Includes `ValidatePatch()` to ensure only supported operations are allowed.
  - Implements **Scope Validation (`IsPatchScopedToMCPRequest()`)** to ensure webhooks can only modify the `mcp_request` container inside the webhook payload, preventing unauthorized modification of the request principal, context, or envelope metadata.
- **`middleware.go`**: The HTTP middleware factory and handler.
  - Skips non-MCP requests gracefully.
  - Executes chained mutating webhooks in configuration order, passing the output of one as the input to the next.
  - Extracts the raw MCP request, evaluates it against the webhook endpoints, and applies the returned JSONPatches.
  - Supports RFC-defined failure policies (`fail` vs `ignore`) for connection errors or malformed patches.

### 2. Runner Wiring (`pkg/runner/`)
- **`config.go`**: Added `MutatingWebhooks []webhook.Config` to `RunConfig` to allow configuring mutating webhooks natively via state persistence or configuration YAML.
- **`middleware.go`**: Registered the mutating webhook middleware factory and inserted it into the middleware execution chain. It executes proactively **before** the validating webhook middleware, matching the RFC specifications.

### 3. Dependencies
- Added `github.com/evanphx/json-patch/v5` for RFC 6902-compliant patch application.

### 4. Addressed Phase 2 leftover review comments
- Inlined the variables in `sendErrorResponse` in the validating webhook middleware.
- Renamed the misleading test in `pkg/webhook/validating/middleware_test.go`.
- Extracted duplicate `convertToJSONRPC2ID` implementations from all 3 middlewares (authz, validating, mutating) to a central location (pkg/mcp/utils.go).

### 5. Full Middleware Chain Integration Test
- Added `TestWebhookMiddlewareChainIntegration` to `pkg/runner/webhook_integration_test.go` to test the execution flow of both mutating and validating webhooks as initialized by the runner configuration parsing.

### 6. Test Coverage Improvements:
- Added new tests checking failure states of patch extraction and application to increase `pkg/webhook/mutating/patch.go` and `pkg/webhook/mutating/middleware.go` coverage.
- Addressed low coverage for `PopulateMiddlewareConfigs` in `pkg/runner/middleware.go` by adding `TestPopulateMiddlewareConfigs_FullCoverage` which spans across all configuration branch setups.


## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

<!--
REQUIRED. Check every verification step you actually ran.
You MUST check at least one item. If you only did manual testing,
describe exactly what you tested below the checkbox.
-->

- [x] Unit tests (`task test`)
- [x] E2E tests (`task test-e2e`)
- [x] Linting (`task lint-fix`)
- [ ] Manual testing (describe below)
