### PR TITLE
Wire HeaderForward into vMCP per-session HTTP client

### DIFF
--- a/pkg/vmcp/headerforward/transport.go
+++ b/pkg/vmcp/headerforward/transport.go
@@ -35,9 +35,13 @@ type headerForwardRoundTripper struct {
 }
 
 // RoundTrip injects the pre-resolved headers onto a clone of the request and
-// delegates to the wrapped transport. Headers already present on the request
-// are left untouched so inner transports (auth, identity, trace) can always
-// override user-supplied values for the same name.
+// delegates to the wrapped transport. Names already present on the inbound
+// request are skipped — this preserves any header the *caller* set on the
+// request before invoking the round-tripper chain. Inner (closer to the wire)
+// transports run AFTER this one and use Set() unconditionally, so on any
+// overlapping name those stages still win on the wire. Restricted names are
+// blocked at resolve time, so user-supplied config cannot reach this point
+// for Host, hop-by-hop, or X-Forwarded-* anyway.
 func (h *headerForwardRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	if len(h.headers) == 0 {
 		return h.base.RoundTrip(req)

--- a/pkg/vmcp/headerforward/transport.go
+++ b/pkg/vmcp/headerforward/transport.go
@@ -64,6 +64,11 @@ func (h *headerForwardRoundTripper) RoundTrip(req *http.Request) (*http.Response
 // backend's pre-resolved HeaderForwardConfig. Returns base unchanged when no
 // header injection is configured or the effective header set is empty.
 //
+// Used by both the vMCP backend client (startup capability discovery) and the
+// per-session backend connector (long-lived MCP traffic). Exported so the
+// session backend in pkg/vmcp/session/internal/backend can share the same
+// transport-chain wiring.
+//
 // Fails loudly (constructor validation, per go-style.md) when a secret identifier
 // cannot be resolved through the provider, so a misconfigured backend surfaces
 // at pod startup — not as a silent missing-header on every request.

--- a/pkg/vmcp/session/internal/backend/mcp_session.go
+++ b/pkg/vmcp/session/internal/backend/mcp_session.go
@@ -17,11 +17,13 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 
 	"github.com/stacklok/toolhive/pkg/auth"
+	"github.com/stacklok/toolhive/pkg/secrets"
 	"github.com/stacklok/toolhive/pkg/versions"
 	"github.com/stacklok/toolhive/pkg/vmcp"
 	vmcpauth "github.com/stacklok/toolhive/pkg/vmcp/auth"
 	authtypes "github.com/stacklok/toolhive/pkg/vmcp/auth/types"
 	"github.com/stacklok/toolhive/pkg/vmcp/conversion"
+	"github.com/stacklok/toolhive/pkg/vmcp/headerforward"
 )
 
 const (
@@ -196,19 +198,25 @@ func (c *mcpSession) GetPrompt(
 //
 // registry provides the authentication strategy for outgoing backend requests.
 // Pass a registry configured with the "unauthenticated" strategy to disable auth.
+//
+// A single secrets.EnvironmentProvider is constructed once per connector and
+// shared across every session it creates; its lifetime matches the connector's.
+// It is consumed by BuildHeaderForwardTripper to resolve secret-backed entries
+// in target.HeaderForward.
 func NewHTTPConnector(registry vmcpauth.OutgoingAuthRegistry) func(
 	ctx context.Context,
 	target *vmcp.BackendTarget,
 	identity *auth.Identity,
 	sessionHint string,
 ) (Session, *vmcp.CapabilityList, error) {
+	provider := secrets.NewEnvironmentProvider()
 	return func(
 		ctx context.Context,
 		target *vmcp.BackendTarget,
 		identity *auth.Identity,
 		sessionHint string,
 	) (Session, *vmcp.CapabilityList, error) {
-		c, err := createMCPClient(target, identity, registry, sessionHint)
+		c, err := createMCPClient(ctx, target, identity, registry, sessionHint, provider)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to create MCP client for backend %s: %w", target.WorkloadID, err)
 		}
@@ -238,11 +246,17 @@ func NewHTTPConnector(registry vmcpauth.OutgoingAuthRegistry) func(
 // to client.Close(), not to any caller-supplied init context.
 // sessionHint, when non-empty, is passed as the initial Mcp-Session-Id for
 // streamable-HTTP transports so the backend can resume an existing session.
+//
+// ctx is used only to resolve secret-backed entries in target.HeaderForward at
+// client-creation time; the transport itself is started with context.Background()
+// as described above. provider supplies values for those secret-backed headers.
 func createMCPClient(
+	ctx context.Context,
 	target *vmcp.BackendTarget,
 	identity *auth.Identity,
 	registry vmcpauth.OutgoingAuthRegistry,
 	sessionHint string,
+	provider secrets.Provider,
 ) (*mcpclient.Client, error) {
 	// Resolve and validate the auth strategy once at client creation time.
 	strategyName := authtypes.StrategyTypeUnauthenticated
@@ -259,7 +273,10 @@ func createMCPClient(
 
 	slog.Debug("Applied authentication strategy", "strategy", strategy.Name(), "backendID", target.WorkloadID)
 
-	// Build shared transport chain: auth → identity propagation.
+	// Build shared transport chain: auth → identity propagation → header forward.
+	// HeaderForward is the outermost stage so inner stages (auth, identity) win
+	// on any overlapping header name — matching the ordering in
+	// headerForwardRoundTripper.RoundTrip, which skips names already set.
 	// The per-transport sections below may add a size-limiting wrapper on top.
 	base := http.RoundTripper(http.DefaultTransport)
 	base = &authRoundTripper{
@@ -269,6 +286,10 @@ func createMCPClient(
 		target:       target,
 	}
 	base = &identityRoundTripper{base: base, identity: identity}
+	base, err = headerforward.BuildHeaderForwardTripper(ctx, base, target.HeaderForward, provider, target.WorkloadID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build header-forward transport for backend %s: %w", target.WorkloadID, err)
+	}
 
 	var c *mcpclient.Client
 	switch target.TransportType {

--- a/pkg/vmcp/session/internal/backend/mcp_session.go
+++ b/pkg/vmcp/session/internal/backend/mcp_session.go
@@ -273,10 +273,15 @@ func createMCPClient(
 
 	slog.Debug("Applied authentication strategy", "strategy", strategy.Name(), "backendID", target.WorkloadID)
 
-	// Build shared transport chain: auth → identity propagation → header forward.
-	// HeaderForward is the outermost stage so inner stages (auth, identity) win
-	// on any overlapping header name — matching the ordering in
-	// headerForwardRoundTripper.RoundTrip, which skips names already set.
+	// Build shared transport chain (innermost first → outermost):
+	//   http.DefaultTransport → authRoundTripper → identityRoundTripper → headerForwardRoundTripper
+	// On an outbound request, the outermost stage runs first: header-forward
+	// injects its headers onto a request that does not yet carry auth/identity
+	// headers, then inner stages run and call Set() unconditionally so any
+	// overlapping name they care about (Authorization, identity headers) wins on
+	// the wire. Restricted header names (Host, hop-by-hop, X-Forwarded-*) are
+	// rejected at resolve time by resolveHeaderForward, so user-supplied
+	// HeaderForward cannot inject them in the first place.
 	// The per-transport sections below may add a size-limiting wrapper on top.
 	base := http.RoundTripper(http.DefaultTransport)
 	base = &authRoundTripper{

--- a/pkg/vmcp/session/internal/backend/mcp_session_capabilities_test.go
+++ b/pkg/vmcp/session/internal/backend/mcp_session_capabilities_test.go
@@ -54,6 +54,11 @@ type fakeBackend struct {
 	// resources/list failure.
 	mu          sync.Mutex
 	methodCalls map[string]int
+
+	// headersByMethod records the inbound request headers keyed by JSON-RPC
+	// method name. Tests asserting transport-chain behavior (e.g. HeaderForward)
+	// use headersFor(method) to inspect the headers a backend actually saw.
+	headersByMethod map[string]http.Header
 }
 
 type jsonRPCError struct {
@@ -68,6 +73,7 @@ func newFakeBackend(t *testing.T, fb *fakeBackend) string {
 	t.Helper()
 	fb.t = t
 	fb.methodCalls = make(map[string]int)
+	fb.headersByMethod = make(map[string]http.Header)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/mcp", fb.handle)
@@ -81,6 +87,19 @@ func (f *fakeBackend) callCount(method string) int {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return f.methodCalls[method]
+}
+
+// headersFor returns a clone of the inbound HTTP headers recorded for the most
+// recent JSON-RPC request with the given method, or nil if no such request was
+// seen. Cloning under the mutex keeps the caller safe from concurrent writes.
+func (f *fakeBackend) headersFor(method string) http.Header {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	h := f.headersByMethod[method]
+	if h == nil {
+		return nil
+	}
+	return h.Clone()
 }
 
 // handle implements the JSON-RPC subset needed for backend init. The
@@ -117,6 +136,7 @@ func (f *fakeBackend) handle(w http.ResponseWriter, r *http.Request) {
 
 	f.mu.Lock()
 	f.methodCalls[msg.Method]++
+	f.headersByMethod[msg.Method] = r.Header.Clone()
 	f.mu.Unlock()
 
 	// Notifications (no id, e.g. notifications/initialized) get an empty 202.
@@ -148,6 +168,16 @@ func (f *fakeBackend) handle(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		f.writeResult(w, msg.ID, map[string]any{"prompts": f.prompts})
+	case string(mcp.MethodToolsCall):
+		// Minimal CallToolResult with a single text content. Tests that exercise
+		// the post-initialize transport chain (e.g. HeaderForward) need a method
+		// they can invoke after Initialize completes; tools/call is the cheapest.
+		f.writeResult(w, msg.ID, map[string]any{
+			"content": []map[string]any{
+				{"type": "text", "text": "ok"},
+			},
+			"isError": false,
+		})
 	default:
 		f.writeError(w, msg.ID, &jsonRPCError{code: mcp.METHOD_NOT_FOUND, message: "Method not found"})
 	}

--- a/pkg/vmcp/session/internal/backend/mcp_session_header_forward_test.go
+++ b/pkg/vmcp/session/internal/backend/mcp_session_header_forward_test.go
@@ -5,11 +5,7 @@ package backend
 
 import (
 	"context"
-	"encoding/json"
-	"io"
 	"net/http"
-	"net/http/httptest"
-	"sync"
 	"testing"
 	"time"
 
@@ -17,174 +13,235 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/stacklok/toolhive/pkg/secrets"
 	"github.com/stacklok/toolhive/pkg/vmcp"
+	vmcpauth "github.com/stacklok/toolhive/pkg/vmcp/auth"
+	authtypes "github.com/stacklok/toolhive/pkg/vmcp/auth/types"
 )
 
-// headerCapturingBackend is a minimal streamable-HTTP MCP fake that records
-// inbound request headers keyed by JSON-RPC method. The test asserts that a
-// user-configured HeaderForward header reaches the backend on POST-INITIALIZE
-// traffic — see issue #5289. The startup capability-discovery path was fixed
-// in PR #5239; per-session HTTP traffic is still missing the wrap.
-type headerCapturingBackend struct {
-	t *testing.T
-
-	mu              sync.Mutex
-	headersByMethod map[string]http.Header
-}
-
-func newHeaderCapturingBackend(t *testing.T) (*headerCapturingBackend, string) {
-	t.Helper()
-	fb := &headerCapturingBackend{
-		t:               t,
-		headersByMethod: make(map[string]http.Header),
-	}
-	mux := http.NewServeMux()
-	mux.HandleFunc("/mcp", fb.handle)
-	ts := httptest.NewServer(mux)
-	t.Cleanup(ts.Close)
-	return fb, ts.URL + "/mcp"
-}
-
-func (f *headerCapturingBackend) headersFor(method string) http.Header {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	return f.headersByMethod[method]
-}
-
-func (f *headerCapturingBackend) handle(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		// Streamable-HTTP transports may open a GET for server-pushed
-		// notifications; rejecting it cleanly is fine for this test.
-		w.WriteHeader(http.StatusMethodNotAllowed)
-		return
-	}
-
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		f.t.Errorf("headerCapturingBackend: read body: %v", err)
-		w.WriteHeader(http.StatusBadRequest)
-		return
-	}
-	defer func() { _ = r.Body.Close() }()
-
-	var msg struct {
-		JSONRPC string          `json:"jsonrpc"`
-		ID      json.RawMessage `json:"id"`
-		Method  string          `json:"method"`
-	}
-	if err := json.Unmarshal(body, &msg); err != nil {
-		f.t.Errorf("headerCapturingBackend: decode: %v body=%s", err, string(body))
-		w.WriteHeader(http.StatusBadRequest)
-		return
-	}
-
-	f.mu.Lock()
-	f.headersByMethod[msg.Method] = r.Header.Clone()
-	f.mu.Unlock()
-
-	// Notifications (no id, e.g. notifications/initialized) get an empty 202.
-	if len(msg.ID) == 0 || string(msg.ID) == "null" {
-		w.WriteHeader(http.StatusAccepted)
-		return
-	}
-
-	switch msg.Method {
-	case string(mcp.MethodInitialize):
-		w.Header().Set("Mcp-Session-Id", "header-forward-test-session")
-		f.writeResult(w, msg.ID, map[string]any{
-			"protocolVersion": mcp.LATEST_PROTOCOL_VERSION,
-			"capabilities": map[string]any{
-				"tools": map[string]any{},
-			},
-			"serverInfo": map[string]any{"name": "header-forward-fake", "version": "0.0.0"},
-		})
-	case string(mcp.MethodToolsList):
-		f.writeResult(w, msg.ID, map[string]any{
-			"tools": []mcp.Tool{{Name: "echo", Description: "echo tool"}},
-		})
-	case string(mcp.MethodToolsCall):
-		f.writeResult(w, msg.ID, map[string]any{
-			"content": []map[string]any{
-				{"type": "text", "text": "ok"},
-			},
-			"isError": false,
-		})
-	default:
-		f.writeResult(w, msg.ID, map[string]any{})
-	}
-}
-
-func (f *headerCapturingBackend) writeResult(w http.ResponseWriter, id json.RawMessage, result any) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
-	if err := json.NewEncoder(w).Encode(map[string]any{
-		"jsonrpc": "2.0",
-		"id":      json.RawMessage(id),
-		"result":  result,
-	}); err != nil {
-		f.t.Errorf("headerCapturingBackend: encode result: %v", err)
-	}
-}
-
-// TestHTTPSession_AppliesHeaderForwardToPostInitializeRequests is the red-phase
-// regression test for issue #5289. PR #5239 fixed HeaderForward for the vMCP
-// backend client (used for startup capability discovery) but did not extend the
-// fix to the session-side connector at pkg/vmcp/session/internal/backend.
-// As a result, user-configured headers (e.g. X-MCP-Toolsets for GitHub MCP)
-// never reach the backend on per-session requests like tools/call.
+// TestHTTPSession_AppliesHeaderForwardToPostInitializeRequests asserts the
+// invariants of the HeaderForward transport stage on the session-side
+// connector (pkg/vmcp/session/internal/backend). Fixes #5289.
 //
-// The test asserts that, after the connector completes Initialize, a
-// subsequent CallTool carries the configured plaintext header on the wire.
-// On main today it fails because the connector's transport chain does not
-// include a header-forward round-tripper — see createMCPClient in
-// mcp_session.go (the chain is http.DefaultTransport → authRoundTripper →
-// identityRoundTripper, with no HeaderForward stage).
+// The three subtests cover, in order:
+//   - plaintext: a user-configured AddPlaintextHeaders entry reaches the
+//     backend on post-initialize traffic (tools/call).
+//   - overlap precedence: when an inner auth stage writes the same header
+//     name that HeaderForward configures, the inner stage's value lands on
+//     the wire — proving the chain ordering documented on
+//     headerForwardRoundTripper.RoundTrip.
+//   - restricted-name rejection: NewHTTPConnector fails fast when
+//     HeaderForward names a restricted header, proving the
+//     resolveHeaderForward guard is wired into the session-side connector.
+//
+// Secret resolution requires t.Setenv and lives in its own non-parallel test
+// below (TestHTTPSession_HeaderForward_ResolvesSecretsFromEnv).
 func TestHTTPSession_AppliesHeaderForwardToPostInitializeRequests(t *testing.T) {
 	t.Parallel()
 
-	const (
-		headerName  = "X-MCP-Toolsets"
-		headerValue = "projects,issues,pull_requests,users,repos"
-	)
+	t.Run("plaintext header reaches backend on tools/call", func(t *testing.T) {
+		t.Parallel()
 
-	fb, url := newHeaderCapturingBackend(t)
+		const (
+			headerName  = "X-MCP-Toolsets"
+			headerValue = "projects,issues,pull_requests,users,repos"
+		)
+
+		fb := &fakeBackend{advertiseTools: true, tools: []mcp.Tool{{Name: "echo"}}}
+		url := newFakeBackend(t, fb)
+
+		target := &vmcp.BackendTarget{
+			WorkloadID:    "header-forward-backend",
+			WorkloadName:  "header-forward-backend",
+			BaseURL:       url,
+			TransportType: "streamable-http",
+			HeaderForward: &vmcp.HeaderForwardConfig{
+				AddPlaintextHeaders: map[string]string{
+					headerName: headerValue,
+				},
+			},
+		}
+
+		sess := connectAndCallEcho(t, target)
+		t.Cleanup(func() { _ = sess.Close() })
+
+		got := fb.headersFor(string(mcp.MethodToolsCall))
+		require.NotNil(t, got, "backend never received a tools/call request")
+		assert.Equal(t, headerValue, got.Get(headerName),
+			"HeaderForward.AddPlaintextHeaders must reach the backend on post-initialize requests")
+	})
+
+	t.Run("inner auth stage wins on overlapping header name", func(t *testing.T) {
+		t.Parallel()
+
+		// The chain runs outer→inner on the outbound request:
+		//   headerForwardRoundTripper → identityRoundTripper → authRoundTripper → http.DefaultTransport
+		// headerForwardRoundTripper sets X-Test-Identity first (request didn't
+		// have it). The inner authRoundTripper's Authenticate() then runs and
+		// calls Set() unconditionally, overwriting. We assert the auth value
+		// is the one on the wire.
+		const (
+			headerName        = "X-Test-Identity"
+			headerForwardVal  = "from-header-forward"
+			authStrategyValue = "from-auth"
+		)
+
+		fb := &fakeBackend{advertiseTools: true, tools: []mcp.Tool{{Name: "echo"}}}
+		url := newFakeBackend(t, fb)
+
+		registry := vmcpauth.NewDefaultOutgoingAuthRegistry()
+		require.NoError(t, registry.RegisterStrategy(
+			"test-header-setter",
+			&testHeaderSettingStrategy{name: "test-header-setter", header: headerName, value: authStrategyValue},
+		))
+
+		target := &vmcp.BackendTarget{
+			WorkloadID:    "overlap-backend",
+			WorkloadName:  "overlap-backend",
+			BaseURL:       url,
+			TransportType: "streamable-http",
+			AuthConfig:    &authtypes.BackendAuthStrategy{Type: "test-header-setter"},
+			HeaderForward: &vmcp.HeaderForwardConfig{
+				AddPlaintextHeaders: map[string]string{
+					headerName: headerForwardVal,
+				},
+			},
+		}
+
+		connector := NewHTTPConnector(registry)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		sess, _, err := connector(ctx, target, nil, "")
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = sess.Close() })
+
+		_, err = sess.CallTool(ctx, "echo", map[string]any{}, nil)
+		require.NoError(t, err)
+
+		got := fb.headersFor(string(mcp.MethodToolsCall))
+		require.NotNil(t, got, "backend never received a tools/call request")
+		assert.Equal(t, authStrategyValue, got.Get(headerName),
+			"inner auth stage must overwrite HeaderForward on overlapping header names")
+	})
+
+	t.Run("restricted header in HeaderForward fails connector at startup", func(t *testing.T) {
+		t.Parallel()
+
+		// resolveHeaderForward rejects names in middleware.RestrictedHeaders.
+		// Asserts the guard is reachable from the session-side connector — a
+		// misconfigured backend surfaces at session creation, not silently as
+		// a missing header on every request.
+		fb := &fakeBackend{advertiseTools: true, tools: []mcp.Tool{{Name: "echo"}}}
+		url := newFakeBackend(t, fb)
+
+		target := &vmcp.BackendTarget{
+			WorkloadID:    "restricted-header-backend",
+			WorkloadName:  "restricted-header-backend",
+			BaseURL:       url,
+			TransportType: "streamable-http",
+			HeaderForward: &vmcp.HeaderForwardConfig{
+				AddPlaintextHeaders: map[string]string{
+					// X-Forwarded-For is in middleware.RestrictedHeaders — letting
+					// user config inject it would enable identity-spoofing of the
+					// caller's IP to the backend.
+					"X-Forwarded-For": "1.2.3.4",
+				},
+			},
+		}
+
+		registry := newTestRegistry(t)
+		connector := NewHTTPConnector(registry)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		_, _, err := connector(ctx, target, nil, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "restricted",
+			"connector must reject restricted header names in HeaderForward config")
+	})
+}
+
+// TestHTTPSession_HeaderForward_ResolvesSecretsFromEnv asserts that an
+// AddHeadersFromSecret entry is resolved via the EnvironmentProvider that
+// NewHTTPConnector constructs internally and reaches the backend on
+// post-initialize traffic.
+//
+// Lives in its own non-parallel top-level test because t.Setenv (the only
+// way to inject a value into the connector's env-backed secrets.Provider
+// without changing production APIs) cannot be used inside a parallel test
+// tree.
+func TestHTTPSession_HeaderForward_ResolvesSecretsFromEnv(t *testing.T) {
+	const (
+		headerName    = "X-GitHub-Auth"
+		secretID      = "GITHUB_PAT"
+		secretEnvName = secrets.EnvVarPrefix + secretID
+		secretValue   = "ghp_test_value_12345"
+	)
+	t.Setenv(secretEnvName, secretValue)
+
+	fb := &fakeBackend{advertiseTools: true, tools: []mcp.Tool{{Name: "echo"}}}
+	url := newFakeBackend(t, fb)
 
 	target := &vmcp.BackendTarget{
-		WorkloadID:    "header-forward-backend",
-		WorkloadName:  "header-forward-backend",
+		WorkloadID:    "secret-header-backend",
+		WorkloadName:  "secret-header-backend",
 		BaseURL:       url,
 		TransportType: "streamable-http",
 		HeaderForward: &vmcp.HeaderForwardConfig{
-			AddPlaintextHeaders: map[string]string{
-				headerName: headerValue,
+			AddHeadersFromSecret: map[string]string{
+				headerName: secretID,
 			},
 		},
 	}
+
+	sess := connectAndCallEcho(t, target)
+	t.Cleanup(func() { _ = sess.Close() })
+
+	got := fb.headersFor(string(mcp.MethodToolsCall))
+	require.NotNil(t, got, "backend never received a tools/call request")
+	assert.Equal(t, secretValue, got.Get(headerName),
+		"HeaderForward.AddHeadersFromSecret must be resolved via the env provider and reach the backend")
+}
+
+// connectAndCallEcho builds an HTTP session for target via the default test
+// registry, makes a single tools/call("echo"), and returns the open session.
+// The caller is responsible for closing the session (typically via t.Cleanup).
+func connectAndCallEcho(t *testing.T, target *vmcp.BackendTarget) Session {
+	t.Helper()
 
 	registry := newTestRegistry(t)
 	connector := NewHTTPConnector(registry)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
+	t.Cleanup(cancel)
 
 	sess, caps, err := connector(ctx, target, nil, "")
 	require.NoError(t, err, "connector must initialise the backend successfully")
 	require.NotNil(t, sess, "connector returned nil session")
 	require.NotNil(t, caps, "connector returned nil capability list")
-	t.Cleanup(func() { _ = sess.Close() })
 
-	// Make a single MCP call AFTER initialize completes. tools/call exercises
-	// the same transport chain as initialize but is unambiguously a
-	// post-handshake request — which is exactly where the regression lives.
 	_, err = sess.CallTool(ctx, "echo", map[string]any{}, nil)
 	require.NoError(t, err, "post-initialize CallTool must succeed")
 
-	// The recorded inbound headers for the tools/call request must include the
-	// user-configured forward header. This is the single assertion target:
-	// the test fails for exactly one reason — header missing on the recorded
-	// post-initialize request.
-	gotHeaders := fb.headersFor(string(mcp.MethodToolsCall))
-	require.NotNil(t, gotHeaders, "backend never received a tools/call request")
-	assert.Equal(t, headerValue, gotHeaders.Get(headerName),
-		"HeaderForward.AddPlaintextHeaders must reach the backend on post-initialize requests")
+	return sess
 }
+
+// testHeaderSettingStrategy is a vmcpauth.Strategy stand-in that unconditionally
+// writes a single header onto every outbound request. Used to drive the
+// overlap-precedence assertion: when HeaderForward configures the same name,
+// this strategy (called from the inner authRoundTripper) must win on the wire.
+type testHeaderSettingStrategy struct {
+	name   string
+	header string
+	value  string
+}
+
+func (s *testHeaderSettingStrategy) Name() string { return s.name }
+
+func (s *testHeaderSettingStrategy) Authenticate(_ context.Context, req *http.Request, _ *authtypes.BackendAuthStrategy) error {
+	req.Header.Set(s.header, s.value)
+	return nil
+}
+
+func (*testHeaderSettingStrategy) Validate(_ *authtypes.BackendAuthStrategy) error { return nil }

--- a/pkg/vmcp/session/internal/backend/mcp_session_header_forward_test.go
+++ b/pkg/vmcp/session/internal/backend/mcp_session_header_forward_test.go
@@ -1,0 +1,190 @@
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package backend
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stacklok/toolhive/pkg/vmcp"
+)
+
+// headerCapturingBackend is a minimal streamable-HTTP MCP fake that records
+// inbound request headers keyed by JSON-RPC method. The test asserts that a
+// user-configured HeaderForward header reaches the backend on POST-INITIALIZE
+// traffic — see issue #5289. The startup capability-discovery path was fixed
+// in PR #5239; per-session HTTP traffic is still missing the wrap.
+type headerCapturingBackend struct {
+	t *testing.T
+
+	mu              sync.Mutex
+	headersByMethod map[string]http.Header
+}
+
+func newHeaderCapturingBackend(t *testing.T) (*headerCapturingBackend, string) {
+	t.Helper()
+	fb := &headerCapturingBackend{
+		t:               t,
+		headersByMethod: make(map[string]http.Header),
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/mcp", fb.handle)
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+	return fb, ts.URL + "/mcp"
+}
+
+func (f *headerCapturingBackend) headersFor(method string) http.Header {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.headersByMethod[method]
+}
+
+func (f *headerCapturingBackend) handle(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		// Streamable-HTTP transports may open a GET for server-pushed
+		// notifications; rejecting it cleanly is fine for this test.
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		f.t.Errorf("headerCapturingBackend: read body: %v", err)
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	defer func() { _ = r.Body.Close() }()
+
+	var msg struct {
+		JSONRPC string          `json:"jsonrpc"`
+		ID      json.RawMessage `json:"id"`
+		Method  string          `json:"method"`
+	}
+	if err := json.Unmarshal(body, &msg); err != nil {
+		f.t.Errorf("headerCapturingBackend: decode: %v body=%s", err, string(body))
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	f.mu.Lock()
+	f.headersByMethod[msg.Method] = r.Header.Clone()
+	f.mu.Unlock()
+
+	// Notifications (no id, e.g. notifications/initialized) get an empty 202.
+	if len(msg.ID) == 0 || string(msg.ID) == "null" {
+		w.WriteHeader(http.StatusAccepted)
+		return
+	}
+
+	switch msg.Method {
+	case string(mcp.MethodInitialize):
+		w.Header().Set("Mcp-Session-Id", "header-forward-test-session")
+		f.writeResult(w, msg.ID, map[string]any{
+			"protocolVersion": mcp.LATEST_PROTOCOL_VERSION,
+			"capabilities": map[string]any{
+				"tools": map[string]any{},
+			},
+			"serverInfo": map[string]any{"name": "header-forward-fake", "version": "0.0.0"},
+		})
+	case string(mcp.MethodToolsList):
+		f.writeResult(w, msg.ID, map[string]any{
+			"tools": []mcp.Tool{{Name: "echo", Description: "echo tool"}},
+		})
+	case string(mcp.MethodToolsCall):
+		f.writeResult(w, msg.ID, map[string]any{
+			"content": []map[string]any{
+				{"type": "text", "text": "ok"},
+			},
+			"isError": false,
+		})
+	default:
+		f.writeResult(w, msg.ID, map[string]any{})
+	}
+}
+
+func (f *headerCapturingBackend) writeResult(w http.ResponseWriter, id json.RawMessage, result any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      json.RawMessage(id),
+		"result":  result,
+	}); err != nil {
+		f.t.Errorf("headerCapturingBackend: encode result: %v", err)
+	}
+}
+
+// TestHTTPSession_AppliesHeaderForwardToPostInitializeRequests is the red-phase
+// regression test for issue #5289. PR #5239 fixed HeaderForward for the vMCP
+// backend client (used for startup capability discovery) but did not extend the
+// fix to the session-side connector at pkg/vmcp/session/internal/backend.
+// As a result, user-configured headers (e.g. X-MCP-Toolsets for GitHub MCP)
+// never reach the backend on per-session requests like tools/call.
+//
+// The test asserts that, after the connector completes Initialize, a
+// subsequent CallTool carries the configured plaintext header on the wire.
+// On main today it fails because the connector's transport chain does not
+// include a header-forward round-tripper — see createMCPClient in
+// mcp_session.go (the chain is http.DefaultTransport → authRoundTripper →
+// identityRoundTripper, with no HeaderForward stage).
+func TestHTTPSession_AppliesHeaderForwardToPostInitializeRequests(t *testing.T) {
+	t.Parallel()
+
+	const (
+		headerName  = "X-MCP-Toolsets"
+		headerValue = "projects,issues,pull_requests,users,repos"
+	)
+
+	fb, url := newHeaderCapturingBackend(t)
+
+	target := &vmcp.BackendTarget{
+		WorkloadID:    "header-forward-backend",
+		WorkloadName:  "header-forward-backend",
+		BaseURL:       url,
+		TransportType: "streamable-http",
+		HeaderForward: &vmcp.HeaderForwardConfig{
+			AddPlaintextHeaders: map[string]string{
+				headerName: headerValue,
+			},
+		},
+	}
+
+	registry := newTestRegistry(t)
+	connector := NewHTTPConnector(registry)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	sess, caps, err := connector(ctx, target, nil, "")
+	require.NoError(t, err, "connector must initialise the backend successfully")
+	require.NotNil(t, sess, "connector returned nil session")
+	require.NotNil(t, caps, "connector returned nil capability list")
+	t.Cleanup(func() { _ = sess.Close() })
+
+	// Make a single MCP call AFTER initialize completes. tools/call exercises
+	// the same transport chain as initialize but is unambiguously a
+	// post-handshake request — which is exactly where the regression lives.
+	_, err = sess.CallTool(ctx, "echo", map[string]any{}, nil)
+	require.NoError(t, err, "post-initialize CallTool must succeed")
+
+	// The recorded inbound headers for the tools/call request must include the
+	// user-configured forward header. This is the single assertion target:
+	// the test fails for exactly one reason — header missing on the recorded
+	// post-initialize request.
+	gotHeaders := fb.headersFor(string(mcp.MethodToolsCall))
+	require.NotNil(t, gotHeaders, "backend never received a tools/call request")
+	assert.Equal(t, headerValue, gotHeaders.Get(headerName),
+		"HeaderForward.AddPlaintextHeaders must reach the backend on post-initialize requests")
+}

--- a/pkg/vmcp/session/internal/backend/mcp_session_test.go
+++ b/pkg/vmcp/session/internal/backend/mcp_session_test.go
@@ -4,11 +4,13 @@
 package backend
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/stacklok/toolhive/pkg/secrets"
 	"github.com/stacklok/toolhive/pkg/vmcp"
 	vmcpauth "github.com/stacklok/toolhive/pkg/vmcp/auth"
 	"github.com/stacklok/toolhive/pkg/vmcp/auth/strategies"
@@ -40,7 +42,7 @@ func TestCreateMCPClient_UnsupportedTransport(t *testing.T) {
 				TransportType: transport,
 			}
 
-			_, err := createMCPClient(target, nil, newTestRegistry(t), "")
+			_, err := createMCPClient(context.Background(), target, nil, newTestRegistry(t), "", secrets.NewEnvironmentProvider())
 			require.Error(t, err)
 			assert.ErrorIs(t, err, vmcp.ErrUnsupportedTransport,
 				"transport %q should return ErrUnsupportedTransport", transport)


### PR DESCRIPTION
## Summary

- **Why:** PR #5239 wired `HeaderForward` into the vMCP startup capability-discovery HTTP client at `pkg/vmcp/client/client.go:309`, but the **per-session MCP HTTP client** at `pkg/vmcp/session/internal/backend/mcp_session.go` builds a parallel transport chain (`DefaultTransport → auth → identity`) and never reads `target.HeaderForward`. Every post-initialize MCP call (`tools/list`, `tools/call`, …) reaches the upstream without user-configured headers. Reported in #5289 and reproduced on staging in v0.27.2 — GitHub Copilot's `X-MCP-Toolsets` filter is silently ignored, so the upstream returns the default 43-tool set instead of the configured subset.
- **What:** Export the existing `BuildHeaderForwardTripper` helper from `pkg/vmcp/client`, construct a single `secrets.EnvironmentProvider` at `NewHTTPConnector` build time, plumb it through `createMCPClient`, and wrap the shared transport chain with the helper as the outermost stage. The ordering preserves vMCP's authoritative auth/identity headers because `headerForwardRoundTripper.RoundTrip` skips header names already set by inner stages.

Fixes #5289

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [x] Unit tests (`task test`) — new `TestHTTPSession_AppliesHeaderForwardToPostInitializeRequests` in `pkg/vmcp/session/internal/backend/`: fakes an MCP server, drives `initialize` + `tools/call`, asserts the post-initialize request carries `X-MCP-Toolsets`. Confirmed fails on the pre-fix code (header is empty on the wire) and passes after the fix. All other tests in `pkg/vmcp/...` still pass. Second commit adds overlap-precedence and `AddHeadersFromSecret` subtests using a shared `fakeBackend`, plus a restricted-name rejection subtest. All pass.
- [x] Linting (`task lint-fix`) — 0 issues.
- [ ] E2E tests (`task test-e2e`)
- [ ] Manual testing — original symptom reproduced on staging (vmcp `0.1.36-main.46.c905a7cc`, toolhive submodule `97b0cc3f` = v0.27.2): `MCPServerEntry/github-copilot-projects` with `X-MCP-Toolsets: projects,issues,pull_requests,users,repos` got the default 43-tool set instead of the filtered ~39-tool set. Fix verified locally via the regression test; staging re-run pending image cut.

## API Compatibility

- [x] This PR does not break the `v1beta1` API, OR the `api-break-allowed` label is applied and the migration guidance is described above.

No CRD changes. The only exported-API delta is renaming `pkg/vmcp/client.buildHeaderForwardTripper` → `BuildHeaderForwardTripper` — there was no prior exported name to break.

## Changes

| File | Change |
|------|--------|
| `pkg/vmcp/client/header_forward.go` | Export `BuildHeaderForwardTripper`; doc comment notes both callers. Comment on `headerForwardRoundTripper.RoundTrip` corrected to describe actual mechanism (outermost runs first; auth/identity win via unconditional `Set()`, not via the "skip if already set" guard). |
| `pkg/vmcp/client/client.go` | Update the one in-package call site to the exported name. |
| `pkg/vmcp/client/header_forward_test.go` | Rename-only test fixup so the package compiles. |
| `pkg/vmcp/session/internal/backend/mcp_session.go` | Construct `secrets.NewEnvironmentProvider()` at connector build time, plumb `ctx` + `provider` into `createMCPClient`, wrap chain with `BuildHeaderForwardTripper` as outermost stage. Chain-ordering comment rewritten to describe actual mechanism (outermost runs first; auth/identity win via unconditional `Set()`, not via the "skip if already set" guard). |
| `pkg/vmcp/session/internal/backend/mcp_session_test.go` | Update one call site for the new `createMCPClient` signature. |
| `pkg/vmcp/session/internal/backend/mcp_session_header_forward_test.go` | New end-to-end regression test for post-initialize header forwarding. Second commit: replace standalone `headerCapturingBackend` with shared `fakeBackend`; add overlap-precedence, restricted-name, and secret-source subtests; trim diff-narrating comments. |
| `pkg/vmcp/session/internal/backend/mcp_session_capabilities_test.go` | Extend `fakeBackend` with per-method header recording + `tools/call` handler. Backward-compatible. |

## Does this introduce a user-facing change?

Yes. `MCPServerEntry.spec.headerForward.addPlaintextHeaders` (and `addHeadersFromSecret`) now reach the upstream MCP server on every per-session call, not just on startup capability discovery. Users relying on header-based upstream config (e.g. GitHub Copilot's `X-MCP-Toolsets`, custom API keys, correlation IDs) will see them applied to live MCP traffic for the first time.

## Implementation plan

<details>
<summary>Approved implementation plan (Option A — minimal change)</summary>

Three options were considered:

- **A — Construct `secrets.Provider` inline in `NewHTTPConnector`** (chosen). ~10 LOC, mirrors `httpBackendClient`, no public-API growth on `NewSessionFactory`/`NewHTTPConnector`. Needed a small bump in scope to *export* `BuildHeaderForwardTripper` (originally package-private) so the session backend can call it — ~3 extra trivial lines.
- B — Thread `secrets.Provider` through `NewSessionFactory` and `NewHTTPConnector` signatures (~25 LOC, signature growth on two public funcs, touches `serve.go`).
- C — `WithSecretsProvider` functional option (~25 LOC, single-consumer config knob — anti-pattern #8).

**Selected A** for the smallest diff and the cleanest match to the existing `httpBackendClient` pattern. Test surface defined first (red-phase test in `pkg/vmcp/session/internal/backend/`), then production fix landed against it. Transport-chain ordering: header-forward wraps *outside* `identityRoundTripper`, matching `client.go:309` and preserving the "inner stages win on overlapping header names" invariant from `headerForwardRoundTripper.RoundTrip`.

</details>

## Follow-ups

- **Move helpers to `pkg/vmcp/headerforward/`** — opened as parallel building-block PR #5302 (draft). Mechanical relocation of `BuildHeaderForwardTripper` and its support types out of `pkg/vmcp/client/` (one of the two consumers) into a neutral home. Independent of this PR; whichever merges first, the other rebases with a one-line import update.
- **SSE backend test fake + table-driven regression** — filed as #5303. The header-forward wrap is shared between `streamable-http` and `sse` branches in `createMCPClient`, so SSE is wired correctly today, but a future refactor could silently break it. The test fake work to lock that down is substantial enough to defer.
- **Provider DI at the composition root** — overlaps with the design surface in #4929 (pluggable backendConnector). Deferred until #4929's plumbing settles, since any DI shape we adopt now would have to be reshaped to fit.
- **`createMCPClient` extraction (`buildSharedBackendTransport`)** — marker only. Worth doing if a 3rd shared-chain dependency (e.g. trace propagation) lands; not needed today.
- **Anti-pattern #8 consolidation** — `pkg/vmcp/client/client.go::defaultClientFactory` and `pkg/vmcp/session/internal/backend/mcp_session.go::createMCPClient` are still two parallel HTTP-client builders. This PR + #5302 reduce the duplication; full consolidation is its own piece of work.

## Special notes for reviewers

- **Anti-pattern #8 surface.** Two parallel HTTP-client builders in vMCP (`pkg/vmcp/client/client.go` for startup discovery, `pkg/vmcp/session/internal/backend/mcp_session.go` for per-session traffic) caused this bug — the first fix only landed in one. Unifying them is out of scope here; PR #5302 is the next mechanical step (helper relocation), and full consolidation is tracked as a follow-up above.
- **Provider DI deferred to the #4929 surface.** A "single `secrets.Provider` constructed at the composition root and injected through `NewSessionFactory`/`NewHTTPConnector`" cleanup overlaps directly with #4929's pluggable `backendConnector` work. Doing provider DI here would force a reshape once #4929 lands, so it is intentionally deferred.
- **Two `secrets.EnvironmentProvider` instances now exist** (one per builder). They're stateless — no shared state, no contention — but if we ever want a single shared provider, that refactor is orthogonal to this fix and folds into the #4929 follow-up above.
- **Test boundary.** The original regression test exercises `AddPlaintextHeaders` only. The second commit adds an explicit `AddHeadersFromSecret` subtest (env-resolved secret value reaches the wire), so both header sources are now covered.

Generated with [Claude Code](https://claude.com/claude-code)
