### PR TITLE
Fall back to request-token claims for opaque upstream tokens

### DIFF
--- a/pkg/authz/authorizers/cedar/core.go
+++ b/pkg/authz/authorizers/cedar/core.go
@@ -492,6 +492,30 @@ func (a *Authorizer) resolveClaims(identity *auth.Identity) (jwt.MapClaims, erro
 		}
 		parsedClaims, err := parseUpstreamJWTClaims(upstreamToken)
 		if err != nil {
+			// Distinguish "not JWT-shaped" (opaque OAuth 2.0 access token —
+			// Google's ya29.*, GitHub's gho_*, etc.) from "JWT-shaped but
+			// malformed/tampered" (a JWT with three segments that fails to
+			// parse). Only fall back for the former; preserve the deny for
+			// the latter so a tampered upstream JWT cannot bypass policy.
+			//
+			// The embedded auth server already mirrors the upstream OIDC
+			// sub/email/name claims into its issued AS token (see
+			// pkg/authserver/server/session/session.go). For opaque-token
+			// providers, falling back to identity.Claims preserves identity
+			// for policies referencing standard OIDC claims; policies that
+			// reference upstream-only claims (groups, hd, custom namespaced
+			// claims) will see those attributes as absent and must be
+			// authored defensively (`has(claim_groups) && ...`).
+			if !looksLikeJWT(upstreamToken) {
+				// The Warn shares claimKeyLog with logClaimKeys below so a busy
+				// Google/GitHub deployment does not emit one line per tool call.
+				a.claimKeyLog.Do(func() {
+					slog.Warn("upstream token is not a JWT; falling back to request-token claims for Cedar evaluation",
+						"provider", a.primaryUpstreamProvider)
+				})
+				a.logClaimKeys("token-fallback", jwt.MapClaims(identity.Claims))
+				return jwt.MapClaims(identity.Claims), nil
+			}
 			return nil, fmt.Errorf("failed to parse upstream token for provider %q: %w",
 				a.primaryUpstreamProvider, err)
 		}
@@ -502,6 +526,13 @@ func (a *Authorizer) resolveClaims(identity *auth.Identity) (jwt.MapClaims, erro
 	claims := jwt.MapClaims(identity.Claims)
 	a.logClaimKeys("token", claims)
 	return claims, nil
+}
+
+// looksLikeJWT returns true when the token has the three-segment shape of a
+// JOSE-compact-serialized JWT (`header.payload.signature`). It does not
+// validate the contents; the parser handles that.
+func looksLikeJWT(tokenStr string) bool {
+	return strings.Count(tokenStr, ".") == 2
 }
 
 // logClaimKeys emits a rate-limited DEBUG log listing the JWT claim keys

