### PR TITLE
Preserve fresh per-request identity in vMCP backend transports

### DIFF
--- a/pkg/vmcp/client/client.go
+++ b/pkg/vmcp/client/client.go
@@ -177,31 +177,68 @@ func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return f(req)
 }
 
-// identityPropagatingRoundTripper propagates identity and health-check markers to backend HTTP requests.
-// This ensures that identity information from the vMCP handler is available for authentication
-// strategies that need it (e.g., token exchange).
+// identityPropagatingRoundTripper propagates the health-check marker and a
+// fallback identity to backend HTTP requests.
 //
-// The health-check marker is stored at transport creation time and re-injected into every
-// outgoing request, including the DELETE that mcp-go sends when closing a streamable-HTTP
-// session. Without this, mcp-go's Close() creates a fresh context.Background()-based request
-// that loses the health-check marker, causing auth strategies (UpstreamInjectStrategy,
-// TokenExchangeStrategy) to fail with "no identity found in context".
+// Identity invariant: an identity already present on req.Context() is NEVER
+// overridden. The per-request identity placed on the request context by
+// auth.TokenValidator.Middleware carries the freshest upstream tokens (the
+// middleware refreshes them transparently on every incoming request via
+// upstreamtoken.InProcessService.GetAllValidTokens). Overriding it with a
+// snapshot captured at session-init time would silently re-inject stale
+// upstream access tokens on every backend call, forcing users to re-auth
+// once the captured access token expired (see issue #5323).
+//
+// The fallback identity is used only when req.Context() carries no identity
+// at all. This covers mcp-go's streamable-HTTP Close() path, which constructs
+// its DELETE request from context.Background() and therefore loses any
+// identity attached to the original tool-call context. Without a fallback,
+// auth strategies (UpstreamInjectStrategy, TokenExchangeStrategy, AWSSTSStrategy)
+// would reject the teardown DELETE with "no identity found in context" — the
+// teardown would still complete locally, but the upstream backend would see
+// an unauthenticated DELETE. The fallback may itself be stale, which is
+// acceptable for a session-close: the request is best-effort and any 401
+// from the upstream does not affect functional behavior.
+//
+// The health-check marker is similarly captured at transport creation time and
+// re-injected into every outgoing request — including the Close() DELETE — so
+// that auth strategies correctly skip authentication for health probes even
+// when the request context has been replaced with context.Background().
 type identityPropagatingRoundTripper struct {
-	base          http.RoundTripper
-	identity      *auth.Identity
-	isHealthCheck bool
+	base http.RoundTripper
+	// fallbackIdentity is injected only when req.Context() carries no identity.
+	// It must never override a non-nil identity present on the request context.
+	fallbackIdentity *auth.Identity
+	isHealthCheck    bool
 }
 
