### PR TITLE
Delegate tokenexchange HTTP plumbing to pkg/oauthproto

### DIFF
--- a/pkg/auth/tokenexchange/exchange.go
+++ b/pkg/auth/tokenexchange/exchange.go
@@ -6,28 +6,16 @@ package tokenexchange
 
 import (
 	"context"
-	"encoding/json"
+	"errors"
 	"fmt"
-	"io"
-	"log/slog"
 	"net/http"
 	"net/url"
-	"strconv"
 	"strings"
-	"time"
 
 	"golang.org/x/oauth2"
 
 	"github.com/stacklok/toolhive/pkg/oauthproto"
 )
-
-// maxResponseBodySize bounds io.LimitReader in executeTokenExchangeRequest so
-// a pathological server cannot exhaust memory. The shared pkg/oauthproto
-// package has an identical unexported constant, but we cannot import it yet —
-// the shared one is consumed by oauthproto.DoTokenRequest, which will replace
-// executeTokenExchangeRequest in a follow-up commit.
-// TODO: drop when executeTokenExchangeRequest is replaced by oauthproto.DoTokenRequest.
-const maxResponseBodySize = 1 << 20
 
 // NormalizeTokenType converts a short token type name to its full URN.
 // Accepts both short forms ("access_token", "id_token", "jwt") and full URNs.
@@ -94,22 +82,6 @@ func (r exchangeRequest) String() string {
 		r.GrantType, r.Audience, r.Resource, r.Scope, oauthproto.Redact(r.SubjectToken), actorToken)
 }
 
