### PR TITLE
Fix DCR failure for authorization servers with non-root issuer paths

### DIFF
--- a/pkg/auth/dcr/request.go
+++ b/pkg/auth/dcr/request.go
@@ -80,10 +80,20 @@ type Request struct {
 	// On this branch the caller is expected to also supply AuthorizationEndpoint
 	// and TokenEndpoint explicitly; the resolver's auth-method selection
 	// defaults to client_secret_basic because no server-capability fields
-	// are available.
+	// are available unless CodeChallengeMethodsSupported is also set.
 	//
 	// Mutually exclusive with DiscoveryURL.
 	RegistrationEndpoint string
+
+	// CodeChallengeMethodsSupported lists the PKCE challenge methods the
+	// upstream advertises. Only consulted when RegistrationEndpoint is set;
+	// on the DiscoveryURL branch the resolver reads this value from the
+	// fetched metadata document. Callers that have already performed
+	// multi-URL AS metadata discovery (e.g. via
+	// oauthproto.FetchAuthorizationServerMetadata) should populate this
+	// field so the S256 PKCE gate fires correctly without a redundant
+	// round-trip.
+	CodeChallengeMethodsSupported []string
 
 	// AuthorizationEndpoint, when non-empty, overrides any value discovered
 	// via DiscoveryURL. Explicit caller configuration always wins.
@@ -117,8 +127,8 @@ type Request struct {
 	// > client_secret_basic > client_secret_post > none, with the same
 	// S256 gate on "none").
 	//
-	// Has no effect on the RegistrationEndpoint-direct branch when the
-	// caller has not also supplied a DiscoveryURL: without
+	// Has no effect on the RegistrationEndpoint-direct branch when neither
+	// DiscoveryURL nor CodeChallengeMethodsSupported is set: without
 	// code_challenge_methods_supported the S256 gate cannot be evaluated,
 	// so the resolver refuses to register as a public client.
 	PublicClient bool

--- a/pkg/auth/dcr/resolver.go
+++ b/pkg/auth/dcr/resolver.go
@@ -881,7 +881,8 @@ func resolveDCREndpoints(
 			return nil, fmt.Errorf("dcr: %w", err)
 		}
 		return &dcrEndpoints{
-			registrationEndpoint: req.RegistrationEndpoint,
+			registrationEndpoint:          req.RegistrationEndpoint,
+			codeChallengeMethodsSupported: req.CodeChallengeMethodsSupported,
 		}, nil
 	}
 

--- a/pkg/auth/dcr/resolver_test.go
+++ b/pkg/auth/dcr/resolver_test.go
@@ -492,6 +492,95 @@ func TestResolveDCRCredentials_SynthesisedRegistrationEndpoint(t *testing.T) {
 	assert.Equal(t, "/register", gotPath)
 }
 
+// TestResolveDCRCredentials_CodeChallengeMethodsSupportedFieldEnablesPublicClient
+// pins the dcr.Request.CodeChallengeMethodsSupported field on the
+// RegistrationEndpoint-direct branch. Without a DiscoveryURL the resolver
+// cannot reach the S256 PKCE gate via a metadata fetch; the caller must
+// supply code_challenge_methods_supported so the gate has an input. This is
+// the path exercised when resolveDCRCredentials pre-fetches AS metadata and
+// forwards the field to the resolver (see resolveDCRCredentials in
+// pkg/auth/discovery, introduced to fix #5356).
+func TestResolveDCRCredentials_CodeChallengeMethodsSupportedFieldEnablesPublicClient(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                          string
+		codeChallengeMethodsSupported []string
+		publicClient                  bool
+		wantErr                       bool
+		wantErrContains               string
+	}{
+		{
+			name:                          "S256 in field allows public client registration",
+			codeChallengeMethodsSupported: []string{"S256"},
+			publicClient:                  true,
+		},
+		{
+			name:                          "plain-only in field rejects public client",
+			codeChallengeMethodsSupported: []string{"plain"},
+			publicClient:                  true,
+			wantErr:                       true,
+			wantErrContains:               "S256",
+		},
+		{
+			name:                          "field absent rejects public client",
+			codeChallengeMethodsSupported: nil,
+			publicClient:                  true,
+			wantErr:                       true,
+			wantErrContains:               "S256",
+		},
+		{
+			name:                          "field absent ok for confidential client",
+			codeChallengeMethodsSupported: nil,
+			publicClient:                  false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var registrationHits int32
+			mux := http.NewServeMux()
+			mux.HandleFunc("/register", func(w http.ResponseWriter, r *http.Request) {
+				body, _ := io.ReadAll(r.Body)
+				_ = r.Body.Close()
+				_ = body
+				atomic.AddInt32(&registrationHits, 1)
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusCreated)
+				_, _ = w.Write([]byte(`{"client_id":"field-supplied-client"}`))
+			})
+			server := httptest.NewServer(mux)
+			t.Cleanup(server.Close)
+
+			cache := newMemoryDCRStore(t)
+			req := &Request{
+				Issuer:                        server.URL,
+				AuthorizationEndpoint:         server.URL + "/authorize",
+				TokenEndpoint:                 server.URL + "/token",
+				Scopes:                        []string{"openid"},
+				RegistrationEndpoint:          server.URL + "/register",
+				CodeChallengeMethodsSupported: tc.codeChallengeMethodsSupported,
+				PublicClient:                  tc.publicClient,
+			}
+
+			_, err := ResolveCredentials(context.Background(), req, cache)
+			if tc.wantErr {
+				require.Error(t, err)
+				if tc.wantErrContains != "" {
+					assert.Contains(t, err.Error(), tc.wantErrContains)
+				}
+				assert.EqualValues(t, 0, atomic.LoadInt32(&registrationHits),
+					"registration endpoint must not be contacted when S256 gate fails")
+				return
+			}
+			require.NoError(t, err)
+			assert.EqualValues(t, 1, atomic.LoadInt32(&registrationHits))
+		})
+	}
+}
+
 func TestResolveDCRCredentials_RegistrationEndpointDirectBypassesDiscovery(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/auth/discovery/dcr_resolver_test.go
+++ b/pkg/auth/discovery/dcr_resolver_test.go
@@ -347,6 +347,134 @@ func TestHandleDynamicRegistration_NonRootIssuerRFC8414PathInsertion(t *testing.
 		"expected exactly one /oauth/register call")
 }
 
