### PR TITLE
Add file, URL, and embedded registry sources

### DIFF
--- a/pkg/registry/embedded_registry.go
+++ b/pkg/registry/embedded_registry.go
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package registry
+
+import (
+	"fmt"
+
+	catalog "github.com/stacklok/toolhive-catalog/pkg/catalog/toolhive"
+)
+
+// EmbeddedRegistryName is the canonical name for the registry backed by the
+// asset baked into the binary. It is what `thv registry list` displays for
+// the default-shipped entry.
+const EmbeddedRegistryName = "embedded"
+
+// NewEmbeddedRegistry constructs a Registry from the registry data baked
+// into the binary at build time. Used as the default registry in fresh
+// installs.
+//
+// The optional name override lets callers override the default
+// EmbeddedRegistryName — useful only for tests; production uses the
+// constant.
+func NewEmbeddedRegistry(name string) (Registry, error) {
+	if name == "" {
+		name = EmbeddedRegistryName
+	}
+	entries, err := parseEntries(catalog.Upstream())
+	if err != nil {
+		return nil, fmt.Errorf("embedded registry %q: %w", name, err)
+	}
+	return NewStore(name, entries)
+}

--- a/pkg/registry/embedded_registry_test.go
+++ b/pkg/registry/embedded_registry_test.go
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package registry
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewEmbeddedRegistry(t *testing.T) {
+	t.Parallel()
+
+	t.Run("loads with default name", func(t *testing.T) {
+		t.Parallel()
+		r, err := NewEmbeddedRegistry("")
+		require.NoError(t, err)
+		assert.Equal(t, EmbeddedRegistryName, r.Name())
+
+		// Embedded asset must contain at least one entry — sanity check that
+		// the build-time bundle is wired up correctly.
+		entries, err := r.List(Filter{})
+		require.NoError(t, err)
+		assert.NotEmpty(t, entries, "embedded registry should ship with entries")
+	})
+
+	t.Run("accepts name override", func(t *testing.T) {
+		t.Parallel()
+		r, err := NewEmbeddedRegistry("custom")
+		require.NoError(t, err)
+		assert.Equal(t, "custom", r.Name())
+	})
+}

--- a/pkg/registry/file_registry.go
+++ b/pkg/registry/file_registry.go
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package registry
+
+import (
+	"fmt"
+	"os"
+)
+
+// NewFileRegistry constructs a Registry backed by an upstream-format JSON
+// file on disk. The file is read once at construction; subsequent file
+// changes require restart (config-mutability is restart-only in v1).
+//
+// name is the registry identifier reported by Registry.Name(). It must be
+// non-empty.
+func NewFileRegistry(name, path string) (Registry, error) {
+	if path == "" {
+		return nil, fmt.Errorf("file registry %q: path must not be empty", name)
+	}
+	// #nosec G304 -- the path is supplied by the user via configuration; reading
+	// arbitrary local files is the entire purpose of a file-source registry.
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("file registry %q: read %s: %w", name, path, err)
+	}
+	entries, err := parseEntries(data)
+	if err != nil {
+		return nil, fmt.Errorf("file registry %q: %w", name, err)
+	}
+	return NewStore(name, entries)
+}

--- a/pkg/registry/file_registry_test.go
+++ b/pkg/registry/file_registry_test.go
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package registry
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func writeFixtureFile(t *testing.T, contents string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "registry.json")
+	require.NoError(t, os.WriteFile(path, []byte(contents), 0o600))
+	return path
+}
+
+func TestNewFileRegistry(t *testing.T) {
+	t.Parallel()
+
+	t.Run("loads upstream-format file", func(t *testing.T) {
+		t.Parallel()
+		path := writeFixtureFile(t, upstreamWithServersAndSkills)
+
+		r, err := NewFileRegistry("local", path)
+		require.NoError(t, err)
+		assert.Equal(t, "local", r.Name())
+
+		entries, err := r.List(Filter{})
+		require.NoError(t, err)
+		assert.Len(t, entries, 4)
+	})
+
+	t.Run("rejects empty path", func(t *testing.T) {
+		t.Parallel()
+		_, err := NewFileRegistry("local", "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "path must not be empty")
+	})
+
+	t.Run("rejects missing file", func(t *testing.T) {
+		t.Parallel()
+		_, err := NewFileRegistry("local", filepath.Join(t.TempDir(), "missing.json"))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "read")
+	})
+
+	t.Run("rejects invalid JSON", func(t *testing.T) {
+		t.Parallel()
+		path := writeFixtureFile(t, "not json")
+		_, err := NewFileRegistry("local", path)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "parse upstream registry")
+	})
+
+	t.Run("returns ErrLegacyFormat for legacy input", func(t *testing.T) {
+		t.Parallel()
+		path := writeFixtureFile(t, legacyFormat)
+		_, err := NewFileRegistry("local", path)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrLegacyFormat))
+	})
+}