-// response is used to decode the remote server response during an OAuth 2.0 token exchange.
-type response struct {
-	AccessToken     string `json:"access_token"`
-	IssuedTokenType string `json:"issued_token_type"`
-	TokenType       string `json:"token_type"`
-	ExpiresIn       int    `json:"expires_in"`
-	Scope           string `json:"scope"`
-	RefreshToken    string `json:"refresh_token"`
-}
-
-// String implements fmt.Stringer for response, redacting sensitive tokens.
-func (r response) String() string {
-	return fmt.Sprintf("response{AccessToken: %s, TokenType: %s, ExpiresIn: %d, RefreshToken: %s}",
-		oauthproto.Redact(r.AccessToken), r.TokenType, r.ExpiresIn, oauthproto.Redact(r.RefreshToken))
-}
-
 // clientAuthentication represents OAuth client credentials for token exchange.
 type clientAuthentication struct {
 	ClientID     string
@@ -166,6 +138,13 @@ type ExchangeConfig struct {
 }
 
 // Validate checks if the ExchangeConfig contains all required fields.
+//
+// Side effect: when SubjectTokenType is provided as a short form
+// ("access_token", "id_token", "jwt"), Validate normalizes it to the full
+// RFC 8693 URN and writes the result back onto the receiver. Callers in
+// pkg/vmcp/auth/strategies/tokenexchange.go and pkg/runner/config_builder.go
+// read the normalized value after Validate returns, so this mutation is part
+// of the documented contract.
 func (c *ExchangeConfig) Validate() error {
 	if c.TokenURL == "" {
 		return fmt.Errorf("TokenURL is required")
@@ -267,33 +246,18 @@ func (ts *tokenSource) Token() (*oauth2.Token, error) {
 		return nil, err
 	}
 
-	// Validate required RFC 8693 response fields
-	if resp.AccessToken == "" {
-		return nil, fmt.Errorf("token exchange: server returned empty access_token")
+	// RFC 8693 Section 2.2.1 requires token_type in the response. The shared
+	// oauthproto.ParseTokenResponse is intentionally permissive on this field
+	// (matching x/oauth2); token exchange tightens it back.
+	if resp.Token.TokenType == "" {
+		return nil, fmt.Errorf("token exchange: server returned empty token_type (required by RFC 8693)")
 	}
-	if resp.TokenType == "" {
-		return nil, fmt.Errorf("token exchange: server returned empty token_type")
-	}
+	// RFC 8693 Section 2.2.1 requires issued_token_type in the response.
 	if resp.IssuedTokenType == "" {
 		return nil, fmt.Errorf("token exchange: server returned empty issued_token_type (required by RFC 8693)")
 	}
 
-	// Build oauth2.Token
-	token := &oauth2.Token{
-		AccessToken: resp.AccessToken,
-		TokenType:   resp.TokenType,
-	}
-
-	// Set expiry if provided
-	if resp.ExpiresIn > 0 {
-		token.Expiry = time.Now().Add(time.Duration(resp.ExpiresIn) * time.Second)
-	}
-
-	if resp.RefreshToken != "" {
-		token.RefreshToken = resp.RefreshToken
-	}
-
-	return token, nil
+	return resp.Token, nil
 }
 
 // TokenSource returns an oauth2.TokenSource that performs token exchange.
@@ -312,36 +276,35 @@ func exchangeToken(
 	request *exchangeRequest,
 	auth clientAuthentication,
 	client *http.Client,
-) (*response, error) {
-	data, err := buildTokenExchangeFormData(request)
+) (*oauthproto.TokenResponse, error) {
+	data, err := buildFormData(request)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := createTokenExchangeRequest(ctx, endpoint, data, auth)
+	req, err := oauthproto.NewFormRequest(ctx, endpoint, data, auth.ClientID, auth.ClientSecret)
 	if err != nil {
+		return nil, fmt.Errorf("tokenexchange: build request: %w", err)
+	}
+
+	resp, err := oauthproto.DoTokenRequest(client, req)
+	if err != nil {
+		// Preserve the pre-refactor behavior: scrub RetrieveError.Body so raw
+		// upstream content cannot leak into error strings via err.Error().
+		// pkg/oauthproto deliberately preserves Body for general-purpose
+		// callers; tokenexchange opts back into the stricter behavior because
+		// its errors propagate through vmcp / runner paths that may log them.
+		var retrieveErr *oauth2.RetrieveError
+		if errors.As(err, &retrieveErr) {
+			retrieveErr.Body = nil
+		}
 		return nil, err
 	}
-
-	if client == nil {
-		client = oauthproto.DefaultHTTPClient()
-	}
-
-	body, err := executeTokenExchangeRequest(client, req)
-	if err != nil {
-		return nil, err
-	}
-
-	tokenResp, err := parseTokenExchangeResponse(body)
-	if err != nil {
-		return nil, err
-	}
-
-	return tokenResp, nil
+	return resp, nil
 }
 
-// buildTokenExchangeFormData constructs the form data for a token exchange request according to RFC 8693.
-func buildTokenExchangeFormData(request *exchangeRequest) (url.Values, error) {
+// buildFormData constructs the form data for a token exchange request according to RFC 8693.
+func buildFormData(request *exchangeRequest) (url.Values, error) {
 	data := url.Values{}
 
 	// Grant type is always token exchange
@@ -392,111 +355,4 @@ func addOptionalFields(data url.Values, request *exchangeRequest) {
 			data.Set("actor_token_type", request.ActingParty.ActorTokenType)
 		}
 	}
-}
-
-// createTokenExchangeRequest creates an HTTP POST request for token exchange.
-// Client credentials are sent via HTTP Basic Authentication as recommended by RFC 6749 Section 2.3.1.
-func createTokenExchangeRequest(
-	ctx context.Context,
-	endpoint string,
-	data url.Values,
-	auth clientAuthentication,
-) (*http.Request, error) {
-	encodedData := data.Encode()
-	req, err := http.NewRequestWithContext(ctx, "POST", endpoint, strings.NewReader(encodedData))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create token exchange request: %w", err)
-	}
-
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	req.Header.Set("Content-Length", strconv.Itoa(len(encodedData)))
-
-	// Add client authentication via HTTP Basic Auth per RFC 6749 Section 2.3.1
-	// Per RFC 6749 and Go's SetBasicAuth documentation, credentials must be URL-encoded
-	// before being passed to SetBasicAuth for OAuth2 compatibility
-	if auth.ClientID != "" && auth.ClientSecret != "" {
-		req.SetBasicAuth(url.QueryEscape(auth.ClientID), url.QueryEscape(auth.ClientSecret))
-	}
-
-	return req, nil
-}
-
-// executeTokenExchangeRequest sends the HTTP request and returns the response body.
-func executeTokenExchangeRequest(client *http.Client, req *http.Request) ([]byte, error) {
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("token exchange request failed: %w", err)
-	}
-	defer func() {
-		// Close without draining — matches oauthproto.DoTokenRequest. The
-		// LimitReader below caps how much we read; draining the remainder
-		// would be unbounded on oversized or never-terminating bodies and
-		// defeat the 1 MiB memory cap. Connection reuse is the tradeoff.
-		if closeErr := resp.Body.Close(); closeErr != nil {
-			slog.Debug("token exchange: close response body", "error", closeErr)
-		}
-	}()
-
-	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBodySize))
-	if err != nil {
-		return nil, fmt.Errorf("failed to read token exchange response: %w", err)
-	}
-
-	if err := validateResponseStatus(resp, body); err != nil {
-		return nil, err
-	}
-
-	return body, nil
-}
-
-// validateResponseStatus checks the HTTP status code and returns an error if not successful.
-// On non-2xx responses it extracts RFC 6749 §5.2 fields (error, error_description, error_uri)
-// onto the structured fields of the returned *oauth2.RetrieveError. Body is always cleared so
-// callers cannot interpolate raw upstream content into error strings — matching the pattern used
-// by Ory Hydra, which never surfaces raw error bodies through its public error type.
-func validateResponseStatus(resp *http.Response, body []byte) error {
-	if resp.StatusCode >= 200 && resp.StatusCode <= 299 {
-		return nil
-	}
-
-	retrieveErr := &oauth2.RetrieveError{
-		Response: resp,
-		Body:     body,
-	}
-
-	// Best-effort parse of the RFC 6749 Section 5.2 error response. Non-JSON or
-	// non-error-shaped bodies leave ErrorCode/ErrorDescription/ErrorURI empty.
-	var oauthErr struct {
-		Error            string `json:"error"`
-		ErrorDescription string `json:"error_description,omitempty"`
-		ErrorURI         string `json:"error_uri,omitempty"`
-	}
-	if err := json.Unmarshal(body, &oauthErr); err == nil {
-		retrieveErr.ErrorCode = oauthErr.Error
-		retrieveErr.ErrorDescription = oauthErr.ErrorDescription
-		retrieveErr.ErrorURI = oauthErr.ErrorURI
-	}
-
-	if retrieveErr.ErrorCode != "" {
-		slog.Debug("Token exchange OAuth error",
-			"oauth_error_code", retrieveErr.ErrorCode,
-			"description", retrieveErr.ErrorDescription)
-	} else {
-		slog.Debug("Token exchange failed", "status", resp.StatusCode, "body_length", len(body), "body", string(body))
-	}
-
-	retrieveErr.Body = nil
-
-	return retrieveErr
-}
-
-// parseTokenExchangeResponse parses the token exchange response body.
-func parseTokenExchangeResponse(body []byte) (*response, error) {
-	var tokenResp response
-	if err := json.Unmarshal(body, &tokenResp); err != nil {
-		slog.Debug("Failed to parse token exchange response", "error", err)
-		return nil, fmt.Errorf("failed to parse token exchange response: %w", err)
-	}
-
-	return &tokenResp, nil
 }

