### PR TITLE
Classify OCI pull errors and fall back to git for skills content API

### DIFF
--- a/docs/server/docs.go
+++ b/docs/server/docs.go
@@ -5409,6 +5409,26 @@ const docTemplate = `{
                         },
                         "description": "Bad Request"
                     },
+                    "401": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Unauthorized (registry refused credentials)"
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Not Found (artifact not present in registry)"
+                    },
                     "409": {
                         "content": {
                             "application/json": {
@@ -5418,6 +5438,16 @@ const docTemplate = `{
                             }
                         },
                         "description": "Conflict"
+                    },
+                    "429": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Too Many Requests (registry rate limit)"
                     },
                     "500": {
                         "content": {
@@ -5437,7 +5467,17 @@ const docTemplate = `{
                                 }
                             }
                         },
-                        "description": "Bad Gateway"
+                        "description": "Bad Gateway (upstream registry failure)"
+                    },
+                    "504": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Gateway Timeout (upstream pull timed out)"
                     }
                 },
                 "summary": "Install a skill",
@@ -5625,6 +5665,36 @@ const docTemplate = `{
                         },
                         "description": "Bad Request"
                     },
+                    "401": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Unauthorized (registry refused credentials)"
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Not Found (artifact not present in registry)"
+                    },
+                    "429": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Too Many Requests (registry rate limit)"
+                    },
                     "500": {
                         "content": {
                             "application/json": {
@@ -5643,7 +5713,17 @@ const docTemplate = `{
                                 }
                             }
                         },
-                        "description": "Bad Gateway"
+                        "description": "Bad Gateway (upstream registry or git resolver failure)"
+                    },
+                    "504": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Gateway Timeout (upstream pull timed out)"
                     }
                 },
                 "summary": "Get skill content",

--- a/docs/server/swagger.json
+++ b/docs/server/swagger.json
@@ -5402,6 +5402,26 @@
                         },
                         "description": "Bad Request"
                     },
+                    "401": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Unauthorized (registry refused credentials)"
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Not Found (artifact not present in registry)"
+                    },
                     "409": {
                         "content": {
                             "application/json": {
@@ -5411,6 +5431,16 @@
                             }
                         },
                         "description": "Conflict"
+                    },
+                    "429": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Too Many Requests (registry rate limit)"
                     },
                     "500": {
                         "content": {
@@ -5430,7 +5460,17 @@
                                 }
                             }
                         },
-                        "description": "Bad Gateway"
+                        "description": "Bad Gateway (upstream registry failure)"
+                    },
+                    "504": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Gateway Timeout (upstream pull timed out)"
                     }
                 },
                 "summary": "Install a skill",
@@ -5618,6 +5658,36 @@
                         },
                         "description": "Bad Request"
                     },
+                    "401": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Unauthorized (registry refused credentials)"
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Not Found (artifact not present in registry)"
+                    },
+                    "429": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Too Many Requests (registry rate limit)"
+                    },
                     "500": {
                         "content": {
                             "application/json": {
@@ -5636,7 +5706,17 @@
                                 }
                             }
                         },
-                        "description": "Bad Gateway"
+                        "description": "Bad Gateway (upstream registry or git resolver failure)"
+                    },
+                    "504": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Gateway Timeout (upstream pull timed out)"
                     }
                 },
                 "summary": "Get skill content",

--- a/docs/server/swagger.yaml
+++ b/docs/server/swagger.yaml
@@ -4324,12 +4324,30 @@ paths:
               schema:
                 type: string
           description: Bad Request
+        "401":
+          content:
+            application/json:
+              schema:
+                type: string
+          description: Unauthorized (registry refused credentials)
+        "404":
+          content:
+            application/json:
+              schema:
+                type: string
+          description: Not Found (artifact not present in registry)
         "409":
           content:
             application/json:
               schema:
                 type: string
           description: Conflict
+        "429":
+          content:
+            application/json:
+              schema:
+                type: string
+          description: Too Many Requests (registry rate limit)
         "500":
           content:
             application/json:
@@ -4341,7 +4359,13 @@ paths:
             application/json:
               schema:
                 type: string
-          description: Bad Gateway
+          description: Bad Gateway (upstream registry failure)
+        "504":
+          content:
+            application/json:
+              schema:
+                type: string
+          description: Gateway Timeout (upstream pull timed out)
       summary: Install a skill
       tags:
       - skills
@@ -4560,6 +4584,24 @@ paths:
               schema:
                 type: string
           description: Bad Request
+        "401":
+          content:
+            application/json:
+              schema:
+                type: string
+          description: Unauthorized (registry refused credentials)
+        "404":
+          content:
+            application/json:
+              schema:
+                type: string
+          description: Not Found (artifact not present in registry)
+        "429":
+          content:
+            application/json:
+              schema:
+                type: string
+          description: Too Many Requests (registry rate limit)
         "500":
           content:
             application/json:
@@ -4571,7 +4613,13 @@ paths:
             application/json:
               schema:
                 type: string
-          description: Bad Gateway
+          description: Bad Gateway (upstream registry or git resolver failure)
+        "504":
+          content:
+            application/json:
+              schema:
+                type: string
+          description: Gateway Timeout (upstream pull timed out)
       summary: Get skill content
       tags:
       - skills

--- a/pkg/api/errors/handler.go
+++ b/pkg/api/errors/handler.go
@@ -44,7 +44,11 @@ func ErrorHandler(fn HandlerWithError) http.HandlerFunc {
 		// Extract HTTP status code from the error
 		code := httperr.Code(err)
 
-		// For 5xx errors, log the full error but return a generic message
+		// For 5xx errors, log the full error and report it to Sentry/OTel.
+		// 500 Internal Server Error may wrap internal details (DB drivers,
+		// container runtimes, connection strings) so we return only the
+		// generic status text. 502/503/504 represent upstream failures the
+		// caller can act on — their messages are safe to return verbatim.
 		if code >= http.StatusInternalServerError {
 			slog.Error("internal server error", "error", err)
 			span := trace.SpanFromContext(r.Context())
@@ -56,11 +60,27 @@ func ErrorHandler(fn HandlerWithError) http.HandlerFunc {
 			// Sentry span processor only creates transactions; call CaptureException
 			// explicitly so 5xx errors also appear as Issues in the Sentry Issues tab.
 			sentrypkg.CaptureException(r, err)
+
+			if isUpstreamStatus(code) {
+				http.Error(w, err.Error(), code)
+				return
+			}
 			http.Error(w, http.StatusText(code), code)
 			return
 		}
 
 		// For 4xx errors, return the error message to the client
 		http.Error(w, err.Error(), code)
+	}
+}
+
+// isUpstreamStatus reports whether code represents an upstream/gateway
+// failure whose error message can safely be returned to the client.
+func isUpstreamStatus(code int) bool {
+	switch code {
+	case http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout:
+		return true
+	default:
+		return false
 	}
 }

--- a/pkg/api/errors/handler_test.go
+++ b/pkg/api/errors/handler_test.go
@@ -116,6 +116,64 @@ func TestErrorHandler(t *testing.T) {
 		require.Contains(t, rec.Body.String(), "Internal Server Error")
 	})
 
+	t.Run("surfaces 502 upstream error message to client", func(t *testing.T) {
+		t.Parallel()
+
+		handler := ErrorHandler(func(_ http.ResponseWriter, _ *http.Request) error {
+			return httperr.WithCode(
+				fmt.Errorf("pulling OCI artifact %q: registry returned 401", "ghcr.io/org/skill:v1"),
+				http.StatusBadGateway,
+			)
+		})
+
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		rec := httptest.NewRecorder()
+
+		handler.ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusBadGateway, rec.Code)
+		require.Contains(t, rec.Body.String(), "pulling OCI artifact")
+		require.Contains(t, rec.Body.String(), "registry returned 401")
+	})
+
+	t.Run("surfaces 503 upstream error message to client", func(t *testing.T) {
+		t.Parallel()
+
+		handler := ErrorHandler(func(_ http.ResponseWriter, _ *http.Request) error {
+			return httperr.WithCode(
+				fmt.Errorf("downstream service unavailable"),
+				http.StatusServiceUnavailable,
+			)
+		})
+
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		rec := httptest.NewRecorder()
+
+		handler.ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusServiceUnavailable, rec.Code)
+		require.Contains(t, rec.Body.String(), "downstream service unavailable")
+	})
+
+	t.Run("surfaces 504 gateway timeout message to client", func(t *testing.T) {
+		t.Parallel()
+
+		handler := ErrorHandler(func(_ http.ResponseWriter, _ *http.Request) error {
+			return httperr.WithCode(
+				fmt.Errorf("upstream deadline exceeded while pulling %q", "ghcr.io/org/skill:v1"),
+				http.StatusGatewayTimeout,
+			)
+		})
+
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		rec := httptest.NewRecorder()
+
+		handler.ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusGatewayTimeout, rec.Code)
+		require.Contains(t, rec.Body.String(), "upstream deadline exceeded")
+	})
+
 	t.Run("error without code defaults to 500 with generic message", func(t *testing.T) {
 		t.Parallel()
 

--- a/pkg/api/v1/skills.go
+++ b/pkg/api/v1/skills.go
@@ -85,9 +85,13 @@ func (s *SkillsRoutes) listSkills(w http.ResponseWriter, r *http.Request) error 
 //	@Success		201		{object}	installSkillResponse
 //	@Header			201		{string}	Location	"URI of the installed skill resource"
 //	@Failure		400		{string}	string		"Bad Request"
+//	@Failure		401		{string}	string		"Unauthorized (registry refused credentials)"
+//	@Failure		404		{string}	string		"Not Found (artifact not present in registry)"
 //	@Failure		409		{string}	string		"Conflict"
+//	@Failure		429		{string}	string		"Too Many Requests (registry rate limit)"
 //	@Failure		500		{string}	string		"Internal Server Error"
-//	@Failure		502		{string}	string		"Bad Gateway"
+//	@Failure		502		{string}	string		"Bad Gateway (upstream registry failure)"
+//	@Failure		504		{string}	string		"Gateway Timeout (upstream pull timed out)"
 //	@Router			/api/v1beta/skills [post]
 func (s *SkillsRoutes) installSkill(w http.ResponseWriter, r *http.Request) error {
 	var req installSkillRequest
@@ -335,8 +339,12 @@ func (s *SkillsRoutes) deleteBuild(w http.ResponseWriter, r *http.Request) error
 //	@Param			ref	query		string	true	"OCI reference or local build tag"
 //	@Success		200	{object}	skills.SkillContent
 //	@Failure		400	{string}	string	"Bad Request"
-//	@Failure		502	{string}	string	"Bad Gateway"
+//	@Failure		401	{string}	string	"Unauthorized (registry refused credentials)"
+//	@Failure		404	{string}	string	"Not Found (artifact not present in registry)"
+//	@Failure		429	{string}	string	"Too Many Requests (registry rate limit)"
 //	@Failure		500	{string}	string	"Internal Server Error"
+//	@Failure		502	{string}	string	"Bad Gateway (upstream registry or git resolver failure)"
+//	@Failure		504	{string}	string	"Gateway Timeout (upstream pull timed out)"
 //	@Router			/api/v1beta/skills/content [get]
 func (s *SkillsRoutes) getSkillContent(w http.ResponseWriter, r *http.Request) error {
 	ref := r.URL.Query().Get("ref")

--- a/pkg/skills/skillsvc/content.go
+++ b/pkg/skills/skillsvc/content.go
@@ -69,21 +69,21 @@ func (s *service) GetContent(ctx context.Context, opts skills.ContentOptions) (*
 	//     registry resolution which preferred OCI → git.
 	if parsedRef, isOCI, parseErr := parseOCIReference(ref); parseErr == nil && isOCI &&
 		isUnambiguousOCIRef(ref, parsedRef) {
-		if gitURL, _ := s.resolveGitFallbackForOCIRef(parsedRef); gitURL != "" {
+		if gitURL := s.resolveGitFallbackForOCIRef(parsedRef); gitURL != "" {
 			slog.Info(
 				"OCI content fetch failed; falling back to git package declared in registry entry",
 				"oci_ref", ref,
 				"git_url", gitURL,
 				"oci_error", ociErr,
 			)
-			if c, gitErr := s.getContentFromGit(ctx, gitURL); gitErr == nil {
+			c, gitErr := s.getContentFromGit(ctx, gitURL)
+			if gitErr == nil {
 				return c, nil
-			} else {
-				return nil, fmt.Errorf(
-					"OCI pull failed (%w); registry git fallback also failed: %v",
-					ociErr, gitErr,
-				)
 			}
+			return nil, fmt.Errorf(
+				"OCI pull failed (%w); registry git fallback also failed: %v",
+				ociErr, gitErr,
+			)
 		}
 		return nil, ociErr
 	}

--- a/pkg/skills/skillsvc/content.go
+++ b/pkg/skills/skillsvc/content.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"strings"
@@ -57,14 +58,36 @@ func (s *service) GetContent(ctx context.Context, opts skills.ContentOptions) (*
 		return content, nil
 	}
 
-	// OCI failed — try resolving via registry name lookup (e.g. "skill-creator"
-	// or "io.github.stacklok/skill-creator" from the catalog index). Skip for
-	// refs that are unambiguously OCI (digest, explicit tag, or multi-segment
-	// path) to avoid a wasted network round-trip.
+	// OCI failed. The fallback strategy depends on how the caller referenced
+	// the skill:
+	//
+	//   - Unambiguous OCI refs (tag/digest/multi-segment path) — try a
+	//     registry lookup *by OCI identifier* to find the same skill's git
+	//     package, so an ephemeral OCI outage can transparently fall back to
+	//     git when the registry catalog has both.
+	//   - Ambiguous refs (plain skill name) — use the existing name-based
+	//     registry resolution which preferred OCI → git.
 	if parsedRef, isOCI, parseErr := parseOCIReference(ref); parseErr == nil && isOCI &&
 		isUnambiguousOCIRef(ref, parsedRef) {
+		if gitURL, _ := s.resolveGitFallbackForOCIRef(parsedRef); gitURL != "" {
+			slog.Info(
+				"OCI content fetch failed; falling back to git package declared in registry entry",
+				"oci_ref", ref,
+				"git_url", gitURL,
+				"oci_error", ociErr,
+			)
+			if c, gitErr := s.getContentFromGit(ctx, gitURL); gitErr == nil {
+				return c, nil
+			} else {
+				return nil, fmt.Errorf(
+					"OCI pull failed (%w); registry git fallback also failed: %v",
+					ociErr, gitErr,
+				)
+			}
+		}
 		return nil, ociErr
 	}
+
 	resolved, regErr := s.resolveFromRegistry(ref)
 	if regErr != nil {
 		return nil, regErr
@@ -176,7 +199,7 @@ func (s *service) getContentFromOCI(ctx context.Context, ref string) (*skills.Sk
 		if pullErr != nil {
 			return nil, httperr.WithCode(
 				fmt.Errorf("pulling OCI artifact %q: %w", qualifiedRef, pullErr),
-				http.StatusBadGateway,
+				classifyPullError(pullErr),
 			)
 		}
 	}

--- a/pkg/skills/skillsvc/content_test.go
+++ b/pkg/skills/skillsvc/content_test.go
@@ -298,6 +298,247 @@ func TestGetContent(t *testing.T) {
 		assert.Empty(t, builds, "content API must not leak pulled artifacts into ListBuilds")
 	})
 
+	t.Run("unambiguous OCI falls back to registry-declared git package on pull failure", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+
+		ociStore, err := ociskills.NewStore(t.TempDir())
+		require.NoError(t, err)
+
+		reg := ocimocks.NewMockRegistryClient(ctrl)
+		reg.EXPECT().Pull(gomock.Any(), ociStore, "ghcr.io/stacklok/dockyard/skills/yara-rule-authoring:0.1.0").
+			Return(godigest.Digest(""), fmt.Errorf("registry unreachable"))
+
+		// Registry entry has both an OCI package (the one we just failed to
+		// pull) and a git package with pinned commit. The fallback should
+		// reach the git resolver.
+		lookup := regmocks.NewMockProvider(ctrl)
+		lookup.EXPECT().SearchSkills("yara-rule-authoring").Return([]regtypes.Skill{
+			{
+				Namespace: "io.github.stacklok",
+				Name:      "yara-rule-authoring",
+				Packages: []regtypes.SkillPackage{
+					{
+						RegistryType: "oci",
+						Identifier:   "ghcr.io/stacklok/dockyard/skills/yara-rule-authoring:0.1.0",
+					},
+					{
+						RegistryType: "git",
+						URL:          "https://github.com/trailofbits/skills",
+						Ref:          "e8cc5baf9329ccb491bfa200e82eacbac83b1ead",
+						Subfolder:    "plugins/yara-authoring/skills/yara-rule-authoring",
+					},
+				},
+			},
+		}, nil)
+
+		gr := gitmocks.NewMockResolver(ctrl)
+		gr.EXPECT().Resolve(gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ context.Context, ref *gitresolver.GitReference) (*gitresolver.ResolveResult, error) {
+				// Verify the fallback pinned ref and subfolder. Scheme depends on
+				// TOOLHIVE_DEV (http in dev, https in prod) so we only assert the
+				// suffix here.
+				assert.True(t, strings.HasSuffix(ref.URL, "://github.com/trailofbits/skills"),
+					"unexpected clone URL %q", ref.URL)
+				assert.Equal(t, "e8cc5baf9329ccb491bfa200e82eacbac83b1ead", ref.Ref)
+				assert.Equal(t, "plugins/yara-authoring/skills/yara-rule-authoring", ref.Path)
+				return &gitresolver.ResolveResult{
+					SkillConfig: &skills.ParseResult{
+						Name: "yara-rule-authoring",
+						Body: []byte("# YARA Rule Authoring"),
+					},
+					Files:      []gitresolver.FileEntry{{Path: "SKILL.md", Content: []byte("# YARA"), Mode: 0644}},
+					CommitHash: testCommitHash,
+				}, nil
+			})
+
+		svc := New(&storage.NoopSkillStore{},
+			WithOCIStore(ociStore),
+			WithRegistryClient(reg),
+			WithSkillLookup(lookup),
+			WithGitResolver(gr),
+		)
+		content, err := svc.GetContent(t.Context(), skills.ContentOptions{
+			Reference: "ghcr.io/stacklok/dockyard/skills/yara-rule-authoring:0.1.0",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "yara-rule-authoring", content.Name)
+		assert.Contains(t, content.Body, "YARA Rule Authoring")
+	})
+
+	t.Run("registry fallback tolerates different OCI version tag", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+
+		ociStore, err := ociskills.NewStore(t.TempDir())
+		require.NoError(t, err)
+
+		reg := ocimocks.NewMockRegistryClient(ctrl)
+		reg.EXPECT().Pull(gomock.Any(), ociStore, "ghcr.io/org/my-skill:v9").
+			Return(godigest.Digest(""), fmt.Errorf("manifest unknown"))
+
+		// The registry entry records :0.1.0 while the caller asked for :v9.
+		// Both resolve to the same repository path so the fallback must fire.
+		lookup := regmocks.NewMockProvider(ctrl)
+		lookup.EXPECT().SearchSkills("my-skill").Return([]regtypes.Skill{
+			{
+				Namespace: "io.github.example",
+				Name:      "my-skill",
+				Packages: []regtypes.SkillPackage{
+					{RegistryType: "oci", Identifier: "ghcr.io/org/my-skill:0.1.0"},
+					{RegistryType: "git", URL: "https://github.com/example/repo"},
+				},
+			},
+		}, nil)
+
+		gr := gitmocks.NewMockResolver(ctrl)
+		gr.EXPECT().Resolve(gomock.Any(), gomock.Any()).Return(&gitresolver.ResolveResult{
+			SkillConfig: &skills.ParseResult{Name: "my-skill", Body: []byte("# git fallback")},
+			Files:       []gitresolver.FileEntry{{Path: "SKILL.md", Content: []byte("# x"), Mode: 0644}},
+			CommitHash:  testCommitHash,
+		}, nil)
+
+		svc := New(&storage.NoopSkillStore{},
+			WithOCIStore(ociStore),
+			WithRegistryClient(reg),
+			WithSkillLookup(lookup),
+			WithGitResolver(gr),
+		)
+		content, err := svc.GetContent(t.Context(), skills.ContentOptions{Reference: "ghcr.io/org/my-skill:v9"})
+		require.NoError(t, err)
+		assert.Equal(t, "my-skill", content.Name)
+	})
+
+	t.Run("OCI failure with registry match but no git package returns original error", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+
+		ociStore, err := ociskills.NewStore(t.TempDir())
+		require.NoError(t, err)
+
+		reg := ocimocks.NewMockRegistryClient(ctrl)
+		reg.EXPECT().Pull(gomock.Any(), ociStore, "ghcr.io/org/my-skill:v1").
+			Return(godigest.Digest(""), fmt.Errorf("registry offline"))
+
+		// Registry entry matches but only has an OCI package.
+		lookup := regmocks.NewMockProvider(ctrl)
+		lookup.EXPECT().SearchSkills("my-skill").Return([]regtypes.Skill{
+			{
+				Namespace: "io.github.example",
+				Name:      "my-skill",
+				Packages: []regtypes.SkillPackage{
+					{RegistryType: "oci", Identifier: "ghcr.io/org/my-skill:v1"},
+				},
+			},
+		}, nil)
+
+		// Git resolver must NOT be invoked.
+		svc := New(&storage.NoopSkillStore{},
+			WithOCIStore(ociStore),
+			WithRegistryClient(reg),
+			WithSkillLookup(lookup),
+		)
+		_, err = svc.GetContent(t.Context(), skills.ContentOptions{Reference: "ghcr.io/org/my-skill:v1"})
+		require.Error(t, err)
+		assert.Equal(t, http.StatusBadGateway, httperr.Code(err))
+		assert.Contains(t, err.Error(), "registry offline")
+	})
+
+	t.Run("OCI failure with ambiguous registry matches skips git fallback", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+
+		ociStore, err := ociskills.NewStore(t.TempDir())
+		require.NoError(t, err)
+
+		reg := ocimocks.NewMockRegistryClient(ctrl)
+		reg.EXPECT().Pull(gomock.Any(), ociStore, "ghcr.io/org/my-skill:v1").
+			Return(godigest.Digest(""), fmt.Errorf("registry offline"))
+
+		// Two registry entries both point at the same repo path — ambiguous.
+		// We refuse to guess and propagate the original OCI error.
+		lookup := regmocks.NewMockProvider(ctrl)
+		lookup.EXPECT().SearchSkills("my-skill").Return([]regtypes.Skill{
+			{
+				Namespace: "io.github.alice",
+				Name:      "my-skill",
+				Packages: []regtypes.SkillPackage{
+					{RegistryType: "oci", Identifier: "ghcr.io/org/my-skill:v1"},
+					{RegistryType: "git", URL: "https://github.com/alice/repo"},
+				},
+			},
+			{
+				Namespace: "io.github.bob",
+				Name:      "my-skill",
+				Packages: []regtypes.SkillPackage{
+					{RegistryType: "oci", Identifier: "ghcr.io/org/my-skill:v2"},
+					{RegistryType: "git", URL: "https://github.com/bob/repo"},
+				},
+			},
+		}, nil)
+
+		// Git resolver must NOT be invoked.
+		svc := New(&storage.NoopSkillStore{},
+			WithOCIStore(ociStore),
+			WithRegistryClient(reg),
+			WithSkillLookup(lookup),
+		)
+		_, err = svc.GetContent(t.Context(), skills.ContentOptions{Reference: "ghcr.io/org/my-skill:v1"})
+		require.Error(t, err)
+		assert.Equal(t, http.StatusBadGateway, httperr.Code(err))
+		assert.Contains(t, err.Error(), "registry offline")
+	})
+
+	t.Run("OCI success skips registry lookup entirely", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+
+		ociStore, err := ociskills.NewStore(t.TempDir())
+		require.NoError(t, err)
+		indexDigest := buildTestArtifact(t, ociStore, "my-skill", "2.0.0")
+
+		reg := ocimocks.NewMockRegistryClient(ctrl)
+		reg.EXPECT().Pull(gomock.Any(), ociStore, "ghcr.io/org/my-skill:v2").
+			Return(indexDigest, nil)
+
+		// lookup mock with NO expectations — gomock will fail the test if
+		// SearchSkills is ever invoked.
+		lookup := regmocks.NewMockProvider(ctrl)
+
+		svc := New(&storage.NoopSkillStore{},
+			WithOCIStore(ociStore),
+			WithRegistryClient(reg),
+			WithSkillLookup(lookup),
+		)
+		_, err = svc.GetContent(t.Context(), skills.ContentOptions{Reference: "ghcr.io/org/my-skill:v2"})
+		require.NoError(t, err)
+	})
+
+	t.Run("registry lookup error treated as no fallback, returns original OCI error", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+
+		ociStore, err := ociskills.NewStore(t.TempDir())
+		require.NoError(t, err)
+
+		reg := ocimocks.NewMockRegistryClient(ctrl)
+		reg.EXPECT().Pull(gomock.Any(), ociStore, "ghcr.io/org/my-skill:v1").
+			Return(godigest.Digest(""), fmt.Errorf("registry offline"))
+
+		lookup := regmocks.NewMockProvider(ctrl)
+		lookup.EXPECT().SearchSkills("my-skill").Return(nil, fmt.Errorf("registry index unreachable"))
+
+		svc := New(&storage.NoopSkillStore{},
+			WithOCIStore(ociStore),
+			WithRegistryClient(reg),
+			WithSkillLookup(lookup),
+		)
+		_, err = svc.GetContent(t.Context(), skills.ContentOptions{Reference: "ghcr.io/org/my-skill:v1"})
+		require.Error(t, err)
+		assert.Equal(t, http.StatusBadGateway, httperr.Code(err))
+		assert.Contains(t, err.Error(), "registry offline")
+	})
+
 	t.Run("qualified namespace/name filters registry matches", func(t *testing.T) {
 		t.Parallel()
 		ctrl := gomock.NewController(t)

--- a/pkg/skills/skillsvc/install_oci.go
+++ b/pkg/skills/skillsvc/install_oci.go
@@ -61,7 +61,7 @@ func (s *service) installFromOCI(
 	if err != nil {
 		return nil, httperr.WithCode(
 			fmt.Errorf("pulling OCI artifact %q: %w", ociRef, err),
-			http.StatusBadGateway,
+			classifyPullError(err),
 		)
 	}
 

--- a/pkg/skills/skillsvc/pull_errors.go
+++ b/pkg/skills/skillsvc/pull_errors.go
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package skillsvc
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"oras.land/oras-go/v2/errdef"
+	"oras.land/oras-go/v2/registry/remote/errcode"
+)
+
+// classifyPullError maps an error returned by Registry.Pull (which wraps
+// oras.Copy) into an HTTP status code that best describes the failure to a
+// caller. The classifier inspects:
+//
+//   - context.DeadlineExceeded / context.Canceled — mapped to 504 so callers
+//     can distinguish upstream slowness from a registry-side rejection.
+//   - *errcode.ErrorResponse (HTTP error from the remote registry) — mapped
+//     by StatusCode: 401/403 → 401, 404 → 404, 429 → 429, other 4xx → 502,
+//     5xx → 502.
+//   - errdef.ErrNotFound — mapped to 404 (covers cases where oras surfaces
+//     not-found as a sentinel rather than an ErrorResponse).
+//
+// Anything else is treated as a generic 502 Bad Gateway.
+//
+// The returned code is always in the 4xx or 5xx range; callers wrap the
+// original error with httperr.WithCode(code) so the ErrorHandler renders an
+// appropriate response.
+func classifyPullError(err error) int {
+	if err == nil {
+		return http.StatusOK
+	}
+
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+		return http.StatusGatewayTimeout
+	}
+
+	var httpErr *errcode.ErrorResponse
+	if errors.As(err, &httpErr) {
+		switch httpErr.StatusCode {
+		case http.StatusUnauthorized, http.StatusForbidden:
+			return http.StatusUnauthorized
+		case http.StatusNotFound:
+			return http.StatusNotFound
+		case http.StatusTooManyRequests:
+			return http.StatusTooManyRequests
+		}
+		// Other 4xx and 5xx registry responses are treated as generic
+		// upstream failures.
+		return http.StatusBadGateway
+	}
+
+	if errors.Is(err, errdef.ErrNotFound) {
+		return http.StatusNotFound
+	}
+
+	return http.StatusBadGateway
+}

--- a/pkg/skills/skillsvc/pull_errors_test.go
+++ b/pkg/skills/skillsvc/pull_errors_test.go
@@ -1,0 +1,128 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package skillsvc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"oras.land/oras-go/v2/errdef"
+	"oras.land/oras-go/v2/registry/remote/errcode"
+)
+
+func TestClassifyPullError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want int
+	}{
+		{
+			name: "nil error returns 200",
+			err:  nil,
+			want: http.StatusOK,
+		},
+		{
+			name: "context deadline exceeded maps to 504",
+			err:  context.DeadlineExceeded,
+			want: http.StatusGatewayTimeout,
+		},
+		{
+			name: "wrapped context deadline exceeded maps to 504",
+			err:  fmt.Errorf("pulling OCI artifact: %w", context.DeadlineExceeded),
+			want: http.StatusGatewayTimeout,
+		},
+		{
+			name: "context canceled maps to 504",
+			err:  context.Canceled,
+			want: http.StatusGatewayTimeout,
+		},
+		{
+			name: "registry 401 maps to 401",
+			err:  newErrResp(http.StatusUnauthorized),
+			want: http.StatusUnauthorized,
+		},
+		{
+			name: "registry 403 maps to 401",
+			err:  newErrResp(http.StatusForbidden),
+			want: http.StatusUnauthorized,
+		},
+		{
+			name: "registry 404 maps to 404",
+			err:  newErrResp(http.StatusNotFound),
+			want: http.StatusNotFound,
+		},
+		{
+			name: "registry 429 maps to 429",
+			err:  newErrResp(http.StatusTooManyRequests),
+			want: http.StatusTooManyRequests,
+		},
+		{
+			name: "registry 400 maps to 502",
+			err:  newErrResp(http.StatusBadRequest),
+			want: http.StatusBadGateway,
+		},
+		{
+			name: "registry 500 maps to 502",
+			err:  newErrResp(http.StatusInternalServerError),
+			want: http.StatusBadGateway,
+		},
+		{
+			name: "registry 503 maps to 502",
+			err:  newErrResp(http.StatusServiceUnavailable),
+			want: http.StatusBadGateway,
+		},
+		{
+			name: "wrapped registry 401 maps to 401",
+			err:  fmt.Errorf("copy graph: %w", newErrResp(http.StatusUnauthorized)),
+			want: http.StatusUnauthorized,
+		},
+		{
+			name: "errdef.ErrNotFound maps to 404",
+			err:  errdef.ErrNotFound,
+			want: http.StatusNotFound,
+		},
+		{
+			name: "wrapped errdef.ErrNotFound maps to 404",
+			err:  fmt.Errorf("fetching manifest: %w", errdef.ErrNotFound),
+			want: http.StatusNotFound,
+		},
+		{
+			name: "generic error maps to 502",
+			err:  errors.New("connection refused"),
+			want: http.StatusBadGateway,
+		},
+		{
+			name: "registry error takes precedence over generic wrapper",
+			err: fmt.Errorf("pulling from registry: %w",
+				fmt.Errorf("wrapped: %w", newErrResp(http.StatusNotFound))),
+			want: http.StatusNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := classifyPullError(tt.err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// newErrResp constructs a *errcode.ErrorResponse with the given HTTP status
+// for use as a synthetic oras-go error.
+func newErrResp(status int) *errcode.ErrorResponse {
+	u, _ := url.Parse("https://registry.example.com/v2/foo/manifests/latest")
+	return &errcode.ErrorResponse{
+		Method:     http.MethodGet,
+		URL:        u,
+		StatusCode: status,
+	}
+}

--- a/pkg/skills/skillsvc/registry.go
+++ b/pkg/skills/skillsvc/registry.go
@@ -91,6 +91,126 @@ func splitQualifiedName(s string) (namespace, name string) {
 	return s[:idx], s[idx+1:]
 }
 
+// resolveGitFallbackForOCIRef attempts to find a git:// URL in the skill
+// registry that can serve as a fallback when an OCI pull failed for ref.
+//
+// The lookup is purely advisory: any error, ambiguity, or missing data is
+// treated as "no fallback available" so the caller can simply return the
+// original OCI error. Returning ("", nil) means "no fallback found".
+//
+// Matching strategy:
+//   - Derive a search term from the ref's tail path segment (e.g.
+//     "yara-rule-authoring" from "ghcr.io/stacklok/dockyard/skills/yara-rule-authoring:0.1.0").
+//   - Query the registry via SearchSkills — no new interface method required.
+//   - Post-filter to registry entries whose OCI packages share the same
+//     repository path as ref (ignoring tag/digest, so :0.1.0 and :latest match
+//     the same entry).
+//   - If exactly one entry matches and it has a git package, build and return
+//     its git:// URL. Multiple matches would be ambiguous so we skip the
+//     fallback rather than guess.
+func (s *service) resolveGitFallbackForOCIRef(ref nameref.Reference) (string, error) {
+	if s.skillLookup == nil {
+		return "", nil
+	}
+
+	repo := ref.Context().RepositoryStr()
+	tail := repo
+	if idx := strings.LastIndex(repo, "/"); idx >= 0 {
+		tail = repo[idx+1:]
+	}
+	if tail == "" {
+		return "", nil
+	}
+
+	results, err := s.skillLookup.SearchSkills(tail)
+	if err != nil {
+		slog.Debug("registry lookup for OCI fallback failed, skipping fallback",
+			"ref", ref.String(), "error", err)
+		return "", nil
+	}
+
+	wantRepo := canonicalOCIRepo(ref)
+
+	var matches []regtypes.Skill
+	for _, sk := range results {
+		if !skillHasMatchingOCIRepo(sk, wantRepo) {
+			continue
+		}
+		matches = append(matches, sk)
+	}
+
+	// Ambiguous: bail out rather than guess. An ambiguous fallback is worse
+	// than surfacing the original OCI error because it could silently serve
+	// content from the wrong skill.
+	if len(matches) != 1 {
+		return "", nil
+	}
+
+	return firstGitPackageURL(matches[0].Packages), nil
+}
+
+// canonicalOCIRepo returns the registry+repository portion of ref without a
+// tag or digest so two references to the same repository at different versions
+// compare equal.
+func canonicalOCIRepo(ref nameref.Reference) string {
+	ctx := ref.Context()
+	return ctx.RegistryStr() + "/" + ctx.RepositoryStr()
+}
+
+// skillHasMatchingOCIRepo reports whether sk has any OCI package whose
+// identifier refers to the same repository as wantRepo.
+func skillHasMatchingOCIRepo(sk regtypes.Skill, wantRepo string) bool {
+	for _, pkg := range sk.Packages {
+		if pkg.RegistryType != "oci" || pkg.Identifier == "" {
+			continue
+		}
+		parsed, err := nameref.ParseReference(pkg.Identifier)
+		if err != nil {
+			continue
+		}
+		if canonicalOCIRepo(parsed) == wantRepo {
+			return true
+		}
+	}
+	return false
+}
+
+// firstGitPackageURL returns the git:// URL for the first usable git package
+// in pkgs, or "" if none is usable. The format follows gitresolver's parser:
+//
+//	git://host/owner/repo[@ref][#subfolder]
+//
+// Commit is preferred over Ref for reproducibility; both are optional.
+func firstGitPackageURL(pkgs []regtypes.SkillPackage) string {
+	for _, pkg := range pkgs {
+		if pkg.RegistryType != "git" || pkg.URL == "" {
+			continue
+		}
+		gitURL, err := buildGitReferenceFromRegistryURL(pkg.URL)
+		if err != nil {
+			continue
+		}
+		if ref := preferredGitRef(pkg); ref != "" {
+			gitURL += "@" + ref
+		}
+		if pkg.Subfolder != "" {
+			gitURL += "#" + pkg.Subfolder
+		}
+		return gitURL
+	}
+	return ""
+}
+
+// preferredGitRef returns the ref to pin the git fallback to. Commit is
+// preferred over branch/tag for reproducibility because the registry records
+// both when available.
+func preferredGitRef(pkg regtypes.SkillPackage) string {
+	if pkg.Commit != "" {
+		return pkg.Commit
+	}
+	return pkg.Ref
+}
+
 // resolveRegistryPackages selects the best installable package from a registry
 // entry. OCI packages are preferred; git is the fallback.
 func resolveRegistryPackages(name string, packages []regtypes.SkillPackage) (*registryResolveResult, error) {

--- a/pkg/skills/skillsvc/registry.go
+++ b/pkg/skills/skillsvc/registry.go
@@ -96,7 +96,7 @@ func splitQualifiedName(s string) (namespace, name string) {
 //
 // The lookup is purely advisory: any error, ambiguity, or missing data is
 // treated as "no fallback available" so the caller can simply return the
-// original OCI error. Returning ("", nil) means "no fallback found".
+// original OCI error. Returning "" means "no fallback found".
 //
 // Matching strategy:
 //   - Derive a search term from the ref's tail path segment (e.g.
@@ -108,9 +108,9 @@ func splitQualifiedName(s string) (namespace, name string) {
 //   - If exactly one entry matches and it has a git package, build and return
 //     its git:// URL. Multiple matches would be ambiguous so we skip the
 //     fallback rather than guess.
-func (s *service) resolveGitFallbackForOCIRef(ref nameref.Reference) (string, error) {
+func (s *service) resolveGitFallbackForOCIRef(ref nameref.Reference) string {
 	if s.skillLookup == nil {
-		return "", nil
+		return ""
 	}
 
 	repo := ref.Context().RepositoryStr()
@@ -119,14 +119,14 @@ func (s *service) resolveGitFallbackForOCIRef(ref nameref.Reference) (string, er
 		tail = repo[idx+1:]
 	}
 	if tail == "" {
-		return "", nil
+		return ""
 	}
 
 	results, err := s.skillLookup.SearchSkills(tail)
 	if err != nil {
 		slog.Debug("registry lookup for OCI fallback failed, skipping fallback",
 			"ref", ref.String(), "error", err)
-		return "", nil
+		return ""
 	}
 
 	wantRepo := canonicalOCIRepo(ref)
@@ -143,10 +143,10 @@ func (s *service) resolveGitFallbackForOCIRef(ref nameref.Reference) (string, er
 	// than surfacing the original OCI error because it could silently serve
 	// content from the wrong skill.
 	if len(matches) != 1 {
-		return "", nil
+		return ""
 	}
 
-	return firstGitPackageURL(matches[0].Packages), nil
+	return firstGitPackageURL(matches[0].Packages)
 }
 
 // canonicalOCIRepo returns the registry+repository portion of ref without a


### PR DESCRIPTION
## Summary

- Follow-up on the flat 502 behaviour from #4956: a content fetch that fails upstream now tells the caller *why* (auth vs not-found vs timeout vs network), and — when the registry entry declares both an OCI and a git package — transparently falls back to git instead of surfacing the failure at all.
- Motivating case: `GET /api/v1beta/skills/content?ref=ghcr.io%2Fstacklok%2Fdockyard%2Fskills%2Fyara-rule-authoring%3A0.1.0` returned a bare `502 Bad Gateway` with no body, even though the catalog entry for `yara-rule-authoring` also lists a git package pinned to a commit on a public repo that would have served the same content.
- Swagger annotations on `POST /api/v1beta/skills` and `GET /api/v1beta/skills/content` now advertise `401`, `404`, `429`, and `504` alongside the existing codes, and `docs/server/{docs.go,swagger.json,swagger.yaml}` are regenerated to match.
- Four independent commits, each shipped in isolation so they can be reviewed / reverted individually.

## Fix A — surface upstream 5xx error messages

`pkg/api/errors/handler.go` previously collapsed every 5xx response body to `http.StatusText(code)`. That's right for 500 (may wrap DB connection strings, container-runtime internals, etc.) but hides actionable detail for 502/503/504 — those are explicitly *upstream* failures the caller can act on.

Branch the 5xx path: keep 500 generic, return `err.Error()` for 502/503/504. Server-side slog/OTel/Sentry reporting is unchanged.

## Fix B — classify oras-go pull errors

`Registry.Pull` failures in both `getContentFromOCI` and `installFromOCI` were mapped to a flat `502`, so a 401 from GHCR looked the same as a network outage or a timeout. A new `classifyPullError` helper (`pkg/skills/skillsvc/pull_errors.go`) maps:

| oras-go error                                          | HTTP status             |
|--------------------------------------------------------|-------------------------|
| `context.DeadlineExceeded` / `context.Canceled`        | `504 Gateway Timeout`   |
| `*errcode.ErrorResponse` `401` / `403`                 | `401 Unauthorized`      |
| `*errcode.ErrorResponse` `404`                         | `404 Not Found`         |
| `*errcode.ErrorResponse` `429`                         | `429 Too Many Requests` |
| `*errcode.ErrorResponse` other 4xx / 5xx               | `502 Bad Gateway`       |
| `errdef.ErrNotFound`                                   | `404 Not Found`         |
| fallback                                               | `502 Bad Gateway`       |

4xx classifications flow through the unchanged 4xx handler path, so auth / not-found errors surface verbatim without relying on the 5xx body change in Fix A.

## Fix C — registry-declared git fallback

`GetContent` short-circuited whenever the ref was "unambiguous OCI" (digest / explicit tag / multi-segment path), which is why the YARA case above never tried the git package declared on the same registry entry.

A new `resolveGitFallbackForOCIRef` in `registry.go`:

- Derives a search term from the ref's tail path segment (e.g. `yara-rule-authoring`).
- Calls the existing `SkillLookup.SearchSkills` (no interface change).
- Post-filters matches to entries whose OCI package identifier parses to the same repository path — tag/digest agnostic, so `:0.1.0` and `:latest` match the same entry.
- Requires exactly one match; ambiguous catalog matches are deliberately skipped (refusing to guess beats silently serving the wrong skill).
- Returns a pinned `git://host/owner/repo[@commit][#subfolder]` URL.

`GetContent` now tries this fallback before returning the OCI error for unambiguous OCI refs. The existing name-based registry resolution for ambiguous refs (plain name / single-segment path) is kept intact.

## Flow after the change

```mermaid
flowchart TD
    start[GET /content?ref] --> classify{ref scheme}
    classify -->|git:// or https://| git[getContentFromGit]
    classify -->|OCI| oci[getContentFromOCI]
    oci -->|success| ok[200 with content]
    oci -->|failure| classifyErr[classifyPullError]
    classifyErr --> lookup[resolveGitFallbackForOCIRef]
    lookup -->|unique git package| gitFallback[getContentFromGit]
    gitFallback -->|success| ok
    gitFallback -->|failure| err["return wrapped error (401/404/429/502/504)"]
    lookup -->|no fallback| err
    classify -->|plain name| nameLookup[resolveFromRegistry]
    nameLookup --> oci
    nameLookup --> git
```

## Type of change

- [x] Bug fix (observability of content-preview failures)
- [x] New functionality (automatic git fallback when the OCI pull fails)
- [x] Documentation (OpenAPI spec updated for the new status codes)

## Test plan

- [x] `go test ./pkg/skills/skillsvc/... -count=1`
- [x] `go test ./pkg/api/errors/... -count=1`
- [x] `go build ./...`
- [x] `swag init -g pkg/api/server.go --v3.1 -o docs/server --parseDependencyLevel 1` regenerated cleanly.
- [x] New `TestClassifyPullError` table-driven cases cover every branch of the classifier (context errors, each registry status code, wrapped errors, generic fallback).
- [x] New `TestErrorHandler` subtests assert 500 stays generic while 502/503/504 now include `err.Error()`.
- [x] New `TestGetContent` subtests cover: fallback succeeds with pinned commit; fallback tolerates a different OCI version tag (`:v9` caller vs `:0.1.0` catalog); no git package → original OCI error; ambiguous catalog matches → no fallback; OCI success → registry lookup never invoked (verified via gomock with no `SearchSkills` expectation); registry lookup error → treated as no-fallback.

## Changes

| File | Change |
|------|--------|
| `pkg/api/errors/handler.go` | `isUpstreamStatus` helper; 502/503/504 responses now include `err.Error()` |
| `pkg/api/errors/handler_test.go` | Three new subtests for 502/503/504; 500-generic assertion kept |
| `pkg/skills/skillsvc/pull_errors.go` | **New** — `classifyPullError(err) int` |
| `pkg/skills/skillsvc/pull_errors_test.go` | **New** — table-driven classifier tests |
| `pkg/skills/skillsvc/content.go` | Wire `classifyPullError` at the `registry.Pull` site; dispatcher tries `resolveGitFallbackForOCIRef` before returning the OCI error for unambiguous OCI refs |
| `pkg/skills/skillsvc/install_oci.go` | Reuse `classifyPullError` at the install pull site |
| `pkg/skills/skillsvc/registry.go` | `resolveGitFallbackForOCIRef` + `canonicalOCIRepo` / `skillHasMatchingOCIRepo` / `firstGitPackageURL` / `preferredGitRef` helpers |
| `pkg/skills/skillsvc/content_test.go` | Six new subtests covering git-fallback success / version-tag tolerance / no-git / ambiguous / OCI-success-skips-lookup / lookup-error cases |
| `pkg/api/v1/skills.go`, `docs/server/{docs.go,swagger.json,swagger.yaml}` | Swagger `@Failure` annotations for the new 401/404/429/504 responses on `installSkill` and `getSkillContent`; regenerated OpenAPI spec |

## Does this introduce a user-facing change?

Yes — two, both additive:

- **Sharper error responses.** Clients calling `GET /api/v1beta/skills/content` or `POST /api/v1beta/skills/install` that previously saw `502 Bad Gateway` with an empty body now see `401 Unauthorized` / `404 Not Found` / `429 Too Many Requests` / `504 Gateway Timeout` where appropriate, and the `502` body now includes the wrapped error for debugging.
- **Automatic git fallback.** A content-preview request for an OCI ref whose pull fails will transparently serve the content from the registry-declared git package when there is exactly one unambiguous match. An ambiguous catalog (two entries for the same repo tail) still returns the original OCI error.
