### PR TITLE
Isolate `TestParseGitReference` from ambient env

### DIFF
--- a/pkg/skills/gitresolver/reference_test.go
+++ b/pkg/skills/gitresolver/reference_test.go
@@ -35,8 +35,12 @@ func TestIsGitReference(t *testing.T) {
 	}
 }
 
+//nolint:paralleltest // t.Setenv is incompatible with t.Parallel
 func TestParseGitReference(t *testing.T) {
-	t.Parallel()
+	// Ensure dev mode is off regardless of the ambient environment, so that
+	// SSRF checks and https:// scheme selection are exercised as they would be
+	// in production.
+	t.Setenv("TOOLHIVE_DEV", "")
 
 	tests := []struct {
 		name        string
@@ -159,7 +163,6 @@ func TestParseGitReference(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
 			result, err := ParseGitReference(tt.input)
 
 			if tt.expectError != "" {


### PR DESCRIPTION
The subtests failed when `TOOLHIVE_DEV=true` was set in the shell environment. `isDevMode()` reads that variable, causing the function to use `http://` instead of `https://` and to skip SSRF rejection -- the opposite of what the non-dev test cases assert.

Fix: remove `t.Parallel()` from `TestParseGitReference` and add `t.Setenv("TOOLHIVE_DEV", "")` so the test always runs in a clean environment, matching the pattern used by `TestParseGitReferenceDevMode`.