### PR TITLE
Wire identityFromToken through authserver config and runtime

### DIFF
--- a/cmd/thv-operator/pkg/controllerutil/authserver.go
+++ b/cmd/thv-operator/pkg/controllerutil/authserver.go
@@ -834,6 +834,14 @@ func buildOAuth2UpstreamRunConfig(
 			ExpiresInPath:    m.ExpiresInPath,
 		}
 	}
+	if cfg.IdentityFromToken != nil {
+		ift := cfg.IdentityFromToken
+		runConfig.IdentityFromToken = &authserver.IdentityFromTokenRunConfig{
+			SubjectPath: ift.SubjectPath,
+			NamePath:    ift.NamePath,
+			EmailPath:   ift.EmailPath,
+		}
+	}
 	if cfg.DCRConfig != nil {
 		runConfig.DCRConfig = buildDCRUpstreamRunConfig(cfg.DCRConfig, initialAccessTokenEnvVar)
 	}

--- a/cmd/thv-operator/pkg/controllerutil/authserver_test.go
+++ b/cmd/thv-operator/pkg/controllerutil/authserver_test.go
@@ -1423,6 +1423,121 @@ func TestBuildAuthServerRunConfig(t *testing.T) {
 					"DCRConfig should remain nil when only ClientID is set")
 			},
 		},
