### PR TITLE
Validate audience matches resourceUrl for embedded auth server

### DIFF
--- a/cmd/thv-operator/controllers/mcpserver_externalauth_runconfig_test.go
+++ b/cmd/thv-operator/controllers/mcpserver_externalauth_runconfig_test.go
@@ -250,6 +250,7 @@ func TestAddExternalAuthConfigOptions(t *testing.T) {
 				},
 			},
 			oidcConfig: &oidc.OIDCConfig{
+				Audience:    "http://test-server.default.svc.cluster.local:8080",
 				ResourceURL: "http://test-server.default.svc.cluster.local:8080",
 				Scopes:      []string{"openid", "offline_access"},
 			},
@@ -754,7 +755,7 @@ func TestCreateRunConfigFromMCPServer_WithExternalAuth(t *testing.T) {
 					},
 					OIDCConfigRef: &mcpv1alpha1.MCPOIDCConfigReference{
 						Name:     "embedded-oidc",
-						Audience: "toolhive",
+						Audience: "http://embedded-auth-server.default.svc.cluster.local:8080",
 						Scopes:   []string{"openid", "offline_access", "mcp:tools"},
 					},
 				},

--- a/cmd/thv-operator/pkg/controllerutil/authserver.go
+++ b/cmd/thv-operator/pkg/controllerutil/authserver.go
@@ -395,24 +395,8 @@ func AddEmbeddedAuthServerConfigOptions(
 		return fmt.Errorf("embedded auth server configuration is nil for type embeddedAuthServer")
 	}
 
