### PR TITLE
Fix stale config in registry routes and WorkloadService

### DIFF
--- a/pkg/api/v1/registry.go
+++ b/pkg/api/v1/registry.go
@@ -285,9 +285,10 @@ type RegistryRoutes struct {
 
 // NewRegistryRoutes creates a new RegistryRoutes with the default config provider
 func NewRegistryRoutes() *RegistryRoutes {
+	p := config.NewProvider()
 	return &RegistryRoutes{
-		configProvider: config.NewProvider(),
-		configService:  regpkg.NewConfigurator(),
+		configProvider: p,
+		configService:  regpkg.NewConfiguratorWithProvider(p),
 	}
 }
 
@@ -303,9 +304,10 @@ func NewRegistryRoutesWithProvider(provider config.Provider) *RegistryRoutes {
 // NewRegistryRoutesForServe creates RegistryRoutes configured for serve mode.
 // In serve mode, the registry provider uses non-interactive auth (no browser OAuth).
 func NewRegistryRoutesForServe() *RegistryRoutes {
+	p := config.NewProvider()
 	return &RegistryRoutes{
-		configProvider: config.NewProvider(),
-		configService:  regpkg.NewConfigurator(),
+		configProvider: p,
+		configService:  regpkg.NewConfiguratorWithProvider(p),
 		serveMode:      true,
 	}
 }

--- a/pkg/api/v1/registry_factory_test.go
+++ b/pkg/api/v1/registry_factory_test.go
@@ -199,3 +199,91 @@ func TestNewRegistryRoutesForServe_NoFactory_ReturnsValidRoutes(t *testing.T) {
 	assert.NotNil(t, routes.configService, "configService must be initialised")
 	assert.True(t, routes.serveMode, "serveMode must be true for NewRegistryRoutesForServe")
 }
+
+// TestNewRegistryRoutes_ConfigServiceAndProviderAreConsistent verifies that
+// configService (which drives the type/source fields) and getCurrentProvider
+// (which drives the server list) both draw from the same config provider instance.
+// Before the fix, configService used config.NewDefaultProvider() independently,
+// causing type/source to reflect local config while the server list could reflect
+// a factory-backed config (or vice versa) — inconsistency within a single response.
+//
+//nolint:paralleltest // Mutates global state: config.registeredFactory and regpkg.defaultProviderOnce
+func TestNewRegistryRoutes_ConfigServiceAndProviderAreConsistent(t *testing.T) {
+	const sentinelName = "consistency-sentinel-server"
+
+	configPath := writeFactorySentinelRegistry(t, sentinelName)
+
+	config.RegisterProviderFactory(func() config.Provider {
+		return config.NewPathProvider(configPath)
+	})
+	t.Cleanup(func() {
+		config.RegisterProviderFactory(nil)
+		registry.ResetDefaultProvider()
+	})
+
+	routes := NewRegistryRoutes()
+	registry.ResetDefaultProvider()
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/registry", nil)
+	routes.listRegistries(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code, "listRegistries should return 200")
+
+	var body registryListResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&body), "response body should be valid JSON")
+	require.Len(t, body.Registries, 1, "should return exactly one registry")
+
+	reg := body.Registries[0]
+	// configService reads Type/Source from the shared provider. On the old code,
+	// configService used config.NewDefaultProvider() which bypassed the factory,
+	// so Type would be "default" and Source would be "" even when a factory was set.
+	assert.Equal(t, RegistryTypeFile, reg.Type,
+		"Type must be 'file' — proves configService uses the factory-backed provider, not an independent one")
+	assert.NotEmpty(t, reg.Source,
+		"Source must be non-empty for a file registry — proves configService reads from the shared provider")
+
+	// getCurrentProvider also uses the shared provider, so it loads servers from the same registry.
+	// ServerCount > 0 proves both data sources are in sync.
+	assert.Greater(t, reg.ServerCount, 0,
+		"ServerCount must be > 0 — proves getCurrentProvider uses the same factory-backed provider as configService")
+}
+
+// TestNewRegistryRoutesForServe_ConfigServiceAndProviderAreConsistent is the
+// serve-mode equivalent of TestNewRegistryRoutes_ConfigServiceAndProviderAreConsistent.
+//
+//nolint:paralleltest // Mutates global state: config.registeredFactory and regpkg.defaultProviderOnce
+func TestNewRegistryRoutesForServe_ConfigServiceAndProviderAreConsistent(t *testing.T) {
+	const sentinelName = "consistency-sentinel-server"
+
+	configPath := writeFactorySentinelRegistry(t, sentinelName)
+
+	config.RegisterProviderFactory(func() config.Provider {
+		return config.NewPathProvider(configPath)
+	})
+	t.Cleanup(func() {
+		config.RegisterProviderFactory(nil)
+		registry.ResetDefaultProvider()
+	})
+
+	routes := NewRegistryRoutesForServe()
+	registry.ResetDefaultProvider()
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/registry", nil)
+	routes.listRegistries(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code, "listRegistries should return 200 in serve mode")
+
+	var body registryListResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&body), "response body should be valid JSON")
+	require.Len(t, body.Registries, 1, "should return exactly one registry")
+
+	reg := body.Registries[0]
+	assert.Equal(t, RegistryTypeFile, reg.Type,
+		"Type must be 'file' in serve mode — proves configService uses the factory-backed provider")
+	assert.NotEmpty(t, reg.Source,
+		"Source must be non-empty for a file registry in serve mode")
+	assert.Greater(t, reg.ServerCount, 0,
+		"ServerCount must be > 0 in serve mode — proves getCurrentProvider uses the same factory-backed provider as configService")
+}

