### PR TITLE
Carry forward upstream refresh token on re-authorization

### DIFF
--- a/pkg/authserver/integration_test.go
+++ b/pkg/authserver/integration_test.go
@@ -16,6 +16,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -2505,4 +2506,280 @@ func TestIntegration_MultiUpstreamChain_MixedExpiryOrderings_Redis(t *testing.T)
 			assert.NotEmpty(t, tokensMap["provider-2"], "provider-2 access token must be present")
 		})
 	}
+}
+
+// ============================================================================
+// Callback Refresh-Token Carry-Forward Integration Tests
+// ============================================================================
+
+// rtStrippingProxy wraps a mockoidc server and intercepts its token endpoint.
+// When stripRT is true the proxy omits the "refresh_token" field from every
+// token-endpoint response, replicating the common IdP behavior where the RT
+// is only issued on the first authorization (e.g. Google without prompt=consent).
+//
+// All other endpoints (authorize, userinfo, jwks, discovery) are forwarded
+// verbatim so that the real mockoidc can still sign tokens and serve user info.
+//
+// We use this proxy instead of the real mockoidc token endpoint for the second
+// authorize → callback leg because mockoidc's setTokens() always generates a
+// refresh_token for authorization_code grants and offers no API to suppress it.
+type rtStrippingProxy struct {
+	stripRT atomic.Bool
+	target  string // real mockoidc base URL (e.g. "http://127.0.0.1:PORT")
+}
+
+func (p *rtStrippingProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Forward the request to the real mockoidc.
+	proxyURL := p.target + r.URL.RequestURI()
+	proxyReq, err := http.NewRequestWithContext(r.Context(), r.Method, proxyURL, r.Body)
+	if err != nil {
+		http.Error(w, "proxy: failed to build request", http.StatusInternalServerError)
+		return
+	}
+	proxyReq.Header = r.Header.Clone()
+
+	resp, err := http.DefaultTransport.RoundTrip(proxyReq)
+	if err != nil {
+		http.Error(w, "proxy: upstream request failed", http.StatusBadGateway)
+		return
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		http.Error(w, "proxy: failed to read response", http.StatusInternalServerError)
+		return
+	}
+
+	// Strip refresh_token when the flag is set and this is the token endpoint.
+	if p.stripRT.Load() && r.URL.Path == "/oidc/token" {
+		var m map[string]json.RawMessage
+		if jsonErr := json.Unmarshal(body, &m); jsonErr == nil {
+			delete(m, "refresh_token")
+			if rewritten, jsonErr := json.Marshal(m); jsonErr == nil {
+				body = rewritten
+			}
+		}
+	}
+
+	// Copy response headers and status code.
+	for k, vs := range resp.Header {
+		for _, v := range vs {
+			w.Header().Add(k, v)
+		}
+	}
+	// Drop the upstream Content-Length; the body may have been rewritten (RT
+	// stripped) so the original length is stale. net/http will set it correctly
+	// from the buffered body.
+	w.Header().Del("Content-Length")
+	w.WriteHeader(resp.StatusCode)
+	_, _ = w.Write(body)
+}
+
+// setupTestServerWithRTProxy creates a test server backed by a real mockoidc but
+// with the upstream OAuth2 provider pointing to the rtStrippingProxy instead of
+// the mockoidc server directly. This allows toggling RT suppression mid-test.
+func setupTestServerWithRTProxy(t *testing.T, m *mockoidc.MockOIDC, proxy *rtStrippingProxy) *testServerWithUpstream {
+	t.Helper()
+
+	proxyServer := httptest.NewServer(proxy)
+	t.Cleanup(proxyServer.Close)
+
+	cfg := m.Config()
+
+	upstreamCfg := &upstream.OAuth2Config{
+		CommonOAuthConfig: upstream.CommonOAuthConfig{
+			ClientID:     cfg.ClientID,
+			ClientSecret: cfg.ClientSecret,
+			Scopes:       []string{"openid", "profile", "email"},
+			// RedirectURI must point at our auth server (resolved below after httptest.NewServer).
+			RedirectURI: testIssuer + "/oauth/callback",
+		},
+		// Authorization and token go through the proxy; userinfo comes from the proxy too.
+		AuthorizationEndpoint: proxyServer.URL + "/oidc/authorize",
+		TokenEndpoint:         proxyServer.URL + "/oidc/token",
+		UserInfo: &upstream.UserInfoConfig{
+			EndpointURL: proxyServer.URL + "/oidc/userinfo",
+			FieldMapping: &upstream.UserInfoFieldMapping{
+				SubjectFields: []string{"sub", "email"},
+			},
+		},
+	}
+	upstreamProvider, err := upstream.NewOAuth2Provider(upstreamCfg)
+	require.NoError(t, err)
+
+	ts := setupTestServer(t,
+		withUpstream(upstreamProvider),
+		withScopes(registration.DefaultScopes),
+	)
+
+	return &testServerWithUpstream{
+		testServer:       ts,
+		mockOIDC:         m,
+		upstreamProvider: upstreamProvider,
+	}
+}
+
+// TestIntegration_Callback_PreservesRefreshTokenOnReauth verifies the carry-forward
+// behavior introduced in the CallbackHandler: when an upstream IdP omits refresh_token
+// on re-authorization, the callback must copy the RT from the most-recent prior row
+// for the same (userID, providerID) pair rather than leaving it empty.
+//
+// Flow summary:
+//  1. First authorize → callback: IdP issues an RT → stored normally.
+//  2. Second authorize → callback (same user): IdP omits RT → callback carries forward
+//     the RT from the first row. Canonical regression assertion: new row's RT == priorRT.
+//  3. Third authorize → callback (different user): no prior row exists for the new user →
+//     new row has empty RT. This exercises the ErrNotFound branch of the guard
+//     (GetLatestUpstreamTokensForUser returns ErrNotFound → nothing to carry).
+//     Note: the handler-level unit tests in callback_handler_test.go cover the
+//     UpstreamSubject mismatch guard directly; this leg covers the natural not-found path.
+func TestIntegration_Callback_PreservesRefreshTokenOnReauth(t *testing.T) {
+	t.Parallel()
+
+	const providerName = "default"
+	const userSubject = "reauth-user-001"
+	const userEmail = "reauth@example.com"
+
+	// Step 1: Stand up a real mockoidc server.
+	m, err := mockoidc.Run()
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, m.Shutdown()) })
+
+	// Step 2: Build the RT-stripping proxy (initially pass-through).
+	proxy := &rtStrippingProxy{
+		target: m.Addr(),
+	}
+
+	// Step 3: Stand up the auth server with the upstream pointing at the proxy.
+	ts := setupTestServerWithRTProxy(t, m, proxy)
+
+	ctx := context.Background()
+
+	// =========================================================================
+	// Leg 1: First authorize → callback (normal — IdP issues a refresh_token)
+	// =========================================================================
+
+	// Queue the test user for the first flow.
+	m.QueueUser(&mockoidc.MockUser{
+		Subject: userSubject,
+		Email:   userEmail,
+	})
+
+	verifier1 := servercrypto.GeneratePKCEVerifier()
+	challenge1 := servercrypto.ComputePKCEChallenge(verifier1)
+
+	authCode1, _ := completeAuthorizationFlow(t, ts.Server.URL, authorizationParams{
+		ClientID:     testClientID,
+		RedirectURI:  testRedirectURI,
+		State:        "rt-carry-leg1",
+		Challenge:    challenge1,
+		Scope:        "openid profile",
+		ResponseType: "code",
+	})
+
+	tokenData1 := exchangeCodeForTokens(t, ts.Server.URL, authCode1, verifier1, testAudience)
+	accessToken1, ok := tokenData1["access_token"].(string)
+	require.True(t, ok, "leg 1: access_token should be present")
+
+	sessionID1 := extractTSID(t, accessToken1, ts.PrivateKey.Public())
+
+	// Verify the first leg stored a non-empty RT (mockoidc always issues one).
+	tokens1, err := ts.storage.GetUpstreamTokens(ctx, sessionID1, providerName)
+	require.NoError(t, err, "leg 1: upstream tokens should be stored")
+	require.NotEmpty(t, tokens1.RefreshToken, "leg 1: RT must be non-empty (sanity check)")
+
+	priorRT := tokens1.RefreshToken
+
+	// =========================================================================
+	// Leg 2: Second authorize → callback (re-auth, same user, IdP omits RT)
+	// =========================================================================
+
+	// Enable RT stripping: the proxy will now remove "refresh_token" from the
+	// token endpoint JSON before the oauth2 library sees it. This replicates
+	// the real-world behavior of IdPs that do not re-issue refresh_tokens on
+	// subsequent authorizations (e.g. Google without prompt=consent).
+	proxy.stripRT.Store(true)
+
+	// Queue the same user again so the auth server resolves the same internal UserID.
+	m.QueueUser(&mockoidc.MockUser{
+		Subject: userSubject,
+		Email:   userEmail,
+	})
+
+	verifier2 := servercrypto.GeneratePKCEVerifier()
+	challenge2 := servercrypto.ComputePKCEChallenge(verifier2)
+
+	authCode2, _ := completeAuthorizationFlow(t, ts.Server.URL, authorizationParams{
+		ClientID:     testClientID,
+		RedirectURI:  testRedirectURI,
+		State:        "rt-carry-leg2",
+		Challenge:    challenge2,
+		Scope:        "openid profile",
+		ResponseType: "code",
+	})
+
+	tokenData2 := exchangeCodeForTokens(t, ts.Server.URL, authCode2, verifier2, testAudience)
+	accessToken2, ok := tokenData2["access_token"].(string)
+	require.True(t, ok, "leg 2: access_token should be present")
+
+	sessionID2 := extractTSID(t, accessToken2, ts.PrivateKey.Public())
+
+	// The second authorize flow must create a new session (new TSID).
+	require.NotEqual(t, sessionID1, sessionID2, "leg 2: must use a distinct session ID")
+
+	// Canonical regression assertion: the new row's RT was carried forward from
+	// the prior session even though the IdP omitted it in the token response.
+	tokens2, err := ts.storage.GetUpstreamTokens(ctx, sessionID2, providerName)
+	require.NoError(t, err, "leg 2: upstream tokens should be stored")
+	assert.Equal(t, priorRT, tokens2.RefreshToken,
+		"leg 2: RT must be carried forward from the prior session (regression assertion)")
+
+	// =========================================================================
+	// Leg 3: Third authorize → callback (different user — no prior row)
+	// =========================================================================
+	// A different upstream subject causes ResolveUser to create a NEW internal user
+	// (new UserID). GetLatestUpstreamTokensForUser returns ErrNotFound for this new
+	// user, so the carry-forward guard is not triggered and the new row's RT is empty.
+	//
+	// This leg exercises the ErrNotFound branch in maybeCarryForwardRefreshToken.
+	// The UpstreamSubject mismatch guard is covered by handler-level unit tests.
+
+	const otherUserSubject = "reauth-other-user-999"
+	const otherUserEmail = "other@example.com"
+
+	// Keep RT stripping enabled for the third leg as well.
+	m.QueueUser(&mockoidc.MockUser{
+		Subject: otherUserSubject,
+		Email:   otherUserEmail,
+	})
+
+	verifier3 := servercrypto.GeneratePKCEVerifier()
+	challenge3 := servercrypto.ComputePKCEChallenge(verifier3)
+
+	authCode3, _ := completeAuthorizationFlow(t, ts.Server.URL, authorizationParams{
+		ClientID:     testClientID,
+		RedirectURI:  testRedirectURI,
+		State:        "rt-carry-leg3",
+		Challenge:    challenge3,
+		Scope:        "openid profile",
+		ResponseType: "code",
+	})
+
+	tokenData3 := exchangeCodeForTokens(t, ts.Server.URL, authCode3, verifier3, testAudience)
+	accessToken3, ok := tokenData3["access_token"].(string)
+	require.True(t, ok, "leg 3: access_token should be present")
+
+	sessionID3 := extractTSID(t, accessToken3, ts.PrivateKey.Public())
+	require.NotEqual(t, sessionID2, sessionID3, "leg 3: must use a distinct session ID from leg 2")
+	require.NotEqual(t, sessionID1, sessionID3, "leg 3: must use a distinct session ID from leg 1")
+
+	// No carry-forward: RT stripping is still on, so storageTokens.RefreshToken is
+	// empty when we enter maybeCarryForwardRefreshToken. The new user has no prior
+	// row either, so GetLatestUpstreamTokensForUser returns ErrNotFound and the
+	// guard returns early — the stored RT stays empty (ErrNotFound branch).
+	tokens3, err := ts.storage.GetUpstreamTokens(ctx, sessionID3, providerName)
+	require.NoError(t, err, "leg 3: upstream tokens should be stored")
+	assert.Empty(t, tokens3.RefreshToken,
+		"leg 3: no RT carry-forward for a new user with no prior row (ErrNotFound path)")
 }

