### PR TITLE
Set User-Agent on OAuth token refresh requests

### DIFF
--- a/pkg/auth/oauth/flow.go
+++ b/pkg/auth/oauth/flow.go
@@ -503,8 +503,12 @@ func (f *Flow) processToken(_ context.Context, token *oauth2.Token) *TokenResult
 		// Use resourceTokenSource wrapper to add resource parameter to refresh requests (RFC 8707)
 		base = NewResourceTokenSource(f.oauth2Config, token, f.config.Resource)
 	} else {
-		// No resource parameter needed, use standard token source
-		base = f.oauth2Config.TokenSource(context.Background(), token)
+		// No resource parameter needed, use standard token source. Inject an
+		// HTTP client whose transport sets the ToolHive User-Agent so the
+		// oauth2 library does not fall back to Go-http-client/2.0 on token
+		// refresh requests.
+		ctx := context.WithValue(context.Background(), oauth2.HTTPClient, oauthproto.NewHTTPClient())
+		base = f.oauth2Config.TokenSource(ctx, token)
 	}
 
 	// ReuseTokenSource ensures that refresh happens only when needed

--- a/pkg/auth/oauth/non_caching_refresher.go
+++ b/pkg/auth/oauth/non_caching_refresher.go
@@ -13,6 +13,8 @@ import (
 	"time"
 
 	"golang.org/x/oauth2"
+
+	"github.com/stacklok/toolhive/pkg/oauthproto"
 )
 
 // NonCachingRefresher is an oauth2.TokenSource that always performs a network
@@ -47,7 +49,7 @@ func NewNonCachingRefresher(cfg *oauth2.Config, refreshToken, resource string) *
 		cfg:          cfg,
 		resource:     resource,
 		refreshToken: refreshToken,
-		httpClient:   &http.Client{Timeout: 30 * time.Second},
+		httpClient:   oauthproto.NewHTTPClient(),
 	}
 }
 

--- a/pkg/auth/oauth/resource_token_source_test.go
+++ b/pkg/auth/oauth/resource_token_source_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2"
+
+	"github.com/stacklok/toolhive/pkg/oauthproto"
 )
 
 func clientCredentialsFromRequest(r *http.Request) (clientID, clientSecret string) {
@@ -164,6 +166,7 @@ func TestResourceTokenSource_Token_ExpiredToken(t *testing.T) {
 		require.NotNil(t, capturedRequest)
 		assert.Equal(t, "POST", capturedRequest.Method)
 		assert.Equal(t, "application/x-www-form-urlencoded", capturedRequest.Header.Get("Content-Type"))
+		assert.Equal(t, oauthproto.UserAgent, capturedRequest.Header.Get("User-Agent"))
 	})
 
 	t.Run("includes client credentials in refresh request", func(t *testing.T) {

--- a/pkg/auth/remote/persisting_token_source.go
+++ b/pkg/auth/remote/persisting_token_source.go
@@ -12,6 +12,7 @@ import (
 	"golang.org/x/oauth2"
 
 	"github.com/stacklok/toolhive/pkg/auth/oauth"
+	"github.com/stacklok/toolhive/pkg/oauthproto"
 )
 
 // TokenPersister is a callback function that persists OAuth refresh tokens.
@@ -98,7 +99,11 @@ func CreateTokenSourceFromCached(
 	if resource != "" {
 		base = oauth.NewResourceTokenSource(config, token, resource)
 	} else {
-		base = config.TokenSource(context.TODO(), token)
+		// Inject an HTTP client whose transport sets the ToolHive User-Agent
+		// so the oauth2 library does not fall back to Go-http-client/2.0 on
+		// token refresh requests.
+		ctx := context.WithValue(context.Background(), oauth2.HTTPClient, oauthproto.NewHTTPClient())
+		base = config.TokenSource(ctx, token)
 	}
 
 	return oauth2.ReuseTokenSource(token, base)

--- a/pkg/auth/remote/persisting_token_source_test.go
+++ b/pkg/auth/remote/persisting_token_source_test.go
@@ -4,7 +4,10 @@
 package remote
 
 import (
+	"encoding/json"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -12,6 +15,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2"
+
+	"github.com/stacklok/toolhive/pkg/oauthproto"
 )
 
 // mockTokenSource is a test implementation of oauth2.TokenSource
@@ -237,4 +242,53 @@ func TestCreateTokenSourceFromCached(t *testing.T) {
 	)
 
 	assert.NotNil(t, tokenSource)
+}
+
+// TestCreateTokenSourceFromCached_SetsUserAgent verifies that token refresh
+// requests carry the ToolHive User-Agent header for both the standard and
+// resource-aware (RFC 8707) refresh paths. Without this, the oauth2 library
+// falls back to Go-http-client/2.0, which makes ToolHive traffic indistinguishable
+// from generic Go programs at the server side.
+func TestCreateTokenSourceFromCached_SetsUserAgent(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		resource string
+	}{
+		{name: "standard refresh", resource: ""},
+		{name: "resource-aware refresh", resource: "https://api.example.com"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var capturedUserAgent string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				capturedUserAgent = r.Header.Get("User-Agent")
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"access_token":  "new-access-token",
+					"refresh_token": "new-refresh-token",
+					"token_type":    "Bearer",
+					"expires_in":    3600,
+				})
+			}))
+			t.Cleanup(server.Close)
+
+			cfg := &oauth2.Config{
+				ClientID:     "test-client",
+				ClientSecret: "test-secret",
+				Endpoint:     oauth2.Endpoint{TokenURL: server.URL},
+			}
+
+			ts := CreateTokenSourceFromCached(cfg, "old-refresh-token", time.Now().Add(-time.Hour), tt.resource)
+
+			tok, err := ts.Token()
+			require.NoError(t, err)
+			require.NotNil(t, tok)
+			assert.Equal(t, oauthproto.UserAgent, capturedUserAgent)
+		})
+	}
 }

