### PR TITLE
Add deflake skill for finding and fixing flaky tests

### DIFF
--- a/.claude/skills/deflake/SKILL.md
+++ b/.claude/skills/deflake/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: deflake
+description: Finds flaky tests on the main branch by analyzing GitHub Actions failures, ranks them by frequency, and enters parallel plan mode to design deflake strategies. Use when you want to find and fix the flakiest tests.
+---
+
+# Deflake Tests
+
+Discovers, ranks, and plans fixes for flaky tests by analyzing GitHub Actions failures on `main`.
+
+## Arguments
+
+```
+/deflake                    # Full analysis: discover, rank, and plan fixes
+/deflake --report           # Report only: show flake rankings without planning fixes
+/deflake --top N            # Analyze and plan fixes for the top N flakes (default: 3)
+```
+
+---
+
+## Phase 1: Collect and Rank Flakes
+
+Run the collection script. It handles all deterministic data collection and aggregation. If CI log formats change over time, update the script directly.
+
+```bash
+python3 .claude/skills/deflake/collect-flakes.py
+```
+
+The script outputs three sections:
+1. **FLAKE REPORT** — overall stats (total runs, failure rate, date range)
+2. **RANKED FAILURES** — table sorted by failure count with job, mode, and test name
+3. **FAILURE DETAILS** — per-test breakdown with links to each failed run
+
+### Phase 1 complete
+
+Read the script output and use it directly for the report. The LLM's only job in this phase is to **categorize** each entry as a flake, real bug, or infra issue:
+
+- **Flake**: Appears multiple times intermittently, interspersed with successful runs
+- **Real bug**: Appeared after a specific commit and every run after that failed until a fix landed. Check `git log` for related fixes
+- **Infra flake**: Entries tagged `[INFRA]` by the script, or failures with mode `connection refused` / `infra`
+
+---
+
+## Phase 2: Present the Report
+
+Present the script output as a formatted report. Add categorization (flake / real bug / infra) to each entry. Example format:
+
+```markdown
+## Flake Report — main branch
+
+**Period**: 2026-04-01 to 2026-04-10
+**Runs analyzed**: 23 total, 8 failed (35% failure rate)
+
+### Top Flaky Tests
+
+| Rank | Test | Job | Failures | Failure Mode |
+|------|------|-----|----------|--------------|
+| 1 | Workload lifecycle ... [It] should track ... | E2E (api-workloads) | 5/23 | timeout (120s) |
+| 2 | ... | ... | ... | ... |
+
+### Real Bugs (not flakes)
+- [Test name] — Introduced by [commit], fixed by [commit/PR]
+
+### Infra Failures
+- [N] runs failed due to [description]
+```
+
+If the user passed `--report`, stop here. Otherwise continue to Phase 3.
+
+---
+
+## Phase 3: Plan Deflake Fixes
+
+### 3.1 Parallel Investigation
+
+For the top N flakes (default 3), launch **parallel agents** to investigate each one simultaneously.
+
+For each flake, spawn an Agent (subagent_type: `general-purpose`) that:
+
+1. **Reads the test code**: Find the test file, understand what it does and what behavior it's verifying
+2. **Reads the production code**: Read all the production code that the test exercises — handlers, services, middleware, etc. Understand the code path end-to-end
+3. **Maps test coverage for this feature**: Search the entire repo for all tests that cover this same feature or code path. Don't assume test locations — grep for the feature name, function names, and related keywords across the whole codebase. Tests may live in `_test.go` files alongside prod code, in `e2e/`, in `acceptance_test` files, or elsewhere. For each test found, document what it covers, what level it operates at (unit/integration/E2E), and whether it's stable or also flaky
+4. **Reads the failure logs**: Get 2-3 example failure logs from different runs
+5. **Identifies the root cause**: Why does this test fail intermittently?
+   - Timing-dependent (hardcoded sleeps, tight timeouts)?
+   - Resource contention (port conflicts, shared state)?
+   - Ordering dependency (relies on another test's side effects)?
+   - External dependency (network call, container pull)?
+   - Race condition (concurrent access, missing synchronization)?
+6. **Proposes a fix strategy**: Following the deflake principles below, informed by the full picture of prod code and existing test coverage
+
+**IMPORTANT**: Launch all agents in a single message so they run in parallel.
+
+Wait for all agents to complete, then consolidate findings.
+
+### 3.2 Present Deflake Plans
+
+For each flake, present a high-level plan with alternatives considered:
+
+```markdown
+### Flake #N: [Test Name]
+
+**Root cause**: [one-sentence explanation]
+**Failure logs**: [links to 2-3 example runs]
+
+**Options considered**:
+1. [Option A] — [why it was rejected or chosen]
+2. [Option B] — [why it was rejected or chosen]
+3. [Option C] — [why it was rejected or chosen]
+
+**Recommended approach**: [which option and why it's the best fit]
+- [High-level description of the changes]
+
+**Confidence**: High / Medium / Low
+**Risk**: [What could go wrong with this approach]
+```
+
+Present all plans and wait for user feedback. The user may choose a different option, combine approaches, or ask for more investigation. Do NOT enter plan mode or start implementing until the user approves the approach for each flake.
+
+### 3.3 Implement Approved Fixes
+
+Once the user approves approaches, enter plan mode to design the detailed implementation. The plan should:
+
+- Group related fixes (e.g., if multiple tests share the same root cause)
+- Order by impact (fix the flake that fails most often first)
+- Each fix should be its own commit for easy revert
+
+---
+
+## Deflake Principles
+
+These principles guide all fix proposals. **Prefer simplifying code and tests over adding complexity.**
+
+### Prefer removal over addition
+- Delete flaky tests only if they're duplicative with other **stable tests at the same level**
+- If multiple E2E tests cover fine-grained behavior for one feature, move the fine-grained cases to unit tests and keep a single E2E smoke test
+- Never remove **all** E2E coverage for a feature — at least one smoke test must remain
+- Remove unnecessary setup/teardown that introduces timing sensitivity
+
+### Fix the test, not the production code
+- If flakiness exposes a real bug, fix the production code
+- Do NOT add complexity to production code just to make a flaky test pass (retry logic, test-only hooks, feature flags)
+- Ask: what's the intention of this test? Can we capture it in a more reliable form?
+
+### Fix options
+- **Delete the test** if redundant (keeping at least one E2E smoke test per feature)
+- **Rewrite as a unit test** if the behavior can be tested without integration
+- **Refactor hard-to-test code** so the behavior under test can be easily isolated and reliably examined
+- **Reduce scope** — test one thing instead of a full lifecycle
+- **Use polling with short intervals** instead of fixed sleeps (e.g., `Eventually` with 1s poll interval)
+- **Increase timeouts** — only as a last resort, and only for `Eventually`/`Consistently` matchers, not arbitrary `time.Sleep`
+
+### Anti-patterns to avoid
+- Adding `time.Sleep()` to "fix" timing issues
+- Adding retry loops around flaky assertions
+- Marking tests as `[Flaky]` or `Skip` without fixing them
+- Adding production code complexity (feature flags, test modes) to make tests pass
+- Increasing parallelism limits or resource requests as a band-aid

--- a/.claude/skills/deflake/collect-flakes.py
+++ b/.claude/skills/deflake/collect-flakes.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Collect and rank flaky tests from GitHub Actions on main."""
+
+import json
+import re
+import subprocess
+import sys
+from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+REPO = "stacklok/toolhive"
+WORKFLOW_NAME = "Main build"
+PER_PAGE = 100
+MAX_PAGES = 3  # Up to 300 runs; increase if needed
+
+
+def gh_api(endpoint):
+    """Call gh api and return parsed JSON."""
+    result = subprocess.run(
+        ["gh", "api", endpoint],
+        capture_output=True, text=True, check=True,
+    )
+    return json.loads(result.stdout)
+
+
+def fetch_all_runs():
+    """Fetch workflow runs across multiple pages."""
+    all_runs = []
+    for page in range(1, MAX_PAGES + 1):
+        data = gh_api(
+            f"repos/{REPO}/actions/runs?branch=main&event=push"
+            f"&per_page={PER_PAGE}&page={page}"
+        )
+        runs = [r for r in data["workflow_runs"] if r["name"] == WORKFLOW_NAME]
+        all_runs.extend(runs)
+        if len(data["workflow_runs"]) < PER_PAGE:
+            break  # No more pages
+        print(f"Fetched page {page}: {len(runs)} Main build runs", file=sys.stderr)
+    return all_runs
+
+
+def get_failed_logs(run_id):
+    """Get failed job logs for a run."""
+    result = subprocess.run(
+        ["gh", "run", "view", str(run_id), "--repo", REPO, "--log-failed"],
+        capture_output=True, text=True,
+    )
+    return result.stdout + result.stderr
+
+
+def strip_ansi(text):
+    """Remove ANSI escape sequences."""
+    return re.sub(r'\x1b\[[0-9;]*m', '', text)
+
+
+def extract_ginkgo_failures(log_lines):
+    """Extract Ginkgo test names from [FAIL] lines."""
+    failures = []
+    for line in log_lines:
+        if '[FAIL]' not in line:
+            continue
+        clean = strip_ansi(line)
+        # Also strip literal ANSI-like codes that gh outputs as text
+        clean = re.sub(r'\[\d+;\d+m', '', clean)
+        clean = re.sub(r'\[0m', '', clean)
+        match = re.search(r'\[FAIL\]\s+(.*?\[It\]\s+[^\[]+)', clean)
+        if match:
+            test_name = match.group(1).strip()
+            failures.append(test_name)
+    return failures
+
+
+def extract_unit_test_failures(log_lines):
+    """Extract Go unit test names from ❌ lines."""
+    failures = []
+    for line in log_lines:
+        if '❌' not in line:
+            continue
+        clean = strip_ansi(line)
+        clean = re.sub(r'\[\d+;\d+m', '', clean)
+        clean = re.sub(r'\[0m', '', clean)
+        match = re.search(r'❌\s+(\S+)', clean)
+        if match:
+            test_name = match.group(1).strip()
+            failures.append(test_name)
+    return failures
+
+
+def extract_job_name(line):
+    """Extract job name from log line prefix."""
+    match = re.match(r'^(.+?)\t', line)
+    return match.group(1).strip() if match else "unknown"
+
+
+def extract_failure_mode(log_text):
+    """Determine failure mode from log content."""
+    clean = strip_ansi(log_text)
+    if re.search(r'Timed out after [\d.]+s', clean):
+        match = re.search(r'Timed out after ([\d.]+)s', clean)
+        return f"timeout ({match.group(1)}s)" if match else "timeout"
+    if 'Expected' in clean and 'to equal' in clean:
+        return "assertion"
+    if 'panic:' in clean:
+        return "panic"
+    if 'connection refused' in clean.lower():
+        return "connection refused"
+    if 'Server should be running' in clean:
+        return "server startup timeout"
+    return "assertion"
+
+
+def main():
+    # Fetch all recent runs on main (paginated)
+    all_runs = fetch_all_runs()
+    failed_runs = [r for r in all_runs if r["conclusion"] == "failure"]
+    success_runs = [r for r in all_runs if r["conclusion"] == "success"]
+
+    total = len(all_runs)
+    num_failed = len(failed_runs)
+
+    print(f"=== FLAKE REPORT ===")
+    print(f"Total Main build runs on main: {total}")
+    print(f"Failed: {num_failed}")
+    print(f"Succeeded: {len(success_runs)}")
+    print(f"Failure rate: {num_failed/total*100:.1f}%" if total > 0 else "N/A")
+    if all_runs:
+        dates = sorted(r["created_at"][:10] for r in all_runs)
+        print(f"Period: {dates[0]} to {dates[-1]}")
+    print()
+
+    # Collect failures from each run — fetch logs in parallel
+    test_failures = defaultdict(list)  # test_name -> [{run_id, date, job, mode}]
+
+    def process_run(run):
+        """Fetch logs and extract failures for a single run."""
+        run_id = run["id"]
+        run_date = run["created_at"][:10]
+        run_title = run["display_title"]
+        print(f"Fetching logs for run {run_id} ({run_date}: {run_title[:60]})...",
+              file=sys.stderr)
+
+        log_text = get_failed_logs(run_id)
+        log_lines = log_text.splitlines()
+
+        results = []
+
+        # Extract Ginkgo failures
+        ginkgo_fails = extract_ginkgo_failures(log_lines)
+        for test_name in ginkgo_fails:
+            job = "unknown"
+            for line in log_lines:
+                if '[FAIL]' in line and test_name.split('[It]')[0].strip()[:20] in strip_ansi(line):
+                    job = extract_job_name(line)
+                    break
+            mode = extract_failure_mode(log_text)
+            results.append((test_name, {
+                "run_id": run_id, "date": run_date, "job": job, "mode": mode,
+            }))
+
+        # Extract unit test failures
+        unit_fails = extract_unit_test_failures(log_lines)
+        for test_name in unit_fails:
+            if '/' in test_name:
+                parent = test_name.split('/')[0]
+                if parent in unit_fails:
+                    continue
+            job = "unknown"
+            for line in log_lines:
+                if '❌' in line and test_name in line:
+                    job = extract_job_name(line)
+                    break
+            mode = extract_failure_mode(log_text)
+            results.append((test_name, {
+                "run_id": run_id, "date": run_date, "job": job, "mode": mode,
+            }))
+
+        # Infra-only failures
+        if not ginkgo_fails and not unit_fails:
+            results.append(("[INFRA] " + run_title[:80], {
+                "run_id": run_id, "date": run_date, "job": "infra", "mode": "infra",
+            }))
+
+        return results
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        futures = {pool.submit(process_run, run): run for run in failed_runs}
+        for future in as_completed(futures):
+            for test_name, occurrence in future.result():
+                test_failures[test_name].append(occurrence)
+
+    # Sort by failure count descending
+    ranked = sorted(test_failures.items(), key=lambda x: -len(x[1]))
+
+    # Print ranked table
+    print()
+    print("=== RANKED FAILURES ===")
+    print(f"{'Rank':<5} {'Count':<6} {'Job':<45} {'Mode':<25} {'Test'}")
+    print("-" * 140)
+    for i, (test_name, occurrences) in enumerate(ranked, 1):
+        job = occurrences[0]["job"]
+        mode = occurrences[0]["mode"]
+        count = len(occurrences)
+        print(f"{i:<5} {count:<6} {job:<45} {mode:<25} {test_name}")
+
+    # Print details per failure
+    print()
+    print("=== FAILURE DETAILS ===")
+    for test_name, occurrences in ranked:
+        print(f"\n## {test_name}")
+        print(f"   Failures: {len(occurrences)}/{total} runs")
+        for occ in occurrences:
+            url = f"https://github.com/{REPO}/actions/runs/{occ['run_id']}"
+            print(f"   - {occ['date']} | {occ['mode']} | {occ['job']} | {url}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/deflake/collect-flakes.py
+++ b/.claude/skills/deflake/collect-flakes.py
@@ -95,18 +95,54 @@ def extract_job_name(line):
 def extract_failure_mode(log_text):
     """Determine failure mode from log content."""
     clean = strip_ansi(log_text)
+    # Also strip literal ANSI-like codes
+    clean = re.sub(r'\[\d+;\d+m', '', clean)
+    clean = re.sub(r'\[0m', '', clean)
     if re.search(r'Timed out after [\d.]+s', clean):
         match = re.search(r'Timed out after ([\d.]+)s', clean)
         return f"timeout ({match.group(1)}s)" if match else "timeout"
-    if 'Expected' in clean and 'to equal' in clean:
-        return "assertion"
+    if 'Server should be running' in clean:
+        return "server startup timeout"
     if 'panic:' in clean:
         return "panic"
     if 'connection refused' in clean.lower():
         return "connection refused"
-    if 'Server should be running' in clean:
-        return "server startup timeout"
+    if 'Expected' in clean and 'to equal' in clean:
+        return "assertion"
     return "assertion"
+
+
+def find_failure_context(log_lines, test_name, fail_line_idx):
+    """Find the [FAILED] block associated with a test near its [FAIL] summary line.
+
+    Ginkgo logs have two relevant markers:
+    - [FAILED] with the failure reason (e.g., "Timed out after 120s") — appears
+      in the failure block, potentially thousands of lines before the summary
+    - [FAIL] with the test name — appears in the summary section at the end
+
+    Search backwards from the [FAIL] line for the nearest [FAILED] block that
+    belongs to this test, then extract context around it.
+    """
+    # Search backwards from the fail summary line for [FAILED].
+    # Ginkgo emits multiple [FAILED] lines per test failure — the first has
+    # the reason (e.g., "Timed out after 120s"), later ones are summaries.
+    # Collect all [FAILED] lines in the block and return context around them.
+    search_start = max(0, fail_line_idx - 5000)
+    failed_lines = []
+    for i in range(fail_line_idx, search_start, -1):
+        clean_line = strip_ansi(log_lines[i])
+        if '[FAILED]' in clean_line:
+            failed_lines.append(i)
+    if failed_lines:
+        # Use the earliest (first) [FAILED] line — it has the failure reason
+        earliest = min(failed_lines)
+        latest = max(failed_lines)
+        start = max(0, earliest - 5)
+        end = min(len(log_lines), latest + 5)
+        return "\n".join(log_lines[start:end])
+    # Fallback: use lines around the [FAIL] summary
+    start = max(0, fail_line_idx - 50)
+    return "\n".join(log_lines[start:fail_line_idx + 1])
 
 
 def main():
@@ -154,10 +190,9 @@ def main():
                     job = extract_job_name(line)
                     fail_line_idx = i
                     break
-            # Extract per-test log context (50 lines before the [FAIL] line)
+            # Find the [FAILED] block for this test to get accurate failure mode
             if fail_line_idx is not None:
-                start = max(0, fail_line_idx - 50)
-                test_log = "\n".join(log_lines[start:fail_line_idx + 1])
+                test_log = find_failure_context(log_lines, test_name, fail_line_idx)
             else:
                 test_log = log_text
             mode = extract_failure_mode(test_log)

--- a/.claude/skills/deflake/collect-flakes.py
+++ b/.claude/skills/deflake/collect-flakes.py
@@ -11,7 +11,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 REPO = "stacklok/toolhive"
 WORKFLOW_NAME = "Main build"
 PER_PAGE = 100
-MAX_PAGES = 3  # Up to 300 runs; increase if needed
+MAX_PAGES = 3  # Pages of all push-triggered workflow runs (not just Main build)
 
 
 def gh_api(endpoint):
@@ -148,11 +148,19 @@ def main():
         ginkgo_fails = extract_ginkgo_failures(log_lines)
         for test_name in ginkgo_fails:
             job = "unknown"
-            for line in log_lines:
+            fail_line_idx = None
+            for i, line in enumerate(log_lines):
                 if '[FAIL]' in line and test_name.split('[It]')[0].strip()[:20] in strip_ansi(line):
                     job = extract_job_name(line)
+                    fail_line_idx = i
                     break
-            mode = extract_failure_mode(log_text)
+            # Extract per-test log context (50 lines before the [FAIL] line)
+            if fail_line_idx is not None:
+                start = max(0, fail_line_idx - 50)
+                test_log = "\n".join(log_lines[start:fail_line_idx + 1])
+            else:
+                test_log = log_text
+            mode = extract_failure_mode(test_log)
             results.append((test_name, {
                 "run_id": run_id, "date": run_date, "job": job, "mode": mode,
             }))
@@ -165,11 +173,19 @@ def main():
                 if parent in unit_fails:
                     continue
             job = "unknown"
-            for line in log_lines:
+            fail_line_idx = None
+            for i, line in enumerate(log_lines):
                 if '❌' in line and test_name in line:
                     job = extract_job_name(line)
+                    fail_line_idx = i
                     break
-            mode = extract_failure_mode(log_text)
+            # Extract per-test log context (50 lines before the ❌ line)
+            if fail_line_idx is not None:
+                start = max(0, fail_line_idx - 50)
+                test_log = "\n".join(log_lines[start:fail_line_idx + 1])
+            else:
+                test_log = log_text
+            mode = extract_failure_mode(test_log)
             results.append((test_name, {
                 "run_id": run_id, "date": run_date, "job": job, "mode": mode,
             }))
@@ -185,8 +201,13 @@ def main():
     with ThreadPoolExecutor(max_workers=8) as pool:
         futures = {pool.submit(process_run, run): run for run in failed_runs}
         for future in as_completed(futures):
-            for test_name, occurrence in future.result():
-                test_failures[test_name].append(occurrence)
+            run = futures[future]
+            try:
+                for test_name, occurrence in future.result():
+                    test_failures[test_name].append(occurrence)
+            except Exception as e:
+                print(f"Warning: failed to process run {run['id']}: {e}",
+                      file=sys.stderr)
 
     # Sort by failure count descending
     ranked = sorted(test_failures.items(), key=lambda x: -len(x[1]))


### PR DESCRIPTION
## Summary

- Main branch has a 40% CI failure rate — roughly 2 in 5 pushes fail due to flaky tests
- Adds a `/deflake` skill that systematically discovers, ranks, and plans fixes for flaky tests by analyzing GitHub Actions failures on main
- Includes a Python collection script (`collect-flakes.py`) that deterministically fetches failed run logs in parallel, extracts test names from Ginkgo and gotestfmt output, and produces a ranked flake report
- Used this skill to identify and fix the top flake in #4745

## Type of change

- [x] New feature

## Test plan

- [x] Manual testing (describe below)

Ran `/deflake --report` end-to-end: the script analyzed 147 runs across 3 API pages, identified 33 distinct failing tests, and produced a ranked report with categorization (flake vs real bug vs infra). Then used the skill's Phase 3 to investigate the top flake and produce a fix (#4745).

## Does this introduce a user-facing change?

No — this is a Claude Code skill for developer workflow, not a user-facing feature.

Generated with [Claude Code](https://claude.com/claude-code)