--- a/pkg/authserver/server/handlers/callback.go
+++ b/pkg/authserver/server/handlers/callback.go
@@ -5,6 +5,7 @@ package handlers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -157,6 +158,8 @@ func (h *Handler) CallbackHandler(w http.ResponseWriter, req *http.Request) {
 		UpstreamSubject:  providerSubject, // Upstream IDP's subject claim
 	}
 
+	h.maybeCarryForwardRefreshToken(ctx, storageTokens, subject, providerSubject, providerID)
+
 	if err := h.storage.StoreUpstreamTokens(ctx, sessionID, providerID, storageTokens); err != nil {
 		slog.Error("failed to store upstream tokens",
 			"error", err,
@@ -168,6 +171,45 @@ func (h *Handler) CallbackHandler(w http.ResponseWriter, req *http.Request) {
 	}
 
 	h.continueChainOrComplete(ctx, w, req, ar, pending, sessionID, subject, userName, userEmail)
+}
+
+// maybeCarryForwardRefreshToken preserves a prior refresh token when the upstream IdP
+// omits refresh_token on re-authorization (a common behavior, e.g. Google without
+// prompt=consent). Without this, the new row would be written with an empty RefreshToken,
+// orphaning the previously-issued RT and forcing the next refresh attempt to fail.
+// Mirrors the preservation pattern in upstreamTokenRefresher.RefreshAndStore.
+//
+// The UpstreamSubject == providerSubject guard is defense-in-depth against account-linking
+// edge cases where one internal user might have two distinct upstream subjects on the
+// same provider.
+//
+// storageTokens is mutated in-place only when a carry-forward is warranted.
+func (h *Handler) maybeCarryForwardRefreshToken(
+	ctx context.Context,
+	storageTokens *storage.UpstreamTokens,
+	subject, providerSubject, providerID string,
+) {
+	if storageTokens.RefreshToken != "" {
+		return
+	}
+	prior, err := h.storage.GetLatestUpstreamTokensForUser(ctx, subject, providerID)
+	switch {
+	case err == nil:
+		if prior != nil && prior.UpstreamSubject == providerSubject && prior.RefreshToken != "" {
+			storageTokens.RefreshToken = prior.RefreshToken
+			slog.Debug("preserved upstream refresh token from prior row",
+				"user_id", subject, "provider_id", providerID,
+			)
+		}
+	case errors.Is(err, storage.ErrNotFound):
+		// First authorization for this user/provider — nothing to preserve.
+	default:
+		// Storage error — log and continue with empty RT. Failing the callback
+		// would be a worse user experience than the (already broken) status quo.
+		slog.Warn("failed to look up prior upstream tokens for RT preservation",
+			"error", err, "user_id", subject, "provider_id", providerID,
+		)
+	}
 }
 
 // writeAuthorizationResponse generates an authorization code and writes the redirect response.

--- a/pkg/authserver/server/handlers/callback_test.go
+++ b/pkg/authserver/server/handlers/callback_test.go
@@ -884,6 +884,13 @@ func TestCallbackHandler_RefreshTokenCarryForward(t *testing.T) {
 			lookupErr:        errors.New("simulated storage failure"),
 			expectedStoredRT: "",
 		},
+		{
+			name:             "does not carry prior RT when prior RT is empty",
+			priorRow:         &priorRow{sessionID: "old-session", upstreamSubject: "user-123", refreshToken: ""},
+			idpRefreshToken:  "",
+			idpSubject:       "user-123",
+			expectedStoredRT: "",
+		},
 	}
 
 	for _, tc := range cases {
@@ -964,6 +971,12 @@ func TestCallbackHandler_RefreshTokenCarryForward(t *testing.T) {
 			newRow, ok := storState.upstreamTokens[newSessionID+":"+providerName]
 			require.True(t, ok, "token row for new session should be stored")
 			assert.Equal(t, tc.expectedStoredRT, newRow.RefreshToken)
+			// Sanity-check the rest of the row was written by the callback path so a
+			// regression that early-returns before StoreUpstreamTokens cannot pass.
+			assert.Equal(t, "new-access-token", newRow.AccessToken)
+			assert.Equal(t, "new-id-token", newRow.IDToken)
+			assert.Equal(t, tc.idpSubject, newRow.UpstreamSubject)
+			assert.False(t, newRow.ExpiresAt.IsZero(), "ExpiresAt must be populated")
 		})
 	}
 }

--- a/pkg/authserver/server/handlers/callback_test.go
+++ b/pkg/authserver/server/handlers/callback_test.go
@@ -826,6 +826,148 @@ func TestCallbackHandler_TwoUpstreams_StorePendingError_CleansUp(t *testing.T) {
 	}
 }
 
