### PR TITLE
Recognize mcp-go authorization-required sentinels as auth

### DIFF
--- a/pkg/vmcp/client/client.go
+++ b/pkg/vmcp/client/client.go
@@ -444,6 +444,17 @@ func wrapBackendError(err error, backendID string, operation string) error {
 		return fmt.Errorf("%w: failed to %s for backend %s: %v",
 			vmcp.ErrAuthenticationFailed, operation, backendID, err)
 	}
+	// transport.ErrAuthorizationRequired is returned (wrapped in *transport.Error
+	// and *transport.AuthorizationRequiredError) for 401 responses with a
+	// WWW-Authenticate header. transport.ErrOAuthAuthorizationRequired is the
+	// companion sentinel from the OAuth-handler path. Both must map to
+	// ErrAuthenticationFailed so health monitoring engages the auth-aware
+	// branch (#4935) instead of treating the probe as unhealthy (#5223).
+	if errors.Is(err, transport.ErrAuthorizationRequired) ||
+		errors.Is(err, transport.ErrOAuthAuthorizationRequired) {
+		return fmt.Errorf("%w: failed to %s for backend %s: %v",
+			vmcp.ErrAuthenticationFailed, operation, backendID, err)
+	}
 	// ErrLegacySSEServer is returned for any 4xx (except 401) on initialize POST.
 	// This includes 403 (auth rejection) and 404/405 (endpoint not found/method not allowed).
 	// We cannot distinguish auth failures from routing errors without the raw status code,

--- a/pkg/vmcp/client/client_test.go
+++ b/pkg/vmcp/client/client_test.go
@@ -1001,6 +1001,34 @@ func TestWrapBackendError(t *testing.T) {
 			err:          context.DeadlineExceeded,
 			wantSentinel: vmcp.ErrTimeout,
 		},
+		{
+			// mcp-go v0.49.0 added ErrAuthorizationRequired for 401 responses
+			// with a WWW-Authenticate header. Issue #5223: probe of GitHub
+			// Copilot's MCP returns this; without recognizing the sentinel here
+			// the error falls through to ErrBackendUnavailable and the health
+			// monitor never engages the auth-aware branch (#4935).
+			name:         "ErrAuthorizationRequired maps to ErrAuthenticationFailed",
+			err:          transport.ErrAuthorizationRequired,
+			wantSentinel: vmcp.ErrAuthenticationFailed,
+		},
+		{
+			// Production chain mcp-go produces: transport.Error wrapping
+			// *AuthorizationRequiredError. Error() formats as
+			// "transport error: authorization required" — byte-for-byte
+			// the string seen in North's WARN logs (issue #5223). Both
+			// layers Unwrap() to the sentinel so errors.Is must succeed.
+			name:         "wrapped AuthorizationRequiredError (production chain) maps to ErrAuthenticationFailed",
+			err:          transport.NewError(&transport.AuthorizationRequiredError{}),
+			wantSentinel: vmcp.ErrAuthenticationFailed,
+		},
+		{
+			// Companion sentinel for the OAuth-handler path. Less hot in
+			// practice but belongs in the same matcher block; the existing
+			// transport.ErrUnauthorized check would not catch it.
+			name:         "ErrOAuthAuthorizationRequired maps to ErrAuthenticationFailed",
+			err:          transport.ErrOAuthAuthorizationRequired,
+			wantSentinel: vmcp.ErrAuthenticationFailed,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/vmcp/errors.go
+++ b/pkg/vmcp/errors.go
@@ -119,6 +119,14 @@ func IsAuthenticationError(err error) bool {
 		return true
 	}
 
+	// mcp-go ErrAuthorizationRequired ("authorization required") and
+	// ErrOAuthAuthorizationRequired ("no valid token available, authorization
+	// required") string forms. Used as a fallback when the typed sentinel is
+	// not preserved through the error chain (issue #5223).
+	if strings.Contains(errLower, "authorization required") {
+		return true
+	}
+
 	return false
 }
 

