### PR TITLE
fix(operator): add +listType=map and +listMapKey=type to CRD Conditions fields

### DIFF
--- a/cmd/thv-operator/api/v1alpha1/embeddingserver_types.go
+++ b/cmd/thv-operator/api/v1alpha1/embeddingserver_types.go
@@ -156,6 +156,8 @@ type EmbeddingStatefulSetOverrides struct {
 // EmbeddingServerStatus defines the observed state of EmbeddingServer
 type EmbeddingServerStatus struct {
 	// Conditions represent the latest available observations of the EmbeddingServer's state
+	// +listType=map
+	// +listMapKey=type
 	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 

--- a/cmd/thv-operator/api/v1alpha1/mcpexternalauthconfig_types.go
+++ b/cmd/thv-operator/api/v1alpha1/mcpexternalauthconfig_types.go
@@ -704,6 +704,8 @@ type UpstreamInjectSpec struct {
 // MCPExternalAuthConfigStatus defines the observed state of MCPExternalAuthConfig
 type MCPExternalAuthConfigStatus struct {
 	// Conditions represent the latest available observations of the MCPExternalAuthConfig's state
+	// +listType=map
+	// +listMapKey=type
 	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 

--- a/cmd/thv-operator/api/v1alpha1/mcpgroup_types.go
+++ b/cmd/thv-operator/api/v1alpha1/mcpgroup_types.go
@@ -42,6 +42,8 @@ type MCPGroupStatus struct {
 	RemoteProxyCount int `json:"remoteProxyCount,omitempty"`
 
 	// Conditions represent observations
+	// +listType=map
+	// +listMapKey=type
 	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }

--- a/cmd/thv-operator/api/v1alpha1/mcpoidcconfig_types.go
+++ b/cmd/thv-operator/api/v1alpha1/mcpoidcconfig_types.go
@@ -168,6 +168,8 @@ type WorkloadReference struct {
 // MCPOIDCConfigStatus defines the observed state of MCPOIDCConfig
 type MCPOIDCConfigStatus struct {
 	// Conditions represent the latest available observations of the MCPOIDCConfig's state
+	// +listType=map
+	// +listMapKey=type
 	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 

--- a/cmd/thv-operator/api/v1alpha1/mcpremoteproxy_types.go
+++ b/cmd/thv-operator/api/v1alpha1/mcpremoteproxy_types.go
@@ -157,6 +157,8 @@ type MCPRemoteProxyStatus struct {
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 
 	// Conditions represent the latest available observations of the MCPRemoteProxy's state
+	// +listType=map
+	// +listMapKey=type
 	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 

--- a/cmd/thv-operator/api/v1alpha1/mcpserver_types.go
+++ b/cmd/thv-operator/api/v1alpha1/mcpserver_types.go
@@ -882,6 +882,8 @@ type OpenTelemetryMetricsConfig struct {
 // MCPServerStatus defines the observed state of MCPServer
 type MCPServerStatus struct {
 	// Conditions represent the latest available observations of the MCPServer's state
+	// +listType=map
+	// +listMapKey=type
 	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 

--- a/cmd/thv-operator/api/v1alpha1/mcptelemetryconfig_types.go
+++ b/cmd/thv-operator/api/v1alpha1/mcptelemetryconfig_types.go
@@ -98,6 +98,8 @@ type MCPTelemetryConfigSpec struct {
 // MCPTelemetryConfigStatus defines the observed state of MCPTelemetryConfig
 type MCPTelemetryConfigStatus struct {
 	// Conditions represent the latest available observations of the MCPTelemetryConfig's state
+	// +listType=map
+	// +listMapKey=type
 	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 

--- a/cmd/thv-operator/api/v1alpha1/virtualmcpcompositetooldefinition_types.go
+++ b/cmd/thv-operator/api/v1alpha1/virtualmcpcompositetooldefinition_types.go
@@ -39,6 +39,8 @@ type VirtualMCPCompositeToolDefinitionStatus struct {
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 
 	// Conditions represent the latest available observations of the workflow's state
+	// +listType=map
+	// +listMapKey=type
 	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }

--- a/cmd/thv-operator/api/v1alpha1/virtualmcpserver_types.go
+++ b/cmd/thv-operator/api/v1alpha1/virtualmcpserver_types.go
@@ -191,6 +191,8 @@ type DiscoveredBackend = vmcptypes.DiscoveredBackend
 // VirtualMCPServerStatus defines the observed state of VirtualMCPServer
 type VirtualMCPServerStatus struct {
 	// Conditions represent the latest available observations of the VirtualMCPServer's state
+	// +listType=map
+	// +listMapKey=type
 	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 

--- a/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_embeddingservers.yaml
+++ b/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_embeddingservers.yaml
@@ -321,6 +321,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               message:
                 description: Message provides additional information about the current
                   phase

--- a/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpexternalauthconfigs.yaml
+++ b/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpexternalauthconfigs.yaml
@@ -946,6 +946,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               configHash:
                 description: ConfigHash is a hash of the current configuration for
                   change detection

--- a/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpgroups.yaml
+++ b/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpgroups.yaml
@@ -121,6 +121,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               observedGeneration:
                 description: ObservedGeneration reflects the generation most recently
                   observed by the controller

--- a/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpoidcconfigs.yaml
+++ b/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpoidcconfigs.yaml
@@ -264,6 +264,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               configHash:
                 description: ConfigHash is a hash of the current configuration for
                   change detection

--- a/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpremoteproxies.yaml
+++ b/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpremoteproxies.yaml
@@ -756,6 +756,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               externalAuthConfigHash:
                 description: ExternalAuthConfigHash is the hash of the referenced
                   MCPExternalAuthConfig spec

--- a/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpservers.yaml
+++ b/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpservers.yaml
@@ -928,6 +928,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               externalAuthConfigHash:
                 description: ExternalAuthConfigHash is the hash of the referenced
                   MCPExternalAuthConfig spec

--- a/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcptelemetryconfigs.yaml
+++ b/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcptelemetryconfigs.yaml
@@ -237,6 +237,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               configHash:
                 description: ConfigHash is a hash of the current configuration for
                   change detection

--- a/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_virtualmcpcompositetooldefinitions.yaml
+++ b/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_virtualmcpcompositetooldefinitions.yaml
@@ -386,6 +386,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               observedGeneration:
                 description: |-
                   ObservedGeneration is the most recent generation observed for this VirtualMCPCompositeToolDefinition

--- a/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_virtualmcpservers.yaml
+++ b/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_virtualmcpservers.yaml
@@ -2316,6 +2316,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               discoveredBackends:
                 description: DiscoveredBackends lists discovered backend configurations
                   from the MCPGroup

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_embeddingservers.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_embeddingservers.yaml
@@ -324,6 +324,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               message:
                 description: Message provides additional information about the current
                   phase

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpexternalauthconfigs.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpexternalauthconfigs.yaml
@@ -949,6 +949,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               configHash:
                 description: ConfigHash is a hash of the current configuration for
                   change detection

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpgroups.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpgroups.yaml
@@ -124,6 +124,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               observedGeneration:
                 description: ObservedGeneration reflects the generation most recently
                   observed by the controller

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpoidcconfigs.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpoidcconfigs.yaml
@@ -267,6 +267,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               configHash:
                 description: ConfigHash is a hash of the current configuration for
                   change detection

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpremoteproxies.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpremoteproxies.yaml
@@ -759,6 +759,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               externalAuthConfigHash:
                 description: ExternalAuthConfigHash is the hash of the referenced
                   MCPExternalAuthConfig spec

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpservers.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpservers.yaml
@@ -931,6 +931,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               externalAuthConfigHash:
                 description: ExternalAuthConfigHash is the hash of the referenced
                   MCPExternalAuthConfig spec

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcptelemetryconfigs.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcptelemetryconfigs.yaml
@@ -240,6 +240,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               configHash:
                 description: ConfigHash is a hash of the current configuration for
                   change detection

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_virtualmcpcompositetooldefinitions.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_virtualmcpcompositetooldefinitions.yaml
@@ -389,6 +389,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               observedGeneration:
                 description: |-
                   ObservedGeneration is the most recent generation observed for this VirtualMCPCompositeToolDefinition

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_virtualmcpservers.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_virtualmcpservers.yaml
@@ -2319,6 +2319,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               discoveredBackends:
                 description: DiscoveredBackends lists discovered backend configurations
                   from the MCPGroup


### PR DESCRIPTION
9 out of 11 CRDs were missing the standard Kubernetes `+listType=map` and `+listMapKey=type` markers on their `Conditions` fields. Without these markers, Server-Side Apply treats the conditions list as atomic, replacing the entire list on each update rather than merging by condition type.

MCPRegistry and MCPToolConfig already had the correct markers. This brings the remaining 9 CRDs into alignment with upstream Kubernetes API conventions.

**Changes:**
- Added `+listType=map` and `+listMapKey=type` markers to Conditions fields in: MCPServer, VirtualMCPServer, MCPGroup, MCPRemoteProxy, MCPExternalAuthConfig, EmbeddingServer, VirtualMCPCompositeToolDefinition, MCPOIDCConfig, MCPTelemetryConfig
- Regenerated CRD manifests via `task operator-manifests`

No controller code changes needed. Current controllers use `Status().Update()` (PUT), so this is a markers-only schema metadata change. Existing manifests continue to work without modification.

- `task lint` passes (0 issues)
- `go build ./cmd/thv-operator/...` compiles clean

Fixes #4535