### PR TITLE
Expose hook for embedder-driven MCP elicitation

### DIFF
--- a/pkg/vmcp/server/sdk_elicitation_adapter.go
+++ b/pkg/vmcp/server/sdk_elicitation_adapter.go
@@ -31,12 +31,19 @@ type sdkElicitationAdapter struct {
 	mcpServer *server.MCPServer
 }
 
-// newSDKElicitationAdapter creates a new elicitation adapter that wraps the mark3labs SDK server.
+// NewSDKElicitationAdapter creates a new elicitation adapter that wraps the mark3labs SDK server.
 //
 // The returned adapter implements composer.SDKElicitationRequester by delegating to the
 // SDK's RequestElicitation method. Session management and JSON-RPC ID correlation are
 // handled entirely by the SDK.
-func newSDKElicitationAdapter(mcpServer *server.MCPServer) composer.SDKElicitationRequester {
+//
+// Intended for embedders that wrap the vMCP composer in their own pipeline and need to
+// drive MCP elicitation through the same SDK server that serves /mcp traffic. Pass the
+// *server.MCPServer obtained from (*Server).MCPServer() so the returned requester
+// correlates with the server handling incoming client sessions; a parallel MCPServer
+// constructed by the caller will not work because ClientSession correlation is keyed
+// to the server that received the initialize request.
+func NewSDKElicitationAdapter(mcpServer *server.MCPServer) composer.SDKElicitationRequester {
 	return &sdkElicitationAdapter{
 		mcpServer: mcpServer,
 	}

--- a/pkg/vmcp/server/sdk_elicitation_adapter_test.go
+++ b/pkg/vmcp/server/sdk_elicitation_adapter_test.go
@@ -103,9 +103,23 @@ func TestSDKElicitationAdapter_Integration(t *testing.T) {
 	t.Parallel()
 
 	mcpServer := server.NewMCPServer("test", "1.0.0")
-	adapter := newSDKElicitationAdapter(mcpServer)
+	adapter := NewSDKElicitationAdapter(mcpServer)
 
 	assert.NotNil(t, adapter)
+}
+
+// TestServer_MCPServer_ReturnsSameInstance verifies that (*Server).MCPServer
+// returns the exact mark3labs server pointer stored at construction time.
+// Identity matters because ClientSession correlation is keyed to the server
+// that received the initialize request; embedders building their own
+// elicitation requester must receive the authoritative instance.
+func TestServer_MCPServer_ReturnsSameInstance(t *testing.T) {
+	t.Parallel()
+
+	mcpServer := server.NewMCPServer("test", "1.0.0")
+	srv := &Server{mcpServer: mcpServer}
+
+	assert.Same(t, mcpServer, srv.MCPServer())
 }
 
 type testSDKElicitationRequester struct {

--- a/pkg/vmcp/server/server.go
+++ b/pkg/vmcp/server/server.go
@@ -341,7 +341,7 @@ func New(
 
 	// Create SDK elicitation adapter for workflow engine
 	// This wraps the mark3labs SDK to provide elicitation functionality to the composer
-	sdkElicitationRequester := newSDKElicitationAdapter(mcpServer)
+	sdkElicitationRequester := NewSDKElicitationAdapter(mcpServer)
 
 	// Create elicitation handler for workflow engine
 	// This provides SDK-agnostic elicitation with security validation
@@ -975,6 +975,43 @@ func (s *Server) handleReadiness(w http.ResponseWriter, r *http.Request) {
 // This is useful for testing and monitoring.
 func (s *Server) SessionManager() *transportsession.Manager {
 	return s.sessionManager
+}
+
+// MCPServer returns the underlying mark3labs *server.MCPServer instance
+// servicing this vMCP server's /mcp endpoint.
+//
+// Intended for embedders that wrap the vMCP composer in their own pipeline and
+// need to drive SDK-level operations (such as RequestElicitation) against the
+// same server that handles incoming client traffic. A parallel MCPServer
+// constructed by the embedder will not work: ClientSession correlation is
+// keyed to the server that received the initialize request.
+//
+// Trust boundary: this accessor is in-process only; the returned pointer is
+// the same instance for the lifetime of the Server and is safe for concurrent
+// use per mark3labs guarantees.
+//
+// Safe operations include RequestElicitation against an active session,
+// registering observability hooks, and reading registered
+// tools/resources/prompts. Callers MUST NOT call shutdown/close or alter the
+// serving lifecycle; that is owned by (*Server).Start and (*Server).Stop.
+// Callers SHOULD prefer per-session tool registration over global
+// AddTool/SetTools: globally registered tools are served to every session and
+// bypass vMCP's per-session capability scoping (they still pass through the
+// HTTP auth/authz chain).
+//
+// Elicitation callers must:
+//   - Propagate the inbound request ctx so ClientSession resolves, and pass a
+//     bounded deadline; RequestElicitation blocks on the remote client.
+//   - Ensure the connected client advertised the "elicitation" capability
+//     during initialize.
+//   - Handle accept / decline / cancel responses distinctly per MCP 2025-06-18;
+//     keep requestedSchema as a flat object of primitives (string / number /
+//     integer / boolean / enum), which is what conforming clients accept.
+//   - Never include secrets, credentials, tokens, or internal addressing
+//     (backend IDs, pod names, routing-table entries) in the prompt message
+//     or schema: elicitation payloads are surfaced to end-user clients.
+func (s *Server) MCPServer() *server.MCPServer {
+	return s.mcpServer
 }
 
 // Ready returns a channel that is closed when the server is ready to accept connections.


### PR DESCRIPTION
## Summary

- **Why**: Embedders that wrap the vMCP composer in their own pipeline (gateway-level audit, custom elicitation surface, ahead-of-time schema validation) cannot today drive MCP elicitation through the mark3labs `*server.MCPServer` that actually handles `/mcp` traffic. The field is unexported, there is no accessor, and the SDK adapter constructor is also unexported. A parallel `MCPServer` built by the embedder does not work because `ClientSession` correlation is keyed to the server that received `initialize`.
- **What**: Two additive, read-only seams on `pkg/vmcp/server`:
  - `(*Server).MCPServer() *server.MCPServer` returns the authoritative serving instance.
  - `NewSDKElicitationAdapter` exports the existing adapter constructor so embedders can obtain a `composer.SDKElicitationRequester` bound to the serving `MCPServer`.
- Doc comments spell out the in-process trust boundary, lifecycle ownership (`Start`/`Stop` only), the "prefer per-session over global tool registration" footgun, and the MCP 2025-06-18 elicitation caller contract: ctx propagation with a bounded deadline, client capability advertisement, distinct accept/decline/cancel handling, flat-schema shape, and no secrets or internal addressing in prompt payloads.

Closes #4930

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)
- [x] Manual testing (describe below)

Manual verification in the worktree:

- `task lint-fix` — 0 issues.
- `go test -count=1 ./pkg/vmcp/server/...` — all green, including the new `TestServer_MCPServer_ReturnsSameInstance` whitebox test that asserts the accessor returns the exact pointer stored at construction.
- `go build ./...` — clean.
- Grep for stale `newSDKElicitationAdapter` references — none remain.

## Does this introduce a user-facing change?

No end-user behavior change. Public API of `pkg/vmcp/server` gains two exported symbols (`(*Server).MCPServer()` and `NewSDKElicitationAdapter`); the addition is purely additive and no existing call site behavior changes.

## Implementation plan

<details>
<summary>Approved implementation plan</summary>

### Approach

Implement options (a) + (b) from the issue — the two minimal, orthogonal, additive seams.

**Rejected alternatives**:
- Option (c) (`WithElicitationHandler` override): the stated use case is embedders running their *own* composer pipeline, not replacing toolhive's internal one. (c) would add surface without serving the described need.
- A `NewElicitationRequester(*Server) composer.SDKElicitationRequester` that hides the mark3labs type was considered (mitigates anti-pattern #5 in `.claude/rules/vmcp-anti-patterns.md`). Rejected because the issue explicitly asks for `*MCPServer` disclosure and the embedder use case extends beyond elicitation (hooks, notifications, sampling). The doc comment on `MCPServer()` acknowledges the SDK-type exposure as a deliberate, narrow tradeoff.

### Changes

1. Export `NewSDKElicitationAdapter` in `pkg/vmcp/server/sdk_elicitation_adapter.go` (was `newSDKElicitationAdapter`). Struct stays unexported; only the constructor is public. Doc expanded to direct embedders to `(*Server).MCPServer()`. One internal caller updated (`server.go:344`) and one test reference updated.
2. Add `(*Server).MCPServer() *server.MCPServer` in `pkg/vmcp/server/server.go`, placed next to `SessionManager()`, with a doc comment covering:
   - Intent: same-server correlation for embedder elicitation.
   - Trust boundary: in-process only.
   - Lifecycle: `Start`/`Stop` own it; callers MUST NOT close or reconfigure.
   - Tool-registration footgun: prefer per-session over global.
   - MCP 2025-06-18 elicitation prerequisites: bounded-ctx, client capability, accept/decline/cancel, flat schema, no secrets in prompts.

### Things NOT changing

- `composer.SDKElicitationRequester` / `composer.NewDefaultElicitationHandler` — already public.
- `Config` struct — no new field.
- Construction path — no behavior change.

### Anti-pattern check (`.claude/rules/vmcp-anti-patterns.md`)

- **#3 god object**: no new fields on `Server`; one accessor method.
- **#5 SDK coupling leak**: deliberate; documented as a narrow, intentional exposure per issue scope.
- **#8 unnecessary abstraction**: minimum surface; no caches, wrappers, or interface changes.

### Pre-code reviews

Reviewed by `toolhive-expert`, `security-advisor`, `mcp-protocol-expert`, and `Plan` agents in parallel before any code was written. Findings (em-dash removal in docs, protocol-caller notes, test name and redundancy) folded into the final doc comments and test.

### Post-code reviews

Reviewed by `code-reviewer`, `toolhive-expert`, `mcp-protocol-expert`, `security-advisor`, `unit-test-writer`, and the `vmcp-review` skill in parallel on the diff. All findings addressed; no blocking issues remain.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)