### PR TITLE
Update registry API image to v1.1.1

### DIFF
--- a/deploy/charts/operator/README.md
+++ b/deploy/charts/operator/README.md
@@ -99,6 +99,6 @@ The command removes all the Kubernetes components associated with the chart and 
 | operator.vmcpImage | string | `"ghcr.io/stacklok/toolhive/vmcp:v0.19.0"` | Image to use for Virtual MCP Server (vMCP) deployments |
 | operator.volumeMounts | list | `[]` | Additional volume mounts on the operator container |
 | operator.volumes | list | `[]` | Additional volumes to mount on the operator pod |
-| registryAPI | object | `{"image":"ghcr.io/stacklok/thv-registry-api:v1.0.1"}` | All values for the registry API deployment and associated resources |
-| registryAPI.image | string | `"ghcr.io/stacklok/thv-registry-api:v1.0.1"` | Container image for the registry API |
+| registryAPI | object | `{"image":"ghcr.io/stacklok/thv-registry-api:v1.1.1"}` | All values for the registry API deployment and associated resources |
+| registryAPI.image | string | `"ghcr.io/stacklok/thv-registry-api:v1.1.1"` | Container image for the registry API |
 

--- a/deploy/charts/operator/values-openshift.yaml
+++ b/deploy/charts/operator/values-openshift.yaml
@@ -206,4 +206,4 @@ operator:
 # -- All values for the registry API deployment and associated resources
 registryAPI:
   # -- Container image for the registry API
-  image: "ghcr.io/stacklok/thv-registry-api:v1.0.1"
+  image: "ghcr.io/stacklok/thv-registry-api:v1.1.1"

--- a/deploy/charts/operator/values.yaml
+++ b/deploy/charts/operator/values.yaml
@@ -206,4 +206,4 @@ operator:
 # -- All values for the registry API deployment and associated resources
 registryAPI:
   # -- Container image for the registry API
-  image: "ghcr.io/stacklok/thv-registry-api:v1.0.1"
+  image: "ghcr.io/stacklok/thv-registry-api:v1.1.1"


### PR DESCRIPTION
## Summary

- The operator Helm chart was pinned to `thv-registry-api:v1.0.1`. Bump to the latest release `v1.1.1` to pick up recent registry server improvements.

## Type of change

- [x] Dependency update

## Test plan

- [x] Manual testing (describe below)

Verified that `ghcr.io/stacklok/thv-registry-api:v1.1.1` exists as a published release on [toolhive-registry-server](https://github.com/stacklok/toolhive-registry-server/releases/tag/v1.1.1).

## Does this introduce a user-facing change?

No — the operator will deploy a newer registry API image when installed via the Helm chart.

Generated with [Claude Code](https://claude.com/claude-code)