### PR TITLE
Add horizontal scaling tests for vmcp

### DIFF
--- a/cmd/thv-operator/controllers/virtualmcpserver_deployment.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_deployment.go
@@ -197,7 +197,7 @@ func (r *VirtualMCPServerReconciler) deploymentForVirtualMCPServer(
 							vmcpLivenessInitialDelay, vmcpLivenessPeriod, vmcpLivenessTimeout, vmcpLivenessFailures,
 						),
 						ReadinessProbe: ctrlutil.BuildHealthProbe(
-							"/health", "http",
+							"/readyz", "http",
 							vmcpReadinessInitialDelay, vmcpReadinessPeriod, vmcpReadinessTimeout, vmcpReadinessFailures,
 						),
 						SecurityContext: containerSecurityContext,

--- a/cmd/vmcp/app/commands.go
+++ b/cmd/vmcp/app/commands.go
@@ -630,11 +630,18 @@ func runServe(cmd *cobra.Command, _ []string) error {
 		AuditConfig:             cfg.Audit,
 		HealthMonitorConfig:     healthMonitorConfig,
 		StatusReportingInterval: getStatusReportingInterval(cfg),
-		Watcher:                 backendWatcher,
+		Watcher:                 nil, // set below if backendWatcher is non-nil
 		StatusReporter:          statusReporter,
 		OptimizerConfig:         optCfg,
 		SessionFactory:          sessionFactory,
 		SessionStorage:          cfg.SessionStorage,
+	}
+
+	// Assign Watcher only when backendWatcher is non-nil. A typed nil *k8s.BackendWatcher
+	// assigned directly to the Watcher interface field produces a non-nil interface value,
+	// which bypasses the nil check in handleReadiness and panics on the first /readyz probe.
+	if backendWatcher != nil {
+		serverCfg.Watcher = backendWatcher
 	}
 
 	// Convert composite tool configurations to workflow definitions

--- a/pkg/cache/validating_cache.go
+++ b/pkg/cache/validating_cache.go
@@ -132,14 +132,15 @@ func (c *ValidatingCache[K, V]) Get(key K) (V, bool) {
 			// pressure between the two calls — fall back to our freshly loaded
 			// value in that case rather than returning a zero value.
 			winner, found := c.lruCache.Get(key)
-			if !found {
-				// Winner was evicted between ContainsOrAdd and Get; keep our
-				// freshly loaded value rather than returning a zero value.
-				return result{v: v}, nil
-			}
-			// Discard our loaded value in favour of the winner.
+			// Discard our loaded value in favour of the winner (or clean up if
+			// the winner was itself evicted between ContainsOrAdd and Get).
 			if c.onEvict != nil {
 				c.onEvict(key, v)
+			}
+			if !found {
+				// Winner was evicted before we could retrieve it; signal a cache
+				// miss so the caller retries rather than receiving a stale value.
+				return nil, nil
 			}
 			return result{v: winner}, nil
 		}
