### PR TITLE
Document 502 Bad Gateway failure for installSkill in OpenAPI spec

### DIFF
--- a/docs/server/docs.go
+++ b/docs/server/docs.go
@@ -5420,6 +5420,16 @@ const docTemplate = `{
                             }
                         },
                         "description": "Internal Server Error"
+                    },
+                    "502": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Bad Gateway"
                     }
                 },
                 "summary": "Install a skill",

--- a/docs/server/swagger.json
+++ b/docs/server/swagger.json
@@ -5413,6 +5413,16 @@
                             }
                         },
                         "description": "Internal Server Error"
+                    },
+                    "502": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Bad Gateway"
                     }
                 },
                 "summary": "Install a skill",

--- a/docs/server/swagger.yaml
+++ b/docs/server/swagger.yaml
@@ -4325,6 +4325,12 @@ paths:
               schema:
                 type: string
           description: Internal Server Error
+        "502":
+          content:
+            application/json:
+              schema:
+                type: string
+          description: Bad Gateway
       summary: Install a skill
       tags:
       - skills

--- a/pkg/api/v1/skills.go
+++ b/pkg/api/v1/skills.go
@@ -87,6 +87,7 @@ func (s *SkillsRoutes) listSkills(w http.ResponseWriter, r *http.Request) error 
 //	@Failure		400		{string}	string		"Bad Request"
 //	@Failure		409		{string}	string		"Conflict"
 //	@Failure		500		{string}	string		"Internal Server Error"
+//	@Failure		502		{string}	string		"Bad Gateway"
 //	@Router			/api/v1beta/skills [post]
 func (s *SkillsRoutes) installSkill(w http.ResponseWriter, r *http.Request) error {
 	var req installSkillRequest


### PR DESCRIPTION
## Summary

Follow-up on review feedback from #4956 ([comment](https://github.com/stacklok/toolhive/pull/4956)): `installFromGit` already returned `502 Bad Gateway` on upstream pull failures, and #4956 aligned `installFromOCI` with the same behaviour — but the `@Failure` list on `installSkill` in `pkg/api/v1/skills.go` still only advertised `400 / 409 / 500`.

Add `@Failure 502 {string} string "Bad Gateway"` to the annotation and regenerate the OpenAPI spec so clients see the real contract for `POST /api/v1beta/skills`.

Pre-existing documentation gap, not introduced by #4956.

## Type of change

- [x] Documentation update (OpenAPI spec only, no runtime behaviour change)

## Test plan

- [x] Spec regenerated with `task docs`
- [x] Verified `swagger.yaml` now lists `502 Bad Gateway` alongside `400 / 409 / 500` on `POST /api/v1beta/skills`

## Changes

| File | Change |
|------|--------|
| `pkg/api/v1/skills.go` | Add `@Failure 502 {string} string "Bad Gateway"` to the `installSkill` annotation |
| `docs/server/docs.go`, `docs/server/swagger.json`, `docs/server/swagger.yaml` | Regenerated spec |

## Does this introduce a user-facing change?

No runtime behaviour change — only the generated OpenAPI spec is updated. API clients consuming the spec will now see `502 Bad Gateway` as a documented response for `POST /api/v1beta/skills`, which already matched the runtime behaviour as of #4956.