+		{
+			name:        "OAuth2 upstream with identityFromToken all fields set",
+			resourceURL: defaultResourceURL,
+			authConfig: &mcpv1beta1.EmbeddedAuthServerConfig{
+				Issuer: "https://auth.example.com",
+				SigningKeySecretRefs: []mcpv1beta1.SecretKeyRef{
+					{Name: "signing-key", Key: "private.pem"},
+				},
+				HMACSecretRefs: []mcpv1beta1.SecretKeyRef{
+					{Name: "hmac-secret", Key: "hmac"},
+				},
+				UpstreamProviders: []mcpv1beta1.UpstreamProviderConfig{
+					{
+						Name: "snowflake",
+						Type: mcpv1beta1.UpstreamProviderTypeOAuth2,
+						OAuth2Config: &mcpv1beta1.OAuth2UpstreamConfig{
+							AuthorizationEndpoint: "https://account.snowflakecomputing.com/oauth/authorize",
+							TokenEndpoint:         "https://account.snowflakecomputing.com/oauth/token-request",
+							ClientID:              "sf-client-id",
+							IdentityFromToken: &mcpv1beta1.IdentityFromTokenConfig{
+								SubjectPath: "username",
+								NamePath:    "display_name",
+								EmailPath:   "email",
+							},
+						},
+					},
+				},
+			},
+			allowedAudiences: defaultAudiences,
+			scopesSupported:  defaultScopes,
+			checkFunc: func(t *testing.T, config *authserver.RunConfig) {
+				t.Helper()
+				require.Len(t, config.Upstreams, 1)
+				upstream := config.Upstreams[0]
+				require.NotNil(t, upstream.OAuth2Config)
+				require.NotNil(t, upstream.OAuth2Config.IdentityFromToken)
+				assert.Equal(t, "username", upstream.OAuth2Config.IdentityFromToken.SubjectPath)
+				assert.Equal(t, "display_name", upstream.OAuth2Config.IdentityFromToken.NamePath)
+				assert.Equal(t, "email", upstream.OAuth2Config.IdentityFromToken.EmailPath)
+			},
+		},
+		{
+			name:        "OAuth2 upstream with identityFromToken only subjectPath set",
+			resourceURL: defaultResourceURL,
+			authConfig: &mcpv1beta1.EmbeddedAuthServerConfig{
+				Issuer: "https://auth.example.com",
+				SigningKeySecretRefs: []mcpv1beta1.SecretKeyRef{
+					{Name: "signing-key", Key: "private.pem"},
+				},
+				HMACSecretRefs: []mcpv1beta1.SecretKeyRef{
+					{Name: "hmac-secret", Key: "hmac"},
+				},
+				UpstreamProviders: []mcpv1beta1.UpstreamProviderConfig{
+					{
+						Name: "slack",
+						Type: mcpv1beta1.UpstreamProviderTypeOAuth2,
+						OAuth2Config: &mcpv1beta1.OAuth2UpstreamConfig{
+							AuthorizationEndpoint: "https://slack.com/oauth/v2/authorize",
+							TokenEndpoint:         "https://slack.com/api/oauth.v2.access",
+							ClientID:              "slack-client-id",
+							IdentityFromToken: &mcpv1beta1.IdentityFromTokenConfig{
+								SubjectPath: "authed_user.id",
+							},
+						},
+					},
+				},
+			},
+			allowedAudiences: defaultAudiences,
+			scopesSupported:  defaultScopes,
+			checkFunc: func(t *testing.T, config *authserver.RunConfig) {
+				t.Helper()
+				require.Len(t, config.Upstreams, 1)
+				upstream := config.Upstreams[0]
+				require.NotNil(t, upstream.OAuth2Config)
+				require.NotNil(t, upstream.OAuth2Config.IdentityFromToken)
+				assert.Equal(t, "authed_user.id", upstream.OAuth2Config.IdentityFromToken.SubjectPath)
+				assert.Empty(t, upstream.OAuth2Config.IdentityFromToken.NamePath)
+				assert.Empty(t, upstream.OAuth2Config.IdentityFromToken.EmailPath)
+			},
+		},
+		{
+			name:        "OAuth2 upstream with no identityFromToken produces nil",
+			resourceURL: defaultResourceURL,
+			authConfig: &mcpv1beta1.EmbeddedAuthServerConfig{
+				Issuer: "https://auth.example.com",
+				SigningKeySecretRefs: []mcpv1beta1.SecretKeyRef{
+					{Name: "signing-key", Key: "private.pem"},
+				},
+				HMACSecretRefs: []mcpv1beta1.SecretKeyRef{
+					{Name: "hmac-secret", Key: "hmac"},
+				},
+				UpstreamProviders: []mcpv1beta1.UpstreamProviderConfig{
+					{
+						Name: "github-no-ift",
+						Type: mcpv1beta1.UpstreamProviderTypeOAuth2,
+						OAuth2Config: &mcpv1beta1.OAuth2UpstreamConfig{
+							AuthorizationEndpoint: "https://github.com/login/oauth/authorize",
+							TokenEndpoint:         "https://github.com/login/oauth/access_token",
+							UserInfo:              &mcpv1beta1.UserInfoConfig{EndpointURL: "https://api.github.com/user"},
+							ClientID:              "client-id",
+						},
+					},
+				},
+			},
+			allowedAudiences: defaultAudiences,
+			scopesSupported:  defaultScopes,
+			checkFunc: func(t *testing.T, config *authserver.RunConfig) {
+				t.Helper()
+				require.Len(t, config.Upstreams, 1)
+				upstream := config.Upstreams[0]
+				require.NotNil(t, upstream.OAuth2Config)
+				assert.Nil(t, upstream.OAuth2Config.IdentityFromToken,
+					"IdentityFromToken must be nil when not configured")
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/docs/server/docs.go
+++ b/docs/server/docs.go
@@ -375,6 +375,24 @@ const docTemplate = `{
                 },
                 "type": "object"
             },
+            "github_com_stacklok_toolhive_pkg_authserver.IdentityFromTokenRunConfig": {
+                "description": "IdentityFromToken extracts user identity (subject, name, email) directly from the\nOAuth2 token-endpoint response body using gjson dot-notation paths. When set, the\nembedded auth server skips the userinfo HTTP call entirely. Mirrors the CRD type\n(cmd/thv-operator/api/v1beta1.IdentityFromTokenConfig) — the authoritative\ntrust-model and uniqueness documentation lives there.",
+                "properties": {
+                    "email_path": {
+                        "description": "EmailPath is the dot-notation path to the email address field.",
+                        "type": "string"
+                    },
+                    "name_path": {
+                        "description": "NamePath is the dot-notation path to the display name field.",
+                        "type": "string"
+                    },
+                    "subject_path": {
+                        "description": "SubjectPath is the dot-notation path to the subject (user ID) field.\nRequired when IdentityFromToken is set.",
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
             "github_com_stacklok_toolhive_pkg_authserver.OAuth2UpstreamRunConfig": {
                 "description": "OAuth2Config contains OAuth 2.0-specific configuration.\nRequired when Type is \"oauth2\", must be nil when Type is \"oidc\".",
                 "properties": {
@@ -403,6 +421,9 @@ const docTemplate = `{
                     },
                     "dcr_config": {
                         "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_authserver.DCRUpstreamConfig"
+                    },
+                    "identity_from_token": {
+                        "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_authserver.IdentityFromTokenRunConfig"
                     },
                     "redirect_uri": {
                         "description": "RedirectURI is the callback URL where the upstream IDP will redirect after authentication.\nWhen not specified, defaults to ` + "`" + `{issuer}/oauth/callback` + "`" + `.",

--- a/docs/server/swagger.json
+++ b/docs/server/swagger.json
@@ -368,6 +368,24 @@
                 },
                 "type": "object"
             },
+            "github_com_stacklok_toolhive_pkg_authserver.IdentityFromTokenRunConfig": {
+                "description": "IdentityFromToken extracts user identity (subject, name, email) directly from the\nOAuth2 token-endpoint response body using gjson dot-notation paths. When set, the\nembedded auth server skips the userinfo HTTP call entirely. Mirrors the CRD type\n(cmd/thv-operator/api/v1beta1.IdentityFromTokenConfig) — the authoritative\ntrust-model and uniqueness documentation lives there.",
+                "properties": {
+                    "email_path": {
+                        "description": "EmailPath is the dot-notation path to the email address field.",
+                        "type": "string"
+                    },
+                    "name_path": {
+                        "description": "NamePath is the dot-notation path to the display name field.",
+                        "type": "string"
+                    },
+                    "subject_path": {
+                        "description": "SubjectPath is the dot-notation path to the subject (user ID) field.\nRequired when IdentityFromToken is set.",
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
             "github_com_stacklok_toolhive_pkg_authserver.OAuth2UpstreamRunConfig": {
                 "description": "OAuth2Config contains OAuth 2.0-specific configuration.\nRequired when Type is \"oauth2\", must be nil when Type is \"oidc\".",
                 "properties": {
@@ -396,6 +414,9 @@
                     },
                     "dcr_config": {
                         "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_authserver.DCRUpstreamConfig"
+                    },
+                    "identity_from_token": {
+                        "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_authserver.IdentityFromTokenRunConfig"
                     },
                     "redirect_uri": {
                         "description": "RedirectURI is the callback URL where the upstream IDP will redirect after authentication.\nWhen not specified, defaults to `{issuer}/oauth/callback`.",

--- a/docs/server/swagger.yaml
+++ b/docs/server/swagger.yaml
@@ -410,6 +410,26 @@ components:
             server trusts.
           type: string
       type: object
+    github_com_stacklok_toolhive_pkg_authserver.IdentityFromTokenRunConfig:
+      description: |-
+        IdentityFromToken extracts user identity (subject, name, email) directly from the
+        OAuth2 token-endpoint response body using gjson dot-notation paths. When set, the
+        embedded auth server skips the userinfo HTTP call entirely. Mirrors the CRD type
+        (cmd/thv-operator/api/v1beta1.IdentityFromTokenConfig) — the authoritative
+        trust-model and uniqueness documentation lives there.
+      properties:
+        email_path:
+          description: EmailPath is the dot-notation path to the email address field.
+          type: string
+        name_path:
+          description: NamePath is the dot-notation path to the display name field.
+          type: string
+        subject_path:
+          description: |-
+            SubjectPath is the dot-notation path to the subject (user ID) field.
+            Required when IdentityFromToken is set.
+          type: string
+      type: object
     github_com_stacklok_toolhive_pkg_authserver.OAuth2UpstreamRunConfig:
       description: |-
         OAuth2Config contains OAuth 2.0-specific configuration.
@@ -445,6 +465,8 @@ components:
           type: string
         dcr_config:
           $ref: '#/components/schemas/github_com_stacklok_toolhive_pkg_authserver.DCRUpstreamConfig'
+        identity_from_token:
+          $ref: '#/components/schemas/github_com_stacklok_toolhive_pkg_authserver.IdentityFromTokenRunConfig'
         redirect_uri:
           description: |-
             RedirectURI is the callback URL where the upstream IDP will redirect after authentication.

--- a/pkg/authserver/config.go
+++ b/pkg/authserver/config.go
@@ -280,6 +280,14 @@ type OAuth2UpstreamRunConfig struct {
 	//nolint:lll // field tags require full JSON+YAML names
 	TokenResponseMapping *TokenResponseMappingRunConfig `json:"token_response_mapping,omitempty" yaml:"token_response_mapping,omitempty"`
 
+	// IdentityFromToken extracts user identity (subject, name, email) directly from the
+	// OAuth2 token-endpoint response body using gjson dot-notation paths. When set, the
+	// embedded auth server skips the userinfo HTTP call entirely. Mirrors the CRD type
+	// (cmd/thv-operator/api/v1beta1.IdentityFromTokenConfig) — the authoritative
+	// trust-model and uniqueness documentation lives there.
+	//nolint:lll // field tags require full JSON+YAML names
+	IdentityFromToken *IdentityFromTokenRunConfig `json:"identity_from_token,omitempty" yaml:"identity_from_token,omitempty"`
+
 	// AdditionalAuthorizationParams are extra query parameters to include in
 	// authorization requests. Useful for provider-specific parameters like
 	// Google's access_type=offline.
@@ -381,6 +389,22 @@ type TokenResponseMappingRunConfig struct {
 
 	// ExpiresInPath is the dot-notation path to the expires_in value. Defaults to "expires_in".
 	ExpiresInPath string `json:"expires_in_path,omitempty" yaml:"expires_in_path,omitempty"`
+}
+
+// IdentityFromTokenRunConfig configures extracting user identity claims directly from
+// the token-endpoint response body. Mirrors the CRD type
+// (cmd/thv-operator/api/v1beta1.IdentityFromTokenConfig) — the authoritative
+// trust-model and uniqueness documentation lives there.
+type IdentityFromTokenRunConfig struct {
+	// SubjectPath is the dot-notation path to the subject (user ID) field.
+	// Required when IdentityFromToken is set.
+	SubjectPath string `json:"subject_path" yaml:"subject_path"`
+
+	// NamePath is the dot-notation path to the display name field.
+	NamePath string `json:"name_path,omitempty" yaml:"name_path,omitempty"`
+
+	// EmailPath is the dot-notation path to the email address field.
+	EmailPath string `json:"email_path,omitempty" yaml:"email_path,omitempty"`
 }
 
 // UserInfoRunConfig contains UserInfo endpoint configuration.
@@ -616,6 +640,10 @@ func (c *OAuth2UpstreamRunConfig) Validate() error {
 						"when dcr_config.registration_endpoint is set (no discovery to populate them)")
 			}
 		}
+	}
+
+	if c.IdentityFromToken != nil && c.IdentityFromToken.SubjectPath == "" {
+		return fmt.Errorf("oauth2 upstream: identity_from_token.subject_path must not be empty when identity_from_token is configured")
 	}
 
 	return nil

--- a/pkg/authserver/config_test.go
+++ b/pkg/authserver/config_test.go
@@ -347,6 +347,32 @@ func TestOAuth2UpstreamRunConfigValidate(t *testing.T) {
 				},
 			},
 		},
+
+		// IdentityFromToken subject_path requirement.
+		{
+			name: "IdentityFromToken with empty SubjectPath rejects",
+			config: OAuth2UpstreamRunConfig{
+				ClientID:          "c",
+				IdentityFromToken: &IdentityFromTokenRunConfig{},
+			},
+			wantErr: true,
+			errMsg:  "identity_from_token.subject_path must not be empty",
+		},
+		{
+			name: "IdentityFromToken with non-empty SubjectPath is valid",
+			config: OAuth2UpstreamRunConfig{
+				ClientID: "c",
+				IdentityFromToken: &IdentityFromTokenRunConfig{
+					SubjectPath: "username",
+				},
+			},
+		},
+		{
+			name: "nil IdentityFromToken is valid",
+			config: OAuth2UpstreamRunConfig{
+				ClientID: "c",
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/authserver/runner/embeddedauthserver.go
+++ b/pkg/authserver/runner/embeddedauthserver.go
@@ -62,6 +62,10 @@ func NewEmbeddedAuthServer(ctx context.Context, cfg *authserver.RunConfig) (*Emb
 		return nil, fmt.Errorf("config is required")
 	}
 
+	// Register gjson modifiers used by IdentityFromToken configs (e.g. @upstreamjwt).
+	// Without this, modifier-bearing paths silently fail to resolve.
+	upstream.RegisterModifiers()
+
 	// Fail loudly on operator-supplied misconfiguration (e.g. a baseline
 	// scope absent from scopes_supported) BEFORE touching storage or any
 	// other side-effecting work, so a bad config never reaches the network

--- a/pkg/authserver/runner/embeddedauthserver.go
+++ b/pkg/authserver/runner/embeddedauthserver.go
@@ -569,6 +569,14 @@ func buildPureOAuth2Config(rc *authserver.UpstreamRunConfig) (*upstream.OAuth2Co
 		}
 	}
 
+	if oauth2.IdentityFromToken != nil {
+		cfg.IdentityFromToken = &upstream.IdentityFromTokenConfig{
+			SubjectPath: oauth2.IdentityFromToken.SubjectPath,
+			NamePath:    oauth2.IdentityFromToken.NamePath,
+			EmailPath:   oauth2.IdentityFromToken.EmailPath,
+		}
+	}
+
 	return cfg, nil
 }
 

--- a/pkg/authserver/runner/embeddedauthserver_test.go
+++ b/pkg/authserver/runner/embeddedauthserver_test.go
@@ -623,6 +623,73 @@ func TestBuildPureOAuth2ConfigWithEnvVar(t *testing.T) {
 	})
 }
 