@@ -159,12 +160,6 @@ func (c *ValidatingCache[K, V]) Get(key K) (V, bool) {
 // onEvict is called for it.
 func (c *ValidatingCache[K, V]) Set(key K, value V) {
 	c.lruCache.Add(key, value)
-}
-
-// Remove evicts the entry for key, calling onEvict if the key was present.
-// It is a no-op if the key is not in the cache.
-func (c *ValidatingCache[K, V]) Remove(key K) {
-	c.lruCache.Remove(key)
 }
 
 // Len returns the number of entries currently in the cache.

--- a/pkg/cache/validating_cache.go
+++ b/pkg/cache/validating_cache.go
@@ -132,15 +132,14 @@ func (c *ValidatingCache[K, V]) Get(key K) (V, bool) {
 			// pressure between the two calls — fall back to our freshly loaded
 			// value in that case rather than returning a zero value.
 			winner, found := c.lruCache.Get(key)
-			// Discard our loaded value in favour of the winner (or clean up if
-			// the winner was itself evicted between ContainsOrAdd and Get).
+			if !found {
+				// Winner was evicted between ContainsOrAdd and Get; keep our
+				// freshly loaded value rather than returning a zero value.
+				return result{v: v}, nil
+			}
+			// Discard our loaded value in favour of the winner.
 			if c.onEvict != nil {
 				c.onEvict(key, v)
-			}
-			if !found {
-				// Winner was evicted before we could retrieve it; signal a cache
-				// miss so the caller retries rather than receiving a stale value.
-				return nil, nil
 			}
 			return result{v: winner}, nil
 		}
@@ -160,6 +159,12 @@ func (c *ValidatingCache[K, V]) Get(key K) (V, bool) {
 // onEvict is called for it.
 func (c *ValidatingCache[K, V]) Set(key K, value V) {
 	c.lruCache.Add(key, value)
+}
+
+// Remove evicts the entry for key, calling onEvict if the key was present.
+// It is a no-op if the key is not in the cache.
+func (c *ValidatingCache[K, V]) Remove(key K) {
+	c.lruCache.Remove(key)
 }
 
 // Len returns the number of entries currently in the cache.

--- a/pkg/vmcp/k8s/manager.go
+++ b/pkg/vmcp/k8s/manager.go
@@ -190,7 +190,7 @@ func (w *BackendWatcher) Start(ctx context.Context) error {
 	slog.Info("watching backend resources", "namespace", w.namespace, "group", w.groupRef)
 
 	// Register backend watch controller to reconcile MCPServer/MCPRemoteProxy changes
-	err := w.addBackendWatchController()
+	err := w.addBackendWatchController(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to add backend watch controller: %w", err)
 	}
@@ -285,7 +285,7 @@ func (w *BackendWatcher) WaitForCacheSync(ctx context.Context) bool {
 // Returns:
 //   - nil: Reconciler registered successfully
 //   - error: Failed to create discoverer or register reconciler
-func (w *BackendWatcher) addBackendWatchController() error {
+func (w *BackendWatcher) addBackendWatchController(ctx context.Context) error {
 	// Create K8s discoverer for backend conversion
 	// This reuses the existing workloads package conversion logic
 	discoverer := workloads.NewK8SDiscovererWithClient(
@@ -300,6 +300,12 @@ func (w *BackendWatcher) addBackendWatchController() error {
 		GroupRef:   w.groupRef,
 		Registry:   w.registry,
 		Discoverer: discoverer,
+	}
+
+	// Register field indexes required by the reconciler's watch handlers.
+	// Must be called before SetupWithManager.
+	if err := reconciler.SetupIndexes(ctx, w.ctrlManager); err != nil {
+		return fmt.Errorf("failed to setup backend reconciler indexes: %w", err)
 	}
 
 	// Register reconciler with manager

--- a/pkg/vmcp/server/server.go
+++ b/pkg/vmcp/server/server.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 
 	"github.com/stacklok/toolhive/pkg/audit"
@@ -489,6 +490,24 @@ func New(
 	// See handleSessionRegistration for implementation details.
 	hooks.AddOnRegisterSession(func(ctx context.Context, session server.ClientSession) {
 		srv.handleSessionRegistration(ctx, session)
+	})
+
+	// Register OnBeforeListTools hook for lazy session tool injection.
+	//
+	// When a session is reconstructed from Redis on a different pod (cross-pod sharing),
+	// the SDK's per-session tool store is empty because OnRegisterSession only fires
+	// during Initialize, which the client doesn't re-send to pod B. This hook lazily
+	// injects the tools from the VMCP session manager into the ephemeral SDK session
+	// before handleListTools reads from the per-session tool store.
+	hooks.AddBeforeListTools(func(ctx context.Context, _ any, _ *mcp.ListToolsRequest) {
+		srv.lazyInjectSessionTools(ctx)
+	})
+
+	// Register OnBeforeCallTool hook for the same reason as OnBeforeListTools.
+	// A client may call a tool directly without first calling tools/list, so we
+	// also need to ensure the tool handlers are registered before the call is routed.
+	hooks.AddBeforeCallTool(func(ctx context.Context, _ any, _ *mcp.CallToolRequest) {
+		srv.lazyInjectSessionTools(ctx)
 	})
 
 	// Disarm the close-on-error guard: Server is fully constructed.
@@ -1006,6 +1025,40 @@ func setSessionToolsDirect(session server.ClientSession, tools []server.ServerTo
 	}
 	sessionWithTools.SetSessionTools(toolMap)
 	return nil
+}
+
+// lazyInjectSessionTools injects tools into the SDK ephemeral session for sessions
+// that were reconstructed from Redis on a different pod (cross-pod session sharing).
+//
+// When a client connects to pod B with an existing session ID (established on pod A),
+// the SDK creates an ephemeral session with no tools because OnRegisterSession only fires
+// during Initialize, which the client doesn't re-send to pod B. This method is called
+// from OnBeforeListTools and OnBeforeCallTool hooks to lazily inject the tools before
+// the SDK handler reads from the per-session tool store.
+//
+// For sessions initialized on this pod (normal case), tools are already in the store
+// (set by setSessionToolsDirect during OnRegisterSession); this method is a no-op.
+func (s *Server) lazyInjectSessionTools(ctx context.Context) {
+	sess := server.ClientSessionFromContext(ctx)
+	if sess == nil {
+		return
+	}
+	sessionWithTools, ok := sess.(server.SessionWithTools)
+	if !ok {
+		return
+	}
+	if len(sessionWithTools.GetSessionTools()) > 0 {
+		return // tools already registered (normal pod-local case)
+	}
+	sessionID := sess.SessionID()
+	adaptedTools, err := s.vmcpSessionMgr.GetAdaptedTools(sessionID)
+	if err != nil || len(adaptedTools) == 0 {
+		slog.Debug("lazyInjectSessionTools: no tools available for session", "session_id", sessionID)
+		return
+	}
+	if err := setSessionToolsDirect(sess, adaptedTools); err != nil {
+		slog.Warn("lazyInjectSessionTools: failed to inject tools", "session_id", sessionID, "error", err)
+	}
 }
 
 // handleSessionRegistration processes a new MCP session registration.

--- a/pkg/vmcp/server/sessionmanager/horizontal_scaling_integration_test.go
+++ b/pkg/vmcp/server/sessionmanager/horizontal_scaling_integration_test.go
@@ -271,18 +271,16 @@ func TestHorizontalScaling_AllBackendsFailOnRestore(t *testing.T) {
 	// Use a stoppable backend so we can shut it down mid-test.
 	backend, stopBackend := startStoppableMCPBackend(t, "backend-alpha", "echo")
 
-	sm := newTestManagerWithSharedStorage(t, storage, []*vmcp.Backend{backend})
-	sessionID := createSession(t, sm, nil)
+	smWriter := newTestManagerWithSharedStorage(t, storage, []*vmcp.Backend{backend})
+	sessionID := createSession(t, smWriter, nil)
 
 	// Stop the backend — RestoreSession will be unable to reconnect.
 	stopBackend()
 
-	// Evict from the local cache so the next Get takes the restore path.
-	sm.sessions.Delete(sessionID)
-
-	// GetMultiSession must return a session (not false/nil) even though the
-	// backend is unreachable — the session comes back with an empty tool list.
-	sess, ok := sm.GetMultiSession(sessionID)
+	// Use a fresh manager: its cache is empty, so GetMultiSession takes the
+	// restore path without needing to explicitly evict the session.
+	smReader := newTestManagerWithSharedStorage(t, storage, []*vmcp.Backend{backend})
+	sess, ok := smReader.GetMultiSession(sessionID)
 	require.True(t, ok, "GetMultiSession must return ok=true even when backends are unreachable")
 	require.NotNil(t, sess)
 	assert.Empty(t, sess.Tools(), "routing table must be empty when no backend reconnected")
@@ -321,7 +319,8 @@ func TestHorizontalScaling_BackendExpiry_SkipsExpiredOnRestore(t *testing.T) {
 	require.True(t, toolNames["tool-alpha"], "session A must have tool-alpha before expiry")
 	require.True(t, toolNames["tool-beta"], "session A must have tool-beta before expiry")
 
-	// NotifyBackendExpired updates Redis to remove backend-beta and evicts from pod A's cache.
+	// NotifyBackendExpired updates Redis to remove backend-beta; the node-local cache
+	// entry is evicted lazily on the next GetMultiSession when checkSession detects drift.
 	smA.NotifyBackendExpired(sessionID, backendB.ID)
 
 	// Pod C: fresh Manager, same storage and both backends in registry.

--- a/pkg/vmcp/server/sessionmanager/horizontal_scaling_integration_test.go
+++ b/pkg/vmcp/server/sessionmanager/horizontal_scaling_integration_test.go
@@ -321,7 +321,7 @@ func TestHorizontalScaling_BackendExpiry_SkipsExpiredOnRestore(t *testing.T) {
 
 	// NotifyBackendExpired updates Redis to remove backend-beta; the node-local cache
 	// entry is evicted lazily on the next GetMultiSession when checkSession detects drift.
-	smA.NotifyBackendExpired(sessionID, backendB.ID)
+	smA.NotifyBackendExpired(sessionID, backendB.ID, sessA.GetMetadata())
 
 	// Pod C: fresh Manager, same storage and both backends in registry.
 	// (backendB is still running — we're testing that RestoreSession filters

--- a/pkg/vmcp/server/sessionmanager/horizontal_scaling_integration_test.go
+++ b/pkg/vmcp/server/sessionmanager/horizontal_scaling_integration_test.go
@@ -1,0 +1,382 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package sessionmanager
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	mcpmcp "github.com/mark3labs/mcp-go/mcp"
+	mcpserver "github.com/mark3labs/mcp-go/server"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stacklok/toolhive/pkg/auth"
+	transportsession "github.com/stacklok/toolhive/pkg/transport/session"
+	"github.com/stacklok/toolhive/pkg/vmcp"
+	vmcpauth "github.com/stacklok/toolhive/pkg/vmcp/auth"
+	"github.com/stacklok/toolhive/pkg/vmcp/auth/strategies"
+	authtypes "github.com/stacklok/toolhive/pkg/vmcp/auth/types"
+	vmcpsession "github.com/stacklok/toolhive/pkg/vmcp/session"
+	sessiontypes "github.com/stacklok/toolhive/pkg/vmcp/session/types"
+)
+
+// hmacSecret is a fixed 32-byte secret used across all integration tests.
+var hmacSecret = []byte("test-hmac-secret-32bytes-exactly")
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// newUnauthenticatedAuthRegistry builds an OutgoingAuthRegistry with only the
+// unauthenticated strategy registered — suitable for tests whose backend MCP
+// servers require no auth.
+func newUnauthenticatedAuthRegistry(t *testing.T) vmcpauth.OutgoingAuthRegistry {
+	t.Helper()
+	reg := vmcpauth.NewDefaultOutgoingAuthRegistry()
+	require.NoError(t, reg.RegisterStrategy(authtypes.StrategyTypeUnauthenticated, strategies.NewUnauthenticatedStrategy()))
+	return reg
+}
+
+// newSharedRedisStorage creates a RedisSessionDataStorage pointing at mr.
+// The storage is closed via t.Cleanup.
+func newSharedRedisStorage(t *testing.T, mr *miniredis.Miniredis) transportsession.DataStorage {
+	t.Helper()
+	storage, err := transportsession.NewRedisSessionDataStorage(
+		context.Background(),
+		transportsession.RedisConfig{
+			Addr:      mr.Addr(),
+			KeyPrefix: "test:vmcp:session:",
+		},
+		time.Hour,
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = storage.Close() })
+	return storage
+}
+
+// newTestManagerWithSharedStorage creates a Manager backed by the given
+// DataStorage, a real session factory with the package-level hmacSecret, and
+// an ImmutableRegistry containing backends. Cleanup is registered via
+// t.Cleanup.
+func newTestManagerWithSharedStorage(t *testing.T, storage transportsession.DataStorage, backends []*vmcp.Backend) *Manager {
+	t.Helper()
+	backendList := make([]vmcp.Backend, len(backends))
+	for i, b := range backends {
+		backendList[i] = *b
+	}
+	registry := vmcp.NewImmutableRegistry(backendList)
+	factory := vmcpsession.NewSessionFactory(
+		newUnauthenticatedAuthRegistry(t),
+		vmcpsession.WithHMACSecret(hmacSecret),
+	)
+	sm, cleanup, err := New(storage, &FactoryConfig{Base: factory}, registry)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, cleanup(context.Background())) })
+	return sm
+}
+
+// createSession runs the two-phase Generate + CreateSession flow.
+// identity may be nil for anonymous sessions.
+// Returns the assigned session ID.
+func createSession(t *testing.T, sm *Manager, identity *auth.Identity) string {
+	t.Helper()
+	sessionID := sm.Generate()
+	require.NotEmpty(t, sessionID)
+	ctx := context.Background()
+	if identity != nil {
+		ctx = auth.WithIdentity(ctx, identity)
+	}
+	_, err := sm.CreateSession(ctx, sessionID)
+	require.NoError(t, err)
+	return sessionID
+}
+
+// startMCPBackend starts an in-process streamable-HTTP MCP server that
+// exposes a single tool named toolName (which echoes its "input" argument).
+// The server is shut down when t completes.
+// Returns a *vmcp.Backend pointing at the server.
+func startMCPBackend(t *testing.T, backendID, toolName string) *vmcp.Backend {
+	t.Helper()
+	mcpSrv := mcpserver.NewMCPServer(backendID, "1.0.0")
+	mcpSrv.AddTool(
+		mcpmcp.NewTool(toolName,
+			mcpmcp.WithDescription("Echoes the input argument"),
+			mcpmcp.WithString("input", mcpmcp.Required()),
+		),
+		func(_ context.Context, req mcpmcp.CallToolRequest) (*mcpmcp.CallToolResult, error) {
+			args, _ := req.Params.Arguments.(map[string]any)
+			input, _ := args["input"].(string)
+			return &mcpmcp.CallToolResult{
+				Content: []mcpmcp.Content{mcpmcp.NewTextContent(input)},
+			}, nil
+		},
+	)
+	streamableSrv := mcpserver.NewStreamableHTTPServer(mcpSrv)
+	mux := http.NewServeMux()
+	mux.Handle("/mcp", streamableSrv)
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+	return &vmcp.Backend{
+		ID:            backendID,
+		Name:          backendID,
+		BaseURL:       ts.URL + "/mcp",
+		TransportType: "streamable-http",
+	}
+}
+
+// startStoppableMCPBackend is like startMCPBackend but also returns a stop
+// function so the caller can shut the backend down mid-test (e.g. to simulate
+// a backend going away). The stop function is idempotent and is also
+// registered with t.Cleanup so the server is always closed even if the test
+// fails before the caller invokes stop.
+func startStoppableMCPBackend(t *testing.T, backendID, toolName string) (*vmcp.Backend, func()) {
+	t.Helper()
+	mcpSrv := mcpserver.NewMCPServer(backendID, "1.0.0")
+	mcpSrv.AddTool(
+		mcpmcp.NewTool(toolName,
+			mcpmcp.WithDescription("Echoes the input argument"),
+			mcpmcp.WithString("input", mcpmcp.Required()),
+		),
+		func(_ context.Context, req mcpmcp.CallToolRequest) (*mcpmcp.CallToolResult, error) {
+			args, _ := req.Params.Arguments.(map[string]any)
+			input, _ := args["input"].(string)
+			return &mcpmcp.CallToolResult{
+				Content: []mcpmcp.Content{mcpmcp.NewTextContent(input)},
+			}, nil
+		},
+	)
+	streamableSrv := mcpserver.NewStreamableHTTPServer(mcpSrv)
+	mux := http.NewServeMux()
+	mux.Handle("/mcp", streamableSrv)
+	ts := httptest.NewServer(mux)
+	var once sync.Once
+	stop := func() { once.Do(ts.Close) }
+	t.Cleanup(stop)
+	return &vmcp.Backend{
+		ID:            backendID,
+		Name:          backendID,
+		BaseURL:       ts.URL + "/mcp",
+		TransportType: "streamable-http",
+	}, stop
+}
+
+// ---------------------------------------------------------------------------
+// AC1: Cross-pod session reconstruction
+// ---------------------------------------------------------------------------
+
+// TestHorizontalScaling_CrossPodReconstruction verifies that a session
+// created on "pod A" (Manager A) can be reconstructed on "pod B" (Manager B)
+// via GetMultiSession → cache miss → RestoreSession from Redis.
+func TestHorizontalScaling_CrossPodReconstruction(t *testing.T) {
+	t.Parallel()
+
+	mr := miniredis.RunT(t)
+	storage := newSharedRedisStorage(t, mr)
+	backend := startMCPBackend(t, "backend-alpha", "echo")
+
+	// Pod A: create a session; it is stored in Redis and cached locally in smA.
+	smA := newTestManagerWithSharedStorage(t, storage, []*vmcp.Backend{backend})
+	sessionID := createSession(t, smA, nil)
+
+	// Pod B: fresh Manager, same Redis storage — session is NOT in local cache.
+	smB := newTestManagerWithSharedStorage(t, storage, []*vmcp.Backend{backend})
+
+	// GetMultiSession triggers cache miss → loadSession → RestoreSession from Redis.
+	sess, ok := smB.GetMultiSession(sessionID)
+	require.True(t, ok, "pod B must reconstruct the session from Redis on cache miss")
+	require.NotNil(t, sess)
+
+	// The restored session must have reconnected to the backend and discovered tools.
+	require.NotEmpty(t, sess.Tools(), "restored session must have the backend's tools")
+	assert.Equal(t, "echo", sess.Tools()[0].Name)
+}
+
+// ---------------------------------------------------------------------------
+// AC2: Cross-pod hijack prevention
+// ---------------------------------------------------------------------------
+
+// TestHorizontalScaling_CrossPodHijackPrevention verifies that:
+//   - A session bound to alice on pod A can be reconstructed on pod B.
+//   - After restoration, a wrong-token caller is rejected (ErrUnauthorizedCaller).
+//   - A nil caller is rejected (ErrNilCaller).
+//   - The original caller (correct token) is not rejected at the auth layer.
+func TestHorizontalScaling_CrossPodHijackPrevention(t *testing.T) {
+	t.Parallel()
+
+	mr := miniredis.RunT(t)
+	storage := newSharedRedisStorage(t, mr)
+	backend := startMCPBackend(t, "backend-alpha", "echo")
+
+	identity := &auth.Identity{
+		PrincipalInfo: auth.PrincipalInfo{Subject: "alice"},
+		Token:         "alice-bearer-token",
+	}
+	wrongCaller := &auth.Identity{
+		PrincipalInfo: auth.PrincipalInfo{Subject: "eve"},
+		Token:         "eve-bearer-token",
+	}
+
+	// Pod A: create session bound to alice.
+	smA := newTestManagerWithSharedStorage(t, storage, []*vmcp.Backend{backend})
+	sessionID := createSession(t, smA, identity)
+
+	// Pod B: restore from Redis.
+	smB := newTestManagerWithSharedStorage(t, storage, []*vmcp.Backend{backend})
+	sess, ok := smB.GetMultiSession(sessionID)
+	require.True(t, ok, "session must be restorable on pod B")
+	require.NotNil(t, sess)
+
+	ctx := context.Background()
+
+	// Wrong caller must be rejected before any backend routing.
+	_, err := sess.CallTool(ctx, wrongCaller, "echo", map[string]any{"input": "hi"}, nil)
+	assert.ErrorIs(t, err, sessiontypes.ErrUnauthorizedCaller, "wrong token must be rejected")
+
+	// Nil caller must be rejected.
+	_, err = sess.CallTool(ctx, nil, "echo", map[string]any{"input": "hi"}, nil)
+	assert.ErrorIs(t, err, sessiontypes.ErrNilCaller, "nil caller must be rejected")
+
+	// Original caller must pass auth and successfully route to the backend.
+	// The backend is still running, so the call must complete without error.
+	_, err = sess.CallTool(ctx, identity, "echo", map[string]any{"input": "hi"}, nil)
+	require.NoError(t, err, "correct caller must be able to invoke the tool after restore")
+}
+
+// ---------------------------------------------------------------------------
+// AC3 is intentionally omitted: LRU eviction (RC-10, issue #4221) was dropped
+// in favour of TTL-based Redis eviction.
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// AC4: All backends fail during RestoreSession → empty routing table
+// ---------------------------------------------------------------------------
+
+// TestHorizontalScaling_AllBackendsFailOnRestore verifies that when all
+// backends are unreachable at restore time, GetMultiSession still returns a
+// valid (non-nil) session with an empty routing table — consistent with the
+// makeSession partial-failure behaviour documented in the spec.
+func TestHorizontalScaling_AllBackendsFailOnRestore(t *testing.T) {
+	t.Parallel()
+
+	mr := miniredis.RunT(t)
+	storage := newSharedRedisStorage(t, mr)
+
+	// Use a stoppable backend so we can shut it down mid-test.
+	backend, stopBackend := startStoppableMCPBackend(t, "backend-alpha", "echo")
+
+	sm := newTestManagerWithSharedStorage(t, storage, []*vmcp.Backend{backend})
+	sessionID := createSession(t, sm, nil)
+
+	// Stop the backend — RestoreSession will be unable to reconnect.
+	stopBackend()
+
+	// Evict from the local cache so the next Get takes the restore path.
+	sm.sessions.Delete(sessionID)
+
+	// GetMultiSession must return a session (not false/nil) even though the
+	// backend is unreachable — the session comes back with an empty tool list.
+	sess, ok := sm.GetMultiSession(sessionID)
+	require.True(t, ok, "GetMultiSession must return ok=true even when backends are unreachable")
+	require.NotNil(t, sess)
+	assert.Empty(t, sess.Tools(), "routing table must be empty when no backend reconnected")
+}
+
+// ---------------------------------------------------------------------------
+// AC5: RC-16 backend expiry — NotifyBackendExpired removes metadata;
+//       subsequent RestoreSession skips the expired backend.
+// ---------------------------------------------------------------------------
+
+// TestHorizontalScaling_BackendExpiry_SkipsExpiredOnRestore verifies that
+// after NotifyBackendExpired removes a backend from Redis metadata, a
+// subsequent RestoreSession on a different pod only connects to the remaining
+// backend and does not include the expired backend's tools.
+func TestHorizontalScaling_BackendExpiry_SkipsExpiredOnRestore(t *testing.T) {
+	t.Parallel()
+
+	mr := miniredis.RunT(t)
+	storage := newSharedRedisStorage(t, mr)
+
+	// Two backends with distinct tool names so we can tell them apart.
+	backendA := startMCPBackend(t, "backend-alpha", "tool-alpha")
+	backendB := startMCPBackend(t, "backend-beta", "tool-beta")
+
+	// Pod A: create session connected to both backends.
+	smA := newTestManagerWithSharedStorage(t, storage, []*vmcp.Backend{backendA, backendB})
+	sessionID := createSession(t, smA, nil)
+
+	// Verify session A has tools from both backends before expiry.
+	sessA, ok := smA.GetMultiSession(sessionID)
+	require.True(t, ok)
+	toolNames := make(map[string]bool)
+	for _, tool := range sessA.Tools() {
+		toolNames[tool.Name] = true
+	}
+	require.True(t, toolNames["tool-alpha"], "session A must have tool-alpha before expiry")
+	require.True(t, toolNames["tool-beta"], "session A must have tool-beta before expiry")
+
+	// NotifyBackendExpired updates Redis to remove backend-beta and evicts from pod A's cache.
+	smA.NotifyBackendExpired(sessionID, backendB.ID)
+
+	// Pod C: fresh Manager, same storage and both backends in registry.
+	// (backendB is still running — we're testing that RestoreSession filters
+	// it out based on the updated Redis metadata, not because it's unreachable.)
+	smC := newTestManagerWithSharedStorage(t, storage, []*vmcp.Backend{backendA, backendB})
+	sessC, ok := smC.GetMultiSession(sessionID)
+	require.True(t, ok, "session must be restorable after NotifyBackendExpired")
+	require.NotNil(t, sessC)
+
+	// Restored session must only have tool-alpha; tool-beta was filtered out.
+	restoredTools := make(map[string]bool)
+	for _, tool := range sessC.Tools() {
+		restoredTools[tool.Name] = true
+	}
+	assert.True(t, restoredTools["tool-alpha"], "restored session must have tool-alpha")
+	assert.False(t, restoredTools["tool-beta"], "restored session must NOT have tool-beta after expiry")
+}
+
+// ---------------------------------------------------------------------------
+// AC6: In-memory-only mode (no Redis) — no cross-pod sharing
+// ---------------------------------------------------------------------------
+
+// TestHorizontalScaling_InMemoryOnlyMode verifies that when Redis is not
+// configured (LocalSessionDataStorage), sessions are not visible to a second
+// Manager instance, and single-pod usage continues to work correctly.
+func TestHorizontalScaling_InMemoryOnlyMode(t *testing.T) {
+	t.Parallel()
+
+	backend := startMCPBackend(t, "backend-alpha", "echo")
+
+	newLocalStorage := func(t *testing.T) transportsession.DataStorage {
+		t.Helper()
+		s, err := transportsession.NewLocalSessionDataStorage(time.Hour)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = s.Close() })
+		return s
+	}
+
+	// Pod A and pod B each have their own local storage — no sharing.
+	storageA := newLocalStorage(t)
+	storageB := newLocalStorage(t)
+
+	smA := newTestManagerWithSharedStorage(t, storageA, []*vmcp.Backend{backend})
+	smB := newTestManagerWithSharedStorage(t, storageB, []*vmcp.Backend{backend})
+
+	sessionID := createSession(t, smA, nil)
+
+	// Pod B must not be able to see pod A's session.
+	_, ok := smB.GetMultiSession(sessionID)
+	assert.False(t, ok, "in-memory-only: pod B must not see pod A's session")
+
+	// Single-pod usage on pod A must still work.
+	sess, ok := smA.GetMultiSession(sessionID)
+	require.True(t, ok, "pod A must still serve its own session")
+	require.NotNil(t, sess)
+	assert.NotEmpty(t, sess.Tools(), "session on pod A must have tools")
+}

--- a/pkg/vmcp/server/sessionmanager/session_manager.go
+++ b/pkg/vmcp/server/sessionmanager/session_manager.go
@@ -18,7 +18,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"maps"
 	"strings"
 	"time"
 
@@ -477,11 +476,13 @@ func (sm *Manager) Terminate(sessionID string) (isNotAllowed bool, err error) {
 	}
 
 	if _, isFullSession := metadata[sessiontypes.MetadataKeyTokenHash]; isFullSession {
-		// Phase 2 (full MultiSession): delete from storage. The cache entry will be
-		// evicted lazily on the next Get when checkSession finds the session gone.
+		// Phase 2 (full MultiSession): delete from storage, then evict from the
+		// node-local cache so onEvict closes backend connections immediately rather
+		// than waiting for the next Get or an LRU eviction.
 		if deleteErr := sm.storage.Delete(ctx, sessionID); deleteErr != nil {
 			return false, fmt.Errorf("Manager.Terminate: failed to delete session from storage: %w", deleteErr)
 		}
+		sm.sessions.Remove(sessionID)
 		slog.Info("Manager.Terminate: session terminated", "session_id", sessionID)
 		return false, nil
 	}
@@ -654,9 +655,13 @@ func (sm *Manager) checkSession(sessionID string, sess vmcpsession.MultiSession)
 		return cache.ErrExpired
 	}
 
-	// Evict if any metadata key has drifted, so the next Get restores current state.
-	if !maps.Equal(sess.GetMetadata(), metadata) {
-		return cache.ErrExpired
+	// Compare backend IDs to detect cross-pod metadata drift.
+	// Only compare when the cached session carries MetadataKeyBackendIDs to
+	// avoid spurious evictions for sessions that don't track backend IDs.
+	if cachedIDs, present := sess.GetMetadata()[vmcpsession.MetadataKeyBackendIDs]; present {
+		if cachedIDs != metadata[vmcpsession.MetadataKeyBackendIDs] {
+			return cache.ErrExpired
+		}
 	}
 
 	return nil
@@ -741,8 +746,8 @@ func (sm *Manager) DecorateSession(sessionID string, fn func(sessiontypes.MultiS
 	}
 	if !updated {
 		// Session was deleted (by Terminate or TTL) between Get and Update.
-		// The cache entry will be evicted lazily on the next Get when checkSession
-		// finds the session gone from storage.
+		// Evict the stale cache entry so onEvict closes backend connections.
+		sm.sessions.Remove(sessionID)
 		return fmt.Errorf("DecorateSession: session %q was deleted during decoration", sessionID)
 	}
 	sm.sessions.Set(sessionID, decorated)

--- a/pkg/vmcp/server/sessionmanager/session_manager.go
+++ b/pkg/vmcp/server/sessionmanager/session_manager.go
@@ -658,11 +658,12 @@ func (sm *Manager) checkSession(sessionID string, sess vmcpsession.MultiSession)
 	//
 	// We intentionally compare only MetadataKeyBackendIDs rather than the full
 	// metadata map. Per-backend session IDs (MetadataKeyBackendSessionPrefix+*)
-	// are local connection values that change on every RestoreSession call — a
-	// cross-pod restored session will always have different per-backend session IDs
-	// from what is stored in Redis (established by a different pod). Comparing
-	// the full map would cause the session to be evicted on every cache hit after
-	// a cross-pod restore, preventing tools from ever being served.
+	// are the session IDs negotiated by the restoring pod's backend connections.
+	// RestoreSession sends the stored IDs as Mcp-Session-Id hints, so a backend
+	// that honors session resumption will return the same ID — but not all backends
+	// do (e.g. SSE transports have no session ID at all). Comparing the full map
+	// would evict on every cross-pod cache hit whenever any backend assigns a
+	// fresh ID, preventing tools from ever being served.
 	sessBackendIDs := sess.GetMetadata()[vmcpsession.MetadataKeyBackendIDs]
 	if sessBackendIDs != metadata[vmcpsession.MetadataKeyBackendIDs] {
 		return cache.ErrExpired

--- a/pkg/vmcp/server/sessionmanager/session_manager.go
+++ b/pkg/vmcp/server/sessionmanager/session_manager.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"maps"
 	"strings"
 	"time"
 
@@ -476,13 +477,11 @@ func (sm *Manager) Terminate(sessionID string) (isNotAllowed bool, err error) {
 	}
 
 	if _, isFullSession := metadata[sessiontypes.MetadataKeyTokenHash]; isFullSession {
-		// Phase 2 (full MultiSession): delete from storage, then evict from the
-		// node-local cache so onEvict closes backend connections immediately rather
-		// than waiting for the next Get or an LRU eviction.
+		// Phase 2 (full MultiSession): delete from storage. The cache entry will be
+		// evicted lazily on the next Get when checkSession finds the session gone.
 		if deleteErr := sm.storage.Delete(ctx, sessionID); deleteErr != nil {
 			return false, fmt.Errorf("Manager.Terminate: failed to delete session from storage: %w", deleteErr)
 		}
-		sm.sessions.Remove(sessionID)
 		slog.Info("Manager.Terminate: session terminated", "session_id", sessionID)
 		return false, nil
 	}
@@ -655,13 +654,9 @@ func (sm *Manager) checkSession(sessionID string, sess vmcpsession.MultiSession)
 		return cache.ErrExpired
 	}
 
-	// Compare backend IDs to detect cross-pod metadata drift.
-	// Only compare when the cached session carries MetadataKeyBackendIDs to
-	// avoid spurious evictions for sessions that don't track backend IDs.
-	if cachedIDs, present := sess.GetMetadata()[vmcpsession.MetadataKeyBackendIDs]; present {
-		if cachedIDs != metadata[vmcpsession.MetadataKeyBackendIDs] {
-			return cache.ErrExpired
-		}
+	// Evict if any metadata key has drifted, so the next Get restores current state.
+	if !maps.Equal(sess.GetMetadata(), metadata) {
+		return cache.ErrExpired
 	}
 
 	return nil
@@ -746,8 +741,8 @@ func (sm *Manager) DecorateSession(sessionID string, fn func(sessiontypes.MultiS
 	}
 	if !updated {
 		// Session was deleted (by Terminate or TTL) between Get and Update.
-		// Evict the stale cache entry so onEvict closes backend connections.
-		sm.sessions.Remove(sessionID)
+		// The cache entry will be evicted lazily on the next Get when checkSession
+		// finds the session gone from storage.
 		return fmt.Errorf("DecorateSession: session %q was deleted during decoration", sessionID)
 	}
 	sm.sessions.Set(sessionID, decorated)

--- a/pkg/vmcp/server/sessionmanager/session_manager.go
+++ b/pkg/vmcp/server/sessionmanager/session_manager.go
@@ -18,7 +18,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"maps"
 	"strings"
 	"time"
 
@@ -654,8 +653,18 @@ func (sm *Manager) checkSession(sessionID string, sess vmcpsession.MultiSession)
 		return cache.ErrExpired
 	}
 
-	// Evict if any metadata key has drifted, so the next Get restores current state.
-	if !maps.Equal(sess.GetMetadata(), metadata) {
+	// Evict if the backend ID list has drifted (e.g. NotifyBackendExpired removed a
+	// backend), so the next Get calls RestoreSession with the updated backend list.
+	//
+	// We intentionally compare only MetadataKeyBackendIDs rather than the full
+	// metadata map. Per-backend session IDs (MetadataKeyBackendSessionPrefix+*)
+	// are local connection values that change on every RestoreSession call — a
+	// cross-pod restored session will always have different per-backend session IDs
+	// from what is stored in Redis (established by a different pod). Comparing
+	// the full map would cause the session to be evicted on every cache hit after
+	// a cross-pod restore, preventing tools from ever being served.
+	sessBackendIDs := sess.GetMetadata()[vmcpsession.MetadataKeyBackendIDs]
+	if sessBackendIDs != metadata[vmcpsession.MetadataKeyBackendIDs] {
 		return cache.ErrExpired
 	}
 

--- a/pkg/vmcp/server/sessionmanager/session_manager_test.go
+++ b/pkg/vmcp/server/sessionmanager/session_manager_test.go
@@ -591,9 +591,21 @@ func TestSessionManager_Terminate(t *testing.T) {
 		factory.EXPECT().
 			MakeSessionWithID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 			DoAndReturn(func(_ context.Context, id string, _ *auth.Identity, _ bool, _ []*vmcp.Backend) (vmcpsession.MultiSession, error) {
-				createdSess = newMockSession(t, ctrl, id, tools)
-				// Close() is called eagerly by onEvict when Terminate removes
-				// the entry from the node-local cache after storage.Delete.
+				createdSess = sessionmocks.NewMockMultiSession(ctrl)
+				createdSess.EXPECT().ID().Return(id).AnyTimes()
+				createdSess.EXPECT().GetMetadata().Return(tokenHashMeta).AnyTimes()
+				createdSess.EXPECT().Tools().Return(tools).AnyTimes()
+				createdSess.EXPECT().Type().Return(transportsession.SessionType("")).AnyTimes()
+				createdSess.EXPECT().CreatedAt().Return(time.Time{}).AnyTimes()
+				createdSess.EXPECT().UpdatedAt().Return(time.Time{}).AnyTimes()
+				createdSess.EXPECT().GetData().Return(nil).AnyTimes()
+				createdSess.EXPECT().SetData(gomock.Any()).AnyTimes()
+				createdSess.EXPECT().SetMetadata(gomock.Any(), gomock.Any()).AnyTimes()
+				createdSess.EXPECT().BackendSessions().Return(nil).AnyTimes()
+				createdSess.EXPECT().GetRoutingTable().Return(nil).AnyTimes()
+				createdSess.EXPECT().Prompts().Return(nil).AnyTimes()
+				// Close() is called by onEvict when checkSession detects the session
+				// is gone from storage on the next GetMultiSession call.
 				createdSess.EXPECT().Close().Return(nil).Times(1)
 				return createdSess, nil
 			}).Times(1)
@@ -1927,18 +1939,12 @@ func TestSessionManager_DecorateSession(t *testing.T) {
 				return sess, nil
 			}).Times(1)
 
-		sm, storage := newTestSessionManager(t, factory, newFakeRegistry())
+		sm, _ := newTestSessionManager(t, factory, newFakeRegistry())
 
 		sessionID := sm.Generate()
 		require.NotEmpty(t, sessionID)
 		_, err := sm.CreateSession(context.Background(), sessionID)
 		require.NoError(t, err)
-
-		// Seed MetadataKeyTokenHash into storage so Terminate recognises this
-		// as a Phase 2 (full MultiSession) and deletes rather than marks terminated.
-		require.NoError(t, storage.Upsert(context.Background(), sessionID, map[string]string{
-			sessiontypes.MetadataKeyTokenHash: "",
-		}))
 
 		err = sm.DecorateSession(sessionID, func(sess sessiontypes.MultiSession) sessiontypes.MultiSession {
 			// Simulate concurrent Terminate() completing during decoration.
@@ -2078,7 +2084,7 @@ func TestSessionManager_CheckSession(t *testing.T) {
 		sm.sessions.Set(sessionID, cached)
 
 		err := sm.checkSession(sessionID, cached)
-		assert.NoError(t, err, "absent MetadataKeyBackendIDs in cache must not cause eviction")
+		assert.NoError(t, err, "matching empty metadata must not cause eviction")
 	})
 }
 

--- a/pkg/vmcp/server/sessionmanager/session_manager_test.go
+++ b/pkg/vmcp/server/sessionmanager/session_manager_test.go
@@ -591,37 +591,27 @@ func TestSessionManager_Terminate(t *testing.T) {
 		factory.EXPECT().
 			MakeSessionWithID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 			DoAndReturn(func(_ context.Context, id string, _ *auth.Identity, _ bool, _ []*vmcp.Backend) (vmcpsession.MultiSession, error) {
-				createdSess = sessionmocks.NewMockMultiSession(ctrl)
-				createdSess.EXPECT().ID().Return(id).AnyTimes()
-				createdSess.EXPECT().GetMetadata().Return(tokenHashMeta).AnyTimes()
-				createdSess.EXPECT().Tools().Return(tools).AnyTimes()
-				createdSess.EXPECT().Type().Return(transportsession.SessionType("")).AnyTimes()
-				createdSess.EXPECT().CreatedAt().Return(time.Time{}).AnyTimes()
-				createdSess.EXPECT().UpdatedAt().Return(time.Time{}).AnyTimes()
-				createdSess.EXPECT().GetData().Return(nil).AnyTimes()
-				createdSess.EXPECT().SetData(gomock.Any()).AnyTimes()
-				createdSess.EXPECT().SetMetadata(gomock.Any(), gomock.Any()).AnyTimes()
-				createdSess.EXPECT().BackendSessions().Return(nil).AnyTimes()
-				createdSess.EXPECT().GetRoutingTable().Return(nil).AnyTimes()
-				createdSess.EXPECT().Prompts().Return(nil).AnyTimes()
-				// Close() is called by onEvict when checkSession detects the session
-				// is gone from storage on the next GetMultiSession call.
+				createdSess = newMockSession(t, ctrl, id, tools)
+				// Close() is called eagerly by onEvict when Terminate removes
+				// the entry from the node-local cache after storage.Delete.
 				createdSess.EXPECT().Close().Return(nil).Times(1)
 				return createdSess, nil
 			}).Times(1)
 
 		registry := newFakeRegistry()
-		sm, _ := newTestSessionManager(t, factory, registry)
+		sm, storage := newTestSessionManager(t, factory, registry)
 
 		sessionID := sm.Generate()
 		require.NotEmpty(t, sessionID)
 
-		// Upgrade to full MultiSession; CreateSession writes tokenHashMeta to storage.
 		_, err := sm.CreateSession(context.Background(), sessionID)
 		require.NoError(t, err)
 		require.NotNil(t, createdSess)
 
-		// Terminate deletes from storage; cache entry remains until next Get.
+		// Seed MetadataKeyTokenHash so Terminate takes Phase 2 (storage.Delete + cache Remove).
+		require.NoError(t, storage.Upsert(context.Background(), sessionID, tokenHashMeta))
+
+		// Terminate deletes from storage and removes from cache; onEvict fires Close().
 		isNotAllowed, err := sm.Terminate(sessionID)
 		require.NoError(t, err)
 		assert.False(t, isNotAllowed)
@@ -1937,12 +1927,18 @@ func TestSessionManager_DecorateSession(t *testing.T) {
 				return sess, nil
 			}).Times(1)
 
-		sm, _ := newTestSessionManager(t, factory, newFakeRegistry())
+		sm, storage := newTestSessionManager(t, factory, newFakeRegistry())
 
 		sessionID := sm.Generate()
 		require.NotEmpty(t, sessionID)
 		_, err := sm.CreateSession(context.Background(), sessionID)
 		require.NoError(t, err)
+
+		// Seed MetadataKeyTokenHash into storage so Terminate recognises this
+		// as a Phase 2 (full MultiSession) and deletes rather than marks terminated.
+		require.NoError(t, storage.Upsert(context.Background(), sessionID, map[string]string{
+			sessiontypes.MetadataKeyTokenHash: "",
+		}))
 
 		err = sm.DecorateSession(sessionID, func(sess sessiontypes.MultiSession) sessiontypes.MultiSession {
 			// Simulate concurrent Terminate() completing during decoration.
@@ -2082,7 +2078,7 @@ func TestSessionManager_CheckSession(t *testing.T) {
 		sm.sessions.Set(sessionID, cached)
 
 		err := sm.checkSession(sessionID, cached)
-		assert.NoError(t, err, "matching empty metadata must not cause eviction")
+		assert.NoError(t, err, "absent MetadataKeyBackendIDs in cache must not cause eviction")
 	})
 }
 

--- a/pkg/vmcp/server/sessionmanager/session_manager_test.go
+++ b/pkg/vmcp/server/sessionmanager/session_manager_test.go
@@ -611,7 +611,7 @@ func TestSessionManager_Terminate(t *testing.T) {
 			}).Times(1)
 
 		registry := newFakeRegistry()
-		sm, storage := newTestSessionManager(t, factory, registry)
+		sm, _ := newTestSessionManager(t, factory, registry)
 
 		sessionID := sm.Generate()
 		require.NotEmpty(t, sessionID)
@@ -620,10 +620,12 @@ func TestSessionManager_Terminate(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, createdSess)
 
-		// Seed MetadataKeyTokenHash so Terminate takes Phase 2 (storage.Delete + cache Remove).
-		require.NoError(t, storage.Upsert(context.Background(), sessionID, tokenHashMeta))
+		// CreateSession already persists tokenHashMeta via sess.GetMetadata(),
+		// so Terminate will take the Phase 2 path (storage.Delete) without
+		// any additional seeding.
 
-		// Terminate deletes from storage and removes from cache; onEvict fires Close().
+		// Terminate deletes from storage; the cache entry is evicted lazily on
+		// the next GetMultiSession call when checkSession detects ErrSessionNotFound.
 		isNotAllowed, err := sm.Terminate(sessionID)
 		require.NoError(t, err)
 		assert.False(t, isNotAllowed)

--- a/pkg/vmcp/session/connector_integration_test.go
+++ b/pkg/vmcp/session/connector_integration_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 
 	"github.com/google/uuid"
@@ -464,4 +465,84 @@ func TestTokenBinding_MetadataEncoding(t *testing.T) {
 	saltBytes, err := hex.DecodeString(tokenSalt)
 	require.NoError(t, err, "token salt must be valid hex")
 	assert.Len(t, saltBytes, 16, "decoded token salt must be 16 bytes")
+}
+
+// startInProcessMCPServerWithHeaderCapture starts an in-process MCP server and
+// returns the base URL along with a function that returns all Mcp-Session-Id
+// header values received by the server from clients.
+func startInProcessMCPServerWithHeaderCapture(t *testing.T) (string, func() []string) {
+	t.Helper()
+
+	mcpSrv := mcpserver.NewMCPServer("integration-test-backend", "1.0.0")
+	mcpSrv.AddTool(
+		mcpmcp.NewTool("echo", mcpmcp.WithDescription("echo"), mcpmcp.WithString("input", mcpmcp.Required())),
+		func(_ context.Context, req mcpmcp.CallToolRequest) (*mcpmcp.CallToolResult, error) {
+			args, _ := req.Params.Arguments.(map[string]any)
+			input, _ := args["input"].(string)
+			return &mcpmcp.CallToolResult{Content: []mcpmcp.Content{mcpmcp.NewTextContent(input)}}, nil
+		},
+	)
+
+	streamableSrv := mcpserver.NewStreamableHTTPServer(mcpSrv)
+
+	var mu sync.Mutex
+	var capturedIDs []string
+
+	mux := http.NewServeMux()
+	mux.Handle("/mcp", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if id := r.Header.Get("Mcp-Session-Id"); id != "" {
+			mu.Lock()
+			capturedIDs = append(capturedIDs, id)
+			mu.Unlock()
+		}
+		streamableSrv.ServeHTTP(w, r)
+	}))
+
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+
+	return ts.URL + "/mcp", func() []string {
+		mu.Lock()
+		defer mu.Unlock()
+		out := make([]string, len(capturedIDs))
+		copy(out, capturedIDs)
+		return out
+	}
+}
+
+// TestSessionFactory_Integration_RestoreSession_SendsStoredSessionHintToBackend
+// verifies that RestoreSession passes the stored backend session ID as the
+// Mcp-Session-Id hint in the Initialize request so the backend can resume
+// rather than create a new session.
+func TestSessionFactory_Integration_RestoreSession_SendsStoredSessionHintToBackend(t *testing.T) {
+	t.Parallel()
+
+	baseURL, capturedIDs := startInProcessMCPServerWithHeaderCapture(t)
+	backend := &vmcp.Backend{
+		ID:            "integration-backend",
+		Name:          "integration-backend",
+		BaseURL:       baseURL,
+		TransportType: "streamable-http",
+	}
+
+	factory := NewSessionFactory(newUnauthenticatedRegistry(t))
+
+	// Create the original session — the backend assigns a session ID over
+	// streamable-HTTP and we store it in metadata.
+	orig, err := factory.MakeSessionWithID(context.Background(), uuid.New().String(), nil, true, []*vmcp.Backend{backend})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = orig.Close() })
+
+	storedMeta := orig.GetMetadata()
+	storedBackendSessionID := storedMeta[MetadataKeyBackendSessionPrefix+"integration-backend"]
+	require.NotEmpty(t, storedBackendSessionID, "streamable-HTTP backend must assign a session ID on Initialize")
+
+	// RestoreSession: the factory must send the stored session ID as Mcp-Session-Id.
+	restored, err := factory.RestoreSession(context.Background(), uuid.New().String(), storedMeta, []*vmcp.Backend{backend})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = restored.Close() })
+
+	// The server must have received the stored ID as a hint in the Initialize request.
+	assert.Contains(t, capturedIDs(), storedBackendSessionID,
+		"RestoreSession must send the stored backend session ID as Mcp-Session-Id hint")
 }

