### PR TITLE
Wire MCPOIDCConfig into VirtualMCPServer controller

### DIFF
--- a/cmd/thv-operator/api/v1alpha1/virtualmcpserver_types.go
+++ b/cmd/thv-operator/api/v1alpha1/virtualmcpserver_types.go
@@ -109,9 +109,10 @@ type EmbeddingServerRef struct {
 
 // IncomingAuthConfig configures authentication for clients connecting to the Virtual MCP server
 //
-// +kubebuilder:validation:XValidation:rule="self.type == 'oidc' ? has(self.oidcConfig) : true",message="spec.incomingAuth.oidcConfig is required when type is oidc"
+// +kubebuilder:validation:XValidation:rule="self.type == 'oidc' ? (has(self.oidcConfig) || has(self.oidcConfigRef)) : true",message="spec.incomingAuth.oidcConfig or oidcConfigRef is required when type is oidc"
+// +kubebuilder:validation:XValidation:rule="!(has(self.oidcConfig) && has(self.oidcConfigRef))",message="oidcConfig and oidcConfigRef are mutually exclusive; use oidcConfigRef to reference a shared MCPOIDCConfig"
 //
-//nolint:lll // CEL validation rule exceeds line length limit
+//nolint:lll // CEL validation rules exceed line length limit
 type IncomingAuthConfig struct {
 	// Type defines the authentication type: anonymous or oidc
 	// When no authentication is required, explicitly set this to "anonymous"
@@ -119,10 +120,18 @@ type IncomingAuthConfig struct {
 	// +kubebuilder:validation:Required
 	Type string `json:"type"`
 
-	// OIDCConfig defines OIDC authentication configuration
-	// Reuses MCPServer OIDC patterns
+	// OIDCConfig defines OIDC authentication configuration.
+	// Deprecated: Use OIDCConfigRef to reference a shared MCPOIDCConfig resource instead.
+	// This field will be removed in v1beta1. OIDCConfig and OIDCConfigRef are mutually exclusive.
 	// +optional
 	OIDCConfig *OIDCConfigRef `json:"oidcConfig,omitempty"`
+
+	// OIDCConfigRef references a shared MCPOIDCConfig resource for OIDC authentication.
+	// The referenced MCPOIDCConfig must exist in the same namespace as this VirtualMCPServer.
+	// Per-server overrides (audience, scopes) are specified here; shared provider config
+	// lives in the MCPOIDCConfig resource. Mutually exclusive with oidcConfig.
+	// +optional
+	OIDCConfigRef *MCPOIDCConfigReference `json:"oidcConfigRef,omitempty"`
 
 	// AuthzConfig defines authorization policy configuration
 	// Reuses MCPServer authz patterns
@@ -210,6 +219,11 @@ type VirtualMCPServerStatus struct {
 	// (excludes unavailable, degraded, and unknown backends)
 	// +optional
 	BackendCount int `json:"backendCount,omitempty"`
+
+	// OIDCConfigHash is the hash of the referenced MCPOIDCConfig spec for change detection.
+	// Only populated when IncomingAuth.OIDCConfigRef is set.
+	// +optional
+	OIDCConfigHash string `json:"oidcConfigHash,omitempty"`
 }
 
 // VirtualMCPServerPhase represents the lifecycle phase of a VirtualMCPServer

--- a/cmd/thv-operator/api/v1alpha1/zz_generated.deepcopy.go
+++ b/cmd/thv-operator/api/v1alpha1/zz_generated.deepcopy.go
@@ -625,6 +625,11 @@ func (in *IncomingAuthConfig) DeepCopyInto(out *IncomingAuthConfig) {
 		*out = new(OIDCConfigRef)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.OIDCConfigRef != nil {
+		in, out := &in.OIDCConfigRef, &out.OIDCConfigRef
+		*out = new(MCPOIDCConfigReference)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.AuthzConfig != nil {
 		in, out := &in.AuthzConfig, &out.AuthzConfig
 		*out = new(AuthzConfigRef)

--- a/cmd/thv-operator/controllers/mcpoidcconfig_controller.go
+++ b/cmd/thv-operator/controllers/mcpoidcconfig_controller.go
@@ -46,6 +46,7 @@ type MCPOIDCConfigReconciler struct {
 // +kubebuilder:rbac:groups=toolhive.stacklok.dev,resources=mcpoidcconfigs,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=toolhive.stacklok.dev,resources=mcpoidcconfigs/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=toolhive.stacklok.dev,resources=mcpoidcconfigs/finalizers,verbs=update
+// +kubebuilder:rbac:groups=toolhive.stacklok.dev,resources=virtualmcpservers,verbs=get;list;watch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -199,7 +200,7 @@ func (r *MCPOIDCConfigReconciler) handleDeletion(
 	return ctrl.Result{}, nil
 }
 
-// findReferencingWorkloads returns the workload resources (MCPServer)
+// findReferencingWorkloads returns the workload resources (MCPServer and VirtualMCPServer)
 // that reference this MCPOIDCConfig via their OIDCConfigRef field.
 func (r *MCPOIDCConfigReconciler) findReferencingWorkloads(
 	ctx context.Context,
@@ -216,11 +217,25 @@ func (r *MCPOIDCConfigReconciler) findReferencingWorkloads(
 			refs = append(refs, mcpv1alpha1.WorkloadReference{Kind: "MCPServer", Name: server.Name})
 		}
 	}
+
+	// Check VirtualMCPServers
+	vmcpList := &mcpv1alpha1.VirtualMCPServerList{}
+	if err := r.List(ctx, vmcpList, client.InNamespace(oidcConfig.Namespace)); err != nil {
+		return nil, fmt.Errorf("failed to list VirtualMCPServers: %w", err)
+	}
+	for _, vmcp := range vmcpList.Items {
+		if vmcp.Spec.IncomingAuth != nil &&
+			vmcp.Spec.IncomingAuth.OIDCConfigRef != nil &&
+			vmcp.Spec.IncomingAuth.OIDCConfigRef.Name == oidcConfig.Name {
+			refs = append(refs, mcpv1alpha1.WorkloadReference{Kind: "VirtualMCPServer", Name: vmcp.Name})
+		}
+	}
+
 	return refs, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.
-// Watches MCPServer changes to maintain accurate ReferencingWorkloads status.
+// Watches MCPServer and VirtualMCPServer changes to maintain accurate ReferencingWorkloads status.
 func (r *MCPOIDCConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// Watch MCPServer changes to update ReferencingWorkloads on referenced MCPOIDCConfigs.
 	// This handler enqueues both the currently-referenced MCPOIDCConfig AND any
@@ -274,5 +289,56 @@ func (r *MCPOIDCConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&mcpv1alpha1.MCPOIDCConfig{}).
 		Watches(&mcpv1alpha1.MCPServer{}, mcpServerHandler).
+		Watches(
+			&mcpv1alpha1.VirtualMCPServer{},
+			handler.EnqueueRequestsFromMapFunc(r.mapVirtualMCPServerToOIDCConfig),
+		).
 		Complete(r)
+}
+
+// mapVirtualMCPServerToOIDCConfig maps VirtualMCPServer changes to MCPOIDCConfig reconciliation requests.
+// Enqueues both the currently-referenced config and any config that still lists this
+// VirtualMCPServer in ReferencingWorkloads (handles ref-removal / deletion).
+func (r *MCPOIDCConfigReconciler) mapVirtualMCPServerToOIDCConfig(
+	ctx context.Context, obj client.Object,
+) []reconcile.Request {
+	vmcp, ok := obj.(*mcpv1alpha1.VirtualMCPServer)
+	if !ok {
+		return nil
+	}
+
+	seen := make(map[types.NamespacedName]struct{})
+	var requests []reconcile.Request
+
+	// Enqueue the currently-referenced MCPOIDCConfig (if any)
+	if vmcp.Spec.IncomingAuth != nil && vmcp.Spec.IncomingAuth.OIDCConfigRef != nil {
+		nn := types.NamespacedName{
+			Name:      vmcp.Spec.IncomingAuth.OIDCConfigRef.Name,
+			Namespace: vmcp.Namespace,
+		}
+		seen[nn] = struct{}{}
+		requests = append(requests, reconcile.Request{NamespacedName: nn})
+	}
+
+	// Also enqueue any MCPOIDCConfig that still lists this VirtualMCPServer in
+	// ReferencingWorkloads — handles ref-removal and deletion cases.
+	oidcConfigList := &mcpv1alpha1.MCPOIDCConfigList{}
+	if err := r.List(ctx, oidcConfigList, client.InNamespace(vmcp.Namespace)); err != nil {
+		log.FromContext(ctx).Error(err, "Failed to list MCPOIDCConfigs for VirtualMCPServer watch")
+		return requests
+	}
+	for _, cfg := range oidcConfigList.Items {
+		nn := types.NamespacedName{Name: cfg.Name, Namespace: cfg.Namespace}
+		if _, already := seen[nn]; already {
+			continue
+		}
+		for _, ref := range cfg.Status.ReferencingWorkloads {
+			if ref.Kind == "VirtualMCPServer" && ref.Name == vmcp.Name {
+				requests = append(requests, reconcile.Request{NamespacedName: nn})
+				break
+			}
+		}
+	}
+
+	return requests
 }

--- a/cmd/thv-operator/controllers/virtualmcpserver_controller.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_controller.go
@@ -20,6 +20,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -118,6 +119,8 @@ type VirtualMCPServerReconciler struct {
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=create;get;list;watch
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=create;delete;get;list;patch;update;watch
 // +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=create;delete;get;list;patch;update;watch
+// +kubebuilder:rbac:groups=toolhive.stacklok.dev,resources=mcpoidcconfigs,verbs=get;list;watch
+// +kubebuilder:rbac:groups=toolhive.stacklok.dev,resources=mcpoidcconfigs/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=toolhive.stacklok.dev,resources=embeddingservers,verbs=get;list;watch
 // +kubebuilder:rbac:groups=toolhive.stacklok.dev,resources=embeddingservers/status,verbs=get
 
@@ -149,6 +152,15 @@ func (r *VirtualMCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return ctrl.Result{}, err
 	} else if !cont {
 		return ctrl.Result{}, nil
+	}
+
+	// Validate MCPOIDCConfigRef if referenced (before resource creation).
+	// handleOIDCConfig is a no-op when OIDCConfigRef is nil.
+	if err := r.handleOIDCConfig(ctx, vmcp, statusManager); err != nil {
+		if applyErr := r.applyStatusUpdates(ctx, vmcp, statusManager); applyErr != nil {
+			ctxLogger.Error(applyErr, "Failed to apply status updates after MCPOIDCConfig validation error")
+		}
+		return ctrl.Result{}, err
 	}
 
 	// Ensure all resources
@@ -1268,7 +1280,10 @@ func (r *VirtualMCPServerReconciler) containerNeedsUpdate(
 	}
 
 	// Check if environment variables have changed
-	expectedEnv := r.buildEnvVarsForVmcp(ctx, vmcp, typedWorkloads)
+	expectedEnv, err := r.buildEnvVarsForVmcp(ctx, vmcp, typedWorkloads)
+	if err != nil {
+		return true // Trigger update to surface the error
+	}
 	if !reflect.DeepEqual(container.Env, expectedEnv) {
 		return true
 	}
@@ -2131,6 +2146,12 @@ func (r *VirtualMCPServerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			&mcpv1alpha1.EmbeddingServer{},
 			handler.EnqueueRequestsFromMapFunc(r.mapEmbeddingServerToVirtualMCPServer),
 		).
+		// Watch referenced MCPOIDCConfigs so that validity/hash changes
+		// trigger VirtualMCPServer reconciliation.
+		Watches(
+			&mcpv1alpha1.MCPOIDCConfig{},
+			handler.EnqueueRequestsFromMapFunc(r.mapOIDCConfigToVirtualMCPServer),
+		).
 		Complete(r)
 }
 
@@ -2702,4 +2723,152 @@ func generateHMACSecret() (string, error) {
 
 	// Encode as base64 for safe storage and environment variable use
 	return base64.StdEncoding.EncodeToString(secret), nil
+}
+
+// handleOIDCConfig validates and tracks the hash of the referenced MCPOIDCConfig.
+// It sets the OIDCConfigRefValidated condition and triggers reconciliation when
+// the OIDC configuration changes.
+func (r *VirtualMCPServerReconciler) handleOIDCConfig(
+	ctx context.Context,
+	vmcp *mcpv1alpha1.VirtualMCPServer,
+	statusManager virtualmcpserverstatus.StatusManager,
+) error {
+	ctxLogger := log.FromContext(ctx)
+
+	if vmcp.Spec.IncomingAuth == nil || vmcp.Spec.IncomingAuth.OIDCConfigRef == nil {
+		// No MCPOIDCConfig referenced, clear any stored hash
+		if vmcp.Status.OIDCConfigHash != "" {
+			vmcp.Status.OIDCConfigHash = ""
+			if err := r.Status().Update(ctx, vmcp); err != nil {
+				return fmt.Errorf("failed to clear MCPOIDCConfig hash from status: %w", err)
+			}
+		}
+		return nil
+	}
+
+	ref := vmcp.Spec.IncomingAuth.OIDCConfigRef
+
+	// Get the referenced MCPOIDCConfig
+	oidcConfig, err := ctrlutil.GetOIDCConfigForServer(ctx, r.Client, vmcp.Namespace, ref)
+	if err != nil {
+		statusManager.SetCondition(
+			mcpv1alpha1.ConditionOIDCConfigRefValidated,
+			mcpv1alpha1.ConditionReasonOIDCConfigRefNotFound,
+			fmt.Sprintf("MCPOIDCConfig %s not found: %v", ref.Name, err),
+			metav1.ConditionFalse,
+		)
+		return err
+	}
+
+	if oidcConfig == nil {
+		statusManager.SetCondition(
+			mcpv1alpha1.ConditionOIDCConfigRefValidated,
+			mcpv1alpha1.ConditionReasonOIDCConfigRefNotFound,
+			fmt.Sprintf("MCPOIDCConfig %s not found", ref.Name),
+			metav1.ConditionFalse,
+		)
+		return fmt.Errorf("MCPOIDCConfig %s not found", ref.Name)
+	}
+
+	// Check that the MCPOIDCConfig is valid
+	validCondition := meta.FindStatusCondition(oidcConfig.Status.Conditions, mcpv1alpha1.ConditionTypeOIDCConfigReady)
+	if validCondition == nil || validCondition.Status != metav1.ConditionTrue {
+		msg := fmt.Sprintf("MCPOIDCConfig %s is not valid", ref.Name)
+		if validCondition != nil {
+			msg = fmt.Sprintf("MCPOIDCConfig %s is not valid: %s", ref.Name, validCondition.Message)
+		}
+		statusManager.SetCondition(
+			mcpv1alpha1.ConditionOIDCConfigRefValidated,
+			mcpv1alpha1.ConditionReasonOIDCConfigRefNotValid,
+			msg,
+			metav1.ConditionFalse,
+		)
+		return fmt.Errorf("%s", msg)
+	}
+
+	// Update ReferencingWorkloads on the MCPOIDCConfig status
+	if err := r.updateOIDCConfigReferencingWorkloads(ctx, oidcConfig, vmcp.Name); err != nil {
+		ctxLogger.Error(err, "Failed to update MCPOIDCConfig ReferencingWorkloads")
+		// Non-fatal: continue with reconciliation
+	}
+
+	// Set valid condition
+	statusManager.SetCondition(
+		mcpv1alpha1.ConditionOIDCConfigRefValidated,
+		mcpv1alpha1.ConditionReasonOIDCConfigRefValid,
+		fmt.Sprintf("MCPOIDCConfig %s is valid and ready", ref.Name),
+		metav1.ConditionTrue,
+	)
+
+	// Check if the MCPOIDCConfig hash has changed
+	if vmcp.Status.OIDCConfigHash != oidcConfig.Status.ConfigHash {
+		ctxLogger.Info("MCPOIDCConfig has changed, updating VirtualMCPServer",
+			"vmcp", vmcp.Name,
+			"oidcConfig", oidcConfig.Name,
+			"oldHash", vmcp.Status.OIDCConfigHash,
+			"newHash", oidcConfig.Status.ConfigHash)
+
+		vmcp.Status.OIDCConfigHash = oidcConfig.Status.ConfigHash
+		if err := r.Status().Update(ctx, vmcp); err != nil {
+			return fmt.Errorf("failed to update MCPOIDCConfig hash in status: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// updateOIDCConfigReferencingWorkloads ensures the VirtualMCPServer is listed in
+// the MCPOIDCConfig's ReferencingWorkloads status field.
+func (r *VirtualMCPServerReconciler) updateOIDCConfigReferencingWorkloads(
+	ctx context.Context,
+	oidcConfig *mcpv1alpha1.MCPOIDCConfig,
+	vmcpName string,
+) error {
+	ref := mcpv1alpha1.WorkloadReference{Kind: "VirtualMCPServer", Name: vmcpName}
+	// Check if already listed
+	for _, entry := range oidcConfig.Status.ReferencingWorkloads {
+		if entry.Kind == ref.Kind && entry.Name == ref.Name {
+			return nil
+		}
+	}
+
+	// Add the workload reference
+	oidcConfig.Status.ReferencingWorkloads = append(oidcConfig.Status.ReferencingWorkloads, ref)
+	if err := r.Status().Update(ctx, oidcConfig); err != nil {
+		return fmt.Errorf("failed to update MCPOIDCConfig ReferencingWorkloads: %w", err)
+	}
+
+	return nil
+}
+
+// mapOIDCConfigToVirtualMCPServer maps MCPOIDCConfig changes to VirtualMCPServer reconciliation requests.
+func (r *VirtualMCPServerReconciler) mapOIDCConfigToVirtualMCPServer(
+	ctx context.Context, obj client.Object,
+) []reconcile.Request {
+	oidcConfig, ok := obj.(*mcpv1alpha1.MCPOIDCConfig)
+	if !ok {
+		return nil
+	}
+
+	vmcpList := &mcpv1alpha1.VirtualMCPServerList{}
+	if err := r.List(ctx, vmcpList, client.InNamespace(oidcConfig.Namespace)); err != nil {
+		log.FromContext(ctx).Error(err, "Failed to list VirtualMCPServers for MCPOIDCConfig watch")
+		return nil
+	}
+
+	var requests []reconcile.Request
+	for _, vmcp := range vmcpList.Items {
+		if vmcp.Spec.IncomingAuth != nil &&
+			vmcp.Spec.IncomingAuth.OIDCConfigRef != nil &&
+			vmcp.Spec.IncomingAuth.OIDCConfigRef.Name == oidcConfig.Name {
+			requests = append(requests, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      vmcp.Name,
+					Namespace: vmcp.Namespace,
+				},
+			})
+		}
+	}
+
+	return requests
 }

--- a/cmd/thv-operator/controllers/virtualmcpserver_controller_test.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_controller_test.go
@@ -1687,7 +1687,7 @@ func TestVirtualMCPServerContainerNeedsUpdate(t *testing.T) {
 									Ports: []corev1.ContainerPort{
 										{ContainerPort: 4483},
 									},
-									Env: reconciler.buildEnvVarsForVmcp(context.Background(), vmcp, []workloads.TypedWorkload{}),
+									Env: mustBuildEnvVarsForVmcp(reconciler, vmcp),
 								},
 							},
 							ServiceAccountName: vmcpServiceAccountName(vmcp.Name),
@@ -1711,7 +1711,7 @@ func TestVirtualMCPServerContainerNeedsUpdate(t *testing.T) {
 									Ports: []corev1.ContainerPort{
 										{ContainerPort: 8080},
 									},
-									Env: reconciler.buildEnvVarsForVmcp(context.Background(), vmcp, []workloads.TypedWorkload{}),
+									Env: mustBuildEnvVarsForVmcp(reconciler, vmcp),
 								},
 							},
 							ServiceAccountName: vmcpServiceAccountName(vmcp.Name),
@@ -1762,7 +1762,7 @@ func TestVirtualMCPServerContainerNeedsUpdate(t *testing.T) {
 										{ContainerPort: 4483},
 									},
 									Args: reconciler.buildContainerArgsForVmcp(vmcp),
-									Env:  reconciler.buildEnvVarsForVmcp(context.Background(), vmcp, []workloads.TypedWorkload{}),
+									Env:  mustBuildEnvVarsForVmcp(reconciler, vmcp),
 								},
 							},
 							ServiceAccountName: "wrong-service-account",
@@ -1787,7 +1787,7 @@ func TestVirtualMCPServerContainerNeedsUpdate(t *testing.T) {
 										{ContainerPort: 4483},
 									},
 									Args: []string{"serve", "--config=/etc/vmcp-config/config.yaml", "--host=0.0.0.0", "--port=4483"},
-									Env:  reconciler.buildEnvVarsForVmcp(context.Background(), vmcp, []workloads.TypedWorkload{}),
+									Env:  mustBuildEnvVarsForVmcp(reconciler, vmcp),
 								},
 							},
 							ServiceAccountName: vmcpServiceAccountName(vmcp.Name),
@@ -1825,7 +1825,7 @@ func TestVirtualMCPServerContainerNeedsUpdate(t *testing.T) {
 										{ContainerPort: 4483},
 									},
 									Args: []string{"serve", "--config=/etc/vmcp-config/config.yaml", "--host=0.0.0.0", "--port=4483", "--debug"},
-									Env:  reconciler.buildEnvVarsForVmcp(context.Background(), vmcp, []workloads.TypedWorkload{}),
+									Env:  mustBuildEnvVarsForVmcp(reconciler, vmcp),
 								},
 							},
 							ServiceAccountName: vmcpServiceAccountName(vmcp.Name),
