### PR TITLE
Add missing shortNames to MCPRemoteProxy, EmbeddingServer, and MCPRegistry CRDs

### DIFF
--- a/cmd/thv-operator/api/v1alpha1/embeddingserver_types.go
+++ b/cmd/thv-operator/api/v1alpha1/embeddingserver_types.go
@@ -205,7 +205,7 @@ const (
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
-//+kubebuilder:resource:categories=toolhive
+//+kubebuilder:resource:shortName=emb;embedding,categories=toolhive
 //+kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.phase"
 //+kubebuilder:printcolumn:name="Model",type="string",JSONPath=".spec.model"
 //+kubebuilder:printcolumn:name="Ready",type="integer",JSONPath=".status.readyReplicas"

--- a/cmd/thv-operator/api/v1alpha1/mcpregistry_types.go
+++ b/cmd/thv-operator/api/v1alpha1/mcpregistry_types.go
@@ -681,7 +681,7 @@ const (
 //+kubebuilder:printcolumn:name="Servers",type="integer",JSONPath=".status.syncStatus.serverCount"
 //+kubebuilder:printcolumn:name="Last Sync",type="date",JSONPath=".status.syncStatus.lastSyncTime"
 //+kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
-//+kubebuilder:resource:scope=Namespaced,categories=toolhive
+//+kubebuilder:resource:shortName=mcpreg;registry,scope=Namespaced,categories=toolhive
 //nolint:lll
 //+kubebuilder:validation:XValidation:rule="size(self.spec.registries) > 0",message="at least one registry must be specified"
 

--- a/cmd/thv-operator/api/v1alpha1/mcpremoteproxy_types.go
+++ b/cmd/thv-operator/api/v1alpha1/mcpremoteproxy_types.go
@@ -302,7 +302,7 @@ const (
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
-//+kubebuilder:resource:categories=toolhive
+//+kubebuilder:resource:shortName=rp;mcprp,categories=toolhive
 //+kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase"
 //+kubebuilder:printcolumn:name="Remote URL",type="string",JSONPath=".spec.remoteURL"
 //+kubebuilder:printcolumn:name="URL",type="string",JSONPath=".status.url"

--- a/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_embeddingservers.yaml
+++ b/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_embeddingservers.yaml
@@ -13,6 +13,9 @@ spec:
     kind: EmbeddingServer
     listKind: EmbeddingServerList
     plural: embeddingservers
+    shortNames:
+    - emb
+    - embedding
     singular: embeddingserver
   scope: Namespaced
   versions:

--- a/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpregistries.yaml
+++ b/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpregistries.yaml
@@ -13,6 +13,9 @@ spec:
     kind: MCPRegistry
     listKind: MCPRegistryList
     plural: mcpregistries
+    shortNames:
+    - mcpreg
+    - registry
     singular: mcpregistry
   scope: Namespaced
   versions:

--- a/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpremoteproxies.yaml
+++ b/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpremoteproxies.yaml
@@ -13,6 +13,9 @@ spec:
     kind: MCPRemoteProxy
     listKind: MCPRemoteProxyList
     plural: mcpremoteproxies
+    shortNames:
+    - rp
+    - mcprp
     singular: mcpremoteproxy
   scope: Namespaced
   versions:

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_embeddingservers.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_embeddingservers.yaml
@@ -16,6 +16,9 @@ spec:
     kind: EmbeddingServer
     listKind: EmbeddingServerList
     plural: embeddingservers
+    shortNames:
+    - emb
+    - embedding
     singular: embeddingserver
   scope: Namespaced
   versions:

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpregistries.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpregistries.yaml
@@ -16,6 +16,9 @@ spec:
     kind: MCPRegistry
     listKind: MCPRegistryList
     plural: mcpregistries
+    shortNames:
+    - mcpreg
+    - registry
     singular: mcpregistry
   scope: Namespaced
   versions:

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpremoteproxies.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpremoteproxies.yaml
@@ -16,6 +16,9 @@ spec:
     kind: MCPRemoteProxy
     listKind: MCPRemoteProxyList
     plural: mcpremoteproxies
+    shortNames:
+    - rp
+    - mcprp
     singular: mcpremoteproxy
   scope: Namespaced
   versions:


### PR DESCRIPTION
## Summary

Three CRDs (MCPRemoteProxy, EmbeddingServer, MCPRegistry) were the only ones lacking `shortName` in their `+kubebuilder:resource` markers, while all other 8 CRDs had them. This adds shortNames for consistency, so users can use `kubectl get rp`, `kubectl get emb`, and `kubectl get mcpreg` instead of typing full resource names.

Closes #4592

## Type of change

- [x] Enhancement (non-breaking change which adds functionality)

## Changes

| File | Change |
|------|--------|
| `cmd/thv-operator/api/v1alpha1/mcpremoteproxy_types.go` | Add `shortName=rp;mcprp` to kubebuilder resource marker |
| `cmd/thv-operator/api/v1alpha1/embeddingserver_types.go` | Add `shortName=emb;embedding` to kubebuilder resource marker |
| `cmd/thv-operator/api/v1alpha1/mcpregistry_types.go` | Add `shortName=mcpreg;registry` to kubebuilder resource marker |
| `deploy/charts/operator-crds/files/crds/*.yaml` | Regenerated CRD manifests |
| `deploy/charts/operator-crds/templates/*.yaml` | Regenerated Helm-wrapped CRD templates |

## Test plan

- [x] `task lint-fix` passes with 0 issues
- [x] `task operator-test` passes
- [x] Verified shortNames appear in regenerated CRD YAML files
- [x] Confirmed all 11 CRDs now have shortNames defined

Generated with [Claude Code](https://claude.com/claude-code)