### PR TITLE
Replace ReferencingServers with ReferencingWorkloads on MCPExternalAuthConfig

### DIFF
--- a/cmd/thv-operator/api/v1alpha1/mcpexternalauthconfig_types.go
+++ b/cmd/thv-operator/api/v1alpha1/mcpexternalauthconfig_types.go
@@ -712,10 +712,10 @@ type MCPExternalAuthConfigStatus struct {
 	// +optional
 	ConfigHash string `json:"configHash,omitempty"`
 
-	// ReferencingServers is a list of MCPServer resources that reference this MCPExternalAuthConfig
-	// This helps track which servers need to be reconciled when this config changes
+	// ReferencingWorkloads is a list of workload resources that reference this MCPExternalAuthConfig.
+	// Each entry identifies the workload by kind and name.
 	// +optional
-	ReferencingServers []string `json:"referencingServers,omitempty"`
+	ReferencingWorkloads []WorkloadReference `json:"referencingWorkloads,omitempty"`
 }
 
 // +kubebuilder:object:root=true
@@ -723,7 +723,7 @@ type MCPExternalAuthConfigStatus struct {
 // +kubebuilder:resource:shortName=extauth;mcpextauth,categories=toolhive
 // +kubebuilder:printcolumn:name="Type",type=string,JSONPath=`.spec.type`
 // +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=='Valid')].status`
-// +kubebuilder:printcolumn:name="References",type=string,JSONPath=`.status.referencingServers`
+// +kubebuilder:printcolumn:name="References",type=string,JSONPath=`.status.referencingWorkloads`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // MCPExternalAuthConfig is the Schema for the mcpexternalauthconfigs API.

--- a/cmd/thv-operator/api/v1alpha1/zz_generated.deepcopy.go
+++ b/cmd/thv-operator/api/v1alpha1/zz_generated.deepcopy.go
@@ -876,9 +876,9 @@ func (in *MCPExternalAuthConfigStatus) DeepCopyInto(out *MCPExternalAuthConfigSt
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	if in.ReferencingServers != nil {
-		in, out := &in.ReferencingServers, &out.ReferencingServers
-		*out = make([]string, len(*in))
+	if in.ReferencingWorkloads != nil {
+		in, out := &in.ReferencingWorkloads, &out.ReferencingWorkloads
+		*out = make([]WorkloadReference, len(*in))
 		copy(*out, *in)
 	}
 }

--- a/cmd/thv-operator/controllers/mcpexternalauthconfig_controller.go
+++ b/cmd/thv-operator/controllers/mcpexternalauthconfig_controller.go
@@ -123,9 +123,9 @@ func (r *MCPExternalAuthConfigReconciler) Reconcile(ctx context.Context, req ctr
 		}
 	}
 
-	// Even when hash hasn't changed, update referencing servers list.
-	// This ensures ReferencingServers is updated when MCPServers are created or deleted.
-	return r.updateReferencingServers(ctx, externalAuthConfig)
+	// Even when hash hasn't changed, update referencing workloads list.
+	// This ensures ReferencingWorkloads is updated when MCPServers are created or deleted.
+	return r.updateReferencingWorkloads(ctx, externalAuthConfig)
 }
 
 // calculateConfigHash calculates a hash of the MCPExternalAuthConfig spec using Kubernetes utilities
@@ -155,13 +155,27 @@ func (r *MCPExternalAuthConfigReconciler) handleConfigHashChange(
 		return ctrl.Result{}, fmt.Errorf("failed to find referencing MCPServers: %w", err)
 	}
 
-	// Update the status with the list of referencing servers
-	serverNames := make([]string, 0, len(referencingServers))
+	// Update the status with the list of referencing workloads
+	refs := make([]mcpv1alpha1.WorkloadReference, 0, len(referencingServers))
 	for _, server := range referencingServers {
-		serverNames = append(serverNames, server.Name)
+		refs = append(refs, mcpv1alpha1.WorkloadReference{Kind: "MCPServer", Name: server.Name})
 	}
