### PR TITLE
Upgrade default go builder image to golang:1.26-alpine

### DIFF
--- a/docs/arch/05-runconfig-and-permissions.md
+++ b/docs/arch/05-runconfig-and-permissions.md
@@ -90,7 +90,7 @@ The complete `RunConfig` struct is defined in `pkg/runner/config.go`.
 
 **Fields:**
 - `builder_image`: Override the default base image for the builder stage
-  - Go: Default `golang:1.25-alpine`
+  - Go: Default `golang:1.26-alpine`
   - Node: Default `node:22-alpine`
   - Python: Default `python:3.13-slim`
 - `additional_packages`: Extra packages to install during the build and runtime stages (e.g., build tools, libraries)
@@ -112,7 +112,7 @@ thv run uvx://mcp-server \
 2. User config file (`~/.toolhive/config.yaml` `runtimeConfigs` map)
 3. Built-in defaults
 
-**Note**: For Go workloads, only the builder image is configurable. The runtime stage always uses `alpine:3.22` for simplicity and security.
+**Note**: For Go workloads, only the builder image is configurable. The runtime stage always uses `alpine:3.23` for simplicity and security.
 
 **Implementation**: `pkg/runner/config.go-198`, `pkg/container/templates/runtime_config.go`
 

--- a/docs/runtime-version-customization.md
+++ b/docs/runtime-version-customization.md
@@ -6,7 +6,7 @@ This guide explains how to customize the base images and packages used when runn
 
 When you use protocol schemes like `thv run go://github.com/example/server`, ToolHive automatically generates a container image. By default, it uses:
 
-- **Go**: `golang:1.25-alpine` (builder), `alpine:3.22` (runtime)
+- **Go**: `golang:1.26-alpine` (builder), `alpine:3.23` (runtime)
 - **Node**: `node:22-alpine` (builder and runtime)
 - **Python**: `python:3.13-slim` (builder and runtime)
 
@@ -28,7 +28,7 @@ Override the default base image for the builder stage.
 **Examples:**
 
 ```bash
-# Use Go 1.23 instead of default 1.25
+# Use Go 1.23 instead of default 1.26
 thv run go://github.com/example/server --runtime-image golang:1.23-alpine
 
 # Use Node 20 LTS instead of default 22
@@ -100,7 +100,7 @@ Runtime configurations are resolved in this order (highest priority first):
 
 ### Go Runtime Image
 
-For Go workloads, **only the builder image is customizable**. The runtime stage always uses `alpine:3.22` because:
+For Go workloads, **only the builder image is customizable**. The runtime stage always uses `alpine:3.23` because:
 
 - Go produces static binaries that don't require the Go toolchain at runtime
 - A minimal Alpine runtime keeps images small and secure

--- a/docs/server/docs.go
+++ b/docs/server/docs.go
@@ -979,7 +979,7 @@ const docTemplate = `{
                         "uniqueItems": false
                     },
                     "builder_image": {
-                        "description": "BuilderImage is the full image reference for the builder stage.\nAn empty string signals \"use the default for this transport type\" during config merging.\nExamples: \"golang:1.25-alpine\", \"node:22-alpine\", \"python:3.13-slim\"",
+                        "description": "BuilderImage is the full image reference for the builder stage.\nAn empty string signals \"use the default for this transport type\" during config merging.\nExamples: \"golang:1.26-alpine\", \"node:22-alpine\", \"python:3.13-slim\"",
                         "type": "string"
                     }
                 },

--- a/docs/server/swagger.json
+++ b/docs/server/swagger.json
@@ -972,7 +972,7 @@
                         "uniqueItems": false
                     },
                     "builder_image": {
-                        "description": "BuilderImage is the full image reference for the builder stage.\nAn empty string signals \"use the default for this transport type\" during config merging.\nExamples: \"golang:1.25-alpine\", \"node:22-alpine\", \"python:3.13-slim\"",
+                        "description": "BuilderImage is the full image reference for the builder stage.\nAn empty string signals \"use the default for this transport type\" during config merging.\nExamples: \"golang:1.26-alpine\", \"node:22-alpine\", \"python:3.13-slim\"",
                         "type": "string"
                     }
                 },

--- a/docs/server/swagger.yaml
+++ b/docs/server/swagger.yaml
@@ -957,7 +957,7 @@ components:
           description: |-
             BuilderImage is the full image reference for the builder stage.
             An empty string signals "use the default for this transport type" during config merging.
-            Examples: "golang:1.25-alpine", "node:22-alpine", "python:3.13-slim"
+            Examples: "golang:1.26-alpine", "node:22-alpine", "python:3.13-slim"
           type: string
       type: object
     github_com_stacklok_toolhive_pkg_core.Workload:

