### PR TITLE
Drop empty PULLS column from registry list and search output

### DIFF
--- a/cmd/thv/app/registry.go
+++ b/cmd/thv/app/registry.go
@@ -158,7 +158,7 @@ func printJSONServer(server types.ServerMetadata) error {
 func printTextServers(servers []types.ServerMetadata) {
 	// Create a tabwriter for pretty output
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
-	if _, err := fmt.Fprintln(w, "NAME\tTYPE\tDESCRIPTION\tTIER\tSTARS\tPULLS"); err != nil {
+	if _, err := fmt.Fprintln(w, "NAME\tTYPE\tDESCRIPTION\tTIER\tSTARS"); err != nil {
 		slog.Warn(fmt.Sprintf("Failed to write output: %v", err))
 		return
 	}

--- a/cmd/thv/app/search.go
+++ b/cmd/thv/app/search.go
@@ -84,7 +84,7 @@ func printJSONSearchResults(servers []types.ServerMetadata) error {
 func printTextSearchResults(servers []types.ServerMetadata) {
 	// Create a tabwriter for pretty output
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
-	if _, err := fmt.Fprintln(w, "NAME\tTYPE\tDESCRIPTION\tTRANSPORT\tSTARS\tPULLS"); err != nil {
+	if _, err := fmt.Fprintln(w, "NAME\tTYPE\tDESCRIPTION\tTRANSPORT\tSTARS"); err != nil {
 		slog.Warn(fmt.Sprintf("Failed to write output: %v", err))
 		return
 	}


### PR DESCRIPTION
## Summary

- The `PULLS` column in `thv registry list` and `thv search` text output has been rendering as an empty column. The header advertises 6 fields but the row format only writes 5 values.
- The `Pulls` field was removed from the registry metadata struct in #3881 ("Add overview and deprecate pulls registry fields"), but the CLI column headers were not updated. The rationale for the original deprecation is not stated in the PR description, commit messages, or any linked issue.
- This PR removes the dead header from both commands. If we want pulls back, that needs to start from the data model side.

## Type of change

- [x] Bug fix

## Test plan

- [x] Linting (`task lint-fix`)
- [x] Manual testing (described below)

Built `thv` locally and ran `thv registry list` and `thv search github`. Confirmed the `PULLS` column is gone and remaining columns (`NAME`, `TYPE`, `DESCRIPTION`, `TIER`/`TRANSPORT`, `STARS`) align correctly.

## Does this introduce a user-facing change?

Yes. The `PULLS` column is removed from the text output of `thv registry list` and `thv search`. JSON output is unaffected (no `pulls` field exists in the metadata model). Scripts parsing the text output by column position will need to drop the trailing empty column.

## Special notes for reviewers

A stray `"pulls": 1234` literal remains in a JSON test fixture at `pkg/registry/convert_test.go:33`. It is harmless dead data (the struct field no longer exists, so the converter ignores it) but could be cleaned up in a follow-up if desired.

Generated with [Claude Code](https://claude.com/claude-code)