### PR TITLE
Add Goose, Gemini CLI, and Amp as skill-supporting clients

### DIFF
--- a/docs/arch/12-skills-system.md
+++ b/docs/arch/12-skills-system.md
@@ -137,11 +137,11 @@ Skills install to one of two scopes:
 Skills can be installed for multiple AI clients simultaneously. Each client has its own skill directory structure, so installing a skill for `claude-code` places files differently than for `cursor`.
 
 ```bash
-# Install for default client (first skill-supporting client)
+# Install for all skill-supporting clients (default)
 thv skill install code-review
 
-# Install for specific client
-thv skill install code-review --client claude-code
+# Install for specific clients
+thv skill install code-review --clients claude-code
 ```
 
 The `PathResolver` interface maps (client, skill-name, scope, project-root) to the correct filesystem path for each client.
@@ -244,7 +244,7 @@ flowchart TD
 
 3. **Supply chain validation**: For OCI installs, the skill name in the artifact must match the repository name in the reference.
 
-4. **Client targeting**: When no `--client` flag is provided, the first skill-supporting client is used by default. Specify `--client claude-code` to target a particular client.
+4. **Client targeting**: When no `--clients` flag is provided, all skill-supporting clients are targeted by default. Specify `--clients claude-code` to target a particular client.
 
 **Implementation:** `pkg/skills/skillsvc/skillsvc.go` (Install)
 

--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -410,6 +410,9 @@ var supportedClientIntegrations = []clientAppConfig{
 			types.TransportTypeSSE:            "url",
 			types.TransportTypeStreamableHTTP: "url",
 		},
