### PR TITLE
Remove redundant storage.Load from NotifyBackendExpired

### DIFF
--- a/pkg/vmcp/server/session_manager_interface.go
+++ b/pkg/vmcp/server/session_manager_interface.go
@@ -50,9 +50,13 @@ type SessionManager interface {
 	Terminate(sessionID string) (bool, error)
 
 	// NotifyBackendExpired updates session metadata in storage to reflect that the
-	// backend identified by workloadID is no longer connected. It is a best-effort,
-	// metadata-only operation intended to be called by keepalive or health-monitoring
-	// components when they detect that a backend session has expired or been lost.
-	// Storage errors are logged but not returned.
-	NotifyBackendExpired(sessionID, workloadID string)
+	// backend identified by workloadID is no longer connected. The caller must
+	// supply the session metadata it already holds (e.g. from MultiSession.GetMetadata);
+	// passing nil is treated as "no metadata available" and is a silent no-op.
+	// The metadata map is treated as read-only; the implementation copies it before
+	// making any modifications.
+	// It is a best-effort, metadata-only operation intended to be called by keepalive
+	// or health-monitoring components when they detect that a backend session has
+	// expired or been lost. Storage errors are logged but not returned.
+	NotifyBackendExpired(sessionID, workloadID string, metadata map[string]string)
 }

--- a/pkg/vmcp/server/sessionmanager/session_manager.go
+++ b/pkg/vmcp/server/sessionmanager/session_manager.go
@@ -206,11 +206,9 @@ const terminateTimeout = 5 * time.Second
 // performs a single Redis SET. 5 s is consistent with terminateTimeout.
 const decorateTimeout = 5 * time.Second
 
-// notifyBackendExpiredTimeout bounds each individual storage operation inside
-// NotifyBackendExpired() — one Load and one Upsert, each capped independently.
-// Each is a single-key Redis operation, so 5 s per call is consistent with
-// terminateTimeout and decorateTimeout. Worst-case wall-clock for the function
-// is 2 × 5 s = 10 s.
+// notifyBackendExpiredTimeout bounds the storage.Update call inside
+// NotifyBackendExpired() — a single-key Redis operation, consistent with
+// terminateTimeout and decorateTimeout.
 const notifyBackendExpiredTimeout = 5 * time.Second
 
 // Generate implements the SDK's SessionIdManager.Generate().
