### PR TITLE
Fix partialFailureMode validator to accept CRD enum values

### DIFF
--- a/pkg/vmcp/config/validator.go
+++ b/pkg/vmcp/config/validator.go
@@ -404,7 +404,7 @@ func (*DefaultValidator) validateFailureHandling(fh *FailureHandlingConfig) erro
 		}
 	}
 
-	validModes := []string{"fail", "bestEffort"}
+	validModes := []string{"fail", "best_effort"}
 	if !slices.Contains(validModes, fh.PartialFailureMode) {
 		return fmt.Errorf("partialFailureMode must be one of: %s", strings.Join(validModes, ", "))
 	}

--- a/pkg/vmcp/config/validator_test.go
+++ b/pkg/vmcp/config/validator_test.go
@@ -697,7 +697,7 @@ func TestValidator_ValidateFailureHandling(t *testing.T) {
 			fh: &FailureHandlingConfig{
 				HealthCheckInterval: Duration(30 * time.Second),
 				UnhealthyThreshold:  3,
-				PartialFailureMode:  "bestEffort",
+				PartialFailureMode:  "best_effort",
 				CircuitBreaker: &CircuitBreakerConfig{
 					Enabled: false,
 				},
@@ -800,7 +800,7 @@ func TestValidator_ValidateFailureHandling(t *testing.T) {
 				PartialFailureMode:  "invalid",
 			},
 			wantErr: true,
-			errMsg:  "partialFailureMode must be one of: fail, bestEffort",
+			errMsg:  "partialFailureMode must be one of: fail, best_effort",
 		},
 		{
 			name: "negative health check interval",


### PR DESCRIPTION
## Summary

The camelCase config migration (PR #3195) accidentally changed the accepted `partialFailureMode` enum value from `best_effort` to `bestEffort` in the vMCP config validator, but the CRD still correctly defines the enum as `best_effort`. This made it impossible to enable best-effort partial failure mode — the CRD blocks `bestEffort` at admission and the validator blocks `best_effort` at runtime, so the pod crashes with a validation error on any attempt to use this feature.

This fixes the validator to accept `best_effort`, matching the CRD enum definition.

Fixes #4856

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test plan

- [x] Existing unit tests updated and passing (`TestValidator_ValidateFailureHandling` — all 13 cases pass)
- [x] Lint passes (`task lint-fix` — 0 issues)

Generated with [Claude Code](https://claude.com/claude-code)