### PR TITLE
Rename MCPOIDCConfig condition type from Valid to Ready per RFC-0023

### DIFF
--- a/cmd/thv-operator/api/v1alpha1/mcpoidcconfig_types.go
+++ b/cmd/thv-operator/api/v1alpha1/mcpoidcconfig_types.go
@@ -18,6 +18,18 @@ const (
 	MCPOIDCConfigTypeInline MCPOIDCConfigSourceType = "inline"
 )
 
+// Condition type and reasons for MCPOIDCConfig status (RFC-0023)
+const (
+	// ConditionTypeOIDCConfigReady indicates whether the MCPOIDCConfig is ready for use
+	ConditionTypeOIDCConfigReady = "Ready"
+
+	// ConditionReasonOIDCConfigValid indicates spec validation passed
+	ConditionReasonOIDCConfigValid = "ConfigValid"
+
+	// ConditionReasonOIDCConfigInvalid indicates spec validation failed
+	ConditionReasonOIDCConfigInvalid = "ConfigInvalid"
+)
+
 // MCPOIDCConfigSourceType represents the type of OIDC configuration source for MCPOIDCConfig
 type MCPOIDCConfigSourceType string
 

--- a/cmd/thv-operator/controllers/mcpoidcconfig_controller.go
+++ b/cmd/thv-operator/controllers/mcpoidcconfig_controller.go
@@ -83,9 +83,9 @@ func (r *MCPOIDCConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	if err := oidcConfig.Validate(); err != nil {
 		logger.Error(err, "MCPOIDCConfig spec validation failed")
 		meta.SetStatusCondition(&oidcConfig.Status.Conditions, metav1.Condition{
-			Type:               "Valid",
+			Type:               mcpv1alpha1.ConditionTypeOIDCConfigReady,
 			Status:             metav1.ConditionFalse,
-			Reason:             "ValidationFailed",
+			Reason:             mcpv1alpha1.ConditionReasonOIDCConfigInvalid,
 			Message:            err.Error(),
 			ObservedGeneration: oidcConfig.Generation,
 		})
@@ -95,11 +95,11 @@ func (r *MCPOIDCConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, nil // Don't requeue on validation errors - user must fix spec
 	}
 
-	// Validation succeeded - set Valid=True condition
+	// Validation succeeded - set Ready=True condition
 	conditionChanged := meta.SetStatusCondition(&oidcConfig.Status.Conditions, metav1.Condition{
-		Type:               "Valid",
+		Type:               mcpv1alpha1.ConditionTypeOIDCConfigReady,
 		Status:             metav1.ConditionTrue,
-		Reason:             "ValidationSucceeded",
+		Reason:             mcpv1alpha1.ConditionReasonOIDCConfigValid,
 		Message:            "Spec validation passed",
 		ObservedGeneration: oidcConfig.Generation,
 	})

--- a/cmd/thv-operator/controllers/mcpoidcconfig_controller_test.go
+++ b/cmd/thv-operator/controllers/mcpoidcconfig_controller_test.go
@@ -227,7 +227,7 @@ func TestMCPOIDCConfigReconciler_ValidationRecovery(t *testing.T) {
 		},
 	}
 
-	// Reconcile invalid config — should set Valid=False
+	// Reconcile invalid config — should set Ready=False
 	_, err := r.Reconcile(ctx, req)
 	require.NoError(t, err)
 
@@ -237,12 +237,12 @@ func TestMCPOIDCConfigReconciler_ValidationRecovery(t *testing.T) {
 
 	var foundFalse bool
 	for _, cond := range invalidConfig.Status.Conditions {
-		if cond.Type == conditionTypeValid {
+		if cond.Type == mcpv1alpha1.ConditionTypeOIDCConfigReady {
 			assert.Equal(t, metav1.ConditionFalse, cond.Status)
 			foundFalse = true
 		}
 	}
-	require.True(t, foundFalse, "Should have Valid=False condition")
+	require.True(t, foundFalse, "Should have Ready=False condition")
 	assert.Empty(t, invalidConfig.Status.ConfigHash, "Hash should not be set for invalid config")
 
 	// Fix the config by adding the inline spec
@@ -254,7 +254,7 @@ func TestMCPOIDCConfigReconciler_ValidationRecovery(t *testing.T) {
 	err = fakeClient.Update(ctx, &invalidConfig)
 	require.NoError(t, err)
 
-	// Reconcile again — should set Valid=True and compute hash
+	// Reconcile again — should set Ready=True and compute hash
 	_, err = r.Reconcile(ctx, req)
 	require.NoError(t, err)
 
@@ -264,13 +264,13 @@ func TestMCPOIDCConfigReconciler_ValidationRecovery(t *testing.T) {
 
 	var foundTrue bool
 	for _, cond := range recoveredConfig.Status.Conditions {
-		if cond.Type == conditionTypeValid {
-			assert.Equal(t, metav1.ConditionTrue, cond.Status, "Valid condition should recover to True")
-			assert.Equal(t, "ValidationSucceeded", cond.Reason)
+		if cond.Type == mcpv1alpha1.ConditionTypeOIDCConfigReady {
+			assert.Equal(t, metav1.ConditionTrue, cond.Status, "Ready condition should recover to True")
+			assert.Equal(t, mcpv1alpha1.ConditionReasonOIDCConfigValid, cond.Reason)
 			foundTrue = true
 		}
 	}
-	assert.True(t, foundTrue, "Should have Valid=True condition after fix")
+	assert.True(t, foundTrue, "Should have Ready=True condition after fix")
 	assert.NotEmpty(t, recoveredConfig.Status.ConfigHash, "Hash should be set after recovery")
 }
 
@@ -461,21 +461,21 @@ func TestMCPOIDCConfigReconciler_ValidationFailureSetsCondition(t *testing.T) {
 	_, err := r.Reconcile(ctx, req)
 	require.NoError(t, err)
 
-	// Check that the Valid condition is set to False
+	// Check that the Ready condition is set to False
 	var updatedConfig mcpv1alpha1.MCPOIDCConfig
 	err = fakeClient.Get(ctx, req.NamespacedName, &updatedConfig)
 	require.NoError(t, err)
 
 	var foundCondition bool
 	for _, cond := range updatedConfig.Status.Conditions {
-		if cond.Type == conditionTypeValid {
+		if cond.Type == mcpv1alpha1.ConditionTypeOIDCConfigReady {
 			foundCondition = true
-			assert.Equal(t, metav1.ConditionFalse, cond.Status, "Valid condition should be False")
-			assert.Equal(t, "ValidationFailed", cond.Reason)
+			assert.Equal(t, metav1.ConditionFalse, cond.Status, "Ready condition should be False")
+			assert.Equal(t, mcpv1alpha1.ConditionReasonOIDCConfigInvalid, cond.Reason)
 			break
 		}
 	}
-	assert.True(t, foundCondition, "Should have a Valid condition")
+	assert.True(t, foundCondition, "Should have a Ready condition")
 }
 
 func TestMCPOIDCConfig_Validate(t *testing.T) {

--- a/cmd/thv-operator/controllers/mcpserver_controller.go
+++ b/cmd/thv-operator/controllers/mcpserver_controller.go
@@ -2070,12 +2070,12 @@ func (r *MCPServerReconciler) handleOIDCConfig(ctx context.Context, m *mcpv1alph
 		return fmt.Errorf("MCPOIDCConfig %s not found", m.Spec.OIDCConfigRef.Name)
 	}
 
-	// Check that the MCPOIDCConfig is valid
-	validCondition := meta.FindStatusCondition(oidcConfig.Status.Conditions, "Valid")
-	if validCondition == nil || validCondition.Status != metav1.ConditionTrue {
-		msg := fmt.Sprintf("MCPOIDCConfig %s is not valid", m.Spec.OIDCConfigRef.Name)
-		if validCondition != nil {
-			msg = fmt.Sprintf("MCPOIDCConfig %s is not valid: %s", m.Spec.OIDCConfigRef.Name, validCondition.Message)
+	// Check that the MCPOIDCConfig is ready
+	readyCondition := meta.FindStatusCondition(oidcConfig.Status.Conditions, mcpv1alpha1.ConditionTypeOIDCConfigReady)
+	if readyCondition == nil || readyCondition.Status != metav1.ConditionTrue {
+		msg := fmt.Sprintf("MCPOIDCConfig %s is not ready", m.Spec.OIDCConfigRef.Name)
+		if readyCondition != nil {
+			msg = fmt.Sprintf("MCPOIDCConfig %s is not ready: %s", m.Spec.OIDCConfigRef.Name, readyCondition.Message)
 		}
 		setOIDCConfigRefCondition(m, metav1.ConditionFalse,
 			mcpv1alpha1.ConditionReasonOIDCConfigRefNotValid, msg)

--- a/cmd/thv-operator/controllers/mcpserver_oidcconfig_test.go
+++ b/cmd/thv-operator/controllers/mcpserver_oidcconfig_test.go
@@ -22,9 +22,9 @@ import (
 func TestMCPServerReconciler_handleOIDCConfig(t *testing.T) {
 	t.Parallel()
 
-	// validOIDCCondition is a helper to build a Valid=True condition slice.
+	// validOIDCCondition is a helper to build a Ready=True condition slice.
 	validOIDCCondition := []metav1.Condition{{
-		Type: "Valid", Status: metav1.ConditionTrue, Reason: "ValidationSucceeded",
+		Type: mcpv1alpha1.ConditionTypeOIDCConfigReady, Status: metav1.ConditionTrue, Reason: mcpv1alpha1.ConditionReasonOIDCConfigValid,
 	}}
 
 	tests := []struct {
@@ -62,7 +62,7 @@ func TestMCPServerReconciler_handleOIDCConfig(t *testing.T) {
 			expectConditionReason: mcpv1alpha1.ConditionReasonOIDCConfigRefNotFound,
 		},
 		{
-			name: "config with Valid=False sets NotValid condition",
+			name: "config with Ready=False sets NotValid condition",
 			mcpServer: &mcpv1alpha1.MCPServer{
 				ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "default"},
 				Spec: mcpv1alpha1.MCPServerSpec{
@@ -78,13 +78,13 @@ func TestMCPServerReconciler_handleOIDCConfig(t *testing.T) {
 				},
 				Status: mcpv1alpha1.MCPOIDCConfigStatus{
 					Conditions: []metav1.Condition{{
-						Type: "Valid", Status: metav1.ConditionFalse, Reason: "ValidationFailed",
+						Type: mcpv1alpha1.ConditionTypeOIDCConfigReady, Status: metav1.ConditionFalse, Reason: mcpv1alpha1.ConditionReasonOIDCConfigInvalid,
 						Message: "missing fields",
 					}},
 				},
 			},
 			expectError:           true,
-			expectErrorContains:   "not valid",
+			expectErrorContains:   "not ready",
 			expectConditionStatus: conditionStatusPtr(metav1.ConditionFalse),
 			expectConditionReason: mcpv1alpha1.ConditionReasonOIDCConfigRefNotValid,
 		},

--- a/cmd/thv-operator/test-integration/mcp-oidc-config/mcpoidcconfig_controller_integration_test.go
+++ b/cmd/thv-operator/test-integration/mcp-oidc-config/mcpoidcconfig_controller_integration_test.go
@@ -20,7 +20,7 @@ const (
 )
 
 var _ = Describe("MCPOIDCConfig Controller", func() {
-	It("should set Valid condition and config hash on creation", func() {
+	It("should set Ready condition and config hash on creation", func() {
 		oidcConfig := &mcpv1alpha1.MCPOIDCConfig{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-oidc-creation",
@@ -50,7 +50,7 @@ var _ = Describe("MCPOIDCConfig Controller", func() {
 			return fetched.Status.ConfigHash != ""
 		}, timeout, interval).Should(BeTrue())
 
-		// Verify Valid condition is set to True
+		// Verify Ready condition is set to True
 		Eventually(func() bool {
 			fetched := &mcpv1alpha1.MCPOIDCConfig{}
 			err := k8sClient.Get(ctx, types.NamespacedName{
@@ -61,7 +61,7 @@ var _ = Describe("MCPOIDCConfig Controller", func() {
 				return false
 			}
 			for _, cond := range fetched.Status.Conditions {
-				if cond.Type == "Valid" && cond.Status == metav1.ConditionTrue {
+				if cond.Type == mcpv1alpha1.ConditionTypeOIDCConfigReady && cond.Status == metav1.ConditionTrue {
 					return true
 				}
 			}

--- a/cmd/thv-operator/test-integration/mcp-oidc-config/mcpoidcconfig_mcpserver_integration_test.go
+++ b/cmd/thv-operator/test-integration/mcp-oidc-config/mcpoidcconfig_mcpserver_integration_test.go
@@ -61,7 +61,7 @@ var _ = Describe("MCPOIDCConfig and MCPServer Cross-Resource Integration Tests",
 			}
 			Expect(k8sClient.Create(ctx, oidcConfig)).Should(Succeed())
 
-			// Wait for Valid condition and ConfigHash to be set
+			// Wait for Ready condition and ConfigHash to be set
 			Eventually(func() bool {
 				updated := &mcpv1alpha1.MCPOIDCConfig{}
 				err := k8sClient.Get(ctx, types.NamespacedName{
@@ -75,7 +75,7 @@ var _ = Describe("MCPOIDCConfig and MCPServer Cross-Resource Integration Tests",
 					return false
 				}
 				for _, cond := range updated.Status.Conditions {
-					if cond.Type == "Valid" && cond.Status == metav1.ConditionTrue {
+					if cond.Type == mcpv1alpha1.ConditionTypeOIDCConfigReady && cond.Status == metav1.ConditionTrue {
 						return true
 					}
 				}


### PR DESCRIPTION
## Summary

- RFC-0023 specifies `type: Ready` with reasons `ConfigValid`/`ConfigInvalid` for shared config resource conditions. The initial MCPOIDCConfig controller (PR #4481) used `type: Valid` with `ValidationSucceeded`/`ValidationFailed` instead.
- Define `ConditionTypeOIDCConfigReady`, `ConditionReasonOIDCConfigValid`, and `ConditionReasonOIDCConfigInvalid` constants in `mcpoidcconfig_types.go` and replace all raw string usages across writers, readers, and tests.

## Type of change

- [x] Refactoring (no behavior change)

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)

## Changes

| File | Change |
|------|--------|
| `cmd/thv-operator/api/v1alpha1/mcpoidcconfig_types.go` | Add `ConditionTypeOIDCConfigReady`, `ConditionReasonOIDCConfigValid`, `ConditionReasonOIDCConfigInvalid` constants |
| `cmd/thv-operator/controllers/mcpoidcconfig_controller.go` | Use new constants instead of raw `"Valid"`/`"ValidationSucceeded"`/`"ValidationFailed"` strings |
| `cmd/thv-operator/controllers/mcpserver_controller.go` | Update OIDC config readiness check from `"Valid"` to `ConditionTypeOIDCConfigReady` |
| `cmd/thv-operator/controllers/mcpoidcconfig_controller_test.go` | Align assertions with new condition type and reason constants |
| `cmd/thv-operator/controllers/mcpserver_oidcconfig_test.go` | Align test fixtures with new condition type and reason constants |
| `cmd/thv-operator/test-integration/mcp-oidc-config/` | Update both integration test files to use the new constant |

## Does this introduce a user-facing change?

The MCPOIDCConfig status condition type changes from `Valid` to `Ready`, and reasons change from `ValidationSucceeded`/`ValidationFailed` to `ConfigValid`/`ConfigInvalid`. Users or tooling that inspect `.status.conditions` on MCPOIDCConfig resources will see the new names.

## Special notes for reviewers

- The shared `conditionTypeValid` test helper in `helpers_test.go` is preserved for other config controllers (MCPTelemetryConfig, MCPExternalAuthConfig, MCPToolConfig) that still use `type: Valid`. Those are separate follow-up items.
- The VirtualMCPServer controller's own spec-validation `"Valid"` condition (lines 231/240) is unrelated — it validates the VirtualMCPServer spec, not the MCPOIDCConfig condition.

Generated with [Claude Code](https://claude.com/claude-code)