### PR TITLE
Add MinLength=1 validation to MCPServer Image field

### DIFF
--- a/cmd/thv-operator/api/v1alpha1/mcpserver_types.go
+++ b/cmd/thv-operator/api/v1alpha1/mcpserver_types.go
@@ -159,6 +159,7 @@ const SessionStorageProviderRedis = "redis"
 type MCPServerSpec struct {
 	// Image is the container image for the MCP server
 	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MinLength=1
 	Image string `json:"image"`
 
 	// Transport is the transport method for the MCP server (stdio, streamable-http or sse)

--- a/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpservers.yaml
+++ b/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpservers.yaml
@@ -183,6 +183,7 @@ spec:
                 type: string
               image:
                 description: Image is the container image for the MCP server
+                minLength: 1
                 type: string
               mcpPort:
                 description: McpPort is the port that MCP server listens to

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpservers.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpservers.yaml
@@ -186,6 +186,7 @@ spec:
                 type: string
               image:
                 description: Image is the container image for the MCP server
+                minLength: 1
                 type: string
               mcpPort:
                 description: McpPort is the port that MCP server listens to


### PR DESCRIPTION
## Summary

- The `Image` field in `MCPServerSpec` only had a `Required` kubebuilder marker, which prevents omission but still accepts empty strings (`image: ""`). An empty image passes CRD admission validation but fails at container runtime when the controller creates a Deployment. Adding `MinLength=1` catches this invalid input at admission time, matching the pattern already used by other validated string fields in the same CRD.

Fixes #4585

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)
- [x] Manual testing (describe below)

Verified `minLength: 1` appears in the regenerated CRD manifest for the `image` field.

## Does this introduce a user-facing change?

Yes — `image: ""` in MCPServer manifests will now be rejected at admission time with a validation error, rather than being accepted and failing asynchronously at container runtime. This is a validation tightening; empty image strings were never valid at runtime.

Generated with [Claude Code](https://claude.com/claude-code)