--- a/pkg/authz/authorizers/cedar/core_test.go
+++ b/pkg/authz/authorizers/cedar/core_test.go
@@ -1296,7 +1296,7 @@ func TestAuthorizeWithJWTClaims_UpstreamProvider(t *testing.T) {
 			errContains: "upstream token for provider",
 		},
 		{
-			name: "upstream_token_opaque_not_parseable",
+			name: "upstream_token_opaque_falls_back_to_request_claims_denied",
 			identity: &auth.Identity{
 				PrincipalInfo: auth.PrincipalInfo{
 					Subject: "thv-user",
@@ -1304,6 +1304,45 @@ func TestAuthorizeWithJWTClaims_UpstreamProvider(t *testing.T) {
 				},
 				UpstreamTokens: map[string]string{
 					providerName: "opaque-token-cannot-be-parsed",
+				},
+			},
+			// Opaque upstream tokens (Google's ya29.*, GitHub's gho_*, etc.)
+			// trigger the fallback to identity.Claims. Here the request-token
+			// sub does not match the policy, so authorization is correctly
+			// denied based on policy evaluation rather than a parse-time error.
+			wantAuthorize: false,
+		},
+		{
+			name: "upstream_token_opaque_falls_back_to_request_claims_permitted",
+			identity: &auth.Identity{
+				PrincipalInfo: auth.PrincipalInfo{
+					Subject: "upstream-user",
+					Claims:  map[string]any{"sub": "upstream-user"},
+				},
+				UpstreamTokens: map[string]string{
+					providerName: "opaque-token-cannot-be-parsed",
+				},
+			},
+			// When the upstream token is not a JWT, Cedar evaluates against
+			// the request-token claims. The embedded auth server already
+			// mirrors the upstream OIDC sub/email/name into its issued token,
+			// so a policy referencing claim_sub still matches the user.
+			wantAuthorize: true,
+		},
+		{
+			name: "upstream_token_jwt_shaped_but_malformed_still_errors",
+			identity: &auth.Identity{
+				PrincipalInfo: auth.PrincipalInfo{
+					Subject: "thv-user",
+					Claims:  map[string]any{"sub": "thv-user"},
+				},
+				UpstreamTokens: map[string]string{
+					// Three-segment shape (looks like a JWT) but the segments are
+					// not valid base64-encoded JSON — i.e. a tampered or
+					// corrupted JWT. The fallback path MUST NOT trigger here:
+					// silently degrading a tampered upstream JWT to fallback
+					// claims would be a security regression.
+					providerName: "not-base64.not-base64.not-base64",
 				},
 			},
 			wantErr:     true,


### PR DESCRIPTION
## Summary

- VirtualMCPServer's incoming Cedar authorizer denied every request when the embedded auth server's upstream provider issues opaque OAuth 2.0 access tokens (Google's `ya29.*`, GitHub's `gho_*`). `resolveClaims` JWT-parsed the upstream token unconditionally and returned the parse error verbatim, so every authorization check failed and the gateway skipped every tool.
- Discriminate by token shape: if the upstream token is not three dot-separated segments it cannot be a JWT (per JOSE compact serialization), so fall back to `identity.Claims` (the request-token claims). The embedded auth server already mirrors the upstream OIDC `sub`/`email`/`name` into its issued AS token (see `pkg/authserver/server/session/session.go`), so policies referencing standard OIDC claims continue to evaluate correctly.
- JWT-shaped tokens (three segments) that fail to parse still return the error: a tampered or corrupted upstream JWT must not silently degrade to fallback claims. The added `looksLikeJWT(tokenStr) = strings.Count(tokenStr, ".") == 2` discriminator keeps that boundary explicit.
- The auto-binding of `PrimaryUpstreamProvider` added in #5002 (operator side, `cmd/thv-operator/pkg/vmcpconfig/converter.go`) doesn't expose an opt-out CRD field, so users with opaque-token providers had no in-config workaround. This change unblocks them without changing operator behavior.

Closes #5146

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [x] Unit tests (`go test ./pkg/authz/...`)
- [x] `go vet ./pkg/authz/...`
- [x] `gofmt -l pkg/authz/authorizers/cedar/` (clean)
- [x] End-to-end verified on a GKE staging cluster: `VirtualMCPServer` with `accounts.google.com` upstream, Cedar policy referencing `claim_email`. Pre-fix: `tools/list` returns empty with `Authorization check failed for tool, skipping` per tool. Post-fix: full aggregated tool list returned, single WARN line `upstream token is not a JWT; falling back to request-token claims for Cedar evaluation provider=google`.

The existing `TestParseUpstreamJWTClaims/opaque_token_returns_error` row stays unchanged — the helper still returns the same error; only the caller's recovery behavior changes.

## API Compatibility

- [x] This PR does not break the `v1beta1` API. No CRD or `ConfigOptions` schema change.

## Changes

| File | Change |
|------|--------|
| `pkg/authz/authorizers/cedar/core.go` | `resolveClaims` discriminates `looksLikeJWT(tokenStr)` before falling back. Opaque (≠3 segments) → fall back to `identity.Claims` with a WARN. JWT-shaped but unparseable → return the original parse error (deny). Adds the `looksLikeJWT` helper. |
| `pkg/authz/authorizers/cedar/core_test.go` | Replaces the `upstream_token_opaque_not_parseable` row in `TestAuthorizeWithJWTClaims_UpstreamProvider` with three rows: opaque-fallback-denied (policy mismatch via fallback claims), opaque-fallback-permitted (policy matches via fallback claims), and JWT-shaped-but-malformed-still-errors (security-regression guard for tampered JWTs). |

## Does this introduce a user-facing change?

Yes — bug-fix only. Operators with Google (or any opaque-access-token) upstream OIDC provider now receive the aggregated tools list instead of an empty one. No CRD or configuration change required. A WARN log surfaces each fallback so operators can observe the path their identity claims take.

Tampered or corrupted upstream JWTs still hard-deny — there is no behavior change for JWT-access-token providers (Okta, Azure AD with JWT access tokens, etc.).

## Special notes for reviewers

A complementary operator-side change — only auto-set `PrimaryUpstreamProvider` when the user hasn't asked for the explicit fallback — would expose the documented escape hatch via a CRD field, since the docstring on `PrimaryUpstreamProvider` already says *"When empty, claims from the ToolHive-issued token are used."* That route is more invasive (CRD + types + converter + tests). Happy to PR it separately if you'd prefer the opt-in surface over the implicit fallback in this PR. Either approach unblocks the failing case.

The fallback could also be argued to belong behind a `ConfigOptions.AllowOpaqueTokenFallback` knob (default false). I left it implicit here because (a) the discriminator preserves the deny for tampered JWTs, which is the security-relevant case, and (b) for opaque-token providers the previous behavior was always-deny — there's no operator who relied on it doing anything useful. Open to adding the gate if you'd prefer the more conservative surface.