@@ -1850,7 +1850,7 @@ func TestVirtualMCPServerContainerNeedsUpdate(t *testing.T) {
 										{ContainerPort: 4483},
 									},
 									Args: reconciler.buildContainerArgsForVmcp(vmcp),
-									Env:  reconciler.buildEnvVarsForVmcp(context.Background(), vmcp, []workloads.TypedWorkload{}),
+									Env:  mustBuildEnvVarsForVmcp(reconciler, vmcp),
 								},
 							},
 							ServiceAccountName: vmcpServiceAccountName(vmcp.Name),
@@ -2145,7 +2145,7 @@ func TestVirtualMCPServerDeploymentNeedsUpdate(t *testing.T) {
 									Ports: []corev1.ContainerPort{
 										{ContainerPort: 4483},
 									},
-									Env: reconciler.buildEnvVarsForVmcp(context.Background(), vmcp, []workloads.TypedWorkload{}),
+									Env: mustBuildEnvVarsForVmcp(reconciler, vmcp),
 								},
 							},
 							ServiceAccountName: vmcpServiceAccountName(vmcp.Name),
@@ -2178,7 +2178,7 @@ func TestVirtualMCPServerDeploymentNeedsUpdate(t *testing.T) {
 									Ports: []corev1.ContainerPort{
 										{ContainerPort: 4483},
 									},
-									Env: reconciler.buildEnvVarsForVmcp(context.Background(), vmcp, []workloads.TypedWorkload{}),
+									Env: mustBuildEnvVarsForVmcp(reconciler, vmcp),
 								},
 							},
 							ServiceAccountName: vmcpServiceAccountName(vmcp.Name),