-// RoundTrip implements http.RoundTripper by adding identity and health-check marker to the request context.
+// RoundTrip implements http.RoundTripper.
+//
+// It preserves any identity already present on req.Context() (the fresh,
+// per-request identity placed there by TokenValidator.Middleware). When the
+// request context carries no identity — for example, mcp-go's Close() DELETE
+// is constructed from context.Background() — the captured fallback identity
+// is injected so session-teardown requests can still authenticate. The
+// health-check marker is always re-injected when configured.
 func (i *identityPropagatingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	ctx := req.Context()
-	if i.identity != nil {
-		ctx = auth.WithIdentity(ctx, i.identity)
+	mutated := false
+
+	// Inject the fallback identity ONLY when the request context carries no
+	// identity. We must never overwrite a non-nil identity already on ctx —
+	// doing so would clobber the freshly refreshed upstream tokens that the
+	// auth middleware places on every incoming request (see #5323).
+	if _, hasIdentity := auth.IdentityFromContext(ctx); !hasIdentity && i.fallbackIdentity != nil {
+		ctx = auth.WithIdentity(ctx, i.fallbackIdentity)
+		mutated = true
 	}
+
 	if i.isHealthCheck {
 		ctx = healthcontext.WithHealthCheckMarker(ctx)
+		mutated = true
 	}
-	if i.identity != nil || i.isHealthCheck {
+
+	if mutated {
 		req = req.Clone(ctx)
 	}
 	return i.base.RoundTrip(req)
@@ -314,16 +351,22 @@ func (h *httpBackendClient) defaultClientFactory(ctx context.Context, target *vm
 		return nil, fmt.Errorf("failed to build header-forward transport: %w", err)
 	}
 
-	// Extract identity and health-check marker from context and propagate them to backend
-	// requests. The health-check marker must be carried through to the DELETE request that
-	// mcp-go emits when closing a streamable-HTTP session: mcp-go creates that request with
-	// context.Background(), which loses both the identity and the health-check marker that
-	// were present on the original ListCapabilities call context.
-	identity, _ := auth.IdentityFromContext(ctx)
+	// Capture a fallback identity and the health-check marker from the construction
+	// context. These are used ONLY when the per-request context lacks them:
+	//
+	//   - Normal backend requests inherit the fresh, per-request identity placed on
+	//     the request context by auth.TokenValidator.Middleware. The transport
+	//     preserves it untouched so upstream-token refresh is not bypassed (#5323).
+	//
+	//   - mcp-go's streamable-HTTP Close() builds its DELETE from context.Background(),
+	//     which loses both the identity and the health-check marker. Re-injecting them
+	//     here keeps the teardown DELETE authenticated and tagged as a health-check
+	//     probe when the original session was a probe (#4613).
+	fallbackIdentity, _ := auth.IdentityFromContext(ctx)
 	baseTransport = &identityPropagatingRoundTripper{
-		base:          baseTransport,
-		identity:      identity,
-		isHealthCheck: healthcontext.IsHealthCheck(ctx),
+		base:             baseTransport,
+		fallbackIdentity: fallbackIdentity,
+		isHealthCheck:    healthcontext.IsHealthCheck(ctx),
 	}
 
 	// Inject W3C Trace Context headers (traceparent/tracestate) into outgoing requests.

--- a/pkg/vmcp/client/client.go
+++ b/pkg/vmcp/client/client.go
@@ -204,10 +204,21 @@ func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 // re-injected into every outgoing request — including the Close() DELETE — so
 // that auth strategies correctly skip authentication for health probes even
 // when the request context has been replaced with context.Background().
+//
+// This is the canonical location for the #5323 fallback-only identity
+// invariant. A near-clone exists at identityRoundTripper in
+// pkg/vmcp/session/internal/backend/mcp_session.go (without isHealthCheck
+// support, since health probes do not flow through the session-backed
+// connector). Keep the invariant in sync across both implementations until
+// #5333 lands a shared transport.
 type identityPropagatingRoundTripper struct {
 	base http.RoundTripper
 	// fallbackIdentity is injected only when req.Context() carries no identity.
 	// It must never override a non-nil identity present on the request context.
+	//
+	// Shared across all concurrent RoundTrip invocations on this transport; the
+	// pointed-to *auth.Identity (including UpstreamTokens) MUST be treated as
+	// immutable — see pkg/auth/identity.go.
 	fallbackIdentity *auth.Identity
 	isHealthCheck    bool
 }

--- a/pkg/vmcp/client/client.go
+++ b/pkg/vmcp/client/client.go
@@ -368,13 +368,20 @@ func (h *httpBackendClient) defaultClientFactory(ctx context.Context, target *vm
 	// Scope note: httpBackendClient calls this factory on every CallTool /
 	// ReadResource / GetPrompt / ListCapabilities with the per-call context, so
 	// the captured "fallback" is per-call, not per-session, in this path. The
-	// fallback is therefore functionally only required to keep mcp-go's
-	// Close() DELETE — which is built from context.Background() and loses any
-	// identity attached to the original call context — authenticated. The
-	// always-stale capture-at-session-init behavior that caused #5323 lives
-	// in the persistent-session path (pkg/vmcp/session/internal/backend); this
+	// always-stale capture-at-session-init behavior that caused #5323 lives in
+	// the persistent-session path (pkg/vmcp/session/internal/backend); this
 	// transport uses the same RoundTripper out of consistency, not because it
 	// suffered the same bug.
+	//
+	// Fallback injection scope: the round-tripper injects the captured fallback
+	// identity on ANY outgoing request whose context lacks an identity — not
+	// only the teardown DELETE. In the current code paths the only known caller
+	// that drops the per-request identity is mcp-go's streamable-HTTP Close()
+	// (which builds its DELETE from context.Background()), so in practice the
+	// fallback only fires for teardown. If a future code path wraps the client
+	// with a context that doesn't carry identity (audit, telemetry, background
+	// reconciliation), it will be silently authenticated using the captured
+	// snapshot. Add an explicit method/URL gate if that becomes undesirable.
 	//
 	//   - Normal backend requests inherit the fresh, per-request identity placed on
 	//     the request context by auth.TokenValidator.Middleware. The transport

--- a/pkg/vmcp/client/client.go
+++ b/pkg/vmcp/client/client.go
@@ -352,7 +352,18 @@ func (h *httpBackendClient) defaultClientFactory(ctx context.Context, target *vm
 	}
 
 	// Capture a fallback identity and the health-check marker from the construction
-	// context. These are used ONLY when the per-request context lacks them:
+	// context. These are used ONLY when the per-request context lacks them.
+	//
+	// Scope note: httpBackendClient calls this factory on every CallTool /
+	// ReadResource / GetPrompt / ListCapabilities with the per-call context, so
+	// the captured "fallback" is per-call, not per-session, in this path. The
+	// fallback is therefore functionally only required to keep mcp-go's
+	// Close() DELETE — which is built from context.Background() and loses any
+	// identity attached to the original call context — authenticated. The
+	// always-stale capture-at-session-init behavior that caused #5323 lives
+	// in the persistent-session path (pkg/vmcp/session/internal/backend); this
+	// transport uses the same RoundTripper out of consistency, not because it
+	// suffered the same bug.
 	//
 	//   - Normal backend requests inherit the fresh, per-request identity placed on
 	//     the request context by auth.TokenValidator.Middleware. The transport

--- a/pkg/vmcp/client/client_test.go
+++ b/pkg/vmcp/client/client_test.go
@@ -1055,15 +1055,8 @@ func TestWrapBackendError(t *testing.T) {
 // identityPropagatingRoundTripper
 // ---------------------------------------------------------------------------
 //
-// Design invariant (see issue #5323): the per-request identity placed on
-// req.Context() by auth.TokenValidator.Middleware is THE canonical source of
-// identity for outgoing backend requests. It carries upstream tokens that the
-// middleware transparently refreshes per request. The captured fallback
-// identity is a teardown-DELETE escape hatch only — it covers the case where
-// mcp-go's Close() builds its DELETE from context.Background() and loses the
-// per-request identity. The fallback MUST NEVER override a non-nil identity
-// already present on req.Context(); doing so silently re-injects stale tokens
-// and is the bug fixed by #5323.
+// See identityPropagatingRoundTripper in pkg/vmcp/client/client.go for the
+// canonical description of the #5323 fallback-only identity invariant.
 //
 // Tests below are grouped to reflect this hierarchy:
 //   1. Per-request identity (normal path)            — *_PerRequestIdentity_*

--- a/pkg/vmcp/client/client_test.go
+++ b/pkg/vmcp/client/client_test.go
@@ -1055,12 +1055,15 @@ func TestWrapBackendError(t *testing.T) {
 // identityPropagatingRoundTripper
 // ---------------------------------------------------------------------------
 
-func TestIdentityPropagatingRoundTripper_WithIdentity_PropagatesIdentityInContext(t *testing.T) {
+// TestIdentityPropagatingRoundTripper_FallbackIdentity_InjectedWhenContextLacksIdentity
+// verifies that the fallback identity is injected when req.Context() carries no
+// identity (e.g. mcp-go's Close() DELETE built from context.Background()).
+func TestIdentityPropagatingRoundTripper_FallbackIdentity_InjectedWhenContextLacksIdentity(t *testing.T) {
 	t.Parallel()
 
 	base := &mockRoundTripper{response: &http.Response{StatusCode: http.StatusOK}}
-	identity := &pkgauth.Identity{PrincipalInfo: pkgauth.PrincipalInfo{Subject: "user-1"}}
-	rt := &identityPropagatingRoundTripper{base: base, identity: identity}
+	fallback := &pkgauth.Identity{PrincipalInfo: pkgauth.PrincipalInfo{Subject: "fallback-user"}}
+	rt := &identityPropagatingRoundTripper{base: base, fallbackIdentity: fallback}
 
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://backend.example.com/mcp", nil)
 	require.NoError(t, err)
@@ -1070,15 +1073,83 @@ func TestIdentityPropagatingRoundTripper_WithIdentity_PropagatesIdentityInContex
 
 	require.NotNil(t, base.capturedReq)
 	got, ok := pkgauth.IdentityFromContext(base.capturedReq.Context())
-	require.True(t, ok, "identity should be in downstream request context")
-	assert.Equal(t, "user-1", got.Subject)
+	require.True(t, ok, "fallback identity should be in downstream request context")
+	assert.Equal(t, "fallback-user", got.Subject)
 }
 
-func TestIdentityPropagatingRoundTripper_NilIdentity_NoIdentityInContext(t *testing.T) {
+// TestIdentityPropagatingRoundTripper_RequestContextIdentity_NotOverridden is the
+// regression test for issue #5323: a fresh identity already on req.Context() (placed
+// there by TokenValidator.Middleware on every incoming request) must survive the
+// transport untouched. Overriding it with a captured fallback would silently
+// re-inject stale upstream tokens on every backend call.
+func TestIdentityPropagatingRoundTripper_RequestContextIdentity_NotOverridden(t *testing.T) {
 	t.Parallel()
 
 	base := &mockRoundTripper{response: &http.Response{StatusCode: http.StatusOK}}
-	rt := &identityPropagatingRoundTripper{base: base, identity: nil}
+	stale := &pkgauth.Identity{
+		PrincipalInfo: pkgauth.PrincipalInfo{Subject: "stale-user"},
+		UpstreamTokens: map[string]string{
+			"provider": "stale-token",
+		},
+	}
+	rt := &identityPropagatingRoundTripper{base: base, fallbackIdentity: stale}
+
+	fresh := &pkgauth.Identity{
+		PrincipalInfo: pkgauth.PrincipalInfo{Subject: "fresh-user"},
+		UpstreamTokens: map[string]string{
+			"provider": "fresh-token",
+		},
+	}
+	ctx := pkgauth.WithIdentity(context.Background(), fresh)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "http://backend.example.com/mcp", nil)
+	require.NoError(t, err)
+
+	_, err = rt.RoundTrip(req)
+	require.NoError(t, err)
+
+	require.NotNil(t, base.capturedReq)
+	got, ok := pkgauth.IdentityFromContext(base.capturedReq.Context())
+	require.True(t, ok, "identity from req.Context() must be present downstream")
+	assert.Equal(t, "fresh-user", got.Subject,
+		"identity on req.Context() must not be overridden by the captured fallback (#5323)")
+	assert.Equal(t, "fresh-token", got.UpstreamTokens["provider"],
+		"fresh upstream tokens must reach auth strategies unchanged (#5323)")
+}
+
+// TestIdentityPropagatingRoundTripper_NoFallback_RequestContextIdentityPreserved
+// verifies the normal per-request flow: identity is on req.Context() (placed by
+// TokenValidator.Middleware), no fallback is configured, and the transport leaves
+// the identity untouched so the freshly refreshed upstream tokens reach the
+// downstream auth strategies.
+func TestIdentityPropagatingRoundTripper_NoFallback_RequestContextIdentityPreserved(t *testing.T) {
+	t.Parallel()
+
+	base := &mockRoundTripper{response: &http.Response{StatusCode: http.StatusOK}}
+	rt := &identityPropagatingRoundTripper{base: base, fallbackIdentity: nil}
+
+	fresh := &pkgauth.Identity{
+		PrincipalInfo:  pkgauth.PrincipalInfo{Subject: "fresh-user"},
+		UpstreamTokens: map[string]string{"provider": "fresh-token"},
+	}
+	ctx := pkgauth.WithIdentity(context.Background(), fresh)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "http://backend.example.com/mcp", nil)
+	require.NoError(t, err)
+
+	_, err = rt.RoundTrip(req)
+	require.NoError(t, err)
+
+	require.NotNil(t, base.capturedReq)
+	got, ok := pkgauth.IdentityFromContext(base.capturedReq.Context())
+	require.True(t, ok)
+	assert.Equal(t, "fresh-user", got.Subject)
+	assert.Equal(t, "fresh-token", got.UpstreamTokens["provider"])
+}
+
+func TestIdentityPropagatingRoundTripper_NilFallback_NoIdentityInContext(t *testing.T) {
+	t.Parallel()
+
+	base := &mockRoundTripper{response: &http.Response{StatusCode: http.StatusOK}}
+	rt := &identityPropagatingRoundTripper{base: base, fallbackIdentity: nil}
 
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://backend.example.com/mcp", nil)
 	require.NoError(t, err)
@@ -1088,14 +1159,14 @@ func TestIdentityPropagatingRoundTripper_NilIdentity_NoIdentityInContext(t *test
 
 	require.NotNil(t, base.capturedReq)
 	_, ok := pkgauth.IdentityFromContext(base.capturedReq.Context())
-	assert.False(t, ok, "no identity should be in downstream context when nil identity configured")
+	assert.False(t, ok, "no identity should be in downstream context when no fallback and no req-ctx identity")
 }
 
 func TestIdentityPropagatingRoundTripper_HealthCheck_PropagatesMarker(t *testing.T) {
 	t.Parallel()
 
 	base := &mockRoundTripper{response: &http.Response{StatusCode: http.StatusOK}}
-	rt := &identityPropagatingRoundTripper{base: base, identity: nil, isHealthCheck: true}
+	rt := &identityPropagatingRoundTripper{base: base, fallbackIdentity: nil, isHealthCheck: true}
 
 	// Simulate mcp-go Close(): request created with context.Background(), no health check marker.
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodDelete, "http://backend.example.com/mcp", nil)
@@ -1113,7 +1184,7 @@ func TestIdentityPropagatingRoundTripper_NonHealthCheck_NoMarkerAdded(t *testing
 	t.Parallel()
 
 	base := &mockRoundTripper{response: &http.Response{StatusCode: http.StatusOK}}
-	rt := &identityPropagatingRoundTripper{base: base, identity: nil, isHealthCheck: false}
+	rt := &identityPropagatingRoundTripper{base: base, fallbackIdentity: nil, isHealthCheck: false}
 
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://backend.example.com/mcp", nil)
 	require.NoError(t, err)
@@ -1126,12 +1197,12 @@ func TestIdentityPropagatingRoundTripper_NonHealthCheck_NoMarkerAdded(t *testing
 		"health check marker should not be injected for non-health-check transports")
 }
 
-func TestIdentityPropagatingRoundTripper_HealthCheckWithIdentity_PropagatesBoth(t *testing.T) {
+func TestIdentityPropagatingRoundTripper_HealthCheckWithFallbackIdentity_PropagatesBoth(t *testing.T) {
 	t.Parallel()
 
 	base := &mockRoundTripper{response: &http.Response{StatusCode: http.StatusOK}}
 	identity := &pkgauth.Identity{PrincipalInfo: pkgauth.PrincipalInfo{Subject: "svc-account"}}
-	rt := &identityPropagatingRoundTripper{base: base, identity: identity, isHealthCheck: true}
+	rt := &identityPropagatingRoundTripper{base: base, fallbackIdentity: identity, isHealthCheck: true}
 
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://backend.example.com/mcp", nil)
 	require.NoError(t, err)
@@ -1155,7 +1226,7 @@ func TestIdentityPropagatingRoundTripper_HealthCheckClose_OriginalRequestContext
 	t.Parallel()
 
 	base := &mockRoundTripper{response: &http.Response{StatusCode: http.StatusOK}}
-	rt := &identityPropagatingRoundTripper{base: base, identity: nil, isHealthCheck: true}
+	rt := &identityPropagatingRoundTripper{base: base, fallbackIdentity: nil, isHealthCheck: true}
 
 	originalCtx := context.Background() // no health check marker — simulates mcp-go Close()
 	req, err := http.NewRequestWithContext(originalCtx, http.MethodDelete, "http://backend.example.com/mcp", nil)

--- a/pkg/vmcp/client/client_test.go
+++ b/pkg/vmcp/client/client_test.go
@@ -1054,18 +1054,42 @@ func TestWrapBackendError(t *testing.T) {
 // ---------------------------------------------------------------------------
 // identityPropagatingRoundTripper
 // ---------------------------------------------------------------------------
+//
+// Design invariant (see issue #5323): the per-request identity placed on
+// req.Context() by auth.TokenValidator.Middleware is THE canonical source of
+// identity for outgoing backend requests. It carries upstream tokens that the
+// middleware transparently refreshes per request. The captured fallback
+// identity is a teardown-DELETE escape hatch only — it covers the case where
+// mcp-go's Close() builds its DELETE from context.Background() and loses the
+// per-request identity. The fallback MUST NEVER override a non-nil identity
+// already present on req.Context(); doing so silently re-injects stale tokens
+// and is the bug fixed by #5323.
+//
+// Tests below are grouped to reflect this hierarchy:
+//   1. Per-request identity (normal path)            — *_PerRequestIdentity_*
+//   2. Fallback identity (no-identity-on-context)    — *_FallbackIdentity_*
+//   3. Health-check marker propagation               — *_HealthCheck*
 
-// TestIdentityPropagatingRoundTripper_FallbackIdentity_InjectedWhenContextLacksIdentity
-// verifies that the fallback identity is injected when req.Context() carries no
-// identity (e.g. mcp-go's Close() DELETE built from context.Background()).
-func TestIdentityPropagatingRoundTripper_FallbackIdentity_InjectedWhenContextLacksIdentity(t *testing.T) {
+// --- Per-request identity (normal path) -----------------------------------
+
+// TestIdentityPropagatingRoundTripper_PerRequestIdentity_FlowsThroughUnchanged
+// verifies the normal per-request flow: identity is on req.Context() (placed by
+// TokenValidator.Middleware), no fallback is configured, and the transport leaves
+// the identity untouched so the freshly refreshed upstream tokens reach the
+// downstream auth strategies. This is the path taken on every authenticated
+// tool call.
+func TestIdentityPropagatingRoundTripper_PerRequestIdentity_FlowsThroughUnchanged(t *testing.T) {
 	t.Parallel()
 
 	base := &mockRoundTripper{response: &http.Response{StatusCode: http.StatusOK}}
-	fallback := &pkgauth.Identity{PrincipalInfo: pkgauth.PrincipalInfo{Subject: "fallback-user"}}
-	rt := &identityPropagatingRoundTripper{base: base, fallbackIdentity: fallback}
+	rt := &identityPropagatingRoundTripper{base: base, fallbackIdentity: nil}
 
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://backend.example.com/mcp", nil)
+	fresh := &pkgauth.Identity{
+		PrincipalInfo:  pkgauth.PrincipalInfo{Subject: "fresh-user"},
+		UpstreamTokens: map[string]string{"provider": "fresh-token"},
+	}
+	ctx := pkgauth.WithIdentity(context.Background(), fresh)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "http://backend.example.com/mcp", nil)
 	require.NoError(t, err)
 
 	_, err = rt.RoundTrip(req)
@@ -1073,16 +1097,18 @@ func TestIdentityPropagatingRoundTripper_FallbackIdentity_InjectedWhenContextLac
 
 	require.NotNil(t, base.capturedReq)
 	got, ok := pkgauth.IdentityFromContext(base.capturedReq.Context())
-	require.True(t, ok, "fallback identity should be in downstream request context")
-	assert.Equal(t, "fallback-user", got.Subject)
+	require.True(t, ok)
+	assert.Equal(t, "fresh-user", got.Subject)
+	assert.Equal(t, "fresh-token", got.UpstreamTokens["provider"])
 }
 
-// TestIdentityPropagatingRoundTripper_RequestContextIdentity_NotOverridden is the
-// regression test for issue #5323: a fresh identity already on req.Context() (placed
-// there by TokenValidator.Middleware on every incoming request) must survive the
-// transport untouched. Overriding it with a captured fallback would silently
-// re-inject stale upstream tokens on every backend call.
-func TestIdentityPropagatingRoundTripper_RequestContextIdentity_NotOverridden(t *testing.T) {
+// TestIdentityPropagatingRoundTripper_PerRequestIdentity_NotOverriddenByFallback
+// is the regression test for issue #5323: a fresh identity already on
+// req.Context() (placed there by TokenValidator.Middleware on every incoming
+// request) must survive the transport untouched, even when a stale fallback
+// identity is captured. Overriding it would silently re-inject stale upstream
+// tokens on every backend call and is exactly the bug this PR fixes.
+func TestIdentityPropagatingRoundTripper_PerRequestIdentity_NotOverriddenByFallback(t *testing.T) {
 	t.Parallel()
 
 	base := &mockRoundTripper{response: &http.Response{StatusCode: http.StatusOK}}
@@ -1116,23 +1142,19 @@ func TestIdentityPropagatingRoundTripper_RequestContextIdentity_NotOverridden(t 
 		"fresh upstream tokens must reach auth strategies unchanged (#5323)")
 }
 
-// TestIdentityPropagatingRoundTripper_NoFallback_RequestContextIdentityPreserved
-// verifies the normal per-request flow: identity is on req.Context() (placed by
-// TokenValidator.Middleware), no fallback is configured, and the transport leaves
-// the identity untouched so the freshly refreshed upstream tokens reach the
-// downstream auth strategies.
-func TestIdentityPropagatingRoundTripper_NoFallback_RequestContextIdentityPreserved(t *testing.T) {
+// --- Fallback identity (teardown / no-identity-on-context path) ------------
+
+// TestIdentityPropagatingRoundTripper_FallbackIdentity_InjectedWhenContextLacksIdentity
+// verifies that the fallback identity is injected when req.Context() carries no
+// identity (e.g. mcp-go's Close() DELETE built from context.Background()).
+func TestIdentityPropagatingRoundTripper_FallbackIdentity_InjectedWhenContextLacksIdentity(t *testing.T) {
 	t.Parallel()
 
 	base := &mockRoundTripper{response: &http.Response{StatusCode: http.StatusOK}}
-	rt := &identityPropagatingRoundTripper{base: base, fallbackIdentity: nil}
+	fallback := &pkgauth.Identity{PrincipalInfo: pkgauth.PrincipalInfo{Subject: "fallback-user"}}
+	rt := &identityPropagatingRoundTripper{base: base, fallbackIdentity: fallback}
 
-	fresh := &pkgauth.Identity{
-		PrincipalInfo:  pkgauth.PrincipalInfo{Subject: "fresh-user"},
-		UpstreamTokens: map[string]string{"provider": "fresh-token"},
-	}
-	ctx := pkgauth.WithIdentity(context.Background(), fresh)
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "http://backend.example.com/mcp", nil)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://backend.example.com/mcp", nil)
 	require.NoError(t, err)
 
 	_, err = rt.RoundTrip(req)
@@ -1140,12 +1162,11 @@ func TestIdentityPropagatingRoundTripper_NoFallback_RequestContextIdentityPreser
 
 	require.NotNil(t, base.capturedReq)
 	got, ok := pkgauth.IdentityFromContext(base.capturedReq.Context())
-	require.True(t, ok)
-	assert.Equal(t, "fresh-user", got.Subject)
-	assert.Equal(t, "fresh-token", got.UpstreamTokens["provider"])
+	require.True(t, ok, "fallback identity should be in downstream request context")
+	assert.Equal(t, "fallback-user", got.Subject)
 }
 
-func TestIdentityPropagatingRoundTripper_NilFallback_NoIdentityInContext(t *testing.T) {
+func TestIdentityPropagatingRoundTripper_FallbackIdentity_NilFallback_NoIdentityInContext(t *testing.T) {
 	t.Parallel()
 
 	base := &mockRoundTripper{response: &http.Response{StatusCode: http.StatusOK}}
@@ -1161,6 +1182,8 @@ func TestIdentityPropagatingRoundTripper_NilFallback_NoIdentityInContext(t *test
 	_, ok := pkgauth.IdentityFromContext(base.capturedReq.Context())
 	assert.False(t, ok, "no identity should be in downstream context when no fallback and no req-ctx identity")
 }
+
+// --- Health-check marker propagation ---------------------------------------
 
 func TestIdentityPropagatingRoundTripper_HealthCheck_PropagatesMarker(t *testing.T) {
 	t.Parallel()

--- a/pkg/vmcp/session/internal/backend/mcp_session.go
+++ b/pkg/vmcp/session/internal/backend/mcp_session.go
@@ -75,6 +75,14 @@ func (a *authRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 // context other than the per-request handler context (e.g. streamable-HTTP
 // Close() uses context.Background()). The fallback may itself be stale; that
 // is acceptable for the teardown DELETE since the request is best-effort.
+//
+// No health-check marker is re-injected here. Health probes do not flow through
+// session-backed clients — they go through the per-call client in
+// pkg/vmcp/client (whose identityPropagatingRoundTripper IS health-check aware).
+// If a future change routes health probes through this connector, the
+// isHealthCheck propagation pattern from pkg/vmcp/client/client.go must be
+// mirrored here so the Close() DELETE built from context.Background() retains
+// the marker.
 type identityRoundTripper struct {
 	base http.RoundTripper
 	// fallbackIdentity is injected only when req.Context() carries no identity.

--- a/pkg/vmcp/session/internal/backend/mcp_session.go
+++ b/pkg/vmcp/session/internal/backend/mcp_session.go
@@ -59,15 +59,34 @@ func (a *authRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 	return a.base.RoundTrip(reqClone)
 }
 
-// identityRoundTripper propagates the caller's identity to outgoing backend requests.
+// identityRoundTripper propagates a fallback identity to outgoing backend requests
+// when the request context carries none.
+//
+// Identity invariant: an identity already present on req.Context() is NEVER
+// overridden. The per-request identity placed on the request context by
+// auth.TokenValidator.Middleware carries the freshest upstream tokens
+// (transparently refreshed by upstreamtoken.InProcessService.GetAllValidTokens).
+// Overriding it with a snapshot captured at session-init time would silently
+// re-inject stale upstream access tokens on every backend call, forcing users
+// to re-auth once the captured access token expired (see issue #5323).
+//
+// The fallback identity is used only when req.Context() carries no identity at
+// all. This covers paths where the mcp-go transport constructs requests from a
+// context other than the per-request handler context (e.g. streamable-HTTP
+// Close() uses context.Background()). The fallback may itself be stale; that
+// is acceptable for the teardown DELETE since the request is best-effort.
 type identityRoundTripper struct {
-	base     http.RoundTripper
-	identity *auth.Identity
+	base http.RoundTripper
+	// fallbackIdentity is injected only when req.Context() carries no identity.
+	// It must never override a non-nil identity present on the request context.
+	fallbackIdentity *auth.Identity
 }
 
+// RoundTrip preserves any identity already on req.Context() and only injects
+// the captured fallback when the request context carries no identity.
 func (i *identityRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	if i.identity != nil {
-		ctx := auth.WithIdentity(req.Context(), i.identity)
+	if _, hasIdentity := auth.IdentityFromContext(req.Context()); !hasIdentity && i.fallbackIdentity != nil {
+		ctx := auth.WithIdentity(req.Context(), i.fallbackIdentity)
 		req = req.Clone(ctx)
 	}
 	return i.base.RoundTrip(req)
@@ -290,7 +309,12 @@ func createMCPClient(
 		authConfig:   target.AuthConfig,
 		target:       target,
 	}
-	base = &identityRoundTripper{base: base, identity: identity}
+	// The identity captured here is a fallback used only when the per-request
+	// context carries no identity (e.g. mcp-go's Close() DELETE built from
+	// context.Background()). Normal backend requests preserve the freshly
+	// refreshed identity placed on the request context by
+	// auth.TokenValidator.Middleware (see issue #5323).
+	base = &identityRoundTripper{base: base, fallbackIdentity: identity}
 	base, err = headerforward.BuildHeaderForwardTripper(ctx, base, target.HeaderForward, provider, target.WorkloadID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build header-forward transport for backend %s: %w", target.WorkloadID, err)

--- a/pkg/vmcp/session/internal/backend/mcp_session.go
+++ b/pkg/vmcp/session/internal/backend/mcp_session.go
@@ -59,34 +59,29 @@ func (a *authRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 	return a.base.RoundTrip(reqClone)
 }
 
-// identityRoundTripper propagates a fallback identity to outgoing backend requests
-// when the request context carries none.
+// identityRoundTripper propagates a fallback identity to outgoing backend
+// requests when the request context carries none. It is the session-backed
+// twin of identityPropagatingRoundTripper in pkg/vmcp/client/client.go, which
+// holds the canonical description of the #5323 fallback-only identity
+// invariant.
 //
-// Identity invariant: an identity already present on req.Context() is NEVER
-// overridden. The per-request identity placed on the request context by
-// auth.TokenValidator.Middleware carries the freshest upstream tokens
-// (transparently refreshed by upstreamtoken.InProcessService.GetAllValidTokens).
-// Overriding it with a snapshot captured at session-init time would silently
-// re-inject stale upstream access tokens on every backend call, forcing users
-// to re-auth once the captured access token expired (see issue #5323).
+// Differences from the canonical twin:
+//   - No isHealthCheck propagation. Health probes do not flow through
+//     session-backed clients — they go through the per-call client in
+//     pkg/vmcp/client. If a future change routes health probes through this
+//     connector, mirror the isHealthCheck pattern from client.go so the
+//     Close() DELETE built from context.Background() retains the marker.
 //
-// The fallback identity is used only when req.Context() carries no identity at
-// all. This covers paths where the mcp-go transport constructs requests from a
-// context other than the per-request handler context (e.g. streamable-HTTP
-// Close() uses context.Background()). The fallback may itself be stale; that
-// is acceptable for the teardown DELETE since the request is best-effort.
-//
-// No health-check marker is re-injected here. Health probes do not flow through
-// session-backed clients — they go through the per-call client in
-// pkg/vmcp/client (whose identityPropagatingRoundTripper IS health-check aware).
-// If a future change routes health probes through this connector, the
-// isHealthCheck propagation pattern from pkg/vmcp/client/client.go must be
-// mirrored here so the Close() DELETE built from context.Background() retains
-// the marker.
+// Consolidation is tracked by #5333; until then, keep the fallback-only
+// invariant in sync across both implementations.
 type identityRoundTripper struct {
 	base http.RoundTripper
 	// fallbackIdentity is injected only when req.Context() carries no identity.
 	// It must never override a non-nil identity present on the request context.
+	//
+	// Shared across all concurrent RoundTrip invocations on this transport; the
+	// pointed-to *auth.Identity (including UpstreamTokens) MUST be treated as
+	// immutable — see pkg/auth/identity.go.
 	fallbackIdentity *auth.Identity
 }
 

--- a/pkg/vmcp/session/internal/backend/mcp_session_capabilities_test.go
+++ b/pkg/vmcp/session/internal/backend/mcp_session_capabilities_test.go
@@ -92,6 +92,12 @@ func (f *fakeBackend) callCount(method string) int {
 // headersFor returns a clone of the inbound HTTP headers recorded for the most
 // recent JSON-RPC request with the given method, or nil if no such request was
 // seen. Cloning under the mutex keeps the caller safe from concurrent writes.
+//
+// The helper accepts any MCP method name; in-tree callers currently converge
+// on tools/call, which trips unparam — but the helper must stay
+// method-agnostic so future tests can inspect headers for Initialize, etc.
+//
+//nolint:unparam // method-agnostic test helper; see doc comment above.
 func (f *fakeBackend) headersFor(method string) http.Header {
 	f.mu.Lock()
 	defer f.mu.Unlock()

--- a/pkg/vmcp/session/internal/backend/mcp_session_identity_refresh_test.go
+++ b/pkg/vmcp/session/internal/backend/mcp_session_identity_refresh_test.go
@@ -1,0 +1,194 @@
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package backend
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stacklok/toolhive/pkg/auth"
+	"github.com/stacklok/toolhive/pkg/vmcp"
+	vmcpauth "github.com/stacklok/toolhive/pkg/vmcp/auth"
+	"github.com/stacklok/toolhive/pkg/vmcp/auth/strategies"
+	authtypes "github.com/stacklok/toolhive/pkg/vmcp/auth/types"
+)
+
+// TestHTTPSession_PerRequestIdentity_DrivesUpstreamAuthHeader is the
+// higher-level regression test for issue #5323. It exercises the full
+// transport chain — headerForwardRoundTripper → identityRoundTripper →
+// authRoundTripper (UpstreamInjectStrategy) → http.DefaultTransport — and
+// asserts that the upstream Authorization header on each tool call reflects
+// the identity placed on the per-request context, NOT the identity captured
+// at session-init time.
+//
+// Without the fix, the captured session-init identity would override the
+// per-request identity on every outbound tool call, and the upstream would
+// see the stale bearer token on the second CallTool. The test would then
+// observe the same token on both calls — the symptom users experienced as
+// "forced re-auth every ~24h" once the captured access token expired.
+//
+// Scope: this is the higher-level test called out by the AC5 review feedback.
+// It stops short of wiring auth.TokenValidator.Middleware end-to-end (that
+// would pull in pkg/auth/upstreamtoken and a JWT signer) and instead injects
+// the fresh identity directly onto the per-request context, which is exactly
+// what TokenValidator.Middleware does on every authenticated request.
+func TestHTTPSession_PerRequestIdentity_DrivesUpstreamAuthHeader(t *testing.T) {
+	t.Parallel()
+
+	const (
+		providerName = "test-provider"
+		// staleToken is captured at session-creation time. If the
+		// (pre-fix) bug is reintroduced, the upstream will see this on
+		// every tool call.
+		staleToken = "stale-access-token"
+		// freshToken is placed on the per-request context immediately
+		// before each tool call. The post-fix transport must let it
+		// reach the upstream unchanged.
+		freshToken = "fresh-access-token"
+	)
+
+	fb := &fakeBackend{advertiseTools: true, tools: []mcp.Tool{{Name: "echo"}}}
+	url := newFakeBackend(t, fb)
+
+	registry := vmcpauth.NewDefaultOutgoingAuthRegistry()
+	require.NoError(t, registry.RegisterStrategy(
+		authtypes.StrategyTypeUpstreamInject,
+		strategies.NewUpstreamInjectStrategy(),
+	))
+
+	target := &vmcp.BackendTarget{
+		WorkloadID:    "identity-refresh-backend",
+		WorkloadName:  "identity-refresh-backend",
+		BaseURL:       url,
+		TransportType: "streamable-http",
+		AuthConfig: &authtypes.BackendAuthStrategy{
+			Type:           authtypes.StrategyTypeUpstreamInject,
+			UpstreamInject: &authtypes.UpstreamInjectConfig{ProviderName: providerName},
+		},
+	}
+
+	// staleIdentity is captured at session-init time and stored as the
+	// fallback. A pre-fix transport would re-inject this on every backend
+	// request, regardless of what is on the per-request context.
+	staleIdentity := &auth.Identity{
+		PrincipalInfo:  auth.PrincipalInfo{Subject: "user-1"},
+		UpstreamTokens: map[string]string{providerName: staleToken},
+	}
+
+	connector := NewHTTPConnector(registry)
+	initCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+
+	sess, _, err := connector(initCtx, target, staleIdentity, "")
+	require.NoError(t, err, "connector must initialise the backend successfully")
+	t.Cleanup(func() { _ = sess.Close() })
+
+	// Sanity check: the Initialize request (sent during connector(), which
+	// got the staleIdentity as its identity argument) saw the stale token.
+	// This documents the captured fallback's role and gives the headersFor
+	// helper a non-tools/call call site so the parameter is genuinely
+	// keyed by method.
+	initHeaders := fb.headersFor(string(mcp.MethodInitialize))
+	require.NotNil(t, initHeaders, "backend never received an initialize request")
+	assert.Equal(t, "Bearer "+staleToken, initHeaders.Get("Authorization"),
+		"initialize request should use the identity passed to connector()")
+
+	// CallTool with a fresh identity on the per-request context. This
+	// simulates what auth.TokenValidator.Middleware does on every
+	// authenticated incoming request: the identity it places on the
+	// context carries upstream tokens that were transparently refreshed
+	// by upstreamtoken.InProcessService.GetAllValidTokens.
+	freshIdentity := &auth.Identity{
+		PrincipalInfo:  auth.PrincipalInfo{Subject: "user-1"},
+		UpstreamTokens: map[string]string{providerName: freshToken},
+	}
+	callCtx, cancelCall := context.WithTimeout(
+		auth.WithIdentity(context.Background(), freshIdentity),
+		5*time.Second,
+	)
+	t.Cleanup(cancelCall)
+
+	_, err = sess.CallTool(callCtx, "echo", map[string]any{}, nil)
+	require.NoError(t, err, "tools/call with fresh identity must succeed")
+
+	got := fb.headersFor(string(mcp.MethodToolsCall))
+	require.NotNil(t, got, "backend never received a tools/call request")
+
+	// REGRESSION GUARD (#5323): the upstream must see the FRESH token from
+	// the per-request context, not the stale token captured at session-init.
+	assert.Equal(t, "Bearer "+freshToken, got.Get("Authorization"),
+		"per-request identity must drive the upstream Authorization header (#5323)")
+	assert.NotEqual(t, "Bearer "+staleToken, got.Get("Authorization"),
+		"captured session-init identity must not override per-request identity (#5323)")
+}
+
+// TestHTTPSession_FallbackIdentity_UsedWhenContextHasNoIdentity verifies the
+// complementary invariant: when the per-request context carries no identity
+// (e.g. mcp-go's Close() DELETE built from context.Background()), the captured
+// session-init identity is used as a fallback so the teardown DELETE remains
+// authenticated. This keeps the streamable-HTTP Close() path working without
+// a 401-on-teardown regression.
+func TestHTTPSession_FallbackIdentity_UsedWhenContextHasNoIdentity(t *testing.T) {
+	t.Parallel()
+
+	const (
+		providerName     = "test-provider"
+		fallbackTokenVal = "fallback-token"
+	)
+
+	fb := &fakeBackend{advertiseTools: true, tools: []mcp.Tool{{Name: "echo"}}}
+	url := newFakeBackend(t, fb)
+
+	registry := vmcpauth.NewDefaultOutgoingAuthRegistry()
+	require.NoError(t, registry.RegisterStrategy(
+		authtypes.StrategyTypeUpstreamInject,
+		strategies.NewUpstreamInjectStrategy(),
+	))
+
+	target := &vmcp.BackendTarget{
+		WorkloadID:    "identity-fallback-backend",
+		WorkloadName:  "identity-fallback-backend",
+		BaseURL:       url,
+		TransportType: "streamable-http",
+		AuthConfig: &authtypes.BackendAuthStrategy{
+			Type:           authtypes.StrategyTypeUpstreamInject,
+			UpstreamInject: &authtypes.UpstreamInjectConfig{ProviderName: providerName},
+		},
+	}
+
+	fallbackIdentity := &auth.Identity{
+		PrincipalInfo:  auth.PrincipalInfo{Subject: "user-1"},
+		UpstreamTokens: map[string]string{providerName: fallbackTokenVal},
+	}
+
+	connector := NewHTTPConnector(registry)
+	initCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+
+	sess, _, err := connector(initCtx, target, fallbackIdentity, "")
+	require.NoError(t, err, "connector must initialise the backend successfully")
+	t.Cleanup(func() { _ = sess.Close() })
+
+	// CallTool with a bare context.Background() — no identity attached.
+	// This models the teardown path where the SDK rebuilds the request
+	// from a fresh background context.
+	callCtx, cancelCall := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancelCall)
+
+	_, err = sess.CallTool(callCtx, "echo", map[string]any{}, nil)
+	require.NoError(t, err, "tools/call must succeed via fallback identity")
+
+	got := fb.headersFor(string(mcp.MethodToolsCall))
+	require.NotNil(t, got, "backend never received a tools/call request")
+
+	// The captured fallback must reach the upstream when the request
+	// context has nothing to override it with.
+	assert.Equal(t, "Bearer "+fallbackTokenVal, got.Get("Authorization"),
+		"fallback identity must be injected when req.Context() carries none")
+}

--- a/pkg/vmcp/session/internal/backend/mcp_session_identity_refresh_test.go
+++ b/pkg/vmcp/session/internal/backend/mcp_session_identity_refresh_test.go
@@ -89,22 +89,6 @@ func TestHTTPSession_PerRequestIdentity_DrivesUpstreamAuthHeader(t *testing.T) {
 	require.NoError(t, err, "connector must initialise the backend successfully")
 	t.Cleanup(func() { _ = sess.Close() })
 
-	// Sanity check: the Initialize request (sent during connector(), which
-	// got the staleIdentity as its identity argument) saw the stale token.
-	// This documents the captured fallback's role at session-init time.
-	//
-	// Maintenance note: do not delete this block without also varying the
-	// other headersFor call site below. fakeBackend.headersFor takes a
-	// `method` parameter; if both call sites end up passing the same
-	// constant (e.g. only tools/call), the `unparam` linter will fail
-	// because the parameter becomes effectively dead. This Initialize
-	// assertion is therefore load-bearing for lint as well as for test
-	// documentation — keep at least one non-tools/call invocation.
-	initHeaders := fb.headersFor(string(mcp.MethodInitialize))
-	require.NotNil(t, initHeaders, "backend never received an initialize request")
-	assert.Equal(t, "Bearer "+staleToken, initHeaders.Get("Authorization"),
-		"initialize request should use the identity passed to connector()")
-
 	// CallTool with a fresh identity on the per-request context. This
 	// simulates what auth.TokenValidator.Middleware does on every
 	// authenticated incoming request: the identity it places on the

--- a/pkg/vmcp/session/internal/backend/mcp_session_identity_refresh_test.go
+++ b/pkg/vmcp/session/internal/backend/mcp_session_identity_refresh_test.go
@@ -91,9 +91,15 @@ func TestHTTPSession_PerRequestIdentity_DrivesUpstreamAuthHeader(t *testing.T) {
 
 	// Sanity check: the Initialize request (sent during connector(), which
 	// got the staleIdentity as its identity argument) saw the stale token.
-	// This documents the captured fallback's role and gives the headersFor
-	// helper a non-tools/call call site so the parameter is genuinely
-	// keyed by method.
+	// This documents the captured fallback's role at session-init time.
+	//
+	// Maintenance note: do not delete this block without also varying the
+	// other headersFor call site below. fakeBackend.headersFor takes a
+	// `method` parameter; if both call sites end up passing the same
+	// constant (e.g. only tools/call), the `unparam` linter will fail
+	// because the parameter becomes effectively dead. This Initialize
+	// assertion is therefore load-bearing for lint as well as for test
+	// documentation — keep at least one non-tools/call invocation.
 	initHeaders := fb.headersFor(string(mcp.MethodInitialize))
 	require.NotNil(t, initHeaders, "backend never received an initialize request")
 	assert.Equal(t, "Bearer "+staleToken, initHeaders.Get("Authorization"),

--- a/pkg/vmcp/session/internal/backend/roundtripper_test.go
+++ b/pkg/vmcp/session/internal/backend/roundtripper_test.go
@@ -189,24 +189,15 @@ func TestAuthRoundTripper_AuthStrategyReceivesClonedRequest(t *testing.T) {
 // identityRoundTripper
 // ---------------------------------------------------------------------------
 //
-// Design invariant (see issue #5323): the per-request identity placed on
-// req.Context() by auth.TokenValidator.Middleware is THE canonical source of
-// identity for outgoing backend requests. It carries upstream tokens that the
-// middleware transparently refreshes per request. The captured fallback
-// identity is a teardown-DELETE escape hatch only — it covers the case where
-// mcp-go's Close() builds its DELETE from context.Background() and loses the
-// per-request identity. The fallback MUST NEVER override a non-nil identity
-// already present on req.Context(); doing so silently re-injects stale tokens
-// and is the bug fixed by #5323.
+// See identityPropagatingRoundTripper in pkg/vmcp/client/client.go for the
+// canonical description of the #5323 fallback-only identity invariant. The
+// session-backed twin in mcp_session.go omits health-check propagation
+// because health probes do not flow through this connector; if that ever
+// changes, mirror the health-check test set from client_test.go here.
 //
 // Tests below are grouped to reflect this hierarchy:
 //   1. Per-request identity (normal path)            — *_PerRequestIdentity_*
 //   2. Fallback identity (no-identity-on-context)    — *_FallbackIdentity_*
-//
-// The session-backed connector does not propagate a health-check marker
-// because health probes do not flow through it (see identityRoundTripper
-// doc comment in mcp_session.go). If that changes, mirror the health-check
-// test set from pkg/vmcp/client/client_test.go here.
 
 // --- Per-request identity (normal path) -----------------------------------
 

--- a/pkg/vmcp/session/internal/backend/roundtripper_test.go
+++ b/pkg/vmcp/session/internal/backend/roundtripper_test.go
@@ -189,12 +189,15 @@ func TestAuthRoundTripper_AuthStrategyReceivesClonedRequest(t *testing.T) {
 // identityRoundTripper
 // ---------------------------------------------------------------------------
 
-func TestIdentityRoundTripper_WithIdentity_PropagatesIdentityInContext(t *testing.T) {
+// TestIdentityRoundTripper_FallbackIdentity_InjectedWhenContextLacksIdentity verifies
+// that the captured fallback identity is injected when req.Context() carries no
+// identity (e.g. mcp-go's Close() DELETE built from context.Background()).
+func TestIdentityRoundTripper_FallbackIdentity_InjectedWhenContextLacksIdentity(t *testing.T) {
 	t.Parallel()
 
-	identity := &auth.Identity{PrincipalInfo: auth.PrincipalInfo{Subject: "user-42"}}
+	fallback := &auth.Identity{PrincipalInfo: auth.PrincipalInfo{Subject: "user-42"}}
 	base := &okTransport{}
-	rt := &identityRoundTripper{base: base, identity: identity}
+	rt := &identityRoundTripper{base: base, fallbackIdentity: fallback}
 
 	orig := newTestRequest(context.Background(), t)
 	resp, err := rt.RoundTrip(orig)
@@ -202,10 +205,10 @@ func TestIdentityRoundTripper_WithIdentity_PropagatesIdentityInContext(t *testin
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-	// Downstream request must carry the identity in its context.
+	// Downstream request must carry the fallback identity in its context.
 	require.NotNil(t, base.received)
 	got, ok := auth.IdentityFromContext(base.received.Context())
-	require.True(t, ok, "identity not found in downstream request context")
+	require.True(t, ok, "fallback identity not found in downstream request context")
 	assert.Equal(t, "user-42", got.Subject)
 
 	// Original request context must be unmodified.
@@ -213,11 +216,45 @@ func TestIdentityRoundTripper_WithIdentity_PropagatesIdentityInContext(t *testin
 	assert.False(t, origOk, "original request context was mutated")
 }
 
-func TestIdentityRoundTripper_NilIdentity_ContextUnchanged(t *testing.T) {
+// TestIdentityRoundTripper_RequestContextIdentity_NotOverridden is the regression
+// test for issue #5323: a fresh identity already on req.Context() (placed there by
+// TokenValidator.Middleware on every incoming request) must survive the transport
+// untouched. Overriding it with a captured fallback would silently re-inject stale
+// upstream tokens on every backend call, forcing daily re-auth.
+func TestIdentityRoundTripper_RequestContextIdentity_NotOverridden(t *testing.T) {
+	t.Parallel()
+
+	stale := &auth.Identity{
+		PrincipalInfo:  auth.PrincipalInfo{Subject: "stale-user"},
+		UpstreamTokens: map[string]string{"provider": "stale-token"},
+	}
+	base := &okTransport{}
+	rt := &identityRoundTripper{base: base, fallbackIdentity: stale}
+
+	fresh := &auth.Identity{
+		PrincipalInfo:  auth.PrincipalInfo{Subject: "fresh-user"},
+		UpstreamTokens: map[string]string{"provider": "fresh-token"},
+	}
+	ctx := auth.WithIdentity(context.Background(), fresh)
+	orig := newTestRequest(ctx, t)
+
+	_, err := rt.RoundTrip(orig)
+	require.NoError(t, err)
+
+	require.NotNil(t, base.received)
+	got, ok := auth.IdentityFromContext(base.received.Context())
+	require.True(t, ok, "identity from req.Context() must be present downstream")
+	assert.Equal(t, "fresh-user", got.Subject,
+		"identity on req.Context() must not be overridden by the captured fallback (#5323)")
+	assert.Equal(t, "fresh-token", got.UpstreamTokens["provider"],
+		"fresh upstream tokens must reach auth strategies unchanged (#5323)")
+}
+
+func TestIdentityRoundTripper_NilFallback_ContextUnchanged(t *testing.T) {
 	t.Parallel()
 
 	base := &okTransport{}
-	rt := &identityRoundTripper{base: base, identity: nil}
+	rt := &identityRoundTripper{base: base, fallbackIdentity: nil}
 
 	orig := newTestRequest(context.Background(), t)
 	resp, err := rt.RoundTrip(orig)
@@ -228,21 +265,50 @@ func TestIdentityRoundTripper_NilIdentity_ContextUnchanged(t *testing.T) {
 	// No identity should be present in the downstream context.
 	require.NotNil(t, base.received)
 	_, ok := auth.IdentityFromContext(base.received.Context())
-	assert.False(t, ok, "identity unexpectedly found in context when nil identity was configured")
+	assert.False(t, ok, "identity unexpectedly found in context when no fallback and no req-ctx identity")
 }
 
-func TestIdentityRoundTripper_WithIdentity_ClonesRequest(t *testing.T) {
+// TestIdentityRoundTripper_RequestContextIdentity_NoFallback_Preserved verifies the
+// normal per-request flow: identity is on req.Context() (placed by
+// TokenValidator.Middleware), no fallback is configured, and the transport leaves
+// the identity untouched so the freshly refreshed upstream tokens reach the
+// downstream auth strategies.
+func TestIdentityRoundTripper_RequestContextIdentity_NoFallback_Preserved(t *testing.T) {
 	t.Parallel()
 
-	identity := &auth.Identity{PrincipalInfo: auth.PrincipalInfo{Subject: "user-99"}}
 	base := &okTransport{}
-	rt := &identityRoundTripper{base: base, identity: identity}
+	rt := &identityRoundTripper{base: base, fallbackIdentity: nil}
+
+	fresh := &auth.Identity{
+		PrincipalInfo:  auth.PrincipalInfo{Subject: "fresh-user"},
+		UpstreamTokens: map[string]string{"provider": "fresh-token"},
+	}
+	ctx := auth.WithIdentity(context.Background(), fresh)
+	orig := newTestRequest(ctx, t)
+
+	_, err := rt.RoundTrip(orig)
+	require.NoError(t, err)
+
+	require.NotNil(t, base.received)
+	got, ok := auth.IdentityFromContext(base.received.Context())
+	require.True(t, ok)
+	assert.Equal(t, "fresh-user", got.Subject)
+	assert.Equal(t, "fresh-token", got.UpstreamTokens["provider"])
+}
+
+func TestIdentityRoundTripper_FallbackInjection_ClonesRequest(t *testing.T) {
+	t.Parallel()
+
+	fallback := &auth.Identity{PrincipalInfo: auth.PrincipalInfo{Subject: "user-99"}}
+	base := &okTransport{}
+	rt := &identityRoundTripper{base: base, fallbackIdentity: fallback}
 
 	orig := newTestRequest(context.Background(), t)
 	_, err := rt.RoundTrip(orig)
 	require.NoError(t, err)
 
-	// A non-nil identity must cause the request to be cloned.
+	// When the fallback is injected, the request must be cloned so the original
+	// request's context remains untouched.
 	require.NotNil(t, base.received)
-	assert.NotSame(t, orig, base.received, "non-nil identity should clone the request")
+	assert.NotSame(t, orig, base.received, "fallback injection should clone the request")
 }

--- a/pkg/vmcp/session/internal/backend/roundtripper_test.go
+++ b/pkg/vmcp/session/internal/backend/roundtripper_test.go
@@ -188,40 +188,64 @@ func TestAuthRoundTripper_AuthStrategyReceivesClonedRequest(t *testing.T) {
 // ---------------------------------------------------------------------------
 // identityRoundTripper
 // ---------------------------------------------------------------------------
+//
+// Design invariant (see issue #5323): the per-request identity placed on
+// req.Context() by auth.TokenValidator.Middleware is THE canonical source of
+// identity for outgoing backend requests. It carries upstream tokens that the
+// middleware transparently refreshes per request. The captured fallback
+// identity is a teardown-DELETE escape hatch only — it covers the case where
+// mcp-go's Close() builds its DELETE from context.Background() and loses the
+// per-request identity. The fallback MUST NEVER override a non-nil identity
+// already present on req.Context(); doing so silently re-injects stale tokens
+// and is the bug fixed by #5323.
+//
+// Tests below are grouped to reflect this hierarchy:
+//   1. Per-request identity (normal path)            — *_PerRequestIdentity_*
+//   2. Fallback identity (no-identity-on-context)    — *_FallbackIdentity_*
+//
+// The session-backed connector does not propagate a health-check marker
+// because health probes do not flow through it (see identityRoundTripper
+// doc comment in mcp_session.go). If that changes, mirror the health-check
+// test set from pkg/vmcp/client/client_test.go here.
 
-// TestIdentityRoundTripper_FallbackIdentity_InjectedWhenContextLacksIdentity verifies
-// that the captured fallback identity is injected when req.Context() carries no
-// identity (e.g. mcp-go's Close() DELETE built from context.Background()).
-func TestIdentityRoundTripper_FallbackIdentity_InjectedWhenContextLacksIdentity(t *testing.T) {
+// --- Per-request identity (normal path) -----------------------------------
+
+// TestIdentityRoundTripper_PerRequestIdentity_FlowsThroughUnchanged verifies
+// the normal per-request flow: identity is on req.Context() (placed by
+// TokenValidator.Middleware), no fallback is configured, and the transport
+// leaves the identity untouched so the freshly refreshed upstream tokens
+// reach the downstream auth strategies. This is the path taken on every
+// authenticated tool call.
+func TestIdentityRoundTripper_PerRequestIdentity_FlowsThroughUnchanged(t *testing.T) {
 	t.Parallel()
 
-	fallback := &auth.Identity{PrincipalInfo: auth.PrincipalInfo{Subject: "user-42"}}
 	base := &okTransport{}
-	rt := &identityRoundTripper{base: base, fallbackIdentity: fallback}
+	rt := &identityRoundTripper{base: base, fallbackIdentity: nil}
 
-	orig := newTestRequest(context.Background(), t)
-	resp, err := rt.RoundTrip(orig)
+	fresh := &auth.Identity{
+		PrincipalInfo:  auth.PrincipalInfo{Subject: "fresh-user"},
+		UpstreamTokens: map[string]string{"provider": "fresh-token"},
+	}
+	ctx := auth.WithIdentity(context.Background(), fresh)
+	orig := newTestRequest(ctx, t)
 
+	_, err := rt.RoundTrip(orig)
 	require.NoError(t, err)
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-	// Downstream request must carry the fallback identity in its context.
 	require.NotNil(t, base.received)
 	got, ok := auth.IdentityFromContext(base.received.Context())
-	require.True(t, ok, "fallback identity not found in downstream request context")
-	assert.Equal(t, "user-42", got.Subject)
-
-	// Original request context must be unmodified.
-	_, origOk := auth.IdentityFromContext(orig.Context())
-	assert.False(t, origOk, "original request context was mutated")
+	require.True(t, ok)
+	assert.Equal(t, "fresh-user", got.Subject)
+	assert.Equal(t, "fresh-token", got.UpstreamTokens["provider"])
 }
 
-// TestIdentityRoundTripper_RequestContextIdentity_NotOverridden is the regression
-// test for issue #5323: a fresh identity already on req.Context() (placed there by
-// TokenValidator.Middleware on every incoming request) must survive the transport
-// untouched. Overriding it with a captured fallback would silently re-inject stale
-// upstream tokens on every backend call, forcing daily re-auth.
-func TestIdentityRoundTripper_RequestContextIdentity_NotOverridden(t *testing.T) {
+// TestIdentityRoundTripper_PerRequestIdentity_NotOverriddenByFallback is the
+// regression test for issue #5323: a fresh identity already on req.Context()
+// (placed there by TokenValidator.Middleware on every incoming request) must
+// survive the transport untouched, even when a stale fallback identity is
+// captured. Overriding it would silently re-inject stale upstream tokens on
+// every backend call, forcing daily re-auth.
+func TestIdentityRoundTripper_PerRequestIdentity_NotOverriddenByFallback(t *testing.T) {
 	t.Parallel()
 
 	stale := &auth.Identity{
@@ -250,7 +274,36 @@ func TestIdentityRoundTripper_RequestContextIdentity_NotOverridden(t *testing.T)
 		"fresh upstream tokens must reach auth strategies unchanged (#5323)")
 }
 
-func TestIdentityRoundTripper_NilFallback_ContextUnchanged(t *testing.T) {
+// --- Fallback identity (teardown / no-identity-on-context path) ------------
+
+// TestIdentityRoundTripper_FallbackIdentity_InjectedWhenContextLacksIdentity
+// verifies that the captured fallback identity is injected when req.Context()
+// carries no identity (e.g. mcp-go's Close() DELETE built from context.Background()).
+func TestIdentityRoundTripper_FallbackIdentity_InjectedWhenContextLacksIdentity(t *testing.T) {
+	t.Parallel()
+
+	fallback := &auth.Identity{PrincipalInfo: auth.PrincipalInfo{Subject: "user-42"}}
+	base := &okTransport{}
+	rt := &identityRoundTripper{base: base, fallbackIdentity: fallback}
+
+	orig := newTestRequest(context.Background(), t)
+	resp, err := rt.RoundTrip(orig)
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Downstream request must carry the fallback identity in its context.
+	require.NotNil(t, base.received)
+	got, ok := auth.IdentityFromContext(base.received.Context())
+	require.True(t, ok, "fallback identity not found in downstream request context")
+	assert.Equal(t, "user-42", got.Subject)
+
+	// Original request context must be unmodified.
+	_, origOk := auth.IdentityFromContext(orig.Context())
+	assert.False(t, origOk, "original request context was mutated")
+}
+
+func TestIdentityRoundTripper_FallbackIdentity_NilFallback_ContextUnchanged(t *testing.T) {
 	t.Parallel()
 
 	base := &okTransport{}
@@ -268,35 +321,7 @@ func TestIdentityRoundTripper_NilFallback_ContextUnchanged(t *testing.T) {
 	assert.False(t, ok, "identity unexpectedly found in context when no fallback and no req-ctx identity")
 }
 
-// TestIdentityRoundTripper_RequestContextIdentity_NoFallback_Preserved verifies the
-// normal per-request flow: identity is on req.Context() (placed by
-// TokenValidator.Middleware), no fallback is configured, and the transport leaves
-// the identity untouched so the freshly refreshed upstream tokens reach the
-// downstream auth strategies.
-func TestIdentityRoundTripper_RequestContextIdentity_NoFallback_Preserved(t *testing.T) {
-	t.Parallel()
-
-	base := &okTransport{}
-	rt := &identityRoundTripper{base: base, fallbackIdentity: nil}
-
-	fresh := &auth.Identity{
-		PrincipalInfo:  auth.PrincipalInfo{Subject: "fresh-user"},
-		UpstreamTokens: map[string]string{"provider": "fresh-token"},
-	}
-	ctx := auth.WithIdentity(context.Background(), fresh)
-	orig := newTestRequest(ctx, t)
-
-	_, err := rt.RoundTrip(orig)
-	require.NoError(t, err)
-
-	require.NotNil(t, base.received)
-	got, ok := auth.IdentityFromContext(base.received.Context())
-	require.True(t, ok)
-	assert.Equal(t, "fresh-user", got.Subject)
-	assert.Equal(t, "fresh-token", got.UpstreamTokens["provider"])
-}
-
-func TestIdentityRoundTripper_FallbackInjection_ClonesRequest(t *testing.T) {
+func TestIdentityRoundTripper_FallbackIdentity_InjectionClonesRequest(t *testing.T) {
 	t.Parallel()
 
 	fallback := &auth.Identity{PrincipalInfo: auth.PrincipalInfo{Subject: "user-99"}}


### PR DESCRIPTION
## Summary

- vMCP backend HTTP clients captured the request `*auth.Identity` once at session/client-creation time and re-injected that snapshot on every outgoing backend request, overriding the fresh identity placed on `req.Context()` by `auth.TokenValidator.Middleware`. Because that fresh identity carries upstream tokens transparently refreshed by `upstreamtoken.InProcessService.GetAllValidTokens`, the override silently re-injected stale upstream access tokens for the entire session lifetime — users saw a forced re-auth roughly every 24h (the upstream provider's access-token lifespan).
- The captured identity is now treated as a fallback: it is injected only when `req.Context()` carries no identity. This preserves the streamable-HTTP `Close()`/DELETE teardown path — mcp-go constructs that request from `context.Background()`, which loses the per-request identity — while letting normal backend calls use the freshly refreshed identity from the request context.
- The fix is applied to both transport chains that exhibited the bug: `identityPropagatingRoundTripper` in `pkg/vmcp/client/client.go` (per-call client) and the new `identityRoundTripper` in `pkg/vmcp/session/internal/backend/mcp_session.go` (persistent session-backed client). Existing health-check marker propagation in the per-call client is preserved.

Closes #5323

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)
- [x] Manual testing (describe below)

Unit-test coverage added/updated:

- `pkg/vmcp/client/client_test.go` — round-tripper tests reorganized into Per-request / Fallback / Health-check sections; new cases assert that a fresh identity on `req.Context()` is preserved unchanged, that the fallback is injected only when the request context has no identity, and that the health-check marker behavior is unchanged.
- `pkg/vmcp/session/internal/backend/roundtripper_test.go` — mirrors the above for the session-backed `identityRoundTripper`.
- `pkg/vmcp/session/internal/backend/mcp_session_identity_refresh_test.go` (new) — higher-level regression test that exercises the full transport chain (`headerForwardRoundTripper` → `identityRoundTripper` → `authRoundTripper` with `UpstreamInjectStrategy` → `http.DefaultTransport`) against a fake backend. Asserts that the upstream `Authorization` header on each `tools/call` reflects the identity placed on the per-request context, NOT the identity captured at session-init time. Verified to fail under the pre-fix always-override behavior, so it is a true #5323 regression guard.

Manual verification: traced through `auth.TokenValidator.Middleware` → `InProcessService.GetAllValidTokens` → vMCP outgoing-auth strategies (`upstream_inject`, `tokenexchange`, `aws_sts`) to confirm that all three read identity from `req.Context()` and therefore benefit from the fix.

## API Compatibility

- [x] This PR does not break the `v1beta1` API, OR the `api-break-allowed` label is applied and the migration guidance is described above.

## Changes

| File | Change |
|------|--------|
| `pkg/vmcp/client/client.go` | `identityPropagatingRoundTripper` no longer overrides identity on `req.Context()`; the captured identity is now a fallback used only when the request context carries none. Doc comments rewritten to document the invariant. |
| `pkg/vmcp/session/internal/backend/mcp_session.go` | New `identityRoundTripper` with the same fallback-only semantics, inserted into the session-backed transport chain. Documents asymmetric health-check handling (not needed in this chain). |
| `pkg/vmcp/client/client_test.go` | Reorganized round-tripper tests; new cases for per-request identity preservation, fallback-only injection, and health-check marker behavior. |
| `pkg/vmcp/session/internal/backend/roundtripper_test.go` | Same coverage for the session-backed round-tripper. |
| `pkg/vmcp/session/internal/backend/mcp_session_identity_refresh_test.go` | New higher-level regression test exercising the full transport chain end-to-end. |

## Does this introduce a user-facing change?

Yes. Users of vMCP backends configured with `upstreamInject`, `tokenExchange`, or `awsSTS` outgoing auth no longer see forced re-auth when the upstream provider's access token expires mid-session. Upstream tokens are transparently refreshed on every tool call as long as the vMCP-issued refresh token remains valid.

## Special notes for reviewers

- The fix is intentionally scoped to the round-tripper layer. The broader Phase 2 work tracked in #3877 (proactive refresh, session-scoped client lifecycle per THV-0038) and the reactive 401/403 retry safety net in #3869 remain open and unchanged by this PR. This change is essentially Part 1 of #3877, filed separately because it has a concrete user-visible impact worth landing on its own.
- Two duplicate round-tripper implementations now exist (one in `pkg/vmcp/client`, one in `pkg/vmcp/session/internal/backend`). They share the same invariant and were left duplicated to keep this PR focused on the bug fix. Consolidation is tracked in follow-up issue #5333.
- The higher-level regression test stops short of wiring `auth.TokenValidator.Middleware` end-to-end (which would pull in `pkg/auth/upstreamtoken` and a JWT signer) and instead injects the fresh identity directly onto the per-request context — which is exactly what the middleware does on every authenticated request. Extending the test to literally wire the middleware + a fake `UpstreamTokenRefresher` (AC5 as written on the issue) is tracked in follow-up issue #5334.
- Invariant to preserve in future changes: **a non-nil identity in `req.Context()` must never be silently overridden by a captured one**. The doc comments on both round-trippers state this explicitly.
