### PR TITLE
Refresh docs/arch/ to match current codebase

### DIFF
--- a/docs/arch/00-overview.md
+++ b/docs/arch/00-overview.md
@@ -87,7 +87,7 @@ thv run go://package-name
 
 Manages MCP servers in Kubernetes clusters using custom resources.
 
-The operator watches for `MCPServer`, `MCPRegistry`, `MCPToolConfig`, `MCPExternalAuthConfig`, `MCPGroup`, and `VirtualMCPServer` CRDs, reconciling them into Kubernetes resources (Deployments, StatefulSets, Services).
+The operator watches a layered set of CRDs (Core: `MCPServer`, `MCPRemoteProxy`, `MCPServerEntry`; Organization: `MCPGroup`; Aggregation: `VirtualMCPServer`, `VirtualMCPCompositeToolDefinition`; Discovery: `MCPRegistry`; Configuration: `MCPToolConfig`, `MCPExternalAuthConfig`, `MCPOIDCConfig`, `MCPTelemetryConfig`, `MCPWebhookConfig`; Auxiliary: `EmbeddingServer`) and reconciles them into Kubernetes resources (proxy-runner Deployments and Services; ConfigMaps; the MCP server itself is created as a StatefulSet by the proxy-runner, while `EmbeddingServer`'s StatefulSet is created by the operator directly). See [Operator Architecture](09-operator-architecture.md) for the full taxonomy.
 
 **For details**, see:
 - [`cmd/thv-operator/README.md`](../../cmd/thv-operator/README.md) - Operator overview and usage
@@ -173,7 +173,7 @@ Via [ToolHive Studio](https://github.com/stacklok/toolhive-studio):
 
 Everything is driven by `thv-operator`:
 - Listens for Kubernetes custom resources
-- Creates Kubernetes-native resources (Deployments, StatefulSets, Services)
+- Creates Kubernetes-native resources (Deployments, Services, ConfigMaps for the proxy-runner; StatefulSets are created by the proxy-runner for MCP server pods)
 - Uses `thv-proxyrunner` binary (not `thv`)
 - Provides cluster-scale management
 

--- a/docs/arch/01-deployment-modes.md
+++ b/docs/arch/01-deployment-modes.md
@@ -15,7 +15,7 @@ graph LR
         Operator[Operator Mode<br/>thv-operator]
     end
 
-    CLI --> Docker[Docker/Podman<br/>Colima<br/>Rancher Desktop]
+    CLI --> Docker[Docker/Podman<br/>Colima<br/>Rancher Desktop<br/>OrbStack]
     UI --> Docker
     Operator --> K8s[Kubernetes]
 
@@ -31,7 +31,7 @@ graph LR
 | Feature | Local CLI | Local UI | Kubernetes |
 |---------|-----------|----------|------------|
 | **Binary** | `thv` | `thv` (API server) | `thv-operator` + `thv-proxyrunner` |
-| **Container Runtime** | Docker/Podman/Colima/Rancher | Docker/Podman/Colima/Rancher | Kubernetes |
+| **Container Runtime** | Docker/Podman/Colima/Rancher/OrbStack | Docker/Podman/Colima/Rancher/OrbStack | Kubernetes |
 | **Process Management** | Detached processes | API-managed | Operator-managed |
 | **State Storage** | Local filesystem | Local filesystem | etcd (K8s API) |
 | **Scaling** | Single machine | Single machine | Cluster-wide |
@@ -45,7 +45,7 @@ graph LR
 graph TB
     User[User] -->|CLI Commands| THV[thv binary]
     THV -->|spawn detached| Proxy[Proxy Process]
-    Proxy -->|Docker API| Runtime[Container Runtime<br/>Docker/Podman/Colima]
+    Proxy -->|Docker API| Runtime[Container Runtime<br/>Docker/Podman/Colima<br/>Rancher Desktop/OrbStack]
     Runtime -->|creates| Container[MCP Server Container]
     Proxy -->|stdin/stdout or HTTP| Container
     Client[MCP Client] -->|HTTP/SSE/Streamable| Proxy
@@ -65,7 +65,7 @@ graph TB
    - Instantiates workloads API (`pkg/workloads/manager.go`)
 
 3. **Workload Manager**:
-   - Detects available container runtime (Podman → Colima → Docker)
+   - Detects available container runtime (Podman → Docker → Colima)
    - Creates container via Runtime API
    - Spawns detached proxy process
 
@@ -76,13 +76,14 @@ graph TB
    - Exposes local HTTP endpoint for MCP clients
 
 5. **State Management**:
-   - RunConfig saved to `~/.toolhive/state/` (or XDG equivalent)
-   - PID file for process management
-   - Status file for workload state tracking
+   - RunConfig saved under `$XDG_STATE_HOME/toolhive/runconfigs/`
+   - PID file in `$XDG_DATA_HOME/toolhive/pids/` for process management
+   - Status file in `$XDG_DATA_HOME/toolhive/statuses/` for workload state tracking
+   - See the platform path table below for full XDG layout
 
 ### Container Runtime Selection
 
-**Implementation**: `pkg/container/factory.go`
+**Implementation**: `pkg/container/docker/sdk/factory.go` (with per-runtime socket discovery in `pkg/container/docker/sdk/client_unix.go`)
 
 The CLI automatically detects container runtimes in this order:
 
@@ -93,17 +94,17 @@ The CLI automatically detects container runtimes in this order:
    - `~/.local/share/containers/podman/machine/podman.sock` (Podman Machine on macOS)
    - `$TMPDIR/podman/*-api.sock` (Podman Machine API on macOS)
 
-2. **Colima** - Checks for Colima socket at:
-   - `$TOOLHIVE_COLIMA_SOCKET` (if set)
-   - `~/.colima/default/docker.sock`
-
-3. **Docker** (including Docker Desktop, Rancher Desktop, and OrbStack) - Checks for Docker socket at:
+2. **Docker** (including Docker Desktop, Rancher Desktop, and OrbStack) - Checks for Docker socket at:
    - `$TOOLHIVE_DOCKER_SOCKET` (if set)
    - `/var/run/docker.sock`
    - `~/.docker/run/docker.sock` (Docker Desktop on macOS)
    - `~/.docker/desktop/docker.sock` (Docker Desktop on Linux)
    - `~/.rd/docker.sock` (Rancher Desktop on macOS)
    - `~/.orbstack/run/docker.sock` (OrbStack on macOS)
+
+3. **Colima** - Checks for Colima socket at:
+   - `$TOOLHIVE_COLIMA_SOCKET` (if set)
+   - `~/.colima/default/docker.sock`
 
 ### Detached Process Model
 
@@ -129,9 +130,8 @@ sequenceDiagram
 
 **Key Implementation**:
 - `pkg/workloads/manager.go` - `RunWorkloadDetached` method
-- Uses `exec.Command` with `SysProcAttr` to detach
-- Sets `TOOLHIVE_DETACHED=true` environment variable
-- Redirects stdout/stderr to log file: `~/.toolhive/logs/<workload>.log`
+- Uses `exec.Command` with `SysProcAttr` (`Setsid` on Unix, equivalent flag on Windows) to detach from the parent session
+- Redirects stdout/stderr to log file under `$XDG_DATA_HOME/toolhive/logs/<workload>.log`
 
 ### File Locations
 
@@ -186,7 +186,7 @@ graph TB
 
 5. **Runtime Selection**:
    - Picks runtime driver based on environment
-   - Docker, Podman, or Rancher Desktop
+   - Docker, Podman, Colima, OrbStack, or Rancher Desktop (same set as CLI mode)
    - Uses driver API to spawn containers
 
 ### API Endpoints
@@ -231,7 +231,7 @@ Available flags:
 |------|-------------|-------------|
 | `--sentry-dsn` | `SENTRY_DSN` | Sentry Data Source Name (required to enable) |
 | `--sentry-environment` | `SENTRY_ENVIRONMENT` | Environment name (e.g. `production`, `development`) |
-| `--sentry-traces-sample-rate` | `SENTRY_TRACES_SAMPLE_RATE` | Trace sampling rate, 0.0–1.0 (default: `1.0`) |
+| `--sentry-traces-sample-rate` | — | Trace sampling rate, 0.0–1.0 (default: `1.0`) |
 
 When no DSN is configured, all Sentry operations are no-ops with zero overhead.
 
@@ -281,7 +281,7 @@ graph TB
 
 3. **Operator creates Deployment**:
    - Runs `thv-proxyrunner` container
-   - Mounts RunConfig as ConfigMap or secret
+   - Mounts RunConfig as ConfigMap
    - Applies middleware configuration
 
 4. **Proxy runner creates StatefulSet**:

--- a/docs/arch/02-core-concepts.md
+++ b/docs/arch/02-core-concepts.md
@@ -38,6 +38,8 @@ A **workload** is the fundamental deployment unit in ToolHive. It represents eve
 - `error` - Workload encountered an error
 - `unhealthy` - Workload is running but unhealthy
 - `unauthenticated` - Remote workload cannot authenticate (expired tokens)
+- `unknown` - Workload status cannot be determined
+- `policy_stopped` - Workload was stopped by policy enforcement
 
 **Implementation:**
 - Interface: `pkg/workloads/manager.go`
@@ -50,7 +52,7 @@ A **workload** is the fundamental deployment unit in ToolHive. It represents eve
 
 A **transport** defines how MCP clients communicate with MCP servers. It encapsulates the protocol and proxy implementation.
 
-**Three types:**
+**Transport types:**
 
 1. **stdio**: Standard input/output communication
    - Container speaks stdin/stdout
@@ -66,6 +68,10 @@ A **transport** defines how MCP clients communicate with MCP servers. It encapsu
    - Container speaks HTTP with `/mcp` endpoint
    - Transparent HTTP proxy (same as SSE)
    - Session management via headers
+
+4. **inspector**: Debug-only transport
+   - Special transport used for the MCP Inspector tooling
+   - Not intended for production workloads
 
 **Implementation:**
 - Interface: `pkg/transport/types/transport.go`
@@ -112,18 +118,24 @@ A **proxy** is the component that sits between MCP clients and MCP servers, forw
 
 - **Authentication** (`auth`) - JWT token validation
 - **Token Exchange** (`tokenexchange`) - OAuth token exchange
+- **Upstream Swap** (`upstreamswap`) - Swap ToolHive JWTs for upstream IdP tokens (embedded auth server)
+- **AWS STS** (`awssts`) - Exchange tokens for AWS STS credentials
+- **OBO** (`obo`) - On-Behalf-Of token flow
 - **MCP Parser** (`mcp-parser`) - JSON-RPC parsing
 - **Tool Filter** (`tool-filter`) - Filter and override tools in `tools/list` responses
 - **Tool Call Filter** (`tool-call-filter`) - Validate and map `tools/call` requests
+- **Rate Limit** (`ratelimit`) - Per-client request rate limiting
 - **Usage Metrics** (`usagemetrics`) - Anonymous usage metrics for ToolHive development (opt-out: `thv config usage-metrics disable`)
 - **Telemetry** (`telemetry`) - OpenTelemetry instrumentation
 - **Authorization** (`authorization`) - Cedar policy evaluation
 - **Audit** (`audit`) - Request logging
+- **Recovery** (`recovery`) - Panic recovery for the proxy chain
+- **Header Forward** (`header-forward`) - Forward selected request headers to upstream
+- **Validating Webhook** (`validating-webhook`) - Call external validating webhooks
+- **Mutating Webhook** (`mutating-webhook`) - Call external mutating webhooks
 
 **Execution order (request flow):**
-Middleware applied in reverse configuration order. Requests flow through: Audit* → Authorization* → Telemetry* → Usage Metrics* → Parser → Token Exchange* → Auth → Tool Call Filter* → Tool Filter* → MCP Server
-
-(*optional middleware, only present if configured)
+Middleware is applied in reverse configuration order, and the chain composed for a given workload depends on which features are enabled. See [`docs/middleware.md`](../middleware.md) for the complete chain, ordering rules, and per-middleware semantics.
 
 **Implementation:**
 - Interface: `pkg/transport/types/transport.go`
@@ -187,9 +199,7 @@ A **permission profile** defines security boundaries for MCP servers:
 - `network` - Full network access
 
 **Implementation:**
-- Definition: `pkg/permissions/profile.go`
-- Network: `pkg/permissions/profile.go`
-- Mount declarations: `pkg/permissions/profile.go`
+- Definition, network permissions, and mount declarations: `github.com/stacklok/toolhive-core/permissions` (imported as `permissions` in `pkg/runner/`)
 
 **Related concepts:** RunConfig, Workload, Security
 
@@ -323,7 +333,7 @@ A **registry** is a catalog of MCP server definitions with metadata, configurati
 - `groups` - Predefined groups of servers
 
 **Implementation:**
-- Registry types: `pkg/registry/types.go`
+- Registry types: `github.com/stacklok/toolhive-core/registry/types`
 - Provider abstraction: `pkg/registry/provider.go`, `pkg/registry/factory.go`
 - Local provider: `pkg/registry/provider_local.go`
 - Remote provider: `pkg/registry/provider_remote.go`
@@ -389,11 +399,15 @@ A **runtime** is an abstraction over container orchestration systems. It provide
 - `IsWorkloadRunning` - Check if running
 
 **Runtime detection:**
-Order: Podman → Colima → Docker → Kubernetes (via env)
+Runtimes are registered with a numeric `Priority` (lower wins) in the runtime registry (`pkg/container/runtime/registry.go`). Today the registered runtimes are:
+
+- **Docker runtime** (`Priority: 100`, registered in `pkg/container/docker/register.go`) — covers Docker, Podman, Colima, Rancher Desktop, and OrbStack via per-runtime socket discovery (Podman → Docker → Colima).
+- **Kubernetes runtime** (`Priority: 200`, registered in `pkg/container/kubernetes/register.go`) — activated when running in-cluster (via `KUBERNETES_SERVICE_HOST`) or when `TOOLHIVE_RUNTIME=kubernetes` is set.
 
 **Implementation:**
 - Interface: `pkg/container/runtime/types.go`
-- Factory: `pkg/container/factory.go`
+- Registry: `pkg/container/runtime/registry.go`
+- Docker SDK factory and socket discovery: `pkg/container/docker/sdk/factory.go`, `pkg/container/docker/sdk/client_unix.go`
 - Detection: `pkg/container/runtime/types.go`
 
 **Related concepts:** Deployer, Workload, Container
@@ -449,7 +463,7 @@ A **skill** is an Agent Skill -- a markdown-based instruction set (SKILL.md) tha
 5. **Uninstall** - Remove files and metadata
 
 **Implementation:**
-- Service: `pkg/skills/skillsvc/skillsvc.go`
+- Service interface: `pkg/skills/service.go`; implementation in `pkg/skills/skillsvc/` (entry point `pkg/skills/skillsvc/service.go`)
 - Types: `pkg/skills/types.go`
 - Storage: `pkg/storage/sqlite/skill_store.go`
 - CLI: `cmd/thv/app/skill*.go`
@@ -480,7 +494,7 @@ A **skill** is an Agent Skill -- a markdown-based instruction set (SKILL.md) tha
 2. Start proxy
 3. Configure authentication (if needed)
 4. Apply middleware
-4. Update state
+5. Update state
 
 **Commands:**
 - `thv run <image|url>` - Deploy and start
@@ -717,7 +731,7 @@ See `pkg/audit/mcp_events.go` for complete list of event types.
 - Shutdown if unhealthy
 
 **Implementation:**
-- Monitor: `pkg/container/docker/monitor.go`
+- Monitor: `pkg/container/runtime/monitor.go`
 - Health checker: `pkg/healthcheck/healthcheck.go`
 
 **Related concepts:** Workload, Transport, Proxy
@@ -759,7 +773,7 @@ graph LR
     style Chain fill:#fff9c4
 ```
 
-Requests pass through up to 9 middleware components (Auth, Token Exchange, Tool Filter, Tool Call Filter, Parser, Usage Metrics, Telemetry, Authorization, Audit). See `docs/middleware.md` for complete middleware architecture and execution order.
+Requests pass through a configurable chain of middleware components. See [`docs/middleware.md`](../middleware.md) for the complete chain and execution order.
 
 ### Data Hierarchy
 

--- a/docs/arch/03-transport-architecture.md
+++ b/docs/arch/03-transport-architecture.md
@@ -226,9 +226,9 @@ graph LR
 ```
 
 **Implementation:**
-- `pkg/transport/types/transport.go` - MiddlewareFunction type
+- `pkg/transport/types/transport.go` - `MiddlewareFunction` and `NamedMiddleware` types
 - Middleware applied in reverse order (last registered = outermost)
-- Each transport type accepts `[]MiddlewareFunction` in constructor
+- Each transport type accepts `[]NamedMiddleware` in constructor (each wraps a `MiddlewareFunction` with its name for logging)
 
 ## Remote MCP Server Proxying
 
@@ -446,24 +446,22 @@ ToolHive uses two port concepts:
 
 ### MCP Environment Variables
 
-**Implementation**: `pkg/transport/http.go`
+**Implementation**: `pkg/environment/environment.go` sets `MCP_TRANSPORT`, `MCP_PORT`, and `FASTMCP_PORT` for the CLI/local path. `pkg/runtime/setup.go` sets all four variables (`MCP_TRANSPORT`, `MCP_PORT`, `FASTMCP_PORT`, and `MCP_HOST`) when deploying workloads through the runtime (used by both local and Kubernetes/proxy-runner paths). The `TargetHost` default of `127.0.0.1` (`transport.LocalhostIPv4`) is established by `WithTargetHost` in `pkg/runner/config_builder.go` (around line 204), not by the env-emitting code — both code paths simply read `RunConfig.TargetHost`.
 
 Environment variables set automatically for container configuration:
 
 - `MCP_TRANSPORT`: Transport type (stdio, sse, streamable-http)
 - `MCP_PORT`: Target port (for SSE/Streamable HTTP)
-- `MCP_HOST`: Target host - always `127.0.0.1` (both local and Kubernetes)
+- `MCP_HOST`: Target host - defaults to `127.0.0.1` (`transport.LocalhostIPv4`), with the default applied by `WithTargetHost` in `pkg/runner/config_builder.go` when `RunConfig.TargetHost` is empty
 - `FASTMCP_PORT`: Alias for `MCP_PORT` (legacy support)
 
 **Architecture distinction:**
-- **Target host** (`MCP_HOST` env var): Where container listens - always `127.0.0.1`
-- **Proxy host**: Where proxy binds - `127.0.0.1` in local mode, `0.0.0.0` in Kubernetes for cluster access
+- **Target host** (`MCP_HOST` env var): Where the container's MCP server listens - defaults to `127.0.0.1`
+- **Proxy host**: Where the proxy binds - `127.0.0.1` in local mode, `0.0.0.0` in Kubernetes for cluster access
 
 **Merge strategy**:
 - User-provided values take precedence
 - ToolHive sets deployment-appropriate defaults
-
-**Reference**: PR #1890 - Runtime Authoring Guide
 
 ## Container Attach (Stdio Transport)
 
@@ -484,7 +482,7 @@ stdin, stdout, err := t.deployer.AttachToWorkload(ctx, t.containerName)
 5. **Framing** - Newline-delimited JSON-RPC messages
 
 **Monitoring:**
-- Container monitor detects exit: `pkg/container/docker/monitor.go`
+- Container monitor detects exit: `pkg/container/runtime/monitor.go`
 - Proxy automatically stopped on container exit
 - Workload status updated
 
@@ -625,7 +623,7 @@ spec:
   trustProxyHeaders: true
 ```
 
-**Implementation**: `pkg/transport/proxy/transparent/transparent_proxy.go` - `rewriteEndpointURL()`, `getSSERewriteConfig()`
+**Implementation**: `pkg/transport/proxy/transparent/sse_response_processor.go` - `rewriteEndpointURL()`, `getSSERewriteConfig()`
 
 ## Transport Factory
 

--- a/docs/arch/04-secrets-management.md
+++ b/docs/arch/04-secrets-management.md
@@ -26,7 +26,9 @@ graph LR
 
 ## Provider Types
 
-**Implementation**: `pkg/secrets/types.go`
+**Implementation**:
+- `pkg/secrets/factory.go` (`ProviderType` enum: `EncryptedType`, `OnePasswordType`, `EnvironmentType`)
+- `pkg/secrets/types.go` defines the `Provider` interface (the contract every provider implements) and the `EnvVarPrefix` constant (`"TOOLHIVE_SECRET_"`) used by the environment provider
 
 ### 1. Encrypted
 
@@ -68,7 +70,7 @@ MCPServer resources reference Kubernetes Secrets via `SecretRef`. Secrets are in
 
 **Implementation**:
 - CRD types: `cmd/thv-operator/api/v1beta1/mcpserver_types.go`
-- Pod builder: `cmd/thv-operator/controllers/mcpserver_podtemplatespec_builder.go`
+- Pod builder: `cmd/thv-operator/pkg/controllerutil/podtemplatespec_builder.go`
 
 ### External Authentication Secrets
 
@@ -79,7 +81,7 @@ OAuth/OIDC client secrets are stored in Kubernetes Secrets and referenced using 
    - **Secret injection**: `cmd/thv-operator/pkg/controllerutil/tokenexchange.go`
 
 2. **OIDC Authentication (MCPOIDCConfig)**: OIDC client secrets for token introspection
-   - **CRD field**: `InlineOIDCSharedConfig.ClientSecretRef` in `cmd/thv-operator/api/v1beta1/mcpoidcconfig_types.go`
+   - **CRD field**: `spec.inline.clientSecretRef` on the `MCPOIDCConfig` resource (Go: `MCPOIDCConfig.Spec.Inline.ClientSecretRef`, where `Inline` is of type `*InlineOIDCSharedConfig`), defined in `cmd/thv-operator/api/v1beta1/mcpoidcconfig_types.go`
    - **Secret injection**: `cmd/thv-operator/pkg/controllerutil/oidc.go`
    - **Runtime loading**: `pkg/auth/token.go` (via `TOOLHIVE_OIDC_CLIENT_SECRET` environment variable)
 
@@ -134,7 +136,7 @@ thv run my-server --secret "api-key,target=API_KEY"
 - Log exposure: ✅
 - Malicious container: ❌ (has env access)
 
-**Implementation**: `pkg/secrets/aes/aes.go`, `pkg/secrets/keyring/`
+**Implementation**: `pkg/secrets/aes/aes.go` (AES-256-GCM), `pkg/secrets/keyring/` (OS keyring storage), `pkg/secrets/factory.go` (SHA-256 key derivation via `sha256.Sum256(secretsPassword)`)
 
 ## Integration Points
 

--- a/docs/arch/05-runconfig-and-permissions.md
+++ b/docs/arch/05-runconfig-and-permissions.md
@@ -70,7 +70,7 @@ The complete `RunConfig` struct is defined in `pkg/runner/config.go`.
 }
 ```
 
-**Implementation**: `pkg/runner/config.go-49`
+**Implementation**: `pkg/runner/config.go`
 
 #### Runtime Configuration
 
@@ -109,12 +109,12 @@ thv run uvx://mcp-server \
 
 **Configuration priority** (highest to lowest):
 1. Per-workload override in `RunConfig.RuntimeConfig`
-2. User config file (`~/.toolhive/config.yaml` `runtimeConfigs` map)
+2. User config file (`$XDG_CONFIG_HOME/toolhive/config.yaml` `runtimeConfigs` map)
 3. Built-in defaults
 
 **Note**: For Go workloads, only the builder image is configurable. The runtime stage always uses `alpine:3.23` for simplicity and security.
 
-**Implementation**: `pkg/runner/config.go-198`, `pkg/container/templates/runtime_config.go`
+**Implementation**: `pkg/runner/config.go`, `pkg/container/templates/runtime_config.go`
 
 #### Transport Configuration
 
@@ -147,7 +147,7 @@ thv run uvx://mcp-server \
 - `target_host`: Container host (default: `127.0.0.1`)
 - `proxy_mode`: For stdio: `sse` or `streamable-http`
 
-**Implementation**: `pkg/runner/config.go-76`, `139`
+**Implementation**: `pkg/runner/config.go`
 
 #### Environment Variables
 
@@ -178,7 +178,7 @@ thv run uvx://mcp-server \
 }
 ```
 
-**Implementation**: `pkg/runner/config.go-88`, `290-303`
+**Implementation**: `pkg/runner/config.go`
 
 #### Volumes
 
@@ -196,7 +196,7 @@ thv run uvx://mcp-server \
 
 **Relative paths**: Resolved relative to current directory
 
-**Implementation**: `pkg/runner/config.go-95`
+**Implementation**: `pkg/runner/config.go`
 
 #### Secrets
 
@@ -216,11 +216,10 @@ thv run uvx://mcp-server \
 - `encrypted`: Encrypted local storage
 - `1password`: 1Password SDK integration
 - `environment`: Environment variable provider
-- `none`: No-op provider (for testing)
 
 **Note**: There is no automatic default provider. Users must run `thv secret setup` to configure a provider before using secrets functionality.
 
-**Implementation**: `pkg/runner/config.go`, `307-341`
+**Implementation**: `pkg/runner/config.go`
 
 ### Middleware Configuration
 
@@ -238,7 +237,7 @@ thv run uvx://mcp-server \
       }
     },
     {
-      "type": "authz",
+      "type": "authorization",
       "parameters": {
         "policies": "permit(...);"
       }
@@ -247,17 +246,26 @@ thv run uvx://mcp-server \
 }
 ```
 
-**Middleware types:**
+**Middleware types** (registered in `GetSupportedMiddlewareFactories` in `pkg/runner/middleware.go`):
 - `auth` - JWT authentication
-- `tokenexchange` - OAuth token exchange
+- `tokenexchange` - OAuth 2.0 token exchange (RFC 8693)
+- `upstreamswap` - Swap ToolHive JWTs for upstream IdP tokens (embedded auth server)
+- `awssts` - AWS STS credential exchange
+- `obo` - On-Behalf-Of token flow
+- `mcp-parser` - Parse JSON-RPC (always present)
 - `tool-filter` - Filter tool lists
 - `tool-call-filter` - Filter tool calls
-- `mcp-parser` - Parse JSON-RPC (always present)
+- `ratelimit` - Request rate limiting
+- `usagemetrics` - Usage telemetry
 - `telemetry` - OpenTelemetry
-- `authz` - Cedar authorization
+- `authorization` - Cedar authorization
 - `audit` - Request logging
+- `recovery` - Panic recovery
+- `header-forward` - Forward request headers to upstream (constant: `HeaderForwardMiddlewareName`)
+- `validating-webhook` - Validating admission webhook
+- `mutating-webhook` - Mutating admission webhook
 
-**Implementation**: `pkg/runner/config.go-161`, `pkg/transport/types/transport.go-39`
+**Implementation**: `pkg/runner/config.go`, `pkg/transport/types/transport.go`
 
 ### Tool Filtering
 
@@ -283,7 +291,7 @@ thv run uvx://mcp-server \
 }
 ```
 
-**Implementation**: `pkg/runner/config.go-154`, `464-472`
+**Implementation**: `pkg/runner/config.go`
 
 ## RunConfig Lifecycle
 
@@ -319,7 +327,7 @@ config, err := runner.ReadJSON(reader)
 - Unknown fields ignored (forward compatibility)
 - Required fields validated
 
-**Implementation**: `pkg/runner/config.go-206`
+**Implementation**: `pkg/runner/config.go`
 
 ### State Storage
 
@@ -364,7 +372,7 @@ Permission profiles define security boundaries for MCP servers using a defense-i
 2. **Network isolation** - Control inbound/outbound connections
 3. **Privilege isolation** - Avoid privileged mode
 
-**Implementation**: `pkg/permissions/profile.go`
+**Implementation**: `github.com/stacklok/toolhive-core/permissions`
 
 ### Profile Structure
 
@@ -377,6 +385,8 @@ type Profile struct {
     Privileged bool                `json:"privileged,omitempty"`
 }
 ```
