### PR TITLE
Rename remoteURL and externalURL JSON tags to standard camelCase

### DIFF
--- a/cmd/thv-operator/api/v1alpha1/mcpremoteproxy_types.go
+++ b/cmd/thv-operator/api/v1alpha1/mcpremoteproxy_types.go
@@ -44,7 +44,7 @@ type MCPRemoteProxySpec struct {
 	// RemoteURL is the URL of the remote MCP server to proxy
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Pattern=`^https?://`
-	RemoteURL string `json:"remoteURL"`
+	RemoteURL string `json:"remoteUrl"`
 
 	// ProxyPort is the port to expose the MCP proxy on
 	// +kubebuilder:validation:Minimum=1
@@ -158,7 +158,7 @@ type MCPRemoteProxyStatus struct {
 
 	// ExternalURL is the external URL where the proxy can be accessed (if exposed externally)
 	// +optional
-	ExternalURL string `json:"externalURL,omitempty"`
+	ExternalURL string `json:"externalUrl,omitempty"`
 
 	// ObservedGeneration reflects the generation of the most recently observed MCPRemoteProxy
 	// +optional
@@ -327,7 +327,7 @@ const (
 	// ConditionReasonHeaderSecretNotFound indicates a referenced header Secret was not found
 	ConditionReasonHeaderSecretNotFound = "HeaderSecretNotFound"
 
-	// ConditionReasonRemoteURLInvalid indicates the remoteURL is malformed or has an invalid scheme
+	// ConditionReasonRemoteURLInvalid indicates the remoteUrl is malformed or has an invalid scheme
 	ConditionReasonRemoteURLInvalid = "RemoteURLInvalid"
 
 	// ConditionReasonJWKSURLInvalid indicates the JWKS URL is malformed or has an invalid scheme
@@ -338,7 +338,7 @@ const (
 //+kubebuilder:subresource:status
 //+kubebuilder:resource:shortName=rp;mcprp,categories=toolhive
 //+kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase"
-//+kubebuilder:printcolumn:name="Remote URL",type="string",JSONPath=".spec.remoteURL"
+//+kubebuilder:printcolumn:name="Remote URL",type="string",JSONPath=".spec.remoteUrl"
 //+kubebuilder:printcolumn:name="URL",type="string",JSONPath=".status.url"
 //+kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"
 //+kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"

--- a/cmd/thv-operator/api/v1alpha1/mcpserverentry_types.go
+++ b/cmd/thv-operator/api/v1alpha1/mcpserverentry_types.go
@@ -15,7 +15,7 @@ type MCPServerEntrySpec struct {
 	// Both HTTP and HTTPS schemes are accepted at admission time.
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Pattern=`^https?://`
-	RemoteURL string `json:"remoteURL"`
+	RemoteURL string `json:"remoteUrl"`
 
 	// Transport is the transport method for the remote server (sse or streamable-http).
 	// No default is set (unlike MCPRemoteProxy) because MCPServerEntry points at external
@@ -154,7 +154,7 @@ const (
 //+kubebuilder:resource:shortName=mcpentry,categories=toolhive
 //+kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase"
 //+kubebuilder:printcolumn:name="Transport",type="string",JSONPath=".spec.transport"
-//+kubebuilder:printcolumn:name="Remote URL",type="string",JSONPath=".spec.remoteURL"
+//+kubebuilder:printcolumn:name="Remote URL",type="string",JSONPath=".spec.remoteUrl"
 //+kubebuilder:printcolumn:name="Group",type="string",JSONPath=".spec.groupRef"
 //+kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 

--- a/cmd/thv-operator/controllers/mcpremoteproxy_runconfig.go
+++ b/cmd/thv-operator/controllers/mcpremoteproxy_runconfig.go
@@ -249,7 +249,7 @@ func (*MCPRemoteProxyReconciler) validateRunConfigForRemoteProxy(ctx context.Con
 	}
 
 	if config.RemoteURL == "" {
-		return fmt.Errorf("remoteURL is required for remote proxy")
+		return fmt.Errorf("remoteUrl is required for remote proxy")
 	}
 
 	if config.Name == "" {

--- a/cmd/thv-operator/controllers/mcpremoteproxy_runconfig_test.go
+++ b/cmd/thv-operator/controllers/mcpremoteproxy_runconfig_test.go
@@ -791,7 +791,7 @@ func TestValidateRunConfigForRemoteProxy(t *testing.T) {
 				Host:      "0.0.0.0",
 			},
 			expectErr: true,
-			errMsg:    "remoteURL is required",
+			errMsg:    "remoteUrl is required",
 		},
 		{
 			name: "missing name",

--- a/cmd/thv-operator/controllers/mcpserver_controller.go
+++ b/cmd/thv-operator/controllers/mcpserver_controller.go
@@ -492,7 +492,7 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			host,
 			int(mcpServer.GetProxyPort()),
 			mcpServer.Name,
-			"", // empty remoteURL for MCPServer (not remote proxy)
+			"", // empty remoteUrl for MCPServer (not remote proxy)
 		)
 		err = r.Status().Update(ctx, mcpServer)
 		if err != nil {

--- a/cmd/thv-operator/test-integration/mcp-remote-proxy/mcpremoteproxy_validation_integration_test.go
+++ b/cmd/thv-operator/test-integration/mcp-remote-proxy/mcpremoteproxy_validation_integration_test.go
@@ -93,7 +93,7 @@ var _ = Describe("MCPRemoteProxy Configuration Validation", Label("k8s", "remote
 			By("verifying the API server rejects the resource")
 			err := k8sClient.Create(testCtx, proxy)
 			Expect(err).To(HaveOccurred(), "expected CRD validation to reject ftp:// URL")
-			Expect(err.Error()).To(ContainSubstring("remoteURL"))
+			Expect(err.Error()).To(ContainSubstring("remoteUrl"))
 		})
 	})
 

--- a/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpremoteproxies.yaml
+++ b/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpremoteproxies.yaml
@@ -23,7 +23,7 @@ spec:
     - jsonPath: .status.phase
       name: Phase
       type: string
-    - jsonPath: .spec.remoteURL
+    - jsonPath: .spec.remoteUrl
       name: Remote URL
       type: string
     - jsonPath: .status.url
@@ -478,7 +478,7 @@ spec:
                 maximum: 65535
                 minimum: 1
                 type: integer
-              remoteURL:
+              remoteUrl:
                 description: RemoteURL is the URL of the remote MCP server to proxy
                 pattern: ^https?://
                 type: string
@@ -728,7 +728,7 @@ spec:
                   and X-Forwarded-Prefix headers to construct endpoint URLs
                 type: boolean
             required:
-            - remoteURL
+            - remoteUrl
             type: object
             x-kubernetes-validations:
             - message: oidcConfig and oidcConfigRef are mutually exclusive; use oidcConfigRef
@@ -807,7 +807,7 @@ spec:
                 description: ExternalAuthConfigHash is the hash of the referenced
                   MCPExternalAuthConfig spec
                 type: string
-              externalURL:
+              externalUrl:
                 description: ExternalURL is the external URL where the proxy can be
                   accessed (if exposed externally)
                 type: string

--- a/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpserverentries.yaml
+++ b/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpserverentries.yaml
@@ -25,7 +25,7 @@ spec:
     - jsonPath: .spec.transport
       name: Transport
       type: string
-    - jsonPath: .spec.remoteURL
+    - jsonPath: .spec.remoteUrl
       name: Remote URL
       type: string
     - jsonPath: .spec.groupRef
@@ -162,7 +162,7 @@ spec:
                       Use addHeadersFromSecret for sensitive data like API keys or tokens.
                     type: object
                 type: object
-              remoteURL:
+              remoteUrl:
                 description: |-
                   RemoteURL is the URL of the remote MCP server.
                   Both HTTP and HTTPS schemes are accepted at admission time.
@@ -179,7 +179,7 @@ spec:
                 type: string
             required:
             - groupRef
-            - remoteURL
+            - remoteUrl
             - transport
             type: object
           status:

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpremoteproxies.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpremoteproxies.yaml
@@ -26,7 +26,7 @@ spec:
     - jsonPath: .status.phase
       name: Phase
       type: string
-    - jsonPath: .spec.remoteURL
+    - jsonPath: .spec.remoteUrl
       name: Remote URL
       type: string
     - jsonPath: .status.url
@@ -481,7 +481,7 @@ spec:
                 maximum: 65535
                 minimum: 1
                 type: integer
-              remoteURL:
+              remoteUrl:
                 description: RemoteURL is the URL of the remote MCP server to proxy
                 pattern: ^https?://
                 type: string
@@ -731,7 +731,7 @@ spec:
                   and X-Forwarded-Prefix headers to construct endpoint URLs
                 type: boolean
             required:
-            - remoteURL
+            - remoteUrl
             type: object
             x-kubernetes-validations:
             - message: oidcConfig and oidcConfigRef are mutually exclusive; use oidcConfigRef
@@ -810,7 +810,7 @@ spec:
                 description: ExternalAuthConfigHash is the hash of the referenced
                   MCPExternalAuthConfig spec
                 type: string
-              externalURL:
+              externalUrl:
                 description: ExternalURL is the external URL where the proxy can be
                   accessed (if exposed externally)
                 type: string

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpserverentries.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpserverentries.yaml
@@ -28,7 +28,7 @@ spec:
     - jsonPath: .spec.transport
       name: Transport
       type: string
-    - jsonPath: .spec.remoteURL
+    - jsonPath: .spec.remoteUrl
       name: Remote URL
       type: string
     - jsonPath: .spec.groupRef
@@ -165,7 +165,7 @@ spec:
                       Use addHeadersFromSecret for sensitive data like API keys or tokens.
                     type: object
                 type: object
-              remoteURL:
+              remoteUrl:
                 description: |-
                   RemoteURL is the URL of the remote MCP server.
                   Both HTTP and HTTPS schemes are accepted at admission time.
@@ -182,7 +182,7 @@ spec:
                 type: string
             required:
             - groupRef
-            - remoteURL
+            - remoteUrl
             - transport
             type: object
           status:

--- a/docs/arch/02-core-concepts.md
+++ b/docs/arch/02-core-concepts.md
@@ -144,7 +144,7 @@ Middleware applied in reverse configuration order. Requests flow through: Audit*
 - **Customization**: `envVars`, `volumes`, `toolsFilter`, `toolsOverride`, `ignoreConfig`
 - **Organization**: `group`, `containerLabels`
 - **Middleware**: `middlewareConfigs` - Dynamic middleware chain configuration
-- **Remote servers**: `remoteURL`, `remoteAuthConfig`
+- **Remote servers**: `remoteUrl`, `remoteAuthConfig`
 - **Kubernetes**: `k8sPodTemplatePatch`
 
 See `pkg/runner/config.go` for complete field reference.

--- a/docs/arch/02-core-concepts.md
+++ b/docs/arch/02-core-concepts.md
@@ -144,7 +144,7 @@ Middleware applied in reverse configuration order. Requests flow through: Audit*
 - **Customization**: `envVars`, `volumes`, `toolsFilter`, `toolsOverride`, `ignoreConfig`
 - **Organization**: `group`, `containerLabels`
 - **Middleware**: `middlewareConfigs` - Dynamic middleware chain configuration
-- **Remote servers**: `remoteUrl`, `remoteAuthConfig`
+- **Remote servers**: `remoteURL`, `remoteAuthConfig`
 - **Kubernetes**: `k8sPodTemplatePatch`
 
 See `pkg/runner/config.go` for complete field reference.

--- a/docs/arch/03-transport-architecture.md
+++ b/docs/arch/03-transport-architecture.md
@@ -361,7 +361,7 @@ thv run my-slow-server
 
 Remote MCP servers will be supported in Kubernetes mode by:
 
-1. **MCPServer CRD** with `remoteURL` field
+1. **MCPServer CRD** with `remoteUrl` field
 2. **Operator creates Deployment** with proxy-runner
 3. **No StatefulSet created** - proxy forwards to remote URL
 4. **Service exposes proxy** - Clients use ClusterIP/LoadBalancer

--- a/docs/arch/05-runconfig-and-permissions.md
+++ b/docs/arch/05-runconfig-and-permissions.md
@@ -24,7 +24,7 @@ The complete `RunConfig` struct is defined in `pkg/runner/config.go`.
 
 **Key field categories:**
 - **Identity**: `name`, `containerName`, `baseName` - Workload identifiers
-- **What to run**: `image` or `remoteUrl` - Container image or remote endpoint
+- **What to run**: `image` or `remoteURL` - Container image or remote endpoint
 - **Transport**: `transport`, `host`, `port`, `targetPort`, `proxyMode` - Communication configuration
 - **Execution**: `cmdArgs`, `envVars` - Runtime parameters
 - **Security**: `permissionProfile`, `isolateNetwork` - Permission boundaries

--- a/docs/arch/05-runconfig-and-permissions.md
+++ b/docs/arch/05-runconfig-and-permissions.md
@@ -24,7 +24,7 @@ The complete `RunConfig` struct is defined in `pkg/runner/config.go`.
 
 **Key field categories:**
 - **Identity**: `name`, `containerName`, `baseName` - Workload identifiers
-- **What to run**: `image` or `remoteURL` - Container image or remote endpoint
+- **What to run**: `image` or `remoteUrl` - Container image or remote endpoint
 - **Transport**: `transport`, `host`, `port`, `targetPort`, `proxyMode` - Communication configuration
 - **Execution**: `cmdArgs`, `envVars` - Runtime parameters
 - **Security**: `permissionProfile`, `isolateNetwork` - Permission boundaries

--- a/docs/arch/09-operator-architecture.md
+++ b/docs/arch/09-operator-architecture.md
@@ -254,7 +254,7 @@ For examples, see [`examples/operator/mcp-servers/mcpserver_fetch_otel.yaml`](..
 Defines a proxy for remote MCP servers with authentication, authorization, audit logging, and tool filtering.
 
 **Key fields:**
-- `remoteURL` - URL of the remote MCP server to proxy
+- `remoteUrl` - URL of the remote MCP server to proxy
 - `oidcConfigRef` - Reference to shared MCPOIDCConfig (preferred, with per-server `audience` and `scopes`)
 - `oidcConfig` - Inline OIDC authentication (deprecated, use `oidcConfigRef` instead)
 - `externalAuthConfigRef` - Token exchange for remote service authentication
@@ -272,7 +272,7 @@ Defines a proxy for remote MCP servers with authentication, authorization, audit
 Declares a remote MCP endpoint as a zero-infrastructure catalog entry. Unlike MCPServer and MCPRemoteProxy, MCPServerEntry never creates a Deployment, Service, or Pod. vMCP connects directly to the declared remote URL.
 
 **Key fields:**
-- `remoteURL` - URL of the remote MCP server (required)
+- `remoteUrl` - URL of the remote MCP server (required)
 - `groupRef` - MCPGroup membership for discovery by VirtualMCPServer
 - `externalAuthConfigRef` - Token exchange for remote service authentication
 - `caBundleRef` - Reference to a ConfigMap containing CA certificate data for TLS verification

--- a/docs/operator/crd-api.md
+++ b/docs/operator/crd-api.md
@@ -2256,7 +2256,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `remoteURL` _string_ | RemoteURL is the URL of the remote MCP server to proxy |  | Pattern: `^https?://` <br />Required: \{\} <br /> |
+| `remoteUrl` _string_ | RemoteURL is the URL of the remote MCP server to proxy |  | Pattern: `^https?://` <br />Required: \{\} <br /> |
 | `proxyPort` _integer_ | ProxyPort is the port to expose the MCP proxy on | 8080 | Maximum: 65535 <br />Minimum: 1 <br /> |
 | `transport` _string_ | Transport is the transport method for the remote proxy (sse or streamable-http) | streamable-http | Enum: [sse streamable-http] <br /> |
 | `oidcConfig` _[api.v1alpha1.OIDCConfigRef](#apiv1alpha1oidcconfigref)_ | OIDCConfig defines OIDC authentication configuration for the proxy.<br />Deprecated: Use OIDCConfigRef to reference a shared MCPOIDCConfig resource instead.<br />This field will be removed in v1beta1. OIDCConfig and OIDCConfigRef are mutually exclusive. |  | Optional: \{\} <br /> |
@@ -2292,7 +2292,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `phase` _[api.v1alpha1.MCPRemoteProxyPhase](#apiv1alpha1mcpremoteproxyphase)_ | Phase is the current phase of the MCPRemoteProxy |  | Enum: [Pending Ready Failed Terminating] <br />Optional: \{\} <br /> |
 | `url` _string_ | URL is the internal cluster URL where the proxy can be accessed |  | Optional: \{\} <br /> |
-| `externalURL` _string_ | ExternalURL is the external URL where the proxy can be accessed (if exposed externally) |  | Optional: \{\} <br /> |
+| `externalUrl` _string_ | ExternalURL is the external URL where the proxy can be accessed (if exposed externally) |  | Optional: \{\} <br /> |
 | `observedGeneration` _integer_ | ObservedGeneration reflects the generation of the most recently observed MCPRemoteProxy |  | Optional: \{\} <br /> |
 | `conditions` _[Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#condition-v1-meta) array_ | Conditions represent the latest available observations of the MCPRemoteProxy's state |  | Optional: \{\} <br /> |
 | `toolConfigHash` _string_ | ToolConfigHash stores the hash of the referenced ToolConfig for change detection |  | Optional: \{\} <br /> |
@@ -2402,7 +2402,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `remoteURL` _string_ | RemoteURL is the URL of the remote MCP server.<br />Both HTTP and HTTPS schemes are accepted at admission time. |  | Pattern: `^https?://` <br />Required: \{\} <br /> |
+| `remoteUrl` _string_ | RemoteURL is the URL of the remote MCP server.<br />Both HTTP and HTTPS schemes are accepted at admission time. |  | Pattern: `^https?://` <br />Required: \{\} <br /> |
 | `transport` _string_ | Transport is the transport method for the remote server (sse or streamable-http).<br />No default is set (unlike MCPRemoteProxy) because MCPServerEntry points at external<br />servers the user doesn't control — requiring explicit transport avoids silent mismatches. |  | Enum: [sse streamable-http] <br />Required: \{\} <br /> |
 | `groupRef` _string_ | GroupRef is the name of the MCPGroup this entry belongs to.<br />Required — every MCPServerEntry must be part of a group for vMCP discovery. |  | MinLength: 1 <br />Required: \{\} <br /> |
 | `externalAuthConfigRef` _[api.v1alpha1.ExternalAuthConfigRef](#apiv1alpha1externalauthconfigref)_ | ExternalAuthConfigRef references a MCPExternalAuthConfig resource for token exchange<br />when connecting to the remote MCP server. The referenced MCPExternalAuthConfig must<br />exist in the same namespace as this MCPServerEntry. |  | Optional: \{\} <br /> |

--- a/docs/operator/virtualmcpserver-api.md
+++ b/docs/operator/virtualmcpserver-api.md
@@ -60,7 +60,7 @@ kind: MCPServerEntry
 metadata:
   name: context7
 spec:
-  remoteURL: https://mcp.context7.com/mcp
+  remoteUrl: https://mcp.context7.com/mcp
   transport: streamable-http
   groupRef: engineering-team
   # No externalAuthConfigRef — public endpoint, no auth needed

--- a/docs/operator/virtualmcpserver-kubernetes-guide.md
+++ b/docs/operator/virtualmcpserver-kubernetes-guide.md
@@ -441,7 +441,7 @@ kind: MCPRemoteProxy
 metadata:
   name: context7
 spec:
-  remoteURL: https://mcp.context7.com/mcp
+  remoteUrl: https://mcp.context7.com/mcp
   transport: streamable-http
   groupRef: engineering-team
   # Requires OIDC config, deploys proxy pod
@@ -454,7 +454,7 @@ kind: MCPServerEntry
 metadata:
   name: context7
 spec:
-  remoteURL: https://mcp.context7.com/mcp
+  remoteUrl: https://mcp.context7.com/mcp
   transport: streamable-http
   groupRef: engineering-team
   # No pods deployed, VirtualMCPServer connects directly

--- a/examples/operator/external-auth/mcpremoteproxy_with_bearer_token.yaml
+++ b/examples/operator/external-auth/mcpremoteproxy_with_bearer_token.yaml
@@ -36,7 +36,7 @@ metadata:
   name: api-proxy
   namespace: default
 spec:
-  remoteURL: "https://mcp.example.com/api"
+  remoteUrl: "https://mcp.example.com/api"
   proxyPort: 8080
   transport: streamable-http
 

--- a/examples/operator/mcp-server-entries/mcpserverentry_basic.yaml
+++ b/examples/operator/mcp-server-entries/mcpserverentry_basic.yaml
@@ -20,6 +20,6 @@ metadata:
   name: context7
   namespace: toolhive-system
 spec:
-  remoteURL: https://mcp.context7.com/mcp
+  remoteUrl: https://mcp.context7.com/mcp
   transport: streamable-http
   groupRef: remote-tools

--- a/examples/operator/mcp-server-entries/mcpserverentry_mixed_group.yaml
+++ b/examples/operator/mcp-server-entries/mcpserverentry_mixed_group.yaml
@@ -33,7 +33,7 @@ metadata:
   name: context7
   namespace: toolhive-system
 spec:
-  remoteURL: https://mcp.context7.com/mcp
+  remoteUrl: https://mcp.context7.com/mcp
   transport: streamable-http
   groupRef: engineering-team
 

--- a/examples/operator/mcp-server-entries/mcpserverentry_with_ca_bundle.yaml
+++ b/examples/operator/mcp-server-entries/mcpserverentry_with_ca_bundle.yaml
@@ -23,7 +23,7 @@ metadata:
   name: internal-mcp
   namespace: toolhive-system
 spec:
-  remoteURL: https://internal-mcp.corp:8443/mcp
+  remoteUrl: https://internal-mcp.corp:8443/mcp
   transport: streamable-http
   groupRef: remote-tools
   caBundleRef:

--- a/examples/operator/mcp-server-entries/mcpserverentry_with_header_forward.yaml
+++ b/examples/operator/mcp-server-entries/mcpserverentry_with_header_forward.yaml
@@ -10,7 +10,7 @@ metadata:
   name: internal-api
   namespace: toolhive-system
 spec:
-  remoteURL: https://internal-mcp.corp.example.com/mcp
+  remoteUrl: https://internal-mcp.corp.example.com/mcp
   transport: sse
   groupRef: remote-tools
   headerForward:

--- a/examples/operator/mcp-server-entries/mcpserverentry_with_token_exchange.yaml
+++ b/examples/operator/mcp-server-entries/mcpserverentry_with_token_exchange.yaml
@@ -30,7 +30,7 @@ metadata:
   name: salesforce-mcp
   namespace: toolhive-system
 spec:
-  remoteURL: https://mcp.salesforce.com/v1
+  remoteUrl: https://mcp.salesforce.com/v1
   transport: streamable-http
   groupRef: remote-tools
   externalAuthConfigRef:

--- a/examples/operator/mcp-servers/mcpremoteproxy_with_inline_oidc_secretref.yaml
+++ b/examples/operator/mcp-servers/mcpremoteproxy_with_inline_oidc_secretref.yaml
@@ -16,7 +16,7 @@ metadata:
   name: github-proxy
   namespace: toolhive-system
 spec:
-  remoteURL: "https://api.github.com/mcp"
+  remoteUrl: "https://api.github.com/mcp"
   transport: streamable-http
   oidcConfig:
     type: inline

--- a/examples/operator/mcp-servers/mcpremoteproxy_with_oidcconfig_ref.yaml
+++ b/examples/operator/mcp-servers/mcpremoteproxy_with_oidcconfig_ref.yaml
@@ -22,7 +22,7 @@ metadata:
   name: github-proxy
   namespace: toolhive-system
 spec:
-  remoteURL: "https://api.github.com/mcp"
+  remoteUrl: "https://api.github.com/mcp"
   transport: streamable-http
   oidcConfigRef:
     name: proxy-idp

--- a/pkg/vmcp/workloads/k8s.go
+++ b/pkg/vmcp/workloads/k8s.go
@@ -475,7 +475,7 @@ func (d *k8sDiscoverer) getMCPServerEntryAsBackend(ctx context.Context, entryNam
 	}
 
 	// Unlike MCPServer/MCPRemoteProxy (which use status.URL, empty until ready),
-	// MCPServerEntry always has spec.remoteURL set. Explicitly check phase to
+	// MCPServerEntry always has spec.remoteUrl set. Explicitly check phase to
 	// avoid routing to entries that failed validation.
 	if mcpServerEntry.Status.Phase != mcpv1alpha1.MCPServerEntryPhaseValid {
 		slog.Debug("skipping server entry with non-valid phase",


### PR DESCRIPTION
## Summary

The `remoteURL` and `externalURL` JSON tags on CRD types use all-caps `URL`, which is inconsistent with the rest of the codebase where 6+ fields use title-case `Url` (e.g., `issuerUrl`, `jwksUrl`, `tokenUrl`). This aligns the minority all-caps pattern with the majority convention and Kubernetes API camelCase standards.

- Rename `json:"remoteURL"` to `json:"remoteUrl"` on `MCPRemoteProxySpec` and `MCPServerEntrySpec`
- Rename `json:"externalURL"` to `json:"externalUrl"` on `MCPRemoteProxyStatus`
- Update kubebuilder printcolumn JSONPaths, error messages, tests, generated CRD manifests, example YAMLs, and documentation

Fixes #4581

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)

## Migration guide

This is a **breaking wire-format change** for `MCPRemoteProxy` and `MCPServerEntry` CRDs. Existing manifests must be updated before applying them against the new CRD version.

> **Impact on existing resources:** After the CRD upgrade, existing resources in etcd still contain the old `remoteURL` key. The controller will deserialize this as an empty field (since the JSON tag is now `remoteUrl`), causing reconciliation to fail with `"remoteUrl is required for remote proxy"`. Existing resources will enter a degraded state until manifests are re-applied with the new field names. Any `kubectl` commands or tooling using JSONPath `.spec.remoteURL` or `.status.externalURL` must also be updated.
>
> This is a v1alpha1 API where breaking changes are expected.

### Field renames

| CRD | Field | Old key | New key |
|-----|-------|---------|---------|
| `MCPRemoteProxy` | `.spec.remoteURL` | `remoteURL` | `remoteUrl` |
| `MCPRemoteProxy` | `.status.externalURL` | `externalURL` | `externalUrl` |
| `MCPServerEntry` | `.spec.remoteURL` | `remoteURL` | `remoteUrl` |

### Steps to migrate

1. **Update all `MCPRemoteProxy` manifests** — change `remoteURL:` to `remoteUrl:` in spec:

   ```yaml
   # Before
   spec:
     remoteURL: https://mcp.example.com

   # After
   spec:
     remoteUrl: https://mcp.example.com
   ```

2. **Update all `MCPServerEntry` manifests** — same change:

   ```yaml
   # Before
   spec:
     remoteURL: https://mcp.example.com

   # After
   spec:
     remoteUrl: https://mcp.example.com
   ```

3. **Update the CRDs** — install the new CRD definitions before applying updated manifests:

   ```bash
   # If using Helm
   helm upgrade --install toolhive-operator-crds deploy/charts/operator-crds

   # If using kubectl
   kubectl apply -f deploy/charts/operator-crds/files/crds/
   ```

4. **Re-apply your manifests** with the updated field names.

### What does NOT change

- **RunConfig** (`pkg/runner/config.go`) is unaffected — it uses `remote_url` (snake_case) and is mapped via Go code, not JSON serialization.
- **Go struct field names** (`RemoteURL`, `ExternalURL`) and Go constants (e.g., `ConditionReasonRemoteURLInvalid`) are unchanged.
- **Status field `externalUrl`** is operator-managed — no user action needed, but any tooling that reads `.status.externalURL` must update to `.status.externalUrl`.

## Changes

| File | Change |
|------|--------|
| `cmd/thv-operator/api/v1alpha1/mcpremoteproxy_types.go` | JSON tags `remoteURL` → `remoteUrl`, `externalURL` → `externalUrl`, printcolumn JSONPath |
| `cmd/thv-operator/api/v1alpha1/mcpserverentry_types.go` | Same JSON tag and printcolumn changes for MCPServerEntry |
| `cmd/thv-operator/controllers/mcpremoteproxy_runconfig.go` | Error message updated |
| `cmd/thv-operator/controllers/mcpremoteproxy_runconfig_test.go` | Test assertion updated |
| `cmd/thv-operator/controllers/mcpserver_controller.go` | Comment updated |
| `cmd/thv-operator/test-integration/...` | Integration test assertion updated |
| `deploy/charts/operator-crds/` (4 files) | Regenerated CRD manifests |
| `docs/` (6 files) | Architecture and operator docs updated |
| `examples/operator/` (8 files) | Example YAML manifests updated |
| `pkg/vmcp/workloads/k8s.go` | Comment updated |

## Special notes for reviewers

- Go struct field names (`RemoteURL`, `ExternalURL`) and Go constants (e.g., `ConditionReasonRemoteURLInvalid`) are intentionally unchanged — only JSON wire-format tags are affected.
- The codebase already uses `Url` in 6+ other fields (`issuerUrl`, `jwksUrl`, `tokenUrl`, `endpointUrl`, `resourceUrl`, `url`), making this the standard convention.

Generated with [Claude Code](https://claude.com/claude-code)