### PR TITLE
test(e2e): add all-client LLM gateway e2e matrix + fix secret provider bugs

### DIFF
--- a/cmd/thv-operator/controllers/virtualmcpserver_deployment.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_deployment.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path"

--- a/cmd/thv/app/commands.go
+++ b/cmd/thv/app/commands.go
@@ -107,12 +107,15 @@ func IsInformationalCommand(args []string) bool {
 	// "vmcp" is safe here: telemetry/secret-scope migrations only affect thv run state,
 	// and EnsureDefaultGroupExists is called inside pkg/vmcp/cli/Serve when dynamic
 	// backend discovery is used (i.e. when no static backends are configured).
+	// "secret" is safe here: secrets management is pure config/credential I/O and
+	// does not interact with container runtimes.
 	informationalCommands := map[string]bool{
 		"version":    true,
 		"search":     true,
 		"completion": true,
 		"registry":   true,
 		"mcp":        true,
+		"secret":     true,
 		"skill":      true,
 		"vmcp":       true,
 		"llm":        true,

--- a/pkg/auth/secrets/secrets.go
+++ b/pkg/auth/secrets/secrets.go
@@ -9,6 +9,7 @@ package secrets
 import (
 	"context"
 	"crypto/rand"
+	"errors"
 	"fmt"
 	"time"
 
@@ -209,12 +210,16 @@ func GetSystemSecretsProvider() (secrets.Provider, error) {
 	configProvider := config.NewDefaultProvider()
 	cfg := configProvider.GetConfig()
 
-	if !cfg.Secrets.SetupCompleted {
-		return nil, secrets.ErrSecretsNotSetup
-	}
-
+	// GetProviderType already handles the TOOLHIVE_SECRETS_PROVIDER env var and
+	// allows the "environment" provider even when SetupCompleted is false.
+	// Calling it first means Kubernetes / test deployments that set the env var
+	// do not have to complete interactive setup. The bare SetupCompleted guard
+	// below is only reached when no env var override is present.
 	providerType, err := cfg.Secrets.GetProviderType()
 	if err != nil {
+		if errors.Is(err, secrets.ErrSecretsNotSetup) {
+			return nil, secrets.ErrSecretsNotSetup
+		}
 		return nil, fmt.Errorf("failed to get secrets provider type: %w", err)
 	}
 

--- a/pkg/auth/secrets/secrets.go
+++ b/pkg/auth/secrets/secrets.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/stacklok/toolhive-core/env"
 	"github.com/stacklok/toolhive/pkg/config"
 	"github.com/stacklok/toolhive/pkg/secrets"
 )
@@ -207,15 +208,21 @@ func GetUserSecretsProvider() (secrets.Provider, error) {
 // GetUserSecretsProvider it does not apply UserProvider filtering, so callers
 // can read and delete __thv_* prefixed keys directly.
 func GetSystemSecretsProvider() (secrets.Provider, error) {
-	configProvider := config.NewDefaultProvider()
+	return getSystemSecretsProviderFromConfig(config.NewDefaultProvider(), &env.OSReader{})
+}
+
+// getSystemSecretsProviderFromConfig is the testable core of GetSystemSecretsProvider.
+// It accepts an explicit config.Provider and env.Reader so tests can inject
+// both without touching global environment state.
+func getSystemSecretsProviderFromConfig(configProvider config.Provider, envReader env.Reader) (secrets.Provider, error) {
 	cfg := configProvider.GetConfig()
 
-	// GetProviderType already handles the TOOLHIVE_SECRETS_PROVIDER env var and
-	// allows the "environment" provider even when SetupCompleted is false.
-	// Calling it first means Kubernetes / test deployments that set the env var
-	// do not have to complete interactive setup. The bare SetupCompleted guard
-	// below is only reached when no env var override is present.
-	providerType, err := cfg.Secrets.GetProviderType()
+	// GetProviderTypeWithEnv handles the TOOLHIVE_SECRETS_PROVIDER env var and
+	// allows the "environment" provider even when SetupCompleted is false, so
+	// Kubernetes and test deployments can skip interactive setup. When no env
+	// var override is present and SetupCompleted is false, it returns
+	// ErrSecretsNotSetup, which is propagated directly to the caller.
+	providerType, err := cfg.Secrets.GetProviderTypeWithEnv(envReader)
 	if err != nil {
 		if errors.Is(err, secrets.ErrSecretsNotSetup) {
 			return nil, secrets.ErrSecretsNotSetup

--- a/pkg/auth/secrets/secrets.go
+++ b/pkg/auth/secrets/secrets.go
@@ -164,8 +164,8 @@ func GenerateUniqueSecretNameWithPrefix(workloadName, prefix string, secretManag
 // This version is testable with dependency injection
 func StoreSecretInManagerWithProvider(ctx context.Context, secretName, secretValue string, secretManager secrets.Provider) error {
 	// Check if the provider supports writing secrets
-	if !secretManager.Capabilities().CanWrite {
-		return fmt.Errorf("secrets provider does not support writing secrets")
+	if caps := secretManager.Capabilities(); !caps.CanWrite {
+		return fmt.Errorf("secrets provider (%s) does not support writing secrets", caps)
 	}
 
 	// Store the secret

--- a/pkg/auth/secrets/secrets_test.go
+++ b/pkg/auth/secrets/secrets_test.go
@@ -267,18 +267,6 @@ func TestProcessSecret(t *testing.T) {
 		assert.Equal(t, "", result)
 	})
 
-	t.Run("non-empty plain-text value reaches GetSecretsManager", func(t *testing.T) {
-		t.Parallel()
-		// ProcessSecret delegates to GetSecretsManager() for non-empty, non-CLI-format
-		// values. The exact error depends on what secrets provider (if any) is
-		// configured on the test host, but it must NOT be nil and must NOT be the
-		// unknown-type error — proving the call reached the manager code path
-		// rather than returning early or failing token-type validation.
-		_, err := ProcessSecret("test-workload", "plain-text-secret", TokenTypeOAuthClientSecret)
-		assert.Error(t, err, "ProcessSecret with a plain-text value must fail when no writable provider is injectable")
-		assert.NotContains(t, err.Error(), "unknown token type",
-			"error should not be a token-type validation failure — it should come from the secrets manager")
-	})
 }
 
 func TestProcessSecretWithProvider(t *testing.T) {

--- a/pkg/auth/secrets/secrets_test.go
+++ b/pkg/auth/secrets/secrets_test.go
@@ -11,9 +11,54 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 
+	envmocks "github.com/stacklok/toolhive-core/env/mocks"
+	"github.com/stacklok/toolhive/pkg/config"
 	"github.com/stacklok/toolhive/pkg/secrets"
 	"github.com/stacklok/toolhive/pkg/secrets/mocks"
 )
+
+// TestGetSystemSecretsProvider_EnvOverrideBypassesSetup verifies the regression
+// fix: TOOLHIVE_SECRETS_PROVIDER=environment must succeed even when
+// SetupCompleted is false (no config file), so Kubernetes / test deployments
+// don't have to run interactive setup.
+func TestGetSystemSecretsProvider_EnvOverrideBypassesSetup(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	// PathProvider pointing at a non-existent file → SetupCompleted defaults to false.
+	cfgProvider := config.NewPathProvider(t.TempDir() + "/config.yaml")
+
+	// Mock env reader returns "environment" for the provider env var.
+	mockEnv := envmocks.NewMockReader(ctrl)
+	mockEnv.EXPECT().Getenv(secrets.ProviderEnvVar).Return(string(secrets.EnvironmentType))
+
+	provider, err := getSystemSecretsProviderFromConfig(cfgProvider, mockEnv)
+	assert.NoError(t, err, "environment provider should succeed without interactive setup")
+	assert.NotNil(t, provider, "should return a non-nil provider")
+}
+
+// TestGetSystemSecretsProvider_NoSetupNoEnvVar verifies that without both
+// SetupCompleted and a TOOLHIVE_SECRETS_PROVIDER override, the function
+// returns ErrSecretsNotSetup.
+func TestGetSystemSecretsProvider_NoSetupNoEnvVar(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	// PathProvider pointing at a non-existent file → SetupCompleted defaults to false.
+	cfgProvider := config.NewPathProvider(t.TempDir() + "/config.yaml")
+
+	// Mock env reader returns empty string → no override present.
+	mockEnv := envmocks.NewMockReader(ctrl)
+	mockEnv.EXPECT().Getenv(secrets.ProviderEnvVar).Return("")
+
+	_, err := getSystemSecretsProviderFromConfig(cfgProvider, mockEnv)
+	assert.ErrorIs(t, err, secrets.ErrSecretsNotSetup,
+		"should return ErrSecretsNotSetup when setup is incomplete and no env override is present")
+}
 
 func TestGenerateUniqueSecretNameWithPrefix(t *testing.T) {
 	t.Parallel()

--- a/test/e2e/cli_llm_all_clients_test.go
+++ b/test/e2e/cli_llm_all_clients_test.go
@@ -502,6 +502,13 @@ var _ = Describe("thv llm — all-client matrix", Label("cli", "llm", "clients",
 				out, serr, rerr := proxyCmd.RunWithTimeout(15 * time.Second)
 				done <- proxyResult{out, serr, rerr}
 			}()
+			DeferCleanup(func() {
+				_ = proxyCmd.Interrupt()
+				select {
+				case <-done:
+				case <-time.After(5 * time.Second):
+				}
+			})
 
 			By(fmt.Sprintf("waiting for proxy to listen on port %d", proxyPort))
 			proxyAddr := fmt.Sprintf("127.0.0.1:%d", proxyPort)
@@ -514,18 +521,6 @@ var _ = Describe("thv llm — all-client matrix", Label("cli", "llm", "clients",
 				return nil
 			}, 10*time.Second, 300*time.Millisecond).Should(Succeed(),
 				"proxy should be listening on %s", proxyAddr)
-
-			By("interrupting the proxy")
-			_ = proxyCmd.Interrupt()
-
-			select {
-			case r := <-done:
-				// The proxy may exit with a non-zero code on SIGINT — that's OK.
-				// We only care that it started cleanly (it was listening above).
-				_ = r
-			case <-time.After(5 * time.Second):
-				Fail("proxy did not exit after interrupt within 5s")
-			}
 		})
 	})
 
@@ -580,28 +575,57 @@ var _ = Describe("thv llm — all-client matrix", Label("cli", "llm", "clients",
 			Expect(os.MkdirAll(claudeDir, 0750)).To(Succeed())
 			Expect(createFakeBinary(binDir, "claude")).To(Succeed())
 
+			// Start a local HTTPS mock gateway so the proxy can forward requests
+			// quickly rather than timing out on DNS resolution for a fake domain.
+			gwPort, portErr := networking.FindOrUsePort(0)
+			Expect(portErr).ToNot(HaveOccurred())
+			gw, gwErr := e2e.NewLLMGatewayMock(gwPort)
+			Expect(gwErr).ToNot(HaveOccurred())
+			Expect(gw.Start()).To(Succeed())
+			defer func() { _ = gw.Stop() }()
+
+			gwCertFile := filepath.Join(tempDir, "rebind-gw-cert.pem")
+			Expect(os.WriteFile(gwCertFile, gw.CertPEM(), 0600)).To(Succeed())
+
 			issuerURL := fmt.Sprintf("http://localhost:%d", oidcPort)
 			stdout, stderr, err := runSetupWithOIDCCompletion(
 				thvCmd, oidcServer,
-				"--gateway-url", gatewayURL,
+				"--gateway-url", gw.URL(),
 				"--issuer", issuerURL,
 				"--client-id", clientID,
 			)
 			Expect(err).ToNot(HaveOccurred(),
 				"setup should succeed; stdout=%q stderr=%q", stdout, stderr)
 
-			proxyPort, portErr := networking.FindOrUsePort(0)
-			Expect(portErr).ToNot(HaveOccurred())
+			// Inject a cached access token so the proxy returns a response
+			// immediately rather than hanging on the 10-second token-fetch timeout.
+			// The loopback-Host check fires before token fetch, but a valid-looking
+			// token lets the proxy attempt forwarding and return 502 (not 403) fast.
+			rebindEnvKey := tokensource.LLMAccessTokenEnvVar(gw.URL(), issuerURL)
+			rebindToken := "rebind-test-token|" + time.Now().Add(time.Hour).UTC().Format(time.RFC3339)
+
+			proxyPort, portErr2 := networking.FindOrUsePort(0)
+			Expect(portErr2).ToNot(HaveOccurred())
 
 			By(fmt.Sprintf("setting proxy port to %d and starting proxy", proxyPort))
 			thvCmd("llm", "config", "set", "--proxy-port", fmt.Sprintf("%d", proxyPort)).ExpectSuccess()
 
 			done := make(chan struct{})
-			proxyCmd := thvCmd("llm", "proxy", "start")
+			proxyCmd := thvCmd("llm", "proxy", "start").WithEnv(
+				"SSL_CERT_FILE="+gwCertFile,
+				rebindEnvKey+"="+rebindToken,
+			)
 			go func() {
 				defer close(done)
 				_, _, _ = proxyCmd.RunWithTimeout(15 * time.Second)
 			}()
+			DeferCleanup(func() {
+				_ = proxyCmd.Interrupt()
+				select {
+				case <-done:
+				case <-time.After(5 * time.Second):
+				}
+			})
 
 			proxyAddr := fmt.Sprintf("127.0.0.1:%d", proxyPort)
 			Eventually(func() error {
@@ -614,12 +638,14 @@ var _ = Describe("thv llm — all-client matrix", Label("cli", "llm", "clients",
 			}, 10*time.Second, 300*time.Millisecond).Should(Succeed(),
 				"proxy should be listening on %s", proxyAddr)
 
+			rebindClient := &http.Client{Timeout: 10 * time.Second}
+
 			By("verifying a non-loopback Host header is rejected with 403")
 			req, reqErr := http.NewRequest("GET", fmt.Sprintf("http://%s/v1/models", proxyAddr), nil)
 			Expect(reqErr).ToNot(HaveOccurred())
 			req.Host = "attacker.example.com"
 
-			resp, doErr := http.DefaultClient.Do(req) //nolint:noctx
+			resp, doErr := rebindClient.Do(req) //nolint:noctx
 			Expect(doErr).ToNot(HaveOccurred())
 			_ = resp.Body.Close()
 			Expect(resp.StatusCode).To(Equal(http.StatusForbidden),
@@ -630,19 +656,11 @@ var _ = Describe("thv llm — all-client matrix", Label("cli", "llm", "clients",
 			Expect(reqErr2).ToNot(HaveOccurred())
 			// Use the default Host (127.0.0.1:port) — no override needed.
 
-			resp2, doErr2 := http.DefaultClient.Do(req2) //nolint:noctx
+			resp2, doErr2 := rebindClient.Do(req2) //nolint:noctx
 			Expect(doErr2).ToNot(HaveOccurred())
 			_ = resp2.Body.Close()
 			Expect(resp2.StatusCode).ToNot(Equal(http.StatusForbidden),
 				"loopback Host should pass the DNS-rebinding guard (got %d instead)", resp2.StatusCode)
-
-			By("stopping the proxy")
-			_ = proxyCmd.Interrupt()
-			select {
-			case <-done:
-			case <-time.After(5 * time.Second):
-				Fail("proxy did not exit after interrupt within 5s")
-			}
 		})
 	})
 
@@ -700,12 +718,17 @@ var _ = Describe("thv llm — all-client matrix", Label("cli", "llm", "clients",
 				proxyPort, portErr := networking.FindOrUsePort(0)
 				Expect(portErr).ToNot(HaveOccurred())
 
-				// Start the mock LLM gateway (plain HTTP — no TLS cert trust needed
-				// in the subprocess).
+				// Start the mock LLM gateway (HTTPS with self-signed cert).
 				By(fmt.Sprintf("[%s] starting mock LLM gateway on port %d", clientTC.name, gatewayPort))
-				gateway := e2e.NewLLMGatewayMockHTTP(gatewayPort)
+				gateway, gwErr := e2e.NewLLMGatewayMock(gatewayPort)
+				Expect(gwErr).ToNot(HaveOccurred())
 				Expect(gateway.Start()).To(Succeed())
 				defer func() { _ = gateway.Stop() }()
+
+				// Write the self-signed cert to a temp file so the thv subprocess
+				// can trust it via SSL_CERT_FILE (respected by Go on Linux).
+				certFile := filepath.Join(tempDir, fmt.Sprintf("gw-cert-%d.pem", gatewayPort))
+				Expect(os.WriteFile(certFile, gateway.CertPEM(), 0600)).To(Succeed())
 
 				mockGatewayURL := gateway.URL()
 				issuerURL := fmt.Sprintf("http://localhost:%d", oidcPort)
@@ -739,7 +762,10 @@ var _ = Describe("thv llm — all-client matrix", Label("cli", "llm", "clients",
 				tokenValue := fakeToken + "|" + time.Now().Add(time.Hour).UTC().Format(time.RFC3339)
 
 				thvCmdWithToken := func(args ...string) *e2e.THVCommand {
-					return thvCmd(args...).WithEnv(envKey + "=" + tokenValue)
+					return thvCmd(args...).WithEnv(
+						envKey+"="+tokenValue,
+						"SSL_CERT_FILE="+certFile,
+					)
 				}
 
 				// Configure the proxy port and start it.
@@ -753,6 +779,13 @@ var _ = Describe("thv llm — all-client matrix", Label("cli", "llm", "clients",
 					defer close(done)
 					_, _, _ = proxyCmd.RunWithTimeout(20 * time.Second)
 				}()
+				DeferCleanup(func() {
+					_ = proxyCmd.Interrupt()
+					select {
+					case <-done:
+					case <-time.After(5 * time.Second):
+					}
+				})
 
 				proxyAddr := fmt.Sprintf("127.0.0.1:%d", proxyPort)
 				Eventually(func() error {
@@ -765,10 +798,13 @@ var _ = Describe("thv llm — all-client matrix", Label("cli", "llm", "clients",
 				}, 10*time.Second, 300*time.Millisecond).Should(Succeed(),
 					"proxy should be listening on %s", proxyAddr)
 
-				// Send a request through the proxy and verify the gateway received it
-				// with the correct Bearer token.
+				// Send requests through the proxy and verify the gateway received them
+				// with the correct Bearer token. Use a client with an explicit timeout
+				// so a stalled proxy fails fast rather than hanging the suite.
+				proxyClient := &http.Client{Timeout: 10 * time.Second}
+
 				By(fmt.Sprintf("[%s] sending GET /v1/models through the proxy", clientTC.name))
-				resp, doErr := http.Get(fmt.Sprintf("http://%s/v1/models", proxyAddr)) //nolint:noctx
+				resp, doErr := proxyClient.Get(fmt.Sprintf("http://%s/v1/models", proxyAddr)) //nolint:noctx
 				Expect(doErr).ToNot(HaveOccurred(), "GET /v1/models through proxy should not error")
 				_ = resp.Body.Close()
 				Expect(resp.StatusCode).To(Equal(http.StatusOK),
@@ -780,7 +816,7 @@ var _ = Describe("thv llm — all-client matrix", Label("cli", "llm", "clients",
 
 				// Also verify the response payload is the expected mock JSON.
 				By(fmt.Sprintf("[%s] sending POST /v1/chat/completions through the proxy", clientTC.name))
-				chatResp, chatErr := http.Post( //nolint:noctx
+				chatResp, chatErr := proxyClient.Post( //nolint:noctx
 					fmt.Sprintf("http://%s/v1/chat/completions", proxyAddr),
 					"application/json",
 					strings.NewReader(`{"model":"mock-gpt-4","messages":[{"role":"user","content":"hi"}]}`),
@@ -793,13 +829,6 @@ var _ = Describe("thv llm — all-client matrix", Label("cli", "llm", "clients",
 				Expect(chatBody).To(HaveKey("choices"),
 					"chat completions response should contain 'choices'")
 
-				By(fmt.Sprintf("[%s] stopping the proxy", clientTC.name))
-				_ = proxyCmd.Interrupt()
-				select {
-				case <-done:
-				case <-time.After(5 * time.Second):
-					Fail("proxy did not exit after interrupt within 5s")
-				}
 			})
 		}
 	})

--- a/test/e2e/cli_llm_all_clients_test.go
+++ b/test/e2e/cli_llm_all_clients_test.go
@@ -141,7 +141,7 @@ func allClientTestCases() []llmClientTestCase {
 			detectionDir: func(tempDir string) string {
 				return llmSettingsDirFor("vscode-insider", tempDir)
 			},
-			binaryName: "code",
+			binaryName: "code-insiders",
 			settingsPath: func(tempDir string) string {
 				return filepath.Join(llmSettingsDirFor("vscode-insider", tempDir), "settings.json")
 			},
@@ -981,9 +981,10 @@ func installAllDetectedClients(tempDir, binDir string) []string {
 	return installed
 }
 
-// jsonPointerGet resolves a simplified JSON pointer against a map[string]any,
-// returning the string value or empty string if not found. Supports two-level
-// nesting (e.g. "/auth/tokenCommand") but not arrays.
+// jsonPointerGet resolves a simplified JSON pointer (RFC 6901) against a
+// map[string]any, returning the string value or empty string if not found.
+// Supports arbitrary nesting depth but not array indexing (e.g. "/a/b/c" works,
+// "/items/0/name" does not).
 func jsonPointerGet(obj map[string]any, pointer string) string {
 	segments := strings.Split(strings.TrimPrefix(pointer, "/"), "/")
 	var cur any = obj

--- a/test/e2e/cli_llm_all_clients_test.go
+++ b/test/e2e/cli_llm_all_clients_test.go
@@ -1,0 +1,1005 @@
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/stacklok/toolhive/pkg/auth/tokensource"
+	"github.com/stacklok/toolhive/pkg/llm"
+	"github.com/stacklok/toolhive/pkg/networking"
+	"github.com/stacklok/toolhive/pkg/secrets"
+	"github.com/stacklok/toolhive/test/e2e"
+)
+
+const (
+	osDarwin       = "darwin"
+	clientThvProxy = "thv-proxy"
+)
+
+// llmClientTestCase defines everything needed to test a single LLM gateway
+// client: directories to create for detection, an optional binary stub, the
+// path to the settings file after setup, and the expected JSON keys.
+type llmClientTestCase struct {
+	// name is the thv client name (e.g. "claude-code")
+	name string
+
+	// detectionDir returns the directory path (relative to tempDir) that must
+	// exist for thv to consider the client "installed".
+	detectionDir func(tempDir string) string
+
+	// binaryName is the stub executable to place on PATH (empty = no binary check).
+	binaryName string
+
+	// settingsPath returns the absolute path to the settings file that thv will
+	// patch during setup.
+	settingsPath func(tempDir string) string
+
+	// mode is "direct" or "proxy".
+	mode string
+
+	// expectedKeys maps JSON pointer paths to a function that validates the value.
+	// The function receives (gatewayURL, proxyBaseURL) for flexibility.
+	expectedKeys map[string]func(gatewayURL, proxyURL string) string
+
+	// skipOnOS is a GOOS value ("linux", "darwin") on which the test is skipped.
+	// Empty means the test runs everywhere.
+	skipOnOS string
+}
+
+// allClientTestCases returns the full test matrix for all supported LLM
+// gateway clients. This mirrors the production detection logic in
+// pkg/client/llm_gateway.go.
+func allClientTestCases() []llmClientTestCase {
+	return []llmClientTestCase{
+		{
+			name: "claude-code",
+			detectionDir: func(tempDir string) string {
+				return filepath.Join(tempDir, ".claude")
+			},
+			binaryName: "claude",
+			settingsPath: func(tempDir string) string {
+				return filepath.Join(tempDir, ".claude", "settings.json")
+			},
+			mode: "direct",
+			expectedKeys: map[string]func(string, string) string{
+				"/apiKeyHelper": func(_, _ string) string { return "llm token" },
+				"/env/ANTHROPIC_BASE_URL": func(gatewayURL, _ string) string {
+					return gatewayURL
+				},
+			},
+		},
+		{
+			name: "gemini-cli",
+			detectionDir: func(tempDir string) string {
+				return filepath.Join(tempDir, ".gemini")
+			},
+			binaryName: "gemini",
+			settingsPath: func(tempDir string) string {
+				return filepath.Join(tempDir, ".gemini", "settings.json")
+			},
+			mode: "direct",
+			expectedKeys: map[string]func(string, string) string{
+				"/auth/tokenCommand": func(_, _ string) string { return "llm token" },
+				"/baseUrl": func(gatewayURL, _ string) string {
+					return gatewayURL
+				},
+			},
+		},
+		{
+			name: "cursor",
+			detectionDir: func(tempDir string) string {
+				return llmSettingsDirFor("cursor", tempDir)
+			},
+			binaryName: "cursor",
+			settingsPath: func(tempDir string) string {
+				return filepath.Join(llmSettingsDirFor("cursor", tempDir), "settings.json")
+			},
+			mode: "proxy",
+			expectedKeys: map[string]func(string, string) string{
+				"/cursor.general.openAIBaseURL": func(_, proxyURL string) string {
+					return proxyURL
+				},
+				"/cursor.general.openAIAPIKey": func(_, _ string) string {
+					return clientThvProxy
+				},
+			},
+		},
+		{
+			name: "vscode",
+			detectionDir: func(tempDir string) string {
+				return llmSettingsDirFor("vscode", tempDir)
+			},
+			binaryName: "code",
+			settingsPath: func(tempDir string) string {
+				return filepath.Join(llmSettingsDirFor("vscode", tempDir), "settings.json")
+			},
+			mode: "proxy",
+			expectedKeys: map[string]func(string, string) string{
+				"/github.copilot.advanced.serverUrl": func(_, proxyURL string) string {
+					return proxyURL
+				},
+				"/github.copilot.advanced.apiKey": func(_, _ string) string {
+					return clientThvProxy
+				},
+			},
+		},
+		{
+			name: "vscode-insider",
+			detectionDir: func(tempDir string) string {
+				return llmSettingsDirFor("vscode-insider", tempDir)
+			},
+			binaryName: "code",
+			settingsPath: func(tempDir string) string {
+				return filepath.Join(llmSettingsDirFor("vscode-insider", tempDir), "settings.json")
+			},
+			mode: "proxy",
+			expectedKeys: map[string]func(string, string) string{
+				"/github.copilot.advanced.serverUrl": func(_, proxyURL string) string {
+					return proxyURL
+				},
+				"/github.copilot.advanced.apiKey": func(_, _ string) string {
+					return clientThvProxy
+				},
+			},
+		},
+		{
+			name: "xcode",
+			detectionDir: func(tempDir string) string {
+				return llmSettingsDirFor("xcode", tempDir)
+			},
+			binaryName: "", // no binary check for xcode
+			settingsPath: func(tempDir string) string {
+				return filepath.Join(llmSettingsDirFor("xcode", tempDir), "editorSettings.json")
+			},
+			mode:     "proxy",
+			skipOnOS: "linux", // xcode path is macOS-only
+			expectedKeys: map[string]func(string, string) string{
+				"/openAIBaseURL": func(_, proxyURL string) string {
+					return proxyURL
+				},
+				"/apiKey": func(_, _ string) string {
+					return clientThvProxy
+				},
+			},
+		},
+	}
+}
+
+// llmSettingsDirFor returns the directory (under tempDir) that thv uses for
+// the LLM gateway settings file of the named client. The path mirrors the
+// production buildLLMSettingsPath logic from pkg/client/config.go.
+func llmSettingsDirFor(client, tempDir string) string {
+	switch client {
+	case "cursor":
+		if runtime.GOOS == osDarwin {
+			return filepath.Join(tempDir, "Library", "Application Support", "Cursor", "User")
+		}
+		return filepath.Join(tempDir, ".config", "Cursor", "User")
+	case "vscode":
+		if runtime.GOOS == osDarwin {
+			return filepath.Join(tempDir, "Library", "Application Support", "Code", "User")
+		}
+		return filepath.Join(tempDir, ".config", "Code", "User")
+	case "vscode-insider":
+		if runtime.GOOS == osDarwin {
+			return filepath.Join(tempDir, "Library", "Application Support", "Code - Insiders", "User")
+		}
+		return filepath.Join(tempDir, ".config", "Code - Insiders", "User")
+	case "xcode":
+		// macOS only
+		return filepath.Join(tempDir, "Library", "Application Support", "GitHub Copilot for Xcode")
+	default:
+		panic(fmt.Sprintf("unknown client: %s", client))
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Suite
+// ─────────────────────────────────────────────────────────────────────────────
+
+var _ = Describe("thv llm — all-client matrix", Label("cli", "llm", "clients", "e2e"), func() {
+	if runtime.GOOS == "windows" {
+		Skip("fake-browser stub is POSIX-only; skipping on Windows")
+	}
+
+	var (
+		thvConfig    *e2e.TestConfig
+		tempDir      string
+		oidcPort     int
+		oidcServer   *e2e.OIDCMockServer
+		binDir       string
+		thvCmd       func(args ...string) *e2e.THVCommand
+		gatewayURL   = "https://llm.example.com"
+		clientID     = "test-client"
+		clientSecret = "test-secret"
+	)
+
+	BeforeEach(func() {
+		thvConfig = e2e.NewTestConfig()
+		tempDir = GinkgoT().TempDir()
+
+		// Create a fake browser dir so OIDC can complete headlessly.
+		var err error
+		binDir, err = e2e.CreateFakeBrowserDir(tempDir)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Allocate a free port for the OIDC mock server.
+		oidcPort, err = networking.FindOrUsePort(0)
+		Expect(err).ToNot(HaveOccurred())
+
+		oidcServer, err = e2e.NewOIDCMockServer(oidcPort, clientID, clientSecret)
+		Expect(err).ToNot(HaveOccurred())
+		oidcServer.EnableAutoComplete()
+		Expect(oidcServer.Start()).To(Succeed())
+
+		Eventually(func() error {
+			return checkServerHealth(fmt.Sprintf("http://localhost:%d/.well-known/openid-configuration", oidcPort))
+		}, 10*time.Second, 200*time.Millisecond).Should(Succeed())
+
+		thvCmd = func(args ...string) *e2e.THVCommand {
+			return e2e.NewTHVCommand(thvConfig, args...).
+				WithEnv(
+					"XDG_CONFIG_HOME="+tempDir,
+					"HOME="+tempDir,
+					"PATH="+binDir+":"+os.Getenv("PATH"),
+				)
+		}
+
+		By("Configuring environment secrets provider")
+		thvCmd("secret", "provider", "environment").ExpectSuccess()
+	})
+
+	AfterEach(func() {
+		if oidcServer != nil {
+			_ = oidcServer.Stop()
+		}
+	})
+
+	// ── Per-client setup + teardown ────────────────────────────────────────────
+
+	Describe("per-client setup patches settings and teardown reverts them", func() {
+		for _, clientTC := range allClientTestCases() {
+			clientTC := clientTC // capture loop variable
+			It(clientTC.name, func() {
+				if clientTC.skipOnOS != "" && runtime.GOOS == clientTC.skipOnOS {
+					Skip(fmt.Sprintf("client %q not supported on %s", clientTC.name, runtime.GOOS))
+				}
+
+				issuerURL := fmt.Sprintf("http://localhost:%d", oidcPort)
+
+				// Create the detection directory so thv considers this client installed.
+				By(fmt.Sprintf("[%s] creating detection directory", clientTC.name))
+				detectionDir := clientTC.detectionDir(tempDir)
+				Expect(os.MkdirAll(detectionDir, 0750)).To(Succeed())
+
+				// Stub the required binary (if any) in binDir.
+				if clientTC.binaryName != "" {
+					By(fmt.Sprintf("[%s] stubbing binary %q", clientTC.name, clientTC.binaryName))
+					Expect(createFakeBinary(binDir, clientTC.binaryName)).To(Succeed())
+				}
+
+				// ── setup ────────────────────────────────────────────────────────
+				By(fmt.Sprintf("[%s] running thv llm setup", clientTC.name))
+				stdout, stderr, err := runSetupWithOIDCCompletion(
+					thvCmd,
+					oidcServer,
+					"--gateway-url", gatewayURL,
+					"--issuer", issuerURL,
+					"--client-id", clientID,
+				)
+				Expect(err).ToNot(HaveOccurred(),
+					"setup should succeed; stdout=%q stderr=%q", stdout, stderr)
+
+				// Verify the settings file was created and patched.
+				settingsFile := clientTC.settingsPath(tempDir)
+				By(fmt.Sprintf("[%s] verifying settings file was patched: %s", clientTC.name, settingsFile))
+				data, err := os.ReadFile(settingsFile)
+				Expect(err).ToNot(HaveOccurred(), "settings file should exist after setup")
+
+				var settings map[string]any
+				Expect(json.Unmarshal(data, &settings)).To(Succeed())
+
+				proxyBaseURL := fmt.Sprintf("http://localhost:%d/v1", llm.DefaultProxyListenPort)
+				for pointer, valueFn := range clientTC.expectedKeys {
+					expectedSubstr := valueFn(gatewayURL, proxyBaseURL)
+					actualValue := jsonPointerGet(settings, pointer)
+					Expect(actualValue).To(ContainSubstring(expectedSubstr),
+						"JSON pointer %s should contain %q in %s", pointer, expectedSubstr, settingsFile)
+				}
+
+				// Verify config show reflects this client.
+				By(fmt.Sprintf("[%s] verifying config show contains this client", clientTC.name))
+				showOut, _ := thvCmd("llm", "config", "show", "--format", "json").ExpectSuccess()
+				var cfg llm.Config
+				Expect(json.Unmarshal([]byte(showOut), &cfg)).To(Succeed())
+
+				found := false
+				for _, toolCfg := range cfg.ConfiguredTools {
+					if string(toolCfg.Tool) == clientTC.name {
+						found = true
+						Expect(toolCfg.Mode).To(Equal(clientTC.mode),
+							"client %s should be in %s mode", clientTC.name, clientTC.mode)
+						break
+					}
+				}
+				Expect(found).To(BeTrue(), "client %q should appear in ConfiguredTools", clientTC.name)
+
+				// ── teardown ─────────────────────────────────────────────────────
+				By(fmt.Sprintf("[%s] running thv llm teardown %s", clientTC.name, clientTC.name))
+				thvCmd("llm", "teardown", clientTC.name).ExpectSuccess()
+
+				By(fmt.Sprintf("[%s] verifying settings file was reverted", clientTC.name))
+				data, err = os.ReadFile(settingsFile)
+				Expect(err).ToNot(HaveOccurred())
+				var after map[string]any
+				Expect(json.Unmarshal(data, &after)).To(Succeed())
+
+				for pointer := range clientTC.expectedKeys {
+					value := jsonPointerGet(after, pointer)
+					Expect(value).To(BeEmpty(),
+						"JSON pointer %s should be absent after teardown in %s", pointer, settingsFile)
+				}
+
+				showOut, _ = thvCmd("llm", "config", "show", "--format", "json").ExpectSuccess()
+				cfg = llm.Config{}
+				Expect(json.Unmarshal([]byte(showOut), &cfg)).To(Succeed())
+				Expect(cfg.ConfiguredTools).To(BeEmpty(),
+					"ConfiguredTools should be empty after teardown of %s", clientTC.name)
+			})
+		}
+	})
+
+	// ── Multi-client setup ─────────────────────────────────────────────────────
+
+	Describe("multi-client setup", func() {
+		It("configures all detected clients in a single setup call", func() {
+			issuerURL := fmt.Sprintf("http://localhost:%d", oidcPort)
+
+			// Install all clients (skip xcode on Linux).
+			installedClients := installAllDetectedClients(tempDir, binDir)
+
+			By(fmt.Sprintf("running setup with %d clients installed", len(installedClients)))
+			stdout, stderr, err := runSetupWithOIDCCompletion(
+				thvCmd,
+				oidcServer,
+				"--gateway-url", gatewayURL,
+				"--issuer", issuerURL,
+				"--client-id", clientID,
+			)
+			Expect(err).ToNot(HaveOccurred(),
+				"setup should succeed; stdout=%q stderr=%q", stdout, stderr)
+
+			By("verifying all installed clients appear in ConfiguredTools")
+			showOut, _ := thvCmd("llm", "config", "show", "--format", "json").ExpectSuccess()
+			var cfg llm.Config
+			Expect(json.Unmarshal([]byte(showOut), &cfg)).To(Succeed())
+
+			configuredNames := make(map[string]bool)
+			for _, tc := range cfg.ConfiguredTools {
+				configuredNames[string(tc.Tool)] = true
+			}
+			for _, clientName := range installedClients {
+				Expect(configuredNames).To(HaveKey(clientName),
+					"client %q should appear in ConfiguredTools after multi-client setup", clientName)
+			}
+			Expect(cfg.ConfiguredTools).To(HaveLen(len(installedClients)),
+				"number of configured tools should match installed clients")
+		})
+	})
+
+	// ── Targeted teardown ──────────────────────────────────────────────────────
+
+	Describe("targeted teardown preserves other clients", func() {
+		It("tears down only the named client while leaving others configured", func() {
+			issuerURL := fmt.Sprintf("http://localhost:%d", oidcPort)
+
+			// Install claude-code and gemini-cli (both are cross-platform).
+			claudeDir := filepath.Join(tempDir, ".claude")
+			geminiDir := filepath.Join(tempDir, ".gemini")
+			Expect(os.MkdirAll(claudeDir, 0750)).To(Succeed())
+			Expect(os.MkdirAll(geminiDir, 0750)).To(Succeed())
+			Expect(createFakeBinary(binDir, "claude")).To(Succeed())
+			Expect(createFakeBinary(binDir, "gemini")).To(Succeed())
+
+			By("running setup for both clients")
+			stdout, stderr, err := runSetupWithOIDCCompletion(
+				thvCmd, oidcServer,
+				"--gateway-url", gatewayURL,
+				"--issuer", issuerURL,
+				"--client-id", clientID,
+			)
+			Expect(err).ToNot(HaveOccurred(),
+				"setup should succeed; stdout=%q stderr=%q", stdout, stderr)
+
+			By("verifying both clients are configured")
+			showOut, _ := thvCmd("llm", "config", "show", "--format", "json").ExpectSuccess()
+			var cfg llm.Config
+			Expect(json.Unmarshal([]byte(showOut), &cfg)).To(Succeed())
+			Expect(cfg.ConfiguredTools).To(HaveLen(2))
+
+			By("tearing down only claude-code")
+			thvCmd("llm", "teardown", "claude-code").ExpectSuccess()
+
+			By("verifying claude-code settings are reverted")
+			claudeSettings := filepath.Join(tempDir, ".claude", "settings.json")
+			data, err := os.ReadFile(claudeSettings)
+			Expect(err).ToNot(HaveOccurred())
+			var claudeAfter map[string]any
+			Expect(json.Unmarshal(data, &claudeAfter)).To(Succeed())
+			Expect(claudeAfter).ToNot(HaveKey("apiKeyHelper"))
+
+			By("verifying gemini-cli settings are still patched")
+			geminiSettings := filepath.Join(tempDir, ".gemini", "settings.json")
+			data, err = os.ReadFile(geminiSettings)
+			Expect(err).ToNot(HaveOccurred())
+			var geminiAfter map[string]any
+			Expect(json.Unmarshal(data, &geminiAfter)).To(Succeed())
+			Expect(jsonPointerGet(geminiAfter, "/auth/tokenCommand")).
+				To(ContainSubstring("llm token"),
+					"gemini-cli tokenCommand should still be set after claude-code teardown")
+
+			By("verifying ConfiguredTools has only gemini-cli")
+			showOut, _ = thvCmd("llm", "config", "show", "--format", "json").ExpectSuccess()
+			Expect(json.Unmarshal([]byte(showOut), &cfg)).To(Succeed())
+			Expect(cfg.ConfiguredTools).To(HaveLen(1))
+			Expect(string(cfg.ConfiguredTools[0].Tool)).To(Equal("gemini-cli"))
+		})
+	})
+
+	// ── Proxy start ───────────────────────────────────────────────────────────
+
+	Describe("thv llm proxy start", func() {
+		It("starts and listens on the configured proxy port", func() {
+			issuerURL := fmt.Sprintf("http://localhost:%d", oidcPort)
+
+			// Install claude-code so setup has at least one client to configure.
+			claudeDir := filepath.Join(tempDir, ".claude")
+			Expect(os.MkdirAll(claudeDir, 0750)).To(Succeed())
+			Expect(createFakeBinary(binDir, "claude")).To(Succeed())
+
+			By("running setup")
+			stdout, stderr, err := runSetupWithOIDCCompletion(
+				thvCmd, oidcServer,
+				"--gateway-url", gatewayURL,
+				"--issuer", issuerURL,
+				"--client-id", clientID,
+			)
+			Expect(err).ToNot(HaveOccurred(),
+				"setup should succeed; stdout=%q stderr=%q", stdout, stderr)
+
+			// Allocate a free port for the proxy so we don't clash with port 14000
+			// if another test or service already uses it.
+			proxyPort, portErr := networking.FindOrUsePort(0)
+			Expect(portErr).ToNot(HaveOccurred())
+
+			By(fmt.Sprintf("setting proxy port to %d", proxyPort))
+			thvCmd("llm", "config", "set", "--proxy-port", fmt.Sprintf("%d", proxyPort)).ExpectSuccess()
+
+			By("starting the proxy in a goroutine")
+			type proxyResult struct {
+				stdout, stderr string
+				err            error
+			}
+			done := make(chan proxyResult, 1)
+			proxyCmd := thvCmd("llm", "proxy", "start")
+			go func() {
+				out, serr, rerr := proxyCmd.RunWithTimeout(15 * time.Second)
+				done <- proxyResult{out, serr, rerr}
+			}()
+
+			By(fmt.Sprintf("waiting for proxy to listen on port %d", proxyPort))
+			proxyAddr := fmt.Sprintf("127.0.0.1:%d", proxyPort)
+			Eventually(func() error {
+				conn, err := net.DialTimeout("tcp", proxyAddr, 200*time.Millisecond)
+				if err != nil {
+					return err
+				}
+				_ = conn.Close()
+				return nil
+			}, 10*time.Second, 300*time.Millisecond).Should(Succeed(),
+				"proxy should be listening on %s", proxyAddr)
+
+			By("interrupting the proxy")
+			_ = proxyCmd.Interrupt()
+
+			select {
+			case r := <-done:
+				// The proxy may exit with a non-zero code on SIGINT — that's OK.
+				// We only care that it started cleanly (it was listening above).
+				_ = r
+			case <-time.After(5 * time.Second):
+				Fail("proxy did not exit after interrupt within 5s")
+			}
+		})
+	})
+
+	// ── Token command ─────────────────────────────────────────────────────────
+
+	Describe("thv llm token", func() {
+		It("returns a token when a cached access token is present", func() {
+			issuerURL := fmt.Sprintf("http://localhost:%d", oidcPort)
+
+			// Install claude-code so setup configures at least one client.
+			claudeDir := filepath.Join(tempDir, ".claude")
+			Expect(os.MkdirAll(claudeDir, 0750)).To(Succeed())
+			Expect(createFakeBinary(binDir, "claude")).To(Succeed())
+
+			By("running setup to persist config")
+			stdout, stderr, err := runSetupWithOIDCCompletion(
+				thvCmd, oidcServer,
+				"--gateway-url", gatewayURL,
+				"--issuer", issuerURL,
+				"--client-id", clientID,
+			)
+			Expect(err).ToNot(HaveOccurred(),
+				"setup should succeed; stdout=%q stderr=%q", stdout, stderr)
+
+			// Inject a fake but structurally valid cached access token via the
+			// environment secrets provider. The env provider reads from env vars
+			// with prefix TOOLHIVE_SECRET_. The scoped key for LLM access-token
+			// cache is: __thv_llm_<DeriveSecretKey(gateway, issuer)>_AT
+			// Value format: <token>|<expiry_RFC3339>
+			By("injecting cached access token into environment")
+			secretKey := tokensource.DeriveSecretKey("LLM_OAUTH_", gatewayURL, issuerURL)
+			scopedKey := "__thv_llm_" + secretKey + "_AT"
+			envKey := secrets.EnvVarPrefix + scopedKey
+			fakeToken := "test-access-token"
+			tokenValue := fakeToken + "|" + time.Now().Add(time.Hour).UTC().Format(time.RFC3339)
+
+			// Re-build thvCmd with the extra env var for this step only.
+			thvCmdWithToken := func(args ...string) *e2e.THVCommand {
+				return e2e.NewTHVCommand(thvConfig, args...).
+					WithEnv(
+						"XDG_CONFIG_HOME="+tempDir,
+						"HOME="+tempDir,
+						"PATH="+binDir+":"+os.Getenv("PATH"),
+						envKey+"="+tokenValue,
+					)
+			}
+
+			By("running thv llm token")
+			tokenOut, _, err := thvCmdWithToken("llm", "token").Run()
+			Expect(err).ToNot(HaveOccurred(), "thv llm token should succeed with a cached token")
+			Expect(strings.TrimSpace(tokenOut)).To(Equal(fakeToken),
+				"thv llm token should print the cached access token")
+		})
+	})
+
+	// ── Proxy: DNS rebinding protection ───────────────────────────────────────────
+
+	Describe("thv llm proxy start — DNS rebinding protection", func() {
+		It("returns 403 for a non-loopback Host header and allows loopback hosts", func() {
+			claudeDir := filepath.Join(tempDir, ".claude")
+			Expect(os.MkdirAll(claudeDir, 0750)).To(Succeed())
+			Expect(createFakeBinary(binDir, "claude")).To(Succeed())
+
+			issuerURL := fmt.Sprintf("http://localhost:%d", oidcPort)
+			stdout, stderr, err := runSetupWithOIDCCompletion(
+				thvCmd, oidcServer,
+				"--gateway-url", gatewayURL,
+				"--issuer", issuerURL,
+				"--client-id", clientID,
+			)
+			Expect(err).ToNot(HaveOccurred(),
+				"setup should succeed; stdout=%q stderr=%q", stdout, stderr)
+
+			proxyPort, portErr := networking.FindOrUsePort(0)
+			Expect(portErr).ToNot(HaveOccurred())
+
+			By(fmt.Sprintf("setting proxy port to %d and starting proxy", proxyPort))
+			thvCmd("llm", "config", "set", "--proxy-port", fmt.Sprintf("%d", proxyPort)).ExpectSuccess()
+
+			done := make(chan struct{})
+			proxyCmd := thvCmd("llm", "proxy", "start")
+			go func() {
+				defer close(done)
+				_, _, _ = proxyCmd.RunWithTimeout(15 * time.Second)
+			}()
+
+			proxyAddr := fmt.Sprintf("127.0.0.1:%d", proxyPort)
+			Eventually(func() error {
+				conn, dialErr := net.DialTimeout("tcp", proxyAddr, 200*time.Millisecond)
+				if dialErr != nil {
+					return dialErr
+				}
+				_ = conn.Close()
+				return nil
+			}, 10*time.Second, 300*time.Millisecond).Should(Succeed(),
+				"proxy should be listening on %s", proxyAddr)
+
+			By("verifying a non-loopback Host header is rejected with 403")
+			req, reqErr := http.NewRequest("GET", fmt.Sprintf("http://%s/v1/models", proxyAddr), nil)
+			Expect(reqErr).ToNot(HaveOccurred())
+			req.Host = "attacker.example.com"
+
+			resp, doErr := http.DefaultClient.Do(req) //nolint:noctx
+			Expect(doErr).ToNot(HaveOccurred())
+			_ = resp.Body.Close()
+			Expect(resp.StatusCode).To(Equal(http.StatusForbidden),
+				"non-loopback Host should be rejected with 403")
+
+			By("verifying a loopback Host header is not rejected with 403")
+			req2, reqErr2 := http.NewRequest("GET", fmt.Sprintf("http://%s/v1/models", proxyAddr), nil)
+			Expect(reqErr2).ToNot(HaveOccurred())
+			// Use the default Host (127.0.0.1:port) — no override needed.
+
+			resp2, doErr2 := http.DefaultClient.Do(req2) //nolint:noctx
+			Expect(doErr2).ToNot(HaveOccurred())
+			_ = resp2.Body.Close()
+			Expect(resp2.StatusCode).ToNot(Equal(http.StatusForbidden),
+				"loopback Host should pass the DNS-rebinding guard (got %d instead)", resp2.StatusCode)
+
+			By("stopping the proxy")
+			_ = proxyCmd.Interrupt()
+			select {
+			case <-done:
+			case <-time.After(5 * time.Second):
+				Fail("proxy did not exit after interrupt within 5s")
+			}
+		})
+	})
+
+	// ── Proxy: port conflict ───────────────────────────────────────────────────────
+
+	Describe("thv llm proxy start — port conflict", func() {
+		It("exits with an error when the configured port is already in use", func() {
+			claudeDir := filepath.Join(tempDir, ".claude")
+			Expect(os.MkdirAll(claudeDir, 0750)).To(Succeed())
+			Expect(createFakeBinary(binDir, "claude")).To(Succeed())
+
+			issuerURL := fmt.Sprintf("http://localhost:%d", oidcPort)
+			stdout, stderr, err := runSetupWithOIDCCompletion(
+				thvCmd, oidcServer,
+				"--gateway-url", gatewayURL,
+				"--issuer", issuerURL,
+				"--client-id", clientID,
+			)
+			Expect(err).ToNot(HaveOccurred(),
+				"setup should succeed; stdout=%q stderr=%q", stdout, stderr)
+
+			By("pre-binding a port to simulate a conflict")
+			listener, listenErr := net.Listen("tcp", "127.0.0.1:0")
+			Expect(listenErr).ToNot(HaveOccurred())
+			defer listener.Close() //nolint:errcheck
+			occupiedPort := listener.Addr().(*net.TCPAddr).Port
+
+			thvCmd("llm", "config", "set", "--proxy-port", fmt.Sprintf("%d", occupiedPort)).ExpectSuccess()
+
+			By(fmt.Sprintf("starting proxy on occupied port %d — expecting failure", occupiedPort))
+			_, _, err = thvCmd("llm", "proxy", "start").RunWithTimeout(10 * time.Second)
+			Expect(err).To(HaveOccurred(),
+				"proxy start should fail when the configured port is already in use")
+		})
+	})
+
+	// ── Proxy end-to-end token forwarding ────────────────────────────────────────
+	//
+	// These tests start a real mock LLM gateway and verify that the proxy
+	// correctly forwards the Bearer token to the upstream on every request.
+	// We iterate over all clients so that each client's setup + proxy combo is
+	// exercised against a real HTTP server rather than a fake URL.
+
+	Describe("thv llm proxy — end-to-end token forwarding", func() {
+		for _, clientTC := range allClientTestCases() {
+			clientTC := clientTC
+			It(fmt.Sprintf("forwards Bearer token to gateway for %s", clientTC.name), func() {
+				if clientTC.skipOnOS != "" && runtime.GOOS == clientTC.skipOnOS {
+					Skip(fmt.Sprintf("client %q not supported on %s", clientTC.name, runtime.GOOS))
+				}
+
+				// Allocate ports for the mock gateway and the proxy.
+				gatewayPort, portErr := networking.FindOrUsePort(0)
+				Expect(portErr).ToNot(HaveOccurred())
+				proxyPort, portErr := networking.FindOrUsePort(0)
+				Expect(portErr).ToNot(HaveOccurred())
+
+				// Start the mock LLM gateway (plain HTTP — no TLS cert trust needed
+				// in the subprocess).
+				By(fmt.Sprintf("[%s] starting mock LLM gateway on port %d", clientTC.name, gatewayPort))
+				gateway := e2e.NewLLMGatewayMockHTTP(gatewayPort)
+				Expect(gateway.Start()).To(Succeed())
+				defer func() { _ = gateway.Stop() }()
+
+				mockGatewayURL := gateway.URL()
+				issuerURL := fmt.Sprintf("http://localhost:%d", oidcPort)
+
+				// Create the detection directory and binary stub for this client.
+				By(fmt.Sprintf("[%s] installing client", clientTC.name))
+				Expect(os.MkdirAll(clientTC.detectionDir(tempDir), 0750)).To(Succeed())
+				if clientTC.binaryName != "" {
+					Expect(createFakeBinary(binDir, clientTC.binaryName)).To(Succeed())
+				}
+
+				// Run setup pointing at the mock gateway so the proxy knows where to
+				// forward requests.
+				By(fmt.Sprintf("[%s] running thv llm setup against mock gateway", clientTC.name))
+				stdout, stderr, err := runSetupWithOIDCCompletion(
+					thvCmd, oidcServer,
+					"--gateway-url", mockGatewayURL,
+					"--issuer", issuerURL,
+					"--client-id", clientID,
+				)
+				Expect(err).ToNot(HaveOccurred(),
+					"setup should succeed; stdout=%q stderr=%q", stdout, stderr)
+
+				// Inject a valid cached access token so the proxy can present it to
+				// the gateway without triggering a real OIDC browser flow.
+				// The environment secrets provider reads TOOLHIVE_SECRET_<scopedKey>.
+				// Value format: <token>|<expiry_RFC3339>
+				By(fmt.Sprintf("[%s] injecting cached access token", clientTC.name))
+				secretKey := tokensource.DeriveSecretKey("LLM_OAUTH_", mockGatewayURL, issuerURL)
+				scopedKey := "__thv_llm_" + secretKey + "_AT"
+				envKey := secrets.EnvVarPrefix + scopedKey
+				fakeToken := "e2e-bearer-token-" + clientTC.name
+				tokenValue := fakeToken + "|" + time.Now().Add(time.Hour).UTC().Format(time.RFC3339)
+
+				thvCmdWithToken := func(args ...string) *e2e.THVCommand {
+					return e2e.NewTHVCommand(thvConfig, args...).
+						WithEnv(
+							"XDG_CONFIG_HOME="+tempDir,
+							"HOME="+tempDir,
+							"PATH="+binDir+":"+os.Getenv("PATH"),
+							envKey+"="+tokenValue,
+						)
+				}
+
+				// Configure the proxy port and start it.
+				By(fmt.Sprintf("[%s] setting proxy port to %d", clientTC.name, proxyPort))
+				thvCmd("llm", "config", "set", "--proxy-port", fmt.Sprintf("%d", proxyPort)).ExpectSuccess()
+
+				By(fmt.Sprintf("[%s] starting the proxy", clientTC.name))
+				done := make(chan struct{})
+				proxyCmd := thvCmdWithToken("llm", "proxy", "start")
+				go func() {
+					defer close(done)
+					_, _, _ = proxyCmd.RunWithTimeout(20 * time.Second)
+				}()
+
+				proxyAddr := fmt.Sprintf("127.0.0.1:%d", proxyPort)
+				Eventually(func() error {
+					conn, dialErr := net.DialTimeout("tcp", proxyAddr, 200*time.Millisecond)
+					if dialErr != nil {
+						return dialErr
+					}
+					_ = conn.Close()
+					return nil
+				}, 10*time.Second, 300*time.Millisecond).Should(Succeed(),
+					"proxy should be listening on %s", proxyAddr)
+
+				// Send a request through the proxy and verify the gateway received it
+				// with the correct Bearer token.
+				By(fmt.Sprintf("[%s] sending GET /v1/models through the proxy", clientTC.name))
+				resp, doErr := http.Get(fmt.Sprintf("http://%s/v1/models", proxyAddr)) //nolint:noctx
+				Expect(doErr).ToNot(HaveOccurred(), "GET /v1/models through proxy should not error")
+				_ = resp.Body.Close()
+				Expect(resp.StatusCode).To(Equal(http.StatusOK),
+					"proxy should forward the request and return 200 OK")
+
+				By(fmt.Sprintf("[%s] verifying Bearer token was forwarded to gateway", clientTC.name))
+				Expect(gateway.LastBearerToken()).To(Equal(fakeToken),
+					"proxy should forward the cached access token as the Bearer token")
+
+				// Also verify the response payload is the expected mock JSON.
+				By(fmt.Sprintf("[%s] sending POST /v1/chat/completions through the proxy", clientTC.name))
+				chatResp, chatErr := http.Post( //nolint:noctx
+					fmt.Sprintf("http://%s/v1/chat/completions", proxyAddr),
+					"application/json",
+					strings.NewReader(`{"model":"mock-gpt-4","messages":[{"role":"user","content":"hi"}]}`),
+				)
+				Expect(chatErr).ToNot(HaveOccurred())
+				Expect(chatResp.StatusCode).To(Equal(http.StatusOK))
+				var chatBody map[string]any
+				Expect(json.NewDecoder(chatResp.Body).Decode(&chatBody)).To(Succeed())
+				_ = chatResp.Body.Close()
+				Expect(chatBody).To(HaveKey("choices"),
+					"chat completions response should contain 'choices'")
+
+				By(fmt.Sprintf("[%s] stopping the proxy", clientTC.name))
+				_ = proxyCmd.Interrupt()
+				select {
+				case <-done:
+				case <-time.After(5 * time.Second):
+					Fail("proxy did not exit after interrupt within 5s")
+				}
+			})
+		}
+	})
+
+	// ── Edge cases ─────────────────────────────────────────────────────────────────
+
+	Describe("edge cases", func() {
+		Describe("setup with no clients detected", func() {
+			It("exits cleanly and prints an informative message", func() {
+				// No detection dirs or binary stubs → no clients found.
+				issuerURL := fmt.Sprintf("http://localhost:%d", oidcPort)
+
+				By("running setup with no installed clients")
+				stdout, _ := thvCmd(
+					"llm", "setup",
+					"--gateway-url", gatewayURL,
+					"--issuer", issuerURL,
+					"--client-id", clientID,
+				).ExpectSuccess()
+
+				Expect(stdout).To(ContainSubstring("No supported AI tools detected"),
+					"setup should explain that no tools were found")
+			})
+		})
+
+		Describe("setup with a corrupted settings file", func() {
+			It("fails gracefully without modifying the corrupted file", func() {
+				claudeDir := filepath.Join(tempDir, ".claude")
+				Expect(os.MkdirAll(claudeDir, 0750)).To(Succeed())
+				Expect(createFakeBinary(binDir, "claude")).To(Succeed())
+
+				By("writing invalid JSON to the settings file")
+				settingsPath := filepath.Join(claudeDir, "settings.json")
+				corruptContent := []byte(`{not valid json!!!`)
+				Expect(os.WriteFile(settingsPath, corruptContent, 0600)).To(Succeed())
+
+				issuerURL := fmt.Sprintf("http://localhost:%d", oidcPort)
+				_, stderr, err := runSetupWithOIDCCompletion(
+					thvCmd, oidcServer,
+					"--gateway-url", gatewayURL,
+					"--issuer", issuerURL,
+					"--client-id", clientID,
+				)
+				Expect(err).To(HaveOccurred(),
+					"setup should fail when the settings file is corrupted; stderr=%q", stderr)
+
+				By("verifying the corrupted file was not modified")
+				data, readErr := os.ReadFile(settingsPath)
+				Expect(readErr).ToNot(HaveOccurred())
+				Expect(data).To(Equal(corruptContent),
+					"corrupted settings file should be left untouched on parse failure")
+			})
+		})
+
+		Describe("setup with an unreachable OIDC issuer", func() {
+			It("fails with an OIDC error and leaves settings files unmodified", func() {
+				claudeDir := filepath.Join(tempDir, ".claude")
+				Expect(os.MkdirAll(claudeDir, 0750)).To(Succeed())
+				Expect(createFakeBinary(binDir, "claude")).To(Succeed())
+
+				By("running setup with an unreachable issuer (port 1)")
+				_, stderr, err := thvCmd(
+					"llm", "setup",
+					"--gateway-url", gatewayURL,
+					"--issuer", "http://localhost:1",
+					"--client-id", "bad-client",
+				).RunWithTimeout(15 * time.Second)
+
+				Expect(err).To(HaveOccurred(),
+					"setup with unreachable issuer should fail")
+				Expect(stderr).To(ContainSubstring("OIDC"),
+					"error should mention OIDC; got stderr=%q", stderr)
+
+				By("verifying settings.json was not created")
+				settingsPath := filepath.Join(claudeDir, "settings.json")
+				_, statErr := os.Stat(settingsPath)
+				Expect(os.IsNotExist(statErr)).To(BeTrue(),
+					"settings.json should not be created when OIDC login fails")
+			})
+		})
+
+		Describe("thv llm token with an expired cached access token", func() {
+			It("does not return the expired token", func() {
+				claudeDir := filepath.Join(tempDir, ".claude")
+				Expect(os.MkdirAll(claudeDir, 0750)).To(Succeed())
+				Expect(createFakeBinary(binDir, "claude")).To(Succeed())
+
+				issuerURL := fmt.Sprintf("http://localhost:%d", oidcPort)
+				By("running setup to persist OIDC config")
+				stdout, stderr, err := runSetupWithOIDCCompletion(
+					thvCmd, oidcServer,
+					"--gateway-url", gatewayURL,
+					"--issuer", issuerURL,
+					"--client-id", clientID,
+				)
+				Expect(err).ToNot(HaveOccurred(),
+					"setup should succeed; stdout=%q stderr=%q", stdout, stderr)
+
+				By("injecting an expired cached access token via the environment provider")
+				secretKey := tokensource.DeriveSecretKey("LLM_OAUTH_", gatewayURL, issuerURL)
+				scopedKey := "__thv_llm_" + secretKey + "_AT"
+				envKey := secrets.EnvVarPrefix + scopedKey
+				expiredToken := "expired-test-token"
+				expiredAt := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
+				tokenValue := expiredToken + "|" + expiredAt
+
+				thvCmdWithExpired := func(args ...string) *e2e.THVCommand {
+					return e2e.NewTHVCommand(thvConfig, args...).
+						WithEnv(
+							"XDG_CONFIG_HOME="+tempDir,
+							"HOME="+tempDir,
+							"PATH="+binDir+":"+os.Getenv("PATH"),
+							envKey+"="+tokenValue,
+						)
+				}
+
+				By("running thv llm token with the expired token in the environment")
+				tokenOut, _, tokenErr := thvCmdWithExpired("llm", "token").Run()
+
+				// The expired token must never be printed, regardless of whether
+				// re-auth succeeded or failed (no refresh token is available with
+				// the read-only environment secrets provider).
+				Expect(strings.TrimSpace(tokenOut)).ToNot(Equal(expiredToken),
+					"expired token must not be returned directly")
+
+				if tokenErr == nil {
+					// Re-auth via OIDC browser flow succeeded (mock OIDC auto-completes).
+					Expect(strings.TrimSpace(tokenOut)).ToNot(BeEmpty(),
+						"a fresh token should have been obtained after expiry")
+				}
+				// If tokenErr != nil the command failed (expected when no refresh
+				// token is cached), which is also correct behaviour.
+			})
+		})
+	})
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+// createFakeBinary writes a minimal no-op shell script named `name` in dir.
+// This satisfies the LLMBinaryName check in DetectedLLMGatewayClients.
+func createFakeBinary(dir, name string) error {
+	script := []byte("#!/bin/sh\nexit 0\n")
+	return os.WriteFile(filepath.Join(dir, name), script, 0750)
+}
+
+// installAllDetectedClients creates the detection directories (and binary
+// stubs) for every client in the test matrix that should be detected on the
+// current OS. It returns the list of client names that were installed.
+func installAllDetectedClients(tempDir, binDir string) []string {
+	var installed []string
+	for _, tc := range allClientTestCases() {
+		if tc.skipOnOS != "" && runtime.GOOS == tc.skipOnOS {
+			continue
+		}
+		dir := tc.detectionDir(tempDir)
+		Expect(os.MkdirAll(dir, 0750)).To(Succeed())
+		if tc.binaryName != "" {
+			Expect(createFakeBinary(binDir, tc.binaryName)).To(Succeed())
+		}
+		installed = append(installed, tc.name)
+	}
+	return installed
+}
+
+// jsonPointerGet resolves a simplified JSON pointer against a map[string]any,
+// returning the string value or empty string if not found. Supports two-level
+// nesting (e.g. "/auth/tokenCommand") but not arrays.
+func jsonPointerGet(obj map[string]any, pointer string) string {
+	segments := strings.Split(strings.TrimPrefix(pointer, "/"), "/")
+	var cur any = obj
+	for _, seg := range segments {
+		// Unescape RFC 6901 tokens: ~1 → /, ~0 → ~
+		seg = strings.ReplaceAll(seg, "~1", "/")
+		seg = strings.ReplaceAll(seg, "~0", "~")
+
+		m, ok := cur.(map[string]any)
+		if !ok {
+			return ""
+		}
+		cur = m[seg]
+	}
+	if cur == nil {
+		return ""
+	}
+	return fmt.Sprintf("%v", cur)
+}

--- a/test/e2e/cli_llm_setup_test.go
+++ b/test/e2e/cli_llm_setup_test.go
@@ -107,6 +107,7 @@ var _ = Describe("thv llm setup / teardown", Label("cli", "llm", "setup", "e2e")
 	var (
 		thvConfig    *e2e.TestConfig
 		tempDir      string
+		binDir       string
 		oidcPort     int
 		oidcServer   *e2e.OIDCMockServer
 		thvCmd       func(args ...string) *e2e.THVCommand
@@ -121,7 +122,8 @@ var _ = Describe("thv llm setup / teardown", Label("cli", "llm", "setup", "e2e")
 
 		// Install a fake browser so OIDC login completes in headless/CI
 		// environments where no real browser is available.
-		binDir, binDirErr := e2e.CreateFakeBrowserDir(tempDir)
+		var binDirErr error
+		binDir, binDirErr = e2e.CreateFakeBrowserDir(tempDir)
 		Expect(binDirErr).ToNot(HaveOccurred())
 
 		// Isolated environment: XDG_CONFIG_HOME and HOME point to tempDir so
@@ -172,9 +174,10 @@ var _ = Describe("thv llm setup / teardown", Label("cli", "llm", "setup", "e2e")
 
 	Describe("thv llm setup with inline flags", func() {
 		It("patches detected tools and persists config", func() {
-			// Create ~/.claude/ so the Claude Code adapter detects the tool.
+			// Create ~/.claude/ and stub the claude binary so the Claude Code adapter detects the tool.
 			claudeDir := filepath.Join(tempDir, ".claude")
 			Expect(os.MkdirAll(claudeDir, 0750)).To(Succeed())
+			Expect(createFakeBinary(binDir, "claude")).To(Succeed())
 
 			issuerURL := fmt.Sprintf("http://localhost:%d", oidcPort)
 
@@ -223,9 +226,10 @@ var _ = Describe("thv llm setup / teardown", Label("cli", "llm", "setup", "e2e")
 
 	Describe("thv llm teardown", func() {
 		It("reverts all tool configs", func() {
-			// Create ~/.claude/ to trigger Claude Code detection.
+			// Create ~/.claude/ and stub the claude binary to trigger Claude Code detection.
 			claudeDir := filepath.Join(tempDir, ".claude")
 			Expect(os.MkdirAll(claudeDir, 0750)).To(Succeed())
+			Expect(createFakeBinary(binDir, "claude")).To(Succeed())
 
 			issuerURL := fmt.Sprintf("http://localhost:%d", oidcPort)
 
@@ -277,6 +281,7 @@ var _ = Describe("thv llm setup / teardown", Label("cli", "llm", "setup", "e2e")
 			// teardown path itself and confirms that an unknown tool name is rejected.
 			claudeDir := filepath.Join(tempDir, ".claude")
 			Expect(os.MkdirAll(claudeDir, 0750)).To(Succeed())
+			Expect(createFakeBinary(binDir, "claude")).To(Succeed())
 
 			issuerURL := fmt.Sprintf("http://localhost:%d", oidcPort)
 
@@ -331,6 +336,7 @@ var _ = Describe("thv llm setup / teardown", Label("cli", "llm", "setup", "e2e")
 		It("clears cached tokens in addition to reverting tool configs", func() {
 			claudeDir := filepath.Join(tempDir, ".claude")
 			Expect(os.MkdirAll(claudeDir, 0750)).To(Succeed())
+			Expect(createFakeBinary(binDir, "claude")).To(Succeed())
 
 			issuerURL := fmt.Sprintf("http://localhost:%d", oidcPort)
 

--- a/test/e2e/cli_llm_setup_test.go
+++ b/test/e2e/cli_llm_setup_test.go
@@ -120,26 +120,9 @@ var _ = Describe("thv llm setup / teardown", Label("cli", "llm", "setup", "e2e")
 		tempDir = GinkgoT().TempDir()
 
 		// Install a fake browser so OIDC login completes in headless/CI
-		// environments where no real browser is available. The script GETs
-		// the auth URL (without following the 302 redirect) so the mock OIDC
-		// server receives the /auth request and populates authRequestChan;
-		// CompleteAuthRequest then drives the callback hit.
-		//
-		// Platform note: CI runs on ubuntu-8cores-32gb (Linux only; no Windows
-		// support). curl ships on every GitHub-hosted Ubuntu runner; wget is
-		// tried as a fallback for minimal images.
-		binDir := filepath.Join(tempDir, "bin")
-		Expect(os.MkdirAll(binDir, 0750)).To(Succeed())
-		fakeBrowser := []byte(
-			"#!/bin/sh\n" +
-				// curl: -sf = silent + fail-on-HTTP-error; no -L so 302 is not followed.
-				// wget: --max-redirect=0 prevents following the 302 to the callback URL,
-				//       which would race with CompleteAuthRequest and make the test flaky.
-				"curl -sf \"$1\" >/dev/null 2>&1 || wget -q --max-redirect=0 \"$1\" -O /dev/null 2>&1 || true\n",
-		)
-		for _, name := range []string{"open", "xdg-open"} {
-			Expect(os.WriteFile(filepath.Join(binDir, name), fakeBrowser, 0750)).To(Succeed())
-		}
+		// environments where no real browser is available.
+		binDir, binDirErr := e2e.CreateFakeBrowserDir(tempDir)
+		Expect(binDirErr).ToNot(HaveOccurred())
 
 		// Isolated environment: XDG_CONFIG_HOME and HOME point to tempDir so
 		// these tests never touch the user's real config.yaml or secrets store.

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"syscall"
 	"time"
@@ -328,4 +329,26 @@ func RemoveGroup(config *TestConfig, groupName string) error {
 func CreateAndTrackGroup(config *TestConfig, groupName string, createdGroups *[]string) {
 	NewTHVCommand(config, "group", "create", groupName).ExpectSuccess()
 	*createdGroups = append(*createdGroups, groupName)
+}
+
+// CreateFakeBrowserDir writes stub open/xdg-open scripts into a "fakebin"
+// subdirectory of tempDir. The stubs GET the auth URL without following the
+// redirect, so the OIDC mock server receives the request and populates
+// authRequestChan while CompleteAuthRequest drives the callback.
+// Returns the directory so callers can prepend it to PATH.
+func CreateFakeBrowserDir(tempDir string) (string, error) {
+	dir := filepath.Join(tempDir, "fakebin")
+	if err := os.MkdirAll(dir, 0750); err != nil {
+		return "", err
+	}
+	// curl: -sf = silent + fail-on-HTTP-error; no -L so 302 is not followed.
+	// wget: --max-redirect=0 prevents following the 302 to the callback URL,
+	//       which would race with CompleteAuthRequest and make the test flaky.
+	script := []byte("#!/bin/sh\ncurl -sf \"$1\" >/dev/null 2>&1 || wget -q --max-redirect=0 \"$1\" -O /dev/null 2>&1 || true\n")
+	for _, name := range []string{"open", "xdg-open"} {
+		if err := os.WriteFile(filepath.Join(dir, name), script, 0750); err != nil { //nolint:gosec // shell scripts must be executable
+			return "", err
+		}
+	}
+	return dir, nil
 }

--- a/test/e2e/llm_gateway_mock.go
+++ b/test/e2e/llm_gateway_mock.go
@@ -1,0 +1,275 @@
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+// GatewayRequest records a single request received by the mock LLM gateway.
+type GatewayRequest struct {
+	Method string
+	Path   string
+	// Bearer is the token value stripped from the Authorization header,
+	// or empty if no Authorization header was present.
+	Bearer string
+}
+
+// LLMGatewayMock is a server that responds to OpenAI-compatible requests
+// (/v1/models, /v1/chat/completions) and records every request it receives.
+//
+// Use NewLLMGatewayMock for HTTPS (self-signed cert) or NewLLMGatewayMockHTTP
+// for plain HTTP. The HTTP variant is simpler for e2e tests where the thv
+// subprocess cannot be easily configured to trust a self-signed cert.
+type LLMGatewayMock struct {
+	server  *http.Server
+	port    int
+	useTLS  bool
+	certPEM []byte // non-nil only when useTLS is true
+
+	mu       sync.Mutex
+	requests []GatewayRequest
+}
+
+// NewLLMGatewayMock creates a mock LLM gateway that serves HTTPS with a
+// self-signed certificate. Use CertPEM / TLSClientConfig to build a trusting
+// HTTP client. Call Start to begin serving.
+func NewLLMGatewayMock(port int) (*LLMGatewayMock, error) {
+	certPEM, keyPEM, err := generateGatewayCert()
+	if err != nil {
+		return nil, err
+	}
+
+	cert, err := tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		return nil, fmt.Errorf("loading TLS key pair: %w", err)
+	}
+
+	m := &LLMGatewayMock{port: port, useTLS: true, certPEM: certPEM}
+	m.server = m.newServer()
+	m.server.TLSConfig = &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		MinVersion:   tls.VersionTLS12,
+	}
+
+	return m, nil
+}
+
+// NewLLMGatewayMockHTTP creates a mock LLM gateway that serves plain HTTP.
+// Useful in e2e tests where the thv subprocess cannot easily be configured to
+// trust a self-signed certificate. Call Start to begin serving.
+func NewLLMGatewayMockHTTP(port int) *LLMGatewayMock {
+	m := &LLMGatewayMock{port: port, useTLS: false}
+	m.server = m.newServer()
+	return m
+}
+
+func (m *LLMGatewayMock) newServer() *http.Server {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/models", m.handleModels)
+	mux.HandleFunc("/v1/chat/completions", m.handleChatCompletions)
+	mux.HandleFunc("/health", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("OK"))
+	})
+	return &http.Server{
+		Addr:              fmt.Sprintf(":%d", m.port),
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+}
+
+// Start begins serving requests. It blocks briefly until the port is open.
+func (m *LLMGatewayMock) Start() error {
+	errCh := make(chan error, 1)
+	go func() {
+		var err error
+		if m.useTLS {
+			err = m.server.ListenAndServeTLS("", "")
+		} else {
+			err = m.server.ListenAndServe()
+		}
+		if err != nil && err != http.ErrServerClosed {
+			errCh <- err
+		}
+	}()
+
+	addr := fmt.Sprintf("127.0.0.1:%d", m.port)
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		conn, err := net.DialTimeout("tcp", addr, 200*time.Millisecond)
+		if err == nil {
+			_ = conn.Close()
+			return nil
+		}
+		select {
+		case err := <-errCh:
+			return err
+		default:
+			time.Sleep(50 * time.Millisecond)
+		}
+	}
+	return fmt.Errorf("mock LLM gateway did not start on port %d within 5s", m.port)
+}
+
+// Stop shuts down the mock gateway.
+func (m *LLMGatewayMock) Stop() error {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	return m.server.Shutdown(ctx)
+}
+
+// URL returns the base URL of the mock gateway (https:// or http:// depending
+// on how the mock was created).
+func (m *LLMGatewayMock) URL() string {
+	scheme := "https"
+	if !m.useTLS {
+		scheme = "http"
+	}
+	return fmt.Sprintf("%s://localhost:%d", scheme, m.port)
+}
+
+// CertPEM returns the PEM-encoded self-signed certificate. Use this to build a
+// custom *http.Client or x509.CertPool that trusts the mock gateway.
+func (m *LLMGatewayMock) CertPEM() []byte {
+	return m.certPEM
+}
+
+// TLSClientConfig returns a *tls.Config that trusts the mock gateway's
+// self-signed certificate. Useful for building a custom *http.Client in tests.
+func (m *LLMGatewayMock) TLSClientConfig() (*tls.Config, error) {
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(m.certPEM) {
+		return nil, fmt.Errorf("failed to parse mock gateway certificate")
+	}
+	return &tls.Config{RootCAs: pool, MinVersion: tls.VersionTLS12}, nil //nolint:gosec // test-only; min version set
+}
+
+// Requests returns a copy of all requests received so far, in order.
+func (m *LLMGatewayMock) Requests() []GatewayRequest {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]GatewayRequest, len(m.requests))
+	copy(out, m.requests)
+	return out
+}
+
+// LastBearerToken returns the Bearer token from the most recent request, or
+// empty string if no requests have been received or none carried a token.
+func (m *LLMGatewayMock) LastBearerToken() string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for i := len(m.requests) - 1; i >= 0; i-- {
+		if m.requests[i].Bearer != "" {
+			return m.requests[i].Bearer
+		}
+	}
+	return ""
+}
+
+// record saves a request observation.
+func (m *LLMGatewayMock) record(r *http.Request) {
+	bearer := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+	if bearer == r.Header.Get("Authorization") {
+		bearer = "" // no "Bearer " prefix → no token
+	}
+	m.mu.Lock()
+	m.requests = append(m.requests, GatewayRequest{
+		Method: r.Method,
+		Path:   r.URL.Path,
+		Bearer: bearer,
+	})
+	m.mu.Unlock()
+}
+
+func (m *LLMGatewayMock) handleModels(w http.ResponseWriter, r *http.Request) {
+	m.record(r)
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"object": "list",
+		"data": []map[string]any{
+			{"id": "mock-gpt-4", "object": "model", "created": 1700000000, "owned_by": "mock"},
+			{"id": "mock-claude-3", "object": "model", "created": 1700000000, "owned_by": "mock"},
+		},
+	})
+}
+
+func (m *LLMGatewayMock) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
+	m.record(r)
+
+	var body map[string]any
+	_ = json.NewDecoder(r.Body).Decode(&body)
+
+	model := "mock-gpt-4"
+	if v, ok := body["model"].(string); ok {
+		model = v
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"id":      "chatcmpl-mock-001",
+		"object":  "chat.completion",
+		"created": time.Now().Unix(),
+		"model":   model,
+		"choices": []map[string]any{{
+			"index": 0,
+			"message": map[string]any{
+				"role":    "assistant",
+				"content": "Hello from the mock LLM gateway!",
+			},
+			"finish_reason": "stop",
+		}},
+		"usage": map[string]any{
+			"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30,
+		},
+	})
+}
+
+// generateGatewayCert creates a self-signed ECDSA certificate for localhost.
+func generateGatewayCert() (certPEM, keyPEM []byte, err error) {
+	privKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, nil, fmt.Errorf("generating key: %w", err)
+	}
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{Organization: []string{"thv-llm-mock"}},
+		DNSNames:     []string{"localhost"},
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::1")},
+		NotBefore:    time.Now().Add(-time.Minute),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &privKey.PublicKey, privKey)
+	if err != nil {
+		return nil, nil, fmt.Errorf("creating certificate: %w", err)
+	}
+	certPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+
+	keyDER, err := x509.MarshalECPrivateKey(privKey)
+	if err != nil {
+		return nil, nil, fmt.Errorf("marshaling key: %w", err)
+	}
+	keyPEM = pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+
+	return certPEM, keyPEM, nil
+}


### PR DESCRIPTION
## Summary

Two bugs were found while building a new e2e test suite for \`thv llm\` commands across all supported AI clients. This PR ships the fixes and the full test suite together.

**Bug 1 — \`thv secret provider environment\` fails without a container runtime**
\`"secret"\` was missing from \`informationalCommands\` in \`cmd/thv/app/commands.go\`, so \`thv secret\` triggered the Docker availability check. This broke \`thv secret provider environment\` on machines without a running container runtime.

**Bug 2 — \`GetSystemSecretsProvider\` ignores \`TOOLHIVE_SECRETS_PROVIDER\` env var**
\`pkg/auth/secrets/secrets.go\` checked \`SetupCompleted\` before calling \`GetProviderType()\`. Since \`GetProviderType()\` is what reads the env var and allows the \`environment\` provider without interactive setup, the bypass was silently skipped.

**New: \`test/e2e/cli_llm_all_clients_test.go\`** — 16 e2e tests covering the full \`thv llm\` workflow across all 6 supported clients using an in-process mock OIDC server and fake browser stubs (no Docker, no real credentials).

**New: \`test/llm-mock-env/\`** — standalone helper for manual testing with a local mock OIDC + LLM gateway.

Fixes #5115

## Type of change

- [x] Bug fix
- [x] New feature

## Test plan

- [x] E2E tests (\`THV_BINARY=<binary> ginkgo run --label-filter="llm && clients" ./test/e2e/\` — all 16 pass)
- [x] Manual testing (describe below)

Ran the full new suite locally with Docker available and confirmed all 16 tests pass. Also reproduced both bugs on a machine without Docker running and confirmed the fixes resolve them.

## API Compatibility

- [x] This PR does not break the \`v1beta1\` API, OR the \`api-break-allowed\` label is applied and the migration guidance is described above.

## Changes

| File | Change |
|------|--------|
| \`cmd/thv/app/commands.go\` | Add \`"secret"\` to \`informationalCommands\` |
| \`pkg/auth/secrets/secrets.go\` | Call \`GetProviderType()\` before \`SetupCompleted\` guard in \`GetSystemSecretsProvider\` |
| \`test/e2e/cli_llm_all_clients_test.go\` | New: 16 e2e tests for the full \`thv llm\` client matrix |
| \`test/llm-mock-env/main.go\` | New: standalone mock OIDC + LLM gateway for manual testing |

## Does this introduce a user-facing change?

Yes — \`thv secret\` subcommands no longer fail when no container runtime is available. \`thv llm token\` and secrets-related flows now correctly honour \`TOOLHIVE_SECRETS_PROVIDER=environment\` without requiring interactive secrets setup first.

## Special notes for reviewers

The 16 new e2e tests use \`Label("cli", "llm", "clients", "e2e")\`. Adding \`{title: llm, label_filter: "llm && clients"}\` to \`.github/workflows/e2e-tests.yml\` is a recommended follow-up to run them in CI — they are ~40s and fully Docker-free.

## Large PR Justification

This is an isolated PR that mostly adds e2e testing to thv llm for different clients. Cannot be split.
