### PR TITLE
Guard RedisStorageConfig CEL rules with has() checks

### DIFF
--- a/cmd/thv-operator/api/v1beta1/mcpexternalauthconfig_types.go
+++ b/cmd/thv-operator/api/v1beta1/mcpexternalauthconfig_types.go
@@ -664,8 +664,8 @@ type AuthServerStorageConfig struct {
 // addr points to a Redis Cluster discovery endpoint (GCP Memorystore Cluster,
 // AWS ElastiCache cluster mode enabled).
 //
-// +kubebuilder:validation:XValidation:rule="(self.addr.size() > 0) != has(self.sentinelConfig)",message="exactly one of addr or sentinelConfig must be set"
-// +kubebuilder:validation:XValidation:rule="!self.clusterMode || self.addr.size() > 0",message="clusterMode requires addr to be set"
+// +kubebuilder:validation:XValidation:rule="(has(self.addr) && self.addr.size() > 0) != has(self.sentinelConfig)",message="exactly one of addr or sentinelConfig must be set"
+// +kubebuilder:validation:XValidation:rule="!(has(self.clusterMode) && self.clusterMode) || (has(self.addr) && self.addr.size() > 0)",message="clusterMode requires addr to be set"
 //
 //nolint:lll // CEL validation rules exceed line length limit
 type RedisStorageConfig struct {

--- a/cmd/thv-operator/test-integration/mcp-external-auth/redis_storage_validation_test.go
+++ b/cmd/thv-operator/test-integration/mcp-external-auth/redis_storage_validation_test.go
@@ -1,0 +1,155 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package controllers
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+)
+
+// These tests exercise the CEL XValidation rules on RedisStorageConfig through
+// the real apiserver (envtest). They guard against regressions like the one
+// where the rules referenced self.addr / self.clusterMode without a has()
+// guard and rejected every sentinel-only config with "no such key: addr".
+var _ = Describe("MCPExternalAuthConfig RedisStorageConfig CEL validation", func() {
+	const namespace = "default"
+
+	// makeAuthConfig returns a minimum-valid embeddedAuthServer config whose
+	// only varying piece is the Redis storage block.
+	makeAuthConfig := func(name string, redis *mcpv1beta1.RedisStorageConfig) *mcpv1beta1.MCPExternalAuthConfig {
+		return &mcpv1beta1.MCPExternalAuthConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+			Spec: mcpv1beta1.MCPExternalAuthConfigSpec{
+				Type: "embeddedAuthServer",
+				EmbeddedAuthServer: &mcpv1beta1.EmbeddedAuthServerConfig{
+					Issuer: "https://auth.example.com",
+					UpstreamProviders: []mcpv1beta1.UpstreamProviderConfig{{
+						Name: "github",
+						Type: mcpv1beta1.UpstreamProviderTypeOAuth2,
+						OAuth2Config: &mcpv1beta1.OAuth2UpstreamConfig{
+							AuthorizationEndpoint: "https://github.com/login/oauth/authorize",
+							TokenEndpoint:         "https://github.com/login/oauth/access_token",
+							ClientID:              "test-client-id",
+						},
+					}},
+					Storage: &mcpv1beta1.AuthServerStorageConfig{
+						Type:  mcpv1beta1.AuthServerStorageTypeRedis,
+						Redis: redis,
+					},
+				},
+			},
+		}
+	}
+
+	aclUserConfig := &mcpv1beta1.RedisACLUserConfig{
+		PasswordSecretRef: &mcpv1beta1.SecretKeyRef{
+			Name: "redis-credentials",
+			Key:  "password",
+		},
+	}
+
+	BeforeEach(func() {
+		_ = k8sClient.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}})
+	})
+
+	type validationCase struct {
+		name        string
+		redis       *mcpv1beta1.RedisStorageConfig
+		shouldAdmit bool
+		errMatch    string // substring expected on rejection; ignored when shouldAdmit is true
+	}
+
+	cases := []validationCase{
+		{
+			name: "sentinel only (the github-mcp-demo case)",
+			redis: &mcpv1beta1.RedisStorageConfig{
+				SentinelConfig: &mcpv1beta1.RedisSentinelConfig{
+					MasterName: "mymaster",
+					SentinelService: &mcpv1beta1.SentinelServiceRef{
+						Name:      "rfs-redis",
+						Namespace: "redis",
+					},
+				},
+				ACLUserConfig: aclUserConfig,
+			},
+			shouldAdmit: true,
+		},
+		{
+			name: "standalone via addr",
+			redis: &mcpv1beta1.RedisStorageConfig{
+				Addr:          "redis.example.com:6379",
+				ACLUserConfig: aclUserConfig,
+			},
+			shouldAdmit: true,
+		},
+		{
+			name: "cluster mode with addr",
+			redis: &mcpv1beta1.RedisStorageConfig{
+				Addr:          "redis-cluster.example.com:6379",
+				ClusterMode:   true,
+				ACLUserConfig: aclUserConfig,
+			},
+			shouldAdmit: true,
+		},
+		{
+			name: "neither addr nor sentinelConfig set",
+			redis: &mcpv1beta1.RedisStorageConfig{
+				ACLUserConfig: aclUserConfig,
+			},
+			shouldAdmit: false,
+			errMatch:    "exactly one of addr or sentinelConfig must be set",
+		},
+		{
+			name: "both addr and sentinelConfig set",
+			redis: &mcpv1beta1.RedisStorageConfig{
+				Addr: "redis.example.com:6379",
+				SentinelConfig: &mcpv1beta1.RedisSentinelConfig{
+					MasterName:    "mymaster",
+					SentinelAddrs: []string{"sentinel-0.example.com:26379"},
+				},
+				ACLUserConfig: aclUserConfig,
+			},
+			shouldAdmit: false,
+			errMatch:    "exactly one of addr or sentinelConfig must be set",
+		},
+		{
+			name: "clusterMode without addr",
+			redis: &mcpv1beta1.RedisStorageConfig{
+				ClusterMode: true,
+				SentinelConfig: &mcpv1beta1.RedisSentinelConfig{
+					MasterName:    "mymaster",
+					SentinelAddrs: []string{"sentinel-0.example.com:26379"},
+				},
+				ACLUserConfig: aclUserConfig,
+			},
+			shouldAdmit: false,
+			errMatch:    "clusterMode requires addr to be set",
+		},
+	}
+
+	for i, c := range cases {
+		name := fmt.Sprintf("redis-storage-validation-%d", i)
+		It(c.name, func() {
+			cfg := makeAuthConfig(name, c.redis)
+			err := k8sClient.Create(ctx, cfg)
+			if c.shouldAdmit {
+				Expect(err).NotTo(HaveOccurred(),
+					"expected apiserver to admit config: %s", c.name)
+				DeferCleanup(func() {
+					Expect(k8sClient.Delete(ctx, cfg)).To(Succeed())
+				})
+				return
+			}
+			Expect(err).To(HaveOccurred(),
+				"expected apiserver to reject config: %s", c.name)
+			Expect(err.Error()).To(ContainSubstring(c.errMatch))
+		})
+	}
+})