--- a/pkg/auth/tokenexchange/exchange_test.go
+++ b/pkg/auth/tokenexchange/exchange_test.go
@@ -21,60 +21,13 @@ import (
 	"golang.org/x/oauth2"
 
 	"github.com/stacklok/toolhive/pkg/oauthproto"
+	"github.com/stacklok/toolhive/pkg/oauthproto/oauthtest"
 )
 
 const (
 	// testSubjectToken is a test subject token value used across multiple test cases
 	testSubjectToken = "test-subject-token"
 )
-
-// Test helper - builder pattern for creating mock responses
-
-// responseBuilder builds test OAuth 2.0 token exchange responses.
-type responseBuilder struct {
-	resp response
-}
-
-// newResponse creates a new response builder with sensible defaults.
-// Returns a minimal valid response (access_token, token_type, issued_token_type).
-func newResponse() *responseBuilder {
-	return &responseBuilder{
-		resp: response{
-			AccessToken:     "token",
-			IssuedTokenType: oauthproto.TokenTypeAccessToken,
-			TokenType:       "Bearer",
-		},
-	}
-}
-
-// withAccessToken sets a custom access token.
-func (b *responseBuilder) withAccessToken(token string) *responseBuilder {
-	b.resp.AccessToken = token
-	return b
-}
-
-// withExpiry sets the token expiry in seconds.
-func (b *responseBuilder) withExpiry(seconds int) *responseBuilder {
-	b.resp.ExpiresIn = seconds
-	return b
-}
-
-// withRefreshToken adds a refresh token to the response.
-func (b *responseBuilder) withRefreshToken(token string) *responseBuilder {
-	b.resp.RefreshToken = token
-	return b
-}
-
-// withScope sets the scope for the response.
-func (b *responseBuilder) withScope(scope string) *responseBuilder {
-	b.resp.Scope = scope
-	return b
-}
-
-// build returns the constructed response.
-func (b *responseBuilder) build() response {
-	return b.resp
-}
 
 // TestNormalizeTokenType tests the NormalizeTokenType function.
 func TestNormalizeTokenType(t *testing.T) {
@@ -205,15 +158,15 @@ func TestTokenSource_Token_Success(t *testing.T) {
 		assert.Empty(t, r.Form.Get("client_secret"), "client_secret should not be in request body")
 
 		// Return successful response
-		resp := newResponse().
-			withAccessToken("exchanged-access-token").
-			withScope("read write").
-			withExpiry(3600).
-			build()
+		body := oauthtest.NewResponse().
+			WithAccessToken("exchanged-access-token").
+			WithScope("read write").
+			WithExpiresIn(3600).
+			Build()
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		err = json.NewEncoder(w).Encode(resp)
+		_, err = w.Write(body)
 		require.NoError(t, err)
 	}))
 	t.Cleanup(server.Close)
@@ -248,15 +201,15 @@ func TestTokenSource_Token_WithRefreshToken(t *testing.T) {
 	t.Parallel()
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		resp := newResponse().
-			withAccessToken("exchanged-access-token").
-			withRefreshToken("refresh-token-value").
-			withExpiry(3600).
-			build()
+		body := oauthtest.NewResponse().
+			WithAccessToken("exchanged-access-token").
+			WithRefreshToken("refresh-token-value").
+			WithExpiresIn(3600).
+			Build()
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		_ = json.NewEncoder(w).Encode(resp)
+		_, _ = w.Write(body)
 	}))
 	t.Cleanup(server.Close)
 
