### PR TITLE
Bump toolhive-core on release day via Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,6 +16,11 @@
       "schedule": ["at any time"]
     },
     {
+      "description": "Update toolhive-core dependency daily",
+      "matchPackageNames": ["github.com/stacklok/toolhive-core"],
+      "schedule": ["at any time"]
+    },
+    {
       "groupName": "toolhive images",
       "matchDatasources": ["docker"],
       "matchPackageNames": [


### PR DESCRIPTION
## Summary

- **Why**: `github.com/stacklok/toolhive-core` is on the global `"every weekend"` Renovate schedule, so new releases sit in the dependency dashboard for up to a week. For example, `v0.0.18` shipped 2026-05-12 and `v0.0.20` shipped 2026-05-14, but the bump from `v0.0.17` → `v0.0.20` is still "Awaiting Schedule" in #561 as of today.
- **What**: Add a `packageRules` entry that overrides the schedule to `"at any time"`, mirroring the existing `toolhive-catalog` rule so the two first-party Stacklok modules pick up new releases on the same cadence.

## Type of change

- [x] Other (please describe): Renovate configuration change

## Test plan

- [x] Verified the JSON parses (file edited inline, structure preserved).
- [ ] After merge: confirm Renovate opens the `v0.0.17 → v0.0.20` PR for `toolhive-core` on the next run instead of waiting for the weekend window.

## Does this introduce a user-facing change?

No.

Generated with [Claude Code](https://claude.com/claude-code)