### PR TITLE
Add registry-aware workload creation

### DIFF
--- a/docs/server/docs.go
+++ b/docs/server/docs.go
@@ -2515,6 +2515,10 @@ const docTemplate = `{
                         "description": "Port for the HTTP proxy to listen on",
                         "type": "integer"
                     },
+                    "registry": {
+                        "description": "Registry is the optional registry name to resolve the server from (e.g. \"default\").",
+                        "type": "string"
+                    },
                     "runtime_config": {
                         "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_container_templates.RuntimeConfig"
                     },
@@ -2525,6 +2529,10 @@ const docTemplate = `{
                         },
                         "type": "array",
                         "uniqueItems": false
+                    },
+                    "server": {
+                        "description": "Server is the optional server name in the registry (e.g. \"io.github.stacklok/fetch\").\nWhen both Registry and Server are set, thv resolves the server metadata\nserver-side, filling in image, transport, env vars, permissions, etc.\nUser-provided fields always override registry defaults.",
+                        "type": "string"
                     },
                     "target_port": {
                         "description": "Port to expose from the container",

--- a/docs/server/docs.go
+++ b/docs/server/docs.go
@@ -2493,6 +2493,10 @@ const docTemplate = `{
                         "description": "Port for the HTTP proxy to listen on",
                         "type": "integer"
                     },
+                    "registry": {
+                        "description": "Registry is the optional registry name to resolve the server from (e.g. \"default\").",
+                        "type": "string"
+                    },
                     "runtime_config": {
                         "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_container_templates.RuntimeConfig"
                     },
@@ -2503,6 +2507,10 @@ const docTemplate = `{
                         },
                         "type": "array",
                         "uniqueItems": false
+                    },
+                    "server": {
+                        "description": "Server is the optional server name in the registry (e.g. \"io.github.stacklok/fetch\").\nWhen both Registry and Server are set, thv resolves the server metadata\nserver-side, filling in image, transport, env vars, permissions, etc.\nUser-provided fields always override registry defaults.",
+                        "type": "string"
                     },
                     "target_port": {
                         "description": "Port to expose from the container",

--- a/docs/server/swagger.json
+++ b/docs/server/swagger.json
@@ -2486,6 +2486,10 @@
                         "description": "Port for the HTTP proxy to listen on",
                         "type": "integer"
                     },
+                    "registry": {
+                        "description": "Registry is the optional registry name to resolve the server from (e.g. \"default\").",
+                        "type": "string"
+                    },
                     "runtime_config": {
                         "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_container_templates.RuntimeConfig"
                     },
@@ -2496,6 +2500,10 @@
                         },
                         "type": "array",
                         "uniqueItems": false
+                    },
+                    "server": {
+                        "description": "Server is the optional server name in the registry (e.g. \"io.github.stacklok/fetch\").\nWhen both Registry and Server are set, thv resolves the server metadata\nserver-side, filling in image, transport, env vars, permissions, etc.\nUser-provided fields always override registry defaults.",
+                        "type": "string"
                     },
                     "target_port": {
                         "description": "Port to expose from the container",

--- a/docs/server/swagger.json
+++ b/docs/server/swagger.json
@@ -2508,6 +2508,10 @@
                         "description": "Port for the HTTP proxy to listen on",
                         "type": "integer"
                     },
+                    "registry": {
+                        "description": "Registry is the optional registry name to resolve the server from (e.g. \"default\").",
+                        "type": "string"
+                    },
                     "runtime_config": {
                         "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_container_templates.RuntimeConfig"
                     },
@@ -2518,6 +2522,10 @@
                         },
                         "type": "array",
                         "uniqueItems": false