+
+`NetworkPermissions` also carries a `Mode` field (`"host"`, `"bridge"`, `"none"`) that selects the container runtime network mode; when empty, the runtime default is used.
 
 ### Filesystem Permissions
 
@@ -408,7 +418,7 @@ Three formats supported:
 - Architectural reason: Containers run Linux internally, requiring Linux-style paths
 - Example: `C:\Users\name\data:/data` (Windows host → Linux container path)
 
-**Implementation**: `pkg/permissions/profile.go`
+**Implementation**: `github.com/stacklok/toolhive-core/permissions`
 
 #### Read vs Write
 
@@ -437,7 +447,7 @@ Three formats supported:
 - Command injection patterns rejected
 - Windows paths handled specially
 
-**Implementation**: `pkg/permissions/profile.go-182`
+**Implementation**: `github.com/stacklok/toolhive-core/permissions`
 
 ### Network Permissions
 
@@ -488,7 +498,7 @@ Three formats supported:
 }
 ```
 
-**Implementation**: `pkg/permissions/profile.go-66`
+**Implementation**: `github.com/stacklok/toolhive-core/permissions`
 
 #### Inbound Connections
 
@@ -505,7 +515,7 @@ Three formats supported:
 
 **Note**: Inbound restrictions currently have limited implementation.
 
-**Implementation**: `pkg/permissions/profile.go-72`
+**Implementation**: `github.com/stacklok/toolhive-core/permissions`
 
 #### Network Isolation
 
@@ -547,7 +557,7 @@ When `isolate_network: true` in RunConfig:
 }
 ```
 
