### PR TITLE
pkg/llm: implement OIDC token source and thv llm token command

### DIFF
--- a/cmd/thv/app/llm.go
+++ b/cmd/thv/app/llm.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -203,6 +204,43 @@ tokens from the secrets provider.`,
 	}
 }
 
+// runLLMToken prints a fresh LLM gateway access token to stdout.
+// All diagnostic output goes to stderr so the caller can capture the token
+// cleanly (e.g. apiKeyHelper or auth.command in Claude Code / Cursor).
+func runLLMToken(ctx context.Context) error {
+	provider := config.NewDefaultProvider()
+	llmCfg := provider.GetConfig().LLM
+
+	if !llmCfg.IsConfigured() {
+		return fmt.Errorf("LLM gateway is not configured — run \"thv llm config set\" first")
+	}
+
+	secretsProvider, err := secrets.GetSystemSecretsProvider()
+	if err != nil {
+		return fmt.Errorf("failed to get secrets provider: %w", err)
+	}
+	scoped := pkgsecrets.NewScopedProvider(secretsProvider, pkgsecrets.ScopeLLM)
+
+	updater := func(key string, expiry time.Time) {
+		if err := config.UpdateConfig(func(c *config.Config) error {
+			c.LLM.OIDC.CachedRefreshTokenRef = key
+			c.LLM.OIDC.CachedTokenExpiry = expiry
+			return nil
+		}); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to persist LLM token reference: %v\n", err)
+		}
+	}
+
+	ts := llm.NewTokenSource(&llmCfg, scoped, false /* non-interactive */, updater)
+	token, err := ts.Token(ctx)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(token)
+	return nil
+}
+
 // deleteLLMSecrets removes all secrets stored under the LLM scope.
 func deleteLLMSecrets(ctx context.Context) error {
 	provider, err := secrets.GetSystemSecretsProvider()
@@ -287,11 +325,8 @@ func newLLMTokenCommand() *cobra.Command {
 Intended for use as apiKeyHelper or auth.command in OIDC-capable AI tools.
 Runs non-interactively — will not launch a browser flow.`,
 		Args: cobra.NoArgs,
-		RunE: func(_ *cobra.Command, _ []string) error {
-			// Print the error to stderr so it doesn't corrupt the token value
-			// expected on stdout by callers such as apiKeyHelper or auth.command.
-			return fmt.Errorf("thv llm token is not yet implemented — " +
-				"run \"thv llm setup\" once it is available to configure your tools")
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runLLMToken(cmd.Context())
 		},
 	}
 

