### PR TITLE
Add --client flag to thv llm setup and teardown

### DIFF
--- a/cmd/thv/app/llm.go
+++ b/cmd/thv/app/llm.go
@@ -215,11 +215,12 @@ func newLLMSetupCommand() *cobra.Command {
 	var (
 		opts          llm.SetOptions
 		tlsSkipVerify bool
+		targetClient  string
 	)
 
 	cmd := &cobra.Command{
 		Use:   "setup",
-		Short: "Configure all detected AI tools to use the LLM gateway",
+		Short: "Configure detected AI tools to use the LLM gateway",
 		Long: `Detect installed AI coding tools (Claude Code, Gemini CLI, Cursor, VS Code,
 Xcode) and patch each tool's configuration to route through the LLM gateway.
 
@@ -228,6 +229,9 @@ Token-helper tools (Claude Code, Gemini CLI) are configured to call
 
 Proxy-mode tools (Cursor, VS Code, Xcode) are configured to send requests to
 the localhost reverse proxy started by "thv llm proxy start".
+
+Use --client to configure only a single named tool instead of all detected
+tools. An error is returned if the named client is not installed.
 
 Inline flags (--gateway-url, --issuer, --client-id, etc.) are applied for this
 run and persisted to config only after login and tool patching succeed. This
@@ -245,7 +249,7 @@ Run "thv llm teardown" to revert all changes.`,
 			}
 			return runLLMSetup(
 				cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(),
-				cm, config.NewDefaultProvider(), oidcLogin, opts,
+				cm, config.NewDefaultProvider(), oidcLogin, opts, targetClient,
 			)
 		},
 	}
@@ -261,6 +265,8 @@ Run "thv llm teardown" to revert all changes.`,
 			"For direct-mode tools (Claude Code, Gemini CLI) this sets NODE_TLS_REJECT_UNAUTHORIZED=0, "+
 			"disabling TLS for ALL of that tool's outbound connections. "+
 			"For proxy-mode tools only the proxy-to-gateway connection is affected.")
+	cmd.Flags().StringVar(&targetClient, "client", "",
+		"Configure only this AI tool by name (e.g. claude-code, cursor). Omit to configure all detected tools.")
 
 	return cmd
 }
@@ -279,23 +285,33 @@ func oidcLogin(ctx context.Context, cfg *llm.Config) error {
 func runLLMSetup(
 	ctx context.Context, out, errOut io.Writer,
 	cm *client.ClientManager, provider config.Provider, login llm.LoginFunc,
-	inlineOpts llm.SetOptions,
+	inlineOpts llm.SetOptions, targetClient string,
 ) error {
-	return llm.Setup(ctx, out, errOut, &clientManagerAdapter{cm}, &configUpdaterAdapter{provider}, login, inlineOpts)
+	return llm.Setup(ctx, out, errOut, &clientManagerAdapter{cm}, &configUpdaterAdapter{provider}, login, inlineOpts, targetClient)
 }
 
 func newLLMTeardownCommand() *cobra.Command {
-	var purgeTokens bool
+	var (
+		purgeTokens  bool
+		targetClient string
+	)
 
 	cmd := &cobra.Command{
 		Use:   "teardown [tool-name]",
 		Short: "Remove LLM gateway configuration from all (or one) configured tools",
 		Long: `Revert the configuration changes made by "thv llm setup" for all configured
-tools, or for a single tool when tool-name is provided.
+tools, or for a single tool when tool-name is provided as a positional argument
+or via --client.
 
 Use --purge-tokens to also remove cached OIDC tokens from the secrets provider.`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if targetClient != "" && len(args) > 0 {
+				return fmt.Errorf("cannot use --client and a positional tool-name argument at the same time")
+			}
+			if targetClient != "" {
+				args = []string{targetClient}
+			}
 			cm, err := client.NewClientManager()
 			if err != nil {
 				return fmt.Errorf("initializing client manager: %w", err)
@@ -305,6 +321,8 @@ Use --purge-tokens to also remove cached OIDC tokens from the secrets provider.`
 	}
 
 	cmd.Flags().BoolVar(&purgeTokens, "purge-tokens", false, "Also delete cached OIDC tokens from the secrets provider")
