### PR TITLE
Opt 12 v1beta1 CRDs into storage-version migration + CI guard

### DIFF
--- a/cmd/thv-operator/api/v1alpha1/types.go
+++ b/cmd/thv-operator/api/v1alpha1/types.go
@@ -280,6 +280,7 @@ type MCPTelemetryConfigList struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:storageversion
+//+kubebuilder:metadata:labels=toolhive.stacklok.dev/auto-migrate-storage-version=true
 //+kubebuilder:subresource:status
 //+kubebuilder:resource:shortName=mwc,categories=toolhive
 //+kubebuilder:printcolumn:name="Valid",type=string,JSONPath=`.status.conditions[?(@.type=='Valid')].status`

--- a/cmd/thv-operator/api/v1alpha1/types.go
+++ b/cmd/thv-operator/api/v1alpha1/types.go
@@ -280,8 +280,8 @@ type MCPTelemetryConfigList struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:storageversion
-//+kubebuilder:metadata:labels=toolhive.stacklok.dev/auto-migrate-storage-version=true
 //+kubebuilder:subresource:status
+//+kubebuilder:metadata:labels=toolhive.stacklok.dev/auto-migrate-storage-version=true
 //+kubebuilder:resource:shortName=mwc,categories=toolhive
 //+kubebuilder:printcolumn:name="Valid",type=string,JSONPath=`.status.conditions[?(@.type=='Valid')].status`
 //+kubebuilder:printcolumn:name="References",type=string,JSONPath=`.status.referencingWorkloads`

