### PR TITLE
Fix skill install for qualified namespace/name references and missing parent directory

### DIFF
--- a/pkg/skills/gitresolver/writer.go
+++ b/pkg/skills/gitresolver/writer.go
@@ -22,6 +22,12 @@ func WriteFiles(files []FileEntry, targetDir string, force bool) error {
 	// Sanitize targetDir early so all downstream os calls use the clean path.
 	targetDir = filepath.Clean(targetDir)
 
+	// Ensure the parent directory exists before acquiring the lock.
+	// WithFileLock opens targetDir+".lock", which requires the parent to exist.
+	if err := os.MkdirAll(filepath.Dir(targetDir), skills.DirPermissions); err != nil {
+		return fmt.Errorf("creating parent directory: %w", err)
+	}
+
 	return fileutils.WithFileLock(targetDir, func() error {
 		// Handle existing directory
 		if _, statErr := os.Stat(targetDir); statErr == nil { // lgtm[go/path-injection] #nosec G304

--- a/pkg/skills/gitresolver/writer_test.go
+++ b/pkg/skills/gitresolver/writer_test.go
@@ -79,6 +79,25 @@ func TestWriteFiles(t *testing.T) {
 		},
 	}
 
+	t.Run("parent directory does not exist", func(t *testing.T) {
+		t.Parallel()
+		baseDir := resolvedTempDir(t)
+		// Point targetDir one level deeper than a non-existent subdirectory.
+		targetDir := filepath.Join(baseDir, "nonexistent", "my-skill")
+
+		files := []FileEntry{{Path: "SKILL.md", Content: []byte("# Skill"), Mode: 0644}}
+		err := WriteFiles(files, targetDir, false)
+		require.NoError(t, err)
+
+		// Both the parent and the skill directory must now exist.
+		_, statErr := os.Stat(targetDir)
+		require.NoError(t, statErr)
+
+		content, readErr := os.ReadFile(filepath.Join(targetDir, "SKILL.md"))
+		require.NoError(t, readErr)
+		assert.Equal(t, []byte("# Skill"), content)
+	})
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()

--- a/pkg/skills/skillsvc/skillsvc.go
+++ b/pkg/skills/skillsvc/skillsvc.go
@@ -240,12 +240,14 @@ func (s *service) Install(ctx context.Context, opts skills.InstallOptions) (*ski
 			return s.installAndRegister(ctx, result, opts.Group, opts.Name, scope, opts.ProjectRoot)
 		}
 		// OCI pull failed — fall back to registry lookup for names that look
-		// like a qualified "namespace/name" (no ':' or '@'). Names with an
-		// explicit tag or digest are unambiguously OCI and should not trigger
-		// a registry search (e.g. "ghcr.io/org/skill:v1" should not fall back).
-		if strings.ContainsAny(opts.Name, ":@") {
+		// like a qualified "namespace/name" (no ':' or '@', exactly one '/').
+		// Names with an explicit tag or digest, or with more than one '/'
+		// (e.g. "ghcr.io/org/skill" or "ghcr.io/org/skill:v1"), are
+		// unambiguously OCI refs and must not trigger a registry search.
+		if strings.ContainsAny(opts.Name, ":@") || strings.Count(opts.Name, "/") > 1 {
 			return nil, ociErr
 		}
+		slog.Debug("OCI pull failed, attempting registry fallback", "name", opts.Name, "error", ociErr)
 		resolved, regErr := s.resolveFromRegistry(opts.Name)
 		if regErr != nil {
 			return nil, regErr
@@ -350,7 +352,10 @@ func (s *service) installFromResolvedRegistry(
 		if ociErr != nil {
 			return nil, ociErr
 		}
-		return s.installAndRegister(ctx, result, opts.Group, opts.Name, scope, opts.ProjectRoot)
+		// Use the skill name extracted from the artifact, not opts.Name which
+		// holds the OCI ref string. installFromOCI mutates its own copy of opts
+		// (Go pass-by-value), so the caller never sees the updated name.
+		return s.installAndRegister(ctx, result, opts.Group, result.Skill.Metadata.Name, scope, opts.ProjectRoot)
 	case resolved.GitURL != "":
 		slog.Info("resolved skill from registry (git)", "name", opts.Name, "git_url", resolved.GitURL)
 		opts.Name = resolved.GitURL
@@ -495,9 +500,9 @@ func (s *service) GetContent(ctx context.Context, opts skills.ContentOptions) (*
 
 	// OCI failed — try resolving via registry name lookup (e.g. "skill-creator"
 	// or "io.github.stacklok/skill-creator" from the catalog index).
-	// Skip for refs that are clearly OCI references (contain : or @) to avoid
-	// a wasted network round-trip searching for e.g. "skill:v1".
-	if strings.ContainsAny(ref, ":@") {
+	// Skip for refs that are clearly OCI references (contain ':', '@', or more
+	// than one '/') to avoid a wasted network round-trip.
+	if strings.ContainsAny(ref, ":@") || strings.Count(ref, "/") > 1 {
 		return nil, ociErr
 	}
 	resolved, regErr := s.resolveFromRegistry(ref)

--- a/pkg/skills/skillsvc/skillsvc.go
+++ b/pkg/skills/skillsvc/skillsvc.go
@@ -235,11 +235,25 @@ func (s *service) Install(ctx context.Context, opts skills.InstallOptions) (*ski
 		)
 	}
 	if isOCI {
-		result, err := s.installFromOCI(ctx, opts, scope, ref)
-		if err != nil {
-			return nil, err
+		result, ociErr := s.installFromOCI(ctx, opts, scope, ref)
+		if ociErr == nil {
+			return s.installAndRegister(ctx, result, opts.Group, opts.Name, scope, opts.ProjectRoot)
 		}
-		return s.installAndRegister(ctx, result, opts.Group, opts.Name, scope, opts.ProjectRoot)
+		// OCI pull failed — fall back to registry lookup for names that look
+		// like a qualified "namespace/name" (no ':' or '@'). Names with an
+		// explicit tag or digest are unambiguously OCI and should not trigger
+		// a registry search (e.g. "ghcr.io/org/skill:v1" should not fall back).
+		if strings.ContainsAny(opts.Name, ":@") {
+			return nil, ociErr
+		}
+		resolved, regErr := s.resolveFromRegistry(opts.Name)
+		if regErr != nil {
+			return nil, regErr
+		}
+		if resolved != nil {
+			return s.installFromResolvedRegistry(ctx, opts, scope, resolved)
+		}
+		return nil, ociErr
 	}
 
 	// Plain skill name — validate and proceed with existing flow.
@@ -309,24 +323,7 @@ func (s *service) installFromRegistryLookup(
 		return nil, regErr
 	}
 	if resolved != nil {
-		switch {
-		case resolved.OCIRef != nil:
-			slog.Info("resolved skill from registry (OCI)", "name", opts.Name, "oci_reference", resolved.OCIRef.String())
-			opts.Name = resolved.OCIRef.String()
-			result, ociErr := s.installFromOCI(ctx, opts, scope, resolved.OCIRef)
-			if ociErr != nil {
-				return nil, ociErr
-			}
-			return s.installAndRegister(ctx, result, opts.Group, opts.Name, scope, opts.ProjectRoot)
-		case resolved.GitURL != "":
-			slog.Info("resolved skill from registry (git)", "name", opts.Name, "git_url", resolved.GitURL)
-			opts.Name = resolved.GitURL
-			result, gitErr := s.installFromGit(ctx, opts, scope)
-			if gitErr != nil {
-				return nil, gitErr
-			}
-			return s.installAndRegister(ctx, result, opts.Group, result.Skill.Metadata.Name, scope, opts.ProjectRoot)
-		}
+		return s.installFromResolvedRegistry(ctx, opts, scope, resolved)
 	}
 
 	return nil, httperr.WithCode(
@@ -334,6 +331,38 @@ func (s *service) installFromRegistryLookup(
 			" install by OCI reference:\n  thv skill install ghcr.io/<namespace>/%s:<version>",
 			opts.Name, opts.Name),
 		http.StatusNotFound,
+	)
+}
+
+// installFromResolvedRegistry dispatches an install to the appropriate
+// backend (OCI or git) based on the result of a registry lookup.
+func (s *service) installFromResolvedRegistry(
+	ctx context.Context,
+	opts skills.InstallOptions,
+	scope skills.Scope,
+	resolved *registryResolveResult,
+) (*skills.InstallResult, error) {
+	switch {
+	case resolved.OCIRef != nil:
+		slog.Info("resolved skill from registry (OCI)", "name", opts.Name, "oci_reference", resolved.OCIRef.String())
+		opts.Name = resolved.OCIRef.String()
+		result, ociErr := s.installFromOCI(ctx, opts, scope, resolved.OCIRef)
+		if ociErr != nil {
+			return nil, ociErr
+		}
+		return s.installAndRegister(ctx, result, opts.Group, opts.Name, scope, opts.ProjectRoot)
+	case resolved.GitURL != "":
+		slog.Info("resolved skill from registry (git)", "name", opts.Name, "git_url", resolved.GitURL)
+		opts.Name = resolved.GitURL
+		result, gitErr := s.installFromGit(ctx, opts, scope)
+		if gitErr != nil {
+			return nil, gitErr
+		}
+		return s.installAndRegister(ctx, result, opts.Group, result.Skill.Metadata.Name, scope, opts.ProjectRoot)
+	}
+	return nil, httperr.WithCode(
+		fmt.Errorf("skill %q resolved from registry but has no installable package", opts.Name),
+		http.StatusUnprocessableEntity,
 	)
 }
 

--- a/pkg/skills/skillsvc/skillsvc.go
+++ b/pkg/skills/skillsvc/skillsvc.go
@@ -240,11 +240,10 @@ func (s *service) Install(ctx context.Context, opts skills.InstallOptions) (*ski
 			return s.installAndRegister(ctx, result, opts.Group, opts.Name, scope, opts.ProjectRoot)
 		}
 		// OCI pull failed — fall back to registry lookup for names that look
-		// like a qualified "namespace/name" (no ':' or '@', exactly one '/').
-		// Names with an explicit tag or digest, or with more than one '/'
-		// (e.g. "ghcr.io/org/skill" or "ghcr.io/org/skill:v1"), are
-		// unambiguously OCI refs and must not trigger a registry search.
-		if strings.ContainsAny(opts.Name, ":@") || strings.Count(opts.Name, "/") > 1 {
+		// like a qualified "namespace/name". Names that are unambiguously OCI
+		// (digest, explicit tag, or multi-segment path) must not trigger a
+		// registry search. See isUnambiguousOCIRef for the full rule set.
+		if isUnambiguousOCIRef(opts.Name, ref) {
 			return nil, ociErr
 		}
 		slog.Debug("OCI pull failed, attempting registry fallback", "name", opts.Name, "error", ociErr)
@@ -499,10 +498,11 @@ func (s *service) GetContent(ctx context.Context, opts skills.ContentOptions) (*
 	}
 
 	// OCI failed — try resolving via registry name lookup (e.g. "skill-creator"
-	// or "io.github.stacklok/skill-creator" from the catalog index).
-	// Skip for refs that are clearly OCI references (contain ':', '@', or more
-	// than one '/') to avoid a wasted network round-trip.
-	if strings.ContainsAny(ref, ":@") || strings.Count(ref, "/") > 1 {
+	// or "io.github.stacklok/skill-creator" from the catalog index). Skip for
+	// refs that are unambiguously OCI (digest, explicit tag, or multi-segment
+	// path) to avoid a wasted network round-trip.
+	if parsedRef, isOCI, parseErr := parseOCIReference(ref); parseErr == nil && isOCI &&
+		isUnambiguousOCIRef(ref, parsedRef) {
 		return nil, ociErr
 	}
 	resolved, regErr := s.resolveFromRegistry(ref)
@@ -842,6 +842,27 @@ func parseOCIReference(name string) (nameref.Reference, bool, error) {
 		return nil, true, err
 	}
 	return ref, true, nil
+}
+
+// isUnambiguousOCIRef reports whether raw was clearly intended by the user as
+// an OCI reference, meaning a failed pull must NOT fall back to a registry
+// catalogue lookup. A ref is unambiguous if any of the following hold:
+//
+//   - the parsed form is a digest reference (e.g. "name@sha256:...")
+//   - the raw string contains ':' (explicit tag such as "name:v1")
+//   - the raw string has more than one '/' (multi-segment path such as
+//     "ghcr.io/org/skill")
+//
+// The parsed Reference alone is insufficient for the tag case:
+// nameref.ParseReference normalizes "foo/bar" to "foo/bar:latest" (a name.Tag),
+// making it indistinguishable from an explicitly tagged reference. We therefore
+// rely on the parsed form for the digest check and fall back to string
+// inspection for the tag and segment-count checks.
+func isUnambiguousOCIRef(raw string, ref nameref.Reference) bool {
+	if _, isDigest := ref.(nameref.Digest); isDigest {
+		return true
+	}
+	return strings.Contains(raw, ":") || strings.Count(raw, "/") > 1
 }
 
 // installFromOCI pulls a skill artifact from a remote registry, extracts

--- a/pkg/skills/skillsvc/skillsvc_test.go
+++ b/pkg/skills/skillsvc/skillsvc_test.go
@@ -2931,6 +2931,208 @@ func TestInstallFromRegistryGitFallback(t *testing.T) {
 	}
 }
 
+// TestInstallQualifiedNameOCIFallback covers the scenario where Install
+// receives a "namespace/name" string, which is parsed as an OCI reference but
+// fails to pull because the namespace looks like a registry host. The service
+// must fall back to a registry catalogue lookup and complete the install from
+// the resolved package (OCI or git). Names that carry an explicit tag or digest
+// (unambiguously OCI) must NOT trigger a fallback.
+func TestInstallQualifiedNameOCIFallback(t *testing.T) {
+	t.Parallel()
+
+	commitHash := testCommitHash
+
+	tests := []struct {
+		name     string
+		opts     skills.InstallOptions
+		setup    func(t *testing.T, ctrl *gomock.Controller) (*regmocks.MockProvider, *ocimocks.MockRegistryClient, *ociskills.Store, *gitmocks.MockResolver, *storemocks.MockSkillStore, *skillsmocks.MockPathResolver)
+		wantCode int
+		wantErr  string
+		wantName string
+	}{
+		{
+			name: "qualified namespace/name falls back to registry OCI package",
+			opts: skills.InstallOptions{Name: "io.github.stacklok/my-skill"},
+			setup: func(t *testing.T, ctrl *gomock.Controller) (*regmocks.MockProvider, *ocimocks.MockRegistryClient, *ociskills.Store, *gitmocks.MockResolver, *storemocks.MockSkillStore, *skillsmocks.MockPathResolver) {
+				t.Helper()
+				ociStore, err := ociskills.NewStore(tempDir(t))
+				require.NoError(t, err)
+
+				indexDigest := buildTestArtifact(t, ociStore, "my-skill", "1.0.0")
+
+				reg := ocimocks.NewMockRegistryClient(ctrl)
+				// First Pull is for the raw "io.github.stacklok/my-skill" — fails.
+				reg.EXPECT().Pull(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(godigest.Digest(""), fmt.Errorf("no such host")).
+					Times(1)
+				// Second Pull is after registry lookup resolves the real OCI ref.
+				reg.EXPECT().Pull(gomock.Any(), gomock.Any(), "ghcr.io/stacklok/my-skill:v1.0.0").
+					Return(indexDigest, nil)
+
+				lookup := regmocks.NewMockProvider(ctrl)
+				lookup.EXPECT().SearchSkills("my-skill").Return([]regtypes.Skill{
+					{
+						Namespace: "io.github.stacklok",
+						Name:      "my-skill",
+						Packages: []regtypes.SkillPackage{
+							{RegistryType: "oci", Identifier: "ghcr.io/stacklok/my-skill:v1.0.0"},
+						},
+					},
+				}, nil)
+
+				installBase := filepath.Join(tempDir(t), "installed")
+				require.NoError(t, os.MkdirAll(installBase, 0o755))
+
+				store := storemocks.NewMockSkillStore(ctrl)
+				store.EXPECT().Get(gomock.Any(), "my-skill", skills.ScopeUser, "").Return(skills.InstalledSkill{}, storage.ErrNotFound)
+				store.EXPECT().Create(gomock.Any(), gomock.Any()).Return(nil)
+
+				pr := skillsmocks.NewMockPathResolver(ctrl)
+				pr.EXPECT().GetSkillPath("claude-code", "my-skill", skills.ScopeUser, "").Return(filepath.Join(installBase, "my-skill"), nil)
+				pr.EXPECT().ListSkillSupportingClients().Return([]string{"claude-code"})
+
+				return lookup, reg, ociStore, nil, store, pr
+			},
+			wantName: "my-skill",
+		},
+		{
+			name: "qualified namespace/name falls back to registry git package",
+			opts: skills.InstallOptions{Name: "io.github.stacklok/my-skill"},
+			setup: func(t *testing.T, ctrl *gomock.Controller) (*regmocks.MockProvider, *ocimocks.MockRegistryClient, *ociskills.Store, *gitmocks.MockResolver, *storemocks.MockSkillStore, *skillsmocks.MockPathResolver) {
+				t.Helper()
+				ociStore, err := ociskills.NewStore(tempDir(t))
+				require.NoError(t, err)
+
+				reg := ocimocks.NewMockRegistryClient(ctrl)
+				reg.EXPECT().Pull(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(godigest.Digest(""), fmt.Errorf("no such host"))
+
+				lookup := regmocks.NewMockProvider(ctrl)
+				lookup.EXPECT().SearchSkills("my-skill").Return([]regtypes.Skill{
+					{
+						Namespace: "io.github.stacklok",
+						Name:      "my-skill",
+						Packages: []regtypes.SkillPackage{
+							{RegistryType: "git", URL: "https://github.com/stacklok/my-skill"},
+						},
+					},
+				}, nil)
+
+				gr := gitmocks.NewMockResolver(ctrl)
+				gr.EXPECT().Resolve(gomock.Any(), gomock.Any()).Return(&gitresolver.ResolveResult{
+					SkillConfig: &skills.ParseResult{Name: "my-skill", Version: "1.0.0"},
+					Files:       []gitresolver.FileEntry{{Path: "SKILL.md", Content: []byte("---\nname: my-skill\n---\n"), Mode: 0644}},
+					CommitHash:  commitHash,
+				}, nil)
+
+				installBase := filepath.Join(tempDir(t), "installed")
+				require.NoError(t, os.MkdirAll(installBase, 0o755))
+
+				store := storemocks.NewMockSkillStore(ctrl)
+				store.EXPECT().Get(gomock.Any(), "my-skill", skills.ScopeUser, "").Return(skills.InstalledSkill{}, storage.ErrNotFound)
+				store.EXPECT().Create(gomock.Any(), gomock.Any()).Return(nil)
+
+				pr := skillsmocks.NewMockPathResolver(ctrl)
+				pr.EXPECT().GetSkillPath("claude-code", "my-skill", skills.ScopeUser, "").Return(filepath.Join(installBase, "my-skill"), nil)
+				pr.EXPECT().ListSkillSupportingClients().Return([]string{"claude-code"})
+
+				return lookup, reg, ociStore, gr, store, pr
+			},
+			wantName: "my-skill",
+		},
+		{
+			name: "explicit OCI tag does not fall back to registry on pull failure",
+			opts: skills.InstallOptions{Name: "ghcr.io/org/my-skill:v1"},
+			setup: func(t *testing.T, ctrl *gomock.Controller) (*regmocks.MockProvider, *ocimocks.MockRegistryClient, *ociskills.Store, *gitmocks.MockResolver, *storemocks.MockSkillStore, *skillsmocks.MockPathResolver) {
+				t.Helper()
+				ociStore, err := ociskills.NewStore(tempDir(t))
+				require.NoError(t, err)
+
+				reg := ocimocks.NewMockRegistryClient(ctrl)
+				reg.EXPECT().Pull(gomock.Any(), gomock.Any(), "ghcr.io/org/my-skill:v1").
+					Return(godigest.Digest(""), fmt.Errorf("auth required"))
+
+				// pathResolver must be non-nil so installFromOCI proceeds past its
+				// nil guard and reaches the Pull call.
+				pr := skillsmocks.NewMockPathResolver(ctrl)
+
+				store := storemocks.NewMockSkillStore(ctrl)
+
+				// No lookup mock — gomock will fail the test if SearchSkills is called.
+				return nil, reg, ociStore, nil, store, pr
+			},
+			wantCode: http.StatusBadRequest,
+			wantErr:  "auth required",
+		},
+		{
+			name: "qualified name with no registry match returns original OCI error",
+			opts: skills.InstallOptions{Name: "io.github.stacklok/my-skill"},
+			setup: func(t *testing.T, ctrl *gomock.Controller) (*regmocks.MockProvider, *ocimocks.MockRegistryClient, *ociskills.Store, *gitmocks.MockResolver, *storemocks.MockSkillStore, *skillsmocks.MockPathResolver) {
+				t.Helper()
+				ociStore, err := ociskills.NewStore(tempDir(t))
+				require.NoError(t, err)
+
+				reg := ocimocks.NewMockRegistryClient(ctrl)
+				reg.EXPECT().Pull(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(godigest.Digest(""), fmt.Errorf("no such host"))
+
+				// pathResolver must be non-nil so installFromOCI proceeds past its
+				// nil guard and reaches the Pull call.
+				pr := skillsmocks.NewMockPathResolver(ctrl)
+
+				lookup := regmocks.NewMockProvider(ctrl)
+				lookup.EXPECT().SearchSkills("my-skill").Return(nil, nil)
+
+				store := storemocks.NewMockSkillStore(ctrl)
+				return lookup, reg, ociStore, nil, store, pr
+			},
+			wantCode: http.StatusBadRequest,
+			wantErr:  "no such host",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			lookup, reg, ociStore, gr, store, pr := tt.setup(t, ctrl)
+
+			var opts []Option
+			if lookup != nil {
+				opts = append(opts, WithSkillLookup(lookup))
+			}
+			if reg != nil {
+				opts = append(opts, WithRegistryClient(reg))
+			}
+			if ociStore != nil {
+				opts = append(opts, WithOCIStore(ociStore))
+			}
+			if gr != nil {
+				opts = append(opts, WithGitResolver(gr))
+			}
+			if pr != nil {
+				opts = append(opts, WithPathResolver(pr))
+			}
+
+			svc := New(store, opts...)
+			result, err := svc.Install(t.Context(), tt.opts)
+
+			if tt.wantCode != 0 {
+				require.Error(t, err)
+				assert.Equal(t, tt.wantCode, httperr.Code(err))
+				if tt.wantErr != "" {
+					assert.Contains(t, err.Error(), tt.wantErr)
+				}
+				return
+			}
+			require.NoError(t, err)
+			if tt.wantName != "" {
+				assert.Equal(t, tt.wantName, result.Skill.Metadata.Name)
+			}
+		})
+	}
+}
+
 func TestUninstallRemovesSkillFromGroups(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/skills/skillsvc/skillsvc_test.go
+++ b/pkg/skills/skillsvc/skillsvc_test.go
@@ -2961,8 +2961,8 @@ func TestInstallQualifiedNameOCIFallback(t *testing.T) {
 				indexDigest := buildTestArtifact(t, ociStore, "my-skill", "1.0.0")
 
 				reg := ocimocks.NewMockRegistryClient(ctrl)
-				// First Pull is for the raw "io.github.stacklok/my-skill" — fails.
-				reg.EXPECT().Pull(gomock.Any(), gomock.Any(), gomock.Any()).
+				// First Pull is for the raw "io.github.stacklok/my-skill:latest" — fails.
+				reg.EXPECT().Pull(gomock.Any(), gomock.Any(), "io.github.stacklok/my-skill:latest").
 					Return(godigest.Digest(""), fmt.Errorf("no such host")).
 					Times(1)
 				// Second Pull is after registry lookup resolves the real OCI ref.
@@ -3004,7 +3004,7 @@ func TestInstallQualifiedNameOCIFallback(t *testing.T) {
 				require.NoError(t, err)
 
 				reg := ocimocks.NewMockRegistryClient(ctrl)
-				reg.EXPECT().Pull(gomock.Any(), gomock.Any(), gomock.Any()).
+				reg.EXPECT().Pull(gomock.Any(), gomock.Any(), "io.github.stacklok/my-skill:latest").
 					Return(godigest.Digest(""), fmt.Errorf("no such host"))
 
 				lookup := regmocks.NewMockProvider(ctrl)
@@ -3073,7 +3073,7 @@ func TestInstallQualifiedNameOCIFallback(t *testing.T) {
 				require.NoError(t, err)
 
 				reg := ocimocks.NewMockRegistryClient(ctrl)
-				reg.EXPECT().Pull(gomock.Any(), gomock.Any(), gomock.Any()).
+				reg.EXPECT().Pull(gomock.Any(), gomock.Any(), "io.github.stacklok/my-skill:latest").
 					Return(godigest.Digest(""), fmt.Errorf("no such host"))
 
 				// pathResolver must be non-nil so installFromOCI proceeds past its
@@ -3088,6 +3088,78 @@ func TestInstallQualifiedNameOCIFallback(t *testing.T) {
 			},
 			wantCode: http.StatusBadRequest,
 			wantErr:  "no such host",
+		},
+		{
+			name: "digest ref does not fall back to registry on pull failure",
+			// A full 64-char SHA256 hex digest — required for nameref.ParseReference to accept it.
+			opts: skills.InstallOptions{Name: "ghcr.io/org/my-skill@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+			setup: func(t *testing.T, ctrl *gomock.Controller) (*regmocks.MockProvider, *ocimocks.MockRegistryClient, *ociskills.Store, *gitmocks.MockResolver, *storemocks.MockSkillStore, *skillsmocks.MockPathResolver) {
+				t.Helper()
+				ociStore, err := ociskills.NewStore(tempDir(t))
+				require.NoError(t, err)
+
+				reg := ocimocks.NewMockRegistryClient(ctrl)
+				reg.EXPECT().Pull(gomock.Any(), gomock.Any(), "ghcr.io/org/my-skill@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa").
+					Return(godigest.Digest(""), fmt.Errorf("manifest unknown"))
+
+				pr := skillsmocks.NewMockPathResolver(ctrl)
+				store := storemocks.NewMockSkillStore(ctrl)
+				// No lookup mock — gomock will fail the test if SearchSkills is called.
+				return nil, reg, ociStore, nil, store, pr
+			},
+			wantCode: http.StatusBadRequest,
+			wantErr:  "manifest unknown",
+		},
+		{
+			name: "multi-segment OCI ref does not fall back to registry on pull failure",
+			opts: skills.InstallOptions{Name: "ghcr.io/org/my-skill"},
+			setup: func(t *testing.T, ctrl *gomock.Controller) (*regmocks.MockProvider, *ocimocks.MockRegistryClient, *ociskills.Store, *gitmocks.MockResolver, *storemocks.MockSkillStore, *skillsmocks.MockPathResolver) {
+				t.Helper()
+				ociStore, err := ociskills.NewStore(tempDir(t))
+				require.NoError(t, err)
+
+				reg := ocimocks.NewMockRegistryClient(ctrl)
+				reg.EXPECT().Pull(gomock.Any(), gomock.Any(), "ghcr.io/org/my-skill:latest").
+					Return(godigest.Digest(""), fmt.Errorf("auth required"))
+
+				pr := skillsmocks.NewMockPathResolver(ctrl)
+				store := storemocks.NewMockSkillStore(ctrl)
+				// No lookup mock — gomock will fail if SearchSkills is called.
+				return nil, reg, ociStore, nil, store, pr
+			},
+			wantCode: http.StatusBadRequest,
+			wantErr:  "auth required",
+		},
+		{
+			name: "registry ambiguity error surfaced to caller",
+			// resolveFromRegistry returns a conflict error when multiple registry
+			// entries match the same name — the Install method must propagate it.
+			opts: skills.InstallOptions{Name: "io.github.stacklok/my-skill"},
+			setup: func(t *testing.T, ctrl *gomock.Controller) (*regmocks.MockProvider, *ocimocks.MockRegistryClient, *ociskills.Store, *gitmocks.MockResolver, *storemocks.MockSkillStore, *skillsmocks.MockPathResolver) {
+				t.Helper()
+				ociStore, err := ociskills.NewStore(tempDir(t))
+				require.NoError(t, err)
+
+				reg := ocimocks.NewMockRegistryClient(ctrl)
+				reg.EXPECT().Pull(gomock.Any(), gomock.Any(), "io.github.stacklok/my-skill:latest").
+					Return(godigest.Digest(""), fmt.Errorf("no such host"))
+
+				pr := skillsmocks.NewMockPathResolver(ctrl)
+
+				// Return two results with the same namespace/name so that
+				// resolveFromRegistry treats this as an ambiguous match and
+				// returns a conflict error rather than nil.
+				lookup := regmocks.NewMockProvider(ctrl)
+				lookup.EXPECT().SearchSkills("my-skill").Return([]regtypes.Skill{
+					{Namespace: "io.github.stacklok", Name: "my-skill", Packages: []regtypes.SkillPackage{{RegistryType: "git", URL: "https://github.com/a/my-skill"}}},
+					{Namespace: "io.github.stacklok", Name: "my-skill", Packages: []regtypes.SkillPackage{{RegistryType: "git", URL: "https://github.com/b/my-skill"}}},
+				}, nil)
+
+				store := storemocks.NewMockSkillStore(ctrl)
+				return lookup, reg, ociStore, nil, store, pr
+			},
+			wantCode: http.StatusConflict,
+			wantErr:  "ambiguous",
 		},
 	}
 


### PR DESCRIPTION
## Summary

- Fix `Install` to fall back to registry catalog lookup when a `namespace/name` reference (e.g. `io.github.stacklok/skill-creator`) fails OCI pull because the namespace is parsed as a registry host. Names with an explicit tag or digest (e.g. `ghcr.io/org/skill:v1`) or more than one `/` (e.g. `ghcr.io/org/skill`) are unambiguously OCI and do not fall back
- Extract `installFromResolvedRegistry` helper to share dispatch logic between `installFromRegistryLookup` and the new fallback path
- Fix `WriteFiles` failing to acquire the lock when the parent skills directory does not yet exist (e.g. first install to `~/.cline/skills/`)
- Fix pre-existing bug in `installFromResolvedRegistry` OCI branch: pass `result.Skill.Metadata.Name` instead of `opts.Name` (the OCI ref string) to `installAndRegister`, so group registration and rollback use the correct skill name

## Behavioral change note

Previously, a registry entry that existed but had no installable OCI or git package fell through and returned **404 Not Found**. It now returns **422 Unprocessable Entity** ("resolved but no installable package"), which is a more accurate response.

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)

## Changes

| File | Change |
|------|--------|
| `pkg/skills/skillsvc/skillsvc.go` | Add OCI→registry fallback in `Install` and `GetContent`; tighten guard to also block multi-segment refs; add debug log before fallback; fix `opts.Name` bug in OCI branch of `installFromResolvedRegistry` |
| `pkg/skills/skillsvc/skillsvc_test.go` | Extend `TestInstallQualifiedNameOCIFallback` with digest, multi-segment, and ambiguity cases; pin `Pull` mock arguments |
| `pkg/skills/gitresolver/writer.go` | `MkdirAll` parent before acquiring file lock |
| `pkg/skills/gitresolver/writer_test.go` | Add test for missing parent directory |

## Does this introduce a user-facing change?

Yes — `thv skill install io.github.stacklok/<skill-name>` now works correctly instead of failing with "no such host".