+func TestBuildPureOAuth2ConfigIdentityFromToken(t *testing.T) {
+	t.Parallel()
+
+	baseRC := func() *authserver.UpstreamRunConfig {
+		return &authserver.UpstreamRunConfig{
+			Type: authserver.UpstreamProviderTypeOAuth2,
+			OAuth2Config: &authserver.OAuth2UpstreamRunConfig{
+				AuthorizationEndpoint: "https://example.com/authorize",
+				TokenEndpoint:         "https://example.com/token",
+				ClientID:              "my-client-id",
+				RedirectURI:           "https://my-app.com/callback",
+			},
+		}
+	}
+
+	t.Run("nil IdentityFromToken produces nil in runtime config", func(t *testing.T) {
+		t.Parallel()
+
+		rc := baseRC()
+		// IdentityFromToken is not set
+
+		cfg, err := buildPureOAuth2Config(rc)
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+
+		assert.Nil(t, cfg.IdentityFromToken, "IdentityFromToken must be nil when not configured")
+	})
+
+	t.Run("all three paths round-trip correctly", func(t *testing.T) {
+		t.Parallel()
+
+		rc := baseRC()
+		rc.OAuth2Config.IdentityFromToken = &authserver.IdentityFromTokenRunConfig{
+			SubjectPath: "username",
+			NamePath:    "display_name",
+			EmailPath:   "email",
+		}
+
+		cfg, err := buildPureOAuth2Config(rc)
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+
+		require.NotNil(t, cfg.IdentityFromToken)
+		assert.Equal(t, "username", cfg.IdentityFromToken.SubjectPath)
+		assert.Equal(t, "display_name", cfg.IdentityFromToken.NamePath)
+		assert.Equal(t, "email", cfg.IdentityFromToken.EmailPath)
+	})
+
+	t.Run("only SubjectPath set, name and email empty", func(t *testing.T) {
+		t.Parallel()
+
+		rc := baseRC()
+		rc.OAuth2Config.IdentityFromToken = &authserver.IdentityFromTokenRunConfig{
+			SubjectPath: "authed_user.id",
+		}
+
+		cfg, err := buildPureOAuth2Config(rc)
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+
+		require.NotNil(t, cfg.IdentityFromToken)
+		assert.Equal(t, "authed_user.id", cfg.IdentityFromToken.SubjectPath)
+		assert.Empty(t, cfg.IdentityFromToken.NamePath)
+		assert.Empty(t, cfg.IdentityFromToken.EmailPath)
+	})
+}
+
 func TestNewHMACSecrets(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/authserver/upstream/identity_from_token.go
+++ b/pkg/authserver/upstream/identity_from_token.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"sync"
 
 	"github.com/tidwall/gjson"
 )
