### PR TITLE
Handle stale ReferencingWorkloads in telemetry watch handler

### DIFF
--- a/cmd/thv-operator/controllers/mcptelemetryconfig_controller.go
+++ b/cmd/thv-operator/controllers/mcptelemetryconfig_controller.go
@@ -140,26 +140,54 @@ func (r *MCPTelemetryConfigReconciler) Reconcile(ctx context.Context, req ctrl.R
 }
 
 // SetupWithManager sets up the controller with the Manager.
+// Watches MCPServer changes to maintain accurate ReferencingWorkloads status.
 func (r *MCPTelemetryConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	// Watch MCPServer changes to update ReferencingWorkloads status
+	// Watch MCPServer changes to update ReferencingWorkloads on referenced MCPTelemetryConfigs.
+	// This handler enqueues both the currently-referenced MCPTelemetryConfig AND any
+	// MCPTelemetryConfig that still lists this server in ReferencingWorkloads (covers the
+	// case where a server removes its telemetryConfigRef — the previously-referenced
+	// config needs to reconcile and clean up the stale entry).
 	mcpServerHandler := handler.EnqueueRequestsFromMapFunc(
-		func(_ context.Context, obj client.Object) []reconcile.Request {
-			mcpServer, ok := obj.(*mcpv1alpha1.MCPServer)
+		func(ctx context.Context, obj client.Object) []reconcile.Request {
+			server, ok := obj.(*mcpv1alpha1.MCPServer)
 			if !ok {
 				return nil
 			}
 
-			// If this MCPServer references a MCPTelemetryConfig, enqueue it for reconciliation
-			if mcpServer.Spec.TelemetryConfigRef == nil {
-				return nil
+			seen := make(map[types.NamespacedName]struct{})
+			var requests []reconcile.Request
+
+			// Enqueue the currently-referenced MCPTelemetryConfig (if any)
+			if server.Spec.TelemetryConfigRef != nil {
+				nn := types.NamespacedName{
+					Name:      server.Spec.TelemetryConfigRef.Name,
+					Namespace: server.Namespace,
+				}
+				seen[nn] = struct{}{}
+				requests = append(requests, reconcile.Request{NamespacedName: nn})
 			}
 
-			return []reconcile.Request{{
-				NamespacedName: types.NamespacedName{
-					Name:      mcpServer.Spec.TelemetryConfigRef.Name,
-					Namespace: mcpServer.Namespace,
-				},
-			}}
+			// Also enqueue any MCPTelemetryConfig that still lists this server in
+			// ReferencingWorkloads — handles ref-removal and server-deletion cases.
+			telemetryConfigList := &mcpv1alpha1.MCPTelemetryConfigList{}
+			if err := r.List(ctx, telemetryConfigList, client.InNamespace(server.Namespace)); err != nil {
+				log.FromContext(ctx).Error(err, "Failed to list MCPTelemetryConfigs for MCPServer watch")
+				return requests
+			}
+			for _, cfg := range telemetryConfigList.Items {
+				nn := types.NamespacedName{Name: cfg.Name, Namespace: cfg.Namespace}
+				if _, already := seen[nn]; already {
+					continue
+				}
+				for _, ref := range cfg.Status.ReferencingWorkloads {
+					if ref.Kind == "MCPServer" && ref.Name == server.Name {
+						requests = append(requests, reconcile.Request{NamespacedName: nn})
+						break
+					}
+				}
+			}
+
+			return requests
 		},
 	)
 


### PR DESCRIPTION
## Summary

The MCPTelemetryConfig types were already migrated to `ReferencingWorkloads []WorkloadReference` in #4487, but the watch handler in `SetupWithManager` only enqueued the *currently-referenced* MCPTelemetryConfig when an MCPServer changed. If a server removed its `telemetryConfigRef` or was deleted, the previously-referenced config was never re-reconciled, leaving stale entries in `ReferencingWorkloads`.

This updates the watch handler to also scan all MCPTelemetryConfigs in the namespace and enqueue any that still list the changed server in their `ReferencingWorkloads` status, matching the pattern from the MCPOIDCConfig controller (#4492).

Partial fix for #4491

## Type of change

- [x] Bug fix

## Changes

| File | Changes |
|------|---------|
| `mcptelemetryconfig_controller.go` | Update watch handler to enqueue configs with stale `ReferencingWorkloads` entries using `ref.Kind == "MCPServer" && ref.Name == server.Name` matching, with deduplication via `seen` map |

## Test plan

- [x] Unit tests passing (`go test ./cmd/thv-operator/controllers/... -run TelemetryConfig`)
- [x] Operator builds cleanly (`go build ./cmd/thv-operator/...`)
- [x] Lint passes

## Special notes for reviewers

The types/status migration was already done in #4487. This PR only addresses the watch handler gap that could leave stale refs when servers are deleted or stop referencing a telemetry config.

Generated with [Claude Code](https://claude.com/claude-code)