### PR TITLE
Add implementation plan section to PR template

### DIFF
--- a/.claude/rules/pr-creation.md
+++ b/.claude/rules/pr-creation.md
@@ -13,6 +13,7 @@ You MUST follow the template at `.github/pull_request_template.md` when creating
 Do NOT leave optional sections empty or with only placeholder/template text. Either fill them in or delete them.
 
 - **Changes**: File-by-file table for PRs touching more than a few files.
+- **Implementation plan**: Include when the PR was planned with an AI assistant. Paste the approved plan inside the collapsible `<details>` block. This gives reviewers visibility into the intended design and tradeoffs. Remove the section entirely for PRs that were not AI-planned.
 - **Does this introduce a user-facing change?**: Describe the change from the user's perspective. Write "No" if not applicable.
 - **Special notes for reviewers**: Non-obvious design decisions, known limitations, areas wanting extra scrutiny, or planned follow-up work.
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -61,6 +61,22 @@ If no, write "No".
 Remove this section entirely if not applicable.
 -->
 
+## Implementation plan
+
+<!--
+Optional — include when this PR was planned with an AI assistant (Claude Code, etc.).
+Paste the approved plan inside the <details> block so reviewers can see the intended
+design without cluttering the main PR description. Remove this section entirely
+for PRs that were not AI-planned.
+-->
+
+<details>
+<summary>Approved implementation plan</summary>
+
+<!-- Paste the plan here -->
+
+</details>
+
 ## Special notes for reviewers
 
 <!--


### PR DESCRIPTION
## Summary

Stealing the idea from: @rdimitrov who mentioned a similar idea the other day

- AI-assisted PRs lose the approved implementation plan once the conversation ends, making it harder for reviewers to understand the intended design and tradeoffs
- Adds a collapsible "Implementation plan" `<details>` section to the PR template so the approved plan is preserved in the PR body
- Updates `.claude/rules/pr-creation.md` to document when to include or remove the section

## Type of change

- [x] Other (describe): PR template improvement

## Test plan

- [x] Manual testing (describe below)

Verified the template renders correctly with the new collapsible section and that the PR creation rules are consistent with the template.

## Does this introduce a user-facing change?

No

Generated with [Claude Code](https://claude.com/claude-code)