### PR TITLE
Add resourceUrl field to MCPOIDCConfigReference

### DIFF
--- a/cmd/thv-operator/api/v1alpha1/mcpoidcconfig_types.go
+++ b/cmd/thv-operator/api/v1alpha1/mcpoidcconfig_types.go
@@ -241,6 +241,13 @@ type MCPOIDCConfigReference struct {
 	// +listType=atomic
 	// +optional
 	Scopes []string `json:"scopes,omitempty"`
+
+	// ResourceURL is the public URL for OAuth protected resource metadata (RFC 9728).
+	// When the server is exposed via Ingress or gateway, set this to the external
+	// URL that MCP clients connect to. If not specified, defaults to the internal
+	// Kubernetes service URL.
+	// +optional
+	ResourceURL string `json:"resourceUrl,omitempty"`
 }
 
 // Validate performs validation on the MCPOIDCConfig spec.

--- a/cmd/thv-operator/pkg/oidc/resolver.go
+++ b/cmd/thv-operator/pkg/oidc/resolver.go
@@ -82,7 +82,10 @@ func (r *resolver) ResolveFromConfigRef(
 		return nil, nil
 	}
 
-	resourceURL := createServiceURL(serverName, namespace, proxyPort)
+	resourceURL := ref.ResourceURL
+	if resourceURL == "" {
+		resourceURL = createServiceURL(serverName, namespace, proxyPort)
+	}
 
 	switch oidcCfg.Spec.Type {
 	case mcpv1alpha1.MCPOIDCConfigTypeKubernetesServiceAccount:

--- a/cmd/thv-operator/pkg/oidc/resolver_configref_test.go
+++ b/cmd/thv-operator/pkg/oidc/resolver_configref_test.go
@@ -71,6 +71,29 @@ func TestResolveFromConfigRef_KubernetesServiceAccountType(t *testing.T) {
 			},
 		},
 		{
+			name: "empty resourceUrl falls back to derived service URL",
+			ref: &mcpv1alpha1.MCPOIDCConfigReference{
+				Name: "k", Audience: "my-aud", Scopes: []string{"openid"},
+				ResourceURL: "",
+			},
+			oidcCfg: &mcpv1alpha1.MCPOIDCConfig{
+				Spec: mcpv1alpha1.MCPOIDCConfigSpec{
+					Type: mcpv1alpha1.MCPOIDCConfigTypeKubernetesServiceAccount,
+					KubernetesServiceAccount: &mcpv1alpha1.KubernetesServiceAccountOIDCConfig{
+						Issuer: "https://kubernetes.default.svc",
+					},
+				},
+			},
+			expected: &OIDCConfig{
+				Issuer: "https://kubernetes.default.svc", Audience: "my-aud",
+				Scopes:             []string{"openid"},
+				ResourceURL:        "http://srv.default.svc.cluster.local:8080",
+				ThvCABundlePath:    defaultK8sCABundlePath,
+				JWKSAuthTokenPath:  defaultK8sTokenPath,
+				JWKSAllowPrivateIP: true,
+			},
+		},
+		{
 			name: "nil KSA config falls back to all defaults",
 			ref: &mcpv1alpha1.MCPOIDCConfigReference{
 				Name: "k", Audience: "aud",

--- a/cmd/thv-operator/pkg/oidc/resolver_configref_test.go
+++ b/cmd/thv-operator/pkg/oidc/resolver_configref_test.go
@@ -90,6 +90,29 @@ func TestResolveFromConfigRef_KubernetesServiceAccountType(t *testing.T) {
 			},
 		},
 		{
+			name: "explicit resourceUrl overrides derived service URL",
+			ref: &mcpv1alpha1.MCPOIDCConfigReference{
+				Name: "k", Audience: "my-aud", Scopes: []string{"openid"},
+				ResourceURL: "https://mcp-gateway.example.com/mcp",
+			},
+			oidcCfg: &mcpv1alpha1.MCPOIDCConfig{
+				Spec: mcpv1alpha1.MCPOIDCConfigSpec{
+					Type: mcpv1alpha1.MCPOIDCConfigTypeKubernetesServiceAccount,
+					KubernetesServiceAccount: &mcpv1alpha1.KubernetesServiceAccountOIDCConfig{
+						Issuer: "https://kubernetes.default.svc",
+					},
+				},
+			},
+			expected: &OIDCConfig{
+				Issuer: "https://kubernetes.default.svc", Audience: "my-aud",
+				Scopes:             []string{"openid"},
+				ResourceURL:        "https://mcp-gateway.example.com/mcp",
+				ThvCABundlePath:    defaultK8sCABundlePath,
+				JWKSAuthTokenPath:  defaultK8sTokenPath,
+				JWKSAllowPrivateIP: true,
+			},
+		},
+		{
 			name: "UseClusterAuth false omits CA and token paths",
 			ref: &mcpv1alpha1.MCPOIDCConfigReference{
 				Name: "k", Audience: "aud",
@@ -177,6 +200,28 @@ func TestResolveFromConfigRef_InlineType(t *testing.T) {
 				ResourceURL:                     "http://srv.default.svc.cluster.local:8080",
 				ProtectedResourceAllowPrivateIP: true,
 				JWKSAllowPrivateIP:              false,
+			},
+		},
+		{
+			name: "explicit resourceUrl overrides derived service URL for inline config",
+			ref: &mcpv1alpha1.MCPOIDCConfigReference{
+				Name: "i", Audience: "inline-aud", Scopes: []string{"openid"},
+				ResourceURL: "https://mcp.corp.internal/tools",
+			},
+			oidcCfg: &mcpv1alpha1.MCPOIDCConfig{
+				Spec: mcpv1alpha1.MCPOIDCConfigSpec{
+					Type: mcpv1alpha1.MCPOIDCConfigTypeInline,
+					Inline: &mcpv1alpha1.InlineOIDCSharedConfig{
+						Issuer:   "https://accounts.google.com",
+						ClientID: "gid",
+					},
+				},
+			},
+			expected: &OIDCConfig{
+				Issuer: "https://accounts.google.com", Audience: "inline-aud",
+				ClientID:    "gid",
+				ResourceURL: "https://mcp.corp.internal/tools",
+				Scopes:      []string{"openid"},
 			},
 		},
 		{

--- a/cmd/thv-operator/test-integration/mcp-oidc-config/mcpoidcconfig_virtualmcpserver_integration_test.go
+++ b/cmd/thv-operator/test-integration/mcp-oidc-config/mcpoidcconfig_virtualmcpserver_integration_test.go
@@ -157,7 +157,7 @@ var _ = Describe("MCPOIDCConfig and VirtualMCPServer Cross-Resource Integration 
 			}, timeout, interval).Should(BeTrue())
 		})
 
