### PR TITLE
Introduce LLMClientApp type to remove xcode from MCP API swagger enum

### DIFF
--- a/docs/server/docs.go
+++ b/docs/server/docs.go
@@ -851,8 +851,7 @@ const docTemplate = `{
                     "mistral-vibe",
                     "codex",
                     "kimi-cli",
-                    "factory",
-                    "xcode"
+                    "factory"
                 ],
                 "type": "string",
                 "x-enum-varnames": [
@@ -882,8 +881,7 @@ const docTemplate = `{
                     "MistralVibe",
                     "Codex",
                     "KimiCli",
-                    "Factory",
-                    "Xcode"
+                    "Factory"
                 ]
             },
             "github_com_stacklok_toolhive_pkg_client.ClientAppStatus": {

--- a/docs/server/swagger.json
+++ b/docs/server/swagger.json
@@ -844,8 +844,7 @@
                     "mistral-vibe",
                     "codex",
                     "kimi-cli",
-                    "factory",
-                    "xcode"
+                    "factory"
                 ],
                 "type": "string",
                 "x-enum-varnames": [
@@ -875,8 +874,7 @@
                     "MistralVibe",
                     "Codex",
                     "KimiCli",
-                    "Factory",
-                    "Xcode"
+                    "Factory"
                 ]
             },
             "github_com_stacklok_toolhive_pkg_client.ClientAppStatus": {

--- a/docs/server/swagger.yaml
+++ b/docs/server/swagger.yaml
@@ -837,7 +837,6 @@ components:
       - codex
       - kimi-cli
       - factory
-      - xcode
       type: string
       x-enum-varnames:
       - RooCode
@@ -867,7 +866,6 @@ components:
       - Codex
       - KimiCli
       - Factory
-      - Xcode
     github_com_stacklok_toolhive_pkg_client.ClientAppStatus:
       properties:
         client_type:

--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -27,11 +27,18 @@ import (
 const defaultURLFieldName = "url"
 
 // ClientApp is an enum of MCP-capable AI clients (IDEs, editors, and coding tools).
-// Note: "xcode" is an LLM-gateway-only client (use "thv llm setup"); it is
-// intentionally excluded from MCP client registration endpoints.
+// Only clients that support MCP registration appear here; LLM-gateway-only
+// tools (e.g. Xcode) are represented by the separate LLMClientApp type so
+// that code generators (swag) do not include them in the MCP API enum.
 //
 //nolint:revive // ClientApp is intentionally named for clarity across packages
 type ClientApp string
+
+// LLMClientApp identifies tools that support the LLM gateway but do not
+// support MCP client registration (e.g. GitHub Copilot for Xcode).
+// Keeping this type separate from ClientApp prevents swag from including
+// these tools in the MCP API ClientApp enum.
+type LLMClientApp string
 
 const (
 	// RooCode represents the Roo Code extension for VS Code.
@@ -88,9 +95,14 @@ const (
 	KimiCli ClientApp = "kimi-cli"
 	// Factory represents the Factory.ai Droid CLI.
 	Factory ClientApp = "factory"
+)
+
+const (
 	// Xcode represents GitHub Copilot for Xcode.
-	// Xcode does not support MCP; it is an LLM-gateway-only entry.
-	Xcode ClientApp = "xcode"
+	// Xcode does not support MCP; it is an LLM-gateway-only tool.
+	// It is declared as LLMClientApp (not ClientApp) so that code generators
+	// such as swag do not include "xcode" in the MCP API ClientApp enum.
+	Xcode LLMClientApp = "xcode"
 )
 
 // Extension is extension of the client config file.
@@ -917,7 +929,9 @@ var supportedClientIntegrations = []clientAppConfig{
 	},
 	{
 		// Xcode does not support MCP; it is an LLM-gateway-only entry.
-		ClientType:     Xcode,
+		// Cast LLMClientApp → ClientApp for internal config storage; the type
+		// distinction matters only for swag enum generation (see LLMClientApp).
+		ClientType:     ClientApp(Xcode),
 		Description:    "GitHub Copilot for Xcode",
 		LLMGatewayOnly: true,
 		LLMGatewayMode: "proxy",

--- a/pkg/client/config_test.go
+++ b/pkg/client/config_test.go
@@ -528,8 +528,6 @@ func TestSuccessfulClientConfigOperations(t *testing.T) {
 				// TOML files are created empty and initialized on first use
 				// Just verify the file exists and is readable
 				assert.NotNil(t, content, "TOML config should be readable")
-			case Xcode:
-				// Xcode is LLM-gateway-only and has no MCP config file
 			}
 		}
 	})
@@ -568,8 +566,6 @@ func TestSuccessfulClientConfigOperations(t *testing.T) {
 				MistralVibe, Codex, KimiCli, Factory:
 				assert.Contains(t, string(content), testURL,
 					"Config should contain the server URL")
-			case Xcode:
-				// Xcode is LLM-gateway-only and has no MCP config file
 			}
 		}
 	})
