### PR TITLE
Enforce v1beta1 API stability

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -42,6 +42,25 @@ describe exactly what you tested below the checkbox.
 - [ ] Linting (`task lint-fix`)
 - [ ] Manual testing (describe below)
 
+## API Compatibility
+
+<!--
+The CRD Schema Compatibility check guards the v1beta1 operator API.
+If the check flags this PR as Incompatible and the break is intentional,
+apply the `api-break-allowed` label and describe below:
+
+1. Which fields, types, or CRDs are changing.
+2. Why the break is unavoidable.
+3. The user-facing migration path (what cluster admins need to do).
+
+See CONTRIBUTING.md → "API Stability" for the full rubric. Coordinate
+with maintainers before applying the label.
+
+Remove this section entirely if the PR does not touch operator API surface.
+-->
+
+- [ ] This PR does not break the `v1beta1` API, OR the `api-break-allowed` label is applied and the migration guidance is described above.
+
 ## Changes
 
 <!--

--- a/.github/workflows/api-compat.yml
+++ b/.github/workflows/api-compat.yml
@@ -2,10 +2,11 @@ name: API Compatibility
 
 # This workflow guards the stability of the v1beta1 operator API surface.
 #
-# Phase 1 (current): advisory only. `crd-schema-check` runs with
-# continue-on-error: true so breaking-change findings are surfaced via the
-# job's step summary but do not block merges. Remove continue-on-error in
-# Phase 2 to start enforcing.
+# A breaking CRD schema change (field removal, type change, required-field
+# addition, etc.) fails this check and blocks the PR. If the break is
+# intentional — almost exclusively for graduation to v1beta2 — apply the
+# `api-break-allowed` label to skip the check. See CONTRIBUTING.md → "API
+# Stability" for the full rubric.
 
 on:
   pull_request:
@@ -28,8 +29,11 @@ jobs:
   crd-schema-check:
     name: CRD Schema Compatibility
     runs-on: ubuntu-latest
-    # Phase 1: advisory only. Remove in Phase 2 to enforce.
-    continue-on-error: true
+    # Skip the check entirely when `api-break-allowed` is applied — a
+    # required check that is skipped (rather than failed) counts as passing
+    # for branch protection, so this is the escape hatch for intentional
+    # breaks. Do not remove the label guard without a replacement path.
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'api-break-allowed') }}
     # Expected runtime is ~1 minute (checkout + go setup + git fetch tag +
     # go install + per-CRD checker loop). 10 minutes is a cheap upper
     # bound that protects against a hung go install or git fetch.
