### PR TITLE
Fix ServiceAccount annotation indentation in operator Helm chart

### DIFF
--- a/deploy/charts/operator/templates/serviceaccount.yaml
+++ b/deploy/charts/operator/templates/serviceaccount.yaml
@@ -12,7 +12,7 @@ metadata:
   {{- end }}
   {{- if .Values.operator.serviceAccount.annotations }}
   annotations:
-    {{- toYaml .Values.operator.serviceAccount.annotations | nindent 12 }}
+    {{- toYaml .Values.operator.serviceAccount.annotations | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.operator.serviceAccount.automountServiceAccountToken }}
 {{- end }}


### PR DESCRIPTION
## Summary

The operator Helm chart's `serviceaccount.yaml` template used `nindent 12` for annotations, but the `annotations:` key is at indent level 2 (under `metadata:`), so values should use `nindent 4`. This produced malformed YAML whenever `operator.serviceAccount.annotations` was set. The bug was latent because the default value is `{}`.

Fixes #4602

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test plan

- [x] Verified the template: `labels` on line 11 correctly uses `nindent 4`; `annotations` on line 15 now matches
- [x] Confirmed default value `{}` means no behavioral change for existing users without annotations set

Generated with [Claude Code](https://claude.com/claude-code)