### PR TITLE
Fix GetDefaultProvider bypassing registered config factory

### DIFF
--- a/pkg/api/v1/registry.go
+++ b/pkg/api/v1/registry.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
-	"github.com/stacklok/toolhive-core/registry/types"
+	registry "github.com/stacklok/toolhive-core/registry/types"
 	"github.com/stacklok/toolhive/pkg/config"
 	regpkg "github.com/stacklok/toolhive/pkg/registry"
 	"github.com/stacklok/toolhive/pkg/registry/auth"
@@ -286,7 +286,7 @@ type RegistryRoutes struct {
 // NewRegistryRoutes creates a new RegistryRoutes with the default config provider
 func NewRegistryRoutes() *RegistryRoutes {
 	return &RegistryRoutes{
-		configProvider: config.NewDefaultProvider(),
+		configProvider: config.NewProvider(),
 		configService:  regpkg.NewConfigurator(),
 	}
 }
@@ -304,7 +304,7 @@ func NewRegistryRoutesWithProvider(provider config.Provider) *RegistryRoutes {
 // In serve mode, the registry provider uses non-interactive auth (no browser OAuth).
 func NewRegistryRoutesForServe() *RegistryRoutes {
 	return &RegistryRoutes{
-		configProvider: config.NewDefaultProvider(),
+		configProvider: config.NewProvider(),
 		configService:  regpkg.NewConfigurator(),
 		serveMode:      true,
 	}

--- a/pkg/api/v1/registry_factory_test.go
+++ b/pkg/api/v1/registry_factory_test.go
@@ -1,0 +1,201 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/stacklok/toolhive/pkg/config"
+	"github.com/stacklok/toolhive/pkg/registry"
+)
+
+// writeFactorySentinelRegistry creates a legacy-format registry JSON file with a
+// single server named sentinelName and a YAML config pointing to it.
+// Returns the config file path.
+func writeFactorySentinelRegistry(t *testing.T, sentinelName string) string {
+	t.Helper()
+
+	dir := t.TempDir()
+
+	// Write legacy registry JSON with the sentinel server.
+	type serverEntry struct {
+		Image       string `json:"image"`
+		Description string `json:"description"`
+	}
+	type registryFile struct {
+		Version     string                 `json:"version"`
+		LastUpdated string                 `json:"last_updated"`
+		Servers     map[string]serverEntry `json:"servers"`
+	}
+
+	regData, err := json.Marshal(registryFile{
+		Version:     "1.0.0",
+		LastUpdated: "2025-01-01T00:00:00Z",
+		Servers: map[string]serverEntry{
+			sentinelName: {
+				Image:       "factory/server:latest",
+				Description: "Factory sentinel server",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	registryPath := filepath.Join(dir, "registry.json")
+	require.NoError(t, os.WriteFile(registryPath, regData, 0600))
+
+	// Write YAML config pointing to the registry JSON.
+	type configFile struct {
+		LocalRegistryPath string `yaml:"local_registry_path"`
+	}
+
+	cfgData, err := yaml.Marshal(configFile{LocalRegistryPath: registryPath})
+	require.NoError(t, err)
+
+	configPath := filepath.Join(dir, "config.yaml")
+	require.NoError(t, os.WriteFile(configPath, cfgData, 0600))
+
+	return configPath
+}
+
+// makeListServersRequest builds an httptest request for GET /{name}/servers
+// with the chi URL param "name" set to registryName.
+func makeListServersRequest(registryName string) *http.Request {
+	req := httptest.NewRequest(http.MethodGet, "/"+registryName+"/servers", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("name", registryName)
+	return req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+}
+
+// TestNewRegistryRoutes_RespectsRegisteredFactory is the critical regression test
+// for the bug fix. Before the fix, NewRegistryRoutes called config.NewDefaultProvider(),
+// which bypassed any registered ProviderFactory. The fix changed it to call
+// config.NewProvider(), which checks the factory first.
+//
+// The test registers a factory that returns a PathProvider pointing at a local
+// registry JSON containing a sentinel server name. If NewRegistryRoutes correctly
+// forwards the factory-backed provider to getCurrentProvider, the listServers
+// handler will return that sentinel server in its response.
+//
+//nolint:paralleltest // Mutates global state: config.registeredFactory and regpkg.defaultProviderOnce
+func TestNewRegistryRoutes_RespectsRegisteredFactory(t *testing.T) {
+	const sentinelName = "factory-sentinel-server"
+
+	configPath := writeFactorySentinelRegistry(t, sentinelName)
+
+	config.RegisterProviderFactory(func() config.Provider {
+		return config.NewPathProvider(configPath)
+	})
+	t.Cleanup(func() {
+		config.RegisterProviderFactory(nil)
+		registry.ResetDefaultProvider()
+	})
+
+	routes := NewRegistryRoutes()
+
+	// Clear provider cache so getCurrentProvider re-initialises using our factory.
+	registry.ResetDefaultProvider()
+
+	w := httptest.NewRecorder()
+	routes.listServers(w, makeListServersRequest("default"))
+
+	assert.Equal(t, http.StatusOK, w.Code,
+		"listServers should return 200 when factory-backed provider is used")
+
+	var body listServersResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&body),
+		"response body should be valid JSON")
+
+	names := make([]string, 0, len(body.Servers))
+	for _, s := range body.Servers {
+		names = append(names, s.GetName())
+	}
+	assert.Contains(t, names, sentinelName,
+		"sentinel server must be present; this would fail on the old code that called config.NewDefaultProvider()")
+}
+
+// TestNewRegistryRoutesForServe_RespectsRegisteredFactory verifies that the
+// serve-mode constructor also honours the registered ProviderFactory. This
+// mirrors TestNewRegistryRoutes_RespectsRegisteredFactory but exercises
+// NewRegistryRoutesForServe and the serveMode code path.
+//
+//nolint:paralleltest // Mutates global state: config.registeredFactory and regpkg.defaultProviderOnce
+func TestNewRegistryRoutesForServe_RespectsRegisteredFactory(t *testing.T) {
+	const sentinelName = "factory-sentinel-server"
+
+	configPath := writeFactorySentinelRegistry(t, sentinelName)
+
+	config.RegisterProviderFactory(func() config.Provider {
+		return config.NewPathProvider(configPath)
+	})
+	t.Cleanup(func() {
+		config.RegisterProviderFactory(nil)
+		registry.ResetDefaultProvider()
+	})
+
+	routes := NewRegistryRoutesForServe()
+
+	// Clear provider cache so getCurrentProvider re-initialises using our factory.
+	registry.ResetDefaultProvider()
+
+	w := httptest.NewRecorder()
+	routes.listServers(w, makeListServersRequest("default"))
+
+	assert.Equal(t, http.StatusOK, w.Code,
+		"listServers should return 200 when factory-backed provider is used in serve mode")
+
+	var body listServersResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&body),
+		"response body should be valid JSON")
+
+	names := make([]string, 0, len(body.Servers))
+	for _, s := range body.Servers {
+		names = append(names, s.GetName())
+	}
+	assert.Contains(t, names, sentinelName,
+		"sentinel server must be present; this would fail on the old code that called config.NewDefaultProvider()")
+}
+
+// TestNewRegistryRoutes_NoFactory_ReturnsValidRoutes verifies that NewRegistryRoutes
+// returns a fully-initialised struct when no ProviderFactory is registered.
+//
+//nolint:paralleltest // Mutates global state: config.registeredFactory
+func TestNewRegistryRoutes_NoFactory_ReturnsValidRoutes(t *testing.T) {
+	config.RegisterProviderFactory(nil)
+	t.Cleanup(func() { config.RegisterProviderFactory(nil) })
+
+	routes := NewRegistryRoutes()
+
+	require.NotNil(t, routes, "NewRegistryRoutes must return a non-nil value")
+	assert.NotNil(t, routes.configProvider, "configProvider must be initialised")
+	assert.NotNil(t, routes.configService, "configService must be initialised")
+	assert.False(t, routes.serveMode, "serveMode must be false for NewRegistryRoutes")
+}
+
+// TestNewRegistryRoutesForServe_NoFactory_ReturnsValidRoutes verifies that
+// NewRegistryRoutesForServe returns a fully-initialised struct with serveMode
+// set to true when no ProviderFactory is registered.
+//
+//nolint:paralleltest // Mutates global state: config.registeredFactory
+func TestNewRegistryRoutesForServe_NoFactory_ReturnsValidRoutes(t *testing.T) {
+	config.RegisterProviderFactory(nil)
+	t.Cleanup(func() { config.RegisterProviderFactory(nil) })
+
+	routes := NewRegistryRoutesForServe()
+
+	require.NotNil(t, routes, "NewRegistryRoutesForServe must return a non-nil value")
+	assert.NotNil(t, routes.configProvider, "configProvider must be initialised")
+	assert.NotNil(t, routes.configService, "configService must be initialised")
+	assert.True(t, routes.serveMode, "serveMode must be true for NewRegistryRoutesForServe")
+}

--- a/pkg/registry/factory.go
+++ b/pkg/registry/factory.go
@@ -79,10 +79,19 @@ func NewRegistryProvider(cfg *config.Config, opts ...ProviderOption) (Provider, 
 	return NewLocalRegistryProvider(), nil
 }
 
-// GetDefaultProvider returns the default registry provider instance
-// This maintains backward compatibility with the existing singleton pattern
+// GetDefaultProvider returns the default registry provider instance.
+// config.NewProvider() is called inside the sync.Once closure so that any
+// registered ProviderFactory is invoked at most once, not on every call.
 func GetDefaultProvider() (Provider, error) {
-	return GetDefaultProviderWithConfig(config.NewProvider())
+	defaultProviderOnce.Do(func() {
+		cfg, err := config.NewProvider().LoadOrCreateConfig()
+		if err != nil {
+			defaultProviderErr = err
+			return
+		}
+		defaultProvider, defaultProviderErr = NewRegistryProvider(cfg)
+	})
+	return defaultProvider, defaultProviderErr
 }
 
 // GetDefaultProviderWithConfig returns a registry provider using the given config provider.

--- a/pkg/registry/factory.go
+++ b/pkg/registry/factory.go
@@ -10,22 +10,30 @@ import (
 	"fmt"
 	"log/slog"
 	"sync"
+	"sync/atomic"
 
 	"github.com/stacklok/toolhive/pkg/config"
 	"github.com/stacklok/toolhive/pkg/registry/auth"
 	"github.com/stacklok/toolhive/pkg/secrets"
 )
 
-var (
-	defaultProvider     Provider
-	defaultProviderOnce sync.Once
-	defaultProviderErr  error
-	// defaultProviderMu protects the ResetDefaultProvider operation
-	// to prevent race conditions when resetting the sync.Once.
-	// The mutex is NOT needed for GetDefaultProviderWithConfig since
-	// sync.Once already provides thread-safety for initialization.
-	defaultProviderMu sync.Mutex
-)
+// providerState groups the sync.Once with the values it initialises.
+// Storing all three together behind an atomic pointer means ResetDefaultProvider
+// can swap in a fresh struct without ever writing to a struct that another
+// goroutine may be reading — eliminating the data race between Reset and Do.
+type providerState struct {
+	once     sync.Once
+	provider Provider
+	err      error
+}
+
+// currentProviderState is the live singleton state. Replaced atomically by
+// ResetDefaultProvider; never mutated after creation except inside once.Do.
+var currentProviderState atomic.Pointer[providerState]
+
+func init() {
+	currentProviderState.Store(&providerState{})
+}
 
 // ProviderOption configures optional behavior for NewRegistryProvider.
 type ProviderOption func(*providerOptions)
@@ -83,15 +91,16 @@ func NewRegistryProvider(cfg *config.Config, opts ...ProviderOption) (Provider, 
 // config.NewProvider() is called inside the sync.Once closure so that any
 // registered ProviderFactory is invoked at most once, not on every call.
 func GetDefaultProvider() (Provider, error) {
-	defaultProviderOnce.Do(func() {
+	s := currentProviderState.Load()
+	s.once.Do(func() {
 		cfg, err := config.NewProvider().LoadOrCreateConfig()
 		if err != nil {
-			defaultProviderErr = err
+			s.err = err
 			return
 		}
-		defaultProvider, defaultProviderErr = NewRegistryProvider(cfg)
+		s.provider, s.err = NewRegistryProvider(cfg)
 	})
-	return defaultProvider, defaultProviderErr
+	return s.provider, s.err
 }
 
 // GetDefaultProviderWithConfig returns a registry provider using the given config provider.
@@ -99,31 +108,25 @@ func GetDefaultProvider() (Provider, error) {
 // The interactive flag controls whether browser-based OAuth flows are allowed.
 // Pass true for CLI contexts, false for headless/serve mode.
 func GetDefaultProviderWithConfig(configProvider config.Provider, opts ...ProviderOption) (Provider, error) {
-	defaultProviderOnce.Do(func() {
+	s := currentProviderState.Load()
+	s.once.Do(func() {
 		cfg, err := configProvider.LoadOrCreateConfig()
 		if err != nil {
-			defaultProviderErr = err
+			s.err = err
 			return
 		}
-		defaultProvider, defaultProviderErr = NewRegistryProvider(cfg, opts...)
+		s.provider, s.err = NewRegistryProvider(cfg, opts...)
 	})
-
-	return defaultProvider, defaultProviderErr
+	return s.provider, s.err
 }
 
-// ResetDefaultProvider clears the cached default provider instance
-// This allows the provider to be recreated with updated configuration.
-// This function is thread-safe and can be called concurrently.
-// The mutex is required here because we're modifying the sync.Once itself,
-// which is not a thread-safe operation.
+// ResetDefaultProvider clears the cached default provider instance so the
+// next call to GetDefaultProvider or GetDefaultProviderWithConfig creates a
+// fresh one. The atomic swap is safe to call concurrently: goroutines that
+// already hold a reference to the old state finish against that state cleanly,
+// while goroutines that load after the swap initialise against the new state.
 func ResetDefaultProvider() {
-	defaultProviderMu.Lock()
-	defer defaultProviderMu.Unlock()
-
-	// Reset the sync.Once to allow re-initialization
-	defaultProviderOnce = sync.Once{}
-	defaultProvider = nil
-	defaultProviderErr = nil
+	currentProviderState.Store(&providerState{})
 }
 
 // resolveTokenSource creates a TokenSource from the config if registry auth is configured.

--- a/pkg/registry/factory.go
+++ b/pkg/registry/factory.go
@@ -82,7 +82,7 @@ func NewRegistryProvider(cfg *config.Config, opts ...ProviderOption) (Provider, 
 // GetDefaultProvider returns the default registry provider instance
 // This maintains backward compatibility with the existing singleton pattern
 func GetDefaultProvider() (Provider, error) {
-	return GetDefaultProviderWithConfig(config.NewDefaultProvider())
+	return GetDefaultProviderWithConfig(config.NewProvider())
 }
 
 // GetDefaultProviderWithConfig returns a registry provider using the given config provider.

--- a/pkg/registry/factory_test.go
+++ b/pkg/registry/factory_test.go
@@ -75,10 +75,11 @@ func writeTempConfigYAML(t *testing.T, dir, localRegistryPath string) string {
 	return configPath
 }
 
-//nolint:paralleltest // Mutates global config factory and provider state singletons
 // TestGetDefaultProvider_NoFactoryRegistered verifies that when no factory is
 // registered, GetDefaultProvider returns a non-nil provider backed by the
 // embedded registry data (which must contain at least one server).
+//
+//nolint:paralleltest // Mutates global config factory and provider state singletons
 func TestGetDefaultProvider_NoFactoryRegistered(t *testing.T) {
 	resetGlobalState(t)
 	// Ensure no factory is active and the cache is clear before the call.
@@ -98,7 +99,6 @@ func TestGetDefaultProvider_NoFactoryRegistered(t *testing.T) {
 	assert.NotEmpty(t, servers, "embedded registry must contain at least one server")
 }
 
-//nolint:paralleltest // Mutates global config factory and provider state singletons
 // TestGetDefaultProvider_RespectsRegisteredFactory is the critical regression
 // test for the bug fix. Before the fix, GetDefaultProvider called
 // config.NewDefaultProvider(), which bypassed any registered factory. The fix
@@ -111,6 +111,8 @@ func TestGetDefaultProvider_NoFactoryRegistered(t *testing.T) {
 //  3. Registers a factory that returns a PathProvider for that config file.
 //  4. Asserts that GetDefaultProvider() returns a provider whose ListServers
 //     includes the sentinel server — proving the factory was honoured.
+//
+//nolint:paralleltest // Mutates global config factory and provider state singletons
 func TestGetDefaultProvider_RespectsRegisteredFactory(t *testing.T) {
 	resetGlobalState(t)
 
@@ -142,10 +144,11 @@ func TestGetDefaultProvider_RespectsRegisteredFactory(t *testing.T) {
 			"this would fail on the old code that called config.NewDefaultProvider()")
 }
 
-//nolint:paralleltest // Mutates global config factory and provider state singletons
 // TestGetDefaultProvider_FactoryReturnsNil_FallsThrough verifies that when the
 // registered factory returns nil, GetDefaultProvider falls through to the
 // embedded registry (non-nil provider, non-empty server list).
+//
+//nolint:paralleltest // Mutates global config factory and provider state singletons
 func TestGetDefaultProvider_FactoryReturnsNil_FallsThrough(t *testing.T) {
 	resetGlobalState(t)
 
@@ -166,10 +169,11 @@ func TestGetDefaultProvider_FactoryReturnsNil_FallsThrough(t *testing.T) {
 	assert.NotEmpty(t, servers, "fallback to embedded registry must yield at least one server")
 }
 
-//nolint:paralleltest // Mutates global config factory and provider state singletons
 // TestGetDefaultProvider_CachesResult verifies that two consecutive calls to
 // GetDefaultProvider (without a reset in between) return the exact same
 // provider pointer, confirming the sync.Once caching semantics.
+//
+//nolint:paralleltest // Mutates global config factory and provider state singletons
 func TestGetDefaultProvider_CachesResult(t *testing.T) {
 	resetGlobalState(t)
 
@@ -190,10 +194,11 @@ func TestGetDefaultProvider_CachesResult(t *testing.T) {
 	assert.Same(t, first, second, "consecutive calls must return the same cached provider instance")
 }
 
-//nolint:paralleltest // Mutates global config factory and provider state singletons
 // TestResetDefaultProvider_AllowsReinit verifies that calling ResetDefaultProvider
 // clears the sync.Once cache so the next call to GetDefaultProvider creates a
 // fresh provider instance (a different pointer).
+//
+//nolint:paralleltest // Mutates global config factory and provider state singletons
 func TestResetDefaultProvider_AllowsReinit(t *testing.T) {
 	resetGlobalState(t)
 

--- a/pkg/registry/factory_test.go
+++ b/pkg/registry/factory_test.go
@@ -1,0 +1,212 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package registry
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/stacklok/toolhive/pkg/config"
+)
+
+// resetGlobalState resets both the registry factory and default provider cache.
+// It must be called via t.Cleanup in every test that touches global state.
+func resetGlobalState(t *testing.T) {
+	t.Helper()
+	t.Cleanup(func() {
+		config.RegisterProviderFactory(nil)
+		ResetDefaultProvider()
+	})
+}
+
+// writeTempRegistryJSON writes a legacy-format registry JSON file to dir and
+// returns its path. serverName is used as the only server key.
+func writeTempRegistryJSON(t *testing.T, dir, serverName string) string {
+	t.Helper()
+
+	type serverEntry struct {
+		Image       string `json:"image"`
+		Description string `json:"description"`
+	}
+	type registryFile struct {
+		Version     string                 `json:"version"`
+		LastUpdated string                 `json:"last_updated"`
+		Servers     map[string]serverEntry `json:"servers"`
+	}
+
+	data, err := json.Marshal(registryFile{
+		Version:     "1.0.0",
+		LastUpdated: "2025-01-01T00:00:00Z",
+		Servers: map[string]serverEntry{
+			serverName: {
+				Image:       "enterprise/server:latest",
+				Description: "Enterprise test server",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	registryPath := filepath.Join(dir, "registry.json")
+	require.NoError(t, os.WriteFile(registryPath, data, 0600))
+	return registryPath
+}
+
+// writeTempConfigYAML writes a YAML config file that sets local_registry_path
+// and returns the config file path.
+func writeTempConfigYAML(t *testing.T, dir, localRegistryPath string) string {
+	t.Helper()
+
+	type configFile struct {
+		LocalRegistryPath string `yaml:"local_registry_path"`
+	}
+
+	data, err := yaml.Marshal(configFile{LocalRegistryPath: localRegistryPath})
+	require.NoError(t, err)
+
+	configPath := filepath.Join(dir, "config.yaml")
+	require.NoError(t, os.WriteFile(configPath, data, 0600))
+	return configPath
+}
+
+// TestGetDefaultProvider_NoFactoryRegistered verifies that when no factory is
+// registered, GetDefaultProvider returns a non-nil provider backed by the
+// embedded registry data (which must contain at least one server).
+func TestGetDefaultProvider_NoFactoryRegistered(t *testing.T) {
+	resetGlobalState(t)
+	// Ensure no factory is active and the cache is clear before the call.
+	config.RegisterProviderFactory(nil)
+	ResetDefaultProvider()
+
+	// Ensure the test does not accidentally run in a Kubernetes environment.
+	t.Setenv("KUBERNETES_SERVICE_HOST", "")
+	t.Setenv("KUBERNETES_SERVICE_PORT", "")
+
+	provider, err := GetDefaultProvider()
+	require.NoError(t, err)
+	require.NotNil(t, provider)
+
+	servers, err := provider.ListServers()
+	require.NoError(t, err)
+	assert.NotEmpty(t, servers, "embedded registry must contain at least one server")
+}
+
+// TestGetDefaultProvider_RespectsRegisteredFactory is the critical regression
+// test for the bug fix. Before the fix, GetDefaultProvider called
+// config.NewDefaultProvider(), which bypassed any registered factory. The fix
+// changed the call to config.NewProvider(), which checks the registered factory
+// first.
+//
+// This test:
+//  1. Writes a local registry JSON with a sentinel server name.
+//  2. Writes a config YAML pointing to that registry.
+//  3. Registers a factory that returns a PathProvider for that config file.
+//  4. Asserts that GetDefaultProvider() returns a provider whose ListServers
+//     includes the sentinel server — proving the factory was honoured.
+func TestGetDefaultProvider_RespectsRegisteredFactory(t *testing.T) {
+	resetGlobalState(t)
+
+	dir := t.TempDir()
+	const sentinelName = "enterprise-test-server"
+
+	registryPath := writeTempRegistryJSON(t, dir, sentinelName)
+	configPath := writeTempConfigYAML(t, dir, registryPath)
+
+	config.RegisterProviderFactory(func() config.Provider {
+		return config.NewPathProvider(configPath)
+	})
+	// Reset after factory is registered so the next call re-initialises.
+	ResetDefaultProvider()
+
+	provider, err := GetDefaultProvider()
+	require.NoError(t, err)
+	require.NotNil(t, provider)
+
+	servers, err := provider.ListServers()
+	require.NoError(t, err)
+
+	names := make([]string, 0, len(servers))
+	for _, s := range servers {
+		names = append(names, s.GetName())
+	}
+	assert.Contains(t, names, sentinelName,
+		"provider must expose the sentinel server from the custom registry; "+
+			"this would fail on the old code that called config.NewDefaultProvider()")
+}
+
+// TestGetDefaultProvider_FactoryReturnsNil_FallsThrough verifies that when the
+// registered factory returns nil, GetDefaultProvider falls through to the
+// embedded registry (non-nil provider, non-empty server list).
+func TestGetDefaultProvider_FactoryReturnsNil_FallsThrough(t *testing.T) {
+	resetGlobalState(t)
+
+	t.Setenv("KUBERNETES_SERVICE_HOST", "")
+	t.Setenv("KUBERNETES_SERVICE_PORT", "")
+
+	config.RegisterProviderFactory(func() config.Provider {
+		return nil
+	})
+	ResetDefaultProvider()
+
+	provider, err := GetDefaultProvider()
+	require.NoError(t, err)
+	require.NotNil(t, provider)
+
+	servers, err := provider.ListServers()
+	require.NoError(t, err)
+	assert.NotEmpty(t, servers, "fallback to embedded registry must yield at least one server")
+}
+
+// TestGetDefaultProvider_CachesResult verifies that two consecutive calls to
+// GetDefaultProvider (without a reset in between) return the exact same
+// provider pointer, confirming the sync.Once caching semantics.
+func TestGetDefaultProvider_CachesResult(t *testing.T) {
+	resetGlobalState(t)
+
+	t.Setenv("KUBERNETES_SERVICE_HOST", "")
+	t.Setenv("KUBERNETES_SERVICE_PORT", "")
+
+	config.RegisterProviderFactory(nil)
+	ResetDefaultProvider()
+
+	first, err := GetDefaultProvider()
+	require.NoError(t, err)
+	require.NotNil(t, first)
+
+	second, err := GetDefaultProvider()
+	require.NoError(t, err)
+	require.NotNil(t, second)
+
+	assert.Same(t, first, second, "consecutive calls must return the same cached provider instance")
+}
+
+// TestResetDefaultProvider_AllowsReinit verifies that calling ResetDefaultProvider
+// clears the sync.Once cache so the next call to GetDefaultProvider creates a
+// fresh provider instance (a different pointer).
+func TestResetDefaultProvider_AllowsReinit(t *testing.T) {
+	resetGlobalState(t)
+
+	t.Setenv("KUBERNETES_SERVICE_HOST", "")
+	t.Setenv("KUBERNETES_SERVICE_PORT", "")
+
+	config.RegisterProviderFactory(nil)
+	ResetDefaultProvider()
+
+	first, err := GetDefaultProvider()
+	require.NoError(t, err)
+	require.NotNil(t, first)
+
+	ResetDefaultProvider()
+
+	second, err := GetDefaultProvider()
+	require.NoError(t, err)
+	require.NotNil(t, second)
+
+	assert.NotSame(t, first, second, "after ResetDefaultProvider the next call must return a new instance")
+}

--- a/pkg/registry/factory_test.go
+++ b/pkg/registry/factory_test.go
@@ -75,6 +75,7 @@ func writeTempConfigYAML(t *testing.T, dir, localRegistryPath string) string {
 	return configPath
 }
 
+//nolint:paralleltest // Mutates global config factory and provider state singletons
 // TestGetDefaultProvider_NoFactoryRegistered verifies that when no factory is
 // registered, GetDefaultProvider returns a non-nil provider backed by the
 // embedded registry data (which must contain at least one server).
@@ -97,6 +98,7 @@ func TestGetDefaultProvider_NoFactoryRegistered(t *testing.T) {
 	assert.NotEmpty(t, servers, "embedded registry must contain at least one server")
 }
 
+//nolint:paralleltest // Mutates global config factory and provider state singletons
 // TestGetDefaultProvider_RespectsRegisteredFactory is the critical regression
 // test for the bug fix. Before the fix, GetDefaultProvider called
 // config.NewDefaultProvider(), which bypassed any registered factory. The fix
@@ -140,6 +142,7 @@ func TestGetDefaultProvider_RespectsRegisteredFactory(t *testing.T) {
 			"this would fail on the old code that called config.NewDefaultProvider()")
 }
 
+//nolint:paralleltest // Mutates global config factory and provider state singletons
 // TestGetDefaultProvider_FactoryReturnsNil_FallsThrough verifies that when the
 // registered factory returns nil, GetDefaultProvider falls through to the
 // embedded registry (non-nil provider, non-empty server list).
@@ -163,6 +166,7 @@ func TestGetDefaultProvider_FactoryReturnsNil_FallsThrough(t *testing.T) {
 	assert.NotEmpty(t, servers, "fallback to embedded registry must yield at least one server")
 }
 
+//nolint:paralleltest // Mutates global config factory and provider state singletons
 // TestGetDefaultProvider_CachesResult verifies that two consecutive calls to
 // GetDefaultProvider (without a reset in between) return the exact same
 // provider pointer, confirming the sync.Once caching semantics.
@@ -186,6 +190,7 @@ func TestGetDefaultProvider_CachesResult(t *testing.T) {
 	assert.Same(t, first, second, "consecutive calls must return the same cached provider instance")
 }
 
+//nolint:paralleltest // Mutates global config factory and provider state singletons
 // TestResetDefaultProvider_AllowsReinit verifies that calling ResetDefaultProvider
 // clears the sync.Once cache so the next call to GetDefaultProvider creates a
 // fresh provider instance (a different pointer).


### PR DESCRIPTION
## Summary

`GetDefaultProvider()` in `pkg/registry/factory.go` called `config.NewDefaultProvider()`, which bypasses the `RegisterProviderFactory` hook entirely and always reads the local XDG config file. This means any enterprise build that registers a factory (e.g. to supply an `EnterpriseProvider` that fetches config from a remote server) was silently ignored — `thv registry` commands always showed the embedded registry instead of the configured one.

- Change the call from `config.NewDefaultProvider()` to `config.NewProvider()`, which checks the registered factory first and falls back to the default only when no factory is registered
- Add unit tests covering: factory respected, factory returns nil falls through, caching semantics (`sync.Once`), and reset behaviour

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test`)

The regression test `TestGetDefaultProvider_RespectsRegisteredFactory` registers a factory pointing to a custom registry with a sentinel server name and asserts that server appears in `ListServers()` — this test fails on the old code and passes with the fix.

## Does this introduce a user-facing change?

No change in open-source builds. In enterprise builds that register a `ProviderFactory`, `thv registry list` and related commands now correctly use the factory-backed config (e.g. a remote registry URL from the enterprise config server) instead of falling back to the embedded registry.

Generated with [Claude Code](https://claude.com/claude-code)