### PR TITLE
Remove Upsert from DataStorage interface — closes #4726

### DIFF
--- a/pkg/transport/session/session_data_storage.go
+++ b/pkg/transport/session/session_data_storage.go
@@ -23,11 +23,12 @@ import (
 // # Contract
 //
 //   - Create atomically creates metadata for id only if it does not already exist.
-//     Use this in preference to Load+Upsert to avoid TOCTOU races.
-//   - Upsert creates or overwrites the metadata for id, refreshing the TTL.
+//     Returns (true, nil) if created, (false, nil) if the key already existed.
 //   - Update overwrites metadata only if the key already exists (SET XX semantics).
 //     Returns (true, nil) if updated, (false, nil) if the session was not found.
-//     Use this instead of Load+Upsert to avoid TOCTOU resurrection races.
+//     Use this instead of Load→mutate→unconditional-write to avoid TOCTOU
+//     resurrection races (a concurrent Delete between Load and write would be
+//     silently undone by an unconditional write).
 //   - Load retrieves metadata and refreshes the TTL (sliding-window expiry).
 //     Returns ErrSessionNotFound if the session does not exist.
 //   - Delete removes the session. It is not an error if the session is absent.
@@ -39,26 +40,22 @@ import (
 //   - LocalSessionDataStorage (in-memory, single-process)
 //   - RedisSessionDataStorage (Redis/Valkey, multi-process)
 type DataStorage interface {
-	// Upsert creates or updates session metadata with a sliding TTL.
-	Upsert(ctx context.Context, id string, metadata map[string]string) error
+	// Create atomically creates session metadata only if the session ID
+	// does not already exist. Returns (true, nil) if the entry was created,
+	// (false, nil) if it already existed, or (false, err) on storage errors.
+	Create(ctx context.Context, id string, metadata map[string]string) (bool, error)
 
 	// Update overwrites session metadata only if the session ID already exists
 	// (conditional write, equivalent to Redis SET XX). Returns (true, nil) if
 	// the entry was updated, (false, nil) if it was not found, or (false, err)
-	// on storage errors. Use this instead of Load+Upsert to prevent resurrections
-	// after a concurrent Delete.
+	// on storage errors. Use this (SET XX) for writes that must not recreate a
+	// key that was concurrently deleted — an unconditional write would silently
+	// resurrect a session the caller intentionally terminated.
 	Update(ctx context.Context, id string, metadata map[string]string) (bool, error)
 
 	// Load retrieves session metadata and refreshes its TTL.
 	// Returns ErrSessionNotFound if the session does not exist.
 	Load(ctx context.Context, id string) (map[string]string, error)
-
-	// Create atomically creates session metadata only if the session ID
-	// does not already exist. Returns (true, nil) if the entry was created,
-	// (false, nil) if it already existed, or (false, err) on storage errors.
-	// Use this in preference to Load+Upsert to avoid TOCTOU races in
-	// multi-pod deployments.
-	Create(ctx context.Context, id string, metadata map[string]string) (bool, error)
 
 	// Delete removes session metadata. Not an error if absent.
 	Delete(ctx context.Context, id string) error

--- a/pkg/transport/session/session_data_storage_local.go
+++ b/pkg/transport/session/session_data_storage_local.go
@@ -42,20 +42,6 @@ type LocalSessionDataStorage struct {
 	stopOnce sync.Once
 }
 
-// Upsert creates or updates session metadata.
-func (s *LocalSessionDataStorage) Upsert(_ context.Context, id string, metadata map[string]string) error {
-	if id == "" {
-		return fmt.Errorf("cannot write session data with empty ID")
-	}
-	if metadata == nil {
-		metadata = make(map[string]string)
-	}
-	s.mu.Lock()
-	s.sessions[id] = newLocalDataEntry(maps.Clone(metadata))
-	s.mu.Unlock()
-	return nil
-}
-
 // Load retrieves session metadata and refreshes its last-access timestamp.
 // Returns ErrSessionNotFound if the session does not exist.
 func (s *LocalSessionDataStorage) Load(_ context.Context, id string) (map[string]string, error) {

--- a/pkg/transport/session/session_data_storage_redis.go
+++ b/pkg/transport/session/session_data_storage_redis.go
@@ -16,7 +16,7 @@ import (
 // RedisSessionDataStorage implements DataStorage backed by Redis/Valkey.
 //
 // Metadata is serialized as a JSON object and stored with a sliding-window TTL:
-// each Upsert/Load call refreshes the key's expiry so that active sessions
+// each Create/Update/Load call refreshes the key's expiry so that active sessions
 // never expire while they are in use.
 //
 // Because only plain map[string]string is stored, there are no type assertions
@@ -29,7 +29,7 @@ type RedisSessionDataStorage struct {
 
 // NewRedisSessionDataStorage constructs a RedisSessionDataStorage.
 // cfg provides connection parameters; ttl is the sliding-window expiry applied
-// on every Upsert and Load. The caller must call Close when done.
+// on every Create/Update and Load. The caller must call Close when done.
 func NewRedisSessionDataStorage(ctx context.Context, cfg RedisConfig, ttl time.Duration) (*RedisSessionDataStorage, error) {
 	if err := validateRedisConfig(&cfg); err != nil {
 		return nil, fmt.Errorf("invalid redis configuration: %w", err)
@@ -50,21 +50,6 @@ func NewRedisSessionDataStorage(ctx context.Context, cfg RedisConfig, ttl time.D
 
 func (s *RedisSessionDataStorage) key(id string) string {
 	return s.keyPrefix + id
-}
-
-// Upsert serializes metadata as JSON and writes it to Redis with a sliding TTL.
-func (s *RedisSessionDataStorage) Upsert(ctx context.Context, id string, metadata map[string]string) error {
-	if id == "" {
-		return fmt.Errorf("cannot write session data with empty ID")
-	}
-	if metadata == nil {
-		metadata = make(map[string]string)
-	}
-	data, err := json.Marshal(metadata)
-	if err != nil {
-		return fmt.Errorf("failed to serialize session metadata: %w", err)
-	}
-	return s.client.Set(ctx, s.key(id), data, s.ttl).Err()
 }
 
 // Load retrieves metadata from Redis and refreshes the key's TTL via GETEX.
@@ -120,8 +105,9 @@ func (s *RedisSessionDataStorage) Update(ctx context.Context, id string, metadat
 }
 
 // Create atomically creates session metadata only if the key does not
-// already exist. Uses Redis SET NX (set-if-not-exists) to eliminate the
-// TOCTOU race between Load and Upsert in multi-pod deployments.
+// already exist. Uses Redis SET NX (set-if-not-exists) to avoid the
+// read-then-write TOCTOU race that a Load-then-unconditional-write pattern
+// would introduce in multi-pod deployments.
 func (s *RedisSessionDataStorage) Create(ctx context.Context, id string, metadata map[string]string) (bool, error) {
 	if id == "" {
 		return false, fmt.Errorf("cannot write session data with empty ID")

--- a/pkg/transport/session/session_data_storage_test.go
+++ b/pkg/transport/session/session_data_storage_test.go
@@ -25,13 +25,15 @@ import (
 func runDataStorageTests(t *testing.T, newStorage func(t *testing.T) DataStorage) {
 	t.Helper()
 
-	t.Run("Upsert and Load round-trip", func(t *testing.T) {
+	t.Run("Create and Load round-trip", func(t *testing.T) {
 		t.Parallel()
 		s := newStorage(t)
 		ctx := context.Background()
 
 		meta := map[string]string{"key": "value", "env": "test"}
-		require.NoError(t, s.Upsert(ctx, "sess-1", meta))
+		stored, err := s.Create(ctx, "sess-1", meta)
+		require.NoError(t, err)
+		require.True(t, stored)
 
 		loaded, err := s.Load(ctx, "sess-1")
 		require.NoError(t, err)
@@ -39,37 +41,17 @@ func runDataStorageTests(t *testing.T, newStorage func(t *testing.T) DataStorage
 		assert.Equal(t, "test", loaded["env"])
 	})
 
-	t.Run("Upsert overwrites existing entry", func(t *testing.T) {
+	t.Run("Create nil metadata is treated as empty map", func(t *testing.T) {
 		t.Parallel()
 		s := newStorage(t)
 		ctx := context.Background()
 
-		require.NoError(t, s.Upsert(ctx, "sess-upsert", map[string]string{"v": "1"}))
-		require.NoError(t, s.Upsert(ctx, "sess-upsert", map[string]string{"v": "2"}))
-
-		loaded, err := s.Load(ctx, "sess-upsert")
+		stored, err := s.Create(ctx, "sess-nil-meta", nil)
 		require.NoError(t, err)
-		assert.Equal(t, "2", loaded["v"])
-	})
-
-	t.Run("Upsert nil metadata is treated as empty map", func(t *testing.T) {
-		t.Parallel()
-		s := newStorage(t)
-		ctx := context.Background()
-
-		require.NoError(t, s.Upsert(ctx, "sess-nil-meta", nil))
+		require.True(t, stored)
 		loaded, err := s.Load(ctx, "sess-nil-meta")
 		require.NoError(t, err)
 		assert.NotNil(t, loaded)
-	})
-
-	t.Run("Upsert with empty ID returns error", func(t *testing.T) {
-		t.Parallel()
-		s := newStorage(t)
-		ctx := context.Background()
-
-		err := s.Upsert(ctx, "", map[string]string{})
-		assert.Error(t, err)
 	})
 
 	t.Run("Load miss returns ErrSessionNotFound", func(t *testing.T) {
@@ -109,7 +91,8 @@ func runDataStorageTests(t *testing.T, newStorage func(t *testing.T) DataStorage
 		s := newStorage(t)
 		ctx := context.Background()
 
-		require.NoError(t, s.Upsert(ctx, "sess-existing", map[string]string{"x": "original"}))
+		_, err := s.Create(ctx, "sess-existing", map[string]string{"x": "original"})
+		require.NoError(t, err)
 
 		stored, err := s.Create(ctx, "sess-existing", map[string]string{"x": "overwrite"})
 		require.NoError(t, err)
@@ -167,10 +150,11 @@ func runDataStorageTests(t *testing.T, newStorage func(t *testing.T) DataStorage
 		s := newStorage(t)
 		ctx := context.Background()
 
-		require.NoError(t, s.Upsert(ctx, "sess-del", map[string]string{}))
+		_, err := s.Create(ctx, "sess-del", map[string]string{})
+		require.NoError(t, err)
 		require.NoError(t, s.Delete(ctx, "sess-del"))
 
-		_, err := s.Load(ctx, "sess-del")
+		_, err = s.Load(ctx, "sess-del")
 		assert.ErrorIs(t, err, ErrSessionNotFound)
 	})
 
@@ -197,7 +181,8 @@ func runDataStorageTests(t *testing.T, newStorage func(t *testing.T) DataStorage
 		s := newStorage(t)
 		ctx := context.Background()
 
-		require.NoError(t, s.Upsert(ctx, "sess-update", map[string]string{"v": "original"}))
+		_, err := s.Create(ctx, "sess-update", map[string]string{"v": "original"})
+		require.NoError(t, err)
 
 		updated, err := s.Update(ctx, "sess-update", map[string]string{"v": "updated"})
 		require.NoError(t, err)
@@ -227,7 +212,8 @@ func runDataStorageTests(t *testing.T, newStorage func(t *testing.T) DataStorage
 		s := newStorage(t)
 		ctx := context.Background()
 
-		require.NoError(t, s.Upsert(ctx, "sess-deleted", map[string]string{"v": "1"}))
+		_, err := s.Create(ctx, "sess-deleted", map[string]string{"v": "1"})
+		require.NoError(t, err)
 		require.NoError(t, s.Delete(ctx, "sess-deleted"))
 
 		updated, err := s.Update(ctx, "sess-deleted", map[string]string{"v": "2"})
@@ -249,7 +235,8 @@ func runDataStorageTests(t *testing.T, newStorage func(t *testing.T) DataStorage
 		s := newStorage(t)
 		ctx := context.Background()
 
-		require.NoError(t, s.Upsert(ctx, "sess-update-nil", map[string]string{"v": "original"}))
+		_, err := s.Create(ctx, "sess-update-nil", map[string]string{"v": "original"})
+		require.NoError(t, err)
 
 		updated, err := s.Update(ctx, "sess-update-nil", nil)
 		require.NoError(t, err)
@@ -286,7 +273,8 @@ func TestLocalSessionDataStorage(t *testing.T) {
 		t.Cleanup(func() { _ = s.Close() })
 		ctx := context.Background()
 
-		require.NoError(t, s.Upsert(ctx, "ttl-sess", map[string]string{"k": "v"}))
+		_, err = s.Create(ctx, "ttl-sess", map[string]string{"k": "v"})
+		require.NoError(t, err)
 		backdateLocalEntry(t, s, "ttl-sess", ttl+time.Millisecond)
 		s.deleteExpired()
 
@@ -302,7 +290,8 @@ func TestLocalSessionDataStorage(t *testing.T) {
 		t.Cleanup(func() { _ = s.Close() })
 		ctx := context.Background()
 
-		require.NoError(t, s.Upsert(ctx, "active-sess", map[string]string{}))
+		_, err = s.Create(ctx, "active-sess", map[string]string{})
+		require.NoError(t, err)
 		backdateLocalEntry(t, s, "active-sess", ttl+time.Millisecond)
 
 		// Load should refresh the entry's timestamp.
@@ -362,10 +351,11 @@ func TestRedisSessionDataStorage(t *testing.T) {
 		s, mr := newTestRedisDataStorage(t)
 		ctx := context.Background()
 
-		require.NoError(t, s.Upsert(ctx, "ttl-refresh", map[string]string{}))
+		_, err := s.Create(ctx, "ttl-refresh", map[string]string{})
+		require.NoError(t, err)
 		mr.FastForward(29 * time.Minute)
 
-		_, err := s.Load(ctx, "ttl-refresh")
+		_, err = s.Load(ctx, "ttl-refresh")
 		require.NoError(t, err, "load should succeed before expiry")
 
 		// Advance past the original TTL; load should have reset the clock.
@@ -380,10 +370,11 @@ func TestRedisSessionDataStorage(t *testing.T) {
 		s, mr := newTestRedisDataStorage(t)
 		ctx := context.Background()
 
-		require.NoError(t, s.Upsert(ctx, "expiring", map[string]string{}))
+		_, err := s.Create(ctx, "expiring", map[string]string{})
+		require.NoError(t, err)
 		mr.FastForward(31 * time.Minute)
 
-		_, err := s.Load(ctx, "expiring")
+		_, err = s.Load(ctx, "expiring")
 		assert.ErrorIs(t, err, ErrSessionNotFound)
 	})
 
@@ -406,7 +397,8 @@ func TestRedisSessionDataStorage(t *testing.T) {
 		s, mr := newTestRedisDataStorage(t)
 		ctx := context.Background()
 
-		require.NoError(t, s.Upsert(ctx, "ttl-update", map[string]string{"v": "1"}))
+		_, err := s.Create(ctx, "ttl-update", map[string]string{"v": "1"})
+		require.NoError(t, err)
 		mr.FastForward(29 * time.Minute)
 
 		updated, err := s.Update(ctx, "ttl-update", map[string]string{"v": "2"})

--- a/pkg/vmcp/server/sessionmanager/session_manager_test.go
+++ b/pkg/vmcp/server/sessionmanager/session_manager_test.go
@@ -80,14 +80,11 @@ func newMockFactoryWithError(t *testing.T, ctrl *gomock.Controller, err error) *
 	return factory
 }
 
-// alwaysFailDataStorage is a DataStorage whose Upsert/Create always return an
+// alwaysFailDataStorage is a DataStorage whose Create/Update always return an
 // error. It is used to exercise the Generate() double-failure path (UUID collision
 // simulation — both attempts to Create fail, so Generate() must return "").
 type alwaysFailDataStorage struct{}
 
-func (alwaysFailDataStorage) Upsert(_ context.Context, _ string, _ map[string]string) error {
-	return errors.New("storage unavailable")
-}
 func (alwaysFailDataStorage) Load(_ context.Context, _ string) (map[string]string, error) {
 	return nil, transportsession.ErrSessionNotFound
 }
@@ -105,20 +102,13 @@ func (alwaysFailDataStorage) Close() error                             { return 
 type configurableFailDataStorage struct {
 	transportsession.DataStorage
 	storeCallCount int
-	failStoreAfter int // fail Upsert/Create after this many successful calls (0 = never fail, -1 = always fail)
+	failStoreAfter int // fail Create/Update after this many successful calls (0 = never fail, -1 = always fail)
 	failDelete     bool
 }
 
 func (s *configurableFailDataStorage) shouldFail() bool {
 	s.storeCallCount++
 	return s.failStoreAfter == -1 || (s.failStoreAfter >= 0 && s.storeCallCount > s.failStoreAfter)
-}
-
-func (s *configurableFailDataStorage) Upsert(ctx context.Context, id string, metadata map[string]string) error {
-	if s.shouldFail() {
-		return errors.New("injected Upsert failure")
-	}
-	return s.DataStorage.Upsert(ctx, id, metadata)
 }
 
 func (s *configurableFailDataStorage) Create(ctx context.Context, id string, metadata map[string]string) (bool, error) {
@@ -658,9 +648,10 @@ func TestSessionManager_Terminate(t *testing.T) {
 
 		// Seed MetadataKeyTokenHash into storage so Terminate recognises this
 		// as a Phase 2 (full MultiSession) and deletes rather than marks terminated.
-		require.NoError(t, storage.Upsert(context.Background(), sessionID, map[string]string{
+		_, err = storage.Update(context.Background(), sessionID, map[string]string{
 			sessiontypes.MetadataKeyTokenHash: "",
-		}))
+		})
+		require.NoError(t, err)
 
 		// Session must exist before termination.
 		_, loadErr := storage.Load(context.Background(), sessionID)
@@ -858,7 +849,8 @@ func TestSessionManager_GetMultiSession(t *testing.T) {
 		sessionID := "restore-placeholder-session"
 		// Write placeholder metadata directly to storage, bypassing the cache.
 		// Generate() stores an empty map with no token hash.
-		require.NoError(t, sm.storage.Upsert(context.Background(), sessionID, map[string]string{}))
+		_, err := sm.storage.Create(context.Background(), sessionID, map[string]string{})
+		require.NoError(t, err)
 
 		// loadSession detects absent MetadataKeyTokenHash → ErrSessionNotFound.
 		multiSess, ok := sm.GetMultiSession(sessionID)
@@ -892,7 +884,8 @@ func TestSessionManager_GetMultiSession(t *testing.T) {
 			sessiontypes.MetadataKeyTokenHash: "", // anonymous sentinel — present but empty
 			vmcpsession.MetadataKeyBackendIDs: "", // always written; empty = zero backends
 		}
-		require.NoError(t, sm.storage.Upsert(context.Background(), sessionID, initializedMeta))
+		_, err := sm.storage.Create(context.Background(), sessionID, initializedMeta)
+		require.NoError(t, err)
 
 		// loadSession should call RestoreSession, not treat it as a placeholder.
 		multiSess, ok := sm.GetMultiSession(sessionID)
@@ -928,7 +921,8 @@ func TestSessionManager_GetMultiSession(t *testing.T) {
 			sessiontypes.MetadataKeyTokenHash: "", // Phase 2 completion marker
 			// MetadataKeyBackendIDs intentionally absent (legacy record)
 		}
-		require.NoError(t, sm.storage.Upsert(context.Background(), sessionID, legacyMeta))
+		_, err := sm.storage.Create(context.Background(), sessionID, legacyMeta)
+		require.NoError(t, err)
 
 		multiSess, ok := sm.GetMultiSession(sessionID)
 		require.True(t, ok, "legacy record without MetadataKeyBackendIDs must still be restorable")
@@ -1990,9 +1984,10 @@ func TestSessionManager_CheckSession(t *testing.T) {
 		t.Parallel()
 		sm, storage := newTestSessionManager(t, makeFactory(t), newFakeRegistry())
 		sessionID := "alive-session"
-		require.NoError(t, storage.Upsert(context.Background(), sessionID, map[string]string{}))
+		_, err := storage.Create(context.Background(), sessionID, map[string]string{})
+		require.NoError(t, err)
 
-		err := sm.checkSession(sessionID, makeEmptySess(t))
+		err = sm.checkSession(sessionID, makeEmptySess(t))
 		assert.NoError(t, err, "alive session must return nil")
 	})
 
@@ -2011,11 +2006,12 @@ func TestSessionManager_CheckSession(t *testing.T) {
 		// so the cache evicts the entry and onEvict closes backend connections.
 		sm, storage := newTestSessionManager(t, makeFactory(t), newFakeRegistry())
 		sessionID := "terminated-session"
-		require.NoError(t, storage.Upsert(context.Background(), sessionID, map[string]string{
+		_, err := storage.Create(context.Background(), sessionID, map[string]string{
 			MetadataKeyTerminated: MetadataValTrue,
-		}))
+		})
+		require.NoError(t, err)
 
-		err := sm.checkSession(sessionID, makeEmptySess(t))
+		err = sm.checkSession(sessionID, makeEmptySess(t))
 		assert.ErrorIs(t, err, cache.ErrExpired, "terminated session must return ErrExpired")
 	})
 
@@ -2029,9 +2025,10 @@ func TestSessionManager_CheckSession(t *testing.T) {
 		sessionID := "stale-session"
 
 		// Seed storage with the up-to-date backend list (backend-a expired).
-		require.NoError(t, storage.Upsert(context.Background(), sessionID, map[string]string{
+		_, err := storage.Create(context.Background(), sessionID, map[string]string{
 			vmcpsession.MetadataKeyBackendIDs: "backend-b",
-		}))
+		})
+		require.NoError(t, err)
 
 		// Inject a cached session whose metadata still lists both backends,
 		// simulating what this pod had before it learned about the expiry.
@@ -2042,7 +2039,7 @@ func TestSessionManager_CheckSession(t *testing.T) {
 		}).AnyTimes()
 		sm.sessions.Set(sessionID, cached)
 
-		err := sm.checkSession(sessionID, cached)
+		err = sm.checkSession(sessionID, cached)
 		assert.ErrorIs(t, err, cache.ErrExpired,
 			"stale backend list must return ErrExpired to trigger cross-pod eviction")
 	})
@@ -2052,9 +2049,10 @@ func TestSessionManager_CheckSession(t *testing.T) {
 		sm, storage := newTestSessionManager(t, makeFactory(t), newFakeRegistry())
 		sessionID := "fresh-session"
 
-		require.NoError(t, storage.Upsert(context.Background(), sessionID, map[string]string{
+		_, err := storage.Create(context.Background(), sessionID, map[string]string{
 			vmcpsession.MetadataKeyBackendIDs: "backend-a",
-		}))
+		})
+		require.NoError(t, err)
 
 		ctrl := gomock.NewController(t)
 		cached := sessionmocks.NewMockMultiSession(ctrl)
@@ -2063,7 +2061,7 @@ func TestSessionManager_CheckSession(t *testing.T) {
 		}).AnyTimes()
 		sm.sessions.Set(sessionID, cached)
 
-		err := sm.checkSession(sessionID, cached)
+		err = sm.checkSession(sessionID, cached)
 		assert.NoError(t, err, "matching backend list must return nil")
 	})
 
@@ -2074,14 +2072,15 @@ func TestSessionManager_CheckSession(t *testing.T) {
 		sm, storage := newTestSessionManager(t, makeFactory(t), newFakeRegistry())
 		sessionID := "no-ids-session"
 
-		require.NoError(t, storage.Upsert(context.Background(), sessionID, map[string]string{}))
+		_, err := storage.Create(context.Background(), sessionID, map[string]string{})
+		require.NoError(t, err)
 
 		ctrl := gomock.NewController(t)
 		cached := sessionmocks.NewMockMultiSession(ctrl)
 		cached.EXPECT().GetMetadata().Return(map[string]string{}).AnyTimes()
 		sm.sessions.Set(sessionID, cached)
 
-		err := sm.checkSession(sessionID, cached)
+		err = sm.checkSession(sessionID, cached)
 		assert.NoError(t, err, "matching empty metadata must not cause eviction")
 	})
 }
@@ -2105,7 +2104,9 @@ func TestNotifyBackendExpired(t *testing.T) {
 		for workloadID, sessID := range sessionIDs {
 			meta[vmcpsession.MetadataKeyBackendSessionPrefix+workloadID] = sessID
 		}
-		require.NoError(t, storage.Upsert(context.Background(), sessionID, meta))
+		updated, err := storage.Update(context.Background(), sessionID, meta)
+		require.NoError(t, err)
+		require.True(t, updated, "session must exist before seeding backend metadata")
 		return meta
 	}
 
@@ -2187,7 +2188,8 @@ func TestNotifyBackendExpired(t *testing.T) {
 			vmcpsession.MetadataKeyBackendSessionPrefix + "workload-a": "sess-a",
 			// MetadataKeyBackendIDs intentionally absent
 		}
-		require.NoError(t, storage.Upsert(context.Background(), sessionID, corruptedMeta))
+		_, err := storage.Update(context.Background(), sessionID, corruptedMeta)
+		require.NoError(t, err)
 
 		corruptedMetaBefore := maps.Clone(corruptedMeta)
 		sm.NotifyBackendExpired(sessionID, "workload-a", corruptedMeta)
@@ -2245,9 +2247,10 @@ func TestNotifyBackendExpired(t *testing.T) {
 
 		// Seed MetadataKeyTokenHash into storage so Terminate recognises this
 		// as a Phase 2 (full MultiSession) and deletes rather than marks terminated.
-		require.NoError(t, storage.Upsert(context.Background(), sessionID, map[string]string{
+		_, err = storage.Update(context.Background(), sessionID, map[string]string{
 			sessiontypes.MetadataKeyTokenHash: "",
-		}))
+		})
+		require.NoError(t, err)
 
 		_, err = sm.Terminate(sessionID)
 		require.NoError(t, err)


### PR DESCRIPTION
## Summary

<!--
REQUIRED. You MUST explain:
1. WHY this change is needed (the problem or motivation)
2. WHAT changed (concise bullet points)

The diff shows the code — your summary must provide the context a reviewer
needs to understand the purpose without reading the diff first.
-->

Upsert had zero production callers after #4669 converted all call sites to the safer Create/Update methods. Keeping it in the interface was a footgun that invited the unconditional-write pattern back.

- Remove Upsert from DataStorage interface and both implementations
- Update contract tests to use Create for round-trip and nil-metadata cases
- Drop the two Upsert-specific contract tests (overwrite and empty-ID) that tested behaviour no longer in the interface
- Replace test fixture setup calls with Create (new sessions) or Update (sessions already written by CreateSession/Generate)

<!--
Link related issues. Use "Closes" or "Fixes" to auto-close on merge.
Remove this line if there is no related issue.
-->

Fixes #4726

## Type of change

<!-- REQUIRED. Check exactly one. -->

- [ ] Bug fix
- [ ] New feature
- [x] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

<!--
REQUIRED. Check every verification step you actually ran.
You MUST check at least one item. If you only did manual testing,
describe exactly what you tested below the checkbox.
-->

- [x] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [x] Linting (`task lint-fix`)
- [ ] Manual testing (describe below)

## Changes

<!--
Optional — include for PRs touching more than a few files to help
reviewers navigate the diff. Remove this entire section for small PRs.
-->

| File | Change |
|------|--------|
|      |        |

## Does this introduce a user-facing change?

<!--
If yes, describe the change from the user's perspective. This helps with release notes.
If no, write "No".
Remove this section entirely if not applicable.
-->

## Implementation plan

<!--
Optional — include when this PR was planned with an AI assistant (Claude Code, etc.).
Paste the approved plan inside the <details> block so reviewers can see the intended
design without cluttering the main PR description. Remove this section entirely
for PRs that were not AI-planned.
-->

<details>
<summary>Approved implementation plan</summary>

<!-- Paste the plan here -->

</details>

## Special notes for reviewers

<!--
Optional — call out anything non-obvious: tricky logic, known limitations,
areas where you'd like extra scrutiny, or follow-up work planned.
Remove this section if not needed.
-->