--- a/pkg/llm/tokensource.go
+++ b/pkg/llm/tokensource.go
@@ -1,0 +1,257 @@
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package llm
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"golang.org/x/oauth2"
+
+	"github.com/stacklok/toolhive/pkg/auth/oauth"
+	"github.com/stacklok/toolhive/pkg/auth/remote"
+	"github.com/stacklok/toolhive/pkg/secrets"
+)
+
+// ErrTokenRequired is returned when a fresh token is needed but no cached or
+// refreshable token exists and the caller is non-interactive (browser flow
+// disabled). The caller should run "thv llm setup" to perform initial login.
+var ErrTokenRequired = errors.New(
+	"LLM gateway authentication required: run \"thv llm setup\" to log in",
+)
+
+// preemptiveRefreshWindow is how far before actual expiry a token is treated as
+// expired, triggering a proactive refresh before the gateway rejects it.
+const preemptiveRefreshWindow = 30 * time.Second
+
+// TokenRefUpdater is a callback invoked after a successful browser flow or token
+// refresh to persist the refresh token key and expiry into the application config.
+// The callback is called with the secret key and token expiry time.
+// Callers typically wire this to config.UpdateConfig.
+type TokenRefUpdater func(refreshTokenKey string, expiry time.Time)
+
+// TokenSource provides fresh LLM gateway access tokens using a three-tier strategy:
+//
+//  1. In-memory cached oauth2.TokenSource (auto-refreshes transparently)
+//  2. Refresh token stored in the secrets provider (restores across CLI invocations)
+//  3. Browser-based OIDC+PKCE flow (only when interactive is true)
+//
+// Access tokens are held in memory only and are never written to disk or logged.
+type TokenSource struct {
+	cfg             *Config
+	secretsProvider secrets.Provider
+	interactive     bool
+	tokenRefUpdater TokenRefUpdater
+	mu              sync.Mutex
+	tokenSource     oauth2.TokenSource
+}
+
+// NewTokenSource creates a TokenSource for the LLM gateway.
+// secretsProvider may be nil if the secrets store is unavailable (tier 2 is skipped).
+// tokenRefUpdater is called after login/refresh to persist the token reference into
+// config — pass nil to skip config persistence (useful in tests).
+// Set interactive to false for non-interactive callers such as thv llm token.
+func NewTokenSource(
+	cfg *Config, secretsProvider secrets.Provider, interactive bool, tokenRefUpdater TokenRefUpdater,
+) *TokenSource {
+	return &TokenSource{
+		cfg:             cfg,
+		secretsProvider: secretsProvider,
+		interactive:     interactive,
+		tokenRefUpdater: tokenRefUpdater,
+	}
+}
+
+// Token returns a valid LLM gateway access token.
+// It is safe for concurrent use.
+func (t *TokenSource) Token(ctx context.Context) (string, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	// Tier 1: in-memory token source handles auto-refresh transparently.
+	if t.tokenSource != nil {
+		tok, err := t.tokenSource.Token()
+		if err == nil && tok.Valid() {
+			return tok.AccessToken, nil
+		}
+		t.tokenSource = nil
+	}
+
+	// Tier 2: restore from a cached refresh token in the secrets provider.
+	if err := t.tryRestoreFromCache(ctx); err == nil && t.tokenSource != nil {
+		tok, err := t.tokenSource.Token()
+		if err == nil && tok.Valid() {
+			return tok.AccessToken, nil
+		}
+		t.tokenSource = nil
+	}
+
+	// Tier 3: browser OIDC+PKCE flow — only in interactive mode.
+	if !t.interactive {
+		return "", ErrTokenRequired
+	}
+	if err := t.performBrowserFlow(ctx); err != nil {
+		return "", fmt.Errorf("OIDC browser flow failed: %w", err)
+	}
+	tok, err := t.tokenSource.Token()
+	if err != nil {
+		return "", fmt.Errorf("failed to get token after browser flow: %w", err)
+	}
+	return tok.AccessToken, nil
+}
+
+// tryRestoreFromCache attempts to build a token source from the cached refresh
+// token stored in the secrets provider.
+func (t *TokenSource) tryRestoreFromCache(ctx context.Context) error {
+	if t.secretsProvider == nil {
+		return fmt.Errorf("no secrets provider available")
+	}
+	key := t.refreshTokenKey()
+	refreshToken, err := t.secretsProvider.GetSecret(ctx, key)
+	if err != nil || refreshToken == "" {
+		return fmt.Errorf("no cached refresh token")
+	}
+
+	oauth2Cfg, err := t.buildOAuth2Config(ctx)
+	if err != nil {
+		return fmt.Errorf("building oauth2 config for cache restore: %w", err)
+	}
+
+	// Subtract preemptiveRefreshWindow so the oauth2 library considers the token
+	// expired 30 s before its actual expiry, triggering proactive refresh.
+	expiry := t.cfg.OIDC.CachedTokenExpiry
+	if !expiry.IsZero() {
+		expiry = expiry.Add(-preemptiveRefreshWindow)
+	}
+
+	t.tokenSource = remote.CreateTokenSourceFromCached(oauth2Cfg, refreshToken, expiry, "")
+	return nil
+}
+
+// performBrowserFlow runs the interactive OIDC+PKCE browser flow and persists
+// the resulting refresh token for future non-interactive use.
+func (t *TokenSource) performBrowserFlow(ctx context.Context) error {
+	flowCfg, err := t.buildFlowConfig(ctx)
+	if err != nil {
+		return err
+	}
+
+	flow, err := oauth.NewFlow(flowCfg)
+	if err != nil {
+		return fmt.Errorf("creating OAuth flow: %w", err)
+	}
+
+	tokenResult, err := flow.Start(ctx, false)
+	if err != nil {
+		return fmt.Errorf("OAuth flow start failed: %w", err)
+	}
+
+	base := flow.TokenSource()
+	key := t.refreshTokenKey()
+
+	if t.secretsProvider != nil {
+		base = remote.NewPersistingTokenSource(base, t.makeTokenPersister(key))
+		if tokenResult.RefreshToken != "" {
+			if err := t.secretsProvider.SetSecret(ctx, key, tokenResult.RefreshToken); err != nil {
+				slog.Warn("failed to persist initial LLM gateway refresh token", "error", err)
+			}
+		} else {
+			slog.Debug("OIDC provider did not return a refresh token; token will not be persisted")
+		}
+		t.updateConfigTokenRef(key, tokenResult.Expiry)
+	}
+
+	t.tokenSource = base
+	return nil
+}
+
+// buildFlowConfig creates an oauth.Config for the interactive browser flow.
+// PKCE (S256) is always enabled per OAuth 2.1 requirements for public clients.
+func (t *TokenSource) buildFlowConfig(ctx context.Context) (*oauth.Config, error) {
+	return oauth.CreateOAuthConfigFromOIDC(
+		ctx,
+		t.cfg.OIDC.Issuer,
+		t.cfg.OIDC.ClientID,
+		"", // public client — no client secret
+		ensureOfflineAccess(t.cfg.OIDC.EffectiveScopes()),
+		true, // always use PKCE
+		t.cfg.OIDC.CallbackPort,
+		t.cfg.OIDC.Audience,
+	)
+}
+
+// buildOAuth2Config creates a minimal oauth2.Config suitable for token refresh
+// via the cached refresh token path (no browser required).
+func (t *TokenSource) buildOAuth2Config(ctx context.Context) (*oauth2.Config, error) {
+	flowCfg, err := t.buildFlowConfig(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &oauth2.Config{
+		ClientID: flowCfg.ClientID,
+		Scopes:   flowCfg.Scopes,
+		Endpoint: oauth2.Endpoint{
+			AuthURL:   flowCfg.AuthURL,
+			TokenURL:  flowCfg.TokenURL,
+			AuthStyle: oauth2.AuthStyleInParams,
+		},
+	}, nil
+}
+
+// makeTokenPersister returns a remote.TokenPersister that stores the refresh
+// token in the secrets provider and updates the config expiry reference.
+func (t *TokenSource) makeTokenPersister(key string) remote.TokenPersister {
+	return func(refreshToken string, expiry time.Time) error {
+		ctx := context.Background()
+		if err := t.secretsProvider.SetSecret(ctx, key, refreshToken); err != nil {
+			return fmt.Errorf("persisting LLM gateway refresh token: %w", err)
+		}
+		t.updateConfigTokenRef(key, expiry)
+		return nil
+	}
+}
+
+// updateConfigTokenRef calls the injected tokenRefUpdater (if set) to persist
+// the refresh token key and expiry so future invocations can restore the session.
+func (t *TokenSource) updateConfigTokenRef(key string, expiry time.Time) {
+	if t.tokenRefUpdater != nil {
+		t.tokenRefUpdater(key, expiry)
+	}
+}
+
+// refreshTokenKey returns the secrets-provider key for the LLM refresh token.
+// If a key was previously persisted in config, that key is reused; otherwise a
+// new key is derived deterministically from the gateway URL and issuer.
+func (t *TokenSource) refreshTokenKey() string {
+	if t.cfg.OIDC.CachedRefreshTokenRef != "" {
+		return t.cfg.OIDC.CachedRefreshTokenRef
+	}
+	return DeriveSecretKey(t.cfg.GatewayURL, t.cfg.OIDC.Issuer)
+}
+
+// DeriveSecretKey computes the secrets-provider key for an LLM gateway refresh
+// token. The formula is: LLM_OAUTH_<8 hex chars> where the hex is derived from
+// sha256(gatewayURL + "\x00" + issuer)[:4], matching the pattern used by the
+// registry auth package.
+func DeriveSecretKey(gatewayURL, issuer string) string {
+	h := sha256.Sum256([]byte(gatewayURL + "\x00" + issuer))
+	return "LLM_OAUTH_" + hex.EncodeToString(h[:4])
+}
+
+// ensureOfflineAccess returns scopes with "offline_access" appended if absent.
+// This scope is required for the provider to return a refresh token.
+func ensureOfflineAccess(scopes []string) []string {
+	for _, s := range scopes {
+		if s == "offline_access" {
+			return scopes
+		}
+	}
+	return append(scopes[:len(scopes):len(scopes)], "offline_access")
+}

--- a/pkg/llm/tokensource.go
+++ b/pkg/llm/tokensource.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
 	"time"
 
@@ -20,30 +21,45 @@ import (
 	"github.com/stacklok/toolhive/pkg/secrets"
 )
 
+// errCacheMiss is a sentinel used internally to distinguish "no token in cache"
+// from real backend errors. It is never exposed to callers.
+var errCacheMiss = errors.New("no cached refresh token")
+
 // ErrTokenRequired is returned when a fresh token is needed but no cached or
 // refreshable token exists and the caller is non-interactive (browser flow
-// disabled). The caller should run "thv llm setup" to perform initial login.
+// disabled). The user must first complete an interactive login so that a
+// refresh token is persisted for subsequent non-interactive calls.
 var ErrTokenRequired = errors.New(
-	"LLM gateway authentication required: run \"thv llm setup\" to log in",
+	"LLM gateway authentication required: no cached credentials found; " +
+		"complete an interactive login first (\"thv llm setup\" — coming soon)",
 )
 
 // preemptiveRefreshWindow is how far before actual expiry a token is treated as
 // expired, triggering a proactive refresh before the gateway rejects it.
 const preemptiveRefreshWindow = 30 * time.Second
 
-// TokenRefUpdater is a callback invoked after a successful browser flow or token
-// refresh to persist the refresh token key and expiry into the application config.
-// The callback is called with the secret key and token expiry time.
+// TokenRefUpdater is a callback invoked when the refresh token changes — either
+// after a successful browser flow (initial login) or when the OIDC provider
+// rotates the refresh token during a refresh. It persists the secret key and
+// the new token expiry into the application config so future CLI invocations
+// can restore the session. It is NOT called on routine access-token refreshes
+// where the refresh token is unchanged.
 // Callers typically wire this to config.UpdateConfig.
 type TokenRefUpdater func(refreshTokenKey string, expiry time.Time)
 
 // TokenSource provides fresh LLM gateway access tokens using a three-tier strategy:
 //
 //  1. In-memory cached oauth2.TokenSource (auto-refreshes transparently)
-//  2. Refresh token stored in the secrets provider (restores across CLI invocations)
-//  3. Browser-based OIDC+PKCE flow (only when interactive is true)
+//  2. Secrets-provider cached access token (cross-process reuse — avoids racing
+//     on the refresh token when multiple short-lived processes run concurrently)
+//  3. Refresh token stored in the secrets provider (restores across CLI invocations)
+//  4. Browser-based OIDC+PKCE flow (only when interactive is true)
 //
-// Access tokens are held in memory only and are never written to disk or logged.
+// Both the refresh token and the short-lived access token are stored in the
+// secrets provider (system keychain). The access token is cached alongside the
+// refresh token to prevent concurrent processes from racing to exchange the same
+// refresh token — a race that causes invalid_grant on providers that rotate
+// refresh tokens on use. Access tokens are never written to log output.
 type TokenSource struct {
 	cfg             *Config
 	secretsProvider secrets.Provider
@@ -54,7 +70,9 @@ type TokenSource struct {
 }
 
 // NewTokenSource creates a TokenSource for the LLM gateway.
-// secretsProvider may be nil if the secrets store is unavailable (tier 2 is skipped).
+// secretsProvider may be nil if the secrets store is unavailable; in that case
+// tier 2 returns an actionable error ("no secrets provider available") rather
+// than the generic ErrTokenRequired, so the caller sees the real cause.
 // tokenRefUpdater is called after login/refresh to persist the token reference into
 // config — pass nil to skip config persistence (useful in tests).
 // Set interactive to false for non-interactive callers such as thv llm token.
@@ -75,26 +93,37 @@ func (t *TokenSource) Token(ctx context.Context) (string, error) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
-	// Tier 1: in-memory token source handles auto-refresh transparently.
-	if t.tokenSource != nil {
-		tok, err := t.tokenSource.Token()
-		if err == nil && tok.Valid() {
-			return tok.AccessToken, nil
-		}
-		t.tokenSource = nil
+	// lastErr tracks the most recent actionable error from tiers 1/2. In
+	// non-interactive mode we return it instead of the generic ErrTokenRequired
+	// so the caller sees the real cause (e.g. invalid_grant, keyring locked).
+	var lastErr error
+
+	if tok, found, err := t.tryInMemoryToken(); found {
+		return tok, nil
+	} else if err != nil {
+		lastErr = err
 	}
 
-	// Tier 2: restore from a cached refresh token in the secrets provider.
-	if err := t.tryRestoreFromCache(ctx); err == nil && t.tokenSource != nil {
-		tok, err := t.tokenSource.Token()
-		if err == nil && tok.Valid() {
-			return tok.AccessToken, nil
-		}
-		t.tokenSource = nil
+	// Tier 1.5: secrets-cached access token — avoids IdP exchange when the
+	// access token is still fresh. Concurrent short-lived processes (e.g., thv
+	// llm token) share this cached value instead of all racing to exchange the
+	// same refresh token, preventing invalid_grant from OIDC providers that
+	// rotate refresh tokens on use.
+	if tok, found := t.tryAccessTokenCache(ctx); found {
+		return tok, nil
+	}
+
+	if tok, found, err := t.tryCachedToken(ctx); found {
+		return tok, nil
+	} else if err != nil {
+		lastErr = err
 	}
 
 	// Tier 3: browser OIDC+PKCE flow — only in interactive mode.
 	if !t.interactive {
+		if lastErr != nil {
+			return "", lastErr
+		}
 		return "", ErrTokenRequired
 	}
 	if err := t.performBrowserFlow(ctx); err != nil {
@@ -104,7 +133,39 @@ func (t *TokenSource) Token(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to get token after browser flow: %w", err)
 	}
+	t.cacheAccessToken(ctx, tok.AccessToken, tok.Expiry)
 	return tok.AccessToken, nil
+}
+
+// tryInMemoryToken tries the in-memory token source (tier 1).
+func (t *TokenSource) tryInMemoryToken() (string, bool, error) {
+	if t.tokenSource == nil {
+		return "", false, nil
+	}
+	tok, err := t.tokenSource.Token()
+	if err == nil && tok.Valid() {
+		return tok.AccessToken, true, nil
+	}
+	t.tokenSource = nil
+	return "", false, err
+}
+
+// tryCachedToken restores a token source from the secrets provider (tier 2)
+// and tries to obtain a valid token from it.
+func (t *TokenSource) tryCachedToken(ctx context.Context) (string, bool, error) {
+	if err := t.tryRestoreFromCache(ctx); err != nil {
+		if errors.Is(err, errCacheMiss) {
+			return "", false, nil
+		}
+		return "", false, err
+	}
+	tok, err := t.tokenSource.Token()
+	if err == nil && tok.Valid() {
+		t.cacheAccessToken(ctx, tok.AccessToken, tok.Expiry)
+		return tok.AccessToken, true, nil
+	}
+	t.tokenSource = nil
+	return "", false, err
 }
 
 // tryRestoreFromCache attempts to build a token source from the cached refresh
@@ -115,8 +176,14 @@ func (t *TokenSource) tryRestoreFromCache(ctx context.Context) error {
 	}
 	key := t.refreshTokenKey()
 	refreshToken, err := t.secretsProvider.GetSecret(ctx, key)
-	if err != nil || refreshToken == "" {
-		return fmt.Errorf("no cached refresh token")
+	if err != nil {
+		if secrets.IsNotFoundError(err) {
+			return errCacheMiss
+		}
+		return fmt.Errorf("reading cached refresh token: %w", err)
+	}
+	if refreshToken == "" {
+		return errCacheMiss
 	}
 
 	oauth2Cfg, err := t.buildOAuth2Config(ctx)
@@ -124,14 +191,16 @@ func (t *TokenSource) tryRestoreFromCache(ctx context.Context) error {
 		return fmt.Errorf("building oauth2 config for cache restore: %w", err)
 	}
 
-	// Subtract preemptiveRefreshWindow so the oauth2 library considers the token
-	// expired 30 s before its actual expiry, triggering proactive refresh.
-	expiry := t.cfg.OIDC.CachedTokenExpiry
-	if !expiry.IsZero() {
-		expiry = expiry.Add(-preemptiveRefreshWindow)
-	}
+	base := remote.CreateTokenSourceFromCached(oauth2Cfg, refreshToken, t.cfg.OIDC.CachedTokenExpiry, t.cfg.OIDC.Audience)
 
-	t.tokenSource = remote.CreateTokenSourceFromCached(oauth2Cfg, refreshToken, expiry, "")
+	// Persist rotated refresh tokens back to the secrets provider so future CLI
+	// invocations can still restore the session if the provider invalidates the
+	// old token on refresh (common with OIDC providers that rotate refresh tokens).
+	base = remote.NewPersistingTokenSource(base, t.makeTokenPersister(key))
+
+	// Wrap with preemptive refresh so tokens are renewed 30 s before real expiry
+	// on every subsequent refresh, not just the first restore.
+	t.tokenSource = withPreemptiveRefresh(base)
 	return nil
 }
 
@@ -161,14 +230,16 @@ func (t *TokenSource) performBrowserFlow(ctx context.Context) error {
 		if tokenResult.RefreshToken != "" {
 			if err := t.secretsProvider.SetSecret(ctx, key, tokenResult.RefreshToken); err != nil {
 				slog.Warn("failed to persist initial LLM gateway refresh token", "error", err)
+			} else {
+				t.updateConfigTokenRef(key, tokenResult.Expiry)
 			}
 		} else {
 			slog.Debug("OIDC provider did not return a refresh token; token will not be persisted")
 		}
-		t.updateConfigTokenRef(key, tokenResult.Expiry)
 	}
 
-	t.tokenSource = base
+	// Wrap with preemptive refresh so tokens are renewed 30 s before real expiry.
+	t.tokenSource = withPreemptiveRefresh(base)
 	return nil
 }
 
@@ -236,6 +307,53 @@ func (t *TokenSource) refreshTokenKey() string {
 	return DeriveSecretKey(t.cfg.GatewayURL, t.cfg.OIDC.Issuer)
 }
 
+// accessTokenCacheKey returns the secrets-provider key for the cached access token.
+func (t *TokenSource) accessTokenCacheKey() string {
+	return t.refreshTokenKey() + "_AT"
+}
+
+// tryAccessTokenCache reads a previously cached access token from the secrets
+// provider and returns it if still valid. The stored expiry already accounts for
+// preemptiveRefreshWindow, so a plain time.Now().Before(expiry) check suffices.
+// All errors are treated as cache misses — a missing or corrupt entry is harmless.
+func (t *TokenSource) tryAccessTokenCache(ctx context.Context) (string, bool) {
+	if t.secretsProvider == nil {
+		return "", false
+	}
+	raw, err := t.secretsProvider.GetSecret(ctx, t.accessTokenCacheKey())
+	if err != nil || raw == "" {
+		return "", false
+	}
+	idx := strings.LastIndex(raw, "|")
+	if idx < 0 {
+		return "", false
+	}
+	expiry, err := time.Parse(time.RFC3339, raw[idx+1:])
+	if err != nil {
+		return "", false
+	}
+	if time.Now().Before(expiry) {
+		return raw[:idx], true
+	}
+	return "", false
+}
+
+// cacheAccessToken writes the access token and its expiry to the secrets
+// provider so concurrent short-lived processes can reuse it without hitting the
+// IdP. The expiry stored is the (already preemptively-shifted) expiry returned
+// by the token source, so callers can use a plain time.Now().Before(expiry)
+// check to decide validity. Errors are logged at debug level and suppressed —
+// a write failure degrades gracefully to a full refresh on the next call.
+func (t *TokenSource) cacheAccessToken(ctx context.Context, token string, expiry time.Time) {
+	if t.secretsProvider == nil || token == "" || expiry.IsZero() {
+		return
+	}
+	val := token + "|" + expiry.UTC().Format(time.RFC3339)
+	if err := t.secretsProvider.SetSecret(ctx, t.accessTokenCacheKey(), val); err != nil {
+		slog.Debug("failed to cache access token", "error", err)
+	}
+}
+
 // DeriveSecretKey computes the secrets-provider key for an LLM gateway refresh
 // token. The formula is: LLM_OAUTH_<8 hex chars> where the hex is derived from
 // sha256(gatewayURL + "\x00" + issuer)[:4], matching the pattern used by the
@@ -243,6 +361,34 @@ func (t *TokenSource) refreshTokenKey() string {
 func DeriveSecretKey(gatewayURL, issuer string) string {
 	h := sha256.Sum256([]byte(gatewayURL + "\x00" + issuer))
 	return "LLM_OAUTH_" + hex.EncodeToString(h[:4])
+}
+
+// preemptiveTokenSource wraps an oauth2.TokenSource and shifts each returned
+// token's expiry back by preemptiveRefreshWindow. This causes oauth2.ReuseTokenSource
+// to treat the token as expired 30 s before the gateway would, triggering a
+// proactive refresh on both the browser-flow and refresh-token-restore paths.
+type preemptiveTokenSource struct {
+	inner oauth2.TokenSource
+}
+
+func (p *preemptiveTokenSource) Token() (*oauth2.Token, error) {
+	tok, err := p.inner.Token()
+	if err != nil {
+		return nil, err
+	}
+	if !tok.Expiry.IsZero() {
+		shifted := *tok
+		shifted.Expiry = tok.Expiry.Add(-preemptiveRefreshWindow)
+		return &shifted, nil
+	}
+	return tok, nil
+}
+
+// withPreemptiveRefresh wraps src so tokens appear expired preemptiveRefreshWindow
+// before they actually expire, then re-wraps with ReuseTokenSource so the refresh
+// is only triggered once per window.
+func withPreemptiveRefresh(src oauth2.TokenSource) oauth2.TokenSource {
+	return oauth2.ReuseTokenSource(nil, &preemptiveTokenSource{inner: src})
 }
 
 // ensureOfflineAccess returns scopes with "offline_access" appended if absent.

--- a/pkg/llm/tokensource_test.go
+++ b/pkg/llm/tokensource_test.go
@@ -6,12 +6,14 @@ package llm
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
+	"golang.org/x/oauth2"
 
 	secretsmocks "github.com/stacklok/toolhive/pkg/secrets/mocks"
 )
@@ -83,6 +85,7 @@ func TestTokenSource_NonInteractive_NoCache_ReturnsErrTokenRequired(t *testing.T
 	t.Parallel()
 
 	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
 	mockSecrets := secretsmocks.NewMockProvider(ctrl)
 
 	// Secrets provider returns not-found for any key lookup.
@@ -98,16 +101,50 @@ func TestTokenSource_NonInteractive_NoCache_ReturnsErrTokenRequired(t *testing.T
 	require.ErrorIs(t, err, ErrTokenRequired)
 }
 
-// ── Token – non-interactive, no secrets provider → ErrTokenRequired ──────────
+// ── Token – non-interactive, actionable tier-2 error surfaces as lastErr ─────
 
-func TestTokenSource_NonInteractive_NilSecrets_ReturnsErrTokenRequired(t *testing.T) {
+// When the secrets backend returns a non-not-found error (e.g. keyring locked),
+// Token() must return that specific error rather than the generic ErrTokenRequired
+// so the caller can distinguish a backend failure from a missing session.
+func TestTokenSource_NonInteractive_BackendError_ReturnsLastErr(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+	mockSecrets := secretsmocks.NewMockProvider(ctrl)
+
+	// "keyring is locked" does not match IsNotFoundError, so it is an actionable
+	// error, not a cache miss. tier 1.5 silently ignores it; tier 2 surfaces it.
+	backendErr := errors.New("keyring is locked")
+	mockSecrets.EXPECT().
+		GetSecret(gomock.Any(), gomock.Any()).
+		Return("", backendErr).
+		AnyTimes()
+
+	ts := NewTokenSource(minimalConfig(), mockSecrets, false /* non-interactive */, nil)
+	_, err := ts.Token(context.Background())
+
+	require.Error(t, err)
+	assert.False(t, errors.Is(err, ErrTokenRequired),
+		"backend error must surface as lastErr, not the generic ErrTokenRequired")
+	assert.ErrorContains(t, err, "keyring is locked")
+}
+
+// ── Token – non-interactive, no secrets provider → error (not ErrTokenRequired) ──
+
+// When secretsProvider is nil, tier 2 returns an actionable error rather than
+// the generic ErrTokenRequired so the caller knows why the token could not be
+// obtained (no secrets store configured).
+func TestTokenSource_NonInteractive_NilSecrets_ReturnsError(t *testing.T) {
 	t.Parallel()
 
 	cfg := minimalConfig()
 	ts := NewTokenSource(cfg, nil /* no secrets */, false, nil)
 
 	_, err := ts.Token(context.Background())
-	require.ErrorIs(t, err, ErrTokenRequired)
+	require.Error(t, err)
+	assert.False(t, errors.Is(err, ErrTokenRequired),
+		"nil secrets provider should return an actionable error, not the generic ErrTokenRequired")
 }
 
 // ── refreshTokenKey – uses CachedRefreshTokenRef when set ────────────────────
@@ -135,6 +172,60 @@ func TestTokenSource_RefreshTokenKey_DerivedWhenEmpty(t *testing.T) {
 	assert.Equal(t, expected, key)
 }
 
+// ── preemptiveTokenSource – shifts expiry back by preemptiveRefreshWindow ────
+
+// staticTokenSource is a minimal oauth2.TokenSource for tests.
+type staticTokenSource struct{ tok *oauth2.Token }
+
+func (s *staticTokenSource) Token() (*oauth2.Token, error) { return s.tok, nil }
+
+func TestPreemptiveTokenSource_ShiftsExpiry(t *testing.T) {
+	t.Parallel()
+
+	realExpiry := time.Now().Add(2 * time.Minute)
+	inner := &staticTokenSource{tok: &oauth2.Token{
+		AccessToken: "access",
+		Expiry:      realExpiry,
+	}}
+
+	pts := &preemptiveTokenSource{inner: inner}
+	tok, err := pts.Token()
+	require.NoError(t, err)
+
+	wantExpiry := realExpiry.Add(-preemptiveRefreshWindow)
+	assert.WithinDuration(t, wantExpiry, tok.Expiry, time.Millisecond,
+		"expiry must be shifted back by preemptiveRefreshWindow")
+}
+
+func TestPreemptiveTokenSource_ZeroExpiry_Unchanged(t *testing.T) {
+	t.Parallel()
+
+	inner := &staticTokenSource{tok: &oauth2.Token{
+		AccessToken: "access",
+		Expiry:      time.Time{}, // zero — no expiry info
+	}}
+
+	pts := &preemptiveTokenSource{inner: inner}
+	tok, err := pts.Token()
+	require.NoError(t, err)
+	assert.True(t, tok.Expiry.IsZero(), "zero expiry must be passed through unchanged")
+}
+
+func TestPreemptiveTokenSource_PropagatesError(t *testing.T) {
+	t.Parallel()
+
+	inner := &errTokenSource{err: errors.New("refresh failed")}
+
+	pts := &preemptiveTokenSource{inner: inner}
+	_, err := pts.Token()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "refresh failed")
+}
+
+type errTokenSource struct{ err error }
+
+func (e *errTokenSource) Token() (*oauth2.Token, error) { return nil, e.err }
+
 // ── Preemptive refresh: expiry is shifted back by 30 s ───────────────────────
 
 func TestPreemptiveRefreshWindow_Value(t *testing.T) {
@@ -160,6 +251,157 @@ func TestTokenSource_PreemptiveRefreshWindow_ExpiryShift(t *testing.T) {
 		0.001,
 		"shift must equal preemptiveRefreshWindow",
 	)
+}
+
+// ── tryRestoreFromCache – empty secret value treated as missing ───────────────
+
+func TestTokenSource_TryRestoreFromCache_EmptySecret_ReturnsError(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+	mockSecrets := secretsmocks.NewMockProvider(ctrl)
+
+	// Provider returns success but empty string — treated as "no token".
+	mockSecrets.EXPECT().
+		GetSecret(gomock.Any(), gomock.Any()).
+		Return("", nil)
+
+	ts := NewTokenSource(minimalConfig(), mockSecrets, false, nil)
+	err := ts.tryRestoreFromCache(context.Background())
+	require.Error(t, err, "empty refresh token must be treated as missing")
+}
+
+// ── tryRestoreFromCache – backend error is propagated, not swallowed ──────────
+
+func TestTokenSource_TryRestoreFromCache_BackendError_Propagated(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+	mockSecrets := secretsmocks.NewMockProvider(ctrl)
+
+	// Simulate a real backend failure (keyring locked, network error, etc.).
+	backendErr := errors.New("keyring is locked")
+	mockSecrets.EXPECT().
+		GetSecret(gomock.Any(), gomock.Any()).
+		Return("", backendErr)
+
+	ts := NewTokenSource(minimalConfig(), mockSecrets, false, nil)
+	err := ts.tryRestoreFromCache(context.Background())
+
+	require.Error(t, err)
+	// Must surface the underlying backend error, not hide it as "no cached token".
+	assert.Contains(t, err.Error(), "keyring is locked",
+		"backend error must be propagated, not swallowed as a cache miss")
+}
+
+// ── tryRestoreFromCache – uses CachedRefreshTokenRef key for lookup ──────────
+
+func TestTokenSource_TryRestoreFromCache_UsesPersistedKey(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+	mockSecrets := secretsmocks.NewMockProvider(ctrl)
+
+	cfg := minimalConfig()
+	cfg.OIDC.CachedRefreshTokenRef = "persisted-ref-key"
+
+	// Must look up the persisted key, not a derived one.
+	mockSecrets.EXPECT().
+		GetSecret(gomock.Any(), "persisted-ref-key").
+		Return("", errors.New("not found"))
+
+	ts := NewTokenSource(cfg, mockSecrets, false, nil)
+	_ = ts.tryRestoreFromCache(context.Background())
+}
+
+// ── tryRestoreFromCache – GetSecret is called with the derived key ────────────
+
+// TestTokenSource_TryRestoreFromCache_CallsGetSecretWithDerivedKey verifies that
+// tier 2 looks up the refresh token using the derived key (no cached ref set).
+// A short context deadline makes the subsequent OIDC discovery call fail
+// immediately so the test never makes a real network connection.
+func TestTokenSource_TryRestoreFromCache_CallsGetSecretWithDerivedKey(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+	mockSecrets := secretsmocks.NewMockProvider(ctrl)
+
+	cfg := minimalConfig()
+	expectedKey := DeriveSecretKey(cfg.GatewayURL, cfg.OIDC.Issuer)
+
+	mockSecrets.EXPECT().
+		GetSecret(gomock.Any(), expectedKey).
+		Return("stored-refresh-token", nil)
+
+	// Cancel immediately after GetSecret so OIDC discovery aborts without
+	// making a real network call.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	ts := NewTokenSource(cfg, mockSecrets, false, nil)
+	err := ts.tryRestoreFromCache(ctx)
+
+	// Error must come from the cancelled context, not from a missing token.
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "no cached refresh token",
+		"error must be from OIDC discovery, not from missing token")
+}
+
+// ── makeTokenPersister – stores refresh token and calls updater ──────────────
+
+func TestTokenSource_MakeTokenPersister_StoresTokenAndCallsUpdater(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+	mockSecrets := secretsmocks.NewMockProvider(ctrl)
+
+	const secretKey = "LLM_OAUTH_test"
+	wantToken := "new-refresh-token"
+	wantExpiry := time.Now().Add(time.Hour)
+
+	mockSecrets.EXPECT().
+		SetSecret(gomock.Any(), secretKey, wantToken).
+		Return(nil)
+
+	var updaterKey string
+	var updaterExpiry time.Time
+	updater := func(key string, expiry time.Time) {
+		updaterKey = key
+		updaterExpiry = expiry
+	}
+
+	ts := NewTokenSource(minimalConfig(), mockSecrets, false, updater)
+	persister := ts.makeTokenPersister(secretKey)
+
+	require.NoError(t, persister(wantToken, wantExpiry))
+	assert.Equal(t, secretKey, updaterKey, "updater must receive the secret key")
+	assert.Equal(t, wantExpiry, updaterExpiry, "updater must receive the token expiry")
+}
+
+// ── makeTokenPersister – SetSecret failure is returned as error ───────────────
+
+func TestTokenSource_MakeTokenPersister_SetSecretFailure(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+	mockSecrets := secretsmocks.NewMockProvider(ctrl)
+
+	mockSecrets.EXPECT().
+		SetSecret(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(errors.New("keyring locked"))
+
+	ts := NewTokenSource(minimalConfig(), mockSecrets, false, nil)
+	persister := ts.makeTokenPersister("some-key")
+
+	err := persister("token", time.Now())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "keyring locked")
 }
 
 // ── updateConfigTokenRef – calls the injected updater ────────────────────────
@@ -193,4 +435,177 @@ func TestTokenSource_UpdateConfigTokenRef_NilUpdater_NoOp(t *testing.T) {
 	assert.NotPanics(t, func() {
 		ts.updateConfigTokenRef("key", time.Now())
 	})
+}
+
+// ── tryAccessTokenCache ───────────────────────────────────────────────────────
+
+func TestTokenSource_TryAccessTokenCache_NilProvider_ReturnsFalse(t *testing.T) {
+	t.Parallel()
+
+	ts := NewTokenSource(minimalConfig(), nil, false, nil)
+	tok, found := ts.tryAccessTokenCache(context.Background())
+	assert.False(t, found)
+	assert.Empty(t, tok)
+}
+
+func TestTokenSource_TryAccessTokenCache_NotFound_ReturnsFalse(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+	mockSecrets := secretsmocks.NewMockProvider(ctrl)
+
+	mockSecrets.EXPECT().
+		GetSecret(gomock.Any(), gomock.Any()).
+		Return("", errors.New("not found"))
+
+	ts := NewTokenSource(minimalConfig(), mockSecrets, false, nil)
+	tok, found := ts.tryAccessTokenCache(context.Background())
+	assert.False(t, found)
+	assert.Empty(t, tok)
+}
+
+func TestTokenSource_TryAccessTokenCache_ValidToken_ReturnsToken(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+	mockSecrets := secretsmocks.NewMockProvider(ctrl)
+
+	expiry := time.Now().Add(5 * time.Minute).UTC()
+	cached := "access-token-value|" + expiry.Format(time.RFC3339)
+
+	mockSecrets.EXPECT().
+		GetSecret(gomock.Any(), gomock.Any()).
+		Return(cached, nil)
+
+	ts := NewTokenSource(minimalConfig(), mockSecrets, false, nil)
+	tok, found := ts.tryAccessTokenCache(context.Background())
+	assert.True(t, found)
+	assert.Equal(t, "access-token-value", tok)
+}
+
+func TestTokenSource_TryAccessTokenCache_ExpiredToken_ReturnsFalse(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+	mockSecrets := secretsmocks.NewMockProvider(ctrl)
+
+	expiry := time.Now().Add(-1 * time.Minute).UTC()
+	cached := "access-token-value|" + expiry.Format(time.RFC3339)
+
+	mockSecrets.EXPECT().
+		GetSecret(gomock.Any(), gomock.Any()).
+		Return(cached, nil)
+
+	ts := NewTokenSource(minimalConfig(), mockSecrets, false, nil)
+	tok, found := ts.tryAccessTokenCache(context.Background())
+	assert.False(t, found)
+	assert.Empty(t, tok)
+}
+
+func TestTokenSource_TryAccessTokenCache_MalformedEntry_ReturnsFalse(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		raw  string
+	}{
+		{"no pipe", "just-a-token"},
+		{"bad expiry", "token|not-a-date"},
+		{"empty value", ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctrl := gomock.NewController(t)
+			t.Cleanup(ctrl.Finish)
+			mockSecrets := secretsmocks.NewMockProvider(ctrl)
+
+			mockSecrets.EXPECT().
+				GetSecret(gomock.Any(), gomock.Any()).
+				Return(tc.raw, nil).
+				AnyTimes()
+
+			ts := NewTokenSource(minimalConfig(), mockSecrets, false, nil)
+			tok, found := ts.tryAccessTokenCache(context.Background())
+			assert.False(t, found)
+			assert.Empty(t, tok)
+		})
+	}
+}
+
+// ── cacheAccessToken ──────────────────────────────────────────────────────────
+
+func TestTokenSource_CacheAccessToken_StoresToken(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+	mockSecrets := secretsmocks.NewMockProvider(ctrl)
+
+	expiry := time.Now().Add(time.Hour).UTC().Truncate(time.Second)
+	expectedVal := "my-access-token|" + expiry.Format(time.RFC3339)
+
+	mockSecrets.EXPECT().
+		SetSecret(gomock.Any(), gomock.Any(), expectedVal).
+		Return(nil)
+
+	ts := NewTokenSource(minimalConfig(), mockSecrets, false, nil)
+	ts.cacheAccessToken(context.Background(), "my-access-token", expiry)
+}
+
+func TestTokenSource_CacheAccessToken_NilProvider_NoOp(t *testing.T) {
+	t.Parallel()
+
+	ts := NewTokenSource(minimalConfig(), nil, false, nil)
+	// Must not panic.
+	assert.NotPanics(t, func() {
+		ts.cacheAccessToken(context.Background(), "token", time.Now().Add(time.Hour))
+	})
+}
+
+func TestTokenSource_CacheAccessToken_ZeroExpiry_NoOp(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+	mockSecrets := secretsmocks.NewMockProvider(ctrl)
+	// SetSecret must NOT be called.
+
+	ts := NewTokenSource(minimalConfig(), mockSecrets, false, nil)
+	ts.cacheAccessToken(context.Background(), "token", time.Time{})
+}
+
+func TestTokenSource_CacheAccessToken_WriteFailure_DoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+	mockSecrets := secretsmocks.NewMockProvider(ctrl)
+
+	mockSecrets.EXPECT().
+		SetSecret(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(errors.New("keyring locked"))
+
+	ts := NewTokenSource(minimalConfig(), mockSecrets, false, nil)
+	assert.NotPanics(t, func() {
+		ts.cacheAccessToken(context.Background(), "token", time.Now().Add(time.Hour))
+	})
+}
+
+// ── accessTokenCacheKey ───────────────────────────────────────────────────────
+
+func TestTokenSource_AccessTokenCacheKey_HasATSuffix(t *testing.T) {
+	t.Parallel()
+
+	ts := NewTokenSource(minimalConfig(), nil, false, nil)
+	key := ts.accessTokenCacheKey()
+	assert.True(t, strings.HasSuffix(key, "_AT"),
+		"access token cache key must end with _AT, got %q", key)
+	assert.Contains(t, key, ts.refreshTokenKey(),
+		"access token cache key must be derived from the refresh token key")
 }

--- a/pkg/llm/tokensource_test.go
+++ b/pkg/llm/tokensource_test.go
@@ -1,0 +1,196 @@
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package llm
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	secretsmocks "github.com/stacklok/toolhive/pkg/secrets/mocks"
+)
+
+// minimalConfig returns a Config with the minimum fields for a configured gateway.
+func minimalConfig() *Config {
+	return &Config{
+		GatewayURL: "https://llm.example.com",
+		OIDC: OIDCConfig{
+			Issuer:   "https://auth.example.com",
+			ClientID: "test-client",
+		},
+	}
+}
+
+// ── DeriveSecretKey ───────────────────────────────────────────────────────────
+
+func TestDeriveSecretKey(t *testing.T) {
+	t.Parallel()
+
+	key1 := DeriveSecretKey("https://llm.example.com", "https://auth.example.com")
+	key2 := DeriveSecretKey("https://llm.example.com", "https://auth.example.com")
+	key3 := DeriveSecretKey("https://other.example.com", "https://auth.example.com")
+
+	assert.Equal(t, key1, key2, "same inputs must produce the same key")
+	assert.NotEqual(t, key1, key3, "different gateway URLs must produce different keys")
+	assert.Contains(t, key1, "LLM_OAUTH_", "key must start with expected prefix")
+}
+
+// ── ensureOfflineAccess ───────────────────────────────────────────────────────
+
+func TestEnsureOfflineAccess(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		input  []string
+		expect []string
+	}{
+		{
+			name:   "already present",
+			input:  []string{"openid", "offline_access"},
+			expect: []string{"openid", "offline_access"},
+		},
+		{
+			name:   "not present",
+			input:  []string{"openid"},
+			expect: []string{"openid", "offline_access"},
+		},
+		{
+			name:   "empty",
+			input:  []string{},
+			expect: []string{"offline_access"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := ensureOfflineAccess(tc.input)
+			assert.Equal(t, tc.expect, got)
+		})
+	}
+}
+
+// ── Token – non-interactive, no cached token → ErrTokenRequired ──────────────
+
+func TestTokenSource_NonInteractive_NoCache_ReturnsErrTokenRequired(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	mockSecrets := secretsmocks.NewMockProvider(ctrl)
+
+	// Secrets provider returns not-found for any key lookup.
+	mockSecrets.EXPECT().
+		GetSecret(gomock.Any(), gomock.Any()).
+		Return("", errors.New("not found")).
+		AnyTimes()
+
+	cfg := minimalConfig()
+	ts := NewTokenSource(cfg, mockSecrets, false /* non-interactive */, nil)
+
+	_, err := ts.Token(context.Background())
+	require.ErrorIs(t, err, ErrTokenRequired)
+}
+
+// ── Token – non-interactive, no secrets provider → ErrTokenRequired ──────────
+
+func TestTokenSource_NonInteractive_NilSecrets_ReturnsErrTokenRequired(t *testing.T) {
+	t.Parallel()
+
+	cfg := minimalConfig()
+	ts := NewTokenSource(cfg, nil /* no secrets */, false, nil)
+
+	_, err := ts.Token(context.Background())
+	require.ErrorIs(t, err, ErrTokenRequired)
+}
+
+// ── refreshTokenKey – uses CachedRefreshTokenRef when set ────────────────────
+
+func TestTokenSource_RefreshTokenKey_UsesCached(t *testing.T) {
+	t.Parallel()
+
+	cfg := minimalConfig()
+	cfg.OIDC.CachedRefreshTokenRef = "my-persisted-key"
+
+	ts := NewTokenSource(cfg, nil, false, nil)
+	assert.Equal(t, "my-persisted-key", ts.refreshTokenKey())
+}
+
+// ── refreshTokenKey – derives key when no cached ref ─────────────────────────
+
+func TestTokenSource_RefreshTokenKey_DerivedWhenEmpty(t *testing.T) {
+	t.Parallel()
+
+	cfg := minimalConfig()
+	ts := NewTokenSource(cfg, nil, false, nil)
+
+	key := ts.refreshTokenKey()
+	expected := DeriveSecretKey(cfg.GatewayURL, cfg.OIDC.Issuer)
+	assert.Equal(t, expected, key)
+}
+
+// ── Preemptive refresh: expiry is shifted back by 30 s ───────────────────────
+
+func TestPreemptiveRefreshWindow_Value(t *testing.T) {
+	t.Parallel()
+	// The window must be exactly 30 s so token helpers and proxy workers
+	// consistently treat tokens as expired before the gateway does.
+	assert.Equal(t, 30*time.Second, preemptiveRefreshWindow)
+}
+
+func TestTokenSource_PreemptiveRefreshWindow_ExpiryShift(t *testing.T) {
+	t.Parallel()
+
+	// Verify the expiry shift arithmetic: a token expiring in 2 minutes should
+	// have its effective expiry moved back by preemptiveRefreshWindow.
+	realExpiry := time.Now().Add(2 * time.Minute)
+	shifted := realExpiry.Add(-preemptiveRefreshWindow)
+
+	assert.True(t, shifted.Before(realExpiry),
+		"shifted expiry must be earlier than the real expiry")
+	assert.InDelta(t,
+		preemptiveRefreshWindow.Seconds(),
+		realExpiry.Sub(shifted).Seconds(),
+		0.001,
+		"shift must equal preemptiveRefreshWindow",
+	)
+}
+
+// ── updateConfigTokenRef – calls the injected updater ────────────────────────
+
+func TestTokenSource_UpdateConfigTokenRef_CallsUpdater(t *testing.T) {
+	t.Parallel()
+
+	var gotKey string
+	var gotExpiry time.Time
+
+	updater := func(key string, expiry time.Time) {
+		gotKey = key
+		gotExpiry = expiry
+	}
+
+	ts := NewTokenSource(minimalConfig(), nil, false, updater)
+	wantExpiry := time.Now().Add(time.Hour)
+	ts.updateConfigTokenRef("test-key", wantExpiry)
+
+	assert.Equal(t, "test-key", gotKey)
+	assert.Equal(t, wantExpiry, gotExpiry)
+}
+
+// ── updateConfigTokenRef – nil updater is a no-op ────────────────────────────
+
+func TestTokenSource_UpdateConfigTokenRef_NilUpdater_NoOp(t *testing.T) {
+	t.Parallel()
+
+	ts := NewTokenSource(minimalConfig(), nil, false, nil)
+	// Must not panic.
+	assert.NotPanics(t, func() {
+		ts.updateConfigTokenRef("key", time.Now())
+	})
+}