--- a/pkg/oauthproto/useragent.go
+++ b/pkg/oauthproto/useragent.go
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package oauthproto
+
+import (
+	"net/http"
+	"time"
+)
+
+// httpClientTimeout matches the timeout already used by NonCachingRefresher's
+// http.Client and is appropriate for OAuth token endpoints, which respond
+// quickly under healthy conditions.
+const httpClientTimeout = 30 * time.Second
+
+// UserAgentTransport is an http.RoundTripper that adds the ToolHive User-Agent
+// header to outbound requests when no User-Agent is already set.
+//
+// It is intended for HTTP clients passed to golang.org/x/oauth2 via the
+// oauth2.HTTPClient context value. Without it, the library falls back to
+// http.DefaultClient and Go's default Go-http-client/2.0 User-Agent, which
+// upstream servers and WAFs cannot attribute to ToolHive.
+type UserAgentTransport struct {
+	// Base is the underlying RoundTripper. If nil, http.DefaultTransport is used.
+	Base http.RoundTripper
+}
+
+// RoundTrip implements http.RoundTripper. It clones the request before
+// mutating headers, per the RoundTripper contract, and sets User-Agent only
+// when the request has no User-Agent set so that callers layering another
+// transport can override the value.
+func (t *UserAgentTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	base := t.Base
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	clonedReq := req.Clone(req.Context())
+	if clonedReq.Header == nil {
+		clonedReq.Header = make(http.Header)
+	}
+	if clonedReq.Header.Get("User-Agent") == "" {
+		clonedReq.Header.Set("User-Agent", UserAgent)
+	}
+	return base.RoundTrip(clonedReq)
+}
+
+// NewHTTPClient returns an *http.Client whose transport sets the ToolHive
+// User-Agent on every outbound request and that has a sensible timeout for
+// OAuth token endpoint calls. Use it for HTTP clients passed to
+// golang.org/x/oauth2 via the oauth2.HTTPClient context value.
+func NewHTTPClient() *http.Client {
+	return &http.Client{
+		Transport: &UserAgentTransport{},
+		Timeout:   httpClientTimeout,
+	}
+}