--- a/pkg/registry/parse.go
+++ b/pkg/registry/parse.go
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package registry
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	types "github.com/stacklok/toolhive-core/registry/types"
+	"github.com/stacklok/toolhive/pkg/registry/legacyhint"
+)
+
+// ErrLegacyFormat is returned when input matches the legacy ToolHive registry
+// format instead of the upstream MCP registry format. The error wording
+// carries the migration guidance (run `thv registry convert`) so callers can
+// surface it directly.
+//
+// We detect the legacy format up front because Go's json.Unmarshal silently
+// produces an empty UpstreamRegistry for legacy input — the legacy
+// top-level "servers" field does not match upstream's "data.servers" path,
+// so the decoder sees no error and the caller gets a registry with no
+// entries.
+var ErrLegacyFormat = errors.New(legacyhint.MigrationMessage)
+
+// parseEntries decodes raw JSON in the upstream MCP registry format
+// (types.UpstreamRegistry) into a slice of Entry values.
+//
+// Entry validation (kind/payload consistency, non-empty name) is the
+// caller's responsibility — typically performed by NewStore.
+//
+// Returns ErrLegacyFormat when the input matches the legacy ToolHive
+// registry format.
+func parseEntries(data []byte) ([]*Entry, error) {
+	if !legacyhint.IsUpstream(data) && legacyhint.Looks(data) {
+		return nil, ErrLegacyFormat
+	}
+
+	var upstream types.UpstreamRegistry
+	if err := json.Unmarshal(data, &upstream); err != nil {
+		return nil, fmt.Errorf("parse upstream registry: %w", err)
+	}
+
+	out := make([]*Entry, 0, len(upstream.Data.Servers)+len(upstream.Data.Skills))
+
+	for i := range upstream.Data.Servers {
+		server := &upstream.Data.Servers[i]
+		out = append(out, &Entry{
+			Kind:   KindServer,
+			Name:   server.Name,
+			Server: server,
+		})
+	}
+
+	for i := range upstream.Data.Skills {
+		skill := &upstream.Data.Skills[i]
+		out = append(out, &Entry{
+			Kind:  KindSkill,
+			Name:  skillEntryName(skill),
+			Skill: skill,
+		})
+	}
+
+	return out, nil
+}
+
+// skillEntryName produces the registry-unique identifier for a skill by
+// combining namespace and name. The resulting form (e.g.
+// "io.github.user/summarizer") mirrors how upstream ServerJSON names are
+// reverse-DNS-qualified, so a single Get(name) lookup works uniformly
+// across kinds.
+func skillEntryName(s *types.Skill) string {
+	if s.Namespace == "" {
+		return s.Name
+	}
+	return s.Namespace + "/" + s.Name
+}