-		It("should produce a ConfigMap with OIDC config from the MCPOIDCConfig", func() {
+		It("should produce a ConfigMap with all OIDC fields from the MCPOIDCConfig and ref", func() {
 			configMapName := vmcpName + "-vmcp-config"
 			configMap := &corev1.ConfigMap{}
 			Eventually(func() error {
@@ -173,8 +173,19 @@ var _ = Describe("MCPOIDCConfig and VirtualMCPServer Cross-Resource Integration 
 
 			Expect(config.IncomingAuth).NotTo(BeNil())
 			Expect(config.IncomingAuth.OIDC).NotTo(BeNil(), "OIDC config from MCPOIDCConfig should be present in ConfigMap")
+
+			// Shared config fields from MCPOIDCConfig
 			Expect(config.IncomingAuth.OIDC.Issuer).To(Equal("https://accounts.google.com"))
+			Expect(config.IncomingAuth.OIDC.ClientID).To(Equal("test-client"))
+
+			// Per-server fields from MCPOIDCConfigReference
 			Expect(config.IncomingAuth.OIDC.Audience).To(Equal("test-vmcp-audience"))
+			Expect(config.IncomingAuth.OIDC.Scopes).To(Equal([]string{"openid"}))
+
+			// Resource URL: no resourceUrl set on the ref, so falls back to internal service URL
+			Expect(config.IncomingAuth.OIDC.Resource).To(
+				MatchRegexp(`^http://test-vmcp-server\..*\.svc\.cluster\.local:\d+$`),
+				"resource should be the derived internal service URL when resourceUrl is not set on the ref")
 		})
 
 		It("should track VirtualMCPServer in MCPOIDCConfig ReferencingWorkloads", func() {
@@ -822,7 +833,7 @@ var _ = Describe("MCPOIDCConfig and VirtualMCPServer Cross-Resource Integration 
 			Expect(k8sClient.Delete(ctx, ns)).Should(Succeed())
 		})
 
-		It("should produce a ConfigMap with the explicit resourceUrl instead of internal service URL", func() {
+		It("should produce a ConfigMap with the explicit resourceUrl overriding internal service URL", func() {
 			configMapName := vmcpName + "-vmcp-config"
 			configMap := &corev1.ConfigMap{}
 			Eventually(func() error {
@@ -838,8 +849,18 @@ var _ = Describe("MCPOIDCConfig and VirtualMCPServer Cross-Resource Integration 
 
 			Expect(config.IncomingAuth).NotTo(BeNil())
 			Expect(config.IncomingAuth.OIDC).NotTo(BeNil())
+
+			// Shared config fields from MCPOIDCConfig
+			Expect(config.IncomingAuth.OIDC.Issuer).To(Equal("https://accounts.google.com"))
+			Expect(config.IncomingAuth.OIDC.ClientID).To(Equal("test-client"))
+
+			// Per-server fields from MCPOIDCConfigReference
+			Expect(config.IncomingAuth.OIDC.Audience).To(Equal("test-vmcp-audience"))
+			Expect(config.IncomingAuth.OIDC.Scopes).To(Equal([]string{"openid"}))
+
+			// Resource URL: explicit resourceUrl on the ref overrides the internal service URL
 			Expect(config.IncomingAuth.OIDC.Resource).To(Equal("https://mcp-gateway.example.com/mcp"),
-				"ConfigMap should contain the explicit resourceUrl, not the internal service URL")
+				"resource should be the explicit resourceUrl, not the internal service URL")
 		})
 	})
 })

--- a/cmd/thv-operator/test-integration/mcp-oidc-config/mcpoidcconfig_virtualmcpserver_integration_test.go
+++ b/cmd/thv-operator/test-integration/mcp-oidc-config/mcpoidcconfig_virtualmcpserver_integration_test.go
@@ -183,7 +183,7 @@ var _ = Describe("MCPOIDCConfig and VirtualMCPServer Cross-Resource Integration 
 			Expect(config.IncomingAuth.OIDC.Audience).To(Equal("test-vmcp-audience"))
 			Expect(config.IncomingAuth.OIDC.Scopes).To(Equal([]string{"openid"}))
 
-			// Resource URL: no resourceUrl set on the ref, so falls back to internal service URL
+			// Resource URL: explicit resourceUrl on the ref overrides the internal service URL
 			Expect(config.IncomingAuth.OIDC.Resource).To(Equal("https://mcp-gateway.example.com/mcp"),
 				"resource should be the explicit resourceUrl, not the internal service URL")
 		})

--- a/cmd/thv-operator/test-integration/mcp-oidc-config/mcpoidcconfig_virtualmcpserver_integration_test.go
+++ b/cmd/thv-operator/test-integration/mcp-oidc-config/mcpoidcconfig_virtualmcpserver_integration_test.go
@@ -107,9 +107,10 @@ var _ = Describe("MCPOIDCConfig and VirtualMCPServer Cross-Resource Integration 
 					IncomingAuth: &mcpv1alpha1.IncomingAuthConfig{
 						Type: "oidc",
 						OIDCConfigRef: &mcpv1alpha1.MCPOIDCConfigReference{
-							Name:     configName,
-							Audience: "test-vmcp-audience",
-							Scopes:   []string{"openid"},
+							Name:        configName,
+							Audience:    "test-vmcp-audience",
+							Scopes:      []string{"openid"},
+							ResourceURL: "https://mcp-gateway.example.com/mcp",
 						},
 					},
 				},
@@ -183,9 +184,8 @@ var _ = Describe("MCPOIDCConfig and VirtualMCPServer Cross-Resource Integration 
 			Expect(config.IncomingAuth.OIDC.Scopes).To(Equal([]string{"openid"}))
 
 			// Resource URL: no resourceUrl set on the ref, so falls back to internal service URL
-			Expect(config.IncomingAuth.OIDC.Resource).To(
-				MatchRegexp(`^http://test-vmcp-server\..*\.svc\.cluster\.local:\d+$`),
-				"resource should be the derived internal service URL when resourceUrl is not set on the ref")
+			Expect(config.IncomingAuth.OIDC.Resource).To(Equal("https://mcp-gateway.example.com/mcp"),
+				"resource should be the explicit resourceUrl, not the internal service URL")
 		})
 
 		It("should track VirtualMCPServer in MCPOIDCConfig ReferencingWorkloads", func() {
@@ -729,138 +729,6 @@ var _ = Describe("MCPOIDCConfig and VirtualMCPServer Cross-Resource Integration 
 				}
 				return hasMCPServer && hasVMCPServer
 			}, timeout, interval).Should(BeTrue())
-		})
-	})
-
-	Context("When VirtualMCPServer sets resourceUrl on oidcConfigRef", Ordered, func() {
-		var (
-			namespace  string
-			configName string
-			vmcpName   string
-			groupName  string
-			oidcConfig *mcpv1alpha1.MCPOIDCConfig
-			vmcpServer *mcpv1alpha1.VirtualMCPServer
-			mcpGroup   *mcpv1alpha1.MCPGroup
-			ns         *corev1.Namespace
-		)
-
-		BeforeAll(func() {
-			ns = &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "test-vmcp-oidcref-resurl-",
-				},
-			}
-			Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
-			namespace = ns.Name
-
-			configName = testOIDCConfigName
-			vmcpName = testVMCPServerName
-			groupName = testVMCPGroupName
-
-			// Create MCPGroup (required by VirtualMCPServer)
-			mcpGroup = &mcpv1alpha1.MCPGroup{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      groupName,
-					Namespace: namespace,
-				},
-			}
-			Expect(k8sClient.Create(ctx, mcpGroup)).Should(Succeed())
-
-			// Create MCPOIDCConfig
-			oidcConfig = &mcpv1alpha1.MCPOIDCConfig{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      configName,
-					Namespace: namespace,
-				},
-				Spec: mcpv1alpha1.MCPOIDCConfigSpec{
-					Type: mcpv1alpha1.MCPOIDCConfigTypeInline,
-					Inline: &mcpv1alpha1.InlineOIDCSharedConfig{
-						Issuer:   "https://accounts.google.com",
-						ClientID: "test-client",
-					},
-				},
-			}
-			Expect(k8sClient.Create(ctx, oidcConfig)).Should(Succeed())
-
-			// Wait for Valid condition and ConfigHash to be set
-			Eventually(func() bool {
-				updated := &mcpv1alpha1.MCPOIDCConfig{}
-				err := k8sClient.Get(ctx, types.NamespacedName{
-					Name:      configName,
-					Namespace: namespace,
-				}, updated)
-				if err != nil {
-					return false
-				}
-				if updated.Status.ConfigHash == "" {
-					return false
-				}
-				for _, cond := range updated.Status.Conditions {
-					if cond.Type == mcpv1alpha1.ConditionTypeOIDCConfigValid && cond.Status == metav1.ConditionTrue {
-						return true
-					}
-				}
-				return false
-			}, timeout, interval).Should(BeTrue())
-
-			// Create VirtualMCPServer with OIDCConfigRef that includes ResourceURL
-			vmcpServer = &mcpv1alpha1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      vmcpName,
-					Namespace: namespace,
-				},
-				Spec: mcpv1alpha1.VirtualMCPServerSpec{
-					GroupRef: &mcpv1alpha1.MCPGroupRef{Name: groupName},
-					Config:   vmcpconfig.Config{Group: groupName},
-					IncomingAuth: &mcpv1alpha1.IncomingAuthConfig{
-						Type: "oidc",
-						OIDCConfigRef: &mcpv1alpha1.MCPOIDCConfigReference{
-							Name:        configName,
-							Audience:    "test-vmcp-audience",
-							Scopes:      []string{"openid"},
-							ResourceURL: "https://mcp-gateway.example.com/mcp",
-						},
-					},
-				},
-			}
-			Expect(k8sClient.Create(ctx, vmcpServer)).Should(Succeed())
-		})
-
-		AfterAll(func() {
-			_ = k8sClient.Delete(ctx, vmcpServer)
-			_ = k8sClient.Delete(ctx, oidcConfig)
-			_ = k8sClient.Delete(ctx, mcpGroup)
-			Expect(k8sClient.Delete(ctx, ns)).Should(Succeed())
-		})
-
-		It("should produce a ConfigMap with the explicit resourceUrl overriding internal service URL", func() {
-			configMapName := vmcpName + "-vmcp-config"
-			configMap := &corev1.ConfigMap{}
-			Eventually(func() error {
-				return k8sClient.Get(ctx, types.NamespacedName{
-					Name:      configMapName,
-					Namespace: namespace,
-				}, configMap)
-			}, timeout, interval).Should(Succeed())
-
-			Expect(configMap.Data).To(HaveKey("config.yaml"))
-			var config vmcpconfig.Config
-			Expect(yaml.Unmarshal([]byte(configMap.Data["config.yaml"]), &config)).To(Succeed())
-
-			Expect(config.IncomingAuth).NotTo(BeNil())
-			Expect(config.IncomingAuth.OIDC).NotTo(BeNil())
-
-			// Shared config fields from MCPOIDCConfig
-			Expect(config.IncomingAuth.OIDC.Issuer).To(Equal("https://accounts.google.com"))
-			Expect(config.IncomingAuth.OIDC.ClientID).To(Equal("test-client"))
-
-			// Per-server fields from MCPOIDCConfigReference
-			Expect(config.IncomingAuth.OIDC.Audience).To(Equal("test-vmcp-audience"))
-			Expect(config.IncomingAuth.OIDC.Scopes).To(Equal([]string{"openid"}))
-
-			// Resource URL: explicit resourceUrl on the ref overrides the internal service URL
-			Expect(config.IncomingAuth.OIDC.Resource).To(Equal("https://mcp-gateway.example.com/mcp"),
-				"resource should be the explicit resourceUrl, not the internal service URL")
 		})
 	})
 })

