### PR TITLE
Remove empty parent directories on skill uninstall

### DIFF
--- a/pkg/skills/installer.go
+++ b/pkg/skills/installer.go
@@ -217,6 +217,21 @@ func ValidatePathNoSymlinks(targetDir string) error {
 	return nil
 }
 
+// RemoveEmptyParents walks up from dir, removing each directory that is empty,
+// stopping at stopAt (which is never removed) or when a non-empty directory is
+// encountered. Errors are silently ignored — this is best-effort cleanup.
+func RemoveEmptyParents(dir, stopAt string) {
+	dir = filepath.Clean(dir)
+	stopAt = filepath.Clean(stopAt)
+	for dir != stopAt && filepath.Dir(dir) != dir {
+		if err := os.Remove(dir); err != nil {
+			// Directory is not empty, doesn't exist, or we lack permission — stop.
+			return
+		}
+		dir = filepath.Dir(dir)
+	}
+}
+
 // pathDepth counts the number of non-empty components in an absolute path.
 // For example, "/var/home/user/skills" returns 4.
 func pathDepth(absPath string) int {

--- a/pkg/skills/installer_test.go
+++ b/pkg/skills/installer_test.go
@@ -231,3 +231,76 @@ func TestNewInstaller(t *testing.T) {
 	inst := NewInstaller()
 	require.NotNil(t, inst)
 }
+
+func TestRemoveEmptyParents(t *testing.T) {
+	t.Parallel()
+
+	t.Run("removes a chain of empty directories up to stop boundary", func(t *testing.T) {
+		t.Parallel()
+		// Create: stopAt/a/b/c (all empty)
+		stopAt, _ := filepath.EvalSymlinks(t.TempDir())
+		chain := filepath.Join(stopAt, "a", "b", "c")
+		require.NoError(t, os.MkdirAll(chain, 0750))
+
+		RemoveEmptyParents(chain, stopAt)
+
+		// a, a/b, a/b/c should all be gone
+		_, err := os.Stat(filepath.Join(stopAt, "a"))
+		assert.True(t, os.IsNotExist(err), "directory 'a' should have been removed")
+	})
+
+	t.Run("stops when a directory is not empty", func(t *testing.T) {
+		t.Parallel()
+		// Create: stopAt/a/b/c (c is empty; b has an extra file)
+		stopAt, _ := filepath.EvalSymlinks(t.TempDir())
+		chain := filepath.Join(stopAt, "a", "b", "c")
+		require.NoError(t, os.MkdirAll(chain, 0750))
+		require.NoError(t, os.WriteFile(filepath.Join(stopAt, "a", "b", "other.txt"), []byte("x"), 0600))
+
+		RemoveEmptyParents(chain, stopAt)
+
+		// c should be gone but b (and a) should remain because b is not empty
+		_, errC := os.Stat(chain)
+		assert.True(t, os.IsNotExist(errC), "directory 'c' should have been removed")
+
+		_, errB := os.Stat(filepath.Join(stopAt, "a", "b"))
+		assert.NoError(t, errB, "directory 'b' should still exist (not empty)")
+	})
+
+	t.Run("never removes the stop directory itself", func(t *testing.T) {
+		t.Parallel()
+		stopAt, _ := filepath.EvalSymlinks(t.TempDir())
+		// The stop dir is also the immediate parent of what we pass in.
+		child := filepath.Join(stopAt, "skill")
+		require.NoError(t, os.MkdirAll(child, 0750))
+
+		RemoveEmptyParents(child, stopAt)
+
+		// child is removed but stopAt must remain
+		_, errChild := os.Stat(child)
+		assert.True(t, os.IsNotExist(errChild), "child directory should have been removed")
+
+		_, errStop := os.Stat(stopAt)
+		assert.NoError(t, errStop, "stop directory must not be removed")
+	})
+
+	t.Run("is a no-op when directory does not exist", func(t *testing.T) {
+		t.Parallel()
+		stopAt, _ := filepath.EvalSymlinks(t.TempDir())
+		missing := filepath.Join(stopAt, "does-not-exist")
+
+		// Should not panic or error.
+		RemoveEmptyParents(missing, stopAt)
+
+		_, err := os.Stat(stopAt)
+		assert.NoError(t, err, "stop directory must not be touched")
+	})
+
+	t.Run("stop and dir equal — does nothing", func(t *testing.T) {
+		t.Parallel()
+		dir, _ := filepath.EvalSymlinks(t.TempDir())
+		RemoveEmptyParents(dir, dir)
+		_, err := os.Stat(dir)
+		assert.NoError(t, err, "directory must not be removed when it equals stopAt")
+	})
+}

--- a/pkg/skills/skillsvc/skillsvc.go
+++ b/pkg/skills/skillsvc/skillsvc.go
@@ -359,6 +359,14 @@ func (s *service) Uninstall(ctx context.Context, opts skills.UninstallOptions) e
 		return err
 	}
 
+	// Determine the boundary directory for empty-parent cleanup.
+	stopDir := opts.ProjectRoot
+	if scope == skills.ScopeUser {
+		if homeDir, err := os.UserHomeDir(); err == nil {
+			stopDir = homeDir
+		}
+	}
+
 	// Remove files for each client — best-effort: collect errors but don't
 	// abort on the first failure so we clean up as much as possible.
 	var cleanupErrs []error
@@ -371,6 +379,10 @@ func (s *service) Uninstall(ctx context.Context, opts skills.UninstallOptions) e
 			}
 			if rmErr := s.installer.Remove(skillPath); rmErr != nil {
 				cleanupErrs = append(cleanupErrs, fmt.Errorf("removing files for client %q: %w", clientType, rmErr))
+				continue
+			}
+			if stopDir != "" {
+				skills.RemoveEmptyParents(filepath.Dir(skillPath), stopDir)
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

- When a skill is uninstalled, the skill directory (e.g. `~/.claude/skills/my-skill`) is removed but any now-empty intermediate directories (e.g. `~/.claude/skills/`) are left behind.
- Add `RemoveEmptyParents` to the installer that walks up from the removed skill's parent directory, calling `os.Remove` on each directory until reaching the home dir (user scope) or project root (project scope). Because `os.Remove` only removes empty directories, this is inherently safe and stops automatically when another skill or file is present.

## Type of change

- Bug fix (non-breaking)

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)

## Changes

| File | Change |
|------|--------|
| `pkg/skills/installer.go` | Add `RemoveEmptyParents(dir, stopAt string)` package-level function |
| `pkg/skills/skillsvc/skillsvc.go` | Call `RemoveEmptyParents` after each successful per-client `Remove` in `Uninstall` |
| `pkg/skills/installer_test.go` | 5 new subtests covering: empty chain removal, non-empty stop, stop boundary protection, missing dir no-op, dir==stopAt no-op |

## Does this introduce a user-facing change?

Yes — after uninstalling the last skill for a client, the empty `skills/` (and any other empty intermediate) directories are cleaned up automatically.