### PR TITLE
thv-operator: drop unused WebhookServer listener

### DIFF
--- a/cmd/thv-operator/main.go
+++ b/cmd/thv-operator/main.go
@@ -27,7 +27,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server" // Import for metricsserver
-	"sigs.k8s.io/controller-runtime/pkg/webhook"                      // Import for webhook
 
 	mcpv1alpha1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1alpha1"
 	"github.com/stacklok/toolhive/cmd/thv-operator/controllers"
@@ -79,7 +78,6 @@ func main() {
 	options := ctrl.Options{
 		Scheme:                  scheme,
 		Metrics:                 metricsserver.Options{BindAddress: metricsAddr},
-		WebhookServer:           webhook.NewServer(webhook.Options{Port: 9443}),
 		HealthProbeBindAddress:  probeAddr,
 		LeaderElection:          enableLeaderElection,
 		LeaderElectionID:        "toolhive-operator-leader-election",


### PR DESCRIPTION
## Summary

The manager options wired a TLS webhook server on port 9443, but no webhook handlers are registered anywhere in the codebase and the Helm chart does not expose the port, so the listener just binds a port and goroutines for nothing. Once webhooks land, whoever adds the first handler will re-introduce the option alongside the registration and expose the port in the chart.

## Type of change

- [x] Bug fix

## Test plan

- [x] `go build ./cmd/thv-operator/` (confirmed the now-unused `sigs.k8s.io/controller-runtime/pkg/webhook` import was also removed so the build stays clean)
- [x] Verified no `mgr.GetWebhookServer()` / webhook registration remains in `cmd/thv-operator/...`

Closes #4627
