### PR TITLE
Route OIDCConfigHash through StatusManager in VirtualMCPServer

### DIFF
--- a/cmd/thv-operator/controllers/virtualmcpserver_controller.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_controller.go
@@ -2772,10 +2772,7 @@ func (r *VirtualMCPServerReconciler) handleOIDCConfig(
 	if vmcp.Spec.IncomingAuth == nil || vmcp.Spec.IncomingAuth.OIDCConfigRef == nil {
 		// No MCPOIDCConfig referenced, clear any stored hash
 		if vmcp.Status.OIDCConfigHash != "" {
-			vmcp.Status.OIDCConfigHash = ""
-			if err := r.Status().Update(ctx, vmcp); err != nil {
-				return fmt.Errorf("failed to clear MCPOIDCConfig hash from status: %w", err)
-			}
+			statusManager.SetOIDCConfigHash("")
 		}
 		return nil
 	}
@@ -2842,10 +2839,7 @@ func (r *VirtualMCPServerReconciler) handleOIDCConfig(
 			"oldHash", vmcp.Status.OIDCConfigHash,
 			"newHash", oidcConfig.Status.ConfigHash)
 
-		vmcp.Status.OIDCConfigHash = oidcConfig.Status.ConfigHash
-		if err := r.Status().Update(ctx, vmcp); err != nil {
-			return fmt.Errorf("failed to update MCPOIDCConfig hash in status: %w", err)
-		}
+		statusManager.SetOIDCConfigHash(oidcConfig.Status.ConfigHash)
 	}
 
 	return nil

--- a/cmd/thv-operator/pkg/virtualmcpserverstatus/collector.go
+++ b/cmd/thv-operator/pkg/virtualmcpserverstatus/collector.go
@@ -25,6 +25,7 @@ type StatusCollector struct {
 	message            *string
 	url                *string
 	observedGeneration *int64
+	oidcConfigHash     *string
 	conditions         map[string]metav1.Condition
 	discoveredBackends []mcpv1alpha1.DiscoveredBackend
 }
