### PR TITLE
Allow local key provider to bypass OIDC discovery failure

### DIFF
--- a/pkg/auth/token.go
+++ b/pkg/auth/token.go
@@ -641,7 +641,13 @@ func NewTokenValidator(ctx context.Context, config TokenValidatorConfig, opts ..
 			"issuer", config.Issuer,
 		)
 	} else if jwksURL == "" && config.Issuer != "" {
-		slog.Debug("OIDC discovery deferred - will discover on first validation request", "issuer", config.Issuer)
+		if o.keyProvider != nil {
+			slog.Debug("OIDC discovery deferred - failure non-fatal with local key provider",
+				"issuer", config.Issuer)
+		} else {
+			slog.Debug("OIDC discovery deferred - will discover on first validation request",
+				"issuer", config.Issuer)
+		}
 	}
 
 	// Ensure we have either an explicit JWKS URL, an issuer to discover from,
@@ -892,9 +898,15 @@ func (v *TokenValidator) getKeyFromJWKS(ctx context.Context, token *jwt.Token) (
 	}
 
 	// Fall through to HTTP-based JWKS lookup.
-	// Defensive check: JWKS URL must be set before calling this function.
-	// This invariant is normally guaranteed by ValidateToken calling ensureOIDCDiscovered first.
+	// When a local key provider is present, OIDC discovery may have been
+	// skipped entirely, so jwksURL can legitimately be empty.
 	if v.jwksURL == "" {
+		if v.keyProvider != nil {
+			return nil, fmt.Errorf(
+				"local key provider could not resolve key and no JWKS URL is available: %w",
+				ErrMissingJWKSURL,
+			)
+		}
 		return nil, ErrMissingJWKSURL
 	}
 
@@ -1041,10 +1053,20 @@ func (v *TokenValidator) introspectOpaqueToken(ctx context.Context, tokenStr str
 
 // ValidateToken validates a token.
 func (v *TokenValidator) ValidateToken(ctx context.Context, tokenString string) (jwt.MapClaims, error) {
-	// Ensure OIDC discovery is complete (lazy discovery with retry)
-	// This is a no-op if discovery was already performed or if JWKS URL was provided directly
+	// Ensure OIDC discovery is complete (lazy discovery with retry).
+	// When a local key provider is configured (embedded auth server),
+	// discovery failure is non-fatal — signing keys can be resolved
+	// in-process and the issuer URL may not be reachable from within
+	// the cluster. Mark discovery as done to avoid per-request retries.
 	if err := v.ensureOIDCDiscovered(ctx); err != nil {
-		return nil, fmt.Errorf("OIDC discovery failed: %w", err)
+		if v.keyProvider == nil {
+			return nil, fmt.Errorf("OIDC discovery failed: %w", err)
+		}
+		slog.Warn("OIDC discovery failed, proceeding with local key provider",
+			"issuer", v.issuer, "error", err)
+		v.oidcDiscoveryMu.Lock()
+		v.oidcDiscovered = true
+		v.oidcDiscoveryMu.Unlock()
 	}
 
 	// Parse the token

--- a/pkg/auth/token_test.go
+++ b/pkg/auth/token_test.go
@@ -2599,3 +2599,216 @@ func TestGetKeyFromLocalProvider(t *testing.T) {
 		require.Nil(t, key)
 	})
 }