--- a/pkg/registry/parse_test.go
+++ b/pkg/registry/parse_test.go
@@ -1,0 +1,124 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package registry
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const upstreamWithServersAndSkills = `{
+  "$schema": "https://example.com/schema.json",
+  "version": "1.0.0",
+  "meta": { "last_updated": "2026-01-01T00:00:00Z" },
+  "data": {
+    "servers": [
+      {
+        "$schema": "https://example.com/server.json",
+        "name": "io.github.user/weather",
+        "description": "Weather forecasts",
+        "version": "1.0.0"
+      },
+      {
+        "$schema": "https://example.com/server.json",
+        "name": "io.github.user/postgres",
+        "description": "PostgreSQL database access",
+        "version": "0.5.1"
+      }
+    ],
+    "skills": [
+      {
+        "namespace": "io.github.user",
+        "name": "summarize",
+        "description": "Condense long text",
+        "version": "1.0.0"
+      },
+      {
+        "name": "no-namespace",
+        "description": "No namespace specified",
+        "version": "0.1.0"
+      }
+    ]
+  }
+}`
+
+const upstreamEmpty = `{
+  "$schema": "https://example.com/schema.json",
+  "version": "1.0.0",
+  "meta": { "last_updated": "2026-01-01T00:00:00Z" },
+  "data": { "servers": [] }
+}`
+
+const legacyFormat = `{
+  "version": "1.0.0",
+  "servers": {
+    "weather": { "image": "weather:latest", "description": "weather" }
+  }
+}`
+
+func TestParseEntries(t *testing.T) {
+	t.Parallel()
+
+	t.Run("decodes servers and skills", func(t *testing.T) {
+		t.Parallel()
+		entries, err := parseEntries([]byte(upstreamWithServersAndSkills))
+		require.NoError(t, err)
+		require.Len(t, entries, 4)
+
+		// Servers come first, in document order.
+		assert.Equal(t, KindServer, entries[0].Kind)
+		assert.Equal(t, "io.github.user/weather", entries[0].Name)
+		require.NotNil(t, entries[0].Server)
+		assert.Equal(t, "Weather forecasts", entries[0].Server.Description)
+		assert.Nil(t, entries[0].Skill)
+
+		assert.Equal(t, KindServer, entries[1].Kind)
+		assert.Equal(t, "io.github.user/postgres", entries[1].Name)
+
+		// Skills follow.
+		assert.Equal(t, KindSkill, entries[2].Kind)
+		assert.Equal(t, "io.github.user/summarize", entries[2].Name)
+		require.NotNil(t, entries[2].Skill)
+		assert.Equal(t, "io.github.user", entries[2].Skill.Namespace)
+		assert.Nil(t, entries[2].Server)
+
+		// Skill without namespace uses the bare name.
+		assert.Equal(t, KindSkill, entries[3].Kind)
+		assert.Equal(t, "no-namespace", entries[3].Name)
+	})
+
+	t.Run("decodes empty data", func(t *testing.T) {
+		t.Parallel()
+		entries, err := parseEntries([]byte(upstreamEmpty))
+		require.NoError(t, err)
+		assert.Empty(t, entries)
+	})
+
+	t.Run("rejects invalid JSON", func(t *testing.T) {
+		t.Parallel()
+		_, err := parseEntries([]byte("not json"))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "parse upstream registry")
+	})
+
+	t.Run("returns ErrLegacyFormat for legacy input", func(t *testing.T) {
+		t.Parallel()
+		_, err := parseEntries([]byte(legacyFormat))
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrLegacyFormat),
+			"want ErrLegacyFormat, got %v", err)
+	})
+
+	t.Run("output entries are valid", func(t *testing.T) {
+		t.Parallel()
+		entries, err := parseEntries([]byte(upstreamWithServersAndSkills))
+		require.NoError(t, err)
+		for i, e := range entries {
+			assert.NoError(t, e.Validate(), "entries[%d] failed validation", i)
+		}
+	})
+}

--- a/pkg/registry/url_registry.go
+++ b/pkg/registry/url_registry.go
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package registry
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// defaultURLFetchSizeLimit caps the body URL registries will read from a
+// remote endpoint. 32 MiB comfortably fits real-world registries while
+// preventing a malicious or misconfigured server from exhausting memory.
+const defaultURLFetchSizeLimit = 32 * 1024 * 1024
+
+// NewURLRegistry constructs a Registry by fetching an upstream-format JSON
+// document from url. The body is read once at construction; subsequent
+// remote changes require restart.
+//
+// httpClient may be nil, in which case http.DefaultClient is used. The
+// caller is responsible for setting timeouts via ctx or a custom client.
+func NewURLRegistry(ctx context.Context, name, url string, httpClient *http.Client) (Registry, error) {
+	if url == "" {
+		return nil, fmt.Errorf("url registry %q: url must not be empty", name)
+	}
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("url registry %q: build request: %w", name, err)
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, &UnavailableError{URL: url, Err: err}
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		// Drain so the connection can be reused.
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return nil, &UnavailableError{
+			URL: url,
+			Err: fmt.Errorf("unexpected status %d", resp.StatusCode),
+		}
+	}
+
+	data, err := io.ReadAll(io.LimitReader(resp.Body, defaultURLFetchSizeLimit+1))
+	if err != nil {
+		return nil, &UnavailableError{URL: url, Err: fmt.Errorf("read body: %w", err)}
+	}
+	if len(data) > defaultURLFetchSizeLimit {
+		return nil, fmt.Errorf("url registry %q: response exceeds %d-byte size limit", name, defaultURLFetchSizeLimit)
+	}
+
+	entries, err := parseEntries(data)
+	if err != nil {
+		return nil, fmt.Errorf("url registry %q: %w", name, err)
+	}
+	return NewStore(name, entries)
+}

