### PR TITLE
Add OpenAPI annotations to v0.1 skills registry endpoints

### DIFF
--- a/docs/server/docs.go
+++ b/docs/server/docs.go
@@ -2506,6 +2506,17 @@ const docTemplate = `{
                 },
                 "type": "object"
             },
+            "pkg_api_v1.registryErrorResponse": {
+                "properties": {
+                    "code": {
+                        "type": "string"
+                    },
+                    "message": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
             "pkg_api_v1.registryInfo": {
                 "description": "Basic information about a registry",
                 "properties": {
@@ -2668,6 +2679,41 @@ const docTemplate = `{
                         "description": "List of installed skills",
                         "items": {
                             "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_skills.InstalledSkill"
+                        },
+                        "type": "array",
+                        "uniqueItems": false
+                    }
+                },
+                "type": "object"
+            },
+            "pkg_api_v1.skillsV01Metadata": {
+                "description": "Metadata contains pagination information",
+                "properties": {
+                    "limit": {
+                        "description": "Limit is the maximum number of skills per page",
+                        "type": "integer"
+                    },
+                    "page": {
+                        "description": "Page is the current page number (1-based)",
+                        "type": "integer"
+                    },
+                    "total": {
+                        "description": "Total is the total number of skills matching the query",
+                        "type": "integer"
+                    }
+                },
+                "type": "object"
+            },
+            "pkg_api_v1.skillsV01Response": {
+                "description": "Paginated list of skills from the registry",
+                "properties": {
+                    "metadata": {
+                        "$ref": "#/components/schemas/pkg_api_v1.skillsV01Metadata"
+                    },
+                    "skills": {
+                        "description": "Skills is the list of skills on the current page",
+                        "items": {
+                            "$ref": "#/components/schemas/registry.Skill"
                         },
                         "type": "array",
                         "uniqueItems": false
@@ -3268,6 +3314,152 @@ const docTemplate = `{
                     },
                     "url": {
                         "description": "URL is the endpoint URL for the remote MCP server (e.g., https://api.example.com/mcp)",
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "registry.Skill": {
+                "properties": {
+                    "_meta": {
+                        "additionalProperties": {},
+                        "description": "Meta is an opaque payload with extended meta data details of the skill.",
+                        "type": "object"
+                    },
+                    "allowedTools": {
+                        "description": "AllowedTools is the list of tools that the skill is compatible with.\nThis is experimental.",
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "uniqueItems": false
+                    },
+                    "compatibility": {
+                        "description": "Compatibility is the environment requirements of the skill.",
+                        "type": "string"
+                    },
+                    "description": {
+                        "description": "Description is the description of the skill.",
+                        "type": "string"
+                    },
+                    "icons": {
+                        "description": "Icons is the list of icons for the skill.",
+                        "items": {
+                            "$ref": "#/components/schemas/registry.SkillIcon"
+                        },
+                        "type": "array",
+                        "uniqueItems": false
+                    },
+                    "license": {
+                        "description": "License is the SPDX license identifier of the skill.",
+                        "type": "string"
+                    },
+                    "metadata": {
+                        "additionalProperties": {},
+                        "description": "Metadata is the official metadata of the skill as reported in the\nSKILL.md file.",
+                        "type": "object"
+                    },
+                    "name": {
+                        "description": "Name is the name of the skill.\nThe format is that of identifiers, e.g. \"my-skill\".",
+                        "type": "string"
+                    },
+                    "namespace": {
+                        "description": "Namespace is the namespace of the skill.\nThe format is reverse-DNS, e.g. \"io.github.user\".",
+                        "type": "string"
+                    },
+                    "packages": {
+                        "description": "Packages is the list of packages for the skill.",
+                        "items": {
+                            "$ref": "#/components/schemas/registry.SkillPackage"
+                        },
+                        "type": "array",
+                        "uniqueItems": false
+                    },
+                    "repository": {
+                        "$ref": "#/components/schemas/registry.SkillRepository"
+                    },
+                    "status": {
+                        "description": "Status is the status of the skill.\nCan be one of \"active\", \"deprecated\", or \"archived\".",
+                        "type": "string"
+                    },
+                    "title": {
+                        "description": "Title is the title of the skill.\nThis is for human consumption, not an identifier.",
+                        "type": "string"
+                    },
+                    "version": {
+                        "description": "Version is the version of the skill.\nAny non-empty string is valid, but ideally it should be either a\nsemantic version or a commit hash.",
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "registry.SkillIcon": {
+                "properties": {
+                    "label": {
+                        "description": "Label is the label of the icon.",
+                        "type": "string"
+                    },
+                    "size": {
+                        "description": "Size is the size of the icon.",
+                        "type": "string"
+                    },
+                    "src": {
+                        "description": "Src is the source of the icon.",
+                        "type": "string"
+                    },
+                    "type": {
+                        "description": "Type is the type of the icon.",
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "registry.SkillPackage": {
+                "properties": {
+                    "commit": {
+                        "description": "Commit is the commit of the package.",
+                        "type": "string"
+                    },
+                    "digest": {
+                        "description": "Digest is the digest of the package.",
+                        "type": "string"
+                    },
+                    "identifier": {
+                        "description": "Identifier is the OCI identifier of the package.",
+                        "type": "string"
+                    },
+                    "mediaType": {
+                        "description": "MediaType is the media type of the package.",
+                        "type": "string"
+                    },
+                    "ref": {
+                        "description": "Ref is the reference of the package.",
+                        "type": "string"
+                    },
+                    "registryType": {
+                        "description": "RegistryType is the type of registry the package is from.\nCan be \"oci\" or \"git\".",
+                        "type": "string"
+                    },
+                    "subfolder": {
+                        "description": "Subfolder is the subfolder of the package.",
+                        "type": "string"
+                    },
+                    "url": {
+                        "description": "URL is the URL of the package.",
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "registry.SkillRepository": {
+                "description": "Repository is the source repository of the skill.",
+                "properties": {
+                    "type": {
+                        "description": "Type is the type of the repository.",
+                        "type": "string"
+                    },
+                    "url": {
+                        "description": "URL is the URL of the repository.",
                         "type": "string"
                     }
                 },
@@ -5966,6 +6158,162 @@ const docTemplate = `{
                 "summary": "Health check",
                 "tags": [
                     "system"
+                ]
+            }
+        },
+        "/registry/{registryName}/v0.1/x/dev.toolhive/skills": {
+            "get": {
+                "description": "Get a paginated list of skills from the registry. Supports optional full-text search and pagination.",
+                "parameters": [
+                    {
+                        "description": "Registry name (currently ignored, uses the default provider)",
+                        "in": "path",
+                        "name": "registryName",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Search filter — matches against skill name, namespace, and description",
+                        "in": "query",
+                        "name": "q",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Page number, 1-based (default: 1)",
+                        "in": "query",
+                        "name": "page",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "description": "Items per page, max 200 (default: 50)",
+                        "in": "query",
+                        "name": "limit",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/pkg_api_v1.skillsV01Response"
+                                }
+                            }
+                        },
+                        "description": "OK"
+                    },
+                    "500": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/pkg_api_v1.registryErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Internal server error"
+                    },
+                    "503": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/pkg_api_v1.registryErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Registry authentication required or upstream registry unavailable"
+                    }
+                },
+                "summary": "List available registry skills",
+                "tags": [
+                    "registry-skills"
+                ]
+            }
+        },
+        "/registry/{registryName}/v0.1/x/dev.toolhive/skills/{namespace}/{skillName}": {
+            "get": {
+                "description": "Retrieve a single skill by its namespace and name from the registry.",
+                "parameters": [
+                    {
+                        "description": "Registry name (currently ignored, uses the default provider)",
+                        "in": "path",
+                        "name": "registryName",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Skill namespace in reverse-DNS format (e.g. io.github.stacklok)",
+                        "in": "path",
+                        "name": "namespace",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Skill name",
+                        "in": "path",
+                        "name": "skillName",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/registry.Skill"
+                                }
+                            }
+                        },
+                        "description": "OK"
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/pkg_api_v1.registryErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Skill not found"
+                    },
+                    "500": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/pkg_api_v1.registryErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Internal server error"
+                    },
+                    "503": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/pkg_api_v1.registryErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Registry authentication required or upstream registry unavailable"
+                    }
+                },
+                "summary": "Get a registry skill",
+                "tags": [
+                    "registry-skills"
                 ]
             }
         }

