### PR TITLE
Extract backendCheck type for per-backend goroutine lifecycle

### DIFF
--- a/pkg/vmcp/health/monitor.go
+++ b/pkg/vmcp/health/monitor.go
@@ -72,7 +72,7 @@ type backendCheck struct {
 // Locking: the caller must hold both m.mu and m.backendsMu. m.mu prevents
 // wg.Add() from racing with wg.Wait() in Stop().
 func (bc *backendCheck) start(parentCtx context.Context, m *Monitor, isInitial bool) {
-	ctx, cancel := context.WithCancel(parentCtx) //nolint:gosec // G118 - cancel stored in bc.cancel, called via stop()
+	ctx, cancel := context.WithCancel(parentCtx)
 	bc.cancel = cancel
 	m.wg.Add(1)
 	if isInitial {


### PR DESCRIPTION
## Summary

Addresses [review feedback](https://github.com/stacklok/toolhive/pull/4524#discussion_r3033951659) from #4524: the `activeChecks` map held raw `context.CancelFunc` values, and goroutine lifecycle (cancel, create context, add to waitgroup, launch goroutine) was duplicated across `Start()` and `UpdateBackends()`.

This introduces a `backendCheck` struct that owns both the backend snapshot and the cancel function for a single health check goroutine, with `start()` and `stop()` methods. `activeChecks` now holds `*backendCheck` instead of bare cancel funcs, which:
- Consolidates goroutine lifecycle into one place
- Eliminates the separate `oldBackends` map in `UpdateBackends` since `activeChecks` now carries backend data directly
- Gives a natural place to hang future per-backend state (e.g., circuit breaker)

## Type of change

- [x] Refactoring (no functional changes)

## Changes

| File | Change |
|---|---|
| `pkg/vmcp/health/monitor.go` | Add `backendCheck` struct with `start()`/`stop()` methods; update `Monitor.activeChecks` type from `map[string]context.CancelFunc` to `map[string]*backendCheck`; simplify `Start()` and `UpdateBackends()` |

## Test plan

- [x] All existing health monitor tests pass (no behavioral change)
- [x] Lint passes with zero issues
- [x] Full build succeeds

Generated with [Claude Code](https://claude.com/claude-code)