### PR TITLE
Consolidate authserver DCR types onto pkg/oauthproto

### DIFF
--- a/pkg/authserver/server/handlers/dcr.go
+++ b/pkg/authserver/server/handlers/dcr.go
@@ -14,6 +14,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/stacklok/toolhive/pkg/authserver/server/registration"
+	"github.com/stacklok/toolhive/pkg/oauthproto"
 )
 
 // maxDCRBodySize is the maximum allowed size for DCR request bodies (64KB).
@@ -40,8 +41,10 @@ func (h *Handler) RegisterClientHandler(w http.ResponseWriter, req *http.Request
 		return
 	}
 
-	// Parse request body
-	var dcrReq registration.DCRRequest
+	// Parse request body. oauthproto.ScopeList.UnmarshalJSON handles both
+	// RFC 7591 wire formats for "scope" (space-delimited string or JSON
+	// array) so we accept either shape transparently here.
+	var dcrReq oauthproto.DynamicClientRegistrationRequest
 	if err := json.NewDecoder(req.Body).Decode(&dcrReq); err != nil {
 		writeDCRError(w, http.StatusBadRequest, &registration.DCRError{
 			Error:            registration.DCRErrorInvalidClientMetadata,
@@ -58,7 +61,7 @@ func (h *Handler) RegisterClientHandler(w http.ResponseWriter, req *http.Request
 	}
 
 	// Validate requested scopes against server's supported scopes
-	scopes, dcrErr := registration.ValidateScopes(dcrReq.Scope, h.config.ScopesSupported)
+	scopes, dcrErr := registration.ValidateScopes(dcrReq.Scopes, h.config.ScopesSupported)
 	if dcrErr != nil {
 		writeDCRError(w, http.StatusBadRequest, dcrErr)
 		return
@@ -151,13 +154,14 @@ func (h *Handler) RegisterClientHandler(w http.ResponseWriter, req *http.Request
 	slog.Debug("registered new DCR client", logAttrs...)
 
 	// Build response per RFC 7591 Section 3.2.1.
-	// Scope reflects the scopes actually granted to this client: the
+	// Scopes reflects the scopes actually granted to this client: the
 	// client-supplied scope set was validated against ScopesSupported by
 	// ValidateScopes above, then (if configured) unioned with
 	// BaselineClientScopes — which is itself guaranteed by startup-time
 	// validation to be a subset of ScopesSupported. The unioned set is NOT
-	// re-validated here.
-	response := registration.DCRResponse{
+	// re-validated here. ScopeList.MarshalJSON emits the RFC 7591 §2
+	// space-delimited wire form on the way out.
+	response := oauthproto.DynamicClientRegistrationResponse{
 		ClientID:                clientID,
 		ClientIDIssuedAt:        time.Now().Unix(),
 		RedirectURIs:            validated.RedirectURIs,
@@ -165,7 +169,7 @@ func (h *Handler) RegisterClientHandler(w http.ResponseWriter, req *http.Request
 		TokenEndpointAuthMethod: validated.TokenEndpointAuthMethod,
 		GrantTypes:              validated.GrantTypes,
 		ResponseTypes:           validated.ResponseTypes,
-		Scope:                   registration.FormatScopes(scopes),
+		Scopes:                  oauthproto.ScopeList(scopes),
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/pkg/authserver/server/handlers/dcr_test.go
+++ b/pkg/authserver/server/handlers/dcr_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stacklok/toolhive/pkg/authserver/server"
 	"github.com/stacklok/toolhive/pkg/authserver/server/registration"
 	"github.com/stacklok/toolhive/pkg/authserver/storage/mocks"
+	"github.com/stacklok/toolhive/pkg/oauthproto"
 )
 
 func TestRegisterClientHandler(t *testing.T) {
@@ -36,7 +37,7 @@ func TestRegisterClientHandler(t *testing.T) {
 	}{
 		{
 			name: "success",
-			requestBody: registration.DCRRequest{
+			requestBody: oauthproto.DynamicClientRegistrationRequest{
 				RedirectURIs: []string{"http://127.0.0.1:8080/callback"},
 				ClientName:   "Test Client",
 			},
@@ -50,7 +51,7 @@ func TestRegisterClientHandler(t *testing.T) {
 		},
 		{
 			name: "validation error propagated",
-			requestBody: registration.DCRRequest{
+			requestBody: oauthproto.DynamicClientRegistrationRequest{
 				RedirectURIs: []string{"http://example.com/callback"},
 			},
 			expectedStatus: http.StatusBadRequest,
@@ -58,7 +59,7 @@ func TestRegisterClientHandler(t *testing.T) {
 		},
 		{
 			name: "storage failure returns 500",
-			requestBody: registration.DCRRequest{
+			requestBody: oauthproto.DynamicClientRegistrationRequest{
 				RedirectURIs: []string{"http://127.0.0.1:8080/callback"},
 			},
 			storageErr:      errors.New("disk full"),
@@ -111,7 +112,7 @@ func TestRegisterClientHandler(t *testing.T) {
 					assert.Contains(t, errResp.ErrorDescription, tc.expectedErrDesc)
 				}
 			} else {
-				var resp registration.DCRResponse
+				var resp oauthproto.DynamicClientRegistrationResponse
 				require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 				assert.NotEmpty(t, resp.ClientID)
 				assert.NotZero(t, resp.ClientIDIssuedAt)
@@ -137,7 +138,7 @@ func TestRegisterClientHandler_ScopeInResponse(t *testing.T) {
 		},
 	}
 
-	reqBody, err := json.Marshal(registration.DCRRequest{
+	reqBody, err := json.Marshal(oauthproto.DynamicClientRegistrationRequest{
 		RedirectURIs: []string{"http://127.0.0.1:8080/callback"},
 	})
 	require.NoError(t, err)
@@ -149,9 +150,9 @@ func TestRegisterClientHandler_ScopeInResponse(t *testing.T) {
 	handler.RegisterClientHandler(w, req)
 	require.Equal(t, http.StatusCreated, w.Code)
 
-	var resp registration.DCRResponse
+	var resp oauthproto.DynamicClientRegistrationResponse
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-	assert.Equal(t, registration.FormatScopes(registration.DefaultScopes), resp.Scope,
+	assert.Equal(t, []string(registration.DefaultScopes), []string(resp.Scopes),
 		"DCR response should include granted scopes per RFC 7591 Section 3.2.1")
 }
 
@@ -239,9 +240,9 @@ func TestRegisterClientHandler_BaselineClientScopes(t *testing.T) {
 			}
 			handler := &Handler{storage: stor, config: cfg}
 
-			reqBody, err := json.Marshal(registration.DCRRequest{
+			reqBody, err := json.Marshal(oauthproto.DynamicClientRegistrationRequest{
 				RedirectURIs: []string{"http://127.0.0.1:8080/callback"},
-				Scope:        tc.requestScope,
+				Scopes:       oauthproto.ScopeList(strings.Fields(tc.requestScope)),
 			})
 			require.NoError(t, err)
 
@@ -253,9 +254,9 @@ func TestRegisterClientHandler_BaselineClientScopes(t *testing.T) {
 
 			require.Equal(t, http.StatusCreated, w.Code)
 
-			var resp registration.DCRResponse
+			var resp oauthproto.DynamicClientRegistrationResponse
 			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-			assert.Equal(t, registration.FormatScopes(tc.expectedScopes), resp.Scope,
+			assert.Equal(t, tc.expectedScopes, []string(resp.Scopes),
 				"DCR response scope must equal the union of requested and baseline scopes")
 
 			require.NotNil(t, capturedClient, "storage was not called")
@@ -285,7 +286,7 @@ func TestRegisterClientHandler_ClientIsStored(t *testing.T) {
 	}
 	handler := &Handler{storage: stor, config: cfg}
 
-	reqBody, err := json.Marshal(registration.DCRRequest{
+	reqBody, err := json.Marshal(oauthproto.DynamicClientRegistrationRequest{
 		RedirectURIs: []string{"http://127.0.0.1:8080/callback"},
 		ClientName:   "Stored Client",
 	})
@@ -298,7 +299,7 @@ func TestRegisterClientHandler_ClientIsStored(t *testing.T) {
 	handler.RegisterClientHandler(w, req)
 	require.Equal(t, http.StatusCreated, w.Code)
 
-	var resp registration.DCRResponse
+	var resp oauthproto.DynamicClientRegistrationResponse
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 
 	require.NotNil(t, storedClient)
@@ -310,4 +311,51 @@ func TestRegisterClientHandler_ClientIsStored(t *testing.T) {
 	assert.Equal(t, []string{"http://127.0.0.1:8080/callback"}, loopbackClient.GetRedirectURIs())
 	assert.Equal(t, fosite.Arguments(allowedAudiences), loopbackClient.GetAudience(),
 		"DCR client must inherit server's AllowedAudiences so refresh token requests with resource= succeed")
+}
+
+// TestRegisterClientHandler_ScopeAsJSONArray verifies that the /oauth/register
+// endpoint accepts the RFC 7591 array form of "scope". Prior to consolidating
+// onto oauthproto.ScopeList, the handler only accepted space-delimited strings
+// and would reject this body as a JSON decode error.
+func TestRegisterClientHandler_ScopeAsJSONArray(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	stor := mocks.NewMockStorage(ctrl)
+	var capturedClient fosite.Client
+	stor.EXPECT().RegisterClient(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, c fosite.Client) error {
+			capturedClient = c
+			return nil
+		})
+
+	handler := &Handler{
+		storage: stor,
+		config: &server.AuthorizationServerConfig{
+			Config:          &fosite.Config{AccessTokenIssuer: "https://test-authserver"},
+			ScopesSupported: registration.DefaultScopes,
+		},
+	}
+
+	// Raw JSON body with scope as a JSON array — the form that
+	// well-formed RFC 7591 clients can send and that the previous
+	// space-delimited-only authserver implementation rejected.
+	body := []byte(`{"redirect_uris":["http://127.0.0.1:8080/callback"],"scope":["openid","offline_access"]}`)
+	req := httptest.NewRequest(http.MethodPost, "/oauth/register", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler.RegisterClientHandler(w, req)
+
+	require.Equal(t, http.StatusCreated, w.Code,
+		"array-form scope must be accepted per RFC 7591 §2 ambiguity")
+
+	var resp oauthproto.DynamicClientRegistrationResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, []string{"openid", "offline_access"}, []string(resp.Scopes),
+		"granted scopes must reflect the array-form request")
+
+	require.NotNil(t, capturedClient, "storage was not called")
+	assert.Equal(t, fosite.Arguments([]string{"openid", "offline_access"}), capturedClient.GetScopes(),
+		"the array-form scopes must reach storage")
 }

--- a/pkg/authserver/server/handlers/dcr_test.go
+++ b/pkg/authserver/server/handlers/dcr_test.go
@@ -165,7 +165,7 @@ func TestRegisterClientHandler_BaselineClientScopes(t *testing.T) {
 
 	tests := []struct {
 		name                 string
-		requestScope         string
+		requestScopes        []string
 		baselineClientScopes []string
 		extraScopesSupported []string // appended to DefaultScopes in ScopesSupported
 		expectedScopes       []string
@@ -175,7 +175,7 @@ func TestRegisterClientHandler_BaselineClientScopes(t *testing.T) {
 			// The baseline adds "custom:scope" (not in DefaultScopes), so the
 			// union expands the set: DefaultScopes + ["custom:scope"].
 			name:                 "empty client scope with non-empty baseline adds baseline scope",
-			requestScope:         "",
+			requestScopes:        nil,
 			baselineClientScopes: []string{"custom:scope"},
 			extraScopesSupported: []string{"custom:scope"},
 			expectedScopes:       append(append([]string{}, registration.DefaultScopes...), "custom:scope"),
@@ -183,7 +183,7 @@ func TestRegisterClientHandler_BaselineClientScopes(t *testing.T) {
 		{
 			// Requested scopes already contain the baseline; no expansion occurs.
 			name:                 "baseline is subset of requested scopes no expansion",
-			requestScope:         "openid profile email offline_access",
+			requestScopes:        []string{"openid", "profile", "email", "offline_access"},
 			baselineClientScopes: []string{"openid"},
 			extraScopesSupported: nil,
 			expectedScopes:       []string{"openid", "profile", "email", "offline_access"},
@@ -193,7 +193,7 @@ func TestRegisterClientHandler_BaselineClientScopes(t *testing.T) {
 			// "offline_access" not in the request. Exercises the dedup+append paths
 			// of unionScopes in the same handler call.
 			name:                 "partial overlap baseline appends only non-overlapping scopes",
-			requestScope:         "openid profile",
+			requestScopes:        []string{"openid", "profile"},
 			baselineClientScopes: []string{"openid", "offline_access"},
 			extraScopesSupported: nil,
 			expectedScopes:       []string{"openid", "profile", "offline_access"},
@@ -202,7 +202,7 @@ func TestRegisterClientHandler_BaselineClientScopes(t *testing.T) {
 			// Canonical regression: client registers with "openid" only,
 			// baseline adds "offline_access" → union is both.
 			name:                 "disjoint baseline expands registered scope set",
-			requestScope:         "openid",
+			requestScopes:        []string{"openid"},
 			baselineClientScopes: []string{"offline_access"},
 			extraScopesSupported: nil,
 			expectedScopes:       []string{"openid", "offline_access"},
@@ -210,7 +210,7 @@ func TestRegisterClientHandler_BaselineClientScopes(t *testing.T) {
 		{
 			// Nil baseline must not alter the registered scope set.
 			name:                 "nil baseline preserves existing behavior",
-			requestScope:         "openid",
+			requestScopes:        []string{"openid"},
 			baselineClientScopes: nil,
 			extraScopesSupported: nil,
 			expectedScopes:       []string{"openid"},
@@ -242,7 +242,7 @@ func TestRegisterClientHandler_BaselineClientScopes(t *testing.T) {
 
 			reqBody, err := json.Marshal(oauthproto.DynamicClientRegistrationRequest{
 				RedirectURIs: []string{"http://127.0.0.1:8080/callback"},
-				Scopes:       oauthproto.ScopeList(strings.Fields(tc.requestScope)),
+				Scopes:       oauthproto.ScopeList(tc.requestScopes),
 			})
 			require.NoError(t, err)
 
@@ -316,46 +316,104 @@ func TestRegisterClientHandler_ClientIsStored(t *testing.T) {
 // TestRegisterClientHandler_ScopeAsJSONArray verifies that the /oauth/register
 // endpoint accepts the RFC 7591 array form of "scope". Prior to consolidating
 // onto oauthproto.ScopeList, the handler only accepted space-delimited strings
-// and would reject this body as a JSON decode error.
+// and would reject these bodies as a JSON decode error.
+//
+// Each case sends a raw JSON body (not a Go literal that round-trips through
+// ScopeList.MarshalJSON) so the dual-format UnmarshalJSON path is exercised
+// end-to-end at the handler boundary.
 func TestRegisterClientHandler_ScopeAsJSONArray(t *testing.T) {
 	t.Parallel()
 
-	ctrl := gomock.NewController(t)
-	stor := mocks.NewMockStorage(ctrl)
-	var capturedClient fosite.Client
-	stor.EXPECT().RegisterClient(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, c fosite.Client) error {
-			capturedClient = c
-			return nil
-		})
-
-	handler := &Handler{
-		storage: stor,
-		config: &server.AuthorizationServerConfig{
-			Config:          &fosite.Config{AccessTokenIssuer: "https://test-authserver"},
-			ScopesSupported: registration.DefaultScopes,
+	tests := []struct {
+		name             string
+		body             string
+		expectedStatus   int
+		expectedScopes   []string // ignored when expectedStatus != 201
+		expectedWireFrag string   // ignored when expectedStatus != 201
+		expectedError    string   // DCR error code when expectedStatus != 201
+	}{
+		{
+			name:             "happy path: array form is accepted and granted",
+			body:             `{"redirect_uris":["http://127.0.0.1:8080/callback"],"scope":["openid","offline_access"]}`,
+			expectedStatus:   http.StatusCreated,
+			expectedScopes:   []string{"openid", "offline_access"},
+			expectedWireFrag: `"scope":"openid offline_access"`,
+		},
+		{
+			// Mirrors the string-form unsupported-scope path from
+			// TestValidateScopes ("unknown scope rejected") at the handler
+			// boundary, but routed through the array-form decoder.
+			name:           "array form with unsupported scope is rejected",
+			body:           `{"redirect_uris":["http://127.0.0.1:8080/callback"],"scope":["openid","sneaky_admin"]}`,
+			expectedStatus: http.StatusBadRequest,
+			expectedError:  registration.DCRErrorInvalidClientMetadata,
+		},
+		{
+			// Empty-array case. ScopeList.UnmarshalJSON normalizes [] to
+			// nil, ValidateScopes then falls back to DefaultScopes.
+			// Documented intentional behavior change: pre-consolidation the
+			// authserver returned 400 for this body because the
+			// space-delimited-only decoder could not consume a JSON array.
+			name:             "empty array falls back to DefaultScopes",
+			body:             `{"redirect_uris":["http://127.0.0.1:8080/callback"],"scope":[]}`,
+			expectedStatus:   http.StatusCreated,
+			expectedScopes:   registration.DefaultScopes,
+			expectedWireFrag: `"scope":"openid profile email offline_access"`,
 		},
 	}
 
-	// Raw JSON body with scope as a JSON array — the form that
-	// well-formed RFC 7591 clients can send and that the previous
-	// space-delimited-only authserver implementation rejected.
-	body := []byte(`{"redirect_uris":["http://127.0.0.1:8080/callback"],"scope":["openid","offline_access"]}`)
-	req := httptest.NewRequest(http.MethodPost, "/oauth/register", bytes.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	w := httptest.NewRecorder()
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-	handler.RegisterClientHandler(w, req)
+			ctrl := gomock.NewController(t)
+			stor := mocks.NewMockStorage(ctrl)
+			var capturedClient fosite.Client
+			stor.EXPECT().RegisterClient(gomock.Any(), gomock.Any()).DoAndReturn(
+				func(_ context.Context, c fosite.Client) error {
+					capturedClient = c
+					return nil
+				}).AnyTimes()
 
-	require.Equal(t, http.StatusCreated, w.Code,
-		"array-form scope must be accepted per RFC 7591 §2 ambiguity")
+			handler := &Handler{
+				storage: stor,
+				config: &server.AuthorizationServerConfig{
+					Config:          &fosite.Config{AccessTokenIssuer: "https://test-authserver"},
+					ScopesSupported: registration.DefaultScopes,
+				},
+			}
 
-	var resp oauthproto.DynamicClientRegistrationResponse
-	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-	assert.Equal(t, []string{"openid", "offline_access"}, []string(resp.Scopes),
-		"granted scopes must reflect the array-form request")
+			req := httptest.NewRequest(http.MethodPost, "/oauth/register", bytes.NewReader([]byte(tc.body)))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
 
-	require.NotNil(t, capturedClient, "storage was not called")
-	assert.Equal(t, fosite.Arguments([]string{"openid", "offline_access"}), capturedClient.GetScopes(),
-		"the array-form scopes must reach storage")
+			handler.RegisterClientHandler(w, req)
+
+			require.Equal(t, tc.expectedStatus, w.Code)
+
+			if tc.expectedStatus != http.StatusCreated {
+				var errResp registration.DCRError
+				require.NoError(t, json.Unmarshal(w.Body.Bytes(), &errResp))
+				assert.Equal(t, tc.expectedError, errResp.Error)
+				return
+			}
+
+			// Pin the response wire form: RFC 7591 §3.2.1 requires a
+			// space-delimited scope string, not a JSON array. A raw-body
+			// assertion catches a regression that the dual-format
+			// ScopeList.UnmarshalJSON would otherwise mask when decoding
+			// resp.Scopes back into a slice.
+			assert.Contains(t, w.Body.String(), tc.expectedWireFrag,
+				"RFC 7591 §3.2.1: response scope must be space-delimited string, not JSON array")
+
+			var resp oauthproto.DynamicClientRegistrationResponse
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+			assert.Equal(t, tc.expectedScopes, []string(resp.Scopes),
+				"granted scopes must reflect the array-form request")
+
+			require.NotNil(t, capturedClient, "storage was not called")
+			assert.Equal(t, fosite.Arguments(tc.expectedScopes), capturedClient.GetScopes(),
+				"the array-form scopes must reach storage")
+		})
+	}
 }

--- a/pkg/authserver/server/registration/dcr.go
+++ b/pkg/authserver/server/registration/dcr.go
@@ -20,7 +20,6 @@ package registration
 import (
 	"fmt"
 	"slices"
-	"strings"
 
 	"github.com/stacklok/toolhive/pkg/oauthproto"
 )
@@ -78,73 +77,6 @@ const (
 	MaxSoftwareIDLength = 256
 )
 
-// DCRRequest represents an OAuth 2.0 Dynamic Client Registration request
-// per RFC 7591 Section 2.
-type DCRRequest struct {
-	// RedirectURIs is an array of redirection URIs for the client.
-	// Required for public clients.
-	RedirectURIs []string `json:"redirect_uris"`
-
-	// ClientName is a human-readable name for the client.
-	ClientName string `json:"client_name,omitempty"`
-
-	// TokenEndpointAuthMethod is the requested authentication method for the token endpoint.
-	// For public clients, this must be "none".
-	TokenEndpointAuthMethod string `json:"token_endpoint_auth_method,omitempty"`
-
-	// GrantTypes is an array of OAuth 2.0 grant types the client may use.
-	// Defaults to ["authorization_code"] if not specified.
-	GrantTypes []string `json:"grant_types,omitempty"`
-
-	// ResponseTypes is an array of OAuth 2.0 response types the client may use.
-	// Defaults to ["code"] if not specified.
-	ResponseTypes []string `json:"response_types,omitempty"`
-
-	// Scope is a space-separated list of OAuth 2.0 scope values the client may use.
-	// If not specified, defaults to the server's default scopes.
-	// All requested scopes must be supported by the server.
-	Scope string `json:"scope,omitempty"`
-
-	// SoftwareID is the RFC 7591 "software_id" — a unique identifier for the
-	// client software. Captured from the incoming registration request for
-	// observability (audit logs surfaced on the successful-registration
-	// Info log); not persisted as part of the registered client, so it
-	// cannot be correlated with subsequent token requests. Bounded by
-	// MaxSoftwareIDLength and restricted to printable ASCII by
-	// ValidateDCRRequest.
-	SoftwareID string `json:"software_id,omitempty"`
-}
-
-// DCRResponse represents a successful OAuth 2.0 Dynamic Client Registration
-// response per RFC 7591 Section 3.2.1.
-type DCRResponse struct {
-	// ClientID is the unique identifier for the client.
-	ClientID string `json:"client_id"`
-
-	// ClientIDIssuedAt is the time at which the client identifier was issued,
-	// as a Unix timestamp.
-	ClientIDIssuedAt int64 `json:"client_id_issued_at,omitempty"`
-
-	// RedirectURIs is an array of redirection URIs for the client.
-	RedirectURIs []string `json:"redirect_uris"`
-
-	// ClientName is a human-readable name for the client.
-	ClientName string `json:"client_name,omitempty"`
-
-	// TokenEndpointAuthMethod is the authentication method for the token endpoint.
-	TokenEndpointAuthMethod string `json:"token_endpoint_auth_method"`
-
-	// GrantTypes is an array of OAuth 2.0 grant types the client may use.
-	GrantTypes []string `json:"grant_types"`
-
-	// ResponseTypes is an array of OAuth 2.0 response types the client may use.
-	ResponseTypes []string `json:"response_types"`
-
-	// Scope is a space-separated list of OAuth 2.0 scope values the client may use.
-	// Per RFC 7591 Section 3.2, this tells the client what scopes it was granted.
-	Scope string `json:"scope,omitempty"`
-}
-
 // DCRError represents an OAuth 2.0 Dynamic Client Registration error
 // response per RFC 7591 Section 3.2.2.
 type DCRError struct {
@@ -175,7 +107,13 @@ var allowedResponseTypes = map[string]bool{
 // ValidateDCRRequest validates a DCR request according to RFC 7591
 // and the server's security policy (loopback-only public clients).
 // Returns the validated request with defaults applied, or an error.
-func ValidateDCRRequest(req *DCRRequest) (*DCRRequest, *DCRError) {
+//
+// The validated request does NOT carry the requested scopes — scope
+// validation against the server's supported set is a separate step,
+// handled by ValidateScopes using the caller's policy inputs.
+func ValidateDCRRequest(
+	req *oauthproto.DynamicClientRegistrationRequest,
+) (*oauthproto.DynamicClientRegistrationRequest, *DCRError) {
 	// 1. Validate redirect_uris - required
 	if len(req.RedirectURIs) == 0 {
 		return nil, &DCRError{
@@ -241,7 +179,7 @@ func ValidateDCRRequest(req *DCRRequest) (*DCRRequest, *DCRError) {
 	}
 
 	// Return validated request with defaults applied
-	return &DCRRequest{
+	return &oauthproto.DynamicClientRegistrationRequest{
 		RedirectURIs:            req.RedirectURIs,
 		ClientName:              req.ClientName,
 		TokenEndpointAuthMethod: authMethod,
@@ -342,20 +280,25 @@ func ValidateRedirectURI(uri string) *DCRError {
 // ValidateScopes validates that all requested scopes are in the allowed set.
 // Returns the validated scopes (or defaults if empty) and any error.
 // This enforces server-side scope restrictions per RFC 7591 Section 2.
-func ValidateScopes(requestedScope string, allowedScopes []string) ([]string, *DCRError) {
+//
+// Callers pass already-parsed scope slices: oauthproto.ScopeList handles the
+// RFC 7591 dual-format (string or array) decode on the wire, so by the time
+// scopes reach this function they are a plain []string. Duplicates in the
+// input are preserved by ScopeList — this function deduplicates per RFC 6749
+// Section 3.3 semantics (scope is a set of case-sensitive strings).
+func ValidateScopes(requestedScopes, allowedScopes []string) ([]string, *DCRError) {
 	// Build allowed scope set for O(1) lookup
 	allowed := make(map[string]bool, len(allowedScopes))
 	for _, s := range allowedScopes {
 		allowed[s] = true
 	}
 
-	// Parse space-separated scope string per RFC 6749 Section 3.3.
-	// Deduplicate to ensure each scope appears at most once (RFC 6749
-	// defines scope as a set of case-sensitive strings).
+	// Deduplicate while validating each requested scope against the
+	// allowed set.
 	var scopes []string
-	if requestedScope != "" {
+	if len(requestedScopes) > 0 {
 		seen := make(map[string]bool)
-		for _, s := range strings.Fields(requestedScope) {
+		for _, s := range requestedScopes {
 			if !allowed[s] {
 				return nil, &DCRError{
 					Error:            DCRErrorInvalidClientMetadata,
@@ -383,9 +326,4 @@ func ValidateScopes(requestedScope string, allowedScopes []string) ([]string, *D
 	}
 
 	return scopes, nil
-}
-
-// FormatScopes formats a scope slice as a space-separated string.
-func FormatScopes(scopes []string) string {
-	return strings.Join(scopes, " ")
 }

--- a/pkg/authserver/server/registration/dcr.go
+++ b/pkg/authserver/server/registration/dcr.go
@@ -277,15 +277,15 @@ func ValidateRedirectURI(uri string) *DCRError {
 	return nil
 }
 
-// ValidateScopes validates that all requested scopes are in the allowed set.
-// Returns the validated scopes (or defaults if empty) and any error.
-// This enforces server-side scope restrictions per RFC 7591 Section 2.
+// ValidateScopes validates a slice of already-parsed scope tokens against
+// the server's allowed set per RFC 7591 §2.
 //
-// Callers pass already-parsed scope slices: oauthproto.ScopeList handles the
-// RFC 7591 dual-format (string or array) decode on the wire, so by the time
-// scopes reach this function they are a plain []string. Duplicates in the
-// input are preserved by ScopeList — this function deduplicates per RFC 6749
-// Section 3.3 semantics (scope is a set of case-sensitive strings).
+//   - Empty/nil input falls back to DefaultScopes (which must itself be a
+//     subset of allowedScopes; otherwise the call returns an error).
+//   - Each requested scope must appear in allowedScopes; otherwise returns
+//     invalid_client_metadata.
+//   - Duplicates in the input are tolerated and deduplicated per RFC 6749
+//     §3.3 (scope is a set of case-sensitive strings).
 func ValidateScopes(requestedScopes, allowedScopes []string) ([]string, *DCRError) {
 	// Build allowed scope set for O(1) lookup
 	allowed := make(map[string]bool, len(allowedScopes))

--- a/pkg/authserver/server/registration/dcr_test.go
+++ b/pkg/authserver/server/registration/dcr_test.go
@@ -142,7 +142,7 @@ func TestValidateDCRRequest(t *testing.T) {
 
 	tests := []struct {
 		name               string
-		request            *DCRRequest
+		request            *oauthproto.DynamicClientRegistrationRequest
 		expectError        bool
 		errorCode          string
 		expectedAuthMethod string
@@ -152,7 +152,7 @@ func TestValidateDCRRequest(t *testing.T) {
 		// Valid requests
 		{
 			name: "valid minimal request with loopback redirect URI",
-			request: &DCRRequest{
+			request: &oauthproto.DynamicClientRegistrationRequest{
 				RedirectURIs: []string{"http://127.0.0.1/callback"},
 			},
 			expectError:        false,
@@ -162,7 +162,7 @@ func TestValidateDCRRequest(t *testing.T) {
 		},
 		{
 			name: "valid request with all fields specified",
-			request: &DCRRequest{
+			request: &oauthproto.DynamicClientRegistrationRequest{
 				RedirectURIs:            []string{"http://localhost:8080/callback", "https://example.com/callback"},
 				ClientName:              "My Test Client",
 				TokenEndpointAuthMethod: "none",
@@ -176,7 +176,7 @@ func TestValidateDCRRequest(t *testing.T) {
 		},
 		{
 			name: "valid request with https redirect URI",
-			request: &DCRRequest{
+			request: &oauthproto.DynamicClientRegistrationRequest{
 				RedirectURIs: []string{"https://example.com/oauth/callback"},
 			},
 			expectError:        false,
@@ -188,7 +188,7 @@ func TestValidateDCRRequest(t *testing.T) {
 		// Empty redirect_uris
 		{
 			name: "empty redirect_uris",
-			request: &DCRRequest{
+			request: &oauthproto.DynamicClientRegistrationRequest{
 				RedirectURIs: []string{},
 			},
 			expectError: true,
@@ -196,7 +196,7 @@ func TestValidateDCRRequest(t *testing.T) {
 		},
 		{
 			name: "nil redirect_uris",
-			request: &DCRRequest{
+			request: &oauthproto.DynamicClientRegistrationRequest{
 				RedirectURIs: nil,
 			},
 			expectError: true,
@@ -206,7 +206,7 @@ func TestValidateDCRRequest(t *testing.T) {
 		// Too many redirect URIs
 		{
 			name: "too many redirect URIs",
-			request: &DCRRequest{
+			request: &oauthproto.DynamicClientRegistrationRequest{
 				RedirectURIs: []string{
 					"http://127.0.0.1:1/callback",
 					"http://127.0.0.1:2/callback",
@@ -228,7 +228,7 @@ func TestValidateDCRRequest(t *testing.T) {
 		// Invalid redirect URI in list
 		{
 			name: "invalid redirect URI in list",
-			request: &DCRRequest{
+			request: &oauthproto.DynamicClientRegistrationRequest{
 				RedirectURIs: []string{"http://127.0.0.1/callback", "http://example.com/callback"},
 			},
 			expectError: true,
@@ -236,7 +236,7 @@ func TestValidateDCRRequest(t *testing.T) {
 		},
 		{
 			name: "malformed redirect URI in list",
-			request: &DCRRequest{
+			request: &oauthproto.DynamicClientRegistrationRequest{
 				RedirectURIs: []string{"://invalid"},
 			},
 			expectError: true,
@@ -246,7 +246,7 @@ func TestValidateDCRRequest(t *testing.T) {
 		// token_endpoint_auth_method validation
 		{
 			name: "token_endpoint_auth_method = none",
-			request: &DCRRequest{
+			request: &oauthproto.DynamicClientRegistrationRequest{
 				RedirectURIs:            []string{"http://127.0.0.1/callback"},
 				TokenEndpointAuthMethod: "none",
 			},
@@ -255,7 +255,7 @@ func TestValidateDCRRequest(t *testing.T) {
 		},
 		{
 			name: "token_endpoint_auth_method empty defaults to none",
-			request: &DCRRequest{
+			request: &oauthproto.DynamicClientRegistrationRequest{
 				RedirectURIs:            []string{"http://127.0.0.1/callback"},
 				TokenEndpointAuthMethod: "",
 			},
@@ -264,7 +264,7 @@ func TestValidateDCRRequest(t *testing.T) {
 		},
 		{
 			name: "token_endpoint_auth_method = client_secret_basic fails",
-			request: &DCRRequest{
+			request: &oauthproto.DynamicClientRegistrationRequest{
 				RedirectURIs:            []string{"http://127.0.0.1/callback"},
 				TokenEndpointAuthMethod: "client_secret_basic",
 			},
@@ -273,7 +273,7 @@ func TestValidateDCRRequest(t *testing.T) {
 		},
 		{
 			name: "token_endpoint_auth_method = client_secret_post fails",
-			request: &DCRRequest{
+			request: &oauthproto.DynamicClientRegistrationRequest{
 				RedirectURIs:            []string{"http://127.0.0.1/callback"},
 				TokenEndpointAuthMethod: "client_secret_post",
 			},
@@ -284,7 +284,7 @@ func TestValidateDCRRequest(t *testing.T) {
 		// grant_types validation
 		{
 			name: "grant_types defaults when empty",
-			request: &DCRRequest{
+			request: &oauthproto.DynamicClientRegistrationRequest{
 				RedirectURIs: []string{"http://127.0.0.1/callback"},
 				GrantTypes:   []string{},
 			},
@@ -293,7 +293,7 @@ func TestValidateDCRRequest(t *testing.T) {
 		},
 		{
 			name: "grant_types defaults when nil",
-			request: &DCRRequest{
+			request: &oauthproto.DynamicClientRegistrationRequest{
 				RedirectURIs: []string{"http://127.0.0.1/callback"},
 				GrantTypes:   nil,
 			},
@@ -302,7 +302,7 @@ func TestValidateDCRRequest(t *testing.T) {
 		},
 		{
 			name: "grant_types without authorization_code fails",
-			request: &DCRRequest{
+			request: &oauthproto.DynamicClientRegistrationRequest{
 				RedirectURIs: []string{"http://127.0.0.1/callback"},
 				GrantTypes:   []string{"refresh_token"},
 			},
@@ -311,7 +311,7 @@ func TestValidateDCRRequest(t *testing.T) {
 		},
 		{
 			name: "grant_types with only client_credentials fails",
-			request: &DCRRequest{
+			request: &oauthproto.DynamicClientRegistrationRequest{
 				RedirectURIs: []string{"http://127.0.0.1/callback"},
 				GrantTypes:   []string{"client_credentials"},
 			},
@@ -320,7 +320,7 @@ func TestValidateDCRRequest(t *testing.T) {
 		},
 		{
 			name: "grant_types with authorization_code passes",
-			request: &DCRRequest{
+			request: &oauthproto.DynamicClientRegistrationRequest{
 				RedirectURIs: []string{"http://127.0.0.1/callback"},
 				GrantTypes:   []string{"authorization_code"},
 			},
@@ -329,7 +329,7 @@ func TestValidateDCRRequest(t *testing.T) {
 		},
 		{
 			name: "grant_types with unsupported type rejected",
-			request: &DCRRequest{
+			request: &oauthproto.DynamicClientRegistrationRequest{
 				RedirectURIs: []string{"http://127.0.0.1/callback"},
 				GrantTypes:   []string{"authorization_code", "client_credentials"},
 			},
@@ -340,7 +340,7 @@ func TestValidateDCRRequest(t *testing.T) {
 		// response_types validation
 		{
 			name: "response_types defaults when empty",
-			request: &DCRRequest{
+			request: &oauthproto.DynamicClientRegistrationRequest{
 				RedirectURIs:  []string{"http://127.0.0.1/callback"},
 				ResponseTypes: []string{},
 			},
@@ -349,7 +349,7 @@ func TestValidateDCRRequest(t *testing.T) {
 		},
 		{
 			name: "response_types defaults when nil",
-			request: &DCRRequest{
+			request: &oauthproto.DynamicClientRegistrationRequest{
 				RedirectURIs:  []string{"http://127.0.0.1/callback"},
 				ResponseTypes: nil,
 			},
@@ -358,7 +358,7 @@ func TestValidateDCRRequest(t *testing.T) {
 		},
 		{
 			name: "response_types without code fails",
-			request: &DCRRequest{
+			request: &oauthproto.DynamicClientRegistrationRequest{
 				RedirectURIs:  []string{"http://127.0.0.1/callback"},
 				ResponseTypes: []string{"token"},
 			},
@@ -367,7 +367,7 @@ func TestValidateDCRRequest(t *testing.T) {
 		},
 		{
 			name: "response_types with only id_token fails",
-			request: &DCRRequest{
+			request: &oauthproto.DynamicClientRegistrationRequest{
 				RedirectURIs:  []string{"http://127.0.0.1/callback"},
 				ResponseTypes: []string{"id_token"},
 			},
@@ -376,7 +376,7 @@ func TestValidateDCRRequest(t *testing.T) {
 		},
 		{
 			name: "response_types with code passes",
-			request: &DCRRequest{
+			request: &oauthproto.DynamicClientRegistrationRequest{
 				RedirectURIs:  []string{"http://127.0.0.1/callback"},
 				ResponseTypes: []string{"code"},
 			},
@@ -385,7 +385,7 @@ func TestValidateDCRRequest(t *testing.T) {
 		},
 		{
 			name: "response_types with unsupported type rejected",
-			request: &DCRRequest{
+			request: &oauthproto.DynamicClientRegistrationRequest{
 				RedirectURIs:  []string{"http://127.0.0.1/callback"},
 				ResponseTypes: []string{"code", "token"},
 			},
@@ -396,7 +396,7 @@ func TestValidateDCRRequest(t *testing.T) {
 		// ClientName validation
 		{
 			name: "client_name is preserved",
-			request: &DCRRequest{
+			request: &oauthproto.DynamicClientRegistrationRequest{
 				RedirectURIs: []string{"http://127.0.0.1/callback"},
 				ClientName:   "My Application",
 			},
@@ -404,7 +404,7 @@ func TestValidateDCRRequest(t *testing.T) {
 		},
 		{
 			name: "client_name exceeding max length is rejected",
-			request: &DCRRequest{
+			request: &oauthproto.DynamicClientRegistrationRequest{
 				RedirectURIs: []string{"http://127.0.0.1/callback"},
 				ClientName:   strings.Repeat("a", MaxClientNameLength+1),
 			},
@@ -413,7 +413,7 @@ func TestValidateDCRRequest(t *testing.T) {
 		},
 		{
 			name: "client_name at max length is accepted",
-			request: &DCRRequest{
+			request: &oauthproto.DynamicClientRegistrationRequest{
 				RedirectURIs: []string{"http://127.0.0.1/callback"},
 				ClientName:   strings.Repeat("a", MaxClientNameLength),
 			},
@@ -423,7 +423,7 @@ func TestValidateDCRRequest(t *testing.T) {
 		// software_id length cap and charset enforcement
 		{
 			name: "software_id at max length is accepted",
-			request: &DCRRequest{
+			request: &oauthproto.DynamicClientRegistrationRequest{
 				RedirectURIs: []string{"http://127.0.0.1/callback"},
 				SoftwareID:   strings.Repeat("a", MaxSoftwareIDLength),
 			},
@@ -431,7 +431,7 @@ func TestValidateDCRRequest(t *testing.T) {
 		},
 		{
 			name: "software_id exceeding max length is rejected",
-			request: &DCRRequest{
+			request: &oauthproto.DynamicClientRegistrationRequest{
 				RedirectURIs: []string{"http://127.0.0.1/callback"},
 				SoftwareID:   strings.Repeat("a", MaxSoftwareIDLength+1),
 			},
@@ -440,7 +440,7 @@ func TestValidateDCRRequest(t *testing.T) {
 		},
 		{
 			name: "software_id with control character is rejected",
-			request: &DCRRequest{
+			request: &oauthproto.DynamicClientRegistrationRequest{
 				RedirectURIs: []string{"http://127.0.0.1/callback"},
 				SoftwareID:   "bad\x00id",
 			},
@@ -449,7 +449,7 @@ func TestValidateDCRRequest(t *testing.T) {
 		},
 		{
 			name: "software_id with non-ASCII character is rejected",
-			request: &DCRRequest{
+			request: &oauthproto.DynamicClientRegistrationRequest{
 				RedirectURIs: []string{"http://127.0.0.1/callback"},
 				SoftwareID:   "softwäre",
 			},
@@ -458,7 +458,7 @@ func TestValidateDCRRequest(t *testing.T) {
 		},
 		{
 			name: "empty software_id is accepted (field is optional)",
-			request: &DCRRequest{
+			request: &oauthproto.DynamicClientRegistrationRequest{
 				RedirectURIs: []string{"http://127.0.0.1/callback"},
 				SoftwareID:   "",
 			},
@@ -466,7 +466,7 @@ func TestValidateDCRRequest(t *testing.T) {
 		},
 		{
 			name: "printable-ASCII software_id is accepted",
-			request: &DCRRequest{
+			request: &oauthproto.DynamicClientRegistrationRequest{
 				RedirectURIs: []string{"http://127.0.0.1/callback"},
 				SoftwareID:   "example-app-v1.2.3",
 			},
@@ -518,64 +518,64 @@ func TestValidateScopes(t *testing.T) {
 	allowedScopes := []string{"openid", "profile", "email", "offline_access"}
 
 	tests := []struct {
-		name           string
-		requestedScope string
-		allowedScopes  []string
-		expectError    bool
-		errorCode      string
-		expectedScopes []string
+		name            string
+		requestedScopes []string
+		allowedScopes   []string
+		expectError     bool
+		errorCode       string
+		expectedScopes  []string
 	}{
 		{
-			name:           "valid subset of allowed scopes",
-			requestedScope: "openid profile",
-			allowedScopes:  allowedScopes,
-			expectedScopes: []string{"openid", "profile"},
+			name:            "valid subset of allowed scopes",
+			requestedScopes: []string{"openid", "profile"},
+			allowedScopes:   allowedScopes,
+			expectedScopes:  []string{"openid", "profile"},
 		},
 		{
-			name:           "full set of allowed scopes accepted",
-			requestedScope: "openid profile email offline_access",
-			allowedScopes:  allowedScopes,
-			expectedScopes: []string{"openid", "profile", "email", "offline_access"},
+			name:            "full set of allowed scopes accepted",
+			requestedScopes: []string{"openid", "profile", "email", "offline_access"},
+			allowedScopes:   allowedScopes,
+			expectedScopes:  []string{"openid", "profile", "email", "offline_access"},
 		},
 		{
-			name:           "unknown scope rejected",
-			requestedScope: "openid sneaky_admin",
-			allowedScopes:  allowedScopes,
-			expectError:    true,
-			errorCode:      DCRErrorInvalidClientMetadata,
+			name:            "unknown scope rejected",
+			requestedScopes: []string{"openid", "sneaky_admin"},
+			allowedScopes:   allowedScopes,
+			expectError:     true,
+			errorCode:       DCRErrorInvalidClientMetadata,
 		},
 		{
-			name:           "prefix of valid scope rejected",
-			requestedScope: "openid.evil",
-			allowedScopes:  allowedScopes,
-			expectError:    true,
-			errorCode:      DCRErrorInvalidClientMetadata,
+			name:            "prefix of valid scope rejected",
+			requestedScopes: []string{"openid.evil"},
+			allowedScopes:   allowedScopes,
+			expectError:     true,
+			errorCode:       DCRErrorInvalidClientMetadata,
 		},
 		{
-			name:           "substring of valid scope rejected",
-			requestedScope: "open",
-			allowedScopes:  allowedScopes,
-			expectError:    true,
-			errorCode:      DCRErrorInvalidClientMetadata,
+			name:            "substring of valid scope rejected",
+			requestedScopes: []string{"open"},
+			allowedScopes:   allowedScopes,
+			expectError:     true,
+			errorCode:       DCRErrorInvalidClientMetadata,
 		},
 		{
-			name:           "empty input returns default scopes",
-			requestedScope: "",
-			allowedScopes:  allowedScopes,
-			expectedScopes: DefaultScopes,
+			name:            "empty input returns default scopes",
+			requestedScopes: nil,
+			allowedScopes:   allowedScopes,
+			expectedScopes:  DefaultScopes,
 		},
 		{
-			name:           "duplicate scopes are deduplicated",
-			requestedScope: "openid openid profile",
-			allowedScopes:  allowedScopes,
-			expectedScopes: []string{"openid", "profile"},
+			name:            "duplicate scopes are deduplicated",
+			requestedScopes: []string{"openid", "openid", "profile"},
+			allowedScopes:   allowedScopes,
+			expectedScopes:  []string{"openid", "profile"},
 		},
 		{
-			name:           "empty input rejected when defaults not in allowed set",
-			requestedScope: "",
-			allowedScopes:  []string{"custom_scope"},
-			expectError:    true,
-			errorCode:      DCRErrorInvalidClientMetadata,
+			name:            "empty input rejected when defaults not in allowed set",
+			requestedScopes: nil,
+			allowedScopes:   []string{"custom_scope"},
+			expectError:     true,
+			errorCode:       DCRErrorInvalidClientMetadata,
 		},
 	}
 
@@ -583,7 +583,7 @@ func TestValidateScopes(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			scopes, dcrErr := ValidateScopes(tt.requestedScope, tt.allowedScopes)
+			scopes, dcrErr := ValidateScopes(tt.requestedScopes, tt.allowedScopes)
 
 			if tt.expectError {
 				require.NotNil(t, dcrErr, "expected error")

--- a/pkg/oauthproto/dcr.go
+++ b/pkg/oauthproto/dcr.go
@@ -29,6 +29,11 @@ type DynamicClientRegistrationRequest struct {
 	GrantTypes              []string  `json:"grant_types,omitempty"`
 	ResponseTypes           []string  `json:"response_types,omitempty"`
 	Scopes                  ScopeList `json:"scope,omitempty"`
+
+	// SoftwareID is the RFC 7591 Section 2 "software_id": a unique identifier
+	// for the client software. Optional; servers may capture it for audit
+	// or telemetry but it is not required to register.
+	SoftwareID string `json:"software_id,omitempty"`
 }
 
 // ScopeList represents the "scope" field in both dynamic client registration requests and responses.

--- a/pkg/oauthproto/dcr.go
+++ b/pkg/oauthproto/dcr.go
@@ -127,12 +127,18 @@ type DynamicClientRegistrationResponse struct {
 	RegistrationAccessToken string `json:"registration_access_token,omitempty"`
 	RegistrationClientURI   string `json:"registration_client_uri,omitempty"`
 
-	// Echo back the essential request fields
+	// Echo back the essential request fields. RFC 7591 §3.2.1 requires the
+	// AS to return redirect_uris, token_endpoint_auth_method, grant_types,
+	// and response_types in every successful registration response, so
+	// those four are emitted unconditionally (no omitempty) — a partial
+	// response built by a future code path that skips ValidateDCRRequest
+	// would still produce a spec-conformant key set, even if the values
+	// are empty.
 	ClientName              string    `json:"client_name,omitempty"`
-	RedirectURIs            []string  `json:"redirect_uris,omitempty"`
-	TokenEndpointAuthMethod string    `json:"token_endpoint_auth_method,omitempty"`
-	GrantTypes              []string  `json:"grant_types,omitempty"`
-	ResponseTypes           []string  `json:"response_types,omitempty"`
+	RedirectURIs            []string  `json:"redirect_uris"`
+	TokenEndpointAuthMethod string    `json:"token_endpoint_auth_method"`
+	GrantTypes              []string  `json:"grant_types"`
+	ResponseTypes           []string  `json:"response_types"`
 	Scopes                  ScopeList `json:"scope,omitempty"`
 }
 


### PR DESCRIPTION
## Summary

- The authserver carried its own `DCRRequest` / `DCRResponse` types alongside the canonical `pkg/oauthproto` ones, a leftover from #5036 that was explicitly deferred there. Two parallel structs modelling the same RFC 7591 surface drift over time — the exact anti-pattern flagged in `.claude/rules/go-style.md` — and they had already diverged in behavior.
- Concretely, the authserver's `Scope string` only accepted the space-delimited wire form, while `oauthproto.ScopeList` accepts both the string and JSON-array forms permitted by RFC 7591 §2. Well-formed clients sending `"scope": ["a", "b"]` to `/oauth/register` were being rejected by the authserver but accepted by the upstream-facing DCR client in the same binary.
- This PR removes the duplication: `registration.DCRRequest`, `registration.DCRResponse`, and `registration.FormatScopes` are deleted; the handler and validators now operate on `oauthproto.DynamicClientRegistrationRequest` / `Response`; and `oauthproto.DynamicClientRegistrationRequest` gains the `SoftwareID` field that was the only structural gap between the two request types.

Closes #5371

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

Note: this is a behavior-preserving refactor for existing clients (space-delimited scope still works), but it does fix a latent format-mismatch where the array form of `scope` was incorrectly rejected. New test coverage locks the array-form path in.

## Test plan

- [x] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [x] Linting (`task lint-fix`)
- [ ] Manual testing (describe below)

All existing space-delimited scope tests in `pkg/authserver/server/handlers/dcr_test.go` and `pkg/authserver/server/registration/dcr_test.go` continue to pass unchanged, exercising `ScopeList.UnmarshalJSON`'s string-form branch. A new positive-path test, `TestRegisterClientHandler_ScopeAsJSONArray`, submits `"scope": ["openid", "offline_access"]` and asserts a 201 with the granted scopes echoed in the response and propagated to storage.

## Changes

| File | Change |
|------|--------|
| `pkg/oauthproto/dcr.go` | Add `SoftwareID string` field with `software_id,omitempty` JSON tag to `DynamicClientRegistrationRequest` (RFC 7591 §2). |
| `pkg/authserver/server/registration/dcr.go` | Delete `DCRRequest`, `DCRResponse`, and `FormatScopes`. Re-type `ValidateDCRRequest` to take/return `*oauthproto.DynamicClientRegistrationRequest`. Re-type `ValidateScopes` from `(requestedScope string, allowedScopes []string)` to `(requestedScopes, allowedScopes []string)` — `ScopeList` already does the space-delimited / array decode upstream. `DCRError` and the server-side validation policy stay put. |
| `pkg/authserver/server/handlers/dcr.go` | Decode into `oauthproto.DynamicClientRegistrationRequest`, build an `oauthproto.DynamicClientRegistrationResponse`, and assign `Scopes: oauthproto.ScopeList(scopes)` instead of calling the removed `FormatScopes` (the space-delimited wire form is now produced by `ScopeList.MarshalJSON`). |
| `pkg/authserver/server/handlers/dcr_test.go` | Migrate all eight call sites to the `oauthproto` types and add `TestRegisterClientHandler_ScopeAsJSONArray` covering the array-form scope path. |
| `pkg/authserver/server/registration/dcr_test.go` | Migrate validator tests to the `oauthproto` types and the new `[]string` scope signature. |

## Does this introduce a user-facing change?

Yes. `/oauth/register` now accepts the RFC 7591 array form of `scope` (e.g. `"scope": ["openid", "offline_access"]`) in addition to the space-delimited string form it already accepted. No client that was working before needs to change. `software_id` is now formally part of the shared `oauthproto` request type, so it is available to any future consumer of that type, not just the authserver handler.

## Implementation plan

<details>
<summary>Approved implementation plan</summary>

From issue #5371 — "Proposed fix":

1. Add `SoftwareID` to `oauthproto.DynamicClientRegistrationRequest` (RFC 7591 §2 field; only structural gap between the two request types).
2. Delete `registration.DCRRequest` and `registration.DCRResponse`. Replace every reference with the `oauthproto` equivalents.
3. Change `registration.ValidateDCRRequest` to accept `*oauthproto.DynamicClientRegistrationRequest` and return the same type. The validator stays in the authserver package — it encodes server-side policy (loopback-only public clients, `software_id` length cap, `token_endpoint_auth_method == "none"`) that does not belong in the protocol package.
4. Change `registration.ValidateScopes` signature from `(requestedScope string, allowedScopes []string)` to `(requestedScopes []string, allowedScopes []string)`. Caller in `pkg/authserver/server/handlers/dcr.go` passes `dcrReq.Scopes` (a `ScopeList`, which is `[]string`) directly.
5. Delete `registration.FormatScopes`. The handler currently calls it to produce the space-delimited response scope. That formatting now lives in `ScopeList.MarshalJSON`, so the handler just assigns `Scopes: oauthproto.ScopeList(scopes)`.
6. Keep `registration.DCRError` where it is. It is a server-side response shape, not a request/response duplicated in `pkg/oauthproto`.
7. Update tests in `pkg/authserver/server/handlers/dcr_test.go` to construct `oauthproto.DynamicClientRegistrationRequest` literals and decode into `oauthproto.DynamicClientRegistrationResponse`. Add at least one positive-path test that submits scope as a JSON array (`"scope": ["a", "b"]`) to lock in the array-form wire compatibility that this change unlocks.

</details>

## Special notes for reviewers

- `registration.DCRError` is intentionally kept in the authserver package. It only models the server-emitted error response and has no upstream-client counterpart in `pkg/oauthproto` today; promoting it is called out as out-of-scope in the issue.
- The validator's returned `DynamicClientRegistrationRequest` deliberately does not carry the requested scopes — scope validation is the separate `ValidateScopes` step, which takes the caller's policy inputs (`ScopesSupported`, `BaselineClientScopes`). The new doc comment on `ValidateDCRRequest` makes this explicit.
- `ScopeList` preserves duplicates from the wire; `ValidateScopes` deduplicates per RFC 6749 §3.3 set semantics. This matches the previous behavior of the space-delimited path.
- No changes to the resolver / upstream DCR flow in `pkg/auth/dcr/` and no changes outside `pkg/authserver/server/{handlers,registration}` and `pkg/oauthproto/dcr.go`.
