### PR TITLE
Thread image verification mode through workload service

### DIFF
--- a/pkg/api/v1/workload_service.go
+++ b/pkg/api/v1/workload_service.go
@@ -66,6 +66,10 @@ type WorkloadService struct {
 	imageRetriever   retriever.Retriever
 	imagePuller      retriever.ImagePuller
 	configProvider   config.Provider
+	// imageVerification is the mode (warn/enabled/disabled) used when verifying
+	// image provenance for both the registry-resolved path and the imageRetriever
+	// path. Kept as a single field so the two paths can't drift.
+	imageVerification string
 }
 
 // NewWorkloadService creates a new WorkloadService instance
@@ -76,13 +80,14 @@ func NewWorkloadService(
 	debugMode bool,
 ) *WorkloadService {
 	return &WorkloadService{
-		workloadManager:  workloadManager,
-		groupManager:     groupManager,
-		containerRuntime: containerRuntime,
-		debugMode:        debugMode,
-		imageRetriever:   retriever.ResolveMCPServer,
-		imagePuller:      retriever.PullMCPServerImage,
-		configProvider:   config.NewProvider(),
+		workloadManager:   workloadManager,
+		groupManager:      groupManager,
+		containerRuntime:  containerRuntime,
+		debugMode:         debugMode,
+		imageRetriever:    retriever.ResolveMCPServer,
+		imagePuller:       retriever.PullMCPServerImage,
+		configProvider:    config.NewProvider(),
+		imageVerification: retriever.VerifyImageWarn,
 	}
 }
 
