### PR TITLE
Default redirectUri on upstream providers as documented in CRD

### DIFF
--- a/cmd/thv-operator/pkg/controllerutil/authserver.go
+++ b/cmd/thv-operator/pkg/controllerutil/authserver.go
@@ -407,6 +407,7 @@ func AddEmbeddedAuthServerConfigOptions(
 	embeddedConfig, err := BuildAuthServerRunConfig(
 		namespace, mcpServerName, authServerConfig,
 		[]string{oidcConfig.ResourceURL}, oidcConfig.Scopes,
+		oidcConfig.ResourceURL,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to build embedded auth server config: %w", err)
@@ -421,15 +422,19 @@ func AddEmbeddedAuthServerConfigOptions(
 // BuildAuthServerRunConfig converts CRD EmbeddedAuthServerConfig to authserver.RunConfig.
 // The RunConfig is serializable and contains file paths for secrets (not the secrets themselves).
 //
-// AllowedAudiences and ScopesSupported are caller-provided because different controllers
-// derive them from different sources (MCPServer uses oidcConfig.ResourceURL/Scopes;
+// AllowedAudiences, ScopesSupported, and resourceURL are caller-provided because different
+// controllers derive them from different sources (MCPServer uses oidcConfig.ResourceURL/Scopes;
 // VirtualMCPServer derives from the resolved vmcp Config).
+//
+// resourceURL is used to default the RedirectURI on upstream providers when not explicitly set.
+// The default is {resourceURL}/oauth/callback as documented in the MCPExternalAuthConfig CRD.
 func BuildAuthServerRunConfig(
 	namespace string,
 	name string,
 	authConfig *mcpv1alpha1.EmbeddedAuthServerConfig,
 	allowedAudiences []string,
 	scopesSupported []string,
+	resourceURL string,
 ) (*authserver.RunConfig, error) {
 	config := &authserver.RunConfig{
 		SchemaVersion:                authserver.CurrentSchemaVersion,
@@ -474,7 +479,7 @@ func BuildAuthServerRunConfig(
 	bindings := buildUpstreamSecretBindings(authConfig.UpstreamProviders)
 	config.Upstreams = make([]authserver.UpstreamRunConfig, 0, len(bindings))
 	for _, b := range bindings {
-		config.Upstreams = append(config.Upstreams, *buildUpstreamRunConfig(b.Provider, b.EnvVarName))
+		config.Upstreams = append(config.Upstreams, *buildUpstreamRunConfig(b.Provider, b.EnvVarName, resourceURL))
 	}
 
 	// Build storage configuration
@@ -600,12 +605,21 @@ func resolveSentinelAddrs(
 	return []string{dnsName}, nil
 }
 
+// defaultRedirectURI returns the default redirect URI for an upstream provider
+// when one is not explicitly configured. The default is {resourceURL}/oauth/callback
+// as documented in the MCPExternalAuthConfig CRD.
+func defaultRedirectURI(resourceURL string) string {
+	return strings.TrimRight(resourceURL, "/") + "/oauth/callback"
+}
+
 // buildUpstreamRunConfig converts CRD UpstreamProviderConfig to authserver.UpstreamRunConfig.
 // The envVarName is computed by buildUpstreamSecretBindings to keep Pod env
-// and runtime config in sync.
+// and runtime config in sync. When a provider's RedirectURI is empty, it is
+// defaulted to {resourceURL}/oauth/callback.
 func buildUpstreamRunConfig(
 	provider *mcpv1alpha1.UpstreamProviderConfig,
 	envVarName string,
+	resourceURL string,
 ) *authserver.UpstreamRunConfig {
 	config := &authserver.UpstreamRunConfig{
 		Name: provider.Name,
@@ -615,10 +629,14 @@ func buildUpstreamRunConfig(
 	switch provider.Type {
 	case mcpv1alpha1.UpstreamProviderTypeOIDC:
 		if provider.OIDCConfig != nil {
+			redirectURI := provider.OIDCConfig.RedirectURI
+			if redirectURI == "" && resourceURL != "" {
+				redirectURI = defaultRedirectURI(resourceURL)
+			}
 			config.OIDCConfig = &authserver.OIDCUpstreamRunConfig{
 				IssuerURL:   provider.OIDCConfig.IssuerURL,
 				ClientID:    provider.OIDCConfig.ClientID,
-				RedirectURI: provider.OIDCConfig.RedirectURI,
+				RedirectURI: redirectURI,
 				Scopes:      provider.OIDCConfig.Scopes,
 			}
 			// If client secret is configured, reference it via env var
@@ -631,11 +649,15 @@ func buildUpstreamRunConfig(
 		}
 	case mcpv1alpha1.UpstreamProviderTypeOAuth2:
 		if provider.OAuth2Config != nil {
+			redirectURI := provider.OAuth2Config.RedirectURI
+			if redirectURI == "" && resourceURL != "" {
+				redirectURI = defaultRedirectURI(resourceURL)
+			}
 			config.OAuth2Config = &authserver.OAuth2UpstreamRunConfig{
 				AuthorizationEndpoint: provider.OAuth2Config.AuthorizationEndpoint,
 				TokenEndpoint:         provider.OAuth2Config.TokenEndpoint,
 				ClientID:              provider.OAuth2Config.ClientID,
-				RedirectURI:           provider.OAuth2Config.RedirectURI,
+				RedirectURI:           redirectURI,
 				Scopes:                provider.OAuth2Config.Scopes,
 			}
 			// If client secret is configured, reference it via env var
@@ -769,6 +791,7 @@ func AddAuthServerRefOptions(
 	embeddedConfig, err := BuildAuthServerRunConfig(
 		namespace, mcpServerName, authServerConfig,
 		[]string{oidcConfig.ResourceURL}, oidcConfig.Scopes,
+		oidcConfig.ResourceURL,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to build embedded auth server config: %w", err)

--- a/cmd/thv-operator/pkg/controllerutil/authserver.go
+++ b/cmd/thv-operator/pkg/controllerutil/authserver.go
@@ -403,6 +403,7 @@ func AddEmbeddedAuthServerConfigOptions(
 	embeddedConfig, err := BuildAuthServerRunConfig(
 		namespace, mcpServerName, authServerConfig,
 		[]string{oidcConfig.ResourceURL}, oidcConfig.Scopes,
+		oidcConfig.ResourceURL,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to build embedded auth server config: %w", err)
@@ -453,15 +454,19 @@ func validateOIDCConfigForEmbeddedAuthServer(oidcConfig *oidc.OIDCConfig) error 
 // BuildAuthServerRunConfig converts CRD EmbeddedAuthServerConfig to authserver.RunConfig.
 // The RunConfig is serializable and contains file paths for secrets (not the secrets themselves).
 //
-// AllowedAudiences and ScopesSupported are caller-provided because different controllers
-// derive them from different sources (MCPServer uses oidcConfig.ResourceURL/Scopes;
+// AllowedAudiences, ScopesSupported, and resourceURL are caller-provided because different
+// controllers derive them from different sources (MCPServer uses oidcConfig.ResourceURL/Scopes;
 // VirtualMCPServer derives from the resolved vmcp Config).
+//
+// resourceURL is used to default the RedirectURI on upstream providers when not explicitly set.
+// The default is {resourceURL}/oauth/callback as documented in the MCPExternalAuthConfig CRD.
 func BuildAuthServerRunConfig(
 	namespace string,
 	name string,
 	authConfig *mcpv1alpha1.EmbeddedAuthServerConfig,
 	allowedAudiences []string,
 	scopesSupported []string,
+	resourceURL string,
 ) (*authserver.RunConfig, error) {
 	config := &authserver.RunConfig{
 		SchemaVersion:                authserver.CurrentSchemaVersion,
@@ -506,7 +511,7 @@ func BuildAuthServerRunConfig(
 	bindings := buildUpstreamSecretBindings(authConfig.UpstreamProviders)
 	config.Upstreams = make([]authserver.UpstreamRunConfig, 0, len(bindings))
 	for _, b := range bindings {
-		config.Upstreams = append(config.Upstreams, *buildUpstreamRunConfig(b.Provider, b.EnvVarName))
+		config.Upstreams = append(config.Upstreams, *buildUpstreamRunConfig(b.Provider, b.EnvVarName, resourceURL))
 	}
 
 	// Build storage configuration
@@ -632,12 +637,21 @@ func resolveSentinelAddrs(
 	return []string{dnsName}, nil
 }
 
+// defaultRedirectURI returns the default redirect URI for an upstream provider
+// when one is not explicitly configured. The default is {resourceURL}/oauth/callback
+// as documented in the MCPExternalAuthConfig CRD.
+func defaultRedirectURI(resourceURL string) string {
+	return strings.TrimRight(resourceURL, "/") + "/oauth/callback"
+}
+
 // buildUpstreamRunConfig converts CRD UpstreamProviderConfig to authserver.UpstreamRunConfig.
 // The envVarName is computed by buildUpstreamSecretBindings to keep Pod env
-// and runtime config in sync.
+// and runtime config in sync. When a provider's RedirectURI is empty, it is
+// defaulted to {resourceURL}/oauth/callback.
 func buildUpstreamRunConfig(
 	provider *mcpv1alpha1.UpstreamProviderConfig,
 	envVarName string,
+	resourceURL string,
 ) *authserver.UpstreamRunConfig {
 	config := &authserver.UpstreamRunConfig{
 		Name: provider.Name,
@@ -647,10 +661,14 @@ func buildUpstreamRunConfig(
 	switch provider.Type {
 	case mcpv1alpha1.UpstreamProviderTypeOIDC:
 		if provider.OIDCConfig != nil {
+			redirectURI := provider.OIDCConfig.RedirectURI
+			if redirectURI == "" && resourceURL != "" {
+				redirectURI = defaultRedirectURI(resourceURL)
+			}
 			config.OIDCConfig = &authserver.OIDCUpstreamRunConfig{
 				IssuerURL:                     provider.OIDCConfig.IssuerURL,
 				ClientID:                      provider.OIDCConfig.ClientID,
-				RedirectURI:                   provider.OIDCConfig.RedirectURI,
+				RedirectURI:                   redirectURI,
 				Scopes:                        provider.OIDCConfig.Scopes,
 				AdditionalAuthorizationParams: provider.OIDCConfig.AdditionalAuthorizationParams,
 			}
@@ -664,11 +682,15 @@ func buildUpstreamRunConfig(
 		}
 	case mcpv1alpha1.UpstreamProviderTypeOAuth2:
 		if provider.OAuth2Config != nil {
+			redirectURI := provider.OAuth2Config.RedirectURI
+			if redirectURI == "" && resourceURL != "" {
+				redirectURI = defaultRedirectURI(resourceURL)
+			}
 			config.OAuth2Config = &authserver.OAuth2UpstreamRunConfig{
 				AuthorizationEndpoint:         provider.OAuth2Config.AuthorizationEndpoint,
 				TokenEndpoint:                 provider.OAuth2Config.TokenEndpoint,
 				ClientID:                      provider.OAuth2Config.ClientID,
-				RedirectURI:                   provider.OAuth2Config.RedirectURI,
+				RedirectURI:                   redirectURI,
 				Scopes:                        provider.OAuth2Config.Scopes,
 				AdditionalAuthorizationParams: provider.OAuth2Config.AdditionalAuthorizationParams,
 			}
@@ -799,6 +821,7 @@ func AddAuthServerRefOptions(
 	embeddedConfig, err := BuildAuthServerRunConfig(
 		namespace, mcpServerName, authServerConfig,
 		[]string{oidcConfig.ResourceURL}, oidcConfig.Scopes,
+		oidcConfig.ResourceURL,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to build embedded auth server config: %w", err)

--- a/cmd/thv-operator/pkg/controllerutil/authserver_test.go
+++ b/cmd/thv-operator/pkg/controllerutil/authserver_test.go
@@ -690,11 +690,14 @@ func TestBuildAuthServerRunConfig(t *testing.T) {
 	defaultAudiences := []string{"http://test-server.default.svc.cluster.local:8080"}
 	defaultScopes := []string{"openid", "offline_access"}
 
+	defaultResourceURL := "http://test-server.default.svc.cluster.local:8080"
+
 	tests := []struct {
 		name             string
 		authConfig       *mcpv1alpha1.EmbeddedAuthServerConfig
 		allowedAudiences []string
 		scopesSupported  []string
+		resourceURL      string
 		checkFunc        func(t *testing.T, config *authserver.RunConfig)
 	}{
 		{
@@ -774,7 +777,8 @@ func TestBuildAuthServerRunConfig(t *testing.T) {
 			},
 		},
 		{
-			name: "with OIDC upstream provider",
+			name:        "with OIDC upstream provider",
+			resourceURL: defaultResourceURL,
 			authConfig: &mcpv1alpha1.EmbeddedAuthServerConfig{
 				Issuer: "https://auth.example.com",
 				SigningKeySecretRefs: []mcpv1alpha1.SecretKeyRef{
@@ -811,7 +815,8 @@ func TestBuildAuthServerRunConfig(t *testing.T) {
 			},
 		},
 		{
-			name: "with OAuth2 upstream provider with userinfo config",
+			name:        "with OAuth2 upstream provider with userinfo config",
+			resourceURL: defaultResourceURL,
 			authConfig: &mcpv1alpha1.EmbeddedAuthServerConfig{
 				Issuer: "https://auth.example.com",
 				SigningKeySecretRefs: []mcpv1alpha1.SecretKeyRef{
@@ -904,7 +909,8 @@ func TestBuildAuthServerRunConfig(t *testing.T) {
 			},
 		},
 		{
-			name: "with multiple upstream providers all are included",
+			name:        "with multiple upstream providers all are included",
+			resourceURL: defaultResourceURL,
 			authConfig: &mcpv1alpha1.EmbeddedAuthServerConfig{
 				Issuer: "https://auth.example.com",
 				SigningKeySecretRefs: []mcpv1alpha1.SecretKeyRef{
@@ -967,13 +973,141 @@ func TestBuildAuthServerRunConfig(t *testing.T) {
 				assert.Equal(t, UpstreamClientSecretEnvVar+"_GITHUB", github.OAuth2Config.ClientSecretEnvVar)
 			},
 		},
+		{
+			name:        "OIDC upstream with empty redirectUri defaults to resourceURL/oauth/callback",
+			resourceURL: "https://mcp.example.com",
+			authConfig: &mcpv1alpha1.EmbeddedAuthServerConfig{
+				Issuer: "https://auth.example.com",
+				SigningKeySecretRefs: []mcpv1alpha1.SecretKeyRef{
+					{Name: "signing-key", Key: "private.pem"},
+				},
+				HMACSecretRefs: []mcpv1alpha1.SecretKeyRef{
+					{Name: "hmac-secret", Key: "hmac"},
+				},
+				UpstreamProviders: []mcpv1alpha1.UpstreamProviderConfig{
+					{
+						Name: "okta",
+						Type: mcpv1alpha1.UpstreamProviderTypeOIDC,
+						OIDCConfig: &mcpv1alpha1.OIDCUpstreamConfig{
+							IssuerURL: "https://okta.example.com",
+							ClientID:  "client-id",
+							// RedirectURI intentionally omitted
+						},
+					},
+				},
+			},
+			allowedAudiences: defaultAudiences,
+			scopesSupported:  defaultScopes,
+			checkFunc: func(t *testing.T, config *authserver.RunConfig) {
+				t.Helper()
+				require.Len(t, config.Upstreams, 1)
+				require.NotNil(t, config.Upstreams[0].OIDCConfig)
+				assert.Equal(t, "https://mcp.example.com/oauth/callback", config.Upstreams[0].OIDCConfig.RedirectURI)
+			},
+		},
+		{
+			name:        "OAuth2 upstream with empty redirectUri defaults to resourceURL/oauth/callback",
+			resourceURL: "https://mcp.example.com",
+			authConfig: &mcpv1alpha1.EmbeddedAuthServerConfig{
+				Issuer: "https://auth.example.com",
+				SigningKeySecretRefs: []mcpv1alpha1.SecretKeyRef{
+					{Name: "signing-key", Key: "private.pem"},
+				},
+				HMACSecretRefs: []mcpv1alpha1.SecretKeyRef{
+					{Name: "hmac-secret", Key: "hmac"},
+				},
+				UpstreamProviders: []mcpv1alpha1.UpstreamProviderConfig{
+					{
+						Name: "github",
+						Type: mcpv1alpha1.UpstreamProviderTypeOAuth2,
+						OAuth2Config: &mcpv1alpha1.OAuth2UpstreamConfig{
+							AuthorizationEndpoint: "https://github.com/login/oauth/authorize",
+							TokenEndpoint:         "https://github.com/login/oauth/access_token",
+							ClientID:              "client-id",
+							// RedirectURI intentionally omitted
+						},
+					},
+				},
+			},
+			allowedAudiences: defaultAudiences,
+			scopesSupported:  defaultScopes,
+			checkFunc: func(t *testing.T, config *authserver.RunConfig) {
+				t.Helper()
+				require.Len(t, config.Upstreams, 1)
+				require.NotNil(t, config.Upstreams[0].OAuth2Config)
+				assert.Equal(t, "https://mcp.example.com/oauth/callback", config.Upstreams[0].OAuth2Config.RedirectURI)
+			},
+		},
+		{
+			name:        "explicit redirectUri is preserved when resourceURL is also set",
+			resourceURL: "https://mcp.example.com",
+			authConfig: &mcpv1alpha1.EmbeddedAuthServerConfig{
+				Issuer: "https://auth.example.com",
+				SigningKeySecretRefs: []mcpv1alpha1.SecretKeyRef{
+					{Name: "signing-key", Key: "private.pem"},
+				},
+				HMACSecretRefs: []mcpv1alpha1.SecretKeyRef{
+					{Name: "hmac-secret", Key: "hmac"},
+				},
+				UpstreamProviders: []mcpv1alpha1.UpstreamProviderConfig{
+					{
+						Name: "okta",
+						Type: mcpv1alpha1.UpstreamProviderTypeOIDC,
+						OIDCConfig: &mcpv1alpha1.OIDCUpstreamConfig{
+							IssuerURL:   "https://okta.example.com",
+							ClientID:    "client-id",
+							RedirectURI: "https://custom.example.com/callback",
+						},
+					},
+				},
+			},
+			allowedAudiences: defaultAudiences,
+			scopesSupported:  defaultScopes,
+			checkFunc: func(t *testing.T, config *authserver.RunConfig) {
+				t.Helper()
+				require.Len(t, config.Upstreams, 1)
+				require.NotNil(t, config.Upstreams[0].OIDCConfig)
+				assert.Equal(t, "https://custom.example.com/callback", config.Upstreams[0].OIDCConfig.RedirectURI)
+			},
+		},
+		{
+			name:        "resourceURL with trailing slash produces correct default redirectUri",
+			resourceURL: "https://mcp.example.com/",
+			authConfig: &mcpv1alpha1.EmbeddedAuthServerConfig{
+				Issuer: "https://auth.example.com",
+				SigningKeySecretRefs: []mcpv1alpha1.SecretKeyRef{
+					{Name: "signing-key", Key: "private.pem"},
+				},
+				HMACSecretRefs: []mcpv1alpha1.SecretKeyRef{
+					{Name: "hmac-secret", Key: "hmac"},
+				},
+				UpstreamProviders: []mcpv1alpha1.UpstreamProviderConfig{
+					{
+						Name: "okta",
+						Type: mcpv1alpha1.UpstreamProviderTypeOIDC,
+						OIDCConfig: &mcpv1alpha1.OIDCUpstreamConfig{
+							IssuerURL: "https://okta.example.com",
+							ClientID:  "client-id",
+						},
+					},
+				},
+			},
+			allowedAudiences: defaultAudiences,
+			scopesSupported:  defaultScopes,
+			checkFunc: func(t *testing.T, config *authserver.RunConfig) {
+				t.Helper()
+				require.Len(t, config.Upstreams, 1)
+				require.NotNil(t, config.Upstreams[0].OIDCConfig)
+				assert.Equal(t, "https://mcp.example.com/oauth/callback", config.Upstreams[0].OIDCConfig.RedirectURI)
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			config, err := BuildAuthServerRunConfig("default", "test-server", tt.authConfig, tt.allowedAudiences, tt.scopesSupported)
+			config, err := BuildAuthServerRunConfig("default", "test-server", tt.authConfig, tt.allowedAudiences, tt.scopesSupported, tt.resourceURL)
 
 			require.NoError(t, err)
 			require.NotNil(t, config)
@@ -1538,6 +1672,7 @@ func TestBuildAuthServerRunConfig_WithRedisStorage(t *testing.T) {
 		"default", "my-mcp-server", authConfig,
 		[]string{"http://test-server.default.svc.cluster.local:8080"},
 		[]string{"openid"},
+		"http://test-server.default.svc.cluster.local:8080",
 	)
 
 	require.NoError(t, err)

--- a/cmd/thv-operator/pkg/controllerutil/authserver_test.go
+++ b/cmd/thv-operator/pkg/controllerutil/authserver_test.go
@@ -690,11 +690,14 @@ func TestBuildAuthServerRunConfig(t *testing.T) {
 	defaultAudiences := []string{"http://test-server.default.svc.cluster.local:8080"}
 	defaultScopes := []string{"openid", "offline_access"}
 
+	defaultResourceURL := "http://test-server.default.svc.cluster.local:8080"
+
 	tests := []struct {
 		name             string
 		authConfig       *mcpv1alpha1.EmbeddedAuthServerConfig
 		allowedAudiences []string
 		scopesSupported  []string
+		resourceURL      string
 		checkFunc        func(t *testing.T, config *authserver.RunConfig)
 	}{
 		{
@@ -774,7 +777,8 @@ func TestBuildAuthServerRunConfig(t *testing.T) {
 			},
 		},
 		{
-			name: "with OIDC upstream provider",
+			name:        "with OIDC upstream provider",
+			resourceURL: defaultResourceURL,
 			authConfig: &mcpv1alpha1.EmbeddedAuthServerConfig{
 				Issuer: "https://auth.example.com",
 				SigningKeySecretRefs: []mcpv1alpha1.SecretKeyRef{
@@ -811,7 +815,8 @@ func TestBuildAuthServerRunConfig(t *testing.T) {
 			},
 		},
 		{
-			name: "with OAuth2 upstream provider with userinfo config",
+			name:        "with OAuth2 upstream provider with userinfo config",
+			resourceURL: defaultResourceURL,
 			authConfig: &mcpv1alpha1.EmbeddedAuthServerConfig{
 				Issuer: "https://auth.example.com",
 				SigningKeySecretRefs: []mcpv1alpha1.SecretKeyRef{
@@ -904,7 +909,8 @@ func TestBuildAuthServerRunConfig(t *testing.T) {
 			},
 		},
 		{
-			name: "with multiple upstream providers all are included",
+			name:        "with multiple upstream providers all are included",
+			resourceURL: defaultResourceURL,
 			authConfig: &mcpv1alpha1.EmbeddedAuthServerConfig{
 				Issuer: "https://auth.example.com",
 				SigningKeySecretRefs: []mcpv1alpha1.SecretKeyRef{
@@ -1047,7 +1053,7 @@ func TestBuildAuthServerRunConfig(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			config, err := BuildAuthServerRunConfig("default", "test-server", tt.authConfig, tt.allowedAudiences, tt.scopesSupported)
+			config, err := BuildAuthServerRunConfig("default", "test-server", tt.authConfig, tt.allowedAudiences, tt.scopesSupported, tt.resourceURL)
 
 			require.NoError(t, err)
 			require.NotNil(t, config)
@@ -1634,6 +1640,7 @@ func TestBuildAuthServerRunConfig_WithRedisStorage(t *testing.T) {
 		"default", "my-mcp-server", authConfig,
 		[]string{"http://test-server.default.svc.cluster.local:8080"},
 		[]string{"openid"},
+		"http://test-server.default.svc.cluster.local:8080",
 	)
 
 	require.NoError(t, err)

--- a/cmd/thv-operator/pkg/controllerutil/authserver_test.go
+++ b/cmd/thv-operator/pkg/controllerutil/authserver_test.go
@@ -1047,6 +1047,134 @@ func TestBuildAuthServerRunConfig(t *testing.T) {
 					upstream.OAuth2Config.AdditionalAuthorizationParams)
 			},
 		},
+		{
+			name:        "OIDC upstream with empty redirectUri defaults to resourceURL/oauth/callback",
+			resourceURL: "https://mcp.example.com",
+			authConfig: &mcpv1alpha1.EmbeddedAuthServerConfig{
+				Issuer: "https://auth.example.com",
+				SigningKeySecretRefs: []mcpv1alpha1.SecretKeyRef{
+					{Name: "signing-key", Key: "private.pem"},
+				},
+				HMACSecretRefs: []mcpv1alpha1.SecretKeyRef{
+					{Name: "hmac-secret", Key: "hmac"},
+				},
+				UpstreamProviders: []mcpv1alpha1.UpstreamProviderConfig{
+					{
+						Name: "okta",
+						Type: mcpv1alpha1.UpstreamProviderTypeOIDC,
+						OIDCConfig: &mcpv1alpha1.OIDCUpstreamConfig{
+							IssuerURL: "https://okta.example.com",
+							ClientID:  "client-id",
+							// RedirectURI intentionally omitted
+						},
+					},
+				},
+			},
+			allowedAudiences: defaultAudiences,
+			scopesSupported:  defaultScopes,
+			checkFunc: func(t *testing.T, config *authserver.RunConfig) {
+				t.Helper()
+				require.Len(t, config.Upstreams, 1)
+				require.NotNil(t, config.Upstreams[0].OIDCConfig)
+				assert.Equal(t, "https://mcp.example.com/oauth/callback", config.Upstreams[0].OIDCConfig.RedirectURI)
+			},
+		},
+		{
+			name:        "OAuth2 upstream with empty redirectUri defaults to resourceURL/oauth/callback",
+			resourceURL: "https://mcp.example.com",
+			authConfig: &mcpv1alpha1.EmbeddedAuthServerConfig{
+				Issuer: "https://auth.example.com",
+				SigningKeySecretRefs: []mcpv1alpha1.SecretKeyRef{
+					{Name: "signing-key", Key: "private.pem"},
+				},
+				HMACSecretRefs: []mcpv1alpha1.SecretKeyRef{
+					{Name: "hmac-secret", Key: "hmac"},
+				},
+				UpstreamProviders: []mcpv1alpha1.UpstreamProviderConfig{
+					{
+						Name: "github",
+						Type: mcpv1alpha1.UpstreamProviderTypeOAuth2,
+						OAuth2Config: &mcpv1alpha1.OAuth2UpstreamConfig{
+							AuthorizationEndpoint: "https://github.com/login/oauth/authorize",
+							TokenEndpoint:         "https://github.com/login/oauth/access_token",
+							ClientID:              "client-id",
+							// RedirectURI intentionally omitted
+						},
+					},
+				},
+			},
+			allowedAudiences: defaultAudiences,
+			scopesSupported:  defaultScopes,
+			checkFunc: func(t *testing.T, config *authserver.RunConfig) {
+				t.Helper()
+				require.Len(t, config.Upstreams, 1)
+				require.NotNil(t, config.Upstreams[0].OAuth2Config)
+				assert.Equal(t, "https://mcp.example.com/oauth/callback", config.Upstreams[0].OAuth2Config.RedirectURI)
+			},
+		},
+		{
+			name:        "explicit redirectUri is preserved when resourceURL is also set",
+			resourceURL: "https://mcp.example.com",
+			authConfig: &mcpv1alpha1.EmbeddedAuthServerConfig{
+				Issuer: "https://auth.example.com",
+				SigningKeySecretRefs: []mcpv1alpha1.SecretKeyRef{
+					{Name: "signing-key", Key: "private.pem"},
+				},
+				HMACSecretRefs: []mcpv1alpha1.SecretKeyRef{
+					{Name: "hmac-secret", Key: "hmac"},
+				},
+				UpstreamProviders: []mcpv1alpha1.UpstreamProviderConfig{
+					{
+						Name: "okta",
+						Type: mcpv1alpha1.UpstreamProviderTypeOIDC,
+						OIDCConfig: &mcpv1alpha1.OIDCUpstreamConfig{
+							IssuerURL:   "https://okta.example.com",
+							ClientID:    "client-id",
+							RedirectURI: "https://custom.example.com/callback",
+						},
+					},
+				},
+			},
+			allowedAudiences: defaultAudiences,
+			scopesSupported:  defaultScopes,
+			checkFunc: func(t *testing.T, config *authserver.RunConfig) {
+				t.Helper()
+				require.Len(t, config.Upstreams, 1)
+				require.NotNil(t, config.Upstreams[0].OIDCConfig)
+				assert.Equal(t, "https://custom.example.com/callback", config.Upstreams[0].OIDCConfig.RedirectURI)
+			},
+		},
+		{
+			name:        "resourceURL with trailing slash produces correct default redirectUri",
+			resourceURL: "https://mcp.example.com/",
+			authConfig: &mcpv1alpha1.EmbeddedAuthServerConfig{
+				Issuer: "https://auth.example.com",
+				SigningKeySecretRefs: []mcpv1alpha1.SecretKeyRef{
+					{Name: "signing-key", Key: "private.pem"},
+				},
+				HMACSecretRefs: []mcpv1alpha1.SecretKeyRef{
+					{Name: "hmac-secret", Key: "hmac"},
+				},
+				UpstreamProviders: []mcpv1alpha1.UpstreamProviderConfig{
+					{
+						Name: "okta",
+						Type: mcpv1alpha1.UpstreamProviderTypeOIDC,
+						OIDCConfig: &mcpv1alpha1.OIDCUpstreamConfig{
+							IssuerURL: "https://okta.example.com",
+							ClientID:  "client-id",
+						},
+					},
+				},
+			},
+			allowedAudiences: defaultAudiences,
+			scopesSupported:  defaultScopes,
+			checkFunc: func(t *testing.T, config *authserver.RunConfig) {
+				t.Helper()
+				require.Len(t, config.Upstreams, 1)
+				require.NotNil(t, config.Upstreams[0].OIDCConfig)
+				assert.Equal(t, "https://mcp.example.com/oauth/callback", config.Upstreams[0].OIDCConfig.RedirectURI)
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/cmd/thv-operator/pkg/vmcpconfig/converter.go
+++ b/cmd/thv-operator/pkg/vmcpconfig/converter.go
@@ -318,6 +318,7 @@ func (*Converter) convertAuthServerConfig(
 		vmcp.Spec.AuthServerConfig,
 		deriveAllowedAudiences(config),
 		deriveScopesSupported(config),
+		deriveResourceURL(config),
 	)
 }
 
@@ -342,6 +343,16 @@ func deriveAllowedAudiences(config *vmcpconfig.Config) []string {
 		return nil
 	}
 	return []string{resource}
+}
+
+// deriveResourceURL returns the resource URL from the resolved incoming OIDC config.
+// Returns empty string when OIDC is not configured or Resource is empty.
+// Used to default upstream provider RedirectURIs to {resourceURL}/oauth/callback.
+func deriveResourceURL(config *vmcpconfig.Config) string {
+	if config.IncomingAuth == nil || config.IncomingAuth.OIDC == nil {
+		return ""
+	}
+	return config.IncomingAuth.OIDC.Resource
 }
 
 // deriveScopesSupported returns the scopes from the resolved incoming OIDC config.

--- a/cmd/thv-operator/pkg/vmcpconfig/converter_test.go
+++ b/cmd/thv-operator/pkg/vmcpconfig/converter_test.go
@@ -1710,6 +1710,60 @@ func TestDeriveScopesSupported(t *testing.T) {
 	}
 }
 
+func TestDeriveResourceURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		config   *vmcpconfig.Config
+		expected string
+	}{
+		{
+			name:     "nil IncomingAuth returns empty",
+			config:   &vmcpconfig.Config{},
+			expected: "",
+		},
+		{
+			name: "nil OIDC returns empty",
+			config: &vmcpconfig.Config{
+				IncomingAuth: &vmcpconfig.IncomingAuthConfig{Type: "oidc"},
+			},
+			expected: "",
+		},
+		{
+			name: "empty Resource returns empty",
+			config: &vmcpconfig.Config{
+				IncomingAuth: &vmcpconfig.IncomingAuthConfig{
+					Type: "oidc",
+					OIDC: &vmcpconfig.OIDCConfig{},
+				},
+			},
+			expected: "",
+		},
+		{
+			name: "populated Resource is returned",
+			config: &vmcpconfig.Config{
+				IncomingAuth: &vmcpconfig.IncomingAuthConfig{
+					Type: "oidc",
+					OIDC: &vmcpconfig.OIDCConfig{
+						Resource: "https://resource.example.com",
+					},
+				},
+			},
+			expected: "https://resource.example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := deriveResourceURL(tt.config)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
 // TestConvert_AuthServerConfigIntegration is an integration-level test that exercises the
 // full Convert() path with an AuthServerConfig set on the VirtualMCPServer. It verifies that
 // the returned RunConfig has the correct Issuer, Upstreams, and AllowedAudiences derived


### PR DESCRIPTION
## Summary

The `MCPExternalAuthConfig` CRD documents that `redirectUri` on upstream providers defaults to `{resourceUrl}/oauth/callback` when omitted, but the operator was passing the empty string through to the proxy runner without resolving the default. This caused the embedded auth server to reject the configuration at runtime with `redirect_uri is required`.

This PR applies the documented default for both OIDC and OAuth2 upstream providers in `BuildAuthServerRunConfig`, fixing the bug for both MCPServer and VirtualMCPServer controllers.

Closes #4874

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)

## Changes

| File | Change |
|------|--------|
| `cmd/thv-operator/pkg/controllerutil/authserver.go` | Thread `resourceURL` through `BuildAuthServerRunConfig` and `buildUpstreamRunConfig`; default empty `RedirectURI` to `{resourceURL}/oauth/callback` for both OIDC and OAuth2 providers |
| `cmd/thv-operator/pkg/controllerutil/authserver_test.go` | Add test cases for empty redirectUri defaulting (OIDC, OAuth2), explicit redirectUri preservation, and trailing-slash handling |
| `cmd/thv-operator/pkg/vmcpconfig/converter.go` | Add `deriveResourceURL` helper to extract resource URL from resolved vMCP config for the new parameter |
| `cmd/thv-operator/pkg/vmcpconfig/converter_test.go` | Add unit tests for `deriveResourceURL` covering nil, empty, and populated cases |

## Does this introduce a user-facing change?

Yes. Operators that omit `redirectUri` from upstream provider configs in `MCPExternalAuthConfig` will now get the documented default (`{resourceUrl}/oauth/callback`) instead of a runtime error. Users who already set `redirectUri` explicitly are unaffected.

Generated with [Claude Code](https://claude.com/claude-code)