@@ -2210,7 +2210,7 @@ func TestVirtualMCPServerDeploymentNeedsUpdate(t *testing.T) {
 										{ContainerPort: 4483},
 									},
 									Args: reconciler.buildContainerArgsForVmcp(vmcp),
-									Env:  reconciler.buildEnvVarsForVmcp(context.Background(), vmcp, []workloads.TypedWorkload{}),
+									Env:  mustBuildEnvVarsForVmcp(reconciler, vmcp),
 								},
 							},
 							ServiceAccountName: vmcpServiceAccountName(vmcp.Name),
@@ -2242,7 +2242,7 @@ func TestVirtualMCPServerDeploymentNeedsUpdate(t *testing.T) {
 										{ContainerPort: 4483},
 									},
 									Args: reconciler.buildContainerArgsForVmcp(vmcp),
-									Env:  reconciler.buildEnvVarsForVmcp(context.Background(), vmcp, []workloads.TypedWorkload{}),
+									Env:  mustBuildEnvVarsForVmcp(reconciler, vmcp),
 								},
 							},
 							ServiceAccountName: vmcpServiceAccountName(vmcp.Name),
@@ -2790,7 +2790,7 @@ func TestVirtualMCPServerEnsureDeployment_NoUpdateNeeded(t *testing.T) {
 							Ports: []corev1.ContainerPort{
 								{ContainerPort: 4483},
 							},
-							Env: reconciler.buildEnvVarsForVmcp(context.Background(), vmcp, []workloads.TypedWorkload{}),
+							Env: mustBuildEnvVarsForVmcp(reconciler, vmcp),
 						},
 					},
 					ServiceAccountName: vmcpServiceAccountName(vmcp.Name),
@@ -3306,4 +3306,14 @@ func TestVirtualMCPServerEnsureDeployment_ReplicaSync_NilPassthrough(t *testing.
 	// HPA-managed replica count must not be overwritten
 	require.NotNil(t, updated.Spec.Replicas)
 	assert.Equal(t, int32(5), *updated.Spec.Replicas)
+}
+
+// mustBuildEnvVarsForVmcp is a test helper that calls buildEnvVarsForVmcp and panics on error.
+// All test VirtualMCPServers use anonymous auth (no OIDCConfigRef), so the error path is unreachable.
+func mustBuildEnvVarsForVmcp(r *VirtualMCPServerReconciler, vmcp *mcpv1alpha1.VirtualMCPServer) []corev1.EnvVar {
+	env, err := r.buildEnvVarsForVmcp(context.Background(), vmcp, []workloads.TypedWorkload{})
+	if err != nil {
+		panic("mustBuildEnvVarsForVmcp: " + err.Error())
+	}
+	return env
 }

--- a/cmd/thv-operator/controllers/virtualmcpserver_deployment.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_deployment.go
@@ -124,8 +124,16 @@ func (r *VirtualMCPServerReconciler) deploymentForVirtualMCPServer(
 
 	// Build deployment components using helper functions
 	args := r.buildContainerArgsForVmcp(vmcp)
-	volumeMounts, volumes := r.buildVolumesForVmcp(vmcp)
-	env := r.buildEnvVarsForVmcp(ctx, vmcp, typedWorkloads)
+	volumeMounts, volumes, err := r.buildVolumesForVmcp(ctx, vmcp)
+	if err != nil {
+		log.FromContext(ctx).Error(err, "Failed to build volumes for VirtualMCPServer")
+		return nil
+	}
+	env, err := r.buildEnvVarsForVmcp(ctx, vmcp, typedWorkloads)
+	if err != nil {
+		log.FromContext(ctx).Error(err, "Failed to build env vars for VirtualMCPServer")
+		return nil
+	}
 
 	// Add embedded auth server volumes and env vars if configured (inline config)
 	if vmcp.Spec.AuthServerConfig != nil {
@@ -235,9 +243,10 @@ func (*VirtualMCPServerReconciler) buildContainerArgsForVmcp(
 }
 
 // buildVolumesForVmcp builds volumes and volume mounts for vmcp
-func (*VirtualMCPServerReconciler) buildVolumesForVmcp(
+func (r *VirtualMCPServerReconciler) buildVolumesForVmcp(
+	ctx context.Context,
 	vmcp *mcpv1alpha1.VirtualMCPServer,
-) ([]corev1.VolumeMount, []corev1.Volume) {
+) ([]corev1.VolumeMount, []corev1.Volume, error) {
 	volumeMounts := []corev1.VolumeMount{}
 	volumes := []corev1.Volume{}
 
@@ -260,9 +269,30 @@ func (*VirtualMCPServerReconciler) buildVolumesForVmcp(
 		},
 	})
 
+	// Add OIDC CA bundle volume if configured
+	if vmcp.Spec.IncomingAuth != nil {
+		if vmcp.Spec.IncomingAuth.OIDCConfig != nil {
+			caVolumes, caMounts := ctrlutil.AddOIDCCABundleVolumes(vmcp.Spec.IncomingAuth.OIDCConfig)
+			volumes = append(volumes, caVolumes...)
+			volumeMounts = append(volumeMounts, caMounts...)
+		} else if vmcp.Spec.IncomingAuth.OIDCConfigRef != nil {
+			oidcCfg, err := ctrlutil.GetOIDCConfigForServer(
+				ctx, r.Client, vmcp.Namespace, vmcp.Spec.IncomingAuth.OIDCConfigRef)
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to get MCPOIDCConfig %s for CA bundle: %w",
+					vmcp.Spec.IncomingAuth.OIDCConfigRef.Name, err)
+			}
+			if oidcCfg != nil {
+				caVolumes, caMounts := ctrlutil.AddOIDCConfigRefCABundleVolumes(oidcCfg)
+				volumes = append(volumes, caVolumes...)
+				volumeMounts = append(volumeMounts, caMounts...)
+			}
+		}
+	}
+
 	// TODO: Add volumes for composite tool definitions from VirtualMCPCompositeToolDefinition refs
 
-	return volumeMounts, volumes
+	return volumeMounts, volumes, nil
 }
 
 // buildEnvVarsForVmcp builds environment variables for the vmcp container
@@ -270,7 +300,7 @@ func (r *VirtualMCPServerReconciler) buildEnvVarsForVmcp(
 	ctx context.Context,
 	vmcp *mcpv1alpha1.VirtualMCPServer,
 	typedWorkloads []workloads.TypedWorkload,
-) []corev1.EnvVar {
+) ([]corev1.EnvVar, error) {
 	env := []corev1.EnvVar{}
 
 	// Add basic environment variables
@@ -285,7 +315,11 @@ func (r *VirtualMCPServerReconciler) buildEnvVarsForVmcp(
 	})
 
 	// Mount OIDC client secret
