### PR TITLE
fix(thv-operator): default upstream redirectUri to {resourceUrl}/oauth/callback

### DIFF
--- a/cmd/thv-operator/pkg/controllerutil/authserver.go
+++ b/cmd/thv-operator/pkg/controllerutil/authserver.go
@@ -407,6 +407,7 @@ func AddEmbeddedAuthServerConfigOptions(
 	embeddedConfig, err := BuildAuthServerRunConfig(
 		namespace, mcpServerName, authServerConfig,
 		[]string{oidcConfig.ResourceURL}, oidcConfig.Scopes,
+		oidcConfig.ResourceURL,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to build embedded auth server config: %w", err)
@@ -430,6 +431,7 @@ func BuildAuthServerRunConfig(
 	authConfig *mcpv1alpha1.EmbeddedAuthServerConfig,
 	allowedAudiences []string,
 	scopesSupported []string,
+	resourceURL string,
 ) (*authserver.RunConfig, error) {
 	config := &authserver.RunConfig{
 		SchemaVersion:                authserver.CurrentSchemaVersion,
@@ -473,8 +475,13 @@ func BuildAuthServerRunConfig(
 	// Build upstream provider configs using shared bindings
 	bindings := buildUpstreamSecretBindings(authConfig.UpstreamProviders)
 	config.Upstreams = make([]authserver.UpstreamRunConfig, 0, len(bindings))
+	// The embedded auth server mounts /oauth/* at the transport root, so the
+	// default upstream callback must hang off the resource's scheme+host, not
+	// its full path. A resourceUrl like "https://gw.example.com/mcp" still
+	// needs the callback at "https://gw.example.com/oauth/callback".
+	defaultRedirectURI := deriveDefaultRedirectURI(resourceURL)
 	for _, b := range bindings {
-		config.Upstreams = append(config.Upstreams, *buildUpstreamRunConfig(b.Provider, b.EnvVarName))
+		config.Upstreams = append(config.Upstreams, *buildUpstreamRunConfig(b.Provider, b.EnvVarName, defaultRedirectURI))
 	}
 
 	// Build storage configuration
@@ -606,10 +613,17 @@ func resolveSentinelAddrs(
 func buildUpstreamRunConfig(
 	provider *mcpv1alpha1.UpstreamProviderConfig,
 	envVarName string,
+	defaultRedirectURI string,
 ) *authserver.UpstreamRunConfig {
 	config := &authserver.UpstreamRunConfig{
 		Name: provider.Name,
 		Type: authserver.UpstreamProviderType(provider.Type),
+	}
+	resolveRedirectURI := func(configured string) string {
+		if configured != "" {
+			return configured
+		}
+		return defaultRedirectURI
 	}
 
 	switch provider.Type {
@@ -618,7 +632,7 @@ func buildUpstreamRunConfig(
 			config.OIDCConfig = &authserver.OIDCUpstreamRunConfig{
 				IssuerURL:   provider.OIDCConfig.IssuerURL,
 				ClientID:    provider.OIDCConfig.ClientID,
-				RedirectURI: provider.OIDCConfig.RedirectURI,
+				RedirectURI: resolveRedirectURI(provider.OIDCConfig.RedirectURI),
 				Scopes:      provider.OIDCConfig.Scopes,
 			}
 			// If client secret is configured, reference it via env var
@@ -635,7 +649,7 @@ func buildUpstreamRunConfig(
 				AuthorizationEndpoint: provider.OAuth2Config.AuthorizationEndpoint,
 				TokenEndpoint:         provider.OAuth2Config.TokenEndpoint,
 				ClientID:              provider.OAuth2Config.ClientID,
-				RedirectURI:           provider.OAuth2Config.RedirectURI,
+				RedirectURI:           resolveRedirectURI(provider.OAuth2Config.RedirectURI),
 				Scopes:                provider.OAuth2Config.Scopes,
 			}
 			// If client secret is configured, reference it via env var
@@ -679,6 +693,24 @@ func buildUserInfoRunConfig(
 	}
 
 	return config
+}
+
+// deriveDefaultRedirectURI builds the fallback upstream callback URL by
+// appending "/oauth/callback" to resourceUrl, matching the default documented
+// on MCPExternalAuthConfig.UpstreamProviderConfig.RedirectURI. Returns ""
+// when resourceUrl is empty -- the caller falls back to the existing
+// "redirect_uri is required" error.
+//
+// Deployments that serve the resource under a path prefix (for example an
+// ingress gateway at "https://gw.example.com/mcp") also mount the auth
+// server's /oauth/* routes under that same prefix, so the literal
+// "{resourceUrl}/oauth/callback" concatenation is the right default across
+// both host-only and path-prefixed resource URLs.
+func deriveDefaultRedirectURI(resourceURL string) string {
+	if resourceURL == "" {
+		return ""
+	}
+	return strings.TrimRight(resourceURL, "/") + "/oauth/callback"
 }
 
 // ValidateAndAddAuthServerRefOptions performs conflict validation between authServerRef
@@ -769,6 +801,7 @@ func AddAuthServerRefOptions(
 	embeddedConfig, err := BuildAuthServerRunConfig(
 		namespace, mcpServerName, authServerConfig,
 		[]string{oidcConfig.ResourceURL}, oidcConfig.Scopes,
+		oidcConfig.ResourceURL,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to build embedded auth server config: %w", err)

--- a/cmd/thv-operator/pkg/controllerutil/authserver_test.go
+++ b/cmd/thv-operator/pkg/controllerutil/authserver_test.go
@@ -807,6 +807,7 @@ func TestBuildAuthServerRunConfig(t *testing.T) {
 				require.NotNil(t, upstream.OIDCConfig)
 				assert.Equal(t, "https://okta.example.com", upstream.OIDCConfig.IssuerURL)
 				assert.Equal(t, "client-id", upstream.OIDCConfig.ClientID)
+				assert.Equal(t, "https://auth.example.com/callback", upstream.OIDCConfig.RedirectURI)
 				assert.Equal(t, []string{"openid", "profile"}, upstream.OIDCConfig.Scopes)
 			},
 		},
@@ -857,12 +858,113 @@ func TestBuildAuthServerRunConfig(t *testing.T) {
 				assert.Equal(t, "https://github.com/login/oauth/authorize",
 					upstream.OAuth2Config.AuthorizationEndpoint)
 				require.NotNil(t, upstream.OAuth2Config.UserInfo)
+				assert.Equal(t, "https://auth.example.com/callback", upstream.OAuth2Config.RedirectURI)
 				assert.Equal(t, "https://api.github.com/user",
 					upstream.OAuth2Config.UserInfo.EndpointURL)
 				assert.Equal(t, "GET", upstream.OAuth2Config.UserInfo.HTTPMethod)
 				require.NotNil(t, upstream.OAuth2Config.UserInfo.FieldMapping)
 				assert.Equal(t, []string{"id", "login"},
 					upstream.OAuth2Config.UserInfo.FieldMapping.SubjectFields)
+			},
+		},
+		{
+			name: "defaults upstream redirect URI from resource URL when empty",
+			authConfig: &mcpv1alpha1.EmbeddedAuthServerConfig{
+				Issuer: "https://auth.example.com",
+				UpstreamProviders: []mcpv1alpha1.UpstreamProviderConfig{
+					{
+						Name: "okta",
+						Type: mcpv1alpha1.UpstreamProviderTypeOIDC,
+						OIDCConfig: &mcpv1alpha1.OIDCUpstreamConfig{
+							IssuerURL: "https://okta.example.com",
+							ClientID:  "client-id",
+						},
+					},
+				},
+			},
+			allowedAudiences: []string{"https://mcp.example.com"},
+			scopesSupported:  defaultScopes,
+			checkFunc: func(t *testing.T, config *authserver.RunConfig) {
+				t.Helper()
+				require.Len(t, config.Upstreams, 1)
+				require.NotNil(t, config.Upstreams[0].OIDCConfig)
+				assert.Equal(t, "https://mcp.example.com/oauth/callback", config.Upstreams[0].OIDCConfig.RedirectURI)
+			},
+		},
+		{
+			name: "defaults redirect URI under path-prefixed resource URL",
+			authConfig: &mcpv1alpha1.EmbeddedAuthServerConfig{
+				Issuer: "https://auth.example.com",
+				UpstreamProviders: []mcpv1alpha1.UpstreamProviderConfig{
+					{
+						Name: "okta",
+						Type: mcpv1alpha1.UpstreamProviderTypeOIDC,
+						OIDCConfig: &mcpv1alpha1.OIDCUpstreamConfig{
+							IssuerURL: "https://okta.example.com",
+							ClientID:  "client-id",
+						},
+					},
+				},
+			},
+			allowedAudiences: []string{"https://mcp-gateway.example.com/mcp"},
+			scopesSupported:  defaultScopes,
+			checkFunc: func(t *testing.T, config *authserver.RunConfig) {
+				t.Helper()
+				require.Len(t, config.Upstreams, 1)
+				require.NotNil(t, config.Upstreams[0].OIDCConfig)
+				// Path-prefixed ingress deployments serve /oauth/* under the
+				// same prefix, so the default preserves the path from resourceUrl.
+				assert.Equal(t, "https://mcp-gateway.example.com/mcp/oauth/callback", config.Upstreams[0].OIDCConfig.RedirectURI)
+			},
+		},
+		{
+			name: "trims trailing slash from resource URL before appending callback",
+			authConfig: &mcpv1alpha1.EmbeddedAuthServerConfig{
+				Issuer: "https://auth.example.com",
+				UpstreamProviders: []mcpv1alpha1.UpstreamProviderConfig{
+					{
+						Name: "okta",
+						Type: mcpv1alpha1.UpstreamProviderTypeOIDC,
+						OIDCConfig: &mcpv1alpha1.OIDCUpstreamConfig{
+							IssuerURL: "https://okta.example.com",
+							ClientID:  "client-id",
+						},
+					},
+				},
+			},
+			allowedAudiences: []string{"https://mcp.example.com/"},
+			scopesSupported:  defaultScopes,
+			checkFunc: func(t *testing.T, config *authserver.RunConfig) {
+				t.Helper()
+				require.Len(t, config.Upstreams, 1)
+				require.NotNil(t, config.Upstreams[0].OIDCConfig)
+				assert.Equal(t, "https://mcp.example.com/oauth/callback", config.Upstreams[0].OIDCConfig.RedirectURI)
+			},
+		},
+		{
+			name: "preserves explicit upstream redirect URI over resource URL default",
+			authConfig: &mcpv1alpha1.EmbeddedAuthServerConfig{
+				Issuer: "https://auth.example.com",
+				UpstreamProviders: []mcpv1alpha1.UpstreamProviderConfig{
+					{
+						Name: "github",
+						Type: mcpv1alpha1.UpstreamProviderTypeOAuth2,
+						OAuth2Config: &mcpv1alpha1.OAuth2UpstreamConfig{
+							AuthorizationEndpoint: "https://github.com/login/oauth/authorize",
+							TokenEndpoint:         "https://github.com/login/oauth/access_token",
+							ClientID:              "client-id",
+							RedirectURI:           "https://configured.example.com/callback",
+						},
+					},
+				},
+			},
+			allowedAudiences: []string{"https://mcp.example.com"},
+			scopesSupported:  defaultScopes,
+			checkFunc: func(t *testing.T, config *authserver.RunConfig) {
+				t.Helper()
+				require.Len(t, config.Upstreams, 1)
+				require.NotNil(t, config.Upstreams[0].OAuth2Config)
+				assert.Equal(t, "https://configured.example.com/callback", config.Upstreams[0].OAuth2Config.RedirectURI)
 			},
 		},
 		{
@@ -973,7 +1075,13 @@ func TestBuildAuthServerRunConfig(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			config, err := BuildAuthServerRunConfig("default", "test-server", tt.authConfig, tt.allowedAudiences, tt.scopesSupported)
+			resourceURL := ""
+			if len(tt.allowedAudiences) > 0 {
+				resourceURL = tt.allowedAudiences[0]
+			}
+			config, err := BuildAuthServerRunConfig(
+				"default", "test-server", tt.authConfig, tt.allowedAudiences, tt.scopesSupported, resourceURL,
+			)
 
 			require.NoError(t, err)
 			require.NotNil(t, config)
@@ -1538,6 +1646,7 @@ func TestBuildAuthServerRunConfig_WithRedisStorage(t *testing.T) {
 		"default", "my-mcp-server", authConfig,
 		[]string{"http://test-server.default.svc.cluster.local:8080"},
 		[]string{"openid"},
+		"http://test-server.default.svc.cluster.local:8080",
 	)
 
 	require.NoError(t, err)

--- a/cmd/thv-operator/pkg/vmcpconfig/converter.go
+++ b/cmd/thv-operator/pkg/vmcpconfig/converter.go
@@ -318,6 +318,7 @@ func (*Converter) convertAuthServerConfig(
 		vmcp.Spec.AuthServerConfig,
 		deriveAllowedAudiences(config),
 		deriveScopesSupported(config),
+		deriveResourceURL(config),
 	)
 }
 
@@ -342,6 +343,16 @@ func deriveAllowedAudiences(config *vmcpconfig.Config) []string {
 		return nil
 	}
 	return []string{resource}
+}
+
+// deriveResourceURL returns the resource URL from the resolved incoming OIDC
+// config. Returns "" when OIDC is not configured -- BuildAuthServerRunConfig
+// treats that as "no default redirect URI to fall back to".
+func deriveResourceURL(config *vmcpconfig.Config) string {
+	if config.IncomingAuth == nil || config.IncomingAuth.OIDC == nil {
+		return ""
+	}
+	return config.IncomingAuth.OIDC.Resource
 }
 
 // deriveScopesSupported returns the scopes from the resolved incoming OIDC config.


### PR DESCRIPTION
## Summary

Per the `MCPExternalAuthConfig.UpstreamProviderConfig.RedirectURI` godoc, the upstream provider `redirectUri` defaults to `{resourceUrl}/oauth/callback` when unset. The operator was copying the empty string from the CRD straight into the runconfig, so the embedded auth server rejected registration with `upstream "okta": redirect_uri is required`.

## Fix

- Thread `resourceUrl` from `AddEmbeddedAuthServerConfigOptions` (both MCPServer and VirtualMCPServer paths) and from `vmcpconfig/converter.go` into `BuildAuthServerRunConfig`.
- New helper `deriveDefaultRedirectURI(resourceURL)` returns `{resourceUrl}/oauth/callback` (with a trailing-slash trim so `"https://host/"` and `"https://host"` produce the same value), or `""` when resourceUrl is empty.
- `buildUpstreamRunConfig` takes a `defaultRedirectURI` argument and resolves it when the CRD's `RedirectURI` is empty. Explicit upstream `RedirectURI` values are preserved.
- Applies to both OIDC and OAuth2 upstream provider types.

## Note on path-prefixed resourceURLs

Codex review flagged an initial implementation that stripped the path from `resourceUrl` before appending `/oauth/callback`. After investigating the ingress/gateway deployment pattern (e.g. `https://mcp-gateway.example.com/mcp`), those deployments mount `/oauth/*` under the same path prefix, so literal `{resourceUrl}/oauth/callback` concatenation is correct in both host-only and path-prefixed cases. Kept the implementation aligned with the CRD godoc contract.

## Changes

- `cmd/thv-operator/pkg/controllerutil/authserver.go`: new `deriveDefaultRedirectURI` helper; extended `BuildAuthServerRunConfig` signature with `resourceURL`; threads the default through `buildUpstreamRunConfig`; both in-file callers now pass `oidcConfig.ResourceURL`.
- `cmd/thv-operator/pkg/vmcpconfig/converter.go`: new `deriveResourceURL` helper mirroring `deriveAllowedAudiences`; `convertAuthServerConfig` passes it through.
- `cmd/thv-operator/pkg/controllerutil/authserver_test.go`: existing `TestBuildAuthServerRunConfig` call sites updated for the new signature. Added cases for:
  - empty upstream `RedirectURI` defaulting to `{resourceUrl}/oauth/callback`
  - explicit upstream `RedirectURI` preserved over the default
  - path-prefixed resourceUrl preserves the path in the default
  - trailing-slash resourceUrl normalized before appending

## Test plan

```
go build ./...
go test ./cmd/thv-operator/pkg/controllerutil/... ./cmd/thv-operator/pkg/vmcpconfig/... -count=1
```

Both pass (323 tests total, +2 new cases for the defaulting behavior).

Fixes #4874
[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
