### PR TITLE
Add advisory CRD schema compatibility CI check

### DIFF
--- a/.github/workflows/api-compat.yml
+++ b/.github/workflows/api-compat.yml
@@ -14,8 +14,16 @@ on:
   pull_request:
     paths:
       - 'cmd/thv-operator/api/**'
+      # files/crds is the source of truth — controller-gen emits here, and
+      # crd-helm-wrapper copies from here into templates/. Any drift in
+      # templates/ is caught by operator-ci.yml's generate-crds job, so
+      # watching templates/ would be redundant. values.yaml and the
+      # crd-helm-wrapper only affect Helm conditionals and annotations the
+      # checker ignores; the workflow's explicit --set flags force every
+      # CRD to render regardless of those files.
       - 'deploy/charts/operator-crds/files/crds/**'
-      - 'deploy/charts/operator-crds/templates/**'
+      # Self-exercise the workflow when the workflow itself changes.
+      - '.github/workflows/api-compat.yml'
 
 permissions:
   contents: read
@@ -26,6 +34,11 @@ jobs:
     runs-on: ubuntu-latest
     # Phase 1: advisory only. Remove in Phase 2 to enforce.
     continue-on-error: true
+    # Expected runtime is ~3 minutes (checkout + go/helm setup + helm pull +
+    # go install + two renders + checker). 10 minutes is a cheap upper bound
+    # that protects against a hung helm pull or go install without being
+    # disruptive to legitimate slow runs.
+    timeout-minutes: 10
     steps:
       - name: Checkout PR HEAD
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -55,9 +68,13 @@ jobs:
           if [ -n "$LATEST_VERSION" ]; then
             echo "Attempting to pull published chart for $LATEST_TAG..."
             mkdir -p /tmp/baseline-release
+            # Don't redirect stderr — helm pull's own error line (one line,
+            # e.g. "Error: ... not found") is useful evidence in the log
+            # when we fall back. Redirecting hides transient ghcr.io outages
+            # behind the expected "tag not yet published" path.
             if helm pull "oci://ghcr.io/stacklok/toolhive/toolhive-operator-crds" \
                  --version "$LATEST_VERSION" \
-                 --untar --untardir /tmp/baseline-release 2>/dev/null; then
+                 --untar --untardir /tmp/baseline-release; then
               BASELINE_SOURCE="release $LATEST_TAG"
               BASELINE_CHART_DIR="/tmp/baseline-release/toolhive-operator-crds"
               echo "Using published chart at $LATEST_TAG"
@@ -79,6 +96,13 @@ jobs:
           echo "chart-dir=$BASELINE_CHART_DIR" >> "$GITHUB_OUTPUT"
 
       - name: Render baseline CRDs
+        env:
+          # Route step outputs through env vars so bash quotes them instead
+          # of the runner substituting them directly into the script body.
+          # Current values are hardcoded literals, so not injectable today —
+          # this is defense-in-depth against a future edit that routes a
+          # PR-controlled string through these outputs.
+          CHART_DIR: ${{ steps.baseline.outputs.chart-dir }}
         run: |
           set -euo pipefail
           mkdir -p /tmp/baseline-crds
@@ -88,7 +112,7 @@ jobs:
           # The yq filter is defensive — the chart currently only templates
           # CRDs, but this keeps the invariant explicit if non-CRD resources
           # are ever added.
-          helm template toolhive-operator-crds "${{ steps.baseline.outputs.chart-dir }}" \
+          helm template toolhive-operator-crds "$CHART_DIR" \
             --set crds.install.server=true \
             --set crds.install.registry=true \
             --set crds.install.virtualMcp=true \
@@ -109,10 +133,19 @@ jobs:
           echo "Rendered $(grep -c '^kind: CustomResourceDefinition' /tmp/head-crds/all.yaml || echo 0) HEAD CRDs"
 
       - name: Install crd-schema-checker
-        run: go install github.com/openshift/crd-schema-checker/cmd/crd-schema-checker@latest
+        # SHA-pinned: openshift/crd-schema-checker has no release tags at the
+        # time of writing, so @latest is the only other option. Pinning makes
+        # CI deterministic and mitigates supply-chain risk (upstream compromise
+        # would otherwise execute attacker code on the runner with GITHUB_TOKEN
+        # in env). Bump via a deliberate PR after verifying the new output
+        # locally. SHA pinned on 2026-04-21.
+        run: go install github.com/openshift/crd-schema-checker/cmd/crd-schema-checker@3fee146022bfe6f4adf84998de35d7267b864bef
 
       - name: Check CRD schema compatibility
         id: checker