@@ -283,12 +236,12 @@ func TestTokenSource_Token_NoExpiry(t *testing.T) {
 	t.Parallel()
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		resp := newResponse().withAccessToken("exchanged-access-token").build()
-		// No expiry (ExpiresIn: 0)
+		body := oauthtest.NewResponse().WithAccessToken("exchanged-access-token").Build()
+		// No expiry (ExpiresIn unset → omitted)
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		_ = json.NewEncoder(w).Encode(resp)
+		_, _ = w.Write(body)
 	}))
 	t.Cleanup(server.Close)
 
@@ -363,7 +316,9 @@ func TestTokenSource_Token_ContextCancellation(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Nil(t, token)
-	assert.Contains(t, err.Error(), "token exchange request failed")
+	// oauth.DoTokenRequest wraps transport-level failures (including
+	// context cancellation) with "oauth: token request failed".
+	assert.Contains(t, err.Error(), "oauth: token request failed")
 }
 
 // TestExchangeToken_HTTPErrorResponses tests various HTTP error responses.
@@ -406,7 +361,7 @@ func TestExchangeToken_HTTPErrorResponses(t *testing.T) {
 			name:         "503 Service Unavailable",
 			statusCode:   http.StatusServiceUnavailable,
 			responseBody: "Service temporarily unavailable",
-			// Non-JSON body: ErrorCode stays empty, body cleared to prevent info leak.
+			// Non-JSON body: ErrorCode stays empty, body cleared.
 		},
 	}
 
@@ -443,6 +398,8 @@ func TestExchangeToken_HTTPErrorResponses(t *testing.T) {
 			assert.Equal(t, tt.statusCode, retrieveErr.Response.StatusCode)
 			assert.Equal(t, tt.expectedErrorCode, retrieveErr.ErrorCode)
 			assert.Equal(t, tt.expectedDescription, retrieveErr.ErrorDescription)
+			// Regression: exchangeToken must scrub RetrieveError.Body so raw
+			// upstream content cannot leak into error strings.
 			assert.Nil(t, retrieveErr.Body)
 		})
 	}
@@ -495,7 +452,7 @@ func TestExchangeToken_MalformedJSON(t *testing.T) {
 
 			require.Error(t, err)
 			assert.Nil(t, resp)
-			assert.Contains(t, err.Error(), "failed to parse token exchange response")
+			assert.Contains(t, err.Error(), "oauth: cannot parse token response")
 		})
 	}
 }
@@ -537,10 +494,9 @@ func TestExchangeToken_DefaultValues(t *testing.T) {
 		assert.Equal(t, "urn:ietf:params:oauth:token-type:access_token", r.Form.Get("subject_token_type"))
 		assert.Equal(t, "urn:ietf:params:oauth:token-type:access_token", r.Form.Get("requested_token_type"))
 
-		resp := newResponse().build()
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		_ = json.NewEncoder(w).Encode(resp)
+		_, _ = w.Write(oauthtest.NewResponse().Build())
 	}))
 	t.Cleanup(server.Close)
 
@@ -572,10 +528,9 @@ func TestExchangeToken_OptionalFields(t *testing.T) {
 		assert.Equal(t, "actor-token-value", r.Form.Get("actor_token"))
 		assert.Equal(t, "urn:ietf:params:oauth:token-type:jwt", r.Form.Get("actor_token_type"))
 
-		resp := newResponse().build()
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		_ = json.NewEncoder(w).Encode(resp)
+		_, _ = w.Write(oauthtest.NewResponse().Build())
 	}))
 	t.Cleanup(server.Close)
 
@@ -613,10 +568,9 @@ func TestExchangeToken_ActorTokenWithoutType(t *testing.T) {
 		assert.Equal(t, "actor-token-value", r.Form.Get("actor_token"))
 		assert.Empty(t, r.Form.Get("actor_token_type"))
 
-		resp := newResponse().build()
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		_ = json.NewEncoder(w).Encode(resp)
+		_, _ = w.Write(oauthtest.NewResponse().Build())
 	}))
 	t.Cleanup(server.Close)
 
@@ -650,7 +604,9 @@ func TestExchangeToken_InvalidURL(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Nil(t, resp)
-	assert.Contains(t, err.Error(), "failed to create token exchange request")
+	// Request construction now goes through oauth.NewFormRequest and the
+	// tokenexchange call site wraps with its own prefix.
+	assert.Contains(t, err.Error(), "tokenexchange: build request")
 }
 
 // TestExchangeToken_NetworkError tests error handling for network failures.
@@ -668,7 +624,8 @@ func TestExchangeToken_NetworkError(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Nil(t, resp)
-	assert.Contains(t, err.Error(), "token exchange request failed")
+	// oauth.DoTokenRequest wraps transport-level failures with this prefix.
+	assert.Contains(t, err.Error(), "oauth: token request failed")
 }
 
 // TestExchangeToken_ResponseSizeLimit tests that large responses are properly limited.
