### PR TITLE
Add missing SPDX-FileCopyrightText headers to EmbeddingServer files

### DIFF
--- a/cmd/thv-operator/api/v1alpha1/embeddingserver_types.go
+++ b/cmd/thv-operator/api/v1alpha1/embeddingserver_types.go
@@ -1,3 +1,4 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 package v1alpha1

--- a/cmd/thv-operator/controllers/embeddingserver_controller.go
+++ b/cmd/thv-operator/controllers/embeddingserver_controller.go
@@ -1,3 +1,4 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package controllers contains the reconciliation logic for the EmbeddingServer custom resource.


### PR DESCRIPTION
## Summary

- Two EmbeddingServer files were missing the required `SPDX-FileCopyrightText` copyright line, having only the `SPDX-License-Identifier`. This creates inconsistency with the rest of the codebase and may not satisfy REUSE specification requirements.
- Added the missing `// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.` header to both files.

Fixes #4595

## Type of change

- [x] Bug fix

## Test plan

- [x] Linting (`task lint-fix`)
- [x] Manual testing (describe below)

Ran `task license-check` — passes with no errors. Verified both files now have the correct two-line SPDX header matching all other Go files in the repository.

Generated with [Claude Code](https://claude.com/claude-code)