### PR TITLE
Add +listType annotations to all CRD slice fields

### DIFF
--- a/cmd/thv-operator/api/v1alpha1/embeddingserver_types.go
+++ b/cmd/thv-operator/api/v1alpha1/embeddingserver_types.go
@@ -68,10 +68,13 @@ type EmbeddingServerSpec struct {
 	Port int32 `json:"port,omitempty"`
 
 	// Args are additional arguments to pass to the embedding inference server
+	// +listType=atomic
 	// +optional
 	Args []string `json:"args,omitempty"`
 
 	// Env are environment variables to set in the container
+	// +listType=map
+	// +listMapKey=name
 	// +optional
 	Env []EnvVar `json:"env,omitempty"`
 

--- a/cmd/thv-operator/api/v1alpha1/mcpexternalauthconfig_types.go
+++ b/cmd/thv-operator/api/v1alpha1/mcpexternalauthconfig_types.go
@@ -115,6 +115,7 @@ type TokenExchangeConfig struct {
 	Audience string `json:"audience"`
 
 	// Scopes is a list of OAuth 2.0 scopes to request for the exchanged token
+	// +listType=atomic
 	// +optional
 	Scopes []string `json:"scopes,omitempty"`
 
@@ -193,6 +194,7 @@ type EmbeddedAuthServerConfig struct {
 	// If not specified, an ephemeral signing key will be auto-generated (development only -
 	// JWTs will be invalid after restart).
 	// +kubebuilder:validation:MaxItems=5
+	// +listType=atomic
 	// +optional
 	SigningKeySecretRefs []SecretKeyRef `json:"signingKeySecretRefs,omitempty"`
 
@@ -202,6 +204,7 @@ type EmbeddedAuthServerConfig struct {
 	// Supports secret rotation via multiple entries (first is current, rest are for verification).
 	// If not specified, an ephemeral secret will be auto-generated (development only -
 	// auth codes and refresh tokens will be invalid after restart).
+	// +listType=atomic
 	// +optional
 	HMACSecretRefs []SecretKeyRef `json:"hmacSecretRefs,omitempty"`
 
@@ -215,6 +218,8 @@ type EmbeddedAuthServerConfig struct {
 	// MCPServer and MCPRemoteProxy support a single upstream; VirtualMCPServer supports multiple.
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MinItems=1
+	// +listType=map
+	// +listMapKey=name
 	UpstreamProviders []UpstreamProviderConfig `json:"upstreamProviders"`
 
 	// Storage configures the storage backend for the embedded auth server.
@@ -317,6 +322,7 @@ type OIDCUpstreamConfig struct {
 
 	// Scopes are the OAuth scopes to request from the upstream IDP.
 	// If not specified, defaults to ["openid", "offline_access"].
+	// +listType=atomic
 	// +optional
 	Scopes []string `json:"scopes,omitempty"`
 
@@ -362,6 +368,7 @@ type OAuth2UpstreamConfig struct {
 	RedirectURI string `json:"redirectUri,omitempty"`
 
 	// Scopes are the OAuth scopes to request from the upstream IDP.
+	// +listType=atomic
 	// +optional
 	Scopes []string `json:"scopes,omitempty"`
 
@@ -441,18 +448,21 @@ type UserInfoFieldMapping struct {
 	// SubjectFields is an ordered list of field names to try for the user ID.
 	// The first non-empty value found will be used.
 	// Default: ["sub"]
+	// +listType=atomic
 	// +optional
 	SubjectFields []string `json:"subjectFields,omitempty"`
 
 	// NameFields is an ordered list of field names to try for the display name.
 	// The first non-empty value found will be used.
 	// Default: ["name"]
+	// +listType=atomic
 	// +optional
 	NameFields []string `json:"nameFields,omitempty"`
 
 	// EmailFields is an ordered list of field names to try for the email address.
 	// The first non-empty value found will be used.
 	// Default: ["email"]
+	// +listType=atomic
 	// +optional
 	EmailFields []string `json:"emailFields,omitempty"`
 }
@@ -535,6 +545,7 @@ type RedisSentinelConfig struct {
 
 	// SentinelAddrs is a list of Sentinel host:port addresses.
 	// Mutually exclusive with SentinelService.
+	// +listType=atomic
 	// +optional
 	SentinelAddrs []string `json:"sentinelAddrs,omitempty"`
 
@@ -627,6 +638,7 @@ type AWSStsConfig struct {
 	// RoleMappings defines claim-based role selection rules
 	// Allows mapping JWT claims (e.g., groups, roles) to specific IAM roles
 	// Lower priority values are evaluated first (higher priority)
+	// +listType=atomic
 	// +optional
 	RoleMappings []RoleMapping `json:"roleMappings,omitempty"`
 
@@ -720,6 +732,8 @@ type MCPExternalAuthConfigStatus struct {
 
 	// ReferencingWorkloads is a list of workload resources that reference this MCPExternalAuthConfig.
 	// Each entry identifies the workload by kind and name.
+	// +listType=map
+	// +listMapKey=name
 	// +optional
 	ReferencingWorkloads []WorkloadReference `json:"referencingWorkloads,omitempty"`
 }

--- a/cmd/thv-operator/api/v1alpha1/mcpgroup_types.go
+++ b/cmd/thv-operator/api/v1alpha1/mcpgroup_types.go
@@ -26,6 +26,7 @@ type MCPGroupStatus struct {
 	Phase MCPGroupPhase `json:"phase,omitempty"`
 
 	// Servers lists MCPServer names in this group
+	// +listType=set
 	// +optional
 	Servers []string `json:"servers"`
 
@@ -34,6 +35,7 @@ type MCPGroupStatus struct {
 	ServerCount int `json:"serverCount"`
 
 	// RemoteProxies lists MCPRemoteProxy names in this group
+	// +listType=set
 	// +optional
 	RemoteProxies []string `json:"remoteProxies,omitempty"`
 

--- a/cmd/thv-operator/api/v1alpha1/mcpoidcconfig_types.go
+++ b/cmd/thv-operator/api/v1alpha1/mcpoidcconfig_types.go
@@ -183,6 +183,8 @@ type MCPOIDCConfigStatus struct {
 
 	// ReferencingWorkloads is a list of workload resources that reference this MCPOIDCConfig.
 	// Each entry identifies the workload by kind and name.
+	// +listType=map
+	// +listMapKey=name
 	// +optional
 	ReferencingWorkloads []WorkloadReference `json:"referencingWorkloads,omitempty"`
 }
@@ -232,6 +234,7 @@ type MCPOIDCConfigReference struct {
 
 	// Scopes is the list of OAuth scopes to advertise in the well-known endpoint (RFC 9728).
 	// If empty, defaults to ["openid"].
+	// +listType=atomic
 	// +optional
 	Scopes []string `json:"scopes,omitempty"`
 }

--- a/cmd/thv-operator/api/v1alpha1/mcpregistry_types.go
+++ b/cmd/thv-operator/api/v1alpha1/mcpregistry_types.go
@@ -27,6 +27,8 @@ type MCPRegistrySpec struct {
 	// Registries defines the configuration for the registry data sources
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MinItems=1
+	// +listType=map
+	// +listMapKey=name
 	Registries []MCPRegistryConfig `json:"registries"`
 
 	// EnforceServers indicates whether MCPServers in this namespace must have their images
@@ -261,10 +263,12 @@ type RegistryFilter struct {
 // NameFilter defines name-based filtering
 type NameFilter struct {
 	// Include is a list of glob patterns to include
+	// +listType=atomic
 	// +optional
 	Include []string `json:"include,omitempty"`
 
 	// Exclude is a list of glob patterns to exclude
+	// +listType=atomic
 	// +optional
 	Exclude []string `json:"exclude,omitempty"`
 }
@@ -272,10 +276,12 @@ type NameFilter struct {
 // TagFilter defines tag-based filtering
 type TagFilter struct {
 	// Include is a list of tags to include
+	// +listType=atomic
 	// +optional
 	Include []string `json:"include,omitempty"`
 
 	// Exclude is a list of tags to exclude
+	// +listType=atomic
 	// +optional
 	Exclude []string `json:"exclude,omitempty"`
 }
@@ -391,11 +397,14 @@ type MCPRegistryOAuthConfig struct {
 	// Providers defines the OAuth/OIDC providers for authentication
 	// Multiple providers can be configured (e.g., Kubernetes + external IDP)
 	// +kubebuilder:validation:MinItems=1
+	// +listType=map
+	// +listMapKey=name
 	// +optional
 	Providers []MCPRegistryOAuthProviderConfig `json:"providers,omitempty"`
 
 	// ScopesSupported defines the OAuth scopes supported by this resource (RFC 9728)
 	// Defaults to ["mcp-registry:read", "mcp-registry:write"] if not specified
+	// +listType=atomic
 	// +optional
 	ScopesSupported []string `json:"scopesSupported,omitempty"`
 

--- a/cmd/thv-operator/api/v1alpha1/mcpremoteproxy_types.go
+++ b/cmd/thv-operator/api/v1alpha1/mcpremoteproxy_types.go
@@ -16,6 +16,8 @@ type HeaderForwardConfig struct {
 	AddPlaintextHeaders map[string]string `json:"addPlaintextHeaders,omitempty"`
 
 	// AddHeadersFromSecret references Kubernetes Secrets for sensitive header values.
+	// +listType=map
+	// +listMapKey=headerName
 	// +optional
 	AddHeadersFromSecret []HeaderFromSecret `json:"addHeadersFromSecret,omitempty"`
 }

--- a/cmd/thv-operator/api/v1alpha1/mcpserver_types.go
+++ b/cmd/thv-operator/api/v1alpha1/mcpserver_types.go
@@ -188,14 +188,19 @@ type MCPServerSpec struct {
 	McpPort int32 `json:"mcpPort,omitempty"`
 
 	// Args are additional arguments to pass to the MCP server
+	// +listType=atomic
 	// +optional
 	Args []string `json:"args,omitempty"`
 
 	// Env are environment variables to set in the MCP server container
+	// +listType=map
+	// +listMapKey=name
 	// +optional
 	Env []EnvVar `json:"env,omitempty"`
 
 	// Volumes are volumes to mount in the MCP server container
+	// +listType=map
+	// +listMapKey=name
 	// +optional
 	Volumes []Volume `json:"volumes,omitempty"`
 
@@ -204,6 +209,8 @@ type MCPServerSpec struct {
 	Resources ResourceRequirements `json:"resources,omitempty"`
 
 	// Secrets are references to secrets to mount in the MCP server container
+	// +listType=map
+	// +listMapKey=name
 	// +optional
 	Secrets []SecretRef `json:"secrets,omitempty"`
 
@@ -347,11 +354,14 @@ type ProxyDeploymentOverrides struct {
 	// Env are environment variables to set in the proxy container (thv run process)
 	// These affect the toolhive proxy itself, not the MCP server it manages
 	// Use TOOLHIVE_DEBUG=true to enable debug logging in the proxy
+	// +listType=map
+	// +listMapKey=name
 	// +optional
 	Env []EnvVar `json:"env,omitempty"`
 
 	// ImagePullSecrets allows specifying image pull secrets for the proxy runner
 	// These are applied to both the Deployment and the ServiceAccount
+	// +listType=atomic
 	// +optional
 	ImagePullSecrets []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
 }
@@ -523,10 +533,12 @@ type PermissionProfileRef struct {
 // PermissionProfileSpec defines the permissions for an MCP server
 type PermissionProfileSpec struct {
 	// Read is a list of paths that the MCP server can read from
+	// +listType=atomic
 	// +optional
 	Read []string `json:"read,omitempty"`
 
 	// Write is a list of paths that the MCP server can write to
+	// +listType=atomic
 	// +optional
 	Write []string `json:"write,omitempty"`
 
@@ -555,10 +567,12 @@ type OutboundNetworkPermissions struct {
 	InsecureAllowAll bool `json:"insecureAllowAll,omitempty"`
 
 	// AllowHost is a list of hosts to allow connections to
+	// +listType=set
 	// +optional
 	AllowHost []string `json:"allowHost,omitempty"`
 
 	// AllowPort is a list of ports to allow connections to
+	// +listType=set
 	// +optional
 	AllowPort []int32 `json:"allowPort,omitempty"`
 }
@@ -720,6 +734,7 @@ type InlineOIDCConfig struct {
 
 	// Scopes is the list of OAuth scopes to advertise in the well-known endpoint (RFC 9728)
 	// If empty, defaults to ["openid"]
+	// +listType=atomic
 	// +optional
 	Scopes []string `json:"scopes,omitempty"`
 }
@@ -780,6 +795,7 @@ type InlineAuthzConfig struct {
 	// Policies is a list of Cedar policy strings
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MinItems=1
+	// +listType=atomic
 	Policies []string `json:"policies"`
 
 	// EntitiesJSON is a JSON string representing Cedar entities
@@ -826,6 +842,7 @@ type OpenTelemetryConfig struct {
 
 	// Headers contains authentication headers for the OTLP endpoint
 	// Specified as key=value pairs
+	// +listType=atomic
 	// +optional
 	Headers []string `json:"headers,omitempty"`
 

--- a/cmd/thv-operator/api/v1alpha1/mcptelemetryconfig_types.go
+++ b/cmd/thv-operator/api/v1alpha1/mcptelemetryconfig_types.go
@@ -56,6 +56,8 @@ type MCPTelemetryOTelConfig struct {
 	// SensitiveHeaders contains headers whose values are stored in Kubernetes Secrets.
 	// Use this for credential headers (e.g., API keys, bearer tokens) instead of
 	// embedding secrets in the headers field.
+	// +listType=map
+	// +listMapKey=name
 	// +optional
 	SensitiveHeaders []SensitiveHeader `json:"sensitiveHeaders,omitempty"`
 
@@ -112,6 +114,8 @@ type MCPTelemetryConfigStatus struct {
 	ConfigHash string `json:"configHash,omitempty"`
 
 	// ReferencingWorkloads lists workloads that reference this MCPTelemetryConfig
+	// +listType=map
+	// +listMapKey=name
 	// +optional
 	ReferencingWorkloads []WorkloadReference `json:"referencingWorkloads,omitempty"`
 }

--- a/cmd/thv-operator/api/v1alpha1/toolconfig_types.go
+++ b/cmd/thv-operator/api/v1alpha1/toolconfig_types.go
@@ -27,6 +27,7 @@ type MCPToolConfigSpec struct {
 	// ToolsFilter is a list of tool names to filter (allow list).
 	// Only tools in this list will be exposed by the MCP server.
 	// If empty, all tools are exposed.
+	// +listType=set
 	// +optional
 	ToolsFilter []string `json:"toolsFilter,omitempty"`
 
@@ -98,6 +99,8 @@ type MCPToolConfigStatus struct {
 
 	// ReferencingWorkloads is a list of workload resources that reference this MCPToolConfig.
 	// Each entry identifies the workload by kind and name.
+	// +listType=map
+	// +listMapKey=name
 	// +optional
 	ReferencingWorkloads []WorkloadReference `json:"referencingWorkloads,omitempty"`
 }

--- a/cmd/thv-operator/api/v1alpha1/virtualmcpcompositetooldefinition_types.go
+++ b/cmd/thv-operator/api/v1alpha1/virtualmcpcompositetooldefinition_types.go
@@ -25,11 +25,13 @@ type VirtualMCPCompositeToolDefinitionStatus struct {
 	ValidationStatus ValidationStatus `json:"validationStatus,omitempty"`
 
 	// ValidationErrors contains validation error messages if ValidationStatus is Invalid
+	// +listType=atomic
 	// +optional
 	ValidationErrors []string `json:"validationErrors,omitempty"`
 
 	// ReferencingVirtualServers lists VirtualMCPServer resources that reference this workflow
 	// This helps track which servers need to be reconciled when this workflow changes
+	// +listType=set
 	// +optional
 	ReferencingVirtualServers []string `json:"referencingVirtualServers,omitempty"`
 

--- a/cmd/thv-operator/api/v1alpha1/virtualmcpserver_types.go
+++ b/cmd/thv-operator/api/v1alpha1/virtualmcpserver_types.go
@@ -214,6 +214,8 @@ type VirtualMCPServerStatus struct {
 	URL string `json:"url,omitempty"`
 
 	// DiscoveredBackends lists discovered backend configurations from the MCPGroup
+	// +listType=map
+	// +listMapKey=name
 	// +optional
 	DiscoveredBackends []DiscoveredBackend `json:"discoveredBackends,omitempty"`
 

--- a/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_embeddingservers.yaml
+++ b/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_embeddingservers.yaml
@@ -63,6 +63,7 @@ spec:
                 items:
                   type: string
                 type: array
+                x-kubernetes-list-type: atomic
               env:
                 description: Env are environment variables to set in the container
                 items:
@@ -79,6 +80,9 @@ spec:
                   - value
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
               hfTokenSecretRef:
                 description: |-
                   HFTokenSecretRef is a reference to a Kubernetes Secret containing the huggingface token.

--- a/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpexternalauthconfigs.yaml
+++ b/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpexternalauthconfigs.yaml
@@ -137,6 +137,7 @@ spec:
                       - roleArn
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   service:
                     default: aws-mcp
                     description: |-
@@ -222,6 +223,7 @@ spec:
                       - name
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   issuer:
                     description: |-
                       Issuer is the issuer identifier for this authorization server.
@@ -250,6 +252,7 @@ spec:
                       type: object
                     maxItems: 5
                     type: array
+                    x-kubernetes-list-type: atomic
                   storage:
                     description: |-
                       Storage configures the storage backend for the embedded auth server.
@@ -328,6 +331,7 @@ spec:
                                 items:
                                   type: string
                                 type: array
+                                x-kubernetes-list-type: atomic
                               sentinelService:
                                 description: |-
                                   SentinelService enables automatic discovery from a Kubernetes Service.
@@ -511,6 +515,7 @@ spec:
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                             tokenEndpoint:
                               description: TokenEndpoint is the URL for the OAuth
                                 token endpoint.
@@ -578,6 +583,7 @@ spec:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     nameFields:
                                       description: |-
                                         NameFields is an ordered list of field names to try for the display name.
@@ -586,6 +592,7 @@ spec:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     subjectFields:
                                       description: |-
                                         SubjectFields is an ordered list of field names to try for the user ID.
@@ -594,6 +601,7 @@ spec:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                   type: object
                                 httpMethod:
                                   description: |-
@@ -655,6 +663,7 @@ spec:
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                             userInfoOverride:
                               description: |-
                                 UserInfoOverride allows customizing UserInfo fetching behavior for OIDC providers.
@@ -687,6 +696,7 @@ spec:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     nameFields:
                                       description: |-
                                         NameFields is an ordered list of field names to try for the display name.
@@ -695,6 +705,7 @@ spec:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     subjectFields:
                                       description: |-
                                         SubjectFields is an ordered list of field names to try for the user ID.
@@ -703,6 +714,7 @@ spec:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                   type: object
                                 httpMethod:
                                   description: |-
@@ -732,6 +744,9 @@ spec:
                       type: object
                     minItems: 1
                     type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
                 required:
                 - issuer
                 - upstreamProviders
@@ -804,6 +819,7 @@ spec:
                     items:
                       type: string
                     type: array
+                    x-kubernetes-list-type: atomic
                   subjectProviderName:
                     description: |-
                       SubjectProviderName is the name of the upstream provider whose token is used as the
@@ -984,6 +1000,9 @@ spec:
                   - name
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
             type: object
         type: object
     served: true

--- a/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpgroups.yaml
+++ b/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpgroups.yaml
@@ -142,6 +142,7 @@ spec:
                 items:
                   type: string
                 type: array
+                x-kubernetes-list-type: set
               remoteProxyCount:
                 description: RemoteProxyCount is the number of MCPRemoteProxies
                 type: integer
@@ -153,6 +154,7 @@ spec:
                 items:
                   type: string
                 type: array
+                x-kubernetes-list-type: set
             type: object
         type: object
     served: true

--- a/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpoidcconfigs.yaml
+++ b/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpoidcconfigs.yaml
@@ -301,6 +301,9 @@ spec:
                   - name
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
             type: object
         type: object
     served: true

--- a/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpregistries.yaml
+++ b/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpregistries.yaml
@@ -230,6 +230,9 @@ spec:
                           type: object
                         minItems: 1
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
                       realm:
                         description: |-
                           Realm is the protection space identifier for WWW-Authenticate header (RFC 7235)
@@ -247,6 +250,7 @@ spec:
                         items:
                           type: string
                         type: array
+                        x-kubernetes-list-type: atomic
                     type: object
                 type: object
               databaseConfig:
@@ -465,11 +469,13 @@ spec:
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                             include:
                               description: Include is a list of glob patterns to include
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                           type: object
                         tags:
                           description: Tags defines tag-based filtering
@@ -479,11 +485,13 @@ spec:
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                             include:
                               description: Include is a list of tags to include
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                           type: object
                       type: object
                     format:
@@ -651,6 +659,9 @@ spec:
                   type: object
                 minItems: 1
                 type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
             required:
             - registries
             type: object

--- a/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpremoteproxies.yaml
+++ b/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpremoteproxies.yaml
@@ -105,6 +105,7 @@ spec:
                           type: string
                         minItems: 1
                         type: array
+                        x-kubernetes-list-type: atomic
                     required:
                     - policies
                     type: object
@@ -184,6 +185,9 @@ spec:
                       - valueSecretRef
                       type: object
                     type: array
+                    x-kubernetes-list-map-keys:
+                    - headerName
+                    x-kubernetes-list-type: map
                   addPlaintextHeaders:
                     additionalProperties:
                       type: string
@@ -344,6 +348,7 @@ spec:
                         items:
                           type: string
                         type: array
+                        x-kubernetes-list-type: atomic
                     required:
                     - issuer
                     type: object
@@ -437,6 +442,7 @@ spec:
                     items:
                       type: string
                     type: array
+                    x-kubernetes-list-type: atomic
                 required:
                 - audience
                 - name
@@ -485,6 +491,9 @@ spec:
                           - value
                           type: object
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
                       imagePullSecrets:
                         description: |-
                           ImagePullSecrets allows specifying image pull secrets for the proxy runner
@@ -506,6 +515,7 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         type: array
+                        x-kubernetes-list-type: atomic
                       labels:
                         additionalProperties:
                           type: string
@@ -611,6 +621,7 @@ spec:
                         items:
                           type: string
                         type: array
+                        x-kubernetes-list-type: atomic
                       insecure:
                         default: false
                         description: Insecure indicates whether to use HTTP instead

--- a/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpservers.yaml
+++ b/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpservers.yaml
@@ -65,6 +65,7 @@ spec:
                 items:
                   type: string
                 type: array
+                x-kubernetes-list-type: atomic
               audit:
                 description: Audit defines audit logging configuration for the MCP
                   server
@@ -112,6 +113,7 @@ spec:
                           type: string
                         minItems: 1
                         type: array
+                        x-kubernetes-list-type: atomic
                     required:
                     - policies
                     type: object
@@ -165,6 +167,9 @@ spec:
                   - value
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
               externalAuthConfigRef:
                 description: |-
                   ExternalAuthConfigRef references a MCPExternalAuthConfig resource for external authentication.
@@ -341,6 +346,7 @@ spec:
                         items:
                           type: string
                         type: array
+                        x-kubernetes-list-type: atomic
                     required:
                     - issuer
                     type: object
@@ -434,6 +440,7 @@ spec:
                     items:
                       type: string
                     type: array
+                    x-kubernetes-list-type: atomic
                 required:
                 - audience
                 - name
@@ -533,6 +540,9 @@ spec:
                           - value
                           type: object
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
                       imagePullSecrets:
                         description: |-
                           ImagePullSecrets allows specifying image pull secrets for the proxy runner
@@ -554,6 +564,7 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         type: array
+                        x-kubernetes-list-type: atomic
                       labels:
                         additionalProperties:
                           type: string
@@ -644,6 +655,9 @@ spec:
                   - name
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
               serviceAccount:
                 description: |-
                   ServiceAccount is the name of an already existing service account to use by the MCP server.
@@ -730,6 +744,7 @@ spec:
                         items:
                           type: string
                         type: array
+                        x-kubernetes-list-type: atomic
                       insecure:
                         default: false
                         description: Insecure indicates whether to use HTTP instead
@@ -857,6 +872,9 @@ spec:
                   - name
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
             required:
             - image
             type: object

--- a/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcptelemetryconfigs.yaml
+++ b/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcptelemetryconfigs.yaml
@@ -142,6 +142,9 @@ spec:
                       - secretKeyRef
                       type: object
                     type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
                   tracing:
                     description: Tracing defines OpenTelemetry tracing configuration
                     properties:
@@ -273,6 +276,9 @@ spec:
                   - name
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
             type: object
         type: object
     served: true

--- a/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcptoolconfigs.yaml
+++ b/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcptoolconfigs.yaml
@@ -69,6 +69,7 @@ spec:
                 items:
                   type: string
                 type: array
+                x-kubernetes-list-type: set
               toolsOverride:
                 additionalProperties:
                   description: |-
@@ -212,6 +213,9 @@ spec:
                   - name
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
             type: object
         type: object
     served: true

--- a/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_virtualmcpcompositetooldefinitions.yaml
+++ b/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_virtualmcpcompositetooldefinitions.yaml
@@ -402,12 +402,14 @@ spec:
                 items:
                   type: string
                 type: array
+                x-kubernetes-list-type: set
               validationErrors:
                 description: ValidationErrors contains validation error messages if
                   ValidationStatus is Invalid
                 items:
                   type: string
                 type: array
+                x-kubernetes-list-type: atomic
               validationStatus:
                 description: |-
                   ValidationStatus indicates the validation state of the workflow

--- a/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_virtualmcpservers.yaml
+++ b/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_virtualmcpservers.yaml
@@ -108,6 +108,7 @@ spec:
                       - name
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   issuer:
                     description: |-
                       Issuer is the issuer identifier for this authorization server.
@@ -136,6 +137,7 @@ spec:
                       type: object
                     maxItems: 5
                     type: array
+                    x-kubernetes-list-type: atomic
                   storage:
                     description: |-
                       Storage configures the storage backend for the embedded auth server.
@@ -214,6 +216,7 @@ spec:
                                 items:
                                   type: string
                                 type: array
+                                x-kubernetes-list-type: atomic
                               sentinelService:
                                 description: |-
                                   SentinelService enables automatic discovery from a Kubernetes Service.
@@ -397,6 +400,7 @@ spec:
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                             tokenEndpoint:
                               description: TokenEndpoint is the URL for the OAuth
                                 token endpoint.
@@ -464,6 +468,7 @@ spec:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     nameFields:
                                       description: |-
                                         NameFields is an ordered list of field names to try for the display name.
@@ -472,6 +477,7 @@ spec:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     subjectFields:
                                       description: |-
                                         SubjectFields is an ordered list of field names to try for the user ID.
@@ -480,6 +486,7 @@ spec:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                   type: object
                                 httpMethod:
                                   description: |-
@@ -541,6 +548,7 @@ spec:
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                             userInfoOverride:
                               description: |-
                                 UserInfoOverride allows customizing UserInfo fetching behavior for OIDC providers.
@@ -573,6 +581,7 @@ spec:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     nameFields:
                                       description: |-
                                         NameFields is an ordered list of field names to try for the display name.
@@ -581,6 +590,7 @@ spec:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     subjectFields:
                                       description: |-
                                         SubjectFields is an ordered list of field names to try for the user ID.
@@ -589,6 +599,7 @@ spec:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                   type: object
                                 httpMethod:
                                   description: |-
@@ -618,6 +629,9 @@ spec:
                       type: object
                     minItems: 1
                     type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
                 required:
                 - issuer
                 - upstreamProviders
@@ -1794,6 +1808,7 @@ spec:
                               type: string
                             minItems: 1
                             type: array
+                            x-kubernetes-list-type: atomic
                         required:
                         - policies
                         type: object
@@ -1966,6 +1981,7 @@ spec:
                             items:
                               type: string
                             type: array
+                            x-kubernetes-list-type: atomic
                         required:
                         - issuer
                         type: object
@@ -2061,6 +2077,7 @@ spec:
                         items:
                           type: string
                         type: array
+                        x-kubernetes-list-type: atomic
                     required:
                     - audience
                     - name
@@ -2378,6 +2395,9 @@ spec:
                   - name
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
               message:
                 description: Message provides additional information about the current
                   phase

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_embeddingservers.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_embeddingservers.yaml
@@ -66,6 +66,7 @@ spec:
                 items:
                   type: string
                 type: array
+                x-kubernetes-list-type: atomic
               env:
                 description: Env are environment variables to set in the container
                 items:
@@ -82,6 +83,9 @@ spec:
                   - value
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
               hfTokenSecretRef:
                 description: |-
                   HFTokenSecretRef is a reference to a Kubernetes Secret containing the huggingface token.

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpexternalauthconfigs.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpexternalauthconfigs.yaml
@@ -140,6 +140,7 @@ spec:
                       - roleArn
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   service:
                     default: aws-mcp
                     description: |-
@@ -225,6 +226,7 @@ spec:
                       - name
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   issuer:
                     description: |-
                       Issuer is the issuer identifier for this authorization server.
@@ -253,6 +255,7 @@ spec:
                       type: object
                     maxItems: 5
                     type: array
+                    x-kubernetes-list-type: atomic
                   storage:
                     description: |-
                       Storage configures the storage backend for the embedded auth server.
@@ -331,6 +334,7 @@ spec:
                                 items:
                                   type: string
                                 type: array
+                                x-kubernetes-list-type: atomic
                               sentinelService:
                                 description: |-
                                   SentinelService enables automatic discovery from a Kubernetes Service.
@@ -514,6 +518,7 @@ spec:
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                             tokenEndpoint:
                               description: TokenEndpoint is the URL for the OAuth
                                 token endpoint.
@@ -581,6 +586,7 @@ spec:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     nameFields:
                                       description: |-
                                         NameFields is an ordered list of field names to try for the display name.
@@ -589,6 +595,7 @@ spec:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     subjectFields:
                                       description: |-
                                         SubjectFields is an ordered list of field names to try for the user ID.
@@ -597,6 +604,7 @@ spec:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                   type: object
                                 httpMethod:
                                   description: |-
@@ -658,6 +666,7 @@ spec:
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                             userInfoOverride:
                               description: |-
                                 UserInfoOverride allows customizing UserInfo fetching behavior for OIDC providers.
@@ -690,6 +699,7 @@ spec:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     nameFields:
                                       description: |-
                                         NameFields is an ordered list of field names to try for the display name.
@@ -698,6 +708,7 @@ spec:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     subjectFields:
                                       description: |-
                                         SubjectFields is an ordered list of field names to try for the user ID.
@@ -706,6 +717,7 @@ spec:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                   type: object
                                 httpMethod:
                                   description: |-
@@ -735,6 +747,9 @@ spec:
                       type: object
                     minItems: 1
                     type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
                 required:
                 - issuer
                 - upstreamProviders
@@ -807,6 +822,7 @@ spec:
                     items:
                       type: string
                     type: array
+                    x-kubernetes-list-type: atomic
                   subjectProviderName:
                     description: |-
                       SubjectProviderName is the name of the upstream provider whose token is used as the
@@ -987,6 +1003,9 @@ spec:
                   - name
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
             type: object
         type: object
     served: true

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpgroups.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpgroups.yaml
@@ -145,6 +145,7 @@ spec:
                 items:
                   type: string
                 type: array
+                x-kubernetes-list-type: set
               remoteProxyCount:
                 description: RemoteProxyCount is the number of MCPRemoteProxies
                 type: integer
@@ -156,6 +157,7 @@ spec:
                 items:
                   type: string
                 type: array
+                x-kubernetes-list-type: set
             type: object
         type: object
     served: true

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpoidcconfigs.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpoidcconfigs.yaml
@@ -304,6 +304,9 @@ spec:
                   - name
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
             type: object
         type: object
     served: true

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpregistries.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpregistries.yaml
@@ -233,6 +233,9 @@ spec:
                           type: object
                         minItems: 1
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
                       realm:
                         description: |-
                           Realm is the protection space identifier for WWW-Authenticate header (RFC 7235)
@@ -250,6 +253,7 @@ spec:
                         items:
                           type: string
                         type: array
+                        x-kubernetes-list-type: atomic
                     type: object
                 type: object
               databaseConfig:
@@ -468,11 +472,13 @@ spec:
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                             include:
                               description: Include is a list of glob patterns to include
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                           type: object
                         tags:
                           description: Tags defines tag-based filtering
@@ -482,11 +488,13 @@ spec:
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                             include:
                               description: Include is a list of tags to include
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                           type: object
                       type: object
                     format:
@@ -654,6 +662,9 @@ spec:
                   type: object
                 minItems: 1
                 type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
             required:
             - registries
             type: object

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpremoteproxies.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpremoteproxies.yaml
@@ -108,6 +108,7 @@ spec:
                           type: string
                         minItems: 1
                         type: array
+                        x-kubernetes-list-type: atomic
                     required:
                     - policies
                     type: object
@@ -187,6 +188,9 @@ spec:
                       - valueSecretRef
                       type: object
                     type: array
+                    x-kubernetes-list-map-keys:
+                    - headerName
+                    x-kubernetes-list-type: map
                   addPlaintextHeaders:
                     additionalProperties:
                       type: string
@@ -347,6 +351,7 @@ spec:
                         items:
                           type: string
                         type: array
+                        x-kubernetes-list-type: atomic
                     required:
                     - issuer
                     type: object
@@ -440,6 +445,7 @@ spec:
                     items:
                       type: string
                     type: array
+                    x-kubernetes-list-type: atomic
                 required:
                 - audience
                 - name
@@ -488,6 +494,9 @@ spec:
                           - value
                           type: object
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
                       imagePullSecrets:
                         description: |-
                           ImagePullSecrets allows specifying image pull secrets for the proxy runner
@@ -509,6 +518,7 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         type: array
+                        x-kubernetes-list-type: atomic
                       labels:
                         additionalProperties:
                           type: string
@@ -614,6 +624,7 @@ spec:
                         items:
                           type: string
                         type: array
+                        x-kubernetes-list-type: atomic
                       insecure:
                         default: false
                         description: Insecure indicates whether to use HTTP instead

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpservers.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpservers.yaml
@@ -68,6 +68,7 @@ spec:
                 items:
                   type: string
                 type: array
+                x-kubernetes-list-type: atomic
               audit:
                 description: Audit defines audit logging configuration for the MCP
                   server
@@ -115,6 +116,7 @@ spec:
                           type: string
                         minItems: 1
                         type: array
+                        x-kubernetes-list-type: atomic
                     required:
                     - policies
                     type: object
@@ -168,6 +170,9 @@ spec:
                   - value
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
               externalAuthConfigRef:
                 description: |-
                   ExternalAuthConfigRef references a MCPExternalAuthConfig resource for external authentication.
@@ -344,6 +349,7 @@ spec:
                         items:
                           type: string
                         type: array
+                        x-kubernetes-list-type: atomic
                     required:
                     - issuer
                     type: object
@@ -437,6 +443,7 @@ spec:
                     items:
                       type: string
                     type: array
+                    x-kubernetes-list-type: atomic
                 required:
                 - audience
                 - name
@@ -536,6 +543,9 @@ spec:
                           - value
                           type: object
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
                       imagePullSecrets:
                         description: |-
                           ImagePullSecrets allows specifying image pull secrets for the proxy runner
@@ -557,6 +567,7 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         type: array
+                        x-kubernetes-list-type: atomic
                       labels:
                         additionalProperties:
                           type: string
@@ -647,6 +658,9 @@ spec:
                   - name
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
               serviceAccount:
                 description: |-
                   ServiceAccount is the name of an already existing service account to use by the MCP server.
@@ -733,6 +747,7 @@ spec:
                         items:
                           type: string
                         type: array
+                        x-kubernetes-list-type: atomic
                       insecure:
                         default: false
                         description: Insecure indicates whether to use HTTP instead
@@ -860,6 +875,9 @@ spec:
                   - name
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
             required:
             - image
             type: object

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcptelemetryconfigs.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcptelemetryconfigs.yaml
@@ -145,6 +145,9 @@ spec:
                       - secretKeyRef
                       type: object
                     type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
                   tracing:
                     description: Tracing defines OpenTelemetry tracing configuration
                     properties:
@@ -276,6 +279,9 @@ spec:
                   - name
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
             type: object
         type: object
     served: true

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcptoolconfigs.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcptoolconfigs.yaml
@@ -72,6 +72,7 @@ spec:
                 items:
                   type: string
                 type: array
+                x-kubernetes-list-type: set
               toolsOverride:
                 additionalProperties:
                   description: |-
@@ -215,6 +216,9 @@ spec:
                   - name
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
             type: object
         type: object
     served: true

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_virtualmcpcompositetooldefinitions.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_virtualmcpcompositetooldefinitions.yaml
@@ -405,12 +405,14 @@ spec:
                 items:
                   type: string
                 type: array
+                x-kubernetes-list-type: set
               validationErrors:
                 description: ValidationErrors contains validation error messages if
                   ValidationStatus is Invalid
                 items:
                   type: string
                 type: array
+                x-kubernetes-list-type: atomic
               validationStatus:
                 description: |-
                   ValidationStatus indicates the validation state of the workflow

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_virtualmcpservers.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_virtualmcpservers.yaml
@@ -111,6 +111,7 @@ spec:
                       - name
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   issuer:
                     description: |-
                       Issuer is the issuer identifier for this authorization server.
@@ -139,6 +140,7 @@ spec:
                       type: object
                     maxItems: 5
                     type: array
+                    x-kubernetes-list-type: atomic
                   storage:
                     description: |-
                       Storage configures the storage backend for the embedded auth server.
@@ -217,6 +219,7 @@ spec:
                                 items:
                                   type: string
                                 type: array
+                                x-kubernetes-list-type: atomic
                               sentinelService:
                                 description: |-
                                   SentinelService enables automatic discovery from a Kubernetes Service.
@@ -400,6 +403,7 @@ spec:
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                             tokenEndpoint:
                               description: TokenEndpoint is the URL for the OAuth
                                 token endpoint.
@@ -467,6 +471,7 @@ spec:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     nameFields:
                                       description: |-
                                         NameFields is an ordered list of field names to try for the display name.
@@ -475,6 +480,7 @@ spec:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     subjectFields:
                                       description: |-
                                         SubjectFields is an ordered list of field names to try for the user ID.
@@ -483,6 +489,7 @@ spec:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                   type: object
                                 httpMethod:
                                   description: |-
@@ -544,6 +551,7 @@ spec:
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                             userInfoOverride:
                               description: |-
                                 UserInfoOverride allows customizing UserInfo fetching behavior for OIDC providers.
@@ -576,6 +584,7 @@ spec:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     nameFields:
                                       description: |-
                                         NameFields is an ordered list of field names to try for the display name.
@@ -584,6 +593,7 @@ spec:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     subjectFields:
                                       description: |-
                                         SubjectFields is an ordered list of field names to try for the user ID.
@@ -592,6 +602,7 @@ spec:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                   type: object
                                 httpMethod:
                                   description: |-
@@ -621,6 +632,9 @@ spec:
                       type: object
                     minItems: 1
                     type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
                 required:
                 - issuer
                 - upstreamProviders
@@ -1797,6 +1811,7 @@ spec:
                               type: string
                             minItems: 1
                             type: array
+                            x-kubernetes-list-type: atomic
                         required:
                         - policies
                         type: object
@@ -1969,6 +1984,7 @@ spec:
                             items:
                               type: string
                             type: array
+                            x-kubernetes-list-type: atomic
                         required:
                         - issuer
                         type: object
@@ -2064,6 +2080,7 @@ spec:
                         items:
                           type: string
                         type: array
+                        x-kubernetes-list-type: atomic
                     required:
                     - audience
                     - name
@@ -2381,6 +2398,9 @@ spec:
                   - name
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
               message:
                 description: Message provides additional information about the current
                   phase


### PR DESCRIPTION
## Summary

Server-side apply (SSA) cannot determine merge strategy for CRD list fields without `+listType`/`+listMapKey` annotations, causing GitOps tools to fail or produce incorrect merges. This adds annotations to ~40 slice fields across all 11 CRD types, unblocking v1beta1 CRD stabilization.

All `Status.Conditions` fields already had correct annotations and served as the reference pattern.

Fixes #4583

## Type of change

- [x] Enhancement (non-breaking change which adds functionality)

## Changes

| File(s) | Change |
|---------|--------|
| `cmd/thv-operator/api/v1alpha1/*_types.go` (11 files) | Add `+listType` and `+listMapKey` marker comments to all slice fields |
| `deploy/charts/operator-crds/files/crds/*.yaml` (11 files) | Regenerated CRD manifests with `x-kubernetes-list-type` and `x-kubernetes-list-map-keys` |
| `deploy/charts/operator-crds/templates/*.yaml` (11 files) | Regenerated Helm-wrapped CRD templates |

## Annotation strategy

- **`+listType=map` + `+listMapKey=<field>`** for struct slices with a unique identifier (Env/name, Volumes/name, Secrets/name, UpstreamProviders/name, AddHeadersFromSecret/headerName, etc.)
- **`+listType=set`** for unique scalar slices where duplicates are semantically invalid (Servers, RemoteProxies, ToolsFilter, AllowHost, AllowPort, ReferencingVirtualServers)
- **`+listType=atomic`** for ordered or opaque slices that should be replaced wholesale (Args, Scopes, Policies, Headers, ValidationErrors, SigningKeySecretRefs, HMACSecretRefs, RoleMappings, filter Include/Exclude lists)

## Test plan

- [x] `task lint-fix` passes (0 issues)
- [x] Operator unit tests pass (`go test ./cmd/thv-operator/api/... ./cmd/thv-operator/controllers/... ./cmd/thv-operator/pkg/...`)
- [x] Operator builds (`go build ./cmd/thv-operator/...`)
- [x] CRD manifests regenerated via `task -d cmd/thv-operator operator-manifests`
- [x] Verified generated YAML includes `x-kubernetes-list-type` and `x-kubernetes-list-map-keys`

Generated with [Claude Code](https://claude.com/claude-code)