### PR TITLE
fix(api,cli): stop auto-deriving RFC 8707 resource indicator from URL

### DIFF
--- a/cmd/thv/app/run_flags.go
+++ b/cmd/thv/app/run_flags.go
@@ -948,12 +948,7 @@ func getRemoteAuthFromRemoteServerMetadata(
 	authCfg.AuthorizeURL = firstNonEmpty(f.RemoteAuthAuthorizeURL, oc.AuthorizeURL)
 	authCfg.TokenURL = firstNonEmpty(f.RemoteAuthTokenURL, oc.TokenURL)
 
-	resourceIndicator := firstNonEmpty(f.RemoteAuthResource, oc.Resource)
-	if resourceIndicator != "" {
-		authCfg.Resource = resourceIndicator
-	} else {
-		authCfg.Resource = remote.DefaultResourceIndicator(remoteServerMetadata.URL)
-	}
+	authCfg.Resource = firstNonEmpty(f.RemoteAuthResource, oc.Resource)
 
 	// OAuthParams: REPLACE metadata when CLI provides any key/value.
 	if len(runFlags.OAuthParams) > 0 {

--- a/cmd/thv/app/run_flags.go
+++ b/cmd/thv/app/run_flags.go
@@ -948,6 +948,10 @@ func getRemoteAuthFromRemoteServerMetadata(
 	authCfg.AuthorizeURL = firstNonEmpty(f.RemoteAuthAuthorizeURL, oc.AuthorizeURL)
 	authCfg.TokenURL = firstNonEmpty(f.RemoteAuthTokenURL, oc.TokenURL)
 
+	// Resource is only set from explicit user flag or registry metadata.
+	// Unlike the direct-URL path (getRemoteAuthFromRunFlags), --resource-url
+	// derivation is intentionally not applied here: registry metadata is the
+	// authoritative source for the resource indicator in this path.
 	authCfg.Resource = firstNonEmpty(f.RemoteAuthResource, oc.Resource)
 
 	// OAuthParams: REPLACE metadata when CLI provides any key/value.

--- a/pkg/api/v1/workload_service.go
+++ b/pkg/api/v1/workload_service.go
@@ -429,13 +429,10 @@ func buildRemoteAuthConfigFromMetadata(req *createRequest, md *regtypes.RemoteSe
 		return nil
 	}
 
-	// Default resource: user-provided > registry metadata > derived from remote URL
+	// Default resource: user-provided > registry metadata
 	resource := req.OAuthConfig.Resource
 	if resource == "" {
 		resource = md.OAuthConfig.Resource
-	}
-	if resource == "" && md.URL != "" {
-		resource = remote.DefaultResourceIndicator(md.URL)
 	}
 
 	cfg := &remote.Config{
@@ -466,11 +463,7 @@ func createRequestToRemoteAuthConfig(
 	req *createRequest,
 ) *remote.Config {
 
-	// Default resource: user-provided > derived from remote URL
 	resource := req.OAuthConfig.Resource
-	if resource == "" && req.URL != "" {
-		resource = remote.DefaultResourceIndicator(req.URL)
-	}
 
 	// Create RemoteAuthConfig
 	remoteAuthConfig := &remote.Config{

--- a/pkg/api/v1/workload_service.go
+++ b/pkg/api/v1/workload_service.go
@@ -463,8 +463,6 @@ func createRequestToRemoteAuthConfig(
 	req *createRequest,
 ) *remote.Config {
 
-	resource := req.OAuthConfig.Resource
-
 	// Create RemoteAuthConfig
 	remoteAuthConfig := &remote.Config{
 		ClientID:     req.OAuthConfig.ClientID,
@@ -473,7 +471,7 @@ func createRequestToRemoteAuthConfig(
 		AuthorizeURL: req.OAuthConfig.AuthorizeURL,
 		TokenURL:     req.OAuthConfig.TokenURL,
 		UsePKCE:      req.OAuthConfig.UsePKCE,
-		Resource:     resource,
+		Resource:     req.OAuthConfig.Resource,
 		OAuthParams:  req.OAuthConfig.OAuthParams,
 		CallbackPort: req.OAuthConfig.CallbackPort,
 		SkipBrowser:  req.OAuthConfig.SkipBrowser,

--- a/pkg/api/v1/workload_service_test.go
+++ b/pkg/api/v1/workload_service_test.go
@@ -753,7 +753,7 @@ func TestBuildRemoteAuthConfigFromMetadata(t *testing.T) {
 		assert.Equal(t, "https://resource.example.com", cfg.Resource)
 	})
 
-	t.Run("resource derived from URL when both user and metadata unset", func(t *testing.T) {
+	t.Run("resource empty when both user and metadata unset", func(t *testing.T) {
 		t.Parallel()
 
 		md := baseMetadata()
@@ -762,7 +762,7 @@ func TestBuildRemoteAuthConfigFromMetadata(t *testing.T) {
 		cfg := buildRemoteAuthConfigFromMetadata(&createRequest{}, md)
 
 		require.NotNil(t, cfg)
-		assert.NotEmpty(t, cfg.Resource, "resource should be derived from md.URL")
+		assert.Empty(t, cfg.Resource, "resource should not be auto-derived from URL")
 	})
 
 	t.Run("user ClientSecret is applied in CLI string format", func(t *testing.T) {

--- a/pkg/api/v1/workloads_types_test.go
+++ b/pkg/api/v1/workloads_types_test.go
@@ -516,8 +516,8 @@ func TestCreateRequestToRemoteAuthConfig(t *testing.T) {
 		})
 	}
 
-	// The coder removed auto-derivation of resource from URL (RFC 8707 resource
-	// indicator). These sub-tests guard against that fallback being re-introduced.
+	// Guard against reintroduction of RFC 8707 auto-derivation from URL.
+	// Resource must only be set when explicitly provided (see #5203).
 	t.Run("resource empty when URL set but resource not explicitly provided", func(t *testing.T) {
 		t.Parallel()
 

--- a/pkg/api/v1/workloads_types_test.go
+++ b/pkg/api/v1/workloads_types_test.go
@@ -515,6 +515,44 @@ func TestCreateRequestToRemoteAuthConfig(t *testing.T) {
 			assert.Equal(t, tt.expectedBearerToken, result.BearerToken)
 		})
 	}
+
+	// The coder removed auto-derivation of resource from URL (RFC 8707 resource
+	// indicator). These sub-tests guard against that fallback being re-introduced.
+	t.Run("resource empty when URL set but resource not explicitly provided", func(t *testing.T) {
+		t.Parallel()
+
+		req := &createRequest{
+			updateRequest: updateRequest{
+				URL:         "https://mcp.example.com/mcp",
+				OAuthConfig: remoteOAuthConfig{ClientID: "some-client"},
+			},
+		}
+
+		cfg := createRequestToRemoteAuthConfig(context.Background(), req)
+
+		require.NotNil(t, cfg)
+		assert.Empty(t, cfg.Resource, "resource must not be auto-derived from URL when not explicitly set")
+	})
+
+	t.Run("resource preserved when user provides it explicitly", func(t *testing.T) {
+		t.Parallel()
+
+		req := &createRequest{
+			updateRequest: updateRequest{
+				URL: "https://mcp.example.com/mcp",
+				OAuthConfig: remoteOAuthConfig{
+					ClientID: "some-client",
+					Resource: "https://explicit-resource.example.com",
+				},
+			},
+		}
+
+		cfg := createRequestToRemoteAuthConfig(context.Background(), req)
+
+		require.NotNil(t, cfg)
+		assert.Equal(t, "https://explicit-resource.example.com", cfg.Resource,
+			"user-provided resource must be preserved verbatim")
+	})
 }
 
 func TestValidateHeaderForwardConfig(t *testing.T) {


### PR DESCRIPTION
## Summary

- Remove unconditional auto-derivation of the RFC 8707 `resource` parameter from the server URL in the API and CLI registry paths
- The `resource` parameter is now only set when explicitly provided by the user or registry metadata
- This aligns the API and CLI-from-registry behavior with the direct CLI path, which only derives `resource` when `--resource-url` is explicitly passed

Fixes #5203

## Root cause

Three code paths built `remote.Config` for OAuth:

| Path | Function | Auto-derived `resource`? |
|------|----------|--------------------------|
| API from registry | `buildRemoteAuthConfigFromMetadata` | Yes (unconditionally) |
| API direct | `createRequestToRemoteAuthConfig` | Yes (unconditionally) |
| CLI from registry | `getRemoteAuthFromRemoteServerMetadata` | Yes (unconditionally) |
| CLI direct | `getRemoteAuthFromRunFlags` | Only if `--resource-url` set |

The first three always fell back to `DefaultResourceIndicator(url)`, sending `resource=<server-url>` in the OAuth authorize URL. Servers that don't support RFC 8707 (e.g., Common Room) reject this with "Service not found".

After this fix, all paths behave consistently: `resource` is only set from explicit user input or registry metadata. Servers that support RFC 9728 will still work via runtime discovery (`.well-known/oauth-protected-resource`).

## Test plan

- [x] Existing `TestBuildRemoteAuthConfigFromMetadata` tests updated and pass
- [x] New regression tests for `createRequestToRemoteAuthConfig` verify resource is not auto-derived
- [x] `go test ./pkg/api/v1/...` passes
- [x] `go build ./cmd/thv/...` passes
- [x] Manual test: Common Room MCP server OAuth flow succeeds from ToolHive Studio


_____

Tested vs ToolHive Studio

https://github.com/user-attachments/assets/b6cc4f37-3a40-4baa-9912-666d0f27a1c8



🤖 Generated with [Claude Code](https://claude.com/claude-code)