### PR TITLE
Expose content array alongside structuredContent in workflow templates

### DIFF
--- a/pkg/vmcp/composer/composer.go
+++ b/pkg/vmcp/composer/composer.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/stacklok/toolhive/pkg/vmcp"
 	"github.com/stacklok/toolhive/pkg/vmcp/config"
 )
 
@@ -212,8 +213,13 @@ type StepResult struct {
 	// Status is the step status.
 	Status StepStatusType
 
-	// Output contains the step output data.
+	// Output contains the step output data (from StructuredContent or ContentArrayToMap fallback).
 	Output map[string]any
+
+	// Content holds the raw content array from the tool call result.
+	// This is exposed separately in templates via {{.steps.stepID.content.*}} so that
+	// structuredContent remains clean for outputSchema validation.
+	Content []vmcp.Content
 
 	// Error contains error information if the step failed.
 	Error error

--- a/pkg/vmcp/composer/template_expander.go
+++ b/pkg/vmcp/composer/template_expander.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/stacklok/toolhive/pkg/templates"
+	"github.com/stacklok/toolhive/pkg/vmcp/conversion"
 )
 
 const (
@@ -163,7 +164,10 @@ func (e *defaultTemplateExpander) expandString(
 }
 
 // buildStepsContext converts StepResult map to a template-friendly structure.
-// This provides access to step outputs via {{.steps.stepid.output.field}}.
+// This provides access to step outputs via:
+//   - {{.steps.stepid.output.field}} for structuredContent fields
+//   - {{.steps.stepid.content.text}} for text content from the content array
+//   - {{.steps.stepid.content.resource}} for embedded resource content from the content array
 func (*defaultTemplateExpander) buildStepsContext(workflowCtx *WorkflowContext) map[string]any {
 	// Acquire read lock to safely access Steps map during concurrent execution
 	workflowCtx.mu.RLock()
@@ -173,8 +177,9 @@ func (*defaultTemplateExpander) buildStepsContext(workflowCtx *WorkflowContext) 
 
 	for stepID, result := range workflowCtx.Steps {
 		stepData := map[string]any{
-			"status": string(result.Status),
-			"output": result.Output,
+			"status":  string(result.Status),
+			"output":  result.Output,
+			"content": conversion.ContentArrayToMap(result.Content),
 		}
 
 		// Add error information if step failed

--- a/pkg/vmcp/composer/template_expander_test.go
+++ b/pkg/vmcp/composer/template_expander_test.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/stacklok/toolhive/pkg/vmcp"
 )
 
 func TestTemplateExpander_Expand(t *testing.T) {
@@ -73,6 +75,40 @@ func TestTemplateExpander_Expand(t *testing.T) {
 			data:     map[string]any{"val": "{{.params.nonexistent}}"},
 			params:   map[string]any{},
 			expected: map[string]any{"val": "<no value>"},
+		},
+		{
+			name: "step content resource substitution",
+			data: map[string]any{"sbom": "{{.steps.fetch.content.resource}}"},
+			steps: map[string]*StepResult{
+				"fetch": {
+					Status: StepStatusCompleted,
+					Output: map[string]any{"format": "spdx"},
+					Content: []vmcp.Content{
+						{Type: vmcp.ContentTypeResource, Text: `{"spdxVersion":"SPDX-2.3"}`, URI: "file://sbom.json"},
+					},
+				},
+			},
+			expected: map[string]any{"sbom": `{"spdxVersion":"SPDX-2.3"}`},
+		},
+		{
+			name: "step output and content are independent namespaces",
+			data: map[string]any{
+				"format": "{{.steps.fetch.output.format}}",
+				"text":   "{{.steps.fetch.content.text}}",
+			},
+			steps: map[string]*StepResult{
+				"fetch": {
+					Status: StepStatusCompleted,
+					Output: map[string]any{"format": "spdx", "text": "structured text"},
+					Content: []vmcp.Content{
+						{Type: vmcp.ContentTypeText, Text: "content array text"},
+					},
+				},
+			},
+			expected: map[string]any{
+				"format": "spdx",
+				"text":   "content array text",
+			},
 		},
 	}
 
@@ -154,7 +190,7 @@ func TestWorkflowContext_Lifecycle(t *testing.T) {
 	assert.Equal(t, StepStatusRunning, ctx.Steps["s1"].Status)
 
 	time.Sleep(10 * time.Millisecond)
-	ctx.RecordStepSuccess("s1", map[string]any{"result": "ok"})
+	ctx.RecordStepSuccess("s1", map[string]any{"result": "ok"}, nil)
 	assert.Equal(t, StepStatusCompleted, ctx.Steps["s1"].Status)
 	assert.Greater(t, ctx.Steps["s1"].Duration, time.Duration(0))
 
@@ -185,12 +221,12 @@ func TestWorkflowContext_GetLastStepOutput(t *testing.T) {
 	// Add steps with different completion times
 	ctx.RecordStepStart("s1")
 	time.Sleep(5 * time.Millisecond)
-	ctx.RecordStepSuccess("s1", map[string]any{"order": 1})
+	ctx.RecordStepSuccess("s1", map[string]any{"order": 1}, nil)
 
 	time.Sleep(5 * time.Millisecond)
 	ctx.RecordStepStart("s2")
 	time.Sleep(5 * time.Millisecond)
-	ctx.RecordStepSuccess("s2", map[string]any{"order": 2})
+	ctx.RecordStepSuccess("s2", map[string]any{"order": 2}, nil)
 
 	// Should return latest (s2)
 	output := ctx.GetLastStepOutput()

--- a/pkg/vmcp/composer/workflow_context.go
+++ b/pkg/vmcp/composer/workflow_context.go
@@ -10,6 +10,8 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/stacklok/toolhive/pkg/vmcp"
 )
 
 // workflowContextManager manages workflow execution contexts.
@@ -87,13 +89,15 @@ func (ctx *WorkflowContext) RecordStepStart(stepID string) {
 
 // RecordStepSuccess records a successful step completion.
 // Thread-safe for concurrent step execution.
-func (ctx *WorkflowContext) RecordStepSuccess(stepID string, output map[string]any) {
+// The content parameter is optional (may be nil for non-tool steps like elicitation).
+func (ctx *WorkflowContext) RecordStepSuccess(stepID string, output map[string]any, content []vmcp.Content) {
 	ctx.mu.Lock()
 	defer ctx.mu.Unlock()
 
 	if result, exists := ctx.Steps[stepID]; exists {
 		result.Status = StepStatusCompleted
 		result.Output = output
+		result.Content = content
 		result.EndTime = time.Now()
 		result.Duration = result.EndTime.Sub(result.StartTime)
 	}
@@ -207,10 +211,16 @@ func (ctx *WorkflowContext) Clone() *WorkflowContext {
 
 	// Clone step results
 	for stepID, result := range ctx.Steps {
+		var contentCopy []vmcp.Content
+		if result.Content != nil {
+			contentCopy = make([]vmcp.Content, len(result.Content))
+			copy(contentCopy, result.Content)
+		}
 		clone.Steps[stepID] = &StepResult{
 			StepID:     result.StepID,
 			Status:     result.Status,
 			Output:     cloneMap(result.Output),
+			Content:    contentCopy,
 			Error:      result.Error,
 			StartTime:  result.StartTime,
 			EndTime:    result.EndTime,

--- a/pkg/vmcp/composer/workflow_engine.go
+++ b/pkg/vmcp/composer/workflow_engine.go
@@ -428,24 +428,32 @@ func (e *workflowEngine) executeToolStep(
 	}
 
 	// Call tool with retry logic
-	output, retryCount, err := e.callToolWithRetry(ctx, target, step, expandedArgs, workflowCtx)
+	result, retryCount, err := e.callToolWithRetry(ctx, target, step, expandedArgs, workflowCtx)
 
 	// Handle result
 	if err != nil {
 		return e.handleToolStepFailure(step, workflowCtx, retryCount, err)
 	}
 
-	return e.handleToolStepSuccess(ctx, step, workflowCtx, output, retryCount)
+	// Extract output map from result.
+	// Prefer StructuredContent (already a map), fall back to Content array conversion.
+	output := result.StructuredContent
+	if output == nil {
+		output = conversion.ContentArrayToMap(result.Content)
+	}
+
+	return e.handleToolStepSuccess(ctx, step, workflowCtx, output, result.Content, retryCount)
 }
 
 // callToolWithRetry calls a tool with retry logic using exponential backoff.
+// Returns the full ToolCallResult so callers can access both StructuredContent and Content.
 func (e *workflowEngine) callToolWithRetry(
 	ctx context.Context,
 	target *vmcp.BackendTarget,
 	step *WorkflowStep,
 	args map[string]any,
 	_ *WorkflowContext,
-) (map[string]any, int, error) {
+) (*vmcp.ToolCallResult, int, error) {
 	maxRetries, initialDelay := e.getRetryConfig(step)
 
 	// Configure exponential backoff
@@ -455,7 +463,7 @@ func (e *workflowEngine) callToolWithRetry(
 	expBackoff.Reset()
 
 	attemptCount := 0
-	operation := func() (map[string]any, error) {
+	operation := func() (*vmcp.ToolCallResult, error) {
 		attemptCount++
 		// TODO: For composite tools, we may want to propagate metadata from the parent request
 		result, err := e.backendClient.CallTool(ctx, target, step.Tool, args, nil)
@@ -482,22 +490,12 @@ func (e *workflowEngine) callToolWithRetry(
 			return nil, fmt.Errorf("%w: %s", vmcp.ErrToolExecutionFailed, errorMsg)
 		}
 
-		// Extract output map from result.
-		// Workflow logic uses map[string]any for template variable substitution.
-		// Prefer StructuredContent (already a map), fall back to Content array conversion.
-		// The _meta field is not needed for workflow execution, so we don't extract it.
-		if result.StructuredContent != nil {
-			return result.StructuredContent, nil
-		}
-
-		// Fallback: convert Content array to map for backward compatibility.
-		// This happens when backends return only Content without StructuredContent.
-		return conversion.ContentArrayToMap(result.Content), nil
+		return result, nil
 	}
 
 	// Execute with retry
 	// Safe conversion: maxRetries is capped by maxRetryCount constant (10)
-	output, err := backoff.Retry(ctx, operation,
+	result, err := backoff.Retry(ctx, operation,
 		backoff.WithBackOff(expBackoff),
 		backoff.WithMaxTries(uint(maxRetries+1)), // #nosec G115 -- +1 because it includes the initial attempt
 		backoff.WithNotify(func(_ error, duration time.Duration) {
@@ -505,7 +503,7 @@ func (e *workflowEngine) callToolWithRetry(
 		}),
 	)
 
-	return output, attemptCount - 1, err // Return retry count (attempts - 1)
+	return result, attemptCount - 1, err // Return retry count (attempts - 1)
 }
 
 // extractErrorMessage extracts a user-friendly error message from a failed tool call result.
@@ -595,9 +593,10 @@ func (e *workflowEngine) handleToolStepSuccess(
 	step *WorkflowStep,
 	workflowCtx *WorkflowContext,
 	output map[string]any,
+	content []vmcp.Content,
 	retryCount int,
 ) error {
-	workflowCtx.RecordStepSuccess(step.ID, output)
+	workflowCtx.RecordStepSuccess(step.ID, output, content)
 
 	// Update retry count
 	if result, exists := workflowCtx.GetStepResult(step.ID); exists {
@@ -698,7 +697,7 @@ func (*workflowEngine) handleElicitationAccept(
 		"content": response.Content,
 	}
 
-	workflowCtx.RecordStepSuccess(step.ID, output)
+	workflowCtx.RecordStepSuccess(step.ID, output, nil)
 	slog.Debug("step completed with user-provided data", "step", step.ID)
 	return nil
 }
@@ -772,7 +771,7 @@ func (*workflowEngine) handleElicitationAction(
 			"action":  reason,
 			"skipped": true,
 		}
-		workflowCtx.RecordStepSuccess(step.ID, output)
+		workflowCtx.RecordStepSuccess(step.ID, output, nil)
 		// Return a special error that the workflow engine can detect
 		// For now, we'll just complete the step successfully
 		return nil
@@ -795,7 +794,7 @@ func (*workflowEngine) handleElicitationAction(
 		output := map[string]any{
 			"action": reason,
 		}
-		workflowCtx.RecordStepSuccess(step.ID, output)
+		workflowCtx.RecordStepSuccess(step.ID, output, nil)
 		return nil
 
 	default:

--- a/pkg/vmcp/composer/workflow_engine_test.go
+++ b/pkg/vmcp/composer/workflow_engine_test.go
@@ -846,3 +846,64 @@ func TestWorkflowEngine_SessionEngine_ToolNotInList_ReturnsNilSchema(t *testing.
 	require.NoError(t, err)
 	assert.Equal(t, WorkflowStatusCompleted, result.Status)
 }
+
+func TestWorkflowEngine_EmbeddedResourceAccessibleFromTemplate(t *testing.T) {
+	t.Parallel()
+	te := newTestEngine(t)
+
+	// Step 1: tool returns structuredContent (schema-conformant) + embedded resource in Content array.
+	// Step 2: accesses structuredContent via .output and content array via .content.
+	// This keeps structuredContent clean for outputSchema validation while making
+	// content array data (text, resources) accessible through a separate namespace.
+	def := simpleWorkflow("resource-chain",
+		toolStep("fetch", "registry.get_referrer_content", map[string]any{
+			"image": "ghcr.io/org/repo:latest",
+		}),
+		toolStepWithDeps("analyze", "sbom.analyze", map[string]any{
+			"sbom_data": "{{.steps.fetch.content.resource}}",
+			"format":    "{{.steps.fetch.output.format}}",
+		}, []string{"fetch"}),
+	)
+
+	target := &vmcp.BackendTarget{
+		WorkloadID:   "test-backend",
+		WorkloadName: "test",
+		BaseURL:      "http://test:8080",
+	}
+	te.Router.EXPECT().RouteTool(gomock.Any(), "registry.get_referrer_content").Return(target, nil)
+	te.Backend.EXPECT().CallTool(gomock.Any(), target, "registry.get_referrer_content",
+		map[string]any{"image": "ghcr.io/org/repo:latest"}, gomock.Any()).
+		Return(&vmcp.ToolCallResult{
+			StructuredContent: map[string]any{
+				"contentType": "sbom",
+				"format":      "spdx",
+				"size":        float64(5347),
+			},
+			Content: []vmcp.Content{
+				{Type: vmcp.ContentTypeText, Text: "summary of SBOM"},
+				{Type: vmcp.ContentTypeResource, Text: `{"spdxVersion":"SPDX-2.3","name":"mypackage"}`, URI: "file://sbom.json"},
+			},
+		}, nil)
+
+	// Step 2: verify the template-expanded args pull from the right namespaces.
+	te.Router.EXPECT().RouteTool(gomock.Any(), "sbom.analyze").Return(target, nil)
+	te.Backend.EXPECT().CallTool(gomock.Any(), target, "sbom.analyze", gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ *vmcp.BackendTarget, _ string, args map[string]any, _ map[string]any) (*vmcp.ToolCallResult, error) {
+			// .content.resource comes from the Content array's embedded resource
+			assert.Equal(t, `{"spdxVersion":"SPDX-2.3","name":"mypackage"}`, args["sbom_data"])
+			// .output.format comes from structuredContent
+			assert.Equal(t, "spdx", args["format"])
+			return &vmcp.ToolCallResult{
+				StructuredContent: map[string]any{"result": "analyzed"},
+				Content:           []vmcp.Content{},
+			}, nil
+		})
+
+	result, err := execute(t, te.Engine, def, nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, WorkflowStatusCompleted, result.Status)
+	assert.Len(t, result.Steps, 2)
+	assert.Equal(t, StepStatusCompleted, result.Steps["fetch"].Status)
+	assert.Equal(t, StepStatusCompleted, result.Steps["analyze"].Status)
+}

--- a/pkg/vmcp/conversion/content.go
+++ b/pkg/vmcp/conversion/content.go
@@ -376,8 +376,10 @@ func ToMCPToolAnnotations(annotations *vmcp.ToolAnnotations) mcp.ToolAnnotation 
 //   - First text content: key="text"
 //   - Subsequent text content: key="text_1", "text_2", etc.
 //   - Image content: key="image_0", "image_1", etc.
+//   - First resource content: key="resource" (text resources use .Text, blob resources use .Data)
+//   - Subsequent resource content: key="resource_1", "resource_2", etc.
 //   - Audio content: ignored (not supported for template substitution)
-//   - Resource content: ignored (handled separately, not converted to map)
+//   - Resource links: ignored (not supported for template substitution)
 //   - Unknown content types: ignored (warnings logged at conversion boundaries)
 //
 // This ensures consistent behavior between client response handling and workflow step output processing.
@@ -389,6 +391,7 @@ func ContentArrayToMap(content []vmcp.Content) map[string]any {
 
 	textIndex := 0
 	imageIndex := 0
+	resourceIndex := 0
 
 	for _, item := range content {
 		switch item.Type {
@@ -405,10 +408,23 @@ func ContentArrayToMap(content []vmcp.Content) map[string]any {
 			result[key] = item.Data
 			imageIndex++
 
-		case vmcp.ContentTypeAudio, vmcp.ContentTypeResource, vmcp.ContentTypeLink:
+		case vmcp.ContentTypeResource:
+			key := "resource"
+			if resourceIndex > 0 {
+				key = fmt.Sprintf("resource_%d", resourceIndex)
+			}
+			// Text resources use .Text, blob resources use .Data
+			value := item.Text
+			if value == "" {
+				value = item.Data
+			}
+			result[key] = value
+			resourceIndex++
+
+		case vmcp.ContentTypeAudio, vmcp.ContentTypeLink:
 			// Purposely ignored for template substitution:
 			// - Audio content is ignored (not supported for template substitution)
-			// - Resource content/link is handled separately, not converted to map
+			// - Resource links are ignored (not supported for template substitution)
 		default:
 			// Unknown content types are ignored (warnings logged at conversion boundaries)
 		}

--- a/pkg/vmcp/conversion/conversion_test.go
+++ b/pkg/vmcp/conversion/conversion_test.go
@@ -686,7 +686,58 @@ func TestContentArrayToMap(t *testing.T) {
 			content: []vmcp.Content{
 				{Type: vmcp.ContentTypeText, Text: "Text"},
 				{Type: "unknown", Text: "Should be ignored"},
-				{Type: vmcp.ContentTypeResource, URI: "file://test"},
+			},
+			expected: map[string]any{
+				"text": "Text",
+			},
+		},
+		{
+			name: "single text resource content",
+			content: []vmcp.Content{
+				{Type: vmcp.ContentTypeResource, Text: "SBOM JSON data", URI: "file://sbom.json", MimeType: "application/json"},
+			},
+			expected: map[string]any{
+				"resource": "SBOM JSON data",
+			},
+		},
+		{
+			name: "single blob resource content uses Data field",
+			content: []vmcp.Content{
+				{Type: vmcp.ContentTypeResource, Data: "base64blobdata", URI: "file://binary", MimeType: "application/octet-stream"},
+			},
+			expected: map[string]any{
+				"resource": "base64blobdata",
+			},
+		},
+		{
+			name: "multiple resource contents",
+			content: []vmcp.Content{
+				{Type: vmcp.ContentTypeResource, Text: "First resource", URI: "file://a"},
+				{Type: vmcp.ContentTypeResource, Text: "Second resource", URI: "file://b"},
+				{Type: vmcp.ContentTypeResource, Data: "Third blob", URI: "file://c"},
+			},
+			expected: map[string]any{
+				"resource":   "First resource",
+				"resource_1": "Second resource",
+				"resource_2": "Third blob",
+			},
+		},
+		{
+			name: "mixed text and resource content",
+			content: []vmcp.Content{
+				{Type: vmcp.ContentTypeText, Text: "summary"},
+				{Type: vmcp.ContentTypeResource, Text: "SBOM JSON", URI: "file://sbom.json"},
+			},
+			expected: map[string]any{
+				"text":     "summary",
+				"resource": "SBOM JSON",
+			},
+		},
+		{
+			name: "resource link content is still ignored",
+			content: []vmcp.Content{
+				{Type: vmcp.ContentTypeText, Text: "Text"},
+				{Type: vmcp.ContentTypeLink, URI: "file://link", Name: "link"},
 			},
 			expected: map[string]any{
 				"text": "Text",


### PR DESCRIPTION
## Summary

- The MCP spec (2025-11-25) defines `structuredContent` and `content` as separate concerns: `structuredContent` must conform to `outputSchema`, while the `content` array is the backward-compatible representation (text, images, embedded resources). The vmcp workflow engine only exposed `structuredContent` to templates, so composite tools could not access embedded resource data from downstream steps.
- Additionally, `ContentArrayToMap` explicitly ignored `EmbeddedResource` content types, so even the fallback path (no `structuredContent`) dropped resource data.

This PR:
- Handles `ContentTypeResource` in `ContentArrayToMap`, mapping embedded resource text/data to `resource`, `resource_1`, etc.
- Adds a `Content` field to `StepResult` and wires it through the workflow engine, so the raw content array is preserved alongside `StructuredContent`.
- Exposes content array data as a separate `content` namespace in templates via `{{.steps.X.content.*}}`, keeping `structuredContent` clean for `outputSchema` validation.

Template access after this change:
- `{{.steps.get_sbom.output.format}}` -- structuredContent field (schema-conformant)
- `{{.steps.get_sbom.content.resource}}` -- embedded resource text from content array
- `{{.steps.get_sbom.content.text}}` -- text content from content array

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)

## Changes

| File | Change |
|------|--------|
| `pkg/vmcp/conversion/content.go` | Handle `ContentTypeResource` in `ContentArrayToMap` with `resource`, `resource_1`, etc. key pattern |
| `pkg/vmcp/composer/composer.go` | Add `Content []vmcp.Content` field to `StepResult` |
| `pkg/vmcp/composer/workflow_context.go` | Update `RecordStepSuccess` to accept and store Content; fix `Clone()` to copy it |
| `pkg/vmcp/composer/workflow_engine.go` | Return full `ToolCallResult` from `callToolWithRetry`; pass Content through to `RecordStepSuccess` |
| `pkg/vmcp/composer/template_expander.go` | Expose `content` key in `buildStepsContext` via `ContentArrayToMap` |
| `pkg/vmcp/client/client.go` | Keep structuredContent clean (no flat merge) |
| `pkg/vmcp/session/internal/backend/mcp_session.go` | Same as client.go |
| `pkg/vmcp/conversion/conversion_test.go` | Tests for resource mapping in `ContentArrayToMap` |
| `pkg/vmcp/composer/template_expander_test.go` | Tests for `{{.steps.X.content.resource}}` and namespace independence |
| `pkg/vmcp/composer/workflow_engine_test.go` | Workflow test: step accesses embedded resource via `.content` and structured data via `.output` |

## Does this introduce a user-facing change?

Composite tool workflows can now access embedded resource content from downstream steps via `{{.steps.stepID.content.resource}}`. Structured output remains accessible via `{{.steps.stepID.output.field}}` as before.

## Special notes for reviewers

The key design decision is keeping `output` and `content` as independent template namespaces rather than merging content array keys into structuredContent. Merging would violate `outputSchema` validation when `additionalProperties: false` is set, since the extra keys from the content array would fail schema checks.

When a backend returns only a Content array (no StructuredContent), `output` and `content` both resolve to `ContentArrayToMap(result.Content)`, so `{{.steps.X.output.text}}` and `{{.steps.X.content.text}}` return the same value. This is the expected fallback behavior.

Generated with [Claude Code](https://claude.com/claude-code)