### PR TITLE
Wire authserver DCR resolver and add structured logs

### DIFF
--- a/pkg/auth/monitored_token_source.go
+++ b/pkg/auth/monitored_token_source.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
+	"net/http"
 	"os"
 	"strconv"
 	"strings"
@@ -444,18 +445,33 @@ func isTransientNetworkError(err error) bool {
 }
 
 // isPermanentTokenEndpointError reports whether err is an *oauth2.RetrieveError
-// with a non-5xx HTTP status (i.e. a permanent token-endpoint response such as
-// 400, 401, 403). Used at state-transition boundaries to decide whether to
-// emit a DCR/CIMD remediation hint alongside the unauthentication.
+// whose status implies the cached client credentials are themselves the
+// problem — specifically 400 (invalid_grant / invalid_client), 401, or
+// 403. Used at state-transition boundaries to decide whether to emit a
+// DCR/CIMD remediation hint alongside the unauthentication.
+//
+// Other 4xx codes are intentionally NOT treated as permanent here even
+// though isTransientNetworkError classifies the whole RetrieveError
+// branch as non-transient. 408 (Request Timeout) and 429 (Too Many
+// Requests) are typically transient back-pressure that the operator
+// cannot remediate by deleting cached credentials; firing the
+// "delete the cached credentials and restart" Warn on those would
+// mislead operators chasing a transient hiccup. The narrower allowlist
+// keeps the remediation hint truthful.
 func isPermanentTokenEndpointError(err error) bool {
 	retrieveErr, ok := errors.AsType[*oauth2.RetrieveError](err)
 	if !ok {
 		return false
 	}
 	if retrieveErr.Response == nil {
-		return true
+		return false
 	}
-	return retrieveErr.Response.StatusCode < 500
+	switch retrieveErr.Response.StatusCode {
+	case http.StatusBadRequest, http.StatusUnauthorized, http.StatusForbidden:
+		return true
+	default:
+		return false
+	}
 }
 
 // isOAuthParseError detects errors from the oauth2 library that indicate the

