### PR TITLE
TEST: add optional Owner field to MCPGroupSpec (do not merge)

### DIFF
--- a/cmd/thv-operator/api/v1beta1/mcpgroup_types.go
+++ b/cmd/thv-operator/api/v1beta1/mcpgroup_types.go
@@ -12,6 +12,12 @@ type MCPGroupSpec struct {
 	// Description provides human-readable context
 	// +optional
 	Description string `json:"description,omitempty"`
+
+	// Owner identifies the team or person responsible for this group.
+	// TEST: deliberately added as a new optional field to validate that
+	// api-compat.yml reports Compatible on additive changes. Do NOT merge.
+	// +optional
+	Owner string `json:"owner,omitempty"`
 }
 
 // MCPGroupStatus defines observed state

--- a/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpgroups.yaml
+++ b/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpgroups.yaml
@@ -62,6 +62,12 @@ spec:
               description:
                 description: Description provides human-readable context
                 type: string
+              owner:
+                description: |-
+                  Owner identifies the team or person responsible for this group.
+                  TEST: deliberately added as a new optional field to validate that
+                  api-compat.yml reports Compatible on additive changes. Do NOT merge.
+                type: string
             type: object
           status:
             description: MCPGroupStatus defines observed state
@@ -215,6 +221,12 @@ spec:
             properties:
               description:
                 description: Description provides human-readable context
+                type: string
+              owner:
+                description: |-
+                  Owner identifies the team or person responsible for this group.
+                  TEST: deliberately added as a new optional field to validate that
+                  api-compat.yml reports Compatible on additive changes. Do NOT merge.
                 type: string
             type: object
           status:

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpgroups.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpgroups.yaml
@@ -65,6 +65,12 @@ spec:
               description:
                 description: Description provides human-readable context
                 type: string
+              owner:
+                description: |-
+                  Owner identifies the team or person responsible for this group.
+                  TEST: deliberately added as a new optional field to validate that
+                  api-compat.yml reports Compatible on additive changes. Do NOT merge.
+                type: string
             type: object
           status:
             description: MCPGroupStatus defines observed state
@@ -218,6 +224,12 @@ spec:
             properties:
               description:
                 description: Description provides human-readable context
+                type: string
+              owner:
+                description: |-
+                  Owner identifies the team or person responsible for this group.
+                  TEST: deliberately added as a new optional field to validate that
+                  api-compat.yml reports Compatible on additive changes. Do NOT merge.
                 type: string
             type: object
           status:


### PR DESCRIPTION
## ⚠️ DO NOT MERGE

Additive-change counterpart to #4988. That PR demonstrated the api-compat workflow **fails** on a breaking change (JSON tag rename). This PR demonstrates the workflow **passes** on a legitimate non-breaking addition, so the check isn't a noise-generator that blocks routine additive API evolution.

**Close this PR** once the check has been demonstrated.

## What changed

`MCPGroupSpec` gains one optional field:

```go
Owner string `json:"owner,omitempty"`
```

`Description` is untouched. `task operator-generate` and `task operator-manifests` regenerated the CRD YAML and Helm template; both `v1alpha1` and `v1beta1` now expose `spec.owner` alongside `spec.description`.

## Why this is not a breaking change

- Field is optional (`omitempty`) — existing `MCPGroup` resources without `owner` are valid against the new schema.
- No existing field was removed, renamed, retyped, or narrowed.
- No field was added to `required[]`.

`crd-schema-checker` recognises pure additions as compatible: none of its validators (`NoFieldRemoval`, `NoFieldTypeChange`, `NoMaxLengthDecrease`, `NoEnumRemoval`, `NoNewRequiredFields`, etc.) fire.

## Expected CI behavior

The `CRD Schema Compatibility` job should:

1. Resolve baseline tag via `gh release list --limit 1` → `v0.23.1`.
2. Shallow-fetch the tag.
3. Iterate `files/crds/*.yaml`. When it gets to `toolhive.stacklok.dev_mcpgroups.yaml`:
   - `git show v0.23.1:.../toolhive.stacklok.dev_mcpgroups.yaml` returns a version with only `spec.description`.
   - The on-disk version has `spec.description` AND `spec.owner`.
   - The checker finds no breaking differences and exits 0.
4. All other 11 CRDs are byte-identical to `v0.23.1` and pass cleanly.
5. Step exits 0. Step summary shows `Status: Compatible`.

## What to look for on the PR

- The `CRD Schema Compatibility` check run appears (path filter matches).
- The check run shows **green** (exit 0, no findings).
- The workflow summary reports `Status: Compatible` with an empty collapsible.
- Contrast with #4988, which flagged `NoFieldRemoval` twice in the same spot.

## Type of change

- [x] Other (test-only / CI validation)

## Test plan

- [x] `task operator-generate` regenerated deepcopy cleanly
- [x] `task operator-manifests` regenerated the CRD YAML and Helm template
- [x] Both `v1alpha1` and `v1beta1` CRD versions expose `spec.owner` alongside `spec.description`
- [ ] CI: `CRD Schema Compatibility` check reports `Status: Compatible`, exit 0, zero findings
- [ ] CI: check run shows green in the PR checks list

## Does this introduce a user-facing change?

**No.** This PR will never be merged.

Generated with [Claude Code](https://claude.com/claude-code)