+
+func TestValidateToken_DiscoveryFailsWithKeyProvider(t *testing.T) {
+	t.Parallel()
+
+	// closedTLSServer returns a closed TLS server URL and its CA cert path.
+	// Connection refused is instant because DNS resolves but the socket is closed.
+	closedTLSServer := func(t *testing.T) (string, string) {
+		t.Helper()
+		server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		certPath := writeTestServerCert(t, server)
+		server.Close()
+		return server.URL, certPath
+	}
+
+	// setupClosedServerTest generates an RSA key pair, creates a validator pointed
+	// at a closed TLS server, and returns a signed JWT for that issuer. The
+	// keyProviderKID controls whether a mock key provider is configured:
+	//   - non-empty: configures a mock returning a key with that kid
+	//   - empty: no key provider is attached
+	type closedServerFixture struct {
+		validator   *TokenValidator
+		tokenString string
+	}
+	setupClosedServerTest := func(t *testing.T, keyProviderKID string) closedServerFixture {
+		t.Helper()
+
+		ctrl := gomock.NewController(t)
+		mockEnv := envmocks.NewMockReader(ctrl)
+		mockEnv.EXPECT().Getenv(gomock.Any()).Return("").AnyTimes()
+
+		privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+		require.NoError(t, err)
+
+		opts := []TokenValidatorOption{WithEnvReader(mockEnv)}
+		if keyProviderKID != "" {
+			mockProvider := keysmocks.NewMockPublicKeyProvider(ctrl)
+			mockProvider.EXPECT().PublicKeys(gomock.Any()).Return([]*keys.PublicKeyData{
+				{KeyID: keyProviderKID, Algorithm: "RS256", PublicKey: &privateKey.PublicKey},
+			}, nil).AnyTimes()
+			opts = append(opts, WithKeyProvider(mockProvider))
+		}
+
+		closedURL, certPath := closedTLSServer(t)
+
+		ctx := context.Background()
+		validator, err := NewTokenValidator(ctx, TokenValidatorConfig{
+			Issuer:         closedURL,
+			Audience:       "test-audience",
+			ClientID:       "test-client",
+			CACertPath:     certPath,
+			AllowPrivateIP: true,
+		}, opts...)
+		require.NoError(t, err)
+
+		token := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.MapClaims{
+			"iss": closedURL,
+			"aud": "test-audience",
+			"exp": time.Now().Add(time.Hour).Unix(),
+			"sub": "test-user",
+		})
+		token.Header["kid"] = testKeyID
+		tokenString, err := token.SignedString(privateKey)
+		require.NoError(t, err)
+
+		return closedServerFixture{validator: validator, tokenString: tokenString}
+	}
+
+	tests := []struct {
+		name            string
+		keyProviderKID  string // empty means no key provider
+		wantErr         error  // nil means success
+		wantSub         string // checked only when wantErr is nil
+		checkDiscovered bool   // whether to assert oidcDiscovered state after tolerated failure
+	}{
+		{
+			name:            "discovery fails but keyProvider resolves key",
+			keyProviderKID:  testKeyID,
+			wantErr:         nil,
+			wantSub:         "test-user",
+			checkDiscovered: true,
+		},
+		{
+			name:           "discovery fails and keyProvider kid miss returns error",
+			keyProviderKID: "other-kid",
+			wantErr:        ErrMissingJWKSURL,
+		},
+		{
+			name:    "discovery fails without keyProvider returns discovery error",
+			wantErr: ErrFailedToDiscoverOIDC,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			fix := setupClosedServerTest(t, tt.keyProviderKID)
+			ctx := context.Background()
+
+			claims, err := fix.validator.ValidateToken(ctx, fix.tokenString)
+			if tt.wantErr != nil {
+				require.Error(t, err)
+				require.ErrorIs(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.wantSub, claims["sub"])
+			}
+			if tt.checkDiscovered {
+				// Discovery was attempted, failed, and tolerated — marked as done
+				// to avoid per-request retry penalty.
+				require.True(t, fix.validator.oidcDiscovered)
+			}
+		})
+	}
+
+	t.Run("keyProvider miss falls through to explicit JWKS URL", func(t *testing.T) {
+		t.Parallel()
+
+		ctrl := gomock.NewController(t)
+		mockEnv := envmocks.NewMockReader(ctrl)
+		mockEnv.EXPECT().Getenv(gomock.Any()).Return("").AnyTimes()
+
+		privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+		require.NoError(t, err)
+
+		// Mock key provider returns a key with a DIFFERENT kid than the token,
+		// so getKeyFromLocalProvider returns (nil, nil) on kid mismatch.
+		mockProvider := keysmocks.NewMockPublicKeyProvider(ctrl)
+		mockProvider.EXPECT().PublicKeys(gomock.Any()).Return([]*keys.PublicKeyData{
+			{KeyID: "other-kid", Algorithm: "RS256", PublicKey: &privateKey.PublicKey},
+		}, nil).AnyTimes()
+
+		// Build JWK key set for the JWKS server with the CORRECT kid
+		jwkKey, err := jwk.Import(&privateKey.PublicKey)
+		require.NoError(t, err)
+		require.NoError(t, jwkKey.Set(jwk.KeyIDKey, testKeyID))
+		require.NoError(t, jwkKey.Set(jwk.AlgorithmKey, "RS256"))
+		require.NoError(t, jwkKey.Set(jwk.KeyUsageKey, "sig"))
+		keySet := jwk.NewSet()
+		require.NoError(t, keySet.AddKey(jwkKey))
+
+		jwksServer, certPath := createTestJWKSServer(t, keySet)
+		t.Cleanup(jwksServer.Close)
+
+		ctx := context.Background()
+		validator, err := NewTokenValidator(ctx, TokenValidatorConfig{
+			JWKSURL:        jwksServer.URL,
+			Audience:       "test-audience",
+			ClientID:       "test-client",
+			CACertPath:     certPath,
+			AllowPrivateIP: true,
+		}, WithEnvReader(mockEnv), WithKeyProvider(mockProvider))
+		require.NoError(t, err)
+
+		token := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.MapClaims{
+			"aud": "test-audience",
+			"exp": time.Now().Add(time.Hour).Unix(),
+			"sub": "test-user",
+		})
+		token.Header["kid"] = testKeyID
+		tokenString, err := token.SignedString(privateKey)
+		require.NoError(t, err)
+
+		claims, err := validator.ValidateToken(ctx, tokenString)
+		require.NoError(t, err)
+		require.Equal(t, "test-user", claims["sub"])
+	})
+
+	t.Run("keyProvider PublicKeys error falls through to JWKS miss", func(t *testing.T) {
+		t.Parallel()
+
+		ctrl := gomock.NewController(t)
+		mockEnv := envmocks.NewMockReader(ctrl)
+		mockEnv.EXPECT().Getenv(gomock.Any()).Return("").AnyTimes()
+
+		privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+		require.NoError(t, err)
+
+		mockProvider := keysmocks.NewMockPublicKeyProvider(ctrl)
+		mockProvider.EXPECT().PublicKeys(gomock.Any()).Return(nil, errors.New("key store unavailable")).AnyTimes()
+
+		closedURL, certPath := closedTLSServer(t)
+
+		ctx := context.Background()
+		validator, err := NewTokenValidator(ctx, TokenValidatorConfig{
+			Issuer:         closedURL,
+			Audience:       "test-audience",
+			ClientID:       "test-client",
+			CACertPath:     certPath,
+			AllowPrivateIP: true,
+		}, WithEnvReader(mockEnv), WithKeyProvider(mockProvider))
+		require.NoError(t, err)
+
+		token := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.MapClaims{
+			"iss": closedURL,
+			"aud": "test-audience",
+			"exp": time.Now().Add(time.Hour).Unix(),
+			"sub": "test-user",
+		})
+		token.Header["kid"] = testKeyID
+		tokenString, err := token.SignedString(privateKey)
+		require.NoError(t, err)
+
+		// Provider error is swallowed (falls back to HTTP JWKS), but
+		// discovery was also skipped so no JWKS URL is available.
+		_, err = validator.ValidateToken(ctx, tokenString)
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrMissingJWKSURL)
+		require.Contains(t, err.Error(), "local key provider could not resolve key")
+	})
+}


