### PR TITLE
Restore ServerBuilder.WithMiddleware and WithRoute

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -144,24 +144,28 @@ func (b *ServerBuilder) WithOtelEnabled(enabled bool) *ServerBuilder {
 
 // WithMiddleware appends HTTP middleware that runs after the default middleware
 // stack (request-ID, body-size limit, headers, update-check, auth) and before
-// route handlers. Consumed by ApplyServerExtensions hooks that inject custom
-// authentication or request-scoping middleware into the API server.
+// route handlers. Part of the ApplyServerExtensions extension point — used by
+// downstream consumers to inject custom authentication or request-scoping
+// middleware into the API server.
 //
-// Required for the ApplyServerExtensions extension point — do not remove even
-// if deadcode analysis reports it unused, since the callers live behind build
-// tags not exercised by upstream CI.
+// Public extension API. Do not remove based on deadcode analysis alone:
+// callers may live in repositories that are not visible to this module's
+// analyzer. The test in server_test.go intentionally exercises this method
+// to keep it reachable.
 func (b *ServerBuilder) WithMiddleware(mw ...func(http.Handler) http.Handler) *ServerBuilder {
 	b.middlewares = append(b.middlewares, mw...)
 	return b
 }
 
 // WithRoute mounts a sub-router at the given prefix. The caller is responsible
-// for any per-route timeout middleware. Consumed by ApplyServerExtensions hooks
-// that add additional API surface alongside the built-in routes.
+// for any per-route timeout middleware. Part of the ApplyServerExtensions
+// extension point — used by downstream consumers to add API surface alongside
+// the built-in routes.
 //
-// Required for the ApplyServerExtensions extension point — do not remove even
-// if deadcode analysis reports it unused, since the callers live behind build
-// tags not exercised by upstream CI.
+// Public extension API. Do not remove based on deadcode analysis alone:
+// callers may live in repositories that are not visible to this module's
+// analyzer. The test in server_test.go intentionally exercises this method
+// to keep it reachable.
 func (b *ServerBuilder) WithRoute(prefix string, handler http.Handler) *ServerBuilder {
 	b.customRoutes[prefix] = handler
 	return b

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -142,6 +142,31 @@ func (b *ServerBuilder) WithOtelEnabled(enabled bool) *ServerBuilder {
 	return b
 }
 
+// WithMiddleware appends HTTP middleware that runs after the default middleware
+// stack (request-ID, body-size limit, headers, update-check, auth) and before
+// route handlers. Consumed by ApplyServerExtensions hooks that inject custom
+// authentication or request-scoping middleware into the API server.
+//
+// Required for the ApplyServerExtensions extension point — do not remove even
+// if deadcode analysis reports it unused, since the callers live behind build
+// tags not exercised by upstream CI.
+func (b *ServerBuilder) WithMiddleware(mw ...func(http.Handler) http.Handler) *ServerBuilder {
+	b.middlewares = append(b.middlewares, mw...)
+	return b
+}
+
+// WithRoute mounts a sub-router at the given prefix. The caller is responsible
+// for any per-route timeout middleware. Consumed by ApplyServerExtensions hooks
+// that add additional API surface alongside the built-in routes.
+//
+// Required for the ApplyServerExtensions extension point — do not remove even
+// if deadcode analysis reports it unused, since the callers live behind build
+// tags not exercised by upstream CI.
+func (b *ServerBuilder) WithRoute(prefix string, handler http.Handler) *ServerBuilder {
+	b.customRoutes[prefix] = handler
+	return b
+}
+
 // Build creates and configures the HTTP router
 func (b *ServerBuilder) Build(ctx context.Context) (*chi.Mux, error) {
 	r := chi.NewRouter()

--- a/pkg/api/server_test.go
+++ b/pkg/api/server_test.go
@@ -90,9 +90,11 @@ func TestListenURL(t *testing.T) {
 }
 
 // TestServerBuilderExtensionPoints exercises WithMiddleware and WithRoute so
-// the deadcode tool keeps them alive. Both methods are the only public API
-// available to ApplyServerExtensions hooks (e.g. the enterprise overlay),
-// whose callers live behind build tags not exercised by upstream CI.
+// they remain reachable to deadcode analysis. Both methods form the public
+// surface for ApplyServerExtensions consumers, whose callers may live in
+// downstream repositories that this module's analyzer cannot see. Without
+// this test, a future deadcode pass would flag them as unreachable (as
+// happened in #5355) even though external callers depend on them.
 func TestServerBuilderExtensionPoints(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/api/server_test.go
+++ b/pkg/api/server_test.go
@@ -6,9 +6,11 @@ package api
 import (
 	"fmt"
 	"net"
+	"net/http"
 	"regexp"
 	"testing"
 
+	"github.com/go-chi/chi/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -85,4 +87,42 @@ func TestListenURL(t *testing.T) {
 			assert.Equal(t, tt.expected(s), s.ListenURL())
 		})
 	}
+}
+
+// TestServerBuilderExtensionPoints exercises WithMiddleware and WithRoute so
+// the deadcode tool keeps them alive. Both methods are the only public API
+// available to ApplyServerExtensions hooks (e.g. the enterprise overlay),
+// whose callers live behind build tags not exercised by upstream CI.
+func TestServerBuilderExtensionPoints(t *testing.T) {
+	t.Parallel()
+
+	t.Run("WithMiddleware appends to middleware chain", func(t *testing.T) {
+		t.Parallel()
+
+		b := NewServerBuilder()
+		mw := func(next http.Handler) http.Handler { return next }
+		b.WithMiddleware(mw, mw)
+
+		assert.Len(t, b.middlewares, 2)
+	})
+
+	t.Run("WithRoute registers handler at prefix", func(t *testing.T) {
+		t.Parallel()
+
+		b := NewServerBuilder()
+		b.WithRoute("/ext", chi.NewRouter())
+
+		_, ok := b.customRoutes["/ext"]
+		assert.True(t, ok, "expected /ext to be registered")
+	})
+
+	t.Run("methods chain on the builder", func(t *testing.T) {
+		t.Parallel()
+
+		b := NewServerBuilder().
+			WithMiddleware(func(next http.Handler) http.Handler { return next }).
+			WithRoute("/ext", chi.NewRouter())
+
+		assert.NotNil(t, b)
+	})
 }


### PR DESCRIPTION
## Summary

- **Why**: #5355 ("Remove unreachable functions identified by deadcode analysis") dropped `ServerBuilder.WithMiddleware` and `ServerBuilder.WithRoute`. These are the only public surface available to `ApplyServerExtensions` consumers — the extension point this codebase exposes for downstream builds to inject middleware and mount additional routes. The deadcode tool reported them as unreachable because their callers live in repositories whose source it doesn't have access to. After v0.28.2, any build that wires `ApplyServerExtensions` fails to compile (`b.WithMiddleware undefined`, `b.WithRoute undefined`).
- **What**:
  - Restore both methods on `ServerBuilder` with doc comments stating that they are part of the public extension contract and should not be deleted on deadcode analysis alone.
  - Add `TestServerBuilderExtensionPoints` so future deadcode passes see both methods as live within this repository.

The other five `With*` methods deleted in #5355 (`WithContainerRuntime`, `WithClientManager`, `WithWorkloadManager`, `WithGroupManager`, `WithSkillManager`) remain removed — no known consumer needs them.

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test` for `./pkg/api/...` — all green, including the new `TestServerBuilderExtensionPoints`)
- [x] Linting (`task lint-fix` — 0 issues)
- [x] Manual testing: verified a downstream consumer that calls `b.WithMiddleware(...)` and `b.WithRoute(...)` via `ApplyServerExtensions` compiles cleanly with this patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)