+// TestHandleDynamicRegistration_PreDiscoveredPathNonRootIssuer tests the path
+// where the CLI already has OAuth endpoints from a prior discovery
+// (config.RegistrationEndpoint/AuthorizeURL/TokenURL are all populated) and
+// the issuer has a non-root path. getDiscoveryDocument short-circuits on this
+// path and returns a synthesised document with empty
+// code_challenge_methods_supported; resolveDCRCredentials must then re-fetch
+// via multi-URL fallback to populate the S256 PKCE gate. This is the more
+// common production scenario vs the fresh-discovery path tested by
+// TestHandleDynamicRegistration_NonRootIssuerRFC8414PathInsertion.
+func TestHandleDynamicRegistration_PreDiscoveredPathNonRootIssuer(t *testing.T) {
+	t.Parallel()
+
+	var registrationHits int32
+	var server *httptest.Server
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/.well-known/oauth-authorization-server/oauth", func(w http.ResponseWriter, _ *http.Request) {
+		md := oauthproto.AuthorizationServerMetadata{
+			Issuer:                            server.URL + "/oauth",
+			AuthorizationEndpoint:             server.URL + "/oauth/authorize",
+			TokenEndpoint:                     server.URL + "/oauth/token",
+			RegistrationEndpoint:              server.URL + "/oauth/register",
+			CodeChallengeMethodsSupported:     []string{"S256"},
+			TokenEndpointAuthMethodsSupported: []string{"none"},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(md)
+	})
+
+	mux.HandleFunc("/oauth/register", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.ReadAll(r.Body)
+		_ = r.Body.Close()
+		atomic.AddInt32(&registrationHits, 1)
+		resp := oauthproto.DynamicClientRegistrationResponse{
+			ClientID:                "pre-discovered-client",
+			TokenEndpointAuthMethod: "none",
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(resp)
+	})
+
+	server = httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	// Simulate the pre-discovered path: all three endpoints are already set so
+	// getDiscoveryDocument short-circuits without a network call and returns a
+	// synthesised document with empty code_challenge_methods_supported.
+	config := &OAuthFlowConfig{
+		Scopes:               []string{"openid", "profile"},
+		CallbackPort:         8765,
+		RegistrationEndpoint: server.URL + "/oauth/register",
+		AuthorizeURL:         server.URL + "/oauth/authorize",
+		TokenURL:             server.URL + "/oauth/token",
+	}
+
+	err := handleDynamicRegistration(context.Background(), server.URL+"/oauth", config)
+	require.NoError(t, err, "DCR must succeed on pre-discovered path with non-root issuer")
+	assert.Equal(t, "pre-discovered-client", config.ClientID)
+	assert.EqualValues(t, 1, atomic.LoadInt32(&registrationHits))
+}
+
+// TestHandleDynamicRegistration_SynthesisesEndpointWhenMetadataOmitsIt
+// verifies that when the re-discovery call inside resolveDCRCredentials returns
+// ErrRegistrationEndpointMissing (valid metadata but no registration_endpoint),
+// the endpoint is synthesised as {issuer}/register and the registration is
+// routed there — mirroring the nanobot/Hydra convention that the resolver's
+// DiscoveryURL branch applies. The pre-discovered path is used to bypass the
+// handleDynamicRegistration guard that otherwise exits early when
+// registration_endpoint is absent from the initial discovery document.
+func TestHandleDynamicRegistration_SynthesisesEndpointWhenMetadataOmitsIt(t *testing.T) {
+	t.Parallel()
+
+	var registrationHits int32
+	var server *httptest.Server
+	mux := http.NewServeMux()
+
+	// Metadata has all required fields but deliberately omits
+	// registration_endpoint, causing FetchAuthorizationServerMetadata to
+	// return (partialMeta, ErrRegistrationEndpointMissing).
+	mux.HandleFunc("/.well-known/oauth-authorization-server", func(w http.ResponseWriter, _ *http.Request) {
+		md := oauthproto.AuthorizationServerMetadata{
+			Issuer:                            server.URL,
+			AuthorizationEndpoint:             server.URL + "/authorize",
+			TokenEndpoint:                     server.URL + "/token",
+			CodeChallengeMethodsSupported:     []string{"S256"},
+			TokenEndpointAuthMethodsSupported: []string{"none"},
+			// registration_endpoint intentionally absent
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(md)
+	})
+
+	// resolveDCRCredentials synthesises {issuer}/register for a root issuer.
+	mux.HandleFunc("/register", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.ReadAll(r.Body)
+		_ = r.Body.Close()
+		atomic.AddInt32(&registrationHits, 1)
+		resp := oauthproto.DynamicClientRegistrationResponse{
+			ClientID:                "synthesised-client",
+			TokenEndpointAuthMethod: "none",
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(resp)
+	})
+
+	server = httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	// The pre-discovered path sets RegistrationEndpoint so
+	// handleDynamicRegistration's guard passes; resolveDCRCredentials then
+	// re-fetches and hits the ErrRegistrationEndpointMissing synthesis branch.
+	config := &OAuthFlowConfig{
+		Scopes:               []string{"openid", "profile"},
+		CallbackPort:         8765,
+		RegistrationEndpoint: server.URL + "/register",
+		AuthorizeURL:         server.URL + "/authorize",
+		TokenURL:             server.URL + "/token",
+	}
+
+	err := handleDynamicRegistration(context.Background(), server.URL, config)
+	require.NoError(t, err, "DCR must succeed when registration_endpoint is absent from re-fetched metadata")
+	assert.Equal(t, "synthesised-client", config.ClientID)
+	assert.EqualValues(t, 1, atomic.LoadInt32(&registrationHits),
+		"synthesised endpoint must be contacted exactly once")
+}
+
 // TestHandleDynamicRegistration_PopulatesEndpoints verifies the contract
 // the rest of the CLI flow depends on: handleDynamicRegistration writes
 // the resolved AuthorizeURL / TokenURL onto OAuthFlowConfig so

--- a/pkg/auth/discovery/dcr_resolver_test.go
+++ b/pkg/auth/discovery/dcr_resolver_test.go
@@ -284,6 +284,69 @@ func TestHandleDynamicRegistration_InheritsSingleflightDedup(t *testing.T) {
 		N, atomic.LoadInt32(&registrationHits))
 }
 