### PR DESCRIPTION
## Summary

When the vMCP has an embedded auth server, `ensureOIDCDiscovered()`
fails fatally if the issuer URL is unreachable from inside the cluster.
This prevents the local key provider from ever being consulted, even
though it can resolve signing keys in-process without any network call.

- Make OIDC discovery failure non-fatal when a `keyProvider` is
  configured — the local provider resolves signing keys in-process and
  the issuer URL may not be reachable from within the cluster
- Mark discovery as completed after a tolerated failure to avoid the
  per-request retry penalty (3 attempts with exponential backoff)
- When the issuer IS reachable, discovery succeeds normally and the
  HTTP JWKS fallback remains available for key ID misses against the
  local provider
- Improve error message when the local provider cannot resolve a key
  and no JWKS URL is available
- Add a constructor log distinguishing deferred discovery from
  non-fatal discovery

Fixes #4747

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)

## Changes

| File | Change |
|------|--------|
| `pkg/auth/token.go` | Tolerate `ensureOIDCDiscovered()` failure when `keyProvider` is set; mark discovery done to suppress retries; improve error message; add constructor log branch |
| `pkg/auth/token_test.go` | Add `TestValidateToken_DiscoveryFailsWithKeyProvider` covering 5 scenarios: key hit, kid miss, no keyProvider, explicit JWKS URL fallback, provider error |

## Does this introduce a user-facing change?

No. This is an internal fix for the embedded auth server scenario where
the issuer URL is not reachable from the validation side.

## Special notes for reviewers

The key design decision is **tolerate failure** (attempt discovery, handle
error) rather than **skip entirely** (don't call `ensureOIDCDiscovered`).
Skipping entirely breaks the kid-miss HTTP JWKS fallback path tested by
`TestNewOIDCAuthMiddleware_KeyProvider_KidMissFallback` in
`pkg/vmcp/auth/factory/`. The tolerate approach preserves that fallback
when the issuer IS reachable, while still handling the unreachable case.

After a tolerated failure, `oidcDiscovered` is set to `true` under the
mutex to prevent subsequent `ValidateToken` calls from retrying discovery
(3 attempts × 5s timeout per attempt).

Generated with [Claude Code](https://claude.com/claude-code)