### PR TITLE
Add VS Code and VS Code Insiders as skill-supporting clients

### DIFF
--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -294,6 +294,9 @@ var supportedClientIntegrations = []clientAppConfig{
 			types.TransportTypeSSE:            "url",
 			types.TransportTypeStreamableHTTP: "url",
 		},
+		SupportsSkills:    true,
+		SkillsGlobalPath:  []string{".copilot", "skills"},
+		SkillsProjectPath: []string{".github", "skills"},
 	},
 	{
 		ClientType:           Cursor,

--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -268,6 +268,9 @@ var supportedClientIntegrations = []clientAppConfig{
 			types.TransportTypeSSE:            "url",
 			types.TransportTypeStreamableHTTP: "url",
 		},
+		SupportsSkills:    true,
+		SkillsGlobalPath:  []string{".copilot", "skills"},
+		SkillsProjectPath: []string{".github", "skills"},
 	},
 	{
 		ClientType:   VSCode,

--- a/pkg/client/discovery_test.go
+++ b/pkg/client/discovery_test.go
@@ -121,11 +121,14 @@ func TestGetClientStatus(t *testing.T) {
 			SkillsProjectPath: []string{".cursor", "skills"},
 		},
 		{
-			ClientType:   VSCode,
-			Description:  "Visual Studio Code (Test)",
-			SettingsFile: "mcp.json",
-			RelPath:      []string{".config", "Code", "User"}, // This path won't exist in test
-			Extension:    JSON,
+			ClientType:        VSCode,
+			Description:       "Visual Studio Code (Test)",
+			SettingsFile:      "mcp.json",
+			RelPath:           []string{".config", "Code", "User"}, // This path won't exist in test
+			Extension:         JSON,
+			SupportsSkills:    true,
+			SkillsGlobalPath:  []string{".copilot", "skills"},
+			SkillsProjectPath: []string{".github", "skills"},
 		},
 	}
 
