### PR TITLE
Add Factory.ai as a supported MCP client

### DIFF
--- a/docs/cli/thv_client_register.md
+++ b/docs/cli/thv_client_register.md
@@ -29,6 +29,7 @@ Valid clients:
   - codex: OpenAI Codex CLI
   - continue: Continue.dev IDE plugins
   - cursor: Cursor editor
+  - factory: Factory.ai Droid CLI
   - gemini-cli: Google Gemini CLI
   - goose: Goose AI agent
   - kimi-cli: Kimi Code CLI

--- a/docs/cli/thv_client_remove.md
+++ b/docs/cli/thv_client_remove.md
@@ -29,6 +29,7 @@ Valid clients:
   - codex: OpenAI Codex CLI
   - continue: Continue.dev IDE plugins
   - cursor: Cursor editor
+  - factory: Factory.ai Droid CLI
   - gemini-cli: Google Gemini CLI
   - goose: Goose AI agent
   - kimi-cli: Kimi Code CLI

--- a/docs/server/docs.go
+++ b/docs/server/docs.go
@@ -828,7 +828,8 @@ const docTemplate = `{
                     "vscode-server",
                     "mistral-vibe",
                     "codex",
-                    "kimi-cli"
+                    "kimi-cli",
+                    "factory"
                 ],
                 "type": "string",
                 "x-enum-varnames": [
@@ -857,7 +858,8 @@ const docTemplate = `{
                     "VSCodeServer",
                     "MistralVibe",
                     "Codex",
-                    "KimiCli"
+                    "KimiCli",
+                    "Factory"
                 ]
             },
             "github_com_stacklok_toolhive_pkg_client.ClientAppStatus": {

--- a/docs/server/swagger.json
+++ b/docs/server/swagger.json
@@ -821,7 +821,8 @@
                     "vscode-server",
                     "mistral-vibe",
                     "codex",
-                    "kimi-cli"
+                    "kimi-cli",
+                    "factory"
                 ],
                 "type": "string",
                 "x-enum-varnames": [
@@ -850,7 +851,8 @@
                     "VSCodeServer",
                     "MistralVibe",
                     "Codex",
-                    "KimiCli"
+                    "KimiCli",
+                    "Factory"
                 ]
             },
             "github_com_stacklok_toolhive_pkg_client.ClientAppStatus": {

--- a/docs/server/swagger.yaml
+++ b/docs/server/swagger.yaml
@@ -801,6 +801,7 @@ components:
       - mistral-vibe
       - codex
       - kimi-cli
+      - factory
       type: string
       x-enum-varnames:
       - RooCode
@@ -829,6 +830,7 @@ components:
       - MistralVibe
       - Codex
       - KimiCli
+      - Factory
     github_com_stacklok_toolhive_pkg_client.ClientAppStatus:
       properties:
         client_type:

--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -84,6 +84,8 @@ const (
 	Codex ClientApp = "codex"
 	// KimiCli represents the Kimi Code CLI.
 	KimiCli ClientApp = "kimi-cli"
+	// Factory represents the Factory.ai Droid CLI.
+	Factory ClientApp = "factory"
 )
 
 // Extension is extension of the client config file.
@@ -769,6 +771,28 @@ var supportedClientIntegrations = []clientAppConfig{
 		SupportsSkills:    true,
 		SkillsGlobalPath:  []string{".kimi", "skills"},
 		SkillsProjectPath: []string{".kimi", "skills"},
+	},
+	{
+		ClientType:           Factory,
+		Description:          "Factory.ai Droid CLI",
+		SettingsFile:         "mcp.json",
+		MCPServersPathPrefix: "/mcpServers",
+		RelPath:              []string{".factory"},
+		Extension:            JSON,
+		SupportedTransportTypesMap: map[types.TransportType]string{
+			types.TransportTypeStdio:          "http",
+			types.TransportTypeSSE:            "sse",
+			types.TransportTypeStreamableHTTP: "http",
+		},
+		IsTransportTypeFieldSupported: true,
+		MCPServersUrlLabelMap: map[types.TransportType]string{
+			types.TransportTypeStdio:          "url",
+			types.TransportTypeSSE:            "url",
+			types.TransportTypeStreamableHTTP: "url",
+		},
+		SupportsSkills:    true,
+		SkillsGlobalPath:  []string{".factory", "skills"},
+		SkillsProjectPath: []string{".factory", "skills"},
 	},
 }
 

