### PR TITLE
Address review findings from v0.1 skills OpenAPI PR

### DIFF
--- a/docs/server/docs.go
+++ b/docs/server/docs.go
@@ -2507,11 +2507,14 @@ const docTemplate = `{
                 "type": "object"
             },
             "pkg_api_v1.registryErrorResponse": {
+                "description": "Structured error response returned by registry endpoints",
                 "properties": {
                     "code": {
+                        "description": "Code is a machine-readable error code (e.g. \"not_found\", \"registry_auth_required\")",
                         "type": "string"
                     },
                     "message": {
+                        "description": "Message is a human-readable description of the error",
                         "type": "string"
                     }
                 },

--- a/docs/server/swagger.json
+++ b/docs/server/swagger.json
@@ -2500,11 +2500,14 @@
                 "type": "object"
             },
             "pkg_api_v1.registryErrorResponse": {
+                "description": "Structured error response returned by registry endpoints",
                 "properties": {
                     "code": {
+                        "description": "Code is a machine-readable error code (e.g. \"not_found\", \"registry_auth_required\")",
                         "type": "string"
                     },
                     "message": {
+                        "description": "Message is a human-readable description of the error",
                         "type": "string"
                     }
                 },

--- a/docs/server/swagger.yaml
+++ b/docs/server/swagger.yaml
@@ -2221,10 +2221,13 @@ components:
           type: string
       type: object
     pkg_api_v1.registryErrorResponse:
+      description: Structured error response returned by registry endpoints
       properties:
         code:
+          description: Code is a machine-readable error code (e.g. "not_found", "registry_auth_required")
           type: string
         message:
+          description: Message is a human-readable description of the error
           type: string
       type: object
     pkg_api_v1.registryInfo:

--- a/pkg/api/v1/registry.go
+++ b/pkg/api/v1/registry.go
@@ -26,11 +26,15 @@ import (
 // Desktop clients (Studio) match on this value to display the correct UI.
 const RegistryAuthRequiredCode = "registry_auth_required"
 
-// registryErrorResponse is the JSON body for structured HTTP 503 error responses.
+// registryErrorResponse is the JSON body for structured HTTP error responses.
 // The "code" field allows clients (e.g. Studio) to distinguish between
 // "registry_auth_required" and "registry_unavailable" conditions.
+//
+//	@Description	Structured error response returned by registry endpoints
 type registryErrorResponse struct {
-	Code    string `json:"code"`
+	// Code is a machine-readable error code (e.g. "not_found", "registry_auth_required")
+	Code string `json:"code"`
+	// Message is a human-readable description of the error
 	Message string `json:"message"`
 }
 

--- a/pkg/api/v1/registry_v01_skills.go
+++ b/pkg/api/v1/registry_v01_skills.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"log/slog"
+	"math"
 	"net/http"
 	"strconv"
 	"strings"
@@ -209,8 +210,15 @@ func parseSkillsPagination(r *http.Request) (page, limit int) {
 			page = v
 		}
 	}
+	// Cap page so (page-1)*limit cannot overflow int in the caller.
+	if maxPage := math.MaxInt / limit; page > maxPage {
+		page = maxPage
+	}
 	if l := r.URL.Query().Get("limit"); l != "" {
-		if v, err := strconv.Atoi(l); err == nil && v > 0 && v <= skillsMaxLimit {
+		if v, err := strconv.Atoi(l); err == nil && v > 0 {
+			if v > skillsMaxLimit {
+				v = skillsMaxLimit
+			}
 			limit = v
 		}
 	}
@@ -228,8 +236,6 @@ type skillsV01Response struct {
 }
 
 // skillsV01Metadata holds pagination metadata for the v0.1 skills list response.
-//
-//	@Description	Pagination metadata for a skills list response
 type skillsV01Metadata struct {
 	// Total is the total number of skills matching the query
 	Total int `json:"total"`

--- a/pkg/api/v1/registry_v01_skills_test.go
+++ b/pkg/api/v1/registry_v01_skills_test.go
@@ -5,6 +5,8 @@ package v1
 
 import (
 	"encoding/json"
+	"fmt"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -60,7 +62,9 @@ func TestParseSkillsPagination(t *testing.T) {
 		{"custom limit", "limit=10", 1, 10},
 		{"both", "page=2&limit=25", 2, 25},
 		{"invalid page", "page=-1", 1, skillsDefaultLimit},
-		{"limit over max", "limit=999", 1, skillsDefaultLimit},
+		{"limit over max", "limit=999", 1, skillsMaxLimit},
+		{"limit at max", "limit=200", 1, skillsMaxLimit},
+		{"page overflow", fmt.Sprintf("page=%d", math.MaxInt), math.MaxInt / skillsDefaultLimit, skillsDefaultLimit},
 		{"non-numeric", "page=abc&limit=xyz", 1, skillsDefaultLimit},
 	}
 


### PR DESCRIPTION
## Summary

Addresses the three review comments from #4800:

- Clamp out-of-range `limit` values to the max (200) instead of silently falling back to the default (50) — `?limit=201` now returns 200 results
- Remove dead `@Description` annotation on `skillsV01Metadata` (swag overrides it with the field comment from `skillsV01Response`)
- Add `@Description` and field comments to `registryErrorResponse` so the generated schema includes a description

Ref: #4800

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)
- [x] Spec regenerated with `task docs`

## Changes

| File | Change |
|------|--------|
| `pkg/api/v1/registry_v01_skills.go` | Clamp limit to max instead of ignoring; remove dead `@Description` |
| `pkg/api/v1/registry.go` | Add `@Description` and field comments to `registryErrorResponse` |
| `pkg/api/v1/registry_v01_skills_test.go` | Update "limit over max" expectation to 200; add "limit at max" case |
| `docs/server/*` | Regenerated spec |

## Does this introduce a user-facing change?

Yes — `?limit=N` where N > 200 now returns 200 items (clamped) instead of silently returning 50.