### PR TITLE
mcp/server: stop TestBuildServerConfig on buildServerConfig failure

### DIFF
--- a/pkg/mcp/server/handler_test.go
+++ b/pkg/mcp/server/handler_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	regtypes "github.com/stacklok/toolhive-core/registry/types"
 	"github.com/stacklok/toolhive/pkg/runner"
@@ -340,11 +341,19 @@ func TestBuildServerConfig(t *testing.T) {
 			runConfig, err := buildServerConfig(ctx, args, tt.imageURL, tt.imageMetadata, tt.extraOpts...)
 
 			if tt.expectError {
-				assert.Error(t, err)
-				assert.Nil(t, runConfig)
+				require.Error(t, err)
+				require.Nil(t, runConfig)
 			} else {
-				assert.NoError(t, err)
-				assert.NotNil(t, runConfig)
+				// Use require instead of assert: if buildServerConfig
+				// fails (e.g. when no container runtime is available on
+				// the host) it returns (nil, err). With the earlier
+				// assert.* calls, execution fell through to
+				// tt.checkConfig(t, nil) and the test binary crashed
+				// with a nil pointer panic. Stopping the subtest here
+				// turns that crash into a clean failure, see
+				// stacklok/toolhive#4760.
+				require.NoError(t, err)
+				require.NotNil(t, runConfig)
 				if tt.checkConfig != nil {
 					tt.checkConfig(t, runConfig)
 				}


### PR DESCRIPTION
Fixes #4760.

## Problem

When no container runtime (Docker/Podman) is available on the host, `buildServerConfig` returns `(nil, err)`. The subtest body in `TestBuildServerConfig` uses `assert.NoError` / `assert.NotNil`, which record a failure but keep the subtest body running. Execution then falls through to

```go
tt.checkConfig(t, nil)
```

and the test binary crashes with a nil-pointer dereference that masks results from every other package in the same `go test ./...` run:

```
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
pkg/mcp/server.TestBuildServerConfig.func2(...)
    pkg/mcp/server/handler_test.go:349
```

## Fix

Swap the four relevant `assert.*` calls in the subtest to `require.*` equivalents so a failed `buildServerConfig` cleanly ends the subtest instead of marching into a nil deref. `require` is already pulled in through the existing import block.

No production code changes.

Signed off per DCO.
