### PR TITLE
MCPGroup Ready column misleadingly shows MCPServersChecked condition

### DIFF
--- a/cmd/thv-operator/api/v1alpha1/types.go
+++ b/cmd/thv-operator/api/v1alpha1/types.go
@@ -76,7 +76,7 @@ type MCPExternalAuthConfigList struct {
 //+kubebuilder:resource:shortName=mcpg;mcpgroup,categories=toolhive
 //+kubebuilder:printcolumn:name="Servers",type="integer",JSONPath=".status.serverCount"
 //+kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase"
-//+kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type=='MCPServersChecked')].status"
+//+kubebuilder:printcolumn:name="Checked",type="string",JSONPath=".status.conditions[?(@.type=='MCPServersChecked')].status"
 //+kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
 // MCPGroup is the deprecated v1alpha1 version of the MCPGroup resource.

--- a/cmd/thv-operator/api/v1beta1/mcpgroup_types.go
+++ b/cmd/thv-operator/api/v1beta1/mcpgroup_types.go
@@ -91,7 +91,7 @@ const (
 //+kubebuilder:resource:shortName=mcpg;mcpgroup,categories=toolhive
 //+kubebuilder:printcolumn:name="Servers",type="integer",JSONPath=".status.serverCount"
 //+kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase"
-//+kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type=='MCPServersChecked')].status"
+//+kubebuilder:printcolumn:name="Checked",type="string",JSONPath=".status.conditions[?(@.type=='MCPServersChecked')].status"
 //+kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
 // MCPGroup is the Schema for the mcpgroups API

--- a/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpgroups.yaml
+++ b/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpgroups.yaml
@@ -27,7 +27,7 @@ spec:
       name: Phase
       type: string
     - jsonPath: .status.conditions[?(@.type=='MCPServersChecked')].status
-      name: Ready
+      name: Checked
       type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
@@ -183,7 +183,7 @@ spec:
       name: Phase
       type: string
     - jsonPath: .status.conditions[?(@.type=='MCPServersChecked')].status
-      name: Ready
+      name: Checked
       type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpgroups.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpgroups.yaml
@@ -30,7 +30,7 @@ spec:
       name: Phase
       type: string
     - jsonPath: .status.conditions[?(@.type=='MCPServersChecked')].status
-      name: Ready
+      name: Checked
       type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
@@ -186,7 +186,7 @@ spec:
       name: Phase
       type: string
     - jsonPath: .status.conditions[?(@.type=='MCPServersChecked')].status
-      name: Ready
+      name: Checked
       type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age


### PR DESCRIPTION
## Summary


 Rename the MCPGroup printer column from `Ready` to `Checked`.

  The column was displaying the `MCPServersChecked` condition, which only indicates whether the controller has checked referenced MCPServers. Labeling that value as `Ready` was misleading
  because MCPGroup does not currently define a conventional `Ready` condition.

<!--
REQUIRED. You MUST explain:
1. WHY this change is needed (the problem or motivation)
2. WHAT changed (concise bullet points)

The diff shows the code — your summary must provide the context a reviewer
needs to understand the purpose without reading the diff first.
-->

<!--
Link related issues. Use "Closes" or "Fixes" to auto-close on merge.
Remove this line if there is no related issue.
-->

Fixes #4617 

## Type of change

<!-- REQUIRED. Check exactly one. -->

- [ ] Bug fix
- [ ] New feature
- [x] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

<!--
REQUIRED. Check every verification step you actually ran.
You MUST check at least one item. If you only did manual testing,
describe exactly what you tested below the checkbox.
-->

- [x] Unit tests (`task test`)
- [x] E2E tests (`task test-e2e`)
- [x] Linting (`task lint-fix`)
- [ ] Manual testing (describe below)

## API Compatibility

<!--
The CRD Schema Compatibility check guards the v1beta1 operator API.
If the check flags this PR as Incompatible and the break is intentional,
apply the `api-break-allowed` label and describe below:

1. Which fields, types, or CRDs are changing.
2. Why the break is unavoidable.
3. The user-facing migration path (what cluster admins need to do).

See CONTRIBUTING.md → "API Stability" for the full rubric. Coordinate
with maintainers before applying the label.

Remove this section entirely if the PR does not touch operator API surface.
-->

- [x] This PR does not break the `v1beta1` API, OR the `api-break-allowed` label is applied and the migration guidance is described above.

## Changes

<!--
Optional — include for PRs touching more than a few files to help
reviewers navigate the diff. Remove this entire section for small PRs.
-->

- Updated MCPGroup print column markers in `v1alpha1` and `v1beta1`
- Regenerated CRD manifests and Helm CRD templates
- Kept the existing JSONPath unchanged so the column still reports `MCPServersChecked`