--- a/docs/server/swagger.json
+++ b/docs/server/swagger.json
@@ -2499,6 +2499,17 @@
                 },
                 "type": "object"
             },
+            "pkg_api_v1.registryErrorResponse": {
+                "properties": {
+                    "code": {
+                        "type": "string"
+                    },
+                    "message": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
             "pkg_api_v1.registryInfo": {
                 "description": "Basic information about a registry",
                 "properties": {
@@ -2661,6 +2672,41 @@
                         "description": "List of installed skills",
                         "items": {
                             "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_skills.InstalledSkill"
+                        },
+                        "type": "array",
+                        "uniqueItems": false
+                    }
+                },
+                "type": "object"
+            },
+            "pkg_api_v1.skillsV01Metadata": {
+                "description": "Metadata contains pagination information",
+                "properties": {
+                    "limit": {
+                        "description": "Limit is the maximum number of skills per page",
+                        "type": "integer"
+                    },
+                    "page": {
+                        "description": "Page is the current page number (1-based)",
+                        "type": "integer"
+                    },
+                    "total": {
+                        "description": "Total is the total number of skills matching the query",
+                        "type": "integer"
+                    }
+                },
+                "type": "object"
+            },
+            "pkg_api_v1.skillsV01Response": {
+                "description": "Paginated list of skills from the registry",
+                "properties": {
+                    "metadata": {
+                        "$ref": "#/components/schemas/pkg_api_v1.skillsV01Metadata"
+                    },
+                    "skills": {
+                        "description": "Skills is the list of skills on the current page",
+                        "items": {
+                            "$ref": "#/components/schemas/registry.Skill"
                         },
                         "type": "array",
                         "uniqueItems": false
@@ -3261,6 +3307,152 @@
                     },
                     "url": {
                         "description": "URL is the endpoint URL for the remote MCP server (e.g., https://api.example.com/mcp)",
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "registry.Skill": {
+                "properties": {
+                    "_meta": {
+                        "additionalProperties": {},
+                        "description": "Meta is an opaque payload with extended meta data details of the skill.",
+                        "type": "object"
+                    },
+                    "allowedTools": {
+                        "description": "AllowedTools is the list of tools that the skill is compatible with.\nThis is experimental.",
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "uniqueItems": false
+                    },
+                    "compatibility": {
+                        "description": "Compatibility is the environment requirements of the skill.",
+                        "type": "string"
+                    },
+                    "description": {
+                        "description": "Description is the description of the skill.",
+                        "type": "string"
+                    },
+                    "icons": {
+                        "description": "Icons is the list of icons for the skill.",
+                        "items": {
+                            "$ref": "#/components/schemas/registry.SkillIcon"
+                        },
+                        "type": "array",
+                        "uniqueItems": false
+                    },
+                    "license": {
+                        "description": "License is the SPDX license identifier of the skill.",
+                        "type": "string"
+                    },
+                    "metadata": {
+                        "additionalProperties": {},
+                        "description": "Metadata is the official metadata of the skill as reported in the\nSKILL.md file.",
+                        "type": "object"
+                    },
+                    "name": {
+                        "description": "Name is the name of the skill.\nThe format is that of identifiers, e.g. \"my-skill\".",
+                        "type": "string"
+                    },
+                    "namespace": {
+                        "description": "Namespace is the namespace of the skill.\nThe format is reverse-DNS, e.g. \"io.github.user\".",
+                        "type": "string"
+                    },
+                    "packages": {
+                        "description": "Packages is the list of packages for the skill.",
+                        "items": {
+                            "$ref": "#/components/schemas/registry.SkillPackage"
+                        },
+                        "type": "array",
+                        "uniqueItems": false
+                    },
+                    "repository": {
+                        "$ref": "#/components/schemas/registry.SkillRepository"
+                    },
+                    "status": {
+                        "description": "Status is the status of the skill.\nCan be one of \"active\", \"deprecated\", or \"archived\".",
+                        "type": "string"
+                    },
+                    "title": {
+                        "description": "Title is the title of the skill.\nThis is for human consumption, not an identifier.",
+                        "type": "string"
+                    },
+                    "version": {
+                        "description": "Version is the version of the skill.\nAny non-empty string is valid, but ideally it should be either a\nsemantic version or a commit hash.",
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "registry.SkillIcon": {
+                "properties": {
+                    "label": {
+                        "description": "Label is the label of the icon.",
+                        "type": "string"
+                    },
+                    "size": {
+                        "description": "Size is the size of the icon.",
+                        "type": "string"
+                    },
+                    "src": {
+                        "description": "Src is the source of the icon.",
+                        "type": "string"
+                    },
+                    "type": {
+                        "description": "Type is the type of the icon.",
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "registry.SkillPackage": {
+                "properties": {
+                    "commit": {
+                        "description": "Commit is the commit of the package.",
+                        "type": "string"
+                    },
+                    "digest": {
+                        "description": "Digest is the digest of the package.",
+                        "type": "string"
+                    },
+                    "identifier": {
+                        "description": "Identifier is the OCI identifier of the package.",
+                        "type": "string"
+                    },
+                    "mediaType": {
+                        "description": "MediaType is the media type of the package.",
+                        "type": "string"
+                    },
+                    "ref": {
+                        "description": "Ref is the reference of the package.",
+                        "type": "string"
+                    },
+                    "registryType": {
+                        "description": "RegistryType is the type of registry the package is from.\nCan be \"oci\" or \"git\".",
+                        "type": "string"
+                    },
+                    "subfolder": {
+                        "description": "Subfolder is the subfolder of the package.",
+                        "type": "string"
+                    },
+                    "url": {
+                        "description": "URL is the URL of the package.",
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "registry.SkillRepository": {
+                "description": "Repository is the source repository of the skill.",
+                "properties": {
+                    "type": {
+                        "description": "Type is the type of the repository.",
+                        "type": "string"
+                    },
+                    "url": {
+                        "description": "URL is the URL of the repository.",
                         "type": "string"
                     }
                 },
@@ -5959,6 +6151,162 @@
                 "summary": "Health check",
                 "tags": [
                     "system"
+                ]
+            }
+        },
+        "/registry/{registryName}/v0.1/x/dev.toolhive/skills": {
+            "get": {
+                "description": "Get a paginated list of skills from the registry. Supports optional full-text search and pagination.",
+                "parameters": [
+                    {
+                        "description": "Registry name (currently ignored, uses the default provider)",
+                        "in": "path",
+                        "name": "registryName",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Search filter — matches against skill name, namespace, and description",
+                        "in": "query",
+                        "name": "q",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Page number, 1-based (default: 1)",
+                        "in": "query",
+                        "name": "page",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "description": "Items per page, max 200 (default: 50)",
+                        "in": "query",
+                        "name": "limit",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/pkg_api_v1.skillsV01Response"
+                                }
+                            }
+                        },
+                        "description": "OK"
+                    },
+                    "500": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/pkg_api_v1.registryErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Internal server error"
+                    },
+                    "503": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/pkg_api_v1.registryErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Registry authentication required or upstream registry unavailable"
+                    }
+                },
+                "summary": "List available registry skills",
+                "tags": [
+                    "registry-skills"
+                ]
+            }
+        },
+        "/registry/{registryName}/v0.1/x/dev.toolhive/skills/{namespace}/{skillName}": {
+            "get": {
+                "description": "Retrieve a single skill by its namespace and name from the registry.",
+                "parameters": [
+                    {
+                        "description": "Registry name (currently ignored, uses the default provider)",
+                        "in": "path",
+                        "name": "registryName",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Skill namespace in reverse-DNS format (e.g. io.github.stacklok)",
+                        "in": "path",
+                        "name": "namespace",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Skill name",
+                        "in": "path",
+                        "name": "skillName",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/registry.Skill"
+                                }
+                            }
+                        },
+                        "description": "OK"
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/pkg_api_v1.registryErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Skill not found"
+                    },
+                    "500": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/pkg_api_v1.registryErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Internal server error"
+                    },
+                    "503": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/pkg_api_v1.registryErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Registry authentication required or upstream registry unavailable"
+                    }
+                },
+                "summary": "Get a registry skill",
+                "tags": [
+                    "registry-skills"
                 ]
             }
         }

--- a/docs/server/swagger.yaml
+++ b/docs/server/swagger.yaml
@@ -2220,6 +2220,13 @@ components:
           description: OCI reference to push
           type: string
       type: object
+    pkg_api_v1.registryErrorResponse:
+      properties:
+        code:
+          type: string
+        message:
+          type: string
+      type: object
     pkg_api_v1.registryInfo:
       description: Basic information about a registry
       properties:
@@ -2351,6 +2358,31 @@ components:
           description: List of installed skills
           items:
             $ref: '#/components/schemas/github_com_stacklok_toolhive_pkg_skills.InstalledSkill'
+          type: array
+          uniqueItems: false
+      type: object
+    pkg_api_v1.skillsV01Metadata:
+      description: Metadata contains pagination information
+      properties:
+        limit:
+          description: Limit is the maximum number of skills per page
+          type: integer
+        page:
+          description: Page is the current page number (1-based)
+          type: integer
+        total:
+          description: Total is the total number of skills matching the query
+          type: integer
+      type: object
+    pkg_api_v1.skillsV01Response:
+      description: Paginated list of skills from the registry
+      properties:
+        metadata:
+          $ref: '#/components/schemas/pkg_api_v1.skillsV01Metadata'
+        skills:
+          description: Skills is the list of skills on the current page
+          items:
+            $ref: '#/components/schemas/registry.Skill'
           type: array
           uniqueItems: false
       type: object
@@ -2876,6 +2908,131 @@ components:
           type: string
         url:
           description: URL is the endpoint URL for the remote MCP server (e.g., https://api.example.com/mcp)
+          type: string
+      type: object
+    registry.Skill:
+      properties:
+        _meta:
+          additionalProperties: {}
+          description: Meta is an opaque payload with extended meta data details of
+            the skill.
+          type: object
+        allowedTools:
+          description: |-
+            AllowedTools is the list of tools that the skill is compatible with.
+            This is experimental.
+          items:
+            type: string
+          type: array
+          uniqueItems: false
+        compatibility:
+          description: Compatibility is the environment requirements of the skill.
+          type: string
+        description:
+          description: Description is the description of the skill.
+          type: string
+        icons:
+          description: Icons is the list of icons for the skill.
+          items:
+            $ref: '#/components/schemas/registry.SkillIcon'
+          type: array
+          uniqueItems: false
+        license:
+          description: License is the SPDX license identifier of the skill.
+          type: string
+        metadata:
+          additionalProperties: {}
+          description: |-
+            Metadata is the official metadata of the skill as reported in the
+            SKILL.md file.
+          type: object
+        name:
+          description: |-
+            Name is the name of the skill.
+            The format is that of identifiers, e.g. "my-skill".
+          type: string
+        namespace:
+          description: |-
+            Namespace is the namespace of the skill.
+            The format is reverse-DNS, e.g. "io.github.user".
+          type: string
+        packages:
+          description: Packages is the list of packages for the skill.
+          items:
+            $ref: '#/components/schemas/registry.SkillPackage'
+          type: array
+          uniqueItems: false
+        repository:
+          $ref: '#/components/schemas/registry.SkillRepository'
+        status:
+          description: |-
+            Status is the status of the skill.
+            Can be one of "active", "deprecated", or "archived".
+          type: string
+        title:
+          description: |-
+            Title is the title of the skill.
+            This is for human consumption, not an identifier.
+          type: string
+        version:
+          description: |-
+            Version is the version of the skill.
+            Any non-empty string is valid, but ideally it should be either a
+            semantic version or a commit hash.
+          type: string
+      type: object
+    registry.SkillIcon:
+      properties:
+        label:
+          description: Label is the label of the icon.
+          type: string
+        size:
+          description: Size is the size of the icon.
+          type: string
+        src:
+          description: Src is the source of the icon.
+          type: string
+        type:
+          description: Type is the type of the icon.
+          type: string
+      type: object
+    registry.SkillPackage:
+      properties:
+        commit:
+          description: Commit is the commit of the package.
+          type: string
+        digest:
+          description: Digest is the digest of the package.
+          type: string
+        identifier:
+          description: Identifier is the OCI identifier of the package.
+          type: string
+        mediaType:
+          description: MediaType is the media type of the package.
+          type: string
+        ref:
+          description: Ref is the reference of the package.
+          type: string
+        registryType:
+          description: |-
+            RegistryType is the type of registry the package is from.
+            Can be "oci" or "git".
+          type: string
+        subfolder:
+          description: Subfolder is the subfolder of the package.
+          type: string
+        url:
+          description: URL is the URL of the package.
+          type: string
+      type: object
+    registry.SkillRepository:
+      description: Repository is the source repository of the skill.
+      properties:
+        type:
+          description: Type is the type of the repository.
+          type: string
+        url:
+          description: URL is the URL of the repository.
           type: string
       type: object
     registry.VerifiedAttestation:
@@ -4539,3 +4696,101 @@ paths:
       summary: Health check
       tags:
       - system
+  /registry/{registryName}/v0.1/x/dev.toolhive/skills:
+    get:
+      description: Get a paginated list of skills from the registry. Supports optional
+        full-text search and pagination.
+      parameters:
+      - description: Registry name (currently ignored, uses the default provider)
+        in: path
+        name: registryName
+        required: true
+        schema:
+          type: string
+      - description: Search filter — matches against skill name, namespace, and description
+        in: query
+        name: q
+        schema:
+          type: string
+      - description: 'Page number, 1-based (default: 1)'
+        in: query
+        name: page
+        schema:
+          type: integer
+      - description: 'Items per page, max 200 (default: 50)'
+        in: query
+        name: limit
+        schema:
+          type: integer
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/pkg_api_v1.skillsV01Response'
+          description: OK
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/pkg_api_v1.registryErrorResponse'
+          description: Internal server error
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/pkg_api_v1.registryErrorResponse'
+          description: Registry authentication required or upstream registry unavailable
+      summary: List available registry skills
+      tags:
+      - registry-skills
+  /registry/{registryName}/v0.1/x/dev.toolhive/skills/{namespace}/{skillName}:
+    get:
+      description: Retrieve a single skill by its namespace and name from the registry.
+      parameters:
+      - description: Registry name (currently ignored, uses the default provider)
+        in: path
+        name: registryName
+        required: true
+        schema:
+          type: string
+      - description: Skill namespace in reverse-DNS format (e.g. io.github.stacklok)
+        in: path
+        name: namespace
+        required: true
+        schema:
+          type: string
+      - description: Skill name
+        in: path
+        name: skillName
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/registry.Skill'
+          description: OK
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/pkg_api_v1.registryErrorResponse'
+          description: Skill not found
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/pkg_api_v1.registryErrorResponse'
+          description: Internal server error
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/pkg_api_v1.registryErrorResponse'
+          description: Registry authentication required or upstream registry unavailable
+      summary: Get a registry skill
+      tags:
+      - registry-skills

--- a/pkg/api/v1/registry_v01_skills.go
+++ b/pkg/api/v1/registry_v01_skills.go
@@ -77,6 +77,19 @@ func writeJSONError(w http.ResponseWriter, status int, code, message string) {
 }
 
 // listSkillsV01 handles GET /registry/{registryName}/v0.1/x/dev.toolhive/skills
+//
+//	@Summary		List available registry skills
+//	@Description	Get a paginated list of skills from the registry. Supports optional full-text search and pagination.
+//	@Tags			registry-skills
+//	@Produce		json
+//	@Param			registryName	path		string	true	"Registry name (currently ignored, uses the default provider)"
+//	@Param			q				query		string	false	"Search filter — matches against skill name, namespace, and description"
+//	@Param			page			query		integer	false	"Page number, 1-based (default: 1)"
+//	@Param			limit			query		integer	false	"Items per page, max 200 (default: 50)"
+//	@Success		200				{object}	skillsV01Response
+//	@Failure		500				{object}	registryErrorResponse	"Internal server error"
+//	@Failure		503				{object}	registryErrorResponse	"Registry authentication required or upstream registry unavailable"
+//	@Router			/registry/{registryName}/v0.1/x/dev.toolhive/skills [get]
 func listSkillsV01(w http.ResponseWriter, r *http.Request) {
 	provider, ok := getSkillsProvider(w)
 	if !ok {
@@ -124,6 +137,19 @@ func listSkillsV01(w http.ResponseWriter, r *http.Request) {
 }
 
 // getSkillV01 handles GET /registry/{registryName}/v0.1/x/dev.toolhive/skills/{namespace}/{skillName}
+//
+//	@Summary		Get a registry skill
+//	@Description	Retrieve a single skill by its namespace and name from the registry.
+//	@Tags			registry-skills
+//	@Produce		json
+//	@Param			registryName	path		string	true	"Registry name (currently ignored, uses the default provider)"
+//	@Param			namespace		path		string	true	"Skill namespace in reverse-DNS format (e.g. io.github.stacklok)"
+//	@Param			skillName		path		string	true	"Skill name"
+//	@Success		200				{object}	types.Skill
+//	@Failure		404				{object}	registryErrorResponse	"Skill not found"
+//	@Failure		500				{object}	registryErrorResponse	"Internal server error"
+//	@Failure		503				{object}	registryErrorResponse	"Registry authentication required or upstream registry unavailable"
+//	@Router			/registry/{registryName}/v0.1/x/dev.toolhive/skills/{namespace}/{skillName} [get]
 func getSkillV01(w http.ResponseWriter, r *http.Request) {
 	namespace := chi.URLParam(r, "namespace")
 	skillName := chi.URLParam(r, "skillName")
@@ -191,13 +217,24 @@ func parseSkillsPagination(r *http.Request) (page, limit int) {
 	return page, limit
 }
 
+// skillsV01Response is the response body for the v0.1 skills list endpoint.
+//
+//	@Description	Paginated list of skills from the registry
 type skillsV01Response struct {
-	Skills   []types.Skill     `json:"skills"`
+	// Skills is the list of skills on the current page
+	Skills []types.Skill `json:"skills"`
+	// Metadata contains pagination information
 	Metadata skillsV01Metadata `json:"metadata"`
 }
 
+// skillsV01Metadata holds pagination metadata for the v0.1 skills list response.
+//
+//	@Description	Pagination metadata for a skills list response
 type skillsV01Metadata struct {
+	// Total is the total number of skills matching the query
 	Total int `json:"total"`
-	Page  int `json:"page"`
+	// Page is the current page number (1-based)
+	Page int `json:"page"`
+	// Limit is the maximum number of skills per page
 	Limit int `json:"limit"`
 }


### PR DESCRIPTION
## Summary

PR #4753 added two read-only skills browsing endpoints under the `x/dev.toolhive` extension namespace but did not include swag annotations, so the endpoints were absent from the generated OpenAPI spec.

- Add `@Summary`, `@Description`, `@Param`, `@Success`, `@Failure`, and `@Router` annotations to `listSkillsV01` and `getSkillV01`
- Add `@Description` doc comments to `skillsV01Response` and `skillsV01Metadata` so swag generates them as named schema components
- Regenerate `docs/server/` (`swagger.json`, `swagger.yaml`, `docs.go`)

Ref: #4753

## Type of change

Documentation

## Test plan

- [x] Linting (`task lint-fix`)
- [x] Spec regenerated with `task docs` and verified both paths appear

## Changes

| File | Change |
|------|--------|
| `pkg/api/v1/registry_v01_skills.go` | Add swag annotations to both handlers and `@Description` to response types |
| `docs/server/swagger.json` / `swagger.yaml` / `docs.go` | Regenerated — includes the two new paths and `skillsV01Response`, `skillsV01Metadata`, `registry.Skill` schemas |

## Does this introduce a user-facing change?

Yes — the two v0.1 skills endpoints now appear in the OpenAPI spec served at `/api/openapi.json`:
- `GET /registry/{registryName}/v0.1/x/dev.toolhive/skills`
- `GET /registry/{registryName}/v0.1/x/dev.toolhive/skills/{namespace}/{skillName}`