### PR TITLE
ci(release): mint GitHub App installation token instead of RELEASE_TOKEN PAT

### DIFF
--- a/.claude/skills/toolhive-release/references/WORKFLOW-REFERENCE.md
+++ b/.claude/skills/toolhive-release/references/WORKFLOW-REFERENCE.md
@@ -68,11 +68,13 @@ Detailed documentation of the ToolHive release workflow chain.
    - Version in commit message matches VERSION file
 3. Check if tag already exists (skip if so)
 4. Create annotated git tag `vX.Y.Z`
-5. Push tag using `RELEASE_TOKEN` (PAT required to trigger downstream workflows)
+5. Push tag using a GitHub App installation token (required to trigger downstream workflows; `GITHUB_TOKEN`-authored events do not)
 6. Create GitHub Release with auto-generated notes
 
 **Requirements**:
-- `RELEASE_TOKEN` secret (PAT with repo access)
+- GitHub App installed on the repo with `contents: write` permission
+- `RELEASE_APP_CLIENT_ID` repository **variable** (the app's Client ID)
+- `RELEASE_APP_PRIVATE_KEY` repository **secret** (the app's private key in PEM)
 
 ## Workflow 3: releaser.yml
 
@@ -162,7 +164,8 @@ If a previous Create Release PR run failed after creating the branch but before 
 ### Tag creation fails
 
 - Tag may already exist: `git tag | grep vX.Y.Z`
-- RELEASE_TOKEN may be expired or lack permissions
+- Release GitHub App may be uninstalled, or the `RELEASE_APP_CLIENT_ID` variable / `RELEASE_APP_PRIVATE_KEY` secret may be missing or stale
+- App may lack `contents: write` permission on the repo
 
 ### Releaser workflow fails
 

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -30,6 +30,13 @@ jobs:
     name: Create Release PR
     runs-on: ubuntu-latest
     steps:
+      - name: Generate release app token
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -73,7 +80,7 @@ jobs:
         with:
           releaseo_version: v0.0.4
           bump_type: ${{ inputs.bump_type }}
-          token: ${{ secrets.RELEASE_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           version_files: |
             - file: deploy/charts/operator-crds/Chart.yaml
               path: version

--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -20,6 +20,13 @@ jobs:
   create-tag:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate release app token
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -134,7 +141,7 @@ jobs:
           git push https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git "$TAG"
           echo "Created and pushed tag: $TAG"
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Check if GitHub Release exists
         id: check-release
@@ -148,7 +155,7 @@ jobs:
             echo "exists=false" >> $GITHUB_OUTPUT
           fi
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Create GitHub Release
         if: steps.check-release.outputs.exists == 'false'
@@ -157,7 +164,8 @@ jobs:
           TRIGGERED_BY="${{ steps.actor.outputs.triggered_by }}"
 
           # Create GitHub Release (triggers releaser.yml via release event)
-          # Note: Must use PAT (GH_TOKEN) because GITHUB_TOKEN cannot trigger other workflows
+          # Note: Uses a GitHub App installation token rather than GITHUB_TOKEN,
+          # because events from GITHUB_TOKEN cannot trigger downstream workflows.
           # Include actor metadata as HTML comment if available (parsed by releaser.yml)
           if [ -n "$TRIGGERED_BY" ]; then
             gh release create "$TAG" \
@@ -171,7 +179,7 @@ jobs:
           fi
           echo "Created GitHub Release: $TAG"
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Summary
         run: |


### PR DESCRIPTION
## Summary

- Replace the long-lived `RELEASE_TOKEN` PAT with a GitHub App installation token minted via [`actions/create-github-app-token@v3.1.1`](https://github.com/actions/create-github-app-token) in `create-release-pr.yml` and `create-release-tag.yml`.
- Update the `toolhive-release` skill reference docs to describe the new app-based setup and replace the PAT-rotation guidance.
- Installation tokens are short-lived (1h) and repo-scoped, while still satisfying the constraint that `GITHUB_TOKEN` cannot trigger downstream workflows (e.g. `releaser.yml`).

## Pre-merge configuration (required)

The release workflows will fail until the following are configured on this repo:

1. Install the release GitHub App on `stacklok/toolhive` with repository permissions:
   - `contents: write` (for the tag workflow)
   - `pull-requests: write` (for the release PR workflow)
2. Set repository **variable** `RELEASE_APP_CLIENT_ID` to the app's Client ID.
3. Set repository **secret** `RELEASE_APP_PRIVATE_KEY` to the app's private key (PEM).

## Post-merge cleanup

- Delete the now-unused `RELEASE_TOKEN` repository secret from repo settings.

## Test plan

- [ ] Verify GitHub App is installed on `stacklok/toolhive` with required permissions.
- [ ] Verify `vars.RELEASE_APP_CLIENT_ID` and `secrets.RELEASE_APP_PRIVATE_KEY` are set on the repo.
- [ ] Trigger `Create Release PR` (patch bump) once via `workflow_dispatch` and confirm the PR is opened by the App actor.
- [ ] Merge that release PR and confirm `create-release-tag.yml` succeeds, the tag is pushed, and the GitHub Release is published, triggering `releaser.yml`.
- [ ] After successful release, delete the `RELEASE_TOKEN` repo secret.

Closes #4835

🤖 Generated with [Claude Code](https://claude.com/claude-code)