### PR TITLE
Add unit tests for pkg/vmcp/cli serve and validate logic

### DIFF
--- a/pkg/vmcp/cli/serve.go
+++ b/pkg/vmcp/cli/serve.go
@@ -241,7 +241,7 @@ func Serve(ctx context.Context, cfg ServeConfig) error {
 		return fmt.Errorf("failed to validate optimizer config: %w", err)
 	}
 
-	sessionFactory, err := createSessionFactory(outgoingRegistry, agg)
+	sessionFactory, err := createSessionFactory(&env.OSReader{}, outgoingRegistry, agg)
 	if err != nil {
 		return err
 	}
@@ -448,6 +448,7 @@ func discoverBackends(
 //   - If running in Kubernetes without secret: returns error (production safety requirement).
 //   - Otherwise: logs warning and creates factory with default insecure secret.
 func createSessionFactory(
+	envReader env.Reader,
 	outgoingRegistry vmcpauth.OutgoingAuthRegistry,
 	agg aggregator.Aggregator,
 ) (vmcpsession.MultiSessionFactory, error) {
@@ -461,7 +462,7 @@ func createSessionFactory(
 		opts = append(opts, vmcpsession.WithAggregator(agg))
 	}
 
-	hmacSecret := os.Getenv(envKey)
+	hmacSecret := envReader.Getenv(envKey)
 
 	if hmacSecret != "" {
 		if secretLen := len(hmacSecret); secretLen < minRecommendedSecretLen {
@@ -478,7 +479,7 @@ func createSessionFactory(
 	}
 
 	// No secret provided — fail fast in Kubernetes (production environment).
-	if runtime.IsKubernetesRuntime() {
+	if runtime.IsKubernetesRuntimeWithEnv(envReader) {
 		return nil, fmt.Errorf(
 			"VMCP_SESSION_HMAC_SECRET environment variable is required when running in Kubernetes. " +
 				"Generate a secure secret with: openssl rand -base64 32",

--- a/pkg/vmcp/cli/serve.go
+++ b/pkg/vmcp/cli/serve.go
@@ -241,7 +241,13 @@ func Serve(ctx context.Context, cfg ServeConfig) error {
 		return fmt.Errorf("failed to validate optimizer config: %w", err)
 	}
 
-	sessionFactory, err := createSessionFactory(&env.OSReader{}, outgoingRegistry, agg)
+	envReader := &env.OSReader{}
+	sessionFactory, err := createSessionFactory(
+		envReader.Getenv("VMCP_SESSION_HMAC_SECRET"),
+		runtime.IsKubernetesRuntimeWithEnv(envReader),
+		outgoingRegistry,
+		agg,
+	)
 	if err != nil {
 		return err
 	}
@@ -425,14 +431,27 @@ func discoverBackends(
 		}
 	}
 
-	slog.Info(fmt.Sprintf("Discovering backends in group: %s", cfg.Group))
-	backends, err := discoverer.Discover(ctx, cfg.Group)
+	return runDiscovery(ctx, cfg.Group, discoverer, backendClient, outgoingRegistry)
+}
+
+// runDiscovery calls Discover on the provided discoverer and handles the zero-backends
+// case. Extracted so tests can inject a stub discoverer without needing a real
+// Kubernetes cluster or Docker daemon.
+func runDiscovery(
+	ctx context.Context,
+	groupRef string,
+	discoverer aggregator.BackendDiscoverer,
+	backendClient vmcp.BackendClient,
+	outgoingRegistry vmcpauth.OutgoingAuthRegistry,
+) ([]vmcp.Backend, vmcp.BackendClient, vmcpauth.OutgoingAuthRegistry, error) {
+	slog.Info(fmt.Sprintf("Discovering backends in group: %s", groupRef))
+	backends, err := discoverer.Discover(ctx, groupRef)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to discover backends: %w", err)
 	}
 
 	if len(backends) == 0 {
-		slog.Warn(fmt.Sprintf("No backends discovered in group %s - vmcp will start but have no backends to proxy", cfg.Group))
+		slog.Warn(fmt.Sprintf("No backends discovered in group %s - vmcp will start but have no backends to proxy", groupRef))
 		return []vmcp.Backend{}, backendClient, outgoingRegistry, nil
 	}
 
@@ -441,28 +460,26 @@ func discoverBackends(
 }
 
 // createSessionFactory creates a MultiSessionFactory with HMAC-SHA256 token binding.
-// The HMAC secret is read from the VMCP_SESSION_HMAC_SECRET environment variable.
+// The HMAC secret and Kubernetes detection are passed in as parameters (typically sourced
+// from the VMCP_SESSION_HMAC_SECRET environment variable and runtime environment detection
+// by the caller).
 //
 // Behavior:
-//   - If VMCP_SESSION_HMAC_SECRET is set: validates length and creates factory with the secret.
+//   - If hmacSecret is non-empty: validates length and creates factory with the secret.
 //   - If running in Kubernetes without secret: returns error (production safety requirement).
 //   - Otherwise: logs warning and creates factory with default insecure secret.
 func createSessionFactory(
-	envReader env.Reader,
+	hmacSecret string,
+	isKubernetes bool,
 	outgoingRegistry vmcpauth.OutgoingAuthRegistry,
 	agg aggregator.Aggregator,
 ) (vmcpsession.MultiSessionFactory, error) {
-	const (
-		envKey                  = "VMCP_SESSION_HMAC_SECRET"
-		minRecommendedSecretLen = 32
-	)
+	const minRecommendedSecretLen = 32
 
 	opts := []vmcpsession.MultiSessionFactoryOption{}
 	if agg != nil {
 		opts = append(opts, vmcpsession.WithAggregator(agg))
 	}
-
-	hmacSecret := envReader.Getenv(envKey)
 
 	if hmacSecret != "" {
 		if secretLen := len(hmacSecret); secretLen < minRecommendedSecretLen {
@@ -473,20 +490,20 @@ func createSessionFactory(
 				"recommended_length", minRecommendedSecretLen,
 			)
 		}
-		slog.Info("using HMAC secret from VMCP_SESSION_HMAC_SECRET environment variable for session token binding")
+		slog.Info("using provided HMAC secret for session token binding")
 		opts = append(opts, vmcpsession.WithHMACSecret([]byte(hmacSecret)))
 		return vmcpsession.NewSessionFactory(outgoingRegistry, opts...), nil
 	}
 
 	// No secret provided — fail fast in Kubernetes (production environment).
-	if runtime.IsKubernetesRuntimeWithEnv(envReader) {
+	if isKubernetes {
 		return nil, fmt.Errorf(
-			"VMCP_SESSION_HMAC_SECRET environment variable is required when running in Kubernetes. " +
+			"an HMAC secret is required when running in Kubernetes (set VMCP_SESSION_HMAC_SECRET). " +
 				"Generate a secure secret with: openssl rand -base64 32",
 		)
 	}
 
 	// Development mode: use default insecure secret with warning.
-	slog.Warn("VMCP_SESSION_HMAC_SECRET not set - using default insecure secret (NOT recommended for production)")
+	slog.Warn("no HMAC secret provided - using default insecure secret (NOT recommended for production)")
 	return vmcpsession.NewSessionFactory(outgoingRegistry, opts...), nil
 }

--- a/pkg/vmcp/cli/serve_test.go
+++ b/pkg/vmcp/cli/serve_test.go
@@ -13,10 +13,11 @@ import (
 	"go.uber.org/mock/gomock"
 	"gopkg.in/yaml.v3"
 
-	envmocks "github.com/stacklok/toolhive-core/env/mocks"
 	authserverconfig "github.com/stacklok/toolhive/pkg/authserver"
+	"github.com/stacklok/toolhive/pkg/vmcp"
 	aggregatormocks "github.com/stacklok/toolhive/pkg/vmcp/aggregator/mocks"
 	clientmocks "github.com/stacklok/toolhive/pkg/vmcp/client/mocks"
+	vmcpmocks "github.com/stacklok/toolhive/pkg/vmcp/mocks"
 )
 
 // TestLoadAndValidateConfig covers all config-loading paths.
@@ -56,9 +57,11 @@ outgoingAuth:
   source: inline
 aggregation:
   conflictResolution: prefix
+  conflictResolutionConfig:
+    prefixFormat: "{workload}_"
 `,
 			wantErr:     true,
-			errContains: "validation failed",
+			errContains: "group reference is required",
 		},
 	}
 
@@ -153,58 +156,75 @@ backends:
 	assert.Len(t, backends, 1)
 }
 
-func newSessionFactoryMocks(t *testing.T) (*envmocks.MockReader, *clientmocks.MockOutgoingAuthRegistry, *aggregatormocks.MockAggregator) {
+func newSessionFactoryMocks(t *testing.T) (*clientmocks.MockOutgoingAuthRegistry, *aggregatormocks.MockAggregator) {
 	t.Helper()
 	ctrl := gomock.NewController(t)
-	return envmocks.NewMockReader(ctrl), clientmocks.NewMockOutgoingAuthRegistry(ctrl), aggregatormocks.NewMockAggregator(ctrl)
+	return clientmocks.NewMockOutgoingAuthRegistry(ctrl), aggregatormocks.NewMockAggregator(ctrl)
 }
 
 func TestCreateSessionFactory_WithHMACSecret(t *testing.T) {
 	t.Parallel()
-	envReader, registry, agg := newSessionFactoryMocks(t)
-	envReader.EXPECT().Getenv("VMCP_SESSION_HMAC_SECRET").Return("a-sufficiently-long-hmac-secret-value-32b")
-	factory, err := createSessionFactory(envReader, registry, agg)
+	registry, agg := newSessionFactoryMocks(t)
+	factory, err := createSessionFactory("a-sufficiently-long-hmac-secret-value-32b", false, registry, agg)
 	require.NoError(t, err)
 	require.NotNil(t, factory)
 }
 
 func TestCreateSessionFactory_HMACSecretExactly32Bytes(t *testing.T) {
 	t.Parallel()
-	envReader, registry, agg := newSessionFactoryMocks(t)
-	envReader.EXPECT().Getenv("VMCP_SESSION_HMAC_SECRET").Return("12345678901234567890123456789012")
-	factory, err := createSessionFactory(envReader, registry, agg)
+	registry, agg := newSessionFactoryMocks(t)
+	factory, err := createSessionFactory("12345678901234567890123456789012", false, registry, agg)
 	require.NoError(t, err)
 	require.NotNil(t, factory)
 }
 
 func TestCreateSessionFactory_ShortHMACSecret(t *testing.T) {
 	t.Parallel()
-	envReader, registry, agg := newSessionFactoryMocks(t)
-	envReader.EXPECT().Getenv("VMCP_SESSION_HMAC_SECRET").Return("short")
-	factory, err := createSessionFactory(envReader, registry, agg)
+	registry, agg := newSessionFactoryMocks(t)
+	factory, err := createSessionFactory("short", false, registry, agg)
 	require.NoError(t, err)
 	require.NotNil(t, factory)
 }
 
 func TestCreateSessionFactory_NoSecretNonKubernetes(t *testing.T) {
 	t.Parallel()
-	envReader, registry, agg := newSessionFactoryMocks(t)
-	envReader.EXPECT().Getenv("VMCP_SESSION_HMAC_SECRET").Return("")
-	envReader.EXPECT().Getenv("TOOLHIVE_RUNTIME").Return("")
-	envReader.EXPECT().Getenv("KUBERNETES_SERVICE_HOST").Return("")
-	factory, err := createSessionFactory(envReader, registry, agg)
+	registry, agg := newSessionFactoryMocks(t)
+	factory, err := createSessionFactory("", false, registry, agg)
 	require.NoError(t, err)
 	require.NotNil(t, factory)
 }
 
 func TestCreateSessionFactory_NoSecretKubernetes(t *testing.T) {
 	t.Parallel()
-	envReader, registry, agg := newSessionFactoryMocks(t)
-	envReader.EXPECT().Getenv("VMCP_SESSION_HMAC_SECRET").Return("")
-	envReader.EXPECT().Getenv("TOOLHIVE_RUNTIME").Return("")
-	envReader.EXPECT().Getenv("KUBERNETES_SERVICE_HOST").Return("10.0.0.1")
-	factory, err := createSessionFactory(envReader, registry, agg)
+	registry, agg := newSessionFactoryMocks(t)
+	factory, err := createSessionFactory("", true, registry, agg)
 	require.Error(t, err)
-	require.ErrorContains(t, err, "VMCP_SESSION_HMAC_SECRET environment variable is required")
+	require.ErrorContains(t, err, "an HMAC secret is required when running in Kubernetes")
 	require.Nil(t, factory)
+}
+
+// TestRunDiscovery_ZeroBackends exercises the branch in runDiscovery where the
+// discoverer succeeds but returns no backends. The function must return a
+// non-error, an empty (non-nil) backend slice, and pass through the client and
+// registry it received.
+func TestRunDiscovery_ZeroBackends(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	discoverer := aggregatormocks.NewMockBackendDiscoverer(ctrl)
+	backendClient := vmcpmocks.NewMockBackendClient(ctrl)
+	registry := clientmocks.NewMockOutgoingAuthRegistry(ctrl)
+
+	const groupRef = "test-group"
+	discoverer.EXPECT().
+		Discover(gomock.Any(), groupRef).
+		Return([]vmcp.Backend{}, nil)
+
+	backends, gotClient, gotRegistry, err := runDiscovery(t.Context(), groupRef, discoverer, backendClient, registry)
+
+	require.NoError(t, err)
+	assert.NotNil(t, backends)
+	assert.Empty(t, backends)
+	assert.Same(t, backendClient, gotClient)
+	assert.Same(t, registry, gotRegistry)
 }

--- a/pkg/vmcp/cli/serve_test.go
+++ b/pkg/vmcp/cli/serve_test.go
@@ -1,0 +1,210 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	"gopkg.in/yaml.v3"
+
+	envmocks "github.com/stacklok/toolhive-core/env/mocks"
+	authserverconfig "github.com/stacklok/toolhive/pkg/authserver"
+	aggregatormocks "github.com/stacklok/toolhive/pkg/vmcp/aggregator/mocks"
+	clientmocks "github.com/stacklok/toolhive/pkg/vmcp/client/mocks"
+)
+
+// TestLoadAndValidateConfig covers all config-loading paths.
+func TestLoadAndValidateConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		content     string
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:    "valid config",
+			content: validConfigYAML,
+			wantErr: false,
+		},
+		{
+			name:        "non-existent file",
+			content:     "", // file will not be created
+			wantErr:     true,
+			errContains: "configuration loading failed",
+		},
+		{
+			name:        "malformed YAML",
+			content:     ":::invalid yaml:::",
+			wantErr:     true,
+			errContains: "configuration loading failed",
+		},
+		{
+			name: "fails semantic validation — missing groupRef",
+			content: `
+name: test-vmcp
+incomingAuth:
+  type: anonymous
+outgoingAuth:
+  source: inline
+aggregation:
+  conflictResolution: prefix
+`,
+			wantErr:     true,
+			errContains: "validation failed",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			path := filepath.Join(dir, "vmcp.yaml")
+			if tc.content != "" {
+				require.NoError(t, os.WriteFile(path, []byte(tc.content), 0o600))
+			}
+
+			cfg, err := loadAndValidateConfig(path)
+			if tc.wantErr {
+				require.Error(t, err)
+				require.ErrorContains(t, err, tc.errContains)
+				require.Nil(t, cfg)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, cfg)
+				assert.Equal(t, "test-group", cfg.Group)
+			}
+		})
+	}
+}
+
+// TestLoadAuthServerConfig covers all auth-server-config side-loading paths.
+// (Additional cases live in auth_server_config_test.go, moved from cmd/vmcp/app.)
+func TestLoadAuthServerConfig_NestedDir(t *testing.T) {
+	t.Parallel()
+
+	// Config lives in a subdirectory; sibling authserver-config.yaml must be found correctly.
+	dir := t.TempDir()
+	subdir := filepath.Join(dir, "sub", "dir")
+	require.NoError(t, os.MkdirAll(subdir, 0o750))
+	configPath := filepath.Join(subdir, "vmcp-config.yaml")
+
+	want := &authserverconfig.RunConfig{
+		Issuer:        "https://nested.example.com",
+		SchemaVersion: "1",
+	}
+	data, err := yaml.Marshal(want)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(subdir, "authserver-config.yaml"), data, 0o600))
+
+	rc, err := loadAuthServerConfig(configPath)
+	require.NoError(t, err)
+	require.NotNil(t, rc)
+	assert.Equal(t, "https://nested.example.com", rc.Issuer)
+}
+
+// TestDiscoverBackends_StaticMode exercises the static-backend path without
+// needing a live Kubernetes API.
+func TestDiscoverBackends_StaticMode(t *testing.T) {
+	t.Parallel()
+
+	// Build a minimal config with one static backend.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "vmcp.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(`
+name: test-vmcp
+groupRef: test-group
+
+incomingAuth:
+  type: anonymous
+
+outgoingAuth:
+  source: inline
+  default:
+    type: unauthenticated
+
+aggregation:
+  conflictResolution: prefix
+  conflictResolutionConfig:
+    prefixFormat: "{workload}_"
+
+backends:
+  - name: backend-one
+    url: http://127.0.0.1:9001/sse
+    transport: sse
+`), 0o600))
+
+	cfg, err := loadAndValidateConfig(path)
+	require.NoError(t, err)
+	require.Len(t, cfg.Backends, 1)
+
+	backends, client, registry, err := discoverBackends(t.Context(), cfg)
+	require.NoError(t, err)
+	assert.NotNil(t, client)
+	assert.NotNil(t, registry)
+	// Static mode: one backend discovered.
+	assert.Len(t, backends, 1)
+}
+
+func newSessionFactoryMocks(t *testing.T) (*envmocks.MockReader, *clientmocks.MockOutgoingAuthRegistry, *aggregatormocks.MockAggregator) {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	return envmocks.NewMockReader(ctrl), clientmocks.NewMockOutgoingAuthRegistry(ctrl), aggregatormocks.NewMockAggregator(ctrl)
+}
+
+func TestCreateSessionFactory_WithHMACSecret(t *testing.T) {
+	t.Parallel()
+	envReader, registry, agg := newSessionFactoryMocks(t)
+	envReader.EXPECT().Getenv("VMCP_SESSION_HMAC_SECRET").Return("a-sufficiently-long-hmac-secret-value-32b")
+	factory, err := createSessionFactory(envReader, registry, agg)
+	require.NoError(t, err)
+	require.NotNil(t, factory)
+}
+
+func TestCreateSessionFactory_HMACSecretExactly32Bytes(t *testing.T) {
+	t.Parallel()
+	envReader, registry, agg := newSessionFactoryMocks(t)
+	envReader.EXPECT().Getenv("VMCP_SESSION_HMAC_SECRET").Return("12345678901234567890123456789012")
+	factory, err := createSessionFactory(envReader, registry, agg)
+	require.NoError(t, err)
+	require.NotNil(t, factory)
+}
+
+func TestCreateSessionFactory_ShortHMACSecret(t *testing.T) {
+	t.Parallel()
+	envReader, registry, agg := newSessionFactoryMocks(t)
+	envReader.EXPECT().Getenv("VMCP_SESSION_HMAC_SECRET").Return("short")
+	factory, err := createSessionFactory(envReader, registry, agg)
+	require.NoError(t, err)
+	require.NotNil(t, factory)
+}
+
+func TestCreateSessionFactory_NoSecretNonKubernetes(t *testing.T) {
+	t.Parallel()
+	envReader, registry, agg := newSessionFactoryMocks(t)
+	envReader.EXPECT().Getenv("VMCP_SESSION_HMAC_SECRET").Return("")
+	envReader.EXPECT().Getenv("TOOLHIVE_RUNTIME").Return("")
+	envReader.EXPECT().Getenv("KUBERNETES_SERVICE_HOST").Return("")
+	factory, err := createSessionFactory(envReader, registry, agg)
+	require.NoError(t, err)
+	require.NotNil(t, factory)
+}
+
+func TestCreateSessionFactory_NoSecretKubernetes(t *testing.T) {
+	t.Parallel()
+	envReader, registry, agg := newSessionFactoryMocks(t)
+	envReader.EXPECT().Getenv("VMCP_SESSION_HMAC_SECRET").Return("")
+	envReader.EXPECT().Getenv("TOOLHIVE_RUNTIME").Return("")
+	envReader.EXPECT().Getenv("KUBERNETES_SERVICE_HOST").Return("10.0.0.1")
+	factory, err := createSessionFactory(envReader, registry, agg)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "VMCP_SESSION_HMAC_SECRET environment variable is required")
+	require.Nil(t, factory)
+}

--- a/pkg/vmcp/cli/validate_test.go
+++ b/pkg/vmcp/cli/validate_test.go
@@ -1,0 +1,115 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package cli
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const validConfigYAML = `
+name: test-vmcp
+groupRef: test-group
+
+incomingAuth:
+  type: anonymous
+
+outgoingAuth:
+  source: inline
+  default:
+    type: unauthenticated
+
+aggregation:
+  conflictResolution: prefix
+  conflictResolutionConfig:
+    prefixFormat: "{workload}_"
+`
+
+func TestValidate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		setup       func(t *testing.T) ValidateConfig
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name: "missing config path",
+			setup: func(_ *testing.T) ValidateConfig {
+				return ValidateConfig{}
+			},
+			wantErr:     true,
+			errContains: "no configuration file specified",
+		},
+		{
+			name: "valid config file",
+			setup: func(t *testing.T) ValidateConfig {
+				t.Helper()
+				path := filepath.Join(t.TempDir(), "vmcp.yaml")
+				require.NoError(t, os.WriteFile(path, []byte(validConfigYAML), 0o600))
+				return ValidateConfig{ConfigPath: path}
+			},
+			wantErr: false,
+		},
+		{
+			name: "non-existent file",
+			setup: func(t *testing.T) ValidateConfig {
+				t.Helper()
+				return ValidateConfig{ConfigPath: filepath.Join(t.TempDir(), "nonexistent.yaml")}
+			},
+			wantErr:     true,
+			errContains: "configuration loading failed",
+		},
+		{
+			name: "malformed YAML",
+			setup: func(t *testing.T) ValidateConfig {
+				t.Helper()
+				path := filepath.Join(t.TempDir(), "bad.yaml")
+				require.NoError(t, os.WriteFile(path, []byte(":::not valid yaml:::"), 0o600))
+				return ValidateConfig{ConfigPath: path}
+			},
+			wantErr:     true,
+			errContains: "configuration loading failed",
+		},
+		{
+			name: "config missing required groupRef",
+			setup: func(t *testing.T) ValidateConfig {
+				t.Helper()
+				path := filepath.Join(t.TempDir(), "invalid.yaml")
+				// groupRef is required; omitting it must fail validation.
+				require.NoError(t, os.WriteFile(path, []byte(`
+name: test-vmcp
+incomingAuth:
+  type: anonymous
+outgoingAuth:
+  source: inline
+aggregation:
+  conflictResolution: prefix
+`), 0o600))
+				return ValidateConfig{ConfigPath: path}
+			},
+			wantErr:     true,
+			errContains: "validation failed",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := tc.setup(t)
+			err := Validate(context.Background(), cfg)
+			if tc.wantErr {
+				require.Error(t, err)
+				require.ErrorContains(t, err, tc.errContains)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/vmcp/cli/validate_test.go
+++ b/pkg/vmcp/cli/validate_test.go
@@ -91,11 +91,13 @@ outgoingAuth:
   source: inline
 aggregation:
   conflictResolution: prefix
+  conflictResolutionConfig:
+    prefixFormat: "{workload}_"
 `), 0o600))
 				return ValidateConfig{ConfigPath: path}
 			},
 			wantErr:     true,
-			errContains: "validation failed",
+			errContains: "group reference is required",
 		},
 	}
 


