### PR TITLE
Wait for running state before deleting in lifecycle E2E test

### DIFF
--- a/test/e2e/api_workloads_test.go
+++ b/test/e2e/api_workloads_test.go
@@ -543,6 +543,18 @@ var _ = Describe("Workloads API", Label("api", "api-workloads", "workloads", "e2
 			}, 60*time.Second, 2*time.Second).Should(BeTrue(),
 				"Created workload should appear in list")
 
+			By("Step 3.5: Waiting for workload to reach running state")
+			Eventually(func() bool {
+				workloads := listWorkloads(apiServer, true)
+				for _, w := range workloads {
+					if w.Name == workloadName && w.Status == runtime.WorkloadStatusRunning {
+						return true
+					}
+				}
+				return false
+			}, 60*time.Second, 2*time.Second).Should(BeTrue(),
+				"Workload should reach running state before deletion")
+
 			By("Step 4: Deleting workload")
 			delResp := deleteWorkloadAsync(apiServer, workloadName)
 			delResp.Body.Close()


### PR DESCRIPTION
## Summary

- The workload lifecycle E2E test (`should track workload through create-list-delete lifecycle`) intermittently times out on main — 12/147 runs (8.2% failure rate), always at 120s
- Root cause: the test deletes the workload before the proxy-runner finishes setting status to "running". The proxy-runner then overwrites the "removing" status back to "running", causing the delete verification poll to never complete
- Add a "wait for running" poll between the list verification and delete steps, matching the pattern used by the stable "delete running workload" test

## Type of change

- [x] Bug fix

## Test plan

- [x] Linting (`task lint-fix`)
- [x] Manual testing (describe below)

Verified the fix compiles. The flake requires CI to reproduce — this PR should reduce the `api-workloads` E2E failure rate from ~8% to near zero for this test.

## Special notes for reviewers

The underlying production race (proxy-runner can overwrite "removing" status with "running" during concurrent delete + startup) is a separate issue worth tracking. This PR only fixes the test-side trigger.

Generated with [Claude Code](https://claude.com/claude-code)