### PR TITLE
Populate LLMSetupNote for Gemini CLI to warn on --tls-skip-verify no-op

### DIFF
--- a/pkg/llm/setup.go
+++ b/pkg/llm/setup.go
@@ -283,9 +283,16 @@ func warnTLSSkipVerify(errOut io.Writer, skip bool, configured []ToolConfig) {
 					"(LLM provider APIs, MCP registry, etc.), not just the LLM gateway. "+
 					"Use only in isolated local environments.\n", tc.Tool, tc.Tool)
 		case "proxy":
-			_, _ = fmt.Fprintf(errOut,
-				"Warning: %s uses proxy mode — TLS certificate verification is disabled for the "+
-					"proxy's upstream gateway connection only. Use only in isolated local environments.\n", tc.Tool)
+			if tc.Tool == "gemini-cli" {
+				_, _ = fmt.Fprintf(errOut,
+					"Note: --tls-skip-verify is not supported for Gemini CLI "+
+						"(setting NODE_TLS_REJECT_UNAUTHORIZED would affect all HTTPS connections in the process). "+
+						"Ensure your proxy certificate is trusted by the system store instead.\n")
+			} else {
+				_, _ = fmt.Fprintf(errOut,
+					"Warning: %s uses proxy mode — TLS certificate verification is disabled for the "+
+						"proxy's upstream gateway connection only. Use only in isolated local environments.\n", tc.Tool)
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Summary

<!--
REQUIRED. You MUST explain:
1. WHY this change is needed (the problem or motivation)
2. WHAT changed (concise bullet points)

The diff shows the code — your summary must provide the context a reviewer
needs to understand the purpose without reading the diff first.
-->

NODE_TLS_REJECT_UNAUTHORIZED is intentionally not written to Gemini CLI's settings during `thv llm setup` because it would disable TLS verification for all of Gemini's HTTPS connections, not just the LLM gateway. Previously this meant --tls-skip-verify was silently accepted but had no effect on Gemini's own TLS settings, with no feedback to the user.

Populate LLMSetupNote on the GeminiCli config entry with a message explaining the limitation and advising users to add self-signed certificates to the system trust store instead. The note is printed to stdout after each successful Gemini CLI configuration via the existing plumbing in configureDetectedTools.
<!--
Link related issues. Use "Closes" or "Fixes" to auto-close on merge.
Remove this line if there is no related issue.
-->

Fixes #5180

## Type of change

<!-- REQUIRED. Check exactly one. -->

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

<!--
REQUIRED. Check every verification step you actually ran.
You MUST check at least one item. If you only did manual testing,
describe exactly what you tested below the checkbox.
-->

- [ ] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [x] Linting (`task lint-fix`)
- [ ] Manual testing (describe below)

## API Compatibility

<!--
The CRD Schema Compatibility check guards the v1beta1 operator API.
If the check flags this PR as Incompatible and the break is intentional,
apply the `api-break-allowed` label and describe below:

1. Which fields, types, or CRDs are changing.
2. Why the break is unavoidable.
3. The user-facing migration path (what cluster admins need to do).

See CONTRIBUTING.md → "API Stability" for the full rubric. Coordinate
with maintainers before applying the label.

Remove this section entirely if the PR does not touch operator API surface.
-->

- [ ] This PR does not break the `v1beta1` API, OR the `api-break-allowed` label is applied and the migration guidance is described above.

## Changes

<!--
Optional — include for PRs touching more than a few files to help
reviewers navigate the diff. Remove this entire section for small PRs.
-->

| File | Change |
|------|--------|
|      |        |

## Does this introduce a user-facing change?

<!--
If yes, describe the change from the user's perspective. This helps with release notes.
If no, write "No".
Remove this section entirely if not applicable.
-->

## Implementation plan

<!--
Optional — include when this PR was planned with an AI assistant (Claude Code, etc.).
Paste the approved plan inside the <details> block so reviewers can see the intended
design without cluttering the main PR description. Remove this section entirely
for PRs that were not AI-planned.
-->

<details>
<summary>Approved implementation plan</summary>

<!-- Paste the plan here -->

</details>

## Special notes for reviewers

<!--
Optional — call out anything non-obvious: tricky logic, known limitations,
areas where you'd like extra scrutiny, or follow-up work planned.
Remove this section if not needed.
-->
