### PR TITLE
Make Cedar group entity type name configurable

### DIFF
--- a/pkg/authz/authorizers/cedar/core.go
+++ b/pkg/authz/authorizers/cedar/core.go
@@ -201,9 +201,50 @@ type ConfigOptions struct {
 
 	// RoleClaimName is the JWT claim key that contains role membership for the
 	// principal. When set, the claim is extracted separately from GroupClaimName
-	// and both are mapped to Cedar THVGroup entities.
+	// and both are mapped to the configured group entity type (default "THVGroup").
 	// When empty, no role extraction is performed (backward compatible).
 	RoleClaimName string `json:"role_claim_name,omitempty" yaml:"role_claim_name,omitempty"`
+
+	// GroupEntityType is the Cedar entity type name used for Client parent UIDs
+	// synthesised from JWT group/role claims. Defaults to "THVGroup" when empty,
+	// preserving the original behaviour. Must be a valid Cedar identifier — namespaced
+	// names (e.g. "Platform::Group") are not yet supported and are rejected at
+	// construction. See issue #5072.
+	GroupEntityType string `json:"group_entity_type,omitempty" yaml:"group_entity_type,omitempty"`
+}
+
+// validateGroupEntityType validates a GroupEntityType value. Empty string is
+// valid — it means "use the default" and is resolved by NewEntityFactory.
+// Non-empty values must:
+//   - not contain Cedar's "::" namespace separator (out of scope per #5072), and
+//   - parse cleanly as a Cedar identifier when used as an entity type in a
+//     synthetic policy. We delegate the identifier-grammar check to cedar-go's
+//     policy parser so that future grammar refinements in upstream cedar-go are
+//     picked up automatically — this is the source of truth for Cedar identifier
+//     validity. Hand-rolling the grammar (reserved words, ANYIDENT regex,
+//     __cedar prefix) duplicates rules cedar-go already enforces.
+func validateGroupEntityType(s string) error {
+	if s == "" {
+		return nil
+	}
+
+	// Check for namespace separator first: namespaced types are out of scope.
+	// This must run before the cedar-go round-trip because the Cedar parser
+	// accepts "Foo::Bar" as a valid namespaced type, but we reject it for
+	// project-specific reasons.
+	if strings.Contains(s, "::") {
+		return fmt.Errorf("group_entity_type %q contains \"::\": namespaced entity types are not yet supported", s)
+	}
+
+	// Round-trip through cedar-go's policy parser. If the synthesized policy
+	// text fails to parse, the type name violates Cedar's identifier grammar
+	// (reserved word, invalid character, leading digit, etc.).
+	synth := fmt.Sprintf(`permit(principal in %s::"x", action, resource);`, s)
+	var p cedar.Policy
+	if err := p.UnmarshalCedar([]byte(synth)); err != nil {
+		return fmt.Errorf("group_entity_type %q is not a valid Cedar identifier: %w", s, err)
+	}
+	return nil
 }
 
 // NewCedarAuthorizer creates a new Cedar authorizer.
