### PR TITLE
Add RFC 7523 JWT Bearer grant package

### DIFF
--- a/pkg/oauthproto/constants.go
+++ b/pkg/oauthproto/constants.go
@@ -69,6 +69,9 @@ const (
 const (
 	// GrantTypeTokenExchange is the OAuth 2.0 Token Exchange grant type (RFC 8693).
 	GrantTypeTokenExchange = "urn:ietf:params:oauth:grant-type:token-exchange"
+
+	// GrantTypeJWTBearer is the JWT Bearer grant type (RFC 7523).
+	GrantTypeJWTBearer = "urn:ietf:params:oauth:grant-type:jwt-bearer"
 )
 
 // HTTP client constants.

--- a/pkg/oauthproto/jwtbearer/doc.go
+++ b/pkg/oauthproto/jwtbearer/doc.go
@@ -1,0 +1,7 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package jwtbearer provides an OAuth 2.0 JWT Bearer Grant (RFC 7523) implementation.
+// It exchanges a JWT assertion (such as an ID-JAG) for an access token at a target
+// authorization server.
+package jwtbearer

--- a/pkg/oauthproto/jwtbearer/grant.go
+++ b/pkg/oauthproto/jwtbearer/grant.go
@@ -1,0 +1,168 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package jwtbearer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"golang.org/x/oauth2"
+
+	"github.com/stacklok/toolhive/pkg/networking"
+	"github.com/stacklok/toolhive/pkg/oauthproto"
+)
+
+// Config holds configuration for an OAuth 2.0 JWT Bearer Grant (RFC 7523).
+type Config struct {
+	// TokenURL is the target authorization server's token endpoint (required).
+	TokenURL string
+
+	// ClientID is the OAuth client identifier at the target AS. When both ClientID
+	// and ClientSecret are set, the request is authenticated with HTTP Basic per
+	// RFC 6749 Section 2.3.1. Public-client identification via a body client_id
+	// parameter (RFC 6749 Section 3.2.1) is not supported — XAA / ID-JAG §8.1
+	// requires confidential clients, and that is the only intended consumer.
+	ClientID string
+
+	// ClientSecret is the OAuth client secret at the target AS.
+	ClientSecret string //nolint:gosec // G101: field name, not a credential
+
+	// Scopes are the requested scopes for the access token.
+	Scopes []string
+
+	// AssertionProvider returns the JWT assertion (e.g., the ID-JAG from Step A).
+	// Called on each Token() invocation; must not be nil. The returned JWT must
+	// satisfy RFC 7523 Section 3 (iss/sub/aud/exp); aud should typically be the
+	// target AS's token endpoint (TokenURL). The provider must be safe for
+	// concurrent use — Token() may be called from multiple goroutines (e.g.,
+	// when wrapped in oauth2.ReuseTokenSource).
+	AssertionProvider func() (string, error)
+
+	// HTTPClient is the HTTP client to use. If nil, oauthproto.DefaultHTTPClient()
+	// is used.
+	HTTPClient *http.Client
+}
+
+// Validate checks that the Config contains all required fields.
+func (c *Config) Validate() error {
+	if c.TokenURL == "" {
+		return fmt.Errorf("TokenURL is required")
+	}
+
+	if c.AssertionProvider == nil {
+		return fmt.Errorf("AssertionProvider is required")
+	}
+
+	// Validate TokenURL: must be https (or http on localhost) per RFC 6749 Section 3.2
+	// and RFC 7523 Section 7. Reuses the repo-wide endpoint validator for scheme,
+	// and adds host and fragment checks that it does not perform.
+	if err := networking.ValidateEndpointURL(c.TokenURL); err != nil {
+		return fmt.Errorf("TokenURL: %w", err)
+	}
+	u, err := url.Parse(c.TokenURL)
+	if err != nil {
+		return fmt.Errorf("TokenURL is not a valid URL: %w", err)
+	}
+	if u.Host == "" {
+		return fmt.Errorf("TokenURL must include a host")
+	}
+	if u.Fragment != "" {
+		return fmt.Errorf("TokenURL must not contain a fragment")
+	}
+	if u.User != nil {
+		return fmt.Errorf("TokenURL must not contain embedded credentials")
+	}
+
+	return nil
+}
+
+// String implements fmt.Stringer for Config, redacting sensitive fields.
+func (c *Config) String() string {
+	assertion := oauthproto.Redact("")
+	if c.AssertionProvider != nil {
+		assertion = oauthproto.Redact("set")
+	}
+
+	return fmt.Sprintf("Config{TokenURL: %s, ClientID: %s, ClientSecret: %s, Scopes: %v, Assertion: %s}",
+		c.TokenURL, c.ClientID, oauthproto.Redact(c.ClientSecret), c.Scopes, assertion)
+}
+
+// Compile-time assertion that *tokenSource implements oauth2.TokenSource.
+var _ oauth2.TokenSource = (*tokenSource)(nil)
+
+// TokenSource returns an oauth2.TokenSource that performs the JWT Bearer grant.
+func (c *Config) TokenSource(ctx context.Context) oauth2.TokenSource {
+	return &tokenSource{
+		ctx:  ctx,
+		conf: c,
+	}
+}
+
+// tokenSource implements oauth2.TokenSource for the JWT Bearer grant.
+type tokenSource struct {
+	ctx  context.Context
+	conf *Config
+}
+
+// Token implements the oauth2.TokenSource interface.
+// It performs the JWT Bearer grant and returns an oauth2.Token.
+func (ts *tokenSource) Token() (*oauth2.Token, error) {
+	conf := ts.conf
+
+	if err := conf.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid config: %w", err)
+	}
+
+	assertion, err := conf.AssertionProvider()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get assertion: %w", err)
+	}
+
+	data := buildFormData(assertion, conf.Scopes)
+
+	req, err := oauthproto.NewFormRequest(ts.ctx, conf.TokenURL, data, conf.ClientID, conf.ClientSecret)
+	if err != nil {
+		return nil, fmt.Errorf("jwtbearer: build request: %w", err)
+	}
+
+	resp, err := oauthproto.DoTokenRequest(conf.HTTPClient, req)
+	if err != nil {
+		// Scrub RetrieveError.Body so raw upstream content cannot leak into
+		// error strings via err.Error(). pkg/oauthproto deliberately preserves
+		// Body for general-purpose callers; jwtbearer opts back into the
+		// stricter behavior because its errors propagate through vmcp / runner
+		// paths that may log them. Matches pkg/oauthproto/tokenexchange.
+		var retrieveErr *oauth2.RetrieveError
+		if errors.As(err, &retrieveErr) {
+			retrieveErr.Body = nil
+		}
+		return nil, err
+	}
+
+	// RFC 6749 Section 5.1 requires token_type in the response. The shared
+	// oauthproto.ParseTokenResponse is intentionally permissive on this field
+	// (matching x/oauth2); the JWT Bearer grant tightens it back.
+	if resp.Token.TokenType == "" {
+		return nil, fmt.Errorf("jwtbearer: server returned empty token_type (required by RFC 6749 Section 5.1)")
+	}
+
+	return resp.Token, nil
+}
+
+// buildFormData constructs the form data for a JWT Bearer grant request.
+func buildFormData(assertion string, scopes []string) url.Values {
+	data := url.Values{}
+	data.Set("grant_type", oauthproto.GrantTypeJWTBearer)
+	data.Set("assertion", assertion)
+
+	if len(scopes) > 0 {
+		data.Set("scope", strings.Join(scopes, " "))
+	}
+
+	return data
+}

