### PR TITLE
Add Kimi Code CLI as a supported MCP client

### DIFF
--- a/docs/cli/thv_client_register.md
+++ b/docs/cli/thv_client_register.md
@@ -31,6 +31,7 @@ Valid clients:
   - cursor: Cursor editor
   - gemini-cli: Google Gemini CLI
   - goose: Goose AI agent
+  - kimi-cli: Kimi Code CLI
   - kiro: Kiro AI IDE
   - lm-studio: LM Studio application
   - mistral-vibe: Mistral Vibe IDE

--- a/docs/cli/thv_client_remove.md
+++ b/docs/cli/thv_client_remove.md
@@ -31,6 +31,7 @@ Valid clients:
   - cursor: Cursor editor
   - gemini-cli: Google Gemini CLI
   - goose: Goose AI agent
+  - kimi-cli: Kimi Code CLI
   - kiro: Kiro AI IDE
   - lm-studio: LM Studio application
   - mistral-vibe: Mistral Vibe IDE

--- a/docs/server/docs.go
+++ b/docs/server/docs.go
@@ -827,7 +827,8 @@ const docTemplate = `{
                     "gemini-cli",
                     "vscode-server",
                     "mistral-vibe",
-                    "codex"
+                    "codex",
+                    "kimi-cli"
                 ],
                 "type": "string",
                 "x-enum-varnames": [
@@ -855,7 +856,8 @@ const docTemplate = `{
                     "GeminiCli",
                     "VSCodeServer",
                     "MistralVibe",
-                    "Codex"
+                    "Codex",
+                    "KimiCli"
                 ]
             },
             "github_com_stacklok_toolhive_pkg_client.ClientAppStatus": {

--- a/docs/server/swagger.json
+++ b/docs/server/swagger.json
@@ -820,7 +820,8 @@
                     "gemini-cli",
                     "vscode-server",
                     "mistral-vibe",
-                    "codex"
+                    "codex",
+                    "kimi-cli"
                 ],
                 "type": "string",
                 "x-enum-varnames": [
@@ -848,7 +849,8 @@
                     "GeminiCli",
                     "VSCodeServer",
                     "MistralVibe",
-                    "Codex"
+                    "Codex",
+                    "KimiCli"
                 ]
             },
             "github_com_stacklok_toolhive_pkg_client.ClientAppStatus": {

--- a/docs/server/swagger.yaml
+++ b/docs/server/swagger.yaml
@@ -800,6 +800,7 @@ components:
       - vscode-server
       - mistral-vibe
       - codex
+      - kimi-cli
       type: string
       x-enum-varnames:
       - RooCode
@@ -827,6 +828,7 @@ components:
       - VSCodeServer
       - MistralVibe
       - Codex
+      - KimiCli
     github_com_stacklok_toolhive_pkg_client.ClientAppStatus:
       properties:
         client_type:

--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -82,6 +82,8 @@ const (
 	MistralVibe ClientApp = "mistral-vibe"
 	// Codex represents the OpenAI Codex CLI.
 	Codex ClientApp = "codex"
+	// KimiCli represents the Kimi Code CLI.
+	KimiCli ClientApp = "kimi-cli"
 )
 
 // Extension is extension of the client config file.
@@ -743,6 +745,24 @@ var supportedClientIntegrations = []clientAppConfig{
 		SupportsSkills:    true,
 		SkillsGlobalPath:  []string{".agents", "skills"},
 		SkillsProjectPath: []string{".agents", "skills"},
+	},
+	{
+		ClientType:           KimiCli,
+		Description:          "Kimi Code CLI",
+		SettingsFile:         "mcp.json",
+		MCPServersPathPrefix: "/mcpServers",
+		RelPath:              []string{".kimi"},
+		Extension:            JSON,
+		// Kimi CLI does not use a transport type field in the config file
+		IsTransportTypeFieldSupported: false,
+		MCPServersUrlLabelMap: map[types.TransportType]string{
+			types.TransportTypeStdio:          "url",
+			types.TransportTypeSSE:            "url",
+			types.TransportTypeStreamableHTTP: "url",
+		},
+		SupportsSkills:    true,
+		SkillsGlobalPath:  []string{".kimi", "skills"},
+		SkillsProjectPath: []string{".kimi", "skills"},
 	},
 }
 