--- a/pkg/vmcp/session/default_session_test.go
+++ b/pkg/vmcp/session/default_session_test.go
@@ -537,7 +537,7 @@ func TestNewSessionFactory_MakeSession(t *testing.T) {
 	}
 
 	//nolint:unparam // second return is always nil by design in the success-path connector
-	successConnector := func(_ context.Context, _ *vmcp.BackendTarget, _ *auth.Identity) (internalbk.Session, *vmcp.CapabilityList, error) {
+	successConnector := func(_ context.Context, _ *vmcp.BackendTarget, _ *auth.Identity, _ string) (internalbk.Session, *vmcp.CapabilityList, error) {
 		return &mockConnectedBackend{sessID: "bs-1"}, &vmcp.CapabilityList{
 			Tools:     []vmcp.Tool{tool},
 			Resources: []vmcp.Resource{resource},
@@ -616,7 +616,7 @@ func TestNewSessionFactory_PartialInitialisation(t *testing.T) {
 		{ID: "fail", Name: "fail", BaseURL: "http://fail:9999", TransportType: "streamable-http"},
 	}
 
-	connector := func(_ context.Context, target *vmcp.BackendTarget, _ *auth.Identity) (internalbk.Session, *vmcp.CapabilityList, error) {
+	connector := func(_ context.Context, target *vmcp.BackendTarget, _ *auth.Identity, _ string) (internalbk.Session, *vmcp.CapabilityList, error) {
 		if target.WorkloadID == "fail" {
 			return nil, nil, errors.New("backend unavailable")
 		}
@@ -650,20 +650,20 @@ func TestNewSessionFactory_ConnectorReturnsNilWithoutError(t *testing.T) {
 	}{
 		{
 			name: "nil conn with nil caps",
-			connector: func(_ context.Context, _ *vmcp.BackendTarget, _ *auth.Identity) (internalbk.Session, *vmcp.CapabilityList, error) {
+			connector: func(_ context.Context, _ *vmcp.BackendTarget, _ *auth.Identity, _ string) (internalbk.Session, *vmcp.CapabilityList, error) {
 				return nil, nil, nil
 			},
 		},
 		{
 			name: "nil conn with non-nil caps",
-			connector: func(_ context.Context, _ *vmcp.BackendTarget, _ *auth.Identity) (internalbk.Session, *vmcp.CapabilityList, error) {
+			connector: func(_ context.Context, _ *vmcp.BackendTarget, _ *auth.Identity, _ string) (internalbk.Session, *vmcp.CapabilityList, error) {
 				return nil, &vmcp.CapabilityList{}, nil
 			},
 		},
 		{
 			name:          "non-nil conn with nil caps must close conn to avoid leak",
 			wantConnClose: true,
-			connector: func(_ context.Context, _ *vmcp.BackendTarget, _ *auth.Identity) (internalbk.Session, *vmcp.CapabilityList, error) {
+			connector: func(_ context.Context, _ *vmcp.BackendTarget, _ *auth.Identity, _ string) (internalbk.Session, *vmcp.CapabilityList, error) {
 				return &mockConnectedBackend{}, nil, nil
 			},
 		},
@@ -676,8 +676,8 @@ func TestNewSessionFactory_ConnectorReturnsNilWithoutError(t *testing.T) {
 			// Replace the connector with one that captures the mock so we can
 			// inspect closeCalled after MakeSession returns.
 			var captured *mockConnectedBackend
-			wrappedConnector := func(ctx context.Context, target *vmcp.BackendTarget, id *auth.Identity) (internalbk.Session, *vmcp.CapabilityList, error) {
-				conn, caps, err := tt.connector(ctx, target, id)
+			wrappedConnector := func(ctx context.Context, target *vmcp.BackendTarget, id *auth.Identity, hint string) (internalbk.Session, *vmcp.CapabilityList, error) {
+				conn, caps, err := tt.connector(ctx, target, id, hint)
 				if m, ok := conn.(*mockConnectedBackend); ok {
 					captured = m
 				}
@@ -707,7 +707,7 @@ func TestNewSessionFactory_ConnectorReturnsConnWithError(t *testing.T) {
 	backend := &vmcp.Backend{ID: "b1", Name: "b1", BaseURL: "http://x:9", TransportType: "streamable-http"}
 	leaked := &mockConnectedBackend{}
 
-	connector := func(_ context.Context, _ *vmcp.BackendTarget, _ *auth.Identity) (internalbk.Session, *vmcp.CapabilityList, error) {
+	connector := func(_ context.Context, _ *vmcp.BackendTarget, _ *auth.Identity, _ string) (internalbk.Session, *vmcp.CapabilityList, error) {
 		return leaked, nil, errors.New("init failed but conn was partially opened")
 	}
 
@@ -732,7 +732,7 @@ func TestNewSessionFactory_CapabilityNameConflictIsResolvedDeterministically(t *
 		{ID: "alpha", Name: "alpha", BaseURL: "http://alpha:9", TransportType: "streamable-http"},
 	}
 
-	connector := func(_ context.Context, target *vmcp.BackendTarget, _ *auth.Identity) (internalbk.Session, *vmcp.CapabilityList, error) {
+	connector := func(_ context.Context, target *vmcp.BackendTarget, _ *auth.Identity, _ string) (internalbk.Session, *vmcp.CapabilityList, error) {
 		return &mockConnectedBackend{sessID: target.WorkloadID}, &vmcp.CapabilityList{
 			Tools:     []vmcp.Tool{{Name: "fetch", BackendID: target.WorkloadID}},
 			Resources: []vmcp.Resource{{URI: "file://data", BackendID: target.WorkloadID}},
@@ -766,7 +766,7 @@ func TestNewSessionFactory_AllBackendsFail(t *testing.T) {
 	t.Parallel()
 
 	backend := &vmcp.Backend{ID: "b1", Name: "b1", BaseURL: "http://x:9", TransportType: "streamable-http"}
-	connector := func(_ context.Context, _ *vmcp.BackendTarget, _ *auth.Identity) (internalbk.Session, *vmcp.CapabilityList, error) {
+	connector := func(_ context.Context, _ *vmcp.BackendTarget, _ *auth.Identity, _ string) (internalbk.Session, *vmcp.CapabilityList, error) {
 		return nil, nil, errors.New("down")
 	}
 
@@ -785,7 +785,7 @@ func TestNewSessionFactory_BackendInitTimeout(t *testing.T) {
 	backend := &vmcp.Backend{ID: "slow", Name: "slow", BaseURL: "http://x:9", TransportType: "streamable-http"}
 
 	released := make(chan struct{})
-	connector := func(ctx context.Context, _ *vmcp.BackendTarget, _ *auth.Identity) (internalbk.Session, *vmcp.CapabilityList, error) {
+	connector := func(ctx context.Context, _ *vmcp.BackendTarget, _ *auth.Identity, _ string) (internalbk.Session, *vmcp.CapabilityList, error) {
 		select {
 		case <-ctx.Done():
 			return nil, nil, ctx.Err()
@@ -823,7 +823,7 @@ func TestNewSessionFactory_ParallelInit(t *testing.T) {
 	var mu sync.Mutex
 	var maxConcurrent, current int32
 
-	connector := func(_ context.Context, target *vmcp.BackendTarget, _ *auth.Identity) (internalbk.Session, *vmcp.CapabilityList, error) {
+	connector := func(_ context.Context, target *vmcp.BackendTarget, _ *auth.Identity, _ string) (internalbk.Session, *vmcp.CapabilityList, error) {
 		mu.Lock()
 		current++
 		if current > maxConcurrent {
@@ -864,10 +864,10 @@ func TestNewSessionFactory_MakeSession_Metadata(t *testing.T) {
 	backend2 := &vmcp.Backend{ID: "b2", Name: "backend-2", BaseURL: "http://localhost:9002", TransportType: "streamable-http"}
 
 	//nolint:unparam // error return is always nil by design in the success-path connector
-	successConnector := func(_ context.Context, _ *vmcp.BackendTarget, _ *auth.Identity) (internalbk.Session, *vmcp.CapabilityList, error) {
+	successConnector := func(_ context.Context, _ *vmcp.BackendTarget, _ *auth.Identity, _ string) (internalbk.Session, *vmcp.CapabilityList, error) {
 		return &mockConnectedBackend{}, &vmcp.CapabilityList{}, nil
 	}
-	failConnector := func(_ context.Context, _ *vmcp.BackendTarget, _ *auth.Identity) (internalbk.Session, *vmcp.CapabilityList, error) {
+	failConnector := func(_ context.Context, _ *vmcp.BackendTarget, _ *auth.Identity, _ string) (internalbk.Session, *vmcp.CapabilityList, error) {
 		return nil, nil, errors.New("connection refused")
 	}
 
@@ -1132,7 +1132,7 @@ func TestValidateSessionID(t *testing.T) {
 func TestMakeSessionWithID_InvalidIDReturnsError(t *testing.T) {
 	t.Parallel()
 
-	f := newSessionFactoryWithConnector(func(_ context.Context, _ *vmcp.BackendTarget, _ *auth.Identity) (internalbk.Session, *vmcp.CapabilityList, error) {
+	f := newSessionFactoryWithConnector(func(_ context.Context, _ *vmcp.BackendTarget, _ *auth.Identity, _ string) (internalbk.Session, *vmcp.CapabilityList, error) {
 		return nil, nil, nil
 	})
 

--- a/pkg/vmcp/session/factory.go
+++ b/pkg/vmcp/session/factory.go
@@ -108,6 +108,11 @@ type MultiSessionFactory interface {
 //  2. Running the MCP Initialize handshake.
 //  3. Querying backend capabilities (tools, resources, prompts).
 //
+// sessionHint is the backend-assigned session ID from a prior connection (stored
+// in Redis metadata). When non-empty the connector should send it as the
+// Mcp-Session-Id hint during Initialize so the backend can resume rather than
+// re-initialize. Pass an empty string for brand-new sessions.
+//
 // The returned backend.Session owns the underlying transport connection and
 // must be closed when the session ends. The returned CapabilityList is used
 // to populate the session's routing table and capability lists.
@@ -118,6 +123,7 @@ type backendConnector func(
 	ctx context.Context,
 	target *vmcp.BackendTarget,
 	identity *auth.Identity,
+	sessionHint string,
 ) (backend.Session, *vmcp.CapabilityList, error)
 
 // defaultMultiSessionFactory is the production MultiSessionFactory implementation.
@@ -220,12 +226,13 @@ func (f *defaultMultiSessionFactory) initOneBackend(
 	ctx context.Context,
 	b *vmcp.Backend,
 	identity *auth.Identity,
+	sessionHint string,
 ) *initResult {
 	bCtx, cancel := context.WithTimeout(ctx, f.backendInitTimeout)
 	defer cancel()
 
 	target := vmcp.BackendToTarget(b)
-	conn, caps, err := f.connector(bCtx, target, identity)
+	conn, caps, err := f.connector(bCtx, target, identity, sessionHint)
 	if err != nil {
 		if conn != nil {
 			_ = conn.Close()
@@ -415,6 +422,7 @@ func (f *defaultMultiSessionFactory) makeBaseSession(
 	sessID string,
 	identity *auth.Identity,
 	backends []*vmcp.Backend,
+	sessionHints map[string]string,
 ) (*defaultMultiSession, error) {
 	filtered := make([]*vmcp.Backend, 0, len(backends))
 	for _, b := range backends {
@@ -435,7 +443,7 @@ func (f *defaultMultiSessionFactory) makeBaseSession(
 			defer wg.Done()
 			sem <- struct{}{}
 			defer func() { <-sem }()
-			rawResults[i] = f.initOneBackend(ctx, b, identity)
+			rawResults[i] = f.initOneBackend(ctx, b, identity, sessionHints[b.ID])
 		}(i, b)
 	}
 	wg.Wait()
@@ -507,7 +515,7 @@ func (f *defaultMultiSessionFactory) makeSession(
 	identity *auth.Identity,
 	backends []*vmcp.Backend,
 ) (MultiSession, error) {
-	baseSession, err := f.makeBaseSession(ctx, sessID, identity, backends)
+	baseSession, err := f.makeBaseSession(ctx, sessID, identity, backends, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -558,9 +566,18 @@ func (f *defaultMultiSessionFactory) RestoreSession(
 		identity.Subject = subject
 	}
 
+	// Extract stored per-backend session IDs as hints so each backend can
+	// resume its session (via Mcp-Session-Id) rather than starting a new one.
+	sessionHints := make(map[string]string, len(filteredBackends))
+	for _, b := range filteredBackends {
+		if hint := storedMetadata[MetadataKeyBackendSessionPrefix+b.ID]; hint != "" {
+			sessionHints[b.ID] = hint
+		}
+	}
+
 	// Build the base session (backend connections + routing table) without the
 	// security wrapper. The wrapper is applied separately using stored hash/salt.
-	baseSession, err := f.makeBaseSession(ctx, id, identity, filteredBackends)
+	baseSession, err := f.makeBaseSession(ctx, id, identity, filteredBackends, sessionHints)
 	if err != nil {
 		return nil, fmt.Errorf("RestoreSession: failed to rebuild backend connections: %w", err)
 	}

--- a/pkg/vmcp/session/factory_metadata_test.go
+++ b/pkg/vmcp/session/factory_metadata_test.go
@@ -6,6 +6,7 @@ package session
 import (
 	"context"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/google/uuid"
@@ -23,7 +24,7 @@ func TestMakeSession_PersistsBackendSessionIDs(t *testing.T) {
 	t.Run("two backends: both session IDs written to metadata", func(t *testing.T) {
 		t.Parallel()
 
-		connector := func(_ context.Context, target *vmcp.BackendTarget, _ *auth.Identity) (internalbk.Session, *vmcp.CapabilityList, error) {
+		connector := func(_ context.Context, target *vmcp.BackendTarget, _ *auth.Identity, _ string) (internalbk.Session, *vmcp.CapabilityList, error) {
 			ids := map[string]string{
 				"backend-a": "sess-a",
 				"backend-b": "sess-b",
@@ -71,7 +72,7 @@ func TestMakeSession_PersistsBackendSessionIDs(t *testing.T) {
 	t.Run("partial failure: only successful backend written", func(t *testing.T) {
 		t.Parallel()
 
-		connector := func(_ context.Context, target *vmcp.BackendTarget, _ *auth.Identity) (internalbk.Session, *vmcp.CapabilityList, error) {
+		connector := func(_ context.Context, target *vmcp.BackendTarget, _ *auth.Identity, _ string) (internalbk.Session, *vmcp.CapabilityList, error) {
 			if target.WorkloadID == "backend-ok" {
 				return &mockConnectedBackend{sessID: "sess-ok"}, &vmcp.CapabilityList{}, nil
 			}
@@ -102,7 +103,7 @@ func TestMakeSession_PersistsBackendSessionIDs(t *testing.T) {
 func TestRestoreSession_FreshlyPopulatesMetadataKeyBackendIDs(t *testing.T) {
 	t.Parallel()
 
-	connector := func(_ context.Context, target *vmcp.BackendTarget, _ *auth.Identity) (internalbk.Session, *vmcp.CapabilityList, error) {
+	connector := func(_ context.Context, target *vmcp.BackendTarget, _ *auth.Identity, _ string) (internalbk.Session, *vmcp.CapabilityList, error) {
 		ids := map[string]string{
 			"backend-a": "sess-a",
 			"backend-b": "sess-b",
@@ -165,4 +166,87 @@ func TestRestoreSession_AbsentMetadataKeyBackendIDsReturnsError(t *testing.T) {
 	require.Error(t, err, "absent MetadataKeyBackendIDs must return an error")
 	assert.Contains(t, err.Error(), MetadataKeyBackendIDs,
 		"error message must name the missing key")
+}
+
+// TestRestoreSession_PassesStoredSessionHintToConnector verifies that
+// RestoreSession reads the per-backend session IDs stored in metadata and
+// passes them as session hints to the backend connector, so backends can
+// resume rather than re-initialize their sessions.
+func TestRestoreSession_PassesStoredSessionHintToConnector(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	hintsReceived := map[string]string{}
+
+	// connector records the session hint it receives for each backend.
+	// It always returns a stable session ID so that the original session
+	// has predictable per-backend metadata to store.
+	connector := func(_ context.Context, target *vmcp.BackendTarget, _ *auth.Identity, sessionHint string) (internalbk.Session, *vmcp.CapabilityList, error) {
+		mu.Lock()
+		hintsReceived[target.WorkloadID] = sessionHint
+		mu.Unlock()
+		return &mockConnectedBackend{sessID: "orig-" + target.WorkloadID}, &vmcp.CapabilityList{}, nil
+	}
+
+	factory := newSessionFactoryWithConnector(connector)
+	backends := []*vmcp.Backend{
+		{ID: "backend-a"},
+		{ID: "backend-b"},
+	}
+
+	// Create the original session — connector receives empty hints.
+	original, err := factory.MakeSessionWithID(t.Context(), uuid.New().String(), nil, true, backends)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = original.Close() })
+
+	// Confirm original session stored per-backend session IDs in metadata.
+	storedMeta := original.GetMetadata()
+	storedHintA := storedMeta[MetadataKeyBackendSessionPrefix+"backend-a"]
+	storedHintB := storedMeta[MetadataKeyBackendSessionPrefix+"backend-b"]
+	require.NotEmpty(t, storedHintA, "original session must write backend-a session ID to metadata")
+	require.NotEmpty(t, storedHintB, "original session must write backend-b session ID to metadata")
+
+	// Reset captured hints before calling RestoreSession.
+	mu.Lock()
+	hintsReceived = map[string]string{}
+	mu.Unlock()
+
+	// RestoreSession must pass the stored session IDs as hints to the connector.
+	restored, err := factory.RestoreSession(t.Context(), uuid.New().String(), storedMeta, backends)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = restored.Close() })
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, storedHintA, hintsReceived["backend-a"],
+		"RestoreSession must pass stored backend-a session ID as hint to connector")
+	assert.Equal(t, storedHintB, hintsReceived["backend-b"],
+		"RestoreSession must pass stored backend-b session ID as hint to connector")
+}
+
+// TestMakeSession_PassesEmptySessionHintToConnector verifies that MakeSession
+// (creating a new session, not restoring) passes an empty hint so that the
+// backend always creates a fresh session.
+func TestMakeSession_PassesEmptySessionHintToConnector(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	hintsReceived := map[string]string{}
+
+	connector := func(_ context.Context, target *vmcp.BackendTarget, _ *auth.Identity, sessionHint string) (internalbk.Session, *vmcp.CapabilityList, error) {
+		mu.Lock()
+		hintsReceived[target.WorkloadID] = sessionHint
+		mu.Unlock()
+		return &mockConnectedBackend{sessID: "new-sess"}, &vmcp.CapabilityList{}, nil
+	}
+
+	factory := newSessionFactoryWithConnector(connector)
+	sess, err := factory.MakeSessionWithID(t.Context(), uuid.New().String(), nil, true, []*vmcp.Backend{{ID: "backend-a"}})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sess.Close() })
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Empty(t, hintsReceived["backend-a"],
+		"MakeSession must pass an empty session hint to the connector")
 }

--- a/pkg/vmcp/session/internal/backend/mcp_session.go
+++ b/pkg/vmcp/session/internal/backend/mcp_session.go
@@ -199,13 +199,15 @@ func NewHTTPConnector(registry vmcpauth.OutgoingAuthRegistry) func(
 	ctx context.Context,
 	target *vmcp.BackendTarget,
 	identity *auth.Identity,
+	sessionHint string,
 ) (Session, *vmcp.CapabilityList, error) {
 	return func(
 		ctx context.Context,
 		target *vmcp.BackendTarget,
 		identity *auth.Identity,
+		sessionHint string,
 	) (Session, *vmcp.CapabilityList, error) {
-		c, err := createMCPClient(target, identity, registry)
+		c, err := createMCPClient(target, identity, registry, sessionHint)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to create MCP client for backend %s: %w", target.WorkloadID, err)
 		}
@@ -233,10 +235,13 @@ func NewHTTPConnector(registry vmcpauth.OutgoingAuthRegistry) func(
 // createMCPClient builds and starts a mark3labs MCP client for target.
 // The transport is started with context.Background() so its lifetime is bound
 // to client.Close(), not to any caller-supplied init context.
+// sessionHint, when non-empty, is passed as the initial Mcp-Session-Id for
+// streamable-HTTP transports so the backend can resume an existing session.
 func createMCPClient(
 	target *vmcp.BackendTarget,
 	identity *auth.Identity,
 	registry vmcpauth.OutgoingAuthRegistry,
+	sessionHint string,
 ) (*mcpclient.Client, error) {
 	// Resolve and validate the auth strategy once at client creation time.
 	strategyName := authtypes.StrategyTypeUnauthenticated
@@ -294,11 +299,14 @@ func createMCPClient(
 			Transport: sizeLimited,
 			Timeout:   defaultBackendRequestTimeout,
 		}
-		c, err = mcpclient.NewStreamableHttpClient(
-			target.BaseURL,
+		streamableOpts := []mcptransport.StreamableHTTPCOption{
 			mcptransport.WithHTTPTimeout(defaultBackendRequestTimeout),
 			mcptransport.WithHTTPBasicClient(httpClient),
-		)
+		}
+		if sessionHint != "" {
+			streamableOpts = append(streamableOpts, mcptransport.WithSession(sessionHint))
+		}
+		c, err = mcpclient.NewStreamableHttpClient(target.BaseURL, streamableOpts...)
 	case "sse":
 		// For SSE, the entire session is delivered as one long-lived HTTP
 		// response body. Applying io.LimitReader to that body would silently

--- a/pkg/vmcp/session/internal/backend/mcp_session_test.go
+++ b/pkg/vmcp/session/internal/backend/mcp_session_test.go
@@ -40,7 +40,7 @@ func TestCreateMCPClient_UnsupportedTransport(t *testing.T) {
 				TransportType: transport,
 			}
 
-			_, err := createMCPClient(target, nil, newTestRegistry(t))
+			_, err := createMCPClient(target, nil, newTestRegistry(t), "")
 			require.Error(t, err)
 			assert.ErrorIs(t, err, vmcp.ErrUnsupportedTransport,
 				"transport %q should return ErrUnsupportedTransport", transport)

--- a/pkg/vmcp/session/token_binding_test.go
+++ b/pkg/vmcp/session/token_binding_test.go
@@ -26,7 +26,7 @@ import (
 // backend to be skipped during init. This lets us exercise session-metadata
 // logic without real backend connections.
 func nilBackendConnector() backendConnector {
-	return func(_ context.Context, _ *vmcp.BackendTarget, _ *auth.Identity) (internalbk.Session, *vmcp.CapabilityList, error) {
+	return func(_ context.Context, _ *vmcp.BackendTarget, _ *auth.Identity, _ string) (internalbk.Session, *vmcp.CapabilityList, error) {
 		return nil, nil, nil
 	}
 }

--- a/test/e2e/thv-operator/virtualmcp/helpers.go
+++ b/test/e2e/thv-operator/virtualmcp/helpers.go
@@ -34,6 +34,13 @@ import (
 	"github.com/stacklok/toolhive/test/e2e/thv-operator/testutil"
 )
 
+// Shared test constants used across all e2e test files in this package.
+const (
+	defaultNamespace = "default"
+	e2eTimeout       = 5 * time.Minute
+	e2ePollInterval  = 2 * time.Second
+)
+
 // WaitForVirtualMCPServerReady waits for a VirtualMCPServer to reach Ready status
 // and ensures at least one associated pod is actually running and ready.
 // This is used when waiting for a single expected pod (e.g., one replica deployment).
@@ -828,7 +835,7 @@ func GetVMCPNodePort(
 		}
 
 		// Verify the HTTP server is ready to handle requests
-		if err := checkHTTPHealthReady(nodePort, 2*time.Second); err != nil {
+		if err := checkHTTPHealthReady(nodePort); err != nil {
 			return fmt.Errorf("nodePort %d accessible but HTTP server not ready: %w", nodePort, err)
 		}
 
@@ -847,25 +854,21 @@ func checkPortAccessible(nodePort int32, timeout time.Duration) error {
 	if err != nil {
 		return fmt.Errorf("port %d not accessible: %w", nodePort, err)
 	}
-	// Port is accessible - close connection (ignore errors as port accessibility is confirmed)
 	_ = conn.Close()
 	return nil
 }
 
 // checkHTTPHealthReady verifies the HTTP server is ready by checking the /health endpoint.
 // This is more reliable than just TCP check as it ensures the application is serving requests.
-func checkHTTPHealthReady(nodePort int32, timeout time.Duration) error {
-	httpClient := &http.Client{Timeout: timeout}
+func checkHTTPHealthReady(nodePort int32) error {
+	httpClient := &http.Client{Timeout: 2 * time.Second}
 	url := fmt.Sprintf("http://localhost:%d/health", nodePort)
 
 	resp, err := httpClient.Get(url)
 	if err != nil {
 		return fmt.Errorf("health check failed for port %d: %w", nodePort, err)
 	}
-	defer func() {
-		// Error ignored in test cleanup
-		_ = resp.Body.Close()
-	}()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("health check returned status %d for port %d", resp.StatusCode, nodePort)

--- a/test/e2e/thv-operator/virtualmcp/mcpserver_scaling_test.go
+++ b/test/e2e/thv-operator/virtualmcp/mcpserver_scaling_test.go
@@ -26,17 +26,23 @@ import (
 
 	mcpv1alpha1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1alpha1"
 	"github.com/stacklok/toolhive/test/e2e/images"
+	"github.com/stacklok/toolhive/test/e2e/thv-operator/testutil"
+)
+
+const (
+	proxyPort = int32(8080) // MCPServer proxy container port
+	vmcpPort  = int32(4483) // VirtualMCPServer container port
 )
 
 // deployRedis creates a single-replica Redis Deployment and ClusterIP Service.
 // Returns after the deployment has at least one ready replica.
-func deployRedis(namespace, name string, timeout, pollInterval time.Duration) {
+func deployRedis(name string) {
 	labels := map[string]string{"app": name}
 
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: namespace,
+			Namespace: defaultNamespace,
 			Labels:    labels,
 		},
 		Spec: appsv1.DeploymentSpec{
@@ -68,7 +74,7 @@ func deployRedis(namespace, name string, timeout, pollInterval time.Duration) {
 	service := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: namespace,
+			Namespace: defaultNamespace,
 		},
 		Spec: corev1.ServiceSpec{
 			Selector: labels,
@@ -85,20 +91,20 @@ func deployRedis(namespace, name string, timeout, pollInterval time.Duration) {
 	ginkgo.By("Waiting for Redis to become ready")
 	gomega.Eventually(func() bool {
 		dep := &appsv1.Deployment{}
-		if err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, dep); err != nil {
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: defaultNamespace}, dep); err != nil {
 			return false
 		}
 		return dep.Status.ReadyReplicas > 0
-	}, timeout, pollInterval).Should(gomega.BeTrue(), "Redis should be ready")
+	}, e2eTimeout, e2ePollInterval).Should(gomega.BeTrue(), "Redis should be ready")
 }
 
 // cleanupRedis removes the Redis Deployment and Service.
-func cleanupRedis(namespace, name string) {
+func cleanupRedis(name string) {
 	_ = k8sClient.Delete(ctx, &appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: defaultNamespace},
 	})
 	_ = k8sClient.Delete(ctx, &corev1.Service{
-		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: defaultNamespace},
 	})
 }
 
@@ -130,23 +136,10 @@ func getReadyMCPServerPods(mcpServerName, namespace string) ([]corev1.Pod, error
 	return ready, nil
 }
 
-// waitForMCPServerRunning waits for an MCPServer to reach Running phase.
-func waitForMCPServerRunning(name, namespace string, timeout, pollInterval time.Duration) {
-	gomega.Eventually(func() error {
-		server := &mcpv1alpha1.MCPServer{}
-		if err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, server); err != nil {
-			return err
-		}
-		if server.Status.Phase != mcpv1alpha1.MCPServerPhaseReady {
-			return fmt.Errorf("MCPServer phase is %s, want Ready", server.Status.Phase)
-		}
-		return nil
-	}, timeout, pollInterval).Should(gomega.Succeed())
-}
-
-// portForwardToPod starts a kubectl port-forward to a specific pod and returns the
-// local port and a cleanup function. The caller must call cleanup to stop the port-forward.
-func portForwardToPod(podName string) (int, func(), error) {
+// portForwardToPod starts a kubectl port-forward to a specific pod's containerPort and
+// returns the local port and a cleanup function. The caller must call cleanup to stop
+// the port-forward.
+func portForwardToPod(podName string, containerPort int32) (int, func(), error) {
 	// Find a free local port
 	listener, err := net.Listen("tcp", ":0")
 	if err != nil {
@@ -159,9 +152,9 @@ func portForwardToPod(podName string) (int, func(), error) {
 	kubeconfigArg := fmt.Sprintf("--kubeconfig=%s", kubeconfig)
 	//nolint:gosec // kubeconfig, podName, and ports are test-controlled values
 	cmd := exec.Command("kubectl", kubeconfigArg,
-		"-n", "default", "port-forward",
+		"-n", defaultNamespace, "port-forward",
 		fmt.Sprintf("pod/%s", podName),
-		fmt.Sprintf("%d:%d", localPort, 8080))
+		fmt.Sprintf("%d:%d", localPort, containerPort))
 	if err := cmd.Start(); err != nil {
 		return 0, nil, fmt.Errorf("failed to start port-forward to %s: %w", podName, err)
 	}
@@ -188,12 +181,6 @@ func portForwardToPod(podName string) (int, func(), error) {
 }
 
 var _ = ginkgo.Describe("MCPServer Cross-Replica Session Routing with Redis", func() {
-	const (
-		timeout          = time.Minute * 5
-		pollInterval     = time.Second * 2
-		defaultNamespace = "default"
-		proxyPort        = int32(8080)
-	)
 
 	ginkgo.Context("When MCPServer has replicas=2 and backendReplicas=2", ginkgo.Ordered, func() {
 		var (
@@ -207,7 +194,7 @@ var _ = ginkgo.Describe("MCPServer Cross-Replica Session Routing with Redis", fu
 			redisName = fmt.Sprintf("e2e-redis-be-%d", ts)
 
 			ginkgo.By("Deploying Redis for session storage")
-			deployRedis(defaultNamespace, redisName, timeout, pollInterval)
+			deployRedis(redisName)
 
 			replicas := int32(2)
 			backendReplicas := int32(2)
@@ -232,7 +219,7 @@ var _ = ginkgo.Describe("MCPServer Cross-Replica Session Routing with Redis", fu
 			})).To(gomega.Succeed())
 
 			ginkgo.By("Waiting for MCPServer to be Running")
-			waitForMCPServerRunning(mcpServerName, defaultNamespace, timeout, pollInterval)
+			testutil.WaitForMCPServerRunning(ctx, k8sClient, mcpServerName, defaultNamespace, e2eTimeout, e2ePollInterval)
 
 			ginkgo.By("Waiting for 2 ready proxy runner pods")
 			gomega.Eventually(func() (int, error) {
@@ -241,19 +228,19 @@ var _ = ginkgo.Describe("MCPServer Cross-Replica Session Routing with Redis", fu
 					return 0, err
 				}
 				return len(pods), nil
-			}, timeout, pollInterval).Should(gomega.Equal(2))
+			}, e2eTimeout, e2ePollInterval).Should(gomega.Equal(2))
 		})
 
 		ginkgo.AfterAll(func() {
 			_ = k8sClient.Delete(ctx, &mcpv1alpha1.MCPServer{
 				ObjectMeta: metav1.ObjectMeta{Name: mcpServerName, Namespace: defaultNamespace},
 			})
-			cleanupRedis(defaultNamespace, redisName)
+			cleanupRedis(redisName)
 
 			gomega.Eventually(func() bool {
 				err := k8sClient.Get(ctx, types.NamespacedName{Name: mcpServerName, Namespace: defaultNamespace}, &mcpv1alpha1.MCPServer{})
 				return apierrors.IsNotFound(err)
-			}, timeout, pollInterval).Should(gomega.BeTrue())
+			}, e2eTimeout, e2ePollInterval).Should(gomega.BeTrue())
 		})
 
 		ginkgo.It("Should route session from proxy A to proxy B via Redis-shared state", func() {
@@ -266,7 +253,7 @@ var _ = ginkgo.Describe("MCPServer Cross-Replica Session Routing with Redis", fu
 					return 0, err
 				}
 				return len(pods), nil
-			}, timeout, pollInterval).Should(gomega.Equal(2))
+			}, e2eTimeout, e2ePollInterval).Should(gomega.Equal(2))
 
 			podA := pods[0]
 			podB := pods[1]
@@ -274,12 +261,12 @@ var _ = ginkgo.Describe("MCPServer Cross-Replica Session Routing with Redis", fu
 				"The two proxy pods must be distinct")
 
 			ginkgo.By(fmt.Sprintf("Setting up port-forward to proxy A (%s)", podA.Name))
-			localPortA, cleanupA, err := portForwardToPod(podA.Name)
+			localPortA, cleanupA, err := portForwardToPod(podA.Name, proxyPort)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			defer cleanupA()
 
 			ginkgo.By(fmt.Sprintf("Setting up port-forward to proxy B (%s)", podB.Name))
-			localPortB, cleanupB, err := portForwardToPod(podB.Name)
+			localPortB, cleanupB, err := portForwardToPod(podB.Name, proxyPort)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			defer cleanupB()
 
@@ -337,7 +324,7 @@ var _ = ginkgo.Describe("MCPServer Cross-Replica Session Routing with Redis", fu
 			redisName = fmt.Sprintf("e2e-redis-%d", ts)
 
 			ginkgo.By("Deploying Redis for session storage")
-			deployRedis(defaultNamespace, redisName, timeout, pollInterval)
+			deployRedis(redisName)
 
 			replicas := int32(2)
 			redisAddr := fmt.Sprintf("%s.%s.svc.cluster.local:6379", redisName, defaultNamespace)
@@ -360,7 +347,7 @@ var _ = ginkgo.Describe("MCPServer Cross-Replica Session Routing with Redis", fu
 			})).To(gomega.Succeed())
 
 			ginkgo.By("Waiting for MCPServer to be Running")
-			waitForMCPServerRunning(mcpServerName, defaultNamespace, timeout, pollInterval)
+			testutil.WaitForMCPServerRunning(ctx, k8sClient, mcpServerName, defaultNamespace, e2eTimeout, e2ePollInterval)
 
 			ginkgo.By("Waiting for 2 ready pods")
 			gomega.Eventually(func() (int, error) {
@@ -369,19 +356,19 @@ var _ = ginkgo.Describe("MCPServer Cross-Replica Session Routing with Redis", fu
 					return 0, err
 				}
 				return len(pods), nil
-			}, timeout, pollInterval).Should(gomega.Equal(2))
+			}, e2eTimeout, e2ePollInterval).Should(gomega.Equal(2))
 		})
 
 		ginkgo.AfterAll(func() {
 			_ = k8sClient.Delete(ctx, &mcpv1alpha1.MCPServer{
 				ObjectMeta: metav1.ObjectMeta{Name: mcpServerName, Namespace: defaultNamespace},
 			})
-			cleanupRedis(defaultNamespace, redisName)
+			cleanupRedis(redisName)
 
 			gomega.Eventually(func() bool {
 				err := k8sClient.Get(ctx, types.NamespacedName{Name: mcpServerName, Namespace: defaultNamespace}, &mcpv1alpha1.MCPServer{})
 				return apierrors.IsNotFound(err)
-			}, timeout, pollInterval).Should(gomega.BeTrue())
+			}, e2eTimeout, e2ePollInterval).Should(gomega.BeTrue())
 		})
 
 		ginkgo.It("Should have SessionStorageWarning=False since Redis is configured", func() {
@@ -400,7 +387,7 @@ var _ = ginkgo.Describe("MCPServer Cross-Replica Session Routing with Redis", fu
 					}
 				}
 				return fmt.Errorf("SessionStorageWarning condition not found")
-			}, timeout, pollInterval).Should(gomega.Succeed())
+			}, e2eTimeout, e2ePollInterval).Should(gomega.Succeed())
 		})
 
 		ginkgo.It("Should allow a session established on pod A to be used on pod B", func() {
@@ -413,7 +400,7 @@ var _ = ginkgo.Describe("MCPServer Cross-Replica Session Routing with Redis", fu
 					return 0, err
 				}
 				return len(pods), nil
-			}, timeout, pollInterval).Should(gomega.Equal(2))
+			}, e2eTimeout, e2ePollInterval).Should(gomega.Equal(2))
 
 			podA := pods[0]
 			podB := pods[1]
@@ -421,12 +408,12 @@ var _ = ginkgo.Describe("MCPServer Cross-Replica Session Routing with Redis", fu
 				"The two pods must be distinct")
 
 			ginkgo.By(fmt.Sprintf("Setting up port-forward to pod A (%s)", podA.Name))
-			localPortA, cleanupA, err := portForwardToPod(podA.Name)
+			localPortA, cleanupA, err := portForwardToPod(podA.Name, proxyPort)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			defer cleanupA()
 
 			ginkgo.By(fmt.Sprintf("Setting up port-forward to pod B (%s)", podB.Name))
-			localPortB, cleanupB, err := portForwardToPod(podB.Name)
+			localPortB, cleanupB, err := portForwardToPod(podB.Name, proxyPort)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			defer cleanupB()
 

--- a/test/e2e/thv-operator/virtualmcp/mcpserver_scaling_test.go
+++ b/test/e2e/thv-operator/virtualmcp/mcpserver_scaling_test.go
@@ -146,9 +146,7 @@ func waitForMCPServerRunning(name, namespace string, timeout, pollInterval time.
 
 // portForwardToPod starts a kubectl port-forward to a specific pod and returns the
 // local port and a cleanup function. The caller must call cleanup to stop the port-forward.
-//
-//nolint:unparam // namespace kept as parameter for reusability across test contexts
-func portForwardToPod(podName, namespace string, targetPort int32) (int, func(), error) {
+func portForwardToPod(podName string) (int, func(), error) {
 	// Find a free local port
 	listener, err := net.Listen("tcp", ":0")
 	if err != nil {
@@ -159,11 +157,11 @@ func portForwardToPod(podName, namespace string, targetPort int32) (int, func(),
 	_ = listener.Close()
 
 	kubeconfigArg := fmt.Sprintf("--kubeconfig=%s", kubeconfig)
-	//nolint:gosec // kubeconfig, namespace, podName, and ports are test-controlled values
+	//nolint:gosec // kubeconfig, podName, and ports are test-controlled values
 	cmd := exec.Command("kubectl", kubeconfigArg,
-		"-n", namespace, "port-forward",
+		"-n", "default", "port-forward",
 		fmt.Sprintf("pod/%s", podName),
-		fmt.Sprintf("%d:%d", localPort, targetPort))
+		fmt.Sprintf("%d:%d", localPort, 8080))
 	if err := cmd.Start(); err != nil {
 		return 0, nil, fmt.Errorf("failed to start port-forward to %s: %w", podName, err)
 	}
@@ -276,12 +274,12 @@ var _ = ginkgo.Describe("MCPServer Cross-Replica Session Routing with Redis", fu
 				"The two proxy pods must be distinct")
 
 			ginkgo.By(fmt.Sprintf("Setting up port-forward to proxy A (%s)", podA.Name))
-			localPortA, cleanupA, err := portForwardToPod(podA.Name, defaultNamespace, proxyPort)
+			localPortA, cleanupA, err := portForwardToPod(podA.Name)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			defer cleanupA()
 
 			ginkgo.By(fmt.Sprintf("Setting up port-forward to proxy B (%s)", podB.Name))
-			localPortB, cleanupB, err := portForwardToPod(podB.Name, defaultNamespace, proxyPort)
+			localPortB, cleanupB, err := portForwardToPod(podB.Name)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			defer cleanupB()
 
@@ -423,12 +421,12 @@ var _ = ginkgo.Describe("MCPServer Cross-Replica Session Routing with Redis", fu
 				"The two pods must be distinct")
 
 			ginkgo.By(fmt.Sprintf("Setting up port-forward to pod A (%s)", podA.Name))
-			localPortA, cleanupA, err := portForwardToPod(podA.Name, defaultNamespace, proxyPort)
+			localPortA, cleanupA, err := portForwardToPod(podA.Name)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			defer cleanupA()
 
 			ginkgo.By(fmt.Sprintf("Setting up port-forward to pod B (%s)", podB.Name))
-			localPortB, cleanupB, err := portForwardToPod(podB.Name, defaultNamespace, proxyPort)
+			localPortB, cleanupB, err := portForwardToPod(podB.Name)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			defer cleanupB()
 

--- a/test/e2e/thv-operator/virtualmcp/mcpserver_scaling_test.go
+++ b/test/e2e/thv-operator/virtualmcp/mcpserver_scaling_test.go
@@ -6,9 +6,11 @@ package virtualmcp
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net"
 	"os/exec"
+	"strings"
 	"time"
 
 	mcpclient "github.com/mark3labs/mcp-go/client"
@@ -16,6 +18,7 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
+	"github.com/redis/go-redis/v9"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -178,6 +181,64 @@ func portForwardToPod(podName string, containerPort int32) (int, func(), error) 
 
 	cleanup()
 	return 0, nil, fmt.Errorf("port-forward to %s never became ready on localhost:%d", podName, localPort)
+}
+
+// readRedisSessionBackendIDs port-forwards to the Redis pod with label app=redisName,
+// reads the session key keyPrefix+sessionID, and returns only the per-backend session
+// ID entries (keys prefixed with "vmcp.backend.session.").
+func readRedisSessionBackendIDs(redisName, keyPrefix, sessionID string) (map[string]string, error) {
+	// Find the Redis pod.
+	podList := &corev1.PodList{}
+	if err := k8sClient.List(ctx, podList,
+		client.InNamespace(defaultNamespace),
+		client.MatchingLabels{"app": redisName},
+	); err != nil {
+		return nil, fmt.Errorf("listing Redis pods: %w", err)
+	}
+	var redisPodName string
+	for _, pod := range podList.Items {
+		if pod.Status.Phase == corev1.PodRunning {
+			redisPodName = pod.Name
+			break
+		}
+	}
+	if redisPodName == "" {
+		return nil, fmt.Errorf("no running Redis pod found for app=%s", redisName)
+	}
+
+	// Port-forward to Redis.
+	localPort, cleanup, err := portForwardToPod(redisPodName, 6379)
+	if err != nil {
+		return nil, fmt.Errorf("port-forward to Redis pod %s: %w", redisPodName, err)
+	}
+	defer cleanup()
+
+	rdb := redis.NewClient(&redis.Options{
+		Addr: fmt.Sprintf("localhost:%d", localPort),
+	})
+	defer rdb.Close()
+
+	readCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	raw, err := rdb.Get(readCtx, keyPrefix+sessionID).Bytes()
+	if err != nil {
+		return nil, fmt.Errorf("Redis GET %s%s: %w", keyPrefix, sessionID, err)
+	}
+
+	var all map[string]string
+	if err := json.Unmarshal(raw, &all); err != nil {
+		return nil, fmt.Errorf("unmarshal session metadata: %w", err)
+	}
+
+	const backendSessionPrefix = "vmcp.backend.session."
+	result := make(map[string]string)
+	for k, v := range all {
+		if strings.HasPrefix(k, backendSessionPrefix) {
+			result[k] = v
+		}
+	}
+	return result, nil
 }
 
 var _ = ginkgo.Describe("MCPServer Cross-Replica Session Routing with Redis", func() {

--- a/test/e2e/thv-operator/virtualmcp/virtualmcp_redis_session_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcp_redis_session_test.go
@@ -291,6 +291,12 @@ var _ = ginkgo.Describe("VirtualMCPServer Redis-Backed Session Sharing", func() 
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			gomega.Expect(toolsA.Tools).NotTo(gomega.BeEmpty(), "pod A must return tools")
 
+			ginkgo.By("Verifying pod A stored backend session IDs in Redis")
+			backendIDsBeforeRestore, err := readRedisSessionBackendIDs(redisName, "thv:vmcp:e2e:", sessionID)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(backendIDsBeforeRestore).NotTo(gomega.BeEmpty(),
+				"pod A must have written per-backend session IDs to Redis so pod B can use them as hints")
+
 			ginkgo.By(fmt.Sprintf("Connecting to pod B (%s) with the same session ID", podB.Name))
 			serverURLB := fmt.Sprintf("http://localhost:%d/mcp", localPortB)
 			clientB, err := mcpclient.NewStreamableHttpClient(serverURLB, transport.WithSession(sessionID))
@@ -307,6 +313,13 @@ var _ = ginkgo.Describe("VirtualMCPServer Redis-Backed Session Sharing", func() 
 			toolsB, err := clientB.ListTools(listCtx, mcp.ListToolsRequest{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			gomega.Expect(toolsB.Tools).NotTo(gomega.BeEmpty(), "pod B must return tools via Redis-reconstructed session")
+
+			ginkgo.By("Verifying backend session IDs in Redis are the same hints pod B received")
+			backendIDsAfterRestore, err := readRedisSessionBackendIDs(redisName, "thv:vmcp:e2e:", sessionID)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(backendIDsAfterRestore).To(gomega.Equal(backendIDsBeforeRestore),
+				"RestoreSession must not overwrite the backend session IDs stored by pod A — "+
+					"pod B used them as hints and the IDs must be stable")
 
 			ginkgo.By("Verifying both pods return the same tool count")
 			gomega.Expect(toolsB.Tools).To(gomega.HaveLen(len(toolsA.Tools)),
@@ -655,8 +668,8 @@ var _ = ginkgo.Describe("VirtualMCPServer Redis-Backed Session Sharing", func() 
 			defer func() { _ = clientB.Close() }()
 
 			startCtx, startCancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer startCancel()
 			gomega.Expect(clientB.Start(startCtx)).To(gomega.Succeed())
-			startCancel()
 
 			listCtxB, listCancelB := context.WithTimeout(context.Background(), 30*time.Second)
 			toolsB, err := clientB.ListTools(listCtxB, mcp.ListToolsRequest{})

--- a/test/e2e/thv-operator/virtualmcp/virtualmcp_redis_session_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcp_redis_session_test.go
@@ -1,0 +1,315 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package virtualmcp contains e2e tests for VirtualMCPServer against a real Kubernetes cluster
+package virtualmcp
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	mcpclient "github.com/mark3labs/mcp-go/client"
+	"github.com/mark3labs/mcp-go/client/transport"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	mcpv1alpha1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1alpha1"
+	vmcpconfig "github.com/stacklok/toolhive/pkg/vmcp/config"
+	"github.com/stacklok/toolhive/test/e2e/images"
+)
+
+var _ = ginkgo.Describe("VirtualMCPServer Redis-Backed Session Sharing", func() {
+	const (
+		timeout          = time.Minute * 5
+		pollInterval     = time.Second * 2
+		defaultNamespace = "default"
+	)
+
+	// -------------------------------------------------------------------------
+	// Context 1: replicas=2 + Redis → SessionStorageWarning is False
+	// -------------------------------------------------------------------------
+
+	ginkgo.Context("When VirtualMCPServer has replicas=2 with Redis configured", ginkgo.Ordered, func() {
+		var (
+			mcpGroupName string
+			backendName  string
+			vmcpName     string
+			redisName    string
+		)
+
+		ginkgo.BeforeAll(func() {
+			ts := time.Now().UnixNano()
+			mcpGroupName = fmt.Sprintf("e2e-redis-group-%d", ts)
+			backendName = fmt.Sprintf("e2e-redis-backend-%d", ts)
+			vmcpName = fmt.Sprintf("e2e-redis-vmcp-%d", ts)
+			redisName = fmt.Sprintf("e2e-redis-%d", ts)
+
+			ginkgo.By("Deploying Redis")
+			deployRedis(defaultNamespace, redisName, timeout, pollInterval)
+
+			ginkgo.By("Creating MCPGroup")
+			CreateMCPGroupAndWait(ctx, k8sClient, mcpGroupName, defaultNamespace,
+				"E2E Redis session group", timeout, pollInterval)
+
+			ginkgo.By("Creating backend MCPServer")
+			gomega.Expect(k8sClient.Create(ctx, &mcpv1alpha1.MCPServer{
+				ObjectMeta: metav1.ObjectMeta{Name: backendName, Namespace: defaultNamespace},
+				Spec: mcpv1alpha1.MCPServerSpec{
+					GroupRef:  mcpGroupName,
+					Image:     images.YardstickServerImage,
+					Transport: "streamable-http",
+					ProxyPort: 8080,
+					McpPort:   8080,
+				},
+			})).To(gomega.Succeed())
+
+			ginkgo.By("Waiting for backend MCPServer to be ready")
+			gomega.Eventually(func() error {
+				server := &mcpv1alpha1.MCPServer{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      backendName,
+					Namespace: defaultNamespace,
+				}, server); err != nil {
+					return fmt.Errorf("failed to get MCPServer: %w", err)
+				}
+				if server.Status.Phase != mcpv1alpha1.MCPServerPhaseReady {
+					return fmt.Errorf("MCPServer not ready yet, phase: %s", server.Status.Phase)
+				}
+				return nil
+			}, timeout, pollInterval).Should(gomega.Succeed(), "backend MCPServer should be ready")
+
+			replicas := int32(2)
+			redisAddr := fmt.Sprintf("%s.%s.svc.cluster.local:6379", redisName, defaultNamespace)
+
+			ginkgo.By("Creating VirtualMCPServer with replicas=2 and Redis")
+			gomega.Expect(k8sClient.Create(ctx, &mcpv1alpha1.VirtualMCPServer{
+				ObjectMeta: metav1.ObjectMeta{Name: vmcpName, Namespace: defaultNamespace},
+				Spec: mcpv1alpha1.VirtualMCPServerSpec{
+					Config:          vmcpconfig.Config{Group: mcpGroupName},
+					IncomingAuth:    &mcpv1alpha1.IncomingAuthConfig{Type: "anonymous"},
+					Replicas:        &replicas,
+					SessionAffinity: "None",
+					SessionStorage: &mcpv1alpha1.SessionStorageConfig{
+						Provider:  mcpv1alpha1.SessionStorageProviderRedis,
+						Address:   redisAddr,
+						KeyPrefix: "thv:vmcp:e2e:",
+					},
+				},
+			})).To(gomega.Succeed())
+
+			ginkgo.By("Waiting for 2 ready pods")
+			gomega.Eventually(func() (int, error) {
+				return countReadyPods(vmcpName)
+			}, timeout, pollInterval).Should(gomega.Equal(2))
+
+			ginkgo.By("Waiting for VirtualMCPServer to report Ready")
+			WaitForVirtualMCPServerReady(ctx, k8sClient, vmcpName, defaultNamespace, timeout, pollInterval)
+		})
+
+		ginkgo.AfterAll(func() {
+			_ = k8sClient.Delete(ctx, &mcpv1alpha1.VirtualMCPServer{
+				ObjectMeta: metav1.ObjectMeta{Name: vmcpName, Namespace: defaultNamespace},
+			})
+			_ = k8sClient.Delete(ctx, &mcpv1alpha1.MCPServer{
+				ObjectMeta: metav1.ObjectMeta{Name: backendName, Namespace: defaultNamespace},
+			})
+			_ = k8sClient.Delete(ctx, &mcpv1alpha1.MCPGroup{
+				ObjectMeta: metav1.ObjectMeta{Name: mcpGroupName, Namespace: defaultNamespace},
+			})
+			cleanupRedis(defaultNamespace, redisName)
+			gomega.Eventually(func() bool {
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: vmcpName, Namespace: defaultNamespace}, &mcpv1alpha1.VirtualMCPServer{})
+				return apierrors.IsNotFound(err)
+			}, timeout, pollInterval).Should(gomega.BeTrue())
+		})
+
+		ginkgo.It("Should set SessionStorageWarning=False when Redis is configured", func() {
+			WaitForCondition(ctx, k8sClient, vmcpName, defaultNamespace,
+				mcpv1alpha1.ConditionSessionStorageWarning, "False",
+				timeout, pollInterval)
+		})
+
+		ginkgo.It("Should report Ready=True when Redis is configured", func() {
+			WaitForCondition(ctx, k8sClient, vmcpName, defaultNamespace,
+				mcpv1alpha1.ConditionTypeVirtualMCPServerReady, "True",
+				timeout, pollInterval)
+		})
+	})
+
+	// -------------------------------------------------------------------------
+	// Context 2: cross-pod session reconstruction with Redis
+	// -------------------------------------------------------------------------
+
+	ginkgo.Context("When cross-pod session reconstruction with Redis", ginkgo.Ordered, func() {
+		var (
+			mcpGroupName string
+			backendName  string
+			vmcpName     string
+			redisName    string
+		)
+
+		ginkgo.BeforeAll(func() {
+			ts := time.Now().UnixNano()
+			mcpGroupName = fmt.Sprintf("e2e-redis-xpod-group-%d", ts)
+			backendName = fmt.Sprintf("e2e-redis-xpod-backend-%d", ts)
+			vmcpName = fmt.Sprintf("e2e-redis-xpod-vmcp-%d", ts)
+			redisName = fmt.Sprintf("e2e-redis-xpod-%d", ts)
+
+			ginkgo.By("Deploying Redis")
+			deployRedis(defaultNamespace, redisName, timeout, pollInterval)
+
+			ginkgo.By("Creating MCPGroup")
+			CreateMCPGroupAndWait(ctx, k8sClient, mcpGroupName, defaultNamespace,
+				"E2E Redis cross-pod session group", timeout, pollInterval)
+
+			ginkgo.By("Creating backend MCPServer")
+			gomega.Expect(k8sClient.Create(ctx, &mcpv1alpha1.MCPServer{
+				ObjectMeta: metav1.ObjectMeta{Name: backendName, Namespace: defaultNamespace},
+				Spec: mcpv1alpha1.MCPServerSpec{
+					GroupRef:  mcpGroupName,
+					Image:     images.YardstickServerImage,
+					Transport: "streamable-http",
+					ProxyPort: 8080,
+					McpPort:   8080,
+				},
+			})).To(gomega.Succeed())
+
+			ginkgo.By("Waiting for backend MCPServer to be ready")
+			gomega.Eventually(func() error {
+				server := &mcpv1alpha1.MCPServer{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      backendName,
+					Namespace: defaultNamespace,
+				}, server); err != nil {
+					return fmt.Errorf("failed to get MCPServer: %w", err)
+				}
+				if server.Status.Phase != mcpv1alpha1.MCPServerPhaseReady {
+					return fmt.Errorf("MCPServer not ready yet, phase: %s", server.Status.Phase)
+				}
+				return nil
+			}, timeout, pollInterval).Should(gomega.Succeed(), "backend MCPServer should be ready")
+
+			replicas := int32(2)
+			redisAddr := fmt.Sprintf("%s.%s.svc.cluster.local:6379", redisName, defaultNamespace)
+
+			ginkgo.By("Creating VirtualMCPServer with replicas=2 and Redis")
+			gomega.Expect(k8sClient.Create(ctx, &mcpv1alpha1.VirtualMCPServer{
+				ObjectMeta: metav1.ObjectMeta{Name: vmcpName, Namespace: defaultNamespace},
+				Spec: mcpv1alpha1.VirtualMCPServerSpec{
+					Config:          vmcpconfig.Config{Group: mcpGroupName},
+					IncomingAuth:    &mcpv1alpha1.IncomingAuthConfig{Type: "anonymous"},
+					Replicas:        &replicas,
+					SessionAffinity: "None",
+					SessionStorage: &mcpv1alpha1.SessionStorageConfig{
+						Provider:  mcpv1alpha1.SessionStorageProviderRedis,
+						Address:   redisAddr,
+						KeyPrefix: "thv:vmcp:e2e:",
+					},
+				},
+			})).To(gomega.Succeed())
+
+			ginkgo.By("Waiting for 2 ready pods")
+			gomega.Eventually(func() (int, error) {
+				return countReadyPods(vmcpName)
+			}, timeout, pollInterval).Should(gomega.Equal(2))
+
+			ginkgo.By("Waiting for VirtualMCPServer to report Ready")
+			WaitForVirtualMCPServerReady(ctx, k8sClient, vmcpName, defaultNamespace, timeout, pollInterval)
+		})
+
+		ginkgo.AfterAll(func() {
+			_ = k8sClient.Delete(ctx, &mcpv1alpha1.VirtualMCPServer{
+				ObjectMeta: metav1.ObjectMeta{Name: vmcpName, Namespace: defaultNamespace},
+			})
+			_ = k8sClient.Delete(ctx, &mcpv1alpha1.MCPServer{
+				ObjectMeta: metav1.ObjectMeta{Name: backendName, Namespace: defaultNamespace},
+			})
+			_ = k8sClient.Delete(ctx, &mcpv1alpha1.MCPGroup{
+				ObjectMeta: metav1.ObjectMeta{Name: mcpGroupName, Namespace: defaultNamespace},
+			})
+			cleanupRedis(defaultNamespace, redisName)
+			gomega.Eventually(func() bool {
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: vmcpName, Namespace: defaultNamespace}, &mcpv1alpha1.VirtualMCPServer{})
+				return apierrors.IsNotFound(err)
+			}, timeout, pollInterval).Should(gomega.BeTrue())
+		})
+
+		ginkgo.It("Should allow a session established on pod A to be used on pod B", func() {
+			ginkgo.By("Getting the two ready pods")
+			var pods []corev1.Pod
+			gomega.Eventually(func() (int, error) {
+				podList, err := GetVirtualMCPServerPods(ctx, k8sClient, vmcpName, defaultNamespace)
+				if err != nil {
+					return 0, err
+				}
+				var ready []corev1.Pod
+				for _, pod := range podList.Items {
+					if pod.Status.Phase != corev1.PodRunning {
+						continue
+					}
+					for _, c := range pod.Status.Conditions {
+						if c.Type == corev1.PodReady && c.Status == corev1.ConditionTrue {
+							ready = append(ready, pod)
+						}
+					}
+				}
+				pods = ready
+				return len(ready), nil
+			}, timeout, pollInterval).Should(gomega.Equal(2))
+
+			podA := pods[0]
+			podB := pods[1]
+			gomega.Expect(podA.Name).NotTo(gomega.Equal(podB.Name), "The two pods must be distinct")
+
+			ginkgo.By(fmt.Sprintf("Port-forwarding to pod A (%s)", podA.Name))
+			localPortA, cleanupA, err := portForwardToPod(podA.Name)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			defer cleanupA()
+
+			ginkgo.By(fmt.Sprintf("Port-forwarding to pod B (%s)", podB.Name))
+			localPortB, cleanupB, err := portForwardToPod(podB.Name)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			defer cleanupB()
+
+			ginkgo.By("Initializing session on pod A")
+			clientA, err := CreateInitializedMCPClient(int32(localPortA), "e2e-redis-test", 30*time.Second)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			defer clientA.Close()
+
+			sessionID := clientA.Client.GetSessionId()
+			gomega.Expect(sessionID).NotTo(gomega.BeEmpty(), "session ID must be assigned after Initialize")
+
+			ginkgo.By("Listing tools on pod A")
+			toolsA, err := clientA.Client.ListTools(clientA.Ctx, mcp.ListToolsRequest{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(toolsA.Tools).NotTo(gomega.BeEmpty(), "pod A must return tools")
+
+			ginkgo.By(fmt.Sprintf("Connecting to pod B (%s) with the same session ID", podB.Name))
+			serverURLB := fmt.Sprintf("http://localhost:%d/mcp", localPortB)
+			clientB, err := mcpclient.NewStreamableHttpClient(serverURLB, transport.WithSession(sessionID))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			defer func() { _ = clientB.Close() }()
+
+			startCtx, startCancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer startCancel()
+			gomega.Expect(clientB.Start(startCtx)).To(gomega.Succeed())
+
+			ginkgo.By("Listing tools on pod B using the session from pod A")
+			listCtx, listCancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer listCancel()
+			toolsB, err := clientB.ListTools(listCtx, mcp.ListToolsRequest{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(toolsB.Tools).NotTo(gomega.BeEmpty(), "pod B must return tools via Redis-reconstructed session")
+
+			ginkgo.By("Verifying both pods return the same tool count")
+			gomega.Expect(toolsB.Tools).To(gomega.HaveLen(len(toolsA.Tools)),
+				"pod B must see same session state as pod A")
+		})
+	})
+})

--- a/test/e2e/thv-operator/virtualmcp/virtualmcp_redis_session_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcp_redis_session_test.go
@@ -6,7 +6,9 @@ package virtualmcp
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
 	"time"
 
 	mcpclient "github.com/mark3labs/mcp-go/client"
@@ -26,9 +28,8 @@ import (
 
 var _ = ginkgo.Describe("VirtualMCPServer Redis-Backed Session Sharing", func() {
 	const (
-		timeout          = time.Minute * 5
-		pollInterval     = time.Second * 2
-		defaultNamespace = "default"
+		timeout      = time.Minute * 5
+		pollInterval = time.Second * 2
 	)
 
 	// -------------------------------------------------------------------------
@@ -51,7 +52,7 @@ var _ = ginkgo.Describe("VirtualMCPServer Redis-Backed Session Sharing", func() 
 			redisName = fmt.Sprintf("e2e-redis-%d", ts)
 
 			ginkgo.By("Deploying Redis")
-			deployRedis(defaultNamespace, redisName, timeout, pollInterval)
+			deployRedis(redisName)
 
 			ginkgo.By("Creating MCPGroup")
 			CreateMCPGroupAndWait(ctx, k8sClient, mcpGroupName, defaultNamespace,
@@ -65,7 +66,7 @@ var _ = ginkgo.Describe("VirtualMCPServer Redis-Backed Session Sharing", func() 
 					Image:     images.YardstickServerImage,
 					Transport: "streamable-http",
 					ProxyPort: 8080,
-					McpPort:   8080,
+					MCPPort:   8080,
 				},
 			})).To(gomega.Succeed())
 
@@ -122,7 +123,7 @@ var _ = ginkgo.Describe("VirtualMCPServer Redis-Backed Session Sharing", func() 
 			_ = k8sClient.Delete(ctx, &mcpv1alpha1.MCPGroup{
 				ObjectMeta: metav1.ObjectMeta{Name: mcpGroupName, Namespace: defaultNamespace},
 			})
-			cleanupRedis(defaultNamespace, redisName)
+			cleanupRedis(redisName)
 			gomega.Eventually(func() bool {
 				err := k8sClient.Get(ctx, types.NamespacedName{Name: vmcpName, Namespace: defaultNamespace}, &mcpv1alpha1.VirtualMCPServer{})
 				return apierrors.IsNotFound(err)
@@ -162,7 +163,7 @@ var _ = ginkgo.Describe("VirtualMCPServer Redis-Backed Session Sharing", func() 
 			redisName = fmt.Sprintf("e2e-redis-xpod-%d", ts)
 
 			ginkgo.By("Deploying Redis")
-			deployRedis(defaultNamespace, redisName, timeout, pollInterval)
+			deployRedis(redisName)
 
 			ginkgo.By("Creating MCPGroup")
 			CreateMCPGroupAndWait(ctx, k8sClient, mcpGroupName, defaultNamespace,
@@ -176,7 +177,7 @@ var _ = ginkgo.Describe("VirtualMCPServer Redis-Backed Session Sharing", func() 
 					Image:     images.YardstickServerImage,
 					Transport: "streamable-http",
 					ProxyPort: 8080,
-					McpPort:   8080,
+					MCPPort:   8080,
 				},
 			})).To(gomega.Succeed())
 
@@ -233,14 +234,14 @@ var _ = ginkgo.Describe("VirtualMCPServer Redis-Backed Session Sharing", func() 
 			_ = k8sClient.Delete(ctx, &mcpv1alpha1.MCPGroup{
 				ObjectMeta: metav1.ObjectMeta{Name: mcpGroupName, Namespace: defaultNamespace},
 			})
-			cleanupRedis(defaultNamespace, redisName)
+			cleanupRedis(redisName)
 			gomega.Eventually(func() bool {
 				err := k8sClient.Get(ctx, types.NamespacedName{Name: vmcpName, Namespace: defaultNamespace}, &mcpv1alpha1.VirtualMCPServer{})
 				return apierrors.IsNotFound(err)
 			}, timeout, pollInterval).Should(gomega.BeTrue())
 		})
 
-		ginkgo.It("Should allow a session established on pod A to be used on pod B", func() {
+		ginkgo.It("Should allow a session established on pod A to be reconstructed on pod B", func() {
 			ginkgo.By("Getting the two ready pods")
 			var pods []corev1.Pod
 			gomega.Eventually(func() (int, error) {
@@ -268,12 +269,12 @@ var _ = ginkgo.Describe("VirtualMCPServer Redis-Backed Session Sharing", func() 
 			gomega.Expect(podA.Name).NotTo(gomega.Equal(podB.Name), "The two pods must be distinct")
 
 			ginkgo.By(fmt.Sprintf("Port-forwarding to pod A (%s)", podA.Name))
-			localPortA, cleanupA, err := portForwardToPod(podA.Name)
+			localPortA, cleanupA, err := portForwardToPod(podA.Name, vmcpPort)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			defer cleanupA()
 
 			ginkgo.By(fmt.Sprintf("Port-forwarding to pod B (%s)", podB.Name))
-			localPortB, cleanupB, err := portForwardToPod(podB.Name)
+			localPortB, cleanupB, err := portForwardToPod(podB.Name, vmcpPort)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			defer cleanupB()
 
@@ -310,6 +311,395 @@ var _ = ginkgo.Describe("VirtualMCPServer Redis-Backed Session Sharing", func() 
 			ginkgo.By("Verifying both pods return the same tool count")
 			gomega.Expect(toolsB.Tools).To(gomega.HaveLen(len(toolsA.Tools)),
 				"pod B must see same session state as pod A")
+		})
+	})
+
+	// -------------------------------------------------------------------------
+	// Context 3: VirtualMCPServer pod restart — session survives in Redis
+	// -------------------------------------------------------------------------
+
+	ginkgo.Context("When a VirtualMCPServer pod restarts with Redis configured", ginkgo.Ordered, func() {
+		var (
+			mcpGroupName string
+			backendName  string
+			vmcpName     string
+			redisName    string
+		)
+
+		ginkgo.BeforeAll(func() {
+			ts := time.Now().UnixNano()
+			mcpGroupName = fmt.Sprintf("e2e-redis-restart-group-%d", ts)
+			backendName = fmt.Sprintf("e2e-redis-restart-backend-%d", ts)
+			vmcpName = fmt.Sprintf("e2e-redis-restart-vmcp-%d", ts)
+			redisName = fmt.Sprintf("e2e-redis-restart-%d", ts)
+
+			ginkgo.By("Deploying Redis")
+			deployRedis(redisName)
+
+			ginkgo.By("Creating MCPGroup")
+			CreateMCPGroupAndWait(ctx, k8sClient, mcpGroupName, defaultNamespace,
+				"E2E Redis pod restart group", timeout, pollInterval)
+
+			ginkgo.By("Creating backend MCPServer")
+			gomega.Expect(k8sClient.Create(ctx, &mcpv1alpha1.MCPServer{
+				ObjectMeta: metav1.ObjectMeta{Name: backendName, Namespace: defaultNamespace},
+				Spec: mcpv1alpha1.MCPServerSpec{
+					GroupRef:  mcpGroupName,
+					Image:     images.YardstickServerImage,
+					Transport: "streamable-http",
+					ProxyPort: 8080,
+					MCPPort:   8080,
+				},
+			})).To(gomega.Succeed())
+
+			ginkgo.By("Waiting for backend MCPServer to be ready")
+			gomega.Eventually(func() error {
+				server := &mcpv1alpha1.MCPServer{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: backendName, Namespace: defaultNamespace}, server); err != nil {
+					return err
+				}
+				if server.Status.Phase != mcpv1alpha1.MCPServerPhaseReady {
+					return fmt.Errorf("MCPServer not ready, phase: %s", server.Status.Phase)
+				}
+				return nil
+			}, timeout, pollInterval).Should(gomega.Succeed())
+
+			replicas := int32(1)
+			redisAddr := fmt.Sprintf("%s.%s.svc.cluster.local:6379", redisName, defaultNamespace)
+
+			ginkgo.By("Creating VirtualMCPServer with replicas=1, Redis, and NodePort")
+			gomega.Expect(k8sClient.Create(ctx, &mcpv1alpha1.VirtualMCPServer{
+				ObjectMeta: metav1.ObjectMeta{Name: vmcpName, Namespace: defaultNamespace},
+				Spec: mcpv1alpha1.VirtualMCPServerSpec{
+					Config:          vmcpconfig.Config{Group: mcpGroupName},
+					IncomingAuth:    &mcpv1alpha1.IncomingAuthConfig{Type: "anonymous"},
+					Replicas:        &replicas,
+					ServiceType:     "NodePort",
+					SessionAffinity: "None",
+					SessionStorage: &mcpv1alpha1.SessionStorageConfig{
+						Provider:  mcpv1alpha1.SessionStorageProviderRedis,
+						Address:   redisAddr,
+						KeyPrefix: "thv:vmcp:e2e:",
+					},
+				},
+			})).To(gomega.Succeed())
+
+			ginkgo.By("Waiting for VirtualMCPServer to be ready")
+			WaitForVirtualMCPServerReady(ctx, k8sClient, vmcpName, defaultNamespace, timeout, pollInterval)
+		})
+
+		ginkgo.AfterAll(func() {
+			_ = k8sClient.Delete(ctx, &mcpv1alpha1.VirtualMCPServer{
+				ObjectMeta: metav1.ObjectMeta{Name: vmcpName, Namespace: defaultNamespace},
+			})
+			_ = k8sClient.Delete(ctx, &mcpv1alpha1.MCPServer{
+				ObjectMeta: metav1.ObjectMeta{Name: backendName, Namespace: defaultNamespace},
+			})
+			_ = k8sClient.Delete(ctx, &mcpv1alpha1.MCPGroup{
+				ObjectMeta: metav1.ObjectMeta{Name: mcpGroupName, Namespace: defaultNamespace},
+			})
+			cleanupRedis(redisName)
+			gomega.Eventually(func() bool {
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: vmcpName, Namespace: defaultNamespace}, &mcpv1alpha1.VirtualMCPServer{})
+				return apierrors.IsNotFound(err)
+			}, timeout, pollInterval).Should(gomega.BeTrue())
+		})
+
+		ginkgo.It("Should recover the session on the new pod after the original pod is deleted", func() {
+			ginkgo.By("Getting the NodePort for the VirtualMCPServer")
+			vmcpNodePort := GetVMCPNodePort(ctx, k8sClient, vmcpName, defaultNamespace, timeout, pollInterval)
+
+			ginkgo.By("Initializing an MCP session")
+			mcpClientA, err := CreateInitializedMCPClient(vmcpNodePort, "e2e-redis-restart-test", 30*time.Second)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			sessionID := mcpClientA.Client.GetSessionId()
+			gomega.Expect(sessionID).NotTo(gomega.BeEmpty(), "session ID must be assigned after Initialize")
+
+			ginkgo.By("Verifying tools are available before pod restart")
+			toolsBefore, err := mcpClientA.Client.ListTools(mcpClientA.Ctx, mcp.ListToolsRequest{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(toolsBefore.Tools).NotTo(gomega.BeEmpty())
+
+			// Cancel context to stop in-flight requests without sending DELETE.
+			// This simulates the pod being killed, not a clean client disconnect.
+			// We intentionally skip Client.Close() here because Close() sends a
+			// DELETE /mcp request that would terminate the session in Redis before
+			// the pod is restarted — defeating the purpose of this test.
+			// The transport's background goroutine (started by Start()) selects on
+			// ctx.Done(), so Cancel() is sufficient to stop it without leaking.
+			mcpClientA.Cancel()
+
+			ginkgo.By("Getting the running pod name before restart")
+			var pods []corev1.Pod
+			gomega.Eventually(func() (int, error) {
+				podList, err := GetVirtualMCPServerPods(ctx, k8sClient, vmcpName, defaultNamespace)
+				if err != nil {
+					return 0, err
+				}
+				var ready []corev1.Pod
+				for _, pod := range podList.Items {
+					if pod.Status.Phase != corev1.PodRunning {
+						continue
+					}
+					for _, c := range pod.Status.Conditions {
+						if c.Type == corev1.PodReady && c.Status == corev1.ConditionTrue {
+							ready = append(ready, pod)
+						}
+					}
+				}
+				pods = ready
+				return len(ready), nil
+			}, timeout, pollInterval).Should(gomega.Equal(1))
+			oldPodName := pods[0].Name
+
+			ginkgo.By(fmt.Sprintf("Deleting pod %s (Deployment will recreate it)", oldPodName))
+			gomega.Expect(k8sClient.Delete(ctx, &pods[0])).To(gomega.Succeed())
+
+			ginkgo.By("Waiting for a new pod to be Running+Ready")
+			gomega.Eventually(func() (string, error) {
+				podList, err := GetVirtualMCPServerPods(ctx, k8sClient, vmcpName, defaultNamespace)
+				if err != nil {
+					return "", err
+				}
+				for _, pod := range podList.Items {
+					if pod.Name == oldPodName || pod.Status.Phase != corev1.PodRunning {
+						continue
+					}
+					for _, c := range pod.Status.Conditions {
+						if c.Type == corev1.PodReady && c.Status == corev1.ConditionTrue {
+							return pod.Name, nil
+						}
+					}
+				}
+				return "", fmt.Errorf("waiting for new pod")
+			}, timeout, pollInterval).ShouldNot(gomega.BeEmpty())
+
+			ginkgo.By("Waiting for the NodePort to be serving HTTP again")
+			gomega.Eventually(func() error {
+				return checkHTTPHealthReady(vmcpNodePort)
+			}, timeout, pollInterval).Should(gomega.Succeed())
+
+			ginkgo.By("Creating a new client with the SAME session ID")
+			serverURL := fmt.Sprintf("http://localhost:%d/mcp", vmcpNodePort)
+			newClient, err := mcpclient.NewStreamableHttpClient(serverURL, transport.WithSession(sessionID))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			defer func() { _ = newClient.Close() }()
+
+			startCtx, startCancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer startCancel()
+			gomega.Expect(newClient.Start(startCtx)).To(gomega.Succeed())
+
+			// Send 5 requests to give confidence the fix holds: without Redis-backed
+			// session reconstruction, each request would fail because the new pod's
+			// in-memory cache is cold.
+			ginkgo.By("Sending 5 requests to verify the session is recovered from Redis on the new pod")
+			for i := range 5 {
+				listCtx, listCancel := context.WithTimeout(context.Background(), 30*time.Second)
+				toolsAfter, listErr := newClient.ListTools(listCtx, mcp.ListToolsRequest{})
+				listCancel()
+				gomega.Expect(listErr).NotTo(gomega.HaveOccurred(),
+					"Request %d/5 should succeed after pod restart — session must be recovered from Redis", i+1)
+				gomega.Expect(toolsAfter.Tools).To(gomega.HaveLen(len(toolsBefore.Tools)),
+					"Request %d/5 should return the same tools as before restart", i+1)
+			}
+		})
+	})
+
+	// -------------------------------------------------------------------------
+	// Context 4: Terminated session rejected by pod B via lazy eviction (#4731)
+	// -------------------------------------------------------------------------
+
+	ginkgo.Context("When a session is terminated on pod A, pod B rejects it via lazy eviction", ginkgo.Ordered, func() {
+		var (
+			mcpGroupName string
+			backendName  string
+			vmcpName     string
+			redisName    string
+		)
+
+		ginkgo.BeforeAll(func() {
+			ts := time.Now().UnixNano()
+			mcpGroupName = fmt.Sprintf("e2e-redis-term-group-%d", ts)
+			backendName = fmt.Sprintf("e2e-redis-term-backend-%d", ts)
+			vmcpName = fmt.Sprintf("e2e-redis-term-vmcp-%d", ts)
+			redisName = fmt.Sprintf("e2e-redis-term-%d", ts)
+
+			ginkgo.By("Deploying Redis")
+			deployRedis(redisName)
+
+			ginkgo.By("Creating MCPGroup")
+			CreateMCPGroupAndWait(ctx, k8sClient, mcpGroupName, defaultNamespace,
+				"E2E Redis terminated session group", timeout, pollInterval)
+
+			ginkgo.By("Creating backend MCPServer")
+			gomega.Expect(k8sClient.Create(ctx, &mcpv1alpha1.MCPServer{
+				ObjectMeta: metav1.ObjectMeta{Name: backendName, Namespace: defaultNamespace},
+				Spec: mcpv1alpha1.MCPServerSpec{
+					GroupRef:  mcpGroupName,
+					Image:     images.YardstickServerImage,
+					Transport: "streamable-http",
+					ProxyPort: 8080,
+					MCPPort:   8080,
+				},
+			})).To(gomega.Succeed())
+
+			ginkgo.By("Waiting for backend MCPServer to be ready")
+			gomega.Eventually(func() error {
+				server := &mcpv1alpha1.MCPServer{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: backendName, Namespace: defaultNamespace}, server); err != nil {
+					return err
+				}
+				if server.Status.Phase != mcpv1alpha1.MCPServerPhaseReady {
+					return fmt.Errorf("MCPServer not ready, phase: %s", server.Status.Phase)
+				}
+				return nil
+			}, timeout, pollInterval).Should(gomega.Succeed())
+
+			replicas := int32(2)
+			redisAddr := fmt.Sprintf("%s.%s.svc.cluster.local:6379", redisName, defaultNamespace)
+
+			ginkgo.By("Creating VirtualMCPServer with replicas=2, Redis, and SessionAffinity=None")
+			gomega.Expect(k8sClient.Create(ctx, &mcpv1alpha1.VirtualMCPServer{
+				ObjectMeta: metav1.ObjectMeta{Name: vmcpName, Namespace: defaultNamespace},
+				Spec: mcpv1alpha1.VirtualMCPServerSpec{
+					Config:          vmcpconfig.Config{Group: mcpGroupName},
+					IncomingAuth:    &mcpv1alpha1.IncomingAuthConfig{Type: "anonymous"},
+					Replicas:        &replicas,
+					SessionAffinity: "None",
+					SessionStorage: &mcpv1alpha1.SessionStorageConfig{
+						Provider:  mcpv1alpha1.SessionStorageProviderRedis,
+						Address:   redisAddr,
+						KeyPrefix: "thv:vmcp:e2e:",
+					},
+				},
+			})).To(gomega.Succeed())
+
+			ginkgo.By("Waiting for 2 ready pods")
+			gomega.Eventually(func() (int, error) {
+				return countReadyPods(vmcpName)
+			}, timeout, pollInterval).Should(gomega.Equal(2))
+
+			ginkgo.By("Waiting for VirtualMCPServer to report Ready")
+			WaitForVirtualMCPServerReady(ctx, k8sClient, vmcpName, defaultNamespace, timeout, pollInterval)
+		})
+
+		ginkgo.AfterAll(func() {
+			_ = k8sClient.Delete(ctx, &mcpv1alpha1.VirtualMCPServer{
+				ObjectMeta: metav1.ObjectMeta{Name: vmcpName, Namespace: defaultNamespace},
+			})
+			_ = k8sClient.Delete(ctx, &mcpv1alpha1.MCPServer{
+				ObjectMeta: metav1.ObjectMeta{Name: backendName, Namespace: defaultNamespace},
+			})
+			_ = k8sClient.Delete(ctx, &mcpv1alpha1.MCPGroup{
+				ObjectMeta: metav1.ObjectMeta{Name: mcpGroupName, Namespace: defaultNamespace},
+			})
+			cleanupRedis(redisName)
+			gomega.Eventually(func() bool {
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: vmcpName, Namespace: defaultNamespace}, &mcpv1alpha1.VirtualMCPServer{})
+				return apierrors.IsNotFound(err)
+			}, timeout, pollInterval).Should(gomega.BeTrue())
+		})
+
+		ginkgo.It("Should reject the session on pod B after it is terminated on pod A", func() {
+			ginkgo.By("Getting the two ready pods")
+			var pods []corev1.Pod
+			gomega.Eventually(func() (int, error) {
+				podList, err := GetVirtualMCPServerPods(ctx, k8sClient, vmcpName, defaultNamespace)
+				if err != nil {
+					return 0, err
+				}
+				var ready []corev1.Pod
+				for _, pod := range podList.Items {
+					if pod.Status.Phase != corev1.PodRunning {
+						continue
+					}
+					for _, c := range pod.Status.Conditions {
+						if c.Type == corev1.PodReady && c.Status == corev1.ConditionTrue {
+							ready = append(ready, pod)
+						}
+					}
+				}
+				pods = ready
+				return len(ready), nil
+			}, timeout, pollInterval).Should(gomega.Equal(2))
+
+			podA := pods[0]
+			podB := pods[1]
+			gomega.Expect(podA.Name).NotTo(gomega.Equal(podB.Name), "The two pods must be distinct")
+
+			ginkgo.By(fmt.Sprintf("Port-forwarding to pod A (%s)", podA.Name))
+			localPortA, cleanupA, err := portForwardToPod(podA.Name, vmcpPort)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			defer cleanupA()
+
+			ginkgo.By(fmt.Sprintf("Port-forwarding to pod B (%s)", podB.Name))
+			localPortB, cleanupB, err := portForwardToPod(podB.Name, vmcpPort)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			defer cleanupB()
+
+			ginkgo.By("Initializing a session on pod A")
+			clientA, err := CreateInitializedMCPClient(int32(localPortA), "e2e-redis-term-test", 30*time.Second)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			sessionID := clientA.Client.GetSessionId()
+			gomega.Expect(sessionID).NotTo(gomega.BeEmpty(), "session ID must be assigned after Initialize")
+
+			ginkgo.By("Verifying the session is usable on pod A")
+			toolsA, err := clientA.Client.ListTools(clientA.Ctx, mcp.ListToolsRequest{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(toolsA.Tools).NotTo(gomega.BeEmpty())
+
+			ginkgo.By(fmt.Sprintf("Reconstructing the session on pod B (%s) via Redis", podB.Name))
+			serverURLB := fmt.Sprintf("http://localhost:%d/mcp", localPortB)
+			clientB, err := mcpclient.NewStreamableHttpClient(serverURLB, transport.WithSession(sessionID))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			defer func() { _ = clientB.Close() }()
+
+			startCtx, startCancel := context.WithTimeout(context.Background(), 30*time.Second)
+			gomega.Expect(clientB.Start(startCtx)).To(gomega.Succeed())
+			startCancel()
+
+			listCtxB, listCancelB := context.WithTimeout(context.Background(), 30*time.Second)
+			toolsB, err := clientB.ListTools(listCtxB, mcp.ListToolsRequest{})
+			listCancelB()
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(toolsB.Tools).NotTo(gomega.BeEmpty(),
+				"pod B should serve the session before termination")
+
+			// Terminate the session on pod A by sending DELETE /mcp directly.
+			// We do this via raw HTTP rather than clientA.Close() to avoid the
+			// context-cancellation ordering in InitializedMCPClient.Close().
+			ginkgo.By("Terminating the session on pod A via DELETE /mcp")
+			deleteURL := fmt.Sprintf("http://localhost:%d/mcp", localPortA)
+			deleteCtx, deleteCancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer deleteCancel()
+			req, err := http.NewRequestWithContext(deleteCtx, http.MethodDelete, deleteURL, nil)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			req.Header.Set("Mcp-Session-Id", sessionID)
+			resp, err := http.DefaultClient.Do(req)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			_ = resp.Body.Close()
+			gomega.Expect(resp.StatusCode).To(gomega.BeElementOf(http.StatusOK, http.StatusNoContent),
+				"DELETE /mcp should return 200 or 204")
+			clientA.Cancel()
+
+			// Pod B's in-memory cache still holds the session, but the ValidatingCache's
+			// checkSession callback will find the key absent in Redis (deleted by the
+			// Terminate call above) and return ErrExpired, triggering lazy eviction.
+			// The next request from pod B should therefore fail with a session-not-found error.
+			ginkgo.By("Verifying pod B rejects subsequent requests for the terminated session")
+			gomega.Eventually(func() error {
+				listCtx, listCancel := context.WithTimeout(context.Background(), 5*time.Second)
+				defer listCancel()
+				_, listErr := clientB.ListTools(listCtx, mcp.ListToolsRequest{})
+				if listErr == nil {
+					return fmt.Errorf("expected pod B to reject the terminated session, but request succeeded")
+				}
+				if !errors.Is(listErr, transport.ErrSessionTerminated) {
+					return fmt.Errorf("expected ErrSessionTerminated (404), got: %w", listErr)
+				}
+				return nil
+			}, timeout, pollInterval).Should(gomega.Succeed(),
+				"pod B should reject the session after it is terminated on pod A")
 		})
 	})
 })

--- a/test/e2e/thv-operator/virtualmcp/virtualmcpserver_scaling_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcpserver_scaling_test.go
@@ -22,8 +22,8 @@ import (
 )
 
 // countReadyPods returns the number of Running+Ready pods for a VirtualMCPServer.
-func countReadyPods(vmcpName, namespace string) (int, error) {
-	podList, err := GetVirtualMCPServerPods(ctx, k8sClient, vmcpName, namespace)
+func countReadyPods(vmcpName string) (int, error) {
+	podList, err := GetVirtualMCPServerPods(ctx, k8sClient, vmcpName, "default")
 	if err != nil {
 		return 0, err
 	}
@@ -124,7 +124,7 @@ var _ = ginkgo.Describe("VirtualMCPServer Horizontal Scaling", func() {
 		ginkgo.It("Should eventually run 2 ready pods", func() {
 			ginkgo.By("Waiting for 2 pods to become Running+Ready")
 			gomega.Eventually(func() (int, error) {
-				return countReadyPods(vmcpName, defaultNamespace)
+				return countReadyPods(vmcpName)
 			}, timeout, pollInterval).Should(gomega.Equal(2))
 		})
 
@@ -217,7 +217,7 @@ var _ = ginkgo.Describe("VirtualMCPServer Horizontal Scaling", func() {
 
 		ginkgo.It("Should initially have 1 running pod and no SessionStorageWarning", func() {
 			gomega.Eventually(func() (int, error) {
-				return countReadyPods(vmcpName, defaultNamespace)
+				return countReadyPods(vmcpName)
 			}, timeout, pollInterval).Should(gomega.Equal(1))
 
 			WaitForCondition(ctx, k8sClient, vmcpName, defaultNamespace,
@@ -251,7 +251,7 @@ var _ = ginkgo.Describe("VirtualMCPServer Horizontal Scaling", func() {
 
 			ginkgo.By("Verifying 2 pods become ready")
 			gomega.Eventually(func() (int, error) {
-				return countReadyPods(vmcpName, defaultNamespace)
+				return countReadyPods(vmcpName)
 			}, timeout, pollInterval).Should(gomega.Equal(2))
 
 			ginkgo.By("Verifying SessionStorageWarning is now set")

--- a/test/e2e/thv-operator/virtualmcp/virtualmcpserver_scaling_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcpserver_scaling_test.go
@@ -23,7 +23,7 @@ import (
 
 // countReadyPods returns the number of Running+Ready pods for a VirtualMCPServer.
 func countReadyPods(vmcpName string) (int, error) {
-	podList, err := GetVirtualMCPServerPods(ctx, k8sClient, vmcpName, "default")
+	podList, err := GetVirtualMCPServerPods(ctx, k8sClient, vmcpName, defaultNamespace)
 	if err != nil {
 		return 0, err
 	}
@@ -43,9 +43,8 @@ func countReadyPods(vmcpName string) (int, error) {
 
 var _ = ginkgo.Describe("VirtualMCPServer Horizontal Scaling", func() {
 	const (
-		timeout          = time.Minute * 5
-		pollInterval     = time.Second * 2
-		defaultNamespace = "default"
+		timeout      = time.Minute * 5
+		pollInterval = time.Second * 2
 	)
 
 	// -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Add integration and e2e tests for Redis-backed vMCP session sharing

Integration tests (pkg/vmcp/server/sessionmanager, miniredis):
- AC1: cross-pod session reconstruction via RestoreSession on cache miss
- AC2: hijack prevention — wrong/nil callers rejected after restore, correct caller routes successfully
- AC4: all backends unreachable on restore → empty routing table returned
- AC5: NotifyBackendExpired removes backend from Redis metadata; subsequent restore on a fresh pod skips the expired backend
- AC6: LocalSessionDataStorage (no Redis) → no cross-pod sharing

E2E tests (test/e2e/thv-operator/virtualmcp, Kind + real Redis):
- replicas=2 + Redis → SessionStorageWarning=False and Ready=True
- cross-pod session reconstruction: session initialized on pod A is usable on pod B via transport.WithSession(sessionID)

Note: AC3 (LRU eviction, RC-10) is intentionally excluded — TTL-based Redis eviction is sufficient.

**Runtime fix** (`pkg/vmcp/k8s/manager.go`): `SetupIndexes` is now called before `SetupWithManager` when registering the BackendReconciler. The reconciler's watch handlers depend on field indexes registered against the controller-manager's cache; calling `SetupWithManager` without them causes watch predicates to fail silently (or panic at first use). This bug was surfaced by the new e2e tests, which exercise the multi-replica path that triggers the reconciler.

Fixes #4222 

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [x] Unit tests (`task test`)
- [x] E2E tests (`task test-e2e`)
- [ ] Linting (`task lint-fix`)
- [ ] Manual testing (describe below)

## Large PR Justification

This is a complete PR including e2e tests. Cannot be split.