### PR TITLE
Fix non-expiring upstream token handling and storage TTL bugs

### DIFF
--- a/pkg/authserver/integration_test.go
+++ b/pkg/authserver/integration_test.go
@@ -19,10 +19,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/alicebob/miniredis/v2"
 	"github.com/go-jose/go-jose/v4"
 	"github.com/go-jose/go-jose/v4/jwt"
 	"github.com/oauth2-proxy/mockoidc"
 	"github.com/ory/fosite"
+	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -46,11 +48,29 @@ const (
 )
 
 // testServer bundles all test server components together.
+//
+// The mr field is non-nil only when the test server was constructed
+// with withRedisBackedStorage(); otherwise it is nil and the in-memory
+// backend is used. Tests that need to advance Redis time call Miniredis(t)
+// rather than dereferencing this field directly so a misconfigured test
+// fails loudly instead of nil-panicking.
 type testServer struct {
 	Server     *httptest.Server
 	PrivateKey *rsa.PrivateKey
 	authServer Server
 	storage    storage.UpstreamTokenStorage
+	mr         *miniredis.Miniredis
+}
+
+// Miniredis returns the miniredis instance backing this test server. Fails
+// the test loudly with a useful message if the server was not constructed
+// with withRedisBackedStorage(). Use this rather than dereferencing the
+// field directly.
+func (ts *testServer) Miniredis(t *testing.T) *miniredis.Miniredis {
+	t.Helper()
+	require.NotNil(t, ts.mr,
+		"testServer was not constructed with withRedisBackedStorage(); call setupTestServer*(..., withRedisBackedStorage()) to enable miniredis access")
+	return ts.mr
 }
 
 // testServerOptions configures the test server setup.
@@ -58,6 +78,13 @@ type testServerOptions struct {
 	upstream            upstream.OAuth2Provider
 	scopes              []string
 	accessTokenLifespan time.Duration
+	// storageFactory, when non-nil, supplies the storage backend instead of
+	// the default in-memory implementation. The factory may also return a
+	// *miniredis.Miniredis instance; when it does, the setup helper stashes
+	// it on testServer.mr (accessed via testServer.Miniredis()) so tests can drive its clock. A nil
+	// miniredis return value is valid (e.g., for non-Redis alternative
+	// backends).
+	storageFactory func(t *testing.T) (storage.Storage, *miniredis.Miniredis)
 }
 
 // testServerOption is a functional option for test server setup.