@@ -228,8 +233,9 @@ func (s *WorkloadService) BuildFullRunConfig(
 	// Verify image provenance for registry-resolved image servers.
 	// The normal imageRetriever path calls verifyImage internally, but
 	// we bypass it for registry references, so we must verify here.
+	// Both paths use s.imageVerification so their behavior stays in sync.
 	if imageMetadata != nil && registryResolvedMetadata != nil {
-		if err := retriever.VerifyImage(imageURL, imageMetadata, retriever.VerifyImageWarn); err != nil {
+		if err := retriever.VerifyImage(imageURL, imageMetadata, s.imageVerification); err != nil {
 			return nil, fmt.Errorf("image verification failed: %w", err)
 		}
 	}
@@ -264,7 +270,7 @@ func (s *WorkloadService) BuildFullRunConfig(
 			imageCtx,
 			req.Image,
 			"", // We do not let the user specify a CA cert path here.
-			retriever.VerifyImageWarn,
+			s.imageVerification,
 			"", // Registry-based group lookups are not supported
 			retrievalRuntimeConfig,
 		)

--- a/pkg/api/v1/workload_service_test.go
+++ b/pkg/api/v1/workload_service_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stacklok/toolhive/pkg/container/templates"
 	groupsmocks "github.com/stacklok/toolhive/pkg/groups/mocks"
 	"github.com/stacklok/toolhive/pkg/runner"
+	"github.com/stacklok/toolhive/pkg/runner/retriever"
 	"github.com/stacklok/toolhive/pkg/secrets"
 	workloadsmocks "github.com/stacklok/toolhive/pkg/workloads/mocks"
 )
@@ -159,6 +160,54 @@ func TestNewWorkloadService(t *testing.T) {
 	require.NotNil(t, service)
 	assert.NotNil(t, service.configProvider,
 		"configProvider must be initialized so config is read fresh on each call, not snapshotted at construction")
+	assert.Equal(t, retriever.VerifyImageWarn, service.imageVerification,
+		"imageVerification must default to warn so registry-resolved and imageRetriever paths stay consistent")
+}
+
+// TestBuildFullRunConfig_ThreadsImageVerification verifies the imageRetriever path
+// uses s.imageVerification rather than a hardcoded value. Paired with the registry-
+// resolved path's direct call to retriever.VerifyImage(imageURL, imageMetadata,
+// s.imageVerification), this ensures both paths read the mode from the same field.
+func TestBuildFullRunConfig_ThreadsImageVerification(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockGroupManager := groupsmocks.NewMockManager(ctrl)
+	mockGroupManager.EXPECT().Exists(gomock.Any(), "default").Return(true, nil)
+
+	const testImage = "test-image"
+
+	var observed string
+	mockRetriever := func(
+		_ context.Context,
+		_ string, _ string,
+		verificationType string,
+		_ string,
+		_ *templates.RuntimeConfig,
+	) (string, regtypes.ServerMetadata, error) {
+		observed = verificationType
+		return testImage, &regtypes.ImageMetadata{Image: testImage}, nil
+	}
+
+	service := &WorkloadService{
+		groupManager:      mockGroupManager,
+		imageRetriever:    mockRetriever,
+		imagePuller:       func(_ context.Context, _ string) error { return nil },
+		configProvider:    config.NewDefaultProvider(),
+		imageVerification: retriever.VerifyImageDisabled,
+	}
+
+	req := &createRequest{
+		Name:          "testserver",
+		updateRequest: updateRequest{Image: testImage},
+	}
+
+	_, err := service.BuildFullRunConfig(context.Background(), req, 0)
+	require.NoError(t, err)
+	assert.Equal(t, retriever.VerifyImageDisabled, observed,
+		"imageRetriever must receive s.imageVerification verbatim")
 }
 
 // writeFactorySentinelConfig writes a YAML config file with DisableUsageMetrics: true

--- a/pkg/api/v1/workloads_test.go
+++ b/pkg/api/v1/workloads_test.go
@@ -279,11 +279,12 @@ func TestCreateWorkload(t *testing.T) {
 				groupManager:     mockGroupManager,
 				debugMode:        false,
 				workloadService: &WorkloadService{
-					groupManager:    mockGroupManager,
-					workloadManager: mockWorkloadManager,
-					imageRetriever:  mockRetriever,
-					imagePuller:     func(_ context.Context, _ string) error { return nil },
-					configProvider:  config.NewDefaultProvider(),
+					groupManager:      mockGroupManager,
+					workloadManager:   mockWorkloadManager,
+					imageRetriever:    mockRetriever,
+					imagePuller:       func(_ context.Context, _ string) error { return nil },
+					configProvider:    config.NewDefaultProvider(),
+					imageVerification: retriever.VerifyImageWarn,
 				},
 			}
 
@@ -499,11 +500,12 @@ func TestUpdateWorkload(t *testing.T) {
 				groupManager:     mockGroupManager,
 				debugMode:        false,
 				workloadService: &WorkloadService{
-					groupManager:    mockGroupManager,
-					workloadManager: mockWorkloadManager,
-					imageRetriever:  mockRetriever,
-					imagePuller:     func(_ context.Context, _ string) error { return nil },
-					configProvider:  config.NewDefaultProvider(),
+					groupManager:      mockGroupManager,
+					workloadManager:   mockWorkloadManager,
+					imageRetriever:    mockRetriever,
+					imagePuller:       func(_ context.Context, _ string) error { return nil },
+					configProvider:    config.NewDefaultProvider(),
+					imageVerification: retriever.VerifyImageWarn,
 				},
 			}
 
@@ -622,12 +624,13 @@ func TestUpdateWorkload_PortReuse(t *testing.T) {
 				groupManager:     mockGroupManager,
 				debugMode:        false,
 				workloadService: &WorkloadService{
-					groupManager:     mockGroupManager,
-					workloadManager:  mockWorkloadManager,
-					containerRuntime: mockRuntime,
-					imageRetriever:   mockRetriever,
-					imagePuller:      func(_ context.Context, _ string) error { return nil },
-					configProvider:   config.NewDefaultProvider(),
+					groupManager:      mockGroupManager,
+					workloadManager:   mockWorkloadManager,
+					containerRuntime:  mockRuntime,
+					imageRetriever:    mockRetriever,
+					imagePuller:       func(_ context.Context, _ string) error { return nil },
+					configProvider:    config.NewDefaultProvider(),
+					imageVerification: retriever.VerifyImageWarn,
 				},
 			}
 
@@ -688,12 +691,13 @@ func TestUpdateWorkload_PortReuse(t *testing.T) {
 			groupManager:     mockGroupManager,
 			debugMode:        false,
 			workloadService: &WorkloadService{
-				groupManager:     mockGroupManager,
-				workloadManager:  mockWorkloadManager,
-				containerRuntime: mockRuntime,
-				imageRetriever:   mockRetriever,
-				imagePuller:      func(_ context.Context, _ string) error { return nil },
-				configProvider:   config.NewDefaultProvider(),
+				groupManager:      mockGroupManager,
+				workloadManager:   mockWorkloadManager,
+				containerRuntime:  mockRuntime,
+				imageRetriever:    mockRetriever,
+				imagePuller:       func(_ context.Context, _ string) error { return nil },
+				configProvider:    config.NewDefaultProvider(),
+				imageVerification: retriever.VerifyImageWarn,
 			},
 		}
 


### PR DESCRIPTION
## Summary

- Follow-up nit from the review on #4872: the registry-resolved image path hardcoded `retriever.VerifyImageWarn` while the `imageRetriever` path threaded verification through a parameter. Two inline literals means the paths can silently drift if one is later made configurable.
- Store the mode on `WorkloadService` (still defaulting to `warn`) and read it in both call sites in `BuildFullRunConfig`, so the two paths can no longer disagree and a future caller toggling verification is a one-line change.

## Type of change

- [x] Refactor (no functional changes, no API changes)

## Test plan

- [x] Unit tests pass locally (`go test -race ./pkg/api/v1/...`)
- [x] Linter passes (`task lint-fix`)
- [x] Added `TestBuildFullRunConfig_ThreadsImageVerification` to prove the field's value (not a literal) reaches the retriever
- [x] Extended `TestNewWorkloadService` to assert the default is `VerifyImageWarn`

## Does this introduce a user-facing change?

No. Default behavior is unchanged (still `warn`).

## Special notes for reviewers

Follow-up to the non-blocking nit in https://github.com/stacklok/toolhive/pull/4872#pullrequestreview-PRR_kwDOOHdoXs73L10L. The API doesn't yet expose image verification to callers; this just removes the drift risk so that when it does, only one place needs to change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)