### PR TITLE
TEST: validate api-break-allowed escape hatch (do not merge)

### DIFF
--- a/cmd/thv-operator/api/v1beta1/mcpgroup_types.go
+++ b/cmd/thv-operator/api/v1beta1/mcpgroup_types.go
@@ -9,9 +9,13 @@ import (
 
 // MCPGroupSpec defines the desired state of MCPGroup
 type MCPGroupSpec struct {
-	// Description provides human-readable context
+	// Description provides human-readable context.
+	// TEST: JSON tag deliberately renamed from "description" to "summary" to
+	// validate that enforcement blocks the PR and that the api-break-allowed
+	// escape hatch unblocks it. Go field name is kept so existing callers
+	// still compile. Do NOT merge this PR.
 	// +optional
-	Description string `json:"description,omitempty"`
+	Description string `json:"summary,omitempty"`
 }
 
 // MCPGroupStatus defines observed state

--- a/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpgroups.yaml
+++ b/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpgroups.yaml
@@ -59,8 +59,13 @@ spec:
           spec:
             description: MCPGroupSpec defines the desired state of MCPGroup
             properties:
-              description:
-                description: Description provides human-readable context
+              summary:
+                description: |-
+                  Description provides human-readable context.
+                  TEST: JSON tag deliberately renamed from "description" to "summary" to
+                  validate that enforcement blocks the PR and that the api-break-allowed
+                  escape hatch unblocks it. Go field name is kept so existing callers
+                  still compile. Do NOT merge this PR.
                 type: string
             type: object
           status:
@@ -213,8 +218,13 @@ spec:
           spec:
             description: MCPGroupSpec defines the desired state of MCPGroup
             properties:
-              description:
-                description: Description provides human-readable context
+              summary:
+                description: |-
+                  Description provides human-readable context.
+                  TEST: JSON tag deliberately renamed from "description" to "summary" to
+                  validate that enforcement blocks the PR and that the api-break-allowed
+                  escape hatch unblocks it. Go field name is kept so existing callers
+                  still compile. Do NOT merge this PR.
                 type: string
             type: object
           status:

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpgroups.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpgroups.yaml
@@ -62,8 +62,13 @@ spec:
           spec:
             description: MCPGroupSpec defines the desired state of MCPGroup
             properties:
-              description:
-                description: Description provides human-readable context
+              summary:
+                description: |-
+                  Description provides human-readable context.
+                  TEST: JSON tag deliberately renamed from "description" to "summary" to
+                  validate that enforcement blocks the PR and that the api-break-allowed
+                  escape hatch unblocks it. Go field name is kept so existing callers
+                  still compile. Do NOT merge this PR.
                 type: string
             type: object
           status:
@@ -216,8 +221,13 @@ spec:
           spec:
             description: MCPGroupSpec defines the desired state of MCPGroup
             properties:
-              description:
-                description: Description provides human-readable context
+              summary:
+                description: |-
+                  Description provides human-readable context.
+                  TEST: JSON tag deliberately renamed from "description" to "summary" to
+                  validate that enforcement blocks the PR and that the api-break-allowed
+                  escape hatch unblocks it. Go field name is kept so existing callers
+                  still compile. Do NOT merge this PR.
                 type: string
             type: object
           status:


### PR DESCRIPTION
## ⚠️ DO NOT MERGE

Phase 2 enforcement validation. Pairs with #4988 (pre-enforcement) to close the loop: the same breaking change that previously only turned the check red should now **block the PR**, and applying `api-break-allowed` should unblock it.

**Close this PR** once the escape hatch has been demonstrated.

## What changed

Same surgical change as #4988: the JSON tag on `MCPGroupSpec.Description` is renamed from `"description"` to `"summary"`. Go field name stays, only the schema-visible key moves. `task operator-generate` + `task operator-manifests` regenerated the CRD YAML and Helm template.

## Test procedure

1. **Observe enforcement kicks in.**
   - `CRD Schema Compatibility` runs, reports 2× `NoFieldRemoval` on `mcpgroups` (`v1alpha1` and `v1beta1`).
   - Check run conclusion: `failure`.
   - Workflow conclusion: also `failure` (unlike #4988, there's no `continue-on-error` softening it).
   - `mergeStateStatus: BLOCKED` — the PR cannot be merged.

2. **Apply the escape hatch.**
   - Add the `api-break-allowed` label to the PR.
   - **Important caveat**: the workflow's `pull_request` trigger uses default types (`opened`, `synchronize`, `reopened`) — label changes don't trigger a re-run on their own. After labelling, do one of:
     - Push a new commit (e.g. `git commit --allow-empty -m trigger && git push`).
     - Close + reopen the PR.
     - Manually re-run the failed job from the Actions UI.
   - The workflow re-evaluates its `if:` guard: `!contains(labels.*.name, 'api-break-allowed')` is now false, so the `crd-schema-check` job is **skipped**.
   - GitHub treats a skipped required check as passing. `mergeStateStatus` flips to an unblocked state.

3. **Close the PR** without merging.

## Expected signals

| Stage | check conclusion | workflow conclusion | mergeStateStatus |
|---|---|---|---|
| Initial (no label) | `failure` | `failure` | `BLOCKED` |
| After label + re-trigger | `skipped` | `skipped` (or whatever the other jobs produce) | `CLEAN` or similar |

## Recommended follow-up (not this PR)

Add `types: [opened, synchronize, reopened, labeled, unlabeled]` to the `pull_request` trigger in `.github/workflows/api-compat.yml`. That would let the escape hatch work without the push/reopen/manual-rerun dance — applying the label alone would re-run the workflow and skip the job. Small, self-contained follow-up PR.

## Type of change

- [x] Other (test-only / CI validation)

## Test plan

- [x] `task operator-generate` / `task operator-manifests` regenerated cleanly
- [x] Both `v1alpha1` and `v1beta1` CRD versions now expose `spec.summary` instead of `spec.description`
- [x] Phase 1: CRD Schema Compatibility check fails, workflow fails, PR is BLOCKED
- [ ] Phase 2: after applying `api-break-allowed` and re-triggering, the job is skipped and the PR is no longer blocked by this check
- [ ] PR closed without merging

## API Compatibility

- [x] This PR does not break the `v1beta1` API, OR the `api-break-allowed` label is applied and the migration guidance is described above.

(This is a test PR. The "break" is intentional and will be reverted by closing the PR without merging. The checkbox above is for contributor-facing PRs; this PR deliberately trips the check to validate enforcement.)

## Does this introduce a user-facing change?

**No.** This PR will never be merged.

Generated with [Claude Code](https://claude.com/claude-code)