### PR TITLE
Pin npipe round-trip and pipe lifecycle invariants

### DIFF
--- a/pkg/api/socket_windows_test.go
+++ b/pkg/api/socket_windows_test.go
@@ -131,10 +131,9 @@ func TestSetupUnixSocket_NamedPipe_FirstInstanceWins(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = first.Close() })
 
-	second, err := setupUnixSocket(pipePath)
+	// setupUnixSocket returns (nil, err) on the named-pipe failure path, so
+	// no defensive Close is needed for the second listener.
+	_, err = setupUnixSocket(pipePath)
 	require.Error(t, err, "second ListenPipe on the same name must fail")
-	if second != nil {
-		_ = second.Close()
-	}
 	assert.Contains(t, err.Error(), "failed to create named pipe listener")
 }

--- a/pkg/api/socket_windows_test.go
+++ b/pkg/api/socket_windows_test.go
@@ -116,3 +116,25 @@ func TestCleanupUnixSocket_NamedPipe_NoOp(t *testing.T) {
 	// cleanly.
 	cleanupUnixSocket(`\\.\pipe\thv-api-cleanup-noop`)
 }
+
+// TestSetupUnixSocket_NamedPipe_FirstInstanceWins pins winio's first-wins
+// semantics: ListenPipe sets FILE_FLAG_FIRST_PIPE_INSTANCE, so a second
+// listener targeting the same name must fail. This is the safety net the
+// discovery layer relies on to detect a stale-PID conflict; if a future winio
+// bump silently relaxed it, two thv processes could bind the same pipe and
+// quietly race for traffic.
+func TestSetupUnixSocket_NamedPipe_FirstInstanceWins(t *testing.T) {
+	t.Parallel()
+	pipePath := uniqueTestPipe()
+
+	first, err := setupUnixSocket(pipePath)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = first.Close() })
+
+	second, err := setupUnixSocket(pipePath)
+	require.Error(t, err, "second ListenPipe on the same name must fail")
+	if second != nil {
+		_ = second.Close()
+	}
+	assert.Contains(t, err.Error(), "failed to create named pipe listener")
+}

--- a/pkg/server/discovery/discovery_test.go
+++ b/pkg/server/discovery/discovery_test.go
@@ -54,6 +54,31 @@ func TestWriteReadServerInfo_UnixSocket(t *testing.T) {
 	assert.Equal(t, info.Nonce, got.Nonce)
 }
 
