### PR TITLE
References printcolumn shows raw JSON instead of useful summary

### DIFF
--- a/cmd/thv-operator/api/v1alpha1/types.go
+++ b/cmd/thv-operator/api/v1alpha1/types.go
@@ -47,7 +47,7 @@ type EmbeddingServerList struct {
 //+kubebuilder:resource:shortName=extauth;mcpextauth,categories=toolhive
 //+kubebuilder:printcolumn:name="Type",type=string,JSONPath=`.spec.type`
 //+kubebuilder:printcolumn:name="Valid",type=string,JSONPath=`.status.conditions[?(@.type=='Valid')].status`
-//+kubebuilder:printcolumn:name="References",type=string,JSONPath=`.status.referencingWorkloads`
+//+kubebuilder:printcolumn:name="References",type=integer,JSONPath=`.status.referenceCount`
 //+kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // MCPExternalAuthConfig is the deprecated v1alpha1 version of the MCPExternalAuthConfig resource.
@@ -105,7 +105,7 @@ type MCPGroupList struct {
 //+kubebuilder:resource:shortName=mcpoidc,categories=toolhive
 //+kubebuilder:printcolumn:name="Source",type=string,JSONPath=`.spec.type`
 //+kubebuilder:printcolumn:name="Valid",type=string,JSONPath=`.status.conditions[?(@.type=='Valid')].status`
-//+kubebuilder:printcolumn:name="References",type=string,JSONPath=`.status.referencingWorkloads`
+//+kubebuilder:printcolumn:name="References",type=integer,JSONPath=`.status.referenceCount`
 //+kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // MCPOIDCConfig is the deprecated v1alpha1 version of the MCPOIDCConfig resource.
@@ -311,7 +311,7 @@ type MCPWebhookConfigList struct {
 //+kubebuilder:subresource:status
 //+kubebuilder:resource:shortName=tc;toolconfig,categories=toolhive
 //+kubebuilder:printcolumn:name="Valid",type=string,JSONPath=`.status.conditions[?(@.type=='Valid')].status`
-//+kubebuilder:printcolumn:name="References",type=string,JSONPath=`.status.referencingWorkloads`
+//+kubebuilder:printcolumn:name="References",type=integer,JSONPath=`.status.referenceCount`
 //+kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // MCPToolConfig is the deprecated v1alpha1 version of the MCPToolConfig resource.

--- a/cmd/thv-operator/api/v1beta1/mcpexternalauthconfig_types.go
+++ b/cmd/thv-operator/api/v1beta1/mcpexternalauthconfig_types.go
@@ -1036,6 +1036,10 @@ type MCPExternalAuthConfigStatus struct {
 	// +optional
 	ConfigHash string `json:"configHash,omitempty"`
 
+	// ReferenceCount is the number of workloads referencing this config.
+	// +optional
+	ReferenceCount int32 `json:"referenceCount,omitempty"`
+
 	// ReferencingWorkloads is a list of workload resources that reference this MCPExternalAuthConfig.
 	// Each entry identifies the workload by kind and name.
 	// +listType=map
@@ -1050,7 +1054,7 @@ type MCPExternalAuthConfigStatus struct {
 // +kubebuilder:resource:shortName=extauth;mcpextauth,categories=toolhive
 // +kubebuilder:printcolumn:name="Type",type=string,JSONPath=`.spec.type`
 // +kubebuilder:printcolumn:name="Valid",type=string,JSONPath=`.status.conditions[?(@.type=='Valid')].status`
-// +kubebuilder:printcolumn:name="References",type=string,JSONPath=`.status.referencingWorkloads`
+// +kubebuilder:printcolumn:name="References",type=integer,JSONPath=`.status.referenceCount`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // MCPExternalAuthConfig is the Schema for the mcpexternalauthconfigs API.

--- a/cmd/thv-operator/api/v1beta1/mcpoidcconfig_types.go
+++ b/cmd/thv-operator/api/v1beta1/mcpoidcconfig_types.go
@@ -185,6 +185,10 @@ type MCPOIDCConfigStatus struct {
 	// +optional
 	ConfigHash string `json:"configHash,omitempty"`
 
+	// ReferenceCount is the number of workloads referencing this config.
+	// +optional
+	ReferenceCount int32 `json:"referenceCount,omitempty"`
+
 	// ReferencingWorkloads is a list of workload resources that reference this MCPOIDCConfig.
 	// Each entry identifies the workload by kind and name.
 	// +listType=map
@@ -199,7 +203,7 @@ type MCPOIDCConfigStatus struct {
 // +kubebuilder:resource:shortName=mcpoidc,categories=toolhive
 // +kubebuilder:printcolumn:name="Source",type=string,JSONPath=`.spec.type`
 // +kubebuilder:printcolumn:name="Valid",type=string,JSONPath=`.status.conditions[?(@.type=='Valid')].status`
-// +kubebuilder:printcolumn:name="References",type=string,JSONPath=`.status.referencingWorkloads`
+// +kubebuilder:printcolumn:name="References",type=integer,JSONPath=`.status.referenceCount`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // MCPOIDCConfig is the Schema for the mcpoidcconfigs API.

--- a/cmd/thv-operator/api/v1beta1/toolconfig_types.go
+++ b/cmd/thv-operator/api/v1beta1/toolconfig_types.go
@@ -97,6 +97,10 @@ type MCPToolConfigStatus struct {
 	// +optional
 	ConfigHash string `json:"configHash,omitempty"`
 
+	// ReferenceCount is the number of workloads referencing this config.
+	// +optional
+	ReferenceCount int32 `json:"referenceCount,omitempty"`
+
 	// ReferencingWorkloads is a list of workload resources that reference this MCPToolConfig.
 	// Each entry identifies the workload by kind and name.
 	// +listType=map
@@ -110,7 +114,7 @@ type MCPToolConfigStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:shortName=tc;toolconfig,categories=toolhive
 // +kubebuilder:printcolumn:name="Valid",type=string,JSONPath=`.status.conditions[?(@.type=='Valid')].status`
-// +kubebuilder:printcolumn:name="References",type=string,JSONPath=`.status.referencingWorkloads`
+// +kubebuilder:printcolumn:name="References",type=integer,JSONPath=`.status.referenceCount`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // MCPToolConfig is the Schema for the mcptoolconfigs API.

--- a/cmd/thv-operator/controllers/mcpexternalauthconfig_controller.go
+++ b/cmd/thv-operator/controllers/mcpexternalauthconfig_controller.go
@@ -216,6 +216,7 @@ func (r *MCPExternalAuthConfigReconciler) handleConfigHashChange(
 	}
 	ctrlutil.SortWorkloadRefs(refs)
 	externalAuthConfig.Status.ReferencingWorkloads = refs
+	externalAuthConfig.Status.ReferenceCount = workloadReferenceCount(refs)
 
 	// Update the MCPExternalAuthConfig status
 	if err := r.Status().Update(ctx, externalAuthConfig); err != nil {
@@ -271,6 +272,7 @@ func (r *MCPExternalAuthConfigReconciler) handleDeletion(
 				ObservedGeneration: externalAuthConfig.Generation,
 			})
 			externalAuthConfig.Status.ReferencingWorkloads = referencingWorkloads
+			externalAuthConfig.Status.ReferenceCount = workloadReferenceCount(referencingWorkloads)
 			if updateErr := r.Status().Update(ctx, externalAuthConfig); updateErr != nil {
 				logger.Error(updateErr, "Failed to update status during deletion block")
 			}
@@ -559,8 +561,10 @@ func (r *MCPExternalAuthConfigReconciler) updateReferencingWorkloads(
 		return ctrl.Result{}, fmt.Errorf("failed to find referencing workloads: %w", err)
 	}
 
-	if !ctrlutil.WorkloadRefsEqual(externalAuthConfig.Status.ReferencingWorkloads, refs) {
+	if !ctrlutil.WorkloadRefsEqual(externalAuthConfig.Status.ReferencingWorkloads, refs) ||
+		externalAuthConfig.Status.ReferenceCount != workloadReferenceCount(refs) {
 		externalAuthConfig.Status.ReferencingWorkloads = refs
+		externalAuthConfig.Status.ReferenceCount = workloadReferenceCount(refs)
 		if err := r.Status().Update(ctx, externalAuthConfig); err != nil {
 			logger := log.FromContext(ctx)
 			logger.Error(err, "Failed to update MCPExternalAuthConfig status")

--- a/cmd/thv-operator/controllers/mcpexternalauthconfig_controller_test.go
+++ b/cmd/thv-operator/controllers/mcpexternalauthconfig_controller_test.go
@@ -756,6 +756,7 @@ func TestMCPExternalAuthConfigReconciler_ReferencingWorkloadsUpdatedWithoutHashC
 	require.NoError(t, err)
 	assert.NotEmpty(t, updatedConfig.Status.ConfigHash)
 	assert.Empty(t, updatedConfig.Status.ReferencingWorkloads, "No workloads should be referencing yet")
+	assert.EqualValues(t, 0, updatedConfig.Status.ReferenceCount)
 
 	// Now add an MCPServer that references this config (without changing the config spec)
 	mcpServer := &mcpv1beta1.MCPServer{
@@ -781,6 +782,7 @@ func TestMCPExternalAuthConfigReconciler_ReferencingWorkloadsUpdatedWithoutHashC
 	assert.Contains(t, updatedConfig.Status.ReferencingWorkloads,
 		mcpv1beta1.WorkloadReference{Kind: "MCPServer", Name: "new-server"},
 		"ReferencingWorkloads should be updated even without hash change")
+	assert.EqualValues(t, 1, updatedConfig.Status.ReferenceCount)
 }
 
 func TestMCPExternalAuthConfigReconciler_ReferencingWorkloadsRemovedOnServerDeletion(t *testing.T) {
@@ -857,6 +859,7 @@ func TestMCPExternalAuthConfigReconciler_ReferencingWorkloadsRemovedOnServerDele
 	require.NoError(t, err)
 	assert.Contains(t, updatedConfig.Status.ReferencingWorkloads,
 		mcpv1beta1.WorkloadReference{Kind: "MCPServer", Name: "server-to-delete"})
+	assert.EqualValues(t, 1, updatedConfig.Status.ReferenceCount)
 
 	// Delete the MCPServer
 	require.NoError(t, fakeClient.Delete(ctx, mcpServer))
@@ -869,6 +872,7 @@ func TestMCPExternalAuthConfigReconciler_ReferencingWorkloadsRemovedOnServerDele
 	require.NoError(t, err)
 	assert.Empty(t, updatedConfig.Status.ReferencingWorkloads,
 		"ReferencingWorkloads should be empty after server deletion")
+	assert.EqualValues(t, 0, updatedConfig.Status.ReferenceCount)
 }
 
 func TestMCPExternalAuthConfigReconciler_findReferencingWorkloads_authServerRef(t *testing.T) {

--- a/cmd/thv-operator/controllers/mcpoidcconfig_controller.go
+++ b/cmd/thv-operator/controllers/mcpoidcconfig_controller.go
@@ -129,8 +129,10 @@ func (r *MCPOIDCConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	referencingWorkloads, err := r.findReferencingWorkloads(ctx, oidcConfig)
 	if err != nil {
 		logger.Error(err, "Failed to find referencing workloads")
-	} else if !ctrlutil.WorkloadRefsEqual(oidcConfig.Status.ReferencingWorkloads, referencingWorkloads) {
+	} else if !ctrlutil.WorkloadRefsEqual(oidcConfig.Status.ReferencingWorkloads, referencingWorkloads) ||
+		oidcConfig.Status.ReferenceCount != workloadReferenceCount(referencingWorkloads) {
 		oidcConfig.Status.ReferencingWorkloads = referencingWorkloads
+		oidcConfig.Status.ReferenceCount = workloadReferenceCount(referencingWorkloads)
 		conditionChanged = true
 	}
 
@@ -181,6 +183,7 @@ func (r *MCPOIDCConfigReconciler) handleDeletion(
 				ObservedGeneration: oidcConfig.Generation,
 			})
 			oidcConfig.Status.ReferencingWorkloads = referencingWorkloads
+			oidcConfig.Status.ReferenceCount = workloadReferenceCount(referencingWorkloads)
 			if updateErr := r.Status().Update(ctx, oidcConfig); updateErr != nil {
 				logger.Error(updateErr, "Failed to update status during deletion block")
 			}

--- a/cmd/thv-operator/controllers/mcpoidcconfig_controller_test.go
+++ b/cmd/thv-operator/controllers/mcpoidcconfig_controller_test.go
@@ -567,3 +567,72 @@ func TestMCPOIDCConfig_Validate(t *testing.T) {
 		})
 	}
 }
+
+func TestMCPOIDCConfigReconciler_ReferenceCountUpdatedWithWorkloads(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	scheme := runtime.NewScheme()
+	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	oidcConfig := &mcpv1beta1.MCPOIDCConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "test-config",
+			Namespace:  "default",
+			Generation: 1,
+		},
+		Spec: mcpv1beta1.MCPOIDCConfigSpec{
+			Type: mcpv1beta1.MCPOIDCConfigTypeInline,
+			Inline: &mcpv1beta1.InlineOIDCSharedConfig{
+				Issuer:   "https://issuer.example.com",
+				ClientID: "test-client",
+			},
+		},
+	}
+	mcpServer := &mcpv1beta1.MCPServer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "server-to-track",
+			Namespace: "default",
+		},
+		Spec: mcpv1beta1.MCPServerSpec{
+			Image: "test-image",
+			OIDCConfigRef: &mcpv1beta1.MCPOIDCConfigReference{
+				Name: "test-config",
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(oidcConfig, mcpServer).
+		WithStatusSubresource(&mcpv1beta1.MCPOIDCConfig{}).
+		Build()
+	reconciler := &MCPOIDCConfigReconciler{Client: fakeClient, Scheme: scheme}
+	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: oidcConfig.Name, Namespace: oidcConfig.Namespace}}
+
+	result, err := reconciler.Reconcile(ctx, req)
+	require.NoError(t, err)
+	assert.Greater(t, result.RequeueAfter, time.Duration(0))
+
+	_, err = reconciler.Reconcile(ctx, req)
+	require.NoError(t, err)
+
+	_, err = reconciler.Reconcile(ctx, req)
+	require.NoError(t, err)
+
+	var updatedConfig mcpv1beta1.MCPOIDCConfig
+	require.NoError(t, fakeClient.Get(ctx, req.NamespacedName, &updatedConfig))
+	assert.Contains(t, updatedConfig.Status.ReferencingWorkloads,
+		mcpv1beta1.WorkloadReference{Kind: mcpv1beta1.WorkloadKindMCPServer, Name: "server-to-track"})
+	assert.EqualValues(t, 1, updatedConfig.Status.ReferenceCount)
+
+	require.NoError(t, fakeClient.Delete(ctx, mcpServer))
+
+	_, err = reconciler.Reconcile(ctx, req)
+	require.NoError(t, err)
+
+	require.NoError(t, fakeClient.Get(ctx, req.NamespacedName, &updatedConfig))
+	assert.Empty(t, updatedConfig.Status.ReferencingWorkloads)
+	assert.EqualValues(t, 0, updatedConfig.Status.ReferenceCount)
+}

--- a/cmd/thv-operator/controllers/mcpremoteproxy_controller.go
+++ b/cmd/thv-operator/controllers/mcpremoteproxy_controller.go
@@ -1024,12 +1024,19 @@ func (r *MCPRemoteProxyReconciler) updateOIDCConfigReferencingWorkloads(
 	// Check if already listed
 	for _, entry := range oidcConfig.Status.ReferencingWorkloads {
 		if entry.Kind == ref.Kind && entry.Name == ref.Name {
+			if oidcConfig.Status.ReferenceCount != workloadReferenceCount(oidcConfig.Status.ReferencingWorkloads) {
+				oidcConfig.Status.ReferenceCount = workloadReferenceCount(oidcConfig.Status.ReferencingWorkloads)
+				if err := r.Status().Update(ctx, oidcConfig); err != nil {
+					return fmt.Errorf("failed to update MCPOIDCConfig ReferenceCount: %w", err)
+				}
+			}
 			return nil
 		}
 	}
 
 	// Add the workload reference
 	oidcConfig.Status.ReferencingWorkloads = append(oidcConfig.Status.ReferencingWorkloads, ref)
+	oidcConfig.Status.ReferenceCount = workloadReferenceCount(oidcConfig.Status.ReferencingWorkloads)
 	if err := r.Status().Update(ctx, oidcConfig); err != nil {
 		return fmt.Errorf("failed to update MCPOIDCConfig ReferencingWorkloads: %w", err)
 	}

--- a/cmd/thv-operator/controllers/mcpremoteproxy_controller.go
+++ b/cmd/thv-operator/controllers/mcpremoteproxy_controller.go
@@ -1024,12 +1024,6 @@ func (r *MCPRemoteProxyReconciler) updateOIDCConfigReferencingWorkloads(
 	// Check if already listed
 	for _, entry := range oidcConfig.Status.ReferencingWorkloads {
 		if entry.Kind == ref.Kind && entry.Name == ref.Name {
-			if oidcConfig.Status.ReferenceCount != workloadReferenceCount(oidcConfig.Status.ReferencingWorkloads) {
-				oidcConfig.Status.ReferenceCount = workloadReferenceCount(oidcConfig.Status.ReferencingWorkloads)
-				if err := r.Status().Update(ctx, oidcConfig); err != nil {
-					return fmt.Errorf("failed to update MCPOIDCConfig ReferenceCount: %w", err)
-				}
-			}
 			return nil
 		}
 	}

--- a/cmd/thv-operator/controllers/mcpremoteproxy_controller_test.go
+++ b/cmd/thv-operator/controllers/mcpremoteproxy_controller_test.go
@@ -1382,3 +1382,63 @@ func TestGetExternalAuthConfigForMCPRemoteProxy(t *testing.T) {
 	assert.NotNil(t, result)
 	assert.Equal(t, "test-auth", result.Name)
 }
+
+func TestMCPRemoteProxyReconciler_updateOIDCConfigReferencingWorkloads(t *testing.T) {
+	t.Parallel()
+
+	existingRef := mcpv1beta1.WorkloadReference{
+		Kind: mcpv1beta1.WorkloadKindMCPRemoteProxy,
+		Name: "existing",
+	}
+	newRef := mcpv1beta1.WorkloadReference{
+		Kind: mcpv1beta1.WorkloadKindMCPRemoteProxy,
+		Name: "new",
+	}
+
+	tests := []struct {
+		name          string
+		proxyName     string
+		expectedRefs  []mcpv1beta1.WorkloadReference
+		expectedCount int32
+	}{
+		{
+			name:          "adds new proxy reference",
+			proxyName:     "new",
+			expectedRefs:  []mcpv1beta1.WorkloadReference{existingRef, newRef},
+			expectedCount: 2,
+		},
+		{
+			name:          "updates stale count for existing reference",
+			proxyName:     "existing",
+			expectedRefs:  []mcpv1beta1.WorkloadReference{existingRef},
+			expectedCount: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := t.Context()
+			scheme := runtime.NewScheme()
+			require.NoError(t, mcpv1beta1.AddToScheme(scheme))
+
+			oidcConfig := &mcpv1beta1.MCPOIDCConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: "cfg", Namespace: "default"},
+				Status: mcpv1beta1.MCPOIDCConfigStatus{
+					ReferencingWorkloads: []mcpv1beta1.WorkloadReference{existingRef},
+				},
+			}
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(oidcConfig).
+				WithStatusSubresource(&mcpv1beta1.MCPOIDCConfig{}).
+				Build()
+			reconciler := &MCPRemoteProxyReconciler{Client: fakeClient, Scheme: scheme}
+
+			require.NoError(t, reconciler.updateOIDCConfigReferencingWorkloads(ctx, oidcConfig, tt.proxyName))
+			assert.ElementsMatch(t, tt.expectedRefs, oidcConfig.Status.ReferencingWorkloads)
+			assert.Equal(t, tt.expectedCount, oidcConfig.Status.ReferenceCount)
+		})
+	}
+}

--- a/cmd/thv-operator/controllers/mcpremoteproxy_controller_test.go
+++ b/cmd/thv-operator/controllers/mcpremoteproxy_controller_test.go
@@ -1408,7 +1408,7 @@ func TestMCPRemoteProxyReconciler_updateOIDCConfigReferencingWorkloads(t *testin
 			expectedCount: 2,
 		},
 		{
-			name:          "updates stale count for existing reference",
+			name:          "does not duplicate existing reference",
 			proxyName:     "existing",
 			expectedRefs:  []mcpv1beta1.WorkloadReference{existingRef},
 			expectedCount: 1,
@@ -1427,6 +1427,7 @@ func TestMCPRemoteProxyReconciler_updateOIDCConfigReferencingWorkloads(t *testin
 				ObjectMeta: metav1.ObjectMeta{Name: "cfg", Namespace: "default"},
 				Status: mcpv1beta1.MCPOIDCConfigStatus{
 					ReferencingWorkloads: []mcpv1beta1.WorkloadReference{existingRef},
+					ReferenceCount:       1,
 				},
 			}
 			fakeClient := fake.NewClientBuilder().

--- a/cmd/thv-operator/controllers/mcpserver_controller.go
+++ b/cmd/thv-operator/controllers/mcpserver_controller.go
@@ -2298,12 +2298,19 @@ func (r *MCPServerReconciler) updateOIDCConfigReferencingWorkloads(
 	// Check if already listed
 	for _, entry := range oidcConfig.Status.ReferencingWorkloads {
 		if entry.Kind == ref.Kind && entry.Name == ref.Name {
+			if oidcConfig.Status.ReferenceCount != workloadReferenceCount(oidcConfig.Status.ReferencingWorkloads) {
+				oidcConfig.Status.ReferenceCount = workloadReferenceCount(oidcConfig.Status.ReferencingWorkloads)
+				if err := r.Status().Update(ctx, oidcConfig); err != nil {
+					return fmt.Errorf("failed to update MCPOIDCConfig ReferenceCount: %w", err)
+				}
+			}
 			return nil
 		}
 	}
 
 	// Add the workload reference
 	oidcConfig.Status.ReferencingWorkloads = append(oidcConfig.Status.ReferencingWorkloads, ref)
+	oidcConfig.Status.ReferenceCount = workloadReferenceCount(oidcConfig.Status.ReferencingWorkloads)
 	if err := r.Status().Update(ctx, oidcConfig); err != nil {
 		return fmt.Errorf("failed to update MCPOIDCConfig ReferencingWorkloads: %w", err)
 	}

--- a/cmd/thv-operator/controllers/mcpserver_controller.go
+++ b/cmd/thv-operator/controllers/mcpserver_controller.go
@@ -2298,12 +2298,6 @@ func (r *MCPServerReconciler) updateOIDCConfigReferencingWorkloads(
 	// Check if already listed
 	for _, entry := range oidcConfig.Status.ReferencingWorkloads {
 		if entry.Kind == ref.Kind && entry.Name == ref.Name {
-			if oidcConfig.Status.ReferenceCount != workloadReferenceCount(oidcConfig.Status.ReferencingWorkloads) {
-				oidcConfig.Status.ReferenceCount = workloadReferenceCount(oidcConfig.Status.ReferencingWorkloads)
-				if err := r.Status().Update(ctx, oidcConfig); err != nil {
-					return fmt.Errorf("failed to update MCPOIDCConfig ReferenceCount: %w", err)
-				}
-			}
 			return nil
 		}
 	}

--- a/cmd/thv-operator/controllers/mcpserver_oidcconfig_test.go
+++ b/cmd/thv-operator/controllers/mcpserver_oidcconfig_test.go
@@ -224,7 +224,10 @@ func TestMCPServerReconciler_updateOIDCConfigReferencingWorkloads(t *testing.T) 
 
 		cfg := &mcpv1beta1.MCPOIDCConfig{
 			ObjectMeta: metav1.ObjectMeta{Name: "cfg", Namespace: "default"},
-			Status:     mcpv1beta1.MCPOIDCConfigStatus{ReferencingWorkloads: []mcpv1beta1.WorkloadReference{existingRef}},
+			Status: mcpv1beta1.MCPOIDCConfigStatus{
+				ReferencingWorkloads: []mcpv1beta1.WorkloadReference{existingRef},
+				ReferenceCount:       1,
+			},
 		}
 		fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cfg).
 			WithStatusSubresource(&mcpv1beta1.MCPOIDCConfig{}).Build()
@@ -244,7 +247,10 @@ func TestMCPServerReconciler_updateOIDCConfigReferencingWorkloads(t *testing.T) 
 
 		cfg := &mcpv1beta1.MCPOIDCConfig{
 			ObjectMeta: metav1.ObjectMeta{Name: "cfg", Namespace: "default"},
-			Status:     mcpv1beta1.MCPOIDCConfigStatus{ReferencingWorkloads: []mcpv1beta1.WorkloadReference{existingRef}},
+			Status: mcpv1beta1.MCPOIDCConfigStatus{
+				ReferencingWorkloads: []mcpv1beta1.WorkloadReference{existingRef},
+				ReferenceCount:       1,
+			},
 		}
 		fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cfg).
 			WithStatusSubresource(&mcpv1beta1.MCPOIDCConfig{}).Build()

--- a/cmd/thv-operator/controllers/mcpserver_oidcconfig_test.go
+++ b/cmd/thv-operator/controllers/mcpserver_oidcconfig_test.go
@@ -233,6 +233,7 @@ func TestMCPServerReconciler_updateOIDCConfigReferencingWorkloads(t *testing.T) 
 		require.NoError(t, r.updateOIDCConfigReferencingWorkloads(ctx, cfg, "new"))
 		newRef := mcpv1beta1.WorkloadReference{Kind: "MCPServer", Name: "new"}
 		assert.ElementsMatch(t, []mcpv1beta1.WorkloadReference{existingRef, newRef}, cfg.Status.ReferencingWorkloads)
+		assert.EqualValues(t, 2, cfg.Status.ReferenceCount)
 	})
 
 	t.Run("does not duplicate existing reference", func(t *testing.T) {
@@ -251,6 +252,7 @@ func TestMCPServerReconciler_updateOIDCConfigReferencingWorkloads(t *testing.T) 
 
 		require.NoError(t, r.updateOIDCConfigReferencingWorkloads(ctx, cfg, "existing"))
 		assert.Len(t, cfg.Status.ReferencingWorkloads, 1)
+		assert.EqualValues(t, 1, cfg.Status.ReferenceCount)
 	})
 }
 

--- a/cmd/thv-operator/controllers/toolconfig_controller.go
+++ b/cmd/thv-operator/controllers/toolconfig_controller.go
@@ -101,8 +101,10 @@ func (r *ToolConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	referencingWorkloads, err := r.findReferencingWorkloads(ctx, toolConfig)
 	if err != nil {
 		logger.Error(err, "Failed to find referencing workloads")
-	} else if !ctrlutil.WorkloadRefsEqual(toolConfig.Status.ReferencingWorkloads, referencingWorkloads) {
+	} else if !ctrlutil.WorkloadRefsEqual(toolConfig.Status.ReferencingWorkloads, referencingWorkloads) ||
+		toolConfig.Status.ReferenceCount != workloadReferenceCount(referencingWorkloads) {
 		toolConfig.Status.ReferencingWorkloads = referencingWorkloads
+		toolConfig.Status.ReferenceCount = workloadReferenceCount(referencingWorkloads)
 		conditionChanged = true
 	}
 
@@ -147,6 +149,7 @@ func (r *ToolConfigReconciler) handleConfigHashChange(
 	}
 	ctrlutil.SortWorkloadRefs(refs)
 	toolConfig.Status.ReferencingWorkloads = refs
+	toolConfig.Status.ReferenceCount = workloadReferenceCount(refs)
 
 	// Update the MCPToolConfig status
 	if err := r.Status().Update(ctx, toolConfig); err != nil {
@@ -202,6 +205,7 @@ func (r *ToolConfigReconciler) handleDeletion(ctx context.Context, toolConfig *m
 				ObservedGeneration: toolConfig.Generation,
 			})
 			toolConfig.Status.ReferencingWorkloads = referencingWorkloads
+			toolConfig.Status.ReferenceCount = workloadReferenceCount(referencingWorkloads)
 			if updateErr := r.Status().Update(ctx, toolConfig); updateErr != nil {
 				logger.Error(updateErr, "Failed to update status during deletion block")
 			}

--- a/cmd/thv-operator/controllers/toolconfig_controller_test.go
+++ b/cmd/thv-operator/controllers/toolconfig_controller_test.go
@@ -362,6 +362,7 @@ func TestToolConfigReconciler_ReferencingWorkloadsUpdatedWithoutHashChange(t *te
 	require.NoError(t, err)
 	assert.NotEmpty(t, updatedConfig.Status.ConfigHash)
 	assert.Empty(t, updatedConfig.Status.ReferencingWorkloads, "No servers should be referencing yet")
+	assert.EqualValues(t, 0, updatedConfig.Status.ReferenceCount)
 
 	// Verify Valid condition is set after initial reconciliation
 	cond := k8smeta.FindStatusCondition(updatedConfig.Status.Conditions, mcpv1beta1.ConditionToolConfigValid)
@@ -392,6 +393,7 @@ func TestToolConfigReconciler_ReferencingWorkloadsUpdatedWithoutHashChange(t *te
 	assert.Contains(t, updatedConfig.Status.ReferencingWorkloads,
 		mcpv1beta1.WorkloadReference{Kind: "MCPServer", Name: "new-server"},
 		"ReferencingWorkloads should be updated even without hash change")
+	assert.EqualValues(t, 1, updatedConfig.Status.ReferenceCount)
 }
 
 func TestToolConfigReconciler_ReferencingWorkloadsRemovedOnServerDeletion(t *testing.T) {
@@ -458,6 +460,7 @@ func TestToolConfigReconciler_ReferencingWorkloadsRemovedOnServerDeletion(t *tes
 	require.NoError(t, err)
 	assert.Contains(t, updatedConfig.Status.ReferencingWorkloads,
 		mcpv1beta1.WorkloadReference{Kind: "MCPServer", Name: "server-to-delete"})
+	assert.EqualValues(t, 1, updatedConfig.Status.ReferenceCount)
 
 	// Delete the MCPServer
 	require.NoError(t, fakeClient.Delete(ctx, mcpServer))
@@ -470,6 +473,7 @@ func TestToolConfigReconciler_ReferencingWorkloadsRemovedOnServerDeletion(t *tes
 	require.NoError(t, err)
 	assert.Empty(t, updatedConfig.Status.ReferencingWorkloads,
 		"ReferencingWorkloads should be empty after server deletion")
+	assert.EqualValues(t, 0, updatedConfig.Status.ReferenceCount)
 }
 
 func TestToolConfigReconciler_ValidConditionObservedGeneration(t *testing.T) {

--- a/cmd/thv-operator/controllers/virtualmcpserver_controller.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_controller.go
@@ -3365,12 +3365,6 @@ func (r *VirtualMCPServerReconciler) updateOIDCConfigReferencingWorkloads(
 	// Check if already listed
 	for _, entry := range oidcConfig.Status.ReferencingWorkloads {
 		if entry.Kind == ref.Kind && entry.Name == ref.Name {
-			if oidcConfig.Status.ReferenceCount != workloadReferenceCount(oidcConfig.Status.ReferencingWorkloads) {
-				oidcConfig.Status.ReferenceCount = workloadReferenceCount(oidcConfig.Status.ReferencingWorkloads)
-				if err := r.Status().Update(ctx, oidcConfig); err != nil {
-					return fmt.Errorf("failed to update MCPOIDCConfig ReferenceCount: %w", err)
-				}
-			}
 			return nil
 		}
 	}

--- a/cmd/thv-operator/controllers/virtualmcpserver_controller.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_controller.go
@@ -3365,12 +3365,19 @@ func (r *VirtualMCPServerReconciler) updateOIDCConfigReferencingWorkloads(
 	// Check if already listed
 	for _, entry := range oidcConfig.Status.ReferencingWorkloads {
 		if entry.Kind == ref.Kind && entry.Name == ref.Name {
+			if oidcConfig.Status.ReferenceCount != workloadReferenceCount(oidcConfig.Status.ReferencingWorkloads) {
+				oidcConfig.Status.ReferenceCount = workloadReferenceCount(oidcConfig.Status.ReferencingWorkloads)
+				if err := r.Status().Update(ctx, oidcConfig); err != nil {
+					return fmt.Errorf("failed to update MCPOIDCConfig ReferenceCount: %w", err)
+				}
+			}
 			return nil
 		}
 	}
 
 	// Add the workload reference
 	oidcConfig.Status.ReferencingWorkloads = append(oidcConfig.Status.ReferencingWorkloads, ref)
+	oidcConfig.Status.ReferenceCount = workloadReferenceCount(oidcConfig.Status.ReferencingWorkloads)
 	if err := r.Status().Update(ctx, oidcConfig); err != nil {
 		return fmt.Errorf("failed to update MCPOIDCConfig ReferencingWorkloads: %w", err)
 	}

--- a/cmd/thv-operator/controllers/virtualmcpserver_controller_test.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_controller_test.go
@@ -4197,7 +4197,7 @@ func TestVirtualMCPServerReconciler_updateOIDCConfigReferencingWorkloads(t *test
 			expectedCount: 2,
 		},
 		{
-			name:          "updates stale count for existing reference",
+			name:          "does not duplicate existing reference",
 			vmcpName:      "existing",
 			expectedRefs:  []mcpv1beta1.WorkloadReference{existingRef},
 			expectedCount: 1,
@@ -4216,6 +4216,7 @@ func TestVirtualMCPServerReconciler_updateOIDCConfigReferencingWorkloads(t *test
 				ObjectMeta: metav1.ObjectMeta{Name: "cfg", Namespace: "default"},
 				Status: mcpv1beta1.MCPOIDCConfigStatus{
 					ReferencingWorkloads: []mcpv1beta1.WorkloadReference{existingRef},
+					ReferenceCount:       1,
 				},
 			}
 			fakeClient := fake.NewClientBuilder().

--- a/cmd/thv-operator/controllers/virtualmcpserver_controller_test.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_controller_test.go
@@ -4171,3 +4171,63 @@ func TestVirtualMCPServerReconciler_IdentitySynthesizedTransitionsOnValidationFa
 	assert.NotContains(t, cond.Message, "atlassian",
 		"stale message naming the now-removed upstream must not survive the broken edit")
 }
+
+func TestVirtualMCPServerReconciler_updateOIDCConfigReferencingWorkloads(t *testing.T) {
+	t.Parallel()
+
+	existingRef := mcpv1beta1.WorkloadReference{
+		Kind: mcpv1beta1.WorkloadKindVirtualMCPServer,
+		Name: "existing",
+	}
+	newRef := mcpv1beta1.WorkloadReference{
+		Kind: mcpv1beta1.WorkloadKindVirtualMCPServer,
+		Name: "new",
+	}
+
+	tests := []struct {
+		name          string
+		vmcpName      string
+		expectedRefs  []mcpv1beta1.WorkloadReference
+		expectedCount int32
+	}{
+		{
+			name:          "adds new virtual server reference",
+			vmcpName:      "new",
+			expectedRefs:  []mcpv1beta1.WorkloadReference{existingRef, newRef},
+			expectedCount: 2,
+		},
+		{
+			name:          "updates stale count for existing reference",
+			vmcpName:      "existing",
+			expectedRefs:  []mcpv1beta1.WorkloadReference{existingRef},
+			expectedCount: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := t.Context()
+			scheme := runtime.NewScheme()
+			require.NoError(t, mcpv1beta1.AddToScheme(scheme))
+
+			oidcConfig := &mcpv1beta1.MCPOIDCConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: "cfg", Namespace: "default"},
+				Status: mcpv1beta1.MCPOIDCConfigStatus{
+					ReferencingWorkloads: []mcpv1beta1.WorkloadReference{existingRef},
+				},
+			}
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(oidcConfig).
+				WithStatusSubresource(&mcpv1beta1.MCPOIDCConfig{}).
+				Build()
+			reconciler := &VirtualMCPServerReconciler{Client: fakeClient, Scheme: scheme}
+
+			require.NoError(t, reconciler.updateOIDCConfigReferencingWorkloads(ctx, oidcConfig, tt.vmcpName))
+			assert.ElementsMatch(t, tt.expectedRefs, oidcConfig.Status.ReferencingWorkloads)
+			assert.Equal(t, tt.expectedCount, oidcConfig.Status.ReferenceCount)
+		})
+	}
+}

--- a/cmd/thv-operator/controllers/workload_reference_count.go
+++ b/cmd/thv-operator/controllers/workload_reference_count.go
@@ -10,9 +10,13 @@ import (
 )
 
 func workloadReferenceCount(refs []mcpv1beta1.WorkloadReference) int32 {
-	if len(refs) > math.MaxInt32 {
+	return workloadReferenceCountFromLen(len(refs))
+}
+
+func workloadReferenceCountFromLen(length int) int32 {
+	if length > math.MaxInt32 {
 		return math.MaxInt32
 	}
 
-	return int32(len(refs)) //nolint:gosec // guarded above against int32 overflow
+	return int32(length) //nolint:gosec // guarded above against int32 overflow
 }

--- a/cmd/thv-operator/controllers/workload_reference_count.go
+++ b/cmd/thv-operator/controllers/workload_reference_count.go
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package controllers
+
+import (
+	"math"
+
+	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+)
+
+func workloadReferenceCount(refs []mcpv1beta1.WorkloadReference) int32 {
+	if len(refs) > math.MaxInt32 {
+		return math.MaxInt32
+	}
+
+	return int32(len(refs)) //nolint:gosec // guarded above against int32 overflow
+}

--- a/cmd/thv-operator/controllers/workload_reference_count_test.go
+++ b/cmd/thv-operator/controllers/workload_reference_count_test.go
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package controllers
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+)
+
+func TestWorkloadReferenceCount(t *testing.T) {
+	t.Parallel()
+
+	refs := []mcpv1beta1.WorkloadReference{
+		{Kind: mcpv1beta1.WorkloadKindMCPServer, Name: "server-1"},
+		{Kind: mcpv1beta1.WorkloadKindMCPRemoteProxy, Name: "proxy-1"},
+	}
+
+	assert.EqualValues(t, 2, workloadReferenceCount(refs))
+	assert.Equal(t, int32(math.MaxInt32), workloadReferenceCountFromLen(math.MaxInt32+1))
+}

--- a/cmd/thv-operator/controllers/workload_reference_count_test.go
+++ b/cmd/thv-operator/controllers/workload_reference_count_test.go
@@ -15,6 +15,9 @@ import (
 func TestWorkloadReferenceCount(t *testing.T) {
 	t.Parallel()
 
+	assert.EqualValues(t, 0, workloadReferenceCount(nil))
+	assert.EqualValues(t, 0, workloadReferenceCount([]mcpv1beta1.WorkloadReference{}))
+
 	refs := []mcpv1beta1.WorkloadReference{
 		{Kind: mcpv1beta1.WorkloadKindMCPServer, Name: "server-1"},
 		{Kind: mcpv1beta1.WorkloadKindMCPRemoteProxy, Name: "proxy-1"},

--- a/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpexternalauthconfigs.yaml
+++ b/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpexternalauthconfigs.yaml
@@ -26,9 +26,9 @@ spec:
     - jsonPath: .status.conditions[?(@.type=='Valid')].status
       name: Valid
       type: string
-    - jsonPath: .status.referencingWorkloads
+    - jsonPath: .status.referenceCount
       name: References
-      type: string
+      type: integer
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -1221,6 +1221,11 @@ spec:
                   It corresponds to the MCPExternalAuthConfig's generation, which is updated on mutation by the API Server.
                 format: int64
                 type: integer
+              referenceCount:
+                description: ReferenceCount is the number of workloads referencing
+                  this config.
+                format: int32
+                type: integer
               referencingWorkloads:
                 description: |-
                   ReferencingWorkloads is a list of workload resources that reference this MCPExternalAuthConfig.
@@ -1262,9 +1267,9 @@ spec:
     - jsonPath: .status.conditions[?(@.type=='Valid')].status
       name: Valid
       type: string
-    - jsonPath: .status.referencingWorkloads
+    - jsonPath: .status.referenceCount
       name: References
-      type: string
+      type: integer
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -2457,6 +2462,11 @@ spec:
                   ObservedGeneration is the most recent generation observed for this MCPExternalAuthConfig.
                   It corresponds to the MCPExternalAuthConfig's generation, which is updated on mutation by the API Server.
                 format: int64
+                type: integer
+              referenceCount:
+                description: ReferenceCount is the number of workloads referencing
+                  this config.
+                format: int32
                 type: integer
               referencingWorkloads:
                 description: |-

--- a/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpoidcconfigs.yaml
+++ b/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpoidcconfigs.yaml
@@ -25,9 +25,9 @@ spec:
     - jsonPath: .status.conditions[?(@.type=='Valid')].status
       name: Valid
       type: string
-    - jsonPath: .status.referencingWorkloads
+    - jsonPath: .status.referenceCount
       name: References
-      type: string
+      type: integer
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -279,6 +279,11 @@ spec:
                   for this MCPOIDCConfig.
                 format: int64
                 type: integer
+              referenceCount:
+                description: ReferenceCount is the number of workloads referencing
+                  this config.
+                format: int32
+                type: integer
               referencingWorkloads:
                 description: |-
                   ReferencingWorkloads is a list of workload resources that reference this MCPOIDCConfig.
@@ -320,9 +325,9 @@ spec:
     - jsonPath: .status.conditions[?(@.type=='Valid')].status
       name: Valid
       type: string
-    - jsonPath: .status.referencingWorkloads
+    - jsonPath: .status.referenceCount
       name: References
-      type: string
+      type: integer
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -574,6 +579,11 @@ spec:
                 description: ObservedGeneration is the most recent generation observed
                   for this MCPOIDCConfig.
                 format: int64
+                type: integer
+              referenceCount:
+                description: ReferenceCount is the number of workloads referencing
+                  this config.
+                format: int32
                 type: integer
               referencingWorkloads:
                 description: |-

--- a/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcptoolconfigs.yaml
+++ b/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcptoolconfigs.yaml
@@ -23,9 +23,9 @@ spec:
     - jsonPath: .status.conditions[?(@.type=='Valid')].status
       name: Valid
       type: string
-    - jsonPath: .status.referencingWorkloads
+    - jsonPath: .status.referenceCount
       name: References
-      type: string
+      type: integer
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -187,6 +187,11 @@ spec:
                   It corresponds to the MCPToolConfig's generation, which is updated on mutation by the API Server.
                 format: int64
                 type: integer
+              referenceCount:
+                description: ReferenceCount is the number of workloads referencing
+                  this config.
+                format: int32
+                type: integer
               referencingWorkloads:
                 description: |-
                   ReferencingWorkloads is a list of workload resources that reference this MCPToolConfig.
@@ -225,9 +230,9 @@ spec:
     - jsonPath: .status.conditions[?(@.type=='Valid')].status
       name: Valid
       type: string
-    - jsonPath: .status.referencingWorkloads
+    - jsonPath: .status.referenceCount
       name: References
-      type: string
+      type: integer
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -389,6 +394,11 @@ spec:
                   ObservedGeneration is the most recent generation observed for this MCPToolConfig.
                   It corresponds to the MCPToolConfig's generation, which is updated on mutation by the API Server.
                 format: int64
+                type: integer
+              referenceCount:
+                description: ReferenceCount is the number of workloads referencing
+                  this config.
+                format: int32
                 type: integer
               referencingWorkloads:
                 description: |-

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpexternalauthconfigs.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpexternalauthconfigs.yaml
@@ -29,9 +29,9 @@ spec:
     - jsonPath: .status.conditions[?(@.type=='Valid')].status
       name: Valid
       type: string
-    - jsonPath: .status.referencingWorkloads
+    - jsonPath: .status.referenceCount
       name: References
-      type: string
+      type: integer
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -1224,6 +1224,11 @@ spec:
                   It corresponds to the MCPExternalAuthConfig's generation, which is updated on mutation by the API Server.
                 format: int64
                 type: integer
+              referenceCount:
+                description: ReferenceCount is the number of workloads referencing
+                  this config.
+                format: int32
+                type: integer
               referencingWorkloads:
                 description: |-
                   ReferencingWorkloads is a list of workload resources that reference this MCPExternalAuthConfig.
@@ -1265,9 +1270,9 @@ spec:
     - jsonPath: .status.conditions[?(@.type=='Valid')].status
       name: Valid
       type: string
-    - jsonPath: .status.referencingWorkloads
+    - jsonPath: .status.referenceCount
       name: References
-      type: string
+      type: integer
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -2460,6 +2465,11 @@ spec:
                   ObservedGeneration is the most recent generation observed for this MCPExternalAuthConfig.
                   It corresponds to the MCPExternalAuthConfig's generation, which is updated on mutation by the API Server.
                 format: int64
+                type: integer
+              referenceCount:
+                description: ReferenceCount is the number of workloads referencing
+                  this config.
+                format: int32
                 type: integer
               referencingWorkloads:
                 description: |-

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpoidcconfigs.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpoidcconfigs.yaml
@@ -28,9 +28,9 @@ spec:
     - jsonPath: .status.conditions[?(@.type=='Valid')].status
       name: Valid
       type: string
-    - jsonPath: .status.referencingWorkloads
+    - jsonPath: .status.referenceCount
       name: References
-      type: string
+      type: integer
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -282,6 +282,11 @@ spec:
                   for this MCPOIDCConfig.
                 format: int64
                 type: integer
+              referenceCount:
+                description: ReferenceCount is the number of workloads referencing
+                  this config.
+                format: int32
+                type: integer
               referencingWorkloads:
                 description: |-
                   ReferencingWorkloads is a list of workload resources that reference this MCPOIDCConfig.
@@ -323,9 +328,9 @@ spec:
     - jsonPath: .status.conditions[?(@.type=='Valid')].status
       name: Valid
       type: string
-    - jsonPath: .status.referencingWorkloads
+    - jsonPath: .status.referenceCount
       name: References
-      type: string
+      type: integer
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -577,6 +582,11 @@ spec:
                 description: ObservedGeneration is the most recent generation observed
                   for this MCPOIDCConfig.
                 format: int64
+                type: integer
+              referenceCount:
+                description: ReferenceCount is the number of workloads referencing
+                  this config.
+                format: int32
                 type: integer
               referencingWorkloads:
                 description: |-

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcptoolconfigs.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcptoolconfigs.yaml
@@ -26,9 +26,9 @@ spec:
     - jsonPath: .status.conditions[?(@.type=='Valid')].status
       name: Valid
       type: string
-    - jsonPath: .status.referencingWorkloads
+    - jsonPath: .status.referenceCount
       name: References
-      type: string
+      type: integer
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -190,6 +190,11 @@ spec:
                   It corresponds to the MCPToolConfig's generation, which is updated on mutation by the API Server.
                 format: int64
                 type: integer
+              referenceCount:
+                description: ReferenceCount is the number of workloads referencing
+                  this config.
+                format: int32
+                type: integer
               referencingWorkloads:
                 description: |-
                   ReferencingWorkloads is a list of workload resources that reference this MCPToolConfig.
@@ -228,9 +233,9 @@ spec:
     - jsonPath: .status.conditions[?(@.type=='Valid')].status
       name: Valid
       type: string
-    - jsonPath: .status.referencingWorkloads
+    - jsonPath: .status.referenceCount
       name: References
-      type: string
+      type: integer
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -392,6 +397,11 @@ spec:
                   ObservedGeneration is the most recent generation observed for this MCPToolConfig.
                   It corresponds to the MCPToolConfig's generation, which is updated on mutation by the API Server.
                 format: int64
+                type: integer
+              referenceCount:
+                description: ReferenceCount is the number of workloads referencing
+                  this config.
+                format: int32
                 type: integer
               referencingWorkloads:
                 description: |-

--- a/docs/operator/crd-api.md
+++ b/docs/operator/crd-api.md
@@ -1683,6 +1683,7 @@ _Appears in:_
 | `conditions` _[Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#condition-v1-meta) array_ | Conditions represent the latest available observations of the MCPExternalAuthConfig's state |  | Optional: \{\} <br /> |
 | `observedGeneration` _integer_ | ObservedGeneration is the most recent generation observed for this MCPExternalAuthConfig.<br />It corresponds to the MCPExternalAuthConfig's generation, which is updated on mutation by the API Server. |  | Optional: \{\} <br /> |
 | `configHash` _string_ | ConfigHash is a hash of the current configuration for change detection |  | Optional: \{\} <br /> |
+| `referenceCount` _integer_ | ReferenceCount is the number of workloads referencing this config. |  | Optional: \{\} <br /> |
 | `referencingWorkloads` _[api.v1beta1.WorkloadReference](#apiv1beta1workloadreference) array_ | ReferencingWorkloads is a list of workload resources that reference this MCPExternalAuthConfig.<br />Each entry identifies the workload by kind and name. |  | Optional: \{\} <br /> |
 
 
@@ -1927,6 +1928,7 @@ _Appears in:_
 | `conditions` _[Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#condition-v1-meta) array_ | Conditions represent the latest available observations of the MCPOIDCConfig's state |  | Optional: \{\} <br /> |
 | `observedGeneration` _integer_ | ObservedGeneration is the most recent generation observed for this MCPOIDCConfig. |  | Optional: \{\} <br /> |
 | `configHash` _string_ | ConfigHash is a hash of the current configuration for change detection |  | Optional: \{\} <br /> |
+| `referenceCount` _integer_ | ReferenceCount is the number of workloads referencing this config. |  | Optional: \{\} <br /> |
 | `referencingWorkloads` _[api.v1beta1.WorkloadReference](#apiv1beta1workloadreference) array_ | ReferencingWorkloads is a list of workload resources that reference this MCPOIDCConfig.<br />Each entry identifies the workload by kind and name. |  | Optional: \{\} <br /> |
 
 
@@ -2610,6 +2612,7 @@ _Appears in:_
 | `conditions` _[Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#condition-v1-meta) array_ | Conditions represent the latest available observations of the MCPToolConfig's state |  | Optional: \{\} <br /> |
 | `observedGeneration` _integer_ | ObservedGeneration is the most recent generation observed for this MCPToolConfig.<br />It corresponds to the MCPToolConfig's generation, which is updated on mutation by the API Server. |  | Optional: \{\} <br /> |
 | `configHash` _string_ | ConfigHash is a hash of the current configuration for change detection |  | Optional: \{\} <br /> |
+| `referenceCount` _integer_ | ReferenceCount is the number of workloads referencing this config. |  | Optional: \{\} <br /> |
 | `referencingWorkloads` _[api.v1beta1.WorkloadReference](#apiv1beta1workloadreference) array_ | ReferencingWorkloads is a list of workload resources that reference this MCPToolConfig.<br />Each entry identifies the workload by kind and name. |  | Optional: \{\} <br /> |
 
 


### PR DESCRIPTION
## Summary

<!--
REQUIRED. You MUST explain:
1. WHY this change is needed (the problem or motivation)
2. WHAT changed (concise bullet points)

The diff shows the code — your summary must provide the context a reviewer
needs to understand the purpose without reading the diff first.
-->

- `kubectl get` output for MCPExternalAuthConfig, MCPOIDCConfig, and MCPToolConfig rendered `References` as raw JSON because the printer column pointed at
`.status.referencingWorkloads`, which is an array of workload reference objects.
- Added a `status.referenceCount` field to those resources and updated the `References` printer column to show the integer count instead.
- Updated controllers to keep `referenceCount` in sync whenever `referencingWorkloads` changes.
- Regenerated CRD manifests and Helm CRD templates.

<!--
Link related issues. Use "Closes" or "Fixes" to auto-close on merge.
Remove this line if there is no related issue.
-->

Fixes #4618 

## Type of change

<!-- REQUIRED. Check exactly one. -->

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

<!--
REQUIRED. Check every verification step you actually ran.
You MUST check at least one item. If you only did manual testing,
describe exactly what you tested below the checkbox.
-->

- [x] Unit tests (`task test`)
- [x] E2E tests (`task test-e2e`)
- [x] Linting (`task lint-fix`)
- [ ] Manual testing (describe below)

## API Compatibility

<!--
The CRD Schema Compatibility check guards the v1beta1 operator API.
If the check flags this PR as Incompatible and the break is intentional,
apply the `api-break-allowed` label and describe below:

1. Which fields, types, or CRDs are changing.
2. Why the break is unavoidable.
3. The user-facing migration path (what cluster admins need to do).

See CONTRIBUTING.md → "API Stability" for the full rubric. Coordinate
with maintainers before applying the label.

Remove this section entirely if the PR does not touch operator API surface.
-->

- [x] This PR does not break the `v1beta1` API, OR the `api-break-allowed` label is applied and the migration guidance is described above.

This adds an optional status field, referenceCount, and keeps the existing referencingWorkloads field unchanged.

## Changes

<!--
Optional — include for PRs touching more than a few files to help
reviewers navigate the diff. Remove this entire section for small PRs.
-->

| File | Change |
|------|--------|
| cmd/thv-operator/api/v1alpha1/types.go | Updated affected v1alpha1 print columns to use .status.referenceCount |
| cmd/thv-operator/api/v1beta1/*config_types.go | Added referenceCount status fields and updated print columns |
| cmd/thv-operator/controllers/* | Populated referenceCount alongside referencingWorkloads |
| cmd/thv-operator/controllers/workload_reference_count.go | Added guarded helper for converting workload reference length to int32 |
| deploy/charts/operator-crds/** | Regenerated CRD manifests and Helm templates |

## Does this introduce a user-facing change?

<!--
If yes, describe the change from the user's perspective. This helps with release notes.
If no, write "No".
Remove this section entirely if not applicable.
-->

Yes. kubectl get now shows the References column as a count instead of raw JSON for MCPExternalAuthConfig, MCPOIDCConfig, and MCPToolConfig.

## Special notes for reviewers

<!--
Optional — call out anything non-obvious: tricky logic, known limitations,
areas where you'd like extra scrutiny, or follow-up work planned.
Remove this section if not needed.
-->
The detailed workload references are still available in .status.referencingWorkloads; this only changes the default table output to use .status.referenceCount.