--- a/pkg/client/config_test.go
+++ b/pkg/client/config_test.go
@@ -217,6 +217,14 @@ func createMockClientConfigs() []clientAppConfig {
 			MCPServersPathPrefix: "/mcpServers",
 			Extension:            JSON,
 		},
+		{
+			ClientType:           Factory,
+			Description:          "Factory.ai Droid CLI (Mock)",
+			RelPath:              []string{"mock_factory"},
+			SettingsFile:         "mcp.json",
+			MCPServersPathPrefix: "/mcpServers",
+			Extension:            JSON,
+		},
 	}
 }
 
@@ -403,6 +411,7 @@ func TestSuccessfulClientConfigOperations(t *testing.T) {
 					string(MistralVibe),
 					string(Codex),
 					string(KimiCli),
+					string(Factory),
 				},
 			},
 		}
@@ -495,7 +504,7 @@ func TestSuccessfulClientConfigOperations(t *testing.T) {
 			case AmpWindsurf:
 				assert.Contains(t, string(content), `"mcpServers":`,
 					"AmpWindsurf config should contain mcpServers key")
-			case LMStudio, Trae, Kiro, Antigravity, GeminiCli, KimiCli:
+			case LMStudio, Trae, Kiro, Antigravity, GeminiCli, KimiCli, Factory:
 				assert.Contains(t, string(content), `"mcpServers":`,
 					"Config should contain mcpServers key")
 			case VSCodeServer:
@@ -554,7 +563,7 @@ func TestSuccessfulClientConfigOperations(t *testing.T) {
 					"VSCode config should contain the server URL")
 			case Cursor, RooCode, ClaudeCode, Cline, Windsurf, WindsurfJetBrains, AmpCli,
 				AmpVSCode, AmpCursor, AmpVSCodeInsider, AmpWindsurf, LMStudio, Goose, Trae, Continue, OpenCode, Kiro, Antigravity, Zed, GeminiCli, VSCodeServer,
-				MistralVibe, Codex, KimiCli:
+				MistralVibe, Codex, KimiCli, Factory:
 				assert.Contains(t, string(content), testURL,
 					"Config should contain the server URL")
 			}