--- a/cmd/thv-operator/test-integration/mcp-oidc-config/mcpoidcconfig_virtualmcpserver_integration_test.go
+++ b/cmd/thv-operator/test-integration/mcp-oidc-config/mcpoidcconfig_virtualmcpserver_integration_test.go
@@ -720,4 +720,126 @@ var _ = Describe("MCPOIDCConfig and VirtualMCPServer Cross-Resource Integration 
 			}, timeout, interval).Should(BeTrue())
 		})
 	})
+
+	Context("When VirtualMCPServer sets resourceUrl on oidcConfigRef", Ordered, func() {
+		var (
+			namespace  string
+			configName string
+			vmcpName   string
+			groupName  string
+			oidcConfig *mcpv1alpha1.MCPOIDCConfig
+			vmcpServer *mcpv1alpha1.VirtualMCPServer
+			mcpGroup   *mcpv1alpha1.MCPGroup
+			ns         *corev1.Namespace
+		)
+
+		BeforeAll(func() {
+			ns = &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-vmcp-oidcref-resurl-",
+				},
+			}
+			Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
+			namespace = ns.Name
+
+			configName = testOIDCConfigName
+			vmcpName = testVMCPServerName
+			groupName = testVMCPGroupName
+
+			// Create MCPGroup (required by VirtualMCPServer)
+			mcpGroup = &mcpv1alpha1.MCPGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      groupName,
+					Namespace: namespace,
+				},
+			}
+			Expect(k8sClient.Create(ctx, mcpGroup)).Should(Succeed())
+
+			// Create MCPOIDCConfig
+			oidcConfig = &mcpv1alpha1.MCPOIDCConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      configName,
+					Namespace: namespace,
+				},
+				Spec: mcpv1alpha1.MCPOIDCConfigSpec{
+					Type: mcpv1alpha1.MCPOIDCConfigTypeInline,
+					Inline: &mcpv1alpha1.InlineOIDCSharedConfig{
+						Issuer:   "https://accounts.google.com",
+						ClientID: "test-client",
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, oidcConfig)).Should(Succeed())
+
+			// Wait for Valid condition and ConfigHash to be set
+			Eventually(func() bool {
+				updated := &mcpv1alpha1.MCPOIDCConfig{}
+				err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      configName,
+					Namespace: namespace,
+				}, updated)
+				if err != nil {
+					return false
+				}
+				if updated.Status.ConfigHash == "" {
+					return false
+				}
+				for _, cond := range updated.Status.Conditions {
+					if cond.Type == mcpv1alpha1.ConditionTypeOIDCConfigValid && cond.Status == metav1.ConditionTrue {
+						return true
+					}
+				}
+				return false
+			}, timeout, interval).Should(BeTrue())
+
+			// Create VirtualMCPServer with OIDCConfigRef that includes ResourceURL
+			vmcpServer = &mcpv1alpha1.VirtualMCPServer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      vmcpName,
+					Namespace: namespace,
+				},
+				Spec: mcpv1alpha1.VirtualMCPServerSpec{
+					GroupRef: &mcpv1alpha1.MCPGroupRef{Name: groupName},
+					Config:   vmcpconfig.Config{Group: groupName},
+					IncomingAuth: &mcpv1alpha1.IncomingAuthConfig{
+						Type: "oidc",
+						OIDCConfigRef: &mcpv1alpha1.MCPOIDCConfigReference{
+							Name:        configName,
+							Audience:    "test-vmcp-audience",
+							Scopes:      []string{"openid"},
+							ResourceURL: "https://mcp-gateway.example.com/mcp",
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, vmcpServer)).Should(Succeed())
+		})
+
+		AfterAll(func() {
+			_ = k8sClient.Delete(ctx, vmcpServer)
+			_ = k8sClient.Delete(ctx, oidcConfig)
+			_ = k8sClient.Delete(ctx, mcpGroup)
+			Expect(k8sClient.Delete(ctx, ns)).Should(Succeed())
+		})
+
+		It("should produce a ConfigMap with the explicit resourceUrl instead of internal service URL", func() {
+			configMapName := vmcpName + "-vmcp-config"
+			configMap := &corev1.ConfigMap{}
+			Eventually(func() error {
+				return k8sClient.Get(ctx, types.NamespacedName{
+					Name:      configMapName,
+					Namespace: namespace,
+				}, configMap)
+			}, timeout, interval).Should(Succeed())
+
+			Expect(configMap.Data).To(HaveKey("config.yaml"))
+			var config vmcpconfig.Config
+			Expect(yaml.Unmarshal([]byte(configMap.Data["config.yaml"]), &config)).To(Succeed())
+
+			Expect(config.IncomingAuth).NotTo(BeNil())
+			Expect(config.IncomingAuth.OIDC).NotTo(BeNil())
+			Expect(config.IncomingAuth.OIDC.Resource).To(Equal("https://mcp-gateway.example.com/mcp"),
+				"ConfigMap should contain the explicit resourceUrl, not the internal service URL")
+		})
+	})
 })