+		SupportsSkills:    true,
+		SkillsGlobalPath:  []string{".agents", "skills"},
+		SkillsProjectPath: []string{".agents", "skills"},
 	},
 	{
 		ClientType:           AmpVSCode,
@@ -556,6 +559,9 @@ var supportedClientIntegrations = []clientAppConfig{
 			"timeout":     60,
 			"description": "",
 		},
+		SupportsSkills:    true,
+		SkillsGlobalPath:  []string{".agents", "skills"},
+		SkillsProjectPath: []string{".agents", "skills"},
 	},
 	{
 		ClientType:           Trae,
@@ -697,6 +703,9 @@ var supportedClientIntegrations = []clientAppConfig{
 			types.TransportTypeSSE:            "url",
 			types.TransportTypeStreamableHTTP: "httpUrl",
 		},
+		SupportsSkills:    true,
+		SkillsGlobalPath:  []string{".agents", "skills"},
+		SkillsProjectPath: []string{".agents", "skills"},
 	},
 	{
 		ClientType:   VSCodeServer,

--- a/pkg/client/skills_test.go
+++ b/pkg/client/skills_test.go
@@ -71,6 +71,24 @@ func testSkillClientIntegrations() []clientAppConfig {
 			SkillsProjectPath: []string{".github", "skills"},
 		},
 		{
+			ClientType:        Goose,
+			SupportsSkills:    true,
+			SkillsGlobalPath:  []string{".agents", "skills"},
+			SkillsProjectPath: []string{".agents", "skills"},
+		},
+		{
+			ClientType:        GeminiCli,
+			SupportsSkills:    true,
+			SkillsGlobalPath:  []string{".agents", "skills"},
+			SkillsProjectPath: []string{".agents", "skills"},
+		},
+		{
+			ClientType:        AmpCli,
+			SupportsSkills:    true,
+			SkillsGlobalPath:  []string{".agents", "skills"},
+			SkillsProjectPath: []string{".agents", "skills"},
+		},
+		{
 			ClientType: Windsurf,
 			// SupportsSkills defaults to false
 		},
@@ -105,6 +123,9 @@ func TestSupportsSkills(t *testing.T) {
 		{name: "VSCode supports skills", client: VSCode, expected: true},
 		{name: "VSCodeInsider supports skills", client: VSCodeInsider, expected: true},
 		{name: "Factory supports skills", client: Factory, expected: true},
+		{name: "Goose supports skills", client: Goose, expected: true},
+		{name: "GeminiCli supports skills", client: GeminiCli, expected: true},
+		{name: "AmpCli supports skills", client: AmpCli, expected: true},
 		{name: "Windsurf does not support skills", client: Windsurf, expected: false},
 		{name: "unknown client returns false", client: ClientApp("nonexistent"), expected: false},
 	}
@@ -122,8 +143,8 @@ func TestListSkillSupportingClients(t *testing.T) {
 	cm := newTestSkillManager()
 	clients := cm.ListSkillSupportingClients()
 
-	// Should include ClaudeCode, Codex, Cursor, Factory, KimiCli, OpenCode, VSCode, VSCodeInsider, and our test-only no-paths-client
-	require.Len(t, clients, 9, "unexpected number of skill-supporting clients: %v", clients)
+	// Should include AmpCli, ClaudeCode, Codex, Cursor, Factory, GeminiCli, Goose, KimiCli, OpenCode, VSCode, VSCodeInsider, and our test-only no-paths-client
+	require.Len(t, clients, 12, "unexpected number of skill-supporting clients: %v", clients)
 
 	// Verify sorted order
 	for i := 1; i < len(clients); i++ {
@@ -294,6 +315,51 @@ func TestGetSkillPath(t *testing.T) {
 			scope:       skills.ScopeProject,
 			projectRoot: "/tmp/myproject",
 			wantPath:    filepath.Join("/tmp/myproject", ".github", "skills", "my-skill"),
+		},
+		{
+			name:      "ScopeUser Goose",
+			client:    Goose,
+			skillName: "my-skill",
+			scope:     skills.ScopeUser,
+			wantPath:  filepath.Join(testHomeDir, ".agents", "skills", "my-skill"),
+		},
+		{
+			name:        "ScopeProject Goose with explicit root",
+			client:      Goose,
+			skillName:   "my-skill",
+			scope:       skills.ScopeProject,
+			projectRoot: "/tmp/myproject",
+			wantPath:    filepath.Join("/tmp/myproject", ".agents", "skills", "my-skill"),
+		},
+		{
+			name:      "ScopeUser GeminiCli",
+			client:    GeminiCli,
+			skillName: "my-skill",
+			scope:     skills.ScopeUser,
+			wantPath:  filepath.Join(testHomeDir, ".agents", "skills", "my-skill"),
+		},
+		{
+			name:        "ScopeProject GeminiCli with explicit root",
+			client:      GeminiCli,
+			skillName:   "my-skill",
+			scope:       skills.ScopeProject,
+			projectRoot: "/tmp/myproject",
+			wantPath:    filepath.Join("/tmp/myproject", ".agents", "skills", "my-skill"),
+		},
+		{
+			name:      "ScopeUser AmpCli",
+			client:    AmpCli,
+			skillName: "my-skill",
+			scope:     skills.ScopeUser,
+			wantPath:  filepath.Join(testHomeDir, ".agents", "skills", "my-skill"),
+		},
+		{
+			name:        "ScopeProject AmpCli with explicit root",
+			client:      AmpCli,
+			skillName:   "my-skill",
+			scope:       skills.ScopeProject,
+			projectRoot: "/tmp/myproject",
+			wantPath:    filepath.Join("/tmp/myproject", ".agents", "skills", "my-skill"),
 		},
 		{
 			name:      "client that does not support skills",


### PR DESCRIPTION
## Summary

Enables Goose, Google Gemini CLI, and Sourcegraph Amp CLI as skill-supporting clients in ToolHive. All three use the `.agents/skills/` convention for both user (`~/.agents/skills/<name>`) and project (`<project>/.agents/skills/<name>`) scope, aligning with the cross-client Agent Skills standard.

Each client also discovers skills from its native path (Gemini from `.gemini/skills/`, Amp from `~/.config/agents/skills/`), but `.agents/skills/` has highest or equal precedence in all three, making it the best single install target.

Also fixes a pre-existing doc inaccuracy: `--client` → `--clients` and "first client" → "all clients" in the skills architecture doc.

Documentation references:
- [Gemini CLI skills](https://geminicli.com/docs/cli/skills/)
- [Goose skills](https://goose-docs.ai/docs/guides/context-engineering/using-skills/)
- [Amp skills](https://ampcode.com/manual#agent-skills)

## Type of change

- [x] New feature

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)

## Changes

| File | Change |
|------|--------|
| `pkg/client/config.go` | Add `SupportsSkills`, `SkillsGlobalPath`, `SkillsProjectPath` to Goose, GeminiCli, and AmpCli entries |
| `pkg/client/skills_test.go` | Add all three to fixtures, `TestSupportsSkills`, `TestListSkillSupportingClients` (9 → 12), and `TestGetSkillPath` (6 new cases) |
| `docs/arch/12-skills-system.md` | Fix `--client` → `--clients` flag name and default behavior description |

## Does this introduce a user-facing change?

Yes — `thv skill install --clients goose`, `--clients gemini-cli`, and `--clients amp-cli` (or `--clients all`) now work. Skills land in `~/.agents/skills/` so all three clients pick them up automatically.