### PR TITLE
Auto-detect Docker Desktop socket on Linux

### DIFF
--- a/docs/arch/01-deployment-modes.md
+++ b/docs/arch/01-deployment-modes.md
@@ -101,6 +101,7 @@ The CLI automatically detects container runtimes in this order:
    - `$TOOLHIVE_DOCKER_SOCKET` (if set)
    - `/var/run/docker.sock`
    - `~/.docker/run/docker.sock` (Docker Desktop on macOS)
+   - `~/.docker/desktop/docker.sock` (Docker Desktop on Linux)
    - `~/.rd/docker.sock` (Rancher Desktop on macOS)
    - `~/.orbstack/run/docker.sock` (OrbStack on macOS)
 

--- a/pkg/container/docker/sdk/client_unix.go
+++ b/pkg/container/docker/sdk/client_unix.go
@@ -166,17 +166,22 @@ func findPodmanSocket() (string, error) {
 	return "", fmt.Errorf("podman socket not found in standard locations")
 }
 
+// systemDockerSocketPath is the system-wide Docker socket path probed by
+// findDockerSocket. It defaults to DockerSocketPath and is package-private so
+// tests can redirect the system check to a sandbox path.
+var systemDockerSocketPath = DockerSocketPath
+
 // findDockerSocket attempts to locate a Docker socket
 func findDockerSocket() (string, error) {
 	// Try Docker socket as fallback
-	_, err := os.Stat(DockerSocketPath)
+	_, err := os.Stat(systemDockerSocketPath)
 
 	if err == nil {
-		slog.Debug("found Docker socket", "path", DockerSocketPath)
-		return DockerSocketPath, nil
+		slog.Debug("found Docker socket", "path", systemDockerSocketPath)
+		return systemDockerSocketPath, nil
 	}
 
-	slog.Debug("failed to check Docker socket", "path", DockerSocketPath, "error", err)
+	slog.Debug("failed to check Docker socket", "path", systemDockerSocketPath, "error", err)
 
 	// Try Docker Desktop socket path on macOS
 	if home := os.Getenv("HOME"); home != "" {
@@ -191,6 +196,21 @@ func findDockerSocket() (string, error) {
 
 		//nolint:gosec // G706: socket path derived from HOME env var
 		slog.Debug("failed to check Docker Desktop socket", "path", dockerDesktopPath, "error", err)
+	}
+
+	// Try Docker Desktop socket path on Linux
+	if home := os.Getenv("HOME"); home != "" {
+		dockerDesktopLinuxPath := filepath.Join(home, DockerDesktopLinuxSocketPath)
+		_, err := os.Stat(dockerDesktopLinuxPath) // #nosec G703 -- path is built from HOME + constant socket path
+
+		if err == nil {
+			//nolint:gosec // G706: socket path derived from HOME env var
+			slog.Debug("found Docker Desktop socket", "path", dockerDesktopLinuxPath)
+			return dockerDesktopLinuxPath, nil
+		}
+
+		//nolint:gosec // G706: socket path derived from HOME env var
+		slog.Debug("failed to check Docker Desktop socket", "path", dockerDesktopLinuxPath, "error", err)
 	}
 
 	// Try Rancher Desktop socket path on macOS

--- a/pkg/container/docker/sdk/client_unix_test.go
+++ b/pkg/container/docker/sdk/client_unix_test.go
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !windows
+
+package sdk
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stacklok/toolhive/pkg/container/runtime"
+)
+
+// clearSocketEnv removes any inherited TOOLHIVE_*_SOCKET overrides so the
+// helpers fall through to filesystem discovery during the test.
+func clearSocketEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv(PodmanSocketEnv, "")
+	t.Setenv(DockerSocketEnv, "")
+	t.Setenv(ColimaSocketEnv, "")
+}
+
+// redirectSystemDockerSocket points the system-socket probe at a path that
+// definitely does not exist, so user-level fallbacks are exercised regardless
+// of whether the host has a real /var/run/docker.sock.
+func redirectSystemDockerSocket(t *testing.T) {
+	t.Helper()
+	orig := systemDockerSocketPath
+	systemDockerSocketPath = filepath.Join(t.TempDir(), "no-such-docker.sock")
+	t.Cleanup(func() { systemDockerSocketPath = orig })
+}
+
+func TestFindDockerSocket_DockerDesktopOnLinux(t *testing.T) {
+	clearSocketEnv(t)
+	redirectSystemDockerSocket(t)
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	socketDir := filepath.Join(home, filepath.Dir(DockerDesktopLinuxSocketPath))
+	require.NoError(t, os.MkdirAll(socketDir, 0o755))
+	socketPath := filepath.Join(home, DockerDesktopLinuxSocketPath)
+	require.NoError(t, os.WriteFile(socketPath, nil, 0o600))
+
+	got, err := findDockerSocket()
+	require.NoError(t, err)
+	assert.Equal(t, socketPath, got)
+}
+
+func TestFindPlatformContainerSocket_DockerEnvOverrideWins(t *testing.T) {
+	clearSocketEnv(t)
+
+	tmp := t.TempDir()
+	envSocket := filepath.Join(tmp, "docker-from-env.sock")
+	require.NoError(t, os.WriteFile(envSocket, nil, 0o600))
+	t.Setenv(DockerSocketEnv, envSocket)
+
+	// Even with a Docker Desktop on Linux socket present at $HOME, the env
+	// var must take precedence.
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	socketDir := filepath.Join(home, filepath.Dir(DockerDesktopLinuxSocketPath))
+	require.NoError(t, os.MkdirAll(socketDir, 0o755))
+	homeSocket := filepath.Join(home, DockerDesktopLinuxSocketPath)
+	require.NoError(t, os.WriteFile(homeSocket, nil, 0o600))
+
+	path, rt, err := findPlatformContainerSocket(runtime.TypeDocker)
+	require.NoError(t, err)
+	assert.Equal(t, envSocket, path)
+	assert.Equal(t, runtime.TypeDocker, rt)
+}
+
+func TestFindPlatformContainerSocket_NotFound(t *testing.T) {
+	clearSocketEnv(t)
+	redirectSystemDockerSocket(t)
+
+	// Empty HOME with no sockets created — every discovery path should miss.
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_RUNTIME_DIR", "")
+	t.Setenv("TMPDIR", "")
+
+	_, _, err := findPlatformContainerSocket(runtime.TypeDocker)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrRuntimeNotFound), "expected ErrRuntimeNotFound, got %v", err)
+}

