### PR TITLE
Preserve user fields in EmbeddingServer podTemplateSpec merge

### DIFF
--- a/cmd/thv-operator/controllers/embeddingserver_controller.go
+++ b/cmd/thv-operator/controllers/embeddingserver_controller.go
@@ -7,6 +7,7 @@ package controllers
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"maps"
 	"reflect"
@@ -21,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -396,7 +398,7 @@ func (r *EmbeddingServerReconciler) validateAndUpdatePodTemplateStatus(
 
 // statefulSetForEmbedding creates a StatefulSet for the embedding server
 func (r *EmbeddingServerReconciler) statefulSetForEmbedding(
-	_ context.Context,
+	ctx context.Context,
 	embedding *mcpv1beta1.EmbeddingServer,
 ) *appsv1.StatefulSet {
 	replicas := embedding.GetReplicas()
@@ -436,6 +438,14 @@ func (r *EmbeddingServerReconciler) statefulSetForEmbedding(
 	// Add volumeClaimTemplates if model caching is enabled
 	if embedding.IsModelCacheEnabled() {
 		statefulSet.Spec.VolumeClaimTemplates = r.buildVolumeClaimTemplates(embedding)
+	}
+
+	// Apply user-provided PodTemplateSpec customizations via strategic merge patch.
+	// This must happen after the controller-generated template is fully populated so
+	// that user fields override controller defaults rather than the other way around.
+	if err := r.applyPodTemplateSpecToStatefulSet(ctx, embedding, statefulSet); err != nil {
+		log.FromContext(ctx).Error(err, "Failed to apply PodTemplateSpec to StatefulSet")
+		return nil
 	}
 
 	if err := ctrl.SetControllerReference(embedding, statefulSet, r.Scheme); err != nil {
@@ -634,13 +644,17 @@ func (*EmbeddingServerReconciler) applyResourceRequirements(embedding *mcpv1beta
 	}
 }
 
-// buildPodTemplate builds the pod template for the statefulset
-func (r *EmbeddingServerReconciler) buildPodTemplate(
-	embedding *mcpv1beta1.EmbeddingServer,
+// buildPodTemplate builds the pod template for the statefulset.
+// User-provided PodTemplateSpec customizations are applied later in
+// statefulSetForEmbedding via strategic merge patch.
+func (*EmbeddingServerReconciler) buildPodTemplate(
+	_ *mcpv1beta1.EmbeddingServer,
 	labels map[string]string,
 	container corev1.Container,
 ) corev1.PodTemplateSpec {
-	podTemplate := corev1.PodTemplateSpec{
+	// Note: Volumes for model cache are managed by StatefulSet volumeClaimTemplates
+	// and will be automatically mounted with the name "model-cache"
+	return corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: labels,
 		},
@@ -648,73 +662,60 @@ func (r *EmbeddingServerReconciler) buildPodTemplate(
 			Containers: []corev1.Container{container},
 		},
 	}
-
-	// Note: Volumes for model cache are managed by StatefulSet volumeClaimTemplates
-	// and will be automatically mounted with the name "model-cache"
-
-	// Merge with user-provided PodTemplateSpec if specified
-	r.mergePodTemplateSpec(embedding, &podTemplate)
-
-	return podTemplate
 }
 
-// mergePodTemplateSpec merges user-provided PodTemplateSpec customizations
-func (r *EmbeddingServerReconciler) mergePodTemplateSpec(
+// applyPodTemplateSpecToStatefulSet applies user-provided PodTemplateSpec customizations
+// to the StatefulSet's pod template using strategic merge patch. This preserves every
+// user-supplied PodSpec field (imagePullSecrets, additional volumes, priorityClassName,
+// topologySpreadConstraints, init containers, sidecars, etc.) while keeping controller
+// defaults for fields the user did not set.
+//
+// The raw user JSON is used as the patch input (rather than re-marshaling a parsed
+// PodTemplateSpec). This avoids Go's `json.Marshal` turning nil slices into `[]`, which
+// strategic merge patch interprets as "replace with empty" and would clobber controller
+// defaults.
+func (*EmbeddingServerReconciler) applyPodTemplateSpecToStatefulSet(
+	ctx context.Context,
 	embedding *mcpv1beta1.EmbeddingServer,
-	podTemplate *corev1.PodTemplateSpec,
-) {
-	if embedding.Spec.PodTemplateSpec == nil {
-		return
+	statefulSet *appsv1.StatefulSet,
+) error {
+	if embedding.Spec.PodTemplateSpec == nil || len(embedding.Spec.PodTemplateSpec.Raw) == 0 {
+		return nil
 	}
 
-	builder, err := ctrlutil.NewPodTemplateSpecBuilder(embedding.Spec.PodTemplateSpec, embeddingContainerName)
+	// Validate the user-provided PodTemplateSpec is well-formed JSON.
+	// We don't check builder.Build() == nil for "empty" customizations: that helper
+	// only enumerates a subset of PodSpec fields and would skip the patch for
+	// fields like runtimeClassName or topologySpreadConstraints. Strategic merge
+	// patch is a no-op for `{}` anyway, so always running it is safe.
+	if _, err := ctrlutil.NewPodTemplateSpecBuilder(embedding.Spec.PodTemplateSpec, embeddingContainerName); err != nil {
+		return fmt.Errorf("failed to build PodTemplateSpec: %w", err)
+	}
+
+	userJSON := embedding.Spec.PodTemplateSpec.Raw
+
+	originalJSON, err := json.Marshal(statefulSet.Spec.Template)
 	if err != nil {
-		return
+		return fmt.Errorf("failed to marshal original PodTemplateSpec: %w", err)
 	}
 
-	userTemplate := builder.Build()
-	if userTemplate == nil {
-		return
+	patchedJSON, err := strategicpatch.StrategicMergePatch(originalJSON, userJSON, corev1.PodTemplateSpec{})
+	if err != nil {
+		return fmt.Errorf("failed to apply strategic merge patch: %w", err)
 	}
 
-	// Merge user customizations into base pod template
-	if userTemplate.Spec.NodeSelector != nil {
-		podTemplate.Spec.NodeSelector = userTemplate.Spec.NodeSelector
-	}
-	if userTemplate.Spec.Affinity != nil {
-		podTemplate.Spec.Affinity = userTemplate.Spec.Affinity
-	}
-	if len(userTemplate.Spec.Tolerations) > 0 {
-		podTemplate.Spec.Tolerations = userTemplate.Spec.Tolerations
-	}
-	if userTemplate.Spec.SecurityContext != nil {
-		podTemplate.Spec.SecurityContext = userTemplate.Spec.SecurityContext
-	}
-	if userTemplate.Spec.ServiceAccountName != "" {
-		podTemplate.Spec.ServiceAccountName = userTemplate.Spec.ServiceAccountName
+	var patchedPodTemplateSpec corev1.PodTemplateSpec
+	if err := json.Unmarshal(patchedJSON, &patchedPodTemplateSpec); err != nil {
+		return fmt.Errorf("failed to unmarshal patched PodTemplateSpec: %w", err)
 	}
 
-	// Merge container-level customizations
-	r.mergeContainerSecurityContext(podTemplate, userTemplate)
-}
+	statefulSet.Spec.Template = patchedPodTemplateSpec
 
-// mergeContainerSecurityContext merges container-level security context
-func (*EmbeddingServerReconciler) mergeContainerSecurityContext(
-	podTemplate *corev1.PodTemplateSpec,
-	userTemplate *corev1.PodTemplateSpec,
-) {
-	for i := range podTemplate.Spec.Containers {
-		if podTemplate.Spec.Containers[i].Name != embeddingContainerName {
-			continue
-		}
-		for _, userContainer := range userTemplate.Spec.Containers {
-			if userContainer.Name == embeddingContainerName && userContainer.SecurityContext != nil {
-				podTemplate.Spec.Containers[i].SecurityContext = userContainer.SecurityContext
-				break
-			}
-		}
-		break
-	}
+	log.FromContext(ctx).V(1).Info("Applied PodTemplateSpec customizations to StatefulSet",
+		"embeddingserver", embedding.Name,
+		"namespace", embedding.Namespace)
+
+	return nil
 }
 
 // applyStatefulSetOverrides applies statefulset-level overrides and returns annotations and labels

--- a/cmd/thv-operator/controllers/embeddingserver_controller.go
+++ b/cmd/thv-operator/controllers/embeddingserver_controller.go
@@ -7,7 +7,6 @@ package controllers
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"maps"
 	"reflect"
@@ -22,7 +21,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -408,7 +406,7 @@ func (r *EmbeddingServerReconciler) statefulSetForEmbedding(
 	container := r.buildEmbeddingContainer(embedding)
 
 	// Build pod template
-	podTemplate := r.buildPodTemplate(embedding, labels, container)
+	podTemplate := r.buildPodTemplate(labels, container)
 
 	// Apply statefulset overrides
 	stsAnnotations, stsLabels := r.applyStatefulSetOverrides(embedding, &podTemplate)
@@ -443,10 +441,9 @@ func (r *EmbeddingServerReconciler) statefulSetForEmbedding(
 	// Apply user-provided PodTemplateSpec customizations via strategic merge patch.
 	// This must happen after the controller-generated template is fully populated so
 	// that user fields override controller defaults rather than the other way around.
-	if err := r.applyPodTemplateSpecToStatefulSet(ctx, embedding, statefulSet); err != nil {
-		log.FromContext(ctx).Error(err, "Failed to apply PodTemplateSpec to StatefulSet")
-		return nil
-	}
+	// The merge is soft-fail: invalid input is logged and the StatefulSet is built
+	// from controller defaults. See applyPodTemplateSpecToStatefulSet's godoc.
+	r.applyPodTemplateSpecToStatefulSet(ctx, embedding, statefulSet)
 
 	if err := ctrl.SetControllerReference(embedding, statefulSet, r.Scheme); err != nil {
 		return nil
@@ -648,7 +645,6 @@ func (*EmbeddingServerReconciler) applyResourceRequirements(embedding *mcpv1beta
 // User-provided PodTemplateSpec customizations are applied later in
 // statefulSetForEmbedding via strategic merge patch.
 func (*EmbeddingServerReconciler) buildPodTemplate(
-	_ *mcpv1beta1.EmbeddingServer,
 	labels map[string]string,
 	container corev1.Container,
 ) corev1.PodTemplateSpec {
@@ -670,25 +666,26 @@ func (*EmbeddingServerReconciler) buildPodTemplate(
 // topologySpreadConstraints, init containers, sidecars, etc.) while keeping controller
 // defaults for fields the user did not set.
 //
-// The raw user JSON is used as the patch input (rather than re-marshaling a parsed
-// PodTemplateSpec). This avoids Go's `json.Marshal` turning nil slices into `[]`, which
-// strategic merge patch interprets as "replace with empty" and would clobber controller
-// defaults.
+// The merge itself is delegated to ctrlutil.ApplyPodTemplateSpecPatch — which is
+// policy-neutral. Invalid user input is treated here as a soft failure: the merge is
+// skipped and the StatefulSet is built from controller defaults. The user-facing signal
+// lives on the EmbeddingServer status (set by validateAndUpdatePodTemplateStatus):
+// Phase=Failed and ConditionPodTemplateValid=False. This mirrors the pre-existing
+// tolerant behavior — refusing to create the StatefulSet would leave the resource stuck
+// with no pod and no observable controller-side state, while the validation condition
+// already tells the user exactly why their input was rejected. The vMCP controller
+// makes the opposite choice (hard-fail) for the same helper; both are documented on
+// ApplyPodTemplateSpecPatch's godoc.
 //
-// Invalid user input is treated as a soft failure: the merge is skipped and the
-// StatefulSet is built from controller defaults. The user-facing signal lives on the
-// EmbeddingServer status (set by validateAndUpdatePodTemplateStatus): Phase=Failed
-// and ConditionPodTemplateValid=False. This mirrors the pre-existing tolerant
-// behavior — refusing to create the StatefulSet would leave the resource stuck with
-// no pod and no observable controller-side state, while the validation condition
-// already tells the user exactly why their input was rejected.
+// The function does not return an error: every failure mode is converted to a log line
+// plus controller-default fallback at this call site.
 func (*EmbeddingServerReconciler) applyPodTemplateSpecToStatefulSet(
 	ctx context.Context,
 	embedding *mcpv1beta1.EmbeddingServer,
 	statefulSet *appsv1.StatefulSet,
-) error {
+) {
 	if embedding.Spec.PodTemplateSpec == nil || len(embedding.Spec.PodTemplateSpec.Raw) == 0 {
-		return nil
+		return
 	}
 
 	logger := log.FromContext(ctx)
@@ -703,41 +700,25 @@ func (*EmbeddingServerReconciler) applyPodTemplateSpecToStatefulSet(
 			"error", err.Error(),
 			"embeddingserver", embedding.Name,
 			"namespace", embedding.Namespace)
-		return nil
+		return
 	}
 
-	userJSON := embedding.Spec.PodTemplateSpec.Raw
-
-	originalJSON, err := json.Marshal(statefulSet.Spec.Template)
+	merged, err := ctrlutil.ApplyPodTemplateSpecPatch(statefulSet.Spec.Template, embedding.Spec.PodTemplateSpec.Raw)
 	if err != nil {
-		return fmt.Errorf("failed to marshal original PodTemplateSpec: %w", err)
-	}
-
-	patchedJSON, err := strategicpatch.StrategicMergePatch(originalJSON, userJSON, corev1.PodTemplateSpec{})
-	if err != nil {
+		// Soft failure: log and fall back to controller defaults. See function
+		// godoc above for the rationale and the contrast with the vMCP caller.
 		logger.Info("Skipping PodTemplateSpec merge: strategic merge patch failed; StatefulSet will use controller defaults",
 			"error", err.Error(),
 			"embeddingserver", embedding.Name,
 			"namespace", embedding.Namespace)
-		return nil
+		return
 	}
 
-	var patchedPodTemplateSpec corev1.PodTemplateSpec
-	if err := json.Unmarshal(patchedJSON, &patchedPodTemplateSpec); err != nil {
-		logger.Info("Skipping PodTemplateSpec merge: patched output failed to unmarshal; StatefulSet will use controller defaults",
-			"error", err.Error(),
-			"embeddingserver", embedding.Name,
-			"namespace", embedding.Namespace)
-		return nil
-	}
-
-	statefulSet.Spec.Template = patchedPodTemplateSpec
+	statefulSet.Spec.Template = merged
 
 	logger.V(1).Info("Applied PodTemplateSpec customizations to StatefulSet",
 		"embeddingserver", embedding.Name,
 		"namespace", embedding.Namespace)
-
-	return nil
 }
 
 // applyStatefulSetOverrides applies statefulset-level overrides and returns annotations and labels

--- a/cmd/thv-operator/controllers/embeddingserver_controller.go
+++ b/cmd/thv-operator/controllers/embeddingserver_controller.go
@@ -674,6 +674,14 @@ func (*EmbeddingServerReconciler) buildPodTemplate(
 // PodTemplateSpec). This avoids Go's `json.Marshal` turning nil slices into `[]`, which
 // strategic merge patch interprets as "replace with empty" and would clobber controller
 // defaults.
+//
+// Invalid user input is treated as a soft failure: the merge is skipped and the
+// StatefulSet is built from controller defaults. The user-facing signal lives on the
+// EmbeddingServer status (set by validateAndUpdatePodTemplateStatus): Phase=Failed
+// and ConditionPodTemplateValid=False. This mirrors the pre-existing tolerant
+// behavior — refusing to create the StatefulSet would leave the resource stuck with
+// no pod and no observable controller-side state, while the validation condition
+// already tells the user exactly why their input was rejected.
 func (*EmbeddingServerReconciler) applyPodTemplateSpecToStatefulSet(
 	ctx context.Context,
 	embedding *mcpv1beta1.EmbeddingServer,
@@ -683,13 +691,19 @@ func (*EmbeddingServerReconciler) applyPodTemplateSpecToStatefulSet(
 		return nil
 	}
 
-	// Validate the user-provided PodTemplateSpec is well-formed JSON.
+	logger := log.FromContext(ctx)
+
+	// Validate the user-provided PodTemplateSpec is well-formed.
 	// We don't check builder.Build() == nil for "empty" customizations: that helper
 	// only enumerates a subset of PodSpec fields and would skip the patch for
 	// fields like runtimeClassName or topologySpreadConstraints. Strategic merge
 	// patch is a no-op for `{}` anyway, so always running it is safe.
 	if _, err := ctrlutil.NewPodTemplateSpecBuilder(embedding.Spec.PodTemplateSpec, embeddingContainerName); err != nil {
-		return fmt.Errorf("failed to build PodTemplateSpec: %w", err)
+		logger.Info("Skipping PodTemplateSpec merge: input is invalid; StatefulSet will use controller defaults",
+			"error", err.Error(),
+			"embeddingserver", embedding.Name,
+			"namespace", embedding.Namespace)
+		return nil
 	}
 
 	userJSON := embedding.Spec.PodTemplateSpec.Raw
@@ -701,17 +715,25 @@ func (*EmbeddingServerReconciler) applyPodTemplateSpecToStatefulSet(
 
 	patchedJSON, err := strategicpatch.StrategicMergePatch(originalJSON, userJSON, corev1.PodTemplateSpec{})
 	if err != nil {
-		return fmt.Errorf("failed to apply strategic merge patch: %w", err)
+		logger.Info("Skipping PodTemplateSpec merge: strategic merge patch failed; StatefulSet will use controller defaults",
+			"error", err.Error(),
+			"embeddingserver", embedding.Name,
+			"namespace", embedding.Namespace)
+		return nil
 	}
 
 	var patchedPodTemplateSpec corev1.PodTemplateSpec
 	if err := json.Unmarshal(patchedJSON, &patchedPodTemplateSpec); err != nil {
-		return fmt.Errorf("failed to unmarshal patched PodTemplateSpec: %w", err)
+		logger.Info("Skipping PodTemplateSpec merge: patched output failed to unmarshal; StatefulSet will use controller defaults",
+			"error", err.Error(),
+			"embeddingserver", embedding.Name,
+			"namespace", embedding.Namespace)
+		return nil
 	}
 
 	statefulSet.Spec.Template = patchedPodTemplateSpec
 
-	log.FromContext(ctx).V(1).Info("Applied PodTemplateSpec customizations to StatefulSet",
+	logger.V(1).Info("Applied PodTemplateSpec customizations to StatefulSet",
 		"embeddingserver", embedding.Name,
 		"namespace", embedding.Namespace)
 

--- a/cmd/thv-operator/controllers/embeddingserver_controller_test.go
+++ b/cmd/thv-operator/controllers/embeddingserver_controller_test.go
@@ -953,6 +953,67 @@ func TestEmbeddingServer_PodTemplateSpec_PreservesUserFields(t *testing.T) {
 				assert.True(t, hasSidecar, "user-provided sidecar should be present")
 			},
 		},
+		{
+			// Strategic merge patch merges container arrays by name. A user-supplied
+			// container called `embedding` is a separate code path from a sidecar with a
+			// different name: env and volumeMounts get merged *into* the controller's
+			// container rather than appended as a new entry. This test pins that path so
+			// future changes can't silently break it.
+			name: "extra env vars and volumeMounts on the embedding container are merged in by name",
+			userPTS: &corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: embeddingContainerName,
+							Env: []corev1.EnvVar{
+								{Name: "EXTRA_ENV", Value: "user-set"},
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{Name: "extra-config", MountPath: "/etc/extra"},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "extra-config",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{Name: "extra-cm"},
+								},
+							},
+						},
+					},
+				},
+			},
+			assertPodSpec: func(t *testing.T, podSpec corev1.PodSpec) {
+				t.Helper()
+				require.Len(t, podSpec.Containers, 1, "no new container should have been appended")
+				c := podSpec.Containers[0]
+				assert.Equal(t, embeddingContainerName, c.Name)
+				assert.Equal(t, "test-image:latest", c.Image,
+					"controller-set image must survive the by-name merge")
+
+				// User env var was merged in.
+				var foundEnv bool
+				for _, e := range c.Env {
+					if e.Name == "EXTRA_ENV" {
+						foundEnv = true
+						assert.Equal(t, "user-set", e.Value)
+					}
+				}
+				assert.True(t, foundEnv, "user-provided env var should be present on embedding container")
+
+				// User volumeMount was merged in.
+				var foundMount bool
+				for _, m := range c.VolumeMounts {
+					if m.Name == "extra-config" {
+						foundMount = true
+						assert.Equal(t, "/etc/extra", m.MountPath)
+					}
+				}
+				assert.True(t, foundMount, "user-provided volumeMount should be present on embedding container")
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/cmd/thv-operator/controllers/embeddingserver_controller_test.go
+++ b/cmd/thv-operator/controllers/embeddingserver_controller_test.go
@@ -801,3 +801,200 @@ func TestUpdateEmbeddingServerStatus(t *testing.T) {
 		})
 	}
 }
+
+// TestEmbeddingServer_PodTemplateSpec_PreservesUserFields is a regression test for
+// https://github.com/stacklok/toolhive/issues/5100. The previous merge implementation
+// only copied an enumerated subset of PodSpec fields (NodeSelector, Affinity,
+// Tolerations, SecurityContext, ServiceAccountName, and the embedding container's
+// SecurityContext) and silently dropped everything else the user provided —
+// including imagePullSecrets, additional volumes, priorityClassName,
+// topologySpreadConstraints, runtimeClassName, init containers, and sidecars.
+//
+// This test reconciles an EmbeddingServer with a variety of previously-dropped
+// fields set on spec.podTemplateSpec.spec and asserts that they appear on the
+// resulting StatefulSet's Pod template.
+func TestEmbeddingServer_PodTemplateSpec_PreservesUserFields(t *testing.T) {
+	t.Parallel()
+
+	runtimeClassName := "kata"
+
+	tests := []struct {
+		name string
+		// userPTS is the user-provided pod template spec.
+		userPTS *corev1.PodTemplateSpec
+		// assertPodSpec runs after reconciliation against the resulting pod spec.
+		assertPodSpec func(t *testing.T, podSpec corev1.PodSpec)
+	}{
+		{
+			name: "imagePullSecrets are preserved",
+			userPTS: &corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					ImagePullSecrets: []corev1.LocalObjectReference{
+						{Name: "my-registry-creds"},
+						{Name: "second-registry"},
+					},
+				},
+			},
+			assertPodSpec: func(t *testing.T, podSpec corev1.PodSpec) {
+				t.Helper()
+				assert.ElementsMatch(t,
+					[]corev1.LocalObjectReference{
+						{Name: "my-registry-creds"},
+						{Name: "second-registry"},
+					},
+					podSpec.ImagePullSecrets,
+				)
+			},
+		},
+		{
+			name: "priorityClassName is preserved",
+			userPTS: &corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					PriorityClassName: "high-priority",
+				},
+			},
+			assertPodSpec: func(t *testing.T, podSpec corev1.PodSpec) {
+				t.Helper()
+				assert.Equal(t, "high-priority", podSpec.PriorityClassName)
+			},
+		},
+		{
+			name: "additional volumes are preserved alongside controller volumes",
+			userPTS: &corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Volumes: []corev1.Volume{
+						{
+							Name: "extra-config",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{Name: "extra-cm"},
+								},
+							},
+						},
+					},
+				},
+			},
+			assertPodSpec: func(t *testing.T, podSpec corev1.PodSpec) {
+				t.Helper()
+				var found bool
+				for _, v := range podSpec.Volumes {
+					if v.Name == "extra-config" {
+						found = true
+						require.NotNil(t, v.ConfigMap)
+						assert.Equal(t, "extra-cm", v.ConfigMap.Name)
+					}
+				}
+				assert.True(t, found, "user-provided volume should be present")
+			},
+		},
+		{
+			name: "runtimeClassName is preserved",
+			userPTS: &corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					RuntimeClassName: &runtimeClassName,
+				},
+			},
+			assertPodSpec: func(t *testing.T, podSpec corev1.PodSpec) {
+				t.Helper()
+				require.NotNil(t, podSpec.RuntimeClassName)
+				assert.Equal(t, "kata", *podSpec.RuntimeClassName)
+			},
+		},
+		{
+			name: "topologySpreadConstraints are preserved",
+			userPTS: &corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
+						{
+							MaxSkew:           1,
+							TopologyKey:       "topology.kubernetes.io/zone",
+							WhenUnsatisfiable: corev1.DoNotSchedule,
+							LabelSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{"app": "embedding"},
+							},
+						},
+					},
+				},
+			},
+			assertPodSpec: func(t *testing.T, podSpec corev1.PodSpec) {
+				t.Helper()
+				require.Len(t, podSpec.TopologySpreadConstraints, 1)
+				assert.Equal(t, int32(1), podSpec.TopologySpreadConstraints[0].MaxSkew)
+				assert.Equal(t, "topology.kubernetes.io/zone", podSpec.TopologySpreadConstraints[0].TopologyKey)
+			},
+		},
+		{
+			name: "sidecar container is preserved while embedding container keeps controller defaults",
+			userPTS: &corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "log-shipper",
+							Image: "fluentd:latest",
+						},
+					},
+				},
+			},
+			assertPodSpec: func(t *testing.T, podSpec corev1.PodSpec) {
+				t.Helper()
+				var hasEmbedding, hasSidecar bool
+				for _, c := range podSpec.Containers {
+					switch c.Name {
+					case embeddingContainerName:
+						hasEmbedding = true
+						assert.Equal(t, "test-image:latest", c.Image,
+							"controller-generated embedding container must keep its image")
+					case "log-shipper":
+						hasSidecar = true
+						assert.Equal(t, "fluentd:latest", c.Image)
+					}
+				}
+				assert.True(t, hasEmbedding, "embedding container should still be present")
+				assert.True(t, hasSidecar, "user-provided sidecar should be present")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			embedding := createTestEmbeddingServer("test", testNamespaceDefault, "test-image:latest", "test-model")
+			embedding.Spec.PodTemplateSpec = podTemplateSpecToRawExtension(t, tt.userPTS)
+
+			scheme := createEmbeddingServerTestScheme()
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithRuntimeObjects(embedding).
+				WithStatusSubresource(embedding).
+				Build()
+
+			reconciler := &EmbeddingServerReconciler{
+				Client:           fakeClient,
+				Scheme:           scheme,
+				Recorder:         events.NewFakeRecorder(10),
+				PlatformDetector: ctrlutil.NewSharedPlatformDetector(),
+			}
+
+			ctx := t.Context()
+			req := ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      embedding.Name,
+					Namespace: embedding.Namespace,
+				},
+			}
+
+			_, err := reconciler.Reconcile(ctx, req)
+			require.NoError(t, err)
+
+			sts := &appsv1.StatefulSet{}
+			err = fakeClient.Get(ctx, types.NamespacedName{
+				Name:      embedding.Name,
+				Namespace: embedding.Namespace,
+			}, sts)
+			require.NoError(t, err, "StatefulSet should be created")
+
+			tt.assertPodSpec(t, sts.Spec.Template.Spec)
+		})
+	}
+}