### PR DESCRIPTION

## Summary

<!--
REQUIRED. You MUST explain:
1. WHY this change is needed (the problem or motivation)
2. WHAT changed (concise bullet points)

The diff shows the code — your summary must provide the context a reviewer
needs to understand the purpose without reading the diff first.
-->

Adds a three-tier TokenSource (in-memory → cached refresh token → browser OIDC+PKCE flow) for the LLM gateway. Access tokens are held in memory only; refresh tokens are persisted via ScopeLLM secrets. A 30 s preemptive refresh window avoids gateway rejections on expiry.

thv llm token is now fully implemented: non-interactive, prints a fresh JWT to stdout with all other output on stderr, suitable for use as apiKeyHelper or auth.command in Claude Code / Cursor.

<!--
Link related issues. Use "Closes" or "Fixes" to auto-close on merge.
Remove this line if there is no related issue.
-->

Fixes #5028 

## Type of change

<!-- REQUIRED. Check exactly one. -->

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

<!--
REQUIRED. Check every verification step you actually ran.
You MUST check at least one item. If you only did manual testing,
describe exactly what you tested below the checkbox.
-->

- [x] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [ ] Linting (`task lint-fix`)
- [ ] Manual testing (describe below)

## API Compatibility

<!--
The CRD Schema Compatibility check guards the v1beta1 operator API.
If the check flags this PR as Incompatible and the break is intentional,
apply the `api-break-allowed` label and describe below:

