### PR TITLE
Add missing encoding/json import to virtualmcpserver_deployment.go

### DIFF
--- a/cmd/thv-operator/controllers/virtualmcpserver_deployment.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_deployment.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path"


### PR DESCRIPTION
## Summary

- PR #5107 (`Add explicit imagePullSecrets field to VirtualMCPServer`) added a \`json.Marshal\` call to \`cmd/thv-operator/controllers/virtualmcpserver_deployment.go:733\` but did not add the corresponding \`"encoding/json"\` import. This breaks the build on main:
  \`\`\`
  cmd/thv-operator/controllers/virtualmcpserver_deployment.go:733:20: undefined: json
  \`\`\`
- Adding the missing import restores the build. No behavior change.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [x] Unit tests (\`task test\`) — \`cmd/thv-operator/controllers/...\` package builds and tests pass after the fix
- [ ] E2E tests (\`task test-e2e\`)
- [x] Linting (\`task lint-fix\`) — 0 issues
- [x] Manual verification: \`go build ./cmd/thv-operator/...\` succeeds with the fix; reproduces the \`undefined: json\` error without it

## API Compatibility

- [x] This PR does not break the \`v1beta1\` API.

No CRD or schema changes; no behavior change.

## Does this introduce a user-facing change?

No.

🤖 Generated with [Claude Code](https://claude.com/claude-code)