### PR TITLE
Detect imagePullSecrets drift on proxy Deployments

### DIFF
--- a/cmd/thv-operator/controllers/mcpremoteproxy_controller.go
+++ b/cmd/thv-operator/controllers/mcpremoteproxy_controller.go
@@ -15,6 +15,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -1254,6 +1255,10 @@ func (r *MCPRemoteProxyReconciler) deploymentNeedsUpdate(
 		return true
 	}
 
+	if r.podSpecNeedsUpdate(deployment, proxy) {
+		return true
+	}
+
 	return false
 }
 
@@ -1381,6 +1386,20 @@ func (r *MCPRemoteProxyReconciler) podTemplateMetadataNeedsUpdate(
 	}
 
 	return false
+}
+
+// podSpecNeedsUpdate checks if pod-level fields (not container fields) have drifted.
+//
+// Currently compares ImagePullSecrets sourced from spec.resourceOverrides.proxyDeployment.
+// Uses equality.Semantic.DeepEqual so nil and empty slices are treated as equal,
+// which matches Kubernetes' own serialization semantics.
+func (*MCPRemoteProxyReconciler) podSpecNeedsUpdate(
+	deployment *appsv1.Deployment,
+	proxy *mcpv1beta1.MCPRemoteProxy,
+) bool {
+	expected := imagePullSecretsForRemoteProxy(proxy)
+	current := deployment.Spec.Template.Spec.ImagePullSecrets
+	return !equality.Semantic.DeepEqual(current, expected)
 }
 
 // serviceNeedsUpdate checks if the service needs to be updated

--- a/cmd/thv-operator/controllers/mcpremoteproxy_deployment_test.go
+++ b/cmd/thv-operator/controllers/mcpremoteproxy_deployment_test.go
@@ -880,6 +880,104 @@ func TestMCPRemoteProxyDeploymentNeedsUpdate_TokenExchangeDoesNotDrift(t *testin
 	assert.False(t, reconciler.deploymentNeedsUpdate(t.Context(), deployment, proxy, "test-checksum"))
 }
 