@@ -29,7 +30,7 @@ type partialIdentity struct {
 // "associated_user.id") into the raw JSON body returned by the token
 // endpoint. Path semantics, trust-model warnings, and uniqueness notes are
 // documented on the corresponding CRD type
-// (cmd/thv-operator/api/v1alpha1.IdentityFromTokenConfig).
+// (cmd/thv-operator/api/v1beta1.IdentityFromTokenConfig).
 type IdentityFromTokenConfig struct {
 	// SubjectPath is the gjson path to the unique user identifier (required).
 	SubjectPath string
@@ -43,16 +44,25 @@ type IdentityFromTokenConfig struct {
 	EmailPath string
 }
 
+// registerOnce ensures gjson modifiers are registered exactly once, even
+// when RegisterModifiers is called concurrently from multiple goroutines
+// (e.g. parallel auth-server constructors in tests or during thundering-herd
+// restarts). gjson.AddModifier writes to a global map without internal
+// synchronization, so concurrent calls race without this guard.
+var registerOnce sync.Once
+
 // RegisterModifiers registers the gjson custom modifiers used by this
 // package's path-based identity extractors. Call once during application
 // or test wire-up before invoking any extractor that consumes a
-// modifier-bearing path. Repeated calls are safe — gjson.AddModifier
-// overwrites the existing entry.
+// modifier-bearing path. Repeated calls are safe — the registration is
+// protected by a sync.Once and executes at most once per process.
 //
 // Modifiers registered:
 //   - @upstreamjwt: see upstreamJWTModifier.
 func RegisterModifiers() {
-	gjson.AddModifier("upstreamjwt", upstreamJWTModifier)
+	registerOnce.Do(func() {
+		gjson.AddModifier("upstreamjwt", upstreamJWTModifier)
+	})
 }
 
 // extractIdentityFromTokenResponse extracts user identity fields from a raw


### PR DESCRIPTION
## Summary

The `identityFromToken` field was added to the v1beta1 CRD in #5269 but the translation layers that carry it from the CRD into the running auth server were missing, so the field was silently ignored.

- Add the operator-side translation: `v1beta1.IdentityFromTokenConfig` → `authserver.IdentityFromTokenRunConfig` in `buildOAuth2UpstreamRunConfig` (mirrors `TokenResponseMapping` plumbing)
- Add the runtime-side translation: `authserver.IdentityFromTokenRunConfig` → `upstream.IdentityFromTokenConfig` in `buildPureOAuth2Config`
- Add `IdentityFromTokenRunConfig` type to `pkg/authserver/config.go` alongside `TokenResponseMappingRunConfig`
- Fix `RegisterModifiers()` — the call existed only in test `TestMain` functions, so `@upstreamjwt` modifier paths silently no-op'd in production; move the call into `NewEmbeddedAuthServer` and guard it with `sync.Once` to prevent races between concurrent constructors
- Add startup validation: reject `identity_from_token` configs where `subject_path` is empty (would produce `sub: ""` in issued tokens)
- Remove `omitempty` from `SubjectPath` struct tag to reflect its required-when-set semantics

## Type of change

- [x] New feature

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)

Unit tests cover:
- Round-trip translation on both the operator side (`TestBuildAuthServerRunConfig`) and runner side (`TestBuildPureOAuth2ConfigIdentityFromToken`) for nil, partial, and full-fields cases
- New `OAuth2UpstreamRunConfig.Validate` cases for empty `SubjectPath` rejection

## API Compatibility

- [x] This PR does not break the `v1beta1` API, OR the `api-break-allowed` label is applied and the migration guidance is described above.

## Changes

| File | Change |
|------|--------|
| `cmd/thv-operator/pkg/controllerutil/authserver.go` | CRD → RunConfig translation for `IdentityFromToken`, moved inside `buildOAuth2UpstreamRunConfig` |
| `cmd/thv-operator/pkg/controllerutil/authserver_test.go` | Three new table cases covering full, partial, and nil `IdentityFromToken` |
| `pkg/authserver/config.go` | New `IdentityFromTokenRunConfig` type; field on `OAuth2UpstreamRunConfig`; `Validate` rejects empty `SubjectPath` |
| `pkg/authserver/config_test.go` | Three new `Validate` cases for `IdentityFromToken` |
| `pkg/authserver/runner/embeddedauthserver.go` | `RegisterModifiers()` call in constructor; RunConfig → upstream translation |
| `pkg/authserver/runner/embeddedauthserver_test.go` | Three new subtests for nil/partial/full round-trip |
| `pkg/authserver/upstream/identity_from_token.go` | `sync.Once` guard on modifier registration; fix stale `v1alpha1` → `v1beta1` comment |

## Special notes for reviewers

`RegisterModifiers()` previously relied on callers (only test `TestMain` functions) to register the `@upstreamjwt` gjson modifier before use. The `sync.Once` guard ensures registration happens exactly once even under concurrent `NewEmbeddedAuthServer` calls, which is safe because gjson's modifier map has no internal synchronisation.

Generated with [Claude Code](https://claude.com/claude-code)