-	// Validate OIDC config is provided with ResourceURL (required for embedded auth server)
-	if oidcConfig == nil {
-		return fmt.Errorf("OIDC config is required for embedded auth server: OIDCConfigRef must be set on the MCPServer")
-	}
-	if oidcConfig.ResourceURL == "" {
-		return fmt.Errorf("OIDC config resourceUrl is required for embedded auth server: set resourceUrl in OIDCConfigRef")
-	}
-
-	// The embedded auth server mints tokens with aud = ResourceURL (the value
-	// clients send as the RFC 8707 resource parameter). The token validator
-	// checks aud against Audience. These must match or every authenticated
-	// request will fail with an audience mismatch (#4860).
-	if oidcConfig.Audience != oidcConfig.ResourceURL {
-		return fmt.Errorf(
-			"oidcConfigRef.audience %q must match resourceUrl %q when an embedded auth server is active; "+
-				"set audience to %q or set resourceUrl to match audience",
-			oidcConfig.Audience, oidcConfig.ResourceURL, oidcConfig.ResourceURL,
-		)
+	if err := validateOIDCConfigForEmbeddedAuthServer(oidcConfig); err != nil {
+		return err
 	}
 
 	// Build the embedded auth server config for runner
@@ -427,6 +411,42 @@ func AddEmbeddedAuthServerConfigOptions(
 	// Add the configuration option
 	*options = append(*options, runner.WithEmbeddedAuthServerConfig(embeddedConfig))
 
+	return nil
+}
+
+// validateOIDCConfigForEmbeddedAuthServer validates OIDC configuration
+// requirements when an embedded auth server is active.
+//
+// The embedded auth server mints tokens with aud = ResourceURL (the value
+// clients send as the RFC 8707 resource parameter via discovery). The token
+// validator checks aud against Audience. If these differ, every authenticated
+// request fails with an audience mismatch.
+//
+// We validate consistency at reconciliation time (rather than silently
+// overriding Audience with ResourceURL) so that operators see exactly what
+// values are in play and control both sides explicitly. This mirrors the
+// existing vMCP inline config validation (ValidateAuthServerIntegration).
+func validateOIDCConfigForEmbeddedAuthServer(oidcConfig *oidc.OIDCConfig) error {
+	if oidcConfig == nil {
+		return fmt.Errorf("OIDC config is required for embedded auth server: OIDCConfigRef must be set on the MCPServer")
+	}
+	if oidcConfig.ResourceURL == "" {
+		return fmt.Errorf("OIDC config resourceUrl is required for embedded auth server: set resourceUrl in OIDCConfigRef")
+	}
+	if oidcConfig.Audience == "" {
+		return fmt.Errorf(
+			"oidcConfigRef.audience is required when an embedded auth server is active; "+
+				"set audience to %q to match resourceUrl",
+			oidcConfig.ResourceURL,
+		)
+	}
+	if oidcConfig.Audience != oidcConfig.ResourceURL {
+		return fmt.Errorf(
+			"oidcConfigRef.audience %q must match resourceUrl %q when an embedded auth server is active; "+
+				"set audience to %q or set resourceUrl to match audience",
+			oidcConfig.Audience, oidcConfig.ResourceURL, oidcConfig.ResourceURL,
+		)
+	}
 	return nil
 }
 
@@ -769,24 +789,8 @@ func AddAuthServerRefOptions(
 		return fmt.Errorf("embedded auth server configuration is nil for type embeddedAuthServer")
 	}
 
-	// Validate OIDC config is provided with ResourceURL (required for embedded auth server)
-	if oidcConfig == nil {
-		return fmt.Errorf("OIDC config is required for embedded auth server: OIDCConfigRef must be set on the MCPServer")
-	}
-	if oidcConfig.ResourceURL == "" {
-		return fmt.Errorf("OIDC config resourceUrl is required for embedded auth server: set resourceUrl in OIDCConfigRef")
-	}
-
-	// The embedded auth server mints tokens with aud = ResourceURL (the value
-	// clients send as the RFC 8707 resource parameter). The token validator
-	// checks aud against Audience. These must match or every authenticated
-	// request will fail with an audience mismatch (#4860).
-	if oidcConfig.Audience != oidcConfig.ResourceURL {
-		return fmt.Errorf(
-			"oidcConfigRef.audience %q must match resourceUrl %q when an embedded auth server is active; "+
-				"set audience to %q or set resourceUrl to match audience",
-			oidcConfig.Audience, oidcConfig.ResourceURL, oidcConfig.ResourceURL,
-		)
+	if err := validateOIDCConfigForEmbeddedAuthServer(oidcConfig); err != nil {
+		return err
 	}
 
 	// Build the embedded auth server config for runner

--- a/cmd/thv-operator/pkg/controllerutil/authserver.go
+++ b/cmd/thv-operator/pkg/controllerutil/authserver.go
@@ -403,6 +403,18 @@ func AddEmbeddedAuthServerConfigOptions(
 		return fmt.Errorf("OIDC config resourceUrl is required for embedded auth server: set resourceUrl in OIDCConfigRef")
 	}
 
+	// The embedded auth server mints tokens with aud = ResourceURL (the value
+	// clients send as the RFC 8707 resource parameter). The token validator
+	// checks aud against Audience. These must match or every authenticated
+	// request will fail with an audience mismatch (#4860).
+	if oidcConfig.Audience != oidcConfig.ResourceURL {
+		return fmt.Errorf(
+			"oidcConfigRef.audience %q must match resourceUrl %q when an embedded auth server is active; "+
+				"set audience to %q or set resourceUrl to match audience",
+			oidcConfig.Audience, oidcConfig.ResourceURL, oidcConfig.ResourceURL,
+		)
+	}
+
 	// Build the embedded auth server config for runner
 	embeddedConfig, err := BuildAuthServerRunConfig(
 		namespace, mcpServerName, authServerConfig,
@@ -763,6 +775,18 @@ func AddAuthServerRefOptions(
 	}
 	if oidcConfig.ResourceURL == "" {
 		return fmt.Errorf("OIDC config resourceUrl is required for embedded auth server: set resourceUrl in OIDCConfigRef")
+	}
+
+	// The embedded auth server mints tokens with aud = ResourceURL (the value
+	// clients send as the RFC 8707 resource parameter). The token validator
+	// checks aud against Audience. These must match or every authenticated
+	// request will fail with an audience mismatch (#4860).
+	if oidcConfig.Audience != oidcConfig.ResourceURL {
+		return fmt.Errorf(
+			"oidcConfigRef.audience %q must match resourceUrl %q when an embedded auth server is active; "+
+				"set audience to %q or set resourceUrl to match audience",
+			oidcConfig.Audience, oidcConfig.ResourceURL, oidcConfig.ResourceURL,
+		)
 	}
 
 	// Build the embedded auth server config for runner

--- a/cmd/thv-operator/pkg/controllerutil/authserver_test.go
+++ b/cmd/thv-operator/pkg/controllerutil/authserver_test.go
@@ -1036,6 +1036,7 @@ func TestAddEmbeddedAuthServerConfigOptions_Validation(t *testing.T) {
 		{
 			name: "valid OIDC config succeeds",
 			oidcConfig: &oidc.OIDCConfig{
+				Audience:    "http://test-server.default.svc.cluster.local:8080",
 				ResourceURL: "http://test-server.default.svc.cluster.local:8080",
 				Scopes:      []string{"openid", "offline_access"},
 			},
@@ -1044,10 +1045,21 @@ func TestAddEmbeddedAuthServerConfigOptions_Validation(t *testing.T) {
 		{
 			name: "valid OIDC config with nil scopes succeeds",
 			oidcConfig: &oidc.OIDCConfig{
+				Audience:    "http://test-server.default.svc.cluster.local:8080",
 				ResourceURL: "http://test-server.default.svc.cluster.local:8080",
 				Scopes:      nil,
 			},
 			expectError: false,
+		},
+		{
+			name: "audience mismatch with resourceUrl returns error",
+			oidcConfig: &oidc.OIDCConfig{
+				Audience:    "https://different-audience.example.com",
+				ResourceURL: "http://test-server.default.svc.cluster.local:8080",
+				Scopes:      []string{"openid"},
+			},
+			expectError: true,
+			errContains: "must match resourceUrl",
 		},
 	}
 
@@ -1591,6 +1603,7 @@ func TestAddAuthServerRefOptions(t *testing.T) {
 	}
 
 	validOIDCConfig := &oidc.OIDCConfig{
+		Audience:    "https://mcp.example.com",
 		ResourceURL: "https://mcp.example.com",
 		Scopes:      []string{"openid"},
 	}
@@ -1663,6 +1676,36 @@ func TestAddAuthServerRefOptions(t *testing.T) {
 			objects:     func() []runtime.Object { return []runtime.Object{newValidEmbeddedAuthConfig()} },
 			wantErr:     true,
 			errContains: "OIDC config is required",
+		},
+		{
+			name: "audience mismatch with resourceUrl returns error",
+			authServerRef: &mcpv1alpha1.AuthServerRef{
+				Kind: "MCPExternalAuthConfig",
+				Name: "auth-server-config",
+			},
+			oidcConfig: &oidc.OIDCConfig{
+				Audience:    "https://wrong-audience.example.com",
+				ResourceURL: "https://mcp.example.com",
+				Scopes:      []string{"openid"},
+			},
+			objects:     func() []runtime.Object { return []runtime.Object{newValidEmbeddedAuthConfig()} },
+			wantErr:     true,
+			errContains: "must match resourceUrl",
+		},
+		{
+			name: "audience matching resourceUrl succeeds",
+			authServerRef: &mcpv1alpha1.AuthServerRef{
+				Kind: "MCPExternalAuthConfig",
+				Name: "auth-server-config",
+			},
+			oidcConfig: &oidc.OIDCConfig{
+				Audience:    "https://mcp.example.com",
+				ResourceURL: "https://mcp.example.com",
+				Scopes:      []string{"openid"},
+			},
+			objects:     func() []runtime.Object { return []runtime.Object{newValidEmbeddedAuthConfig()} },
+			wantErr:     false,
+			wantOptions: 1,
 		},
 	}
 
@@ -1739,6 +1782,7 @@ func TestValidateAndAddAuthServerRefOptions(t *testing.T) {
 	}
 
 	validOIDC := &oidc.OIDCConfig{
+		Audience:    "https://mcp.example.com",
 		ResourceURL: "https://mcp.example.com",
 		Scopes:      []string{"openid"},
 	}

--- a/cmd/thv-operator/pkg/controllerutil/authserver_test.go
+++ b/cmd/thv-operator/pkg/controllerutil/authserver_test.go
@@ -1061,6 +1061,16 @@ func TestAddEmbeddedAuthServerConfigOptions_Validation(t *testing.T) {
 			expectError: true,
 			errContains: "must match resourceUrl",
 		},
+		{
+			name: "empty audience returns specific error",
+			oidcConfig: &oidc.OIDCConfig{
+				Audience:    "",
+				ResourceURL: "http://test-server.default.svc.cluster.local:8080",
+				Scopes:      []string{"openid"},
+			},
+			expectError: true,
+			errContains: "audience is required when an embedded auth server is active",
+		},
 	}
 
 	for _, tt := range tests {

--- a/cmd/thv-operator/test-integration/mcp-remote-proxy/remoteproxy_helpers.go
+++ b/cmd/thv-operator/test-integration/mcp-remote-proxy/remoteproxy_helpers.go
@@ -116,10 +116,13 @@ func (rb *RemoteProxyBuilder) WithAuthServerRef(name string) *RemoteProxyBuilder
 }
 
 // WithOIDCConfigRef sets the OIDCConfigRef for the proxy.
-func (rb *RemoteProxyBuilder) WithOIDCConfigRef(name, audience string) *RemoteProxyBuilder {
+// resourceURL sets both Audience and ResourceURL to the same value, which is
+// required when an embedded auth server is active (#4860).
+func (rb *RemoteProxyBuilder) WithOIDCConfigRef(name, resourceURL string) *RemoteProxyBuilder {
 	rb.proxy.Spec.OIDCConfigRef = &mcpv1alpha1.MCPOIDCConfigReference{
-		Name:     name,
-		Audience: audience,
+		Name:        name,
+		Audience:    resourceURL,
+		ResourceURL: resourceURL,
 	}
 	return rb
 }

--- a/cmd/thv-operator/test-integration/mcp-server/mcpserver_authserverref_integration_test.go
+++ b/cmd/thv-operator/test-integration/mcp-server/mcpserver_authserverref_integration_test.go
@@ -81,8 +81,9 @@ var _ = Describe("MCPServer AuthServerRef Integration Tests", func() {
 						Name: authConfigName,
 					},
 					OIDCConfigRef: &mcpv1alpha1.MCPOIDCConfigReference{
-						Name:     oidcConfigName,
-						Audience: "https://test-resource.example.com",
+						Name:        oidcConfigName,
+						Audience:    "https://test-resource.example.com",
+						ResourceURL: "https://test-resource.example.com",
 					},
 				},
 			}
@@ -197,8 +198,9 @@ var _ = Describe("MCPServer AuthServerRef Integration Tests", func() {
 						Name: authConfigConflict,
 					},
 					OIDCConfigRef: &mcpv1alpha1.MCPOIDCConfigReference{
-						Name:     oidcConfigName,
-						Audience: "https://test-resource.example.com",
+						Name:        oidcConfigName,
+						Audience:    "https://test-resource.example.com",
+						ResourceURL: "https://test-resource.example.com",
 					},
 				},
 			}
@@ -376,8 +378,9 @@ var _ = Describe("MCPServer AuthServerRef Integration Tests", func() {
 						Name: authConfigName,
 					},
 					OIDCConfigRef: &mcpv1alpha1.MCPOIDCConfigReference{
-						Name:     oidcConfigName,
-						Audience: "https://test-resource.example.com",
+						Name:        oidcConfigName,
+						Audience:    "https://test-resource.example.com",
+						ResourceURL: "https://test-resource.example.com",
 					},
 				},
 			}


### PR DESCRIPTION
## Summary

When an MCPServer uses both an `OIDCConfigRef` and an embedded auth server, the token `aud` claim is derived from the `ResourceURL` (which is auto-computed when not specified), but the token validator checks against the user-specified `OIDCConfigRef.Audience`. If these values differ, every authenticated request silently fails with an audience mismatch -- a frustrating failure mode with no clear error message pointing to the root cause.

This PR adds reconciliation-time validation that `Audience` and `ResourceURL` match when an embedded auth server is active, surfacing the misconfiguration early with actionable error messages instead of letting it fail silently at runtime.

Closes #4860

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)

## Changes

| File | Change |
|------|--------|
| `cmd/thv-operator/pkg/controllerutil/authserver.go` | Extract duplicated OIDC validation into `validateOIDCConfigForEmbeddedAuthServer` helper; add audience-vs-resourceUrl consistency check with descriptive error messages |
| `cmd/thv-operator/pkg/controllerutil/authserver_test.go` | Add test cases for audience mismatch, empty audience, and matching audience scenarios in both `AddEmbeddedAuthServerConfigOptions` and `AddAuthServerRefOptions` |
| `cmd/thv-operator/controllers/mcpserver_externalauth_runconfig_test.go` | Update test fixtures to use matching audience/resourceUrl values |

## Does this introduce a user-facing change?

Yes. Operators who configure an `OIDCConfigRef` with an `Audience` that does not match the auto-computed `ResourceURL` will now see a clear reconciliation error instead of silently broken authentication. The error message tells them exactly what value to set.

## Special notes for reviewers

This implements Option D from the issue (validate consistency at reconciliation time). This approach was chosen over silently overriding `Audience` because it keeps both values explicit and gives operators full visibility into what the system expects -- consistent with how the existing `ValidateAuthServerIntegration` works for inline vMCP config.

Generated with [Claude Code](https://claude.com/claude-code)
