### PR TITLE
fix(telemetry): warn instead of crashing when OTLP endpoint has no enabled exporters

### DIFF
--- a/pkg/telemetry/serve.go
+++ b/pkg/telemetry/serve.go
@@ -78,9 +78,9 @@ func NewServeProvider(ctx context.Context) (provider *Provider, otelEnabled bool
 	return p, true, nil
 }
 
-// handleUnusedEndpoint clears the OTLP endpoint when both tracing and metrics
-// are disabled, so the server can start normally instead of crashing with a
-// fatal validation error.
+// handleUnusedEndpoint enables tracing by default when an OTLP endpoint is
+// configured but both tracing and metrics are disabled, so the server can start
+// normally instead of crashing with a fatal validation error.
 func handleUnusedEndpoint(otelCfg *config.OpenTelemetryConfig) {
 	if otelCfg.Endpoint == "" {
 		return
@@ -88,8 +88,9 @@ func handleUnusedEndpoint(otelCfg *config.OpenTelemetryConfig) {
 	tracingOff := otelCfg.TracingEnabled == nil || !*otelCfg.TracingEnabled
 	metricsOff := otelCfg.MetricsEnabled == nil || !*otelCfg.MetricsEnabled
 	if tracingOff && metricsOff {
-		slog.Warn("OTLP endpoint is configured but tracing and metrics are both disabled; ignoring endpoint",
+		slog.Warn("OTLP endpoint is configured but tracing and metrics are both disabled; enabling tracing by default",
 			"endpoint", otelCfg.Endpoint)
-		otelCfg.Endpoint = ""
+		enabled := true
+		otelCfg.TracingEnabled = &enabled
 	}
 }


### PR DESCRIPTION
## Summary
- When an OTLP endpoint is configured (`thv config otel set-endpoint`) but both tracing and metrics are disabled, `thv serve` crashes with a fatal validation error (exit code 1)
- This causes ToolHive Studio to show a "Health check failed" error with no clear indication of the root cause
- Instead of crashing, we now **enable tracing by default** when an endpoint is configured but no exporters are enabled, so the endpoint is actually used rather than silently ignored

## Test plan
- [x] Configured an OTLP endpoint (`thv config otel set-endpoint localhost:4317`) with tracing/metrics not enabled
- [x] Verified `thv serve` starts with a warning and tracing enabled by default, instead of crashing
- [x] Verified existing telemetry tests pass (`go test ./pkg/telemetry/...`)
- [ ] Verify normal OTLP flow still works when tracing or metrics are explicitly enabled

Fixes #4647

🤖 Generated with [Claude Code](https://claude.com/claude-code)