### PR TITLE
Strip Content-Length when wrapping tool filter response

### DIFF
--- a/pkg/mcp/tool_filter.go
+++ b/pkg/mcp/tool_filter.go
@@ -315,8 +315,15 @@ type toolFilterWriter struct {
 	config *toolMiddlewareConfig
 }
 
-// WriteHeader captures the status code
+// WriteHeader captures the status code.
+//
+// Content-Length is stripped because applying tool filters or overrides may
+// change the body size (e.g. a longer override description). Without this,
+// net/http rejects the rewritten body with "http: wrote more than the declared
+// Content-Length" and the client receives only the headers. Removing the
+// header lets Go fall back to chunked transfer encoding.
 func (rw *toolFilterWriter) WriteHeader(statusCode int) {
+	rw.ResponseWriter.Header().Del("Content-Length")
 	rw.ResponseWriter.WriteHeader(statusCode)
 }
 

--- a/pkg/mcp/tool_filter_test.go
+++ b/pkg/mcp/tool_filter_test.go
@@ -1252,6 +1252,68 @@ func TestToolFilterWriter_Flush(t *testing.T) {
 	}
 }
 
+// TestToolFilterWriter_WriteHeader verifies that Content-Length is stripped
+// from the underlying ResponseWriter's headers regardless of content type.
+// The middleware re-encodes tool list responses to apply filters/overrides,
+// which changes the body size; without this strip, net/http rejects the
+// rewritten body with "http: wrote more than the declared Content-Length"
+// and the client receives only the headers. Regression guard for #5075.
+func TestToolFilterWriter_WriteHeader(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		initialHeaders http.Header
+		statusCode     int
+	}{
+		{
+			name: "application/json with Content-Length is stripped",
+			initialHeaders: http.Header{
+				"Content-Type":   []string{"application/json"},
+				"Content-Length": []string{"123"},
+			},
+			statusCode: http.StatusOK,
+		},
+		{
+			name: "text/event-stream with Content-Length is stripped",
+			initialHeaders: http.Header{
+				"Content-Type":   []string{"text/event-stream"},
+				"Content-Length": []string{"14743"},
+			},
+			statusCode: http.StatusOK,
+		},
+		{
+			name: "no Content-Length leaves headers unchanged",
+			initialHeaders: http.Header{
+				"Content-Type": []string{"application/json"},
+			},
+			statusCode: http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mockWriter := &mockResponseWriter{
+				headers: tt.initialHeaders.Clone(),
+				buffer:  &bytes.Buffer{},
+			}
+			rw := &toolFilterWriter{ResponseWriter: mockWriter}
+
+			rw.WriteHeader(tt.statusCode)
+
+			assert.Equal(t, tt.statusCode, mockWriter.statusCode, "status code should pass through")
+			assert.Empty(t, mockWriter.headers.Get("Content-Length"), "Content-Length must be stripped")
+			// Other headers must survive — only Content-Length is removed.
+			assert.Equal(t,
+				tt.initialHeaders.Get("Content-Type"),
+				mockWriter.headers.Get("Content-Type"),
+				"Content-Type must be preserved")
+		})
+	}
+}
+
 // mockResponseWriter implements http.ResponseWriter for testing
 type mockResponseWriter struct {
 	headers    http.Header


### PR DESCRIPTION
## Summary

`--tools-override` and `--tools-filter` are silently broken on `--transport streamable-http` whenever the upstream MCP server sets a `Content-Length` header on a `tools/list` response. The middleware re-encodes the body to apply overrides/filters, but `toolFilterWriter.WriteHeader` passes the upstream's original `Content-Length` through unchanged. When the rewritten body is a different size, Go's `net/http` rejects the write with `http: wrote more than the declared Content-Length` (or, for filtering, holds the connection waiting for bytes that never arrive), and the client sees headers but no body. The MCP handshake then stalls at `tools/list`.

- WHY: any streamable-http server that uses fixed-length framing for `tools/list` (e.g. `mcr.microsoft.com/playwright/mcp`) becomes unusable with overrides/filters. Servers using chunked encoding (e.g. `osv-mcp`) happen to dodge it, which is why the bug went unnoticed.
- WHAT: delete `Content-Length` in `toolFilterWriter.WriteHeader` so Go falls back to chunked transfer encoding, which is permitted by the [MCP Streamable HTTP transport spec](https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#streamable-http) and HTTP/1.1 (RFC 9112 §6).

Fixes #5075

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [x] Unit tests (`task test`) — full suite passes in devcontainer
- [ ] E2E tests (`task test-e2e`)
- [ ] Linting (`task lint-fix`)
- [x] Manual testing (describe below)

**Manual repro and verification** against `mcr.microsoft.com/playwright/mcp:v0.0.70`:

Before fix — `tools/list` proxy log:
```
keep buffering buffered_bytes=3881
flushing buffer bytes=14864
ERROR error writing buffer error=\"http: wrote more than the declared Content-Length\"
```
Client receives headers (`Content-Length: 14743`, `Content-Type: text/event-stream`) and **zero body bytes**.

After fix — same handshake:
- \`initialize\` succeeds with \`Transfer-Encoding: chunked\` (was \`Content-Length: 191\`)
- \`tools/list\` returns the full 14864-byte rewritten body
- Override description for \`browser_navigate\` is visible in the response
- No \"wrote more than the declared Content-Length\" errors in the proxy log

## API Compatibility

- [x] This PR does not break the \`v1beta1\` API, OR the \`api-break-allowed\` label is applied and the migration guidance is described above.

## Does this introduce a user-facing change?

Yes. \`thv run --transport streamable-http --tools-override <file>\` (and \`--tools-filter\`) now works against MCP servers that send \`Content-Length\` on their \`tools/list\` responses; previously the MCP client would hang or error out after \`initialize\`.

## Special notes for reviewers

### Spec compliance

The MCP Streamable HTTP transport spec ([2025-11-25](https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#streamable-http)) and the prior 2025-06-18 version both constrain MCP-level concerns — content types, status codes, session/version headers, SSE event semantics — but neither says anything about HTTP framing. RFC 9112 §6 explicitly permits \`Transfer-Encoding: chunked\` as an alternative to \`Content-Length\`, and HTTP/1.1 clients MUST support both. The fix preserves \`Content-Type\`, \`MCP-Session-Id\`, and the unmodified SSE event stream / JSON body — including SSE \`id:\` lines, so \`Last-Event-ID\` resumption (per the new 2025-11-25 connection/stream lifecycle rules) is unaffected.

### Considered alternative: recompute \`Content-Length\` after rewrite

Instead of stripping the header, we could update it to the rewritten body's size. The complication is timing: the reverse proxy calls \`WriteHeader\` (which commits headers) before the response body has been fully buffered and processed. Recomputing correctly would require deferring \`WriteHeader\` until \`Flush()\` finishes processing the entire body, which breaks the streaming contract that \`FlushInterval: -1\` is set up to provide for non-\`tools/list\` responses (e.g. SSE \`text/event-stream\` initialize responses, or any future server-streamed messages). Stripping \`Content-Length\` keeps streaming intact and lets Go pick the appropriate framing automatically; the only cost is the small per-chunk overhead of chunked encoding.

### Why the bug only surfaces on some servers

The same middleware code path is exercised on \`stdio\` and \`streamable-http\`, but \`stdio\` is unaffected because \`httpsse.HTTPSSEProxy\` generates its own SSE responses with no fixed \`Content-Length\`. On \`streamable-http\`, the bug triggers only when the upstream sets a \`Content-Length\` on the \`tools/list\` response. Empirically:

| Server | tools/list framing | Affected? |
|---|---|---|
| \`mcr.microsoft.com/playwright/mcp\` | \`text/event-stream\` + \`Content-Length\` | Yes |
| \`ghcr.io/stackloklabs/osv-mcp/server\` | \`application/json\` + \`Transfer-Encoding: chunked\` | No |

Any server that buffers and serializes \`tools/list\` to \`application/json\` with the default framework conventions (Go \`net/http\`, Express \`res.json()\`, Starlette \`JSONResponse\`, …) is likely to send \`Content-Length\` and would be affected without this fix.

### Both directions of the mismatch are broken

This PR was triggered by \`--tools-override\` *enlarging* the body (longer override description). The same root cause also breaks \`--tools-filter\` when filtering *shrinks* the body below the declared \`Content-Length\`: Go would write fewer bytes than promised, and the client would hang or see truncation. A single \`Content-Length\` strip fixes both directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)