### PR TITLE
Include nested files when resolving git skills

### DIFF
--- a/pkg/skills/gitresolver/resolver.go
+++ b/pkg/skills/gitresolver/resolver.go
@@ -14,6 +14,8 @@ import (
 	"regexp"
 	"time"
 
+	"github.com/go-git/go-git/v5/plumbing/object"
+
 	"github.com/stacklok/toolhive/pkg/git"
 	"github.com/stacklok/toolhive/pkg/skills"
 )
@@ -151,9 +153,9 @@ func (r *defaultResolver) Resolve(ctx context.Context, ref *GitReference) (*Reso
 		return nil, fmt.Errorf("invalid skill name in SKILL.md: %w", err)
 	}
 
-	// Collect all files in the skill directory.
-	// For now, we read SKILL.md as the primary file. Additional files in the
-	// skill directory are discovered by listing the tree entries.
+	// Collect all files in the skill directory, recursively walking nested
+	// subtrees so that companion files in subdirectories (e.g. references/,
+	// scripts/) are included in the resolved skill bundle.
 	files, err := r.collectFiles(repoInfo, ref.Path)
 	if err != nil {
 		return nil, fmt.Errorf("collecting skill files: %w", err)
@@ -166,7 +168,12 @@ func (r *defaultResolver) Resolve(ctx context.Context, ref *GitReference) (*Reso
 	}, nil
 }
 
