### PR TITLE
Consolidate ToolApplyConfig and LLMApplyConfig into pkg/llmgateway

### DIFF
--- a/cmd/thv/app/llm.go
+++ b/cmd/thv/app/llm.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stacklok/toolhive/pkg/config"
 	"github.com/stacklok/toolhive/pkg/llm"
 	llmproxy "github.com/stacklok/toolhive/pkg/llm/proxy"
+	"github.com/stacklok/toolhive/pkg/llmgateway"
 	pkgsecrets "github.com/stacklok/toolhive/pkg/secrets"
 )
 
@@ -348,13 +349,8 @@ func (a *clientManagerAdapter) DetectedLLMGatewayClients() []string {
 	return result
 }
 
-func (a *clientManagerAdapter) ConfigureLLMGateway(clientType string, cfg llm.ToolApplyConfig) (string, error) {
-	return a.cm.ConfigureLLMGateway(client.ClientApp(clientType), client.LLMApplyConfig{
-		GatewayURL:         cfg.GatewayURL,
-		ProxyBaseURL:       cfg.ProxyBaseURL,
-		TokenHelperCommand: cfg.TokenHelperCommand,
-		TLSSkipVerify:      cfg.TLSSkipVerify,
-	})
+func (a *clientManagerAdapter) ConfigureLLMGateway(clientType string, cfg llmgateway.ApplyConfig) (string, error) {
+	return a.cm.ConfigureLLMGateway(client.ClientApp(clientType), cfg)
 }
 
 func (a *clientManagerAdapter) LLMGatewayModeFor(clientType string) string {

--- a/pkg/client/llm_gateway.go
+++ b/pkg/client/llm_gateway.go
@@ -13,6 +13,7 @@ import (
 	"github.com/tailscale/hujson"
 
 	"github.com/stacklok/toolhive/pkg/fileutils"
+	"github.com/stacklok/toolhive/pkg/llmgateway"
 )
 
 // llmPlaceholderAPIKey is the static API key written into proxy-mode tool
@@ -27,21 +28,13 @@ type llmPatchOp struct {
 	Value json.RawMessage `json:"value,omitempty"`
 }
 
-// LLMApplyConfig holds the values needed to configure an LLM gateway for a tool.
-type LLMApplyConfig struct {
-	GatewayURL         string // direct-mode: URL of the upstream LLM gateway
-	ProxyBaseURL       string // proxy-mode: URL of the localhost reverse proxy
-	TokenHelperCommand string // direct-mode: command that prints a fresh access token
-	TLSSkipVerify      bool   // when true, instruct the tool to skip TLS verification
-}
-
 // ConfigureLLMGateway patches the tool's LLM-gateway settings file with cfg
 // and returns the absolute path of the patched file.
 //
 // It uses fileutils.WithFileLock so concurrent calls (e.g. two "thv llm setup"
 // invocations) are serialised. Comments and trailing commas in JSONC settings
 // files are preserved via hujson. Writes are crash-safe via AtomicWriteFile.
-func (cm *ClientManager) ConfigureLLMGateway(clientType ClientApp, cfg LLMApplyConfig) (string, error) {
+func (cm *ClientManager) ConfigureLLMGateway(clientType ClientApp, cfg llmgateway.ApplyConfig) (string, error) {
 	appCfg := cm.lookupClientAppConfig(clientType)
 	if appCfg == nil || appCfg.LLMGatewayMode == "" {
 		return "", fmt.Errorf("client %q does not support LLM gateway configuration", clientType)
@@ -86,7 +79,7 @@ func (cm *ClientManager) ConfigureLLMGateway(clientType ClientApp, cfg LLMApplyC
 // Specs with ClearWhenEmpty=true are removed when their resolved value is empty,
 // allowing conditional keys (e.g. NODE_TLS_REJECT_UNAUTHORIZED) to be cleaned
 // up when the associated flag is cleared.
-func applyLLMGatewayKeys(v *hujson.Value, specs []LLMGatewayKeySpec, cfg LLMApplyConfig, filePath string) error {
+func applyLLMGatewayKeys(v *hujson.Value, specs []LLMGatewayKeySpec, cfg llmgateway.ApplyConfig, filePath string) error {
 	// Ensure ancestors only for specs that will be written (not removed).
 	for _, spec := range specs {
 		if spec.ClearWhenEmpty && llmValueForSpec(spec.ValueField, cfg) == "" {
@@ -268,7 +261,7 @@ func (cm *ClientManager) buildLLMSettingsPath(cfg *clientAppConfig) string {
 // llmValueForSpec returns the config value corresponding to the ValueField name.
 // For "NodeTLSRejectUnauthorized", returns "0" when TLSSkipVerify is true, or ""
 // when false (which triggers removal when ClearWhenEmpty is set on the spec).
-func llmValueForSpec(valueField string, cfg LLMApplyConfig) string {
+func llmValueForSpec(valueField string, cfg llmgateway.ApplyConfig) string {
 	switch valueField {
 	case "GatewayURL":
 		return cfg.GatewayURL

--- a/pkg/client/llm_gateway_test.go
+++ b/pkg/client/llm_gateway_test.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/stacklok/toolhive/pkg/llmgateway"
 )
 
 // fakeLLMBinary is the sentinel binary name used in tests that exercise the
@@ -32,7 +34,7 @@ func TestRealClientConfigs_ConfigureAndRevert(t *testing.T) {
 	// Use real supportedClientIntegrations so we exercise the actual paths and keys.
 	cm := NewTestClientManager(home, nil, supportedClientIntegrations, nil)
 
-	applyCfg := LLMApplyConfig{
+	applyCfg := llmgateway.ApplyConfig{
 		GatewayURL:         "https://gw.example.com",
 		ProxyBaseURL:       "http://localhost:14000/v1",
 		TokenHelperCommand: `"thv" llm token`,
@@ -162,7 +164,7 @@ func TestConfigureLLMGateway_DeepNestedKey(t *testing.T) {
 	claudeDir := filepath.Join(home, ".claude")
 	require.NoError(t, os.MkdirAll(claudeDir, 0o700))
 
-	path, err := cm.ConfigureLLMGateway(ClaudeCode, LLMApplyConfig{
+	path, err := cm.ConfigureLLMGateway(ClaudeCode, llmgateway.ApplyConfig{
 		GatewayURL: "https://gw.example.com",
 	})
 	require.NoError(t, err)
@@ -223,7 +225,7 @@ func TestConfigureLLMGateway_CreatesFile(t *testing.T) {
 	claudeDir := filepath.Join(home, ".claude")
 	require.NoError(t, os.MkdirAll(claudeDir, 0o700))
 
-	path, err := cm.ConfigureLLMGateway(ClaudeCode, LLMApplyConfig{
+	path, err := cm.ConfigureLLMGateway(ClaudeCode, llmgateway.ApplyConfig{
 		TokenHelperCommand: `"thv" llm token`,
 	})
 	require.NoError(t, err)
@@ -247,7 +249,7 @@ func TestConfigureLLMGateway_PreservesExistingKeys(t *testing.T) {
 	settingsPath := filepath.Join(claudeDir, "settings.json")
 	require.NoError(t, os.WriteFile(settingsPath, []byte(`{"permissions":{"allow":["read"]}}`), 0o600))
 
-	_, err := cm.ConfigureLLMGateway(ClaudeCode, LLMApplyConfig{
+	_, err := cm.ConfigureLLMGateway(ClaudeCode, llmgateway.ApplyConfig{
 		TokenHelperCommand: `"thv" llm token`,
 	})
 	require.NoError(t, err)
@@ -275,7 +277,7 @@ func TestConfigureLLMGateway_JSONCPreservesExistingParent(t *testing.T) {
   "env": { "EXISTING_KEY": "keep-me" },
 }`), 0o600))
 
-	_, err := cm.ConfigureLLMGateway(ClaudeCode, LLMApplyConfig{
+	_, err := cm.ConfigureLLMGateway(ClaudeCode, llmgateway.ApplyConfig{
 		GatewayURL: "https://gw.example.com",
 	})
 	require.NoError(t, err)
@@ -297,7 +299,7 @@ func TestConfigureLLMGateway_UnsupportedClient(t *testing.T) {
 	home := t.TempDir()
 	cm := NewTestClientManager(home, nil, nil, nil)
 
-	_, err := cm.ConfigureLLMGateway(ClaudeCode, LLMApplyConfig{})
+	_, err := cm.ConfigureLLMGateway(ClaudeCode, llmgateway.ApplyConfig{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "does not support LLM gateway")
 }
@@ -309,7 +311,7 @@ func TestConfigureLLMGateway_Idempotent(t *testing.T) {
 	claudeDir := filepath.Join(home, ".claude")
 	require.NoError(t, os.MkdirAll(claudeDir, 0o700))
 
-	cfg := LLMApplyConfig{TokenHelperCommand: `"thv" llm token`}
+	cfg := llmgateway.ApplyConfig{TokenHelperCommand: `"thv" llm token`}
 	_, err := cm.ConfigureLLMGateway(ClaudeCode, cfg)
 	require.NoError(t, err)
 	_, err = cm.ConfigureLLMGateway(ClaudeCode, cfg)
@@ -391,7 +393,7 @@ func TestConfigureLLMGateway_ProxyMode(t *testing.T) {
 	dir := filepath.Join(home, ".cursor-test")
 	require.NoError(t, os.MkdirAll(dir, 0o700))
 
-	path, err := cm.ConfigureLLMGateway(Cursor, LLMApplyConfig{
+	path, err := cm.ConfigureLLMGateway(Cursor, llmgateway.ApplyConfig{
 		ProxyBaseURL: "http://localhost:14000/v1",
 	})
 	require.NoError(t, err)
@@ -561,7 +563,7 @@ func TestConfigureLLMGateway_TLSSkipVerify_WritesNodeEnv(t *testing.T) {
 	claudeDir := filepath.Join(home, ".claude")
 	require.NoError(t, os.MkdirAll(claudeDir, 0o700))
 
-	_, err := cm.ConfigureLLMGateway(ClaudeCode, LLMApplyConfig{
+	_, err := cm.ConfigureLLMGateway(ClaudeCode, llmgateway.ApplyConfig{
 		TokenHelperCommand: `"thv" llm token`,
 		TLSSkipVerify:      true,
 	})
@@ -580,7 +582,7 @@ func TestConfigureLLMGateway_TLSSkipVerify_NotSet_DoesNotWriteNodeEnv(t *testing
 	claudeDir := filepath.Join(home, ".claude")
 	require.NoError(t, os.MkdirAll(claudeDir, 0o700))
 
-	_, err := cm.ConfigureLLMGateway(ClaudeCode, LLMApplyConfig{
+	_, err := cm.ConfigureLLMGateway(ClaudeCode, llmgateway.ApplyConfig{
 		TokenHelperCommand: `"thv" llm token`,
 		TLSSkipVerify:      false,
 	})
@@ -599,7 +601,7 @@ func TestConfigureLLMGateway_TLSSkipVerify_ClearRemovesKey(t *testing.T) {
 	require.NoError(t, os.MkdirAll(claudeDir, 0o700))
 
 	// First run: set tls-skip-verify
-	_, err := cm.ConfigureLLMGateway(ClaudeCode, LLMApplyConfig{
+	_, err := cm.ConfigureLLMGateway(ClaudeCode, llmgateway.ApplyConfig{
 		TokenHelperCommand: `"thv" llm token`,
 		TLSSkipVerify:      true,
 	})
@@ -611,7 +613,7 @@ func TestConfigureLLMGateway_TLSSkipVerify_ClearRemovesKey(t *testing.T) {
 	require.Contains(t, string(data), "NODE_TLS_REJECT_UNAUTHORIZED", "key must be present after first configure")
 
 	// Second run: clear tls-skip-verify
-	_, err = cm.ConfigureLLMGateway(ClaudeCode, LLMApplyConfig{
+	_, err = cm.ConfigureLLMGateway(ClaudeCode, llmgateway.ApplyConfig{
 		TokenHelperCommand: `"thv" llm token`,
 		TLSSkipVerify:      false,
 	})

--- a/pkg/llm/setup.go
+++ b/pkg/llm/setup.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/stacklok/toolhive/pkg/llmgateway"
 	pkgsecrets "github.com/stacklok/toolhive/pkg/secrets"
 )
 
@@ -18,23 +19,13 @@ import (
 // parameter so that tests can inject a no-op without touching the keyring.
 type LoginFunc func(ctx context.Context, cfg *Config) error
 
-// ToolApplyConfig carries the values needed to configure a single tool's LLM
-// gateway settings. Using a struct prevents positional-argument mistakes when
-// the caller has multiple similar string values in scope.
-type ToolApplyConfig struct {
-	GatewayURL         string // direct-mode: URL of the upstream LLM gateway
-	ProxyBaseURL       string // proxy-mode: URL of the localhost reverse proxy
-	TokenHelperCommand string // direct-mode: shell command that prints a fresh token
-	TLSSkipVerify      bool   // when true, instruct the tool to skip TLS verification
-}
-
 // GatewayManager is the subset of client.ClientManager used by Setup and
 // Teardown. Defined here so pkg/llm does not import pkg/client.
 type GatewayManager interface {
 	// DetectedLLMGatewayClients returns tool names for all installed LLM-gateway-capable tools.
 	DetectedLLMGatewayClients() []string
 	// ConfigureLLMGateway patches the tool's config file and returns the config path.
-	ConfigureLLMGateway(clientType string, cfg ToolApplyConfig) (string, error)
+	ConfigureLLMGateway(clientType string, cfg llmgateway.ApplyConfig) (string, error)
 	// LLMGatewayModeFor returns "direct", "proxy", or "" for the given client.
 	LLMGatewayModeFor(clientType string) string
 	// RevertLLMGateway removes the LLM gateway settings from the tool's config file.
@@ -313,7 +304,7 @@ func configureDetectedTools(
 ) ([]ToolConfig, error) {
 	var configured []ToolConfig
 	for _, clientType := range detected {
-		configPath, err := gm.ConfigureLLMGateway(clientType, ToolApplyConfig{
+		configPath, err := gm.ConfigureLLMGateway(clientType, llmgateway.ApplyConfig{
 			GatewayURL:         gatewayURL,
 			ProxyBaseURL:       proxyBaseURL,
 			TokenHelperCommand: tokenHelperCommand,

--- a/pkg/llm/setup_test.go
+++ b/pkg/llm/setup_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	"github.com/stacklok/toolhive/pkg/llmgateway"
 	"github.com/stacklok/toolhive/pkg/secrets"
 	secretsmocks "github.com/stacklok/toolhive/pkg/secrets/mocks"
 )
@@ -97,7 +98,7 @@ type stubGatewayManager struct {
 }
 
 func (*stubGatewayManager) DetectedLLMGatewayClients() []string { return nil }
-func (*stubGatewayManager) ConfigureLLMGateway(_ string, _ ToolApplyConfig) (string, error) {
+func (*stubGatewayManager) ConfigureLLMGateway(_ string, _ llmgateway.ApplyConfig) (string, error) {
 	return "", nil
 }
 func (*stubGatewayManager) LLMGatewayModeFor(_ string) string { return "" }

--- a/pkg/llmgateway/config.go
+++ b/pkg/llmgateway/config.go
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package llmgateway contains shared types for the LLM gateway feature,
+// imported by both pkg/llm and pkg/client to avoid an import cycle.
+package llmgateway
+
+// ApplyConfig holds the values needed to configure a single tool's LLM
+// gateway settings. Using a struct prevents positional-argument mistakes when
+// the caller has multiple similar string values in scope.
+type ApplyConfig struct {
+	GatewayURL         string // direct-mode: URL of the upstream LLM gateway
+	ProxyBaseURL       string // proxy-mode: URL of the localhost reverse proxy
+	TokenHelperCommand string // direct-mode: shell command that prints a fresh token
+	TLSSkipVerify      bool   // when true, instruct the tool to skip TLS verification
+}


### PR DESCRIPTION
## Summary

<!--
REQUIRED. You MUST explain:
1. WHY this change is needed (the problem or motivation)
2. WHAT changed (concise bullet points)

The diff shows the code — your summary must provide the context a reviewer
needs to understand the purpose without reading the diff first.
-->

The two types were structurally identical, kept separate only to avoid an import cycle between pkg/llm and pkg/client. The adapter in cmd/thv/app/llm.go did nothing but field-copy between them, meaning every new field had to be added in three places.

Introduce pkg/llmgateway with a single ApplyConfig struct imported by both packages. The adapter method is now a one-liner.
<!--
Link related issues. Use "Closes" or "Fixes" to auto-close on merge.
Remove this line if there is no related issue.
-->

Fixes #5137 

## Type of change

<!-- REQUIRED. Check exactly one. -->

- [ ] Bug fix
- [ ] New feature
- [x] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

<!--
REQUIRED. Check every verification step you actually ran.
You MUST check at least one item. If you only did manual testing,
describe exactly what you tested below the checkbox.
-->

- [x] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [ ] Linting (`task lint-fix`)
- [ ] Manual testing (describe below)

## API Compatibility

<!--
The CRD Schema Compatibility check guards the v1beta1 operator API.
If the check flags this PR as Incompatible and the break is intentional,
apply the `api-break-allowed` label and describe below:

1. Which fields, types, or CRDs are changing.
2. Why the break is unavoidable.
3. The user-facing migration path (what cluster admins need to do).

See CONTRIBUTING.md → "API Stability" for the full rubric. Coordinate
with maintainers before applying the label.

Remove this section entirely if the PR does not touch operator API surface.
-->

- [x] This PR does not break the `v1beta1` API, OR the `api-break-allowed` label is applied and the migration guidance is described above.

## Changes

<!--
Optional — include for PRs touching more than a few files to help
reviewers navigate the diff. Remove this entire section for small PRs.
-->

| File | Change |
|------|--------|
|      |        |

## Does this introduce a user-facing change?

<!--
If yes, describe the change from the user's perspective. This helps with release notes.
If no, write "No".
Remove this section entirely if not applicable.
-->

## Implementation plan

<!--
Optional — include when this PR was planned with an AI assistant (Claude Code, etc.).
Paste the approved plan inside the <details> block so reviewers can see the intended
design without cluttering the main PR description. Remove this section entirely
for PRs that were not AI-planned.
-->

<details>
<summary>Approved implementation plan</summary>

<!-- Paste the plan here -->

</details>

## Special notes for reviewers

<!--
Optional — call out anything non-obvious: tricky logic, known limitations,
areas where you'd like extra scrutiny, or follow-up work planned.
Remove this section if not needed.
-->
