### PR TITLE
pkg/llm: fix withPreemptiveRefresh composition and stale _AT on rotation

### DIFF
--- a/pkg/auth/oauth/non_caching_refresher.go
+++ b/pkg/auth/oauth/non_caching_refresher.go
@@ -1,0 +1,131 @@
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package oauth
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/oauth2"
+)
+
+// NonCachingRefresher is an oauth2.TokenSource that always performs a network
+// refresh when Token() is called — it holds no internal token cache.
+//
+// This is the correct innermost source for a preemptive-refresh chain:
+// the outer oauth2.ReuseTokenSource provides caching; the inner source must
+// always refresh when asked so that one network round-trip occurs per
+// preemptive window instead of looping indefinitely.
+//
+// It handles both standard OAuth 2.0 refresh (resource == "") and RFC 8707
+// resource-indicator refresh (resource != "") in a single type.
+//
+// Token() is safe for concurrent use. mu serializes access to refreshToken,
+// which is updated in place when the IdP rotates it.
+//
+// When the IdP omits a new refresh token the previous token is preserved so
+// the session survives providers that do not rotate on every refresh.
+type NonCachingRefresher struct {
+	mu           sync.Mutex
+	cfg          *oauth2.Config
+	resource     string // RFC 8707 resource indicator; empty for standard OAuth 2.0
+	refreshToken string
+	httpClient   *http.Client
+}
+
+// NewNonCachingRefresher creates a NonCachingRefresher that refreshes using
+// cfg and the given refresh token. resource is the RFC 8707 resource indicator;
+// pass "" for standard OAuth 2.0 refresh.
+func NewNonCachingRefresher(cfg *oauth2.Config, refreshToken, resource string) *NonCachingRefresher {
+	return &NonCachingRefresher{
+		cfg:          cfg,
+		resource:     resource,
+		refreshToken: refreshToken,
+		httpClient:   &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+// Token always performs a token-endpoint refresh. It updates the stored refresh
+// token when the IdP rotates it so callers (e.g. PersistingTokenSource) can
+// detect the change and persist it.
+func (n *NonCachingRefresher) Token() (*oauth2.Token, error) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	if n.refreshToken == "" {
+		return nil, fmt.Errorf("no refresh token available")
+	}
+
+	ctx := context.WithValue(context.Background(), oauth2.HTTPClient, n.httpClient)
+
+	var (
+		tok *oauth2.Token
+		err error
+	)
+	if n.resource != "" {
+		tok, err = n.refreshWithResource(ctx)
+	} else {
+		tok, err = n.refreshStandard(ctx)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	if tok.RefreshToken == "" {
+		tok.RefreshToken = n.refreshToken
+	} else {
+		n.refreshToken = tok.RefreshToken
+	}
+
+	slog.Debug("Token refreshed", "resource", n.resource)
+	return tok, nil
+}
+
+// refreshStandard uses the library's native tokenRefresher path, which sends
+// grant_type=refresh_token without the empty code= parameter that Exchange
+// always appends. A fresh TokenSource is constructed on each call so there is
+// no internal cache. Scopes are not sent explicitly; servers must preserve them
+// per RFC 6749 §6 (MUST).
+func (n *NonCachingRefresher) refreshStandard(ctx context.Context) (*oauth2.Token, error) {
+	// Passing an always-expired token forces the ReuseTokenSource returned by
+	// cfg.TokenSource to call the inner tokenRefresher immediately.
+	ts := n.cfg.TokenSource(ctx, &oauth2.Token{
+		RefreshToken: n.refreshToken,
+		Expiry:       time.Unix(1, 0),
+	})
+	tok, err := ts.Token()
+	if err != nil {
+		return nil, fmt.Errorf("token refresh failed: %w", err)
+	}
+	return tok, nil
+}
+
+// refreshWithResource uses cfg.Exchange with overridden grant_type and
+// refresh_token parameters to send the RFC 8707 resource= indicator.
+// golang.org/x/oauth2 has no native support for resource indicators, so the
+// Exchange workaround is unavoidable here. The side-effect empty code=
+// parameter from Exchange is acceptable: resource-indicator IdPs are required
+// to dispatch on grant_type first and typically tolerate extra parameters.
+// Scopes are sent explicitly because some resource-indicator IdPs do not
+// preserve them when omitted despite the RFC 6749 §6 MUST requirement.
+func (n *NonCachingRefresher) refreshWithResource(ctx context.Context) (*oauth2.Token, error) {
+	opts := []oauth2.AuthCodeOption{
+		oauth2.SetAuthURLParam("grant_type", "refresh_token"),
+		oauth2.SetAuthURLParam("refresh_token", n.refreshToken),
+		oauth2.SetAuthURLParam("resource", n.resource),
+	}
+	if len(n.cfg.Scopes) > 0 {
+		opts = append(opts, oauth2.SetAuthURLParam("scope", strings.Join(n.cfg.Scopes, " ")))
+	}
+	tok, err := n.cfg.Exchange(ctx, "", opts...)
+	if err != nil {
+		return nil, fmt.Errorf("token refresh failed: %w", err)
+	}
+	return tok, nil
+}

--- a/pkg/auth/oauth/resource_token_source.go
+++ b/pkg/auth/oauth/resource_token_source.go
@@ -4,24 +4,16 @@
 package oauth
 
 import (
-	"context"
-	"fmt"
-	"log/slog"
-	"net/http"
-	"strings"
-	"time"
-
 	"golang.org/x/oauth2"
 )
 
-// resourceTokenSource wraps an oauth2.TokenSource and adds the resource parameter
-// to token refresh requests per RFC 8707. This is necessary because the standard
-// golang.org/x/oauth2 library doesn't support adding custom parameters during refresh.
+// resourceTokenSource wraps a NonCachingRefresher with an internal token cache
+// and adds the resource parameter to token refresh requests per RFC 8707.
+// Token() returns the cached token when still valid and delegates to the
+// inner NonCachingRefresher only when a refresh is needed.
 type resourceTokenSource struct {
-	config     *oauth2.Config
-	resource   string
-	token      *oauth2.Token
-	httpClient *http.Client
+	ncr   *NonCachingRefresher
+	token *oauth2.Token
 }
 
 // NewResourceTokenSource creates a token source that includes the resource parameter
@@ -29,75 +21,24 @@ type resourceTokenSource struct {
 // The resource parameter must be non-empty (caller should check before calling).
 func NewResourceTokenSource(config *oauth2.Config, token *oauth2.Token, resource string) oauth2.TokenSource {
 	return &resourceTokenSource{
-		config:   config,
-		resource: resource,
-		token:    token,
-		httpClient: &http.Client{
-			Timeout: 30 * time.Second,
-		},
+		ncr:   NewNonCachingRefresher(config, token.RefreshToken, resource),
+		token: token,
 	}
 }
 
 // Token returns a valid token, refreshing it if necessary.
-// When refreshing, it adds the resource parameter to the request.
+// When refreshing, it delegates to NonCachingRefresher which adds the resource
+// parameter per RFC 8707.
 func (r *resourceTokenSource) Token() (*oauth2.Token, error) {
-	// If token is still valid, return it
 	if r.token.Valid() {
 		return r.token, nil
 	}
 
-	// Token expired, refresh with resource parameter
-	ctx := context.Background()
-	newToken, err := r.refreshWithResource(ctx)
+	newToken, err := r.ncr.Token()
 	if err != nil {
 		return nil, err
 	}
 
 	r.token = newToken
 	return newToken, nil
-}
-
-// refreshWithResource performs token refresh with the resource parameter per RFC 8707.
-func (r *resourceTokenSource) refreshWithResource(ctx context.Context) (*oauth2.Token, error) {
-	if r.token == nil || r.token.RefreshToken == "" {
-		return nil, fmt.Errorf("no refresh token available")
-	}
-
-	// Use x/oauth2 internals via Exchange() so we get:
-	// - expires_in -> Expiry handling
-	// - AuthStyle from the Config's Endpoint (AuthStyleInParams)
-	// - structured error parsing via oauth2.RetrieveError
-	//
-	// Note: Exchange() will include an empty "code" parameter in the body.
-	// This is a known workaround for adding custom refresh params.
-	refreshToken := r.token.RefreshToken
-	opts := []oauth2.AuthCodeOption{
-		oauth2.SetAuthURLParam("grant_type", "refresh_token"),
-		oauth2.SetAuthURLParam("refresh_token", refreshToken),
-		oauth2.SetAuthURLParam("resource", r.resource),
-	}
-
-	// Include scope in refresh request. RFC 6749 section 6 says servers MUST
-	// preserve scopes when omitted, but not all do. Being explicit is safe.
-	if len(r.config.Scopes) > 0 {
-		opts = append(opts, oauth2.SetAuthURLParam("scope", strings.Join(r.config.Scopes, " ")))
-	}
-
-	ctx = context.WithValue(ctx, oauth2.HTTPClient, r.httpClient)
-
-	token, err := r.config.Exchange(ctx, "", opts...)
-	if err != nil {
-		return nil, fmt.Errorf("token refresh with resource parameter failed: %w", err)
-	}
-
-	// Preserve refresh token if the server does not return a new one.
-	if token.RefreshToken == "" {
-		token.RefreshToken = refreshToken
-	}
-
-	slog.Debug("Token refreshed with resource parameter",
-		"resource", r.resource,
-	)
-
-	return token, nil
 }

--- a/pkg/auth/oauth/resource_token_source_test.go
+++ b/pkg/auth/oauth/resource_token_source_test.go
@@ -52,13 +52,12 @@ func TestNewResourceTokenSource(t *testing.T) {
 		ts := NewResourceTokenSource(config, validToken, "https://api.example.com")
 		require.NotNil(t, ts)
 
-		// Should be our custom type
 		rts, ok := ts.(*resourceTokenSource)
 		require.True(t, ok, "expected resourceTokenSource type")
-		assert.Equal(t, "https://api.example.com", rts.resource)
-		assert.Equal(t, config, rts.config)
-		assert.NotNil(t, rts.httpClient)
-		assert.Equal(t, 30*time.Second, rts.httpClient.Timeout)
+		assert.Equal(t, "https://api.example.com", rts.ncr.resource)
+		assert.Equal(t, config, rts.ncr.cfg)
+		assert.NotNil(t, rts.ncr.httpClient)
+		assert.Equal(t, 30*time.Second, rts.ncr.httpClient.Timeout)
 	})
 
 	t.Run("stores token reference", func(t *testing.T) {
@@ -300,7 +299,7 @@ func TestResourceTokenSource_RefreshErrors(t *testing.T) {
 		ts := NewResourceTokenSource(config, expiredToken, "https://api.example.com")
 		_, err := ts.Token()
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "token refresh with resource parameter failed")
+		assert.Contains(t, err.Error(), "token refresh failed")
 	})
 
 	t.Run("returns error on invalid JSON response", func(t *testing.T) {
@@ -328,7 +327,7 @@ func TestResourceTokenSource_RefreshErrors(t *testing.T) {
 		ts := NewResourceTokenSource(config, expiredToken, "https://api.example.com")
 		_, err := ts.Token()
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "token refresh with resource parameter failed")
+		assert.Contains(t, err.Error(), "token refresh failed")
 	})
 
 	t.Run("returns error when token endpoint is unreachable", func(t *testing.T) {
@@ -350,7 +349,7 @@ func TestResourceTokenSource_RefreshErrors(t *testing.T) {
 		ts := NewResourceTokenSource(config, expiredToken, "https://api.example.com")
 		_, err := ts.Token()
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "token refresh with resource parameter failed")
+		assert.Contains(t, err.Error(), "token refresh failed")
 	})
 
 	t.Run("returns error on non-200 status codes", func(t *testing.T) {
@@ -391,7 +390,7 @@ func TestResourceTokenSource_RefreshErrors(t *testing.T) {
 				ts := NewResourceTokenSource(config, expiredToken, "https://api.example.com")
 				_, err := ts.Token()
 				require.Error(t, err)
-				assert.Contains(t, err.Error(), "token refresh with resource parameter failed")
+				assert.Contains(t, err.Error(), "token refresh failed")
 			})
 		}
 	})
