### PR TITLE
Free orphaned proxy port on stop and rm

### DIFF
--- a/docs/arch/08-workloads-lifecycle.md
+++ b/docs/arch/08-workloads-lifecycle.md
@@ -134,6 +134,12 @@ The same `Applier` backs both the CLI (`thv upgrade apply`) and the API (`POST /
 
 **Implementation**: `pkg/workloads/upgrade/`, `cmd/thv/app/upgrade.go`
 
+### Proxy termination
+
+Stop and delete terminate the proxy using its recorded PID. When PID-based termination is unavailable or fails (for example, the status file is missing, records no PID, or the process is already gone), they fall back to port-based cleanup: the process holding the proxy port is terminated only after it is confirmed to be this workload's proxy. This prevents an orphaned proxy from continuing to hold the port after the container has been stopped or removed.
+
+**Implementation**: `pkg/workloads/manager.go`
+
 ### List
 
 Listing combines container workloads from the runtime with remote workloads from persisted state. The manager can filter workloads by label or group, and can optionally include stopped workloads.

--- a/pkg/workloads/manager.go
+++ b/pkg/workloads/manager.go
@@ -101,6 +101,7 @@ type DefaultManager struct {
 	retryConfig     *retryConfig
 	newRunner       mcpRunnerFactory
 	detachedSpawner detachedProcessSpawner
+	portFreer       portFreer
 }
 
 // mcpRunner is the subset of *runner.Runner that RunWorkload's retry loop
@@ -122,6 +123,11 @@ type mcpRunnerFactory func(*runner.RunConfig, statuses.StatusManager) mcpRunner
 // Tests override this with a no-op so the test binary does not re-exec
 // itself.
 type detachedProcessSpawner func(ctx context.Context, runConfig *runner.RunConfig) (pid int, err error)
+
+// portFreer kills an orphaned ToolHive proxy still holding a workload's proxy
+// port. In production it is freePortHolderIfNeeded; tests override it to observe
+// the stop/delete fallback without making real OS calls.
+type portFreer func(ctx context.Context, runConfig *runner.RunConfig)
 
 // retryConfig bundles the RunWorkload retry loop's tunable parameters.
 type retryConfig struct {
@@ -160,6 +166,12 @@ func withDetachedSpawner(s detachedProcessSpawner) managerOption {
 	return func(d *DefaultManager) { d.detachedSpawner = s }
 }
 
+// withPortFreer overrides the function used to free an orphaned proxy port
+// during stop/delete. Intended for tests so they do not make real OS calls.
+func withPortFreer(f portFreer) managerOption {
+	return func(d *DefaultManager) { d.portFreer = f }
+}
+
 // retryConfigOrDefault returns the manager's retryConfig if set, otherwise defaults.
 func (d *DefaultManager) retryConfigOrDefault() retryConfig {
 	if d.retryConfig == nil {
@@ -185,6 +197,15 @@ func (d *DefaultManager) detachedSpawnerOrDefault() detachedProcessSpawner {
 		return d.detachedSpawner
 	}
 	return d.spawnDetached
+}
+
+// portFreerOrDefault returns the manager's port freer if set, otherwise the
+// production default that frees the proxy port via freePortHolderIfNeeded.
+func (d *DefaultManager) portFreerOrDefault() portFreer {
+	if d.portFreer != nil {
+		return d.portFreer
+	}
+	return d.freePortHolderIfNeeded
 }
 
 // ErrWorkloadNotRunning is returned when a container cannot be found by name.
@@ -415,9 +436,10 @@ func (d *DefaultManager) stopSingleWorkload(ctx context.Context, name string) er
 	// First, try to load the run configuration to check if it's a remote workload
 	runConfig, err := runner.LoadState(childCtx, name)
 	if err != nil {
-		// If we can't load the state, it might be a container workload or the workload doesn't exist
-		// Try to stop it as a container workload
-		return d.stopContainerWorkload(childCtx, name)
+		// If we can't load the state, it might be a container workload or the workload doesn't exist.
+		// Try to stop it as a container workload. Without a run config we cannot recover the proxy
+		// port for port-based cleanup, so pass nil.
+		return d.stopContainerWorkload(childCtx, name, nil)
 	}
 
 	// Check if this is a remote workload
@@ -426,57 +448,63 @@ func (d *DefaultManager) stopSingleWorkload(ctx context.Context, name string) er
 	}
 
 	// This is a container-based workload
-	return d.stopContainerWorkload(childCtx, name)
+	return d.stopContainerWorkload(childCtx, name, runConfig)
 }
 
 // stopRemoteWorkload stops a remote workload
 func (d *DefaultManager) stopRemoteWorkload(ctx context.Context, name string, runConfig *runner.RunConfig) error {
 	slog.Debug("stopping remote workload", "workload", name)
 
-	// Check if the workload is running by checking its status
+	// A remote workload's proxy can outlive its recorded status (e.g. the status
+	// file went missing), so we always try to free an orphaned proxy below — only
+	// the status transitions and client-config cleanup are gated on the workload
+	// actually running.
 	workload, err := d.statuses.GetWorkload(ctx, name)
-	if err != nil {
-		if errors.Is(err, rt.ErrWorkloadNotFound) {
-			// Log but don't fail the entire operation for not found workload
-			slog.Warn("failed to stop workload", "workload", name, "error", err)
-			return nil
-		}
+	if err != nil && !errors.Is(err, rt.ErrWorkloadNotFound) {
 		return fmt.Errorf("failed to find workload %s: %w", name, err)
 	}
-
-	if workload.Status != rt.WorkloadStatusRunning {
+	running := err == nil && workload.Status == rt.WorkloadStatusRunning
+	switch {
+	case err != nil:
+		// Status is gone (e.g. a missing status file); don't fail the operation,
+		// but still free an orphaned proxy below.
+		slog.Warn("failed to stop workload", "workload", name, "error", err)
+	case !running:
 		slog.Warn("Failed to stop workload", "workload", name, "error", ErrWorkloadNotRunning)
-		return nil
 	}
 
-	// Set status to stopping
-	if err := d.statuses.SetWorkloadStatus(ctx, name, rt.WorkloadStatusStopping, ""); err != nil {
-		slog.Debug("failed to set workload status to stopping", "workload", name, "error", err)
+	if running {
+		if err := d.statuses.SetWorkloadStatus(ctx, name, rt.WorkloadStatusStopping, ""); err != nil {
+			slog.Debug("failed to set workload status to stopping", "workload", name, "error", err)
+		}
 	}
 
-	// Stop proxy if running
+	// Stop the proxy and free its port even when the status is missing or not
+	// running — an orphaned proxy can still be holding the port.
 	if runConfig.BaseName != "" {
-		d.stopProxyIfNeeded(ctx, name, runConfig.BaseName)
+		d.ensureProxyStopped(ctx, name, runConfig.BaseName, runConfig)
 	}
 
-	// For remote workloads, we only need to clean up client configurations
-	// The saved state should be preserved for restart capability
-	if err := removeClientConfigurations(name, false); err != nil {
-		slog.Warn("failed to remove client configurations", "error", err)
-	} else {
-		slog.Debug("client configurations removed", "workload", name)
+	if running {
+		// For remote workloads we only need to clean up client configurations; the
+		// saved state is preserved for restart capability.
+		if err := removeClientConfigurations(name, false); err != nil {
+			slog.Warn("failed to remove client configurations", "error", err)
+		} else {
+			slog.Debug("client configurations removed", "workload", name)
+		}
+		if err := d.statuses.SetWorkloadStatus(ctx, name, rt.WorkloadStatusStopped, ""); err != nil {
+			slog.Debug("failed to set workload status to stopped", "workload", name, "error", err)
+		}
+		slog.Debug("remote workload stopped", "workload", name)
 	}
-
-	// Set status to stopped
-	if err := d.statuses.SetWorkloadStatus(ctx, name, rt.WorkloadStatusStopped, ""); err != nil {
-		slog.Debug("failed to set workload status to stopped", "workload", name, "error", err)
-	}
-	slog.Debug("remote workload stopped", "workload", name)
 	return nil
 }
 
-// stopContainerWorkload stops a container-based workload
-func (d *DefaultManager) stopContainerWorkload(ctx context.Context, name string) error {
+// stopContainerWorkload stops a container-based workload. runConfig may be nil
+// when the run config could not be loaded; it is used only for port-based proxy
+// cleanup when the tracked PID is unavailable.
+func (d *DefaultManager) stopContainerWorkload(ctx context.Context, name string, runConfig *runner.RunConfig) error {
 	container, err := d.runtime.GetWorkloadInfo(ctx, name)
 	if err != nil {
 		if errors.Is(err, rt.ErrWorkloadNotFound) {
@@ -500,7 +528,7 @@ func (d *DefaultManager) stopContainerWorkload(ctx context.Context, name string)
 	}
 
 	// Use the existing stopWorkloads method for container workloads
-	return d.stopSingleContainerWorkload(ctx, &container)
+	return d.stopSingleContainerWorkload(ctx, &container, runConfig)
 }
 
 // RunWorkload runs a workload in the foreground with automatic restart on container exit.
@@ -850,9 +878,10 @@ func (d *DefaultManager) deleteWorkload(ctx context.Context, name string) error 
 	// First, check if this is a remote workload by trying to load its run configuration
 	runConfig, err := runner.LoadState(childCtx, name)
 	if err != nil {
-		// If we can't load the state, it might be a container workload or the workload doesn't exist
-		// Continue with the container-based deletion logic
-		return d.deleteContainerWorkload(childCtx, name)
+		// If we can't load the state, it might be a container workload or the workload doesn't exist.
+		// Continue with the container-based deletion logic. Without a run config we cannot recover the
+		// proxy port for port-based cleanup, so pass nil.
+		return d.deleteContainerWorkload(childCtx, name, nil)
 	}
 
 	// If this is a remote workload (has RemoteURL), handle it differently
@@ -861,7 +890,7 @@ func (d *DefaultManager) deleteWorkload(ctx context.Context, name string) error 
 	}
 
 	// This is a container-based workload, use the existing logic
-	return d.deleteContainerWorkload(childCtx, name)
+	return d.deleteContainerWorkload(childCtx, name, runConfig)
 }
 
 // deleteRemoteWorkload handles deletion of a remote workload
@@ -876,7 +905,7 @@ func (d *DefaultManager) deleteRemoteWorkload(ctx context.Context, name string, 
 
 	// Stop proxy if running
 	if runConfig.BaseName != "" {
-		d.stopProxyIfNeeded(ctx, name, runConfig.BaseName)
+		d.ensureProxyStopped(ctx, name, runConfig.BaseName, runConfig)
 	}
 
 	// Clean up associated resources (remote workloads are not auxiliary)
@@ -891,8 +920,10 @@ func (d *DefaultManager) deleteRemoteWorkload(ctx context.Context, name string, 
 	return nil
 }
 
-// deleteContainerWorkload handles deletion of a container-based workload (existing logic)
-func (d *DefaultManager) deleteContainerWorkload(ctx context.Context, name string) error {
+// deleteContainerWorkload handles deletion of a container-based workload (existing logic).
+// runConfig may be nil; when present it lets delete fall back to port-based proxy cleanup
+// if the tracked PID is unavailable (e.g. a missing status file).
+func (d *DefaultManager) deleteContainerWorkload(ctx context.Context, name string, runConfig *runner.RunConfig) error {
 
 	// Find and validate the container
 	container, err := d.getWorkloadContainer(ctx, name)
@@ -929,7 +960,7 @@ func (d *DefaultManager) deleteContainerWorkload(ctx context.Context, name strin
 	// Stop proxy-runner process AFTER container removal to prevent recreation
 	// Skip for auxiliary workloads like inspector that don't use proxy processes
 	if !isAuxiliary {
-		d.stopProxyIfNeeded(ctx, name, baseName)
+		d.ensureProxyStopped(ctx, name, baseName, runConfig)
 	} else {
 		slog.Debug("skipping proxy-runner stop for auxiliary workload", "workload", name)
 	}
@@ -984,47 +1015,84 @@ func (d *DefaultManager) isSupervisorProcessAlive(ctx context.Context, name stri
 	return true
 }
 
-// stopProcess stops the proxy process associated with the container
-func (d *DefaultManager) stopProcess(ctx context.Context, name string) {
+// stopProcess stops the proxy process associated with the container. It reports
+// whether a tracked proxy process was actually stopped: true only when a valid
+// PID was found and killed. A false return (no PID recorded, e.g. a missing
+// status file, or the kill failed) signals callers to fall back to port-based
+// cleanup so an orphaned proxy does not keep holding the workload's port.
+func (d *DefaultManager) stopProcess(ctx context.Context, name string) bool {
 	if name == "" {
 		slog.Warn("could not find base container name in labels")
-		return
+		return false
 	}
 
 	// Try to read the PID and kill the process
 	pid, err := d.statuses.GetWorkloadPID(ctx, name)
 	if err != nil {
 		slog.Debug("no PID found, proxy may not be running in detached mode", "workload", name)
-		return
+		return false
 	}
 
 	// PID found, try to kill the process
 	slog.Debug("stopping proxy process", "pid", pid)
+	stopped := false
 	if err := process.KillProcess(pid); err != nil {
 		slog.Debug("failed to kill proxy process", "error", err)
 	} else {
 		slog.Debug("proxy process stopped")
+		stopped = true
 	}
 
 	// Remove the PID of the terminated process
 	if err := d.statuses.ResetWorkloadPID(ctx, name); err != nil {
 		slog.Warn("failed to reset workload PID", "workload", name, "error", err)
 	}
+
+	return stopped
 }
 
-// stopProxyIfNeeded stops the proxy process if the workload has a base name
-func (d *DefaultManager) stopProxyIfNeeded(ctx context.Context, name, baseName string) {
+// stopProxyIfNeeded stops the proxy process if the workload has a base name. It
+// reports whether a tracked proxy process was stopped (see stopProcess); false
+// when there is no base name or no proxy was killed.
+func (d *DefaultManager) stopProxyIfNeeded(ctx context.Context, name, baseName string) bool {
 	slog.Debug("removing proxy process", "workload", name)
-	if baseName != "" {
-		d.stopProcess(ctx, baseName)
+	if baseName == "" {
+		return false
+	}
+	return d.stopProcess(ctx, baseName)
+}
+
+// ensureProxyStopped stops the workload's proxy and guarantees its port is freed.
+// It first stops the tracked PID (stopProxyIfNeeded); if that does not stop a
+// proxy — no PID is recorded (e.g. the status file is missing) or the kill fails
+// (e.g. a stale PID whose process is already gone) — it falls back to port-based
+// cleanup, which only kills a process verified to be this workload's own proxy.
+// runConfig may be nil (no port fallback then). Used by the stop and delete
+// paths; the restart path instead frees the port itself, just before the child
+// re-binds.
+func (d *DefaultManager) ensureProxyStopped(ctx context.Context, name, baseName string, runConfig *runner.RunConfig) {
+	if !d.stopProxyIfNeeded(ctx, name, baseName) {
+		d.portFreerOrDefault()(ctx, runConfig)
 	}
 }
 
-// freePortHolderIfNeeded kills the process holding the proxy port if it is in use.
-// This ensures the port is free before the child attempts to bind, preventing
-// "address already in use" errors on restart.
+// freePortHolderIfNeeded kills the process holding the proxy port if it is in
+// use, but only when that process is verified to be this workload's own proxy.
+// It serves two callers:
+//   - restart, where it frees the port before the child re-binds (preventing
+//     "address already in use"), and
+//   - stop/delete, as a fallback when PID-based termination is unavailable or
+//     fails, so an orphaned proxy does not keep holding the port.
 func (*DefaultManager) freePortHolderIfNeeded(ctx context.Context, runConfig *runner.RunConfig) {
 	if runConfig == nil || runConfig.Port <= 0 {
+		return
+	}
+
+	// Without a base name we cannot confirm the port holder is this workload's own
+	// proxy — IsToolHiveProxyForWorkload matches any ToolHive proxy when the name
+	// is empty — so refuse to kill rather than risk taking down an unrelated
+	// workload's proxy that happens to hold the port.
+	if runConfig.BaseName == "" {
 		return
 	}
 
@@ -1332,7 +1400,7 @@ func (d *DefaultManager) maybeSetupRemoteWorkload(
 
 	// Ensure port is free before spawning. Kill the process holding the port if bound.
 	// This prevents "address already in use" when the new child tries to bind.
-	d.freePortHolderIfNeeded(ctx, mcpRunner.Config)
+	d.portFreerOrDefault()(ctx, mcpRunner.Config)
 
 	slog.Debug("loaded configuration from state", "workload", runConfig.BaseName)
 	return mcpRunner, nil
@@ -1570,8 +1638,12 @@ func (*DefaultManager) cleanupTempPermissionProfile(ctx context.Context, baseNam
 	return nil
 }
 
-// stopSingleContainerWorkload stops a single container workload
-func (d *DefaultManager) stopSingleContainerWorkload(ctx context.Context, workload *rt.ContainerInfo) error {
+// stopSingleContainerWorkload stops a single container workload. runConfig may
+// be nil; when present it lets stop fall back to port-based proxy cleanup if the
+// tracked PID is unavailable (e.g. a missing status file).
+func (d *DefaultManager) stopSingleContainerWorkload(
+	ctx context.Context, workload *rt.ContainerInfo, runConfig *runner.RunConfig,
+) error {
 	childCtx, cancel := context.WithTimeout(context.Background(), AsyncOperationTimeout)
 	defer cancel()
 
@@ -1580,7 +1652,7 @@ func (d *DefaultManager) stopSingleContainerWorkload(ctx context.Context, worklo
 	if labels.IsAuxiliaryWorkload(workload.Labels) {
 		slog.Debug("skipping proxy stop for auxiliary workload", "workload", name)
 	} else {
-		d.stopProcess(ctx, name)
+		d.ensureProxyStopped(ctx, name, name, runConfig)
 	}
 
 	slog.Debug("stopping containers", "workload", name)

--- a/pkg/workloads/manager_test.go
+++ b/pkg/workloads/manager_test.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os/exec"
+	goruntime "runtime"
 	"testing"
 	"time"
 
@@ -2259,4 +2261,367 @@ func TestGetRemoteWorkloadsFromState_AuthRetryingVisibleWithoutAll(t *testing.T)
 		"remote workload in AuthRetrying should be visible in default thv list (listAll=false)")
 	assert.False(t, sawDead,
 		"remote workload in Unauthenticated should remain hidden in default thv list (listAll=false)")
+}
+
+// startKillableProcess starts a real, long-lived child process and returns its
+// PID. The process is killed and reaped on test cleanup. It is used to exercise
+// the path where stopProcess finds a valid PID and KillProcess succeeds. The
+// helper relies on the Unix `sleep` command, so it skips on Windows (the CI unit
+// test matrix is Linux-only) and if the process cannot be started.
+func startKillableProcess(t *testing.T) int {
+	t.Helper()
+	if goruntime.GOOS == "windows" {
+		t.Skip("startKillableProcess relies on the Unix sleep command")
+	}
+	cmd := exec.Command("sleep", "300")
+	if err := cmd.Start(); err != nil {
+		t.Skipf("could not start helper process: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	})
+	return cmd.Process.Pid
+}
+
+// TestDefaultManager_stopProcess verifies the boolean contract that the
+// stop/delete port-cleanup fallback relies on: stopProcess reports true only
+// when it found a tracked PID and killed it. A false return (no PID recorded —
+// e.g. a missing status file — or a failed kill) is what triggers the
+// port-based cleanup fallback in stopSingleContainerWorkload/deleteContainerWorkload.
+func TestDefaultManager_stopProcess(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		workload   string
+		setupMocks func(t *testing.T, sm *statusMocks.MockStatusManager)
+		want       bool
+	}{
+		{
+			name:     "empty name returns false",
+			workload: "",
+			setupMocks: func(_ *testing.T, _ *statusMocks.MockStatusManager) {
+				// No status manager calls expected for an empty name.
+			},
+			want: false,
+		},
+		{
+			name:     "GetWorkloadPID error returns false",
+			workload: "test-workload",
+			setupMocks: func(_ *testing.T, sm *statusMocks.MockStatusManager) {
+				sm.EXPECT().GetWorkloadPID(gomock.Any(), "test-workload").Return(0, errors.New("boom"))
+			},
+			want: false,
+		},
+		{
+			name:     "missing status file (pid 0) returns false",
+			workload: "test-workload",
+			setupMocks: func(_ *testing.T, sm *statusMocks.MockStatusManager) {
+				// A missing status file yields PID 0 with no error; KillProcess(0) fails,
+				// so no proxy is stopped. The PID is still reset.
+				sm.EXPECT().GetWorkloadPID(gomock.Any(), "test-workload").Return(0, nil)
+				sm.EXPECT().ResetWorkloadPID(gomock.Any(), "test-workload").Return(nil)
+			},
+			want: false,
+		},
+		{
+			name:     "valid running PID returns true",
+			workload: "test-workload",
+			setupMocks: func(t *testing.T, sm *statusMocks.MockStatusManager) {
+				t.Helper()
+				pid := startKillableProcess(t)
+				sm.EXPECT().GetWorkloadPID(gomock.Any(), "test-workload").Return(pid, nil)
+				sm.EXPECT().ResetWorkloadPID(gomock.Any(), "test-workload").Return(nil)
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			sm := statusMocks.NewMockStatusManager(ctrl)
+			tt.setupMocks(t, sm)
+
+			manager := &DefaultManager{statuses: sm}
+
+			got := manager.stopProcess(context.Background(), tt.workload)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestDefaultManager_orphanProxyPortCleanup verifies that stop and rm fall back
+// to port-based proxy cleanup when the tracked PID is unavailable (the missing
+// status-file scenario), and that the fallback does not run on the normal path
+// where the proxy was stopped by PID.
+func TestDefaultManager_orphanProxyPortCleanup(t *testing.T) {
+	t.Parallel()
+
+	const workloadName = "test-workload"
+	containerInfo := func() runtime.ContainerInfo {
+		return runtime.ContainerInfo{
+			Name:   workloadName,
+			State:  "running",
+			Labels: map[string]string{"toolhive-basename": workloadName},
+		}
+	}
+
+	t.Run("stop frees orphan proxy port when status file missing", func(t *testing.T) {
+		t.Parallel()
+
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		sm := statusMocks.NewMockStatusManager(ctrl)
+		rtMock := runtimeMocks.NewMockRuntime(ctrl)
+
+		// Missing status file: no tracked PID, so the proxy is not killed by PID.
+		sm.EXPECT().GetWorkloadPID(gomock.Any(), workloadName).Return(0, nil)
+		sm.EXPECT().ResetWorkloadPID(gomock.Any(), workloadName).Return(nil)
+		rtMock.EXPECT().StopWorkload(gomock.Any(), workloadName).Return(nil)
+		sm.EXPECT().SetWorkloadStatus(gomock.Any(), workloadName, runtime.WorkloadStatusStopped, "").Return(nil)
+
+		var freed []*runner.RunConfig
+		runConfig := &runner.RunConfig{BaseName: workloadName, Port: 54321}
+		manager := &DefaultManager{statuses: sm, runtime: rtMock}
+		withPortFreer(func(_ context.Context, rc *runner.RunConfig) {
+			freed = append(freed, rc)
+		})(manager)
+
+		ci := containerInfo()
+		err := manager.stopSingleContainerWorkload(context.Background(), &ci, runConfig)
+		require.NoError(t, err)
+
+		require.Len(t, freed, 1, "port-cleanup fallback should run exactly once")
+		assert.Equal(t, workloadName, freed[0].BaseName, "fallback should receive the workload's run config")
+		assert.Equal(t, 54321, freed[0].Port, "fallback should receive the workload's proxy port")
+	})
+
+	t.Run("stop does not free port on normal shutdown", func(t *testing.T) {
+		t.Parallel()
+
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		sm := statusMocks.NewMockStatusManager(ctrl)
+		rtMock := runtimeMocks.NewMockRuntime(ctrl)
+
+		// A valid, killable PID: the proxy is stopped by PID, so no fallback.
+		pid := startKillableProcess(t)
+		sm.EXPECT().GetWorkloadPID(gomock.Any(), workloadName).Return(pid, nil)
+		sm.EXPECT().ResetWorkloadPID(gomock.Any(), workloadName).Return(nil)
+		rtMock.EXPECT().StopWorkload(gomock.Any(), workloadName).Return(nil)
+		sm.EXPECT().SetWorkloadStatus(gomock.Any(), workloadName, runtime.WorkloadStatusStopped, "").Return(nil)
+
+		freedCalls := 0
+		manager := &DefaultManager{statuses: sm, runtime: rtMock}
+		withPortFreer(func(_ context.Context, _ *runner.RunConfig) {
+			freedCalls++
+		})(manager)
+
+		ci := containerInfo()
+		err := manager.stopSingleContainerWorkload(
+			context.Background(), &ci, &runner.RunConfig{BaseName: workloadName, Port: 54321},
+		)
+		require.NoError(t, err)
+
+		assert.Zero(t, freedCalls, "port-cleanup fallback must not run when the proxy was stopped by PID")
+	})
+
+	t.Run("delete frees orphan proxy port when status file missing", func(t *testing.T) {
+		t.Parallel()
+
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		sm := statusMocks.NewMockStatusManager(ctrl)
+		rtMock := runtimeMocks.NewMockRuntime(ctrl)
+
+		// Container is found and removed cleanly.
+		rtMock.EXPECT().GetWorkloadInfo(gomock.Any(), workloadName).Return(containerInfo(), nil)
+		sm.EXPECT().SetWorkloadStatus(gomock.Any(), workloadName, runtime.WorkloadStatusRemoving, "").Return(nil)
+		rtMock.EXPECT().RemoveWorkload(gomock.Any(), workloadName).Return(nil)
+		// removeContainer waits for the container to disappear from the runtime.
+		rtMock.EXPECT().GetWorkloadInfo(gomock.Any(), workloadName).Return(runtime.ContainerInfo{}, runtime.ErrWorkloadNotFound)
+		// Missing status file: no tracked PID, so the proxy is not killed by PID.
+		sm.EXPECT().GetWorkloadPID(gomock.Any(), workloadName).Return(0, nil)
+		sm.EXPECT().ResetWorkloadPID(gomock.Any(), workloadName).Return(nil)
+		sm.EXPECT().DeleteWorkloadStatus(gomock.Any(), workloadName).Return(nil)
+
+		var freed []*runner.RunConfig
+		runConfig := &runner.RunConfig{BaseName: workloadName, Port: 54321}
+		manager := &DefaultManager{statuses: sm, runtime: rtMock}
+		withPortFreer(func(_ context.Context, rc *runner.RunConfig) {
+			freed = append(freed, rc)
+		})(manager)
+
+		err := manager.deleteContainerWorkload(context.Background(), workloadName, runConfig)
+		require.NoError(t, err)
+
+		require.Len(t, freed, 1, "port-cleanup fallback should run exactly once")
+		assert.Equal(t, workloadName, freed[0].BaseName, "fallback should receive the workload's run config")
+		assert.Equal(t, 54321, freed[0].Port, "fallback should receive the workload's proxy port")
+	})
+
+	t.Run("delete does not free port on normal shutdown", func(t *testing.T) {
+		t.Parallel()
+
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		sm := statusMocks.NewMockStatusManager(ctrl)
+		rtMock := runtimeMocks.NewMockRuntime(ctrl)
+
+		rtMock.EXPECT().GetWorkloadInfo(gomock.Any(), workloadName).Return(containerInfo(), nil)
+		sm.EXPECT().SetWorkloadStatus(gomock.Any(), workloadName, runtime.WorkloadStatusRemoving, "").Return(nil)
+		rtMock.EXPECT().RemoveWorkload(gomock.Any(), workloadName).Return(nil)
+		rtMock.EXPECT().GetWorkloadInfo(gomock.Any(), workloadName).Return(runtime.ContainerInfo{}, runtime.ErrWorkloadNotFound)
+		// A valid, killable PID: the proxy is stopped by PID, so no fallback.
+		pid := startKillableProcess(t)
+		sm.EXPECT().GetWorkloadPID(gomock.Any(), workloadName).Return(pid, nil)
+		sm.EXPECT().ResetWorkloadPID(gomock.Any(), workloadName).Return(nil)
+		sm.EXPECT().DeleteWorkloadStatus(gomock.Any(), workloadName).Return(nil)
+
+		freedCalls := 0
+		manager := &DefaultManager{statuses: sm, runtime: rtMock}
+		withPortFreer(func(_ context.Context, _ *runner.RunConfig) {
+			freedCalls++
+		})(manager)
+
+		err := manager.deleteContainerWorkload(
+			context.Background(), workloadName, &runner.RunConfig{BaseName: workloadName, Port: 54321},
+		)
+		require.NoError(t, err)
+
+		assert.Zero(t, freedCalls, "port-cleanup fallback must not run when the proxy was stopped by PID")
+	})
+
+	t.Run("remote stop frees orphan proxy port when status file missing", func(t *testing.T) {
+		t.Parallel()
+
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		sm := statusMocks.NewMockStatusManager(ctrl)
+
+		// Real orphan: the status file is gone, so GetWorkload cannot find the
+		// workload (a remote workload has no container to fall back to). The proxy
+		// may still be holding the port, so the fallback must still fire — and the
+		// status transitions are skipped since the workload is not "running".
+		sm.EXPECT().GetWorkload(gomock.Any(), workloadName).Return(core.Workload{}, runtime.ErrWorkloadNotFound)
+		// No tracked PID, so the proxy is not killed by PID.
+		sm.EXPECT().GetWorkloadPID(gomock.Any(), workloadName).Return(0, nil)
+		sm.EXPECT().ResetWorkloadPID(gomock.Any(), workloadName).Return(nil)
+
+		var freed []*runner.RunConfig
+		runConfig := &runner.RunConfig{BaseName: workloadName, Port: 54321}
+		manager := &DefaultManager{statuses: sm}
+		withPortFreer(func(_ context.Context, rc *runner.RunConfig) {
+			freed = append(freed, rc)
+		})(manager)
+
+		err := manager.stopRemoteWorkload(context.Background(), workloadName, runConfig)
+		require.NoError(t, err)
+
+		require.Len(t, freed, 1, "port-cleanup fallback should run exactly once")
+		assert.Equal(t, workloadName, freed[0].BaseName, "fallback should receive the workload's run config")
+		assert.Equal(t, 54321, freed[0].Port, "fallback should receive the workload's proxy port")
+	})
+
+	t.Run("remote delete frees orphan proxy port when status file missing", func(t *testing.T) {
+		t.Parallel()
+
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		sm := statusMocks.NewMockStatusManager(ctrl)
+
+		sm.EXPECT().SetWorkloadStatus(gomock.Any(), workloadName, runtime.WorkloadStatusRemoving, "").Return(nil)
+		// Missing status file: no tracked PID, so the proxy is not killed by PID.
+		sm.EXPECT().GetWorkloadPID(gomock.Any(), workloadName).Return(0, nil)
+		sm.EXPECT().ResetWorkloadPID(gomock.Any(), workloadName).Return(nil)
+		sm.EXPECT().DeleteWorkloadStatus(gomock.Any(), workloadName).Return(nil)
+
+		var freed []*runner.RunConfig
+		runConfig := &runner.RunConfig{BaseName: workloadName, Port: 54321}
+		manager := &DefaultManager{statuses: sm}
+		withPortFreer(func(_ context.Context, rc *runner.RunConfig) {
+			freed = append(freed, rc)
+		})(manager)
+
+		err := manager.deleteRemoteWorkload(context.Background(), workloadName, runConfig)
+		require.NoError(t, err)
+
+		require.Len(t, freed, 1, "port-cleanup fallback should run exactly once")
+		assert.Equal(t, workloadName, freed[0].BaseName, "fallback should receive the workload's run config")
+		assert.Equal(t, 54321, freed[0].Port, "fallback should receive the workload's proxy port")
+	})
+
+	t.Run("remote stop does not free port on normal shutdown", func(t *testing.T) {
+		t.Parallel()
+
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		sm := statusMocks.NewMockStatusManager(ctrl)
+
+		sm.EXPECT().GetWorkload(gomock.Any(), workloadName).Return(core.Workload{
+			Name:   workloadName,
+			Status: runtime.WorkloadStatusRunning,
+		}, nil)
+		sm.EXPECT().SetWorkloadStatus(gomock.Any(), workloadName, runtime.WorkloadStatusStopping, "").Return(nil)
+		// A valid, killable PID: the proxy is stopped by PID, so no fallback.
+		pid := startKillableProcess(t)
+		sm.EXPECT().GetWorkloadPID(gomock.Any(), workloadName).Return(pid, nil)
+		sm.EXPECT().ResetWorkloadPID(gomock.Any(), workloadName).Return(nil)
+		sm.EXPECT().SetWorkloadStatus(gomock.Any(), workloadName, runtime.WorkloadStatusStopped, "").Return(nil)
+
+		freedCalls := 0
+		manager := &DefaultManager{statuses: sm}
+		withPortFreer(func(_ context.Context, _ *runner.RunConfig) {
+			freedCalls++
+		})(manager)
+
+		err := manager.stopRemoteWorkload(
+			context.Background(), workloadName, &runner.RunConfig{BaseName: workloadName, Port: 54321},
+		)
+		require.NoError(t, err)
+
+		assert.Zero(t, freedCalls, "port-cleanup fallback must not run when the proxy was stopped by PID")
+	})
+
+	t.Run("remote delete does not free port on normal shutdown", func(t *testing.T) {
+		t.Parallel()
+
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		sm := statusMocks.NewMockStatusManager(ctrl)
+
+		sm.EXPECT().SetWorkloadStatus(gomock.Any(), workloadName, runtime.WorkloadStatusRemoving, "").Return(nil)
+		// A valid, killable PID: the proxy is stopped by PID, so no fallback.
+		pid := startKillableProcess(t)
+		sm.EXPECT().GetWorkloadPID(gomock.Any(), workloadName).Return(pid, nil)
+		sm.EXPECT().ResetWorkloadPID(gomock.Any(), workloadName).Return(nil)
+		sm.EXPECT().DeleteWorkloadStatus(gomock.Any(), workloadName).Return(nil)
+
+		freedCalls := 0
+		manager := &DefaultManager{statuses: sm}
+		withPortFreer(func(_ context.Context, _ *runner.RunConfig) {
+			freedCalls++
+		})(manager)
+
+		err := manager.deleteRemoteWorkload(
+			context.Background(), workloadName, &runner.RunConfig{BaseName: workloadName, Port: 54321},
+		)
+		require.NoError(t, err)
+
+		assert.Zero(t, freedCalls, "port-cleanup fallback must not run when the proxy was stopped by PID")
+	})
 }


### PR DESCRIPTION
## Summary

When a workload's status file is missing, `thv stop` and `thv rm` report success but leave the workload's proxy process running and holding its port. The proxy-stop path kills the proxy by the PID recorded in the status file, so with the file gone nothing is killed:

- After `thv stop`, the surviving supervisor restarts the container, so the workload returns to `running` on its own.
- After `thv rm`, the container is removed but the orphaned proxy keeps holding the port, so it cannot be reused without killing the process by hand.

This makes stop and rm fall back to the existing port-based cleanup when the PID-based stop finds no proxy to kill, so the proxy is terminated and the port freed even when the status file is missing. The fallback reuses `freePortHolderIfNeeded` (already used on the restart path), which only kills a process verified to be this workload's own proxy.

- Make `stopProcess` / `stopProxyIfNeeded` report whether a tracked proxy was actually killed.
- Thread the already-loaded `runConfig` into the container stop/delete paths so the fallback knows the proxy port.
- When the PID-based stop fails for a non-auxiliary workload, run the port-based cleanup as a backstop.

Fixes #5393

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [x] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [x] Linting (`task lint-fix`)
- [x] Manual testing (describe below)

Manual testing on macOS + OrbStack with a real container workload (`fetch`):

- Reproduced the bug: with the status file moved aside, `thv stop` left the supervisor process alive (verified by PID) and it recreated the container — a new container ID and new `StartedAt` — returning the workload to `running`; `thv rm` left the orphaned proxy holding the port.
- With the fix: both `thv stop` and `thv rm` terminate the proxy (PID gone) and free the port.
- Confirmed the normal path (status file present) is unchanged: the proxy is stopped by PID and the port-based fallback does not run.

The added unit tests fail without the fix and pass with it.

## Does this introduce a user-facing change?

Yes. `thv stop` and `thv rm` now reliably stop the workload's proxy and free its port even when the workload's status file is missing, instead of leaving an orphaned proxy that holds the port (and, for `stop`, restarts the container).

## Special notes for reviewers

- The fallback is **gated**: it runs only when the PID-based stop returns false (no tracked PID, or the kill failed). The normal stop/rm path is unchanged — no added latency, no behavior change.
- The kill is **identity-verified**: `freePortHolderIfNeeded` → `process.IsToolHiveProxyForWorkload` confirms the process on the port is this workload's `thv start <name>` proxy before killing it, so it cannot touch an unrelated process or another workload's proxy.
- **Limitation:** if `runner.LoadState` itself fails (the run config is gone, not just the status file), the proxy port cannot be recovered. In the reported scenario only the status file is missing, so `LoadState` succeeds and the port is recoverable.
- The deeper question of *why* a status file goes missing is out of scope here; this fixes the resulting inability to stop/remove the workload.

Generated with [Claude Code](https://claude.com/claude-code)