--- a/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpremoteproxies.yaml
+++ b/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpremoteproxies.yaml
@@ -246,6 +246,13 @@ spec:
                     description: Name is the name of the MCPOIDCConfig resource
                     minLength: 1
                     type: string
+                  resourceUrl:
+                    description: |-
+                      ResourceURL is the public URL for OAuth protected resource metadata (RFC 9728).
+                      When the server is exposed via Ingress or gateway, set this to the external
+                      URL that MCP clients connect to. If not specified, defaults to the internal
+                      Kubernetes service URL.
+                    type: string
                   scopes:
                     description: |-
                       Scopes is the list of OAuth scopes to advertise in the well-known endpoint (RFC 9728).

--- a/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpservers.yaml
+++ b/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpservers.yaml
@@ -241,6 +241,13 @@ spec:
                     description: Name is the name of the MCPOIDCConfig resource
                     minLength: 1
                     type: string
+                  resourceUrl:
+                    description: |-
+                      ResourceURL is the public URL for OAuth protected resource metadata (RFC 9728).
+                      When the server is exposed via Ingress or gateway, set this to the external
+                      URL that MCP clients connect to. If not specified, defaults to the internal
+                      Kubernetes service URL.
+                    type: string
                   scopes:
                     description: |-
                       Scopes is the list of OAuth scopes to advertise in the well-known endpoint (RFC 9728).