+	cmd.Flags().StringVar(&targetClient, "client", "",
+		"Remove configuration for only this AI tool by name (e.g. claude-code, cursor). Omit to revert all configured tools.")
 
 	return cmd
 }

--- a/cmd/thv/app/llm_test.go
+++ b/cmd/thv/app/llm_test.go
@@ -71,7 +71,7 @@ func TestRunLLMSetup_NotConfigured(t *testing.T) {
 	provider := llmProvider(t, llm.Config{}) // no gateway URL
 
 	var stdout, stderr bytes.Buffer
-	err := runLLMSetup(context.Background(), &stdout, &stderr, cm, provider, noopLogin, llm.SetOptions{})
+	err := runLLMSetup(context.Background(), &stdout, &stderr, cm, provider, noopLogin, llm.SetOptions{}, "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not configured")
 }
@@ -98,7 +98,7 @@ func TestRunLLMSetup_NoDetectedTools(t *testing.T) {
 	})
 
 	var stdout, stderr bytes.Buffer
-	err := runLLMSetup(context.Background(), &stdout, &stderr, cm, provider, noopLogin, llm.SetOptions{})
+	err := runLLMSetup(context.Background(), &stdout, &stderr, cm, provider, noopLogin, llm.SetOptions{}, "")
 	require.NoError(t, err)
 	assert.Contains(t, stdout.String(), "No supported AI tools detected")
 }
@@ -142,7 +142,7 @@ func TestRunLLMSetup_PartialFailure(t *testing.T) {
 	})
 
 	var stdout, stderr bytes.Buffer
-	err := runLLMSetup(context.Background(), &stdout, &stderr, cm, provider, noopLogin, llm.SetOptions{})
+	err := runLLMSetup(context.Background(), &stdout, &stderr, cm, provider, noopLogin, llm.SetOptions{}, "")
 	require.NoError(t, err)
 	assert.Contains(t, stderr.String(), "Warning: failed to configure claude-code")
 	assert.Contains(t, stdout.String(), "Configured gemini-cli")