--- a/pkg/oauthproto/useragent_test.go
+++ b/pkg/oauthproto/useragent_test.go
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package oauthproto
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// recordingRoundTripper captures the User-Agent header from every request it
+// sees and returns a 200 response.
+type recordingRoundTripper struct {
+	userAgents []string
+}
+
+func (r *recordingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	r.userAgents = append(r.userAgents, req.Header.Get("User-Agent"))
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       http.NoBody,
+		Header:     make(http.Header),
+		Request:    req,
+	}, nil
+}
+
+func TestUserAgentTransport_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		incomingUserAgent string
+		wantUserAgent     string
+	}{
+		{
+			name:              "sets User-Agent when missing",
+			incomingUserAgent: "",
+			wantUserAgent:     UserAgent,
+		},
+		{
+			name:              "preserves caller-provided User-Agent",
+			incomingUserAgent: "custom-client/2.5",
+			wantUserAgent:     "custom-client/2.5",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			recorder := &recordingRoundTripper{}
+			transport := &UserAgentTransport{Base: recorder}
+
+			req, err := http.NewRequest(http.MethodGet, "https://example.test/", nil)
+			require.NoError(t, err)
+			if tt.incomingUserAgent != "" {
+				req.Header.Set("User-Agent", tt.incomingUserAgent)
+			}
+			originalIncomingUA := req.Header.Get("User-Agent")
+
+			resp, err := transport.RoundTrip(req)
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+
+			require.Len(t, recorder.userAgents, 1)
+			assert.Equal(t, tt.wantUserAgent, recorder.userAgents[0])
+
+			// The RoundTripper contract requires that RoundTrip not mutate
+			// the caller's *http.Request. Verify the User-Agent the caller
+			// set (or didn't set) is unchanged on the original request.
+			assert.Equal(t, originalIncomingUA, req.Header.Get("User-Agent"), "caller's User-Agent was mutated")
+		})
+	}
+}
+
+// TestUserAgentTransport_NilBase verifies that a UserAgentTransport with no
+// Base falls back to http.DefaultTransport. We exercise this by sending a real
+// request through an httptest.Server (not just a recorder, since the recorder
+// would short-circuit the Base lookup).
+func TestUserAgentTransport_NilBase(t *testing.T) {
+	t.Parallel()
+
+	var got string
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		got = r.Header.Get("User-Agent")
+	}))
+	t.Cleanup(server.Close)
+
+	client := &http.Client{Transport: &UserAgentTransport{}}
+	resp, err := client.Get(server.URL)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = resp.Body.Close() })
+
+	assert.Equal(t, UserAgent, got)
+}


### PR DESCRIPTION
## Summary

- ToolHive sets `User-Agent: ToolHive/1.0` on the OAuth/OIDC requests it constructs directly (DCR, discovery, token introspection, GitHub provider), but token refresh requests go through `golang.org/x/oauth2` and fall back to Go's default `Go-http-client/<version>` User-Agent. Server operators investigating WAF blocks, rate limits, or IP allowlists cannot identify the traffic as ToolHive, and `Go-http-client/*` is itself a common bot-detection signal that may trigger false positives.
- Adds `oauthproto.UserAgentTransport` (an `http.RoundTripper` that sets the ToolHive User-Agent when one is not already set) and `oauthproto.NewHTTPClient()` (a small constructor that bundles the transport with a 30s timeout).
- Wires the helper into the three call sites that construct a refreshing `oauth2.TokenSource`: `pkg/auth/oauth/non_caching_refresher.go`, `pkg/auth/oauth/flow.go`, and `pkg/auth/remote/persisting_token_source.go`.

