### PR TITLE
Exclude docker/docker plugin and AuthZ vulns from govulncheck

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -68,7 +68,24 @@ jobs:
           #   Indirect dependency via mcp-go, invopop/jsonschema, wk8/go-ordered-map.
           #   The vulnerability is in the Delete function which is not called by ToolHive
           #   or any of its dependencies. No fixed version exists yet (all versions affected).
-          IGNORED_VULNS="GO-2025-4192 GO-2026-4514"
+          # GO-2026-4883: docker/docker plugin privilege validation off-by-one (CVE-2026-33997)
+          #   CVSS 6.8 (Moderate). Affects Docker Engine's plugin installation privilege
+          #   comparison logic, allowing a malicious plugin to receive privileges the user
+          #   did not approve. ToolHive is a pure Docker API client -- it never installs,
+          #   enables, or manages Docker plugins. No plugin-related APIs are called anywhere
+          #   in the codebase. Fixed in Docker Engine 29.3.1 / moby/moby/v2 v2.0.0-beta.8,
+          #   but no fix exists for the github.com/docker/docker v28.x module path we use.
+          # GO-2026-4887: docker/docker AuthZ plugin bypass via oversized body (CVE-2026-34040)
+          #   CVSS 8.8 (High). Incomplete fix for CVE-2024-41110. Allows bypassing AuthZ
+          #   plugins by sending requests with oversized bodies so the daemon forwards the
+          #   request without the body, causing plugins to approve requests they should deny.
+          #   Exploitable only when the Docker *daemon* is configured with AuthZ plugins and
+          #   an attacker has local API access. ToolHive is a client-only consumer of the
+          #   Docker API via the standard Go SDK -- it does not run a daemon, does not expose
+          #   Docker API endpoints, and does not implement any AuthZ plugin middleware.
+          #   Fixed in Docker Engine 29.3.1 / moby/moby/v2 v2.0.0-beta.8, but no fix
+          #   exists for the github.com/docker/docker v28.x module path we use.
+          IGNORED_VULNS="GO-2025-4192 GO-2026-4514 GO-2026-4883 GO-2026-4887"
 
           # Show the raw output for debugging
           echo "::group::govulncheck raw output"


### PR DESCRIPTION
## Summary

Two new Docker Engine vulnerabilities (published 2026-04-02) are failing the govulncheck CI check across all PRs. Neither is exploitable in ToolHive because we are a pure Docker API client, but no patched release exists for the `github.com/docker/docker` v28.x module path we consume.

- **GO-2026-4883** (CVE-2026-33997, CVSS 6.8): Off-by-one error in Docker Engine's plugin privilege validation during `docker plugin install`. ToolHive never installs, enables, or manages Docker plugins -- zero plugin-related API calls exist in the codebase.
- **GO-2026-4887** (CVE-2026-34040, CVSS 8.8): AuthZ plugin bypass via oversized request bodies (incomplete fix for CVE-2024-41110). Exploitable only when the Docker *daemon* is configured with AuthZ plugins and an attacker has local API access. ToolHive does not run a Docker daemon, does not expose Docker API endpoints, and does not implement AuthZ plugin middleware.

Both are fixed in Docker Engine 29.3.1 / `moby/moby/v2 v2.0.0-beta.8`, but the `github.com/docker/docker` module (all v28.x) has no patched release. Added to the govulncheck exclusion list with detailed justification comments.

## Type of change

- [x] Other (describe): CI govulncheck exclusion for non-applicable vulnerabilities

## Test plan

- [x] Manual testing (describe below)

Verified the exclusion list format matches the existing pattern and that the govulncheck step's jq/grep pipeline will correctly filter these IDs.

## Does this introduce a user-facing change?

No.

Generated with [Claude Code](https://claude.com/claude-code)