### PR TITLE
Split api-workloads E2E suite into parallel entries

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -66,8 +66,13 @@ jobs:
             label_filter: api-registry
             artifact: e2e-test-results-api-registry
           - title: api-workloads
-            label_filter: api-workloads
+            label_filter: "api-workloads && !lifecycle"
             artifact: e2e-test-results-api-workloads
+            test_timeout: 25m
+          - title: api-workloads-lifecycle
+            label_filter: "api-workloads && lifecycle"
+            artifact: e2e-test-results-api-workloads-lifecycle
+            test_timeout: 25m
           - title: api-clients
             label_filter: api-clients
             artifact: e2e-test-results-api-clients
@@ -133,7 +138,7 @@ jobs:
         env:
           THV_BINARY: ${{ github.workspace }}/bin/thv
           TOOLHIVE_EGRESS_IMAGE: ghcr.io/stacklok/toolhive/egress-proxy:latest
-          TEST_TIMEOUT: 15m
+          TEST_TIMEOUT: ${{ matrix.test_timeout || '15m' }}
           LABEL_FILTER: ${{ matrix.label_filter }}
         run: ./test/e2e/run_tests.sh
 


### PR DESCRIPTION
## Summary

- The `api-workloads` matrix entry was hitting the shared 15m `TEST_TIMEOUT` because it runs 56 `It` blocks (17 CRUD + 39 lifecycle) sequentially. Observed runtimes ranged up to 14m40s, leaving almost no margin for runner jitter — three confirmed timeouts on `main` and recent PRs (see #5265).
- Splits the entry into two parallel matrix jobs using the `lifecycle` label that already exists on `api_workload_lifecycle_test.go`, requiring no test code changes.
- Adds a `test_timeout` field to the matrix (defaulting to `15m` for all other entries) so the two new entries can each get a 25m budget without affecting the rest of the suite.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test plan

- [x] Opened as a draft PR to trigger `E2E Tests Core` — verify 12 matrix entries appear (was 11), with both `api-workloads` and `api-workloads-lifecycle` present
- [x] Verify `api-workloads` runs ~17 specs (Workloads API describe block) and `api-workloads-lifecycle` runs ~39 specs (Workload Lifecycle API describe block)
- [x] Verify all other matrix entries still use 15m timeout

## Does this introduce a user-facing change?

No

## Special notes for reviewers

The `lifecycle` label on `api_workload_lifecycle_test.go` (line 20) is what makes the label-filter split work without any test code changes. Ginkgo's `--label-filter` supports boolean expressions (`&&`, `||`, `!`).

Fixes #5265

Generated with [Claude Code](https://claude.com/claude-code)