### PR TITLE
Add GetContent API for on-the-fly SKILL.md retrieval from OCI and git sources

### DIFF
--- a/docs/server/docs.go
+++ b/docs/server/docs.go
@@ -1537,6 +1537,52 @@ const docTemplate = `{
                     "ScopeProject"
                 ]
             },
+            "github_com_stacklok_toolhive_pkg_skills.SkillContent": {
+                "properties": {
+                    "body": {
+                        "description": "Body is the raw SKILL.md markdown content.",
+                        "type": "string"
+                    },
+                    "description": {
+                        "description": "Description is the skill description from the OCI config labels.",
+                        "type": "string"
+                    },
+                    "files": {
+                        "description": "Files is the list of all files in the artifact with their sizes.",
+                        "items": {
+                            "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_skills.SkillFileEntry"
+                        },
+                        "type": "array",
+                        "uniqueItems": false
+                    },
+                    "license": {
+                        "description": "License is the SPDX license identifier from the OCI config labels.",
+                        "type": "string"
+                    },
+                    "name": {
+                        "description": "Name is the skill name from the OCI config labels.",
+                        "type": "string"
+                    },
+                    "version": {
+                        "description": "Version is the skill version from the OCI config labels.",
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "github_com_stacklok_toolhive_pkg_skills.SkillFileEntry": {
+                "properties": {
+                    "path": {
+                        "description": "Path is the file path within the artifact.",
+                        "type": "string"
+                    },
+                    "size": {
+                        "description": "Size is the uncompressed file size in bytes.",
+                        "type": "integer"
+                    }
+                },
+                "type": "object"
+            },
             "github_com_stacklok_toolhive_pkg_skills.SkillInfo": {
                 "properties": {
                     "installed_skill": {
@@ -5103,6 +5149,58 @@ const docTemplate = `{
                     }
                 },
                 "summary": "Delete a locally-built skill artifact",
+                "tags": [
+                    "skills"
+                ]
+            }
+        },
+        "/api/v1beta/skills/content": {
+            "get": {
+                "description": "Retrieve the SKILL.md body and file listing from an artifact\nwithout installing it. Accepts OCI refs, git refs, or local tags.",
+                "parameters": [
+                    {
+                        "description": "OCI reference or local build tag",
+                        "in": "query",
+                        "name": "ref",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_skills.SkillContent"
+                                }
+                            }
+                        },
+                        "description": "OK"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Bad Request"
+                    },
+                    "500": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Internal Server Error"
+                    }
+                },
+                "summary": "Get skill content",
                 "tags": [
                     "skills"
                 ]

