### PR TITLE
fix(llm): use correct binary name for VS Code Insiders detection

### DIFF
--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -334,7 +334,7 @@ var supportedClientIntegrations = []clientAppConfig{
 		SkillsProjectPath: []string{".github", "skills"},
 		// LLM gateway: patches settings.json (same dir as mcp.json, different file)
 		LLMGatewayMode:     "proxy",
-		LLMBinaryName:      "code",
+		LLMBinaryName:      "code-insiders",
 		LLMSettingsFile:    "settings.json",
 		LLMSettingsRelPath: []string{"Code - Insiders", "User"},
 		LLMSettingsPlatformPrefix: map[Platform][]string{

--- a/pkg/client/llm_gateway_test.go
+++ b/pkg/client/llm_gateway_test.go
@@ -507,6 +507,36 @@ func TestDetectedLLMGatewayClients_NeitherDirNorBinary(t *testing.T) {
 	assert.Empty(t, cm.DetectedLLMGatewayClients())
 }
 
+// TestRealClientConfigs_LLMBinaryNames asserts the expected binary name for
+// every LLM-gateway-capable entry in supportedClientIntegrations. This is a
+// regression guard: a silent typo (e.g. "code" instead of "code-insiders")
+// causes detection to fail on machines that only have the Insiders build.
+func TestRealClientConfigs_LLMBinaryNames(t *testing.T) {
+	t.Parallel()
+
+	want := map[ClientApp]string{
+		VSCodeInsider: "code-insiders",
+		VSCode:        "code",
+		Cursor:        "cursor",
+		ClaudeCode:    "claude",
+		GeminiCli:     "gemini",
+		// Tools without a binary check (dir-only detection) are omitted.
+	}
+
+	home := t.TempDir()
+	cm := NewTestClientManager(home, nil, supportedClientIntegrations, nil)
+
+	for clientType, wantBinary := range want {
+		t.Run(string(clientType), func(t *testing.T) {
+			t.Parallel()
+			cfg := cm.lookupClientAppConfig(clientType)
+			require.NotNil(t, cfg, "missing entry in supportedClientIntegrations for %s", clientType)
+			assert.Equal(t, wantBinary, cfg.LLMBinaryName,
+				"wrong LLMBinaryName for %s: detection will fail on machines that only have the expected binary", clientType)
+		})
+	}
+}
+
 // countSubstring counts non-overlapping occurrences of substr in s.
 func countSubstring(s, substr string) int {
 	count := 0


### PR DESCRIPTION
## Summary

`DetectedLLMGatewayClients()` uses `exec.LookPath(cfg.LLMBinaryName)` to verify a tool is actually installed before reporting it as detected. The `vscode-insider` entry had `LLMBinaryName: "code"` — the stable VS Code binary name — instead of `"code-insiders"`, which is the actual CLI shim shipped by the Insiders build.

On a machine with only VS Code Insiders installed (no stable VS Code), `LookPath("code")` returns not-found, so `thv llm setup` silently skips the Insiders integration even though the tool is present.

- Fixes `LLMBinaryName` for `vscode-insider` from `"code"` to `"code-insiders"`
- Adds `TestRealClientConfigs_LLMBinaryNames` as a regression guard that asserts the binary name for every LLM-gateway-capable tool in `supportedClientIntegrations`

Fixes #5089

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [x] Unit tests (`task test`) — `TestRealClientConfigs_LLMBinaryNames` passes and would have caught the bug
- [ ] E2E tests (`task test-e2e`)
- [x] Linting (`task lint-fix`)
- [ ] Manual testing (describe below)

## API Compatibility

- [x] This PR does not break the `v1beta1` API, OR the `api-break-allowed` label is applied and the migration guidance is described above.

## Does this introduce a user-facing change?

Yes. `thv llm setup` now correctly detects VS Code Insiders on machines where only the Insiders build is installed.

## Special notes for reviewers

The regression test checks the binary name for all five tools that have `LLMBinaryName` set. If a future entry gets the wrong name, the test will catch it immediately rather than requiring manual verification on a machine with that specific tool installed.