+// TestWriteReadServerInfo_NamedPipe pins the producer/consumer contract for
+// npipe:// discovery URLs end to end. The individual pieces (socketURL emit,
+// HTTPClientForURL dispatch, ParseNamedPipeURL parse) are covered in their
+// own tests; this test asserts that an npipe URL survives the discovery
+// file's JSON serialization round-trip without being mangled.
+func TestWriteReadServerInfo_NamedPipe(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	info := &ServerInfo{
+		URL:       "npipe://thv-api",
+		PID:       99999,
+		Nonce:     "test-nonce-pipe",
+		StartedAt: time.Date(2026, 5, 7, 14, 0, 0, 0, time.UTC),
+	}
+
+	require.NoError(t, writeServerInfoTo(dir, info))
+
+	got, err := readServerInfoFrom(dir)
+	require.NoError(t, err)
+	assert.Equal(t, info.URL, got.URL)
+	assert.Equal(t, info.PID, got.PID)
+	assert.Equal(t, info.Nonce, got.Nonce)
+}
+
 func TestReadServerInfo_NotFound(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()

--- a/pkg/server/discovery/health_windows_test.go
+++ b/pkg/server/discovery/health_windows_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/Microsoft/go-winio"
 	"github.com/stretchr/testify/assert"
@@ -50,4 +51,47 @@ func TestCheckHealth_NamedPipe_NotFound(t *testing.T) {
 	err := CheckHealth(context.Background(), "npipe://nonexistent-pipe-thv-test", "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "health check failed")
+}
+
+// TestCheckHealth_NamedPipe_HungServerCancelsOnContext pins that a peer which
+// accepts the connection but never responds does not wedge CheckHealth: when
+// the caller's context expires the dial / read returns and CheckHealth surfaces
+// a wrapped error. This is the discovery StateUnhealthy path; without this
+// guarantee a hung peer would block the previous-instance probe forever.
+func TestCheckHealth_NamedPipe_HungServerCancelsOnContext(t *testing.T) {
+	t.Parallel()
+
+	pipeName := fmt.Sprintf("thv-test-hung-%d", pipeNameSeq.Add(1))
+	pipePath := `\\.\pipe\` + pipeName
+
+	listener, err := winio.ListenPipe(pipePath, &winio.PipeConfig{})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = listener.Close() })
+
+	// Drain accepts so the dial succeeds, but never write anything back. The
+	// goroutine exits when the listener is closed via t.Cleanup.
+	go func() {
+		for {
+			conn, acceptErr := listener.Accept()
+			if acceptErr != nil {
+				return
+			}
+			// Hold the connection open without responding so CheckHealth's
+			// HTTP read blocks until the context deadline fires.
+			t.Cleanup(func() { _ = conn.Close() })
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	err = CheckHealth(ctx, "npipe://"+pipeName, "")
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	// The CheckHealth call must return promptly after the context expires
+	// rather than blocking on the hung peer indefinitely. healthTimeout is
+	// 5 s, so anything within ~2 s of the 250 ms ctx is the context path.
+	assert.Less(t, elapsed, 2*time.Second, "CheckHealth wedged on a hung peer")
 }

--- a/pkg/server/discovery/health_windows_test.go
+++ b/pkg/server/discovery/health_windows_test.go
@@ -8,7 +8,9 @@ package discovery
 import (
 	"context"
 	"fmt"
+	"net"
 	"net/http"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -68,8 +70,25 @@ func TestCheckHealth_NamedPipe_HungServerCancelsOnContext(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = listener.Close() })
 
+	// Collect accepted conns under a mutex so the background goroutine never
+	// touches t after the test body returns. t.Cleanup must be registered
+	// from the test goroutine, not from the accept loop, otherwise a late
+	// Accept could race with test teardown ("Log in goroutine after Test
+	// has completed").
+	var (
+		connsMu sync.Mutex
+		conns   []net.Conn
+	)
+	t.Cleanup(func() {
+		connsMu.Lock()
+		defer connsMu.Unlock()
+		for _, c := range conns {
+			_ = c.Close()
+		}
+	})
+
 	// Drain accepts so the dial succeeds, but never write anything back. The
-	// goroutine exits when the listener is closed via t.Cleanup.
+	// goroutine exits when the listener is closed via t.Cleanup above.
 	go func() {
 		for {
 			conn, acceptErr := listener.Accept()
@@ -78,7 +97,9 @@ func TestCheckHealth_NamedPipe_HungServerCancelsOnContext(t *testing.T) {
 			}
 			// Hold the connection open without responding so CheckHealth's
 			// HTTP read blocks until the context deadline fires.
-			t.Cleanup(func() { _ = conn.Close() })
+			connsMu.Lock()
+			conns = append(conns, conn)
+			connsMu.Unlock()
 		}
 	}()
 


### PR DESCRIPTION
## Summary

Follow-up to #5201 ([review thread](https://github.com/stacklok/toolhive/pull/5201#pullrequestreview-4243582372)). Stacked on `socker-windows`; will rebase onto `main` once #5201 merges. Sibling to #5214 and #5215.

Adds three regression tests around the named-pipe transport that the original PR did not cover. None reproduce a live bug today; they pin invariants the named-pipe path implicitly relies on so a future change can't silently break them.

- **`TestWriteReadServerInfo_NamedPipe`** (cross-platform) — closes the producer/consumer loop for the discovery file: an `npipe://` URL written by `socketURL` must survive `WriteServerInfo` + `ReadServerInfo` without being mangled. The individual emit/parse pieces have their own tests; this one pins the seam.
- **`TestSetupUnixSocket_NamedPipe_FirstInstanceWins`** (Windows-only) — asserts that two `winio.ListenPipe` calls on the same name fail the second time. `winio` sets `FILE_FLAG_FIRST_PIPE_INSTANCE` so two `thv` processes cannot bind the same pipe and race for traffic; if a future `winio` bump silently relaxed that, this test catches it before the discovery layer does in production.
- **`TestCheckHealth_NamedPipe_HungServerCancelsOnContext`** (Windows-only) — covers the `StateUnhealthy` path: a peer that accepts connections but never responds must not wedge `CheckHealth` past the caller's context deadline. The existing success and not-found tests don't exercise this case.

Addresses inline review comments [3201085442](https://github.com/stacklok/toolhive/pull/5201#discussion_r3201085442) (round-trip), [3201085446](https://github.com/stacklok/toolhive/pull/5201#discussion_r3201085446) (first-instance-wins), and [3201085449](https://github.com/stacklok/toolhive/pull/5201#discussion_r3201085449) (hung-peer).

## Type of change

- Test coverage / regression hardening

## Test plan

- [x] `go test ./pkg/api/... ./pkg/server/discovery/...` — green on macOS (round-trip and Unix tests).
- [x] `task lint-fix` — 0 issues.
- [x] `GOOS=windows go vet` and `GOOS=windows go test -c -o /dev/null` for both packages — both clean.
- [x] Manual `go test -tags windows -run NamedPipe` on a Windows host — pending; deferred to a reviewer with a Windows host. The Windows-only tests are guarded by build tags and do not run on macOS / Linux.

## Does this introduce a user-facing change?

No.

Made with [Cursor](https://cursor.com)