### PR TITLE
Deflake transientRefresher singleflight test

### DIFF
--- a/pkg/auth/monitored_token_source.go
+++ b/pkg/auth/monitored_token_source.go
@@ -139,28 +139,16 @@ type transientRefresher struct {
 	upstream string
 	clientID string
 
-	// newBackOff is a factory for the backoff used during retries.
-	// Nil in production; overridable in tests for fast execution.
+	// newBackOff constructs the exponential backoff applied during transient-error
+	// retries. Always non-nil; set by the constructor.
 	newBackOff func() backoff.BackOff
-
-	// beforeEntry and afterEntry are nil in production. Tests set them to
-	// synchronise goroutines so that the singleflight group is fully formed
-	// before the leader's retry returns.
-	beforeEntry func()
-	afterEntry  func()
 }
 
 // Refresh deduplicates concurrent callers via singleflight and retries the
 // underlying token source with exponential backoff until the context is
 // cancelled or a non-transient error is returned.
 func (r *transientRefresher) Refresh(ctx context.Context, origErr error) (*oauth2.Token, error) {
-	if r.beforeEntry != nil {
-		r.beforeEntry()
-	}
 	v, err, _ := r.group.Do("token-refresh", func() (interface{}, error) {
-		if r.afterEntry != nil {
-			r.afterEntry()
-		}
 		return r.retry(ctx, origErr)
 	})
 	if err != nil {
@@ -169,13 +157,33 @@ func (r *transientRefresher) Refresh(ctx context.Context, origErr error) (*oauth
 	return v.(*oauth2.Token), nil
 }
 
+func newTransientRefresher(
+	source oauth2.TokenSource,
+	workload, upstream, clientID string,
+	newBackOff func() backoff.BackOff,
+) *transientRefresher {
+	return &transientRefresher{
+		source:     source,
+		workload:   workload,
+		upstream:   upstream,
+		clientID:   clientID,
+		newBackOff: newBackOff,
+	}
+}
+
+func defaultBackOff() backoff.BackOff {
+	eb := backoff.NewExponentialBackOff()
+	eb.InitialInterval = resolveTokenRefreshInitialRetryInterval()
+	eb.MaxInterval = resolveTokenRefreshMaxRetryInterval()
+	eb.Reset()
+	return eb
+}
+
 func (r *transientRefresher) retry(ctx context.Context, origErr error) (*oauth2.Token, error) {
 	slog.Warn("token refresh failed due to transient network error, retrying with backoff",
 		"workload", r.workload,
 		"error", origErr,
 	)
-
-	b := r.getBackOff()
 
 	return backoff.Retry(ctx, func() (*oauth2.Token, error) {
 		t, tokenErr := r.source.Token()
@@ -187,7 +195,7 @@ func (r *transientRefresher) retry(ctx context.Context, origErr error) (*oauth2.
 		}
 		return nil, tokenErr
 	},
-		backoff.WithBackOff(b),
+		backoff.WithBackOff(r.newBackOff()),
 		backoff.WithNotify(func(retryErr error, d time.Duration) {
 			slog.Warn("token refresh retry failed",
 				"workload", r.workload,
@@ -198,17 +206,6 @@ func (r *transientRefresher) retry(ctx context.Context, origErr error) (*oauth2.
 		backoff.WithMaxTries(resolveTokenRefreshMaxTries()),
 		backoff.WithMaxElapsedTime(resolveTokenRefreshMaxElapsedTime()),
 	)
-}
-
-func (r *transientRefresher) getBackOff() backoff.BackOff {
-	if r.newBackOff != nil {
-		return r.newBackOff()
-	}
-	eb := backoff.NewExponentialBackOff()
-	eb.InitialInterval = resolveTokenRefreshInitialRetryInterval()
-	eb.MaxInterval = resolveTokenRefreshMaxRetryInterval()
-	eb.Reset()
-	return eb
 }
 
 // MonitoredTokenSource is a wrapper around an oauth2.TokenSource that monitors authentication
@@ -259,6 +256,18 @@ func NewMonitoredTokenSource(
 	clientID string,
 	statusUpdater StatusUpdater,
 ) *MonitoredTokenSource {
+	return newMonitoredTokenSourceWithBackOff(ctx, tokenSource, workloadName, upstream, clientID, statusUpdater, defaultBackOff)
+}
+
+func newMonitoredTokenSourceWithBackOff(
+	ctx context.Context,
+	tokenSource oauth2.TokenSource,
+	workloadName string,
+	upstream string,
+	clientID string,
+	statusUpdater StatusUpdater,
+	newBackOff func() backoff.BackOff,
+) *MonitoredTokenSource {
 	return &MonitoredTokenSource{
 		tokenSource:    tokenSource,
 		workloadName:   workloadName,
@@ -268,12 +277,7 @@ func NewMonitoredTokenSource(
 		monitoringCtx:  ctx,
 		stopMonitoring: make(chan struct{}),
 		stopped:        make(chan struct{}),
-		refresher: &transientRefresher{
-			source:   tokenSource,
-			workload: workloadName,
-			upstream: upstream,
-			clientID: clientID,
-		},
+		refresher:      newTransientRefresher(tokenSource, workloadName, upstream, clientID, newBackOff),
 	}
 }
 

--- a/pkg/auth/monitored_token_source_test.go
+++ b/pkg/auth/monitored_token_source_test.go
@@ -444,22 +444,32 @@ func TestMonitoredTokenSource_MultipleCallsToToken(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 }
 
-// TestTransientRefresher_SingleflightDeduplicatesConcurrentRetries verifies that
-// concurrent Refresh() calls are funnelled through a single retry loop via
-// singleflight, so the underlying token source is not hammered by independent
-// retry loops ("thundering herd").
+// TestTransientRefresher_SingleflightDeduplicatesConcurrentRetries verifies the
+// one property the refresher owns: it calls singleflight.Group.Do with a
+// constant key, so concurrent Refresh() invocations are coalesced. Singleflight
+// itself is a stable library; we don't re-validate its dedup semantics here.
+//
+// A regression that swapped the constant "token-refresh" key for something
+// per-caller (e.g. a per-upstream key) would let the follower start its own
+// flight, doubling the Token() call count, and this test would catch it.
 func TestTransientRefresher_SingleflightDeduplicatesConcurrentRetries(t *testing.T) {
 	t.Parallel()
-
-	const numCallers = 10
 
 	tokenSource := newMockTokenSource()
 	recoveredToken := &oauth2.Token{
 		AccessToken: "recovered-token",
 		Expiry:      time.Now().Add(time.Hour),
 	}
+
+	// Block the leader inside the singleflight callback so the follower has
+	// a window to join the in-flight entry.
+	releaseLeader := make(chan struct{})
+	leaderEntered := make(chan struct{})
+	var leaderOnce sync.Once
 	tokenSource.setTokenFn(func() (*oauth2.Token, error) {
-		return recoveredToken, nil // retry always succeeds immediately
+		leaderOnce.Do(func() { close(leaderEntered) })
+		<-releaseLeader
+		return recoveredToken, nil
 	})
 
 	transientErr := &net.OpError{
@@ -467,94 +477,78 @@ func TestTransientRefresher_SingleflightDeduplicatesConcurrentRetries(t *testing
 		Err: &os.SyscallError{Syscall: "connect", Err: syscall.ECONNREFUSED},
 	}
 
-	// Two-phase synchronisation to guarantee deterministic singleflight deduplication:
-	//
-	// Phase 1 (beforeEntry): all numCallers goroutines arrive here before calling
-	// Refresh. A WaitGroup barrier ensures they are all released simultaneously,
-	// so they race to group.Do together.
-	//
-	// Phase 2 (afterEntry): the singleflight leader enters this hook from inside
-	// group.Do and waits until all numCallers goroutines have signalled they are
-	// about to call Refresh (i.e. finished Phase 1). At that point the leader is
-	// still running inside Do, so any follower that subsequently calls Do will be
-	// deduplicated rather than starting an independent retry loop.
-	//
-	// Without Phase 2 the leader could return before late goroutines reached Do,
-	// causing each to start its own singleflight group and hammer the token source.
-	allAtSingleflight := make(chan struct{})
-	var atSingleflight sync.WaitGroup
-	atSingleflight.Add(numCallers)
-	var closeOnce sync.Once
-
-	var beforeDo sync.WaitGroup
-	beforeDo.Add(numCallers)
-
 	ctx := context.Background()
-	refresher := &transientRefresher{
-		source:     tokenSource,
-		workload:   "test-workload",
-		newBackOff: fastBackOff,
-		beforeEntry: func() {
-			// Phase 1: barrier — release all goroutines simultaneously.
-			atSingleflight.Done()
-			closeOnce.Do(func() {
-				atSingleflight.Wait()
-				close(allAtSingleflight)
-			})
-			<-allAtSingleflight
-			// Signal: I am about to call group.Do.
-			beforeDo.Done()
-		},
-		afterEntry: func() {
-			// Phase 2: leader waits until all goroutines have signalled they are
-			// about to call group.Do, so the group is fully formed before retry returns.
-			beforeDo.Wait()
-		},
+	refresher := newTransientRefresher(tokenSource, "test-workload", "", "", fastBackOff)
+
+	type result struct {
+		tok *oauth2.Token
+		err error
 	}
 
-	var wg sync.WaitGroup
-	tokens := make([]*oauth2.Token, numCallers)
-	errs := make([]error, numCallers)
-	for i := range numCallers {
-		wg.Add(1)
-		go func(idx int) {
-			defer wg.Done()
-			tokens[idx], errs[idx] = refresher.Refresh(ctx, transientErr)
-		}(i)
+	leaderResult := make(chan result, 1)
+	go func() {
+		tok, err := refresher.Refresh(ctx, transientErr)
+		leaderResult <- result{tok, err}
+	}()
+
+	// Wait until the leader is provably inside Token() — only then is it safe
+	// to spawn a follower that will deterministically join this flight.
+	select {
+	case <-leaderEntered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("leader did not enter Token() within 5s")
 	}
 
-	// Guard against a deadlock in the synchronisation barriers turning into a
-	// silent hang. Use the test deadline if available; otherwise fall back to a
-	// conservative fixed timeout.
-	done := make(chan struct{})
-	go func() { wg.Wait(); close(done) }()
-	timeout := 10 * time.Second
+	followerResult := make(chan result, 1)
+	go func() {
+		tok, err := refresher.Refresh(ctx, transientErr)
+		followerResult <- result{tok, err}
+	}()
+
+	// Short sleep to let the follower call group.Do and join the in-flight
+	// entry before we release the leader. This is the same technique used by
+	// golang.org/x/sync's own singleflight tests — singleflight exposes no
+	// observable "follower is queued" signal.
+	time.Sleep(10 * time.Millisecond)
+	close(releaseLeader)
+
+	timeout := 5 * time.Second
 	if deadline, ok := t.Deadline(); ok {
 		timeout = time.Until(deadline) - 500*time.Millisecond
 	}
+
+	var leader, follower result
 	select {
-	case <-done:
+	case leader = <-leaderResult:
 	case <-time.After(timeout):
-		t.Fatal("test timed out — likely deadlock in synchronisation barriers")
+		t.Fatal("leader did not finish")
+	}
+	select {
+	case follower = <-followerResult:
+	case <-time.After(timeout):
+		t.Fatal("follower did not finish")
 	}
 
-	// All callers must succeed with the recovered token.
-	for i := range numCallers {
-		if errs[i] != nil {
-			t.Errorf("caller %d: unexpected error: %v", i, errs[i])
-		}
-		if tokens[i] == nil || tokens[i].AccessToken != "recovered-token" {
-			t.Errorf("caller %d: expected recovered-token, got %v", i, tokens[i])
-		}
+	if leader.err != nil {
+		t.Errorf("leader: unexpected error: %v", leader.err)
+	}
+	if follower.err != nil {
+		t.Errorf("follower: unexpected error: %v", follower.err)
+	}
+	if leader.tok == nil || leader.tok.AccessToken != "recovered-token" {
+		t.Errorf("leader: expected recovered-token, got %v", leader.tok)
+	}
+	if follower.tok == nil || follower.tok.AccessToken != "recovered-token" {
+		t.Errorf("follower: expected recovered-token, got %v", follower.tok)
 	}
 
-	// KEY ASSERTION: exactly 1 call via singleflight, not numCallers independent calls.
-	// Independent retry loops would produce up to numCallers calls.
+	// The load-bearing assertion: if Refresh used a per-caller key, the
+	// follower's flight would have called Token() a second time.
 	tokenSource.mu.Lock()
 	calls := tokenSource.callCount
 	tokenSource.mu.Unlock()
 	if calls != 1 {
-		t.Errorf("expected 1 tokenSource.Token() call (singleflight deduplication), got %d", calls)
+		t.Errorf("expected exactly 1 tokenSource.Token() call (constant singleflight key), got %d", calls)
 	}
 }
 
@@ -654,8 +648,7 @@ func TestMonitoredTokenSource_BackgroundMonitor_ErrorClassification(t *testing.T
 				statusUpdater, _ := newMockStatusUpdater(ctrl)
 				retrying := tokenSource.notifyOnCall(2)
 
-				ats := NewMonitoredTokenSource(ctx, tokenSource, "test-workload", "", "", statusUpdater)
-				ats.refresher.newBackOff = fastBackOff
+				ats := newMonitoredTokenSourceWithBackOff(ctx, tokenSource, "test-workload", "", "", statusUpdater, fastBackOff)
 				ats.StartBackgroundMonitoring()
 
 				<-retrying // Ensure the retry loop has been entered before cancelling.
@@ -674,8 +667,7 @@ func TestMonitoredTokenSource_BackgroundMonitor_ErrorClassification(t *testing.T
 					Return(nil).
 					Times(1)
 
-				ats := NewMonitoredTokenSource(ctx, tokenSource, "test-workload", "", "", statusUpdater)
-				ats.refresher.newBackOff = fastBackOff
+				ats := newMonitoredTokenSourceWithBackOff(ctx, tokenSource, "test-workload", "", "", statusUpdater, fastBackOff)
 				ats.StartBackgroundMonitoring()
 
 				<-ats.Stopped() // Monitor stops itself after marking unauthenticated.
@@ -864,8 +856,7 @@ func TestMonitoredTokenSource_TransientErrorRetriesAndSucceeds(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	ats := NewMonitoredTokenSource(ctx, tokenSource, "test-workload", "", "", statusUpdater)
-	ats.refresher.newBackOff = fastBackOff
+	ats := newMonitoredTokenSourceWithBackOff(ctx, tokenSource, "test-workload", "", "", statusUpdater, fastBackOff)
 	ats.StartBackgroundMonitoring()
 
 	// Block until the monitor has successfully recovered, then stop it.
@@ -904,8 +895,7 @@ func TestMonitoredTokenSource_TransientErrorContextCancellation(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 
-	ats := NewMonitoredTokenSource(ctx, tokenSource, "test-workload", "", "", statusUpdater)
-	ats.refresher.newBackOff = fastBackOff
+	ats := newMonitoredTokenSourceWithBackOff(ctx, tokenSource, "test-workload", "", "", statusUpdater, fastBackOff)
 	ats.StartBackgroundMonitoring()
 
 	// Cancel once we know the retry loop is running, then wait for clean exit.
@@ -959,8 +949,7 @@ func TestMonitoredTokenSource_TransientThenNonTransientMarksUnauthenticated(t *t
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	ats := NewMonitoredTokenSource(ctx, tokenSource, "test-workload", "", "", statusUpdater)
-	ats.refresher.newBackOff = fastBackOff
+	ats := newMonitoredTokenSourceWithBackOff(ctx, tokenSource, "test-workload", "", "", statusUpdater, fastBackOff)
 	ats.StartBackgroundMonitoring()
 
 	// Monitor stops itself after the non-transient error; wait for that.


### PR DESCRIPTION
## Summary

The `TestTransientRefresher_SingleflightDeduplicatesConcurrentRetries` test was flaky on loaded CI runners because it asserted "exactly 1 `Token()` call" across 10 goroutines stampeding into `group.Do`, but singleflight only pools callers that reach `Do` *while a flight is in progress*. A late goroutine could land after the leader's flight completed and start a fresh flight, producing a second `Token()` call and failing the assertion.

The same test also leaned on `beforeEntry`/`afterEntry` nil-checked hook fields living on the production `transientRefresher` struct — a pattern explicitly prohibited by `.claude/rules/testing.md` ("Test Hooks in Production Structs"). The struct's `newBackOff` field was the same anti-pattern: documented as "Nil in production; overridable in tests for fast execution."

Two changes:

- **Test**: replace the 10-goroutine stampede with a focused 2-goroutine test that verifies the one property the refresher actually owns — `Refresh` uses a constant singleflight key, so a follower joining an in-flight call does not trigger a second `Token()` invocation. Singleflight's own dedup semantics are not re-validated here.
- **Production**: promote `newBackOff` from a nil-checked hook to a required constructor parameter. New unexported `newMonitoredTokenSourceWithBackOff` takes the factory explicitly; `NewMonitoredTokenSource` passes the production `defaultBackOff`; tests pass `fastBackOff`. The five test sites no longer mutate refresher fields directly, and the production struct carries no test scaffolding.

## Type of change

- [x] Refactoring (no functional change, no API change)
- [x] Test improvement

## Test plan

- [x] Ran `go test -run TestTransientRefresher_SingleflightDeduplicatesConcurrentRetries -count=200 -race ./pkg/auth/` — passes cleanly across ~670 invocations including stress runs with background `go build` and concurrent test loops competing for goroutine scheduling.
- [x] Ran the full `pkg/auth` test suite to verify the refactor of `NewMonitoredTokenSource` / `newMonitoredTokenSourceWithBackOff` didn't break the four other tests that used to mutate `ats.refresher.newBackOff` directly.

## Does this introduce a user-facing change?

No. `NewMonitoredTokenSource`'s signature is unchanged; the new internals (`newMonitoredTokenSourceWithBackOff`, `newTransientRefresher`, `defaultBackOff`) are all unexported.

## Special notes for reviewers

The new test still relies on a 10 ms sleep to let the follower goroutine reach `group.Do` before the leader's flight is released — singleflight exposes no observable "follower-queued" signal, so this is the same heuristic `golang.org/x/sync`'s own tests use. The failure mode is now strictly narrower than before (one goroutine instead of nine racing the leader's completion), but if CI proves to dislike even this window we can bump the sleep or wrap `singleflight.Group` behind a test-only interface seam.

Generated with [Claude Code](https://claude.com/claude-code)