### PR TITLE
Add regression guard for auth context propagation through Close()

### DIFF
--- a/pkg/vmcp/client/auth_propagation_integration_test.go
+++ b/pkg/vmcp/client/auth_propagation_integration_test.go
@@ -1,0 +1,101 @@
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package client_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stacklok/toolhive/pkg/vmcp"
+	vmcpauth "github.com/stacklok/toolhive/pkg/vmcp/auth"
+	"github.com/stacklok/toolhive/pkg/vmcp/auth/strategies"
+	authtypes "github.com/stacklok/toolhive/pkg/vmcp/auth/types"
+	vmcpclient "github.com/stacklok/toolhive/pkg/vmcp/client"
+	healthcontext "github.com/stacklok/toolhive/pkg/vmcp/health/context"
+)
+
+// TestListCapabilities_AuthContextPropagatedThroughClose is a regression test
+// for the bug fixed in #4613, where mcp-go's Close() emits a DELETE request
+// with context.Background(), discarding the health-check marker and identity
+// from the original ListCapabilities context.
+//
+// Without the fix, UpstreamInjectStrategy fails with "no identity found in
+// context" for the DELETE request. When auth fails, authRoundTripper returns
+// an error before sending the request, so the DELETE never reaches the server.
+//
+// This test would fail if identityPropagatingRoundTripper stopped capturing
+// isHealthCheck at transport creation time and re-injecting it into every
+// outgoing request.
+func TestListCapabilities_AuthContextPropagatedThroughClose(t *testing.T) {
+	t.Parallel()
+
+	// Track whether the server received the DELETE that mcp-go sends on Close().
+	// If auth fails in the transport, the request is dropped before reaching the
+	// server and this stays false.
+	var deleteReceived atomic.Bool
+
+	mcpServer := server.NewMCPServer("test-backend", "1.0.0")
+	streamServer := server.NewStreamableHTTPServer(mcpServer)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/mcp", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete {
+			deleteReceived.Store(true)
+		}
+		streamServer.ServeHTTP(w, r)
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	registry := vmcpauth.NewDefaultOutgoingAuthRegistry()
+	err := registry.RegisterStrategy(authtypes.StrategyTypeUpstreamInject, strategies.NewUpstreamInjectStrategy())
+	require.NoError(t, err)
+
+	backendClient, err := vmcpclient.NewHTTPBackendClient(registry)
+	require.NoError(t, err)
+
+	target := &vmcp.BackendTarget{
+		WorkloadID:    "test-backend",
+		WorkloadName:  "Test Backend",
+		BaseURL:       ts.URL + "/mcp",
+		TransportType: "streamable-http",
+		AuthConfig: &authtypes.BackendAuthStrategy{
+			Type: authtypes.StrategyTypeUpstreamInject,
+			UpstreamInject: &authtypes.UpstreamInjectConfig{
+				ProviderName: "test-provider",
+			},
+		},
+	}
+
+	// Health-check context: UpstreamInjectStrategy skips auth when the
+	// health-check marker is present, so no user identity is needed.
+	ctx, cancel := context.WithTimeout(
+		healthcontext.WithHealthCheckMarker(context.Background()),
+		5*time.Second,
+	)
+	defer cancel()
+
+	// Call ListCapabilities — this exercises the full path:
+	//   defaultClientFactory (captures isHealthCheck=true in transport)
+	//   → Initialize → ListTools/Resources/Prompts
+	//   → deferred c.Close() (mcp-go emits DELETE with context.Background())
+	capabilities, err := backendClient.ListCapabilities(ctx, target)
+	require.NoError(t, err)
+	require.NotNil(t, capabilities)
+
+	// REGRESSION GUARD: the transport must re-inject the health-check marker
+	// into the DELETE from Close(). If it doesn't, UpstreamInjectStrategy
+	// fails with "no identity found in context", authRoundTripper drops the
+	// request before sending, and the server never sees the DELETE.
+	assert.True(t, deleteReceived.Load(),
+		"server did not receive DELETE: auth context propagation regression (#4613) likely reintroduced")
+}


### PR DESCRIPTION
## Summary

<!--
REQUIRED. You MUST explain:
1. WHY this change is needed (the problem or motivation)
2. WHAT changed (concise bullet points)

The diff shows the code — your summary must provide the context a reviewer
needs to understand the purpose without reading the diff first.
-->
Adds an integration test for the ListCapabilities → Close() path that would fail if the context.Background() regression from #4613 were reintroduced. Uses a proper streamable-HTTP server (NewStreamableHTTPServer) so mcp-go issues a session ID and actually sends a DELETE on Close().

The assertion is a server-side atomic flag: if auth fails for the DELETE, authRoundTripper drops the request before it reaches the server, the flag stays false, and the test fails.

<!--
Link related issues. Use "Closes" or "Fixes" to auto-close on merge.
Remove this line if there is no related issue.
-->

Fixes #4725 

## Type of change

<!-- REQUIRED. Check exactly one. -->

- [ ] Bug fix
- [ ] New feature
- [x] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

<!--
REQUIRED. Check every verification step you actually ran.
You MUST check at least one item. If you only did manual testing,
describe exactly what you tested below the checkbox.
-->

- [x] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [x] Linting (`task lint-fix`)
- [ ] Manual testing (describe below)

## Changes

<!--
Optional — include for PRs touching more than a few files to help
reviewers navigate the diff. Remove this entire section for small PRs.
-->

| File | Change |
|------|--------|
|      |        |

## Does this introduce a user-facing change?

<!--
If yes, describe the change from the user's perspective. This helps with release notes.
If no, write "No".
Remove this section entirely if not applicable.
-->

## Implementation plan

<!--
Optional — include when this PR was planned with an AI assistant (Claude Code, etc.).
Paste the approved plan inside the <details> block so reviewers can see the intended
design without cluttering the main PR description. Remove this section entirely
for PRs that were not AI-planned.
-->

<details>
<summary>Approved implementation plan</summary>

<!-- Paste the plan here -->

</details>

## Special notes for reviewers

<!--
Optional — call out anything non-obvious: tricky logic, known limitations,
areas where you'd like extra scrutiny, or follow-up work planned.
Remove this section if not needed.
-->