+                    },
+                    "server": {
+                        "description": "Server is the optional server name in the registry (e.g. \"io.github.stacklok/fetch\").\nWhen both Registry and Server are set, thv resolves the server metadata\nserver-side, filling in image, transport, env vars, permissions, etc.\nUser-provided fields always override registry defaults.",
+                        "type": "string"
                     },
                     "target_port": {
                         "description": "Port to expose from the container",

--- a/docs/server/swagger.yaml
+++ b/docs/server/swagger.yaml
@@ -2242,6 +2242,10 @@ components:
         proxy_port:
           description: Port for the HTTP proxy to listen on
           type: integer
+        registry:
+          description: Registry is the optional registry name to resolve the server
+            from (e.g. "default").
+          type: string
         runtime_config:
           $ref: '#/components/schemas/github_com_stacklok_toolhive_pkg_container_templates.RuntimeConfig'
         secrets:
@@ -2250,6 +2254,13 @@ components:
             $ref: '#/components/schemas/github_com_stacklok_toolhive_pkg_secrets.SecretParameter'
           type: array
           uniqueItems: false
+        server:
+          description: |-
+            Server is the optional server name in the registry (e.g. "io.github.stacklok/fetch").
+            When both Registry and Server are set, thv resolves the server metadata
+            server-side, filling in image, transport, env vars, permissions, etc.
+            User-provided fields always override registry defaults.
+          type: string
         target_port:
           description: Port to expose from the container
           type: integer

--- a/docs/server/swagger.yaml
+++ b/docs/server/swagger.yaml
@@ -2209,6 +2209,10 @@ components:
         proxy_port:
           description: Port for the HTTP proxy to listen on
           type: integer
+        registry:
+          description: Registry is the optional registry name to resolve the server
+            from (e.g. "default").
+          type: string
         runtime_config:
           $ref: '#/components/schemas/github_com_stacklok_toolhive_pkg_container_templates.RuntimeConfig'
         secrets:
@@ -2217,6 +2221,13 @@ components:
             $ref: '#/components/schemas/github_com_stacklok_toolhive_pkg_secrets.SecretParameter'
           type: array
           uniqueItems: false
+        server:
+          description: |-
+            Server is the optional server name in the registry (e.g. "io.github.stacklok/fetch").
+            When both Registry and Server are set, thv resolves the server metadata
+            server-side, filling in image, transport, env vars, permissions, etc.
+            User-provided fields always override registry defaults.
+          type: string
         target_port:
           description: Port to expose from the container
           type: integer

--- a/pkg/api/v1/workload_service.go
+++ b/pkg/api/v1/workload_service.go
@@ -154,7 +154,7 @@ func (s *WorkloadService) BuildFullRunConfig(
 	var registryResolvedMetadata regtypes.ServerMetadata
 	if req.Registry != "" && req.Server != "" {
 		var err error
-		registryResolvedMetadata, err = resolveRegistryServer(req)
+		registryResolvedMetadata, err = s.resolveRegistryServer(req)
 		if err != nil {
 			return nil, fmt.Errorf("failed to resolve server from registry: %w", err)
 		}
@@ -214,9 +214,36 @@ func (s *WorkloadService) BuildFullRunConfig(
 	// remote auth config, proxy port) picks it up automatically.
 	if registryResolvedMetadata != nil {
 		serverMetadata = registryResolvedMetadata
-		if img, ok := registryResolvedMetadata.(*regtypes.ImageMetadata); ok {
-			imageMetadata = img
-			imageURL = img.Image
+		switch md := registryResolvedMetadata.(type) {
+		case *regtypes.ImageMetadata:
+			imageMetadata = md
+			imageURL = md.Image
+		case *regtypes.RemoteServerMetadata:
+			if req.ProxyPort == 0 && md.ProxyPort > 0 {
+				registryProxyPort = md.ProxyPort
+			}
+			if md.OAuthConfig != nil {
+				resource := req.OAuthConfig.Resource
+				if resource == "" {
+					resource = md.OAuthConfig.Resource
+				}
+				if resource == "" && md.URL != "" {
+					resource = remote.DefaultResourceIndicator(md.URL)
+				}
+				remoteAuthConfig = &remote.Config{
+					ClientID:     req.OAuthConfig.ClientID,
+					Scopes:       md.OAuthConfig.Scopes,
+					CallbackPort: md.OAuthConfig.CallbackPort,
+					Issuer:       md.OAuthConfig.Issuer,
+					AuthorizeURL: md.OAuthConfig.AuthorizeURL,
+					TokenURL:     md.OAuthConfig.TokenURL,
+					UsePKCE:      md.OAuthConfig.UsePKCE,
+					Resource:     resource,
+					OAuthParams:  md.OAuthConfig.OAuthParams,
+					Headers:      md.Headers,
+					EnvVars:      md.EnvVars,
+				}
+			}
 		}
 	}
 
@@ -591,14 +618,14 @@ func (s *WorkloadService) GetWorkloadNamesFromRequest(ctx context.Context, req b
 
 // resolveRegistryServer resolves a server from the registry and fills in
 // default values on the request. User-provided fields are not overwritten.
-func resolveRegistryServer(req *createRequest) (regtypes.ServerMetadata, error) {
+func (s *WorkloadService) resolveRegistryServer(req *createRequest) (regtypes.ServerMetadata, error) {
 	// Only "default" registry is currently supported.
 	if req.Registry != "default" {
 		return nil, fmt.Errorf("unknown registry %q; only \"default\" is currently supported", req.Registry)
 	}
 
 	provider, err := registry.GetDefaultProviderWithConfig(
-		config.NewProvider(),
+		s.configProvider,
 		registry.WithInteractive(false),
 	)
 	if err != nil {

--- a/pkg/api/v1/workload_service.go
+++ b/pkg/api/v1/workload_service.go
@@ -147,9 +147,15 @@ func (s *WorkloadService) BuildFullRunConfig(
 	if (req.Registry != "" && req.Server == "") || (req.Registry == "" && req.Server != "") {
 		return nil, fmt.Errorf("both registry and server must be specified together")
 	}
-	// If registry+server specified, resolve from registry and fill defaults
+	// If registry+server specified, resolve from registry and fill defaults.
+	// The returned metadata is assigned to the local variables so the rest of
+	// BuildFullRunConfig (registry info, tool validation, remote auth, etc.)
+	// has access to it without re-looking up the server.
+	var registryResolvedMetadata regtypes.ServerMetadata
 	if req.Registry != "" && req.Server != "" {
-		if err := resolveRegistryServer(req); err != nil {
+		var err error
+		registryResolvedMetadata, err = resolveRegistryServer(req)
+		if err != nil {
 			return nil, fmt.Errorf("failed to resolve server from registry: %w", err)
 		}
 	}
@@ -202,6 +208,18 @@ func (s *WorkloadService) BuildFullRunConfig(
 	var imageMetadata *regtypes.ImageMetadata
 	var serverMetadata regtypes.ServerMetadata
 	var registryProxyPort int
+
+	// If we resolved metadata from a registry reference, assign it to the
+	// local variables so downstream code (registry info, tool validation,
+	// remote auth config, proxy port) picks it up automatically.
+	if registryResolvedMetadata != nil {
+		serverMetadata = registryResolvedMetadata
+		if img, ok := registryResolvedMetadata.(*regtypes.ImageMetadata); ok {
+			imageMetadata = img
+			imageURL = img.Image
+		}
+	}
+
 	runtimeConfigOverride := runtimeConfigFromRequest(req)
 	retrievalRuntimeConfig, err := runtimeConfigForImageBuild(req, runtimeConfigOverride)
 	if err != nil {
@@ -214,13 +232,14 @@ func (s *WorkloadService) BuildFullRunConfig(
 			req.Transport = types.TransportTypeStreamableHTTP.String()
 		}
 		remoteAuthConfig = createRequestToRemoteAuthConfig(ctx, req)
-	} else {
-		// Create a dedicated context with longer timeout for image retrieval
+	} else if registryResolvedMetadata == nil {
+		// Only call imageRetriever if we didn't already resolve from a registry
+		// reference. When registry+server was used, serverMetadata and imageMetadata
+		// are already populated above and re-looking up by bare image ref would fail
+		// (the image ref doesn't match any server name in the registry).
 		imageCtx, cancel := context.WithTimeout(ctx, imageRetrievalTimeout)
 		defer cancel()
 
-		// Resolve the requested image from the registry without pulling it.
-		// The actual pull is deferred until after the policy check.
 		imageURL, serverMetadata, err = s.imageRetriever(
 			imageCtx,
 			req.Image,
@@ -572,10 +591,10 @@ func (s *WorkloadService) GetWorkloadNamesFromRequest(ctx context.Context, req b
 
 // resolveRegistryServer resolves a server from the registry and fills in
 // default values on the request. User-provided fields are not overwritten.
-func resolveRegistryServer(req *createRequest) error {
+func resolveRegistryServer(req *createRequest) (regtypes.ServerMetadata, error) {
 	// Only "default" registry is currently supported.
 	if req.Registry != "default" {
-		return fmt.Errorf("unknown registry %q; only \"default\" is currently supported", req.Registry)
+		return nil, fmt.Errorf("unknown registry %q; only \"default\" is currently supported", req.Registry)
 	}
 
 	provider, err := registry.GetDefaultProviderWithConfig(
@@ -583,16 +602,16 @@ func resolveRegistryServer(req *createRequest) error {
 		registry.WithInteractive(false),
 	)
 	if err != nil {
-		return fmt.Errorf("failed to get registry provider: %w", err)
+		return nil, fmt.Errorf("failed to get registry provider: %w", err)
 	}
 
 	metadata, err := provider.GetServer(req.Server)
 	if err != nil {
-		return fmt.Errorf("server %q not found in registry: %w", req.Server, err)
+		return nil, fmt.Errorf("server %q not found in registry: %w", req.Server, err)
 	}
 
 	applyRegistryDefaults(req, metadata)
-	return nil
+	return metadata, nil
 }
 
 func applyRegistryDefaults(req *createRequest, metadata regtypes.ServerMetadata) {

--- a/pkg/api/v1/workload_service.go
+++ b/pkg/api/v1/workload_service.go
@@ -243,7 +243,23 @@ func (s *WorkloadService) BuildFullRunConfig(
 					Headers:      md.Headers,
 					EnvVars:      md.EnvVars,
 				}
+				// Apply user-provided secrets on top of registry config
+				if req.OAuthConfig.ClientSecret != nil {
+					remoteAuthConfig.ClientSecret = req.OAuthConfig.ClientSecret.ToCLIString()
+				}
+				if req.OAuthConfig.BearerToken != nil {
+					remoteAuthConfig.BearerToken = req.OAuthConfig.BearerToken.ToCLIString()
+				}
 			}
+		}
+	}
+
+	// Verify image provenance for registry-resolved image servers.
+	// The normal imageRetriever path calls verifyImage internally, but
+	// we bypass it for registry references, so we must verify here.
+	if imageMetadata != nil && registryResolvedMetadata != nil {
+		if err := retriever.VerifyImage(imageURL, imageMetadata, retriever.VerifyImageWarn); err != nil {
+			return nil, fmt.Errorf("image verification failed: %w", err)
 		}
 	}
 
@@ -253,12 +269,18 @@ func (s *WorkloadService) BuildFullRunConfig(
 		return nil, fmt.Errorf("%w: %w", retriever.ErrInvalidRunConfig, err)
 	}
 
-	if req.URL != "" {
-		// Configure remote authentication if OAuth config is provided
+	if req.URL != "" && registryResolvedMetadata == nil {
+		// Direct URL from user (not resolved from registry) — build auth from request fields.
 		if req.Transport == "" {
 			req.Transport = types.TransportTypeStreamableHTTP.String()
 		}
 		remoteAuthConfig = createRequestToRemoteAuthConfig(ctx, req)
+	} else if req.URL != "" && registryResolvedMetadata != nil {
+		// URL was filled by registry resolution — remoteAuthConfig was already built
+		// in the assignment block above. Just ensure transport has a default.
+		if req.Transport == "" {
+			req.Transport = types.TransportTypeStreamableHTTP.String()
+		}
 	} else if registryResolvedMetadata == nil {
 		// Only call imageRetriever if we didn't already resolve from a registry
 		// reference. When registry+server was used, serverMetadata and imageMetadata

--- a/pkg/api/v1/workload_service.go
+++ b/pkg/api/v1/workload_service.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stacklok/toolhive/pkg/container/templates"
 	"github.com/stacklok/toolhive/pkg/groups"
 	"github.com/stacklok/toolhive/pkg/networking"
+	"github.com/stacklok/toolhive/pkg/registry"
 	"github.com/stacklok/toolhive/pkg/runner"
 	"github.com/stacklok/toolhive/pkg/runner/retriever"
 	"github.com/stacklok/toolhive/pkg/secrets"
@@ -142,6 +143,16 @@ func (s *WorkloadService) UpdateWorkloadFromRequest(ctx context.Context, name st
 func (s *WorkloadService) BuildFullRunConfig(
 	ctx context.Context, req *createRequest, existingPort int,
 ) (*runner.RunConfig, error) {
+	// If registry+server specified, resolve from registry and fill defaults
+	if req.Registry != "" && req.Server != "" {
+		if err := resolveRegistryServer(req); err != nil {
+			return nil, fmt.Errorf("failed to resolve server from registry: %w", err)
+		}
+	}
+	if (req.Registry != "" && req.Server == "") || (req.Registry == "" && req.Server != "") {
+		return nil, fmt.Errorf("both registry and server must be specified together")
+	}
+
 	// Default proxy mode to streamable-http if not specified (SSE is deprecated)
 	if !types.IsValidProxyMode(req.ProxyMode) {
 		if req.ProxyMode == "" {
@@ -556,4 +567,75 @@ func (s *WorkloadService) GetWorkloadNamesFromRequest(ctx context.Context, req b
 	}
 
 	return workloadNames, nil
+}
+
+// resolveRegistryServer resolves a server from the registry and fills in
+// default values on the request. User-provided fields are not overwritten.
+func resolveRegistryServer(req *createRequest) error {
+	provider, err := registry.GetDefaultProviderWithConfig(
+		config.NewProvider(),
+		registry.WithInteractive(false),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to get registry provider: %w", err)
+	}
+
+	metadata, err := provider.GetServer(req.Server)
+	if err != nil {
+		return fmt.Errorf("server %q not found in registry: %w", req.Server, err)
+	}
+
+	applyRegistryDefaults(req, metadata)
+	return nil
+}
+
+func applyRegistryDefaults(req *createRequest, metadata regtypes.ServerMetadata) {
+	if req.Transport == "" {
+		req.Transport = metadata.GetTransport()
+	}
+	if req.Name == "" {
+		req.Name = metadata.GetName()
+	}
+
+	switch md := metadata.(type) {
+	case *regtypes.ImageMetadata:
+		applyImageDefaults(req, md)
+	case *regtypes.RemoteServerMetadata:
+		applyRemoteDefaults(req, md)
+	}
+}
+
+func applyImageDefaults(req *createRequest, md *regtypes.ImageMetadata) {
+	if req.Image == "" {
+		req.Image = md.Image
+	}
+	if req.TargetPort == 0 && md.TargetPort != 0 {
+		req.TargetPort = md.TargetPort
+	}
+	if len(req.CmdArguments) == 0 && len(md.Args) > 0 {
+		req.CmdArguments = md.Args
+	}
+	if req.PermissionProfile == nil && md.Permissions != nil {
+		req.PermissionProfile = md.Permissions
+	}
+	// Merge env vars: registry defaults first, user overrides take precedence
+	if req.EnvVars == nil {
+		req.EnvVars = make(map[string]string)
+	}
+	for _, ev := range md.EnvVars {
+		if ev.Default != "" {
+			if _, userSet := req.EnvVars[ev.Name]; !userSet {
+				req.EnvVars[ev.Name] = ev.Default
+			}
+		}
+	}
+}
+
+func applyRemoteDefaults(req *createRequest, md *regtypes.RemoteServerMetadata) {
+	if req.URL == "" {
+		req.URL = md.URL
+	}
+	if len(req.Headers) == 0 && len(md.Headers) > 0 {
+		req.Headers = md.Headers
+	}
 }

--- a/pkg/api/v1/workload_service.go
+++ b/pkg/api/v1/workload_service.go
@@ -145,17 +145,11 @@ func (s *WorkloadService) UpdateWorkloadFromRequest(ctx context.Context, name st
 func (s *WorkloadService) BuildFullRunConfig(
 	ctx context.Context, req *createRequest, existingPort int,
 ) (*runner.RunConfig, error) {
-	// Validate registry+server pairing first (guard clause)
-	if (req.Registry != "" && req.Server == "") || (req.Registry == "" && req.Server != "") {
-		return nil, httperr.WithCode(
-			fmt.Errorf("both registry and server must be specified together"),
-			http.StatusBadRequest,
-		)
-	}
 	// If registry+server specified, resolve from registry and fill defaults.
 	// The returned metadata is assigned to the local variables so the rest of
 	// BuildFullRunConfig (registry info, tool validation, remote auth, etc.)
-	// has access to it without re-looking up the server.
+	// has access to it without re-looking up the server. The route handler
+	// already rejects partial registry+server pairs with a 400.
 	var registryResolvedMetadata regtypes.ServerMetadata
 	if req.Registry != "" && req.Server != "" {
 		var err error
@@ -227,35 +221,7 @@ func (s *WorkloadService) BuildFullRunConfig(
 			if req.ProxyPort == 0 && md.ProxyPort > 0 {
 				registryProxyPort = md.ProxyPort
 			}
-			if md.OAuthConfig != nil {
-				resource := req.OAuthConfig.Resource
-				if resource == "" {
-					resource = md.OAuthConfig.Resource
-				}
-				if resource == "" && md.URL != "" {
-					resource = remote.DefaultResourceIndicator(md.URL)
-				}
-				remoteAuthConfig = &remote.Config{
-					ClientID:     req.OAuthConfig.ClientID,
-					Scopes:       md.OAuthConfig.Scopes,
-					CallbackPort: md.OAuthConfig.CallbackPort,
-					Issuer:       md.OAuthConfig.Issuer,
-					AuthorizeURL: md.OAuthConfig.AuthorizeURL,
-					TokenURL:     md.OAuthConfig.TokenURL,
-					UsePKCE:      md.OAuthConfig.UsePKCE,
-					Resource:     resource,
-					OAuthParams:  md.OAuthConfig.OAuthParams,
-					Headers:      md.Headers,
-					EnvVars:      md.EnvVars,
-				}
-				// Apply user-provided secrets on top of registry config
-				if req.OAuthConfig.ClientSecret != nil {
-					remoteAuthConfig.ClientSecret = req.OAuthConfig.ClientSecret.ToCLIString()
-				}
-				if req.OAuthConfig.BearerToken != nil {
-					remoteAuthConfig.BearerToken = req.OAuthConfig.BearerToken.ToCLIString()
-				}
-			}
+			remoteAuthConfig = buildRemoteAuthConfigFromMetadata(req, md)
 		}
 	}
 
@@ -316,41 +282,7 @@ func (s *WorkloadService) BuildFullRunConfig(
 			if req.ProxyPort == 0 && remoteServerMetadata.ProxyPort > 0 {
 				registryProxyPort = remoteServerMetadata.ProxyPort
 			}
-
-			if remoteServerMetadata.OAuthConfig != nil {
-				// Default resource: user-provided > registry metadata > derived from remote URL
-				resource := req.OAuthConfig.Resource
-				if resource == "" {
-					resource = remoteServerMetadata.OAuthConfig.Resource
-				}
-				if resource == "" && remoteServerMetadata.URL != "" {
-					resource = remote.DefaultResourceIndicator(remoteServerMetadata.URL)
-				}
-
-				remoteAuthConfig = &remote.Config{
-					ClientID:     req.OAuthConfig.ClientID,
-					Scopes:       remoteServerMetadata.OAuthConfig.Scopes,
-					CallbackPort: remoteServerMetadata.OAuthConfig.CallbackPort,
-					Issuer:       remoteServerMetadata.OAuthConfig.Issuer,
-					AuthorizeURL: remoteServerMetadata.OAuthConfig.AuthorizeURL,
-					TokenURL:     remoteServerMetadata.OAuthConfig.TokenURL,
-					UsePKCE:      remoteServerMetadata.OAuthConfig.UsePKCE,
-					Resource:     resource,
-					OAuthParams:  remoteServerMetadata.OAuthConfig.OAuthParams,
-					Headers:      remoteServerMetadata.Headers,
-					EnvVars:      remoteServerMetadata.EnvVars,
-				}
-
-				// Store the client secret in CLI format if provided
-				if req.OAuthConfig.ClientSecret != nil {
-					remoteAuthConfig.ClientSecret = req.OAuthConfig.ClientSecret.ToCLIString()
-				}
-
-				// Store the bearer token in CLI format if provided
-				if req.OAuthConfig.BearerToken != nil {
-					remoteAuthConfig.BearerToken = req.OAuthConfig.BearerToken.ToCLIString()
-				}
-			}
+			remoteAuthConfig = buildRemoteAuthConfigFromMetadata(req, remoteServerMetadata)
 		}
 		// Handle server metadata - API only supports container servers.
 		// Use type assertion with nil check to guard against typed nil pointers.
@@ -480,6 +412,46 @@ func (s *WorkloadService) BuildFullRunConfig(
 	}
 
 	return runConfig, nil
+}
+
+// buildRemoteAuthConfigFromMetadata builds a remote.Config from registry
+// RemoteServerMetadata, layering user-provided secrets (ClientSecret,
+// BearerToken) and an optional user-provided Resource on top. Returns nil
+// if the metadata has no OAuthConfig.
+func buildRemoteAuthConfigFromMetadata(req *createRequest, md *regtypes.RemoteServerMetadata) *remote.Config {
+	if md.OAuthConfig == nil {
+		return nil
+	}
+
+	// Default resource: user-provided > registry metadata > derived from remote URL
+	resource := req.OAuthConfig.Resource
+	if resource == "" {
+		resource = md.OAuthConfig.Resource
+	}
+	if resource == "" && md.URL != "" {
+		resource = remote.DefaultResourceIndicator(md.URL)
+	}
+
+	cfg := &remote.Config{
+		ClientID:     req.OAuthConfig.ClientID,
+		Scopes:       md.OAuthConfig.Scopes,
+		CallbackPort: md.OAuthConfig.CallbackPort,
+		Issuer:       md.OAuthConfig.Issuer,
+		AuthorizeURL: md.OAuthConfig.AuthorizeURL,
+		TokenURL:     md.OAuthConfig.TokenURL,
+		UsePKCE:      md.OAuthConfig.UsePKCE,
+		Resource:     resource,
+		OAuthParams:  md.OAuthConfig.OAuthParams,
+		Headers:      md.Headers,
+		EnvVars:      md.EnvVars,
+	}
+	if req.OAuthConfig.ClientSecret != nil {
+		cfg.ClientSecret = req.OAuthConfig.ClientSecret.ToCLIString()
+	}
+	if req.OAuthConfig.BearerToken != nil {
+		cfg.BearerToken = req.OAuthConfig.BearerToken.ToCLIString()
+	}
+	return cfg
 }
 
 // createRequestToRemoteAuthConfig converts API request to runner RemoteAuthConfig

--- a/pkg/api/v1/workload_service.go
+++ b/pkg/api/v1/workload_service.go
@@ -8,11 +8,13 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"strings"
 	"time"
 
 	nameref "github.com/google/go-containerregistry/pkg/name"
 
+	"github.com/stacklok/toolhive-core/httperr"
 	regtypes "github.com/stacklok/toolhive-core/registry/types"
 	groupval "github.com/stacklok/toolhive-core/validation/group"
 	httpval "github.com/stacklok/toolhive-core/validation/http"
@@ -145,7 +147,10 @@ func (s *WorkloadService) BuildFullRunConfig(
 ) (*runner.RunConfig, error) {
 	// Validate registry+server pairing first (guard clause)
 	if (req.Registry != "" && req.Server == "") || (req.Registry == "" && req.Server != "") {
-		return nil, fmt.Errorf("both registry and server must be specified together")
+		return nil, httperr.WithCode(
+			fmt.Errorf("both registry and server must be specified together"),
+			http.StatusBadRequest,
+		)
 	}
 	// If registry+server specified, resolve from registry and fill defaults.
 	// The returned metadata is assigned to the local variables so the rest of
@@ -643,7 +648,10 @@ func (s *WorkloadService) GetWorkloadNamesFromRequest(ctx context.Context, req b
 func (s *WorkloadService) resolveRegistryServer(req *createRequest) (regtypes.ServerMetadata, error) {
 	// Only "default" registry is currently supported.
 	if req.Registry != "default" {
-		return nil, fmt.Errorf("unknown registry %q; only \"default\" is currently supported", req.Registry)
+		return nil, httperr.WithCode(
+			fmt.Errorf("unknown registry %q; only \"default\" is currently supported", req.Registry),
+			http.StatusBadRequest,
+		)
 	}
 
 	provider, err := registry.GetDefaultProviderWithConfig(
@@ -651,12 +659,24 @@ func (s *WorkloadService) resolveRegistryServer(req *createRequest) (regtypes.Se
 		registry.WithInteractive(false),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get registry provider: %w", err)
+		return nil, httperr.WithCode(
+			fmt.Errorf("failed to get registry provider: %w", err),
+			http.StatusServiceUnavailable,
+		)
 	}
 
 	metadata, err := provider.GetServer(req.Server)
 	if err != nil {
-		return nil, fmt.Errorf("server %q not found in registry: %w", req.Server, err)
+		if errors.Is(err, registry.ErrServerNotFound) {
+			return nil, httperr.WithCode(
+				fmt.Errorf("server %q not found in registry: %w", req.Server, err),
+				http.StatusNotFound,
+			)
+		}
+		return nil, httperr.WithCode(
+			fmt.Errorf("failed to look up server %q in registry: %w", req.Server, err),
+			http.StatusServiceUnavailable,
+		)
 	}
 
 	applyRegistryDefaults(req, metadata)

--- a/pkg/api/v1/workload_service.go
+++ b/pkg/api/v1/workload_service.go
@@ -143,14 +143,15 @@ func (s *WorkloadService) UpdateWorkloadFromRequest(ctx context.Context, name st
 func (s *WorkloadService) BuildFullRunConfig(
 	ctx context.Context, req *createRequest, existingPort int,
 ) (*runner.RunConfig, error) {
+	// Validate registry+server pairing first (guard clause)
+	if (req.Registry != "" && req.Server == "") || (req.Registry == "" && req.Server != "") {
+		return nil, fmt.Errorf("both registry and server must be specified together")
+	}
 	// If registry+server specified, resolve from registry and fill defaults
 	if req.Registry != "" && req.Server != "" {
 		if err := resolveRegistryServer(req); err != nil {
 			return nil, fmt.Errorf("failed to resolve server from registry: %w", err)
 		}
-	}
-	if (req.Registry != "" && req.Server == "") || (req.Registry == "" && req.Server != "") {
-		return nil, fmt.Errorf("both registry and server must be specified together")
 	}
 
 	// Default proxy mode to streamable-http if not specified (SSE is deprecated)
@@ -572,6 +573,11 @@ func (s *WorkloadService) GetWorkloadNamesFromRequest(ctx context.Context, req b
 // resolveRegistryServer resolves a server from the registry and fills in
 // default values on the request. User-provided fields are not overwritten.
 func resolveRegistryServer(req *createRequest) error {
+	// Only "default" registry is currently supported.
+	if req.Registry != "default" {
+		return fmt.Errorf("unknown registry %q; only \"default\" is currently supported", req.Registry)
+	}
+
 	provider, err := registry.GetDefaultProviderWithConfig(
 		config.NewProvider(),
 		registry.WithInteractive(false),

--- a/pkg/api/v1/workload_service_test.go
+++ b/pkg/api/v1/workload_service_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stacklok/toolhive/pkg/container/templates"
 	groupsmocks "github.com/stacklok/toolhive/pkg/groups/mocks"
 	"github.com/stacklok/toolhive/pkg/runner"
+	"github.com/stacklok/toolhive/pkg/secrets"
 	workloadsmocks "github.com/stacklok/toolhive/pkg/workloads/mocks"
 )
 
@@ -620,6 +621,132 @@ func TestApplyRemoteDefaults(t *testing.T) {
 			assert.Len(t, tt.req.Headers, tt.wantHeaders)
 		})
 	}
+}
+
+func TestBuildRemoteAuthConfigFromMetadata(t *testing.T) {
+	t.Parallel()
+
+	baseMetadata := func() *regtypes.RemoteServerMetadata {
+		return &regtypes.RemoteServerMetadata{
+			URL:       "https://mcp.example.com/mcp",
+			ProxyPort: 4444,
+			Headers:   []*regtypes.Header{{Name: "X-API-Key"}},
+			EnvVars:   []*regtypes.EnvVar{{Name: "REGION", Default: "us-east-1"}},
+			OAuthConfig: &regtypes.OAuthConfig{
+				Issuer:       "https://issuer.example.com",
+				AuthorizeURL: "https://issuer.example.com/authorize",
+				TokenURL:     "https://issuer.example.com/token",
+				Scopes:       []string{"openid", "profile"},
+				UsePKCE:      true,
+				CallbackPort: 1234,
+				OAuthParams:  map[string]string{"prompt": "consent"},
+				Resource:     "https://resource.example.com",
+			},
+		}
+	}
+
+	t.Run("returns nil when metadata has no OAuthConfig", func(t *testing.T) {
+		t.Parallel()
+
+		md := baseMetadata()
+		md.OAuthConfig = nil
+
+		cfg := buildRemoteAuthConfigFromMetadata(&createRequest{}, md)
+
+		assert.Nil(t, cfg)
+	})
+
+	t.Run("populates all OAuth fields from metadata", func(t *testing.T) {
+		t.Parallel()
+
+		req := &createRequest{
+			updateRequest: updateRequest{
+				OAuthConfig: remoteOAuthConfig{ClientID: "user-client-id"},
+			},
+		}
+
+		cfg := buildRemoteAuthConfigFromMetadata(req, baseMetadata())
+
+		require.NotNil(t, cfg)
+		assert.Equal(t, "user-client-id", cfg.ClientID)
+		assert.Equal(t, []string{"openid", "profile"}, cfg.Scopes)
+		assert.Equal(t, 1234, cfg.CallbackPort)
+		assert.Equal(t, "https://issuer.example.com", cfg.Issuer)
+		assert.Equal(t, "https://issuer.example.com/authorize", cfg.AuthorizeURL)
+		assert.Equal(t, "https://issuer.example.com/token", cfg.TokenURL)
+		assert.True(t, cfg.UsePKCE)
+		assert.Equal(t, map[string]string{"prompt": "consent"}, cfg.OAuthParams)
+		assert.Len(t, cfg.Headers, 1)
+		assert.Len(t, cfg.EnvVars, 1)
+	})
+
+	t.Run("resource precedence: user value wins over metadata and URL", func(t *testing.T) {
+		t.Parallel()
+
+		req := &createRequest{
+			updateRequest: updateRequest{
+				OAuthConfig: remoteOAuthConfig{Resource: "https://user.example.com"},
+			},
+		}
+
+		cfg := buildRemoteAuthConfigFromMetadata(req, baseMetadata())
+
+		require.NotNil(t, cfg)
+		assert.Equal(t, "https://user.example.com", cfg.Resource)
+	})
+
+	t.Run("resource precedence: metadata wins over URL when user unset", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := buildRemoteAuthConfigFromMetadata(&createRequest{}, baseMetadata())
+
+		require.NotNil(t, cfg)
+		assert.Equal(t, "https://resource.example.com", cfg.Resource)
+	})
+
+	t.Run("resource derived from URL when both user and metadata unset", func(t *testing.T) {
+		t.Parallel()
+
+		md := baseMetadata()
+		md.OAuthConfig.Resource = ""
+
+		cfg := buildRemoteAuthConfigFromMetadata(&createRequest{}, md)
+
+		require.NotNil(t, cfg)
+		assert.NotEmpty(t, cfg.Resource, "resource should be derived from md.URL")
+	})
+
+	t.Run("user ClientSecret is applied in CLI string format", func(t *testing.T) {
+		t.Parallel()
+
+		secret := &secrets.SecretParameter{Name: "oauth-secret", Target: "CLIENT_SECRET"}
+		req := &createRequest{
+			updateRequest: updateRequest{
+				OAuthConfig: remoteOAuthConfig{ClientSecret: secret},
+			},
+		}
+
+		cfg := buildRemoteAuthConfigFromMetadata(req, baseMetadata())
+
+		require.NotNil(t, cfg)
+		assert.Equal(t, "oauth-secret,target=CLIENT_SECRET", cfg.ClientSecret)
+	})
+
+	t.Run("user BearerToken is applied in CLI string format", func(t *testing.T) {
+		t.Parallel()
+
+		token := &secrets.SecretParameter{Name: "bearer", Target: "TOKEN"}
+		req := &createRequest{
+			updateRequest: updateRequest{
+				OAuthConfig: remoteOAuthConfig{BearerToken: token},
+			},
+		}
+
+		cfg := buildRemoteAuthConfigFromMetadata(req, baseMetadata())
+
+		require.NotNil(t, cfg)
+		assert.Equal(t, "bearer,target=TOKEN", cfg.BearerToken)
+	})
 }
 
 func TestApplyRegistryDefaults(t *testing.T) {

--- a/pkg/api/v1/workload_service_test.go
+++ b/pkg/api/v1/workload_service_test.go
@@ -6,6 +6,7 @@ package v1
 import (
 	"context"
 	"errors"
+	"net/http"
 	"os"
 	"testing"
 
@@ -13,6 +14,9 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	"github.com/stacklok/toolhive-core/httperr"
+	"github.com/stacklok/toolhive-core/permissions"
+	regtypes "github.com/stacklok/toolhive-core/registry/types"
 	"github.com/stacklok/toolhive/pkg/config"
 	"github.com/stacklok/toolhive/pkg/container/templates"
 	groupsmocks "github.com/stacklok/toolhive/pkg/groups/mocks"
@@ -426,4 +430,294 @@ func TestCreateWorkloadFromRequest_PolicyGateDenied(t *testing.T) {
 
 	require.Error(t, err)
 	require.ErrorIs(t, err, sentinel)
+}
+
+func TestApplyImageDefaults(t *testing.T) {
+	t.Parallel()
+
+	permProfile := &permissions.Profile{}
+
+	baseMetadata := func() *regtypes.ImageMetadata {
+		return &regtypes.ImageMetadata{
+			Image:       "ghcr.io/stacklok/fetch:latest",
+			TargetPort:  8080,
+			Args:        []string{"--listen", "0.0.0.0"},
+			Permissions: permProfile,
+			EnvVars: []*regtypes.EnvVar{
+				{Name: "LOG_LEVEL", Default: "info"},
+				{Name: "REGION", Default: "us-east-1"},
+				{Name: "API_KEY"}, // no default — should not be inserted
+			},
+		}
+	}
+
+	tests := []struct {
+		name        string
+		req         *createRequest
+		wantImage   string
+		wantTarget  int
+		wantArgs    []string
+		wantPermSet bool
+		wantEnvVars map[string]string
+	}{
+		{
+			name:        "empty request fills all defaults",
+			req:         &createRequest{},
+			wantImage:   "ghcr.io/stacklok/fetch:latest",
+			wantTarget:  8080,
+			wantArgs:    []string{"--listen", "0.0.0.0"},
+			wantPermSet: true,
+			wantEnvVars: map[string]string{
+				"LOG_LEVEL": "info",
+				"REGION":    "us-east-1",
+			},
+		},
+		{
+			name: "user image takes precedence over registry image",
+			req: &createRequest{
+				updateRequest: updateRequest{Image: "my-registry/custom:v1"},
+			},
+			wantImage:   "my-registry/custom:v1",
+			wantTarget:  8080,
+			wantArgs:    []string{"--listen", "0.0.0.0"},
+			wantPermSet: true,
+			wantEnvVars: map[string]string{
+				"LOG_LEVEL": "info",
+				"REGION":    "us-east-1",
+			},
+		},
+		{
+			name: "user target port takes precedence",
+			req: &createRequest{
+				updateRequest: updateRequest{TargetPort: 9090},
+			},
+			wantImage:   "ghcr.io/stacklok/fetch:latest",
+			wantTarget:  9090,
+			wantArgs:    []string{"--listen", "0.0.0.0"},
+			wantPermSet: true,
+			wantEnvVars: map[string]string{
+				"LOG_LEVEL": "info",
+				"REGION":    "us-east-1",
+			},
+		},
+		{
+			name: "user cmd arguments take precedence",
+			req: &createRequest{
+				updateRequest: updateRequest{CmdArguments: []string{"--debug"}},
+			},
+			wantImage:   "ghcr.io/stacklok/fetch:latest",
+			wantTarget:  8080,
+			wantArgs:    []string{"--debug"},
+			wantPermSet: true,
+			wantEnvVars: map[string]string{
+				"LOG_LEVEL": "info",
+				"REGION":    "us-east-1",
+			},
+		},
+		{
+			name: "user env var override preserved, other defaults filled",
+			req: &createRequest{
+				updateRequest: updateRequest{
+					EnvVars: map[string]string{"LOG_LEVEL": "debug"},
+				},
+			},
+			wantImage:   "ghcr.io/stacklok/fetch:latest",
+			wantTarget:  8080,
+			wantArgs:    []string{"--listen", "0.0.0.0"},
+			wantPermSet: true,
+			wantEnvVars: map[string]string{
+				"LOG_LEVEL": "debug",
+				"REGION":    "us-east-1",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			applyImageDefaults(tt.req, baseMetadata())
+
+			assert.Equal(t, tt.wantImage, tt.req.Image)
+			assert.Equal(t, tt.wantTarget, tt.req.TargetPort)
+			assert.Equal(t, tt.wantArgs, tt.req.CmdArguments)
+			if tt.wantPermSet {
+				assert.NotNil(t, tt.req.PermissionProfile)
+			}
+			assert.Equal(t, tt.wantEnvVars, tt.req.EnvVars)
+		})
+	}
+}
+
+func TestApplyImageDefaults_UserPermissionProfilePreserved(t *testing.T) {
+	t.Parallel()
+
+	userProfile := &permissions.Profile{Name: "user-provided"}
+	registryProfile := &permissions.Profile{Name: "registry-default"}
+
+	req := &createRequest{
+		updateRequest: updateRequest{PermissionProfile: userProfile},
+	}
+	md := &regtypes.ImageMetadata{Permissions: registryProfile}
+
+	applyImageDefaults(req, md)
+
+	assert.Same(t, userProfile, req.PermissionProfile,
+		"user-provided permission profile must not be replaced by the registry default")
+}
+
+func TestApplyRemoteDefaults(t *testing.T) {
+	t.Parallel()
+
+	baseMetadata := func() *regtypes.RemoteServerMetadata {
+		return &regtypes.RemoteServerMetadata{
+			URL: "https://mcp.example.com/mcp",
+			Headers: []*regtypes.Header{
+				{Name: "X-API-Key"},
+			},
+		}
+	}
+
+	tests := []struct {
+		name        string
+		req         *createRequest
+		wantURL     string
+		wantHeaders int
+	}{
+		{
+			name:        "empty request fills URL and Headers",
+			req:         &createRequest{},
+			wantURL:     "https://mcp.example.com/mcp",
+			wantHeaders: 1,
+		},
+		{
+			name: "user URL takes precedence",
+			req: &createRequest{
+				updateRequest: updateRequest{URL: "https://override.example.com/mcp"},
+			},
+			wantURL:     "https://override.example.com/mcp",
+			wantHeaders: 1,
+		},
+		{
+			name: "user headers take precedence over registry headers",
+			req: &createRequest{
+				updateRequest: updateRequest{
+					Headers: []*regtypes.Header{{Name: "Authorization"}},
+				},
+			},
+			wantURL:     "https://mcp.example.com/mcp",
+			wantHeaders: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			applyRemoteDefaults(tt.req, baseMetadata())
+
+			assert.Equal(t, tt.wantURL, tt.req.URL)
+			assert.Len(t, tt.req.Headers, tt.wantHeaders)
+		})
+	}
+}
+
+func TestApplyRegistryDefaults(t *testing.T) {
+	t.Parallel()
+
+	t.Run("fills transport and name from metadata", func(t *testing.T) {
+		t.Parallel()
+
+		req := &createRequest{}
+		md := &regtypes.ImageMetadata{
+			BaseServerMetadata: regtypes.BaseServerMetadata{
+				Name:      "io.github.stacklok/fetch",
+				Transport: "stdio",
+			},
+			Image: "ghcr.io/stacklok/fetch:latest",
+		}
+
+		applyRegistryDefaults(req, md)
+
+		assert.Equal(t, "stdio", req.Transport)
+		assert.Equal(t, "io.github.stacklok/fetch", req.Name)
+		assert.Equal(t, "ghcr.io/stacklok/fetch:latest", req.Image)
+	})
+
+	t.Run("user transport and name take precedence", func(t *testing.T) {
+		t.Parallel()
+
+		req := &createRequest{
+			Name: "my-workload",
+			updateRequest: updateRequest{
+				Transport: "streamable-http",
+			},
+		}
+		md := &regtypes.ImageMetadata{
+			BaseServerMetadata: regtypes.BaseServerMetadata{
+				Name:      "io.github.stacklok/fetch",
+				Transport: "stdio",
+			},
+		}
+
+		applyRegistryDefaults(req, md)
+
+		assert.Equal(t, "streamable-http", req.Transport)
+		assert.Equal(t, "my-workload", req.Name)
+	})
+
+	t.Run("dispatches to remote defaults for RemoteServerMetadata", func(t *testing.T) {
+		t.Parallel()
+
+		req := &createRequest{}
+		md := &regtypes.RemoteServerMetadata{
+			BaseServerMetadata: regtypes.BaseServerMetadata{
+				Name:      "remote-server",
+				Transport: "streamable-http",
+			},
+			URL: "https://remote.example.com/mcp",
+		}
+
+		applyRegistryDefaults(req, md)
+
+		assert.Equal(t, "streamable-http", req.Transport)
+		assert.Equal(t, "remote-server", req.Name)
+		assert.Equal(t, "https://remote.example.com/mcp", req.URL)
+	})
+
+	t.Run("dispatches to image defaults for ImageMetadata", func(t *testing.T) {
+		t.Parallel()
+
+		req := &createRequest{}
+		md := &regtypes.ImageMetadata{
+			BaseServerMetadata: regtypes.BaseServerMetadata{
+				Transport: "stdio",
+			},
+			Image:      "ghcr.io/stacklok/fetch:latest",
+			TargetPort: 8080,
+		}
+
+		applyRegistryDefaults(req, md)
+
+		assert.Equal(t, "ghcr.io/stacklok/fetch:latest", req.Image)
+		assert.Equal(t, 8080, req.TargetPort)
+	})
+}
+
+func TestWorkloadService_ResolveRegistryServer_UnknownRegistry(t *testing.T) {
+	t.Parallel()
+
+	service := &WorkloadService{configProvider: config.NewDefaultProvider()}
+
+	req := &createRequest{
+		Registry: "nonexistent",
+		Server:   "some-server",
+	}
+
+	metadata, err := service.resolveRegistryServer(req)
+
+	require.Error(t, err)
+	assert.Nil(t, metadata)
+	assert.Equal(t, http.StatusBadRequest, httperr.Code(err))
+	assert.Contains(t, err.Error(), `unknown registry "nonexistent"`)
 }

--- a/pkg/api/v1/workload_types.go
+++ b/pkg/api/v1/workload_types.go
@@ -154,6 +154,13 @@ type createRequest struct {
 	updateRequest
 	// Name of the workload
 	Name string `json:"name"`
+	// Registry is the optional registry name to resolve the server from (e.g. "default").
+	Registry string `json:"registry,omitempty"`
+	// Server is the optional server name in the registry (e.g. "io.github.stacklok/fetch").
+	// When both Registry and Server are set, thv resolves the server metadata
+	// server-side, filling in image, transport, env vars, permissions, etc.
+	// User-provided fields always override registry defaults.
+	Server string `json:"server,omitempty"`
 }
 
 // oidcOptions represents OIDC configuration options

--- a/pkg/api/v1/workloads.go
+++ b/pkg/api/v1/workloads.go
@@ -287,10 +287,10 @@ func (s *WorkloadRoutes) createWorkload(w http.ResponseWriter, r *http.Request) 
 		)
 	}
 
-	// Validate that image or URL is provided
-	if req.Image == "" && req.URL == "" {
+	// Validate that image, URL, or registry+server is provided
+	if req.Image == "" && req.URL == "" && (req.Registry == "" || req.Server == "") {
 		return httperr.WithCode(
-			fmt.Errorf("either 'image' or 'url' field is required"),
+			fmt.Errorf("either 'image', 'url', or 'registry'+'server' fields are required"),
 			http.StatusBadRequest,
 		)
 	}

--- a/pkg/api/v1/workloads.go
+++ b/pkg/api/v1/workloads.go
@@ -287,8 +287,15 @@ func (s *WorkloadRoutes) createWorkload(w http.ResponseWriter, r *http.Request) 
 		)
 	}
 
-	// Validate that image, URL, or registry+server is provided
-	if req.Image == "" && req.URL == "" && (req.Registry == "" || req.Server == "") {
+	// Validate that image, URL, or registry+server is provided.
+	// Check partial registry+server first for a more specific error message.
+	if (req.Registry != "" && req.Server == "") || (req.Registry == "" && req.Server != "") {
+		return httperr.WithCode(
+			fmt.Errorf("both 'registry' and 'server' must be specified together"),
+			http.StatusBadRequest,
+		)
+	}
+	if req.Image == "" && req.URL == "" && req.Registry == "" {
 		return httperr.WithCode(
 			fmt.Errorf("either 'image', 'url', or 'registry'+'server' fields are required"),
 			http.StatusBadRequest,

--- a/pkg/runner/retriever/retriever.go
+++ b/pkg/runner/retriever/retriever.go
@@ -117,7 +117,7 @@ func ResolveMCPServer(
 	}
 
 	// Verify the image against the expected provenance info (if applicable)
-	if err := verifyImage(imageToUse, imageMetadata, verificationType); err != nil {
+	if err := VerifyImage(imageToUse, imageMetadata, verificationType); err != nil {
 		return "", nil, err
 	}
 
@@ -341,8 +341,10 @@ func resolveCACertPath(flagValue string) string {
 	return ""
 }
 
-// verifyImage verifies the image using the specified verification setting (warn, enabled, or disabled)
-func verifyImage(image string, server *types.ImageMetadata, verifySetting string) error {
+// VerifyImage checks the provenance/signature of a container image.
+// The verifySetting controls behavior: VerifyImageDisabled skips checks,
+// VerifyImageWarn logs warnings but continues, VerifyImageEnabled fails on issues.
+func VerifyImage(image string, server *types.ImageMetadata, verifySetting string) error {
 	switch verifySetting {
 	case VerifyImageDisabled:
 		slog.Warn("Image verification is disabled")


### PR DESCRIPTION
## Summary

- Studio currently does a multi-step flow to run a registry server: GET server metadata → extract fields client-side → POST /api/v1beta/workloads with all fields. This is fragile and requires the FE to understand the full metadata structure.
- Add optional `registry` and `server` fields to the workload creation API so clients can create workloads with a single POST. thv resolves the server from the registry and fills in image, transport, env vars, permissions, etc. server-side. User-provided fields always override registry defaults.

Fixes #4870

## Type of change

- [x] New feature

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)

## Changes

| File | Change |
|------|--------|
| `pkg/api/v1/workload_types.go` | Add `registry` and `server` fields to `createRequest` |
| `pkg/api/v1/workload_service.go` | Registry resolution + defaults merging helpers |

## Does this introduce a user-facing change?

Yes — `POST /api/v1beta/workloads` now accepts optional `registry` and `server` fields:
```json
{"registry": "default", "server": "io.github.stacklok/fetch", "env_vars": {"API_KEY": "..."}}
```

Generated with [Claude Code](https://claude.com/claude-code)