--- a/pkg/api/v1/workload_service.go
+++ b/pkg/api/v1/workload_service.go
@@ -79,7 +79,7 @@ func NewWorkloadService(
 		debugMode:        debugMode,
 		imageRetriever:   retriever.ResolveMCPServer,
 		imagePuller:      retriever.PullMCPServerImage,
-		configProvider:   config.NewDefaultProvider(),
+		configProvider:   config.NewProvider(),
 	}
 }
 
@@ -278,9 +278,12 @@ func (s *WorkloadService) BuildFullRunConfig(
 		}
 	}
 
+	// Snapshot config once for this request so all fields within a single BuildFullRunConfig
+	// call are consistent with each other, even if a concurrent registry update fires mid-call.
+	cfg := s.configProvider.GetConfig()
+
 	// Resolve registry source URLs and server name when the server was discovered via registry lookup.
-	// Read config fresh each time so enterprise registry changes take effect without a restart.
-	regAPIURL, regURL := runner.ResolveRegistrySourceURLs(serverMetadata, s.configProvider.GetConfig())
+	regAPIURL, regURL := runner.ResolveRegistrySourceURLs(serverMetadata, cfg)
 	regServerName := runner.ResolveRegistryServerName(serverMetadata)
 
 	options := []runner.RunConfigBuilderOption{
@@ -362,7 +365,7 @@ func (s *WorkloadService) BuildFullRunConfig(
 			"",
 			req.Name,
 			transportType,
-			s.configProvider.GetConfig().DisableUsageMetrics,
+			cfg.DisableUsageMetrics,
 		),
 	)
 

--- a/pkg/api/v1/workload_service.go
+++ b/pkg/api/v1/workload_service.go
@@ -62,7 +62,7 @@ type WorkloadService struct {
 	debugMode        bool
 	imageRetriever   retriever.Retriever
 	imagePuller      retriever.ImagePuller
-	appConfig        *config.Config
+	configProvider   config.Provider
 }
 
 // NewWorkloadService creates a new WorkloadService instance
