### PR TITLE
Introduce MutateAndPatchStatus helper for status writes

### DIFF
--- a/.claude/rules/operator.md
+++ b/.claude/rules/operator.md
@@ -39,11 +39,23 @@ See `cmd/thv-operator/DESIGN.md` for detailed decision guidelines.
 - Always run `task crdref-gen` from `cmd/thv-operator/` after CRD changes to regenerate API docs (uses relative paths)
 - Use `envtest` for integration testing, not real clusters
 - Chainsaw tests require a real Kubernetes cluster
-- Status updates require a separate client patch (`r.Status().Update()`)
+- Status writes must go through `controllerutil.MutateAndPatchStatus` — see the Status Writes section below
 
 ## Status Condition Parity
 
 When adding a status condition to one CRD type, check all parallel types (e.g., `MCPServer` and `VirtualMCPServer`) for the same condition. Conditions that warn about misconfiguration or unsupported states should be consistent across types that share the same feature set — a gap means one type silently accepts invalid config that the other rejects.
+
+## Status Writes
+
+Use `controllerutil.MutateAndPatchStatus` for every status write — not `r.Status().Update` or inline `client.Status().Patch` (see #4633). The helper's doc comment is the authoritative spec.
+
+When adding a status-write call site, check three things:
+
+1. **Caller holds a freshly-`Get`ted object.** Reconciler-start writers do; writers that iterate `List` results (e.g., deletion-path fan-out in `MCPGroupReconciler`) do not and need a fresh `Get` before calling the helper.
+2. **Caller is the sole owner of the entire `Status.Conditions` array.** Per-condition-type ownership is NOT enough. JSON merge-patch replaces the array wholesale for CRDs (the `+listType=map` marker is only honored by strategic-merge-patch), so any concurrent writer whose Patch lands between this caller's Get and Patch — on any condition type, not just the ones this caller touches — will be erased. A fresh `Get` narrows the TOCTOU window but does not eliminate it. If two code paths must write conditions on the same CRD (e.g., operator reconciler + in-pod `K8sReporter`), fix at the design level: consolidate to a single owner, or move one writer to a dedicated status field outside the array.
+3. **Scalar fields the writer touches are not co-owned.** A stale-computed value different from the caller's snapshot will overwrite the live value — the helper cannot defend against this.
+
+Do not use `MutateAndPatchStatus` for spec or metadata writes — those require optimistic locking (`client.MergeFromWithOptions(..., MergeFromWithOptimisticLock{})`). See #4767.
 
 ## Key Operator Commands
 

--- a/cmd/thv-operator/pkg/controllerutil/doc.go
+++ b/cmd/thv-operator/pkg/controllerutil/doc.go
@@ -16,6 +16,7 @@
 //   - config.go: General configuration merging and validation utilities
 //   - podtemplatespec_builder.go: PodTemplateSpec builder for constructing pod template patches
 //   - maps.go: Map comparison utilities (e.g. subset checks for annotations)
+//   - status.go: Status-subresource merge-patch helper (MutateAndPatchStatus)
 //
 // These utilities are used by multiple controllers including MCPServer, MCPRemoteProxy,
 // and ToolConfig controllers to maintain consistent behavior across the operator.

--- a/cmd/thv-operator/pkg/controllerutil/status.go
+++ b/cmd/thv-operator/pkg/controllerutil/status.go
@@ -1,0 +1,100 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package controllerutil
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"reflect"
+
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// MutateAndPatchStatus captures the current state of obj, applies mutate,
+// and patches the status subresource using a plain JSON merge patch.
+//
+// This is the canonical idiom for every status write in the operator. See
+// #4633: a full status PUT (r.Status().Update) clobbers fields the operator
+// does not track (e.g. runtime-reporter-owned fields on VirtualMCPServer
+// status). A merge-patch body only carries fields the caller actually
+// changed, so disjoint status writers coexist.
+//
+// The patch is NOT optimistic-locked: status-subresource writes are scoped
+// to the status stanza, and forcing a 409 on every disjoint-field overlap
+// would produce permanent churn with nothing gained.
+//
+// Caller contract (important — the patch body is the diff between the
+// pre-mutate snapshot and the post-mutate object; it does NOT reflect
+// what is live on the apiserver):
+//
+//   - Conditions-array writes require the caller to be the sole owner
+//     of the entire Status.Conditions array on that CRD. Per-condition-
+//     type ownership is NOT sufficient: client.MergeFrom produces an
+//     RFC 7396 merge patch, which replaces the array wholesale for CRDs
+//     (the +listType=map marker is only honored by strategic-merge-patch).
+//     Any concurrent writer whose Patch lands between this caller's Get
+//     and this caller's Patch — on any condition type, including ones
+//     this caller does not touch — will be erased. A fresh Get narrows
+//     the TOCTOU window but cannot eliminate it. If two code paths must
+//     write conditions on the same CRD, consolidate them into a single
+//     owner or move one writer to a dedicated status field outside the
+//     array.
+//
+//   - Scalar fields land in the patch body only when the post-mutate
+//     value differs from the pre-mutate snapshot. Re-assigning a scalar
+//     to the same value it was read as is a no-op at the wire level —
+//     the field is absent from the patch and a concurrent writer's
+//     value on the live object is preserved. BUT if mutate assigns a
+//     value that differs from the snapshot (e.g., a stale derivation
+//     from pod state), that value will overwrite whatever a concurrent
+//     writer wrote to the live object. There is no defense against
+//     this at the helper level: a stale computation wins. For scalars
+//     co-owned by multiple writers, use a single-owner design or
+//     refresh the object via a fresh Get before calling this helper.
+//
+// Do NOT use for metadata or spec writes. Those need optimistic locking
+// and should call r.Patch directly with
+// client.MergeFromWithOptions(orig, client.MergeFromWithOptimisticLock{}).
+// Rationale and MCPServer spec migration: #4767 (tracking), #4914 (implementation).
+//
+// Typical usage:
+//
+//	err := controllerutil.MutateAndPatchStatus(ctx, r.Client, mcpServer,
+//	    func(s *mcpv1alpha1.MCPServer) {
+//	        meta.SetStatusCondition(&s.Status.Conditions, metav1.Condition{
+//	            Type:   mcpv1alpha1.ConditionReady,
+//	            Status: metav1.ConditionTrue,
+//	            Reason: mcpv1alpha1.ConditionReasonReady,
+//	        })
+//	    })
+func MutateAndPatchStatus[T client.Object](
+	ctx context.Context, c client.Client, obj T, mutate func(T),
+) error {
+	// Reject both a true-nil interface and a typed-nil pointer. T is
+	// constrained to client.Object; every real implementer is a pointer
+	// to a struct, so a nil obj is always a programmer error. Returning
+	// an explicit error is nicer than the raw panic that the subsequent
+	// .(T) type assertion would produce.
+	v := reflect.ValueOf(obj)
+	if !v.IsValid() || (v.Kind() == reflect.Pointer && v.IsNil()) {
+		return fmt.Errorf("MutateAndPatchStatus: obj must be non-nil")
+	}
+	original := obj.DeepCopyObject().(T)
+	mutate(obj)
+	data, err := client.MergeFrom(original).Data(obj)
+	if err != nil {
+		return err
+	}
+	// Skip the wire call for a no-op mutate. The apiserver runs the full
+	// admission and audit pipeline for every PATCH regardless of body
+	// content, so sending {} costs watch-cascade and audit log noise for
+	// no benefit. Controllers like EmbeddingServerReconciler that requeue
+	// at 1s would otherwise generate steady-state no-op PATCH traffic.
+	if bytes.Equal(data, []byte("{}")) {
+		return nil
+	}
+	return c.Status().Patch(ctx, obj, client.RawPatch(types.MergePatchType, data))
+}

--- a/cmd/thv-operator/pkg/controllerutil/status_test.go
+++ b/cmd/thv-operator/pkg/controllerutil/status_test.go
@@ -1,0 +1,493 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package controllerutil
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+)
+
+// statusPatchRecordingClient wraps a client.Client and intercepts
+// .Status().Patch calls so tests can assert the wire-level patch body.
+type statusPatchRecordingClient struct {
+	client.Client
+	mu       sync.Mutex
+	bodies   []string
+	forceErr error
+}
+
+func (c *statusPatchRecordingClient) Status() client.SubResourceWriter {
+	return &statusSubResourceRecorder{parent: c, inner: c.Client.Status()}
+}
+
+type statusSubResourceRecorder struct {
+	parent *statusPatchRecordingClient
+	inner  client.SubResourceWriter
+}
+
+func (r *statusSubResourceRecorder) Create(
+	ctx context.Context, obj client.Object, subResource client.Object, opts ...client.SubResourceCreateOption,
+) error {
+	return r.inner.Create(ctx, obj, subResource, opts...)
+}
+
+func (r *statusSubResourceRecorder) Update(
+	ctx context.Context, obj client.Object, opts ...client.SubResourceUpdateOption,
+) error {
+	return r.inner.Update(ctx, obj, opts...)
+}
+
+func (r *statusSubResourceRecorder) Patch(
+	ctx context.Context, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption,
+) error {
+	if data, err := patch.Data(obj); err == nil {
+		r.parent.mu.Lock()
+		r.parent.bodies = append(r.parent.bodies, string(data))
+		r.parent.mu.Unlock()
+	}
+	if r.parent.forceErr != nil {
+		return r.parent.forceErr
+	}
+	return r.inner.Patch(ctx, obj, patch, opts...)
+}
+
+func (r *statusSubResourceRecorder) Apply(
+	ctx context.Context, obj runtime.ApplyConfiguration, opts ...client.SubResourceApplyOption,
+) error {
+	return r.inner.Apply(ctx, obj, opts...)
+}
+
+func (c *statusPatchRecordingClient) lastBody() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if len(c.bodies) == 0 {
+		return ""
+	}
+	return c.bodies[len(c.bodies)-1]
+}
+
+func buildStatusTestClient(t *testing.T, seed *mcpv1beta1.MCPServer) (*statusPatchRecordingClient, client.Client) {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
+	inner := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(seed).
+		WithStatusSubresource(&mcpv1beta1.MCPServer{}).
+		Build()
+	recorder := &statusPatchRecordingClient{Client: inner}
+	return recorder, inner
+}
+
+func newSeedMCPServer(name string) *mcpv1beta1.MCPServer {
+	return &mcpv1beta1.MCPServer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+		},
+		Spec: mcpv1beta1.MCPServerSpec{
+			Image:     "example/mcp:latest",
+			Transport: "stdio",
+			ProxyMode: "sse",
+			ProxyPort: 8080,
+			MCPPort:   8080,
+		},
+	}
+}
+
+// TestMutateAndPatchStatus_AppliesMutation asserts the happy path:
+// the mutation is applied to the object in place AND persisted via a
+// status-subresource merge patch whose body carries the mutated fields.
+func TestMutateAndPatchStatus_AppliesMutation(t *testing.T) {
+	t.Parallel()
+
+	seed := newSeedMCPServer("mutate-happy")
+	recorder, _ := buildStatusTestClient(t, seed)
+
+	got := seed.DeepCopy()
+	err := MutateAndPatchStatus(context.TODO(), recorder, got, func(s *mcpv1beta1.MCPServer) {
+		meta.SetStatusCondition(&s.Status.Conditions, metav1.Condition{
+			Type:    "Ready",
+			Status:  metav1.ConditionTrue,
+			Reason:  "Testing",
+			Message: "happy path",
+		})
+	})
+	require.NoError(t, err)
+
+	// In-memory object reflects the mutation.
+	readyCond := meta.FindStatusCondition(got.Status.Conditions, "Ready")
+	require.NotNil(t, readyCond)
+	assert.Equal(t, metav1.ConditionTrue, readyCond.Status)
+
+	// Patch body carries the mutated status fields.
+	body := recorder.lastBody()
+	require.NotEmpty(t, body)
+	assert.Contains(t, body, `"conditions"`)
+	assert.Contains(t, body, `"Ready"`)
+}
+
+// TestMutateAndPatchStatus_NoOpMutateSkipsWireCall asserts that when
+// mutate produces no diff, the helper does not issue a PATCH. This
+// matters because the apiserver runs admission, audit, and (on older
+// clusters) watch-notification pipelines for every PATCH regardless of
+// body content — sending {} is not free.
+func TestMutateAndPatchStatus_NoOpMutateSkipsWireCall(t *testing.T) {
+	t.Parallel()
+
+	seed := newSeedMCPServer("mutate-noop")
+	seed.Status.Conditions = []metav1.Condition{{
+		Type:               "Ready",
+		Status:             metav1.ConditionTrue,
+		Reason:             "Initial",
+		LastTransitionTime: metav1.Now(),
+	}}
+	recorder, inner := buildStatusTestClient(t, seed)
+
+	got := &mcpv1beta1.MCPServer{}
+	require.NoError(t, inner.Get(context.TODO(), client.ObjectKeyFromObject(seed), got))
+
+	// meta.SetStatusCondition is idempotent when Status/Reason/Message
+	// all match — the mutation produces no diff at the byte level.
+	err := MutateAndPatchStatus(context.TODO(), recorder, got, func(s *mcpv1beta1.MCPServer) {
+		meta.SetStatusCondition(&s.Status.Conditions, metav1.Condition{
+			Type:   "Ready",
+			Status: metav1.ConditionTrue,
+			Reason: "Initial",
+		})
+	})
+	require.NoError(t, err)
+
+	recorder.mu.Lock()
+	defer recorder.mu.Unlock()
+	assert.Empty(t, recorder.bodies,
+		"helper must not issue a PATCH when mutate produces no diff; "+
+			"recorded %d body/bodies: %v", len(recorder.bodies), recorder.bodies)
+}
+
+// TestMutateAndPatchStatus_DeepCopyIsolatesOriginal asserts that the
+// snapshot captured before mutate is truly independent of obj. A naive
+// implementation that aliased the original would produce an empty diff
+// (both pointers see the mutation), so the patch body would not include
+// the mutated fields. This test guards that invariant.
+func TestMutateAndPatchStatus_DeepCopyIsolatesOriginal(t *testing.T) {
+	t.Parallel()
+
+	seed := newSeedMCPServer("mutate-deepcopy")
+	// Pre-seed a condition so the diff is a clean "one condition changed"
+	// rather than "conditions array created".
+	seed.Status.Conditions = []metav1.Condition{{
+		Type:               "Ready",
+		Status:             metav1.ConditionFalse,
+		Reason:             "Initial",
+		Message:            "before mutate",
+		LastTransitionTime: metav1.Now(),
+	}}
+	recorder, inner := buildStatusTestClient(t, seed)
+
+	got := &mcpv1beta1.MCPServer{}
+	require.NoError(t, inner.Get(context.TODO(), client.ObjectKeyFromObject(seed), got))
+
+	err := MutateAndPatchStatus(context.TODO(), recorder, got, func(s *mcpv1beta1.MCPServer) {
+		meta.SetStatusCondition(&s.Status.Conditions, metav1.Condition{
+			Type:    "Ready",
+			Status:  metav1.ConditionTrue,
+			Reason:  "Promoted",
+			Message: "after mutate",
+		})
+	})
+	require.NoError(t, err)
+
+	body := recorder.lastBody()
+	require.NotEmpty(t, body)
+	// If DeepCopy aliased obj, original and current would both be
+	// ConditionTrue+Promoted by the time MergeFrom computes the diff,
+	// and the body would contain neither the old nor new reason. The
+	// presence of "Promoted" in the body proves the snapshot captured
+	// the pre-mutation state.
+	assert.Contains(t, body, "Promoted",
+		"patch body should reflect the mutated condition reason; "+
+			"DeepCopy may have aliased the original. body=%s", body)
+}
+
+// TestMutateAndPatchStatus_PreservesDisjointStatusFields is the core
+// regression test for the helper's stated purpose (#4633): when a
+// caller writes status from a stale snapshot, fields owned by a
+// different writer must survive. A full Status().Update would clobber
+// them (PUT semantics replace the whole status stanza); a merge patch
+// computed from the stale snapshot only carries the fields this caller
+// changed, so disjoint fields on the live object are left alone.
+//
+// Test shape: seed an object, snapshot it, let a "second writer" mutate
+// a disjoint field on the live object, then call the helper on the
+// stale snapshot and mutate a different field. Assert both fields are
+// present on a fresh Get of the live object.
+func TestMutateAndPatchStatus_PreservesDisjointStatusFields(t *testing.T) {
+	t.Parallel()
+
+	seed := newSeedMCPServer("preserve-disjoint")
+	recorder, inner := buildStatusTestClient(t, seed)
+
+	// Stale snapshot taken before the second writer modifies live state.
+	staleObj := &mcpv1beta1.MCPServer{}
+	require.NoError(t, inner.Get(context.TODO(), client.ObjectKeyFromObject(seed), staleObj))
+
+	// Simulate a second writer (e.g. a runtime reporter) that owns
+	// Phase/Message on the live object. staleObj does not know about
+	// these writes.
+	other := &mcpv1beta1.MCPServer{}
+	require.NoError(t, inner.Get(context.TODO(), client.ObjectKeyFromObject(seed), other))
+	other.Status.Phase = mcpv1beta1.MCPServerPhaseReady
+	other.Status.Message = "managed by the other writer"
+	require.NoError(t, inner.Status().Update(context.TODO(), other))
+
+	// Helper mutates a disjoint field on the stale snapshot.
+	err := MutateAndPatchStatus(context.TODO(), recorder, staleObj, func(s *mcpv1beta1.MCPServer) {
+		s.Status.URL = "http://mutated.example"
+	})
+	require.NoError(t, err)
+
+	// Fresh Get: the field we mutated must be persisted, and the fields
+	// the second writer owns must survive. If the helper were swapped
+	// back to Status().Update, Phase and Message would be zeroed here.
+	live := &mcpv1beta1.MCPServer{}
+	require.NoError(t, inner.Get(context.TODO(), client.ObjectKeyFromObject(seed), live))
+	assert.Equal(t, "http://mutated.example", live.Status.URL,
+		"mutated field must be persisted by the patch")
+	assert.Equal(t, mcpv1beta1.MCPServerPhaseReady, live.Status.Phase,
+		"disjoint field owned by another writer must survive the patch")
+	assert.Equal(t, "managed by the other writer", live.Status.Message,
+		"disjoint field owned by another writer must survive the patch")
+}
+
+// TestMutateAndPatchStatus_StaleScalarComputationClobbersConcurrentWrite
+// codifies the scalar-field half of the caller contract and its wire-level
+// semantics. Two sub-cases:
+//
+//  1. Re-assigning the read value is a no-op at the wire level —
+//     merge-patch omits unchanged fields, so the concurrent writer's
+//     value on the live object is preserved.
+//  2. Assigning a value that differs from the stale snapshot sends the
+//     field in the patch body and overwrites a concurrent writer's
+//     value on the live object.
+//
+// The test guards both cases so that a future change to the helper's
+// diff semantics fails loudly and forces a design discussion.
+func TestMutateAndPatchStatus_StaleScalarComputationClobbersConcurrentWrite(t *testing.T) {
+	t.Parallel()
+
+	// Sub-case (1): stale writer re-assigns the read value → no-op diff,
+	// concurrent writer preserved.
+	t.Run("reassigning_read_value_is_noop", func(t *testing.T) {
+		t.Parallel()
+
+		seed := newSeedMCPServer("stale-noop")
+		seed.Status.Phase = mcpv1beta1.MCPServerPhasePending
+		recorder, inner := buildStatusTestClient(t, seed)
+
+		staleObj := &mcpv1beta1.MCPServer{}
+		require.NoError(t, inner.Get(context.TODO(), client.ObjectKeyFromObject(seed), staleObj))
+		stalePhase := staleObj.Status.Phase // "Pending"
+
+		// Concurrent writer sets Phase to Ready.
+		other := &mcpv1beta1.MCPServer{}
+		require.NoError(t, inner.Get(context.TODO(), client.ObjectKeyFromObject(seed), other))
+		other.Status.Phase = mcpv1beta1.MCPServerPhaseReady
+		require.NoError(t, inner.Status().Update(context.TODO(), other))
+
+		// Stale writer assigns the value it read.
+		err := MutateAndPatchStatus(context.TODO(), recorder, staleObj, func(s *mcpv1beta1.MCPServer) {
+			s.Status.Phase = stalePhase
+		})
+		require.NoError(t, err)
+
+		body := recorder.lastBody()
+		assert.NotContains(t, body, `"phase"`,
+			"re-assigning a scalar to its pre-mutate value must be omitted from "+
+				"the merge-patch body. body=%s", body)
+
+		live := &mcpv1beta1.MCPServer{}
+		require.NoError(t, inner.Get(context.TODO(), client.ObjectKeyFromObject(seed), live))
+		assert.Equal(t, mcpv1beta1.MCPServerPhaseReady, live.Status.Phase,
+			"when the diff omits the field, the concurrent writer's value must survive")
+	})
+
+	// Sub-case (2): stale writer computes a new value that differs from
+	// its snapshot. The field lands in the patch and overwrites live.
+	t.Run("stale_computation_clobbers_concurrent_write", func(t *testing.T) {
+		t.Parallel()
+
+		seed := newSeedMCPServer("stale-clobbers-scalar")
+		seed.Status.Phase = mcpv1beta1.MCPServerPhasePending
+		recorder, inner := buildStatusTestClient(t, seed)
+
+		staleObj := &mcpv1beta1.MCPServer{}
+		require.NoError(t, inner.Get(context.TODO(), client.ObjectKeyFromObject(seed), staleObj))
+
+		// Concurrent writer sets Phase to Ready on the live object.
+		other := &mcpv1beta1.MCPServer{}
+		require.NoError(t, inner.Get(context.TODO(), client.ObjectKeyFromObject(seed), other))
+		other.Status.Phase = mcpv1beta1.MCPServerPhaseReady
+		other.Status.Message = "set by the concurrent writer"
+		require.NoError(t, inner.Status().Update(context.TODO(), other))
+
+		// Stale writer computes a new Phase from stale-derived state
+		// (here, Failed — something neither the snapshot nor the live
+		// object currently has).
+		err := MutateAndPatchStatus(context.TODO(), recorder, staleObj, func(s *mcpv1beta1.MCPServer) {
+			s.Status.Phase = mcpv1beta1.MCPServerPhaseFailed
+		})
+		require.NoError(t, err)
+
+		body := recorder.lastBody()
+		assert.Contains(t, body, `"phase"`,
+			"a new value distinct from the snapshot must land in the patch body. body=%s", body)
+
+		live := &mcpv1beta1.MCPServer{}
+		require.NoError(t, inner.Get(context.TODO(), client.ObjectKeyFromObject(seed), live))
+		assert.Equal(t, mcpv1beta1.MCPServerPhaseFailed, live.Status.Phase,
+			"stale-computed value must overwrite the concurrent writer's Phase; "+
+				"if this assertion ever fails, the helper's contract has changed "+
+				"and callers co-owning scalars may need fewer defensive measures")
+	})
+}
+
+// TestMutateAndPatchStatus_StaleSnapshotClobbersConditionsFromAnotherWriter
+// codifies a known limitation of the helper's RFC 7396 merge-patch
+// semantics: a stale snapshot combined with a concurrent writer on a
+// different condition type will erase the other writer's conditions,
+// because JSON merge-patch replaces arrays wholesale for CRDs.
+//
+// This is the mirror image of the disjoint-preservation test above:
+// disjoint scalar fields survive (they are absent from the diff), but
+// the Conditions array does not, because any mutation to it causes the
+// full array to appear in the patch body.
+//
+// The test does not assert a desirable behavior — it guards the
+// documented caller contract. If a future change silently "fixes" this
+// (e.g., by switching to strategic-merge-patch or by having the helper
+// internally refresh before writing), the test will fail and force a
+// design discussion rather than quietly altering the contract.
+func TestMutateAndPatchStatus_StaleSnapshotClobbersConditionsFromAnotherWriter(t *testing.T) {
+	t.Parallel()
+
+	seed := newSeedMCPServer("stale-clobbers-conditions")
+	seed.Status.Conditions = []metav1.Condition{{
+		Type:               "Foo",
+		Status:             metav1.ConditionTrue,
+		Reason:             "Initial",
+		LastTransitionTime: metav1.Now(),
+	}}
+	recorder, inner := buildStatusTestClient(t, seed)
+
+	// Stale snapshot captured before the second writer mutates live state.
+	staleObj := &mcpv1beta1.MCPServer{}
+	require.NoError(t, inner.Get(context.TODO(), client.ObjectKeyFromObject(seed), staleObj))
+
+	// Second writer owns a different condition type ("Bar") and sets it
+	// on the live object. Because apiserver lacks strategic-merge-patch
+	// for CRDs, the stale writer below will clobber this on merge.
+	other := &mcpv1beta1.MCPServer{}
+	require.NoError(t, inner.Get(context.TODO(), client.ObjectKeyFromObject(seed), other))
+	meta.SetStatusCondition(&other.Status.Conditions, metav1.Condition{
+		Type:    "Bar",
+		Status:  metav1.ConditionTrue,
+		Reason:  "OwnedByOther",
+		Message: "set by the concurrent writer",
+	})
+	require.NoError(t, inner.Status().Update(context.TODO(), other))
+
+	// Stale writer mutates "Foo" on the snapshot. The merge patch will
+	// carry the whole Conditions array as the stale writer sees it — a
+	// single-element array containing only Foo.
+	err := MutateAndPatchStatus(context.TODO(), recorder, staleObj, func(s *mcpv1beta1.MCPServer) {
+		meta.SetStatusCondition(&s.Status.Conditions, metav1.Condition{
+			Type:   "Foo",
+			Status: metav1.ConditionFalse,
+			Reason: "Demoted",
+		})
+	})
+	require.NoError(t, err)
+
+	live := &mcpv1beta1.MCPServer{}
+	require.NoError(t, inner.Get(context.TODO(), client.ObjectKeyFromObject(seed), live))
+
+	// Foo was mutated and should be persisted.
+	fooCond := meta.FindStatusCondition(live.Status.Conditions, "Foo")
+	require.NotNil(t, fooCond, "mutated condition must be persisted")
+	assert.Equal(t, metav1.ConditionFalse, fooCond.Status)
+
+	// Bar was owned by the concurrent writer and should have been erased
+	// by the wholesale array replacement. If this assertion ever fails,
+	// the helper's merge-patch contract has changed — update the doc
+	// comment and consider whether callers in Conditions-shared paths
+	// can be simplified.
+	barCond := meta.FindStatusCondition(live.Status.Conditions, "Bar")
+	assert.Nil(t, barCond,
+		"stale snapshot + RFC 7396 merge patch must erase the concurrent "+
+			"writer's condition; this test guards the documented contract "+
+			"so callers know Conditions writes require a fresh Get")
+}
+
+// TestMutateAndPatchStatus_RejectsNilObj asserts that a typed-nil obj
+// returns a descriptive error rather than panicking inside the .(T)
+// type assertion. A nil obj is always a programmer error, but the
+// helper returns an error so the reconciler's requeue and logging
+// machinery handles it cleanly instead of crashing the worker.
+func TestMutateAndPatchStatus_RejectsNilObj(t *testing.T) {
+	t.Parallel()
+
+	seed := newSeedMCPServer("mutate-nil")
+	recorder, _ := buildStatusTestClient(t, seed)
+
+	var nilObj *mcpv1beta1.MCPServer
+	err := MutateAndPatchStatus(context.TODO(), recorder, nilObj, func(_ *mcpv1beta1.MCPServer) {
+		t.Fatal("mutate must not be called when obj is nil")
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "obj must be non-nil",
+		"error message should name the offending parameter for debugging; got %v", err)
+
+	recorder.mu.Lock()
+	defer recorder.mu.Unlock()
+	assert.Empty(t, recorder.bodies,
+		"no PATCH should be issued when the input is invalid")
+}
+
+// TestMutateAndPatchStatus_PropagatesPatchError asserts that an error
+// from the underlying status.Patch is returned to the caller unmodified.
+// Controllers rely on the error for requeue decisions; swallowing it
+// would cause silent status drift.
+func TestMutateAndPatchStatus_PropagatesPatchError(t *testing.T) {
+	t.Parallel()
+
+	seed := newSeedMCPServer("mutate-err")
+	recorder, _ := buildStatusTestClient(t, seed)
+	want := errors.New("simulated apiserver failure")
+	recorder.forceErr = want
+
+	got := seed.DeepCopy()
+	err := MutateAndPatchStatus(context.TODO(), recorder, got, func(s *mcpv1beta1.MCPServer) {
+		meta.SetStatusCondition(&s.Status.Conditions, metav1.Condition{
+			Type:   "Ready",
+			Status: metav1.ConditionTrue,
+			Reason: "Testing",
+		})
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, want,
+		"helper should propagate the apiserver error unchanged; got %v", err)
+}


### PR DESCRIPTION
## Summary

- The operator's status writes use `r.Status().Update`, which sends a full
  PUT of the status stanza and zeros any field a disjoint writer owns
  (e.g. a runtime reporter writing status on the same CR). #4633 tracks
  migrating to merge-patch; this PR introduces the helper the migration
  will call at every site so the DeepCopy-before-mutate discipline is
  captured in one place instead of re-implemented per call.
- `MutateAndPatchStatus[T client.Object](ctx, c, obj, mutate)` collapses
  the `DeepCopy → mutate → Status().Patch(MergeFrom(original))` idiom to
  a single call. Plain merge patch, not optimistic-lock: status-subresource
  writers with disjoint fields must coexist without forcing a 409 on every
  overlap. Spec and metadata writes still require optimistic locking —
  see #4767 (tracking) / #4914 (MCPServer migration).
- The helper does not make every multi-writer pattern safe. The doc
  comment's Caller contract spells out what it cannot defend against:
  Conditions-array writers must be the sole owner of the entire array
  (merge-patch replaces arrays wholesale for CRDs; `+listType=map` is
  only honored by strategic-merge-patch), and a scalar re-computed from
  a stale snapshot that differs from the live value will clobber a
  concurrent writer.
- Operational safeguards: no-op mutations skip the wire call to avoid
  steady-state PATCH noise on fast-requeue reconcilers, and a nil obj
  returns a descriptive error instead of panicking in the `.(T)` assertion.
- Codified checklist for new call sites added to `.claude/rules/operator.md`.
- Pure addition — no existing call-site touched in this PR. Migration of
  the existing `r.Status().Update` call sites will follow.

Relates to #4633

## Type of change

- [x] Refactoring (no behavior change)

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)

Tests in `cmd/thv-operator/pkg/controllerutil/status_test.go` cover:
- Happy path: mutation applied in-memory AND reflected in the patch body.
- DeepCopy isolation: regression guard for snapshot aliasing.
- No-op mutate: helper skips the wire call when the diff is `{}`.
- Disjoint-writer preservation: stale snapshot + second writer on a different
  scalar field; fresh `Get` confirms both the mutated field and the second
  writer's fields survive.
- Stale snapshot clobbers conditions from another writer: guards the
  documented Caller contract (distinct condition types do not survive a
  stale writer's merge patch, so callers must own the entire array).
- Stale scalar computation: re-assigning the read value is a wire-level
  no-op (concurrent writer preserved); assigning a differing value
  overwrites live state.
- Nil obj rejected with a descriptive error, no PATCH issued.
- Error propagation: apiserver failure returned unchanged for requeue.

## Does this introduce a user-facing change?

No.

Generated with [Claude Code](https://claude.com/claude-code)