@@ -69,6 +70,12 @@ func (s *StatusCollector) SetURL(url string) {
 // SetObservedGeneration sets the observed generation to be updated.
 func (s *StatusCollector) SetObservedGeneration(generation int64) {
 	s.observedGeneration = &generation
+	s.hasChanges = true
+}
+
+// SetOIDCConfigHash sets the OIDC config hash to be updated.
+func (s *StatusCollector) SetOIDCConfigHash(hash string) {
+	s.oidcConfigHash = &hash
 	s.hasChanges = true
 }
 
@@ -169,6 +176,11 @@ func (s *StatusCollector) UpdateStatus(ctx context.Context, vmcpStatus *mcpv1alp
 			vmcpStatus.ObservedGeneration = *s.observedGeneration
 		}
 
+		// Apply OIDC config hash change
+		if s.oidcConfigHash != nil {
+			vmcpStatus.OIDCConfigHash = *s.oidcConfigHash
+		}
+
 		// Apply condition changes
 		for _, condition := range s.conditions {
 			if condition.Status == "" {
@@ -195,6 +207,7 @@ func (s *StatusCollector) UpdateStatus(ctx context.Context, vmcpStatus *mcpv1alp
 		ctxLogger.V(1).Info("Batched status update applied",
 			"phase", s.phase,
 			"message", s.message,
+			"oidcConfigHash", s.oidcConfigHash,
 			"conditionsCount", len(s.conditions),
 			"discoveredBackendsCount", len(s.discoveredBackends))
 		return true

--- a/cmd/thv-operator/pkg/virtualmcpserverstatus/collector_test.go
+++ b/cmd/thv-operator/pkg/virtualmcpserverstatus/collector_test.go
@@ -73,6 +73,36 @@ func TestStatusCollector_SetObservedGeneration(t *testing.T) {
 	assert.Equal(t, int64(42), status.ObservedGeneration)
 }
 
+func TestStatusCollector_SetOIDCConfigHash(t *testing.T) {
+	t.Parallel()
+
+	vmcp := &mcpv1alpha1.VirtualMCPServer{}
+	collector := NewStatusManager(vmcp)
+
+	collector.SetOIDCConfigHash("abc123hash")
+
+	status := &mcpv1alpha1.VirtualMCPServerStatus{}
+	hasUpdates := collector.UpdateStatus(context.Background(), status)
+
+	assert.True(t, hasUpdates)
+	assert.Equal(t, "abc123hash", status.OIDCConfigHash)
+}
+
+func TestStatusCollector_SetOIDCConfigHash_Clear(t *testing.T) {
+	t.Parallel()
+
+	vmcp := &mcpv1alpha1.VirtualMCPServer{}
+	collector := NewStatusManager(vmcp)
+
+	collector.SetOIDCConfigHash("")
+
+	status := &mcpv1alpha1.VirtualMCPServerStatus{OIDCConfigHash: "old-hash"}
+	hasUpdates := collector.UpdateStatus(context.Background(), status)
+
+	assert.True(t, hasUpdates)
+	assert.Empty(t, status.OIDCConfigHash)
+}
+
 func TestStatusCollector_SetGroupRefValidatedCondition(t *testing.T) {
 	t.Parallel()
 
@@ -122,6 +152,7 @@ func TestStatusCollector_BatchedUpdates(t *testing.T) {
 	collector.SetMessage("test message")
 	collector.SetURL("http://test.example.com")
 	collector.SetObservedGeneration(42)
+	collector.SetOIDCConfigHash("oidc-hash-123")
 	collector.SetGroupRefValidatedCondition("TestReason", "group is valid", metav1.ConditionTrue)
 	collector.SetReadyCondition("DeploymentReady", "deployment is ready", metav1.ConditionTrue)
 
@@ -134,6 +165,7 @@ func TestStatusCollector_BatchedUpdates(t *testing.T) {
 	assert.Equal(t, "test message", status.Message)
 	assert.Equal(t, "http://test.example.com", status.URL)
 	assert.Equal(t, int64(42), status.ObservedGeneration)
+	assert.Equal(t, "oidc-hash-123", status.OIDCConfigHash)
 	assert.Len(t, status.Conditions, 2)
 }
 

--- a/cmd/thv-operator/pkg/virtualmcpserverstatus/mocks/mock_collector.go
+++ b/cmd/thv-operator/pkg/virtualmcpserverstatus/mocks/mock_collector.go
@@ -162,6 +162,18 @@ func (mr *MockStatusManagerMockRecorder) SetMessage(message any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetMessage", reflect.TypeOf((*MockStatusManager)(nil).SetMessage), message)
 }
 
+// SetOIDCConfigHash mocks base method.
+func (m *MockStatusManager) SetOIDCConfigHash(hash string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetOIDCConfigHash", hash)
+}
+
+// SetOIDCConfigHash indicates an expected call of SetOIDCConfigHash.
+func (mr *MockStatusManagerMockRecorder) SetOIDCConfigHash(hash any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetOIDCConfigHash", reflect.TypeOf((*MockStatusManager)(nil).SetOIDCConfigHash), hash)
+}
+
 // SetObservedGeneration mocks base method.
 func (m *MockStatusManager) SetObservedGeneration(generation int64) {
 	m.ctrl.T.Helper()

--- a/cmd/thv-operator/pkg/virtualmcpserverstatus/types.go
+++ b/cmd/thv-operator/pkg/virtualmcpserverstatus/types.go
@@ -32,6 +32,9 @@ type StatusManager interface {
 	// SetObservedGeneration sets the observed generation
 	SetObservedGeneration(generation int64)
 
+	// SetOIDCConfigHash sets the OIDC config hash for change detection
+	SetOIDCConfigHash(hash string)
+
 	// SetGroupRefValidatedCondition sets the GroupRef validation condition
 	SetGroupRefValidatedCondition(reason, message string, status metav1.ConditionStatus)
 


### PR DESCRIPTION
## Summary

`handleOIDCConfig` wrote `OIDCConfigHash` directly via `r.Status().Update(ctx, vmcp)` while every other VirtualMCPServer status field used the batched `StatusManager`. This mixed-write pattern could produce spurious 409 Conflict errors when the original `vmcp` object's `resourceVersion` became stale after earlier `applyStatusUpdates` calls in the same reconciliation.

Adds `SetOIDCConfigHash` to the `StatusManager` interface and routes both the set and clear paths through it, eliminating all direct VirtualMCPServer status writes from `handleOIDCConfig`.

Fixes #4504

## Type of change

- [x] Bug fix

## Changes

| File | Change |
|------|--------|
| `types.go` | Add `SetOIDCConfigHash(hash string)` to `StatusManager` interface |
| `collector.go` | Add `oidcConfigHash *string` field, setter, `UpdateStatus` application logic, debug log |
| `virtualmcpserver_controller.go` | Replace 2 direct `r.Status().Update()` calls with `statusManager.SetOIDCConfigHash(...)` |
| `collector_test.go` | Add set + clear tests, update batched test |
| `mocks/mock_collector.go` | Regenerated via `go generate` |

## Test plan

- [x] Unit tests (`task test`) — all pass, including 2 new collector tests
- [x] Linting (`task lint`) — 0 issues
- [x] Existing integration tests unaffected (no VirtualMCPServer unit test exercises `handleOIDCConfig`)

## Special notes for reviewers

- The `r.Status().Update(ctx, oidcConfig)` in `updateOIDCConfigReferencingWorkloads` is intentionally unchanged — it writes to the MCPOIDCConfig resource (different resource), not VirtualMCPServer.
- Empty string clears the hash (matching `SetURL`/`SetMessage` semantics). The `*string` pointer in the collector distinguishes "never called" from "called with empty string".
- After this fix, `handleOIDCConfig` makes zero direct VirtualMCPServer status writes on any path.

Generated with [Claude Code](https://claude.com/claude-code)