### PR TITLE
Validate LocalStore paths stay in state directory

### DIFF
--- a/pkg/state/local.go
+++ b/pkg/state/local.go
@@ -52,20 +52,30 @@ func NewLocalStore(appName string, storeName string) (*LocalStore, error) {
 	}, nil
 }
 
-// getFilePath returns the full file path for a configuration
-func (s *LocalStore) getFilePath(name string) string {
+// getFilePath returns the full file path for a configuration.
+func (s *LocalStore) getFilePath(name string) (string, error) {
 	// Ensure the name has the correct extension
 	if !strings.HasSuffix(name, FileExtension) {
 		name = name + FileExtension
 	}
-	return filepath.Join(s.basePath, name)
+
+	basePath := filepath.Clean(s.basePath)
+	filePath := filepath.Clean(filepath.Join(basePath, name))
+	if !strings.HasPrefix(filePath, basePath+string(os.PathSeparator)) {
+		return "", fmt.Errorf("state path %q escapes state directory", name)
+	}
+
+	return filePath, nil
 }
 
 // GetReader returns a reader for the state data
 func (s *LocalStore) GetReader(_ context.Context, name string) (io.ReadCloser, error) {
 	// Open the file
-	filePath := s.getFilePath(name)
-	// #nosec G304 - filePath is controlled by getFilePath which ensures it's within our designated directory
+	filePath, err := s.getFilePath(name)
+	if err != nil {
+		return nil, err
+	}
+	// #nosec G304 - filePath is validated by getFilePath to stay within the state directory
 	file, err := os.Open(filePath)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -80,8 +90,11 @@ func (s *LocalStore) GetReader(_ context.Context, name string) (io.ReadCloser, e
 // GetWriter returns a writer for the state data
 func (s *LocalStore) GetWriter(_ context.Context, name string) (io.WriteCloser, error) {
 	// Create the file
-	filePath := s.getFilePath(name)
-	// #nosec G304 - filePath is controlled by getFilePath which ensures it's within our designated directory
+	filePath, err := s.getFilePath(name)
+	if err != nil {
+		return nil, err
+	}
+	// #nosec G304 - filePath is validated by getFilePath to stay within the state directory
 	file, err := os.OpenFile(filePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create file: %w", err)
@@ -93,9 +106,12 @@ func (s *LocalStore) GetWriter(_ context.Context, name string) (io.WriteCloser, 
 // CreateExclusive creates a new state entry exclusively, failing if it already exists.
 // This provides atomic check-and-create semantics using O_EXCL to prevent race conditions.
 func (s *LocalStore) CreateExclusive(_ context.Context, name string) (io.WriteCloser, error) {
-	filePath := s.getFilePath(name)
+	filePath, err := s.getFilePath(name)
+	if err != nil {
+		return nil, err
+	}
 	// O_EXCL with O_CREATE provides atomic check-and-create behavior
-	// #nosec G304 - filePath is controlled by getFilePath which ensures it's within our designated directory
+	// #nosec G304 - filePath is validated by getFilePath to stay within the state directory
 	file, err := os.OpenFile(filePath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
 	if err != nil {
 		if os.IsExist(err) {
@@ -112,8 +128,11 @@ func (s *LocalStore) CreateExclusive(_ context.Context, name string) (io.WriteCl
 
 // Delete removes the data for the given name
 func (s *LocalStore) Delete(_ context.Context, name string) error {
-	filePath := s.getFilePath(name)
-	// #nosec G304 - filePath is controlled by getFilePath which ensures it's within our designated directory
+	filePath, err := s.getFilePath(name)
+	if err != nil {
+		return err
+	}
+	// #nosec G304 - filePath is validated by getFilePath to stay within the state directory
 	if err := os.Remove(filePath); err != nil {
 		if os.IsNotExist(err) {
 			return fmt.Errorf("state '%s' not found", name)
@@ -154,8 +173,11 @@ func (s *LocalStore) List(_ context.Context) ([]string, error) {
 
 // Exists checks if data exists for the given name
 func (s *LocalStore) Exists(_ context.Context, name string) (bool, error) {
-	filePath := s.getFilePath(name)
-	_, err := os.Stat(filePath)
+	filePath, err := s.getFilePath(name)
+	if err != nil {
+		return false, err
+	}
+	_, err = os.Stat(filePath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return false, nil

--- a/pkg/state/local_test.go
+++ b/pkg/state/local_test.go
@@ -1,0 +1,104 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package state
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLocalStoreRejectsPathTraversalNames(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	tests := []struct {
+		name          string
+		setupOutside  bool
+		expectOutside bool
+		run           func(*testing.T, context.Context, *LocalStore, string) error
+	}{
+		{
+			name:          "GetReader",
+			setupOutside:  true,
+			expectOutside: true,
+			run: func(t *testing.T, ctx context.Context, store *LocalStore, name string) error {
+				reader, err := store.GetReader(ctx, name)
+				if reader != nil {
+					require.NoError(t, reader.Close())
+				}
+				return err
+			},
+		},
+		{
+			name: "GetWriter",
+			run: func(t *testing.T, ctx context.Context, store *LocalStore, name string) error {
+				writer, err := store.GetWriter(ctx, name)
+				if writer != nil {
+					require.NoError(t, writer.Close())
+				}
+				return err
+			},
+		},
+		{
+			name: "CreateExclusive",
+			run: func(t *testing.T, ctx context.Context, store *LocalStore, name string) error {
+				writer, err := store.CreateExclusive(ctx, name)
+				if writer != nil {
+					require.NoError(t, writer.Close())
+				}
+				return err
+			},
+		},
+		{
+			name:          "Delete",
+			setupOutside:  true,
+			expectOutside: true,
+			run: func(_ *testing.T, ctx context.Context, store *LocalStore, name string) error {
+				return store.Delete(ctx, name)
+			},
+		},
+		{
+			name:          "Exists",
+			setupOutside:  true,
+			expectOutside: true,
+			run: func(_ *testing.T, ctx context.Context, store *LocalStore, name string) error {
+				_, err := store.Exists(ctx, name)
+				return err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			tempDir := t.TempDir()
+			basePath := filepath.Join(tempDir, "state")
+			require.NoError(t, os.MkdirAll(basePath, 0750))
+
+			outsidePath := filepath.Join(tempDir, "outside.json")
+			if tt.setupOutside {
+				require.NoError(t, os.WriteFile(outsidePath, []byte("{}"), 0600))
+			}
+
+			store := &LocalStore{basePath: basePath}
+			err := tt.run(t, ctx, store, "../outside")
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "escapes state directory")
+			if tt.expectOutside {
+				assert.FileExists(t, outsidePath)
+			} else {
+				assert.NoFileExists(t, outsidePath)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- `LocalStore.getFilePath` accepted names that could resolve outside the state directory when they contained path traversal segments.
- Added path containment validation before returning file paths and propagated invalid-name errors through read, write, create, delete, and exists operations.
- Corrected the `#nosec G304` justifications and added regression coverage for traversal attempts across all affected operations.

Fixes #4736

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [x] Unit tests (`go test ./pkg/state`)
- [x] Unit tests (`go test -count=1 ./pkg/state ./pkg/groups ./pkg/workloads/types ./pkg/migration`)
- [x] Whitespace check (`git diff --check`)
- [ ] E2E tests (`task test-e2e`)
- [ ] Linting (`task lint-fix`)

## API Compatibility

- [x] This PR does not break the `v1beta1` API, OR the `api-break-allowed` label is applied and the migration guidance is described above.

## Does this introduce a user-facing change?

No.

## Special notes for reviewers

I also attempted `go test ./...` locally. It reached unrelated environment-bound suites and failed because this machine is missing `/usr/local/kubebuilder/bin/etcd`, a `thv` binary in `PATH`, a kubeconfig, and an available container runtime; one runner test also found port 8001 unavailable.