### PR TITLE
Honor --allow-private-ip on thv registry login --registry

### DIFF
--- a/cmd/thv/app/registry_login.go
+++ b/cmd/thv/app/registry_login.go
@@ -14,11 +14,12 @@ import (
 )
 
 var (
-	loginRegistry string
-	loginIssuer   string
-	loginClientID string
-	loginAudience string
-	loginScopes   []string
+	loginRegistry       string
+	loginIssuer         string
+	loginClientID       string
+	loginAudience       string
+	loginScopes         []string
+	loginAllowPrivateIP bool
 )
 
 var registryLoginCmd = &cobra.Command{
@@ -46,6 +47,9 @@ func init() {
 		"OAuth audience parameter for registry authentication (optional)")
 	registryLoginCmd.Flags().StringSliceVar(&loginScopes, "scopes", nil,
 		"OAuth scopes for registry authentication (defaults to openid,offline_access)")
+	registryLoginCmd.Flags().BoolVarP(&loginAllowPrivateIP, "allow-private-ip", "p", false,
+		"Allow --registry to reference a private IP address (default false). "+
+			"Mirrors the flag on 'thv config set-registry'.")
 }
 
 func registryLoginCmdFunc(cmd *cobra.Command, _ []string) error {
@@ -56,11 +60,12 @@ func registryLoginCmdFunc(cmd *cobra.Command, _ []string) error {
 	}
 
 	opts := auth.LoginOptions{
-		RegistryURL: loginRegistry,
-		Issuer:      loginIssuer,
-		ClientID:    loginClientID,
-		Audience:    loginAudience,
-		Scopes:      loginScopes,
+		RegistryURL:    loginRegistry,
+		Issuer:         loginIssuer,
+		ClientID:       loginClientID,
+		Audience:       loginAudience,
+		Scopes:         loginScopes,
+		AllowPrivateIP: loginAllowPrivateIP,
 	}
 
 	return auth.Login(cmd.Context(), configProvider, secretsProvider, opts)

--- a/docs/cli/thv_registry_login.md
+++ b/docs/cli/thv_registry_login.md
@@ -32,6 +32,7 @@ thv registry login [flags]
 ### Options
 
 ```
+  -p, --allow-private-ip   Allow --registry to reference a private IP address (default false). Mirrors the flag on 'thv config set-registry'.
       --audience string    OAuth audience parameter for registry authentication (optional)
       --client-id string   OAuth client ID for registry authentication
   -h, --help               help for login

--- a/pkg/registry/auth/login.go
+++ b/pkg/registry/auth/login.go
@@ -38,6 +38,10 @@ type LoginOptions struct {
 	Audience string
 	// Scopes overrides the default OAuth scopes (defaults to ["openid", "offline_access"]).
 	Scopes []string
+	// AllowPrivateIP permits RegistryURL to resolve to a private IP address.
+	// Mirrors the `--allow-private-ip` flag on `thv config set-registry`; only
+	// honored when RegistryURL is supplied (no-op when reusing stored config).
+	AllowPrivateIP bool
 }
 
 // Login performs an interactive OAuth login against the configured registry.
@@ -196,7 +200,7 @@ func ensureRegistryURL(configProvider config.Provider, opts LoginOptions) error 
 		return nil
 	}
 
-	registryType, cleanPath := config.DetectRegistryType(opts.RegistryURL, false)
+	registryType, cleanPath := config.DetectRegistryType(opts.RegistryURL, opts.AllowPrivateIP)
 
 	// Always clear auth when a registry URL is explicitly provided, so that
 	// tokens are never sent to the wrong server.
@@ -209,11 +213,11 @@ func ensureRegistryURL(configProvider config.Provider, opts LoginOptions) error 
 
 	switch registryType {
 	case config.RegistryTypeAPI:
-		if err := configProvider.SetRegistryAPI(cleanPath, false); err != nil {
+		if err := configProvider.SetRegistryAPI(cleanPath, opts.AllowPrivateIP); err != nil {
 			return fmt.Errorf("saving registry API URL: %w", err)
 		}
 	case config.RegistryTypeURL:
-		if err := configProvider.SetRegistryURL(cleanPath, false); err != nil {
+		if err := configProvider.SetRegistryURL(cleanPath, opts.AllowPrivateIP); err != nil {
 			return fmt.Errorf("saving registry URL: %w", err)
 		}
 	case config.RegistryTypeFile:

--- a/pkg/registry/auth/login_test.go
+++ b/pkg/registry/auth/login_test.go
@@ -334,6 +334,19 @@ func TestEnsureRegistryURL(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "AllowPrivateIP propagates to SetRegistryURL",
+			cfg:  &config.Config{},
+			opts: LoginOptions{
+				RegistryURL:    "https://registry.example.com/mcp.json",
+				AllowPrivateIP: true,
+			},
+			setupMock: func(m *configmocks.MockProvider) {
+				m.EXPECT().UpdateConfig(gomock.Any()).Return(nil)
+				m.EXPECT().SetRegistryURL(gomock.Any(), true).Return(nil)
+			},
+			wantErr: false,
+		},
+		{
 			name: "opts supply file path - clears auth then calls SetRegistryFile",
 			cfg:  &config.Config{},
 			opts: LoginOptions{RegistryURL: "file:///tmp/registry.json"},


### PR DESCRIPTION
## Summary

`thv config set-registry --allow-private-ip <url>` lets an operator point the CLI at a registry behind a private/corp IP. The matching option is missing from `thv registry login`, and even via the Go API the boolean was hardcoded one layer down — so an operator combining registration + login in a single step (`thv registry login --registry http://10.x.y.z/api --issuer ... --client-id ...`) always hits the private-IP rejection regardless of intent.

The same gap applies to `auth.Login` when used programmatically: `LoginOptions` had no way to express "this registry is allowed on a private IP."

This PR closes the gap symmetrically:

- `pkg/registry/auth/login.go` — adds `AllowPrivateIP bool` to `LoginOptions`. `ensureRegistryURL` threads it into `config.DetectRegistryType` (so the API-vs-static probe can actually reach the registry) and into the `SetRegistryAPI` / `SetRegistryURL` calls (which were `false` literals).
- `cmd/thv/app/registry_login.go` — adds `-p` / `--allow-private-ip`, mirroring the flag on `thv config set-registry`. Default is `false`.
- `docs/cli/thv_registry_login.md` — regenerated via `task docs`.
- `pkg/registry/auth/login_test.go` — new table case in `TestEnsureRegistryURL` proving `AllowPrivateIP: true` propagates to `SetRegistryURL`. The existing `false`-cases stay untouched, so the no-flag path is regression-guarded.

No behavior change for callers that leave the new field at its zero value.

Fixes #5351

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)
- [x] CLI docs regenerated (`task docs`)
- [x] Manual: `go build ./cmd/thv` + `thv registry login --help` shows the new `-p, --allow-private-ip` flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)