### PR TITLE
Add name attribute alias on Resource entities

### DIFF
--- a/pkg/authz/authorizers/cedar/core.go
+++ b/pkg/authz/authorizers/cedar/core.go
@@ -637,6 +637,7 @@ func (a *Authorizer) authorizeResourceRead(
 
 	// Create attributes for the entities
 	attributes := mergeContexts(map[string]interface{}{
+		"name":      resourceURI,
 		"uri":       resourceURI,
 		"operation": "read",
 		"feature":   "resource",

--- a/pkg/authz/authorizers/cedar/core_test.go
+++ b/pkg/authz/authorizers/cedar/core_test.go
@@ -270,6 +270,69 @@ func TestAuthorizeWithJWTClaims(t *testing.T) {
 			expectAuthorized: true,
 		},
 		{
+			name: "Resource entity exposes name attribute for Cedar schema",
+			policy: `
+			permit(
+				principal,
+				action == Action::"read_resource",
+				resource
+			)
+			when {
+				resource.name == "sensitive_data"
+			};
+			`,
+			claims: jwt.MapClaims{
+				"sub": "user123",
+			},
+			feature:          authorizers.MCPFeatureResource,
+			operation:        authorizers.MCPOperationRead,
+			resourceID:       "sensitive_data",
+			arguments:        nil,
+			expectAuthorized: true,
+		},
+		{
+			name: "Resource entity retains uri attribute for backward compat",
+			policy: `
+			permit(
+				principal,
+				action == Action::"read_resource",
+				resource
+			)
+			when {
+				resource.uri == "sensitive_data"
+			};
+			`,
+			claims: jwt.MapClaims{
+				"sub": "user123",
+			},
+			feature:          authorizers.MCPFeatureResource,
+			operation:        authorizers.MCPOperationRead,
+			resourceID:       "sensitive_data",
+			arguments:        nil,
+			expectAuthorized: true,
+		},
+		{
+			name: "Resource name and uri attributes carry the same value",
+			policy: `
+			permit(
+				principal,
+				action == Action::"read_resource",
+				resource
+			)
+			when {
+				resource.name == resource.uri
+			};
+			`,
+			claims: jwt.MapClaims{
+				"sub": "user123",
+			},
+			feature:          authorizers.MCPFeatureResource,
+			operation:        authorizers.MCPOperationRead,
+			resourceID:       "sensitive_data",
+			arguments:        nil,
+			expectAuthorized: true,
+		},
+		{
 			name: "User can get prompt",
 			policy: `
 			permit(

--- a/pkg/authz/authorizers/cedar/entity.go
+++ b/pkg/authz/authorizers/cedar/entity.go
@@ -79,11 +79,15 @@ func (*EntityFactory) CreateResourceEntity(
 ) (cedar.EntityUID, cedar.Entity) {
 	uid := cedar.NewEntityUID(cedar.EntityType(resourceType), cedar.String(resourceID))
 
-	// Ensure name attribute is set
+	// Ensure name attribute is set — but don't overwrite if the caller
+	// already provided one (e.g. authorizeResourceRead sets name to the
+	// original URI before sanitization).
 	if attributes == nil {
 		attributes = make(map[string]interface{})
 	}
-	attributes["name"] = resourceID
+	if _, exists := attributes["name"]; !exists {
+		attributes["name"] = resourceID
+	}
 
 	attrs := convertMapToCedarRecord(attributes)
 

--- a/pkg/authz/authorizers/cedar/entity_test.go
+++ b/pkg/authz/authorizers/cedar/entity_test.go
@@ -161,6 +161,69 @@ func TestCreateResourceEntity_Parents(t *testing.T) {
 	}
 }
 
+// TestCreateResourceEntity_NamePreservation is a regression test for the bug
+// where CreateResourceEntity unconditionally overwrote attributes["name"] with
+// resourceID (the sanitized entity UID). authorizeResourceRead sets name to the
+// original, unsanitized URI before calling CreateResourceEntity — the caller's
+// value must survive. When no name is provided, resourceID is used as fallback.
+func TestCreateResourceEntity_NamePreservation(t *testing.T) {
+	t.Parallel()
+
+	factory := NewEntityFactory()
+
+	tests := []struct {
+		name       string
+		resourceID string
+		attributes map[string]interface{}
+		wantName   string
+	}{
+		{
+			name:       "caller_name_preserved",
+			resourceID: "sanitized-resource-id",
+			attributes: map[string]interface{}{
+				"name": "original/unsanitized:uri",
+			},
+			wantName: "original/unsanitized:uri",
+		},
+		{
+			name:       "uri_with_special_characters_preserved",
+			resourceID: "https___example_com_api_v1_resource_id=42",
+			attributes: map[string]interface{}{
+				"name": "https://example.com/api/v1/resource?id=42",
+			},
+			wantName: "https://example.com/api/v1/resource?id=42",
+		},
+		{
+			name:       "fallback_to_resourceID_when_name_absent",
+			resourceID: "weather",
+			attributes: map[string]interface{}{
+				"description": "Weather tool",
+			},
+			wantName: "weather",
+		},
+		{
+			name:       "fallback_to_resourceID_when_attributes_nil",
+			resourceID: "weather",
+			attributes: nil,
+			wantName:   "weather",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, entity := factory.CreateResourceEntity(
+				"Resource", tt.resourceID, tt.attributes,
+			)
+
+			nameVal, found := entity.Attributes.Get(cedar.String("name"))
+			require.True(t, found, "name attribute must always be set")
+			assert.Equal(t, tt.wantName, string(nameVal.(cedar.String)))
+		})
+	}
+}
+
 // TestCreateEntitiesForRequest_GroupsAsParents verifies that
 // CreateEntitiesForRequest sets THVGroup parent UIDs on the principal but
 // does NOT insert separate THVGroup entities into the entity map (fixing


### PR DESCRIPTION
## Summary

- Resource entities in `authorizeResourceRead` lacked a `name` attribute, while Tool and Prompt entities had one populated by `CreateResourceEntity`. This allows the admin to declare `name: String` as required on all three entity kinds
- Adds `"name": resourceURI` to the attributes map in `authorizeResourceRead` so Resource entities satisfy the schema.
- Makes `CreateResourceEntity` default `name` to `resourceID` only when the caller has not already set it, so the unsanitized URI supplied by `authorizeResourceRead` survives and policies can match on the real URI rather than the Cedar-sanitized entity ID.

Fixes #4766

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [x] Unit tests (`task test`)
- [x] Manual testing (describe below)

Manual E2E in a Kind cluster with real Entra ID tokens, using this policy:

```cedar
permit(principal in THVGroup::"mcp-admin",
       action == Action::"call_tool",
       resource in MCP::"entra-role-test")
  when { resource.name == "echo" };
```

With an Entra JWT carrying `"roles": ["mcp-admin", "developer"]`:

- `call_tool "echo"` → 200 (`resource.name` matches)
- `call_tool "nonexistent_tool"` → 403 (name mismatch)

Two regression unit tests were added:

- `TestCreateResourceEntity_NamePreservation` — guards against reintroducing the unconditional `attributes["name"] = resourceID` overwrite.
- A new test in `core_test.go` exercising the `authorizeResourceRead` path to confirm the `name` attribute is emitted.