--- a/pkg/client/config_test.go
+++ b/pkg/client/config_test.go
@@ -209,6 +209,14 @@ func createMockClientConfigs() []clientAppConfig {
 			Extension:            TOML,
 			TOMLStorageType:      TOMLStorageTypeMap,
 		},
+		{
+			ClientType:           KimiCli,
+			Description:          "Kimi Code CLI (Mock)",
+			RelPath:              []string{"mock_kimi"},
+			SettingsFile:         "mcp.json",
+			MCPServersPathPrefix: "/mcpServers",
+			Extension:            JSON,
+		},
 	}
 }
 
@@ -394,6 +402,7 @@ func TestSuccessfulClientConfigOperations(t *testing.T) {
 					string(VSCodeServer),
 					string(MistralVibe),
 					string(Codex),
+					string(KimiCli),
 				},
 			},
 		}
@@ -486,7 +495,7 @@ func TestSuccessfulClientConfigOperations(t *testing.T) {
 			case AmpWindsurf:
 				assert.Contains(t, string(content), `"mcpServers":`,
 					"AmpWindsurf config should contain mcpServers key")
-			case LMStudio, Trae, Kiro, Antigravity, GeminiCli:
+			case LMStudio, Trae, Kiro, Antigravity, GeminiCli, KimiCli:
 				assert.Contains(t, string(content), `"mcpServers":`,
 					"Config should contain mcpServers key")
 			case VSCodeServer:
@@ -543,9 +552,9 @@ func TestSuccessfulClientConfigOperations(t *testing.T) {
 			case VSCode, VSCodeInsider:
 				assert.Contains(t, string(content), testURL,
 					"VSCode config should contain the server URL")
-			case Cursor, RooCode, ClaudeCode, Cline, Windsurf, WindsurfJetBrains, AmpCli,
-				AmpVSCode, AmpCursor, AmpVSCodeInsider, AmpWindsurf, LMStudio, Goose, Trae, Continue, OpenCode, Kiro, Antigravity, Zed, GeminiCli, VSCodeServer,
-				MistralVibe, Codex:
+		case Cursor, RooCode, ClaudeCode, Cline, Windsurf, WindsurfJetBrains, AmpCli,
+			AmpVSCode, AmpCursor, AmpVSCodeInsider, AmpWindsurf, LMStudio, Goose, Trae, Continue, OpenCode, Kiro, Antigravity, Zed, GeminiCli, VSCodeServer,
+			MistralVibe, Codex, KimiCli:
 				assert.Contains(t, string(content), testURL,
 					"Config should contain the server URL")
 			}
@@ -1274,8 +1283,8 @@ func TestGetAllClients(t *testing.T) {
 
 	clients := GetAllClients()
 
-	// Should return all 25 supported clients
-	assert.Len(t, clients, 25, "Expected 25 supported clients")
+	// Should return all 26 supported clients
+	assert.Len(t, clients, 26, "Expected 26 supported clients")
 
 	// Verify the list is sorted alphabetically
 	for i := 1; i < len(clients); i++ {
@@ -1463,5 +1472,5 @@ func TestGetClientListCSV(t *testing.T) {
 
 	// Count the number of clients (should be 25)
 	clients := strings.Split(csv, ", ")
-	assert.Len(t, clients, 25, "Expected 25 clients in CSV list")
+	assert.Len(t, clients, 26, "Expected 26 clients in CSV list")
 }

--- a/pkg/client/config_test.go
+++ b/pkg/client/config_test.go
@@ -552,9 +552,9 @@ func TestSuccessfulClientConfigOperations(t *testing.T) {
 			case VSCode, VSCodeInsider:
 				assert.Contains(t, string(content), testURL,
 					"VSCode config should contain the server URL")
-		case Cursor, RooCode, ClaudeCode, Cline, Windsurf, WindsurfJetBrains, AmpCli,
-			AmpVSCode, AmpCursor, AmpVSCodeInsider, AmpWindsurf, LMStudio, Goose, Trae, Continue, OpenCode, Kiro, Antigravity, Zed, GeminiCli, VSCodeServer,
-			MistralVibe, Codex, KimiCli:
+			case Cursor, RooCode, ClaudeCode, Cline, Windsurf, WindsurfJetBrains, AmpCli,
+				AmpVSCode, AmpCursor, AmpVSCodeInsider, AmpWindsurf, LMStudio, Goose, Trae, Continue, OpenCode, Kiro, Antigravity, Zed, GeminiCli, VSCodeServer,
+				MistralVibe, Codex, KimiCli:
 				assert.Contains(t, string(content), testURL,
 					"Config should contain the server URL")
 			}

--- a/pkg/client/skills_test.go
+++ b/pkg/client/skills_test.go
@@ -47,6 +47,12 @@ func testSkillClientIntegrations() []clientAppConfig {
 			SkillsProjectPath: []string{".cursor", "skills"},
 		},
 		{
+			ClientType:        KimiCli,
+			SupportsSkills:    true,
+			SkillsGlobalPath:  []string{".kimi", "skills"},
+			SkillsProjectPath: []string{".kimi", "skills"},
+		},
+		{
 			ClientType: VSCode,
 			// SupportsSkills defaults to false
 		},
@@ -77,6 +83,7 @@ func TestSupportsSkills(t *testing.T) {
 		{name: "Codex supports skills", client: Codex, expected: true},
 		{name: "OpenCode supports skills", client: OpenCode, expected: true},
 		{name: "Cursor supports skills", client: Cursor, expected: true},
+		{name: "KimiCli supports skills", client: KimiCli, expected: true},
 		{name: "unknown client returns false", client: ClientApp("nonexistent"), expected: false},
 	}
 
@@ -93,8 +100,8 @@ func TestListSkillSupportingClients(t *testing.T) {
 	cm := newTestSkillManager()
 	clients := cm.ListSkillSupportingClients()
 
-	// Should include ClaudeCode, Codex, Cursor, OpenCode, and our test-only no-paths-client
-	require.Len(t, clients, 5, "unexpected number of skill-supporting clients: %v", clients)
+	// Should include ClaudeCode, Codex, Cursor, KimiCli, OpenCode, and our test-only no-paths-client
+	require.Len(t, clients, 6, "unexpected number of skill-supporting clients: %v", clients)
 
 	// Verify sorted order
 	for i := 1; i < len(clients); i++ {
@@ -205,6 +212,21 @@ func TestGetSkillPath(t *testing.T) {
 			scope:       skills.ScopeProject,
 			projectRoot: "/tmp/myproject",
 			wantPath:    filepath.Join("/tmp/myproject", ".cursor", "skills", "my-skill"),
+		},
+		{
+			name:      "ScopeUser KimiCli",
+			client:    KimiCli,
+			skillName: "my-skill",
+			scope:     skills.ScopeUser,
+			wantPath:  filepath.Join(testHomeDir, ".kimi", "skills", "my-skill"),
+		},
+		{
+			name:        "ScopeProject KimiCli with explicit root",
+			client:      KimiCli,
+			skillName:   "my-skill",
+			scope:       skills.ScopeProject,
+			projectRoot: "/tmp/myproject",
+			wantPath:    filepath.Join("/tmp/myproject", ".kimi", "skills", "my-skill"),
 		},
 		{
 			name:      "client that does not support skills",


### PR DESCRIPTION
## Summary

Registers [Kimi Code CLI](https://github.com/MoonshotAI/kimi-cli) as a supported MCP client in ToolHive.

- MCP servers are written to `~/.kimi/mcp.json` using the standard `mcpServers` format; no transport type field is written — Kimi CLI auto-detects from URL presence
- Skills install to `~/.kimi/skills/<name>` (user scope) and `<project>/.kimi/skills/<name>` (project scope) — matching Kimi's brand group path convention

Closes #4786

## Type of change

New feature

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)

## Changes

| File | Change |
|------|--------|
| `pkg/client/config.go` | Add `KimiCli` constant and `clientAppConfig` entry with MCP + skills config |
| `pkg/client/config_test.go` | Add mock config, extend switch cases, bump client count 25 → 26 |
| `pkg/client/skills_test.go` | Add `KimiCli` to fixture, `TestSupportsSkills`, `TestListSkillSupportingClients`, `TestGetSkillPath` |
| `docs/server/swagger.json` / `docs/server/docs.go` | Add `kimi-cli` to `ClientApp` enum |
| `docs/cli/thv_client_register.md` / `docs/cli/thv_client_remove.md` | Regenerated client list |

## Does this introduce a user-facing change?

Yes — `thv client register kimi-cli` and `thv skill install --clients kimi-cli` (or `--clients all`) now work. MCP servers land in `~/.kimi/mcp.json` and skills in `~/.kimi/skills/` so Kimi CLI picks them up automatically.