### PR TITLE
Replace ReferencingServers with ReferencingWorkloads on MCPToolConfig

### DIFF
--- a/cmd/thv-operator/api/v1alpha1/toolconfig_types.go
+++ b/cmd/thv-operator/api/v1alpha1/toolconfig_types.go
@@ -96,17 +96,17 @@ type MCPToolConfigStatus struct {
 	// +optional
 	ConfigHash string `json:"configHash,omitempty"`
 
-	// ReferencingServers is a list of MCPServer resources that reference this MCPToolConfig
-	// This helps track which servers need to be reconciled when this config changes
+	// ReferencingWorkloads is a list of workload resources that reference this MCPToolConfig.
+	// Each entry identifies the workload by kind and name.
 	// +optional
-	ReferencingServers []string `json:"referencingServers,omitempty"`
+	ReferencingWorkloads []WorkloadReference `json:"referencingWorkloads,omitempty"`
 }
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:shortName=tc;toolconfig,categories=toolhive
 // +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=='Valid')].status`
-// +kubebuilder:printcolumn:name="References",type=string,JSONPath=`.status.referencingServers`
+// +kubebuilder:printcolumn:name="References",type=string,JSONPath=`.status.referencingWorkloads`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // MCPToolConfig is the Schema for the mcptoolconfigs API.

--- a/cmd/thv-operator/api/v1alpha1/zz_generated.deepcopy.go
+++ b/cmd/thv-operator/api/v1alpha1/zz_generated.deepcopy.go
@@ -1998,9 +1998,9 @@ func (in *MCPToolConfigStatus) DeepCopyInto(out *MCPToolConfigStatus) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	if in.ReferencingServers != nil {
-		in, out := &in.ReferencingServers, &out.ReferencingServers
-		*out = make([]string, len(*in))
+	if in.ReferencingWorkloads != nil {
+		in, out := &in.ReferencingWorkloads, &out.ReferencingWorkloads
+		*out = make([]WorkloadReference, len(*in))
 		copy(*out, *in)
 	}
 }

--- a/cmd/thv-operator/controllers/toolconfig_controller.go
+++ b/cmd/thv-operator/controllers/toolconfig_controller.go
@@ -98,6 +98,15 @@ func (r *ToolConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return r.handleConfigHashChange(ctx, toolConfig, configHash)
 	}
 
+	// Refresh ReferencingWorkloads list
+	referencingWorkloads, err := r.findReferencingWorkloads(ctx, toolConfig)
+	if err != nil {
+		logger.Error(err, "Failed to find referencing workloads")
+	} else if !slices.Equal(toolConfig.Status.ReferencingWorkloads, referencingWorkloads) {
+		toolConfig.Status.ReferencingWorkloads = referencingWorkloads
+		conditionChanged = true
+	}
+
 	// Update condition if it changed (even without hash change)
 	if conditionChanged {
 		if err := r.Status().Update(ctx, toolConfig); err != nil {
@@ -106,9 +115,7 @@ func (r *ToolConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		}
 	}
 
-	// Even when hash hasn't changed, update referencing servers list.
-	// This ensures ReferencingServers is updated when MCPServers are created or deleted.
-	return r.updateReferencingServers(ctx, toolConfig)
+	return ctrl.Result{}, nil
 }
 
 // handleConfigHashChange handles the logic when the config hash changes
