### PR TITLE
Add missing ObservedGeneration to condition structs in 3 controllers

### DIFF
--- a/cmd/thv-operator/controllers/embeddingserver_controller.go
+++ b/cmd/thv-operator/controllers/embeddingserver_controller.go
@@ -420,10 +420,11 @@ func (r *EmbeddingServerReconciler) validateImage(ctx context.Context, embedding
 	if err == validation.ErrImageNotChecked {
 		ctxLogger.Info("Image validation skipped - no enforcement configured")
 		meta.SetStatusCondition(&embedding.Status.Conditions, metav1.Condition{
-			Type:    mcpv1alpha1.ConditionImageValidated,
-			Status:  metav1.ConditionTrue,
-			Reason:  mcpv1alpha1.ConditionReasonImageValidationSkipped,
-			Message: "Image validation was not performed (no enforcement configured)",
+			Type:               mcpv1alpha1.ConditionImageValidated,
+			Status:             metav1.ConditionTrue,
+			Reason:             mcpv1alpha1.ConditionReasonImageValidationSkipped,
+			Message:            "Image validation was not performed (no enforcement configured)",
+			ObservedGeneration: embedding.Generation,
 		})
 		return nil
 	} else if err == validation.ErrImageInvalid {
@@ -431,29 +432,32 @@ func (r *EmbeddingServerReconciler) validateImage(ctx context.Context, embedding
 		embedding.Status.Phase = mcpv1alpha1.EmbeddingServerPhaseFailed
 		embedding.Status.Message = err.Error()
 		meta.SetStatusCondition(&embedding.Status.Conditions, metav1.Condition{
-			Type:    mcpv1alpha1.ConditionImageValidated,
-			Status:  metav1.ConditionFalse,
-			Reason:  mcpv1alpha1.ConditionReasonImageValidationFailed,
-			Message: err.Error(),
+			Type:               mcpv1alpha1.ConditionImageValidated,
+			Status:             metav1.ConditionFalse,
+			Reason:             mcpv1alpha1.ConditionReasonImageValidationFailed,
+			Message:            err.Error(),
+			ObservedGeneration: embedding.Generation,
 		})
 		return err
 	} else if err != nil {
 		ctxLogger.Error(err, "EmbeddingServer image validation system error", "image", embedding.Spec.Image)
 		meta.SetStatusCondition(&embedding.Status.Conditions, metav1.Condition{
-			Type:    mcpv1alpha1.ConditionImageValidated,
-			Status:  metav1.ConditionFalse,
-			Reason:  mcpv1alpha1.ConditionReasonImageValidationError,
-			Message: fmt.Sprintf("Error checking image validity: %v", err),
+			Type:               mcpv1alpha1.ConditionImageValidated,
+			Status:             metav1.ConditionFalse,
+			Reason:             mcpv1alpha1.ConditionReasonImageValidationError,
+			Message:            fmt.Sprintf("Error checking image validity: %v", err),
+			ObservedGeneration: embedding.Generation,
 		})
 		return err
 	}
 
 	ctxLogger.Info("Image validation passed", "image", embedding.Spec.Image)
 	meta.SetStatusCondition(&embedding.Status.Conditions, metav1.Condition{
-		Type:    mcpv1alpha1.ConditionImageValidated,
-		Status:  metav1.ConditionTrue,
-		Reason:  mcpv1alpha1.ConditionReasonImageValidationSuccess,
-		Message: "Image validation passed",
+		Type:               mcpv1alpha1.ConditionImageValidated,
+		Status:             metav1.ConditionTrue,
+		Reason:             mcpv1alpha1.ConditionReasonImageValidationSuccess,
+		Message:            "Image validation passed",
+		ObservedGeneration: embedding.Generation,
 	})
 
 	return nil

--- a/cmd/thv-operator/controllers/mcpremoteproxy_controller.go
+++ b/cmd/thv-operator/controllers/mcpremoteproxy_controller.go
@@ -961,37 +961,41 @@ func (r *MCPRemoteProxyReconciler) updateMCPRemoteProxyStatus(ctx context.Contex
 		proxy.Status.Phase = mcpv1alpha1.MCPRemoteProxyPhaseReady
 		proxy.Status.Message = "Remote proxy is running"
 		meta.SetStatusCondition(&proxy.Status.Conditions, metav1.Condition{
-			Type:    mcpv1alpha1.ConditionTypeReady,
-			Status:  metav1.ConditionTrue,
-			Reason:  mcpv1alpha1.ConditionReasonDeploymentReady,
-			Message: "Deployment is ready and running",
+			Type:               mcpv1alpha1.ConditionTypeReady,
+			Status:             metav1.ConditionTrue,
+			Reason:             mcpv1alpha1.ConditionReasonDeploymentReady,
+			Message:            "Deployment is ready and running",
+			ObservedGeneration: proxy.Generation,
 		})
 	} else if pending > 0 {
 		proxy.Status.Phase = mcpv1alpha1.MCPRemoteProxyPhasePending
 		proxy.Status.Message = "Remote proxy is starting"
 		meta.SetStatusCondition(&proxy.Status.Conditions, metav1.Condition{
-			Type:    mcpv1alpha1.ConditionTypeReady,
-			Status:  metav1.ConditionFalse,
-			Reason:  mcpv1alpha1.ConditionReasonDeploymentNotReady,
-			Message: "Deployment is not yet ready",
+			Type:               mcpv1alpha1.ConditionTypeReady,
+			Status:             metav1.ConditionFalse,
+			Reason:             mcpv1alpha1.ConditionReasonDeploymentNotReady,
+			Message:            "Deployment is not yet ready",
+			ObservedGeneration: proxy.Generation,
 		})
 	} else if failed > 0 {
 		proxy.Status.Phase = mcpv1alpha1.MCPRemoteProxyPhaseFailed
 		proxy.Status.Message = "Remote proxy failed to start"
 		meta.SetStatusCondition(&proxy.Status.Conditions, metav1.Condition{
-			Type:    mcpv1alpha1.ConditionTypeReady,
-			Status:  metav1.ConditionFalse,
-			Reason:  mcpv1alpha1.ConditionReasonDeploymentNotReady,
-			Message: "Deployment failed",
+			Type:               mcpv1alpha1.ConditionTypeReady,
+			Status:             metav1.ConditionFalse,
+			Reason:             mcpv1alpha1.ConditionReasonDeploymentNotReady,
+			Message:            "Deployment failed",
+			ObservedGeneration: proxy.Generation,
 		})
 	} else {
 		proxy.Status.Phase = mcpv1alpha1.MCPRemoteProxyPhasePending
 		proxy.Status.Message = "No pods found for remote proxy"
 		meta.SetStatusCondition(&proxy.Status.Conditions, metav1.Condition{
-			Type:    mcpv1alpha1.ConditionTypeReady,
-			Status:  metav1.ConditionFalse,
-			Reason:  mcpv1alpha1.ConditionReasonDeploymentNotReady,
-			Message: "No pods found",
+			Type:               mcpv1alpha1.ConditionTypeReady,
+			Status:             metav1.ConditionFalse,
+			Reason:             mcpv1alpha1.ConditionReasonDeploymentNotReady,
+			Message:            "No pods found",
+			ObservedGeneration: proxy.Generation,
 		})
 	}
 

--- a/cmd/thv-operator/controllers/mcpserver_controller.go
+++ b/cmd/thv-operator/controllers/mcpserver_controller.go
@@ -680,10 +680,11 @@ func (r *MCPServerReconciler) updateCABundleStatus(ctx context.Context, mcpServe
 // This reduces code duplication in the image validation logic
 func setImageValidationCondition(mcpServer *mcpv1alpha1.MCPServer, status metav1.ConditionStatus, reason, message string) {
 	meta.SetStatusCondition(&mcpServer.Status.Conditions, metav1.Condition{
-		Type:    mcpv1alpha1.ConditionImageValidated,
-		Status:  status,
-		Reason:  reason,
-		Message: message,
+		Type:               mcpv1alpha1.ConditionImageValidated,
+		Status:             status,
+		Reason:             reason,
+		Message:            message,
+		ObservedGeneration: mcpServer.Generation,
 	})
 }
 


### PR DESCRIPTION
## Summary

- Several condition-setting helpers across MCPServer, MCPRemoteProxy, and EmbeddingServer controllers omit `ObservedGeneration` from their `metav1.Condition` structs, preventing clients from distinguishing current vs stale conditions
- Adds `ObservedGeneration: <resource>.Generation` to all 9 affected conditions, matching the pattern already used by other helpers in the same files

Fixes #4597

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes

| File | Change |
|------|--------|
| `cmd/thv-operator/controllers/mcpserver_controller.go` | Add `ObservedGeneration` to `setImageValidationCondition` (1 condition) |
| `cmd/thv-operator/controllers/mcpremoteproxy_controller.go` | Add `ObservedGeneration` to all 4 branches in `updateMCPRemoteProxyStatus` |
| `cmd/thv-operator/controllers/embeddingserver_controller.go` | Add `ObservedGeneration` to all 4 branches in `validateImage` |

## Test plan

- [x] Existing operator controller tests pass (`go test ./cmd/thv-operator/controllers/...`)
- [x] Operator builds successfully (`go build ./cmd/thv-operator/...`)

Generated with [Claude Code](https://claude.com/claude-code)