### PR TITLE
Add printer columns to all CRDs

### DIFF
--- a/cmd/thv-operator/api/v1alpha1/mcpexternalauthconfig_types.go
+++ b/cmd/thv-operator/api/v1alpha1/mcpexternalauthconfig_types.go
@@ -722,6 +722,8 @@ type MCPExternalAuthConfigStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:shortName=extauth;mcpextauth,categories=toolhive
 // +kubebuilder:printcolumn:name="Type",type=string,JSONPath=`.spec.type`
+// +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=='Valid')].status`
+// +kubebuilder:printcolumn:name="References",type=string,JSONPath=`.status.referencingServers`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // MCPExternalAuthConfig is the Schema for the mcpexternalauthconfigs API.

--- a/cmd/thv-operator/api/v1alpha1/mcpgroup_types.go
+++ b/cmd/thv-operator/api/v1alpha1/mcpgroup_types.go
@@ -75,11 +75,10 @@ const (
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 //+kubebuilder:resource:shortName=mcpg;mcpgroup,categories=toolhive
-//nolint:lll
-//+kubebuilder:printerColumn:name="Servers",type="integer",JSONPath=".status.serverCount",description="The number of MCPServers in this group"
-//+kubebuilder:printerColumn:name="Phase",type="string",JSONPath=".status.phase",description="The phase of the MCPGroup"
-//+kubebuilder:printerColumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="The age of the MCPGroup"
+//+kubebuilder:printcolumn:name="Servers",type="integer",JSONPath=".status.serverCount"
+//+kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase"
 //+kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type=='MCPServersChecked')].status"
+//+kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
 // MCPGroup is the Schema for the mcpgroups API
 type MCPGroup struct {

--- a/cmd/thv-operator/api/v1alpha1/mcpoidcconfig_types.go
+++ b/cmd/thv-operator/api/v1alpha1/mcpoidcconfig_types.go
@@ -154,7 +154,9 @@ type MCPOIDCConfigStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:shortName=mcpoidc,categories=toolhive
-// +kubebuilder:printcolumn:name="Type",type=string,JSONPath=`.spec.type`
+// +kubebuilder:printcolumn:name="Source",type=string,JSONPath=`.spec.type`
+// +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=='Valid')].status`
+// +kubebuilder:printcolumn:name="References",type=string,JSONPath=`.status.referencingServers`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // MCPOIDCConfig is the Schema for the mcpoidcconfigs API.

--- a/cmd/thv-operator/api/v1alpha1/mcptelemetryconfig_types.go
+++ b/cmd/thv-operator/api/v1alpha1/mcptelemetryconfig_types.go
@@ -68,8 +68,8 @@ type MCPTelemetryConfigStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:shortName=mcpotel,categories=toolhive
 // +kubebuilder:printcolumn:name="Endpoint",type=string,JSONPath=`.spec.endpoint`
-// +kubebuilder:printcolumn:name="Tracing",type=boolean,JSONPath=`.spec.tracingEnabled`
-// +kubebuilder:printcolumn:name="Metrics",type=boolean,JSONPath=`.spec.metricsEnabled`
+// +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=='Valid')].status`
+// +kubebuilder:printcolumn:name="References",type=string,JSONPath=`.status.referencingServers`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // MCPTelemetryConfig is the Schema for the mcptelemetryconfigs API.

--- a/cmd/thv-operator/api/v1alpha1/toolconfig_types.go
+++ b/cmd/thv-operator/api/v1alpha1/toolconfig_types.go
@@ -105,9 +105,8 @@ type MCPToolConfigStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:shortName=tc;toolconfig,categories=toolhive
-// +kubebuilder:printcolumn:name="Filter Count",type=integer,JSONPath=`.spec.toolsFilter[*]`
-// +kubebuilder:printcolumn:name="Override Count",type=integer,JSONPath=`.spec.toolsOverride`
-// +kubebuilder:printcolumn:name="Referenced By",type=string,JSONPath=`.status.referencingServers`
+// +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=='Valid')].status`
+// +kubebuilder:printcolumn:name="References",type=string,JSONPath=`.status.referencingServers`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // MCPToolConfig is the Schema for the mcptoolconfigs API.

--- a/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpexternalauthconfigs.yaml
+++ b/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpexternalauthconfigs.yaml
@@ -23,6 +23,12 @@ spec:
     - jsonPath: .spec.type
       name: Type
       type: string
+    - jsonPath: .status.conditions[?(@.type=='Valid')].status
+      name: Ready
+      type: string
+    - jsonPath: .status.referencingServers
+      name: References
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date

--- a/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpgroups.yaml
+++ b/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpgroups.yaml
@@ -20,9 +20,18 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
+    - jsonPath: .status.serverCount
+      name: Servers
+      type: integer
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
     - jsonPath: .status.conditions[?(@.type=='MCPServersChecked')].status
       name: Ready
       type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpoidcconfigs.yaml
+++ b/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpoidcconfigs.yaml
@@ -20,7 +20,13 @@ spec:
   versions:
   - additionalPrinterColumns:
     - jsonPath: .spec.type
-      name: Type
+      name: Source
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Valid')].status
+      name: Ready
+      type: string
+    - jsonPath: .status.referencingServers
+      name: References
       type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age

--- a/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcptelemetryconfigs.yaml
+++ b/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcptelemetryconfigs.yaml
@@ -22,12 +22,12 @@ spec:
     - jsonPath: .spec.endpoint
       name: Endpoint
       type: string
-    - jsonPath: .spec.tracingEnabled
-      name: Tracing
-      type: boolean
-    - jsonPath: .spec.metricsEnabled
-      name: Metrics
-      type: boolean
+    - jsonPath: .status.conditions[?(@.type=='Valid')].status
+      name: Ready
+      type: string
+    - jsonPath: .status.referencingServers
+      name: References
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date

--- a/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcptoolconfigs.yaml
+++ b/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcptoolconfigs.yaml
@@ -20,14 +20,11 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .spec.toolsFilter[*]
-      name: Filter Count
-      type: integer
-    - jsonPath: .spec.toolsOverride
-      name: Override Count
-      type: integer
+    - jsonPath: .status.conditions[?(@.type=='Valid')].status
+      name: Ready
+      type: string
     - jsonPath: .status.referencingServers
-      name: Referenced By
+      name: References
       type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpexternalauthconfigs.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpexternalauthconfigs.yaml
@@ -26,6 +26,12 @@ spec:
     - jsonPath: .spec.type
       name: Type
       type: string
+    - jsonPath: .status.conditions[?(@.type=='Valid')].status
+      name: Ready
+      type: string
+    - jsonPath: .status.referencingServers
+      name: References
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpgroups.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpgroups.yaml
@@ -23,9 +23,18 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
+    - jsonPath: .status.serverCount
+      name: Servers
+      type: integer
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
     - jsonPath: .status.conditions[?(@.type=='MCPServersChecked')].status
       name: Ready
       type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpoidcconfigs.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpoidcconfigs.yaml
@@ -23,7 +23,13 @@ spec:
   versions:
   - additionalPrinterColumns:
     - jsonPath: .spec.type
-      name: Type
+      name: Source
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Valid')].status
+      name: Ready
+      type: string
+    - jsonPath: .status.referencingServers
+      name: References
       type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcptelemetryconfigs.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcptelemetryconfigs.yaml
@@ -25,12 +25,12 @@ spec:
     - jsonPath: .spec.endpoint
       name: Endpoint
       type: string
-    - jsonPath: .spec.tracingEnabled
-      name: Tracing
-      type: boolean
-    - jsonPath: .spec.metricsEnabled
-      name: Metrics
-      type: boolean
+    - jsonPath: .status.conditions[?(@.type=='Valid')].status
+      name: Ready
+      type: string
+    - jsonPath: .status.referencingServers
+      name: References
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcptoolconfigs.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcptoolconfigs.yaml
@@ -23,14 +23,11 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .spec.toolsFilter[*]
-      name: Filter Count
-      type: integer
-    - jsonPath: .spec.toolsOverride
-      name: Override Count
-      type: integer
+    - jsonPath: .status.conditions[?(@.type=='Valid')].status
+      name: Ready
+      type: string
     - jsonPath: .status.referencingServers
-      name: Referenced By
+      name: References
       type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age


### PR DESCRIPTION
## Summary

- `kubectl get` output for config CRDs was minimal (just name + age), forcing operators to use `-o yaml` to check readiness or discover which MCPServers reference a config. This adds informative printer columns to all config CRDs and fixes inconsistencies found during audit.
- Adds Ready and References columns to MCPOIDCConfig, MCPTelemetryConfig, MCPExternalAuthConfig, and MCPToolConfig. Fixes the MCPGroup `printerColumn` marker typo that silently prevented column rendering.

Closes #4252

## Type of change

- [x] New feature

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)
- [x] CRD manifest regeneration (`task operator-manifests`) — verified generated YAML matches markers

## Changes

| File | Change |
|------|--------|
| `mcpoidcconfig_types.go` | Rename "Type" → "Source", add Ready + References columns |
| `mcptelemetryconfig_types.go` | Replace Tracing/Metrics columns with Ready + References |
| `mcpexternalauthconfig_types.go` | Add Ready + References columns |
| `mcpgroup_types.go` | Fix `printerColumn` typo → `printcolumn`, reorder columns |
| `toolconfig_types.go` | Remove broken Filter/Override Count columns, add Ready |
| `deploy/charts/operator-crds/**` | Regenerated CRD manifests (files + templates) |

## Does this introduce a user-facing change?

Yes. `kubectl get` output is now significantly more informative for all CRDs:

**MCPOIDCConfig — before:**
```
NAME              TYPE                       AGE
my-oidc-config    kubernetesServiceAccount   5m
```

**MCPOIDCConfig — after:**
```
NAME              SOURCE                     READY   REFERENCES              AGE
my-oidc-config    kubernetesServiceAccount   True    ["my-server","other"]   5m
```

**MCPTelemetryConfig — before:**
```
NAME              ENDPOINT                        TRACING   METRICS   AGE
my-otel-config    https://otel-collector:4318     true      true      5m
```

**MCPTelemetryConfig — after:**
```
NAME              ENDPOINT                        READY   REFERENCES       AGE
my-otel-config    https://otel-collector:4318     True    ["my-server"]    5m
```

**MCPExternalAuthConfig — before:**
```
NAME              TYPE              AGE
my-auth-config    tokenExchange     5m
```

**MCPExternalAuthConfig — after:**
```
NAME              TYPE              READY   REFERENCES       AGE
my-auth-config    tokenExchange     True    ["my-server"]    5m
```

**MCPToolConfig — before:**
```
NAME             FILTER COUNT   OVERRIDE COUNT   REFERENCED BY      AGE
my-tool-config                                   ["my-server"]      5m
```

**MCPToolConfig — after:**
```
NAME             READY   REFERENCES       AGE
my-tool-config   True    ["my-server"]    5m
```

**MCPGroup — before (columns silently missing due to typo):**
```
NAME       READY    AGE
my-group   True     5m
```

**MCPGroup — after (all columns now render):**
```
NAME       SERVERS   PHASE   READY   AGE
my-group   3         Ready   True    5m
```

## Special notes for reviewers

- The MCPGroup had three `+kubebuilder:printerColumn` markers (capital C) which is **not** a recognized kubebuilder marker — only `+kubebuilder:printcolumn` works. This means the Servers, Phase, and Age columns were silently dropped from the generated CRD. Only the Ready column (which used the correct spelling) was rendering.
- Config CRDs use a `"Valid"` condition type (not `"Ready"`) for their status, so the Ready column maps to `.status.conditions[?(@.type=='Valid')].status`.
- MCPToolConfig's previous "Filter Count" and "Override Count" columns used `type=integer` with JSONPaths that resolve to arrays/maps, not integers — they produced empty output. Replaced with a Ready column.

Generated with [Claude Code](https://claude.com/claude-code)