@@ -212,10 +253,14 @@ type ConfigOptions struct {
 // If a second runtime-injected value is needed, bundle both into a
 // RuntimeContext struct to keep the factory interface stable.
 func NewCedarAuthorizer(options ConfigOptions, serverName string) (authorizers.Authorizer, error) {
+	if err := validateGroupEntityType(options.GroupEntityType); err != nil {
+		return nil, err
+	}
+
 	authorizer := &Authorizer{
 		policySet:               cedar.NewPolicySet(),
 		entities:                cedar.EntityMap{},
-		entityFactory:           NewEntityFactory(),
+		entityFactory:           NewEntityFactory(cedar.EntityType(options.GroupEntityType)),
 		primaryUpstreamProvider: options.PrimaryUpstreamProvider,
 		groupClaimName:          options.GroupClaimName,
 		roleClaimName:           options.RoleClaimName,
@@ -242,6 +287,23 @@ func NewCedarAuthorizer(options ConfigOptions, serverName string) (authorizers.A
 	if options.EntitiesJSON != "" {
 		if err := json.Unmarshal([]byte(options.EntitiesJSON), &authorizer.entities); err != nil {
 			return nil, fmt.Errorf("failed to parse entities JSON: %w", err)
+		}
+
+		// Warn once if entities_json contains stale THVGroup entities while
+		// GroupEntityType is configured to a different type. Cedar's `in` operator
+		// compares entity UIDs by type name, so the pre-loaded THVGroup entities will
+		// never match the synthesised parents and any policy referencing them will
+		// silently deny every request.
+		if options.GroupEntityType != "" && options.GroupEntityType != string(EntityTypeTHVGroup) {
+			for uid := range authorizer.entities {
+				if uid.Type == EntityTypeTHVGroup {
+					slog.Warn("Cedar entities_json contains THVGroup entities but GroupEntityType is set to a different value; "+
+						"synthesised group parents will not match these pre-loaded entities and policies that reference them will silently deny",
+						"configured_group_entity_type", options.GroupEntityType,
+						"stale_entity_uid", uid.String())
+					break
+				}
+			}
 		}
 	}
 
@@ -325,9 +387,10 @@ func (a *Authorizer) GetEntityFactory() *EntityFactory {
 // - resource: The object being accessed (e.g., "Tool::weather")
 // - context: Additional information about the request
 //
-// Note: group-based Cedar policies (e.g. "principal in THVGroup::\"eng\"") require
-// that THVGroup parent entities are included in the entity map. See #4768 for the
-// group parent wiring that will set these up via CreatePrincipalEntity.
+// Note: group-based Cedar policies (e.g. "principal in THVGroup::\"eng\"" with the
+// default group entity type — see ConfigOptions.GroupEntityType) require that
+// group parent entities are included in the entity map. See #4768 for the group
+// parent wiring that will set these up via CreatePrincipalEntity.
 // - entities: Optional Cedar entity map with attributes
 func (a *Authorizer) IsAuthorized(
 	principal, action, resource string,
@@ -763,8 +826,9 @@ func (a *Authorizer) AuthorizeWithJWTClaims(
 	}
 
 	// Extract groups from the group claim (or well-known defaults) and the
-	// role claim, merge, and dedup. Both claim sources map to Cedar THVGroup
-	// entities. Extraction runs BEFORE preprocessClaims so the raw claim
+	// role claim, merge, and dedup. Both claim sources map to the configured
+	// group entity type (default "THVGroup"). Extraction runs BEFORE
+	// preprocessClaims so the raw claim
 	// values are available.
 	// The identity pointer is not mutated here because Identity MUST NOT be
 	// modified after it is placed in the request context (concurrent reads).

--- a/pkg/authz/authorizers/cedar/core_test.go
+++ b/pkg/authz/authorizers/cedar/core_test.go
@@ -4,8 +4,10 @@
 package cedar
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"log/slog"
 	"testing"
 
 	cedar "github.com/cedar-policy/cedar-go"
@@ -2830,6 +2832,301 @@ func TestConfigOptionsRoleClaimNameJSON(t *testing.T) {
 					"empty RoleClaimName must be omitted from JSON output")
 			} else {
 				assert.Contains(t, string(marshalled), "role_claim_name")
+			}
+		})
+	}
+}
+
+// TestValidateGroupEntityType exercises the private validateGroupEntityType helper
+// directly. Each case names an input, states whether it should succeed, and — for
+// error cases — a substring that the error message must contain so operators can
+// diagnose misconfiguration from a single log line.
+//
+// Only our package's contract is tested here:
+//  1. Empty string short-circuits to nil.
+//  2. Inputs containing "::" are rejected with our project-specific error.
+//  3. Valid Cedar identifiers pass through (smoke test of the cedar-go delegation path).
+//  4. Invalid Cedar identifiers surface the cedar-go rejection wrapped with our message.
+//  5. __cedarFoo is accepted — the Cedar spec only reserves the bare "__cedar" token,
+//     not the entire prefix namespace. This intentional behavioral difference vs older
+//     hand-rolled validators would be the most surprising case for a future reader.
+//
+// Exhaustive grammar testing (hyphens, leading digits, whitespace, reserved words, …)
+// belongs in cedar-go's own test suite, not here.
+func TestValidateGroupEntityType(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name        string
+		input       string
+		wantErr     bool
+		errContains string // substring the error message must contain (ignored when wantErr=false)
+	}{
+		{
+			// Empty string triggers the short-circuit: our function returns nil immediately
+			// without consulting cedar-go's parser.
+			name:    "empty string accepted (short-circuit, means use default)",
+			input:   "",
+			wantErr: false,
+		},
+		{
+			// Smoke test: a plain valid identifier must pass the cedar-go delegation path.
+			name:    "valid Cedar identifier accepted",
+			input:   "OrgRole",
+			wantErr: false,
+		},
+		{
+			// Our project rule: "::" always means a namespaced type which is never a
+			// valid bare entity-type name. We reject before delegating to cedar-go.
+			name:        "namespaced type rejected with project-specific message",
+			input:       "Foo::Bar",
+			wantErr:     true,
+			errContains: "::",
+		},
+		{
+			// Smoke test: an invalid Cedar identifier must produce an error containing
+			// our wrapper text, proving the cedar-go rejection bubbles up correctly.
+			// One representative case is sufficient; the grammar details are cedar-go's domain.
+			name:        "invalid Cedar identifier rejected with wrapper message",
+			input:       "Org-Role",
+			wantErr:     true,
+			errContains: "not a valid Cedar identifier",
+		},
+		{
+			// The Cedar spec reserves the literal "__cedar" token. "__cedarFoo" (with a
+			// suffix) is accepted because the reservation does NOT extend to the whole
+			// prefix namespace. This is intentionally different from older hand-rolled
+			// validators that rejected the entire "__cedar" prefix — keep this case so a
+			// future refactor cannot silently regress to the stricter behavior.
+			name:    "__cedarFoo accepted (Cedar spec only reserves bare __cedar)",
+			input:   "__cedarFoo",
+			wantErr: false,
+		},
+		{
+			// Sanity check that cedar-go's reserved-word rejection surfaces through our
+			// wrapper. One reserved word is enough to prove the path works.
+			name:        "reserved word 'in' rejected",
+			input:       "in",
+			wantErr:     true,
+			errContains: "not a valid Cedar identifier",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := validateGroupEntityType(tc.input)
+
+			if tc.wantErr {
+				require.Error(t, err, "expected an error for input %q", tc.input)
+				assert.Contains(t, err.Error(), tc.errContains,
+					"error for %q should mention %q", tc.input, tc.errContains)
+			} else {
+				require.NoError(t, err, "unexpected error for input %q", tc.input)
+			}
+		})
+	}
+}
+
+// TestAuthorizeWithJWTClaims_CustomGroupEntityType proves that GroupEntityType
+// actually flows through Cedar evaluation, not just through entity construction.
+// Case A: GroupEntityType "OrgRole" with policy "principal in OrgRole::..." → Permit.
+// Case B: same policy, default GroupEntityType "" (resolves to THVGroup) → Deny,
+// because the parent UIDs are typed THVGroup::"engineering" which is not in OrgRole.
+// The two cases are adjacent so the contrast is visible to reviewers.
+func TestAuthorizeWithJWTClaims_CustomGroupEntityType(t *testing.T) {
+	t.Parallel()
+
+	// Policy references OrgRole — only a factory configured with GroupEntityType "OrgRole"
+	// will synthesise parent UIDs that match this policy.
+	policy := `
+		permit(
+			principal in OrgRole::"engineering",
+			action == Action::"call_tool",
+			resource == Tool::"deploy"
+		);
+	`
+
+	identity := &auth.Identity{
+		PrincipalInfo: auth.PrincipalInfo{
+			Subject: "user1",
+			Claims: map[string]any{
+				"sub":    "user1",
+				"groups": []interface{}{"engineering"},
+			},
+		},
+	}
+
+	tests := []struct {
+		name            string
+		groupEntityType string
+		wantAuthorize   bool
+	}{
+		{
+			// GroupEntityType "OrgRole" makes the factory emit OrgRole::"engineering"
+			// as the principal's parent UID. Cedar's `in` resolves to true → Permit.
+			name:            "custom_type_OrgRole_permits",
+			groupEntityType: "OrgRole",
+			wantAuthorize:   true,
+		},
+		{
+			// Default GroupEntityType "" resolves to THVGroup. The factory emits
+			// THVGroup::"engineering" instead of OrgRole::"engineering". Cedar's `in`
+			// for OrgRole::"engineering" evaluates to false → Deny by default.
+			name:            "default_type_THVGroup_denies",
+			groupEntityType: "",
+			wantAuthorize:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			authorizer, err := NewCedarAuthorizer(ConfigOptions{
+				Policies:        []string{policy},
+				EntitiesJSON:    `[]`,
+				GroupClaimName:  "groups",
+				GroupEntityType: tt.groupEntityType,
+			}, "")
+			require.NoError(t, err)
+
+			ctx := auth.WithIdentity(context.Background(), identity)
+
+			authorized, err := authorizer.AuthorizeWithJWTClaims(
+				ctx,
+				authorizers.MCPFeatureTool,
+				authorizers.MCPOperationCall,
+				"deploy",
+				nil,
+			)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantAuthorize, authorized,
+				"GroupEntityType=%q: expected allow=%v", tt.groupEntityType, tt.wantAuthorize)
+		})
+	}
+}
+
+// TestNewCedarAuthorizerGroupEntityTypeValidation is a thin wiring proof
+// that NewCedarAuthorizer actually invokes validateGroupEntityType. The
+// exhaustive rejection coverage lives in TestValidateGroupEntityType — this
+// test only confirms one valid input passes through and one invalid input
+// produces the validator's error at the constructor boundary.
+func TestNewCedarAuthorizerGroupEntityTypeValidation(t *testing.T) {
+	t.Parallel()
+
+	validPolicy := []string{`permit(principal, action, resource);`}
+
+	testCases := []struct {
+		name            string
+		groupEntityType string
+		wantErr         bool
+		errContains     string
+	}{
+		{name: "empty string succeeds", groupEntityType: "", wantErr: false},
+		{name: "namespaced type fails", groupEntityType: "Foo::Bar", wantErr: true, errContains: "::"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := NewCedarAuthorizer(ConfigOptions{
+				Policies:        validPolicy,
+				GroupEntityType: tc.groupEntityType,
+			}, "")
+
+			if tc.wantErr {
+				require.Error(t, err, "expected construction error for GroupEntityType=%q", tc.groupEntityType)
+				assert.Contains(t, err.Error(), tc.errContains,
+					"validator error must bubble up unchanged to the constructor boundary")
+			} else {
+				require.NoError(t, err, "unexpected error for GroupEntityType=%q", tc.groupEntityType)
+			}
+		})
+	}
+}
+
+// captureSlogWarn redirects slog's default logger to a bytes.Buffer for the
+// duration of f, then restores the original default. Returns the captured
+// output. This helper exists because slog.SetDefault is a process-global
+// side effect — tests that use it must NOT run in parallel.
+func captureSlogWarn(t *testing.T, f func()) string {
+	t.Helper()
+
+	var buf bytes.Buffer
+	handler := slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})
+	orig := slog.Default()
+	slog.SetDefault(slog.New(handler))
+	t.Cleanup(func() { slog.SetDefault(orig) })
+
+	f()
+
+	return buf.String()
+}
+
+// TestStaleTHVGroupWarning verifies that NewCedarAuthorizer emits a WARN log
+// when entities_json contains entities of type "THVGroup" while GroupEntityType
+// is configured to a different value. The mismatch causes Cedar's `in` operator
+// to evaluate to false for those entities — a silent deny that is hard to debug
+// without this diagnostic.
+//
+// Subtests use slog.SetDefault (process-global), so they must NOT run in
+// parallel with other tests. The parent is still parallel-safe because it does
+// not touch global state itself.
+//
+//nolint:paralleltest,tparallel // Subtests redirect slog.Default, which is process-global state
+func TestStaleTHVGroupWarning(t *testing.T) {
+	t.Parallel()
+
+	const thvGroupEntity = `[{"uid":{"type":"THVGroup","id":"engineering"},"attrs":{},"parents":[]}]`
+	validPolicy := []string{`permit(principal, action, resource);`}
+
+	tests := []struct {
+		name            string
+		groupEntityType string
+		entitiesJSON    string
+		wantWarn        bool
+		wantContains    []string // when wantWarn=true, log must contain each of these
+	}{
+		{
+			name:            "warns when stale THVGroup present and GroupEntityType differs",
+			groupEntityType: "OrgRole",
+			entitiesJSON:    thvGroupEntity,
+			wantWarn:        true,
+			wantContains:    []string{"GroupEntityType", "OrgRole", "THVGroup"},
+		},
+		{
+			// Most common path: GroupEntityType is empty (uses THVGroup default), so no
+			// conflict is possible. One negative is sufficient to prove the guard works.
+			name:            "no warning when GroupEntityType is empty (uses THVGroup default)",
+			groupEntityType: "",
+			entitiesJSON:    thvGroupEntity,
+			wantWarn:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Cannot be parallel: subtests redirect slog.Default.
+			output := captureSlogWarn(t, func() {
+				_, err := NewCedarAuthorizer(ConfigOptions{
+					Policies:        validPolicy,
+					EntitiesJSON:    tt.entitiesJSON,
+					GroupEntityType: tt.groupEntityType,
+				}, "")
+				require.NoError(t, err)
+			})
+
+			if tt.wantWarn {
+				require.NotEmpty(t, output, "expected a warn log")
+				for _, want := range tt.wantContains {
+					assert.Contains(t, output, want,
+						"warn log must mention %q", want)
+				}
+			} else {
+				assert.Empty(t, output, "no warning expected")
 			}
 		})
 	}

