### PR TITLE
runner: keep the container-internal target port as requested

### DIFF
--- a/pkg/runner/config.go
+++ b/pkg/runner/config.go
@@ -507,14 +507,28 @@ func (c *RunConfig) WithPorts(proxyPort, targetPort int) (*RunConfig, error) {
 	}
 	c.Port = selectedPort
 
-	// Select a target port for the container if using SSE or Streamable HTTP transport
+	// Select a target port for the container if using SSE or Streamable HTTP transport.
+	// The target port is the port the MCP server listens on *inside the
+	// container*, so it must not be validated against host port
+	// availability: if the requested target port happens to be busy on
+	// the host, networking.FindOrUsePort would silently swap in a
+	// random alternative and the proxy would end up pointing at the
+	// wrong container-internal port. Only fall through to
+	// FindOrUsePort when no target port was requested, so we still
+	// pick an available number for the proxy side to route to. See
+	// stacklok/toolhive#4761.
 	if c.Transport == types.TransportTypeSSE || c.Transport == types.TransportTypeStreamableHTTP {
-		selectedTargetPort, err := networking.FindOrUsePort(targetPort)
-		if err != nil {
-			return c, fmt.Errorf("target port error: %w", err)
+		if targetPort != 0 {
+			slog.Debug("using requested target port", "port", targetPort)
+			c.TargetPort = targetPort
+		} else {
+			selectedTargetPort, err := networking.FindOrUsePort(0)
+			if err != nil {
+				return c, fmt.Errorf("target port error: %w", err)
+			}
+			slog.Debug("using target port", "port", selectedTargetPort)
+			c.TargetPort = selectedTargetPort
 		}
-		slog.Debug("using target port", "port", selectedTargetPort)
-		c.TargetPort = selectedTargetPort
 	}
 
 	return c, nil


### PR DESCRIPTION
Fixes #4761.

## Problem

`RunConfig.WithPorts` treats the container-internal *target* port the same way it treats the *proxy* port: it pipes both through `networking.FindOrUsePort`, which checks host-side availability and silently swaps to a random free port when the requested number is busy on the host.

For the proxy port that's correct (it really does bind on the host). For the target port — the port the MCP server listens on *inside* the container — host availability is irrelevant. The result is:

1. `TestRunConfigBuilder_MetadataOverrides/Metadata_transport_used_...` fails non-deterministically when port 3000 is in use on the developer laptop (expected 3000, got a random port).
2. In production, a container whose metadata sets `TargetPort: 3000` on a host where 3000 is busy silently gets reconfigured to a random target port. The MCP server inside the container is not listening there, so every request through the proxy hits a connection error.

## Fix

In `pkg/runner/config.go`, when the caller has asked for a specific `targetPort`, keep it as-is. Only fall through to `networking.FindOrUsePort(0)` when no target port was requested, so we still pick an available number when we're choosing for the caller.

```go
if c.Transport == types.TransportTypeSSE || c.Transport == types.TransportTypeStreamableHTTP {
    if targetPort != 0 {
        c.TargetPort = targetPort
    } else {
        selectedTargetPort, err := networking.FindOrUsePort(0)
        if err != nil { return c, fmt.Errorf("target port error: %w", err) }
        c.TargetPort = selectedTargetPort
    }
}
```

Proxy-port logic above this block is untouched.

Signed off per DCO.