-	env = append(env, r.buildOIDCEnvVars(vmcp)...)
+	oidcEnv, err := r.buildOIDCEnvVars(ctx, vmcp)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build OIDC env vars: %w", err)
+	}
+	env = append(env, oidcEnv...)
 
 	// Mount outgoing auth secrets
 	env = append(env, r.buildOutgoingAuthEnvVars(ctx, vmcp, typedWorkloads)...)
@@ -296,22 +330,24 @@ func (r *VirtualMCPServerReconciler) buildEnvVarsForVmcp(
 	// Mount Redis password secret when session storage provider is Redis.
 	env = append(env, r.buildRedisPasswordEnvVar(vmcp)...)
 
-	return ctrlutil.EnsureRequiredEnvVars(ctx, env)
+	return ctrlutil.EnsureRequiredEnvVars(ctx, env), nil
 }
 
 // buildOIDCEnvVars builds environment variables for OIDC client secret mounting.
-func (*VirtualMCPServerReconciler) buildOIDCEnvVars(vmcp *mcpv1alpha1.VirtualMCPServer) []corev1.EnvVar {
+func (r *VirtualMCPServerReconciler) buildOIDCEnvVars(
+	ctx context.Context, vmcp *mcpv1alpha1.VirtualMCPServer,
+) ([]corev1.EnvVar, error) {
 	var env []corev1.EnvVar
 
-	if vmcp.Spec.IncomingAuth == nil ||
-		vmcp.Spec.IncomingAuth.OIDCConfig == nil ||
-		vmcp.Spec.IncomingAuth.OIDCConfig.Inline == nil {
-		return env
+	if vmcp.Spec.IncomingAuth == nil {
+		return env, nil
 	}
 
-	inline := vmcp.Spec.IncomingAuth.OIDCConfig.Inline
-
-	if inline.ClientSecretRef != nil {
+	// Legacy path: inline OIDCConfig client secret
+	if vmcp.Spec.IncomingAuth.OIDCConfig != nil &&
+		vmcp.Spec.IncomingAuth.OIDCConfig.Inline != nil &&
+		vmcp.Spec.IncomingAuth.OIDCConfig.Inline.ClientSecretRef != nil {
+		inline := vmcp.Spec.IncomingAuth.OIDCConfig.Inline
 		env = append(env, corev1.EnvVar{
 			Name: "VMCP_OIDC_CLIENT_SECRET",
 			ValueFrom: &corev1.EnvVarSource{
@@ -325,7 +361,33 @@ func (*VirtualMCPServerReconciler) buildOIDCEnvVars(vmcp *mcpv1alpha1.VirtualMCP
 		})
 	}
 
-	return env
+	// New path: MCPOIDCConfig inline client secret
+	if vmcp.Spec.IncomingAuth.OIDCConfigRef != nil {
+		oidcCfg, err := ctrlutil.GetOIDCConfigForServer(
+			ctx, r.Client, vmcp.Namespace, vmcp.Spec.IncomingAuth.OIDCConfigRef)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get MCPOIDCConfig %s for client secret: %w",
+				vmcp.Spec.IncomingAuth.OIDCConfigRef.Name, err)
+		}
+		if oidcCfg != nil &&
+			oidcCfg.Spec.Type == mcpv1alpha1.MCPOIDCConfigTypeInline &&
+			oidcCfg.Spec.Inline != nil &&
+			oidcCfg.Spec.Inline.ClientSecretRef != nil {
+			env = append(env, corev1.EnvVar{
+				Name: "VMCP_OIDC_CLIENT_SECRET",
+				ValueFrom: &corev1.EnvVarSource{
+					SecretKeyRef: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: oidcCfg.Spec.Inline.ClientSecretRef.Name,
+						},
+						Key: oidcCfg.Spec.Inline.ClientSecretRef.Key,
+					},
+				},
+			})
+		}
+	}
+
+	return env, nil
 }
 
 // buildHMACSecretEnvVar builds environment variable for HMAC secret mounting.
@@ -741,7 +803,7 @@ func (r *VirtualMCPServerReconciler) validateSecretReferences(
 	ctx context.Context,
 	vmcp *mcpv1alpha1.VirtualMCPServer,
 ) error {
-	// Validate OIDC client secret if configured
+	// Validate OIDC client secret if configured (legacy inline path)
 	if vmcp.Spec.IncomingAuth != nil &&
 		vmcp.Spec.IncomingAuth.OIDCConfig != nil &&
 		vmcp.Spec.IncomingAuth.OIDCConfig.Inline != nil &&
@@ -750,6 +812,26 @@ func (r *VirtualMCPServerReconciler) validateSecretReferences(
 			vmcp.Spec.IncomingAuth.OIDCConfig.Inline.ClientSecretRef,
 			"OIDC client secret"); err != nil {
 			return err
+		}
+	}
+
+	// Validate MCPOIDCConfig inline client secret if configured
+	if vmcp.Spec.IncomingAuth != nil && vmcp.Spec.IncomingAuth.OIDCConfigRef != nil {
+		oidcCfg, err := ctrlutil.GetOIDCConfigForServer(
+			ctx, r.Client, vmcp.Namespace, vmcp.Spec.IncomingAuth.OIDCConfigRef)
+		if err != nil {
+			return fmt.Errorf("failed to get MCPOIDCConfig %s for secret validation: %w",
+				vmcp.Spec.IncomingAuth.OIDCConfigRef.Name, err)
+		}
+		if oidcCfg != nil &&
+			oidcCfg.Spec.Type == mcpv1alpha1.MCPOIDCConfigTypeInline &&
+			oidcCfg.Spec.Inline != nil &&
+			oidcCfg.Spec.Inline.ClientSecretRef != nil {
+			if err := r.validateSecretKeyRef(ctx, vmcp.Namespace,
+				oidcCfg.Spec.Inline.ClientSecretRef,
+				"MCPOIDCConfig OIDC client secret"); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/cmd/thv-operator/controllers/virtualmcpserver_deployment_test.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_deployment_test.go
@@ -206,7 +206,8 @@ func TestBuildVolumesForVmcp(t *testing.T) {
 	}
 
 	r := &VirtualMCPServerReconciler{}
-	volumeMounts, volumes := r.buildVolumesForVmcp(vmcp)
+	volumeMounts, volumes, err := r.buildVolumesForVmcp(context.Background(), vmcp)
+	require.NoError(t, err)
 
 	// Verify vmcp config volume
 	require.Len(t, volumeMounts, 1)
@@ -235,7 +236,8 @@ func TestBuildEnvVarsForVmcp(t *testing.T) {
 	}
 
 	r := &VirtualMCPServerReconciler{}
-	env := r.buildEnvVarsForVmcp(context.Background(), vmcp, []workloads.TypedWorkload{})
+	env, err := r.buildEnvVarsForVmcp(context.Background(), vmcp, []workloads.TypedWorkload{})
+	require.NoError(t, err)
 
 	// Should have VMCP_NAME and VMCP_NAMESPACE
 	foundName := false

--- a/cmd/thv-operator/pkg/vmcpconfig/converter.go
+++ b/cmd/thv-operator/pkg/vmcpconfig/converter.go
@@ -177,8 +177,31 @@ func (c *Converter) convertIncomingAuth(
 		Type: vmcp.Spec.IncomingAuth.Type,
 	}
 
-	// Convert OIDC configuration if present
-	if vmcp.Spec.IncomingAuth.OIDCConfig != nil {
+	// Convert OIDC configuration if present.
+	// New path: resolve from MCPOIDCConfig reference (preferred over legacy inline OIDCConfig)
+	if vmcp.Spec.IncomingAuth.OIDCConfigRef != nil {
+		oidcCfg, err := controllerutil.GetOIDCConfigForServer(
+			ctx, c.k8sClient, vmcp.Namespace, vmcp.Spec.IncomingAuth.OIDCConfigRef)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get MCPOIDCConfig %s: %w",
+				vmcp.Spec.IncomingAuth.OIDCConfigRef.Name, err)
+		}
+		resolvedConfig, err := c.oidcResolver.ResolveFromConfigRef(
+			ctx, vmcp.Spec.IncomingAuth.OIDCConfigRef, oidcCfg,
+			vmcp.Name, vmcp.Namespace, vmcp.GetProxyPort())
+		if err != nil {
+			ctxLogger.Error(err, "failed to resolve OIDC config from MCPOIDCConfig",
+				"vmcp", vmcp.Name,
+				"namespace", vmcp.Namespace,
+				"oidcConfigRef", vmcp.Spec.IncomingAuth.OIDCConfigRef.Name)
+			return nil, fmt.Errorf("OIDC resolution failed from MCPOIDCConfig %q: %w",
+				vmcp.Spec.IncomingAuth.OIDCConfigRef.Name, err)
+		}
+		if resolvedConfig != nil {
+			incoming.OIDC = mapResolvedOIDCToVmcpConfigFromRef(resolvedConfig, oidcCfg)
+		}
+	} else if vmcp.Spec.IncomingAuth.OIDCConfig != nil {
+		// Legacy path: resolve from inline OIDCConfig
 		// Use the OIDC resolver to handle all OIDC types (kubernetes, configMap, inline)
 		// VirtualMCPServer implements OIDCConfigurable, so the resolver can work with it directly
 		resolvedConfig, err := c.oidcResolver.Resolve(ctx, vmcp)
@@ -259,6 +282,38 @@ func mapResolvedOIDCToVmcpConfig(
 			}
 			// OIDCConfigTypeKubernetes does not use client secrets (uses service account tokens)
 		}
+	}
+
+	return config
+}
+
+// mapResolvedOIDCToVmcpConfigFromRef maps from oidc.OIDCConfig (resolved by the OIDC resolver)
+// to vmcpconfig.OIDCConfig when using an MCPOIDCConfig reference.
+// Client secret detection uses the MCPOIDCConfig's inline config rather than OIDCConfigRef.
+func mapResolvedOIDCToVmcpConfigFromRef(
+	resolved *oidc.OIDCConfig,
+	oidcCfg *mcpv1alpha1.MCPOIDCConfig,
+) *vmcpconfig.OIDCConfig {
+	if resolved == nil {
+		return nil
+	}
+
+	config := &vmcpconfig.OIDCConfig{
+		Issuer:                          resolved.Issuer,
+		ClientID:                        resolved.ClientID,
+		Audience:                        resolved.Audience,
+		Resource:                        resolved.ResourceURL,
+		ProtectedResourceAllowPrivateIP: resolved.JWKSAllowPrivateIP,
+		InsecureAllowHTTP:               resolved.InsecureAllowHTTP,
+		Scopes:                          resolved.Scopes,
+	}
+
+	// MCPOIDCConfig inline type may have a client secret
+	if oidcCfg != nil &&
+		oidcCfg.Spec.Type == mcpv1alpha1.MCPOIDCConfigTypeInline &&
+		oidcCfg.Spec.Inline != nil &&
+		oidcCfg.Spec.Inline.ClientSecretRef != nil {
+		config.ClientSecretEnv = vmcpOIDCClientSecretEnvVar
 	}
 
 	return config

--- a/cmd/thv-operator/test-integration/mcp-oidc-config/mcpoidcconfig_virtualmcpserver_integration_test.go
+++ b/cmd/thv-operator/test-integration/mcp-oidc-config/mcpoidcconfig_virtualmcpserver_integration_test.go
@@ -1,0 +1,697 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package controllers
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	mcpv1alpha1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1alpha1"
+	vmcpconfig "github.com/stacklok/toolhive/pkg/vmcp/config"
+)
+
+const (
+	testVMCPServerName = "test-vmcp-server"
+	testVMCPGroupName  = "test-vmcp-group"
+)
+
+var _ = Describe("MCPOIDCConfig and VirtualMCPServer Cross-Resource Integration Tests", func() {
+	Context("When VirtualMCPServer references an MCPOIDCConfig", Ordered, func() {
+		var (
+			namespace  string
+			configName string
+			vmcpName   string
+			groupName  string
+			oidcConfig *mcpv1alpha1.MCPOIDCConfig
+			vmcpServer *mcpv1alpha1.VirtualMCPServer
+			mcpGroup   *mcpv1alpha1.MCPGroup
+			ns         *corev1.Namespace
+		)
+
+		BeforeAll(func() {
+			// Create a unique namespace for this test context
+			ns = &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-vmcp-oidcref-",
+				},
+			}
+			Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
+			namespace = ns.Name
+
+			configName = testOIDCConfigName
+			vmcpName = testVMCPServerName
+			groupName = testVMCPGroupName
+
+			// Create MCPGroup (required by VirtualMCPServer)
+			mcpGroup = &mcpv1alpha1.MCPGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      groupName,
+					Namespace: namespace,
+				},
+			}
+			Expect(k8sClient.Create(ctx, mcpGroup)).Should(Succeed())
+
+			// Create MCPOIDCConfig
+			oidcConfig = &mcpv1alpha1.MCPOIDCConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      configName,
+					Namespace: namespace,
+				},
+				Spec: mcpv1alpha1.MCPOIDCConfigSpec{
+					Type: mcpv1alpha1.MCPOIDCConfigTypeInline,
+					Inline: &mcpv1alpha1.InlineOIDCSharedConfig{
+						Issuer:   "https://accounts.google.com",
+						ClientID: "test-client",
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, oidcConfig)).Should(Succeed())
+
+			// Wait for Valid condition and ConfigHash to be set
+			Eventually(func() bool {
+				updated := &mcpv1alpha1.MCPOIDCConfig{}
+				err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      configName,
+					Namespace: namespace,
+				}, updated)
+				if err != nil {
+					return false
+				}
+				if updated.Status.ConfigHash == "" {
+					return false
+				}
+				for _, cond := range updated.Status.Conditions {
+					if cond.Type == mcpv1alpha1.ConditionTypeOIDCConfigReady && cond.Status == metav1.ConditionTrue {
+						return true
+					}
+				}
+				return false
+			}, timeout, interval).Should(BeTrue())
+
+			// Create VirtualMCPServer with OIDCConfigRef
+			vmcpServer = &mcpv1alpha1.VirtualMCPServer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      vmcpName,
+					Namespace: namespace,
+				},
+				Spec: mcpv1alpha1.VirtualMCPServerSpec{
+					Config: vmcpconfig.Config{Group: groupName},
+					IncomingAuth: &mcpv1alpha1.IncomingAuthConfig{
+						Type: "oidc",
+						OIDCConfigRef: &mcpv1alpha1.MCPOIDCConfigReference{
+							Name:     configName,
+							Audience: "test-vmcp-audience",
+							Scopes:   []string{"openid"},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, vmcpServer)).Should(Succeed())
+		})
+
+		AfterAll(func() {
+			// Ignore errors on cleanup since some tests may have already deleted these
+			_ = k8sClient.Delete(ctx, vmcpServer)
+			_ = k8sClient.Delete(ctx, oidcConfig)
+			_ = k8sClient.Delete(ctx, mcpGroup)
+			Expect(k8sClient.Delete(ctx, ns)).Should(Succeed())
+		})
+
+		It("should set OIDCConfigRefValidated condition to True", func() {
+			Eventually(func() bool {
+				updated := &mcpv1alpha1.VirtualMCPServer{}
+				err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      vmcpName,
+					Namespace: namespace,
+				}, updated)
+				if err != nil {
+					return false
+				}
+				condition := meta.FindStatusCondition(updated.Status.Conditions, mcpv1alpha1.ConditionOIDCConfigRefValidated)
+				if condition == nil {
+					return false
+				}
+				return condition.Status == metav1.ConditionTrue
+			}, timeout, interval).Should(BeTrue())
+		})
+
+		It("should set OIDCConfigHash in VirtualMCPServer status", func() {
+			Eventually(func() bool {
+				updated := &mcpv1alpha1.VirtualMCPServer{}
+				err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      vmcpName,
+					Namespace: namespace,
+				}, updated)
+				if err != nil {
+					return false
+				}
+				return updated.Status.OIDCConfigHash != ""
+			}, timeout, interval).Should(BeTrue())
+		})
+
+		It("should track VirtualMCPServer in MCPOIDCConfig ReferencingWorkloads", func() {
+			Eventually(func() bool {
+				updated := &mcpv1alpha1.MCPOIDCConfig{}
+				err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      configName,
+					Namespace: namespace,
+				}, updated)
+				if err != nil {
+					return false
+				}
+				expectedRef := mcpv1alpha1.WorkloadReference{Kind: "VirtualMCPServer", Name: vmcpName}
+				for _, ref := range updated.Status.ReferencingWorkloads {
+					if ref == expectedRef {
+						return true
+					}
+				}
+				return false
+			}, timeout, interval).Should(BeTrue())
+		})
+	})
+
+	Context("When VirtualMCPServer is deleted, should clean up ReferencingWorkloads", Ordered, func() {
+		var (
+			namespace  string
+			configName string
+			vmcpName   string
+			groupName  string
+			oidcConfig *mcpv1alpha1.MCPOIDCConfig
+			vmcpServer *mcpv1alpha1.VirtualMCPServer
+			mcpGroup   *mcpv1alpha1.MCPGroup
+			ns         *corev1.Namespace
+		)
+
+		BeforeAll(func() {
+			// Create a unique namespace for this test context
+			ns = &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-vmcp-oidcref-cleanup-",
+				},
+			}
+			Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
+			namespace = ns.Name
+
+			configName = testOIDCConfigName
+			vmcpName = testVMCPServerName
+			groupName = testVMCPGroupName
+
+			// Create MCPGroup (required by VirtualMCPServer)
+			mcpGroup = &mcpv1alpha1.MCPGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      groupName,
+					Namespace: namespace,
+				},
+			}
+			Expect(k8sClient.Create(ctx, mcpGroup)).Should(Succeed())
+
+			// Create MCPOIDCConfig
+			oidcConfig = &mcpv1alpha1.MCPOIDCConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      configName,
+					Namespace: namespace,
+				},
+				Spec: mcpv1alpha1.MCPOIDCConfigSpec{
+					Type: mcpv1alpha1.MCPOIDCConfigTypeInline,
+					Inline: &mcpv1alpha1.InlineOIDCSharedConfig{
+						Issuer:   "https://accounts.google.com",
+						ClientID: "test-client",
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, oidcConfig)).Should(Succeed())
+
+			// Wait for ready
+			Eventually(func() bool {
+				updated := &mcpv1alpha1.MCPOIDCConfig{}
+				err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      configName,
+					Namespace: namespace,
+				}, updated)
+				if err != nil {
+					return false
+				}
+				return updated.Status.ConfigHash != ""
+			}, timeout, interval).Should(BeTrue())
+
+			// Create VirtualMCPServer with OIDCConfigRef
+			vmcpServer = &mcpv1alpha1.VirtualMCPServer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      vmcpName,
+					Namespace: namespace,
+				},
+				Spec: mcpv1alpha1.VirtualMCPServerSpec{
+					Config: vmcpconfig.Config{Group: groupName},
+					IncomingAuth: &mcpv1alpha1.IncomingAuthConfig{
+						Type: "oidc",
+						OIDCConfigRef: &mcpv1alpha1.MCPOIDCConfigReference{
+							Name:     configName,
+							Audience: "test-vmcp-audience",
+							Scopes:   []string{"openid"},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, vmcpServer)).Should(Succeed())
+
+			// Wait for ReferencingWorkloads to contain the VirtualMCPServer
+			Eventually(func() bool {
+				updated := &mcpv1alpha1.MCPOIDCConfig{}
+				err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      configName,
+					Namespace: namespace,
+				}, updated)
+				if err != nil {
+					return false
+				}
+				expectedRef := mcpv1alpha1.WorkloadReference{Kind: "VirtualMCPServer", Name: vmcpName}
+				for _, ref := range updated.Status.ReferencingWorkloads {
+					if ref == expectedRef {
+						return true
+					}
+				}
+				return false
+			}, timeout, interval).Should(BeTrue())
+		})
+
+		AfterAll(func() {
+			_ = k8sClient.Delete(ctx, oidcConfig)
+			_ = k8sClient.Delete(ctx, mcpGroup)
+			Expect(k8sClient.Delete(ctx, ns)).Should(Succeed())
+		})
+
+		It("should remove VirtualMCPServer from ReferencingWorkloads after deletion", func() {
+			// Delete the VirtualMCPServer
+			Expect(k8sClient.Delete(ctx, vmcpServer)).Should(Succeed())
+
+			// Eventually the referencing workloads list should not contain the vmcp entry
+			Eventually(func() bool {
+				updated := &mcpv1alpha1.MCPOIDCConfig{}
+				err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      configName,
+					Namespace: namespace,
+				}, updated)
+				if err != nil {
+					return false
+				}
+				expectedRef := mcpv1alpha1.WorkloadReference{Kind: "VirtualMCPServer", Name: vmcpName}
+				for _, ref := range updated.Status.ReferencingWorkloads {
+					if ref == expectedRef {
+						return false
+					}
+				}
+				return true
+			}, timeout, interval).Should(BeTrue())
+		})
+	})
+
+	Context("When deleting MCPOIDCConfig with active VirtualMCPServer references", Ordered, func() {
+		var (
+			namespace  string
+			configName string
+			vmcpName   string
+			groupName  string
+			oidcConfig *mcpv1alpha1.MCPOIDCConfig
+			vmcpServer *mcpv1alpha1.VirtualMCPServer
+			mcpGroup   *mcpv1alpha1.MCPGroup
+			ns         *corev1.Namespace
+		)
+
+		BeforeAll(func() {
+			// Create a unique namespace for this test context
+			ns = &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-vmcp-oidcref-delete-",
+				},
+			}
+			Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
+			namespace = ns.Name
+
+			configName = testOIDCConfigName
+			vmcpName = testVMCPServerName
+			groupName = testVMCPGroupName
+
+			// Create MCPGroup (required by VirtualMCPServer)
+			mcpGroup = &mcpv1alpha1.MCPGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      groupName,
+					Namespace: namespace,
+				},
+			}
+			Expect(k8sClient.Create(ctx, mcpGroup)).Should(Succeed())
+
+			// Create MCPOIDCConfig
+			oidcConfig = &mcpv1alpha1.MCPOIDCConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      configName,
+					Namespace: namespace,
+				},
+				Spec: mcpv1alpha1.MCPOIDCConfigSpec{
+					Type: mcpv1alpha1.MCPOIDCConfigTypeInline,
+					Inline: &mcpv1alpha1.InlineOIDCSharedConfig{
+						Issuer:   "https://accounts.google.com",
+						ClientID: "test-client",
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, oidcConfig)).Should(Succeed())
+
+			// Wait for ready
+			Eventually(func() bool {
+				updated := &mcpv1alpha1.MCPOIDCConfig{}
+				err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      configName,
+					Namespace: namespace,
+				}, updated)
+				if err != nil {
+					return false
+				}
+				return updated.Status.ConfigHash != ""
+			}, timeout, interval).Should(BeTrue())
+
+			// Create VirtualMCPServer with OIDCConfigRef
+			vmcpServer = &mcpv1alpha1.VirtualMCPServer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      vmcpName,
+					Namespace: namespace,
+				},
+				Spec: mcpv1alpha1.VirtualMCPServerSpec{
+					Config: vmcpconfig.Config{Group: groupName},
+					IncomingAuth: &mcpv1alpha1.IncomingAuthConfig{
+						Type: "oidc",
+						OIDCConfigRef: &mcpv1alpha1.MCPOIDCConfigReference{
+							Name:     configName,
+							Audience: "test-vmcp-audience",
+							Scopes:   []string{"openid"},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, vmcpServer)).Should(Succeed())
+
+			// Wait for ReferencingWorkloads to be populated
+			Eventually(func() bool {
+				updated := &mcpv1alpha1.MCPOIDCConfig{}
+				err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      configName,
+					Namespace: namespace,
+				}, updated)
+				if err != nil {
+					return false
+				}
+				expectedRef := mcpv1alpha1.WorkloadReference{Kind: "VirtualMCPServer", Name: vmcpName}
+				for _, ref := range updated.Status.ReferencingWorkloads {
+					if ref == expectedRef {
+						return true
+					}
+				}
+				return false
+			}, timeout, interval).Should(BeTrue())
+
+			// Attempt to delete the MCPOIDCConfig (should be blocked by finalizer)
+			Expect(k8sClient.Delete(ctx, oidcConfig)).Should(Succeed())
+		})
+
+		AfterAll(func() {
+			// Cleanup: delete the VirtualMCPServer first to unblock the finalizer,
+			// then wait for the MCPOIDCConfig to be fully deleted, then delete the namespace.
+			_ = k8sClient.Delete(ctx, vmcpServer)
+
+			// Wait for MCPOIDCConfig to be fully removed
+			Eventually(func() bool {
+				updated := &mcpv1alpha1.MCPOIDCConfig{}
+				err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      configName,
+					Namespace: namespace,
+				}, updated)
+				return errors.IsNotFound(err)
+			}, timeout, interval).Should(BeTrue())
+
+			_ = k8sClient.Delete(ctx, mcpGroup)
+			Expect(k8sClient.Delete(ctx, ns)).Should(Succeed())
+		})
+
+		It("should not be deleted while referenced by VirtualMCPServer", func() {
+			// The object should still exist because the finalizer blocks deletion
+			Eventually(func() bool {
+				updated := &mcpv1alpha1.MCPOIDCConfig{}
+				err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      configName,
+					Namespace: namespace,
+				}, updated)
+				if err != nil {
+					return false
+				}
+				return !updated.DeletionTimestamp.IsZero()
+			}, timeout, interval).Should(BeTrue())
+		})
+
+		It("should be deleted after VirtualMCPServer reference is removed", func() {
+			// Delete the VirtualMCPServer to remove the reference
+			Expect(k8sClient.Delete(ctx, vmcpServer)).Should(Succeed())
+
+			// The MCPOIDCConfig should eventually be fully deleted
+			Eventually(func() bool {
+				updated := &mcpv1alpha1.MCPOIDCConfig{}
+				err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      configName,
+					Namespace: namespace,
+				}, updated)
+				return errors.IsNotFound(err)
+			}, timeout, interval).Should(BeTrue())
+		})
+	})
+
+	Context("When VirtualMCPServer references non-existent MCPOIDCConfig", Ordered, func() {
+		var (
+			namespace  string
+			vmcpName   string
+			groupName  string
+			vmcpServer *mcpv1alpha1.VirtualMCPServer
+			mcpGroup   *mcpv1alpha1.MCPGroup
+			ns         *corev1.Namespace
+		)
+
+		BeforeAll(func() {
+			// Create a unique namespace for this test context
+			ns = &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-vmcp-oidcref-missing-",
+				},
+			}
+			Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
+			namespace = ns.Name
+
+			vmcpName = testVMCPServerName
+			groupName = testVMCPGroupName
+
+			// Create MCPGroup (required by VirtualMCPServer)
+			mcpGroup = &mcpv1alpha1.MCPGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      groupName,
+					Namespace: namespace,
+				},
+			}
+			Expect(k8sClient.Create(ctx, mcpGroup)).Should(Succeed())
+
+			// Create VirtualMCPServer with OIDCConfigRef pointing to a non-existent config
+			vmcpServer = &mcpv1alpha1.VirtualMCPServer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      vmcpName,
+					Namespace: namespace,
+				},
+				Spec: mcpv1alpha1.VirtualMCPServerSpec{
+					Config: vmcpconfig.Config{Group: groupName},
+					IncomingAuth: &mcpv1alpha1.IncomingAuthConfig{
+						Type: "oidc",
+						OIDCConfigRef: &mcpv1alpha1.MCPOIDCConfigReference{
+							Name:     "does-not-exist",
+							Audience: "test-vmcp-audience",
+							Scopes:   []string{"openid"},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, vmcpServer)).Should(Succeed())
+		})
+
+		AfterAll(func() {
+			_ = k8sClient.Delete(ctx, vmcpServer)
+			_ = k8sClient.Delete(ctx, mcpGroup)
+			Expect(k8sClient.Delete(ctx, ns)).Should(Succeed())
+		})
+
+		It("should set OIDCConfigRefValidated condition to False with NotFound reason", func() {
+			Eventually(func() bool {
+				updated := &mcpv1alpha1.VirtualMCPServer{}
+				err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      vmcpName,
+					Namespace: namespace,
+				}, updated)
+				if err != nil {
+					return false
+				}
+				condition := meta.FindStatusCondition(updated.Status.Conditions, mcpv1alpha1.ConditionOIDCConfigRefValidated)
+				if condition == nil {
+					return false
+				}
+				return condition.Status == metav1.ConditionFalse &&
+					condition.Reason == mcpv1alpha1.ConditionReasonOIDCConfigRefNotFound
+			}, timeout, interval).Should(BeTrue())
+		})
+	})
+
+	Context("When both MCPServer and VirtualMCPServer reference same MCPOIDCConfig", Ordered, func() {
+		var (
+			namespace  string
+			configName string
+			serverName string
+			vmcpName   string
+			groupName  string
+			oidcConfig *mcpv1alpha1.MCPOIDCConfig
+			mcpServer  *mcpv1alpha1.MCPServer
+			vmcpServer *mcpv1alpha1.VirtualMCPServer
+			mcpGroup   *mcpv1alpha1.MCPGroup
+			ns         *corev1.Namespace
+		)
+
+		BeforeAll(func() {
+			// Create a unique namespace for this test context
+			ns = &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-vmcp-oidcref-both-",
+				},
+			}
+			Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
+			namespace = ns.Name
+
+			configName = testOIDCConfigName
+			serverName = testServerName
+			vmcpName = testVMCPServerName
+			groupName = testVMCPGroupName
+
+			// Create MCPGroup (required by VirtualMCPServer)
+			mcpGroup = &mcpv1alpha1.MCPGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      groupName,
+					Namespace: namespace,
+				},
+			}
+			Expect(k8sClient.Create(ctx, mcpGroup)).Should(Succeed())
+
+			// Create MCPOIDCConfig
+			oidcConfig = &mcpv1alpha1.MCPOIDCConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      configName,
+					Namespace: namespace,
+				},
+				Spec: mcpv1alpha1.MCPOIDCConfigSpec{
+					Type: mcpv1alpha1.MCPOIDCConfigTypeInline,
+					Inline: &mcpv1alpha1.InlineOIDCSharedConfig{
+						Issuer:   "https://accounts.google.com",
+						ClientID: "test-client",
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, oidcConfig)).Should(Succeed())
+
+			// Wait for Valid condition and ConfigHash to be set
+			Eventually(func() bool {
+				updated := &mcpv1alpha1.MCPOIDCConfig{}
+				err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      configName,
+					Namespace: namespace,
+				}, updated)
+				if err != nil {
+					return false
+				}
+				if updated.Status.ConfigHash == "" {
+					return false
+				}
+				for _, cond := range updated.Status.Conditions {
+					if cond.Type == mcpv1alpha1.ConditionTypeOIDCConfigReady && cond.Status == metav1.ConditionTrue {
+						return true
+					}
+				}
+				return false
+			}, timeout, interval).Should(BeTrue())
+
+			// Create MCPServer with OIDCConfigRef
+			mcpServer = &mcpv1alpha1.MCPServer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      serverName,
+					Namespace: namespace,
+				},
+				Spec: mcpv1alpha1.MCPServerSpec{
+					Image: testServerImage,
+					OIDCConfigRef: &mcpv1alpha1.MCPOIDCConfigReference{
+						Name:     configName,
+						Audience: "test-audience",
+						Scopes:   []string{"openid"},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, mcpServer)).Should(Succeed())
+
+			// Create VirtualMCPServer with OIDCConfigRef
+			vmcpServer = &mcpv1alpha1.VirtualMCPServer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      vmcpName,
+					Namespace: namespace,
+				},
+				Spec: mcpv1alpha1.VirtualMCPServerSpec{
+					Config: vmcpconfig.Config{Group: groupName},
+					IncomingAuth: &mcpv1alpha1.IncomingAuthConfig{
+						Type: "oidc",
+						OIDCConfigRef: &mcpv1alpha1.MCPOIDCConfigReference{
+							Name:     configName,
+							Audience: "test-vmcp-audience",
+							Scopes:   []string{"openid"},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, vmcpServer)).Should(Succeed())
+		})
+
+		AfterAll(func() {
+			_ = k8sClient.Delete(ctx, vmcpServer)
+			_ = k8sClient.Delete(ctx, mcpServer)
+			_ = k8sClient.Delete(ctx, oidcConfig)
+			_ = k8sClient.Delete(ctx, mcpGroup)
+			Expect(k8sClient.Delete(ctx, ns)).Should(Succeed())
+		})
+
+		It("should track both workloads in ReferencingWorkloads", func() {
+			Eventually(func() bool {
+				updated := &mcpv1alpha1.MCPOIDCConfig{}
+				err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      configName,
+					Namespace: namespace,
+				}, updated)
+				if err != nil {
+					return false
+				}
+				mcpServerRef := mcpv1alpha1.WorkloadReference{Kind: "MCPServer", Name: serverName}
+				vmcpServerRef := mcpv1alpha1.WorkloadReference{Kind: "VirtualMCPServer", Name: vmcpName}
+				hasMCPServer := false
+				hasVMCPServer := false
+				for _, ref := range updated.Status.ReferencingWorkloads {
+					if ref == mcpServerRef {
+						hasMCPServer = true
+					}
+					if ref == vmcpServerRef {
+						hasVMCPServer = true
+					}
+				}
+				return hasMCPServer && hasVMCPServer
+			}, timeout, interval).Should(BeTrue())
+		})
+	})
+})

