### PR TITLE
Preserve runconfig-checksum on pod template overrides

### DIFF
--- a/cmd/thv-operator/controllers/mcpserver_controller.go
+++ b/cmd/thv-operator/controllers/mcpserver_controller.go
@@ -1218,7 +1218,7 @@ func (r *MCPServerReconciler) deploymentForMCPServer(
 					m.Spec.ResourceOverrides.ProxyDeployment.PodTemplateMetadataOverrides.Labels)
 			}
 			if m.Spec.ResourceOverrides.ProxyDeployment.PodTemplateMetadataOverrides.Annotations != nil {
-				deploymentTemplateAnnotations = ctrlutil.MergeAnnotations(deploymentAnnotations,
+				deploymentTemplateAnnotations = ctrlutil.MergeAnnotations(deploymentTemplateAnnotations,
 					m.Spec.ResourceOverrides.ProxyDeployment.PodTemplateMetadataOverrides.Annotations)
 			}
 		}

--- a/cmd/thv-operator/controllers/mcpserver_resource_overrides_test.go
+++ b/cmd/thv-operator/controllers/mcpserver_resource_overrides_test.go
@@ -26,6 +26,7 @@ import (
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
 	ctrlutil "github.com/stacklok/toolhive/cmd/thv-operator/pkg/controllerutil"
+	checksum "github.com/stacklok/toolhive/cmd/thv-operator/pkg/runconfig/configmap/checksum"
 	"github.com/stacklok/toolhive/pkg/container/kubernetes"
 )
 
