### PR TITLE
Add edited trigger to PR size labeler workflow

### DIFF
--- a/.github/workflows/pr-size-labeler.yml
+++ b/.github/workflows/pr-size-labeler.yml
@@ -2,7 +2,7 @@ name: PR Size Labeler - Calculate
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, edited]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Update the triggers on the PR Size Labeler workflow (pr-size-labeler.yaml) to run when the submitter edits their PR description with the justification.

Previously, only a push or manual re-run of the workflow would trigger it.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [x] Other (describe): workflow

## Test plan

<!--
REQUIRED. Check every verification step you actually ran.
You MUST check at least one item. If you only did manual testing,
describe exactly what you tested below the checkbox.
-->

- [ ] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [ ] Linting (`task lint-fix`)
- [x] Manual testing (describe below)

N/A, workflow-only change.

## Does this introduce a user-facing change?

No

---

Signed-off-by: Dan Barr <6922515+danbarr@users.noreply.github.com>