@@ -434,15 +433,15 @@ func TestResourceTokenSource_HTTPClientReuse(t *testing.T) {
 		rts := ts.(*resourceTokenSource)
 
 		// Verify HTTP client is created
-		require.NotNil(t, rts.httpClient)
-		client1 := rts.httpClient
+		require.NotNil(t, rts.ncr.httpClient)
+		client1 := rts.ncr.httpClient
 
 		// First refresh
 		_, err := ts.Token()
 		require.NoError(t, err)
 
 		// Verify same client instance
-		assert.Same(t, client1, rts.httpClient, "HTTP client should be reused")
+		assert.Same(t, client1, rts.ncr.httpClient, "HTTP client should be reused")
 		assert.Equal(t, 1, callCount)
 	})
 
@@ -465,7 +464,7 @@ func TestResourceTokenSource_HTTPClientReuse(t *testing.T) {
 		ts := NewResourceTokenSource(config, token, "https://api.example.com")
 		rts := ts.(*resourceTokenSource)
 
-		assert.Equal(t, 30*time.Second, rts.httpClient.Timeout)
+		assert.Equal(t, 30*time.Second, rts.ncr.httpClient.Timeout)
 	})
 }
 

--- a/pkg/llm/tokensource.go
+++ b/pkg/llm/tokensource.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"strings"
 	"sync"
 	"time"
@@ -191,24 +192,24 @@ func (t *TokenSource) tryRestoreFromCache(ctx context.Context) error {
 		return fmt.Errorf("building oauth2 config for cache restore: %w", err)
 	}
 
-	// Build the raw refresher directly without an inner ReuseTokenSource.
-	// CreateTokenSourceFromCached wraps in ReuseTokenSource, which causes the
-	// preemptive window to loop: the inner source returns the cached real token,
-	// preemptiveTokenSource shifts it back, the outer ReuseTokenSource caches an
-	// already-expired shifted token, and every subsequent Token() call re-enters
-	// the inner chain instead of one refresh per window.
-	// Target stacking: ReuseTokenSource(nil, preemptive{PersistingTokenSource{rawRefresher}})
-	rawToken := &oauth2.Token{
-		RefreshToken: refreshToken,
-		Expiry:       t.cfg.OIDC.CachedTokenExpiry,
-		TokenType:    "Bearer",
-	}
-	var rawRefresher oauth2.TokenSource
-	if t.cfg.OIDC.Audience != "" {
-		rawRefresher = oauth.NewResourceTokenSource(oauth2Cfg, rawToken, t.cfg.OIDC.Audience)
-	} else {
-		rawRefresher = oauth2Cfg.TokenSource(ctx, rawToken)
-	}
+	// Use a non-caching refresher as the innermost source.
+	//
+	// oauth.NewResourceTokenSource and oauth2Cfg.TokenSource both cache the token
+	// internally and only refresh when the real expiry passes. When the outer
+	// ReuseTokenSource enters the preemptive window (30 s before real expiry) it
+	// calls preemptiveTokenSource, which calls the inner source; the inner source
+	// sees the real token as still valid and returns it unchanged;
+	// preemptiveTokenSource shifts the expiry back by 30 s, producing an
+	// already-expired token; the outer ReuseTokenSource then re-enters the chain
+	// on every subsequent call — an infinite non-refreshing loop.
+	//
+	// A non-caching refresher always performs a network round-trip when called, so
+	// the first call inside the preemptive window obtains a fresh token with a
+	// real-future expiry. The outer ReuseTokenSource caches the shifted result and
+	// serves it until the next window — exactly one refresh per window.
+	//
+	// Target stacking: ReuseTokenSource(nil, preemptive{PersistingTokenSource{nonCachingRefresher}})
+	rawRefresher := newNonCachingRefresher(oauth2Cfg, refreshToken, t.cfg.OIDC.Audience)
 
 	// Persist rotated refresh tokens back to the secrets provider so future CLI
 	// invocations can still restore the session if the provider invalidates the
