### PR TITLE
Return 502 Bad Gateway when OCI skill pull fails

### DIFF
--- a/pkg/skills/skillsvc/content.go
+++ b/pkg/skills/skillsvc/content.go
@@ -170,7 +170,7 @@ func (s *service) getContentFromOCI(ctx context.Context, ref string) (*skills.Sk
 		if pullErr != nil {
 			return nil, httperr.WithCode(
 				fmt.Errorf("pulling OCI artifact %q: %w", qualifiedRef, pullErr),
-				http.StatusBadRequest,
+				http.StatusBadGateway,
 			)
 		}
 	}

--- a/pkg/skills/skillsvc/content_test.go
+++ b/pkg/skills/skillsvc/content_test.go
@@ -125,7 +125,7 @@ func TestGetContent(t *testing.T) {
 		assert.Equal(t, http.StatusBadRequest, httperr.Code(err))
 	})
 
-	t.Run("pull failure propagates as 400", func(t *testing.T) {
+	t.Run("pull failure propagates as 502", func(t *testing.T) {
 		t.Parallel()
 		ctrl := gomock.NewController(t)
 
@@ -142,7 +142,7 @@ func TestGetContent(t *testing.T) {
 		)
 		_, err = svc.GetContent(t.Context(), skills.ContentOptions{Reference: "ghcr.io/org/my-skill:v1"})
 		require.Error(t, err)
-		assert.Equal(t, http.StatusBadRequest, httperr.Code(err))
+		assert.Equal(t, http.StatusBadGateway, httperr.Code(err))
 		assert.Contains(t, err.Error(), "registry unreachable")
 	})
 

--- a/pkg/skills/skillsvc/install_oci.go
+++ b/pkg/skills/skillsvc/install_oci.go
@@ -56,7 +56,7 @@ func (s *service) installFromOCI(
 	if err != nil {
 		return nil, httperr.WithCode(
 			fmt.Errorf("pulling OCI artifact %q: %w", ociRef, err),
-			http.StatusBadRequest,
+			http.StatusBadGateway,
 		)
 	}
 

--- a/pkg/skills/skillsvc/install_oci_test.go
+++ b/pkg/skills/skillsvc/install_oci_test.go
@@ -579,7 +579,7 @@ func TestInstallQualifiedNameOCIFallback(t *testing.T) {
 				// No lookup mock — gomock will fail the test if SearchSkills is called.
 				return nil, reg, ociStore, nil, store, pr
 			},
-			wantCode: http.StatusBadRequest,
+			wantCode: http.StatusBadGateway,
 			wantErr:  "auth required",
 		},
 		{
@@ -604,7 +604,7 @@ func TestInstallQualifiedNameOCIFallback(t *testing.T) {
 				store := storemocks.NewMockSkillStore(ctrl)
 				return lookup, reg, ociStore, nil, store, pr
 			},
-			wantCode: http.StatusBadRequest,
+			wantCode: http.StatusBadGateway,
 			wantErr:  "no such host",
 		},
 		{
@@ -625,7 +625,7 @@ func TestInstallQualifiedNameOCIFallback(t *testing.T) {
 				// No lookup mock — gomock will fail the test if SearchSkills is called.
 				return nil, reg, ociStore, nil, store, pr
 			},
-			wantCode: http.StatusBadRequest,
+			wantCode: http.StatusBadGateway,
 			wantErr:  "manifest unknown",
 		},
 		{
@@ -645,7 +645,7 @@ func TestInstallQualifiedNameOCIFallback(t *testing.T) {
 				// No lookup mock — gomock will fail if SearchSkills is called.
 				return nil, reg, ociStore, nil, store, pr
 			},
-			wantCode: http.StatusBadRequest,
+			wantCode: http.StatusBadGateway,
 			wantErr:  "auth required",
 		},
 		{


### PR DESCRIPTION
## Summary

- Follow-up on review feedback from #4810 ([discussion](https://github.com/stacklok/toolhive/pull/4810#discussion_r3082033217)): `registry.Pull` failures in `getContentFromOCI` and `installFromOCI` were mapped to `400 Bad Request`, but auth errors, unreachable registries, missing manifests, and network timeouts are upstream failures the caller cannot fix by changing their input.
- Return `502 Bad Gateway` instead, matching the git-resolve path in `getContentFromGit` which already uses `502` for the equivalent upstream failure.
- Parse / validation / "reference not found locally and registry not configured" paths continue to return `400` — those are genuine caller errors.

## Type of change

- [x] Bug fix (HTTP status semantics)

## Test plan

- [x] Unit tests (`go test ./pkg/skills/skillsvc/...`)
- [x] Existing tests updated to assert `502` where appropriate; `400` assertions for parse / missing-registry / invalid-reference cases left intact

## Changes

| File | Change |
|------|--------|
| `pkg/skills/skillsvc/content.go` | `getContentFromOCI`: `StatusBadRequest` → `StatusBadGateway` on `registry.Pull` failure |
| `pkg/skills/skillsvc/install_oci.go` | `installFromOCI`: `StatusBadRequest` → `StatusBadGateway` on `registry.Pull` failure |
| `pkg/skills/skillsvc/content_test.go` | Rename `pull failure propagates as 400` → `...as 502`; assert `StatusBadGateway` |
| `pkg/skills/skillsvc/install_oci_test.go` | Update `wantCode` to `StatusBadGateway` in four pull-failure fall-back tests (explicit tag, qualified name, digest ref, multi-segment ref) |

## Does this introduce a user-facing change?

Yes — API clients that previously received `400 Bad Request` on a remote OCI pull failure now receive `502 Bad Gateway`. This is a more accurate signal that the failure originated upstream (registry/network) rather than from a malformed request, and matches the behaviour already in place for git pulls (and already documented in the swagger annotation introduced in #4810).