--- a/cmd/thv-operator/controllers/embeddingserver_controller_test.go
+++ b/cmd/thv-operator/controllers/embeddingserver_controller_test.go
@@ -998,3 +998,124 @@ func TestEmbeddingServer_PodTemplateSpec_PreservesUserFields(t *testing.T) {
 		})
 	}
 }
+
+// TestEmbeddingServer_PodTemplateSpec_SoftFailFallback verifies that when the
+// user-provided PodTemplateSpec passes validation (its JSON unmarshals into
+// corev1.PodTemplateSpec) but causes StrategicMergePatch to fail, the
+// reconciler does not surface an error — it logs and falls back to a
+// StatefulSet built entirely from controller defaults. This is the
+// EmbeddingServer caller's documented "soft-fail" policy on the otherwise
+// policy-neutral ctrlutil.ApplyPodTemplateSpecPatch helper.
+//
+// The payload below uses an unknown `$patch` directive nested inside a
+// container. Strategic merge patch rejects unknown directives at apply time,
+// while json.Unmarshal silently drops the unknown field when targeting
+// corev1.Container — so the validation pass accepts it and only the merge
+// fails.
+func TestEmbeddingServer_PodTemplateSpec_SoftFailFallback(t *testing.T) {
+	t.Parallel()
+
+	embedding := createTestEmbeddingServer("test", testNamespaceDefault, "test-image:latest", "test-model")
+	embedding.Spec.PodTemplateSpec = &runtime.RawExtension{
+		Raw: []byte(`{"spec":{"containers":[{"name":"embedding","$patch":"invalid"}]}}`),
+	}
+
+	scheme := createEmbeddingServerTestScheme()
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithRuntimeObjects(embedding).
+		WithStatusSubresource(embedding).
+		Build()
+
+	reconciler := &EmbeddingServerReconciler{
+		Client:           fakeClient,
+		Scheme:           scheme,
+		Recorder:         events.NewFakeRecorder(10),
+		PlatformDetector: ctrlutil.NewSharedPlatformDetector(),
+	}
+
+	ctx := t.Context()
+	req := ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      embedding.Name,
+			Namespace: embedding.Namespace,
+		},
+	}
+
+	_, err := reconciler.Reconcile(ctx, req)
+	require.NoError(t, err, "soft-fail: reconcile must not surface a strategic-merge-patch error")
+
+	sts := &appsv1.StatefulSet{}
+	err = fakeClient.Get(ctx, types.NamespacedName{
+		Name:      embedding.Name,
+		Namespace: embedding.Namespace,
+	}, sts)
+	require.NoError(t, err, "StatefulSet should be created with controller defaults")
+
+	// Controller defaults must survive: a single embedding container with the
+	// configured image, our health probes, and the http port.
+	require.Len(t, sts.Spec.Template.Spec.Containers, 1)
+	c := sts.Spec.Template.Spec.Containers[0]
+	assert.Equal(t, embeddingContainerName, c.Name)
+	assert.Equal(t, "test-image:latest", c.Image)
+	require.NotNil(t, c.LivenessProbe, "controller-generated liveness probe should be present")
+	require.NotNil(t, c.ReadinessProbe, "controller-generated readiness probe should be present")
+	require.Len(t, c.Ports, 1)
+	assert.Equal(t, "http", c.Ports[0].Name)
+}
+
+// TestEmbeddingServer_PodTemplateSpec_EmptyObjectIsNoOp verifies that a
+// PodTemplateSpec of `{}` is treated as a no-op: the StatefulSet is built
+// entirely from controller defaults, with nothing clobbered. This guards
+// against the regression where strategic merge patch on `{}` would replace
+// controller-generated arrays with empty slices.
+func TestEmbeddingServer_PodTemplateSpec_EmptyObjectIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	embedding := createTestEmbeddingServer("test", testNamespaceDefault, "test-image:latest", "test-model")
+	embedding.Spec.PodTemplateSpec = &runtime.RawExtension{Raw: []byte(`{}`)}
+
+	scheme := createEmbeddingServerTestScheme()
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithRuntimeObjects(embedding).
+		WithStatusSubresource(embedding).
+		Build()
+
+	reconciler := &EmbeddingServerReconciler{
+		Client:           fakeClient,
+		Scheme:           scheme,
+		Recorder:         events.NewFakeRecorder(10),
+		PlatformDetector: ctrlutil.NewSharedPlatformDetector(),
+	}
+
+	ctx := t.Context()
+	req := ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      embedding.Name,
+			Namespace: embedding.Namespace,
+		},
+	}
+
+	_, err := reconciler.Reconcile(ctx, req)
+	require.NoError(t, err)
+
+	sts := &appsv1.StatefulSet{}
+	err = fakeClient.Get(ctx, types.NamespacedName{
+		Name:      embedding.Name,
+		Namespace: embedding.Namespace,
+	}, sts)
+	require.NoError(t, err, "StatefulSet should be created")
+
+	// Every controller-generated field must survive an empty patch.
+	require.Len(t, sts.Spec.Template.Spec.Containers, 1)
+	c := sts.Spec.Template.Spec.Containers[0]
+	assert.Equal(t, embeddingContainerName, c.Name)
+	assert.Equal(t, "test-image:latest", c.Image)
+	require.NotNil(t, c.LivenessProbe)
+	require.NotNil(t, c.ReadinessProbe)
+	require.Len(t, c.Ports, 1)
+	assert.Equal(t, "http", c.Ports[0].Name)
+	assert.Contains(t, c.Args, "--model-id")
+	assert.Contains(t, c.Args, "test-model")
+}