Fixes #5167

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test`) — including a new `TestUserAgentTransport_RoundTrip` table test, a new `TestUserAgentTransport_NilBase` round-trip test, an extra `User-Agent` assertion on the existing `TestResourceTokenSource_Token_ExpiredToken`, and a new `TestCreateTokenSourceFromCached_SetsUserAgent` covering both refresh paths.
- [x] Linting (`task lint-fix`)
- [x] Manual testing — built `thv` from this branch and ran a standalone harness that imports `pkg/auth/remote.CreateTokenSourceFromCached` against an `httptest.Server` and captures the User-Agent on the wire. On `main` (8c90184f) both refresh paths emit `Go-http-client/1.1`; on this branch both emit `ToolHive/1.0`.

## API Compatibility

- [x] This PR does not break the `v1beta1` API, OR the `api-break-allowed` label is applied and the migration guidance is described above.

## Does this introduce a user-facing change?

OAuth token refresh requests now advertise `User-Agent: ToolHive/1.0` instead of Go's default `Go-http-client/<version>`. Operators of upstream IdPs can identify ToolHive traffic in logs, WAF rules, and rate-limit dashboards.

## Implementation plan

<details>
<summary>Approved implementation plan</summary>

**Helper** — `pkg/oauthproto/useragent.go`:
- `UserAgentTransport` struct with a public `Base http.RoundTripper` field (mirrors stdlib `http.Transport` and `oauth2.Transport` shape). Nil `Base` falls back to `http.DefaultTransport`. `RoundTrip` clones the request before mutating headers (per the RoundTripper contract) and sets `User-Agent` only when not already set, so layered transports can override.
- `NewHTTPClient()` returns an `*http.Client` whose transport is `&UserAgentTransport{}` and whose `Timeout` is `30 * time.Second`. Used at all three call sites to lock in a single timeout invariant.

**Wire-up** — three call sites:
- `pkg/auth/oauth/non_caching_refresher.go` — `httpClient: oauthproto.NewHTTPClient()` on the `NonCachingRefresher` struct. Covers both standard and RFC 8707 resource-aware refresh (the refresher injects this client via `oauth2.HTTPClient` context value before each refresh). This also covers `pkg/auth/oauth/resource_token_source.go`, which delegates to `NonCachingRefresher`.
- `pkg/auth/oauth/flow.go` (`processToken` non-resource branch) — build a `*http.Client` via `oauthproto.NewHTTPClient()` and inject it via `oauth2.HTTPClient` into the context passed to `oauth2Config.TokenSource`. Preserves the existing `context.Background()` reasoning (the OAuth callback ctx is cancelled when the callback server shuts down).
- `pkg/auth/remote/persisting_token_source.go` (`CreateTokenSourceFromCached` non-resource branch) — same pattern; replaces the previous `context.TODO()`.

**Why the helper lives in `pkg/oauthproto`:** co-located with the existing `oauthproto.UserAgent` constant; the package already owns "set the ToolHive UA on outbound OAuth requests" via `pkg/oauthproto/dcr.go` and `pkg/oauthproto/discovery.go`. A future PR that fixes non-OAuth gaps (e.g. webhook delivery, transparent proxy health checks, etc.) can import the transport from here or move it to `pkg/networking` if that ends up being the better long-term home.

</details>

## Special notes for reviewers

- The doc comment on `UserAgentTransport` calls out the WAF/attribution motivation so the rationale is durable in the source.
- `TestUserAgentTransport_NilBase` exercises the `nil → http.DefaultTransport` fallback through a real `httptest.Server` round-trip rather than relying on a recorder, since a recorder would mask the fallback.
- The standalone refresh paths are covered, but I deliberately did not add a dedicated unit test for `flow.go`'s `processToken` change — that path requires a full OAuth callback flow to exercise. The `non_caching_refresher` and `persisting_token_source` tests verify the transport behavior; the `flow.go` wire-up is the same three-line pattern.
- The fix is scoped to the OAuth token refresh path. ToolHive has other outbound HTTP code paths that are also missing the User-Agent (e.g. `pkg/auth/discovery`, `pkg/authserver/upstream`, `pkg/webhook`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
