### PR TITLE
Persist per-backend session IDs to transport metadata on session creation

### DIFF
--- a/pkg/vmcp/session/factory.go
+++ b/pkg/vmcp/session/factory.go
@@ -36,6 +36,11 @@ const (
 	// a comma-separated, sorted list of successfully-connected backend IDs.
 	// The key is omitted entirely when no backends connected.
 	MetadataKeyBackendIDs = "vmcp.backend.ids"
+
+	// MetadataKeyBackendSessionPrefix is the key prefix for per-backend session IDs.
+	// Full key: MetadataKeyBackendSessionPrefix + workloadID → backend_session_id.
+	// Used by RestoreSession to reconnect backends with the correct session hint.
+	MetadataKeyBackendSessionPrefix = "vmcp.backend.session."
 )
 
 var (
@@ -349,13 +354,22 @@ func validateSessionID(id string) error {
 	return nil
 }
 
-// populateBackendMetadata adds backend IDs to session metadata.
-// IDs are extracted from the already-sorted results slice to avoid a second sort.
+// populateBackendMetadata writes backend metadata to the transport session.
+// It writes MetadataKeyBackendIDs (comma-separated, sorted workload IDs) and,
+// for each backend that reports a non-empty session ID,
+// MetadataKeyBackendSessionPrefix+workloadID. Backends with an empty session ID
+// (e.g. SSE transports) are included in MetadataKeyBackendIDs but have no
+// per-session-ID key, so downstream restore logic can treat key presence as a
+// usable hint. IDs are extracted from the already-sorted results slice to avoid
+// a second sort.
 func populateBackendMetadata(transportSess transportsession.Session, results []initResult) {
 	if len(results) > 0 {
 		ids := make([]string, len(results))
 		for i, r := range results {
 			ids[i] = r.target.WorkloadID
+			if sessID := r.conn.SessionID(); sessID != "" {
+				transportSess.SetMetadata(MetadataKeyBackendSessionPrefix+r.target.WorkloadID, sessID)
+			}
 		}
 		transportSess.SetMetadata(MetadataKeyBackendIDs, strings.Join(ids, ","))
 	}

--- a/pkg/vmcp/session/factory_metadata_test.go
+++ b/pkg/vmcp/session/factory_metadata_test.go
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package session
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stacklok/toolhive/pkg/auth"
+	"github.com/stacklok/toolhive/pkg/vmcp"
+	internalbk "github.com/stacklok/toolhive/pkg/vmcp/session/internal/backend"
+)
+
+func TestMakeSession_PersistsBackendSessionIDs(t *testing.T) {
+	t.Parallel()
+
+	t.Run("two backends: both session IDs written to metadata", func(t *testing.T) {
+		t.Parallel()
+
+		connector := func(_ context.Context, target *vmcp.BackendTarget, _ *auth.Identity) (internalbk.Session, *vmcp.CapabilityList, error) {
+			ids := map[string]string{
+				"backend-a": "sess-a",
+				"backend-b": "sess-b",
+			}
+			sessID, ok := ids[target.WorkloadID]
+			if !ok {
+				return nil, nil, nil
+			}
+			return &mockConnectedBackend{sessID: sessID}, &vmcp.CapabilityList{}, nil
+		}
+
+		factory := newSessionFactoryWithConnector(connector)
+		backends := []*vmcp.Backend{
+			{ID: "backend-a"},
+			{ID: "backend-b"},
+		}
+		sess, err := factory.MakeSessionWithID(t.Context(), uuid.New().String(), nil, true, backends)
+		require.NoError(t, err)
+
+		meta := sess.GetMetadata()
+		assert.Equal(t, "sess-a", meta[MetadataKeyBackendSessionPrefix+"backend-a"])
+		assert.Equal(t, "sess-b", meta[MetadataKeyBackendSessionPrefix+"backend-b"])
+		// MetadataKeyBackendIDs must still be written correctly.
+		ids := strings.Split(meta[MetadataKeyBackendIDs], ",")
+		assert.ElementsMatch(t, []string{"backend-a", "backend-b"}, ids)
+	})
+
+	t.Run("zero backends: no backend session keys written", func(t *testing.T) {
+		t.Parallel()
+
+		factory := newSessionFactoryWithConnector(nilBackendConnector())
+		sess, err := factory.MakeSessionWithID(t.Context(), uuid.New().String(), nil, true, nil)
+		require.NoError(t, err)
+
+		meta := sess.GetMetadata()
+		for k := range meta {
+			assert.False(t, strings.HasPrefix(k, MetadataKeyBackendSessionPrefix),
+				"no backend session keys expected when no backends connected, got %q", k)
+		}
+		_, present := meta[MetadataKeyBackendIDs]
+		assert.False(t, present, "MetadataKeyBackendIDs must be absent when no backends connected")
+	})
+
+	t.Run("partial failure: only successful backend written", func(t *testing.T) {
+		t.Parallel()
+
+		connector := func(_ context.Context, target *vmcp.BackendTarget, _ *auth.Identity) (internalbk.Session, *vmcp.CapabilityList, error) {
+			if target.WorkloadID == "backend-ok" {
+				return &mockConnectedBackend{sessID: "sess-ok"}, &vmcp.CapabilityList{}, nil
+			}
+			// backend-fail returns nil — skipped during init.
+			return nil, nil, nil
+		}
+
+		factory := newSessionFactoryWithConnector(connector)
+		backends := []*vmcp.Backend{
+			{ID: "backend-ok"},
+			{ID: "backend-fail"},
+		}
+		sess, err := factory.MakeSessionWithID(t.Context(), uuid.New().String(), nil, true, backends)
+		require.NoError(t, err)
+
+		meta := sess.GetMetadata()
+		assert.Equal(t, "sess-ok", meta[MetadataKeyBackendSessionPrefix+"backend-ok"])
+		_, present := meta[MetadataKeyBackendSessionPrefix+"backend-fail"]
+		assert.False(t, present, "failed backend must not have a session ID key")
+	})
+
+	t.Run("MetadataKeyBackendSessionPrefix constant value", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, "vmcp.backend.session.", MetadataKeyBackendSessionPrefix)
+	})
+}


