### PR TITLE
Support RFC 8414 path-based issuer discovery URLs

### DIFF
--- a/pkg/authserver/runner/embeddedauthserver.go
+++ b/pkg/authserver/runner/embeddedauthserver.go
@@ -148,15 +148,21 @@ func (e *EmbeddedAuthServer) UpstreamTokenRefresher() storage.UpstreamTokenRefre
 // the vMCP server owns /.well-known/oauth-protected-resource (RFC 9728) on the same
 // mux. Adding a new AS /.well-known/ endpoint therefore requires an explicit entry here.
 //
+// Discovery paths are registered with both exact and trailing-slash (prefix) patterns.
+// The trailing-slash variants support RFC 8414 Section 3.1 path-based issuers, where
+// the client constructs /.well-known/oauth-authorization-server/{issuer-path}.
+//
 // The /oauth/ subtree is registered as a prefix, so new /oauth/* endpoints added to
 // the chi router are picked up automatically without changes to this method.
 func (e *EmbeddedAuthServer) Routes() map[string]http.Handler {
 	handler := e.Handler()
 	return map[string]http.Handler{
-		"/.well-known/openid-configuration":       handler,
-		"/.well-known/oauth-authorization-server": handler,
-		"/.well-known/jwks.json":                  handler,
-		"/oauth/":                                 handler,
+		"/.well-known/openid-configuration":        handler,
+		"/.well-known/openid-configuration/":       handler,
+		"/.well-known/oauth-authorization-server":  handler,
+		"/.well-known/oauth-authorization-server/": handler,
+		"/.well-known/jwks.json":                   handler,
+		"/oauth/":                                  handler,
 	}
 }
 

--- a/pkg/authserver/runner/embeddedauthserver_test.go
+++ b/pkg/authserver/runner/embeddedauthserver_test.go
@@ -1118,7 +1118,9 @@ func TestRoutes(t *testing.T) {
 
 	expectedKeys := []string{
 		"/.well-known/openid-configuration",
+		"/.well-known/openid-configuration/",
 		"/.well-known/oauth-authorization-server",
+		"/.well-known/oauth-authorization-server/",
 		"/.well-known/jwks.json",
 		"/oauth/",
 	}

--- a/pkg/authserver/server/handlers/handler.go
+++ b/pkg/authserver/server/handlers/handler.go
@@ -95,10 +95,17 @@ func (h *Handler) OAuthRoutes(r chi.Router) {
 // at least one discovery mechanism, with both supported for maximum interoperability:
 // - /.well-known/oauth-authorization-server (RFC 8414) for OAuth-only clients
 // - /.well-known/openid-configuration (OIDC Discovery 1.0) for OIDC clients
+//
+// The wildcard variants (/.well-known/oauth-authorization-server/*) handle RFC 8414
+// Section 3.1 path-based issuers, where clients insert /.well-known/ before the
+// issuer's path component (e.g., /.well-known/oauth-authorization-server/inject-test
+// for issuer https://example.com/inject-test).
 func (h *Handler) WellKnownRoutes(r chi.Router) {
 	r.Get("/.well-known/jwks.json", h.JWKSHandler)
 	r.Get("/.well-known/oauth-authorization-server", h.OAuthDiscoveryHandler)
+	r.Get("/.well-known/oauth-authorization-server/*", h.OAuthDiscoveryHandler)
 	r.Get("/.well-known/openid-configuration", h.OIDCDiscoveryHandler)
+	r.Get("/.well-known/openid-configuration/*", h.OIDCDiscoveryHandler)
 }
 
 // nextMissingUpstream returns the name of the next upstream provider in the


### PR DESCRIPTION
## Summary

- PR #4348 replaced the `/.well-known/` catch-all mux pattern with explicit
  exact registrations to prevent the auth server from intercepting
  `/.well-known/oauth-protected-resource` (owned by the vMCP server). This
  inadvertently broke RFC 8414 Section 3.1 discovery for path-based issuers:
  clients construct `/.well-known/oauth-authorization-server/{issuer-path}`
  but the exact pattern only matched `/.well-known/oauth-authorization-server`.
- Register trailing-slash prefix variants on both the `http.ServeMux`
  (`Routes()`) and chi router (`WellKnownRoutes`) so subpaths are routed to
  the discovery handlers.

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test`)
- [x] Manual testing (describe below)

Verified end-to-end with a VirtualMCPServer deployed to a kind cluster
behind ngrok with a path-based issuer (`https://toolhive.ngrok.app/inject-test`).
Claude Code successfully discovered the auth server via
`/.well-known/oauth-authorization-server/inject-test`, completed the
multi-upstream OAuth flow (Okta + GitHub + Google), and called tools.

## Changes

| File | Change |
|------|--------|
| `pkg/authserver/runner/embeddedauthserver.go` | Add trailing-slash prefix entries to `Routes()` for discovery paths |
| `pkg/authserver/server/handlers/handler.go` | Add wildcard chi routes for discovery handlers |
| `pkg/authserver/runner/embeddedauthserver_test.go` | Update `TestRoutes` expected count (4 → 6) |

## Special notes for reviewers

The regression was introduced in #4348 which correctly avoided a `/.well-known/`
catch-all but did not account for RFC 8414 Section 3.1 where clients insert
`/.well-known/oauth-authorization-server` *before* the issuer's path component.
This only manifests when the issuer has a path (e.g., multi-tenant deployments
behind a shared domain). Issuers at the domain root are unaffected.

Generated with [Claude Code](https://claude.com/claude-code)