### PR TITLE
Preserve scopes in token refresh request

### DIFF
--- a/pkg/auth/oauth/resource_token_source.go
+++ b/pkg/auth/oauth/resource_token_source.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"strings"
 	"time"
 
 	"golang.org/x/oauth2"
@@ -74,6 +75,12 @@ func (r *resourceTokenSource) refreshWithResource(ctx context.Context) (*oauth2.
 		oauth2.SetAuthURLParam("grant_type", "refresh_token"),
 		oauth2.SetAuthURLParam("refresh_token", refreshToken),
 		oauth2.SetAuthURLParam("resource", r.resource),
+	}
+
+	// Include scope in refresh request. RFC 6749 section 6 says servers MUST
+	// preserve scopes when omitted, but not all do. Being explicit is safe.
+	if len(r.config.Scopes) > 0 {
+		opts = append(opts, oauth2.SetAuthURLParam("scope", strings.Join(r.config.Scopes, " ")))
 	}
 
 	ctx = context.WithValue(ctx, oauth2.HTTPClient, r.httpClient)

--- a/pkg/auth/oauth/resource_token_source_test.go
+++ b/pkg/auth/oauth/resource_token_source_test.go
@@ -567,3 +567,69 @@ func TestResourceTokenSource_RFC8707Compliance(t *testing.T) {
 		}
 	})
 }
+
+func TestResourceTokenSource_ScopeInRefresh(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name          string
+		scopes        []string
+		expectedScope string
+	}{
+		{"multiple scopes", []string{"read", "write", "admin"}, "read write admin"},
+		{"single scope", []string{"openid"}, "openid"},
+		{"no scopes", nil, ""},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var capturedForm url.Values
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				err := r.ParseForm()
+				require.NoError(t, err)
+				capturedForm = r.Form
+
+				response := map[string]interface{}{
+					"access_token":  "new-token",
+					"refresh_token": "new-refresh",
+					"token_type":    "Bearer",
+					"expires_in":    3600,
+				}
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(response)
+			}))
+			defer server.Close()
+
+			config := &oauth2.Config{
+				ClientID: "test-client",
+				Scopes:   tc.scopes,
+				Endpoint: oauth2.Endpoint{
+					TokenURL: server.URL,
+				},
+			}
+
+			expiredToken := &oauth2.Token{
+				AccessToken:  "old",
+				RefreshToken: "refresh",
+				Expiry:       time.Now().Add(-1 * time.Hour),
+			}
+
+			ts := NewResourceTokenSource(config, expiredToken, "https://api.example.com")
+			_, err := ts.Token()
+			require.NoError(t, err)
+
+			require.NotNil(t, capturedForm)
+			if tc.expectedScope == "" {
+				assert.Empty(t, capturedForm.Get("scope"),
+					"scope parameter must not be present when config.Scopes is empty")
+			} else {
+				assert.Equal(t, tc.expectedScope, capturedForm.Get("scope"),
+					"scope parameter must match space-separated config.Scopes")
+			}
+			assert.Equal(t, "refresh_token", capturedForm.Get("grant_type"))
+			assert.Equal(t, "https://api.example.com", capturedForm.Get("resource"))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- OAuth servers that don't comply with RFC 6749 section 6 silently strip scopes during token refresh, breaking all scoped tool calls until manual re-auth
- Include the `scope` parameter in `refreshWithResource()` when `config.Scopes` is non-empty, matching the existing defensive approach for the RFC 8707 `resource` parameter

Fixes #4427

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)

## Does this introduce a user-facing change?

Users connecting to OAuth servers that don't preserve scopes during token refresh will no longer silently lose scopes. Previously, scoped tool calls would fail after token expiry until manual re-auth.

## Special notes for reviewers

`resourceTokenSource` already exists because Go's standard `oauth2` library doesn't support adding custom parameters during refresh. This change extends that philosophy to `scope`: while RFC 6749 section 6 says servers MUST preserve scopes when omitted, being explicit is always spec-safe and protects against non-compliant servers.

Generated with [Claude Code](https://claude.com/claude-code)