--- a/pkg/authz/authorizers/cedar/entity.go
+++ b/pkg/authz/authorizers/cedar/entity.go
@@ -8,17 +8,27 @@ import (
 	cedar "github.com/cedar-policy/cedar-go"
 )
 
-// EntityTypeTHVGroup is the Cedar entity type representing group membership.
-// Principals are added as children of THVGroup entities so that Cedar's `in`
-// operator can evaluate group-based policies (e.g. `principal in THVGroup::"engineering"`).
+// EntityTypeTHVGroup is the default Cedar entity type representing group membership.
+// It is used when ConfigOptions.GroupEntityType is empty. Principals are added as
+// children of group entities so that Cedar's `in` operator can evaluate
+// group-based policies (e.g. `principal in THVGroup::"engineering"`).
 const EntityTypeTHVGroup cedar.EntityType = "THVGroup"
 
 // EntityFactory creates Cedar entities for authorization.
-type EntityFactory struct{}
+type EntityFactory struct {
+	// groupEntityType is the Cedar entity type used for Client parent UIDs
+	// synthesised from JWT group/role claims. Resolved at construction —
+	// defaults to EntityTypeTHVGroup when the caller passes an empty string.
+	groupEntityType cedar.EntityType
+}
 
-// NewEntityFactory creates a new entity factory.
-func NewEntityFactory() *EntityFactory {
-	return &EntityFactory{}
+// NewEntityFactory creates a new entity factory. An empty groupEntityType
+// falls back to EntityTypeTHVGroup so existing callers stay backward compatible.
+func NewEntityFactory(groupEntityType cedar.EntityType) *EntityFactory {
+	if groupEntityType == "" {
+		groupEntityType = EntityTypeTHVGroup
+	}
+	return &EntityFactory{groupEntityType: groupEntityType}
 }
 
 // CreatePrincipalEntity creates a principal entity with the given ID, attributes,
@@ -102,10 +112,11 @@ func (*EntityFactory) CreateResourceEntity(
 }
 
 // CreateEntitiesForRequest creates entities for a specific authorization request.
-// Groups are converted to THVGroup parent UIDs on the principal entity so that
-// Cedar's `in` operator works for group-based policies. Unlike the pre-refactor
-// code, no separate THVGroup entities are inserted into the entity map — those
-// must come from entities_json to preserve the role hierarchy.
+// Groups are converted to parent UIDs (using the configured group entity type,
+// default "THVGroup") on the principal entity so that Cedar's `in` operator works
+// for group-based policies. Unlike the pre-refactor code, no separate group
+// entities are inserted into the entity map — those must come from entities_json
+// to preserve the role hierarchy.
 //
 // When serverName is non-empty, resource entities include an MCP parent UID so
 // that server-scoped Cedar policies (e.g. `resource in MCP::"github"`) evaluate
@@ -138,14 +149,15 @@ func (f *EntityFactory) CreateEntitiesForRequest(
 	entities := make(cedar.EntityMap)
 
 	// Build parent UIDs from groups so the principal's Parents set contains
-	// THVGroup references (needed for Cedar's `in` operator). Unlike the
-	// pre-refactor code, we do NOT insert separate THVGroup entities into the
-	// entity map — those come from entities_json and must not be overwritten
-	// (see merge-order hazard described in the RFC). #4768 will restructure
-	// this further for full role hierarchy support.
+	// references using the configured group entity type (default "THVGroup"),
+	// needed for Cedar's `in` operator. Unlike the pre-refactor code, we do
+	// NOT insert separate group entities into the entity map — those come from
+	// entities_json and must not be overwritten (see merge-order hazard
+	// described in the RFC). #4768 will restructure this further for full role
+	// hierarchy support.
 	parentUIDs := make([]cedar.EntityUID, 0, len(groups))
 	for _, g := range groups {
-		parentUIDs = append(parentUIDs, cedar.NewEntityUID(EntityTypeTHVGroup, cedar.String(g)))
+		parentUIDs = append(parentUIDs, cedar.NewEntityUID(f.groupEntityType, cedar.String(g)))
 	}
 
 	principalUID, principalEntity := f.CreatePrincipalEntity(principalType, principalID, claimsMap, parentUIDs...)

--- a/pkg/authz/authorizers/cedar/entity_test.go
+++ b/pkg/authz/authorizers/cedar/entity_test.go
@@ -16,7 +16,7 @@ import (
 func TestCreatePrincipalEntity_Parents(t *testing.T) {
 	t.Parallel()
 
-	factory := NewEntityFactory()
+	factory := NewEntityFactory("")
 
 	groupUID := cedar.NewEntityUID(EntityTypeTHVGroup, cedar.String("engineering"))
 	roleUID := cedar.NewEntityUID("THVRole", cedar.String("admin"))
@@ -83,7 +83,7 @@ func TestCreatePrincipalEntity_Parents(t *testing.T) {
 func TestCreatePrincipalEntity_NoGroupEntities(t *testing.T) {
 	t.Parallel()
 
-	factory := NewEntityFactory()
+	factory := NewEntityFactory("")
 
 	// Pass a THVGroup parent UID — the function must NOT return extra entities.
 	groupUID := cedar.NewEntityUID(EntityTypeTHVGroup, cedar.String("engineering"))
@@ -100,7 +100,7 @@ func TestCreatePrincipalEntity_NoGroupEntities(t *testing.T) {
 func TestCreateResourceEntity_Parents(t *testing.T) {
 	t.Parallel()
 
-	factory := NewEntityFactory()
+	factory := NewEntityFactory("")
 
 	mcpUID := cedar.NewEntityUID("MCP", cedar.String("server-a"))
 	orgUID := cedar.NewEntityUID("Org", cedar.String("stacklok"))
@@ -169,7 +169,7 @@ func TestCreateResourceEntity_Parents(t *testing.T) {
 func TestCreateResourceEntity_NamePreservation(t *testing.T) {
 	t.Parallel()
 
-	factory := NewEntityFactory()
+	factory := NewEntityFactory("")
 
 	tests := []struct {
 		name       string
@@ -231,7 +231,7 @@ func TestCreateResourceEntity_NamePreservation(t *testing.T) {
 func TestCreateEntitiesForRequest_GroupsAsParents(t *testing.T) {
 	t.Parallel()
 
-	factory := NewEntityFactory()
+	factory := NewEntityFactory("")
 
 	tests := []struct {
 		name            string
@@ -295,6 +295,45 @@ func TestCreateEntitiesForRequest_GroupsAsParents(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestCreateEntitiesForRequest_CustomGroupEntityType verifies that a factory
+// built with a custom groupEntityType produces parent UIDs with that type rather
+// than the default "THVGroup", and that no entity of the custom type is inserted
+// into the entity map (mirroring the THVGroup invariant).
+func TestCreateEntitiesForRequest_CustomGroupEntityType(t *testing.T) {
+	t.Parallel()
+
+	factory := NewEntityFactory(cedar.EntityType("OrgRole"))
+
+	entities, err := factory.CreateEntitiesForRequest(
+		"Client::user1",
+		"Action::call_tool",
+		"Tool::weather",
+		map[string]interface{}{"sub": "user1"},
+		map[string]interface{}{"name": "weather"},
+		[]string{"engineering"},
+		"",
+	)
+	require.NoError(t, err)
+	require.NotNil(t, entities)
+
+	// Entity map must contain only principal + action + resource — no OrgRole entries.
+	assert.Len(t, entities, 3)
+	for uid := range entities {
+		assert.NotEqual(t, cedar.EntityType("OrgRole"), uid.Type,
+			"OrgRole entity should not be inserted into the entity map")
+	}
+
+	// Principal's Parents set must contain OrgRole::"engineering".
+	principalUID := cedar.NewEntityUID("Client", cedar.String("user1"))
+	principalEntity, found := entities[principalUID]
+	require.True(t, found, "principal entity not found in map")
+	require.Equal(t, 1, principalEntity.Parents.Len())
+
+	wantParent := cedar.NewEntityUID(cedar.EntityType("OrgRole"), cedar.String("engineering"))
+	assert.True(t, principalEntity.Parents.Contains(wantParent),
+		"expected OrgRole::\"engineering\" in principal.Parents")
 }
 
 // TestCreateCedarEntities tests the createCedarEntities function.
@@ -385,7 +424,7 @@ func TestCreateCedarEntities(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			// Create entity factory
-			factory := NewEntityFactory()
+			factory := NewEntityFactory("")
 
 			// Create Cedar entities (no groups for these test cases)
 			entities, err := factory.CreateEntitiesForRequest(tc.principal, tc.action, tc.resource, tc.claimsMap, tc.attributes, nil, "")
@@ -471,7 +510,7 @@ func TestCreateCedarEntities(t *testing.T) {
 func TestCreateEntitiesForRequest_MCPParent(t *testing.T) {
 	t.Parallel()
 
-	factory := NewEntityFactory()
+	factory := NewEntityFactory("")
 
 	tests := []struct {
 		name            string


### PR DESCRIPTION
## Summary

- The Cedar authorizer hardcoded `EntityTypeTHVGroup = "THVGroup"` as the entity type used to construct principal `Parents` UIDs from JWT group/role claims. Deployments whose policy vocabulary doesn't use "THVGroup" had no way to switch without patching the authorizer.
- Add an optional `GroupEntityType` field to `cedar.ConfigOptions` so deployments can use names like `OrgRole` or `Group` that fit their policy vocabulary. Empty defaults to `"THVGroup"`, so existing deployments are unaffected.
- Validate non-empty values up front in `NewCedarAuthorizer` by round-tripping through cedar-go's policy parser. This delegates Cedar's identifier grammar to upstream — reserved words, ANYIDENT shape, the `__cedar` token — so future cedar-go refinements land automatically. The one project-specific rule we keep is rejecting the `::` namespace separator (namespaced types are out of scope until `parseCedarEntityID` handles them).
- Warn at construction when `entities_json` contains stale entities of type `"THVGroup"` while `GroupEntityType` is set to a different value. The mismatch causes Cedar's `in` operator to silently evaluate to false on those entities — a silent deny that is otherwise hard to debug.

Closes #5072

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)

No e2e tests added — the new field is consumed today only via the standalone CLI's `--authz-config <file>` path. The operator and vMCP construct `cedar.ConfigOptions` by hand and don't yet surface the field; that's tracked as a separate follow-up.

## API Compatibility

- [x] This PR does not break the `v1beta1` API. The new field lives on the inline Cedar `ConfigOptions` struct, which CRD consumers pass through as opaque YAML/JSON — no CRD schema change.

## Changes

| File | Change |
|------|--------|
| `pkg/authz/authorizers/cedar/core.go` | Add `GroupEntityType` field to `ConfigOptions`; add `validateGroupEntityType` helper that delegates to cedar-go's policy parser; wire validation + factory construction into `NewCedarAuthorizer`; emit silent-deny warn diagnostic |
| `pkg/authz/authorizers/cedar/entity.go` | Make `EntityFactory` stateful with a `groupEntityType` field; change `NewEntityFactory` signature to accept the type (empty defaults to `EntityTypeTHVGroup`); replace the hardcoded constant in `CreateEntitiesForRequest` with the configured value |
| `pkg/authz/authorizers/cedar/core_test.go` | Validator unit test, constructor wiring proof, permit/deny end-to-end contrast, stale-`THVGroup` warn diagnostic test |
| `pkg/authz/authorizers/cedar/entity_test.go` | Custom-entity-type test plus updated call sites for the new `NewEntityFactory` signature |

## Does this introduce a user-facing change?

Yes. Users with a YAML/JSON authz config (`thv run --authz-config <file>`) can now set an optional `group_entity_type:` field to any valid Cedar identifier. Empty (or absent) keeps the existing `"THVGroup"` behaviour. Invalid values fail at startup with a message naming the offending input — namespace separators (`::`), Cedar reserved words, and identifier-grammar violations are all rejected.

## Implementation plan

<details>
<summary>Approved implementation plan</summary>

### Context

`pkg/authz/authorizers/cedar/entity.go` hardcoded `EntityTypeTHVGroup cedar.EntityType = "THVGroup"`. `EntityFactory.CreateEntitiesForRequest` used it to build `Client.Parents` UIDs from JWT group/role claims. Existing deployments couldn't rename the principal-hierarchy entity type without a code change.

### Approach

Add an optional `GroupEntityType` field to `ConfigOptions` (`json:"group_entity_type,omitempty"`). Make `EntityFactory` stateful so the configured type is resolved once at construction. Keep `EntityTypeTHVGroup` as the default constant and fallback. The wire type stays `string`; `NewEntityFactory` takes a `cedar.EntityType` so callers cast at the boundary.

Validate non-empty input in `NewCedarAuthorizer` before allocation. Originally the validator hand-rolled the rules (regex + reserved-word map + `__cedar` prefix check); the final form delegates to `cedar.Policy.UnmarshalCedar` against a synthetic `permit(principal in <TYPE>::"x", action, resource);` policy. Reasoning:

- cedar-go's parser is the authoritative grammar.
- Future Cedar grammar refinements upstream land automatically.
- Empty input is *not* a misconfiguration — it explicitly means "use the default" and is accepted.
- The `::` namespace rejection stays as a project-specific rule (issue text defers namespaced types).

Add a startup `WARN` log when `entities_json` contains entities of type `"THVGroup"` while `GroupEntityType` is configured to a different non-empty value. Cedar's `in` would silently evaluate to false on those stale entities; the diagnostic surfaces the mismatch so operators don't spend hours debugging a silent deny. Scoped to entities_json — policy-text scanning was rejected as fragile.

### Out of scope

- Namespaced entity types (`Foo::Bar`). Blocked by `parseCedarEntityID`. Tracked for follow-up.
- Surfacing `GroupEntityType` (and the existing `GroupClaimName` / `RoleClaimName`) through the operator's `AuthzConfigRef.Inline` and vMCP's `AuthzConfig` boundaries. Both layers currently construct `cedar.ConfigOptions` by hand and forward only a subset of fields. Tracked for a separate PR.

### Files modified

- `pkg/authz/authorizers/cedar/core.go` (production)
- `pkg/authz/authorizers/cedar/entity.go` (production)
- `pkg/authz/authorizers/cedar/core_test.go` (test)
- `pkg/authz/authorizers/cedar/entity_test.go` (test)

</details>

## Special notes for reviewers

- **cedar-go delegation in the validator**: rather than hand-rolling Cedar's identifier grammar, the validator round-trips a synthetic `permit()` policy through `cedar.Policy.UnmarshalCedar`. That makes cedar-go the source of truth for "is this a valid Cedar identifier" and means we don't have to track upstream grammar changes. The one project-specific rule we keep is rejecting `::`. The behavioural consequence vs a strict hand-rolled version is that `__cedarFoo` is now accepted — the Cedar spec only reserves the literal `__cedar` token, not the entire prefix namespace.
- **Silent-deny diagnostic at construction**: scoped to `entities_json` only. Policy-text scanning was considered and rejected — false positives during phased migrations are likely, and the policy parser has no schema-aware type check. The entities-json scan is deterministic (entity types in JSON are explicit) and runs once at startup.
- **Test coverage philosophy**: `TestValidateGroupEntityType` deliberately covers our package's branches (empty short-circuit, `::` rejection, valid/invalid smoke tests, the `__cedarFoo` acceptance) rather than enumerating every input cedar-go's parser would reject. The exhaustive grammar coverage lives in cedar-go's test suite — re-asserting it here would test a dependency, not our code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)