### PR TITLE
Pin helm-crd-wrapper to v0.0.1

### DIFF
--- a/cmd/thv-operator/Taskfile.yml
+++ b/cmd/thv-operator/Taskfile.yml
@@ -192,8 +192,7 @@ tasks:
       - $(go env GOPATH)/bin/controller-gen rbac:roleName=toolhive-operator-manager-role paths="{{.CONTROLLER_GEN_PATHS}}" output:rbac:artifacts:config={{.PROJECT_ROOT}}/deploy/charts/operator/templates/clusterrole
       - $(go env GOPATH)/bin/controller-gen crd webhook paths="{{.CONTROLLER_GEN_PATHS}}" output:crd:artifacts:config={{.PROJECT_ROOT}}/deploy/charts/operator-crds/files/crds
       # Wrap CRDs with Helm templates for conditional installation.
-      # No tagged release yet; pin to a known-good main SHA.
-      - go install github.com/stacklok/helm-crd-wrapper@a736420b58d68304fac3934cce57c67d0a989fe7
+      - go install github.com/stacklok/helm-crd-wrapper@v0.0.1
       - $(go env GOPATH)/bin/helm-crd-wrapper -source {{.PROJECT_ROOT}}/deploy/charts/operator-crds/files/crds -target {{.PROJECT_ROOT}}/deploy/charts/operator-crds/templates
 
   operator-test:


### PR DESCRIPTION
## Summary

- Follow-up to #5281: `stacklok/helm-crd-wrapper` now has its first tagged release (`v0.0.1`), so swap the pseudo-version SHA pin (`a736420b...`) for the semver tag. This brings the Taskfile in line with how `go install` pins for tagged releases elsewhere in the repo and removes the "no tagged release yet" comment.
- Verified locally that `go install github.com/stacklok/helm-crd-wrapper@v0.0.1` produces byte-identical output for all 13 wrapped CRD templates compared with the previously-pinned SHA, so this is a pure version bump with no template churn.

## Type of change

- [x] Dependency update

## Test plan

- [x] Manual testing (described below)

Manual verification:

1. `go install github.com/stacklok/helm-crd-wrapper@v0.0.1` succeeds.
2. Running the wrapper against `deploy/charts/operator-crds/files/crds/` into a temp directory produces output that `diff -r` reports as identical to the current `deploy/charts/operator-crds/templates/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)