### PR TITLE
fix(operator): standardize secret references to custom SecretKeyRef

### DIFF
--- a/cmd/thv-operator/api/v1alpha1/mcpregistry_types.go
+++ b/cmd/thv-operator/api/v1alpha1/mcpregistry_types.go
@@ -178,7 +178,7 @@ type GitAuthConfig struct {
 	//     key: token
 	//
 	// +kubebuilder:validation:Required
-	PasswordSecretRef corev1.SecretKeySelector `json:"passwordSecretRef"`
+	PasswordSecretRef SecretKeyRef `json:"passwordSecretRef"`
 }
 
 // APISource defines API source configuration for ToolHive Registry APIs
@@ -344,14 +344,14 @@ type MCPRegistryDatabaseConfig struct {
 	// that is mounted to the registry API container.
 	//
 	// +kubebuilder:validation:Required
-	DBAppUserPasswordSecretRef corev1.SecretKeySelector `json:"dbAppUserPasswordSecretRef"`
+	DBAppUserPasswordSecretRef SecretKeyRef `json:"dbAppUserPasswordSecretRef"`
 
 	// DBMigrationUserPasswordSecretRef references a Kubernetes Secret containing the password for the migration database user.
 	// The operator will use this password along with DBAppUserPasswordSecretRef to generate a pgpass file
 	// that is mounted to the registry API container.
 	//
 	// +kubebuilder:validation:Required
-	DBMigrationUserPasswordSecretRef corev1.SecretKeySelector `json:"dbMigrationUserPasswordSecretRef"`
+	DBMigrationUserPasswordSecretRef SecretKeyRef `json:"dbMigrationUserPasswordSecretRef"`
 }
 
 // MCPRegistryAuthMode represents the authentication mode for the registry API server