@@ -698,9 +655,10 @@ func TestExchangeToken_ResponseSizeLimit(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Nil(t, resp)
-	// The io.LimitReader allows reading up to 1MB, then truncates the response
-	// This causes a JSON parsing error rather than a read error
-	assert.Contains(t, err.Error(), "failed to parse token exchange response")
+	// oauth.DoTokenRequest uses io.LimitReader to cap the body at 1 MiB, then
+	// truncates further bytes. That produces a JSON parse failure rather than
+	// a read error, surfaced as "oauth: cannot parse token response".
+	assert.Contains(t, err.Error(), "oauth: cannot parse token response")
 }
 
 // TestExchangeToken_NoCredentialLeakage tests that credentials are not leaked in error messages.
@@ -779,10 +737,9 @@ func TestExchangeToken_FormEncoding(t *testing.T) {
 		// Verify that special characters are properly decoded
 		assert.Equal(t, specialChars, r.Form.Get("subject_token"))
 
-		resp := newResponse().build()
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		_ = json.NewEncoder(w).Encode(resp)
+		_, _ = w.Write(oauthtest.NewResponse().Build())
 	}))
 	t.Cleanup(server.Close)
 
@@ -808,14 +765,13 @@ func TestExchangeToken_ContentLength(t *testing.T) {
 		assert.NotEmpty(t, contentLength)
 
 		// Read body and verify it matches Content-Length
-		body, err := io.ReadAll(r.Body)
+		reqBody, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
-		assert.Equal(t, contentLength, fmt.Sprintf("%d", len(body)))
+		assert.Equal(t, contentLength, fmt.Sprintf("%d", len(reqBody)))
 
-		resp := newResponse().build()
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		_ = json.NewEncoder(w).Encode(resp)
+		_, _ = w.Write(oauthtest.NewResponse().Build())
 	}))
 	t.Cleanup(server.Close)
 
@@ -896,10 +852,10 @@ func TestSubjectTokenProvider_Variants(t *testing.T) {
 
 			// Create server within subtest to avoid race conditions with parallel execution
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-				resp := newResponse().withAccessToken("exchanged-token").build()
+				body := oauthtest.NewResponse().WithAccessToken("exchanged-token").Build()
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusOK)
-				_ = json.NewEncoder(w).Encode(resp)
+				_, _ = w.Write(body)
 			}))
 			t.Cleanup(server.Close)
 
@@ -945,10 +901,9 @@ func TestExchangeToken_EmptyClientCredentials(t *testing.T) {
 		assert.Empty(t, r.Form.Get("client_id"))
 		assert.Empty(t, r.Form.Get("client_secret"))
 
-		resp := newResponse().build()
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		_ = json.NewEncoder(w).Encode(resp)
+		_, _ = w.Write(oauthtest.NewResponse().Build())
 	}))
 	t.Cleanup(server.Close)
 
@@ -983,10 +938,9 @@ func TestExchangeToken_OnlyClientID(t *testing.T) {
 		assert.Empty(t, r.Form.Get("client_id"))
 		assert.Empty(t, r.Form.Get("client_secret"))
 
-		resp := newResponse().build()
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		_ = json.NewEncoder(w).Encode(resp)
+		_, _ = w.Write(oauthtest.NewResponse().Build())
 	}))
 	t.Cleanup(server.Close)
 
@@ -1010,15 +964,15 @@ func TestExchangeToken_ResponseFields(t *testing.T) {
 	t.Parallel()
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		resp := newResponse().
-			withAccessToken("access-token-value").
-			withScope("openid profile email").
-			withRefreshToken("refresh-token-value").
-			withExpiry(7200).
-			build()
+		body := oauthtest.NewResponse().
+			WithAccessToken("access-token-value").
+			WithScope("openid profile email").
+			WithRefreshToken("refresh-token-value").
+			WithExpiresIn(7200).
+			Build()
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		_ = json.NewEncoder(w).Encode(resp)
+		_, _ = w.Write(body)
 	}))
 	t.Cleanup(server.Close)
 
@@ -1031,12 +985,14 @@ func TestExchangeToken_ResponseFields(t *testing.T) {
 	resp, err := exchangeToken(ctx, server.URL, request, auth, nil)
 
 	require.NoError(t, err)
-	assert.Equal(t, "access-token-value", resp.AccessToken)
+	assert.Equal(t, "access-token-value", resp.Token.AccessToken)
 	assert.Equal(t, "urn:ietf:params:oauth:token-type:access_token", resp.IssuedTokenType)
-	assert.Equal(t, "Bearer", resp.TokenType)
-	assert.Equal(t, 7200, resp.ExpiresIn)
+	assert.Equal(t, "Bearer", resp.Token.TokenType)
+	// expires_in is folded into Token.Expiry by oauth.ParseTokenResponse.
+	assert.False(t, resp.Token.Expiry.IsZero())
+	assert.WithinDuration(t, time.Now().Add(7200*time.Second), resp.Token.Expiry, 5*time.Second)
 	assert.Equal(t, "openid profile email", resp.Scope)
-	assert.Equal(t, "refresh-token-value", resp.RefreshToken)
+	assert.Equal(t, "refresh-token-value", resp.Token.RefreshToken)
 }
 
 // TestExchangeToken_MinimalResponse tests response with only required fields.
