### PR TITLE
Automate Gemini CLI .env injection for LLM gateway proxy setup

### DIFF
--- a/cmd/thv/app/llm.go
+++ b/cmd/thv/app/llm.go
@@ -384,8 +384,12 @@ func (a *clientManagerAdapter) LLMGatewayModeFor(clientType string) string {
 	return a.cm.LLMGatewayModeFor(client.ClientApp(clientType))
 }
 
-func (a *clientManagerAdapter) LLMSetupNoteFor(clientType string) string {
-	return a.cm.LLMSetupNoteFor(client.ClientApp(clientType))
+func (a *clientManagerAdapter) ConfigureEnvFile(clientType string, cfg llmgateway.ApplyConfig) (string, error) {
+	return a.cm.ConfigureEnvFile(client.ClientApp(clientType), cfg)
+}
+
+func (a *clientManagerAdapter) RevertEnvFile(clientType, envFilePath string) error {
+	return a.cm.RevertEnvFile(client.ClientApp(clientType), envFilePath)
 }
 
 func (a *clientManagerAdapter) RevertLLMGateway(clientType, configPath string) error {

--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -184,6 +184,21 @@ type LLMGatewayKeySpec struct {
 	ClearWhenEmpty bool   // remove the key when the resolved value is empty (ignored for Literal)
 }
 
+// LLMEnvFileKeySpec describes a single KEY=value entry to write to a dotenv
+// file when configuring (or reverting) LLM gateway access for a tool.
+//
+// Exactly one of ValueField or Literal must be set. ValueField semantics are
+// identical to LLMGatewayKeySpec.ValueField.
+type LLMEnvFileKeySpec struct {
+	// Name is the environment variable name (e.g. "GEMINI_API_KEY").
+	Name string
+	// ValueField names which ApplyConfig field to resolve. Valid values are the
+	// same as LLMGatewayKeySpec.ValueField. Mutually exclusive with Literal.
+	ValueField string
+	// Literal is written verbatim as the variable value. Mutually exclusive with ValueField.
+	Literal string
+}
+
 // clientAppConfig represents a configuration path for a supported MCP client.
 type clientAppConfig struct {
 	ClientType                    ClientApp
@@ -236,10 +251,15 @@ type clientAppConfig struct {
 	// LLMGatewayKeys lists the JSON Pointer paths and value-field mappings to
 	// apply when setting up (or reverting) LLM gateway access.
 	LLMGatewayKeys []LLMGatewayKeySpec
-	// LLMSetupNote is an optional message printed to stdout after a successful
-	// "thv llm setup" for this client. Use it to surface manual steps that
-	// toolhive cannot automate (e.g. env vars the tool reads from a .env file).
-	LLMSetupNote string
+	// LLMEnvFileRelPath is the path segments from home dir to the directory
+	// containing the .env file to manage for LLM gateway (e.g. []string{".gemini"}).
+	// Empty means this client has no .env file to manage.
+	LLMEnvFileRelPath []string
+	// LLMEnvFileName is the filename of the .env file (e.g. ".env").
+	LLMEnvFileName string
+	// LLMEnvFileKeys lists the key=value entries to write to the .env file when
+	// setting up (or reverting) LLM gateway access.
+	LLMEnvFileKeys []LLMEnvFileKeySpec
 }
 
 // extractServersKeyFromConfig extracts the servers key from MCPServersPathPrefix
@@ -874,11 +894,14 @@ var supportedClientIntegrations = []clientAppConfig{
 		LLMGatewayKeys: []LLMGatewayKeySpec{
 			// Force API-key auth so GOOGLE_GEMINI_BASE_URL is respected.
 			{JSONPointer: "/security/auth/selectedType", Literal: "gemini-api-key"},
-			// Placeholder API key (proxy does not validate it).
-			{JSONPointer: "/env/GEMINI_API_KEY", Literal: llmPlaceholderAPIKey},
-			// Proxy origin for Gemini CLI; path is stripped because Gemini
-			// CLI appends its own /v1beta/... path to the base URL.
-			{JSONPointer: "/env/GOOGLE_GEMINI_BASE_URL", ValueField: "ProxyOrigin"},
+		},
+		// Gemini CLI reads GEMINI_API_KEY and GOOGLE_GEMINI_BASE_URL from
+		// process.env (not from settings.json), so they are injected via .env.
+		LLMEnvFileRelPath: []string{".gemini"},
+		LLMEnvFileName:    ".env",
+		LLMEnvFileKeys: []LLMEnvFileKeySpec{
+			{Name: "GEMINI_API_KEY", Literal: llmPlaceholderAPIKey},
+			{Name: "GOOGLE_GEMINI_BASE_URL", ValueField: "ProxyOrigin"},
 		},
 	},
 	{

--- a/pkg/client/env_file.go
+++ b/pkg/client/env_file.go
@@ -1,0 +1,206 @@
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package client
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/stacklok/toolhive/pkg/fileutils"
+	"github.com/stacklok/toolhive/pkg/llmgateway"
+)
+
+// ConfigureEnvFile writes the client's LLM env-file entries to the nominated
+// dotenv file (e.g. ~/.gemini/.env). Existing entries for other keys are
+// preserved; entries managed by thv are added or updated.
+//
+// Returns the absolute path of the written file, or ("", nil) when the client
+// has no env-file entries configured.
+func (cm *ClientManager) ConfigureEnvFile(clientType ClientApp, cfg llmgateway.ApplyConfig) (string, error) {
+	appCfg := cm.lookupClientAppConfig(clientType)
+	if appCfg == nil || len(appCfg.LLMEnvFileKeys) == 0 {
+		return "", nil
+	}
+
+	path := cm.buildEnvFilePath(appCfg)
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return "", fmt.Errorf("creating directory for %s: %w", path, err)
+	}
+
+	err := fileutils.WithFileLock(path, func() error {
+		content, err := readOrInitFile(path, nil)
+		if err != nil {
+			return err
+		}
+
+		entries := parseEnvFile(content)
+
+		for _, spec := range appCfg.LLMEnvFileKeys {
+			val, err := envFileValueForSpec(spec, cfg)
+			if err != nil {
+				return err
+			}
+			entries = setEnvEntry(entries, spec.Name, val)
+		}
+
+		return fileutils.AtomicWriteFile(path, marshalEnvFile(entries), 0o600)
+	})
+	if err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+// RevertEnvFile removes the entries that ConfigureEnvFile wrote for clientType
+// from the nominated dotenv file. Other entries in the file are preserved.
+// If the file does not exist the call is a no-op.
+func (cm *ClientManager) RevertEnvFile(clientType ClientApp, envFilePath string) error {
+	appCfg := cm.lookupClientAppConfig(clientType)
+	if appCfg == nil || len(appCfg.LLMEnvFileKeys) == 0 {
+		return nil
+	}
+	if envFilePath == "" {
+		return nil
+	}
+
+	if _, err := os.Stat(envFilePath); os.IsNotExist(err) {
+		return nil
+	}
+
+	return fileutils.WithFileLock(envFilePath, func() error {
+		content, err := os.ReadFile(envFilePath) // #nosec G304 -- path is a known tool config file
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return fmt.Errorf("reading %s: %w", envFilePath, err)
+		}
+
+		entries := parseEnvFile(content)
+		for _, spec := range appCfg.LLMEnvFileKeys {
+			entries = removeEnvEntry(entries, spec.Name)
+		}
+
+		return fileutils.AtomicWriteFile(envFilePath, marshalEnvFile(entries), 0o600)
+	})
+}
+
+// buildEnvFilePath constructs the absolute path to the .env file for the
+// given client, using the same home-dir convention as LLM settings paths.
+func (cm *ClientManager) buildEnvFilePath(cfg *clientAppConfig) string {
+	return buildConfigFilePath(
+		cfg.LLMEnvFileName,
+		cfg.LLMEnvFileRelPath,
+		nil, // no platform prefix for env files
+		[]string{cm.homeDir},
+	)
+}
+
+// HasEnvFileSupport reports whether clientType has .env file entries to manage.
+func (cm *ClientManager) HasEnvFileSupport(clientType ClientApp) bool {
+	cfg := cm.lookupClientAppConfig(clientType)
+	return cfg != nil && len(cfg.LLMEnvFileKeys) > 0
+}
+
+// envFileValueForSpec resolves the value to write for a single LLMEnvFileKeySpec.
+// Exactly one of spec.Literal or spec.ValueField must be set.
+func envFileValueForSpec(spec LLMEnvFileKeySpec, cfg llmgateway.ApplyConfig) (string, error) {
+	if spec.Literal != "" && spec.ValueField != "" {
+		return "", fmt.Errorf("LLMEnvFileKeySpec for %q has both Literal and ValueField set; exactly one must be set", spec.Name)
+	}
+	if spec.Literal == "" && spec.ValueField == "" {
+		return "", fmt.Errorf("LLMEnvFileKeySpec for %q has neither Literal nor ValueField set; exactly one must be set", spec.Name)
+	}
+	if spec.Literal != "" {
+		return spec.Literal, nil
+	}
+	if v, ok := resolveApplyConfigField(spec.ValueField, cfg); ok {
+		return v, nil
+	}
+	return "", fmt.Errorf("unknown ValueField %q in LLMEnvFileKeySpec for %q; use Literal for constant values",
+		spec.ValueField, spec.Name)
+}
+
+// envEntry is an ordered KEY=value entry in a dotenv file. Comments and blank
+// lines are stored verbatim so that round-tripping preserves formatting.
+type envEntry struct {
+	raw   string // raw line for comments / blank lines (when key == "")
+	key   string // non-empty for KEY=value lines
+	value string
+}
+
+// parseEnvFile parses the content of a dotenv file into an ordered list of
+// entries. Comments, blank lines, and malformed lines (no "=") are stored as
+// raw entries so they survive a round-trip through marshalEnvFile.
+func parseEnvFile(content []byte) []envEntry {
+	var entries []envEntry
+	// bytes.SplitSeq handles arbitrarily long lines since content is already in
+	// memory; bufio.Scanner would error on lines longer than its 64 KiB limit.
+	// Trim trailing newlines first so an empty or newline-only file produces no
+	// entries, and to avoid a spurious empty token after the final newline.
+	trimmed := bytes.TrimRight(content, "\r\n")
+	if len(trimmed) == 0 {
+		return entries
+	}
+	for rawLine := range bytes.SplitSeq(trimmed, []byte("\n")) {
+		// Strip \r to handle CRLF files.
+		line := string(bytes.TrimRight(rawLine, "\r"))
+		if line == "" || strings.HasPrefix(line, "#") {
+			entries = append(entries, envEntry{raw: line})
+			continue
+		}
+		key, value, found := strings.Cut(line, "=")
+		if !found {
+			// Malformed line — preserve as raw.
+			entries = append(entries, envEntry{raw: line})
+			continue
+		}
+		entries = append(entries, envEntry{key: key, value: value})
+	}
+	return entries
+}
+
+// marshalEnvFile serialises entries back to a dotenv-formatted byte slice.
+// A trailing newline is always appended.
+func marshalEnvFile(entries []envEntry) []byte {
+	var b bytes.Buffer
+	for _, e := range entries {
+		if e.key == "" {
+			b.WriteString(e.raw)
+		} else {
+			b.WriteString(e.key)
+			b.WriteByte('=')
+			b.WriteString(e.value)
+		}
+		b.WriteByte('\n')
+	}
+	return b.Bytes()
+}
+
+// setEnvEntry updates the value for key in entries, or appends a new entry if
+// key is not present. Returns the (possibly grown) slice.
+func setEnvEntry(entries []envEntry, key, value string) []envEntry {
+	for i, e := range entries {
+		if e.key == key {
+			entries[i].value = value
+			return entries
+		}
+	}
+	return append(entries, envEntry{key: key, value: value})
+}
+
+// removeEnvEntry removes the entry with the given key from entries (if any).
+func removeEnvEntry(entries []envEntry, key string) []envEntry {
+	result := entries[:0:len(entries)]
+	for _, e := range entries {
+		if e.key != key {
+			result = append(result, e)
+		}
+	}
+	return result
+}

--- a/pkg/client/env_file_test.go
+++ b/pkg/client/env_file_test.go
@@ -1,0 +1,248 @@
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package client
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stacklok/toolhive/pkg/llmgateway"
+)
+
+// ── parseEnvFile / marshalEnvFile ─────────────────────────────────────────────
+
+func TestParseEnvFile_Empty(t *testing.T) {
+	t.Parallel()
+	entries := parseEnvFile(nil)
+	assert.Empty(t, entries)
+}
+
+func TestParseEnvFile_KeyValueLines(t *testing.T) {
+	t.Parallel()
+	content := []byte("FOO=bar\nBAZ=qux\n")
+	entries := parseEnvFile(content)
+	require.Len(t, entries, 2)
+	assert.Equal(t, "FOO", entries[0].key)
+	assert.Equal(t, "bar", entries[0].value)
+	assert.Equal(t, "BAZ", entries[1].key)
+	assert.Equal(t, "qux", entries[1].value)
+}
+
+func TestParseEnvFile_CommentsAndBlanks(t *testing.T) {
+	t.Parallel()
+	content := []byte("# comment\n\nFOO=bar\n")
+	entries := parseEnvFile(content)
+	require.Len(t, entries, 3)
+	assert.Equal(t, "# comment", entries[0].raw)
+	assert.Equal(t, "", entries[1].raw) // blank line
+	assert.Equal(t, "FOO", entries[2].key)
+}
+
+func TestParseEnvFile_MalformedLinePreserved(t *testing.T) {
+	t.Parallel()
+	content := []byte("NOT_VALID_LINE\nFOO=bar\n")
+	entries := parseEnvFile(content)
+	require.Len(t, entries, 2)
+	assert.Equal(t, "NOT_VALID_LINE", entries[0].raw)
+	assert.Equal(t, "FOO", entries[1].key)
+}
+
+func TestParseEnvFile_ValueWithEquals(t *testing.T) {
+	t.Parallel()
+	// Values may contain '=' (e.g. base64-encoded tokens).
+	content := []byte("KEY=abc=xyz\n")
+	entries := parseEnvFile(content)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "KEY", entries[0].key)
+	assert.Equal(t, "abc=xyz", entries[0].value)
+}
+
+func TestMarshalEnvFile_RoundTrip(t *testing.T) {
+	t.Parallel()
+	original := []byte("# header\nFOO=bar\nBAZ=qux\n")
+	entries := parseEnvFile(original)
+	got := marshalEnvFile(entries)
+	assert.Equal(t, string(original), string(got))
+}
+
+// ── setEnvEntry / removeEnvEntry ──────────────────────────────────────────────
+
+func TestSetEnvEntry_AddsNew(t *testing.T) {
+	t.Parallel()
+	entries := setEnvEntry(nil, "KEY", "value")
+	require.Len(t, entries, 1)
+	assert.Equal(t, "KEY", entries[0].key)
+	assert.Equal(t, "value", entries[0].value)
+}
+
+func TestSetEnvEntry_UpdatesExisting(t *testing.T) {
+	t.Parallel()
+	entries := []envEntry{{key: "KEY", value: "old"}}
+	entries = setEnvEntry(entries, "KEY", "new")
+	require.Len(t, entries, 1)
+	assert.Equal(t, "new", entries[0].value)
+}
+
+func TestRemoveEnvEntry_RemovesKey(t *testing.T) {
+	t.Parallel()
+	entries := []envEntry{{key: "KEEP", value: "1"}, {key: "REMOVE", value: "2"}}
+	entries = removeEnvEntry(entries, "REMOVE")
+	require.Len(t, entries, 1)
+	assert.Equal(t, "KEEP", entries[0].key)
+}
+
+func TestRemoveEnvEntry_NoopWhenMissing(t *testing.T) {
+	t.Parallel()
+	entries := []envEntry{{key: "KEEP", value: "1"}}
+	entries = removeEnvEntry(entries, "MISSING")
+	require.Len(t, entries, 1)
+}
+
+// ── ConfigureEnvFile ──────────────────────────────────────────────────────────
+
+func TestConfigureEnvFile_CreatesFile(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	cm := NewTestClientManager(dir, nil, supportedClientIntegrations, nil)
+
+	_, err := cm.ConfigureEnvFile(GeminiCli, llmgateway.ApplyConfig{
+		ProxyBaseURL: "http://localhost:14000/v1",
+	})
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(filepath.Join(dir, ".gemini", ".env"))
+	require.NoError(t, err)
+	content := string(data)
+	assert.Contains(t, content, "GEMINI_API_KEY=thv-proxy\n")
+	assert.Contains(t, content, "GOOGLE_GEMINI_BASE_URL=http://localhost:14000\n")
+}
+
+func TestConfigureEnvFile_UpdatesExistingFile(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	geminiDir := filepath.Join(dir, ".gemini")
+	require.NoError(t, os.MkdirAll(geminiDir, 0o700))
+	existing := "# user comment\nOTHER_VAR=keep\nGOOGLE_GEMINI_BASE_URL=old\n"
+	require.NoError(t, os.WriteFile(filepath.Join(geminiDir, ".env"), []byte(existing), 0o600))
+
+	cm := NewTestClientManager(dir, nil, supportedClientIntegrations, nil)
+	_, err := cm.ConfigureEnvFile(GeminiCli, llmgateway.ApplyConfig{
+		ProxyBaseURL: "http://localhost:14000/v1",
+	})
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(filepath.Join(geminiDir, ".env"))
+	require.NoError(t, err)
+	content := string(data)
+	// Original entries preserved.
+	assert.Contains(t, content, "# user comment\n")
+	assert.Contains(t, content, "OTHER_VAR=keep\n")
+	// thv-managed entries written or updated.
+	assert.Contains(t, content, "GEMINI_API_KEY=thv-proxy\n")
+	assert.Contains(t, content, "GOOGLE_GEMINI_BASE_URL=http://localhost:14000\n")
+	// Old value replaced (not duplicated).
+	assert.NotContains(t, content, "GOOGLE_GEMINI_BASE_URL=old")
+}
+
+func TestConfigureEnvFile_NoopForClientWithoutEnvKeys(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	cm := NewTestClientManager(dir, nil, supportedClientIntegrations, nil)
+
+	// Claude Code has no LLMEnvFileKeys → returns ("", nil).
+	path, err := cm.ConfigureEnvFile(ClaudeCode, llmgateway.ApplyConfig{})
+	require.NoError(t, err)
+	assert.Empty(t, path)
+}
+
+// ── RevertEnvFile ─────────────────────────────────────────────────────────────
+
+func TestRevertEnvFile_RemovesEntries(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	geminiDir := filepath.Join(dir, ".gemini")
+	require.NoError(t, os.MkdirAll(geminiDir, 0o700))
+	initial := "OTHER_VAR=keep\nGEMINI_API_KEY=thv-proxy\nGOOGLE_GEMINI_BASE_URL=http://localhost:14000\n"
+	envPath := filepath.Join(geminiDir, ".env")
+	require.NoError(t, os.WriteFile(envPath, []byte(initial), 0o600))
+
+	cm := NewTestClientManager(dir, nil, supportedClientIntegrations, nil)
+	require.NoError(t, cm.RevertEnvFile(GeminiCli, envPath))
+
+	data, err := os.ReadFile(envPath)
+	require.NoError(t, err)
+	content := string(data)
+	assert.Contains(t, content, "OTHER_VAR=keep\n")
+	assert.NotContains(t, content, "GEMINI_API_KEY")
+	assert.NotContains(t, content, "GOOGLE_GEMINI_BASE_URL")
+}
+
+func TestRevertEnvFile_NoopWhenFileMissing(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	cm := NewTestClientManager(dir, nil, supportedClientIntegrations, nil)
+	// File does not exist — must not return an error.
+	require.NoError(t, cm.RevertEnvFile(GeminiCli, filepath.Join(dir, ".gemini", ".env")))
+}
+
+func TestRevertEnvFile_NoopWhenPathEmpty(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	cm := NewTestClientManager(dir, nil, supportedClientIntegrations, nil)
+	require.NoError(t, cm.RevertEnvFile(GeminiCli, ""))
+}
+
+// ── envFileValueForSpec ───────────────────────────────────────────────────────
+
+func TestEnvFileValueForSpec_Literal(t *testing.T) {
+	t.Parallel()
+	spec := LLMEnvFileKeySpec{Name: "KEY", Literal: "constant"}
+	val, err := envFileValueForSpec(spec, llmgateway.ApplyConfig{})
+	require.NoError(t, err)
+	assert.Equal(t, "constant", val)
+}
+
+func TestEnvFileValueForSpec_ProxyOrigin(t *testing.T) {
+	t.Parallel()
+	spec := LLMEnvFileKeySpec{Name: "KEY", ValueField: "ProxyOrigin"}
+	val, err := envFileValueForSpec(spec, llmgateway.ApplyConfig{ProxyBaseURL: "http://localhost:14000/v1"})
+	require.NoError(t, err)
+	assert.Equal(t, "http://localhost:14000", val)
+}
+
+func TestEnvFileValueForSpec_PlaceholderAPIKey(t *testing.T) {
+	t.Parallel()
+	spec := LLMEnvFileKeySpec{Name: "KEY", ValueField: "PlaceholderAPIKey"}
+	val, err := envFileValueForSpec(spec, llmgateway.ApplyConfig{})
+	require.NoError(t, err)
+	assert.Equal(t, llmPlaceholderAPIKey, val)
+}
+
+func TestEnvFileValueForSpec_UnknownFieldReturnsError(t *testing.T) {
+	t.Parallel()
+	spec := LLMEnvFileKeySpec{Name: "KEY", ValueField: "NotAField"}
+	_, err := envFileValueForSpec(spec, llmgateway.ApplyConfig{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "NotAField")
+}
+
+func TestEnvFileValueForSpec_BothSetReturnsError(t *testing.T) {
+	t.Parallel()
+	spec := LLMEnvFileKeySpec{Name: "KEY", Literal: "val", ValueField: "GatewayURL"}
+	_, err := envFileValueForSpec(spec, llmgateway.ApplyConfig{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "both Literal and ValueField")
+}
+
+func TestEnvFileValueForSpec_NeitherSetReturnsError(t *testing.T) {
+	t.Parallel()
+	spec := LLMEnvFileKeySpec{Name: "KEY"}
+	_, err := envFileValueForSpec(spec, llmgateway.ApplyConfig{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "neither Literal nor ValueField")
+}

--- a/pkg/client/llm_gateway.go
+++ b/pkg/client/llm_gateway.go
@@ -47,7 +47,7 @@ func (cm *ClientManager) ConfigureLLMGateway(clientType ClientApp, cfg llmgatewa
 	}
 
 	err := fileutils.WithFileLock(path, func() error {
-		content, err := readOrInit(path)
+		content, err := readOrInitFile(path, []byte("{}"))
 		if err != nil {
 			return err
 		}
@@ -84,11 +84,15 @@ func applyLLMGatewayKeys(v *hujson.Value, specs []LLMGatewayKeySpec, cfg llmgate
 	// any file is modified.
 	values := make([]string, len(specs))
 	for i, spec := range specs {
-		val, err := llmValueForSpec(spec, cfg)
-		if err != nil {
-			return err
+		if spec.Literal != "" {
+			values[i] = spec.Literal
+		} else {
+			v, err := llmValueForSpec(spec.ValueField, cfg)
+			if err != nil {
+				return err
+			}
+			values[i] = v
 		}
-		values[i] = val
 	}
 
 	// Ensure ancestors only for specs that will be written (not removed).
@@ -230,15 +234,6 @@ func (cm *ClientManager) LLMGatewayModeFor(clientType ClientApp) string {
 	return cfg.LLMGatewayMode
 }
 
-// LLMSetupNoteFor returns the post-setup note for clientType, or "" if none.
-func (cm *ClientManager) LLMSetupNoteFor(clientType ClientApp) string {
-	cfg := cm.lookupClientAppConfig(clientType)
-	if cfg == nil {
-		return ""
-	}
-	return cfg.LLMSetupNote
-}
-
 // DetectedLLMGatewayClients returns the subset of LLM-gateway-capable clients
 // that are installed on this machine. A client is considered installed when:
 //  1. Its settings directory exists on disk.
@@ -278,43 +273,48 @@ func (cm *ClientManager) buildLLMSettingsPath(cfg *clientAppConfig) string {
 	)
 }
 
-// llmValueForSpec returns the value to write for spec given cfg.
-// If spec.Literal is set it is returned directly.
-// Otherwise spec.ValueField is resolved against cfg; an unrecognised ValueField
-// returns an error so typos are caught at call time rather than silently written
-// as unexpected strings into the user's settings file.
-func llmValueForSpec(spec LLMGatewayKeySpec, cfg llmgateway.ApplyConfig) (string, error) {
-	if spec.Literal != "" {
-		return spec.Literal, nil
-	}
-	switch spec.ValueField {
+// resolveApplyConfigField maps a ValueField name to its runtime value from cfg.
+// Returns (value, true) for any recognized field, ("", false) for unknown ones.
+// This is the single source of truth for ValueField semantics shared by both
+// LLMGatewayKeySpec (settings-file patching) and LLMEnvFileKeySpec (.env injection).
+func resolveApplyConfigField(valueField string, cfg llmgateway.ApplyConfig) (string, bool) {
+	switch valueField {
 	case "GatewayURL":
-		return cfg.GatewayURL, nil
+		return cfg.GatewayURL, true
 	case "AnthropicBaseURL":
 		// Use the pre-computed Anthropic base URL when available; fall back to
 		// GatewayURL so existing configs continue to work without the prefix.
 		if cfg.AnthropicBaseURL != "" {
-			return cfg.AnthropicBaseURL, nil
+			return cfg.AnthropicBaseURL, true
 		}
-		return cfg.GatewayURL, nil
+		return cfg.GatewayURL, true
 	case "ProxyBaseURL":
-		return cfg.ProxyBaseURL, nil
+		return cfg.ProxyBaseURL, true
+	case "ProxyOrigin":
+		return llmgateway.ProxyOriginOf(cfg.ProxyBaseURL), true
 	case "TokenHelperCommand":
-		return cfg.TokenHelperCommand, nil
+		return cfg.TokenHelperCommand, true
 	case "PlaceholderAPIKey":
-		return llmPlaceholderAPIKey, nil
+		return llmPlaceholderAPIKey, true
 	case "NodeTLSRejectUnauthorized":
 		if cfg.TLSSkipVerify {
-			return "0", nil
+			return "0", true
 		}
-		return "", nil
-	case "ProxyOrigin":
-		// Like ProxyBaseURL but with the path stripped; see llmgateway.ProxyOriginOf.
-		return llmgateway.ProxyOriginOf(cfg.ProxyBaseURL), nil
+		return "", true
 	default:
-		return "", fmt.Errorf("unknown ValueField %q in LLMGatewayKeySpec for %q; use Literal for constant values",
-			spec.ValueField, spec.JSONPointer)
+		return "", false
 	}
+}
+
+// llmValueForSpec returns the config value for a settings-file key spec.
+// An unrecognised ValueField is a programming error and returns an error so
+// typos are caught at call time rather than silently written into user config.
+// Use LLMGatewayKeySpec.Literal for constant values.
+func llmValueForSpec(valueField string, cfg llmgateway.ApplyConfig) (string, error) {
+	if v, ok := resolveApplyConfigField(valueField, cfg); ok {
+		return v, nil
+	}
+	return "", fmt.Errorf("unknown ValueField %q in LLMGatewayKeySpec; use Literal for constant values", valueField)
 }
 
 // ensureLLMAncestors walks every ancestor of ptr from root inward and creates
@@ -380,18 +380,19 @@ func jsonPointerExists(data []byte, pointer string) bool {
 	return true
 }
 
-// readOrInit reads path and returns its content, or "{}" if the file is missing
-// or empty. Returns an error only for real IO failures.
-func readOrInit(path string) ([]byte, error) {
+// readOrInitFile reads path and returns its content.
+// When the file is missing or empty it returns defaultContent instead.
+// Returns an error only for real IO failures.
+func readOrInitFile(path string, defaultContent []byte) ([]byte, error) {
 	data, err := os.ReadFile(path) // #nosec G304 -- path is a known tool config file location
 	if err != nil {
 		if os.IsNotExist(err) {
-			return []byte("{}"), nil
+			return defaultContent, nil
 		}
 		return nil, fmt.Errorf("reading %s: %w", path, err)
 	}
 	if len(data) == 0 {
-		return []byte("{}"), nil
+		return defaultContent, nil
 	}
 	return data, nil
 }

--- a/pkg/client/llm_gateway_test.go
+++ b/pkg/client/llm_gateway_test.go
@@ -94,9 +94,6 @@ func TestRealClientConfigs_ConfigureAndRevert(t *testing.T) {
 			clientType: GeminiCli,
 			wantPointers: map[string]string{
 				"/security/auth/selectedType": "gemini-api-key",
-				"/env/GEMINI_API_KEY":         "thv-proxy",
-				// ProxyOriginOf strips the /v1 path suffix.
-				"/env/GOOGLE_GEMINI_BASE_URL": "http://localhost:14000",
 			},
 		},
 		{
@@ -701,45 +698,42 @@ func TestLLMValueForSpec(t *testing.T) {
 	}
 
 	cases := []struct {
-		name    string
-		spec    LLMGatewayKeySpec
-		cfg     llmgateway.ApplyConfig
-		want    string
-		wantErr bool
+		name       string
+		valueField string
+		cfg        llmgateway.ApplyConfig
+		want       string
+		wantErr    bool
 	}{
-		// ValueField — known names resolve correctly
-		{name: "GatewayURL", spec: LLMGatewayKeySpec{ValueField: "GatewayURL"}, cfg: cfg, want: "https://gw.example.com"},
-		{name: "ProxyBaseURL", spec: LLMGatewayKeySpec{ValueField: "ProxyBaseURL"}, cfg: cfg, want: "http://localhost:14000/v1"},
-		{name: "TokenHelperCommand", spec: LLMGatewayKeySpec{ValueField: "TokenHelperCommand"}, cfg: cfg, want: `"thv" llm token`},
-		{name: "PlaceholderAPIKey", spec: LLMGatewayKeySpec{ValueField: "PlaceholderAPIKey"}, cfg: cfg, want: "thv-proxy"},
+		// Known ValueField names resolve correctly
+		{name: "GatewayURL", valueField: "GatewayURL", cfg: cfg, want: "https://gw.example.com"},
+		{name: "ProxyBaseURL", valueField: "ProxyBaseURL", cfg: cfg, want: "http://localhost:14000/v1"},
+		{name: "TokenHelperCommand", valueField: "TokenHelperCommand", cfg: cfg, want: `"thv" llm token`},
+		{name: "PlaceholderAPIKey", valueField: "PlaceholderAPIKey", cfg: cfg, want: "thv-proxy"},
 		// NodeTLSRejectUnauthorized: "0" when set, "" when clear
-		{name: "NodeTLSRejectUnauthorized/skip=false", spec: LLMGatewayKeySpec{ValueField: "NodeTLSRejectUnauthorized"}, cfg: cfg, want: ""},
-		{name: "NodeTLSRejectUnauthorized/skip=true", spec: LLMGatewayKeySpec{ValueField: "NodeTLSRejectUnauthorized"}, cfg: llmgateway.ApplyConfig{TLSSkipVerify: true}, want: "0"},
+		{name: "NodeTLSRejectUnauthorized/skip=false", valueField: "NodeTLSRejectUnauthorized", cfg: cfg, want: ""},
+		{name: "NodeTLSRejectUnauthorized/skip=true", valueField: "NodeTLSRejectUnauthorized", cfg: llmgateway.ApplyConfig{TLSSkipVerify: true}, want: "0"},
 		// ProxyOrigin strips path, query, and fragment from ProxyBaseURL
-		{name: "ProxyOrigin/strips_path", spec: LLMGatewayKeySpec{ValueField: "ProxyOrigin"}, cfg: cfg, want: "http://localhost:14000"},
-		{name: "ProxyOrigin/long_path", spec: LLMGatewayKeySpec{ValueField: "ProxyOrigin"}, cfg: llmgateway.ApplyConfig{ProxyBaseURL: "http://localhost:9000/v1beta/openai"}, want: "http://localhost:9000"},
-		{name: "ProxyOrigin/strips_query_and_fragment", spec: LLMGatewayKeySpec{ValueField: "ProxyOrigin"}, cfg: llmgateway.ApplyConfig{ProxyBaseURL: "http://host:8080/path?q=1#frag"}, want: "http://host:8080"},
+		{name: "ProxyOrigin/strips_path", valueField: "ProxyOrigin", cfg: cfg, want: "http://localhost:14000"},
+		{name: "ProxyOrigin/long_path", valueField: "ProxyOrigin", cfg: llmgateway.ApplyConfig{ProxyBaseURL: "http://localhost:9000/v1beta/openai"}, want: "http://localhost:9000"},
+		{name: "ProxyOrigin/strips_query_and_fragment", valueField: "ProxyOrigin", cfg: llmgateway.ApplyConfig{ProxyBaseURL: "http://host:8080/path?q=1#frag"}, want: "http://host:8080"},
 		// ForceQuery: trailing "?" with no key must not leak into the origin.
-		{name: "ProxyOrigin/force_query", spec: LLMGatewayKeySpec{ValueField: "ProxyOrigin"}, cfg: llmgateway.ApplyConfig{ProxyBaseURL: "http://host:8080/path?"}, want: "http://host:8080"},
+		{name: "ProxyOrigin/force_query", valueField: "ProxyOrigin", cfg: llmgateway.ApplyConfig{ProxyBaseURL: "http://host:8080/path?"}, want: "http://host:8080"},
 		// ProxyOrigin falls back to the raw value when URL parsing fails
-		{name: "ProxyOrigin/invalid_url_fallback", spec: LLMGatewayKeySpec{ValueField: "ProxyOrigin"}, cfg: llmgateway.ApplyConfig{ProxyBaseURL: "::invalid"}, want: "::invalid"},
-		// Literal — written verbatim regardless of cfg
-		{name: "Literal/gemini-api-key", spec: LLMGatewayKeySpec{Literal: "gemini-api-key"}, cfg: cfg, want: "gemini-api-key"},
-		{name: "Literal/some-constant", spec: LLMGatewayKeySpec{Literal: "some-constant"}, cfg: cfg, want: "some-constant"},
-		// Unknown ValueField — must return an error (no silent literal fallback)
-		{name: "unknown_ValueField/typo", spec: LLMGatewayKeySpec{ValueField: "GatwayURL"}, cfg: cfg, wantErr: true},
-		{name: "unknown_ValueField/arbitrary", spec: LLMGatewayKeySpec{ValueField: "not-a-field"}, cfg: cfg, wantErr: true},
+		{name: "ProxyOrigin/invalid_url_fallback", valueField: "ProxyOrigin", cfg: llmgateway.ApplyConfig{ProxyBaseURL: "::invalid"}, want: "::invalid"},
+		// Unknown ValueField names are programming errors and must return an error
+		{name: "unknown_ValueField/typo", valueField: "GatwayURL", cfg: cfg, wantErr: true},
+		{name: "unknown_ValueField/arbitrary", valueField: "gemini-api-key", cfg: cfg, wantErr: true},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			got, err := llmValueForSpec(tc.spec, tc.cfg)
+			got, err := llmValueForSpec(tc.valueField, tc.cfg)
 			if tc.wantErr {
-				assert.Error(t, err)
+				require.Error(t, err)
 				return
 			}
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tc.want, got)
 		})
 	}

--- a/pkg/llm/config.go
+++ b/pkg/llm/config.go
@@ -46,6 +46,9 @@ type ToolConfig struct {
 	Mode string `yaml:"mode" json:"mode"`
 	// ConfigPath is the absolute path to the tool's config file that was patched.
 	ConfigPath string `yaml:"config_path" json:"config_path"`
+	// EnvFilePath is the absolute path to the .env file written during setup,
+	// or empty if no .env file was managed for this tool.
+	EnvFilePath string `yaml:"env_file_path,omitempty" json:"env_file_path,omitempty"`
 }
 
 // IsConfigured reports whether the minimum required fields are present for the

--- a/pkg/llm/setup.go
+++ b/pkg/llm/setup.go
@@ -31,9 +31,12 @@ type GatewayManager interface {
 	ConfigureLLMGateway(clientType string, cfg llmgateway.ApplyConfig) (string, error)
 	// LLMGatewayModeFor returns "direct", "proxy", or "" for the given client.
 	LLMGatewayModeFor(clientType string) string
-	// LLMSetupNoteFor returns an optional post-setup message for the given
-	// client, or "" when there is nothing to surface.
-	LLMSetupNoteFor(clientType string) string
+	// ConfigureEnvFile writes .env file entries for the client and returns the
+	// env file path. Returns ("", nil) when the client has no env-file entries.
+	ConfigureEnvFile(clientType string, cfg llmgateway.ApplyConfig) (string, error)
+	// RevertEnvFile removes the .env file entries that setup wrote. envFilePath
+	// is the value returned by ConfigureEnvFile; a no-op when empty.
+	RevertEnvFile(clientType, envFilePath string) error
 	// RevertLLMGateway removes the LLM gateway settings from the tool's config file.
 	RevertLLMGateway(clientType, configPath string) error
 }
@@ -131,12 +134,7 @@ func Setup(
 		// Roll back every tool we successfully patched so the tool config files
 		// are not left in a modified state without a persisted record of what
 		// was changed (which would make teardown unable to revert them).
-		for _, tc := range configured {
-			if revertErr := gm.RevertLLMGateway(tc.Tool, tc.ConfigPath); revertErr != nil {
-				_, _ = fmt.Fprintf(errOut,
-					"Warning: rollback of %s failed: %v\n", tc.Tool, revertErr)
-			}
-		}
+		rollbackConfiguredTools(errOut, gm, configured)
 		return fmt.Errorf("persisting tool configuration: %w", err)
 	}
 
@@ -215,11 +213,7 @@ func Teardown(
 	// Revert tool config files best-effort; warn on failure but do not undo
 	// the config update above (the user can re-run setup+teardown to reconcile).
 	for _, tc := range toRevert {
-		if err := gm.RevertLLMGateway(tc.Tool, tc.ConfigPath); err != nil {
-			_, _ = fmt.Fprintf(errOut, "Warning: failed to revert %s: %v\n", tc.Tool, err)
-			continue
-		}
-		_, _ = fmt.Fprintf(out, "Reverted %s  (%s)\n", tc.Tool, tc.ConfigPath)
+		revertToolConfig(out, errOut, gm, tc)
 	}
 
 	if purgeTokens && secretsProvider != nil {
@@ -337,26 +331,34 @@ func configureDetectedTools(
 			}
 		}
 
-		configPath, err := gm.ConfigureLLMGateway(clientType, llmgateway.ApplyConfig{
+		applyCfg := llmgateway.ApplyConfig{
 			GatewayURL:         gatewayURL,
 			AnthropicBaseURL:   anthropicBaseURL,
 			ProxyBaseURL:       proxyBaseURL,
 			TokenHelperCommand: tokenHelperCommand,
 			TLSSkipVerify:      tlsSkipVerify,
-		})
+		}
+		configPath, err := gm.ConfigureLLMGateway(clientType, applyCfg)
 		if err != nil {
 			_, _ = fmt.Fprintf(errOut, "Warning: failed to configure %s: %v\n", clientType, err)
 			continue
 		}
+		envFilePath, err := gm.ConfigureEnvFile(clientType, applyCfg)
+		if err != nil {
+			_, _ = fmt.Fprintf(errOut, "Warning: failed to write .env for %s: %v\n", clientType, err)
+			// Roll back the settings-file patch we just made.
+			if revertErr := gm.RevertLLMGateway(clientType, configPath); revertErr != nil {
+				_, _ = fmt.Fprintf(errOut, "Warning: rollback of %s failed: %v\n", clientType, revertErr)
+			}
+			continue
+		}
 		configured = append(configured, ToolConfig{
-			Tool:       clientType,
-			Mode:       mode,
-			ConfigPath: configPath,
+			Tool:        clientType,
+			Mode:        mode,
+			ConfigPath:  configPath,
+			EnvFilePath: envFilePath,
 		})
 		_, _ = fmt.Fprintf(out, "Configured %s (%s mode)  →  %s\n", clientType, mode, configPath)
-		if note := gm.LLMSetupNoteFor(clientType); note != "" {
-			_, _ = fmt.Fprintln(out, note)
-		}
 	}
 	if len(configured) == 0 {
 		return nil, fmt.Errorf("failed to configure any detected tools")
@@ -465,6 +467,34 @@ func hasDirectModeClient(gm GatewayManager, detected []string) bool {
 		}
 	}
 	return false
+}
+
+// revertToolConfig reverts the settings-file and .env patches for a single
+// tool. Errors are logged as warnings so the caller can continue with others.
+func revertToolConfig(out, errOut io.Writer, gm GatewayManager, tc ToolConfig) {
+	ok := true
+	if err := gm.RevertLLMGateway(tc.Tool, tc.ConfigPath); err != nil {
+		_, _ = fmt.Fprintf(errOut, "Warning: failed to revert %s settings: %v\n", tc.Tool, err)
+		ok = false
+	}
+	if tc.EnvFilePath != "" {
+		if err := gm.RevertEnvFile(tc.Tool, tc.EnvFilePath); err != nil {
+			_, _ = fmt.Fprintf(errOut, "Warning: failed to revert %s .env: %v\n", tc.Tool, err)
+			ok = false
+		}
+	}
+	if ok {
+		_, _ = fmt.Fprintf(out, "Reverted %s  (%s)\n", tc.Tool, tc.ConfigPath)
+	}
+}
+
+// rollbackConfiguredTools reverts the settings-file and .env patches for every
+// entry in configured. Errors are logged as warnings so all tools are attempted.
+func rollbackConfiguredTools(errOut io.Writer, gm GatewayManager, configured []ToolConfig) {
+	// Use a discard writer for the "Reverted" line — rollback is silent on success.
+	for _, tc := range configured {
+		revertToolConfig(io.Discard, errOut, gm, tc)
+	}
 }
 
 // hasProxyMode reports whether any of the given tool configs uses proxy mode.

--- a/pkg/llm/setup_test.go
+++ b/pkg/llm/setup_test.go
@@ -104,7 +104,10 @@ func (*stubGatewayManager) ConfigureLLMGateway(_ string, _ llmgateway.ApplyConfi
 	return "", nil
 }
 func (*stubGatewayManager) LLMGatewayModeFor(_ string) string { return "" }
-func (*stubGatewayManager) LLMSetupNoteFor(_ string) string   { return "" }
+func (*stubGatewayManager) ConfigureEnvFile(_ string, _ llmgateway.ApplyConfig) (string, error) {
+	return "", nil
+}
+func (*stubGatewayManager) RevertEnvFile(_, _ string) error { return nil }
 func (s *stubGatewayManager) RevertLLMGateway(clientType, _ string) error {
 	s.reverted = append(s.reverted, clientType)
 	return nil
@@ -191,6 +194,10 @@ func (g *capturingGatewayManager) ConfigureLLMGateway(_ string, cfg llmgateway.A
 func (g *capturingGatewayManager) LLMGatewayModeFor(_ string) string { return g.mode }
 func (*capturingGatewayManager) LLMSetupNoteFor(_ string) string     { return "" }
 func (*capturingGatewayManager) RevertLLMGateway(_, _ string) error  { return nil }
+func (*capturingGatewayManager) ConfigureEnvFile(_ string, _ llmgateway.ApplyConfig) (string, error) {
+	return "", nil
+}
+func (*capturingGatewayManager) RevertEnvFile(_, _ string) error { return nil }
 
 func TestConfigureDetectedTools_PathPrefixAppendedForDirectMode(t *testing.T) {
 	t.Parallel()

--- a/test/e2e/cli_llm_all_clients_test.go
+++ b/test/e2e/cli_llm_all_clients_test.go
@@ -54,6 +54,14 @@ type llmClientTestCase struct {
 	// The function receives (gatewayURL, proxyBaseURL) for flexibility.
 	expectedKeys map[string]func(gatewayURL, proxyURL string) string
 
+	// envFilePath returns the absolute path to the .env file that thv will write,
+	// or nil when the client has no .env file to manage.
+	envFilePath func(tempDir string) string
+
+	// expectedEnvKeys maps env var names to resolver functions, checked in the
+	// .env file written by setup. Only used when envFilePath is non-nil.
+	expectedEnvKeys map[string]func(gatewayURL, proxyURL string) string
+
 	// skipOnOS is a GOOS value ("linux", "darwin") on which the test is skipped.
 	// Empty means the test runs everywhere.
 	skipOnOS string
@@ -94,12 +102,15 @@ func allClientTestCases() []llmClientTestCase {
 			expectedKeys: map[string]func(string, string) string{
 				// Force API-key auth so GOOGLE_GEMINI_BASE_URL is respected.
 				"/security/auth/selectedType": func(_, _ string) string { return "gemini-api-key" },
-				"/env/GEMINI_API_KEY":         func(_, _ string) string { return clientThvProxy },
-				// ProxyOrigin strips the entire path (and any query/fragment) from
-				// the proxy base URL so Gemini CLI can append its own /v1beta/...
-				// path without doubling segments. Mirror the production logic here
-				// so the expectation stays correct if the proxy path changes.
-				"/env/GOOGLE_GEMINI_BASE_URL": func(_, proxyURL string) string {
+			},
+			// Gemini CLI reads these from process.env, so thv writes them to .env.
+			envFilePath: func(tempDir string) string {
+				return filepath.Join(tempDir, ".gemini", ".env")
+			},
+			expectedEnvKeys: map[string]func(string, string) string{
+				"GEMINI_API_KEY": func(_, _ string) string { return clientThvProxy },
+				// ProxyOrigin strips the path so Gemini CLI can append /v1beta/...
+				"GOOGLE_GEMINI_BASE_URL": func(_, proxyURL string) string {
 					return llmgateway.ProxyOriginOf(proxyURL)
 				},
 			},
@@ -328,6 +339,20 @@ var _ = Describe("thv llm — all-client matrix", Label("cli", "llm", "clients",
 						"JSON pointer %s should contain %q in %s", pointer, expectedSubstr, settingsFile)
 				}
 
+				// Verify the .env file was written (if applicable).
+				if clientTC.envFilePath != nil {
+					envFile := clientTC.envFilePath(tempDir)
+					By(fmt.Sprintf("[%s] verifying .env file was written: %s", clientTC.name, envFile))
+					envData, err := os.ReadFile(envFile)
+					Expect(err).ToNot(HaveOccurred(), ".env file should exist after setup")
+					envContent := string(envData)
+					for key, valueFn := range clientTC.expectedEnvKeys {
+						expectedVal := valueFn(gatewayURL, proxyBaseURL)
+						Expect(envContent).To(ContainSubstring(key+"="+expectedVal),
+							".env file should contain %s=%s", key, expectedVal)
+					}
+				}
+
 				// Verify config show reflects this client.
 				By(fmt.Sprintf("[%s] verifying config show contains this client", clientTC.name))
 				showOut, _ := thvCmd("llm", "config", "show", "--format", "json").ExpectSuccess()
@@ -359,6 +384,19 @@ var _ = Describe("thv llm — all-client matrix", Label("cli", "llm", "clients",
 					_, found := jsonPointerGet(after, pointer)
 					Expect(found).To(BeFalse(),
 						"JSON pointer %s should be absent after teardown in %s", pointer, settingsFile)
+				}
+
+				// Verify the .env file had thv-managed entries removed (if applicable).
+				if clientTC.envFilePath != nil {
+					envFile := clientTC.envFilePath(tempDir)
+					By(fmt.Sprintf("[%s] verifying .env file entries were removed: %s", clientTC.name, envFile))
+					envData, err := os.ReadFile(envFile)
+					Expect(err).ToNot(HaveOccurred(), ".env file should still exist after teardown")
+					envContent := string(envData)
+					for key := range clientTC.expectedEnvKeys {
+						Expect(envContent).ToNot(ContainSubstring(key+"="),
+							".env file should not contain %s after teardown", key)
+					}
 				}
 
 				showOut, _ = thvCmd("llm", "config", "show", "--format", "json").ExpectSuccess()
@@ -449,17 +487,24 @@ var _ = Describe("thv llm — all-client matrix", Label("cli", "llm", "clients",
 			Expect(json.Unmarshal(data, &claudeAfter)).To(Succeed())
 			Expect(claudeAfter).ToNot(HaveKey("apiKeyHelper"))
 
-			By("verifying gemini-cli settings are still patched")
+			By("verifying gemini-cli settings.json still has auth type patched")
 			geminiSettings := filepath.Join(tempDir, ".gemini", "settings.json")
 			data, err = os.ReadFile(geminiSettings)
 			Expect(err).ToNot(HaveOccurred())
 			var geminiAfter map[string]any
 			Expect(json.Unmarshal(data, &geminiAfter)).To(Succeed())
-			baseURL, found := jsonPointerGet(geminiAfter, "/env/GOOGLE_GEMINI_BASE_URL")
+			authType, found := jsonPointerGet(geminiAfter, "/security/auth/selectedType")
 			Expect(found).To(BeTrue(),
-				"gemini-cli /env/GOOGLE_GEMINI_BASE_URL should still be present after claude-code teardown")
-			Expect(baseURL).ToNot(BeEmpty(),
-				"gemini-cli GOOGLE_GEMINI_BASE_URL should still be set after claude-code teardown")
+				"gemini-cli /security/auth/selectedType should still be present after claude-code teardown")
+			Expect(authType).To(Equal("gemini-api-key"),
+				"gemini-cli auth type should still be gemini-api-key after claude-code teardown")
+
+			By("verifying gemini-cli .env file still has proxy env vars")
+			geminiEnv := filepath.Join(tempDir, ".gemini", ".env")
+			envData, envErr := os.ReadFile(geminiEnv)
+			Expect(envErr).ToNot(HaveOccurred(), ".env file should still exist after claude-code teardown")
+			Expect(string(envData)).To(ContainSubstring("GOOGLE_GEMINI_BASE_URL="),
+				"gemini-cli GOOGLE_GEMINI_BASE_URL should still be in .env after claude-code teardown")
 
 			By("verifying ConfiguredTools has only gemini-cli")
 			showOut, _ = thvCmd("llm", "config", "show", "--format", "json").ExpectSuccess()

--- a/test/e2e/llm_gateway_mock.go
+++ b/test/e2e/llm_gateway_mock.go
@@ -84,6 +84,10 @@ func (m *LLMGatewayMock) newServer() *http.Server {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/v1/models", m.handleModels)
 	mux.HandleFunc("/v1/chat/completions", m.handleChatCompletions)
+	// Gemini CLI sends requests to /v1beta/models/{model}:generateContent.
+	// The mock handles any /v1beta/ path so proxy routing tests can verify
+	// end-to-end request flow without a real Envoy AI Gateway.
+	mux.HandleFunc("/v1beta/", m.handleGeminiGenerate)
 	mux.HandleFunc("/health", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("OK"))
@@ -237,6 +241,30 @@ func (m *LLMGatewayMock) handleChatCompletions(w http.ResponseWriter, r *http.Re
 		}},
 		"usage": map[string]any{
 			"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30,
+		},
+	})
+}
+
+// handleGeminiGenerate handles Gemini CLI's native API path:
+// /v1beta/models/{model}:generateContent (and other /v1beta/* variants).
+// It returns a minimal Gemini GenerateContent response so proxy routing tests
+// can verify end-to-end flow without a real Envoy AI Gateway.
+func (m *LLMGatewayMock) handleGeminiGenerate(w http.ResponseWriter, r *http.Request) {
+	m.record(r)
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"candidates": []map[string]any{{
+			"content": map[string]any{
+				"parts": []map[string]any{{"text": "Hello from the mock LLM gateway!"}},
+				"role":  "model",
+			},
+			"finishReason": "STOP",
+			"index":        0,
+		}},
+		"usageMetadata": map[string]any{
+			"promptTokenCount":     10,
+			"candidatesTokenCount": 20,
+			"totalTokenCount":      30,
 		},
 	})
 }


### PR DESCRIPTION
## Summary

<!--
REQUIRED. You MUST explain:
1. WHY this change is needed (the problem or motivation)
2. WHAT changed (concise bullet points)

The diff shows the code — your summary must provide the context a reviewer
needs to understand the purpose without reading the diff first.
-->

thv llm setup --client gemini-cli now writes GEMINI_API_KEY and GOOGLE_GEMINI_BASE_URL to ~/.gemini/.env automatically instead of printing a manual-step note. thv llm teardown removes those entries.

Adds a general-purpose env-file mechanism to clientAppConfig (LLMEnvFileKeys/RelPath/FileName) so any future client with the same constraint can use it without new plumbing.

The mock LLM gateway now handles /v1beta/* paths so proxy routing tests can exercise the full Gemini CLI request path end-to-end.
<!--
Link related issues. Use "Closes" or "Fixes" to auto-close on merge.
Remove this line if there is no related issue.
-->

Fixes #5173

## Type of change

<!-- REQUIRED. Check exactly one. -->

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

<!--
REQUIRED. Check every verification step you actually ran.
You MUST check at least one item. If you only did manual testing,
describe exactly what you tested below the checkbox.
-->

- [x] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [x] Linting (`task lint-fix`)
- [ ] Manual testing (describe below)

## API Compatibility

<!--
The CRD Schema Compatibility check guards the v1beta1 operator API.
If the check flags this PR as Incompatible and the break is intentional,
apply the `api-break-allowed` label and describe below:

1. Which fields, types, or CRDs are changing.
2. Why the break is unavoidable.
3. The user-facing migration path (what cluster admins need to do).

See CONTRIBUTING.md → "API Stability" for the full rubric. Coordinate
with maintainers before applying the label.

Remove this section entirely if the PR does not touch operator API surface.
-->

- [ ] This PR does not break the `v1beta1` API, OR the `api-break-allowed` label is applied and the migration guidance is described above.

## Changes

<!--
Optional — include for PRs touching more than a few files to help
reviewers navigate the diff. Remove this entire section for small PRs.
-->

| File | Change |
|------|--------|
|      |        |

## Does this introduce a user-facing change?

<!--
If yes, describe the change from the user's perspective. This helps with release notes.
If no, write "No".
Remove this section entirely if not applicable.
-->

## Implementation plan

<!--
Optional — include when this PR was planned with an AI assistant (Claude Code, etc.).
Paste the approved plan inside the <details> block so reviewers can see the intended
design without cluttering the main PR description. Remove this section entirely
for PRs that were not AI-planned.
-->

<details>
<summary>Approved implementation plan</summary>

<!-- Paste the plan here -->

</details>

## Special notes for reviewers

<!--
Optional — call out anything non-obvious: tricky logic, known limitations,
areas where you'd like extra scrutiny, or follow-up work planned.
Remove this section if not needed.
-->
