### PR TITLE
Improve code-review-assist skill for clearer reviews

### DIFF
--- a/.claude/skills/code-review-assist/SKILL.md
+++ b/.claude/skills/code-review-assist/SKILL.md
@@ -17,16 +17,19 @@ The `code-reviewer` agent runs autonomously and checks for best practices, secur
 
 When invoked without a specific PR, start by scoping the session:
 
-1. **Discover PRs**: Use GitHub to find (a) open PRs requesting the user's review, (b) PRs merged since their last review session that they haven't reviewed yet, and (c) open PRs the user has previously reviewed that have new pushes or comments since their last review (contributors may push updates without re-requesting review).
-2. **Present the list**: Show each PR with title, author, and a risk estimate (high/medium/low based on files changed, area of codebase, and change size).
-3. **Ask the user**:
+1. **Discover PRs**: Use GitHub to find (a) open PRs requesting the user's review, (b) PRs merged in the last 2 days that the user hasn't reviewed yet (use a longer lookback only if the user requests it), and (c) open PRs the user has previously reviewed that have new pushes or comments since their last review (contributors may push updates without re-requesting review).
+2. **Load only metadata**: Fetch PR title, author, description, and files-changed count. Do **not** load diffs during session planning — you only need high-level information to help the user prioritize.
+3. **Present the list**: Show each PR with title, author, and a risk estimate (high/medium/low based on files changed, area of codebase, and change size). Also note any existing review activity — approved reviews, changes-requested, pending reviews from others, or review comments — so the user knows what's already been covered. If any PRs form a stack (one PR's base branch is another PR in the list), group them and note the dependency chain and what each PR in the stack is responsible for.
+4. **Ask the user**:
    - Which PRs to include — all open, all merged, or a subset?
    - Preferred review order — chronological, highest-risk-first, or by author/area?
-4. **Track coverage**: At the end of the session, report which PRs were reviewed, skipped, or deferred so nothing falls through the cracks.
+5. **Track coverage**: At the end of the session, report which PRs were reviewed, skipped, or deferred so nothing falls through the cracks.
 
 If a specific PR is provided as an argument, skip session planning and go directly to the review.
 
 ## Instructions
+
+Present PRs **one at a time**. Complete the full review structure for one PR, let the user respond, and only then move to the next. Do not batch multiple PR reviews into a single response.
 
 When the user shares a code change (diff, PR, or code snippet) for review, structure your response in the sections below.
 
@@ -34,9 +37,38 @@ When the user shares a code change (diff, PR, or code snippet) for review, struc
 
 In 2-4 sentences, explain what this change does and why it appears to exist. State the apparent intent plainly. If the intent is unclear, say so — that's a review finding in itself.
 
-### 2. Key Review Questions
+### 2. Background
 