@@ -1283,8 +1292,8 @@ func TestGetAllClients(t *testing.T) {
 
 	clients := GetAllClients()
 
-	// Should return all 26 supported clients
-	assert.Len(t, clients, 26, "Expected 26 supported clients")
+	// Should return all 27 supported clients
+	assert.Len(t, clients, 27, "Expected 27 supported clients")
 
 	// Verify the list is sorted alphabetically
 	for i := 1; i < len(clients); i++ {
@@ -1472,5 +1481,5 @@ func TestGetClientListCSV(t *testing.T) {
 
 	// Count the number of clients (should be 25)
 	clients := strings.Split(csv, ", ")
-	assert.Len(t, clients, 26, "Expected 26 clients in CSV list")
+	assert.Len(t, clients, 27, "Expected 27 clients in CSV list")
 }

--- a/pkg/client/skills_test.go
+++ b/pkg/client/skills_test.go
@@ -53,6 +53,12 @@ func testSkillClientIntegrations() []clientAppConfig {
 			SkillsProjectPath: []string{".kimi", "skills"},
 		},
 		{
+			ClientType:        Factory,
+			SupportsSkills:    true,
+			SkillsGlobalPath:  []string{".factory", "skills"},
+			SkillsProjectPath: []string{".factory", "skills"},
+		},
+		{
 			ClientType:        VSCode,
 			SupportsSkills:    true,
 			SkillsGlobalPath:  []string{".copilot", "skills"},
@@ -98,6 +104,7 @@ func TestSupportsSkills(t *testing.T) {
 		{name: "KimiCli supports skills", client: KimiCli, expected: true},
 		{name: "VSCode supports skills", client: VSCode, expected: true},
 		{name: "VSCodeInsider supports skills", client: VSCodeInsider, expected: true},
+		{name: "Factory supports skills", client: Factory, expected: true},
 		{name: "Windsurf does not support skills", client: Windsurf, expected: false},
 		{name: "unknown client returns false", client: ClientApp("nonexistent"), expected: false},
 	}
@@ -115,8 +122,8 @@ func TestListSkillSupportingClients(t *testing.T) {
 	cm := newTestSkillManager()
 	clients := cm.ListSkillSupportingClients()
 
-	// Should include ClaudeCode, Codex, Cursor, KimiCli, OpenCode, VSCode, VSCodeInsider, and our test-only no-paths-client
-	require.Len(t, clients, 8, "unexpected number of skill-supporting clients: %v", clients)
+	// Should include ClaudeCode, Codex, Cursor, Factory, KimiCli, OpenCode, VSCode, VSCodeInsider, and our test-only no-paths-client
+	require.Len(t, clients, 9, "unexpected number of skill-supporting clients: %v", clients)
 
 	// Verify sorted order
 	for i := 1; i < len(clients); i++ {
@@ -242,6 +249,21 @@ func TestGetSkillPath(t *testing.T) {
 			scope:       skills.ScopeProject,
 			projectRoot: "/tmp/myproject",
 			wantPath:    filepath.Join("/tmp/myproject", ".kimi", "skills", "my-skill"),
+		},
+		{
+			name:      "ScopeUser Factory",
+			client:    Factory,
+			skillName: "my-skill",
+			scope:     skills.ScopeUser,
+			wantPath:  filepath.Join(testHomeDir, ".factory", "skills", "my-skill"),
+		},
+		{
+			name:        "ScopeProject Factory with explicit root",
+			client:      Factory,
+			skillName:   "my-skill",
+			scope:       skills.ScopeProject,
+			projectRoot: "/tmp/myproject",
+			wantPath:    filepath.Join("/tmp/myproject", ".factory", "skills", "my-skill"),
 		},
 		{
 			name:      "ScopeUser VSCode",


### PR DESCRIPTION
## Summary

Registers [Factory.ai (Droid)](https://docs.factory.ai/cli/configuration/mcp) as a supported MCP client in ToolHive.

- MCP servers are written to `~/.factory/mcp.json` using the standard `mcpServers` format; transport type field is written as `"http"` or `"sse"` per Factory's schema
- Skills install to `~/.factory/skills/<name>` (user scope) and `<project>/.factory/skills/<name>` (project scope) — matching Factory's conventions

## Type of change

New feature

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)

## Changes

| File | Change |
|------|--------|
| `pkg/client/config.go` | Add `Factory` constant and `clientAppConfig` entry with MCP + skills config |
| `pkg/client/config_test.go` | Add mock config, extend switch cases, bump client count 26 → 27 |
| `pkg/client/skills_test.go` | Add `Factory` to fixture, `TestSupportsSkills`, `TestListSkillSupportingClients`, `TestGetSkillPath` |
| docs/cli/thv_client_register.md / docs/cli/thv_client_remove.md | Add factory to client list |

## Does this introduce a user-facing change?

Yes — `thv client register factory` and `thv skill install --clients factory` (or `--clients all`) now work. MCP servers land in `~/.factory/mcp.json` and skills in `~/.factory/skills/` so Droid picks them up automatically.