### PR TITLE
Add omitempty to MCPGroupStatus JSON fields

### DIFF
--- a/cmd/thv-operator/api/v1beta1/mcpgroup_types.go
+++ b/cmd/thv-operator/api/v1beta1/mcpgroup_types.go
@@ -28,11 +28,11 @@ type MCPGroupStatus struct {
 	// Servers lists MCPServer names in this group
 	// +listType=set
 	// +optional
-	Servers []string `json:"servers"`
+	Servers []string `json:"servers,omitempty"`
 
 	// ServerCount is the number of MCPServers
 	// +optional
-	ServerCount int32 `json:"serverCount"`
+	ServerCount int32 `json:"serverCount,omitempty"`
 
 	// RemoteProxies lists MCPRemoteProxy names in this group
 	// +listType=set


### PR DESCRIPTION
Fixes #4537

## Summary

<!--
REQUIRED. You MUST explain:
1. WHY this change is needed (the problem or motivation)
2. WHAT changed (concise bullet points)

The diff shows the code — your summary must provide the context a reviewer
needs to understand the purpose without reading the diff first.
-->

- Add omitempty to servers and serverCount JSON tags in MCPGroupStatus so optional fields are omitted from serialized output when empty, consistent with other optional fields in the struct.

<!--
Link related issues. Use "Closes" or "Fixes" to auto-close on merge.
Remove this line if there is no related issue.
-->

Fixes #

## Type of change

<!-- REQUIRED. Check exactly one. -->

- [ ] Bug fix
- [ ] New feature
- [x] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

<!--
REQUIRED. Check every verification step you actually ran.
You MUST check at least one item. If you only did manual testing,
describe exactly what you tested below the checkbox.
-->

- [x] Unit tests (`task test`)
- [x] E2E tests (`task test-e2e`)
- [x] Linting (`task lint-fix`)
- [ ] Manual testing (describe below)