### PR DESCRIPTION
## Summary

<!--
REQUIRED. You MUST explain:
1. WHY this change is needed (the problem or motivation)
2. WHAT changed (concise bullet points)

The diff shows the code — your summary must provide the context a reviewer
needs to understand the purpose without reading the diff first.
-->

Add MetadataKeyBackendSessionPrefix ("vmcp.backend.session.") constant and extend populateBackendMetadata to write vmcp.backend.session.{workloadID} → backend_session_id for each successfully connected backend alongside the existing MetadataKeyBackendIDs entry.

This closes the gap identified in RC-8 (stacklok/toolhive#4211): per-backend session IDs were collected at makeSession time but never written to the serializable transport-session metadata, so they were lost after pod restart. With this change, the IDs flow through to Redis and are available for future cross-pod session reconstruction.

<!--
Link related issues. Use "Closes" or "Fixes" to auto-close on merge.
Remove this line if there is no related issue.
-->

Fixes #4211 

## Type of change

<!-- REQUIRED. Check exactly one. -->

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

<!--
REQUIRED. Check every verification step you actually ran.
You MUST check at least one item. If you only did manual testing,
describe exactly what you tested below the checkbox.
-->

- [x] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [x] Linting (`task lint-fix`)
- [ ] Manual testing (describe below)

## Changes

<!--
Optional — include for PRs touching more than a few files to help
reviewers navigate the diff. Remove this entire section for small PRs.
-->

| File | Change |
|------|--------|
|      |        |

## Does this introduce a user-facing change?

<!--
If yes, describe the change from the user's perspective. This helps with release notes.
If no, write "No".
Remove this section entirely if not applicable.
-->

## Special notes for reviewers

<!--
Optional — call out anything non-obvious: tricky logic, known limitations,
areas where you'd like extra scrutiny, or follow-up work planned.
Remove this section if not needed.
-->