@@ -81,6 +108,31 @@ func withScopes(scopes []string) testServerOption {
 func withAccessTokenLifespan(d time.Duration) testServerOption {
 	return func(opts *testServerOptions) {
 		opts.accessTokenLifespan = d
+	}
+}
+
+// withRedisBackedStorage swaps the default in-memory storage for a
+// miniredis-backed *RedisStorage. This exercises the same Lua scripts and
+// Redis-shape key layout used in production, while remaining hermetic and
+// fast: each test gets its own miniredis instance with no external
+// dependencies. The {ns:test} hash tag in the key prefix matches the
+// production-shape cluster routing so multi-key Lua operations target the
+// same hash slot.
+//
+// The setup helper stashes the *miniredis.Miniredis on testServer.mr (accessed via testServer.Miniredis())
+// so tests can call FastForward(d) to advance Redis-side TTLs without
+// real-world sleeping.
+func withRedisBackedStorage() testServerOption {
+	return func(opts *testServerOptions) {
+		opts.storageFactory = func(t *testing.T) (storage.Storage, *miniredis.Miniredis) {
+			t.Helper()
+			mr := miniredis.RunT(t)
+			client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+			t.Cleanup(func() {
+				_ = client.Close()
+			})
+			return storage.NewRedisStorageWithClient(client, "test:auth:{ns:test}:"), mr
+		}
 	}
 }
 
@@ -130,8 +182,17 @@ func setupTestServer(t *testing.T, opts ...testServerOption) *testServer {
 	_, err = rand.Read(secret)
 	require.NoError(t, err)
 
-	// 3. Create storage
-	stor := storage.NewMemoryStorage()
+	// 3. Create storage. Tests opting into withRedisBackedStorage() get a
+	// miniredis-backed *RedisStorage; everyone else keeps the default
+	// in-memory backend. The mr return value is preserved so tests can
+	// FastForward Redis-side TTLs.
+	var (
+		stor storage.Storage = storage.NewMemoryStorage()
+		mr   *miniredis.Miniredis
+	)
+	if options.storageFactory != nil {
+		stor, mr = options.storageFactory(t)
+	}
 
 	// 4. Register test client (public client for PKCE)
 	err = stor.RegisterClient(ctx, &fosite.DefaultClient{
@@ -198,6 +259,7 @@ func setupTestServer(t *testing.T, opts ...testServerOption) *testServer {
 		PrivateKey: privateKey,
 		authServer: srv,
 		storage:    srv.IDPTokenStorage(),
+		mr:         mr,
 	}
 }
 
@@ -842,9 +904,18 @@ func TestIntegration_FullPKCEFlow_DefaultAudience(t *testing.T) {
 //   - UpstreamConfig{Type: OIDC, OIDCConfig: ...}
 //   - defaultUpstreamFactory dispatching to NewOIDCProvider
 //   - OIDCProviderImpl with OIDC discovery, ID token validation, and nonce support
-func setupTestServerWithOIDCProvider(t *testing.T, m *mockoidc.MockOIDC) *testServerWithUpstream {
+//
+// Variadic opts allow swapping the storage backend (e.g. withRedisBackedStorage);
+// the upstream is fixed because this helper exists specifically to exercise the
+// real OIDC factory path. Other testServerOptions are silently ignored.
+func setupTestServerWithOIDCProvider(t *testing.T, m *mockoidc.MockOIDC, opts ...testServerOption) *testServerWithUpstream {
 	t.Helper()
 	ctx := context.Background()
+
+	options := &testServerOptions{}
+	for _, opt := range opts {
+		opt(options)
+	}
 
 	cfg := m.Config()
 
@@ -857,8 +928,14 @@ func setupTestServerWithOIDCProvider(t *testing.T, m *mockoidc.MockOIDC) *testSe
 	_, err = rand.Read(secret)
 	require.NoError(t, err)
 
-	// 3. Create storage
-	stor := storage.NewMemoryStorage()
+	// 3. Create storage. See setupTestServer for the factory contract.
+	var (
+		stor storage.Storage = storage.NewMemoryStorage()
+		mr   *miniredis.Miniredis
+	)
+	if options.storageFactory != nil {
+		stor, mr = options.storageFactory(t)
+	}
 
 	// 4. Register test client (public client for PKCE)
 	err = stor.RegisterClient(ctx, &fosite.DefaultClient{
@@ -917,6 +994,7 @@ func setupTestServerWithOIDCProvider(t *testing.T, m *mockoidc.MockOIDC) *testSe
 			PrivateKey: privateKey,
 			authServer: srv,
 			storage:    srv.IDPTokenStorage(),
+			mr:         mr,
 		},
 		mockOIDC: m,
 	}
@@ -1634,9 +1712,18 @@ func TestIntegration_RefreshPreservesUpstreamTokenBinding(t *testing.T) {
 // configured as sequential upstream providers. This exercises the multi-upstream
 // authorization chain where the callback handler redirects to the next upstream
 // after each successful code exchange.
-func setupTestServerWithTwoUpstreams(t *testing.T, m1, m2 *mockoidc.MockOIDC) *testServer {
+//
+// Variadic opts allow swapping the storage backend (e.g. withRedisBackedStorage)
+// without affecting the rest of the chain wiring. Upstream-related options are
+// silently ignored because the helper hard-wires the two providers itself.
+func setupTestServerWithTwoUpstreams(t *testing.T, m1, m2 *mockoidc.MockOIDC, opts ...testServerOption) *testServer {
 	t.Helper()
 	ctx := context.Background()
+
+	options := &testServerOptions{}
+	for _, opt := range opts {
+		opt(options)
+	}
 
 	// 1. Generate RSA key for signing
 	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
@@ -1647,8 +1734,14 @@ func setupTestServerWithTwoUpstreams(t *testing.T, m1, m2 *mockoidc.MockOIDC) *t
 	_, err = rand.Read(secret)
 	require.NoError(t, err)
 
-	// 3. Create storage
-	stor := storage.NewMemoryStorage()
+	// 3. Create storage. See setupTestServer for the factory contract.
+	var (
+		stor storage.Storage = storage.NewMemoryStorage()
+		mr   *miniredis.Miniredis
+	)
+	if options.storageFactory != nil {
+		stor, mr = options.storageFactory(t)
+	}
 
 	// 4. Register test client (public client for PKCE)
 	err = stor.RegisterClient(ctx, &fosite.DefaultClient{
@@ -1752,6 +1845,7 @@ func setupTestServerWithTwoUpstreams(t *testing.T, m1, m2 *mockoidc.MockOIDC) *t
 		PrivateKey: privateKey,
 		authServer: srv,
 		storage:    srv.IDPTokenStorage(),
+		mr:         mr,
 	}
 }
 
@@ -2206,6 +2300,209 @@ func TestIntegration_MultiUpstreamChain_MixedExpiryOrderings(t *testing.T) {
 			require.Len(t, all, 2, "GetAllValidTokens must return both providers regardless of expiry ordering")
 			assert.NotEmpty(t, all["provider-1"], "provider-1 access token must be present")
 			assert.NotEmpty(t, all["provider-2"], "provider-2 access token must be present")
+		})
+	}
+}
+
+// ============================================================================
+// Redis-Backed Integration Variants
+// ============================================================================
+//
+// These tests run the same end-to-end flows as their in-memory counterparts
+// but against a miniredis-backed *RedisStorage. They are smoke tests for the
+// chain handler ↔ Redis storage path: the Redis backend executes Lua scripts,
+// performs JSON round-trips, and maintains the per-session index set — none of
+// which the in-memory backend exercises. A regression where the chain handler
+// invokes Redis with the wrong inputs (wrong key, wrong serialization, wrong
+// index update) would surface here.
+//
+// The harness (withRedisBackedStorage(), testServer.Miniredis(t)) is reusable
+// for any future test that needs to drive the full HTTP flow against Redis or
+// advance Redis-side time via FastForward without real-world sleeping.
+//
+// What these tests do NOT cover: the Lua TTL inversion regression (commit
+// fec89b040). That bug only fires when marshalUpstreamTokensWithTTL produces
+// ttlMs == 0, which requires both ExpiresAt and SessionExpiresAt to be zero.
+// Since callback.go unconditionally sets SessionExpiresAt = now +
+// RefreshTokenLifespan (commit 1b3bc81e2), the integration flow always
+// produces ttlMs > 0 and the buggy Lua branch is unreachable. The Lua
+// invariant is locked down at unit level by
+// pkg/authserver/storage/redis_test.go, which can construct UpstreamTokens
+// with both fields zero directly.
+
+// TestIntegration_FullFlow_NonExpiringUpstreamToken_Redis is the Redis-backed
+// twin of TestIntegration_FullFlow_NonExpiringUpstreamToken. The unit-level
+// Redis test of Store/GetUpstreamTokens already covers the round-trip; this
+// subtest exists for symmetry — it confirms convertOAuth2Token's zero-Expiry
+// preservation reaches Redis storage when the request originates from the
+// real HTTP chain.
+func TestIntegration_FullFlow_NonExpiringUpstreamToken_Redis(t *testing.T) {
+	t.Parallel()
+
+	m := startMockOIDCNoExpiresIn(t)
+	m.QueueUser(&mockoidc.MockUser{
+		Subject: "non-expiring-user-redis",
+		Email:   "non-expiring-redis@example.com",
+	})
+
+	ts := setupTestServerWithMockOIDC(t, m, withRedisBackedStorage())
+	ts.Miniredis(t) // assert harness was wired with withRedisBackedStorage
+
+	verifier := servercrypto.GeneratePKCEVerifier()
+	challenge := servercrypto.ComputePKCEChallenge(verifier)
+
+	authCode, _ := completeAuthorizationFlow(t, ts.Server.URL, authorizationParams{
+		ClientID:     testClientID,
+		RedirectURI:  testRedirectURI,
+		State:        "non-expiring-redis",
+		Challenge:    challenge,
+		Scope:        "openid profile offline_access",
+		ResponseType: "code",
+	})
+
+	tokenData := exchangeCodeForTokens(t, ts.Server.URL, authCode, verifier, testAudience)
+
+	accessToken, ok := tokenData["access_token"].(string)
+	require.True(t, ok)
+	tsid := extractTSID(t, accessToken, ts.PrivateKey.Public())
+
+	stor := ts.authServer.IDPTokenStorage()
+
+	// Same invariants as the memory-backed twin: zero ExpiresAt in storage,
+	// no refresh on read, no rewrite of the stored row.
+	original, err := stor.GetUpstreamTokens(context.Background(), tsid, "default")
+	require.NoError(t, err)
+	require.NotNil(t, original)
+	require.NotEmpty(t, original.AccessToken)
+	assert.True(t, original.ExpiresAt.IsZero(),
+		"upstream ExpiresAt must be zero for a token response without expires_in (got %v)",
+		original.ExpiresAt)
+
+	svc := upstreamtoken.NewInProcessService(stor, ts.authServer.UpstreamTokenRefresher())
+	cred, err := svc.GetValidTokens(context.Background(), tsid, "default")
+	require.NoError(t, err)
+	require.NotNil(t, cred)
+	assert.Equal(t, original.AccessToken, cred.AccessToken,
+		"non-expiring access token must be returned unchanged (no refresh)")
+
+	after, err := stor.GetUpstreamTokens(context.Background(), tsid, "default")
+	require.NoError(t, err)
+	assert.True(t, after.ExpiresAt.IsZero(),
+		"non-expiring token must keep zero ExpiresAt after GetValidTokens (got %v)",
+		after.ExpiresAt)
+	assert.Equal(t, original.AccessToken, after.AccessToken,
+		"access token in storage must be unchanged after GetValidTokens")
+}
+
+// TestIntegration_MultiUpstreamChain_MixedExpiryOrderings_Redis is the Redis-
+// backed smoke test for the two-leg chain with one upstream returning expires_in
+// and the other omitting it. It exercises the chain handler ↔ Redis storage
+// path through real Redis Lua execution in both orderings: a regression where
+// the chain handler invokes Redis with the wrong inputs (wrong key, wrong
+// serialization, wrong index update) would surface here.
+//
+// This test does NOT cover the Lua TTL inversion regression (commit fec89b040)
+// at integration level. That bug only fires when marshalUpstreamTokensWithTTL
+// produces ttlMs == 0, which requires both ExpiresAt and SessionExpiresAt to
+// be zero on the UpstreamTokens. Since callback.go unconditionally sets
+// SessionExpiresAt = now + RefreshTokenLifespan (commit 1b3bc81e2), the
+// integration flow always produces ttlMs > 0 and the buggy Lua branch is
+// unreachable from a real auth chain. The Lua invariant is locked down at
+// unit level by pkg/authserver/storage/redis_test.go.
+func TestIntegration_MultiUpstreamChain_MixedExpiryOrderings_Redis(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name                 string
+		firstUpstreamExpires bool
+	}{
+		{name: "non_expiring_then_expiring", firstUpstreamExpires: false},
+		{name: "expiring_then_non_expiring", firstUpstreamExpires: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Build provider-1 and provider-2 mockoidc instances so the
+			// non-expiring one matches tc.firstUpstreamExpires.
+			var m1, m2 *mockoidc.MockOIDC
+			if tc.firstUpstreamExpires {
+				m1 = startMockOIDC(t)
+				m2 = startMockOIDCNoExpiresIn(t)
+			} else {
+				m1 = startMockOIDCNoExpiresIn(t)
+				m2 = startMockOIDC(t)
+			}
+
+			m1.QueueUser(&mockoidc.MockUser{
+				Subject: "user-from-m1-redis-" + tc.name,
+				Email:   "u1-redis-" + tc.name + "@m1.example.com",
+			})
+			m2.QueueUser(&mockoidc.MockUser{
+				Subject: "user-from-m2-redis-" + tc.name,
+				Email:   "u2-redis-" + tc.name + "@m2.example.com",
+			})
+
+			ts := setupTestServerWithTwoUpstreams(t, m1, m2, withRedisBackedStorage())
+			ts.Miniredis(t) // assert harness was wired with withRedisBackedStorage
+
+			verifier := servercrypto.GeneratePKCEVerifier()
+			challenge := servercrypto.ComputePKCEChallenge(verifier)
+
+			authCode := runChainFlow(t, ts.Server.URL, challenge, "mixed-expiry-redis-"+tc.name)
+			tokenData := exchangeCodeForTokens(t, ts.Server.URL, authCode, verifier, testAudience)
+
+			accessToken, ok := tokenData["access_token"].(string)
+			require.True(t, ok)
+			tsid := extractTSID(t, accessToken, ts.PrivateKey.Public())
+
+			ctx := context.Background()
+			stor := ts.authServer.IDPTokenStorage()
+
+			// Sanity: both providers' tokens must be in storage immediately
+			// after the chain, with the expected ExpiresAt shapes. This is
+			// the same per-leg storage invariant the memory-backed twin
+			// asserts; replicated here so a Redis-only divergence in the
+			// chain handler's storage write would surface.
+			tokens1, err := stor.GetUpstreamTokens(ctx, tsid, "provider-1")
+			require.NoError(t, err, "provider-1 tokens must be retrievable")
+			require.NotNil(t, tokens1)
+			tokens2, err := stor.GetUpstreamTokens(ctx, tsid, "provider-2")
+			require.NoError(t, err, "provider-2 tokens must be retrievable")
+			require.NotNil(t, tokens2)
+
+			if tc.firstUpstreamExpires {
+				assert.False(t, tokens1.ExpiresAt.IsZero(),
+					"provider-1 (expiring) must carry a non-zero ExpiresAt")
+				assert.True(t, tokens2.ExpiresAt.IsZero(),
+					"provider-2 (non-expiring) must carry a zero ExpiresAt")
+			} else {
+				assert.True(t, tokens1.ExpiresAt.IsZero(),
+					"provider-1 (non-expiring) must carry a zero ExpiresAt")
+				assert.False(t, tokens2.ExpiresAt.IsZero(),
+					"provider-2 (expiring) must carry a non-zero ExpiresAt")
+			}
+
+			svc := upstreamtoken.NewInProcessService(stor, ts.authServer.UpstreamTokenRefresher())
+
+			// Both providers' tokens must be retrievable through Redis after the chain.
+			// This is a smoke test for the chain-handler ↔ Redis storage path: a
+			// regression where the chain handler invokes Redis storage with the wrong
+			// inputs (wrong key, wrong serialization, wrong index update) would fail here.
+			//
+			// Note: this test does NOT exercise the Lua TTL inversion bug. That bug
+			// only manifests when marshalUpstreamTokensWithTTL produces ttlMs == 0,
+			// which requires both ExpiresAt and SessionExpiresAt to be zero. Since
+			// the callback unconditionally sets SessionExpiresAt = now + RefreshTokenLifespan
+			// (commit 1b3bc81e2), the integration flow always produces ttlMs > 0 and
+			// the buggy Lua branch is unreachable from a real auth chain. The Lua
+			// invariant is exercised at unit level by pkg/authserver/storage/redis_test.go.
+			tokensMap, err := svc.GetAllValidTokens(ctx, tsid)
+			require.NoError(t, err)
+			require.Len(t, tokensMap, 2, "GetAllValidTokens must return both providers after chain")
+			assert.NotEmpty(t, tokensMap["provider-1"], "provider-1 access token must be present")
+			assert.NotEmpty(t, tokensMap["provider-2"], "provider-2 access token must be present")
 		})
 	}
 }

--- a/pkg/authserver/integration_test.go
+++ b/pkg/authserver/integration_test.go
@@ -1329,6 +1329,72 @@ func TestIntegration_UpstreamTokenService_RefreshExpiredTokens(t *testing.T) {
 	_ = originalAccessToken // used only to confirm the flow completed
 }
 
+// TestIntegration_UpstreamTokenService_NonExpiringToken verifies that a token with
+// a zero ExpiresAt is treated as non-expiring: GetValidTokens must return the
+// stored access token unchanged and must not attempt a refresh. If a refresh were
+// triggered, mockoidc would return an error because no user is queued — that
+// outcome is the failure signal for this test.
+func TestIntegration_UpstreamTokenService_NonExpiringToken(t *testing.T) {
+	t.Parallel()
+
+	m := startMockOIDC(t)
+	ts := setupTestServerWithMockOIDC(t, m)
+
+	verifier := servercrypto.GeneratePKCEVerifier()
+	challenge := servercrypto.ComputePKCEChallenge(verifier)
+
+	authCode, _ := completeAuthorizationFlow(t, ts.Server.URL, authorizationParams{
+		ClientID:     testClientID,
+		RedirectURI:  testRedirectURI,
+		State:        "upstream-nonexpiring-test",
+		Challenge:    challenge,
+		Scope:        "openid profile offline_access",
+		ResponseType: "code",
+	})
+
+	tokenData := exchangeCodeForTokens(t, ts.Server.URL, authCode, verifier, testAudience)
+
+	accessToken, ok := tokenData["access_token"].(string)
+	require.True(t, ok)
+	tsid := extractTSID(t, accessToken, ts.PrivateKey.Public())
+
+	stor := ts.authServer.IDPTokenStorage()
+
+	// Read the tokens stored during the OAuth callback.
+	original, err := stor.GetUpstreamTokens(context.Background(), tsid, "default")
+	require.NoError(t, err)
+	require.NotNil(t, original)
+
+	// Overwrite storage with a copy where ExpiresAt is zero (non-expiring).
+	// No mockoidc user is queued — if a refresh is attempted, the test will fail.
+	nonExpiring := &storage.UpstreamTokens{
+		ProviderID:      original.ProviderID,
+		AccessToken:     original.AccessToken,
+		RefreshToken:    original.RefreshToken,
+		IDToken:         original.IDToken,
+		ExpiresAt:       time.Time{},
+		UserID:          original.UserID,
+		UpstreamSubject: original.UpstreamSubject,
+		ClientID:        original.ClientID,
+	}
+	require.NoError(t, stor.StoreUpstreamTokens(context.Background(), tsid, "default", nonExpiring))
+
+	svc := upstreamtoken.NewInProcessService(stor, ts.authServer.UpstreamTokenRefresher())
+
+	cred, err := svc.GetValidTokens(context.Background(), tsid, "default")
+	require.NoError(t, err)
+	require.NotNil(t, cred)
+	assert.NotEmpty(t, cred.AccessToken)
+
+	// Confirm the token in storage still has a zero ExpiresAt — no refresh occurred.
+	refreshed, err := stor.GetUpstreamTokens(context.Background(), tsid, "default")
+	require.NoError(t, err)
+	assert.True(t, refreshed.ExpiresAt.IsZero(),
+		"non-expiring token must not gain an ExpiresAt after GetValidTokens")
+	assert.Equal(t, original.AccessToken, cred.AccessToken,
+		"access token must be unchanged — no refresh occurred")
+}
+
 // TestIntegration_UpstreamTokenService_SessionNotFound verifies that the service
 // returns ErrSessionNotFound for a non-existent session.
 func TestIntegration_UpstreamTokenService_SessionNotFound(t *testing.T) {

--- a/pkg/authserver/integration_test.go
+++ b/pkg/authserver/integration_test.go
@@ -4,12 +4,14 @@
 package authserver
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -1748,6 +1750,7 @@ func setupTestServerWithTwoUpstreams(t *testing.T, m1, m2 *mockoidc.MockOIDC) *t
 	return &testServer{
 		Server:     httpServer,
 		PrivateKey: privateKey,
+		authServer: srv,
 		storage:    srv.IDPTokenStorage(),
 	}
 }
@@ -1784,92 +1787,15 @@ func TestIntegration_MultiUpstreamSequentialChain(t *testing.T) {
 	})
 
 	ts := setupTestServerWithTwoUpstreams(t, m1, m2)
-	client := noRedirectClient()
 
 	verifier := servercrypto.GeneratePKCEVerifier()
 	challenge := servercrypto.ComputePKCEChallenge(verifier)
 	clientState := "multi-upstream-client-state"
 
-	parsedServerURL, err := url.Parse(ts.Server.URL)
-	require.NoError(t, err)
-
-	// === Leg 1: Client -> /authorize -> provider-1 ===
-
-	// Step 1: Start authorization flow on our server
-	authorizeURL := ts.Server.URL + "/oauth/authorize?" + url.Values{
-		"client_id":             {testClientID},
-		"redirect_uri":          {testRedirectURI},
-		"state":                 {clientState},
-		"code_challenge":        {challenge},
-		"code_challenge_method": {"S256"},
-		"response_type":         {"code"},
-		"scope":                 {"openid profile"},
-	}.Encode()
-
-	resp, err := client.Get(authorizeURL)
-	require.NoError(t, err)
-	require.Equal(t, http.StatusFound, resp.StatusCode, "expected redirect to provider-1")
-	m1Location, err := resp.Location()
-	require.NoError(t, err)
-	resp.Body.Close()
-
-	// Step 2: Follow redirect to provider-1's authorization endpoint (mockoidc auto-approves)
-	resp, err = client.Get(m1Location.String())
-	require.NoError(t, err)
-	require.Equal(t, http.StatusFound, resp.StatusCode, "expected redirect from provider-1 to our callback")
-	callbackFromM1, err := resp.Location()
-	require.NoError(t, err)
-	resp.Body.Close()
-
-	// Step 3: Rewrite callback URL to use actual test server (mockoidc redirects to localhost)
-	callbackFromM1.Scheme = parsedServerURL.Scheme
-	callbackFromM1.Host = parsedServerURL.Host
-
-	// Step 4: Call our /callback with provider-1's code
-	// This should NOT redirect to the client yet — it should redirect to provider-2
-	resp, err = client.Get(callbackFromM1.String())
-	require.NoError(t, err)
-	require.Equal(t, http.StatusFound, resp.StatusCode,
-		"expected 302 redirect to provider-2 (chain continues), not 303 to client")
-	m2Location, err := resp.Location()
-	require.NoError(t, err)
-	resp.Body.Close()
-
-	// === Leg 2: provider-2 ===
-
-	// Step 5: Follow redirect to provider-2's authorization endpoint (mockoidc auto-approves)
-	resp, err = client.Get(m2Location.String())
-	require.NoError(t, err)
-	require.Equal(t, http.StatusFound, resp.StatusCode, "expected redirect from provider-2 to our callback")
-	callbackFromM2, err := resp.Location()
-	require.NoError(t, err)
-	resp.Body.Close()
-
-	// Step 6: Rewrite callback URL to use actual test server
-	callbackFromM2.Scheme = parsedServerURL.Scheme
-	callbackFromM2.Host = parsedServerURL.Host
-
-	// Step 7: Call our /callback with provider-2's code
-	// All upstreams are now satisfied, so this should redirect to the client with an auth code (303)
-	resp, err = client.Get(callbackFromM2.String())
-	require.NoError(t, err)
-	require.Equal(t, http.StatusSeeOther, resp.StatusCode,
-		"expected 303 redirect to client with auth code (all upstreams satisfied)")
-	clientLocation, err := resp.Location()
-	require.NoError(t, err)
-	resp.Body.Close()
-
-	// === Verify the final redirect to the client ===
-
-	// Verify the original client state was preserved through the entire chain
-	returnedState := clientLocation.Query().Get("state")
-	assert.Equal(t, clientState, returnedState, "client state should be preserved through the multi-upstream chain")
-
-	// Extract authorization code
-	authCode := clientLocation.Query().Get("code")
-	require.NotEmpty(t, authCode, "authorization code should be present in the final redirect")
-
-	// === Exchange code for tokens ===
+	// runChainFlow drives the two-leg chain (authorize → provider-1 callback →
+	// provider-2 callback → 303 to client) and asserts the chain-level invariants:
+	// each leg returns the expected redirect, and client state is preserved end-to-end.
+	authCode := runChainFlow(t, ts.Server.URL, challenge, clientState)
 
 	tokenData := exchangeCodeForTokens(t, ts.Server.URL, authCode, verifier, testAudience)
 
@@ -1931,4 +1857,355 @@ func TestIntegration_MultiUpstreamSequentialChain(t *testing.T) {
 		"provider-2 UpstreamSubject should come from m2's queued user")
 	assert.NotEqual(t, tokens1.UpstreamSubject, tokens2.UpstreamSubject,
 		"upstream subjects should differ (different IDPs)")
+}
+
+// ============================================================================
+// Non-Expiring Upstream Token Regression Tests
+// ============================================================================
+
+// captureResponseWriter buffers a handler's HTTP response so a middleware can
+// inspect or rewrite it before flushing to the real ResponseWriter.
+type captureResponseWriter struct {
+	header http.Header
+	body   bytes.Buffer
+	status int
+}
+
+func newCaptureResponseWriter() *captureResponseWriter {
+	return &captureResponseWriter{header: http.Header{}, status: http.StatusOK}
+}
+
+func (c *captureResponseWriter) Header() http.Header { return c.header }
+
+func (c *captureResponseWriter) WriteHeader(status int) { c.status = status }
+
+func (c *captureResponseWriter) Write(b []byte) (int, error) { return c.body.Write(b) }
+
+// stripExpiresInMiddleware returns a middleware that, for token-endpoint
+// responses, removes the `expires_in` field from the JSON body. This emulates
+// upstream IDPs that issue non-expiring access tokens (e.g., long-lived PATs)
+// without requiring a fork of mockoidc.
+//
+// Important: this exercises the same wire shape a real provider would emit, so
+// our auth server's `convertOAuth2Token` runs with `oauth2.Token.Expiry ==
+// time.Time{}`. A regression that re-introduces a synthetic expiry there would
+// produce a non-zero `ExpiresAt` in storage and is caught by callers of this
+// helper.
+func stripExpiresInMiddleware(tokenPath string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			if req.URL.Path != tokenPath {
+				next.ServeHTTP(rw, req)
+				return
+			}
+
+			capture := newCaptureResponseWriter()
+			next.ServeHTTP(capture, req)
+
+			// Only rewrite successful JSON token responses. Errors and
+			// non-JSON bodies are passed through unchanged.
+			body := capture.body.Bytes()
+			contentType := capture.header.Get("Content-Type")
+			if capture.status == http.StatusOK && strings.Contains(contentType, "json") {
+				var payload map[string]interface{}
+				if err := json.Unmarshal(body, &payload); err == nil {
+					delete(payload, "expires_in")
+					if rewritten, err := json.Marshal(payload); err == nil {
+						body = rewritten
+						capture.header.Set("Content-Length", fmt.Sprintf("%d", len(body)))
+					}
+				}
+			}
+
+			for k, v := range capture.header {
+				rw.Header()[k] = v
+			}
+			rw.WriteHeader(capture.status)
+			_, _ = rw.Write(body)
+		})
+	}
+}
+
+// startMockOIDCNoExpiresIn starts a mockoidc instance whose token endpoint
+// responses have `expires_in` stripped, so the upstream OAuth2 client parses
+// `Expiry == time.Time{}`. The test still gets a fully working OIDC server
+// for the rest of the flow (authorize, userinfo, JWKS).
+//
+// No default user is queued; callers must call QueueUser themselves so the
+// failure mode for an unintended refresh (mockoidc returning an error because
+// no user is queued) is preserved.
+func startMockOIDCNoExpiresIn(t *testing.T) *mockoidc.MockOIDC {
+	t.Helper()
+
+	m, err := mockoidc.NewServer(nil)
+	require.NoError(t, err)
+
+	require.NoError(t, m.AddMiddleware(stripExpiresInMiddleware(mockoidc.TokenEndpoint)))
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	require.NoError(t, m.Start(ln, nil))
+
+	t.Cleanup(func() {
+		require.NoError(t, m.Shutdown())
+	})
+
+	return m
+}
+
+// TestIntegration_FullFlow_NonExpiringUpstreamToken drives the full HTTP flow
+// (authorize -> callback -> token) against an upstream IDP whose token
+// endpoint omits `expires_in`. It asserts that the upstream tokens reach
+// storage with `ExpiresAt.IsZero()` and that GetValidTokens does not trigger
+// a refresh on a non-expiring token.
+//
+// This pins the end-to-end behavior of `convertOAuth2Token`: a regression
+// that re-introduces a synthetic expiry (e.g., defaulting to time.Hour) would
+// fail the IsZero assertion below. The single queued mockoidc user is
+// consumed during /authorize; if GetValidTokens accidentally triggered a
+// refresh, mockoidc would error because no further user is queued — that
+// outcome is the failure signal.
+func TestIntegration_FullFlow_NonExpiringUpstreamToken(t *testing.T) {
+	t.Parallel()
+
+	m := startMockOIDCNoExpiresIn(t)
+	m.QueueUser(&mockoidc.MockUser{
+		Subject: "non-expiring-user",
+		Email:   "non-expiring@example.com",
+	})
+
+	ts := setupTestServerWithMockOIDC(t, m)
+
+	verifier := servercrypto.GeneratePKCEVerifier()
+	challenge := servercrypto.ComputePKCEChallenge(verifier)
+
+	authCode, _ := completeAuthorizationFlow(t, ts.Server.URL, authorizationParams{
+		ClientID:     testClientID,
+		RedirectURI:  testRedirectURI,
+		State:        "non-expiring-full-flow",
+		Challenge:    challenge,
+		Scope:        "openid profile offline_access",
+		ResponseType: "code",
+	})
+
+	tokenData := exchangeCodeForTokens(t, ts.Server.URL, authCode, verifier, testAudience)
+
+	accessToken, ok := tokenData["access_token"].(string)
+	require.True(t, ok)
+	tsid := extractTSID(t, accessToken, ts.PrivateKey.Public())
+
+	stor := ts.authServer.IDPTokenStorage()
+
+	// The upstream tokens written during /callback must carry a zero ExpiresAt:
+	// the upstream response had no expires_in, so convertOAuth2Token must
+	// preserve the zero value all the way into storage.
+	original, err := stor.GetUpstreamTokens(context.Background(), tsid, "default")
+	require.NoError(t, err)
+	require.NotNil(t, original)
+	require.NotEmpty(t, original.AccessToken)
+	assert.True(t, original.ExpiresAt.IsZero(),
+		"upstream ExpiresAt must be zero for a token response without expires_in (got %v)",
+		original.ExpiresAt)
+
+	// GetValidTokens on a non-expiring token must return the stored access
+	// token unchanged. No refresh user is queued — a refresh attempt would
+	// cause mockoidc to return an error and fail the assertion below.
+	svc := upstreamtoken.NewInProcessService(stor, ts.authServer.UpstreamTokenRefresher())
+	cred, err := svc.GetValidTokens(context.Background(), tsid, "default")
+	require.NoError(t, err)
+	require.NotNil(t, cred)
+	assert.Equal(t, original.AccessToken, cred.AccessToken,
+		"non-expiring access token must be returned unchanged (no refresh)")
+
+	// Re-read storage: ExpiresAt must still be zero, confirming no refresh
+	// side effect rewrote the row.
+	after, err := stor.GetUpstreamTokens(context.Background(), tsid, "default")
+	require.NoError(t, err)
+	assert.True(t, after.ExpiresAt.IsZero(),
+		"non-expiring token must keep zero ExpiresAt after GetValidTokens (got %v)",
+		after.ExpiresAt)
+	assert.Equal(t, original.AccessToken, after.AccessToken,
+		"access token in storage must be unchanged after GetValidTokens")
+}
+
+// runChainFlow performs the two-leg multi-upstream authorization chain and
+// returns the final authorization code redirected to the client. It mirrors
+// the hand-crafted flow in TestIntegration_MultiUpstreamSequentialChain but
+// is reused by the mixed-expiry orderings test. The PKCE verifier is the
+// caller's responsibility — it's only needed at the final /token exchange.
+func runChainFlow(
+	t *testing.T,
+	serverURL string,
+	challenge string,
+	clientState string,
+) string {
+	t.Helper()
+	client := noRedirectClient()
+
+	parsedServerURL, err := url.Parse(serverURL)
+	require.NoError(t, err)
+
+	// Leg 1: client -> /authorize -> first upstream
+	authorizeURL := serverURL + "/oauth/authorize?" + url.Values{
+		"client_id":             {testClientID},
+		"redirect_uri":          {testRedirectURI},
+		"state":                 {clientState},
+		"code_challenge":        {challenge},
+		"code_challenge_method": {"S256"},
+		"response_type":         {"code"},
+		"scope":                 {"openid profile"},
+	}.Encode()
+
+	resp, err := client.Get(authorizeURL)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusFound, resp.StatusCode)
+	firstUpstreamLocation, err := resp.Location()
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	resp, err = client.Get(firstUpstreamLocation.String())
+	require.NoError(t, err)
+	require.Equal(t, http.StatusFound, resp.StatusCode)
+	firstCallback, err := resp.Location()
+	require.NoError(t, err)
+	resp.Body.Close()
+	firstCallback.Scheme = parsedServerURL.Scheme
+	firstCallback.Host = parsedServerURL.Host
+
+	resp, err = client.Get(firstCallback.String())
+	require.NoError(t, err)
+	require.Equal(t, http.StatusFound, resp.StatusCode,
+		"expected redirect to second upstream, not 303 to client")
+	secondUpstreamLocation, err := resp.Location()
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	// Leg 2: second upstream -> callback -> client
+	resp, err = client.Get(secondUpstreamLocation.String())
+	require.NoError(t, err)
+	require.Equal(t, http.StatusFound, resp.StatusCode)
+	secondCallback, err := resp.Location()
+	require.NoError(t, err)
+	resp.Body.Close()
+	secondCallback.Scheme = parsedServerURL.Scheme
+	secondCallback.Host = parsedServerURL.Host
+
+	resp, err = client.Get(secondCallback.String())
+	require.NoError(t, err)
+	require.Equal(t, http.StatusSeeOther, resp.StatusCode,
+		"expected 303 to client after both upstreams satisfied")
+	clientLocation, err := resp.Location()
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	// Client state must be preserved through the entire chain — universal
+	// invariant of the authorization chain, asserted here so every caller benefits.
+	require.Equal(t, clientState, clientLocation.Query().Get("state"),
+		"client state should be preserved through the multi-upstream chain")
+
+	authCode := clientLocation.Query().Get("code")
+	require.NotEmpty(t, authCode)
+	return authCode
+}
+
+// TestIntegration_MultiUpstreamChain_MixedExpiryOrderings exercises the two-leg
+// authorization chain with one upstream returning expires_in and the other
+// omitting it. Both orderings must succeed and both providers' tokens must be
+// retrievable via GetAllValidTokens.
+//
+// This pins the chain handler's per-leg storage write and the
+// convertOAuth2Token zero-Expiry path through the full HTTP flow, in both
+// orderings. It does NOT exercise the Redis Lua TTL inversion fix
+// (commit fec89b040) because the in-process integration harness uses
+// storage.NewMemoryStorage(); the Lua semantics are covered directly by
+// pkg/authserver/storage/redis_test.go via miniredis.
+func TestIntegration_MultiUpstreamChain_MixedExpiryOrderings(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name                 string
+		firstUpstreamExpires bool // true => provider-1 returns expires_in; false => provider-1 omits it
+	}{
+		{name: "non_expiring_then_expiring", firstUpstreamExpires: false},
+		{name: "expiring_then_non_expiring", firstUpstreamExpires: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Build provider-1 and provider-2 mockoidc instances so the
+			// non-expiring one matches tc.firstUpstreamExpires.
+			var m1, m2 *mockoidc.MockOIDC
+			if tc.firstUpstreamExpires {
+				m1 = startMockOIDC(t)
+				m2 = startMockOIDCNoExpiresIn(t)
+			} else {
+				m1 = startMockOIDCNoExpiresIn(t)
+				m2 = startMockOIDC(t)
+			}
+
+			// Each mockoidc consumes one queued user during /authorize.
+			// startMockOIDC queues a default user; startMockOIDCNoExpiresIn
+			// does not, so we queue explicitly. Use distinct emails so the
+			// per-provider UpstreamSubject is observably different.
+			m1.QueueUser(&mockoidc.MockUser{
+				Subject: "user-from-m1-" + tc.name,
+				Email:   "u1-" + tc.name + "@m1.example.com",
+			})
+			m2.QueueUser(&mockoidc.MockUser{
+				Subject: "user-from-m2-" + tc.name,
+				Email:   "u2-" + tc.name + "@m2.example.com",
+			})
+
+			ts := setupTestServerWithTwoUpstreams(t, m1, m2)
+
+			verifier := servercrypto.GeneratePKCEVerifier()
+			challenge := servercrypto.ComputePKCEChallenge(verifier)
+
+			authCode := runChainFlow(t, ts.Server.URL, challenge, "mixed-expiry-"+tc.name)
+			tokenData := exchangeCodeForTokens(t, ts.Server.URL, authCode, verifier, testAudience)
+
+			accessToken, ok := tokenData["access_token"].(string)
+			require.True(t, ok)
+			tsid := extractTSID(t, accessToken, ts.PrivateKey.Public())
+
+			ctx := context.Background()
+			stor := ts.authServer.IDPTokenStorage()
+
+			// Both providers' tokens must be in storage. The non-expiring
+			// one must have a zero ExpiresAt; the expiring one must have a
+			// future ExpiresAt. This pins the per-leg storage write path.
+			tokens1, err := stor.GetUpstreamTokens(ctx, tsid, "provider-1")
+			require.NoError(t, err, "provider-1 tokens must be retrievable")
+			require.NotNil(t, tokens1)
+			tokens2, err := stor.GetUpstreamTokens(ctx, tsid, "provider-2")
+			require.NoError(t, err, "provider-2 tokens must be retrievable")
+			require.NotNil(t, tokens2)
+
+			if tc.firstUpstreamExpires {
+				assert.False(t, tokens1.ExpiresAt.IsZero(),
+					"provider-1 (expiring) must carry a non-zero ExpiresAt")
+				assert.True(t, tokens2.ExpiresAt.IsZero(),
+					"provider-2 (non-expiring) must carry a zero ExpiresAt")
+			} else {
+				assert.True(t, tokens1.ExpiresAt.IsZero(),
+					"provider-1 (non-expiring) must carry a zero ExpiresAt")
+				assert.False(t, tokens2.ExpiresAt.IsZero(),
+					"provider-2 (expiring) must carry a non-zero ExpiresAt")
+			}
+
+			// GetAllValidTokens must return both providers' access tokens.
+			// Before the Lua TTL fix, the non-expiring provider's index could
+			// be evicted prematurely depending on chain ordering, so this
+			// would have returned an empty or incomplete map for one
+			// ordering.
+			svc := upstreamtoken.NewInProcessService(stor, ts.authServer.UpstreamTokenRefresher())
+			all, err := svc.GetAllValidTokens(ctx, tsid)
+			require.NoError(t, err)
+			require.Len(t, all, 2, "GetAllValidTokens must return both providers regardless of expiry ordering")
+			assert.NotEmpty(t, all["provider-1"], "provider-1 access token must be present")
+			assert.NotEmpty(t, all["provider-2"], "provider-2 access token must be present")
+		})
+	}
 }

