### PR TITLE
Return error from `UpdateConfig` callbacks

### DIFF
--- a/cmd/thv/app/client.go
+++ b/cmd/thv/app/client.go
@@ -292,15 +292,16 @@ func registerClientsGlobally(
 ) error {
 	for _, clientToRegister := range clients {
 		// Update the global config to register the client
-		err := config.UpdateConfig(func(c *config.Config) {
+		err := config.UpdateConfig(func(c *config.Config) error {
 			for _, registeredClient := range c.Clients.RegisteredClients {
 				if registeredClient == string(clientToRegister.Name) {
 					slog.Debug(fmt.Sprintf("Client %s is already registered, skipping...", clientToRegister.Name))
-					return
+					return nil
 				}
 			}
 
 			c.Clients.RegisteredClients = append(c.Clients.RegisteredClients, string(clientToRegister.Name))
+			return nil
 		})
 		if err != nil {
 			return fmt.Errorf("failed to update configuration for client %s: %w", clientToRegister.Name, err)
@@ -411,15 +412,16 @@ func removeClientGlobally(
 	}
 
 	// Remove client from global registered clients list
-	err = config.UpdateConfig(func(c *config.Config) {
+	err = config.UpdateConfig(func(c *config.Config) error {
 		for i, registeredClient := range c.Clients.RegisteredClients {
 			if registeredClient == string(clientToRemove.Name) {
 				// Remove client from slice
 				c.Clients.RegisteredClients = append(c.Clients.RegisteredClients[:i], c.Clients.RegisteredClients[i+1:]...)
 				slog.Debug(fmt.Sprintf("Successfully unregistered client: %s", clientToRemove.Name))
-				return
+				return nil
 			}
 		}
+		return nil
 	})
 	if err != nil {
 		return fmt.Errorf("failed to update configuration for client %s: %w", clientToRemove.Name, err)

--- a/cmd/thv/app/common.go
+++ b/cmd/thv/app/common.go
@@ -78,9 +78,10 @@ func SetSecretsProvider(ctx context.Context, provider secrets.ProviderType) erro
 	}
 
 	// Update the secrets provider type and mark setup as completed
-	err := config.UpdateConfig(func(c *config.Config) {
+	err := config.UpdateConfig(func(c *config.Config) error {
 		c.Secrets.ProviderType = string(provider)
 		c.Secrets.SetupCompleted = true
+		return nil
 	})
 	if err != nil {
 		return fmt.Errorf("failed to update configuration: %w", err)

--- a/cmd/thv/app/config.go
+++ b/cmd/thv/app/config.go
@@ -344,8 +344,9 @@ func usageMetricsCmdFunc(_ *cobra.Command, args []string) error {
 		return fmt.Errorf("invalid argument: %s (expected 'enable' or 'disable')", action)
 	}
 
-	err := config.UpdateConfig(func(c *config.Config) {
+	err := config.UpdateConfig(func(c *config.Config) error {
 		c.DisableUsageMetrics = disable
+		return nil
 	})
 	if err != nil {
 		return fmt.Errorf("failed to update configuration: %w", err)

--- a/cmd/thv/app/otel.go
+++ b/cmd/thv/app/otel.go
@@ -235,8 +235,9 @@ func setOtelEndpointCmdFunc(_ *cobra.Command, args []string) error {
 	}
 
 	// Update the configuration
-	err := config.UpdateConfig(func(c *config.Config) {
+	err := config.UpdateConfig(func(c *config.Config) error {
 		c.OTEL.Endpoint = endpoint
+		return nil
 	})
 	if err != nil {
 		return fmt.Errorf("failed to update configuration: %w", err)
@@ -269,8 +270,9 @@ func unsetOtelEndpointCmdFunc(_ *cobra.Command, _ []string) error {
 	}
 
 	// Update the configuration
-	err := config.UpdateConfig(func(c *config.Config) {
+	err := config.UpdateConfig(func(c *config.Config) error {
 		c.OTEL.Endpoint = ""
+		return nil
 	})
 	if err != nil {
 		return fmt.Errorf("failed to update configuration: %w", err)
@@ -292,8 +294,9 @@ func setOtelSamplingRateCmdFunc(_ *cobra.Command, args []string) error {
 	}
 
 	// Update the configuration
-	err = config.UpdateConfig(func(c *config.Config) {
+	err = config.UpdateConfig(func(c *config.Config) error {
 		c.OTEL.SamplingRate = rate
+		return nil
 	})
 	if err != nil {
 		return fmt.Errorf("failed to update configuration: %w", err)
@@ -326,8 +329,9 @@ func unsetOtelSamplingRateCmdFunc(_ *cobra.Command, _ []string) error {
 	}
 
 	// Update the configuration
-	err := config.UpdateConfig(func(c *config.Config) {
+	err := config.UpdateConfig(func(c *config.Config) error {
 		c.OTEL.SamplingRate = 0.0
+		return nil
 	})
 	if err != nil {
 		return fmt.Errorf("failed to update configuration: %w", err)
@@ -346,8 +350,9 @@ func setOtelEnvVarsCmdFunc(_ *cobra.Command, args []string) error {
 	}
 
 	// Update the configuration
-	err := config.UpdateConfig(func(c *config.Config) {
+	err := config.UpdateConfig(func(c *config.Config) error {
 		c.OTEL.EnvVars = vars
+		return nil
 	})
 	if err != nil {
 		return fmt.Errorf("failed to update configuration: %w", err)
@@ -380,8 +385,9 @@ func unsetOtelEnvVarsCmdFunc(_ *cobra.Command, _ []string) error {
 	}
 
 	// Update the configuration
-	err := config.UpdateConfig(func(c *config.Config) {
+	err := config.UpdateConfig(func(c *config.Config) error {
 		c.OTEL.EnvVars = []string{}
+		return nil
 	})
 	if err != nil {
 		return fmt.Errorf("failed to update configuration: %w", err)
@@ -398,8 +404,9 @@ func setOtelMetricsEnabledCmdFunc(_ *cobra.Command, args []string) error {
 	}
 
 	// Update the configuration
-	err = config.UpdateConfig(func(c *config.Config) {
+	err = config.UpdateConfig(func(c *config.Config) error {
 		c.OTEL.MetricsEnabled = &enabled
+		return nil
 	})
 	if err != nil {
 		return fmt.Errorf("failed to update configuration: %w", err)
@@ -428,8 +435,9 @@ func unsetOtelMetricsEnabledCmdFunc(_ *cobra.Command, _ []string) error {
 	}
 
 	// Update the configuration
-	err := config.UpdateConfig(func(c *config.Config) {
+	err := config.UpdateConfig(func(c *config.Config) error {
 		c.OTEL.MetricsEnabled = nil
+		return nil
 	})
 	if err != nil {
 		return fmt.Errorf("failed to update configuration: %w", err)
@@ -446,8 +454,9 @@ func setOtelTracingEnabledCmdFunc(_ *cobra.Command, args []string) error {
 	}
 
 	// Update the configuration
-	err = config.UpdateConfig(func(c *config.Config) {
+	err = config.UpdateConfig(func(c *config.Config) error {
 		c.OTEL.TracingEnabled = &enabled
+		return nil
 	})
 	if err != nil {
 		return fmt.Errorf("failed to update configuration: %w", err)
@@ -476,8 +485,9 @@ func unsetOtelTracingEnabledCmdFunc(_ *cobra.Command, _ []string) error {
 	}
 
 	// Update the configuration
-	err := config.UpdateConfig(func(c *config.Config) {
+	err := config.UpdateConfig(func(c *config.Config) error {
 		c.OTEL.TracingEnabled = nil
+		return nil
 	})
 	if err != nil {
 		return fmt.Errorf("failed to update configuration: %w", err)
@@ -494,8 +504,9 @@ func setOtelInsecureCmdFunc(_ *cobra.Command, args []string) error {
 	}
 
 	// Update the configuration
-	err = config.UpdateConfig(func(c *config.Config) {
+	err = config.UpdateConfig(func(c *config.Config) error {
 		c.OTEL.Insecure = enabled
+		return nil
 	})
 	if err != nil {
 		return fmt.Errorf("failed to update configuration: %w", err)
@@ -523,8 +534,9 @@ func unsetOtelInsecureCmdFunc(_ *cobra.Command, _ []string) error {
 	}
 
 	// Update the configuration
-	err := config.UpdateConfig(func(c *config.Config) {
+	err := config.UpdateConfig(func(c *config.Config) error {
 		c.OTEL.Insecure = false
+		return nil
 	})
 	if err != nil {
 		return fmt.Errorf("failed to update configuration: %w", err)
@@ -541,8 +553,9 @@ func setOtelEnablePrometheusMetricsPathCmdFunc(_ *cobra.Command, args []string) 
 	}
 
 	// Update the configuration
-	err = config.UpdateConfig(func(c *config.Config) {
+	err = config.UpdateConfig(func(c *config.Config) error {
 		c.OTEL.EnablePrometheusMetricsPath = enabled
+		return nil
 	})
 	if err != nil {
 		return fmt.Errorf("failed to update configuration: %w", err)
@@ -570,8 +583,9 @@ func unsetOtelEnablePrometheusMetricsPathCmdFunc(_ *cobra.Command, _ []string) e
 	}
 
 	// Update the configuration
-	err := config.UpdateConfig(func(c *config.Config) {
+	err := config.UpdateConfig(func(c *config.Config) error {
 		c.OTEL.EnablePrometheusMetricsPath = false
+		return nil
 	})
 	if err != nil {
 		return fmt.Errorf("failed to update configuration: %w", err)

--- a/cmd/thv/app/run_flags_test.go
+++ b/cmd/thv/app/run_flags_test.go
@@ -43,7 +43,7 @@ func createTestConfigProvider(t *testing.T, cfg *config.Config) (config.Provider
 
 	// Write the config file if one is provided
 	if cfg != nil {
-		err = provider.UpdateConfig(func(c *config.Config) { *c = *cfg })
+		err = provider.UpdateConfig(func(c *config.Config) error { *c = *cfg; return nil })
 		require.NoError(t, err)
 	}
 

--- a/pkg/api/v1/clients.go
+++ b/pkg/api/v1/clients.go
@@ -351,15 +351,16 @@ func (c *ClientRoutes) performClientRegistration(ctx context.Context, clients []
 	} else {
 		// We should never reach this point once groups are enabled
 		for _, clientToRegister := range clients {
-			err := config.UpdateConfig(func(c *config.Config) {
+			err := config.UpdateConfig(func(c *config.Config) error {
 				for _, registeredClient := range c.Clients.RegisteredClients {
 					if registeredClient == string(clientToRegister.Name) {
 						slog.Debug("client already registered, skipping", "client", clientToRegister.Name)
-						return
+						return nil
 					}
 				}
 
 				c.Clients.RegisteredClients = append(c.Clients.RegisteredClients, string(clientToRegister.Name))
+				return nil
 			})
 			if err != nil {
 				return fmt.Errorf("failed to update configuration for client %s: %w", clientToRegister.Name, err)
@@ -459,15 +460,16 @@ func (c *ClientRoutes) removeClientGlobally(
 
 	// Remove clients from global registered clients list
 	for _, clientToRemove := range clients {
-		err := config.UpdateConfig(func(c *config.Config) {
+		err := config.UpdateConfig(func(c *config.Config) error {
 			for i, registeredClient := range c.Clients.RegisteredClients {
 				if registeredClient == string(clientToRemove.Name) {
 					// Remove client from slice
 					c.Clients.RegisteredClients = append(c.Clients.RegisteredClients[:i], c.Clients.RegisteredClients[i+1:]...)
 					slog.Debug("successfully unregistered client", "client", clientToRemove.Name)
-					return
+					return nil
 				}
 			}
+			return nil
 		})
 		if err != nil {
 			return fmt.Errorf("failed to update configuration for client %s: %w", clientToRemove.Name, err)

--- a/pkg/api/v1/registry_test.go
+++ b/pkg/api/v1/registry_test.go
@@ -41,7 +41,7 @@ func CreateTestConfigProvider(t *testing.T, cfg *config.Config) (config.Provider
 
 	// Write the config file if one is provided
 	if cfg != nil {
-		err = provider.UpdateConfig(func(c *config.Config) { *c = *cfg })
+		err = provider.UpdateConfig(func(c *config.Config) error { *c = *cfg; return nil })
 		require.NoError(t, err)
 	}
 

--- a/pkg/api/v1/secrets.go
+++ b/pkg/api/v1/secrets.go
@@ -182,9 +182,10 @@ func (s *SecretsRoutes) setupSecretsProvider(w http.ResponseWriter, r *http.Requ
 	}
 
 	// Update the secrets provider type and mark setup as completed
-	err := s.configProvider.UpdateConfig(func(c *config.Config) {
+	err := s.configProvider.UpdateConfig(func(c *config.Config) error {
 		c.Secrets.ProviderType = string(providerType)
 		c.Secrets.SetupCompleted = true
+		return nil
 	})
 	if err != nil {
 		return fmt.Errorf("failed to update configuration: %w", err)

--- a/pkg/client/config_test.go
+++ b/pkg/client/config_test.go
@@ -249,7 +249,7 @@ func CreateTestConfigProvider(t *testing.T, cfg *config.Config) (config.Provider
 
 	// Write the config file if one is provided
 	if cfg != nil {
-		err = provider.UpdateConfig(func(c *config.Config) { *c = *cfg })
+		err = provider.UpdateConfig(func(c *config.Config) error { *c = *cfg; return nil })
 		require.NoError(t, err)
 	}
 

--- a/pkg/client/discovery_test.go
+++ b/pkg/client/discovery_test.go
@@ -66,7 +66,7 @@ func createTestConfigProvider(t *testing.T, cfg *config.Config) (config.Provider
 
 	// Write the config file if one is provided
 	if cfg != nil {
-		err = provider.UpdateConfig(func(c *config.Config) { *c = *cfg })
+		err = provider.UpdateConfig(func(c *config.Config) error { *c = *cfg; return nil })
 		require.NoError(t, err)
 	}
 

--- a/pkg/config/buildauthfile.go
+++ b/pkg/config/buildauthfile.go
@@ -43,12 +43,13 @@ func markBuildAuthFileConfigured(p Provider, name string) error {
 		return err
 	}
 
-	return p.UpdateConfig(func(c *Config) {
+	return p.UpdateConfig(func(c *Config) error {
 		if c.BuildAuthFiles == nil {
 			c.BuildAuthFiles = make(map[string]string)
 		}
 		// Store only a marker - actual content is in secrets
 		c.BuildAuthFiles[name] = "secret:" + BuildAuthFileSecretName(name)
+		return nil
 	})
 }
 
@@ -81,10 +82,11 @@ func getConfiguredBuildAuthFiles(p Provider) []string {
 // Note: This only removes the config marker. The caller should also delete
 // the corresponding secret from the secrets provider.
 func unsetBuildAuthFile(p Provider, name string) error {
-	return p.UpdateConfig(func(c *Config) {
+	return p.UpdateConfig(func(c *Config) error {
 		if c.BuildAuthFiles != nil {
 			delete(c.BuildAuthFiles, name)
 		}
+		return nil
 	})
 }
 
@@ -92,7 +94,8 @@ func unsetBuildAuthFile(p Provider, name string) error {
 // Note: This only removes the config markers. The caller should also delete
 // the corresponding secrets from the secrets provider.
 func unsetAllBuildAuthFiles(p Provider) error {
-	return p.UpdateConfig(func(c *Config) {
+	return p.UpdateConfig(func(c *Config) error {
 		c.BuildAuthFiles = nil
+		return nil
 	})
 }

--- a/pkg/config/buildenv.go
+++ b/pkg/config/buildenv.go
@@ -125,11 +125,12 @@ func setBuildEnv(p Provider, key, value string) error {
 		return err
 	}
 
-	return p.UpdateConfig(func(c *Config) {
+	return p.UpdateConfig(func(c *Config) error {
 		if c.BuildEnv == nil {
 			c.BuildEnv = make(map[string]string)
 		}
 		c.BuildEnv[key] = value
+		return nil
 	})
 }
 
@@ -159,17 +160,19 @@ func getAllBuildEnv(p Provider) map[string]string {
 
 // unsetBuildEnv is a helper function that removes a specific build environment variable.
 func unsetBuildEnv(p Provider, key string) error {
-	return p.UpdateConfig(func(c *Config) {
+	return p.UpdateConfig(func(c *Config) error {
 		if c.BuildEnv != nil {
 			delete(c.BuildEnv, key)
 		}
+		return nil
 	})
 }
 
 // unsetAllBuildEnv is a helper function that removes all build environment variables.
 func unsetAllBuildEnv(p Provider) error {
-	return p.UpdateConfig(func(c *Config) {
+	return p.UpdateConfig(func(c *Config) error {
 		c.BuildEnv = nil
+		return nil
 	})
 }
 
@@ -185,11 +188,12 @@ func setBuildEnvFromSecret(p Provider, key, secretName string) error {
 		return err
 	}
 
-	return p.UpdateConfig(func(c *Config) {
+	return p.UpdateConfig(func(c *Config) error {
 		if c.BuildEnvFromSecrets == nil {
 			c.BuildEnvFromSecrets = make(map[string]string)
 		}
 		c.BuildEnvFromSecrets[key] = secretName
+		return nil
 	})
 }
 
@@ -218,10 +222,11 @@ func getAllBuildEnvFromSecrets(p Provider) map[string]string {
 
 // unsetBuildEnvFromSecret removes a secret reference.
 func unsetBuildEnvFromSecret(p Provider, key string) error {
-	return p.UpdateConfig(func(c *Config) {
+	return p.UpdateConfig(func(c *Config) error {
 		if c.BuildEnvFromSecrets != nil {
 			delete(c.BuildEnvFromSecrets, key)
 		}
+		return nil
 	})
 }
 
@@ -242,8 +247,9 @@ func setBuildEnvFromShell(p Provider, key string) error {
 		return err
 	}
 
-	return p.UpdateConfig(func(c *Config) {
+	return p.UpdateConfig(func(c *Config) error {
 		c.BuildEnvFromShell = append(c.BuildEnvFromShell, key)
+		return nil
 	})
 }
 
@@ -292,9 +298,9 @@ func getAllBuildEnvFromShell(p Provider) []string {
 
 // unsetBuildEnvFromShell removes a key from shell environment list.
 func unsetBuildEnvFromShell(p Provider, key string) error {
-	return p.UpdateConfig(func(c *Config) {
+	return p.UpdateConfig(func(c *Config) error {
 		if c.BuildEnvFromShell == nil {
-			return
+			return nil
 		}
 		newList := make([]string, 0, len(c.BuildEnvFromShell))
 		for _, k := range c.BuildEnvFromShell {
@@ -303,5 +309,6 @@ func unsetBuildEnvFromShell(p Provider, key string) error {
 			}
 		}
 		c.BuildEnvFromShell = newList
+		return nil
 	})
 }

--- a/pkg/config/cacert.go
+++ b/pkg/config/cacert.go
@@ -37,8 +37,9 @@ func setCACert(provider Provider, certPath string) error {
 	}
 
 	// Update the configuration
-	err = provider.UpdateConfig(func(c *Config) {
+	err = provider.UpdateConfig(func(c *Config) error {
 		c.CACertificatePath = cleanPath
+		return nil
 	})
 	if err != nil {
 		return fmt.Errorf("failed to update configuration: %w", err)
@@ -86,8 +87,9 @@ func unsetCACert(provider Provider) error {
 	}
 
 	// Update the configuration
-	err := provider.UpdateConfig(func(c *Config) {
+	err := provider.UpdateConfig(func(c *Config) error {
 		c.CACertificatePath = ""
+		return nil
 	})
 	if err != nil {
 		return fmt.Errorf("failed to update configuration: %w", err)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -335,7 +335,7 @@ func (c *Config) saveToPath(configPath string) error {
 
 // UpdateConfig locks a separate lock file, reads from disk, applies the changes
 // from the anonymous function, writes to disk and unlocks the file.
-func UpdateConfig(updateFn func(*Config)) error {
+func UpdateConfig(updateFn func(*Config) error) error {
 	provider := NewProvider()
 	return provider.UpdateConfig(updateFn)
 }
@@ -343,7 +343,7 @@ func UpdateConfig(updateFn func(*Config)) error {
 // UpdateConfigAtPath locks a separate lock file, reads from disk, applies the changes
 // from the anonymous function, writes to disk and unlocks the file.
 // If configPath is empty, it uses the default path.
-func UpdateConfigAtPath(configPath string, updateFn func(*Config)) error {
+func UpdateConfigAtPath(configPath string, updateFn func(*Config) error) error {
 	if configPath == "" {
 		var err error
 		configPath, err = getConfigPath()
@@ -375,7 +375,9 @@ func UpdateConfigAtPath(configPath string, updateFn func(*Config)) error {
 	}
 
 	// Apply changes to the config file.
-	updateFn(c)
+	if err := updateFn(c); err != nil {
+		return fmt.Errorf("update function failed: %w", err)
+	}
 
 	// Write the updated config to disk.
 	err = c.saveToPath(configPath)
@@ -430,10 +432,11 @@ func setRuntimeConfig(provider Provider, transportType string, runtimeConfig *te
 		}
 	}
 
-	return provider.UpdateConfig(func(c *Config) {
+	return provider.UpdateConfig(func(c *Config) error {
 		if c.RuntimeConfigs == nil {
 			c.RuntimeConfigs = make(map[string]*templates.RuntimeConfig)
 		}
 		c.RuntimeConfigs[transportType] = runtimeConfig
+		return nil
 	})
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -160,8 +160,9 @@ func TestRegistryURLConfig(t *testing.T) {
 
 		// Test setting a registry URL
 		testURL := "https://example.com/registry.json"
-		err := UpdateConfigAtPath(configPath, func(c *Config) {
+		err := UpdateConfigAtPath(configPath, func(c *Config) error {
 			c.RegistryUrl = testURL
+			return nil
 		})
 		require.NoError(t, err)
 
@@ -171,8 +172,9 @@ func TestRegistryURLConfig(t *testing.T) {
 		assert.Equal(t, testURL, config.RegistryUrl)
 
 		// Test unsetting the registry URL
-		err = UpdateConfigAtPath(configPath, func(c *Config) {
+		err = UpdateConfigAtPath(configPath, func(c *Config) error {
 			c.RegistryUrl = ""
+			return nil
 		})
 		require.NoError(t, err)
 
@@ -195,8 +197,9 @@ func TestRegistryURLConfig(t *testing.T) {
 		testURL := "https://custom-registry.example.com/registry.json"
 
 		// Set the registry URL
-		err := UpdateConfigAtPath(configPath, func(c *Config) {
+		err := UpdateConfigAtPath(configPath, func(c *Config) error {
 			c.RegistryUrl = testURL
+			return nil
 		})
 		require.NoError(t, err)
 
@@ -226,8 +229,9 @@ func TestRegistryURLConfig(t *testing.T) {
 		})
 
 		// Test enabling
-		err := UpdateConfigAtPath(configPath, func(c *Config) {
+		err := UpdateConfigAtPath(configPath, func(c *Config) error {
 			c.AllowPrivateRegistryIp = true
+			return nil
 		})
 		require.NoError(t, err)
 
@@ -237,8 +241,9 @@ func TestRegistryURLConfig(t *testing.T) {
 		assert.Equal(t, true, config.AllowPrivateRegistryIp)
 
 		// Test toggling setting to false
-		err = UpdateConfigAtPath(configPath, func(c *Config) {
+		err = UpdateConfigAtPath(configPath, func(c *Config) error {
 			c.AllowPrivateRegistryIp = false
+			return nil
 		})
 		require.NoError(t, err)
 

--- a/pkg/config/interface.go
+++ b/pkg/config/interface.go
@@ -13,7 +13,7 @@ import (
 //go:generate mockgen -destination=mocks/mock_provider.go -package=mocks -source=interface.go Provider
 type Provider interface {
 	GetConfig() *Config
-	UpdateConfig(updateFn func(*Config)) error
+	UpdateConfig(updateFn func(*Config) error) error
 	LoadOrCreateConfig() (*Config, error)
 
 	// Registry operations
@@ -73,7 +73,7 @@ func (*DefaultProvider) GetConfig() *Config {
 }
 
 // UpdateConfig updates the config using the default path
-func (*DefaultProvider) UpdateConfig(updateFn func(*Config)) error {
+func (*DefaultProvider) UpdateConfig(updateFn func(*Config) error) error {
 	return UpdateConfigAtPath("", updateFn)
 }
 
@@ -244,7 +244,7 @@ func (p *PathProvider) GetConfig() *Config {
 }
 
 // UpdateConfig updates the config at the specific path
-func (p *PathProvider) UpdateConfig(updateFn func(*Config)) error {
+func (p *PathProvider) UpdateConfig(updateFn func(*Config) error) error {
 	return UpdateConfigAtPath(p.configPath, updateFn)
 }
 
@@ -409,7 +409,7 @@ func (*KubernetesProvider) GetConfig() *Config {
 }
 
 // UpdateConfig is a no-op for Kubernetes environments
-func (*KubernetesProvider) UpdateConfig(_ func(*Config)) error {
+func (*KubernetesProvider) UpdateConfig(_ func(*Config) error) error {
 	return nil
 }
 

--- a/pkg/config/interface_test.go
+++ b/pkg/config/interface_test.go
@@ -79,8 +79,9 @@ func TestDefaultProvider(t *testing.T) {
 		require.NoError(t, err)
 
 		// Update config
-		err = pathProvider.UpdateConfig(func(c *Config) {
+		err = pathProvider.UpdateConfig(func(c *Config) error {
 			c.RegistryUrl = "https://example.com"
+			return nil
 		})
 		assert.NoError(t, err)
 
@@ -165,8 +166,9 @@ func TestPathProvider(t *testing.T) {
 		require.NoError(t, err)
 
 		// Update config
-		err = provider.UpdateConfig(func(c *Config) {
+		err = provider.UpdateConfig(func(c *Config) error {
 			c.RegistryUrl = "https://updated.com"
+			return nil
 		})
 		assert.NoError(t, err)
 
@@ -203,8 +205,9 @@ func TestKubernetesProvider(t *testing.T) {
 
 	t.Run("UpdateConfig", func(t *testing.T) {
 		t.Parallel()
-		err := provider.UpdateConfig(func(c *Config) {
+		err := provider.UpdateConfig(func(c *Config) error {
 			c.RegistryUrl = "https://example.com"
+			return nil
 		})
 		assert.NoError(t, err) // Should be no-op
 	})

--- a/pkg/config/mocks/mock_provider.go
+++ b/pkg/config/mocks/mock_provider.go
@@ -471,7 +471,7 @@ func (mr *MockProviderMockRecorder) UnsetRegistry() *gomock.Call {
 }
 
 // UpdateConfig mocks base method.
-func (m *MockProvider) UpdateConfig(updateFn func(*config.Config)) error {
+func (m *MockProvider) UpdateConfig(updateFn func(*config.Config) error) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateConfig", updateFn)
 	ret0, _ := ret[0].(error)

--- a/pkg/config/registry.go
+++ b/pkg/config/registry.go
@@ -274,11 +274,12 @@ func setRegistryURL(provider Provider, registryURL string, allowPrivateRegistryI
 	}
 
 	// Update the configuration
-	err = provider.UpdateConfig(func(c *Config) {
+	err = provider.UpdateConfig(func(c *Config) error {
 		c.RegistryUrl = registryURL
 		c.RegistryApiUrl = ""    // Clear API URL when setting static URL
 		c.LocalRegistryPath = "" // Clear local path when setting URL
 		c.AllowPrivateRegistryIp = allowPrivateRegistryIp
+		return nil
 	})
 	if err != nil {
 		return fmt.Errorf("failed to update configuration: %w", err)
@@ -320,10 +321,11 @@ func setRegistryFile(provider Provider, registryPath string) error {
 	}
 
 	// Update the configuration
-	err = provider.UpdateConfig(func(c *Config) {
+	err = provider.UpdateConfig(func(c *Config) error {
 		c.LocalRegistryPath = absPath
 		c.RegistryUrl = ""    // Clear URL when setting local path
 		c.RegistryApiUrl = "" // Clear API URL when setting local path
+		return nil
 	})
 	if err != nil {
 		return fmt.Errorf("failed to update configuration: %w", err)
@@ -442,11 +444,12 @@ func setRegistryAPI(provider Provider, apiURL string, allowPrivateRegistryIp boo
 	}
 
 	// Update the configuration
-	err = provider.UpdateConfig(func(c *Config) {
+	err = provider.UpdateConfig(func(c *Config) error {
 		c.RegistryApiUrl = apiURL
 		c.RegistryUrl = ""       // Clear static registry URL when setting API URL
 		c.LocalRegistryPath = "" // Clear local path when setting API URL
 		c.AllowPrivateRegistryIp = allowPrivateRegistryIp
+		return nil
 	})
 	if err != nil {
 		return fmt.Errorf("failed to update configuration: %w", err)
@@ -457,11 +460,12 @@ func setRegistryAPI(provider Provider, apiURL string, allowPrivateRegistryIp boo
 
 // unsetRegistry resets registry configuration to defaults using the provided provider
 func unsetRegistry(provider Provider) error {
-	err := provider.UpdateConfig(func(c *Config) {
+	err := provider.UpdateConfig(func(c *Config) error {
 		c.RegistryUrl = ""
 		c.RegistryApiUrl = ""
 		c.LocalRegistryPath = ""
 		c.AllowPrivateRegistryIp = false
+		return nil
 	})
 	if err != nil {
 		return fmt.Errorf("failed to update configuration: %w", err)

--- a/pkg/migration/middleware_telemetry.go
+++ b/pkg/migration/middleware_telemetry.go
@@ -32,8 +32,9 @@ func CheckAndPerformMiddlewareTelemetryMigration() {
 		}
 
 		// Mark migration as completed
-		if err := config.UpdateConfig(func(c *config.Config) {
+		if err := config.UpdateConfig(func(c *config.Config) error {
 			c.MiddlewareTelemetryMigration = true
+			return nil
 		}); err != nil {
 			slog.Error("failed to update config after middleware telemetry migration", "error", err)
 		}

--- a/pkg/migration/secret_scope.go
+++ b/pkg/migration/secret_scope.go
@@ -58,8 +58,9 @@ func CheckAndPerformSecretScopeMigration() {
 			}
 		}
 
-		if err := config.UpdateConfig(func(c *config.Config) {
+		if err := config.UpdateConfig(func(c *config.Config) error {
 			c.SecretScopeMigration = true
+			return nil
 		}); err != nil {
 			slog.Error("failed to update config after secret scope migration", "error", err)
 		}

--- a/pkg/migration/telemetry_config.go
+++ b/pkg/migration/telemetry_config.go
@@ -37,8 +37,9 @@ func CheckAndPerformTelemetryConfigMigration() {
 		}
 
 		// Mark migration as completed
-		if err := config.UpdateConfig(func(c *config.Config) {
+		if err := config.UpdateConfig(func(c *config.Config) error {
 			c.TelemetryConfigMigration = true
+			return nil
 		}); err != nil {
 			slog.Error("failed to update config after telemetry config migration", "error", err)
 		}

--- a/pkg/registry/auth/login.go
+++ b/pkg/registry/auth/login.go
@@ -129,11 +129,12 @@ func Logout(ctx context.Context, configProvider config.Provider, secretsProvider
 		slog.Debug("failed to clear registry cache", "error", err)
 	}
 
-	return configProvider.UpdateConfig(func(c *config.Config) {
+	return configProvider.UpdateConfig(func(c *config.Config) error {
 		if c.RegistryAuth.OAuth != nil {
 			c.RegistryAuth.OAuth.CachedRefreshTokenRef = ""
 			c.RegistryAuth.OAuth.CachedTokenExpiry = time.Time{}
 		}
+		return nil
 	})
 }
 
@@ -199,8 +200,9 @@ func ensureRegistryURL(configProvider config.Provider, opts LoginOptions) error 
 
 	// Always clear auth when a registry URL is explicitly provided, so that
 	// tokens are never sent to the wrong server.
-	if err := configProvider.UpdateConfig(func(c *config.Config) {
+	if err := configProvider.UpdateConfig(func(c *config.Config) error {
 		c.RegistryAuth = config.RegistryAuth{}
+		return nil
 	}); err != nil {
 		return fmt.Errorf("clearing stale auth config: %w", err)
 	}
@@ -262,7 +264,7 @@ func registryURLFromConfig(cfg *config.Config) string {
 // implementation used by both Login and AuthManager.SetOAuthAuth.
 func ConfigureOAuth(
 	ctx context.Context, issuer, clientID, audience string, scopes []string,
-) (func(*config.Config), error) {
+) (func(*config.Config) error, error) {
 	if err := validateIssuerURL(issuer); err != nil {
 		return nil, err
 	}
@@ -281,7 +283,8 @@ func ConfigureOAuth(
 		return DefaultOAuthScopes()
 	}()
 
-	return func(c *config.Config) {
+	//nolint:unparam // error return is part of the UpdateConfig callback contract; this closure always succeeds
+	return func(c *config.Config) error {
 		c.RegistryAuth = config.RegistryAuth{
 			Type: config.RegistryAuthTypeOAuth,
 			OAuth: &config.RegistryOAuthConfig{
@@ -292,6 +295,7 @@ func ConfigureOAuth(
 				CallbackPort: remote.DefaultCallbackPort,
 			},
 		}
+		return nil
 	}, nil
 }
 

--- a/pkg/registry/auth/login_test.go
+++ b/pkg/registry/auth/login_test.go
@@ -453,9 +453,9 @@ func TestEnsureOAuthConfig(t *testing.T) {
 			cfg:     &config.Config{},
 			useOIDC: true,
 			setupMock: func(m *configmocks.MockProvider) {
-				m.EXPECT().UpdateConfig(gomock.Any()).DoAndReturn(func(fn func(*config.Config)) error {
+				m.EXPECT().UpdateConfig(gomock.Any()).DoAndReturn(func(fn func(*config.Config) error) error {
 					c := &config.Config{}
-					fn(c)
+					require.NoError(t, fn(c))
 					// Verify the update function sets expected values.
 					require.Equal(t, config.RegistryAuthTypeOAuth, c.RegistryAuth.Type)
 					require.NotNil(t, c.RegistryAuth.OAuth)
@@ -473,9 +473,9 @@ func TestEnsureOAuthConfig(t *testing.T) {
 			useOIDC:        true,
 			overrideScopes: []string{"openid", "email"},
 			setupMock: func(m *configmocks.MockProvider) {
-				m.EXPECT().UpdateConfig(gomock.Any()).DoAndReturn(func(fn func(*config.Config)) error {
+				m.EXPECT().UpdateConfig(gomock.Any()).DoAndReturn(func(fn func(*config.Config) error) error {
 					c := &config.Config{}
-					fn(c)
+					require.NoError(t, fn(c))
 					require.Equal(t, []string{"openid", "email"}, c.RegistryAuth.OAuth.Scopes)
 					return nil
 				})
@@ -488,9 +488,9 @@ func TestEnsureOAuthConfig(t *testing.T) {
 			useOIDC:          true,
 			overrideAudience: "api://my-api",
 			setupMock: func(m *configmocks.MockProvider) {
-				m.EXPECT().UpdateConfig(gomock.Any()).DoAndReturn(func(fn func(*config.Config)) error {
+				m.EXPECT().UpdateConfig(gomock.Any()).DoAndReturn(func(fn func(*config.Config) error) error {
 					c := &config.Config{}
-					fn(c)
+					require.NoError(t, fn(c))
 					require.Equal(t, "api://my-api", c.RegistryAuth.OAuth.Audience)
 					return nil
 				})
@@ -653,8 +653,8 @@ func TestLogout_DeletesCachedToken(t *testing.T) {
 	derivedKey := DeriveSecretKey(cfg.RegistryApiUrl, cfg.RegistryAuth.OAuth.Issuer)
 	mockSecrets.EXPECT().DeleteSecret(gomock.Any(), derivedKey).Return(nil)
 
-	mockCfg.EXPECT().UpdateConfig(gomock.Any()).DoAndReturn(func(fn func(*config.Config)) error {
-		fn(cfg)
+	mockCfg.EXPECT().UpdateConfig(gomock.Any()).DoAndReturn(func(fn func(*config.Config) error) error {
+		require.NoError(t, fn(cfg))
 		require.Empty(t, cfg.RegistryAuth.OAuth.CachedRefreshTokenRef)
 		require.True(t, cfg.RegistryAuth.OAuth.CachedTokenExpiry.IsZero())
 		return nil

--- a/pkg/registry/auth/oauth_token_source.go
+++ b/pkg/registry/auth/oauth_token_source.go
@@ -212,11 +212,12 @@ func (o *oauthTokenSource) createTokenPersister(refreshTokenKey string) remote.T
 
 // updateConfigTokenRef updates the config with the refresh token reference and expiry.
 func (*oauthTokenSource) updateConfigTokenRef(refreshTokenKey string, expiry time.Time) {
-	if err := config.UpdateConfig(func(cfg *config.Config) {
+	if err := config.UpdateConfig(func(cfg *config.Config) error {
 		if cfg.RegistryAuth.OAuth != nil {
 			cfg.RegistryAuth.OAuth.CachedRefreshTokenRef = refreshTokenKey
 			cfg.RegistryAuth.OAuth.CachedTokenExpiry = expiry
 		}
+		return nil
 	}); err != nil {
 		slog.Warn("Failed to update config with token reference", "error", err)
 	}

--- a/pkg/registry/auth_manager.go
+++ b/pkg/registry/auth_manager.go
@@ -76,8 +76,9 @@ func (c *DefaultAuthManager) SetOAuthAuth(ctx context.Context, issuer, clientID,
 
 // UnsetAuth removes registry authentication configuration.
 func (c *DefaultAuthManager) UnsetAuth() error {
-	return c.provider.UpdateConfig(func(cfg *config.Config) {
+	return c.provider.UpdateConfig(func(cfg *config.Config) error {
 		cfg.RegistryAuth = config.RegistryAuth{}
+		return nil
 	})
 }
 

--- a/pkg/registry/auth_manager_test.go
+++ b/pkg/registry/auth_manager_test.go
@@ -43,7 +43,7 @@ func TestDefaultAuthManager_UnsetAuth(t *testing.T) {
 			// Capture the update function and verify it zeroes RegistryAuth.
 			mockProvider.EXPECT().
 				UpdateConfig(gomock.Any()).
-				DoAndReturn(func(fn func(*config.Config)) error {
+				DoAndReturn(func(fn func(*config.Config) error) error {
 					if tt.updateErr != nil {
 						return tt.updateErr
 					}
@@ -56,7 +56,7 @@ func TestDefaultAuthManager_UnsetAuth(t *testing.T) {
 							},
 						},
 					}
-					fn(cfg)
+					require.NoError(t, fn(cfg))
 					// After the update function runs, RegistryAuth must be zero.
 					require.Equal(t, config.RegistryAuth{}, cfg.RegistryAuth)
 					return nil

--- a/test/e2e/client_test.go
+++ b/test/e2e/client_test.go
@@ -85,8 +85,9 @@ var _ = Describe("Client Management", Label("core", "client", "e2e"), func() {
 		BeforeEach(func() {
 			// Pre-populate temporary config with multiple registered clients in non-alphabetical order
 			testClients := []string{"vscode", "cursor", "roo-code", "cline", "claude-code"}
-			err := config.UpdateConfigAtPath(tempConfigPath, func(c *config.Config) {
+			err := config.UpdateConfigAtPath(tempConfigPath, func(c *config.Config) error {
 				c.Clients.RegisteredClients = testClients
+				return nil
 			})
 			Expect(err).ToNot(HaveOccurred())
 		})


### PR DESCRIPTION
Change the `UpdateConfig` callback signature from `func(*Config)` to `func(*Config) error` so that future callers can propagate validation or transformation errors from inside the closure instead of relying on side-channel error handling.

All existing closures return nil. `UpdateConfigAtPath` now short-circuits before writing to disk when the callback returns an error.