--- a/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_virtualmcpservers.yaml
+++ b/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_virtualmcpservers.yaml
@@ -1878,6 +1878,13 @@ spec:
                         description: Name is the name of the MCPOIDCConfig resource
                         minLength: 1
                         type: string
+                      resourceUrl:
+                        description: |-
+                          ResourceURL is the public URL for OAuth protected resource metadata (RFC 9728).
+                          When the server is exposed via Ingress or gateway, set this to the external
+                          URL that MCP clients connect to. If not specified, defaults to the internal
+                          Kubernetes service URL.
+                        type: string
                       scopes:
                         description: |-
                           Scopes is the list of OAuth scopes to advertise in the well-known endpoint (RFC 9728).

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpremoteproxies.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpremoteproxies.yaml
@@ -249,6 +249,13 @@ spec:
                     description: Name is the name of the MCPOIDCConfig resource
                     minLength: 1
                     type: string
+                  resourceUrl:
+                    description: |-
+                      ResourceURL is the public URL for OAuth protected resource metadata (RFC 9728).
+                      When the server is exposed via Ingress or gateway, set this to the external
+                      URL that MCP clients connect to. If not specified, defaults to the internal
+                      Kubernetes service URL.
+                    type: string
                   scopes:
                     description: |-
                       Scopes is the list of OAuth scopes to advertise in the well-known endpoint (RFC 9728).

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpservers.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpservers.yaml
@@ -244,6 +244,13 @@ spec:
                     description: Name is the name of the MCPOIDCConfig resource
                     minLength: 1
                     type: string