@@ -1320,6 +1316,34 @@ func TestGetAllClients(t *testing.T) {
 
 	for _, expected := range expectedClients {
 		assert.True(t, clientMap[expected], "Expected client %s to be in the list", expected)
+	}
+
+	// LLM-gateway-only tools must not appear in the MCP client list.
+	assert.NotContains(t, clients, ClientApp(Xcode),
+		"Xcode is LLM-gateway-only and must not appear in the MCP ClientApp enum")
+}
+
+// TestLLMGatewayOnlyExcludedFromClientListAndValidation verifies that every
+// supportedClientIntegrations entry marked LLMGatewayOnly is excluded from
+// GetAllClients and rejected by IsValidClient.
+func TestLLMGatewayOnlyExcludedFromClientListAndValidation(t *testing.T) {
+	t.Parallel()
+
+	allClients := GetAllClients()
+	clientSet := make(map[ClientApp]bool, len(allClients))
+	for _, c := range allClients {
+		clientSet[c] = true
+	}
+
+	for _, cfg := range supportedClientIntegrations {
+		if !cfg.LLMGatewayOnly {
+			continue
+		}
+		assert.False(t, clientSet[cfg.ClientType],
+			"LLM-gateway-only tool %q must not appear in GetAllClients(); "+
+				"declare it as LLMClientApp, not ClientApp", cfg.ClientType)
+		assert.False(t, IsValidClient(string(cfg.ClientType)),
+			"LLM-gateway-only tool %q must not be accepted by IsValidClient()", cfg.ClientType)
 	}
 }
 

--- a/pkg/client/llm_gateway_test.go
+++ b/pkg/client/llm_gateway_test.go
@@ -81,7 +81,7 @@ func TestRealClientConfigs_ConfigureAndRevert(t *testing.T) {
 		},
 		{
 			// ~/Library/Application Support/GitHub Copilot for Xcode/editorSettings.json
-			clientType: Xcode,
+			clientType: ClientApp(Xcode),
 			expectedKeys: []string{
 				"openAIBaseURL", "http://localhost:14000/v1",
 				"apiKey", "thv-proxy",


### PR DESCRIPTION
## Summary

<!--
REQUIRED. You MUST explain:
1. WHY this change is needed (the problem or motivation)
2. WHAT changed (concise bullet points)

The diff shows the code — your summary must provide the context a reviewer
needs to understand the purpose without reading the diff first.
-->

Xcode (GitHub Copilot for Xcode) supports LLM gateway but not MCP client registration. Previously declared as a ClientApp constant, it was included in the generated swagger enum for the MCP API, misleading consumers into attempting unsupported operations.

Introduce a separate LLMClientApp type for LLM-gateway-only tools and move the Xcode constant to it. The internal clientAppConfig entry uses an explicit ClientApp(Xcode) cast so the config table continues to work unchanged. Regenerate swagger docs to confirm xcode no longer appears in the enum.
<!--
Link related issues. Use "Closes" or "Fixes" to auto-close on merge.
Remove this line if there is no related issue.
-->

Fixes #5073

## Type of change

<!-- REQUIRED. Check exactly one. -->

- [ ] Bug fix
- [ ] New feature
- [x] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

<!--
REQUIRED. Check every verification step you actually ran.
You MUST check at least one item. If you only did manual testing,
describe exactly what you tested below the checkbox.
-->

- [ ] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [x] Linting (`task lint-fix`)
- [ ] Manual testing (describe below)

## API Compatibility

<!--
The CRD Schema Compatibility check guards the v1beta1 operator API.
If the check flags this PR as Incompatible and the break is intentional,
apply the `api-break-allowed` label and describe below:

1. Which fields, types, or CRDs are changing.
2. Why the break is unavoidable.
3. The user-facing migration path (what cluster admins need to do).

See CONTRIBUTING.md → "API Stability" for the full rubric. Coordinate
with maintainers before applying the label.

Remove this section entirely if the PR does not touch operator API surface.
-->

- [ ] This PR does not break the `v1beta1` API, OR the `api-break-allowed` label is applied and the migration guidance is described above.

## Changes

<!--
Optional — include for PRs touching more than a few files to help
reviewers navigate the diff. Remove this entire section for small PRs.
-->

| File | Change |
|------|--------|
|      |        |

## Does this introduce a user-facing change?

<!--
If yes, describe the change from the user's perspective. This helps with release notes.
If no, write "No".
Remove this section entirely if not applicable.
-->

## Implementation plan

<!--
Optional — include when this PR was planned with an AI assistant (Claude Code, etc.).
Paste the approved plan inside the <details> block so reviewers can see the intended
design without cluttering the main PR description. Remove this section entirely
for PRs that were not AI-planned.
-->

<details>
<summary>Approved implementation plan</summary>

<!-- Paste the plan here -->

</details>

## Special notes for reviewers

<!--
Optional — call out anything non-obvious: tricky logic, known limitations,
areas where you'd like extra scrutiny, or follow-up work planned.
Remove this section if not needed.
-->