--- a/pkg/auth/monitored_token_source.go
+++ b/pkg/auth/monitored_token_source.go
@@ -132,9 +132,9 @@ type transientRefresher struct {
 	// upstream identifies the upstream authorization server that issued the
 	// token, and clientID is the OAuth 2.0 client_id used by this workload.
 	// Both are optional and are only surfaced in structured logs (notably the
-	// DCR remediation warning emitted from isTransientNetworkError when a
-	// permanent 4xx indicates a stale cached DCR client). Empty strings are
-	// acceptable and are omitted from log output by the slog handler.
+	// DCR/CIMD remediation warning emitted from MonitoredTokenSource on the
+	// transition to Unauthenticated). Empty strings are acceptable and are
+	// omitted from log output by the slog handler.
 	upstream string
 	clientID string
 
@@ -181,7 +181,7 @@ func (r *transientRefresher) retry(ctx context.Context, origErr error) (*oauth2.
 		if tokenErr == nil {
 			return t, nil
 		}
-		if !isTransientNetworkError(tokenErr, r.workload, r.upstream, r.clientID) {
+		if !isTransientNetworkError(tokenErr) {
 			return nil, backoff.Permanent(tokenErr)
 		}
 		return nil, tokenErr
@@ -239,11 +239,12 @@ type MonitoredTokenSource struct {
 // oauth2.TokenSource and monitors it for authentication failures.
 //
 // upstream and clientID annotate structured logs emitted by the token source,
-// most importantly the DCR remediation warning fired from
-// isTransientNetworkError when the token endpoint returns a permanent 4xx
-// (which frequently indicates a stale cached RFC 7591 registration). Pass
-// empty strings when the workload does not use DCR or the upstream issuer
-// is unknown; the slog handler will render the attributes as empty.
+// most importantly the DCR/CIMD remediation warning fired on the transition
+// to Unauthenticated when the token endpoint returns a permanent 4xx (which
+// frequently indicates stale cached credentials). Pass empty strings when
+// the workload does not use DCR/CIMD or the upstream issuer is unknown; the
+// remediation log will be suppressed when clientID is empty since its
+// operator-correlation field would be blank.
 //
 // The fields are fixed at construction time rather than exposed via a setter
 // so there is no data race between a late writer and the readers in Token()
@@ -295,8 +296,11 @@ func (mts *MonitoredTokenSource) Token() (*oauth2.Token, error) {
 		return tok, nil
 	}
 
-	if !isTransientNetworkError(err, mts.workloadName, mts.upstream, mts.clientID) {
-		mts.markAsUnauthenticated(fmt.Sprintf("Token retrieval failed: %v", err))
+	if !isTransientNetworkError(err) {
+		mts.markAsUnauthenticated(
+			fmt.Sprintf("Token retrieval failed: %v", err),
+			isPermanentTokenEndpointError(err),
+		)
 		return nil, err
 	}
 
@@ -305,7 +309,10 @@ func (mts *MonitoredTokenSource) Token() (*oauth2.Token, error) {
 	tok, err = mts.refresher.Refresh(mts.monitoringCtx, err)
 	if err != nil {
 		if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
-			mts.markAsUnauthenticated(fmt.Sprintf("Token refresh failed after retries: %v", err))
+			mts.markAsUnauthenticated(
+				fmt.Sprintf("Token refresh failed after retries: %v", err),
+				isPermanentTokenEndpointError(err),
+			)
 		}
 		return nil, err
 	}
@@ -382,12 +389,11 @@ func (mts *MonitoredTokenSource) onTick() (bool, time.Duration) {
 // (certificate verification, handshake failure) are NOT considered transient and
 // return false so the workload is marked unauthenticated immediately.
 //
-// workload, upstream, and clientID are context strings used only in
-// structured logs — notably the DCR remediation warning emitted in the
-// permanent-4xx branch, which suggests the cached RFC 7591 registration is
-// no longer recognised by the authorization server. All three are optional;
-// pass empty strings when the context is unknown.
-func isTransientNetworkError(err error, workload, upstream, clientID string) bool {
+// The function is side-effect free; callers that want to emit a DCR
+// remediation hint on a permanent 4xx must do so themselves at the
+// state-transition boundary using isPermanentTokenEndpointError to
+// classify, so a tight Token() loop does not spam the same record.
+func isTransientNetworkError(err error) bool {
 	if err == nil ||
 		errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 		return false
@@ -403,20 +409,6 @@ func isTransientNetworkError(err error, workload, upstream, clientID string) boo
 			)
 			return true
 		}
-		// Permanent 4xx from the token endpoint frequently indicates that the
-		// cached Dynamic Client Registration has been revoked, rotated, or is
-		// no longer recognised by the authorization server. Emit a remediation
-		// hint before returning false so operators can correlate the
-		// unauthentication with a stale DCR rather than a user-action issue.
-		// The returned boolean is unchanged.
-		//nolint:gosec // G706: client_id is public metadata per RFC 7591.
-		slog.Warn(
-			"cached DCR client is no longer recognized by the authorization server; "+
-				"delete the cached credentials and restart to re-register.",
-			"workload", workload,
-			"upstream", upstream,
-			"client_id", clientID,
-		)
 		return false
 	}
 
@@ -451,6 +443,21 @@ func isTransientNetworkError(err error, workload, upstream, clientID string) boo
 	return false
 }
 
+// isPermanentTokenEndpointError reports whether err is an *oauth2.RetrieveError
+// with a non-5xx HTTP status (i.e. a permanent token-endpoint response such as
+// 400, 401, 403). Used at state-transition boundaries to decide whether to
+// emit a DCR/CIMD remediation hint alongside the unauthentication.
+func isPermanentTokenEndpointError(err error) bool {
+	retrieveErr, ok := errors.AsType[*oauth2.RetrieveError](err)
+	if !ok {
+		return false
+	}
+	if retrieveErr.Response == nil {
+		return true
+	}
+	return retrieveErr.Response.StatusCode < 500
+}
+
 // isOAuthParseError detects errors from the oauth2 library that indicate the
 // token endpoint returned an unparsable response body on a 2xx status. This
 // typically happens when a load balancer, CDN, or reverse proxy intercepts the
@@ -466,13 +473,39 @@ func isOAuthParseError(err error) bool {
 		strings.Contains(msg, "oauth2: cannot parse response")
 }
 
-// markAsUnauthenticated marks the workload as unauthenticated and stops background monitoring.
-func (mts *MonitoredTokenSource) markAsUnauthenticated(reason string) {
+// markAsUnauthenticated marks the workload as unauthenticated and stops
+// background monitoring. If permanent4xx is true and the workload was
+// constructed with a non-empty client_id, a one-shot DCR/CIMD remediation
+// hint is emitted alongside the stop transition. The hint and the close
+// of stopMonitoring share stopOnce, so a caller (e.g. a tight Token()
+// loop) cannot spam the record on every call after the workload has
+// already transitioned to Unauthenticated.
+func (mts *MonitoredTokenSource) markAsUnauthenticated(reason string, permanent4xx bool) {
 	_ = mts.statusUpdater.SetWorkloadStatus(
 		context.Background(),
 		mts.workloadName,
 		runtime.WorkloadStatusUnauthenticated,
 		reason,
 	)
-	mts.stopOnce.Do(func() { close(mts.stopMonitoring) })
+	mts.stopOnce.Do(func() {
+		// A permanent 4xx from the token endpoint commonly indicates the
+		// cached client (DCR or CIMD) is no longer recognised — but the
+		// same branch fires for revoked consent, disabled accounts, and
+		// statically configured clients, so the message has to be honest
+		// about the variability. Gating on clientID != "" suppresses the
+		// log entirely for workloads where no client_id context is
+		// available; the operator-correlation it provides would be empty.
+		if permanent4xx && mts.clientID != "" {
+			//nolint:gosec // G706: client_id is public metadata per RFC 7591.
+			slog.Warn(
+				"token endpoint returned a permanent error; if this workload uses "+
+					"cached DCR or CIMD credentials they may be stale — delete the "+
+					"cached credentials and restart to re-register.",
+				"workload", mts.workloadName,
+				"upstream", mts.upstream,
+				"client_id", mts.clientID,
+			)
+		}
+		close(mts.stopMonitoring)
+	})
 }

--- a/pkg/auth/monitored_token_source.go
+++ b/pkg/auth/monitored_token_source.go
@@ -129,6 +129,15 @@ type transientRefresher struct {
 	source   oauth2.TokenSource
 	workload string
 
+	// upstream identifies the upstream authorization server that issued the
+	// token, and clientID is the OAuth 2.0 client_id used by this workload.
+	// Both are optional and are only surfaced in structured logs (notably the
+	// DCR remediation warning emitted from isTransientNetworkError when a
+	// permanent 4xx indicates a stale cached DCR client). Empty strings are
+	// acceptable and are omitted from log output by the slog handler.
+	upstream string
+	clientID string
+
 	// newBackOff is a factory for the backoff used during retries.
 	// Nil in production; overridable in tests for fast execution.
 	newBackOff func() backoff.BackOff
@@ -172,7 +181,7 @@ func (r *transientRefresher) retry(ctx context.Context, origErr error) (*oauth2.
 		if tokenErr == nil {
 			return t, nil
 		}
-		if !isTransientNetworkError(tokenErr) {
+		if !isTransientNetworkError(tokenErr, r.workload, r.upstream, r.clientID) {
 			return nil, backoff.Permanent(tokenErr)
 		}
 		return nil, tokenErr
@@ -212,6 +221,8 @@ func (r *transientRefresher) getBackOff() backoff.BackOff {
 type MonitoredTokenSource struct {
 	tokenSource    oauth2.TokenSource
 	workloadName   string
+	upstream       string
+	clientID       string
 	statusUpdater  StatusUpdater
 	monitoringCtx  context.Context
 	stopMonitoring chan struct{}
@@ -226,20 +237,41 @@ type MonitoredTokenSource struct {
 
 // NewMonitoredTokenSource creates a new MonitoredTokenSource that wraps the provided
 // oauth2.TokenSource and monitors it for authentication failures.
+//
+// upstream and clientID annotate structured logs emitted by the token source,
+// most importantly the DCR remediation warning fired from
+// isTransientNetworkError when the token endpoint returns a permanent 4xx
+// (which frequently indicates a stale cached RFC 7591 registration). Pass
+// empty strings when the workload does not use DCR or the upstream issuer
+// is unknown; the slog handler will render the attributes as empty.
+//
+// The fields are fixed at construction time rather than exposed via a setter
+// so there is no data race between a late writer and the readers in Token()
+// / transientRefresher.retry() — both of which may run on the background
+// monitor goroutine started by StartBackgroundMonitoring.
 func NewMonitoredTokenSource(
 	ctx context.Context,
 	tokenSource oauth2.TokenSource,
 	workloadName string,
+	upstream string,
+	clientID string,
 	statusUpdater StatusUpdater,
 ) *MonitoredTokenSource {
 	return &MonitoredTokenSource{
 		tokenSource:    tokenSource,
 		workloadName:   workloadName,
+		upstream:       upstream,
+		clientID:       clientID,
 		statusUpdater:  statusUpdater,
 		monitoringCtx:  ctx,
 		stopMonitoring: make(chan struct{}),
 		stopped:        make(chan struct{}),
-		refresher:      &transientRefresher{source: tokenSource, workload: workloadName},
+		refresher: &transientRefresher{
+			source:   tokenSource,
+			workload: workloadName,
+			upstream: upstream,
+			clientID: clientID,
+		},
 	}
 }
 
@@ -263,7 +295,7 @@ func (mts *MonitoredTokenSource) Token() (*oauth2.Token, error) {
 		return tok, nil
 	}
 
-	if !isTransientNetworkError(err) {
+	if !isTransientNetworkError(err, mts.workloadName, mts.upstream, mts.clientID) {
 		mts.markAsUnauthenticated(fmt.Sprintf("Token retrieval failed: %v", err))
 		return nil, err
 	}
@@ -349,7 +381,13 @@ func (mts *MonitoredTokenSource) onTick() (bool, time.Duration) {
 // OAuth2 client-level auth failures (invalid_grant, 401, 400) and TLS errors
 // (certificate verification, handshake failure) are NOT considered transient and
 // return false so the workload is marked unauthenticated immediately.
-func isTransientNetworkError(err error) bool {
+//
+// workload, upstream, and clientID are context strings used only in
+// structured logs — notably the DCR remediation warning emitted in the
+// permanent-4xx branch, which suggests the cached RFC 7591 registration is
+// no longer recognised by the authorization server. All three are optional;
+// pass empty strings when the context is unknown.
+func isTransientNetworkError(err error, workload, upstream, clientID string) bool {
 	if err == nil ||
 		errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 		return false
@@ -365,6 +403,20 @@ func isTransientNetworkError(err error) bool {
 			)
 			return true
 		}
+		// Permanent 4xx from the token endpoint frequently indicates that the
+		// cached Dynamic Client Registration has been revoked, rotated, or is
+		// no longer recognised by the authorization server. Emit a remediation
+		// hint before returning false so operators can correlate the
+		// unauthentication with a stale DCR rather than a user-action issue.
+		// The returned boolean is unchanged.
+		//nolint:gosec // G706: client_id is public metadata per RFC 7591.
+		slog.Warn(
+			"cached DCR client is no longer recognized by the authorization server; "+
+				"delete the cached credentials and restart to re-register.",
+			"workload", workload,
+			"upstream", upstream,
+			"client_id", clientID,
+		)
 		return false
 	}
 

--- a/pkg/auth/monitored_token_source_test.go
+++ b/pkg/auth/monitored_token_source_test.go
@@ -118,7 +118,7 @@ func TestMonitoredTokenSource_SuccessfulTokenRetrieval(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	ats := NewMonitoredTokenSource(ctx, tokenSource, "test-workload", statusUpdater)
+	ats := NewMonitoredTokenSource(ctx, tokenSource, "test-workload", "", "", statusUpdater)
 
 	// Test successful token retrieval
 	token, err := ats.Token()
@@ -151,7 +151,7 @@ func TestMonitoredTokenSource_AuthenticationErrorMarksUnauthenticated(t *testing
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	ats := NewMonitoredTokenSource(ctx, tokenSource, "test-workload", statusUpdater)
+	ats := NewMonitoredTokenSource(ctx, tokenSource, "test-workload", "", "", statusUpdater)
 
 	// Expect SetWorkloadStatus to be called with unauthenticated status
 	statusManager.EXPECT().
@@ -195,7 +195,7 @@ func TestMonitoredTokenSource_ErrorMarksUnauthenticated(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	ats := NewMonitoredTokenSource(ctx, tokenSource, "test-workload", statusUpdater)
+	ats := NewMonitoredTokenSource(ctx, tokenSource, "test-workload", "", "", statusUpdater)
 
 	// Expect SetWorkloadStatus to be called for any error
 	statusManager.EXPECT().
@@ -245,7 +245,7 @@ func TestMonitoredTokenSource_BackgroundMonitoring(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	ats := NewMonitoredTokenSource(ctx, tokenSource, "test-workload", statusUpdater)
+	ats := NewMonitoredTokenSource(ctx, tokenSource, "test-workload", "", "", statusUpdater)
 
 	// Expect SetWorkloadStatus to be called when auth error occurs
 	statusManager.EXPECT().
@@ -297,7 +297,7 @@ func TestMonitoredTokenSource_BackgroundMonitoringStopsOnAnyError(t *testing.T) 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	ats := NewMonitoredTokenSource(ctx, tokenSource, "test-workload", statusUpdater)
+	ats := NewMonitoredTokenSource(ctx, tokenSource, "test-workload", "", "", statusUpdater)
 
 	// Expect SetWorkloadStatus to be called when any error occurs
 	statusManager.EXPECT().
@@ -341,7 +341,7 @@ func TestMonitoredTokenSource_ExpiredTokenHandling(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	ats := NewMonitoredTokenSource(ctx, tokenSource, "test-workload", statusUpdater)
+	ats := NewMonitoredTokenSource(ctx, tokenSource, "test-workload", "", "", statusUpdater)
 
 	// Should not mark as unauthenticated just for expired token
 	// (oauth2 library should handle refresh; we only mark on actual auth errors)
@@ -374,7 +374,7 @@ func TestMonitoredTokenSource_StopMonitoring(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	ats := NewMonitoredTokenSource(ctx, tokenSource, "test-workload", statusUpdater)
+	ats := NewMonitoredTokenSource(ctx, tokenSource, "test-workload", "", "", statusUpdater)
 	ats.StartBackgroundMonitoring()
 
 	// Wait a bit to ensure monitoring started
@@ -407,7 +407,7 @@ func TestMonitoredTokenSource_MultipleCallsToToken(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	ats := NewMonitoredTokenSource(ctx, tokenSource, "test-workload", statusUpdater)
+	ats := NewMonitoredTokenSource(ctx, tokenSource, "test-workload", "", "", statusUpdater)
 
 	statusManager.EXPECT().
 		SetWorkloadStatus(
@@ -627,7 +627,7 @@ func TestMonitoredTokenSource_BackgroundMonitor_ErrorClassification(t *testing.T
 				statusUpdater, _ := newMockStatusUpdater(ctrl)
 				retrying := tokenSource.notifyOnCall(2)
 
-				ats := NewMonitoredTokenSource(ctx, tokenSource, "test-workload", statusUpdater)
+				ats := NewMonitoredTokenSource(ctx, tokenSource, "test-workload", "", "", statusUpdater)
 				ats.refresher.newBackOff = fastBackOff
 				ats.StartBackgroundMonitoring()
 
@@ -647,7 +647,7 @@ func TestMonitoredTokenSource_BackgroundMonitor_ErrorClassification(t *testing.T
 					Return(nil).
 					Times(1)
 
-				ats := NewMonitoredTokenSource(ctx, tokenSource, "test-workload", statusUpdater)
+				ats := NewMonitoredTokenSource(ctx, tokenSource, "test-workload", "", "", statusUpdater)
 				ats.refresher.newBackOff = fastBackOff
 				ats.StartBackgroundMonitoring()
 
@@ -698,7 +698,7 @@ func TestMonitoredTokenSource_TransientErrorRetriesAndSucceeds(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	ats := NewMonitoredTokenSource(ctx, tokenSource, "test-workload", statusUpdater)
+	ats := NewMonitoredTokenSource(ctx, tokenSource, "test-workload", "", "", statusUpdater)
 	ats.refresher.newBackOff = fastBackOff
 	ats.StartBackgroundMonitoring()
 
@@ -738,7 +738,7 @@ func TestMonitoredTokenSource_TransientErrorContextCancellation(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 
-	ats := NewMonitoredTokenSource(ctx, tokenSource, "test-workload", statusUpdater)
+	ats := NewMonitoredTokenSource(ctx, tokenSource, "test-workload", "", "", statusUpdater)
 	ats.refresher.newBackOff = fastBackOff
 	ats.StartBackgroundMonitoring()
 
@@ -793,7 +793,7 @@ func TestMonitoredTokenSource_TransientThenNonTransientMarksUnauthenticated(t *t
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	ats := NewMonitoredTokenSource(ctx, tokenSource, "test-workload", statusUpdater)
+	ats := NewMonitoredTokenSource(ctx, tokenSource, "test-workload", "", "", statusUpdater)
 	ats.refresher.newBackOff = fastBackOff
 	ats.StartBackgroundMonitoring()
 

--- a/pkg/auth/remote/config.go
+++ b/pkg/auth/remote/config.go
@@ -186,6 +186,30 @@ func (c *Config) ClearCachedClientCredentials() {
 	c.CachedRegTokenRef = ""
 }
 
+// LogContext returns the upstream issuer and resolved client_id for use as
+// log-correlation fields on the MonitoredTokenSource. Returns ("", "")
+// when c is nil so callers do not need to guard the call. Mirrors the
+// precedence applied at runtime when sending the client_id on token
+// refresh: cached CIMD URL > cached DCR client_id > statically configured
+// client_id. Lives next to resolveClientCredentials so the precedence has
+// a single home — adding a fourth cached field updates both call sites
+// in one place.
+func (c *Config) LogContext() (upstream, clientID string) {
+	if c == nil {
+		return "", ""
+	}
+	clientID = func() string {
+		if c.CachedCIMDClientID != "" {
+			return c.CachedCIMDClientID
+		}
+		if c.CachedClientID != "" {
+			return c.CachedClientID
+		}
+		return c.ClientID
+	}()
+	return c.Issuer, clientID
+}
+
 // DefaultResourceIndicator derives the resource indicator (RFC 8707) from the remote server URL.
 // This function should only be called when the user has not explicitly provided a resource indicator.
 // If the resource indicator cannot be derived, it returns an empty string.

--- a/pkg/auth/remote/config_test.go
+++ b/pkg/auth/remote/config_test.go
@@ -252,3 +252,76 @@ func TestConfig_ClearCachedClientCredentials(t *testing.T) {
 		t.Errorf("CachedClientSecretRef should be empty, got %s", config.CachedClientSecretRef)
 	}
 }
+
+func TestConfig_LogContext(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		cfg          *Config
+		wantUpstream string
+		wantClientID string
+	}{
+		{
+			name:         "nil config returns empty strings",
+			cfg:          nil,
+			wantUpstream: "",
+			wantClientID: "",
+		},
+		{
+			name: "static client_id when no cache",
+			cfg: &Config{
+				Issuer:   "https://idp.example.com",
+				ClientID: "static-client-id",
+			},
+			wantUpstream: "https://idp.example.com",
+			wantClientID: "static-client-id",
+		},
+		{
+			name: "cached DCR client_id wins over static",
+			cfg: &Config{
+				Issuer:         "https://idp.example.com",
+				ClientID:       "static-client-id",
+				CachedClientID: "dcr-client-id",
+			},
+			wantUpstream: "https://idp.example.com",
+			wantClientID: "dcr-client-id",
+		},
+		{
+			name: "cached CIMD client_id wins over DCR and static",
+			cfg: &Config{
+				Issuer:             "https://idp.example.com",
+				ClientID:           "static-client-id",
+				CachedClientID:     "dcr-client-id",
+				CachedCIMDClientID: "https://idp.example.com/cimd",
+			},
+			wantUpstream: "https://idp.example.com",
+			wantClientID: "https://idp.example.com/cimd",
+		},
+		{
+			name: "cached CIMD client_id used when no DCR or static",
+			cfg: &Config{
+				Issuer:             "https://idp.example.com",
+				CachedCIMDClientID: "https://idp.example.com/cimd",
+			},
+			wantUpstream: "https://idp.example.com",
+			wantClientID: "https://idp.example.com/cimd",
+		},
+		{
+			name:         "empty config returns empty fields",
+			cfg:          &Config{},
+			wantUpstream: "",
+			wantClientID: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			upstream, clientID := tc.cfg.LogContext()
+			assert.Equal(t, tc.wantUpstream, upstream)
+			assert.Equal(t, tc.wantClientID, clientID)
+		})
+	}
+}

--- a/pkg/authserver/runner/dcr.go
+++ b/pkg/authserver/runner/dcr.go
@@ -12,6 +12,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"regexp"
 	"runtime/debug"
 	"slices"
 	"sort"
@@ -21,6 +22,7 @@ import (
 	"golang.org/x/sync/singleflight"
 
 	"github.com/stacklok/toolhive/pkg/authserver"
+	"github.com/stacklok/toolhive/pkg/authserver/upstream"
 	"github.com/stacklok/toolhive/pkg/networking"
 	"github.com/stacklok/toolhive/pkg/oauthproto"
 )
@@ -96,6 +98,15 @@ type DCRResolution struct {
 	// token endpoint for this client.
 	TokenEndpointAuthMethod string
 
+	// RedirectURI is the redirect URI presented to the authorization server
+	// during registration. When the caller's run-config did not specify one,
+	// this holds the defaulted value derived from the issuer + /oauth/callback
+	// (via resolveUpstreamRedirectURI). Persisting it on the resolution lets
+	// applyResolution write it back onto the run-config COPY so that
+	// downstream consumers (buildPureOAuth2Config, upstream.OAuth2Config
+	// validation) see a non-empty RedirectURI.
+	RedirectURI string
+
 	// ClientIDIssuedAt is the RFC 7591 §3.2.1 "client_id_issued_at" value
 	// converted to a Go time.Time. Zero when the upstream omitted the field
 	// (the field is OPTIONAL per RFC 7591). Informational; not used to
@@ -132,23 +143,41 @@ func needsDCR(rc *authserver.OAuth2UpstreamRunConfig) bool {
 	return rc.ClientID == "" && rc.DCRConfig != nil
 }
 
-// applyResolution copies resolved credentials and endpoints from res into rc.
+// applyResolution copies resolved credentials and endpoints from res into rc
+// and consumes rc.DCRConfig (sets it to nil), transitioning the run-config
+// copy from "DCR-pending" (ClientID == "" && DCRConfig != nil) to "DCR-
+// resolved" (ClientID populated && DCRConfig == nil).
+//
 // Callers must pass a COPY of the upstream run-config (per the
 // copy-before-mutate rule in .claude/rules/go-style.md); applyResolution does
 // not clone rc internally.
 //
-// All three fields (ClientID, AuthorizationEndpoint, TokenEndpoint) are
-// written only when rc leaves them empty — explicit caller configuration
-// always wins. resolveDCRCredentials enforces ClientID == "" up front via
-// validateResolveInputs, so the conditional write here is defence-in-depth
-// against future call sites that bypass the resolver and invoke
-// applyResolution directly: an unconditional overwrite would silently
+// Why DCRConfig is cleared: OAuth2UpstreamRunConfig.Validate enforces
+// ClientID xor DCRConfig — a resolved copy that left DCRConfig set would
+// fail the validator that runs downstream in buildPureOAuth2Config. The
+// caller's *original* OAuth2Config is unaffected because
+// buildUpstreamConfigs deep-copies before resolution; only the post-
+// resolution copy is mutated here.
+//
+// ClientID, the endpoints, and RedirectURI are written only when rc leaves
+// them empty — explicit caller configuration always wins. The conditional
+// ClientID write is defence-in-depth against future call sites that bypass
+// the resolver's validateResolveInputs precondition (which enforces
+// ClientID == "" up front); an unconditional overwrite would silently
 // clobber a pre-provisioned ClientID with no error.
 //
-// Note: the resolved ClientSecret is NOT copied onto rc because
-// OAuth2UpstreamRunConfig models secrets as file-or-env references, not
-// inline values. Callers that need the resolved secret must read it from
-// the DCRResolution directly.
+// The defaulted RedirectURI write closes the loop on resolver-side defaulting:
+// when the caller's run-config left RedirectURI empty, resolveUpstreamRedirectURI
+// derived issuer + /oauth/callback and persisted it on the resolution; copying
+// it back here means the downstream upstream.OAuth2Config has a non-empty
+// RedirectURI, which authserver.Config validation requires.
+//
+// Note on ClientSecret: applyResolution does NOT write the resolved secret
+// to rc because OAuth2UpstreamRunConfig models secrets as file-or-env
+// references only. To propagate the DCR-resolved secret into the final
+// upstream.OAuth2Config, callers must pair this call with
+// applyResolutionToOAuth2Config once the config has been built. Keeping the
+// two helpers side-by-side localises the DCR-specific application logic.
 func applyResolution(rc *authserver.OAuth2UpstreamRunConfig, res *DCRResolution) {
 	if rc == nil || res == nil {
 		return
@@ -156,12 +185,35 @@ func applyResolution(rc *authserver.OAuth2UpstreamRunConfig, res *DCRResolution)
 	if rc.ClientID == "" {
 		rc.ClientID = res.ClientID
 	}
+	rc.DCRConfig = nil
 	if rc.AuthorizationEndpoint == "" {
 		rc.AuthorizationEndpoint = res.AuthorizationEndpoint
 	}
 	if rc.TokenEndpoint == "" {
 		rc.TokenEndpoint = res.TokenEndpoint
 	}
+	if rc.RedirectURI == "" {
+		rc.RedirectURI = res.RedirectURI
+	}
+}
+
+// applyResolutionToOAuth2Config overlays the DCR-resolved ClientSecret onto
+// a built *upstream.OAuth2Config. This is the companion to applyResolution:
+// where that function writes fields representable in the file-or-env run-
+// config model, this one writes the inline-only ClientSecret directly on
+// the runtime config.
+//
+// The split exists because buildPureOAuth2Config intentionally retains a
+// narrow file-or-env contract (no DCR awareness) and because OAuth2's
+// ClientSecret on the run-config is modelled as a reference rather than an
+// inline string. Any future output path from OAuth2UpstreamRunConfig to
+// upstream.OAuth2Config must call both helpers to get a fully-resolved
+// DCR client — exercised by TestBuildUpstreamConfigs_DCR.
+func applyResolutionToOAuth2Config(cfg *upstream.OAuth2Config, res *DCRResolution) {
+	if cfg == nil || res == nil {
+		return
+	}
+	cfg.ClientSecret = res.ClientSecret
 }
 
 // scopesHash returns the SHA-256 hex digest of the canonical scope set.
@@ -193,6 +245,58 @@ func scopesHash(scopes []string) string {
 	return hex.EncodeToString(h.Sum(nil))
 }
 
+// Step identifiers for structured error logs emitted by the caller of
+// resolveDCRCredentials. These values flow through the "step" attribute so
+// operators can narrow failures to a specific phase without parsing error
+// messages. They are reported only at the boundary log — see
+// DCRStepError — so a single failure produces a single slog.Error record.
+const (
+	dcrStepValidate         = "validate"
+	dcrStepResolveRedirect  = "resolve_redirect_uri"
+	dcrStepCacheRead        = "cache_read"
+	dcrStepMetadata         = "metadata_discovery"
+	dcrStepSelectAuthMethod = "select_auth_method"
+	dcrStepRegister         = "dcr_call"
+	dcrStepCacheWrite       = "cache_write"
+)
+
+// DCRStepError annotates a resolver error with the phase it was produced
+// in. The boundary caller (buildUpstreamConfigs) emits the single
+// slog.Error record for the failure; individual error branches inside
+// resolveDCRCredentials do not log so that each failure surfaces exactly
+// once in the combined log stream.
+//
+// RedirectURI is included when known so that operators can correlate the
+// failure with a specific upstream registration without parsing the
+// wrapped error string. A zero-value DCRStepError is invalid; construct
+// via newDCRStepError or the resolver's internal helpers.
+type DCRStepError struct {
+	Step        string
+	Issuer      string
+	RedirectURI string
+	Err         error
+}
+
+// Error implements error. The "step" tag mirrors the structured-log
+// attribute so command-line log scrapers see the same phase identifier.
+func (e *DCRStepError) Error() string {
+	return fmt.Sprintf("dcr: %s: %s", e.Step, e.Err.Error())
+}
+
+// Unwrap lets errors.Is / errors.As reach the wrapped cause.
+func (e *DCRStepError) Unwrap() error { return e.Err }
+
+// newDCRStepError builds a DCRStepError. It never returns nil for a
+// non-nil cause.
+func newDCRStepError(step, issuer, redirectURI string, err error) *DCRStepError {
+	return &DCRStepError{
+		Step:        step,
+		Issuer:      issuer,
+		RedirectURI: redirectURI,
+		Err:         err,
+	}
+}
+
 // resolveDCRCredentials performs Dynamic Client Registration for rc against
 // the upstream authorization server identified by rc.DCRConfig, caching the
 // resulting credentials in cache. On cache hit the resolver returns
@@ -212,6 +316,16 @@ func scopesHash(scopes []string) string {
 // The caller is responsible for applying the returned resolution onto a COPY
 // of rc via applyResolution (per the copy-before-mutate rule). This function
 // neither mutates rc nor the cache on failure.
+//
+// Observability: this function never calls slog.Error directly — all
+// failures are annotated with a *DCRStepError and returned to the caller,
+// which is expected to emit the boundary Error record. This avoids the
+// double-logging pattern where both the resolver and the outer frame
+// report the same failure. Cache-hit Debug / stale-Warn logs and the
+// successful-registration Debug log are emitted here because they have no
+// outer-frame equivalent. No secret values (client_secret,
+// registration_access_token, initial_access_token) are ever logged — only
+// public metadata such as client_id and redirect_uri.
 func resolveDCRCredentials(
 	ctx context.Context,
 	rc *authserver.OAuth2UpstreamRunConfig,
@@ -219,12 +333,13 @@ func resolveDCRCredentials(
 	cache DCRCredentialStore,
 ) (*DCRResolution, error) {
 	if err := validateResolveInputs(rc, localIssuer, cache); err != nil {
-		return nil, err
+		return nil, newDCRStepError(dcrStepValidate, localIssuer, "", err)
 	}
 
 	redirectURI, err := resolveUpstreamRedirectURI(rc.RedirectURI, localIssuer)
 	if err != nil {
-		return nil, fmt.Errorf("dcr: resolve redirect uri: %w", err)
+		return nil, newDCRStepError(dcrStepResolveRedirect, localIssuer, "",
+			fmt.Errorf("resolve redirect uri: %w", err))
 	}
 
 	scopes := slices.Clone(rc.Scopes)
@@ -236,7 +351,7 @@ func resolveDCRCredentials(
 
 	// Cache lookup short-circuits before any network I/O.
 	if cached, hit, err := lookupCachedResolution(ctx, cache, key, localIssuer, redirectURI); err != nil {
-		return nil, err
+		return nil, newDCRStepError(dcrStepCacheRead, localIssuer, redirectURI, err)
 	} else if hit {
 		return cached, nil
 	}
@@ -253,7 +368,9 @@ func resolveDCRCredentials(
 	// for the same DCRKey would all crash with the same value. The panic is
 	// still surfaced: it is logged at Error with a stack trace, and the
 	// returned error wraps the recovered value so callers can react to it as
-	// a normal failure.
+	// a normal failure. The wrapped error is annotated with the dcrStepRegister
+	// step so LogDCRStepError surfaces it in the same step taxonomy as the
+	// other registration failures.
 	flightKey := key.Issuer + "\n" + key.RedirectURI + "\n" + key.ScopesHash
 	resolutionAny, err, _ := dcrFlight.Do(flightKey, func() (res any, err error) {
 		defer func() {
@@ -262,7 +379,8 @@ func resolveDCRCredentials(
 					"panic", fmt.Sprintf("%v", r),
 					"stack", string(debug.Stack()),
 				)
-				err = fmt.Errorf("dcr: registration panicked: %v", r)
+				err = newDCRStepError(dcrStepRegister, localIssuer, redirectURI,
+					fmt.Errorf("registration panicked: %v", r))
 				res = nil
 			}
 		}()
@@ -290,7 +408,7 @@ func registerAndCache(
 	// Recheck cache: another flight that just finished may have populated
 	// it between our initial lookup and our singleflight entry.
 	if cached, hit, err := lookupCachedResolution(ctx, cache, key, localIssuer, redirectURI); err != nil {
-		return nil, err
+		return nil, newDCRStepError(dcrStepCacheRead, localIssuer, redirectURI, err)
 	} else if hit {
 		return cached, nil
 	}
@@ -303,7 +421,7 @@ func registerAndCache(
 	// RFC 8414 §3.3 metadata verification (which is the upstream's concern).
 	endpoints, err := resolveDCREndpoints(ctx, rc.DCRConfig)
 	if err != nil {
-		return nil, err
+		return nil, newDCRStepError(dcrStepMetadata, localIssuer, redirectURI, err)
 	}
 	applyExplicitEndpointOverrides(endpoints, rc)
 
@@ -315,7 +433,7 @@ func registerAndCache(
 		endpoints.codeChallengeMethodsSupported,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("dcr: %w", err)
+		return nil, newDCRStepError(dcrStepSelectAuthMethod, localIssuer, redirectURI, err)
 	}
 
 	registrationScopes := chooseRegistrationScopes(scopes, endpoints.scopesSupported, localIssuer)
@@ -323,15 +441,16 @@ func registerAndCache(
 	response, err := performRegistration(ctx, rc.DCRConfig, endpoints.registrationEndpoint,
 		redirectURI, authMethod, registrationScopes)
 	if err != nil {
-		return nil, err
+		return nil, newDCRStepError(dcrStepRegister, localIssuer, redirectURI, err)
 	}
 
-	resolution := buildResolution(response, endpoints, authMethod)
+	resolution := buildResolution(response, endpoints, authMethod, redirectURI)
 
 	// Write to durable storage before updating caller state (per
 	// .claude/rules/go-style.md "write to durable storage before in-memory").
 	if err := cache.Put(ctx, key, resolution); err != nil {
-		return nil, fmt.Errorf("dcr: cache put: %w", err)
+		return nil, newDCRStepError(dcrStepCacheWrite, localIssuer, redirectURI,
+			fmt.Errorf("cache put: %w", err))
 	}
 
 	//nolint:gosec // G706: client_id is public metadata per RFC 7591.
@@ -342,6 +461,113 @@ func registerAndCache(
 	)
 	return resolution, nil
 }
+
+// LogDCRStepError emits the single boundary slog.Error record for a DCR
+// resolver failure, carrying the step / issuer / redirect_uri attributes
+// extracted from err. If err is not a *DCRStepError, it is logged with a
+// generic "unknown" step — resolveDCRCredentials always wraps its errors,
+// so this branch indicates a programming error in a future caller rather
+// than a runtime condition.
+//
+// Every wrapped error is passed through sanitizeErrorForLog to strip URL
+// query parameters that could plausibly contain sensitive tokens (defense
+// in depth — the current DCR flow sends the initial access token as an
+// Authorization header, not a query parameter, but nothing in the type
+// system prevents a future refactor from doing otherwise).
+func LogDCRStepError(upstreamName string, err error) {
+	var stepErr *DCRStepError
+	if !errors.As(err, &stepErr) {
+		slog.Error("dcr: resolve failed",
+			"upstream", upstreamName,
+			"step", "unknown",
+			"error", sanitizeErrorForLog(err),
+		)
+		return
+	}
+
+	attrs := []any{
+		"upstream", upstreamName,
+		"step", stepErr.Step,
+		"issuer", stepErr.Issuer,
+		"error", sanitizeErrorForLog(stepErr.Err),
+	}
+	if stepErr.RedirectURI != "" {
+		attrs = append(attrs, "redirect_uri", stepErr.RedirectURI)
+	}
+	slog.Error("dcr: resolve failed", attrs...)
+}
+
+// sanitizeErrorForLog strips query strings from any URLs embedded in err's
+// message. The Go HTTP client, url.Error, and other net/* wrappers embed
+// the full request URL — including query parameters — in their error
+// strings. Query parameters rarely carry secrets in our DCR flow (the
+// initial access token is sent as an Authorization header), but a future
+// change could silently introduce a token in a query parameter; stripping
+// query strings here is defense in depth that protects the log regardless.
+//
+// Only the query component of URL-shaped substrings is replaced; scheme,
+// host, and path are preserved so operators retain enough context to
+// correlate with upstream server logs. Trailing sentence punctuation
+// adjacent to the URL (e.g. the comma in "reaching URL?q=1, retrying")
+// is preserved — see trimURLTrailingPunctuation for the list of
+// characters considered terminators.
+//
+// Scope: the regex only matches http:// and https:// schemes. Other
+// schemes (file://, raw host:port) are not sanitised; the current DCR
+// flow never embeds those in errors, and broadening the match risks
+// false positives on unrelated text.
+func sanitizeErrorForLog(err error) string {
+	if err == nil {
+		return ""
+	}
+	msg := err.Error()
+	return queryStrippingPattern.ReplaceAllStringFunc(msg, func(match string) string {
+		// Split any trailing sentence punctuation off the match before
+		// handing it to url.Parse. Without this, a period / comma /
+		// closing bracket at the end of the sentence is absorbed into
+		// the URL's raw query and dropped along with the rest of the
+		// query component, mangling the error text. The trimmed
+		// punctuation is re-appended to the replacement so the
+		// surrounding prose is preserved verbatim.
+		core, tail := trimURLTrailingPunctuation(match)
+		u, parseErr := url.Parse(core)
+		if parseErr != nil || u.RawQuery == "" {
+			return match
+		}
+		u.RawQuery = ""
+		return u.String() + tail
+	})
+}
+
+// trimURLTrailingPunctuation returns (core, tail) where tail is the run of
+// trailing ASCII punctuation that commonly terminates a URL inside prose
+// but is never a meaningful part of the URL itself. The characters chosen
+// here mirror those used by general-purpose URL extractors (e.g.,
+// Chromium's autolinker): sentence-ending punctuation, closing brackets,
+// and a few separators that appear between URLs in freeform text.
+//
+// Note that ')' and ']' are stripped unconditionally — a URL legitimately
+// containing a percent-encoded closing bracket will have it as "%29" or
+// "%5D", not as a literal, so this cannot truncate a real URL path or
+// query. The reverse case (an unescaped ')' inside a path) is
+// non-conforming per RFC 3986 and out of scope for a log sanitiser.
+func trimURLTrailingPunctuation(s string) (core, tail string) {
+	const terminators = ".,;:!?)]}>"
+	i := len(s)
+	for i > 0 && strings.ContainsRune(terminators, rune(s[i-1])) {
+		i--
+	}
+	return s[:i], s[i:]
+}
+
+// queryStrippingPattern matches URL-shaped substrings inside an error
+// message — sufficient to reach the url.Parse path in sanitizeErrorForLog
+// and let it decide whether a query component exists to strip. The regexp
+// is intentionally narrow (http/https schemes only) to avoid false
+// positives. Trailing sentence punctuation that the character class
+// happens to include (e.g. '.', ',', ')') is stripped by
+// trimURLTrailingPunctuation before the match is parsed.
+var queryStrippingPattern = regexp.MustCompile(`https?://[^\s"']+`)
 
 // -----------------------------------------------------------------------------
 // Private helpers
@@ -378,13 +604,24 @@ func validateResolveInputs(
 // returns (resolution, true, nil). On miss it returns (nil, false, nil). An
 // error is returned only on backend failure.
 //
-// Entries whose RFC 7591 §3.2.1 client_secret_expires_at has already passed
-// are treated as misses so the singleflight body (registerAndCache) re-runs
-// the registration and overwrites the stale entry via cache.Put. Without
-// this check the cache would serve an expired secret indefinitely; the
-// upstream's token endpoint would 401 on every use and the resolver would
-// have no signal to refetch. The check is skipped when the field is zero,
-// per the RFC 7591 convention "0 means the secret does not expire".
+// Two distinct staleness signals shape the hit/miss decision and the log:
+//
+//   - Hard expiry (RFC 7591 §3.2.1 client_secret_expires_at): when the
+//     cached resolution's ClientSecretExpiresAt is non-zero and in the
+//     past, the entry is treated as a miss so the singleflight body
+//     (registerAndCache) re-runs the registration and overwrites the stale
+//     entry via cache.Put. Without this check the cache would serve an
+//     expired secret indefinitely; the upstream's token endpoint would 401
+//     on every use and the resolver would have no signal to refetch. The
+//     check is skipped when the field is zero, per the RFC 7591 convention
+//     "0 means the secret does not expire". This is the authoritative
+//     signal — the upstream said when its credential expires.
+//   - Soft staleness (now - CreatedAt vs dcrStaleAgeThreshold): the age in
+//     days is logged on every hit, and if it exceeds the threshold an
+//     additional slog.Warn is emitted with a remediation hint so operators
+//     can act on long-lived registrations that may need rotation or
+//     re-registration. This is observability only, not a cache-invalidation
+//     trigger.
 func lookupCachedResolution(
 	ctx context.Context,
 	cache DCRCredentialStore,
@@ -408,11 +645,32 @@ func lookupCachedResolution(
 		)
 		return nil, false, nil
 	}
+
+	age := time.Since(cached.CreatedAt)
+	ageDays := int(age / (24 * time.Hour))
+
+	//nolint:gosec // G706: client_id is public metadata per RFC 7591.
 	slog.Debug("dcr: cache hit",
 		"local_issuer", localIssuer,
 		"redirect_uri", redirectURI,
 		"client_id", cached.ClientID,
+		"dcr_age_days", ageDays,
 	)
+
+	if age > dcrStaleAgeThreshold {
+		//nolint:gosec // G706: client_id is public metadata per RFC 7591.
+		slog.Warn(
+			"dcr: cached registration exceeds staleness threshold; "+
+				"consider rotating the registration via RFC 7592 deregistration "+
+				"and re-registering at next startup",
+			"local_issuer", localIssuer,
+			"redirect_uri", redirectURI,
+			"client_id", cached.ClientID,
+			"dcr_age_days", ageDays,
+			"stale_threshold_days", int(dcrStaleAgeThreshold/(24*time.Hour)),
+		)
+	}
+
 	return cached, true, nil
 }
 
@@ -484,7 +742,10 @@ func performRegistration(
 // buildResolution assembles the DCRResolution from the RFC 7591 response and
 // the resolved endpoints. If the server did not echo a
 // token_endpoint_auth_method in the response, the method actually sent is
-// recorded so downstream consumers see a definite value.
+// recorded so downstream consumers see a definite value. redirectURI is the
+// value passed to the registration endpoint (caller-supplied or defaulted
+// via resolveUpstreamRedirectURI); it is persisted on the resolution so
+// applyResolution can propagate a defaulted value back to the run-config.
 //
 // RFC 7591 §3.2.1 client_id_issued_at and client_secret_expires_at are
 // converted from int64 epoch seconds to time.Time. The wire value 0 means
@@ -494,6 +755,7 @@ func buildResolution(
 	response *oauthproto.DynamicClientRegistrationResponse,
 	endpoints *dcrEndpoints,
 	sentAuthMethod string,
+	redirectURI string,
 ) *DCRResolution {
 	authMethod := response.TokenEndpointAuthMethod
 	if authMethod == "" {
@@ -507,6 +769,7 @@ func buildResolution(
 		RegistrationAccessToken: response.RegistrationAccessToken,
 		RegistrationClientURI:   response.RegistrationClientURI,
 		TokenEndpointAuthMethod: authMethod,
+		RedirectURI:             redirectURI,
 		ClientIDIssuedAt:        epochSecondsToTime(response.ClientIDIssuedAt),
 		ClientSecretExpiresAt:   epochSecondsToTime(response.ClientSecretExpiresAt),
 		CreatedAt:               time.Now(),

--- a/pkg/authserver/runner/dcr.go
+++ b/pkg/authserver/runner/dcr.go
@@ -36,9 +36,16 @@ import (
 // concurrent registrations. Followers wait for the leader's result and
 // observe the same DCRResolution.
 //
-// Package-level rather than per-store because the deduplication concern is
-// the resolver's, not the cache's: a future Redis-backed store would still
-// want this in-process gate so a single replica does not double-register.
+// Lifetime: process-wide. This intentionally contrasts with
+// EmbeddedAuthServer.dcrStore, which is per-instance. The asymmetry is
+// load-bearing: the singleflight only deduplicates the in-flight network
+// call, while the cache deduplicates the resolution itself across calls.
+// Process-wide flight means concurrent EmbeddedAuthServer instances in
+// the same process targeting the same upstream still get deduplicated;
+// the per-instance cache is correct because each instance independently
+// decides whether the resolution is fresh enough to reuse. A future
+// Redis-backed store would still want this in-process gate so a single
+// replica does not double-register against itself.
 var dcrFlight singleflight.Group
 
 // defaultUpstreamRedirectPath is the redirect path derived from the issuer
@@ -67,7 +74,7 @@ var authMethodPreference = []string{
 // upstream advertises so the caller need not re-discover them.
 //
 // The struct is the unit of storage in DCRCredentialStore and the unit of
-// application via applyResolution.
+// application via consumeResolution.
 type DCRResolution struct {
 	// ClientID is the RFC 7591 "client_id" returned by the authorization
 	// server.
@@ -102,7 +109,7 @@ type DCRResolution struct {
 	// during registration. When the caller's run-config did not specify one,
 	// this holds the defaulted value derived from the issuer + /oauth/callback
 	// (via resolveUpstreamRedirectURI). Persisting it on the resolution lets
-	// applyResolution write it back onto the run-config COPY so that
+	// consumeResolution write it back onto the run-config COPY so that
 	// downstream consumers (buildPureOAuth2Config, upstream.OAuth2Config
 	// validation) see a non-empty RedirectURI.
 	RedirectURI string
@@ -143,14 +150,16 @@ func needsDCR(rc *authserver.OAuth2UpstreamRunConfig) bool {
 	return rc.ClientID == "" && rc.DCRConfig != nil
 }
 
-// applyResolution copies resolved credentials and endpoints from res into rc
-// and consumes rc.DCRConfig (sets it to nil), transitioning the run-config
-// copy from "DCR-pending" (ClientID == "" && DCRConfig != nil) to "DCR-
-// resolved" (ClientID populated && DCRConfig == nil).
+// consumeResolution copies resolved credentials and endpoints from res into
+// rc and consumes rc.DCRConfig (sets it to nil), transitioning the run-
+// config copy from "DCR-pending" (ClientID == "" && DCRConfig != nil) to
+// "DCR-resolved" (ClientID populated && DCRConfig == nil). The "consume"
+// name is deliberate: a second call after the first is a no-op only
+// because the first cleared DCRConfig — this is a one-shot state
+// transition, not an idempotent default-fill.
 //
-// Callers must pass a COPY of the upstream run-config (per the
-// copy-before-mutate rule in .claude/rules/go-style.md); applyResolution does
-// not clone rc internally.
+// Callers must pass a COPY of the upstream run-config so the caller's
+// original is unaffected; consumeResolution does not clone rc internally.
 //
 // Why DCRConfig is cleared: OAuth2UpstreamRunConfig.Validate enforces
 // ClientID xor DCRConfig — a resolved copy that left DCRConfig set would
@@ -172,13 +181,14 @@ func needsDCR(rc *authserver.OAuth2UpstreamRunConfig) bool {
 // it back here means the downstream upstream.OAuth2Config has a non-empty
 // RedirectURI, which authserver.Config validation requires.
 //
-// Note on ClientSecret: applyResolution does NOT write the resolved secret
-// to rc because OAuth2UpstreamRunConfig models secrets as file-or-env
-// references only. To propagate the DCR-resolved secret into the final
-// upstream.OAuth2Config, callers must pair this call with
-// applyResolutionToOAuth2Config once the config has been built. Keeping the
-// two helpers side-by-side localises the DCR-specific application logic.
-func applyResolution(rc *authserver.OAuth2UpstreamRunConfig, res *DCRResolution) {
+// Note on ClientSecret: consumeResolution does NOT write the resolved
+// secret to rc because OAuth2UpstreamRunConfig models secrets as file-or-
+// env references only. To propagate the DCR-resolved secret into the
+// final upstream.OAuth2Config, callers must pair this call with
+// applyResolutionToOAuth2Config once the config has been built. Keeping
+// the two helpers side-by-side localises the DCR-specific application
+// logic.
+func consumeResolution(rc *authserver.OAuth2UpstreamRunConfig, res *DCRResolution) {
 	if rc == nil || res == nil {
 		return
 	}
@@ -198,17 +208,20 @@ func applyResolution(rc *authserver.OAuth2UpstreamRunConfig, res *DCRResolution)
 }
 
 // applyResolutionToOAuth2Config overlays the DCR-resolved ClientSecret onto
-// a built *upstream.OAuth2Config. This is the companion to applyResolution:
-// where that function writes fields representable in the file-or-env run-
-// config model, this one writes the inline-only ClientSecret directly on
-// the runtime config.
+// a built *upstream.OAuth2Config. This is the companion to
+// consumeResolution: where that function writes fields representable in
+// the file-or-env run-config model, this one writes the inline-only
+// ClientSecret directly on the runtime config.
 //
 // The split exists because buildPureOAuth2Config intentionally retains a
 // narrow file-or-env contract (no DCR awareness) and because OAuth2's
-// ClientSecret on the run-config is modelled as a reference rather than an
-// inline string. Any future output path from OAuth2UpstreamRunConfig to
-// upstream.OAuth2Config must call both helpers to get a fully-resolved
-// DCR client — exercised by TestBuildUpstreamConfigs_DCR.
+// ClientSecret on the run-config is modelled as a reference rather than
+// an inline string. Any future output path from OAuth2UpstreamRunConfig
+// to upstream.OAuth2Config must call BOTH consumeResolution (run-config
+// side) AND applyResolutionToOAuth2Config (built-config side) to get a
+// fully-resolved DCR client. Forgetting the second call leaves
+// ClientSecret empty and produces silent auth failures at request time —
+// the type system does not enforce the pair, so the invariant lives here.
 func applyResolutionToOAuth2Config(cfg *upstream.OAuth2Config, res *DCRResolution) {
 	if cfg == nil || res == nil {
 		return
@@ -249,7 +262,7 @@ func scopesHash(scopes []string) string {
 // resolveDCRCredentials. These values flow through the "step" attribute so
 // operators can narrow failures to a specific phase without parsing error
 // messages. They are reported only at the boundary log — see
-// DCRStepError — so a single failure produces a single slog.Error record.
+// dcrStepError — so a single failure produces a single slog.Error record.
 const (
 	dcrStepValidate         = "validate"
 	dcrStepResolveRedirect  = "resolve_redirect_uri"
@@ -260,7 +273,7 @@ const (
 	dcrStepCacheWrite       = "cache_write"
 )
 
-// DCRStepError annotates a resolver error with the phase it was produced
+// dcrStepError annotates a resolver error with the phase it was produced
 // in. The boundary caller (buildUpstreamConfigs) emits the single
 // slog.Error record for the failure; individual error branches inside
 // resolveDCRCredentials do not log so that each failure surfaces exactly
@@ -268,28 +281,32 @@ const (
 //
 // RedirectURI is included when known so that operators can correlate the
 // failure with a specific upstream registration without parsing the
-// wrapped error string. A zero-value DCRStepError is invalid; construct
-// via newDCRStepError or the resolver's internal helpers.
-type DCRStepError struct {
+// wrapped error string. Stack carries a captured stack trace for the
+// dcrStepRegister panic-recovery branch so logDCRStepError can include
+// it in the single boundary record without the in-defer site emitting
+// its own duplicate slog.Error. A zero-value dcrStepError is invalid;
+// construct via newDCRStepError or the resolver's internal helpers.
+type dcrStepError struct {
 	Step        string
 	Issuer      string
 	RedirectURI string
+	Stack       string
 	Err         error
 }
 
 // Error implements error. The "step" tag mirrors the structured-log
 // attribute so command-line log scrapers see the same phase identifier.
-func (e *DCRStepError) Error() string {
+func (e *dcrStepError) Error() string {
 	return fmt.Sprintf("dcr: %s: %s", e.Step, e.Err.Error())
 }
 
 // Unwrap lets errors.Is / errors.As reach the wrapped cause.
-func (e *DCRStepError) Unwrap() error { return e.Err }
+func (e *dcrStepError) Unwrap() error { return e.Err }
 
-// newDCRStepError builds a DCRStepError. It never returns nil for a
+// newDCRStepError builds a dcrStepError. It never returns nil for a
 // non-nil cause.
-func newDCRStepError(step, issuer, redirectURI string, err error) *DCRStepError {
-	return &DCRStepError{
+func newDCRStepError(step, issuer, redirectURI string, err error) *dcrStepError {
+	return &dcrStepError{
 		Step:        step,
 		Issuer:      issuer,
 		RedirectURI: redirectURI,
@@ -314,11 +331,11 @@ func newDCRStepError(step, issuer, redirectURI string, err error) *DCRStepError 
 // redirect and a cache key that does not identify the auth-server context.
 //
 // The caller is responsible for applying the returned resolution onto a COPY
-// of rc via applyResolution (per the copy-before-mutate rule). This function
+// of rc via consumeResolution (per the copy-before-mutate rule). This function
 // neither mutates rc nor the cache on failure.
 //
 // Observability: this function never calls slog.Error directly — all
-// failures are annotated with a *DCRStepError and returned to the caller,
+// failures are annotated with a *dcrStepError and returned to the caller,
 // which is expected to emit the boundary Error record. This avoids the
 // double-logging pattern where both the resolver and the outer frame
 // report the same failure. Cache-hit Debug / stale-Warn logs and the
@@ -366,21 +383,18 @@ func resolveDCRCredentials(
 	// (or anything it calls) into a normal error. Without this, singleflight
 	// re-panics the leader's panic in every follower — N concurrent callers
 	// for the same DCRKey would all crash with the same value. The panic is
-	// still surfaced: it is logged at Error with a stack trace, and the
-	// returned error wraps the recovered value so callers can react to it as
-	// a normal failure. The wrapped error is annotated with the dcrStepRegister
-	// step so LogDCRStepError surfaces it in the same step taxonomy as the
-	// other registration failures.
+	// still surfaced: the captured stack trace is attached to the wrapped
+	// dcrStepError and surfaces in the single boundary log emitted by
+	// logDCRStepError, so the failure produces exactly one Error record (no
+	// in-defer log here) and callers can react to it as a normal failure.
 	flightKey := key.Issuer + "\n" + key.RedirectURI + "\n" + key.ScopesHash
 	resolutionAny, err, _ := dcrFlight.Do(flightKey, func() (res any, err error) {
 		defer func() {
 			if r := recover(); r != nil {
-				slog.Error("dcr: registration panicked",
-					"panic", fmt.Sprintf("%v", r),
-					"stack", string(debug.Stack()),
-				)
-				err = newDCRStepError(dcrStepRegister, localIssuer, redirectURI,
+				stepErr := newDCRStepError(dcrStepRegister, localIssuer, redirectURI,
 					fmt.Errorf("registration panicked: %v", r))
+				stepErr.Stack = string(debug.Stack())
+				err = stepErr
 				res = nil
 			}
 		}()
@@ -446,8 +460,10 @@ func registerAndCache(
 
 	resolution := buildResolution(response, endpoints, authMethod, redirectURI)
 
-	// Write to durable storage before updating caller state (per
-	// .claude/rules/go-style.md "write to durable storage before in-memory").
+	// Write to durable storage before returning the resolution so a Put
+	// failure leaves no in-memory state diverging from the cache: the
+	// next call simply re-resolves rather than reading a value the cache
+	// never saw.
 	if err := cache.Put(ctx, key, resolution); err != nil {
 		return nil, newDCRStepError(dcrStepCacheWrite, localIssuer, redirectURI,
 			fmt.Errorf("cache put: %w", err))
@@ -462,20 +478,24 @@ func registerAndCache(
 	return resolution, nil
 }
 
-// LogDCRStepError emits the single boundary slog.Error record for a DCR
+// logDCRStepError emits the single boundary slog.Error record for a DCR
 // resolver failure, carrying the step / issuer / redirect_uri attributes
-// extracted from err. If err is not a *DCRStepError, it is logged with a
+// extracted from err. If err is not a *dcrStepError, it is logged with a
 // generic "unknown" step — resolveDCRCredentials always wraps its errors,
 // so this branch indicates a programming error in a future caller rather
-// than a runtime condition.
+// than a runtime condition. err == nil is a no-op so this function is
+// safe to call without an outer guard.
 //
 // Every wrapped error is passed through sanitizeErrorForLog to strip URL
 // query parameters that could plausibly contain sensitive tokens (defense
 // in depth — the current DCR flow sends the initial access token as an
 // Authorization header, not a query parameter, but nothing in the type
 // system prevents a future refactor from doing otherwise).
-func LogDCRStepError(upstreamName string, err error) {
-	var stepErr *DCRStepError
+func logDCRStepError(upstreamName string, err error) {
+	if err == nil {
+		return
+	}
+	var stepErr *dcrStepError
 	if !errors.As(err, &stepErr) {
 		slog.Error("dcr: resolve failed",
 			"upstream", upstreamName,
@@ -494,28 +514,32 @@ func LogDCRStepError(upstreamName string, err error) {
 	if stepErr.RedirectURI != "" {
 		attrs = append(attrs, "redirect_uri", stepErr.RedirectURI)
 	}
+	if stepErr.Stack != "" {
+		attrs = append(attrs, "stack", stepErr.Stack)
+	}
 	slog.Error("dcr: resolve failed", attrs...)
 }
 
-// sanitizeErrorForLog strips query strings from any URLs embedded in err's
-// message. The Go HTTP client, url.Error, and other net/* wrappers embed
-// the full request URL — including query parameters — in their error
-// strings. Query parameters rarely carry secrets in our DCR flow (the
-// initial access token is sent as an Authorization header), but a future
-// change could silently introduce a token in a query parameter; stripping
-// query strings here is defense in depth that protects the log regardless.
+// sanitizeErrorForLog strips secret-bearing components from any URLs
+// embedded in err's message. The Go HTTP client, url.Error, and other
+// net/* wrappers embed the full request URL — including userinfo,
+// query, and fragment — in their error strings. Any of those can carry
+// credentials or tokens (e.g. https://user:pass@host, ?token=…,
+// implicit-flow callbacks #access_token=…); the current DCR flow does
+// not embed any of them today, but stripping them here is defense in
+// depth that protects the log regardless of future changes.
 //
-// Only the query component of URL-shaped substrings is replaced; scheme,
-// host, and path are preserved so operators retain enough context to
-// correlate with upstream server logs. Trailing sentence punctuation
-// adjacent to the URL (e.g. the comma in "reaching URL?q=1, retrying")
-// is preserved — see trimURLTrailingPunctuation for the list of
-// characters considered terminators.
+// Scheme, host, and path are preserved so operators retain enough
+// context to correlate with upstream server logs. Trailing sentence
+// punctuation adjacent to the URL (e.g. the comma in "reaching
+// URL?q=1, retrying") is preserved — see trimURLTrailingPunctuation
+// for the list of characters considered terminators.
 //
-// Scope: the regex only matches http:// and https:// schemes. Other
-// schemes (file://, raw host:port) are not sanitised; the current DCR
-// flow never embeds those in errors, and broadening the match risks
-// false positives on unrelated text.
+// Scope: the regex matches http:// and https:// schemes
+// (case-insensitively per RFC 3986 §3.1). Other schemes (file://, raw
+// host:port) are not sanitised; the current DCR flow never embeds
+// those in errors, and broadening the match risks false positives on
+// unrelated text.
 func sanitizeErrorForLog(err error) string {
 	if err == nil {
 		return ""
@@ -531,10 +555,15 @@ func sanitizeErrorForLog(err error) string {
 		// surrounding prose is preserved verbatim.
 		core, tail := trimURLTrailingPunctuation(match)
 		u, parseErr := url.Parse(core)
-		if parseErr != nil || u.RawQuery == "" {
+		if parseErr != nil {
 			return match
 		}
+		if u.User == nil && u.RawQuery == "" && u.Fragment == "" {
+			return match
+		}
+		u.User = nil
 		u.RawQuery = ""
+		u.Fragment = ""
 		return u.String() + tail
 	})
 }
@@ -552,9 +581,12 @@ func sanitizeErrorForLog(err error) string {
 // query. The reverse case (an unescaped ')' inside a path) is
 // non-conforming per RFC 3986 and out of scope for a log sanitiser.
 func trimURLTrailingPunctuation(s string) (core, tail string) {
+	// terminators is intentionally ASCII-only; Unicode terminators (e.g.
+	// '」') are out of scope for this log sanitiser, so byte indexing is
+	// safe and avoids the rune-decoding overhead of strings.ContainsRune.
 	const terminators = ".,;:!?)]}>"
 	i := len(s)
-	for i > 0 && strings.ContainsRune(terminators, rune(s[i-1])) {
+	for i > 0 && strings.IndexByte(terminators, s[i-1]) >= 0 {
 		i--
 	}
 	return s[:i], s[i:]
@@ -562,12 +594,14 @@ func trimURLTrailingPunctuation(s string) (core, tail string) {
 
 // queryStrippingPattern matches URL-shaped substrings inside an error
 // message — sufficient to reach the url.Parse path in sanitizeErrorForLog
-// and let it decide whether a query component exists to strip. The regexp
-// is intentionally narrow (http/https schemes only) to avoid false
-// positives. Trailing sentence punctuation that the character class
+// and let it decide whether a secret-bearing component exists to strip.
+// The regexp is intentionally narrow (http/https schemes only) to avoid
+// false positives, but matches schemes case-insensitively per RFC 3986
+// §3.1 since upstream metadata or user input can carry mixed-case
+// schemes. Trailing sentence punctuation that the character class
 // happens to include (e.g. '.', ',', ')') is stripped by
 // trimURLTrailingPunctuation before the match is parsed.
-var queryStrippingPattern = regexp.MustCompile(`https?://[^\s"']+`)
+var queryStrippingPattern = regexp.MustCompile(`(?i)https?://[^\s"']+`)
 
 // -----------------------------------------------------------------------------
 // Private helpers
@@ -745,7 +779,7 @@ func performRegistration(
 // recorded so downstream consumers see a definite value. redirectURI is the
 // value passed to the registration endpoint (caller-supplied or defaulted
 // via resolveUpstreamRedirectURI); it is persisted on the resolution so
-// applyResolution can propagate a defaulted value back to the run-config.
+// consumeResolution can propagate a defaulted value back to the run-config.
 //
 // RFC 7591 §3.2.1 client_id_issued_at and client_secret_expires_at are
 // converted from int64 epoch seconds to time.Time. The wire value 0 means

--- a/pkg/authserver/runner/dcr_store.go
+++ b/pkg/authserver/runner/dcr_store.go
@@ -73,9 +73,9 @@ type DCRCredentialStore interface {
 // durability, and cross-process coordination gaps documented below.
 //
 // Entries are retained for the process lifetime; there is no TTL and no
-// background cleanup goroutine. The unbounded-cache footgun called out in
-// .claude/rules/go-style.md "Resource Leaks" does not bite here because the
-// key space is bounded by the operator-configured upstream count, and this
+// background cleanup goroutine. The usual concern about an unbounded
+// cache leaking memory does not apply here because the key space is
+// bounded by the operator-configured upstream count, and this
 // implementation is not the production answer.
 //
 // What this enables: serialises Get/Put against a single in-process map so
@@ -122,8 +122,8 @@ func (s *inMemoryDCRCredentialStore) Get(_ context.Context, key DCRKey) (*DCRRes
 		return nil, false, nil
 	}
 	// Return a defensive copy so mutations by the caller never reach the
-	// cache entry. This mirrors the copy-before-mutate rule in
-	// .claude/rules/go-style.md.
+	// cache entry — internal maps and pointers must not be reachable from
+	// the caller's value.
 	cp := *res
 	return &cp, true, nil
 }
@@ -132,8 +132,8 @@ func (s *inMemoryDCRCredentialStore) Get(_ context.Context, key DCRKey) (*DCRRes
 //
 // A nil resolution is rejected rather than silently no-oped: a caller
 // passing nil would otherwise get a successful return, observe a miss on
-// the next Get, and have no error trail to debug from. Per the constructor-
-// validation rule in .claude/rules/go-style.md, fail loudly at the boundary.
+// the next Get, and have no error trail to debug from. Failing loudly at
+// the boundary makes such bugs visible at the first call.
 func (s *inMemoryDCRCredentialStore) Put(_ context.Context, key DCRKey, resolution *DCRResolution) error {
 	if resolution == nil {
 		return fmt.Errorf("dcr: resolution must not be nil")

--- a/pkg/authserver/runner/dcr_store_test.go
+++ b/pkg/authserver/runner/dcr_store_test.go
@@ -244,10 +244,9 @@ func TestScopesHash_NoCollisionFromBoundaryJoin(t *testing.T) {
 // interface doc. With go test -race this catches any future change that
 // drops the lock or introduces a data race in the map access.
 //
-// The test is bounded by a fail-fast deadline per .claude/rules/testing.md
-// "Concurrent Tests: Always Add Timeouts to Blocking Barriers" — a
-// regression that deadlocks would otherwise hang until the global Go test
-// timeout.
+// The test is bounded by a fail-fast deadline so a regression that
+// deadlocks fails loudly with a clear message rather than hanging until
+// the global Go test timeout.
 func TestInMemoryDCRCredentialStore_ConcurrentAccess(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/authserver/runner/dcr_test.go
+++ b/pkg/authserver/runner/dcr_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -661,6 +662,30 @@ func TestApplyResolution_FillsMissingEndpoints(t *testing.T) {
 	assert.Equal(t, "got-client", rc.ClientID)
 	assert.Equal(t, "https://discovered/authorize", rc.AuthorizationEndpoint)
 	assert.Equal(t, "https://discovered/token", rc.TokenEndpoint)
+}
+
+// TestApplyResolution_ConsumesDCRConfig pins the contract that
+// applyResolution clears DCRConfig on the run-config copy after writing the
+// resolved ClientID. Without this, OAuth2UpstreamRunConfig.Validate (run by
+// buildPureOAuth2Config downstream) trips its ClientID-xor-DCRConfig rule
+// on the resolved copy and rejects the upstream at boot.
+func TestApplyResolution_ConsumesDCRConfig(t *testing.T) {
+	t.Parallel()
+
+	rc := &authserver.OAuth2UpstreamRunConfig{
+		DCRConfig: &authserver.DCRUpstreamConfig{
+			RegistrationEndpoint: "https://idp.example.com/register",
+		},
+	}
+	res := &DCRResolution{
+		ClientID: "dcr-issued-client",
+	}
+
+	applyResolution(rc, res)
+
+	assert.Equal(t, "dcr-issued-client", rc.ClientID)
+	assert.Nil(t, rc.DCRConfig,
+		"applyResolution must clear DCRConfig so the resolved copy satisfies the ClientID-xor-DCRConfig invariant")
 }
 
 func TestResolveUpstreamRedirectURI(t *testing.T) {
@@ -1326,7 +1351,9 @@ func TestResolveDCRCredentials_CacheGetFailureWrapped(t *testing.T) {
 	require.Error(t, err)
 	assert.ErrorIs(t, err, storeErr,
 		"cache.Get error must be wrapped with %%w so callers can inspect the cause")
-	assert.Contains(t, err.Error(), "dcr: cache lookup",
+	assert.Contains(t, err.Error(), dcrStepCacheRead,
+		"step identifier is part of the operator-debugging contract")
+	assert.Contains(t, err.Error(), "cache lookup",
 		"the wrap message is part of the operator-debugging contract")
 }
 
@@ -1353,7 +1380,9 @@ func TestResolveDCRCredentials_CachePutFailureWrapped(t *testing.T) {
 	require.Error(t, err)
 	assert.ErrorIs(t, err, storeErr,
 		"cache.Put error must be wrapped with %%w so callers can inspect the cause")
-	assert.Contains(t, err.Error(), "dcr: cache put",
+	assert.Contains(t, err.Error(), dcrStepCacheWrite,
+		"step identifier is part of the operator-debugging contract")
+	assert.Contains(t, err.Error(), "cache put",
 		"the wrap message is part of the operator-debugging contract")
 }
 
@@ -1413,6 +1442,7 @@ func TestBuildResolution_PopulatesRFC7591ExpiryFields(t *testing.T) {
 					tokenEndpoint:         "https://idp.example.com/token",
 				},
 				"client_secret_basic",
+				"https://idp.example.com/oauth/callback",
 			)
 			assert.Equal(t, tc.wantIssuedAt, resolution.ClientIDIssuedAt)
 			assert.Equal(t, tc.wantExpiresAt, resolution.ClientSecretExpiresAt)
@@ -1594,5 +1624,129 @@ func TestResolveDCRCredentials_RecoversPanicInsideSingleflight(t *testing.T) {
 			i, errs[i].Error())
 		assert.Contains(t, errs[i].Error(), "boom",
 			"goroutine %d's error must include the panic value so the cause is recoverable", i)
+	}
+}
+
+func TestDCRStepError(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Error formats step and cause", func(t *testing.T) {
+		t.Parallel()
+
+		cause := fmt.Errorf("boom")
+		e := newDCRStepError(dcrStepRegister, "https://as", "https://app/cb", cause)
+		assert.Equal(t, "dcr: dcr_call: boom", e.Error())
+	})
+
+	t.Run("Unwrap returns cause", func(t *testing.T) {
+		t.Parallel()
+
+		cause := fmt.Errorf("inner")
+		e := newDCRStepError(dcrStepValidate, "", "", cause)
+		assert.Same(t, cause, errors.Unwrap(e))
+	})
+
+	t.Run("errors.As extracts the typed error", func(t *testing.T) {
+		t.Parallel()
+
+		cause := fmt.Errorf("inner")
+		e := newDCRStepError(dcrStepCacheRead, "https://as", "https://app/cb", cause)
+		wrapped := fmt.Errorf("outer: %w", e)
+
+		var got *DCRStepError
+		require.True(t, errors.As(wrapped, &got))
+		assert.Equal(t, dcrStepCacheRead, got.Step)
+		assert.Equal(t, "https://as", got.Issuer)
+		assert.Equal(t, "https://app/cb", got.RedirectURI)
+	})
+
+	t.Run("resolveDCRCredentials wraps every failure in a DCRStepError", func(t *testing.T) {
+		t.Parallel()
+
+		// Precondition failure → dcrStepValidate.
+		_, err := resolveDCRCredentials(context.Background(), nil, "https://as",
+			NewInMemoryDCRCredentialStore())
+		require.Error(t, err)
+		var stepErr *DCRStepError
+		require.True(t, errors.As(err, &stepErr))
+		assert.Equal(t, dcrStepValidate, stepErr.Step)
+	})
+}
+
+func TestSanitizeErrorForLog(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		in       error
+		expected string
+	}{
+		{
+			name:     "nil error returns empty string",
+			in:       nil,
+			expected: "",
+		},
+		{
+			name:     "no URL passes through unchanged",
+			in:       fmt.Errorf("something went wrong"),
+			expected: "something went wrong",
+		},
+		{
+			name:     "URL without query is preserved",
+			in:       fmt.Errorf("GET https://as.example.com/register failed"),
+			expected: "GET https://as.example.com/register failed",
+		},
+		{
+			name:     "URL query is stripped",
+			in:       fmt.Errorf("GET https://as.example.com/register?token=leak&foo=bar failed"),
+			expected: "GET https://as.example.com/register failed",
+		},
+		{
+			name:     "multiple URLs — only queries are stripped, hosts and paths remain",
+			in:       fmt.Errorf("from https://a.example/p1?x=1 to https://b.example/p2?y=2"),
+			expected: "from https://a.example/p1 to https://b.example/p2",
+		},
+		// Trailing punctuation regression cases: the query is stripped
+		// but the sentence punctuation adjacent to the URL must be
+		// preserved verbatim. Without trimURLTrailingPunctuation the
+		// regex's greedy character class would absorb these into the
+		// raw query and drop them along with it.
+		{
+			name:     "trailing comma is preserved when query is stripped",
+			in:       fmt.Errorf("error reaching https://as.example.com/register?x=1, retrying."),
+			expected: "error reaching https://as.example.com/register, retrying.",
+		},
+		{
+			name:     "trailing period is preserved when query is stripped",
+			in:       fmt.Errorf("failed: https://a.example/p?q=1."),
+			expected: "failed: https://a.example/p.",
+		},
+		{
+			name:     "trailing closing paren is preserved when query is stripped",
+			in:       fmt.Errorf("(see https://ex.com/a?b=1)"),
+			expected: "(see https://ex.com/a)",
+		},
+		{
+			name:     "mixed trailing punctuation is preserved when query is stripped",
+			in:       fmt.Errorf("at https://ex.com/a?b=1]!"),
+			expected: "at https://ex.com/a]!",
+		},
+		{
+			name:     "trailing punctuation on URL without query is still preserved",
+			in:       fmt.Errorf("see https://ex.com/a."),
+			expected: "see https://ex.com/a.",
+		},
+		{
+			name:     "go http client style quoted URL is sanitised",
+			in:       fmt.Errorf(`Get "https://as.example.com/register?token=abc": EOF`),
+			expected: `Get "https://as.example.com/register": EOF`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.expected, sanitizeErrorForLog(tc.in))
+		})
 	}
 }

--- a/pkg/authserver/runner/dcr_test.go
+++ b/pkg/authserver/runner/dcr_test.go
@@ -631,7 +631,7 @@ func TestNeedsDCR(t *testing.T) {
 	}
 }
 
-func TestApplyResolution_RespectsExplicitEndpoints(t *testing.T) {
+func TestConsumeResolution_RespectsExplicitEndpoints(t *testing.T) {
 	t.Parallel()
 
 	rc := &authserver.OAuth2UpstreamRunConfig{
@@ -643,13 +643,13 @@ func TestApplyResolution_RespectsExplicitEndpoints(t *testing.T) {
 		AuthorizationEndpoint: "https://discovered/authorize",
 		TokenEndpoint:         "https://discovered/token",
 	}
-	applyResolution(rc, res)
+	consumeResolution(rc, res)
 	assert.Equal(t, "got-client", rc.ClientID)
 	assert.Equal(t, "https://explicit/authorize", rc.AuthorizationEndpoint)
 	assert.Equal(t, "https://explicit/token", rc.TokenEndpoint)
 }
 
-func TestApplyResolution_FillsMissingEndpoints(t *testing.T) {
+func TestConsumeResolution_FillsMissingEndpoints(t *testing.T) {
 	t.Parallel()
 
 	rc := &authserver.OAuth2UpstreamRunConfig{}
@@ -658,18 +658,18 @@ func TestApplyResolution_FillsMissingEndpoints(t *testing.T) {
 		AuthorizationEndpoint: "https://discovered/authorize",
 		TokenEndpoint:         "https://discovered/token",
 	}
-	applyResolution(rc, res)
+	consumeResolution(rc, res)
 	assert.Equal(t, "got-client", rc.ClientID)
 	assert.Equal(t, "https://discovered/authorize", rc.AuthorizationEndpoint)
 	assert.Equal(t, "https://discovered/token", rc.TokenEndpoint)
 }
 
-// TestApplyResolution_ConsumesDCRConfig pins the contract that
-// applyResolution clears DCRConfig on the run-config copy after writing the
-// resolved ClientID. Without this, OAuth2UpstreamRunConfig.Validate (run by
-// buildPureOAuth2Config downstream) trips its ClientID-xor-DCRConfig rule
-// on the resolved copy and rejects the upstream at boot.
-func TestApplyResolution_ConsumesDCRConfig(t *testing.T) {
+// TestConsumeResolution_ClearsDCRConfig pins the contract that
+// consumeResolution clears DCRConfig on the run-config copy after writing
+// the resolved ClientID. Without this, OAuth2UpstreamRunConfig.Validate
+// (run by buildPureOAuth2Config downstream) trips its ClientID-xor-
+// DCRConfig rule on the resolved copy and rejects the upstream at boot.
+func TestConsumeResolution_ClearsDCRConfig(t *testing.T) {
 	t.Parallel()
 
 	rc := &authserver.OAuth2UpstreamRunConfig{
@@ -681,11 +681,11 @@ func TestApplyResolution_ConsumesDCRConfig(t *testing.T) {
 		ClientID: "dcr-issued-client",
 	}
 
-	applyResolution(rc, res)
+	consumeResolution(rc, res)
 
 	assert.Equal(t, "dcr-issued-client", rc.ClientID)
 	assert.Nil(t, rc.DCRConfig,
-		"applyResolution must clear DCRConfig so the resolved copy satisfies the ClientID-xor-DCRConfig invariant")
+		"consumeResolution must clear DCRConfig so the resolved copy satisfies the ClientID-xor-DCRConfig invariant")
 }
 
 func TestResolveUpstreamRedirectURI(t *testing.T) {
@@ -1197,11 +1197,11 @@ func TestResolveUpstreamRedirectURI_PreservesIssuerPath(t *testing.T) {
 	}
 }
 
-// TestApplyResolution_DoesNotOverwritePreProvisionedClientID verifies the
-// defence-in-depth in applyResolution: a caller that bypasses
-// validateResolveInputs and invokes applyResolution directly with a
+// TestConsumeResolution_DoesNotOverwritePreProvisionedClientID verifies
+// the defence-in-depth in consumeResolution: a caller that bypasses
+// validateResolveInputs and invokes consumeResolution directly with a
 // pre-provisioned ClientID does not have it silently clobbered.
-func TestApplyResolution_DoesNotOverwritePreProvisionedClientID(t *testing.T) {
+func TestConsumeResolution_DoesNotOverwritePreProvisionedClientID(t *testing.T) {
 	t.Parallel()
 
 	rc := &authserver.OAuth2UpstreamRunConfig{
@@ -1210,9 +1210,9 @@ func TestApplyResolution_DoesNotOverwritePreProvisionedClientID(t *testing.T) {
 	res := &DCRResolution{
 		ClientID: "would-be-overwrite",
 	}
-	applyResolution(rc, res)
+	consumeResolution(rc, res)
 	assert.Equal(t, "pre-provisioned", rc.ClientID,
-		"applyResolution must not overwrite a non-empty ClientID")
+		"consumeResolution must not overwrite a non-empty ClientID")
 }
 
 // TestResolveDCREndpoints_DirectRegistrationEndpointValidated covers
@@ -1568,8 +1568,9 @@ func (s panickingPutDCRStore) Put(_ context.Context, _ DCRKey, _ *DCRResolution)
 // singleflight.Group re-panics the leader's panic in every follower, so
 // without the recover N concurrent callers for the same DCRKey would all
 // crash with the same value. The defer/recover converts the panic to a
-// normal error, the panic is logged at Error with a stack, and every
-// caller gets the same wrapped error.
+// *dcrStepError(dcrStepRegister, ..., Stack: <captured>); the boundary
+// caller's logDCRStepError emits the single Error record and every caller
+// gets the same wrapped error.
 func TestResolveDCRCredentials_RecoversPanicInsideSingleflight(t *testing.T) {
 	t.Parallel()
 
@@ -1624,10 +1625,21 @@ func TestResolveDCRCredentials_RecoversPanicInsideSingleflight(t *testing.T) {
 			i, errs[i].Error())
 		assert.Contains(t, errs[i].Error(), "boom",
 			"goroutine %d's error must include the panic value so the cause is recoverable", i)
+
+		// The captured stack and dcrStepRegister tag must travel with the
+		// returned error so the boundary log (logDCRStepError) emits a
+		// single Error record without a duplicate in-defer log.
+		var stepErr *dcrStepError
+		require.True(t, errors.As(errs[i], &stepErr),
+			"goroutine %d's error must wrap a *dcrStepError; got %T", i, errs[i])
+		assert.Equal(t, dcrStepRegister, stepErr.Step,
+			"goroutine %d's wrapped error must carry the dcrStepRegister step", i)
+		assert.NotEmpty(t, stepErr.Stack,
+			"goroutine %d's wrapped error must include the captured panic stack", i)
 	}
 }
 
-func TestDCRStepError(t *testing.T) {
+func TestDcrStepError(t *testing.T) {
 	t.Parallel()
 
 	t.Run("Error formats step and cause", func(t *testing.T) {
@@ -1653,21 +1665,21 @@ func TestDCRStepError(t *testing.T) {
 		e := newDCRStepError(dcrStepCacheRead, "https://as", "https://app/cb", cause)
 		wrapped := fmt.Errorf("outer: %w", e)
 
-		var got *DCRStepError
+		var got *dcrStepError
 		require.True(t, errors.As(wrapped, &got))
 		assert.Equal(t, dcrStepCacheRead, got.Step)
 		assert.Equal(t, "https://as", got.Issuer)
 		assert.Equal(t, "https://app/cb", got.RedirectURI)
 	})
 
-	t.Run("resolveDCRCredentials wraps every failure in a DCRStepError", func(t *testing.T) {
+	t.Run("resolveDCRCredentials wraps every failure in a dcrStepError", func(t *testing.T) {
 		t.Parallel()
 
 		// Precondition failure → dcrStepValidate.
 		_, err := resolveDCRCredentials(context.Background(), nil, "https://as",
 			NewInMemoryDCRCredentialStore())
 		require.Error(t, err)
-		var stepErr *DCRStepError
+		var stepErr *dcrStepError
 		require.True(t, errors.As(err, &stepErr))
 		assert.Equal(t, dcrStepValidate, stepErr.Step)
 	})
@@ -1740,6 +1752,28 @@ func TestSanitizeErrorForLog(t *testing.T) {
 			name:     "go http client style quoted URL is sanitised",
 			in:       fmt.Errorf(`Get "https://as.example.com/register?token=abc": EOF`),
 			expected: `Get "https://as.example.com/register": EOF`,
+		},
+		{
+			name:     "embedded userinfo is stripped",
+			in:       fmt.Errorf("connect https://user:pass@host.example/path?q=1 failed"),
+			expected: "connect https://host.example/path failed",
+		},
+		{
+			name:     "embedded userinfo without query is stripped",
+			in:       fmt.Errorf("connect https://user:pass@host.example/path failed"),
+			expected: "connect https://host.example/path failed",
+		},
+		{
+			name:     "fragment is stripped",
+			in:       fmt.Errorf("callback https://app.example/cb#access_token=abc failed"),
+			expected: "callback https://app.example/cb failed",
+		},
+		{
+			// url.Parse normalises the scheme to lowercase, so the
+			// post-sanitisation form matches the canonical scheme casing.
+			name:     "uppercase scheme is sanitised",
+			in:       fmt.Errorf("GET HTTPS://as.example.com/register?token=leak failed"),
+			expected: "GET https://as.example.com/register failed",
 		},
 	}
 

--- a/pkg/authserver/runner/embeddedauthserver.go
+++ b/pkg/authserver/runner/embeddedauthserver.go
@@ -42,6 +42,21 @@ type EmbeddedAuthServer struct {
 	// dcrStore caches RFC 7591 Dynamic Client Registration resolutions across
 	// calls to buildUpstreamConfigs so that re-entrant boot/reload paths reuse
 	// previously-registered upstream clients instead of re-registering.
+	//
+	// Lifetime: per-instance — the store is owned by this EmbeddedAuthServer
+	// and is GC'd when the server is unreferenced. This intentionally
+	// contrasts with the package-level dcrFlight singleflight in dcr.go,
+	// which is process-wide so concurrent EmbeddedAuthServer instances
+	// targeting the same upstream still deduplicate the network call. The
+	// cache (per-instance) and the flight (process-wide) protect different
+	// resources: the cache prevents redundant registrations across reboots,
+	// the flight prevents N concurrent /register calls during a thundering
+	// herd. The asymmetry is by design.
+	//
+	// DCRCredentialStore has no Close method today because the in-memory
+	// implementation needs no release. A future Phase 3 backend (Redis,
+	// sqlite) with handles will need Close added to the interface and
+	// invoked from EmbeddedAuthServer.Close.
 	dcrStore  DCRCredentialStore
 	closeOnce sync.Once
 	closeErr  error
@@ -283,14 +298,14 @@ func parseTokenLifespans(cfg *authserver.TokenLifespanRunConfig) (access, refres
 // RFC 7591 Dynamic Client Registration against the upstream authorization
 // server (hitting the network on first call, using dcrStore on subsequent
 // calls) and overlays the resulting ClientID / ClientSecret onto the output
-// config via applyResolution + applyResolutionToOAuth2Config. The caller's
-// runConfigs slice is not mutated: per the copy-before-mutate rule in
-// .claude/rules/go-style.md we clone each element before applying DCR
-// resolution.
+// config via consumeResolution + applyResolutionToOAuth2Config. The
+// caller's runConfigs slice is not mutated: in-place mutation of
+// caller-provided values surprises callers and can cause data races, so
+// each element is cloned before applying DCR resolution.
 //
 // Error logging: this function is the boundary for DCR errors — on any
 // failure from resolveDCRCredentials it emits exactly one structured
-// slog.Error via LogDCRStepError and returns the wrapped error to the
+// slog.Error via logDCRStepError and returns the wrapped error to the
 // caller without logging further. The resolver itself does not log
 // errors, which avoids the log-and-return double-reporting pattern.
 func buildUpstreamConfigs(
@@ -312,7 +327,7 @@ func buildUpstreamConfigs(
 		// "does this upstream require DCR" avoids drift if the condition
 		// ever needs to be extended (e.g., to support OIDC DCR).
 		if needsDCR(rcCopy.OAuth2Config) {
-			// Deep-copy the OAuth2 sub-config so applyResolution writes to the
+			// Deep-copy the OAuth2 sub-config so consumeResolution writes to the
 			// copy, not the caller's OAuth2UpstreamRunConfig pointer.
 			o2Copy := *rcCopy.OAuth2Config
 			rcCopy.OAuth2Config = &o2Copy
@@ -322,10 +337,10 @@ func buildUpstreamConfigs(
 				// Emit the single boundary Error record with enough context to
 				// correlate the failure back to this upstream; then return the
 				// wrapped error without further logging.
-				LogDCRStepError(rc.Name, err)
+				logDCRStepError(rc.Name, err)
 				return nil, fmt.Errorf("upstream %q: %w", rc.Name, err)
 			}
-			applyResolution(&o2Copy, resolution)
+			consumeResolution(&o2Copy, resolution)
 			dcrResolution = resolution
 		}
 
@@ -335,7 +350,7 @@ func buildUpstreamConfigs(
 		}
 
 		// Apply the DCR-resolved ClientSecret to the built OAuth2Config.
-		// The split between applyResolution (run-config fields) and
+		// The split between consumeResolution (run-config fields) and
 		// applyResolutionToOAuth2Config (inline-only ClientSecret) is
 		// documented in dcr.go — both calls must be paired to produce a
 		// fully-resolved DCR client.

--- a/pkg/authserver/runner/embeddedauthserver.go
+++ b/pkg/authserver/runner/embeddedauthserver.go
@@ -39,8 +39,12 @@ const (
 type EmbeddedAuthServer struct {
 	server      authserver.Server
 	keyProvider keys.KeyProvider
-	closeOnce   sync.Once
-	closeErr    error
+	// dcrStore caches RFC 7591 Dynamic Client Registration resolutions across
+	// calls to buildUpstreamConfigs so that re-entrant boot/reload paths reuse
+	// previously-registered upstream clients instead of re-registering.
+	dcrStore  DCRCredentialStore
+	closeOnce sync.Once
+	closeErr  error
 }
 
 // NewEmbeddedAuthServer creates an EmbeddedAuthServer from authserver.RunConfig.
@@ -73,8 +77,10 @@ func NewEmbeddedAuthServer(ctx context.Context, cfg *authserver.RunConfig) (*Emb
 		return nil, fmt.Errorf("failed to parse token lifespans: %w", err)
 	}
 
-	// 4. Build upstream configurations
-	upstreams, err := buildUpstreamConfigs(ctx, cfg.Upstreams)
+	// 4. Build upstream configurations (resolves DCR credentials for any
+	// upstream configured with DCRConfig, caching resolutions in dcrStore).
+	dcrStore := NewInMemoryDCRCredentialStore()
+	upstreams, err := buildUpstreamConfigs(ctx, cfg.Upstreams, cfg.Issuer, dcrStore)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build upstream configs: %w", err)
 	}
@@ -108,6 +114,7 @@ func NewEmbeddedAuthServer(ctx context.Context, cfg *authserver.RunConfig) (*Emb
 	return &EmbeddedAuthServer{
 		server:      server,
 		keyProvider: keyProvider,
+		dcrStore:    dcrStore,
 	}, nil
 }
 
@@ -271,14 +278,71 @@ func parseTokenLifespans(cfg *authserver.TokenLifespanRunConfig) (access, refres
 // buildUpstreamConfigs converts UpstreamRunConfig slice to UpstreamConfig slice.
 // It preserves the provider type so the factory can create the correct provider
 // (OIDCProviderImpl for OIDC, BaseOAuth2Provider for OAuth2).
-func buildUpstreamConfigs(_ context.Context, runConfigs []authserver.UpstreamRunConfig) ([]authserver.UpstreamConfig, error) {
+//
+// For OAuth2 upstreams configured with DCRConfig, buildUpstreamConfigs performs
+// RFC 7591 Dynamic Client Registration against the upstream authorization
+// server (hitting the network on first call, using dcrStore on subsequent
+// calls) and overlays the resulting ClientID / ClientSecret onto the output
+// config via applyResolution + applyResolutionToOAuth2Config. The caller's
+// runConfigs slice is not mutated: per the copy-before-mutate rule in
+// .claude/rules/go-style.md we clone each element before applying DCR
+// resolution.
+//
+// Error logging: this function is the boundary for DCR errors — on any
+// failure from resolveDCRCredentials it emits exactly one structured
+// slog.Error via LogDCRStepError and returns the wrapped error to the
+// caller without logging further. The resolver itself does not log
+// errors, which avoids the log-and-return double-reporting pattern.
+func buildUpstreamConfigs(
+	ctx context.Context,
+	runConfigs []authserver.UpstreamRunConfig,
+	issuer string,
+	dcrStore DCRCredentialStore,
+) ([]authserver.UpstreamConfig, error) {
 	configs := make([]authserver.UpstreamConfig, 0, len(runConfigs))
 
 	for _, rc := range runConfigs {
-		cfg, err := buildUpstreamConfig(&rc)
+		// Shallow copy of the outer UpstreamRunConfig so DCR resolution never
+		// mutates the caller's slice element.
+		rcCopy := rc
+
+		var dcrResolution *DCRResolution
+		// needsDCR returns false for nil input, so the explicit Type ==
+		// OAuth2 guard is redundant. Keeping a single source of truth for
+		// "does this upstream require DCR" avoids drift if the condition
+		// ever needs to be extended (e.g., to support OIDC DCR).
+		if needsDCR(rcCopy.OAuth2Config) {
+			// Deep-copy the OAuth2 sub-config so applyResolution writes to the
+			// copy, not the caller's OAuth2UpstreamRunConfig pointer.
+			o2Copy := *rcCopy.OAuth2Config
+			rcCopy.OAuth2Config = &o2Copy
+
+			resolution, err := resolveDCRCredentials(ctx, &o2Copy, issuer, dcrStore)
+			if err != nil {
+				// Emit the single boundary Error record with enough context to
+				// correlate the failure back to this upstream; then return the
+				// wrapped error without further logging.
+				LogDCRStepError(rc.Name, err)
+				return nil, fmt.Errorf("upstream %q: %w", rc.Name, err)
+			}
+			applyResolution(&o2Copy, resolution)
+			dcrResolution = resolution
+		}
+
+		cfg, err := buildUpstreamConfig(&rcCopy)
 		if err != nil {
 			return nil, fmt.Errorf("upstream %q: %w", rc.Name, err)
 		}
+
+		// Apply the DCR-resolved ClientSecret to the built OAuth2Config.
+		// The split between applyResolution (run-config fields) and
+		// applyResolutionToOAuth2Config (inline-only ClientSecret) is
+		// documented in dcr.go — both calls must be paired to produce a
+		// fully-resolved DCR client.
+		if dcrResolution != nil && cfg.OAuth2Config != nil {
+			applyResolutionToOAuth2Config(cfg.OAuth2Config, dcrResolution)
+		}
+
 		configs = append(configs, *cfg)
 	}
 

--- a/pkg/authserver/runner/embeddedauthserver_test.go
+++ b/pkg/authserver/runner/embeddedauthserver_test.go
@@ -9,12 +9,15 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/x509"
+	"encoding/json"
 	"encoding/pem"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -25,6 +28,7 @@ import (
 	servercrypto "github.com/stacklok/toolhive/pkg/authserver/server/crypto"
 	"github.com/stacklok/toolhive/pkg/authserver/server/keys"
 	"github.com/stacklok/toolhive/pkg/authserver/storage"
+	"github.com/stacklok/toolhive/pkg/oauthproto"
 )
 
 func TestCreateKeyProvider(t *testing.T) {
@@ -1358,4 +1362,269 @@ func TestRegisterHandlers(t *testing.T) {
 		assert.Equal(t, http.StatusNotFound, rec.Code,
 			"expected 404 for unregistered root path")
 	})
+}
+
+// newMockAuthorizationServer stands up a mock authorization server that
+// serves RFC 8414 discovery metadata and an RFC 7591 /register endpoint.
+// Every request is counted via the returned *int32 so tests can assert that
+// cache hits issue zero additional network I/O. The issuer advertised in
+// metadata is the server's own URL (loopback), which satisfies the HTTPS
+// redirect-URI policy in resolveUpstreamRedirectURI.
+func newMockAuthorizationServer(t *testing.T) (*httptest.Server, *int32) {
+	t.Helper()
+
+	var total int32
+	var server *httptest.Server
+
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/.well-known/oauth-authorization-server", func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&total, 1)
+		md := oauthproto.AuthorizationServerMetadata{
+			Issuer:                            server.URL,
+			AuthorizationEndpoint:             server.URL + "/authorize",
+			TokenEndpoint:                     server.URL + "/token",
+			RegistrationEndpoint:              server.URL + "/register",
+			TokenEndpointAuthMethodsSupported: []string{"client_secret_basic"},
+			ScopesSupported:                   []string{"openid", "profile"},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(md)
+	})
+
+	mux.HandleFunc("/register", func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&total, 1)
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		_ = r.Body.Close()
+		var req oauthproto.DynamicClientRegistrationRequest
+		if err := json.Unmarshal(body, &req); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		resp := oauthproto.DynamicClientRegistrationResponse{
+			ClientID:                "dcr-client-id",
+			ClientSecret:            "dcr-client-secret",
+			RegistrationAccessToken: "dcr-reg-token",
+			TokenEndpointAuthMethod: req.TokenEndpointAuthMethod,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(resp)
+	})
+
+	// Catch-all to count unexpected requests.
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&total, 1)
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	server = httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	return server, &total
+}
+
+// TestBuildUpstreamConfigs_DCR verifies the end-to-end DCR wiring inside
+// buildUpstreamConfigs: on first call it registers with the mock AS and
+// overlays the resolved client_id/client_secret; on second call it hits the
+// in-memory store and issues zero additional HTTP requests; and neither call
+// mutates the caller's original RunConfig.Upstreams slice.
+func TestBuildUpstreamConfigs_DCR(t *testing.T) {
+	t.Parallel()
+
+	t.Run("DCR boot registers and overlays credentials", func(t *testing.T) {
+		t.Parallel()
+
+		server, requestCount := newMockAuthorizationServer(t)
+
+		cfg := &authserver.RunConfig{
+			SchemaVersion: authserver.CurrentSchemaVersion,
+			Issuer:        server.URL,
+			Upstreams: []authserver.UpstreamRunConfig{
+				{
+					Name: "dcr-upstream",
+					Type: authserver.UpstreamProviderTypeOAuth2,
+					OAuth2Config: &authserver.OAuth2UpstreamRunConfig{
+						// ClientID intentionally empty: triggers DCR.
+						ClientID:              "",
+						AuthorizationEndpoint: server.URL + "/authorize",
+						TokenEndpoint:         server.URL + "/token",
+						Scopes:                []string{"openid", "profile"},
+						DCRConfig: &authserver.DCRUpstreamConfig{
+							DiscoveryURL: server.URL + "/.well-known/oauth-authorization-server",
+						},
+					},
+				},
+			},
+			AllowedAudiences: []string{"https://mcp.example.com"},
+		}
+
+		store := NewInMemoryDCRCredentialStore()
+		got, err := buildUpstreamConfigs(context.Background(), cfg.Upstreams, cfg.Issuer, store)
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+
+		// DCR-resolved credentials appear on the built OAuth2Config.
+		require.NotNil(t, got[0].OAuth2Config)
+		assert.Equal(t, "dcr-client-id", got[0].OAuth2Config.ClientID)
+		assert.Equal(t, "dcr-client-secret", got[0].OAuth2Config.ClientSecret)
+
+		// Store now contains the resolution under the canonical DCRKey.
+		redirectURI := server.URL + "/oauth/callback"
+		key := DCRKey{
+			Issuer:      server.URL,
+			RedirectURI: redirectURI,
+			ScopesHash:  scopesHash([]string{"openid", "profile"}),
+		}
+		cached, ok, err := store.Get(context.Background(), key)
+		require.NoError(t, err)
+		require.True(t, ok, "store should contain the DCR resolution keyed by DCRKey")
+		assert.Equal(t, "dcr-client-id", cached.ClientID)
+
+		// First call must have hit the mock AS at least once (metadata +
+		// register). The exact count depends on well-known path fallbacks,
+		// but it must be strictly greater than zero.
+		assert.Greater(t, atomic.LoadInt32(requestCount), int32(0),
+			"DCR boot should have issued network I/O to the mock AS")
+
+		// Copy-before-mutate: the caller's original slice element is
+		// unchanged — ClientID is still empty; DCRConfig is still set.
+		assert.Equal(t, "", cfg.Upstreams[0].OAuth2Config.ClientID,
+			"original OAuth2Config.ClientID must not be mutated by DCR resolution")
+		assert.NotNil(t, cfg.Upstreams[0].OAuth2Config.DCRConfig,
+			"original OAuth2Config.DCRConfig must not be cleared by DCR resolution")
+	})
+
+	t.Run("cache hit on second call issues zero additional HTTP requests", func(t *testing.T) {
+		t.Parallel()
+
+		server, requestCount := newMockAuthorizationServer(t)
+
+		cfg := &authserver.RunConfig{
+			SchemaVersion: authserver.CurrentSchemaVersion,
+			Issuer:        server.URL,
+			Upstreams: []authserver.UpstreamRunConfig{
+				{
+					Name: "dcr-upstream",
+					Type: authserver.UpstreamProviderTypeOAuth2,
+					OAuth2Config: &authserver.OAuth2UpstreamRunConfig{
+						ClientID:              "",
+						AuthorizationEndpoint: server.URL + "/authorize",
+						TokenEndpoint:         server.URL + "/token",
+						Scopes:                []string{"openid", "profile"},
+						DCRConfig: &authserver.DCRUpstreamConfig{
+							DiscoveryURL: server.URL + "/.well-known/oauth-authorization-server",
+						},
+					},
+				},
+			},
+			AllowedAudiences: []string{"https://mcp.example.com"},
+		}
+
+		store := NewInMemoryDCRCredentialStore()
+
+		// First call: populates the store.
+		_, err := buildUpstreamConfigs(context.Background(), cfg.Upstreams, cfg.Issuer, store)
+		require.NoError(t, err)
+		firstCallRequests := atomic.LoadInt32(requestCount)
+		require.Greater(t, firstCallRequests, int32(0),
+			"first call should have issued network I/O")
+
+		// Second call: must short-circuit on the cache and issue zero
+		// additional HTTP requests against the mock AS.
+		got, err := buildUpstreamConfigs(context.Background(), cfg.Upstreams, cfg.Issuer, store)
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		assert.Equal(t, "dcr-client-id", got[0].OAuth2Config.ClientID)
+		assert.Equal(t, "dcr-client-secret", got[0].OAuth2Config.ClientSecret)
+
+		assert.Equal(t, firstCallRequests, atomic.LoadInt32(requestCount),
+			"second call must not issue any additional HTTP requests to the mock AS")
+
+		// Copy-before-mutate still holds after both calls.
+		assert.Equal(t, "", cfg.Upstreams[0].OAuth2Config.ClientID,
+			"original OAuth2Config.ClientID must remain empty after both calls")
+		assert.NotNil(t, cfg.Upstreams[0].OAuth2Config.DCRConfig,
+			"original OAuth2Config.DCRConfig must remain set after both calls")
+	})
+}
+
+// TestNewEmbeddedAuthServer_DCRBoot drives the full NewEmbeddedAuthServer
+// boot path against a mock upstream AS: signing keys are generated
+// ephemerally, storage defaults to memory, and the DCR resolver runs
+// inside the constructor. It verifies that (a) the constructor plumbs a
+// dcrStore onto EmbeddedAuthServer, (b) that store is populated with the
+// canonical DCRKey after boot, and (c) the caller's original
+// RunConfig.Upstreams[i] slice element is unchanged.
+//
+// This complements TestBuildUpstreamConfigs_DCR by exercising the full
+// wiring — signing-key creation, HMAC secret defaults, storage
+// instantiation, authserver.New() — rather than the internal helper in
+// isolation.
+func TestNewEmbeddedAuthServer_DCRBoot(t *testing.T) {
+	t.Parallel()
+
+	server, requestCount := newMockAuthorizationServer(t)
+
+	cfg := &authserver.RunConfig{
+		SchemaVersion: authserver.CurrentSchemaVersion,
+		Issuer:        server.URL,
+		Upstreams: []authserver.UpstreamRunConfig{
+			{
+				Name: "dcr-upstream",
+				Type: authserver.UpstreamProviderTypeOAuth2,
+				OAuth2Config: &authserver.OAuth2UpstreamRunConfig{
+					ClientID:              "",
+					AuthorizationEndpoint: server.URL + "/authorize",
+					TokenEndpoint:         server.URL + "/token",
+					Scopes:                []string{"openid", "profile"},
+					DCRConfig: &authserver.DCRUpstreamConfig{
+						DiscoveryURL: server.URL + "/.well-known/oauth-authorization-server",
+					},
+				},
+			},
+		},
+		AllowedAudiences: []string{"https://mcp.example.com"},
+	}
+
+	// Retain a pointer to the caller's OAuth2Config to verify that the
+	// constructor did not mutate it via the shared pointer.
+	originalOAuth2 := cfg.Upstreams[0].OAuth2Config
+
+	embed, err := NewEmbeddedAuthServer(context.Background(), cfg)
+	require.NoError(t, err)
+	require.NotNil(t, embed)
+	t.Cleanup(func() { _ = embed.Close() })
+
+	// The constructor must have populated a non-nil dcrStore.
+	require.NotNil(t, embed.dcrStore, "NewEmbeddedAuthServer must initialise a dcrStore")
+
+	// The DCR registration must have hit the mock AS at least once.
+	assert.Greater(t, atomic.LoadInt32(requestCount), int32(0),
+		"DCR boot should have issued network I/O to the mock AS")
+
+	// The store on the EmbeddedAuthServer contains the canonical DCRKey
+	// for this upstream — no separate in-memory store was created.
+	redirectURI := server.URL + "/oauth/callback"
+	key := DCRKey{
+		Issuer:      server.URL,
+		RedirectURI: redirectURI,
+		ScopesHash:  scopesHash([]string{"openid", "profile"}),
+	}
+	cached, ok, err := embed.dcrStore.Get(context.Background(), key)
+	require.NoError(t, err)
+	require.True(t, ok, "dcrStore on EmbeddedAuthServer must hold the DCR resolution")
+	assert.Equal(t, "dcr-client-id", cached.ClientID)
+	assert.Equal(t, "dcr-client-secret", cached.ClientSecret)
+
+	// Copy-before-mutate: the caller's OAuth2Config pointer is unchanged.
+	assert.Equal(t, "", originalOAuth2.ClientID,
+		"NewEmbeddedAuthServer must not mutate the caller's OAuth2Config.ClientID")
+	assert.NotNil(t, originalOAuth2.DCRConfig,
+		"NewEmbeddedAuthServer must not clear the caller's OAuth2Config.DCRConfig")
+	assert.Same(t, originalOAuth2, cfg.Upstreams[0].OAuth2Config,
+		"NewEmbeddedAuthServer must not replace the caller's OAuth2Config pointer")
 }

--- a/pkg/authserver/server/handlers/authorize_test.go
+++ b/pkg/authserver/server/handlers/authorize_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/stacklok/toolhive/pkg/authserver/server"
 	servercrypto "github.com/stacklok/toolhive/pkg/authserver/server/crypto"
 )
 
@@ -164,6 +165,24 @@ func TestNewHandler_ErrorsOnEmptyUpstreams(t *testing.T) {
 
 	_, err = NewHandler(nil, nil, nil, []NamedUpstream{})
 	require.Error(t, err, "NewHandler should error when upstreams is empty slice")
+}
+
+// TestNewHandler_ErrorsOnNilConfig pins the constructor invariant that a
+// nil AuthorizationServerConfig (or one with a nil embedded *fosite.Config)
+// is rejected at construction time. Without this guard, issuer() (and any
+// other helper that reads config.Config.*) panics inside an HTTP handler
+// at request time — far harder to diagnose than a startup error.
+func TestNewHandler_ErrorsOnNilConfig(t *testing.T) {
+	t.Parallel()
+
+	upstreams := []NamedUpstream{{Name: "x", Provider: nil}}
+
+	_, err := NewHandler(nil, nil, nil, upstreams)
+	require.Error(t, err, "NewHandler should error when AuthorizationServerConfig is nil")
+
+	_, err = NewHandler(nil, &server.AuthorizationServerConfig{}, nil, upstreams)
+	require.Error(t, err,
+		"NewHandler should error when AuthorizationServerConfig.Config is nil")
 }
 
 func TestAuthorizeHandler_RedirectsToUpstream(t *testing.T) {

--- a/pkg/authserver/server/handlers/dcr.go
+++ b/pkg/authserver/server/handlers/dcr.go
@@ -95,12 +95,14 @@ func (h *Handler) RegisterClientHandler(w http.ResponseWriter, req *http.Request
 		return
 	}
 
-	// INFO-level: one success record per DCR registration is useful audit
-	// signal and low enough cardinality to keep at INFO. client_id,
-	// software_id, token_endpoint_auth_method, and scopes are public client
-	// metadata per RFC 7591 and not credentials.
+	// Successful DCR registration is a normal operational event, not a
+	// long-running operation, so it logs at Debug to stay silent at INFO+.
+	// client_id, software_id, token_endpoint_auth_method, and scopes are
+	// public client metadata per RFC 7591 and not credentials. If audit
+	// signal is desired in future, the right home is a dedicated audit-
+	// log emission path rather than promoting this record to INFO.
 	//
-	// Note: the "issuer" attribute here identifies the THIS server (the
+	// Note: the "issuer" attribute here identifies THIS server (the
 	// ToolHive-embedded AS that is performing the registration), not the
 	// upstream AS being registered against. That distinction is important
 	// when correlating these logs with the resolver's logs in
@@ -118,7 +120,7 @@ func (h *Handler) RegisterClientHandler(w http.ResponseWriter, req *http.Request
 		logAttrs = append(logAttrs, "issuer", issuer)
 	}
 	//nolint:gosec // G706: client_id is public metadata per RFC 7591.
-	slog.Info("registered new DCR client", logAttrs...)
+	slog.Debug("registered new DCR client", logAttrs...)
 
 	// Build response per RFC 7591 Section 3.2.1.
 	// Scope reflects the scopes actually granted to this client (from

--- a/pkg/authserver/server/handlers/dcr.go
+++ b/pkg/authserver/server/handlers/dcr.go
@@ -95,10 +95,30 @@ func (h *Handler) RegisterClientHandler(w http.ResponseWriter, req *http.Request
 		return
 	}
 
-	slog.Debug("registered new DCR client",
+	// INFO-level: one success record per DCR registration is useful audit
+	// signal and low enough cardinality to keep at INFO. client_id,
+	// software_id, token_endpoint_auth_method, and scopes are public client
+	// metadata per RFC 7591 and not credentials.
+	//
+	// Note: the "issuer" attribute here identifies the THIS server (the
+	// ToolHive-embedded AS that is performing the registration), not the
+	// upstream AS being registered against. That distinction is important
+	// when correlating these logs with the resolver's logs in
+	// pkg/authserver/runner/dcr.go, which use "issuer" to mean the
+	// upstream AS. The two uses live at opposite ends of the DCR flow.
+	// No "upstream" attribute is emitted because the /oauth/register
+	// endpoint has no upstream concept.
+	logAttrs := []any{
 		"client_id", clientID,
-		"client_name", validated.ClientName,
-	)
+		"software_id", validated.SoftwareID,
+		"token_endpoint_auth_method", validated.TokenEndpointAuthMethod,
+		"scopes", scopes,
+	}
+	if issuer := h.issuer(); issuer != "" {
+		logAttrs = append(logAttrs, "issuer", issuer)
+	}
+	//nolint:gosec // G706: client_id is public metadata per RFC 7591.
+	slog.Info("registered new DCR client", logAttrs...)
 
 	// Build response per RFC 7591 Section 3.2.1.
 	// Scope reflects the scopes actually granted to this client (from

--- a/pkg/authserver/server/handlers/dcr_test.go
+++ b/pkg/authserver/server/handlers/dcr_test.go
@@ -82,6 +82,7 @@ func TestRegisterClientHandler(t *testing.T) {
 			stor := mocks.NewMockStorage(ctrl)
 			stor.EXPECT().RegisterClient(gomock.Any(), gomock.Any()).Return(tc.storageErr).AnyTimes()
 			cfg := &server.AuthorizationServerConfig{
+				Config:          &fosite.Config{AccessTokenIssuer: "https://test-authserver"},
 				ScopesSupported: registration.DefaultScopes,
 			}
 			handler := &Handler{storage: stor, config: cfg}
@@ -131,6 +132,7 @@ func TestRegisterClientHandler_ScopeInResponse(t *testing.T) {
 	handler := &Handler{
 		storage: stor,
 		config: &server.AuthorizationServerConfig{
+			Config:          &fosite.Config{AccessTokenIssuer: "https://test-authserver"},
 			ScopesSupported: registration.DefaultScopes,
 		},
 	}
@@ -167,6 +169,7 @@ func TestRegisterClientHandler_ClientIsStored(t *testing.T) {
 
 	allowedAudiences := []string{"https://mcp.example.com"}
 	cfg := &server.AuthorizationServerConfig{
+		Config:           &fosite.Config{AccessTokenIssuer: "https://test-authserver"},
 		ScopesSupported:  registration.DefaultScopes,
 		AllowedAudiences: allowedAudiences,
 	}

--- a/pkg/authserver/server/handlers/handler.go
+++ b/pkg/authserver/server/handlers/handler.go
@@ -136,3 +136,17 @@ func (h *Handler) upstreamByName(name string) (upstream.OAuth2Provider, bool) {
 	}
 	return nil, false
 }
+
+// issuer returns the authorization-server issuer URL. Both h.config and
+// the embedded *fosite.Config are required to be non-nil — NewHandler does
+// not exercise this path (no separate constructor validation for the
+// embedded Config), but every handler that calls issuer() reaches it only
+// after the handler has been fully wired via a working
+// AuthorizationServerConfig. Tests that exercise issuer()-emitting
+// handlers must therefore supply a valid *fosite.Config (even if its
+// fields are zero-valued). Returning a silent default on a nil config
+// would hide real wiring bugs — see .claude/rules/go-style.md
+// §"Constructor Validation: Fail Loudly on Invalid Input".
+func (h *Handler) issuer() string {
+	return h.config.AccessTokenIssuer
+}

--- a/pkg/authserver/server/handlers/handler.go
+++ b/pkg/authserver/server/handlers/handler.go
@@ -47,13 +47,20 @@ type Handler struct {
 // upstreams defines the ordered sequence of upstream providers consulted
 // during multi-upstream authorization flows (e.g., sequential token acquisition).
 //
-// Returns an error if upstreams is empty or if any entry has an empty name or nil provider.
+// Returns an error if config is nil, if config's embedded *fosite.Config is
+// nil, if upstreams is empty, or if any entry has an empty name or nil
+// provider. Catching misconfiguration here is far easier to diagnose than
+// a nil-deref panic deep inside an HTTP handler at request time.
 func NewHandler(
 	provider fosite.OAuth2Provider,
 	config *server.AuthorizationServerConfig,
 	stor storage.Storage,
 	upstreams []NamedUpstream,
 ) (*Handler, error) {
+	if config == nil || config.Config == nil {
+		return nil, fmt.Errorf(
+			"handlers: AuthorizationServerConfig with embedded *fosite.Config must be non-nil")
+	}
 	if len(upstreams) == 0 {
 		return nil, fmt.Errorf("handlers: upstreams must not be empty")
 	}
@@ -137,16 +144,9 @@ func (h *Handler) upstreamByName(name string) (upstream.OAuth2Provider, bool) {
 	return nil, false
 }
 
-// issuer returns the authorization-server issuer URL. Both h.config and
-// the embedded *fosite.Config are required to be non-nil — NewHandler does
-// not exercise this path (no separate constructor validation for the
-// embedded Config), but every handler that calls issuer() reaches it only
-// after the handler has been fully wired via a working
-// AuthorizationServerConfig. Tests that exercise issuer()-emitting
-// handlers must therefore supply a valid *fosite.Config (even if its
-// fields are zero-valued). Returning a silent default on a nil config
-// would hide real wiring bugs — see .claude/rules/go-style.md
-// §"Constructor Validation: Fail Loudly on Invalid Input".
+// issuer returns the authorization-server issuer URL. NewHandler enforces
+// that h.config and h.config.Config are non-nil, so this method does not
+// re-validate.
 func (h *Handler) issuer() string {
 	return h.config.AccessTokenIssuer
 }

--- a/pkg/authserver/server/handlers/handler_chain_test.go
+++ b/pkg/authserver/server/handlers/handler_chain_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ory/fosite"
 	"github.com/ory/fosite/compose"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -148,4 +149,38 @@ func TestNextMissingUpstream_StorageError(t *testing.T) {
 	assert.ErrorContains(t, err, "failed to check upstream token state")
 	assert.ErrorIs(t, err, storageErr)
 	assert.Empty(t, got)
+}
+
+func TestHandler_issuer(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		config   *server.AuthorizationServerConfig
+		expected string
+	}{
+		{
+			name: "returns configured AccessTokenIssuer",
+			config: &server.AuthorizationServerConfig{
+				Config: &fosite.Config{AccessTokenIssuer: "https://as.example.com"},
+			},
+			expected: "https://as.example.com",
+		},
+		{
+			name: "returns empty string when AccessTokenIssuer is unset",
+			config: &server.AuthorizationServerConfig{
+				Config: &fosite.Config{},
+			},
+			expected: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := &Handler{config: tc.config}
+			assert.Equal(t, tc.expected, h.issuer())
+		})
+	}
 }

--- a/pkg/authserver/server/registration/dcr.go
+++ b/pkg/authserver/server/registration/dcr.go
@@ -42,6 +42,12 @@ const (
 
 	// MaxClientNameLength is the maximum allowed length for a client name.
 	MaxClientNameLength = 256
+
+	// MaxSoftwareIDLength is the maximum allowed length for a software_id
+	// value. RFC 7591 does not mandate an upper bound, so we reuse the
+	// client_name cap for consistency — a software_id is a similar-purpose
+	// human-oriented identifier and the same ballpark DoS concerns apply.
+	MaxSoftwareIDLength = 256
 )
 
 // DCRRequest represents an OAuth 2.0 Dynamic Client Registration request
@@ -70,6 +76,15 @@ type DCRRequest struct {
 	// If not specified, defaults to the server's default scopes.
 	// All requested scopes must be supported by the server.
 	Scope string `json:"scope,omitempty"`
+
+	// SoftwareID is the RFC 7591 "software_id" — a unique identifier for the
+	// client software. Captured from the incoming registration request for
+	// observability (audit logs surfaced on the successful-registration
+	// Info log); not persisted as part of the registered client, so it
+	// cannot be correlated with subsequent token requests. Bounded by
+	// MaxSoftwareIDLength and restricted to printable ASCII by
+	// ValidateDCRRequest.
+	SoftwareID string `json:"software_id,omitempty"`
 }
 
 // DCRResponse represents a successful OAuth 2.0 Dynamic Client Registration
@@ -164,6 +179,15 @@ func ValidateDCRRequest(req *DCRRequest) (*DCRRequest, *DCRError) {
 		}
 	}
 
+	// 4a. Validate software_id: length cap + printable-ASCII charset.
+	// RFC 7591 does not mandate an upper bound or a character class for
+	// software_id, but since we capture the value in audit logs we want a
+	// predictable shape and a hard cap against DoS — a caller sending
+	// multi-MB strings would slip past only the 64 KiB body cap otherwise.
+	if dcrErr := validateSoftwareID(req.SoftwareID); dcrErr != nil {
+		return nil, dcrErr
+	}
+
 	// 5. Validate/default token_endpoint_auth_method
 	authMethod := req.TokenEndpointAuthMethod
 	if authMethod == "" {
@@ -195,7 +219,36 @@ func ValidateDCRRequest(req *DCRRequest) (*DCRRequest, *DCRError) {
 		TokenEndpointAuthMethod: authMethod,
 		GrantTypes:              grantTypes,
 		ResponseTypes:           responseTypes,
+		SoftwareID:              req.SoftwareID,
 	}, nil
+}
+
+// validateSoftwareID enforces the length cap and printable-ASCII charset
+// for a DCR request's software_id. An empty value is accepted (the field
+// is optional per RFC 7591).
+func validateSoftwareID(softwareID string) *DCRError {
+	if softwareID == "" {
+		return nil
+	}
+	if len(softwareID) > MaxSoftwareIDLength {
+		return &DCRError{
+			Error:            DCRErrorInvalidClientMetadata,
+			ErrorDescription: "software_id too long (maximum 256 characters)",
+		}
+	}
+	// Allow printable ASCII (0x20..0x7E) only. Control characters and
+	// non-ASCII input are rejected: we log this value and want a
+	// predictable on-disk representation regardless of handler choice.
+	for i := 0; i < len(softwareID); i++ {
+		c := softwareID[i]
+		if c < 0x20 || c > 0x7E {
+			return &DCRError{
+				Error:            DCRErrorInvalidClientMetadata,
+				ErrorDescription: "software_id must contain only printable ASCII characters",
+			}
+		}
+	}
+	return nil
 }
 
 func validateGrantTypes(grantTypes []string) ([]string, *DCRError) {

--- a/pkg/authserver/server/registration/dcr_test.go
+++ b/pkg/authserver/server/registration/dcr_test.go
@@ -419,6 +419,59 @@ func TestValidateDCRRequest(t *testing.T) {
 			},
 			expectError: false,
 		},
+
+		// software_id length cap and charset enforcement
+		{
+			name: "software_id at max length is accepted",
+			request: &DCRRequest{
+				RedirectURIs: []string{"http://127.0.0.1/callback"},
+				SoftwareID:   strings.Repeat("a", MaxSoftwareIDLength),
+			},
+			expectError: false,
+		},
+		{
+			name: "software_id exceeding max length is rejected",
+			request: &DCRRequest{
+				RedirectURIs: []string{"http://127.0.0.1/callback"},
+				SoftwareID:   strings.Repeat("a", MaxSoftwareIDLength+1),
+			},
+			expectError: true,
+			errorCode:   DCRErrorInvalidClientMetadata,
+		},
+		{
+			name: "software_id with control character is rejected",
+			request: &DCRRequest{
+				RedirectURIs: []string{"http://127.0.0.1/callback"},
+				SoftwareID:   "bad\x00id",
+			},
+			expectError: true,
+			errorCode:   DCRErrorInvalidClientMetadata,
+		},
+		{
+			name: "software_id with non-ASCII character is rejected",
+			request: &DCRRequest{
+				RedirectURIs: []string{"http://127.0.0.1/callback"},
+				SoftwareID:   "softwäre",
+			},
+			expectError: true,
+			errorCode:   DCRErrorInvalidClientMetadata,
+		},
+		{
+			name: "empty software_id is accepted (field is optional)",
+			request: &DCRRequest{
+				RedirectURIs: []string{"http://127.0.0.1/callback"},
+				SoftwareID:   "",
+			},
+			expectError: false,
+		},
+		{
+			name: "printable-ASCII software_id is accepted",
+			request: &DCRRequest{
+				RedirectURIs: []string{"http://127.0.0.1/callback"},
+				SoftwareID:   "example-app-v1.2.3",
+			},
+			expectError: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -451,6 +504,9 @@ func TestValidateDCRRequest(t *testing.T) {
 
 				// Verify client_name is preserved
 				assert.Equal(t, tt.request.ClientName, result.ClientName)
+
+				// Verify software_id is preserved
+				assert.Equal(t, tt.request.SoftwareID, result.SoftwareID)
 			}
 		})
 	}

--- a/pkg/oauthproto/dcr.go
+++ b/pkg/oauthproto/dcr.go
@@ -303,8 +303,13 @@ func handleHTTPResponse(resp *http.Response) (*DynamicClientRegistrationResponse
 
 	// Check response status
 	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
-		// Try to read error response
-		errorBody, _ := io.ReadAll(resp.Body)
+		// Cap the upstream's error body so a misbehaving or malicious AS
+		// cannot inflate operator logs by echoing arbitrary content. 8 KiB
+		// is far larger than any conformant RFC 7591 error response and
+		// still small enough that the surrounding error chain stays
+		// readable.
+		const maxErrorBodySize = 8 * 1024
+		errorBody, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodySize))
 
 		// Detect if DCR is not supported by the provider.
 		// Common HTTP status codes when DCR is unsupported:

--- a/pkg/oauthproto/dcr.go
+++ b/pkg/oauthproto/dcr.go
@@ -310,6 +310,10 @@ func handleHTTPResponse(resp *http.Response) (*DynamicClientRegistrationResponse
 		// readable.
 		const maxErrorBodySize = 8 * 1024
 		errorBody, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodySize))
+		// Drain whatever exceeded the cap so net/http can reuse the TCP
+		// connection — without this the deferred Close terminates the
+		// connection mid-stream when the upstream returned more than 8 KiB.
+		_, _ = io.Copy(io.Discard, resp.Body)
 
 		// Detect if DCR is not supported by the provider.
 		// Common HTTP status codes when DCR is unsupported:

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -407,11 +407,11 @@ func (r *Runner) Run(ctx context.Context) error {
 			// remediation warning emitted by isTransientNetworkError on a
 			// permanent 4xx (indicating a stale RFC 7591 registration)
 			// carries enough context for an operator to identify which
-			// upstream AS + client_id to re-register. The cached DCR
-			// client_id wins over any statically configured ClientID,
-			// matching the precedence used by resolveClientCredentials in
-			// pkg/auth/remote.
-			upstream, clientID := remoteAuthLogContext(r.Config.RemoteAuthConfig)
+			// upstream AS + client_id to re-register. Precedence (cached
+			// CIMD > cached DCR > static) lives next to
+			// resolveClientCredentials in pkg/auth/remote so both call
+			// sites stay in sync.
+			upstream, clientID := r.Config.RemoteAuthConfig.LogContext()
 
 			r.authenticatedTokenSource = auth.NewMonitoredTokenSource(
 				r.monitoringCtx,
@@ -799,28 +799,6 @@ func (r *Runner) handleRemoteAuthentication(ctx context.Context) (oauth2.TokenSo
 	}
 
 	return tokenSource, nil
-}
-
-// remoteAuthLogContext extracts the upstream issuer and resolved client_id
-// from a remote auth config for use as log-correlation fields on the
-// MonitoredTokenSource. Returns ("", "") when cfg is nil so callers do not
-// need to guard the call. Mirrors the precedence applied at runtime when
-// sending the client_id on token refresh: cached CIMD URL > cached DCR
-// client_id > statically configured client_id.
-func remoteAuthLogContext(cfg *remote.Config) (upstream, clientID string) {
-	if cfg == nil {
-		return "", ""
-	}
-	clientID = func() string {
-		if cfg.CachedCIMDClientID != "" {
-			return cfg.CachedCIMDClientID
-		}
-		if cfg.CachedClientID != "" {
-			return cfg.CachedClientID
-		}
-		return cfg.ClientID
-	}()
-	return cfg.Issuer, clientID
 }
 
 // Cleanup performs cleanup operations for the runner, including shutting down all middleware.

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -804,20 +804,23 @@ func (r *Runner) handleRemoteAuthentication(ctx context.Context) (oauth2.TokenSo
 // remoteAuthLogContext extracts the upstream issuer and resolved client_id
 // from a remote auth config for use as log-correlation fields on the
 // MonitoredTokenSource. Returns ("", "") when cfg is nil so callers do not
-// need to guard the call. DCR-cached credentials win over statically
-// configured ones, mirroring the precedence used by
-// remote.Handler.resolveClientCredentials at runtime.
+// need to guard the call. Mirrors the precedence applied at runtime when
+// sending the client_id on token refresh: cached CIMD URL > cached DCR
+// client_id > statically configured client_id.
 func remoteAuthLogContext(cfg *remote.Config) (upstream, clientID string) {
 	if cfg == nil {
 		return "", ""
 	}
-	upstream = cfg.Issuer
-	if cfg.CachedClientID != "" {
-		clientID = cfg.CachedClientID
-	} else {
-		clientID = cfg.ClientID
-	}
-	return upstream, clientID
+	clientID = func() string {
+		if cfg.CachedCIMDClientID != "" {
+			return cfg.CachedCIMDClientID
+		}
+		if cfg.CachedClientID != "" {
+			return cfg.CachedClientID
+		}
+		return cfg.ClientID
+	}()
+	return cfg.Issuer, clientID
 }
 
 // Cleanup performs cleanup operations for the runner, including shutting down all middleware.

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -402,7 +402,25 @@ func (r *Runner) Run(ctx context.Context) error {
 			r.monitoringCtx, r.monitoringCancel = context.WithCancel(ctx)
 			// Create adapter to bridge statuses.StatusManager to auth.StatusUpdater
 			adapter := &statusManagerAdapter{sm: r.statusManager}
-			r.authenticatedTokenSource = auth.NewMonitoredTokenSource(r.monitoringCtx, tokenSource, r.Config.BaseName, adapter)
+
+			// Capture the upstream issuer and resolved client_id so the DCR
+			// remediation warning emitted by isTransientNetworkError on a
+			// permanent 4xx (indicating a stale RFC 7591 registration)
+			// carries enough context for an operator to identify which
+			// upstream AS + client_id to re-register. The cached DCR
+			// client_id wins over any statically configured ClientID,
+			// matching the precedence used by resolveClientCredentials in
+			// pkg/auth/remote.
+			upstream, clientID := remoteAuthLogContext(r.Config.RemoteAuthConfig)
+
+			r.authenticatedTokenSource = auth.NewMonitoredTokenSource(
+				r.monitoringCtx,
+				tokenSource,
+				r.Config.BaseName,
+				upstream,
+				clientID,
+				adapter,
+			)
 			tokenSource = r.authenticatedTokenSource
 			r.authenticatedTokenSource.StartBackgroundMonitoring()
 		}
@@ -781,6 +799,25 @@ func (r *Runner) handleRemoteAuthentication(ctx context.Context) (oauth2.TokenSo
 	}
 
 	return tokenSource, nil
+}
+
+// remoteAuthLogContext extracts the upstream issuer and resolved client_id
+// from a remote auth config for use as log-correlation fields on the
+// MonitoredTokenSource. Returns ("", "") when cfg is nil so callers do not
+// need to guard the call. DCR-cached credentials win over statically
+// configured ones, mirroring the precedence used by
+// remote.Handler.resolveClientCredentials at runtime.
+func remoteAuthLogContext(cfg *remote.Config) (upstream, clientID string) {
+	if cfg == nil {
+		return "", ""
+	}
+	upstream = cfg.Issuer
+	if cfg.CachedClientID != "" {
+		clientID = cfg.CachedClientID
+	} else {
+		clientID = cfg.ClientID
+	}
+	return upstream, clientID
 }
 
 // Cleanup performs cleanup operations for the runner, including shutting down all middleware.

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
-	"github.com/stacklok/toolhive/pkg/auth/remote"
 	"github.com/stacklok/toolhive/pkg/auth/upstreamtoken"
 	"github.com/stacklok/toolhive/pkg/authserver"
 	authserverrunner "github.com/stacklok/toolhive/pkg/authserver/runner"
@@ -537,77 +536,4 @@ func TestRunner_GetUpstreamTokenReader(t *testing.T) {
 		assert.NotNil(t, reader)
 		assert.Equal(t, svc, reader)
 	})
-}
-
-func TestRemoteAuthLogContext(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name         string
-		cfg          *remote.Config
-		wantUpstream string
-		wantClientID string
-	}{
-		{
-			name:         "nil config returns empty strings",
-			cfg:          nil,
-			wantUpstream: "",
-			wantClientID: "",
-		},
-		{
-			name: "static client_id when no cache",
-			cfg: &remote.Config{
-				Issuer:   "https://idp.example.com",
-				ClientID: "static-client-id",
-			},
-			wantUpstream: "https://idp.example.com",
-			wantClientID: "static-client-id",
-		},
-		{
-			name: "cached DCR client_id wins over static",
-			cfg: &remote.Config{
-				Issuer:         "https://idp.example.com",
-				ClientID:       "static-client-id",
-				CachedClientID: "dcr-client-id",
-			},
-			wantUpstream: "https://idp.example.com",
-			wantClientID: "dcr-client-id",
-		},
-		{
-			name: "cached CIMD client_id wins over DCR and static",
-			cfg: &remote.Config{
-				Issuer:             "https://idp.example.com",
-				ClientID:           "static-client-id",
-				CachedClientID:     "dcr-client-id",
-				CachedCIMDClientID: "https://idp.example.com/cimd",
-			},
-			wantUpstream: "https://idp.example.com",
-			wantClientID: "https://idp.example.com/cimd",
-		},
-		{
-			name: "cached CIMD client_id used when no DCR or static",
-			cfg: &remote.Config{
-				Issuer:             "https://idp.example.com",
-				CachedCIMDClientID: "https://idp.example.com/cimd",
-			},
-			wantUpstream: "https://idp.example.com",
-			wantClientID: "https://idp.example.com/cimd",
-		},
-		{
-			name:         "empty config returns empty fields",
-			cfg:          &remote.Config{},
-			wantUpstream: "",
-			wantClientID: "",
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			upstream, clientID := remoteAuthLogContext(tc.cfg)
-			assert.Equal(t, tc.wantUpstream, upstream)
-			assert.Equal(t, tc.wantClientID, clientID)
-		})
-	}
 }

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -574,6 +574,26 @@ func TestRemoteAuthLogContext(t *testing.T) {
 			wantClientID: "dcr-client-id",
 		},
 		{
+			name: "cached CIMD client_id wins over DCR and static",
+			cfg: &remote.Config{
+				Issuer:             "https://idp.example.com",
+				ClientID:           "static-client-id",
+				CachedClientID:     "dcr-client-id",
+				CachedCIMDClientID: "https://idp.example.com/cimd",
+			},
+			wantUpstream: "https://idp.example.com",
+			wantClientID: "https://idp.example.com/cimd",
+		},
+		{
+			name: "cached CIMD client_id used when no DCR or static",
+			cfg: &remote.Config{
+				Issuer:             "https://idp.example.com",
+				CachedCIMDClientID: "https://idp.example.com/cimd",
+			},
+			wantUpstream: "https://idp.example.com",
+			wantClientID: "https://idp.example.com/cimd",
+		},
+		{
 			name:         "empty config returns empty fields",
 			cfg:          &remote.Config{},
 			wantUpstream: "",

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	"github.com/stacklok/toolhive/pkg/auth/remote"
 	"github.com/stacklok/toolhive/pkg/auth/upstreamtoken"
 	"github.com/stacklok/toolhive/pkg/authserver"
 	authserverrunner "github.com/stacklok/toolhive/pkg/authserver/runner"
@@ -536,4 +537,57 @@ func TestRunner_GetUpstreamTokenReader(t *testing.T) {
 		assert.NotNil(t, reader)
 		assert.Equal(t, svc, reader)
 	})
+}
+
+func TestRemoteAuthLogContext(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		cfg          *remote.Config
+		wantUpstream string
+		wantClientID string
+	}{
+		{
+			name:         "nil config returns empty strings",
+			cfg:          nil,
+			wantUpstream: "",
+			wantClientID: "",
+		},
+		{
+			name: "static client_id when no cache",
+			cfg: &remote.Config{
+				Issuer:   "https://idp.example.com",
+				ClientID: "static-client-id",
+			},
+			wantUpstream: "https://idp.example.com",
+			wantClientID: "static-client-id",
+		},
+		{
+			name: "cached DCR client_id wins over static",
+			cfg: &remote.Config{
+				Issuer:         "https://idp.example.com",
+				ClientID:       "static-client-id",
+				CachedClientID: "dcr-client-id",
+			},
+			wantUpstream: "https://idp.example.com",
+			wantClientID: "dcr-client-id",
+		},
+		{
+			name:         "empty config returns empty fields",
+			cfg:          &remote.Config{},
+			wantUpstream: "",
+			wantClientID: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			upstream, clientID := remoteAuthLogContext(tc.cfg)
+			assert.Equal(t, tc.wantUpstream, upstream)
+			assert.Equal(t, tc.wantClientID, clientID)
+		})
+	}
 }


### PR DESCRIPTION
## Summary

<!--
Phase 2 of the DCR story (#4978) needs the resolver from the prior sub-issue
to actually run during authserver boot, and every DCR code path needs enough
structured logging that operators can diagnose cache staleness and
revocation without reading the source.
-->

- **Why**: `resolveDCRCredentials` was wired up and unit-tested in the prior sub-issue, but `EmbeddedAuthServer` never called it, so any upstream configured with `DCRConfig` still booted without a client. This PR makes the resolver load-bearing and adds the operator-visible structured logs the Phase 2 spec calls for (cache-hit age, stale-registration warning, per-step errors, and a remediation hint when an upstream rejects a cached client as 4xx).
- **What**:
  - `EmbeddedAuthServer` now owns an in-memory `DCRCredentialStore` and calls `resolveDCRCredentials` + `consumeResolution` for every OAuth2 upstream whose config requests DCR. `buildPureOAuth2Config` deliberately keeps its pure, network-free signature; the DCR-resolved `ClientSecret` is layered on afterwards via a new `applyResolutionToOAuth2Config` helper so the two application sites stay side-by-side.
  - Each upstream `RunConfig` element is shallow-copied and its OAuth2 sub-config is deep-copied before mutation, preserving the caller's `RunConfig.Upstreams` slice.
  - `resolveDCRCredentials` returns a new `dcrStepError` wrapping the originating step (metadata discovery, DCR call, store read, store write) instead of logging-and-returning at each branch. The boundary caller (`buildUpstreamConfigs`) emits one `slog.Error` via `logDCRStepError`, so there is a single error line per failure. A panic inside the singleflight closure is converted to the same `dcrStepError` carrying the captured `debug.Stack()`, so the boundary log surfaces it without an in-defer duplicate.
  - Cache-hit path emits `slog.Debug` with `dcr_age_days` and additionally `slog.Warn` with remediation text when the cached registration exceeds the 90-day `dcrStaleAgeThreshold`.
  - The `/oauth/register` handler success log emits at `Debug` with `issuer`, `client_id`, `software_id`, `token_endpoint_auth_method`, and `scopes` — silent at INFO+ per the project's logging convention. `SoftwareID` is threaded through `ValidateDCRRequest`, which now also caps it to 256 printable-ASCII characters.
  - `MonitoredTokenSource` accepts `upstream` and `client_id` at construction (replacing the earlier `SetUpstreamContext` setter, which had an unsynchronized writer). On the first transition to `Unauthenticated` driven by a permanent token-endpoint 4xx, it emits a single `slog.Warn` with a DCR/CIMD remediation hint (gated by `stopOnce` so a tight `Token()` loop cannot spam it, and suppressed when no `client_id` context is available). The classifier itself (`isTransientNetworkError`) is side-effect free.
  - `NewHandler` now fails loudly when `AuthorizationServerConfig` or its embedded `*fosite.Config` is nil; `issuer()` no longer carries a runtime nil-guard.
  - Error strings are run through a sanitizer that strips URL **userinfo, query, and fragment** components before logging. The regex matches `http(s)://` case-insensitively per RFC 3986 §3.1, and trailing sentence punctuation around a URL is preserved so prose is not mangled.
  - `pkg/oauthproto/dcr.go` `handleHTTPResponse` caps the upstream `/register` error body at 8 KiB via `io.LimitReader` so a non-conformant or malicious upstream cannot inflate operator log volume.

Closes #5039

## Type of change

- [x] New feature

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)

New coverage added:

- `pkg/authserver/runner/embeddedauthserver_test.go` — full DCR boot against a mock AS (metadata + `/register`), cache-hit short-circuit (zero additional HTTP requests on the second `buildUpstreamConfigs`), copy-before-mutate assertion on the caller's `RunConfig.Upstreams` slice, and `TestNewEmbeddedAuthServer_DCRBoot` driving the real constructor to assert `dcrStore` is populated.
- `pkg/authserver/runner/dcr_test.go` — cache-hit Debug log with `dcr_age_days`, stale-age Warn above threshold, one `dcrStepError`-returning case per failure step, and the panic-recovery test now asserts the wrapped error is a `*dcrStepError(dcrStepRegister, …, Stack: <captured>)`.
- `pkg/authserver/server/handlers/handler_chain_test.go` — `TestHandler_issuer` covers both populated and zero-value `AccessTokenIssuer`. `TestNewHandler_ErrorsOnNilConfig` (in `authorize_test.go`) pins the new constructor invariant.
- `pkg/authserver/server/registration/dcr_test.go` — `software_id` length cap and non-printable-ASCII rejection.
- `pkg/auth/monitored_token_source_test.go` — permanent-4xx branch emits the remediation Warn with `workload`/`upstream`/`client_id` populated via the new constructor parameters.
- `pkg/runner/runner_test.go` — `TestRemoteAuthLogContext` covers the full `cached CIMD > cached DCR > static` precedence.
- Sanitizer unit tests cover commas, periods, closing parens, mixed runs, a Go `http.Client`-style quoted URL, embedded `user:pass@host` userinfo (with and without query), implicit-flow `#access_token=…` fragments, and uppercase `HTTPS://` schemes.

## Changes

| File | Change |
|------|--------|
| `pkg/authserver/runner/embeddedauthserver.go` | Add `dcrStore` field and wire resolver into `buildUpstreamConfigs`; introduce `applyResolutionToOAuth2Config`; document the per-instance store vs. process-wide singleflight asymmetry. |
| `pkg/authserver/runner/dcr.go` | Introduce `dcrStepError` / `logDCRStepError`; emit cache-hit Debug, stale-age Warn, and per-step error context; carry panic stack on the wrapped error so a single boundary record surfaces it; URL-secret-stripping sanitizer (userinfo + query + fragment, case-insensitive scheme match). |
| `pkg/authserver/runner/dcr_store.go` | Inline doc rationale (no path citations) for resource-leak, copy-before-mutate, and constructor-validation reasoning. |
| `pkg/authserver/server/handlers/dcr.go` | DCR success log emits at `Debug`, drop redundant `upstream` attribute, thread `software_id` through. |
| `pkg/authserver/server/handlers/handler.go` | `NewHandler` validates `config` and `config.Config`; remove the runtime nil-guard from `issuer()`. |
| `pkg/authserver/server/registration/dcr.go` | Cap `software_id` to 256 printable-ASCII characters; export `MaxSoftwareIDLength`. |
| `pkg/auth/monitored_token_source.go` | Accept `upstream`/`client_id` as constructor parameters; emit DCR/CIMD remediation Warn from `markAsUnauthenticated` (once per state transition, gated by `stopOnce`, suppressed when `clientID == ""`). The classifier is side-effect free. |
| `pkg/runner/runner.go` | Populate new `MonitoredTokenSource` fields from `RemoteAuthConfig` with `cached CIMD > cached DCR > static` precedence (mirrors `remote.Handler.resolveClientCredentials`). |
| `pkg/oauthproto/dcr.go` | Cap the upstream `/register` error body at 8 KiB via `io.LimitReader` before embedding it in the returned error string. |
| `pkg/authserver/runner/embeddedauthserver_test.go` | DCR boot, cache-hit, and copy-before-mutate integration tests. |
| `pkg/authserver/runner/dcr_test.go` | Log and per-step error tests, sanitizer userinfo/fragment/uppercase cases, augmented panic-recovery assertions. |
| `pkg/authserver/server/handlers/handler_chain_test.go`, `authorize_test.go` | `TestHandler_issuer` and `TestNewHandler_ErrorsOnNilConfig`. |
| `pkg/authserver/server/handlers/dcr_test.go`, `pkg/authserver/server/registration/dcr_test.go` | Assertions for new log fields and `software_id` validation. |
| `pkg/auth/monitored_token_source_test.go`, `pkg/runner/runner_test.go` | New constructor plumbing, remediation Warn, and the CIMD-wins precedence case (closes review finding F26). |

## Large PR Justification

The PR exceeds the 400-LOC / 10-file guideline (1342+/104- across 18 files), but the change cannot be split without leaving the codebase in an intermediate non-functional state:

- ~660 lines are tests (`*_test.go`) — table-driven coverage for the resolver wiring, the new error taxonomy, the staleness + remediation logs, and the sanitizer.
- The remaining ~510 production lines across 9 files implement one logical change (wire the resolver into the auth-server boot path) plus four tightly-coupled sub-concerns: resolver wiring, `dcrStepError` taxonomy + boundary logging, monitored-token-source remediation log, and `software_id` validation. Splitting the resolver wiring without the matching error taxonomy would land a regression in observability; splitting the error taxonomy without the wiring would orphan the new types.

## Does this introduce a user-facing change?

Operators gain two new diagnostic signals on DCR-enabled upstreams:

1. A `Warn` when a cached DCR registration is older than 90 days, hinting that the operator may want to rotate.
2. A `Warn` on the first transition to `Unauthenticated` driven by a permanent token-endpoint 4xx, hinting that the workload's cached DCR or CIMD credentials may be stale and that deleting them and restarting will trigger re-registration. The Warn fires at most once per state transition and is suppressed entirely for workloads with no `client_id` context.

The `MonitoredTokenSource` constructor signature has changed to require `upstream` and `client_id`, but it is an internal API with no public surface, and the prior `SetUpstreamContext` setter is removed.

Successful DCR registrations log at `Debug`, not `Info`, in keeping with the project's silent-success-at-INFO+ convention.

## Special notes for reviewers

- The purity gate on `buildPureOAuth2Config` is load-bearing: it takes no `context.Context` and performs no network I/O. DCR resolution is deliberately sequenced *around* it, not inside it, so the pure config builder stays trivially testable. Please flag any future change that threads `ctx` into it.
- `dcrStepError` moves the "one error line per failure" invariant from the resolver to the boundary caller. If a future caller forgets to invoke `logDCRStepError`, the error will still propagate normally but the structured log will be missing. Worth keeping in mind if we add more resolver call sites.
- `consumeResolution` (formerly `applyResolution`) is a one-shot state transition, not an idempotent default-fill: a second call after the first is a no-op only because the first cleared `DCRConfig`. The companion `applyResolutionToOAuth2Config` writes the inline-only `ClientSecret` onto the built `*upstream.OAuth2Config`; any future output path from `OAuth2UpstreamRunConfig` to `upstream.OAuth2Config` must call **both** helpers to get a fully-resolved DCR client.
- The package-level `dcrFlight` singleflight is intentionally process-wide while `EmbeddedAuthServer.dcrStore` is per-instance — see the doc comments on each. The asymmetry is load-bearing for concurrent `EmbeddedAuthServer` instances in the same process.

Generated with [Claude Code](https://claude.com/claude-code)
