### PR TITLE
Migrate session manager to DataStorage with cross-pod restore

### DIFF
--- a/cmd/vmcp/app/commands.go
+++ b/cmd/vmcp/app/commands.go
@@ -614,6 +614,7 @@ func runServe(cmd *cobra.Command, _ []string) error {
 		StatusReporter:          statusReporter,
 		OptimizerConfig:         optCfg,
 		SessionFactory:          sessionFactory,
+		SessionStorage:          cfg.SessionStorage,
 	}
 
 	// Convert composite tool configurations to workflow definitions

--- a/pkg/vmcp/server/server.go
+++ b/pkg/vmcp/server/server.go
@@ -16,6 +16,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -32,6 +33,7 @@ import (
 	transportsession "github.com/stacklok/toolhive/pkg/transport/session"
 	"github.com/stacklok/toolhive/pkg/vmcp"
 	"github.com/stacklok/toolhive/pkg/vmcp/composer"
+	vmcpconfig "github.com/stacklok/toolhive/pkg/vmcp/config"
 	"github.com/stacklok/toolhive/pkg/vmcp/discovery"
 	"github.com/stacklok/toolhive/pkg/vmcp/health"
 	"github.com/stacklok/toolhive/pkg/vmcp/optimizer"
@@ -171,6 +173,13 @@ type Config struct {
 	// SessionFactory creates MultiSessions for session management.
 	// Required; must not be nil.
 	SessionFactory vmcpsession.MultiSessionFactory
+
+	// SessionStorage configures the session storage backend.
+	// When nil or provider is "memory", local in-process storage is used.
+	// When provider is "redis", a Redis-backed store is created for cross-pod
+	// session persistence; the Redis password is read from the
+	// THV_SESSION_REDIS_PASSWORD environment variable.
+	SessionStorage *vmcpconfig.SessionStorageConfig
 }
 
 // Server is the Virtual MCP Server that aggregates multiple backends.
@@ -243,6 +252,42 @@ type Server struct {
 	// Populated during Start() initialization before blocking; no mutex needed
 	// since Stop() is only called after Start()'s select returns.
 	shutdownFuncs []func(context.Context) error
+}
+
+// buildSessionDataStorage constructs the DataStorage backend from cfg.
+// When cfg.SessionStorage is nil or provider is "memory" (or empty), local in-process
+// storage is used. When provider is "redis", a Redis-backed store is created
+// using the address, DB, and key prefix from cfg.SessionStorage; the password
+// is read from the THV_SESSION_REDIS_PASSWORD environment variable.
+// Any other provider value is a misconfiguration and returns an error.
+func buildSessionDataStorage(ctx context.Context, cfg *Config) (transportsession.DataStorage, error) {
+	// Default to in-process storage when session storage is not configured,
+	// or when the provider is explicitly "memory" or left empty.
+	if cfg.SessionStorage == nil ||
+		cfg.SessionStorage.Provider == "" ||
+		strings.EqualFold(cfg.SessionStorage.Provider, "memory") {
+		return transportsession.NewLocalSessionDataStorage(cfg.SessionTTL)
+	}
+	if cfg.SessionStorage.Provider != "redis" {
+		return nil, fmt.Errorf("unsupported session storage provider %q (supported: \"memory\", \"redis\")",
+			cfg.SessionStorage.Provider)
+	}
+	keyPrefix := cfg.SessionStorage.KeyPrefix
+	if keyPrefix == "" {
+		keyPrefix = "thv:vmcp:session:"
+	}
+	redisCfg := transportsession.RedisConfig{
+		Addr:      cfg.SessionStorage.Address,
+		Password:  os.Getenv(vmcpconfig.RedisPasswordEnvVar),
+		DB:        int(cfg.SessionStorage.DB),
+		KeyPrefix: keyPrefix,
+	}
+	slog.Info("using Redis session storage",
+		"address", cfg.SessionStorage.Address,
+		"db", cfg.SessionStorage.DB,
+		"key_prefix", keyPrefix,
+	)
+	return transportsession.NewRedisSessionDataStorage(ctx, redisCfg, cfg.SessionTTL)
 }
 
 // New creates a new Virtual MCP Server instance.
@@ -366,9 +411,7 @@ func New(
 	// keyed by the same session ID.
 	sessionManager := transportsession.NewManager(cfg.SessionTTL, transportsession.NewStreamableSession)
 
-	// Create session data storage. Default to local in-memory storage; a future
-	// SessionStorageConfig field can wire up Redis for multi-pod deployments.
-	sessionDataStorage, err := transportsession.NewLocalSessionDataStorage(cfg.SessionTTL)
+	sessionDataStorage, err := buildSessionDataStorage(ctx, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create session data storage: %w", err)
 	}


### PR DESCRIPTION
## Summary

Follow-on to #4464 (merged). That PR landed the core DataStorage migration — `RestorableCache`, `sessionmanager.Manager` rewrite, `MultiSessionGetter` interface, and `RestoreSession`. This PR adds the remaining piece: Redis session storage wiring.

**Redis session storage wiring**

Add `SessionStorage *vmcpconfig.SessionStorageConfig` to `vmcpserver.Config` and introduce `buildSessionDataStorage`:

- When `SessionStorage` is nil, provider is `"memory"`, or provider is empty/unset, local in-process storage is used (default behaviour unchanged).
- When provider is `"redis"`, a `RedisSessionDataStorage` is constructed (password from `THV_SESSION_REDIS_PASSWORD`) — enabling cross-pod session persistence.
- Any other provider value is rejected immediately with a clear error (e.g. a typo like `"Redis"` will not silently fall back to local storage).
- Provider matching is case-insensitive for `"memory"`.

Pass `cfg.SessionStorage` from `commands.go` so the operator-provided Redis config reaches the server.

Fixes #4220

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [x] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [x] Linting (`task lint-fix`)
- [ ] Manual testing (describe below)

## Does this introduce a user-facing change?

No new user-facing changes beyond #4464. The Redis wiring is a configuration opt-in (operator sets `sessionStorage.provider: redis`); default behaviour (local in-process storage) is unchanged.