--- a/pkg/container/templates/runtime_config.go
+++ b/pkg/container/templates/runtime_config.go
@@ -24,7 +24,7 @@ var packageNamePattern = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._+\-]*$`)
 type RuntimeConfig struct {
 	// BuilderImage is the full image reference for the builder stage.
 	// An empty string signals "use the default for this transport type" during config merging.
-	// Examples: "golang:1.25-alpine", "node:22-alpine", "python:3.13-slim"
+	// Examples: "golang:1.26-alpine", "node:22-alpine", "python:3.13-slim"
 	BuilderImage string `json:"builder_image" yaml:"builder_image"`
 
 	// AdditionalPackages lists extra packages to install in the builder and
@@ -75,7 +75,7 @@ func (rc *RuntimeConfig) Validate() error {
 // RuntimeDefaults provides default configurations for each runtime type
 var RuntimeDefaults = map[TransportType]RuntimeConfig{
 	TransportTypeGO: {
-		BuilderImage:       "golang:1.25-alpine",
+		BuilderImage:       "golang:1.26-alpine",
 		AdditionalPackages: []string{"ca-certificates", "git"},
 	},
 	TransportTypeNPX: {

--- a/pkg/container/templates/runtime_config_test.go
+++ b/pkg/container/templates/runtime_config_test.go
@@ -23,7 +23,7 @@ func TestGetDefaultRuntimeConfig(t *testing.T) {
 		{
 			name:          "Go default config",
 			transportType: TransportTypeGO,
-			wantImage:     "golang:1.25-alpine",
+			wantImage:     "golang:1.26-alpine",
 			wantPackages:  []string{"ca-certificates", "git"},
 		},
 		{
@@ -136,7 +136,7 @@ func TestGetDockerfileTemplateUsesDefaultWhenNil(t *testing.T) {
 	}
 
 	// Should use default Go version
-	if !strings.Contains(result, "FROM golang:1.25-alpine AS builder") {
+	if !strings.Contains(result, "FROM golang:1.26-alpine AS builder") {
 		t.Error("Dockerfile does not contain default Go version")
 	}
 }
@@ -162,7 +162,7 @@ func TestRuntimeConfigValidate_ValidPackageNames(t *testing.T) {
 			t.Parallel()
 
 			rc := &RuntimeConfig{
-				BuilderImage:       "golang:1.25-alpine",
+				BuilderImage:       "golang:1.26-alpine",
 				AdditionalPackages: []string{pkg},
 			}
 			assert.NoError(t, rc.Validate())
@@ -198,7 +198,7 @@ func TestRuntimeConfigValidate_InvalidPackageNames(t *testing.T) {
 			t.Parallel()
 
 			rc := &RuntimeConfig{
-				BuilderImage:       "golang:1.25-alpine",
+				BuilderImage:       "golang:1.26-alpine",
 				AdditionalPackages: []string{tt.pkg},
 			}
 			err := rc.Validate()

--- a/pkg/container/templates/templates_test.go
+++ b/pkg/container/templates/templates_test.go
@@ -423,7 +423,7 @@ func TestRuntimeStageInstallsAdditionalPackages(t *testing.T) {
 			name:          "GO runtime stage installs extra packages",
 			transportType: TransportTypeGO,
 			runtimeConfig: &RuntimeConfig{
-				BuilderImage:       "golang:1.25-alpine",
+				BuilderImage:       "golang:1.26-alpine",
 				AdditionalPackages: []string{"ca-certificates", "git", "curl"},
 			},
 			wantInRuntime: "curl",
@@ -479,7 +479,7 @@ func TestEmptyAdditionalPackagesDoesNotBreakBuild(t *testing.T) {
 			name:          "GO with empty packages",
 			transportType: TransportTypeGO,
 			runtimeConfig: &RuntimeConfig{
-				BuilderImage:       "golang:1.25-alpine",
+				BuilderImage:       "golang:1.26-alpine",
 				AdditionalPackages: []string{},
 			},
 		},
@@ -503,7 +503,7 @@ func TestEmptyAdditionalPackagesDoesNotBreakBuild(t *testing.T) {
 			name:          "GO with nil packages",
 			transportType: TransportTypeGO,
 			runtimeConfig: &RuntimeConfig{
-				BuilderImage:       "golang:1.25-alpine",
+				BuilderImage:       "golang:1.26-alpine",
 				AdditionalPackages: nil,
 			},
 		},

--- a/pkg/runner/protocol_test.go
+++ b/pkg/runner/protocol_test.go
@@ -373,7 +373,7 @@ func TestMergeRuntimeConfig(t *testing.T) {
 				BuilderImage:       "",
 				AdditionalPackages: []string{"make"},
 			},
-			wantImage:    "golang:1.25-alpine",
+			wantImage:    "golang:1.26-alpine",
 			wantPackages: []string{"ca-certificates", "git", "make"},
 		},
 		{


### PR DESCRIPTION
## Summary

- **Why**: Go 1.26 was released in Feb 2026 and is the current stable release. Bumping the default `go://` builder image keeps new go-scheme workloads on the current toolchain line with the latest runtime, stdlib, and security updates.
- **What**: Change the default `RuntimeConfig.BuilderImage` for `TransportTypeGO` from `golang:1.25-alpine` to `golang:1.26-alpine`, and update test expectations and docs accordingly. OpenAPI output regenerated via `task docs` picks up the doc-comment example change.
- **Drive-by doc fix**: Two references in `docs/runtime-version-customization.md` and `docs/arch/05-runconfig-and-permissions.md` claimed the Go runtime stage uses `alpine:3.22`, but `go.tmpl` already pins `alpine:3.23@sha256:...`. Updated both to match the code.

Users who need an older toolchain can still override via `--runtime-image golang:1.25-alpine` (or earlier) or a config file, exactly as before.

## Type of change

- [x] Other (default upgrade + minor doc correction)

## Test plan

- [x] Regenerated OpenAPI docs via `task docs`
- [x] Cross-checked `golang:1.26-alpine` manifest digest against the Docker Hub API and the Docker Registry v2 API — both return `sha256:f85330846cde1e57ca9ec309382da3b8e6ae3ab943d2739500e08c86393a21b1`
- [ ] CI runs `task test` across affected packages (`pkg/container/templates/...`, `pkg/runner/...`)

## Does this introduce a user-facing change?

Yes — new `go://`-scheme workloads built with default settings now use a Go 1.26 builder. Workloads with an explicit `--runtime-image` or a `runtime_configs.go.builder_image` entry are unaffected.

## Special notes for reviewers

The `alpine:3.23` digest currently pinned in `go.tmpl` is from an earlier snapshot of the 3.23 tag and is still a valid, working image — refreshing that digest is intentionally left for a separate PR to keep this change narrow.

Generated with [Claude Code](https://claude.com/claude-code)