-**Implementation**: `pkg/permissions/profile.go-44`
+**Implementation**: `github.com/stacklok/toolhive-core/permissions`
 
 ### Built-in Profiles
 
@@ -573,7 +583,7 @@ When `isolate_network: true` in RunConfig:
 
 **Use for**: Maximum security, no external access needed
 
-**Implementation**: `pkg/permissions/profile.go`
+**Implementation**: `github.com/stacklok/toolhive-core/permissions`
 
 #### `network` Profile
 
@@ -595,7 +605,7 @@ When `isolate_network: true` in RunConfig:
 
 **Use for**: API calls, web scraping, external services
 
-**Implementation**: `pkg/permissions/profile.go`
+**Implementation**: `github.com/stacklok/toolhive-core/permissions`
 
 ### Custom Profiles
 
@@ -624,17 +634,17 @@ Custom permission profiles can be defined in JSON files for reusable security po
 
 **Profile resolution**: Profiles can be referenced by name (built-in), file path (custom), or from registry metadata (server-specific defaults).
 
-**Implementation**: `pkg/permissions/profile.go`
+**Implementation**: `github.com/stacklok/toolhive-core/permissions`
 
 ### Profile Selection
 
 **Priority order:**
 1. Direct profile object: `WithPermissionProfile(profile)` (programmatic use)
-2. Command-line flag: `--permission-profile <name|path>` (supports "none", "network", "stdio", or file path)
+2. Command-line flag: `--permission-profile <name|path>` (supports "none", "network", or file path)
 3. Registry default: From server metadata
 4. Global default: `network`
 
-**Implementation**: `pkg/permissions/`, registry metadata
+**Implementation**: `github.com/stacklok/toolhive-core/permissions`, registry metadata
 
 ## Security Best Practices
 
@@ -683,7 +693,7 @@ Custom permission profiles can be defined in JSON files for reusable security po
 }
 ```
 
-**Implementation**: `pkg/networking/`, `pkg/permissions/profile.go`
+**Implementation**: `pkg/networking/`, `github.com/stacklok/toolhive-core/permissions`
 
 ### Secrets Management
 
@@ -699,7 +709,6 @@ Custom permission profiles can be defined in JSON files for reusable security po
 - **encrypted**: Password-protected local storage
 - **1password**: 1Password SDK integration for enterprise vaults
 - **environment**: CI/CD environment variables
-- **none**: Testing/development no-op provider
 
 **Implementation**: `pkg/secrets/`, `pkg/runner/config.go`
 

--- a/docs/arch/06-registry-system.md
+++ b/docs/arch/06-registry-system.md
@@ -71,14 +71,16 @@ thv run server-name
 ```
 
 **Implementation:**
