### PR TITLE
Return registry type on error for accurate user-facing messages

### DIFF
--- a/cmd/thv/app/config.go
+++ b/cmd/thv/app/config.go
@@ -313,14 +313,17 @@ func enhanceRegistryError(err error, url, registryType string) error {
 
 		// Check for validation errors (502 Bad Gateway)
 		if errors.Is(regErr.Err, config.ErrRegistryValidationFailed) {
-			return fmt.Errorf("validation failed\n"+
-				"The %s at %s returned an invalid response or does not appear to be a valid registry.\n"+
-				"Please verify:\n"+
-				"  - The URL points to a valid MCP registry\n"+
-				"  - The remote URL returns valid JSON (not an HTML page)\n"+
-				"  - The registry format is correct\n"+
-				"  - The registry contains at least one server\n"+
-				"Original error: %v", registryType, url, regErr.Err)
+			msg := "validation failed\n" +
+				"The %s at %s returned an invalid response or does not appear to be a valid registry.\n" +
+				"Please verify:\n"
+			if registryType != config.RegistryTypeFile {
+				msg += "  - The URL points to a valid MCP registry\n" +
+					"  - The remote URL returns valid JSON (not an HTML page)\n"
+			}
+			msg += "  - The registry format is correct\n" +
+				"  - The registry contains at least one server\n" +
+				"Original error: %v"
+			return fmt.Errorf(msg, registryType, url, regErr.Err)
 		}
 	}
 

--- a/cmd/thv/app/config.go
+++ b/cmd/thv/app/config.go
@@ -317,6 +317,7 @@ func enhanceRegistryError(err error, url, registryType string) error {
 				"The %s at %s returned an invalid response or does not appear to be a valid registry.\n"+
 				"Please verify:\n"+
 				"  - The URL points to a valid MCP registry\n"+
+				"  - The remote URL returns valid JSON (not an HTML page)\n"+
 				"  - The registry format is correct\n"+
 				"  - The registry contains at least one server\n"+
 				"Original error: %v", registryType, url, regErr.Err)

--- a/pkg/registry/service.go
+++ b/pkg/registry/service.go
@@ -64,19 +64,19 @@ func (s *DefaultConfigurator) SetRegistryFromInput(input string, allowPrivateIP 
 	case config.RegistryTypeURL:
 		err = s.provider.SetRegistryURL(cleanPath, allowPrivateIP)
 		if err != nil {
-			return "", fmt.Errorf("failed to set remote registry: %w", err)
+			return registryType, fmt.Errorf("failed to set remote registry: %w", err)
 		}
 
 	case config.RegistryTypeAPI:
 		err = s.provider.SetRegistryAPI(cleanPath, allowPrivateIP)
 		if err != nil {
-			return "", fmt.Errorf("failed to set registry API: %w", err)
+			return registryType, fmt.Errorf("failed to set registry API: %w", err)
 		}
 
 	case config.RegistryTypeFile:
 		err = s.provider.SetRegistryFile(cleanPath)
 		if err != nil {
-			return "", fmt.Errorf("failed to set local registry file: %w", err)
+			return registryType, fmt.Errorf("failed to set local registry file: %w", err)
 		}
 
 	default:

--- a/pkg/registry/service.go
+++ b/pkg/registry/service.go
@@ -80,7 +80,7 @@ func (s *DefaultConfigurator) SetRegistryFromInput(input string, allowPrivateIP 
 		}
 
 	default:
-		return "", fmt.Errorf("unsupported registry type: %s", registryType)
+		return registryType, fmt.Errorf("unsupported registry type: %s", registryType)
 	}
 
 	// Reset the config singleton to clear cached configuration

--- a/pkg/registry/service_test.go
+++ b/pkg/registry/service_test.go
@@ -51,6 +51,7 @@ func TestConfigurator_SetRegistryFromInput(t *testing.T) {
 		{
 			name:           "invalid local file - missing",
 			allowPrivateIP: false,
+			expectedType:   config.RegistryTypeFile,
 			expectError:    true,
 			setupFunc: func(_ *testing.T) string {
 				return "/tmp/non-existent-file-xyz123.json"
@@ -59,6 +60,7 @@ func TestConfigurator_SetRegistryFromInput(t *testing.T) {
 		{
 			name:           "invalid local file - wrong structure",
 			allowPrivateIP: false,
+			expectedType:   config.RegistryTypeFile,
 			expectError:    true,
 			setupFunc: func(t *testing.T) string {
 				t.Helper()
@@ -94,6 +96,7 @@ func TestConfigurator_SetRegistryFromInput(t *testing.T) {
 			// Check results
 			if tt.expectError {
 				assert.Error(t, err, "Expected an error")
+				assert.Equal(t, tt.expectedType, registryType, "Registry type should be returned even on error")
 			} else {
 				assert.NoError(t, err, "Should not return error")
 				assert.Equal(t, tt.expectedType, registryType, "Registry type should match")


### PR DESCRIPTION
## Summary

When `thv config set-registry` fails validation, the error message was missing the registry type (e.g., `"The  at https://..."` with a blank). This happened because `SetRegistryFromInput` returned an empty string for the registry type on all error paths, and `enhanceRegistryError` used that empty value in its format string.

- Return the detected `registryType` instead of `""` on error paths in `SetRegistryFromInput`
- Add a hint in the validation error that the remote URL must return valid JSON (not an HTML page)
- Add test assertions verifying the registry type is returned on error

## Type of change

- [x] Bug fix

## Test plan

- [x] Linting (`task lint-fix`)
- [x] Manual testing (describe below)

Reproduced the original error with `thv config set-registry https://github.com/mcp` and confirmed the error message now correctly shows the registry type and the JSON hint.

## Does this introduce a user-facing change?

Yes — the validation error message for `thv config set-registry` now correctly identifies the registry type and includes a hint that the URL must return JSON.

Generated with [Claude Code](https://claude.com/claude-code)