### PR TITLE
Fix wrapper name in api-compat workflow comments

### DIFF
--- a/.github/workflows/api-compat.yml
+++ b/.github/workflows/api-compat.yml
@@ -21,10 +21,10 @@ on:
     paths:
       - 'cmd/thv-operator/api/**'
       # files/crds is the source of truth — controller-gen emits here, and
-      # crd-helm-wrapper copies from here into templates/. Any drift in
+      # helm-crd-wrapper copies from here into templates/. Any drift in
       # templates/ is caught by operator-ci.yml's generate-crds job, so
       # watching templates/ would be redundant. values.yaml and the
-      # crd-helm-wrapper only affect Helm conditionals and annotations the
+      # helm-crd-wrapper only affect Helm conditionals and annotations the
       # checker ignores, so they can't change what we compare.
       - 'deploy/charts/operator-crds/files/crds/**'
       # Self-exercise when either workflow file (real or no-op companion)


### PR DESCRIPTION
## Summary

- Addresses review feedback on #5281: two comments in `.github/workflows/api-compat.yml` still referenced the old in-repo wrapper name (`crd-helm-wrapper`) after the Taskfile switched to the external package (`helm-crd-wrapper`).
- Comments-only change, no behavior impact.

## Type of change

- [x] Documentation

## Test plan

- [x] Manual testing (described below)

Verified the diff is two comment-line text replacements in `.github/workflows/api-compat.yml`; nothing else touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)