### PR TITLE
Fix flaky VirtualMCPServer composite tool watch integration test

### DIFF
--- a/cmd/thv-operator/test-integration/virtualmcp/virtualmcpserver_compositetool_watch_test.go
+++ b/cmd/thv-operator/test-integration/virtualmcp/virtualmcpserver_compositetool_watch_test.go
@@ -157,57 +157,37 @@ var _ = Describe("VirtualMCPServer CompositeToolDefinition Watch Integration Tes
 			}
 			Expect(k8sClient.Create(ctx, compositeToolDef)).Should(Succeed())
 
-			// Wait for VirtualMCPServer to reconcile after the composite tool definition is created
-			// First, wait for the CompositeToolRefsValidated condition to become True
+			// Wait for VirtualMCPServer to reach a stable successful state after the composite
+			// tool definition is created. All conditions are checked atomically in a single
+			// Eventually to avoid races where the controller passes through a transient state
+			// (CompositeToolRefsValidated=True but Phase still=Failed from a prior reconcile)
+			// that satisfies each check individually but not all at once.
 			Eventually(func() bool {
 				updatedVMCP := &mcpv1beta1.VirtualMCPServer{}
-				err := k8sClient.Get(ctx, types.NamespacedName{
+				if err := k8sClient.Get(ctx, types.NamespacedName{
 					Name:      vmcpName,
 					Namespace: namespace,
-				}, updatedVMCP)
-				if err != nil {
+				}, updatedVMCP); err != nil {
 					return false
 				}
 
-				// Check for CompositeToolRefsValidated condition to be True
+				conditionValid := false
 				for _, cond := range updatedVMCP.Status.Conditions {
 					if cond.Type == mcpv1beta1.ConditionTypeCompositeToolRefsValidated {
-						return cond.Status == metav1.ConditionTrue &&
+						conditionValid = cond.Status == metav1.ConditionTrue &&
 							cond.Reason == mcpv1beta1.ConditionReasonCompositeToolRefsValid
+						break
 					}
 				}
-				return false
+
+				phaseOK := updatedVMCP.Status.Phase == mcpv1beta1.VirtualMCPServerPhaseReady ||
+					updatedVMCP.Status.Phase == mcpv1beta1.VirtualMCPServerPhasePending
+
+				return conditionValid &&
+					updatedVMCP.Status.ObservedGeneration > 0 &&
+					updatedVMCP.Status.ObservedGeneration == updatedVMCP.Generation &&
+					phaseOK
 			}, timeout, interval).Should(BeTrue())
-
-			// Then verify that ObservedGeneration is set and matches Generation
-			// This indicates successful reconciliation
-			Eventually(func() bool {
-				updatedVMCP := &mcpv1beta1.VirtualMCPServer{}
-				err := k8sClient.Get(ctx, types.NamespacedName{
-					Name:      vmcpName,
-					Namespace: namespace,
-				}, updatedVMCP)
-				if err != nil {
-					return false
-				}
-
-				// Check that ObservedGeneration is set and matches Generation
-				return updatedVMCP.Status.ObservedGeneration > 0 &&
-					updatedVMCP.Status.ObservedGeneration == updatedVMCP.Generation
-			}, timeout, interval).Should(BeTrue())
-
-			// Verify the VirtualMCPServer is in a valid state
-			updatedVMCP := &mcpv1beta1.VirtualMCPServer{}
-			Expect(k8sClient.Get(ctx, types.NamespacedName{
-				Name:      vmcpName,
-				Namespace: namespace,
-			}, updatedVMCP)).Should(Succeed())
-
-			Expect(updatedVMCP.Status.ObservedGeneration).To(Equal(updatedVMCP.Generation))
-			Expect(updatedVMCP.Status.Phase).To(Or(
-				Equal(mcpv1beta1.VirtualMCPServerPhaseReady),
-				Equal(mcpv1beta1.VirtualMCPServerPhasePending),
-			))
 		})
 	})
 


### PR DESCRIPTION
## Summary

- The `VirtualMCPServer` composite tool watch integration test was intermittently failing on `main` due to a race condition in how it asserted reconciler state. The test had three sequential assertions — two `Eventually` blocks and one direct `Expect` — that could each be satisfied individually by a transient intermediate state produced by the controller: `CompositeToolRefsValidated=True` and `ObservedGeneration=1` but `Phase=Failed`. This happened when `validateCompositeToolRefs` succeeded but a later step in `ensureAllResources` failed (e.g., cache propagation delay for the newly-created composite tool in envtest), leaving `phase=nil` in the `StatusCollector`, which caused `applyStatusUpdates` to preserve the prior `Phase=Failed` from the `BeforeAll` setup. The first two `Eventually` blocks passed on this transient state; the direct `Expect` then saw `Phase=Failed` and failed.
- Replaced the three sequential assertions with a single atomic `Eventually` that checks `CompositeToolRefsValidated=True`, `ObservedGeneration>0 && ==Generation`, and `Phase in (Ready, Pending)` simultaneously, so the test only exits once the controller has reached a fully stable state.

## Type of change

- [x] Bug fix

## Test plan

- [x] Manual testing (describe below)

Traced the failure to the specific transient state by reading the controller's `applyStatusUpdates` + `StatusCollector` and confirmed the race window. The fix ensures the `Eventually` predicate can only return `true` when all conditions hold at the same instant, eliminating the window.

## Special notes for reviewers

The three original `Eventually` blocks were not equivalent to a single atomic one — passing them sequentially was a necessary but insufficient condition for correctness. The controller's `StatusCollector` preserves `Phase` from a prior reconcile when `s.phase == nil`, which is the normal success path for `validateCompositeToolRefs`. This made the transient state `{CompositeToolRefsValidated=True, Phase=Failed}` reachable and stable long enough for the test's sequential checks to pass through it.

Generated with [Claude Code](https://claude.com/claude-code)