@@ -1046,11 +1002,11 @@ func TestExchangeToken_MinimalResponse(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		// Minimal valid response according to RFC 8693
 		// All three fields (access_token, token_type, issued_token_type) are required
-		resp := newResponse().withAccessToken("access-token-value").build()
+		body := oauthtest.NewResponse().WithAccessToken("access-token-value").Build()
 		// ExpiresIn, Scope, RefreshToken are optional
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		_ = json.NewEncoder(w).Encode(resp)
+		_, _ = w.Write(body)
 	}))
 	t.Cleanup(server.Close)
 
@@ -1063,12 +1019,13 @@ func TestExchangeToken_MinimalResponse(t *testing.T) {
 	resp, err := exchangeToken(ctx, server.URL, request, auth, nil)
 
 	require.NoError(t, err)
-	assert.Equal(t, "access-token-value", resp.AccessToken)
-	assert.Equal(t, "Bearer", resp.TokenType)
+	assert.Equal(t, "access-token-value", resp.Token.AccessToken)
+	assert.Equal(t, "Bearer", resp.Token.TokenType)
 	assert.Equal(t, oauthproto.TokenTypeAccessToken, resp.IssuedTokenType)
-	assert.Equal(t, 0, resp.ExpiresIn)
+	// Absent expires_in leaves Token.Expiry as the zero value.
+	assert.True(t, resp.Token.Expiry.IsZero())
 	assert.Empty(t, resp.Scope)
-	assert.Empty(t, resp.RefreshToken)
+	assert.Empty(t, resp.Token.RefreshToken)
 }
 
 // TestExchangeToken_ScopeArray tests that scope array is properly converted to space-separated string.
@@ -1116,10 +1073,9 @@ func TestExchangeToken_ScopeArray(t *testing.T) {
 					assert.Equal(t, tt.expectedScope, r.Form.Get("scope"))
 				}
 
-				resp := newResponse().build()
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusOK)
-				_ = json.NewEncoder(w).Encode(resp)
+				_, _ = w.Write(oauthtest.NewResponse().Build())
 			}))
 			t.Cleanup(server.Close)
 
@@ -1239,31 +1195,6 @@ func TestExchangeRequest_StructFields(t *testing.T) {
 	assert.Equal(t, "subject-token-type", req.SubjectTokenType)
 }
 
-// TestResponse_JSONTags tests that response struct has correct JSON tags.
-func TestResponse_JSONTags(t *testing.T) {
-	t.Parallel()
-
-	jsonData := `{
-		"access_token": "test-access-token",
-		"issued_token_type": "test-issued-token-type",
-		"token_type": "test-token-type",
-		"expires_in": 3600,
-		"scope": "test-scope",
-		"refresh_token": "test-refresh-token"
-	}`
-
-	var resp response
-	err := json.Unmarshal([]byte(jsonData), &resp)
-
-	require.NoError(t, err)
-	assert.Equal(t, "test-access-token", resp.AccessToken)
-	assert.Equal(t, "test-issued-token-type", resp.IssuedTokenType)
-	assert.Equal(t, "test-token-type", resp.TokenType)
-	assert.Equal(t, 3600, resp.ExpiresIn)
-	assert.Equal(t, "test-scope", resp.Scope)
-	assert.Equal(t, "test-refresh-token", resp.RefreshToken)
-}
-
 // TestClientAuthentication_Fields tests clientAuthentication struct fields.
 func TestClientAuthentication_Fields(t *testing.T) {
 	t.Parallel()
@@ -1323,10 +1254,9 @@ func TestExchangeToken_URLValues(t *testing.T) {
 		// Store received form values
 		receivedValues = r.Form
 
-		resp := newResponse().build()
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		_ = json.NewEncoder(w).Encode(resp)
+		_, _ = w.Write(oauthtest.NewResponse().Build())
 	}))
 	t.Cleanup(server.Close)
 
@@ -1388,10 +1318,9 @@ func TestExchangeToken_BasicAuthURLEncoding(t *testing.T) {
 		assert.Equal(t, url.QueryEscape(specialClientID), username, "ClientID should be URL-encoded")
 		assert.Equal(t, url.QueryEscape(specialClientSecret), password, "ClientSecret should be URL-encoded")
 
-		resp := newResponse().build()
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		_ = json.NewEncoder(w).Encode(resp)
+		_, _ = w.Write(oauthtest.NewResponse().Build())
 	}))
 	t.Cleanup(server.Close)
 
@@ -1468,6 +1397,42 @@ func TestExchangeConfig_Validate_SubjectTokenType(t *testing.T) {
 	}
 }
 