--- a/pkg/authserver/refresher.go
+++ b/pkg/authserver/refresher.go
@@ -59,14 +59,15 @@ func (r *upstreamTokenRefresher) RefreshAndStore(
 
 	// Build updated storage tokens preserving binding fields from the original
 	updated := &storage.UpstreamTokens{
-		ProviderID:      expired.ProviderID,
-		AccessToken:     newTokens.AccessToken,
-		RefreshToken:    newTokens.RefreshToken,
-		IDToken:         newTokens.IDToken,
-		ExpiresAt:       newTokens.ExpiresAt,
-		UserID:          expired.UserID,
-		UpstreamSubject: expired.UpstreamSubject,
-		ClientID:        expired.ClientID,
+		ProviderID:       expired.ProviderID,
+		AccessToken:      newTokens.AccessToken,
+		RefreshToken:     newTokens.RefreshToken,
+		IDToken:          newTokens.IDToken,
+		ExpiresAt:        newTokens.ExpiresAt,
+		SessionExpiresAt: expired.SessionExpiresAt,
+		UserID:           expired.UserID,
+		UpstreamSubject:  expired.UpstreamSubject,
+		ClientID:         expired.ClientID,
 	}
 
 	// If the provider didn't rotate the refresh token, keep the original

--- a/pkg/authserver/refresher.go
+++ b/pkg/authserver/refresher.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/stacklok/toolhive/pkg/authserver/storage"
 	"github.com/stacklok/toolhive/pkg/authserver/upstream"
@@ -18,9 +19,16 @@ import (
 // UpstreamTokenStorage (for persisting the refreshed tokens). On each refresh
 // call it dispatches to the correct provider based on the expired token's
 // ProviderID.
+//
+// refreshTokenLifespan is used as the defensive re-anchor value for
+// SessionExpiresAt when the persisted row pre-dates the unconditional callback
+// write (legacy data) and the upstream provider drops expires_in on the
+// refresh response. Without this, both bounds would be zero and the row would
+// be persisted with no TTL — see RefreshAndStore.
 type upstreamTokenRefresher struct {
-	providers map[string]upstream.OAuth2Provider
-	storage   storage.UpstreamTokenStorage
+	providers            map[string]upstream.OAuth2Provider
+	storage              storage.UpstreamTokenStorage
+	refreshTokenLifespan time.Duration
 }
 
 // Compile-time check that upstreamTokenRefresher implements storage.UpstreamTokenRefresher.
@@ -57,6 +65,25 @@ func (r *upstreamTokenRefresher) RefreshAndStore(
 		return nil, fmt.Errorf("upstream token refresh failed: %w", err)
 	}
 
+	// Defensive re-anchor of SessionExpiresAt: the post-PR callback write sets
+	// SessionExpiresAt unconditionally so it can be carried forward here as a
+	// storage TTL bound. Pre-PR rows persisted without that field decode as
+	// zero. If such a legacy row is refreshed and the upstream rotation drops
+	// expires_in, both ExpiresAt and SessionExpiresAt would be zero, the row
+	// would be stored without any TTL bound, and the Memory backend would
+	// retain it indefinitely. Re-anchor to now+RefreshTokenLifespan to restore
+	// the invariant. The Redis 30-day per-key TTL also caps the legacy
+	// behavior, but Memory has no such backstop.
+	sessionExpiresAt := expired.SessionExpiresAt
+	if sessionExpiresAt.IsZero() && newTokens.ExpiresAt.IsZero() {
+		sessionExpiresAt = time.Now().Add(r.refreshTokenLifespan)
+		slog.Debug("re-anchored zero SessionExpiresAt on refresh of legacy upstream token row",
+			"session_id", sessionID,
+			"provider_id", expired.ProviderID,
+			"refresh_token_lifespan", r.refreshTokenLifespan,
+		)
+	}
+
 	// Build updated storage tokens preserving binding fields from the original
 	updated := &storage.UpstreamTokens{
 		ProviderID:       expired.ProviderID,
@@ -64,7 +91,7 @@ func (r *upstreamTokenRefresher) RefreshAndStore(
 		RefreshToken:     newTokens.RefreshToken,
 		IDToken:          newTokens.IDToken,
 		ExpiresAt:        newTokens.ExpiresAt,
-		SessionExpiresAt: expired.SessionExpiresAt,
+		SessionExpiresAt: sessionExpiresAt,
 		UserID:           expired.UserID,
 		UpstreamSubject:  expired.UpstreamSubject,
 		ClientID:         expired.ClientID,

--- a/pkg/authserver/refresher_test.go
+++ b/pkg/authserver/refresher_test.go
@@ -149,6 +149,56 @@ func TestUpstreamTokenRefresher_RefreshAndStore(t *testing.T) {
 			},
 		},
 		{
+			// Defensive re-anchor for legacy data. Pre-PR Redis rows decode
+			// SessionExpiresAt as zero (the field was not persisted). If such a
+			// row is refreshed and the upstream rotation also drops expires_in,
+			// both bounds are zero — the row would be stored without any TTL,
+			// and the Memory backend would retain it indefinitely. The refresher
+			// must re-anchor SessionExpiresAt to now+RefreshTokenLifespan so the
+			// row carries a storage TTL bound forward.
+			name:      "re-anchors SessionExpiresAt when legacy row and provider both omit expiry",
+			sessionID: "session-legacy",
+			expired: &storage.UpstreamTokens{
+				ProviderID:       "github",
+				AccessToken:      "old-access",
+				RefreshToken:     "old-refresh",
+				IDToken:          "old-id-token",
+				ExpiresAt:        time.Time{}, // legacy row decoded with zero expiry
+				SessionExpiresAt: time.Time{}, // legacy row missing the field entirely
+				UserID:           "user-123",
+				UpstreamSubject:  "upstream-sub-456",
+				ClientID:         "client-abc",
+			},
+			setupProvider: func(_ *testing.T, p *upstreammocks.MockOAuth2Provider) {
+				p.EXPECT().RefreshTokens(gomock.Any(), "old-refresh", "upstream-sub-456").
+					Return(&upstream.Tokens{
+						AccessToken:  "new-access",
+						RefreshToken: "new-refresh",
+						IDToken:      "new-id-token",
+						// ExpiresAt intentionally zero — provider also omitted expires_in.
+					}, nil)
+			},
+			setupStorage: func(_ *testing.T, s *storagemocks.MockUpstreamTokenStorage) {
+				s.EXPECT().StoreUpstreamTokens(gomock.Any(), "session-legacy", "github", gomock.Any()).
+					DoAndReturn(func(_ context.Context, _, _ string, tokens *storage.UpstreamTokens) error {
+						assert.False(t, tokens.SessionExpiresAt.IsZero(),
+							"refresher must re-anchor SessionExpiresAt for legacy zero/zero rows")
+						assert.True(t, tokens.ExpiresAt.IsZero(),
+							"new ExpiresAt should be zero (provider omitted expires_in)")
+						// The re-anchor uses the configured lifespan (24h in this test).
+						assert.WithinDuration(t, time.Now().Add(24*time.Hour), tokens.SessionExpiresAt, time.Minute,
+							"re-anchored SessionExpiresAt should be ~now+RefreshTokenLifespan")
+						return nil
+					})
+			},
+			checkResult: func(t *testing.T, result *storage.UpstreamTokens) {
+				t.Helper()
+				assert.False(t, result.SessionExpiresAt.IsZero(),
+					"returned tokens must also carry the re-anchored SessionExpiresAt")
+				assert.True(t, result.ExpiresAt.IsZero())
+			},
+		},
+		{
 			name:           "nil expired tokens returns error",
 			sessionID:      "session-3",
 			expired:        nil,
@@ -247,8 +297,9 @@ func TestUpstreamTokenRefresher_RefreshAndStore(t *testing.T) {
 			tt.setupStorage(t, mockStorage)
 
 			refresher := &upstreamTokenRefresher{
-				providers: map[string]upstream.OAuth2Provider{"github": mockProvider},
-				storage:   mockStorage,
+				providers:            map[string]upstream.OAuth2Provider{"github": mockProvider},
+				storage:              mockStorage,
+				refreshTokenLifespan: 24 * time.Hour,
 			}
 
 			result, err := refresher.RefreshAndStore(context.Background(), tt.sessionID, tt.expired)

--- a/pkg/authserver/refresher_test.go
+++ b/pkg/authserver/refresher_test.go
@@ -23,16 +23,18 @@ func TestUpstreamTokenRefresher_RefreshAndStore(t *testing.T) {
 	t.Parallel()
 
 	newExpiry := time.Now().Add(1 * time.Hour)
+	sessionBound := time.Now().Add(7 * 24 * time.Hour)
 
 	baseExpired := &storage.UpstreamTokens{
-		ProviderID:      "github",
-		AccessToken:     "old-access",
-		RefreshToken:    "old-refresh",
-		IDToken:         "old-id-token",
-		ExpiresAt:       time.Now().Add(-1 * time.Hour),
-		UserID:          "user-123",
-		UpstreamSubject: "upstream-sub-456",
-		ClientID:        "client-abc",
+		ProviderID:       "github",
+		AccessToken:      "old-access",
+		RefreshToken:     "old-refresh",
+		IDToken:          "old-id-token",
+		ExpiresAt:        time.Now().Add(-1 * time.Hour),
+		SessionExpiresAt: sessionBound,
+		UserID:           "user-123",
+		UpstreamSubject:  "upstream-sub-456",
+		ClientID:         "client-abc",
 	}
 
 	tests := []struct {
@@ -111,6 +113,39 @@ func TestUpstreamTokenRefresher_RefreshAndStore(t *testing.T) {
 				t.Helper()
 				assert.Equal(t, "new-access", result.AccessToken)
 				assert.Equal(t, "old-refresh", result.RefreshToken)
+			},
+		},
+		{
+			// Regression for the refresh-path bound. SessionExpiresAt must be carried
+			// forward unchanged so a refresh that returns a token with zero ExpiresAt
+			// (provider stops asserting expires_in) still has a storage TTL bound.
+			// Without this, the row would be stored with no TTL and leak indefinitely.
+			name:      "preserves SessionExpiresAt when provider omits expires_in",
+			sessionID: "session-bound",
+			expired:   baseExpired,
+			setupProvider: func(_ *testing.T, p *upstreammocks.MockOAuth2Provider) {
+				p.EXPECT().RefreshTokens(gomock.Any(), "old-refresh", "upstream-sub-456").
+					Return(&upstream.Tokens{
+						AccessToken:  "new-access",
+						RefreshToken: "new-refresh",
+						// ExpiresAt intentionally zero — provider omitted expires_in.
+					}, nil)
+			},
+			setupStorage: func(_ *testing.T, s *storagemocks.MockUpstreamTokenStorage) {
+				s.EXPECT().StoreUpstreamTokens(gomock.Any(), "session-bound", "github", gomock.Any()).
+					DoAndReturn(func(_ context.Context, _, _ string, tokens *storage.UpstreamTokens) error {
+						assert.Equal(t, sessionBound, tokens.SessionExpiresAt,
+							"refresher must carry SessionExpiresAt forward unchanged")
+						assert.True(t, tokens.ExpiresAt.IsZero(),
+							"new ExpiresAt should be zero (provider omitted expires_in)")
+						return nil
+					})
+			},
+			checkResult: func(t *testing.T, result *storage.UpstreamTokens) {
+				t.Helper()
+				assert.Equal(t, sessionBound, result.SessionExpiresAt,
+					"returned tokens must also carry SessionExpiresAt forward")
+				assert.True(t, result.ExpiresAt.IsZero())
 			},
 		},
 		{

--- a/pkg/authserver/server/handlers/callback.go
+++ b/pkg/authserver/server/handlers/callback.go
@@ -128,21 +128,19 @@ func (h *Handler) CallbackHandler(w http.ResponseWriter, req *http.Request) {
 	}
 
 	// Convert IDP tokens to storage tokens with binding fields.
-	// SessionExpiresAt is only set for non-expiring upstream tokens (zero ExpiresAt).
-	// It bounds the storage lifetime to the Fosite session so tokens are evicted when
-	// the session is no longer live. For tokens with a provider-asserted ExpiresAt, the
-	// storage TTL is derived directly from that expiry and SessionExpiresAt is unused.
-	var sessionExpiresAt time.Time
-	if idpTokens.ExpiresAt.IsZero() {
-		sessionExpiresAt = time.Now().Add(h.config.RefreshTokenLifespan)
-	}
+	// SessionExpiresAt is set unconditionally as the Fosite session bound. Storage
+	// backends use it as a fallback storage lifetime when ExpiresAt is zero (a
+	// non-expiring upstream token). Setting it on every write — even when ExpiresAt
+	// is non-zero — protects the refresh path: if the upstream provider stops
+	// asserting expires_in on a later refresh, the carried-forward SessionExpiresAt
+	// still bounds the storage lifetime instead of leaving the row indefinitely.
 	storageTokens := &storage.UpstreamTokens{
 		ProviderID:       providerID,
 		AccessToken:      idpTokens.AccessToken,
 		RefreshToken:     idpTokens.RefreshToken,
 		IDToken:          idpTokens.IDToken,
 		ExpiresAt:        idpTokens.ExpiresAt,
-		SessionExpiresAt: sessionExpiresAt,
+		SessionExpiresAt: time.Now().Add(h.config.RefreshTokenLifespan),
 		ClientID:         pending.ClientID,
 		UserID:           subject,         // Internal ToolHive user ID
 		UpstreamSubject:  providerSubject, // Upstream IDP's subject claim

--- a/pkg/authserver/server/handlers/callback.go
+++ b/pkg/authserver/server/handlers/callback.go
@@ -127,16 +127,25 @@ func (h *Handler) CallbackHandler(w http.ResponseWriter, req *http.Request) {
 		h.userResolver.UpdateLastAuthenticated(ctx, providerID, providerSubject)
 	}
 
-	// Convert IDP tokens to storage tokens with binding fields
+	// Convert IDP tokens to storage tokens with binding fields.
+	// SessionExpiresAt is only set for non-expiring upstream tokens (zero ExpiresAt).
+	// It bounds the storage lifetime to the Fosite session so tokens are evicted when
+	// the session is no longer live. For tokens with a provider-asserted ExpiresAt, the
+	// storage TTL is derived directly from that expiry and SessionExpiresAt is unused.
+	var sessionExpiresAt time.Time
+	if idpTokens.ExpiresAt.IsZero() {
+		sessionExpiresAt = time.Now().Add(h.config.RefreshTokenLifespan)
+	}
 	storageTokens := &storage.UpstreamTokens{
-		ProviderID:      providerID,
-		AccessToken:     idpTokens.AccessToken,
-		RefreshToken:    idpTokens.RefreshToken,
-		IDToken:         idpTokens.IDToken,
-		ExpiresAt:       idpTokens.ExpiresAt,
-		ClientID:        pending.ClientID,
-		UserID:          subject,         // Internal ToolHive user ID
-		UpstreamSubject: providerSubject, // Upstream IDP's subject claim
+		ProviderID:       providerID,
+		AccessToken:      idpTokens.AccessToken,
+		RefreshToken:     idpTokens.RefreshToken,
+		IDToken:          idpTokens.IDToken,
+		ExpiresAt:        idpTokens.ExpiresAt,
+		SessionExpiresAt: sessionExpiresAt,
+		ClientID:         pending.ClientID,
+		UserID:           subject,         // Internal ToolHive user ID
+		UpstreamSubject:  providerSubject, // Upstream IDP's subject claim
 	}
 
 	if err := h.storage.StoreUpstreamTokens(ctx, sessionID, providerID, storageTokens); err != nil {

--- a/pkg/authserver/server_impl.go
+++ b/pkg/authserver/server_impl.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"time"
 
 	josev3 "github.com/go-jose/go-jose/v3"
 	"github.com/ory/fosite"
@@ -24,6 +25,10 @@ type server struct {
 	handler   http.Handler
 	storage   storage.Storage
 	upstreams []handlers.NamedUpstream
+	// refreshTokenLifespan mirrors the validated Config.RefreshTokenLifespan.
+	// It is threaded into upstreamTokenRefresher so the refresh path can
+	// re-anchor SessionExpiresAt for legacy storage rows missing that field.
+	refreshTokenLifespan time.Duration
 }
 
 // upstreamProviderFactory creates an upstream OAuth2Provider from configuration.
@@ -165,9 +170,10 @@ func newServer(ctx context.Context, cfg Config, stor storage.Storage, opts ...se
 	)
 
 	return &server{
-		handler:   router,
-		storage:   stor,
-		upstreams: upstreams,
+		handler:              router,
+		storage:              stor,
+		upstreams:            upstreams,
+		refreshTokenLifespan: cfg.RefreshTokenLifespan,
 	}, nil
 }
 
@@ -193,8 +199,9 @@ func (s *server) UpstreamTokenRefresher() storage.UpstreamTokenRefresher {
 		providers[u.Name] = u.Provider
 	}
 	return &upstreamTokenRefresher{
-		providers: providers,
-		storage:   s.storage,
+		providers:            providers,
+		storage:              s.storage,
+		refreshTokenLifespan: s.refreshTokenLifespan,
 	}
 }
 

--- a/pkg/authserver/storage/memory.go
+++ b/pkg/authserver/storage/memory.go
@@ -222,6 +222,10 @@ func (s *MemoryStorage) cleanupExpired() {
 
 	var expiredUpstreamTokens []upstreamKey
 	for k, v := range s.upstreamTokens {
+		// Zero expiresAt is the sentinel for "no TTL" (non-expiring token with no session
+		// bound). Other entry types never use zero expiresAt, so only upstream tokens need
+		// this guard — without it, time.Time{} would compare as before any real time and
+		// every non-expiring token would be swept on the next tick.
 		if !v.expiresAt.IsZero() && now.After(v.expiresAt) {
 			expiredUpstreamTokens = append(expiredUpstreamTokens, k)
 		}
@@ -712,21 +716,25 @@ func (s *MemoryStorage) StoreUpstreamTokens(_ context.Context, sessionID, provid
 		if !tokens.ExpiresAt.IsZero() {
 			return tokens.ExpiresAt.Add(DefaultRefreshTokenTTL)
 		}
-		return time.Time{} // non-expiring token
+		if !tokens.SessionExpiresAt.IsZero() {
+			return tokens.SessionExpiresAt.Add(DefaultRefreshTokenTTL)
+		}
+		return time.Time{} // non-expiring token with no known session bound
 	}()
 
 	// Make a defensive copy to prevent aliasing issues
 	var tokensCopy *UpstreamTokens
 	if tokens != nil {
 		tokensCopy = &UpstreamTokens{
-			ProviderID:      tokens.ProviderID,
-			AccessToken:     tokens.AccessToken,
-			RefreshToken:    tokens.RefreshToken,
-			IDToken:         tokens.IDToken,
-			ExpiresAt:       tokens.ExpiresAt,
-			UserID:          tokens.UserID,
-			UpstreamSubject: tokens.UpstreamSubject,
-			ClientID:        tokens.ClientID,
+			ProviderID:       tokens.ProviderID,
+			AccessToken:      tokens.AccessToken,
+			RefreshToken:     tokens.RefreshToken,
+			IDToken:          tokens.IDToken,
+			ExpiresAt:        tokens.ExpiresAt,
+			SessionExpiresAt: tokens.SessionExpiresAt,
+			UserID:           tokens.UserID,
+			UpstreamSubject:  tokens.UpstreamSubject,
+			ClientID:         tokens.ClientID,
 		}
 	}
 
@@ -763,14 +771,15 @@ func (s *MemoryStorage) GetUpstreamTokens(_ context.Context, sessionID, provider
 		return nil, nil
 	}
 	result := &UpstreamTokens{
-		ProviderID:      tokens.ProviderID,
-		AccessToken:     tokens.AccessToken,
-		RefreshToken:    tokens.RefreshToken,
-		IDToken:         tokens.IDToken,
-		ExpiresAt:       tokens.ExpiresAt,
-		UserID:          tokens.UserID,
-		UpstreamSubject: tokens.UpstreamSubject,
-		ClientID:        tokens.ClientID,
+		ProviderID:       tokens.ProviderID,
+		AccessToken:      tokens.AccessToken,
+		RefreshToken:     tokens.RefreshToken,
+		IDToken:          tokens.IDToken,
+		ExpiresAt:        tokens.ExpiresAt,
+		SessionExpiresAt: tokens.SessionExpiresAt,
+		UserID:           tokens.UserID,
+		UpstreamSubject:  tokens.UpstreamSubject,
+		ClientID:         tokens.ClientID,
 	}
 
 	// Check the token's own ExpiresAt (access token expiry), not the entry's expiresAt
@@ -804,14 +813,15 @@ func (s *MemoryStorage) GetAllUpstreamTokens(_ context.Context, sessionID string
 		}
 		// Defensive copy
 		result[key.providerName] = &UpstreamTokens{
-			ProviderID:      tokens.ProviderID,
-			AccessToken:     tokens.AccessToken,
-			RefreshToken:    tokens.RefreshToken,
-			IDToken:         tokens.IDToken,
-			ExpiresAt:       tokens.ExpiresAt,
-			UserID:          tokens.UserID,
-			UpstreamSubject: tokens.UpstreamSubject,
-			ClientID:        tokens.ClientID,
+			ProviderID:       tokens.ProviderID,
+			AccessToken:      tokens.AccessToken,
+			RefreshToken:     tokens.RefreshToken,
+			IDToken:          tokens.IDToken,
+			ExpiresAt:        tokens.ExpiresAt,
+			SessionExpiresAt: tokens.SessionExpiresAt,
+			UserID:           tokens.UserID,
+			UpstreamSubject:  tokens.UpstreamSubject,
+			ClientID:         tokens.ClientID,
 		}
 	}
 

--- a/pkg/authserver/storage/memory.go
+++ b/pkg/authserver/storage/memory.go
@@ -222,7 +222,7 @@ func (s *MemoryStorage) cleanupExpired() {
 
 	var expiredUpstreamTokens []upstreamKey
 	for k, v := range s.upstreamTokens {
-		if now.After(v.expiresAt) {
+		if !v.expiresAt.IsZero() && now.After(v.expiresAt) {
 			expiredUpstreamTokens = append(expiredUpstreamTokens, k)
 		}
 	}
@@ -704,12 +704,16 @@ func (s *MemoryStorage) StoreUpstreamTokens(_ context.Context, sessionID, provid
 	now := time.Now()
 	// Add DefaultRefreshTokenTTL beyond access token expiry so the refresh token
 	// survives in storage for transparent token refresh by the middleware.
-	var expiresAt time.Time
-	if tokens != nil && !tokens.ExpiresAt.IsZero() {
-		expiresAt = tokens.ExpiresAt.Add(DefaultRefreshTokenTTL)
-	} else {
-		expiresAt = now.Add(DefaultAccessTokenTTL + DefaultRefreshTokenTTL)
-	}
+	// Zero ExpiresAt means the token never expires; no TTL is applied.
+	expiresAt := func() time.Time {
+		if tokens == nil {
+			return now.Add(DefaultAccessTokenTTL + DefaultRefreshTokenTTL)
+		}
+		if !tokens.ExpiresAt.IsZero() {
+			return tokens.ExpiresAt.Add(DefaultRefreshTokenTTL)
+		}
+		return time.Time{} // non-expiring token
+	}()
 
 	// Make a defensive copy to prevent aliasing issues
 	var tokensCopy *UpstreamTokens

--- a/pkg/authserver/storage/memory_test.go
+++ b/pkg/authserver/storage/memory_test.go
@@ -846,6 +846,38 @@ func TestMemoryStorage_CleanupExpired(t *testing.T) {
 		})
 	})
 
+	t.Run("non-expiring token with SessionExpiresAt is evicted after session bound passes", func(t *testing.T) {
+		withStorage(t, func(ctx context.Context, s *MemoryStorage) {
+			err := s.StoreUpstreamTokens(ctx, "sess-1", "github", &UpstreamTokens{
+				AccessToken:      "pat-token",
+				SessionExpiresAt: time.Now().Add(-DefaultRefreshTokenTTL - time.Second),
+			})
+			require.NoError(t, err)
+			assert.Equal(t, 1, s.Stats().UpstreamTokens)
+
+			s.cleanupExpired()
+
+			assert.Equal(t, 0, s.Stats().UpstreamTokens)
+			_, getErr := s.GetUpstreamTokens(ctx, "sess-1", "github")
+			requireNotFoundError(t, getErr)
+		})
+	})
+
+	t.Run("non-expiring token with future SessionExpiresAt is kept", func(t *testing.T) {
+		withStorage(t, func(ctx context.Context, s *MemoryStorage) {
+			err := s.StoreUpstreamTokens(ctx, "sess-2", "github", &UpstreamTokens{
+				AccessToken:      "pat-token",
+				SessionExpiresAt: time.Now().Add(time.Hour),
+			})
+			require.NoError(t, err)
+			assert.Equal(t, 1, s.Stats().UpstreamTokens)
+
+			s.cleanupExpired()
+
+			assert.Equal(t, 1, s.Stats().UpstreamTokens)
+		})
+	})
+
 	t.Run("cleanup expired invalidated codes", func(t *testing.T) {
 		withStorage(t, func(ctx context.Context, s *MemoryStorage) {
 			request := newMockRequesterWithExpiration("req-1", client, fosite.AuthorizeCode, time.Now().Add(time.Hour))

--- a/pkg/authserver/storage/memory_test.go
+++ b/pkg/authserver/storage/memory_test.go
@@ -819,6 +819,33 @@ func TestMemoryStorage_CleanupExpired(t *testing.T) {
 		})
 	}
 
+	t.Run("upstream tokens with zero ExpiresAt are never evicted", func(t *testing.T) {
+		withStorage(t, func(ctx context.Context, s *MemoryStorage) {
+			// Non-expiring token (ExpiresAt zero) must survive cleanup runs.
+			_ = s.StoreUpstreamTokens(ctx, "never-expiring", "provider-a", &UpstreamTokens{
+				AccessToken: "non-expiring-token",
+				// ExpiresAt intentionally zero
+			})
+			// Expiring token to confirm cleanup still works.
+			_ = s.StoreUpstreamTokens(ctx, "expired", "provider-a", &UpstreamTokens{
+				AccessToken: "expired-token",
+				ExpiresAt:   time.Now().Add(-DefaultRefreshTokenTTL - time.Hour),
+			})
+
+			assert.Equal(t, 2, s.Stats().UpstreamTokens)
+
+			s.cleanupExpired()
+
+			assert.Equal(t, 1, s.Stats().UpstreamTokens, "only the expiring token should be removed")
+
+			tokens, err := s.GetUpstreamTokens(ctx, "never-expiring", "provider-a")
+			require.NoError(t, err)
+			require.NotNil(t, tokens)
+			assert.Equal(t, "non-expiring-token", tokens.AccessToken)
+			assert.True(t, tokens.ExpiresAt.IsZero())
+		})
+	})
+
 	t.Run("cleanup expired invalidated codes", func(t *testing.T) {
 		withStorage(t, func(ctx context.Context, s *MemoryStorage) {
 			request := newMockRequesterWithExpiration("req-1", client, fosite.AuthorizeCode, time.Now().Add(time.Hour))

--- a/pkg/authserver/storage/redis.go
+++ b/pkg/authserver/storage/redis.go
@@ -845,6 +845,16 @@ end
 --   * If ALL members are expiring, the index TTL must be at least the longest
 --     member TTL.
 --
+-- Known trade-off: an in-place rewrite of the same (sessionID, providerName)
+-- slot from non-expiring to expiring leaves the index PERSIST'd, even though
+-- the rewritten member was the sole persistence anchor. Detecting this would
+-- require tracking per-member TTL state in the index, which adds complexity.
+-- We accept the trade-off because DeleteUpstreamTokens and session GC clean
+-- the index up anyway. This behaviour is pinned by the test
+-- "same provider rewrite from non-expiring to expiring keeps PERSIST'd until
+-- rewrite" in redis_test.go — a future maintainer who tightens the rule will
+-- see that test fail and can find the rationale here.
+--
 -- We discriminate two cases that look identical AFTER SADD (both have PTTL == -1):
 --   1. A fresh set our SADD just created. We own the TTL decision unconditionally.
 --   2. An existing set previously PERSIST'd by a non-expiring member. Must stay

--- a/pkg/authserver/storage/redis.go
+++ b/pkg/authserver/storage/redis.go
@@ -836,20 +836,42 @@ else
     redis.call('SET', KEYS[1], ARGV[1])
 end
 
--- Add the per-provider key to the session index set
+-- Maintain the session index set's TTL.
+--
+-- Invariant: the index set must outlive every per-provider key it points to.
+--   * If ANY member is non-expiring (ttlMs == 0), the index set must also be
+--     persistent. Otherwise the index evicts and we lose the ability to find
+--     (and clean up) the per-provider key, leaking it forever.
+--   * If ALL members are expiring, the index TTL must be at least the longest
+--     member TTL.
+--
+-- We discriminate two cases that look identical AFTER SADD (both have PTTL == -1):
+--   1. A fresh set our SADD just created. We own the TTL decision unconditionally.
+--   2. An existing set previously PERSIST'd by a non-expiring member. Must stay
+--      persistent — applying a TTL here is the bug this script must avoid.
+--
+-- The trick: read EXISTS BEFORE SADD. SADD creates the set as a side-effect,
+-- so post-SADD any "no TTL" state is ambiguous; pre-SADD it is not.
+local idxExisted = redis.call('EXISTS', KEYS[2])
 redis.call('SADD', KEYS[2], KEYS[1])
--- Keep the index set alive at least as long as the token
-if ttlMs > 0 then
-    local currentTTL = redis.call('PTTL', KEYS[2])
-    if currentTTL < ttlMs then
+
+if ttlMs == 0 then
+    -- This member never expires. Make the index persistent (no-op if already so).
+    redis.call('PERSIST', KEYS[2])
+elseif idxExisted == 0 then
+    -- Fresh set; our SADD created it. Apply our TTL.
+    redis.call('PEXPIRE', KEYS[2], ttlMs)
+else
+    -- Existing set; its TTL summarises prior members.
+    local idxTTL = redis.call('PTTL', KEYS[2])
+    if idxTTL == -1 then
+        -- A previous non-expiring write PERSIST'd it. Leave it alone —
+        -- applying a TTL here is the bug we are fixing.
+    elseif idxTTL < ttlMs then
+        -- Existing TTL is shorter than this member's. Extend.
         redis.call('PEXPIRE', KEYS[2], ttlMs)
     end
-else
-    -- ttlMs == 0: this token does not expire. Remove any TTL that a prior
-    -- expiring-token write may have set on the index set (SADD does not
-    -- reset TTL), so the index set is not evicted while this non-expiring
-    -- token still exists. PERSIST is a no-op if the key has no TTL.
-    redis.call('PERSIST', KEYS[2])
+    -- else: idxTTL >= ttlMs, index already outlives this member.
 end
 
 local newUserID = ARGV[3]

--- a/pkg/authserver/storage/redis.go
+++ b/pkg/authserver/storage/redis.go
@@ -840,6 +840,12 @@ if ttlMs > 0 then
     if currentTTL < ttlMs then
         redis.call('PEXPIRE', KEYS[2], ttlMs)
     end
+else
+    -- ttlMs == 0: this token does not expire. Remove any TTL that a prior
+    -- expiring-token write may have set on the index set (SADD does not
+    -- reset TTL), so the index set is not evicted while this non-expiring
+    -- token still exists. PERSIST is a no-op if the key has no TTL.
+    redis.call('PERSIST', KEYS[2])
 end
 
 local newUserID = ARGV[3]
@@ -887,7 +893,9 @@ func marshalUpstreamTokensWithTTL(tokens *UpstreamTokens) ([]byte, time.Duration
 
 	// Add DefaultRefreshTokenTTL beyond access token expiry so the refresh token
 	// survives in storage for transparent token refresh by the middleware.
-	ttl := DefaultAccessTokenTTL + DefaultRefreshTokenTTL
+	// Zero ExpiresAt means the token never expires; return ttl=0 so the Lua script
+	// stores the key without a Redis TTL.
+	var ttl time.Duration // zero means no Redis TTL (non-expiring token)
 	if !tokens.ExpiresAt.IsZero() {
 		ttl = time.Until(tokens.ExpiresAt) + DefaultRefreshTokenTTL
 		if ttl < 0 {

--- a/pkg/authserver/storage/redis.go
+++ b/pkg/authserver/storage/redis.go
@@ -793,15 +793,19 @@ func (s *RedisStorage) DeletePKCERequestSession(ctx context.Context, signature s
 // -----------------------
 
 // storedUpstreamTokens is a serializable wrapper for UpstreamTokens.
+// Time fields use int64 Unix epoch; 0 is the sentinel meaning "not set".
+// Neither time field uses omitempty so that 0 is always present and the
+// read path can use a consistent != 0 check for both.
 type storedUpstreamTokens struct {
-	ProviderID      string `json:"provider_id"`
-	AccessToken     string `json:"access_token"`  //nolint:gosec // G117: field legitimately holds sensitive data
-	RefreshToken    string `json:"refresh_token"` //nolint:gosec // G117: field legitimately holds sensitive data
-	IDToken         string `json:"id_token"`
-	ExpiresAt       int64  `json:"expires_at"`
-	UserID          string `json:"user_id"`
-	UpstreamSubject string `json:"upstream_subject"`
-	ClientID        string `json:"client_id"`
+	ProviderID       string `json:"provider_id"`
+	AccessToken      string `json:"access_token"`  //nolint:gosec // G117: field legitimately holds sensitive data
+	RefreshToken     string `json:"refresh_token"` //nolint:gosec // G117: field legitimately holds sensitive data
+	IDToken          string `json:"id_token"`
+	ExpiresAt        int64  `json:"expires_at"`
+	SessionExpiresAt int64  `json:"session_expires_at"`
+	UserID           string `json:"user_id"`
+	UpstreamSubject  string `json:"upstream_subject"`
+	ClientID         string `json:"client_id"`
 }
 
 // storeUpstreamTokensScript atomically reads the existing UserID, writes new token
@@ -875,15 +879,21 @@ func marshalUpstreamTokensWithTTL(tokens *UpstreamTokens) ([]byte, time.Duration
 		expiresAtUnix = tokens.ExpiresAt.Unix()
 	}
 
+	var sessionExpiresAtUnix int64
+	if !tokens.SessionExpiresAt.IsZero() {
+		sessionExpiresAtUnix = tokens.SessionExpiresAt.Unix()
+	}
+
 	stored := storedUpstreamTokens{
-		ProviderID:      tokens.ProviderID,
-		AccessToken:     tokens.AccessToken,
-		RefreshToken:    tokens.RefreshToken,
-		IDToken:         tokens.IDToken,
-		ExpiresAt:       expiresAtUnix,
-		UserID:          tokens.UserID,
-		UpstreamSubject: tokens.UpstreamSubject,
-		ClientID:        tokens.ClientID,
+		ProviderID:       tokens.ProviderID,
+		AccessToken:      tokens.AccessToken,
+		RefreshToken:     tokens.RefreshToken,
+		IDToken:          tokens.IDToken,
+		ExpiresAt:        expiresAtUnix,
+		SessionExpiresAt: sessionExpiresAtUnix,
+		UserID:           tokens.UserID,
+		UpstreamSubject:  tokens.UpstreamSubject,
+		ClientID:         tokens.ClientID,
 	}
 
 	data, err := json.Marshal(stored) //nolint:gosec // G117 - internal Redis storage serialization, not exposed to users
@@ -895,11 +905,18 @@ func marshalUpstreamTokensWithTTL(tokens *UpstreamTokens) ([]byte, time.Duration
 	// survives in storage for transparent token refresh by the middleware.
 	// Zero ExpiresAt means the token never expires; return ttl=0 so the Lua script
 	// stores the key without a Redis TTL.
-	var ttl time.Duration // zero means no Redis TTL (non-expiring token)
+	var ttl time.Duration // zero means no Redis TTL (non-expiring token with no known session bound)
 	if !tokens.ExpiresAt.IsZero() {
 		ttl = time.Until(tokens.ExpiresAt) + DefaultRefreshTokenTTL
-		if ttl < 0 {
-			ttl = DefaultRefreshTokenTTL
+		if ttl <= 0 {
+			// Access token and its refresh grace period have both passed — evict promptly.
+			ttl = time.Second
+		}
+	} else if !tokens.SessionExpiresAt.IsZero() {
+		ttl = time.Until(tokens.SessionExpiresAt) + DefaultRefreshTokenTTL
+		if ttl <= 0 {
+			// Session bound and its refresh grace period have both passed — evict promptly.
+			ttl = time.Second
 		}
 	}
 
@@ -1111,15 +1128,21 @@ func unmarshalUpstreamTokens(data []byte) (*UpstreamTokens, error) {
 		expired = time.Now().After(expiresAt)
 	}
 
+	var sessionExpiresAt time.Time
+	if stored.SessionExpiresAt != 0 {
+		sessionExpiresAt = time.Unix(stored.SessionExpiresAt, 0)
+	}
+
 	tokens := &UpstreamTokens{
-		ProviderID:      stored.ProviderID,
-		AccessToken:     stored.AccessToken,
-		RefreshToken:    stored.RefreshToken,
-		IDToken:         stored.IDToken,
-		ExpiresAt:       expiresAt,
-		UserID:          stored.UserID,
-		UpstreamSubject: stored.UpstreamSubject,
-		ClientID:        stored.ClientID,
+		ProviderID:       stored.ProviderID,
+		AccessToken:      stored.AccessToken,
+		RefreshToken:     stored.RefreshToken,
+		IDToken:          stored.IDToken,
+		ExpiresAt:        expiresAt,
+		SessionExpiresAt: sessionExpiresAt,
+		UserID:           stored.UserID,
+		UpstreamSubject:  stored.UpstreamSubject,
+		ClientID:         stored.ClientID,
 	}
 
 	// Return tokens along with ErrExpired so callers can use the refresh token

--- a/pkg/authserver/storage/redis_test.go
+++ b/pkg/authserver/storage/redis_test.go
@@ -643,10 +643,10 @@ func TestRedisStorage_UpstreamTokens(t *testing.T) {
 		})
 	})
 
-	t.Run("zero ExpiresAt tokens are retrievable (no expiry)", func(t *testing.T) {
-		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, _ *miniredis.Miniredis) {
-			// Store tokens with zero ExpiresAt (no expiry set).
-			// These should be retrievable — Redis TTL handles actual expiration.
+	t.Run("zero ExpiresAt tokens are stored without Redis TTL", func(t *testing.T) {
+		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, mr *miniredis.Miniredis) {
+			// Non-expiring tokens (ExpiresAt zero) must be stored without a Redis TTL
+			// so they are never automatically evicted.
 			require.NoError(t, s.StoreUpstreamTokens(ctx, "no-expiry", "provider-a", &UpstreamTokens{
 				AccessToken: "no-expiry-token",
 				ProviderID:  "test-provider",
@@ -658,6 +658,35 @@ func TestRedisStorage_UpstreamTokens(t *testing.T) {
 			assert.Equal(t, "no-expiry-token", retrieved.AccessToken)
 			assert.Equal(t, "test-provider", retrieved.ProviderID)
 			assert.True(t, retrieved.ExpiresAt.IsZero())
+
+			// Verify the key has no Redis TTL (miniredis returns 0 for keys without expiry).
+			key := redisUpstreamKey(s.keyPrefix, "no-expiry", "provider-a")
+			assert.Equal(t, time.Duration(0), mr.TTL(key), "non-expiring token must have no Redis TTL")
+		})
+	})
+
+	t.Run("mixed-expiry session: non-expiring write removes index set TTL", func(t *testing.T) {
+		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, mr *miniredis.Miniredis) {
+			// First store an expiring token — this sets a TTL on the index set.
+			err := s.StoreUpstreamTokens(ctx, "mixed-session", "provider-expiring", &UpstreamTokens{
+				AccessToken: "expiring-token",
+				ProviderID:  "provider-expiring",
+				ExpiresAt:   time.Now().Add(time.Hour),
+			})
+			require.NoError(t, err)
+
+			// Then store a non-expiring token for the same session.
+			err = s.StoreUpstreamTokens(ctx, "mixed-session", "provider-nonexpiring", &UpstreamTokens{
+				AccessToken: "non-expiring-token",
+				ProviderID:  "provider-nonexpiring",
+				// ExpiresAt intentionally zero
+			})
+			require.NoError(t, err)
+
+			// The index set must now have no TTL (PERSIST removed it).
+			idxKey := redisSetKey(s.keyPrefix, KeyTypeUpstreamIdx, "mixed-session")
+			assert.Equal(t, time.Duration(0), mr.TTL(idxKey),
+				"index set TTL must be removed when a non-expiring token is added to the session")
 		})
 	})
 

--- a/pkg/authserver/storage/redis_test.go
+++ b/pkg/authserver/storage/redis_test.go
@@ -863,6 +863,50 @@ func TestRedisStorage_UpstreamTokens(t *testing.T) {
 		})
 	})
 
+	t.Run("deeply stale ExpiresAt branch clamps TTL to one second", func(t *testing.T) {
+		// Regression guard for the clamp introduced in marshalUpstreamTokensWithTTL.
+		// Pre-fix, a token whose access expiry + DefaultRefreshTokenTTL had both
+		// elapsed was stored with a full 30-day grace (DefaultRefreshTokenTTL),
+		// retaining stale tokens far longer than necessary.  The fix clamps to
+		// time.Second so deeply-stale rows evict promptly.  Cold-path callers
+		// (refresher races, admin rewrites, legacy-row migrations) must observe
+		// the 1-second lifetime — not the old 30-day grace — so this test pins
+		// the behavior and will fail loudly if the clamp is reverted.
+		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, mr *miniredis.Miniredis) {
+			stalePast := time.Now().Add(-(DefaultRefreshTokenTTL + time.Hour))
+			require.NoError(t, s.StoreUpstreamTokens(ctx, "stale-expires-session", "provider-a", &UpstreamTokens{
+				AccessToken: "stale-token",
+				ProviderID:  "provider-a",
+				ExpiresAt:   stalePast,
+			}))
+
+			key := redisUpstreamKey(s.keyPrefix, "stale-expires-session", "provider-a")
+			assert.LessOrEqual(t, mr.TTL(key), 2*time.Second,
+				"deeply-stale ExpiresAt token must be stored with a 1s TTL, not the full DefaultRefreshTokenTTL grace")
+		})
+	})
+
+	t.Run("deeply stale SessionExpiresAt branch clamps TTL to one second", func(t *testing.T) {
+		// Mirror of the previous subtest for the SessionExpiresAt branch.
+		// When ExpiresAt is zero but SessionExpiresAt + DefaultRefreshTokenTTL
+		// have both elapsed, the same clamp must apply so that session-bound
+		// non-expiring tokens (e.g. GitHub PATs) don't linger for 30 days after
+		// the session itself has long expired.
+		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, mr *miniredis.Miniredis) {
+			stalePast := time.Now().Add(-(DefaultRefreshTokenTTL + time.Hour))
+			require.NoError(t, s.StoreUpstreamTokens(ctx, "stale-session-expires-session", "github", &UpstreamTokens{
+				AccessToken:      "stale-pat",
+				ProviderID:       "github",
+				SessionExpiresAt: stalePast,
+				// ExpiresAt intentionally zero — exercises the SessionExpiresAt branch
+			}))
+
+			key := redisUpstreamKey(s.keyPrefix, "stale-session-expires-session", "github")
+			assert.LessOrEqual(t, mr.TTL(key), 2*time.Second,
+				"deeply-stale SessionExpiresAt token must be stored with a 1s TTL, not the full DefaultRefreshTokenTTL grace")
+		})
+	})
+
 	t.Run("nil tokens is valid", func(t *testing.T) {
 		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, _ *miniredis.Miniredis) {
 			require.NoError(t, s.StoreUpstreamTokens(ctx, "session-id", "provider-a", nil))

--- a/pkg/authserver/storage/redis_test.go
+++ b/pkg/authserver/storage/redis_test.go
@@ -1012,6 +1012,46 @@ func TestRedisStorage_UpstreamTokens(t *testing.T) {
 		})
 	})
 
+	t.Run("legacy JSON without session_expires_at decodes with zero SessionExpiresAt", func(t *testing.T) {
+		// Pin the wire-shape contract: pre-PR Redis data that has no
+		// "session_expires_at" key must deserialise to SessionExpiresAt.IsZero().
+		// A future DisallowUnknownFields flip or JSON tag rename would break this
+		// without failing any other test in the suite.
+		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, mr *miniredis.Miniredis) {
+			futureExpiry := time.Now().Add(time.Hour).Unix()
+			legacyJSON := fmt.Sprintf(`{
+				"provider_id": "github",
+				"access_token": "legacy-access",
+				"refresh_token": "legacy-refresh",
+				"id_token": "legacy-id",
+				"expires_at": %d,
+				"user_id": "legacy-user-uuid",
+				"upstream_subject": "github-sub-123",
+				"client_id": "legacy-client"
+			}`, futureExpiry)
+
+			// Inject directly into miniredis, bypassing the Store path, to simulate
+			// a pre-PR row written without "session_expires_at".
+			key := redisUpstreamKey(s.keyPrefix, "legacy-session", "github")
+			require.NoError(t, mr.Set(key, legacyJSON))
+
+			retrieved, err := s.GetUpstreamTokens(ctx, "legacy-session", "github")
+			require.NoError(t, err)
+			require.NotNil(t, retrieved)
+
+			assert.Equal(t, "github", retrieved.ProviderID)
+			assert.Equal(t, "legacy-access", retrieved.AccessToken)
+			assert.Equal(t, "legacy-refresh", retrieved.RefreshToken)
+			assert.Equal(t, "legacy-id", retrieved.IDToken)
+			assert.Equal(t, "legacy-user-uuid", retrieved.UserID)
+			assert.Equal(t, "github-sub-123", retrieved.UpstreamSubject)
+			assert.Equal(t, "legacy-client", retrieved.ClientID)
+			assert.Equal(t, time.Unix(futureExpiry, 0), retrieved.ExpiresAt)
+			assert.True(t, retrieved.SessionExpiresAt.IsZero(),
+				"SessionExpiresAt must be zero when absent from legacy JSON")
+		})
+	})
+
 }
 
 // --- Bulk Migration Tests ---

--- a/pkg/authserver/storage/redis_test.go
+++ b/pkg/authserver/storage/redis_test.go
@@ -690,6 +690,151 @@ func TestRedisStorage_UpstreamTokens(t *testing.T) {
 		})
 	})
 
+	t.Run("mixed-expiry session: expiring write after non-expiring keeps index persistent", func(t *testing.T) {
+		// Regression test for the inverse ordering of the prior subtest. When a
+		// non-expiring token is written first and an expiring token follows, the
+		// Lua script must NOT re-apply a TTL to the index set — that would evict
+		// the index and orphan the non-expiring token's per-provider key.
+		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, mr *miniredis.Miniredis) {
+			// Non-expiring first: index gets PERSIST'd.
+			err := s.StoreUpstreamTokens(ctx, "inverse-session", "provider-nonexpiring", &UpstreamTokens{
+				AccessToken: "non-expiring-token",
+				ProviderID:  "provider-nonexpiring",
+				// ExpiresAt intentionally zero
+			})
+			require.NoError(t, err)
+
+			// Expiring second: must NOT re-apply a TTL.
+			err = s.StoreUpstreamTokens(ctx, "inverse-session", "provider-expiring", &UpstreamTokens{
+				AccessToken: "expiring-token",
+				ProviderID:  "provider-expiring",
+				ExpiresAt:   time.Now().Add(time.Hour),
+			})
+			require.NoError(t, err)
+
+			idxKey := redisSetKey(s.keyPrefix, KeyTypeUpstreamIdx, "inverse-session")
+			assert.Equal(t, time.Duration(0), mr.TTL(idxKey),
+				"index set TTL must remain unset after an expiring write follows a non-expiring one")
+
+			// Fast-forward past the expiring token's TTL. The expiring per-provider
+			// key evicts; the non-expiring one remains; the index stays intact.
+			mr.FastForward(time.Hour + DefaultRefreshTokenTTL + time.Second)
+
+			all, err := s.GetAllUpstreamTokens(ctx, "inverse-session")
+			require.NoError(t, err)
+			require.Contains(t, all, "provider-nonexpiring",
+				"non-expiring token must remain reachable through the index")
+			assert.NotContains(t, all, "provider-expiring",
+				"expiring token must have been evicted by Redis TTL")
+		})
+	})
+
+	t.Run("fresh expiring write applies index TTL", func(t *testing.T) {
+		// Regression guard: the Lua script must apply a TTL on the very first
+		// expiring write to a session (where the index set is being created
+		// fresh by the SADD). Without this, the index would never expire.
+		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, mr *miniredis.Miniredis) {
+			require.NoError(t, s.StoreUpstreamTokens(ctx, "fresh-session", "provider-a", &UpstreamTokens{
+				AccessToken: "expiring-token",
+				ProviderID:  "provider-a",
+				ExpiresAt:   time.Now().Add(time.Hour),
+			}))
+
+			idxKey := redisSetKey(s.keyPrefix, KeyTypeUpstreamIdx, "fresh-session")
+			ttl := mr.TTL(idxKey)
+			assert.Greater(t, ttl, time.Duration(0),
+				"index set must have a TTL after a fresh expiring write")
+		})
+	})
+
+	t.Run("longer expiring write after shorter extends index TTL", func(t *testing.T) {
+		// Locks down the idxTTL < ttlMs branch: when a member with longer TTL
+		// is added, the index TTL must be extended to match.
+		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, mr *miniredis.Miniredis) {
+			require.NoError(t, s.StoreUpstreamTokens(ctx, "extend-session", "provider-short", &UpstreamTokens{
+				AccessToken: "short-token",
+				ProviderID:  "provider-short",
+				ExpiresAt:   time.Now().Add(15 * time.Minute),
+			}))
+
+			idxKey := redisSetKey(s.keyPrefix, KeyTypeUpstreamIdx, "extend-session")
+			shortTTL := mr.TTL(idxKey)
+			require.Greater(t, shortTTL, time.Duration(0))
+
+			// Add a member with a much longer TTL.
+			require.NoError(t, s.StoreUpstreamTokens(ctx, "extend-session", "provider-long", &UpstreamTokens{
+				AccessToken: "long-token",
+				ProviderID:  "provider-long",
+				ExpiresAt:   time.Now().Add(24 * time.Hour),
+			}))
+
+			longTTL := mr.TTL(idxKey)
+			assert.Greater(t, longTTL, shortTTL,
+				"index TTL must be extended when a longer-lived member is added")
+		})
+	})
+
+	t.Run("shorter expiring write after longer leaves index TTL unchanged", func(t *testing.T) {
+		// Locks down the idxTTL >= ttlMs no-op branch: shorter-TTL members must
+		// not shrink the index — the longest-lived member governs.
+		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, mr *miniredis.Miniredis) {
+			require.NoError(t, s.StoreUpstreamTokens(ctx, "noshrink-session", "provider-long", &UpstreamTokens{
+				AccessToken: "long-token",
+				ProviderID:  "provider-long",
+				ExpiresAt:   time.Now().Add(24 * time.Hour),
+			}))
+
+			idxKey := redisSetKey(s.keyPrefix, KeyTypeUpstreamIdx, "noshrink-session")
+			longTTL := mr.TTL(idxKey)
+			require.Greater(t, longTTL, time.Duration(0))
+
+			// Add a member with a shorter TTL.
+			require.NoError(t, s.StoreUpstreamTokens(ctx, "noshrink-session", "provider-short", &UpstreamTokens{
+				AccessToken: "short-token",
+				ProviderID:  "provider-short",
+				ExpiresAt:   time.Now().Add(15 * time.Minute),
+			}))
+
+			afterTTL := mr.TTL(idxKey)
+			// Allow tiny clock-drift tolerance: TTL must not have shrunk meaningfully.
+			assert.GreaterOrEqual(t, afterTTL, longTTL-time.Second,
+				"index TTL must not shrink when a shorter-lived member is added")
+		})
+	})
+
+	t.Run("same provider rewrite from non-expiring to expiring keeps PERSIST'd until rewrite", func(t *testing.T) {
+		// When the SAME provider rewrites from non-expiring to expiring, the
+		// index set is no longer intentionally persistent (the only non-expiring
+		// member is gone). With the current "leave PERSIST'd alone" rule, the
+		// index stays without a TTL until something else evicts the entry. This
+		// is acceptable for now — documented limitation, not a leak in practice
+		// because DeleteUpstreamTokens cleans up the whole session.
+		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, mr *miniredis.Miniredis) {
+			require.NoError(t, s.StoreUpstreamTokens(ctx, "rewrite-session", "provider-a", &UpstreamTokens{
+				AccessToken: "non-expiring",
+				ProviderID:  "provider-a",
+			}))
+			require.NoError(t, s.StoreUpstreamTokens(ctx, "rewrite-session", "provider-a", &UpstreamTokens{
+				AccessToken: "now-expiring",
+				ProviderID:  "provider-a",
+				ExpiresAt:   time.Now().Add(time.Hour),
+			}))
+
+			idxKey := redisSetKey(s.keyPrefix, KeyTypeUpstreamIdx, "rewrite-session")
+			// Pre-existing PERSIST is preserved; we accept this trade-off rather
+			// than tracking per-member TTL state in Lua. DeleteUpstreamTokens
+			// remains the cleanup path.
+			assert.Equal(t, time.Duration(0), mr.TTL(idxKey),
+				"index TTL is left alone on same-provider rewrite (acceptable limitation)")
+
+			// The new value is reachable.
+			retrieved, err := s.GetUpstreamTokens(ctx, "rewrite-session", "provider-a")
+			require.NoError(t, err)
+			require.NotNil(t, retrieved)
+			assert.Equal(t, "now-expiring", retrieved.AccessToken)
+		})
+	})
+
 	t.Run("non-expiring token with SessionExpiresAt gets proper Redis TTL", func(t *testing.T) {
 		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, mr *miniredis.Miniredis) {
 			sessionExpiry := time.Now().Add(time.Hour)

--- a/pkg/authserver/storage/redis_test.go
+++ b/pkg/authserver/storage/redis_test.go
@@ -690,6 +690,34 @@ func TestRedisStorage_UpstreamTokens(t *testing.T) {
 		})
 	})
 
