### PR TITLE
Re-export toolhive-core schemas as release assets

### DIFF
--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -145,6 +145,30 @@ jobs:
           mkdir -p build
           tar -czf build/thv-cli-docs.tar.gz -C docs/cli .
 
+      - name: Download toolhive-core schemas at pinned version
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Resolve the toolhive-core version this release was built against
+          # (from go.mod, since we ship binaries compiled against that version).
+          # Re-exporting the schemas here lets downstream consumers (notably
+          # docs-website) skip the two-repo dance of deriving the version and
+          # fetching from a separate release.
+          mkdir -p build
+          CORE_VERSION=$(grep 'github.com/stacklok/toolhive-core' go.mod | awk '{print $2}' | head -1)
+          if [ -z "$CORE_VERSION" ]; then
+            echo "::error::Could not determine toolhive-core version from go.mod"
+            exit 1
+          fi
+          echo "Using toolhive-core version: $CORE_VERSION"
+          gh release download "$CORE_VERSION" \
+            --repo stacklok/toolhive-core \
+            --pattern "toolhive-legacy-registry.schema.json" \
+            --pattern "upstream-registry.schema.json" \
+            --pattern "publisher-provided.schema.json" \
+            --pattern "skill.schema.json" \
+            --dir build/
+
       - name: Remove existing release assets (allows re-runs)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -101,6 +101,10 @@ release:
     name: toolhive
   extra_files:
     - glob: build/thv-cli-docs.tar.gz
+    - glob: build/toolhive-legacy-registry.schema.json
+    - glob: build/upstream-registry.schema.json
+    - glob: build/publisher-provided.schema.json
+    - glob: build/skill.schema.json
     - glob: docs/server/swagger.yaml
     - glob: docs/server/swagger.json
     - glob: docs/operator/crd-api.md


### PR DESCRIPTION
## Summary

Adds four schema JSON files (from `stacklok/toolhive-core` at the go.mod-pinned version) as release assets on every toolhive release:

- `toolhive-legacy-registry.schema.json`
- `upstream-registry.schema.json`
- `publisher-provided.schema.json`
- `skill.schema.json`

## Motivation

Downstream consumers that need these schemas — notably [stacklok/docs-website](https://github.com/stacklok/docs-website) — currently perform a two-repo dance:

1. Fetch toolhive's go.mod at the release tag
2. Extract the `github.com/stacklok/toolhive-core vX.Y.Z` line
3. Call `gh release download` against a **different** repo (toolhive-core)

Re-exporting the schemas here replaces that with a single `gh release download` against toolhive's release. The source of truth (which schemas go with which toolhive version) is now explicit rather than derived.

Paired with [PR #4982](https://github.com/stacklok/toolhive/pull/4982) (CRD manifests as release asset). Together these two PRs eliminate all cross-repo and clone-based logic in [docs-website PR #748](https://github.com/stacklok/docs-website/pull/748), letting the docs regen pipeline work purely off `gh release download`.

## What's in this PR

- `.github/workflows/releaser.yml`: new "Download toolhive-core schemas at pinned version" step. Parses `github.com/stacklok/toolhive-core` from `go.mod`, downloads the four schema files into `build/`.
- `.goreleaser.yaml`: four new `release.extra_files` entries so goreleaser uploads them.

## Test plan

- [ ] Verify on a test release that all four schemas appear as release assets
- [ ] Confirm the go.mod-derived version matches what toolhive was compiled against
- [ ] Confirm the existing release assets are unaffected

Local smoke test (requires a toolhive-core release token for `gh release download`):

\`\`\`
CORE_VERSION=\$(grep 'github.com/stacklok/toolhive-core' go.mod | awk '{print \$2}' | head -1)
mkdir -p /tmp/build
gh release download "\$CORE_VERSION" --repo stacklok/toolhive-core \\
  --pattern "*.schema.json" --dir /tmp/build
ls /tmp/build
\`\`\`

## Notes

If toolhive ever switches to a release model where the binaries aren't compiled against a concrete `toolhive-core` version (e.g., a `replace` directive in go.mod for development), this step would need a fallback. Not a concern today — the go.mod always pins a concrete version at release tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)