@@ -134,13 +141,12 @@ func (r *ToolConfigReconciler) handleConfigHashChange(
 	toolConfig.Status.ConfigHash = configHash
 	toolConfig.Status.ObservedGeneration = toolConfig.Generation
 
-	// Update the status with the list of referencing servers
-	serverNames := make([]string, 0, len(referencingServers))
+	// Update the status with the list of referencing workloads
+	refs := make([]mcpv1alpha1.WorkloadReference, 0, len(referencingServers))
 	for _, server := range referencingServers {
-		serverNames = append(serverNames, server.Name)
+		refs = append(refs, mcpv1alpha1.WorkloadReference{Kind: "MCPServer", Name: server.Name})
 	}
-	slices.Sort(serverNames)
-	toolConfig.Status.ReferencingServers = serverNames
+	toolConfig.Status.ReferencingWorkloads = refs
 
 	// Update the MCPToolConfig status
 	if err := r.Status().Update(ctx, toolConfig); err != nil {
@@ -166,46 +172,6 @@ func (r *ToolConfigReconciler) handleConfigHashChange(
 	return ctrl.Result{}, nil
 }
 
-// updateReferencingServers finds referencing MCPServers and updates the status if the list changed
-func (r *ToolConfigReconciler) updateReferencingServers(
-	ctx context.Context,
-	toolConfig *mcpv1alpha1.MCPToolConfig,
-) (ctrl.Result, error) {
-	referencingServers, err := r.findReferencingMCPServers(ctx, toolConfig)
-	if err != nil {
-		logger := log.FromContext(ctx)
-		logger.Error(err, "Failed to find referencing MCPServers")
-		meta.SetStatusCondition(&toolConfig.Status.Conditions, metav1.Condition{
-			Type:               mcpv1alpha1.ConditionToolConfigValid,
-			Status:             metav1.ConditionFalse,
-			Reason:             mcpv1alpha1.ConditionReasonToolConfigValidationFailed,
-			Message:            "Failed to find referencing MCPServers",
-			ObservedGeneration: toolConfig.Generation,
-		})
-		if updateErr := r.Status().Update(ctx, toolConfig); updateErr != nil {
-			logger.Error(updateErr, "Failed to update MCPToolConfig status after error")
-		}
-		return ctrl.Result{}, fmt.Errorf("failed to find referencing MCPServers: %w", err)
-	}
-
-	serverNames := make([]string, 0, len(referencingServers))
-	for _, server := range referencingServers {
-		serverNames = append(serverNames, server.Name)
-	}
-	slices.Sort(serverNames)
-
-	if !slices.Equal(toolConfig.Status.ReferencingServers, serverNames) {
-		toolConfig.Status.ReferencingServers = serverNames
-		if err := r.Status().Update(ctx, toolConfig); err != nil {
-			logger := log.FromContext(ctx)
-			logger.Error(err, "Failed to update MCPToolConfig status")
-			return ctrl.Result{}, err
-		}
-	}
-
-	return ctrl.Result{}, nil
-}
-
 // calculateConfigHash calculates a hash of the MCPToolConfig spec using Kubernetes utilities
 func (*ToolConfigReconciler) calculateConfigHash(spec mcpv1alpha1.MCPToolConfigSpec) string {
 	return ctrlutil.CalculateConfigHash(spec)
@@ -216,31 +182,32 @@ func (r *ToolConfigReconciler) handleDeletion(ctx context.Context, toolConfig *m
 	logger := log.FromContext(ctx)
 
 	if controllerutil.ContainsFinalizer(toolConfig, ToolConfigFinalizerName) {
-		// Check if any MCPServers are still referencing this MCPToolConfig
-		referencingServers, err := r.findReferencingMCPServers(ctx, toolConfig)
+		// Check if any workloads still reference this MCPToolConfig
+		referencingWorkloads, err := r.findReferencingWorkloads(ctx, toolConfig)
 		if err != nil {
-			logger.Error(err, "Failed to find referencing MCPServers during deletion")
+			logger.Error(err, "Failed to check referencing workloads during deletion")
 			return ctrl.Result{}, err
 		}
 
-		if len(referencingServers) > 0 {
-			// Cannot delete - still referenced
-			serverNames := make([]string, 0, len(referencingServers))
-			for _, server := range referencingServers {
-				serverNames = append(serverNames, server.Name)
-			}
-			logger.Info("Cannot delete MCPToolConfig - still referenced by MCPServers",
-				"toolconfig", toolConfig.Name, "referencingServers", serverNames)
+		if len(referencingWorkloads) > 0 {
+			logger.Info("MCPToolConfig is still referenced by workloads, blocking deletion",
+				"toolconfig", toolConfig.Name,
+				"referencingWorkloads", referencingWorkloads)
 
-			// Update status to show it's still referenced
-			toolConfig.Status.ReferencingServers = serverNames
-			if err := r.Status().Update(ctx, toolConfig); err != nil {
-				logger.Error(err, "Failed to update MCPToolConfig status during deletion")
+			meta.SetStatusCondition(&toolConfig.Status.Conditions, metav1.Condition{
+				Type:               "DeletionBlocked",
+				Status:             metav1.ConditionTrue,
+				Reason:             "ReferencedByWorkloads",
+				Message:            fmt.Sprintf("Cannot delete: referenced by workloads: %v", referencingWorkloads),
+				ObservedGeneration: toolConfig.Generation,
+			})
+			toolConfig.Status.ReferencingWorkloads = referencingWorkloads
+			if updateErr := r.Status().Update(ctx, toolConfig); updateErr != nil {
+				logger.Error(updateErr, "Failed to update status during deletion block")
 			}
 
-			// Return an error to prevent deletion
-			return ctrl.Result{}, fmt.Errorf("MCPToolConfig %s is still referenced by MCPServers: %v",
-				toolConfig.Name, serverNames)
+			// Requeue to check again later
+			return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 		}
 
 		// No references, safe to remove finalizer and allow deletion
@@ -255,7 +222,28 @@ func (r *ToolConfigReconciler) handleDeletion(ctx context.Context, toolConfig *m
 	return ctrl.Result{}, nil
 }
 
-// findReferencingMCPServers finds all MCPServers that reference the given MCPToolConfig
+// findReferencingWorkloads returns the workload resources (MCPServer)
+// that reference this MCPToolConfig via their ToolConfigRef field.
+func (r *ToolConfigReconciler) findReferencingWorkloads(
+	ctx context.Context,
+	toolConfig *mcpv1alpha1.MCPToolConfig,
+) ([]mcpv1alpha1.WorkloadReference, error) {
+	mcpServerList := &mcpv1alpha1.MCPServerList{}
+	if err := r.List(ctx, mcpServerList, client.InNamespace(toolConfig.Namespace)); err != nil {
+		return nil, fmt.Errorf("failed to list MCPServers: %w", err)
+	}
+
+	var refs []mcpv1alpha1.WorkloadReference
+	for _, server := range mcpServerList.Items {
+		if server.Spec.ToolConfigRef != nil && server.Spec.ToolConfigRef.Name == toolConfig.Name {
+			refs = append(refs, mcpv1alpha1.WorkloadReference{Kind: "MCPServer", Name: server.Name})
+		}
+	}
+	return refs, nil
+}
+
+// findReferencingMCPServers finds all MCPServers that reference the given MCPToolConfig.
+// Returns the full MCPServer objects, used by handleConfigHashChange to update server annotations.
 func (r *ToolConfigReconciler) findReferencingMCPServers(
 	ctx context.Context,
 	toolConfig *mcpv1alpha1.MCPToolConfig,
@@ -270,33 +258,59 @@ func (r *ToolConfigReconciler) findReferencingMCPServers(
 }
 
 // SetupWithManager sets up the controller with the Manager.
+// Watches MCPServer changes to maintain accurate ReferencingWorkloads status.
 func (r *ToolConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	// Create a handler that maps MCPServer changes to MCPToolConfig reconciliation requests.
-	// When an MCPServer is created/updated/deleted, we need to reconcile the MCPToolConfig
-	// it references so that the ReferencingServers status field stays up to date.
+	// Watch MCPServer changes to update ReferencingWorkloads on referenced MCPToolConfigs.
+	// This handler enqueues both the currently-referenced MCPToolConfig AND any
+	// MCPToolConfig that still lists this server in ReferencingWorkloads (covers the
+	// case where a server removes its toolConfigRef — the previously-referenced
+	// config needs to reconcile and clean up the stale entry).
 	toolConfigHandler := handler.EnqueueRequestsFromMapFunc(
-		func(_ context.Context, obj client.Object) []reconcile.Request {
-			mcpServer, ok := obj.(*mcpv1alpha1.MCPServer)
+		func(ctx context.Context, obj client.Object) []reconcile.Request {
+			server, ok := obj.(*mcpv1alpha1.MCPServer)
 			if !ok {
 				return nil
 			}
 
-			if mcpServer.Spec.ToolConfigRef == nil {
-				return nil
+			seen := make(map[types.NamespacedName]struct{})
+			var requests []reconcile.Request
+
+			// Enqueue the currently-referenced MCPToolConfig (if any)
+			if server.Spec.ToolConfigRef != nil {
+				nn := types.NamespacedName{
+					Name:      server.Spec.ToolConfigRef.Name,
+					Namespace: server.Namespace,
+				}
+				seen[nn] = struct{}{}
+				requests = append(requests, reconcile.Request{NamespacedName: nn})
 			}
 
-			return []reconcile.Request{{
-				NamespacedName: types.NamespacedName{
-					Name:      mcpServer.Spec.ToolConfigRef.Name,
-					Namespace: mcpServer.Namespace,
-				},
-			}}
+			// Also enqueue any MCPToolConfig that still lists this server in
+			// ReferencingWorkloads — handles ref-removal and server-deletion cases.
+			toolConfigList := &mcpv1alpha1.MCPToolConfigList{}
+			if err := r.List(ctx, toolConfigList, client.InNamespace(server.Namespace)); err != nil {
+				log.FromContext(ctx).Error(err, "Failed to list MCPToolConfigs for MCPServer watch")
+				return requests
+			}
+			for _, cfg := range toolConfigList.Items {
+				nn := types.NamespacedName{Name: cfg.Name, Namespace: cfg.Namespace}
+				if _, already := seen[nn]; already {
+					continue
+				}
+				for _, ref := range cfg.Status.ReferencingWorkloads {
+					if ref.Kind == "MCPServer" && ref.Name == server.Name {
+						requests = append(requests, reconcile.Request{NamespacedName: nn})
+						break
+					}
+				}
+			}
+
+			return requests
 		},
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&mcpv1alpha1.MCPToolConfig{}).
-		// Watch for MCPServers and reconcile the MCPToolConfig when they change
 		Watches(&mcpv1alpha1.MCPServer{}, toolConfigHandler).
 		Complete(r)
 }

--- a/cmd/thv-operator/controllers/toolconfig_controller_edge_cases_test.go
+++ b/cmd/thv-operator/controllers/toolconfig_controller_edge_cases_test.go
@@ -122,7 +122,8 @@ func TestToolConfigReconciler_EdgeCases(t *testing.T) {
 		err = fakeClient.Get(ctx, req.NamespacedName, &updatedConfig)
 		require.NoError(t, err)
 		assert.NotEmpty(t, updatedConfig.Status.ConfigHash)
-		assert.Contains(t, updatedConfig.Status.ReferencingServers, "test-server")
+		assert.Contains(t, updatedConfig.Status.ReferencingWorkloads,
+			mcpv1alpha1.WorkloadReference{Kind: "MCPServer", Name: "test-server"})
 	})
 
 	t.Run("reconcile with changed spec", func(t *testing.T) {
@@ -350,10 +351,13 @@ func TestToolConfigReconciler_ComplexScenarios(t *testing.T) {
 		var updatedConfig mcpv1alpha1.MCPToolConfig
 		err = fakeClient.Get(ctx, req.NamespacedName, &updatedConfig)
 		require.NoError(t, err)
-		assert.Len(t, updatedConfig.Status.ReferencingServers, 3)
-		assert.Contains(t, updatedConfig.Status.ReferencingServers, "server1")
-		assert.Contains(t, updatedConfig.Status.ReferencingServers, "server2")
-		assert.Contains(t, updatedConfig.Status.ReferencingServers, "server3")
+		assert.Len(t, updatedConfig.Status.ReferencingWorkloads, 3)
+		assert.Contains(t, updatedConfig.Status.ReferencingWorkloads,
+			mcpv1alpha1.WorkloadReference{Kind: "MCPServer", Name: "server1"})
+		assert.Contains(t, updatedConfig.Status.ReferencingWorkloads,
+			mcpv1alpha1.WorkloadReference{Kind: "MCPServer", Name: "server2"})
+		assert.Contains(t, updatedConfig.Status.ReferencingWorkloads,
+			mcpv1alpha1.WorkloadReference{Kind: "MCPServer", Name: "server3"})
 	})
 
 	t.Run("empty MCPToolConfig spec", func(t *testing.T) {

--- a/cmd/thv-operator/controllers/toolconfig_controller_test.go
+++ b/cmd/thv-operator/controllers/toolconfig_controller_test.go
@@ -221,11 +221,11 @@ func TestToolConfigReconciler_Reconcile(t *testing.T) {
 					"MCPToolConfig status should have config hash")
 			}
 
-			// Check referencing servers in status
+			// Check referencing workloads in status
 			if tt.existingMCPServer != nil {
-				assert.Contains(t, updatedConfig.Status.ReferencingServers,
-					tt.existingMCPServer.Name,
-					"Status should contain referencing MCPServer")
+				assert.Contains(t, updatedConfig.Status.ReferencingWorkloads,
+					mcpv1alpha1.WorkloadReference{Kind: "MCPServer", Name: tt.existingMCPServer.Name},
+					"Status should contain referencing MCPServer as WorkloadReference")
 			}
 
 			// Check Valid condition is set after successful reconciliation
@@ -238,7 +238,7 @@ func TestToolConfigReconciler_Reconcile(t *testing.T) {
 	}
 }
 
-func TestToolConfigReconciler_findReferencingMCPServers(t *testing.T) {
+func TestToolConfigReconciler_findReferencingWorkloads(t *testing.T) {
 	t.Parallel()
 
 	scheme := runtime.NewScheme()
@@ -302,21 +302,16 @@ func TestToolConfigReconciler_findReferencingMCPServers(t *testing.T) {
 	}
 
 	ctx := t.Context()
-	servers, err := r.findReferencingMCPServers(ctx, toolConfig)
+	refs, err := r.findReferencingWorkloads(ctx, toolConfig)
 	require.NoError(t, err)
 
-	assert.Len(t, servers, 2, "Should find 2 referencing MCPServers")
-
-	serverNames := make([]string, len(servers))
-	for i, s := range servers {
-		serverNames[i] = s.Name
-	}
-	assert.Contains(t, serverNames, "server1")
-	assert.Contains(t, serverNames, "server2")
-	assert.NotContains(t, serverNames, "server3")
+	assert.Len(t, refs, 2, "Should find 2 referencing workloads")
+	assert.Contains(t, refs, mcpv1alpha1.WorkloadReference{Kind: "MCPServer", Name: "server1"})
+	assert.Contains(t, refs, mcpv1alpha1.WorkloadReference{Kind: "MCPServer", Name: "server2"})
+	assert.NotContains(t, refs, mcpv1alpha1.WorkloadReference{Kind: "MCPServer", Name: "server3"})
 }
 
-func TestToolConfigReconciler_ReferencingServersUpdatedWithoutHashChange(t *testing.T) {
+func TestToolConfigReconciler_ReferencingWorkloadsUpdatedWithoutHashChange(t *testing.T) {
 	t.Parallel()
 
 	ctx := t.Context()
@@ -366,7 +361,7 @@ func TestToolConfigReconciler_ReferencingServersUpdatedWithoutHashChange(t *test
 	err = fakeClient.Get(ctx, req.NamespacedName, &updatedConfig)
 	require.NoError(t, err)
 	assert.NotEmpty(t, updatedConfig.Status.ConfigHash)
-	assert.Empty(t, updatedConfig.Status.ReferencingServers, "No servers should be referencing yet")
+	assert.Empty(t, updatedConfig.Status.ReferencingWorkloads, "No servers should be referencing yet")
 
 	// Verify Valid condition is set after initial reconciliation
 	cond := k8smeta.FindStatusCondition(updatedConfig.Status.Conditions, mcpv1alpha1.ConditionToolConfigValid)
@@ -394,11 +389,12 @@ func TestToolConfigReconciler_ReferencingServersUpdatedWithoutHashChange(t *test
 
 	err = fakeClient.Get(ctx, req.NamespacedName, &updatedConfig)
 	require.NoError(t, err)
-	assert.Contains(t, updatedConfig.Status.ReferencingServers, "new-server",
-		"ReferencingServers should be updated even without hash change")
+	assert.Contains(t, updatedConfig.Status.ReferencingWorkloads,
+		mcpv1alpha1.WorkloadReference{Kind: "MCPServer", Name: "new-server"},
+		"ReferencingWorkloads should be updated even without hash change")
 }
 
-func TestToolConfigReconciler_ReferencingServersRemovedOnServerDeletion(t *testing.T) {
+func TestToolConfigReconciler_ReferencingWorkloadsRemovedOnServerDeletion(t *testing.T) {
 	t.Parallel()
 
 	ctx := t.Context()
@@ -460,7 +456,8 @@ func TestToolConfigReconciler_ReferencingServersRemovedOnServerDeletion(t *testi
 	var updatedConfig mcpv1alpha1.MCPToolConfig
 	err = fakeClient.Get(ctx, req.NamespacedName, &updatedConfig)
 	require.NoError(t, err)
-	assert.Contains(t, updatedConfig.Status.ReferencingServers, "server-to-delete")
+	assert.Contains(t, updatedConfig.Status.ReferencingWorkloads,
+		mcpv1alpha1.WorkloadReference{Kind: "MCPServer", Name: "server-to-delete"})
 
 	// Delete the MCPServer
 	require.NoError(t, fakeClient.Delete(ctx, mcpServer))
@@ -471,8 +468,8 @@ func TestToolConfigReconciler_ReferencingServersRemovedOnServerDeletion(t *testi
 
 	err = fakeClient.Get(ctx, req.NamespacedName, &updatedConfig)
 	require.NoError(t, err)
-	assert.Empty(t, updatedConfig.Status.ReferencingServers,
-		"ReferencingServers should be empty after server deletion")
+	assert.Empty(t, updatedConfig.Status.ReferencingWorkloads,
+		"ReferencingWorkloads should be empty after server deletion")
 }
 
 func TestToolConfigReconciler_ValidConditionObservedGeneration(t *testing.T) {

--- a/cmd/thv-operator/test-integration/mcp-toolconfig/mcptoolconfig_controller_integration_test.go
+++ b/cmd/thv-operator/test-integration/mcp-toolconfig/mcptoolconfig_controller_integration_test.go
@@ -303,7 +303,7 @@ var _ = Describe("MCPToolConfig Controller Integration Tests", func() {
 			Expect(k8sClient.Delete(ctx, ns)).Should(Succeed())
 		})
 
-		It("should track referencing servers in status", func() {
+		It("should track referencing workloads in status", func() {
 			Eventually(func() bool {
 				updated := &mcpv1alpha1.MCPToolConfig{}
 				err := k8sClient.Get(ctx, types.NamespacedName{
@@ -313,8 +313,8 @@ var _ = Describe("MCPToolConfig Controller Integration Tests", func() {
 				if err != nil {
 					return false
 				}
-				for _, server := range updated.Status.ReferencingServers {
-					if server == mcpServerName {
+				for _, ref := range updated.Status.ReferencingWorkloads {
+					if ref.Kind == "MCPServer" && ref.Name == mcpServerName {
 						return true
 					}
 				}
@@ -326,7 +326,7 @@ var _ = Describe("MCPToolConfig Controller Integration Tests", func() {
 			// Delete the MCPServer
 			Expect(k8sClient.Delete(ctx, mcpServer)).Should(Succeed())
 
-			// Eventually the referencing servers list should be empty
+			// Eventually the referencing workloads list should be empty
 			Eventually(func() bool {
 				updated := &mcpv1alpha1.MCPToolConfig{}
 				err := k8sClient.Get(ctx, types.NamespacedName{
@@ -336,7 +336,7 @@ var _ = Describe("MCPToolConfig Controller Integration Tests", func() {
 				if err != nil {
 					return false
 				}
-				return len(updated.Status.ReferencingServers) == 0
+				return len(updated.Status.ReferencingWorkloads) == 0
 			}, timeout, interval).Should(BeTrue())
 		})
 	})
@@ -404,7 +404,7 @@ var _ = Describe("MCPToolConfig Controller Integration Tests", func() {
 			}
 			Expect(k8sClient.Create(ctx, mcpServer)).Should(Succeed())
 
-			// Wait for ReferencingServers to be populated
+			// Wait for ReferencingWorkloads to be populated
 			Eventually(func() bool {
 				updated := &mcpv1alpha1.MCPToolConfig{}
 				err := k8sClient.Get(ctx, types.NamespacedName{
@@ -414,8 +414,8 @@ var _ = Describe("MCPToolConfig Controller Integration Tests", func() {
 				if err != nil {
 					return false
 				}
-				for _, server := range updated.Status.ReferencingServers {
-					if server == mcpServerName {
+				for _, ref := range updated.Status.ReferencingWorkloads {
+					if ref.Kind == "MCPServer" && ref.Name == mcpServerName {
 						return true
 					}
 				}

--- a/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcptoolconfigs.yaml
+++ b/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcptoolconfigs.yaml
@@ -23,7 +23,7 @@ spec:
     - jsonPath: .status.conditions[?(@.type=='Valid')].status
       name: Ready
       type: string
-    - jsonPath: .status.referencingServers
+    - jsonPath: .status.referencingWorkloads
       name: References
       type: string
     - jsonPath: .metadata.creationTimestamp
@@ -187,12 +187,30 @@ spec:
                   It corresponds to the MCPToolConfig's generation, which is updated on mutation by the API Server.
                 format: int64
                 type: integer
-              referencingServers:
+              referencingWorkloads:
                 description: |-
-                  ReferencingServers is a list of MCPServer resources that reference this MCPToolConfig
-                  This helps track which servers need to be reconciled when this config changes
+                  ReferencingWorkloads is a list of workload resources that reference this MCPToolConfig.
+                  Each entry identifies the workload by kind and name.
                 items:
-                  type: string
+                  description: |-
+                    WorkloadReference identifies a workload that references a shared configuration resource.
+                    Namespace is implicit — cross-namespace references are not supported.
+                  properties:
+                    kind:
+                      description: Kind is the type of workload resource
+                      enum:
+                      - MCPServer
+                      - VirtualMCPServer
+                      - MCPRemoteProxy
+                      type: string
+                    name:
+                      description: Name is the name of the workload resource
+                      minLength: 1
+                      type: string
+                  required:
+                  - kind
+                  - name
+                  type: object
                 type: array
             type: object
         type: object

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcptoolconfigs.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcptoolconfigs.yaml
@@ -26,7 +26,7 @@ spec:
     - jsonPath: .status.conditions[?(@.type=='Valid')].status
       name: Ready
       type: string
-    - jsonPath: .status.referencingServers
+    - jsonPath: .status.referencingWorkloads
       name: References
       type: string
     - jsonPath: .metadata.creationTimestamp
@@ -190,12 +190,30 @@ spec:
                   It corresponds to the MCPToolConfig's generation, which is updated on mutation by the API Server.
                 format: int64
                 type: integer
-              referencingServers:
+              referencingWorkloads:
                 description: |-
-                  ReferencingServers is a list of MCPServer resources that reference this MCPToolConfig
-                  This helps track which servers need to be reconciled when this config changes
+                  ReferencingWorkloads is a list of workload resources that reference this MCPToolConfig.
+                  Each entry identifies the workload by kind and name.
                 items:
-                  type: string
+                  description: |-
+                    WorkloadReference identifies a workload that references a shared configuration resource.
+                    Namespace is implicit — cross-namespace references are not supported.
+                  properties:
+                    kind:
+                      description: Kind is the type of workload resource
+                      enum:
+                      - MCPServer
+                      - VirtualMCPServer
+                      - MCPRemoteProxy
+                      type: string
+                    name:
+                      description: Name is the name of the workload resource
+                      minLength: 1
+                      type: string
+                  required:
+                  - kind
+                  - name
+                  type: object
                 type: array
             type: object
         type: object

--- a/docs/operator/crd-api.md
+++ b/docs/operator/crd-api.md
@@ -2479,7 +2479,7 @@ _Appears in:_
 | `conditions` _[Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#condition-v1-meta) array_ | Conditions represent the latest available observations of the MCPToolConfig's state |  | Optional: \{\} <br /> |
 | `observedGeneration` _integer_ | ObservedGeneration is the most recent generation observed for this MCPToolConfig.<br />It corresponds to the MCPToolConfig's generation, which is updated on mutation by the API Server. |  | Optional: \{\} <br /> |
 | `configHash` _string_ | ConfigHash is a hash of the current configuration for change detection |  | Optional: \{\} <br /> |
-| `referencingServers` _string array_ | ReferencingServers is a list of MCPServer resources that reference this MCPToolConfig<br />This helps track which servers need to be reconciled when this config changes |  | Optional: \{\} <br /> |
+| `referencingWorkloads` _[api.v1alpha1.WorkloadReference](#apiv1alpha1workloadreference) array_ | ReferencingWorkloads is a list of workload resources that reference this MCPToolConfig.<br />Each entry identifies the workload by kind and name. |  | Optional: \{\} <br /> |
 
 
 #### api.v1alpha1.ModelCacheConfig
@@ -3653,6 +3653,7 @@ Namespace is implicit — cross-namespace references are not supported.
 _Appears in:_
 - [api.v1alpha1.MCPOIDCConfigStatus](#apiv1alpha1mcpoidcconfigstatus)
 - [api.v1alpha1.MCPTelemetryConfigStatus](#apiv1alpha1mcptelemetryconfigstatus)
+- [api.v1alpha1.MCPToolConfigStatus](#apiv1alpha1mcptoolconfigstatus)
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |


### PR DESCRIPTION
## Summary

Migrates MCPToolConfig from `ReferencingServers []string` to `ReferencingWorkloads []WorkloadReference`, aligning it with the structured workload reference pattern established on MCPOIDCConfig in #4492. This enables the status field to distinguish between different workload kinds (MCPServer, VirtualMCPServer, MCPRemoteProxy) rather than assuming all referencing workloads are MCPServers.

Partial fix for #4491

## Type of change

- [x] Enhancement to an existing feature

## Changes

| File | Changes |
|------|---------|
| `toolconfig_types.go` | Replace `ReferencingServers []string` with `ReferencingWorkloads []WorkloadReference`, update printer column |
| `toolconfig_controller.go` | Add `findReferencingWorkloads()`, update reconcile/deletion logic to use structured refs with `DeletionBlocked` condition |
| `toolconfig_controller_test.go` | Update assertions to use `WorkloadReference{Kind, Name}` structs |
| `toolconfig_controller_edge_cases_test.go` | Update assertions to use `WorkloadReference{Kind, Name}` structs |
| `mcptoolconfig_controller_integration_test.go` | Update assertions to use `WorkloadReference{Kind, Name}` structs |
| Generated files | Regenerated deepcopy, CRD YAML manifests |

## Test plan

- [x] Unit tests updated and passing (`go test ./cmd/thv-operator/controllers/... -run ToolConfig`)
- [x] Integration tests updated
- [x] CRD manifests regenerated via `task gen`

## Special notes for reviewers

Follows the exact pattern from #4492 (MCPOIDCConfig migration). MCPExternalAuthConfig migration is in a separate PR. MCPTelemetryConfig will follow separately.

Generated with [Claude Code](https://claude.com/claude-code)