### PR TITLE
Collapse registry provider error ladder into a helper

### DIFF
--- a/pkg/api/v1/registry.go
+++ b/pkg/api/v1/registry.go
@@ -94,6 +94,30 @@ func writeRegistryLegacyFormatError(w http.ResponseWriter, legacyErr *regpkg.Leg
 	_ = json.NewEncoder(w).Encode(body)
 }
 
+// writeProviderError translates a registry provider error into a structured
+// HTTP response if it matches a known failure mode (auth required, legacy
+// format, upstream unavailable) and returns true. The caller is responsible
+// for writing a generic fallback response when this returns false.
+func writeProviderError(w http.ResponseWriter, err error) bool {
+	if isRegistryAuthError(err) {
+		writeRegistryAuthRequiredError(w)
+		return true
+	}
+	var legacyErr *regpkg.LegacyFormatError
+	if errors.As(err, &legacyErr) {
+		slog.Warn("upstream registry in legacy format", "error", err)
+		writeRegistryLegacyFormatError(w, legacyErr)
+		return true
+	}
+	var unavailableErr *regpkg.UnavailableError
+	if errors.As(err, &unavailableErr) {
+		slog.Error("upstream registry unavailable", "error", err)
+		writeRegistryUnavailableError(w, unavailableErr)
+		return true
+	}
+	return false
+}
+
 // resolveAuthStatus returns the auth_status and auth_type strings for API responses
 // by delegating to the AuthManager.
 func (rr *RegistryRoutes) resolveAuthStatus() (authStatus, authType string) {
@@ -289,20 +313,7 @@ func (rr *RegistryRoutes) getCurrentProvider(w http.ResponseWriter) (regpkg.Prov
 	}
 	provider, err := regpkg.GetDefaultProviderWithConfig(rr.configProvider, opts...)
 	if err != nil {
-		if isRegistryAuthError(err) {
-			writeRegistryAuthRequiredError(w)
-			return nil, false
-		}
-		var legacyErr *regpkg.LegacyFormatError
-		if errors.As(err, &legacyErr) {
-			slog.Error("upstream registry in legacy format", "error", err)
-			writeRegistryLegacyFormatError(w, legacyErr)
-			return nil, false
-		}
-		var unavailableErr *regpkg.UnavailableError
-		if errors.As(err, &unavailableErr) {
-			slog.Error("upstream registry unavailable", "error", err)
-			writeRegistryUnavailableError(w, unavailableErr)
+		if writeProviderError(w, err) {
 			return nil, false
 		}
 		http.Error(w, "Failed to get registry provider", http.StatusInternalServerError)
@@ -401,20 +412,7 @@ func (rr *RegistryRoutes) listRegistries(w http.ResponseWriter, _ *http.Request)
 
 	reg, err := provider.GetRegistry()
 	if err != nil {
-		if isRegistryAuthError(err) {
-			writeRegistryAuthRequiredError(w)
-			return
-		}
-		var legacyErr *regpkg.LegacyFormatError
-		if errors.As(err, &legacyErr) {
-			slog.Error("upstream registry in legacy format", "error", err)
-			writeRegistryLegacyFormatError(w, legacyErr)
-			return
-		}
-		var unavailableErr *regpkg.UnavailableError
-		if errors.As(err, &unavailableErr) {
-			slog.Error("upstream registry unavailable", "error", err)
-			writeRegistryUnavailableError(w, unavailableErr)
+		if writeProviderError(w, err) {
 			return
 		}
 		http.Error(w, "Failed to get registry", http.StatusInternalServerError)
@@ -488,20 +486,7 @@ func (rr *RegistryRoutes) getRegistry(w http.ResponseWriter, r *http.Request) {
 
 	reg, err := provider.GetRegistry()
 	if err != nil {
-		if isRegistryAuthError(err) {
-			writeRegistryAuthRequiredError(w)
-			return
-		}
-		var legacyErr *regpkg.LegacyFormatError
-		if errors.As(err, &legacyErr) {
-			slog.Error("upstream registry in legacy format", "error", err)
-			writeRegistryLegacyFormatError(w, legacyErr)
-			return
-		}
-		var unavailableErr *regpkg.UnavailableError
-		if errors.As(err, &unavailableErr) {
-			slog.Error("upstream registry unavailable", "error", err)
-			writeRegistryUnavailableError(w, unavailableErr)
+		if writeProviderError(w, err) {
 			return
 		}
 		http.Error(w, "Failed to get registry", http.StatusInternalServerError)
@@ -781,20 +766,7 @@ func (rr *RegistryRoutes) listServers(w http.ResponseWriter, r *http.Request) {
 	// Get the full registry to access both container and remote servers
 	reg, err := provider.GetRegistry()
 	if err != nil {
-		if isRegistryAuthError(err) {
-			writeRegistryAuthRequiredError(w)
-			return
-		}
-		var legacyErr *regpkg.LegacyFormatError
-		if errors.As(err, &legacyErr) {
-			slog.Error("upstream registry in legacy format", "error", err)
-			writeRegistryLegacyFormatError(w, legacyErr)
-			return
-		}
-		var unavailableErr *regpkg.UnavailableError
-		if errors.As(err, &unavailableErr) {
-			slog.Error("upstream registry unavailable", "error", err)
-			writeRegistryUnavailableError(w, unavailableErr)
+		if writeProviderError(w, err) {
 			return
 		}
 		slog.Error("failed to get registry", "error", err)

--- a/pkg/api/v1/registry_v01.go
+++ b/pkg/api/v1/registry_v01.go
@@ -5,7 +5,6 @@ package v1
 
 import (
 	"encoding/json"
-	"errors"
 	"log/slog"
 	"math"
 	"net/http"
@@ -15,7 +14,6 @@ import (
 
 	"github.com/stacklok/toolhive/pkg/config"
 	regpkg "github.com/stacklok/toolhive/pkg/registry"
-	"github.com/stacklok/toolhive/pkg/registry/auth"
 )
 
 const (
@@ -48,20 +46,7 @@ func getRegistryProvider(w http.ResponseWriter) (regpkg.Provider, bool) {
 		regpkg.WithInteractive(false),
 	)
 	if err != nil {
-		if errors.Is(err, auth.ErrRegistryAuthRequired) {
-			writeRegistryAuthRequiredError(w)
-			return nil, false
-		}
-		var legacyErr *regpkg.LegacyFormatError
-		if errors.As(err, &legacyErr) {
-			slog.Error("upstream registry in legacy format", "error", err)
-			writeRegistryLegacyFormatError(w, legacyErr)
-			return nil, false
-		}
-		var unavailableErr *regpkg.UnavailableError
-		if errors.As(err, &unavailableErr) {
-			slog.Error("upstream registry unavailable", "error", err)
-			writeRegistryUnavailableError(w, unavailableErr)
+		if writeProviderError(w, err) {
 			return nil, false
 		}
 		writeJSONError(w, http.StatusInternalServerError, "internal_error", "Failed to get registry provider")


### PR DESCRIPTION
## Summary

Follow-up on #5260. The `errors.As`/`errors.Is` ladder for `*LegacyFormatError`, `*UnavailableError`, and `auth.ErrRegistryAuthRequired` was copy-pasted across five call sites (`getCurrentProvider`, `listRegistries`, `getRegistry`, `listServers`, `getRegistryProvider`). Each new structured error code had to be wired into five places, and the v0.1 router checked the auth error inline instead of going through `isRegistryAuthError`.

This PR extracts a single `writeProviderError(w, err) bool` helper that handles all three known failure modes and returns whether a response was written. Each callsite collapses to two lines plus a generic fallback. The `errors` and `registry/auth` imports drop out of `registry_v01.go`.

It also lowers the legacy-format log to `slog.Warn`: it signals a user misconfiguration that the API has already translated into a 502 with an actionable hint, not a server-side failure that on-call should investigate. The upstream-unavailable path stays at `slog.Error` since it usually indicates a real outage.

Targeted at `issues/5259` so the diff shows only this refactor — should be rebased onto `main` after #5260 merges.

Net: **-43 lines**.

## Test plan

- [x] `go build ./pkg/api/v1/...` clean
- [x] `go vet ./pkg/api/v1/...` clean
- [x] `gofmt -l pkg/api/v1/` clean
- [x] `go test ./pkg/api/v1/ -run "TestRegistryAPI_GetEndpoint_LegacyFormat|TestRegistryAPI_GetEndpoint_UnavailableUpstream"` passes — confirms the new helper preserves both 502 (legacy) and 503 (unavailable) paths across all three GET handlers, and that the legacy path now logs at WARN
- [x] `go test ./pkg/api/v1/... ./pkg/registry/...` all green

Improves on #5260