### PR TITLE
Add no-op companion for API Compatibility required check

### DIFF
--- a/.github/workflows/api-compat-noop.yml
+++ b/.github/workflows/api-compat-noop.yml
@@ -1,0 +1,37 @@
+name: API Compatibility
+
+# No-op companion to api-compat.yml. Its sole purpose is to satisfy the
+# required `CRD Schema Compatibility` status check on PRs that don't touch
+# any operator API surface. Without this companion, such PRs deadlock:
+# branch protection requires the check, the real workflow's path filter
+# prevents it from firing, and GitHub shows the required status as
+# "expected — waiting to be reported" forever.
+#
+# The workflow `name:` and job `name:` intentionally mirror api-compat.yml
+# so the check-run context string matches (`CRD Schema Compatibility`).
+# GitHub's branch protection treats a successful report from either
+# workflow as satisfying the requirement.
+#
+# The `paths-ignore` list is the exact inverse of api-compat.yml's
+# `paths:` include list. Keep them in sync: a path that moves from one
+# list needs to move from the other, or PRs touching that path will
+# either run both workflows (double-count) or neither (deadlock returns).
+
+on:
+  pull_request:
+    paths-ignore:
+      - 'cmd/thv-operator/api/**'
+      - 'deploy/charts/operator-crds/files/crds/**'
+      - '.github/workflows/api-compat*.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  crd-schema-check:
+    name: CRD Schema Compatibility
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: No API surface changes
+        run: echo "This PR does not touch operator API surface; no compatibility check needed."

--- a/.github/workflows/api-compat.yml
+++ b/.github/workflows/api-compat.yml
@@ -27,8 +27,10 @@ on:
       # crd-helm-wrapper only affect Helm conditionals and annotations the
       # checker ignores, so they can't change what we compare.
       - 'deploy/charts/operator-crds/files/crds/**'
-      # Self-exercise the workflow when the workflow itself changes.
-      - '.github/workflows/api-compat.yml'
+      # Self-exercise when either workflow file (real or no-op companion)
+      # changes. The companion file reports the same required check on
+      # PRs that don't touch the api surface; see api-compat-noop.yml.
+      - '.github/workflows/api-compat*.yml'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Branch protection on `main` requires `CRD Schema Compatibility` to pass. The real workflow (`api-compat.yml`, introduced in #4980 and refined in #4987, #4991, #4993) is filtered to PRs touching `cmd/thv-operator/api/**`, `deploy/charts/operator-crds/files/crds/**`, or the workflow itself — correct in isolation, but it deadlocks every PR that doesn't touch those paths: the workflow never fires, the required check never reports, GitHub marks it as "expected — waiting to be reported" indefinitely, and the PR cannot merge.

Example: #4942 (a status-helper refactor that touches zero API surface) is currently blocked on this.

This PR adds a companion no-op workflow that satisfies the required check on PRs that don't touch the api surface.

## How it works

`.github/workflows/api-compat-noop.yml` uses the same workflow `name:` (`API Compatibility`) and job `name:` (`CRD Schema Compatibility`) as the real workflow, so the resulting check-run context string is identical. Branch protection treats a successful report from either workflow as satisfying the requirement.

The two workflows use strictly complementary path filters:

| File | Filter | Fires when |
|---|---|---|
| `api-compat.yml` | `paths:` include the api-surface paths + `api-compat*.yml` | PR touches any api-surface file or either workflow file |
| `api-compat-noop.yml` | `paths-ignore:` same list | PR touches nothing in that list |

The real workflow also gets a small change: its self-watch path broadens from `.github/workflows/api-compat.yml` to `.github/workflows/api-compat*.yml`, so edits to either workflow fire the real check (and the companion skips via `paths-ignore`, avoiding a double-fire on workflow edits).

## Caveats

1. **This PR unblocks itself.** The edit to `api-compat.yml` matches the real workflow's `paths:` filter, so the real check fires on this very PR. No CRDs changed, so it reports Compatible and the PR is mergeable without the companion needing to exist yet.

2. **Currently-blocked PRs need a resync after merge.** #4942 (and any other PR stuck on the same deadlock) will remain stuck until someone pushes a commit, rebases onto main, or reopens the PR — that's what causes the branch-protection status to re-evaluate against the newly-merged companion. The fix does not unblock retroactively.

3. **Keep the paths lists in sync.** If someone adds a new path to the real workflow's `paths:`, the same path must be added to the companion's `paths-ignore:` (and vice versa). Drift causes either a deadlock (path removed from `paths-ignore` but still in `paths`) or a double-fire (added to one without the other). The companion workflow's header comment calls this out explicitly.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation
- [ ] Other

## Test plan

- [x] Both workflow YAML files parse cleanly (`python3 -c 'import yaml; yaml.safe_load(...)'`).
- [x] The real workflow's self-watch now matches `api-compat*.yml`, so this PR triggers the real check (no CRD changes → Compatible).
- [x] The companion's `paths-ignore` list is byte-identical to the real workflow's `paths` list (modulo the `api-compat*.yml` glob covering both workflow files).
- [ ] After merge: verify #4942 becomes mergeable after a resync (either a rebase onto main or any fresh push).
- [ ] After merge: verify a fresh PR touching only a Go file outside `cmd/thv-operator/api/` sees the companion workflow run to completion in seconds and reports `CRD Schema Compatibility` as success.
- [ ] Unit tests (`task test`) — N/A, no Go changes.
- [ ] Linting (`task lint-fix`) — N/A, no Go changes.

## API Compatibility

- [x] This PR does not break the `v1beta1` API.

## Does this introduce a user-facing change?

No. Internal CI only. Contributors who previously saw PRs deadlock on the required status check will now see the check report success in seconds when their PR doesn't touch api surface.

## Special notes for reviewers

- **Why a whole second workflow file.** The canonical GitHub-recommended pattern for path-filtered required checks. Alternatives like `dorny/paths-filter` inside the main workflow trade the simpler file for more machinery; given this is a 30-line no-op, the two-file approach is cleaner.
- **Job `timeout-minutes: 2`.** The no-op is a single `echo` — it should complete in well under a second. The 2-minute bound protects against runner starvation.
- **Check-name sensitivity.** If either workflow's `job.name:` is ever renamed, both must move together, *and* the branch-protection required-check list must be updated to the new name. The current name `CRD Schema Compatibility` is load-bearing.

Generated with [Claude Code](https://claude.com/claude-code)