### PR TITLE
Finish defaultTEIImage rename in embedding_manager_test.go

### DIFF
--- a/pkg/vmcp/cli/embedding_manager_test.go
+++ b/pkg/vmcp/cli/embedding_manager_test.go
@@ -108,7 +108,7 @@ func TestNewEmbeddingServiceManager_DefaultImage(t *testing.T) {
 		Model: "BAAI/bge-small-en-v1.5",
 	})
 	require.NoError(t, err)
-	assert.Equal(t, defaultTEIImage, mgr.cfg.Image)
+	assert.Equal(t, DefaultEmbeddingImage, mgr.cfg.Image)
 	assert.Equal(t, containerNameForModel("BAAI/bge-small-en-v1.5"), mgr.containerName)
 }
 
@@ -198,7 +198,7 @@ func TestStart_DeployNewContainer(t *testing.T) {
 	mockRT.EXPECT().IsWorkloadRunning(gomock.Any(), mgr.containerName).Return(false, nil)
 	mockRT.EXPECT().DeployWorkload(
 		gomock.Any(),
-		defaultTEIImage,
+		DefaultEmbeddingImage,
 		mgr.containerName,
 		[]string{"--model-id", "BAAI/bge-small-en-v1.5"},
 		gomock.Nil(),
@@ -247,7 +247,7 @@ func TestStart_DeployNewContainer_Kubernetes(t *testing.T) {
 	mockRT.EXPECT().IsWorkloadRunning(gomock.Any(), mgr.containerName).Return(false, nil)
 	mockRT.EXPECT().DeployWorkload(
 		gomock.Any(),
-		defaultTEIImage,
+		DefaultEmbeddingImage,
 		mgr.containerName,
 		[]string{"--model-id", "BAAI/bge-small-en-v1.5"},
 		gomock.Nil(), // no env vars


### PR DESCRIPTION
## Summary

- **Why**: Commit c334edf5 ("vmcp: stop the TEI manager on Start failure and apply image default in Serve", #4948) renamed the unexported `defaultTEIImage` constant to the exported `DefaultEmbeddingImage` so `Serve()` can default the TEI image alongside `DefaultEmbeddingModel`. The rename covered `embedding_manager.go` and `serve.go`, but `embedding_manager_test.go` was missed — three references to the now-undefined identifier remain. `golangci-lint` catches this as a `typecheck` error, and every PR opened against `main` since then hits it on both `Linting / Lint Go Code` and `Tests / Test Go Code`.
- **What**: Replace the three remaining `defaultTEIImage` references in `pkg/vmcp/cli/embedding_manager_test.go` (lines 111, 201, 250) with `DefaultEmbeddingImage`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test plan

- [x] `go vet ./pkg/vmcp/cli/...` clean
- [x] `go test -run TestNewEmbeddingServiceManager ./pkg/vmcp/cli/...` passes
- [ ] CI re-runs `Linting / Lint Go Code` and `Tests / Test Go Code` green on this branch

## Does this introduce a user-facing change?

No — test-only rename to match the production identifier.

Generated with [Claude Code](https://claude.com/claude-code)