### PR TITLE
audit: render LevelAudit as "AUDIT" instead of slog's "INFO+2"

### DIFF
--- a/pkg/audit/auditor.go
+++ b/pkg/audit/auditor.go
@@ -56,6 +56,18 @@ func NewAuditLogger(w io.Writer) *slog.Logger {
 
 	handler := slog.NewJSONHandler(w, &slog.HandlerOptions{
 		Level: LevelAudit,
+		// Render LevelAudit as "AUDIT" rather than slog's default
+		// "INFO+2" so log aggregators (Loki's detected_level,
+		// Elasticsearch, Splunk, etc.) can match the level facet
+		// and users can filter on `level = "AUDIT"` (#4296).
+		ReplaceAttr: func(_ []string, a slog.Attr) slog.Attr {
+			if a.Key == slog.LevelKey {
+				if level, ok := a.Value.Any().(slog.Level); ok && level == LevelAudit {
+					a.Value = slog.StringValue("AUDIT")
+				}
+			}
+			return a
+		},
 	})
 
 	return slog.New(handler)


### PR DESCRIPTION
## Summary

`LevelAudit = slog.Level(2)`, which `slog.JSONHandler` serialises as `"INFO+2"` by default. Log aggregators (Loki `detected_level`, Elasticsearch, Splunk) only recognise standard named levels, so audit events end up as `unknown`/other - exactly the opposite of what we want for the log type users most often filter on.

## Fix

Add a `ReplaceAttr` to the JSON handler that rewrites the level attribute to `"AUDIT"` when it equals `LevelAudit`. Other levels remain unchanged, so a handler enabled at `LevelAudit` still surfaces `WARN` / `ERROR` correctly.

## Type of change

- [x] Bug fix

## Test plan

- [x] `go build ./pkg/audit/`
- [x] `go test ./pkg/audit/... -count=1` passes
- [x] Manually confirmed via `slog.NewJSONHandler` that an `event.LogTo(ctx, logger, LevelAudit)` call now emits `"level":"AUDIT"` instead of `"INFO+2"`

Closes #4296
