### PR TITLE
Upgrade default uvx builder image to python:3.14-slim

### DIFF
--- a/docs/arch/05-runconfig-and-permissions.md
+++ b/docs/arch/05-runconfig-and-permissions.md
@@ -92,7 +92,7 @@ The complete `RunConfig` struct is defined in `pkg/runner/config.go`.
 - `builder_image`: Override the default base image for the builder stage
   - Go: Default `golang:1.26-alpine`
   - Node: Default `node:22-alpine`
-  - Python: Default `python:3.13-slim`
+  - Python: Default `python:3.14-slim`
 - `additional_packages`: Extra packages to install during the build and runtime stages (e.g., build tools, libraries)
 
 **CLI usage:**

--- a/docs/runtime-version-customization.md
+++ b/docs/runtime-version-customization.md
@@ -8,7 +8,7 @@ When you use protocol schemes like `thv run go://github.com/example/server`, Too
 
 - **Go**: `golang:1.26-alpine` (builder), `alpine:3.23` (runtime)
 - **Node**: `node:22-alpine` (builder and runtime)
-- **Python**: `python:3.13-slim` (builder and runtime)
+- **Python**: `python:3.14-slim` (builder and runtime)
 
 You can customize these base images to use different versions or add additional build and runtime packages.
 

--- a/docs/server/docs.go
+++ b/docs/server/docs.go
@@ -979,7 +979,7 @@ const docTemplate = `{
                         "uniqueItems": false
                     },
                     "builder_image": {
-                        "description": "BuilderImage is the full image reference for the builder stage.\nAn empty string signals \"use the default for this transport type\" during config merging.\nExamples: \"golang:1.26-alpine\", \"node:22-alpine\", \"python:3.13-slim\"",
+                        "description": "BuilderImage is the full image reference for the builder stage.\nAn empty string signals \"use the default for this transport type\" during config merging.\nExamples: \"golang:1.26-alpine\", \"node:22-alpine\", \"python:3.14-slim\"",
                         "type": "string"
                     }
                 },

--- a/docs/server/swagger.json
+++ b/docs/server/swagger.json
@@ -972,7 +972,7 @@
                         "uniqueItems": false
                     },
                     "builder_image": {
-                        "description": "BuilderImage is the full image reference for the builder stage.\nAn empty string signals \"use the default for this transport type\" during config merging.\nExamples: \"golang:1.26-alpine\", \"node:22-alpine\", \"python:3.13-slim\"",
+                        "description": "BuilderImage is the full image reference for the builder stage.\nAn empty string signals \"use the default for this transport type\" during config merging.\nExamples: \"golang:1.26-alpine\", \"node:22-alpine\", \"python:3.14-slim\"",
                         "type": "string"
                     }
                 },

--- a/docs/server/swagger.yaml
+++ b/docs/server/swagger.yaml
@@ -957,7 +957,7 @@ components:
           description: |-
             BuilderImage is the full image reference for the builder stage.
             An empty string signals "use the default for this transport type" during config merging.
-            Examples: "golang:1.26-alpine", "node:22-alpine", "python:3.13-slim"
+            Examples: "golang:1.26-alpine", "node:22-alpine", "python:3.14-slim"
           type: string
       type: object
     github_com_stacklok_toolhive_pkg_core.Workload:

--- a/pkg/container/templates/runtime_config.go
+++ b/pkg/container/templates/runtime_config.go
@@ -24,7 +24,7 @@ var packageNamePattern = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._+\-]*$`)
 type RuntimeConfig struct {
 	// BuilderImage is the full image reference for the builder stage.
 	// An empty string signals "use the default for this transport type" during config merging.
-	// Examples: "golang:1.26-alpine", "node:22-alpine", "python:3.13-slim"
+	// Examples: "golang:1.26-alpine", "node:22-alpine", "python:3.14-slim"
 	BuilderImage string `json:"builder_image" yaml:"builder_image"`
 
 	// AdditionalPackages lists extra packages to install in the builder and
@@ -83,7 +83,7 @@ var RuntimeDefaults = map[TransportType]RuntimeConfig{
 		AdditionalPackages: []string{"git", "ca-certificates"},
 	},
 	TransportTypeUVX: {
-		BuilderImage:       "python:3.13-slim",
+		BuilderImage:       "python:3.14-slim",
 		AdditionalPackages: []string{"ca-certificates", "git"},
 	},
 }

