### PR TITLE
Fix flaky VirtualMCPServer scaling e2e test

### DIFF
--- a/pkg/vmcp/health/monitor.go
+++ b/pkg/vmcp/health/monitor.go
@@ -323,22 +323,37 @@ func (m *Monitor) UpdateBackends(newBackends []vmcp.Backend) {
 	// This ensures GetHealthSummary sees new backends before their health checks complete
 	m.backends = newBackends
 
-	// Start monitoring for new backends
+	// Start monitoring for new or changed backends
 	for id, backend := range newBackendsMap {
-		if _, exists := oldBackends[id]; !exists {
-			slog.Info("starting health monitoring for new backend", "backend", backend.Name)
-			backendCopy := backend
-
-			// Circuit breaker will be lazily initialized on first health check
-
-			backendCtx, cancel := context.WithCancel(m.ctx) //nolint:gosec // G118 - cancel stored in m.activeChecks, called during Stop
-			m.activeChecks[id] = cancel
-			m.wg.Add(1)
-			// Clear the "removed" flag if this backend was previously removed
-			// This allows health check results to be recorded again
-			m.statusTracker.ClearRemovedFlag(id)
-			go m.monitorBackend(backendCtx, &backendCopy, false) // false = dynamically added backend
+		oldBackend, exists := oldBackends[id]
+		if exists && !backendChanged(oldBackend, backend) {
+			continue // Existing backend with no relevant changes
 		}
+
+		if exists {
+			// Backend properties changed (e.g., URL updated after operator reconcile).
+			// Cancel the old goroutine so a new one starts with the updated properties.
+			slog.Info("restarting health monitoring for changed backend",
+				"backend", backend.Name, "old_url", oldBackend.BaseURL, "new_url", backend.BaseURL)
+			if cancel, ok := m.activeChecks[id]; ok {
+				cancel()
+				delete(m.activeChecks, id)
+			}
+		} else {
+			slog.Info("starting health monitoring for new backend", "backend", backend.Name)
+		}
+
+		backendCopy := backend
+
+		// Circuit breaker will be lazily initialized on first health check
+
+		backendCtx, cancel := context.WithCancel(m.ctx) //nolint:gosec // G118 - cancel stored in m.activeChecks, called during Stop
+		m.activeChecks[id] = cancel
+		m.wg.Add(1)
+		// Clear the "removed" flag if this backend was previously removed
+		// This allows health check results to be recorded again
+		m.statusTracker.ClearRemovedFlag(id)
+		go m.monitorBackend(backendCtx, &backendCopy, false) // false = dynamically added backend
 	}
 
 	// Stop monitoring for removed backends and clean up their state
@@ -848,4 +863,11 @@ func buildConditions(summary Summary, phase vmcp.Phase, configuredBackendCount i
 	}
 
 	return conditions
+}
+
+// backendChanged returns true if the backend's health-check-relevant properties have changed.
+// This is used by UpdateBackends to detect when an existing backend needs its monitoring
+// goroutine restarted (e.g., URL updated after operator reconcile).
+func backendChanged(old, updated vmcp.Backend) bool {
+	return old.BaseURL != updated.BaseURL || old.TransportType != updated.TransportType
 }

--- a/pkg/vmcp/health/monitor_test.go
+++ b/pkg/vmcp/health/monitor_test.go
@@ -895,6 +895,111 @@ func TestMonitor_UpdateBackends(t *testing.T) {
 	assert.Equal(t, 1, summary.Healthy, "backend-2 should be healthy")
 }
 
+func TestBackendChanged(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		old      vmcp.Backend
+		new      vmcp.Backend
+		expected bool
+	}{
+		{
+			name:     "same URL and transport",
+			old:      vmcp.Backend{BaseURL: "http://svc:8080", TransportType: "sse"},
+			new:      vmcp.Backend{BaseURL: "http://svc:8080", TransportType: "sse"},
+			expected: false,
+		},
+		{
+			name:     "different URL",
+			old:      vmcp.Backend{BaseURL: "http://old-svc:8080", TransportType: "sse"},
+			new:      vmcp.Backend{BaseURL: "http://new-svc:8080", TransportType: "sse"},
+			expected: true,
+		},
+		{
+			name:     "different transport",
+			old:      vmcp.Backend{BaseURL: "http://svc:8080", TransportType: "sse"},
+			new:      vmcp.Backend{BaseURL: "http://svc:8080", TransportType: "streamable-http"},
+			expected: true,
+		},
+		{
+			name:     "both different",
+			old:      vmcp.Backend{BaseURL: "http://old-svc:8080", TransportType: "sse"},
+			new:      vmcp.Backend{BaseURL: "http://new-svc:9090", TransportType: "streamable-http"},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := backendChanged(tt.old, tt.new)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestMonitor_UpdateBackends_PropertyChange(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockClient := mocks.NewMockBackendClient(ctrl)
+
+	// Start with one backend at an old URL
+	initialBackends := []vmcp.Backend{
+		{ID: "backend-1", Name: "Backend 1", BaseURL: "http://old-url:8080", TransportType: "sse"},
+	}
+
+	config := MonitorConfig{
+		CheckInterval:      50 * time.Millisecond,
+		UnhealthyThreshold: 1,
+		Timeout:            10 * time.Millisecond,
+	}
+
+	// Mock health checks for all backends (old and new URLs)
+	mockClient.EXPECT().
+		ListCapabilities(gomock.Any(), gomock.Any()).
+		Return(&vmcp.CapabilityList{}, nil).
+		AnyTimes()
+
+	monitor, err := NewMonitor(mockClient, initialBackends, config)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	err = monitor.Start(ctx)
+	require.NoError(t, err)
+	defer func() {
+		_ = monitor.Stop()
+	}()
+
+	// Wait for initial backend to become healthy
+	require.Eventually(t, func() bool {
+		return monitor.IsBackendHealthy("backend-1")
+	}, 500*time.Millisecond, 10*time.Millisecond, "backend-1 should become healthy")
+
+	// Update the same backend with a new URL (simulating operator reconcile
+	// setting Status.URL after the Service is created)
+	updatedBackends := []vmcp.Backend{
+		{ID: "backend-1", Name: "Backend 1", BaseURL: "http://new-url:8080", TransportType: "sse"},
+	}
+
+	monitor.UpdateBackends(updatedBackends)
+
+	// The backend should still be monitored and become healthy at the new URL.
+	// The old goroutine is cancelled and a new one started with the updated properties.
+	require.Eventually(t, func() bool {
+		return monitor.IsBackendHealthy("backend-1")
+	}, 500*time.Millisecond, 10*time.Millisecond, "backend-1 should remain healthy after URL change")
+
+	// Verify the backend is the only one being monitored
+	summary := monitor.GetHealthSummary()
+	assert.Equal(t, 1, summary.Total, "should still have exactly 1 backend")
+	assert.Equal(t, 1, summary.Healthy, "backend should be healthy")
+}
+
 func TestMonitor_CircuitBreakerDisabled(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/vmcp/workloads/k8s.go
+++ b/pkg/vmcp/workloads/k8s.go
@@ -17,7 +17,6 @@ import (
 
 	mcpv1alpha1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1alpha1"
 	"github.com/stacklok/toolhive/pkg/k8s"
-	"github.com/stacklok/toolhive/pkg/transport"
 	transporttypes "github.com/stacklok/toolhive/pkg/transport/types"
 	"github.com/stacklok/toolhive/pkg/vmcp"
 	"github.com/stacklok/toolhive/pkg/vmcp/auth/converters"
@@ -203,24 +202,12 @@ func (d *k8sDiscoverer) mcpServerToBackend(ctx context.Context, mcpServer *mcpv1
 	// Calculate effective proxy mode
 	effectiveProxyMode := types.GetEffectiveProxyMode(transportType, mcpServer.Spec.ProxyMode)
 
-	// Generate URL from status or reconstruct from spec
+	// Use the URL from status, which is set by the MCPServer controller after
+	// creating the K8s Service. Do NOT fall back to localhost — in K8s mode,
+	// 127.0.0.1 inside the vMCP pod points to the vMCP itself (e.g. its metrics
+	// server on port 8080), not the backend. If Status.URL is empty, the backend
+	// will be skipped and added later by the reconciler once the URL is set.
 	url := mcpServer.Status.URL
-	if url == "" {
-		// Use ProxyPort (not McpPort) because it's the externally accessible port
-		// that the egress proxy listens on. This is what vMCP connects to.
-		// The McpPort is only for internal container-to-container communication.
-		port := int(mcpServer.GetProxyPort())
-		if port > 0 {
-			url = transport.GenerateMCPServerURL(
-				mcpServer.Spec.Transport,
-				mcpServer.Spec.ProxyMode,
-				transport.LocalhostIPv4,
-				port,
-				mcpServer.Name,
-				"",
-			)
-		}
-	}
 
 	// Map workload phase to backend health status
 	healthStatus := mapK8SWorkloadPhaseToHealth(mcpServer.Status.Phase)
@@ -391,14 +378,9 @@ func (d *k8sDiscoverer) mcpRemoteProxyToBackend(ctx context.Context, proxy *mcpv
 		transportType = transporttypes.TransportTypeStreamableHTTP
 	}
 
-	// Use the status URL if available, otherwise reconstruct from service name
+	// Use the URL from status, which is set by the controller after creating the
+	// K8s Service. Do NOT fall back to localhost — see mcpServerToBackend comment.
 	url := proxy.Status.URL
-	if url == "" {
-		port := int(proxy.GetProxyPort())
-		if port > 0 {
-			url = transport.GenerateMCPServerURL(proxy.Spec.Transport, "", transport.LocalhostIPv4, port, proxy.Name, "")
-		}
-	}
 
 	// Map proxy phase to backend health status
 	healthStatus := mapMCPRemoteProxyPhaseToHealth(proxy.Status.Phase)

--- a/pkg/vmcp/workloads/k8s_test.go
+++ b/pkg/vmcp/workloads/k8s_test.go
@@ -652,6 +652,80 @@ func TestListWorkloadsInGroup_MixedWorkloads(t *testing.T) {
 	})
 }
 
+func TestMCPServerToBackend_EmptyStatusURL(t *testing.T) {
+	t.Parallel()
+
+	namespace := testNamespace
+
+	// MCPServer is Running with transport and port, but Status.URL is empty
+	// (the controller hasn't reconciled the Service yet).
+	mcpServer := &mcpv1alpha1.MCPServer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pending-server",
+			Namespace: namespace,
+		},
+		Spec: mcpv1alpha1.MCPServerSpec{
+			Image:     "test-image:latest",
+			Transport: "streamable-http",
+			ProxyPort: 8080,
+		},
+		Status: mcpv1alpha1.MCPServerStatus{
+			Phase: mcpv1alpha1.MCPServerPhaseRunning,
+			// URL intentionally empty — not yet assigned by the operator
+		},
+	}
+
+	k8sClient := setupTestClient(t, mcpServer)
+	discoverer := NewK8SDiscovererWithClient(k8sClient, namespace)
+
+	ctx := context.Background()
+	backend, err := discoverer.GetWorkloadAsVMCPBackend(ctx, TypedWorkload{
+		Name: "pending-server",
+		Type: WorkloadTypeMCPServer,
+	})
+
+	// Backend should be skipped (nil) because Status.URL is empty.
+	// Previously the code fell back to a localhost URL which pointed to the
+	// wrong target inside K8s pods.
+	require.NoError(t, err)
+	require.Nil(t, backend, "should return nil backend when Status.URL is empty")
+}
+
+func TestMCPRemoteProxyToBackend_EmptyStatusURL(t *testing.T) {
+	t.Parallel()
+
+	namespace := testNamespace
+
+	// MCPRemoteProxy is Ready with transport, but Status.URL is empty.
+	proxy := &mcpv1alpha1.MCPRemoteProxy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pending-proxy",
+			Namespace: namespace,
+		},
+		Spec: mcpv1alpha1.MCPRemoteProxySpec{
+			RemoteURL: "https://remote-mcp.example.com",
+			Transport: "streamable-http",
+		},
+		Status: mcpv1alpha1.MCPRemoteProxyStatus{
+			Phase: mcpv1alpha1.MCPRemoteProxyPhaseReady,
+			// URL intentionally empty — not yet assigned by the operator
+		},
+	}
+
+	k8sClient := setupTestClient(t, proxy)
+	discoverer := NewK8SDiscovererWithClient(k8sClient, namespace)
+
+	ctx := context.Background()
+	backend, err := discoverer.GetWorkloadAsVMCPBackend(ctx, TypedWorkload{
+		Name: "pending-proxy",
+		Type: WorkloadTypeMCPRemoteProxy,
+	})
+
+	// Backend should be skipped (nil) because Status.URL is empty.
+	require.NoError(t, err)
+	require.Nil(t, backend, "should return nil backend when Status.URL is empty")
+}
+
 func TestMCPRemoteProxyToBackend_BasicFields(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

The `VirtualMCPServer Horizontal Scaling` e2e test intermittently timed out (300s) waiting for the VirtualMCPServer to become Ready, failing with "All backends are unhealthy". The health monitor permanently reported `server returned 4xx for initialize POST`.

**Root cause:** two bugs working together:

1. **Wrong localhost fallback in K8s backend discovery** — when `MCPServer.Status.URL` hadn't been set yet by the operator (race during startup), `mcpServerToBackend` fell back to `http://127.0.0.1:8080/mcp`. Inside the vMCP pod, port 8080 is the controller-runtime metrics server, which returns 4xx to MCP POST requests.

2. **Stale backend in health monitor** — `UpdateBackends()` only handled adding/removing backends by ID. When the reconciler later updated the registry with the correct service URL, the health check goroutine kept using the captured stale localhost pointer forever.

**Fix:**
- Remove the localhost fallback for both MCPServer and MCPRemoteProxy — if `Status.URL` is empty the backend is skipped and the reconciler adds it once the URL is set
- Teach `UpdateBackends` to restart goroutines when a backend's URL or transport type changes (defense-in-depth)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes

| File | Change |
|---|---|
| `pkg/vmcp/workloads/k8s.go` | Remove localhost URL fallback for MCPServer and MCPRemoteProxy when `Status.URL` is empty |
| `pkg/vmcp/health/monitor.go` | `UpdateBackends()` detects property changes (URL, transport) and restarts monitoring goroutines; add `backendChanged()` helper |
| `pkg/vmcp/workloads/k8s_test.go` | Tests for empty `Status.URL` → backend skipped |
| `pkg/vmcp/health/monitor_test.go` | Tests for `backendChanged()` and `UpdateBackends` property-change restart |

## Test plan

- [x] Existing unit tests pass (`go test ./pkg/vmcp/...`)
- [x] New unit tests cover the empty URL skip and property-change restart scenarios
- [x] Lint passes (only pre-existing goconst issue remains)

## Special notes for reviewers

The flakiness depends on whether the MCPServer controller sets `Status.URL` before or after the vMCP discovers backends. Fast operator reconcile → correct URL → test passes. Slow reconcile → localhost fallback → permanent health check failure.

The localhost fallback was fundamentally wrong for K8s mode where vMCP runs in a separate pod from the backend. Removing it is safe because the backend reconciler (watch controller) will add backends to the registry once `Status.URL` is populated.

Generated with [Claude Code](https://claude.com/claude-code)