### PR TITLE
vmcp: update test references to renamed DefaultEmbeddingImage

### DIFF
--- a/pkg/vmcp/cli/embedding_manager_test.go
+++ b/pkg/vmcp/cli/embedding_manager_test.go
@@ -108,7 +108,7 @@ func TestNewEmbeddingServiceManager_DefaultImage(t *testing.T) {
 		Model: "BAAI/bge-small-en-v1.5",
 	})
 	require.NoError(t, err)
-	assert.Equal(t, defaultTEIImage, mgr.cfg.Image)
+	assert.Equal(t, DefaultEmbeddingImage, mgr.cfg.Image)
 	assert.Equal(t, containerNameForModel("BAAI/bge-small-en-v1.5"), mgr.containerName)
 }
 
@@ -198,7 +198,7 @@ func TestStart_DeployNewContainer(t *testing.T) {
 	mockRT.EXPECT().IsWorkloadRunning(gomock.Any(), mgr.containerName).Return(false, nil)
 	mockRT.EXPECT().DeployWorkload(
 		gomock.Any(),
-		defaultTEIImage,
+		DefaultEmbeddingImage,
 		mgr.containerName,
 		[]string{"--model-id", "BAAI/bge-small-en-v1.5"},
 		gomock.Nil(),
@@ -247,7 +247,7 @@ func TestStart_DeployNewContainer_Kubernetes(t *testing.T) {
 	mockRT.EXPECT().IsWorkloadRunning(gomock.Any(), mgr.containerName).Return(false, nil)
 	mockRT.EXPECT().DeployWorkload(
 		gomock.Any(),
-		defaultTEIImage,
+		DefaultEmbeddingImage,
 		mgr.containerName,
 		[]string{"--model-id", "BAAI/bge-small-en-v1.5"},
 		gomock.Nil(), // no env vars


### PR DESCRIPTION
## Summary

- #4948 renamed the unexported `defaultTEIImage` constant in `pkg/vmcp/cli/embedding_manager.go` to the exported `DefaultEmbeddingImage` but missed three references in `embedding_manager_test.go`. The package fails to build, so every post-merge CI run on `main` has been red — the Lint job reports three `undefined: defaultTEIImage` typecheck errors, and the Test job aborts when `task test-coverage` can't compile the package.
- Point the three test-file references at the new exported name. No behaviour change; this is purely the follow-up rename the original PR missed.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test plan

- [x] `task lint` — 0 issues
- [x] `go test ./pkg/vmcp/cli/...` — passes (10.3s)

## Does this introduce a user-facing change?

No.

Generated with [Claude Code](https://claude.com/claude-code)