--- a/cmd/thv-operator/test-integration/mcp-oidc-config/suite_test.go
+++ b/cmd/thv-operator/test-integration/mcp-oidc-config/suite_test.go
@@ -101,9 +101,46 @@ var _ = BeforeSuite(func() {
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
+	// Set up field indexing for MCPServer.Spec.GroupRef (required by VirtualMCPServer controller)
+	if err := k8sManager.GetFieldIndexer().IndexField(ctx, &mcpv1alpha1.MCPServer{}, "spec.groupRef", func(obj client.Object) []string {
+		mcpServer := obj.(*mcpv1alpha1.MCPServer)
+		if mcpServer.Spec.GroupRef == "" {
+			return nil
+		}
+		return []string{mcpServer.Spec.GroupRef}
+	}); err != nil {
+		Expect(err).ToNot(HaveOccurred())
+	}
+
+	// Set up field indexing for MCPRemoteProxy.Spec.GroupRef (required by VirtualMCPServer controller)
+	if err := k8sManager.GetFieldIndexer().IndexField(ctx, &mcpv1alpha1.MCPRemoteProxy{}, "spec.groupRef", func(obj client.Object) []string {
+		mcpRemoteProxy := obj.(*mcpv1alpha1.MCPRemoteProxy)
+		if mcpRemoteProxy.Spec.GroupRef == "" {
+			return nil
+		}
+		return []string{mcpRemoteProxy.Spec.GroupRef}
+	}); err != nil {
+		Expect(err).ToNot(HaveOccurred())
+	}
+
 	// Register the MCPServer controller (needed because MCPOIDCConfig watches
 	// MCPServer changes and we test cross-resource interactions)
 	err = (&controllers.MCPServerReconciler{
+		Client:           k8sManager.GetClient(),
+		Scheme:           k8sManager.GetScheme(),
+		PlatformDetector: ctrlutil.NewSharedPlatformDetector(),
+	}).SetupWithManager(k8sManager)
+	Expect(err).ToNot(HaveOccurred())
+
+	// Register the MCPGroup controller (VirtualMCPServer depends on MCPGroup)
+	err = (&controllers.MCPGroupReconciler{
+		Client: k8sManager.GetClient(),
+	}).SetupWithManager(k8sManager)
+	Expect(err).ToNot(HaveOccurred())
+
+	// Register the VirtualMCPServer controller (needed because MCPOIDCConfig watches
+	// VirtualMCPServer changes and we test cross-resource interactions)
+	err = (&controllers.VirtualMCPServerReconciler{
 		Client:           k8sManager.GetClient(),
 		Scheme:           k8sManager.GetScheme(),
 		PlatformDetector: ctrlutil.NewSharedPlatformDetector(),

--- a/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_virtualmcpservers.yaml
+++ b/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_virtualmcpservers.yaml
@@ -1797,8 +1797,9 @@ spec:
                       rule: 'self.type == ''inline'' ? has(self.inline) : !has(self.inline)'
                   oidcConfig:
                     description: |-
-                      OIDCConfig defines OIDC authentication configuration
-                      Reuses MCPServer OIDC patterns
+                      OIDCConfig defines OIDC authentication configuration.
+                      Deprecated: Use OIDCConfigRef to reference a shared MCPOIDCConfig resource instead.
+                      This field will be removed in v1beta1. OIDCConfig and OIDCConfigRef are mutually exclusive.
                     properties:
                       configMap:
                         description: |-
@@ -2017,6 +2018,34 @@ spec:
                     - message: kubernetes must not be set when type is not 'kubernetes'
                       rule: 'self.type != ''kubernetes'' ? !has(self.kubernetes) :
                         true'
+                  oidcConfigRef:
+                    description: |-
+                      OIDCConfigRef references a shared MCPOIDCConfig resource for OIDC authentication.
+                      The referenced MCPOIDCConfig must exist in the same namespace as this VirtualMCPServer.
+                      Per-server overrides (audience, scopes) are specified here; shared provider config
+                      lives in the MCPOIDCConfig resource. Mutually exclusive with oidcConfig.
+                    properties:
+                      audience:
+                        description: |-
+                          Audience is the expected audience for token validation.
+                          This MUST be unique per server to prevent token replay attacks.
+                        minLength: 1
+                        type: string
+                      name:
+                        description: Name is the name of the MCPOIDCConfig resource
+                        minLength: 1
+                        type: string
+                      scopes:
+                        description: |-
+                          Scopes is the list of OAuth scopes to advertise in the well-known endpoint (RFC 9728).
+                          If empty, defaults to ["openid"].
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - audience
+                    - name
+                    type: object
                   type:
                     description: |-
                       Type defines the authentication type: anonymous or oidc
@@ -2029,8 +2058,13 @@ spec:
                 - type
                 type: object
                 x-kubernetes-validations:
-                - message: spec.incomingAuth.oidcConfig is required when type is oidc
-                  rule: 'self.type == ''oidc'' ? has(self.oidcConfig) : true'
+                - message: spec.incomingAuth.oidcConfig or oidcConfigRef is required
+                    when type is oidc
+                  rule: 'self.type == ''oidc'' ? (has(self.oidcConfig) || has(self.oidcConfigRef))
+                    : true'
+                - message: oidcConfig and oidcConfigRef are mutually exclusive; use
+                    oidcConfigRef to reference a shared MCPOIDCConfig
+                  rule: '!(has(self.oidcConfig) && has(self.oidcConfigRef))'
               outgoingAuth:
                 description: |-
                   OutgoingAuth configures authentication from Virtual MCP to backend MCPServers.
@@ -2331,6 +2365,11 @@ spec:
                   for this VirtualMCPServer
                 format: int64
                 type: integer
+              oidcConfigHash:
+                description: |-
+                  OIDCConfigHash is the hash of the referenced MCPOIDCConfig spec for change detection.
+                  Only populated when IncomingAuth.OIDCConfigRef is set.
+                type: string
               phase:
                 default: Pending
                 description: Phase is the current phase of the VirtualMCPServer

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_virtualmcpservers.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_virtualmcpservers.yaml
@@ -1800,8 +1800,9 @@ spec:
                       rule: 'self.type == ''inline'' ? has(self.inline) : !has(self.inline)'
                   oidcConfig:
                     description: |-
-                      OIDCConfig defines OIDC authentication configuration
-                      Reuses MCPServer OIDC patterns
+                      OIDCConfig defines OIDC authentication configuration.
+                      Deprecated: Use OIDCConfigRef to reference a shared MCPOIDCConfig resource instead.
+                      This field will be removed in v1beta1. OIDCConfig and OIDCConfigRef are mutually exclusive.
                     properties:
                       configMap:
                         description: |-
@@ -2020,6 +2021,34 @@ spec:
                     - message: kubernetes must not be set when type is not 'kubernetes'
                       rule: 'self.type != ''kubernetes'' ? !has(self.kubernetes) :
                         true'
+                  oidcConfigRef:
+                    description: |-
+                      OIDCConfigRef references a shared MCPOIDCConfig resource for OIDC authentication.
+                      The referenced MCPOIDCConfig must exist in the same namespace as this VirtualMCPServer.
+                      Per-server overrides (audience, scopes) are specified here; shared provider config
+                      lives in the MCPOIDCConfig resource. Mutually exclusive with oidcConfig.
+                    properties:
+                      audience:
+                        description: |-
+                          Audience is the expected audience for token validation.
+                          This MUST be unique per server to prevent token replay attacks.
+                        minLength: 1
+                        type: string
+                      name:
+                        description: Name is the name of the MCPOIDCConfig resource
+                        minLength: 1
+                        type: string
+                      scopes:
+                        description: |-
+                          Scopes is the list of OAuth scopes to advertise in the well-known endpoint (RFC 9728).
+                          If empty, defaults to ["openid"].
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - audience
+                    - name
+                    type: object
                   type:
                     description: |-
                       Type defines the authentication type: anonymous or oidc
@@ -2032,8 +2061,13 @@ spec:
                 - type
                 type: object
                 x-kubernetes-validations:
-                - message: spec.incomingAuth.oidcConfig is required when type is oidc
-                  rule: 'self.type == ''oidc'' ? has(self.oidcConfig) : true'
+                - message: spec.incomingAuth.oidcConfig or oidcConfigRef is required
+                    when type is oidc
+                  rule: 'self.type == ''oidc'' ? (has(self.oidcConfig) || has(self.oidcConfigRef))
+                    : true'
+                - message: oidcConfig and oidcConfigRef are mutually exclusive; use
+                    oidcConfigRef to reference a shared MCPOIDCConfig
+                  rule: '!(has(self.oidcConfig) && has(self.oidcConfigRef))'
               outgoingAuth:
                 description: |-
                   OutgoingAuth configures authentication from Virtual MCP to backend MCPServers.
@@ -2334,6 +2368,11 @@ spec:
                   for this VirtualMCPServer
                 format: int64
                 type: integer
+              oidcConfigHash:
+                description: |-
+                  OIDCConfigHash is the hash of the referenced MCPOIDCConfig spec for change detection.
+                  Only populated when IncomingAuth.OIDCConfigRef is set.
+                type: string
               phase:
                 default: Pending
                 description: Phase is the current phase of the VirtualMCPServer

--- a/docs/operator/crd-api.md
+++ b/docs/operator/crd-api.md
@@ -1353,7 +1353,8 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `type` _string_ | Type defines the authentication type: anonymous or oidc<br />When no authentication is required, explicitly set this to "anonymous" |  | Enum: [anonymous oidc] <br />Required: \{\} <br /> |
-| `oidcConfig` _[api.v1alpha1.OIDCConfigRef](#apiv1alpha1oidcconfigref)_ | OIDCConfig defines OIDC authentication configuration<br />Reuses MCPServer OIDC patterns |  | Optional: \{\} <br /> |
+| `oidcConfig` _[api.v1alpha1.OIDCConfigRef](#apiv1alpha1oidcconfigref)_ | OIDCConfig defines OIDC authentication configuration.<br />Deprecated: Use OIDCConfigRef to reference a shared MCPOIDCConfig resource instead.<br />This field will be removed in v1beta1. OIDCConfig and OIDCConfigRef are mutually exclusive. |  | Optional: \{\} <br /> |
+| `oidcConfigRef` _[api.v1alpha1.MCPOIDCConfigReference](#apiv1alpha1mcpoidcconfigreference)_ | OIDCConfigRef references a shared MCPOIDCConfig resource for OIDC authentication.<br />The referenced MCPOIDCConfig must exist in the same namespace as this VirtualMCPServer.<br />Per-server overrides (audience, scopes) are specified here; shared provider config<br />lives in the MCPOIDCConfig resource. Mutually exclusive with oidcConfig. |  | Optional: \{\} <br /> |
 | `authzConfig` _[api.v1alpha1.AuthzConfigRef](#apiv1alpha1authzconfigref)_ | AuthzConfig defines authorization policy configuration<br />Reuses MCPServer authz patterns |  | Optional: \{\} <br /> |
 
 
@@ -1714,6 +1715,7 @@ The referenced MCPOIDCConfig must be in the same namespace as the MCPServer.
 
 
 _Appears in:_
+- [api.v1alpha1.IncomingAuthConfig](#apiv1alpha1incomingauthconfig)
 - [api.v1alpha1.MCPServerSpec](#apiv1alpha1mcpserverspec)
 
 | Field | Description | Default | Validation |
@@ -3599,6 +3601,7 @@ _Appears in:_
 | `url` _string_ | URL is the URL where the Virtual MCP server can be accessed |  | Optional: \{\} <br /> |
 | `discoveredBackends` _[api.v1alpha1.DiscoveredBackend](#apiv1alpha1discoveredbackend) array_ | DiscoveredBackends lists discovered backend configurations from the MCPGroup |  | Optional: \{\} <br /> |
 | `backendCount` _integer_ | BackendCount is the number of healthy/ready backends<br />(excludes unavailable, degraded, and unknown backends) |  | Optional: \{\} <br /> |
+| `oidcConfigHash` _string_ | OIDCConfigHash is the hash of the referenced MCPOIDCConfig spec for change detection.<br />Only populated when IncomingAuth.OIDCConfigRef is set. |  | Optional: \{\} <br /> |
 
 
 #### api.v1alpha1.Volume


### PR DESCRIPTION
## Summary

- VirtualMCPServer previously only supported inline OIDC configuration (oidcConfig), requiring each server to duplicate shared provider settings. This wires up the shared MCPOIDCConfig resource pattern already established for MCPServer, allowing VirtualMCPServers to reference a shared MCPOIDCConfig via oidcConfigRef with per-server audience and scopes overrides.
- The MCPOIDCConfig controller now also tracks VirtualMCPServer references in ReferencingWorkloads and blocks deletion while referenced.
- This addresses the loose ends from #4248 (readiness probing via vMCP) and #4253 (token exchange via vMCP) by having VirtualMCPServer use the MCPOIDCConfig resource to configure OIDC through its existing vMCP config pipeline.

Closes #4253
Closes #4248

**Stacked on #4492** — merge that first.

## Type of change

- [x] New feature

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)
- [x] Integration tests (envtest-based tests in `test-integration/mcp-oidc-config/`)

## Changes

| File | Change |
|------|--------|
| `api/v1alpha1/virtualmcpserver_types.go` | Add `oidcConfigRef` field to `IncomingAuthConfig` with CEL mutual-exclusivity validation; deprecate `oidcConfig`; add `OIDCConfigHash` to status |
| `controllers/virtualmcpserver_controller.go` | Add `handleOIDCConfig` for reference validation, hash tracking, and ReferencingWorkloads updates; add MCPOIDCConfig watch handler and RBAC |
| `controllers/virtualmcpserver_deployment.go` | Update `buildOIDCEnvVars`, `buildVolumesForVmcp`, and `validateSecretReferences` to handle MCPOIDCConfig inline client secrets and CA bundles; propagate errors |
| `controllers/mcpoidcconfig_controller.go` | Extend `findReferencingWorkloads` to include VirtualMCPServers; add VirtualMCPServer watch for reference tracking |
| `pkg/vmcpconfig/converter.go` | Add `OIDCConfigRef` resolution branch in `convertIncomingAuth` using `ResolveFromConfigRef`; add `mapResolvedOIDCToVmcpConfigFromRef` |
| `test-integration/mcp-oidc-config/suite_test.go` | Register VirtualMCPServer and MCPGroup controllers; add field indexers |
| `test-integration/mcp-oidc-config/mcpoidcconfig_virtualmcpserver_integration_test.go` | 8 integration test specs covering OIDCConfigRef validation, hash tracking, ReferencingWorkloads, deletion protection, and cross-server-type references |

## Does this introduce a user-facing change?

Yes. VirtualMCPServer now supports `spec.incomingAuth.oidcConfigRef` to reference a shared MCPOIDCConfig resource for OIDC authentication. The inline `spec.incomingAuth.oidcConfig` field is deprecated and will be removed in v1beta1. The two fields are mutually exclusive.

## Special notes for reviewers

- The converter's `mapResolvedOIDCToVmcpConfigFromRef` function is intentionally separate from `mapResolvedOIDCToVmcpConfig` because client secret detection differs: the MCPOIDCConfig path checks `MCPOIDCConfig.Spec.Inline.ClientSecretRef` rather than `OIDCConfigRef.Inline.ClientSecretRef`.
- The `handleOIDCConfig` method follows the same pattern as `MCPServerReconciler.handleOIDCConfig` but uses the `StatusManager` interface for batched status updates.
- Deployment builder functions (`buildVolumesForVmcp`, `buildOIDCEnvVars`, `buildEnvVarsForVmcp`) return errors instead of silently dropping MCPOIDCConfig fetch failures, unlike the MCPServer controller which uses the silent-swallow pattern.

Generated with [Claude Code](https://claude.com/claude-code)