+// TestCallbackHandler_RefreshTokenCarryForward verifies the OAuth callback's
+// behavior when the upstream IdP omits refresh_token on re-authorization. The
+// handler looks up a prior (user, provider) row and carries the prior RT
+// forward, with a defensive UpstreamSubject guard against account-linking
+// edge cases. Storage errors during the lookup are non-fatal.
+func TestCallbackHandler_RefreshTokenCarryForward(t *testing.T) {
+	t.Parallel()
+
+	type priorRow struct {
+		sessionID       string
+		upstreamSubject string
+		refreshToken    string
+	}
+
+	cases := []struct {
+		name             string
+		priorRow         *priorRow // nil = no prior row
+		idpRefreshToken  string    // RT returned by upstream exchange
+		idpSubject       string    // subject claim returned by upstream
+		lookupErr        error     // if non-nil, storage lookup returns this error
+		expectedStoredRT string    // expected RefreshToken on the new row
+	}{
+		{
+			name:             "preserves prior RT when IdP omits it",
+			priorRow:         &priorRow{sessionID: "old-session", upstreamSubject: "user-123", refreshToken: "rt-prior"},
+			idpRefreshToken:  "",
+			idpSubject:       "user-123",
+			expectedStoredRT: "rt-prior",
+		},
+		{
+			name:             "no carry across different upstream subjects",
+			priorRow:         &priorRow{sessionID: "alice-session", upstreamSubject: "alice@idp", refreshToken: "rt-prior"},
+			idpRefreshToken:  "",
+			idpSubject:       "bob@idp",
+			expectedStoredRT: "",
+		},
+		{
+			name:             "fresh IdP RT wins",
+			priorRow:         &priorRow{sessionID: "old-session", upstreamSubject: "user-123", refreshToken: "rt-prior"},
+			idpRefreshToken:  "rt-fresh",
+			idpSubject:       "user-123",
+			expectedStoredRT: "rt-fresh",
+		},
+		{
+			name:             "no prior row accepts empty RT",
+			priorRow:         nil,
+			idpRefreshToken:  "",
+			idpSubject:       "user-123",
+			expectedStoredRT: "",
+		},
+		{
+			name:             "storage error during lookup is non-fatal",
+			priorRow:         nil,
+			idpRefreshToken:  "",
+			idpSubject:       "user-123",
+			lookupErr:        errors.New("simulated storage failure"),
+			expectedStoredRT: "",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			const (
+				providerName   = "test-upstream"
+				existingUserID = "user-id"
+				newSessionID   = "new-session"
+			)
+
+			var opts []baseTestSetupOption
+			if tc.lookupErr != nil {
+				opts = append(opts, withGetLatestUpstreamTokensError(tc.lookupErr))
+			}
+			handler, storState, mockUpstream := handlerTestSetup(t, opts...)
+
+			mockUpstream.exchangeResult = &upstream.Identity{
+				Tokens: &upstream.Tokens{
+					AccessToken:  "new-access-token",
+					RefreshToken: tc.idpRefreshToken,
+					IDToken:      "new-id-token",
+					ExpiresAt:    time.Now().Add(time.Hour),
+				},
+				Subject: tc.idpSubject,
+			}
+
+			// Pre-populate user + identity so ResolveUser is deterministic.
+			storState.users[existingUserID] = &storage.User{
+				ID:        existingUserID,
+				CreatedAt: time.Now(),
+				UpdatedAt: time.Now(),
+			}
+			storState.providerIdentities[providerName+":"+tc.idpSubject] = &storage.ProviderIdentity{
+				UserID:          existingUserID,
+				ProviderID:      providerName,
+				ProviderSubject: tc.idpSubject,
+				LinkedAt:        time.Now(),
+				LastUsedAt:      time.Now(),
+			}
+
+			if tc.priorRow != nil {
+				storState.upstreamTokens[tc.priorRow.sessionID+":"+providerName] = &storage.UpstreamTokens{
+					ProviderID:      providerName,
+					AccessToken:     "old-access",
+					RefreshToken:    tc.priorRow.refreshToken,
+					ExpiresAt:       time.Now().Add(30 * time.Minute),
+					ClientID:        testAuthClientID,
+					UserID:          existingUserID,
+					UpstreamSubject: tc.priorRow.upstreamSubject,
+				}
+			}
+
+			internalState := testInternalState
+			storState.pendingAuths[internalState] = &storage.PendingAuthorization{
+				ClientID:             testAuthClientID,
+				RedirectURI:          testAuthRedirectURI,
+				State:                "client-state",
+				PKCEChallenge:        "challenge123",
+				PKCEMethod:           "S256",
+				Scopes:               []string{"openid"},
+				InternalState:        internalState,
+				UpstreamPKCEVerifier: "verifier-1234567890123456789012345678",
+				SessionID:            newSessionID,
+				UpstreamProviderName: providerName,
+				CreatedAt:            time.Now(),
+			}
+
+			req := httptest.NewRequest(http.MethodGet, "/oauth/callback?code=test-code&state="+internalState, nil)
+			rec := httptest.NewRecorder()
+			handler.CallbackHandler(rec, req)
+
+			require.Equal(t, http.StatusSeeOther, rec.Code)
+			assert.NotContains(t, rec.Header().Get("Location"), "error=")
+
+			newRow, ok := storState.upstreamTokens[newSessionID+":"+providerName]
+			require.True(t, ok, "token row for new session should be stored")
+			assert.Equal(t, tc.expectedStoredRT, newRow.RefreshToken)
+		})
+	}
+}
+
 func TestRoutesIncludeAuthorizeAndCallback(t *testing.T) {
 	t.Parallel()
 	handler, _, _ := handlerTestSetup(t)

--- a/pkg/authserver/server/handlers/helpers_test.go
+++ b/pkg/authserver/server/handlers/helpers_test.go
@@ -97,12 +97,19 @@ type testStorageState struct {
 type baseTestSetupOption func(*baseTestSetupConfig)
 
 type baseTestSetupConfig struct {
-	storePendingErr error // if non-nil, StorePendingAuthorization always returns this error
+	storePendingErr            error // if non-nil, StorePendingAuthorization always returns this error
+	getLatestUpstreamTokensErr error // if non-nil, GetLatestUpstreamTokensForUser always returns this error
 }
 
 func withStorePendingError(err error) baseTestSetupOption {
 	return func(c *baseTestSetupConfig) {
 		c.storePendingErr = err
+	}
+}
+
+func withGetLatestUpstreamTokensError(err error) baseTestSetupOption {
+	return func(c *baseTestSetupConfig) {
+		c.getLatestUpstreamTokensErr = err
 	}
 }
 
@@ -346,6 +353,28 @@ func baseTestSetup(t *testing.T, opts ...baseTestSetupOption) (fosite.OAuth2Prov
 			return result, nil
 		}).AnyTimes()
 
+	stor.EXPECT().
+		GetLatestUpstreamTokensForUser(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, userID, providerID string) (*storage.UpstreamTokens, error) {
+			if setupCfg.getLatestUpstreamTokensErr != nil {
+				return nil, setupCfg.getLatestUpstreamTokensErr
+			}
+			var winner *storage.UpstreamTokens
+			for _, t := range storState.upstreamTokens {
+				if t == nil || t.UserID != userID || t.ProviderID != providerID {
+					continue
+				}
+				if winner == nil || t.ExpiresAt.After(winner.ExpiresAt) {
+					winner = t
+				}
+			}
+			if winner == nil {
+				return nil, storage.ErrNotFound
+			}
+			return winner, nil
+		}).
+		AnyTimes()
+
 	// Create fosite provider with authorization code support
 	jwtStrategy := compose.NewOAuth2JWTStrategy(
 		func(_ context.Context) (any, error) {
@@ -368,10 +397,11 @@ func baseTestSetup(t *testing.T, opts ...baseTestSetupOption) (fosite.OAuth2Prov
 }
 
 // handlerTestSetup creates a test setup with all dependencies including an upstream provider.
-func handlerTestSetup(t *testing.T) (*Handler, *testStorageState, *mockIDPProvider) {
+// Any baseTestSetupOption values are forwarded to baseTestSetup.
+func handlerTestSetup(t *testing.T, opts ...baseTestSetupOption) (*Handler, *testStorageState, *mockIDPProvider) {
 	t.Helper()
 
-	provider, oauth2Config, stor, storState := baseTestSetup(t)
+	provider, oauth2Config, stor, storState := baseTestSetup(t, opts...)
 
 	mockUpstream := &mockIDPProvider{
 		providerType:     upstream.ProviderTypeOAuth2,

--- a/pkg/authserver/storage/memory.go
+++ b/pkg/authserver/storage/memory.go
@@ -838,6 +838,23 @@ func (s *MemoryStorage) DeleteUpstreamTokens(_ context.Context, sessionID string
 	return nil
 }
 
+// compareExpiry orders ExpiresAt values for the GetLatestUpstreamTokensForUser
+// tie-breaker. Non-expiring rows (zero ExpiresAt — "alive forever") rank latest;
+// among finite expiries, later ranks latest. Mirrors time.Compare but with the
+// zero sentinel reinterpreted. Returns -1/0/+1.
+func compareExpiry(a, b time.Time) int {
+	aZero, bZero := a.IsZero(), b.IsZero()
+	switch {
+	case aZero && bZero:
+		return 0
+	case aZero:
+		return 1
+	case bZero:
+		return -1
+	}
+	return a.Compare(b)
+}
+
 // GetLatestUpstreamTokensForUser implements UpstreamTokenStorage.
 //
 // Expired tokens (past ExpiresAt) are returned so callers can use the refresh
@@ -859,7 +876,7 @@ func (s *MemoryStorage) GetLatestUpstreamTokensForUser(_ context.Context, userID
 		if entry.value == nil || entry.value.UserID != userID || entry.value.ProviderID != providerID {
 			continue
 		}
-		if winner == nil || entry.value.ExpiresAt.After(winner.ExpiresAt) {
+		if winner == nil || compareExpiry(entry.value.ExpiresAt, winner.ExpiresAt) > 0 {
 			winner = entry.value
 		}
 	}

--- a/pkg/authserver/storage/memory.go
+++ b/pkg/authserver/storage/memory.go
@@ -746,6 +746,24 @@ func (s *MemoryStorage) StoreUpstreamTokens(_ context.Context, sessionID, provid
 	return nil
 }
 
+// cloneUpstreamTokens returns a field-by-field copy of t, or nil if t is nil.
+func cloneUpstreamTokens(t *UpstreamTokens) *UpstreamTokens {
+	if t == nil {
+		return nil
+	}
+	return &UpstreamTokens{
+		ProviderID:       t.ProviderID,
+		AccessToken:      t.AccessToken,
+		RefreshToken:     t.RefreshToken,
+		IDToken:          t.IDToken,
+		ExpiresAt:        t.ExpiresAt,
+		SessionExpiresAt: t.SessionExpiresAt,
+		UserID:           t.UserID,
+		UpstreamSubject:  t.UpstreamSubject,
+		ClientID:         t.ClientID,
+	}
+}
+
 // GetUpstreamTokens retrieves the upstream IDP tokens for a session and provider.
 // Returns a defensive copy to prevent aliasing issues.
 func (s *MemoryStorage) GetUpstreamTokens(_ context.Context, sessionID, providerName string) (*UpstreamTokens, error) {
@@ -766,20 +784,9 @@ func (s *MemoryStorage) GetUpstreamTokens(_ context.Context, sessionID, provider
 	}
 
 	// Return a defensive copy to prevent aliasing issues
-	tokens := entry.value
-	if tokens == nil {
+	result := cloneUpstreamTokens(entry.value)
+	if result == nil {
 		return nil, nil
-	}
-	result := &UpstreamTokens{
-		ProviderID:       tokens.ProviderID,
-		AccessToken:      tokens.AccessToken,
-		RefreshToken:     tokens.RefreshToken,
-		IDToken:          tokens.IDToken,
-		ExpiresAt:        tokens.ExpiresAt,
-		SessionExpiresAt: tokens.SessionExpiresAt,
-		UserID:           tokens.UserID,
-		UpstreamSubject:  tokens.UpstreamSubject,
-		ClientID:         tokens.ClientID,
 	}
 
 	// Check the token's own ExpiresAt (access token expiry), not the entry's expiresAt
@@ -806,23 +813,8 @@ func (s *MemoryStorage) GetAllUpstreamTokens(_ context.Context, sessionID string
 		if key.sessionID != sessionID {
 			continue
 		}
-		tokens := entry.value
-		if tokens == nil {
-			result[key.providerName] = nil
-			continue
-		}
-		// Defensive copy
-		result[key.providerName] = &UpstreamTokens{
-			ProviderID:       tokens.ProviderID,
-			AccessToken:      tokens.AccessToken,
-			RefreshToken:     tokens.RefreshToken,
-			IDToken:          tokens.IDToken,
-			ExpiresAt:        tokens.ExpiresAt,
-			SessionExpiresAt: tokens.SessionExpiresAt,
-			UserID:           tokens.UserID,
-			UpstreamSubject:  tokens.UpstreamSubject,
-			ClientID:         tokens.ClientID,
-		}
+		// Defensive copy (cloneUpstreamTokens handles nil)
+		result[key.providerName] = cloneUpstreamTokens(entry.value)
 	}
 
 	return result, nil
@@ -876,17 +868,7 @@ func (s *MemoryStorage) GetLatestUpstreamTokensForUser(_ context.Context, userID
 		return nil, fmt.Errorf("%w: %w", ErrNotFound, fosite.ErrNotFound.WithHint("Upstream tokens not found"))
 	}
 
-	return &UpstreamTokens{
-		ProviderID:       winner.ProviderID,
-		AccessToken:      winner.AccessToken,
-		RefreshToken:     winner.RefreshToken,
-		IDToken:          winner.IDToken,
-		ExpiresAt:        winner.ExpiresAt,
-		SessionExpiresAt: winner.SessionExpiresAt,
-		UserID:           winner.UserID,
-		UpstreamSubject:  winner.UpstreamSubject,
-		ClientID:         winner.ClientID,
-	}, nil
+	return cloneUpstreamTokens(winner), nil
 }
 
 // -----------------------

--- a/pkg/authserver/storage/memory.go
+++ b/pkg/authserver/storage/memory.go
@@ -877,14 +877,15 @@ func (s *MemoryStorage) GetLatestUpstreamTokensForUser(_ context.Context, userID
 	}
 
 	return &UpstreamTokens{
-		ProviderID:      winner.ProviderID,
-		AccessToken:     winner.AccessToken,
-		RefreshToken:    winner.RefreshToken,
-		IDToken:         winner.IDToken,
-		ExpiresAt:       winner.ExpiresAt,
-		UserID:          winner.UserID,
-		UpstreamSubject: winner.UpstreamSubject,
-		ClientID:        winner.ClientID,
+		ProviderID:       winner.ProviderID,
+		AccessToken:      winner.AccessToken,
+		RefreshToken:     winner.RefreshToken,
+		IDToken:          winner.IDToken,
+		ExpiresAt:        winner.ExpiresAt,
+		SessionExpiresAt: winner.SessionExpiresAt,
+		UserID:           winner.UserID,
+		UpstreamSubject:  winner.UpstreamSubject,
+		ClientID:         winner.ClientID,
 	}, nil
 }
 

--- a/pkg/authserver/storage/memory.go
+++ b/pkg/authserver/storage/memory.go
@@ -846,6 +846,13 @@ func (s *MemoryStorage) DeleteUpstreamTokens(_ context.Context, sessionID string
 	return nil
 }
 
+// GetLatestUpstreamTokensForUser always returns ErrNotFound in this stub. The full
+// implementation lands in the follow-on step; see the interface declaration in
+// types.go for the contract.
+func (*MemoryStorage) GetLatestUpstreamTokensForUser(_ context.Context, _, _ string) (*UpstreamTokens, error) {
+	return nil, fmt.Errorf("%w: %w", ErrNotFound, fosite.ErrNotFound.WithHint("Upstream tokens not found"))
+}
+
 // -----------------------
 // Pending Authorization Storage
 // -----------------------

--- a/pkg/authserver/storage/memory.go
+++ b/pkg/authserver/storage/memory.go
@@ -846,11 +846,46 @@ func (s *MemoryStorage) DeleteUpstreamTokens(_ context.Context, sessionID string
 	return nil
 }
 
-// GetLatestUpstreamTokensForUser always returns ErrNotFound in this stub. The full
-// implementation lands in the follow-on step; see the interface declaration in
-// types.go for the contract.
-func (*MemoryStorage) GetLatestUpstreamTokensForUser(_ context.Context, _, _ string) (*UpstreamTokens, error) {
-	return nil, fmt.Errorf("%w: %w", ErrNotFound, fosite.ErrNotFound.WithHint("Upstream tokens not found"))
+// GetLatestUpstreamTokensForUser implements UpstreamTokenStorage.
+//
+// Expired tokens (past ExpiresAt) are returned so callers can use the refresh
+// token; filtering by access-token expiry is the caller's responsibility.
+// See the interface declaration in types.go for the full contract.
+func (s *MemoryStorage) GetLatestUpstreamTokensForUser(_ context.Context, userID, providerID string) (*UpstreamTokens, error) {
+	if userID == "" {
+		return nil, fosite.ErrInvalidRequest.WithHint("user ID cannot be empty")
+	}
+	if providerID == "" {
+		return nil, fosite.ErrInvalidRequest.WithHint("provider ID cannot be empty")
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	var winner *UpstreamTokens
+	for _, entry := range s.upstreamTokens {
+		if entry.value == nil || entry.value.UserID != userID || entry.value.ProviderID != providerID {
+			continue
+		}
+		if winner == nil || entry.value.ExpiresAt.After(winner.ExpiresAt) {
+			winner = entry.value
+		}
+	}
+
+	if winner == nil {
+		return nil, fmt.Errorf("%w: %w", ErrNotFound, fosite.ErrNotFound.WithHint("Upstream tokens not found"))
+	}
+
+	return &UpstreamTokens{
+		ProviderID:      winner.ProviderID,
+		AccessToken:     winner.AccessToken,
+		RefreshToken:    winner.RefreshToken,
+		IDToken:         winner.IDToken,
+		ExpiresAt:       winner.ExpiresAt,
+		UserID:          winner.UserID,
+		UpstreamSubject: winner.UpstreamSubject,
+		ClientID:        winner.ClientID,
+	}, nil
 }
 
 // -----------------------

--- a/pkg/authserver/storage/memory_test.go
+++ b/pkg/authserver/storage/memory_test.go
@@ -732,9 +732,10 @@ func TestMemoryStorage_GetLatestUpstreamTokensForUser(t *testing.T) {
 		})
 	})
 
-	t.Run("zero_expires_at_loses_to_nonzero", func(t *testing.T) {
+	t.Run("zero_expires_at_wins_over_nonzero", func(t *testing.T) {
 		withStorage(t, func(ctx context.Context, s *MemoryStorage) {
-			// Row with zero ExpiresAt — StoreUpstreamTokens assigns a default storage TTL.
+			// Row with zero ExpiresAt — providers like Slack and GitHub OAuth Apps
+			// genuinely never expire; treated as "alive forever" by IsExpired.
 			require.NoError(t, s.StoreUpstreamTokens(ctx, "session-zero", "prov-X", &UpstreamTokens{
 				ProviderID:   "prov-X",
 				UserID:       "user-A",
@@ -751,7 +752,31 @@ func TestMemoryStorage_GetLatestUpstreamTokensForUser(t *testing.T) {
 
 			got, err := s.GetLatestUpstreamTokensForUser(ctx, "user-A", "prov-X")
 			require.NoError(t, err)
-			assert.Equal(t, "rt-nonzero", got.RefreshToken)
+			assert.Equal(t, "rt-zero", got.RefreshToken)
+		})
+	})
+
+	t.Run("two_zero_expires_at_rows", func(t *testing.T) {
+		withStorage(t, func(ctx context.Context, s *MemoryStorage) {
+			// Both rows have zero ExpiresAt. Go's map iteration is randomized so
+			// we only assert that one of the two is returned.
+			require.NoError(t, s.StoreUpstreamTokens(ctx, "session-zero-1", "prov-X", &UpstreamTokens{
+				ProviderID:   "prov-X",
+				UserID:       "user-A",
+				RefreshToken: "rt-zero-1",
+				ExpiresAt:    time.Time{},
+			}))
+			require.NoError(t, s.StoreUpstreamTokens(ctx, "session-zero-2", "prov-X", &UpstreamTokens{
+				ProviderID:   "prov-X",
+				UserID:       "user-A",
+				RefreshToken: "rt-zero-2",
+				ExpiresAt:    time.Time{},
+			}))
+
+			got, err := s.GetLatestUpstreamTokensForUser(ctx, "user-A", "prov-X")
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			assert.Contains(t, []string{"rt-zero-1", "rt-zero-2"}, got.RefreshToken)
 		})
 	})
 

--- a/pkg/authserver/storage/memory_test.go
+++ b/pkg/authserver/storage/memory_test.go
@@ -770,6 +770,30 @@ func TestMemoryStorage_GetLatestUpstreamTokensForUser(t *testing.T) {
 			require.ErrorIs(t, err, fosite.ErrInvalidRequest)
 		})
 	})
+
+	t.Run("returns_all_fields_round_trip", func(t *testing.T) {
+		withStorage(t, func(ctx context.Context, s *MemoryStorage) {
+			now := time.Now().Truncate(time.Second)
+			fixture := UpstreamTokens{
+				ProviderID:       "prov-X",
+				AccessToken:      "access-tok",
+				RefreshToken:     "refresh-tok",
+				IDToken:          "id-tok",
+				ExpiresAt:        now.Add(time.Hour),
+				SessionExpiresAt: now.Add(2 * time.Hour),
+				UserID:           "user-A",
+				UpstreamSubject:  "sub-upstream",
+				ClientID:         "client-1",
+			}
+
+			require.NoError(t, s.StoreUpstreamTokens(ctx, "session-rt", "prov-X", &fixture))
+
+			got, err := s.GetLatestUpstreamTokensForUser(ctx, "user-A", "prov-X")
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			require.Equal(t, fixture, *got)
+		})
+	})
 }
 
 // --- Pending Authorization Tests ---

--- a/pkg/authserver/storage/memory_test.go
+++ b/pkg/authserver/storage/memory_test.go
@@ -621,6 +621,157 @@ func TestMemoryStorage_UpstreamTokens(t *testing.T) {
 	})
 }
 
+func TestMemoryStorage_GetLatestUpstreamTokensForUser(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no_match", func(t *testing.T) {
+		withStorage(t, func(ctx context.Context, s *MemoryStorage) {
+			_, err := s.GetLatestUpstreamTokensForUser(ctx, "user-A", "prov-X")
+			require.Error(t, err)
+			assert.ErrorIs(t, err, ErrNotFound)
+		})
+	})
+
+	t.Run("one_match_returns_deep_copy", func(t *testing.T) {
+		withStorage(t, func(ctx context.Context, s *MemoryStorage) {
+			require.NoError(t, s.StoreUpstreamTokens(ctx, "session-1", "prov-X", &UpstreamTokens{
+				ProviderID:   "prov-X",
+				UserID:       "user-A",
+				RefreshToken: "rt-1",
+				ExpiresAt:    time.Now().Add(time.Hour),
+			}))
+
+			got, err := s.GetLatestUpstreamTokensForUser(ctx, "user-A", "prov-X")
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			assert.Equal(t, "rt-1", got.RefreshToken)
+
+			// Mutate the returned copy and confirm the stored value is unchanged.
+			got.RefreshToken = "mutated"
+			got2, err := s.GetLatestUpstreamTokensForUser(ctx, "user-A", "prov-X")
+			require.NoError(t, err)
+			assert.Equal(t, "rt-1", got2.RefreshToken, "stored row must be unaffected by mutation of returned copy")
+		})
+	})
+
+	t.Run("multiple_sessions_pick_latest_expires_at", func(t *testing.T) {
+		withStorage(t, func(ctx context.Context, s *MemoryStorage) {
+			now := time.Now()
+			require.NoError(t, s.StoreUpstreamTokens(ctx, "session-1", "prov-X", &UpstreamTokens{
+				ProviderID:   "prov-X",
+				UserID:       "user-A",
+				RefreshToken: "rt-1h",
+				ExpiresAt:    now.Add(time.Hour),
+			}))
+			require.NoError(t, s.StoreUpstreamTokens(ctx, "session-2", "prov-X", &UpstreamTokens{
+				ProviderID:   "prov-X",
+				UserID:       "user-A",
+				RefreshToken: "rt-2h",
+				ExpiresAt:    now.Add(2 * time.Hour),
+			}))
+			require.NoError(t, s.StoreUpstreamTokens(ctx, "session-3", "prov-X", &UpstreamTokens{
+				ProviderID:   "prov-X",
+				UserID:       "user-A",
+				RefreshToken: "rt-3h",
+				ExpiresAt:    now.Add(3 * time.Hour),
+			}))
+
+			got, err := s.GetLatestUpstreamTokensForUser(ctx, "user-A", "prov-X")
+			require.NoError(t, err)
+			assert.Equal(t, "rt-3h", got.RefreshToken)
+		})
+	})
+
+	t.Run("different_user_not_matched", func(t *testing.T) {
+		withStorage(t, func(ctx context.Context, s *MemoryStorage) {
+			require.NoError(t, s.StoreUpstreamTokens(ctx, "session-1", "prov-X", &UpstreamTokens{
+				ProviderID: "prov-X",
+				UserID:     "user-B",
+				ExpiresAt:  time.Now().Add(time.Hour),
+			}))
+
+			_, err := s.GetLatestUpstreamTokensForUser(ctx, "user-A", "prov-X")
+			require.Error(t, err)
+			assert.ErrorIs(t, err, ErrNotFound)
+		})
+	})
+
+	t.Run("different_provider_not_matched", func(t *testing.T) {
+		withStorage(t, func(ctx context.Context, s *MemoryStorage) {
+			// The lookup filters on the stored UpstreamTokens.ProviderID field,
+			// not the map key. StoreUpstreamTokens copies the field from the
+			// input struct, so they always match here.
+			require.NoError(t, s.StoreUpstreamTokens(ctx, "session-1", "prov-Y", &UpstreamTokens{
+				ProviderID: "prov-Y",
+				UserID:     "user-A",
+				ExpiresAt:  time.Now().Add(time.Hour),
+			}))
+
+			_, err := s.GetLatestUpstreamTokensForUser(ctx, "user-A", "prov-X")
+			require.Error(t, err)
+			assert.ErrorIs(t, err, ErrNotFound)
+		})
+	})
+
+	t.Run("tolerate_access_token_expired", func(t *testing.T) {
+		withStorage(t, func(ctx context.Context, s *MemoryStorage) {
+			// ExpiresAt is 1h in the past (access token expired), but the storage TTL
+			// is ExpiresAt + DefaultRefreshTokenTTL which is still in the future,
+			// so the cleanup loop has not swept this row yet.
+			require.NoError(t, s.StoreUpstreamTokens(ctx, "session-1", "prov-X", &UpstreamTokens{
+				ProviderID:   "prov-X",
+				UserID:       "user-A",
+				RefreshToken: "rt-expired-at",
+				ExpiresAt:    time.Now().Add(-time.Hour),
+			}))
+
+			got, err := s.GetLatestUpstreamTokensForUser(ctx, "user-A", "prov-X")
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			assert.Equal(t, "rt-expired-at", got.RefreshToken)
+		})
+	})
+
+	t.Run("zero_expires_at_loses_to_nonzero", func(t *testing.T) {
+		withStorage(t, func(ctx context.Context, s *MemoryStorage) {
+			// Row with zero ExpiresAt — StoreUpstreamTokens assigns a default storage TTL.
+			require.NoError(t, s.StoreUpstreamTokens(ctx, "session-zero", "prov-X", &UpstreamTokens{
+				ProviderID:   "prov-X",
+				UserID:       "user-A",
+				RefreshToken: "rt-zero",
+				ExpiresAt:    time.Time{},
+			}))
+			// Row with a real ExpiresAt in the future.
+			require.NoError(t, s.StoreUpstreamTokens(ctx, "session-nonzero", "prov-X", &UpstreamTokens{
+				ProviderID:   "prov-X",
+				UserID:       "user-A",
+				RefreshToken: "rt-nonzero",
+				ExpiresAt:    time.Now().Add(time.Hour),
+			}))
+
+			got, err := s.GetLatestUpstreamTokensForUser(ctx, "user-A", "prov-X")
+			require.NoError(t, err)
+			assert.Equal(t, "rt-nonzero", got.RefreshToken)
+		})
+	})
+
+	t.Run("empty_user_id", func(t *testing.T) {
+		withStorage(t, func(ctx context.Context, s *MemoryStorage) {
+			_, err := s.GetLatestUpstreamTokensForUser(ctx, "", "prov-X")
+			require.Error(t, err)
+			require.ErrorIs(t, err, fosite.ErrInvalidRequest)
+		})
+	})
+
+	t.Run("empty_provider_id", func(t *testing.T) {
+		withStorage(t, func(ctx context.Context, s *MemoryStorage) {
+			_, err := s.GetLatestUpstreamTokensForUser(ctx, "user-A", "")
+			require.Error(t, err)
+			require.ErrorIs(t, err, fosite.ErrInvalidRequest)
+		})
+	})
+}
+
 // --- Pending Authorization Tests ---
 
 func TestMemoryStorage_PendingAuthorization(t *testing.T) {

--- a/pkg/authserver/storage/mocks/mock_storage.go
+++ b/pkg/authserver/storage/mocks/mock_storage.go
@@ -220,6 +220,21 @@ func (mr *MockUpstreamTokenStorageMockRecorder) GetAllUpstreamTokens(ctx, sessio
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllUpstreamTokens", reflect.TypeOf((*MockUpstreamTokenStorage)(nil).GetAllUpstreamTokens), ctx, sessionID)
 }
 
+// GetLatestUpstreamTokensForUser mocks base method.
+func (m *MockUpstreamTokenStorage) GetLatestUpstreamTokensForUser(ctx context.Context, userID, providerID string) (*storage.UpstreamTokens, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetLatestUpstreamTokensForUser", ctx, userID, providerID)
+	ret0, _ := ret[0].(*storage.UpstreamTokens)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetLatestUpstreamTokensForUser indicates an expected call of GetLatestUpstreamTokensForUser.
+func (mr *MockUpstreamTokenStorageMockRecorder) GetLatestUpstreamTokensForUser(ctx, userID, providerID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLatestUpstreamTokensForUser", reflect.TypeOf((*MockUpstreamTokenStorage)(nil).GetLatestUpstreamTokensForUser), ctx, userID, providerID)
+}
+
 // GetUpstreamTokens mocks base method.
 func (m *MockUpstreamTokenStorage) GetUpstreamTokens(ctx context.Context, sessionID, providerName string) (*storage.UpstreamTokens, error) {
 	m.ctrl.T.Helper()
@@ -691,6 +706,21 @@ func (m *MockStorage) GetClient(ctx context.Context, id string) (fosite.Client, 
 func (mr *MockStorageMockRecorder) GetClient(ctx, id any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClient", reflect.TypeOf((*MockStorage)(nil).GetClient), ctx, id)
+}
+
+// GetLatestUpstreamTokensForUser mocks base method.
+func (m *MockStorage) GetLatestUpstreamTokensForUser(ctx context.Context, userID, providerID string) (*storage.UpstreamTokens, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetLatestUpstreamTokensForUser", ctx, userID, providerID)
+	ret0, _ := ret[0].(*storage.UpstreamTokens)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetLatestUpstreamTokensForUser indicates an expected call of GetLatestUpstreamTokensForUser.
+func (mr *MockStorageMockRecorder) GetLatestUpstreamTokensForUser(ctx, userID, providerID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLatestUpstreamTokensForUser", reflect.TypeOf((*MockStorage)(nil).GetLatestUpstreamTokensForUser), ctx, userID, providerID)
 }
 
 // GetPKCERequestSession mocks base method.

--- a/pkg/authserver/storage/redis.go
+++ b/pkg/authserver/storage/redis.go
@@ -1173,15 +1173,20 @@ func (s *RedisStorage) GetLatestUpstreamTokensForUser(ctx context.Context, userI
 			if stored.ExpiresAt != 0 {
 				expiresAt = time.Unix(stored.ExpiresAt, 0)
 			}
+			var sessionExpiresAt time.Time
+			if stored.SessionExpiresAt != 0 {
+				sessionExpiresAt = time.Unix(stored.SessionExpiresAt, 0)
+			}
 			winnerTokens = &UpstreamTokens{
-				ProviderID:      stored.ProviderID,
-				AccessToken:     stored.AccessToken,
-				RefreshToken:    stored.RefreshToken,
-				IDToken:         stored.IDToken,
-				ExpiresAt:       expiresAt,
-				UserID:          stored.UserID,
-				UpstreamSubject: stored.UpstreamSubject,
-				ClientID:        stored.ClientID,
+				ProviderID:       stored.ProviderID,
+				AccessToken:      stored.AccessToken,
+				RefreshToken:     stored.RefreshToken,
+				IDToken:          stored.IDToken,
+				ExpiresAt:        expiresAt,
+				SessionExpiresAt: sessionExpiresAt,
+				UserID:           stored.UserID,
+				UpstreamSubject:  stored.UpstreamSubject,
+				ClientID:         stored.ClientID,
 			}
 		}
 	}

--- a/pkg/authserver/storage/redis.go
+++ b/pkg/authserver/storage/redis.go
@@ -1124,11 +1124,109 @@ func (s *RedisStorage) DeleteUpstreamTokens(ctx context.Context, sessionID strin
 	return nil
 }
 
-// GetLatestUpstreamTokensForUser always returns ErrNotFound in this stub. The full
-// implementation lands in the follow-on step; see the interface declaration in
-// types.go for the contract.
-func (*RedisStorage) GetLatestUpstreamTokensForUser(_ context.Context, _, _ string) (*UpstreamTokens, error) {
-	return nil, fmt.Errorf("%w: %w", ErrNotFound, fosite.ErrNotFound.WithHint("Upstream tokens not found"))
+// GetLatestUpstreamTokensForUser returns the upstream token row for (userID, providerID)
+// with the highest ExpiresAt across all sessions.
+//
+// Expired tokens (past ExpiresAt) are returned so callers can use the refresh
+// token; filtering by access-token expiry is the caller's responsibility.
+// See the interface declaration in types.go for the full contract.
+func (s *RedisStorage) GetLatestUpstreamTokensForUser(ctx context.Context, userID, providerID string) (*UpstreamTokens, error) {
+	if userID == "" {
+		return nil, fosite.ErrInvalidRequest.WithHint("user ID cannot be empty")
+	}
+	if providerID == "" {
+		return nil, fosite.ErrInvalidRequest.WithHint("provider ID cannot be empty")
+	}
+
+	setKey := redisSetKey(s.keyPrefix, KeyTypeUserUpstream, userID)
+
+	members, err := s.client.SMembers(ctx, setKey).Result()
+	if err != nil && !errors.Is(err, redis.Nil) {
+		return nil, fmt.Errorf("failed to get user upstream index: %w", err)
+	}
+	if len(members) == 0 {
+		return nil, fmt.Errorf("%w: %w", ErrNotFound, fosite.ErrNotFound.WithHint("Upstream tokens not found"))
+	}
+
+	values, err := s.client.MGet(ctx, members...).Result()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get upstream tokens: %w", err)
+	}
+
+	var (
+		winner       *storedUpstreamTokens
+		winnerTokens *UpstreamTokens
+	)
+	for i, val := range values {
+		stored, ok := parseUserUpstreamEntry(val, providerID, members[i])
+		if !ok {
+			continue
+		}
+
+		// Pick the row with the highest ExpiresAt. Zero ExpiresAt (the no-expiry
+		// sentinel) is represented as 0 — the smallest int64 — so it loses to any
+		// real timestamp unless it is the only candidate.
+		if winner == nil || stored.ExpiresAt > winner.ExpiresAt {
+			winner = stored
+
+			var expiresAt time.Time
+			if stored.ExpiresAt != 0 {
+				expiresAt = time.Unix(stored.ExpiresAt, 0)
+			}
+			winnerTokens = &UpstreamTokens{
+				ProviderID:      stored.ProviderID,
+				AccessToken:     stored.AccessToken,
+				RefreshToken:    stored.RefreshToken,
+				IDToken:         stored.IDToken,
+				ExpiresAt:       expiresAt,
+				UserID:          stored.UserID,
+				UpstreamSubject: stored.UpstreamSubject,
+				ClientID:        stored.ClientID,
+			}
+		}
+	}
+
+	if winnerTokens == nil {
+		return nil, fmt.Errorf("%w: %w", ErrNotFound, fosite.ErrNotFound.WithHint("Upstream tokens not found"))
+	}
+
+	return winnerTokens, nil
+}
+
+// parseUserUpstreamEntry parses one raw Redis value from the user-upstream index
+// and returns the decoded storedUpstreamTokens together with a match flag.
+// It returns (nil, false) for nil values, type mismatches, deletion tombstones,
+// JSON decode errors, and rows whose ProviderID does not match providerID.
+// keyName is used only for warning log messages.
+func parseUserUpstreamEntry(val any, providerID, keyName string) (*storedUpstreamTokens, bool) {
+	if val == nil {
+		// Dangling set member: the per-provider key has been TTL-evicted.
+		// Skip it; the next write will clean up the index entry (best-effort).
+		return nil, false
+	}
+
+	data, ok := val.(string)
+	if !ok {
+		slog.Warn("skipping upstream token entry: unexpected type", "key", keyName)
+		return nil, false
+	}
+
+	if data == nullMarker {
+		// Deletion tombstone — treat as absent.
+		return nil, false
+	}
+
+	var stored storedUpstreamTokens
+	if unmarshalErr := json.Unmarshal([]byte(data), &stored); unmarshalErr != nil {
+		slog.Warn("skipping corrupt upstream token entry", "key", keyName, "error", unmarshalErr)
+		return nil, false
+	}
+
+	if stored.ProviderID != providerID {
+		return nil, false
+	}
+
+	return &stored, true
 }
 
 // getUpstreamTokensFromKey retrieves and deserializes upstream tokens from a specific Redis key.

--- a/pkg/authserver/storage/redis.go
+++ b/pkg/authserver/storage/redis.go
@@ -808,6 +808,30 @@ type storedUpstreamTokens struct {
 	ClientID         string `json:"client_id"`
 }
 
+// toUpstreamTokens converts the stored int64 epoch fields to time.Time and returns
+// the populated UpstreamTokens. Zero epoch values are preserved as zero time.Time.
+func (s *storedUpstreamTokens) toUpstreamTokens() *UpstreamTokens {
+	var expiresAt time.Time
+	if s.ExpiresAt != 0 {
+		expiresAt = time.Unix(s.ExpiresAt, 0)
+	}
+	var sessionExpiresAt time.Time
+	if s.SessionExpiresAt != 0 {
+		sessionExpiresAt = time.Unix(s.SessionExpiresAt, 0)
+	}
+	return &UpstreamTokens{
+		ProviderID:       s.ProviderID,
+		AccessToken:      s.AccessToken,
+		RefreshToken:     s.RefreshToken,
+		IDToken:          s.IDToken,
+		ExpiresAt:        expiresAt,
+		SessionExpiresAt: sessionExpiresAt,
+		UserID:           s.UserID,
+		UpstreamSubject:  s.UpstreamSubject,
+		ClientID:         s.ClientID,
+	}
+}
+
 // storeUpstreamTokensScript atomically reads the existing UserID, writes new token
 // data, updates the session index set, and updates user reverse-index sets.
 // This prevents a race condition where concurrent writes for the same session
@@ -1153,10 +1177,7 @@ func (s *RedisStorage) GetLatestUpstreamTokensForUser(ctx context.Context, userI
 		return nil, fmt.Errorf("failed to get upstream tokens: %w", err)
 	}
 
-	var (
-		winner       *storedUpstreamTokens
-		winnerTokens *UpstreamTokens
-	)
+	var winner *storedUpstreamTokens
 	for i, val := range values {
 		stored, ok := parseUserUpstreamEntry(val, providerID, members[i])
 		if !ok {
@@ -1168,34 +1189,14 @@ func (s *RedisStorage) GetLatestUpstreamTokensForUser(ctx context.Context, userI
 		// real timestamp unless it is the only candidate.
 		if winner == nil || stored.ExpiresAt > winner.ExpiresAt {
 			winner = stored
-
-			var expiresAt time.Time
-			if stored.ExpiresAt != 0 {
-				expiresAt = time.Unix(stored.ExpiresAt, 0)
-			}
-			var sessionExpiresAt time.Time
-			if stored.SessionExpiresAt != 0 {
-				sessionExpiresAt = time.Unix(stored.SessionExpiresAt, 0)
-			}
-			winnerTokens = &UpstreamTokens{
-				ProviderID:       stored.ProviderID,
-				AccessToken:      stored.AccessToken,
-				RefreshToken:     stored.RefreshToken,
-				IDToken:          stored.IDToken,
-				ExpiresAt:        expiresAt,
-				SessionExpiresAt: sessionExpiresAt,
-				UserID:           stored.UserID,
-				UpstreamSubject:  stored.UpstreamSubject,
-				ClientID:         stored.ClientID,
-			}
 		}
 	}
 
-	if winnerTokens == nil {
+	if winner == nil {
 		return nil, fmt.Errorf("%w: %w", ErrNotFound, fosite.ErrNotFound.WithHint("Upstream tokens not found"))
 	}
 
-	return winnerTokens, nil
+	return winner.toUpstreamTokens(), nil
 }
 
 // parseUserUpstreamEntry parses one raw Redis value from the user-upstream index
@@ -1259,36 +1260,13 @@ func unmarshalUpstreamTokens(data []byte) (*UpstreamTokens, error) {
 		return nil, fmt.Errorf("failed to unmarshal upstream tokens: %w", err)
 	}
 
-	// Convert stored ExpiresAt back to time.Time.
-	// stored.ExpiresAt == 0 is a sentinel meaning "no expiry" — the write path
-	// stores 0 for zero time. Skip the expiry check in this case since Redis TTL
-	// handles the actual expiration.
-	var expiresAt time.Time
-	var expired bool
-	if stored.ExpiresAt != 0 {
-		expiresAt = time.Unix(stored.ExpiresAt, 0)
-		expired = time.Now().After(expiresAt)
-	}
+	tokens := stored.toUpstreamTokens()
 
-	var sessionExpiresAt time.Time
-	if stored.SessionExpiresAt != 0 {
-		sessionExpiresAt = time.Unix(stored.SessionExpiresAt, 0)
-	}
-
-	tokens := &UpstreamTokens{
-		ProviderID:       stored.ProviderID,
-		AccessToken:      stored.AccessToken,
-		RefreshToken:     stored.RefreshToken,
-		IDToken:          stored.IDToken,
-		ExpiresAt:        expiresAt,
-		SessionExpiresAt: sessionExpiresAt,
-		UserID:           stored.UserID,
-		UpstreamSubject:  stored.UpstreamSubject,
-		ClientID:         stored.ClientID,
-	}
-
-	// Return tokens along with ErrExpired so callers can use the refresh token
-	if expired {
+	// tokens.ExpiresAt is zero when the stored epoch was 0 (the write path stores
+	// 0 for zero time.Time, which toUpstreamTokens leaves as the zero time). Skip
+	// the expiry check in that case since Redis TTL handles the actual expiration.
+	// Return tokens along with ErrExpired so callers can use the refresh token.
+	if !tokens.ExpiresAt.IsZero() && time.Now().After(tokens.ExpiresAt) {
 		return tokens, ErrExpired
 	}
 

--- a/pkg/authserver/storage/redis.go
+++ b/pkg/authserver/storage/redis.go
@@ -1184,10 +1184,11 @@ func (s *RedisStorage) GetLatestUpstreamTokensForUser(ctx context.Context, userI
 			continue
 		}
 
-		// Pick the row with the highest ExpiresAt. Zero ExpiresAt (the no-expiry
-		// sentinel) is represented as 0 — the smallest int64 — so it loses to any
-		// real timestamp unless it is the only candidate.
-		if winner == nil || stored.ExpiresAt > winner.ExpiresAt {
+		// Tie-breaker: prefer non-expiring rows (ExpiresAt == 0, the no-expiry
+		// sentinel for providers like Slack and GitHub OAuth Apps). Among finite
+		// expiries, the latest wins. This aligns with the rest of the package
+		// treating zero ExpiresAt as "alive forever".
+		if winner == nil || compareExpiryInt64(stored.ExpiresAt, winner.ExpiresAt) > 0 {
 			winner = stored
 		}
 	}
@@ -1197,6 +1198,25 @@ func (s *RedisStorage) GetLatestUpstreamTokensForUser(ctx context.Context, userI
 	}
 
 	return winner.toUpstreamTokens(), nil
+}
+
+// compareExpiryInt64 is the int64 (Unix-epoch) variant of compareExpiry. Zero
+// (no-expiry sentinel) ranks latest; among finite epochs, the larger ranks
+// latest. Returns -1/0/+1.
+func compareExpiryInt64(a, b int64) int {
+	switch {
+	case a == 0 && b == 0:
+		return 0
+	case a == 0:
+		return 1
+	case b == 0:
+		return -1
+	case a > b:
+		return 1
+	case a < b:
+		return -1
+	}
+	return 0
 }
 
 // parseUserUpstreamEntry parses one raw Redis value from the user-upstream index

--- a/pkg/authserver/storage/redis.go
+++ b/pkg/authserver/storage/redis.go
@@ -1124,6 +1124,13 @@ func (s *RedisStorage) DeleteUpstreamTokens(ctx context.Context, sessionID strin
 	return nil
 }
 
+// GetLatestUpstreamTokensForUser always returns ErrNotFound in this stub. The full
+// implementation lands in the follow-on step; see the interface declaration in
+// types.go for the contract.
+func (*RedisStorage) GetLatestUpstreamTokensForUser(_ context.Context, _, _ string) (*UpstreamTokens, error) {
+	return nil, fmt.Errorf("%w: %w", ErrNotFound, fosite.ErrNotFound.WithHint("Upstream tokens not found"))
+}
+
 // getUpstreamTokensFromKey retrieves and deserializes upstream tokens from a specific Redis key.
 func (s *RedisStorage) getUpstreamTokensFromKey(ctx context.Context, key string) (*UpstreamTokens, error) {
 	data, err := s.client.Get(ctx, key).Bytes()

--- a/pkg/authserver/storage/redis_test.go
+++ b/pkg/authserver/storage/redis_test.go
@@ -2061,4 +2061,29 @@ func TestRedisStorage_GetLatestUpstreamTokensForUser(t *testing.T) {
 			assert.Equal(t, "rt-real", got.RefreshToken)
 		})
 	})
+
+	t.Run("returns_all_fields_round_trip", func(t *testing.T) {
+		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, _ *miniredis.Miniredis) {
+			// Truncate to second precision: Redis stores time as int64 unix seconds.
+			now := time.Now().Truncate(time.Second)
+			fixture := UpstreamTokens{
+				ProviderID:       "prov-X",
+				AccessToken:      "access-tok",
+				RefreshToken:     "refresh-tok",
+				IDToken:          "id-tok",
+				ExpiresAt:        now.Add(time.Hour),
+				SessionExpiresAt: now.Add(2 * time.Hour),
+				UserID:           "user-A",
+				UpstreamSubject:  "sub-upstream",
+				ClientID:         "client-1",
+			}
+
+			require.NoError(t, s.StoreUpstreamTokens(ctx, "session-rt", "prov-X", &fixture))
+
+			got, err := s.GetLatestUpstreamTokensForUser(ctx, "user-A", "prov-X")
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			require.Equal(t, fixture, *got)
+		})
+	})
 }

--- a/pkg/authserver/storage/redis_test.go
+++ b/pkg/authserver/storage/redis_test.go
@@ -1990,8 +1990,10 @@ func TestRedisStorage_GetLatestUpstreamTokensForUser(t *testing.T) {
 		})
 	})
 
-	t.Run("zero_expires_at_loses_to_nonzero", func(t *testing.T) {
+	t.Run("zero_expires_at_wins_over_nonzero", func(t *testing.T) {
 		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, _ *miniredis.Miniredis) {
+			// Zero ExpiresAt is the no-expiry sentinel for providers like Slack and
+			// GitHub OAuth Apps. Treated as "alive forever" — beats any finite expiry.
 			require.NoError(t, s.StoreUpstreamTokens(ctx, "session-zero", "prov-X", &UpstreamTokens{
 				ProviderID:   "prov-X",
 				UserID:       "user-A",
@@ -2007,7 +2009,7 @@ func TestRedisStorage_GetLatestUpstreamTokensForUser(t *testing.T) {
 
 			got, err := s.GetLatestUpstreamTokensForUser(ctx, "user-A", "prov-X")
 			require.NoError(t, err)
-			assert.Equal(t, "rt-nonzero", got.RefreshToken)
+			assert.Equal(t, "rt-zero", got.RefreshToken)
 		})
 	})
 

--- a/pkg/authserver/storage/redis_test.go
+++ b/pkg/authserver/storage/redis_test.go
@@ -1883,3 +1883,182 @@ func TestRedisStorage_Health_ConnectionFailure(t *testing.T) {
 	err := storage.Health(context.Background())
 	require.Error(t, err)
 }
+
+// --- GetLatestUpstreamTokensForUser Tests ---
+
+func TestRedisStorage_GetLatestUpstreamTokensForUser(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no_match", func(t *testing.T) {
+		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, _ *miniredis.Miniredis) {
+			_, err := s.GetLatestUpstreamTokensForUser(ctx, "user-A", "prov-X")
+			require.Error(t, err)
+			assert.ErrorIs(t, err, ErrNotFound)
+		})
+	})
+
+	t.Run("one_match_returns_record", func(t *testing.T) {
+		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, _ *miniredis.Miniredis) {
+			require.NoError(t, s.StoreUpstreamTokens(ctx, "session-1", "prov-X", &UpstreamTokens{
+				ProviderID:   "prov-X",
+				UserID:       "user-A",
+				RefreshToken: "rt-1",
+				ExpiresAt:    time.Now().Add(time.Hour),
+			}))
+
+			got, err := s.GetLatestUpstreamTokensForUser(ctx, "user-A", "prov-X")
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			assert.Equal(t, "rt-1", got.RefreshToken)
+		})
+	})
+
+	t.Run("multiple_sessions_pick_latest_expires_at", func(t *testing.T) {
+		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, _ *miniredis.Miniredis) {
+			now := time.Now()
+			require.NoError(t, s.StoreUpstreamTokens(ctx, "session-1", "prov-X", &UpstreamTokens{
+				ProviderID:   "prov-X",
+				UserID:       "user-A",
+				RefreshToken: "rt-1h",
+				ExpiresAt:    now.Add(time.Hour),
+			}))
+			require.NoError(t, s.StoreUpstreamTokens(ctx, "session-2", "prov-X", &UpstreamTokens{
+				ProviderID:   "prov-X",
+				UserID:       "user-A",
+				RefreshToken: "rt-2h",
+				ExpiresAt:    now.Add(2 * time.Hour),
+			}))
+			require.NoError(t, s.StoreUpstreamTokens(ctx, "session-3", "prov-X", &UpstreamTokens{
+				ProviderID:   "prov-X",
+				UserID:       "user-A",
+				RefreshToken: "rt-3h",
+				ExpiresAt:    now.Add(3 * time.Hour),
+			}))
+
+			got, err := s.GetLatestUpstreamTokensForUser(ctx, "user-A", "prov-X")
+			require.NoError(t, err)
+			assert.Equal(t, "rt-3h", got.RefreshToken)
+		})
+	})
+
+	t.Run("different_user_not_matched", func(t *testing.T) {
+		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, _ *miniredis.Miniredis) {
+			// This case exits via the empty-SMEMBERS short-circuit (no user-upstream
+			// index for the queried userID), not the per-row ProviderID filter. The
+			// different_provider_not_matched case below exercises the row-level filter.
+			require.NoError(t, s.StoreUpstreamTokens(ctx, "session-1", "prov-X", &UpstreamTokens{
+				ProviderID: "prov-X",
+				UserID:     "user-B",
+				ExpiresAt:  time.Now().Add(time.Hour),
+			}))
+
+			_, err := s.GetLatestUpstreamTokensForUser(ctx, "user-A", "prov-X")
+			require.Error(t, err)
+			assert.ErrorIs(t, err, ErrNotFound)
+		})
+	})
+
+	t.Run("different_provider_not_matched", func(t *testing.T) {
+		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, _ *miniredis.Miniredis) {
+			require.NoError(t, s.StoreUpstreamTokens(ctx, "session-1", "prov-Y", &UpstreamTokens{
+				ProviderID: "prov-Y",
+				UserID:     "user-A",
+				ExpiresAt:  time.Now().Add(time.Hour),
+			}))
+
+			_, err := s.GetLatestUpstreamTokensForUser(ctx, "user-A", "prov-X")
+			require.Error(t, err)
+			assert.ErrorIs(t, err, ErrNotFound)
+		})
+	})
+
+	t.Run("tolerate_access_token_expired", func(t *testing.T) {
+		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, _ *miniredis.Miniredis) {
+			// ExpiresAt is 1 minute in the past. TTL = time.Until(-1min) + DefaultRefreshTokenTTL
+			// which is still large and positive, so Redis keeps the key.
+			require.NoError(t, s.StoreUpstreamTokens(ctx, "session-1", "prov-X", &UpstreamTokens{
+				ProviderID:   "prov-X",
+				UserID:       "user-A",
+				RefreshToken: "rt-expired-at",
+				ExpiresAt:    time.Now().Add(-time.Minute),
+			}))
+
+			got, err := s.GetLatestUpstreamTokensForUser(ctx, "user-A", "prov-X")
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			assert.Equal(t, "rt-expired-at", got.RefreshToken)
+		})
+	})
+
+	t.Run("zero_expires_at_loses_to_nonzero", func(t *testing.T) {
+		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, _ *miniredis.Miniredis) {
+			require.NoError(t, s.StoreUpstreamTokens(ctx, "session-zero", "prov-X", &UpstreamTokens{
+				ProviderID:   "prov-X",
+				UserID:       "user-A",
+				RefreshToken: "rt-zero",
+				ExpiresAt:    time.Time{},
+			}))
+			require.NoError(t, s.StoreUpstreamTokens(ctx, "session-nonzero", "prov-X", &UpstreamTokens{
+				ProviderID:   "prov-X",
+				UserID:       "user-A",
+				RefreshToken: "rt-nonzero",
+				ExpiresAt:    time.Now().Add(time.Hour),
+			}))
+
+			got, err := s.GetLatestUpstreamTokensForUser(ctx, "user-A", "prov-X")
+			require.NoError(t, err)
+			assert.Equal(t, "rt-nonzero", got.RefreshToken)
+		})
+	})
+
+	t.Run("two_zero_expires_at_rows", func(t *testing.T) {
+		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, _ *miniredis.Miniredis) {
+			// Both rows have zero ExpiresAt. The winner is whichever is encountered
+			// first during iteration — iteration order over Redis set members is
+			// non-deterministic, so we assert only that one of them is returned.
+			require.NoError(t, s.StoreUpstreamTokens(ctx, "session-zero-1", "prov-X", &UpstreamTokens{
+				ProviderID:   "prov-X",
+				UserID:       "user-A",
+				RefreshToken: "rt-zero-1",
+				ExpiresAt:    time.Time{},
+			}))
+			require.NoError(t, s.StoreUpstreamTokens(ctx, "session-zero-2", "prov-X", &UpstreamTokens{
+				ProviderID:   "prov-X",
+				UserID:       "user-A",
+				RefreshToken: "rt-zero-2",
+				ExpiresAt:    time.Time{},
+			}))
+
+			got, err := s.GetLatestUpstreamTokensForUser(ctx, "user-A", "prov-X")
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			assert.Contains(t, []string{"rt-zero-1", "rt-zero-2"}, got.RefreshToken)
+		})
+	})
+
+	// stale_index_entry is Redis-specific: a SMEMBER entry pointing at a key that
+	// was never written (simulating a TTL-evicted per-provider key). The real row
+	// must still be returned; the dangling member must not cause an error.
+	t.Run("stale_index_entry", func(t *testing.T) {
+		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, mr *miniredis.Miniredis) {
+			// Store a real row for (user-A, prov-X).
+			require.NoError(t, s.StoreUpstreamTokens(ctx, "session-real", "prov-X", &UpstreamTokens{
+				ProviderID:   "prov-X",
+				UserID:       "user-A",
+				RefreshToken: "rt-real",
+				ExpiresAt:    time.Now().Add(time.Hour),
+			}))
+
+			// Inject a dangling member directly into the user reverse-index set.
+			// The key "test:auth:upstream:phantom-session:prov-X" was never written.
+			setKey := redisSetKey("test:auth:", KeyTypeUserUpstream, "user-A")
+			phantomKey := redisUpstreamKey("test:auth:", "phantom-session", "prov-X")
+			mr.SAdd(setKey, phantomKey)
+
+			got, err := s.GetLatestUpstreamTokensForUser(ctx, "user-A", "prov-X")
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			assert.Equal(t, "rt-real", got.RefreshToken)
+		})
+	})
+}