--- a/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpexternalauthconfigs.yaml
+++ b/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpexternalauthconfigs.yaml
@@ -450,9 +450,10 @@ spec:
                         type: object
                         x-kubernetes-validations:
                         - message: exactly one of addr or sentinelConfig must be set
-                          rule: (self.addr.size() > 0) != has(self.sentinelConfig)
+                          rule: (has(self.addr) && self.addr.size() > 0) != has(self.sentinelConfig)
                         - message: clusterMode requires addr to be set
-                          rule: '!self.clusterMode || self.addr.size() > 0'
+                          rule: '!(has(self.clusterMode) && self.clusterMode) || (has(self.addr)
+                            && self.addr.size() > 0)'
                       type:
                         default: memory
                         description: |-
@@ -1620,9 +1621,10 @@ spec:
                         type: object
                         x-kubernetes-validations:
                         - message: exactly one of addr or sentinelConfig must be set
-                          rule: (self.addr.size() > 0) != has(self.sentinelConfig)
+                          rule: (has(self.addr) && self.addr.size() > 0) != has(self.sentinelConfig)
                         - message: clusterMode requires addr to be set
-                          rule: '!self.clusterMode || self.addr.size() > 0'
+                          rule: '!(has(self.clusterMode) && self.clusterMode) || (has(self.addr)
+                            && self.addr.size() > 0)'
                       type:
                         default: memory
                         description: |-

--- a/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_virtualmcpservers.yaml
+++ b/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_virtualmcpservers.yaml
@@ -323,9 +323,10 @@ spec:
                         type: object
                         x-kubernetes-validations:
                         - message: exactly one of addr or sentinelConfig must be set
-                          rule: (self.addr.size() > 0) != has(self.sentinelConfig)
+                          rule: (has(self.addr) && self.addr.size() > 0) != has(self.sentinelConfig)
                         - message: clusterMode requires addr to be set
-                          rule: '!self.clusterMode || self.addr.size() > 0'
+                          rule: '!(has(self.clusterMode) && self.clusterMode) || (has(self.addr)
+                            && self.addr.size() > 0)'
                       type:
                         default: memory
                         description: |-
@@ -2958,9 +2959,10 @@ spec:
                         type: object
                         x-kubernetes-validations:
                         - message: exactly one of addr or sentinelConfig must be set
-                          rule: (self.addr.size() > 0) != has(self.sentinelConfig)
+                          rule: (has(self.addr) && self.addr.size() > 0) != has(self.sentinelConfig)
                         - message: clusterMode requires addr to be set
-                          rule: '!self.clusterMode || self.addr.size() > 0'
+                          rule: '!(has(self.clusterMode) && self.clusterMode) || (has(self.addr)
+                            && self.addr.size() > 0)'
                       type:
                         default: memory
                         description: |-

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpexternalauthconfigs.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpexternalauthconfigs.yaml
@@ -453,9 +453,10 @@ spec:
                         type: object
                         x-kubernetes-validations:
                         - message: exactly one of addr or sentinelConfig must be set