--- a/pkg/container/docker/sdk/factory.go
+++ b/pkg/container/docker/sdk/factory.go
@@ -39,6 +39,10 @@ const (
 	DockerSocketPath = "/var/run/docker.sock"
 	// DockerDesktopMacSocketPath is the Docker Desktop socket path on macOS
 	DockerDesktopMacSocketPath = ".docker/run/docker.sock"
+	// DockerDesktopLinuxSocketPath is the Docker Desktop socket path on Linux
+	// (relative to $HOME). Docker Desktop on Linux registers a "desktop-linux"
+	// Docker context that points to this socket.
+	DockerDesktopLinuxSocketPath = ".docker/desktop/docker.sock"
 	// RancherDesktopMacSocketPath is the Docker socket path for Rancher Desktop on macOS
 	RancherDesktopMacSocketPath = ".rd/docker.sock"
 	// OrbStackMacSocketPath is the Docker socket path for OrbStack on macOS


### PR DESCRIPTION
## Summary

- On Linux, when Docker Desktop is the only Docker installation (no system Docker Engine on `/var/run/docker.sock`), `thv` fails to start with `no container runtime available`, even though `docker` / `docker ps` work fine. Docker Desktop on Linux runs Engine inside a VM and exposes its socket at `~/.docker/desktop/docker.sock` and registers a `desktop-linux` Docker CLI context pointing there. `findDockerSocket` only probed `/var/run/docker.sock` plus macOS-specific paths (Docker Desktop on macOS, Rancher Desktop, OrbStack), so the Linux Docker Desktop socket was never discovered. The Docker CLI works because it honors `~/.docker/config.json` / `~/.docker/contexts/meta`; ToolHive's Go discovery does not consult contexts, it stats a fixed list.
- Add the Linux Docker Desktop socket path to the auto-detection list so users with only Docker Desktop installed do not have to set `TOOLHIVE_DOCKER_SOCKET` manually.
- Three independent commits — production fix, unit tests, doc update — so each can be reviewed / reverted in isolation.

Fixes #5120

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`go test ./pkg/container/docker/sdk/... ./pkg/container/...`)
- [x] Linting (`task lint-fix` — 0 issues)
- [x] Three new test cases in `pkg/container/docker/sdk/client_unix_test.go`:
  - `TestFindDockerSocket_DockerDesktopOnLinux` — hermetic test that creates a fake `~/.docker/desktop/docker.sock` and asserts `findDockerSocket` returns it.
  - `TestFindPlatformContainerSocket_DockerEnvOverrideWins` — `TOOLHIVE_DOCKER_SOCKET` takes precedence over filesystem discovery.
  - `TestFindPlatformContainerSocket_NotFound` — `ErrRuntimeNotFound` is still returned when no socket is reachable.