--- a/cmd/thv-operator/api/v1beta1/embeddingserver_types.go
+++ b/cmd/thv-operator/api/v1beta1/embeddingserver_types.go
@@ -211,6 +211,7 @@ const (
 //+kubebuilder:object:root=true
 //+kubebuilder:storageversion
 //+kubebuilder:subresource:status
+//+kubebuilder:metadata:labels=toolhive.stacklok.dev/auto-migrate-storage-version=true
 //+kubebuilder:resource:shortName=emb;embedding,categories=toolhive
 //+kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.phase"
 //+kubebuilder:printcolumn:name="Model",type="string",JSONPath=".spec.model"

--- a/cmd/thv-operator/api/v1beta1/mcpexternalauthconfig_types.go
+++ b/cmd/thv-operator/api/v1beta1/mcpexternalauthconfig_types.go
@@ -1117,6 +1117,7 @@ type MCPExternalAuthConfigStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
+// +kubebuilder:metadata:labels=toolhive.stacklok.dev/auto-migrate-storage-version=true
 // +kubebuilder:resource:shortName=extauth;mcpextauth,categories=toolhive
 // +kubebuilder:printcolumn:name="Type",type=string,JSONPath=`.spec.type`
 // +kubebuilder:printcolumn:name="Valid",type=string,JSONPath=`.status.conditions[?(@.type=='Valid')].status`

--- a/cmd/thv-operator/api/v1beta1/mcpgroup_types.go
+++ b/cmd/thv-operator/api/v1beta1/mcpgroup_types.go
@@ -88,6 +88,7 @@ const (
 //+kubebuilder:object:root=true
 //+kubebuilder:storageversion
 //+kubebuilder:subresource:status
+//+kubebuilder:metadata:labels=toolhive.stacklok.dev/auto-migrate-storage-version=true
 //+kubebuilder:resource:shortName=mcpg;mcpgroup,categories=toolhive
 //+kubebuilder:printcolumn:name="Servers",type="integer",JSONPath=".status.serverCount"
 //+kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase"

--- a/cmd/thv-operator/api/v1beta1/mcpoidcconfig_types.go
+++ b/cmd/thv-operator/api/v1beta1/mcpoidcconfig_types.go
@@ -200,6 +200,7 @@ type MCPOIDCConfigStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
+// +kubebuilder:metadata:labels=toolhive.stacklok.dev/auto-migrate-storage-version=true
 // +kubebuilder:resource:shortName=mcpoidc,categories=toolhive
 // +kubebuilder:printcolumn:name="Source",type=string,JSONPath=`.spec.type`
 // +kubebuilder:printcolumn:name="Valid",type=string,JSONPath=`.status.conditions[?(@.type=='Valid')].status`

--- a/cmd/thv-operator/api/v1beta1/mcpregistry_types.go
+++ b/cmd/thv-operator/api/v1beta1/mcpregistry_types.go
@@ -205,6 +205,7 @@ const (
 //+kubebuilder:object:root=true
 //+kubebuilder:storageversion
 //+kubebuilder:subresource:status
+//+kubebuilder:metadata:labels=toolhive.stacklok.dev/auto-migrate-storage-version=true
 //+kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.phase"
 //+kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"
 //+kubebuilder:printcolumn:name="Replicas",type="integer",JSONPath=".status.readyReplicas"

--- a/cmd/thv-operator/api/v1beta1/mcpremoteproxy_types.go
+++ b/cmd/thv-operator/api/v1beta1/mcpremoteproxy_types.go
@@ -356,6 +356,7 @@ const (
 //+kubebuilder:object:root=true
 //+kubebuilder:storageversion
 //+kubebuilder:subresource:status
+//+kubebuilder:metadata:labels=toolhive.stacklok.dev/auto-migrate-storage-version=true
 //+kubebuilder:resource:shortName=rp;mcprp,categories=toolhive
 //+kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase"
 //+kubebuilder:printcolumn:name="Remote URL",type="string",JSONPath=".spec.remoteUrl"

--- a/cmd/thv-operator/api/v1beta1/mcpserver_types.go
+++ b/cmd/thv-operator/api/v1beta1/mcpserver_types.go
@@ -929,6 +929,7 @@ const (
 //+kubebuilder:object:root=true
 //+kubebuilder:storageversion
 //+kubebuilder:subresource:status
+//+kubebuilder:metadata:labels=toolhive.stacklok.dev/auto-migrate-storage-version=true
 //+kubebuilder:resource:shortName=mcpserver;mcpservers,categories=toolhive
 //+kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.phase"
 //+kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"

--- a/cmd/thv-operator/api/v1beta1/mcpserverentry_types.go
+++ b/cmd/thv-operator/api/v1beta1/mcpserverentry_types.go
@@ -164,6 +164,7 @@ const (
 //+kubebuilder:object:root=true
 //+kubebuilder:storageversion
 //+kubebuilder:subresource:status
+//+kubebuilder:metadata:labels=toolhive.stacklok.dev/auto-migrate-storage-version=true
 //+kubebuilder:resource:shortName=mcpentry,categories=toolhive
 //+kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase"
 //+kubebuilder:printcolumn:name="Transport",type="string",JSONPath=".spec.transport"

--- a/cmd/thv-operator/api/v1beta1/mcptelemetryconfig_types.go
+++ b/cmd/thv-operator/api/v1beta1/mcptelemetryconfig_types.go
@@ -139,6 +139,7 @@ type MCPTelemetryConfigStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
+// +kubebuilder:metadata:labels=toolhive.stacklok.dev/auto-migrate-storage-version=true
 // +kubebuilder:resource:shortName=mcpotel,categories=toolhive
 // +kubebuilder:printcolumn:name="Endpoint",type=string,JSONPath=`.spec.openTelemetry.endpoint`
 // +kubebuilder:printcolumn:name="Valid",type=string,JSONPath=`.status.conditions[?(@.type=='Valid')].status`

--- a/cmd/thv-operator/api/v1beta1/toolconfig_types.go
+++ b/cmd/thv-operator/api/v1beta1/toolconfig_types.go
@@ -112,6 +112,7 @@ type MCPToolConfigStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
+// +kubebuilder:metadata:labels=toolhive.stacklok.dev/auto-migrate-storage-version=true
 // +kubebuilder:resource:shortName=tc;toolconfig,categories=toolhive
 // +kubebuilder:printcolumn:name="Valid",type=string,JSONPath=`.status.conditions[?(@.type=='Valid')].status`
 // +kubebuilder:printcolumn:name="References",type=integer,JSONPath=`.status.referenceCount`

--- a/cmd/thv-operator/api/v1beta1/virtualmcpcompositetooldefinition_types.go
+++ b/cmd/thv-operator/api/v1beta1/virtualmcpcompositetooldefinition_types.go
@@ -100,6 +100,7 @@ const (
 //+kubebuilder:object:root=true
 //+kubebuilder:storageversion
 //+kubebuilder:subresource:status
+//+kubebuilder:metadata:labels=toolhive.stacklok.dev/auto-migrate-storage-version=true
 //+kubebuilder:resource:shortName=vmcpctd;compositetool,categories=toolhive
 //+kubebuilder:printcolumn:name="Workflow",type="string",JSONPath=".spec.name",description="Workflow name"
 //+kubebuilder:printcolumn:name="Steps",type="integer",JSONPath=".spec.steps[*]",description="Number of steps"

--- a/cmd/thv-operator/api/v1beta1/virtualmcpserver_types.go
+++ b/cmd/thv-operator/api/v1beta1/virtualmcpserver_types.go
@@ -467,6 +467,7 @@ const (
 //+kubebuilder:object:root=true
 //+kubebuilder:storageversion
 //+kubebuilder:subresource:status
+//+kubebuilder:metadata:labels=toolhive.stacklok.dev/auto-migrate-storage-version=true
 //+kubebuilder:resource:shortName=vmcp;virtualmcp,categories=toolhive
 //+kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase",description="The phase of the VirtualMCPServer"
 //+kubebuilder:printcolumn:name="URL",type="string",JSONPath=".status.url",description="Virtual MCP server URL"

--- a/cmd/thv-operator/controllers/marker_coverage_test.go
+++ b/cmd/thv-operator/controllers/marker_coverage_test.go
@@ -1,0 +1,151 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package controllers
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestV1beta1TypesMarkerCoverage guards against a subtle failure mode in the
+// opt-in-label design for storage-version migration: if a new CRD root type is
+// added to cmd/thv-operator/api/v1beta1/ without the
+//
+//	+kubebuilder:metadata:labels=toolhive.stacklok.dev/auto-migrate-storage-version=true
+//
+// marker, the StorageVersionMigrator controller silently excludes it from
+// reconciliation. The problem surfaces only when a future release tries to
+// drop a deprecated version — at which point it is far too late.
+//
+// The test scans every root type (marker block contains
+// +kubebuilder:object:root=true AND +kubebuilder:storageversion) and fails if
+// any lacks either the migrate marker or an explicit
+// +thv:storage-version-migrator:exclude sibling marker. List types
+// (+kubebuilder:object:root=true WITHOUT +kubebuilder:storageversion) are
+// intentionally skipped — CRD-level labels are keyed on the root type, not
+// the list type.
+func TestV1beta1TypesMarkerCoverage(t *testing.T) {
+	t.Parallel()
+
+	typesDir := filepath.Join("..", "api", "v1beta1")
+	entries, err := os.ReadDir(typesDir)
+	require.NoError(t, err, "reading %s", typesDir)
+
+	const (
+		rootMarker         = "+kubebuilder:object:root=true"
+		storageMarker      = "+kubebuilder:storageversion"
+		migrateMarker      = "+kubebuilder:metadata:labels=toolhive.stacklok.dev/auto-migrate-storage-version=true"
+		excludeMarker      = "+thv:storage-version-migrator:exclude"
+		groupversionInfoGo = "groupversion_info.go"
+		zzGeneratedPrefix  = "zz_generated"
+		suffixTypesGo      = "_types.go"
+	)
+
+	type rootType struct {
+		file        string
+		typeName    string
+		markerBlock []string
+	}
+
+	var roots []rootType
+
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if !strings.HasSuffix(name, suffixTypesGo) {
+			continue
+		}
+		if name == groupversionInfoGo || strings.HasPrefix(name, zzGeneratedPrefix) {
+			continue
+		}
+
+		path := filepath.Join(typesDir, name)
+		f, err := os.Open(path)
+		require.NoError(t, err, "open %s", path)
+
+		scanner := bufio.NewScanner(f)
+		// Raise the max token size — some of the *_types.go files have very
+		// long comment lines (printcolumn JSONPath expressions).
+		scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+
+		var block []string
+		for scanner.Scan() {
+			line := strings.TrimSpace(scanner.Text())
+
+			switch {
+			case strings.HasPrefix(line, "//"):
+				// Accumulate every comment/marker line. kubebuilder convention
+				// often separates markers from the godoc comment with a blank
+				// line, so we keep the block alive across blanks and only
+				// reset on a non-comment, non-blank, non-type line.
+				block = append(block, strings.TrimSpace(strings.TrimPrefix(line, "//")))
+			case strings.HasPrefix(line, "type "):
+				// Only root-level types matter (must contain object:root=true
+				// AND storageversion markers). List types have only object:root=true.
+				if containsMarker(block, rootMarker) && containsMarker(block, storageMarker) {
+					typeName := extractTypeName(line)
+					if typeName != "" {
+						copied := append([]string(nil), block...)
+						roots = append(roots, rootType{file: name, typeName: typeName, markerBlock: copied})
+					}
+				}
+				block = nil
+			case line == "":
+				// Blank line — keep block alive (comment-then-blank-then-type
+				// is idiomatic Go + kubebuilder).
+			default:
+				// Anything else (e.g. struct body, package clause, import) —
+				// drop any in-flight comment block.
+				block = nil
+			}
+		}
+		require.NoError(t, scanner.Err(), "scan %s", path)
+		require.NoError(t, f.Close())
+	}
+
+	require.NotEmpty(t, roots,
+		"no v1beta1 root types found — scanner likely broken; this test is meaningless without coverage")
+
+	for _, r := range roots {
+		hasMigrate := containsMarker(r.markerBlock, migrateMarker)
+		hasExclude := containsMarker(r.markerBlock, excludeMarker)
+		assert.Truef(t, hasMigrate || hasExclude,
+			"v1beta1 root type %s.%s is missing either\n"+
+				"  %s\n"+
+				"(opt in to storage-version migration) or\n"+
+				"  %s\n"+
+				"(explicit opt-out). Every root type must declare one. See\n"+
+				"cmd/thv-operator/controllers/storageversionmigrator_controller.go for context.",
+			r.file, r.typeName, migrateMarker, excludeMarker)
+	}
+}
+
+// containsMarker returns true if any line in block contains the given
+// marker substring.
+func containsMarker(block []string, marker string) bool {
+	for _, l := range block {
+		if strings.Contains(l, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+// extractTypeName returns the identifier in a line of the form `type Foo struct {`.
+// Returns empty string if the line is not a type declaration we care about.
+func extractTypeName(line string) string {
+	fields := strings.Fields(line)
+	if len(fields) < 2 || fields[0] != "type" {
+		return ""
+	}
+	return fields[1]
+}

--- a/cmd/thv-operator/controllers/marker_coverage_test.go
+++ b/cmd/thv-operator/controllers/marker_coverage_test.go
@@ -158,25 +158,61 @@ func TestStorageVersionRootMarkerCoverage(t *testing.T) {
 			"+kubebuilder:storageversion marker; this test is meaningless without coverage")
 
 	for _, r := range roots {
+		key := r.version + "/" + r.file + "." + r.typeName
+		if _, allowed := excludedRootTypes[key]; allowed {
+			continue
+		}
 		assert.Truef(t, containsMarker(r.markerBlock, migrateMarker),
-			"root type %s/%s.%s is missing the storage-version migrate marker:\n"+
+			"root type %s is missing the storage-version migrate marker:\n"+
 				"  %s\n"+
 				"Every root type carrying +kubebuilder:storageversion must declare it.\n"+
 				"See cmd/thv-operator/controllers/storageversionmigrator_controller.go\n"+
 				"for context. There is no opt-out marker — if a CRD legitimately\n"+
 				"should not be auto-migrated, raise it as a PR review conversation\n"+
-				"and update the test's allowlist explicitly.",
-			r.version, r.file, r.typeName, migrateMarker)
+				"and add an entry to excludedRootTypes in this file.",
+			key, migrateMarker)
 	}
 }
 
-// containsMarker returns true if any line in block contains the given
-// marker substring.
+// excludedRootTypes is the (intentionally empty) allowlist of storage-version
+// root types that are deliberately not auto-migrated. Entries are keyed by
+// "<version>/<file>.<TypeName>" (e.g. "v1alpha1/types.go.MCPSomething").
+//
+// Adding an entry here is a deliberate, reviewed decision — not a self-serve
+// escape hatch. If a future CRD legitimately cannot or should not participate
+// in storage-version migration:
+//
+//  1. Open a PR with the entry added here.
+//  2. Make the case in the PR description: why is this CRD different?
+//     What happens at version-drop time if no migration ever runs?
+//  3. The reviewer should push back hard. Excluding a CRD means accepting
+//     that it can never have a version dropped without manual intervention.
+var excludedRootTypes = map[string]struct{}{
+	// Example (do not enable):
+	// "v1alpha1/types.go.MCPSomething": {},
+}
+
+// containsMarker returns true if any line in block carries the given
+// kubebuilder marker as a complete token — the marker must be followed by
+// end-of-line or whitespace.
+//
+// Strict matching matters: the migrate marker ends in "=true". A typo such
+// as "=truee" would still be a substring match under strings.Contains, the
+// test would pass, the generated CRD YAML would have label value "truee",
+// and the controller's runtime check (`labels[key] == "true"`) would
+// silently exclude the CRD. The bug would only surface at version-drop time
+// months later. Whole-token matching catches the typo at PR time.
 func containsMarker(block []string, marker string) bool {
 	for _, l := range block {
-		if strings.Contains(l, marker) {
+		idx := strings.Index(l, marker)
+		if idx < 0 {
+			continue
+		}
+		end := idx + len(marker)
+		if end == len(l) || l[end] == ' ' || l[end] == '\t' {
 			return true
 		}
+		// Marker appeared only as a prefix of a longer token — reject.
 	}
 	return false
 }
@@ -189,4 +225,37 @@ func extractTypeName(line string) string {
 		return ""
 	}
 	return fields[1]
+}
+
+// TestContainsMarkerStrictBoundary defends the whole-token match contract of
+// containsMarker. If someone "improves" it back to strings.Contains semantics,
+// the value-typo failure mode reopens silently. Keep this test as the
+// regression guard.
+func TestContainsMarkerStrictBoundary(t *testing.T) {
+	t.Parallel()
+
+	const marker = "+kubebuilder:metadata:labels=toolhive.stacklok.dev/auto-migrate-storage-version=true"
+
+	tests := []struct {
+		name string
+		line string
+		want bool
+	}{
+		{name: "exact match at end of line", line: marker, want: true},
+		{name: "marker followed by space", line: marker + " // trailing comment", want: true},
+		{name: "marker followed by tab", line: marker + "\t", want: true},
+		{name: "value typo =truee is a prefix match — must reject", line: marker + "e", want: false},
+		{name: "value typo =trueX is a prefix match — must reject", line: marker + "X", want: false},
+		{name: "marker absent", line: "+kubebuilder:object:root=true", want: false},
+		{name: "marker followed by alphanumeric — must reject", line: marker + "0", want: false},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := containsMarker([]string{tc.line}, marker)
+			assert.Equal(t, tc.want, got)
+		})
+	}
 }

--- a/cmd/thv-operator/controllers/marker_coverage_test.go
+++ b/cmd/thv-operator/controllers/marker_coverage_test.go
@@ -14,9 +14,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestV1beta1TypesMarkerCoverage guards against a subtle failure mode in the
-// opt-in-label design for storage-version migration: if a new CRD root type is
-// added to cmd/thv-operator/api/v1beta1/ without the
+// TestStorageVersionRootMarkerCoverage guards against a subtle failure mode in
+// the opt-in-label design for storage-version migration: if a new CRD root
+// type is added under cmd/thv-operator/api/ without the
 //
 //	+kubebuilder:metadata:labels=toolhive.stacklok.dev/auto-migrate-storage-version=true
 //
@@ -24,19 +24,28 @@ import (
 // reconciliation. The problem surfaces only when a future release tries to
 // drop a deprecated version — at which point it is far too late.
 //
-// The test scans every root type (marker block contains
-// +kubebuilder:object:root=true AND +kubebuilder:storageversion) and fails if
-// any lacks either the migrate marker or an explicit
-// +thv:storage-version-migrator:exclude sibling marker. List types
-// (+kubebuilder:object:root=true WITHOUT +kubebuilder:storageversion) are
-// intentionally skipped — CRD-level labels are keyed on the root type, not
-// the list type.
-func TestV1beta1TypesMarkerCoverage(t *testing.T) {
+// The test walks every cmd/thv-operator/api/v*/ directory and scans the
+// *_types.go files inside. For each type whose marker block contains both
+// +kubebuilder:object:root=true AND +kubebuilder:storageversion (i.e., the
+// current storage version's root types), it requires either the migrate
+// marker or an explicit +thv:storage-version-migrator:exclude sibling marker.
+//
+// Notes on the scope:
+//   - List types (+kubebuilder:object:root=true WITHOUT +kubebuilder:storageversion)
+//     are intentionally skipped — CRD-level labels are keyed on the root type,
+//     not the list type.
+//   - Served-but-not-storage versions (e.g. v1alpha1 during a v1alpha1→v1beta1
+//     graduation, or v1beta1 during a future v1beta1→v1beta2 graduation) are
+//     naturally filtered out by the storageversion-marker requirement.
+//   - When a future graduation moves +kubebuilder:storageversion from v1beta1
+//     to v1beta2, the test will automatically start scanning v1beta2's root
+//     types without code changes here.
+func TestStorageVersionRootMarkerCoverage(t *testing.T) {
 	t.Parallel()
 
-	typesDir := filepath.Join("..", "api", "v1beta1")
-	entries, err := os.ReadDir(typesDir)
-	require.NoError(t, err, "reading %s", typesDir)
+	apiDir := filepath.Join("..", "api")
+	versionDirs, err := os.ReadDir(apiDir)
+	require.NoError(t, err, "reading %s", apiDir)
 
 	const (
 		rootMarker         = "+kubebuilder:object:root=true"
@@ -45,10 +54,15 @@ func TestV1beta1TypesMarkerCoverage(t *testing.T) {
 		excludeMarker      = "+thv:storage-version-migrator:exclude"
 		groupversionInfoGo = "groupversion_info.go"
 		zzGeneratedPrefix  = "zz_generated"
-		suffixTypesGo      = "_types.go"
+		// Match both the modern one-type-per-file convention (e.g.
+		// mcpserver_types.go) and the legacy multi-type single-file
+		// convention (api/v1alpha1/types.go) so no root type slips through.
+		exactTypesGo  = "types.go"
+		suffixTypesGo = "_types.go"
 	)
 
 	type rootType struct {
+		version     string // e.g. "v1beta1"
 		file        string
 		typeName    string
 		markerBlock []string
@@ -56,76 +70,98 @@ func TestV1beta1TypesMarkerCoverage(t *testing.T) {
 
 	var roots []rootType
 
-	for _, e := range entries {
-		if e.IsDir() {
+	for _, vd := range versionDirs {
+		// Only descend into directories that look like an API version
+		// (v1alpha1, v1beta1, v1beta2, v1, ...). Anything else under api/ is
+		// not our concern.
+		if !vd.IsDir() || !strings.HasPrefix(vd.Name(), "v") {
 			continue
 		}
-		name := e.Name()
-		if !strings.HasSuffix(name, suffixTypesGo) {
-			continue
-		}
-		if name == groupversionInfoGo || strings.HasPrefix(name, zzGeneratedPrefix) {
-			continue
-		}
+		version := vd.Name()
+		typesDir := filepath.Join(apiDir, version)
 
-		path := filepath.Join(typesDir, name)
-		f, err := os.Open(path)
-		require.NoError(t, err, "open %s", path)
+		entries, err := os.ReadDir(typesDir)
+		require.NoError(t, err, "reading %s", typesDir)
 
-		scanner := bufio.NewScanner(f)
-		// Raise the max token size — some of the *_types.go files have very
-		// long comment lines (printcolumn JSONPath expressions).
-		scanner.Buffer(make([]byte, 64*1024), 1024*1024)
-
-		var block []string
-		for scanner.Scan() {
-			line := strings.TrimSpace(scanner.Text())
-
-			switch {
-			case strings.HasPrefix(line, "//"):
-				// Accumulate every comment/marker line. kubebuilder convention
-				// often separates markers from the godoc comment with a blank
-				// line, so we keep the block alive across blanks and only
-				// reset on a non-comment, non-blank, non-type line.
-				block = append(block, strings.TrimSpace(strings.TrimPrefix(line, "//")))
-			case strings.HasPrefix(line, "type "):
-				// Only root-level types matter (must contain object:root=true
-				// AND storageversion markers). List types have only object:root=true.
-				if containsMarker(block, rootMarker) && containsMarker(block, storageMarker) {
-					typeName := extractTypeName(line)
-					if typeName != "" {
-						copied := append([]string(nil), block...)
-						roots = append(roots, rootType{file: name, typeName: typeName, markerBlock: copied})
-					}
-				}
-				block = nil
-			case line == "":
-				// Blank line — keep block alive (comment-then-blank-then-type
-				// is idiomatic Go + kubebuilder).
-			default:
-				// Anything else (e.g. struct body, package clause, import) —
-				// drop any in-flight comment block.
-				block = nil
+		for _, e := range entries {
+			if e.IsDir() {
+				continue
 			}
+			name := e.Name()
+			if name != exactTypesGo && !strings.HasSuffix(name, suffixTypesGo) {
+				continue
+			}
+			if name == groupversionInfoGo || strings.HasPrefix(name, zzGeneratedPrefix) {
+				continue
+			}
+
+			path := filepath.Join(typesDir, name)
+			f, err := os.Open(path)
+			require.NoError(t, err, "open %s", path)
+
+			scanner := bufio.NewScanner(f)
+			// Raise the max token size — some of the *_types.go files have very
+			// long comment lines (printcolumn JSONPath expressions).
+			scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+
+			var block []string
+			for scanner.Scan() {
+				line := strings.TrimSpace(scanner.Text())
+
+				switch {
+				case strings.HasPrefix(line, "//"):
+					// Accumulate every comment/marker line. kubebuilder convention
+					// often separates markers from the godoc comment with a blank
+					// line, so we keep the block alive across blanks and only
+					// reset on a non-comment, non-blank, non-type line.
+					block = append(block, strings.TrimSpace(strings.TrimPrefix(line, "//")))
+				case strings.HasPrefix(line, "type "):
+					// Only root-level types matter (must contain object:root=true
+					// AND storageversion markers). List types have only object:root=true.
+					if containsMarker(block, rootMarker) && containsMarker(block, storageMarker) {
+						typeName := extractTypeName(line)
+						if typeName != "" {
+							copied := append([]string(nil), block...)
+							roots = append(roots, rootType{
+								version:     version,
+								file:        name,
+								typeName:    typeName,
+								markerBlock: copied,
+							})
+						}
+					}
+					block = nil
+				case line == "":
+					// Blank line — keep block alive (comment-then-blank-then-type
+					// is idiomatic Go + kubebuilder).
+				default:
+					// Anything else (e.g. struct body, package clause, import) —
+					// drop any in-flight comment block.
+					block = nil
+				}
+			}
+			require.NoError(t, scanner.Err(), "scan %s", path)
+			require.NoError(t, f.Close())
 		}
-		require.NoError(t, scanner.Err(), "scan %s", path)
-		require.NoError(t, f.Close())
 	}
 
 	require.NotEmpty(t, roots,
-		"no v1beta1 root types found — scanner likely broken; this test is meaningless without coverage")
+		"no storage-version root types found under cmd/thv-operator/api/ — "+
+			"scanner likely broken or no version directory carries the "+
+			"+kubebuilder:storageversion marker; this test is meaningless without coverage")
 
 	for _, r := range roots {
 		hasMigrate := containsMarker(r.markerBlock, migrateMarker)
 		hasExclude := containsMarker(r.markerBlock, excludeMarker)
 		assert.Truef(t, hasMigrate || hasExclude,
-			"v1beta1 root type %s.%s is missing either\n"+
+			"root type %s/%s.%s is missing either\n"+
 				"  %s\n"+
 				"(opt in to storage-version migration) or\n"+
 				"  %s\n"+
-				"(explicit opt-out). Every root type must declare one. See\n"+
+				"(explicit opt-out). Every root type carrying +kubebuilder:storageversion\n"+
+				"must declare one. See\n"+
 				"cmd/thv-operator/controllers/storageversionmigrator_controller.go for context.",
-			r.file, r.typeName, migrateMarker, excludeMarker)
+			r.version, r.file, r.typeName, migrateMarker, excludeMarker)
 	}
 }
 

--- a/cmd/thv-operator/controllers/marker_coverage_test.go
+++ b/cmd/thv-operator/controllers/marker_coverage_test.go
@@ -251,7 +251,6 @@ func TestContainsMarkerStrictBoundary(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			got := containsMarker([]string{tc.line}, marker)

--- a/cmd/thv-operator/controllers/marker_coverage_test.go
+++ b/cmd/thv-operator/controllers/marker_coverage_test.go
@@ -25,10 +25,18 @@ import (
 // drop a deprecated version — at which point it is far too late.
 //
 // The test walks every cmd/thv-operator/api/v*/ directory and scans the
-// *_types.go files inside. For each type whose marker block contains both
-// +kubebuilder:object:root=true AND +kubebuilder:storageversion (i.e., the
-// current storage version's root types), it requires either the migrate
-// marker or an explicit +thv:storage-version-migrator:exclude sibling marker.
+// *_types.go (and legacy types.go) files inside. For each type whose marker
+// block contains both +kubebuilder:object:root=true AND
+// +kubebuilder:storageversion (i.e., the current storage version's root
+// types), it requires the migrate marker. No escape hatch — every
+// storage-version root must opt in.
+//
+// Why no escape hatch? An "exclude" marker would let a single-version CRD
+// declare "don't auto-migrate me", but at graduation time the developer
+// must remember to swap exclude→migrate. Forgetting the swap reintroduces
+// the silent-skip failure mode the test is meant to prevent. If a CRD ever
+// legitimately needs to be excluded, handle it as a one-off PR conversation
+// (e.g. a hardcoded allowlist here) rather than a self-serve marker.
 //
 // Notes on the scope:
 //   - List types (+kubebuilder:object:root=true WITHOUT +kubebuilder:storageversion)
@@ -51,7 +59,6 @@ func TestStorageVersionRootMarkerCoverage(t *testing.T) {
 		rootMarker         = "+kubebuilder:object:root=true"
 		storageMarker      = "+kubebuilder:storageversion"
 		migrateMarker      = "+kubebuilder:metadata:labels=toolhive.stacklok.dev/auto-migrate-storage-version=true"
-		excludeMarker      = "+thv:storage-version-migrator:exclude"
 		groupversionInfoGo = "groupversion_info.go"
 		zzGeneratedPrefix  = "zz_generated"
 		// Match both the modern one-type-per-file convention (e.g.
@@ -151,17 +158,15 @@ func TestStorageVersionRootMarkerCoverage(t *testing.T) {
 			"+kubebuilder:storageversion marker; this test is meaningless without coverage")
 
 	for _, r := range roots {
-		hasMigrate := containsMarker(r.markerBlock, migrateMarker)
-		hasExclude := containsMarker(r.markerBlock, excludeMarker)
-		assert.Truef(t, hasMigrate || hasExclude,
-			"root type %s/%s.%s is missing either\n"+
+		assert.Truef(t, containsMarker(r.markerBlock, migrateMarker),
+			"root type %s/%s.%s is missing the storage-version migrate marker:\n"+
 				"  %s\n"+
-				"(opt in to storage-version migration) or\n"+
-				"  %s\n"+
-				"(explicit opt-out). Every root type carrying +kubebuilder:storageversion\n"+
-				"must declare one. See\n"+
-				"cmd/thv-operator/controllers/storageversionmigrator_controller.go for context.",
-			r.version, r.file, r.typeName, migrateMarker, excludeMarker)
+				"Every root type carrying +kubebuilder:storageversion must declare it.\n"+
+				"See cmd/thv-operator/controllers/storageversionmigrator_controller.go\n"+
+				"for context. There is no opt-out marker — if a CRD legitimately\n"+
+				"should not be auto-migrated, raise it as a PR review conversation\n"+
+				"and update the test's allowlist explicitly.",
+			r.version, r.file, r.typeName, migrateMarker)
 	}
 }
 

--- a/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_embeddingservers.yaml
+++ b/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_embeddingservers.yaml
@@ -4,6 +4,8 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.3
+  labels:
+    toolhive.stacklok.dev/auto-migrate-storage-version: "true"
   name: embeddingservers.toolhive.stacklok.dev
 spec:
   group: toolhive.stacklok.dev

--- a/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpexternalauthconfigs.yaml
+++ b/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpexternalauthconfigs.yaml
@@ -4,6 +4,8 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.3
+  labels:
+    toolhive.stacklok.dev/auto-migrate-storage-version: "true"
   name: mcpexternalauthconfigs.toolhive.stacklok.dev
 spec:
   group: toolhive.stacklok.dev

--- a/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpgroups.yaml
+++ b/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpgroups.yaml
@@ -4,6 +4,8 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.3
+  labels:
+    toolhive.stacklok.dev/auto-migrate-storage-version: "true"
   name: mcpgroups.toolhive.stacklok.dev
 spec:
   group: toolhive.stacklok.dev

--- a/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpoidcconfigs.yaml
+++ b/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpoidcconfigs.yaml
@@ -4,6 +4,8 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.3
+  labels:
+    toolhive.stacklok.dev/auto-migrate-storage-version: "true"
   name: mcpoidcconfigs.toolhive.stacklok.dev
 spec:
   group: toolhive.stacklok.dev

--- a/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpregistries.yaml
+++ b/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpregistries.yaml
@@ -4,6 +4,8 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.3
+  labels:
+    toolhive.stacklok.dev/auto-migrate-storage-version: "true"
   name: mcpregistries.toolhive.stacklok.dev
 spec:
   group: toolhive.stacklok.dev

--- a/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpremoteproxies.yaml
+++ b/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpremoteproxies.yaml
@@ -4,6 +4,8 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.3
+  labels:
+    toolhive.stacklok.dev/auto-migrate-storage-version: "true"
   name: mcpremoteproxies.toolhive.stacklok.dev
 spec:
   group: toolhive.stacklok.dev

--- a/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpserverentries.yaml
+++ b/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpserverentries.yaml
@@ -4,6 +4,8 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.3
+  labels:
+    toolhive.stacklok.dev/auto-migrate-storage-version: "true"
   name: mcpserverentries.toolhive.stacklok.dev
 spec:
   group: toolhive.stacklok.dev

--- a/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpservers.yaml
+++ b/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpservers.yaml
@@ -4,6 +4,8 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.3
+  labels:
+    toolhive.stacklok.dev/auto-migrate-storage-version: "true"
   name: mcpservers.toolhive.stacklok.dev
 spec:
   group: toolhive.stacklok.dev

--- a/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcptelemetryconfigs.yaml
+++ b/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcptelemetryconfigs.yaml
@@ -4,6 +4,8 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.3
+  labels:
+    toolhive.stacklok.dev/auto-migrate-storage-version: "true"
   name: mcptelemetryconfigs.toolhive.stacklok.dev
 spec:
   group: toolhive.stacklok.dev

--- a/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcptoolconfigs.yaml
+++ b/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcptoolconfigs.yaml
@@ -4,6 +4,8 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.3
+  labels:
+    toolhive.stacklok.dev/auto-migrate-storage-version: "true"
   name: mcptoolconfigs.toolhive.stacklok.dev
 spec:
   group: toolhive.stacklok.dev

--- a/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpwebhookconfigs.yaml
+++ b/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpwebhookconfigs.yaml
@@ -4,6 +4,8 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.3
+  labels:
+    toolhive.stacklok.dev/auto-migrate-storage-version: "true"
   name: mcpwebhookconfigs.toolhive.stacklok.dev
 spec:
   group: toolhive.stacklok.dev

--- a/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_virtualmcpcompositetooldefinitions.yaml
+++ b/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_virtualmcpcompositetooldefinitions.yaml
@@ -4,6 +4,8 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.3
+  labels:
+    toolhive.stacklok.dev/auto-migrate-storage-version: "true"
   name: virtualmcpcompositetooldefinitions.toolhive.stacklok.dev
 spec:
   group: toolhive.stacklok.dev

--- a/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_virtualmcpservers.yaml
+++ b/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_virtualmcpservers.yaml
@@ -4,6 +4,8 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.3
+  labels:
+    toolhive.stacklok.dev/auto-migrate-storage-version: "true"
   name: virtualmcpservers.toolhive.stacklok.dev
 spec:
   group: toolhive.stacklok.dev

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_embeddingservers.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_embeddingservers.yaml
@@ -7,6 +7,8 @@ metadata:
     helm.sh/resource-policy: keep
     {{- end }}
     controller-gen.kubebuilder.io/version: v0.17.3
+  labels:
+    toolhive.stacklok.dev/auto-migrate-storage-version: "true"
   name: embeddingservers.toolhive.stacklok.dev
 spec:
   group: toolhive.stacklok.dev

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpexternalauthconfigs.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpexternalauthconfigs.yaml
@@ -7,6 +7,8 @@ metadata:
     helm.sh/resource-policy: keep
     {{- end }}
     controller-gen.kubebuilder.io/version: v0.17.3
+  labels:
+    toolhive.stacklok.dev/auto-migrate-storage-version: "true"
   name: mcpexternalauthconfigs.toolhive.stacklok.dev
 spec:
   group: toolhive.stacklok.dev

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpgroups.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpgroups.yaml
@@ -7,6 +7,8 @@ metadata:
     helm.sh/resource-policy: keep
     {{- end }}
     controller-gen.kubebuilder.io/version: v0.17.3
+  labels:
+    toolhive.stacklok.dev/auto-migrate-storage-version: "true"
   name: mcpgroups.toolhive.stacklok.dev
 spec:
   group: toolhive.stacklok.dev

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpoidcconfigs.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpoidcconfigs.yaml
@@ -7,6 +7,8 @@ metadata:
     helm.sh/resource-policy: keep
     {{- end }}
     controller-gen.kubebuilder.io/version: v0.17.3
+  labels:
+    toolhive.stacklok.dev/auto-migrate-storage-version: "true"
   name: mcpoidcconfigs.toolhive.stacklok.dev
 spec:
   group: toolhive.stacklok.dev

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpregistries.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpregistries.yaml
@@ -7,6 +7,8 @@ metadata:
     helm.sh/resource-policy: keep
     {{- end }}
     controller-gen.kubebuilder.io/version: v0.17.3
+  labels:
+    toolhive.stacklok.dev/auto-migrate-storage-version: "true"
   name: mcpregistries.toolhive.stacklok.dev
 spec:
   group: toolhive.stacklok.dev

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpremoteproxies.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpremoteproxies.yaml
@@ -7,6 +7,8 @@ metadata:
     helm.sh/resource-policy: keep
     {{- end }}
     controller-gen.kubebuilder.io/version: v0.17.3
+  labels:
+    toolhive.stacklok.dev/auto-migrate-storage-version: "true"
   name: mcpremoteproxies.toolhive.stacklok.dev
 spec:
   group: toolhive.stacklok.dev

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpserverentries.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpserverentries.yaml
@@ -7,6 +7,8 @@ metadata:
     helm.sh/resource-policy: keep
     {{- end }}
     controller-gen.kubebuilder.io/version: v0.17.3
+  labels:
+    toolhive.stacklok.dev/auto-migrate-storage-version: "true"
   name: mcpserverentries.toolhive.stacklok.dev
 spec:
   group: toolhive.stacklok.dev

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpservers.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpservers.yaml
@@ -7,6 +7,8 @@ metadata:
     helm.sh/resource-policy: keep
     {{- end }}
     controller-gen.kubebuilder.io/version: v0.17.3
+  labels:
+    toolhive.stacklok.dev/auto-migrate-storage-version: "true"
   name: mcpservers.toolhive.stacklok.dev
 spec:
   group: toolhive.stacklok.dev

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcptelemetryconfigs.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcptelemetryconfigs.yaml
@@ -7,6 +7,8 @@ metadata:
     helm.sh/resource-policy: keep
     {{- end }}
     controller-gen.kubebuilder.io/version: v0.17.3
+  labels:
+    toolhive.stacklok.dev/auto-migrate-storage-version: "true"
   name: mcptelemetryconfigs.toolhive.stacklok.dev
 spec:
   group: toolhive.stacklok.dev

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcptoolconfigs.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcptoolconfigs.yaml
@@ -7,6 +7,8 @@ metadata:
     helm.sh/resource-policy: keep
     {{- end }}
     controller-gen.kubebuilder.io/version: v0.17.3
+  labels:
+    toolhive.stacklok.dev/auto-migrate-storage-version: "true"
   name: mcptoolconfigs.toolhive.stacklok.dev
 spec:
   group: toolhive.stacklok.dev

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpwebhookconfigs.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpwebhookconfigs.yaml
@@ -7,6 +7,8 @@ metadata:
     helm.sh/resource-policy: keep
     {{- end }}
     controller-gen.kubebuilder.io/version: v0.17.3
+  labels:
+    toolhive.stacklok.dev/auto-migrate-storage-version: "true"
   name: mcpwebhookconfigs.toolhive.stacklok.dev
 spec:
   group: toolhive.stacklok.dev

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_virtualmcpcompositetooldefinitions.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_virtualmcpcompositetooldefinitions.yaml
@@ -7,6 +7,8 @@ metadata:
     helm.sh/resource-policy: keep
     {{- end }}
     controller-gen.kubebuilder.io/version: v0.17.3
+  labels:
+    toolhive.stacklok.dev/auto-migrate-storage-version: "true"
   name: virtualmcpcompositetooldefinitions.toolhive.stacklok.dev
 spec:
   group: toolhive.stacklok.dev

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_virtualmcpservers.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_virtualmcpservers.yaml
@@ -7,6 +7,8 @@ metadata:
     helm.sh/resource-policy: keep
     {{- end }}
     controller-gen.kubebuilder.io/version: v0.17.3
+  labels:
+    toolhive.stacklok.dev/auto-migrate-storage-version: "true"
   name: virtualmcpservers.toolhive.stacklok.dev
 spec:
   group: toolhive.stacklok.dev


### PR DESCRIPTION
## Summary

Adds the opt-in label that the StorageVersionMigrator controller (shipped in #5362) requires to act on a CRD, and a CI guard that prevents future CRD additions from silently skipping migration.

This is **PR-B** of the three-PR sequence for #4969. PR-A (#5362) shipped the controller behind a default-off env-var flag. PR-B (this one) labels every storage-version root type and adds the marker-coverage CI guard. PR-C (next) flips the default to on and ships the helm chart surface + user docs.

Part of #4969. Depends on #5362 (merged).

<details>
<summary><strong>Medium level</strong></summary>

- Adds `+kubebuilder:metadata:labels=toolhive.stacklok.dev/auto-migrate-storage-version=true` to **every storage-version root type** under `cmd/thv-operator/api/`. That's the 12 root types under `api/v1beta1/` plus `MCPWebhookConfig` under `api/v1alpha1/types.go` (the only CRD whose storage version is still v1alpha1). Regenerated CRD YAML so the label appears in `metadata.labels` on every CRD the chart ships.
- New CI test `TestStorageVersionRootMarkerCoverage` in `cmd/thv-operator/controllers/marker_coverage_test.go`. Walks every `cmd/thv-operator/api/v*/` directory and scans `types.go` and `*_types.go`. For every root type carrying both `+kubebuilder:object:root=true` AND `+kubebuilder:storageversion`, the migrate marker is required. **No escape hatch** — if a CRD legitimately should not be auto-migrated, an entry is added to a hardcoded allowlist (`excludedRootTypes` in the same file, currently empty) via PR review, not via a self-serve marker.
- Marker match is **whole-token strict**, not substring. A typo such as `=truee` would pass a substring match but fail the controller's runtime check (`labels[key] == "true"`), silently excluding the CRD. The strict match catches it at PR time. `TestContainsMarkerStrictBoundary` defends the boundary contract against future regressions.
- No code logic changes, no chart-side changes, no default flip. The controller in main is still default-off; PR-B's only behavioural effect is that **if** an admin opts in via the env var, the migrator will now actually find labeled CRDs to act on.

</details>

<details>
<summary><strong>Low level</strong></summary>

| File | Change |
|------|--------|
| `cmd/thv-operator/api/v1beta1/*_types.go` (×12) | `+kubebuilder:metadata:labels=...auto-migrate-storage-version=true` marker on each root type |
| `cmd/thv-operator/api/v1alpha1/types.go` | Same marker added to `MCPWebhookConfig` (the only never-graduated storage-version root) |
| `cmd/thv-operator/controllers/marker_coverage_test.go` | New static-source CI test — scans all `api/v*/` directories, requires migrate marker on every storage-version root, supports an `excludedRootTypes` allowlist for documented exclusions |
| `deploy/charts/operator-crds/files/crds/*.yaml` (×13) | Regenerated — label in `metadata.labels` |
| `deploy/charts/operator-crds/templates/*.yaml` (×13) | Regenerated — same |

</details>

## Type of change

- [x] New feature (additive — extends an already-shipped feature flag)
- [ ] Bug fix
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

## Test plan

- [x] `TestStorageVersionRootMarkerCoverage` passes (scans every root type across all API version dirs, asserts marker presence)
- [x] `TestContainsMarkerStrictBoundary` passes (7 subtests covering exact match, whitespace boundary, value-typo rejection — defends against future regression to permissive substring matching)
- [x] `task operator-manifests` produces no diff after the markers — labels land in CRD YAML cleanly
- [x] Full operator test suite green: `go test -race ./cmd/thv-operator/...`
- [x] envtest suites green including the StorageVersionMigrator suite from PR-A
- [ ] `task lint-fix` — known to be blocked locally by a pre-existing toolchain mismatch (`golangci-lint` built against go1.25 vs repo's go1.26 target); not introduced by this PR

## Why the CI guard matters

Without `TestStorageVersionRootMarkerCoverage`:

1. Someone adds a new CRD root type and forgets the marker.
2. `task operator-manifests` regenerates without the opt-in label.
3. The controller's `isManagedCRD` check returns false for that new CRD; CRs of that kind never get re-encoded.
4. The bug stays invisible until a future release tries to drop a deprecated version from `spec.versions` — at which point storedVersions still contains the deprecated version and the apiserver rejects the CRD update.
5. Diagnosis trail is long cold; the missed marker was on a PR that landed months earlier.

With the test, the PR adding the new CRD fails CI with a clear pointer to the missing marker.

The test is **forward-compatible**: when a future v1beta2 graduation moves `+kubebuilder:storageversion` from v1beta1 root types to v1beta2 root types, the scanner picks up the new directory automatically without code changes here. The previous version's root types lose the storage marker and are naturally filtered out.

## Design choice: no escape hatch

An earlier iteration of this test accepted either the migrate marker or an explicit `+thv:storage-version-migrator:exclude` sibling. That permissive contract opens a graduation-time hole: a single-version CRD created with `exclude` passes CI, but at v1→v2 graduation time the developer has to remember to swap exclude→migrate. Forgetting the swap leaves the CRD silently un-migrated — exactly the failure mode the test is meant to prevent.

Replaced with: every storage-version root **must** have the migrate marker, full stop. If a CRD legitimately needs to be excluded, the path is to add its `<version>/<file>.<TypeName>` key to the `excludedRootTypes` map in the test file as a deliberate, reviewed decision. The allowlist is currently empty and has an example comment showing the format.

## Why every storage-version root (not just multi-version CRDs)

Single-version CRDs today have nothing to migrate — `storedVersions == [storageVersion]`, the controller's `isMigrationNeeded` check returns false, no-op forever. But when that CRD eventually graduates to a second version, `storedVersions` accumulates the old entry and the migrator suddenly needs to know whether to act. Requiring the label from day one means graduation PRs don't need to remember to add it later. The cost of the label on a single-version CRD is zero (a string in `metadata.labels`); the cost of forgetting at graduation is silent data orphaning.

## Special notes for reviewers

- The label key `toolhive.stacklok.dev/auto-migrate-storage-version` is a **stable API surface** once shipped — users may write Kyverno rules or GitOps filters against it, so renaming becomes a breaking change.
- 13 type-file additions (one line each). The 26 generated CRD YAMLs each get the same 2 label lines. These are auto-generated; manually editing them would be wiped on the next `task operator-manifests`.
- Marker match is now whole-token-strict, not substring. A value typo like `=truee` was a real silent-failure class — controller runtime checks for exact string `"true"`, but the CI's substring `Contains` would accept `=truee` as a match. The new `containsMarker` requires the marker to be followed by end-of-line or whitespace, catching the typo at PR time. `TestContainsMarkerStrictBoundary` is the regression guard if anyone "improves" it back to substring semantics.
- No behavioural change for any user until both (a) they opt in via `TOOLHIVE_ENABLE_STORAGE_VERSION_MIGRATOR=true` AND (b) they have CRs whose etcd-stored apiVersion differs from the current storage version. Today no toolhive cluster has the former and the latter is rare.

Generated with [Claude Code](https://claude.com/claude-code)
