### PR TITLE
Add ConfigMap content assertions to vMCP telemetry integration tests

### DIFF
--- a/cmd/thv-operator/test-integration/virtualmcp/virtualmcpserver_telemetryconfig_integration_test.go
+++ b/cmd/thv-operator/test-integration/virtualmcp/virtualmcpserver_telemetryconfig_integration_test.go
@@ -5,6 +5,7 @@
 package controllers
 
 import (
+	"fmt"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -13,6 +14,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/yaml"
 
 	mcpv1alpha1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1alpha1"
 	telemetryconfig "github.com/stacklok/toolhive/pkg/telemetry"
@@ -140,6 +142,33 @@ var _ = Describe("VirtualMCPServer TelemetryConfig Integration",
 					return false
 				}, timeout, interval).Should(BeTrue())
 			})
+
+			It("should produce a ConfigMap with telemetry config from the MCPTelemetryConfig", func() {
+				configMapName := fmt.Sprintf("%s-vmcp-config", virtualMCPServer.Name)
+				Eventually(func() bool {
+					cm := &corev1.ConfigMap{}
+					err := k8sClient.Get(ctx, types.NamespacedName{
+						Name:      configMapName,
+						Namespace: namespace,
+					}, cm)
+					if err != nil {
+						return false
+					}
+					configYAML, ok := cm.Data["config.yaml"]
+					if !ok || configYAML == "" {
+						return false
+					}
+					// Parse the config and verify telemetry fields match the MCPTelemetryConfig
+					var config vmcpconfig.Config
+					if err := yaml.Unmarshal([]byte(configYAML), &config); err != nil {
+						return false
+					}
+					return config.Telemetry != nil &&
+						config.Telemetry.Endpoint == "otel-collector:4317" && // NormalizeTelemetryConfig strips https://
+						config.Telemetry.TracingEnabled &&
+						config.Telemetry.MetricsEnabled
+				}, timeout, interval).Should(BeTrue())
+			})
 		})
 
 		Context("VirtualMCPServer should update when MCPTelemetryConfig spec changes", Ordered, func() {
@@ -252,6 +281,26 @@ var _ = Describe("VirtualMCPServer TelemetryConfig Integration",
 					}
 					return fetched.Status.TelemetryConfigHash != "" &&
 						fetched.Status.TelemetryConfigHash != initialHash
+				}, timeout, interval).Should(BeTrue())
+
+				// Verify the ConfigMap reflects the new endpoint
+				configMapName := fmt.Sprintf("%s-vmcp-config", virtualMCPServer.Name)
+				Eventually(func() bool {
+					cm := &corev1.ConfigMap{}
+					err := k8sClient.Get(ctx, types.NamespacedName{
+						Name:      configMapName,
+						Namespace: namespace,
+					}, cm)
+					if err != nil {
+						return false
+					}
+					var config vmcpconfig.Config
+					if err := yaml.Unmarshal([]byte(cm.Data["config.yaml"]), &config); err != nil {
+						return false
+					}
+					// NormalizeTelemetryConfig strips https:// prefix
+					return config.Telemetry != nil &&
+						config.Telemetry.Endpoint == "new-collector:4317"
 				}, timeout, interval).Should(BeTrue())
 			})
 		})


### PR DESCRIPTION
## Summary

Follow-up to #4801 (VirtualMCPServer TelemetryConfigRef). The integration tests in #4801 verified status conditions and hash tracking but did not assert the actual ConfigMap content produced by the converter. This gap means a bug in the converter's telemetry normalization path could pass all tests while producing incorrect telemetry config in the deployed ConfigMap.

- Add assertion verifying the `{name}-vmcp-config` ConfigMap's `config.yaml` contains the correct telemetry endpoint, tracing enabled, and metrics enabled from the referenced MCPTelemetryConfig
- Add assertion verifying the ConfigMap updates when the MCPTelemetryConfig endpoint changes (endpoint reflected in the ConfigMap data)
- Tests the full data path: CRD spec → converter → ConfigMap → telemetry config

Closes #4792

## Type of change

- [x] New feature

## Test plan

- [x] Linting (`task lint-fix`)
- [x] Integration tests (`task operator-test-integration`) — all 10 suites pass

Generated with [Claude Code](https://claude.com/claude-code)