@@ -176,7 +176,7 @@ func TestRunLLMSetup_RollbackOnConfigUpdateFailure(t *testing.T) {
 	provider := &errOnUpdateProvider{cfg: c, updateErr: errors.New("disk full")}
 
 	var stdout, stderr bytes.Buffer
-	err := runLLMSetup(context.Background(), &stdout, &stderr, cm, provider, noopLogin, llm.SetOptions{})
+	err := runLLMSetup(context.Background(), &stdout, &stderr, cm, provider, noopLogin, llm.SetOptions{}, "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "persisting tool configuration")
 
@@ -226,7 +226,7 @@ func TestRunLLMSetup_RollbackBothToolsOnConfigUpdateFailure(t *testing.T) {
 	provider := &errOnUpdateProvider{cfg: c, updateErr: errors.New("disk full")}
 
 	var stdout, stderr bytes.Buffer
-	err := runLLMSetup(context.Background(), &stdout, &stderr, cm, provider, noopLogin, llm.SetOptions{})
+	err := runLLMSetup(context.Background(), &stdout, &stderr, cm, provider, noopLogin, llm.SetOptions{}, "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "persisting tool configuration")
 
@@ -273,7 +273,7 @@ func TestRunLLMSetup_LoginFailureLeavesNoState(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	err := runLLMSetup(context.Background(), &stdout, &stderr, cm, provider,
 		func(_ context.Context, _ *llm.Config) error { return loginErr },
-		llm.SetOptions{},
+		llm.SetOptions{}, "",
 	)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "OIDC login failed")
@@ -434,4 +434,138 @@ func TestRunLLMTeardown_SingleTool(t *testing.T) {
 	data, err := os.ReadFile(claudePath)
 	require.NoError(t, err)
 	assert.NotContains(t, string(data), "apiKeyHelper")
+}
+
+// ── --client flag (setup) ─────────────────────────────────────────────────────
+
+func TestRunLLMSetup_ClientFlag_ConfiguresSingleTool(t *testing.T) {
+	t.Parallel()
+	// Two tools installed; --client selects only claude-code.
+	// gemini-cli dir exists but must NOT be touched.
+	dir := t.TempDir()
+
+	claudeDir := filepath.Join(dir, ".claude")
+	geminiDir := filepath.Join(dir, ".gemini")
+	require.NoError(t, os.MkdirAll(claudeDir, 0o700))
+	require.NoError(t, os.MkdirAll(geminiDir, 0o700))
+
+	cfgs := client.LLMTestIntegrations([]client.LLMTestEntry{
+		{
+			ClientType:   client.ClaudeCode,
+			Mode:         "direct",
+			SettingsDir:  []string{".claude"},
+			SettingsFile: "settings.json",
+			JSONPointers: []string{"/apiKeyHelper"},
+			ValueFields:  []string{"TokenHelperCommand"},
+		},
+		{
+			ClientType:   client.GeminiCli,
+			Mode:         "direct",
+			SettingsDir:  []string{".gemini"},
+			SettingsFile: "settings.json",
+			JSONPointers: []string{"/baseUrl"},
+			ValueFields:  []string{"GatewayURL"},
+		},
+	})
+	cm := client.NewTestClientManager(dir, nil, cfgs, nil)
+	provider := llmProvider(t, llm.Config{
+		GatewayURL: "https://gw.example.com",
+		OIDC:       llm.OIDCConfig{Issuer: "https://auth.example.com", ClientID: "id"},
+	})
+
+	var stdout, stderr bytes.Buffer
+	err := runLLMSetup(context.Background(), &stdout, &stderr, cm, provider, noopLogin, llm.SetOptions{}, "claude-code")
+	require.NoError(t, err)
+	assert.Contains(t, stdout.String(), "Configured claude-code")
+	assert.NotContains(t, stdout.String(), "gemini-cli")
+
+	// Only claude-code settings file should exist.
+	_, statErr := os.Stat(filepath.Join(claudeDir, "settings.json"))
+	assert.NoError(t, statErr, "claude-code settings.json must be created")
+	_, statErr = os.Stat(filepath.Join(geminiDir, "settings.json"))
+	assert.True(t, os.IsNotExist(statErr), "gemini-cli settings.json must not be created")
+}
+
+func TestRunLLMSetup_ClientFlag_NotInstalled(t *testing.T) {
+	t.Parallel()
+	// --client names a tool that is not detected (no settings dir on disk).
+	dir := t.TempDir()
+
+	cfgs := client.LLMTestIntegrations([]client.LLMTestEntry{
+		{
+			ClientType:   client.ClaudeCode,
+			Mode:         "direct",
+			SettingsDir:  []string{".claude"},
+			SettingsFile: "settings.json",
+			JSONPointers: []string{"/apiKeyHelper"},
+			ValueFields:  []string{"TokenHelperCommand"},
+		},
+	})
+	cm := client.NewTestClientManager(dir, nil, cfgs, nil)
+	provider := llmProvider(t, llm.Config{
+		GatewayURL: "https://gw.example.com",
+		OIDC:       llm.OIDCConfig{Issuer: "https://auth.example.com", ClientID: "id"},
+	})
+
+	var stdout, stderr bytes.Buffer
+	// cursor is not installed (no dir); expect an error.
+	err := runLLMSetup(context.Background(), &stdout, &stderr, cm, provider, noopLogin, llm.SetOptions{}, "cursor")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `"cursor" is not installed or not detected`)
+}
+
+// ── --client flag (teardown) ──────────────────────────────────────────────────
+
+func TestRunLLMTeardown_ClientFlag_RevertsNamedTool(t *testing.T) {
+	t.Parallel()
+	// --client equivalent: pass []string{"claude-code"} as the target.
+	// Reuses the same runLLMTeardown path; the flag is wired in the cobra
+	// command, so here we test the underlying function directly.
+	dir := t.TempDir()
+
+	claudeDir := filepath.Join(dir, ".claude")
+	require.NoError(t, os.MkdirAll(claudeDir, 0o700))
+	claudePath := filepath.Join(claudeDir, "settings.json")
+	require.NoError(t, os.WriteFile(claudePath,
+		[]byte(`{"apiKeyHelper":"thv llm token"}`), 0o600))
+
+	cfgs := client.LLMTestIntegrations([]client.LLMTestEntry{
+		{
+			ClientType:   client.ClaudeCode,
+			Mode:         "direct",
+			SettingsDir:  []string{".claude"},
+			SettingsFile: "settings.json",
+			JSONPointers: []string{"/apiKeyHelper"},
+			ValueFields:  []string{"TokenHelperCommand"},
+		},
+	})
+	cm := client.NewTestClientManager(dir, nil, cfgs, nil)
+	provider := llmProvider(t, llm.Config{
+		ConfiguredTools: []llm.ToolConfig{
+			{Tool: "claude-code", Mode: "direct", ConfigPath: claudePath},
+			{Tool: "cursor", Mode: "proxy", ConfigPath: "/some/cursor/path"},
+		},
+	})
+
+	var stdout, stderr bytes.Buffer
+	// Simulate --client claude-code by passing it as a single-element slice.
+	err := runLLMTeardown(context.Background(), &stdout, &stderr, cm, []string{"claude-code"}, false, provider)
+	require.NoError(t, err)
+	assert.Contains(t, stdout.String(), "Reverted claude-code")
+
+	// cursor must remain configured.
+	cfg := provider.GetConfig()
+	require.Len(t, cfg.LLM.ConfiguredTools, 1)
+	assert.Equal(t, "cursor", cfg.LLM.ConfiguredTools[0].Tool)
+}
+
+func TestLLMTeardownCommand_ClientFlagAndPositionalArgMutuallyExclusive(t *testing.T) {
+	t.Parallel()
+	// Execute the cobra command with both --client and a positional arg; the
+	// RunE mutual-exclusion guard must fire before any client manager is built.
+	cmd := newLLMTeardownCommand()
+	cmd.SetArgs([]string{"--client", "claude-code", "cursor"})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot use --client and a positional tool-name argument at the same time")
 }

--- a/pkg/llm/setup.go
+++ b/pkg/llm/setup.go
@@ -50,7 +50,11 @@ type ConfigUpdater interface {
 	UpdateLLMConfig(fn func(*Config) error) error
 }
 
-// Setup configures all detected AI tools to use the LLM gateway.
+// Setup configures detected AI tools to use the LLM gateway.
+//
+// When targetClient is non-empty only that client is configured; an error is
+// returned if the client is not installed. Pass an empty string to configure
+// all detected clients (the original behaviour).
 //
 // It applies inlineOpts in-memory before login so a failed login leaves no
 // persisted state. Tool config files are patched only after login succeeds;
@@ -58,7 +62,7 @@ type ConfigUpdater interface {
 func Setup(
 	ctx context.Context, out, errOut io.Writer,
 	gm GatewayManager, provider ConfigUpdater, login LoginFunc,
-	inlineOpts SetOptions,
+	inlineOpts SetOptions, targetClient string,
 ) error {
 	llmCfg := provider.GetLLMConfig()
 
@@ -102,7 +106,10 @@ func Setup(
 	// Detect tools before login so we skip the interactive browser flow when
 	// there is nothing to configure. Login still runs before any files are
 	// patched, preserving the guarantee that a failed login leaves no state.
-	detected := gm.DetectedLLMGatewayClients()
+	detected, err := filterDetectedClients(gm.DetectedLLMGatewayClients(), targetClient)
+	if err != nil {
+		return err
+	}
 	if len(detected) == 0 {
 		_, _ = fmt.Fprintln(out, "No supported AI tools detected.")
 		return nil
@@ -299,6 +306,21 @@ func warnTLSSkipVerify(errOut io.Writer, skip bool, configured []ToolConfig) {
 					"proxy's upstream gateway connection only. Use only in isolated local environments.\n", tc.Tool)
 		}
 	}
+}
+
+// filterDetectedClients narrows the detected client list to a single entry when
+// targetClient is non-empty. It returns an error if the named client is not in
+// the detected list. When targetClient is empty the list is returned unchanged.
+func filterDetectedClients(detected []string, targetClient string) ([]string, error) {
+	if targetClient == "" {
+		return detected, nil
+	}
+	for _, c := range detected {
+		if c == targetClient {
+			return []string{targetClient}, nil
+		}
+	}
+	return nil, fmt.Errorf("client %q is not installed or not detected", targetClient)
 }
 
 // configureDetectedTools patches each detected tool's config file and returns


### PR DESCRIPTION
## Summary

<!--
REQUIRED. You MUST explain:
1. WHY this change is needed (the problem or motivation)
2. WHAT changed (concise bullet points)

The diff shows the code — your summary must provide the context a reviewer
needs to understand the purpose without reading the diff first.
-->

`thv llm setup --client <name>` configures only the named AI tool instead of all detected ones. An error is returned if the client is not installed. `thv llm teardown --client <name>` is equivalent to the existing positional-argument form; using both simultaneously is an error.
<!--
Link related issues. Use "Closes" or "Fixes" to auto-close on merge.
Remove this line if there is no related issue.
-->

Fixes #5143 

## Type of change

<!-- REQUIRED. Check exactly one. -->

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

<!--
REQUIRED. Check every verification step you actually ran.
You MUST check at least one item. If you only did manual testing,
describe exactly what you tested below the checkbox.
-->

- [x] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [ ] Linting (`task lint-fix`)
- [ ] Manual testing (describe below)

## API Compatibility

<!--
The CRD Schema Compatibility check guards the v1beta1 operator API.
If the check flags this PR as Incompatible and the break is intentional,
apply the `api-break-allowed` label and describe below:

1. Which fields, types, or CRDs are changing.
2. Why the break is unavoidable.
3. The user-facing migration path (what cluster admins need to do).

See CONTRIBUTING.md → "API Stability" for the full rubric. Coordinate
with maintainers before applying the label.

Remove this section entirely if the PR does not touch operator API surface.
-->

- [x] This PR does not break the `v1beta1` API, OR the `api-break-allowed` label is applied and the migration guidance is described above.

## Changes

<!--
Optional — include for PRs touching more than a few files to help
reviewers navigate the diff. Remove this entire section for small PRs.
-->

| File | Change |
|------|--------|
|      |        |

## Does this introduce a user-facing change?

<!--
If yes, describe the change from the user's perspective. This helps with release notes.
If no, write "No".
Remove this section entirely if not applicable.
-->

## Implementation plan

<!--
Optional — include when this PR was planned with an AI assistant (Claude Code, etc.).
Paste the approved plan inside the <details> block so reviewers can see the intended
design without cluttering the main PR description. Remove this section entirely
for PRs that were not AI-planned.
-->

<details>
<summary>Approved implementation plan</summary>

<!-- Paste the plan here -->

</details>

## Special notes for reviewers

<!--
Optional — call out anything non-obvious: tricky logic, known limitations,
areas where you'd like extra scrutiny, or follow-up work planned.
Remove this section if not needed.
-->