-Surface the 2-5 most important questions the reviewer should be asking about this change. Focus on:
+Before diving into the diff, establish context so the reviewer can understand what's being changed. Read the original files in the repository (not just the diff) and describe the existing design in terms of **owners** and **responsibilities**:
+
+- **Owners** are the key types, interfaces, and functions involved in the change. Bold each owner when introducing it (e.g., **`ProxyHandler`**, **`ToolRegistry`**, **`Reconciler`**).
+- **Responsibilities** are named, bolded behaviors that owners are accountable for (e.g., **request routing**, **connection lifecycle management**, **tool discovery**). Give each responsibility a clear name so it can be referenced throughout the review.
+- When fine-grained responsibilities work together to fulfill a larger responsibility, say so explicitly (e.g., "**`Reconciler`** is responsible for **state synchronization**, which combines **drift detection** on the current spec with **desired-state application** to bring the cluster in line").
+- When a responsibility isn't clearly owned by a single type — e.g., it's spread across multiple functions, or lives in package-level code without a clear home — call that out. Unclear ownership is useful context for evaluating whether the PR improves or worsens the situation.
+
+Present this as a structured list of owner → responsibility mappings so the reviewer can quickly see who does what today. Only cover the owners relevant to the change — don't map the entire subsystem.
+
+### 3. Important Changes
+
+Describe how the change modifies the ownership and responsibility map established in Background. Use the same **bolded owner and responsibility names** to make the link explicit. For each significant change, categorize it:
+
+- **New owners**: New types, interfaces, or functions introduced by this change and what responsibilities they take on.
+- **New responsibilities**: Existing owners that gain new named behavior they didn't have before.
+- **Shifted responsibilities**: A named responsibility that moved from one owner to another — state clearly where it lived before and where it lives now.
+- **Modified responsibilities**: An existing named responsibility on an existing owner that now works differently — describe the behavioral delta.
+
+Only include categories that apply. Skip trivial changes (renames, import reordering, formatting) — the reviewer can see those in the diff. Order by importance, not by file.
+
+### 4. Key Concerns
+
+Surface the 2-5 most important concerns about this change. Each concern MUST be prefixed with a [conventional comment](https://conventionalcomments.org/) severity label:
+
+- **`blocker:`** — Must be resolved before merge. Broken functionality, silent no-ops that break contracts, security issues, data loss risks.
+- **`suggestion:`** — Non-blocking recommendation. Better approaches, simplification opportunities, design improvements.
+- **`nitpick:`** — Trivial, take-it-or-leave-it. Naming, minor style, const extraction.
+- **`question:`** — Seeking clarification, not requesting a change.
+
+When evaluating concerns, focus on:
 
 - **Justification**: Is the problem this solves clear? Is this the right time/place to solve it?
 - **Approach fit**: Could this be solved more simply? Are there obvious alternative approaches with better tradeoffs? If so, briefly sketch them.
@@ -51,7 +83,7 @@ Surface the 2-5 most important questions the reviewer should be asking about thi
 - **Necessity**: Is this the simplest approach that solves the problem? If the change introduces new interfaces, modifies stable interfaces, adds caches, or creates new abstraction layers — challenge it. A stable interface being modified to accommodate one implementation is a sign that concerns are leaking across boundaries. Ask: can this be solved internally to the component that needs it? Is there evidence (profiling, incidents) justifying the added complexity, or should we start simpler?
 - **Premature optimization**: Does the change add caches, pools, or other performance machinery without evidence the unoptimized path is a problem? Optimizations add maintenance cost (invalidation, staleness, lifecycle management) regardless of whether they provide measurable benefit. Ask: has the straightforward approach been measured under realistic load?
 
-### 3. Testing Assessment
+### 5. Testing Assessment
 
 Evaluate whether the change is well-tested relative to its risk:
 
@@ -61,17 +93,17 @@ Evaluate whether the change is well-tested relative to its risk:
 - If tests are missing or weak, say specifically what should be tested.
 - For validation or branching logic, enumerate the full input matrix (type × field combinations, flag × state permutations) and verify each cell is covered. Don't eyeball — be systematic.
 
-### 4. vMCP Anti-Pattern Check
+### 6. vMCP Anti-Pattern Check
 
-If the change touches files under `pkg/vmcp/` or `cmd/vmcp/`, also run the `vmcp-review` skill against those files. Don't reproduce the full vmcp-review report — instead, summarize the most important findings (must-fix and should-fix severity) inline with your Key Review Questions. Link back to the specific anti-pattern by number (e.g., "see vMCP anti-pattern #8") so the reviewer can dig deeper if needed.
+If the change touches files under `pkg/vmcp/` or `cmd/vmcp/`, also run the `vmcp-review` skill against those files. Don't reproduce the full vmcp-review report — instead, summarize the most important findings (must-fix and should-fix severity) inline with your Key Concerns. Link back to the specific anti-pattern by number (e.g., "see vMCP anti-pattern #8") so the reviewer can dig deeper if needed.
 
-### 5. Things That Look Fine
-
-Briefly note which parts of the change appear straightforward and low-risk so the reviewer can skim those confidently.
-
-### 6. Reading Order (large changes only)
+### 7. Reading Order (large changes only)
 
 If the change is large, suggest a reading order — which files/sections to review carefully vs. skim.
+
+### 8. Recommendation
+
+End with one of: **Approve**, **Request Changes**, or **Skip** (e.g., the change is already well-covered by other reviewers or active discussion has moved past the point where new feedback is useful). Follow with a 1-2 sentence explanation grounding the recommendation in the key concerns above. This is a suggestion to the reviewer, not a final verdict.
 
 ## Review Session Tracking
 


### PR DESCRIPTION
## Summary

The review output from the code-review-assist skill was overwhelming — it jumped straight into detailed questions without establishing context, making it hard for reviewers to orient themselves before evaluating concerns. These changes restructure the skill so reviewers build a mental model of the code *before* seeing concerns, and every concern communicates its severity clearly.

## Type of change

- [x] Enhancement to an existing feature

## Changes

| File | Change |
|------|--------|
| `.claude/skills/code-review-assist/SKILL.md` | Restructured session planning and review output format |

### Session planning
- Only load PR metadata (not diffs) during planning for speed
- Default merged-PR lookback to 2 days instead of unbounded
- Surface existing review activity (approvals, pending reviews, comments)
- Identify and group stacked PRs with their dependency chains
- Present PRs one at a time during review sessions

### Review structure
- **New: Background section** — reads original files and maps **owners** (types, interfaces, functions) to named **responsibilities** (behavioral contracts), establishing terminology for the rest of the review
- **New: Important Changes section** — frames the diff as a conceptual delta on the ownership/responsibility map (new owners, new responsibilities, shifted responsibilities, modified responsibilities)
- **Renamed: Key Concerns** (was "Key Review Questions") — each concern now uses conventional comment severity labels (`blocker:`, `suggestion:`, `question:`, `nitpick:`)
- **Replaced: "Things That Look Fine"** with a **Recommendation** (approve, request changes, or skip) grounded in the key concerns

## Test plan

- [ ] Invoke `/code-review-assist` without arguments and verify session planning loads only metadata
- [ ] Invoke `/code-review-assist <PR>` and verify the Background section establishes owners/responsibilities before diving into changes
- [ ] Verify Key Concerns use conventional comment severity labels
- [ ] Verify review ends with a Recommendation

## Does this introduce a user-facing change?

Review sessions now provide a structured conceptual ramp (summary → background → changes → concerns → recommendation) instead of jumping directly into detailed questions, making it easier to understand PRs before evaluating them.

Generated with [Claude Code](https://claude.com/claude-code)