### PR TITLE
Fix health-check close failing auth in vMCP BackendClient

### DIFF
--- a/pkg/vmcp/auth/strategies/header_injection_test.go
+++ b/pkg/vmcp/auth/strategies/header_injection_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	authtypes "github.com/stacklok/toolhive/pkg/vmcp/auth/types"
-	"github.com/stacklok/toolhive/pkg/vmcp/health"
+	healthcontext "github.com/stacklok/toolhive/pkg/vmcp/health/context"
 )
 
 func TestHeaderInjectionStrategy_Name(t *testing.T) {
@@ -43,7 +43,7 @@ func TestHeaderInjectionStrategy_Authenticate(t *testing.T) {
 					HeaderValue: "secret-key-123",
 				},
 			},
-			setupCtx:    func() context.Context { return health.WithHealthCheckMarker(context.Background()) },
+			setupCtx:    func() context.Context { return healthcontext.WithHealthCheckMarker(context.Background()) },
 			expectError: false,
 			checkHeader: func(t *testing.T, req *http.Request) {
 				t.Helper()

--- a/pkg/vmcp/auth/strategies/tokenexchange.go
+++ b/pkg/vmcp/auth/strategies/tokenexchange.go
@@ -18,7 +18,7 @@ import (
 	"github.com/stacklok/toolhive/pkg/auth"
 	"github.com/stacklok/toolhive/pkg/auth/tokenexchange"
 	authtypes "github.com/stacklok/toolhive/pkg/vmcp/auth/types"
-	"github.com/stacklok/toolhive/pkg/vmcp/health"
+	healthcontext "github.com/stacklok/toolhive/pkg/vmcp/health/context"
 )
 
 const (
@@ -107,7 +107,7 @@ func (s *TokenExchangeStrategy) Authenticate(
 	// For health checks there is no user identity to exchange. If client credentials
 	// are configured, use a client credentials grant to authenticate the probe request.
 	// Otherwise skip authentication — the backend will be probed unauthenticated.
-	if health.IsHealthCheck(ctx) {
+	if healthcontext.IsHealthCheck(ctx) {
 		if config.ClientID != "" && config.ClientSecret != "" {
 			return s.authenticateWithClientCredentials(ctx, req, config)
 		}

--- a/pkg/vmcp/auth/strategies/tokenexchange_test.go
+++ b/pkg/vmcp/auth/strategies/tokenexchange_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/stacklok/toolhive-core/env/mocks"
 	"github.com/stacklok/toolhive/pkg/auth"
 	authtypes "github.com/stacklok/toolhive/pkg/vmcp/auth/types"
-	"github.com/stacklok/toolhive/pkg/vmcp/health"
+	healthcontext "github.com/stacklok/toolhive/pkg/vmcp/health/context"
 )
 
 // Test constants
@@ -108,7 +108,7 @@ func TestTokenExchangeStrategy_Authenticate(t *testing.T) {
 	}{
 		{
 			name:     "health check without client credentials skips authentication",
-			setupCtx: func() context.Context { return health.WithHealthCheckMarker(context.Background()) },
+			setupCtx: func() context.Context { return healthcontext.WithHealthCheckMarker(context.Background()) },
 			setupServer: func() *httptest.Server {
 				return httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
 					t.Error("token endpoint should not be called when no client credentials are configured")
@@ -125,7 +125,7 @@ func TestTokenExchangeStrategy_Authenticate(t *testing.T) {
 		},
 		{
 			name:     "health check with client credentials uses client credentials grant",
-			setupCtx: func() context.Context { return health.WithHealthCheckMarker(context.Background()) },
+			setupCtx: func() context.Context { return healthcontext.WithHealthCheckMarker(context.Background()) },
 			setupServer: func() *httptest.Server {
 				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					t.Helper()

--- a/pkg/vmcp/auth/strategies/upstream_inject.go
+++ b/pkg/vmcp/auth/strategies/upstream_inject.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/stacklok/toolhive/pkg/auth"
 	authtypes "github.com/stacklok/toolhive/pkg/vmcp/auth/types"
-	"github.com/stacklok/toolhive/pkg/vmcp/health"
+	healthcontext "github.com/stacklok/toolhive/pkg/vmcp/health/context"
 )
 
 // UpstreamInjectStrategy injects an upstream IDP token into backend request headers.
@@ -62,7 +62,7 @@ func (*UpstreamInjectStrategy) Authenticate(
 	ctx context.Context, req *http.Request, strategy *authtypes.BackendAuthStrategy,
 ) error {
 	// Health checks have no user identity — skip authentication.
-	if health.IsHealthCheck(ctx) {
+	if healthcontext.IsHealthCheck(ctx) {
 		return nil
 	}
 

--- a/pkg/vmcp/auth/strategies/upstream_inject_test.go
+++ b/pkg/vmcp/auth/strategies/upstream_inject_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	authtypes "github.com/stacklok/toolhive/pkg/vmcp/auth/types" // BackendAuthStrategy, ErrUpstreamTokenNotFound
-	"github.com/stacklok/toolhive/pkg/vmcp/health"
+	healthcontext "github.com/stacklok/toolhive/pkg/vmcp/health/context"
 )
 
 func TestUpstreamInjectStrategy_Name(t *testing.T) {
@@ -118,7 +118,7 @@ func TestUpstreamInjectStrategy_Authenticate(t *testing.T) {
 		},
 		{
 			name:     "health check bypass",
-			setupCtx: func() context.Context { return health.WithHealthCheckMarker(context.Background()) },
+			setupCtx: func() context.Context { return healthcontext.WithHealthCheckMarker(context.Background()) },
 			strategy: &authtypes.BackendAuthStrategy{
 				Type: authtypes.StrategyTypeUpstreamInject,
 				UpstreamInject: &authtypes.UpstreamInjectConfig{

--- a/pkg/vmcp/client/client.go
+++ b/pkg/vmcp/client/client.go
@@ -29,7 +29,7 @@ import (
 	vmcpauth "github.com/stacklok/toolhive/pkg/vmcp/auth"
 	authtypes "github.com/stacklok/toolhive/pkg/vmcp/auth/types"
 	"github.com/stacklok/toolhive/pkg/vmcp/conversion"
-	"github.com/stacklok/toolhive/pkg/vmcp/health"
+	healthcontext "github.com/stacklok/toolhive/pkg/vmcp/health/context"
 )
 
 const (
@@ -139,7 +139,7 @@ func (i *identityPropagatingRoundTripper) RoundTrip(req *http.Request) (*http.Re
 		ctx = auth.WithIdentity(ctx, i.identity)
 	}
 	if i.isHealthCheck {
-		ctx = health.WithHealthCheckMarker(ctx)
+		ctx = healthcontext.WithHealthCheckMarker(ctx)
 	}
 	if i.identity != nil || i.isHealthCheck {
 		req = req.Clone(ctx)
@@ -249,7 +249,7 @@ func (h *httpBackendClient) defaultClientFactory(ctx context.Context, target *vm
 	baseTransport = &identityPropagatingRoundTripper{
 		base:          baseTransport,
 		identity:      identity,
-		isHealthCheck: health.IsHealthCheck(ctx),
+		isHealthCheck: healthcontext.IsHealthCheck(ctx),
 	}
 
 	// Inject W3C Trace Context headers (traceparent/tracestate) into outgoing requests.

--- a/pkg/vmcp/client/client_test.go
+++ b/pkg/vmcp/client/client_test.go
@@ -28,7 +28,7 @@ import (
 	authmocks "github.com/stacklok/toolhive/pkg/vmcp/auth/mocks"
 	"github.com/stacklok/toolhive/pkg/vmcp/auth/strategies"
 	authtypes "github.com/stacklok/toolhive/pkg/vmcp/auth/types"
-	"github.com/stacklok/toolhive/pkg/vmcp/health"
+	healthcontext "github.com/stacklok/toolhive/pkg/vmcp/health/context"
 )
 
 func TestHTTPBackendClient_ListCapabilities_WithMockFactory(t *testing.T) {
@@ -912,7 +912,7 @@ func TestIdentityPropagatingRoundTripper_HealthCheck_PropagatesMarker(t *testing
 	require.NoError(t, err)
 
 	require.NotNil(t, base.capturedReq)
-	assert.True(t, health.IsHealthCheck(base.capturedReq.Context()),
+	assert.True(t, healthcontext.IsHealthCheck(base.capturedReq.Context()),
 		"health check marker should be propagated even when original request context lacks it")
 }
 
@@ -929,7 +929,7 @@ func TestIdentityPropagatingRoundTripper_NonHealthCheck_NoMarkerAdded(t *testing
 	require.NoError(t, err)
 
 	require.NotNil(t, base.capturedReq)
-	assert.False(t, health.IsHealthCheck(base.capturedReq.Context()),
+	assert.False(t, healthcontext.IsHealthCheck(base.capturedReq.Context()),
 		"health check marker should not be injected for non-health-check transports")
 }
 
@@ -950,14 +950,14 @@ func TestIdentityPropagatingRoundTripper_HealthCheckWithIdentity_PropagatesBoth(
 	got, ok := pkgauth.IdentityFromContext(base.capturedReq.Context())
 	require.True(t, ok)
 	assert.Equal(t, "svc-account", got.Subject)
-	assert.True(t, health.IsHealthCheck(base.capturedReq.Context()))
+	assert.True(t, healthcontext.IsHealthCheck(base.capturedReq.Context()))
 }
 
-// TestIdentityPropagatingRoundTripper_HealthCheckClose_NoAuthError verifies that when a
-// transient BackendClient is created for a health check (no identity, health check ctx),
-// the transport propagates the health check marker to ALL requests including the DELETE
-// that mcp-go emits on Close(). Auth strategies skip auth for health check requests,
-// so this prevents "no identity found in context" errors in the vMCP logs.
+// TestIdentityPropagatingRoundTripper_HealthCheckClose_OriginalRequestContextUnchanged verifies
+// that when the transport is in health-check mode, RoundTrip injects the health-check marker
+// into the downstream request's context without mutating the original request context. This
+// covers requests (e.g. the DELETE mcp-go emits on Close()) whose context does not already
+// carry the marker.
 func TestIdentityPropagatingRoundTripper_HealthCheckClose_OriginalRequestContextUnchanged(t *testing.T) {
 	t.Parallel()
 
@@ -972,10 +972,10 @@ func TestIdentityPropagatingRoundTripper_HealthCheckClose_OriginalRequestContext
 	require.NoError(t, err)
 
 	// Original request context must NOT be modified.
-	assert.False(t, health.IsHealthCheck(originalCtx),
+	assert.False(t, healthcontext.IsHealthCheck(originalCtx),
 		"original request context must not be mutated")
 	// But downstream context MUST have the marker.
 	require.NotNil(t, base.capturedReq)
-	assert.True(t, health.IsHealthCheck(base.capturedReq.Context()),
+	assert.True(t, healthcontext.IsHealthCheck(base.capturedReq.Context()),
 		"downstream request must carry health check marker")
 }

--- a/pkg/vmcp/health/context/context.go
+++ b/pkg/vmcp/health/context/context.go
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package healthcontext provides a lightweight, dependency-free context marker
+// for identifying health check requests. Keeping this in a separate package
+// allows packages like pkg/vmcp/client and pkg/vmcp/auth/strategies to use
+// the marker without pulling in the heavyweight pkg/vmcp/health dependencies
+// (e.g. k8s.io/apimachinery).
+package healthcontext
+
+import "context"
+
+// healthCheckContextKey is an unexported key type for the health check marker.
+type healthCheckContextKey struct{}
+
+// WithHealthCheckMarker marks a context as a health check request.
+// Authentication layers can use IsHealthCheck to identify and skip authentication
+// for health check requests.
+func WithHealthCheckMarker(ctx context.Context) context.Context {
+	return context.WithValue(ctx, healthCheckContextKey{}, true)
+}
+
+// IsHealthCheck returns true if the context is marked as a health check.
+// Authentication strategies use this to bypass authentication for health checks,
+// since health checks verify backend availability and should not require user credentials.
+// Returns false for nil contexts.
+func IsHealthCheck(ctx context.Context) bool {
+	if ctx == nil {
+		return false
+	}
+	val, ok := ctx.Value(healthCheckContextKey{}).(bool)
+	return ok && val
+}

--- a/pkg/vmcp/health/context/context_test.go
+++ b/pkg/vmcp/health/context/context_test.go
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package healthcontext
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsHealthCheck_WrongValueType(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.WithValue(context.Background(), healthCheckContextKey{}, "not-a-bool")
+	assert.False(t, IsHealthCheck(ctx), "non-bool value should not be treated as health check marker")
+}
+
+func TestIsHealthCheck_FalseValue(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.WithValue(context.Background(), healthCheckContextKey{}, false)
+	assert.False(t, IsHealthCheck(ctx), "explicit false value should not be treated as health check marker")
+}

--- a/pkg/vmcp/health/monitor.go
+++ b/pkg/vmcp/health/monitor.go
@@ -14,16 +14,14 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/stacklok/toolhive/pkg/vmcp"
+	healthcontext "github.com/stacklok/toolhive/pkg/vmcp/health/context"
 )
-
-// healthCheckContextKey is a marker for health check requests.
-type healthCheckContextKey struct{}
 
 // WithHealthCheckMarker marks a context as a health check request.
 // Authentication layers can use IsHealthCheck to identify and skip authentication
 // for health check requests.
 func WithHealthCheckMarker(ctx context.Context) context.Context {
-	return context.WithValue(ctx, healthCheckContextKey{}, true)
+	return healthcontext.WithHealthCheckMarker(ctx)
 }
 
 // IsHealthCheck returns true if the context is marked as a health check.
@@ -31,11 +29,7 @@ func WithHealthCheckMarker(ctx context.Context) context.Context {
 // since health checks verify backend availability and should not require user credentials.
 // Returns false for nil contexts.
 func IsHealthCheck(ctx context.Context) bool {
-	if ctx == nil {
-		return false
-	}
-	val, ok := ctx.Value(healthCheckContextKey{}).(bool)
-	return ok && val
+	return healthcontext.IsHealthCheck(ctx)
 }
 
 // StatusProvider provides read-only access to backend health status.

--- a/pkg/vmcp/health/monitor_test.go
+++ b/pkg/vmcp/health/monitor_test.go
@@ -703,20 +703,6 @@ func TestIsHealthCheck(t *testing.T) {
 			expected: false,
 		},
 		{
-			name: "returns false for context with wrong value type",
-			setupCtx: func() context.Context {
-				return context.WithValue(context.Background(), healthCheckContextKey{}, "not-a-bool")
-			},
-			expected: false,
-		},
-		{
-			name: "returns false for context with false value",
-			setupCtx: func() context.Context {
-				return context.WithValue(context.Background(), healthCheckContextKey{}, false)
-			},
-			expected: false,
-		},
-		{
 			name: "returns true when nested in parent context",
 			setupCtx: func() context.Context {
 				markedCtx := WithHealthCheckMarker(context.Background())


### PR DESCRIPTION
## Summary

<!--
REQUIRED. You MUST explain:
1. WHY this change is needed (the problem or motivation)
2. WHAT changed (concise bullet points)

The diff shows the code — your summary must provide the context a reviewer
needs to understand the purpose without reading the diff first.
-->

mcp-go's StreamableHTTP.Close() creates a DELETE request with context.Background(), discarding the health-check marker and identity from the original call context. The identityPropagatingRoundTripper only stored identity, so when ListCapabilities deferred c.Close(), the DELETE hit auth strategies with neither a health-check marker nor an identity, producing "no identity found in context" errors.

Fix by capturing isHealthCheck at transport creation time and re-injecting both identity and the health-check marker into every outgoing request, including the synthetic DELETE from Close().


<!--
Link related issues. Use "Closes" or "Fixes" to auto-close on merge.
Remove this line if there is no related issue.
-->

Fixes #4573 


## Type of change

<!-- REQUIRED. Check exactly one. -->

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

<!--
REQUIRED. Check every verification step you actually ran.
You MUST check at least one item. If you only did manual testing,
describe exactly what you tested below the checkbox.
-->

- [x] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [x] Linting (`task lint-fix`)
- [ ] Manual testing (describe below)

## Changes

<!--
Optional — include for PRs touching more than a few files to help
reviewers navigate the diff. Remove this entire section for small PRs.
-->

| File | Change |
|------|--------|
|      |        |

## Does this introduce a user-facing change?

<!--
If yes, describe the change from the user's perspective. This helps with release notes.
If no, write "No".
Remove this section entirely if not applicable.
-->

## Special notes for reviewers

<!--
Optional — call out anything non-obvious: tricky logic, known limitations,
areas where you'd like extra scrutiny, or follow-up work planned.
Remove this section if not needed.
-->
