### PR TITLE
Add default OBO handler hooks and vMCP/proxy converter stubs

### DIFF
--- a/cmd/thv-operator/api/v1beta1/mcpexternalauthconfig_types.go
+++ b/cmd/thv-operator/api/v1beta1/mcpexternalauthconfig_types.go
@@ -1115,12 +1115,13 @@ func (r *MCPExternalAuthConfig) Validate() error {
 		// No complex validation needed for these types
 		return nil
 	case ExternalAuthTypeOBO:
-		// OBO validation is delegated to the registered OBO handler at the
-		// controllerutil layer; the CRD-level Validate() is intentionally a
-		// no-op so that an upstream-only build still rejects obo-typed configs
-		// later via controllerutil.OBOValidate -> ErrEnterpriseRequired (wired
-		// in a follow-up task). The CRD enum currently rejects "obo" at the
-		// apiserver layer, so this arm is unreachable in upstream-only builds.
+		// Minimal no-op arm added to satisfy the `exhaustive` linter; dispatch
+		// wiring lands in follow-up task #5328. OBO validation is delegated to
+		// the registered OBO handler at the controllerutil layer (via
+		// controllerutil.OBOValidate -> ErrEnterpriseRequired in upstream-only
+		// builds); the CRD-level Validate() stays a no-op. The CRD enum
+		// currently rejects "obo" at the apiserver layer, so this arm is
+		// unreachable in upstream-only builds.
 		return nil
 	default:
 		// Unknown type - should be caught by enum validation, but handle defensively
@@ -1130,6 +1131,13 @@ func (r *MCPExternalAuthConfig) Validate() error {
 
 // validateTypeConfigConsistency validates that the correct config is set for the selected type.
 // This mirrors the CEL validation rules but provides defense-in-depth for stored objects.
+//
+// TODO(#5329): when OBOConfig is introduced in the CRD admission task, add a
+// matching biconditional row here:
+//
+//	(r.Spec.OBO == nil) == (r.Spec.Type == ExternalAuthTypeOBO)
+//
+// and update the unauthenticated check below to also assert !has(self.obo).
 func (r *MCPExternalAuthConfig) validateTypeConfigConsistency() error {
 	// Check that each type has its corresponding config
 	if (r.Spec.TokenExchange == nil) == (r.Spec.Type == ExternalAuthTypeTokenExchange) {

--- a/cmd/thv-operator/api/v1beta1/mcpexternalauthconfig_types.go
+++ b/cmd/thv-operator/api/v1beta1/mcpexternalauthconfig_types.go
@@ -39,6 +39,13 @@ const (
 	// ExternalAuthTypeUpstreamInject is the type for upstream token injection
 	// This injects an upstream IDP access token as the Authorization: Bearer header
 	ExternalAuthTypeUpstreamInject ExternalAuthType = "upstreamInject"
+
+	// ExternalAuthTypeOBO is the type for on-behalf-of (OBO) flows.
+	// This type requires a build with an OBO handler registered via
+	// controllerutil.RegisterOBOHandler; an upstream-only build surfaces
+	// status.conditions[Valid] = False with Reason: EnterpriseRequired
+	// when an obo-typed MCPExternalAuthConfig is applied.
+	ExternalAuthTypeOBO ExternalAuthType = "obo"
 )
 
 // ExternalAuthType represents the type of external authentication
@@ -1106,6 +1113,14 @@ func (r *MCPExternalAuthConfig) Validate() error {
 		ExternalAuthTypeBearerToken,
 		ExternalAuthTypeUnauthenticated:
 		// No complex validation needed for these types
+		return nil
+	case ExternalAuthTypeOBO:
+		// OBO validation is delegated to the registered OBO handler at the
+		// controllerutil layer; the CRD-level Validate() is intentionally a
+		// no-op so that an upstream-only build still rejects obo-typed configs
+		// later via controllerutil.OBOValidate -> ErrEnterpriseRequired (wired
+		// in a follow-up task). The CRD enum currently rejects "obo" at the
+		// apiserver layer, so this arm is unreachable in upstream-only builds.
 		return nil
 	default:
 		// Unknown type - should be caught by enum validation, but handle defensively

--- a/cmd/thv-operator/api/v1beta1/mcpexternalauthconfig_types.go
+++ b/cmd/thv-operator/api/v1beta1/mcpexternalauthconfig_types.go
@@ -1115,13 +1115,14 @@ func (r *MCPExternalAuthConfig) Validate() error {
 		// No complex validation needed for these types
 		return nil
 	case ExternalAuthTypeOBO:
-		// Minimal no-op arm added to satisfy the `exhaustive` linter; dispatch
-		// wiring lands in follow-up task #5328. OBO validation is delegated to
-		// the registered OBO handler at the controllerutil layer (via
-		// controllerutil.OBOValidate -> ErrEnterpriseRequired in upstream-only
-		// builds); the CRD-level Validate() stays a no-op. The CRD enum
-		// currently rejects "obo" at the apiserver layer, so this arm is
-		// unreachable in upstream-only builds.
+		// TODO(#5328): no body change is planned here — OBO validation is
+		// delegated to the registered OBO handler at the controllerutil layer
+		// (via controllerutil.OBOValidate -> obo.ErrEnterpriseRequired in
+		// upstream-only builds), invoked from the reconcile loop. The
+		// CRD-level Validate() stays a no-op for OBO and exists only to keep
+		// the `exhaustive` linter happy now that ExternalAuthTypeOBO is
+		// defined. The CRD enum currently rejects "obo" at the apiserver
+		// layer, so this arm is unreachable in upstream-only builds.
 		return nil
 	default:
 		// Unknown type - should be caught by enum validation, but handle defensively

--- a/cmd/thv-operator/controllers/virtualmcpserver_deployment.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_deployment.go
@@ -831,6 +831,13 @@ func (r *VirtualMCPServerReconciler) getExternalAuthConfigSecretEnvVar(
 		// No secrets to mount via env vars
 		return nil, nil
 
+	case mcpv1beta1.ExternalAuthTypeOBO:
+		// OBO secret-env-var dispatch is wired in a follow-up task that will
+		// replace this body with a call into controllerutil.OBOSecretEnvVars.
+		// The CRD enum currently rejects "obo" at the apiserver layer, so this
+		// arm is unreachable in upstream-only builds.
+		return nil, nil
+
 	default:
 		return nil, nil // Not applicable
 	}

--- a/cmd/thv-operator/controllers/virtualmcpserver_deployment.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_deployment.go
@@ -832,11 +832,11 @@ func (r *VirtualMCPServerReconciler) getExternalAuthConfigSecretEnvVar(
 		return nil, nil
 
 	case mcpv1beta1.ExternalAuthTypeOBO:
-		// Minimal no-op arm added to satisfy the `exhaustive` linter; dispatch
-		// wiring lands in follow-up task #5328 and will replace this body with
-		// a call into controllerutil.OBOSecretEnvVars. The CRD enum currently
-		// rejects "obo" at the apiserver layer, so this arm is unreachable in
-		// upstream-only builds.
+		// TODO(#5328): replace this body with a call into
+		// controllerutil.OBOSecretEnvVars as part of the dispatch-wiring task.
+		// The arm exists today to satisfy the `exhaustive` linter. The CRD
+		// enum currently rejects "obo" at the apiserver layer, so this arm is
+		// unreachable in upstream-only builds.
 		return nil, nil
 
 	default:

--- a/cmd/thv-operator/controllers/virtualmcpserver_deployment.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_deployment.go
@@ -832,10 +832,11 @@ func (r *VirtualMCPServerReconciler) getExternalAuthConfigSecretEnvVar(
 		return nil, nil
 
 	case mcpv1beta1.ExternalAuthTypeOBO:
-		// OBO secret-env-var dispatch is wired in a follow-up task that will
-		// replace this body with a call into controllerutil.OBOSecretEnvVars.
-		// The CRD enum currently rejects "obo" at the apiserver layer, so this
-		// arm is unreachable in upstream-only builds.
+		// Minimal no-op arm added to satisfy the `exhaustive` linter; dispatch
+		// wiring lands in follow-up task #5328 and will replace this body with
+		// a call into controllerutil.OBOSecretEnvVars. The CRD enum currently
+		// rejects "obo" at the apiserver layer, so this arm is unreachable in
+		// upstream-only builds.
 		return nil, nil
 
 	default:

--- a/cmd/thv-operator/pkg/controllerutil/tokenexchange.go
+++ b/cmd/thv-operator/pkg/controllerutil/tokenexchange.go
@@ -84,6 +84,21 @@ func OBOSecretEnvVars(cfg *mcpv1beta1.MCPExternalAuthConfig) ([]corev1.EnvVar, e
 	return oboHandler.SecretEnvVars(cfg)
 }
 
+// OBOApplyRunConfig runs the registered OBO handler's ApplyRunConfig function.
+// With the default handler it returns ErrEnterpriseRequired without mutating
+// the supplied options slice. The follow-up dispatch-wiring task (#5328) is
+// the first caller of this wrapper; exporting it now keeps the three-method
+// surface symmetric with OBOValidate / OBOSecretEnvVars.
+func OBOApplyRunConfig(
+	ctx context.Context,
+	c client.Client,
+	namespace string,
+	cfg *mcpv1beta1.MCPExternalAuthConfig,
+	opts *[]runner.RunConfigBuilderOption,
+) error {
+	return oboHandler.ApplyRunConfig(ctx, c, namespace, cfg, opts)
+}
+
 // GenerateTokenExchangeEnvVars generates environment variables for token exchange
 func GenerateTokenExchangeEnvVars(
 	ctx context.Context,
@@ -181,11 +196,14 @@ func AddExternalAuthConfigOptions(
 		// Upstream inject is handled by the vMCP converter at runtime
 		return nil
 	case mcpv1beta1.ExternalAuthTypeOBO:
-		// OBO handler dispatch is wired in a follow-up task; the CRD enum
-		// currently rejects "obo" at the apiserver layer, so this arm is
-		// unreachable in upstream-only builds. The follow-up task will
-		// replace this body with a call into oboHandler.ApplyRunConfig.
-		return fmt.Errorf("unsupported external auth type: %s", externalAuthConfig.Spec.Type)
+		// Minimal no-op arm added to satisfy the `exhaustive` linter; dispatch
+		// wiring lands in follow-up task #5328 and will replace this body with
+		// a call into oboHandler.ApplyRunConfig. Until then we surface
+		// ErrEnterpriseRequired so callers can use errors.Is to distinguish
+		// "type known but not wired" from a genuinely unknown type. The CRD
+		// enum currently rejects "obo" at the apiserver layer, so this arm is
+		// unreachable in upstream-only builds.
+		return fmt.Errorf("obo dispatch not yet wired: %w", ErrEnterpriseRequired)
 	default:
 		return fmt.Errorf("unsupported external auth type: %s", externalAuthConfig.Spec.Type)
 	}

--- a/cmd/thv-operator/pkg/controllerutil/tokenexchange.go
+++ b/cmd/thv-operator/pkg/controllerutil/tokenexchange.go
@@ -5,7 +5,6 @@ package controllerutil
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
@@ -15,22 +14,16 @@ import (
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
 	"github.com/stacklok/toolhive/cmd/thv-operator/pkg/oidc"
 	"github.com/stacklok/toolhive/pkg/auth/awssts"
+	"github.com/stacklok/toolhive/pkg/auth/obo"
 	"github.com/stacklok/toolhive/pkg/auth/remote"
 	"github.com/stacklok/toolhive/pkg/oauthproto/tokenexchange"
 	"github.com/stacklok/toolhive/pkg/runner"
 )
 
-// ErrEnterpriseRequired is returned by the default OBO handler when no
-// out-of-tree handler has been registered via RegisterOBOHandler. Callers
-// must use errors.Is to compare; the error wraps cleanly through
-// fmt.Errorf("...: %w", ...).
-var ErrEnterpriseRequired = errors.New(
-	"this MCPExternalAuthConfig type requires a build with an OBO handler registered via controllerutil.RegisterOBOHandler")
-
 // OBOHandler bundles the three operator-time dispatch points for OBO-typed
 // MCPExternalAuthConfig resources. An out-of-tree build replaces the default
-// instance (which returns ErrEnterpriseRequired from every method) by calling
-// RegisterOBOHandler once during init().
+// instance (which returns obo.ErrEnterpriseRequired from every method) by
+// calling RegisterOBOHandler once during init().
 type OBOHandler struct {
 	// Validate is called from MCPExternalAuthConfig validation to verify the
 	// resource's obo-typed config is well-formed.
@@ -51,16 +44,16 @@ type OBOHandler struct {
 }
 
 // oboHandler holds the package-level OBO handler. The default implementation
-// returns ErrEnterpriseRequired from each method; an out-of-tree build
+// returns obo.ErrEnterpriseRequired from each method; an out-of-tree build
 // replaces it via RegisterOBOHandler.
 var oboHandler = OBOHandler{
-	Validate: func(*mcpv1beta1.MCPExternalAuthConfig) error { return ErrEnterpriseRequired },
+	Validate: func(*mcpv1beta1.MCPExternalAuthConfig) error { return obo.ErrEnterpriseRequired },
 	ApplyRunConfig: func(context.Context, client.Client, string,
 		*mcpv1beta1.MCPExternalAuthConfig, *[]runner.RunConfigBuilderOption) error {
-		return ErrEnterpriseRequired
+		return obo.ErrEnterpriseRequired
 	},
 	SecretEnvVars: func(*mcpv1beta1.MCPExternalAuthConfig) ([]corev1.EnvVar, error) {
-		return nil, ErrEnterpriseRequired
+		return nil, obo.ErrEnterpriseRequired
 	},
 }
 
@@ -73,22 +66,22 @@ func RegisterOBOHandler(h OBOHandler) { oboHandler = h }
 
 // OBOValidate runs the registered OBO handler's Validate function on the
 // supplied MCPExternalAuthConfig. With the default handler it returns
-// ErrEnterpriseRequired.
+// obo.ErrEnterpriseRequired.
 func OBOValidate(cfg *mcpv1beta1.MCPExternalAuthConfig) error {
 	return oboHandler.Validate(cfg)
 }
 
 // OBOSecretEnvVars runs the registered OBO handler's SecretEnvVars function.
-// With the default handler it returns (nil, ErrEnterpriseRequired).
+// With the default handler it returns (nil, obo.ErrEnterpriseRequired).
 func OBOSecretEnvVars(cfg *mcpv1beta1.MCPExternalAuthConfig) ([]corev1.EnvVar, error) {
 	return oboHandler.SecretEnvVars(cfg)
 }
 
 // OBOApplyRunConfig runs the registered OBO handler's ApplyRunConfig function.
-// With the default handler it returns ErrEnterpriseRequired without mutating
-// the supplied options slice. The follow-up dispatch-wiring task (#5328) is
-// the first caller of this wrapper; exporting it now keeps the three-method
-// surface symmetric with OBOValidate / OBOSecretEnvVars.
+// With the default handler it returns obo.ErrEnterpriseRequired without
+// mutating the supplied options slice. The follow-up dispatch-wiring task
+// (#5328) is the first caller of this wrapper; exporting it now keeps the
+// three-method surface symmetric with OBOValidate / OBOSecretEnvVars.
 func OBOApplyRunConfig(
 	ctx context.Context,
 	c client.Client,
@@ -196,14 +189,14 @@ func AddExternalAuthConfigOptions(
 		// Upstream inject is handled by the vMCP converter at runtime
 		return nil
 	case mcpv1beta1.ExternalAuthTypeOBO:
-		// Minimal no-op arm added to satisfy the `exhaustive` linter; dispatch
-		// wiring lands in follow-up task #5328 and will replace this body with
-		// a call into oboHandler.ApplyRunConfig. Until then we surface
-		// ErrEnterpriseRequired so callers can use errors.Is to distinguish
-		// "type known but not wired" from a genuinely unknown type. The CRD
-		// enum currently rejects "obo" at the apiserver layer, so this arm is
-		// unreachable in upstream-only builds.
-		return fmt.Errorf("obo dispatch not yet wired: %w", ErrEnterpriseRequired)
+		// TODO(#5328): replace this body with a call into
+		// oboHandler.ApplyRunConfig as part of the dispatch-wiring task. The
+		// arm exists today to satisfy the `exhaustive` linter; until #5328
+		// lands we surface obo.ErrEnterpriseRequired so callers can use
+		// errors.Is to distinguish "type known but not wired" from a genuinely
+		// unknown type. The CRD enum currently rejects "obo" at the apiserver
+		// layer, so this arm is unreachable in upstream-only builds.
+		return fmt.Errorf("obo dispatch not yet wired: %w", obo.ErrEnterpriseRequired)
 	default:
 		return fmt.Errorf("unsupported external auth type: %s", externalAuthConfig.Spec.Type)
 	}

--- a/cmd/thv-operator/pkg/controllerutil/tokenexchange.go
+++ b/cmd/thv-operator/pkg/controllerutil/tokenexchange.go
@@ -6,6 +6,7 @@ package controllerutil
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -43,9 +44,18 @@ type OBOHandler struct {
 	SecretEnvVars func(*mcpv1beta1.MCPExternalAuthConfig) ([]corev1.EnvVar, error)
 }
 
+// oboMu guards reads and writes of oboHandler. Reads dispatched through the
+// exported OBOValidate / OBOSecretEnvVars / OBOApplyRunConfig wrappers take an
+// RLock; RegisterOBOHandler takes the write lock. Production reads today all
+// happen on a single reconcile-loop goroutine, but the lock is here so that
+// out-of-tree builds adding a hot-reload feature or admission-webhook
+// re-registration do not introduce a latent data race.
+var oboMu sync.RWMutex
+
 // oboHandler holds the package-level OBO handler. The default implementation
 // returns obo.ErrEnterpriseRequired from each method; an out-of-tree build
-// replaces it via RegisterOBOHandler.
+// replaces it via RegisterOBOHandler. Access only through currentOBOHandler
+// (read) or RegisterOBOHandler (write) so the mutex contract is preserved.
 var oboHandler = OBOHandler{
 	Validate: func(*mcpv1beta1.MCPExternalAuthConfig) error { return obo.ErrEnterpriseRequired },
 	ApplyRunConfig: func(context.Context, client.Client, string,
@@ -57,24 +67,50 @@ var oboHandler = OBOHandler{
 	},
 }
 
+// currentOBOHandler returns a snapshot of the registered handler under the
+// read lock so callers can dispatch through it without holding any lock for
+// the duration of the call.
+func currentOBOHandler() OBOHandler {
+	oboMu.RLock()
+	defer oboMu.RUnlock()
+	return oboHandler
+}
+
 // RegisterOBOHandler replaces the package-level OBO handler. It is intended
 // to be called exactly once during init() in an out-of-tree package that
 // blank-imports controllerutil. Calling it more than once is allowed and
 // last-write-wins; no panic on double-register, matching the existing
 // pkg/config.RegisterProviderFactory precedent.
-func RegisterOBOHandler(h OBOHandler) { oboHandler = h }
+//
+// Panics if any of the three function fields is nil — a partial registration
+// would nil-deref deep inside dispatch, far from the call site. Surfacing the
+// problem at process start (init() time) is far easier to diagnose than at
+// reconcile time.
+func RegisterOBOHandler(h OBOHandler) {
+	switch {
+	case h.Validate == nil:
+		panic("controllerutil.RegisterOBOHandler: Validate is nil")
+	case h.ApplyRunConfig == nil:
+		panic("controllerutil.RegisterOBOHandler: ApplyRunConfig is nil")
+	case h.SecretEnvVars == nil:
+		panic("controllerutil.RegisterOBOHandler: SecretEnvVars is nil")
+	}
+	oboMu.Lock()
+	defer oboMu.Unlock()
+	oboHandler = h
+}
 
 // OBOValidate runs the registered OBO handler's Validate function on the
 // supplied MCPExternalAuthConfig. With the default handler it returns
 // obo.ErrEnterpriseRequired.
 func OBOValidate(cfg *mcpv1beta1.MCPExternalAuthConfig) error {
-	return oboHandler.Validate(cfg)
+	return currentOBOHandler().Validate(cfg)
 }
 
 // OBOSecretEnvVars runs the registered OBO handler's SecretEnvVars function.
 // With the default handler it returns (nil, obo.ErrEnterpriseRequired).
 func OBOSecretEnvVars(cfg *mcpv1beta1.MCPExternalAuthConfig) ([]corev1.EnvVar, error) {
-	return oboHandler.SecretEnvVars(cfg)
+	return currentOBOHandler().SecretEnvVars(cfg)
 }
 
 // OBOApplyRunConfig runs the registered OBO handler's ApplyRunConfig function.
@@ -89,7 +125,7 @@ func OBOApplyRunConfig(
 	cfg *mcpv1beta1.MCPExternalAuthConfig,
 	opts *[]runner.RunConfigBuilderOption,
 ) error {
-	return oboHandler.ApplyRunConfig(ctx, c, namespace, cfg, opts)
+	return currentOBOHandler().ApplyRunConfig(ctx, c, namespace, cfg, opts)
 }
 
 // GenerateTokenExchangeEnvVars generates environment variables for token exchange

--- a/cmd/thv-operator/pkg/controllerutil/tokenexchange.go
+++ b/cmd/thv-operator/pkg/controllerutil/tokenexchange.go
@@ -5,6 +5,7 @@ package controllerutil
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
@@ -18,6 +19,70 @@ import (
 	"github.com/stacklok/toolhive/pkg/oauthproto/tokenexchange"
 	"github.com/stacklok/toolhive/pkg/runner"
 )
+
+// ErrEnterpriseRequired is returned by the default OBO handler when no
+// out-of-tree handler has been registered via RegisterOBOHandler. Callers
+// must use errors.Is to compare; the error wraps cleanly through
+// fmt.Errorf("...: %w", ...).
+var ErrEnterpriseRequired = errors.New(
+	"this MCPExternalAuthConfig type requires a build with an OBO handler registered via controllerutil.RegisterOBOHandler")
+
+// OBOHandler bundles the three operator-time dispatch points for OBO-typed
+// MCPExternalAuthConfig resources. An out-of-tree build replaces the default
+// instance (which returns ErrEnterpriseRequired from every method) by calling
+// RegisterOBOHandler once during init().
+type OBOHandler struct {
+	// Validate is called from MCPExternalAuthConfig validation to verify the
+	// resource's obo-typed config is well-formed.
+	Validate func(*mcpv1beta1.MCPExternalAuthConfig) error
+
+	// ApplyRunConfig is called from AddExternalAuthConfigOptions to apply
+	// OBO-specific runner configuration options for consuming MCPServer/
+	// MCPRemoteProxy resources.
+	ApplyRunConfig func(
+		ctx context.Context, c client.Client, namespace string,
+		cfg *mcpv1beta1.MCPExternalAuthConfig,
+		opts *[]runner.RunConfigBuilderOption,
+	) error
+
+	// SecretEnvVars is called when computing the consuming resource's pod
+	// environment, to inject any secrets the OBO flow needs at runtime.
+	SecretEnvVars func(*mcpv1beta1.MCPExternalAuthConfig) ([]corev1.EnvVar, error)
+}
+
+// oboHandler holds the package-level OBO handler. The default implementation
+// returns ErrEnterpriseRequired from each method; an out-of-tree build
+// replaces it via RegisterOBOHandler.
+var oboHandler = OBOHandler{
+	Validate: func(*mcpv1beta1.MCPExternalAuthConfig) error { return ErrEnterpriseRequired },
+	ApplyRunConfig: func(context.Context, client.Client, string,
+		*mcpv1beta1.MCPExternalAuthConfig, *[]runner.RunConfigBuilderOption) error {
+		return ErrEnterpriseRequired
+	},
+	SecretEnvVars: func(*mcpv1beta1.MCPExternalAuthConfig) ([]corev1.EnvVar, error) {
+		return nil, ErrEnterpriseRequired
+	},
+}
+
+// RegisterOBOHandler replaces the package-level OBO handler. It is intended
+// to be called exactly once during init() in an out-of-tree package that
+// blank-imports controllerutil. Calling it more than once is allowed and
+// last-write-wins; no panic on double-register, matching the existing
+// pkg/config.RegisterProviderFactory precedent.
+func RegisterOBOHandler(h OBOHandler) { oboHandler = h }
+
+// OBOValidate runs the registered OBO handler's Validate function on the
+// supplied MCPExternalAuthConfig. With the default handler it returns
+// ErrEnterpriseRequired.
+func OBOValidate(cfg *mcpv1beta1.MCPExternalAuthConfig) error {
+	return oboHandler.Validate(cfg)
+}
+
+// OBOSecretEnvVars runs the registered OBO handler's SecretEnvVars function.
+// With the default handler it returns (nil, ErrEnterpriseRequired).
+func OBOSecretEnvVars(cfg *mcpv1beta1.MCPExternalAuthConfig) ([]corev1.EnvVar, error) {
+	return oboHandler.SecretEnvVars(cfg)
+}
 
 // GenerateTokenExchangeEnvVars generates environment variables for token exchange
 func GenerateTokenExchangeEnvVars(
@@ -115,6 +180,12 @@ func AddExternalAuthConfigOptions(
 	case mcpv1beta1.ExternalAuthTypeUpstreamInject:
 		// Upstream inject is handled by the vMCP converter at runtime
 		return nil
+	case mcpv1beta1.ExternalAuthTypeOBO:
+		// OBO handler dispatch is wired in a follow-up task; the CRD enum
+		// currently rejects "obo" at the apiserver layer, so this arm is
+		// unreachable in upstream-only builds. The follow-up task will
+		// replace this body with a call into oboHandler.ApplyRunConfig.
+		return fmt.Errorf("unsupported external auth type: %s", externalAuthConfig.Spec.Type)
 	default:
 		return fmt.Errorf("unsupported external auth type: %s", externalAuthConfig.Spec.Type)
 	}

--- a/cmd/thv-operator/pkg/controllerutil/tokenexchange_test.go
+++ b/cmd/thv-operator/pkg/controllerutil/tokenexchange_test.go
@@ -6,7 +6,6 @@ package controllerutil
 import (
 	"context"
 	"errors"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -15,6 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/pkg/auth/obo"
 	"github.com/stacklok/toolhive/pkg/runner"
 )
 
@@ -27,15 +27,6 @@ func withDefaultOBOHandler(t *testing.T) {
 	t.Cleanup(func() { oboHandler = original })
 }
 
-func TestErrEnterpriseRequired_IsSentinel(t *testing.T) {
-	t.Parallel()
-
-	// Wrapping the sentinel and unwrapping with errors.Is must work both
-	// directly and through fmt.Errorf("...: %w", ...).
-	wrapped := fmt.Errorf("outer wrap: %w", ErrEnterpriseRequired)
-	assert.ErrorIs(t, wrapped, ErrEnterpriseRequired)
-}
-
 func TestDefaultOBOHandler_ReturnsEnterpriseRequired(t *testing.T) {
 	t.Parallel()
 
@@ -43,7 +34,7 @@ func TestDefaultOBOHandler_ReturnsEnterpriseRequired(t *testing.T) {
 		t.Parallel()
 		err := oboHandler.Validate(nil)
 		require.Error(t, err)
-		assert.ErrorIs(t, err, ErrEnterpriseRequired)
+		assert.ErrorIs(t, err, obo.ErrEnterpriseRequired)
 	})
 
 	t.Run("ApplyRunConfig", func(t *testing.T) {
@@ -51,7 +42,7 @@ func TestDefaultOBOHandler_ReturnsEnterpriseRequired(t *testing.T) {
 		var opts []runner.RunConfigBuilderOption
 		err := oboHandler.ApplyRunConfig(context.Background(), nil, "ns", nil, &opts)
 		require.Error(t, err)
-		assert.ErrorIs(t, err, ErrEnterpriseRequired)
+		assert.ErrorIs(t, err, obo.ErrEnterpriseRequired)
 		assert.Empty(t, opts, "default handler must not mutate the options slice")
 	})
 
@@ -59,7 +50,7 @@ func TestDefaultOBOHandler_ReturnsEnterpriseRequired(t *testing.T) {
 		t.Parallel()
 		envVars, err := oboHandler.SecretEnvVars(nil)
 		require.Error(t, err)
-		assert.ErrorIs(t, err, ErrEnterpriseRequired)
+		assert.ErrorIs(t, err, obo.ErrEnterpriseRequired)
 		assert.Nil(t, envVars, "default handler must return nil envVars on the error path")
 	})
 }
@@ -68,10 +59,10 @@ func TestDefaultOBOHandler_ReturnsEnterpriseRequired(t *testing.T) {
 func TestOBOValidate_DispatchesThroughRegisteredHandler(t *testing.T) {
 	withDefaultOBOHandler(t)
 
-	// With the default handler, OBOValidate returns ErrEnterpriseRequired.
+	// With the default handler, OBOValidate returns obo.ErrEnterpriseRequired.
 	err := OBOValidate(nil)
 	require.Error(t, err)
-	assert.ErrorIs(t, err, ErrEnterpriseRequired)
+	assert.ErrorIs(t, err, obo.ErrEnterpriseRequired)
 
 	// After registering a replacement, OBOValidate must dispatch through it.
 	sentinel := errors.New("custom validate failure")
@@ -97,10 +88,10 @@ func TestOBOValidate_DispatchesThroughRegisteredHandler(t *testing.T) {
 func TestOBOSecretEnvVars_DispatchesThroughRegisteredHandler(t *testing.T) {
 	withDefaultOBOHandler(t)
 
-	// With the default handler, OBOSecretEnvVars returns ErrEnterpriseRequired.
+	// With the default handler, OBOSecretEnvVars returns obo.ErrEnterpriseRequired.
 	envVars, err := OBOSecretEnvVars(nil)
 	require.Error(t, err)
-	assert.ErrorIs(t, err, ErrEnterpriseRequired)
+	assert.ErrorIs(t, err, obo.ErrEnterpriseRequired)
 	assert.Nil(t, envVars)
 
 	// After registering a replacement, OBOSecretEnvVars must dispatch through it.
@@ -127,12 +118,12 @@ func TestOBOSecretEnvVars_DispatchesThroughRegisteredHandler(t *testing.T) {
 func TestOBOApplyRunConfig_DispatchesThroughRegisteredHandler(t *testing.T) {
 	withDefaultOBOHandler(t)
 
-	// With the default handler, OBOApplyRunConfig returns ErrEnterpriseRequired
+	// With the default handler, OBOApplyRunConfig returns obo.ErrEnterpriseRequired
 	// without mutating the options slice.
 	var opts []runner.RunConfigBuilderOption
 	err := OBOApplyRunConfig(context.Background(), nil, "ns", nil, &opts)
 	require.Error(t, err)
-	assert.ErrorIs(t, err, ErrEnterpriseRequired)
+	assert.ErrorIs(t, err, obo.ErrEnterpriseRequired)
 	assert.Empty(t, opts, "default handler must not mutate the options slice")
 
 	// After registering a replacement, OBOApplyRunConfig must dispatch through it.

--- a/cmd/thv-operator/pkg/controllerutil/tokenexchange_test.go
+++ b/cmd/thv-operator/pkg/controllerutil/tokenexchange_test.go
@@ -124,6 +124,38 @@ func TestOBOSecretEnvVars_DispatchesThroughRegisteredHandler(t *testing.T) {
 }
 
 //nolint:paralleltest // Mutates package-level oboHandler; must not race other tests.
+func TestOBOApplyRunConfig_DispatchesThroughRegisteredHandler(t *testing.T) {
+	withDefaultOBOHandler(t)
+
+	// With the default handler, OBOApplyRunConfig returns ErrEnterpriseRequired
+	// without mutating the options slice.
+	var opts []runner.RunConfigBuilderOption
+	err := OBOApplyRunConfig(context.Background(), nil, "ns", nil, &opts)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrEnterpriseRequired)
+	assert.Empty(t, opts, "default handler must not mutate the options slice")
+
+	// After registering a replacement, OBOApplyRunConfig must dispatch through it.
+	sentinel := errors.New("custom apply failure")
+	RegisterOBOHandler(OBOHandler{
+		Validate: func(*mcpv1beta1.MCPExternalAuthConfig) error { return nil },
+		ApplyRunConfig: func(
+			context.Context, client.Client, string,
+			*mcpv1beta1.MCPExternalAuthConfig, *[]runner.RunConfigBuilderOption,
+		) error {
+			return sentinel
+		},
+		SecretEnvVars: func(*mcpv1beta1.MCPExternalAuthConfig) ([]corev1.EnvVar, error) {
+			return nil, nil
+		},
+	})
+
+	err = OBOApplyRunConfig(context.Background(), nil, "ns", nil, &opts)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, sentinel, "OBOApplyRunConfig must dispatch through the registered handler")
+}
+
+//nolint:paralleltest // Mutates package-level oboHandler; must not race other tests.
 func TestRegisterOBOHandler_LastWriteWins(t *testing.T) {
 	withDefaultOBOHandler(t)
 

--- a/cmd/thv-operator/pkg/controllerutil/tokenexchange_test.go
+++ b/cmd/thv-operator/pkg/controllerutil/tokenexchange_test.go
@@ -20,19 +20,34 @@ import (
 
 // withDefaultOBOHandler captures the package-level OBO handler and restores it
 // on cleanup so that tests which call RegisterOBOHandler do not leak state to
-// other tests in the package.
+// other tests in the package. The capture and restore both pass through
+// oboMu so they participate in the same synchronization contract as
+// production reads/writes.
 func withDefaultOBOHandler(t *testing.T) {
 	t.Helper()
+	oboMu.RLock()
 	original := oboHandler
-	t.Cleanup(func() { oboHandler = original })
+	oboMu.RUnlock()
+	t.Cleanup(func() {
+		oboMu.Lock()
+		oboHandler = original
+		oboMu.Unlock()
+	})
 }
 
 func TestDefaultOBOHandler_ReturnsEnterpriseRequired(t *testing.T) {
 	t.Parallel()
 
+	// Read the default handler under the read lock so this test does not
+	// data-race other tests that may run sequentially and write through
+	// RegisterOBOHandler. The subtests below dispatch through this snapshot
+	// rather than through the public wrappers so the assertion targets the
+	// default OBOHandler value specifically.
+	defaults := currentOBOHandler()
+
 	t.Run("Validate", func(t *testing.T) {
 		t.Parallel()
-		err := oboHandler.Validate(nil)
+		err := defaults.Validate(nil)
 		require.Error(t, err)
 		assert.ErrorIs(t, err, obo.ErrEnterpriseRequired)
 	})
@@ -40,7 +55,7 @@ func TestDefaultOBOHandler_ReturnsEnterpriseRequired(t *testing.T) {
 	t.Run("ApplyRunConfig", func(t *testing.T) {
 		t.Parallel()
 		var opts []runner.RunConfigBuilderOption
-		err := oboHandler.ApplyRunConfig(context.Background(), nil, "ns", nil, &opts)
+		err := defaults.ApplyRunConfig(context.Background(), nil, "ns", nil, &opts)
 		require.Error(t, err)
 		assert.ErrorIs(t, err, obo.ErrEnterpriseRequired)
 		assert.Empty(t, opts, "default handler must not mutate the options slice")
@@ -48,7 +63,7 @@ func TestDefaultOBOHandler_ReturnsEnterpriseRequired(t *testing.T) {
 
 	t.Run("SecretEnvVars", func(t *testing.T) {
 		t.Parallel()
-		envVars, err := oboHandler.SecretEnvVars(nil)
+		envVars, err := defaults.SecretEnvVars(nil)
 		require.Error(t, err)
 		assert.ErrorIs(t, err, obo.ErrEnterpriseRequired)
 		assert.Nil(t, envVars, "default handler must return nil envVars on the error path")
@@ -183,7 +198,39 @@ func TestRegisterOBOHandler_LastWriteWins(t *testing.T) {
 	_, err := OBOSecretEnvVars(nil)
 	assert.ErrorIs(t, err, second)
 	assert.ErrorIs(t,
-		oboHandler.ApplyRunConfig(context.Background(), nil, "ns", nil, nil),
+		OBOApplyRunConfig(context.Background(), nil, "ns", nil, nil),
 		second,
 	)
+}
+
+//nolint:paralleltest // Mutates package-level oboHandler; must not race other tests.
+func TestRegisterOBOHandler_PanicsOnNilField(t *testing.T) {
+	withDefaultOBOHandler(t)
+
+	validate := func(*mcpv1beta1.MCPExternalAuthConfig) error { return nil }
+	applyRunConfig := func(
+		context.Context, client.Client, string,
+		*mcpv1beta1.MCPExternalAuthConfig, *[]runner.RunConfigBuilderOption,
+	) error {
+		return nil
+	}
+	secretEnvVars := func(*mcpv1beta1.MCPExternalAuthConfig) ([]corev1.EnvVar, error) {
+		return nil, nil
+	}
+
+	tests := []struct {
+		name    string
+		handler OBOHandler
+	}{
+		{name: "Validate nil", handler: OBOHandler{ApplyRunConfig: applyRunConfig, SecretEnvVars: secretEnvVars}},
+		{name: "ApplyRunConfig nil", handler: OBOHandler{Validate: validate, SecretEnvVars: secretEnvVars}},
+		{name: "SecretEnvVars nil", handler: OBOHandler{Validate: validate, ApplyRunConfig: applyRunConfig}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Panics(t, func() { RegisterOBOHandler(tt.handler) },
+				"RegisterOBOHandler must panic when any function field is nil")
+		})
+	}
 }

--- a/cmd/thv-operator/pkg/controllerutil/tokenexchange_test.go
+++ b/cmd/thv-operator/pkg/controllerutil/tokenexchange_test.go
@@ -1,0 +1,166 @@
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package controllerutil
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/pkg/runner"
+)
+
+// withDefaultOBOHandler captures the package-level OBO handler and restores it
+// on cleanup so that tests which call RegisterOBOHandler do not leak state to
+// other tests in the package.
+func withDefaultOBOHandler(t *testing.T) {
+	t.Helper()
+	original := oboHandler
+	t.Cleanup(func() { oboHandler = original })
+}
+
+func TestErrEnterpriseRequired_IsSentinel(t *testing.T) {
+	t.Parallel()
+
+	// Wrapping the sentinel and unwrapping with errors.Is must work both
+	// directly and through fmt.Errorf("...: %w", ...).
+	wrapped := fmt.Errorf("outer wrap: %w", ErrEnterpriseRequired)
+	assert.ErrorIs(t, wrapped, ErrEnterpriseRequired)
+}
+
+func TestDefaultOBOHandler_ReturnsEnterpriseRequired(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Validate", func(t *testing.T) {
+		t.Parallel()
+		err := oboHandler.Validate(nil)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrEnterpriseRequired)
+	})
+
+	t.Run("ApplyRunConfig", func(t *testing.T) {
+		t.Parallel()
+		var opts []runner.RunConfigBuilderOption
+		err := oboHandler.ApplyRunConfig(context.Background(), nil, "ns", nil, &opts)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrEnterpriseRequired)
+		assert.Empty(t, opts, "default handler must not mutate the options slice")
+	})
+
+	t.Run("SecretEnvVars", func(t *testing.T) {
+		t.Parallel()
+		envVars, err := oboHandler.SecretEnvVars(nil)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrEnterpriseRequired)
+		assert.Nil(t, envVars, "default handler must return nil envVars on the error path")
+	})
+}
+
+//nolint:paralleltest // Mutates package-level oboHandler; must not race other tests.
+func TestOBOValidate_DispatchesThroughRegisteredHandler(t *testing.T) {
+	withDefaultOBOHandler(t)
+
+	// With the default handler, OBOValidate returns ErrEnterpriseRequired.
+	err := OBOValidate(nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrEnterpriseRequired)
+
+	// After registering a replacement, OBOValidate must dispatch through it.
+	sentinel := errors.New("custom validate failure")
+	RegisterOBOHandler(OBOHandler{
+		Validate: func(*mcpv1beta1.MCPExternalAuthConfig) error { return sentinel },
+		ApplyRunConfig: func(
+			context.Context, client.Client, string,
+			*mcpv1beta1.MCPExternalAuthConfig, *[]runner.RunConfigBuilderOption,
+		) error {
+			return nil
+		},
+		SecretEnvVars: func(*mcpv1beta1.MCPExternalAuthConfig) ([]corev1.EnvVar, error) {
+			return nil, nil
+		},
+	})
+
+	err = OBOValidate(nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, sentinel, "OBOValidate must dispatch through the registered handler")
+}
+
+//nolint:paralleltest // Mutates package-level oboHandler; must not race other tests.
+func TestOBOSecretEnvVars_DispatchesThroughRegisteredHandler(t *testing.T) {
+	withDefaultOBOHandler(t)
+
+	// With the default handler, OBOSecretEnvVars returns ErrEnterpriseRequired.
+	envVars, err := OBOSecretEnvVars(nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrEnterpriseRequired)
+	assert.Nil(t, envVars)
+
+	// After registering a replacement, OBOSecretEnvVars must dispatch through it.
+	expected := []corev1.EnvVar{{Name: "OBO_TEST", Value: "value"}}
+	RegisterOBOHandler(OBOHandler{
+		Validate: func(*mcpv1beta1.MCPExternalAuthConfig) error { return nil },
+		ApplyRunConfig: func(
+			context.Context, client.Client, string,
+			*mcpv1beta1.MCPExternalAuthConfig, *[]runner.RunConfigBuilderOption,
+		) error {
+			return nil
+		},
+		SecretEnvVars: func(*mcpv1beta1.MCPExternalAuthConfig) ([]corev1.EnvVar, error) {
+			return expected, nil
+		},
+	})
+
+	envVars, err = OBOSecretEnvVars(nil)
+	require.NoError(t, err)
+	assert.Equal(t, expected, envVars)
+}
+
+//nolint:paralleltest // Mutates package-level oboHandler; must not race other tests.
+func TestRegisterOBOHandler_LastWriteWins(t *testing.T) {
+	withDefaultOBOHandler(t)
+
+	first := errors.New("first")
+	second := errors.New("second")
+
+	RegisterOBOHandler(OBOHandler{
+		Validate: func(*mcpv1beta1.MCPExternalAuthConfig) error { return first },
+		ApplyRunConfig: func(
+			context.Context, client.Client, string,
+			*mcpv1beta1.MCPExternalAuthConfig, *[]runner.RunConfigBuilderOption,
+		) error {
+			return first
+		},
+		SecretEnvVars: func(*mcpv1beta1.MCPExternalAuthConfig) ([]corev1.EnvVar, error) {
+			return nil, first
+		},
+	})
+	RegisterOBOHandler(OBOHandler{
+		Validate: func(*mcpv1beta1.MCPExternalAuthConfig) error { return second },
+		ApplyRunConfig: func(
+			context.Context, client.Client, string,
+			*mcpv1beta1.MCPExternalAuthConfig, *[]runner.RunConfigBuilderOption,
+		) error {
+			return second
+		},
+		SecretEnvVars: func(*mcpv1beta1.MCPExternalAuthConfig) ([]corev1.EnvVar, error) {
+			return nil, second
+		},
+	})
+
+	// The second registration must win on every method.
+	assert.ErrorIs(t, OBOValidate(nil), second)
+	_, err := OBOSecretEnvVars(nil)
+	assert.ErrorIs(t, err, second)
+	assert.ErrorIs(t,
+		oboHandler.ApplyRunConfig(context.Background(), nil, "ns", nil, nil),
+		second,
+	)
+}

--- a/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_virtualmcpservers.yaml
+++ b/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_virtualmcpservers.yaml
@@ -1835,7 +1835,7 @@ spec:
                             type:
                               description: 'Type is the auth strategy: "unauthenticated",
                                 "header_injection", "token_exchange", "upstream_inject",
-                                "aws_sts"'
+                                "aws_sts", "obo"'
                               type: string
                             upstreamInject:
                               description: |-
@@ -2006,7 +2006,7 @@ spec:
                           type:
                             description: 'Type is the auth strategy: "unauthenticated",
                               "header_injection", "token_exchange", "upstream_inject",
-                              "aws_sts"'
+                              "aws_sts", "obo"'
                             type: string
                           upstreamInject:
                             description: |-
@@ -4673,7 +4673,7 @@ spec:
                             type:
                               description: 'Type is the auth strategy: "unauthenticated",
                                 "header_injection", "token_exchange", "upstream_inject",
-                                "aws_sts"'
+                                "aws_sts", "obo"'
                               type: string
                             upstreamInject:
                               description: |-
@@ -4844,7 +4844,7 @@ spec:
                           type:
                             description: 'Type is the auth strategy: "unauthenticated",
                               "header_injection", "token_exchange", "upstream_inject",
-                              "aws_sts"'
+                              "aws_sts", "obo"'
                             type: string
                           upstreamInject:
                             description: |-

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_virtualmcpservers.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_virtualmcpservers.yaml
@@ -1838,7 +1838,7 @@ spec:
                             type:
                               description: 'Type is the auth strategy: "unauthenticated",
                                 "header_injection", "token_exchange", "upstream_inject",
-                                "aws_sts"'
+                                "aws_sts", "obo"'
                               type: string
                             upstreamInject:
                               description: |-
@@ -2009,7 +2009,7 @@ spec:
                           type:
                             description: 'Type is the auth strategy: "unauthenticated",
                               "header_injection", "token_exchange", "upstream_inject",
-                              "aws_sts"'
+                              "aws_sts", "obo"'
                             type: string
                           upstreamInject:
                             description: |-
@@ -4676,7 +4676,7 @@ spec:
                             type:
                               description: 'Type is the auth strategy: "unauthenticated",
                                 "header_injection", "token_exchange", "upstream_inject",
-                                "aws_sts"'
+                                "aws_sts", "obo"'
                               type: string
                             upstreamInject:
                               description: |-
@@ -4847,7 +4847,7 @@ spec:
                           type:
                             description: 'Type is the auth strategy: "unauthenticated",
                               "header_injection", "token_exchange", "upstream_inject",
-                              "aws_sts"'
+                              "aws_sts", "obo"'
                             type: string
                           upstreamInject:
                             description: |-

--- a/docs/operator/crd-api.md
+++ b/docs/operator/crd-api.md
@@ -97,7 +97,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `type` _string_ | Type is the auth strategy: "unauthenticated", "header_injection", "token_exchange", "upstream_inject", "aws_sts" |  |  |
+| `type` _string_ | Type is the auth strategy: "unauthenticated", "header_injection", "token_exchange", "upstream_inject", "aws_sts", "obo" |  |  |
 | `headerInjection` _[auth.types.HeaderInjectionConfig](#authtypesheaderinjectionconfig)_ | HeaderInjection contains configuration for header injection auth strategy.<br />Used when Type = "header_injection". |  |  |
 | `tokenExchange` _[auth.types.TokenExchangeConfig](#authtypestokenexchangeconfig)_ | TokenExchange contains configuration for token exchange auth strategy.<br />Used when Type = "token_exchange". |  |  |
 | `upstreamInject` _[auth.types.UpstreamInjectConfig](#authtypesupstreaminjectconfig)_ | UpstreamInject contains configuration for upstream inject auth strategy.<br />Used when Type = "upstream_inject". |  |  |

--- a/docs/operator/crd-api.md
+++ b/docs/operator/crd-api.md
@@ -1425,6 +1425,7 @@ _Appears in:_
 | `embeddedAuthServer` | ExternalAuthTypeEmbeddedAuthServer is the type for embedded OAuth2/OIDC authorization server<br />This enables running an embedded auth server that delegates to upstream IDPs<br /> |
 | `awsSts` | ExternalAuthTypeAWSSts is the type for AWS STS authentication<br /> |
 | `upstreamInject` | ExternalAuthTypeUpstreamInject is the type for upstream token injection<br />This injects an upstream IDP access token as the Authorization: Bearer header<br /> |
+| `obo` | ExternalAuthTypeOBO is the type for on-behalf-of (OBO) flows.<br />This type requires a build with an OBO handler registered via<br />controllerutil.RegisterOBOHandler; an upstream-only build surfaces<br />status.conditions[Valid] = False with Reason: EnterpriseRequired<br />when an obo-typed MCPExternalAuthConfig is applied.<br /> |
 
 
 #### api.v1beta1.HeaderForwardConfig

--- a/pkg/auth/obo/errors.go
+++ b/pkg/auth/obo/errors.go
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package obo
+
+import "errors"
+
+// ErrEnterpriseRequired is returned by every default OBO dispatch point — the
+// controllerutil handler hook, the vMCP converter stub, and the middleware
+// stub — when no out-of-tree handler/factory has been registered. Callers must
+// use errors.Is to compare; the error wraps cleanly through
+// fmt.Errorf("...: %w", ...).
+//
+// Lives in pkg/auth/obo (a leaf package) so that callers in
+// cmd/thv-operator/... and pkg/vmcp/... can share the same sentinel without
+// either layer importing the other. To register an out-of-tree handler, see
+// controllerutil.RegisterOBOHandler (for the operator dispatch points) and
+// obo.RegisterFactory (for the proxy middleware factory).
+var ErrEnterpriseRequired = errors.New(
+	"on-behalf-of (OBO) external auth type requires an enterprise build")

--- a/pkg/auth/obo/errors_test.go
+++ b/pkg/auth/obo/errors_test.go
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package obo
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestErrEnterpriseRequired_IsSentinel(t *testing.T) {
+	t.Parallel()
+
+	// Wrapping the sentinel and unwrapping with errors.Is must work both
+	// directly and through fmt.Errorf("...: %w", ...).
+	wrapped := fmt.Errorf("outer wrap: %w", ErrEnterpriseRequired)
+	assert.ErrorIs(t, wrapped, ErrEnterpriseRequired)
+}

--- a/pkg/auth/obo/middleware.go
+++ b/pkg/auth/obo/middleware.go
@@ -9,6 +9,7 @@ package obo
 
 import (
 	"net/http"
+	"sync"
 
 	"github.com/stacklok/toolhive/pkg/transport/types"
 )
@@ -44,20 +45,52 @@ func (*stub) Handler() types.MiddlewareFunction {
 // Close is a no-op for the stub middleware.
 func (*stub) Close() error { return nil }
 
-// CreateMiddleware is the package-level middleware factory. By default it
-// adds a stub middleware whose handler returns 503 on every request. An
-// out-of-tree build replaces it by calling RegisterFactory once during
-// init(); the literal map in pkg/runner/middleware.go captures this
-// variable's current value at runner-construction time, so all
-// RegisterFactory calls must complete before the first runner is
-// constructed (this is satisfied in practice because runner construction
-// happens inside app.Run() after all init() functions have fired).
-var CreateMiddleware types.MiddlewareFactory = func(config *types.MiddlewareConfig, runner types.MiddlewareRunner) error {
+// factoryMu guards reads and writes of currentFactory. Each call to
+// CreateMiddleware takes the read lock; RegisterFactory takes the write lock.
+// The mutex makes hot-reload / re-registration safe in case a future caller
+// (e.g. an admission webhook) wires it up, even though production today only
+// ever writes during init().
+var factoryMu sync.RWMutex
+
+// currentFactory holds the actual middleware factory dispatched to by
+// CreateMiddleware. The default returns a 503 stub; an out-of-tree build
+// replaces it via RegisterFactory.
+var currentFactory types.MiddlewareFactory = DefaultFactory
+
+// DefaultFactory adds a stub middleware whose handler responds 503 to every
+// request. Exposed primarily so external test code (e.g. pkg/runner) can pass
+// it to RegisterFactory in a t.Cleanup to restore the package's default
+// behavior after a test mutates currentFactory.
+func DefaultFactory(config *types.MiddlewareConfig, runner types.MiddlewareRunner) error {
 	runner.AddMiddleware(config.Type, &stub{})
 	return nil
 }
 
-// RegisterFactory replaces the package-level CreateMiddleware. Calling it
+// CreateMiddleware is the package-level middleware factory. It is a stable
+// indirection over currentFactory: each call dispatches to whatever factory
+// is registered at call time, so out-of-tree builds replacing the factory
+// via RegisterFactory take effect on subsequent calls even if a caller has
+// already captured CreateMiddleware itself (e.g. pkg/runner builds its
+// factory map once and reuses it across runner instances). The default
+// produces a 503 stub.
+var CreateMiddleware types.MiddlewareFactory = func(config *types.MiddlewareConfig, runner types.MiddlewareRunner) error {
+	factoryMu.RLock()
+	f := currentFactory
+	factoryMu.RUnlock()
+	return f(config, runner)
+}
+
+// RegisterFactory replaces the underlying middleware factory. Calling it
 // more than once is allowed and last-write-wins, matching the existing
-// pkg/config.RegisterProviderFactory precedent.
-func RegisterFactory(f types.MiddlewareFactory) { CreateMiddleware = f }
+// pkg/config.RegisterProviderFactory precedent. Panics if f is nil — a nil
+// factory would dispatch into a nil function on the next CreateMiddleware
+// call, far from the registration site; surface the problem at init() time
+// instead.
+func RegisterFactory(f types.MiddlewareFactory) {
+	if f == nil {
+		panic("obo.RegisterFactory: factory is nil")
+	}
+	factoryMu.Lock()
+	defer factoryMu.Unlock()
+	currentFactory = f
+}

--- a/pkg/auth/obo/middleware.go
+++ b/pkg/auth/obo/middleware.go
@@ -73,7 +73,12 @@ func DefaultFactory(config *types.MiddlewareConfig, runner types.MiddlewareRunne
 // already captured CreateMiddleware itself (e.g. pkg/runner builds its
 // factory map once and reuses it across runner instances). The default
 // produces a 503 stub.
-var CreateMiddleware types.MiddlewareFactory = func(config *types.MiddlewareConfig, runner types.MiddlewareRunner) error {
+//
+// Declared as a function (matching sibling middleware packages such as
+// awssts, upstreamswap, and oauthproto/tokenexchange) so RegisterFactory is
+// the only mutation path — there is no second escape hatch via direct
+// assignment to CreateMiddleware.
+func CreateMiddleware(config *types.MiddlewareConfig, runner types.MiddlewareRunner) error {
 	factoryMu.RLock()
 	f := currentFactory
 	factoryMu.RUnlock()

--- a/pkg/auth/obo/middleware.go
+++ b/pkg/auth/obo/middleware.go
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package obo provides the proxy-runtime middleware factory hook for the
+// on-behalf-of (OBO) external auth type. The default factory produces a
+// stub middleware that responds 503 to every request. An out-of-tree build
+// replaces the factory by calling RegisterFactory once during init().
+package obo
+
+import (
+	"net/http"
+
+	"github.com/stacklok/toolhive/pkg/transport/types"
+)
+
+// MiddlewareType is the type identifier used in MiddlewareConfig.Type for
+// OBO middleware. Matches the ExternalAuthType constant value "obo".
+const MiddlewareType = "obo"
+
+// stubMessage is the body returned by the default 503 handler. It is exported
+// at package scope so tests can match on it without duplicating the literal.
+const stubMessage = "obo requires a build with a registered OBO middleware factory"
+
+// stub is the default Middleware implementation. Its handler responds 503
+// with a body explaining that the OBO middleware factory has not been
+// registered. It is never instantiated except by the default CreateMiddleware
+// factory, which an out-of-tree build replaces via RegisterFactory.
+type stub struct{}
+
+// Handler returns a MiddlewareFunction that wraps any downstream handler with
+// a 503 response. The downstream handler is intentionally never called — the
+// stub is the user-visible signal that the OBO middleware factory has not
+// been registered.
+func (*stub) Handler() types.MiddlewareFunction {
+	return func(http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, stubMessage, http.StatusServiceUnavailable)
+		})
+	}
+}
+
+// Close is a no-op for the stub middleware.
+func (*stub) Close() error { return nil }
+
+// CreateMiddleware is the package-level middleware factory. By default it
+// adds a stub middleware whose handler returns 503 on every request. An
+// out-of-tree build replaces it by calling RegisterFactory once during
+// init(); the literal map in pkg/runner/middleware.go captures this
+// variable's current value at runner-construction time, so all
+// RegisterFactory calls must complete before the first runner is
+// constructed (this is satisfied in practice because runner construction
+// happens inside app.Run() after all init() functions have fired).
+var CreateMiddleware types.MiddlewareFactory = func(config *types.MiddlewareConfig, runner types.MiddlewareRunner) error {
+	runner.AddMiddleware(config.Type, &stub{})
+	return nil
+}
+
+// RegisterFactory replaces the package-level CreateMiddleware. Calling it
+// more than once is allowed and last-write-wins, matching the existing
+// pkg/config.RegisterProviderFactory precedent.
+func RegisterFactory(f types.MiddlewareFactory) { CreateMiddleware = f }

--- a/pkg/auth/obo/middleware.go
+++ b/pkg/auth/obo/middleware.go
@@ -17,8 +17,10 @@ import (
 // OBO middleware. Matches the ExternalAuthType constant value "obo".
 const MiddlewareType = "obo"
 
-// stubMessage is the body returned by the default 503 handler. It is exported
-// at package scope so tests can match on it without duplicating the literal.
+// stubMessage is the body returned by the default 503 handler. It is shared
+// between the default handler and tests in this package so the exact literal
+// is only spelled once. Unexported because no caller outside this package has
+// a use for it — tests reference it directly.
 const stubMessage = "obo requires a build with a registered OBO middleware factory"
 
 // stub is the default Middleware implementation. Its handler responds 503

--- a/pkg/auth/obo/middleware_test.go
+++ b/pkg/auth/obo/middleware_test.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -91,10 +90,12 @@ func TestStubHandler_Returns503(t *testing.T) {
 
 			assert.Equal(t, http.StatusServiceUnavailable, rec.Code,
 				"stub handler must respond 503, not call downstream")
-			assert.True(t, strings.Contains(rec.Body.String(), "OBO middleware factory") ||
-				strings.Contains(rec.Body.String(), "registered OBO middleware factory"),
-				"response body should mention OBO middleware factory registration; got: %s",
-				rec.Body.String())
+			// http.Error appends a newline to the supplied message; assert on
+			// the exact body so the cross-file contract with stubMessage stays
+			// pinned (any change to stubMessage that wasn't intentional
+			// breaks this test loudly).
+			assert.Equal(t, stubMessage+"\n", rec.Body.String(),
+				"stub handler must echo the package stubMessage constant")
 		})
 	}
 }

--- a/pkg/auth/obo/middleware_test.go
+++ b/pkg/auth/obo/middleware_test.go
@@ -1,0 +1,139 @@
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package obo
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/stacklok/toolhive/pkg/transport/types"
+	"github.com/stacklok/toolhive/pkg/transport/types/mocks"
+)
+
+// withDefaultFactory swaps the package-level CreateMiddleware for the duration
+// of a test, restoring the original on cleanup so tests that mutate the global
+// state do not leak into each other.
+func withDefaultFactory(t *testing.T) {
+	t.Helper()
+	original := CreateMiddleware
+	t.Cleanup(func() { CreateMiddleware = original })
+}
+
+func TestMiddlewareType(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "obo", MiddlewareType,
+		"MiddlewareType must equal the ExternalAuthType value 'obo'")
+}
+
+func TestDefaultCreateMiddleware_AddsStub(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockRunner := mocks.NewMockMiddlewareRunner(ctrl)
+	mockRunner.EXPECT().AddMiddleware(MiddlewareType, gomock.Any()).Times(1)
+
+	cfg := &types.MiddlewareConfig{Type: MiddlewareType}
+	require.NoError(t, CreateMiddleware(cfg, mockRunner))
+}
+
+func TestStubHandler_Returns503(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		downstream http.Handler
+		method     string
+		path       string
+	}{
+		{
+			name:       "nil downstream handler is ignored",
+			downstream: nil,
+			method:     http.MethodGet,
+			path:       "/anything",
+		},
+		{
+			name: "non-nil downstream handler is not invoked",
+			downstream: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				// If this is ever reached, the stub leaked through — the test
+				// asserts on the response code below to catch that.
+				w.WriteHeader(http.StatusTeapot)
+			}),
+			method: http.MethodPost,
+			path:   "/whatever",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			s := &stub{}
+			wrapper := s.Handler()
+			require.NotNil(t, wrapper)
+
+			h := wrapper(tt.downstream)
+			require.NotNil(t, h)
+
+			req := httptest.NewRequest(tt.method, tt.path, nil)
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+
+			assert.Equal(t, http.StatusServiceUnavailable, rec.Code,
+				"stub handler must respond 503, not call downstream")
+			assert.True(t, strings.Contains(rec.Body.String(), "OBO middleware factory") ||
+				strings.Contains(rec.Body.String(), "registered OBO middleware factory"),
+				"response body should mention OBO middleware factory registration; got: %s",
+				rec.Body.String())
+		})
+	}
+}
+
+func TestStub_Close(t *testing.T) {
+	t.Parallel()
+
+	assert.NoError(t, (&stub{}).Close(), "stub Close must be a no-op")
+}
+
+//nolint:paralleltest // Mutates package-level CreateMiddleware; must not race other tests.
+func TestRegisterFactory_ReplacesDefault(t *testing.T) {
+	withDefaultFactory(t)
+
+	var called bool
+	replacement := types.MiddlewareFactory(func(*types.MiddlewareConfig, types.MiddlewareRunner) error {
+		called = true
+		return nil
+	})
+	RegisterFactory(replacement)
+
+	// Calling through CreateMiddleware after RegisterFactory must dispatch to
+	// the replacement.
+	require.NoError(t, CreateMiddleware(&types.MiddlewareConfig{Type: MiddlewareType}, nil))
+	assert.True(t, called, "RegisterFactory must replace CreateMiddleware")
+}
+
+//nolint:paralleltest // Mutates package-level CreateMiddleware; must not race other tests.
+func TestRegisterFactory_LastWriteWins(t *testing.T) {
+	withDefaultFactory(t)
+
+	sentinel := errors.New("second factory")
+	RegisterFactory(func(*types.MiddlewareConfig, types.MiddlewareRunner) error {
+		return errors.New("first factory")
+	})
+	RegisterFactory(func(*types.MiddlewareConfig, types.MiddlewareRunner) error {
+		return sentinel
+	})
+
+	err := CreateMiddleware(&types.MiddlewareConfig{Type: MiddlewareType}, nil)
+	require.ErrorIs(t, err, sentinel, "second RegisterFactory must overwrite the first")
+}

--- a/pkg/auth/obo/middleware_test.go
+++ b/pkg/auth/obo/middleware_test.go
@@ -17,13 +17,21 @@ import (
 	"github.com/stacklok/toolhive/pkg/transport/types/mocks"
 )
 
-// withDefaultFactory swaps the package-level CreateMiddleware for the duration
-// of a test, restoring the original on cleanup so tests that mutate the global
-// state do not leak into each other.
+// withDefaultFactory captures the underlying middleware factory and restores
+// it on cleanup so tests that call RegisterFactory do not leak state to
+// other tests in the package. Capture and restore both pass through
+// factoryMu so they participate in the same synchronization contract as
+// production reads/writes.
 func withDefaultFactory(t *testing.T) {
 	t.Helper()
-	original := CreateMiddleware
-	t.Cleanup(func() { CreateMiddleware = original })
+	factoryMu.RLock()
+	original := currentFactory
+	factoryMu.RUnlock()
+	t.Cleanup(func() {
+		factoryMu.Lock()
+		currentFactory = original
+		factoryMu.Unlock()
+	})
 }
 
 func TestMiddlewareType(t *testing.T) {
@@ -106,7 +114,7 @@ func TestStub_Close(t *testing.T) {
 	assert.NoError(t, (&stub{}).Close(), "stub Close must be a no-op")
 }
 
-//nolint:paralleltest // Mutates package-level CreateMiddleware; must not race other tests.
+//nolint:paralleltest // Mutates package-level currentFactory; must not race other tests.
 func TestRegisterFactory_ReplacesDefault(t *testing.T) {
 	withDefaultFactory(t)
 
@@ -120,10 +128,10 @@ func TestRegisterFactory_ReplacesDefault(t *testing.T) {
 	// Calling through CreateMiddleware after RegisterFactory must dispatch to
 	// the replacement.
 	require.NoError(t, CreateMiddleware(&types.MiddlewareConfig{Type: MiddlewareType}, nil))
-	assert.True(t, called, "RegisterFactory must replace CreateMiddleware")
+	assert.True(t, called, "RegisterFactory must replace the underlying factory")
 }
 
-//nolint:paralleltest // Mutates package-level CreateMiddleware; must not race other tests.
+//nolint:paralleltest // Mutates package-level currentFactory; must not race other tests.
 func TestRegisterFactory_LastWriteWins(t *testing.T) {
 	withDefaultFactory(t)
 
@@ -137,4 +145,11 @@ func TestRegisterFactory_LastWriteWins(t *testing.T) {
 
 	err := CreateMiddleware(&types.MiddlewareConfig{Type: MiddlewareType}, nil)
 	require.ErrorIs(t, err, sentinel, "second RegisterFactory must overwrite the first")
+}
+
+func TestRegisterFactory_PanicsOnNil(t *testing.T) {
+	t.Parallel()
+
+	assert.Panics(t, func() { RegisterFactory(nil) },
+		"RegisterFactory must panic when the supplied factory is nil")
 }

--- a/pkg/runner/middleware.go
+++ b/pkg/runner/middleware.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stacklok/toolhive/pkg/audit"
 	"github.com/stacklok/toolhive/pkg/auth"
 	"github.com/stacklok/toolhive/pkg/auth/awssts"
+	"github.com/stacklok/toolhive/pkg/auth/obo"
 	"github.com/stacklok/toolhive/pkg/auth/upstreamswap"
 	"github.com/stacklok/toolhive/pkg/authserver"
 	"github.com/stacklok/toolhive/pkg/authz"
@@ -33,6 +34,7 @@ func GetSupportedMiddlewareFactories() map[string]types.MiddlewareFactory {
 		tokenexchange.MiddlewareType:          tokenexchange.CreateMiddleware,
 		upstreamswap.MiddlewareType:           upstreamswap.CreateMiddleware,
 		awssts.MiddlewareType:                 awssts.CreateMiddleware,
+		obo.MiddlewareType:                    obo.CreateMiddleware,
 		mcp.ParserMiddlewareType:              mcp.CreateParserMiddleware,
 		mcp.ToolFilterMiddlewareType:          mcp.CreateToolFilterMiddleware,
 		mcp.ToolCallFilterMiddlewareType:      mcp.CreateToolCallFilterMiddleware,

--- a/pkg/runner/middleware_test.go
+++ b/pkg/runner/middleware_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stacklok/toolhive/pkg/audit"
 	"github.com/stacklok/toolhive/pkg/auth"
 	"github.com/stacklok/toolhive/pkg/auth/awssts"
+	"github.com/stacklok/toolhive/pkg/auth/obo"
 	"github.com/stacklok/toolhive/pkg/auth/upstreamswap"
 	"github.com/stacklok/toolhive/pkg/authserver"
 	"github.com/stacklok/toolhive/pkg/authz"
@@ -217,6 +218,7 @@ func TestGetSupportedMiddlewareFactories(t *testing.T) {
 		headerfwd.HeaderForwardMiddlewareName,
 		upstreamswap.MiddlewareType,
 		awssts.MiddlewareType,
+		obo.MiddlewareType,
 	} {
 		_, ok := factories[key]
 		assert.True(t, ok, "factory map should contain %q", key)

--- a/pkg/runner/middleware_test.go
+++ b/pkg/runner/middleware_test.go
@@ -225,37 +225,39 @@ func TestGetSupportedMiddlewareFactories(t *testing.T) {
 	}
 }
 
-// TestGetSupportedMiddlewareFactories_OBORegisterBeforeConstruction locks the
-// "register before construction" contract for obo.CreateMiddleware. Because
-// CreateMiddleware is a package-level `var`, the literal map in
-// GetSupportedMiddlewareFactories captures the current function value at the
-// moment the map is built. A test (or any other caller) that swaps the factory
-// before constructing the map gets the new factory; a caller that swaps after
-// the map is already built will silently retain the old factory through the
-// runner's supportedMiddleware lookup. This test documents and exercises the
-// expected pre-construction path so a future refactor does not break it.
+// TestGetSupportedMiddlewareFactories_OBODispatchesToCurrentFactory locks the
+// contract that obo.CreateMiddleware is a stable redirector: the literal map
+// in GetSupportedMiddlewareFactories captures CreateMiddleware once, but each
+// invocation reads obo's currentFactory under the package-level RWMutex, so
+// registrations that happen AFTER the map is built still take effect. The
+// register-then-call ordering exercises the production hot path; the
+// call-after-register ordering exercises hot-reload / re-registration.
 //
-//nolint:paralleltest // Mutates package-level obo.CreateMiddleware; must not race other tests.
-func TestGetSupportedMiddlewareFactories_OBORegisterBeforeConstruction(t *testing.T) {
-	original := obo.CreateMiddleware
-	t.Cleanup(func() { obo.RegisterFactory(original) })
+//nolint:paralleltest // Mutates package-level obo currentFactory; must not race other tests.
+func TestGetSupportedMiddlewareFactories_OBODispatchesToCurrentFactory(t *testing.T) {
+	// Build the factory map first so we capture the redirector before any
+	// out-of-test registration happens.
+	factories := GetSupportedMiddlewareFactories()
+	factory, ok := factories[obo.MiddlewareType]
+	require.True(t, ok, "obo factory should be present in the map")
 
 	sentinel := []byte("custom-obo-factory")
 	var observed []byte
-	obo.RegisterFactory(func(cfg *types.MiddlewareConfig, _ types.MiddlewareRunner) error {
+	replacement := func(cfg *types.MiddlewareConfig, _ types.MiddlewareRunner) error {
 		// Capture the marker the caller passes to prove which factory ran.
 		observed = cfg.Parameters
 		return nil
-	})
+	}
 
-	factories := GetSupportedMiddlewareFactories()
-	factory, ok := factories[obo.MiddlewareType]
-	require.True(t, ok, "obo factory should be present in the map after registration")
+	// Register AFTER the map was built. Because CreateMiddleware is a stable
+	// redirector, dispatching through the map must still hit the replacement.
+	obo.RegisterFactory(replacement)
+	t.Cleanup(func() { obo.RegisterFactory(obo.DefaultFactory) })
 
 	cfg := &types.MiddlewareConfig{Type: obo.MiddlewareType, Parameters: sentinel}
 	require.NoError(t, factory(cfg, nil))
 	assert.Equal(t, sentinel, observed,
-		"a factory registered before GetSupportedMiddlewareFactories must be the one captured in the map")
+		"obo.CreateMiddleware must redirect through the current factory, including after the runner map is built")
 }
 
 func TestWithHeaderForwardSecretsBuilderOption(t *testing.T) {

--- a/pkg/runner/middleware_test.go
+++ b/pkg/runner/middleware_test.go
@@ -225,6 +225,39 @@ func TestGetSupportedMiddlewareFactories(t *testing.T) {
 	}
 }
 
+// TestGetSupportedMiddlewareFactories_OBORegisterBeforeConstruction locks the
+// "register before construction" contract for obo.CreateMiddleware. Because
+// CreateMiddleware is a package-level `var`, the literal map in
+// GetSupportedMiddlewareFactories captures the current function value at the
+// moment the map is built. A test (or any other caller) that swaps the factory
+// before constructing the map gets the new factory; a caller that swaps after
+// the map is already built will silently retain the old factory through the
+// runner's supportedMiddleware lookup. This test documents and exercises the
+// expected pre-construction path so a future refactor does not break it.
+//
+//nolint:paralleltest // Mutates package-level obo.CreateMiddleware; must not race other tests.
+func TestGetSupportedMiddlewareFactories_OBORegisterBeforeConstruction(t *testing.T) {
+	original := obo.CreateMiddleware
+	t.Cleanup(func() { obo.RegisterFactory(original) })
+
+	sentinel := []byte("custom-obo-factory")
+	var observed []byte
+	obo.RegisterFactory(func(cfg *types.MiddlewareConfig, _ types.MiddlewareRunner) error {
+		// Capture the marker the caller passes to prove which factory ran.
+		observed = cfg.Parameters
+		return nil
+	})
+
+	factories := GetSupportedMiddlewareFactories()
+	factory, ok := factories[obo.MiddlewareType]
+	require.True(t, ok, "obo factory should be present in the map after registration")
+
+	cfg := &types.MiddlewareConfig{Type: obo.MiddlewareType, Parameters: sentinel}
+	require.NoError(t, factory(cfg, nil))
+	assert.Equal(t, sentinel, observed,
+		"a factory registered before GetSupportedMiddlewareFactories must be the one captured in the map")
+}
+
 func TestWithHeaderForwardSecretsBuilderOption(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/vmcp/auth/converters/interface.go
+++ b/pkg/vmcp/auth/converters/interface.go
@@ -75,7 +75,7 @@ func NewRegistry() *Registry {
 	r.Register(mcpv1beta1.ExternalAuthTypeUnauthenticated, &UnauthenticatedConverter{})
 	r.Register(mcpv1beta1.ExternalAuthTypeUpstreamInject, &UpstreamInjectConverter{})
 	r.Register(mcpv1beta1.ExternalAuthTypeAWSSts, &AwsStsConverter{})
-	r.Register(mcpv1beta1.ExternalAuthTypeOBO, &OBOConverterStub{})
+	r.Register(mcpv1beta1.ExternalAuthTypeOBO, &OBOConverter{})
 
 	return r
 }

--- a/pkg/vmcp/auth/converters/interface.go
+++ b/pkg/vmcp/auth/converters/interface.go
@@ -75,6 +75,7 @@ func NewRegistry() *Registry {
 	r.Register(mcpv1beta1.ExternalAuthTypeUnauthenticated, &UnauthenticatedConverter{})
 	r.Register(mcpv1beta1.ExternalAuthTypeUpstreamInject, &UpstreamInjectConverter{})
 	r.Register(mcpv1beta1.ExternalAuthTypeAWSSts, &AwsStsConverter{})
+	r.Register(mcpv1beta1.ExternalAuthTypeOBO, &OBOConverterStub{})
 
 	return r
 }

--- a/pkg/vmcp/auth/converters/obo.go
+++ b/pkg/vmcp/auth/converters/obo.go
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package converters
+
+import (
+	"context"
+	"fmt"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/pkg/controllerutil"
+	authtypes "github.com/stacklok/toolhive/pkg/vmcp/auth/types"
+)
+
+// OBOConverterStub is the default StrategyConverter for ExternalAuthTypeOBO.
+// Every method returns an error wrapping controllerutil.ErrEnterpriseRequired.
+// An out-of-tree build replaces it by calling DefaultRegistry().Register(...)
+// once during init().
+type OBOConverterStub struct{}
+
+// StrategyType returns the vMCP strategy identifier for OBO.
+func (*OBOConverterStub) StrategyType() string { return authtypes.StrategyTypeOBO }
+
+// ConvertToStrategy returns an error wrapping ErrEnterpriseRequired.
+func (*OBOConverterStub) ConvertToStrategy(
+	_ *mcpv1beta1.MCPExternalAuthConfig,
+) (*authtypes.BackendAuthStrategy, error) {
+	return nil, fmt.Errorf("vMCP OBO converter: %w", controllerutil.ErrEnterpriseRequired)
+}
+
+// ResolveSecrets returns an error wrapping ErrEnterpriseRequired.
+func (*OBOConverterStub) ResolveSecrets(
+	_ context.Context,
+	_ *mcpv1beta1.MCPExternalAuthConfig,
+	_ client.Client,
+	_ string,
+	_ *authtypes.BackendAuthStrategy,
+) (*authtypes.BackendAuthStrategy, error) {
+	return nil, fmt.Errorf("vMCP OBO converter: %w", controllerutil.ErrEnterpriseRequired)
+}

--- a/pkg/vmcp/auth/converters/obo.go
+++ b/pkg/vmcp/auth/converters/obo.go
@@ -10,33 +10,33 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
-	"github.com/stacklok/toolhive/cmd/thv-operator/pkg/controllerutil"
+	"github.com/stacklok/toolhive/pkg/auth/obo"
 	authtypes "github.com/stacklok/toolhive/pkg/vmcp/auth/types"
 )
 
-// OBOConverterStub is the default StrategyConverter for ExternalAuthTypeOBO.
-// Every method returns an error wrapping controllerutil.ErrEnterpriseRequired.
-// An out-of-tree build replaces it by calling DefaultRegistry().Register(...)
+// OBOConverter is the default StrategyConverter for ExternalAuthTypeOBO.
+// Every method returns an error wrapping obo.ErrEnterpriseRequired. An
+// out-of-tree build replaces it by calling DefaultRegistry().Register(...)
 // once during init().
-type OBOConverterStub struct{}
+type OBOConverter struct{}
 
 // StrategyType returns the vMCP strategy identifier for OBO.
-func (*OBOConverterStub) StrategyType() string { return authtypes.StrategyTypeOBO }
+func (*OBOConverter) StrategyType() string { return authtypes.StrategyTypeOBO }
 
-// ConvertToStrategy returns an error wrapping ErrEnterpriseRequired.
-func (*OBOConverterStub) ConvertToStrategy(
+// ConvertToStrategy returns an error wrapping obo.ErrEnterpriseRequired.
+func (*OBOConverter) ConvertToStrategy(
 	_ *mcpv1beta1.MCPExternalAuthConfig,
 ) (*authtypes.BackendAuthStrategy, error) {
-	return nil, fmt.Errorf("vMCP OBO converter: %w", controllerutil.ErrEnterpriseRequired)
+	return nil, fmt.Errorf("vMCP OBO converter: %w", obo.ErrEnterpriseRequired)
 }
 
-// ResolveSecrets returns an error wrapping ErrEnterpriseRequired.
-func (*OBOConverterStub) ResolveSecrets(
+// ResolveSecrets returns an error wrapping obo.ErrEnterpriseRequired.
+func (*OBOConverter) ResolveSecrets(
 	_ context.Context,
 	_ *mcpv1beta1.MCPExternalAuthConfig,
 	_ client.Client,
 	_ string,
 	_ *authtypes.BackendAuthStrategy,
 ) (*authtypes.BackendAuthStrategy, error) {
-	return nil, fmt.Errorf("vMCP OBO converter: %w", controllerutil.ErrEnterpriseRequired)
+	return nil, fmt.Errorf("vMCP OBO converter: %w", obo.ErrEnterpriseRequired)
 }

--- a/pkg/vmcp/auth/converters/obo_test.go
+++ b/pkg/vmcp/auth/converters/obo_test.go
@@ -1,0 +1,100 @@
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package converters
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/pkg/controllerutil"
+	authtypes "github.com/stacklok/toolhive/pkg/vmcp/auth/types"
+)
+
+func TestOBOConverterStub_StrategyType(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, authtypes.StrategyTypeOBO, (&OBOConverterStub{}).StrategyType())
+}
+
+func TestOBOConverterStub_ConvertToStrategy(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		externalCfg *mcpv1beta1.MCPExternalAuthConfig
+	}{
+		{name: "nil config", externalCfg: nil},
+		{
+			name: "obo-typed config",
+			externalCfg: &mcpv1beta1.MCPExternalAuthConfig{
+				Spec: mcpv1beta1.MCPExternalAuthConfigSpec{
+					Type: mcpv1beta1.ExternalAuthTypeOBO,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			strategy, err := (&OBOConverterStub{}).ConvertToStrategy(tt.externalCfg)
+			require.Error(t, err)
+			assert.Nil(t, strategy, "stub must not return a strategy on the error path")
+			assert.ErrorIs(t, err, controllerutil.ErrEnterpriseRequired)
+		})
+	}
+}
+
+func TestOBOConverterStub_ResolveSecrets(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		externalCfg *mcpv1beta1.MCPExternalAuthConfig
+		strategy    *authtypes.BackendAuthStrategy
+	}{
+		{name: "nil inputs", externalCfg: nil, strategy: nil},
+		{
+			name: "non-nil strategy",
+			externalCfg: &mcpv1beta1.MCPExternalAuthConfig{
+				Spec: mcpv1beta1.MCPExternalAuthConfigSpec{
+					Type: mcpv1beta1.ExternalAuthTypeOBO,
+				},
+			},
+			strategy: &authtypes.BackendAuthStrategy{Type: authtypes.StrategyTypeOBO},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			resolved, err := (&OBOConverterStub{}).ResolveSecrets(
+				context.Background(), tt.externalCfg, nil, "default", tt.strategy,
+			)
+			require.Error(t, err)
+			assert.Nil(t, resolved, "stub must not return a strategy on the error path")
+			assert.ErrorIs(t, err, controllerutil.ErrEnterpriseRequired)
+		})
+	}
+}
+
+func TestOBOConverterStub_RegisteredInDefaultRegistry(t *testing.T) {
+	t.Parallel()
+
+	converter, err := NewRegistry().GetConverter(mcpv1beta1.ExternalAuthTypeOBO)
+	require.NoError(t, err)
+	require.NotNil(t, converter)
+	assert.IsType(t, &OBOConverterStub{}, converter)
+
+	// DefaultRegistry should also have it.
+	converter, err = DefaultRegistry().GetConverter(mcpv1beta1.ExternalAuthTypeOBO)
+	require.NoError(t, err)
+	assert.IsType(t, &OBOConverterStub{}, converter)
+}

--- a/pkg/vmcp/auth/converters/obo_test.go
+++ b/pkg/vmcp/auth/converters/obo_test.go
@@ -11,17 +11,17 @@ import (
 	"github.com/stretchr/testify/require"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
-	"github.com/stacklok/toolhive/cmd/thv-operator/pkg/controllerutil"
+	"github.com/stacklok/toolhive/pkg/auth/obo"
 	authtypes "github.com/stacklok/toolhive/pkg/vmcp/auth/types"
 )
 
-func TestOBOConverterStub_StrategyType(t *testing.T) {
+func TestOBOConverter_StrategyType(t *testing.T) {
 	t.Parallel()
 
-	assert.Equal(t, authtypes.StrategyTypeOBO, (&OBOConverterStub{}).StrategyType())
+	assert.Equal(t, authtypes.StrategyTypeOBO, (&OBOConverter{}).StrategyType())
 }
 
-func TestOBOConverterStub_ConvertToStrategy(t *testing.T) {
+func TestOBOConverter_ConvertToStrategy(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -43,15 +43,15 @@ func TestOBOConverterStub_ConvertToStrategy(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			strategy, err := (&OBOConverterStub{}).ConvertToStrategy(tt.externalCfg)
+			strategy, err := (&OBOConverter{}).ConvertToStrategy(tt.externalCfg)
 			require.Error(t, err)
 			assert.Nil(t, strategy, "stub must not return a strategy on the error path")
-			assert.ErrorIs(t, err, controllerutil.ErrEnterpriseRequired)
+			assert.ErrorIs(t, err, obo.ErrEnterpriseRequired)
 		})
 	}
 }
 
-func TestOBOConverterStub_ResolveSecrets(t *testing.T) {
+func TestOBOConverter_ResolveSecrets(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -75,26 +75,26 @@ func TestOBOConverterStub_ResolveSecrets(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			resolved, err := (&OBOConverterStub{}).ResolveSecrets(
+			resolved, err := (&OBOConverter{}).ResolveSecrets(
 				context.Background(), tt.externalCfg, nil, "default", tt.strategy,
 			)
 			require.Error(t, err)
 			assert.Nil(t, resolved, "stub must not return a strategy on the error path")
-			assert.ErrorIs(t, err, controllerutil.ErrEnterpriseRequired)
+			assert.ErrorIs(t, err, obo.ErrEnterpriseRequired)
 		})
 	}
 }
 
-func TestOBOConverterStub_RegisteredInDefaultRegistry(t *testing.T) {
+func TestOBOConverter_RegisteredInDefaultRegistry(t *testing.T) {
 	t.Parallel()
 
 	converter, err := NewRegistry().GetConverter(mcpv1beta1.ExternalAuthTypeOBO)
 	require.NoError(t, err)
 	require.NotNil(t, converter)
-	assert.IsType(t, &OBOConverterStub{}, converter)
+	assert.IsType(t, &OBOConverter{}, converter)
 
 	// DefaultRegistry should also have it.
 	converter, err = DefaultRegistry().GetConverter(mcpv1beta1.ExternalAuthTypeOBO)
 	require.NoError(t, err)
-	assert.IsType(t, &OBOConverterStub{}, converter)
+	assert.IsType(t, &OBOConverter{}, converter)
 }

--- a/pkg/vmcp/auth/converters/registry_test.go
+++ b/pkg/vmcp/auth/converters/registry_test.go
@@ -106,7 +106,7 @@ func TestDefaultRegistry(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, oboConverter)
 		assert.Equal(t, "obo", oboConverter.StrategyType())
-		assert.IsType(t, &OBOConverterStub{}, oboConverter)
+		assert.IsType(t, &OBOConverter{}, oboConverter)
 	})
 }
 

--- a/pkg/vmcp/auth/converters/registry_test.go
+++ b/pkg/vmcp/auth/converters/registry_test.go
@@ -100,6 +100,13 @@ func TestDefaultRegistry(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, awsStsConverter)
 		assert.Equal(t, "aws_sts", awsStsConverter.StrategyType())
+
+		// Test OBO converter stub
+		oboConverter, err := registry.GetConverter(mcpv1beta1.ExternalAuthTypeOBO)
+		require.NoError(t, err)
+		require.NotNil(t, oboConverter)
+		assert.Equal(t, "obo", oboConverter.StrategyType())
+		assert.IsType(t, &OBOConverterStub{}, oboConverter)
 	})
 }
 
@@ -133,6 +140,10 @@ func TestNewRegistry(t *testing.T) {
 		awsStsConverter, err := registry.GetConverter(mcpv1beta1.ExternalAuthTypeAWSSts)
 		require.NoError(t, err)
 		assert.NotNil(t, awsStsConverter)
+
+		oboConverter, err := registry.GetConverter(mcpv1beta1.ExternalAuthTypeOBO)
+		require.NoError(t, err)
+		assert.NotNil(t, oboConverter)
 	})
 
 	t.Run("creates independent instances", func(t *testing.T) {
@@ -160,6 +171,7 @@ func TestNewRegistry(t *testing.T) {
 			{mcpv1beta1.ExternalAuthTypeUnauthenticated, "unauthenticated"},
 			{mcpv1beta1.ExternalAuthTypeUpstreamInject, "upstream_inject"},
 			{mcpv1beta1.ExternalAuthTypeAWSSts, "aws_sts"},
+			{mcpv1beta1.ExternalAuthTypeOBO, "obo"},
 		}
 
 		for _, tc := range testCases {

--- a/pkg/vmcp/auth/types/types.go
+++ b/pkg/vmcp/auth/types/types.go
@@ -43,6 +43,11 @@ const (
 	// This strategy exchanges incoming tokens for AWS STS temporary credentials
 	// and signs requests using SigV4.
 	StrategyTypeAwsSts = "aws_sts"
+
+	// StrategyTypeOBO identifies the on-behalf-of (OBO) authentication strategy.
+	// The default upstream implementation returns ErrEnterpriseRequired from
+	// every method; an out-of-tree build registers a real converter.
+	StrategyTypeOBO = "obo"
 )
 
 // BackendAuthStrategy defines how to authenticate to a specific backend.

--- a/pkg/vmcp/auth/types/types.go
+++ b/pkg/vmcp/auth/types/types.go
@@ -57,7 +57,7 @@ const (
 // +kubebuilder:object:generate=true
 // +gendoc
 type BackendAuthStrategy struct {
-	// Type is the auth strategy: "unauthenticated", "header_injection", "token_exchange", "upstream_inject", "aws_sts"
+	// Type is the auth strategy: "unauthenticated", "header_injection", "token_exchange", "upstream_inject", "aws_sts", "obo"
 	Type string `json:"type" yaml:"type"`
 
 	// HeaderInjection contains configuration for header injection auth strategy.


### PR DESCRIPTION
## Summary

This is the second of four flat technical tasks for the OSS on-behalf-of (OBO) work. It stands up the default stub infrastructure for a new `obo` external auth type at the three dispatch layers (operator, vMCP converter, proxy runtime), plus the Go constant the other layers reference. After this change, an out-of-tree build can register a real OBO implementation by calling three setter functions; an upstream-only build hits the defaults and surfaces a sentinel `obo.ErrEnterpriseRequired` error at every dispatch point.

The CRD enum is **not** widened in this PR — `spec.type: obo` is still rejected at the apiserver layer. The constant, handler hooks, middleware-factory entry, and converter stub live as dark infrastructure that activates the moment the CRD admission task (#5329) merges.

- **Why**: enable out-of-tree builds to register a real OBO implementation without forking, while keeping a clean, function-pointer override hook surface in upstream. Defining the hooks now lets the dispatch-wiring task (#5328) land in isolation against a stable, reviewed surface.
- **What**:
  - Adds `ExternalAuthTypeOBO` constant in `mcpexternalauthconfig_types.go` and minimal no-op `exhaustive` linter arms.
  - Adds the new `pkg/auth/obo/` package — leaf home for `ErrEnterpriseRequired`, `MiddlewareType`, the default `CreateMiddleware` redirector (503 stub), `DefaultFactory`, and `RegisterFactory`. Wires one new entry into `pkg/runner/middleware.go`.
  - Adds the `OBOHandler` struct, `RegisterOBOHandler` setter (panics on partial registration), and `OBOValidate` / `OBOSecretEnvVars` / `OBOApplyRunConfig` wrappers in `controllerutil/tokenexchange.go`. Reads/writes guarded by a `sync.RWMutex`.
  - Adds `OBOConverter` in `pkg/vmcp/auth/converters/obo.go` and registers it as a built-in in `NewRegistry()`.
  - Adds `StrategyTypeOBO` constant in `pkg/vmcp/auth/types/types.go`.
  - Unit tests cover every default-stub behavior, the last-write-wins setter semantics, and the panic-on-partial-registration contract.

Closes #5327

## Type of change

- [x] New feature

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)
- [x] Race-detected unit tests for the touched packages (`go test -race ./pkg/auth/obo/... ./cmd/thv-operator/pkg/controllerutil/... ./pkg/runner/...`)

## API Compatibility

- [x] This PR does not break the `v1beta1` API, OR the `api-break-allowed` label is applied and the migration guidance is described above.

The new `ExternalAuthTypeOBO` Go constant is purely additive and is not yet present in the CRD enum, so the apiserver behavior is unchanged.

## Changes

| File | Change |
|------|--------|
| `cmd/thv-operator/api/v1beta1/mcpexternalauthconfig_types.go` | Add `ExternalAuthTypeOBO` constant; add no-op `Validate()` switch arm with `TODO(#5328)` pointer for the reconcile-loop dispatch site and `TODO(#5329)` pointer for the biconditional/unauthenticated checks |
| `pkg/auth/obo/errors.go` | New leaf home for `ErrEnterpriseRequired` (the cross-layer sentinel imported by both operator and vMCP code paths) |
| `pkg/auth/obo/middleware.go` | `MiddlewareType` constant, `CreateMiddleware` as a stable redirector over `currentFactory` (guarded by `sync.RWMutex`), `DefaultFactory` (exported so external test code can restore default behavior), and `RegisterFactory` (panics on nil factory) |
| `pkg/auth/obo/middleware_test.go` | Tests covering 503 body/status (locked via exact-match against `stubMessage`), default factory's runner registration, last-write-wins re-registration, panic-on-nil |
| `pkg/auth/obo/errors_test.go` | Sentinel-wrap test: `errors.Is` works through `fmt.Errorf("...: %w", ...)` |
| `cmd/thv-operator/pkg/controllerutil/tokenexchange.go` | `OBOHandler` struct, `RegisterOBOHandler` (panics on any nil func field), `OBOValidate` / `OBOSecretEnvVars` / `OBOApplyRunConfig` wrappers; `sync.RWMutex`-guarded `oboHandler` package state; `ExternalAuthTypeOBO` arm in `AddExternalAuthConfigOptions` returns `obo.ErrEnterpriseRequired` (dispatch through the handler hook lands in #5328) |
| `cmd/thv-operator/pkg/controllerutil/tokenexchange_test.go` | Tests covering default handler behavior, dispatch through wrappers, last-write-wins re-registration, panic-on-partial-registration |
| `cmd/thv-operator/controllers/virtualmcpserver_deployment.go` | Add no-op `ExternalAuthTypeOBO` arm to `getExternalAuthConfigSecretEnvVar` switch with `TODO(#5328)` pointer for the dispatch rewrite |
| `pkg/runner/middleware.go` | Add `obo.MiddlewareType: obo.CreateMiddleware` entry to the factory map |
| `pkg/runner/middleware_test.go` | Extend coverage to include the new `obo` entry; lock the call-after-register contract for `obo.CreateMiddleware` |
| `pkg/vmcp/auth/converters/obo.go` | New `OBOConverter` implementing `StrategyConverter` with `obo.ErrEnterpriseRequired`-wrapped errors |
| `pkg/vmcp/auth/converters/obo_test.go` | Tests for stub method behavior and `errors.Is` propagation |
| `pkg/vmcp/auth/converters/interface.go` | Register `OBOConverter` as built-in in `NewRegistry()` |
| `pkg/vmcp/auth/converters/registry_test.go` | Extend coverage to assert `OBOConverter` is registered |
| `pkg/vmcp/auth/types/types.go` | Add `StrategyTypeOBO` constant; extend `BackendAuthStrategy.Type` doc to list `"obo"` |
| `docs/operator/crd-api.md` | Regenerated CRD reference docs to include the new `obo` enum value |

## Does this introduce a user-facing change?

No. The CRD enum still rejects `spec.type: obo`, so no user-visible behavior changes in upstream-only builds. Once the CRD admission task (#5329) lands, an upstream-only build will surface `obo.ErrEnterpriseRequired` as `status.conditions[Valid] = False` with `Reason: EnterpriseRequired` for `obo`-typed resources.

## Special notes for reviewers

- **Dispatch wiring is intentionally deferred**: the `case ExternalAuthTypeOBO` arms in `AddExternalAuthConfigOptions` and `getExternalAuthConfigSecretEnvVar` are minimal placeholders to satisfy the `exhaustive` linter. The next task (#5328) replaces them with real dispatch into `OBOApplyRunConfig` / `OBOSecretEnvVars`, and adds the reconcile-loop branch that maps `obo.ErrEnterpriseRequired` to `Reason: EnterpriseRequired`. Every site that #5328 needs to touch is tagged with `TODO(#5328):` for grep-discoverability.
- **`obo.CreateMiddleware` is a stable redirector**: calls dispatch through `currentFactory` under an `RWMutex` on every invocation, so `RegisterFactory` after the `pkg/runner` middleware map is built still takes effect. This removes the captured-at-construction-time fragility that an earlier revision of this PR carried (review feedback).
- **Partial registration fails loudly**: `RegisterOBOHandler` panics if any of `Validate` / `ApplyRunConfig` / `SecretEnvVars` is nil; `obo.RegisterFactory` panics on a nil factory. Both panic at init() time in real builds, so a misconfigured out-of-tree wiring surfaces at process start, not at reconcile time.
- **Single-slot, last-write-wins**: all three setters (`RegisterOBOHandler`, `obo.RegisterFactory`, and the `Registry.Register` map for the converter) accept double-registration without panic, matching the existing `pkg/config.RegisterProviderFactory` precedent. Tests cover this.
- **Blocks**: #5328 (dispatch wiring) and #5329 (CRD enum admission) both depend on this PR being merged first.

Generated with [Claude Code](https://claude.com/claude-code)
