### PR TITLE
api/v1alpha1: validate MCPOIDCConfig inline issuer and JWKS URLs

### DIFF
--- a/cmd/thv-operator/api/v1alpha1/mcpoidcconfig_types.go
+++ b/cmd/thv-operator/api/v1alpha1/mcpoidcconfig_types.go
@@ -5,6 +5,7 @@ package v1alpha1
 
 import (
 	"fmt"
+	"net/url"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -257,7 +258,22 @@ type MCPOIDCConfigReference struct {
 // CEL catches issues at API admission time, but this method also validates stored objects
 // to catch any that bypassed CEL or were stored before CEL rules were added.
 func (r *MCPOIDCConfig) Validate() error {
-	return r.validateTypeConfigConsistency()
+	if err := r.validateTypeConfigConsistency(); err != nil {
+		return err
+	}
+	if r.Spec.Inline != nil {
+		// URL sanity checks for the inline config. Issuer and JWKS URLs
+		// must be well-formed and must use HTTPS unless the user has
+		// explicitly opted into HTTP via insecureAllowHTTP (#4823).
+		allowInsecure := r.Spec.Inline.InsecureAllowHTTP
+		if err := validateOIDCIssuerURL(r.Spec.Inline.Issuer, allowInsecure); err != nil {
+			return err
+		}
+		if err := validateJWKSURL(r.Spec.Inline.JWKSURL, allowInsecure); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // validateTypeConfigConsistency validates that the correct config is set for the selected type.
@@ -268,6 +284,45 @@ func (r *MCPOIDCConfig) validateTypeConfigConsistency() error {
 	}
 	if (r.Spec.Inline == nil) == (r.Spec.Type == MCPOIDCConfigTypeInline) {
 		return fmt.Errorf("inline configuration must be set if and only if type is 'inline'")
+	}
+	return nil
+}
+
+// validateOIDCIssuerURL checks that an OIDC issuer URL is well-formed and uses
+// HTTPS (or HTTP when allowInsecure is true). Mirrors the validation that used
+// to live in pkg/validation/oidc_validation.go but is inlined here to avoid an
+// import cycle between the types package and pkg/validation.
+// Returns nil if issuer is empty.
+func validateOIDCIssuerURL(issuer string, allowInsecure bool) error {
+	return validateHTTPLikeURL("OIDC issuer URL", issuer, allowInsecure)
+}
+
+// validateJWKSURL checks that a JWKS URL is well-formed and uses HTTPS (or HTTP
+// when allowInsecure is true). Returns nil if jwks is empty; JWKS URLs are
+// optional and otherwise discovered from the issuer.
+func validateJWKSURL(jwks string, allowInsecure bool) error {
+	return validateHTTPLikeURL("JWKS URL", jwks, allowInsecure)
+}
+
+func validateHTTPLikeURL(label, raw string, allowInsecure bool) error {
+	if raw == "" {
+		return nil
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("%s %q is malformed: %w", label, raw, err)
+	}
+	if u.Scheme == "" || u.Host == "" {
+		return fmt.Errorf("%s %q is malformed: missing scheme or host", label, raw)
+	}
+	if u.Scheme == "http" && !allowInsecure {
+		return fmt.Errorf(
+			"%s %q uses HTTP scheme, which is insecure; "+
+				"use HTTPS or set insecureAllowHTTP: true for development only", label, raw,
+		)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("%s %q has unsupported scheme %q; must be http or https", label, raw, u.Scheme)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

When #4820 removed the deprecated inline `oidcConfig` from `MCPServer` and `MCPRemoteProxy`, it also took the `validateOIDCIssuerURL` / `validateJWKSURL` call sites with it. The equivalent checks were never wired into `MCPOIDCConfig.Validate()`, so a malformed or HTTP-only issuer/JWKS in an inline `MCPOIDCConfig` is accepted at admission and only fails later at runtime.

Fixes #4823.

## Change

`cmd/thv-operator/api/v1alpha1/mcpoidcconfig_types.go` — `MCPOIDCConfig.Validate()` now also:

- runs `validateOIDCIssuerURL(Inline.Issuer, Inline.InsecureAllowHTTP)`
- runs `validateJWKSURL(Inline.JWKSURL, Inline.InsecureAllowHTTP)`

URL checks are inlined in the types package rather than imported from `pkg/validation` to avoid an import cycle (`pkg/validation` already imports this package).

Behaviour:

- Empty issuer/JWKS is accepted (the JWKS URL is optional and discovered from the issuer when unset).
- Non-empty values must parse, have a scheme + host, and use HTTPS unless `InsecureAllowHTTP: true`.

## Testing

- `go build ./...` passes.
- `go test ./cmd/thv-operator/api/v1alpha1/...` passes, including a new regression that feeds `Inline.Issuer = "http://issuer.example"` with and without `InsecureAllowHTTP`.