+func TestMCPRemoteProxyDeploymentNeedsUpdate_ImagePullSecretsDrift(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		specSecrets       []corev1.LocalObjectReference // set on proxy.Spec.ResourceOverrides
+		deploymentSecrets []corev1.LocalObjectReference // overrides deployment after build
+		expectNeedsUpdate bool
+	}{
+		{
+			name:              "both empty - no update",
+			specSecrets:       nil,
+			deploymentSecrets: nil,
+			expectNeedsUpdate: false,
+		},
+		{
+			name:              "spec has secrets, deployment has nil - needs update",
+			specSecrets:       []corev1.LocalObjectReference{{Name: "regsec"}},
+			deploymentSecrets: nil,
+			expectNeedsUpdate: true,
+		},
+		{
+			name:              "spec cleared, deployment has stale - needs update",
+			specSecrets:       nil,
+			deploymentSecrets: []corev1.LocalObjectReference{{Name: "old-regsec"}},
+			expectNeedsUpdate: true,
+		},
+		{
+			name:              "match - no update",
+			specSecrets:       []corev1.LocalObjectReference{{Name: "regsec"}},
+			deploymentSecrets: []corev1.LocalObjectReference{{Name: "regsec"}},
+			expectNeedsUpdate: false,
+		},
+		{
+			name:              "spec nil vs deployment empty slice - no update",
+			specSecrets:       nil,
+			deploymentSecrets: []corev1.LocalObjectReference{},
+			expectNeedsUpdate: false,
+		},
+		{
+			name:              "spec empty slice vs deployment empty slice - no update",
+			specSecrets:       []corev1.LocalObjectReference{},
+			deploymentSecrets: []corev1.LocalObjectReference{},
+			expectNeedsUpdate: false,
+		},
+		{
+			name:              "reorder triggers update",
+			specSecrets:       []corev1.LocalObjectReference{{Name: "a"}, {Name: "b"}},
+			deploymentSecrets: []corev1.LocalObjectReference{{Name: "b"}, {Name: "a"}},
+			expectNeedsUpdate: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			scheme := createRunConfigTestScheme()
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+			proxy := &mcpv1beta1.MCPRemoteProxy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-proxy",
+					Namespace: "default",
+				},
+				Spec: mcpv1beta1.MCPRemoteProxySpec{
+					RemoteURL: "https://mcp.example.com",
+					ProxyPort: 8080,
+				},
+			}
+			if tt.specSecrets != nil {
+				proxy.Spec.ResourceOverrides = &mcpv1beta1.ResourceOverrides{
+					ProxyDeployment: &mcpv1beta1.ProxyDeploymentOverrides{
+						ImagePullSecrets: tt.specSecrets,
+					},
+				}
+			}
+
+			reconciler := &MCPRemoteProxyReconciler{
+				Client:           fakeClient,
+				Scheme:           scheme,
+				PlatformDetector: ctrlutil.NewSharedPlatformDetector(),
+			}
+
+			deployment := reconciler.deploymentForMCPRemoteProxy(t.Context(), proxy, "test-checksum")
+			require.NotNil(t, deployment)
+
+			// Simulate the "stored" state by overwriting ImagePullSecrets only.
+			// The freshly built deployment is otherwise fully aligned with the proxy spec,
+			// so any detected drift is caused solely by this field.
+			deployment.Spec.Template.Spec.ImagePullSecrets = tt.deploymentSecrets
+
+			needsUpdate := reconciler.deploymentNeedsUpdate(t.Context(), deployment, proxy, "test-checksum")
+			assert.Equal(t, tt.expectNeedsUpdate, needsUpdate, "ImagePullSecrets drift detection mismatch")
+		})
+	}
+}
+
 // TestBuildEnvVarsForProxy tests environment variable building
 func TestBuildEnvVarsForProxy(t *testing.T) {
 	t.Parallel()

--- a/cmd/thv-operator/controllers/mcpserver_controller.go
+++ b/cmd/thv-operator/controllers/mcpserver_controller.go
@@ -1723,6 +1723,18 @@ func (r *MCPServerReconciler) deploymentNeedsUpdate(
 			return true
 		}
 
+		// Check if image pull secrets have changed.
+		// Sourced from spec.resourceOverrides.proxyDeployment.imagePullSecrets.
+		// Uses equality.Semantic.DeepEqual so nil and empty slices are treated as equal.
+		var expectedPullSecrets []corev1.LocalObjectReference
+		if mcpServer.Spec.ResourceOverrides != nil &&
+			mcpServer.Spec.ResourceOverrides.ProxyDeployment != nil {
+			expectedPullSecrets = mcpServer.Spec.ResourceOverrides.ProxyDeployment.ImagePullSecrets
+		}
+		if !equality.Semantic.DeepEqual(deployment.Spec.Template.Spec.ImagePullSecrets, expectedPullSecrets) {
+			return true
+		}
+
 		// Check if the resource requirements have changed
 		if !equality.Semantic.DeepEqual(container.Resources, resourceRequirementsForMCPServer(mcpServer)) {
 			return true

--- a/cmd/thv-operator/controllers/mcpserver_resource_overrides_test.go
+++ b/cmd/thv-operator/controllers/mcpserver_resource_overrides_test.go
@@ -824,6 +824,102 @@ func TestDeploymentNeedsUpdateProxyEnv(t *testing.T) {
 	}
 }
 
+func TestMCPServerDeploymentNeedsUpdate_ImagePullSecretsDrift(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		specSecrets       []corev1.LocalObjectReference // set on mcpServer.Spec.ResourceOverrides
+		deploymentSecrets []corev1.LocalObjectReference // overrides deployment after build
+		expectNeedsUpdate bool
+	}{
+		{
+			name:              "both empty - no update",
+			specSecrets:       nil,
+			deploymentSecrets: nil,
+			expectNeedsUpdate: false,
+		},
+		{
+			name:              "spec has secrets, deployment has nil - needs update",
+			specSecrets:       []corev1.LocalObjectReference{{Name: "regsec"}},
+			deploymentSecrets: nil,
+			expectNeedsUpdate: true,
+		},
+		{
+			name:              "spec cleared, deployment has stale - needs update",
+			specSecrets:       nil,
+			deploymentSecrets: []corev1.LocalObjectReference{{Name: "old-regsec"}},
+			expectNeedsUpdate: true,
+		},
+		{
+			name:              "match - no update",
+			specSecrets:       []corev1.LocalObjectReference{{Name: "regsec"}},
+			deploymentSecrets: []corev1.LocalObjectReference{{Name: "regsec"}},
+			expectNeedsUpdate: false,
+		},
+		{
+			name:              "spec nil vs deployment empty slice - no update",
+			specSecrets:       nil,
+			deploymentSecrets: []corev1.LocalObjectReference{},
+			expectNeedsUpdate: false,
+		},
+		{
+			name:              "spec empty slice vs deployment empty slice - no update",
+			specSecrets:       []corev1.LocalObjectReference{},
+			deploymentSecrets: []corev1.LocalObjectReference{},
+			expectNeedsUpdate: false,
+		},
+		{
+			name:              "reorder triggers update",
+			specSecrets:       []corev1.LocalObjectReference{{Name: "a"}, {Name: "b"}},
+			deploymentSecrets: []corev1.LocalObjectReference{{Name: "b"}, {Name: "a"}},
+			expectNeedsUpdate: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			scheme := runtime.NewScheme()
+			require.NoError(t, mcpv1beta1.AddToScheme(scheme))
+
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+			r := newTestMCPServerReconciler(fakeClient, scheme, kubernetes.PlatformKubernetes)
+
+			mcpServer := &mcpv1beta1.MCPServer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-server",
+					Namespace: "default",
+				},
+				Spec: mcpv1beta1.MCPServerSpec{
+					Image:     "test-image",
+					ProxyPort: 8080,
+				},
+			}
+			if tt.specSecrets != nil {
+				mcpServer.Spec.ResourceOverrides = &mcpv1beta1.ResourceOverrides{
+					ProxyDeployment: &mcpv1beta1.ProxyDeploymentOverrides{
+						ImagePullSecrets: tt.specSecrets,
+					},
+				}
+			}
+
+			ctx := t.Context()
+			deployment := r.deploymentForMCPServer(ctx, mcpServer, "test-checksum")
+			require.NotNil(t, deployment)
+
+			// Simulate the "stored" state by overwriting ImagePullSecrets only.
+			// The freshly built deployment is otherwise fully aligned with the mcpServer spec,
+			// so any detected drift is caused solely by this field.
+			deployment.Spec.Template.Spec.ImagePullSecrets = tt.deploymentSecrets
+
+			needsUpdate := r.deploymentNeedsUpdate(ctx, deployment, mcpServer, "test-checksum")
+			assert.Equal(t, tt.expectNeedsUpdate, needsUpdate, "ImagePullSecrets drift detection mismatch")
+		})
+	}
+}
+
 func TestMCPServerSessionAffinityNone(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/thv-operator/test-integration/mcp-remote-proxy/mcpremoteproxy_imagepullsecrets_drift_test.go
+++ b/cmd/thv-operator/test-integration/mcp-remote-proxy/mcpremoteproxy_imagepullsecrets_drift_test.go
@@ -1,0 +1,133 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package controllers
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+)
+
+var _ = Describe("MCPRemoteProxy Deployment ImagePullSecrets Drift",
+	Label("k8s", "remoteproxy", "deployment-update"), func() {
+		var (
+			testCtx       context.Context
+			proxyHelper   *MCPRemoteProxyTestHelper
+			testNamespace string
+		)
+
+		BeforeEach(func() {
+			testCtx = context.Background()
+			testNamespace = createTestNamespace(testCtx)
+			proxyHelper = NewMCPRemoteProxyTestHelper(testCtx, k8sClient, testNamespace)
+		})
+
+		AfterEach(func() {
+			Expect(proxyHelper.CleanupRemoteProxies()).To(Succeed())
+			deleteTestNamespace(testCtx, testNamespace)
+		})
+
+		Context("when imagePullSecrets is added after initial creation", func() {
+			It("rolls the Deployment to include the new pull secrets", func() {
+				By("creating an MCPRemoteProxy without resourceOverrides")
+				proxy := proxyHelper.NewRemoteProxyBuilder("ips-add-test").Create(proxyHelper)
+
+				By("waiting for the Deployment to be created")
+				deployment := proxyHelper.WaitForDeployment(proxy.Name, MediumTimeout)
+				Expect(deployment.Spec.Template.Spec.ImagePullSecrets).To(BeEmpty())
+
+				By("patching the proxy to add imagePullSecrets")
+				Eventually(func() error {
+					current, err := proxyHelper.GetRemoteProxy(proxy.Name)
+					if err != nil {
+						return err
+					}
+					current.Spec.ResourceOverrides = &mcpv1beta1.ResourceOverrides{
+						ProxyDeployment: &mcpv1beta1.ProxyDeploymentOverrides{
+							ImagePullSecrets: []corev1.LocalObjectReference{
+								{Name: "registry-creds"},
+							},
+						},
+					}
+					return k8sClient.Update(testCtx, current)
+				}, MediumTimeout, DefaultPollingInterval).Should(Succeed())
+
+				By("waiting for the Deployment to be updated with the new pull secret")
+				Eventually(func() []corev1.LocalObjectReference {
+					d := &appsv1.Deployment{}
+					if err := k8sClient.Get(testCtx, types.NamespacedName{
+						Name:      proxy.Name,
+						Namespace: testNamespace,
+					}, d); err != nil {
+						return nil
+					}
+					return d.Spec.Template.Spec.ImagePullSecrets
+				}, MediumTimeout, DefaultPollingInterval).Should(
+					ContainElement(corev1.LocalObjectReference{Name: "registry-creds"}),
+				)
+			})
+		})
+
+		Context("when imagePullSecrets value is changed", func() {
+			It("rolls the Deployment with the updated pull secret name", func() {
+				By("creating an MCPRemoteProxy with initial imagePullSecrets")
+				proxy := proxyHelper.NewRemoteProxyBuilder("ips-change-test").Build()
+				proxy.Spec.ResourceOverrides = &mcpv1beta1.ResourceOverrides{
+					ProxyDeployment: &mcpv1beta1.ProxyDeploymentOverrides{
+						ImagePullSecrets: []corev1.LocalObjectReference{{Name: "old-creds"}},
+					},
+				}
+				Expect(k8sClient.Create(testCtx, proxy)).To(Succeed())
+
+				By("waiting for the Deployment with the initial pull secret")
+				Eventually(func() []corev1.LocalObjectReference {
+					d := &appsv1.Deployment{}
+					if err := k8sClient.Get(testCtx, types.NamespacedName{
+						Name:      proxy.Name,
+						Namespace: testNamespace,
+					}, d); err != nil {
+						return nil
+					}
+					return d.Spec.Template.Spec.ImagePullSecrets
+				}, MediumTimeout, DefaultPollingInterval).Should(
+					ContainElement(corev1.LocalObjectReference{Name: "old-creds"}),
+				)
+
+				By("patching the proxy to change the pull secret name")
+				Eventually(func() error {
+					current, err := proxyHelper.GetRemoteProxy(proxy.Name)
+					if err != nil {
+						return err
+					}
+					current.Spec.ResourceOverrides.ProxyDeployment.ImagePullSecrets = []corev1.LocalObjectReference{
+						{Name: "new-creds"},
+					}
+					return k8sClient.Update(testCtx, current)
+				}, MediumTimeout, DefaultPollingInterval).Should(Succeed())
+
+				By("waiting for the Deployment to roll with the new pull secret")
+				Eventually(func() []corev1.LocalObjectReference {
+					d := &appsv1.Deployment{}
+					if err := k8sClient.Get(testCtx, types.NamespacedName{
+						Name:      proxy.Name,
+						Namespace: testNamespace,
+					}, d); err != nil {
+						return nil
+					}
+					return d.Spec.Template.Spec.ImagePullSecrets
+				}, MediumTimeout, DefaultPollingInterval).Should(
+					And(
+						ContainElement(corev1.LocalObjectReference{Name: "new-creds"}),
+						Not(ContainElement(corev1.LocalObjectReference{Name: "old-creds"})),
+					),
+				)
+			})
+		})
+	})