1. Which fields, types, or CRDs are changing.
2. Why the break is unavoidable.
3. The user-facing migration path (what cluster admins need to do).

See CONTRIBUTING.md → "API Stability" for the full rubric. Coordinate
with maintainers before applying the label.

Remove this section entirely if the PR does not touch operator API surface.
-->

- [ ] This PR does not break the `v1beta1` API, OR the `api-break-allowed` label is applied and the migration guidance is described above.

## Changes

<!--
Optional — include for PRs touching more than a few files to help
reviewers navigate the diff. Remove this entire section for small PRs.
-->

| File | Change |
|------|--------|
|      |        |

## Does this introduce a user-facing change?

<!--
If yes, describe the change from the user's perspective. This helps with release notes.
If no, write "No".
Remove this section entirely if not applicable.
-->

## Implementation plan

<!--
Optional — include when this PR was planned with an AI assistant (Claude Code, etc.).
Paste the approved plan inside the <details> block so reviewers can see the intended
design without cluttering the main PR description. Remove this section entirely
for PRs that were not AI-planned.
-->

<details>
<summary>Approved implementation plan</summary>

<!-- Paste the plan here -->

</details>

## Special notes for reviewers

<!--
Optional — call out anything non-obvious: tricky logic, known limitations,
areas where you'd like extra scrutiny, or follow-up work planned.
Remove this section if not needed.
-->

## Large PR Justification

This is an isolated PR that covers a single functionality. Cannot be split.