@@ -223,6 +224,7 @@ func TestResourceOverrides(t *testing.T) {
 		mcpServer                *mcpv1beta1.MCPServer
 		expectedDeploymentLabels map[string]string
 		expectedDeploymentAnns   map[string]string
+		expectedPodTemplateAnns  map[string]string
 		expectedServiceLabels    map[string]string
 		expectedServiceAnns      map[string]string
 	}{
@@ -246,6 +248,9 @@ func TestResourceOverrides(t *testing.T) {
 				"toolhive-name":              "test-server",
 			},
 			expectedDeploymentAnns: map[string]string{},
+			expectedPodTemplateAnns: map[string]string{
+				"toolhive.stacklok.dev/runconfig-checksum": "test-checksum",
+			},
 			expectedServiceLabels: map[string]string{
 				"app":                        "mcpserver",
 				"app.kubernetes.io/name":     "mcpserver",
@@ -306,6 +311,9 @@ func TestResourceOverrides(t *testing.T) {
 				"custom-annotation": "deployment-annotation",
 				"monitoring/scrape": "true",
 			},
+			expectedPodTemplateAnns: map[string]string{
+				"toolhive.stacklok.dev/runconfig-checksum": "test-checksum",
+			},
 			expectedServiceLabels: map[string]string{
 				"app":                        "mcpserver",
 				"app.kubernetes.io/name":     "mcpserver",
@@ -364,6 +372,9 @@ func TestResourceOverrides(t *testing.T) {
 				"environment":                "test",
 			},
 			expectedDeploymentAnns: map[string]string{},
+			expectedPodTemplateAnns: map[string]string{
+				"toolhive.stacklok.dev/runconfig-checksum": "test-checksum",
+			},
 			expectedServiceLabels: map[string]string{
 				"app":                        "mcpserver",
 				"app.kubernetes.io/name":     "mcpserver",
@@ -400,6 +411,9 @@ func TestResourceOverrides(t *testing.T) {
 				"toolhive-name":              "test-server",
 			},
 			expectedDeploymentAnns: map[string]string{},
+			expectedPodTemplateAnns: map[string]string{
+				"toolhive.stacklok.dev/runconfig-checksum": "test-checksum",
+			},
 			expectedServiceLabels: map[string]string{
 				"app":                        "mcpserver",
 				"app.kubernetes.io/name":     "mcpserver",
@@ -463,6 +477,9 @@ func TestResourceOverrides(t *testing.T) {
 				"monitoring/enabled": "true",
 				"version":            "v1.2.3",
 			},
+			expectedPodTemplateAnns: map[string]string{
+				"toolhive.stacklok.dev/runconfig-checksum": "test-checksum",
+			},
 			expectedServiceLabels: map[string]string{
 				"app":                        "mcpserver",
 				"app.kubernetes.io/name":     "mcpserver",
@@ -504,6 +521,11 @@ func TestResourceOverrides(t *testing.T) {
 				"toolhive-name":              "test-server",
 			},
 			expectedDeploymentAnns: map[string]string{},
+			expectedPodTemplateAnns: map[string]string{
+				"vault.hashicorp.com/agent-inject":         "true",
+				"vault.hashicorp.com/role":                 "toolhive-mcp-workloads",
+				"toolhive.stacklok.dev/runconfig-checksum": "test-checksum",
+			},
 			expectedServiceLabels: map[string]string{
 				"app":                        "mcpserver",
 				"app.kubernetes.io/name":     "mcpserver",
@@ -529,6 +551,8 @@ func TestResourceOverrides(t *testing.T) {
 
 			assert.Equal(t, tt.expectedDeploymentLabels, deployment.Labels)
 			assert.Equal(t, tt.expectedDeploymentAnns, deployment.Annotations)
+			assert.Equal(t, tt.expectedPodTemplateAnns, deployment.Spec.Template.Annotations,
+				"pod template annotations must contain user overrides plus the runconfig-checksum")
 
 			// Test service creation
 			service := r.serviceForMCPServer(t.Context(), tt.mcpServer)
@@ -591,6 +615,83 @@ func TestResourceOverrides(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDeploymentForMCPServer_PodTemplateOverridesPreserveRunConfigChecksum(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	client := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := newTestMCPServerReconciler(client, scheme, kubernetes.PlatformKubernetes)
+
+	mcpServer := &mcpv1beta1.MCPServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-server", Namespace: "default"},
+		Spec: mcpv1beta1.MCPServerSpec{
+			Image: "test:latest",
+			ResourceOverrides: &mcpv1beta1.ResourceOverrides{
+				ProxyDeployment: &mcpv1beta1.ProxyDeploymentOverrides{
+					PodTemplateMetadataOverrides: &mcpv1beta1.ResourceMetadataOverrides{
+						Annotations: map[string]string{
+							"user.example.com/some-key": "value",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	deployment := r.deploymentForMCPServer(t.Context(), mcpServer, "C1")
+	require.NotNil(t, deployment)
+
+	assert.Equal(t, "C1",
+		deployment.Spec.Template.Annotations[checksum.RunConfigChecksumAnnotation],
+		"runconfig-checksum must survive when PodTemplateMetadataOverrides.Annotations is set")
+	assert.Equal(t, "value",
+		deployment.Spec.Template.Annotations["user.example.com/some-key"],
+		"user override must survive")
+	assert.Len(t, deployment.Spec.Template.Annotations, 2,
+		"no extra keys should leak into the pod template")
+}
+
+func TestDeploymentNeedsUpdate_StableAfterBuildWithPodTemplateOverrides(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	client := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := newTestMCPServerReconciler(client, scheme, kubernetes.PlatformKubernetes)
+
+	mcpServer := &mcpv1beta1.MCPServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-server", Namespace: "default"},
+		Spec: mcpv1beta1.MCPServerSpec{
+			Image: "test:latest",
+			ResourceOverrides: &mcpv1beta1.ResourceOverrides{
+				ProxyDeployment: &mcpv1beta1.ProxyDeploymentOverrides{
+					PodTemplateMetadataOverrides: &mcpv1beta1.ResourceMetadataOverrides{
+						Annotations: map[string]string{
+							"vault.hashicorp.com/agent-inject": "true",
+							"vault.hashicorp.com/role":         "toolhive-mcp-workloads",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	const runConfigChecksum = "stable-checksum"
+	built := r.deploymentForMCPServer(t.Context(), mcpServer, runConfigChecksum)
+	require.NotNil(t, built)
+
+	// Constructor and comparator must agree on the same input — otherwise the
+	// operator gets stuck in a perpetual r.Update loop on every reconcile.
+	needsUpdate := r.deploymentNeedsUpdate(t.Context(), built, mcpServer, runConfigChecksum)
+	assert.False(t, needsUpdate,
+		"deploymentNeedsUpdate must report no drift immediately after deploymentForMCPServer with the same checksum and overrides")
 }
 
 func TestMergeStringMaps(t *testing.T) {


### PR DESCRIPTION
## Summary

When a user populates `Spec.ResourceOverrides.ProxyDeployment.PodTemplateMetadataOverrides.Annotations` on an MCPServer (e.g. for Vault Agent injection), `deploymentForMCPServer` was passing the deployment-level annotations map (typically empty) instead of the pod-template annotations map (which already carried the `runconfig-checksum`) as the precedence base when merging in the user overrides. Because `ctrlutil.MergeAnnotations` is first-arg-wins, the checksum was silently dropped from the pod template, breaking the rolling-restart-on-RunConfig-change mechanism for any setup using pod-template overrides. The same asymmetry caused the drift-checker to disagree with the constructor on every reconcile, leaving the operator in a perpetual `r.Update` loop.

This change flips one variable so the merge starts from the pod-template annotations map. The `MCPRemoteProxy` sibling controller already merged correctly; this aligns `MCPServer` with it and with its own drift-checker. Three layers of regression tests are added so the bug class cannot return.

Fixes #5148

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test`) — `cmd/thv-operator/controllers` is green, including the new tests. There is one pre-existing, unrelated failure in `pkg/workloads/manager_test.go` (`TestDefaultManager_ListWorkloadsInGroup/workloads_with_empty_group_names`) that reproduces with this PR's diff reverted, so it is not introduced here.
- [x] Linting (`task lint-fix`) — `0 issues`.

## API Compatibility

- [x] This PR does not break the `v1beta1` API.

## Changes

| File | Change |
|------|--------|
| `cmd/thv-operator/controllers/mcpserver_controller.go` | One-token fix in `deploymentForMCPServer`: pass `deploymentTemplateAnnotations` (which already carries the runconfig-checksum) instead of `deploymentAnnotations` (deployment-level, typically empty) as the precedence base for `MergeAnnotations`. |
| `cmd/thv-operator/controllers/mcpserver_resource_overrides_test.go` | Add `expectedPodTemplateAnns` column to the table-driven test; add `TestDeploymentForMCPServer_PodTemplateOverridesPreserveRunConfigChecksum` (focused regression) and `TestDeploymentNeedsUpdate_StableAfterBuildWithPodTemplateOverrides` (constructor/comparator parity guardrail). |

## Does this introduce a user-facing change?

Yes — bug fix:

- Users with `PodTemplateMetadataOverrides.Annotations` set will now correctly see proxy pods roll on RunConfig changes (telemetry, inline OIDC, external auth refs). Previously these edits silently failed to reach the running proxy.
- Deployment-level annotations supplied via `ProxyDeployment.Annotations` no longer leak into the pod template. No documentation, example, or test in this repository placed sidecar-injection annotations (Vault Agent, Linkerd, Istio) at the deployment level, so no documented user pattern is regressed. Users who need the same key on both levels can set both fields independently.

## Implementation plan

<details>
<summary>Approved implementation plan (AI-assisted)</summary>

Plan summary:

1. **One-token source fix** in `deploymentForMCPServer` to align with the existing comparator and the `MCPRemoteProxy` sibling pattern.
2. **Extend the table-driven test** so every case asserts on `deployment.Spec.Template.Annotations`. Catches missing-checksum and deployment-level-leak regressions in one place.
3. **Focused regression test** named after the contract it pins (checksum survives, user override survives, no extras).
4. **Constructor/comparator parity test** that calls `deploymentForMCPServer` and immediately calls `deploymentNeedsUpdate` with the same checksum, asserting no drift. Long-term guardrail against the asymmetry that caused the perpetual `r.Update` loop.

Each step was implemented separately and reviewed in parallel by go-expert and kubernetes-go-expert agents (Opus). Reviewers verified:

- The pre-fix code had a real, demonstrable bug (verified by tracing `MergeAnnotations` first-arg-wins semantics through the constructor and the comparator).
- Post-fix behavior aligns with the existing comparator, the `MCPRemoteProxy` sibling, and Kubernetes convention (Deployment-level vs pod-template annotations are intentionally separate scopes).
- The Vault integration is unaffected: `examples/operator/vault/mcpserver-github-with-vault.yaml` and `docs/arch/04-secrets-management.md` both place / recommend Vault annotations under `podTemplateMetadataOverrides.annotations` — the field unaffected by the precedence-base swap.

The four implementation commits were squashed for merge.

</details>

## Special notes for reviewers

The fix is one token; the bulk of the diff is regression coverage. The drift-checker `deploymentNeedsUpdate` (~line 1797 in the same file) was already merging in the correct order — the constructor was the outlier. The `MCPRemoteProxyReconciler.buildPodTemplateMetadata` sibling at `cmd/thv-operator/controllers/mcpremoteproxy_deployment.go:328` is the existing correct model.

Optional follow-up out of scope for this PR: `ProxyDeploymentOverrides.PodTemplateMetadataOverrides` in `cmd/thv-operator/api/v1beta1/mcpserver_types.go:373` has no godoc comment (the equivalent in `embeddingserver_types.go:155` does). Adding a comment that explicitly directs users to put sidecar-injection annotations here, not in the embedded `Annotations` field, would close a documentation gap surfaced by the analysis.

Generated with [Claude Code](https://claude.com/claude-code)