--- a/pkg/oauthproto/jwtbearer/grant_test.go
+++ b/pkg/oauthproto/jwtbearer/grant_test.go
@@ -1,0 +1,341 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package jwtbearer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+
+	"github.com/stacklok/toolhive/pkg/oauthproto"
+	"github.com/stacklok/toolhive/pkg/oauthproto/oauthtest"
+)
+
+const (
+	testAssertion    = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.test-assertion-payload.signature"
+	testClientID     = "test-client-id"
+	testClientSecret = "test-client-secret" //nolint:gosec // G101: test value, not a real credential
+)
+
+// baseConfig returns a Config wired to serverURL with the standard test
+// client credentials and a static assertion provider. Subtests override only
+// the fields that vary.
+func baseConfig(serverURL string) *Config {
+	return &Config{
+		TokenURL:          serverURL,
+		ClientID:          testClientID,
+		ClientSecret:      testClientSecret,
+		AssertionProvider: func() (string, error) { return testAssertion, nil },
+	}
+}
+
+func TestConfig_Validate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		config  Config
+		wantErr string
+	}{
+		{
+			name: "valid config with all fields",
+			config: Config{
+				TokenURL:          "https://as.example.com/token",
+				ClientID:          testClientID,
+				ClientSecret:      testClientSecret,
+				AssertionProvider: func() (string, error) { return testAssertion, nil },
+			},
+		},
+		{
+			name: "valid config without client credentials",
+			config: Config{
+				TokenURL:          "https://as.example.com/token",
+				AssertionProvider: func() (string, error) { return testAssertion, nil },
+			},
+		},
+		{
+			name: "missing TokenURL",
+			config: Config{
+				AssertionProvider: func() (string, error) { return testAssertion, nil },
+			},
+			wantErr: "TokenURL is required",
+		},
+		{
+			name: "missing AssertionProvider",
+			config: Config{
+				TokenURL: "https://as.example.com/token",
+			},
+			wantErr: "AssertionProvider is required",
+		},
+		{
+			name: "http on localhost is permitted",
+			config: Config{
+				TokenURL:          "http://localhost:8080/token",
+				AssertionProvider: func() (string, error) { return testAssertion, nil },
+			},
+		},
+		{
+			name: "http on non-localhost is rejected",
+			config: Config{
+				TokenURL:          "http://as.example.com/token",
+				AssertionProvider: func() (string, error) { return testAssertion, nil },
+			},
+			wantErr: "must use HTTPS",
+		},
+		{
+			name: "non-http scheme is rejected",
+			config: Config{
+				TokenURL:          "file:///etc/passwd",
+				AssertionProvider: func() (string, error) { return testAssertion, nil },
+			},
+			wantErr: "must use HTTPS",
+		},
+		{
+			name: "fragment is rejected",
+			config: Config{
+				TokenURL:          "https://as.example.com/token#section",
+				AssertionProvider: func() (string, error) { return testAssertion, nil },
+			},
+			wantErr: "must not contain a fragment",
+		},
+		{
+			name: "missing host is rejected",
+			config: Config{
+				TokenURL:          "https:///token",
+				AssertionProvider: func() (string, error) { return testAssertion, nil },
+			},
+			wantErr: "must include a host",
+		},
+		{
+			name: "embedded credentials are rejected",
+			config: Config{
+				TokenURL:          "https://user:pass@as.example.com/token",
+				AssertionProvider: func() (string, error) { return testAssertion, nil },
+			},
+			wantErr: "must not contain embedded credentials",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tt.config.Validate()
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestConfig_String(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		config           *Config
+		expectedContains []string
+		expectedExcludes []string
+	}{
+		{
+			name: "redacts client secret",
+			config: &Config{
+				TokenURL:          "https://as.example.com/token",
+				ClientID:          testClientID,
+				ClientSecret:      testClientSecret,
+				AssertionProvider: func() (string, error) { return testAssertion, nil },
+			},
+			expectedContains: []string{"[REDACTED]"},
+			expectedExcludes: []string{testClientSecret},
+		},
+		{
+			name: "shows empty for missing secret",
+			config: &Config{
+				TokenURL:          "https://as.example.com/token",
+				ClientID:          testClientID,
+				AssertionProvider: func() (string, error) { return testAssertion, nil },
+			},
+			expectedContains: []string{"<empty>"},
+		},
+		{
+			name: "shows empty for nil assertion provider",
+			config: &Config{
+				TokenURL: "https://as.example.com/token",
+			},
+			expectedContains: []string{"Assertion: <empty>"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			s := tt.config.String()
+			for _, want := range tt.expectedContains {
+				assert.Contains(t, s, want)
+			}
+			for _, forbidden := range tt.expectedExcludes {
+				assert.NotContains(t, s, forbidden)
+			}
+		})
+	}
+}
+
+func TestTokenSource_Token_Success(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		scopes          []string
+		expectedScope   string
+		responseBuilder func() []byte
+		wantToken       string
+		wantExpiresIn   int
+	}{
+		{
+			name:          "without scopes",
+			scopes:        nil,
+			expectedScope: "",
+			responseBuilder: func() []byte {
+				return oauthtest.NewResponse().
+					WithAccessToken("target-access-token").
+					WithExpiresIn(7200).
+					Build()
+			},
+			wantToken:     "target-access-token",
+			wantExpiresIn: 7200,
+		},
+		{
+			name:          "with scopes joined by space",
+			scopes:        []string{"todos.read", "todos.write"},
+			expectedScope: "todos.read todos.write",
+			responseBuilder: func() []byte {
+				return oauthtest.NewResponse().
+					WithAccessToken("scoped-token").
+					WithExpiresIn(3600).
+					WithScope("todos.read todos.write").
+					Build()
+			},
+			wantToken:     "scoped-token",
+			wantExpiresIn: 3600,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodPost, r.Method)
+				assert.Equal(t, "application/x-www-form-urlencoded", r.Header.Get("Content-Type"))
+
+				username, password, ok := r.BasicAuth()
+				require.True(t, ok, "Basic Auth credentials should be present")
+				assert.Equal(t, testClientID, username)
+				assert.Equal(t, testClientSecret, password)
+
+				require.NoError(t, r.ParseForm())
+				assert.Equal(t, oauthproto.GrantTypeJWTBearer, r.Form.Get("grant_type"))
+				assert.Equal(t, testAssertion, r.Form.Get("assertion"))
+				assert.Equal(t, tt.expectedScope, r.Form.Get("scope"))
+
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write(tt.responseBuilder())
+			}))
+			t.Cleanup(server.Close)
+
+			config := baseConfig(server.URL)
+			config.Scopes = tt.scopes
+
+			token, err := config.TokenSource(context.Background()).Token()
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantToken, token.AccessToken)
+			assert.Equal(t, "Bearer", token.TokenType)
+			assert.WithinDuration(t, time.Now().Add(time.Duration(tt.wantExpiresIn)*time.Second), token.Expiry, 5*time.Second)
+		})
+	}
+}
+
+func TestTokenSource_Token_Errors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("assertion provider returns error", func(t *testing.T) {
+		t.Parallel()
+
+		config := baseConfig("https://as.example.com/token")
+		config.AssertionProvider = func() (string, error) {
+			return "", fmt.Errorf("assertion unavailable")
+		}
+
+		_, err := config.TokenSource(context.Background()).Token()
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to get assertion")
+		assert.Contains(t, err.Error(), "assertion unavailable")
+	})
+
+	t.Run("server returns 400 with OAuth error, body scrubbed", func(t *testing.T) {
+		t.Parallel()
+
+		rawBody := oauthtest.NewErrorResponse().
+			WithError("invalid_grant").
+			WithDescription("assertion expired").
+			WithURI("https://example.com/errors/invalid_grant").
+			Build()
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write(rawBody)
+		}))
+		t.Cleanup(server.Close)
+
+		_, err := baseConfig(server.URL).TokenSource(context.Background()).Token()
+
+		require.Error(t, err)
+
+		var re *oauth2.RetrieveError
+		require.True(t, errors.As(err, &re), "error must unwrap to *oauth2.RetrieveError, got %T: %v", err, err)
+		assert.Equal(t, "invalid_grant", re.ErrorCode)
+		assert.Equal(t, "assertion expired", re.ErrorDescription)
+		assert.Equal(t, "https://example.com/errors/invalid_grant", re.ErrorURI)
+		require.NotNil(t, re.Response)
+		assert.Equal(t, http.StatusBadRequest, re.Response.StatusCode)
+		// Body is scrubbed to keep raw upstream content out of error strings.
+		assert.Nil(t, re.Body, "RetrieveError.Body should be scrubbed")
+	})
+
+	t.Run("empty token_type in response is rejected (RFC 6749 §5.1)", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			body := oauthtest.NewResponse().
+				WithAccessToken("target-access-token").
+				WithTokenType("").
+				Build()
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(body)
+		}))
+		t.Cleanup(server.Close)
+
+		_, err := baseConfig(server.URL).TokenSource(context.Background()).Token()
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "empty token_type")
+		assert.Contains(t, err.Error(), "jwtbearer:")
+	})
+}


