### PR TITLE
Wire MCPRemoteProxy resourceOverrides.proxyDeployment.imagePullSecrets

### DIFF
--- a/cmd/thv-operator/controllers/mcpremoteproxy_controller.go
+++ b/cmd/thv-operator/controllers/mcpremoteproxy_controller.go
@@ -1087,12 +1087,22 @@ func (r *MCPRemoteProxyReconciler) ensureRBACResources(ctx context.Context, prox
 	// Ensure Role with minimal permissions for remote proxies
 	// Remote proxies only need ConfigMap and Secret read access (no StatefulSet/Pod management)
 	_, err := rbacClient.EnsureRBACResources(ctx, rbac.EnsureRBACResourcesParams{
-		Name:      proxyRunnerNameForRBAC,
-		Namespace: proxy.Namespace,
-		Rules:     remoteProxyRBACRules,
-		Owner:     proxy,
+		Name:             proxyRunnerNameForRBAC,
+		Namespace:        proxy.Namespace,
+		Rules:            remoteProxyRBACRules,
+		Owner:            proxy,
+		ImagePullSecrets: imagePullSecretsForRemoteProxy(proxy),
 	})
 	return err
+}
+
+// imagePullSecretsForRemoteProxy returns the image pull secrets configured via
+// spec.resourceOverrides.proxyDeployment.imagePullSecrets, or nil if unset.
+func imagePullSecretsForRemoteProxy(proxy *mcpv1beta1.MCPRemoteProxy) []corev1.LocalObjectReference {
+	if proxy.Spec.ResourceOverrides == nil || proxy.Spec.ResourceOverrides.ProxyDeployment == nil {
+		return nil
+	}
+	return proxy.Spec.ResourceOverrides.ProxyDeployment.ImagePullSecrets
 }
 
 // updateMCPRemoteProxyStatus updates the status of the MCPRemoteProxy

--- a/cmd/thv-operator/controllers/mcpremoteproxy_controller_test.go
+++ b/cmd/thv-operator/controllers/mcpremoteproxy_controller_test.go
@@ -1108,6 +1108,68 @@ func TestMCPRemoteProxyEnsureRBACResources_CustomServiceAccount(t *testing.T) {
 	assert.Error(t, err, "RoleBinding should not be created when custom ServiceAccount is provided")
 }
 
+// TestMCPRemoteProxyEnsureRBACResources_ImagePullSecrets verifies that
+// spec.resourceOverrides.proxyDeployment.imagePullSecrets propagates to both
+// the proxy-runner Deployment and ServiceAccount (regression for #5099).
+func TestMCPRemoteProxyEnsureRBACResources_ImagePullSecrets(t *testing.T) {
+	t.Parallel()
+
+	proxy := &mcpv1beta1.MCPRemoteProxy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pull-secrets-proxy",
+			Namespace: "default",
+		},
+		Spec: mcpv1beta1.MCPRemoteProxySpec{
+			RemoteURL: "https://mcp.example.com",
+			ProxyPort: 8080,
+			ResourceOverrides: &mcpv1beta1.ResourceOverrides{
+				ProxyDeployment: &mcpv1beta1.ProxyDeploymentOverrides{
+					ImagePullSecrets: []corev1.LocalObjectReference{
+						{Name: "my-registry-secret"},
+					},
+				},
+			},
+		},
+	}
+
+	scheme := createRunConfigTestScheme()
+	_ = rbacv1.AddToScheme(scheme)
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithRuntimeObjects(proxy).
+		Build()
+
+	reconciler := &MCPRemoteProxyReconciler{
+		Client:           fakeClient,
+		Scheme:           scheme,
+		PlatformDetector: ctrlutil.NewSharedPlatformDetector(),
+	}
+
+	err := reconciler.ensureRBACResources(t.Context(), proxy)
+	require.NoError(t, err)
+
+	expectedSecrets := []corev1.LocalObjectReference{
+		{Name: "my-registry-secret"},
+	}
+
+	// ServiceAccount must carry the image pull secrets so kubelet can pull
+	// images using the SA's token reference.
+	sa := &corev1.ServiceAccount{}
+	err = fakeClient.Get(t.Context(), types.NamespacedName{
+		Name:      proxyRunnerServiceAccountNameForRemoteProxy(proxy.Name),
+		Namespace: proxy.Namespace,
+	}, sa)
+	require.NoError(t, err)
+	assert.Equal(t, expectedSecrets, sa.ImagePullSecrets)
+
+	// Deployment pod spec must also carry them so the pod-level setting is
+	// applied even when the SA reference is overridden.
+	dep := reconciler.deploymentForMCPRemoteProxy(t.Context(), proxy, "test-checksum")
+	require.NotNil(t, dep)
+	assert.Equal(t, expectedSecrets, dep.Spec.Template.Spec.ImagePullSecrets)
+}
+
 // TestUpdateMCPRemoteProxyStatus tests status update logic
 func TestUpdateMCPRemoteProxyStatus(t *testing.T) {
 	t.Parallel()

--- a/cmd/thv-operator/controllers/mcpremoteproxy_deployment.go
+++ b/cmd/thv-operator/controllers/mcpremoteproxy_deployment.go
@@ -72,6 +72,7 @@ func (r *MCPRemoteProxyReconciler) deploymentForMCPRemoteProxy(
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName: serviceAccountNameForRemoteProxy(proxy),
+					ImagePullSecrets:   imagePullSecretsForRemoteProxy(proxy),
 					Containers: []corev1.Container{{
 						Image:           getToolhiveRunnerImage(),
 						Name:            "toolhive",


### PR DESCRIPTION
## Summary

- The `MCPRemoteProxy` CRD shares the `ResourceOverrides` Go type with `MCPServer`, so its schema accepts `spec.resourceOverrides.proxyDeployment.imagePullSecrets`. The `MCPRemoteProxy` controller never reads that field, so users configuring private-registry credentials silently got no effect: the proxy-runner Deployment and ServiceAccount were created with no image pull secrets, and image pulls failed against authenticated registries.
- Mirror the `MCPServer` wiring: extract `ImagePullSecrets` from `ResourceOverrides` via a small helper, pass it to `rbac.EnsureRBACResourcesParams` (so the controller-managed proxy-runner ServiceAccount carries the secrets) and set it on the proxy-runner Deployment's pod spec.
- Add `TestMCPRemoteProxyEnsureRBACResources_ImagePullSecrets` covering both observable surfaces (Deployment pod spec and ServiceAccount).

Fixes #5099

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)

## API Compatibility

- [x] This PR does not break the `v1beta1` API, OR the `api-break-allowed` label is applied and the migration guidance is described above.

## Does this introduce a user-facing change?

Yes. `MCPRemoteProxy` resources that already set `spec.resourceOverrides.proxyDeployment.imagePullSecrets` will now correctly propagate those secrets to the proxy-runner Deployment and ServiceAccount, so private-registry image pulls succeed without further changes.

Generated with [Claude Code](https://claude.com/claude-code)