### PR TITLE
fix(test): use require instead of assert in TestBuildServerConfig to prevent nil panic

### DIFF
--- a/pkg/mcp/server/handler_test.go
+++ b/pkg/mcp/server/handler_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	regtypes "github.com/stacklok/toolhive-core/registry/types"
 	"github.com/stacklok/toolhive/pkg/runner"
@@ -340,11 +341,11 @@ func TestBuildServerConfig(t *testing.T) {
 			runConfig, err := buildServerConfig(ctx, args, tt.imageURL, tt.imageMetadata, tt.extraOpts...)
 
 			if tt.expectError {
-				assert.Error(t, err)
-				assert.Nil(t, runConfig)
+				require.Error(t, err)
+				require.Nil(t, runConfig)
 			} else {
-				assert.NoError(t, err)
-				assert.NotNil(t, runConfig)
+				require.NoError(t, err)
+				require.NotNil(t, runConfig)
 				if tt.checkConfig != nil {
 					tt.checkConfig(t, runConfig)
 				}


### PR DESCRIPTION
## Summary

`TestBuildServerConfig` in `pkg/mcp/server/handler_test.go` panics with a nil pointer dereference (SIGSEGV) when no container runtime (Docker/Podman) is available. This crashes the entire test binary and masks results from other test packages.

The test uses `assert.NoError` (which continues on failure) instead of `require.NoError` (which stops the test). When `buildServerConfig` returns `(nil, error)`, execution falls through to `tt.checkConfig(t, nil)`, causing the panic.

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`go test -c ./pkg/mcp/server/` — compiles successfully)

## Does this introduce a user-facing change?

No.

## Special notes for reviewers

This is a test-only change with zero production code impact. The fix follows standard Go testing best practices: use `require` for assertions that, if failed, would cause subsequent code to panic or behave incorrectly.

Fixes #4760