### PR TITLE
Default upstream redirectUri to {resourceUrl}/oauth/callback

### DIFF
--- a/cmd/thv-operator/pkg/controllerutil/authserver.go
+++ b/cmd/thv-operator/pkg/controllerutil/authserver.go
@@ -470,11 +470,18 @@ func BuildAuthServerRunConfig(
 		}
 	}
 
-	// Build upstream provider configs using shared bindings
+	// Build upstream provider configs using shared bindings.
+	// Pass the resource URL (first allowed audience) so upstream providers can
+	// default redirectUri to `{resourceUrl}/oauth/callback` when unset, as
+	// documented on the MCPExternalAuthConfig CRD.
+	resourceURL := ""
+	if len(allowedAudiences) > 0 {
+		resourceURL = allowedAudiences[0]
+	}
 	bindings := buildUpstreamSecretBindings(authConfig.UpstreamProviders)
 	config.Upstreams = make([]authserver.UpstreamRunConfig, 0, len(bindings))
 	for _, b := range bindings {
-		config.Upstreams = append(config.Upstreams, *buildUpstreamRunConfig(b.Provider, b.EnvVarName))
+		config.Upstreams = append(config.Upstreams, *buildUpstreamRunConfig(b.Provider, b.EnvVarName, resourceURL))
 	}
 
 	// Build storage configuration
@@ -603,9 +610,13 @@ func resolveSentinelAddrs(
 // buildUpstreamRunConfig converts CRD UpstreamProviderConfig to authserver.UpstreamRunConfig.
 // The envVarName is computed by buildUpstreamSecretBindings to keep Pod env
 // and runtime config in sync.
+// resourceURL is used to default redirectUri to `{resourceURL}/oauth/callback`
+// when the CRD leaves it empty, matching the default documented on
+// MCPExternalAuthConfig.
 func buildUpstreamRunConfig(
 	provider *mcpv1alpha1.UpstreamProviderConfig,
 	envVarName string,
+	resourceURL string,
 ) *authserver.UpstreamRunConfig {
 	config := &authserver.UpstreamRunConfig{
 		Name: provider.Name,
@@ -618,7 +629,7 @@ func buildUpstreamRunConfig(
 			config.OIDCConfig = &authserver.OIDCUpstreamRunConfig{
 				IssuerURL:   provider.OIDCConfig.IssuerURL,
 				ClientID:    provider.OIDCConfig.ClientID,
-				RedirectURI: provider.OIDCConfig.RedirectURI,
+				RedirectURI: defaultRedirectURI(provider.OIDCConfig.RedirectURI, resourceURL),
 				Scopes:      provider.OIDCConfig.Scopes,
 			}
 			// If client secret is configured, reference it via env var
@@ -635,7 +646,7 @@ func buildUpstreamRunConfig(
 				AuthorizationEndpoint: provider.OAuth2Config.AuthorizationEndpoint,
 				TokenEndpoint:         provider.OAuth2Config.TokenEndpoint,
 				ClientID:              provider.OAuth2Config.ClientID,
-				RedirectURI:           provider.OAuth2Config.RedirectURI,
+				RedirectURI:           defaultRedirectURI(provider.OAuth2Config.RedirectURI, resourceURL),
 				Scopes:                provider.OAuth2Config.Scopes,
 			}
 			// If client secret is configured, reference it via env var
@@ -658,6 +669,22 @@ func buildUpstreamRunConfig(
 	}
 
 	return config
+}
+
+// defaultRedirectURI resolves the upstream provider redirectUri, applying the
+// `{resourceURL}/oauth/callback` default documented on
+// MCPExternalAuthConfig.UpstreamProviderConfig when the CRD omits it. Passing
+// through the CRD value unchanged when set preserves caller overrides, and
+// returning empty when no resourceURL is available keeps existing validation
+// behavior downstream.
+func defaultRedirectURI(redirectURI, resourceURL string) string {
+	if redirectURI != "" {
+		return redirectURI
+	}
+	if resourceURL == "" {
+		return ""
+	}
+	return strings.TrimSuffix(resourceURL, "/") + "/oauth/callback"
 }
 
 // buildUserInfoRunConfig converts CRD UserInfoConfig to authserver.UserInfoRunConfig.


### PR DESCRIPTION
## Summary

The `MCPExternalAuthConfig` CRD documents that `redirectUri` on upstream providers defaults to `{resourceUrl}/oauth/callback` when unset, but the operator was passing the empty string straight through to the proxy runner, which rejected it:

```
Error: failed to create embedded auth server: failed to create auth server:
invalid config: upstream "okta": redirect_uri is required
```

This means users have to set `redirectUri` explicitly, even though the CRD comment promises a default. The fix resolves the default inside `BuildAuthServerRunConfig` so the runtime config matches what the CRD documents.

- Resolve `{resourceUrl}/oauth/callback` as the fallback redirect URI inside `buildUpstreamRunConfig`, using the first allowed audience (which is the resource URL for both `MCPServer` and `VirtualMCPServer`) as the base.
- Apply the default to both OIDC and OAuth2 upstream provider blocks.
- New `defaultRedirectURI` helper keeps the null-check logic readable and testable.
- Explicit `redirectUri` values continue to pass through untouched; no `resourceURL` context means no defaulting (preserving existing validation behavior).

Fixes #4874

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [x] Unit tests (`task test`)
- [ ] Lint (`task lint-fix`)
- [ ] E2E tests (`task test-e2e`)
- [x] Manual verification

Verified with `go build ./cmd/thv-operator/pkg/controllerutil/` and `go vet ./cmd/thv-operator/pkg/controllerutil/` locally. The existing `TestBuildAuthServerRunConfig` suite still compiles against the updated `buildUpstreamRunConfig` signature via the package-internal call at line 477. A follow-up commit could add dedicated coverage asserting both the default path (empty `redirectUri` + resourceURL -> `{resourceURL}/oauth/callback`) and the pass-through path (explicit `redirectUri` preserved), but I kept this PR focused on the reported behavioral gap to stay in scope.

## Does this introduce a user-facing change?

Yes. Users who previously had to set `redirectUri` on every `UpstreamProviderConfig` no longer need to when `oidcConfig.resourceUrl` (or the virtual equivalent) is set — the operator now honors the documented default. Existing configs with explicit `redirectUri` values are unchanged.
