### PR TITLE
Use `events.k8s.io` in registry-api Role

### DIFF
--- a/cmd/thv-operator/pkg/registryapi/rbac.go
+++ b/cmd/thv-operator/pkg/registryapi/rbac.go
@@ -55,7 +55,7 @@ var registryAPIRBACRules = []rbacv1.PolicyRule{
 	},
 	// Event creation for leader election status
 	{
-		APIGroups: []string{""},
+		APIGroups: []string{"events.k8s.io"},
 		Resources: []string{"events"},
 		Verbs:     []string{"create", "patch"},
 	},

--- a/cmd/thv-operator/pkg/registryapi/rbac_test.go
+++ b/cmd/thv-operator/pkg/registryapi/rbac_test.go
@@ -223,7 +223,7 @@ func TestRegistryAPIRBACRules(t *testing.T) {
 	assert.ElementsMatch(t, []string{"get", "list", "watch", "create", "update", "patch", "delete"}, registryAPIRBACRules[4].Verbs)
 
 	// Leader election - Events
-	assert.ElementsMatch(t, []string{""}, registryAPIRBACRules[5].APIGroups)
+	assert.ElementsMatch(t, []string{"events.k8s.io"}, registryAPIRBACRules[5].APIGroups)
 	assert.ElementsMatch(t, []string{"events"}, registryAPIRBACRules[5].Resources)
 	assert.ElementsMatch(t, []string{"create", "patch"}, registryAPIRBACRules[5].Verbs)
 }


### PR DESCRIPTION
## Summary
- After #5243 the operator's ClusterRole only grants `events.k8s.io/events`, but the per-`MCPRegistry` Role builder still asked for core `""/events`. RBAC escalation prevention then blocked the operator from creating that Role, leaving every `MCPRegistry` stuck in `phase: Failed` with `reason: RBACFailed`.
- Switch the registry-api Role rule to `events.k8s.io/events` so it matches the operator's own grant.

Fixes #5339

## Test plan
- [x] Unit tests (`go test ./cmd/thv-operator/pkg/registryapi/...`)
- [x] Manual testing: kind cluster, A/B verified — unpatched `origin/main` reproduces the exact `RBACFailed` error from the issue; in-place `helm upgrade` to the patched image reconciles cleanly (Role's events rule becomes `apiGroups: ["events.k8s.io"]`, `MCPRegistry` advances past RBAC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)