### PR TITLE
feat(operator): add Ready printer column to MCPRemoteProxy CRD

### DIFF
--- a/cmd/thv-operator/api/v1alpha1/mcpremoteproxy_types.go
+++ b/cmd/thv-operator/api/v1alpha1/mcpremoteproxy_types.go
@@ -304,6 +304,7 @@ const (
 //+kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase"
 //+kubebuilder:printcolumn:name="Remote URL",type="string",JSONPath=".spec.remoteURL"
 //+kubebuilder:printcolumn:name="URL",type="string",JSONPath=".status.url"
+//+kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"
 //+kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
 // MCPRemoteProxy is the Schema for the mcpremoteproxies API

--- a/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpremoteproxies.yaml
+++ b/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpremoteproxies.yaml
@@ -26,6 +26,9 @@ spec:
     - jsonPath: .status.url
       name: URL
       type: string
+    - jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: Ready
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpremoteproxies.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpremoteproxies.yaml
@@ -29,6 +29,9 @@ spec:
     - jsonPath: .status.url
       name: URL
       type: string
+    - jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: Ready
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date


### PR DESCRIPTION
MCPRemoteProxy was missing a Ready column in `kubectl get` output while other CRDs (MCPServer, MCPToolConfig, MCPGroup, MCPExternalAuthConfig) all surface their condition status. The controller already sets the Ready condition on MCPRemoteProxy resources; this adds the printer column to make it visible.

**Changes:**
- Added `+kubebuilder:printcolumn` marker for Ready status in `mcpremoteproxy_types.go`
- Regenerated CRD manifests via `task operator-manifests`

Fixes #4541