### PR TITLE
Add authserver DCR discovery and config surface

### DIFF
--- a/docs/server/docs.go
+++ b/docs/server/docs.go
@@ -411,6 +411,36 @@ const docTemplate = `{
                 },
                 "type": "object"
             },
+            "github_com_stacklok_toolhive_pkg_authserver.DCRUpstreamConfig": {
+                "description": "DCRConfig enables RFC 7591 Dynamic Client Registration against the\nupstream authorization server. When set, the client credentials are\nobtained at runtime rather than being pre-provisioned via ClientID /\nClientSecretFile / ClientSecretEnvVar, and ClientID must be left empty.\nMutually exclusive with ClientID.",
+                "properties": {
+                    "discovery_url": {
+                        "description": "DiscoveryURL is the RFC 8414 / OIDC Discovery URL from which the\nregistration_endpoint is resolved at runtime. Mutually exclusive with\nRegistrationEndpoint.",
+                        "type": "string"
+                    },
+                    "initial_access_token_env_var": {
+                        "description": "InitialAccessTokenEnvVar is the name of an environment variable\ncontaining the RFC 7591 initial access token. Mutually exclusive with\nInitialAccessTokenFile.",
+                        "type": "string"
+                    },
+                    "initial_access_token_file": {
+                        "description": "InitialAccessTokenFile is the path to a file containing the RFC 7591\ninitial access token presented to the registration endpoint. Mutually\nexclusive with InitialAccessTokenEnvVar. Both may be omitted for open\nregistration endpoints.",
+                        "type": "string"
+                    },
+                    "registration_endpoint": {
+                        "description": "RegistrationEndpoint is the RFC 7591 registration endpoint URL used\ndirectly, bypassing discovery. Mutually exclusive with DiscoveryURL.",
+                        "type": "string"
+                    },
+                    "software_id": {
+                        "description": "SoftwareID is the RFC 7591 \"software_id\" registration metadata value,\nidentifying the client software independent of any particular\nregistration instance.",
+                        "type": "string"
+                    },
+                    "software_statement": {
+                        "description": "SoftwareStatement is the RFC 7591 \"software_statement\" JWT asserting\nmetadata about the client software, signed by a party the authorization\nserver trusts.",
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
             "github_com_stacklok_toolhive_pkg_authserver.OAuth2UpstreamRunConfig": {
                 "description": "OAuth2Config contains OAuth 2.0-specific configuration.\nRequired when Type is \"oauth2\", must be nil when Type is \"oidc\".",
                 "properties": {
@@ -426,7 +456,7 @@ const docTemplate = `{
                         "type": "string"
                     },
                     "client_id": {
-                        "description": "ClientID is the OAuth 2.0 client identifier registered with the upstream IDP.",
+                        "description": "ClientID is the OAuth 2.0 client identifier registered with the upstream IDP.\nMutually exclusive with DCRConfig: when DCRConfig is set, ClientID is obtained\nat runtime via RFC 7591 Dynamic Client Registration and must be left empty.",
                         "type": "string"
                     },
                     "client_secret_env_var": {
@@ -436,6 +466,9 @@ const docTemplate = `{
                     "client_secret_file": {
                         "description": "ClientSecretFile is the path to a file containing the OAuth 2.0 client secret.\nMutually exclusive with ClientSecretEnvVar. Optional for public clients using PKCE.",
                         "type": "string"
+                    },
+                    "dcr_config": {
+                        "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_authserver.DCRUpstreamConfig"
                     },
                     "redirect_uri": {
                         "description": "RedirectURI is the callback URL where the upstream IDP will redirect after authentication.\nWhen not specified, defaults to ` + "`" + `{issuer}/oauth/callback` + "`" + `.",

--- a/docs/server/swagger.json
+++ b/docs/server/swagger.json
@@ -404,6 +404,36 @@
                 },
                 "type": "object"
             },
+            "github_com_stacklok_toolhive_pkg_authserver.DCRUpstreamConfig": {
+                "description": "DCRConfig enables RFC 7591 Dynamic Client Registration against the\nupstream authorization server. When set, the client credentials are\nobtained at runtime rather than being pre-provisioned via ClientID /\nClientSecretFile / ClientSecretEnvVar, and ClientID must be left empty.\nMutually exclusive with ClientID.",
+                "properties": {
+                    "discovery_url": {
+                        "description": "DiscoveryURL is the RFC 8414 / OIDC Discovery URL from which the\nregistration_endpoint is resolved at runtime. Mutually exclusive with\nRegistrationEndpoint.",
+                        "type": "string"
+                    },
+                    "initial_access_token_env_var": {
+                        "description": "InitialAccessTokenEnvVar is the name of an environment variable\ncontaining the RFC 7591 initial access token. Mutually exclusive with\nInitialAccessTokenFile.",
+                        "type": "string"
+                    },
+                    "initial_access_token_file": {
+                        "description": "InitialAccessTokenFile is the path to a file containing the RFC 7591\ninitial access token presented to the registration endpoint. Mutually\nexclusive with InitialAccessTokenEnvVar. Both may be omitted for open\nregistration endpoints.",
+                        "type": "string"
+                    },
+                    "registration_endpoint": {
+                        "description": "RegistrationEndpoint is the RFC 7591 registration endpoint URL used\ndirectly, bypassing discovery. Mutually exclusive with DiscoveryURL.",
+                        "type": "string"
+                    },
+                    "software_id": {
+                        "description": "SoftwareID is the RFC 7591 \"software_id\" registration metadata value,\nidentifying the client software independent of any particular\nregistration instance.",
+                        "type": "string"
+                    },
+                    "software_statement": {
+                        "description": "SoftwareStatement is the RFC 7591 \"software_statement\" JWT asserting\nmetadata about the client software, signed by a party the authorization\nserver trusts.",
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
             "github_com_stacklok_toolhive_pkg_authserver.OAuth2UpstreamRunConfig": {
                 "description": "OAuth2Config contains OAuth 2.0-specific configuration.\nRequired when Type is \"oauth2\", must be nil when Type is \"oidc\".",
                 "properties": {
@@ -419,7 +449,7 @@
                         "type": "string"
                     },
                     "client_id": {
-                        "description": "ClientID is the OAuth 2.0 client identifier registered with the upstream IDP.",
+                        "description": "ClientID is the OAuth 2.0 client identifier registered with the upstream IDP.\nMutually exclusive with DCRConfig: when DCRConfig is set, ClientID is obtained\nat runtime via RFC 7591 Dynamic Client Registration and must be left empty.",
                         "type": "string"
                     },
                     "client_secret_env_var": {
@@ -429,6 +459,9 @@
                     "client_secret_file": {
                         "description": "ClientSecretFile is the path to a file containing the OAuth 2.0 client secret.\nMutually exclusive with ClientSecretEnvVar. Optional for public clients using PKCE.",
                         "type": "string"
+                    },
+                    "dcr_config": {
+                        "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_authserver.DCRUpstreamConfig"
                     },
                     "redirect_uri": {
                         "description": "RedirectURI is the callback URL where the upstream IDP will redirect after authentication.\nWhen not specified, defaults to `{issuer}/oauth/callback`.",

--- a/docs/server/swagger.yaml
+++ b/docs/server/swagger.yaml
@@ -405,6 +405,51 @@ components:
             This is required and must match a configured upstream provider name.
           type: string
       type: object
+    github_com_stacklok_toolhive_pkg_authserver.DCRUpstreamConfig:
+      description: |-
+        DCRConfig enables RFC 7591 Dynamic Client Registration against the
+        upstream authorization server. When set, the client credentials are
+        obtained at runtime rather than being pre-provisioned via ClientID /
+        ClientSecretFile / ClientSecretEnvVar, and ClientID must be left empty.
+        Mutually exclusive with ClientID.
+      properties:
+        discovery_url:
+          description: |-
+            DiscoveryURL is the RFC 8414 / OIDC Discovery URL from which the
+            registration_endpoint is resolved at runtime. Mutually exclusive with
+            RegistrationEndpoint.
+          type: string
+        initial_access_token_env_var:
+          description: |-
+            InitialAccessTokenEnvVar is the name of an environment variable
+            containing the RFC 7591 initial access token. Mutually exclusive with
+            InitialAccessTokenFile.
+          type: string
+        initial_access_token_file:
+          description: |-
+            InitialAccessTokenFile is the path to a file containing the RFC 7591
+            initial access token presented to the registration endpoint. Mutually
+            exclusive with InitialAccessTokenEnvVar. Both may be omitted for open
+            registration endpoints.
+          type: string
+        registration_endpoint:
+          description: |-
+            RegistrationEndpoint is the RFC 7591 registration endpoint URL used
+            directly, bypassing discovery. Mutually exclusive with DiscoveryURL.
+          type: string
+        software_id:
+          description: |-
+            SoftwareID is the RFC 7591 "software_id" registration metadata value,
+            identifying the client software independent of any particular
+            registration instance.
+          type: string
+        software_statement:
+          description: |-
+            SoftwareStatement is the RFC 7591 "software_statement" JWT asserting
+            metadata about the client software, signed by a party the authorization
+            server trusts.
+          type: string
+      type: object
     github_com_stacklok_toolhive_pkg_authserver.OAuth2UpstreamRunConfig:
       description: |-
         OAuth2Config contains OAuth 2.0-specific configuration.
@@ -423,8 +468,10 @@ components:
             endpoint.
           type: string
         client_id:
-          description: ClientID is the OAuth 2.0 client identifier registered with
-            the upstream IDP.
+          description: |-
+            ClientID is the OAuth 2.0 client identifier registered with the upstream IDP.
+            Mutually exclusive with DCRConfig: when DCRConfig is set, ClientID is obtained
+            at runtime via RFC 7591 Dynamic Client Registration and must be left empty.
           type: string
         client_secret_env_var:
           description: |-
@@ -436,6 +483,8 @@ components:
             ClientSecretFile is the path to a file containing the OAuth 2.0 client secret.
             Mutually exclusive with ClientSecretEnvVar. Optional for public clients using PKCE.
           type: string
+        dcr_config:
+          $ref: '#/components/schemas/github_com_stacklok_toolhive_pkg_authserver.DCRUpstreamConfig'
         redirect_uri:
           description: |-
             RedirectURI is the callback URL where the upstream IDP will redirect after authentication.

--- a/pkg/authserver/config.go
+++ b/pkg/authserver/config.go
@@ -211,6 +211,8 @@ type OAuth2UpstreamRunConfig struct {
 	TokenEndpoint string `json:"token_endpoint" yaml:"token_endpoint"`
 
 	// ClientID is the OAuth 2.0 client identifier registered with the upstream IDP.
+	// Mutually exclusive with DCRConfig: when DCRConfig is set, ClientID is obtained
+	// at runtime via RFC 7591 Dynamic Client Registration and must be left empty.
 	ClientID string `json:"client_id" yaml:"client_id"`
 
 	// ClientSecretFile is the path to a file containing the OAuth 2.0 client secret.
@@ -246,6 +248,56 @@ type OAuth2UpstreamRunConfig struct {
 	// Google's access_type=offline.
 	//nolint:lll // field tags require full JSON+YAML names
 	AdditionalAuthorizationParams map[string]string `json:"additional_authorization_params,omitempty" yaml:"additional_authorization_params,omitempty"`
+
+	// DCRConfig enables RFC 7591 Dynamic Client Registration against the
+	// upstream authorization server. When set, the client credentials are
+	// obtained at runtime rather than being pre-provisioned via ClientID /
+	// ClientSecretFile / ClientSecretEnvVar, and ClientID must be left empty.
+	// Mutually exclusive with ClientID.
+	DCRConfig *DCRUpstreamConfig `json:"dcr_config,omitempty" yaml:"dcr_config,omitempty"`
+}
+
+// DCRUpstreamConfig configures RFC 7591 Dynamic Client Registration for an
+// upstream authorization server. When present on an OAuth2 upstream, the
+// authserver performs registration at runtime to obtain client credentials,
+// replacing the need to pre-provision a ClientID.
+//
+// Exactly one of DiscoveryURL or RegistrationEndpoint must be set. DiscoveryURL
+// points at RFC 8414 / OIDC Discovery metadata from which the registration
+// endpoint is resolved; RegistrationEndpoint is used directly when the upstream
+// does not publish discovery metadata.
+type DCRUpstreamConfig struct {
+	// DiscoveryURL is the RFC 8414 / OIDC Discovery URL from which the
+	// registration_endpoint is resolved at runtime. Mutually exclusive with
+	// RegistrationEndpoint.
+	DiscoveryURL string `json:"discovery_url,omitempty" yaml:"discovery_url,omitempty"`
+
+	// RegistrationEndpoint is the RFC 7591 registration endpoint URL used
+	// directly, bypassing discovery. Mutually exclusive with DiscoveryURL.
+	RegistrationEndpoint string `json:"registration_endpoint,omitempty" yaml:"registration_endpoint,omitempty"`
+
+	// InitialAccessTokenFile is the path to a file containing the RFC 7591
+	// initial access token presented to the registration endpoint. Mutually
+	// exclusive with InitialAccessTokenEnvVar. Both may be omitted for open
+	// registration endpoints.
+	//nolint:lll // field tags require full JSON+YAML names
+	InitialAccessTokenFile string `json:"initial_access_token_file,omitempty" yaml:"initial_access_token_file,omitempty"`
+
+	// InitialAccessTokenEnvVar is the name of an environment variable
+	// containing the RFC 7591 initial access token. Mutually exclusive with
+	// InitialAccessTokenFile.
+	//nolint:lll // field tags require full JSON+YAML names
+	InitialAccessTokenEnvVar string `json:"initial_access_token_env_var,omitempty" yaml:"initial_access_token_env_var,omitempty"`
+
+	// SoftwareID is the RFC 7591 "software_id" registration metadata value,
+	// identifying the client software independent of any particular
+	// registration instance.
+	SoftwareID string `json:"software_id,omitempty" yaml:"software_id,omitempty"`
+
+	// SoftwareStatement is the RFC 7591 "software_statement" JWT asserting
+	// metadata about the client software, signed by a party the authorization
+	// server trusts.
+	SoftwareStatement string `json:"software_statement,omitempty" yaml:"software_statement,omitempty"`
 }
 
 // TokenResponseMappingRunConfig maps non-standard token response fields to standard fields.
@@ -596,5 +648,53 @@ func validateIssuerURL(issuer string) error {
 		return fmt.Errorf("must not have trailing slash")
 	}
 
+	return nil
+}
+
+// Validate checks that the OAuth2UpstreamRunConfig is internally consistent.
+// It enforces the mutual exclusivity of ClientID and DCRConfig: exactly one must
+// be set. A ClientID is required for pre-provisioned clients; a DCRConfig is
+// required when client credentials are obtained at runtime via RFC 7591
+// Dynamic Client Registration. When DCRConfig is present, its own validity is
+// also checked via DCRUpstreamConfig.Validate.
+//
+// Validate intentionally does not verify fields handled by the shared
+// CommonOAuthConfig or upstream.OAuth2Config validators — it only covers the
+// run-config surface area unique to OAuth2UpstreamRunConfig.
+func (c *OAuth2UpstreamRunConfig) Validate() error {
+	hasClientID := c.ClientID != ""
+	hasDCR := c.DCRConfig != nil
+	switch {
+	case !hasClientID && !hasDCR:
+		return fmt.Errorf("oauth2 upstream: either client_id or dcr_config is required")
+	case hasClientID && hasDCR:
+		return fmt.Errorf("oauth2 upstream: client_id and dcr_config are mutually exclusive")
+	}
+
+	if hasDCR {
+		if err := c.DCRConfig.Validate(); err != nil {
+			return fmt.Errorf("oauth2 upstream: invalid dcr_config: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// Validate checks that the DCRUpstreamConfig specifies exactly one of
+// DiscoveryURL or RegistrationEndpoint.
+//
+// DiscoveryURL triggers runtime resolution of the registration endpoint via
+// RFC 8414 / OIDC Discovery; RegistrationEndpoint bypasses discovery for
+// providers that do not publish metadata. Requiring exactly one prevents
+// ambiguity about which URL the authserver should contact for registration.
+func (c *DCRUpstreamConfig) Validate() error {
+	hasDiscovery := c.DiscoveryURL != ""
+	hasRegistration := c.RegistrationEndpoint != ""
+	switch {
+	case !hasDiscovery && !hasRegistration:
+		return fmt.Errorf("dcr_config: either discovery_url or registration_endpoint is required")
+	case hasDiscovery && hasRegistration:
+		return fmt.Errorf("dcr_config: discovery_url and registration_endpoint are mutually exclusive")
+	}
 	return nil
 }

--- a/pkg/authserver/config.go
+++ b/pkg/authserver/config.go
@@ -479,6 +479,87 @@ func (c *Config) Validate() error {
 	return nil
 }
 
+// Validate checks that the OAuth2UpstreamRunConfig is internally consistent.
+// It enforces the mutual exclusivity of ClientID and DCRConfig: exactly one must
+// be set. A ClientID is required for pre-provisioned clients; a DCRConfig is
+// required when client credentials are obtained at runtime via RFC 7591
+// Dynamic Client Registration. When DCRConfig is present, its own validity is
+// also checked via DCRUpstreamConfig.Validate.
+//
+// Validate intentionally does not verify fields handled by the shared
+// CommonOAuthConfig or upstream.OAuth2Config validators — it only covers the
+// run-config surface area unique to OAuth2UpstreamRunConfig.
+//
+// Called from buildPureOAuth2Config at the RunConfig → upstream.OAuth2Config
+// conversion boundary so that DCR-specific fields are validated before they
+// are dropped during conversion.
+func (c *OAuth2UpstreamRunConfig) Validate() error {
+	hasClientID := c.ClientID != ""
+	hasDCR := c.DCRConfig != nil
+	switch {
+	case !hasClientID && !hasDCR:
+		return fmt.Errorf("oauth2 upstream: either client_id or dcr_config is required")
+	case hasClientID && hasDCR:
+		return fmt.Errorf("oauth2 upstream: client_id and dcr_config are mutually exclusive")
+	}
+
+	if hasDCR {
+		if err := c.DCRConfig.Validate(); err != nil {
+			return fmt.Errorf("oauth2 upstream: invalid dcr_config: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// Validate checks that the DCRUpstreamConfig specifies exactly one of
+// DiscoveryURL or RegistrationEndpoint, that the configured URL is well-formed
+// and uses HTTPS (or http on a loopback host for local development), and that
+// the two initial-access-token sources (InitialAccessTokenFile and
+// InitialAccessTokenEnvVar) are not both set.
+//
+// DiscoveryURL triggers runtime resolution of the registration endpoint via
+// RFC 8414 / OIDC Discovery; RegistrationEndpoint bypasses discovery for
+// providers that do not publish metadata. Requiring exactly one prevents
+// ambiguity about which URL the authserver should contact for registration.
+//
+// URL well-formedness and HTTPS are enforced here at the schema-validation
+// boundary so misconfiguration fails fast at startup rather than at first DCR
+// attempt; the runtime callers (pkg/oauthproto/discovery.go and
+// pkg/oauthproto/dcr.go) defend in depth, but this is the natural fail-fast
+// point.
+//
+// Rejecting a config that supplies both an InitialAccessTokenFile and an
+// InitialAccessTokenEnvVar prevents a credential-rotation footgun: if both
+// were accepted, an operator updating the env-var value would not realize
+// the file source still wins (or vice versa) and would silently keep
+// presenting a stale token at registration.
+func (c *DCRUpstreamConfig) Validate() error {
+	hasDiscovery := c.DiscoveryURL != ""
+	hasRegistration := c.RegistrationEndpoint != ""
+	switch {
+	case !hasDiscovery && !hasRegistration:
+		return fmt.Errorf("dcr_config: either discovery_url or registration_endpoint is required")
+	case hasDiscovery && hasRegistration:
+		return fmt.Errorf("dcr_config: discovery_url and registration_endpoint are mutually exclusive")
+	case hasDiscovery:
+		if err := networking.ValidateEndpointURL(c.DiscoveryURL); err != nil {
+			return fmt.Errorf("dcr_config: invalid discovery_url: %w", err)
+		}
+	case hasRegistration:
+		if err := networking.ValidateEndpointURL(c.RegistrationEndpoint); err != nil {
+			return fmt.Errorf("dcr_config: invalid registration_endpoint: %w", err)
+		}
+	}
+
+	if c.InitialAccessTokenFile != "" && c.InitialAccessTokenEnvVar != "" {
+		return fmt.Errorf(
+			"dcr_config: initial_access_token_file and initial_access_token_env_var are mutually exclusive")
+	}
+
+	return nil
+}
+
 // validateUpstreams validates the upstream configurations.
 func (c *Config) validateUpstreams() error {
 	if len(c.Upstreams) == 0 {
@@ -648,53 +729,5 @@ func validateIssuerURL(issuer string) error {
 		return fmt.Errorf("must not have trailing slash")
 	}
 
-	return nil
-}
-
-// Validate checks that the OAuth2UpstreamRunConfig is internally consistent.
-// It enforces the mutual exclusivity of ClientID and DCRConfig: exactly one must
-// be set. A ClientID is required for pre-provisioned clients; a DCRConfig is
-// required when client credentials are obtained at runtime via RFC 7591
-// Dynamic Client Registration. When DCRConfig is present, its own validity is
-// also checked via DCRUpstreamConfig.Validate.
-//
-// Validate intentionally does not verify fields handled by the shared
-// CommonOAuthConfig or upstream.OAuth2Config validators — it only covers the
-// run-config surface area unique to OAuth2UpstreamRunConfig.
-func (c *OAuth2UpstreamRunConfig) Validate() error {
-	hasClientID := c.ClientID != ""
-	hasDCR := c.DCRConfig != nil
-	switch {
-	case !hasClientID && !hasDCR:
-		return fmt.Errorf("oauth2 upstream: either client_id or dcr_config is required")
-	case hasClientID && hasDCR:
-		return fmt.Errorf("oauth2 upstream: client_id and dcr_config are mutually exclusive")
-	}
-
-	if hasDCR {
-		if err := c.DCRConfig.Validate(); err != nil {
-			return fmt.Errorf("oauth2 upstream: invalid dcr_config: %w", err)
-		}
-	}
-
-	return nil
-}
-
-// Validate checks that the DCRUpstreamConfig specifies exactly one of
-// DiscoveryURL or RegistrationEndpoint.
-//
-// DiscoveryURL triggers runtime resolution of the registration endpoint via
-// RFC 8414 / OIDC Discovery; RegistrationEndpoint bypasses discovery for
-// providers that do not publish metadata. Requiring exactly one prevents
-// ambiguity about which URL the authserver should contact for registration.
-func (c *DCRUpstreamConfig) Validate() error {
-	hasDiscovery := c.DiscoveryURL != ""
-	hasRegistration := c.RegistrationEndpoint != ""
-	switch {
-	case !hasDiscovery && !hasRegistration:
-		return fmt.Errorf("dcr_config: either discovery_url or registration_endpoint is required")
-	case hasDiscovery && hasRegistration:
-		return fmt.Errorf("dcr_config: discovery_url and registration_endpoint are mutually exclusive")
-	}
 	return nil
 }

--- a/pkg/authserver/config_test.go
+++ b/pkg/authserver/config_test.go
@@ -239,3 +239,134 @@ func assertError(t *testing.T, err error, wantErr bool, errMsg string) {
 		t.Errorf("unexpected error: %v", err)
 	}
 }
+
+func TestOAuth2UpstreamRunConfigValidate(t *testing.T) {
+	t.Parallel()
+
+	validDCR := &DCRUpstreamConfig{
+		DiscoveryURL: "https://idp.example.com/.well-known/oauth-authorization-server",
+	}
+
+	tests := []struct {
+		name    string
+		config  OAuth2UpstreamRunConfig
+		wantErr bool
+		errMsg  string
+	}{
+		// Four ClientID x DCRConfig combinations.
+		{
+			name:    "empty ClientID and nil DCRConfig rejects",
+			config:  OAuth2UpstreamRunConfig{},
+			wantErr: true,
+			errMsg:  "either client_id or dcr_config is required",
+		},
+		{
+			name:    "non-empty ClientID and non-nil DCRConfig rejects",
+			config:  OAuth2UpstreamRunConfig{ClientID: "c", DCRConfig: validDCR},
+			wantErr: true,
+			errMsg:  "client_id and dcr_config are mutually exclusive",
+		},
+		{
+			name:   "non-empty ClientID and nil DCRConfig is valid",
+			config: OAuth2UpstreamRunConfig{ClientID: "c"},
+		},
+		{
+			name:   "empty ClientID and non-nil DCRConfig is valid",
+			config: OAuth2UpstreamRunConfig{DCRConfig: validDCR},
+		},
+
+		// DCRConfig exactly-one-of rule propagates.
+		{
+			name: "DCRConfig with both discovery_url and registration_endpoint rejects",
+			config: OAuth2UpstreamRunConfig{
+				DCRConfig: &DCRUpstreamConfig{
+					DiscoveryURL:         "https://idp.example.com/.well-known/oauth-authorization-server",
+					RegistrationEndpoint: "https://idp.example.com/register",
+				},
+			},
+			wantErr: true,
+			errMsg:  "discovery_url and registration_endpoint are mutually exclusive",
+		},
+		{
+			name: "DCRConfig with neither discovery_url nor registration_endpoint rejects",
+			config: OAuth2UpstreamRunConfig{
+				DCRConfig: &DCRUpstreamConfig{},
+			},
+			wantErr: true,
+			errMsg:  "either discovery_url or registration_endpoint is required",
+		},
+		{
+			name: "DCRConfig with only registration_endpoint is valid",
+			config: OAuth2UpstreamRunConfig{
+				DCRConfig: &DCRUpstreamConfig{
+					RegistrationEndpoint: "https://idp.example.com/register",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := tt.config.Validate()
+			assertError(t, err, tt.wantErr, tt.errMsg)
+		})
+	}
+}
+
+func TestDCRUpstreamConfigValidate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		config  DCRUpstreamConfig
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "neither discovery_url nor registration_endpoint rejects",
+			config:  DCRUpstreamConfig{},
+			wantErr: true,
+			errMsg:  "either discovery_url or registration_endpoint is required",
+		},
+		{
+			name: "both discovery_url and registration_endpoint rejects",
+			config: DCRUpstreamConfig{
+				DiscoveryURL:         "https://idp.example.com/.well-known/oauth-authorization-server",
+				RegistrationEndpoint: "https://idp.example.com/register",
+			},
+			wantErr: true,
+			errMsg:  "discovery_url and registration_endpoint are mutually exclusive",
+		},
+		{
+			name: "only discovery_url is valid",
+			config: DCRUpstreamConfig{
+				DiscoveryURL: "https://idp.example.com/.well-known/oauth-authorization-server",
+			},
+		},
+		{
+			name: "only registration_endpoint is valid",
+			config: DCRUpstreamConfig{
+				RegistrationEndpoint: "https://idp.example.com/register",
+			},
+		},
+		{
+			name: "optional metadata is ignored by validate",
+			config: DCRUpstreamConfig{
+				RegistrationEndpoint:     "https://idp.example.com/register",
+				InitialAccessTokenFile:   "/var/run/secrets/dcr-token",
+				InitialAccessTokenEnvVar: "DCR_TOKEN",
+				SoftwareID:               "toolhive",
+				SoftwareStatement:        "eyJhbGciOi...",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := tt.config.Validate()
+			assertError(t, err, tt.wantErr, tt.errMsg)
+		})
+	}
+}

--- a/pkg/authserver/config_test.go
+++ b/pkg/authserver/config_test.go
@@ -351,13 +351,46 @@ func TestDCRUpstreamConfigValidate(t *testing.T) {
 			},
 		},
 		{
-			name: "optional metadata is ignored by validate",
+			name: "software metadata and a single token source pass validation",
+			config: DCRUpstreamConfig{
+				RegistrationEndpoint:   "https://idp.example.com/register",
+				InitialAccessTokenFile: "/var/run/secrets/dcr-token",
+				SoftwareID:             "toolhive",
+				SoftwareStatement:      "eyJhbGciOi...",
+			},
+		},
+		{
+			name: "both initial_access_token_file and initial_access_token_env_var rejects",
 			config: DCRUpstreamConfig{
 				RegistrationEndpoint:     "https://idp.example.com/register",
 				InitialAccessTokenFile:   "/var/run/secrets/dcr-token",
 				InitialAccessTokenEnvVar: "DCR_TOKEN",
-				SoftwareID:               "toolhive",
-				SoftwareStatement:        "eyJhbGciOi...",
+			},
+			wantErr: true,
+			errMsg:  "initial_access_token_file and initial_access_token_env_var are mutually exclusive",
+		},
+		{
+			name:    "malformed discovery_url rejects",
+			config:  DCRUpstreamConfig{DiscoveryURL: "://broken"},
+			wantErr: true,
+			errMsg:  "invalid discovery_url",
+		},
+		{
+			name:    "non-loopback http discovery_url rejects",
+			config:  DCRUpstreamConfig{DiscoveryURL: "http://idp.example.com/.well-known/oauth-authorization-server"},
+			wantErr: true,
+			errMsg:  "invalid discovery_url",
+		},
+		{
+			name:    "non-loopback http registration_endpoint rejects",
+			config:  DCRUpstreamConfig{RegistrationEndpoint: "http://idp.example.com/register"},
+			wantErr: true,
+			errMsg:  "invalid registration_endpoint",
+		},
+		{
+			name: "loopback http discovery_url is valid",
+			config: DCRUpstreamConfig{
+				DiscoveryURL: "http://localhost:8080/.well-known/oauth-authorization-server",
 			},
 		},
 	}

--- a/pkg/authserver/runner/embeddedauthserver.go
+++ b/pkg/authserver/runner/embeddedauthserver.go
@@ -366,12 +366,20 @@ func buildOIDCConfig(rc *authserver.UpstreamRunConfig) (*upstream.OIDCConfig, er
 }
 
 // buildPureOAuth2Config builds an upstream.OAuth2Config for a pure OAuth2 provider.
+//
+// Run-config-specific invariants (e.g. ClientID/DCRConfig mutual exclusion) are
+// enforced here via OAuth2UpstreamRunConfig.Validate before secrets are
+// resolved, since the downstream upstream.OAuth2Config validator only sees the
+// flattened runtime shape and cannot observe DCR fields.
 func buildPureOAuth2Config(rc *authserver.UpstreamRunConfig) (*upstream.OAuth2Config, error) {
 	if rc.OAuth2Config == nil {
 		return nil, fmt.Errorf("oauth2_config required for OAuth2 provider")
 	}
 
 	oauth2 := rc.OAuth2Config
+	if err := oauth2.Validate(); err != nil {
+		return nil, err
+	}
 	clientSecret, err := resolveSecret(oauth2.ClientSecretFile, oauth2.ClientSecretEnvVar)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve OAuth2 client secret: %w", err)

--- a/pkg/authserver/runner/embeddedauthserver_test.go
+++ b/pkg/authserver/runner/embeddedauthserver_test.go
@@ -521,6 +521,65 @@ func TestBuildPureOAuth2Config(t *testing.T) {
 		assert.Equal(t, map[string]string{"access_type": "offline"},
 			cfg.AdditionalAuthorizationParams)
 	})
+
+	t.Run("rejects config with neither ClientID nor DCRConfig", func(t *testing.T) {
+		t.Parallel()
+
+		rc := &authserver.UpstreamRunConfig{
+			Type: authserver.UpstreamProviderTypeOAuth2,
+			OAuth2Config: &authserver.OAuth2UpstreamRunConfig{
+				AuthorizationEndpoint: "https://example.com/authorize",
+				TokenEndpoint:         "https://example.com/token",
+				RedirectURI:           "https://my-app.com/callback",
+			},
+		}
+
+		_, err := buildPureOAuth2Config(rc)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "client_id or dcr_config is required")
+	})
+
+	t.Run("rejects config with both ClientID and DCRConfig", func(t *testing.T) {
+		t.Parallel()
+
+		rc := &authserver.UpstreamRunConfig{
+			Type: authserver.UpstreamProviderTypeOAuth2,
+			OAuth2Config: &authserver.OAuth2UpstreamRunConfig{
+				AuthorizationEndpoint: "https://example.com/authorize",
+				TokenEndpoint:         "https://example.com/token",
+				ClientID:              "my-client-id",
+				RedirectURI:           "https://my-app.com/callback",
+				DCRConfig: &authserver.DCRUpstreamConfig{
+					RegistrationEndpoint: "https://example.com/register",
+				},
+			},
+		}
+
+		_, err := buildPureOAuth2Config(rc)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "mutually exclusive")
+	})
+
+	t.Run("accepts DCRConfig without ClientID", func(t *testing.T) {
+		t.Parallel()
+
+		rc := &authserver.UpstreamRunConfig{
+			Type: authserver.UpstreamProviderTypeOAuth2,
+			OAuth2Config: &authserver.OAuth2UpstreamRunConfig{
+				AuthorizationEndpoint: "https://example.com/authorize",
+				TokenEndpoint:         "https://example.com/token",
+				RedirectURI:           "https://my-app.com/callback",
+				DCRConfig: &authserver.DCRUpstreamConfig{
+					RegistrationEndpoint: "https://example.com/register",
+				},
+			},
+		}
+
+		cfg, err := buildPureOAuth2Config(rc)
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+		assert.Empty(t, cfg.ClientID)
+	})
 }
 
 // TestBuildPureOAuth2ConfigWithEnvVar tests buildPureOAuth2Config with environment variables.

--- a/pkg/oauthproto/discovery.go
+++ b/pkg/oauthproto/discovery.go
@@ -6,6 +6,7 @@ package oauthproto
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -32,11 +33,18 @@ const discoveryMaxResponseSize = 1024 * 1024 // 1MB
 // metadata for the given issuer, using a three-path fallback that mirrors
 // the guidance in RFC 8414 §3.1 and OpenID Connect Discovery 1.0.
 //
-// The paths are tried in this order; the first 200 OK with a clean
-// application/json response that passes the RFC 8414 §3.3 issuer check wins:
+// The paths are tried in this order:
 //  1. RFC 8414 path-insertion: {origin}/.well-known/oauth-authorization-server{path}
 //  2. OIDC Discovery:          {issuer}/.well-known/openid-configuration
 //  3. Bare RFC 8414:           {origin}/.well-known/oauth-authorization-server
+//
+// A 200 OK response with a clean application/json body that passes the
+// RFC 8414 §3.3 issuer check is a candidate. The first candidate with a
+// non-empty registration_endpoint wins immediately. If no candidate has a
+// registration_endpoint but at least one was otherwise valid, the first such
+// partial document is returned with ErrRegistrationEndpointMissing — never
+// short-circuiting on a partial doc, since a tenant-aware IdP may publish
+// path-insertion metadata without DCR while the OIDC document advertises it.
 //
 // If client is nil, a default *http.Client with a bounded 10 s timeout is
 // used. When client is non-nil, the same bounded 10 s per-call timeout is
@@ -48,12 +56,13 @@ const discoveryMaxResponseSize = 1024 * 1024 // 1MB
 //   - On full success, returns (metadata, nil) with a non-empty
 //     RegistrationEndpoint.
 //
-//   - When the winning document is otherwise valid but omits
-//     registration_endpoint, returns (metadata, ErrRegistrationEndpointMissing).
-//     The metadata is non-nil so callers can reuse the other fields
-//     (TokenEndpoint, JWKSURI, etc.). Note this deviates from the usual Go
-//     "err != nil ⇒ value is invalid" idiom; callers must check with
-//     errors.Is and explicitly decide whether to use the partial doc:
+//   - When at least one candidate document was issuer-validated but every such
+//     document omits registration_endpoint, returns the first partial document
+//     paired with ErrRegistrationEndpointMissing. The metadata is non-nil so
+//     callers can reuse the other fields (TokenEndpoint, JWKSURI, etc.). Note
+//     this deviates from the usual Go "err != nil ⇒ value is invalid" idiom;
+//     callers must check with errors.Is and explicitly decide whether to use
+//     the partial doc:
 //
 //     md, err := FetchAuthorizationServerMetadata(ctx, issuer, nil)
 //     switch {
@@ -66,7 +75,9 @@ const discoveryMaxResponseSize = 1024 * 1024 // 1MB
 //     }
 //
 //   - On any other failure (no URL served a valid doc, transport/decode error,
-//     issuer mismatch), returns (nil, err).
+//     issuer mismatch), returns (nil, err). The returned error wraps the
+//     per-attempt errors via errors.Join so callers can use errors.Is /
+//     errors.As to inspect underlying causes (e.g. context.DeadlineExceeded).
 func FetchAuthorizationServerMetadata(
 	ctx context.Context,
 	issuer string,
@@ -83,22 +94,33 @@ func FetchAuthorizationServerMetadata(
 	fetchCtx, cancel := context.WithTimeout(ctx, discoveryTimeout)
 	defer cancel()
 
-	var attemptErrs []string
+	var attemptErrs []error
+	var partialMetadata *AuthorizationServerMetadata
 	for _, u := range urls {
 		metadata, err := fetchDiscoveryDocument(fetchCtx, httpClient, u, issuer)
 		if err != nil {
-			attemptErrs = append(attemptErrs, fmt.Sprintf("%s: %v", u, err))
+			attemptErrs = append(attemptErrs, fmt.Errorf("%s: %w", u, err))
 			continue
 		}
 		if metadata.RegistrationEndpoint == "" {
-			return metadata, ErrRegistrationEndpointMissing
+			// Stash the first partial doc as a fallback, but keep iterating:
+			// a later URL (e.g. OIDC discovery) may advertise DCR even when
+			// the first hit (e.g. tenant-aware path-insertion) does not.
+			if partialMetadata == nil {
+				partialMetadata = metadata
+			}
+			continue
 		}
 		return metadata, nil
 	}
 
+	if partialMetadata != nil {
+		return partialMetadata, ErrRegistrationEndpointMissing
+	}
+
 	return nil, fmt.Errorf(
-		"failed to discover authorization server metadata for issuer %q: %s",
-		issuer, strings.Join(attemptErrs, "; "),
+		"failed to discover authorization server metadata for issuer %q: %w",
+		issuer, errors.Join(attemptErrs...),
 	)
 }
 
@@ -127,7 +149,10 @@ func buildDiscoveryURLs(issuer string) ([]string, error) {
 	}
 
 	// Strip trailing slash from issuer path so URL joins stay predictable.
-	tenant := strings.Trim(parsed.EscapedPath(), "/")
+	// Use the unescaped Path: assigning back into url.URL.Path means String()
+	// will escape exactly once. Using EscapedPath() here would re-escape
+	// percent-encoded tenants and produce e.g. "%252F" from "%2F".
+	tenant := strings.Trim(parsed.Path, "/")
 
 	origin := &url.URL{Scheme: parsed.Scheme, Host: parsed.Host}
 

--- a/pkg/oauthproto/discovery.go
+++ b/pkg/oauthproto/discovery.go
@@ -1,18 +1,234 @@
-// Copyright 2025 Stacklok, Inc.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
 
 package oauthproto
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"path"
+	"strings"
+	"time"
+)
+
+// discoveryTimeout is the bounded per-call timeout applied when fetching
+// authorization server metadata, regardless of the caller's context deadline.
+//
+// Declared as a var rather than a const so tests that need to exercise the
+// timeout path can shorten it without waiting 10 s per run. Production code
+// MUST NOT mutate this value — it is effectively constant outside tests.
+var discoveryTimeout = 10 * time.Second
+
+// discoveryMaxResponseSize caps the response body size accepted from a
+// discovery endpoint to prevent resource exhaustion from hostile servers.
+const discoveryMaxResponseSize = 1024 * 1024 // 1MB
+
+// FetchAuthorizationServerMetadata fetches RFC 8414 authorization server
+// metadata for the given issuer, using a three-path fallback that mirrors
+// the guidance in RFC 8414 §3.1 and OpenID Connect Discovery 1.0.
+//
+// The paths are tried in this order; the first 200 OK with a clean
+// application/json response that passes the RFC 8414 §3.3 issuer check wins:
+//  1. RFC 8414 path-insertion: {origin}/.well-known/oauth-authorization-server{path}
+//  2. OIDC Discovery:          {issuer}/.well-known/openid-configuration
+//  3. Bare RFC 8414:           {origin}/.well-known/oauth-authorization-server
+//
+// If client is nil, a default *http.Client with a bounded 10 s timeout is
+// used. When client is non-nil, the same bounded 10 s per-call timeout is
+// applied via context.WithTimeout on top of the caller's context to protect
+// against callers that pass context.Background or a long deadline.
+//
+// Return contract:
+//
+//   - On full success, returns (metadata, nil) with a non-empty
+//     RegistrationEndpoint.
+//
+//   - When the winning document is otherwise valid but omits
+//     registration_endpoint, returns (metadata, ErrRegistrationEndpointMissing).
+//     The metadata is non-nil so callers can reuse the other fields
+//     (TokenEndpoint, JWKSURI, etc.). Note this deviates from the usual Go
+//     "err != nil ⇒ value is invalid" idiom; callers must check with
+//     errors.Is and explicitly decide whether to use the partial doc:
+//
+//     md, err := FetchAuthorizationServerMetadata(ctx, issuer, nil)
+//     switch {
+//     case errors.Is(err, ErrRegistrationEndpointMissing):
+//     // md is non-nil; DCR unavailable but token/JWKS endpoints usable.
+//     case err != nil:
+//     // md is nil; discovery failed.
+//     default:
+//     // md fully populated.
+//     }
+//
+//   - On any other failure (no URL served a valid doc, transport/decode error,
+//     issuer mismatch), returns (nil, err).
+func FetchAuthorizationServerMetadata(
+	ctx context.Context,
+	issuer string,
+	client *http.Client,
+) (*AuthorizationServerMetadata, error) {
+	urls, err := buildDiscoveryURLs(issuer)
+	if err != nil {
+		return nil, err
+	}
+
+	httpClient := buildDiscoveryHTTPClient(client)
+
+	// Bound per-call timeout regardless of caller context.
+	fetchCtx, cancel := context.WithTimeout(ctx, discoveryTimeout)
+	defer cancel()
+
+	var attemptErrs []string
+	for _, u := range urls {
+		metadata, err := fetchDiscoveryDocument(fetchCtx, httpClient, u, issuer)
+		if err != nil {
+			attemptErrs = append(attemptErrs, fmt.Sprintf("%s: %v", u, err))
+			continue
+		}
+		if metadata.RegistrationEndpoint == "" {
+			return metadata, ErrRegistrationEndpointMissing
+		}
+		return metadata, nil
+	}
+
+	return nil, fmt.Errorf(
+		"failed to discover authorization server metadata for issuer %q: %s",
+		issuer, strings.Join(attemptErrs, "; "),
+	)
+}
+
+// buildDiscoveryURLs constructs the discovery URLs to try per RFC 8414 §3.1
+// and OpenID Connect Discovery 1.0. The issuer must have an "https" scheme
+// (or "http" with a loopback host, for development).
+//
+// URLs are returned in priority order with exact duplicates removed: for an
+// issuer with no tenant path, path-insertion (1) and bare RFC 8414 (3)
+// collapse to the same URL, so only two distinct URLs are returned. Callers
+// must not rely on a fixed slice length.
+func buildDiscoveryURLs(issuer string) ([]string, error) {
+	if issuer == "" {
+		return nil, fmt.Errorf("issuer is required")
+	}
+
+	parsed, err := url.Parse(issuer)
+	if err != nil {
+		return nil, fmt.Errorf("invalid issuer URL: %w", err)
+	}
+	if parsed.Scheme == "" || parsed.Host == "" {
+		return nil, fmt.Errorf("invalid issuer URL: scheme and host are required")
+	}
+	if parsed.Scheme != "https" && !IsLoopbackHost(parsed.Host) {
+		return nil, fmt.Errorf("issuer must use https (got %q)", parsed.Scheme)
+	}
+
+	// Strip trailing slash from issuer path so URL joins stay predictable.
+	tenant := strings.Trim(parsed.EscapedPath(), "/")
+
+	origin := &url.URL{Scheme: parsed.Scheme, Host: parsed.Host}
+
+	// (1) RFC 8414 §3.1 path-insertion: /.well-known/oauth-authorization-server/{tenant}
+	pathInsertion := *origin
+	pathInsertion.Path = path.Join(WellKnownOAuthServerPath, tenant)
+
+	// (2) OIDC Discovery: {issuer}/.well-known/openid-configuration
+	oidc := *origin
+	oidc.Path = path.Join("/", tenant, WellKnownOIDCPath)
+
+	// (3) Bare RFC 8414: {origin}/.well-known/oauth-authorization-server
+	bare := *origin
+	bare.Path = WellKnownOAuthServerPath
+
+	// Deduplicate while preserving order. A tenant-less issuer causes (1) and
+	// (3) to collapse to the same URL; emitting both would waste a round-trip
+	// and produce confusing duplicate entries in the aggregated error message.
+	candidates := []string{pathInsertion.String(), oidc.String(), bare.String()}
+	seen := make(map[string]struct{}, len(candidates))
+	urls := make([]string, 0, len(candidates))
+	for _, u := range candidates {
+		if _, ok := seen[u]; ok {
+			continue
+		}
+		seen[u] = struct{}{}
+		urls = append(urls, u)
+	}
+	return urls, nil
+}
+
+// buildDiscoveryHTTPClient returns the caller-supplied client, or a default
+// bounded client. The per-call timeout enforced via context.WithTimeout in
+// FetchAuthorizationServerMetadata guarantees the bound is honored even when
+// the caller supplies a client with a larger or missing Timeout.
+func buildDiscoveryHTTPClient(client *http.Client) *http.Client {
+	if client != nil {
+		return client
+	}
+	return &http.Client{
+		Timeout: discoveryTimeout,
+		Transport: &http.Transport{
+			TLSHandshakeTimeout:   5 * time.Second,
+			ResponseHeaderTimeout: 5 * time.Second,
+		},
+	}
+}
+
+// fetchDiscoveryDocument performs a single GET against a discovery URL and
+// returns the parsed AuthorizationServerMetadata, enforcing RFC 8414 §3.3
+// issuer equality.
+func fetchDiscoveryDocument(
+	ctx context.Context,
+	client *http.Client,
+	urlStr string,
+	expectedIssuer string,
+) (*AuthorizationServerMetadata, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, urlStr, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", UserAgent)
+
+	resp, err := client.Do(req) //nolint:gosec // G107: URL is constructed from configured issuer
+	if err != nil {
+		return nil, fmt.Errorf("GET failed: %w", err)
+	}
+	defer func() {
+		// Drain fully before closing so the underlying TCP connection is
+		// eligible for reuse. The JSON decode path below caps the accepted
+		// body via io.LimitReader; we intentionally do NOT limit the drain
+		// here because a bounded drain leaves bytes in the kernel buffer
+		// and defeats connection reuse.
+		_, _ = io.Copy(io.Discard, resp.Body)
+		if cerr := resp.Body.Close(); cerr != nil {
+			slog.Debug("failed to close discovery response body", "error", cerr)
+		}
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("HTTP %d", resp.StatusCode)
+	}
+
+	contentType := strings.ToLower(resp.Header.Get("Content-Type"))
+	if !strings.Contains(contentType, "application/json") {
+		return nil, fmt.Errorf("unexpected content-type %q", contentType)
+	}
+
+	var metadata AuthorizationServerMetadata
+	if err := json.NewDecoder(io.LimitReader(resp.Body, discoveryMaxResponseSize)).Decode(&metadata); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+
+	// RFC 8414 §3.3: the issuer in the metadata MUST exactly match the caller's expected issuer.
+	if metadata.Issuer != expectedIssuer {
+		return nil, fmt.Errorf("issuer mismatch (RFC 8414 §3.3): expected %q, got %q", expectedIssuer, metadata.Issuer)
+	}
+
+	return &metadata, nil
+}
 
 // AuthorizationServerMetadata represents the OAuth 2.0 Authorization Server Metadata
 // per RFC 8414. This is the base structure that OIDC Discovery extends.

--- a/pkg/oauthproto/discovery_test.go
+++ b/pkg/oauthproto/discovery_test.go
@@ -1,22 +1,20 @@
-// Copyright 2025 Stacklok, Inc.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
 
 package oauthproto
 
 import (
+	"context"
+	"encoding/json"
 	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestOIDCDiscoveryDocument_Validate(t *testing.T) {
@@ -124,4 +122,260 @@ func TestOIDCDiscoveryDocument_SupportsGrantType(t *testing.T) {
 			}
 		})
 	}
+}
+
+// writeJSONMetadata serves an AuthorizationServerMetadata document as JSON.
+// Silently swallows encoding errors: the caller is an httptest server handler,
+// which has no way to surface an error back to the test.
+func writeJSONMetadata(w http.ResponseWriter, md AuthorizationServerMetadata) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(md)
+}
+
+func TestFetchAuthorizationServerMetadata(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		// handler builds the test HTTP handler given the issuer URL, since the
+		// issuer is only known after httptest.NewServer is started.
+		handler func(issuer string) http.HandlerFunc
+		// tenantPath is appended to the server URL to form the issuer under test.
+		// Empty string means the issuer is the server's root URL.
+		tenantPath string
+	}{
+		{
+			name: "serves metadata from RFC 8414 path-insertion",
+			// Issuer has a tenant path; only the path-insertion URL responds.
+			tenantPath: "/tenants/acme",
+			handler: func(issuer string) http.HandlerFunc {
+				return func(w http.ResponseWriter, r *http.Request) {
+					if r.URL.Path != "/.well-known/oauth-authorization-server/tenants/acme" {
+						http.NotFound(w, r)
+						return
+					}
+					writeJSONMetadata(w, AuthorizationServerMetadata{
+						Issuer:               issuer,
+						TokenEndpoint:        issuer + "/token",
+						RegistrationEndpoint: issuer + "/register",
+					})
+				}
+			},
+		},
+		{
+			name: "serves metadata from OIDC discovery path",
+			// Issuer has a tenant path. Path-insertion 404s; OIDC wins.
+			tenantPath: "/tenants/acme",
+			handler: func(issuer string) http.HandlerFunc {
+				return func(w http.ResponseWriter, r *http.Request) {
+					if r.URL.Path != "/tenants/acme/.well-known/openid-configuration" {
+						http.NotFound(w, r)
+						return
+					}
+					writeJSONMetadata(w, AuthorizationServerMetadata{
+						Issuer:               issuer,
+						TokenEndpoint:        issuer + "/token",
+						RegistrationEndpoint: issuer + "/register",
+					})
+				}
+			},
+		},
+		{
+			name: "serves metadata from bare RFC 8414 path",
+			// Issuer has a tenant path so attempts 1 and 3 are distinct URLs.
+			// Only the bare path responds, proving the fallback reaches
+			// iteration 3 after 1 and 2 404.
+			tenantPath: "/tenants/acme",
+			handler: func(issuer string) http.HandlerFunc {
+				return func(w http.ResponseWriter, r *http.Request) {
+					if r.URL.Path != "/.well-known/oauth-authorization-server" {
+						http.NotFound(w, r)
+						return
+					}
+					writeJSONMetadata(w, AuthorizationServerMetadata{
+						Issuer:               issuer,
+						TokenEndpoint:        issuer + "/token",
+						RegistrationEndpoint: issuer + "/register",
+					})
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Create a placeholder server so we can derive an issuer URL; swap
+			// the real handler in after the URL is known.
+			server := httptest.NewServer(http.NotFoundHandler())
+			t.Cleanup(server.Close)
+
+			issuer := server.URL + tt.tenantPath
+			server.Config.Handler = tt.handler(issuer)
+
+			metadata, err := FetchAuthorizationServerMetadata(context.Background(), issuer, server.Client())
+			require.NoError(t, err)
+			require.NotNil(t, metadata)
+			assert.Equal(t, issuer, metadata.Issuer)
+			assert.Equal(t, issuer+"/token", metadata.TokenEndpoint)
+			assert.Equal(t, issuer+"/register", metadata.RegistrationEndpoint)
+		})
+	}
+}
+
+func TestFetchAuthorizationServerMetadata_InvalidIssuer(t *testing.T) {
+	t.Parallel()
+
+	// Exercise the input-validation branches of buildDiscoveryURLs via the
+	// public entrypoint: a nil client means no HTTP server is needed, since
+	// these inputs must be rejected before any request is made.
+	tests := []struct {
+		name   string
+		issuer string
+		errSub string
+	}{
+		{name: "empty issuer", issuer: "", errSub: "issuer is required"},
+		{name: "malformed URL", issuer: "://not a url", errSub: "invalid issuer URL"},
+		{name: "missing scheme and host", issuer: "example.com", errSub: "scheme and host are required"},
+		{name: "http non-loopback host", issuer: "http://example.com", errSub: "issuer must use https"},
+		{name: "ftp scheme", issuer: "ftp://example.com", errSub: "issuer must use https"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			metadata, err := FetchAuthorizationServerMetadata(context.Background(), tt.issuer, nil)
+			require.Error(t, err)
+			assert.Nil(t, metadata)
+			assert.Contains(t, err.Error(), tt.errSub)
+		})
+	}
+}
+
+func TestFetchAuthorizationServerMetadata_AllowsLoopbackHTTP(t *testing.T) {
+	t.Parallel()
+
+	// httptest.NewServer binds to 127.0.0.1 over http, which must be accepted
+	// so local development and tests can run without a TLS certificate.
+	// Start with a placeholder handler so we can capture the server URL before
+	// the real handler closes over it.
+	server := httptest.NewServer(http.NotFoundHandler())
+	t.Cleanup(server.Close)
+	issuer := server.URL
+	server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeJSONMetadata(w, AuthorizationServerMetadata{
+			Issuer:               issuer,
+			TokenEndpoint:        issuer + "/token",
+			RegistrationEndpoint: issuer + "/register",
+		})
+	})
+
+	metadata, err := FetchAuthorizationServerMetadata(context.Background(), issuer, server.Client())
+	require.NoError(t, err)
+	require.NotNil(t, metadata)
+	assert.Equal(t, issuer, metadata.Issuer)
+}
+
+// TestFetchAuthorizationServerMetadata_TimeoutOverridesCallerContext cannot
+// run with t.Parallel() because it mutates the package-level discoveryTimeout
+// var; concurrent parallel tests would race when reading it.
+//
+//nolint:paralleltest // see comment above
+func TestFetchAuthorizationServerMetadata_TimeoutOverridesCallerContext(t *testing.T) {
+	// Verifies the documented contract that the function applies a bounded
+	// per-call timeout via context.WithTimeout on top of the caller's context,
+	// so a caller passing context.Background does not hang forever on an
+	// unresponsive server. We shorten discoveryTimeout so the test finishes
+	// in well under a second rather than waiting the production 10 s.
+	originalTimeout := discoveryTimeout
+	discoveryTimeout = 100 * time.Millisecond
+	t.Cleanup(func() { discoveryTimeout = originalTimeout })
+
+	// Handler blocks until the request context is cancelled, so every URL
+	// the function tries will exceed the internal timeout.
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	t.Cleanup(server.Close)
+
+	// Caller passes context.Background (no deadline). If the internal
+	// timeout were not applied, this call would hang indefinitely and the
+	// test runner would eventually time out with an unclear message.
+	done := make(chan struct{})
+	var fetchErr error
+	go func() {
+		_, fetchErr = FetchAuthorizationServerMetadata(context.Background(), server.URL, server.Client())
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("FetchAuthorizationServerMetadata did not honor bounded internal timeout")
+	}
+
+	require.Error(t, fetchErr)
+	assert.Contains(t, fetchErr.Error(), "failed to discover authorization server metadata")
+}
+
+func TestFetchAuthorizationServerMetadata_IssuerMismatch(t *testing.T) {
+	t.Parallel()
+
+	// Server returns metadata whose issuer disagrees with the caller's expected
+	// issuer. Every well-known URL the function tries returns the same bad
+	// document, so all three attempts fail and the aggregated error surfaces
+	// the RFC 8414 §3.3 mismatch.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(AuthorizationServerMetadata{
+			Issuer:               "https://evil.example.com",
+			TokenEndpoint:        "https://evil.example.com/token",
+			RegistrationEndpoint: "https://evil.example.com/register",
+		})
+	}))
+	t.Cleanup(server.Close)
+
+	metadata, err := FetchAuthorizationServerMetadata(context.Background(), server.URL, server.Client())
+
+	require.Error(t, err)
+	require.Nil(t, metadata)
+	assert.Contains(t, err.Error(), "issuer mismatch")
+	assert.Contains(t, err.Error(), "RFC 8414")
+}
+
+func TestFetchAuthorizationServerMetadata_MissingRegistrationEndpoint(t *testing.T) {
+	t.Parallel()
+
+	var issuer string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Only the first attempted URL (path-insertion) serves a document;
+		// the others 404, so the first one is the winner.
+		if !strings.HasPrefix(r.URL.Path, "/.well-known/oauth-authorization-server") {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(AuthorizationServerMetadata{
+			Issuer:        issuer,
+			TokenEndpoint: issuer + "/token",
+			// RegistrationEndpoint intentionally omitted.
+		})
+	}))
+	t.Cleanup(server.Close)
+
+	issuer = server.URL
+
+	metadata, err := FetchAuthorizationServerMetadata(context.Background(), issuer, server.Client())
+
+	require.ErrorIs(t, err, ErrRegistrationEndpointMissing)
+	// Documented return contract: when the winning document lacks
+	// registration_endpoint, the function returns (non-nil metadata,
+	// ErrRegistrationEndpointMissing) so callers can still reuse the other
+	// fields via errors.Is. Assert the full partial document, not just
+	// non-nil, so future regressions that drop the metadata (or that stop
+	// populating a specific field) are caught.
+	require.NotNil(t, metadata)
+	assert.Equal(t, issuer, metadata.Issuer)
+	assert.Equal(t, issuer+"/token", metadata.TokenEndpoint)
+	assert.Empty(t, metadata.RegistrationEndpoint)
 }

--- a/pkg/oauthproto/discovery_test.go
+++ b/pkg/oauthproto/discovery_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -378,4 +379,157 @@ func TestFetchAuthorizationServerMetadata_MissingRegistrationEndpoint(t *testing
 	assert.Equal(t, issuer, metadata.Issuer)
 	assert.Equal(t, issuer+"/token", metadata.TokenEndpoint)
 	assert.Empty(t, metadata.RegistrationEndpoint)
+}
+
+// TestFetchAuthorizationServerMetadata_PreferFullDocOverPartial pins the
+// no-short-circuit-on-partial behavior: when an earlier URL serves a valid
+// document missing registration_endpoint and a later URL serves the full
+// document, the full document must win. A real-world failure mode this
+// guards against is a tenant-aware IdP whose path-insertion document does
+// not advertise DCR while its OIDC discovery document does.
+func TestFetchAuthorizationServerMetadata_PreferFullDocOverPartial(t *testing.T) {
+	t.Parallel()
+
+	// Use a tenant-aware issuer so path-insertion and bare RFC 8414 URLs are
+	// distinct; that lets us serve a partial doc on path-insertion and a
+	// full doc on OIDC discovery without collisions.
+	server := httptest.NewServer(http.NotFoundHandler())
+	t.Cleanup(server.Close)
+	issuer := server.URL + "/tenants/acme"
+
+	server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/oauth-authorization-server/tenants/acme":
+			writeJSONMetadata(w, AuthorizationServerMetadata{
+				Issuer:        issuer,
+				TokenEndpoint: issuer + "/token-from-partial",
+				// RegistrationEndpoint intentionally omitted: partial doc.
+			})
+		case "/tenants/acme/.well-known/openid-configuration":
+			writeJSONMetadata(w, AuthorizationServerMetadata{
+				Issuer:               issuer,
+				TokenEndpoint:        issuer + "/token-from-full",
+				RegistrationEndpoint: issuer + "/register",
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	})
+
+	metadata, err := FetchAuthorizationServerMetadata(context.Background(), issuer, server.Client())
+	require.NoError(t, err)
+	require.NotNil(t, metadata)
+	assert.Equal(t, issuer+"/register", metadata.RegistrationEndpoint,
+		"the OIDC document with a registration_endpoint must win over the partial path-insertion document")
+	assert.Equal(t, issuer+"/token-from-full", metadata.TokenEndpoint,
+		"the OIDC document, not the partial doc, must be returned in full")
+}
+
+// errSentinelTransport is a stand-in for a transport-level failure (e.g.
+// TLS or DNS error). It returns errSentinelTransportFailure from RoundTrip so the
+// test can confirm the per-attempt error is wrapped and reachable via
+// errors.Is on the aggregated discovery error.
+var errSentinelTransportFailure = errors.New("oauthproto-test: simulated transport failure")
+
+type errSentinelTransport struct{}
+
+func (errSentinelTransport) RoundTrip(_ *http.Request) (*http.Response, error) {
+	return nil, errSentinelTransportFailure
+}
+
+// TestFetchAuthorizationServerMetadata_AggregatedErrorPreservesWrap verifies
+// that per-attempt errors are joined via errors.Join (not flattened to a
+// string) so callers can still inspect causes through errors.Is/errors.As.
+func TestFetchAuthorizationServerMetadata_AggregatedErrorPreservesWrap(t *testing.T) {
+	t.Parallel()
+
+	client := &http.Client{Transport: errSentinelTransport{}}
+
+	metadata, err := FetchAuthorizationServerMetadata(
+		context.Background(), "https://idp.example.com/tenants/acme", client)
+
+	require.Error(t, err)
+	require.Nil(t, metadata)
+	assert.ErrorIs(t, err, errSentinelTransportFailure,
+		"aggregated discovery error must wrap per-attempt errors so errors.Is can find them")
+}
+
+// TestFetchAuthorizationServerMetadata_TenantWithEscapedChars guards against
+// the EscapedPath/Path double-encoding regression: a tenant containing
+// characters that url.PathEscape actually transforms (here, a space) must
+// reach the IdP encoded exactly once.
+func TestFetchAuthorizationServerMetadata_TenantWithEscapedChars(t *testing.T) {
+	t.Parallel()
+
+	// Issuer path "tenants/acme corp" — the literal space MUST end up
+	// encoded as %20 in the request path, not as %2520.
+	const escapedTenant = "/tenants/acme%20corp"
+	const wantPathInsertion = "/.well-known/oauth-authorization-server/tenants/acme%20corp"
+
+	server := httptest.NewServer(http.NotFoundHandler())
+	t.Cleanup(server.Close)
+	issuer := server.URL + escapedTenant
+
+	server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// EscapedPath always returns the wire form, regardless of whether
+		// Go's URL parser populated RawPath (it leaves RawPath empty when
+		// the canonical escaping of Path matches the on-the-wire form).
+		// A regression that double-encodes "%20" → "%2520" would alter
+		// EscapedPath here and produce a 404 below.
+		if r.URL.EscapedPath() != wantPathInsertion {
+			http.NotFound(w, r)
+			return
+		}
+		writeJSONMetadata(w, AuthorizationServerMetadata{
+			Issuer:               issuer,
+			TokenEndpoint:        issuer + "/token",
+			RegistrationEndpoint: issuer + "/register",
+		})
+	})
+
+	metadata, err := FetchAuthorizationServerMetadata(context.Background(), issuer, server.Client())
+	require.NoError(t, err)
+	require.NotNil(t, metadata)
+	assert.Equal(t, issuer, metadata.Issuer)
+}
+
+// TestFetchAuthorizationServerMetadata_DedupesPathInsertionAndBare locks in
+// the documented behavior that, for a tenant-less issuer, the path-insertion
+// (1) and bare RFC 8414 (3) URLs collapse to the same request, so only two
+// distinct discovery requests are made: oauth-authorization-server and
+// openid-configuration, in that priority order.
+func TestFetchAuthorizationServerMetadata_DedupesPathInsertionAndBare(t *testing.T) {
+	t.Parallel()
+
+	var (
+		mu        sync.Mutex
+		gotPaths  []string
+		seenPaths = map[string]struct{}{}
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		if _, ok := seenPaths[r.URL.Path]; !ok {
+			seenPaths[r.URL.Path] = struct{}{}
+			gotPaths = append(gotPaths, r.URL.Path)
+		}
+		mu.Unlock()
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(server.Close)
+
+	// Tenant-less issuer; with no tenant path, URLs (1) and (3) are textually
+	// identical and must be deduplicated before the loop runs.
+	_, err := FetchAuthorizationServerMetadata(context.Background(), server.URL, server.Client())
+	require.Error(t, err) // every URL 404s
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Equal(t,
+		[]string{
+			"/.well-known/oauth-authorization-server",
+			"/.well-known/openid-configuration",
+		},
+		gotPaths,
+		"expected exactly two distinct discovery requests in priority order: path-insertion before OIDC",
+	)
 }

--- a/pkg/oauthproto/errors.go
+++ b/pkg/oauthproto/errors.go
@@ -1,16 +1,5 @@
-// Copyright 2025 Stacklok, Inc.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
 
 package oauthproto
 
@@ -32,4 +21,9 @@ var (
 
 	// ErrMissingResponseTypesSupported indicates the response_types_supported field is missing (required for OIDC).
 	ErrMissingResponseTypesSupported = errors.New("missing response_types_supported")
+
+	// ErrRegistrationEndpointMissing indicates the winning authorization server metadata document
+	// does not advertise a registration_endpoint (RFC 7591). Callers that require Dynamic Client
+	// Registration should handle this sentinel and fall back to out-of-band client configuration.
+	ErrRegistrationEndpointMissing = errors.New("authorization server metadata missing registration_endpoint")
 )


### PR DESCRIPTION
## Summary

- The authserver currently requires every OAuth2 upstream to be pre-provisioned with a `ClientID`, which blocks operators who would prefer to register the client at runtime against the IdP. Phase 2 of the DCR story (#4978) introduces RFC 7591 Dynamic Client Registration; this sub-issue lays the leaf-package and config foundation needed by every later step.
- Adds `oauthproto.FetchAuthorizationServerMetadata` — a bounded, leaf-package RFC 8414 / OIDC Discovery client implementing the three-path fallback required to resolve `registration_endpoint` from a bare issuer URL.
- Adds `DCRUpstreamConfig` and a `DCRConfig *DCRUpstreamConfig` field on `OAuth2UpstreamRunConfig`, plus exactly-one-of validation rules (`ClientID` xor `DCRConfig`, and `DiscoveryURL` xor `RegistrationEndpoint`) so misconfiguration fails at startup rather than silently degrading at runtime.
- Purely additive — no behavior change, no CRD changes, no consumer wired up yet. Sub-issue B (credential store + resolver) consumes this surface area.

Closes #5037

## Type of change

- [x] New feature

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)

New table-driven tests cover:

- All three RFC 8414 / OIDC Discovery fallback paths (one `httptest.NewServer` per path), with the bare-path test using a non-empty tenant so the third fallback is actually exercised.
- RFC 8414 §3.3 issuer-equality enforcement (mismatch surfaces a descriptive error).
- `ErrRegistrationEndpointMissing` returned with a non-nil partial metadata document when the winning response omits `registration_endpoint`.
- Issuer URL validation: empty, malformed, missing scheme/host, non-loopback `http://`, and `ftp://` schemes are rejected; loopback `http://` is allowed.
- Internal 10 s timeout overrides a `context.Background` caller (uses a package-private `discoveryTimeout` var so the test does not have to wait the full 10 s).
- All four `ClientID` × `DCRConfig` combinations on `OAuth2UpstreamRunConfig.Validate`, plus the `DiscoveryURL` xor `RegistrationEndpoint` rule on `DCRUpstreamConfig.Validate`.

## API Compatibility

- [x] This PR does not break the `v1beta1` API, OR the `api-break-allowed` label is applied and the migration guidance is described above.

## Changes

| File | Change |
|------|--------|
| `pkg/oauthproto/discovery.go` | Add `FetchAuthorizationServerMetadata` with three-path fallback, bounded timeout, issuer-equality check, and `ErrRegistrationEndpointMissing` partial-success contract. |
| `pkg/oauthproto/discovery_test.go` | Table-driven tests for all three discovery paths, issuer mismatch, missing registration endpoint, issuer validation, loopback carve-out, and timeout override. |
| `pkg/oauthproto/errors.go` | Add `ErrRegistrationEndpointMissing` sentinel. |
| `pkg/authserver/config.go` | Add `DCRUpstreamConfig` struct, `DCRConfig` field on `OAuth2UpstreamRunConfig`, and `Validate()` methods enforcing exactly-one-of rules. |
| `pkg/authserver/config_test.go` | Table-driven tests for the new validation rules. |

## Does this introduce a user-facing change?

No — the new config fields are not yet consumed by any code path, and the discovery function is not yet called from the authserver. User-visible DCR behavior arrives in later sub-issues of #4978.

## Special notes for reviewers

- **Rebase note**: this branch contains commit `3cb8de58` which is the `pkg/oauth` -> `pkg/oauthproto` rename from #4977 (PR #5036). #5036 is still open as of this PR's creation; once it merges to `main`, this branch should be rebased so only the three commits scoped to #5037 remain (`b408d6b2`, `a7de63d6`, `73985137`). The 5037-only diff touches just five files.
- **Partial-success error contract on `FetchAuthorizationServerMetadata`**: returns `(metadata, ErrRegistrationEndpointMissing)` rather than `(nil, err)` when the document is otherwise valid but lacks `registration_endpoint`, so callers that only need `TokenEndpoint` / `JWKSURI` can still use the result. This deviates from the usual Go "err != nil ⇒ value invalid" idiom; the doc comment includes a worked `errors.Is` example and the test asserts the partial document fields are populated.
- **Leaf-package invariant**: `pkg/oauthproto` must not import `pkg/networking`, so the per-call timeout, body cap (1 MB `io.LimitReader`), `Accept` header, and content-type check are implemented directly inside `discovery.go` rather than reused from `pkg/networking/utilities.go`. This duplication is intentional and is documented in the package doc.
- **`discoveryTimeout` is a `var`, not a `const`**: required so the timeout-override test can shorten it to keep the test suite fast. Production code MUST NOT mutate it; the comment on the declaration says so explicitly.
- **`buildDiscoveryURLs` deduplication**: when the issuer has no path component, the path-insertion URL and the bare URL are identical, so the function emits only the deduplicated set to avoid a redundant round-trip and a misleading "tried 3 URLs" error message.
- `CommonOAuthConfig.Validate()` is intentionally not modified — the new `ClientID`/`DCR` mutual-exclusion rules are specific to `OAuth2UpstreamRunConfig` and do not belong in the shared validator.

## Implementation plan

<details>
<summary>Approved implementation plan</summary>

This PR implements Steps 2a, 2b, and 2e of the Phase 2 plan tracked in #4978:

- **Step 2a** — `FetchAuthorizationServerMetadata` in `pkg/oauthproto/discovery.go`. Three-path RFC 8414 / OIDC Discovery fallback (path-insertion, then OIDC Discovery, then bare RFC 8414), bounded 10 s per-call timeout, RFC 8414 §3.3 issuer equality check, `ErrRegistrationEndpointMissing` sentinel for partial success. Mirrors the plumbing of `pkg/auth/discovery/discovery.go:FetchResourceMetadata` (bounded HTTP client, `Accept: application/json`, `io.LimitReader`, content-type check) but stays in the leaf package — no `pkg/networking` import.
- **Step 2b** — `DCRUpstreamConfig` struct in `pkg/authserver/config.go` with `DiscoveryURL`, `RegistrationEndpoint`, `InitialAccessTokenFile`, `InitialAccessTokenEnvVar`, `SoftwareID`, `SoftwareStatement` fields (JSON + YAML tags). Adds `DCRConfig *DCRUpstreamConfig` field to `OAuth2UpstreamRunConfig`.
- **Step 2e** — Extends `OAuth2UpstreamRunConfig.Validate()` and adds `DCRUpstreamConfig.Validate()` to reject all three invalid combinations: both missing, both set, and `DiscoveryURL`/`RegistrationEndpoint` both set or both missing. `CommonOAuthConfig.Validate()` is left alone.

Steps 2c and 2d (credential store + resolver) are deferred to sub-issue B per #4978.

</details>

## Large PR Justification

- Majority lines are generated docs and tests