### PR TITLE
Deep-copy shared fixtures in mapMCPServerToWebhookConfig subtests

### DIFF
--- a/cmd/thv-operator/controllers/mcpwebhookconfig_controller_test.go
+++ b/cmd/thv-operator/controllers/mcpwebhookconfig_controller_test.go
@@ -380,25 +380,27 @@ func TestMCPWebhookConfigReconciler_mapMCPServerToWebhookConfig(t *testing.T) {
 	t.Run("current WebhookConfigRef returns one request", func(t *testing.T) {
 		t.Parallel()
 
+		serverCopy := server.DeepCopy()
 		fakeClient := fake.NewClientBuilder().
 			WithScheme(scheme).
-			WithObjects(server).
+			WithObjects(serverCopy).
 			Build()
 		r := &MCPWebhookConfigReconciler{Client: fakeClient, Scheme: scheme}
 
 		require.ElementsMatch(t, []reconcile.Request{{
 			NamespacedName: types.NamespacedName{Name: "current-config", Namespace: "default"},
-		}}, r.mapMCPServerToWebhookConfig(ctx, server))
+		}}, r.mapMCPServerToWebhookConfig(ctx, serverCopy))
 	})
 
 	t.Run("stale ReferencingWorkloads returns owning config request", func(t *testing.T) {
 		t.Parallel()
 
+		staleConfigCopy := staleConfig.DeepCopy()
 		serverWithoutRef := server.DeepCopy()
 		serverWithoutRef.Spec.WebhookConfigRef = nil
 		fakeClient := fake.NewClientBuilder().
 			WithScheme(scheme).
-			WithObjects(serverWithoutRef, staleConfig).
+			WithObjects(serverWithoutRef, staleConfigCopy).
 			Build()
 		r := &MCPWebhookConfigReconciler{Client: fakeClient, Scheme: scheme}
 
@@ -410,16 +412,19 @@ func TestMCPWebhookConfigReconciler_mapMCPServerToWebhookConfig(t *testing.T) {
 	t.Run("current and stale references are returned without duplicates", func(t *testing.T) {
 		t.Parallel()
 
+		serverCopy := server.DeepCopy()
+		currentConfigCopy := currentConfig.DeepCopy()
+		staleConfigCopy := staleConfig.DeepCopy()
 		fakeClient := fake.NewClientBuilder().
 			WithScheme(scheme).
-			WithObjects(server, currentConfig, staleConfig).
+			WithObjects(serverCopy, currentConfigCopy, staleConfigCopy).
 			Build()
 		r := &MCPWebhookConfigReconciler{Client: fakeClient, Scheme: scheme}
 
 		require.ElementsMatch(t, []reconcile.Request{
 			{NamespacedName: types.NamespacedName{Name: "current-config", Namespace: "default"}},
 			{NamespacedName: types.NamespacedName{Name: "stale-config", Namespace: "default"}},
-		}, r.mapMCPServerToWebhookConfig(ctx, server))
+		}, r.mapMCPServerToWebhookConfig(ctx, serverCopy))
 	})
 
 	t.Run("wrong object type returns nil", func(t *testing.T) {
@@ -435,10 +440,11 @@ func TestMCPWebhookConfigReconciler_mapMCPServerToWebhookConfig(t *testing.T) {
 	t.Run("list failure returns partial current-ref request", func(t *testing.T) {
 		t.Parallel()
 
+		serverCopy := server.DeepCopy()
 		listErr := errors.New("simulated list failure")
 		fakeClient := fake.NewClientBuilder().
 			WithScheme(scheme).
-			WithObjects(server).
+			WithObjects(serverCopy).
 			WithInterceptorFuncs(interceptor.Funcs{
 				List: func(
 					ctx context.Context,
@@ -457,7 +463,7 @@ func TestMCPWebhookConfigReconciler_mapMCPServerToWebhookConfig(t *testing.T) {
 
 		require.ElementsMatch(t, []reconcile.Request{{
 			NamespacedName: types.NamespacedName{Name: "current-config", Namespace: "default"},
-		}}, r.mapMCPServerToWebhookConfig(ctx, server))
+		}}, r.mapMCPServerToWebhookConfig(ctx, serverCopy))
 	})
 }
 


### PR DESCRIPTION
## Summary

- CI race detector intermittently aborts the entire operator test binary in `cmd/thv-operator/controllers` because parallel subtests of `TestMCPWebhookConfigReconciler_mapMCPServerToWebhookConfig` share outer-scope `*MCPServer` and `*MCPWebhookConfig` fixture pointers. `controller-runtime`'s `fake.ClientBuilder.Build()` calls `SetResourceVersion` on the caller's pointer in place (via `versionedTracker.Add`), so two subtests that both pass the same shared pointer to `WithObjects(...)` under `t.Parallel()` race on `ObjectMeta.ResourceVersion` — one race trips the detector, which marks every test in the package failed.
- The fix is test-only and surgical: each affected subtest now deep-copies its fixtures at the top of its body and passes the copies to `WithObjects(...)` and the function under test. Subtest 2's existing `server.DeepCopy()` was left untouched. No production code change.

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test`) — `cmd/thv-operator/controllers` package passes clean
- [x] Manual testing (describe below)

Local race repro:
- `go test -race -count=20 -run TestMCPWebhookConfigReconciler_mapMCPServerToWebhookConfig ./cmd/thv-operator/controllers/...` — clean across 20 iterations
- `go test -race -count=3 ./cmd/thv-operator/controllers/...` — clean

## API Compatibility

- [x] This PR does not break the `v1beta1` API, OR the `api-break-allowed` label is applied and the migration guidance is described above.

## Implementation plan

<details>
<summary>Approved implementation plan</summary>

Root cause: `versionedTracker.Add` (controller-runtime fake client) mutates input objects in place via `SetResourceVersion`. Parallel subtests sharing the same outer-scope `*MCPServer` / `*MCPWebhookConfig` pointer pass it directly to `WithObjects(...)`, so write/read races occur on `ObjectMeta.ResourceVersion`.

Fix: at the top of each subtest in `TestMCPWebhookConfigReconciler_mapMCPServerToWebhookConfig`, deep-copy the shared fixtures and use the copies for both `WithObjects(...)` and the function under test. Each subtest then owns its own memory and concurrent subtests only read shared fixtures via `DeepCopy`, which is safe.

Audit: grep across `cmd/thv-operator/controllers/*_test.go` for the same pattern (`t.Run` + `t.Parallel()` subtests passing outer-scope pointers to `WithObjects(...)`). No other instances found — all other parallel subtests are table-driven (per-row pointer ownership) or construct fresh objects inline.

Anti-patterns avoided: no `time.Sleep`, no removing `t.Parallel()`, no disabling `-race`, no skipping the test.
</details>

## Special notes for reviewers

Diff is intentionally minimal — one `*.DeepCopy()` line per subtest that needed it (subtest 2 was already correct, subtest 4 uses no shared fixtures). The audit ruled out the same pattern elsewhere in the package, so this PR is scoped to the one test function that the race detector caught.

🤖 Generated with [Claude Code](https://claude.com/claude-code)