### PR TITLE
docs: remove stale chart version bump guidance from check-contribution skill

### DIFF
--- a/.claude/skills/check-contribution/SKILL.md
+++ b/.claude/skills/check-contribution/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: check-contribution
-description: Validates operator chart contribution practices (helm template, ct lint, docs generation, version bump) before committing changes.
+description: Validates operator chart contribution practices (helm template, ct lint, docs generation) before committing changes.
 allowed-tools: [Bash, Read]
 ---
 
@@ -28,19 +28,14 @@ helm-docs --dry-run
 ```
 Verify that `values.yaml` variables are documented and the generated README.md matches.
 
-### 4. Chart Version Bump
-If chart files changed, verify:
-- `deploy/charts/operator/Chart.yaml` version is bumped for operator changes
-- `deploy/charts/operator-crds/Chart.yaml` version is bumped for CRD changes
-- Version follows [SemVer](https://semver.org/) and bump type matches the change scope
-
 ## Output Format
 
 ```
 ✅ or ❌ Helm template renders successfully
 ✅ or ❌ Chart linting passes
 ✅ or ❌ Documentation up-to-date
-✅ or ❌ Chart version bumped appropriately
+
+Note: Chart version bumps are automated by the release bot. Feature PRs should NOT modify Chart.yaml.
 ```
 
 Include specific errors for any failing checks with actionable remediation commands.


### PR DESCRIPTION
## Summary

The `.claude/skills/check-contribution/SKILL.md` skill has been instructing contributors (and AI agents) to verify that `Chart.yaml` versions are bumped in feature PRs. This guidance is stale — chart version bumping is now fully automated by the release bot via `.github/workflows/create-release-pr.yml`. Feature PRs should not modify `Chart.yaml`.

What changed:
- Removed section 4 ("Chart Version Bump") from the checklist
- Removed "version bump" from the skill frontmatter description
- Removed "Chart version bumped appropriately" from the output format
- Added a note clarifying that chart version bumps are bot-driven and feature PRs must not modify `Chart.yaml`

Fixes #5095

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [x] Documentation
- [ ] Other (describe):

## Test plan

- [x] Manual testing (verified the skill markdown parses correctly and the changes match the acceptance criteria in #5095)
- [ ] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [ ] Linting (`task lint-fix`)

## API Compatibility

- [x] This PR does not break the `v1beta1` API, OR the `api-break-allowed` label is applied and the migration guidance is described above.

## Does this introduce a user-facing change?

No.