### PR DESCRIPTION
## Summary

- The XAA / ID-JAG flow (issue #5218) is implemented in steps. "Step B" is the OAuth 2.0 JWT Bearer grant (RFC 7523 §2.1) used to exchange a signed JWT assertion at a target authorization server for an access token. This PR adds that primitive as a small, self-contained package so the XAA strategy and any other RFC 7523 caller can reuse it.
- New package `pkg/oauthproto/jwtbearer` exposes a `Config` and `TokenSource` modeled on the sibling `pkg/oauthproto/tokenexchange` and built on the shared `pkg/oauthproto` helpers (`NewFormRequest`, `DoTokenRequest`, `ParseTokenResponse`, `Redact`).
- `TokenURL` validation reuses `pkg/networking.ValidateEndpointURL` (RFC 6749 §3.2 — TLS required, localhost exception) and adds host, fragment, and embedded-userinfo checks to reject URLs that smuggle credentials.
- HTTP errors are returned as `*oauth2.RetrieveError` with `Body` scrubbed before return, matching the stricter behavior of `pkg/oauthproto/tokenexchange` so error strings cannot leak raw upstream content into logs.
- The package targets confidential clients per XAA / ID-JAG §8.1 (HTTP Basic auth, RFC 6749 §2.3.1); public-client `client_id`-in-body is intentionally not supported.
- Also adds the `GrantTypeJWTBearer` URN constant to `pkg/oauthproto`.

Refs #5218

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)

