### PR TITLE
fix(registry): surface legacy registry format as a structured API error

### DIFF
--- a/pkg/api/v1/registry.go
+++ b/pkg/api/v1/registry.go
@@ -57,7 +57,7 @@ func writeRegistryAuthRequiredError(w http.ResponseWriter) {
 const RegistryUnavailableCode = "registry_unavailable"
 
 // RegistryLegacyFormatCode is the machine-readable error code returned in the
-// structured JSON 503 response when the configured registry source serves data
+// structured JSON 502 response when the configured registry source serves data
 // in the legacy ToolHive format instead of the upstream MCP registry format.
 // Desktop clients (Studio) match on this value to display a targeted recovery
 // flow (reset to default registry, point to a `?format=upstream` endpoint, or
@@ -76,17 +76,21 @@ func writeRegistryUnavailableError(w http.ResponseWriter, unavailableErr *regpkg
 	_ = json.NewEncoder(w).Encode(body)
 }
 
-// writeRegistryLegacyFormatError writes a structured JSON 503 response when the
-// configured registry source returns data in the legacy ToolHive format. The
-// message embeds legacyhint.MigrationMessage so CLI users still see the
-// actionable migration step, while desktop clients can branch on Code.
+// writeRegistryLegacyFormatError writes a structured JSON 502 Bad Gateway
+// response when the configured registry source returns data in the legacy
+// ToolHive format. HTTP 502 is correct per RFC 9110 §15.6.3: thv serve is
+// acting as a gateway to the upstream registry, and the upstream returned a
+// response we cannot process. It also aligns with the existing PUT handler
+// which already returns 502 for the same legacy-format detection. The message
+// embeds legacyhint.MigrationMessage so CLI users still see the actionable
+// migration step, while desktop clients can branch on Code.
 func writeRegistryLegacyFormatError(w http.ResponseWriter, legacyErr *regpkg.LegacyFormatError) {
 	body := registryErrorResponse{
 		Code:    RegistryLegacyFormatCode,
 		Message: legacyErr.Error(),
 	}
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusServiceUnavailable)
+	w.WriteHeader(http.StatusBadGateway)
 	_ = json.NewEncoder(w).Encode(body)
 }
 