+	t.Run("non-expiring token with SessionExpiresAt gets proper Redis TTL", func(t *testing.T) {
+		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, mr *miniredis.Miniredis) {
+			sessionExpiry := time.Now().Add(time.Hour)
+			require.NoError(t, s.StoreUpstreamTokens(ctx, "sess-bound", "github", &UpstreamTokens{
+				AccessToken:      "pat-token",
+				ProviderID:       "github",
+				SessionExpiresAt: sessionExpiry,
+			}))
+
+			retrieved, err := s.GetUpstreamTokens(ctx, "sess-bound", "github")
+			require.NoError(t, err)
+			require.NotNil(t, retrieved)
+			assert.Equal(t, "pat-token", retrieved.AccessToken)
+			assert.True(t, retrieved.ExpiresAt.IsZero(), "ExpiresAt must remain zero for non-expiring token")
+			// Assert field survives JSON round-trip (Unix truncation → 1s tolerance).
+			// RefreshAndStore carries SessionExpiresAt forward; silent zeroing here
+			// would cause every token refresh to lose the session bound.
+			assert.WithinDuration(t, sessionExpiry, retrieved.SessionExpiresAt, time.Second,
+				"SessionExpiresAt must survive Store→Get round-trip")
+
+			// Fast-forward past SessionExpiresAt + DefaultRefreshTokenTTL
+			mr.FastForward(time.Hour + DefaultRefreshTokenTTL + time.Second)
+
+			_, err = s.GetUpstreamTokens(ctx, "sess-bound", "github")
+			requireRedisNotFoundError(t, err)
+		})
+	})
+
 	t.Run("nil tokens is valid", func(t *testing.T) {
 		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, _ *miniredis.Miniredis) {
 			require.NoError(t, s.StoreUpstreamTokens(ctx, "session-id", "provider-a", nil))

--- a/pkg/authserver/storage/types.go
+++ b/pkg/authserver/storage/types.go
@@ -64,9 +64,12 @@ type UpstreamTokens struct {
 	// ExpiresAt is when the access token expires. Zero value means the provider
 	// did not assert an expiry; callers must treat it as non-expiring.
 	ExpiresAt time.Time
-	// SessionExpiresAt is the Fosite session expiry time. When set and ExpiresAt is
-	// zero (non-expiring upstream token), storage backends use this as the maximum
-	// storage lifetime so tokens are evicted when the session is no longer live.
+	// SessionExpiresAt is the Fosite session expiry time, set on every write by
+	// the callback handler. Storage backends use it as a fallback storage lifetime
+	// when ExpiresAt is zero (non-expiring upstream token), bounding the row to the
+	// Fosite session. Set unconditionally — including for tokens with their own
+	// ExpiresAt — so the refresh path is safe even if the upstream provider stops
+	// asserting expires_in on a later rotation.
 	SessionExpiresAt time.Time
 
 	// Security binding fields - validated on lookup to prevent cross-session attacks

--- a/pkg/authserver/storage/types.go
+++ b/pkg/authserver/storage/types.go
@@ -64,6 +64,10 @@ type UpstreamTokens struct {
 	// ExpiresAt is when the access token expires. Zero value means the provider
 	// did not assert an expiry; callers must treat it as non-expiring.
 	ExpiresAt time.Time
+	// SessionExpiresAt is the Fosite session expiry time. When set and ExpiresAt is
+	// zero (non-expiring upstream token), storage backends use this as the maximum
+	// storage lifetime so tokens are evicted when the session is no longer live.
+	SessionExpiresAt time.Time
 
 	// Security binding fields - validated on lookup to prevent cross-session attacks
 
@@ -86,6 +90,10 @@ type UpstreamTokens struct {
 // Returns true for nil receivers (treating nil tokens as expired).
 // Zero ExpiresAt means the provider did not assert an expiry; returns false.
 // The now parameter allows for deterministic testing.
+//
+// This method is intended for storage eviction decisions only — it checks exact
+// expiry with no preemptive buffer. For "should I refresh before using?" decisions,
+// use upstream.Tokens.IsExpiredAt which includes a preemptive buffer window.
 func (t *UpstreamTokens) IsExpired(now time.Time) bool {
 	if t == nil {
 		return true

--- a/pkg/authserver/storage/types.go
+++ b/pkg/authserver/storage/types.go
@@ -61,7 +61,9 @@ type UpstreamTokens struct {
 	AccessToken  string //nolint:gosec // G117: field legitimately holds sensitive data
 	RefreshToken string //nolint:gosec // G117: field legitimately holds sensitive data
 	IDToken      string
-	ExpiresAt    time.Time
+	// ExpiresAt is when the access token expires. Zero value means the provider
+	// did not assert an expiry; callers must treat it as non-expiring.
+	ExpiresAt time.Time
 
 	// Security binding fields - validated on lookup to prevent cross-session attacks
 
@@ -81,9 +83,14 @@ type UpstreamTokens struct {
 }
 
 // IsExpired returns true if the access token has expired.
+// Returns true for nil receivers (treating nil tokens as expired).
+// Zero ExpiresAt means the provider did not assert an expiry; returns false.
 // The now parameter allows for deterministic testing.
 func (t *UpstreamTokens) IsExpired(now time.Time) bool {
-	return now.After(t.ExpiresAt)
+	if t == nil {
+		return true
+	}
+	return !t.ExpiresAt.IsZero() && now.After(t.ExpiresAt)
 }
 
 // User represents a user account in the authorization server.

--- a/pkg/authserver/storage/types.go
+++ b/pkg/authserver/storage/types.go
@@ -64,9 +64,12 @@ type UpstreamTokens struct {
 	// ExpiresAt is when the access token expires. Zero value means the provider
 	// did not assert an expiry; callers must treat it as non-expiring.
 	ExpiresAt time.Time
-	// SessionExpiresAt is the Fosite session expiry time, set on every write by
-	// the callback handler. Storage backends use it as a fallback storage lifetime
-	// when ExpiresAt is zero (non-expiring upstream token), bounding the row to the
+	// SessionExpiresAt is the Fosite session expiry time. The callback handler
+	// sets it from RefreshTokenLifespan on every initial write; the refresher
+	// carries it forward unchanged on each subsequent refresh, and defensively
+	// re-anchors it on legacy rows where both ExpiresAt and SessionExpiresAt
+	// are zero. Storage backends use it as a fallback storage lifetime when
+	// ExpiresAt is zero (non-expiring upstream token), bounding the row to the
 	// Fosite session. Set unconditionally — including for tokens with their own
 	// ExpiresAt — so the refresh path is safe even if the upstream provider stops
 	// asserting expires_in on a later rotation.

--- a/pkg/authserver/storage/types_test.go
+++ b/pkg/authserver/storage/types_test.go
@@ -61,10 +61,10 @@ func TestUpstreamTokens_IsExpired(t *testing.T) {
 			want:      false,
 		},
 		{
-			name:      "expired - zero expiration time",
+			name:      "zero expiration time treated as non-expiring",
 			expiresAt: time.Time{},
 			checkTime: now,
-			want:      true,
+			want:      false,
 		},
 		{
 			name:      "not expired - zero check time with future expiration",

--- a/pkg/authserver/upstream/oauth2.go
+++ b/pkg/authserver/upstream/oauth2.go
@@ -449,7 +449,7 @@ func (p *BaseOAuth2Provider) exchangeCodeForTokens(ctx context.Context, code, co
 
 	slog.Debug("authorization code exchange successful",
 		"has_refresh_token", tokens.RefreshToken != "",
-		"expires_at", tokens.ExpiresAt,
+		"expires_at", expiresAtLogValue(tokens.ExpiresAt),
 	)
 
 	return tokens, nil
@@ -489,7 +489,7 @@ func (p *BaseOAuth2Provider) RefreshTokens(ctx context.Context, refreshToken, _ 
 
 	slog.Debug("token refresh successful",
 		"has_new_refresh_token", tokens.RefreshToken != "",
-		"expires_at", tokens.ExpiresAt,
+		"expires_at", expiresAtLogValue(tokens.ExpiresAt),
 	)
 
 	return tokens, nil

--- a/pkg/authserver/upstream/oauth2.go
+++ b/pkg/authserver/upstream/oauth2.go
@@ -90,9 +90,6 @@ type OAuth2Provider interface {
 	RefreshTokens(ctx context.Context, refreshToken, expectedSubject string) (*Tokens, error)
 }
 
-// defaultTokenExpiration is the default token lifetime when expires_in is not specified.
-const defaultTokenExpiration = time.Hour
-
 // CommonOAuthConfig contains fields shared by all OAuth provider types.
 // This provides compile-time type safety by separating OIDC and OAuth2 configuration.
 type CommonOAuthConfig struct {
@@ -220,13 +217,6 @@ func convertOAuth2Token(token *oauth2.Token) (*Tokens, error) {
 		return nil, fmt.Errorf("unexpected token_type: expected \"Bearer\", got %q", token.TokenType)
 	}
 
-	// Calculate expiration time
-	expiresAt := token.Expiry
-	if expiresAt.IsZero() {
-		// Default to 1 hour if not specified
-		expiresAt = time.Now().Add(defaultTokenExpiration)
-	}
-
 	// Extract ID token from extras (OIDC providers include it here)
 	var idToken string
 	if idTokenVal := token.Extra("id_token"); idTokenVal != nil {
@@ -239,7 +229,7 @@ func convertOAuth2Token(token *oauth2.Token) (*Tokens, error) {
 		AccessToken:  token.AccessToken,
 		RefreshToken: token.RefreshToken,
 		IDToken:      idToken,
-		ExpiresAt:    expiresAt,
+		ExpiresAt:    token.Expiry,
 	}, nil
 }
 
@@ -457,9 +447,9 @@ func (p *BaseOAuth2Provider) exchangeCodeForTokens(ctx context.Context, code, co
 		return nil, err
 	}
 
-	slog.Info("authorization code exchange successful",
+	slog.Debug("authorization code exchange successful",
 		"has_refresh_token", tokens.RefreshToken != "",
-		"expires_at", tokens.ExpiresAt.Format(time.RFC3339),
+		"expires_at", tokens.ExpiresAt,
 	)
 
 	return tokens, nil
@@ -497,9 +487,9 @@ func (p *BaseOAuth2Provider) RefreshTokens(ctx context.Context, refreshToken, _ 
 		return nil, err
 	}
 
-	slog.Info("token refresh successful",
+	slog.Debug("token refresh successful",
 		"has_new_refresh_token", tokens.RefreshToken != "",
-		"expires_at", tokens.ExpiresAt.Format(time.RFC3339),
+		"expires_at", tokens.ExpiresAt,
 	)
 
 	return tokens, nil

--- a/pkg/authserver/upstream/oauth2_test.go
+++ b/pkg/authserver/upstream/oauth2_test.go
@@ -627,7 +627,7 @@ func TestBaseOAuth2Provider_exchangeCodeForTokens(t *testing.T) {
 		assert.Contains(t, err.Error(), "unexpected token_type")
 	})
 
-	t.Run("default expiry when not specified", func(t *testing.T) {
+	t.Run("zero expiry when expires_in absent", func(t *testing.T) {
 		t.Parallel()
 
 		mock := newMockOAuth2Server()
@@ -638,7 +638,7 @@ func TestBaseOAuth2Provider_exchangeCodeForTokens(t *testing.T) {
 			resp := testTokenResponse{
 				AccessToken: "token",
 				TokenType:   "Bearer",
-				// ExpiresIn intentionally missing
+				// ExpiresIn intentionally missing — provider issues a non-expiring token
 			}
 			if err := json.NewEncoder(w).Encode(resp); err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -661,9 +661,8 @@ func TestBaseOAuth2Provider_exchangeCodeForTokens(t *testing.T) {
 		tokens, err := provider.exchangeCodeForTokens(ctx, "test-code", "")
 		require.NoError(t, err)
 
-		// Should default to 1 hour
-		expectedExpiry := time.Now().Add(time.Hour)
-		assert.WithinDuration(t, expectedExpiry, tokens.ExpiresAt, 10*time.Second)
+		// No expires_in in the response means the token has no expiry.
+		assert.True(t, tokens.ExpiresAt.IsZero(), "ExpiresAt should be zero for non-expiring tokens")
 	})
 }
 

--- a/pkg/authserver/upstream/oidc.go
+++ b/pkg/authserver/upstream/oidc.go
@@ -11,7 +11,6 @@ import (
 	"net/http"
 	"net/url"
 	"slices"
-	"time"
 
 	"github.com/coreos/go-oidc/v3/oidc"
 	"golang.org/x/oauth2"
@@ -263,7 +262,7 @@ func (p *OIDCProviderImpl) ExchangeCodeForIdentity(
 	slog.Debug("authorization code exchange successful",
 		"has_refresh_token", tokens.RefreshToken != "",
 		"has_id_token", tokens.IDToken != "",
-		"expires_at", tokens.ExpiresAt.Format(time.RFC3339),
+		"expires_at", expiresAtLogValue(tokens.ExpiresAt),
 	)
 
 	// Extract optional standard claims (name, email) from ID token
@@ -409,7 +408,7 @@ func (p *OIDCProviderImpl) RefreshTokens(ctx context.Context, refreshToken, expe
 
 	slog.Debug("token refresh successful",
 		"has_new_refresh_token", tokens.RefreshToken != "",
-		"expires_at", tokens.ExpiresAt.Format(time.RFC3339),
+		"expires_at", expiresAtLogValue(tokens.ExpiresAt),
 	)
 
 	return tokens, nil

--- a/pkg/authserver/upstream/tokens.go
+++ b/pkg/authserver/upstream/tokens.go
@@ -35,7 +35,8 @@ type Tokens struct {
 	// IDToken is the ID token from the upstream IDP (for OIDC).
 	IDToken string
 
-	// ExpiresAt is when the access token expires.
+	// ExpiresAt is when the access token expires. Zero value means the provider
+	// did not assert an expiry; callers must treat it as non-expiring.
 	ExpiresAt time.Time
 }
 
@@ -51,6 +52,9 @@ func (t *Tokens) IsExpired() bool {
 func (t *Tokens) IsExpiredAt(now time.Time) bool {
 	if t == nil {
 		return true
+	}
+	if t.ExpiresAt.IsZero() {
+		return false
 	}
 	// Token is expired if it expires at or before (now + buffer)
 	// Using !After to include the equality case (expires exactly at boundary)

--- a/pkg/authserver/upstream/tokens.go
+++ b/pkg/authserver/upstream/tokens.go
@@ -15,6 +15,7 @@
 package upstream
 
 import (
+	"log/slog"
 	"time"
 )
 
@@ -59,4 +60,20 @@ func (t *Tokens) IsExpiredAt(now time.Time) bool {
 	// Token is expired if it expires at or before (now + buffer)
 	// Using !After to include the equality case (expires exactly at boundary)
 	return !t.ExpiresAt.After(now.Add(tokenExpirationBuffer))
+}
+
+// expiresAtLogValue is a slog.LogValuer wrapper for an ExpiresAt time that
+// renders zero time as "none" rather than the misleading year-0001 timestamp
+// slog would otherwise produce. As a LogValuer, formatting is deferred until
+// the log record is actually emitted, so DEBUG logs do no work when the
+// handler level filters them out.
+type expiresAtLogValue time.Time
+
+// LogValue implements slog.LogValuer.
+func (e expiresAtLogValue) LogValue() slog.Value {
+	t := time.Time(e)
+	if t.IsZero() {
+		return slog.StringValue("none")
+	}
+	return slog.StringValue(t.Format(time.RFC3339))
 }

--- a/pkg/authserver/upstream/tokens_test.go
+++ b/pkg/authserver/upstream/tokens_test.go
@@ -63,6 +63,11 @@ func TestTokens_IsExpired(t *testing.T) {
 			expiresAt: now.Add(1 * time.Hour),
 			want:      false,
 		},
+		{
+			name:      "zero ExpiresAt treated as non-expiring",
+			expiresAt: time.Time{},
+			want:      false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

Users authenticated with non-expiring upstream providers (GitHub OAuth Apps, Slack user tokens, Vault, on-prem providers without `expires_in`) hit a forced re-authentication every 60 minutes. The auth server fabricated a 1h `ExpiresAt` for any token that lacked `expires_in`, then treated those tokens as expired, attempted to refresh them with refresh tokens that didn't exist, hit `ErrNoRefreshToken`, and dropped the provider from downstream responses with `omitting provider with unrefreshable expired token`.

A second silent failure compounded the first: in multi-upstream chains that combined a non-expiring provider with an expiring one (e.g., GitHub PAT + Google), the Redis session-index set could be evicted while the non-expiring per-provider key was still alive — `GetAllUpstreamTokens` would silently drop the non-expiring provider exactly an hour after the session started.

This PR:

- Removes the fabricated 1h `ExpiresAt` in `convertOAuth2Token`. Tokens without `expires_in` flow through with zero `ExpiresAt`.
- Fixes `IsExpired`/`IsExpiredAt` to treat zero `ExpiresAt` as non-expiring (was: returned true → trapped tokens in the cascade).
- Stops storage backends from evicting zero-`ExpiresAt` tokens.
- Adds `SessionExpiresAt` to `UpstreamTokens` as a Fosite-session-bound storage TTL fallback so non-expiring tokens have a finite storage lifetime even when the upstream asserts none. Set unconditionally on every callback so the refresh path is safe even if a provider stops asserting `expires_in` on a later rotation.
- Fixes a Lua TTL inversion in `storeUpstreamTokensScript` that re-applied a TTL to a `PERSIST`'d session index, silently orphaning non-expiring tokens after a subsequent expiring write to the same session.
- Guards the `expires_at` log fields against zero-time formatting (was: emitted `0001-01-01T00:00:00Z`). Now uses a `slog.LogValuer` that lazy-renders to `"none"` for zero time, RFC 3339 otherwise.

Closes #5046

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)
- [x] Race detector (`go test -race ./pkg/authserver/...`) — clean
- [ ] E2E tests (`task test-e2e`) — not run; no change at the CLI/operator boundary

New regression coverage:

- `TestRedisStorage_UpstreamTokens/mixed-expiry_session:_expiring_write_after_non-expiring_keeps_index_persistent` — the Lua bug
- `TestRedisStorage_UpstreamTokens/fresh_expiring_write_applies_index_TTL` — guards the discrimination between fresh-set and PERSIST'd-set
- `TestRedisStorage_UpstreamTokens/longer_expiring_write_after_shorter_extends_index_TTL` and `/shorter_expiring_write_after_longer_leaves_index_TTL_unchanged` — lock down the comparator
- `TestUpstreamTokenRefresher_RefreshAndStore/preserves_SessionExpiresAt_when_provider_omits_expires_in` — refresh-path bound
- `TestIntegration_UpstreamTokenService_NonExpiringToken` — end-to-end regression for the original cascade

## API Compatibility

- [x] This PR does not break the `v1beta1` API.

## Does this introduce a user-facing change?

Yes. Suggested release note:

> Fixes a regression where MCP sessions using non-expiring upstream providers (GitHub OAuth Apps, Slack user tokens, Vault) were forced into hourly re-authentication. Also fixes a silent partial-token-loss in multi-upstream chains where the session index could be evicted before its non-expiring members.

## Special notes for reviewers

- **Scope**: this branch fixes #5046 and a related index-eviction bug. It does **not** fix #5047 (re-authorization orphans Google refresh tokens). #5047 is a structural bug requiring a storage rekey from `(SessionID, providerName)` to `(UserID, providerName)`, which is being designed in a separate RFC and will land as a follow-on PR sequence. This branch is a strict improvement on its own and is forward-compatible with the rekey.
- **The Lua change** in `pkg/authserver/storage/redis.go` (commit `fec89b040`) is the most subtle. The control flow is structured as a decision keyed on `(ttlMs, idxExisted, idxTTL)`. The trick is reading `EXISTS` *before* `SADD` — after `SADD` the set always exists, so a fresh-set and a previously-`PERSIST`'d set are indistinguishable from `PTTL` alone. Inline comments flag the bug-prone branch (`idxTTL == -1` after pre-existing set).
- **Commit-by-commit review** is intentional: each commit is self-contained and the messages explain motivation. The history was rebased to fold MoE-review fixups into their parents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Large PR Justification

- there's a lot of tests, mostly