--- a/pkg/authserver/storage/types.go
+++ b/pkg/authserver/storage/types.go
@@ -268,8 +268,13 @@ type UpstreamTokenStorage interface {
 
 	// GetLatestUpstreamTokensForUser returns the most recently stored upstream tokens
 	// for (userID, providerID) across any session. The "latest" winner is determined
-	// by ExpiresAt descending — both backends use the same tie-breaker so the
-	// carry-forward decision is consistent regardless of deployment shape.
+	// by treating non-expiring rows (zero ExpiresAt — providers like Slack and GitHub
+	// OAuth Apps that genuinely never expire) as the strongest candidate, falling
+	// back to ExpiresAt descending among finite-expiry rows. This aligns with the
+	// rest of the package treating zero ExpiresAt as "alive forever" (see IsExpired,
+	// cleanupExpired, marshalUpstreamTokensWithTTL). Both backends use the same
+	// rule so the carry-forward decision is consistent regardless of deployment
+	// shape.
 	//
 	// This is a secondary lookup that intentionally bypasses the primary
 	// (sessionID, providerName) key. It is used by the OAuth callback to preserve a

--- a/pkg/authserver/storage/types.go
+++ b/pkg/authserver/storage/types.go
@@ -240,8 +240,10 @@ type ClientRegistry interface {
 // middleware that needs to retrieve upstream tokens (e.g., token swap middleware that
 // replaces JWT auth with upstream IDP tokens for backend requests).
 //
-// Tokens are keyed by (sessionID, providerName) to support multiple upstream providers
-// per session. Each provider's tokens are stored and retrieved independently.
+// Tokens are keyed primarily by (sessionID, providerName) to support multiple upstream
+// providers per session. Each provider's tokens are stored and retrieved independently.
+// A secondary lookup by (userID, providerID) is exposed via GetLatestUpstreamTokensForUser;
+// see that method for usage and security contract.
 type UpstreamTokenStorage interface {
 	// StoreUpstreamTokens stores the upstream IDP tokens for a session and provider.
 	// The providerName identifies which upstream provider these tokens belong to.
@@ -263,6 +265,37 @@ type UpstreamTokenStorage interface {
 	// DeleteUpstreamTokens removes all upstream IDP tokens for a session (all providers).
 	// Returns ErrNotFound if the session does not exist.
 	DeleteUpstreamTokens(ctx context.Context, sessionID string) error
+
+	// GetLatestUpstreamTokensForUser returns the most recently stored upstream tokens
+	// for (userID, providerID) across any session. The "latest" winner is determined
+	// by ExpiresAt descending — both backends use the same tie-breaker so the
+	// carry-forward decision is consistent regardless of deployment shape.
+	//
+	// This is a secondary lookup that intentionally bypasses the primary
+	// (sessionID, providerName) key. It is used by the OAuth callback to preserve a
+	// previously-issued refresh token when the upstream IdP omits refresh_token on
+	// re-authorization (e.g. Google without prompt=consent). When a sessionID is
+	// available, callers should use GetUpstreamTokens instead. This method mirrors
+	// the preservation pattern in upstreamTokenRefresher.RefreshAndStore.
+	//
+	// # Liveness
+	//
+	// The returned tokens may be expired. Callers MUST NOT assume liveness; they
+	// must handle the expired case (typically by reading only the RefreshToken,
+	// which remains usable past the access token's expiry). This method does NOT
+	// return ErrExpired and the implementation MUST NOT filter expired rows.
+	//
+	// # Cross-identity safety
+	//
+	// The returned record is NOT filtered by upstream subject. The same internal
+	// UserID can in principle map to multiple upstream subjects on the same provider
+	// (account-linking edge cases or data-integrity issues). Callers MUST verify
+	// that prior.UpstreamSubject == currentProviderSubject before reusing any
+	// credential from the returned record. The OAuth callback applies this guard;
+	// other future callers must do the same.
+	//
+	// Returns ErrNotFound if no record exists for the (userID, providerID) pair.
+	GetLatestUpstreamTokensForUser(ctx context.Context, userID, providerID string) (*UpstreamTokens, error)
 }
 
 // UpstreamTokenRefresher can refresh expired upstream tokens using their stored refresh token.


### PR DESCRIPTION
## Summary

This PR addresses **Root Cause B** of [#5047](https://github.com/stacklok/toolhive/issues/5047): when a user re-authorizes through the auth server, the OAuth callback writes the IdP-supplied `RefreshToken` verbatim into a new `storage.UpstreamTokens` row. Real IdPs commonly **omit** `refresh_token` on a silent re-auth (Google without `prompt=consent`, Microsoft Entra when consent was already granted, GitHub/Okta/Auth0/Keycloak similarly). In every case the previously-issued RT remains valid at the IdP — but today the callback overwrites it with `""`, orphaning the prior good RT and making the next refresh attempt fail. That forces another re-auth, perpetuating the loop.

The fix mirrors the preservation pattern already in place in `upstreamTokenRefresher.RefreshAndStore`: if the IdP returns no RT, look up the most recent prior row for `(userID, providerID)` and carry the prior RT into the new row. A defensive `prior.UpstreamSubject == providerSubject` guard prevents carrying credentials across distinct upstream identities. Storage failures during the lookup are non-fatal — they log a warning and proceed with the empty RT, which is no worse than the current status quo.

- New storage method `UpstreamTokenStorage.GetLatestUpstreamTokensForUser(ctx, userID, providerID)` keyed on user+provider rather than the primary `(sessionID, providerName)` key. Implemented on both Memory and Redis backends; both backends pick the highest `ExpiresAt` so the carry-forward decision is consistent across deployment shapes. Expired rows are intentionally returned (callers want the RT regardless of access-token expiry).
- Callback wiring in `pkg/authserver/server/handlers/callback.go` extracted into `maybeCarryForwardRefreshToken` (gocyclo budget) and called between `storageTokens` construction and `StoreUpstreamTokens`.
- The Redis backend uses the existing `KeyTypeUserUpstream:{userID}` reverse-index set (already maintained atomically by `storeUpstreamTokensScript`), no new Lua script.
- End-to-end integration test against `mockoidc` + a thin RT-stripping reverse proxy (mockoidc unconditionally issues RTs for `authorization_code` and offers no API to suppress them).

**Out of scope, deferred to a follow-up PR**: Root Cause A — the storage rekey from `(sessionID, providerID)` to `(userID, providerID)` plus a one-time Redis migration. Trey's [comment on #5047](https://github.com/stacklok/toolhive/issues/5047#issuecomment-4336470125) describes the split; this PR is the smaller, surgical fix and is valuable on its own because it ends the orphaning loop even before Root Cause A lands.

Closes #5047 partially (Root Cause B; Root Cause A tracked separately).

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [x] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [x] Linting (`task lint-fix`)
- [ ] Manual testing (describe below)

Specifically verified:
- `go test -race -count=1 ./pkg/authserver/...` — all 13 packages pass.
- `go test -race -count=1 -v -run TestIntegration_ ./pkg/authserver/` — all 23 integration tests pass, including the new `TestIntegration_Callback_PreservesRefreshTokenOnReauth` and the existing `TestIntegration_FullFlow_NonExpiringUpstreamToken[_Redis]` and `TestIntegration_MultiUpstreamChain_MixedExpiryOrderings[_Redis]` from #5092.
- `task test` — pre-existing failure in `pkg/workloads/TestDefaultManager_ListWorkloadsInGroup/workloads_with_empty_group_names` is unrelated to this branch.

## API Compatibility

- [x] This PR does not break the `v1beta1` API, OR the `api-break-allowed` label is applied and the migration guidance is described above.

The new method on `storage.UpstreamTokenStorage` is an internal Go interface, not a CRD field. No CRD schema changes.

## Changes

| File | Change |
|------|--------|
| `pkg/authserver/storage/types.go` | Adds `GetLatestUpstreamTokensForUser` to the `UpstreamTokenStorage` interface with explicit godoc on liveness contract (expired rows are returned) and cross-identity caller responsibility. |
| `pkg/authserver/storage/memory.go` | Implements the new method on `MemoryStorage` — RLock'd iteration, deep-copy on hit, wrapped `ErrNotFound` on miss. |
| `pkg/authserver/storage/redis.go` | Implements the new method on `RedisStorage` using `SMembers` over the existing user-upstream reverse index, single `MGet`, deserialized-`ProviderID` filtering. Tolerates dangling SMEMBERs and the `null` deletion tombstone. |
| `pkg/authserver/storage/mocks/mock_storage.go` | Regenerated. |
| `pkg/authserver/server/handlers/callback.go` | New `maybeCarryForwardRefreshToken` helper invoked between struct construction and `StoreUpstreamTokens`. `UpstreamSubject` guard, non-fatal on storage error. |
| `pkg/authserver/storage/memory_test.go` | Table-driven test for the Memory backend (9 subtests including deep-copy assertion, latest-by-`ExpiresAt`, empty-input validation). |
| `pkg/authserver/storage/redis_test.go` | Table-driven test for the Redis backend (9 subtests including the dangling-SMEMBER stale-index case via miniredis `SAdd`, two-zero-`ExpiresAt` corner case). |
| `pkg/authserver/server/handlers/callback_test.go` | Table-driven `TestCallbackHandler_RefreshTokenCarryForward` consolidating the 5 callback scenarios (preserve, subject mismatch, fresh wins, no prior row, storage error). |
| `pkg/authserver/server/handlers/helpers_test.go` | New `withGetLatestUpstreamTokensError` option mirroring the existing `withStorePendingError` pattern; mock checks it first. |
| `pkg/authserver/integration_test.go` | `TestIntegration_Callback_PreservesRefreshTokenOnReauth` — full callback flow against mockoidc with an RT-stripping reverse proxy. |

## Does this introduce a user-facing change?

Yes. Users who previously hit a refresh-token-orphaning loop on re-authorization (most commonly with Google, Entra, Okta, GitHub, Auth0, Keycloak — all of which omit `refresh_token` on silent re-auth) will see refreshes succeed instead of failing into another forced re-auth. The fix is silent: no configuration changes are required.

## Implementation plan

This PR was planned with Claude Code via a per-step `go-expert-developer` + MoE (`code-reviewer` + `go-security-reviewer` / `oauth-expert` / `redis-valkey-advisor`) workflow. Each step landed as a separate commit with independent review.

<details>
<summary>Approved plan (5 steps)</summary>

1. **Add `GetLatestUpstreamTokensForUser` to storage interface + stub implementations + mock regen.** Keeps the diff tiny so the interface surface is reviewed independently.
2. **Implement Memory backend + 9-case table-driven test.** Filters by `(UserID, ProviderID)`, picks highest `ExpiresAt`, returns deep copy.
3. **Implement Redis backend + 9-case table-driven test.** Uses the existing `KeyTypeUserUpstream` reverse set; SMembers → MGet → unmarshal → filter; tolerates stale index entries and `null` tombstones.
4. **Wire the OAuth callback handler + 5-case table-driven test.** Helper `maybeCarryForwardRefreshToken` between `storageTokens` construction and `StoreUpstreamTokens`. Non-fatal on storage error. `UpstreamSubject` guard.
5. **End-to-end integration test against mockoidc + RT-stripping reverse proxy.** Three legs: initial RT issued → strip flag on, second auth carries forward → third auth as different user gets `ErrNotFound` and stays empty.

Cross-project research (via MCP-mounted source): Hydra delegates upstream-token storage to its consent app and avoids the bug class. oauth2-proxy has the same blind-overwrite shape but sidesteps it via opaque-ticket session keys (orphaned rows TTL out instead of being clobbered) — their `IDToken` preservation pattern at `pkg/providers/oidc.go:140-180` is the explicit code-level analog we mirror for `RefreshToken`. infratographer/identity-api is RFC-8693 only, no broker.

</details>

## Special notes for reviewers

- **This is Root Cause B only.** Root Cause A — the full storage rekey from `(sessionID, providerID)` to `(userID, providerID)` with a one-time Redis migration — is intentionally deferred to a follow-up PR. See Trey's plan in #5047. This fix is valuable on its own: even with Root Cause A unresolved, carrying the RT forward to the new sessionID lets the refresher succeed when the new access token expires, ending the re-auth cycle.
- The `UpstreamSubject == providerSubject` guard is **defense-in-depth**. Given the current identity model (`ResolveUser` keys identity by `(providerID, providerSubject)`), the same internal `UserID` cannot legitimately have two different upstream subjects on the same provider — same-provider account-linking is a future TODO in `storage/types.go`. The guard exists so that future code can't accidentally violate that.
- The integration test does **not** request `offline_access` because mockoidc's `ScopesSupported` rejects it as `invalid_scope`. mockoidc unconditionally issues RTs regardless of scope, so the regression assertion (leg 2 RT matches leg 1 RT) is unaffected — but reviewers should know the test does not exercise the realistic precondition that real IdPs gate RT issuance on `offline_access`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Large PR Justification

- the new integration test is the culprit