### PR TITLE
Treat 401/403 from auth-configured backends as healthy

### DIFF
--- a/pkg/vmcp/discovery/middleware.go
+++ b/pkg/vmcp/discovery/middleware.go
@@ -135,9 +135,13 @@ func Middleware(
 // or degraded. Backends that are unhealthy, unknown, or unauthenticated are excluded
 // from capability aggregation to prevent exposing tools from unavailable backends.
 //
-// TODO(#4920): Unauthenticated backends are treated as routable for phase determination
-// but are excluded here because discovery probes cannot carry user tokens. If health
-// probes could authenticate, these backends would be fully healthy and included here.
+// A note on BackendUnauthenticated: a 401/403 from a backend that has an outgoing
+// auth strategy configured is treated as BackendHealthy by the health checker
+// (health probes deliberately do not carry user credentials — the challenge proves
+// reachability). BackendUnauthenticated therefore indicates a misconfiguration:
+// the backend requires authentication but no outgoing auth strategy is configured
+// on the backend target. Excluding such backends from capability aggregation is
+// the correct behavior — their capabilities cannot be safely exposed.
 //
 // Health status filtering:
 //   - healthy: included (fully operational)
@@ -145,7 +149,7 @@ func Middleware(
 //   - empty/zero-value: included (assume healthy when health monitoring is disabled)
 //   - unhealthy: excluded (not responding, circuit breaker may be open)
 //   - unknown: excluded (status not yet determined)
-//   - unauthenticated: excluded (authentication failed)
+//   - unauthenticated: excluded (misconfiguration: backend requires auth but none configured)
 //
 // When healthStatusProvider is provided, the current health status from the health
 // monitor is used (respects circuit breaker state). When nil, falls back to the

--- a/pkg/vmcp/health/checker.go
+++ b/pkg/vmcp/health/checker.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/stacklok/toolhive/pkg/vmcp"
+	authtypes "github.com/stacklok/toolhive/pkg/vmcp/auth/types"
 )
 
 // healthChecker implements vmcp.HealthChecker using ListCapabilities as the health check.
@@ -59,7 +60,14 @@ func NewHealthChecker(
 // Health determination logic:
 //   - Success with fast response: Backend is healthy (BackendHealthy)
 //   - Success with slow response (> degradedThreshold): Backend is degraded (BackendDegraded)
-//   - Authentication error: Backend is unauthenticated (BackendUnauthenticated)
+//   - Authentication error (HTTP 401/403) AND backend has an outgoing auth strategy
+//     configured: Backend is healthy (BackendHealthy). Health probes deliberately do
+//     not carry user credentials, so the backend's auth challenge proves reachability
+//     and a working auth layer — that is success for probe purposes.
+//   - Authentication error AND backend has no outgoing auth strategy configured
+//     (AuthConfig nil or StrategyTypeUnauthenticated): Backend is unauthenticated
+//     (BackendUnauthenticated). This signals operator misconfiguration — the backend
+//     requires authentication but none was configured on the backend target.
 //   - Timeout or connection error: Backend is unhealthy (BackendUnhealthy)
 //   - Other errors: Backend is unhealthy (BackendUnhealthy)
 //
@@ -92,8 +100,19 @@ func (h *healthChecker) CheckHealth(ctx context.Context, target *vmcp.BackendTar
 	responseDuration := time.Since(startTime)
 
 	if err != nil {
-		// Categorize the error to determine health status
-		status := categorizeError(err)
+		// Categorize the error to determine health status. The target's outgoing
+		// auth config is consulted: a 401/403 from a backend with an outgoing auth
+		// strategy is the expected response to a no-credential probe and maps to
+		// BackendHealthy. In that case we return a nil error so the monitor records
+		// this as a successful check and does not open the circuit breaker.
+		status := categorizeError(target, err)
+		if status == vmcp.BackendHealthy {
+			slog.Debug("health check received expected auth challenge — treating as healthy",
+				"backend", target.WorkloadName,
+				"error", err,
+				"duration", responseDuration)
+			return vmcp.BackendHealthy, nil
+		}
 		slog.Debug("health check failed for backend",
 			"backend", target.WorkloadName,
 			"error", err,
@@ -115,10 +134,16 @@ func (h *healthChecker) CheckHealth(ctx context.Context, target *vmcp.BackendTar
 	return vmcp.BackendHealthy, nil
 }
 
-// categorizeError determines the appropriate health status based on the error type.
+// categorizeError determines the appropriate health status based on the error type
+// and the backend's outgoing auth configuration.
+//
 // This uses sentinel error checking with errors.Is() for type-safe error categorization.
 // Falls back to string-based detection for backwards compatibility with non-wrapped errors.
-func categorizeError(err error) vmcp.BackendHealthStatus {
+//
+// For auth errors (HTTP 401/403), the target's AuthConfig is consulted to distinguish
+// an expected auth challenge (backend has outgoing auth configured) from a misconfiguration
+// (backend has no outgoing auth strategy). See authErrorStatus for details.
+func categorizeError(target *vmcp.BackendTarget, err error) vmcp.BackendHealthStatus {
 	if err == nil {
 		return vmcp.BackendHealthy
 	}
@@ -126,7 +151,7 @@ func categorizeError(err error) vmcp.BackendHealthStatus {
 	// 1. Type-safe detection: Check for sentinel errors using errors.Is()
 	// BackendClient now wraps all errors with appropriate sentinel errors
 	if errors.Is(err, vmcp.ErrAuthenticationFailed) || errors.Is(err, vmcp.ErrAuthorizationFailed) {
-		return vmcp.BackendUnauthenticated
+		return authErrorStatus(target)
 	}
 
 	if errors.Is(err, vmcp.ErrTimeout) || errors.Is(err, vmcp.ErrCancelled) {
@@ -140,7 +165,7 @@ func categorizeError(err error) vmcp.BackendHealthStatus {
 	// 2. String-based detection: Fallback for backwards compatibility
 	// This handles errors from sources that don't wrap with sentinel errors
 	if vmcp.IsAuthenticationError(err) {
-		return vmcp.BackendUnauthenticated
+		return authErrorStatus(target)
 	}
 
 	if vmcp.IsTimeoutError(err) || vmcp.IsConnectionError(err) {
@@ -149,4 +174,25 @@ func categorizeError(err error) vmcp.BackendHealthStatus {
 
 	// Default to unhealthy for unknown errors
 	return vmcp.BackendUnhealthy
+}
+
+// authErrorStatus maps an authentication error (HTTP 401/403) to a health status
+// using the backend's outgoing auth configuration.
+//
+// Health probes deliberately do not carry user credentials. If the backend is
+// configured with an outgoing auth strategy, a 401/403 from the backend proves
+// that the backend is alive, the auth layer works, and the network+TLS path is
+// healthy — this is the expected response to an unauthenticated probe and is
+// therefore treated as BackendHealthy.
+//
+// If the backend has no outgoing auth strategy configured (AuthConfig nil or
+// StrategyTypeUnauthenticated), a 401/403 indicates operator misconfiguration:
+// the backend requires authentication but none was configured on the backend
+// target. This is reported as BackendUnauthenticated so it surfaces in status.
+func authErrorStatus(target *vmcp.BackendTarget) vmcp.BackendHealthStatus {
+	if target != nil && target.AuthConfig != nil &&
+		target.AuthConfig.Type != authtypes.StrategyTypeUnauthenticated {
+		return vmcp.BackendHealthy
+	}
+	return vmcp.BackendUnauthenticated
 }

--- a/pkg/vmcp/health/checker_test.go
+++ b/pkg/vmcp/health/checker_test.go
@@ -15,6 +15,7 @@ import (
 	"go.uber.org/mock/gomock"
 
 	"github.com/stacklok/toolhive/pkg/vmcp"
+	authtypes "github.com/stacklok/toolhive/pkg/vmcp/auth/types"
 	"github.com/stacklok/toolhive/pkg/vmcp/mocks"
 )
 
@@ -230,73 +231,178 @@ func TestHealthChecker_CheckHealth_ErrorCategorization(t *testing.T) {
 func TestCategorizeError(t *testing.T) {
 	t.Parallel()
 
+	// Backends with an outgoing auth strategy configured: a 401/403 is the
+	// expected response to a no-credential probe and must be treated as healthy.
+	targetWithUpstreamInject := &vmcp.BackendTarget{
+		AuthConfig: &authtypes.BackendAuthStrategy{Type: authtypes.StrategyTypeUpstreamInject},
+	}
+	targetWithTokenExchange := &vmcp.BackendTarget{
+		AuthConfig: &authtypes.BackendAuthStrategy{Type: authtypes.StrategyTypeTokenExchange},
+	}
+	targetWithHeaderInjection := &vmcp.BackendTarget{
+		AuthConfig: &authtypes.BackendAuthStrategy{Type: authtypes.StrategyTypeHeaderInjection},
+	}
+
+	// Backends without an outgoing auth strategy: a 401/403 indicates operator
+	// misconfiguration and must surface as BackendUnauthenticated.
+	targetNoAuthConfig := &vmcp.BackendTarget{AuthConfig: nil}
+	targetUnauthenticatedStrategy := &vmcp.BackendTarget{
+		AuthConfig: &authtypes.BackendAuthStrategy{Type: authtypes.StrategyTypeUnauthenticated},
+	}
+
 	tests := []struct {
 		name           string
+		target         *vmcp.BackendTarget
 		err            error
 		expectedStatus vmcp.BackendHealthStatus
 	}{
 		{
 			name:           "nil error",
+			target:         targetNoAuthConfig,
 			err:            nil,
 			expectedStatus: vmcp.BackendHealthy,
 		},
+
+		// Auth errors + outgoing auth configured -> healthy (probe challenge is expected).
 		{
-			name:           "authentication failed",
+			name:           "auth error with upstream_inject strategy is healthy",
+			target:         targetWithUpstreamInject,
+			err:            vmcp.ErrAuthenticationFailed,
+			expectedStatus: vmcp.BackendHealthy,
+		},
+		{
+			name:           "auth error with token_exchange strategy is healthy",
+			target:         targetWithTokenExchange,
+			err:            vmcp.ErrAuthenticationFailed,
+			expectedStatus: vmcp.BackendHealthy,
+		},
+		{
+			name:           "auth error with header_injection strategy is healthy",
+			target:         targetWithHeaderInjection,
+			err:            vmcp.ErrAuthenticationFailed,
+			expectedStatus: vmcp.BackendHealthy,
+		},
+		{
+			name:           "authz error with upstream_inject strategy is healthy",
+			target:         targetWithUpstreamInject,
+			err:            vmcp.ErrAuthorizationFailed,
+			expectedStatus: vmcp.BackendHealthy,
+		},
+		{
+			name:           "string-based auth error with header_injection strategy is healthy",
+			target:         targetWithHeaderInjection,
+			err:            errors.New("HTTP 401"),
+			expectedStatus: vmcp.BackendHealthy,
+		},
+
+		// Auth errors + no outgoing auth configured -> unauthenticated (misconfig signal).
+		{
+			name:           "auth error with nil AuthConfig is unauthenticated (misconfig)",
+			target:         targetNoAuthConfig,
+			err:            vmcp.ErrAuthenticationFailed,
+			expectedStatus: vmcp.BackendUnauthenticated,
+		},
+		{
+			name:           "auth error with StrategyTypeUnauthenticated is unauthenticated (misconfig)",
+			target:         targetUnauthenticatedStrategy,
+			err:            vmcp.ErrAuthenticationFailed,
+			expectedStatus: vmcp.BackendUnauthenticated,
+		},
+		{
+			name:           "authentication failed (string) with nil AuthConfig",
+			target:         targetNoAuthConfig,
 			err:            errors.New("authentication failed"),
 			expectedStatus: vmcp.BackendUnauthenticated,
 		},
 		{
-			name:           "authentication error",
+			name:           "authentication error (string) with nil AuthConfig",
+			target:         targetNoAuthConfig,
 			err:            errors.New("authentication error: invalid credentials"),
 			expectedStatus: vmcp.BackendUnauthenticated,
 		},
 		{
-			name:           "request unauthorized",
+			name:           "request unauthorized with nil AuthConfig",
+			target:         targetNoAuthConfig,
 			err:            errors.New("request unauthorized"),
 			expectedStatus: vmcp.BackendUnauthenticated,
 		},
 		{
-			name:           "HTTP 401",
+			name:           "HTTP 401 with nil AuthConfig",
+			target:         targetNoAuthConfig,
 			err:            errors.New("HTTP 401"),
 			expectedStatus: vmcp.BackendUnauthenticated,
 		},
 		{
-			name:           "HTTP 403",
+			name:           "HTTP 403 with nil AuthConfig",
+			target:         targetNoAuthConfig,
 			err:            errors.New("HTTP 403"),
 			expectedStatus: vmcp.BackendUnauthenticated,
 		},
 		{
-			name:           "timeout",
+			name:           "nil target with auth error is unauthenticated",
+			target:         nil,
+			err:            vmcp.ErrAuthenticationFailed,
+			expectedStatus: vmcp.BackendUnauthenticated,
+		},
+
+		// Non-auth errors: AuthConfig is irrelevant; classification is unchanged.
+		{
+			name:           "timeout with upstream_inject strategy is still unhealthy",
+			target:         targetWithUpstreamInject,
 			err:            errors.New("request timeout"),
 			expectedStatus: vmcp.BackendUnhealthy,
 		},
 		{
-			name:           "deadline exceeded",
+			name:           "timeout with nil AuthConfig is unhealthy",
+			target:         targetNoAuthConfig,
+			err:            errors.New("request timeout"),
+			expectedStatus: vmcp.BackendUnhealthy,
+		},
+		{
+			name:           "deadline exceeded with nil AuthConfig is unhealthy",
+			target:         targetNoAuthConfig,
 			err:            errors.New("context deadline exceeded"),
 			expectedStatus: vmcp.BackendUnhealthy,
 		},
 		{
-			name:           "connection refused",
+			name:           "connection refused with nil AuthConfig is unhealthy",
+			target:         targetNoAuthConfig,
 			err:            errors.New("connection refused"),
 			expectedStatus: vmcp.BackendUnhealthy,
 		},
 		{
-			name:           "connection reset",
+			name:           "connection refused with header_injection strategy is still unhealthy",
+			target:         targetWithHeaderInjection,
+			err:            errors.New("connection refused"),
+			expectedStatus: vmcp.BackendUnhealthy,
+		},
+		{
+			name:           "connection reset with nil AuthConfig is unhealthy",
+			target:         targetNoAuthConfig,
 			err:            errors.New("connection reset by peer"),
 			expectedStatus: vmcp.BackendUnhealthy,
 		},
 		{
-			name:           "no route to host",
+			name:           "no route to host with nil AuthConfig is unhealthy",
+			target:         targetNoAuthConfig,
 			err:            errors.New("no route to host"),
 			expectedStatus: vmcp.BackendUnhealthy,
 		},
 		{
-			name:           "network unreachable",
+			name:           "network unreachable with nil AuthConfig is unhealthy",
+			target:         targetNoAuthConfig,
 			err:            errors.New("network is unreachable"),
 			expectedStatus: vmcp.BackendUnhealthy,
 		},
 		{
-			name:           "generic error",
+			name:           "generic error with nil AuthConfig is unhealthy",
+			target:         targetNoAuthConfig,
+			err:            errors.New("something went wrong"),
+			expectedStatus: vmcp.BackendUnhealthy,
+		},
+		{
+			name:           "generic error with token_exchange strategy is still unhealthy",
+			target:         targetWithTokenExchange,
 			err:            errors.New("something went wrong"),
 			expectedStatus: vmcp.BackendUnhealthy,
 		},
@@ -306,7 +412,7 @@ func TestCategorizeError(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			status := categorizeError(tt.err)
+			status := categorizeError(tt.target, tt.err)
 			assert.Equal(t, tt.expectedStatus, status)
 		})
 	}
@@ -486,11 +592,13 @@ func TestHealthChecker_CheckHealth_ContextCarriesHealthCheckMarker(t *testing.T)
 			"apply outgoing auth to health check probes")
 }
 
-// TestHealthChecker_CheckHealth_AuthErrorsCategorizesAsUnauthenticated verifies that auth
-// errors from health checks are correctly categorised as BackendUnauthenticated, not
-// BackendUnhealthy. This distinguishes a backend that is reachable-but-needs-auth
-// from one that is down, which is important for health check probes that apply
-// outgoing auth credentials (header_injection or token_exchange).
+// TestHealthChecker_CheckHealth_AuthErrorsCategorizesAsUnauthenticated verifies that
+// auth errors from health checks are categorised as BackendUnauthenticated when the
+// backend target has no outgoing auth strategy configured (AuthConfig nil in these
+// cases). This represents a misconfiguration: the backend requires authentication
+// but no strategy was configured on the target. A 401/403 from a backend that *does*
+// have an outgoing auth strategy is treated as BackendHealthy by the checker and
+// is covered in TestCategorizeError.
 func TestHealthChecker_CheckHealth_AuthErrorsCategorizesAsUnauthenticated(t *testing.T) {
 	t.Parallel()
 
@@ -551,6 +659,80 @@ func TestHealthChecker_CheckHealth_AuthErrorsCategorizesAsUnauthenticated(t *tes
 			assert.Error(t, err)
 			assert.Equal(t, vmcp.BackendUnauthenticated, status,
 				"auth failure from a health probe should be BackendUnauthenticated, not BackendUnhealthy")
+		})
+	}
+}
+
+// TestHealthChecker_CheckHealth_AuthErrorWithOutgoingAuthIsHealthy verifies that a
+// 401/403 from a backend that has an outgoing auth strategy configured (e.g.,
+// upstream_inject, token_exchange, header_injection) is treated as BackendHealthy.
+// Health probes deliberately do not carry user credentials, so the backend's auth
+// challenge is the expected response and proves reachability. This is the behavior
+// change introduced by the fix for issue #4920.
+func TestHealthChecker_CheckHealth_AuthErrorWithOutgoingAuthIsHealthy(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		authConfig *authtypes.BackendAuthStrategy
+		err        error
+	}{
+		{
+			name:       "upstream_inject + sentinel auth error",
+			authConfig: &authtypes.BackendAuthStrategy{Type: authtypes.StrategyTypeUpstreamInject},
+			err:        vmcp.ErrAuthenticationFailed,
+		},
+		{
+			name:       "token_exchange + status code 401",
+			authConfig: &authtypes.BackendAuthStrategy{Type: authtypes.StrategyTypeTokenExchange},
+			err:        fmt.Errorf("backend unavailable: failed to initialize client for backend my-backend: status code 401"),
+		},
+		{
+			name:       "header_injection + HTTP 403",
+			authConfig: &authtypes.BackendAuthStrategy{Type: authtypes.StrategyTypeHeaderInjection},
+			err:        errors.New("HTTP 403 forbidden"),
+		},
+		{
+			name:       "upstream_inject + wrapped sentinel",
+			authConfig: &authtypes.BackendAuthStrategy{Type: authtypes.StrategyTypeUpstreamInject},
+			err:        fmt.Errorf("%w: unauthorized (401)", vmcp.ErrAuthenticationFailed),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctrl := gomock.NewController(t)
+			t.Cleanup(ctrl.Finish)
+
+			mockClient := mocks.NewMockBackendClient(ctrl)
+			mockClient.EXPECT().
+				ListCapabilities(gomock.Any(), gomock.Any()).
+				Return(nil, tt.err).
+				Times(1)
+
+			checker := NewHealthChecker(mockClient, 5*time.Second, 0)
+			target := &vmcp.BackendTarget{
+				WorkloadID:   "backend-1",
+				WorkloadName: "test-backend",
+				BaseURL:      "http://localhost:8080",
+				AuthConfig:   tt.authConfig,
+			}
+
+			status, err := checker.CheckHealth(t.Context(), target)
+			// When the status is BackendHealthy (expected auth challenge) the
+			// checker returns a nil error so the monitor records it as a
+			// successful check and does not increment failure counters or open
+			// the circuit breaker.
+			assert.NoError(t, err,
+				"auth challenge from an auth-configured backend must be reported "+
+					"as a successful check (nil error) so the monitor records "+
+					"success and the circuit breaker stays closed")
+			assert.Equal(t, vmcp.BackendHealthy, status,
+				"auth failure from a probe against a backend with an outgoing "+
+					"auth strategy configured must be BackendHealthy — the challenge "+
+					"is the expected response to a no-credential probe")
 		})
 	}
 }

--- a/pkg/vmcp/health/monitor.go
+++ b/pkg/vmcp/health/monitor.go
@@ -548,8 +548,14 @@ type Summary struct {
 }
 
 // Routable returns the number of backends that can serve traffic.
-// This includes healthy backends and unauthenticated backends (which are
-// reachable but require per-request user auth, e.g., upstream OAuth).
+//
+// TODO(#4920 follow-up): This counts BackendUnauthenticated toward the routable
+// total for historical reasons (PR #4866 added this when BackendUnauthenticated
+// meant "reachable but needs per-request user auth"). After the #4920 fix,
+// BackendUnauthenticated indicates misconfiguration (backend requires auth but
+// no outgoing auth strategy is configured) and should not be considered routable.
+// Revert to `s.Healthy` in a follow-up PR that also updates the operator status
+// collector and controller counterparts of this logic.
 func (s Summary) Routable() int {
 	return s.Healthy + s.Unauthenticated
 }
@@ -564,11 +570,11 @@ func (s Summary) String() string {
 // This converts backend health information into the format needed for status reporting
 // to the Kubernetes API or CLI output.
 //
-// Phase determination (unauthenticated backends are routable — they need per-request user auth
-// but are reachable and running):
-// - Ready: All backends healthy or unauthenticated, or no backends configured (cold start)
+// Phase determination (see Summary.Routable for the TODO about unauthenticated
+// backends being counted as routable — legacy from PR #4866, to be reverted):
+// - Ready: All backends routable, or no backends configured (cold start)
 // - Pending: Backends configured but no health check data yet (waiting for first check)
-// - Degraded: Some backends routable (healthy/unauthenticated), some degraded/unhealthy
+// - Degraded: Some backends routable, some degraded/unhealthy
 // - Failed: No routable backends (and at least one backend exists)
 //
 // Returns a Status instance with current health information and discovered backends.
@@ -606,12 +612,12 @@ func (m *Monitor) BuildStatus() *vmcp.Status {
 }
 
 // determinePhase determines the overall phase based on backend health.
-// Unauthenticated backends are treated as routable — they are reachable and running,
-// they just require per-request user auth (e.g., upstream OAuth).
+// See Summary.Routable for the TODO about unauthenticated backends being
+// counted as routable (legacy from PR #4866, to be reverted in a follow-up).
 // Takes both the health summary and the count of configured backends to distinguish:
 // - No backends configured (configuredCount==0): Ready (cold start)
 // - Backends configured but no health data (configuredCount>0 && summary.Total==0): Pending
-// - Has health data: Ready/Degraded/Failed based on routable (healthy + unauthenticated) count
+// - Has health data: Ready/Degraded/Failed based on routable count
 func determinePhase(summary Summary, configuredBackendCount int) vmcp.Phase {
 	if summary.Total == 0 {
 		// No health data yet - distinguish cold start from waiting for first check
@@ -785,7 +791,7 @@ func formatBackendMessage(state *State) string {
 		case vmcp.BackendUnhealthy:
 			baseMsg = "Unhealthy"
 		case vmcp.BackendUnauthenticated:
-			baseMsg = "Authentication required"
+			baseMsg = "Authentication misconfigured (backend requires auth, none configured)"
 		case vmcp.BackendUnknown:
 			baseMsg = "Unknown"
 		default:

--- a/pkg/vmcp/server/status.go
+++ b/pkg/vmcp/server/status.go
@@ -93,7 +93,7 @@ func (s *Server) buildStatusResponse(ctx context.Context) StatusResponse {
 		}
 		backendStatuses = append(backendStatuses, status)
 
-		if healthStatus == vmcp.BackendHealthy || healthStatus == vmcp.BackendUnauthenticated {
+		if healthStatus == vmcp.BackendHealthy {
 			hasHealthyBackend = true
 		}
 	}

--- a/pkg/vmcp/types.go
+++ b/pkg/vmcp/types.go
@@ -143,7 +143,16 @@ const (
 	// BackendUnknown indicates the backend health status is unknown.
 	BackendUnknown BackendHealthStatus = "unknown"
 
-	// BackendUnauthenticated indicates the backend is not authenticated.
+	// BackendUnauthenticated indicates the backend returned an authentication error
+	// (HTTP 401/403) while the backend target had no outgoing auth strategy
+	// configured (AuthConfig nil or StrategyTypeUnauthenticated). This signals
+	// operator misconfiguration: the backend requires authentication but no
+	// auth strategy was configured on the backend target.
+	//
+	// Note: a 401/403 from a backend with a configured outgoing auth strategy is
+	// treated as BackendHealthy, because health probes deliberately do not carry
+	// user credentials and the backend's challenge proves reachability and a
+	// working auth layer.
 	BackendUnauthenticated BackendHealthStatus = "unauthenticated"
 )
 
@@ -152,7 +161,7 @@ const (
 //   - healthy → ready
 //   - degraded → degraded
 //   - unhealthy → unavailable
-//   - unauthenticated → unauthenticated (backend is reachable but needs per-request user auth)
+//   - unauthenticated → unauthenticated (misconfig: backend requires auth but none configured)
 //   - unknown → unknown
 func (s BackendHealthStatus) ToCRDStatus() string {
 	switch s {


### PR DESCRIPTION
## Summary

- Health probes deliberately run with no user context, so per-user upstream tokens (`upstream_inject`) are not available at probe time. For OAuth-protected backends, a 401/403 challenge is the *expected* response and proves reachability, a working auth layer, and a working network/TLS path — so treat it as `BackendHealthy`.
- Narrow `BackendUnauthenticated` to a misconfiguration signal (backend demands auth but no outgoing auth strategy is configured on the backend target) and remove discovery's exclusion TODO — the state now accurately reflects "should not expose capabilities."
- Drop the `|| BackendUnauthenticated` clause from `/status`'s healthy computation since the state no longer indicates routability.

Closes #4920

## Type of change

- [x] Bug fix

## Changes

| File | Change |
|---|---|
| `pkg/vmcp/health/checker.go` | `categorizeError` now takes `target`; new `authErrorStatus` helper. `CheckHealth` returns `(BackendHealthy, nil)` on expected auth challenge so the monitor records success and the circuit breaker stays closed. |
| `pkg/vmcp/health/checker_test.go` | Full matrix: auth errors × {upstream_inject, token_exchange, header_injection, nil AuthConfig, StrategyTypeUnauthenticated, nil target} + non-auth errors unchanged. |
| `pkg/vmcp/types.go` | `BackendUnauthenticated` doc narrows to misconfig; `ToCRDStatus` comment updated. |
| `pkg/vmcp/discovery/middleware.go` | Removed `TODO(#4920)`; updated `filterHealthyBackends` comment — excluding `BackendUnauthenticated` from capability aggregation is now the correct behavior. |
| `pkg/vmcp/server/status.go` | `hasHealthyBackend` no longer counts `BackendUnauthenticated`. |
| `pkg/vmcp/health/monitor.go` | Stale "Authentication required" message updated to reflect new misconfig meaning. Doc-comment TODOs added on `Summary.Routable()`, `BuildStatus`, and `determinePhase` noting that PR #4866's routability logic should be reverted in a follow-up (needs operator controller + status collector changes — bigger blast radius). |

## Test plan

- [x] `task lint` — 0 issues
- [x] `task test` — full unit + race suite passes
- [x] New test matrix in `checker_test.go` covers all strategy-type × auth-error combinations plus non-auth errors
- [x] Code review pass (anti-patterns, go-style, security) — no blocking findings

## Does this introduce a user-facing change?

Yes. vMCP deployments where every backend uses per-user OAuth (e.g., `upstream_inject` with Google Drive, Atlassian) will now report those backends as \`healthy\` in \`/status\` and include them in capability aggregation once an authenticated user session runs discovery. Before this fix (even with the PR #4866 workaround), such backends were excluded from capability aggregation and their tools did not appear in aggregated \`tools/list\`. `BackendUnauthenticated` is now reserved for a narrower misconfig case and no longer counts as "healthy-enough" in \`/status\`.

## Special notes for reviewers

Intentionally narrow scope. Explicitly deferred to follow-up PRs:

1. **Revert PR #4866's `Routable() = Healthy + Unauthenticated` semantics** in \`monitor.go\` and the mirrored logic in \`cmd/thv-operator/controllers/virtualmcpserver_controller.go\` and \`cmd/thv-operator/pkg/virtualmcpserverstatus/collector.go\`. Flagged with TODO comments.
2. **`WWW-Authenticate` header validation** before treating 401 as healthy — would require plumbing HTTP response headers through the error chain.
3. **User-opportunistic capability cache** so `/status`-style readers can see tools before the first user session runs discovery.
4. **Opt-in `probe_credentials` strategy** for deployments that *do* have a service-account credential (Workspace, GitHub App) and want full-path probe validation.

## Implementation plan

<details>
<summary>Planned with Claude Code</summary>

The fix was designed after a multi-agent discussion:

1. **Health probe research** confirmed probes go through the same outgoing auth strategies as real requests, with each strategy short-circuiting on \`healthcontext.IsHealthCheck(ctx)\`. \`upstream_inject\` returns no header (no user identity); \`token_exchange\` has a partial client-credentials fallback only when credentials are configured.
2. **Key insight** (from the user): for \`upstream_inject\`, vMCP holds *no* credentials at startup — upstream tokens are per-user, populated only after each user completes their own OAuth (\`pkg/auth/identity.go:47-66\`, \`pkg/auth/token.go:1185-1201\`). \`BackendUnauthenticated\` at startup is the *correct* system state; the gateway has nothing to authenticate with.
3. **Design conclusion**: drop probe-auth, treat 401/403 as healthy if the backend has an outgoing auth strategy configured. RFC 6749 §5.2 / RFC 6750 §3.1 make 401 invalid_token the correct response from a properly-configured resource server — treating it as "reachable and RFC-compliant" is semantically honest.
4. **Code review** flagged the stale "Authentication required" status message and the \`server/status.go\` inconsistency as should-fix-in-this-PR; both addressed.

</details>

Generated with [Claude Code](https://claude.com/claude-code)