-	slices.Sort(serverNames)
-	externalAuthConfig.Status.ReferencingServers = serverNames
+	slices.SortFunc(refs, func(a, b mcpv1alpha1.WorkloadReference) int {
+		if a.Kind != b.Kind {
+			if a.Kind < b.Kind {
+				return -1
+			}
+			return 1
+		}
+		if a.Name < b.Name {
+			return -1
+		}
+		if a.Name > b.Name {
+			return 1
+		}
+		return 0
+	})
+	externalAuthConfig.Status.ReferencingWorkloads = refs
 
 	// Update the MCPExternalAuthConfig status
 	if err := r.Status().Update(ctx, externalAuthConfig); err != nil {
@@ -197,31 +211,32 @@ func (r *MCPExternalAuthConfigReconciler) handleDeletion(
 	logger := log.FromContext(ctx)
 
 	if controllerutil.ContainsFinalizer(externalAuthConfig, ExternalAuthConfigFinalizerName) {
-		// Check if any MCPServers are still referencing this MCPExternalAuthConfig
-		referencingServers, err := r.findReferencingMCPServers(ctx, externalAuthConfig)
+		// Check if any workloads still reference this MCPExternalAuthConfig
+		referencingWorkloads, err := r.findReferencingWorkloads(ctx, externalAuthConfig)
 		if err != nil {
-			logger.Error(err, "Failed to find referencing MCPServers during deletion")
+			logger.Error(err, "Failed to check referencing workloads during deletion")
 			return ctrl.Result{}, err
 		}
 
-		if len(referencingServers) > 0 {
-			// Cannot delete - still referenced
-			serverNames := make([]string, 0, len(referencingServers))
-			for _, server := range referencingServers {
-				serverNames = append(serverNames, server.Name)
-			}
-			logger.Info("Cannot delete MCPExternalAuthConfig - still referenced by MCPServers",
-				"externalAuthConfig", externalAuthConfig.Name, "referencingServers", serverNames)
+		if len(referencingWorkloads) > 0 {
+			logger.Info("MCPExternalAuthConfig is still referenced by workloads, blocking deletion",
+				"externalAuthConfig", externalAuthConfig.Name,
+				"referencingWorkloads", referencingWorkloads)
 
-			// Update status to show it's still referenced
-			externalAuthConfig.Status.ReferencingServers = serverNames
-			if err := r.Status().Update(ctx, externalAuthConfig); err != nil {
-				logger.Error(err, "Failed to update MCPExternalAuthConfig status during deletion")
+			meta.SetStatusCondition(&externalAuthConfig.Status.Conditions, metav1.Condition{
+				Type:               "DeletionBlocked",
+				Status:             metav1.ConditionTrue,
+				Reason:             "ReferencedByWorkloads",
+				Message:            fmt.Sprintf("Cannot delete: referenced by workloads: %v", referencingWorkloads),
+				ObservedGeneration: externalAuthConfig.Generation,
+			})
+			externalAuthConfig.Status.ReferencingWorkloads = referencingWorkloads
+			if updateErr := r.Status().Update(ctx, externalAuthConfig); updateErr != nil {
+				logger.Error(updateErr, "Failed to update status during deletion block")
 			}
 
-			// Return an error to prevent deletion
-			return ctrl.Result{}, fmt.Errorf("MCPExternalAuthConfig %s is still referenced by MCPServers: %v",
-				externalAuthConfig.Name, serverNames)
+			// Requeue to check again later
+			return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 		}
 
 		// No references, safe to remove finalizer and allow deletion
@@ -250,28 +265,75 @@ func (r *MCPExternalAuthConfigReconciler) findReferencingMCPServers(
 		})
 }
 
+// findReferencingWorkloads returns the workload resources (MCPServer)
+// that reference this MCPExternalAuthConfig via their ExternalAuthConfigRef field.
+func (r *MCPExternalAuthConfigReconciler) findReferencingWorkloads(
+	ctx context.Context,
+	externalAuthConfig *mcpv1alpha1.MCPExternalAuthConfig,
+) ([]mcpv1alpha1.WorkloadReference, error) {
+	mcpServerList := &mcpv1alpha1.MCPServerList{}
+	if err := r.List(ctx, mcpServerList, client.InNamespace(externalAuthConfig.Namespace)); err != nil {
+		return nil, fmt.Errorf("failed to list MCPServers: %w", err)
+	}
+
+	var refs []mcpv1alpha1.WorkloadReference
+	for _, server := range mcpServerList.Items {
+		if server.Spec.ExternalAuthConfigRef != nil && server.Spec.ExternalAuthConfigRef.Name == externalAuthConfig.Name {
+			refs = append(refs, mcpv1alpha1.WorkloadReference{Kind: "MCPServer", Name: server.Name})
+		}
+	}
+	return refs, nil
+}
+
 // SetupWithManager sets up the controller with the Manager.
+// Watches MCPServer changes to maintain accurate ReferencingWorkloads status.
 func (r *MCPExternalAuthConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	// Create a handler that maps MCPServer changes to MCPExternalAuthConfig reconciliation requests.
-	// When an MCPServer is created, updated, or deleted, we reconcile the MCPExternalAuthConfig
-	// it references so that the ReferencingServers status field stays up to date.
+	// Watch MCPServer changes to update ReferencingWorkloads on referenced MCPExternalAuthConfigs.
+	// This handler enqueues both the currently-referenced MCPExternalAuthConfig AND any
+	// MCPExternalAuthConfig that still lists this server in ReferencingWorkloads (covers the
+	// case where a server removes its externalAuthConfigRef — the previously-referenced
+	// config needs to reconcile and clean up the stale entry).
 	mcpServerHandler := handler.EnqueueRequestsFromMapFunc(
-		func(_ context.Context, obj client.Object) []reconcile.Request {
-			mcpServer, ok := obj.(*mcpv1alpha1.MCPServer)
+		func(ctx context.Context, obj client.Object) []reconcile.Request {
+			server, ok := obj.(*mcpv1alpha1.MCPServer)
 			if !ok {
 				return nil
 			}
 
-			if mcpServer.Spec.ExternalAuthConfigRef == nil {
-				return nil
+			seen := make(map[types.NamespacedName]struct{})
+			var requests []reconcile.Request
+
+			// Enqueue the currently-referenced MCPExternalAuthConfig (if any)
+			if server.Spec.ExternalAuthConfigRef != nil {
+				nn := types.NamespacedName{
+					Name:      server.Spec.ExternalAuthConfigRef.Name,
+					Namespace: server.Namespace,
+				}
+				seen[nn] = struct{}{}
+				requests = append(requests, reconcile.Request{NamespacedName: nn})
 			}
 
-			return []reconcile.Request{{
-				NamespacedName: types.NamespacedName{
-					Name:      mcpServer.Spec.ExternalAuthConfigRef.Name,
-					Namespace: mcpServer.Namespace,
-				},
-			}}
+			// Also enqueue any MCPExternalAuthConfig that still lists this server in
+			// ReferencingWorkloads — handles ref-removal and server-deletion cases.
+			extAuthConfigList := &mcpv1alpha1.MCPExternalAuthConfigList{}
+			if err := r.List(ctx, extAuthConfigList, client.InNamespace(server.Namespace)); err != nil {
+				log.FromContext(ctx).Error(err, "Failed to list MCPExternalAuthConfigs for MCPServer watch")
+				return requests
+			}
+			for _, cfg := range extAuthConfigList.Items {
+				nn := types.NamespacedName{Name: cfg.Name, Namespace: cfg.Namespace}
+				if _, already := seen[nn]; already {
+					continue
+				}
+				for _, ref := range cfg.Status.ReferencingWorkloads {
+					if ref.Kind == "MCPServer" && ref.Name == server.Name {
+						requests = append(requests, reconcile.Request{NamespacedName: nn})
+						break
+					}
+				}
+			}
+
+			return requests
 		},
 	)
 
@@ -282,26 +344,20 @@ func (r *MCPExternalAuthConfigReconciler) SetupWithManager(mgr ctrl.Manager) err
 		Complete(r)
 }
 
-// updateReferencingServers finds referencing MCPServers and updates the status if the list changed
-func (r *MCPExternalAuthConfigReconciler) updateReferencingServers(
+// updateReferencingWorkloads finds referencing workloads and updates the status if the list changed
+func (r *MCPExternalAuthConfigReconciler) updateReferencingWorkloads(
 	ctx context.Context,
 	externalAuthConfig *mcpv1alpha1.MCPExternalAuthConfig,
 ) (ctrl.Result, error) {
-	referencingServers, err := r.findReferencingMCPServers(ctx, externalAuthConfig)
+	refs, err := r.findReferencingWorkloads(ctx, externalAuthConfig)
 	if err != nil {
 		logger := log.FromContext(ctx)
-		logger.Error(err, "Failed to find referencing MCPServers")
-		return ctrl.Result{}, fmt.Errorf("failed to find referencing MCPServers: %w", err)
+		logger.Error(err, "Failed to find referencing workloads")
+		return ctrl.Result{}, fmt.Errorf("failed to find referencing workloads: %w", err)
 	}
 
-	serverNames := make([]string, 0, len(referencingServers))
-	for _, server := range referencingServers {
-		serverNames = append(serverNames, server.Name)
-	}
-	slices.Sort(serverNames)
-
-	if !slices.Equal(externalAuthConfig.Status.ReferencingServers, serverNames) {
-		externalAuthConfig.Status.ReferencingServers = serverNames
+	if !slices.Equal(externalAuthConfig.Status.ReferencingWorkloads, refs) {
+		externalAuthConfig.Status.ReferencingWorkloads = refs
 		if err := r.Status().Update(ctx, externalAuthConfig); err != nil {
 			logger := log.FromContext(ctx)
 			logger.Error(err, "Failed to update MCPExternalAuthConfig status")

--- a/cmd/thv-operator/controllers/mcpexternalauthconfig_controller_test.go
+++ b/cmd/thv-operator/controllers/mcpexternalauthconfig_controller_test.go
@@ -252,17 +252,17 @@ func TestMCPExternalAuthConfigReconciler_Reconcile(t *testing.T) {
 					"MCPExternalAuthConfig status should have config hash")
 			}
 
-			// Check referencing servers in status
+			// Check referencing workloads in status
 			if tt.existingMCPServer != nil {
-				assert.Contains(t, updatedConfig.Status.ReferencingServers,
-					tt.existingMCPServer.Name,
-					"Status should contain referencing MCPServer")
+				assert.Contains(t, updatedConfig.Status.ReferencingWorkloads,
+					mcpv1alpha1.WorkloadReference{Kind: "MCPServer", Name: tt.existingMCPServer.Name},
+					"Status should contain referencing MCPServer as WorkloadReference")
 			}
 		})
 	}
 }
 
-func TestMCPExternalAuthConfigReconciler_findReferencingMCPServers(t *testing.T) {
+func TestMCPExternalAuthConfigReconciler_findReferencingWorkloads(t *testing.T) {
 	t.Parallel()
 
 	scheme := runtime.NewScheme()
@@ -335,18 +335,13 @@ func TestMCPExternalAuthConfigReconciler_findReferencingMCPServers(t *testing.T)
 	}
 
 	ctx := t.Context()
-	servers, err := r.findReferencingMCPServers(ctx, externalAuthConfig)
+	refs, err := r.findReferencingWorkloads(ctx, externalAuthConfig)
 	require.NoError(t, err)
 
-	assert.Len(t, servers, 2, "Should find 2 referencing MCPServers")
-
-	serverNames := make([]string, len(servers))
-	for i, s := range servers {
-		serverNames[i] = s.Name
-	}
-	assert.Contains(t, serverNames, "server1")
-	assert.Contains(t, serverNames, "server2")
-	assert.NotContains(t, serverNames, "server3")
+	assert.Len(t, refs, 2, "Should find 2 referencing workloads")
+	assert.Contains(t, refs, mcpv1alpha1.WorkloadReference{Kind: "MCPServer", Name: "server1"})
+	assert.Contains(t, refs, mcpv1alpha1.WorkloadReference{Kind: "MCPServer", Name: "server2"})
+	assert.NotContains(t, refs, mcpv1alpha1.WorkloadReference{Kind: "MCPServer", Name: "server3"})
 }
 
 func TestGetExternalAuthConfigForMCPServer(t *testing.T) {
@@ -471,7 +466,7 @@ func TestMCPExternalAuthConfigReconciler_handleDeletion(t *testing.T) {
 		name                   string
 		externalAuthConfig     *mcpv1alpha1.MCPExternalAuthConfig
 		referencingServers     []*mcpv1alpha1.MCPServer
-		expectError            bool
+		expectRequeue          bool
 		expectFinalizerRemoved bool
 	}{
 		{
@@ -498,7 +493,7 @@ func TestMCPExternalAuthConfigReconciler_handleDeletion(t *testing.T) {
 					},
 				},
 			},
-			expectError:            false,
+			expectRequeue:          false,
 			expectFinalizerRemoved: true,
 		},
 		{
@@ -539,7 +534,7 @@ func TestMCPExternalAuthConfigReconciler_handleDeletion(t *testing.T) {
 					},
 				},
 			},
-			expectError:            true,
+			expectRequeue:          true,
 			expectFinalizerRemoved: false,
 		},
 	}
@@ -562,6 +557,7 @@ func TestMCPExternalAuthConfigReconciler_handleDeletion(t *testing.T) {
 			fakeClient := fake.NewClientBuilder().
 				WithScheme(scheme).
 				WithObjects(objs...).
+				WithStatusSubresource(&mcpv1alpha1.MCPExternalAuthConfig{}).
 				Build()
 
 			r := &MCPExternalAuthConfigReconciler{
@@ -571,19 +567,18 @@ func TestMCPExternalAuthConfigReconciler_handleDeletion(t *testing.T) {
 
 			// Call handleDeletion directly
 			result, err := r.handleDeletion(ctx, tt.externalAuthConfig)
+			require.NoError(t, err)
 
-			if tt.expectError {
-				assert.Error(t, err)
-				// When there's an error, finalizer should still be present
+			if tt.expectRequeue {
+				// When still referenced, deletion is blocked with requeue
+				assert.Greater(t, result.RequeueAfter, time.Duration(0),
+					"Should requeue when references exist")
 				assert.Contains(t, tt.externalAuthConfig.Finalizers, ExternalAuthConfigFinalizerName,
-					"Finalizer should still be present after error")
+					"Finalizer should still be present when blocked")
 			} else {
-				assert.NoError(t, err)
 				assert.Equal(t, time.Duration(0), result.RequeueAfter)
 
 				// Check if finalizer was removed from the object in memory
-				// Note: We check the original object because after finalizer removal,
-				// Kubernetes will delete the object and it won't be in the fake client store
 				if tt.expectFinalizerRemoved {
 					assert.NotContains(t, tt.externalAuthConfig.Finalizers, ExternalAuthConfigFinalizerName,
 						"Finalizer should be removed")
@@ -700,7 +695,7 @@ func TestMCPExternalAuthConfigReconciler_ConfigChangeTriggersReconciliation(t *t
 		"MCPServer should have annotation with new config hash")
 }
 
-func TestMCPExternalAuthConfigReconciler_ReferencingServersUpdatedWithoutHashChange(t *testing.T) {
+func TestMCPExternalAuthConfigReconciler_ReferencingWorkloadsUpdatedWithoutHashChange(t *testing.T) {
 	t.Parallel()
 
 	ctx := t.Context()
@@ -760,7 +755,7 @@ func TestMCPExternalAuthConfigReconciler_ReferencingServersUpdatedWithoutHashCha
 	err = fakeClient.Get(ctx, req.NamespacedName, &updatedConfig)
 	require.NoError(t, err)
 	assert.NotEmpty(t, updatedConfig.Status.ConfigHash)
-	assert.Empty(t, updatedConfig.Status.ReferencingServers, "No servers should be referencing yet")
+	assert.Empty(t, updatedConfig.Status.ReferencingWorkloads, "No workloads should be referencing yet")
 
 	// Now add an MCPServer that references this config (without changing the config spec)
 	mcpServer := &mcpv1alpha1.MCPServer{
@@ -783,11 +778,12 @@ func TestMCPExternalAuthConfigReconciler_ReferencingServersUpdatedWithoutHashCha
 
 	err = fakeClient.Get(ctx, req.NamespacedName, &updatedConfig)
 	require.NoError(t, err)
-	assert.Contains(t, updatedConfig.Status.ReferencingServers, "new-server",
-		"ReferencingServers should be updated even without hash change")
+	assert.Contains(t, updatedConfig.Status.ReferencingWorkloads,
+		mcpv1alpha1.WorkloadReference{Kind: "MCPServer", Name: "new-server"},
+		"ReferencingWorkloads should be updated even without hash change")
 }
 
-func TestMCPExternalAuthConfigReconciler_ReferencingServersRemovedOnServerDeletion(t *testing.T) {
+func TestMCPExternalAuthConfigReconciler_ReferencingWorkloadsRemovedOnServerDeletion(t *testing.T) {
 	t.Parallel()
 
 	ctx := t.Context()
@@ -859,7 +855,8 @@ func TestMCPExternalAuthConfigReconciler_ReferencingServersRemovedOnServerDeleti
 	var updatedConfig mcpv1alpha1.MCPExternalAuthConfig
 	err = fakeClient.Get(ctx, req.NamespacedName, &updatedConfig)
 	require.NoError(t, err)
-	assert.Contains(t, updatedConfig.Status.ReferencingServers, "server-to-delete")
+	assert.Contains(t, updatedConfig.Status.ReferencingWorkloads,
+		mcpv1alpha1.WorkloadReference{Kind: "MCPServer", Name: "server-to-delete"})
 
 	// Delete the MCPServer
 	require.NoError(t, fakeClient.Delete(ctx, mcpServer))
@@ -870,6 +867,6 @@ func TestMCPExternalAuthConfigReconciler_ReferencingServersRemovedOnServerDeleti
 
 	err = fakeClient.Get(ctx, req.NamespacedName, &updatedConfig)
 	require.NoError(t, err)
-	assert.Empty(t, updatedConfig.Status.ReferencingServers,
-		"ReferencingServers should be empty after server deletion")
+	assert.Empty(t, updatedConfig.Status.ReferencingWorkloads,
+		"ReferencingWorkloads should be empty after server deletion")
 }

--- a/cmd/thv-operator/test-integration/mcp-external-auth/mcpexternalauthconfig_controller_integration_test.go
+++ b/cmd/thv-operator/test-integration/mcp-external-auth/mcpexternalauthconfig_controller_integration_test.go
@@ -242,8 +242,8 @@ var _ = Describe("MCPExternalAuthConfig Controller Integration Tests", func() {
 			}, timeout, interval).Should(BeTrue())
 		})
 
-		It("Should update MCPExternalAuthConfig status with referencing server", func() {
-			// Wait for the auth config status to be updated with the referencing server
+		It("Should update MCPExternalAuthConfig status with referencing workload", func() {
+			// Wait for the auth config status to be updated with the referencing workload
 			Eventually(func() bool {
 				updatedAuthConfig := &mcpv1alpha1.MCPExternalAuthConfig{}
 				err := k8sClient.Get(ctx, types.NamespacedName{
@@ -253,9 +253,9 @@ var _ = Describe("MCPExternalAuthConfig Controller Integration Tests", func() {
 				if err != nil {
 					return false
 				}
-				// Check if the server is in the referencing servers list
-				for _, server := range updatedAuthConfig.Status.ReferencingServers {
-					if server == mcpServerName {
+				// Check if the server is in the referencing workloads list
+				for _, ref := range updatedAuthConfig.Status.ReferencingWorkloads {
+					if ref.Kind == "MCPServer" && ref.Name == mcpServerName {
 						return true
 					}
 				}

--- a/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpexternalauthconfigs.yaml
+++ b/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpexternalauthconfigs.yaml
@@ -26,7 +26,7 @@ spec:
     - jsonPath: .status.conditions[?(@.type=='Valid')].status
       name: Ready
       type: string
-    - jsonPath: .status.referencingServers
+    - jsonPath: .status.referencingWorkloads
       name: References
       type: string
     - jsonPath: .metadata.creationTimestamp
@@ -952,12 +952,30 @@ spec:
                   It corresponds to the MCPExternalAuthConfig's generation, which is updated on mutation by the API Server.
                 format: int64
                 type: integer
-              referencingServers:
+              referencingWorkloads:
                 description: |-
-                  ReferencingServers is a list of MCPServer resources that reference this MCPExternalAuthConfig
-                  This helps track which servers need to be reconciled when this config changes
+                  ReferencingWorkloads is a list of workload resources that reference this MCPExternalAuthConfig.
+                  Each entry identifies the workload by kind and name.
                 items:
-                  type: string
+                  description: |-
+                    WorkloadReference identifies a workload that references a shared configuration resource.
+                    Namespace is implicit — cross-namespace references are not supported.
+                  properties:
+                    kind:
+                      description: Kind is the type of workload resource
+                      enum:
+                      - MCPServer
+                      - VirtualMCPServer
+                      - MCPRemoteProxy
+                      type: string
+                    name:
+                      description: Name is the name of the workload resource
+                      minLength: 1
+                      type: string
+                  required:
+                  - kind
+                  - name
+                  type: object
                 type: array
             type: object
         type: object

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpexternalauthconfigs.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpexternalauthconfigs.yaml
@@ -29,7 +29,7 @@ spec:
     - jsonPath: .status.conditions[?(@.type=='Valid')].status
       name: Ready
       type: string
-    - jsonPath: .status.referencingServers
+    - jsonPath: .status.referencingWorkloads
       name: References
       type: string
     - jsonPath: .metadata.creationTimestamp
@@ -955,12 +955,30 @@ spec:
                   It corresponds to the MCPExternalAuthConfig's generation, which is updated on mutation by the API Server.
                 format: int64
                 type: integer
-              referencingServers:
+              referencingWorkloads:
                 description: |-
-                  ReferencingServers is a list of MCPServer resources that reference this MCPExternalAuthConfig
-                  This helps track which servers need to be reconciled when this config changes
+                  ReferencingWorkloads is a list of workload resources that reference this MCPExternalAuthConfig.
+                  Each entry identifies the workload by kind and name.
                 items:
-                  type: string
+                  description: |-
+                    WorkloadReference identifies a workload that references a shared configuration resource.
+                    Namespace is implicit — cross-namespace references are not supported.
+                  properties:
+                    kind:
+                      description: Kind is the type of workload resource
+                      enum:
+                      - MCPServer
+                      - VirtualMCPServer
+                      - MCPRemoteProxy
+                      type: string
+                    name:
+                      description: Name is the name of the workload resource
+                      minLength: 1
+                      type: string
+                  required:
+                  - kind
+                  - name
+                  type: object
                 type: array
             type: object
         type: object

--- a/docs/operator/crd-api.md
+++ b/docs/operator/crd-api.md
@@ -1557,7 +1557,7 @@ _Appears in:_
 | `conditions` _[Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#condition-v1-meta) array_ | Conditions represent the latest available observations of the MCPExternalAuthConfig's state |  | Optional: \{\} <br /> |
 | `observedGeneration` _integer_ | ObservedGeneration is the most recent generation observed for this MCPExternalAuthConfig.<br />It corresponds to the MCPExternalAuthConfig's generation, which is updated on mutation by the API Server. |  | Optional: \{\} <br /> |
 | `configHash` _string_ | ConfigHash is a hash of the current configuration for change detection |  | Optional: \{\} <br /> |
-| `referencingServers` _string array_ | ReferencingServers is a list of MCPServer resources that reference this MCPExternalAuthConfig<br />This helps track which servers need to be reconciled when this config changes |  | Optional: \{\} <br /> |
+| `referencingWorkloads` _[api.v1alpha1.WorkloadReference](#apiv1alpha1workloadreference) array_ | ReferencingWorkloads is a list of workload resources that reference this MCPExternalAuthConfig.<br />Each entry identifies the workload by kind and name. |  | Optional: \{\} <br /> |
 
 
 #### api.v1alpha1.MCPGroup
@@ -3651,6 +3651,7 @@ Namespace is implicit — cross-namespace references are not supported.
 
 
 _Appears in:_
+- [api.v1alpha1.MCPExternalAuthConfigStatus](#apiv1alpha1mcpexternalauthconfigstatus)
 - [api.v1alpha1.MCPOIDCConfigStatus](#apiv1alpha1mcpoidcconfigstatus)
 - [api.v1alpha1.MCPTelemetryConfigStatus](#apiv1alpha1mcptelemetryconfigstatus)
 


### PR DESCRIPTION
## Summary

Migrates MCPExternalAuthConfig from `ReferencingServers []string` to `ReferencingWorkloads []WorkloadReference`, aligning it with the structured workload reference pattern established on MCPOIDCConfig in #4492. This enables the status field to distinguish between different workload kinds (MCPServer, VirtualMCPServer, MCPRemoteProxy) rather than assuming all referencing workloads are MCPServers.

Partial fix for #4491

## Type of change

- [x] Enhancement to an existing feature

## Changes

| File | Changes |
|------|---------|
| `mcpexternalauthconfig_types.go` | Replace `ReferencingServers []string` with `ReferencingWorkloads []WorkloadReference`, update printer column |
| `mcpexternalauthconfig_controller.go` | Add `findReferencingWorkloads()`, update reconcile/deletion logic to use structured refs with `DeletionBlocked` condition |
| `mcpexternalauthconfig_controller_test.go` | Update assertions to use `WorkloadReference{Kind, Name}` structs |
| `mcpexternalauthconfig_controller_integration_test.go` | Update assertions to use `WorkloadReference{Kind, Name}` structs |
| Generated files | Regenerated deepcopy, CRD YAML manifests |

## Test plan

- [x] Unit tests updated and passing (`go test ./cmd/thv-operator/controllers/... -run MCPExternalAuthConfig`)
- [x] Integration tests updated
- [x] CRD manifests regenerated via `task gen`

## Special notes for reviewers

Follows the exact pattern from #4492 (MCPOIDCConfig migration). MCPToolConfig migration is in a separate PR. MCPTelemetryConfig will follow separately.

Generated with [Claude Code](https://claude.com/claude-code)