### PR TITLE
Sort client status output alphabetically

### DIFF
--- a/cmd/thv/app/ui/clients_status.go
+++ b/cmd/thv/app/ui/clients_status.go
@@ -22,6 +22,11 @@ func RenderClientStatusTable(clientStatuses []client.ClientAppStatus) error {
 		return nil
 	}
 
+	// Sort clients alphabetically by name
+	sort.Slice(clientStatuses, func(i, j int) bool {
+		return clientStatuses[i].ClientType < clientStatuses[j].ClientType
+	})
+
 	table := tablewriter.NewWriter(os.Stdout)
 	table.Options(
 		tablewriter.WithHeader([]string{"Client Type", "Installed", "Registered"}),


### PR DESCRIPTION
## Summary

- `thv client status` displayed clients in whatever order `supportedClientIntegrations` was defined, while `list-registered` and `setup` both sorted alphabetically. This made the CLI feel inconsistent.
- Add a `sort.Slice` in `RenderClientStatusTable` to match the pattern already used in `RenderRegisteredClientsTable` in the same file.

Fixes #4565

## Type of change

- [x] Bug fix

## Test plan

- [x] Linting (`task lint-fix`)
- [x] Manual testing (describe below)

Ran `thv client status` and verified all clients now appear in alphabetical order.

## Does this introduce a user-facing change?

`thv client status` now lists clients in alphabetical order, consistent with `thv client list-registered` and `thv client setup`.

Generated with [Claude Code](https://claude.com/claude-code)