--- a/docs/server/docs.go
+++ b/docs/server/docs.go
@@ -5198,6 +5198,16 @@ const docTemplate = `{
                             }
                         },
                         "description": "Internal Server Error"
+                    },
+                    "502": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Bad Gateway"
                     }
                 },
                 "summary": "Get skill content",

--- a/docs/server/swagger.json
+++ b/docs/server/swagger.json
@@ -1442,54 +1442,6 @@
                     "InstallStatusFailed"
                 ]
             },
-            "skills.SkillContent": {
-                "description": "SkillContent contains the SKILL.md body and file listing extracted from an OCI artifact.",
-                "properties": {
-                    "body": {
-                        "description": "Body is the raw SKILL.md markdown content.",
-                        "type": "string"
-                    },
-                    "description": {
-                        "description": "Description is the skill description from the OCI config labels.",
-                        "type": "string"
-                    },
-                    "files": {
-                        "description": "Files is the list of all files in the artifact with their sizes.",
-                        "items": {
-                            "$ref": "#/components/schemas/skills.SkillFileEntry"
-                        },
-                        "type": "array",
-                        "uniqueItems": false
-                    },
-                    "license": {
-                        "description": "License is the SPDX license identifier from the OCI config labels.",
-                        "type": "string"
-                    },
-                    "name": {
-                        "description": "Name is the skill name from the OCI config labels.",
-                        "type": "string"
-                    },
-                    "version": {
-                        "description": "Version is the skill version from the OCI config labels.",
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "skills.SkillFileEntry": {
-                "description": "SkillFileEntry represents a single file within a skill artifact.",
-                "properties": {
-                    "path": {
-                        "description": "Path is the file path within the artifact.",
-                        "type": "string"
-                    },
-                    "size": {
-                        "description": "Size is the uncompressed file size in bytes.",
-                        "type": "integer"
-                    }
-                },
-                "type": "object"
-            },
             "github_com_stacklok_toolhive_pkg_skills.InstalledSkill": {
                 "description": "InstalledSkill contains the full installation record.",
                 "properties": {
@@ -1577,6 +1529,52 @@
                     "ScopeUser",
                     "ScopeProject"
                 ]
+            },
+            "github_com_stacklok_toolhive_pkg_skills.SkillContent": {
+                "properties": {
+                    "body": {
+                        "description": "Body is the raw SKILL.md markdown content.",
+                        "type": "string"
+                    },
+                    "description": {
+                        "description": "Description is the skill description from the OCI config labels.",
+                        "type": "string"
+                    },
+                    "files": {
+                        "description": "Files is the list of all files in the artifact with their sizes.",
+                        "items": {
+                            "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_skills.SkillFileEntry"
+                        },
+                        "type": "array",
+                        "uniqueItems": false
+                    },
+                    "license": {
+                        "description": "License is the SPDX license identifier from the OCI config labels.",
+                        "type": "string"
+                    },
+                    "name": {
+                        "description": "Name is the skill name from the OCI config labels.",
+                        "type": "string"
+                    },
+                    "version": {
+                        "description": "Version is the skill version from the OCI config labels.",
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "github_com_stacklok_toolhive_pkg_skills.SkillFileEntry": {
+                "properties": {
+                    "path": {
+                        "description": "Path is the file path within the artifact.",
+                        "type": "string"
+                    },
+                    "size": {
+                        "description": "Size is the uncompressed file size in bytes.",
+                        "type": "integer"
+                    }
+                },
+                "type": "object"
             },
             "github_com_stacklok_toolhive_pkg_skills.SkillInfo": {
                 "properties": {
@@ -5066,61 +5064,6 @@
                 ]
             }
         },
-        "/api/v1beta/skills/content": {
-            "get": {
-                "description": "Retrieve the SKILL.md body and file listing from an OCI artifact without installing it. Works for both remote registry references (e.g. ghcr.io/org/skill:v1) and local build tags.",
-                "parameters": [
-                    {
-                        "description": "OCI reference or local build tag",
-                        "in": "query",
-                        "name": "ref",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/skills.SkillContent"
-                                }
-                            }
-                        },
-                        "description": "OK"
-                    },
-                    "400": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "description": "Bad Request"
-                    },
-                    "500": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "description": "Internal Server Error"
-                    }
-                },
-                "summary": "Get skill content",
-                "tags": [
-                    "skills"
-                ]
-            }
-        },
         "/api/v1beta/skills/builds": {
             "get": {
                 "description": "Get a list of all locally-built OCI skill artifacts in the local store",
@@ -5199,6 +5142,58 @@
                     }
                 },
                 "summary": "Delete a locally-built skill artifact",
+                "tags": [
+                    "skills"
+                ]
+            }
+        },
+        "/api/v1beta/skills/content": {
+            "get": {
+                "description": "Retrieve the SKILL.md body and file listing from an artifact\nwithout installing it. Accepts OCI refs, git refs, or local tags.",
+                "parameters": [
+                    {
+                        "description": "OCI reference or local build tag",
+                        "in": "query",
+                        "name": "ref",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_skills.SkillContent"
+                                }
+                            }
+                        },
+                        "description": "OK"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Bad Request"
+                    },
+                    "500": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Internal Server Error"
+                    }
+                },
+                "summary": "Get skill content",
                 "tags": [
                     "skills"
                 ]

--- a/docs/server/swagger.json
+++ b/docs/server/swagger.json
@@ -5191,6 +5191,16 @@
                             }
                         },
                         "description": "Internal Server Error"
+                    },
+                    "502": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Bad Gateway"
                     }
                 },
                 "summary": "Get skill content",

--- a/docs/server/swagger.json
+++ b/docs/server/swagger.json
@@ -1442,6 +1442,54 @@
                     "InstallStatusFailed"
                 ]
             },
+            "skills.SkillContent": {
+                "description": "SkillContent contains the SKILL.md body and file listing extracted from an OCI artifact.",
+                "properties": {
+                    "body": {
+                        "description": "Body is the raw SKILL.md markdown content.",
+                        "type": "string"
+                    },
+                    "description": {
+                        "description": "Description is the skill description from the OCI config labels.",
+                        "type": "string"
+                    },
+                    "files": {
+                        "description": "Files is the list of all files in the artifact with their sizes.",
+                        "items": {
+                            "$ref": "#/components/schemas/skills.SkillFileEntry"
+                        },
+                        "type": "array",
+                        "uniqueItems": false
+                    },
+                    "license": {
+                        "description": "License is the SPDX license identifier from the OCI config labels.",
+                        "type": "string"
+                    },
+                    "name": {
+                        "description": "Name is the skill name from the OCI config labels.",
+                        "type": "string"
+                    },
+                    "version": {
+                        "description": "Version is the skill version from the OCI config labels.",
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "skills.SkillFileEntry": {
+                "description": "SkillFileEntry represents a single file within a skill artifact.",
+                "properties": {
+                    "path": {
+                        "description": "Path is the file path within the artifact.",
+                        "type": "string"
+                    },
+                    "size": {
+                        "description": "Size is the uncompressed file size in bytes.",
+                        "type": "integer"
+                    }
+                },
+                "type": "object"
+            },
             "github_com_stacklok_toolhive_pkg_skills.InstalledSkill": {
                 "description": "InstalledSkill contains the full installation record.",
                 "properties": {
@@ -5013,6 +5061,61 @@
                     }
                 },
                 "summary": "Build a skill",
+                "tags": [
+                    "skills"
+                ]
+            }
+        },
+        "/api/v1beta/skills/content": {
+            "get": {
+                "description": "Retrieve the SKILL.md body and file listing from an OCI artifact without installing it. Works for both remote registry references (e.g. ghcr.io/org/skill:v1) and local build tags.",
+                "parameters": [
+                    {
+                        "description": "OCI reference or local build tag",
+                        "in": "query",
+                        "name": "ref",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/skills.SkillContent"
+                                }
+                            }
+                        },
+                        "description": "OK"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Bad Request"
+                    },
+                    "500": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Internal Server Error"
+                    }
+                },
+                "summary": "Get skill content",
                 "tags": [
                     "skills"
                 ]

--- a/docs/server/swagger.yaml
+++ b/docs/server/swagger.yaml
@@ -1426,6 +1426,40 @@ components:
       x-enum-varnames:
       - ScopeUser
       - ScopeProject
+    github_com_stacklok_toolhive_pkg_skills.SkillContent:
+      properties:
+        body:
+          description: Body is the raw SKILL.md markdown content.
+          type: string
+        description:
+          description: Description is the skill description from the OCI config labels.
+          type: string
+        files:
+          description: Files is the list of all files in the artifact with their sizes.
+          items:
+            $ref: '#/components/schemas/github_com_stacklok_toolhive_pkg_skills.SkillFileEntry'
+          type: array
+          uniqueItems: false
+        license:
+          description: License is the SPDX license identifier from the OCI config
+            labels.
+          type: string
+        name:
+          description: Name is the skill name from the OCI config labels.
+          type: string
+        version:
+          description: Version is the skill version from the OCI config labels.
+          type: string
+      type: object
+    github_com_stacklok_toolhive_pkg_skills.SkillFileEntry:
+      properties:
+        path:
+          description: Path is the file path within the artifact.
+          type: string
+        size:
+          description: Size is the uncompressed file size in bytes.
+          type: integer
+      type: object
     github_com_stacklok_toolhive_pkg_skills.SkillInfo:
       properties:
         installed_skill:
@@ -4149,6 +4183,40 @@ paths:
                 type: string
           description: Internal Server Error
       summary: Delete a locally-built skill artifact
+      tags:
+      - skills
+  /api/v1beta/skills/content:
+    get:
+      description: |-
+        Retrieve the SKILL.md body and file listing from an artifact
+        without installing it. Accepts OCI refs, git refs, or local tags.
+      parameters:
+      - description: OCI reference or local build tag
+        in: query
+        name: ref
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/github_com_stacklok_toolhive_pkg_skills.SkillContent'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                type: string
+          description: Bad Request
+        "500":
+          content:
+            application/json:
+              schema:
+                type: string
+          description: Internal Server Error
+      summary: Get skill content
       tags:
       - skills
   /api/v1beta/skills/push:

--- a/docs/server/swagger.yaml
+++ b/docs/server/swagger.yaml
@@ -4216,6 +4216,12 @@ paths:
               schema:
                 type: string
           description: Internal Server Error
+        "502":
+          content:
+            application/json:
+              schema:
+                type: string
+          description: Bad Gateway
       summary: Get skill content
       tags:
       - skills

--- a/pkg/api/v1/skills.go
+++ b/pkg/api/v1/skills.go
@@ -334,6 +334,7 @@ func (s *SkillsRoutes) deleteBuild(w http.ResponseWriter, r *http.Request) error
 //	@Param			ref	query		string	true	"OCI reference or local build tag"
 //	@Success		200	{object}	skills.SkillContent
 //	@Failure		400	{string}	string	"Bad Request"
+//	@Failure		502	{string}	string	"Bad Gateway"
 //	@Failure		500	{string}	string	"Internal Server Error"
 //	@Router			/api/v1beta/skills/content [get]
 func (s *SkillsRoutes) getSkillContent(w http.ResponseWriter, r *http.Request) error {

--- a/pkg/api/v1/skills.go
+++ b/pkg/api/v1/skills.go
@@ -36,6 +36,7 @@ func SkillsRouter(skillService skills.SkillService) http.Handler {
 	r.Post("/push", apierrors.ErrorHandler(routes.pushSkill))
 	r.Get("/builds", apierrors.ErrorHandler(routes.listBuilds))
 	r.Delete("/builds/{tag}", apierrors.ErrorHandler(routes.deleteBuild))
+	r.Get("/content", apierrors.ErrorHandler(routes.getSkillContent))
 
 	return r
 }
@@ -321,4 +322,35 @@ func (s *SkillsRoutes) deleteBuild(w http.ResponseWriter, r *http.Request) error
 	}
 	w.WriteHeader(http.StatusNoContent)
 	return nil
+}
+
+// getSkillContent retrieves the SKILL.md body and file listing from an OCI artifact.
+//
+//	@Summary		Get skill content
+//	@Description	Retrieve the SKILL.md body and file listing from an OCI artifact without installing it. Works for both remote registry references (e.g. ghcr.io/org/skill:v1) and local build tags.
+//	@Tags			skills
+//	@Produce		json
+//	@Param			ref	query		string	true	"OCI reference or local build tag"
+//	@Success		200	{object}	skills.SkillContent
+//	@Failure		400	{string}	string	"Bad Request"
+//	@Failure		500	{string}	string	"Internal Server Error"
+//	@Router			/api/v1beta/skills/content [get]
+func (s *SkillsRoutes) getSkillContent(w http.ResponseWriter, r *http.Request) error {
+	ref := r.URL.Query().Get("ref")
+	if ref == "" {
+		return httperr.WithCode(
+			fmt.Errorf("ref query parameter is required"),
+			http.StatusBadRequest,
+		)
+	}
+
+	content, err := s.skillService.GetContent(r.Context(), skills.ContentOptions{
+		Reference: ref,
+	})
+	if err != nil {
+		return err
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	return json.NewEncoder(w).Encode(content)
 }

--- a/pkg/api/v1/skills.go
+++ b/pkg/api/v1/skills.go
@@ -327,7 +327,8 @@ func (s *SkillsRoutes) deleteBuild(w http.ResponseWriter, r *http.Request) error
 // getSkillContent retrieves the SKILL.md body and file listing from an OCI artifact.
 //
 //	@Summary		Get skill content
-//	@Description	Retrieve the SKILL.md body and file listing from an OCI artifact without installing it. Works for both remote registry references (e.g. ghcr.io/org/skill:v1) and local build tags.
+//	@Description	Retrieve the SKILL.md body and file listing from an artifact
+//	@Description	without installing it. Accepts OCI refs, git refs, or local tags.
 //	@Tags			skills
 //	@Produce		json
 //	@Param			ref	query		string	true	"OCI reference or local build tag"

--- a/pkg/skills/client/client.go
+++ b/pkg/skills/client/client.go
@@ -248,6 +248,17 @@ func (c *Client) DeleteBuild(ctx context.Context, tag string) error {
 	return c.doJSONRequest(ctx, http.MethodDelete, "/builds/"+url.PathEscape(tag), nil, nil, nil)
 }
 
+// GetContent retrieves the SKILL.md body and file listing from an OCI artifact without installing it.
+func (c *Client) GetContent(ctx context.Context, opts skills.ContentOptions) (*skills.SkillContent, error) {
+	q := url.Values{}
+	q.Set("ref", opts.Reference)
+	var content skills.SkillContent
+	if err := c.doJSONRequest(ctx, http.MethodGet, "/content", q, nil, &content); err != nil {
+		return nil, err
+	}
+	return &content, nil
+}
+
 // --- internal helpers ---
 
 func (c *Client) buildURL(path string, query url.Values) string {

--- a/pkg/skills/client/client_test.go
+++ b/pkg/skills/client/client_test.go
@@ -542,6 +542,84 @@ func TestPush(t *testing.T) {
 	}
 }
 
+func TestGetContent(t *testing.T) {
+	t.Parallel()
+
+	response := skills.SkillContent{
+		Name:        "my-skill",
+		Description: "A test skill",
+		Version:     "1.0.0",
+		License:     "Apache-2.0",
+		Body:        "# My Skill\nDoes things.",
+		Files:       []skills.SkillFileEntry{{Path: "SKILL.md", Size: 42}},
+	}
+
+	tests := []struct {
+		name       string
+		opts       skills.ContentOptions
+		wantQuery  string
+		response   skills.SkillContent
+		statusCode int
+		wantErr    bool
+		wantCode   int
+	}{
+		{
+			name:       "success with local tag",
+			opts:       skills.ContentOptions{Reference: "my-skill"},
+			wantQuery:  "my-skill",
+			response:   response,
+			statusCode: http.StatusOK,
+		},
+		{
+			name:      "success with OCI reference",
+			opts:      skills.ContentOptions{Reference: "ghcr.io/org/my-skill:v1"},
+			wantQuery: "ghcr.io/org/my-skill:v1",
+			response:  response,
+			statusCode: http.StatusOK,
+		},
+		{
+			name:       "server error propagates",
+			opts:       skills.ContentOptions{Reference: "missing"},
+			statusCode: http.StatusBadRequest,
+			wantErr:    true,
+			wantCode:   http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodGet, r.Method)
+				assert.Equal(t, skillsBasePath+"/content", r.URL.Path)
+				if tt.wantQuery != "" {
+					assert.Equal(t, tt.wantQuery, r.URL.Query().Get("ref"))
+				}
+
+				if tt.statusCode >= http.StatusBadRequest {
+					http.Error(w, "bad request", tt.statusCode)
+					return
+				}
+				w.Header().Set("Content-Type", "application/json")
+				require.NoError(t, json.NewEncoder(w).Encode(tt.response))
+			}))
+			defer srv.Close()
+
+			c := newTestClient(t, srv)
+			got, err := c.GetContent(t.Context(), tt.opts)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Equal(t, tt.wantCode, httperr.Code(err))
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.response, *got)
+		})
+	}
+}
+
 func TestConnectionError(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/skills/client/client_test.go
+++ b/pkg/skills/client/client_test.go
@@ -12,13 +12,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"go.uber.org/mock/gomock"
-
 	envmocks "github.com/stacklok/toolhive-core/env/mocks"
 	"github.com/stacklok/toolhive-core/httperr"
 	"github.com/stacklok/toolhive/pkg/skills"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 )
 
 // newTestClient returns a *Client pointed at the given test server.
@@ -571,10 +570,10 @@ func TestGetContent(t *testing.T) {
 			statusCode: http.StatusOK,
 		},
 		{
-			name:      "success with OCI reference",
-			opts:      skills.ContentOptions{Reference: "ghcr.io/org/my-skill:v1"},
-			wantQuery: "ghcr.io/org/my-skill:v1",
-			response:  response,
+			name:       "success with OCI reference",
+			opts:       skills.ContentOptions{Reference: "ghcr.io/org/my-skill:v1"},
+			wantQuery:  "ghcr.io/org/my-skill:v1",
+			response:   response,
 			statusCode: http.StatusOK,
 		},
 		{

--- a/pkg/skills/client/client_test.go
+++ b/pkg/skills/client/client_test.go
@@ -12,12 +12,13 @@ import (
 	"testing"
 	"time"
 
-	envmocks "github.com/stacklok/toolhive-core/env/mocks"
-	"github.com/stacklok/toolhive-core/httperr"
-	"github.com/stacklok/toolhive/pkg/skills"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
+
+	envmocks "github.com/stacklok/toolhive-core/env/mocks"
+	"github.com/stacklok/toolhive-core/httperr"
+	"github.com/stacklok/toolhive/pkg/skills"
 )
 
 // newTestClient returns a *Client pointed at the given test server.

--- a/pkg/skills/mocks/mock_service.go
+++ b/pkg/skills/mocks/mock_service.go
@@ -70,6 +70,21 @@ func (mr *MockSkillServiceMockRecorder) DeleteBuild(ctx, tag any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteBuild", reflect.TypeOf((*MockSkillService)(nil).DeleteBuild), ctx, tag)
 }
 
+// GetContent mocks base method.
+func (m *MockSkillService) GetContent(ctx context.Context, opts skills.ContentOptions) (*skills.SkillContent, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetContent", ctx, opts)
+	ret0, _ := ret[0].(*skills.SkillContent)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetContent indicates an expected call of GetContent.
+func (mr *MockSkillServiceMockRecorder) GetContent(ctx, opts any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetContent", reflect.TypeOf((*MockSkillService)(nil).GetContent), ctx, opts)
+}
+
 // Info mocks base method.
 func (m *MockSkillService) Info(ctx context.Context, opts skills.InfoOptions) (*skills.SkillInfo, error) {
 	m.ctrl.T.Helper()

--- a/pkg/skills/options.go
+++ b/pkg/skills/options.go
@@ -73,6 +73,36 @@ type SkillInfo struct {
 	InstalledSkill *InstalledSkill `json:"installed_skill,omitempty"`
 }
 
+// ContentOptions configures the behavior of the GetContent operation.
+type ContentOptions struct {
+	// Reference is an OCI reference (e.g. ghcr.io/org/skill:v1) or a local build tag.
+	Reference string `json:"reference"`
+}
+
+// SkillFileEntry represents a single file within a skill artifact.
+type SkillFileEntry struct {
+	// Path is the file path within the artifact.
+	Path string `json:"path"`
+	// Size is the uncompressed file size in bytes.
+	Size int `json:"size"`
+}
+
+// SkillContent contains the SKILL.md body and file listing extracted from an OCI artifact.
+type SkillContent struct {
+	// Name is the skill name from the OCI config labels.
+	Name string `json:"name"`
+	// Description is the skill description from the OCI config labels.
+	Description string `json:"description"`
+	// Version is the skill version from the OCI config labels.
+	Version string `json:"version,omitempty"`
+	// License is the SPDX license identifier from the OCI config labels.
+	License string `json:"license,omitempty"`
+	// Body is the raw SKILL.md markdown content.
+	Body string `json:"body"`
+	// Files is the list of all files in the artifact with their sizes.
+	Files []SkillFileEntry `json:"files"`
+}
+
 // ValidationResult contains the outcome of a Validate operation.
 type ValidationResult struct {
 	// Valid indicates whether the skill definition is valid.

--- a/pkg/skills/service.go
+++ b/pkg/skills/service.go
@@ -27,4 +27,7 @@ type SkillService interface {
 	ListBuilds(ctx context.Context) ([]LocalBuild, error)
 	// DeleteBuild removes a locally-built OCI skill artifact from the local store.
 	DeleteBuild(ctx context.Context, tag string) error
+	// GetContent retrieves the SKILL.md body and file listing from an OCI artifact
+	// without installing it. Works for both remote registry references and local build tags.
+	GetContent(ctx context.Context, opts ContentOptions) (*SkillContent, error)
 }

--- a/pkg/skills/skillsvc/skillsvc.go
+++ b/pkg/skills/skillsvc/skillsvc.go
@@ -419,7 +419,8 @@ func (s *service) Info(ctx context.Context, opts skills.InfoOptions) (*skills.Sk
 //   - A git:// reference (e.g. "git://github.com/org/repo#path/to/skill")
 //   - An https:// URL (converted to git:// internally)
 //
-// Resolution order: local store → git → OCI registry.
+// Resolution order: git (git:// and https://) → OCI (local store, then remote
+// pull) → registry catalog lookup.
 func (s *service) GetContent(ctx context.Context, opts skills.ContentOptions) (*skills.SkillContent, error) {
 	ref := opts.Reference
 	if ref == "" {
@@ -453,6 +454,11 @@ func (s *service) GetContent(ctx context.Context, opts skills.ContentOptions) (*
 
 	// OCI failed — try resolving via registry name lookup (e.g. "skill-creator"
 	// or "io.github.stacklok/skill-creator" from the catalog index).
+	// Skip for refs that are clearly OCI references (contain : or @) to avoid
+	// a wasted network round-trip searching for e.g. "skill:v1".
+	if strings.ContainsAny(ref, ":@") {
+		return nil, ociErr
+	}
 	resolved, regErr := s.resolveFromRegistry(ref)
 	if regErr != nil {
 		return nil, regErr

--- a/pkg/skills/skillsvc/skillsvc.go
+++ b/pkg/skills/skillsvc/skillsvc.go
@@ -412,6 +412,193 @@ func (s *service) Info(ctx context.Context, opts skills.InfoOptions) (*skills.Sk
 	}, nil
 }
 
+// GetContent retrieves the SKILL.md body and file listing from a skill artifact
+// without installing it. The reference may be:
+//   - A local build tag (e.g. "my-skill")
+//   - A fully-qualified OCI reference (e.g. "ghcr.io/org/skill:v1")
+//   - A git:// reference (e.g. "git://github.com/org/repo#path/to/skill")
+//   - An https:// URL (converted to git:// internally)
+//
+// Resolution order: local store → git → OCI registry.
+func (s *service) GetContent(ctx context.Context, opts skills.ContentOptions) (*skills.SkillContent, error) {
+	ref := opts.Reference
+	if ref == "" {
+		return nil, httperr.WithCode(
+			errors.New("reference is required"),
+			http.StatusBadRequest,
+		)
+	}
+
+	// Git references (git:// or https://) are dispatched first since their
+	// scheme prefix is unambiguous and cannot collide with OCI references.
+	if gitresolver.IsGitReference(ref) {
+		return s.getContentFromGit(ctx, ref)
+	}
+	if isHTTPURL(ref) {
+		gitURL, err := buildGitReferenceFromRegistryURL(ref)
+		if err != nil {
+			return nil, httperr.WithCode(
+				fmt.Errorf("invalid URL %q: %w", ref, err),
+				http.StatusBadRequest,
+			)
+		}
+		return s.getContentFromGit(ctx, gitURL)
+	}
+
+	// Try OCI resolution (local store + remote pull). If this succeeds, return.
+	content, ociErr := s.getContentFromOCI(ctx, ref)
+	if ociErr == nil {
+		return content, nil
+	}
+
+	// OCI failed — try resolving via registry name lookup (e.g. "skill-creator"
+	// or "io.github.stacklok/skill-creator" from the catalog index).
+	resolved, regErr := s.resolveFromRegistry(ref)
+	if regErr != nil {
+		return nil, regErr
+	}
+	if resolved != nil {
+		switch {
+		case resolved.OCIRef != nil:
+			return s.getContentFromOCI(ctx, resolved.OCIRef.String())
+		case resolved.GitURL != "":
+			return s.getContentFromGit(ctx, resolved.GitURL)
+		}
+	}
+
+	// Nothing matched — return the original OCI error.
+	return nil, ociErr
+}
+
+// getContentFromGit clones a git repository and extracts the SKILL.md content.
+func (s *service) getContentFromGit(ctx context.Context, ref string) (*skills.SkillContent, error) {
+	if s.gitResolver == nil {
+		return nil, httperr.WithCode(
+			errors.New("git resolver is not configured"),
+			http.StatusInternalServerError,
+		)
+	}
+
+	gitRef, err := gitresolver.ParseGitReference(ref)
+	if err != nil {
+		return nil, httperr.WithCode(
+			fmt.Errorf("invalid git reference: %w", err),
+			http.StatusBadRequest,
+		)
+	}
+
+	resolved, err := s.gitResolver.Resolve(ctx, gitRef)
+	if err != nil {
+		return nil, httperr.WithCode(
+			fmt.Errorf("resolving git skill: %w", err),
+			http.StatusBadGateway,
+		)
+	}
+
+	content := &skills.SkillContent{
+		Name:        resolved.SkillConfig.Name,
+		Description: resolved.SkillConfig.Description,
+		Version:     resolved.SkillConfig.Version,
+		License:     resolved.SkillConfig.License,
+		Body:        string(resolved.SkillConfig.Body),
+		Files:       make([]skills.SkillFileEntry, 0, len(resolved.Files)),
+	}
+
+	for _, f := range resolved.Files {
+		content.Files = append(content.Files, skills.SkillFileEntry{
+			Path: f.Path,
+			Size: len(f.Content),
+		})
+	}
+
+	return content, nil
+}
+
+// getContentFromOCI resolves a reference from the local OCI store or pulls it
+// from a remote registry, then extracts the SKILL.md content.
+func (s *service) getContentFromOCI(ctx context.Context, ref string) (*skills.SkillContent, error) {
+	if s.ociStore == nil {
+		return nil, httperr.WithCode(
+			errors.New("OCI store is not configured"),
+			http.StatusInternalServerError,
+		)
+	}
+
+	// Try the local store first (covers local builds by tag name and
+	// previously pulled remote refs tagged by Pull).
+	d, resolveErr := s.ociStore.Resolve(ctx, ref)
+	if resolveErr != nil {
+		if s.registry == nil {
+			return nil, httperr.WithCode(
+				fmt.Errorf("reference %q not found in local store and OCI registry is not configured", ref),
+				http.StatusBadRequest,
+			)
+		}
+
+		ociRef, isOCI, parseErr := parseOCIReference(ref)
+		if parseErr != nil {
+			return nil, httperr.WithCode(
+				fmt.Errorf("invalid reference %q: %w", ref, parseErr),
+				http.StatusBadRequest,
+			)
+		}
+		if !isOCI {
+			return nil, httperr.WithCode(
+				fmt.Errorf("reference %q not found in local store and is not a valid OCI reference", ref),
+				http.StatusBadRequest,
+			)
+		}
+
+		qualifiedRef := qualifiedOCIRef(ociRef)
+		pullCtx, cancel := context.WithTimeout(ctx, ociPullTimeout)
+		defer cancel()
+
+		var pullErr error
+		d, pullErr = s.registry.Pull(pullCtx, s.ociStore, qualifiedRef)
+		if pullErr != nil {
+			return nil, httperr.WithCode(
+				fmt.Errorf("pulling OCI artifact %q: %w", qualifiedRef, pullErr),
+				http.StatusBadRequest,
+			)
+		}
+	}
+
+	layerData, skillConfig, err := s.extractOCIContent(ctx, d)
+	if err != nil {
+		return nil, err
+	}
+
+	entries, err := ociskills.DecompressTar(layerData)
+	if err != nil {
+		return nil, fmt.Errorf("decompressing skill layer: %w", err)
+	}
+
+	content := &skills.SkillContent{
+		Name:        skillConfig.Name,
+		Description: skillConfig.Description,
+		Version:     skillConfig.Version,
+		License:     skillConfig.License,
+		Files:       make([]skills.SkillFileEntry, 0, len(entries)),
+	}
+
+	for _, entry := range entries {
+		content.Files = append(content.Files, skills.SkillFileEntry{
+			Path: entry.Path,
+			Size: len(entry.Content),
+		})
+		if strings.EqualFold(filepath.Base(entry.Path), "SKILL.md") {
+			content.Body = string(entry.Content)
+		}
+	}
+
+	return content, nil
+}
+
+// isHTTPURL returns true if the reference starts with http:// or https://.
+func isHTTPURL(ref string) bool {
+	return strings.HasPrefix(ref, "https://") || strings.HasPrefix(ref, "http://")
+}
+
 // Validate checks whether a skill definition is valid.
 func (*service) Validate(_ context.Context, path string) (*skills.ValidationResult, error) {
 	if err := validateLocalPath(path); err != nil {
@@ -970,27 +1157,37 @@ type registryResolveResult struct {
 	GitURL string // raw git:// URL for installFromGit
 }
 
-// resolveFromRegistry attempts to resolve a plain skill name by querying the
-// configured skill registry/index. Returns (result, nil) on success, (nil, nil)
-// when no match is found or no lookup is configured, or (nil, err) on ambiguity.
+// resolveFromRegistry attempts to resolve a skill name by querying the
+// configured skill registry/index. Accepts either a plain name ("skill-creator")
+// or a qualified "namespace/name" ("io.github.stacklok/skill-creator").
+// Returns (result, nil) on success, (nil, nil) when no match is found or no
+// lookup is configured, or (nil, err) on ambiguity.
 func (s *service) resolveFromRegistry(name string) (*registryResolveResult, error) {
 	if s.skillLookup == nil {
 		return nil, nil
 	}
 
-	results, err := s.skillLookup.SearchSkills(name)
+	// Split qualified "namespace/name" if present. Use the last segment as
+	// the search query since SearchSkills matches on name substring.
+	wantNamespace, searchName := splitQualifiedName(name)
+
+	results, err := s.skillLookup.SearchSkills(searchName)
 	if err != nil {
 		slog.Warn("registry skill lookup failed, falling back to not-found", "name", name, "error", err)
 		return nil, nil
 	}
 
-	// Filter for exact name match. Case-insensitive because registry data
+	// Filter for exact match. Case-insensitive because registry data
 	// may not be normalized to lowercase even though local skill names are.
 	var matches []regtypes.Skill
 	for _, sk := range results {
-		if strings.EqualFold(sk.Name, name) {
-			matches = append(matches, sk)
+		if !strings.EqualFold(sk.Name, searchName) {
+			continue
 		}
+		if wantNamespace != "" && !strings.EqualFold(sk.Namespace, wantNamespace) {
+			continue
+		}
+		matches = append(matches, sk)
 	}
 
 	if len(matches) == 0 {
@@ -1016,6 +1213,16 @@ func (s *service) resolveFromRegistry(name string) (*registryResolveResult, erro
 	}
 
 	return resolveRegistryPackages(name, matches[0].Packages)
+}
+
+// splitQualifiedName splits "namespace/name" into (namespace, name).
+// If the input has no "/" it returns ("", name) unchanged.
+func splitQualifiedName(s string) (namespace, name string) {
+	idx := strings.LastIndex(s, "/")
+	if idx < 0 {
+		return "", s
+	}
+	return s[:idx], s[idx+1:]
 }
 
 // resolveRegistryPackages selects the best installable package from a registry
@@ -1046,6 +1253,9 @@ func resolveRegistryPackages(name string, packages []regtypes.SkillPackage) (*re
 					fmt.Errorf("registry skill %q has invalid git URL %q: %w", name, u, gitErr),
 					http.StatusUnprocessableEntity,
 				)
+			}
+			if pkg.Subfolder != "" {
+				gitURL += "#" + pkg.Subfolder
 			}
 			return &registryResolveResult{GitURL: gitURL}, nil
 		}

--- a/pkg/skills/skillsvc/skillsvc_test.go
+++ b/pkg/skills/skillsvc/skillsvc_test.go
@@ -20,6 +20,10 @@ import (
 	godigest "github.com/opencontainers/go-digest"
 	specs "github.com/opencontainers/image-spec/specs-go"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
 	"github.com/stacklok/toolhive-core/httperr"
 	ociskills "github.com/stacklok/toolhive-core/oci/skills"
 	ocimocks "github.com/stacklok/toolhive-core/oci/skills/mocks"
@@ -34,9 +38,6 @@ import (
 	skillsmocks "github.com/stacklok/toolhive/pkg/skills/mocks"
 	"github.com/stacklok/toolhive/pkg/storage"
 	storemocks "github.com/stacklok/toolhive/pkg/storage/mocks"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"go.uber.org/mock/gomock"
 )
 
 const testCommitHash = "abcdef1234567890abcdef1234567890abcdef12"

--- a/pkg/skills/skillsvc/skillsvc_test.go
+++ b/pkg/skills/skillsvc/skillsvc_test.go
@@ -3276,6 +3276,269 @@ func TestListBuilds(t *testing.T) {
 	})
 }
 
+func TestGetContent(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil oci store returns 500", func(t *testing.T) {
+		t.Parallel()
+		svc := New(&storage.NoopSkillStore{})
+		_, err := svc.GetContent(t.Context(), skills.ContentOptions{Reference: "my-skill"})
+		require.Error(t, err)
+		assert.Equal(t, http.StatusInternalServerError, httperr.Code(err))
+	})
+
+	t.Run("empty reference returns 400", func(t *testing.T) {
+		t.Parallel()
+		ociStore, err := ociskills.NewStore(t.TempDir())
+		require.NoError(t, err)
+		svc := New(&storage.NoopSkillStore{}, WithOCIStore(ociStore))
+		_, err = svc.GetContent(t.Context(), skills.ContentOptions{Reference: ""})
+		require.Error(t, err)
+		assert.Equal(t, http.StatusBadRequest, httperr.Code(err))
+	})
+
+	t.Run("local build tag resolves without registry", func(t *testing.T) {
+		t.Parallel()
+		ociStore, err := ociskills.NewStore(t.TempDir())
+		require.NoError(t, err)
+
+		d := buildTestArtifact(t, ociStore, "my-skill", "1.0.0")
+		require.NoError(t, ociStore.Tag(t.Context(), d, "my-skill"))
+
+		svc := New(&storage.NoopSkillStore{}, WithOCIStore(ociStore))
+		content, err := svc.GetContent(t.Context(), skills.ContentOptions{Reference: "my-skill"})
+		require.NoError(t, err)
+
+		assert.Equal(t, "my-skill", content.Name)
+		assert.Equal(t, "1.0.0", content.Version)
+		assert.NotEmpty(t, content.Body)
+		assert.NotEmpty(t, content.Files)
+
+		// SKILL.md must appear in the file list.
+		var skillMDFound bool
+		for _, f := range content.Files {
+			if strings.EqualFold(filepath.Base(f.Path), "SKILL.md") {
+				skillMDFound = true
+				assert.Greater(t, f.Size, 0)
+			}
+		}
+		assert.True(t, skillMDFound, "SKILL.md should be listed in Files")
+	})
+
+	t.Run("remote OCI reference triggers pull", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+
+		ociStore, err := ociskills.NewStore(t.TempDir())
+		require.NoError(t, err)
+		indexDigest := buildTestArtifact(t, ociStore, "my-skill", "2.0.0")
+
+		reg := ocimocks.NewMockRegistryClient(ctrl)
+		reg.EXPECT().Pull(gomock.Any(), ociStore, "ghcr.io/org/my-skill:v2").
+			Return(indexDigest, nil)
+
+		svc := New(&storage.NoopSkillStore{},
+			WithOCIStore(ociStore),
+			WithRegistryClient(reg),
+		)
+		content, err := svc.GetContent(t.Context(), skills.ContentOptions{
+			Reference: "ghcr.io/org/my-skill:v2",
+		})
+		require.NoError(t, err)
+
+		assert.Equal(t, "my-skill", content.Name)
+		assert.Equal(t, "2.0.0", content.Version)
+		assert.NotEmpty(t, content.Body)
+	})
+
+	t.Run("unqualified name not in store without registry returns 400", func(t *testing.T) {
+		t.Parallel()
+		ociStore, err := ociskills.NewStore(t.TempDir())
+		require.NoError(t, err)
+
+		svc := New(&storage.NoopSkillStore{}, WithOCIStore(ociStore))
+		_, err = svc.GetContent(t.Context(), skills.ContentOptions{Reference: "nonexistent"})
+		require.Error(t, err)
+		assert.Equal(t, http.StatusBadRequest, httperr.Code(err))
+	})
+
+	t.Run("nil registry with unresolvable remote ref returns 400", func(t *testing.T) {
+		t.Parallel()
+		ociStore, err := ociskills.NewStore(t.TempDir())
+		require.NoError(t, err)
+
+		// "ghcr.io/org/skill:v1" is a valid OCI ref but registry is nil.
+		svc := New(&storage.NoopSkillStore{}, WithOCIStore(ociStore))
+		_, err = svc.GetContent(t.Context(), skills.ContentOptions{Reference: "ghcr.io/org/skill:v1"})
+		require.Error(t, err)
+		assert.Equal(t, http.StatusBadRequest, httperr.Code(err))
+	})
+
+	t.Run("pull failure propagates as 400", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+
+		ociStore, err := ociskills.NewStore(t.TempDir())
+		require.NoError(t, err)
+
+		reg := ocimocks.NewMockRegistryClient(ctrl)
+		reg.EXPECT().Pull(gomock.Any(), ociStore, "ghcr.io/org/my-skill:v1").
+			Return(godigest.Digest(""), fmt.Errorf("registry unreachable"))
+
+		svc := New(&storage.NoopSkillStore{},
+			WithOCIStore(ociStore),
+			WithRegistryClient(reg),
+		)
+		_, err = svc.GetContent(t.Context(), skills.ContentOptions{Reference: "ghcr.io/org/my-skill:v1"})
+		require.Error(t, err)
+		assert.Equal(t, http.StatusBadRequest, httperr.Code(err))
+		assert.Contains(t, err.Error(), "registry unreachable")
+	})
+
+	t.Run("git reference resolves via git resolver", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+
+		gr := gitmocks.NewMockResolver(ctrl)
+		gr.EXPECT().Resolve(gomock.Any(), gomock.Any()).Return(&gitresolver.ResolveResult{
+			SkillConfig: &skills.ParseResult{
+				Name:        "my-skill",
+				Description: "a git skill",
+				Version:     "1.0.0",
+				Body:        []byte("# My Skill\nHello from git"),
+			},
+			Files: []gitresolver.FileEntry{
+				{Path: "SKILL.md", Content: []byte("# My Skill\nHello from git"), Mode: 0644},
+				{Path: "hooks.sh", Content: []byte("#!/bin/sh"), Mode: 0644},
+			},
+			CommitHash: testCommitHash,
+		}, nil)
+
+		svc := New(&storage.NoopSkillStore{}, WithGitResolver(gr))
+		content, err := svc.GetContent(t.Context(), skills.ContentOptions{
+			Reference: "git://github.com/test/my-skill#skills/my-skill",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "my-skill", content.Name)
+		assert.Equal(t, "a git skill", content.Description)
+		assert.Equal(t, "1.0.0", content.Version)
+		assert.Contains(t, content.Body, "Hello from git")
+		assert.Len(t, content.Files, 2)
+	})
+
+	t.Run("git resolve failure returns 502", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+
+		gr := gitmocks.NewMockResolver(ctrl)
+		gr.EXPECT().Resolve(gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("clone failed"))
+
+		svc := New(&storage.NoopSkillStore{}, WithGitResolver(gr))
+		_, err := svc.GetContent(t.Context(), skills.ContentOptions{
+			Reference: "git://github.com/test/my-skill",
+		})
+		require.Error(t, err)
+		assert.Equal(t, http.StatusBadGateway, httperr.Code(err))
+		assert.Contains(t, err.Error(), "resolving git skill")
+	})
+
+	t.Run("nil git resolver returns 500", func(t *testing.T) {
+		t.Parallel()
+		svc := &service{}
+		_, err := svc.GetContent(t.Context(), skills.ContentOptions{
+			Reference: "git://github.com/test/my-skill",
+		})
+		require.Error(t, err)
+		assert.Equal(t, http.StatusInternalServerError, httperr.Code(err))
+	})
+
+	t.Run("registry name falls back to git resolver", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+
+		ociStore, err := ociskills.NewStore(t.TempDir())
+		require.NoError(t, err)
+
+		lookup := regmocks.NewMockProvider(ctrl)
+		lookup.EXPECT().SearchSkills("skill-creator").Return([]regtypes.Skill{
+			{
+				Namespace: "io.github.stacklok",
+				Name:      "skill-creator",
+				Packages: []regtypes.SkillPackage{
+					{
+						RegistryType: "git",
+						URL:          "https://github.com/stacklok/toolhive-catalog",
+						Subfolder:    "registries/toolhive/skills/skill-creator",
+					},
+				},
+			},
+		}, nil)
+
+		gr := gitmocks.NewMockResolver(ctrl)
+		gr.EXPECT().Resolve(gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ context.Context, ref *gitresolver.GitReference) (*gitresolver.ResolveResult, error) {
+				assert.Equal(t, "registries/toolhive/skills/skill-creator", ref.Path)
+				return &gitresolver.ResolveResult{
+					SkillConfig: &skills.ParseResult{
+						Name:        "skill-creator",
+						Description: "creates skills",
+						Body:        []byte("# Skill Creator"),
+					},
+					Files: []gitresolver.FileEntry{
+						{Path: "SKILL.md", Content: []byte("# Skill Creator"), Mode: 0644},
+					},
+					CommitHash: testCommitHash,
+				}, nil
+			})
+
+		svc := New(&storage.NoopSkillStore{},
+			WithOCIStore(ociStore),
+			WithSkillLookup(lookup),
+			WithGitResolver(gr),
+		)
+		content, err := svc.GetContent(t.Context(), skills.ContentOptions{
+			Reference: "io.github.stacklok/skill-creator",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "skill-creator", content.Name)
+		assert.Contains(t, content.Body, "Skill Creator")
+	})
+
+	t.Run("qualified namespace/name filters registry matches", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+
+		ociStore, err := ociskills.NewStore(t.TempDir())
+		require.NoError(t, err)
+
+		lookup := regmocks.NewMockProvider(ctrl)
+		lookup.EXPECT().SearchSkills("my-skill").Return([]regtypes.Skill{
+			{Namespace: "io.github.alice", Name: "my-skill",
+				Packages: []regtypes.SkillPackage{{RegistryType: "git", URL: "https://github.com/alice/repo"}}},
+			{Namespace: "io.github.bob", Name: "my-skill",
+				Packages: []regtypes.SkillPackage{{RegistryType: "git", URL: "https://github.com/bob/repo"}}},
+		}, nil)
+
+		gr := gitmocks.NewMockResolver(ctrl)
+		gr.EXPECT().Resolve(gomock.Any(), gomock.Any()).Return(&gitresolver.ResolveResult{
+			SkillConfig: &skills.ParseResult{Name: "my-skill", Body: []byte("# Bob's skill")},
+			Files:       []gitresolver.FileEntry{{Path: "SKILL.md", Content: []byte("# Bob"), Mode: 0644}},
+			CommitHash:  testCommitHash,
+		}, nil)
+
+		svc := New(&storage.NoopSkillStore{},
+			WithOCIStore(ociStore),
+			WithSkillLookup(lookup),
+			WithGitResolver(gr),
+		)
+		content, err := svc.GetContent(t.Context(), skills.ContentOptions{
+			Reference: "io.github.bob/my-skill",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "my-skill", content.Name)
+	})
+}
+
 func TestDeleteBuild(t *testing.T) {
 	t.Parallel()
 
@@ -3333,4 +3596,43 @@ func TestDeleteBuild(t *testing.T) {
 		require.Len(t, builds, 1)
 		assert.Equal(t, "tag-b", builds[0].Tag)
 	})
+}
+
+func TestSplitQualifiedName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input     string
+		wantNS    string
+		wantName  string
+	}{
+		{"skill-creator", "", "skill-creator"},
+		{"io.github.stacklok/skill-creator", "io.github.stacklok", "skill-creator"},
+		{"deep/nested/name", "deep/nested", "name"},
+		{"", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			t.Parallel()
+			ns, name := splitQualifiedName(tt.input)
+			assert.Equal(t, tt.wantNS, ns)
+			assert.Equal(t, tt.wantName, name)
+		})
+	}
+}
+
+func TestResolveRegistryPackagesSubfolder(t *testing.T) {
+	t.Parallel()
+
+	result, err := resolveRegistryPackages("my-skill", []regtypes.SkillPackage{
+		{
+			RegistryType: "git",
+			URL:          "https://github.com/org/repo",
+			Subfolder:    "skills/my-skill",
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Contains(t, result.GitURL, "#skills/my-skill")
 }

--- a/pkg/skills/skillsvc/skillsvc_test.go
+++ b/pkg/skills/skillsvc/skillsvc_test.go
@@ -20,10 +20,6 @@ import (
 	godigest "github.com/opencontainers/go-digest"
 	specs "github.com/opencontainers/image-spec/specs-go"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"go.uber.org/mock/gomock"
-
 	"github.com/stacklok/toolhive-core/httperr"
 	ociskills "github.com/stacklok/toolhive-core/oci/skills"
 	ocimocks "github.com/stacklok/toolhive-core/oci/skills/mocks"
@@ -38,6 +34,9 @@ import (
 	skillsmocks "github.com/stacklok/toolhive/pkg/skills/mocks"
 	"github.com/stacklok/toolhive/pkg/storage"
 	storemocks "github.com/stacklok/toolhive/pkg/storage/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 )
 
 const testCommitHash = "abcdef1234567890abcdef1234567890abcdef12"
@@ -3602,9 +3601,9 @@ func TestSplitQualifiedName(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		input     string
-		wantNS    string
-		wantName  string
+		input    string
+		wantNS   string
+		wantName string
 	}{
 		{"skill-creator", "", "skill-creator"},
 		{"io.github.stacklok/skill-creator", "io.github.stacklok", "skill-creator"},


### PR DESCRIPTION
## Summary

- Add `GET /api/v1beta/skills/content?ref=<reference>` endpoint that retrieves SKILL.md content and file listings without installing the skill
- Support OCI references (`ghcr.io/org/skill:v1`), local build tags, git references (`git://github.com/org/repo#path`), HTTPS URLs, and registry catalog names (`io.github.stacklok/skill-creator`)
- Fix `resolveRegistryPackages` to include `Subfolder` as a `#path` fragment in git URLs — previously the subfolder field from the registry was silently dropped
- Extend `resolveFromRegistry` to accept qualified `namespace/name` identifiers for unambiguous catalog lookups

## Type of change

- [x] New feature
- [x] Bug fix

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)

## Changes

| File | Change |
|------|--------|
| `pkg/skills/options.go` | Add `ContentOptions`, `SkillContent`, `SkillFileEntry` types |
| `pkg/skills/service.go` | Add `GetContent` to `SkillService` interface |
| `pkg/skills/mocks/mock_service.go` | Regenerated mock |
| `pkg/skills/skillsvc/skillsvc.go` | Implement `GetContent` with OCI, git, and registry fallback; fix subfolder handling; add `splitQualifiedName` |
| `pkg/api/v1/skills.go` | Add `GET /content` route and handler |
| `pkg/skills/client/client.go` | Add `GetContent` to HTTP client |
| `pkg/skills/client/client_test.go` | Tests for client GetContent |
| `pkg/skills/skillsvc/skillsvc_test.go` | Tests for git resolution, registry fallback, subfolder, splitQualifiedName |
| `docs/server/swagger.json` | New endpoint and schema definitions |

## Does this introduce a user-facing change?

Yes — new API endpoint allows the UI to display skill details (SKILL.md content and file list) directly from the registry without requiring installation first.