--- a/pkg/vmcp/health/checker_test.go
+++ b/pkg/vmcp/health/checker_test.go
@@ -451,6 +451,14 @@ func TestIsAuthenticationError(t *testing.T) {
 		{name: "404 not found", err: errors.New("404 not found"), expectErr: false},
 		{name: "500 internal server error", err: errors.New("500 internal server error"), expectErr: false},
 		{name: "hostname with 401", err: errors.New("http://backend401.example.com"), expectErr: false},
+		// Pin against accidental loosening of the "authorization required"
+		// substring matcher: a validation message of the form "field
+		// 'authorization' required" must not be misclassified as an auth
+		// failure. The current matcher uses the contiguous substring
+		// "authorization required" (one space, no punctuation), so this
+		// string does not match — but a future loosening (e.g. allowing
+		// any whitespace) would silently regress.
+		{name: "validation message containing 'authorization' and 'required'", err: errors.New("field 'authorization' required"), expectErr: false},
 		{name: "nil error", err: nil, expectErr: false},
 	}
 
@@ -641,7 +649,7 @@ func TestHealthChecker_CheckHealth_AuthErrorsCategorizesAsUnauthenticated(t *tes
 			// must recognize "authorization required" so the probe error reaches
 			// health monitoring as BackendUnauthenticated rather than falling
 			// through to BackendUnhealthy and producing WARN spam.
-			name: "issue #5223 - mcp-go authorization required production chain",
+			name: "transport.Error wrapping AuthorizationRequiredError",
 			err:  transport.NewError(&transport.AuthorizationRequiredError{}),
 		},
 	}
@@ -715,8 +723,22 @@ func TestHealthChecker_CheckHealth_AuthErrorWithOutgoingAuthIsHealthy(t *testing
 			// classified as auth, #4935's logic must take over and report
 			// BackendHealthy with nil err so the monitor records a successful
 			// check, the circuit breaker stays closed, and the WARN spam stops.
-			name:       "upstream_inject + mcp-go authorization required (issue #5223 North reproducer)",
+			name:       "upstream_inject + transport.Error wrapping AuthorizationRequiredError",
 			authConfig: &authtypes.BackendAuthStrategy{Type: authtypes.StrategyTypeUpstreamInject},
+			err:        transport.NewError(&transport.AuthorizationRequiredError{}),
+		},
+		{
+			// Same mcp-go chain as the upstream_inject row above; this row pins
+			// that token_exchange flows through the same authErrorStatus branch.
+			name:       "token_exchange + transport.Error wrapping AuthorizationRequiredError",
+			authConfig: &authtypes.BackendAuthStrategy{Type: authtypes.StrategyTypeTokenExchange},
+			err:        transport.NewError(&transport.AuthorizationRequiredError{}),
+		},
+		{
+			// Same mcp-go chain as the upstream_inject row above; this row pins
+			// that header_injection flows through the same authErrorStatus branch.
+			name:       "header_injection + transport.Error wrapping AuthorizationRequiredError",
+			authConfig: &authtypes.BackendAuthStrategy{Type: authtypes.StrategyTypeHeaderInjection},
 			err:        transport.NewError(&transport.AuthorizationRequiredError{}),
 		},
 	}

--- a/pkg/vmcp/health/checker_test.go
+++ b/pkg/vmcp/health/checker_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/mark3labs/mcp-go/client/transport"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -633,6 +634,16 @@ func TestHealthChecker_CheckHealth_AuthErrorsCategorizesAsUnauthenticated(t *tes
 			name: "mcp-go ErrUnauthorized wrapped as ErrAuthenticationFailed by wrapBackendError",
 			err:  fmt.Errorf("%w: failed to initialize for backend my-backend: unauthorized (401)", vmcp.ErrAuthenticationFailed),
 		},
