### PR TITLE
Use MCP server entity for list operations when serverName is set

### DIFF
--- a/pkg/authz/authorizers/cedar/core.go
+++ b/pkg/authz/authorizers/cedar/core.go
@@ -677,7 +677,10 @@ func (a *Authorizer) authorizeFeatureList(
 	// Action is to list a feature
 	action := fmt.Sprintf("Action::list_%ss", feature)
 
-	// Resource is the feature type
+	// Resource is the feature type. When serverName is set, the resource
+	// entity gets an MCP parent via CreateEntitiesForRequest so that
+	// server-scoped policies (resource in MCP::"<server>") still match
+	// without overwriting the static MCP entity from entities_json.
 	resource := fmt.Sprintf("FeatureType::%s", feature)
 
 	// Create attributes for the entities

--- a/pkg/authz/authorizers/cedar/core_test.go
+++ b/pkg/authz/authorizers/cedar/core_test.go
@@ -441,6 +441,164 @@ func TestAuthorizeWithJWTClaims(t *testing.T) {
 	}
 }
 
+// TestListAuthorizationWithServerName verifies that authorizeFeatureList keeps
+// FeatureType::<feature> as the resource and adds MCP::<serverName> as a parent
+// when serverName is configured, so both FeatureType and MCP policies match.
+func TestListAuthorizationWithServerName(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name             string
+		serverName       string
+		policy           string
+		feature          authorizers.MCPFeature
+		expectAuthorized bool
+	}{
+		{
+			name:       "MCP policy grants list_tools when serverName is set",
+			serverName: "github",
+			policy: `
+			permit(
+				principal,
+				action == Action::"list_tools",
+				resource in MCP::"github"
+			);
+			`,
+			feature:          authorizers.MCPFeatureTool,
+			expectAuthorized: true,
+		},
+		{
+			name:       "MCP policy grants list_prompts when serverName is set",
+			serverName: "github",
+			policy: `
+			permit(
+				principal,
+				action == Action::"list_prompts",
+				resource in MCP::"github"
+			);
+			`,
+			feature:          authorizers.MCPFeaturePrompt,
+			expectAuthorized: true,
+		},
+		{
+			name:       "MCP policy grants list_resources when serverName is set",
+			serverName: "github",
+			policy: `
+			permit(
+				principal,
+				action == Action::"list_resources",
+				resource in MCP::"github"
+			);
+			`,
+			feature:          authorizers.MCPFeatureResource,
+			expectAuthorized: true,
+		},
+		{
+			name:       "FeatureType policy still works when serverName is set",
+			serverName: "github",
+			policy: `
+			permit(
+				principal,
+				action == Action::"list_tools",
+				resource == FeatureType::"tool"
+			);
+			`,
+			feature:          authorizers.MCPFeatureTool,
+			expectAuthorized: true,
+		},
+		{
+			name:       "FeatureType policy grants list_tools when serverName is empty",
+			serverName: "",
+			policy: `
+			permit(
+				principal,
+				action == Action::"list_tools",
+				resource == FeatureType::"tool"
+			);
+			`,
+			feature:          authorizers.MCPFeatureTool,
+			expectAuthorized: true,
+		},
+		{
+			name:       "FeatureType policy grants list_prompts when serverName is empty",
+			serverName: "",
+			policy: `
+			permit(
+				principal,
+				action == Action::"list_prompts",
+				resource == FeatureType::"prompt"
+			);
+			`,
+			feature:          authorizers.MCPFeaturePrompt,
+			expectAuthorized: true,
+		},
+		{
+			name:       "FeatureType policy grants list_resources when serverName is empty",
+			serverName: "",
+			policy: `
+			permit(
+				principal,
+				action == Action::"list_resources",
+				resource == FeatureType::"resource"
+			);
+			`,
+			feature:          authorizers.MCPFeatureResource,
+			expectAuthorized: true,
+		},
+		{
+			name:       "Special characters in serverName",
+			serverName: "my-server.example.com",
+			policy: `
+			permit(
+				principal,
+				action == Action::"list_tools",
+				resource in MCP::"my-server.example.com"
+			);
+			`,
+			feature:          authorizers.MCPFeatureTool,
+			expectAuthorized: true,
+		},
+		{
+			name:       "MCP policy for different server denies list_tools",
+			serverName: "github",
+			policy: `
+			permit(
+				principal,
+				action == Action::"list_tools",
+				resource in MCP::"atlassian"
+			);
+			`,
+			feature:          authorizers.MCPFeatureTool,
+			expectAuthorized: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+
+			authorizer, err := NewCedarAuthorizer(ConfigOptions{
+				Policies:     []string{tc.policy},
+				EntitiesJSON: `[]`,
+			}, tc.serverName)
+			require.NoError(t, err)
+
+			claims := jwt.MapClaims{
+				"sub":  "user123",
+				"name": "John Doe",
+			}
+			identity := &auth.Identity{PrincipalInfo: auth.PrincipalInfo{Subject: "test-user", Claims: claims}}
+			claimsCtx := auth.WithIdentity(ctx, identity)
+
+			authorized, err := authorizer.AuthorizeWithJWTClaims(claimsCtx, tc.feature, authorizers.MCPOperationList, "", nil)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectAuthorized, authorized, "Authorization result does not match expectation")
+		})
+	}
+}
+
 // TestAuthorizeWithJWTClaimsErrors tests error cases for AuthorizeWithJWTClaims.
 func TestAuthorizeWithJWTClaimsErrors(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Summary

Server-scoped Cedar policies (`resource in MCP::"github"`) did not match list
operations (tools/list, prompts/list, resources/list) because the authorizer
used bare `FeatureType::<feature>` resources with no MCP parent. The entity
wiring added in #4965 already attaches an MCP parent to resource entities when
`serverName` is configured — this change updates the comment to document that
behavior and adds comprehensive tests proving both FeatureType and MCP-scoped
policies evaluate correctly for list operations.

The key insight: `authorizeFeatureList` keeps `FeatureType::<feature>` as the
resource (preserving backward compatibility) while `CreateEntitiesForRequest`
wires `MCP::<serverName>` as a parent entity, so Cedar's `in` operator matches
server-scoped policies without overwriting the static MCP entity from
`entities_json`.

Fixes #4770

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)
- [x] Manual testing (describe below)

E2E tested against a Kind cluster with two MCPServers (github + internal-tools)
sharing one compiled Cedar ConfigMap. Verified with a real Entra ID token:
- `tools/list` on github server returns tools (developer role matches `resource in MCP::"github"`)
- `tools/call` on github server succeeds (HTTP 200)
- `tools/call` on internal-tools server denied (HTTP 403, no ops-team role in token)

## Changes

| File | Change |
|------|--------|
| `pkg/authz/authorizers/cedar/core.go` | Expanded comment on `authorizeFeatureList` documenting MCP parent wiring |
| `pkg/authz/authorizers/cedar/core_test.go` | Added `TestListAuthorizationWithServerName` — 9-case table-driven test covering MCP-scoped, FeatureType-scoped, cross-server deny, and special characters |

## Special notes for reviewers

This is the final PR in a stack of Cedar authorization changes:
1. #4914 — Configurable role claim extraction (merged)
2. #4965 — MCP parent on resource entities (merged)
3. This PR — List operations work with server-scoped policies

The test uses `AuthorizeWithJWTClaims` (the production entry point) rather than
manually constructing entities, so it exercises the full path including
`serverName` threading and entity merge.

Generated with [Claude Code](https://claude.com/claude-code)