--- a/cmd/thv-operator/test-integration/mcp-server/mcpserver_imagepullsecrets_drift_test.go
+++ b/cmd/thv-operator/test-integration/mcp-server/mcpserver_imagepullsecrets_drift_test.go
@@ -1,0 +1,164 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package controllers
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+)
+
+var _ = Describe("MCPServer Deployment ImagePullSecrets Drift", func() {
+	const (
+		timeout  = time.Second * 30
+		interval = time.Millisecond * 250
+	)
+
+	Context("when imagePullSecrets is added after initial creation", Ordered, func() {
+		var (
+			namespace     = "default"
+			mcpServerName = "ips-add-test-server"
+			mcpServer     *mcpv1beta1.MCPServer
+		)
+
+		BeforeAll(func() {
+			mcpServer = &mcpv1beta1.MCPServer{
+				ObjectMeta: metav1.ObjectMeta{Name: mcpServerName, Namespace: namespace},
+				Spec: mcpv1beta1.MCPServerSpec{
+					Image:     "example/mcp-server:latest",
+					Transport: "stdio",
+					ProxyPort: 8080,
+				},
+			}
+			Expect(k8sClient.Create(ctx, mcpServer)).To(Succeed())
+		})
+
+		AfterAll(func() {
+			Expect(k8sClient.Delete(ctx, mcpServer)).To(Succeed())
+		})
+
+		It("rolls the Deployment to include the new pull secrets", func() {
+			By("waiting for the initial Deployment to be created with no pull secrets")
+			Eventually(func() []corev1.LocalObjectReference {
+				d := &appsv1.Deployment{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{
+					Name: mcpServerName, Namespace: namespace,
+				}, d); err != nil {
+					return nil
+				}
+				return d.Spec.Template.Spec.ImagePullSecrets
+			}, timeout, interval).Should(BeEmpty())
+
+			By("patching the MCPServer to add imagePullSecrets")
+			Eventually(func() error {
+				current := &mcpv1beta1.MCPServer{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{
+					Name: mcpServerName, Namespace: namespace,
+				}, current); err != nil {
+					return err
+				}
+				current.Spec.ResourceOverrides = &mcpv1beta1.ResourceOverrides{
+					ProxyDeployment: &mcpv1beta1.ProxyDeploymentOverrides{
+						ImagePullSecrets: []corev1.LocalObjectReference{{Name: "registry-creds"}},
+					},
+				}
+				return k8sClient.Update(ctx, current)
+			}, timeout, interval).Should(Succeed())
+
+			By("waiting for the Deployment to roll with the new pull secret")
+			Eventually(func() []corev1.LocalObjectReference {
+				d := &appsv1.Deployment{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{
+					Name: mcpServerName, Namespace: namespace,
+				}, d); err != nil {
+					return nil
+				}
+				return d.Spec.Template.Spec.ImagePullSecrets
+			}, timeout, interval).Should(
+				ContainElement(corev1.LocalObjectReference{Name: "registry-creds"}),
+			)
+		})
+	})
+
+	Context("when imagePullSecrets value is changed", Ordered, func() {
+		var (
+			namespace     = "default"
+			mcpServerName = "ips-change-test-server"
+			mcpServer     *mcpv1beta1.MCPServer
+		)
+
+		BeforeAll(func() {
+			mcpServer = &mcpv1beta1.MCPServer{
+				ObjectMeta: metav1.ObjectMeta{Name: mcpServerName, Namespace: namespace},
+				Spec: mcpv1beta1.MCPServerSpec{
+					Image:     "example/mcp-server:latest",
+					Transport: "stdio",
+					ProxyPort: 8080,
+					ResourceOverrides: &mcpv1beta1.ResourceOverrides{
+						ProxyDeployment: &mcpv1beta1.ProxyDeploymentOverrides{
+							ImagePullSecrets: []corev1.LocalObjectReference{{Name: "old-creds"}},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, mcpServer)).To(Succeed())
+		})
+
+		AfterAll(func() {
+			Expect(k8sClient.Delete(ctx, mcpServer)).To(Succeed())
+		})
+
+		It("rolls the Deployment with the updated pull secret name", func() {
+			By("waiting for the Deployment with the initial pull secret")
+			Eventually(func() []corev1.LocalObjectReference {
+				d := &appsv1.Deployment{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{
+					Name: mcpServerName, Namespace: namespace,
+				}, d); err != nil {
+					return nil
+				}
+				return d.Spec.Template.Spec.ImagePullSecrets
+			}, timeout, interval).Should(
+				ContainElement(corev1.LocalObjectReference{Name: "old-creds"}),
+			)
+
+			By("patching the MCPServer to change the pull secret name")
+			Eventually(func() error {
+				current := &mcpv1beta1.MCPServer{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{
+					Name: mcpServerName, Namespace: namespace,
+				}, current); err != nil {
+					return err
+				}
+				current.Spec.ResourceOverrides.ProxyDeployment.ImagePullSecrets = []corev1.LocalObjectReference{
+					{Name: "new-creds"},
+				}
+				return k8sClient.Update(ctx, current)
+			}, timeout, interval).Should(Succeed())
+
+			By("waiting for the Deployment to roll with the new pull secret")
+			Eventually(func() []corev1.LocalObjectReference {
+				d := &appsv1.Deployment{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{
+					Name: mcpServerName, Namespace: namespace,
+				}, d); err != nil {
+					return nil
+				}
+				return d.Spec.Template.Spec.ImagePullSecrets
+			}, timeout, interval).Should(
+				And(
+					ContainElement(corev1.LocalObjectReference{Name: "new-creds"}),
+					Not(ContainElement(corev1.LocalObjectReference{Name: "old-creds"})),
+				),
+			)
+		})
+	})
+})


### PR DESCRIPTION
## Summary

- The `MCPServer` and `MCPRemoteProxy` controllers populate `spec.resourceOverrides.proxyDeployment.imagePullSecrets` correctly on initial Deployment creation, but their `deploymentNeedsUpdate` drift checks never compare `Spec.Template.Spec.ImagePullSecrets`. Editing the field on a live CR therefore did not roll the existing Deployment.
- Partial mitigation existed via the proxy-runner ServiceAccount path: `EnsureRBACResources` already refreshes the SA each reconcile, and kubelet honors SA-level pull secrets for *new* pods. The bug bites hardest in the user-managed-ServiceAccount branch, where RBAC reconciliation is skipped and the pod-spec field is the only mechanism that propagates the new value.
- Both controllers now compare `Spec.Template.Spec.ImagePullSecrets` against the value derived from `resourceOverrides.proxyDeployment.imagePullSecrets`, using `equality.Semantic.DeepEqual` so nil and empty slices are treated identically (matching Kubernetes' own serialization semantics) and reorder/add/remove on populated slices triggers a rollout.
- The drift was discovered during review of #5103. The same gap exists in MCPServer and predates that PR; both are fixed here as one logical change.

See also #5105 (operator-level `defaultImagePullSecrets` plumbing for MCPServer) — complementary: that PR adds chart-level defaults at construction sites; this PR ensures any subsequent change to `imagePullSecrets` (per-CR or via PR #5105's defaults on operator upgrade) is detected as drift and rolls the Deployment.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [x] Unit tests (`task test`) — `cmd/thv-operator/controllers/...` package green; the two pre-existing failures in `pkg/skills/client` and `pkg/workloads` reproduce on clean `main` and are not caused by this branch
- [x] Integration tests — new envtest suites added; ran via `KUBEBUILDER_ASSETS=$(setup-envtest use 1.31.0 -p path) ginkgo --focus 'ImagePullSecrets Drift'`; both suites green (4 specs)
- [ ] E2E tests (`task test-e2e`)
- [x] Linting (`task lint-fix`) — 0 issues

## API Compatibility

- [x] This PR does not break the `v1beta1` API, OR the `api-break-allowed` label is applied and the migration guidance is described above.

No CRD or schema changes; only controller drift-detection logic.

## Changes

| File | Change |
|------|--------|
| `cmd/thv-operator/controllers/mcpremoteproxy_controller.go` | Add `podSpecNeedsUpdate` sub-helper; wire it into `deploymentNeedsUpdate`; import `k8s.io/apimachinery/pkg/api/equality`. |
| `cmd/thv-operator/controllers/mcpserver_controller.go` | Add inline `ImagePullSecrets` comparison inside `deploymentNeedsUpdate` (mirrors surrounding inline-check style). |
| `cmd/thv-operator/controllers/mcpremoteproxy_deployment_test.go` | Add `TestMCPRemoteProxyDeploymentNeedsUpdate_ImagePullSecretsDrift` (7-case table). |
| `cmd/thv-operator/controllers/mcpserver_resource_overrides_test.go` | Add `TestMCPServerDeploymentNeedsUpdate_ImagePullSecretsDrift` (7-case table). |
| `cmd/thv-operator/test-integration/mcp-remote-proxy/mcpremoteproxy_imagepullsecrets_drift_test.go` | New envtest suite: add-after-create and value-change scenarios. |
| `cmd/thv-operator/test-integration/mcp-server/mcpserver_imagepullsecrets_drift_test.go` | New envtest suite: add-after-create and value-change scenarios. |

## Does this introduce a user-facing change?

Yes. Editing `spec.resourceOverrides.proxyDeployment.imagePullSecrets` on a live `MCPServer` or `MCPRemoteProxy` now rolls the proxy Deployment within one reconcile. Previously the change took effect only after another spec-driven rollout. No CRD schema change; no migration required.

## Special notes for reviewers

- **Why `equality.Semantic.DeepEqual` over `reflect.DeepEqual`:** Kubernetes treats `nil` and `[]` slices identically when serializing PodSpec; deepcopy roundtrips can flip nil to empty slice and back. Semantic equality collapses that asymmetry; `reflect.DeepEqual` would falsely flag drift after a roundtrip and cause spurious updates.
- **Why field-by-field, not whole-PodSpec compare:** the apiserver fills server-side defaults (`terminationGracePeriodSeconds`, container `imagePullPolicy`, etc.) that the freshly built object does not match, which would cause permanent update loops. Field-by-field is the established pattern in both controllers.
- **MCPRemoteProxy gets a new `podSpecNeedsUpdate` sub-helper** to sit alongside `containerNeedsUpdate` / `deploymentMetadataNeedsUpdate` / `podTemplateMetadataNeedsUpdate`. `ImagePullSecrets` is a pod-level (not container-level) field, so this gives a clear home for future PodSpec drift checks.
- **MCPServer gets an inline check** because its `deploymentNeedsUpdate` is a single ~240-line function with many inline comparisons; matching that style keeps the diff cohesive.
- **Helper consolidation deferred:** `imagePullSecretsForRemoteProxy` (introduced by #5103) and the inline two-level nil-guard in MCPServer (`mcpserver_controller.go:896-901`, `1222-1225`, and now also in `deploymentNeedsUpdate`) both extract the same `*ResourceOverrides.ProxyDeployment.ImagePullSecrets` field. Extracting a shared `ctrlutil.ImagePullSecretsFromOverrides` is a reasonable follow-up refactor; out of scope here.
- **Related drift gaps not addressed here:** `VirtualMCPServer`, `EmbeddingServer` (#5100), and `MCPRegistry` (#5101) have similar patterns; tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)