+		{
+			// Issue #5223: mcp-go v0.49.0+ returns *AuthorizationRequiredError for
+			// 401 with WWW-Authenticate, wrapped in *transport.Error. Both layers
+			// Unwrap() to transport.ErrAuthorizationRequired. The string fallback
+			// must recognize "authorization required" so the probe error reaches
+			// health monitoring as BackendUnauthenticated rather than falling
+			// through to BackendUnhealthy and producing WARN spam.
+			name: "issue #5223 - mcp-go authorization required production chain",
+			err:  transport.NewError(&transport.AuthorizationRequiredError{}),
+		},
 	}
 
 	for _, tt := range tests {
@@ -696,6 +707,17 @@ func TestHealthChecker_CheckHealth_AuthErrorWithOutgoingAuthIsHealthy(t *testing
 			name:       "upstream_inject + wrapped sentinel",
 			authConfig: &authtypes.BackendAuthStrategy{Type: authtypes.StrategyTypeUpstreamInject},
 			err:        fmt.Errorf("%w: unauthorized (401)", vmcp.ErrAuthenticationFailed),
+		},
+		{
+			// Issue #5223 exact reproducer: North's github-copilot-entry backend
+			// behind an upstreamInject auth strategy. Probe carries no user creds;
+			// mcp-go returns the typed authorization-required chain. Once correctly
+			// classified as auth, #4935's logic must take over and report
+			// BackendHealthy with nil err so the monitor records a successful
+			// check, the circuit breaker stays closed, and the WARN spam stops.
+			name:       "upstream_inject + mcp-go authorization required (issue #5223 North reproducer)",
+			authConfig: &authtypes.BackendAuthStrategy{Type: authtypes.StrategyTypeUpstreamInject},
+			err:        transport.NewError(&transport.AuthorizationRequiredError{}),
 		},
 	}
 


### PR DESCRIPTION
Closes #5223

## Summary

The vMCP gateway emits a `backend remains unhealthy` WARN every 30s for
`upstreamInject` backends that are functionally fine. North hit 2780+
consecutive "failures" on `github-copilot-entry` — pure log noise, since
the backend is reachable and only fails because the background probe
carries no user credentials.

Root cause: mcp-go v0.49.0 added two sentinels for 401 responses
(`transport.ErrAuthorizationRequired` and
`transport.ErrOAuthAuthorizationRequired`). `wrapBackendError` did not
check for either, so the error fell through to `ErrBackendUnavailable`
and the health monitor categorized the probe as `BackendUnhealthy`. The
auth-aware fix from #4935 ("treat 401/403 from auth-configured backends
as healthy") therefore never engaged.

- Add typed `errors.Is` checks for both new mcp-go sentinels in
  `wrapBackendError` so production probes through `BackendClient` are
  correctly mapped to `ErrAuthenticationFailed`.
- Add `"authorization required"` to `IsAuthenticationError` as a
  fallback for paths where the typed sentinel is not preserved through
  the error chain (covers the integration-test path where a mock
  bypasses `wrapBackendError`, and any future Unwrap breakage).

With both in place, North’s `upstream_inject` backend reports
`BackendHealthy` (probe gets a `nil` error), the consecutive_failures
counter stays at 0, and the WARN spam stops. Misconfigured backends
(no outgoing auth strategy) continue to surface as
`BackendUnauthenticated` so operators see the diagnostic signal.

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)

Five new test sub-cases were added in a separate red commit before the
fix to lock in the regression:

- `TestWrapBackendError`: three sub-cases — `ErrAuthorizationRequired`,
  the wrapped production chain
  (`transport.Error` → `*AuthorizationRequiredError`), and
  `ErrOAuthAuthorizationRequired` — each must map to
  `ErrAuthenticationFailed`.
- `TestHealthChecker_CheckHealth_AuthErrorsCategorizesAsUnauthenticated`:
  the raw mcp-go chain reaching the checker classifies as
  `BackendUnauthenticated` when no outgoing auth strategy is configured.
- `TestHealthChecker_CheckHealth_AuthErrorWithOutgoingAuthIsHealthy`:
  `upstream_inject` + the raw mcp-go chain (Norths exact reproducer)
  classifies as `BackendHealthy` with `nil` error so the monitor
  records a successful check.

All five sub-cases were red on `main` (verified before commit 1) and
green after the fix.

## Does this introduce a user-facing change?

WARN spam (`backend remains unhealthy`) for `upstreamInject` backends
that respond with 401/`authorization required` to no-credential probes
will stop. Backends previously misclassified as `BackendUnhealthy`
under these conditions will now be reported as `BackendHealthy`, and
the consecutive_failures counter will reset. No CRD or API changes.

Generated with [Claude Code](https://claude.com/claude-code)