### PR TITLE
Move llm setup/teardown orchestration to pkg/llm

### DIFF
--- a/cmd/thv/app/llm.go
+++ b/cmd/thv/app/llm.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -141,7 +140,11 @@ func newConfigResetCommand() *cobra.Command {
 tokens from the secrets provider.`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			purgeCachedTokens(cmd.Context(), cmd.ErrOrStderr())
+			if sp, err := secrets.GetSystemSecretsProvider(); err == nil {
+				llm.PurgeTokens(cmd.Context(), cmd.ErrOrStderr(), sp)
+			} else {
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: could not get secrets provider: %v\n", err)
+			}
 			return config.UpdateConfig(func(c *config.Config) error {
 				c.LLM = llm.Config{}
 				return nil
@@ -243,10 +246,6 @@ Run "thv llm teardown" to revert all changes.`,
 	return cmd
 }
 
-// loginFunc is the function used to perform OIDC login during setup. It is a
-// parameter so that tests can inject a no-op without touching the keyring.
-type loginFunc func(ctx context.Context, cfg *llm.Config) error
-
 func oidcLogin(ctx context.Context, cfg *llm.Config) error {
 	ts, err := buildLLMTokenSource(cfg, true /* interactive */)
 	if err != nil {
@@ -256,143 +255,14 @@ func oidcLogin(ctx context.Context, cfg *llm.Config) error {
 	return err
 }
 
+// runLLMSetup is a thin CLI wrapper: it adapts concrete CLI types to the
+// interfaces expected by llm.Setup and delegates all orchestration there.
 func runLLMSetup(
 	ctx context.Context, out, errOut io.Writer,
-	cm *client.ClientManager, provider config.Provider, login loginFunc,
+	cm *client.ClientManager, provider config.Provider, login llm.LoginFunc,
 	inlineOpts llm.SetOptions,
 ) error {
-	llmCfg := provider.GetConfig().LLM
-
-	// Apply inline flags in-memory so login and tool detection use the merged
-	// config without touching disk. Persistence happens below, only after login
-	// and tool patching succeed, so a failed login leaves no persisted state.
-	if err := llmCfg.SetFields(inlineOpts); err != nil {
-		return fmt.Errorf("invalid inline flag values: %w", err)
-	}
-
-	if !llmCfg.IsConfigured() {
-		return fmt.Errorf("LLM gateway is not configured — run \"thv llm config set\" first")
-	}
-
-	self, err := os.Executable()
-	if err != nil {
-		return fmt.Errorf("resolving thv executable path: %w", err)
-	}
-	// Reject paths that contain shell metacharacters: the token-helper command
-	// is written verbatim into long-lived tool config files and re-executed by
-	// the shell inside Claude Code / Gemini CLI.  A path with '"', '\', ';',
-	// newline, or carriage-return would silently produce a broken or exploitable
-	// command.
-	//
-	// Note: backslashes are Windows path separators, so this check effectively
-	// makes "thv llm setup" unsupported on Windows — consistent with the rest
-	// of the LLM gateway feature (token-helper tools use POSIX-style shells).
-	const shellUnsafe = `"\;` + "\n\r"
-	if strings.ContainsAny(self, shellUnsafe) {
-		return fmt.Errorf(
-			"executable path %q contains shell-unsafe characters; "+
-				"move thv to a path without quotes, backslashes, or semicolons "+
-				"(Windows paths are not supported by thv llm setup)", self)
-	}
-
-	proxyBaseURL := fmt.Sprintf("http://localhost:%d/v1", llmCfg.EffectiveProxyPort())
-	applyCfg := client.LLMApplyConfig{
-		GatewayURL:         llmCfg.GatewayURL,
-		ProxyBaseURL:       proxyBaseURL,
-		TokenHelperCommand: fmt.Sprintf(`"%s" llm token`, self),
-	}
-
-	// Detect tools before login so we skip the interactive browser flow when
-	// there is nothing to configure. Login still runs before any files are
-	// patched, preserving the guarantee that a failed login leaves no state.
-	detected := cm.DetectedLLMGatewayClients()
-	if len(detected) == 0 {
-		_, _ = fmt.Fprintln(out, "No supported AI tools detected.")
-		return nil
-	}
-
-	_, _ = fmt.Fprintln(out, "Ensuring you are logged in to the LLM gateway…")
-	if err := login(ctx, &llmCfg); err != nil {
-		return fmt.Errorf("OIDC login failed: %s", llm.SanitizeTokenError(err))
-	}
-	_, _ = fmt.Fprintln(out, "Login successful.")
-
-	var configured []llm.ToolConfig
-	for _, clientType := range detected {
-		configPath, err := cm.ConfigureLLMGateway(clientType, applyCfg)
-		if err != nil {
-			_, _ = fmt.Fprintf(errOut, "Warning: failed to configure %s: %v\n", clientType, err)
-			continue
-		}
-		mode := cm.LLMGatewayModeFor(clientType)
-		configured = append(configured, llm.ToolConfig{
-			Tool:       string(clientType),
-			Mode:       mode,
-			ConfigPath: configPath,
-		})
-		_, _ = fmt.Fprintf(out, "Configured %s (%s mode)  →  %s\n", clientType, mode, configPath)
-	}
-
-	if len(configured) == 0 {
-		return fmt.Errorf("failed to configure any detected tools")
-	}
-
-	if err := provider.UpdateConfig(func(c *config.Config) error {
-		// SetFields applies inline opts to the on-disk config (preserving any
-		// concurrent writes to unrelated fields) and merges ConfiguredTools
-		// atomically in a single write.
-		if err := c.LLM.SetFields(inlineOpts); err != nil {
-			return fmt.Errorf("persisting inline flags: %w", err)
-		}
-		c.LLM.ConfiguredTools = mergeToolConfigs(c.LLM.ConfiguredTools, configured)
-		return nil
-	}); err != nil {
-		// Roll back every tool we successfully patched so the tool config files
-		// are not left in a modified state without a persisted record of what
-		// was changed (which would make teardown unable to revert them).
-		for _, tc := range configured {
-			if revertErr := cm.RevertLLMGateway(client.ClientApp(tc.Tool), tc.ConfigPath); revertErr != nil {
-				_, _ = fmt.Fprintf(errOut,
-					"Warning: rollback of %s failed: %v\n", tc.Tool, revertErr)
-			}
-		}
-		return fmt.Errorf("persisting tool configuration: %w", err)
-	}
-
-	if hasProxyMode(configured) {
-		_, _ = fmt.Fprintln(out, "One or more tools use proxy mode. Start the proxy with: thv llm proxy start")
-	}
-
-	return nil
-}
-
-// isTarget reports whether toolName appears in the targets slice.
-func isTarget(targets []llm.ToolConfig, toolName string) bool {
-	for _, t := range targets {
-		if t.Tool == toolName {
-			return true
-		}
-	}
-	return false
-}
-
-// mergeToolConfigs merges newly configured tools into the existing list,
-// replacing any entry with the same tool name.
-func mergeToolConfigs(existing, incoming []llm.ToolConfig) []llm.ToolConfig {
-	index := make(map[string]int, len(existing))
-	result := make([]llm.ToolConfig, len(existing))
-	copy(result, existing)
-	for i, tc := range result {
-		index[tc.Tool] = i
-	}
-	for _, tc := range incoming {
-		if i, ok := index[tc.Tool]; ok {
-			result[i] = tc
-		} else {
-			result = append(result, tc)
-		}
-	}
-	return result
+	return llm.Setup(ctx, out, errOut, &clientManagerAdapter{cm}, &configUpdaterAdapter{provider}, login, inlineOpts)
 }
 
 func newLLMTeardownCommand() *cobra.Command {
@@ -420,6 +290,8 @@ Use --purge-tokens to also remove cached OIDC tokens from the secrets provider.`
 	return cmd
 }
 
+// runLLMTeardown is a thin CLI wrapper: it adapts concrete CLI types to the
+// interfaces expected by llm.Teardown and delegates all orchestration there.
 func runLLMTeardown(
 	ctx context.Context,
 	out, errOut io.Writer,
@@ -428,84 +300,60 @@ func runLLMTeardown(
 	purgeTokens bool,
 	provider config.Provider,
 ) error {
-	llmCfg := provider.GetConfig().LLM
-
-	var targets []llm.ToolConfig
-	if len(args) == 1 {
-		for _, tc := range llmCfg.ConfiguredTools {
-			if tc.Tool == args[0] {
-				targets = append(targets, tc)
-				break
-			}
-		}
-		if len(targets) == 0 {
-			return fmt.Errorf("tool %q is not configured", args[0])
-		}
-	} else {
-		targets = llmCfg.ConfiguredTools
-	}
-
-	if len(targets) == 0 {
-		_, _ = fmt.Fprintln(out, "No tools are currently configured.")
-		return nil
-	}
-
-	// Separate tools into those to revert and those to keep, without touching
-	// any files yet. We persist the new config first so that if UpdateConfig
-	// fails, the tool files are left intact and the state stays consistent.
-	var toRevert, remaining []llm.ToolConfig
-	for _, tc := range llmCfg.ConfiguredTools {
-		if isTarget(targets, tc.Tool) {
-			toRevert = append(toRevert, tc)
-		} else {
-			remaining = append(remaining, tc)
-		}
-	}
-
-	// Persist the updated tool list (and clear token metadata if purging) in a
-	// single write before mutating any tool config files. If this fails,
-	// nothing on disk has changed and the caller can retry.
-	if err := provider.UpdateConfig(func(c *config.Config) error {
-		c.LLM.ConfiguredTools = remaining
-		if purgeTokens {
-			c.LLM.OIDC.CachedRefreshTokenRef = ""
-			c.LLM.OIDC.CachedTokenExpiry = time.Time{}
-		}
-		return nil
-	}); err != nil {
-		return fmt.Errorf("persisting tool configuration: %w", err)
-	}
-
-	// Revert tool config files best-effort; warn on failure but do not undo
-	// the config update above (the user can re-run setup+teardown to reconcile).
-	for _, tc := range toRevert {
-		if err := cm.RevertLLMGateway(client.ClientApp(tc.Tool), tc.ConfigPath); err != nil {
-			_, _ = fmt.Fprintf(errOut, "Warning: failed to revert %s: %v\n", tc.Tool, err)
-			continue
-		}
-		_, _ = fmt.Fprintf(out, "Reverted %s  (%s)\n", tc.Tool, tc.ConfigPath)
-	}
-
+	var sp pkgsecrets.Provider
 	if purgeTokens {
-		// Delete secrets after config refs are cleared so there is no window
-		// where secrets are gone but the config still points at them.
-		purgeCachedTokens(ctx, errOut)
+		var err error
+		sp, err = secrets.GetSystemSecretsProvider()
+		if err != nil {
+			_, _ = fmt.Fprintf(errOut, "Warning: could not get secrets provider: %v\n", err)
+		}
 	}
-
-	return nil
+	return llm.Teardown(ctx, out, errOut, &clientManagerAdapter{cm}, args, purgeTokens, &configUpdaterAdapter{provider}, sp)
 }
 
-// purgeCachedTokens deletes all cached OIDC tokens from the system secrets
-// provider. Errors are logged as warnings rather than returned.
-func purgeCachedTokens(ctx context.Context, errOut io.Writer) {
-	secretsProvider, err := secrets.GetSystemSecretsProvider()
-	if err != nil {
-		_, _ = fmt.Fprintf(errOut, "Warning: could not get secrets provider: %v\n", err)
-		return
+// ── CLI adapters ──────────────────────────────────────────────────────────────
+
+// clientManagerAdapter adapts *client.ClientManager to llm.GatewayManager.
+type clientManagerAdapter struct{ cm *client.ClientManager }
+
+func (a *clientManagerAdapter) DetectedLLMGatewayClients() []string {
+	apps := a.cm.DetectedLLMGatewayClients()
+	result := make([]string, len(apps))
+	for i, app := range apps {
+		result[i] = string(app)
 	}
-	if err := llm.DeleteCachedTokens(ctx, secretsProvider); err != nil {
-		_, _ = fmt.Fprintf(errOut, "Warning: could not remove cached LLM tokens: %v\n", err)
-	}
+	return result
+}
+
+func (a *clientManagerAdapter) ConfigureLLMGateway(
+	clientType, gatewayURL, proxyBaseURL, tokenHelperCommand string,
+) (string, error) {
+	return a.cm.ConfigureLLMGateway(client.ClientApp(clientType), client.LLMApplyConfig{
+		GatewayURL:         gatewayURL,
+		ProxyBaseURL:       proxyBaseURL,
+		TokenHelperCommand: tokenHelperCommand,
+	})
+}
+
+func (a *clientManagerAdapter) LLMGatewayModeFor(clientType string) string {
+	return a.cm.LLMGatewayModeFor(client.ClientApp(clientType))
+}
+
+func (a *clientManagerAdapter) RevertLLMGateway(clientType, configPath string) error {
+	return a.cm.RevertLLMGateway(client.ClientApp(clientType), configPath)
+}
+
+// configUpdaterAdapter adapts config.Provider to llm.ConfigUpdater.
+type configUpdaterAdapter struct{ p config.Provider }
+
+func (a *configUpdaterAdapter) GetLLMConfig() llm.Config {
+	return a.p.GetConfig().LLM
+}
+
+func (a *configUpdaterAdapter) UpdateLLMConfig(fn func(*llm.Config) error) error {
+	return a.p.UpdateConfig(func(c *config.Config) error {
+		return fn(&c.LLM)
+	})
 }
 
 // ── proxy subcommand group ────────────────────────────────────────────────────
@@ -579,16 +427,4 @@ Runs non-interactively — will not launch a browser flow.`,
 	}
 
 	return cmd
-}
-
-// ── helpers ───────────────────────────────────────────────────────────────────
-
-// hasProxyMode reports whether any of the given tool configs uses proxy mode.
-func hasProxyMode(cfgs []llm.ToolConfig) bool {
-	for _, t := range cfgs {
-		if t.Mode == "proxy" {
-			return true
-		}
-	}
-	return false
 }

--- a/cmd/thv/app/llm.go
+++ b/cmd/thv/app/llm.go
@@ -308,7 +308,11 @@ func runLLMTeardown(
 			_, _ = fmt.Fprintf(errOut, "Warning: could not get secrets provider: %v\n", err)
 		}
 	}