+                  resourceUrl:
+                    description: |-
+                      ResourceURL is the public URL for OAuth protected resource metadata (RFC 9728).
+                      When the server is exposed via Ingress or gateway, set this to the external
+                      URL that MCP clients connect to. If not specified, defaults to the internal
+                      Kubernetes service URL.
+                    type: string
                   scopes:
                     description: |-
                       Scopes is the list of OAuth scopes to advertise in the well-known endpoint (RFC 9728).

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_virtualmcpservers.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_virtualmcpservers.yaml
@@ -1881,6 +1881,13 @@ spec:
                         description: Name is the name of the MCPOIDCConfig resource
                         minLength: 1
                         type: string
+                      resourceUrl:
+                        description: |-
+                          ResourceURL is the public URL for OAuth protected resource metadata (RFC 9728).
+                          When the server is exposed via Ingress or gateway, set this to the external
+                          URL that MCP clients connect to. If not specified, defaults to the internal
+                          Kubernetes service URL.
+                        type: string
                       scopes:
                         description: |-
                           Scopes is the list of OAuth scopes to advertise in the well-known endpoint (RFC 9728).

--- a/docs/arch/09-operator-architecture.md
+++ b/docs/arch/09-operator-architecture.md
@@ -219,6 +219,7 @@ MCPOIDCConfig eliminates OIDC configuration duplication — define an identity p
 **Per-server overrides** live in the workload's `oidcConfigRef` field (not the shared spec):
 - `audience` (required) — Must be unique per server to prevent token replay
 - `scopes` (optional) — Defaults to `["openid"]`
