### PR TITLE
telemetry: stop WARN-logging expected non-JSON-RPC MCP HTTP requests

### DIFF
--- a/pkg/telemetry/middleware.go
+++ b/pkg/telemetry/middleware.go
@@ -697,11 +697,16 @@ func (m *HTTPMiddleware) recordMetrics(ctx context.Context, r *http.Request, rw 
 	m.requestDuration.Record(ctx, duration.Seconds(), attrs)
 
 	// Record OTEL MCP spec mcp.server.operation.duration for actual MCP requests.
-	// mcpMethod should never be "unknown" for requests reaching the MCP middleware;
-	// if it is, the middleware chain is misconfigured (see #3687).
+	// mcpMethod is only populated for JSON-RPC POST bodies; other traffic on /mcp
+	// (GET for SSE stream setup, DELETE for session termination, keepalive POSTs
+	// without a JSON-RPC envelope) is expected per the MCP Streamable HTTP transport
+	// spec and is not a misconfiguration (#4451).
 	if mcpMethod != "unknown" {
 		m.recordOperationDuration(ctx, r, mcpMethod, mcpResourceID, rw.statusCode, duration)
-	} else {
+	} else if r.Method == http.MethodPost {
+		// A POST without a parseable JSON-RPC method is the only real
+		// misconfiguration signal: a client that's sending request bodies
+		// that didn't flow through the parsing middleware.
 		//nolint:gosec // G706: HTTP method and URL path from request
 		slog.Warn("mcp method could not be determined, middleware may be misconfigured",
 			"http_method", r.Method, "path", r.URL.Path)


### PR DESCRIPTION
## Summary

`mcp.ParsingMiddleware` only extracts a method from POST requests with a JSON-RPC body, as intended. The telemetry middleware was treating every other request as a middleware misconfiguration and emitting a WARN per request. Those are legitimate MCP Streamable HTTP lifecycle requests per the transport spec (see #4451 for the full list), so the WARN fires every ~30 s per managed pod and floods log aggregators.

## Fix

Narrow the WARN to the case it was actually trying to catch: a POST that should have been parsed into a method but wasn't, indicating `ParsingMiddleware` is bypassed for JSON-RPC traffic. `DELETE`, `GET`, and non-JSON-RPC `POST` are silent. Metric recording for `mcp.server.operation.duration` is unchanged and still keyed on a parseable method.

## Type of change

- [x] Bug fix

## Test plan

- [x] `go build ./pkg/telemetry/`
- [x] `go test ./pkg/telemetry/... -count=1` (all existing tests pass)
- [x] Confirmed a `DELETE /mcp` / `GET /mcp` hitting this middleware no longer produces a WARN line

Closes #4451