@@ -157,7 +160,7 @@ func TestGetClientStatus(t *testing.T) {
 	assert.True(t, exists)
 	assert.False(t, vscodeStatus.Installed)
 	assert.False(t, vscodeStatus.Registered)
-	assert.False(t, vscodeStatus.SupportsSkills)
+	assert.True(t, vscodeStatus.SupportsSkills)
 }
 
 func TestGetClientStatus_Sorting(t *testing.T) {

--- a/pkg/client/skills_test.go
+++ b/pkg/client/skills_test.go
@@ -53,7 +53,13 @@ func testSkillClientIntegrations() []clientAppConfig {
 			SkillsProjectPath: []string{".kimi", "skills"},
 		},
 		{
-			ClientType: VSCode,
+			ClientType:        VSCode,
+			SupportsSkills:    true,
+			SkillsGlobalPath:  []string{".copilot", "skills"},
+			SkillsProjectPath: []string{".github", "skills"},
+		},
+		{
+			ClientType: Windsurf,
 			// SupportsSkills defaults to false
 		},
 		{
@@ -84,6 +90,8 @@ func TestSupportsSkills(t *testing.T) {
 		{name: "OpenCode supports skills", client: OpenCode, expected: true},
 		{name: "Cursor supports skills", client: Cursor, expected: true},
 		{name: "KimiCli supports skills", client: KimiCli, expected: true},
+		{name: "VSCode supports skills", client: VSCode, expected: true},
+		{name: "Windsurf does not support skills", client: Windsurf, expected: false},
 		{name: "unknown client returns false", client: ClientApp("nonexistent"), expected: false},
 	}
 
@@ -100,8 +108,8 @@ func TestListSkillSupportingClients(t *testing.T) {
 	cm := newTestSkillManager()
 	clients := cm.ListSkillSupportingClients()
 
-	// Should include ClaudeCode, Codex, Cursor, KimiCli, OpenCode, and our test-only no-paths-client
-	require.Len(t, clients, 6, "unexpected number of skill-supporting clients: %v", clients)
+	// Should include ClaudeCode, Codex, Cursor, KimiCli, OpenCode, VSCode, and our test-only no-paths-client
+	require.Len(t, clients, 7, "unexpected number of skill-supporting clients: %v", clients)
 
 	// Verify sorted order
 	for i := 1; i < len(clients); i++ {
@@ -229,8 +237,23 @@ func TestGetSkillPath(t *testing.T) {
 			wantPath:    filepath.Join("/tmp/myproject", ".kimi", "skills", "my-skill"),
 		},
 		{
-			name:      "client that does not support skills",
+			name:      "ScopeUser VSCode",
 			client:    VSCode,
+			skillName: "my-skill",
+			scope:     skills.ScopeUser,
+			wantPath:  filepath.Join(testHomeDir, ".copilot", "skills", "my-skill"),
+		},
+		{
+			name:        "ScopeProject VSCode with explicit root",
+			client:      VSCode,
+			skillName:   "my-skill",
+			scope:       skills.ScopeProject,
+			projectRoot: "/tmp/myproject",
+			wantPath:    filepath.Join("/tmp/myproject", ".github", "skills", "my-skill"),
+		},
+		{
+			name:      "client that does not support skills",
+			client:    Windsurf,
 			skillName: "my-skill",
 			scope:     skills.ScopeUser,
 			wantErr:   ErrSkillsNotSupported,

--- a/pkg/client/skills_test.go
+++ b/pkg/client/skills_test.go
@@ -59,6 +59,12 @@ func testSkillClientIntegrations() []clientAppConfig {
 			SkillsProjectPath: []string{".github", "skills"},
 		},
 		{
+			ClientType:        VSCodeInsider,
+			SupportsSkills:    true,
+			SkillsGlobalPath:  []string{".copilot", "skills"},
+			SkillsProjectPath: []string{".github", "skills"},
+		},
+		{
 			ClientType: Windsurf,
 			// SupportsSkills defaults to false
 		},
@@ -91,6 +97,7 @@ func TestSupportsSkills(t *testing.T) {
 		{name: "Cursor supports skills", client: Cursor, expected: true},
 		{name: "KimiCli supports skills", client: KimiCli, expected: true},
 		{name: "VSCode supports skills", client: VSCode, expected: true},
+		{name: "VSCodeInsider supports skills", client: VSCodeInsider, expected: true},
 		{name: "Windsurf does not support skills", client: Windsurf, expected: false},
 		{name: "unknown client returns false", client: ClientApp("nonexistent"), expected: false},
 	}
@@ -108,8 +115,8 @@ func TestListSkillSupportingClients(t *testing.T) {
 	cm := newTestSkillManager()
 	clients := cm.ListSkillSupportingClients()
 
-	// Should include ClaudeCode, Codex, Cursor, KimiCli, OpenCode, VSCode, and our test-only no-paths-client
-	require.Len(t, clients, 7, "unexpected number of skill-supporting clients: %v", clients)
+	// Should include ClaudeCode, Codex, Cursor, KimiCli, OpenCode, VSCode, VSCodeInsider, and our test-only no-paths-client
+	require.Len(t, clients, 8, "unexpected number of skill-supporting clients: %v", clients)
 
 	// Verify sorted order
 	for i := 1; i < len(clients); i++ {
@@ -246,6 +253,21 @@ func TestGetSkillPath(t *testing.T) {
 		{
 			name:        "ScopeProject VSCode with explicit root",
 			client:      VSCode,
+			skillName:   "my-skill",
+			scope:       skills.ScopeProject,
+			projectRoot: "/tmp/myproject",
+			wantPath:    filepath.Join("/tmp/myproject", ".github", "skills", "my-skill"),
+		},
+		{
+			name:      "ScopeUser VSCodeInsider",
+			client:    VSCodeInsider,
+			skillName: "my-skill",
+			scope:     skills.ScopeUser,
+			wantPath:  filepath.Join(testHomeDir, ".copilot", "skills", "my-skill"),
+		},
+		{
+			name:        "ScopeProject VSCodeInsider with explicit root",
+			client:      VSCodeInsider,
 			skillName:   "my-skill",
 			scope:       skills.ScopeProject,
 			projectRoot: "/tmp/myproject",


### PR DESCRIPTION
## Summary

Enables VS Code and VS Code Insiders (GitHub Copilot) as skill-supporting clients alongside claude-code, codex, opencode, and cursor.

Both variants run the same GitHub Copilot extension and share the same skill directories:

- Personal skills: `~/.copilot/skills/<name>` (user scope)
- Project skills: `<project>/.github/skills/<name>` (project scope)

Paths sourced from the [VS Code Agent Skills docs](https://code.visualstudio.com/docs/copilot/customization/agent-skills). No platform prefix is needed — unlike VS Code's MCP config (which lives under `Library/Application Support` or `.config/Code/`), the skills dirs are a flat `~/.copilot/` and `.github/` on all platforms.

## Type of change

- [x] New feature

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)

## Changes

| File | Change |
|------|--------|
| `pkg/client/config.go` | Add `SupportsSkills`, `SkillsGlobalPath`, `SkillsProjectPath` to both the VS Code and VS Code Insiders entries |
| `pkg/client/skills_test.go` | Update fixtures, add `TestSupportsSkills` cases, bump list count to 7, add path test cases for both clients |
| `pkg/client/discovery_test.go` | Update VS Code fixture and flip `SupportsSkills` assertion |

## Does this introduce a user-facing change?

Yes — `thv skill install --clients vscode` and `thv skill install --clients vscode-insider` (or `--clients all`) now work. Skills land in `~/.copilot/skills/` so GitHub Copilot picks them up automatically in both VS Code variants.