### PR TITLE
Add color annotations to agent definitions

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -3,6 +3,7 @@ name: code-reviewer
 description: Reviews code for ToolHive best practices, security patterns, Go conventions, and architectural consistency
 tools: [Read, Glob, Grep]
 model: inherit
+color: yellow
 ---
 
 # Code Reviewer Agent

--- a/.claude/agents/golang-code-writer.md
+++ b/.claude/agents/golang-code-writer.md
@@ -4,6 +4,7 @@ description: Write, generate, or create new Go code — functions, structs, inte
 tools: [Read, Write, Edit, Glob, Grep, Bash]
 permissionMode: acceptEdits
 model: inherit
+color: blue
 ---
 
 # Go Code Writer Agent

--- a/.claude/agents/kubernetes-expert.md
+++ b/.claude/agents/kubernetes-expert.md
@@ -3,6 +3,7 @@ name: kubernetes-expert
 description: Specialized in Kubernetes operator patterns, CRDs, controllers, and cloud-native architecture for ToolHive
 tools: [Read, Write, Edit, Glob, Grep, Bash, WebFetch]
 model: inherit
+color: blue
 ---
 
 # Kubernetes Expert Agent

--- a/.claude/agents/toolhive-expert.md
+++ b/.claude/agents/toolhive-expert.md
@@ -2,6 +2,7 @@
 name: toolhive-expert
 description: Codebase knowledge, navigation, and implementation guidance — use for understanding existing code and patterns
 tools: [Read, Glob, Grep, Bash]
+color: green
 model: inherit
 ---
 


### PR DESCRIPTION
## Summary

Adds visual differentiation to Claude Code agent definitions by assigning colors to key agents. This makes it easier to distinguish between different agent types when they appear in the UI.

- `code-reviewer`: yellow
- `golang-code-writer`: blue
- `kubernetes-expert`: blue
- `toolhive-expert`: green

## Type of change

- [x] Other (config/tooling change)

## Test plan

- [x] Verified agent frontmatter syntax is valid
- [x] Confirmed no other changes are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)