+- `resourceUrl` (optional) — Public URL for OAuth protected resource metadata (RFC 9728); defaults to internal service URL
 
 **Status fields** include a `Ready` condition, `configHash` for change detection, and `referencingWorkloads` tracking which resources reference this config. Deletion is blocked while references exist (finalizer pattern).
 
@@ -255,7 +256,7 @@ Defines a proxy for remote MCP servers with authentication, authorization, audit
 
 **Key fields:**
 - `remoteUrl` - URL of the remote MCP server to proxy
-- `oidcConfigRef` - Reference to shared MCPOIDCConfig (with per-server `audience` and `scopes`)
+- `oidcConfigRef` - Reference to shared MCPOIDCConfig (with per-server `audience`, `scopes`, and `resourceUrl`)
 - `externalAuthConfigRef` - Token exchange for remote service authentication
 - `authzConfig` - Authorization policies
 - `toolConfigRef` - Tool filtering and renaming
@@ -629,6 +630,7 @@ spec:
     name: corporate-idp
     audience: my-server      # per-server, prevents token replay
     scopes: ["openid"]       # optional, defaults to ["openid"]
+    resourceUrl: https://mcp.example.com  # optional, defaults to internal service URL
 ```
 
 **MCPTelemetryConfig reference:**

--- a/docs/operator/crd-api.md
+++ b/docs/operator/crd-api.md
@@ -1607,6 +1607,7 @@ _Appears in:_
 | `name` _string_ | Name is the name of the MCPOIDCConfig resource |  | MinLength: 1 <br />Required: \{\} <br /> |
 | `audience` _string_ | Audience is the expected audience for token validation.<br />This MUST be unique per server to prevent token replay attacks. |  | MinLength: 1 <br />Required: \{\} <br /> |
 | `scopes` _string array_ | Scopes is the list of OAuth scopes to advertise in the well-known endpoint (RFC 9728).<br />If empty, defaults to ["openid"]. |  | Optional: \{\} <br /> |
+| `resourceUrl` _string_ | ResourceURL is the public URL for OAuth protected resource metadata (RFC 9728).<br />When the server is exposed via Ingress or gateway, set this to the external<br />URL that MCP clients connect to. If not specified, defaults to the internal<br />Kubernetes service URL. |  | Optional: \{\} <br /> |
 
 
 #### api.v1alpha1.MCPOIDCConfigSourceType


### PR DESCRIPTION
## Summary

- When a VirtualMCPServer is exposed via Ingress, `oidcConfigRef` produces protected resource metadata (RFC 9728) with the internal Kubernetes service URL instead of the public URL. MCP clients connecting through the Ingress receive an unreachable address, making `oidcConfigRef` unusable for any externally-exposed server.
- Add an optional `resourceUrl` field to `MCPOIDCConfigReference` so users can specify the public URL. When unset, the existing internal service URL fallback is preserved for backward compatibility.

Closes #4851

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)

## Changes

| File | Change |
|------|--------|
| `cmd/thv-operator/api/v1alpha1/mcpoidcconfig_types.go` | Add optional `ResourceURL` field to `MCPOIDCConfigReference` struct |
| `cmd/thv-operator/pkg/oidc/resolver.go` | Use `ref.ResourceURL` when set, fall back to `createServiceURL()` when empty |
| `cmd/thv-operator/pkg/oidc/resolver_configref_test.go` | Add 2 test cases: resourceUrl override for KubernetesServiceAccount and Inline types |
| `deploy/charts/operator-crds/files/crds/*.yaml` | Regenerated CRD YAML (MCPServer, VirtualMCPServer, MCPRemoteProxy) |
| `deploy/charts/operator-crds/templates/*.yaml` | Regenerated Helm-wrapped CRD templates |
| `docs/operator/crd-api.md` | Regenerated API reference docs |

## Does this introduce a user-facing change?

Yes. Users can now set `oidcConfigRef.resourceUrl` on MCPServer, VirtualMCPServer, and MCPRemoteProxy resources to specify the public URL for OAuth protected resource metadata when the server is exposed via Ingress or gateway. Existing deployments without this field are unaffected.

## Implementation plan

<details>
<summary>Approved implementation plan</summary>

See `design-oidcConfigRef-resourceUrl.md` in the repository root for the full design document.

</details>

Generated with [Claude Code](https://claude.com/claude-code)