### PR TITLE
Drop legacy registry schema from release artifacts

### DIFF
--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -168,7 +168,6 @@ jobs:
           echo "Using toolhive-core version: $CORE_VERSION"
           gh release download "$CORE_VERSION" \
             --repo stacklok/toolhive-core \
-            --pattern "toolhive-legacy-registry.schema.json" \
             --pattern "upstream-registry.schema.json" \
             --pattern "publisher-provided.schema.json" \
             --pattern "skill.schema.json" \

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -102,7 +102,6 @@ release:
   extra_files:
     - glob: build/thv-cli-docs.tar.gz
     - glob: build/thv-crds.tar.gz
-    - glob: build/toolhive-legacy-registry.schema.json
     - glob: build/upstream-registry.schema.json
     - glob: build/publisher-provided.schema.json
     - glob: build/skill.schema.json


### PR DESCRIPTION
## Summary

The legacy ToolHive registry schema is being removed from `stacklok/toolhive-core`. Once that deletion lands, the next toolhive release would fail at the `gh release download` step trying to pull `toolhive-legacy-registry.schema.json`, and then publish a release entry for a file that no longer exists.

This PR drops both references from the release pipeline so the next release skips the missing asset cleanly.

## Changes

| File | Change |
| --- | --- |
| `.goreleaser.yaml` | Remove the `build/toolhive-legacy-registry.schema.json` glob from `release.extra_files`. |
| `.github/workflows/releaser.yml` | Remove the `--pattern "toolhive-legacy-registry.schema.json"` flag from the `gh release download` invocation that fetches schemas from `stacklok/toolhive-core`. |

No code changes are required: `pkg/registry/legacyhint` and `errLegacyFormat` are top-level-key sniffers and do not consume the schema file.

`grep -rE 'toolhive-legacy-registry' .` returns zero hits after the change.

## Coordination

- toolhive-catalog #1215 — removed the legacy build artifact and `Legacy()` embed.
- toolhive-core (parallel PR) — deletes `registry/types/data/toolhive-legacy-registry.schema.json` and stops publishing it as a release asset.

This PR can merge any time; it just makes the next toolhive release skip an asset that toolhive-core may or may not still be publishing. To minimize broken-release risk, merge before the next toolhive release fires after the toolhive-core schema deletion.

## Type of change

- [x] Other (please describe): release tooling cleanup

## Test plan

- [x] Pre-flight grep confirmed `toolhive-legacy-registry` has zero remaining references in the repo.
- [ ] Verified at the next release cut (only observable end-to-end when the release workflow runs).

## Does this introduce a user-facing change?

No.

Generated with [Claude Code](https://claude.com/claude-code)