### PR TITLE
Use shared toolhive-core redis client for session storage

### DIFF
--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -17,6 +17,7 @@ import (
 
 	"golang.org/x/oauth2"
 
+	tcredis "github.com/stacklok/toolhive-core/redis"
 	"github.com/stacklok/toolhive/pkg/auth"
 	"github.com/stacklok/toolhive/pkg/auth/remote"
 	authsecrets "github.com/stacklok/toolhive/pkg/auth/secrets"
@@ -382,12 +383,11 @@ func (r *Runner) Run(ctx context.Context) error {
 		if keyPrefix == "" {
 			keyPrefix = "thv:proxy:session:"
 		}
-		storage, err := session.NewRedisStorage(ctx, session.RedisConfig{
-			Addr:      redisCfg.Address,
-			Password:  os.Getenv(session.RedisPasswordEnvVar),
-			DB:        int(redisCfg.DB),
-			KeyPrefix: keyPrefix,
-		}, effectiveSessionTTL)
+		storage, err := session.NewRedisStorage(ctx, tcredis.Config{
+			Addr:     redisCfg.Address,
+			Password: os.Getenv(session.RedisPasswordEnvVar),
+			DB:       int(redisCfg.DB),
+		}, keyPrefix, effectiveSessionTTL)
 		if err != nil {
 			return fmt.Errorf("failed to create Redis session storage: %w", err)
 		}

--- a/pkg/transport/session/manager.go
+++ b/pkg/transport/session/manager.go
@@ -11,6 +11,8 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+
+	tcredis "github.com/stacklok/toolhive-core/redis"
 )
 
 const (
@@ -118,12 +120,20 @@ func NewManagerWithStorage(ttl time.Duration, factory Factory, storage Storage) 
 // NewManagerWithRedis creates a session manager backed by Redis.
 // ctx is used for the initial Ping during construction and should carry any
 // deadline appropriate for the connection attempt (e.g. a startup timeout).
-// cfg supplies the Redis connection configuration; ttl is applied as both the
-// manager's cleanup interval and the Redis key TTL.
-// Returns an error if the Redis client cannot be constructed (e.g. invalid config or TLS error).
-// Callers that do not require Redis should use NewManager or NewTypedManager instead.
-func NewManagerWithRedis(ctx context.Context, ttl time.Duration, factory Factory, cfg RedisConfig) (*Manager, error) {
-	storage, err := NewRedisStorage(ctx, cfg, ttl)
+// cfg supplies the Redis connection configuration (delegated to the shared
+// toolhive-core redis package); keyPrefix namespaces the keys and must end
+// with ':'. ttl is applied as both the manager's cleanup interval and the
+// Redis key TTL. Returns an error if the Redis client cannot be constructed
+// (e.g. invalid config or TLS error). Callers that do not require Redis
+// should use NewManager or NewTypedManager instead.
+func NewManagerWithRedis(
+	ctx context.Context,
+	ttl time.Duration,
+	factory Factory,
+	cfg tcredis.Config,
+	keyPrefix string,
+) (*Manager, error) {
+	storage, err := NewRedisStorage(ctx, cfg, keyPrefix, ttl)
 	if err != nil {
 		return nil, fmt.Errorf("creating redis storage: %w", err)
 	}

--- a/pkg/transport/session/manager_redis_test.go
+++ b/pkg/transport/session/manager_redis_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/alicebob/miniredis/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	tcredis "github.com/stacklok/toolhive-core/redis"
 )
 
 func proxyFactory(id string) Session { return NewProxySession(id) }
@@ -23,10 +25,13 @@ func TestNewManagerWithRedis(t *testing.T) {
 		mr := miniredis.RunT(t)
 		defer mr.Close()
 
-		m, err := NewManagerWithRedis(context.Background(), time.Hour, proxyFactory, RedisConfig{
-			Addr:      mr.Addr(),
-			KeyPrefix: "test:mgr:",
-		})
+		m, err := NewManagerWithRedis(
+			context.Background(),
+			time.Hour,
+			proxyFactory,
+			tcredis.Config{Addr: mr.Addr()},
+			"test:mgr:",
+		)
 		require.NoError(t, err)
 		require.NotNil(t, m)
 		defer m.Stop()
@@ -35,23 +40,16 @@ func TestNewManagerWithRedis(t *testing.T) {
 		assert.True(t, isRedis, "storage should be *RedisStorage")
 	})
 
-	t.Run("invalid config returns error", func(t *testing.T) {
+	t.Run("missing key prefix returns error", func(t *testing.T) {
 		t.Parallel()
-		// Missing KeyPrefix → validateRedisConfig fails before Ping
-		m, err := NewManagerWithRedis(context.Background(), time.Hour, proxyFactory, RedisConfig{
-			Addr: "localhost:6379",
-		})
-		require.Error(t, err)
-		assert.Nil(t, m)
-	})
-
-	t.Run("invalid TLS CA cert returns error", func(t *testing.T) {
-		t.Parallel()
-		m, err := NewManagerWithRedis(context.Background(), time.Hour, proxyFactory, RedisConfig{
-			Addr:      "localhost:6379",
-			KeyPrefix: "test:mgr:",
-			TLS:       &RedisTLSConfig{CACert: []byte("not-valid-pem")},
-		})
+		// Empty keyPrefix fails session-invariant check before Ping.
+		m, err := NewManagerWithRedis(
+			context.Background(),
+			time.Hour,
+			proxyFactory,
+			tcredis.Config{Addr: "localhost:6379"},
+			"",
+		)
 		require.Error(t, err)
 		assert.Nil(t, m)
 	})
@@ -61,10 +59,13 @@ func TestNewManagerWithRedis(t *testing.T) {
 		mr := miniredis.RunT(t)
 		defer mr.Close()
 
-		m, err := NewManagerWithRedis(context.Background(), time.Hour, proxyFactory, RedisConfig{
-			Addr:      mr.Addr(),
-			KeyPrefix: "test:mgr:",
-		})
+		m, err := NewManagerWithRedis(
+			context.Background(),
+			time.Hour,
+			proxyFactory,
+			tcredis.Config{Addr: mr.Addr()},
+			"test:mgr:",
+		)
 		require.NoError(t, err)
 		defer m.Stop()
 
@@ -81,10 +82,13 @@ func TestNewManagerWithRedis(t *testing.T) {
 		mr := miniredis.RunT(t)
 		defer mr.Close()
 
-		m, err := NewManagerWithRedis(context.Background(), time.Hour, proxyFactory, RedisConfig{
-			Addr:      mr.Addr(),
-			KeyPrefix: "test:mgr:",
-		})
+		m, err := NewManagerWithRedis(
+			context.Background(),
+			time.Hour,
+			proxyFactory,
+			tcredis.Config{Addr: mr.Addr()},
+			"test:mgr:",
+		)
 		require.NoError(t, err)
 
 		require.NoError(t, m.AddWithID("bbbbbbbb-0002-0001-0001-000000000002"))

--- a/pkg/transport/session/redis_config.go
+++ b/pkg/transport/session/redis_config.go
@@ -3,71 +3,8 @@
 
 package session
 
-import "time"
-
 // RedisPasswordEnvVar is the environment variable name for the Redis session storage password.
 // The operator injects this as a SecretKeyRef when sessionStorage.provider is "redis"
 // and passwordRef is set.
 // #nosec G101 -- This is an environment variable name, not a hardcoded credential
 const RedisPasswordEnvVar = "THV_SESSION_REDIS_PASSWORD"
-
-// Default timeouts for Redis operations.
-const (
-	DefaultDialTimeout  = 5 * time.Second
-	DefaultReadTimeout  = 3 * time.Second
-	DefaultWriteTimeout = 3 * time.Second
-)
-
-// RedisConfig configures the Redis storage backend for session storage.
-// Addr is used for standalone; SentinelConfig activates Sentinel mode (mutually exclusive).
-type RedisConfig struct {
-	// Addr is the Redis server address for standalone mode (e.g., "host:port").
-	Addr string
-
-	// SentinelConfig, when non-nil, activates Sentinel mode. Mutually exclusive with Addr.
-	SentinelConfig *SentinelConfig
-
-	// Username is the Redis ACL username (Redis 6.0+). When non-empty, both
-	// Username and Password are sent as ACL credentials (AUTH username password).
-	// Leave empty to authenticate as the default user (legacy AUTH password).
-	Username string
-
-	// Password is the Redis AUTH password. Used with Username for ACL auth,
-	// or alone for legacy AUTH with the default user.
-	Password string //nolint:gosec // G101: not a hardcoded credential
-
-	// DB is the Redis database index.
-	DB int
-
-	// KeyPrefix namespaces all session keys (e.g., "thv:vmcp:session:").
-	KeyPrefix string
-
-	// DialTimeout is the timeout for establishing a connection. Defaults to 5s.
-	DialTimeout time.Duration
-
-	// ReadTimeout is the timeout for read operations. Defaults to 3s.
-	ReadTimeout time.Duration
-
-	// WriteTimeout is the timeout for write operations. Defaults to 3s.
-	WriteTimeout time.Duration
-
-	// TLS configures TLS for Redis connections. nil means plaintext.
-	TLS *RedisTLSConfig
-}
-
-// SentinelConfig contains Redis Sentinel configuration.
-type SentinelConfig struct {
-	MasterName    string
-	SentinelAddrs []string
-}
-
-// RedisTLSConfig holds TLS configuration for Redis connections.
-// Presence of this struct enables TLS for the connection.
-type RedisTLSConfig struct {
-	// InsecureSkipVerify skips TLS certificate verification.
-	InsecureSkipVerify bool
-
-	// CACert is the PEM-encoded CA certificate for verifying the server.
-	// When nil, the system root CAs are used.
-	CACert []byte
-}

--- a/pkg/transport/session/session_data_storage_redis.go
+++ b/pkg/transport/session/session_data_storage_redis.go
@@ -11,6 +11,8 @@ import (
 	"time"
 
 	"github.com/redis/go-redis/v9"
+
+	tcredis "github.com/stacklok/toolhive-core/redis"
 )
 
 // RedisSessionDataStorage implements DataStorage backed by Redis/Valkey.
@@ -27,23 +29,31 @@ type RedisSessionDataStorage struct {
 	ttl       time.Duration
 }
 
-// NewRedisSessionDataStorage constructs a RedisSessionDataStorage.
-// cfg provides connection parameters; ttl is the sliding-window expiry applied
-// on every Create/Update and Load. The caller must call Close when done.
-func NewRedisSessionDataStorage(ctx context.Context, cfg RedisConfig, ttl time.Duration) (*RedisSessionDataStorage, error) {
-	if err := validateRedisConfig(&cfg); err != nil {
-		return nil, fmt.Errorf("invalid redis configuration: %w", err)
+// NewRedisSessionDataStorage constructs a RedisSessionDataStorage. Connection-mode
+// topology, timeouts, TLS, and credentials are configured through cfg; keyPrefix
+// is the per-tenant key prefix (e.g. "thv:vmcp:session:") and must end with ':'
+// to avoid key collisions. ttl is the sliding-window expiry applied on every
+// Create/Update and Load. The caller must call Close when done.
+//
+// Connection-mode validation, timeout defaults, client construction (standalone,
+// cluster, or sentinel), TLS plumbing, and connectivity verification are
+// delegated to the shared toolhive-core redis package.
+func NewRedisSessionDataStorage(
+	ctx context.Context,
+	cfg tcredis.Config,
+	keyPrefix string,
+	ttl time.Duration,
+) (*RedisSessionDataStorage, error) {
+	if err := validateSessionInvariants(keyPrefix, ttl); err != nil {
+		return nil, err
 	}
-	if ttl <= 0 {
-		return nil, fmt.Errorf("ttl must be a positive duration")
-	}
-	client, err := buildRedisClient(ctx, &cfg)
+	client, err := tcredis.NewClient(ctx, &cfg)
 	if err != nil {
 		return nil, err
 	}
 	return &RedisSessionDataStorage{
 		client:    client,
-		keyPrefix: cfg.KeyPrefix,
+		keyPrefix: keyPrefix,
 		ttl:       ttl,
 	}, nil
 }

--- a/pkg/transport/session/storage_redis.go
+++ b/pkg/transport/session/storage_redis.go
@@ -5,13 +5,13 @@ package session
 
 import (
 	"context"
-	"crypto/tls"
-	"crypto/x509"
 	"errors"
 	"fmt"
 	"time"
 
 	"github.com/redis/go-redis/v9"
+
+	tcredis "github.com/stacklok/toolhive-core/redis"
 )
 
 // RedisStorage implements the Storage interface backed by Redis.
@@ -21,107 +21,33 @@ type RedisStorage struct {
 	ttl       time.Duration
 }
 
-func validateRedisConfig(cfg *RedisConfig) error {
-	if cfg.Addr != "" && cfg.SentinelConfig != nil {
-		return errors.New("addr and SentinelConfig are mutually exclusive")
+// NewRedisStorage constructs a RedisStorage. Connection-mode topology, timeouts,
+// TLS, and credentials are configured through cfg; keyPrefix is the per-tenant
+// key prefix (e.g. "thv:proxy:session:") and must end with ':' to avoid key
+// collisions. ttl is the sliding-window expiry applied to every key on Store
+// and refreshed on every Load (sliding window): sessions remain valid
+// indefinitely while actively used; revocation requires an explicit Delete call.
+//
+// Connection-mode validation, timeout defaults, client construction (standalone,
+// cluster, or sentinel), TLS plumbing, and connectivity verification are
+// delegated to the shared toolhive-core redis package.
+func NewRedisStorage(ctx context.Context, cfg tcredis.Config, keyPrefix string, ttl time.Duration) (*RedisStorage, error) {
+	if err := validateSessionInvariants(keyPrefix, ttl); err != nil {
+		return nil, err
 	}
-	if cfg.Addr == "" && cfg.SentinelConfig == nil {
-		return errors.New("one of Addr (standalone) or SentinelConfig (sentinel) must be set")
-	}
-	if cfg.SentinelConfig != nil {
-		if cfg.SentinelConfig.MasterName == "" {
-			return errors.New("SentinelConfig.MasterName is required")
-		}
-		if len(cfg.SentinelConfig.SentinelAddrs) == 0 {
-			return errors.New("SentinelConfig.SentinelAddrs must not be empty")
-		}
-	}
-	if cfg.KeyPrefix == "" {
-		return errors.New("KeyPrefix is required")
-	}
-	if cfg.KeyPrefix[len(cfg.KeyPrefix)-1] != ':' {
-		return errors.New("KeyPrefix must end with ':' to avoid key collisions (e.g. \"thv:vmcp:session:\")")
-	}
-	return nil
-}
-
-// NewRedisStorage constructs a RedisStorage from a RedisConfig.
-// ttl is the expiry applied to every key on Store and refreshed on every Load (sliding window).
-// Because TTL is sliding, sessions remain valid indefinitely while actively used; revocation
-// requires an explicit Delete call. There is no absolute maximum session lifetime.
-func NewRedisStorage(ctx context.Context, cfg RedisConfig, ttl time.Duration) (*RedisStorage, error) {
-	if err := validateRedisConfig(&cfg); err != nil {
-		return nil, fmt.Errorf("invalid redis configuration: %w", err)
-	}
-	if ttl <= 0 {
-		return nil, fmt.Errorf("ttl must be a positive duration")
-	}
-	client, err := buildRedisClient(ctx, &cfg)
+	client, err := tcredis.NewClient(ctx, &cfg)
 	if err != nil {
 		return nil, err
 	}
 	return &RedisStorage{
 		client:    client,
-		keyPrefix: cfg.KeyPrefix,
+		keyPrefix: keyPrefix,
 		ttl:       ttl,
 	}, nil
 }
 
-// buildRedisClient applies timeout defaults, resolves TLS, constructs either a
-// standalone or Sentinel client from cfg, and verifies the connection with Ping.
-// cfg is modified in place (timeout defaults written back).
-func buildRedisClient(ctx context.Context, cfg *RedisConfig) (redis.UniversalClient, error) {
-	if cfg.DialTimeout == 0 {
-		cfg.DialTimeout = DefaultDialTimeout
-	}
-	if cfg.ReadTimeout == 0 {
-		cfg.ReadTimeout = DefaultReadTimeout
-	}
-	if cfg.WriteTimeout == 0 {
-		cfg.WriteTimeout = DefaultWriteTimeout
-	}
-
-	tlsCfg, err := buildRedisTLSConfig(cfg.TLS)
-	if err != nil {
-		return nil, fmt.Errorf("tls configuration error: %w", err)
-	}
-
-	var client redis.UniversalClient
-	if cfg.SentinelConfig != nil {
-		client = redis.NewFailoverClient(&redis.FailoverOptions{
-			MasterName:    cfg.SentinelConfig.MasterName,
-			SentinelAddrs: cfg.SentinelConfig.SentinelAddrs,
-			Username:      cfg.Username,
-			Password:      cfg.Password,
-			DB:            cfg.DB,
-			DialTimeout:   cfg.DialTimeout,
-			ReadTimeout:   cfg.ReadTimeout,
-			WriteTimeout:  cfg.WriteTimeout,
-			TLSConfig:     tlsCfg,
-		})
-	} else {
-		client = redis.NewClient(&redis.Options{
-			Addr:         cfg.Addr,
-			Username:     cfg.Username,
-			Password:     cfg.Password,
-			DB:           cfg.DB,
-			DialTimeout:  cfg.DialTimeout,
-			ReadTimeout:  cfg.ReadTimeout,
-			WriteTimeout: cfg.WriteTimeout,
-			TLSConfig:    tlsCfg,
-		})
-	}
-
-	if err := client.Ping(ctx).Err(); err != nil {
-		_ = client.Close()
-		return nil, fmt.Errorf("failed to connect to redis: %w", err)
-	}
-	return client, nil
-}
-
 // newRedisStorageWithClient creates a RedisStorage with a pre-configured client.
-// Intended for tests only (bypasses config validation and Ping); production callers
-// must use NewRedisStorage.
+// Intended for tests only (bypasses Ping); production callers must use NewRedisStorage.
 func newRedisStorageWithClient(client redis.UniversalClient, keyPrefix string, ttl time.Duration) *RedisStorage {
 	return &RedisStorage{
 		client:    client,
@@ -130,23 +56,22 @@ func newRedisStorageWithClient(client redis.UniversalClient, keyPrefix string, t
 	}
 }
 
-// buildRedisTLSConfig creates a *tls.Config from a RedisTLSConfig.
-func buildRedisTLSConfig(cfg *RedisTLSConfig) (*tls.Config, error) {
-	if cfg == nil {
-		return nil, nil
+// validateSessionInvariants checks the per-storage invariants that the shared
+// toolhive-core redis package does not enforce (key-prefix conventions, TTL
+// bounds).
+func validateSessionInvariants(keyPrefix string, ttl time.Duration) error {
+	if keyPrefix == "" {
+		return errors.New("invalid redis configuration: key prefix is required")
 	}
-	tc := &tls.Config{
-		MinVersion:         tls.VersionTLS12,
-		InsecureSkipVerify: cfg.InsecureSkipVerify, //nolint:gosec // G402: configurable per-deployment
+	if keyPrefix[len(keyPrefix)-1] != ':' {
+		return errors.New(
+			`invalid redis configuration: key prefix must end with ':' to avoid key collisions (e.g. "thv:vmcp:session:")`,
+		)
 	}
-	if len(cfg.CACert) > 0 {
-		pool := x509.NewCertPool()
-		if !pool.AppendCertsFromPEM(cfg.CACert) {
-			return nil, fmt.Errorf("failed to parse CA certificate PEM data")
-		}
-		tc.RootCAs = pool
+	if ttl <= 0 {
+		return fmt.Errorf("ttl must be a positive duration")
 	}
-	return tc, nil
+	return nil
 }
 
 func (s *RedisStorage) key(id string) string {

--- a/pkg/transport/session/storage_redis_test.go
+++ b/pkg/transport/session/storage_redis_test.go
@@ -16,6 +16,8 @@ import (
 	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	tcredis "github.com/stacklok/toolhive-core/redis"
 )
 
 // --- Test Helpers ---
@@ -44,65 +46,60 @@ func withRedisStorage(t *testing.T, fn func(context.Context, *RedisStorage, *min
 }
 
 // --- Config Validation Tests ---
+//
+// Connection-mode topology, TLS plumbing, and timeout defaults are validated by
+// the shared toolhive-core redis package and are exercised in its own test
+// suite. The cases below cover only the session-specific invariants enforced
+// by NewRedisStorage (key prefix conventions, TTL bounds, ACL pass-through).
 
-func TestValidateRedisConfig(t *testing.T) {
+func TestNewRedisStorageInvariants(t *testing.T) {
 	t.Parallel()
 
+	// These cases fail in validateSessionInvariants before any Redis call, so
+	// the Addr below is never dialed.
 	tests := []struct {
-		name    string
-		cfg     RedisConfig
-		wantErr string
+		name      string
+		keyPrefix string
+		ttl       time.Duration
+		wantErr   string
 	}{
 		{
-			name:    "both Addr and SentinelConfig set",
-			cfg:     RedisConfig{Addr: "localhost:6379", SentinelConfig: &SentinelConfig{MasterName: "m", SentinelAddrs: []string{"s:26379"}}, KeyPrefix: "p:"},
-			wantErr: "mutually exclusive",
+			name:      "empty key prefix",
+			keyPrefix: "",
+			ttl:       time.Minute,
+			wantErr:   "key prefix is required",
 		},
 		{
-			name:    "neither Addr nor SentinelConfig set",
-			cfg:     RedisConfig{KeyPrefix: "p:"},
-			wantErr: "one of Addr",
+			name:      "key prefix without trailing colon",
+			keyPrefix: "thvsession",
+			ttl:       time.Minute,
+			wantErr:   "must end with ':'",
 		},
 		{
-			name:    "Sentinel missing MasterName",
-			cfg:     RedisConfig{SentinelConfig: &SentinelConfig{SentinelAddrs: []string{"s:26379"}}, KeyPrefix: "p:"},
-			wantErr: "MasterName",
+			name:      "zero ttl",
+			keyPrefix: "test:",
+			ttl:       0,
+			wantErr:   "ttl",
 		},
 		{
-			name:    "Sentinel missing SentinelAddrs",
-			cfg:     RedisConfig{SentinelConfig: &SentinelConfig{MasterName: "m"}, KeyPrefix: "p:"},
-			wantErr: "SentinelAddrs",
-		},
-		{
-			name:    "empty KeyPrefix",
-			cfg:     RedisConfig{Addr: "localhost:6379"},
-			wantErr: "KeyPrefix",
-		},
-		{
-			name:    "KeyPrefix without trailing colon",
-			cfg:     RedisConfig{Addr: "localhost:6379", KeyPrefix: "thvsession"},
-			wantErr: "must end with ':'",
-		},
-		{
-			name: "valid standalone",
-			cfg:  RedisConfig{Addr: "localhost:6379", KeyPrefix: "thv:vmcp:session:"},
-		},
-		{
-			name: "valid sentinel",
-			cfg:  RedisConfig{SentinelConfig: &SentinelConfig{MasterName: "m", SentinelAddrs: []string{"s:26379"}}, KeyPrefix: "thv:vmcp:session:"},
+			name:      "negative ttl",
+			keyPrefix: "test:",
+			ttl:       -1 * time.Second,
+			wantErr:   "ttl",
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			err := validateRedisConfig(&tc.cfg)
-			if tc.wantErr == "" {
-				assert.NoError(t, err)
-			} else {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tc.wantErr)
-			}
+			_, err := NewRedisStorage(
+				context.Background(),
+				tcredis.Config{Addr: "localhost:0"},
+				tc.keyPrefix,
+				tc.ttl,
+			)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
 		})
 	}
 }
@@ -116,12 +113,11 @@ func TestNewRedisStorageACLAuth(t *testing.T) {
 		defer mr.Close()
 		mr.RequireUserAuth("alice", "secret")
 
-		storage, err := NewRedisStorage(context.Background(), RedisConfig{
-			Addr:      mr.Addr(),
-			KeyPrefix: "test:acl:",
-			Username:  "alice",
-			Password:  "secret",
-		}, time.Minute)
+		storage, err := NewRedisStorage(context.Background(), tcredis.Config{
+			Addr:     mr.Addr(),
+			Username: "alice",
+			Password: "secret",
+		}, "test:acl:", time.Minute)
 		require.NoError(t, err)
 		defer storage.Close()
 
@@ -139,30 +135,14 @@ func TestNewRedisStorageACLAuth(t *testing.T) {
 		defer mr.Close()
 		mr.RequireUserAuth("alice", "secret")
 
-		_, err := NewRedisStorage(context.Background(), RedisConfig{
-			Addr:      mr.Addr(),
-			KeyPrefix: "test:acl:",
-			Username:  "alice",
-			Password:  "wrong",
-		}, time.Minute)
+		_, err := NewRedisStorage(context.Background(), tcredis.Config{
+			Addr:     mr.Addr(),
+			Username: "alice",
+			Password: "wrong",
+		}, "test:acl:", time.Minute)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "failed to connect to redis")
+		assert.Contains(t, err.Error(), "failed to connect")
 	})
-}
-
-func TestNewRedisStorageTTLValidation(t *testing.T) {
-	t.Parallel()
-	mr := miniredis.RunT(t)
-	defer mr.Close()
-	cfg := RedisConfig{Addr: mr.Addr(), KeyPrefix: "test:"}
-
-	_, err := NewRedisStorage(context.Background(), cfg, 0)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "ttl")
-
-	_, err = NewRedisStorage(context.Background(), cfg, -1*time.Second)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "ttl")
 }
 
 // redisTestIDs holds fixed UUIDs for use across Redis storage tests.

--- a/pkg/vmcp/server/server.go
+++ b/pkg/vmcp/server/server.go
@@ -24,6 +24,7 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 
+	tcredis "github.com/stacklok/toolhive-core/redis"
 	"github.com/stacklok/toolhive/pkg/audit"
 	"github.com/stacklok/toolhive/pkg/auth"
 	asrunner "github.com/stacklok/toolhive/pkg/authserver/runner"
@@ -277,18 +278,17 @@ func buildSessionDataStorage(ctx context.Context, cfg *Config) (transportsession
 	if keyPrefix == "" {
 		keyPrefix = "thv:vmcp:session:"
 	}
-	redisCfg := transportsession.RedisConfig{
-		Addr:      cfg.SessionStorage.Address,
-		Password:  os.Getenv(vmcpconfig.RedisPasswordEnvVar),
-		DB:        int(cfg.SessionStorage.DB),
-		KeyPrefix: keyPrefix,
+	redisCfg := tcredis.Config{
+		Addr:     cfg.SessionStorage.Address,
+		Password: os.Getenv(vmcpconfig.RedisPasswordEnvVar),
+		DB:       int(cfg.SessionStorage.DB),
 	}
 	slog.Info("using Redis session storage",
 		"address", cfg.SessionStorage.Address,
 		"db", cfg.SessionStorage.DB,
 		"key_prefix", keyPrefix,
 	)
-	return transportsession.NewRedisSessionDataStorage(ctx, redisCfg, cfg.SessionTTL)
+	return transportsession.NewRedisSessionDataStorage(ctx, redisCfg, keyPrefix, cfg.SessionTTL)
 }
 
 // New creates a new Virtual MCP Server instance.

--- a/pkg/vmcp/server/sessionmanager/horizontal_scaling_integration_test.go
+++ b/pkg/vmcp/server/sessionmanager/horizontal_scaling_integration_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	tcredis "github.com/stacklok/toolhive-core/redis"
 	"github.com/stacklok/toolhive/pkg/auth"
 	transportsession "github.com/stacklok/toolhive/pkg/transport/session"
 	"github.com/stacklok/toolhive/pkg/vmcp"
@@ -50,10 +51,10 @@ func newSharedRedisStorage(t *testing.T, mr *miniredis.Miniredis) transportsessi
 	t.Helper()
 	storage, err := transportsession.NewRedisSessionDataStorage(
 		context.Background(),
-		transportsession.RedisConfig{
-			Addr:      mr.Addr(),
-			KeyPrefix: "test:vmcp:session:",
+		tcredis.Config{
+			Addr: mr.Addr(),
 		},
+		"test:vmcp:session:",
 		time.Hour,
 	)
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

`pkg/transport/session` carried its own Redis connection layer (`RedisConfig`, `SentinelConfig`, `RedisTLSConfig`, `validateRedisConfig`, `buildRedisClient`, `buildRedisTLSConfig`, timeout default constants) that duplicated what toolhive-core v0.0.21 ships. PR #5318 migrated the auth server onto the shared package; vmcp session storage and the proxy-runner session storage are the remaining in-repo consumers, so this PR finishes that migration.

- Replace the local `RedisConfig`/`SentinelConfig`/`RedisTLSConfig` types and the `validate*`/`build*` helpers with `tcredis.Config` and `tcredis.NewClient`. `NewRedisStorage` and `NewRedisSessionDataStorage` now take `(ctx, tcredis.Config, keyPrefix, ttl)`; they keep the session-specific invariants (key prefix required, must end with `:`, `ttl > 0`) and delegate connection-mode validation, timeout defaults, TLS plumbing, and Ping verification to the shared package.
- `NewManagerWithRedis` gains the same `keyPrefix` parameter so the wrapper matches the underlying storage signature. The vmcp server and proxy runner call sites build a `tcredis.Config` in place and pass `keyPrefix` separately; `RedisPasswordEnvVar` stays in the session package because `pkg/runner` reads it.
- Tests: `TestValidateRedisConfig` is removed (topology checks now live in tcredis) and replaced by `TestNewRedisStorageInvariants`, which covers the session-specific cases (key prefix and ttl). `TestNewRedisStorageACLAuth` is preserved with the new signature. The "invalid TLS CA cert" manager subtest is dropped — it now exercises tcredis code.

Net result: -298 / +165 lines across 9 files; one source of Redis-connection truth shared with the auth server.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Code refactor
- [ ] Configuration change
- [ ] Documentation update
- [ ] Other

## Test plan

- [x] Manual verification by running `go test ./pkg/transport/session/... ./pkg/vmcp/server/... ./pkg/vmcp/server/sessionmanager/... ./pkg/runner/retriever/...` — all pass.
- [x] `golangci-lint` on the changed packages reports 0 issues.
- [x] Confirmed `pkg/runner`'s `TestRunConfigBuilder_MetadataOverrides` failure reproduces on `main` without this diff, so it is pre-existing and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)