### PR TITLE
Enforce non-registry-server policy gate for remote URL workloads

### DIFF
--- a/cmd/thv/app/run.go
+++ b/cmd/thv/app/run.go
@@ -243,6 +243,13 @@ func runSingleServer(ctx context.Context, runFlags *RunFlags, serverOrImage stri
 		return err
 	}
 
+	// Enforce policy in the main process before saving state or spawning a
+	// detached worker, so violations surface synchronously with a non-zero
+	// exit code rather than silently failing in the background log.
+	if err := runner.EagerCheckCreateServer(ctx, runnerConfig); err != nil {
+		return fmt.Errorf("server creation blocked by policy: %w", err)
+	}
+
 	// Always save the run config to disk before starting (both foreground and detached modes)
 	// NOTE: Save before secrets processing to avoid storing secrets in the state store
 	if err := runnerConfig.SaveState(ctx); err != nil {

--- a/cmd/thv/app/run.go
+++ b/cmd/thv/app/run.go
@@ -476,6 +476,13 @@ func runFromConfigFile(ctx context.Context) error {
 		return fmt.Errorf("failed to create workload manager: %w", err)
 	}
 
+	// Enforce policy in the main process before saving state or spawning a
+	// detached worker, so violations surface synchronously with a non-zero
+	// exit code rather than silently failing in the background log.
+	if err := runner.EagerCheckCreateServer(ctx, runConfig); err != nil {
+		return fmt.Errorf("server creation blocked by policy: %w", err)
+	}
+
 	// Save the run config to disk in the usual directory (before running)
 	// This ensures that imported configs are persisted like normal runs
 	if err := runConfig.SaveState(ctx); err != nil {

--- a/pkg/api/v1/workload_service.go
+++ b/pkg/api/v1/workload_service.go
@@ -91,6 +91,13 @@ func (s *WorkloadService) CreateWorkloadFromRequest(ctx context.Context, req *cr
 		return nil, err
 	}
 
+	// Enforce policy before saving state or starting the workload, so
+	// violations are returned as API errors rather than creating the server
+	// in a broken state.
+	if err := runner.EagerCheckCreateServer(ctx, runConfig); err != nil {
+		return nil, fmt.Errorf("server creation blocked by policy: %w", err)
+	}
+
 	// Save the workload state
 	if err := runConfig.SaveState(ctx); err != nil {
 		slog.Error("failed to save workload config", "error", err)

--- a/pkg/api/v1/workload_service_test.go
+++ b/pkg/api/v1/workload_service_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stacklok/toolhive/pkg/config"
 	"github.com/stacklok/toolhive/pkg/container/templates"
 	groupsmocks "github.com/stacklok/toolhive/pkg/groups/mocks"
+	"github.com/stacklok/toolhive/pkg/runner"
 	workloadsmocks "github.com/stacklok/toolhive/pkg/workloads/mocks"
 )
 
@@ -366,4 +367,63 @@ func TestRuntimeConfigForImageBuild(t *testing.T) {
 		override.AdditionalPackages[0] = "git"
 		assert.Equal(t, expectedPackages, result.AdditionalPackages)
 	})
+}
+
+// testDenyPolicyGate is a test helper that always blocks server creation with
+// the configured error.
+type testDenyPolicyGate struct {
+	runner.NoopPolicyGate
+	err error
+}
+
+func (g *testDenyPolicyGate) CheckCreateServer(_ context.Context, _ *runner.RunConfig) error {
+	return g.err
+}
+
+// TestCreateWorkloadFromRequest_PolicyGateDenied verifies that
+// CreateWorkloadFromRequest returns an error immediately when the policy gate
+// blocks the operation, and that RunWorkloadDetached is never called.
+//
+//nolint:paralleltest // Mutates the global policy gate.
+func TestCreateWorkloadFromRequest_PolicyGateDenied(t *testing.T) {
+	sentinel := errors.New("blocked by test policy gate")
+
+	// Save and restore the global gate around the test.
+	original := runner.ActivePolicyGate()
+	runner.RegisterPolicyGate(&testDenyPolicyGate{err: sentinel})
+	t.Cleanup(func() { runner.RegisterPolicyGate(original) })
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	// The group manager must confirm the "default" group exists so that
+	// BuildFullRunConfig can reach the policy check without failing earlier.
+	mockGroupManager := groupsmocks.NewMockManager(ctrl)
+	mockGroupManager.EXPECT().
+		Exists(gomock.Any(), "default").
+		Return(true, nil)
+
+	// No RunWorkloadDetached expectation: any unexpected call will cause gomock
+	// to fail the test, verifying that the policy gate stops execution early.
+	mockWorkloadManager := workloadsmocks.NewMockManager(ctrl)
+
+	service := &WorkloadService{
+		groupManager:    mockGroupManager,
+		workloadManager: mockWorkloadManager,
+		configProvider:  config.NewDefaultProvider(),
+		// imageRetriever and imagePuller are nil because req.URL != "" means the
+		// local image pull path is skipped entirely.
+	}
+
+	req := &createRequest{
+		Name: "testserver",
+		updateRequest: updateRequest{
+			URL: "https://mcp.example.com/mcp",
+		},
+	}
+
+	_, err := service.CreateWorkloadFromRequest(context.Background(), req)
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, sentinel)
 }

--- a/pkg/mcp/server/run_server.go
+++ b/pkg/mcp/server/run_server.go
@@ -76,6 +76,15 @@ func (h *Handler) RunServer(ctx context.Context, request mcp.CallToolRequest) (*
 		return mcp.NewToolResultError(fmt.Sprintf("Failed to enforce policy or pull image: %v", err)), nil
 	}
 