@@ -146,7 +150,7 @@ jobs:
           fi
 
           {
-            echo "## API Compatibility — CRD Schema Check (Phase 1: advisory)"
+            echo "## API Compatibility — CRD Schema Check"
             echo ""
             echo "**Baseline**: $BASELINE_TAG"
             echo "**Status**: $STATUS"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,3 +148,41 @@ We follow the commit formatting recommendations found on
 1. Do not end the subject line with a period
 1. Use the imperative mood in the subject line
 1. Use the body to explain what and why vs. how
+
+## API Stability
+
+The `v1beta1` operator API is stable. CRD schemas and Go types under
+`cmd/thv-operator/api/v1beta1/` carry a compatibility commitment to users
+running the published operator chart. Contributors must not:
+
+- Remove or rename any field, type, or CRD kind in `v1beta1`.
+- Change a field's Go type, JSON tag, or OpenAPI schema type.
+- Add new required fields to existing types.
+- Narrow validation rules (smaller `maxLength`, stricter `pattern`, fewer
+  `enum` values).
+- Rename a finalizer or change a CRD `shortName`.
+- Flip a CRD's `spec.scope` between `Namespaced` and `Cluster`.
+- Un-serve a currently-served version without a deprecation-cycle release.
+
+New fields must be optional. New behaviour must be opt-in via new fields.
+The `CRD Schema Compatibility` CI check enforces the CRD side of this
+contract against the last published release tag on every PR that touches
+`cmd/thv-operator/api/**` or `deploy/charts/operator-crds/files/crds/**`.
+
+### The `api-break-allowed` escape hatch
+
+If you have a genuine reason to break the API — the main expected use
+case is graduation to `v1beta2` — apply the `api-break-allowed` label to
+the PR. This skips the compatibility check.
+
+Before applying the label:
+
+1. **Coordinate with maintainers first.** Open a Discord thread or an
+   issue describing what you are breaking and why.
+2. **Describe the break in the PR description.** Spell out which API
+   elements are changing, what clusters need to do to migrate, and whether
+   downstream consumers (CLI, chart users, operator integrations) need
+   coordinated releases.
+3. **Do not use the label to silence a false positive.** If the check
+   fires on a change you believe is non-breaking, file a bug against the
+   workflow — silencing it hides real breaks on subsequent PRs.


### PR DESCRIPTION
## Summary

The CRD Schema Compatibility check from #4980 (repaired in #4987) has been running in advisory mode — breaking changes were reported in the step summary but never blocked merges. Phase 1 validation is complete: the two test PRs (#4988 breaking, #4989 additive) showed the check catches real breaks cleanly and doesn't false-positive on legitimate additions.

This PR flips the check from advisory to enforcing and documents the stability contract so contributors know the rules and know how to request an exception.

Follows up on #4980 and #4987.

## How it works

Three coordinated changes:

1. **Workflow change** (`.github/workflows/api-compat.yml`):
   - Drop `continue-on-error: true` from the `crd-schema-check` job. The step's exit code now determines the job's conclusion, which flows to the PR check run and branch protection.
   - Add `if: ${{ !contains(github.event.pull_request.labels.*.name, 'api-break-allowed') }}` at the job level. When the label is applied, the job is skipped rather than run — GitHub treats a skipped required check as passing, which is the escape-hatch path.
   - Drop the "Phase 1: advisory" framing from the workflow header comment and the step summary heading.

2. **Docs — `CONTRIBUTING.md`**: add a new top-level `## API Stability` section that states the `v1beta1` contract (no field removal, type change, new required fields, validation narrowing, finalizer rename, scope flip, un-serving a served version) and documents the `api-break-allowed` escape hatch and maintainer-coordination expectations.

3. **PR template** (`.github/pull_request_template.md`): add a standing "API Compatibility" section after "Test plan" that prompts contributors to describe the break + migration path when the label is applied. GitHub templates don't support conditional rendering, so the section is always present with wording that makes the N/A-for-non-breaking-PRs case explicit via the checkbox.

<details>
<summary><strong>Low level</strong></summary>

| File | Change |
|------|--------|
| `.github/workflows/api-compat.yml` | Remove `continue-on-error: true`; add label-guard `if:` on the job; update header comment and step-summary heading. +11/-7. |
| `CONTRIBUTING.md` | New top-level `## API Stability` section with v1beta1 contract + escape-hatch subsection. +38. |
| `.github/pull_request_template.md` | New "API Compatibility" section between "Test plan" and "Changes". +19. |

</details>

## ⚠️ Maintainer actions required after merge

These cannot be automated from a PR. Please perform them in order after merging:

1. **Create the `api-break-allowed` GitHub label.** A label that doesn't exist can still be referenced in `contains(...)`, but contributors can't apply it.

   ```
   gh label create api-break-allowed \
     --repo stacklok/toolhive \
     --color B60205 \
     --description "Intentionally breaks the v1beta1 API contract; requires maintainer coordination. See CONTRIBUTING.md 'API Stability'."
   ```

2. **Add `CRD Schema Compatibility` to required status checks** for the `main` branch. Settings → Branches → main → Branch protection rules → Require status checks to pass before merging → search for and add `CRD Schema Compatibility`. Without this step, the check is enforcing in name only — its failure won't block merge.

Leaving the PR body here so they're visible during review, not buried in the commit message.

## Type of change

- [x] New feature (enforcement of a contract that was previously advisory)
- [ ] Bug fix
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation
- [ ] Other

## Test plan

- [x] Workflow YAML parses cleanly.
- [x] `continue-on-error` no longer present; job's `if:` guard references the label name that will be created post-merge.
- [x] `CONTRIBUTING.md` renders: new `## API Stability` section has contract bullets and the escape-hatch subsection.
- [x] PR template renders: new `## API Compatibility` section sits between "Test plan" and "Changes".
- [ ] Unit tests (`task test`) — N/A, no Go changes.
- [ ] Linting (`task lint-fix`) — N/A, no Go changes.
- [ ] E2E tests (`task test-e2e`) — N/A, no runtime changes.

**Verification of enforcement itself** will land as a separate test PR after this merges (same shape as #4988): rename a field to trigger the check, confirm the PR is blocked (not advisory-passed) until the `api-break-allowed` label is applied or the break is reverted.

## API Compatibility

<!-- The workflow this PR flips is the one that guards API compat, so the flag-is-on-itself is a chicken-and-egg non-event. The PR doesn't touch `cmd/thv-operator/api/**` or `deploy/charts/operator-crds/files/crds/**`, so the check doesn't run on this PR. -->

- [x] This PR does not break the `v1beta1` API.

## Does this introduce a user-facing change?

**Yes.** Contributors will see a new PR template section and a new stability rubric in `CONTRIBUTING.md`. PRs that touch operator API surface with breaking changes will now block merge unless `api-break-allowed` is applied.

## Special notes for reviewers

- **Rename risk on the job name.** `CRD Schema Compatibility` (matches `name:` in the workflow) becomes a branch-protection check identifier after the maintainer action. Don't rename it unless you're prepared to update branch protection at the same time.
- **Skipped-vs-failed semantics.** When the label is applied, the job doesn't run at all — GitHub reports it as skipped, and branch protection treats skipped required checks as passing. This is the only way to bypass a required check without admin override, which is why the label mechanism is the design.
- **No path-filter change.** The workflow still only runs on PRs that touch `cmd/thv-operator/api/**`, `files/crds/**`, or the workflow itself — same as today. This PR doesn't trigger the workflow on its own diff.
- **The test PR we'll open next** will deliberately break `mcpgroups` (similar to #4988 but against enforcement, not advisory) to confirm the check actually blocks. That PR will be draft-only and closed immediately.

Generated with [Claude Code](https://claude.com/claude-code)