### PR TITLE
Drop legacy ToolHive registry format references from docs

### DIFF
--- a/cmd/thv-operator/README.md
+++ b/cmd/thv-operator/README.md
@@ -282,7 +282,6 @@ spec:
   configYAML: |
     sources:
       - name: my-source
-        format: toolhive
         file:
           path: /config/registry/my-source/registry.json
         syncPolicy:

--- a/cmd/thv-operator/REGISTRY.md
+++ b/cmd/thv-operator/REGISTRY.md
@@ -17,19 +17,36 @@ metadata:
 data:
   registry.json: |
     {
-      "$schema": "https://raw.githubusercontent.com/stacklok/toolhive/main/pkg/registry/data/toolhive-legacy-registry.schema.json",
+      "$schema": "https://raw.githubusercontent.com/stacklok/toolhive-core/main/registry/types/data/upstream-registry.schema.json",
       "version": "1.0.0",
-      "last_updated": "2025-01-14T00:00:00Z",
-      "servers": {
-        "github": {
-          "description": "GitHub API integration",
-          "tier": "Official",
-          "status": "Active",
-          "transport": "stdio",
-          "tools": ["create_issue", "search_repositories"],
-          "image": "ghcr.io/github/github-mcp-server:latest",
-          "tags": ["github", "api", "production"]
-        }
+      "meta": {
+        "last_updated": "2025-01-14T00:00:00Z"
+      },
+      "data": {
+        "servers": [
+          {
+            "name": "io.github.github/github",
+            "description": "GitHub API integration",
+            "version": "1.0.0",
+            "packages": [
+              {
+                "registryType": "oci",
+                "identifier": "ghcr.io/github/github-mcp-server:latest",
+                "transport": { "type": "stdio" }
+              }
+            ],
+            "_meta": {
+              "io.modelcontextprotocol.registry/publisher-provided": {
+                "io.github.github": {
+                  "ghcr.io/github/github-mcp-server:latest": {
+                    "tier": "Official",
+                    "tags": ["github", "api", "production"]
+                  }
+                }
+              }
+            }
+          }
+        ]
       }
     }
 ---
@@ -66,7 +83,6 @@ Configure automatic synchronization with interval-based policies per registry:
 spec:
   sources:
     - name: default
-      format: toolhive
       configMapRef:
         name: registry-data
         key: registry.json
@@ -120,7 +136,6 @@ Store registry data in Kubernetes ConfigMaps:
 spec:
   sources:
     - name: default
-      format: toolhive  # or "upstream"
       configMapRef:
         name: registry-data
         key: registry.json  # required
@@ -138,7 +153,6 @@ Synchronize from Git repositories:
 spec:
   sources:
     - name: default
-      format: toolhive
       git:
         repository: "https://github.com/org/mcp-registry"
         branch: "main"
@@ -180,7 +194,6 @@ spec:
   displayName: "Private MCP Registry"
   sources:
     - name: default
-      format: toolhive
       git:
         repository: "https://github.com/org/private-mcp-registry"
         branch: "main"
@@ -214,7 +227,6 @@ Synchronize from HTTP/HTTPS API endpoints compatible with
 spec:
   sources:
     - name: default
-      format: toolhive
       api:
         endpoint: "https://registry.example.com"
   registries:
@@ -223,19 +235,12 @@ spec:
         - default
 ```
 
-The API source automatically detects the registry format by probing the endpoint:
+The API source fetches servers from an endpoint speaking the upstream MCP registry API:
 
-**ToolHive Registry API** (Supported):
 - Endpoint responds to `/v0/info` with registry metadata
 - Fetches servers from `/v0/servers`
 - Fetches server details from `/v0/servers/{name}`
-- No pagination - returns all servers in single response
-- Data already in ToolHive format (no conversion needed)
-
-**Upstream MCP Registry API** (Future, once the data format will stabilize):
-- Endpoint responds to `/openapi.yaml` with OpenAPI specification
-- Will support cursor-based pagination via `/v0/servers?cursor=...`
-- Will convert upstream format to ToolHive format automatically
+- Server entries use the upstream MCP server schema, with ToolHive-specific metadata carried through publisher-provided extensions
 
 Example configurations:
 
@@ -244,7 +249,6 @@ Example configurations:
 spec:
   sources:
     - name: internal-api
-      format: toolhive
       api:
         endpoint: "http://my-registry-api.default.svc.cluster.local:8080"
       syncPolicy:
@@ -260,7 +264,6 @@ spec:
 spec:
   sources:
     - name: upstream
-      format: toolhive
       api:
         endpoint: "https://registry.modelcontextprotocol.io/"
       syncPolicy:
@@ -273,22 +276,23 @@ spec:
 
 **Notes:**
 - API endpoints are validated at sync time
-- Format detection is automatic (ToolHive vs Upstream)
 - HTTPS is recommended for production use
 - Authentication support planned for future release
 
-### Registry Formats
+### Registry Format
 
-**ToolHive Format** (default):
-- Native ToolHive registry schema
-- Supports all ToolHive features
-- See [registry schema](../../pkg/registry/data/toolhive-legacy-registry.schema.json)
+ToolHive registries use the upstream MCP server format published in
+[`stacklok/toolhive-core`](https://github.com/stacklok/toolhive-core)
+under `registry/types/data/`:
 
-**Upstream Format**:
-- Standard MCP registry format
-- Compatible with community registries
-- Automatically converted to ToolHive format
-- **Note**: Not supported until the upstream schema is more stable
+- `upstream-registry.schema.json` validates the registry envelope and
+  references the official MCP server schema.
+- `publisher-provided.schema.json` defines the ToolHive-specific metadata
+  carried under `_meta["io.modelcontextprotocol.registry/publisher-provided"]`
+  (tier, tools, permissions, OAuth/OIDC config, etc.).
+
+The legacy ToolHive-native format is no longer accepted. Existing files
+can be migrated with `thv registry convert --in <file> --in-place`.
 
 ## Filtering
 
@@ -298,7 +302,6 @@ Each registry configuration can define its own filtering rules:
 spec:
   sources:
     - name: production
-      format: toolhive
       configMapRef:
         name: registry-data
         key: registry.json
@@ -509,7 +512,6 @@ spec:
   displayName: "Production MCP Servers"
   sources:
     - name: prod-source
-      format: toolhive
       configMapRef:
         name: prod-registry-data
         key: registry.json
@@ -531,7 +533,6 @@ spec:
   displayName: "Development MCP Servers"
   sources:
     - name: dev-source
-      format: toolhive
       git:
         repository: "https://github.com/org/dev-mcp-registry"
         branch: "develop"
@@ -563,7 +564,6 @@ spec:
   displayName: "Private Organization Registry"
   sources:
     - name: private-source
-      format: toolhive
       git:
         repository: "https://github.com/myorg/private-mcp-servers"
         branch: "main"
@@ -594,7 +594,6 @@ spec:
   displayName: "Multi-Source Registry"
   sources:
     - name: production
-      format: toolhive
       git:
         repository: "https://github.com/org/prod-registry"
         branch: "main"
@@ -606,7 +605,6 @@ spec:
           include:
             - "production"
     - name: development
-      format: toolhive
       configMapRef:
         name: dev-registry-data
         key: registry.json
@@ -629,4 +627,4 @@ Each source must have a unique `name` within the MCPRegistry. Registry views ref
 - [Operator Installation](../../docs/kind/deploying-toolhive-operator.md)
 - [Registry Examples](../../examples/operator/mcp-registries/)
 - [Private Git Registry Example](../../examples/operator/mcp-registries/mcpregistry-git-private.yaml)
-- [Registry Schema](../../pkg/registry/data/toolhive-legacy-registry.schema.json)
+- [Registry Schema](../../docs/registry/schema.md)

--- a/docs/arch/06-registry-system.md
+++ b/docs/arch/06-registry-system.md
@@ -505,7 +505,7 @@ For complete registry server documentation, see:
 
 - [Registry Server Guides](https://docs.stacklok.com/toolhive/guides-registry/) - Configuration, authentication, deployment
 - [Registry API Reference](https://docs.stacklok.com/toolhive/reference/registry-api) - API endpoint documentation
-- [ToolHive Registry Schema](https://docs.stacklok.com/toolhive/reference/registry-schema-toolhive) - Registry format reference
+- [Upstream Registry Schema](https://docs.stacklok.com/toolhive/reference/registry-schema-upstream) - Registry format reference
 
 
 ## MCPRegistry CRD (Kubernetes)
@@ -538,7 +538,6 @@ spec:
   configYAML: |
     sources:
       - name: company-repo
-        format: toolhive
         git:
           repository: https://github.com/company/mcp-registry
           branch: main
@@ -569,7 +568,6 @@ and Kubernetes.
 configYAML: |
   sources:
     - name: my-source
-      format: toolhive
       git:
         repository: https://github.com/example/registry
         branch: main
@@ -604,7 +602,6 @@ spec:
   configYAML: |
     sources:
       - name: private-repo
-        format: toolhive
         git:
           repository: https://github.com/org/private-registry
           branch: main
@@ -653,7 +650,6 @@ spec:
   configYAML: |
     sources:
       - name: production
-        format: toolhive
         file:
           path: /config/registry/production/registry.json
         syncPolicy:
@@ -697,7 +693,6 @@ Sync intervals are configured per-source inside `configYAML`:
 configYAML: |
   sources:
     - name: my-source
-      format: toolhive
       git:
         repository: https://github.com/example/registry
         branch: main
@@ -870,12 +865,12 @@ thv run weather-server --image-verification enabled
 
 ## Upstream MCP Registry Format
 
-ToolHive supports the upstream [MCP registry format](https://github.com/modelcontextprotocol/registry) alongside the legacy ToolHive format.
+ToolHive consumes registries in the upstream [MCP registry format](https://github.com/modelcontextprotocol/registry). The legacy ToolHive-native format is no longer accepted; existing files can be migrated with `thv registry convert --in <file> --in-place`.
 
 **Key features:**
-1. **Dual format support**: Both ToolHive-native and upstream MCP formats
+1. **Standardized schema**: Upstream MCP server format from the modelcontextprotocol/registry project
 2. **Publisher-provided extensions**: ToolHive-specific metadata via `_meta["io.modelcontextprotocol.registry/publisher-provided"]`
-3. **Backward compatibility**: Legacy format continues to work
+3. **Lossless migration**: Every legacy ToolHive field maps to a publisher-provided extension on the corresponding upstream server entry
 
 ### Publisher-Provided Extensions
 
@@ -912,11 +907,11 @@ ToolHive uses the `io.modelcontextprotocol.registry/publisher-provided` extensio
 ```
 
 For the complete schema definition, see:
-- **Schema file**: `pkg/registry/data/publisher-provided.schema.json`
+- **Schemas**: published in [`stacklok/toolhive-core`](https://github.com/stacklok/toolhive-core) under `registry/types/data/`
 - **Documentation**: `docs/registry/schema.md`
 - **Validation**: `pkg/registry/schema_validation.go`
 
-**Implementation**: `pkg/registry/` (supports both formats)
+**Implementation**: `pkg/registry/`
 
 ## Registry Operations
 
@@ -966,8 +961,7 @@ kubectl annotate mcpregistry company-registry toolhive.stacklok.dev/sync-trigger
 ### External Documentation
 - [ToolHive User Documentation](https://docs.stacklok.com/toolhive/) - User-facing guides
 - [Registry Server Documentation](https://docs.stacklok.com/toolhive/guides-registry/) - Enterprise registry server
-- [ToolHive Registry Schema](https://docs.stacklok.com/toolhive/reference/registry-schema-toolhive) - Registry format reference
-- [Upstream Registry Schema](https://docs.stacklok.com/toolhive/reference/registry-schema-upstream) - MCP standard format
+- [Upstream Registry Schema](https://docs.stacklok.com/toolhive/reference/registry-schema-upstream) - MCP standard format used by ToolHive
 - [Registry API Reference](https://docs.stacklok.com/toolhive/reference/registry-api) - API specification
 
 ### Related Repositories


### PR DESCRIPTION
## Summary

PR #5067 removed support for the legacy ToolHive registry format from `pkg/registry`, but several in-repo docs were left documenting it as supported and shipping example YAML / registry data using it. This PR brings the docs in line with the code.

- Rewrites the "Upstream MCP Registry Format" section in `docs/arch/06-registry-system.md` to reflect that ToolHive consumes upstream-format only, and points readers at `thv registry convert` for migration.
- Strips `format: toolhive` from every YAML example across the architecture and operator docs (matches the canonical examples in `examples/operator/mcp-registries/`, which already omit it).
- Updates the Quick Start in `cmd/thv-operator/REGISTRY.md` to use the upstream registry envelope and schema URL instead of the deleted `toolhive-legacy-registry.schema.json`.
- Replaces the operator doc's "Registry Formats" section and API source prose, which still described the legacy format as the default and called upstream "not yet supported".
- Fixes external links that pointed at the deprecated `registry-schema-toolhive` reference page and the deleted local legacy schema file.

Closes #5086

## Type of change

- [x] Documentation update

## Test plan

- [x] Verified no remaining `format: toolhive`, `toolhive format`, or `toolhive-legacy-registry` references in `docs/`, `README.md`, or the operator README/REGISTRY docs.
- [x] Cross-checked YAML examples against the canonical `examples/operator/mcp-registries/` shape.

## Does this introduce a user-facing change?

Documentation only. No code or behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)