+	// Enforce policy eagerly for remote registry servers. EnforcePolicyAndPullImage
+	// returns nil immediately when serverMetadata.IsRemote() == true (it has no image
+	// to pull), so CheckCreateServer is never called for that case. Call
+	// EagerCheckCreateServer here so remote registry servers are blocked before state
+	// is persisted, matching the behaviour in runSingleServer and CreateWorkloadFromRequest.
+	if err := runner.EagerCheckCreateServer(ctx, runConfig); err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Server creation blocked by policy: %v", err)), nil
+	}
+
 	// Save and run the server
 	if err := h.saveAndRunServer(ctx, runConfig, args.Name); err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("Failed to run server: %v", err)), nil

--- a/pkg/runner/policy_gate.go
+++ b/pkg/runner/policy_gate.go
@@ -56,3 +56,11 @@ func ActivePolicyGate() PolicyGate {
 	defer policyGateMu.RUnlock()
 	return policyGate
 }
+
+// EagerCheckCreateServer calls CheckCreateServer on the currently registered
+// policy gate. Callers in the CLI or API layer should call this before saving
+// state or spawning a detached worker so that policy violations surface
+// synchronously in the main process, not silently in the background.
+func EagerCheckCreateServer(ctx context.Context, cfg *RunConfig) error {
+	return ActivePolicyGate().CheckCreateServer(ctx, cfg)
+}

--- a/pkg/runner/policy_gate_test.go
+++ b/pkg/runner/policy_gate_test.go
@@ -78,6 +78,54 @@ func TestActivePolicyGate_DefaultIsAllowAll(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+// TestEagerCheckCreateServer verifies that EagerCheckCreateServer delegates to
+// the currently registered gate and surfaces the gate's result synchronously.
+//
+//nolint:paralleltest // Subtests mutate the global policy gate.
+func TestEagerCheckCreateServer(t *testing.T) {
+	sentinel := errors.New("blocked by eager test policy")
+
+	tests := []struct {
+		name    string
+		gate    PolicyGate
+		wantErr error
+	}{
+		{
+			name:    "allow: default gate permits creation",
+			gate:    allowAllGate{},
+			wantErr: nil,
+		},
+		{
+			name:    "deny: registered gate blocks creation",
+			gate:    &errorPolicyGate{err: sentinel},
+			wantErr: sentinel,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Save and restore the global gate independently for each subtest.
+			policyGateMu.Lock()
+			original := policyGate
+			policyGate = tc.gate
+			policyGateMu.Unlock()
+			t.Cleanup(func() {
+				policyGateMu.Lock()
+				policyGate = original
+				policyGateMu.Unlock()
+			})
+
+			err := EagerCheckCreateServer(context.Background(), NewRunConfig())
+
+			if tc.wantErr == nil {
+				require.NoError(t, err)
+			} else {
+				require.ErrorIs(t, err, tc.wantErr)
+			}
+		})
+	}
+}
+
 // errorPolicyGate is a test helper that always returns the configured error.
 type errorPolicyGate struct {
 	NoopPolicyGate

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -309,12 +309,12 @@ func (r *Runner) Run(ctx context.Context) error {
 	var transportOpts []transport.Option
 	var setupResult *runtime.SetupResult
 
-	if r.Config.RemoteURL == "" {
-		// Check policy gate before creating the server
-		if err := ActivePolicyGate().CheckCreateServer(ctx, r.Config); err != nil {
-			return fmt.Errorf("server creation blocked by policy: %w", err)
-		}
+	// Check policy gate before creating the server (applies to both local and remote)
+	if err := ActivePolicyGate().CheckCreateServer(ctx, r.Config); err != nil {
+		return fmt.Errorf("server creation blocked by policy: %w", err)
+	}
 
+	if r.Config.RemoteURL == "" {
 		// For local workloads, deploy the container using runtime.Setup first
 		var scalingConfig *rt.ScalingConfig
 		if r.Config.ScalingConfig != nil {


### PR DESCRIPTION
## Summary

- **Gap 1 (`runner.go`)**: The `CheckCreateServer` call was inside the `if RemoteURL == ""` block, so remote URL workloads (e.g. `thv run https://mcp.example.com/mcp`) skipped the policy gate on every run. Moved it above the branch so it applies unconditionally to both local and remote workloads.

- **Gap 2 (`policy_gate.go`)**: Added `EagerCheckCreateServer` as an exported helper that calls the active gate synchronously. CLI and API callers invoke this before saving state or spawning a detached worker, so violations surface as a non-zero exit code in the calling process — not silently in a background log.

- **Gap 3 (`run.go` / `workload_service.go`)**: Inserted `EagerCheckCreateServer` before `SaveState` and `RunWorkloadDetached`. The CLI now fails with exit 1 immediately on denial; the API returns an error before persisting anything, preventing broken-state workload entries in the UI.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test plan

- [x] Added `TestEagerCheckCreateServer` in `pkg/runner/policy_gate_test.go` — table-driven, covers allow and deny paths
- [x] Added `TestCreateWorkloadFromRequest_PolicyGateDenied` in `pkg/api/v1/workload_service_test.go` — verifies policy denial blocks execution before `RunWorkloadDetached` is called, using a mock workload manager to detect any unexpected call
- [x] All existing policy gate tests pass (`TestAllowAllGate_CheckCreateServer`, `TestNoopPolicyGate_CheckCreateServer`, `TestRegisterPolicyGate`, `TestActivePolicyGate_DefaultIsAllowAll`)
- [x] `task build` passes

Generated with [Claude Code](https://claude.com/claude-code)