### PR TITLE
Add API endpoint to refresh the registry cache

### DIFF
--- a/docs/server/docs.go
+++ b/docs/server/docs.go
@@ -4867,6 +4867,71 @@ const docTemplate = `{
                 ]
             }
         },
+        "/api/v1beta/registry/{name}/refresh": {
+            "post": {
+                "description": "Force a refresh of the server-side registry cache for the default registry",
+                "parameters": [
+                    {
+                        "description": "Registry name (must be 'default')",
+                        "in": "path",
+                        "name": "name",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "additionalProperties": {
+                                        "type": "string"
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Registry refreshed"
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Not Found"
+                    },
+                    "500": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Internal Server Error"
+                    },
+                    "503": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/pkg_api_v1.registryErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Registry authentication required or upstream registry unavailable"
+                    }
+                },
+                "summary": "Refresh registry cache",
+                "tags": [
+                    "registry"
+                ]
+            }
+        },
         "/api/v1beta/registry/{name}/servers": {
             "get": {
                 "description": "Get a list of servers in a specific registry",

--- a/docs/server/swagger.json
+++ b/docs/server/swagger.json
@@ -4860,6 +4860,71 @@
                 ]
             }
         },
+        "/api/v1beta/registry/{name}/refresh": {
+            "post": {
+                "description": "Force a refresh of the server-side registry cache for the default registry",
+                "parameters": [
+                    {
+                        "description": "Registry name (must be 'default')",
+                        "in": "path",
+                        "name": "name",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "additionalProperties": {
+                                        "type": "string"
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Registry refreshed"
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Not Found"
+                    },
+                    "500": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Internal Server Error"
+                    },
+                    "503": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/pkg_api_v1.registryErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Registry authentication required or upstream registry unavailable"
+                    }
+                },
+                "summary": "Refresh registry cache",
+                "tags": [
+                    "registry"
+                ]
+            }
+        },
         "/api/v1beta/registry/{name}/servers": {
             "get": {
                 "description": "Get a list of servers in a specific registry",

--- a/docs/server/swagger.yaml
+++ b/docs/server/swagger.yaml
@@ -4017,6 +4017,47 @@ paths:
       summary: Update registry configuration
       tags:
       - registry
+  /api/v1beta/registry/{name}/refresh:
+    post:
+      description: Force a refresh of the server-side registry cache for the default
+        registry
+      parameters:
+      - description: Registry name (must be 'default')
+        in: path
+        name: name
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                additionalProperties:
+                  type: string
+                type: object
+          description: Registry refreshed
+        "404":
+          content:
+            application/json:
+              schema:
+                type: string
+          description: Not Found
+        "500":
+          content:
+            application/json:
+              schema:
+                type: string
+          description: Internal Server Error
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/pkg_api_v1.registryErrorResponse'
+          description: Registry authentication required or upstream registry unavailable
+      summary: Refresh registry cache
+      tags:
+      - registry
   /api/v1beta/registry/{name}/servers:
     get:
       description: Get a list of servers in a specific registry

--- a/pkg/api/v1/registry.go
+++ b/pkg/api/v1/registry.go
@@ -376,6 +376,7 @@ func RegistryRouter(serveMode bool) http.Handler {
 	r.Get("/{name}", routes.getRegistry)
 	r.Put("/{name}", routes.updateRegistry)
 	r.Delete("/{name}", routes.removeRegistry)
+	r.Post("/{name}/refresh", routes.refreshRegistry)
 
 	// Add nested routes for servers within a registry
 	r.Route("/{name}/servers", func(r chi.Router) {
@@ -512,6 +513,51 @@ func (rr *RegistryRoutes) getRegistry(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(response); err != nil {
+		slog.Error("failed to encode response", "error", err)
+		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
+		return
+	}
+}
+
+//	 refreshRegistry
+//
+//		@Summary		Refresh registry cache
+//		@Description	Force a refresh of the server-side registry cache for the default registry
+//		@Tags			registry
+//		@Produce		json
+//		@Param			name	path		string	true	"Registry name (must be 'default')"
+//		@Success		200	{object}	map[string]string	"Registry refreshed"
+//		@Failure		404	{string}	string				"Not Found"
+//		@Failure		500	{string}	string				"Internal Server Error"
+//		@Failure		503	{object}	registryErrorResponse	"Registry authentication required or upstream registry unavailable"
+//		@Router			/api/v1beta/registry/{name}/refresh [post]
+func (rr *RegistryRoutes) refreshRegistry(w http.ResponseWriter, r *http.Request) {
+	name := chi.URLParam(r, "name")
+
+	// Only "default" registry is supported currently
+	if name != defaultRegistryName {
+		http.Error(w, "Registry not found", http.StatusNotFound)
+		return
+	}
+
+	provider, ok := rr.getCurrentProvider(w)
+	if !ok {
+		return
+	}
+
+	if cached, ok := provider.(*regpkg.CachedAPIRegistryProvider); ok {
+		if err := cached.ForceRefresh(); err != nil {
+			if writeProviderError(w, err) {
+				return
+			}
+			slog.Error("failed to refresh registry", "error", err)
+			http.Error(w, "Failed to refresh registry", http.StatusInternalServerError)
+			return
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(map[string]string{"status": "refreshed"}); err != nil {
 		slog.Error("failed to encode response", "error", err)
 		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
 		return

--- a/pkg/api/v1/registry_test.go
+++ b/pkg/api/v1/registry_test.go
@@ -12,14 +12,18 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/go-chi/chi/v5"
+	v0 "github.com/modelcontextprotocol/registry/pkg/api/v0"
+	"github.com/modelcontextprotocol/registry/pkg/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/stacklok/toolhive/pkg/config"
 	"github.com/stacklok/toolhive/pkg/registry"
+	regauth "github.com/stacklok/toolhive/pkg/registry/auth"
 )
 
 func CreateTestConfigProvider(t *testing.T, cfg *config.Config) (config.Provider, func()) {
@@ -254,6 +258,209 @@ func TestRegistryRouter(t *testing.T) {
 	provider, _ := CreateTestConfigProvider(t, nil)
 	routes := NewRegistryRoutesWithProvider(provider)
 	assert.NotNil(t, routes)
+}
+
+//nolint:paralleltest // Uses global registry provider singleton
+func TestRefreshRegistry_RefreshesServerSideCache(t *testing.T) {
+	var (
+		mu          sync.RWMutex
+		serverNames = []string{"io.example/old-server"}
+	)
+
+	setServerNames := func(names ...string) {
+		mu.Lock()
+		defer mu.Unlock()
+		serverNames = append([]string(nil), names...)
+	}
+	getServerNames := func() []string {
+		mu.RLock()
+		defer mu.RUnlock()
+		return append([]string(nil), serverNames...)
+	}
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v0.1/servers" {
+			http.NotFound(w, r)
+			return
+		}
+
+		names := getServerNames()
+		servers := make([]v0.ServerResponse, 0, len(names))
+		for _, name := range names {
+			servers = append(servers, v0.ServerResponse{
+				Server: v0.ServerJSON{
+					Schema:      "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+					Name:        name,
+					Description: "Test registry server",
+					Version:     "1.0.0",
+					Packages: []model.Package{
+						{
+							RegistryType: model.RegistryTypeOCI,
+							Identifier:   "ghcr.io/example/" + strings.ReplaceAll(name, "/", "-") + ":1.0.0",
+							Transport: model.Transport{
+								Type: "stdio",
+							},
+						},
+					},
+				},
+			})
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(v0.ServerListResponse{
+			Servers: servers,
+			Metadata: v0.Metadata{
+				Count: len(servers),
+			},
+		}); err != nil {
+			t.Errorf("failed to encode registry response: %v", err)
+		}
+	}))
+	defer upstream.Close()
+
+	cacheFile, err := regauth.RegistryCacheFilePath(upstream.URL)
+	require.NoError(t, err)
+	require.NoError(t, os.RemoveAll(cacheFile))
+	t.Cleanup(func() {
+		_ = os.Remove(cacheFile)
+	})
+
+	cfg := &config.Config{
+		RegistryApiUrl:         upstream.URL,
+		AllowPrivateRegistryIp: true,
+	}
+	configProvider, cleanup := CreateTestConfigProvider(t, cfg)
+	defer cleanup()
+
+	registry.ResetDefaultProvider()
+	t.Cleanup(registry.ResetDefaultProvider)
+
+	routes := &RegistryRoutes{
+		configProvider: configProvider,
+		configService:  registry.NewConfiguratorWithProvider(configProvider),
+		serveMode:      true,
+	}
+
+	first := getRegistryForTest(t, routes)
+	require.Equal(t, 1, first.ServerCount)
+	require.Contains(t, first.Registry.Servers, "io.example/old-server")
+
+	setServerNames("io.example/old-server", "io.example/new-server")
+
+	staleRegistry := getRegistryForTest(t, routes)
+	require.Equal(t, 1, staleRegistry.ServerCount)
+	require.NotContains(t, staleRegistry.Registry.Servers, "io.example/new-server")
+
+	staleServers := listServersForTest(t, routes)
+	require.Len(t, staleServers.Servers, 1)
+
+	refreshReq := requestWithRegistryName(http.MethodPost, "/default/refresh", "default")
+	refreshRecorder := httptest.NewRecorder()
+	routes.refreshRegistry(refreshRecorder, refreshReq)
+	require.Equal(t, http.StatusOK, refreshRecorder.Code)
+
+	var refreshBody map[string]string
+	require.NoError(t, json.NewDecoder(refreshRecorder.Body).Decode(&refreshBody))
+	require.Equal(t, "refreshed", refreshBody["status"])
+
+	refreshedRegistry := getRegistryForTest(t, routes)
+	require.Equal(t, 2, refreshedRegistry.ServerCount)
+	require.Contains(t, refreshedRegistry.Registry.Servers, "io.example/new-server")
+
+	refreshedServers := listServersForTest(t, routes)
+	require.Len(t, refreshedServers.Servers, 2)
+}
+
+//nolint:paralleltest // Uses global registry provider singleton
+func TestRefreshRegistry_NonDefaultRegistryNotFound(t *testing.T) {
+	registry.ResetDefaultProvider()
+	t.Cleanup(registry.ResetDefaultProvider)
+
+	routes := &RegistryRoutes{}
+	req := requestWithRegistryName(http.MethodPost, "/other/refresh", "other")
+	w := httptest.NewRecorder()
+
+	routes.refreshRegistry(w, req)
+
+	require.Equal(t, http.StatusNotFound, w.Code)
+	require.Contains(t, w.Body.String(), "Registry not found")
+}
+
+//nolint:paralleltest // Uses global registry provider singleton
+func TestRefreshRegistry_UnavailableUpstream(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "upstream unavailable", http.StatusInternalServerError)
+	}))
+	defer upstream.Close()
+
+	cacheFile, err := regauth.RegistryCacheFilePath(upstream.URL)
+	require.NoError(t, err)
+	require.NoError(t, os.RemoveAll(cacheFile))
+	t.Cleanup(func() {
+		_ = os.Remove(cacheFile)
+	})
+
+	cfg := &config.Config{
+		RegistryApiUrl:         upstream.URL,
+		AllowPrivateRegistryIp: true,
+	}
+	configProvider, cleanup := CreateTestConfigProvider(t, cfg)
+	defer cleanup()
+
+	registry.ResetDefaultProvider()
+	t.Cleanup(registry.ResetDefaultProvider)
+
+	routes := &RegistryRoutes{
+		configProvider: configProvider,
+		configService:  registry.NewConfiguratorWithProvider(configProvider),
+		serveMode:      true,
+	}
+
+	req := requestWithRegistryName(http.MethodPost, "/default/refresh", "default")
+	w := httptest.NewRecorder()
+
+	routes.refreshRegistry(w, req)
+
+	require.Equal(t, http.StatusServiceUnavailable, w.Code)
+
+	var body registryErrorResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&body))
+	require.Equal(t, RegistryUnavailableCode, body.Code)
+}
+
+func requestWithRegistryName(method, target, name string) *http.Request {
+	req := httptest.NewRequest(method, target, http.NoBody)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("name", name)
+	return req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+}
+
+func getRegistryForTest(t *testing.T, routes *RegistryRoutes) getRegistryResponse {
+	t.Helper()
+
+	req := requestWithRegistryName(http.MethodGet, "/default", "default")
+	w := httptest.NewRecorder()
+	routes.getRegistry(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var response getRegistryResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&response))
+	return response
+}
+
+func listServersForTest(t *testing.T, routes *RegistryRoutes) listServersResponse {
+	t.Helper()
+
+	req := requestWithRegistryName(http.MethodGet, "/default/servers", "default")
+	w := httptest.NewRecorder()
+	routes.listServers(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var response listServersResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&response))
+	return response
 }
 
 //nolint:paralleltest // Cannot use t.Parallel() with t.Setenv() in Go 1.24+


### PR DESCRIPTION
## Summary

When ToolHive is configured with a custom registry API (`registry_api_url`), `thv serve` caches the registry data in memory for 1 hour. If the upstream registry changes during that window, API clients (like the UI) see stale data and have no way to ask for fresh data short of restarting the server.

This adds `POST /api/v1beta/registry/{name}/refresh` so the UI (or any API client) can force a refresh on demand. It does the same thing the CLI's `thv registry list --refresh` already does: type-asserts the provider to `CachedAPIRegistryProvider` and calls `ForceRefresh()`.

Closes #5266

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test plan

- [x] Unit tests added in `pkg/api/v1/registry_test.go`:
  - happy path: GET returns stale data, refresh succeeds, subsequent GET returns fresh data
  - non-default registry name → 404
  - unavailable upstream → 503 with `registry_unavailable` code
- [x] `task lint-fix` passes

## Does this introduce a user-facing change?

Yes — new API endpoint `POST /api/v1beta/registry/{name}/refresh` (currently only `default` is supported). Returns `{"status": "refreshed"}` on success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)