### PR TITLE
vmcp: allow embedders to inject custom session DataStorage

### DIFF
--- a/pkg/vmcp/server/datastorage_injection_test.go
+++ b/pkg/vmcp/server/datastorage_injection_test.go
@@ -1,0 +1,162 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package server_test
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	transportsession "github.com/stacklok/toolhive/pkg/transport/session"
+	"github.com/stacklok/toolhive/pkg/vmcp"
+	vmcpconfig "github.com/stacklok/toolhive/pkg/vmcp/config"
+	discoveryMocks "github.com/stacklok/toolhive/pkg/vmcp/discovery/mocks"
+	"github.com/stacklok/toolhive/pkg/vmcp/mocks"
+	routerMocks "github.com/stacklok/toolhive/pkg/vmcp/router/mocks"
+	"github.com/stacklok/toolhive/pkg/vmcp/server"
+)
+
+// countingDataStorage wraps a real LocalSessionDataStorage and counts how
+// many times Close has been invoked. Used to assert that Server.Stop does
+// not close a caller-supplied DataStorage.
+type countingDataStorage struct {
+	transportsession.DataStorage
+	closeCalls atomic.Int32
+}
+
+func (c *countingDataStorage) Close() error {
+	c.closeCalls.Add(1)
+	return c.DataStorage.Close()
+}
+
+func newCountingDataStorage(t *testing.T) *countingDataStorage {
+	t.Helper()
+	inner, err := transportsession.NewLocalSessionDataStorage(5 * time.Minute)
+	require.NoError(t, err)
+	return &countingDataStorage{DataStorage: inner}
+}
+
+func TestNew_CallerOwnedDataStorageNotClosedOnStop(t *testing.T) {
+	t.Parallel()
+
+	spy := newCountingDataStorage(t)
+	// The spy is caller-owned; close the inner LocalSessionDataStorage
+	// directly at the end of the test so the counter is not ticked by
+	// cleanup — the post-Stop assertion below must reflect only the server's
+	// behaviour. Err ignored: closing an already-closed local store is a
+	// no-op in this implementation.
+	t.Cleanup(func() {
+		_ = spy.DataStorage.Close()
+	})
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	mockRouter := routerMocks.NewMockRouter(ctrl)
+	mockBackendClient := mocks.NewMockBackendClient(ctrl)
+	mockDiscoveryMgr := discoveryMocks.NewMockManager(ctrl)
+	mockDiscoveryMgr.EXPECT().Stop().Times(1)
+
+	srv, err := server.New(
+		t.Context(),
+		&server.Config{
+			Host:           "127.0.0.1",
+			Port:           0,
+			SessionFactory: newNoopMockFactory(t),
+			DataStorage:    spy,
+		},
+		mockRouter,
+		mockBackendClient,
+		mockDiscoveryMgr,
+		vmcp.NewImmutableRegistry([]vmcp.Backend{}),
+		nil,
+	)
+	require.NoError(t, err)
+
+	err = srv.Stop(t.Context())
+	require.NoError(t, err)
+
+	assert.Equal(t, int32(0), spy.closeCalls.Load(),
+		"server must not close a caller-supplied DataStorage")
+}
+
+func TestNew_BothSessionStorageAndDataStorageErrors(t *testing.T) {
+	t.Parallel()
+
+	spy := newCountingDataStorage(t)
+	// Err ignored: closing an already-closed local store is a no-op.
+	t.Cleanup(func() {
+		_ = spy.DataStorage.Close()
+	})
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	mockRouter := routerMocks.NewMockRouter(ctrl)
+	mockBackendClient := mocks.NewMockBackendClient(ctrl)
+	mockDiscoveryMgr := discoveryMocks.NewMockManager(ctrl)
+
+	_, err := server.New(
+		t.Context(),
+		&server.Config{
+			Host:           "127.0.0.1",
+			Port:           0,
+			SessionFactory: newNoopMockFactory(t),
+			SessionStorage: &vmcpconfig.SessionStorageConfig{
+				Provider: "redis",
+				Address:  "127.0.0.1:6379",
+			},
+			DataStorage: spy,
+		},
+		mockRouter,
+		mockBackendClient,
+		mockDiscoveryMgr,
+		vmcp.NewImmutableRegistry([]vmcp.Backend{}),
+		nil,
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "DataStorage")
+	assert.Contains(t, err.Error(), "SessionStorage")
+	assert.Equal(t, int32(0), spy.closeCalls.Load(),
+		"server must not close a caller-supplied DataStorage on misconfiguration")
+}
+
+func TestNew_ServerBuiltDataStorageStopSucceeds(t *testing.T) {
+	// Guards against accidental regression of the server-owned close path
+	// when Close moved from an inline Stop() block onto sessionDataStorageCloser.
+	// Stop() must still complete without error when the server built the store.
+	// This is a smoke test — it cannot observe Close on the internal
+	// LocalSessionDataStorage because that type is constructed inside New().
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	mockRouter := routerMocks.NewMockRouter(ctrl)
+	mockBackendClient := mocks.NewMockBackendClient(ctrl)
+	mockDiscoveryMgr := discoveryMocks.NewMockManager(ctrl)
+	mockDiscoveryMgr.EXPECT().Stop().Times(1)
+
+	srv, err := server.New(
+		t.Context(),
+		&server.Config{
+			Host:           "127.0.0.1",
+			Port:           0,
+			SessionFactory: newNoopMockFactory(t),
+			SessionStorage: &vmcpconfig.SessionStorageConfig{Provider: "memory"},
+		},
+		mockRouter,
+		mockBackendClient,
+		mockDiscoveryMgr,
+		vmcp.NewImmutableRegistry([]vmcp.Backend{}),
+		nil,
+	)
+	require.NoError(t, err)
+
+	require.NoError(t, srv.Stop(t.Context()))
+}

