### PR TITLE
Add v0.1 skills API endpoints

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -354,6 +354,7 @@ func (b *ServerBuilder) setupDefaultRoutes(r *chi.Mux) {
 		"/api/v1beta/secrets":   v1.SecretsRouter(),
 		"/api/v1beta/groups":    v1.GroupsRouter(b.groupManager, b.workloadManager, b.clientManager),
 		"/api/v1beta/skills":    v1.SkillsRouter(b.skillManager),
+		"/registry":             v1.RegistryV01SkillsRouter(),
 	}
 	for prefix, router := range standardRouters {
 		r.Mount(prefix, standardTimeout(router))

--- a/pkg/api/v1/registry_v01_skills.go
+++ b/pkg/api/v1/registry_v01_skills.go
@@ -21,19 +21,20 @@ const (
 	skillsMaxLimit     = 200
 )
 
-// RegistryV01SkillsRouter creates a router for the v0.1 skills API.
-// This provides upstream-compatible endpoints for listing and retrieving skills.
+// RegistryV01SkillsRouter creates a router for the v0.1 skills extension API.
+// Skills live under the x/dev.toolhive extension namespace, matching the
+// registry server's route structure: /registry/{name}/v0.1/x/dev.toolhive/skills
 // The {registryName} path param is currently ignored (always uses default provider).
 func RegistryV01SkillsRouter() http.Handler {
 	r := chi.NewRouter()
-	r.Route("/{registryName}/v0.1", func(r chi.Router) {
+	r.Route("/{registryName}/v0.1/x/dev.toolhive", func(r chi.Router) {
 		r.Get("/skills", listSkillsV01)
 		r.Get("/skills/{namespace}/{skillName}", getSkillV01)
 	})
 	return r
 }
 
-// listSkillsV01 handles GET /registry/{registryName}/v0.1/skills
+// listSkillsV01 handles GET /registry/{registryName}/v0.1/x/dev.toolhive/skills
 func listSkillsV01(w http.ResponseWriter, r *http.Request) {
 	provider, err := registry.GetDefaultProvider()
 	if err != nil {
@@ -82,7 +83,7 @@ func listSkillsV01(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// getSkillV01 handles GET /registry/{registryName}/v0.1/skills/{namespace}/{skillName}
+// getSkillV01 handles GET /registry/{registryName}/v0.1/x/dev.toolhive/skills/{namespace}/{skillName}
 func getSkillV01(w http.ResponseWriter, r *http.Request) {
 	namespace := chi.URLParam(r, "namespace")
 	skillName := chi.URLParam(r, "skillName")

--- a/pkg/api/v1/registry_v01_skills.go
+++ b/pkg/api/v1/registry_v01_skills.go
@@ -5,6 +5,7 @@ package v1
 
 import (
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"net/http"
 	"strconv"
@@ -13,7 +14,9 @@ import (
 	"github.com/go-chi/chi/v5"
 
 	types "github.com/stacklok/toolhive-core/registry/types"
+	"github.com/stacklok/toolhive/pkg/config"
 	"github.com/stacklok/toolhive/pkg/registry"
+	"github.com/stacklok/toolhive/pkg/registry/api"
 )
 
 const (
@@ -34,9 +37,18 @@ func RegistryV01SkillsRouter() http.Handler {
 	return r
 }
 
+// getProvider returns the default registry provider configured for non-interactive
+// (serve) mode to prevent browser-based OAuth flows from HTTP request handlers.
+func getProvider() (registry.Provider, error) {
+	return registry.GetDefaultProviderWithConfig(
+		config.NewProvider(),
+		registry.WithInteractive(false),
+	)
+}
+
 // listSkillsV01 handles GET /registry/{registryName}/v0.1/x/dev.toolhive/skills
 func listSkillsV01(w http.ResponseWriter, r *http.Request) {
-	provider, err := registry.GetDefaultProvider()
+	provider, err := getProvider()
 	if err != nil {
 		slog.Error("failed to get registry provider", "error", err)
 		http.Error(w, "Failed to get registry provider", http.StatusInternalServerError)
@@ -88,7 +100,7 @@ func getSkillV01(w http.ResponseWriter, r *http.Request) {
 	namespace := chi.URLParam(r, "namespace")
 	skillName := chi.URLParam(r, "skillName")
 
-	provider, err := registry.GetDefaultProvider()
+	provider, err := getProvider()
 	if err != nil {
 		slog.Error("failed to get registry provider", "error", err)
 		http.Error(w, "Failed to get registry provider", http.StatusInternalServerError)
@@ -97,6 +109,12 @@ func getSkillV01(w http.ResponseWriter, r *http.Request) {
 
 	skill, err := provider.GetSkill(namespace, skillName)
 	if err != nil {
+		// Map upstream 404 responses to HTTP 404
+		var httpErr *api.RegistryHTTPError
+		if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
+			http.Error(w, "Skill not found", http.StatusNotFound)
+			return
+		}
 		slog.Error("failed to get skill", "namespace", namespace, "name", skillName, "error", err)
 		http.Error(w, "Failed to get skill", http.StatusInternalServerError)
 		return
@@ -114,7 +132,7 @@ func getSkillV01(w http.ResponseWriter, r *http.Request) {
 
 func filterSkillsV01(skills []types.Skill, query string) []types.Skill {
 	q := strings.ToLower(query)
-	var result []types.Skill
+	result := make([]types.Skill, 0)
 	for _, s := range skills {
 		if strings.Contains(strings.ToLower(s.Name), q) ||
 			strings.Contains(strings.ToLower(s.Namespace), q) ||

--- a/pkg/api/v1/registry_v01_skills.go
+++ b/pkg/api/v1/registry_v01_skills.go
@@ -15,8 +15,9 @@ import (
 
 	types "github.com/stacklok/toolhive-core/registry/types"
 	"github.com/stacklok/toolhive/pkg/config"
-	"github.com/stacklok/toolhive/pkg/registry"
+	regpkg "github.com/stacklok/toolhive/pkg/registry"
 	"github.com/stacklok/toolhive/pkg/registry/api"
+	"github.com/stacklok/toolhive/pkg/registry/auth"
 )
 
 const (
@@ -37,28 +38,55 @@ func RegistryV01SkillsRouter() http.Handler {
 	return r
 }
 
-// getProvider returns the default registry provider configured for non-interactive
-// (serve) mode to prevent browser-based OAuth flows from HTTP request handlers.
-func getProvider() (registry.Provider, error) {
-	return registry.GetDefaultProviderWithConfig(
+// getSkillsProvider returns the default registry provider configured for
+// non-interactive (serve) mode to prevent browser-based OAuth flows from
+// HTTP request handlers. Returns false and writes a structured JSON error
+// response if the provider cannot be obtained.
+func getSkillsProvider(w http.ResponseWriter) (regpkg.Provider, bool) {
+	provider, err := regpkg.GetDefaultProviderWithConfig(
 		config.NewProvider(),
-		registry.WithInteractive(false),
+		regpkg.WithInteractive(false),
 	)
+	if err != nil {
+		if errors.Is(err, auth.ErrRegistryAuthRequired) {
+			writeRegistryAuthRequiredError(w)
+			return nil, false
+		}
+		var unavailableErr *regpkg.UnavailableError
+		if errors.As(err, &unavailableErr) {
+			slog.Error("upstream registry unavailable", "error", err)
+			writeRegistryUnavailableError(w, unavailableErr)
+			return nil, false
+		}
+		writeJSONError(w, http.StatusInternalServerError, "internal_error", "Failed to get registry provider")
+		slog.Error("failed to get registry provider", "error", err)
+		return nil, false
+	}
+	return provider, true
+}
+
+// writeJSONError writes a structured JSON error response matching the
+// registryErrorResponse format used by other registry endpoints.
+func writeJSONError(w http.ResponseWriter, status int, code, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(registryErrorResponse{
+		Code:    code,
+		Message: message,
+	})
 }
 
 // listSkillsV01 handles GET /registry/{registryName}/v0.1/x/dev.toolhive/skills
 func listSkillsV01(w http.ResponseWriter, r *http.Request) {
-	provider, err := getProvider()
-	if err != nil {
-		slog.Error("failed to get registry provider", "error", err)
-		http.Error(w, "Failed to get registry provider", http.StatusInternalServerError)
+	provider, ok := getSkillsProvider(w)
+	if !ok {
 		return
 	}
 
 	skills, err := provider.ListAvailableSkills()
 	if err != nil {
 		slog.Error("failed to list skills", "error", err)
-		http.Error(w, "Failed to list skills", http.StatusInternalServerError)
+		writeJSONError(w, http.StatusInternalServerError, "internal_error", "Failed to list skills")
 		return
 	}
 	if skills == nil {
@@ -100,27 +128,31 @@ func getSkillV01(w http.ResponseWriter, r *http.Request) {
 	namespace := chi.URLParam(r, "namespace")
 	skillName := chi.URLParam(r, "skillName")
 
-	provider, err := getProvider()
-	if err != nil {
-		slog.Error("failed to get registry provider", "error", err)
-		http.Error(w, "Failed to get registry provider", http.StatusInternalServerError)
+	provider, ok := getSkillsProvider(w)
+	if !ok {
 		return
 	}
 
 	skill, err := provider.GetSkill(namespace, skillName)
 	if err != nil {
-		// Map upstream 404 responses to HTTP 404
+		// Map upstream HTTP errors to appropriate responses
 		var httpErr *api.RegistryHTTPError
-		if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
-			http.Error(w, "Skill not found", http.StatusNotFound)
-			return
+		if errors.As(err, &httpErr) {
+			switch httpErr.StatusCode {
+			case http.StatusNotFound:
+				writeJSONError(w, http.StatusNotFound, "not_found", "Skill not found")
+				return
+			case http.StatusUnauthorized, http.StatusForbidden:
+				writeRegistryAuthRequiredError(w)
+				return
+			}
 		}
 		slog.Error("failed to get skill", "namespace", namespace, "name", skillName, "error", err)
-		http.Error(w, "Failed to get skill", http.StatusInternalServerError)
+		writeJSONError(w, http.StatusInternalServerError, "internal_error", "Failed to get skill")
 		return
 	}
 	if skill == nil {
-		http.Error(w, "Skill not found", http.StatusNotFound)
+		writeJSONError(w, http.StatusNotFound, "not_found", "Skill not found")
 		return
 	}
 

--- a/pkg/api/v1/registry_v01_skills.go
+++ b/pkg/api/v1/registry_v01_skills.go
@@ -1,0 +1,152 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+
+	types "github.com/stacklok/toolhive-core/registry/types"
+	"github.com/stacklok/toolhive/pkg/registry"
+)
+
+const (
+	skillsDefaultLimit = 50
+	skillsMaxLimit     = 200
+)
+
+// RegistryV01SkillsRouter creates a router for the v0.1 skills API.
+// This provides upstream-compatible endpoints for listing and retrieving skills.
+// The {registryName} path param is currently ignored (always uses default provider).
+func RegistryV01SkillsRouter() http.Handler {
+	r := chi.NewRouter()
+	r.Route("/{registryName}/v0.1", func(r chi.Router) {
+		r.Get("/skills", listSkillsV01)
+		r.Get("/skills/{namespace}/{skillName}", getSkillV01)
+	})
+	return r
+}
+
+// listSkillsV01 handles GET /registry/{registryName}/v0.1/skills
+func listSkillsV01(w http.ResponseWriter, r *http.Request) {
+	provider, err := registry.GetDefaultProvider()
+	if err != nil {
+		slog.Error("failed to get registry provider", "error", err)
+		http.Error(w, "Failed to get registry provider", http.StatusInternalServerError)
+		return
+	}
+
+	skills, err := provider.ListAvailableSkills()
+	if err != nil {
+		slog.Error("failed to list skills", "error", err)
+		http.Error(w, "Failed to list skills", http.StatusInternalServerError)
+		return
+	}
+	if skills == nil {
+		skills = []types.Skill{}
+	}
+
+	// Apply search filter
+	if q := r.URL.Query().Get("q"); q != "" {
+		skills = filterSkillsV01(skills, q)
+	}
+
+	// Paginate
+	page, limit := parseSkillsPagination(r)
+	total := len(skills)
+	start := (page - 1) * limit
+	if start > total {
+		start = total
+	}
+	end := start + limit
+	if end > total {
+		end = total
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(skillsV01Response{
+		Skills: skills[start:end],
+		Metadata: skillsV01Metadata{
+			Total: total,
+			Page:  page,
+			Limit: limit,
+		},
+	}); err != nil {
+		slog.Error("failed to encode skills response", "error", err)
+	}
+}
+
+// getSkillV01 handles GET /registry/{registryName}/v0.1/skills/{namespace}/{skillName}
+func getSkillV01(w http.ResponseWriter, r *http.Request) {
+	namespace := chi.URLParam(r, "namespace")
+	skillName := chi.URLParam(r, "skillName")
+
+	provider, err := registry.GetDefaultProvider()
+	if err != nil {
+		slog.Error("failed to get registry provider", "error", err)
+		http.Error(w, "Failed to get registry provider", http.StatusInternalServerError)
+		return
+	}
+
+	skill, err := provider.GetSkill(namespace, skillName)
+	if err != nil {
+		slog.Error("failed to get skill", "namespace", namespace, "name", skillName, "error", err)
+		http.Error(w, "Failed to get skill", http.StatusInternalServerError)
+		return
+	}
+	if skill == nil {
+		http.Error(w, "Skill not found", http.StatusNotFound)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(skill); err != nil {
+		slog.Error("failed to encode skill response", "error", err)
+	}
+}
+
+func filterSkillsV01(skills []types.Skill, query string) []types.Skill {
+	q := strings.ToLower(query)
+	var result []types.Skill
+	for _, s := range skills {
+		if strings.Contains(strings.ToLower(s.Name), q) ||
+			strings.Contains(strings.ToLower(s.Namespace), q) ||
+			strings.Contains(strings.ToLower(s.Description), q) {
+			result = append(result, s)
+		}
+	}
+	return result
+}
+
+func parseSkillsPagination(r *http.Request) (page, limit int) {
+	page = 1
+	limit = skillsDefaultLimit
+	if p := r.URL.Query().Get("page"); p != "" {
+		if v, err := strconv.Atoi(p); err == nil && v > 0 {
+			page = v
+		}
+	}
+	if l := r.URL.Query().Get("limit"); l != "" {
+		if v, err := strconv.Atoi(l); err == nil && v > 0 && v <= skillsMaxLimit {
+			limit = v
+		}
+	}
+	return page, limit
+}
+
+type skillsV01Response struct {
+	Skills   []types.Skill     `json:"skills"`
+	Metadata skillsV01Metadata `json:"metadata"`
+}
+
+type skillsV01Metadata struct {
+	Total int `json:"total"`
+	Page  int `json:"page"`
+	Limit int `json:"limit"`
+}

--- a/pkg/api/v1/registry_v01_skills_test.go
+++ b/pkg/api/v1/registry_v01_skills_test.go
@@ -29,6 +29,8 @@ func TestFilterSkillsV01(t *testing.T) {
 		wantCount int
 	}{
 		{"code", 1},
+		{"CODE", 1},        // case-insensitive
+		{"Code-Review", 1}, // mixed case
 		{"stacklok", 2},
 		{"weather", 1},
 		{"commits", 1},
@@ -106,4 +108,47 @@ func TestRegistryV01SkillsRouter_GetSkill_NotFound(t *testing.T) {
 	defer resp.Body.Close()
 
 	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	assert.Contains(t, resp.Header.Get("Content-Type"), "application/json",
+		"Error responses should be JSON")
+
+	var body registryErrorResponse
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	assert.Equal(t, "not_found", body.Code)
+}
+
+func TestFilterSkillsV01_EmptyResult_NotNull(t *testing.T) {
+	t.Parallel()
+
+	skills := []types.Skill{
+		{Namespace: "stacklok", Name: "test", Description: "A test skill"},
+	}
+
+	result := filterSkillsV01(skills, "nonexistent")
+	assert.NotNil(t, result, "Filter result should be empty slice, not nil")
+	assert.Empty(t, result)
+
+	// Verify JSON encoding produces [] not null
+	data, err := json.Marshal(result)
+	require.NoError(t, err)
+	assert.Equal(t, "[]", string(data))
+}
+
+func TestRegistryV01SkillsRouter_ListSkills_PaginationBeyondResults(t *testing.T) {
+	t.Parallel()
+
+	handler := RegistryV01SkillsRouter()
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/default/v0.1/x/dev.toolhive/skills?page=999&limit=10")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var body skillsV01Response
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	assert.Empty(t, body.Skills, "Page beyond results should return empty skills")
+	assert.Equal(t, 999, body.Metadata.Page)
+	assert.GreaterOrEqual(t, body.Metadata.Total, 0)
 }

--- a/pkg/api/v1/registry_v01_skills_test.go
+++ b/pkg/api/v1/registry_v01_skills_test.go
@@ -80,7 +80,7 @@ func TestRegistryV01SkillsRouter_ListSkills(t *testing.T) {
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
 
-	resp, err := http.Get(srv.URL + "/default/v0.1/skills")
+	resp, err := http.Get(srv.URL + "/default/v0.1/x/dev.toolhive/skills")
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
@@ -101,7 +101,7 @@ func TestRegistryV01SkillsRouter_GetSkill_NotFound(t *testing.T) {
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
 
-	resp, err := http.Get(srv.URL + "/default/v0.1/skills/nonexistent/noskill")
+	resp, err := http.Get(srv.URL + "/default/v0.1/x/dev.toolhive/skills/nonexistent/noskill")
 	require.NoError(t, err)
 	defer resp.Body.Close()
 

--- a/pkg/api/v1/registry_v01_skills_test.go
+++ b/pkg/api/v1/registry_v01_skills_test.go
@@ -1,0 +1,109 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	types "github.com/stacklok/toolhive-core/registry/types"
+)
+
+func TestFilterSkillsV01(t *testing.T) {
+	t.Parallel()
+
+	skills := []types.Skill{
+		{Namespace: "stacklok", Name: "code-review", Description: "Reviews code for issues"},
+		{Namespace: "stacklok", Name: "commit", Description: "Creates git commits"},
+		{Namespace: "other", Name: "weather", Description: "Weather data"},
+	}
+
+	tests := []struct {
+		query     string
+		wantCount int
+	}{
+		{"code", 1},
+		{"stacklok", 2},
+		{"weather", 1},
+		{"commits", 1},
+		{"nonexistent", 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.query, func(t *testing.T) {
+			t.Parallel()
+			result := filterSkillsV01(skills, tt.query)
+			assert.Len(t, result, tt.wantCount)
+		})
+	}
+}
+
+func TestParseSkillsPagination(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		query     string
+		wantPage  int
+		wantLimit int
+	}{
+		{"defaults", "", 1, skillsDefaultLimit},
+		{"custom page", "page=3", 3, skillsDefaultLimit},
+		{"custom limit", "limit=10", 1, 10},
+		{"both", "page=2&limit=25", 2, 25},
+		{"invalid page", "page=-1", 1, skillsDefaultLimit},
+		{"limit over max", "limit=999", 1, skillsDefaultLimit},
+		{"non-numeric", "page=abc&limit=xyz", 1, skillsDefaultLimit},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			r := httptest.NewRequest(http.MethodGet, "/skills?"+tt.query, nil)
+			page, limit := parseSkillsPagination(r)
+			assert.Equal(t, tt.wantPage, page)
+			assert.Equal(t, tt.wantLimit, limit)
+		})
+	}
+}
+
+func TestRegistryV01SkillsRouter_ListSkills(t *testing.T) {
+	t.Parallel()
+
+	handler := RegistryV01SkillsRouter()
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/default/v0.1/skills")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Contains(t, resp.Header.Get("Content-Type"), "application/json")
+
+	var body skillsV01Response
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	// Should return skills from the embedded catalog (may be empty in test env)
+	assert.NotNil(t, body.Skills)
+	assert.GreaterOrEqual(t, body.Metadata.Total, 0)
+}
+
+func TestRegistryV01SkillsRouter_GetSkill_NotFound(t *testing.T) {
+	t.Parallel()
+
+	handler := RegistryV01SkillsRouter()
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/default/v0.1/skills/nonexistent/noskill")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+}

--- a/pkg/registry/api/skills_client.go
+++ b/pkg/registry/api/skills_client.go
@@ -70,13 +70,13 @@ func NewSkillsClient(baseURL string, allowPrivateIp bool, tokenSource auth.Token
 
 // GetSkill retrieves a skill by namespace and name (latest version).
 func (c *mcpSkillsClient) GetSkill(ctx context.Context, namespace, name string) (*thvregistry.Skill, error) {
-	endpoint, err := url.JoinPath(c.baseURL, skillsBasePath, url.PathEscape(namespace), url.PathEscape(name))
+	path, err := url.JoinPath(skillsBasePath, url.PathEscape(namespace), url.PathEscape(name))
 	if err != nil {
-		return nil, fmt.Errorf("failed to build skills URL: %w", err)
+		return nil, fmt.Errorf("failed to build skills path: %w", err)
 	}
 
 	var skill thvregistry.Skill
-	if err := c.doSkillsGet(ctx, endpoint, &skill); err != nil {
+	if err := c.doSkillsGet(ctx, path, &skill); err != nil {
 		return nil, err
 	}
 	return &skill, nil
@@ -84,15 +84,15 @@ func (c *mcpSkillsClient) GetSkill(ctx context.Context, namespace, name string) 
 
 // GetSkillVersion retrieves a specific version of a skill.
 func (c *mcpSkillsClient) GetSkillVersion(ctx context.Context, namespace, name, version string) (*thvregistry.Skill, error) {
-	endpoint, err := url.JoinPath(c.baseURL, skillsBasePath,
+	path, err := url.JoinPath(skillsBasePath,
 		url.PathEscape(namespace), url.PathEscape(name),
 		"versions", url.PathEscape(version))
 	if err != nil {
-		return nil, fmt.Errorf("failed to build skills URL: %w", err)
+		return nil, fmt.Errorf("failed to build skills path: %w", err)
 	}
 
 	var skill thvregistry.Skill
-	if err := c.doSkillsGet(ctx, endpoint, &skill); err != nil {
+	if err := c.doSkillsGet(ctx, path, &skill); err != nil {
 		return nil, err
 	}
 	return &skill, nil
@@ -141,17 +141,13 @@ func (c *mcpSkillsClient) ListSkills(ctx context.Context, opts *SkillsListOption
 // SearchSkills searches for skills matching the query.
 // Returns a single page of results (no auto-pagination).
 func (c *mcpSkillsClient) SearchSkills(ctx context.Context, query string) (*SkillsListResult, error) {
-	basePath, err := url.JoinPath(c.baseURL, skillsBasePath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to build skills URL: %w", err)
-	}
 	params := url.Values{}
 	params.Add("search", query)
 
-	endpoint := basePath + "?" + params.Encode()
+	pathAndQuery := skillsBasePath + "?" + params.Encode()
 
 	var listResp skillsListResponse
-	if err := c.doSkillsGet(ctx, endpoint, &listResp); err != nil {
+	if err := c.doSkillsGet(ctx, pathAndQuery, &listResp); err != nil {
 		return nil, err
 	}
 
@@ -163,13 +159,13 @@ func (c *mcpSkillsClient) SearchSkills(ctx context.Context, query string) (*Skil
 
 // ListSkillVersions lists all versions of a specific skill.
 func (c *mcpSkillsClient) ListSkillVersions(ctx context.Context, namespace, name string) (*SkillsListResult, error) {
-	endpoint, err := url.JoinPath(c.baseURL, skillsBasePath, url.PathEscape(namespace), url.PathEscape(name), "versions")
+	path, err := url.JoinPath(skillsBasePath, url.PathEscape(namespace), url.PathEscape(name), "versions")
 	if err != nil {
-		return nil, fmt.Errorf("failed to build skills URL: %w", err)
+		return nil, fmt.Errorf("failed to build skills path: %w", err)
 	}
 
 	var listResp skillsListResponse
-	if err := c.doSkillsGet(ctx, endpoint, &listResp); err != nil {
+	if err := c.doSkillsGet(ctx, path, &listResp); err != nil {
 		return nil, err
 	}
 
@@ -195,14 +191,23 @@ type skillsListResponse struct {
 	} `json:"metadata"`
 }
 
-// doSkillsGet performs an HTTP GET request and decodes the JSON response into dest.
-// The endpoint must be rooted at the client's configured baseURL to prevent request forgery.
-func (c *mcpSkillsClient) doSkillsGet(ctx context.Context, endpoint string, dest any) error {
-	if !strings.HasPrefix(endpoint, c.baseURL) {
-		return fmt.Errorf("skills request URL %q is not under the configured base URL %q", endpoint, c.baseURL)
+// doSkillsGet performs an HTTP GET request to the given path (relative to the
+// client's configured baseURL) and decodes the JSON response into dest.
+// The path is joined to the trusted baseURL to prevent request forgery.
+func (c *mcpSkillsClient) doSkillsGet(ctx context.Context, pathAndQuery string, dest any) error {
+	// Parse the trusted base URL and resolve the relative path against it,
+	// ensuring the final request URL is always rooted at the configured base.
+	base, err := url.Parse(c.baseURL)
+	if err != nil {
+		return fmt.Errorf("invalid base URL %q: %w", c.baseURL, err)
 	}
+	ref, err := url.Parse(pathAndQuery)
+	if err != nil {
+		return fmt.Errorf("invalid request path %q: %w", pathAndQuery, err)
+	}
+	resolved := base.ResolveReference(ref)
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, resolved.String(), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create request: %w", err)
 	}
@@ -243,19 +248,15 @@ func (c *mcpSkillsClient) fetchSkillsPage(
 		params.Add("search", opts.Search)
 	}
 
-	basePath, err := url.JoinPath(c.baseURL, skillsBasePath)
-	if err != nil {
-		return nil, "", fmt.Errorf("failed to build skills URL: %w", err)
-	}
-	endpoint := func() string {
+	pathAndQuery := func() string {
 		if len(params) > 0 {
-			return basePath + "?" + params.Encode()
+			return skillsBasePath + "?" + params.Encode()
 		}
-		return basePath
+		return skillsBasePath
 	}()
 
 	var listResp skillsListResponse
-	if err := c.doSkillsGet(ctx, endpoint, &listResp); err != nil {
+	if err := c.doSkillsGet(ctx, pathAndQuery, &listResp); err != nil {
 		return nil, "", err
 	}
 

--- a/pkg/registry/api/skills_client.go
+++ b/pkg/registry/api/skills_client.go
@@ -70,13 +70,13 @@ func NewSkillsClient(baseURL string, allowPrivateIp bool, tokenSource auth.Token
 
 // GetSkill retrieves a skill by namespace and name (latest version).
 func (c *mcpSkillsClient) GetSkill(ctx context.Context, namespace, name string) (*thvregistry.Skill, error) {
-	path, err := url.JoinPath(skillsBasePath, url.PathEscape(namespace), url.PathEscape(name))
+	endpoint, err := url.JoinPath(c.baseURL, skillsBasePath, url.PathEscape(namespace), url.PathEscape(name))
 	if err != nil {
-		return nil, fmt.Errorf("failed to build skills path: %w", err)
+		return nil, fmt.Errorf("failed to build skills URL: %w", err)
 	}
 
 	var skill thvregistry.Skill
-	if err := c.doSkillsGet(ctx, path, &skill); err != nil {
+	if err := c.doSkillsGet(ctx, endpoint, &skill); err != nil {
 		return nil, err
 	}
 	return &skill, nil
@@ -84,15 +84,15 @@ func (c *mcpSkillsClient) GetSkill(ctx context.Context, namespace, name string) 
 
 // GetSkillVersion retrieves a specific version of a skill.
 func (c *mcpSkillsClient) GetSkillVersion(ctx context.Context, namespace, name, version string) (*thvregistry.Skill, error) {
-	path, err := url.JoinPath(skillsBasePath,
+	endpoint, err := url.JoinPath(c.baseURL, skillsBasePath,
 		url.PathEscape(namespace), url.PathEscape(name),
 		"versions", url.PathEscape(version))
 	if err != nil {
-		return nil, fmt.Errorf("failed to build skills path: %w", err)
+		return nil, fmt.Errorf("failed to build skills URL: %w", err)
 	}
 
 	var skill thvregistry.Skill
-	if err := c.doSkillsGet(ctx, path, &skill); err != nil {
+	if err := c.doSkillsGet(ctx, endpoint, &skill); err != nil {
 		return nil, err
 	}
 	return &skill, nil
@@ -141,13 +141,17 @@ func (c *mcpSkillsClient) ListSkills(ctx context.Context, opts *SkillsListOption
 // SearchSkills searches for skills matching the query.
 // Returns a single page of results (no auto-pagination).
 func (c *mcpSkillsClient) SearchSkills(ctx context.Context, query string) (*SkillsListResult, error) {
+	basePath, err := url.JoinPath(c.baseURL, skillsBasePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build skills URL: %w", err)
+	}
 	params := url.Values{}
 	params.Add("search", query)
 
-	pathAndQuery := skillsBasePath + "?" + params.Encode()
+	endpoint := basePath + "?" + params.Encode()
 
 	var listResp skillsListResponse
-	if err := c.doSkillsGet(ctx, pathAndQuery, &listResp); err != nil {
+	if err := c.doSkillsGet(ctx, endpoint, &listResp); err != nil {
 		return nil, err
 	}
 
@@ -159,13 +163,13 @@ func (c *mcpSkillsClient) SearchSkills(ctx context.Context, query string) (*Skil
 
 // ListSkillVersions lists all versions of a specific skill.
 func (c *mcpSkillsClient) ListSkillVersions(ctx context.Context, namespace, name string) (*SkillsListResult, error) {
-	path, err := url.JoinPath(skillsBasePath, url.PathEscape(namespace), url.PathEscape(name), "versions")
+	endpoint, err := url.JoinPath(c.baseURL, skillsBasePath, url.PathEscape(namespace), url.PathEscape(name), "versions")
 	if err != nil {
-		return nil, fmt.Errorf("failed to build skills path: %w", err)
+		return nil, fmt.Errorf("failed to build skills URL: %w", err)
 	}
 
 	var listResp skillsListResponse
-	if err := c.doSkillsGet(ctx, path, &listResp); err != nil {
+	if err := c.doSkillsGet(ctx, endpoint, &listResp); err != nil {
 		return nil, err
 	}
 
@@ -191,29 +195,15 @@ type skillsListResponse struct {
 	} `json:"metadata"`
 }
 
-// doSkillsGet performs an HTTP GET request to the given path (relative to the
-// client's configured baseURL) and decodes the JSON response into dest.
-// The path is joined to the trusted baseURL to prevent request forgery.
-func (c *mcpSkillsClient) doSkillsGet(ctx context.Context, pathAndQuery string, dest any) error {
-	// Parse the trusted base URL and resolve the relative path against it,
-	// ensuring the final request URL is always rooted at the configured base.
-	base, err := url.Parse(c.baseURL)
-	if err != nil {
-		return fmt.Errorf("invalid base URL %q: %w", c.baseURL, err)
-	}
-	ref, err := url.Parse(pathAndQuery)
-	if err != nil {
-		return fmt.Errorf("invalid request path %q: %w", pathAndQuery, err)
-	}
-	resolved := base.ResolveReference(ref)
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, resolved.String(), nil)
+// doSkillsGet performs an HTTP GET request and decodes the JSON response into dest.
+func (c *mcpSkillsClient) doSkillsGet(ctx context.Context, endpoint string, dest any) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
 		return fmt.Errorf("failed to create request: %w", err)
 	}
 	req.Header.Set("User-Agent", c.userAgent)
 
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.httpClient.Do(req) //nolint:gosec // G704: URL from configured registry
 	if err != nil {
 		return fmt.Errorf("failed to execute request: %w", err)
 	}
@@ -248,15 +238,19 @@ func (c *mcpSkillsClient) fetchSkillsPage(
 		params.Add("search", opts.Search)
 	}
 
-	pathAndQuery := func() string {
+	basePath, err := url.JoinPath(c.baseURL, skillsBasePath)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to build skills URL: %w", err)
+	}
+	endpoint := func() string {
 		if len(params) > 0 {
-			return skillsBasePath + "?" + params.Encode()
+			return basePath + "?" + params.Encode()
 		}
-		return skillsBasePath
+		return basePath
 	}()
 
 	var listResp skillsListResponse
-	if err := c.doSkillsGet(ctx, pathAndQuery, &listResp); err != nil {
+	if err := c.doSkillsGet(ctx, endpoint, &listResp); err != nil {
 		return nil, "", err
 	}
 

--- a/pkg/registry/api/skills_client.go
+++ b/pkg/registry/api/skills_client.go
@@ -196,14 +196,19 @@ type skillsListResponse struct {
 }
 
 // doSkillsGet performs an HTTP GET request and decodes the JSON response into dest.
+// The endpoint must be rooted at the client's configured baseURL to prevent request forgery.
 func (c *mcpSkillsClient) doSkillsGet(ctx context.Context, endpoint string, dest any) error {
+	if !strings.HasPrefix(endpoint, c.baseURL) {
+		return fmt.Errorf("skills request URL %q is not under the configured base URL %q", endpoint, c.baseURL)
+	}
+
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
 		return fmt.Errorf("failed to create request: %w", err)
 	}
 	req.Header.Set("User-Agent", c.userAgent)
 
-	resp, err := c.httpClient.Do(req) //nolint:gosec // G704: URL from configured registry
+	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("failed to execute request: %w", err)
 	}


### PR DESCRIPTION
## Summary

- Adds an upstream-compatible API to browse skills from the registry. Today, skills are only available via the internal `POST /api/v1beta/skills` install endpoint — there's no read-only browsing API that follows the v0.1 registry format.
- Add two new endpoints under the `x/dev.toolhive` extension namespace, matching the registry server's route structure. These use the existing `Provider.ListAvailableSkills()` and `Provider.GetSkill()` methods — no changes to the registry internals.

Ref: #4199

## Type of change

- [x] New feature

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)
- [x] Manual testing (describe below)

Started `thv serve`, verified:
- `GET /registry/default/v0.1/x/dev.toolhive/skills` returns paginated skills from embedded catalog (3 skills)
- `GET /registry/default/v0.1/x/dev.toolhive/skills?q=code` returns filtered results (1 match)
- `GET /registry/default/v0.1/x/dev.toolhive/skills?page=1&limit=2` returns correct pagination metadata
- `GET /registry/default/v0.1/x/dev.toolhive/skills/io.github.stacklok/code-review` returns full skill details
- `GET /registry/default/v0.1/x/dev.toolhive/skills/fake/noskill` returns HTTP 404

## Changes

| File | Change |
|------|--------|
| `pkg/api/v1/registry_v01_skills.go` | New handler with list + get endpoints, search filter, pagination, proper error handling for upstream 404s, non-interactive provider access |
| `pkg/api/v1/registry_v01_skills_test.go` | Unit tests for filtering, pagination parsing, and HTTP handlers |
| `pkg/api/server.go` | Mount the new router at `/registry` |

## Does this introduce a user-facing change?

Yes — two new API endpoints for browsing registry skills:
- `GET /registry/{name}/v0.1/x/dev.toolhive/skills` (list, with `?q=` search and `?page=`/`?limit=` pagination)
- `GET /registry/{name}/v0.1/x/dev.toolhive/skills/{namespace}/{skillName}` (get single skill)

## Special notes for reviewers

- The `{registryName}` path param is accepted but currently ignored — always uses the default provider. Multi-registry routing will be added in a follow-up refactor (#4199).
- This is intentionally minimal to unblock the FE team. The full v0.1 API (servers, multi-registry, Store/Source refactor) is planned separately.
- Uses `GetDefaultProviderWithConfig` with `WithInteractive(false)` to match the pattern in existing serve-mode handlers and avoid singleton poisoning.
- Upstream 404s from `RegistryHTTPError` are mapped to HTTP 404 (not 500).
- Filter results use `make([]types.Skill, 0)` to ensure JSON encodes as `[]` not `null`.

Generated with [Claude Code](https://claude.com/claude-code)