### PR TITLE
registry: probe with ValidateEndpoint instead of paginated ListServers

### DIFF
--- a/pkg/registry/provider_api.go
+++ b/pkg/registry/provider_api.go
@@ -58,8 +58,14 @@ func NewAPIRegistryProvider(apiURL string, allowPrivateIp bool, tokenSource auth
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
 
-		// Try to list servers with a small limit to verify API functionality
-		_, err = client.ListServers(ctx, &api.ListOptions{Limit: 1})
+		// Verify the endpoint implements the MCP Registry API. Previously
+		// the probe called ListServers{Limit: 1}; Limit only controls the
+		// page size, so the client still paginated the entire catalog and
+		// a registry with ~100+ entries would exhaust the 10-second
+		// timeout during validation (#4452). ValidateEndpoint is a single
+		// HTTP GET for /openapi.yaml and is exactly the "is this a valid
+		// MCP Registry" question the probe is trying to answer.
+		err = client.ValidateEndpoint(ctx)
 		if err != nil {
 			if errors.Is(err, api.ErrRegistryUnauthorized) {
 				return nil, fmt.Errorf(


### PR DESCRIPTION
## Summary

`APIRegistryProvider`'s validation probe called `ListServers` with `Limit: 1` to confirm the registry was reachable. `Limit` is the page size, not a total cap, so the client keeps paginating until it hits the last cursor - and a registry with ~100+ entries could blow past the 10-second probe timeout with `context deadline exceeded`, blocking `thv registry list` entirely (reported in #4452).

## Fix

Switch the probe to `ValidateEndpoint`, which is a single HTTP GET for `/openapi.yaml` - exactly the "is this a valid MCP Registry?" question the probe is trying to answer. The real catalog fetch on the next line already runs the same code path, so we keep the probe lightweight without losing correctness. Behaviour:

- Reachable MCP Registry → probe passes (same as before).
- 401 Unauthorized → same helpful "configure with --issuer ..." error (kept the `ErrRegistryUnauthorized` branch).
- Any other failure → `UnavailableError`, same as before.

## Type of change

- [x] Bug fix

## Test plan

- [x] `go build ./pkg/registry/`
- [x] `go test ./pkg/registry/ -count=1` (all existing tests pass)

Closes #4452