--- a/pkg/vmcp/server/server.go
+++ b/pkg/vmcp/server/server.go
@@ -181,7 +181,38 @@ type Config struct {
 	// When provider is "redis", a Redis-backed store is created for cross-pod
 	// session persistence; the Redis password is read from the
 	// THV_SESSION_REDIS_PASSWORD environment variable.
+	//
+	// Mutually exclusive with DataStorage: setting both is rejected at New().
 	SessionStorage *vmcpconfig.SessionStorageConfig
+
+	// DataStorage optionally injects a caller-supplied session metadata store,
+	// bypassing the built-in memory/redis providers. When non-nil, the server
+	// uses this store as-is and SessionStorage is ignored in its entirety (no
+	// field of SessionStorage is consulted). Setting both DataStorage and a
+	// non-empty SessionStorage.Provider is rejected at New() as ambiguous
+	// configuration.
+	//
+	// Lifecycle: the caller owns it. The server does NOT call Close() on a
+	// caller-supplied DataStorage, even on error paths in New() or during
+	// Stop(). The caller is responsible for invoking Close() exactly once
+	// after Server.Stop() returns (not before — the session manager may issue
+	// final Update calls during Stop). The caller is likewise responsible for
+	// configuring the store's TTL; cfg.SessionTTL applies only to the
+	// transport-level session manager, not to the caller-supplied DataStorage.
+	//
+	// Sensitive material: the store holds HMAC-hashed token material and
+	// other session metadata. Embedders should treat the backing datastore as
+	// sensitive (dedicated credentials, encryption at rest, restricted read
+	// access). Implementations must not include credentials in Close() error
+	// messages — those errors are surfaced through Server.Stop().
+	//
+	// This seam lets embedders satisfy transportsession.DataStorage against
+	// datastores other than the built-in providers (e.g. Postgres, DynamoDB)
+	// without forking the server. It enables cross-replica session metadata
+	// sharing when backed by a shared store; it does NOT solve cross-replica
+	// message delivery — callers still need session affinity at the load
+	// balancer for streaming responses.
+	DataStorage transportsession.DataStorage
 }
 
 // Server is the Virtual MCP Server that aggregates multiple backends.