-                          rule: (self.addr.size() > 0) != has(self.sentinelConfig)
+                          rule: (has(self.addr) && self.addr.size() > 0) != has(self.sentinelConfig)
                         - message: clusterMode requires addr to be set
-                          rule: '!self.clusterMode || self.addr.size() > 0'
+                          rule: '!(has(self.clusterMode) && self.clusterMode) || (has(self.addr)
+                            && self.addr.size() > 0)'
                       type:
                         default: memory
                         description: |-
@@ -1623,9 +1624,10 @@ spec:
                         type: object
                         x-kubernetes-validations:
                         - message: exactly one of addr or sentinelConfig must be set
-                          rule: (self.addr.size() > 0) != has(self.sentinelConfig)
+                          rule: (has(self.addr) && self.addr.size() > 0) != has(self.sentinelConfig)
                         - message: clusterMode requires addr to be set
-                          rule: '!self.clusterMode || self.addr.size() > 0'
+                          rule: '!(has(self.clusterMode) && self.clusterMode) || (has(self.addr)
+                            && self.addr.size() > 0)'
                       type:
                         default: memory
                         description: |-

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_virtualmcpservers.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_virtualmcpservers.yaml
@@ -326,9 +326,10 @@ spec:
                         type: object
                         x-kubernetes-validations:
                         - message: exactly one of addr or sentinelConfig must be set
-                          rule: (self.addr.size() > 0) != has(self.sentinelConfig)
+                          rule: (has(self.addr) && self.addr.size() > 0) != has(self.sentinelConfig)
                         - message: clusterMode requires addr to be set
-                          rule: '!self.clusterMode || self.addr.size() > 0'
+                          rule: '!(has(self.clusterMode) && self.clusterMode) || (has(self.addr)
+                            && self.addr.size() > 0)'
                       type:
                         default: memory
                         description: |-
@@ -2961,9 +2962,10 @@ spec:
                         type: object
                         x-kubernetes-validations:
                         - message: exactly one of addr or sentinelConfig must be set
-                          rule: (self.addr.size() > 0) != has(self.sentinelConfig)
+                          rule: (has(self.addr) && self.addr.size() > 0) != has(self.sentinelConfig)
                         - message: clusterMode requires addr to be set
-                          rule: '!self.clusterMode || self.addr.size() > 0'
+                          rule: '!(has(self.clusterMode) && self.clusterMode) || (has(self.addr)
+                            && self.addr.size() > 0)'
                       type:
                         default: memory
                         description: |-


### PR DESCRIPTION
## Summary

The CEL XValidation rules on `RedisStorageConfig` rejected every valid sentinel-only configuration with errors like:

```
* spec.embeddedAuthServer.storage.redis: Invalid value: "object": no such key: addr evaluating rule: exactly one of addr or sentinelConfig must be set
* spec.embeddedAuthServer.storage.redis: Invalid value: "object": no such key: clusterMode evaluating rule: clusterMode requires addr to be set
```

Both rules read `self.addr` / `self.clusterMode` directly. Those fields are `+optional` with `omitempty`, so when the user submits a sentinel-only config (no `addr`, no `clusterMode`) the fields are absent from the validated object and CEL aborts evaluation with "no such key" before the rule's own logic runs — rejecting configurations the rules were meant to allow. Other CEL rules in the operator API already guard optional scalar access with `has()` (e.g. `mcpserver_types.go:195-197`); these two rules were the outliers.

Wrap each scalar access in `has(...)`. Truth tables for sentinel-only, standalone, cluster-mode, both-set, and neither-set configurations are unchanged.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes

| File | Change |
|---|---|
| `cmd/thv-operator/api/v1beta1/mcpexternalauthconfig_types.go` | Wrap `self.addr` and `self.clusterMode` in `has()` in both XValidation rules |
| `deploy/charts/operator-crds/{files,templates}/crds/toolhive.stacklok.dev_mcpexternalauthconfigs.yaml` | Regenerated by `task operator-manifests` |
| `deploy/charts/operator-crds/{files,templates}/crds/toolhive.stacklok.dev_virtualmcpservers.yaml` | Regenerated (vMCP embeds the same struct) |

## Test plan

- [x] `task operator-test` (existing controllerutil and v1beta1 API tests pass — Go-level validators are unaffected)
- [x] Manually traced the rules against the user-reported demo config (`StacklokLabs/mcp-demos/github-mcp-demo/02-mcpexternalauthconfig.yaml`, sentinel-only with `sentinelService`) — old rules fail on missing `addr`, new rules accept.

### Test gap (follow-up)

The Go-level validation tests in `cmd/thv-operator/pkg/controllerutil/authserver_test.go` could not catch this regression because they construct the typed struct directly and never round-trip through the apiserver schema where CEL runs. A chainsaw test that `kubectl apply`s a sentinel-only `MCPExternalAuthConfig` would close that gap; tracking as follow-up.

## Does this introduce a user-facing change?

Yes — sentinel-only and standalone+sentinel-mixed configurations that the original rule intent allowed now actually validate. No new fields, no schema break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)