@@ -239,10 +240,9 @@ func (t *TokenSource) performBrowserFlow(ctx context.Context) error {
 		return fmt.Errorf("OAuth flow start failed: %w", err)
 	}
 
-	// Build raw token source from flowCfg fields directly instead of calling
-	// flow.TokenSource(), which returns a ReuseTokenSource and causes the same
-	// double-caching composition issue as CreateTokenSourceFromCached (see
-	// tryRestoreFromCache for a detailed explanation).
+	// Build a non-caching refresher as the innermost source (see tryRestoreFromCache
+	// for a detailed explanation of why caching inner sources cause an infinite loop
+	// inside the preemptive window).
 	// Reuse the already-discovered flowCfg to avoid a second OIDC round-trip.
 	oauth2Cfg := oauth2ConfigFrom(flowCfg)
 	initialToken := &oauth2.Token{
@@ -251,12 +251,7 @@ func (t *TokenSource) performBrowserFlow(ctx context.Context) error {
 		Expiry:       tokenResult.Expiry,
 		TokenType:    tokenResult.TokenType,
 	}
-	var base oauth2.TokenSource
-	if flowCfg.Resource != "" {
-		base = oauth.NewResourceTokenSource(oauth2Cfg, initialToken, flowCfg.Resource)
-	} else {
-		base = oauth2Cfg.TokenSource(ctx, initialToken)
-	}
+	var base oauth2.TokenSource = newNonCachingRefresher(oauth2Cfg, initialToken.RefreshToken, flowCfg.Resource)
 	key := t.refreshTokenKey()
 
 	if t.secretsProvider != nil {
@@ -272,8 +267,9 @@ func (t *TokenSource) performBrowserFlow(ctx context.Context) error {
 		}
 	}
 
-	// Wrap with preemptive refresh so tokens are renewed 30 s before real expiry.
-	t.tokenSource = withPreemptiveRefresh(base)
+	// Pre-seed the outer ReuseTokenSource with the shifted initial token so the
+	// just-obtained access token is served without an immediate network round-trip.
+	t.tokenSource = withPreemptiveRefreshFrom(initialToken, base)
 	return nil
 }
 
@@ -332,7 +328,10 @@ func (t *TokenSource) makeTokenPersister(key string) remote.TokenPersister {
 		t.updateConfigTokenRef(key, expiry)
 		// Invalidate the access-token cache so the next call does not serve a
 		// token minted against the now-rotated refresh token.
-		_ = t.secretsProvider.SetSecret(ctx, t.accessTokenCacheKey(), "")
+		if err := t.secretsProvider.SetSecret(ctx, t.accessTokenCacheKey(), ""); err != nil {
+			slog.Warn("failed to invalidate access-token cache after refresh token rotation",
+				"error", err)
+		}
 		return nil
 	}
 }