@@ -441,7 +441,7 @@ type MCPRegistryOAuthProviderConfig struct {
 	// ClientSecretRef is a reference to a Secret containing the client secret
 	// The secret should have a key "clientSecret" containing the secret value
 	// +optional
-	ClientSecretRef *corev1.SecretKeySelector `json:"clientSecretRef,omitempty"`
+	ClientSecretRef *SecretKeyRef `json:"clientSecretRef,omitempty"`
 
 	// CACertRef is a reference to a ConfigMap containing the CA certificate bundle
 	// for verifying the provider's TLS certificate.
@@ -458,7 +458,7 @@ type MCPRegistryOAuthProviderConfig struct {
 	// to OIDC/JWKS endpoints. Useful when the OIDC discovery or JWKS endpoint requires authentication.
 	// Example: ServiceAccount token for Kubernetes API server
 	// +optional
-	AuthTokenRef *corev1.SecretKeySelector `json:"authTokenRef,omitempty"`
+	AuthTokenRef *SecretKeyRef `json:"authTokenRef,omitempty"`
 
 	// AuthTokenFile is the path to a file containing a bearer token for authenticating to OIDC/JWKS endpoints.
 	// Useful when the OIDC discovery or JWKS endpoint requires authentication.

--- a/cmd/thv-operator/api/v1alpha1/zz_generated.deepcopy.go
+++ b/cmd/thv-operator/api/v1alpha1/zz_generated.deepcopy.go
@@ -1303,8 +1303,8 @@ func (in *MCPRegistryOAuthProviderConfig) DeepCopyInto(out *MCPRegistryOAuthProv
 	*out = *in
 	if in.ClientSecretRef != nil {
 		in, out := &in.ClientSecretRef, &out.ClientSecretRef
-		*out = new(corev1.SecretKeySelector)
-		(*in).DeepCopyInto(*out)
+		*out = new(SecretKeyRef)
+		**out = **in
 	}
 	if in.CACertRef != nil {
 		in, out := &in.CACertRef, &out.CACertRef
@@ -1313,8 +1313,8 @@ func (in *MCPRegistryOAuthProviderConfig) DeepCopyInto(out *MCPRegistryOAuthProv
 	}
 	if in.AuthTokenRef != nil {
 		in, out := &in.AuthTokenRef, &out.AuthTokenRef
-		*out = new(corev1.SecretKeySelector)
-		(*in).DeepCopyInto(*out)
+		*out = new(SecretKeyRef)
+		**out = **in
 	}
 }
 

--- a/cmd/thv-operator/pkg/kubernetes/doc.go
+++ b/cmd/thv-operator/pkg/kubernetes/doc.go
@@ -20,7 +20,7 @@
 //	kubeClient := kubernetes.NewClient(ctrlClient, scheme)
 //
 //	// Access secrets operations via the Secrets field
-//	value, err := kubeClient.Secrets.GetValue(ctx, "default", secretKeySelector)
+//	value, err := kubeClient.Secrets.GetValue(ctx, "default", "secret-name", "secret-key")
 //
 //	// Upsert a secret with owner reference
 //	result, err := kubeClient.Secrets.UpsertWithOwnerReference(ctx, secret, ownerObject)

--- a/cmd/thv-operator/pkg/kubernetes/secrets/secrets.go
+++ b/cmd/thv-operator/pkg/kubernetes/secrets/secrets.go
@@ -45,17 +45,16 @@ func (c *Client) Get(ctx context.Context, name, namespace string) (*corev1.Secre
 }
 
 // GetValue retrieves a specific key's value from a Kubernetes Secret.
-// Uses a SecretKeySelector to identify the secret name and key.
 // Returns the value as a string, or an error if the secret or key is not found.
-func (c *Client) GetValue(ctx context.Context, namespace string, secretRef corev1.SecretKeySelector) (string, error) {
-	secret, err := c.Get(ctx, secretRef.Name, namespace)
+func (c *Client) GetValue(ctx context.Context, namespace, name, key string) (string, error) {
+	secret, err := c.Get(ctx, name, namespace)
 	if err != nil {
 		return "", err
 	}
 
-	value, exists := secret.Data[secretRef.Key]
+	value, exists := secret.Data[key]
 	if !exists {
-		return "", fmt.Errorf("key %s not found in secret %s", secretRef.Key, secretRef.Name)
+		return "", fmt.Errorf("key %s not found in secret %s", key, name)
 	}
 
 	return string(value), nil

--- a/cmd/thv-operator/pkg/kubernetes/secrets/secrets_test.go
+++ b/cmd/thv-operator/pkg/kubernetes/secrets/secrets_test.go
@@ -140,14 +140,7 @@ func TestGetValue(t *testing.T) {
 			Build()
 
 		client := NewClient(fakeClient, scheme)
-		secretRef := corev1.SecretKeySelector{
-			LocalObjectReference: corev1.LocalObjectReference{
-				Name: "test-secret",
-			},
-			Key: "password",
-		}
-
-		value, err := client.GetValue(ctx, "default", secretRef)
+		value, err := client.GetValue(ctx, "default", "test-secret", "password")
 
 		require.NoError(t, err)
 		assert.Equal(t, "super-secret-password", value)
@@ -163,14 +156,7 @@ func TestGetValue(t *testing.T) {
 			Build()
 
 		client := NewClient(fakeClient, scheme)
-		secretRef := corev1.SecretKeySelector{
-			LocalObjectReference: corev1.LocalObjectReference{
-				Name: "non-existent-secret",
-			},
-			Key: "password",
-		}
-
-		value, err := client.GetValue(ctx, "default", secretRef)
+		value, err := client.GetValue(ctx, "default", "non-existent-secret", "password")
 
 		require.Error(t, err)
 		assert.Empty(t, value)
@@ -198,14 +184,7 @@ func TestGetValue(t *testing.T) {
 			Build()
 
 		client := NewClient(fakeClient, scheme)
-		secretRef := corev1.SecretKeySelector{
-			LocalObjectReference: corev1.LocalObjectReference{
-				Name: "test-secret",
-			},
-			Key: "non-existent-key",
-		}
-
-		value, err := client.GetValue(ctx, "default", secretRef)
+		value, err := client.GetValue(ctx, "default", "test-secret", "non-existent-key")
 
 		require.Error(t, err)
 		assert.Empty(t, value)
@@ -243,14 +222,7 @@ func TestGetValue(t *testing.T) {
 			Build()
 
 		client := NewClient(fakeClient, scheme)
-		secretRef := corev1.SecretKeySelector{
-			LocalObjectReference: corev1.LocalObjectReference{
-				Name: "test-secret",
-			},
-			Key: "password",
-		}
-
-		value, err := client.GetValue(ctx, "namespace2", secretRef)
+		value, err := client.GetValue(ctx, "namespace2", "test-secret", "password")
 
 		require.NoError(t, err)
 		assert.Equal(t, "password2", value)
@@ -277,14 +249,7 @@ func TestGetValue(t *testing.T) {
 			Build()
 
 		client := NewClient(fakeClient, scheme)
-		secretRef := corev1.SecretKeySelector{
-			LocalObjectReference: corev1.LocalObjectReference{
-				Name: "test-secret",
-			},
-			Key: "empty-key",
-		}
-
-		value, err := client.GetValue(ctx, "default", secretRef)
+		value, err := client.GetValue(ctx, "default", "test-secret", "empty-key")
 
 		require.NoError(t, err)
 		assert.Empty(t, value)

--- a/cmd/thv-operator/pkg/registryapi/config/config.go
+++ b/cmd/thv-operator/pkg/registryapi/config/config.go
@@ -546,7 +546,7 @@ func buildGitAuthConfig(auth *mcpv1alpha1.GitAuthConfig) (*GitAuthConfig, error)
 
 // buildGitPasswordFilePath constructs the file path where a git password secret will be mounted.
 // The secretRef must have both Name and Key set (validated by buildGitAuthConfig).
-func buildGitPasswordFilePath(secretRef *corev1.SecretKeySelector) string {
+func buildGitPasswordFilePath(secretRef *mcpv1alpha1.SecretKeyRef) string {
 	if secretRef == nil {
 		return ""
 	}
@@ -761,7 +761,7 @@ func buildOAuthProviderConfig(
 }
 
 // buildSecretFilePath constructs the file path where a secret will be mounted
-func buildSecretFilePath(secretRef *corev1.SecretKeySelector) string {
+func buildSecretFilePath(secretRef *mcpv1alpha1.SecretKeyRef) string {
 	if secretRef == nil {
 		return ""
 	}

--- a/cmd/thv-operator/pkg/registryapi/config/config_test.go
+++ b/cmd/thv-operator/pkg/registryapi/config/config_test.go
@@ -495,11 +495,9 @@ func TestBuildConfig_GitAuth(t *testing.T) {
 							Path:       "registry.json",
 							Auth: &mcpv1alpha1.GitAuthConfig{
 								Username: "git",
-								PasswordSecretRef: corev1.SecretKeySelector{
-									LocalObjectReference: corev1.LocalObjectReference{
-										Name: "git-credentials",
-									},
-									Key: "token",
+								PasswordSecretRef: mcpv1alpha1.SecretKeyRef{
+									Name: "git-credentials",
+									Key:  "token",
 								},
 							},
 						},
@@ -543,10 +541,8 @@ func TestBuildConfig_GitAuth(t *testing.T) {
 							Path:       "registry.json",
 							Auth: &mcpv1alpha1.GitAuthConfig{
 								Username: "git",
-								PasswordSecretRef: corev1.SecretKeySelector{
-									LocalObjectReference: corev1.LocalObjectReference{
-										Name: "git-credentials",
-									},
+								PasswordSecretRef: mcpv1alpha1.SecretKeyRef{
+									Name: "git-credentials",
 									// Key is empty - should cause an error
 								},
 							},
@@ -581,11 +577,9 @@ func TestBuildConfig_GitAuth(t *testing.T) {
 							Path:       "registry.json",
 							Auth: &mcpv1alpha1.GitAuthConfig{
 								// Username is empty - should cause an error
-								PasswordSecretRef: corev1.SecretKeySelector{
-									LocalObjectReference: corev1.LocalObjectReference{
-										Name: "git-credentials",
-									},
-									Key: "token",
+								PasswordSecretRef: mcpv1alpha1.SecretKeyRef{
+									Name: "git-credentials",
+									Key:  "token",
 								},
 							},
 						},
@@ -619,11 +613,9 @@ func TestBuildConfig_GitAuth(t *testing.T) {
 							Path:       "registry.json",
 							Auth: &mcpv1alpha1.GitAuthConfig{
 								Username: "git",
-								PasswordSecretRef: corev1.SecretKeySelector{
-									LocalObjectReference: corev1.LocalObjectReference{
-										Name: "", // Empty name should cause an error
-									},
-									Key: "token",
+								PasswordSecretRef: mcpv1alpha1.SecretKeyRef{
+									Name: "", // Empty name should cause an error
+									Key:  "token",
 								},
 							},
 						},
@@ -1673,11 +1665,9 @@ func TestBuildConfig_AuthConfig(t *testing.T) {
 								IssuerURL: "https://keycloak.example.com/realms/myrealm",
 								Audience:  "registry-api",
 								ClientID:  "registry-client",
-								ClientSecretRef: &corev1.SecretKeySelector{
-									LocalObjectReference: corev1.LocalObjectReference{
-										Name: "keycloak-secret",
-									},
-									Key: "client-secret",
+								ClientSecretRef: &mcpv1alpha1.SecretKeyRef{
+									Name: "keycloak-secret",
+									Key:  "client-secret",
 								},
 								CACertRef: &corev1.ConfigMapKeySelector{
 									LocalObjectReference: corev1.LocalObjectReference{
@@ -1984,11 +1974,9 @@ func TestBuildSecretFilePath(t *testing.T) {
 
 	t.Run("secret ref with key", func(t *testing.T) {
 		t.Parallel()
-		secretRef := &corev1.SecretKeySelector{
-			LocalObjectReference: corev1.LocalObjectReference{
-				Name: "my-secret",
-			},
-			Key: "my-key",
+		secretRef := &mcpv1alpha1.SecretKeyRef{
+			Name: "my-secret",
+			Key:  "my-key",
 		}
 		result := buildSecretFilePath(secretRef)
 		assert.Equal(t, "/secrets/my-secret/my-key", result)
@@ -1996,11 +1984,9 @@ func TestBuildSecretFilePath(t *testing.T) {
 
 	t.Run("secret ref without key uses default", func(t *testing.T) {
 		t.Parallel()
-		secretRef := &corev1.SecretKeySelector{
-			LocalObjectReference: corev1.LocalObjectReference{
-				Name: "my-secret",
-			},
-			Key: "",
+		secretRef := &mcpv1alpha1.SecretKeyRef{
+			Name: "my-secret",
+			Key:  "",
 		}
 		result := buildSecretFilePath(secretRef)
 		assert.Equal(t, "/secrets/my-secret/clientSecret", result)
@@ -2176,11 +2162,9 @@ func TestBuildOAuthProviderConfig_DirectPaths(t *testing.T) {
 								IssuerURL:     "https://issuer.example.com",
 								Audience:      "my-app",
 								AuthTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token", // Direct path
-								AuthTokenRef: &corev1.SecretKeySelector{ // Should be ignored
-									LocalObjectReference: corev1.LocalObjectReference{
-										Name: "token-secret",
-									},
-									Key: "token",
+								AuthTokenRef: &mcpv1alpha1.SecretKeyRef{ // Should be ignored
+									Name: "token-secret",
+									Key:  "token",
 								},
 							},
 						},
@@ -2228,11 +2212,9 @@ func TestBuildOAuthProviderConfig_DirectPaths(t *testing.T) {
 								IssuerURL: "https://issuer.example.com",
 								Audience:  "my-app",
 								// AuthTokenFile not set
-								AuthTokenRef: &corev1.SecretKeySelector{
-									LocalObjectReference: corev1.LocalObjectReference{
-										Name: "token-secret",
-									},
-									Key: "my-token",
+								AuthTokenRef: &mcpv1alpha1.SecretKeyRef{
+									Name: "token-secret",
+									Key:  "my-token",
 								},
 							},
 						},

--- a/cmd/thv-operator/pkg/registryapi/deployment_test.go
+++ b/cmd/thv-operator/pkg/registryapi/deployment_test.go
@@ -190,11 +190,9 @@ func TestManagerBuildRegistryAPIDeployment(t *testing.T) {
 								Path:       "registry.json",
 								Auth: &mcpv1alpha1.GitAuthConfig{
 									Username: "git",
-									PasswordSecretRef: corev1.SecretKeySelector{
-										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "git-credentials",
-										},
-										Key: "token",
+									PasswordSecretRef: mcpv1alpha1.SecretKeyRef{
+										Name: "git-credentials",
+										Key:  "token",
 									},
 								},
 							},
@@ -260,11 +258,9 @@ func TestManagerBuildRegistryAPIDeployment(t *testing.T) {
 								Path:       "registry.json",
 								Auth: &mcpv1alpha1.GitAuthConfig{
 									Username: "git",
-									PasswordSecretRef: corev1.SecretKeySelector{
-										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "git-credentials-1",
-										},
-										Key: "token",
+									PasswordSecretRef: mcpv1alpha1.SecretKeyRef{
+										Name: "git-credentials-1",
+										Key:  "token",
 									},
 								},
 							},
@@ -278,11 +274,9 @@ func TestManagerBuildRegistryAPIDeployment(t *testing.T) {
 								Path:       "registry.json",
 								Auth: &mcpv1alpha1.GitAuthConfig{
 									Username: "git",
-									PasswordSecretRef: corev1.SecretKeySelector{
-										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "git-credentials-2",
-										},
-										Key: "password",
+									PasswordSecretRef: mcpv1alpha1.SecretKeyRef{
+										Name: "git-credentials-2",
+										Key:  "password",
 									},
 								},
 							},

--- a/cmd/thv-operator/pkg/registryapi/pgpass.go
+++ b/cmd/thv-operator/pkg/registryapi/pgpass.go
@@ -33,7 +33,12 @@ func (m *manager) ensurePGPassSecret(
 	dbConfig := mcpRegistry.GetDatabaseConfig()
 
 	// Read app user password from secret
-	appUserPassword, err := m.kubeHelper.Secrets.GetValue(ctx, mcpRegistry.Namespace, dbConfig.DBAppUserPasswordSecretRef)
+	appUserPassword, err := m.kubeHelper.Secrets.GetValue(
+		ctx,
+		mcpRegistry.Namespace,
+		dbConfig.DBAppUserPasswordSecretRef.Name,
+		dbConfig.DBAppUserPasswordSecretRef.Key,
+	)
 	if err != nil {
 		return fmt.Errorf("failed to read app user password from secret %s: %w",
 			dbConfig.DBAppUserPasswordSecretRef.Name, err)
@@ -41,7 +46,11 @@ func (m *manager) ensurePGPassSecret(
 
 	// Read migration user password from secret
 	migrationUserPassword, err := m.kubeHelper.Secrets.GetValue(
-		ctx, mcpRegistry.Namespace, dbConfig.DBMigrationUserPasswordSecretRef)
+		ctx,
+		mcpRegistry.Namespace,
+		dbConfig.DBMigrationUserPasswordSecretRef.Name,
+		dbConfig.DBMigrationUserPasswordSecretRef.Key,
+	)
 	if err != nil {
 		return fmt.Errorf("failed to read migration user password from secret %s: %w",
 			dbConfig.DBMigrationUserPasswordSecretRef.Name, err)

--- a/cmd/thv-operator/pkg/registryapi/pgpass_test.go
+++ b/cmd/thv-operator/pkg/registryapi/pgpass_test.go
@@ -256,13 +256,13 @@ func baseMCPRegistry(t *testing.T, opts ...func(*mcpv1alpha1.MCPRegistry)) *mcpv
 				Database:      "test_db",
 				User:          "app_user",
 				MigrationUser: "migration_user",
-				DBAppUserPasswordSecretRef: corev1.SecretKeySelector{
-					LocalObjectReference: corev1.LocalObjectReference{Name: "app-secret"},
-					Key:                  "password",
+				DBAppUserPasswordSecretRef: mcpv1alpha1.SecretKeyRef{
+					Name: "app-secret",
+					Key:  "password",
 				},
-				DBMigrationUserPasswordSecretRef: corev1.SecretKeySelector{
-					LocalObjectReference: corev1.LocalObjectReference{Name: "migration-secret"},
-					Key:                  "password",
+				DBMigrationUserPasswordSecretRef: mcpv1alpha1.SecretKeyRef{
+					Name: "migration-secret",
+					Key:  "password",
 				},
 			},
 			Registries: []mcpv1alpha1.MCPRegistryConfig{

--- a/cmd/thv-operator/pkg/registryapi/podtemplatespec.go
+++ b/cmd/thv-operator/pkg/registryapi/podtemplatespec.go
@@ -347,7 +347,7 @@ func WithPGPassMount(containerName, secretName string) PodTemplateSpecOption {
 // Parameters:
 //   - containerName: The name of the container to add the mount to
 //   - secretRef: The secret key selector referencing the password secret
-func WithGitAuthMount(containerName string, secretRef corev1.SecretKeySelector) PodTemplateSpecOption {
+func WithGitAuthMount(containerName string, secretRef mcpv1alpha1.SecretKeyRef) PodTemplateSpecOption {
 	return func(pts *corev1.PodTemplateSpec) {
 		// Both Name and Key are validated as required by buildGitAuthConfig()
 		if secretRef.Name == "" || secretRef.Key == "" {

--- a/cmd/thv-operator/pkg/registryapi/podtemplatespec_test.go
+++ b/cmd/thv-operator/pkg/registryapi/podtemplatespec_test.go
@@ -1099,11 +1099,9 @@ func TestWithGitAuthMount(t *testing.T) {
 	t.Run("adds secret volume for git auth", func(t *testing.T) {
 		t.Parallel()
 
-		secretRef := corev1.SecretKeySelector{
-			LocalObjectReference: corev1.LocalObjectReference{
-				Name: testSecretName,
-			},
-			Key: "token",
+		secretRef := mcpv1alpha1.SecretKeyRef{
+			Name: testSecretName,
+			Key:  "token",
 		}
 
 		builder := NewPodTemplateSpecBuilderFrom(nil)
@@ -1132,11 +1130,9 @@ func TestWithGitAuthMount(t *testing.T) {
 	t.Run("adds volume mount at correct path", func(t *testing.T) {
 		t.Parallel()
 
-		secretRef := corev1.SecretKeySelector{
-			LocalObjectReference: corev1.LocalObjectReference{
-				Name: testSecretName,
-			},
-			Key: "token",
+		secretRef := mcpv1alpha1.SecretKeyRef{
+			Name: testSecretName,
+			Key:  "token",
 		}
 
 		builder := NewPodTemplateSpecBuilderFrom(nil)
@@ -1165,10 +1161,8 @@ func TestWithGitAuthMount(t *testing.T) {
 	t.Run("does nothing when key is empty", func(t *testing.T) {
 		t.Parallel()
 
-		secretRef := corev1.SecretKeySelector{
-			LocalObjectReference: corev1.LocalObjectReference{
-				Name: testSecretName,
-			},
+		secretRef := mcpv1alpha1.SecretKeyRef{
+			Name: testSecretName,
 			// Key is empty - should be skipped (key is required)
 		}
 
@@ -1187,11 +1181,9 @@ func TestWithGitAuthMount(t *testing.T) {
 	t.Run("does nothing when secret name is empty", func(t *testing.T) {
 		t.Parallel()
 
-		secretRef := corev1.SecretKeySelector{
-			LocalObjectReference: corev1.LocalObjectReference{
-				Name: "", // Empty name should be skipped
-			},
-			Key: "token",
+		secretRef := mcpv1alpha1.SecretKeyRef{
+			Name: "", // Empty name should be skipped
+			Key:  "token",
 		}
 
 		builder := NewPodTemplateSpecBuilderFrom(nil)
@@ -1215,17 +1207,13 @@ func TestWithGitAuthMount(t *testing.T) {
 			secretName2 = "git-credentials-2"
 		)
 
-		secretRef1 := corev1.SecretKeySelector{
-			LocalObjectReference: corev1.LocalObjectReference{
-				Name: secretName1,
-			},
-			Key: "token",
+		secretRef1 := mcpv1alpha1.SecretKeyRef{
+			Name: secretName1,
+			Key:  "token",
 		}
-		secretRef2 := corev1.SecretKeySelector{
-			LocalObjectReference: corev1.LocalObjectReference{
-				Name: secretName2,
-			},
-			Key: "password",
+		secretRef2 := mcpv1alpha1.SecretKeyRef{
+			Name: secretName2,
+			Key:  "password",
 		}
 
 		builder := NewPodTemplateSpecBuilderFrom(nil)
@@ -1254,11 +1242,9 @@ func TestWithGitAuthMount(t *testing.T) {
 	t.Run("volumes are idempotent when called multiple times with same secret", func(t *testing.T) {
 		t.Parallel()
 
-		secretRef := corev1.SecretKeySelector{
-			LocalObjectReference: corev1.LocalObjectReference{
-				Name: testSecretName,
-			},
-			Key: "token",
+		secretRef := mcpv1alpha1.SecretKeyRef{
+			Name: testSecretName,
+			Key:  "token",
 		}
 
 		builder := NewPodTemplateSpecBuilderFrom(nil)

--- a/cmd/thv-operator/test-integration/mcp-registry/registry_helpers.go
+++ b/cmd/thv-operator/test-integration/mcp-registry/registry_helpers.go
@@ -107,11 +107,9 @@ func (rb *RegistryBuilder) WithGitAuth(username, secretName, secretKey string) *
 	}
 	registryConfig.Git.Auth = &mcpv1alpha1.GitAuthConfig{
 		Username: username,
-		PasswordSecretRef: corev1.SecretKeySelector{
-			LocalObjectReference: corev1.LocalObjectReference{
-				Name: secretName,
-			},
-			Key: secretKey,
+		PasswordSecretRef: mcpv1alpha1.SecretKeyRef{
+			Name: secretName,
+			Key:  secretKey,
 		},
 	}
 	return rb

--- a/cmd/thv-operator/test-integration/mcp-registry/registryserver_config_test.go
+++ b/cmd/thv-operator/test-integration/mcp-registry/registryserver_config_test.go
@@ -590,11 +590,9 @@ var _ = Describe("MCPRegistry Server Config (Consolidated)", Label("k8s", "regis
 								Path:       "registry.json",
 								Auth: &mcpv1alpha1.GitAuthConfig{
 									Username: "user1",
-									PasswordSecretRef: corev1.SecretKeySelector{
-										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "git-auth-1",
-										},
-										Key: "password",
+									PasswordSecretRef: mcpv1alpha1.SecretKeyRef{
+										Name: "git-auth-1",
+										Key:  "password",
 									},
 								},
 							},
@@ -611,11 +609,9 @@ var _ = Describe("MCPRegistry Server Config (Consolidated)", Label("k8s", "regis
 								Path:       "servers.json",
 								Auth: &mcpv1alpha1.GitAuthConfig{
 									Username: "user2",
-									PasswordSecretRef: corev1.SecretKeySelector{
-										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "git-auth-2",
-										},
-										Key: "token",
+									PasswordSecretRef: mcpv1alpha1.SecretKeyRef{
+										Name: "git-auth-2",
+										Key:  "token",
 									},
 								},
 							},


### PR DESCRIPTION
## Summary

MCPRegistry was the only CRD using `corev1.SecretKeySelector` for secret references. The other 5 CRDs all use the custom `SecretKeyRef` type. This PR standardizes MCPRegistry to match, converting 5 fields before the API stabilizes.

## Why this matters

The `corev1.SecretKeySelector` type carries an unused `Optional *bool` field that no controller code checks. The custom `SecretKeyRef` is simpler (just `Name` + `Key`, both required) and already used by 13+ fields across other CRDs. Standardizing now avoids a breaking change later.

## Changes

- `mcpregistry_types.go`: Convert 5 fields from `corev1.SecretKeySelector` to `SecretKeyRef` (preserving pointer semantics for optional fields)
- `secrets.go`: Decouple `GetValue` from `corev1` by accepting `name` and `key` as separate string parameters
- `pgpass.go`, `config.go`, `podtemplatespec.go`: Update callers for the new signatures
- Test files: Replace `corev1.SecretKeySelector{LocalObjectReference: ...}` constructors with simpler `SecretKeyRef{Name: ..., Key: ...}`

The JSON wire format is identical (`{"name": "...", "key": "..."}`) so existing manifests work without changes.

## Testing

- Updated all unit and integration test fixtures
- Note: CRD manifests will need regeneration via `task gen` after merge (deepcopy and OpenAPI schema updates)

Fixes #4540

This contribution was developed with AI assistance (Codex).