--- a/pkg/container/templates/runtime_config_test.go
+++ b/pkg/container/templates/runtime_config_test.go
@@ -35,7 +35,7 @@ func TestGetDefaultRuntimeConfig(t *testing.T) {
 		{
 			name:          "UVX default config",
 			transportType: TransportTypeUVX,
-			wantImage:     "python:3.13-slim",
+			wantImage:     "python:3.14-slim",
 			wantPackages:  []string{"ca-certificates", "git"},
 		},
 	}
@@ -215,7 +215,7 @@ func TestRuntimeConfigValidate_ValidBuilderImages(t *testing.T) {
 		"golang:1.24-alpine",
 		"docker.io/library/node:20-alpine",
 		"ghcr.io/stacklok/builder:latest",
-		"python:3.13-slim",
+		"python:3.14-slim",
 		"node:22-alpine",
 		"mcr.microsoft.com/dotnet/sdk:8.0",
 		"registry.example.com/myimage:v1.2.3",

--- a/pkg/container/templates/templates_test.go
+++ b/pkg/container/templates/templates_test.go
@@ -414,7 +414,7 @@ func TestRuntimeStageInstallsAdditionalPackages(t *testing.T) {
 			name:          "UVX runtime stage installs extra packages",
 			transportType: TransportTypeUVX,
 			runtimeConfig: &RuntimeConfig{
-				BuilderImage:       "python:3.13-slim",
+				BuilderImage:       "python:3.14-slim",
 				AdditionalPackages: []string{"ca-certificates", "git", "curl"},
 			},
 			wantInRuntime: "curl",
@@ -487,7 +487,7 @@ func TestEmptyAdditionalPackagesDoesNotBreakBuild(t *testing.T) {
 			name:          "UVX with empty packages",
 			transportType: TransportTypeUVX,
 			runtimeConfig: &RuntimeConfig{
-				BuilderImage:       "python:3.13-slim",
+				BuilderImage:       "python:3.14-slim",
 				AdditionalPackages: []string{},
 			},
 		},
@@ -511,7 +511,7 @@ func TestEmptyAdditionalPackagesDoesNotBreakBuild(t *testing.T) {
 			name:          "UVX with nil packages",
 			transportType: TransportTypeUVX,
 			runtimeConfig: &RuntimeConfig{
-				BuilderImage:       "python:3.13-slim",
+				BuilderImage:       "python:3.14-slim",
 				AdditionalPackages: nil,
 			},
 		},

--- a/pkg/runner/protocol_test.go
+++ b/pkg/runner/protocol_test.go
@@ -270,7 +270,7 @@ func TestBuildFromProtocolSchemeWithNameDryRun(t *testing.T) {
 				"example-package",
 				"--transport",
 				"stdio",
-				"FROM python:3.13-slim",
+				"FROM python:3.14-slim",
 			},
 			wantErr: false,
 		},
@@ -383,7 +383,7 @@ func TestMergeRuntimeConfig(t *testing.T) {
 				BuilderImage:       "",
 				AdditionalPackages: []string{"curl"},
 			},
-			wantImage:    "python:3.13-slim",
+			wantImage:    "python:3.14-slim",
 			wantPackages: []string{"ca-certificates", "git", "curl"},
 		},
 	}


### PR DESCRIPTION
## Summary

- **Why**: Python 3.14 was released in Oct 2025 and is the current stable release. Bumping the default `uvx://` builder image picks up the latest runtime and security updates for new uvx-scheme workloads, and keeps the built-in default aligned with the current supported line.
- **What**: Change the default `RuntimeConfig.BuilderImage` for `TransportTypeUVX` from `python:3.13-slim` to `python:3.14-slim`, and update test expectations and docs accordingly. OpenAPI output regenerated via `task docs` picks up the doc-comment example change.

Users who need an older interpreter can still override via `--runtime-image python:3.13-slim` (or earlier) or a config file, exactly as before.

## Type of change

- [x] Other (default upgrade)

## Test plan

- [x] Regenerated OpenAPI docs via `task docs`
- [x] Cross-checked `python:3.14-slim` manifest digest against the Docker Hub API and the Docker Registry v2 API — both return `sha256:bc389f7dfcb21413e72a28f491985326994795e34d2b86c8ae2f417b4e7818aa`
- [ ] CI runs `task test` across affected packages (`pkg/container/templates/...`, `pkg/runner/...`)

## Does this introduce a user-facing change?

Yes — new `uvx://`-scheme workloads built with default settings now use a Python 3.14 builder. Workloads with an explicit `--runtime-image` or a `runtime_configs.python.builder_image` entry are unaffected.

Generated with [Claude Code](https://claude.com/claude-code)