@@ -451,7 +450,77 @@ func (p *preemptiveTokenSource) Token() (*oauth2.Token, error) {
 // before they actually expire, then re-wraps with ReuseTokenSource so the refresh
 // is only triggered once per window.
 func withPreemptiveRefresh(src oauth2.TokenSource) oauth2.TokenSource {
-	return oauth2.ReuseTokenSource(nil, &preemptiveTokenSource{inner: src})
+	return withPreemptiveRefreshFrom(nil, src)
+}
+
+// withPreemptiveRefreshFrom is like withPreemptiveRefresh but pre-seeds the outer
+// ReuseTokenSource with a shifted copy of initial (if non-nil and valid), so the
+// caller's already-obtained access token is served without an immediate network call.
+func withPreemptiveRefreshFrom(initial *oauth2.Token, src oauth2.TokenSource) oauth2.TokenSource {
+	var seeded *oauth2.Token
+	if initial != nil && initial.Valid() && !initial.Expiry.IsZero() {
+		shifted := *initial
+		shifted.Expiry = initial.Expiry.Add(-preemptiveRefreshWindow)
+		seeded = &shifted
+	}
+	return oauth2.ReuseTokenSource(seeded, &preemptiveTokenSource{inner: src})
+}
+
+// nonCachingRefresher is an oauth2.TokenSource that always performs a network
+// refresh when Token() is called — it holds no internal token cache. This makes it
+// the correct innermost source for withPreemptiveRefresh: the outer ReuseTokenSource
+// provides caching; the inner source must always refresh when asked so that
+// preemptiveTokenSource triggers exactly one network round-trip per window.
+//
+// It handles both standard OAuth 2.0 refresh (resource == "") and RFC 8707
+// resource-indicator refresh (resource != "") in a single type, eliminating the
+// branching that previously introduced caching inner sources on the resource path.
+type nonCachingRefresher struct {
+	cfg          *oauth2.Config
+	resource     string // RFC 8707 resource indicator; empty for standard OAuth 2.0
+	refreshToken string
+	httpClient   *http.Client
+}
+
+func newNonCachingRefresher(cfg *oauth2.Config, refreshToken, resource string) *nonCachingRefresher {
+	return &nonCachingRefresher{
+		cfg:          cfg,
+		resource:     resource,
+		refreshToken: refreshToken,
+		httpClient:   &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+// Token always performs a token-endpoint refresh. It updates the stored refresh
+// token when the IdP rotates it, so PersistingTokenSource above can detect the
+// change and persist it to the secrets provider.
+func (n *nonCachingRefresher) Token() (*oauth2.Token, error) {
+	if n.refreshToken == "" {
+		return nil, fmt.Errorf("no refresh token available")
+	}
+	ctx := context.WithValue(context.Background(), oauth2.HTTPClient, n.httpClient)
+	opts := []oauth2.AuthCodeOption{
+		oauth2.SetAuthURLParam("grant_type", "refresh_token"),
+		oauth2.SetAuthURLParam("refresh_token", n.refreshToken),
+	}
+	if n.resource != "" {
+		opts = append(opts, oauth2.SetAuthURLParam("resource", n.resource))
+	}
+	// Include scope explicitly — RFC 6749 §6 says servers MUST preserve scopes
+	// when omitted, but not all do.
+	if len(n.cfg.Scopes) > 0 {
+		opts = append(opts, oauth2.SetAuthURLParam("scope", strings.Join(n.cfg.Scopes, " ")))
+	}
+	tok, err := n.cfg.Exchange(ctx, "", opts...)
+	if err != nil {
+		return nil, fmt.Errorf("token refresh failed: %w", err)
+	}
+	if tok.RefreshToken == "" {
+		tok.RefreshToken = n.refreshToken
+	} else {
+		n.refreshToken = tok.RefreshToken
+	}
+	return tok, nil
 }
 
 // ensureOfflineAccess returns scopes with "offline_access" appended if absent.

--- a/pkg/llm/tokensource.go
+++ b/pkg/llm/tokensource.go
@@ -191,12 +191,29 @@ func (t *TokenSource) tryRestoreFromCache(ctx context.Context) error {
 		return fmt.Errorf("building oauth2 config for cache restore: %w", err)
 	}
 
-	base := remote.CreateTokenSourceFromCached(oauth2Cfg, refreshToken, t.cfg.OIDC.CachedTokenExpiry, t.cfg.OIDC.Audience)
+	// Build the raw refresher directly without an inner ReuseTokenSource.
+	// CreateTokenSourceFromCached wraps in ReuseTokenSource, which causes the
+	// preemptive window to loop: the inner source returns the cached real token,
+	// preemptiveTokenSource shifts it back, the outer ReuseTokenSource caches an
+	// already-expired shifted token, and every subsequent Token() call re-enters
+	// the inner chain instead of one refresh per window.
+	// Target stacking: ReuseTokenSource(nil, preemptive{PersistingTokenSource{rawRefresher}})
+	rawToken := &oauth2.Token{
+		RefreshToken: refreshToken,
+		Expiry:       t.cfg.OIDC.CachedTokenExpiry,
+		TokenType:    "Bearer",
+	}
+	var rawRefresher oauth2.TokenSource
+	if t.cfg.OIDC.Audience != "" {
+		rawRefresher = oauth.NewResourceTokenSource(oauth2Cfg, rawToken, t.cfg.OIDC.Audience)
+	} else {
+		rawRefresher = oauth2Cfg.TokenSource(ctx, rawToken)
+	}
 
 	// Persist rotated refresh tokens back to the secrets provider so future CLI
 	// invocations can still restore the session if the provider invalidates the
 	// old token on refresh (common with OIDC providers that rotate refresh tokens).
-	base = remote.NewPersistingTokenSource(base, t.makeTokenPersister(key))
+	base := remote.NewPersistingTokenSource(rawRefresher, t.makeTokenPersister(key))
 
 	// Wrap with preemptive refresh so tokens are renewed 30 s before real expiry
 	// on every subsequent refresh, not just the first restore.
@@ -222,7 +239,24 @@ func (t *TokenSource) performBrowserFlow(ctx context.Context) error {
 		return fmt.Errorf("OAuth flow start failed: %w", err)
 	}
 
-	base := flow.TokenSource()
+	// Build raw token source from flowCfg fields directly instead of calling
+	// flow.TokenSource(), which returns a ReuseTokenSource and causes the same
+	// double-caching composition issue as CreateTokenSourceFromCached (see
+	// tryRestoreFromCache for a detailed explanation).
+	// Reuse the already-discovered flowCfg to avoid a second OIDC round-trip.
+	oauth2Cfg := oauth2ConfigFrom(flowCfg)
+	initialToken := &oauth2.Token{
+		AccessToken:  tokenResult.AccessToken,
+		RefreshToken: tokenResult.RefreshToken,
+		Expiry:       tokenResult.Expiry,
+		TokenType:    tokenResult.TokenType,
+	}
+	var base oauth2.TokenSource
+	if flowCfg.Resource != "" {
+		base = oauth.NewResourceTokenSource(oauth2Cfg, initialToken, flowCfg.Resource)
+	} else {
+		base = oauth2Cfg.TokenSource(ctx, initialToken)
+	}
 	key := t.refreshTokenKey()
 
 	if t.secretsProvider != nil {
@@ -265,6 +299,13 @@ func (t *TokenSource) buildOAuth2Config(ctx context.Context) (*oauth2.Config, er
 	if err != nil {
 		return nil, err
 	}
+	return oauth2ConfigFrom(flowCfg), nil
+}
+
+// oauth2ConfigFrom converts an oauth.Config (from OIDC discovery) into the
+// minimal oauth2.Config used for headless token refresh. Callers that already
+// hold a *oauth.Config should use this to avoid a second OIDC discovery round-trip.
+func oauth2ConfigFrom(flowCfg *oauth.Config) *oauth2.Config {
 	return &oauth2.Config{
 		ClientID: flowCfg.ClientID,
 		Scopes:   flowCfg.Scopes,
@@ -273,11 +314,15 @@ func (t *TokenSource) buildOAuth2Config(ctx context.Context) (*oauth2.Config, er
 			TokenURL:  flowCfg.TokenURL,
 			AuthStyle: oauth2.AuthStyleInParams,
 		},
-	}, nil
+	}
 }
 
 // makeTokenPersister returns a remote.TokenPersister that stores the refresh
 // token in the secrets provider and updates the config expiry reference.
+// It also invalidates the access-token cache (_AT entry) so that the next
+// Token() call does not serve an access token minted against the now-rotated
+// refresh token. Without this, a concurrent process could read the stale _AT
+// entry between the SetSecret for the refresh token and the next Token() call.
 func (t *TokenSource) makeTokenPersister(key string) remote.TokenPersister {
 	return func(refreshToken string, expiry time.Time) error {
 		ctx := context.Background()
@@ -285,6 +330,9 @@ func (t *TokenSource) makeTokenPersister(key string) remote.TokenPersister {
 			return fmt.Errorf("persisting LLM gateway refresh token: %w", err)
 		}
 		t.updateConfigTokenRef(key, expiry)
+		// Invalidate the access-token cache so the next call does not serve a
+		// token minted against the now-rotated refresh token.
+		_ = t.secretsProvider.SetSecret(ctx, t.accessTokenCacheKey(), "")
 		return nil
 	}
 }

--- a/pkg/llm/tokensource.go
+++ b/pkg/llm/tokensource.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"net/http"
 	"strings"
 	"sync"
 	"time"
@@ -209,7 +208,7 @@ func (t *TokenSource) tryRestoreFromCache(ctx context.Context) error {
 	// serves it until the next window — exactly one refresh per window.
 	//
 	// Target stacking: ReuseTokenSource(nil, preemptive{PersistingTokenSource{nonCachingRefresher}})
-	rawRefresher := newNonCachingRefresher(oauth2Cfg, refreshToken, t.cfg.OIDC.Audience)
+	rawRefresher := oauth.NewNonCachingRefresher(oauth2Cfg, refreshToken, t.cfg.OIDC.Audience)
 
 	// Persist rotated refresh tokens back to the secrets provider so future CLI
 	// invocations can still restore the session if the provider invalidates the
@@ -251,7 +250,7 @@ func (t *TokenSource) performBrowserFlow(ctx context.Context) error {
 		Expiry:       tokenResult.Expiry,
 		TokenType:    tokenResult.TokenType,
 	}
-	var base oauth2.TokenSource = newNonCachingRefresher(oauth2Cfg, initialToken.RefreshToken, flowCfg.Resource)
+	var base oauth2.TokenSource = oauth.NewNonCachingRefresher(oauth2Cfg, initialToken.RefreshToken, flowCfg.Resource)
 	key := t.refreshTokenKey()
 
 	if t.secretsProvider != nil {
@@ -327,7 +326,14 @@ func (t *TokenSource) makeTokenPersister(key string) remote.TokenPersister {
 		}
 		t.updateConfigTokenRef(key, expiry)
 		// Invalidate the access-token cache so the next call does not serve a
-		// token minted against the now-rotated refresh token.
+		// token minted against the now-rotated refresh token. Order is intentional:
+		// the refresh token (durable) is written first, then the AT cache is cleared.
+		// A reader interleaved between the two writes sees the old AT for a short
+		// window, but will always eventually get a fresh token on the next call.
+		//
+		// We write "" rather than calling DeleteSecret for provider compatibility —
+		// some providers don't support deletion, and tryAccessTokenCache treats an
+		// empty value as a cache miss.
 		if err := t.secretsProvider.SetSecret(ctx, t.accessTokenCacheKey(), ""); err != nil {
 			slog.Warn("failed to invalidate access-token cache after refresh token rotation",
 				"error", err)
@@ -461,66 +467,14 @@ func withPreemptiveRefreshFrom(initial *oauth2.Token, src oauth2.TokenSource) oa
 	if initial != nil && initial.Valid() && !initial.Expiry.IsZero() {
 		shifted := *initial
 		shifted.Expiry = initial.Expiry.Add(-preemptiveRefreshWindow)
-		seeded = &shifted
+		// Only seed when the shifted expiry is still in the future; if the initial
+		// token lifetime is shorter than preemptiveRefreshWindow the shifted token
+		// is already expired and seeding would not avoid the immediate network call.
+		if shifted.Valid() {
+			seeded = &shifted
+		}
 	}
 	return oauth2.ReuseTokenSource(seeded, &preemptiveTokenSource{inner: src})
-}
-
-// nonCachingRefresher is an oauth2.TokenSource that always performs a network
-// refresh when Token() is called — it holds no internal token cache. This makes it
-// the correct innermost source for withPreemptiveRefresh: the outer ReuseTokenSource
-// provides caching; the inner source must always refresh when asked so that
-// preemptiveTokenSource triggers exactly one network round-trip per window.
-//
-// It handles both standard OAuth 2.0 refresh (resource == "") and RFC 8707
-// resource-indicator refresh (resource != "") in a single type, eliminating the
-// branching that previously introduced caching inner sources on the resource path.
-type nonCachingRefresher struct {
-	cfg          *oauth2.Config
-	resource     string // RFC 8707 resource indicator; empty for standard OAuth 2.0
-	refreshToken string
-	httpClient   *http.Client
-}
-
-func newNonCachingRefresher(cfg *oauth2.Config, refreshToken, resource string) *nonCachingRefresher {
-	return &nonCachingRefresher{
-		cfg:          cfg,
-		resource:     resource,
-		refreshToken: refreshToken,
-		httpClient:   &http.Client{Timeout: 30 * time.Second},
-	}
-}
-
-// Token always performs a token-endpoint refresh. It updates the stored refresh
-// token when the IdP rotates it, so PersistingTokenSource above can detect the
-// change and persist it to the secrets provider.
-func (n *nonCachingRefresher) Token() (*oauth2.Token, error) {
-	if n.refreshToken == "" {
-		return nil, fmt.Errorf("no refresh token available")
-	}
-	ctx := context.WithValue(context.Background(), oauth2.HTTPClient, n.httpClient)
-	opts := []oauth2.AuthCodeOption{
-		oauth2.SetAuthURLParam("grant_type", "refresh_token"),
-		oauth2.SetAuthURLParam("refresh_token", n.refreshToken),
-	}
-	if n.resource != "" {
-		opts = append(opts, oauth2.SetAuthURLParam("resource", n.resource))
-	}
-	// Include scope explicitly — RFC 6749 §6 says servers MUST preserve scopes
-	// when omitted, but not all do.
-	if len(n.cfg.Scopes) > 0 {
-		opts = append(opts, oauth2.SetAuthURLParam("scope", strings.Join(n.cfg.Scopes, " ")))
-	}
-	tok, err := n.cfg.Exchange(ctx, "", opts...)
-	if err != nil {
-		return nil, fmt.Errorf("token refresh failed: %w", err)
-	}
-	if tok.RefreshToken == "" {
-		tok.RefreshToken = n.refreshToken
-	} else {
-		n.refreshToken = tok.RefreshToken
-	}
-	return tok, nil
 }
 
 // ensureOfflineAccess returns scopes with "offline_access" appended if absent.

--- a/pkg/llm/tokensource_test.go
+++ b/pkg/llm/tokensource_test.go
@@ -362,12 +362,15 @@ func TestTokenSource_MakeTokenPersister_StoresTokenAndCallsUpdater(t *testing.T)
 
 	cfg := minimalConfig()
 	const secretKey = "LLM_OAUTH_test"
+	// Pin CachedRefreshTokenRef so refreshTokenKey() == secretKey.
+	// accessTokenCacheKey() is then secretKey+"_AT", which must be the key
+	// the persister invalidates — same root as the refresh token it just wrote.
+	cfg.OIDC.CachedRefreshTokenRef = secretKey
 	wantToken := "new-refresh-token"
 	wantExpiry := time.Now().Add(time.Hour)
 
 	// The persister must write the refresh token then invalidate the AT cache.
-	// accessTokenCacheKey is derived from the config, not from secretKey.
-	atKey := DeriveSecretKey(cfg.GatewayURL, cfg.OIDC.Issuer) + "_AT"
+	atKey := secretKey + "_AT"
 	gomock.InOrder(
 		mockSecrets.EXPECT().
 			SetSecret(gomock.Any(), secretKey, wantToken).
@@ -680,6 +683,130 @@ func TestWithPreemptiveRefresh_ExactlyOneRefreshPerWindow(t *testing.T) {
 		"inner source must be called exactly twice: once for the initial short-lived "+
 			"token and once for the preemptive refresh; all remaining calls must be "+
 			"served from the outer ReuseTokenSource cache")
+}
+
+// ── withPreemptiveRefreshFrom – pre-seeds outer cache with shifted initial token ──
+
+// TestWithPreemptiveRefreshFrom_PreSeededToken verifies that withPreemptiveRefreshFrom
+// serves the pre-seeded initial token without calling the inner source, and only
+// calls the inner source after the shifted expiry passes.
+func TestWithPreemptiveRefreshFrom_PreSeededToken(t *testing.T) {
+	t.Parallel()
+
+	fake := &countingTokenSource{
+		tokenFn: func(_ int) *oauth2.Token {
+			return &oauth2.Token{
+				AccessToken: "refreshed-token",
+				Expiry:      time.Now().Add(2 * time.Minute),
+			}
+		},
+	}
+
+	initial := &oauth2.Token{
+		AccessToken: "initial-token",
+		Expiry:      time.Now().Add(2 * time.Minute), // long-lived — shifted expiry is in the future
+	}
+
+	src := withPreemptiveRefreshFrom(initial, fake)
+
+	// All calls within the shifted window must return the pre-seeded token
+	// without touching the inner source.
+	const iterations = 5
+	for i := 0; i < iterations; i++ {
+		tok, err := src.Token()
+		require.NoError(t, err)
+		assert.Equal(t, "initial-token", tok.AccessToken,
+			"call %d: must return pre-seeded token without hitting inner source", i+1)
+	}
+	assert.Equal(t, 0, fake.calls, "inner source must not be called while initial token is valid")
+}
+
+func TestWithPreemptiveRefreshFrom_NilInitial_BehavesLikeWithPreemptiveRefresh(t *testing.T) {
+	t.Parallel()
+
+	fake := &countingTokenSource{
+		tokenFn: func(_ int) *oauth2.Token {
+			return &oauth2.Token{
+				AccessToken: "inner-token",
+				Expiry:      time.Now().Add(2 * time.Minute),
+			}
+		},
+	}
+
+	src := withPreemptiveRefreshFrom(nil, fake)
+
+	tok, err := src.Token()
+	require.NoError(t, err)
+	assert.Equal(t, "inner-token", tok.AccessToken)
+	assert.Equal(t, 1, fake.calls, "nil initial must trigger an inner call on first Token()")
+}
+
+// ── nonCachingRefresher – no-refresh-token guard ─────────────────────────────
+
+func TestNonCachingRefresher_EmptyRefreshToken_ReturnsError(t *testing.T) {
+	t.Parallel()
+
+	cfg := &oauth2.Config{ClientID: "test"}
+	ncr := newNonCachingRefresher(cfg, "" /* no refresh token */, "")
+
+	_, err := ncr.Token()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no refresh token available")
+}
+
+// TestWithPreemptiveRefresh_CachingInnerSource_LoopRegression is a regression
+// test for the bug where a caching inner source (one that returns the same valid
+// token every call) caused the outer ReuseTokenSource to loop indefinitely inside
+// the preemptive window.
+//
+// A caching source always returns the same token regardless of how many times
+// Token() is called. When preemptiveTokenSource shifts its expiry back by 30 s,
+// the outer ReuseTokenSource sees an already-expired token on the very next call
+// and re-enters the chain — forever, with no actual IdP refresh.
+//
+// A non-caching inner source (nonCachingRefresher) fixes this: the first call
+// inside the window returns a fresh token with a real-future expiry, which the
+// outer cache can hold until the next window.
+func TestWithPreemptiveRefresh_CachingInnerSource_LoopRegression(t *testing.T) {
+	t.Parallel()
+
+	// cachingSource simulates the old resourceTokenSource / oauth2.ReuseTokenSource
+	// behaviour: always returns the same token with a fixed near-future expiry
+	// (within the preemptive window), so preemptiveTokenSource always shifts it
+	// to already-expired.
+	staleExpiry := time.Now().Add(preemptiveRefreshWindow / 2) // inside the window
+	cachingInner := &countingTokenSource{
+		tokenFn: func(_ int) *oauth2.Token {
+			return &oauth2.Token{
+				AccessToken: "stale-token",
+				Expiry:      staleExpiry, // fixed — never advances
+			}
+		},
+	}
+
+	src := withPreemptiveRefresh(cachingInner)
+
+	// Drive the source several times. With the old caching inner source this
+	// would loop forever (calls >> iterations). With the fix (non-caching inner
+	// source that returns a fresh token each call), the outer cache eventually
+	// settles once the inner returns a token whose shifted expiry is in the future.
+	//
+	// Here we simply verify that the loop terminates and the number of inner calls
+	// is bounded — it should equal the number of Token() calls until the inner
+	// source returns a long-lived token. Since our fake always returns the same
+	// stale expiry, we expect exactly one call per outer Token() call (the outer
+	// never caches) but NOT an infinite loop within a single Token() call.
+	const iterations = 5
+	for i := 0; i < iterations; i++ {
+		tok, err := src.Token()
+		require.NoError(t, err)
+		assert.Equal(t, "stale-token", tok.AccessToken)
+	}
+	// Each outer Token() call results in exactly one inner call — never multiple
+	// calls per single outer invocation (which would indicate the inner loop bug).
+	assert.Equal(t, iterations, cachingInner.calls,
+		"each outer Token() call must result in exactly one inner call; "+
+			"more calls per invocation would indicate the infinite-loop regression")
 }
 
 // ── accessTokenCacheKey ───────────────────────────────────────────────────────

--- a/pkg/llm/tokensource_test.go
+++ b/pkg/llm/tokensource_test.go
@@ -6,7 +6,12 @@ package llm
 import (
 	"context"
 	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -15,6 +20,7 @@ import (
 	"go.uber.org/mock/gomock"
 	"golang.org/x/oauth2"
 
+	"github.com/stacklok/toolhive/pkg/auth/oauth"
 	secretsmocks "github.com/stacklok/toolhive/pkg/secrets/mocks"
 )
 
@@ -685,6 +691,70 @@ func TestWithPreemptiveRefresh_ExactlyOneRefreshPerWindow(t *testing.T) {
 			"served from the outer ReuseTokenSource cache")
 }
 
+// TestWithPreemptiveRefresh_NoResource_ExactlyOneRefreshPerWindow is a sibling to
+// TestWithPreemptiveRefresh_ExactlyOneRefreshPerWindow, exercising the non-resource
+// (Audience == "") path through a real NonCachingRefresher and an HTTP test server.
+//
+// Regression guard: if tryRestoreFromCache were reverted to use oauth2Cfg.TokenSource
+// (which caches the token internally) instead of NonCachingRefresher, the inner source
+// would return the same stale token on every call inside the preemptive window. The
+// outer ReuseTokenSource would never see a fresh token and would thrash — calling the
+// inner source on every outer Token() call. That path never hits the server at all
+// after the first call, so this test would fail with serverCalls != 2.
+func TestWithPreemptiveRefresh_NoResource_ExactlyOneRefreshPerWindow(t *testing.T) {
+	t.Parallel()
+
+	var serverCalls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		call := int(serverCalls.Add(1))
+		// Call 1: short-lived token — shifted expiry (15 s − 30 s) is already past,
+		// so the outer ReuseTokenSource enters the inner chain again on the next call.
+		// Call 2+: long-lived token — shifted expiry (120 s − 30 s = 90 s) is well in
+		// the future, so the outer ReuseTokenSource can cache and stop calling the inner.
+		expiresIn := 120
+		if call == 1 {
+			expiresIn = 15
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"access_token":"token-%d","token_type":"Bearer","expires_in":%d}`,
+			call, expiresIn)
+	}))
+	t.Cleanup(srv.Close)
+
+	cfg := &oauth2.Config{
+		ClientID: "test-client",
+		Endpoint: oauth2.Endpoint{
+			TokenURL:  srv.URL,
+			AuthStyle: oauth2.AuthStyleInParams,
+		},
+	}
+	ncr := oauth.NewNonCachingRefresher(cfg, "refresh-token", "" /* Audience == "" — standard OAuth 2.0 */)
+	src := withPreemptiveRefresh(ncr)
+
+	// First call: outer has no token → calls inner (server call 1) → short-lived token.
+	tok, err := src.Token()
+	require.NoError(t, err)
+	assert.Equal(t, "token-1", tok.AccessToken)
+	assert.Equal(t, int32(1), serverCalls.Load())
+
+	// Subsequent calls: the short token's shifted expiry is already past, so the outer
+	// calls the inner once more (server call 2), receives a long-lived token, and caches
+	// its shifted expiry which is well in the future. All remaining calls must be served
+	// from the outer ReuseTokenSource cache — the server must not be called again.
+	const iterations = 10
+	for i := 0; i < iterations; i++ {
+		tok, err = src.Token()
+		require.NoError(t, err)
+		assert.Equal(t, "token-2", tok.AccessToken,
+			"all calls after the preemptive refresh must return the cached fresh token")
+	}
+
+	assert.Equal(t, int32(2), serverCalls.Load(),
+		"server must be called exactly twice: once for the initial short-lived token and "+
+			"once for the preemptive refresh; all remaining calls must be served from the "+
+			"outer ReuseTokenSource cache")
+}
+
 // ── withPreemptiveRefreshFrom – pre-seeds outer cache with shifted initial token ──
 
 // TestWithPreemptiveRefreshFrom_PreSeededToken verifies that withPreemptiveRefreshFrom
@@ -721,6 +791,39 @@ func TestWithPreemptiveRefreshFrom_PreSeededToken(t *testing.T) {
 	assert.Equal(t, 0, fake.calls, "inner source must not be called while initial token is valid")
 }
 
+// TestWithPreemptiveRefreshFrom_ShortLivedInitial_NoSeed verifies that when the
+// initial token's lifetime is shorter than preemptiveRefreshWindow, the shifted
+// expiry is already in the past and the outer ReuseTokenSource is not pre-seeded.
+// The first Token() call must therefore go to the inner source immediately.
+func TestWithPreemptiveRefreshFrom_ShortLivedInitial_NoSeed(t *testing.T) {
+	t.Parallel()
+
+	fake := &countingTokenSource{
+		tokenFn: func(_ int) *oauth2.Token {
+			return &oauth2.Token{
+				AccessToken: "inner-token",
+				Expiry:      time.Now().Add(2 * time.Minute),
+			}
+		},
+	}
+
+	// Token lifetime (15 s) is shorter than preemptiveRefreshWindow (30 s), so
+	// the shifted expiry (now − 15 s) is already past — seeding is skipped.
+	initial := &oauth2.Token{
+		AccessToken: "short-lived-token",
+		Expiry:      time.Now().Add(preemptiveRefreshWindow / 2),
+	}
+
+	src := withPreemptiveRefreshFrom(initial, fake)
+
+	tok, err := src.Token()
+	require.NoError(t, err)
+	// Must come from the inner source, not the stale initial token.
+	assert.Equal(t, "inner-token", tok.AccessToken)
+	assert.Equal(t, 1, fake.calls,
+		"short-lived initial token must not be seeded; first Token() must call inner source")
+}
+
 func TestWithPreemptiveRefreshFrom_NilInitial_BehavesLikeWithPreemptiveRefresh(t *testing.T) {
 	t.Parallel()
 
@@ -747,33 +850,68 @@ func TestNonCachingRefresher_EmptyRefreshToken_ReturnsError(t *testing.T) {
 	t.Parallel()
 
 	cfg := &oauth2.Config{ClientID: "test"}
-	ncr := newNonCachingRefresher(cfg, "" /* no refresh token */, "")
+	ncr := oauth.NewNonCachingRefresher(cfg, "" /* no refresh token */, "")
 
 	_, err := ncr.Token()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no refresh token available")
 }
 
-// TestWithPreemptiveRefresh_CachingInnerSource_LoopRegression is a regression
-// test for the bug where a caching inner source (one that returns the same valid
-// token every call) caused the outer ReuseTokenSource to loop indefinitely inside
-// the preemptive window.
-//
-// A caching source always returns the same token regardless of how many times
-// Token() is called. When preemptiveTokenSource shifts its expiry back by 30 s,
-// the outer ReuseTokenSource sees an already-expired token on the very next call
-// and re-enters the chain — forever, with no actual IdP refresh.
-//
-// A non-caching inner source (nonCachingRefresher) fixes this: the first call
-// inside the window returns a fresh token with a real-future expiry, which the
-// outer cache can hold until the next window.
-func TestWithPreemptiveRefresh_CachingInnerSource_LoopRegression(t *testing.T) {
+// TestNonCachingRefresher_StandardPath_NoResourceParam verifies that when
+// Audience/resource is empty the standard OAuth 2.0 refresh path is taken:
+// no "resource" parameter is sent, the returned access token is used, and the
+// previous refresh token is preserved when the IdP does not rotate one.
+func TestNonCachingRefresher_StandardPath_NoResourceParam(t *testing.T) {
 	t.Parallel()
 
-	// cachingSource simulates the old resourceTokenSource / oauth2.ReuseTokenSource
-	// behaviour: always returns the same token with a fixed near-future expiry
-	// (within the preemptive window), so preemptiveTokenSource always shifts it
-	// to already-expired.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		// Assert inside the handler — no cross-goroutine variable sharing.
+		assert.NotContains(t, string(raw), "resource=",
+			"standard (audience=='') path must not include a resource parameter")
+		w.Header().Set("Content-Type", "application/json")
+		// IdP does not rotate the refresh token — omit it from the response.
+		fmt.Fprintln(w, `{"access_token":"new-at","token_type":"Bearer","expires_in":3600}`)
+	}))
+	t.Cleanup(srv.Close)
+
+	cfg := &oauth2.Config{
+		ClientID: "test-client",
+		Endpoint: oauth2.Endpoint{
+			TokenURL:  srv.URL,
+			AuthStyle: oauth2.AuthStyleInParams,
+		},
+		Scopes: []string{"openid"},
+	}
+	ncr := oauth.NewNonCachingRefresher(cfg, "my-refresh-token", "" /* no audience — standard path */)
+
+	tok, err := ncr.Token()
+	require.NoError(t, err)
+	assert.Equal(t, "new-at", tok.AccessToken)
+	// When the IdP omits the refresh token the previous one must be preserved.
+	assert.Equal(t, "my-refresh-token", tok.RefreshToken,
+		"refresh token must be preserved when IdP does not rotate it")
+}
+
+// TestWithPreemptiveRefresh_CachingInnerSource_ThrashesAcrossOuterCalls documents
+// the failure mode of a caching inner source inside the preemptive chain.
+//
+// A caching inner source always returns the same token regardless of how many times
+// Token() is called. When that token's expiry falls within the preemptive window,
+// preemptiveTokenSource shifts it to already-expired. The outer ReuseTokenSource
+// therefore never caches — it thrashes, calling the inner source on every outer
+// Token() invocation instead of settling after one refresh.
+//
+// This test pins that thrashing behaviour: N outer calls → N inner calls. Contrast
+// with TestWithPreemptiveRefresh_ExactlyOneRefreshPerWindow, which shows that a
+// non-caching inner source (NonCachingRefresher) settles after exactly one
+// preemptive refresh — all subsequent outer calls are served from cache.
+func TestWithPreemptiveRefresh_CachingInnerSource_ThrashesAcrossOuterCalls(t *testing.T) {
+	t.Parallel()
+
+	// Simulates the old resourceTokenSource behaviour: always returns the same
+	// token with a fixed expiry inside the preemptive window, so the shifted
+	// expiry is always in the past and the outer cache never settles.
 	staleExpiry := time.Now().Add(preemptiveRefreshWindow / 2) // inside the window
 	cachingInner := &countingTokenSource{
 		tokenFn: func(_ int) *oauth2.Token {
@@ -786,27 +924,19 @@ func TestWithPreemptiveRefresh_CachingInnerSource_LoopRegression(t *testing.T) {
 
 	src := withPreemptiveRefresh(cachingInner)
 
-	// Drive the source several times. With the old caching inner source this
-	// would loop forever (calls >> iterations). With the fix (non-caching inner
-	// source that returns a fresh token each call), the outer cache eventually
-	// settles once the inner returns a token whose shifted expiry is in the future.
-	//
-	// Here we simply verify that the loop terminates and the number of inner calls
-	// is bounded — it should equal the number of Token() calls until the inner
-	// source returns a long-lived token. Since our fake always returns the same
-	// stale expiry, we expect exactly one call per outer Token() call (the outer
-	// never caches) but NOT an infinite loop within a single Token() call.
-	const iterations = 5
+	const iterations = 10
 	for i := 0; i < iterations; i++ {
 		tok, err := src.Token()
 		require.NoError(t, err)
 		assert.Equal(t, "stale-token", tok.AccessToken)
 	}
-	// Each outer Token() call results in exactly one inner call — never multiple
-	// calls per single outer invocation (which would indicate the inner loop bug).
+	// The outer cache never settles: every outer Token() call triggers one inner
+	// call. This is the thrashing behaviour the NonCachingRefresher fixes — once
+	// the inner source returns a long-lived token the outer cache holds it and
+	// subsequent calls cost zero inner calls (see ExactlyOneRefreshPerWindow).
 	assert.Equal(t, iterations, cachingInner.calls,
-		"each outer Token() call must result in exactly one inner call; "+
-			"more calls per invocation would indicate the infinite-loop regression")
+		"caching inner source must be called once per outer Token() call — "+
+			"the outer cache never settles when the inner always returns a stale token")
 }
 
 // ── accessTokenCacheKey ───────────────────────────────────────────────────────

--- a/pkg/llm/tokensource_test.go
+++ b/pkg/llm/tokensource_test.go
@@ -351,7 +351,7 @@ func TestTokenSource_TryRestoreFromCache_CallsGetSecretWithDerivedKey(t *testing
 		"error must be from OIDC discovery, not from missing token")
 }
 
-// ── makeTokenPersister – stores refresh token and calls updater ──────────────
+// ── makeTokenPersister – stores refresh token, calls updater, invalidates AT ──
 
 func TestTokenSource_MakeTokenPersister_StoresTokenAndCallsUpdater(t *testing.T) {
 	t.Parallel()
@@ -360,13 +360,22 @@ func TestTokenSource_MakeTokenPersister_StoresTokenAndCallsUpdater(t *testing.T)
 	t.Cleanup(ctrl.Finish)
 	mockSecrets := secretsmocks.NewMockProvider(ctrl)
 
+	cfg := minimalConfig()
 	const secretKey = "LLM_OAUTH_test"
 	wantToken := "new-refresh-token"
 	wantExpiry := time.Now().Add(time.Hour)
 
-	mockSecrets.EXPECT().
-		SetSecret(gomock.Any(), secretKey, wantToken).
-		Return(nil)
+	// The persister must write the refresh token then invalidate the AT cache.
+	// accessTokenCacheKey is derived from the config, not from secretKey.
+	atKey := DeriveSecretKey(cfg.GatewayURL, cfg.OIDC.Issuer) + "_AT"
+	gomock.InOrder(
+		mockSecrets.EXPECT().
+			SetSecret(gomock.Any(), secretKey, wantToken).
+			Return(nil),
+		mockSecrets.EXPECT().
+			SetSecret(gomock.Any(), atKey, "").
+			Return(nil),
+	)
 
 	var updaterKey string
 	var updaterExpiry time.Time
@@ -375,7 +384,7 @@ func TestTokenSource_MakeTokenPersister_StoresTokenAndCallsUpdater(t *testing.T)
 		updaterExpiry = expiry
 	}
 
-	ts := NewTokenSource(minimalConfig(), mockSecrets, false, updater)
+	ts := NewTokenSource(cfg, mockSecrets, false, updater)
 	persister := ts.makeTokenPersister(secretKey)
 
 	require.NoError(t, persister(wantToken, wantExpiry))
@@ -595,6 +604,82 @@ func TestTokenSource_CacheAccessToken_WriteFailure_DoesNotPanic(t *testing.T) {
 	assert.NotPanics(t, func() {
 		ts.cacheAccessToken(context.Background(), "token", time.Now().Add(time.Hour))
 	})
+}
+
+// ── withPreemptiveRefresh – composition regression ───────────────────────────
+
+// countingTokenSource is a test helper that counts Token() invocations and
+// delegates to a caller-supplied function so each call can return a distinct
+// token. It is not safe for concurrent use; all calls come through the
+// ReuseTokenSource mutex so no additional locking is needed.
+type countingTokenSource struct {
+	calls   int
+	tokenFn func(call int) *oauth2.Token
+}
+
+func (c *countingTokenSource) Token() (*oauth2.Token, error) {
+	c.calls++
+	return c.tokenFn(c.calls), nil
+}
+
+// TestWithPreemptiveRefresh_ExactlyOneRefreshPerWindow is a regression test for
+// the composition bug where an inner ReuseTokenSource inside the preemptive
+// chain would return the same stale cached token on every call inside the
+// preemptive window, causing the outer ReuseTokenSource to see an expired token
+// on every successive call and re-enter the inner chain indefinitely.
+//
+// Correct behaviour: the first call inside the preemptive window triggers
+// exactly one inner Token() call that returns a fresh long-lived token. The
+// outer ReuseTokenSource caches the shifted expiry (which is now in the future)
+// and serves all subsequent calls from cache — no further inner calls.
+func TestWithPreemptiveRefresh_ExactlyOneRefreshPerWindow(t *testing.T) {
+	t.Parallel()
+
+	// Call 1 returns a short-lived token whose shifted expiry is already in the
+	// past, so the outer ReuseTokenSource immediately re-enters the inner chain
+	// on the very next call.
+	// Call 2+ returns a long-lived token; after shifting its expiry is well in
+	// the future, so the outer ReuseTokenSource can cache it and serve all
+	// subsequent Token() calls without touching the inner source again.
+	fake := &countingTokenSource{
+		tokenFn: func(call int) *oauth2.Token {
+			if call == 1 {
+				return &oauth2.Token{
+					AccessToken: "token-short",
+					Expiry:      time.Now().Add(preemptiveRefreshWindow / 2),
+				}
+			}
+			return &oauth2.Token{
+				AccessToken: "token-fresh",
+				Expiry:      time.Now().Add(2 * time.Minute),
+			}
+		},
+	}
+
+	src := withPreemptiveRefresh(fake)
+
+	// First call: outer has no token → calls inner (fake call 1) → short token.
+	tok, err := src.Token()
+	require.NoError(t, err)
+	assert.Equal(t, "token-short", tok.AccessToken)
+	assert.Equal(t, 1, fake.calls)
+
+	// Subsequent calls: the short token's shifted expiry is already past, so the
+	// outer calls the inner once more (fake call 2), receives a long-lived token,
+	// and caches its shifted expiry which is well in the future. All remaining
+	// calls must be served from the outer cache — inner must not be called again.
+	const iterations = 10
+	for i := 0; i < iterations; i++ {
+		tok, err = src.Token()
+		require.NoError(t, err)
+		assert.Equal(t, "token-fresh", tok.AccessToken,
+			"all calls after the preemptive refresh must return the cached fresh token")
+	}
+
+	assert.Equal(t, 2, fake.calls,
+		"inner source must be called exactly twice: once for the initial short-lived "+
+			"token and once for the preemptive refresh; all remaining calls must be "+
+			"served from the outer ReuseTokenSource cache")
 }
 
 // ── accessTokenCacheKey ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Two bugs in `pkg/llm/tokensource.go` flagged in PR review on the `thv-llm-token` branch (#5051).

### Bug 1: `withPreemptiveRefresh` composition is broken

Both callers passed a source already wrapped in `oauth2.ReuseTokenSource` (from `oauth.NewResourceTokenSource` and `oauth2Cfg.TokenSource`), creating a double-caching chain. In the preemptive window the inner `ReuseTokenSource` returned the same cached real-expiry token, `preemptiveTokenSource` shifted it to already-expired, and every `Token()` call re-entered the inner chain indefinitely — no actual IdP refresh occurred.

**Fix:** replace both inner sources with `oauth.NonCachingRefresher` (in `pkg/auth/oauth`), a type that always performs a network round-trip when `Token()` is called, on **both** the resource path (`Audience != ""`) and the standard path (`Audience == ""`). The outer `ReuseTokenSource` (via `withPreemptiveRefresh`) is now the sole caching layer. Target stacking:

```
ReuseTokenSource(nil, preemptiveTokenSource{inner: PersistingTokenSource{source: NonCachingRefresher}})
```

`NonCachingRefresher` consolidates the RFC 8707 resource-indicator logic and standard OAuth 2.0 refresh into one type (branching on `resource == ""`), is safe for concurrent use via an internal `sync.Mutex`, and preserves the previous refresh token when the IdP does not rotate one.

`resourceTokenSource` in `pkg/auth/oauth` is refactored to delegate to `NonCachingRefresher` instead of duplicating the `cfg.Exchange` logic — the two shared the same RFC 8707 resource handling and explicit scope forwarding.

`withPreemptiveRefreshFrom` is added to pre-seed the outer `ReuseTokenSource` with the shifted initial token after the browser flow, so the just-obtained access token is served without an immediate network call.

Also extracts an `oauth2ConfigFrom` helper to reuse the already-discovered `flowCfg` in `performBrowserFlow` without a second OIDC round-trip.

### Bug 2: Stale `_AT` cache after refresh token rotation

`makeTokenPersister` wrote the new refresh token but left the `_AT` access-token cache entry unchanged. A concurrent process (e.g. `thv llm token`) could read the stale `_AT` entry and serve a token minted against the now-invalidated refresh token.

**Fix:** after `SetSecret` for the refresh token succeeds, overwrite the `_AT` entry with an empty string so the next `Token()` call falls through to a fresh access token. Errors from this invalidation are now logged at `Warn` instead of silently discarded.

Closes #5051

## Follow-up issues

- #5066 — Lift `ensureOfflineAccess` and `DeriveSecretKey` to `pkg/auth/oauth` (byte-identical with counterparts in `pkg/registry/auth`) and consider retry/singleflight for `pkg/llm` token refresh (parity with `MonitoredTokenSource`)

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test`)

Added:
- `TestWithPreemptiveRefresh_ExactlyOneRefreshPerWindow`: verifies exactly 2 inner calls (initial + one preemptive refresh), all subsequent calls from outer cache — exercises the resource path (`Audience != ""`)
- `TestWithPreemptiveRefresh_NoResource_ExactlyOneRefreshPerWindow`: same assertion via a real HTTP test server and `NonCachingRefresher` with `resource = ""` — exercises the standard (non-resource) path and catches a revert to `oauth2Cfg.TokenSource`
- `TestWithPreemptiveRefreshFrom_PreSeededToken`: verifies the initial token is served without hitting the inner source
- `TestWithPreemptiveRefreshFrom_NilInitial_BehavesLikeWithPreemptiveRefresh`
- `TestNonCachingRefresher_EmptyRefreshToken_ReturnsError`
- `TestNonCachingRefresher_StandardPath_NoResourceParam`: exercises the standard path against a mock HTTP server, verifying no `resource=` param is sent and the previous RT is preserved when the IdP omits one
- `TestWithPreemptiveRefresh_CachingInnerSource_ThrashesAcrossOuterCalls`: regression test documenting the failure mode (N outer `Token()` calls → N inner calls; contrast with the fixed behaviour above)

Updated `TestTokenSource_MakeTokenPersister_StoresTokenAndCallsUpdater` to expect the AT cache invalidation write in order after the refresh token write, and to align the refresh-token key with the AT key via `CachedRefreshTokenRef`.

## Does this introduce a user-facing change?

No — internal token caching logic. Users see fewer redundant network refreshes in the preemptive window and no stale access tokens after refresh token rotation.

## Special notes for reviewers

- The `_AT` invalidation uses `SetSecret(..., "")` rather than `DeleteSecret` for provider compatibility (some providers do not support delete; an empty value is treated as a cache miss by `tryAccessTokenCache`).
- `NonCachingRefresher` holds a `sync.Mutex` so it is self-safe for concurrent use. It lives in `pkg/auth/oauth` and is now used by both `pkg/llm` and `resourceTokenSource`, eliminating the duplicate `cfg.Exchange` logic.
- The non-resource path (`Audience == ""`) is fully fixed by this PR. The stale hedge in earlier description drafts ("non-resource path still partially broken") was incorrect — `NonCachingRefresher` handles both paths unconditionally.