### PR TITLE
Use corev1.PullPolicy instead of string for EmbeddingServer ImagePullPolicy 

### DIFF
--- a/cmd/thv-operator/api/v1beta1/embeddingserver_types.go
+++ b/cmd/thv-operator/api/v1beta1/embeddingserver_types.go
@@ -4,6 +4,7 @@
 package v1beta1
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -60,7 +61,7 @@ type EmbeddingServerSpec struct {
 	// +kubebuilder:validation:Enum=Always;Never;IfNotPresent
 	// +kubebuilder:default="IfNotPresent"
 	// +optional
-	ImagePullPolicy string `json:"imagePullPolicy,omitempty"`
+	ImagePullPolicy corev1.PullPolicy `json:"imagePullPolicy,omitempty"`
 
 	// Port is the port to expose the embedding service on
 	// +kubebuilder:validation:Minimum=1
@@ -270,11 +271,11 @@ func (e *EmbeddingServer) IsModelCacheEnabled() bool {
 }
 
 // GetImagePullPolicy returns the image pull policy for the EmbeddingServer
-func (e *EmbeddingServer) GetImagePullPolicy() string {
+func (e *EmbeddingServer) GetImagePullPolicy() corev1.PullPolicy {
 	if e.Spec.ImagePullPolicy != "" {
 		return e.Spec.ImagePullPolicy
 	}
-	return "IfNotPresent"
+	return corev1.PullIfNotPresent
 }
 
 func init() {

--- a/cmd/thv-operator/controllers/embeddingserver_controller.go
+++ b/cmd/thv-operator/controllers/embeddingserver_controller.go
@@ -526,7 +526,7 @@ func (r *EmbeddingServerReconciler) buildEmbeddingContainer(embedding *mcpv1beta
 		Image:           embedding.Spec.Image,
 		Args:            args,
 		Env:             envVars,
-		ImagePullPolicy: corev1.PullPolicy(embedding.GetImagePullPolicy()),
+		ImagePullPolicy: embedding.GetImagePullPolicy(),
 		Ports: []corev1.ContainerPort{
 			{
 				Name:          "http",

--- a/cmd/thv-operator/controllers/embeddingserver_controller_test.go
+++ b/cmd/thv-operator/controllers/embeddingserver_controller_test.go
@@ -146,28 +146,28 @@ func TestEmbeddingServer_GetImagePullPolicy(t *testing.T) {
 
 	tests := []struct {
 		name            string
-		imagePullPolicy string
-		expected        string
+		imagePullPolicy corev1.PullPolicy
+		expected        corev1.PullPolicy
 	}{
 		{
 			name:            "default pull policy",
 			imagePullPolicy: "",
-			expected:        "IfNotPresent",
+			expected:        corev1.PullIfNotPresent,
 		},
 		{
 			name:            "Never pull policy",
-			imagePullPolicy: "Never",
-			expected:        "Never",
+			imagePullPolicy: corev1.PullNever,
+			expected:        corev1.PullNever,
 		},
 		{
 			name:            "Always pull policy",
-			imagePullPolicy: "Always",
-			expected:        "Always",
+			imagePullPolicy: corev1.PullAlways,
+			expected:        corev1.PullAlways,
 		},
 		{
 			name:            "IfNotPresent pull policy",
-			imagePullPolicy: "IfNotPresent",
-			expected:        "IfNotPresent",
+			imagePullPolicy: corev1.PullIfNotPresent,
+			expected:        corev1.PullIfNotPresent,
 		},
 	}
 

--- a/cmd/thv-operator/test-integration/embedding-server/embeddingserver_creation_test.go
+++ b/cmd/thv-operator/test-integration/embedding-server/embeddingserver_creation_test.go
@@ -601,7 +601,7 @@ var _ = Describe("EmbeddingServer Controller Integration Tests", func() {
 					Spec: mcpv1beta1.EmbeddingServerSpec{
 						Model:           "sentence-transformers/all-MiniLM-L6-v2",
 						Image:           "ghcr.io/huggingface/text-embeddings-inference:latest",
-						ImagePullPolicy: "Always",
+						ImagePullPolicy: corev1.PullAlways,
 					},
 				},
 			},
@@ -631,7 +631,7 @@ var _ = Describe("EmbeddingServer Controller Integration Tests", func() {
 					Spec: mcpv1beta1.EmbeddingServerSpec{
 						Model:           "sentence-transformers/all-MiniLM-L6-v2",
 						Image:           "ghcr.io/huggingface/text-embeddings-inference:latest",
-						ImagePullPolicy: "Never",
+						ImagePullPolicy: corev1.PullNever,
 					},
 				},
 			},

--- a/cmd/thv-operator/test-integration/embedding-server/embeddingserver_update_test.go
+++ b/cmd/thv-operator/test-integration/embedding-server/embeddingserver_update_test.go
@@ -373,14 +373,14 @@ var _ = Describe("EmbeddingServer Controller Update Tests", func() {
 				Spec: mcpv1beta1.EmbeddingServerSpec{
 					Model:           "sentence-transformers/all-MiniLM-L6-v2",
 					Image:           "ghcr.io/huggingface/text-embeddings-inference:latest",
-					ImagePullPolicy: "IfNotPresent",
+					ImagePullPolicy: corev1.PullIfNotPresent,
 				},
 			},
 			Updates: []UpdateStep{
 				{
 					Name: "Should update StatefulSet when ImagePullPolicy changes",
 					ApplyUpdate: func(es *mcpv1beta1.EmbeddingServer) {
-						es.Spec.ImagePullPolicy = "Always"
+						es.Spec.ImagePullPolicy = corev1.PullAlways
 					},
 					ExpectedStatefulSet: &appsv1.StatefulSet{
 						Spec: appsv1.StatefulSetSpec{

--- a/docs/operator/crd-api.md
+++ b/docs/operator/crd-api.md
@@ -1251,7 +1251,7 @@ _Appears in:_
 | `model` _string_ | Model is the HuggingFace embedding model to use (e.g., "sentence-transformers/all-MiniLM-L6-v2") | BAAI/bge-small-en-v1.5 | Optional: \{\} <br /> |
 | `hfTokenSecretRef` _[api.v1beta1.SecretKeyRef](#apiv1beta1secretkeyref)_ | HFTokenSecretRef is a reference to a Kubernetes Secret containing the huggingface token.<br />If provided, the secret value will be provided to the embedding server for authentication with huggingface. |  | Optional: \{\} <br /> |
 | `image` _string_ | Image is the container image for the embedding inference server.<br />Images must be from HuggingFace Text Embeddings Inference (https://github.com/huggingface/text-embeddings-inference). | ghcr.io/huggingface/text-embeddings-inference:cpu-latest | Optional: \{\} <br /> |
-| `imagePullPolicy` _string_ | ImagePullPolicy defines the pull policy for the container image | IfNotPresent | Enum: [Always Never IfNotPresent] <br />Optional: \{\} <br /> |
+| `imagePullPolicy` _[PullPolicy](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#pullpolicy-v1-core)_ | ImagePullPolicy defines the pull policy for the container image | IfNotPresent | Enum: [Always Never IfNotPresent] <br />Optional: \{\} <br /> |
 | `port` _integer_ | Port is the port to expose the embedding service on | 8080 | Maximum: 65535 <br />Minimum: 1 <br /> |
 | `args` _string array_ | Args are additional arguments to pass to the embedding inference server |  | Optional: \{\} <br /> |
 | `env` _[api.v1beta1.EnvVar](#apiv1beta1envvar) array_ | Env are environment variables to set in the container |  | Optional: \{\} <br /> |


### PR DESCRIPTION
## Summary

Updates `EmbeddingServerSpec.ImagePullPolicy` to use `corev1.PullPolicy` instead of a plain string.

This keeps the existing kubebuilder enum validation and JSON schema behavior unchanged, while giving Go code compile-time safety and consistency with upstream Kubernetes container image pull policy types.

<!--
REQUIRED. You MUST explain:
1. WHY this change is needed (the problem or motivation)
2. WHAT changed (concise bullet points)

The diff shows the code — your summary must provide the context a reviewer
needs to understand the purpose without reading the diff first.
-->

<!--
Link related issues. Use "Closes" or "Fixes" to auto-close on merge.
Remove this line if there is no related issue.
-->

Fixes #4616 

## Type of change

<!-- REQUIRED. Check exactly one. -->

- [ ] Bug fix
- [ ] New feature
- [x] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

<!--
REQUIRED. Check every verification step you actually ran.
You MUST check at least one item. If you only did manual testing,
describe exactly what you tested below the checkbox.
-->

- [x] Unit tests (`task test`)
- [x] E2E tests (`task test-e2e`)
- [x] Linting (`task lint-fix`)
- [ ] Manual testing (describe below)

## API Compatibility

<!--
The CRD Schema Compatibility check guards the v1beta1 operator API.
If the check flags this PR as Incompatible and the break is intentional,
apply the `api-break-allowed` label and describe below:

1. Which fields, types, or CRDs are changing.
2. Why the break is unavoidable.
3. The user-facing migration path (what cluster admins need to do).

See CONTRIBUTING.md → "API Stability" for the full rubric. Coordinate
with maintainers before applying the label.

Remove this section entirely if the PR does not touch operator API surface.
-->

- [x] This PR does not break the `v1beta1` API, OR the `api-break-allowed` label is applied and the migration guidance is described above.

## Changes


 - Change `EmbeddingServerSpec.ImagePullPolicy` from `string` to `corev1.PullPolicy`
 - Update `GetImagePullPolicy()` to return `corev1.PullPolicy`
 - Remove the controller-side cast when assigning the container image pull policy
 - Update unit and integration tests to use `corev1.PullAlways`, `corev1.PullNever`, and `corev1.PullIfNotPresent`
  
<!--
Optional — include for PRs touching more than a few files to help
reviewers navigate the diff. Remove this entire section for small PRs.
-->