--- a/pkg/api/v1/registry.go
+++ b/pkg/api/v1/registry.go
@@ -56,12 +56,34 @@ func writeRegistryAuthRequiredError(w http.ResponseWriter) {
 // structured JSON 503 response when the upstream registry is unreachable.
 const RegistryUnavailableCode = "registry_unavailable"
 
+// RegistryLegacyFormatCode is the machine-readable error code returned in the
+// structured JSON 503 response when the configured registry source serves data
+// in the legacy ToolHive format instead of the upstream MCP registry format.
+// Desktop clients (Studio) match on this value to display a targeted recovery
+// flow (reset to default registry, point to a `?format=upstream` endpoint, or
+// run `thv registry convert`).
+const RegistryLegacyFormatCode = "registry_legacy_format"
+
 // writeRegistryUnavailableError writes a structured JSON 503 response when the
 // upstream registry cannot be reached or returns an unexpected error (e.g. 404).
 func writeRegistryUnavailableError(w http.ResponseWriter, unavailableErr *regpkg.UnavailableError) {
 	body := registryErrorResponse{
 		Code:    RegistryUnavailableCode,
 		Message: unavailableErr.Error(),
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusServiceUnavailable)
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+// writeRegistryLegacyFormatError writes a structured JSON 503 response when the
+// configured registry source returns data in the legacy ToolHive format. The
+// message embeds legacyhint.MigrationMessage so CLI users still see the
+// actionable migration step, while desktop clients can branch on Code.
+func writeRegistryLegacyFormatError(w http.ResponseWriter, legacyErr *regpkg.LegacyFormatError) {
+	body := registryErrorResponse{
+		Code:    RegistryLegacyFormatCode,
+		Message: legacyErr.Error(),
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusServiceUnavailable)
@@ -267,6 +289,12 @@ func (rr *RegistryRoutes) getCurrentProvider(w http.ResponseWriter) (regpkg.Prov
 			writeRegistryAuthRequiredError(w)
 			return nil, false
 		}
+		var legacyErr *regpkg.LegacyFormatError
+		if errors.As(err, &legacyErr) {
+			slog.Error("upstream registry in legacy format", "error", err)
+			writeRegistryLegacyFormatError(w, legacyErr)
+			return nil, false
+		}
 		var unavailableErr *regpkg.UnavailableError
 		if errors.As(err, &unavailableErr) {
 			slog.Error("upstream registry unavailable", "error", err)
@@ -373,6 +401,12 @@ func (rr *RegistryRoutes) listRegistries(w http.ResponseWriter, _ *http.Request)
 			writeRegistryAuthRequiredError(w)
 			return
 		}
+		var legacyErr *regpkg.LegacyFormatError
+		if errors.As(err, &legacyErr) {
+			slog.Error("upstream registry in legacy format", "error", err)
+			writeRegistryLegacyFormatError(w, legacyErr)
+			return
+		}
 		var unavailableErr *regpkg.UnavailableError
 		if errors.As(err, &unavailableErr) {
 			slog.Error("upstream registry unavailable", "error", err)
@@ -452,6 +486,12 @@ func (rr *RegistryRoutes) getRegistry(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		if isRegistryAuthError(err) {
 			writeRegistryAuthRequiredError(w)
+			return
+		}
+		var legacyErr *regpkg.LegacyFormatError
+		if errors.As(err, &legacyErr) {
+			slog.Error("upstream registry in legacy format", "error", err)
+			writeRegistryLegacyFormatError(w, legacyErr)
 			return
 		}
 		var unavailableErr *regpkg.UnavailableError
@@ -739,6 +779,12 @@ func (rr *RegistryRoutes) listServers(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		if isRegistryAuthError(err) {
 			writeRegistryAuthRequiredError(w)
+			return
+		}
+		var legacyErr *regpkg.LegacyFormatError
+		if errors.As(err, &legacyErr) {
+			slog.Error("upstream registry in legacy format", "error", err)
+			writeRegistryLegacyFormatError(w, legacyErr)
 			return
 		}
 		var unavailableErr *regpkg.UnavailableError

--- a/pkg/api/v1/registry_test.go
+++ b/pkg/api/v1/registry_test.go
@@ -140,6 +140,112 @@ func TestRegistryAPI_GetEndpoint_UnavailableUpstream(t *testing.T) {
 	}
 }
 
+// TestRegistryAPI_GetEndpoint_LegacyFormat tests that GET endpoints return 503
+// with a structured "registry_legacy_format" code when the configured custom
+// registry URL serves data in the legacy ToolHive format. Mirrors the
+// UnavailableUpstream test above but covers the new typed error path.
+//
+//nolint:paralleltest // Uses global registry provider singleton
+func TestRegistryAPI_GetEndpoint_LegacyFormat(t *testing.T) {
+	// Mock server that returns a valid HTTP 200 but with legacy ToolHive
+	// registry JSON (top-level "servers" instead of nested "data.servers").
+	// validateConnectivity() must detect this and reject the provider with a
+	// *LegacyFormatError.
+	legacyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"version": "1.0.0",
+			"servers": {"example": {"image": "example:latest"}}
+		}`))
+	}))
+	defer legacyServer.Close()
+
+	// Configure registry to point at the mock legacy-format server via the
+	// remote URL provider path (RegistryUrl, not RegistryApiUrl).
+	cfg := &config.Config{
+		RegistryUrl:            legacyServer.URL,
+		AllowPrivateRegistryIp: true,
+	}
+	configProvider, cleanup := CreateTestConfigProvider(t, cfg)
+	defer cleanup()
+
+	registry.ResetDefaultProvider()
+	t.Cleanup(registry.ResetDefaultProvider)
+
+	routes := &RegistryRoutes{
+		configProvider: configProvider,
+		configService:  registry.NewConfiguratorWithProvider(configProvider),
+		serveMode:      true,
+	}
+
+	endpoints := []struct {
+		name      string
+		method    string
+		path      string
+		handler   http.HandlerFunc
+		urlParams map[string]string
+	}{
+		{
+			name:    "listRegistries",
+			method:  http.MethodGet,
+			path:    "/",
+			handler: routes.listRegistries,
+		},
+		{
+			name:      "getRegistry",
+			method:    http.MethodGet,
+			path:      "/default",
+			handler:   routes.getRegistry,
+			urlParams: map[string]string{"name": "default"},
+		},
+		{
+			name:      "listServers",
+			method:    http.MethodGet,
+			path:      "/default/servers",
+			handler:   routes.listServers,
+			urlParams: map[string]string{"name": "default"},
+		},
+	}
+
+	for _, ep := range endpoints {
+		t.Run(ep.name, func(t *testing.T) {
+			registry.ResetDefaultProvider()
+
+			req := httptest.NewRequest(ep.method, ep.path, nil)
+			if ep.urlParams != nil {
+				rctx := chi.NewRouteContext()
+				for k, v := range ep.urlParams {
+					rctx.URLParams.Add(k, v)
+				}
+				req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+			}
+
+			w := httptest.NewRecorder()
+			ep.handler(w, req)
+
+			assert.Equal(t, http.StatusServiceUnavailable, w.Code,
+				"Expected 503 Service Unavailable when registry is in legacy format")
+
+			var body registryErrorResponse
+			err := json.NewDecoder(w.Body).Decode(&body)
+			require.NoError(t, err, "Response should be valid JSON")
+			assert.Equal(t, RegistryLegacyFormatCode, body.Code,
+				"Response code should be registry_legacy_format")
+			// The body must carry the actionable migration hint so CLI users
+			// and desktop clients both have something to act on.
+			assert.Contains(t, body.Message, "legacy ToolHive format",
+				"Response message should mention the legacy format")
+			assert.Contains(t, body.Message, "thv registry convert",
+				"Response message should include the migration command hint")
+			assert.Contains(t, body.Message, legacyServer.URL,
+				"Response message should identify the offending source URL")
+			assert.Contains(t, w.Header().Get("Content-Type"), "application/json",
+				"Response Content-Type should be application/json")
+		})
+	}
+}
+
 func TestRegistryRouter(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/api/v1/registry_test.go
+++ b/pkg/api/v1/registry_test.go
@@ -140,10 +140,11 @@ func TestRegistryAPI_GetEndpoint_UnavailableUpstream(t *testing.T) {
 	}
 }
 
-// TestRegistryAPI_GetEndpoint_LegacyFormat tests that GET endpoints return 503
+// TestRegistryAPI_GetEndpoint_LegacyFormat tests that GET endpoints return 502
 // with a structured "registry_legacy_format" code when the configured custom
-// registry URL serves data in the legacy ToolHive format. Mirrors the
-// UnavailableUpstream test above but covers the new typed error path.
+// registry URL serves data in the legacy ToolHive format. 502 is correct per
+// RFC 9110 §15.6.3: thv serve acts as a gateway to the upstream registry and
+// the upstream returned a response we cannot process.
 //
 //nolint:paralleltest // Uses global registry provider singleton
 func TestRegistryAPI_GetEndpoint_LegacyFormat(t *testing.T) {
@@ -224,8 +225,8 @@ func TestRegistryAPI_GetEndpoint_LegacyFormat(t *testing.T) {
 			w := httptest.NewRecorder()
 			ep.handler(w, req)
 
-			assert.Equal(t, http.StatusServiceUnavailable, w.Code,
-				"Expected 503 Service Unavailable when registry is in legacy format")
+			assert.Equal(t, http.StatusBadGateway, w.Code,
+				"Expected 502 Bad Gateway when registry is in legacy format")
 
 			var body registryErrorResponse
 			err := json.NewDecoder(w.Body).Decode(&body)

--- a/pkg/api/v1/registry_v01.go
+++ b/pkg/api/v1/registry_v01.go
@@ -52,6 +52,12 @@ func getRegistryProvider(w http.ResponseWriter) (regpkg.Provider, bool) {
 			writeRegistryAuthRequiredError(w)
 			return nil, false
 		}
+		var legacyErr *regpkg.LegacyFormatError
+		if errors.As(err, &legacyErr) {
+			slog.Error("upstream registry in legacy format", "error", err)
+			writeRegistryLegacyFormatError(w, legacyErr)
+			return nil, false
+		}
 		var unavailableErr *regpkg.UnavailableError
 		if errors.As(err, &unavailableErr) {
 			slog.Error("upstream registry unavailable", "error", err)

--- a/pkg/registry/errors.go
+++ b/pkg/registry/errors.go
@@ -6,6 +6,8 @@ package registry
 import (
 	"errors"
 	"fmt"
+
+	"github.com/stacklok/toolhive/pkg/registry/legacyhint"
 )
 
 // ErrServerNotFound indicates a server was not found in the registry.
@@ -28,4 +30,32 @@ func (e *UnavailableError) Error() string {
 
 func (e *UnavailableError) Unwrap() error {
 	return e.Err
+}
+
+// LegacyFormatError indicates the registry source contains data in the legacy
+// ToolHive registry format instead of the upstream MCP registry format.
+// API handlers translate this into a structured HTTP 503 with a
+// "registry_legacy_format" code so desktop clients can surface a targeted
+// recovery flow (instead of a generic error screen).
+//
+// URL is optional and identifies the offending source (remote URL or local
+// file path) when known. The Error() message embeds legacyhint.MigrationMessage
+// so CLI consumers continue to see the same actionable hint.
+type LegacyFormatError struct {
+	URL string
+}
+
+func (e *LegacyFormatError) Error() string {
+	if e.URL != "" {
+		return fmt.Sprintf("registry at %s: %s", e.URL, legacyhint.MigrationMessage)
+	}
+	return legacyhint.MigrationMessage
+}
+
+// Is enables errors.Is matching against any *LegacyFormatError sentinel,
+// regardless of the URL field. Existing callers using a zero-value sentinel
+// (e.g. errLegacyFormat) keep matching when the returned error carries a URL.
+func (*LegacyFormatError) Is(target error) bool {
+	_, ok := target.(*LegacyFormatError)
+	return ok
 }

--- a/pkg/registry/errors.go
+++ b/pkg/registry/errors.go
@@ -34,7 +34,7 @@ func (e *UnavailableError) Unwrap() error {
 
 // LegacyFormatError indicates the registry source contains data in the legacy
 // ToolHive registry format instead of the upstream MCP registry format.
-// API handlers translate this into a structured HTTP 503 with a
+// API handlers translate this into a structured HTTP 502 with a
 // "registry_legacy_format" code so desktop clients can surface a targeted
 // recovery flow (instead of a generic error screen).
 //

--- a/pkg/registry/errors_test.go
+++ b/pkg/registry/errors_test.go
@@ -66,3 +66,82 @@ func TestUnavailableError_ErrorsAs(t *testing.T) {
 	assert.Equal(t, "https://example.com", target.URL)
 	assert.Equal(t, inner, target.Err)
 }
+
+// TestLegacyFormatError_Error covers the two surface forms (with and without
+// URL) so CLI users keep seeing the migration hint and remote callers also see
+// where the legacy content came from.
+func TestLegacyFormatError_Error(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		err            *LegacyFormatError
+		expectedPrefix string
+	}{
+		{
+			name:           "with URL",
+			err:            &LegacyFormatError{URL: "https://example.com/registry.json"},
+			expectedPrefix: "registry at https://example.com/registry.json: ",
+		},
+		{
+			name:           "without URL",
+			err:            &LegacyFormatError{},
+			expectedPrefix: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			msg := tt.err.Error()
+			if tt.expectedPrefix != "" {
+				assert.Truef(t,
+					len(msg) > len(tt.expectedPrefix) && msg[:len(tt.expectedPrefix)] == tt.expectedPrefix,
+					"expected message to start with %q, got %q", tt.expectedPrefix, msg)
+			}
+			// Migration hint must always be present so CLI users get the
+			// actionable step regardless of whether a URL was attached.
+			assert.Contains(t, msg, "legacy ToolHive format")
+			assert.Contains(t, msg, "thv registry convert")
+		})
+	}
+}
+
+// TestLegacyFormatError_ErrorsIs verifies the Is method matches any
+// *LegacyFormatError regardless of URL. This keeps errors.Is(err, errLegacyFormat)
+// working when the returned error carries a populated URL from a remote source.
+func TestLegacyFormatError_ErrorsIs(t *testing.T) {
+	t.Parallel()
+
+	withURL := &LegacyFormatError{URL: "https://example.com/registry.json"}
+	sentinel := &LegacyFormatError{}
+
+	assert.True(t, errors.Is(withURL, sentinel),
+		"errors.Is(withURL, sentinel) should match via Is method")
+	assert.True(t, errors.Is(sentinel, withURL),
+		"errors.Is(sentinel, withURL) should match via Is method")
+
+	// Wrapped via fmt.Errorf should still match through Unwrap chain.
+	wrapped := fmt.Errorf("custom registry at %s is not reachable: %w", withURL.URL, withURL)
+	assert.True(t, errors.Is(wrapped, sentinel),
+		"errors.Is should follow the Unwrap chain to find a *LegacyFormatError")
+
+	// A different error type must not match.
+	other := &UnavailableError{URL: "https://example.com", Err: fmt.Errorf("boom")}
+	assert.False(t, errors.Is(other, sentinel),
+		"errors.Is must not cross-match *UnavailableError as legacy")
+}
+
+// TestLegacyFormatError_ErrorsAs verifies the typed extraction used by the
+// API layer to surface a structured 503 response with the source URL.
+func TestLegacyFormatError_ErrorsAs(t *testing.T) {
+	t.Parallel()
+
+	original := &LegacyFormatError{URL: "https://example.com/registry.json"}
+	wrapped := fmt.Errorf("custom registry at %s is not reachable: %w", original.URL, original)
+
+	var target *LegacyFormatError
+	require.True(t, errors.As(wrapped, &target),
+		"errors.As must extract *LegacyFormatError from the Unwrap chain")
+	assert.Equal(t, "https://example.com/registry.json", target.URL)
+}

--- a/pkg/registry/errors_test.go
+++ b/pkg/registry/errors_test.go
@@ -133,7 +133,7 @@ func TestLegacyFormatError_ErrorsIs(t *testing.T) {
 }
 
 // TestLegacyFormatError_ErrorsAs verifies the typed extraction used by the
-// API layer to surface a structured 503 response with the source URL.
+// API layer to surface a structured 502 response with the source URL.
 func TestLegacyFormatError_ErrorsAs(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/registry/provider_remote.go
+++ b/pkg/registry/provider_remote.go
@@ -82,7 +82,7 @@ func (p *RemoteRegistryProvider) validateConnectivity() error {
 	}
 
 	if legacyhint.Looks(data) {
-		return fmt.Errorf("registry at %s: %s", p.registryURL, legacyhint.MigrationMessage)
+		return &LegacyFormatError{URL: p.registryURL}
 	}
 
 	var upstream types.UpstreamRegistry

--- a/pkg/registry/upstream_parser.go
+++ b/pkg/registry/upstream_parser.go
@@ -5,7 +5,6 @@ package registry
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 
 	v0 "github.com/modelcontextprotocol/registry/pkg/api/v0"
@@ -18,9 +17,13 @@ import (
 // registry format. Without this check, Go's JSON decoder silently produces an
 // empty UpstreamRegistry (the legacy top-level "servers" field does not match
 // upstream's "data.servers" path), leaving the caller with an empty registry
-// and no actionable error. The error wording carries the migration step so
-// consumers can surface it without a typed match.
-var errLegacyFormat = errors.New(legacyhint.MigrationMessage)
+// and no actionable error.
+//
+// It's an instance of *LegacyFormatError so the API layer can detect it via
+// errors.As and emit a structured "registry_legacy_format" response. The Is
+// method on LegacyFormatError keeps errors.Is(err, errLegacyFormat) working
+// even when the returned error carries a populated URL.
+var errLegacyFormat = &LegacyFormatError{}
 
 // parseRegistryData parses raw JSON in the upstream MCP registry format and
 // converts it into the internal types.Registry plus any embedded skills.


### PR DESCRIPTION
## Summary

When a configured custom registry URL serves data in the legacy ToolHive format, the API now returns **HTTP 502 Bad Gateway** with a structured `registry_legacy_format` code, instead of a generic 500 that hides the actionable migration hint in the log.

Before, `NewRemoteRegistryProvider.validateConnectivity()` returned a plain `fmt.Errorf` that the API handler did not recognise (`pkg/api/v1/registry.go:259`), so the response was `HTTP 500 Failed to get registry provider` and clients had no way to branch on the legacy-format case. The hint (`run thv registry convert --in <path> --in-place`) only showed up in `main.log`.

This PR adds a typed `*LegacyFormatError` in `pkg/registry/errors.go` (sister of `*UnavailableError`) that carries the offending source URL, and wires `errors.As` detection plus a new `writeRegistryLegacyFormatError` writer through all four `GET` handlers and the `v0.1` router.

The package-private `errLegacyFormat` sentinel in `pkg/registry/upstream_parser.go` is now an instance of `*LegacyFormatError`; its `Is()` method preserves `errors.Is(err, errLegacyFormat)` for existing callers while enabling `errors.As` extraction of the URL upstream.

Closes #5259

## Why HTTP 502 Bad Gateway

Per [RFC 9110 §15.6.3](https://datatracker.ietf.org/doc/html/rfc9110#section-15.6.3): 502 = "while acting as a gateway or proxy, received an **invalid response** from an inbound server." `thv serve` is acting as a gateway to the configured upstream registry, and that upstream is returning data we cannot process. Exact fit.

502 also matches what the **existing PUT registry handler** already does for the same legacy-format detection (`pkg/api/v1/registry.go:545`, via `ErrRegistryValidationFailed`). Returning 503 from `GET` would split the same condition across two status codes inside the same file.

503 ("temporary overload or scheduled maintenance") does not fit a permanently misconfigured registry source.

The `registry_unavailable` path also handles upstream 404s on a 503 today — arguably also 502 territory — but reclassifying that is out of scope for this PR.

## Changes

- `pkg/registry/errors.go` — new `LegacyFormatError` type with `URL`, `Error()`, `Is()`.
- `pkg/registry/provider_remote.go` — `validateConnectivity()` returns `&LegacyFormatError{URL: p.registryURL}` instead of `fmt.Errorf`.
- `pkg/registry/upstream_parser.go` — `errLegacyFormat` switches to `&LegacyFormatError{}` (same `Error()` output, now typed for `errors.As`).
- `pkg/api/v1/registry.go` — new `RegistryLegacyFormatCode` + `writeRegistryLegacyFormatError` returning **502**; new `errors.As(err, &legacyErr)` branch in `getCurrentProvider`, `listRegistries`, `getRegistry`, `listServers`.
- `pkg/api/v1/registry_v01.go` — same branch in `getRegistryProvider`.
- `pkg/registry/errors_test.go` — covers `Error()` with/without URL, `Is` matching across populated/empty URLs and via `Unwrap`, and `As` extraction from a wrapped error.
- `pkg/api/v1/registry_test.go` — end-to-end test: configure a remote-URL registry pointing at an httptest server that serves legacy JSON, hit each `GET` handler, assert **502** + `code: registry_legacy_format` + migration hint in the message + source URL in the message.

## Test plan

- [x] `go test ./pkg/registry/ -run "TestLegacyFormatError" -count=1` — new error type tests pass
- [x] `go test ./pkg/api/v1/ -run "TestRegistryAPI_GetEndpoint_LegacyFormat" -count=1` — all three GET handlers return 502 with the new code
- [x] `go test ./pkg/registry/ -run "TestParseRegistryData_LegacyFormatDetection|TestLocalRegistryProvider_LegacyFileReturnsMigrationHint|TestRemoteRegistryProvider_ValidateConnectivity" -count=1` — existing legacy-detection coverage still green
- [x] `go vet ./pkg/registry/... ./pkg/api/v1/...` clean
- [x] `gofmt -l` clean

Four pre-existing failures on `main` (`TestGetDefaultProvider_NoFactoryRegistered`, `TestGetDefaultProvider_FactoryReturnsNil_FallsThrough`, `TestRegistryV01Router_GetServer_NotFound`, `TestRegistryV01Router_ListSkills_PaginationBeyondResults`) reproduce on `git stash` of this branch — unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)