### PR TITLE
fix(mcp): disable interactive OAuth in embedded MCP server handler

### DIFF
--- a/pkg/mcp/server/handler.go
+++ b/pkg/mcp/server/handler.go
@@ -29,8 +29,12 @@ func NewHandler(ctx context.Context) (*Handler, error) {
 		return nil, fmt.Errorf("failed to create workload manager: %w", err)
 	}
 
-	// Create registry provider
-	registryProvider, err := registry.GetDefaultProvider()
+	// This handler runs inside `thv serve` — disable browser-based OAuth to
+	// prevent the singleton registry provider from using interactive mode.
+	registryProvider, err := registry.GetDefaultProviderWithConfig(
+		config.NewDefaultProvider(),
+		registry.WithInteractive(false),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get registry provider: %w", err)
 	}


### PR DESCRIPTION
## Summary

When `thv serve` starts with `--experimental-mcp` (always enabled by ToolHive Studio), the MCP server handler was the first code path to create the shared singleton `registry.Provider` via `registry.GetDefaultProvider()`. Because `NewRegistryProvider` defaults to `interactive: true` and the provider is guarded by `sync.Once`, this "poisoned" the singleton — all subsequent callers (including the HTTP API routes that explicitly pass `WithInteractive(false)`) inherited interactive mode.

**The result**: every time the desktop app restarted with invalid registry credentials (e.g. wrong `client_id`), the browser opened automatically for an OAuth flow that would always fail.

- Pass `registry.WithInteractive(false)` explicitly in the MCP handler, aligning it with how all other `thv serve` code paths create the provider.

## Type of change

- [x] Bug fix

## Test plan

- [x] Manual testing (describe below)

Tested with ToolHive Studio connected to a `thv serve` instance with a misconfigured registry (`client_id` wrong). Before the fix, restarting the app opened the browser for OAuth. After the fix, the app correctly shows a registry configuration error without opening the browser.

## Changes

| File | Change |
|------|--------|
| `pkg/mcp/server/handler.go` | Use `GetDefaultProviderWithConfig` with `WithInteractive(false)` instead of `GetDefaultProvider()` |

## Does this introduce a user-facing change?

Yes — when `thv serve` is started with `--experimental-mcp` and the registry has invalid OAuth credentials, the browser no longer opens automatically for an OAuth flow that cannot succeed. Instead, the error is returned to the caller (API or MCP client) for proper handling.

## Special notes for reviewers

The root cause is that `registry.Provider` is a `sync.Once` singleton. Whichever caller creates it first sets `interactive` for all subsequent users. In `thv serve`, the MCP handler goroutine consistently wins the race against `lazySkillLookup` and the API routes. This fix ensures the MCP handler creates the singleton with `interactive: false`, which is the correct behavior for all server-side code paths.

The `POST /auth/login` endpoint is unaffected because it creates its own standalone provider (not the singleton) with `WithInteractive(true)` explicitly.