@@ -72,10 +72,6 @@ func NewWorkloadService(
 	containerRuntime runtime.Runtime,
 	debugMode bool,
 ) *WorkloadService {
-	// Load application config for global settings
-	configProvider := config.NewDefaultProvider()
-	appConfig := configProvider.GetConfig()
-
 	return &WorkloadService{
 		workloadManager:  workloadManager,
 		groupManager:     groupManager,
@@ -83,7 +79,7 @@ func NewWorkloadService(
 		debugMode:        debugMode,
 		imageRetriever:   retriever.ResolveMCPServer,
 		imagePuller:      retriever.PullMCPServerImage,
-		appConfig:        appConfig,
+		configProvider:   config.NewDefaultProvider(),
 	}
 }
 
@@ -283,7 +279,8 @@ func (s *WorkloadService) BuildFullRunConfig(
 	}
 
 	// Resolve registry source URLs and server name when the server was discovered via registry lookup.
-	regAPIURL, regURL := runner.ResolveRegistrySourceURLs(serverMetadata, s.appConfig)
+	// Read config fresh each time so enterprise registry changes take effect without a restart.
+	regAPIURL, regURL := runner.ResolveRegistrySourceURLs(serverMetadata, s.configProvider.GetConfig())
 	regServerName := runner.ResolveRegistryServerName(serverMetadata)
 
 	options := []runner.RunConfigBuilderOption{
@@ -365,7 +362,7 @@ func (s *WorkloadService) BuildFullRunConfig(
 			"",
 			req.Name,
 			transportType,
-			s.appConfig.DisableUsageMetrics,
+			s.configProvider.GetConfig().DisableUsageMetrics,
 		),
 	)
 

--- a/pkg/api/v1/workload_service_test.go
+++ b/pkg/api/v1/workload_service_test.go
@@ -24,7 +24,7 @@ func TestWorkloadService_GetWorkloadNamesFromRequest(t *testing.T) {
 	t.Run("with names", func(t *testing.T) {
 		t.Parallel()
 
-		service := &WorkloadService{appConfig: &config.Config{}}
+		service := &WorkloadService{configProvider: config.NewDefaultProvider()}
 
 		req := bulkOperationRequest{
 			Names: []string{"workload1", "workload2"},
@@ -55,7 +55,7 @@ func TestWorkloadService_GetWorkloadNamesFromRequest(t *testing.T) {
 		service := &WorkloadService{
 			groupManager:    mockGroupManager,
 			workloadManager: mockWorkloadManager,
-			appConfig:       &config.Config{},
+			configProvider:  config.NewDefaultProvider(),
 		}
 
 		req := bulkOperationRequest{
@@ -71,7 +71,7 @@ func TestWorkloadService_GetWorkloadNamesFromRequest(t *testing.T) {
 	t.Run("invalid group name", func(t *testing.T) {
 		t.Parallel()
 
-		service := &WorkloadService{appConfig: &config.Config{}}
+		service := &WorkloadService{configProvider: config.NewDefaultProvider()}
 
 		req := bulkOperationRequest{
 			Group: "invalid-group-name-with-special-chars!@#",
@@ -96,8 +96,8 @@ func TestWorkloadService_GetWorkloadNamesFromRequest(t *testing.T) {
 			Return(false, nil)
 
 		service := &WorkloadService{
-			groupManager: mockGroupManager,
-			appConfig:    &config.Config{},
+			groupManager:   mockGroupManager,
+			configProvider: config.NewDefaultProvider(),
 		}
 
 		req := bulkOperationRequest{
@@ -130,7 +130,7 @@ func TestWorkloadService_GetWorkloadNamesFromRequest(t *testing.T) {
 		service := &WorkloadService{
 			groupManager:    mockGroupManager,
 			workloadManager: mockWorkloadManager,
-			appConfig:       &config.Config{},
+			configProvider:  config.NewDefaultProvider(),
 		}
 
 		req := bulkOperationRequest{
@@ -150,6 +150,10 @@ func TestNewWorkloadService(t *testing.T) {
 
 	service := NewWorkloadService(nil, nil, nil, false)
 	require.NotNil(t, service)
+	// configProvider must be set so GetConfig() is called at point-of-use,
+	// not cached once at startup (fixes stale enterprise registry URL bug).
+	assert.NotNil(t, service.configProvider,
+		"configProvider must be initialized so config is read fresh on each call, not snapshotted at construction")
 }
 
 func TestRuntimeConfigFromRequest(t *testing.T) {

--- a/pkg/api/v1/workload_service_test.go
+++ b/pkg/api/v1/workload_service_test.go
@@ -6,6 +6,7 @@ package v1
 import (
 	"context"
 	"errors"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -150,10 +151,38 @@ func TestNewWorkloadService(t *testing.T) {
 
 	service := NewWorkloadService(nil, nil, nil, false)
 	require.NotNil(t, service)
-	// configProvider must be set so GetConfig() is called at point-of-use,
-	// not cached once at startup (fixes stale enterprise registry URL bug).
 	assert.NotNil(t, service.configProvider,
 		"configProvider must be initialized so config is read fresh on each call, not snapshotted at construction")
+}
+
+// writeFactorySentinelConfig writes a YAML config file with DisableUsageMetrics: true
+// as a sentinel value and returns its path.
+func writeFactorySentinelConfig(t *testing.T, dir string) string {
+	t.Helper()
+	configPath := dir + "/config.yaml"
+	require.NoError(t, os.WriteFile(configPath, []byte("disable_usage_metrics: true\n"), 0600))
+	return configPath
+}
+
+// TestNewWorkloadService_RespectsRegisteredFactory verifies that NewWorkloadService
+// uses config.NewProvider() (which checks the registered ProviderFactory) rather than
+// config.NewDefaultProvider() (which always uses the default XDG path and bypasses factories).
+//
+//nolint:paralleltest // Mutates global state: config.registeredFactory
+func TestNewWorkloadService_RespectsRegisteredFactory(t *testing.T) {
+	configPath := writeFactorySentinelConfig(t, t.TempDir())
+
+	config.RegisterProviderFactory(func() config.Provider {
+		return config.NewPathProvider(configPath)
+	})
+	t.Cleanup(func() { config.RegisterProviderFactory(nil) })
+
+	service := NewWorkloadService(nil, nil, nil, false)
+	require.NotNil(t, service)
+
+	cfg := service.configProvider.GetConfig()
+	assert.True(t, cfg.DisableUsageMetrics,
+		"configProvider must use the factory-backed provider — DisableUsageMetrics is the sentinel set by the factory config")
 }
 
 func TestRuntimeConfigFromRequest(t *testing.T) {

--- a/pkg/api/v1/workloads_test.go
+++ b/pkg/api/v1/workloads_test.go
@@ -283,7 +283,7 @@ func TestCreateWorkload(t *testing.T) {
 					workloadManager: mockWorkloadManager,
 					imageRetriever:  mockRetriever,
 					imagePuller:     func(_ context.Context, _ string) error { return nil },
-					appConfig:       &config.Config{},
+					configProvider:  config.NewDefaultProvider(),
 				},
 			}
 
@@ -505,7 +505,7 @@ func TestUpdateWorkload(t *testing.T) {
 					workloadManager: mockWorkloadManager,
 					imageRetriever:  mockRetriever,
 					imagePuller:     func(_ context.Context, _ string) error { return nil },
-					appConfig:       &config.Config{},
+					configProvider:  config.NewDefaultProvider(),
 				},
 			}
 
@@ -651,7 +651,7 @@ func TestUpdateWorkload_PortReuse(t *testing.T) {
 					containerRuntime: mockRuntime,
 					imageRetriever:   mockRetriever,
 					imagePuller:      func(_ context.Context, _ string) error { return nil },
-					appConfig:        &config.Config{},
+					configProvider:   config.NewDefaultProvider(),
 				},
 			}
 


### PR DESCRIPTION
## Summary

Two independent config caches caused inconsistent state after a registry configuration change.

- **Bug 1 (registry.go)**: `NewRegistryRoutes` and `NewRegistryRoutesForServe` created independent `config.Provider` instances for `configProvider` and `configService`. The `getRegistry`/`listRegistries` responses mixed live metadata from `configService.GetRegistryInfo()` (type/source) with the server list from `getCurrentProvider()` — two separate providers that could reflect different config states. Fix: allocate one `p := config.NewProvider()` and pass it to both, so the response is always internally consistent.

- **Bug 2 (workload_service.go)**: `WorkloadService.appConfig` was a one-time startup snapshot (`*config.Config`). After a registry configuration change, workloads created in the same process lifetime got stale registry URLs baked into their persisted `RunConfig`. Fix: store a `config.Provider` and call `GetConfig()` at the point of use inside `BuildFullRunConfig`.

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)

New tests added:
- `TestNewRegistryRoutes_ConfigServiceAndProviderAreConsistent`: calls `listRegistries` with a factory-backed local registry and asserts that both `Type` (from `configService`) and `ServerCount > 0` (from `getCurrentProvider`) reflect the same config source.
- `TestNewRegistryRoutesForServe_ConfigServiceAndProviderAreConsistent`: same for serve mode.
- `TestNewWorkloadService` extended: asserts `configProvider != nil` so the live-read contract is enforced.

## Changes

| File | Change |
|------|--------|
| `pkg/api/v1/registry.go` | Share single `config.Provider` between `configProvider` and `configService` in both constructors |
| `pkg/api/v1/workload_service.go` | Replace `appConfig *config.Config` snapshot with `configProvider config.Provider`; call `GetConfig()` at point of use |
| `pkg/api/v1/registry_factory_test.go` | Add consistency tests verifying shared provider across `configService` and `getCurrentProvider` |
| `pkg/api/v1/workload_service_test.go` | Update field name; assert `configProvider != nil` in `TestNewWorkloadService` |
| `pkg/api/v1/workloads_test.go` | Update field name from `appConfig` to `configProvider` |

## Does this introduce a user-facing change?

No. The fixes are internal — they eliminate stale state that caused the `/registry` response to be internally inconsistent and caused newly-created workloads to store outdated registry URLs in their persisted `RunConfig`.

## Special notes for reviewers

The pre-existing failure in `TestUpdateWorkload_PortReuse/Edit_with_explicit_port_should_use_that_port` is unrelated to this PR and reproduces on `main` without these changes.

Generated with [Claude Code](https://claude.com/claude-code)