### PR TITLE
Move HeaderForward helpers to pkg/vmcp/headerforward

### DIFF
--- a/pkg/vmcp/client/client.go
+++ b/pkg/vmcp/client/client.go
@@ -33,6 +33,7 @@ import (
 	vmcpauth "github.com/stacklok/toolhive/pkg/vmcp/auth"
 	authtypes "github.com/stacklok/toolhive/pkg/vmcp/auth/types"
 	"github.com/stacklok/toolhive/pkg/vmcp/conversion"
+	"github.com/stacklok/toolhive/pkg/vmcp/headerforward"
 	healthcontext "github.com/stacklok/toolhive/pkg/vmcp/health/context"
 )
 
@@ -306,7 +307,9 @@ func (h *httpBackendClient) defaultClientFactory(ctx context.Context, target *vm
 	// Inject per-backend HTTP headers from MCPServerEntry.spec.headerForward.
 	// Resolves plaintext + secret-backed headers once here; auth (inner) always
 	// wins over user-supplied headers because it runs after this tripper.
-	baseTransport, err = buildHeaderForwardTripper(ctx, baseTransport, target.HeaderForward, h.secretsProvider, target.WorkloadID)
+	baseTransport, err = headerforward.BuildHeaderForwardTripper(
+		ctx, baseTransport, target.HeaderForward, h.secretsProvider, target.WorkloadID,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build header-forward transport: %w", err)
 	}

--- a/pkg/vmcp/headerforward/transport.go
+++ b/pkg/vmcp/headerforward/transport.go
@@ -1,7 +1,12 @@
 // SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-package client
+// Package headerforward provides the HTTP round-tripper that injects
+// per-backend forwarded headers (plaintext + secret-resolved) onto outbound
+// requests. It is consumed by both the capability-discovery HTTP client
+// (pkg/vmcp/client) and the per-session HTTP client
+// (pkg/vmcp/session/internal/backend).
+package headerforward
 
 import (
 	"context"
@@ -55,7 +60,7 @@ func (h *headerForwardRoundTripper) RoundTrip(req *http.Request) (*http.Response
 	return h.base.RoundTrip(reqCopy)
 }
 
-// buildHeaderForwardTripper constructs a headerForwardRoundTripper for the
+// BuildHeaderForwardTripper constructs a headerForwardRoundTripper for the
 // backend's pre-resolved HeaderForwardConfig. Returns base unchanged when no
 // header injection is configured or the effective header set is empty.
 //
@@ -66,7 +71,7 @@ func (h *headerForwardRoundTripper) RoundTrip(req *http.Request) (*http.Response
 // Restricted header names (matching pkg/transport/middleware.RestrictedHeaders)
 // are rejected to prevent Host, Content-Length, Authorization, hop-by-hop, and
 // X-Forwarded-* spoofing via user-supplied config.
-func buildHeaderForwardTripper(
+func BuildHeaderForwardTripper(
 	ctx context.Context,
 	base http.RoundTripper,
 	cfg *vmcp.HeaderForwardConfig,

--- a/pkg/vmcp/headerforward/transport_test.go
+++ b/pkg/vmcp/headerforward/transport_test.go
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-package client
+package headerforward
 
 import (
 	"context"
@@ -237,7 +237,7 @@ func TestResolveHeaderForward_NilCfgReturnsNil(t *testing.T) {
 func TestBuildHeaderForwardTripper_NilCfgReturnsBase(t *testing.T) {
 	t.Parallel()
 	base := &captureTripper{}
-	got, err := buildHeaderForwardTripper(t.Context(), base, nil, nil, "x")
+	got, err := BuildHeaderForwardTripper(t.Context(), base, nil, nil, "x")
 	require.NoError(t, err)
 	assert.Same(t, base, got, "nil cfg must pass base through untouched")
 }


### PR DESCRIPTION
## Summary

- **Why:** PR #5301 exported `BuildHeaderForwardTripper` from `pkg/vmcp/client/` so the per-session HTTP client at `pkg/vmcp/session/internal/backend/` could reuse it without duplicating ~160 LOC of transport-chain construction. That export was the minimum-viable fix for #5289, but `pkg/vmcp/client/` is also a *consumer* of the helper — not its logical home. Two consumers + an awkwardly placed shared helper is one of the shapes vMCP anti-pattern #8 calls out.
- **What:** Lift the helper into its own sibling package `pkg/vmcp/headerforward/`. The companion subpackage `pkg/vmcp/headerforward/wirefmt/` already exists, so the namespace is established. Pure mechanical move — no signature change, no behavior change, existing tests still cover the helper end-to-end.

Related to #5289.

## Type of change

- [x] Refactoring (no behavior change)
- [ ] Bug fix
- [ ] New feature
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [x] Unit tests (`task test`) — existing `BuildHeaderForwardTripper` and `resolveHeaderForward` tests moved alongside the helper, still pass against the new location.
- [x] Linting (`task lint-fix`) — clean.
- [ ] E2E tests (`task test-e2e`)
- [ ] Manual testing

## API Compatibility

- [x] This PR does not break the `v1beta1` API.

No CRD changes. The only API surface delta is the package path of `BuildHeaderForwardTripper`. The helper was exported only by PR #5301; this PR moves that export to its final home before broader use.

## Changes

| File | Change |
|------|--------|
| `pkg/vmcp/headerforward/transport.go` | New — moved from `pkg/vmcp/client/header_forward.go`, package renamed. |
| `pkg/vmcp/headerforward/transport_test.go` | New — moved from `pkg/vmcp/client/header_forward_test.go`. |
| `pkg/vmcp/client/header_forward.go` | Deleted. |
| `pkg/vmcp/client/header_forward_test.go` | Deleted. |
| `pkg/vmcp/client/client.go` | Updated import + call site to `headerforward.BuildHeaderForwardTripper`. |

## Does this introduce a user-facing change?

No.

## Special notes for reviewers

- Branches off `main`, not off `github_mcp_header` (PR #5301). The two PRs are independent. Whichever merges first, the other's rebase is a one-line import-path update in `mcp_session.go` (PR #5301) or `client.go` (this PR).
- `pkg/vmcp/headerforward/wirefmt/` is unchanged — it owns the env-var wire format used by the operator to pass header-forward config into the vmcp pod; the new `transport.go` is the runtime that consumes that config.
- No new logic, no new tests, no new error paths. If this PR's diff isn't entirely renames + import path changes, something is wrong.

Generated with [Claude Code](https://claude.com/claude-code)
