### PR TITLE
Guard against invalid PIDs in process operations

### DIFF
--- a/pkg/process/find_unix.go
+++ b/pkg/process/find_unix.go
@@ -14,6 +14,10 @@ import (
 // FindProcess finds a process by its ID and checks if it's running.
 // This function works on Unix systems (Linux and macOS).
 func FindProcess(pid int) (bool, error) {
+	if pid <= 0 {
+		return false, fmt.Errorf("invalid PID: %d", pid)
+	}
+
 	// On Unix systems, os.FindProcess always succeeds regardless of whether
 	// the process exists or not. We need to send a signal to check if it's running.
 	proc, err := os.FindProcess(pid)

--- a/pkg/process/find_windows.go
+++ b/pkg/process/find_windows.go
@@ -28,6 +28,10 @@ var (
 // FindProcess finds a process by its ID and checks if it's running.
 // This function works on Windows.
 func FindProcess(pid int) (bool, error) {
+	if pid <= 0 {
+		return false, fmt.Errorf("invalid PID: %d", pid)
+	}
+
 	// On Windows, we need to use Windows API to check if a process is running
 
 	// Open the process with PROCESS_QUERY_INFORMATION access right

--- a/pkg/process/kill_unix.go
+++ b/pkg/process/kill_unix.go
@@ -13,6 +13,10 @@ import (
 
 // KillProcess kills a process by its ID
 func KillProcess(pid int) error {
+	if pid <= 0 {
+		return fmt.Errorf("invalid PID: %d", pid)
+	}
+
 	// Check if the process exists
 	process, err := os.FindProcess(pid)
 	if err != nil {

--- a/pkg/process/kill_windows.go
+++ b/pkg/process/kill_windows.go
@@ -12,6 +12,10 @@ import (
 
 // KillProcess kills a process by its ID on Windows
 func KillProcess(pid int) error {
+	if pid <= 0 {
+		return fmt.Errorf("invalid PID: %d", pid)
+	}
+
 	// Check if the process exists
 	process, err := os.FindProcess(pid)
 	if err != nil {

--- a/pkg/process/pid_validation_test.go
+++ b/pkg/process/pid_validation_test.go
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package process
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKillProcess_InvalidPID(t *testing.T) {
+	t.Parallel()
+
+	for _, pid := range []int{0, -1, -100} {
+		t.Run(fmt.Sprintf("pid_%d", pid), func(t *testing.T) {
+			t.Parallel()
+			err := KillProcess(pid)
+			require.Error(t, err, "KillProcess(%d) should return an error", pid)
+			assert.Contains(t, err.Error(), "invalid PID")
+		})
+	}
+}
+
+func TestFindProcess_InvalidPID(t *testing.T) {
+	t.Parallel()
+
+	for _, pid := range []int{0, -1, -100} {
+		t.Run(fmt.Sprintf("pid_%d", pid), func(t *testing.T) {
+			t.Parallel()
+			alive, err := FindProcess(pid)
+			require.Error(t, err, "FindProcess(%d) should return an error", pid)
+			assert.False(t, alive, "FindProcess(%d) should return false", pid)
+			assert.Contains(t, err.Error(), "invalid PID")
+		})
+	}
+}
+
+func TestWaitForExit_InvalidPID(t *testing.T) {
+	t.Parallel()
+
+	for _, pid := range []int{0, -1, -100} {
+		t.Run(fmt.Sprintf("pid_%d", pid), func(t *testing.T) {
+			t.Parallel()
+			err := WaitForExit(context.Background(), pid)
+			require.Error(t, err, "WaitForExit(%d) should return an error", pid)
+			assert.Contains(t, err.Error(), "invalid PID")
+		})
+	}
+}

--- a/pkg/process/wait.go
+++ b/pkg/process/wait.go
@@ -5,6 +5,7 @@ package process
 
 import (
 	"context"
+	"fmt"
 	"time"
 )
 
@@ -14,6 +15,10 @@ import (
 // impose a deadline.
 // Returns nil when the process has exited, or an error on context cancellation.
 func WaitForExit(ctx context.Context, pid int) error {
+	if pid <= 0 {
+		return fmt.Errorf("invalid PID: %d", pid)
+	}
+
 	ticker := time.NewTicker(50 * time.Millisecond)
 	defer ticker.Stop()
 


### PR DESCRIPTION
## Summary

- PID 0 or negative PIDs in status files can reach `KillProcess`, `FindProcess`, and `WaitForExit`, causing process group signals or false-positive liveness checks. See #4400 for root cause details.
- Add `pid <= 0` guards that return a clear error. All existing callers already handle errors gracefully, so no caller changes are needed.

Fixes #4400

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)
- [x] Manual testing: built test binary, verified `thv run` + `thv rm` work normally with the guards in place

## Changes

| File | Change |
|------|--------|
| `pkg/process/kill_unix.go` | `pid <= 0` early return |
| `pkg/process/kill_windows.go` | Same guard |
| `pkg/process/find_unix.go` | `pid <= 0` early return |
| `pkg/process/find_windows.go` | Same guard |
| `pkg/process/wait.go` | `pid <= 0` early return |
| `pkg/process/pid_validation_test.go` | New: tests for PIDs 0, -1, -100 |

## Does this introduce a user-facing change?

No.

Generated with [Claude Code](https://claude.com/claude-code)