### PR TITLE
Set LeaderElectionNamespace from POD_NAMESPACE in operator

### DIFF
--- a/cmd/thv-operator/main.go
+++ b/cmd/thv-operator/main.go
@@ -75,13 +75,16 @@ func main() {
 	// Bridge to slog for consistency with the rest of the ToolHive codebase.
 	ctrl.SetLogger(logr.FromSlogHandler(slog.Default().Handler()))
 
+	podNamespace, _ := os.LookupEnv("POD_NAMESPACE")
+
 	options := ctrl.Options{
-		Scheme:                 scheme,
-		Metrics:                metricsserver.Options{BindAddress: metricsAddr},
-		WebhookServer:          webhook.NewServer(webhook.Options{Port: 9443}),
-		HealthProbeBindAddress: probeAddr,
-		LeaderElection:         enableLeaderElection,
-		LeaderElectionID:       "toolhive-operator-leader-election",
+		Scheme:                  scheme,
+		Metrics:                 metricsserver.Options{BindAddress: metricsAddr},
+		WebhookServer:           webhook.NewServer(webhook.Options{Port: 9443}),
+		HealthProbeBindAddress:  probeAddr,
+		LeaderElection:          enableLeaderElection,
+		LeaderElectionID:        "toolhive-operator-leader-election",
+		LeaderElectionNamespace: podNamespace,
 		Cache: cache.Options{
 			// if nil, defaults to all namespaces
 			DefaultNamespaces: getDefaultNamespaces(),
@@ -107,8 +110,6 @@ func main() {
 		setupLog.Error(err, "unable to set up ready check")
 		os.Exit(1)
 	}
-
-	podNamespace, _ := os.LookupEnv("POD_NAMESPACE")
 	// Set up telemetry service - only runs when elected as leader
 	telemetryService := telemetry.NewService(mgr.GetClient(), podNamespace)
 	if err := mgr.Add(&telemetry.LeaderTelemetryRunnable{


### PR DESCRIPTION
## Summary

- The operator configures `LeaderElectionID` but does not set `LeaderElectionNamespace`, relying on controller-runtime's implicit namespace detection from the service account token mount. If that detection fails, it defaults to the `default` namespace — where the namespace-scoped leader election RBAC `Role` does not exist — causing leader election to silently fail.
- Move the `POD_NAMESPACE` env var lookup (already injected via Kubernetes downward API) earlier and pass it as `LeaderElectionNamespace` in the manager options so the lease is always created in the correct namespace.

## Type of change

- [x] Bug fix

## Test plan

- [x] Linting (`task lint-fix`)
- [x] Manual testing (describe below)

Verified build compiles cleanly, `task lint` passes with 0 issues. The change is a one-field addition to the manager options struct using an env var that was already being read.

## Does this introduce a user-facing change?

No — this fixes an internal operator configuration issue. Operator behavior with `POD_NAMESPACE` set (the default Helm deployment) is unchanged since controller-runtime would have detected the same namespace. The fix prevents breakage in edge cases where the implicit detection fails.

Generated with [Claude Code](https://claude.com/claude-code)