### PR TITLE
Fix macOS symlink test failures and upgrade phonenumbers dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -213,6 +213,7 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
+	github.com/nyaruka/phonenumbers v1.6.12 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/olekukonko/cat v0.0.0-20250911104152-50322a0618f6 // indirect
 	github.com/olekukonko/errors v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -643,8 +643,8 @@ github.com/natefinch/atomic v1.0.1 h1:ZPYKxkqQOx3KZ+RsbnP/YsgvxWQPGxjC0oBt2AhwV0
 github.com/natefinch/atomic v1.0.1/go.mod h1:N/D/ELrljoqDyT3rZrsUmtsuzvHkeB/wWjHV22AZRbM=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
-github.com/nyaruka/phonenumbers v1.1.6 h1:DcueYq7QrOArAprAYNoQfDgp0KetO4LqtnBtQC6Wyes=
-github.com/nyaruka/phonenumbers v1.1.6/go.mod h1:yShPJHDSH3aTKzCbXyVxNpbl2kA+F+Ne5Pun/MvFRos=
+github.com/nyaruka/phonenumbers v1.6.12 h1:aeGHjGQnfLhdN5/mZPevhoYMs13FWcQ0Vus0YQHh1Ec=
+github.com/nyaruka/phonenumbers v1.6.12/go.mod h1:IUu45lj2bSeYXQuxDyyuzOrdV10tyRa1YSsfH8EKN5c=
 github.com/oauth2-proxy/mockoidc v0.0.0-20240214162133-caebfff84d25 h1:9bCMuD3TcnjeqjPT2gSlha4asp8NvgcFRYExCaikCxk=
 github.com/oauth2-proxy/mockoidc v0.0.0-20240214162133-caebfff84d25/go.mod h1:eDjgYHYDJbPLBLsyZ6qRaugP0mX8vePOhZ5id1fdzJw=
 github.com/oklog/ulid v1.3.1 h1:EGfNDEx6MqHz8B3uNV6QAib1UR2Lm97sHi3ocA6ESJ4=

--- a/pkg/server/discovery/health_test.go
+++ b/pkg/server/discovery/health_test.go
@@ -84,7 +84,11 @@ func TestCheckHealth_TCP_NoNonceCheck(t *testing.T) {
 
 func TestCheckHealth_UnixSocket_Success(t *testing.T) {
 	t.Parallel()
-	socketDir := t.TempDir()
+	// Use os.MkdirTemp with a short name to stay under macOS's 104-char Unix socket path limit.
+	// t.TempDir() produces paths like /private/var/folders/.../TestCheckHealth.../001/ which are too long.
+	socketDir, err := os.MkdirTemp("", "thv-")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(socketDir) })
 	socketPath := filepath.Join(socketDir, "test.sock")
 
 	listener, err := net.Listen("unix", socketPath)

--- a/pkg/skills/skillsvc/skillsvc_test.go
+++ b/pkg/skills/skillsvc/skillsvc_test.go
@@ -1783,7 +1783,7 @@ func TestInstallAddsSkillToGroup(t *testing.T) {
 			},
 			setupPR: func(pr *skillsmocks.MockPathResolver) {
 				pr.EXPECT().ListSkillSupportingClients().Return([]string{"claude-code"})
-				pr.EXPECT().GetSkillPath("claude-code", "my-skill", skills.ScopeUser, "").Return(filepath.Join(t.TempDir(), "my-skill"), nil)
+				pr.EXPECT().GetSkillPath("claude-code", "my-skill", skills.ScopeUser, "").Return(filepath.Join(tempDir(t), "my-skill"), nil)
 			},
 			setupGroupMock: func(gm *groupmocks.MockManager) {
 				gm.EXPECT().Get(gomock.Any(), "mygroup").
@@ -1800,7 +1800,7 @@ func TestInstallAddsSkillToGroup(t *testing.T) {
 			},
 			setupPR: func(pr *skillsmocks.MockPathResolver) {
 				pr.EXPECT().ListSkillSupportingClients().Return([]string{"claude-code"})
-				pr.EXPECT().GetSkillPath("claude-code", "my-skill", skills.ScopeUser, "").Return(filepath.Join(t.TempDir(), "my-skill"), nil)
+				pr.EXPECT().GetSkillPath("claude-code", "my-skill", skills.ScopeUser, "").Return(filepath.Join(tempDir(t), "my-skill"), nil)
 			},
 			setupGroupMock: func(gm *groupmocks.MockManager) {
 				gm.EXPECT().Get(gomock.Any(), groups.DefaultGroup).
@@ -1819,7 +1819,7 @@ func TestInstallAddsSkillToGroup(t *testing.T) {
 			},
 			setupPR: func(pr *skillsmocks.MockPathResolver) {
 				pr.EXPECT().ListSkillSupportingClients().Return([]string{"claude-code"})
-				pr.EXPECT().GetSkillPath("claude-code", "my-skill", skills.ScopeUser, "").Return(filepath.Join(t.TempDir(), "my-skill"), nil)
+				pr.EXPECT().GetSkillPath("claude-code", "my-skill", skills.ScopeUser, "").Return(filepath.Join(tempDir(t), "my-skill"), nil)
 			},
 			setupGroupMock: func(gm *groupmocks.MockManager) {
 				gm.EXPECT().Get(gomock.Any(), "badgroup").


### PR DESCRIPTION
## Summary

- Two unit tests were failing on macOS because `t.TempDir()` returns paths under `/var/folders/...`, which is a symlink to `/private/var/...`. The skill extractor rejects paths containing symlinks, and the resolved path also exceeded macOS's 104-char Unix socket path limit.
- Upgrades `github.com/nyaruka/phonenumbers` from v1.1.6 to v1.6.12 to resolve GHSA-fmjh-f678-cv3x (Medium severity).

## Changes

| File | Change |
|------|--------|
| [pkg/skills/skillsvc/skillsvc_test.go](pkg/skills/skillsvc/skillsvc_test.go) | Use existing `tempDir(t)` helper (calls `filepath.EvalSymlinks`) in `setupPR` closures so extracted skill paths pass symlink validation |
| [pkg/server/discovery/health_test.go](pkg/server/discovery/health_test.go) | Use `os.MkdirTemp("", "thv-")` for the Unix socket test to produce a short path that fits within macOS's 104-char limit |
| go.mod / go.sum | Upgrade `github.com/nyaruka/phonenumbers` v1.1.6 → v1.6.12 |

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test plan

- [x] `task test` passes locally with no failures

## Does this introduce a user-facing change?

No

Generated with [Claude Code](https://claude.com/claude-code)