### PR TITLE
Re-run api-compat workflow on label changes

### DIFF
--- a/.github/workflows/api-compat.yml
+++ b/.github/workflows/api-compat.yml
@@ -10,6 +10,14 @@ name: API Compatibility
 
 on:
   pull_request:
+    # Include `labeled` and `unlabeled` so applying or removing
+    # `api-break-allowed` triggers a fresh workflow run. Without these,
+    # re-running the job from the UI uses the original event payload
+    # (which still has the old label set) and the skip condition misfires.
+    # Re-evaluating on `unlabeled` closes the gap where a user could
+    # apply the label, watch the check skip, then remove the label and
+    # merge without the check ever running against the current state.
+    types: [opened, synchronize, reopened, labeled, unlabeled]
     paths:
       - 'cmd/thv-operator/api/**'
       # files/crds is the source of truth — controller-gen emits here, and


### PR DESCRIPTION
## Summary

Phase 2 (#4991) added an `if:` guard on the `crd-schema-check` job that skips the check when the `api-break-allowed` label is applied. Testing on #4992 exposed a gap: applying the label and re-running the job from the Actions UI did **not** skip it, because re-runs use the original event payload — which has the labels as they were when the PR opened, not the current state.

This PR adds `labeled` and `unlabeled` to the workflow's `pull_request` trigger types so label changes fire a fresh workflow run with the current PR state. That closes the UX gap (escape hatch works with a single click, no empty-commit dance) and the security gap (unlabel also re-evaluates, so an apply-skip-unlabel-merge attack is blocked).

Follows up on #4991.

## How it works

`pull_request` workflows default to `types: [opened, synchronize, reopened]`. Under that default, only code-level activity on the branch fires the workflow. Labels, reviews, assignees, and milestones don't trigger re-runs at all.

This PR extends the types list to include `labeled` and `unlabeled`. With that, GitHub fires a new `pull_request` event whenever a label is added or removed. The new event carries the **current** PR state in its payload — including the current labels array — and the `if:` guard's `contains()` call sees the label and correctly skips the job.

`unlabeled` is included for symmetry and safety:
- **UX**: if a user applies the label by mistake and then removes it, the check re-runs and validates correctly against the current state.
- **Security**: without `unlabeled`, someone could apply the label, see the check skip, then remove the label and merge — the check would never have run against the actual breaking change. Re-evaluating on label removal forces the check to validate if the label goes away.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation
- [ ] Other

## Test plan

- [x] Workflow YAML parses cleanly.
- [x] Testing on #4992 (pre-fix): empty-commit retrigger correctly skipped the job. This confirms the `if:` guard logic is sound; the only gap is the trigger.
- [ ] After merge: verify by opening a new test PR with a breaking change, applying the label, and confirming the workflow re-runs automatically and skips the job with no additional action.

## API Compatibility

- [x] This PR does not break the `v1beta1` API.

## Does this introduce a user-facing change?

No. Internal CI only. Contributors applying `api-break-allowed` will see the check re-run and skip automatically, instead of needing to push a commit to retrigger it.

## Special notes for reviewers

- **`labeled` is cheap.** It only fires a workflow if the PR touches one of the paths in the filter, so labelling an unrelated PR doesn't trigger runs.
- **`unlabeled` is not optional.** Dropping it leaves a race where a contributor could apply-skip-unlabel-merge without the check ever validating against the final state. The two types need to move together.
- **No changes to the `if:` condition itself** — that logic was correct all along; only the trigger needed expanding.

Generated with [Claude Code](https://claude.com/claude-code)