### PR TITLE
Clean up health check dead code and timeout

### DIFF
--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -106,11 +106,7 @@ func (hc *HealthChecker) checkMCPStatus(ctx context.Context) *MCPStatus {
 		LastChecked: time.Now(),
 	}
 
-	// Create a context with timeout for the ping
-	pingCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	defer cancel()
-
-	duration, err := hc.mcpPinger.Ping(pingCtx)
+	duration, err := hc.mcpPinger.Ping(ctx)
 
 	if err != nil {
 		status.Available = false

--- a/pkg/transport/proxy/transparent/transparent_proxy.go
+++ b/pkg/transport/proxy/transparent/transparent_proxy.go
@@ -456,14 +456,10 @@ func NewTransparentProxyWithOptions(
 	// Create health checker always for Kubernetes probes
 	var mcpPinger healthcheck.MCPPinger
 	if enableHealthCheck {
-		pingTimeout := proxy.healthCheckPingTimeout
-		if pingTimeout == 0 {
-			pingTimeout = DefaultPingerTimeout
-		}
 		if proxy.stateless {
-			mcpPinger = NewStatelessMCPPingerWithTimeout(targetURI, pingTimeout)
+			mcpPinger = NewStatelessMCPPingerWithTimeout(targetURI, proxy.healthCheckPingTimeout)
 		} else {
-			mcpPinger = NewMCPPingerWithTimeout(targetURI, pingTimeout)
+			mcpPinger = NewMCPPingerWithTimeout(targetURI, proxy.healthCheckPingTimeout)
 		}
 	}
 	proxy.healthChecker = healthcheck.NewHealthChecker(transportType, mcpPinger)
@@ -1246,11 +1242,7 @@ func (p *TransparentProxy) handleHealthCheckFailure(
 }
 
 func (p *TransparentProxy) monitorHealth(parentCtx context.Context) {
-	interval := p.healthCheckInterval
-	if interval == 0 {
-		interval = DefaultHealthCheckInterval
-	}
-	ticker := time.NewTicker(interval)
+	ticker := time.NewTicker(p.healthCheckInterval)
 	defer ticker.Stop()
 
 	consecutiveFailures := 0


### PR DESCRIPTION
## Summary

- PR #4108 made health check parameters configurable. During review, jhrozek identified two remaining cleanup items and agreed to a follow-up PR.
- Remove two dead zero-value guards in `transparent_proxy.go` — the constructor and functional options guarantee positive values, making these unreachable.
- Remove the redundant `context.WithTimeout(ctx, 5*time.Second)` in `checkMCPStatus` — the `MCPPinger` already enforces its own timeout internally (`http.Client.Timeout` for the transparent proxy pinger, non-blocking send for the httpsse pinger). The hardcoded 5s context timeout silently capped `TOOLHIVE_HEALTH_CHECK_PING_TIMEOUT` at 5s.

Fixes #4790

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)

## Special notes for reviewers

The redundant context timeout in `checkMCPStatus` is removed rather than plumbed with the configured value. Both existing `MCPPinger` implementations own their timeouts: the transparent proxy pinger sets `http.Client.Timeout` to the configured ping timeout, and the httpsse pinger is non-blocking (fire-and-forget channel send that returns immediately). The `HealthChecker` doesn't need to duplicate timeout enforcement that the pinger already handles. The equivalent dead guard for `retryDelay` was already removed in PR #4108 (commit a41f8a87).

Generated with [Claude Code](https://claude.com/claude-code)