+// TestExchangeConfig_Validate_NormalizesSubjectTokenType pins the
+// mutation behavior of Validate(): the short-form token type (e.g.
+// "access_token") is written back onto the config as the full RFC 8693
+// URN. pkg/vmcp/auth/strategies/tokenexchange.go and pkg/runner/
+// config_builder.go read this field post-Validate and depend on the
+// normalization.
+func TestExchangeConfig_Validate_NormalizesSubjectTokenType(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "short access_token", input: "access_token", want: oauthproto.TokenTypeAccessToken},
+		{name: "short id_token", input: "id_token", want: oauthproto.TokenTypeIDToken},
+		{name: "short jwt", input: "jwt", want: oauthproto.TokenTypeJWT},
+		{name: "already-normalized URN passes through unchanged", input: oauthproto.TokenTypeAccessToken, want: oauthproto.TokenTypeAccessToken},
+		{name: "empty stays empty", input: "", want: ""},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			c := &ExchangeConfig{
+				TokenURL:             "https://example.com/token",
+				SubjectTokenProvider: func() (string, error) { return "tok", nil },
+				SubjectTokenType:     tc.input,
+			}
+			require.NoError(t, c.Validate())
+			assert.Equal(t, tc.want, c.SubjectTokenType)
+		})
+	}
+}
+
 // TestTokenSource_Token_RequestedTokenTypeAndResource verifies that
 // ExchangeConfig.RequestedTokenType and ExchangeConfig.Resource propagate
 // through tokenSource.Token() onto the token-exchange form body.
@@ -1521,10 +1486,9 @@ func TestTokenSource_Token_RequestedTokenTypeAndResource(t *testing.T) {
 				assert.Equal(t, tt.wantRequestedTokenType, r.Form.Get("requested_token_type"))
 				assert.Equal(t, tt.wantResource, r.Form.Get("resource"))
 
-				resp := newResponse().build()
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusOK)
-				_ = json.NewEncoder(w).Encode(resp)
+				_, _ = w.Write(oauthtest.NewResponse().Build())
 			}))
 			t.Cleanup(server.Close)
 

--- a/pkg/auth/tokenexchange/middleware_test.go
+++ b/pkg/auth/tokenexchange/middleware_test.go
@@ -17,6 +17,7 @@ import (
 	"golang.org/x/oauth2"
 
 	"github.com/stacklok/toolhive/pkg/auth"
+	"github.com/stacklok/toolhive/pkg/oauthproto/oauthtest"
 	"github.com/stacklok/toolhive/pkg/transport/types"
 	"github.com/stacklok/toolhive/pkg/transport/types/mocks"
 )
@@ -271,15 +272,13 @@ func TestCreateTokenExchangeMiddleware_Success(t *testing.T) {
 					receivedScopes = r.Form.Get("scope")
 				}
 
-				resp := response{
-					AccessToken:     "exchanged-token",
-					TokenType:       "Bearer",
-					IssuedTokenType: "urn:ietf:params:oauth:token-type:access_token",
-					ExpiresIn:       3600,
-				}
+				body := oauthtest.NewResponse().
+					WithAccessToken("exchanged-token").
+					WithExpiresIn(3600).
+					Build()
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusOK)
-				_ = json.NewEncoder(w).Encode(resp)
+				_, _ = w.Write(body)
 			}))
 			defer exchangeServer.Close()
 
@@ -447,14 +446,12 @@ func TestCreateTokenExchangeMiddleware_Failures(t *testing.T) {
 		{
 			name: "invalid injection config",
 			serverResponse: func(w http.ResponseWriter, _ *http.Request) {
-				resp := response{
-					AccessToken:     "exchanged-token",
-					TokenType:       "Bearer",
-					IssuedTokenType: "urn:ietf:params:oauth:token-type:access_token",
-				}
+				body := oauthtest.NewResponse().
+					WithAccessToken("exchanged-token").
+					Build()
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusOK)
-				_ = json.NewEncoder(w).Encode(resp)
+				_, _ = w.Write(body)
 			},
 			headerStrategy:     HeaderStrategyCustom,
 			customHeaderName:   "", // Missing header name causes injection failure
@@ -684,15 +681,13 @@ func TestCreateTokenExchangeMiddleware_EnvironmentVariable(t *testing.T) {
 					receivedClientSecret = password
 				}
 
-				resp := response{
-					AccessToken:     "exchanged-token",
-					TokenType:       "Bearer",
-					IssuedTokenType: "urn:ietf:params:oauth:token-type:access_token",
-					ExpiresIn:       3600,
-				}
+				body := oauthtest.NewResponse().
+					WithAccessToken("exchanged-token").
+					WithExpiresIn(3600).
+					Build()
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusOK)
-				_ = json.NewEncoder(w).Encode(resp)
+				_, _ = w.Write(body)
 			}))
 			defer exchangeServer.Close()
 