--- a/cmd/thv-operator/controllers/virtualmcpserver_deployment.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_deployment.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
-	"encoding/json"
 	"fmt"
 	"os"
 	"path"
@@ -21,7 +20,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -926,6 +924,11 @@ func (r *VirtualMCPServerReconciler) validateSecretKeyRef(
 // - User-provided fields override controller-generated defaults
 // - Arrays are merged based on strategic merge patch rules (e.g., containers merged by name)
 // - The "vmcp" container is preserved from the controller-generated spec
+//
+// Hard-fail policy: any patch failure (marshal, patch apply, unmarshal) is returned as
+// an error that blocks Deployment creation. This is the opposite of the EmbeddingServer
+// caller's soft-fail choice. ApplyPodTemplateSpecPatch is policy-neutral; the choice is
+// at this call site by design.
 func (*VirtualMCPServerReconciler) applyPodTemplateSpecToDeployment(
 	ctx context.Context,
 	vmcp *mcpv1beta1.VirtualMCPServer,
@@ -949,29 +952,12 @@ func (*VirtualMCPServerReconciler) applyPodTemplateSpecToDeployment(
 		return nil
 	}
 
-	// Use the raw user JSON directly for strategic merge patch.
-	// This avoids the nil-slice-becomes-empty-array problem that occurs when
-	// we parse JSON into Go structs and re-marshal - Go's json.Marshal converts
-	// nil slices to [], which strategic merge patch interprets as "replace with empty".
-	// By using the raw JSON, we preserve exactly what the user specified.
-	userJSON := vmcp.Spec.PodTemplateSpec.Raw
-
-	originalJSON, err := json.Marshal(deployment.Spec.Template)
+	merged, err := ctrlutil.ApplyPodTemplateSpecPatch(deployment.Spec.Template, vmcp.Spec.PodTemplateSpec.Raw)
 	if err != nil {
-		return fmt.Errorf("failed to marshal original PodTemplateSpec: %w", err)
+		return err
 	}
 
-	patchedJSON, err := strategicpatch.StrategicMergePatch(originalJSON, userJSON, corev1.PodTemplateSpec{})
-	if err != nil {
-		return fmt.Errorf("failed to apply strategic merge patch: %w", err)
-	}
-
-	var patchedPodTemplateSpec corev1.PodTemplateSpec
-	if err := json.Unmarshal(patchedJSON, &patchedPodTemplateSpec); err != nil {
-		return fmt.Errorf("failed to unmarshal patched PodTemplateSpec: %w", err)
-	}
-
-	deployment.Spec.Template = patchedPodTemplateSpec
+	deployment.Spec.Template = merged
 
 	ctxLogger.V(1).Info("Applied PodTemplateSpec customizations to deployment",
 		"virtualmcpserver", vmcp.Name,

--- a/cmd/thv-operator/pkg/controllerutil/podtemplatespec_patch.go
+++ b/cmd/thv-operator/pkg/controllerutil/podtemplatespec_patch.go
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package controllerutil
+
+import (
+	"encoding/json"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
+)
+
+// ApplyPodTemplateSpecPatch applies a raw strategic merge patch to a base
+// PodTemplateSpec and returns the merged result.
+//
+// The patch parameter is the raw user-supplied JSON (e.g. the contents of a
+// CRD's `spec.podTemplateSpec.Raw`). Using the raw bytes — rather than a
+// re-marshaled struct — is intentional: Go's `json.Marshal` converts nil
+// slices to `[]`, which strategic merge patch interprets as "replace with
+// empty" and would clobber controller-generated defaults. Passing the user's
+// JSON through unmodified preserves exactly what they specified, and
+// strategic merge patch leaves controller-set fields the user did not touch
+// alone.
+//
+// Empty inputs are handled as no-ops: if patch has zero length the base is
+// returned unchanged. A patch of `{}` is also a safe no-op because strategic
+// merge patch on an empty object reaches the unmarshal step but produces a
+// document equal to the base.
+//
+// This helper is policy-neutral. It returns an error on any failure (base
+// marshal, patch apply, output unmarshal) and lets the caller decide whether
+// the failure should hard-fail (block resource creation) or soft-fail (log
+// and fall back to controller defaults). Different controllers in this
+// project make different choices for the same failure mode, and that
+// decision is intentionally pushed to the call site:
+//
+//   - VirtualMCPServer hard-fails: an invalid pod template blocks Deployment
+//     creation. The user-facing signal is the reconciler returning the error,
+//     surfaced as a Kubernetes Event and a controller log line.
+//   - EmbeddingServer soft-fails: the merge is skipped and the StatefulSet is
+//     built from controller defaults. The user-facing signal is the
+//     `PodTemplateValid=False` status condition (set elsewhere by the
+//     validation pass) plus a controller log line.
+//
+// Both behaviors are valid; the helper does not pick one.
+func ApplyPodTemplateSpecPatch(base corev1.PodTemplateSpec, patch []byte) (corev1.PodTemplateSpec, error) {
+	if len(patch) == 0 {
+		return base, nil
+	}
+
+	originalJSON, err := json.Marshal(base)
+	if err != nil {
+		return corev1.PodTemplateSpec{}, fmt.Errorf("failed to marshal base PodTemplateSpec: %w", err)
+	}
+
+	patchedJSON, err := strategicpatch.StrategicMergePatch(originalJSON, patch, corev1.PodTemplateSpec{})
+	if err != nil {
+		return corev1.PodTemplateSpec{}, fmt.Errorf("failed to apply strategic merge patch: %w", err)
+	}
+
+	var merged corev1.PodTemplateSpec
+	if err := json.Unmarshal(patchedJSON, &merged); err != nil {
+		return corev1.PodTemplateSpec{}, fmt.Errorf("failed to unmarshal patched PodTemplateSpec: %w", err)
+	}
+
+	return merged, nil
+}

--- a/cmd/thv-operator/pkg/controllerutil/podtemplatespec_patch_test.go
+++ b/cmd/thv-operator/pkg/controllerutil/podtemplatespec_patch_test.go
@@ -1,0 +1,103 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package controllerutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestApplyPodTemplateSpecPatch(t *testing.T) {
+	t.Parallel()
+
+	base := corev1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{"app": "test"},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "main",
+					Image: "main:v1",
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name      string
+		patch     []byte
+		assertOut func(t *testing.T, out corev1.PodTemplateSpec)
+		expectErr bool
+	}{
+		{
+			name:  "nil patch is a no-op",
+			patch: nil,
+			assertOut: func(t *testing.T, out corev1.PodTemplateSpec) {
+				t.Helper()
+				assert.Equal(t, base, out)
+			},
+		},
+		{
+			name:  "empty patch is a no-op",
+			patch: []byte{},
+			assertOut: func(t *testing.T, out corev1.PodTemplateSpec) {
+				t.Helper()
+				assert.Equal(t, base, out)
+			},
+		},
+		{
+			name:  "empty object patch preserves base",
+			patch: []byte(`{}`),
+			assertOut: func(t *testing.T, out corev1.PodTemplateSpec) {
+				t.Helper()
+				require.Len(t, out.Spec.Containers, 1)
+				assert.Equal(t, "main", out.Spec.Containers[0].Name)
+				assert.Equal(t, "main:v1", out.Spec.Containers[0].Image)
+				assert.Equal(t, "test", out.Labels["app"])
+			},
+		},
+		{
+			name:  "user fields outside the base are merged in",
+			patch: []byte(`{"spec":{"imagePullSecrets":[{"name":"creds"}],"priorityClassName":"high"}}`),
+			assertOut: func(t *testing.T, out corev1.PodTemplateSpec) {
+				t.Helper()
+				assert.Equal(t, "high", out.Spec.PriorityClassName)
+				require.Len(t, out.Spec.ImagePullSecrets, 1)
+				assert.Equal(t, "creds", out.Spec.ImagePullSecrets[0].Name)
+				// Base container survives the merge.
+				require.Len(t, out.Spec.Containers, 1)
+				assert.Equal(t, "main", out.Spec.Containers[0].Name)
+			},
+		},
+		{
+			name:      "type-mismatched patch returns an error",
+			patch:     []byte(`{"spec":{"containers":"not-an-array"}}`),
+			expectErr: true,
+		},
+		{
+			name:      "malformed JSON returns an error",
+			patch:     []byte(`{not-json`),
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			out, err := ApplyPodTemplateSpecPatch(base, tt.patch)
+			if tt.expectErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			tt.assertOut(t, out)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

The previous merge function in the EmbeddingServer controller copied
only an enumerated subset of `PodSpec` fields — `NodeSelector`,
`Affinity`, `Tolerations`, `SecurityContext`, `ServiceAccountName`,
and the embedding container's `SecurityContext`. Anything else the
user supplied on `spec.podTemplateSpec.spec` (`imagePullSecrets`,
additional `volumes`, `priorityClassName`, `topologySpreadConstraints`,
`runtimeClassName`, init containers, sidecars, …) was silently dropped.
Validation still passed, so users had no signal that the operator was
ignoring half of their pod template.

This PR replaces the enumerated copy with a strategic merge patch on
the raw user JSON, mirroring the approach already in use in
`VirtualMCPServer`'s deployment builder. The patch preserves every
user-supplied `PodSpec` field while controller defaults remain where
the user did not set a value. Using the raw user JSON (rather than a
re-marshaled struct) avoids the nil-slice-becomes-empty-array problem
that strategic merge patch interprets as "replace with empty".

The old `mergePodTemplateSpec` and `mergeContainerSecurityContext`
methods are removed so there is one merge code path, not two.

Per review feedback, the marshal → `StrategicMergePatch` → unmarshal
sequence has been extracted into a new helper
`ctrlutil.ApplyPodTemplateSpecPatch` in
`cmd/thv-operator/pkg/controllerutil/podtemplatespec_patch.go` and is
now consumed by both the EmbeddingServer (this PR's call site) and
the VirtualMCPServer controller. The helper is policy-neutral: it
returns `(corev1.PodTemplateSpec, error)` and lets each caller pick
its error-handling policy. The two callers keep their existing
divergent behavior — vMCP hard-fails (blocks Deployment creation),
EmbeddingServer soft-fails (logs and falls back to controller
defaults). Both decisions are documented at their call sites; the
helper's godoc explains the trade-off and points at both consumers.

Fixes #5100

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)
- [x] Operator integration tests (`ginkgo ./cmd/thv-operator/test-integration/embedding-server/...` — 80/80 pass with `KUBEBUILDER_ASSETS` from `setup-envtest`)

Added regression tests:

- `TestEmbeddingServer_PodTemplateSpec_PreservesUserFields` (table-driven) — reconciles an EmbeddingServer with each previously-dropped field and asserts the resulting StatefulSet's pod template carries it through. Cases covered: `imagePullSecrets`, `priorityClassName`, extra `volumes`, `runtimeClassName`, `topologySpreadConstraints`, and a user-provided sidecar container alongside the controller-generated embedding container.
- `TestEmbeddingServer_PodTemplateSpec_SoftFailFallback` — uses a payload that the validation pass accepts but `StrategicMergePatch` rejects (an unknown `$patch` directive nested inside a container). Verifies the StatefulSet is still created with controller defaults — the soft-fail contract.
- `TestEmbeddingServer_PodTemplateSpec_EmptyObjectIsNoOp` — verifies a `{}` patch is a no-op: every controller-generated field on the embedding container (image, probes, ports, args) survives unchanged.
- `TestApplyPodTemplateSpecPatch` (new helper unit tests) — covers nil/empty/`{}` inputs, a user-fields merge, malformed JSON, and a type-mismatched patch.

## API Compatibility

- [x] This PR does not break the `v1beta1` API, OR the `api-break-allowed` label is applied and the migration guidance is described above.

## Does this introduce a user-facing change?

Yes. Users of `EmbeddingServer` whose `spec.podTemplateSpec` includes
fields outside the previously-enumerated subset (most notably
`imagePullSecrets`) will now see those fields applied to the pod that
runs the embedding model. Existing manifests that only used the
enumerated fields are unaffected.

## Special notes for reviewers

- The new helper lives at `cmd/thv-operator/pkg/controllerutil/podtemplatespec_patch.go` next to the existing `podtemplatespec_builder.go`.
- The `EmbeddingServer` `applyPodTemplateSpecToStatefulSet` no longer returns an error (the linter caught that the soft-fail path made the return value dead). Updated the call site accordingly.
- Reviewer flagged a pre-existing gap in `PodTemplateSpecBuilder.isEmpty()` that affects vMCP (now invisible on the EmbeddingServer path because the early-exit on `builder.Build() == nil` was already removed in the previous commit on this branch). Filed as #5110 — separate from this PR's scope.

Generated with [Claude Code](https://claude.com/claude-code)
