### PR TITLE
Default to :latest tag for OCI skill install references

### DIFF
--- a/pkg/skills/skillsvc/skillsvc.go
+++ b/pkg/skills/skillsvc/skillsvc.go
@@ -509,6 +509,22 @@ const ociPullTimeout = 5 * time.Minute
 // malicious artifact from causing OOM before the decompression limits kick in.
 const maxCompressedLayerSize int64 = 50 * 1024 * 1024 // 50 MB
 
+// qualifiedOCIRef returns the full OCI reference string including the tag or
+// digest. When the user omits a tag (e.g. "ghcr.io/org/skill"),
+// go-containerregistry's ParseReference defaults to "latest" internally but
+// String() omits it. This function only appends the implicit tag when the
+// original string does not already include one.
+func qualifiedOCIRef(ref nameref.Reference) string {
+	s := ref.String()
+	if _, ok := ref.(nameref.Digest); ok {
+		return s // already has @sha256:...
+	}
+	if strings.Contains(s, ":") {
+		return s // already has an explicit tag
+	}
+	return s + ":" + ref.Identifier()
+}
+
 func parseOCIReference(name string) (nameref.Reference, bool, error) {
 	// Structural check: skill names never contain '/', ':', or '@'.
 	// OCI references always require at least one of these.
@@ -544,7 +560,7 @@ func (s *service) installFromOCI(
 		)
 	}
 
-	ociRef := opts.Name
+	ociRef := qualifiedOCIRef(ref)
 
 	pullCtx, cancel := context.WithTimeout(ctx, ociPullTimeout)
 	defer cancel()
@@ -553,7 +569,7 @@ func (s *service) installFromOCI(
 	if err != nil {
 		return nil, httperr.WithCode(
 			fmt.Errorf("pulling OCI artifact %q: %w", ociRef, err),
-			http.StatusBadGateway,
+			http.StatusBadRequest,
 		)
 	}
 

--- a/pkg/skills/skillsvc/skillsvc_test.go
+++ b/pkg/skills/skillsvc/skillsvc_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 	"time"
 
+	nameref "github.com/google/go-containerregistry/pkg/name"
 	godigest "github.com/opencontainers/go-digest"
 	specs "github.com/opencontainers/image-spec/specs-go"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -2706,6 +2707,41 @@ func TestBuildGitReferenceFromRegistryURL(t *testing.T) {
 			}
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestQualifiedOCIRef(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "explicit tag unchanged",
+			input: "ghcr.io/org/my-skill:v1",
+			want:  "ghcr.io/org/my-skill:v1",
+		},
+		{
+			name:  "no tag defaults to latest",
+			input: "ghcr.io/stacklok/toolhive/skills/toolhive-cli-user",
+			want:  "ghcr.io/stacklok/toolhive/skills/toolhive-cli-user:latest",
+		},
+		{
+			name:  "digest unchanged",
+			input: "ghcr.io/org/my-skill@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+			want:  "ghcr.io/org/my-skill@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ref, err := nameref.ParseReference(tt.input)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, qualifiedOCIRef(ref))
 		})
 	}
 }


### PR DESCRIPTION
## Summary

- Running `thv skill install ghcr.io/org/skill` (without a tag) produced a confusing `Error: failed to install skill: Bad Gateway` because the raw user input was passed to oras-go which requires an explicit tag or digest, while go-containerregistry had already defaulted to `latest` internally but that parsed reference was ignored.
- Build the qualified OCI reference from the parsed `nameref.Reference`, appending `:latest` only when the user omitted a tag. Explicit tags and digests pass through unchanged.
- Change the OCI pull error status from 502 (Bad Gateway) to 400 (Bad Request) since a pull failure due to a bad reference is a client input error, not an upstream gateway failure.

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)

## Does this introduce a user-facing change?

`thv skill install ghcr.io/org/skill` now defaults to the `:latest` tag instead of failing with "Bad Gateway". When OCI pull errors do occur, the error message is now surfaced to the user instead of being hidden behind a generic status text.

Generated with [Claude Code](https://claude.com/claude-code)