### PR TITLE
Fix API group mismatch in operator webhook manifest

### DIFF
--- a/cmd/thv-operator/config/webhook/manifests.yaml
+++ b/cmd/thv-operator/config/webhook/manifests.yaml
@@ -10,12 +10,12 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
-      path: /validate-toolhive-stacklok-com-v1alpha1-mcpexternalauthconfig
+      path: /validate-toolhive-stacklok-dev-v1alpha1-mcpexternalauthconfig
   failurePolicy: Fail
   name: vmcpexternalauthconfig.kb.io
   rules:
   - apiGroups:
-    - toolhive.stacklok.com
+    - toolhive.stacklok.dev
     apiVersions:
     - v1alpha1
     operations:


### PR DESCRIPTION
## Summary

The MCPExternalAuthConfig webhook entry in `cmd/thv-operator/config/webhook/manifests.yaml` incorrectly used the API group `toolhive.stacklok.com` instead of the correct `toolhive.stacklok.dev`. The webhook path also used the wrong domain (`toolhive-stacklok-com` instead of `toolhive-stacklok-dev`). The other two webhooks in the same file and the top-level `config/webhook/manifests.yaml` already used the correct group. This is a latent bug that would cause the webhook to target a non-existent API group if webhooks were ever enabled.

Fixes #4599

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test plan

- [x] Verified that the operator webhook manifest now has all three webhooks consistently using `toolhive.stacklok.dev`
- [x] Confirmed the top-level `config/webhook/manifests.yaml` was already correct and unchanged
- [x] Confirmed the canonical API group is `toolhive.stacklok.dev` per `groupversion_info.go`

Generated with [Claude Code](https://claude.com/claude-code)