-// collectFiles reads all files from the given path in the repository.
+// collectFiles reads all files from the given path in the repository,
+// walking nested subtrees recursively. Returned paths are forward-slash
+// relative to basePath. WriteContainedFile creates parent directories and
+// guards against path traversal; the in-memory clone is bounded by
+// LimitedFs in pkg/git, and the OCI packager re-asserts file count and
+// total size limits independently.
 func (*defaultResolver) collectFiles(repoInfo *git.RepositoryInfo, basePath string) ([]FileEntry, error) {
 	ref, err := repoInfo.Repository.Head()
 	if err != nil {
@@ -183,7 +190,6 @@ func (*defaultResolver) collectFiles(repoInfo *git.RepositoryInfo, basePath stri
 		return nil, fmt.Errorf("getting tree: %w", err)
 	}
 
-	// Navigate to subdirectory if specified
 	if basePath != "" {
 		tree, err = tree.Tree(basePath)
 		if err != nil {
@@ -192,32 +198,22 @@ func (*defaultResolver) collectFiles(repoInfo *git.RepositoryInfo, basePath stri
 	}
 
 	var files []FileEntry
-	for _, entry := range tree.Entries {
-		// Skip directories — we only want files at the top level of the skill dir.
-		// Nested subdirectories are not part of the skill spec today.
-		// WriteFiles includes MkdirAll as defense-in-depth for containment safety.
-		if entry.Mode == 0040000 {
-			continue
-		}
-
-		file, fileErr := tree.File(entry.Name)
-		if fileErr != nil {
-			return nil, fmt.Errorf("reading file %q: %w", entry.Name, fileErr)
-		}
-
-		content, contentErr := file.Contents()
+	err = tree.Files().ForEach(func(f *object.File) error {
+		content, contentErr := f.Contents()
 		if contentErr != nil {
-			return nil, fmt.Errorf("reading content of %q: %w", entry.Name, contentErr)
+			return fmt.Errorf("reading content of %q: %w", f.Name, contentErr)
 		}
 
 		// All files are capped to 0644 by the writer; set a uniform mode here.
-		mode := fs.FileMode(0644)
-
 		files = append(files, FileEntry{
-			Path:    entry.Name,
+			Path:    f.Name,
 			Content: []byte(content),
-			Mode:    mode,
+			Mode:    fs.FileMode(0644),
 		})
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("iterating tree: %w", err)
 	}
 
 	return files, nil

--- a/pkg/skills/gitresolver/resolver_test.go
+++ b/pkg/skills/gitresolver/resolver_test.go
@@ -6,6 +6,7 @@ package gitresolver
 import (
 	"context"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"testing"
@@ -60,6 +61,45 @@ func createTestRepo(t *testing.T, skillPath string, skillMD string) string {
 	require.NoError(t, err)
 
 	_, err = wt.Commit("Add test skill", &gogit.CommitOptions{
+		Author: &object.Signature{
+			Name:  "Test Author",
+			Email: "test@example.com",
+		},
+	})
+	require.NoError(t, err)
+
+	return dir
+}
+
+// nestedFile describes a file to seed into a test repo at a relative path.
+type nestedFile struct {
+	path    string
+	content string
+}
+
+// createNestedTestRepo creates a local git repo containing the given files
+// (with arbitrary nested directory structure) and commits them in a single
+// commit. It returns the repo directory path.
+func createNestedTestRepo(t *testing.T, files []nestedFile) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	repo, err := gogit.PlainInit(dir, false)
+	require.NoError(t, err)
+
+	wt, err := repo.Worktree()
+	require.NoError(t, err)
+
+	for _, f := range files {
+		fullPath := filepath.Join(dir, filepath.FromSlash(f.path))
+		require.NoError(t, os.MkdirAll(filepath.Dir(fullPath), 0755))
+		require.NoError(t, os.WriteFile(fullPath, []byte(f.content), 0644))
+	}
+
+	_, err = wt.Add(".")
+	require.NoError(t, err)
+
+	_, err = wt.Commit("Add nested skill", &gogit.CommitOptions{
 		Author: &object.Signature{
 			Name:  "Test Author",
 			Email: "test@example.com",
@@ -171,6 +211,83 @@ description: bad name
 			assert.Len(t, result.CommitHash, 40)
 		})
 	}
+}
+
+func TestResolver_Resolve_NestedFiles(t *testing.T) {
+	t.Parallel()
+
+	t.Run("skill in subdirectory with nested files", func(t *testing.T) {
+		t.Parallel()
+
+		files := []nestedFile{
+			{path: "skills/sample/SKILL.md", content: validSkillMD},
+			{path: "skills/sample/README.md", content: "# Sample"},
+			{path: "skills/sample/references/foo.md", content: "ref-foo"},
+			{path: "skills/sample/scripts/run.sh", content: "#!/bin/sh\n"},
+			{path: "skills/sample/deep/nested/dir/note.txt", content: "deep"},
+			// File outside the skill subtree must NOT be picked up.
+			{path: "other/unrelated.md", content: "ignore me"},
+		}
+		repoDir := createNestedTestRepo(t, files)
+
+		resolver := NewResolver(WithGitClient(git.NewDefaultGitClient()))
+		ref := &GitReference{URL: repoDir, Path: "skills/sample"}
+
+		result, err := resolver.Resolve(t.Context(), ref)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.Equal(t, "my-skill", result.SkillConfig.Name)
+
+		got := map[string]string{}
+		for _, f := range result.Files {
+			got[f.Path] = string(f.Content)
+			assert.Equal(t, fs.FileMode(0644), f.Mode, "file %q has unexpected mode", f.Path)
+		}
+
+		// Forward-slash paths relative to the skill subtree.
+		assert.Equal(t, validSkillMD, got["SKILL.md"])
+		assert.Equal(t, "# Sample", got["README.md"])
+		assert.Equal(t, "ref-foo", got["references/foo.md"])
+		assert.Equal(t, "#!/bin/sh\n", got["scripts/run.sh"])
+		assert.Equal(t, "deep", got["deep/nested/dir/note.txt"])
+
+		// Files outside the skill subtree must not leak in.
+		_, hasUnrelated := got["unrelated.md"]
+		assert.False(t, hasUnrelated, "files outside the skill subtree must not be included")
+		_, hasFullOther := got["other/unrelated.md"]
+		assert.False(t, hasFullOther, "files outside the skill subtree must not be included")
+
+		assert.Len(t, result.Files, 5, "expected exactly the five files under skills/sample")
+	})
+
+	t.Run("skill at repo root with nested files", func(t *testing.T) {
+		t.Parallel()
+
+		files := []nestedFile{
+			{path: "SKILL.md", content: validSkillMD},
+			{path: "references/foo.md", content: "ref-foo"},
+			{path: "scripts/run.sh", content: "#!/bin/sh\n"},
+		}
+		repoDir := createNestedTestRepo(t, files)
+
+		resolver := NewResolver(WithGitClient(git.NewDefaultGitClient()))
+		ref := &GitReference{URL: repoDir, Path: ""}
+
+		result, err := resolver.Resolve(t.Context(), ref)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+
+		got := map[string]string{}
+		for _, f := range result.Files {
+			got[f.Path] = string(f.Content)
+			assert.Equal(t, fs.FileMode(0644), f.Mode, "file %q has unexpected mode", f.Path)
+		}
+
+		assert.Equal(t, validSkillMD, got["SKILL.md"])
+		assert.Equal(t, "ref-foo", got["references/foo.md"])
+		assert.Equal(t, "#!/bin/sh\n", got["scripts/run.sh"])
+		assert.Len(t, result.Files, 3)
+	})
 }
 
 func TestResolver_Resolve_TagRef(t *testing.T) {

--- a/pkg/skills/gitresolver/writer_test.go
+++ b/pkg/skills/gitresolver/writer_test.go
@@ -98,6 +98,37 @@ func TestWriteFiles(t *testing.T) {
 		assert.Equal(t, []byte("# Skill"), content)
 	})
 
+	t.Run("nested file paths create intermediate directories", func(t *testing.T) {
+		t.Parallel()
+		baseDir := resolvedTempDir(t)
+		targetDir := filepath.Join(baseDir, "my-skill")
+
+		files := []FileEntry{
+			{Path: "SKILL.md", Content: []byte("# Skill"), Mode: 0644},
+			{Path: "references/foo.md", Content: []byte("ref-foo"), Mode: 0644},
+			{Path: "scripts/nested/run.sh", Content: []byte("#!/bin/sh\n"), Mode: 0755},
+			{Path: "deep/nested/dir/note.txt", Content: []byte("deep"), Mode: 0644},
+		}
+		require.NoError(t, WriteFiles(files, targetDir, false))
+
+		for _, f := range files {
+			full := filepath.Join(targetDir, filepath.FromSlash(f.Path))
+			content, readErr := os.ReadFile(full)
+			require.NoError(t, readErr, "file %q should exist on disk", f.Path)
+			assert.Equal(t, f.Content, content)
+
+			info, statErr := os.Stat(full)
+			require.NoError(t, statErr)
+			mode := info.Mode().Perm()
+			assert.True(t, mode <= 0644, "file %q has mode %o, expected <= 0644", f.Path, mode)
+		}
+
+		// Spot-check that an intermediate directory was created.
+		info, statErr := os.Stat(filepath.Join(targetDir, "scripts", "nested"))
+		require.NoError(t, statErr)
+		assert.True(t, info.IsDir(), "intermediate dir scripts/nested should be a directory")
+	})
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()


### PR DESCRIPTION
## Summary

- `dockhand build-skill` against a skill whose source tree has subdirectories (e.g. [`getsentry/skills/skills/security-review`](https://github.com/getsentry/skills/tree/main/skills/security-review), with `infrastructure/`, `languages/`, `references/`) was producing an OCI artifact that contained only the top-level files. The published bundle was effectively unusable: any skill that ships companion docs/scripts in subdirectories shipped with those files silently dropped.
- Root cause is in `pkg/skills/gitresolver/resolver.go::collectFiles`: it iterates `tree.Entries` and explicitly skips entries with mode `0040000` (directories), so nested files never reach `WriteFiles` → `Packager.Package`. Both downstream layers already support nested paths — `WriteContainedFile` does `os.MkdirAll(parentDir, …)` plus a path-traversal guard ([`pkg/fileutils/contained.go`](pkg/fileutils/contained.go)), and toolhive-core's `oci/skills/packager.go` walks the staged directory with `filepath.WalkDir`.
- Switch `collectFiles` to go-git's recursive `*FileIter` via `tree.Files().ForEach(...)`. The iterator walks the navigated subtree depth-first, skips submodules and tree entries automatically, and returns forward-slash relative paths fit for both `WriteContainedFile` and the packager.
- Three independent commits — production fix, resolver regression test, writer regression guard — so each can be reviewed / reverted in isolation.

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`go test ./pkg/skills/gitresolver/... -count=1 -race -v`) — all pass, including two new resolver cases and one new writer case
- [x] Linting (`task lint-fix` — 0 issues)
- [x] `TestResolver_Resolve_NestedFiles/skill_in_subdirectory_with_nested_files` — `Path: "skills/sample"` with a fixture containing `SKILL.md`, `README.md`, `references/foo.md`, `scripts/run.sh`, `deep/nested/dir/note.txt`, plus an out-of-subtree `other/unrelated.md`. Asserts the five expected forward-slash paths are returned, the out-of-subtree file is not picked up, and every entry has mode `0644`.
- [x] `TestResolver_Resolve_NestedFiles/skill_at_repo_root_with_nested_files` — `Path: ""` covers the no-basePath branch (whole tree walk).
- [x] `TestWriteFiles/nested_file_paths_create_intermediate_directories` — independent guard that confirms `WriteFiles` lays nested `FileEntry.Path` values out correctly on disk and caps modes at `0644`.
- [x] All pre-existing tests in the package still pass; the only failing test in `pkg/skills/...` (`pkg/skills/client.TestNewDefaultClient/falls_back_to_default_URL_when_env_is_empty`) reproduces on the unmodified branch tip and is unrelated to this change.

## Changes

| File | Change |
|------|--------|
| `pkg/skills/gitresolver/resolver.go` | Add `plumbing/object` import; rewrite `collectFiles` to walk the navigated subtree recursively via `tree.Files().ForEach(...)`; refresh stale comments. |
| `pkg/skills/gitresolver/resolver_test.go` | Add `nestedFile` helper + `createNestedTestRepo`; add `TestResolver_Resolve_NestedFiles` covering both `Path: "skills/sample"` and `Path: ""` cases. |
| `pkg/skills/gitresolver/writer_test.go` | Add `nested file paths create intermediate directories` subtest exercising `WriteFiles` with subdirectory entries. |

Existing safety nets are unchanged and sufficient: the in-memory clone is still capped via `LimitedFs{MaxFiles: 10_000, TotalFileSize: 100MB}` in [`pkg/git/client.go`](pkg/git/client.go), and toolhive-core's packager re-asserts `maxSkillFiles=1000` / `maxSkillTotalSize=100MB` when staging the artifact, so no new limits are required here.

## Does this introduce a user-facing change?

Yes — bug-fix only. Skills installed from a git source whose directory contains subdirectories now ship with the full subtree. Skills that were already flat see no behavioural change. The OCI artifact produced by `dockhand build-skill` against e.g. `getsentry/skills/skills/security-review` now includes its `infrastructure/`, `languages/`, and `references/` subtrees instead of dropping them.