- [ ] Manual testing on a Linux host with only Docker Desktop installed — pending; happy to defer to a reviewer with that setup, or I can spin up a Linux VM with Docker Desktop and confirm `thv version` / `thv list` work without the env override.

## Changes

| File | Change |
|------|--------|
| `pkg/container/docker/sdk/factory.go` | Add `DockerDesktopLinuxSocketPath` constant for `~/.docker/desktop/docker.sock`. |
| `pkg/container/docker/sdk/client_unix.go` | Probe Docker Desktop on Linux path in `findDockerSocket`; wrap the system socket path in unexported `systemDockerSocketPath` so tests can redirect it. |
| `pkg/container/docker/sdk/client_unix_test.go` | New file — three table-style cases for socket discovery (Linux Docker Desktop, env override, not-found). |
| `docs/arch/01-deployment-modes.md` | Add the new path to the documented Docker discovery order. |

## Does this introduce a user-facing change?

Yes — Linux users running only Docker Desktop now get working `thv` runtime auto-detection with no extra configuration. Hosts that already have `/var/run/docker.sock` (system Docker Engine) see no change; the system socket is still probed first and wins.

## Implementation plan

<details>
<summary>Approved implementation plan</summary>

1. Add `DockerDesktopLinuxSocketPath = ".docker/desktop/docker.sock"` next to the other socket-path constants in `pkg/container/docker/sdk/factory.go`.
2. Extend `findDockerSocket` in `pkg/container/docker/sdk/client_unix.go` to probe `$HOME/.docker/desktop/docker.sock`, ordered after the macOS Docker Desktop check and before the Rancher / OrbStack fallbacks. Keep `/var/run/docker.sock` first so a system Docker Engine still wins.
3. Wrap the system socket path in an unexported `systemDockerSocketPath` package variable defaulted to `DockerSocketPath` so tests can redirect the system probe to a sandbox path without affecting production.
4. Add unit tests in `pkg/container/docker/sdk/client_unix_test.go` covering: discovery of the new Linux Docker Desktop socket, env override (`TOOLHIVE_DOCKER_SOCKET`) precedence, and `ErrRuntimeNotFound` when nothing is reachable.
5. Update `docs/arch/01-deployment-modes.md` so the documented discovery order matches the code.

Out of scope: parsing `~/.docker/config.json` / `~/.docker/contexts/meta` to honor arbitrary Docker contexts. That generalizes beyond the well-known Docker Desktop path but is heavier; leaving it as a follow-up if a custom-context case shows up.

</details>

## Special notes for reviewers

- The new `systemDockerSocketPath` variable is unexported and exists purely as a test seam — its production value is `DockerSocketPath` and never changes at runtime.
- Until this lands, affected users can work around the issue with:
  ```bash
  export TOOLHIVE_DOCKER_SOCKET="$HOME/.docker/desktop/docker.sock"