### PR TITLE
Add Cursor as a skill-supporting client

### DIFF
--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -313,6 +313,9 @@ var supportedClientIntegrations = []clientAppConfig{
 			types.TransportTypeSSE:            "url",
 			types.TransportTypeStreamableHTTP: "url",
 		},
+		SupportsSkills:    true,
+		SkillsGlobalPath:  []string{".cursor", "skills"},
+		SkillsProjectPath: []string{".cursor", "skills"},
 	},
 	{
 		ClientType:           ClaudeCode,

--- a/pkg/client/discovery_test.go
+++ b/pkg/client/discovery_test.go
@@ -111,11 +111,14 @@ func TestGetClientStatus(t *testing.T) {
 			SupportsSkills: true,
 		},
 		{
-			ClientType:   Cursor,
-			Description:  "Cursor editor (Test)",
-			SettingsFile: "mcp.json",
-			RelPath:      []string{".cursor"}, // Check .cursor directory
-			Extension:    JSON,
+			ClientType:        Cursor,
+			Description:       "Cursor editor (Test)",
+			SettingsFile:      "mcp.json",
+			RelPath:           []string{".cursor"}, // Check .cursor directory
+			Extension:         JSON,
+			SupportsSkills:    true,
+			SkillsGlobalPath:  []string{".cursor", "skills"},
+			SkillsProjectPath: []string{".cursor", "skills"},
 		},
 		{
 			ClientType:   VSCode,
@@ -148,7 +151,7 @@ func TestGetClientStatus(t *testing.T) {
 	assert.True(t, exists)
 	assert.True(t, cursorStatus.Installed)
 	assert.False(t, cursorStatus.Registered)
-	assert.False(t, cursorStatus.SupportsSkills)
+	assert.True(t, cursorStatus.SupportsSkills)
 
 	vscodeStatus, exists := statusMap[VSCode]
 	assert.True(t, exists)

--- a/pkg/client/skills_test.go
+++ b/pkg/client/skills_test.go
@@ -41,7 +41,13 @@ func testSkillClientIntegrations() []clientAppConfig {
 			},
 		},
 		{
-			ClientType: Cursor,
+			ClientType:        Cursor,
+			SupportsSkills:    true,
+			SkillsGlobalPath:  []string{".cursor", "skills"},
+			SkillsProjectPath: []string{".cursor", "skills"},
+		},
+		{
+			ClientType: VSCode,
 			// SupportsSkills defaults to false
 		},
 		{
@@ -70,7 +76,7 @@ func TestSupportsSkills(t *testing.T) {
 		{name: "ClaudeCode supports skills", client: ClaudeCode, expected: true},
 		{name: "Codex supports skills", client: Codex, expected: true},
 		{name: "OpenCode supports skills", client: OpenCode, expected: true},
-		{name: "Cursor does not support skills", client: Cursor, expected: false},
+		{name: "Cursor supports skills", client: Cursor, expected: true},
 		{name: "unknown client returns false", client: ClientApp("nonexistent"), expected: false},
 	}
 
@@ -87,8 +93,8 @@ func TestListSkillSupportingClients(t *testing.T) {
 	cm := newTestSkillManager()
 	clients := cm.ListSkillSupportingClients()
 
-	// Should include ClaudeCode, Codex, OpenCode, and our test-only no-paths-client
-	require.Len(t, clients, 4, "unexpected number of skill-supporting clients: %v", clients)
+	// Should include ClaudeCode, Codex, Cursor, OpenCode, and our test-only no-paths-client
+	require.Len(t, clients, 5, "unexpected number of skill-supporting clients: %v", clients)
 
 	// Verify sorted order
 	for i := 1; i < len(clients); i++ {
@@ -186,8 +192,23 @@ func TestGetSkillPath(t *testing.T) {
 			wantErr:   ErrUnsupportedClientType,
 		},
 		{
-			name:      "client that does not support skills",
+			name:      "ScopeUser Cursor",
 			client:    Cursor,
+			skillName: "my-skill",
+			scope:     skills.ScopeUser,
+			wantPath:  filepath.Join(testHomeDir, ".cursor", "skills", "my-skill"),
+		},
+		{
+			name:        "ScopeProject Cursor with explicit root",
+			client:      Cursor,
+			skillName:   "my-skill",
+			scope:       skills.ScopeProject,
+			projectRoot: "/tmp/myproject",
+			wantPath:    filepath.Join("/tmp/myproject", ".cursor", "skills", "my-skill"),
+		},
+		{
+			name:      "client that does not support skills",
+			client:    VSCode,
 			skillName: "my-skill",
 			scope:     skills.ScopeUser,
 			wantErr:   ErrSkillsNotSupported,


### PR DESCRIPTION
## Summary

Enables Cursor as a skill-supporting client alongside claude-code, codex, and opencode.

- Skills install to `~/.cursor/skills/<name>` (user scope) and `<project>/.cursor/skills/<name>` (project scope) — matching Cursor's existing `.cursor/` config directory convention
- No new writer logic needed; the same artifact extraction path used by all other clients applies

## Type of change

New feature

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)

## Changes

| File | Change |
|------|--------|
| `pkg/client/config.go` | Add `SupportsSkills`, `SkillsGlobalPath`, `SkillsProjectPath` to the Cursor entry |
| `pkg/client/skills_test.go` | Update fixture, `TestSupportsSkills`, `TestListSkillSupportingClients`, add Cursor path test cases, use `VSCode` for the "does not support skills" negative case |
| `pkg/client/discovery_test.go` | Update test fixture and flip `SupportsSkills` assertion for Cursor |

## Does this introduce a user-facing change?

Yes — `thv skill install --clients cursor` (or `--clients all`) now works. Skills land in `~/.cursor/skills/` so Cursor picks them up automatically.