### PR TITLE
Fall back across Docker sockets on connect failure

### DIFF
--- a/pkg/container/docker/sdk/client_unix.go
+++ b/pkg/container/docker/sdk/client_unix.go
@@ -43,127 +43,122 @@ func newPlatformClient(socketPath string) (*http.Client, []client.Opt) {
 	return httpClient, opts
 }
 
-// findPlatformContainerSocket finds a container socket path on Unix systems
-func findPlatformContainerSocket(rt runtime.Type) (string, runtime.Type, error) {
-	// First check for custom socket paths via environment variables
+// findPlatformContainerSocket finds container socket paths on Unix systems.
+// Returns every candidate path that exists on disk, in priority order, so the
+// caller can fall back to the next candidate when an earlier one is found but
+// cannot be connected to (e.g. /var/run/docker.sock present but EACCES, while
+// Docker Desktop's per-user socket would have worked).
+func findPlatformContainerSocket(rt runtime.Type) ([]string, runtime.Type, error) {
+	// First check for custom socket paths via environment variables. The
+	// override is explicit, so we don't add other fallbacks alongside it.
 	if customSocketPath := os.Getenv(PodmanSocketEnv); customSocketPath != "" {
 		//nolint:gosec // G706: socket path from trusted environment variable
 		slog.Debug("using Podman socket from env", "path", customSocketPath)
-		// validate the socket path
 		if _, err := os.Stat(customSocketPath); err != nil { //nolint:gosec // G703: socket path from trusted environment variable
-			return "", runtime.TypePodman, fmt.Errorf("invalid Podman socket path: %w", err)
+			return nil, runtime.TypePodman, fmt.Errorf("invalid Podman socket path: %w", err)
 		}
-		return customSocketPath, runtime.TypePodman, nil
+		return []string{customSocketPath}, runtime.TypePodman, nil
 	}
 
 	if customSocketPath := os.Getenv(DockerSocketEnv); customSocketPath != "" {
 		//nolint:gosec // G706: socket path from trusted environment variable
 		slog.Debug("using Docker socket from env", "path", customSocketPath)
-		// validate the socket path
 		if _, err := os.Stat(customSocketPath); err != nil { //nolint:gosec // G703: socket path from trusted environment variable
-			return "", runtime.TypeDocker, fmt.Errorf("invalid Docker socket path: %w", err)
+			return nil, runtime.TypeDocker, fmt.Errorf("invalid Docker socket path: %w", err)
 		}
-		return customSocketPath, runtime.TypeDocker, nil
+		return []string{customSocketPath}, runtime.TypeDocker, nil
 	}
 
 	if customSocketPath := os.Getenv(ColimaSocketEnv); customSocketPath != "" {
 		//nolint:gosec // G706: socket path from trusted environment variable
 		slog.Debug("using Colima socket from env", "path", customSocketPath)
-		// validate the socket path
 		if _, err := os.Stat(customSocketPath); err != nil { //nolint:gosec // G703: socket path from trusted environment variable
-			return "", runtime.TypeDocker, fmt.Errorf("invalid Colima socket path: %w", err)
+			return nil, runtime.TypeDocker, fmt.Errorf("invalid Colima socket path: %w", err)
 		}
-		return customSocketPath, runtime.TypeDocker, nil
+		return []string{customSocketPath}, runtime.TypeDocker, nil
 	}
 
 	if rt == runtime.TypePodman {
-		socketPath, err := findPodmanSocket()
-		if err == nil {
-			return socketPath, runtime.TypePodman, nil
+		if paths := findPodmanSocket(); len(paths) > 0 {
+			return paths, runtime.TypePodman, nil
 		}
 	}
 
 	if rt == runtime.TypeDocker {
-		socketPath, err := findDockerSocket()
-		if err == nil {
-			return socketPath, runtime.TypeDocker, nil
+		if paths := findDockerSocket(); len(paths) > 0 {
+			return paths, runtime.TypeDocker, nil
 		}
 	}
 
 	if rt == runtime.TypeColima {
-		socketPath, err := findColimaSocket()
-		if err == nil {
-			return socketPath, runtime.TypeColima, nil
+		if paths := findColimaSocket(); len(paths) > 0 {
+			return paths, runtime.TypeColima, nil
 		}
 	}
 
-	return "", "", ErrRuntimeNotFound
+	return nil, "", ErrRuntimeNotFound
 }
 
-// findPodmanSocket attempts to locate a Podman socket
-func findPodmanSocket() (string, error) {
-	// Check standard Podman location
-	_, err := os.Stat(PodmanSocketPath)
-	if err == nil {
+// findPodmanSocket attempts to locate Podman sockets. Returns every candidate
+// path that exists on disk in priority order; an empty slice means no Podman
+// socket was found.
+func findPodmanSocket() []string {
+	var paths []string
+
+	if _, err := os.Stat(PodmanSocketPath); err == nil {
 		slog.Debug("found Podman socket", "path", PodmanSocketPath)
-		return PodmanSocketPath, nil
+		paths = append(paths, PodmanSocketPath)
+	} else {
+		slog.Debug("failed to check Podman socket", "path", PodmanSocketPath, "error", err)
 	}
 
-	slog.Debug("failed to check Podman socket", "path", PodmanSocketPath, "error", err)
-
-	// Check XDG_RUNTIME_DIR location for Podman
 	if xdgRuntimeDir := os.Getenv("XDG_RUNTIME_DIR"); xdgRuntimeDir != "" {
 		xdgSocketPath := filepath.Join(xdgRuntimeDir, PodmanXDGRuntimeSocketPath)
-		_, err := os.Stat(xdgSocketPath) //nolint:gosec // G703: path from trusted env + constant
-
-		if err == nil {
+		if _, err := os.Stat(xdgSocketPath); err == nil { //nolint:gosec // G703: path from trusted env + constant
 			//nolint:gosec // G706: socket path derived from XDG_RUNTIME_DIR env var
 			slog.Debug("found Podman socket", "path", xdgSocketPath)
-			return xdgSocketPath, nil
+			paths = append(paths, xdgSocketPath)
+		} else {
+			//nolint:gosec // G706: socket path derived from XDG_RUNTIME_DIR env var
+			slog.Debug("failed to check Podman socket", "path", xdgSocketPath, "error", err)
 		}
-
-		//nolint:gosec // G706: socket path derived from XDG_RUNTIME_DIR env var
-		slog.Debug("failed to check Podman socket", "path", xdgSocketPath, "error", err)
 	}
 
-	// Check user-specific location for Podman
 	if home := os.Getenv("HOME"); home != "" {
 		userSocketPath := filepath.Join(home, ".local/share/containers/podman/machine/podman.sock")
-		_, err := os.Stat(userSocketPath) //nolint:gosec // G703: path from trusted env + constant
-
-		if err == nil {
+		if _, err := os.Stat(userSocketPath); err == nil { //nolint:gosec // G703: path from trusted env + constant
 			//nolint:gosec // G706: socket path derived from HOME env var
 			slog.Debug("found Podman socket", "path", userSocketPath)
-			return userSocketPath, nil
+			paths = append(paths, userSocketPath)
+		} else {
+			//nolint:gosec // G706: socket path derived from HOME env var
+			slog.Debug("failed to check Podman socket", "path", userSocketPath, "error", err)
 		}
-
-		//nolint:gosec // G706: socket path derived from HOME env var
-		slog.Debug("failed to check Podman socket", "path", userSocketPath, "error", err)
 	}
 
-	// Check TMPDIR for Podman Machine API sockets (macOS)
+	// Check TMPDIR for Podman Machine API sockets (macOS).
 	// The socket path follows the pattern: $TMPDIR/podman/<machine-name>-api.sock
 	if tmpDir := os.Getenv("TMPDIR"); tmpDir != "" {
 		podmanTmpDir := filepath.Join(tmpDir, "podman")
 		if _, err := os.Stat(podmanTmpDir); err == nil { //nolint:gosec // G703: path from trusted env
-			// Look for any -api.sock files (there may be multiple machines)
 			matches, err := filepath.Glob(filepath.Join(podmanTmpDir, "*-api.sock"))
 			if err == nil && len(matches) > 0 {
-				// Use the first available API socket
-				socketPath := matches[0]
-				//nolint:gosec // G706: socket path discovered from TMPDIR
-				slog.Debug("found Podman machine API socket", "path", socketPath)
-				return socketPath, nil
+				for _, socketPath := range matches {
+					//nolint:gosec // G706: socket path discovered from TMPDIR
+					slog.Debug("found Podman machine API socket", "path", socketPath)
+					paths = append(paths, socketPath)
+				}
+			} else {
+				//nolint:gosec // G706: directory path from TMPDIR env var
+				slog.Debug("no Podman machine API sockets found", "dir", podmanTmpDir)
 			}
-			//nolint:gosec // G706: directory path from TMPDIR env var
-			slog.Debug("no Podman machine API sockets found", "dir", podmanTmpDir)
 		} else {
 			//nolint:gosec // G706: directory path from TMPDIR env var
 			slog.Debug("podman temp directory not found", "dir", podmanTmpDir, "error", err)
 		}
 	}
 
-	return "", fmt.Errorf("podman socket not found in standard locations")
+	return paths
 }
 
 // systemDockerSocketPath is the system-wide Docker socket path probed by
@@ -171,106 +166,77 @@ func findPodmanSocket() (string, error) {
 // tests can redirect the system check to a sandbox path.
 var systemDockerSocketPath = DockerSocketPath
 
-// findDockerSocket attempts to locate a Docker socket
-func findDockerSocket() (string, error) {
-	// Try Docker socket as fallback
-	_, err := os.Stat(systemDockerSocketPath)
+// findDockerSocket attempts to locate Docker sockets. Returns every candidate
+// path that exists on disk in priority order; an empty slice means no Docker
+// socket was found.
+//
+// Returning every candidate lets callers fall back to a per-user socket like
+// ~/.docker/desktop/docker.sock when the system socket /var/run/docker.sock
+// exists but is not connectable (e.g. the running user is not in the docker
+// group). Stat-OK on a path does not imply the daemon will accept a connect.
+func findDockerSocket() []string {
+	var paths []string
 
-	if err == nil {
+	if _, err := os.Stat(systemDockerSocketPath); err == nil {
 		slog.Debug("found Docker socket", "path", systemDockerSocketPath)
-		return systemDockerSocketPath, nil
+		paths = append(paths, systemDockerSocketPath)
+	} else {
+		slog.Debug("failed to check Docker socket", "path", systemDockerSocketPath, "error", err)
 	}
 
-	slog.Debug("failed to check Docker socket", "path", systemDockerSocketPath, "error", err)
+	home := os.Getenv("HOME")
+	if home == "" {
+		return paths
+	}
 
-	// Try Docker Desktop socket path on macOS
-	if home := os.Getenv("HOME"); home != "" {
-		dockerDesktopPath := filepath.Join(home, DockerDesktopMacSocketPath)
-		_, err := os.Stat(dockerDesktopPath) // #nosec G703 -- path is built from HOME + constant socket path
-
-		if err == nil {
+	userCandidates := []struct {
+		label    string
+		relative string
+	}{
+		{"Docker Desktop socket", DockerDesktopMacSocketPath},
+		{"Docker Desktop socket", DockerDesktopLinuxSocketPath},
+		{"Rancher Desktop socket", RancherDesktopMacSocketPath},
+		{"OrbStack socket", OrbStackMacSocketPath},
+	}
+	for _, c := range userCandidates {
+		path := filepath.Join(home, c.relative)
+		if _, err := os.Stat(path); err == nil { // #nosec G703 -- path is built from HOME + constant socket path
 			//nolint:gosec // G706: socket path derived from HOME env var
-			slog.Debug("found Docker Desktop socket", "path", dockerDesktopPath)
-			return dockerDesktopPath, nil
-		}
-
-		//nolint:gosec // G706: socket path derived from HOME env var
-		slog.Debug("failed to check Docker Desktop socket", "path", dockerDesktopPath, "error", err)
-	}
-
-	// Try Docker Desktop socket path on Linux
-	if home := os.Getenv("HOME"); home != "" {
-		dockerDesktopLinuxPath := filepath.Join(home, DockerDesktopLinuxSocketPath)
-		_, err := os.Stat(dockerDesktopLinuxPath) // #nosec G703 -- path is built from HOME + constant socket path
-
-		if err == nil {
+			slog.Debug("found "+c.label, "path", path)
+			paths = append(paths, path)
+		} else {
 			//nolint:gosec // G706: socket path derived from HOME env var
-			slog.Debug("found Docker Desktop socket", "path", dockerDesktopLinuxPath)
-			return dockerDesktopLinuxPath, nil
+			slog.Debug("failed to check "+c.label, "path", path, "error", err)
 		}
-
-		//nolint:gosec // G706: socket path derived from HOME env var
-		slog.Debug("failed to check Docker Desktop socket", "path", dockerDesktopLinuxPath, "error", err)
 	}
 
-	// Try Rancher Desktop socket path on macOS
-	if home := os.Getenv("HOME"); home != "" {
-		rancherDesktopPath := filepath.Join(home, RancherDesktopMacSocketPath)
-		_, err := os.Stat(rancherDesktopPath) // #nosec G703 -- path is built from HOME + constant socket path
-
-		if err == nil {
-			//nolint:gosec // G706: socket path derived from HOME env var
-			slog.Debug("found Rancher Desktop socket", "path", rancherDesktopPath)
-			return rancherDesktopPath, nil
-		}
-
-		//nolint:gosec // G706: socket path derived from HOME env var
-		slog.Debug("failed to check Rancher Desktop socket", "path", rancherDesktopPath, "error", err)
-	}
-
-	// Try OrbStack socket path on macOS
-	if home := os.Getenv("HOME"); home != "" {
-		orbStackPath := filepath.Join(home, OrbStackMacSocketPath)
-		_, err := os.Stat(orbStackPath) // #nosec G703 -- path is built from HOME + constant socket path
-
-		if err == nil {
-			//nolint:gosec // G706: socket path derived from HOME env var
-			slog.Debug("found OrbStack socket", "path", orbStackPath)
-			return orbStackPath, nil
-		}
-
-		//nolint:gosec // G706: socket path derived from HOME env var
-		slog.Debug("failed to check OrbStack socket", "path", orbStackPath, "error", err)
-	}
-
-	return "", fmt.Errorf("docker socket not found in standard locations")
+	return paths
 }
 
-// findColimaSocket attempts to locate a Colima socket
-func findColimaSocket() (string, error) {
-	// Check standard Colima location
-	_, err := os.Stat(ColimaDesktopMacSocketPath)
-	if err == nil {
+// findColimaSocket attempts to locate Colima sockets. Returns every candidate
+// path that exists on disk in priority order; an empty slice means no Colima
+// socket was found.
+func findColimaSocket() []string {
+	var paths []string
+
+	if _, err := os.Stat(ColimaDesktopMacSocketPath); err == nil {
 		slog.Debug("found Colima socket", "path", ColimaDesktopMacSocketPath)
-		return ColimaDesktopMacSocketPath, nil
+		paths = append(paths, ColimaDesktopMacSocketPath)
+	} else {
+		slog.Debug("failed to check Colima socket", "path", ColimaDesktopMacSocketPath, "error", err)
 	}
 
-	slog.Debug("failed to check Colima socket", "path", ColimaDesktopMacSocketPath, "error", err)
-
-	// Check user-specific location for Colima
 	if home := os.Getenv("HOME"); home != "" {
 		userSocketPath := filepath.Join(home, ColimaDesktopMacSocketPath)
-		_, err := os.Stat(userSocketPath) // #nosec G703 -- path is built from HOME + constant socket path
-
-		if err == nil {
+		if _, err := os.Stat(userSocketPath); err == nil { // #nosec G703 -- path is built from HOME + constant socket path
 			//nolint:gosec // G706: socket path derived from HOME env var
 			slog.Debug("found Colima socket", "path", userSocketPath)
-			return userSocketPath, nil
+			paths = append(paths, userSocketPath)
+		} else {
+			//nolint:gosec // G706: socket path derived from HOME env var
+			slog.Debug("failed to check Colima socket", "path", userSocketPath, "error", err)
 		}
-
-		//nolint:gosec // G706: socket path derived from HOME env var
-		slog.Debug("failed to check Colima socket", "path", userSocketPath, "error", err)
 	}
 
-	return "", fmt.Errorf("colima socket not found in standard locations")
+	return paths
 }

--- a/pkg/container/docker/sdk/client_unix_test.go
+++ b/pkg/container/docker/sdk/client_unix_test.go
@@ -7,6 +7,8 @@ package sdk
 
 import (
 	"errors"
+	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"testing"
@@ -48,9 +50,37 @@ func TestFindDockerSocket_DockerDesktopOnLinux(t *testing.T) {
 	socketPath := filepath.Join(home, DockerDesktopLinuxSocketPath)
 	require.NoError(t, os.WriteFile(socketPath, nil, 0o600))
 
-	got, err := findDockerSocket()
-	require.NoError(t, err)
-	assert.Equal(t, socketPath, got)
+	got := findDockerSocket()
+	assert.Equal(t, []string{socketPath}, got)
+}
+
+// TestFindDockerSocket_ReturnsAllCandidates exercises the multi-candidate path
+// that motivates the slice return type: a system Docker socket AND a
+// Docker Desktop on Linux user socket both exist at once (common when Docker
+// Desktop installs a host-side wrapper at /var/run/docker.sock alongside its
+// per-user socket). Both must be returned, system-first, so NewDockerClient
+// can fall back from one to the other on connect failure.
+func TestFindDockerSocket_ReturnsAllCandidates(t *testing.T) {
+	clearSocketEnv(t)
+
+	sysDir := t.TempDir()
+	sysSocket := filepath.Join(sysDir, "docker.sock")
+	require.NoError(t, os.WriteFile(sysSocket, nil, 0o600))
+	orig := systemDockerSocketPath
+	systemDockerSocketPath = sysSocket
+	t.Cleanup(func() { systemDockerSocketPath = orig })
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	socketDir := filepath.Join(home, filepath.Dir(DockerDesktopLinuxSocketPath))
+	require.NoError(t, os.MkdirAll(socketDir, 0o755))
+	userSocket := filepath.Join(home, DockerDesktopLinuxSocketPath)
+	require.NoError(t, os.WriteFile(userSocket, nil, 0o600))
+
+	got := findDockerSocket()
+	require.Len(t, got, 2, "expected system socket + user socket to both be returned")
+	assert.Equal(t, sysSocket, got[0], "system socket must be probed first")
+	assert.Equal(t, userSocket, got[1], "Docker Desktop on Linux socket must be the next candidate")
 }
 
 func TestFindPlatformContainerSocket_DockerEnvOverrideWins(t *testing.T) {
@@ -62,7 +92,7 @@ func TestFindPlatformContainerSocket_DockerEnvOverrideWins(t *testing.T) {
 	t.Setenv(DockerSocketEnv, envSocket)
 
 	// Even with a Docker Desktop on Linux socket present at $HOME, the env
-	// var must take precedence.
+	// var must take precedence and short-circuit candidate collection.
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	socketDir := filepath.Join(home, filepath.Dir(DockerDesktopLinuxSocketPath))
@@ -70,9 +100,9 @@ func TestFindPlatformContainerSocket_DockerEnvOverrideWins(t *testing.T) {
 	homeSocket := filepath.Join(home, DockerDesktopLinuxSocketPath)
 	require.NoError(t, os.WriteFile(homeSocket, nil, 0o600))
 
-	path, rt, err := findPlatformContainerSocket(runtime.TypeDocker)
+	paths, rt, err := findPlatformContainerSocket(runtime.TypeDocker)
 	require.NoError(t, err)
-	assert.Equal(t, envSocket, path)
+	assert.Equal(t, []string{envSocket}, paths)
 	assert.Equal(t, runtime.TypeDocker, rt)
 }
 
@@ -89,4 +119,36 @@ func TestFindPlatformContainerSocket_NotFound(t *testing.T) {
 	_, _, err := findPlatformContainerSocket(runtime.TypeDocker)
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, ErrRuntimeNotFound), "expected ErrRuntimeNotFound, got %v", err)
+}
+
+func TestDockerPermissionHint(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil error returns empty hint", func(t *testing.T) {
+		t.Parallel()
+		assert.Empty(t, dockerPermissionHint(nil))
+	})
+
+	t.Run("non-permission error returns empty hint", func(t *testing.T) {
+		t.Parallel()
+		assert.Empty(t, dockerPermissionHint(errors.New("connection refused")))
+	})
+
+	t.Run("fs.ErrPermission triggers hint", func(t *testing.T) {
+		t.Parallel()
+		wrapped := fmt.Errorf("failed to ping Docker server: %w", fs.ErrPermission)
+		hint := dockerPermissionHint(wrapped)
+		assert.Contains(t, hint, "docker' group")
+		assert.Contains(t, hint, "usermod -aG docker")
+	})
+
+	t.Run("rendered 'permission denied' substring triggers hint", func(t *testing.T) {
+		t.Parallel()
+		// The Docker SDK wraps the underlying *os.SyscallError in its own
+		// formatted message, which we can't reach via errors.Is. Make sure
+		// the substring fallback still surfaces the hint in that shape.
+		err := errors.New("Got permission denied while trying to connect to the Docker daemon socket at unix:///var/run/docker.sock")
+		hint := dockerPermissionHint(err)
+		assert.NotEmpty(t, hint)
+	})
 }

--- a/pkg/container/docker/sdk/client_windows.go
+++ b/pkg/container/docker/sdk/client_windows.go
@@ -58,8 +58,10 @@ func newPlatformClient(pipePath string) (*http.Client, []client.Opt) {
 	return httpClient, opts
 }
 
-// findPlatformContainerSocket finds a container socket path on Windows
-func findPlatformContainerSocket(rt runtime.Type) (string, runtime.Type, error) {
+// findPlatformContainerSocket finds container pipe paths on Windows. Returns
+// a slice for parity with the Unix implementation, but Windows only ever has
+// one candidate per runtime type (the well-known named pipe).
+func findPlatformContainerSocket(rt runtime.Type) ([]string, runtime.Type, error) {
 	// First check for custom socket paths via environment variables
 	if customPipePath := os.Getenv(PodmanSocketEnv); customPipePath != "" {
 		//nolint:gosec // G706: pipe path from trusted environment variable
@@ -69,10 +71,10 @@ func findPlatformContainerSocket(rt runtime.Type) (string, runtime.Type, error) 
 		defer cancel()
 		conn, err := winio.DialPipeContext(ctx, customPipePath)
 		if err != nil {
-			return "", runtime.TypePodman, fmt.Errorf("invalid Podman pipe path: %w", err)
+			return nil, runtime.TypePodman, fmt.Errorf("invalid Podman pipe path: %w", err)
 		}
 		conn.Close()
-		return customPipePath, runtime.TypePodman, nil
+		return []string{customPipePath}, runtime.TypePodman, nil
 	}
 
 	if customPipePath := os.Getenv(DockerSocketEnv); customPipePath != "" {
@@ -83,10 +85,10 @@ func findPlatformContainerSocket(rt runtime.Type) (string, runtime.Type, error) 
 		defer cancel()
 		conn, err := winio.DialPipeContext(ctx, customPipePath)
 		if err != nil {
-			return "", runtime.TypeDocker, fmt.Errorf("invalid Docker pipe path: %w", err)
+			return nil, runtime.TypeDocker, fmt.Errorf("invalid Docker pipe path: %w", err)
 		}
 		conn.Close()
-		return customPipePath, runtime.TypeDocker, nil
+		return []string{customPipePath}, runtime.TypeDocker, nil
 	}
 
 	if rt == runtime.TypePodman {
@@ -97,7 +99,7 @@ func findPlatformContainerSocket(rt runtime.Type) (string, runtime.Type, error) 
 		if err == nil {
 			slog.Debug("found Podman pipe", "path", PodmanDesktopWindowsPipePath)
 			conn.Close()
-			return PodmanDesktopWindowsPipePath, runtime.TypePodman, nil
+			return []string{PodmanDesktopWindowsPipePath}, runtime.TypePodman, nil
 		}
 		slog.Debug("failed to connect to Podman pipe", "path", PodmanDesktopWindowsPipePath, "error", err)
 	}
@@ -110,10 +112,10 @@ func findPlatformContainerSocket(rt runtime.Type) (string, runtime.Type, error) 
 		if err == nil {
 			slog.Debug("found Docker pipe", "path", DockerDesktopWindowsPipePath)
 			conn.Close()
-			return DockerDesktopWindowsPipePath, runtime.TypeDocker, nil
+			return []string{DockerDesktopWindowsPipePath}, runtime.TypeDocker, nil
 		}
 		slog.Debug("failed to connect to Docker pipe", "path", DockerDesktopWindowsPipePath, "error", err)
 	}
 
-	return "", "", ErrRuntimeNotFound
+	return nil, "", ErrRuntimeNotFound
 }

--- a/pkg/container/docker/sdk/factory.go
+++ b/pkg/container/docker/sdk/factory.go
@@ -6,8 +6,11 @@ package sdk
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io/fs"
 	"log/slog"
+	"strings"
 
 	"github.com/docker/docker/client"
 
@@ -53,15 +56,21 @@ const (
 
 var supportedSocketPaths = []runtime.Type{runtime.TypePodman, runtime.TypeDocker, runtime.TypeColima}
 
-// NewDockerClient creates a new container client
+// NewDockerClient creates a new container client.
+//
+// For each runtime (Podman, Docker, Colima) it asks the platform helper for
+// every candidate socket that exists on disk and then tries to connect to each
+// in turn. This matters in mixed setups — e.g. /var/run/docker.sock is present
+// but the running user is not in the docker group, while Docker Desktop's
+// per-user socket at ~/.docker/desktop/docker.sock would work. Without
+// per-runtime fallback the first stat-OK socket short-circuits discovery and
+// we'd surface "no container runtime available" even though a usable Docker
+// daemon is reachable through a different socket.
 func NewDockerClient(ctx context.Context) (*client.Client, string, runtime.Type, error) {
 	var lastErr error
 
-	// We try to find a container socket for the given runtime
-	// We try Podman first, then Docker as fallback
 	for _, sp := range supportedSocketPaths {
-		// Try to find a container socket for the given runtime
-		socketPath, runtimeType, err := findContainerSocket(sp)
+		socketPaths, runtimeType, err := findContainerSocket(sp)
 		if err != nil {
 			//nolint:gosec // G706: runtime type from internal config
 			slog.Debug("failed to find socket", "runtime", sp, "error", err)
@@ -69,23 +78,45 @@ func NewDockerClient(ctx context.Context) (*client.Client, string, runtime.Type,
 			continue
 		}
 
-		c, err := newClientWithSocketPath(ctx, socketPath)
-		if err != nil {
-			lastErr = err
-			//nolint:gosec // G706: runtime type from internal config
-			slog.Debug("failed to create client", "runtime", sp, "error", err)
-			continue
-		}
+		for _, socketPath := range socketPaths {
+			c, err := newClientWithSocketPath(ctx, socketPath)
+			if err != nil {
+				lastErr = err
+				//nolint:gosec // G706: runtime type from internal config
+				slog.Debug("failed to create client", "runtime", sp, "socket", socketPath, "error", err)
+				continue
+			}
 
-		//nolint:gosec // G706: runtime type from internal detection
-		slog.Debug("successfully connected to runtime", "runtime", runtimeType)
-		return c, socketPath, runtimeType, nil
+			//nolint:gosec // G706: runtime type from internal detection
+			slog.Debug("successfully connected to runtime", "runtime", runtimeType, "socket", socketPath)
+			return c, socketPath, runtimeType, nil
+		}
 	}
 
 	if lastErr != nil {
-		return nil, "", "", fmt.Errorf("no supported container runtime available: %w", lastErr)
+		return nil, "", "", fmt.Errorf("no supported container runtime available%s: %w", dockerPermissionHint(lastErr), lastErr)
 	}
 	return nil, "", "", fmt.Errorf("no supported container runtime found/running")
+}
+
+// dockerPermissionHint returns an actionable hint when the underlying socket
+// connect was rejected with a permission error. The most common cause on
+// Linux is the calling user not being a member of the docker group, which the
+// raw "permission denied" error does not call out.
+func dockerPermissionHint(err error) string {
+	if err == nil {
+		return ""
+	}
+	// errors.Is handles syscall.EACCES/EPERM (which map to fs.ErrPermission via
+	// the syscall.Errno.Is shim); the Docker client wraps the underlying
+	// *os.SyscallError in its own message, so also fall back to a substring
+	// match on the rendered text for robustness across error wrappings.
+	if !errors.Is(err, fs.ErrPermission) && !strings.Contains(err.Error(), "permission denied") {
+		return ""
+	}
+	return " (hint: the Docker socket rejected the connection with 'permission denied' — " +
+		"is your user in the 'docker' group? On Linux: 'sudo usermod -aG docker $USER', " +
+		"then log out and back in. See https://docs.docker.com/engine/install/linux-postinstall/.)"
 }
 
 // NewClientWithSocketPath creates a new container client with a specific socket path
@@ -108,8 +139,11 @@ func newClientWithSocketPath(ctx context.Context, socketPath string) (*client.Cl
 	return dockerClient, nil
 }
 
-// findContainerSocket finds a container socket path, preferring Podman over Docker
-func findContainerSocket(rt runtime.Type) (string, runtime.Type, error) {
+// findContainerSocket finds candidate container socket paths for the given
+// runtime, preferring Podman over Docker. The returned slice is ordered from
+// highest to lowest priority and may contain multiple entries on Unix when
+// several known socket locations exist on disk simultaneously.
+func findContainerSocket(rt runtime.Type) ([]string, runtime.Type, error) {
 	// Use platform-specific implementation
 	return findPlatformContainerSocket(rt)
 }


### PR DESCRIPTION
## Summary

- On a Linux box where `/var/run/docker.sock` exists but is not connectable (typically because the user is not in the `docker` group, returning `EACCES`), socket discovery short-circuited on the first stat-OK path and never tried alternative Docker sockets such as Docker Desktop's `~/.docker/desktop/docker.sock`. The outer loop in `NewDockerClient` only iterated runtime *types* (Podman → Docker → Colima), not multiple sockets within a runtime, so users with a Docker-Desktop-on-Linux setup that also exposes a host-side wrapper at `/var/run/docker.sock` were told "no container runtime available" even though a usable Docker daemon was reachable via a different socket.
- `findDockerSocket` / `findPodmanSocket` / `findColimaSocket` now return every candidate path that exists on disk, in priority order. `NewDockerClient` tries each one and only moves on to the next runtime after every candidate for the current runtime has failed.
- Added `dockerPermissionHint`: when the final error is a `permission denied` on a socket connect, the user now gets an actionable hint (`sudo usermod -aG docker $USER`, log out / back in, link to the Docker post-install docs) appended to the existing error instead of being left to decode `permission denied` themselves.
- Behavior of the `TOOLHIVE_*_SOCKET` env-var overrides is unchanged — the override is explicit so we still short-circuit candidate collection to a single path.

Fixes #5120

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test`) — focused package: `go test -count=1 -race ./pkg/container/docker/sdk/...` passes; full `task test` fails on an unrelated pre-existing test in `pkg/skills/client` that picks up a stale server-discovery file on hosts where another `thv` is running. The diff is confined to `pkg/container/docker/sdk/`.
- [x] Linting (`task lint-fix`) — 0 issues.
- [x] Manual testing — verified the new `TestFindDockerSocket_ReturnsAllCandidates` (two stat-OK Docker sockets, both returned in priority order) and `TestDockerPermissionHint` (covers nil, non-permission, `fs.ErrPermission`-wrapped, and the literal `"permission denied"` substring shape that the Docker SDK renders).

## API Compatibility

- [x] This PR does not break the `v1beta1` API. No operator surface touched; all changes are in `pkg/container/docker/sdk/`.

## Changes

| File | Change |
|------|--------|
| `pkg/container/docker/sdk/client_unix.go` | `findDockerSocket` / `findPodmanSocket` / `findColimaSocket` now return `[]string` of every stat-OK candidate; `findPlatformContainerSocket` returns `([]string, runtime.Type, error)`. |
| `pkg/container/docker/sdk/client_windows.go` | `findPlatformContainerSocket` mirrored to return `[]string` — single-element on success (Windows has one named pipe per runtime). |
| `pkg/container/docker/sdk/factory.go` | `NewDockerClient` iterates over every socket candidate per runtime before moving on; adds `dockerPermissionHint` for actionable EACCES errors. |
| `pkg/container/docker/sdk/client_unix_test.go` | Updates existing tests for the new return types; adds `TestFindDockerSocket_ReturnsAllCandidates` and `TestDockerPermissionHint`. |

## Does this introduce a user-facing change?

Yes. Users with a Docker-Desktop-on-Linux setup, where `/var/run/docker.sock` is present but not connectable by the calling user, will now have `thv` automatically fall back to `~/.docker/desktop/docker.sock` and start cleanly. When all attempts fail with permission errors, the error message now includes a docker-group hint and a link to the Docker post-install docs.

## Special notes for reviewers

- The env-var override path (`TOOLHIVE_DOCKER_SOCKET` etc.) intentionally still returns a single-element slice: when the user explicitly points us at a socket, we should not silently fall through to a different one.
- `dockerPermissionHint` uses both `errors.Is(err, fs.ErrPermission)` and a substring match on `"permission denied"`. The Docker client SDK wraps the underlying `*os.SyscallError` in its own formatted message, so the `errors.Is` chain doesn't always reach `fs.ErrPermission`; the substring fallback keeps the hint reliable across that wrapping.

Made with [Cursor](https://cursor.com)