### PR TITLE
TEST: rename mcpgroups.spec.description → summary (do not merge)

### DIFF
--- a/cmd/thv-operator/api/v1beta1/mcpgroup_types.go
+++ b/cmd/thv-operator/api/v1beta1/mcpgroup_types.go
@@ -9,9 +9,13 @@ import (
 
 // MCPGroupSpec defines the desired state of MCPGroup
 type MCPGroupSpec struct {
-	// Description provides human-readable context
+	// Description provides human-readable context.
+	// TEST: JSON tag deliberately renamed from "description" to "summary" to
+	// validate that the api-compat.yml workflow flags the field rename as a
+	// breaking change. Go field name is kept so existing callers still
+	// compile. Do NOT merge this PR.
 	// +optional
-	Description string `json:"description,omitempty"`
+	Description string `json:"summary,omitempty"`
 }
 
 // MCPGroupStatus defines observed state

--- a/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpgroups.yaml
+++ b/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpgroups.yaml
@@ -59,8 +59,13 @@ spec:
           spec:
             description: MCPGroupSpec defines the desired state of MCPGroup
             properties:
-              description:
-                description: Description provides human-readable context
+              summary:
+                description: |-
+                  Description provides human-readable context.
+                  TEST: JSON tag deliberately renamed from "description" to "summary" to
+                  validate that the api-compat.yml workflow flags the field rename as a
+                  breaking change. Go field name is kept so existing callers still
+                  compile. Do NOT merge this PR.
                 type: string
             type: object
           status:
@@ -213,8 +218,13 @@ spec:
           spec:
             description: MCPGroupSpec defines the desired state of MCPGroup
             properties:
-              description:
-                description: Description provides human-readable context
+              summary:
+                description: |-
+                  Description provides human-readable context.
+                  TEST: JSON tag deliberately renamed from "description" to "summary" to
+                  validate that the api-compat.yml workflow flags the field rename as a
+                  breaking change. Go field name is kept so existing callers still
+                  compile. Do NOT merge this PR.
                 type: string
             type: object
           status:

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpgroups.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpgroups.yaml
@@ -62,8 +62,13 @@ spec:
           spec:
             description: MCPGroupSpec defines the desired state of MCPGroup
             properties:
-              description:
-                description: Description provides human-readable context
+              summary:
+                description: |-
+                  Description provides human-readable context.
+                  TEST: JSON tag deliberately renamed from "description" to "summary" to
+                  validate that the api-compat.yml workflow flags the field rename as a
+                  breaking change. Go field name is kept so existing callers still
+                  compile. Do NOT merge this PR.
                 type: string
             type: object
           status:
@@ -216,8 +221,13 @@ spec:
           spec:
             description: MCPGroupSpec defines the desired state of MCPGroup
             properties:
-              description:
-                description: Description provides human-readable context
+              summary:
+                description: |-
+                  Description provides human-readable context.
+                  TEST: JSON tag deliberately renamed from "description" to "summary" to
+                  validate that the api-compat.yml workflow flags the field rename as a
+                  breaking change. Go field name is kept so existing callers still
+                  compile. Do NOT merge this PR.
                 type: string
             type: object
           status:


### PR DESCRIPTION
## ⚠️ DO NOT MERGE

Deliberate breaking change to validate the api-compat workflow merged in #4987 end-to-end on real CI. **Close this PR** once the check has been demonstrated.

## What changed

In `cmd/thv-operator/api/v1beta1/mcpgroup_types.go`, the JSON tag on `MCPGroupSpec.Description` is renamed from `"description"` to `"summary"`. The Go field name is kept (so the 20+ tests that reference `.Spec.Description` still compile), but the CRD schema emitted by `controller-gen` now exposes `spec.summary` instead of `spec.description`.

`task operator-generate` and `task operator-manifests` regenerated the three affected files:

- `cmd/thv-operator/api/v1beta1/mcpgroup_types.go`
- `deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpgroups.yaml`
- `deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpgroups.yaml`

## Why this is a breaking change

Dropping `description` from the CRD schema means: existing `MCPGroup` resources in user clusters that have `spec.description` set will no longer survive a round-trip (the field gets stripped on read-back), and any client using `.spec.description` instead of `.spec.summary` fails. `crd-schema-checker`'s `NoFieldRemoval` rule catches exactly this.

## Expected CI behavior

The `CRD Schema Compatibility` job (from #4987) should:

1. Resolve the baseline tag via `gh release list --limit 1` → `v0.23.1`.
2. Shallow-fetch `refs/tags/v0.23.1:refs/tags/v0.23.1`.
3. Install `crd-schema-checker` from the pinned SHA.
4. Iterate `deploy/charts/operator-crds/files/crds/*.yaml`. When it gets to `toolhive.stacklok.dev_mcpgroups.yaml`:
   - `git show v0.23.1:.../toolhive.stacklok.dev_mcpgroups.yaml` returns a version with `spec.description`.
   - The on-disk version has `spec.summary`.
   - `crd-schema-checker check-manifests` reports two `NoFieldRemoval` errors — one for `v1alpha1`, one for `v1beta1`.
5. Exit 1. `continue-on-error: true` keeps the workflow overall status passing, so the PR merge button stays unblocked.
6. Step summary shows `Status: Incompatible or Unknown` with the two errors inside the collapsible.

The other 11 CRDs should report clean.

## What to look for on the PR

- The `CRD Schema Compatibility` check run appears (path filter matches `cmd/thv-operator/api/**` and `files/crds/**`).
- The check run shows red — because the step itself exits non-zero.
- The workflow's overall status is green — because `continue-on-error: true` suppresses the failure from the workflow result.
- The step summary under the Actions tab has the expected `NoFieldRemoval` findings on `mcpgroups`.

## Type of change

- [x] Other (test-only / CI validation)

## Test plan

- [x] `task operator-generate` regenerated deepcopy cleanly
- [x] `task operator-manifests` regenerated the CRD YAML and Helm template
- [x] Rendered CRDs confirm both `v1alpha1` and `v1beta1` now expose `spec.summary`
- [x] Local dry-run of the new workflow logic against `v0.23.0` tag: 2× `NoFieldRemoval` on mcpgroups, exit 1
- [ ] CI: `CRD Schema Compatibility` check reports 2× `NoFieldRemoval` in the step summary
- [ ] CI: step exits non-zero, workflow status remains "pass" (advisory mode working)

## Does this introduce a user-facing change?

**No.** This PR will never be merged.

Generated with [Claude Code](https://claude.com/claude-code)