### PR TITLE
Align OpenShift values file image tags with main values.yaml

### DIFF
--- a/deploy/charts/operator/values-openshift.yaml
+++ b/deploy/charts/operator/values-openshift.yaml
@@ -26,15 +26,15 @@ operator:
   # -- List of image pull secrets to use
   imagePullSecrets: []
   # -- Container image for the operator
-  image: ghcr.io/stacklok/toolhive/operator:v0.6.16
+  image: ghcr.io/stacklok/toolhive/operator:v0.15.0
   # -- Image pull policy for the operator container
   imagePullPolicy: IfNotPresent
 
   # -- Image to use for Toolhive runners
-  toolhiveRunnerImage: ghcr.io/stacklok/toolhive/proxyrunner:v0.6.16
+  toolhiveRunnerImage: ghcr.io/stacklok/toolhive/proxyrunner:v0.15.0
 
   # -- Image to use for Virtual MCP Server (vMCP) deployments
-  vmcpImage: ghcr.io/stacklok/toolhive/vmcp:v0.6.16
+  vmcpImage: ghcr.io/stacklok/toolhive/vmcp:v0.15.0
 
   # -- Host for the proxy deployed by the operator
   proxyHost: 0.0.0.0
@@ -206,4 +206,4 @@ operator:
 # -- All values for the registry API deployment and associated resources
 registryAPI:
   # -- Container image for the registry API
-  image: "ghcr.io/stacklok/thv-registry-api:v0.4.7"
+  image: "ghcr.io/stacklok/thv-registry-api:v0.6.6"


### PR DESCRIPTION
## Summary

- The OpenShift values overlay (`values-openshift.yaml`) had image tags stuck at v0.6.16 / v0.4.7, leaving OpenShift users 9+ versions behind with known bugs and missing features
- Updated all four image tags to match the main `values.yaml` (v0.15.0 for operator/proxyrunner/vmcp, v0.6.6 for registry API)

Fixes #4606

## Type of change

- [x] Bug fix

## Test plan

- [x] Linting (`task lint-fix`)
- [x] Manual testing (describe below)

Ran `helm lint` and `helm template` with the OpenShift values overlay — both pass with the updated tags. Verified all four image references now match `values.yaml`.

## Does this introduce a user-facing change?

Yes — OpenShift users who deploy with `values-openshift.yaml` will now get current images (v0.15.0) instead of the severely outdated v0.6.16 images, gaining 9+ releases worth of bug fixes and features.

## Special notes for reviewers

The OpenShift values file intentionally differs from the base `values.yaml` in security context settings (no hardcoded `runAsUser`, explicit `seccompProfile` at pod level) and resource limits (higher memory for OpenShift). These differences are preserved — only the image tags were updated.

Generated with [Claude Code](https://claude.com/claude-code)