### PR TITLE
Add DataStorage interface and implementations

### DIFF
--- a/pkg/transport/session/session_data_storage.go
+++ b/pkg/transport/session/session_data_storage.go
@@ -5,6 +5,7 @@ package session
 
 import (
 	"context"
+	"fmt"
 	"time"
 )
 
@@ -12,11 +13,11 @@ import (
 //
 // Unlike the Session-based Storage interface, DataStorage never attempts
 // to round-trip live session objects (MultiSession, StreamableSession, etc.).
-// It stores only serialisable metadata, keeping data storage and live-object
+// It stores only serializable metadata, keeping data storage and live-object
 // lifecycle as separate concerns.
 //
 // This separation avoids the type-assertion bug where a Redis round-trip
-// deserialises a MultiSession as a plain *StreamableSession, losing all
+// deserializes a MultiSession as a plain *StreamableSession, losing all
 // backend connections and routing state.
 //
 // # Contract
@@ -62,12 +63,16 @@ type DataStorage interface {
 }
 
 // NewLocalSessionDataStorage creates a LocalSessionDataStorage with the given TTL.
+// ttl must be positive; a zero or negative value returns an error.
 // A background cleanup goroutine is started and runs until Close is called.
-func NewLocalSessionDataStorage(ttl time.Duration) *LocalSessionDataStorage {
+func NewLocalSessionDataStorage(ttl time.Duration) (*LocalSessionDataStorage, error) {
+	if ttl <= 0 {
+		return nil, fmt.Errorf("ttl must be a positive duration")
+	}
 	s := &LocalSessionDataStorage{
 		ttl:    ttl,
 		stopCh: make(chan struct{}),
 	}
 	go s.cleanupRoutine()
-	return s
+	return s, nil
 }

--- a/pkg/transport/session/session_data_storage_local.go
+++ b/pkg/transport/session/session_data_storage_local.go
@@ -29,7 +29,7 @@ func (e *localDataEntry) lastAccess() time.Time {
 	return time.Unix(0, e.lastAccessNano.Load())
 }
 
-// LocalSessionDataStorage implements SessionDataStorage using an in-memory
+// LocalSessionDataStorage implements DataStorage using an in-memory
 // sync.Map with TTL-based eviction.
 //
 // Sessions are evicted if they have not been accessed within the configured TTL.
@@ -71,12 +71,10 @@ func (s *LocalSessionDataStorage) Load(_ context.Context, id string) (map[string
 		return nil, fmt.Errorf("invalid entry type in local session data storage")
 	}
 
-	// Refresh last-access by swapping in a new entry pointer. This prevents
-	// a concurrent DeleteExpired from evicting a session that is actively in use.
-	newEntry := newLocalDataEntry(entry.metadata)
-	s.sessions.CompareAndSwap(id, entry, newEntry)
-	// If CAS fails, another goroutine already replaced the entry; the map
-	// always holds a fresh pointer, so eviction of this session is safe.
+	// Refresh last-access in place. deleteExpired re-checks the timestamp
+	// immediately before calling CompareAndDelete, so this atomic store is
+	// sufficient to prevent eviction of an actively accessed entry.
+	entry.lastAccessNano.Store(time.Now().UnixNano())
 
 	return maps.Clone(entry.metadata), nil
 }

--- a/pkg/transport/session/session_data_storage_redis.go
+++ b/pkg/transport/session/session_data_storage_redis.go
@@ -13,14 +13,14 @@ import (
 	"github.com/redis/go-redis/v9"
 )
 
-// RedisSessionDataStorage implements SessionDataStorage backed by Redis/Valkey.
+// RedisSessionDataStorage implements DataStorage backed by Redis/Valkey.
 //
-// Metadata is serialised as a JSON object and stored with a sliding-window TTL:
+// Metadata is serialized as a JSON object and stored with a sliding-window TTL:
 // each Load call refreshes the key's expiry via GETEX so that active sessions
 // never expire while they are in use.
 //
 // Because only plain map[string]string is stored, there are no type assertions
-// or deserialisation tricks — Redis round-trips the map cleanly.
+// or deserialization tricks — Redis round-trips the map cleanly.
 type RedisSessionDataStorage struct {
 	client    redis.UniversalClient
 	keyPrefix string
@@ -37,52 +37,10 @@ func NewRedisSessionDataStorage(ctx context.Context, cfg RedisConfig, ttl time.D
 	if ttl <= 0 {
 		return nil, fmt.Errorf("ttl must be a positive duration")
 	}
-	if cfg.DialTimeout == 0 {
-		cfg.DialTimeout = DefaultDialTimeout
-	}
-	if cfg.ReadTimeout == 0 {
-		cfg.ReadTimeout = DefaultReadTimeout
-	}
-	if cfg.WriteTimeout == 0 {
-		cfg.WriteTimeout = DefaultWriteTimeout
-	}
-
-	tlsCfg, err := buildRedisTLSConfig(cfg.TLS)
+	client, err := buildRedisClient(ctx, &cfg)
 	if err != nil {
-		return nil, fmt.Errorf("tls configuration error: %w", err)
+		return nil, err
 	}
-
-	var client redis.UniversalClient
-	if cfg.SentinelConfig != nil {
-		client = redis.NewFailoverClient(&redis.FailoverOptions{
-			MasterName:    cfg.SentinelConfig.MasterName,
-			SentinelAddrs: cfg.SentinelConfig.SentinelAddrs,
-			Username:      cfg.Username,
-			Password:      cfg.Password,
-			DB:            cfg.DB,
-			DialTimeout:   cfg.DialTimeout,
-			ReadTimeout:   cfg.ReadTimeout,
-			WriteTimeout:  cfg.WriteTimeout,
-			TLSConfig:     tlsCfg,
-		})
-	} else {
-		client = redis.NewClient(&redis.Options{
-			Addr:         cfg.Addr,
-			Username:     cfg.Username,
-			Password:     cfg.Password,
-			DB:           cfg.DB,
-			DialTimeout:  cfg.DialTimeout,
-			ReadTimeout:  cfg.ReadTimeout,
-			WriteTimeout: cfg.WriteTimeout,
-			TLSConfig:    tlsCfg,
-		})
-	}
-
-	if err := client.Ping(ctx).Err(); err != nil {
-		_ = client.Close()
-		return nil, fmt.Errorf("failed to connect to redis: %w", err)
-	}
-
 	return &RedisSessionDataStorage{
 		client:    client,
 		keyPrefix: cfg.KeyPrefix,
@@ -94,7 +52,7 @@ func (s *RedisSessionDataStorage) key(id string) string {
 	return s.keyPrefix + id
 }
 
-// Store serialises metadata as JSON and writes it to Redis with a sliding TTL.
+// Store serializes metadata as JSON and writes it to Redis with a sliding TTL.
 func (s *RedisSessionDataStorage) Store(ctx context.Context, id string, metadata map[string]string) error {
 	if id == "" {
 		return fmt.Errorf("cannot store session data with empty ID")
@@ -104,7 +62,7 @@ func (s *RedisSessionDataStorage) Store(ctx context.Context, id string, metadata
 	}
 	data, err := json.Marshal(metadata)
 	if err != nil {
-		return fmt.Errorf("failed to serialise session metadata: %w", err)
+		return fmt.Errorf("failed to serialize session metadata: %w", err)
 	}
 	return s.client.Set(ctx, s.key(id), data, s.ttl).Err()
 }
@@ -124,7 +82,7 @@ func (s *RedisSessionDataStorage) Load(ctx context.Context, id string) (map[stri
 	}
 	var metadata map[string]string
 	if err := json.Unmarshal(data, &metadata); err != nil {
-		return nil, fmt.Errorf("failed to deserialise session metadata: %w", err)
+		return nil, fmt.Errorf("failed to deserialize session metadata: %w", err)
 	}
 	return metadata, nil
 }
@@ -154,7 +112,7 @@ func (s *RedisSessionDataStorage) StoreIfAbsent(ctx context.Context, id string, 
 	}
 	data, err := json.Marshal(metadata)
 	if err != nil {
-		return false, fmt.Errorf("failed to serialise session metadata: %w", err)
+		return false, fmt.Errorf("failed to serialize session metadata: %w", err)
 	}
 	ok, err := s.client.SetNX(ctx, s.key(id), data, s.ttl).Result()
 	if err != nil {
@@ -168,7 +126,10 @@ func (s *RedisSessionDataStorage) Delete(ctx context.Context, id string) error {
 	if id == "" {
 		return fmt.Errorf("cannot delete session data with empty ID")
 	}
-	return s.client.Del(ctx, s.key(id)).Err()
+	if err := s.client.Del(ctx, s.key(id)).Err(); err != nil {
+		return fmt.Errorf("failed to delete session metadata: %w", err)
+	}
+	return nil
 }
 
 // Close closes the underlying Redis client.

--- a/pkg/transport/session/session_data_storage_test.go
+++ b/pkg/transport/session/session_data_storage_test.go
@@ -5,6 +5,7 @@ package session
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -150,6 +151,39 @@ func runDataStorageTests(t *testing.T, newStorage func(t *testing.T) DataStorage
 		assert.Equal(t, "original", loaded["x"], "original value must be preserved")
 	})
 
+	t.Run("StoreIfAbsent is atomic under concurrent callers", func(t *testing.T) {
+		t.Parallel()
+		s := newStorage(t)
+		ctx := context.Background()
+
+		type result struct {
+			stored bool
+			err    error
+		}
+		const goroutines = 20
+		results := make(chan result, goroutines)
+		for i := range goroutines {
+			go func(val string) {
+				stored, err := s.StoreIfAbsent(ctx, "concurrent-key", map[string]string{"winner": val})
+				results <- result{stored: stored, err: err}
+			}(fmt.Sprintf("contender-%d", i))
+		}
+
+		var winCount int
+		for range goroutines {
+			r := <-results
+			require.NoError(t, r.err)
+			if r.stored {
+				winCount++
+			}
+		}
+		assert.Equal(t, 1, winCount, "exactly one goroutine should have stored the entry")
+
+		loaded, err := s.Load(ctx, "concurrent-key")
+		require.NoError(t, err)
+		assert.NotEmpty(t, loaded["winner"], "stored value must be one of the contenders")
+	})
+
 	t.Run("StoreIfAbsent with empty ID returns error", func(t *testing.T) {
 		t.Parallel()
 		s := newStorage(t)
@@ -199,7 +233,8 @@ func TestLocalSessionDataStorage(t *testing.T) {
 
 	newLocal := func(t *testing.T) DataStorage {
 		t.Helper()
-		s := NewLocalSessionDataStorage(time.Hour)
+		s, err := NewLocalSessionDataStorage(time.Hour)
+		require.NoError(t, err)
 		t.Cleanup(func() { _ = s.Close() })
 		return s
 	}
@@ -208,63 +243,73 @@ func TestLocalSessionDataStorage(t *testing.T) {
 
 	t.Run("TTL eviction removes idle entries", func(t *testing.T) {
 		t.Parallel()
-		s := NewLocalSessionDataStorage(50 * time.Millisecond)
+		const ttl = time.Hour
+		s, err := NewLocalSessionDataStorage(ttl)
+		require.NoError(t, err)
 		t.Cleanup(func() { _ = s.Close() })
 		ctx := context.Background()
 
 		require.NoError(t, s.Store(ctx, "ttl-sess", map[string]string{"k": "v"}))
+		backdateLocalEntry(t, s, "ttl-sess", ttl+time.Millisecond)
+		s.deleteExpired()
 
-		// Background cleanup runs at TTL/2 (~25ms). Wait long enough for it to fire.
-		time.Sleep(200 * time.Millisecond)
-
-		_, err := s.Load(ctx, "ttl-sess")
+		_, err = s.Load(ctx, "ttl-sess")
 		assert.ErrorIs(t, err, ErrSessionNotFound, "idle session should be evicted after TTL")
 	})
 
-	t.Run("Load refreshes TTL so active entries survive cleanup", func(t *testing.T) {
+	t.Run("Load refreshes TTL so active entries survive eviction", func(t *testing.T) {
 		t.Parallel()
-		ttl := 100 * time.Millisecond
-		s := NewLocalSessionDataStorage(ttl)
+		const ttl = time.Hour
+		s, err := NewLocalSessionDataStorage(ttl)
+		require.NoError(t, err)
 		t.Cleanup(func() { _ = s.Close() })
 		ctx := context.Background()
 
 		require.NoError(t, s.Store(ctx, "active-sess", map[string]string{}))
+		backdateLocalEntry(t, s, "active-sess", ttl+time.Millisecond)
 
-		// Repeatedly load to keep the entry fresh, then verify it outlives the TTL.
-		for range 3 {
-			time.Sleep(ttl / 3)
-			_, err := s.Load(ctx, "active-sess")
-			require.NoError(t, err)
-		}
+		// Load should refresh the entry's timestamp.
+		_, err = s.Load(ctx, "active-sess")
+		require.NoError(t, err)
 
-		// Entry should still be present because each Load refreshed it.
-		_, err := s.Load(ctx, "active-sess")
+		// Eviction run should not remove the entry because Load just refreshed it.
+		s.deleteExpired()
+
+		_, err = s.Load(ctx, "active-sess")
 		assert.NoError(t, err, "actively loaded session should not be evicted")
 	})
 
 	t.Run("Exists does not refresh TTL", func(t *testing.T) {
 		t.Parallel()
-		ttl := 60 * time.Millisecond
-		s := NewLocalSessionDataStorage(ttl)
+		const ttl = time.Hour
+		s, err := NewLocalSessionDataStorage(ttl)
+		require.NoError(t, err)
 		t.Cleanup(func() { _ = s.Close() })
 		ctx := context.Background()
 
 		require.NoError(t, s.Store(ctx, "probe-sess", map[string]string{}))
+		backdateLocalEntry(t, s, "probe-sess", ttl+time.Millisecond)
 
-		// Call Exists only (no Load) and wait for the entry to age past TTL.
-		for range 3 {
-			time.Sleep(ttl / 4)
-			ok, err := s.Exists(ctx, "probe-sess")
-			require.NoError(t, err)
-			require.True(t, ok)
-		}
+		// Exists must not refresh the timestamp.
+		ok, err := s.Exists(ctx, "probe-sess")
+		require.NoError(t, err)
+		require.True(t, ok)
 
-		// Give the background cleanup goroutine time to evict it.
-		time.Sleep(ttl * 2)
+		// Eviction run should remove the entry because Exists did not refresh it.
+		s.deleteExpired()
 
-		_, err := s.Load(ctx, "probe-sess")
+		_, err = s.Load(ctx, "probe-sess")
 		assert.ErrorIs(t, err, ErrSessionNotFound, "Exists should not have extended the TTL")
 	})
+}
+
+// backdateLocalEntry moves the last-access timestamp of id back by age,
+// simulating an entry that has been idle for that duration.
+func backdateLocalEntry(t *testing.T, s *LocalSessionDataStorage, id string, age time.Duration) {
+	t.Helper()
+	val, ok := s.sessions.Load(id)
+	require.True(t, ok, "entry %q not found for backdating", id)
+	val.(*localDataEntry).lastAccessNano.Store(time.Now().Add(-age).UnixNano())
 }
 
 // ---------------------------------------------------------------------------

--- a/pkg/transport/session/storage_redis.go
+++ b/pkg/transport/session/storage_redis.go
@@ -56,8 +56,21 @@ func NewRedisStorage(ctx context.Context, cfg RedisConfig, ttl time.Duration) (*
 	if ttl <= 0 {
 		return nil, fmt.Errorf("ttl must be a positive duration")
 	}
+	client, err := buildRedisClient(ctx, &cfg)
+	if err != nil {
+		return nil, err
+	}
+	return &RedisStorage{
+		client:    client,
+		keyPrefix: cfg.KeyPrefix,
+		ttl:       ttl,
+	}, nil
+}
 
-	// Apply timeout defaults
+// buildRedisClient applies timeout defaults, resolves TLS, constructs either a
+// standalone or Sentinel client from cfg, and verifies the connection with Ping.
+// cfg is modified in place (timeout defaults written back).
+func buildRedisClient(ctx context.Context, cfg *RedisConfig) (redis.UniversalClient, error) {
 	if cfg.DialTimeout == 0 {
 		cfg.DialTimeout = DefaultDialTimeout
 	}
@@ -75,7 +88,7 @@ func NewRedisStorage(ctx context.Context, cfg RedisConfig, ttl time.Duration) (*
 
 	var client redis.UniversalClient
 	if cfg.SentinelConfig != nil {
-		opts := &redis.FailoverOptions{
+		client = redis.NewFailoverClient(&redis.FailoverOptions{
 			MasterName:    cfg.SentinelConfig.MasterName,
 			SentinelAddrs: cfg.SentinelConfig.SentinelAddrs,
 			Username:      cfg.Username,
@@ -85,10 +98,9 @@ func NewRedisStorage(ctx context.Context, cfg RedisConfig, ttl time.Duration) (*
 			ReadTimeout:   cfg.ReadTimeout,
 			WriteTimeout:  cfg.WriteTimeout,
 			TLSConfig:     tlsCfg,
-		}
-		client = redis.NewFailoverClient(opts)
+		})
 	} else {
-		opts := &redis.Options{
+		client = redis.NewClient(&redis.Options{
 			Addr:         cfg.Addr,
 			Username:     cfg.Username,
 			Password:     cfg.Password,
@@ -97,20 +109,14 @@ func NewRedisStorage(ctx context.Context, cfg RedisConfig, ttl time.Duration) (*
 			ReadTimeout:  cfg.ReadTimeout,
 			WriteTimeout: cfg.WriteTimeout,
 			TLSConfig:    tlsCfg,
-		}
-		client = redis.NewClient(opts)
+		})
 	}
 
 	if err := client.Ping(ctx).Err(); err != nil {
 		_ = client.Close()
 		return nil, fmt.Errorf("failed to connect to redis: %w", err)
 	}
-
-	return &RedisStorage{
-		client:    client,
-		keyPrefix: cfg.KeyPrefix,
-		ttl:       ttl,
-	}, nil
+	return client, nil
 }
 
 // newRedisStorageWithClient creates a RedisStorage with a pre-configured client.


### PR DESCRIPTION
## Summary

<!--
REQUIRED. You MUST explain:
1. WHY this change is needed (the problem or motivation)
2. WHAT changed (concise bullet points)

The diff shows the code — your summary must provide the context a reviewer
needs to understand the purpose without reading the diff first.
-->

Introduce DataStorage, a key-value metadata store separate from the existing Session-based Storage interface. Unlike Storage, DataStorage never round-trips live session objects — it stores only serialisable map[string]string metadata.

This separation avoids the type-assertion bug where a Redis round-trip deserialises a MultiSession as a plain *StreamableSession, losing all backend connections and routing state.

Two implementations are provided:
- LocalSessionDataStorage: in-memory sync.Map with TTL-based eviction and a background cleanup goroutine.
- RedisSessionDataStorage: Redis/Valkey-backed with sliding-window TTL via GETEX on every Load, and atomic SET NX for StoreIfAbsent.

Both pass a shared contract test suite covering Store/Load round-trips, upsert, nil metadata, empty-ID errors, Exists (without TTL refresh), StoreIfAbsent atomicity, Delete idempotency, and TTL behaviour.
<!--
Link related issues. Use "Closes" or "Fixes" to auto-close on merge.
Remove this line if there is no related issue.
-->

Fixes #4220 

## Type of change

<!-- REQUIRED. Check exactly one. -->

- [ ] Bug fix
- [ ] New feature
- [x] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

<!--
REQUIRED. Check every verification step you actually ran.
You MUST check at least one item. If you only did manual testing,
describe exactly what you tested below the checkbox.
-->

- [ ] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [ ] Linting (`task lint-fix`)
- [ ] Manual testing (describe below)

## Changes

<!--
Optional — include for PRs touching more than a few files to help
reviewers navigate the diff. Remove this entire section for small PRs.
-->

| File | Change |
|------|--------|
|      |        |

## Does this introduce a user-facing change?

<!--
If yes, describe the change from the user's perspective. This helps with release notes.
If no, write "No".
Remove this section entirely if not applicable.
-->

## Special notes for reviewers

<!--
Optional — call out anything non-obvious: tricky logic, known limitations,
areas where you'd like extra scrutiny, or follow-up work planned.
Remove this section if not needed.
-->