`go test ./pkg/oauthproto/jwtbearer/` covers: TokenURL validation (scheme, host, fragment, userinfo, required fields), `String()` redaction of secrets and assertion, success path with and without scopes, and the jwtbearer-specific error paths (assertion-provider error, RetrieveError unwrap + Body scrub, empty `token_type` rejection per RFC 6749 §5.1).

## Does this introduce a user-facing change?

No. This is a library-internal primitive; no CLI surface, CRD, or runtime behavior changes yet. The first user-facing consumer (the XAA / ID-JAG strategy) will land in a follow-up PR.

## Implementation plan

<details>
<summary>Approved implementation plan</summary>

Package scope:
- Implements RFC 7523 §2.1 only (JWT-as-grant). Client authentication is independent: HTTP Basic via `oauthproto.NewFormRequest` per RFC 6749 §2.3.1. No JWT client auth (RFC 7523 §2.2), no `client_secret_post`, no body-only `client_id` — these are out of scope for the XAA consumer and YAGNI for now.
- Mirrors `pkg/oauthproto/tokenexchange`: `Config` with `Validate()` / `String()` / `TokenSource(ctx)`, internal `tokenSource` with `Token()`. `buildFormData` is private and only emits the three RFC 7523 §2.1 fields (`grant_type`, `assertion`, optional `scope`).

Security posture (informed by parallel multi-agent review):
- Reject `TokenURL` with embedded userinfo to prevent credential leakage to the AS / via logs.
- Scrub `RetrieveError.Body` before return so logged errors cannot include raw upstream content (matches `tokenexchange`).
- `Redact()` used in `String()` for `ClientSecret` and the assertion-presence marker.
- TLS enforced via `networking.ValidateEndpointURL` (localhost dev exception).

Validation tightening on top of `oauthproto.ParseTokenResponse`:
- Empty `token_type` is rejected at the jwtbearer layer (RFC 6749 §5.1) since the shared helper is intentionally permissive.

Test scope discipline:
- Tests cover only jwtbearer-specific behavior; paths that exercise `oauthproto.ParseTokenResponse` or `NewFormRequest` branches alone are out of scope and intentionally not tested here (those have their own tests).

</details>

## Special notes for reviewers

- `pkg/oauthproto/tokenexchange/exchange.go` is the closest sibling and a useful reference for parallel structure; one minor follow-up worth doing later is normalizing the error-message prefix in both packages (`jwtbearer:` / `tokenexchange:`).
- The package is currently unused — no consumers in this PR by design. The XAA strategy lands separately so this PR stays small and reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)