@@ -521,26 +519,21 @@ func (sm *Manager) Terminate(sessionID string) (isNotAllowed bool, err error) {
 // cross-pod RestoreSession call does not attempt to reconnect to the expired
 // backend session.
 //
+// The caller supplies the session metadata it already holds (e.g. from
+// MultiSession.GetMetadata). Passing nil metadata is treated as "no metadata
+// available" and is a silent no-op, avoiding a redundant storage round-trip.
+//
 // After a successful storage update, the cached entry is not immediately evicted.
 // On the next GetMultiSession call, checkSession detects that the stored
 // MetadataKeyBackendIDs differs from the cached session's value, evicts the stale
 // entry via onEvict, and triggers RestoreSession with the updated metadata.
 // On storage error, no eviction occurs and the caller retries on the next access.
 //
-// This is a best-effort operation. If the session is absent from storage (not
-// found or terminated) the call is a silent no-op. Storage errors are logged
-// but not returned.
-func (sm *Manager) NotifyBackendExpired(sessionID, workloadID string) {
-	loadCtx, loadCancel := context.WithTimeout(context.Background(), notifyBackendExpiredTimeout)
-	defer loadCancel()
-	metadata, err := sm.storage.Load(loadCtx, sessionID)
-	if err != nil {
-		if !errors.Is(err, transportsession.ErrSessionNotFound) {
-			slog.Warn("NotifyBackendExpired: failed to load session from storage",
-				"session_id", sessionID,
-				"workload_id", workloadID,
-				"error", err)
-		}
+// This is a best-effort operation. If the session key is absent from storage
+// (terminated or expired), updateMetadata's SET XX is a no-op. Storage errors
+// are logged but not returned.
+func (sm *Manager) NotifyBackendExpired(sessionID, workloadID string, metadata map[string]string) {
+	if metadata == nil {
 		return
 	}
 	if metadata[MetadataKeyTerminated] == MetadataValTrue {
@@ -563,16 +556,26 @@ func (sm *Manager) NotifyBackendExpired(sessionID, workloadID string) {
 	// populateBackendMetadata, which uses key presence to distinguish an
 	// explicit zero-backend state from absent/corrupted metadata in
 	// RestoreSession. Trim spaces and drop empty parts for robustness.
-	delete(metadata, vmcpsession.MetadataKeyBackendSessionPrefix+workloadID)
+	//
+	// Copy before mutating so the caller's map is not modified. Mutating the
+	// caller's map would silently corrupt the in-memory session state, which
+	// would defeat lazy eviction: checkSession compares stored vs cached
+	// MetadataKeyBackendIDs to detect drift, so the values must differ after
+	// this update for eviction to trigger on the next GetMultiSession call.
+	updated := make(map[string]string, len(metadata))
+	for k, v := range metadata {
+		updated[k] = v
+	}
+	delete(updated, vmcpsession.MetadataKeyBackendSessionPrefix+workloadID)
 	var remaining []string
 	for _, p := range strings.Split(backendIDs, ",") {
 		if t := strings.TrimSpace(p); t != "" && t != workloadID {
 			remaining = append(remaining, t)
 		}
 	}
-	metadata[vmcpsession.MetadataKeyBackendIDs] = strings.Join(remaining, ",")
+	updated[vmcpsession.MetadataKeyBackendIDs] = strings.Join(remaining, ",")
 
-	if err := sm.updateMetadata(sessionID, metadata); err != nil {
+	if err := sm.updateMetadata(sessionID, updated); err != nil {
 		slog.Warn("NotifyBackendExpired: failed to persist backend expiry to storage",
 			"session_id", sessionID,
 			"workload_id", workloadID,

--- a/pkg/vmcp/server/sessionmanager/session_manager_test.go
+++ b/pkg/vmcp/server/sessionmanager/session_manager_test.go
@@ -6,6 +6,7 @@ package sessionmanager
 import (
 	"context"
 	"errors"
+	"maps"
 	"strings"
 	"testing"
 	"time"
@@ -2094,8 +2095,9 @@ func TestNotifyBackendExpired(t *testing.T) {
 
 	// seedBackendMetadata stores backend metadata directly in storage so that
 	// NotifyBackendExpired has something to operate on. This simulates what
-	// populateBackendMetadata writes during session creation.
-	seedBackendMetadata := func(t *testing.T, storage transportsession.DataStorage, sessionID string, ids []string, sessionIDs map[string]string) {
+	// populateBackendMetadata writes during session creation. It returns the
+	// metadata map so callers can pass it directly to NotifyBackendExpired.
+	seedBackendMetadata := func(t *testing.T, storage transportsession.DataStorage, sessionID string, ids []string, sessionIDs map[string]string) map[string]string {
 		t.Helper()
 		meta := map[string]string{
 			vmcpsession.MetadataKeyBackendIDs: strings.Join(ids, ","),
@@ -2104,6 +2106,7 @@ func TestNotifyBackendExpired(t *testing.T) {
 			meta[vmcpsession.MetadataKeyBackendSessionPrefix+workloadID] = sessID
 		}
 		require.NoError(t, storage.Upsert(context.Background(), sessionID, meta))
+		return meta
 	}
 
 	t.Run("clears backend session key and removes from MetadataKeyBackendIDs", func(t *testing.T) {
@@ -2120,12 +2123,14 @@ func TestNotifyBackendExpired(t *testing.T) {
 		_, err := sm.CreateSession(t.Context(), sessionID)
 		require.NoError(t, err)
 
-		seedBackendMetadata(t, storage, sessionID,
+		meta := seedBackendMetadata(t, storage, sessionID,
 			[]string{"workload-a", "workload-b"},
 			map[string]string{"workload-a": "sess-a", "workload-b": "sess-b"},
 		)
 
-		sm.NotifyBackendExpired(sessionID, "workload-a")
+		metaBefore := maps.Clone(meta)
+		sm.NotifyBackendExpired(sessionID, "workload-a", meta)
+		assert.Equal(t, metaBefore, meta, "NotifyBackendExpired must not mutate the caller's metadata map")
 
 		got, loadErr := storage.Load(context.Background(), sessionID)
 		require.NoError(t, loadErr)
@@ -2150,12 +2155,14 @@ func TestNotifyBackendExpired(t *testing.T) {
 		_, err := sm.CreateSession(t.Context(), sessionID)
 		require.NoError(t, err)
 
-		seedBackendMetadata(t, storage, sessionID,
+		meta := seedBackendMetadata(t, storage, sessionID,
 			[]string{"workload-a"},
 			map[string]string{"workload-a": "sess-a"},
 		)
 
-		sm.NotifyBackendExpired(sessionID, "workload-a")
+		metaBefore := maps.Clone(meta)
+		sm.NotifyBackendExpired(sessionID, "workload-a", meta)
+		assert.Equal(t, metaBefore, meta, "NotifyBackendExpired must not mutate the caller's metadata map")
 
 		got, loadErr := storage.Load(context.Background(), sessionID)
 		require.NoError(t, loadErr)
@@ -2176,12 +2183,15 @@ func TestNotifyBackendExpired(t *testing.T) {
 		sessionID := sm.Generate()
 		// Seed metadata that is missing MetadataKeyBackendIDs — simulates
 		// corrupted or partially-written storage.
-		require.NoError(t, storage.Upsert(context.Background(), sessionID, map[string]string{
+		corruptedMeta := map[string]string{
 			vmcpsession.MetadataKeyBackendSessionPrefix + "workload-a": "sess-a",
 			// MetadataKeyBackendIDs intentionally absent
-		}))
+		}
+		require.NoError(t, storage.Upsert(context.Background(), sessionID, corruptedMeta))
 
-		sm.NotifyBackendExpired(sessionID, "workload-a")
+		corruptedMetaBefore := maps.Clone(corruptedMeta)
+		sm.NotifyBackendExpired(sessionID, "workload-a", corruptedMeta)
+		assert.Equal(t, corruptedMetaBefore, corruptedMeta, "NotifyBackendExpired must not mutate the caller's metadata map")
 
 		// Storage must be unchanged — clobbering with "" would drop all backends.
 		got, loadErr := storage.Load(context.Background(), sessionID)
@@ -2199,7 +2209,7 @@ func TestNotifyBackendExpired(t *testing.T) {
 		factory := sessionfactorymocks.NewMockMultiSessionFactory(ctrl)
 		sm, _ := newTestSessionManager(t, factory, newFakeRegistry())
 
-		sm.NotifyBackendExpired("nonexistent-session", "workload-a") // must not panic
+		sm.NotifyBackendExpired("nonexistent-session", "workload-a", nil) // must not panic
 	})
 
 	t.Run("placeholder session (no backend IDs) is a no-op", func(t *testing.T) {
@@ -2211,7 +2221,7 @@ func TestNotifyBackendExpired(t *testing.T) {
 
 		// Generate creates a placeholder with empty metadata.
 		sessionID := sm.Generate()
-		sm.NotifyBackendExpired(sessionID, "workload-a")
+		sm.NotifyBackendExpired(sessionID, "workload-a", map[string]string{})
 
 		// Placeholder must still exist and be unmodified.
 		got, loadErr := storage.Load(context.Background(), sessionID)
@@ -2242,7 +2252,11 @@ func TestNotifyBackendExpired(t *testing.T) {
 		_, err = sm.Terminate(sessionID)
 		require.NoError(t, err)
 
-		sm.NotifyBackendExpired(sessionID, "workload-a")
+		// Caller holds the metadata it observed before termination; updateMetadata's
+		// SET XX is a no-op because Terminate already deleted the key.
+		sm.NotifyBackendExpired(sessionID, "workload-a", map[string]string{
+			vmcpsession.MetadataKeyBackendIDs: "workload-a",
+		})
 
 		// Session must remain absent — Load after Terminate deletes from storage.
 		_, loadErr := storage.Load(context.Background(), sessionID)
@@ -2268,7 +2282,7 @@ func TestNotifyBackendExpired(t *testing.T) {
 		_, err := sm.CreateSession(t.Context(), sessionID)
 		require.NoError(t, err)
 
-		seedBackendMetadata(t, storage, sessionID,
+		meta := seedBackendMetadata(t, storage, sessionID,
 			[]string{"workload-a"},
 			map[string]string{"workload-a": "sess-a"},
 		)
@@ -2279,7 +2293,9 @@ func TestNotifyBackendExpired(t *testing.T) {
 		// storage.Update (SET XX) in updateMetadata returns (false, nil) because
 		// the key no longer exists — NotifyBackendExpired must bail without
 		// recreating the record.
-		sm.NotifyBackendExpired(sessionID, "workload-a")
+		metaBefore := maps.Clone(meta)
+		sm.NotifyBackendExpired(sessionID, "workload-a", meta)
+		assert.Equal(t, metaBefore, meta, "NotifyBackendExpired must not mutate the caller's metadata map")
 
 		_, loadErr := storage.Load(context.Background(), sessionID)
 		assert.ErrorIs(t, loadErr, transportsession.ErrSessionNotFound,
@@ -2300,19 +2316,20 @@ func TestNotifyBackendExpired(t *testing.T) {
 		_, err := sm.CreateSession(t.Context(), sessionID)
 		require.NoError(t, err)
 
-		seedBackendMetadata(t, storage, sessionID,
+		meta := seedBackendMetadata(t, storage, sessionID,
 			[]string{"workload-a"},
 			map[string]string{"workload-a": "sess-a"},
 		)
 
 		// Simulate cross-pod termination: another pod called storage.Delete while
-		// this pod was inside NotifyBackendExpired (after the Load, before the
-		// Upsert). We delete the key here to represent that state.
+		// this pod was inside NotifyBackendExpired (before the Upsert).
+		// We delete the key here to represent that state.
 		require.NoError(t, storage.Delete(context.Background(), sessionID))
 
-		// updateMetadata must re-check storage before upserting; seeing
-		// ErrSessionNotFound it must bail without recreating the record.
-		sm.NotifyBackendExpired(sessionID, "workload-a")
+		// updateMetadata's SET XX sees the absent key and bails without recreating.
+		metaBefore := maps.Clone(meta)
+		sm.NotifyBackendExpired(sessionID, "workload-a", meta)
+		assert.Equal(t, metaBefore, meta, "NotifyBackendExpired must not mutate the caller's metadata map")
 
 		_, loadErr := storage.Load(context.Background(), sessionID)
 		assert.ErrorIs(t, loadErr, transportsession.ErrSessionNotFound,
@@ -2336,12 +2353,14 @@ func TestNotifyBackendExpired(t *testing.T) {
 		// Session must be in cache after CreateSession.
 		assert.Equal(t, 1, sm.sessions.Len(), "session must be in node-local cache after CreateSession")
 
-		seedBackendMetadata(t, storage, sessionID,
+		meta := seedBackendMetadata(t, storage, sessionID,
 			[]string{"workload-a"},
 			map[string]string{"workload-a": "sess-a"},
 		)
 
-		sm.NotifyBackendExpired(sessionID, "workload-a")
+		metaBefore := maps.Clone(meta)
+		sm.NotifyBackendExpired(sessionID, "workload-a", meta)
+		assert.Equal(t, metaBefore, meta, "NotifyBackendExpired must not mutate the caller's metadata map")
 
 		// With lazy eviction, session is still in cache immediately after NotifyBackendExpired.
 		// checkSession detects drift on the next GetMultiSession call.


### PR DESCRIPTION

## Summary

<!--
REQUIRED. You MUST explain:
1. WHY this change is needed (the problem or motivation)
2. WHAT changed (concise bullet points)

The diff shows the code — your summary must provide the context a reviewer
needs to understand the purpose without reading the diff first.
-->

Accept the caller's metadata map directly rather than re-loading it from storage. Any caller that detects a backend expiry already holds the session metadata (e.g. from MultiSession.GetMetadata), so the extra round-trip is unnecessary. Passing nil is treated as a silent no-op. Safety is preserved: updateMetadata uses SET XX, so a concurrently terminated (deleted) session is never resurrected.
<!--
Link related issues. Use "Closes" or "Fixes" to auto-close on merge.
Remove this line if there is no related issue.
-->

Fixes #4667 

## Type of change

<!-- REQUIRED. Check exactly one. -->

- [ ] Bug fix
- [ ] New feature
- [x] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

<!--
REQUIRED. Check every verification step you actually ran.
You MUST check at least one item. If you only did manual testing,
describe exactly what you tested below the checkbox.
-->

- [x] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [x] Linting (`task lint-fix`)
- [ ] Manual testing (describe below)

## Changes

<!--
Optional — include for PRs touching more than a few files to help
reviewers navigate the diff. Remove this entire section for small PRs.
-->

| File | Change |
|------|--------|
|      |        |

## Does this introduce a user-facing change?

<!--
If yes, describe the change from the user's perspective. This helps with release notes.
If no, write "No".
Remove this section entirely if not applicable.
-->

## Implementation plan

<!--
Optional — include when this PR was planned with an AI assistant (Claude Code, etc.).
Paste the approved plan inside the <details> block so reviewers can see the intended
design without cluttering the main PR description. Remove this section entirely
for PRs that were not AI-planned.
-->

<details>
<summary>Approved implementation plan</summary>

<!-- Paste the plan here -->

</details>

## Special notes for reviewers

<!--
Optional — call out anything non-obvious: tricky logic, known limitations,
areas where you'd like extra scrutiny, or follow-up work planned.
Remove this section if not needed.
-->
