### PR TITLE
Add `Audience` to authserver test client fixture

### DIFF
--- a/pkg/authserver/integration_test.go
+++ b/pkg/authserver/integration_test.go
@@ -139,6 +139,7 @@ func setupTestServer(t *testing.T, opts ...testServerOption) *testServer {
 		ResponseTypes: []string{"code"},
 		GrantTypes:    []string{"authorization_code", "refresh_token"},
 		Scopes:        options.scopes,
+		Audience:      []string{testAudience},
 		Public:        true,
 	})
 	require.NoError(t, err)


### PR DESCRIPTION
Fosite validates that a granted audience appears in the client's own `GetAudience()` list when handling refresh tokens. The main `setupTestServer` helper registered the test client without an `Audience` field, so the check failed with HTTP 400 after the token handler began defaulting to the sole `AllowedAudience` on the initial `authorization_code` exchange.

DCR registration always sets `Audience` to `AllowedAudiences`; align the test fixture with that production behaviour.