-- Embedded: `pkg/registry/data/registry.json`
+- Built-in catalog: loaded from the [`github.com/stacklok/toolhive-catalog`](https://github.com/stacklok/toolhive-catalog) package (`pkg/catalog/toolhive`), via `catalog.Upstream()` in `pkg/registry/provider_local.go`
 - Manager: `pkg/registry/provider.go`, `pkg/registry/provider_local.go`, `pkg/registry/provider_remote.go`
 
 ## Registry Format
 
+> **Note**: The JSON examples in this section show the parsed in-memory shape (`types.Registry` in `toolhive-core`), which is what consumers operate on after the upstream payload has been converted. The actual on-disk / wire format is `UpstreamRegistry` (with `$schema`, `version`, `meta.last_updated`, `data.servers`, `data.skills`). See [Upstream MCP Registry Format](#upstream-mcp-registry-format) below for the wire format and how legacy fields map onto it.
+
 ### Top-Level Structure
 
-**Implementation**: `pkg/registry/types.go`
+**Implementation**: `github.com/stacklok/toolhive-core/registry/types/registry_types.go`
 
 ```json
 {
@@ -98,7 +100,7 @@ thv run server-name
 
 ### Server Entry (Container-based)
 
-**Implementation**: `pkg/registry/types.go`
+**Implementation**: `github.com/stacklok/toolhive-core/registry/types/registry_types.go`
 
 ```json
 {
@@ -147,7 +149,7 @@ thv run server-name
 
 ### Remote Server Entry
 
-**Implementation**: `pkg/registry/types.go`
+**Implementation**: `github.com/stacklok/toolhive-core/registry/types/registry_types.go`
 
 ```json
 {
@@ -185,7 +187,7 @@ thv run server-name
 
 ### Group Entry
 
-**Implementation**: `pkg/registry/types.go`
+**Implementation**: `github.com/stacklok/toolhive-core/registry/types/registry_types.go`
 
 ```json
 {
@@ -276,13 +278,15 @@ User overrides take precedence over registry defaults.
 - Stores secrets securely
 - Adds to RunConfig
 
-**Implementation**: `pkg/registry/types.go`
+**Implementation**: `github.com/stacklok/toolhive-core/registry/types/registry_types.go`
 
 ## Custom Registries
 
 Organizations can provide their own registries.
 
 ### File-Based Registry
+
+> **Note**: The snippet below shows the legacy/in-memory shape for readability. On disk, the file must be in the upstream MCP registry format with servers under `data.servers` (see [Upstream MCP Registry Format](#upstream-mcp-registry-format)). Use `thv registry convert --in <file> --in-place` to migrate legacy files.
 
 **Create registry JSON:**
 ```json
@@ -360,7 +364,7 @@ thv config unset-registry
 
 The API endpoint must implement:
 - `GET /v0.1/servers` - List all servers with pagination
-- `GET /v0.1/servers/:name` - Get specific server by reverse-DNS name
+- `GET /v0.1/servers/:name/versions/latest` - Get the latest version of a specific server by reverse-DNS name
 - `GET /v0.1/servers?search=<query>` - Search servers
 - `GET /openapi.yaml` - OpenAPI specification (version 1.0.0)
 
@@ -716,11 +720,11 @@ The operator always creates a registry API deployment for each MCPRegistry:
 **Access:**
 ```bash
 # Within cluster
-curl http://company-registry-api.default.svc.cluster.local:8080/api/v1/registry
+curl http://company-registry-api.default.svc.cluster.local:8080/v0.1/servers
 
 # Via port-forward
 kubectl port-forward svc/company-registry-api 8080:8080
-curl http://localhost:8080/api/v1/registry
+curl http://localhost:8080/v0.1/servers
 ```
 
 **Implementation**: `cmd/thv-operator/pkg/registryapi/`
@@ -779,7 +783,7 @@ data from its configured sources (Git, API, Kubernetes, etc.) at runtime.
 - `repository_url` - Source code URL
 - `tags` - Categorization labels
 
-**Implementation**: `pkg/registry/types.go`
+**Implementation**: `github.com/stacklok/toolhive-core/registry/types/registry_types.go`
 
 ### RemoteServerMetadata (Remote Servers)
 
@@ -798,7 +802,7 @@ data from its configured sources (Git, API, Kubernetes, etc.) at runtime.
 - `repository_url` - Documentation URL
 - `tags` - Categorization labels
 
-**Implementation**: `pkg/registry/types.go`
+**Implementation**: `github.com/stacklok/toolhive-core/registry/types/registry_types.go`
 
 ### Group
 
@@ -823,11 +827,17 @@ data from its configured sources (Git, API, Kubernetes, etc.) at runtime.
 - Organizational structure
 
 **Run all servers in group:**
+
+> **Note**: `thv group run` is deprecated -- registry-based group deployment is no longer supported. The modern path is to create a local group with `thv group create <name>`, then run each server with `thv run <server> --group <name>`.
+
 ```bash
-thv group run data-pipeline  # assuming 'data-pipeline' is defined in your registry
+# Modern path: create a local group, then add servers to it
+thv group create data-pipeline
+thv run data-reader --group data-pipeline
+thv run data-processor --group data-pipeline
 ```
 
-**Implementation**: `pkg/registry/types.go`
+**Implementation**: `github.com/stacklok/toolhive-core/registry/types/registry_types.go`
 
 ## Provenance and Security
 
@@ -942,9 +952,14 @@ kubectl get mcpregistry company-registry -o yaml
 ```
 
 **Trigger manual sync:**
-```bash
-kubectl annotate mcpregistry company-registry toolhive.stacklok.dev/sync-trigger=true
-```
+
+Sync is handled internally by the registry server based on each source's
+`syncPolicy` in `configYAML`. The operator itself does not expose a
+trigger annotation in current code — `cmd/thv-operator/REGISTRY.md`
+documents a `toolhive.stacklok.dev/manual-sync` annotation, but no
+corresponding constant or handler exists in
+`cmd/thv-operator/controllers/mcpregistry_controller.go`. To force a
+re-sync, modify `configYAML` (or restart the registry API pod).
 
 **Implementation**: `cmd/thv-operator/controllers/mcpregistry_controller.go`
 

--- a/docs/arch/07-groups.md
+++ b/docs/arch/07-groups.md
@@ -69,7 +69,7 @@ Registry groups are predefined collections of servers that can be deployed toget
 - Group deployment creates a runtime group with all member servers
 - Each server maintains its individual identity and configuration
 
-**Implementation**: `pkg/registry/types.go`
+**Implementation**: `github.com/stacklok/toolhive-core/registry/types/registry_types.go`
 
 **Use case**: Deploy complete stacks (e.g., a full data processing pipeline) with a single command, ensuring all required components are available together.
 

--- a/docs/arch/08-workloads-lifecycle.md
+++ b/docs/arch/08-workloads-lifecycle.md
@@ -39,6 +39,7 @@ stateDiagram-v2
 **States**: `pkg/container/runtime/types.go`
 - `starting`, `running`, `stopping`, `stopped`
 - `removing`, `error`, `unhealthy`, `unauthenticated`
+- `policy_stopped`, `unknown`
 
 ## Core Operations
 
@@ -105,11 +106,9 @@ Listing combines container workloads from the runtime with remote workloads from
 
 Some operations (stop, delete) support processing multiple workloads in a single invocation, handling each workload sequentially or in parallel as appropriate.
 
-**Pattern**: Operations return `errgroup.Group`
+**Pattern**: Operations return a `CompletionFunc` (call to block until completion); internally uses `golang.org/x/sync/errgroup`
 
 **Timeout**: 5 minutes per operation
-
-**Implementation**: Uses `golang.org/x/sync/errgroup`
 
 ## Container vs Remote
 

--- a/docs/arch/09-operator-architecture.md
+++ b/docs/arch/09-operator-architecture.md
@@ -67,6 +67,12 @@ MCPServer is the fundamental building block. All other CRDs either **organize**,
         │              CONFIGURATION (attaches to any)     │
         │  ToolConfig   MCPExternalAuthConfig              │
         │  MCPOIDCConfig   MCPTelemetryConfig              │
+        │  MCPWebhookConfig                                │
+        └──────────────────────────────────────────────────┘
+
+        ┌──────────────────────────────────────────────────┐
+        │              AUXILIARY                           │
+        │  EmbeddingServer                                 │
         └──────────────────────────────────────────────────┘
 ```
 
@@ -76,7 +82,8 @@ MCPServer is the fundamental building block. All other CRDs either **organize**,
 | **Organization** | MCPGroup | Group related servers together |
 | **Aggregation** | VirtualMCPServer, VirtualMCPCompositeToolDefinition | Combine multiple servers into one endpoint |
 | **Discovery** | MCPRegistry | Help clients find available servers |
-| **Configuration** | ToolConfig, MCPExternalAuthConfig, MCPOIDCConfig, MCPTelemetryConfig | Shared config that attaches to any layer |
+| **Configuration** | MCPToolConfig, MCPExternalAuthConfig, MCPOIDCConfig, MCPTelemetryConfig, MCPWebhookConfig | Shared config that attaches to any layer |
+| **Auxiliary** | EmbeddingServer | Supporting infrastructure (e.g., embedding inference for vMCP) |
 
 #### Workload CRDs (Deploy Running Pods)
 
@@ -86,6 +93,7 @@ MCPServer is the fundamental building block. All other CRDs either **organize**,
 | **MCPRemoteProxy** | Deployment | Proxy to external/remote MCP servers |
 | **VirtualMCPServer** | Deployment | Aggregates multiple backends into one endpoint |
 | **MCPRegistry** | Deployment | Registry API server for MCP discovery |
+| **EmbeddingServer** | StatefulSet | HuggingFace text-embeddings-inference server (e.g., for vMCP semantic search) |
 
 #### Logical/Configuration CRDs (No Pods)
 
@@ -93,10 +101,11 @@ MCPServer is the fundamental building block. All other CRDs either **organize**,
 |-----|---------|
 | **MCPServerEntry** | Zero-infrastructure declaration of a remote MCP endpoint |
 | **MCPGroup** | Logical grouping of workloads (status tracking only) |
-| **ToolConfig** | Tool filtering and renaming configuration |
+| **MCPToolConfig** | Tool filtering and renaming configuration |
 | **MCPExternalAuthConfig** | Token exchange / header injection configuration |
 | **MCPOIDCConfig** | Shared OIDC provider settings referenced by workload CRDs |
 | **MCPTelemetryConfig** | Shared OpenTelemetry/Prometheus settings referenced by workload CRDs |
+| **MCPWebhookConfig** | Validating/mutating webhook middleware definitions referenced by MCPServer |
 | **VirtualMCPCompositeToolDefinition** | Workflow definitions (webhook validation only) |
 
 ### CRD Relationships
@@ -121,14 +130,15 @@ graph TB
     subgraph "Configuration Only"
         CTD[VirtualMCPCompositeToolDefinition<br/>Webhook validation]
         ExtAuth[MCPExternalAuthConfig<br/>No resources]
-        ToolCfg[ToolConfig<br/>No resources]
+        ToolCfg[MCPToolConfig<br/>No resources]
         OIDCCfg[MCPOIDCConfig<br/>No resources]
         TelCfg[MCPTelemetryConfig<br/>No resources]
+        WebhookCfg[MCPWebhookConfig<br/>No resources]
     end
 
     VMCP -->|groupRef| Group
-    VMCP -->|compositeToolRefs| CTD
-    VMCP -.->|oidcConfigRef| OIDCCfg
+    VMCP -->|config.compositeToolRefs| CTD
+    VMCP -.->|incomingAuth.oidcConfigRef| OIDCCfg
     VMCP -.->|telemetryConfigRef| TelCfg
 
     Server -->|groupRef| Group
@@ -137,6 +147,7 @@ graph TB
     Server -.->|toolConfigRef| ToolCfg
     Server -.->|oidcConfigRef| OIDCCfg
     Server -.->|telemetryConfigRef| TelCfg
+    Server -.->|webhookConfigRef| WebhookCfg
 
     Proxy -->|groupRef| Group
     Proxy -.->|externalAuthConfigRef| ExtAuth
@@ -176,11 +187,18 @@ For examples, see:
 
 ### MCPRegistry
 
-Manages MCP server registries in Kubernetes, supporting both Git-based and ConfigMap-based registry sources with automatic or manual synchronization.
+Deploys a registry API server that serves MCP server metadata to clients. The registry server itself handles fetching, parsing, and refreshing registry data from upstream sources (Git, files, etc.) — the operator is responsible only for running the server and feeding it configuration.
 
 **Implementation**: `cmd/thv-operator/api/v1beta1/mcpregistry_types.go`
 
-MCPRegistry resources can sync registry data from external sources and optionally deploy a registry API service for serving the registry data to other components.
+**Key fields:**
+- `configYAML` (required) — the complete `config.yaml` for the registry server. The operator stores this verbatim in a ConfigMap mounted at `/config/config.yaml` and does NOT parse, validate, or transform it.
+- `volumes` / `volumeMounts` — additional volumes the registry server needs (e.g., a Secret containing Git credentials referenced by file path from `configYAML`).
+- `pgpassSecretRef` — dedicated field for PostgreSQL `.pgpass` credentials (handled via an init container because libpq requires mode 0600).
+- `podTemplateSpec` — pod-level customizations (resources, affinity, tolerations).
+- `imagePullSecrets` — applied to both the Deployment and the operator-managed ServiceAccount.
+
+**Security note**: `configYAML` is stored in a ConfigMap, so credentials must NOT be inlined there. Reference them by file path and mount the corresponding Secret via `volumes` / `volumeMounts`.
 
 **Controller**: `cmd/thv-operator/controllers/mcpregistry_controller.go`
 
@@ -233,7 +251,7 @@ MCPOIDCConfig eliminates OIDC configuration duplication — define an identity p
 
 **Status fields** include a `Ready` condition, `configHash` for change detection, and `referencingWorkloads` tracking which resources reference this config. Deletion is blocked while references exist (finalizer pattern).
 
-**Referenced by**: MCPServer, MCPRemoteProxy, VirtualMCPServer (via `oidcConfigRef`)
+**Referenced by**: MCPServer and MCPRemoteProxy (via `spec.oidcConfigRef`); VirtualMCPServer (via `spec.incomingAuth.oidcConfigRef`)
 
 **Controller**: `cmd/thv-operator/controllers/mcpoidcconfig_controller.go`
 
@@ -259,6 +277,35 @@ MCPTelemetryConfig centralises telemetry infrastructure settings (collector endp
 **Controller**: `cmd/thv-operator/controllers/mcptelemetryconfig_controller.go`
 
 For examples, see [`examples/operator/mcp-servers/mcpserver_fetch_otel.yaml`](../../examples/operator/mcp-servers/mcpserver_fetch_otel.yaml).
+
+### MCPWebhookConfig
+
+Defines reusable validating and mutating webhook middleware configurations that can be referenced by MCPServer resources.
+
+**Implementation**: `cmd/thv-operator/api/v1beta1/mcpwebhookconfig_types.go`
+
+MCPWebhookConfig declares one or more `validating` and/or `mutating` webhooks (URL, timeout, failure policy, optional TLS, optional HMAC signing). At least one webhook must be defined (CEL-enforced). The MCPServer references it via `spec.webhookConfigRef`, and the proxy-runner injects the corresponding middleware into the request chain.
+
+**Key features:**
+- Per-webhook `failurePolicy` (`fail` or `ignore`) for handling webhook errors
+- Optional `tlsConfig` with CA bundle, mTLS client cert, or `insecureSkipVerify`
+- Optional `hmacSecretRef` adds the `X-Toolhive-Signature` header to outgoing payloads
+
+**Status fields** include a `Ready` condition, `configHash` for change detection, and `referencingWorkloads`.
+
+**Referenced by**: MCPServer (via `webhookConfigRef`)
+
+**Controller**: `cmd/thv-operator/controllers/mcpwebhookconfig_controller.go`
+
+### EmbeddingServer
+
+Deploys a HuggingFace text-embeddings-inference container as a StatefulSet, used by VirtualMCPServer for features such as semantic tool search.
+
+**Implementation**: `cmd/thv-operator/api/v1beta1/embeddingserver_types.go`
+
+EmbeddingServer encapsulates the model (defaulting to `BAAI/bge-small-en-v1.5`), image, port, optional HuggingFace token, and an optional persistent model cache. The operator reconciles each EmbeddingServer into a StatefulSet plus Service.
+
+**Controller**: `cmd/thv-operator/controllers/embeddingserver_controller.go`
 
 ### MCPRemoteProxy
 
@@ -324,7 +371,7 @@ MCPGroup resources allow grouping related MCP servers. Servers reference their g
 
 **Status fields** include phase (Ready, Pending, Failed), list of server names, and server count.
 
-**Referenced by MCPServer** using `spec.groupRef.name`.
+**Referenced by**: MCPServer, MCPRemoteProxy, MCPServerEntry, and VirtualMCPServer using `spec.groupRef.name`.
 
 **Controller**: `cmd/thv-operator/controllers/mcpgroup_controller.go`
 
@@ -405,7 +452,7 @@ Defines reusable composite tool workflows that can be shared across multiple Vir
 
 Composite tools orchestrate calls to multiple backend tools in sequence or parallel, enabling complex workflows without client awareness of the underlying backends. Workflow steps form a DAG (Directed Acyclic Graph) with support for conditional execution and error handling.
 
-**Referenced by**: VirtualMCPServer (via `spec.compositeToolRefs`)
+**Referenced by**: VirtualMCPServer (via `spec.config.compositeToolRefs`)
 
 **Status fields** track validation status and which VirtualMCPServers reference the definition.
 
@@ -414,6 +461,10 @@ For examples, see the [`examples/operator/`](../../examples/operator/) directory
 For complete examples of all CRDs, see the [`examples/operator/mcp-servers/`](../../examples/operator/mcp-servers/) directory.
 
 ## Operator Components
+
+### Entry Point
+
+The operator binary's `main` package delegates to `cmd/thv-operator/app/app.go`. `Run()` performs flag parsing, manager construction, and leader-election setup, then calls `setupControllersAndWebhooks`, which fans out to `setupServerControllers` (MCPServer, MCPRemoteProxy, MCPServerEntry, MCPGroup, and shared config CRDs), `setupRegistryController` (MCPRegistry), and `setupAggregationControllers` (VirtualMCPServer, VirtualMCPCompositeToolDefinition, EmbeddingServer). Webhooks are registered alongside their controllers.
 
 ### Controller
 
@@ -489,17 +540,16 @@ graph LR
 5. Apply middleware chain
 6. Forward traffic to StatefulSet pods
 
-**Command:**
-```bash
-thv-proxyrunner run
-```
+**Container invocation:**
+
+The operator sets `Container.Args` (not `Command`) on the proxy-runner Deployment. The image's default entrypoint runs the `thv-proxyrunner` binary; the operator passes `run` as the first argument, optionally followed by `--k8s-pod-patch=<json>` when the user supplied a `podTemplateSpec`, then the MCP image reference. See `deploymentForMCPServer` in `cmd/thv-operator/controllers/mcpserver_controller.go`.
 
 **Environment:**
 - `KUBERNETES_SERVICE_HOST` - Detects K8s environment
 - RunConfig path from mount
 - In-cluster Kubernetes client
 
-**Implementation**: `cmd/thv-proxyrunner/app/commands.go`
+**Implementation**: `cmd/thv-proxyrunner/app/commands.go` (cobra wiring), `cmd/thv-proxyrunner/app/run.go` (`run` command logic)
 
 ## Design Principles
 
@@ -543,7 +593,7 @@ spec:
 
 **Why**: Simple Phase + Ready condition + ReadyReplicas + URL, enables `kubectl wait --for=condition=Ready`
 
-**Implementation**: `cmd/thv-operator/controllers/mcpregistry_controller.go`
+**Implementation**: `cmd/thv-operator/pkg/controllerutil/status.go` (`MutateAndPatchStatus` merge-patch helper used by all CRD controllers)
 
 ## MCPRegistry Controller
 
@@ -552,84 +602,50 @@ spec:
 ```mermaid
 graph TB
     MCPReg[MCPRegistry CRD] --> Controller[Controller]
-    Controller --> Source[Source Handler]
+    Controller --> Manager[Registry API Manager]
 
-    Source -->|git| Git[Git Clone]
-    Source -->|configmap| CM[Read ConfigMap]
+    Manager --> CM[ConfigMap<br/>raw configYAML]
+    Manager --> SA[ServiceAccount + Role/RoleBinding]
+    Manager --> Deploy[Deployment<br/>thv-registry-api]
+    Manager --> SVC[Service]
 
-    Git --> Storage[Storage Manager]
-    CM --> Storage
+    Deploy -.mounts.-> CM
 
-    Storage --> ConfigMap[ConfigMap Storage]
-    Controller --> API[Registry API Service]
-
-    API --> Deploy[Deployment]
-    API --> SVC[Service]
+    Source[Registry source<br/>Git / file / DB] -->|fetched at runtime| Deploy
 
     style Controller fill:#5c6bc0
-    style Storage fill:#e3f2fd
-    style API fill:#ba68c8
+    style Manager fill:#e3f2fd
+    style Deploy fill:#ba68c8
 ```
 
-### Source Handlers
+The operator is intentionally thin: it materialises a Deployment, Service, ServiceAccount, RBAC, and a config ConfigMap. All registry-source logic (Git cloning, file watching, database access, refresh scheduling) lives in the registry-api server and is driven entirely by the `configYAML` the user supplies.
 
-**Git source**: `cmd/thv-operator/pkg/sources/git.go`
-- Clones repository
-- Reads registry.json
-- Calculates hash for change detection
+### Registry API Manager
 
-**ConfigMap source**: `cmd/thv-operator/pkg/sources/configmap.go`
-- Reads from existing ConfigMap
-- Watches for updates
+The MCPRegistry controller delegates workload management to a Manager that creates the ConfigMap, ServiceAccount, RBAC, Deployment, and Service for the registry-api server.
 
-**Storage Manager**: `cmd/thv-operator/pkg/sources/storage_manager.go`
-- Creates ConfigMap with key `registry.json` containing full registry data
-- Sync operations are handled by the registry server itself
+**Implementation entry point**: `cmd/thv-operator/pkg/registryapi/manager.go`
 
-**Interface**: `cmd/thv-operator/pkg/sources/types.go`
+Supporting files in `cmd/thv-operator/pkg/registryapi/`:
+- `deployment.go` — builds the registry-api Deployment
+- `service.go` — builds the Service
+- `rbac.go` — builds the ServiceAccount, Role, and RoleBinding
+- `podtemplatespec.go` — merges user-supplied `podTemplateSpec` into the generated PodSpec
+- `config/raw_config.go` — wraps the raw `configYAML` in a ConfigMap (no parsing)
 
-### Storage Manager
+### Config Delivery
 
-**Purpose**: Persist registry data in cluster
+The operator passes `spec.configYAML` verbatim into a ConfigMap (`<registry-name>-registry-server-config`) and mounts it at `/config/config.yaml`. A content-checksum annotation on the ConfigMap triggers Deployment rollouts when the YAML changes.
 
-**Implementation**: `cmd/thv-operator/pkg/sources/storage_manager.go`
-
-**Storage**: ConfigMap with owner reference
-
-**Format:**
 ```yaml
 data:
-  registry.json: |
-    { full registry data }
+  config.yaml: |
+    { raw user-supplied configYAML }
 ```
 
-Sync operations are handled by the registry server, not the operator.
+### Refresh Behavior
 
-### Sync Policy
-
-**Automatic sync:**
-```yaml
-spec:
-  syncPolicy:
-    interval: 1h
-```
-
-Operator syncs every hour. The presence of `syncPolicy` with an `interval` enables automatic synchronization.
-
-**Manual sync:**
-
-Omit the `syncPolicy` field entirely.
-
-Trigger: Add or update annotation `toolhive.stacklok.dev/sync-trigger=<unique-value>` where the value can be any non-empty string. The operator triggers sync when this value changes, allowing multiple manual syncs by using different values (e.g., timestamps, counters).
-
-### Registry API Service
-
-When enabled, operator creates:
-- Deployment running `thv-registry-api`
-- Service exposing API
-- ConfigMap mount with registry data
-
-**Implementation**: `cmd/thv-operator/pkg/registryapi/service.go`
+Refresh policy, source location, and credentials are all defined inside `configYAML` and interpreted by the registry-api server. The operator does not poll, schedule, or trigger registry syncs.
 
 ## Configuration References
 

--- a/docs/arch/10-virtual-mcp-architecture.md
+++ b/docs/arch/10-virtual-mcp-architecture.md
@@ -237,12 +237,16 @@ Middleware is applied by wrapping handlers, so execution order is outer-to-inner
 | Order | Middleware | Required | Purpose |
 |-------|------------|----------|---------|
 | 1 | Recovery | Always | Catches panics, returns HTTP 500 |
-| 2 | Authentication | Optional | Validates incoming JWT tokens (OIDC/Anonymous) |
-| 3 | Authorization | Optional | Evaluates Cedar policies (composed with auth) |
-| 4 | Audit | Optional | Logs request events for compliance |
-| 5 | Discovery | Always | Aggregates backend capabilities per session |
-| 6 | Backend Enrichment | Optional | Adds backend name to audit context |
-| 7 | Telemetry | Optional | OpenTelemetry instrumentation |
+| 2 | WriteTimeout | Always | Clears the server `WriteTimeout` for qualifying SSE connections |
+| 3 | Header Validation | Always | Rejects GETs without `Accept: text/event-stream` before they reach the MCP handler |
+| 4 | Authentication (+ MCP parsing) | Optional | Validates incoming credentials (OIDC/local/anonymous); MCP parsing is composed inside so downstream layers see `ParsedMCPRequest` |
+| 5 | Audit | Optional | Logs request events for compliance |
+| 6 | Discovery | Always | Aggregates backend capabilities per session |
+| 7 | Annotation Enrichment | Optional | Injects tool annotations into context for annotation-aware authz (only when Authorization is configured) |
+| 8 | Authorization | Optional | Evaluates Cedar policies after discovery and annotation enrichment |
+| 9 | Backend Enrichment | Optional | Adds backend name to audit context (only when Audit is configured) |
+| 10 | MCP Parsing | Always | Second application is a no-op when auth already parsed; ensures telemetry can label metrics with `mcp_method` when auth is nil |
+| 11 | Telemetry | Optional | OpenTelemetry instrumentation |
 
 ### Discovery Middleware
 
@@ -272,13 +276,16 @@ This enriches audit events with the backend name for better observability.
 
 ### Authentication Composition
 
-When Authorization is configured, Authentication middleware is composed with MCP Parsing and Authorization:
+`pkg/vmcp/auth/factory/incoming.NewIncomingAuthMiddleware()` returns two separate middlewares:
+
+- `authMw`: Authentication composed with MCP Parsing (parsing runs immediately after auth so downstream layers see `ParsedMCPRequest`).
+- `authzMw`: Authorization, returned independently so the server can place it after discovery and annotation enrichment in the chain.
+
+The server wires them around discovery/annotation-enrichment so the effective execution order is:
 
 ```
-Authentication → MCP Parsing → Authorization → Next Handler
+Authentication → MCP Parsing → Audit → Discovery → Annotation Enrichment → Authorization → Next Handler
 ```
-
-This composition is created by `pkg/vmcp/auth/factory/incoming.NewIncomingAuthMiddleware()`.
 
 **Implementation**: `pkg/vmcp/server/server.go`, `pkg/vmcp/discovery/middleware.go`, `pkg/vmcp/auth/factory/`
 
@@ -326,12 +333,12 @@ Status reporting enables vMCP runtime to report operational status directly inst
 
 ### Key Concepts
 
-- `StatusReporter` interface (`pkg/vmcp/status/reporter.go`): `ReportStatus(ctx, *vmcp.Status)` and `Start(ctx)` returning shutdown func.
+- `Reporter` interface (`pkg/vmcp/status/reporter.go`); set via `Config.StatusReporter` field: `ReportStatus(ctx, *vmcp.Status)` and `Start(ctx)` returning shutdown func.
 - Status model (`pkg/vmcp/types.go`):
   - Phase: Pending, Ready, Degraded, Failed
   - Conditions: `metav1.Condition` (ready, backends discovered, auth configured) using shared constants
   - DiscoveredBackends: backend URL/auth type/health with timestamps
-- CLI reporter: Logging-only reporter (no persistence) always logs status updates.
+- CLI reporter: Logging-only reporter (no persistence) logs status updates at Debug level (visible when `--debug` is set).
 - Lifecycle hook: server starts the reporter, collects shutdown funcs, and stops them during graceful shutdown.
 
 ### Integration in vMCP Runtime

--- a/docs/arch/11-auth-server-storage.md
+++ b/docs/arch/11-auth-server-storage.md
@@ -7,7 +7,7 @@ The embedded authorization server uses a pluggable storage backend to persist OA
 The auth server stores OAuth 2.0 protocol state including access tokens, refresh tokens, authorization codes, PKCE challenges, client registrations, user accounts, and upstream IDP tokens. Two storage backends are available:
 
 1. **Memory** (default): In-process storage with mutex-based concurrency. Suitable for single-instance deployments.
-2. **Redis**: Shared storage backed by Redis. Supports standalone mode (single endpoint, suitable for managed services like GCP Memorystore and AWS ElastiCache) and Sentinel mode (high-availability with automatic failover). Required for horizontal scaling across multiple auth server replicas.
+2. **Redis**: Shared storage backed by Redis. Supports standalone mode (single endpoint, suitable for managed services like GCP Memorystore Basic and AWS ElastiCache without cluster mode), Cluster mode (Redis Cluster discovery endpoint, e.g. GCP Memorystore Cluster and AWS ElastiCache with cluster mode enabled), and Sentinel mode (high-availability with automatic failover). Required for horizontal scaling across multiple auth server replicas.
 
 ```mermaid
 graph TB
@@ -20,7 +20,7 @@ graph TB
     subgraph "Storage Backend"
         direction TB
         Memory[In-Memory Storage<br/>Single instance only]
-        Redis[Redis<br/>Standalone or Sentinel<br/>Shared state]
+        Redis[Redis<br/>Standalone, Cluster, or Sentinel<br/>Shared state]
     end
 
     AS1 -.->|single instance| Memory
@@ -30,15 +30,18 @@ graph TB
 
     subgraph "Redis Deployment Options"
         Standalone[Standalone<br/>Managed services]
+        Cluster[Redis Cluster<br/>Managed services]
         Sentinel[Sentinel Cluster<br/>Self-managed HA]
     end
 
     Redis --> Standalone
+    Redis --> Cluster
     Redis --> Sentinel
 
     style Memory fill:#fff3e0
     style Redis fill:#e1f5fe
     style Standalone fill:#e8f5e9
+    style Cluster fill:#e8f5e9
     style Sentinel fill:#e8f5e9
 ```
 
@@ -58,6 +61,7 @@ The storage layer implements multiple interfaces from the [fosite](https://githu
 - `UpstreamTokenStorage` — Upstream IDP token caching with user binding
 - `PendingAuthorizationStorage` — In-flight authorization tracking
 - `UserStorage` — Internal user accounts and provider identity linking
+- `DCRCredentialStore` — DCR client secret persistence; intentionally NOT embedded in `Storage` (each backend implements it separately and call sites reach it via an explicit `stor.(DCRCredentialStore)` type assertion)
 
 **Implementation:**
 - Interface definitions: `pkg/authserver/storage/types.go`
@@ -80,7 +84,7 @@ An operator opt-in path that extracts identity claims directly from the token en
 
 **Reverse-index implication (Redis backend).** Stable user IDs mean `KeyTypeUserUpstream` works as designed — one set per user accumulates session IDs across re-authentications. No set churn.
 
-**Operator visibility.** The `IdentitySynthesized` condition does not fire for upstreams using `IdentityFromToken`. However, `SyntheticIdentityUpstreams()` (the controller-side predicate that drives the condition) currently checks only for `userInfo == nil` and does not yet inspect `IdentityFromToken`. Until the CRD type and controller logic land in a follow-up, an upstream with `IdentityFromToken` configured but no `userInfo` will still trigger `IdentitySynthesizedActive` — even though synthesis is not reached at runtime.
+**Operator visibility.** The `IdentitySynthesized` condition does not fire for upstreams using `IdentityFromToken`. `SyntheticIdentityUpstreams()` (the controller-side predicate that drives the condition) skips upstreams where either `userInfo` or `identityFromToken` is configured — only the dual-unconfigured case is reported as synthesis-mode.
 
 **Implementation.**
 - `pkg/authserver/upstream/oauth2.go` — `ExchangeCodeForIdentity` priority 1 branch
@@ -101,9 +105,9 @@ Reached when both `IdentityFromToken` is unconfigured AND `userInfo` is absent. 
 
 **`UserResolver` bypass.** The bypass is gated on `Identity.Synthetic` in `callback.go` — synthesis is the only path that sets this field. Synthetic identities skip `UserResolver.ResolveUser` entirely — no row is created in `UserStorage`, no entry is written to provider-identities, and `UpdateLastAuthenticated` is not called. The synthesized subject rotates per access token, so persisting it would create a fresh `users` row on every re-authentication. `UpstreamTokens.UserID` therefore carries the `tk-…` value directly rather than a stable internal UUID.
 
-**Reverse-index implication (Redis backend).** The `KeyTypeUserUpstream` secondary-index set under `thv:auth:{ns:name}:user:upstream:{userID}` is designed around stable user IDs — one set per user, holding all of that user's session IDs. Under synthesis the userID rotates with every re-authentication, so each session lands in its own one-element set. Reads continue to work, but set churn is much higher than under OIDC. The existing TODO at `pkg/authserver/storage/redis.go:43-45` to scan and clean up stale secondary-index entries applies, and synthesis-mode workloads make a periodic scan more important.
+**Reverse-index implication (Redis backend).** The `KeyTypeUserUpstream` secondary-index set under `thv:auth:{ns:name}:user:upstream:{userID}` is designed around stable user IDs — one set per user, holding all of that user's session IDs. Under synthesis the userID rotates with every re-authentication, so each session lands in its own one-element set. Reads continue to work, but set churn is much higher than under OIDC. The existing TODO in `pkg/authserver/storage/redis.go` (on `warnOnCleanupErr`) to scan and clean up stale secondary-index entries applies, and synthesis-mode workloads make a periodic scan more important.
 
-**Operator visibility.** When at least one configured OAuth2 upstream has `userInfo == nil`, the controller surfaces the `IdentitySynthesized` condition on the `MCPExternalAuthConfig` and `VirtualMCPServer` status (Reason `IdentitySynthesizedActive`, naming the affected upstreams). The condition flips to `False` (Reason `IdentitySynthesizedInactive`) once every upstream has `userInfo` configured. Note: the controller predicate (`SyntheticIdentityUpstreams`) checks only for `userInfo == nil` and does not yet account for `IdentityFromToken`; see the known gap noted under priority 1.
+**Operator visibility.** When at least one configured OAuth2 upstream has both `userInfo` and `identityFromToken` unconfigured, the controller surfaces the `IdentitySynthesized` condition on the `MCPExternalAuthConfig` and `VirtualMCPServer` status (Reason `IdentitySynthesizedActive`, naming the affected upstreams). The condition flips to `False` (Reason `IdentitySynthesizedInactive`) once every upstream has either `userInfo` or `identityFromToken` configured.
 
 **Implementation.**
 - `pkg/authserver/upstream/oauth2.go` — `synthesizeIdentity`, `synthesizeSubjectFromAccessToken`, `IsSynthesizedSubject`
@@ -129,10 +133,11 @@ The Redis backend stores all OAuth 2.0 state as JSON-serialized values in Redis.
 
 ### Connection Architecture
 
-Two connection modes are supported:
+Three connection modes are supported. Client construction (standalone, cluster, or sentinel), connection-mode validation, TLS plumbing, and connectivity verification are delegated to the shared `github.com/stacklok/toolhive-core/redis` package; `RedisStorage` holds a `redis.UniversalClient` so the same call sites work across all three topologies.
 
-- **Standalone** (`redis.NewClient()`): A single endpoint for managed Redis services. The caller is responsible for endpoint availability (the managed service handles HA internally).
-- **Sentinel** (`redis.NewFailoverClient()`): Connects via Sentinel for self-managed high-availability deployments. Sentinel handles master discovery, automatic failover, and configuration updates.
+- **Standalone**: A single endpoint for managed Redis services. The caller is responsible for endpoint availability (the managed service handles HA internally).
+- **Cluster**: A Redis Cluster discovery endpoint (e.g., GCP Memorystore Cluster, AWS ElastiCache with cluster mode enabled). Enabled by setting `clusterMode: true` alongside `addr` in the CRD.
+- **Sentinel**: Connects via Sentinel for self-managed high-availability deployments. Sentinel handles master discovery, automatic failover, and configuration updates.
 
 ### Multi-Tenancy
 
@@ -200,17 +205,23 @@ MCPExternalAuthConfig
   └── spec.embeddedAuthServer.storage
         ├── type: "memory" | "redis"
         └── redis
-              ├── addr (standalone)  ─── mutually exclusive ───  sentinelConfig
-              │                                                         ├── masterName
-              │                                                         ├── sentinelAddrs[] (or sentinelService)
-              │                                                         └── db
+              ├── addr (standalone or cluster)  ─── mutually exclusive ───  sentinelConfig
+              │                                                                   ├── masterName
+              │                                                                   ├── sentinelAddrs[] (or sentinelService)
+              │                                                                   └── db
+              ├── clusterMode (optional; requires addr — Redis Cluster protocol)
               ├── aclUserConfig
               │     ├── usernameSecretRef  (optional; omit for password-only AUTH)
               │     └── passwordSecretRef
-              ├── tls (optional)
+              ├── tls (optional, master/cluster connection)
               │     ├── caCertSecretRef
               │     └── insecureSkipVerify
-              └── timeouts (dial, read, write)
+              ├── sentinelTls (optional, sentinel connection only)
+              │     ├── caCertSecretRef
+              │     └── insecureSkipVerify
+              ├── dialTimeout
+              ├── readTimeout
+              └── writeTimeout
 ```
 
 **Implementation:** `cmd/thv-operator/api/v1beta1/mcpexternalauthconfig_types.go`
@@ -226,7 +237,7 @@ When passing configuration across process boundaries (operator → proxy-runner)
 - **ACL or legacy authentication**: Redis ACL users (Redis 6+) provide fine-grained access control. When a username is omitted, go-redis sends legacy password-only `AUTH`, which is required for managed Redis tiers that do not expose an ACL subsystem (e.g. GCP Memorystore Basic/Standard HA, Azure Cache for Redis).
 - **Key prefix isolation**: Each auth server is restricted to its own key prefix via Redis ACL rules (`~thv:auth:*`).
 - **Credential handling**: In Kubernetes, credentials are stored in Secrets and injected as environment variables. They are never written to disk or logged.
-- **TLS support**: TLS is supported for both master and Sentinel connections via `tls` and `sentinelTLS` in the CRD. For managed services with private CAs (e.g. GCP Memorystore), provide the CA certificate via `caCertSecretRef`.
+- **TLS support**: TLS is supported for both master and Sentinel connections via `tls` and `sentinelTls` in the CRD. For managed services with private CAs (e.g. GCP Memorystore), provide the CA certificate via `caCertSecretRef`.
 
 ## Related Documentation
 
@@ -251,7 +262,7 @@ All other `Storage` methods (`RegisterClient`, token storage, upstream token sto
 
 ### Unwrap pattern
 
-`CIMDStorageDecorator` implements `Unwrap() Storage` to expose the concrete backend through the decorator layer. Two call sites in `server_impl.go` depend on this:
+`CIMDStorageDecorator` implements `Unwrap() Storage` to expose the concrete backend through the decorator layer. Two call sites in `pkg/authserver/server_impl.go` depend on this:
 
 - **`DCRCredentialStore` assertion** (`newServer`): The `DCRCredentialStore` interface is narrower than `Storage` and not embedded in it. The assertion `unwrapStorage(stor).(storage.DCRCredentialStore)` reaches the concrete backend through the decorator.
 - **`RedisStorage` migration** (`runLegacyMigration`): A type assertion to `*storage.RedisStorage` is needed to run a one-shot data migration. Same `unwrapStorage` call.

--- a/docs/arch/12-skills-system.md
+++ b/docs/arch/12-skills-system.md
@@ -112,7 +112,7 @@ Instructions for how the AI assistant should perform code reviews...
 | `toolhive.requires` | No | OCI references for skill dependencies |
 | `license` | No | SPDX license identifier |
 | `compatibility` | No | Client compatibility string (max 500 chars) |
-| `metadata` | No | Arbitrary key-value pairs |
+| `metadata` | No | Arbitrary string-keyed, string-valued metadata |
 
 **Implementation:** `pkg/skills/types.go` (SkillFrontmatter), `pkg/skills/parser.go`, `pkg/skills/validator.go`
 
@@ -175,7 +175,7 @@ thv skill build ./my-skill/ --tag v1.0.0
 3. Package all files into a tar.gz OCI layer
 4. Store in the local OCI store with the specified tag
 
-**Implementation:** `pkg/skills/skillsvc/skillsvc.go` (Build), `toolhive-core/oci/skills` (SkillPackager)
+**Implementation:** `pkg/skills/skillsvc/build.go` (Build), `toolhive-core/oci/skills` (SkillPackager)
 
 ### 3. Publishing
 
@@ -185,7 +185,7 @@ Push a locally-built artifact to a remote OCI registry:
 thv skill push ghcr.io/org/my-skill:v1.0.0
 ```
 
-**Implementation:** `pkg/skills/skillsvc/skillsvc.go` (Push), `toolhive-core/oci/skills` (RegistryClient)
+**Implementation:** `pkg/skills/skillsvc/build.go` (Push), `toolhive-core/oci/skills` (RegistryClient)
 
 ### 4. Installation
 
@@ -244,9 +244,9 @@ flowchart TD
 
 3. **Supply chain validation**: For OCI installs, the skill name in the artifact must match the repository name in the reference.
 
-4. **Client targeting**: When no `--clients` flag is provided, all skill-supporting clients are targeted by default. Specify `--clients claude-code` to target a particular client.
+4. **Client targeting**: When no `--clients` flag is provided, all skill-supporting clients detected on the host are targeted by default. Specify `--clients claude-code` to target a particular client.
 
-**Implementation:** `pkg/skills/skillsvc/skillsvc.go` (Install)
+**Implementation:** `pkg/skills/skillsvc/install.go` (Install)
 
 ### 5. Uninstallation
 
@@ -256,7 +256,7 @@ thv skill uninstall code-review
 
 Removes the skill files from the filesystem, deletes the database record, and removes the skill from all groups.
 
-**Implementation:** `pkg/skills/skillsvc/skillsvc.go` (Uninstall), `pkg/groups/skills.go` (RemoveSkillFromAllGroups)
+**Implementation:** `pkg/skills/skillsvc/uninstall.go` (Uninstall), `pkg/groups/skills.go` (RemoveSkillFromAllGroups)
 
 ## Git-Based Skill Resolution
 
@@ -272,7 +272,7 @@ git://github.com/org/repo@main#skills/my-skill  # Branch + subdirectory
 **Resolution process:**
 1. Parse the git reference (host, repo, ref, path)
 2. Resolve authentication (`GITHUB_TOKEN` for github.com, `GITLAB_TOKEN` for gitlab.com — both host-scoped to prevent credential exfiltration; `GIT_TOKEN` as an unscoped fallback sent to any host)
-3. Clone the repository (2-minute timeout, shallow clone)
+3. Clone the repository (2-minute timeout; shallow clone when a branch or tag is specified)
 4. Extract the skill directory files
 5. Validate and install as normal
 
@@ -282,7 +282,7 @@ git://github.com/org/repo@main#skills/my-skill  # Branch + subdirectory
 
 ## Storage
 
-Skill installation records are persisted in SQLite across four tables. The `entries` table is a shared parent for all entry types (skills share it with future entry kinds); `installed_skills` holds skill-specific columns and references `entries` via a foreign key; `oci_tags` caches OCI reference-to-digest mappings for upgrade detection and deduplication:
+Skill installation records are persisted in SQLite across four tables. The `entries` table is a shared parent for all entry types (skills share it with future entry kinds); `installed_skills` holds skill-specific columns and references `entries` via a foreign key; `oci_tags` is reserved for caching OCI reference-to-digest mappings but is not currently populated:
 
 ```
 entries table
@@ -317,7 +317,7 @@ skill_dependencies table
 ├── dep_digest          (TEXT)
 └── PRIMARY KEY(installed_skill_id, dep_reference)
 
-oci_tags table
+oci_tags table (reserved; not currently populated)
 ├── reference  (TEXT, PRIMARY KEY — OCI reference string)
 └── digest     (TEXT NOT NULL — content digest)
 ```
@@ -341,6 +341,7 @@ oci_tags table
 | `POST` | `/push` | Push built skill to registry |
 | `GET` | `/builds` | List local builds |
 | `DELETE` | `/builds/{tag}` | Delete a local build |
+| `GET` | `/content` | Get a skill's SKILL.md body and file listing for a reference |
 
 **Implementation:** `pkg/api/v1/skills.go`
 
@@ -408,7 +409,7 @@ The skills system applies defense-in-depth across multiple layers:
 - Resolves symlinks in parent components before applying depth checks
 
 ### Supply Chain
-- OCI artifact skill name must match repository name in the reference
+- OCI artifact skill name must match the last path component of the OCI repository
 - Git authentication is host-scoped (GitHub token only sent to github.com)
 - SSRF prevention: rejects localhost and private IPs in git references
 
@@ -441,7 +442,7 @@ ToolHive owns the installation lifecycle, scoping model, CLI/API interfaces, and
 |---|---|
 | Type definitions | `pkg/skills/types.go` |
 | Service interface | `pkg/skills/service.go` |
-| Service implementation | `pkg/skills/skillsvc/skillsvc.go` |
+| Service implementation | `pkg/skills/skillsvc/` |
 | Options / DTOs | `pkg/skills/options.go` |
 | Validation | `pkg/skills/validator.go` |
 | Parsing | `pkg/skills/parser.go` |

--- a/docs/arch/13-vmcp-scalability.md
+++ b/docs/arch/13-vmcp-scalability.md
@@ -67,9 +67,8 @@ aggregation.
 ### Redis sliding-window TTL
 
 When Redis session storage is enabled, every `Load` call issues a `GETEX` that
-resets the key's TTL atomically
-(`pkg/transport/session/storage_redis.go:NewRedisStorage` and the comment at
-line 177). This means:
+resets the key's TTL atomically (see `pkg/transport/session/storage_redis.go`,
+`NewRedisStorage` and the `Load` function docstring). This means:
 
 - Active sessions are preserved indefinitely as long as they receive at least
   one request per TTL window.
@@ -109,7 +108,7 @@ request (`Load` + `GETEX`). Redis is on the hot path.
 
 | Parameter | Default | Notes |
 | --------- | ------- | ----- |
-| Dial timeout | 5 s (`DefaultDialTimeout`) | `pkg/transport/session/redis_config.go` |
+| Dial timeout | 5 s (`DefaultDialTimeout`) | `github.com/stacklok/toolhive-core/redis/config.go` |
 | Read timeout | 3 s (`DefaultReadTimeout`) | |
 | Write timeout | 3 s (`DefaultWriteTimeout`) | |
 | Key prefix | configurable | Must end with `:` to avoid collisions |
@@ -119,12 +118,12 @@ estimate: 10–50 KB per session depending on backend count and tool count.
 Maximum concurrent session count across the fleet is `replicas × 1,000`.
 
 **Connection pools:** Each vMCP pod creates one go-redis client with its own
-connection pool. No explicit `PoolSize` is configured
-(`pkg/transport/session/storage_redis.go`), so go-redis applies its default of
-`10 × GOMAXPROCS` connections per pool. Total Redis connections therefore scale
-as `replicas × (10 × GOMAXPROCS)`. Size the Redis `maxclients` setting
-accordingly, and tune `PoolSize` in `RedisConfig` if the default is too large
-or too small for your workload.
+connection pool. Client construction is delegated to
+`github.com/stacklok/toolhive-core/redis` and no explicit `PoolSize` is
+configured (the `tcredis.Config` struct does not expose one), so go-redis
+applies its default of `10 × GOMAXPROCS` connections per pool. Total Redis
+connections therefore scale as `replicas × (10 × GOMAXPROCS)`. Size the Redis
+`maxclients` setting accordingly.
 
 **Eviction policy:** Use `allkeys-lru` so Redis can shed stale sessions under
 memory pressure rather than returning errors on new writes.
@@ -174,16 +173,16 @@ for session affinity design details.
 | Per-pod session cache | 1,000 sessions | `sessionmanager/factory.go:defaultCacheCapacity` | No (internal field) |
 | vMCP session TTL | 30 minutes | `vmcp/server/server.go:defaultSessionTTL` | Via `server.Config.SessionTTL` (not CRD-exposed) |
 | MCPServer proxy session TTL | 2 hours | `transport/session/proxy_session.go:DefaultSessionTTL` | No |
-| Redis dial timeout | 5 s | `transport/session/redis_config.go:DefaultDialTimeout` | Via `RedisConfig.DialTimeout` |
-| Redis read timeout | 3 s | `transport/session/redis_config.go:DefaultReadTimeout` | Via `RedisConfig.ReadTimeout` |
-| Redis write timeout | 3 s | `transport/session/redis_config.go:DefaultWriteTimeout` | Via `RedisConfig.WriteTimeout` |
-| forEach max iterations | 1,000 | `vmcp/config/config.go:MaxForEachIterations` | Via `WorkflowStepConfig.MaxIterations` (capped at 1,000) |
+| Redis dial timeout | 5 s | `toolhive-core/redis/config.go:DefaultDialTimeout` | Via `tcredis.Config.DialTimeout` |
+| Redis read timeout | 3 s | `toolhive-core/redis/config.go:DefaultReadTimeout` | Via `tcredis.Config.ReadTimeout` |
+| Redis write timeout | 3 s | `toolhive-core/redis/config.go:DefaultWriteTimeout` | Via `tcredis.Config.WriteTimeout` |
+| forEach max iterations | 1,000 | `vmcp/config/composite_validation.go:MaxForEachIterations` | Via `WorkflowStepConfig.MaxIterations` (capped at 1,000) |
 
 ## Related
 
 - `pkg/vmcp/server/sessionmanager/factory.go` — LRU cache and `FactoryConfig`
 - `pkg/vmcp/server/server.go` — `defaultSessionTTL`, `Config.SessionTTL`
 - `pkg/transport/session/storage_redis.go` — sliding-window TTL via `GETEX`
-- `pkg/transport/session/redis_config.go` — timeout defaults
+- `github.com/stacklok/toolhive-core/redis/config.go` — Redis client config and timeout defaults
 - `docs/arch/10-virtual-mcp-architecture.md` — overall vMCP architecture
 - `docs/arch/11-auth-server-storage.md` — Redis Sentinel for auth server sessions

--- a/docs/arch/vmcp-library.md
+++ b/docs/arch/vmcp-library.md
@@ -56,6 +56,7 @@ The table below maps every sub-package to its stability level per RFC THV-0059. 
 | `pkg/vmcp/cache` | Internal | Token cache; not intended for external use |
 | `pkg/vmcp/conversion` | Internal | CRD-to-config conversion; K8s-specific, not for local embedding |
 | `pkg/vmcp/discovery` | Internal | Discovery middleware; use via aggregator, not directly |
+| `pkg/vmcp/headerforward` | Internal | Per-backend HTTP header-forwarding round-tripper; the root `headerforward` package only; `pkg/vmcp/headerforward/wirefmt` is a separate wire-format helper used by aggregator/workloads/cli/operator |
 | `pkg/vmcp/k8s` | Internal | Kubernetes-specific discovery; not for local embedding |
 | `pkg/vmcp/workloads` | Internal | Backend workload helpers for K8s mode; not for local embedding |
 | `pkg/vmcp/schema` | Internal | MCP schema parsing; subject to change |


### PR DESCRIPTION
## Summary

The architecture documentation under `docs/arch/` had drifted since the v1beta1 CRD graduation and the migration of several packages (`permissions`, `registry/types`, redis client construction, etc.) into the sibling `toolhive-core` repository. This PR refreshes all 15 affected docs so that every code reference, field path, and behavioural claim resolves against the current code in both `toolhive` and `toolhive-core`.

The refresh was produced by a two-pass review: one read-only cross-reference pass per doc (verifying every claim against the codebase), followed by a fix pass that applies confirmed drifts only.

Highlights:

- Repoint moved packages — `pkg/permissions`, `pkg/registry/types`, `pkg/registry/data/registry.json`, runtime monitor, registry-api manager.
- Expand the operator CRD inventory — add `EmbeddingServer` (Auxiliary, StatefulSet) and `MCPWebhookConfig`; rename `ToolConfig` to `MCPToolConfig` in tables and relationship diagram.
- Fix CRD field paths — `spec.config.compositeToolRefs`, `spec.incomingAuth.oidcConfigRef` on `VirtualMCPServer`, `MCPGroupRef` consumers expanded to all four CRDs that reference it.
- Rewrite vMCP middleware order table to match the wrap order in `pkg/vmcp/server/server.go`; correct `Reporter` interface naming; note that the CLI logging reporter is Debug-level.
- Auth-server storage doc gains Cluster mode end-to-end (overview, diagram, CRD shape); flatten the `timeouts` CRD diagram into sibling fields; fix `sentinelTls` casing; surface `DCRCredentialStore`.
- Replace stale registry pieces — built-in catalog source, legacy top-level JSON examples (clarified as in-memory `types.Registry` shape vs on-disk `UpstreamRegistry`), registry-API endpoint paths (`/v0.1/servers`, `/v0.1/servers/:name/versions/latest`); deprecation note on `thv group run`.
- Transport doc updates — `NamedMiddleware` constructor type; MCP env vars emitted only by `pkg/runtime/setup.go`; `127.0.0.1` default lives in the config builder; SSE rewrite functions in `sse_response_processor.go`.
- Complete middleware enumeration in `02-core-concepts.md` and `05-runconfig-and-permissions.md` (adds upstreamswap, awssts, obo, ratelimit, usagemetrics, recovery, header-forward, validating-webhook, mutating-webhook); fix `authz` -> `authorization` constant.
- Restore the `pkg/secrets/types.go` reference for `EnvVarPrefix` + `Provider` interface; point the pod builder at `pkg/controllerutil/`.
- Skills doc — replace the nonexistent `skillsvc.go` references with the real file inventory; document the `GET /content` REST endpoint; mark `oci_tags` as reserved; correct the OCI artifact name-match rule (last path component).
- Smaller fixes — OrbStack added across runtime lists; runtime detection order corrected (`Podman` -> `Docker` -> `Colima`); drop bogus `TOOLHIVE_DETACHED` env var and `SENTRY_TRACES_SAMPLE_RATE` env-var fallback claim; add `unknown` and `policy_stopped` to the workload lifecycle states; add `inspector` transport.
- StatefulSet wording preserved throughout — `thv-proxyrunner` runs as a Deployment, but the MCP server pod itself is a StatefulSet created via `pkg/container/kubernetes/client.go` `applyStatefulSet`. An earlier audit got this wrong; this PR does not repeat that.

## Type of change

- [x] Documentation update

## Test plan

- [x] Cross-referenced every claim in each updated doc against the current code in `toolhive` and `toolhive-core` (read-only verification pass).
- [x] Verified each applied edit against the cited file/symbol (fix pass).
- [x] Spot-checked Mermaid diagram syntax for the modified diagrams.
- [x] Confirmed StatefulSet/Deployment wording survives the refresh (the prior audit was wrong on this; verified against `applyStatefulSet`).

## Does this introduce a user-facing change?

No — docs only.

## Special notes for reviewers

This PR is bigger than the usual 400-line / 10-file limit, which is acceptable for docs-only changes per `.claude/rules/pr-creation.md`. Per-file diffs are small except for `09-operator-architecture.md`, which had the largest structural drift (MCPRegistry source-handler section had referred to a `pkg/sources/` tree that no longer exists). The new section reflects the current model where `configYAML` is passed verbatim to the registry-api server.

One adjacent code drift was noted but **not fixed** here (out of scope): `cmd/thv-operator/controllers/mcpexternalauthconfig_controller.go:192` — the `IdentitySynthesizedInactive` message still says "All OAuth2 upstreams have userInfo configured" even though the predicate now also accepts `identityFromToken`. Worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)