+        env:
+          # See Render baseline CRDs step for rationale on env-based interpolation.
+          BASELINE_SOURCE: ${{ steps.baseline.outputs.source }}
         run: |
           # NoBools and NoMaps are OpenShift API-style conventions, not
           # compat-breaking rules. They fire on fields we legitimately use
@@ -137,7 +170,7 @@ jobs:
           {
             echo "## API Compatibility — CRD Schema Check (Phase 1: advisory)"
             echo ""
-            echo "**Baseline source**: ${{ steps.baseline.outputs.source }}"
+            echo "**Baseline source**: $BASELINE_SOURCE"
             echo "**Status**: $STATUS"
             echo ""
             echo "<details><summary>crd-schema-checker output</summary>"

--- a/.github/workflows/api-compat.yml
+++ b/.github/workflows/api-compat.yml
@@ -59,41 +59,28 @@ jobs:
         run: |
           set -euo pipefail
 
-          BASELINE_SOURCE=""
-          BASELINE_CHART_DIR=""
-
-          LATEST_TAG="$(gh release list --repo "$GITHUB_REPOSITORY" --limit 1 --json tagName --jq '.[0].tagName' 2>/dev/null || true)"
+          # Baseline is always the most recent published release chart from
+          # OCI. If the pull fails (no releases, OCI outage, or the chart
+          # for the most recent tag is not yet published), the job fails —
+          # an API-touching PR must be checked against a real released
+          # baseline or not at all. Falling back to origin/main was
+          # rejected in review: it can silently compare against an
+          # already-broken baseline once a break lands on main.
+          LATEST_TAG="$(gh release list --repo "$GITHUB_REPOSITORY" --limit 1 --json tagName --jq '.[0].tagName')"
+          if [ -z "$LATEST_TAG" ]; then
+            echo "::error::No releases found for $GITHUB_REPOSITORY; cannot establish an API compatibility baseline."
+            exit 1
+          fi
           LATEST_VERSION="${LATEST_TAG#v}"
 
-          if [ -n "$LATEST_VERSION" ]; then
-            echo "Attempting to pull published chart for $LATEST_TAG..."
-            mkdir -p /tmp/baseline-release
-            # Don't redirect stderr — helm pull's own error line (one line,
-            # e.g. "Error: ... not found") is useful evidence in the log
-            # when we fall back. Redirecting hides transient ghcr.io outages
-            # behind the expected "tag not yet published" path.
-            if helm pull "oci://ghcr.io/stacklok/toolhive/toolhive-operator-crds" \
-                 --version "$LATEST_VERSION" \
-                 --untar --untardir /tmp/baseline-release; then
-              BASELINE_SOURCE="release $LATEST_TAG"
-              BASELINE_CHART_DIR="/tmp/baseline-release/toolhive-operator-crds"
-              echo "Using published chart at $LATEST_TAG"
-            else
-              echo "Chart pull failed (not yet published?); falling back to origin/main"
-            fi
-          else
-            echo "No releases found; falling back to origin/main"
-          fi
+          echo "Pulling published chart for $LATEST_TAG..."
+          mkdir -p /tmp/baseline-release
+          helm pull "oci://ghcr.io/stacklok/toolhive/toolhive-operator-crds" \
+            --version "$LATEST_VERSION" \
+            --untar --untardir /tmp/baseline-release
 
-          if [ -z "$BASELINE_SOURCE" ]; then
-            git fetch origin main --depth=1
-            git worktree add --detach /tmp/baseline-main FETCH_HEAD
-            BASELINE_SOURCE="main"
-            BASELINE_CHART_DIR="/tmp/baseline-main/deploy/charts/operator-crds"
-          fi
-
-          echo "source=$BASELINE_SOURCE" >> "$GITHUB_OUTPUT"
-          echo "chart-dir=$BASELINE_CHART_DIR" >> "$GITHUB_OUTPUT"
+          echo "source=release $LATEST_TAG" >> "$GITHUB_OUTPUT"
+          echo "chart-dir=/tmp/baseline-release/toolhive-operator-crds" >> "$GITHUB_OUTPUT"
 
       - name: Render baseline CRDs
         env:

--- a/.github/workflows/api-compat.yml
+++ b/.github/workflows/api-compat.yml
@@ -6,9 +6,6 @@ name: API Compatibility
 # continue-on-error: true so breaking-change findings are surfaced via the
 # job's step summary but do not block merges. Remove continue-on-error in
 # Phase 2 to start enforcing.
-#
-# See design-api-compat-ci.md and CONTRIBUTING.md ("API Stability") for the
-# full rollout plan and escape-hatch process.
 
 on:
   pull_request:

--- a/.github/workflows/api-compat.yml
+++ b/.github/workflows/api-compat.yml
@@ -1,0 +1,152 @@
+name: API Compatibility
+
+# This workflow guards the stability of the v1beta1 operator API surface.
+#
+# Phase 1 (current): advisory only. `crd-schema-check` runs with
+# continue-on-error: true so breaking-change findings are surfaced via the
+# job's step summary but do not block merges. Remove continue-on-error in
+# Phase 2 to start enforcing.
+#
+# See design-api-compat-ci.md and CONTRIBUTING.md ("API Stability") for the
+# full rollout plan and escape-hatch process.
+
+on:
+  pull_request:
+    paths:
+      - 'cmd/thv-operator/api/**'
+      - 'deploy/charts/operator-crds/files/crds/**'
+      - 'deploy/charts/operator-crds/templates/**'
+
+permissions:
+  contents: read
+
+jobs:
+  crd-schema-check:
+    name: CRD Schema Compatibility
+    runs-on: ubuntu-latest
+    # Phase 1: advisory only. Remove in Phase 2 to enforce.
+    continue-on-error: true
+    steps:
+      - name: Checkout PR HEAD
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version: 'stable'
+          cache: true
+
+      - name: Set up Helm
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
+
+      - name: Resolve baseline source
+        id: baseline
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          BASELINE_SOURCE=""
+          BASELINE_CHART_DIR=""
+
+          LATEST_TAG="$(gh release list --repo "$GITHUB_REPOSITORY" --limit 1 --json tagName --jq '.[0].tagName' 2>/dev/null || true)"
+          LATEST_VERSION="${LATEST_TAG#v}"
+
+          if [ -n "$LATEST_VERSION" ]; then
+            echo "Attempting to pull published chart for $LATEST_TAG..."
+            mkdir -p /tmp/baseline-release
+            if helm pull "oci://ghcr.io/stacklok/toolhive/toolhive-operator-crds" \
+                 --version "$LATEST_VERSION" \
+                 --untar --untardir /tmp/baseline-release 2>/dev/null; then
+              BASELINE_SOURCE="release $LATEST_TAG"
+              BASELINE_CHART_DIR="/tmp/baseline-release/toolhive-operator-crds"
+              echo "Using published chart at $LATEST_TAG"
+            else
+              echo "Chart pull failed (not yet published?); falling back to origin/main"
+            fi
+          else
+            echo "No releases found; falling back to origin/main"
+          fi
+
+          if [ -z "$BASELINE_SOURCE" ]; then
+            git fetch origin main --depth=1
+            git worktree add --detach /tmp/baseline-main FETCH_HEAD
+            BASELINE_SOURCE="main"
+            BASELINE_CHART_DIR="/tmp/baseline-main/deploy/charts/operator-crds"
+          fi
+
+          echo "source=$BASELINE_SOURCE" >> "$GITHUB_OUTPUT"
+          echo "chart-dir=$BASELINE_CHART_DIR" >> "$GITHUB_OUTPUT"
+
+      - name: Render baseline CRDs
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/baseline-crds
+          # All three feature flags must be set so the Helm wrapper emits every
+          # CRD (see deploy/charts/operator-crds/crd-helm-wrapper). Missing a
+          # flag silently drops CRDs from the comparison.
+          # The yq filter is defensive — the chart currently only templates
+          # CRDs, but this keeps the invariant explicit if non-CRD resources
+          # are ever added.
+          helm template toolhive-operator-crds "${{ steps.baseline.outputs.chart-dir }}" \
+            --set crds.install.server=true \
+            --set crds.install.registry=true \
+            --set crds.install.virtualMcp=true \
+            | yq 'select(.kind == "CustomResourceDefinition")' \
+            > /tmp/baseline-crds/all.yaml
+          echo "Rendered $(grep -c '^kind: CustomResourceDefinition' /tmp/baseline-crds/all.yaml || echo 0) baseline CRDs"
+
+      - name: Render HEAD CRDs
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/head-crds
+          helm template toolhive-operator-crds deploy/charts/operator-crds \
+            --set crds.install.server=true \
+            --set crds.install.registry=true \
+            --set crds.install.virtualMcp=true \
+            | yq 'select(.kind == "CustomResourceDefinition")' \
+            > /tmp/head-crds/all.yaml
+          echo "Rendered $(grep -c '^kind: CustomResourceDefinition' /tmp/head-crds/all.yaml || echo 0) HEAD CRDs"
+
+      - name: Install crd-schema-checker
+        run: go install github.com/openshift/crd-schema-checker/cmd/crd-schema-checker@latest
+
+      - name: Check CRD schema compatibility
+        id: checker
+        run: |
+          # NoBools and NoMaps are OpenShift API-style conventions, not
+          # compat-breaking rules. They fire on fields we legitimately use
+          # (e.g. embeddingservers.spec.modelCache.enabled) and drown out
+          # real findings. Re-enable only if upstream clarifies breaking-
+          # change semantics for them.
+          set +e
+          crd-schema-checker check-manifests \
+            --existing-crd-filename /tmp/baseline-crds/all.yaml \
+            --new-crd-filename /tmp/head-crds/all.yaml \
+            --disabled-validators=NoBools,NoMaps \
+            2>&1 | tee /tmp/checker-output.txt
+          CHECK_EXIT=${PIPESTATUS[0]}
+          set -e
+
+          if [ "$CHECK_EXIT" -eq 0 ]; then
+            STATUS="Compatible"
+          else
+            STATUS="Incompatible or Unknown"
+          fi
+
+          {
+            echo "## API Compatibility — CRD Schema Check (Phase 1: advisory)"
+            echo ""
+            echo "**Baseline source**: ${{ steps.baseline.outputs.source }}"
+            echo "**Status**: $STATUS"
+            echo ""
+            echo "<details><summary>crd-schema-checker output</summary>"
+            echo ""
+            echo '```'
+            cat /tmp/checker-output.txt
+            echo '```'
+            echo ""
+            echo "</details>"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          exit "$CHECK_EXIT"


### PR DESCRIPTION
## Summary

The v1beta1 graduation in #4849 made a stability commitment that is enforced only by convention and code review. A reviewer can miss a field removal, tightened validation, or renamed finalizer and ship a breaking change to users of the released CRDs.

This PR adds the **Phase 1 (advisory)** part of the API compatibility CI plan: a new `.github/workflows/api-compat.yml` workflow that runs `crd-schema-checker` against the last published CRD chart on every PR touching operator API surface. Findings appear in the job's step summary. The job uses `continue-on-error: true` so breaking-change findings do not block merges yet — that flips in Phase 2 after ~2 weeks of observation.

Part of #4972.

<details>
<summary><strong>Medium level</strong></summary>

- New top-level workflow `.github/workflows/api-compat.yml`, triggered on PRs that modify `cmd/thv-operator/api/**`, `deploy/charts/operator-crds/files/crds/**`, or `deploy/charts/operator-crds/templates/**`.
- Single job `crd-schema-check` that: resolves a baseline (published chart from `oci://ghcr.io/stacklok/toolhive/toolhive-operator-crds` for the latest tag, falling back to `origin/main` when the chart for the tag is not yet published); renders baseline and HEAD CRDs via `helm template`; runs `crd-schema-checker` with `NoBools,NoMaps` disabled; writes a markdown summary (baseline source + Compatible/Incompatible + raw output) to `\$GITHUB_STEP_SUMMARY`.
- `continue-on-error: true` at the job level: the step summary is visible and the check-run reports its real status, but the workflow's overall result doesn't block the PR. Phase 2 removes this flag.
- Phases 2 (enforcement + `api-break-allowed` label + CONTRIBUTING/template updates) and 3 (`apidiff` + toolhive invariants) ship as separate PRs after Phase 1 has been observed.

</details>

<details>
<summary><strong>Low level</strong></summary>

| File | Change |
|------|--------|
| `.github/workflows/api-compat.yml` | New workflow. Pinned action SHAs (checkout v6, setup-go v6, setup-helm v4.3.1) match operator-ci.yml. Installs `crd-schema-checker` via \`go install @latest\` (acceptable for Phase 1; pin after stability confirmed). Uses \`\${PIPESTATUS[0]}\` to capture the checker's exit code through the \`tee\` pipeline. |

</details>

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other

## Test plan

- [x] Workflow YAML parses cleanly (\`python3 -c 'import yaml; yaml.safe_load(...)'\`)
- [x] \`crd-schema-checker\` main-vs-main: exit 0, no output (clean baseline, no existing noise)
- [x] \`crd-schema-checker\` v0.22.0-vs-main with \`--disabled-validators=NoBools,NoMaps\`: exit 0, no output
- [x] Simulated field-removal (\`yq -i 'del(.. | select(has(\"replicas\")).replicas)'\`): correctly flagged as \`NoFieldRemoval\`, exit 1
- [x] \`helm pull oci://.../toolhive-operator-crds --version 0.22.0\`: succeeds — OCI pull path works
- [x] \`helm pull\` for the latest tag (v0.23.0): fails — confirms the \`origin/main\` fallback is exercised on this very PR since the v0.23.0 chart isn't yet published
- [ ] Unit tests (\`task test\`) — **N/A**, no Go changes
- [ ] E2E tests (\`task test-e2e\`) — **N/A**, no runtime changes
- [ ] Linting (\`task lint-fix\`) — **N/A**, no Go changes
- [x] Manual end-to-end verification will happen on this PR's own Actions run, which is the first real exercise of the workflow

## Does this introduce a user-facing change?

No. Internal CI only. The \`api-break-allowed\` label and \`CONTRIBUTING.md\` "API Stability" section land in the Phase 2 PR.

## Implementation plan

<details>
<summary>Approved implementation plan</summary>

Planned with Claude Code as a three-phase rollout (advisory → enforcement + docs → expanded invariants). This PR is Stage 1 only; Stages 2 and 3 will ship as separate PRs.

**Stage 1 scope** (this PR):
- Create \`.github/workflows/api-compat.yml\` as a top-level workflow with \`on: pull_request: paths:\` filter.
- Baseline resolution: OCI chart for last release tag, with \`origin/main\` fallback when \`helm pull\` fails.
- Single \`crd-schema-check\` job running with \`continue-on-error: true\`.
- Step summary output format: heading + baseline source + Compatible/Incompatible/Unknown status + fenced block with raw checker output.

**Key design decisions surfaced in this PR**:
- Top-level workflow (not reusable) to get \`paths:\` filter support; trade-off: won't appear under \`PR Checks\` umbrella, each job is its own check run.
- Style validators \`NoBools\` and \`NoMaps\` disabled — they are OpenShift API conventions, not compat-breaking rules. Verified locally that \`NoFieldRemoval\` and other real compat rules still fire with them disabled.
- \`go install ...@latest\` for \`crd-schema-checker\` accepted for Phase 1; pin once observation confirms stability.
- Label-skip guard (\`if: !contains(...'api-break-allowed'...)\`) is absent here — the label doesn't exist yet and is created alongside the Phase 2 enforcement flip to prevent early misuse.

**Follow-up PRs** (separate \`/implement-code\` runs):
- Stage 2: remove \`continue-on-error\`; add \`if: !contains(...)\` guard; create \`api-break-allowed\` label via \`gh label create\` runbook; update \`CONTRIBUTING.md\` with an "API Stability" section; add "API Compatibility" section to \`.github/pull_request_template.md\`; maintainer action: add \`crd-schema-check\` to required status checks.
- Stage 3: add \`go-api-check\` job running \`apidiff\` on \`./cmd/thv-operator/api/v1beta1\`; add \`toolhive-invariants\` job checking \`spec.names\` stability and finalizer-string stability (regex narrowed to \`/finalizer\` suffix to avoid false-positives on \`restart-*\` annotations).

</details>

## Special notes for reviewers

- **First-run behavior**: this PR's own Actions run will hit the fallback path (v0.23.0's CRD chart isn't on OCI yet). The step summary should report \`Baseline source: main\` and \`Status: Compatible\`. If it reports anything else, treat as a real finding rather than workflow-setup noise.
- **Disabled validators**: \`NoBools,NoMaps\` are intentionally disabled. A \`main\` vs last-release run without them produces 9 spurious errors on \`embeddingservers\` fields added since v0.22.0. These validators are style rules from OpenShift, not compat-breaking semantics. Local verification confirmed real compat rules (\`NoFieldRemoval\`, etc.) still fire.
- **Check run will show a red X when findings appear**: \`continue-on-error: true\` prevents the workflow from blocking the PR, but GitHub still reports the job's real status on the check run. Reviewers should treat red X on this job as "read the step summary" rather than "this PR is broken" during Phase 1.
- **Tool pin deferred**: \`crd-schema-checker\` installs from \`@latest\`. If upstream breaks semantics in a release, Phase 1's advisory mode absorbs the noise. Pin after Phase 1 stabilizes.

Generated with [Claude Code](https://claude.com/claude-code)