--- a/pkg/registry/url_registry_test.go
+++ b/pkg/registry/url_registry_test.go
@@ -1,0 +1,124 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package registry
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewURLRegistry(t *testing.T) {
+	t.Parallel()
+
+	t.Run("loads upstream-format response", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, upstreamWithServersAndSkills)
+		}))
+		t.Cleanup(srv.Close)
+
+		r, err := NewURLRegistry(context.Background(), "remote", srv.URL, srv.Client())
+		require.NoError(t, err)
+		assert.Equal(t, "remote", r.Name())
+
+		entries, err := r.List(Filter{})
+		require.NoError(t, err)
+		assert.Len(t, entries, 4)
+	})
+
+	t.Run("rejects empty url", func(t *testing.T) {
+		t.Parallel()
+		_, err := NewURLRegistry(context.Background(), "remote", "", nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "url must not be empty")
+	})
+
+	t.Run("returns UnavailableError on non-200", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusServiceUnavailable)
+		}))
+		t.Cleanup(srv.Close)
+
+		_, err := NewURLRegistry(context.Background(), "remote", srv.URL, srv.Client())
+		require.Error(t, err)
+		var ue *UnavailableError
+		require.True(t, errors.As(err, &ue), "want UnavailableError, got %v", err)
+		assert.Equal(t, srv.URL, ue.URL)
+	})
+
+	t.Run("returns UnavailableError on connection error", func(t *testing.T) {
+		t.Parallel()
+		// Server that closes connections immediately.
+		srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}))
+		srv.Close() // start, then close, so URL is unreachable
+
+		_, err := NewURLRegistry(context.Background(), "remote", srv.URL, srv.Client())
+		require.Error(t, err)
+		var ue *UnavailableError
+		assert.True(t, errors.As(err, &ue))
+	})
+
+	t.Run("rejects oversized response", func(t *testing.T) {
+		t.Parallel()
+		// Build a response just over the size limit. Has to be valid JSON
+		// up to size limit so the size check, not the parser, fires.
+		big := strings.Repeat("x", defaultURLFetchSizeLimit+10)
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			fmt.Fprint(w, big)
+		}))
+		t.Cleanup(srv.Close)
+
+		_, err := NewURLRegistry(context.Background(), "remote", srv.URL, srv.Client())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "size limit")
+	})
+
+	t.Run("uses default client when nil passed", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			fmt.Fprint(w, upstreamEmpty)
+		}))
+		t.Cleanup(srv.Close)
+
+		r, err := NewURLRegistry(context.Background(), "remote", srv.URL, nil)
+		require.NoError(t, err)
+		assert.Equal(t, "remote", r.Name())
+	})
+
+	t.Run("returns ErrLegacyFormat for legacy input", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			fmt.Fprint(w, legacyFormat)
+		}))
+		t.Cleanup(srv.Close)
+
+		_, err := NewURLRegistry(context.Background(), "remote", srv.URL, srv.Client())
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrLegacyFormat))
+	})
+
+	t.Run("respects context cancellation", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			fmt.Fprint(w, upstreamEmpty)
+		}))
+		t.Cleanup(srv.Close)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // already cancelled
+
+		_, err := NewURLRegistry(ctx, "remote", srv.URL, srv.Client())
+		require.Error(t, err)
+	})
+}


### PR DESCRIPTION
## Summary

Why: PR 1 introduces the `Registry` interface and `Store` but no implementations. This PR adds the bulk-load sources — file, URL, and embedded — that the manager in PR 3 will own. These are the simple cases: load once at construction, serve from memory. The API source (proxy semantics, per-registry expansion) is split off into a follow-up PR for a focused review.

What:

- `parse.go` — shared parser. Decodes `toolhivetypes.UpstreamRegistry` JSON into `[]*Entry`. Detects the legacy ToolHive format up front via `legacyhint` and returns `ErrLegacyFormat` carrying the migration message — Go's JSON decoder silently produces an empty registry from legacy input, so we have to short-circuit.
- `file_registry.go` — `NewFileRegistry(name, path)` reads the file and hands bytes to the parser.
- `url_registry.go` — `NewURLRegistry(ctx, name, url, client)` does an HTTP GET, caps the body at 32 MiB, parses. Network errors map to `UnavailableError` so handlers can translate to 503.
- `embedded_registry.go` — `NewEmbeddedRegistry(name)` reads the bytes baked into the binary via `toolhive-catalog`.

Each loads at construction; runtime config changes still require restart in v1 (matches the broader simplification).

Stacked on PR #5133 — base set accordingly.

Part of #4199.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [x] Unit tests (\`task test\`)
- [x] Linting (\`task lint-fix\`)

## Does this introduce a user-facing change?

No.

## Special notes for reviewers

- Bulk-load (read-once-at-construction) is a deliberate departure from today's \`LocalRegistryProvider\` (which re-reads on every \`GetRegistry\` call). With multi-active fan-out, repeating disk I/O per query is wasteful, and config-mutability is restart-only in v1.
- API source (\`api_registry.go\`) is the obvious missing piece. It's in its own follow-up PR because it has different semantics (proxy, expansion to N peer registries via \`GET /v1/registries\`) and should not be reviewed in the same diff as bulk-load.
- The 32 MiB body cap in url_registry.go is a defensive default. Adjustable in future via an option if anyone hits it.
- The \`#nosec G304\` annotation on \`os.ReadFile(path)\` is intentional — reading a user-supplied path is the entire purpose of a file source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)