### PR TITLE
Fix MCPRegistry probe port and bump registry image to v1.3.0

### DIFF
--- a/cmd/thv-operator/pkg/registryapi/podtemplatespec.go
+++ b/cmd/thv-operator/pkg/registryapi/podtemplatespec.go
@@ -367,7 +367,7 @@ func BuildRegistryAPIContainer(image string) corev1.Container {
 			ProbeHandler: corev1.ProbeHandler{
 				HTTPGet: &corev1.HTTPGetAction{
 					Path: HealthCheckPath,
-					Port: intstr.FromInt32(RegistryAPIPort),
+					Port: intstr.FromInt32(RegistryAPIHealthPort),
 				},
 			},
 			InitialDelaySeconds: LivenessInitialDelay,
@@ -377,7 +377,7 @@ func BuildRegistryAPIContainer(image string) corev1.Container {
 			ProbeHandler: corev1.ProbeHandler{
 				HTTPGet: &corev1.HTTPGetAction{
 					Path: ReadinessCheckPath,
-					Port: intstr.FromInt32(RegistryAPIPort),
+					Port: intstr.FromInt32(RegistryAPIHealthPort),
 				},
 			},
 			InitialDelaySeconds: ReadinessInitialDelay,

--- a/cmd/thv-operator/pkg/registryapi/podtemplatespec_test.go
+++ b/cmd/thv-operator/pkg/registryapi/podtemplatespec_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/stacklok/toolhive/cmd/thv-operator/pkg/registryapi/config"
 )
@@ -253,6 +254,10 @@ func TestBuildRegistryAPIContainer(t *testing.T) {
 	assert.NotNil(t, container.ReadinessProbe)
 	assert.Equal(t, HealthCheckPath, container.LivenessProbe.HTTPGet.Path)
 	assert.Equal(t, ReadinessCheckPath, container.ReadinessProbe.HTTPGet.Path)
+	// Probes hit the internal health listener on RegistryAPIHealthPort,
+	// not the public API port. See toolhive-registry-server v1.1.0+.
+	assert.Equal(t, intstr.FromInt32(RegistryAPIHealthPort), container.LivenessProbe.HTTPGet.Port)
+	assert.Equal(t, intstr.FromInt32(RegistryAPIHealthPort), container.ReadinessProbe.HTTPGet.Port)
 }
 
 func TestMergePodTemplateSpecs(t *testing.T) {

--- a/cmd/thv-operator/pkg/registryapi/types.go
+++ b/cmd/thv-operator/pkg/registryapi/types.go
@@ -19,6 +19,11 @@ const (
 	RegistryAPIPort = 8080
 	// RegistryAPIPortName is the name assigned to the registry API port
 	RegistryAPIPortName = "http"
+	// RegistryAPIHealthPort is the port of the registry API's internal HTTP
+	// listener that serves liveness and readiness probes. Introduced in
+	// toolhive-registry-server v1.1.0 to separate probe traffic from the
+	// public API listener on RegistryAPIPort.
+	RegistryAPIHealthPort = 8081
 
 	// DefaultCPURequest is the default CPU request for the registry API container
 	DefaultCPURequest = "100m"

--- a/cmd/thv-operator/test-integration/mcp-registry/registry_helpers.go
+++ b/cmd/thv-operator/test-integration/mcp-registry/registry_helpers.go
@@ -47,7 +47,6 @@ const (
 // registryBuilderConfig holds the configuration data used to generate configYAML
 type registryBuilderConfig struct {
 	SourceName   string
-	Format       string
 	SourceType   string
 	FilePath     string // for file sources: path inside the mounted volume
 	GitRepo      string
@@ -83,7 +82,6 @@ func (h *MCPRegistryTestHelper) NewRegistryBuilder(name string) *RegistryBuilder
 		},
 		config: registryBuilderConfig{
 			SourceName: "default",
-			Format:     "toolhive",
 		},
 	}
 }
@@ -121,12 +119,6 @@ func (rb *RegistryBuilder) WithRegistryName(name string) *RegistryBuilder {
 	if rb.config.SourceType == sourceTypeFile {
 		rb.config.FilePath = fmt.Sprintf("/config/registry/%s/registry.json", name)
 	}
-	return rb
-}
-
-// WithUpstreamFormat configures the source to use upstream MCP format
-func (rb *RegistryBuilder) WithUpstreamFormat() *RegistryBuilder {
-	rb.config.Format = "upstream"
 	return rb
 }
 
@@ -244,7 +236,6 @@ func (rb *RegistryBuilder) buildConfigYAML() string {
 	// Sources section
 	b.WriteString("sources:\n")
 	fmt.Fprintf(&b, "  - name: %s\n", rb.config.SourceName)
-	fmt.Fprintf(&b, "    format: %s\n", rb.config.Format)
 
 	// Source type specific fields
 	switch rb.config.SourceType {
@@ -336,15 +327,6 @@ func (h *MCPRegistryTestHelper) CreateBasicConfigMapRegistry(name, configMapName
 func (h *MCPRegistryTestHelper) CreateManualSyncRegistry(name, configMapName string) *mcpv1beta1.MCPRegistry {
 	return h.NewRegistryBuilder(name).
 		WithConfigMapSource(configMapName, "registry.json").
-		Create(h)
-}
-
-// CreateUpstreamFormatRegistry creates an MCPRegistry with upstream format
-func (h *MCPRegistryTestHelper) CreateUpstreamFormatRegistry(name, configMapName string) *mcpv1beta1.MCPRegistry {
-	return h.NewRegistryBuilder(name).
-		WithConfigMapSource(configMapName, "registry.json").
-		WithUpstreamFormat().
-		WithSyncPolicy("30m").
 		Create(h)
 }
 
@@ -494,18 +476,13 @@ func containsFinalizer(finalizers []string, _ string) bool {
 }
 
 // buildConfigYAMLForMultipleSources generates a configYAML string for multiple sources.
-// Each source is specified as a map with keys: name, format, sourceType, and type-specific fields.
+// Each source is specified as a map with keys: name, sourceType, and type-specific fields.
 func buildConfigYAMLForMultipleSources(sources []map[string]string) string {
 	var b strings.Builder
 
 	b.WriteString("sources:\n")
 	for _, src := range sources {
 		fmt.Fprintf(&b, "  - name: %s\n", src["name"])
-		format := src["format"]
-		if format == "" {
-			format = "toolhive"
-		}
-		fmt.Fprintf(&b, "    format: %s\n", format)
 
 		switch src["sourceType"] {
 		case sourceTypeFile:

--- a/cmd/thv-operator/test-integration/mcp-registry/registry_lifecycle_test.go
+++ b/cmd/thv-operator/test-integration/mcp-registry/registry_lifecycle_test.go
@@ -178,7 +178,6 @@ var _ = Describe("MCPRegistry Lifecycle Management", Label("k8s", "registry"), f
 
 			registry2 := registryHelper.NewRegistryBuilder("registry-2").
 				WithConfigMapSource(configMap2.Name, "registry.json").
-				// WithUpstreamFormat().
 				WithSyncPolicy("30m").
 				Create(registryHelper)
 
@@ -189,8 +188,6 @@ var _ = Describe("MCPRegistry Lifecycle Management", Label("k8s", "registry"), f
 			// Verify they operate independently by checking their configYAML
 			Expect(registry1.Spec.ConfigYAML).To(ContainSubstring("interval: 1h"))
 			Expect(registry2.Spec.ConfigYAML).To(ContainSubstring("interval: 30m"))
-			Expect(registry1.Spec.ConfigYAML).To(ContainSubstring("format: toolhive"))
-			Expect(registry2.Spec.ConfigYAML).To(ContainSubstring("format: toolhive"))
 		})
 
 		It("should allow multiple registries with same ConfigMap source", func() {

--- a/deploy/charts/operator/README.md
+++ b/deploy/charts/operator/README.md
@@ -93,6 +93,6 @@ The command removes all the Kubernetes components associated with the chart and 
 | operator.vmcpImage | string | `"ghcr.io/stacklok/toolhive/vmcp:v0.24.0"` | Image to use for Virtual MCP Server (vMCP) deployments |
 | operator.volumeMounts | list | `[]` | Additional volume mounts on the operator container |
 | operator.volumes | list | `[]` | Additional volumes to mount on the operator pod |
-| registryAPI | object | `{"image":"ghcr.io/stacklok/thv-registry-api:v1.1.1"}` | All values for the registry API deployment and associated resources |
-| registryAPI.image | string | `"ghcr.io/stacklok/thv-registry-api:v1.1.1"` | Container image for the registry API |
+| registryAPI | object | `{"image":"ghcr.io/stacklok/thv-registry-api:v1.3.0"}` | All values for the registry API deployment and associated resources |
+| registryAPI.image | string | `"ghcr.io/stacklok/thv-registry-api:v1.3.0"` | Container image for the registry API |
 

--- a/deploy/charts/operator/values.yaml
+++ b/deploy/charts/operator/values.yaml
@@ -206,4 +206,4 @@ operator:
 # -- All values for the registry API deployment and associated resources
 registryAPI:
   # -- Container image for the registry API
-  image: "ghcr.io/stacklok/thv-registry-api:v1.1.1"
+  image: "ghcr.io/stacklok/thv-registry-api:v1.3.0"

--- a/examples/operator/mcp-registries/mcpregistry-configyaml-api.yaml
+++ b/examples/operator/mcp-registries/mcpregistry-configyaml-api.yaml
@@ -5,10 +5,6 @@
 # HTTP from another registry server, so no volumes or volume mounts are
 # needed -- the registry server handles the network call internally.
 #
-# API sources must use "format: upstream" because the remote registry
-# serves data in the upstream registry server format (not the legacy
-# toolhive JSON format).
-#
 # This is functionally equivalent to mcpregistry-api-basic.yaml but uses
 # the decoupled configYAML path instead of the legacy typed fields.
 
@@ -22,7 +18,6 @@ spec:
   configYAML: |
     sources:
       - name: upstream
-        format: upstream
         api:
           # Base API URL for the upstream registry server
           endpoint: http://upstream-registry.default.svc.cluster.local:8080

--- a/examples/operator/mcp-registries/mcpregistry-configyaml-configmap.yaml
+++ b/examples/operator/mcp-registries/mcpregistry-configyaml-configmap.yaml
@@ -23,55 +23,77 @@ metadata:
 data:
   registry.json: |
     {
-      "$schema": "https://raw.githubusercontent.com/stacklok/toolhive/main/pkg/registry/data/toolhive-legacy-registry.schema.json",
+      "$schema": "https://raw.githubusercontent.com/stacklok/toolhive-core/main/registry/types/data/upstream-registry.schema.json",
       "version": "1.0.0",
-      "last_updated": "2025-09-08T12:00:00Z",
-      "servers": {
-        "filesystem": {
-          "description": "Allows you to do filesystem operations",
-          "tier": "Official",
-          "status": "Active",
-          "transport": "stdio",
-          "tools": ["read_file", "write_file", "list_directory"],
-          "tags": ["filesystem", "production"],
-          "image": "docker.io/mcp/filesystem:latest",
-          "permissions": {
-            "network": {
-              "outbound": {}
+      "meta": {
+        "last_updated": "2025-09-08T12:00:00Z"
+      },
+      "data": {
+        "servers": [
+          {
+            "name": "io.github.example/filesystem",
+            "description": "Allows you to do filesystem operations",
+            "version": "1.0.0",
+            "packages": [
+              {
+                "registryType": "oci",
+                "identifier": "docker.io/mcp/filesystem:latest",
+                "transport": { "type": "stdio" }
+              }
+            ],
+            "_meta": {
+              "io.modelcontextprotocol.registry/publisher-provided": {
+                "io.github.example": {
+                  "docker.io/mcp/filesystem:latest": {
+                    "tags": ["filesystem", "production"]
+                  }
+                }
+              }
             }
-          }
-        },
-        "github": {
-          "description": "Provides integration with GitHub APIs",
-          "tier": "Official",
-          "status": "Active",
-          "transport": "stdio",
-          "tools": ["create_issue", "create_pull_request"],
-          "tags": ["github", "production"],
-          "image": "ghcr.io/github/github-mcp-server:latest",
-          "permissions": {
-            "network": {
-              "outbound": {
-                "allow_host": [".github.com"],
-                "allow_port": [443]
+          },
+          {
+            "name": "io.github.example/github",
+            "description": "Provides integration with GitHub APIs",
+            "version": "1.0.0",
+            "packages": [
+              {
+                "registryType": "oci",
+                "identifier": "ghcr.io/github/github-mcp-server:latest",
+                "transport": { "type": "stdio" }
+              }
+            ],
+            "_meta": {
+              "io.modelcontextprotocol.registry/publisher-provided": {
+                "io.github.example": {
+                  "ghcr.io/github/github-mcp-server:latest": {
+                    "tags": ["github", "production"]
+                  }
+                }
+              }
+            }
+          },
+          {
+            "name": "io.github.example/experimental-ai",
+            "description": "Experimental AI tools - not production ready",
+            "version": "0.1.0",
+            "packages": [
+              {
+                "registryType": "oci",
+                "identifier": "docker.io/mcp/experimental-ai:latest",
+                "transport": { "type": "stdio" }
+              }
+            ],
+            "_meta": {
+              "io.modelcontextprotocol.registry/publisher-provided": {
+                "io.github.example": {
+                  "docker.io/mcp/experimental-ai:latest": {
+                    "tags": ["ai", "experimental"]
+                  }
+                }
               }
             }
           }
-        },
-        "experimental-ai": {
-          "description": "Experimental AI tools - not production ready",
-          "tier": "Community",
-          "status": "Active",
-          "transport": "stdio",
-          "tools": ["analyze_code"],
-          "tags": ["ai", "experimental"],
-          "image": "docker.io/mcp/experimental-ai:latest",
-          "permissions": {
-            "network": {
-              "outbound": {}
-            }
-          }
-        }
+        ]
       }
     }
 ---
@@ -85,7 +107,6 @@ spec:
   configYAML: |
     sources:
       - name: production
-        format: toolhive
         file:
           # This path must match the volumeMount mountPath below
           path: /config/registry/production/registry.json

--- a/examples/operator/mcp-registries/mcpregistry-configyaml-git-auth.yaml
+++ b/examples/operator/mcp-registries/mcpregistry-configyaml-git-auth.yaml
@@ -43,7 +43,6 @@ spec:
   configYAML: |
     sources:
       - name: private-repo
-        format: toolhive
         git:
           repository: https://github.com/your-org/private-mcp-registry
           branch: main

--- a/examples/operator/mcp-registries/mcpregistry-configyaml-minimal.yaml
+++ b/examples/operator/mcp-registries/mcpregistry-configyaml-minimal.yaml
@@ -23,7 +23,6 @@ spec:
   configYAML: |
     sources:
       - name: k8s
-        format: upstream
         kubernetes: {}
     registries:
       - name: default

--- a/examples/operator/mcp-registries/mcpregistry-configyaml-oauth.yaml
+++ b/examples/operator/mcp-registries/mcpregistry-configyaml-oauth.yaml
@@ -25,7 +25,6 @@ spec:
   configYAML: |
     sources:
       - name: production
-        format: toolhive
         file:
           path: /config/registry/production/registry.json
     registries:

--- a/examples/operator/mcp-registries/mcpregistry-configyaml-pgpass.yaml
+++ b/examples/operator/mcp-registries/mcpregistry-configyaml-pgpass.yaml
@@ -47,7 +47,6 @@ spec:
   configYAML: |
     sources:
       - name: production
-        format: toolhive
         file:
           path: /config/registry/production/registry.json
     registries:


### PR DESCRIPTION
## Summary

Fixes two bugs reported in #5012 that both surface when deploying an `MCPRegistry` through the operator with defaults:

- **Failing liveness/readiness probes**: the operator's probes target port 8080, but toolhive-registry-server has served `/health` and `/readiness` on its internal listener (`:8081`) since v1.1.0. The probe port was never updated, so every registry pod enters a restart loop.
- **`source.format: upstream` still required**: the operator pins `thv-registry-api:v1.1.1` in its chart, where an empty `format` field produces `registry data validation failed: unsupported format:`. toolhive-registry-server v1.3.0 dropped the field entirely, but the pinned image never advanced.

Both share a root cause — the chart's default registry image tag was three minor releases behind the registry server. Bumping to v1.3.0 covers the format issue and aligns with the probe-port fix (v1.3.0 still serves probes on 8081).

**What changed:**

- Introduce `RegistryAPIHealthPort = 8081`; point both `LivenessProbe` and `ReadinessProbe` at it. The container's published `ContainerPort` stays on 8080 (the API) — probes are pod-local and don't need a `Service` entry.
- Harden `TestBuildRegistryAPIContainer` with explicit probe-port assertions to guard against regression.
- Bump `registryAPI.image` from `v1.1.1` to `v1.3.0` in `deploy/charts/operator/values.yaml`; regenerate the chart README via `helm-docs`.
- Strip `format:` lines from all six example `mcpregistry-configyaml-*.yaml` manifests. Convert the ConfigMap example's embedded registry data from the removed toolhive JSON format to the upstream MCP registry format so it stays functional against v1.3.0.
- Drop the stale `Format` plumbing from `cmd/thv-operator/test-integration/mcp-registry/registry_helpers.go` (`WithUpstreamFormat`, `CreateUpstreamFormatRegistry`, `format: %s` emission) and remove the now-stale `format: toolhive` assertions from `registry_lifecycle_test.go`.

Fixes #5012

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`) — 0 issues
- [x] Operator tests (`task operator-test`) — pass, including the new probe-port assertions

Manual verification recommended before merge:
- Render the chart: `helm template deploy/charts/operator | grep -A2 "Probe:"` → probes on port 8081, image `v1.3.0`.
- Kind e2e: deploy the operator, apply `examples/operator/mcp-registries/mcpregistry-configyaml-minimal.yaml`, confirm the registry-api pod reaches `Running`/`Ready` and logs show a successful sync with no `unsupported format` error.

## API Compatibility

- [x] This PR does not break the `v1beta1` API, OR the `api-break-allowed` label is applied and the migration guidance is described above.

No CRD schema changes. `format` was never a CRD field — it lived inside the free-form `ConfigYAML` string, which the operator does not parse.

## Changes

| File | Change |
|------|--------|
| `cmd/thv-operator/pkg/registryapi/types.go` | Add `RegistryAPIHealthPort = 8081` |
| `cmd/thv-operator/pkg/registryapi/podtemplatespec.go` | Point both probes at `RegistryAPIHealthPort` |
| `cmd/thv-operator/pkg/registryapi/podtemplatespec_test.go` | Assert probe ports equal `RegistryAPIHealthPort` |
| `deploy/charts/operator/values.yaml` | Bump `registryAPI.image` to `v1.3.0` |
| `deploy/charts/operator/README.md` | Regenerated via `helm-docs` |
| `examples/operator/mcp-registries/mcpregistry-configyaml-*.yaml` (6 files) | Remove `format:` lines; rewrite ConfigMap example's inline JSON to upstream format |
| `cmd/thv-operator/test-integration/mcp-registry/registry_helpers.go` | Drop `Format` field, `WithUpstreamFormat`, `CreateUpstreamFormatRegistry`, `format:` emission |
| `cmd/thv-operator/test-integration/mcp-registry/registry_lifecycle_test.go` | Remove stale `format: toolhive` assertions |

## Does this introduce a user-facing change?

Yes. Users installing the operator chart at this version will get a registry-api pod that actually passes probes, and writing an `MCPRegistry` without `source.format` is now the expected shape. Users who pinned `registryAPI.image` to their own older tag in their Helm values are unaffected but will still see the original symptoms against those older images.

## Implementation plan

<details>
<summary>Approved implementation plan</summary>

### Root cause

The operator's Helm chart pins `ghcr.io/stacklok/thv-registry-api:v1.1.1` — three minor releases behind current `v1.3.0`. Registry server evolution the operator never tracked:

- **v1.1.0** (PR toolhive-registry-server#701) introduced a separate internal HTTP listener on `:8081` for `/health` and `/readiness`. The main API on `:8080` stopped answering these paths. The operator's hardcoded probe port of 8080 has been wrong since v1.1.0.
- **v1.3.0** (PR toolhive-registry-server#724) dropped the `format` field entirely. In v1.1.1, `ValidateData()` switches on `format` and falls through to `unsupported format:` when empty.

### Strategy

Ship as one PR — both fixes address the same user-visible symptom (MCPRegistry deployment breaks), and releasing the image bump alone would leave probes broken. No changes needed in `toolhive-registry-server`.

### Changes

1. **Probe port** — `types.go` adds `RegistryAPIHealthPort = 8081`; `podtemplatespec.go` switches both probes; tests hardened.
2. **Default registry image** — `values.yaml` → `v1.3.0`; chart README regenerated.
3. **Examples** — strip `format:` from all six `configyaml-*.yaml`; rewrite ConfigMap example's inline JSON to upstream format (v1.3.0 rejects the legacy toolhive JSON).
4. **Test-integration helpers** — drop `Format` plumbing now that the server ignores it.

### Verification

- `task lint-fix` → 0 issues.
- `task operator-test` → pass.
- Kind e2e walkthrough documented in test plan.

### Follow-ups (not in this PR)

- Add Chainsaw coverage for MCPRegistry pod readiness (its absence is why this shipped).
- Consider appending `--internal-address=:8081` to the registry-api container Args as belt-and-suspenders; requires small refactor of the Args composition split between `BuildRegistryAPIContainer` and `WithRegistryServerConfigMount`.

</details>

## Special notes for reviewers

- The ConfigMap example's embedded JSON had to be rewritten (not just `format:` removed) because v1.3.0 rejects the legacy toolhive schema entirely. The new JSON follows the upstream registry schema shape (`version` / `meta.last_updated` / `data.servers[]`) and places tags under `_meta.io.modelcontextprotocol.registry/publisher-provided.<publisher>.<image>.tags` where the registry server's `ExtractTags` looks for them.
- Sanity-check: verify that the tag-filter assertion in the ConfigMap example (`filter.tags.include: ["production"]`) still makes sense given the rewritten data.
- A follow-up issue for Chainsaw e2e coverage of MCPRegistry probe readiness is worth filing — the absence of that coverage is why this bug shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)