### PR TITLE
Fix CI extraVolumes test using wrong value keys

### DIFF
--- a/deploy/charts/operator/ci/extraVolumes-values.yaml
+++ b/deploy/charts/operator/ci/extraVolumes-values.yaml
@@ -2,11 +2,11 @@ operator:
   image: ko.local/thv-operator:ci-test
   toolhiveRunnerImage: ko.local/thv-proxyrunner:ci-test
   vmcpImage: ko.local/vmcp:ci-test
-  extraVolumeMounts:
+  volumeMounts:
     - name: test
       mountPath: /somepath
       readOnly: true
-  extraVolumes:
+  volumes:
     - name: test
       emptyDir:
         sizeLimit: 5Mi


### PR DESCRIPTION
## Summary

The CI test file `deploy/charts/operator/ci/extraVolumes-values.yaml` used `operator.extraVolumeMounts` and `operator.extraVolumes`, but the deployment template reads `.Values.operator.volumeMounts` and `.Values.operator.volumes`. This key mismatch meant the CI test silently passed without actually exercising volume injection, giving false confidence that volumes work correctly.

Renamed the keys to match what the template and `values.yaml` expect.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test plan

- [x] Verified `values.yaml` defines `operator.volumes` and `operator.volumeMounts` (not `extraVolumes`/`extraVolumeMounts`)
- [x] Verified `deployment.yaml` template reads `.Values.operator.volumeMounts` and `.Values.operator.volumes`
- [x] Confirmed CI values file now uses the correct matching keys

Generated with [Claude Code](https://claude.com/claude-code)