### PR TITLE
Use scoped secrets provider for registry auth

### DIFF
--- a/pkg/api/v1/registry.go
+++ b/pkg/api/v1/registry.go
@@ -97,7 +97,7 @@ func newSecretsProvider(configProvider config.Provider) (secrets.Provider, error
 	if err != nil {
 		return nil, fmt.Errorf("getting secrets provider type: %w", err)
 	}
-	return secrets.CreateSecretProvider(providerType)
+	return secrets.CreateProvider(providerType, secrets.WithScope(secrets.ScopeRegistry))
 }
 
 // registryAuthLogin handles POST /registry/auth/login.

--- a/pkg/registry/factory.go
+++ b/pkg/registry/factory.go
@@ -143,7 +143,7 @@ func resolveTokenSource(cfg *config.Config, interactive bool) auth.TokenSource {
 		slog.Debug("Secrets provider not available for registry auth token persistence",
 			"error", err)
 	} else {
-		secretsProvider, err = secrets.CreateSecretProvider(providerType)
+		secretsProvider, err = secrets.CreateProvider(providerType, secrets.WithScope(secrets.ScopeRegistry))
 		if err != nil {
 			slog.Warn("Failed to create secrets provider for registry auth, tokens will not be persisted",
 				"error", err)

--- a/pkg/secrets/encrypted.go
+++ b/pkg/secrets/encrypted.go
@@ -82,7 +82,7 @@ func (e *EncryptedManager) DeleteSecret(_ context.Context, name string) error {
 			return err
 		}
 		if _, ok := secrets[name]; !ok {
-			return fmt.Errorf("cannot delete non-existent secret: %s", name)
+			return fmt.Errorf("%w: %s", ErrSecretNotFound, name)
 		}
 		delete(secrets, name)
 		return e.writeFileSecrets(secrets)

--- a/pkg/secrets/encrypted_test.go
+++ b/pkg/secrets/encrypted_test.go
@@ -117,7 +117,7 @@ func TestEncryptedManager_DeleteSecret(t *testing.T) {
 	// Test deleting a non-existent secret
 	err := manager.DeleteSecret(ctx, "non-existent")
 	assert.Error(t, err, "Deleting a non-existent secret should return an error")
-	assert.Contains(t, err.Error(), "cannot delete non-existent", "Error message should indicate the secret does not exist")
+	assert.ErrorIs(t, err, ErrSecretNotFound, "Error should be ErrSecretNotFound for a non-existent secret")
 
 	// Test deleting a secret with an empty name
 	err = manager.DeleteSecret(ctx, "")


### PR DESCRIPTION
## Summary

- `thv registry login` stores tokens under the scoped key `__thv_registry_REGISTRY_OAUTH_<hash>`, but `resolveTokenSource` in the factory and `newSecretsProvider` in the API handler both used the bare `CreateSecretProvider`. The bare provider looks up `REGISTRY_OAUTH_<hash>` directly, finds nothing, and falls back to a new OAuth flow — prompting the browser again even though the user just logged in.
- Switch both call sites to `CreateProvider(..., WithScope(ScopeRegistry))` so token reads go to the scoped namespace, with `ScopedProvider.GetSecret`'s bare-key fallback covering the migration window.
- Fix `EncryptedManager.DeleteSecret` to return the `ErrSecretNotFound` sentinel (matching `GetSecret`) so callers using `IsNotFoundError` handle delete-not-found correctly.

Fixes #4892

## Type of change

- [x] Bug fix

## Test plan

- [x] Manual testing (describe below)

`thv registry login` followed by `thv registry list` no longer re-opens the browser OAuth flow.

Generated with [Claude Code](https://claude.com/claude-code)