### PR TITLE
fix: validate k8s export volume format

### DIFF
--- a/pkg/export/k8s.go
+++ b/pkg/export/k8s.go
@@ -167,8 +167,11 @@ func runConfigToMCPServer(config *runner.RunConfig) (*v1beta1.MCPServer, error) 
 // parseVolumeString parses a volume string in the format "host-path:container-path[:ro]"
 func parseVolumeString(volStr string, index int) (v1beta1.Volume, error) {
 	parts := strings.Split(volStr, ":")
-	if len(parts) < 2 {
+	if len(parts) < 2 || len(parts) > 3 {
 		return v1beta1.Volume{}, fmt.Errorf("invalid volume format, expected 'host-path:container-path[:ro]'")
+	}
+	if len(parts) == 3 && parts[2] != "ro" {
+		return v1beta1.Volume{}, fmt.Errorf("invalid volume mode %q, expected 'ro'", parts[2])
 	}
 
 	volume := v1beta1.Volume{

--- a/pkg/export/k8s_test.go
+++ b/pkg/export/k8s_test.go
@@ -306,6 +306,18 @@ func TestParseVolumeString(t *testing.T) {
 			index:   0,
 			wantErr: true,
 		},
+		{
+			name:    "invalid format - too many fields",
+			volStr:  "/host/path:/container/path:ro:extra",
+			index:   0,
+			wantErr: true,
+		},
+		{
+			name:    "invalid format - unknown mode",
+			volStr:  "/host/path:/container/path:rw",
+			index:   0,
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Small papercut fix for k8s export.

`host-path:container-path[:ro]` was documented, but the exporter accepted stuff like `/host:/container:rw` or `/host:/container:ro:extra` and just kept going. bit yikes, because the generated MCPServer can hide a bad saved RunConfig instead of failing fast.

Repro:
```bash
go test ./pkg/export -run TestParseVolumeString -count=1
```

Before this patch, the new malformed cases fail because no error is returned. After it, unknown modes and extra fields are rejected.

Checked:
```bash
go test ./pkg/export -count=1
go test ./cmd/thv/app -run Test -count=1
go test ./pkg/...
```

No external quota or k8s limit makes this unreachable; it is plain RunConfig string data loaded by `thv export --format k8s`.