### PR TITLE
vmcp: stop the TEI manager on Start failure and apply image default in Serve

### DIFF
--- a/pkg/vmcp/cli/embedding_manager.go
+++ b/pkg/vmcp/cli/embedding_manager.go
@@ -28,8 +28,9 @@ import (
 )
 
 const (
-	// defaultTEIImage is the default HuggingFace Text Embeddings Inference image.
-	defaultTEIImage = "ghcr.io/huggingface/text-embeddings-inference:cpu-latest"
+	// DefaultEmbeddingImage is the default HuggingFace Text Embeddings
+	// Inference image used when ServeConfig.EmbeddingImage is empty.
+	DefaultEmbeddingImage = "ghcr.io/huggingface/text-embeddings-inference:cpu-latest"
 
 	// DefaultEmbeddingModel is the HuggingFace model used when EmbeddingModel is empty.
 	DefaultEmbeddingModel = "BAAI/bge-small-en-v1.5"
@@ -89,7 +90,7 @@ type EmbeddingServiceManagerConfig struct {
 	Model string
 
 	// Image is the TEI container image to run.
-	// Defaults to defaultTEIImage when empty.
+	// Defaults to DefaultEmbeddingImage when empty.
 	Image string
 }
 
@@ -142,7 +143,7 @@ func NewEmbeddingServiceManager(factory ContainerFactory, cfg EmbeddingServiceMa
 		return nil, fmt.Errorf("model must not be empty")
 	}
 	if cfg.Image == "" {
-		cfg.Image = defaultTEIImage
+		cfg.Image = DefaultEmbeddingImage
 	}
 
 	containerName := containerNameForModel(cfg.Model)

--- a/pkg/vmcp/cli/serve.go
+++ b/pkg/vmcp/cli/serve.go
@@ -302,9 +302,13 @@ func Serve(ctx context.Context, cfg ServeConfig) error {
 		if model == "" {
 			model = DefaultEmbeddingModel
 		}
+		image := cfg.EmbeddingImage
+		if image == "" {
+			image = DefaultEmbeddingImage
+		}
 		m, err := NewEmbeddingServiceManager(container.NewFactory(), EmbeddingServiceManagerConfig{
 			Model: model,
-			Image: cfg.EmbeddingImage,
+			Image: image,
 		})
 		if err != nil {
 			return fmt.Errorf("failed to create embedding service manager: %w", err)
@@ -437,6 +441,9 @@ func injectOptimizerConfig(ctx context.Context, cfg ServeConfig, vmcpCfg *config
 	}
 	teiURL, err := mgr.Start(ctx)
 	if err != nil {
+		// Best-effort cleanup: a Start failure can still leave a partial
+		// container behind (created but health poll timed out, etc.).
+		_ = mgr.Stop(context.Background())
 		return nil, fmt.Errorf("failed to start TEI embedding service: %w", err)
 	}
 	vmcpCfg.Optimizer.EmbeddingService = teiURL


### PR DESCRIPTION
## Summary

Two small fixes in `pkg/vmcp/cli/` raised by #4945 (both originally noticed in the #4941 review but dropped when that PR scoped down to e2e tests).

Fixes #4945.

## 1. TEI container leak on partial Start failure

`injectOptimizerConfig` in `pkg/vmcp/cli/serve.go` calls `mgr.Start(ctx)` and propagates the error straight up. If Start has already deployed the container and then e.g. the health poll times out, the container is left running and `mgr.Stop` is never called.

This PR adds a best-effort cleanup before returning the wrapped error:

```go
teiURL, err := mgr.Start(ctx)
if err != nil {
    _ = mgr.Stop(context.Background())
    return nil, fmt.Errorf("failed to start TEI embedding service: %w", err)
}
```

`Stop` is best-effort because the container may legitimately not exist at this point; either way we're no worse off than before.

## 2. `EmbeddingImage` defaulted at `Serve()` alongside `EmbeddingModel`

`Serve()` already defaults `ServeConfig.EmbeddingModel` to `DefaultEmbeddingModel` when empty. The sibling `EmbeddingImage` was passed straight to `NewEmbeddingServiceManager`, which applied its own private `defaultTEIImage` default. That's inconsistent, and there was no exported constant for external callers.

This PR:

- Renames `defaultTEIImage` → `DefaultEmbeddingImage` (exported) in `pkg/vmcp/cli/embedding_manager.go`.
- Applies the default in `Serve()` the same way `DefaultEmbeddingModel` is applied.
- Keeps the manager's empty-`Image` fallback intact (still points at the same constant) so direct callers of `NewEmbeddingServiceManager` are unaffected.

## Testing

- `go build ./...` and `go test ./pkg/vmcp/...` pass.
- No behaviour change on the happy path; image defaulting is semantically unchanged, just moved one layer up.
