### PR TITLE
Restrict Windows named-pipe DACL to creating user

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -61,6 +61,7 @@ import (
 const (
 	middlewareTimeout  = 60 * time.Second
 	readHeaderTimeout  = 10 * time.Second
+	idleTimeout        = 120 * time.Second
 	shutdownTimeout    = 30 * time.Second
 	nonceBytes         = 16
 	socketPermissions  = 0660    // Socket file permissions (owner/group read-write)
@@ -559,6 +560,12 @@ func NewServer(ctx context.Context, builder *ServerBuilder) (*Server, error) {
 		Addr:              builder.address,
 		Handler:           handler,
 		ReadHeaderTimeout: readHeaderTimeout,
+		// IdleTimeout caps how long a keep-alive connection can sit idle.
+		// On Windows named pipes winio.MaxInstances defaults to 255, so a
+		// slow client cannot hold an instance forever and starve new
+		// connections; on POSIX it bounds keep-alive resource use the same
+		// way the http stdlib defaults would for a tcp listener.
+		IdleTimeout: idleTimeout,
 	}
 
 	return &Server{

--- a/pkg/api/socket_windows.go
+++ b/pkg/api/socket_windows.go
@@ -22,6 +22,15 @@ import (
 // (Docker, containerd, Podman) and is well above any single HTTP header chunk.
 const namedPipeBufferSize = 64 * 1024
 
+// namedPipeSDDL restricts the named-pipe DACL to the creating user (OW) and
+// SYSTEM (SY), each granted GenericAll. The Protected flag (P) blocks ACE
+// inheritance from any container object. Without an explicit DACL, winio
+// inherits CreateNamedPipeW's default which permits other interactive users
+// to open the pipe and exercise the entire REST API; on shared, RDP, or
+// Citrix hosts that is reachable by anyone with a desktop session, since
+// OIDC is opt-in (WithOIDCConfig) rather than always-on.
+const namedPipeSDDL = `D:P(A;;GA;;;OW)(A;;GA;;;SY)`
+
 // supportsNamedPipe reports whether the current build target can host a
 // Windows named-pipe listener. Used by createListener to choose between the
 // pipe and AF_UNIX paths without dragging the runtime package into server.go.
@@ -30,22 +39,26 @@ func supportsNamedPipe() bool { return true }
 // setupUnixSocket creates either a Windows named-pipe listener (when address
 // has the \\.\pipe\ prefix) or an AF_UNIX listener at a filesystem path.
 //
-// Named pipes are kernel objects rather than files, so the os.Stat / os.Remove
-// precheck, os.MkdirAll, and os.Chmod steps are skipped: the pipe namespace
-// has no parent directory, and access control is governed by the security
-// descriptor on the listener (winio's default restricts access to the
-// creating user, which matches the toolhive-studio same-user use case).
+// Named pipes are kernel objects rather than files, so the os.Remove,
+// os.MkdirAll, and os.Chmod steps are skipped: the pipe namespace has no
+// parent directory, and access control is governed by the SDDL passed to
+// winio.ListenPipe (see namedPipeSDDL).
 //
 // AF_UNIX is supported on Windows 10 1803+. The chmod step is dropped on this
-// path because POSIX file modes do not apply on Windows.
+// path because POSIX file modes do not apply on Windows; the resulting
+// .sock file inherits the parent directory's NTFS ACL, which is best-effort.
+// Prefer the named-pipe path when listener access control matters.
 func setupUnixSocket(address string) (net.Listener, error) {
 	if isNamedPipeAddress(address) {
 		// MessageMode is left at false (byte stream) explicitly because HTTP
-		// requires byte-oriented framing.
+		// requires byte-oriented framing. SecurityDescriptor restricts the
+		// pipe DACL to the creating user and SYSTEM; without it the winio
+		// default permits other interactive users to dial the pipe.
 		listener, err := winio.ListenPipe(address, &winio.PipeConfig{
-			MessageMode:      false,
-			InputBufferSize:  namedPipeBufferSize,
-			OutputBufferSize: namedPipeBufferSize,
+			MessageMode:        false,
+			InputBufferSize:    namedPipeBufferSize,
+			OutputBufferSize:   namedPipeBufferSize,
+			SecurityDescriptor: namedPipeSDDL,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to create named pipe listener: %w", err)


### PR DESCRIPTION
## Summary

Follow-up to #5201 ([review thread](https://github.com/stacklok/toolhive/pull/5201#pullrequestreview-4243582372)). Stacked on `socker-windows`; will rebase onto `main` once #5201 merges.

By default `winio.ListenPipe` inherits `CreateNamedPipeW`'s default DACL, which on shared / RDP / Citrix hosts permits any other interactive user to open the pipe and exercise the entire REST API (OIDC is opt-in via `WithOIDCConfig`, not always present). This PR sets an explicit SDDL on the pipe and adds defense-in-depth around connection lifecycle:

- **Pipe DACL** (`pkg/api/socket_windows.go`) — `D:P(A;;GA;;;OW)(A;;GA;;;SY)` grants GenericAll to the creating user (`OW`) and SYSTEM (`SY`) only, with the Protected flag (`P`) blocking any inherited ACEs that could widen the descriptor.
- **Doc-comment alignment** — soften the "winio's default restricts access to the creating user" claim to match what's actually enforced now (the explicit SDDL above).
- **AF_UNIX fallback marked best-effort** — the Windows AF_UNIX path still inherits the parent directory's NTFS ACL since `os.Chmod` is meaningless on Windows; the named-pipe path is the recommended transport.
- **`http.Server.IdleTimeout`** (`pkg/api/server.go`) — winio's default `MaxInstances` is 255, a hard concurrency ceiling unlike POSIX, so a slow client cannot be allowed to hold an instance idle forever and starve new connections. Applies cross-platform.

Addresses inline review comments [3201085355](https://github.com/stacklok/toolhive/pull/5201#discussion_r3201085355) (pipe DACL) and [3201085359](https://github.com/stacklok/toolhive/pull/5201#discussion_r3201085359) (AF_UNIX fallback ACL), plus the IdleTimeout note in [3201085433](https://github.com/stacklok/toolhive/pull/5201#discussion_r3201085433).

## Type of change

- Security improvement / hardening

## Test plan

- [x] Unit tests (`go test ./pkg/api/...`) — green on macOS.
- [x] `GOOS=windows go vet ./pkg/api/...` and `GOOS=windows go test -c -o /dev/null ./pkg/api/` — both clean.
- [ ] Manual verification on a Windows host that a second-user `CreateFile(\\.\pipe\thv-api)` is rejected with `ERROR_ACCESS_DENIED` — pending; deferred to a reviewer with a Windows host.

## Does this introduce a user-facing change?

Yes (Windows only). Other local users on the same Windows host can no longer dial `\\.\pipe\thv-api`; only the user that started `thv serve` and SYSTEM can. macOS / Linux behaviour is unchanged.
