### PR TITLE
TEST: validate api-compat.yml flags breaking v1beta1 change (do not merge)

### DIFF
--- a/cmd/thv-operator/api/v1beta1/mcpgroup_types.go
+++ b/cmd/thv-operator/api/v1beta1/mcpgroup_types.go
@@ -12,6 +12,12 @@ type MCPGroupSpec struct {
 	// Description provides human-readable context
 	// +optional
 	Description string `json:"description,omitempty"`
+
+	// TestBreakingChange is deliberately added as a required field to validate
+	// that api-compat.yml flags new-required-field additions as breaking.
+	// Do NOT merge this PR — see PR description.
+	// +kubebuilder:validation:Required
+	TestBreakingChange string `json:"testBreakingChange"`
 }
 
 // MCPGroupStatus defines observed state

--- a/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpgroups.yaml
+++ b/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpgroups.yaml
@@ -62,6 +62,14 @@ spec:
               description:
                 description: Description provides human-readable context
                 type: string
+              testBreakingChange:
+                description: |-
+                  TestBreakingChange is deliberately added as a required field to validate
+                  that api-compat.yml flags new-required-field additions as breaking.
+                  Do NOT merge this PR — see PR description.
+                type: string
+            required:
+            - testBreakingChange
             type: object
           status:
             description: MCPGroupStatus defines observed state
@@ -216,6 +224,14 @@ spec:
               description:
                 description: Description provides human-readable context
                 type: string
+              testBreakingChange:
+                description: |-
+                  TestBreakingChange is deliberately added as a required field to validate
+                  that api-compat.yml flags new-required-field additions as breaking.
+                  Do NOT merge this PR — see PR description.
+                type: string
+            required:
+            - testBreakingChange
             type: object
           status:
             description: MCPGroupStatus defines observed state

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpgroups.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpgroups.yaml
@@ -65,6 +65,14 @@ spec:
               description:
                 description: Description provides human-readable context
                 type: string
+              testBreakingChange:
+                description: |-
+                  TestBreakingChange is deliberately added as a required field to validate
+                  that api-compat.yml flags new-required-field additions as breaking.
+                  Do NOT merge this PR — see PR description.
+                type: string
+            required:
+            - testBreakingChange
             type: object
           status:
             description: MCPGroupStatus defines observed state
@@ -219,6 +227,14 @@ spec:
               description:
                 description: Description provides human-readable context
                 type: string
+              testBreakingChange:
+                description: |-
+                  TestBreakingChange is deliberately added as a required field to validate
+                  that api-compat.yml flags new-required-field additions as breaking.
+                  Do NOT merge this PR — see PR description.
+                type: string
+            required:
+            - testBreakingChange
             type: object
           status:
             description: MCPGroupStatus defines observed state


### PR DESCRIPTION
## ⚠️ DO NOT MERGE

This PR intentionally introduces a breaking change to the `v1beta1` operator API to validate that the `api-compat.yml` workflow (added in #4980) correctly flags it.

**Close this PR** as soon as the check has been demonstrated — the change must never land on main.

## What changed

A new **required** field `TestBreakingChange` was added to `MCPGroupSpec` in `cmd/thv-operator/api/v1beta1/mcpgroup_types.go`, then the CRD YAML and Helm-wrapped template were regenerated via `task operator-manifests`.

Adding a new required field is a breaking change because existing `MCPGroup` resources in user clusters will fail validation against the new schema.

## Expected CI behavior

The `CRD Schema Compatibility` job should:

1. Pull the published CRD chart for `v0.23.0` from `oci://ghcr.io/stacklok/toolhive/toolhive-operator-crds:0.23.0` (baseline).
2. Render both baseline and HEAD CRDs via `helm template`.
3. Run `crd-schema-checker` and emit a `NoNewRequiredFields` error on `mcpgroups.toolhive.stacklok.dev`.
4. Write a step summary with `Status: Incompatible or Unknown` and the raw checker output.
5. Exit non-zero, but because Phase 1 has `continue-on-error: true`, the failure does **not** block the PR.

## What to look for on the PR

- The check run for `CRD Schema Compatibility` should appear (path filter matches `cmd/thv-operator/api/**` and `files/crds/**`).
- The check run will show red (actual step exited non-zero).
- The workflow summary under the Actions tab should contain the step summary markdown with the expected `NoNewRequiredFields` finding.
- The PR's overall merge button should remain green/unblocked because `continue-on-error: true` keeps the workflow status passing.

## Type of change

- [x] Other (test-only / validation of CI tooling)

## Test plan

- [x] `task operator-generate` regenerated deepcopy cleanly
- [x] `task operator-manifests` regenerated the CRD YAML and Helm template
- [x] Required marker confirmed in `deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpgroups.yaml` (contains `required: [testBreakingChange]`)
- [ ] CI: `CRD Schema Compatibility` check reports `NoNewRequiredFields` in step summary
- [ ] CI: job exits non-zero but workflow status is "passing" (advisory mode working)

## Does this introduce a user-facing change?

**No.** This PR will never be merged.

Generated with [Claude Code](https://claude.com/claude-code)