@@ -224,9 +255,15 @@ type Server struct {
 	sessionManager *transportsession.Manager
 
 	// sessionDataStorage is the pluggable key-value backend for session metadata.
-	// Currently always LocalSessionDataStorage (in-memory, single-process).
-	// Redis-backed storage for multi-pod deployments is not yet wired.
+	// It may be LocalSessionDataStorage (in-memory, single-process), a Redis-backed
+	// store, or a caller-supplied implementation injected via Config.DataStorage.
 	sessionDataStorage transportsession.DataStorage
+
+	// sessionDataStorageCloser closes sessionDataStorage on shutdown. It is
+	// set only when the server built the store itself (memory or redis
+	// providers). When Config.DataStorage was supplied by the caller, this is
+	// nil and the caller is responsible for closing the store.
+	sessionDataStorageCloser func(context.Context) error
 
 	// Capability adapter for converting aggregator types to SDK types
 	capabilityAdapter *adapter.CapabilityAdapter
@@ -257,21 +294,51 @@ type Server struct {
 }
 
 // buildSessionDataStorage constructs the DataStorage backend from cfg.
-// When cfg.SessionStorage is nil or provider is "memory" (or empty), local in-process
-// storage is used. When provider is "redis", a Redis-backed store is created
-// using the address, DB, and key prefix from cfg.SessionStorage; the password
-// is read from the THV_SESSION_REDIS_PASSWORD environment variable.
-// Any other provider value is a misconfiguration and returns an error.
-func buildSessionDataStorage(ctx context.Context, cfg *Config) (transportsession.DataStorage, error) {
+//
+// Resolution order:
+//
+//  1. cfg.DataStorage (caller-supplied) takes precedence. When non-nil, the
+//     store is returned as-is with a nil closer — the caller owns the
+//     lifecycle. Setting both cfg.DataStorage and a non-empty
+//     cfg.SessionStorage.Provider is rejected as ambiguous.
+//  2. cfg.SessionStorage.Provider "memory" (or empty, or nil SessionStorage):
+//     local in-process storage is created.
+//  3. cfg.SessionStorage.Provider "redis": a Redis-backed store is created
+//     using the address, DB, and key prefix from cfg.SessionStorage. The
+//     password is read from the THV_SESSION_REDIS_PASSWORD environment
+//     variable.
+//  4. Any other provider value is a misconfiguration and returns an error.
+//
+// For cases 2 and 3 (server-built stores), the returned closer wraps the
+// store's Close method. For case 1 (caller-supplied), the closer is nil.
+// New() routes the returned closer through Server.sessionDataStorageCloser
+// so Close is invoked on shutdown (and on New() error after this point) —
+// but only for server-built stores.
+func buildSessionDataStorage(
+	ctx context.Context,
+	cfg *Config,
+) (transportsession.DataStorage, func(context.Context) error, error) {
+	if cfg.DataStorage != nil {
+		if cfg.SessionStorage != nil && cfg.SessionStorage.Provider != "" {
+			return nil, nil, fmt.Errorf(
+				"cannot set both Config.DataStorage and Config.SessionStorage.Provider (%q); pick one",
+				cfg.SessionStorage.Provider)
+		}
+		return cfg.DataStorage, nil, nil
+	}
 	// Default to in-process storage when session storage is not configured,
 	// or when the provider is explicitly "memory" or left empty.
 	if cfg.SessionStorage == nil ||
 		cfg.SessionStorage.Provider == "" ||
 		strings.EqualFold(cfg.SessionStorage.Provider, "memory") {
-		return transportsession.NewLocalSessionDataStorage(cfg.SessionTTL)
+		store, err := transportsession.NewLocalSessionDataStorage(cfg.SessionTTL)
+		if err != nil {
+			return nil, nil, err
+		}
+		return store, closerFor(store), nil
 	}
 	if cfg.SessionStorage.Provider != "redis" {
-		return nil, fmt.Errorf("unsupported session storage provider %q (supported: \"memory\", \"redis\")",
+		return nil, nil, fmt.Errorf("unsupported session storage provider %q (supported: \"memory\", \"redis\")",
 			cfg.SessionStorage.Provider)
 	}
 	keyPrefix := cfg.SessionStorage.KeyPrefix
@@ -288,7 +355,19 @@ func buildSessionDataStorage(ctx context.Context, cfg *Config) (transportsession
 		"db", cfg.SessionStorage.DB,
 		"key_prefix", keyPrefix,
 	)
-	return transportsession.NewRedisSessionDataStorage(ctx, redisCfg, keyPrefix, cfg.SessionTTL)
+	store, err := transportsession.NewRedisSessionDataStorage(ctx, redisCfg, keyPrefix, cfg.SessionTTL)
+	if err != nil {
+		return nil, nil, err
+	}
+	return store, closerFor(store), nil
+}
+
+// closerFor adapts DataStorage.Close (no context) to the
+// func(context.Context) error signature used by Server.sessionDataStorageCloser.
+func closerFor(store transportsession.DataStorage) func(context.Context) error {
+	return func(context.Context) error {
+		return store.Close()
+	}
 }
 
 // New creates a new Virtual MCP Server instance.
@@ -412,16 +491,18 @@ func New(
 	// keyed by the same session ID.
 	sessionManager := transportsession.NewManager(cfg.SessionTTL, transportsession.NewStreamableSession)
 
-	sessionDataStorage, err := buildSessionDataStorage(ctx, cfg)
+	sessionDataStorage, sessionDataStorageCloser, err := buildSessionDataStorage(ctx, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create session data storage: %w", err)
 	}
-	// Close sessionDataStorage if New() returns an error after this point so the
-	// background cleanup goroutine does not leak.
-	closeStorageOnErr := true
+	// If we built the store ourselves, close it when New() returns an error
+	// after this point so the background cleanup goroutine does not leak.
+	// For a caller-supplied store (sessionDataStorageCloser == nil), the
+	// caller owns the lifecycle and we leave it untouched on every path.
+	closeStorageOnErr := sessionDataStorageCloser != nil
 	defer func() {
 		if closeStorageOnErr {
-			_ = sessionDataStorage.Close()
+			_ = sessionDataStorageCloser(ctx)
 		}
 	}()
 
@@ -485,6 +566,12 @@ func New(
 	if optimizerCleanup != nil {
 		srv.shutdownFuncs = append(srv.shutdownFuncs, optimizerCleanup)
 	}
+
+	// Store the session data storage closer on the Server so Stop() can invoke
+	// it last (after session manager and discovery manager have stopped). For
+	// a caller-supplied store this is nil and Stop() leaves it alone — the
+	// caller owns the lifecycle.
+	srv.sessionDataStorageCloser = sessionDataStorageCloser
 
 	// Register OnRegisterSession hook to inject capabilities after SDK registers session.
 	// See handleSessionRegistration for implementation details.
@@ -848,8 +935,10 @@ func (s *Server) Stop(ctx context.Context) error {
 
 	// Close session data storage last: HTTP server is down (no new in-flight requests),
 	// all other components have stopped (no further restore or liveness checks).
-	if s.sessionDataStorage != nil {
-		if err := s.sessionDataStorage.Close(); err != nil {
+	// Only invoked when the server built the store itself; caller-supplied stores
+	// (Config.DataStorage) are left for the caller to close.
+	if s.sessionDataStorageCloser != nil {
+		if err := s.sessionDataStorageCloser(ctx); err != nil {
 			errs = append(errs, fmt.Errorf("failed to close session data storage: %w", err))
 		}
 	}


### PR DESCRIPTION
## Summary

- **Why:** `pkg/vmcp/server.Server` currently forces embedders to pick between the two providers encoded in `SessionStorageConfig` — `memory` or `redis`. `buildSessionDataStorage` hardcodes `NewLocalSessionDataStorage` / `NewRedisSessionDataStorage` off that enum. Embedders that already operate other datastores (Postgres, DynamoDB, Spanner, MongoDB, etc.) either have to fork `server.go` or fall back to in-memory sessions and lose cross-pod persistence.
- **What:** Add an optional `Config.DataStorage transportsession.DataStorage` field. When non-nil, the server uses the caller-supplied store directly and `SessionStorage` is ignored in its entirety. Setting both is rejected at `New()` so misconfiguration surfaces loudly instead of silently favouring one.
- **Lifecycle:** the caller owns the injected store — the server never calls `Close()` on it. This matches the convention every other caller-supplied dependency on `Config` already follows (`TelemetryProvider`, `StatusReporter`, `Watcher`, `OptimizerFactory`). `buildSessionDataStorage` now returns an ownership-aware closer so the server-owned path still closes cleanly while the caller-owned path is left untouched on every exit (New error, Start error, Stop).
- **Interface:** no change to `transportsession.DataStorage`. No change to the `memory` / `redis` fast paths. Purely additive.

Closes #4928

## Type of change

- [x] New feature

## Test plan

- [x] Unit tests (`task test`) — full `pkg/vmcp/server/...` suite green (pre-existing flakes in `pkg/auth/oauth` and `pkg/transport/proxy/transparent` are unrelated to this change)
- [x] Linting (`task lint-fix`) — 0 issues
- [x] Manual testing (see below)

Three new unit tests in `pkg/vmcp/server/datastorage_injection_test.go`:

1. `TestNew_CallerOwnedDataStorageNotClosedOnStop` — constructs `Server` with a counting spy wrapping `LocalSessionDataStorage`, runs `Stop()`, asserts `closeCalls == 0`. This is the load-bearing contract assertion.
2. `TestNew_BothSessionStorageAndDataStorageErrors` — asserts `New()` returns an error mentioning both fields when `SessionStorage.Provider="redis"` and `DataStorage` are set simultaneously; also asserts the spy is still untouched on the rejection path.
3. `TestNew_ServerBuiltDataStorageStopSucceeds` — smoke-tests the unchanged server-owned lifecycle with `memory` provider, guarding against accidental regression when the close call moved from an inline block in `Stop()` onto `sessionDataStorageCloser`.

Manual: existing CLI flow (`thv vmcp serve -c <memory-session-storage-config>`) is unchanged; `pkg/vmcp/cli/serve.go` never sets `Config.DataStorage`, so every existing deployment path is bit-identical.

## Does this introduce a user-facing change?

Yes — additive API on `pkg/vmcp/server.Config`. Embedders integrating vMCP as a library can now supply their own `transportsession.DataStorage` implementation. No CLI flag or config-file change; `thv vmcp serve` behaviour is unchanged.

## Implementation plan

<details>
<summary>Approved implementation plan</summary>

### Context

`pkg/vmcp/server.Server` only supports `memory` or `redis` for session data storage via `SessionStorageConfig.Provider`. The `transportsession.DataStorage` interface is already public and stable, so the right fix is a narrow, purely additive seam: let the embedder pass their own `DataStorage` at server construction.

### Design Decisions (validated with an independent Plan agent)

1. **`Config` struct field, not a functional option.** Every other caller-supplied dependency on `server.Config` is a field. `.claude/rules/go-style.md` explicitly blesses the field pattern as compile-time safe.
2. **Caller owns the lifecycle.** Matches the convention for every other caller-supplied dependency on `Config`: server never calls `Close()`/`Shutdown()` on them.
3. **Closer return from `buildSessionDataStorage`** rather than a `bool` on `Server`, mirroring the existing `optimizerCleanup` style. Caller-supplied store → nil closer. Server-built store → real closer.
4. **Fail loudly on ambiguous config.** If both `Config.DataStorage` and a non-empty `Config.SessionStorage.Provider` are set, `New()` returns an error. Allowing silent precedence would leave Redis config looking live but ignored — a diagnosis nightmare.
5. **No changes to the `DataStorage` interface itself.** No changes to `SessionStorageConfig` or its validator. Purely additive.

### Changes

**`pkg/vmcp/server/server.go`**

- Add `DataStorage transportsession.DataStorage` to `Config` with a doc block covering mutual exclusivity with `SessionStorage`, caller-owned lifecycle (including Close ordering relative to `Server.Stop()`), that `cfg.SessionTTL` does not flow into a caller-supplied store, and that the store holds HMAC-hashed token material.
- Change `buildSessionDataStorage` signature to `(DataStorage, func(context.Context) error, error)`. Ambiguous config → error. Caller-supplied → `(store, nil, nil)`. Server-built → `(store, closerFor(store), nil)`.
- Add `Server.sessionDataStorageCloser func(context.Context) error`. Set once in `New()`; invoked once in `Stop()`; nil for caller-owned stores.
- Rework the close-on-error `defer` inside `New()` to gate on `sessionDataStorageCloser != nil` so caller-supplied stores are untouched even on construction failure.
- Rewire the end of `Stop()` to use the closer instead of calling `Close()` on the raw store, preserving the "close data storage last" ordering (after session manager and discovery manager have stopped).

**`pkg/vmcp/server/datastorage_injection_test.go`** (new)

- `countingDataStorage` — 10-line spy wrapping `LocalSessionDataStorage` with an atomic Close counter.
- Three tests (see Test plan above).

### Files NOT modified

- `pkg/transport/session/session_data_storage.go` — interface is stable.
- `pkg/vmcp/config/config.go` / `validator.go` — no config surface change (validator gap for `SessionStorageConfig.Provider` is a separate concern, tracked for a follow-up PR per the one-logical-change rule).
- `pkg/vmcp/cli/serve.go` — the CLI never sets `DataStorage`; behaviour preserved.
- `test/integration/vmcp/helpers/vmcp_server.go` — unchanged.
- `pkg/vmcp/server/sessionmanager/factory.go` — treats `DataStorage` as an opaque dependency.

### Review agents run before pushing

- **code-reviewer**: no blockers; suggested doc tweak around `SessionTTL`-not-applying and test-name clarity — both applied.
- **toolhive-expert**: verified architectural consistency with every other caller-supplied dependency on `Config`; verified `Stop()` ordering; no regression in CLI or operator paths.
- **security-advisor**: confirmed the change adds no data-leakage path, no auth-middleware bypass, and no new credential surface. Recommended doc hardening warning embedders that the store holds HMAC token material and must not leak credentials through `Close()` errors — applied.
- **vmcp-review skill**: clean against all 10 vMCP anti-patterns; noted the Server god-object and Config bloat as pre-existing conditions not expanded by this change.

</details>

Generated with [Claude Code](https://claude.com/claude-code)