--- a/pkg/vmcp/auth/strategies/tokenexchange_test.go
+++ b/pkg/vmcp/auth/strategies/tokenexchange_test.go
@@ -311,8 +311,10 @@ func TestTokenExchangeStrategy_Authenticate(t *testing.T) {
 			strategy: func(server *httptest.Server) *authtypes.BackendAuthStrategy {
 				return createTokenExchangeStrategy(server.URL)
 			},
-			expectError:   true,
-			errorContains: "empty access_token",
+			expectError: true,
+			// oauth.ParseTokenResponse enforces RFC 6749 Section 5.1 centrally;
+			// the tokenexchange call site no longer duplicates the check.
+			errorContains: "missing access_token",
 		},
 		{
 			name: "exchanges upstream token when SubjectProviderName is set",


### PR DESCRIPTION
## Summary

- **Why:** `pkg/auth/tokenexchange` carried its own copies of token-endpoint request construction, body draining, size capping, and RFC 6749 response parsing. Earlier commits in this series moved those into `pkg/oauthproto` for the upcoming JWT-bearer grant. Keeping the local duplicates around meant the two paths would drift, so this PR completes the migration and fulfils the `TODO: drop when executeTokenExchangeRequest is replaced by oauthproto.DoTokenRequest` planted in #5212.
- **What:**
  - `exchangeToken` now collapses to `buildFormData` + `oauthproto.NewFormRequest` + `oauthproto.DoTokenRequest`. The 5 local helpers (`createTokenExchangeRequest`, `executeTokenExchangeRequest`, `parseTokenExchangeResponse`, `validateResponseStatus`, the local `response` struct, and the `maxResponseBodySize` constant) are deleted, along with the now-unused imports `encoding/json`, `io`, `log/slog`, `strconv`, `time`.
  - RFC 8693 §2.2.1 enforcement (non-empty `token_type` and `issued_token_type`) is preserved at the call site — `oauthproto.ParseTokenResponse` is intentionally permissive on `token_type` to match `x/oauth2`/Google, so the exchange grant tightens it back. The redundant `access_token` empty check is gone; `oauthproto.ParseTokenResponse` emits `"oauth: token response missing access_token (RFC 6749 Section 5.1)"` centrally.
  - The historical `SubjectTokenType` short-form normalization in `Validate()` is preserved and pinned by `TestExchangeConfig_Validate_NormalizesSubjectTokenType`.
  - Test fixtures migrate from the in-file `responseBuilder` to the shared `oauthtest.ResponseBuilder` from `pkg/oauthproto/oauthtest`. Three literal `response{...}` constructions in `middleware_test.go` get the same treatment.
  - `RetrieveError.Body` scrubbing is preserved as an explicit opt-in: `pkg/oauthproto.parseRetrieveError` keeps `Body` populated for general-purpose callers, but `tokenexchange.exchangeToken` does an `errors.As` + `Body = nil` step right after `DoTokenRequest`. `TestExchangeToken_HTTPErrorResponses` re-asserts `Body == nil` so the property cannot drift again.

## Type of change

- [x] Refactoring (no behavior change)

## Test plan

- [x] Unit tests (`task test`) — `pkg/auth/tokenexchange/...` and `pkg/vmcp/auth/strategies/...` pass with `-race`.
- [x] Linting (`task lint-fix`) — 0 issues.
- [x] E2E tests (`task test-e2e` via PR CI on kindest/node v1.33/v1.34/v1.35).

## API Compatibility

- [x] This PR does not break the `v1beta1` API.

## Does this introduce a user-facing change?

Yes — operators or alerts keyed on the old `tokenexchange` error strings need to pick up the new substrings:
- `"token exchange request failed"` → `"oauth: token request failed"`
- `"failed to parse token exchange response"` → `"oauth: cannot parse token response"`
- `"failed to create token exchange request"` → `"tokenexchange: build request"`
- `"empty access_token"` (vmcp strategy path) → `"missing access_token"`

Error **types** are unchanged: `*oauth2.RetrieveError` still surfaces on non-2xx responses (and now on 2xx responses that carry an RFC 6749 §5.2 `error` field), and `errors.As` chains still work.

## Special notes for reviewers

- Third PR in the `pkg/oauthproto` consolidation series (after #5212 and the CIMD refactor). The shared `NewFormRequest` / `DoTokenRequest` / `ParseTokenResponse` helpers landed in earlier commits; this PR is purely the consumer migration.
- The body-clearing on `RetrieveError` (commit body section "RetrieveError.Body preservation") is an explicit opt-in to keep the pre-refactor security property — `pkg/oauthproto` deliberately preserves `Body` so general-purpose callers can surface server replies verbatim, but the `tokenexchange` errors flow through paths that may log `err.Error()`, so the package opts back into the stricter behavior.
- Diff is dominated by test churn (most of `exchange_test.go` is migrated to `oauthtest.ResponseBuilder`); the production-code delta in `exchange.go` is the substantive change.
- An initial draft of this PR also tightened `ExchangeConfig.Validate()` on `TokenURL` to reject plain-HTTP non-localhost endpoints. That hardening was reverted (force-pushed) after the e2e suite — which spins up cluster-local plain-HTTP mock auth servers — surfaced it as a behavior change. A refactor PR shouldn't carry it; the tightening will be proposed separately with appropriate plumbing for in-cluster test setups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)