### PR TITLE
Add OverrideTokenSource hook to registry factory

### DIFF
--- a/pkg/registry/factory.go
+++ b/pkg/registry/factory.go
@@ -25,6 +25,12 @@ var (
 	// The mutex is NOT needed for GetDefaultProviderWithConfig since
 	// sync.Once already provides thread-safety for initialization.
 	defaultProviderMu sync.Mutex
+
+	// OverrideTokenSource, if non-nil, is called before the built-in OAuth
+	// token source logic. Return a non-nil TokenSource to use it; return nil
+	// to fall through to the default behaviour. This allows external builds
+	// to inject a custom token source without modifying OSS code.
+	OverrideTokenSource func(cfg *config.Config) auth.TokenSource
 )
 
 // ProviderOption configures optional behavior for NewRegistryProvider.
@@ -120,6 +126,12 @@ func ResetDefaultProvider() {
 // resolveTokenSource creates a TokenSource from the config if registry auth is configured.
 // Returns nil if no auth is configured or if token source creation fails (logs warning).
 func resolveTokenSource(cfg *config.Config, interactive bool) auth.TokenSource {
+	if OverrideTokenSource != nil {
+		if ts := OverrideTokenSource(cfg); ts != nil {
+			return ts
+		}
+	}
+
 	if cfg == nil || cfg.RegistryAuth.Type != config.RegistryAuthTypeOAuth || cfg.RegistryAuth.OAuth == nil {
 		return nil
 	}


### PR DESCRIPTION
## Summary

- The registry factory's `resolveTokenSource` only supports the built-in OAuth config path. External builds that manage authentication separately (e.g. via a session manager) have no way to inject a token source without forking OSS code.
- Adds an `OverrideTokenSource` package-level hook. When set, it is called before the OAuth logic; returning a non-nil `TokenSource` uses it, returning `nil` falls through to existing behaviour unchanged.
- In OSS builds the variable is `nil` and the code path is identical to before.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Test plan

- [x] Existing unit tests pass (`task test`)
- [x] Manual review: OSS default path is a pure no-op when `OverrideTokenSource` is nil — the added guard is a nil check before the existing logic