### PR TITLE
Simplify `UpdateConfig` error path and add test

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -376,7 +376,7 @@ func UpdateConfigAtPath(configPath string, updateFn func(*Config) error) error {
 
 	// Apply changes to the config file.
 	if err := updateFn(c); err != nil {
-		return fmt.Errorf("update function failed: %w", err)
+		return err
 	}
 
 	// Write the updated config to disk.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -4,6 +4,7 @@
 package config
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -258,6 +259,27 @@ func TestRegistryURLConfig(t *testing.T) {
 			}
 		})
 	})
+}
+
+func TestUpdateConfigAtPath_CallbackError(t *testing.T) {
+	t.Parallel()
+
+	_, configPath := SetupTestConfig(t, &Config{
+		RegistryUrl: "https://original.example.com",
+	})
+
+	cbErr := errors.New("validation failed")
+	err := UpdateConfigAtPath(configPath, func(c *Config) error {
+		c.RegistryUrl = "https://should-not-persist.example.com"
+		return cbErr
+	})
+	require.ErrorIs(t, err, cbErr)
+
+	// The config on disk must be unchanged.
+	config, err := LoadOrCreateConfigWithPath(configPath)
+	require.NoError(t, err)
+	assert.Equal(t, "https://original.example.com", config.RegistryUrl,
+		"config should not be written to disk when the callback returns an error")
 }
 
 func TestSecrets_GetProviderType_EnvironmentVariable(t *testing.T) {


### PR DESCRIPTION
Remove the "update function failed" error wrapping in `UpdateConfigAtPath`. A bare return avoids double-nesting once callers start returning real errors from their callbacks. Add `TestUpdateConfigAtPath_CallbackError` to exercise the error path: when the callback returns an error the config must not be written to disk.