### PR TITLE
feat(vmcp): plumb operational.timeouts.default into request timeouts

### DIFF
--- a/pkg/vmcp/cli/serve.go
+++ b/pkg/vmcp/cli/serve.go
@@ -329,11 +329,16 @@ func Serve(ctx context.Context, cfg ServeConfig) error {
 	}
 
 	envReader := &env.OSReader{}
+	var backendRequestTimeout time.Duration
+	if vmcpCfg.Operational != nil && vmcpCfg.Operational.Timeouts != nil {
+		backendRequestTimeout = time.Duration(vmcpCfg.Operational.Timeouts.Default)
+	}
 	sessionFactory, err := createSessionFactory(
 		envReader.Getenv("VMCP_SESSION_HMAC_SECRET"),
 		runtime.IsKubernetesRuntimeWithEnv(envReader),
 		outgoingRegistry,
 		agg,
+		backendRequestTimeout,
 	)
 	if err != nil {
 		return err
@@ -386,6 +391,7 @@ func Serve(ctx context.Context, cfg ServeConfig) error {
 		OptimizerConfig:         optCfg,
 		SessionFactory:          sessionFactory,
 		SessionStorage:          vmcpCfg.SessionStorage,
+		RequestTimeout:          backendRequestTimeout, // see createSessionFactory; same value
 	}
 
 	// Assign Watcher only when backendWatcher is non-nil. A typed nil
@@ -640,12 +646,16 @@ func createSessionFactory(
 	isKubernetes bool,
 	outgoingRegistry vmcpauth.OutgoingAuthRegistry,
 	agg aggregator.Aggregator,
+	backendRequestTimeout time.Duration,
 ) (vmcpsession.MultiSessionFactory, error) {
 	const minRecommendedSecretLen = 32
 
 	opts := []vmcpsession.MultiSessionFactoryOption{}
 	if agg != nil {
 		opts = append(opts, vmcpsession.WithAggregator(agg))
+	}
+	if backendRequestTimeout > 0 {
+		opts = append(opts, vmcpsession.WithBackendRequestTimeout(backendRequestTimeout))
 	}
 
 	if hmacSecret != "" {

--- a/pkg/vmcp/cli/serve_test.go
+++ b/pkg/vmcp/cli/serve_test.go
@@ -168,7 +168,7 @@ func newSessionFactoryMocks(t *testing.T) (*clientmocks.MockOutgoingAuthRegistry
 func TestCreateSessionFactory_WithHMACSecret(t *testing.T) {
 	t.Parallel()
 	registry, agg := newSessionFactoryMocks(t)
-	factory, err := createSessionFactory("a-sufficiently-long-hmac-secret-value-32b", false, registry, agg)
+	factory, err := createSessionFactory("a-sufficiently-long-hmac-secret-value-32b", false, registry, agg, 0)
 	require.NoError(t, err)
 	require.NotNil(t, factory)
 }
@@ -176,7 +176,7 @@ func TestCreateSessionFactory_WithHMACSecret(t *testing.T) {
 func TestCreateSessionFactory_HMACSecretExactly32Bytes(t *testing.T) {
 	t.Parallel()
 	registry, agg := newSessionFactoryMocks(t)
-	factory, err := createSessionFactory("12345678901234567890123456789012", false, registry, agg)
+	factory, err := createSessionFactory("12345678901234567890123456789012", false, registry, agg, 0)
 	require.NoError(t, err)
 	require.NotNil(t, factory)
 }
@@ -184,7 +184,7 @@ func TestCreateSessionFactory_HMACSecretExactly32Bytes(t *testing.T) {
 func TestCreateSessionFactory_ShortHMACSecret(t *testing.T) {
 	t.Parallel()
 	registry, agg := newSessionFactoryMocks(t)
-	factory, err := createSessionFactory("short", false, registry, agg)
+	factory, err := createSessionFactory("short", false, registry, agg, 0)
 	require.NoError(t, err)
 	require.NotNil(t, factory)
 }
@@ -192,7 +192,7 @@ func TestCreateSessionFactory_ShortHMACSecret(t *testing.T) {
 func TestCreateSessionFactory_NoSecretNonKubernetes(t *testing.T) {
 	t.Parallel()
 	registry, agg := newSessionFactoryMocks(t)
-	factory, err := createSessionFactory("", false, registry, agg)
+	factory, err := createSessionFactory("", false, registry, agg, 0)
 	require.NoError(t, err)
 	require.NotNil(t, factory)
 }
@@ -200,7 +200,7 @@ func TestCreateSessionFactory_NoSecretNonKubernetes(t *testing.T) {
 func TestCreateSessionFactory_NoSecretKubernetes(t *testing.T) {
 	t.Parallel()
 	registry, agg := newSessionFactoryMocks(t)
-	factory, err := createSessionFactory("", true, registry, agg)
+	factory, err := createSessionFactory("", true, registry, agg, 0)
 	require.Error(t, err)
 	require.ErrorContains(t, err, "an HMAC secret is required when running in Kubernetes")
 	require.Nil(t, factory)

--- a/pkg/vmcp/server/server.go
+++ b/pkg/vmcp/server/server.go
@@ -181,6 +181,14 @@ type Config struct {
 	// session persistence; the Redis password is read from the
 	// THV_SESSION_REDIS_PASSWORD environment variable.
 	SessionStorage *vmcpconfig.SessionStorageConfig
+
+	// RequestTimeout overrides the inbound http.Server's ReadTimeout and
+	// WriteTimeout (defaults: 30s). When 0, the defaults are used.
+	// Applies to non-SSE routes; SSE GETs clear their per-request write
+	// deadline via transportmiddleware.WriteTimeout. Plumb the same value
+	// you pass to session.WithBackendRequestTimeout so a tool call that
+	// takes longer than 30s upstream can still complete its inbound POST.
+	RequestTimeout time.Duration
 }
 
 // Server is the Virtual MCP Server that aggregates multiple backends.
@@ -689,12 +697,18 @@ func (s *Server) Start(ctx context.Context) error {
 
 	// Create HTTP server
 	addr := fmt.Sprintf("%s:%d", s.config.Host, s.config.Port)
+	readTimeout := defaultReadTimeout
+	writeTimeout := defaultWriteTimeout
+	if s.config.RequestTimeout > 0 {
+		readTimeout = s.config.RequestTimeout
+		writeTimeout = s.config.RequestTimeout
+	}
 	s.httpServer = &http.Server{
 		Addr:              addr,
 		Handler:           handler,
 		ReadHeaderTimeout: defaultReadHeaderTimeout,
-		ReadTimeout:       defaultReadTimeout,
-		WriteTimeout:      defaultWriteTimeout,
+		ReadTimeout:       readTimeout,
+		WriteTimeout:      writeTimeout,
 		IdleTimeout:       defaultIdleTimeout,
 		MaxHeaderBytes:    defaultMaxHeaderBytes,
 	}

--- a/pkg/vmcp/session/factory.go
+++ b/pkg/vmcp/session/factory.go
@@ -128,11 +128,12 @@ type backendConnector func(
 
 // defaultMultiSessionFactory is the production MultiSessionFactory implementation.
 type defaultMultiSessionFactory struct {
-	connector          backendConnector
-	maxConcurrency     int
-	backendInitTimeout time.Duration
-	hmacSecret         []byte                // Server-managed secret for HMAC-SHA256 token hashing
-	aggregator         aggregator.Aggregator // Optional: applies tool transforms (overrides, conflict resolution, filter)
+	connector             backendConnector
+	maxConcurrency        int
+	backendInitTimeout    time.Duration
+	backendRequestTimeout time.Duration         // Per-tool-call timeout; 0 = use upstream default (30s).
+	hmacSecret            []byte                // Server-managed secret for HMAC-SHA256 token hashing
+	aggregator            aggregator.Aggregator // Optional: applies tool transforms (overrides, conflict resolution, filter)
 }
 
 // MultiSessionFactoryOption configures a defaultMultiSessionFactory.
@@ -154,6 +155,19 @@ func WithBackendInitTimeout(d time.Duration) MultiSessionFactoryOption {
 	return func(f *defaultMultiSessionFactory) {
 		if d > 0 {
 			f.backendInitTimeout = d
+		}
+	}
+}
+
+// WithBackendRequestTimeout sets the per-tool-call wall-clock deadline for
+// streamable-HTTP backend requests. Plumbs through to the http.Client and
+// the mark3labs SDK constructed in backend.NewHTTPConnector. Defaults to 30s
+// (the upstream default) when not set or set to 0. SSE backends ignore this
+// value because their stream lifetime is unbounded by design.
+func WithBackendRequestTimeout(d time.Duration) MultiSessionFactoryOption {
+	return func(f *defaultMultiSessionFactory) {
+		if d > 0 {
+			f.backendRequestTimeout = d
 		}
 	}
 }
@@ -191,7 +205,15 @@ func WithAggregator(agg aggregator.Aggregator) MultiSessionFactoryOption {
 // NewSessionFactory creates a MultiSessionFactory that connects to backends
 // over HTTP using the given outgoing auth registry.
 func NewSessionFactory(registry vmcpauth.OutgoingAuthRegistry, opts ...MultiSessionFactoryOption) MultiSessionFactory {
-	return newSessionFactoryWithConnector(backend.NewHTTPConnector(registry), opts...)
+	// Pre-apply opts to a sentinel to extract config the connector needs at
+	// construction time. The same opts run a second time inside
+	// newSessionFactoryWithConnector to populate the real factory; option
+	// functions are pure setters, so double-application is idempotent.
+	pre := &defaultMultiSessionFactory{}
+	for _, opt := range opts {
+		opt(pre)
+	}
+	return newSessionFactoryWithConnector(backend.NewHTTPConnector(registry, pre.backendRequestTimeout), opts...)
 }
 
 // newSessionFactoryWithConnector creates a MultiSessionFactory backed by an

--- a/pkg/vmcp/session/internal/backend/mcp_session.go
+++ b/pkg/vmcp/session/internal/backend/mcp_session.go
@@ -29,9 +29,12 @@ const (
 	// see createMCPClient for the rationale.
 	maxBackendResponseSize = 100 * 1024 * 1024 // 100 MB
 
-	// defaultBackendRequestTimeout is the wall-clock deadline for individual
-	// streamable-HTTP requests. Applied at both the http.Client and SDK layers
-	// (defense-in-depth). Not used for SSE, whose stream lifetime is unbounded.
+	// defaultBackendRequestTimeout is the fallback wall-clock deadline for
+	// individual streamable-HTTP requests when the caller passes 0. Applied at
+	// both the http.Client and SDK layers (defense-in-depth). Not used for SSE,
+	// whose stream lifetime is unbounded. Override via NewHTTPConnector's
+	// requestTimeout argument, which is plumbed from the
+	// VirtualMCPServer.spec.config.operational.timeouts.default CRD field.
 	defaultBackendRequestTimeout = 30 * time.Second
 )
 
@@ -195,7 +198,12 @@ func (c *mcpSession) GetPrompt(
 //
 // registry provides the authentication strategy for outgoing backend requests.
 // Pass a registry configured with the "unauthenticated" strategy to disable auth.
-func NewHTTPConnector(registry vmcpauth.OutgoingAuthRegistry) func(
+//
+// requestTimeout sets the per-tool-call wall-clock deadline applied to the
+// streamable-HTTP http.Client and the mark3labs SDK. Pass 0 to use the
+// upstream default (defaultBackendRequestTimeout, 30s). SSE backends ignore
+// this argument because their stream lifetime is unbounded by design.
+func NewHTTPConnector(registry vmcpauth.OutgoingAuthRegistry, requestTimeout time.Duration) func(
 	ctx context.Context,
 	target *vmcp.BackendTarget,
 	identity *auth.Identity,
@@ -207,7 +215,7 @@ func NewHTTPConnector(registry vmcpauth.OutgoingAuthRegistry) func(
 		identity *auth.Identity,
 		sessionHint string,
 	) (Session, *vmcp.CapabilityList, error) {
-		c, err := createMCPClient(target, identity, registry, sessionHint)
+		c, err := createMCPClient(target, identity, registry, sessionHint, requestTimeout)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to create MCP client for backend %s: %w", target.WorkloadID, err)
 		}
@@ -242,7 +250,11 @@ func createMCPClient(
 	identity *auth.Identity,
 	registry vmcpauth.OutgoingAuthRegistry,
 	sessionHint string,
+	requestTimeout time.Duration,
 ) (*mcpclient.Client, error) {
+	if requestTimeout <= 0 {
+		requestTimeout = defaultBackendRequestTimeout
+	}
 	// Resolve and validate the auth strategy once at client creation time.
 	strategyName := authtypes.StrategyTypeUnauthenticated
 	if target.AuthConfig != nil {
@@ -297,10 +309,10 @@ func createMCPClient(
 		})
 		httpClient := &http.Client{
 			Transport: sizeLimited,
-			Timeout:   defaultBackendRequestTimeout,
+			Timeout:   requestTimeout,
 		}
 		streamableOpts := []mcptransport.StreamableHTTPCOption{
-			mcptransport.WithHTTPTimeout(defaultBackendRequestTimeout),
+			mcptransport.WithHTTPTimeout(requestTimeout),
 			mcptransport.WithHTTPBasicClient(httpClient),
 		}
 		if sessionHint != "" {

--- a/pkg/vmcp/session/internal/backend/mcp_session_test.go
+++ b/pkg/vmcp/session/internal/backend/mcp_session_test.go
@@ -40,7 +40,7 @@ func TestCreateMCPClient_UnsupportedTransport(t *testing.T) {
 				TransportType: transport,
 			}
 
-			_, err := createMCPClient(target, nil, newTestRegistry(t), "")
+			_, err := createMCPClient(target, nil, newTestRegistry(t), "", 0)
 			require.Error(t, err)
 			assert.ErrorIs(t, err, vmcp.ErrUnsupportedTransport,
 				"transport %q should return ErrUnsupportedTransport", transport)


### PR DESCRIPTION
## Problem

The CRD field `VirtualMCPServer.spec.config.operational.timeouts.default` is documented as "the default timeout for backend requests" but is currently dead config. It's defined (`pkg/vmcp/config/config.go:524`), defaulted (`pkg/vmcp/config/defaults.go:54`) and validated (`pkg/vmcp/config/validator.go:367`), but never read by any request-path code.

The actual ceiling is hardcoded in two places:

1. **Outbound** — vmcp → backend MCPServer:
   `pkg/vmcp/session/internal/backend/mcp_session.go:35`
   ```go
   defaultBackendRequestTimeout = 30 * time.Second
   ```
   Applied at lines 298–304 to the streamable-http `http.Client.Timeout` and the mark3labs SDK's `WithHTTPTimeout`.

2. **Inbound** — vmcp's own http.Server:
   `pkg/vmcp/server/server.go:53,59`
   ```go
   defaultReadTimeout  = 30 * time.Second
   defaultWriteTimeout = 30 * time.Second
   ```
   Applied at lines 696–697 in `Server.Start`.

User-visible symptom: any tool call that takes >30s upstream returns 502 from any nginx in front of vmcp, even with `operational.timeouts.default: 120s` set on the CR. Heavy ClickHouse aggregations, deep Perplexity research, and large GitHub searches are the common cases.

I confirmed both layers fire by bisecting in production: 28s queries succeed; 35s queries 502'd until BOTH timeouts were lifted. mcp-clickhouse pod logs show the upstream completing the query in all cases — vmcp hangs up before the response can be relayed.

## Change

Plumb `operational.timeouts.default` (already a `time.Duration`-castable custom Duration type) through to both layers:

- **`pkg/vmcp/session/internal/backend/mcp_session.go`** — `NewHTTPConnector(registry, requestTimeout)` and `createMCPClient(..., requestTimeout)` accept a `time.Duration`. `0` falls back to the existing 30s constant. SSE backends are unaffected.
- **`pkg/vmcp/session/factory.go`** — new `WithBackendRequestTimeout(d)` factory option, mirrors the existing `WithBackendInitTimeout` shape. `NewSessionFactory` pre-applies opts to a sentinel struct so the connector can be constructed with the configured timeout (option funcs are pure setters, double-application is idempotent).
- **`pkg/vmcp/server/server.go`** — new `Config.RequestTimeout`. When > 0, overrides both `ReadTimeout` and `WriteTimeout`. SSE GET routes still clear their per-request write deadline via `transportmiddleware.WriteTimeout` (golang/go#16100), so SSE behavior is unchanged.
- **`pkg/vmcp/cli/serve.go`** — reads `cfg.Operational.Timeouts.Default`, passes it to `createSessionFactory` (forwarded via the new option) AND sets `serverCfg.RequestTimeout`. Nil-safe — defaults preserved when `Operational` or `Timeouts` is unset.

Tests in `pkg/vmcp/session/internal/backend/mcp_session_test.go` and `pkg/vmcp/cli/serve_test.go` pass `0` for the new arg to preserve the prior behavior.

## Test plan

- [x] `go build ./...` — clean.
- [x] `go test ./pkg/vmcp/session/... ./pkg/vmcp/cli/... ./pkg/vmcp/server/...` — all green.
- [x] Built ko image from this branch and ran in production for ~30 minutes against a homelab cluster: 100 fresh-connection probes return 401 (no 5xx regressions); previously-502'ing 35s ClickHouse query now returns 200 in 35s. The remaining ceiling at ~60s is the operator-side `streamable_proxy.defaultRequestTimeout` (already env-overridable via `TOOLHIVE_PROXY_REQUEST_TIMEOUT`).

## Notes

- Backwards-compatible: the new `requestTimeout`/`RequestTimeout` parameters default to `0`, which preserves the existing 30s constants. Existing callers that don't pass anything see no change.
- Doesn't address the operator-side `pkg/transport/proxy/streamable/streamable_proxy.go:35` 60s default (already overridable via `TOOLHIVE_PROXY_REQUEST_TIMEOUT` env on the proxy container). That's a separate hop for a separate PR if anyone wants symmetry.