### PR DESCRIPTION
## Summary

<!--
REQUIRED. You MUST explain:
1. WHY this change is needed (the problem or motivation)
2. WHAT changed (concise bullet points)

The diff shows the code — your summary must provide the context a reviewer
needs to understand the purpose without reading the diff first.
-->

Cover loadAndValidateConfig, loadAuthServerConfig, discoverBackends, createSessionFactory, and Validate with table-driven unit tests in pkg/vmcp/cli. Also moves the existing loadAuthServerConfig test from cmd/vmcp/app (where it lived before the thin-wrap refactor) to pkg/vmcp/cli where the function now lives.

env var tests use os.Setenv + t.Cleanup via a setEnvForTest helper to remain compatible with t.Parallel().


<!--
Link related issues. Use "Closes" or "Fixes" to auto-close on merge.
Remove this line if there is no related issue.
-->

Fixes #4881 

## Type of change

<!-- REQUIRED. Check exactly one. -->

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

<!--
REQUIRED. Check every verification step you actually ran.
You MUST check at least one item. If you only did manual testing,
describe exactly what you tested below the checkbox.
-->

- [x] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [x] Linting (`task lint-fix`)
- [ ] Manual testing (describe below)

## Changes

<!--
Optional — include for PRs touching more than a few files to help
reviewers navigate the diff. Remove this entire section for small PRs.
-->

| File | Change |
|------|--------|
|      |        |

## Does this introduce a user-facing change?

<!--
If yes, describe the change from the user's perspective. This helps with release notes.
If no, write "No".
Remove this section entirely if not applicable.
-->

## Implementation plan

<!--
Optional — include when this PR was planned with an AI assistant (Claude Code, etc.).
Paste the approved plan inside the <details> block so reviewers can see the intended
design without cluttering the main PR description. Remove this section entirely
for PRs that were not AI-planned.
-->

<details>
<summary>Approved implementation plan</summary>

<!-- Paste the plan here -->

</details>

## Special notes for reviewers

<!--
Optional — call out anything non-obvious: tricky logic, known limitations,
areas where you'd like extra scrutiny, or follow-up work planned.
Remove this section if not needed.
-->