-	return llm.Teardown(ctx, out, errOut, &clientManagerAdapter{cm}, args, purgeTokens, &configUpdaterAdapter{provider}, sp)
+	var targetTool string
+	if len(args) == 1 {
+		targetTool = args[0]
+	}
+	return llm.Teardown(ctx, out, errOut, &clientManagerAdapter{cm}, targetTool, purgeTokens, &configUpdaterAdapter{provider}, sp)
 }
 
 // ── CLI adapters ──────────────────────────────────────────────────────────────
@@ -325,13 +329,11 @@ func (a *clientManagerAdapter) DetectedLLMGatewayClients() []string {
 	return result
 }
 
-func (a *clientManagerAdapter) ConfigureLLMGateway(
-	clientType, gatewayURL, proxyBaseURL, tokenHelperCommand string,
-) (string, error) {
+func (a *clientManagerAdapter) ConfigureLLMGateway(clientType string, cfg llm.ToolApplyConfig) (string, error) {
 	return a.cm.ConfigureLLMGateway(client.ClientApp(clientType), client.LLMApplyConfig{
-		GatewayURL:         gatewayURL,
-		ProxyBaseURL:       proxyBaseURL,
-		TokenHelperCommand: tokenHelperCommand,
+		GatewayURL:         cfg.GatewayURL,
+		ProxyBaseURL:       cfg.ProxyBaseURL,
+		TokenHelperCommand: cfg.TokenHelperCommand,
 	})
 }
 

--- a/cmd/thv/app/llm_test.go
+++ b/cmd/thv/app/llm_test.go
@@ -43,6 +43,10 @@ func llmProvider(t *testing.T, llmCfg llm.Config) config.Provider {
 	return tempProvider(t, c)
 }
 
+// noopLogin is a LoginFunc that always succeeds without touching the keyring.
+// Use it in tests that don't exercise the authentication path.
+var noopLogin llm.LoginFunc = func(context.Context, *llm.Config) error { return nil }
+
 // errOnUpdateProvider wraps a base Provider but returns a fixed error from
 // UpdateConfig. Used to inject deterministic failures without relying on
 // filesystem permission tricks that are unreliable on Windows.
@@ -67,7 +71,7 @@ func TestRunLLMSetup_NotConfigured(t *testing.T) {
 	provider := llmProvider(t, llm.Config{}) // no gateway URL
 
 	var stdout, stderr bytes.Buffer
-	err := runLLMSetup(context.Background(), &stdout, &stderr, cm, provider, func(_ context.Context, _ *llm.Config) error { return nil }, llm.SetOptions{})
+	err := runLLMSetup(context.Background(), &stdout, &stderr, cm, provider, noopLogin, llm.SetOptions{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not configured")
 }
@@ -94,7 +98,7 @@ func TestRunLLMSetup_NoDetectedTools(t *testing.T) {
 	})
 
 	var stdout, stderr bytes.Buffer
-	err := runLLMSetup(context.Background(), &stdout, &stderr, cm, provider, func(_ context.Context, _ *llm.Config) error { return nil }, llm.SetOptions{})
+	err := runLLMSetup(context.Background(), &stdout, &stderr, cm, provider, noopLogin, llm.SetOptions{})
 	require.NoError(t, err)
 	assert.Contains(t, stdout.String(), "No supported AI tools detected")
 }
@@ -138,7 +142,7 @@ func TestRunLLMSetup_PartialFailure(t *testing.T) {
 	})
 
 	var stdout, stderr bytes.Buffer
