### PR TITLE
Standardize condition type naming for config CRDs

### DIFF
--- a/cmd/thv-operator/api/v1alpha1/mcpexternalauthconfig_types.go
+++ b/cmd/thv-operator/api/v1alpha1/mcpexternalauthconfig_types.go
@@ -728,7 +728,7 @@ type MCPExternalAuthConfigStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:shortName=extauth;mcpextauth,categories=toolhive
 // +kubebuilder:printcolumn:name="Type",type=string,JSONPath=`.spec.type`
-// +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=='Valid')].status`
+// +kubebuilder:printcolumn:name="Valid",type=string,JSONPath=`.status.conditions[?(@.type=='Valid')].status`
 // +kubebuilder:printcolumn:name="References",type=string,JSONPath=`.status.referencingWorkloads`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 

--- a/cmd/thv-operator/api/v1alpha1/mcpoidcconfig_types.go
+++ b/cmd/thv-operator/api/v1alpha1/mcpoidcconfig_types.go
@@ -20,8 +20,8 @@ const (
 
 // Condition type and reasons for MCPOIDCConfig status (RFC-0023)
 const (
-	// ConditionTypeOIDCConfigReady indicates whether the MCPOIDCConfig is ready for use
-	ConditionTypeOIDCConfigReady = "Ready"
+	// ConditionTypeOIDCConfigValid indicates whether the MCPOIDCConfig configuration is valid
+	ConditionTypeOIDCConfigValid = "Valid"
 
 	// ConditionReasonOIDCConfigValid indicates spec validation passed
 	ConditionReasonOIDCConfigValid = "ConfigValid"
@@ -191,7 +191,7 @@ type MCPOIDCConfigStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:shortName=mcpoidc,categories=toolhive
 // +kubebuilder:printcolumn:name="Source",type=string,JSONPath=`.spec.type`
-// +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=='Ready')].status`
+// +kubebuilder:printcolumn:name="Valid",type=string,JSONPath=`.status.conditions[?(@.type=='Valid')].status`
 // +kubebuilder:printcolumn:name="References",type=string,JSONPath=`.status.referencingWorkloads`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 

--- a/cmd/thv-operator/api/v1alpha1/mcptelemetryconfig_types.go
+++ b/cmd/thv-operator/api/v1alpha1/mcptelemetryconfig_types.go
@@ -120,7 +120,7 @@ type MCPTelemetryConfigStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:shortName=mcpotel,categories=toolhive
 // +kubebuilder:printcolumn:name="Endpoint",type=string,JSONPath=`.spec.openTelemetry.endpoint`
-// +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=='Valid')].status`
+// +kubebuilder:printcolumn:name="Valid",type=string,JSONPath=`.status.conditions[?(@.type=='Valid')].status`
 // +kubebuilder:printcolumn:name="Tracing",type=boolean,JSONPath=`.spec.openTelemetry.tracing.enabled`
 // +kubebuilder:printcolumn:name="Metrics",type=boolean,JSONPath=`.spec.openTelemetry.metrics.enabled`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`

--- a/cmd/thv-operator/api/v1alpha1/toolconfig_types.go
+++ b/cmd/thv-operator/api/v1alpha1/toolconfig_types.go
@@ -105,7 +105,7 @@ type MCPToolConfigStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:shortName=tc;toolconfig,categories=toolhive
-// +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=='Valid')].status`
+// +kubebuilder:printcolumn:name="Valid",type=string,JSONPath=`.status.conditions[?(@.type=='Valid')].status`
 // +kubebuilder:printcolumn:name="References",type=string,JSONPath=`.status.referencingWorkloads`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 

--- a/cmd/thv-operator/controllers/mcpoidcconfig_controller.go
+++ b/cmd/thv-operator/controllers/mcpoidcconfig_controller.go
@@ -84,7 +84,7 @@ func (r *MCPOIDCConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	if err := oidcConfig.Validate(); err != nil {
 		logger.Error(err, "MCPOIDCConfig spec validation failed")
 		meta.SetStatusCondition(&oidcConfig.Status.Conditions, metav1.Condition{
-			Type:               mcpv1alpha1.ConditionTypeOIDCConfigReady,
+			Type:               mcpv1alpha1.ConditionTypeOIDCConfigValid,
 			Status:             metav1.ConditionFalse,
 			Reason:             mcpv1alpha1.ConditionReasonOIDCConfigInvalid,
 			Message:            err.Error(),
@@ -96,9 +96,9 @@ func (r *MCPOIDCConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, nil // Don't requeue on validation errors - user must fix spec
 	}
 
-	// Validation succeeded - set Ready=True condition
+	// Validation succeeded - set Valid=True condition
 	conditionChanged := meta.SetStatusCondition(&oidcConfig.Status.Conditions, metav1.Condition{
-		Type:               mcpv1alpha1.ConditionTypeOIDCConfigReady,
+		Type:               mcpv1alpha1.ConditionTypeOIDCConfigValid,
 		Status:             metav1.ConditionTrue,
 		Reason:             mcpv1alpha1.ConditionReasonOIDCConfigValid,
 		Message:            "Spec validation passed",

--- a/cmd/thv-operator/controllers/mcpoidcconfig_controller_test.go
+++ b/cmd/thv-operator/controllers/mcpoidcconfig_controller_test.go
@@ -237,7 +237,7 @@ func TestMCPOIDCConfigReconciler_ValidationRecovery(t *testing.T) {
 
 	var foundFalse bool
 	for _, cond := range invalidConfig.Status.Conditions {
-		if cond.Type == mcpv1alpha1.ConditionTypeOIDCConfigReady {
+		if cond.Type == mcpv1alpha1.ConditionTypeOIDCConfigValid {
 			assert.Equal(t, metav1.ConditionFalse, cond.Status)
 			foundFalse = true
 		}
@@ -264,8 +264,8 @@ func TestMCPOIDCConfigReconciler_ValidationRecovery(t *testing.T) {
 
 	var foundTrue bool
 	for _, cond := range recoveredConfig.Status.Conditions {
-		if cond.Type == mcpv1alpha1.ConditionTypeOIDCConfigReady {
-			assert.Equal(t, metav1.ConditionTrue, cond.Status, "Ready condition should recover to True")
+		if cond.Type == mcpv1alpha1.ConditionTypeOIDCConfigValid {
+			assert.Equal(t, metav1.ConditionTrue, cond.Status, "Valid condition should recover to True")
 			assert.Equal(t, mcpv1alpha1.ConditionReasonOIDCConfigValid, cond.Reason)
 			foundTrue = true
 		}
@@ -468,9 +468,9 @@ func TestMCPOIDCConfigReconciler_ValidationFailureSetsCondition(t *testing.T) {
 
 	var foundCondition bool
 	for _, cond := range updatedConfig.Status.Conditions {
-		if cond.Type == mcpv1alpha1.ConditionTypeOIDCConfigReady {
+		if cond.Type == mcpv1alpha1.ConditionTypeOIDCConfigValid {
 			foundCondition = true
-			assert.Equal(t, metav1.ConditionFalse, cond.Status, "Ready condition should be False")
+			assert.Equal(t, metav1.ConditionFalse, cond.Status, "Valid condition should be False")
 			assert.Equal(t, mcpv1alpha1.ConditionReasonOIDCConfigInvalid, cond.Reason)
 			break
 		}

--- a/cmd/thv-operator/controllers/mcpremoteproxy_controller.go
+++ b/cmd/thv-operator/controllers/mcpremoteproxy_controller.go
@@ -811,11 +811,11 @@ func (r *MCPRemoteProxyReconciler) fetchAndValidateOIDCConfig(
 		return nil, fmt.Errorf("MCPOIDCConfig %s not found", proxy.Spec.OIDCConfigRef.Name)
 	}
 
-	readyCondition := meta.FindStatusCondition(oidcConfig.Status.Conditions, mcpv1alpha1.ConditionTypeOIDCConfigReady)
-	if readyCondition == nil || readyCondition.Status != metav1.ConditionTrue {
-		msg := fmt.Sprintf("MCPOIDCConfig %s is not ready", proxy.Spec.OIDCConfigRef.Name)
-		if readyCondition != nil {
-			msg = fmt.Sprintf("MCPOIDCConfig %s is not ready: %s", proxy.Spec.OIDCConfigRef.Name, readyCondition.Message)
+	validCondition := meta.FindStatusCondition(oidcConfig.Status.Conditions, mcpv1alpha1.ConditionTypeOIDCConfigValid)
+	if validCondition == nil || validCondition.Status != metav1.ConditionTrue {
+		msg := fmt.Sprintf("MCPOIDCConfig %s is not valid", proxy.Spec.OIDCConfigRef.Name)
+		if validCondition != nil {
+			msg = fmt.Sprintf("MCPOIDCConfig %s is not valid: %s", proxy.Spec.OIDCConfigRef.Name, validCondition.Message)
 		}
 		meta.SetStatusCondition(&proxy.Status.Conditions, metav1.Condition{
 			Type:               mcpv1alpha1.ConditionOIDCConfigRefValidated,

--- a/cmd/thv-operator/controllers/mcpserver_controller.go
+++ b/cmd/thv-operator/controllers/mcpserver_controller.go
@@ -2117,11 +2117,11 @@ func (r *MCPServerReconciler) fetchAndValidateOIDCConfig(
 		return nil, fmt.Errorf("MCPOIDCConfig %s not found", m.Spec.OIDCConfigRef.Name)
 	}
 
-	readyCondition := meta.FindStatusCondition(oidcConfig.Status.Conditions, mcpv1alpha1.ConditionTypeOIDCConfigReady)
-	if readyCondition == nil || readyCondition.Status != metav1.ConditionTrue {
-		msg := fmt.Sprintf("MCPOIDCConfig %s is not ready", m.Spec.OIDCConfigRef.Name)
-		if readyCondition != nil {
-			msg = fmt.Sprintf("MCPOIDCConfig %s is not ready: %s", m.Spec.OIDCConfigRef.Name, readyCondition.Message)
+	validCondition := meta.FindStatusCondition(oidcConfig.Status.Conditions, mcpv1alpha1.ConditionTypeOIDCConfigValid)
+	if validCondition == nil || validCondition.Status != metav1.ConditionTrue {
+		msg := fmt.Sprintf("MCPOIDCConfig %s is not valid", m.Spec.OIDCConfigRef.Name)
+		if validCondition != nil {
+			msg = fmt.Sprintf("MCPOIDCConfig %s is not valid: %s", m.Spec.OIDCConfigRef.Name, validCondition.Message)
 		}
 		setOIDCConfigRefCondition(m, metav1.ConditionFalse,
 			mcpv1alpha1.ConditionReasonOIDCConfigRefNotValid, msg)

--- a/cmd/thv-operator/controllers/mcpserver_oidcconfig_test.go
+++ b/cmd/thv-operator/controllers/mcpserver_oidcconfig_test.go
@@ -25,7 +25,7 @@ func TestMCPServerReconciler_handleOIDCConfig(t *testing.T) {
 
 	// validOIDCCondition is a helper to build a Ready=True condition slice.
 	validOIDCCondition := []metav1.Condition{{
-		Type: mcpv1alpha1.ConditionTypeOIDCConfigReady, Status: metav1.ConditionTrue, Reason: mcpv1alpha1.ConditionReasonOIDCConfigValid,
+		Type: mcpv1alpha1.ConditionTypeOIDCConfigValid, Status: metav1.ConditionTrue, Reason: mcpv1alpha1.ConditionReasonOIDCConfigValid,
 	}}
 
 	tests := []struct {
@@ -63,7 +63,7 @@ func TestMCPServerReconciler_handleOIDCConfig(t *testing.T) {
 			expectConditionReason: mcpv1alpha1.ConditionReasonOIDCConfigRefNotFound,
 		},
 		{
-			name: "config with Ready=False sets NotValid condition",
+			name: "config with Valid=False sets NotValid condition",
 			mcpServer: &mcpv1alpha1.MCPServer{
 				ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "default"},
 				Spec: mcpv1alpha1.MCPServerSpec{
@@ -79,13 +79,13 @@ func TestMCPServerReconciler_handleOIDCConfig(t *testing.T) {
 				},
 				Status: mcpv1alpha1.MCPOIDCConfigStatus{
 					Conditions: []metav1.Condition{{
-						Type: mcpv1alpha1.ConditionTypeOIDCConfigReady, Status: metav1.ConditionFalse, Reason: mcpv1alpha1.ConditionReasonOIDCConfigInvalid,
+						Type: mcpv1alpha1.ConditionTypeOIDCConfigValid, Status: metav1.ConditionFalse, Reason: mcpv1alpha1.ConditionReasonOIDCConfigInvalid,
 						Message: "missing fields",
 					}},
 				},
 			},
 			expectError:           true,
-			expectErrorContains:   "not ready",
+			expectErrorContains:   "not valid",
 			expectConditionStatus: conditionStatusPtr(metav1.ConditionFalse),
 			expectConditionReason: mcpv1alpha1.ConditionReasonOIDCConfigRefNotValid,
 		},
@@ -262,7 +262,7 @@ func TestMCPServerReconciler_handleOIDCConfig_ConditionPersistedOnRecovery(t *te
 	ctx := t.Context()
 
 	validOIDCCondition := []metav1.Condition{{
-		Type: mcpv1alpha1.ConditionTypeOIDCConfigReady, Status: metav1.ConditionTrue, Reason: mcpv1alpha1.ConditionReasonOIDCConfigValid,
+		Type: mcpv1alpha1.ConditionTypeOIDCConfigValid, Status: metav1.ConditionTrue, Reason: mcpv1alpha1.ConditionReasonOIDCConfigValid,
 	}}
 
 	mcpServer := &mcpv1alpha1.MCPServer{

--- a/cmd/thv-operator/controllers/virtualmcpserver_controller.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_controller.go
@@ -2802,7 +2802,7 @@ func (r *VirtualMCPServerReconciler) handleOIDCConfig(
 	}
 
 	// Check that the MCPOIDCConfig is valid
-	validCondition := meta.FindStatusCondition(oidcConfig.Status.Conditions, mcpv1alpha1.ConditionTypeOIDCConfigReady)
+	validCondition := meta.FindStatusCondition(oidcConfig.Status.Conditions, mcpv1alpha1.ConditionTypeOIDCConfigValid)
 	if validCondition == nil || validCondition.Status != metav1.ConditionTrue {
 		msg := fmt.Sprintf("MCPOIDCConfig %s is not valid", ref.Name)
 		if validCondition != nil {

--- a/cmd/thv-operator/test-integration/mcp-oidc-config/mcpoidcconfig_controller_integration_test.go
+++ b/cmd/thv-operator/test-integration/mcp-oidc-config/mcpoidcconfig_controller_integration_test.go
@@ -61,7 +61,7 @@ var _ = Describe("MCPOIDCConfig Controller", func() {
 				return false
 			}
 			for _, cond := range fetched.Status.Conditions {
-				if cond.Type == mcpv1alpha1.ConditionTypeOIDCConfigReady && cond.Status == metav1.ConditionTrue {
+				if cond.Type == mcpv1alpha1.ConditionTypeOIDCConfigValid && cond.Status == metav1.ConditionTrue {
 					return true
 				}
 			}

--- a/cmd/thv-operator/test-integration/mcp-oidc-config/mcpoidcconfig_mcpremoteproxy_integration_test.go
+++ b/cmd/thv-operator/test-integration/mcp-oidc-config/mcpoidcconfig_mcpremoteproxy_integration_test.go
@@ -109,7 +109,7 @@ var _ = Describe("MCPOIDCConfig and MCPRemoteProxy Cross-Resource Integration Te
 					return false
 				}
 				for _, cond := range updated.Status.Conditions {
-					if cond.Type == mcpv1alpha1.ConditionTypeOIDCConfigReady && cond.Status == metav1.ConditionTrue {
+					if cond.Type == mcpv1alpha1.ConditionTypeOIDCConfigValid && cond.Status == metav1.ConditionTrue {
 						return true
 					}
 				}
@@ -299,7 +299,7 @@ var _ = Describe("MCPOIDCConfig and MCPRemoteProxy Cross-Resource Integration Te
 				}
 				originalCfgHash = updated.Status.ConfigHash
 				for _, cond := range updated.Status.Conditions {
-					if cond.Type == mcpv1alpha1.ConditionTypeOIDCConfigReady && cond.Status == metav1.ConditionTrue {
+					if cond.Type == mcpv1alpha1.ConditionTypeOIDCConfigValid && cond.Status == metav1.ConditionTrue {
 						return true
 					}
 				}
@@ -553,7 +553,7 @@ var _ = Describe("MCPOIDCConfig and MCPRemoteProxy Cross-Resource Integration Te
 					return false
 				}
 				for _, cond := range updated.Status.Conditions {
-					if cond.Type == mcpv1alpha1.ConditionTypeOIDCConfigReady && cond.Status == metav1.ConditionTrue {
+					if cond.Type == mcpv1alpha1.ConditionTypeOIDCConfigValid && cond.Status == metav1.ConditionTrue {
 						return true
 					}
 				}

--- a/cmd/thv-operator/test-integration/mcp-oidc-config/mcpoidcconfig_mcpserver_integration_test.go
+++ b/cmd/thv-operator/test-integration/mcp-oidc-config/mcpoidcconfig_mcpserver_integration_test.go
@@ -75,7 +75,7 @@ var _ = Describe("MCPOIDCConfig and MCPServer Cross-Resource Integration Tests",
 					return false
 				}
 				for _, cond := range updated.Status.Conditions {
-					if cond.Type == mcpv1alpha1.ConditionTypeOIDCConfigReady && cond.Status == metav1.ConditionTrue {
+					if cond.Type == mcpv1alpha1.ConditionTypeOIDCConfigValid && cond.Status == metav1.ConditionTrue {
 						return true
 					}
 				}

--- a/cmd/thv-operator/test-integration/mcp-oidc-config/mcpoidcconfig_virtualmcpserver_integration_test.go
+++ b/cmd/thv-operator/test-integration/mcp-oidc-config/mcpoidcconfig_virtualmcpserver_integration_test.go
@@ -87,7 +87,7 @@ var _ = Describe("MCPOIDCConfig and VirtualMCPServer Cross-Resource Integration 
 					return false
 				}
 				for _, cond := range updated.Status.Conditions {
-					if cond.Type == mcpv1alpha1.ConditionTypeOIDCConfigReady && cond.Status == metav1.ConditionTrue {
+					if cond.Type == mcpv1alpha1.ConditionTypeOIDCConfigValid && cond.Status == metav1.ConditionTrue {
 						return true
 					}
 				}
@@ -615,7 +615,7 @@ var _ = Describe("MCPOIDCConfig and VirtualMCPServer Cross-Resource Integration 
 					return false
 				}
 				for _, cond := range updated.Status.Conditions {
-					if cond.Type == mcpv1alpha1.ConditionTypeOIDCConfigReady && cond.Status == metav1.ConditionTrue {
+					if cond.Type == mcpv1alpha1.ConditionTypeOIDCConfigValid && cond.Status == metav1.ConditionTrue {
 						return true
 					}
 				}

--- a/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpexternalauthconfigs.yaml
+++ b/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpexternalauthconfigs.yaml
@@ -24,7 +24,7 @@ spec:
       name: Type
       type: string
     - jsonPath: .status.conditions[?(@.type=='Valid')].status
-      name: Ready
+      name: Valid
       type: string
     - jsonPath: .status.referencingWorkloads
       name: References

--- a/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpoidcconfigs.yaml
+++ b/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpoidcconfigs.yaml
@@ -22,8 +22,8 @@ spec:
     - jsonPath: .spec.type
       name: Source
       type: string
-    - jsonPath: .status.conditions[?(@.type=='Ready')].status
-      name: Ready
+    - jsonPath: .status.conditions[?(@.type=='Valid')].status
+      name: Valid
       type: string
     - jsonPath: .status.referencingWorkloads
       name: References

--- a/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcptelemetryconfigs.yaml
+++ b/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcptelemetryconfigs.yaml
@@ -23,7 +23,7 @@ spec:
       name: Endpoint
       type: string
     - jsonPath: .status.conditions[?(@.type=='Valid')].status
-      name: Ready
+      name: Valid
       type: string
     - jsonPath: .spec.openTelemetry.tracing.enabled
       name: Tracing

--- a/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcptoolconfigs.yaml
+++ b/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcptoolconfigs.yaml
@@ -21,7 +21,7 @@ spec:
   versions:
   - additionalPrinterColumns:
     - jsonPath: .status.conditions[?(@.type=='Valid')].status
-      name: Ready
+      name: Valid
       type: string
     - jsonPath: .status.referencingWorkloads
       name: References

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpexternalauthconfigs.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpexternalauthconfigs.yaml
@@ -27,7 +27,7 @@ spec:
       name: Type
       type: string
     - jsonPath: .status.conditions[?(@.type=='Valid')].status
-      name: Ready
+      name: Valid
       type: string
     - jsonPath: .status.referencingWorkloads
       name: References

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpoidcconfigs.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpoidcconfigs.yaml
@@ -25,8 +25,8 @@ spec:
     - jsonPath: .spec.type
       name: Source
       type: string
-    - jsonPath: .status.conditions[?(@.type=='Ready')].status
-      name: Ready
+    - jsonPath: .status.conditions[?(@.type=='Valid')].status
+      name: Valid
       type: string
     - jsonPath: .status.referencingWorkloads
       name: References

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcptelemetryconfigs.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcptelemetryconfigs.yaml
@@ -26,7 +26,7 @@ spec:
       name: Endpoint
       type: string
     - jsonPath: .status.conditions[?(@.type=='Valid')].status
-      name: Ready
+      name: Valid
       type: string
     - jsonPath: .spec.openTelemetry.tracing.enabled
       name: Tracing

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcptoolconfigs.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcptoolconfigs.yaml
@@ -24,7 +24,7 @@ spec:
   versions:
   - additionalPrinterColumns:
     - jsonPath: .status.conditions[?(@.type=='Valid')].status
-      name: Ready
+      name: Valid
       type: string
     - jsonPath: .status.referencingWorkloads
       name: References


### PR DESCRIPTION
## Summary

Config CRDs validate configuration correctness, not operational readiness, so their condition type should be "Valid" rather than "Ready". Before API stabilization beyond v1alpha1, two inconsistencies need fixing:

- **MCPOIDCConfig** is the sole config CRD using a `Ready` condition type — the other three (MCPExternalAuthConfig, MCPTelemetryConfig, MCPToolConfig) already use `Valid`. Its own reason values (`ConfigValid`/`ConfigInvalid`) confirm the semantic mismatch.
- **All four config CRDs** had their printer column labeled "Ready" in `kubectl get` output, but three of them actually query the `Valid` condition — misleading to users.

Fixes #4584
Partially addresses #4534

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test`) — all OIDC-related controller tests pass
- [x] Linting (`task lint-fix`) — 0 issues

## Changes

| File | Change |
|------|--------|
| `mcpoidcconfig_types.go` | Rename `ConditionTypeOIDCConfigReady` → `ConditionTypeOIDCConfigValid`, change value `"Ready"` → `"Valid"`, update printer column |
| `mcpexternalauthconfig_types.go` | Printer column label `"Ready"` → `"Valid"` |
| `mcptelemetryconfig_types.go` | Printer column label `"Ready"` → `"Valid"` |
| `toolconfig_types.go` | Printer column label `"Ready"` → `"Valid"` |
| `mcpoidcconfig_controller.go` | Update condition type constant references and comment |
| `mcpserver_controller.go` | Rename variable `readyCondition` → `validCondition`, update error messages |
| `mcpremoteproxy_controller.go` | Same as above |
| `virtualmcpserver_controller.go` | Update constant reference (already used `validCondition` naming) |
| `*_test.go` / `*_integration_test.go` | Update constant references and assertion messages |
| `deploy/charts/operator-crds/` | Regenerated CRD manifests reflecting printer column and condition type changes |

## Does this introduce a user-facing change?

Yes. `kubectl get` output for config CRDs now shows a "Valid" column instead of "Ready", accurately reflecting the condition type. MCPOIDCConfig's condition type changes from `Ready` to `Valid`, which affects any scripts or tooling querying conditions by type name (e.g., `kubectl wait --for=condition=Ready` must become `--for=condition=Valid`).

## Special notes for reviewers

- This is Part 3 of #4534's suggested PR structure (MCPOIDCConfig condition type) combined with printer column fixes
- Parts 1 and 2 of #4534 (MCPServer/EmbeddingServer phase `Running` → `Ready`) are separate changes and will be addressed in follow-up PRs
- The API is `v1alpha1` so these are not breaking changes per Kubernetes API versioning conventions, but should be noted in release notes

Generated with [Claude Code](https://claude.com/claude-code)