### PR TITLE
Fix stale MCPOIDCConfig printer column JSONPaths

### DIFF
--- a/cmd/thv-operator/api/v1alpha1/mcpoidcconfig_types.go
+++ b/cmd/thv-operator/api/v1alpha1/mcpoidcconfig_types.go
@@ -189,8 +189,8 @@ type MCPOIDCConfigStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:shortName=mcpoidc,categories=toolhive
 // +kubebuilder:printcolumn:name="Source",type=string,JSONPath=`.spec.type`
-// +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=='Valid')].status`
-// +kubebuilder:printcolumn:name="References",type=string,JSONPath=`.status.referencingServers`
+// +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=='Ready')].status`
+// +kubebuilder:printcolumn:name="References",type=string,JSONPath=`.status.referencingWorkloads`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // MCPOIDCConfig is the Schema for the mcpoidcconfigs API.

--- a/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpoidcconfigs.yaml
+++ b/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpoidcconfigs.yaml
@@ -22,10 +22,10 @@ spec:
     - jsonPath: .spec.type
       name: Source
       type: string
-    - jsonPath: .status.conditions[?(@.type=='Valid')].status
+    - jsonPath: .status.conditions[?(@.type=='Ready')].status
       name: Ready
       type: string
-    - jsonPath: .status.referencingServers
+    - jsonPath: .status.referencingWorkloads
       name: References
       type: string
     - jsonPath: .metadata.creationTimestamp

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpoidcconfigs.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpoidcconfigs.yaml
@@ -25,10 +25,10 @@ spec:
     - jsonPath: .spec.type
       name: Source
       type: string
-    - jsonPath: .status.conditions[?(@.type=='Valid')].status
+    - jsonPath: .status.conditions[?(@.type=='Ready')].status
       name: Ready
       type: string
-    - jsonPath: .status.referencingServers
+    - jsonPath: .status.referencingWorkloads
       name: References
       type: string
     - jsonPath: .metadata.creationTimestamp


### PR DESCRIPTION
## Summary

The MCPOIDCConfig printer columns for `Ready` and `References` were not updated when the condition type was renamed from `Valid` to `Ready` (PR #4490) and the status field was renamed from `referencingServers` to `referencingWorkloads` (PR #4492). This caused both columns to show empty in `kubectl get mcpoidc` output.

- Update `Ready` column JSONPath from `@.type=='Valid'` to `@.type=='Ready'`
- Update `References` column JSONPath from `.status.referencingServers` to `.status.referencingWorkloads`
- Regenerate CRD manifests via `task operator-manifests`

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test`) — MCPOIDCConfig controller tests pass
- [x] Linting (`task lint-fix`) — no new issues (pre-existing unparam in unrelated file)

## Does this introduce a user-facing change?

Yes. `kubectl get mcpoidc` will now correctly display the `READY` and `REFERENCES` columns instead of showing empty values.

Generated with [Claude Code](https://claude.com/claude-code)