-	err := runLLMSetup(context.Background(), &stdout, &stderr, cm, provider, func(_ context.Context, _ *llm.Config) error { return nil }, llm.SetOptions{})
+	err := runLLMSetup(context.Background(), &stdout, &stderr, cm, provider, noopLogin, llm.SetOptions{})
 	require.NoError(t, err)
 	assert.Contains(t, stderr.String(), "Warning: failed to configure claude-code")
 	assert.Contains(t, stdout.String(), "Configured gemini-cli")
@@ -172,7 +176,7 @@ func TestRunLLMSetup_RollbackOnConfigUpdateFailure(t *testing.T) {
 	provider := &errOnUpdateProvider{cfg: c, updateErr: errors.New("disk full")}
 
 	var stdout, stderr bytes.Buffer
-	err := runLLMSetup(context.Background(), &stdout, &stderr, cm, provider, func(_ context.Context, _ *llm.Config) error { return nil }, llm.SetOptions{})
+	err := runLLMSetup(context.Background(), &stdout, &stderr, cm, provider, noopLogin, llm.SetOptions{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "persisting tool configuration")
 
@@ -222,7 +226,7 @@ func TestRunLLMSetup_RollbackBothToolsOnConfigUpdateFailure(t *testing.T) {
 	provider := &errOnUpdateProvider{cfg: c, updateErr: errors.New("disk full")}
 
 	var stdout, stderr bytes.Buffer
-	err := runLLMSetup(context.Background(), &stdout, &stderr, cm, provider, func(_ context.Context, _ *llm.Config) error { return nil }, llm.SetOptions{})
+	err := runLLMSetup(context.Background(), &stdout, &stderr, cm, provider, noopLogin, llm.SetOptions{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "persisting tool configuration")
 

--- a/cmd/thv/app/llm_test.go
+++ b/cmd/thv/app/llm_test.go
@@ -57,65 +57,6 @@ func (p *errOnUpdateProvider) UpdateConfig(_ func(*config.Config) error) error {
 	return p.updateErr
 }
 
-// ── mergeToolConfigs ──────────────────────────────────────────────────────────
-
-func TestMergeToolConfigs_EmptyExisting(t *testing.T) {
-	t.Parallel()
-	incoming := []llm.ToolConfig{{Tool: "claude-code", Mode: "direct", ConfigPath: "/a"}}
-	got := mergeToolConfigs(nil, incoming)
-	assert.Equal(t, incoming, got)
-}
-
-func TestMergeToolConfigs_AppendsNew(t *testing.T) {
-	t.Parallel()
-	existing := []llm.ToolConfig{{Tool: "cursor", Mode: "proxy", ConfigPath: "/c"}}
-	incoming := []llm.ToolConfig{{Tool: "claude-code", Mode: "direct", ConfigPath: "/a"}}
-	got := mergeToolConfigs(existing, incoming)
-	assert.Len(t, got, 2)
-	assert.Equal(t, "cursor", got[0].Tool)
-	assert.Equal(t, "claude-code", got[1].Tool)
-}
-
-func TestMergeToolConfigs_ReplacesExisting(t *testing.T) {
-	t.Parallel()
-	existing := []llm.ToolConfig{{Tool: "cursor", Mode: "proxy", ConfigPath: "/old"}}
-	incoming := []llm.ToolConfig{{Tool: "cursor", Mode: "proxy", ConfigPath: "/new"}}
-	got := mergeToolConfigs(existing, incoming)
-	assert.Len(t, got, 1)
-	assert.Equal(t, "/new", got[0].ConfigPath)
-}
-
-func TestMergeToolConfigs_MixedReplaceAndAppend(t *testing.T) {
-	t.Parallel()
-	existing := []llm.ToolConfig{
-		{Tool: "cursor", ConfigPath: "/old-cursor"},
-		{Tool: "vscode", ConfigPath: "/old-vscode"},
-	}
-	incoming := []llm.ToolConfig{
-		{Tool: "cursor", ConfigPath: "/new-cursor"},
-		{Tool: "claude-code", ConfigPath: "/claude"},
-	}
-	got := mergeToolConfigs(existing, incoming)
-	assert.Len(t, got, 3)
-	assert.Equal(t, "/new-cursor", got[0].ConfigPath)
-	assert.Equal(t, "/old-vscode", got[1].ConfigPath)
-	assert.Equal(t, "/claude", got[2].ConfigPath)
-}
-
-// ── isTarget ─────────────────────────────────────────────────────────────────
-
-func TestIsTarget(t *testing.T) {
-	t.Parallel()
-	targets := []llm.ToolConfig{
-		{Tool: "claude-code"},
-		{Tool: "cursor"},
-	}
-	assert.True(t, isTarget(targets, "claude-code"))
-	assert.True(t, isTarget(targets, "cursor"))
-	assert.False(t, isTarget(targets, "vscode"))
-	assert.False(t, isTarget(targets, ""))
-}
-
 // ── runLLMSetup ───────────────────────────────────────────────────────────────
 
 func TestRunLLMSetup_NotConfigured(t *testing.T) {

--- a/pkg/llm/setup.go
+++ b/pkg/llm/setup.go
@@ -1,0 +1,279 @@
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package llm
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	pkgsecrets "github.com/stacklok/toolhive/pkg/secrets"
+)
+
+// LoginFunc performs the interactive OIDC login during setup. It is a
+// parameter so that tests can inject a no-op without touching the keyring.
+type LoginFunc func(ctx context.Context, cfg *Config) error
+
+// GatewayManager is the subset of client.ClientManager used by Setup and
+// Teardown. Defined here so pkg/llm does not import pkg/client.
+type GatewayManager interface {
+	// DetectedLLMGatewayClients returns tool names for all installed LLM-gateway-capable tools.
+	DetectedLLMGatewayClients() []string
+	// ConfigureLLMGateway patches the tool's config file and returns the config path.
+	ConfigureLLMGateway(clientType, gatewayURL, proxyBaseURL, tokenHelperCommand string) (string, error)
+	// LLMGatewayModeFor returns "direct", "proxy", or "" for the given client.
+	LLMGatewayModeFor(clientType string) string
+	// RevertLLMGateway removes the LLM gateway settings from the tool's config file.
+	RevertLLMGateway(clientType, configPath string) error
+}
+
+// ConfigUpdater is the subset of config.Provider used by Setup and Teardown.
+// Defined here so pkg/llm does not import pkg/config.
+type ConfigUpdater interface {
+	// GetLLMConfig returns the current LLM section of the config.
+	GetLLMConfig() Config
+	// UpdateLLMConfig atomically reads, applies fn, and persists the LLM config.
+	UpdateLLMConfig(fn func(*Config) error) error
+}
+
+// Setup configures all detected AI tools to use the LLM gateway.
+//
+// It applies inlineOpts in-memory before login so a failed login leaves no
+// persisted state. Tool config files are patched only after login succeeds;
+// on any persistence failure the patches are rolled back.
+func Setup(
+	ctx context.Context, out, errOut io.Writer,
+	gm GatewayManager, provider ConfigUpdater, login LoginFunc,
+	inlineOpts SetOptions,
+) error {
+	llmCfg := provider.GetLLMConfig()
+
+	// Apply inline flags in-memory so login and tool detection use the merged
+	// config without touching disk. Persistence happens below, only after login
+	// and tool patching succeed, so a failed login leaves no persisted state.
+	if err := llmCfg.SetFields(inlineOpts); err != nil {
+		return fmt.Errorf("invalid inline flag values: %w", err)
+	}
+
+	if !llmCfg.IsConfigured() {
+		return fmt.Errorf("LLM gateway is not configured — run \"thv llm config set\" first")
+	}
+
+	self, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("resolving thv executable path: %w", err)
+	}
+	// Reject paths that contain shell metacharacters: the token-helper command
+	// is written verbatim into long-lived tool config files and re-executed by
+	// the shell inside Claude Code / Gemini CLI.  A path with '"', '\', ';',
+	// newline, or carriage-return would silently produce a broken or exploitable
+	// command.
+	//
+	// Note: backslashes are Windows path separators, so this check effectively
+	// makes "thv llm setup" unsupported on Windows — consistent with the rest
+	// of the LLM gateway feature (token-helper tools use POSIX-style shells).
+	const shellUnsafe = `"\;` + "\n\r"
+	if strings.ContainsAny(self, shellUnsafe) {
+		return fmt.Errorf(
+			"executable path %q contains shell-unsafe characters; "+
+				"move thv to a path without quotes, backslashes, or semicolons "+
+				"(Windows paths are not supported by thv llm setup)", self)
+	}
+
+	proxyBaseURL := fmt.Sprintf("http://localhost:%d/v1", llmCfg.EffectiveProxyPort())
+	tokenHelperCommand := fmt.Sprintf(`"%s" llm token`, self)
+
+	// Detect tools before login so we skip the interactive browser flow when
+	// there is nothing to configure. Login still runs before any files are
+	// patched, preserving the guarantee that a failed login leaves no state.
+	detected := gm.DetectedLLMGatewayClients()
+	if len(detected) == 0 {
+		_, _ = fmt.Fprintln(out, "No supported AI tools detected.")
+		return nil
+	}
+
+	_, _ = fmt.Fprintln(out, "Ensuring you are logged in to the LLM gateway…")
+	if err := login(ctx, &llmCfg); err != nil {
+		return fmt.Errorf("OIDC login failed: %s", SanitizeTokenError(err))
+	}
+	_, _ = fmt.Fprintln(out, "Login successful.")
+
+	var configured []ToolConfig
+	for _, clientType := range detected {
+		configPath, err := gm.ConfigureLLMGateway(clientType, llmCfg.GatewayURL, proxyBaseURL, tokenHelperCommand)
+		if err != nil {
+			_, _ = fmt.Fprintf(errOut, "Warning: failed to configure %s: %v\n", clientType, err)
+			continue
+		}
+		mode := gm.LLMGatewayModeFor(clientType)
+		configured = append(configured, ToolConfig{
+			Tool:       clientType,
+			Mode:       mode,
+			ConfigPath: configPath,
+		})
+		_, _ = fmt.Fprintf(out, "Configured %s (%s mode)  →  %s\n", clientType, mode, configPath)
+	}
+
+	if len(configured) == 0 {
+		return fmt.Errorf("failed to configure any detected tools")
+	}
+
+	if err := provider.UpdateLLMConfig(func(c *Config) error {
+		// SetFields applies inline opts to the on-disk config (preserving any
+		// concurrent writes to unrelated fields) and merges ConfiguredTools
+		// atomically in a single write.
+		if err := c.SetFields(inlineOpts); err != nil {
+			return fmt.Errorf("persisting inline flags: %w", err)
+		}
+		c.ConfiguredTools = mergeToolConfigs(c.ConfiguredTools, configured)
+		return nil
+	}); err != nil {
+		// Roll back every tool we successfully patched so the tool config files
+		// are not left in a modified state without a persisted record of what
+		// was changed (which would make teardown unable to revert them).
+		for _, tc := range configured {
+			if revertErr := gm.RevertLLMGateway(tc.Tool, tc.ConfigPath); revertErr != nil {
+				_, _ = fmt.Fprintf(errOut,
+					"Warning: rollback of %s failed: %v\n", tc.Tool, revertErr)
+			}
+		}
+		return fmt.Errorf("persisting tool configuration: %w", err)
+	}
+
+	if hasProxyMode(configured) {
+		_, _ = fmt.Fprintln(out, "One or more tools use proxy mode. Start the proxy with: thv llm proxy start")
+	}
+
+	return nil
+}
+
+// Teardown removes LLM gateway configuration from all (or one) configured tools.
+//
+// If secretsProvider is non-nil and purgeTokens is true, cached OIDC tokens
+// are deleted after the config update succeeds.
+func Teardown(
+	ctx context.Context,
+	out, errOut io.Writer,
+	gm GatewayManager,
+	args []string,
+	purgeTokens bool,
+	provider ConfigUpdater,
+	secretsProvider pkgsecrets.Provider,
+) error {
+	llmCfg := provider.GetLLMConfig()
+
+	var targets []ToolConfig
+	if len(args) == 1 {
+		for _, tc := range llmCfg.ConfiguredTools {
+			if tc.Tool == args[0] {
+				targets = append(targets, tc)
+				break
+			}
+		}
+		if len(targets) == 0 {
+			return fmt.Errorf("tool %q is not configured", args[0])
+		}
+	} else {
+		targets = llmCfg.ConfiguredTools
+	}
+
+	if len(targets) == 0 {
+		_, _ = fmt.Fprintln(out, "No tools are currently configured.")
+		return nil
+	}
+
+	// Separate tools into those to revert and those to keep, without touching
+	// any files yet. We persist the new config first so that if UpdateLLMConfig
+	// fails, the tool files are left intact and the state stays consistent.
+	var toRevert, remaining []ToolConfig
+	for _, tc := range llmCfg.ConfiguredTools {
+		if isTarget(targets, tc.Tool) {
+			toRevert = append(toRevert, tc)
+		} else {
+			remaining = append(remaining, tc)
+		}
+	}
+
+	// Persist the updated tool list (and clear token metadata if purging) in a
+	// single write before mutating any tool config files. If this fails,
+	// nothing on disk has changed and the caller can retry.
+	if err := provider.UpdateLLMConfig(func(c *Config) error {
+		c.ConfiguredTools = remaining
+		if purgeTokens {
+			c.OIDC.CachedRefreshTokenRef = ""
+			c.OIDC.CachedTokenExpiry = time.Time{}
+		}
+		return nil
+	}); err != nil {
+		return fmt.Errorf("persisting tool configuration: %w", err)
+	}
+
+	// Revert tool config files best-effort; warn on failure but do not undo
+	// the config update above (the user can re-run setup+teardown to reconcile).
+	for _, tc := range toRevert {
+		if err := gm.RevertLLMGateway(tc.Tool, tc.ConfigPath); err != nil {
+			_, _ = fmt.Fprintf(errOut, "Warning: failed to revert %s: %v\n", tc.Tool, err)
+			continue
+		}
+		_, _ = fmt.Fprintf(out, "Reverted %s  (%s)\n", tc.Tool, tc.ConfigPath)
+	}
+
+	if purgeTokens && secretsProvider != nil {
+		// Delete secrets after config refs are cleared so there is no window
+		// where secrets are gone but the config still points at them.
+		PurgeTokens(ctx, errOut, secretsProvider)
+	}
+
+	return nil
+}
+
+// PurgeTokens deletes all cached OIDC tokens from the provided secrets
+// provider. Errors are logged as warnings rather than returned.
+func PurgeTokens(ctx context.Context, errOut io.Writer, provider pkgsecrets.Provider) {
+	if err := DeleteCachedTokens(ctx, provider); err != nil {
+		_, _ = fmt.Fprintf(errOut, "Warning: could not remove cached LLM tokens: %v\n", err)
+	}
+}
+
+// isTarget reports whether toolName appears in the targets slice.
+func isTarget(targets []ToolConfig, toolName string) bool {
+	for _, t := range targets {
+		if t.Tool == toolName {
+			return true
+		}
+	}
+	return false
+}
+
+// mergeToolConfigs merges newly configured tools into the existing list,
+// replacing any entry with the same tool name.
+func mergeToolConfigs(existing, incoming []ToolConfig) []ToolConfig {
+	index := make(map[string]int, len(existing))
+	result := make([]ToolConfig, len(existing))
+	copy(result, existing)
+	for i, tc := range result {
+		index[tc.Tool] = i
+	}
+	for _, tc := range incoming {
+		if i, ok := index[tc.Tool]; ok {
+			result[i] = tc
+		} else {
+			result = append(result, tc)
+		}
+	}
+	return result
+}
+
+// hasProxyMode reports whether any of the given tool configs uses proxy mode.
+func hasProxyMode(cfgs []ToolConfig) bool {
+	for _, t := range cfgs {
+		if t.Mode == "proxy" {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/llm/setup.go
+++ b/pkg/llm/setup.go
@@ -18,13 +18,22 @@ import (
 // parameter so that tests can inject a no-op without touching the keyring.
 type LoginFunc func(ctx context.Context, cfg *Config) error
 
+// ToolApplyConfig carries the values needed to configure a single tool's LLM
+// gateway settings. Using a struct prevents positional-argument mistakes when
+// the caller has multiple similar string values in scope.
+type ToolApplyConfig struct {
+	GatewayURL         string // direct-mode: URL of the upstream LLM gateway
+	ProxyBaseURL       string // proxy-mode: URL of the localhost reverse proxy
+	TokenHelperCommand string // direct-mode: shell command that prints a fresh token
+}
+
 // GatewayManager is the subset of client.ClientManager used by Setup and
 // Teardown. Defined here so pkg/llm does not import pkg/client.
 type GatewayManager interface {
 	// DetectedLLMGatewayClients returns tool names for all installed LLM-gateway-capable tools.
 	DetectedLLMGatewayClients() []string
 	// ConfigureLLMGateway patches the tool's config file and returns the config path.
-	ConfigureLLMGateway(clientType, gatewayURL, proxyBaseURL, tokenHelperCommand string) (string, error)
+	ConfigureLLMGateway(clientType string, cfg ToolApplyConfig) (string, error)
 	// LLMGatewayModeFor returns "direct", "proxy", or "" for the given client.
 	LLMGatewayModeFor(clientType string) string
 	// RevertLLMGateway removes the LLM gateway settings from the tool's config file.
@@ -70,17 +79,19 @@ func Setup(
 	// Reject paths that contain shell metacharacters: the token-helper command
 	// is written verbatim into long-lived tool config files and re-executed by
 	// the shell inside Claude Code / Gemini CLI.  A path with '"', '\', ';',
-	// newline, or carriage-return would silently produce a broken or exploitable
-	// command.
+	// '$', '`', newline, or carriage-return would silently produce a broken or
+	// exploitable command.  '$' and '`' are included because they trigger
+	// variable and command substitution even inside double-quoted strings.
 	//
 	// Note: backslashes are Windows path separators, so this check effectively
 	// makes "thv llm setup" unsupported on Windows — consistent with the rest
 	// of the LLM gateway feature (token-helper tools use POSIX-style shells).
-	const shellUnsafe = `"\;` + "\n\r"
+	const shellUnsafe = `"\;$` + "`\n\r"
 	if strings.ContainsAny(self, shellUnsafe) {
 		return fmt.Errorf(
 			"executable path %q contains shell-unsafe characters; "+
-				"move thv to a path without quotes, backslashes, or semicolons "+
+				"move thv to a path without quotes, backslashes, semicolons, "+
+				"dollar signs, or backticks "+
 				"(Windows paths are not supported by thv llm setup)", self)
 	}
 
@@ -104,7 +115,11 @@ func Setup(
 
 	var configured []ToolConfig
 	for _, clientType := range detected {
-		configPath, err := gm.ConfigureLLMGateway(clientType, llmCfg.GatewayURL, proxyBaseURL, tokenHelperCommand)
+		configPath, err := gm.ConfigureLLMGateway(clientType, ToolApplyConfig{
+			GatewayURL:         llmCfg.GatewayURL,
+			ProxyBaseURL:       proxyBaseURL,
+			TokenHelperCommand: tokenHelperCommand,
+		})
 		if err != nil {
 			_, _ = fmt.Fprintf(errOut, "Warning: failed to configure %s: %v\n", clientType, err)
 			continue
@@ -153,13 +168,17 @@ func Setup(
 
 // Teardown removes LLM gateway configuration from all (or one) configured tools.
 //
+// targetTool selects which tool to revert; pass an empty string to revert all
+// configured tools. An error is returned when targetTool is non-empty but not
+// found in the configured tool list.
+//
 // If secretsProvider is non-nil and purgeTokens is true, cached OIDC tokens
 // are deleted after the config update succeeds.
 func Teardown(
 	ctx context.Context,
 	out, errOut io.Writer,
 	gm GatewayManager,
-	args []string,
+	targetTool string,
 	purgeTokens bool,
 	provider ConfigUpdater,
 	secretsProvider pkgsecrets.Provider,
@@ -167,15 +186,15 @@ func Teardown(
 	llmCfg := provider.GetLLMConfig()
 
 	var targets []ToolConfig
-	if len(args) == 1 {
+	if targetTool != "" {
 		for _, tc := range llmCfg.ConfiguredTools {
-			if tc.Tool == args[0] {
+			if tc.Tool == targetTool {
 				targets = append(targets, tc)
 				break
 			}
 		}
 		if len(targets) == 0 {
-			return fmt.Errorf("tool %q is not configured", args[0])
+			return fmt.Errorf("tool %q is not configured", targetTool)
 		}
 	} else {
 		targets = llmCfg.ConfiguredTools
@@ -262,6 +281,7 @@ func mergeToolConfigs(existing, incoming []ToolConfig) []ToolConfig {
 		if i, ok := index[tc.Tool]; ok {
 			result[i] = tc
 		} else {
+			index[tc.Tool] = len(result)
 			result = append(result, tc)
 		}
 	}

--- a/pkg/llm/setup_test.go
+++ b/pkg/llm/setup_test.go
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package llm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// ── mergeToolConfigs ──────────────────────────────────────────────────────────
+
+func TestMergeToolConfigs_EmptyExisting(t *testing.T) {
+	t.Parallel()
+	incoming := []ToolConfig{{Tool: "claude-code", Mode: "direct", ConfigPath: "/a"}}
+	got := mergeToolConfigs(nil, incoming)
+	assert.Equal(t, incoming, got)
+}
+
+func TestMergeToolConfigs_AppendsNew(t *testing.T) {
+	t.Parallel()
+	existing := []ToolConfig{{Tool: "cursor", Mode: "proxy", ConfigPath: "/c"}}
+	incoming := []ToolConfig{{Tool: "claude-code", Mode: "direct", ConfigPath: "/a"}}
+	got := mergeToolConfigs(existing, incoming)
+	assert.Len(t, got, 2)
+	assert.Equal(t, "cursor", got[0].Tool)
+	assert.Equal(t, "claude-code", got[1].Tool)
+}
+
+func TestMergeToolConfigs_ReplacesExisting(t *testing.T) {
+	t.Parallel()
+	existing := []ToolConfig{{Tool: "cursor", Mode: "proxy", ConfigPath: "/old"}}
+	incoming := []ToolConfig{{Tool: "cursor", Mode: "proxy", ConfigPath: "/new"}}
+	got := mergeToolConfigs(existing, incoming)
+	assert.Len(t, got, 1)
+	assert.Equal(t, "/new", got[0].ConfigPath)
+}
+
+func TestMergeToolConfigs_MixedReplaceAndAppend(t *testing.T) {
+	t.Parallel()
+	existing := []ToolConfig{
+		{Tool: "cursor", ConfigPath: "/old-cursor"},
+		{Tool: "vscode", ConfigPath: "/old-vscode"},
+	}
+	incoming := []ToolConfig{
+		{Tool: "cursor", ConfigPath: "/new-cursor"},
+		{Tool: "claude-code", ConfigPath: "/claude"},
+	}
+	got := mergeToolConfigs(existing, incoming)
+	assert.Len(t, got, 3)
+	assert.Equal(t, "/new-cursor", got[0].ConfigPath)
+	assert.Equal(t, "/old-vscode", got[1].ConfigPath)
+	assert.Equal(t, "/claude", got[2].ConfigPath)
+}
+
+// ── isTarget ─────────────────────────────────────────────────────────────────
+
+func TestIsTarget(t *testing.T) {
+	t.Parallel()
+	targets := []ToolConfig{
+		{Tool: "claude-code"},
+		{Tool: "cursor"},
+	}
+	assert.True(t, isTarget(targets, "claude-code"))
+	assert.True(t, isTarget(targets, "cursor"))
+	assert.False(t, isTarget(targets, "vscode"))
+	assert.False(t, isTarget(targets, ""))
+}

--- a/pkg/llm/setup_test.go
+++ b/pkg/llm/setup_test.go
@@ -4,9 +4,17 @@
 package llm
 
 import (
+	"bytes"
+	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/stacklok/toolhive/pkg/secrets"
+	secretsmocks "github.com/stacklok/toolhive/pkg/secrets/mocks"
 )
 
 // ── mergeToolConfigs ──────────────────────────────────────────────────────────
@@ -54,6 +62,19 @@ func TestMergeToolConfigs_MixedReplaceAndAppend(t *testing.T) {
 	assert.Equal(t, "/claude", got[2].ConfigPath)
 }
 
+func TestMergeToolConfigs_DuplicatesInIncoming(t *testing.T) {
+	t.Parallel()
+	// If incoming contains the same tool name twice, the last entry wins and
+	// the result must not contain duplicates.
+	incoming := []ToolConfig{
+		{Tool: "claude-code", ConfigPath: "/first"},
+		{Tool: "claude-code", ConfigPath: "/second"},
+	}
+	got := mergeToolConfigs(nil, incoming)
+	assert.Len(t, got, 1)
+	assert.Equal(t, "/second", got[0].ConfigPath)
+}
+
 // ── isTarget ─────────────────────────────────────────────────────────────────
 
 func TestIsTarget(t *testing.T) {
@@ -66,4 +87,86 @@ func TestIsTarget(t *testing.T) {
 	assert.True(t, isTarget(targets, "cursor"))
 	assert.False(t, isTarget(targets, "vscode"))
 	assert.False(t, isTarget(targets, ""))
+}
+
+// ── Teardown purgeTokens path ─────────────────────────────────────────────────
+
+// stubGatewayManager is a minimal GatewayManager for Teardown tests.
+type stubGatewayManager struct {
+	reverted []string
+}
+
+func (*stubGatewayManager) DetectedLLMGatewayClients() []string { return nil }
+func (*stubGatewayManager) ConfigureLLMGateway(_ string, _ ToolApplyConfig) (string, error) {
+	return "", nil
+}
+func (*stubGatewayManager) LLMGatewayModeFor(_ string) string { return "" }
+func (s *stubGatewayManager) RevertLLMGateway(clientType, _ string) error {
+	s.reverted = append(s.reverted, clientType)
+	return nil
+}
+
+// stubConfigUpdater is a minimal ConfigUpdater for Teardown tests.
+type stubConfigUpdater struct {
+	cfg Config
+}
+
+func (s *stubConfigUpdater) GetLLMConfig() Config { return s.cfg }
+func (s *stubConfigUpdater) UpdateLLMConfig(fn func(*Config) error) error {
+	return fn(&s.cfg)
+}
+
+func TestTeardown_PurgeTokens_ClearsConfigRefsAndDeletesSecrets(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	sp := secretsmocks.NewMockProvider(ctrl)
+	sp.EXPECT().Capabilities().Return(secrets.ProviderCapabilities{
+		CanRead: true, CanWrite: true, CanDelete: true, CanList: true,
+	}).AnyTimes()
+	// DeleteCachedTokens lists then deletes; for simplicity return empty list so
+	// the delete call is skipped — we only need to verify the config refs are cleared.
+	sp.EXPECT().ListSecrets(gomock.Any()).Return(nil, nil)
+
+	expiry := time.Now()
+	provider := &stubConfigUpdater{cfg: Config{
+		OIDC: OIDCConfig{
+			CachedRefreshTokenRef: "some-ref",
+			CachedTokenExpiry:     expiry,
+		},
+		ConfiguredTools: []ToolConfig{{Tool: "cursor", ConfigPath: "/tmp/cursor.json"}},
+	}}
+	gm := &stubGatewayManager{}
+
+	var stdout, stderr bytes.Buffer
+	err := Teardown(context.Background(), &stdout, &stderr, gm, "", true, provider, sp)
+	require.NoError(t, err)
+
+	// Config refs must be cleared.
+	assert.Empty(t, provider.cfg.OIDC.CachedRefreshTokenRef)
+	assert.True(t, provider.cfg.OIDC.CachedTokenExpiry.IsZero())
+	// Tool must have been reverted.
+	assert.Equal(t, []string{"cursor"}, gm.reverted)
+}
+
+func TestTeardown_NoPurge_LeavesTokenRefsIntact(t *testing.T) {
+	t.Parallel()
+
+	expiry := time.Now()
+	provider := &stubConfigUpdater{cfg: Config{
+		OIDC: OIDCConfig{
+			CachedRefreshTokenRef: "some-ref",
+			CachedTokenExpiry:     expiry,
+		},
+		ConfiguredTools: []ToolConfig{{Tool: "cursor", ConfigPath: "/tmp/cursor.json"}},
+	}}
+	gm := &stubGatewayManager{}
+
+	var stdout, stderr bytes.Buffer
+	err := Teardown(context.Background(), &stdout, &stderr, gm, "", false, provider, nil)
+	require.NoError(t, err)
+
+	// Token refs must be untouched when purgeTokens=false.
+	assert.Equal(t, "some-ref", provider.cfg.OIDC.CachedRefreshTokenRef)
+	assert.Equal(t, expiry, provider.cfg.OIDC.CachedTokenExpiry)
 }


### PR DESCRIPTION
## Summary

<!--
REQUIRED. You MUST explain:
1. WHY this change is needed (the problem or motivation)
2. WHAT changed (concise bullet points)

The diff shows the code — your summary must provide the context a reviewer
needs to understand the purpose without reading the diff first.
-->

runLLMSetup and runLLMTeardown in cmd/thv/app/llm.go contained ~200 lines of business logic (login injection, rollback, atomic persistence, tool patching). Per cli-commands.md the CLI layer should be a thin wrapper.

Move Setup, Teardown, LoginFunc, mergeToolConfigs, hasProxyMode, isTarget, and PurgeTokens to pkg/llm/setup.go. Introduce GatewayManager and ConfigUpdater interfaces so pkg/llm does not need to import pkg/client or pkg/config (which both transitively import pkg/llm). CLI adapters in cmd/thv/app/llm.go bridge the concrete types to these interfaces.
<!--
Link related issues. Use "Closes" or "Fixes" to auto-close on merge.
Remove this line if there is no related issue.
-->

Fixes #5091 

## Type of change

<!-- REQUIRED. Check exactly one. -->

- [ ] Bug fix
- [ ] New feature
- [x] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

<!--
REQUIRED. Check every verification step you actually ran.
You MUST check at least one item. If you only did manual testing,
describe exactly what you tested below the checkbox.
-->

- [ ] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [x] Linting (`task lint-fix`)
- [ ] Manual testing (describe below)

## API Compatibility

<!--
The CRD Schema Compatibility check guards the v1beta1 operator API.
If the check flags this PR as Incompatible and the break is intentional,
apply the `api-break-allowed` label and describe below:

1. Which fields, types, or CRDs are changing.
2. Why the break is unavoidable.
3. The user-facing migration path (what cluster admins need to do).

See CONTRIBUTING.md → "API Stability" for the full rubric. Coordinate
with maintainers before applying the label.

Remove this section entirely if the PR does not touch operator API surface.
-->

- [ ] This PR does not break the `v1beta1` API, OR the `api-break-allowed` label is applied and the migration guidance is described above.

## Changes

<!--
Optional — include for PRs touching more than a few files to help
reviewers navigate the diff. Remove this entire section for small PRs.
-->

| File | Change |
|------|--------|
|      |        |

## Does this introduce a user-facing change?

<!--
If yes, describe the change from the user's perspective. This helps with release notes.
If no, write "No".
Remove this section entirely if not applicable.
-->

## Implementation plan

<!--
Optional — include when this PR was planned with an AI assistant (Claude Code, etc.).
Paste the approved plan inside the <details> block so reviewers can see the intended
design without cluttering the main PR description. Remove this section entirely
for PRs that were not AI-planned.
-->

<details>
<summary>Approved implementation plan</summary>

<!-- Paste the plan here -->

</details>

## Special notes for reviewers

<!--
Optional — call out anything non-obvious: tricky logic, known limitations,
areas where you'd like extra scrutiny, or follow-up work planned.
Remove this section if not needed.
-->