+// TestHandleDynamicRegistration_NonRootIssuerRFC8414PathInsertion is a
+// regression test for #5356. Authorization servers with a non-root issuer
+// path (e.g. https://example.com/oauth) may serve their RFC 8414 metadata
+// exclusively at the path-insertion URL
+// (scheme://host/.well-known/oauth-authorization-server/path), not at the
+// OIDC issuer-suffix URL ({issuer}/.well-known/openid-configuration).
+// Prior to the fix, resolveDCRCredentials only constructed the OIDC URL and
+// failed for those servers. The fix routes through
+// oauthproto.FetchAuthorizationServerMetadata which tries all well-known
+// URL forms in priority order.
+func TestHandleDynamicRegistration_NonRootIssuerRFC8414PathInsertion(t *testing.T) {
+	t.Parallel()
+
+	var registrationHits int32
+	var server *httptest.Server
+	mux := http.NewServeMux()
+
+	// Serve metadata ONLY at the RFC 8414 §3.1 path-insertion URL.
+	// The OIDC issuer-suffix URL (/oauth/.well-known/openid-configuration)
+	// is intentionally not mounted — it returns 404, simulating the Gleean
+	// AS behaviour that triggered #5356.
+	mux.HandleFunc("/.well-known/oauth-authorization-server/oauth", func(w http.ResponseWriter, _ *http.Request) {
+		// Issuer must carry the non-root path to pass RFC 8414 §3.3 validation.
+		md := oauthproto.AuthorizationServerMetadata{
+			Issuer:                            server.URL + "/oauth",
+			AuthorizationEndpoint:             server.URL + "/oauth/authorize",
+			TokenEndpoint:                     server.URL + "/oauth/token",
+			RegistrationEndpoint:              server.URL + "/oauth/register",
+			CodeChallengeMethodsSupported:     []string{"S256"},
+			TokenEndpointAuthMethodsSupported: []string{"none"},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(md)
+	})
+
+	mux.HandleFunc("/oauth/register", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.ReadAll(r.Body)
+		_ = r.Body.Close()
+		atomic.AddInt32(&registrationHits, 1)
+		resp := oauthproto.DynamicClientRegistrationResponse{
+			ClientID:                "non-root-client",
+			TokenEndpointAuthMethod: "none",
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(resp)
+	})
+
+	server = httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	config := &OAuthFlowConfig{
+		Scopes:       []string{"openid", "profile"},
+		CallbackPort: 8765,
+	}
+
+	err := handleDynamicRegistration(context.Background(), server.URL+"/oauth", config)
+	require.NoError(t, err, "DCR must succeed when metadata is served only at RFC 8414 path-insertion URL")
+	assert.Equal(t, "non-root-client", config.ClientID)
+	assert.EqualValues(t, 1, atomic.LoadInt32(&registrationHits),
+		"expected exactly one /oauth/register call")
+}
+
 // TestHandleDynamicRegistration_PopulatesEndpoints verifies the contract
 // the rest of the CLI flow depends on: handleDynamicRegistration writes
 // the resolved AuthorizeURL / TokenURL onto OAuthFlowConfig so

--- a/pkg/auth/discovery/discovery.go
+++ b/pkg/auth/discovery/discovery.go
@@ -673,30 +673,22 @@ func handleDynamicRegistration(ctx context.Context, issuer string, config *OAuth
 // to register with token_endpoint_auth_method=none and to refuse when
 // S256 PKCE is not advertised (rather than silently downgrading).
 //
-// Redundant discovery fetch — acknowledged trade-off. The CLI's
-// pre-discovery layer (pkg/auth/remote/handler.go via
-// ValidateAndDiscoverAuthServer) populates OAuthFlowConfig.AuthorizeURL /
-// TokenURL / RegistrationEndpoint but does NOT carry the upstream's
-// code_challenge_methods_supported through to here — that field is the
-// S256 PKCE gate's only input, and AuthServerInfo does not model it. So
-// when the CLI already has endpoints in hand, the resolver MUST still
-// re-fetch the upstream's discovery document to evaluate the gate; the
-// alternative ("skip the gate on the pre-discovered path") would either
-// regress the inherited-S256 acceptance criterion or silently downgrade
-// to a non-public-PKCE registration. Threading
-// code_challenge_methods_supported through AuthServerInfo (and updating
-// every caller of ValidateAndDiscoverAuthServer) would close this loop
-// and is the natural follow-up; it is out of scope for sub-issue 4b.
+// Discovery fetch — multi-URL fallback. oauthproto.FetchAuthorizationServerMetadata
+// tries the three well-known URL forms defined by RFC 8414 §3.1 and OIDC
+// Discovery in priority order: RFC 8414 path-insertion
+// (scheme://host/.well-known/oauth-authorization-server/{path}), OIDC
+// issuer-suffix ({issuer}/.well-known/openid-configuration), and bare
+// RFC 8414 (scheme://host/.well-known/oauth-authorization-server). Using
+// this function rather than constructing a single OIDC URL ensures that
+// authorization servers with non-root issuer paths whose metadata lives
+// at the path-insertion URL are correctly reached (fixes #5356).
+// The fetched code_challenge_methods_supported is forwarded to the
+// resolver via dcr.Request so the S256 PKCE gate fires without a
+// second discovery round-trip inside the resolver.
 //
-// Threat-model correctness in the multi-tenant case: a few upstreams
-// (multi-tenant IdPs) serve their OIDC discovery document at a path
-// the issuer-derived well-known URL would not reach. For those
-// providers the remote handler's pre-discovery already accepted the
-// non-well-known URL via DiscoverActualIssuer; the resolver's second
-// fetch against {issuer}/.well-known/openid-configuration may then 404.
-// The CLI surfaces a clean resolver error in that case rather than
-// silently registering. This is a known limitation of the option (b)
-// migration and is documented for follow-up.
+// Threading code_challenge_methods_supported through AuthServerInfo (and
+// updating every caller of ValidateAndDiscoverAuthServer) would eliminate
+// this fetch on the pre-discovered path and is a natural follow-up.
 func resolveDCRCredentials(
 	ctx context.Context,
 	issuer string,
@@ -723,22 +715,37 @@ func resolveDCRCredentials(
 		PublicClient:          true,
 	}
 
-	// Route the resolver through discovery (not direct registration
-	// endpoint) so the upstream's code_challenge_methods_supported is
-	// available to the S256 PKCE gate. See the function-level doc for
-	// why a second fetch is required even when endpoints are already in
-	// hand. The discovered metadata.RegistrationEndpoint will round-trip
-	// through the fetch — explicit AuthorizationEndpoint / TokenEndpoint
-	// overrides still win for endpoint selection.
-	//
-	// discoveredDoc.Issuer is non-empty for every reachable caller (both
-	// branches of getDiscoveryDocument set it), so the conditional is
-	// defence-in-depth against a future refactor that produces an empty-
-	// issuer doc; on that branch DiscoveryURL stays empty and the
-	// resolver would have nothing to fetch, surfacing a clean validation
-	// error rather than dereferencing an empty URL.
+	// Fetch AS metadata using the multi-URL fallback so non-root issuers
+	// are correctly reached (see function-level doc). discoveredDoc.Issuer
+	// is non-empty for every reachable caller; the else branch is
+	// defence-in-depth for a future refactor that produces an empty-issuer
+	// doc and preserves the pre-existing RegistrationEndpoint-direct path.
 	if discoveredDoc.Issuer != "" {
-		req.DiscoveryURL = strings.TrimRight(discoveredDoc.Issuer, "/") + "/.well-known/openid-configuration"
+		fullMeta, metaErr := oauthproto.FetchAuthorizationServerMetadata(ctx, discoveredDoc.Issuer, nil)
+		if metaErr != nil && !errors.Is(metaErr, oauthproto.ErrRegistrationEndpointMissing) {
+			return nil, fmt.Errorf("dynamic client registration failed: discover authorization server metadata: %w", metaErr)
+		}
+		if fullMeta == nil {
+			// Contract violation guard — FetchAuthorizationServerMetadata
+			// guarantees non-nil metadata alongside ErrRegistrationEndpointMissing.
+			return nil, fmt.Errorf("dynamic client registration failed: authorization server metadata unexpectedly nil")
+		}
+		regEndpoint := fullMeta.RegistrationEndpoint
+		if regEndpoint == "" {
+			// Synthesise per nanobot/Hydra convention, mirroring the resolver's
+			// own synthesiseRegistrationEndpoint for the DiscoveryURL branch.
+			u, parseErr := url.Parse(discoveredDoc.Issuer)
+			if parseErr != nil {
+				return nil, fmt.Errorf("dynamic client registration failed: parse issuer for endpoint synthesis: %w", parseErr)
+			}
+			regEndpoint = (&url.URL{
+				Scheme: u.Scheme,
+				Host:   u.Host,
+				Path:   strings.TrimRight(u.Path, "/") + "/register",
+			}).String()
+		}
+		req.RegistrationEndpoint = regEndpoint
+		req.CodeChallengeMethodsSupported = fullMeta.CodeChallengeMethodsSupported
 	} else {
 		req.RegistrationEndpoint = discoveredDoc.RegistrationEndpoint
 	}


### PR DESCRIPTION
## Summary

Authorization servers whose issuer has a non-root path (e.g. `https://example.com/oauth`) may serve their RFC 8414 metadata exclusively at the path-insertion URL (`scheme://host/.well-known/oauth-authorization-server/path`), not at the OIDC issuer-suffix URL (`{issuer}/.well-known/openid-configuration`). After upgrading to v0.28.0, `thv run` would fail for these servers before opening the browser — the workload never entered running state.

- PR #5250 introduced a re-fetch of AS metadata inside `resolveDCRCredentials` to get `code_challenge_methods_supported` for the S256 PKCE gate. It constructed a single OIDC issuer-suffix URL for that fetch and passed it to `FetchAuthorizationServerMetadataFromURL`, which fetches exactly one URL with no fallback. Servers that only serve the RFC 8414 path-insertion URL returned HTML or a 404, producing the `unexpected content-type "text/html"` error from the issue.
- The pre-existing v0.27.x code (`discoverOIDCEndpointsWithClientAndValidation`) tried both URL forms and fell back gracefully; that fallback was lost in the migration.
- Fix routes the re-fetch through `oauthproto.FetchAuthorizationServerMetadata`, which tries all three well-known URL forms in priority order (RFC 8414 path-insertion → OIDC issuer-suffix → bare RFC 8414). The fetched `code_challenge_methods_supported` is forwarded to the resolver via a new `dcr.Request.CodeChallengeMethodsSupported` field so the S256 PKCE gate fires without a second round-trip inside the resolver.

Fixes #5356.

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)

New and updated tests:

- `TestHandleDynamicRegistration_NonRootIssuerRFC8414PathInsertion` — regression test: mounts metadata only at `/.well-known/oauth-authorization-server/oauth`, verifies DCR succeeds end-to-end (would have failed before the fix).
- `TestHandleDynamicRegistration_PreDiscoveredPathNonRootIssuer` — same scenario on the pre-discovered path (endpoints already in `OAuthFlowConfig`), which is the more common production case.
- `TestHandleDynamicRegistration_SynthesisesEndpointWhenMetadataOmitsIt` — verifies the `ErrRegistrationEndpointMissing` synthesis branch in `resolveDCRCredentials` routes to `{issuer}/register`.
- `TestResolveDCRCredentials_CodeChallengeMethodsSupportedFieldEnablesPublicClient` — pins the new `dcr.Request.CodeChallengeMethodsSupported` field: S256 present allows public client, `plain`-only or absent rejects it, absent is fine for confidential clients.

## API Compatibility

- [x] This PR does not break the `v1beta1` API, OR the `api-break-allowed` label is applied and the migration guidance is described above.

## Changes

| File | Change |
|------|--------|
| `pkg/auth/dcr/request.go` | Add `CodeChallengeMethodsSupported []string` to `Request`; active on the `RegistrationEndpoint` branch so callers can supply already-discovered capability fields. |
| `pkg/auth/dcr/resolver.go` | Thread `req.CodeChallengeMethodsSupported` into `dcrEndpoints` on the `RegistrationEndpoint` branch so the S256 gate fires from the caller-supplied field. |
| `pkg/auth/discovery/discovery.go` | Replace the single OIDC URL construction in `resolveDCRCredentials` with `oauthproto.FetchAuthorizationServerMetadata` (multi-URL fallback); forward `CodeChallengeMethodsSupported` to the resolver. Update function doc. |
| `pkg/auth/discovery/dcr_resolver_test.go` | Add three tests (regression, pre-discovered path, endpoint synthesis). |
| `pkg/auth/dcr/resolver_test.go` | Add table test for `CodeChallengeMethodsSupported` field on `RegistrationEndpoint` branch. |

## Does this introduce a user-facing change?

DCR now succeeds for authorization servers with non-root issuer paths (e.g. `https://example.com/oauth`) that serve RFC 8414 metadata at the path-insertion URL. These servers were broken in v0.28.0; this restores v0.27.x behaviour.

## Special notes for reviewers

The architectural root cause (#5250 doc comment, "known limitation of the option (b) migration") is that `code_challenge_methods_supported` is not threaded through `AuthServerInfo` to the CLI call site. That follow-up (threading the field through `ValidateAndDiscoverAuthServer` and all its callers) would eliminate the re-fetch entirely on the pre-discovered path and remains open. This PR takes the minimal targeted fix: use the multi-URL fallback for the re-fetch and forward the result via the new field, without touching `AuthServerInfo` or its callers.

Generated with [Claude Code](https://claude.com/claude-code)