### PR TITLE
Add Applier for upgrading workloads in place

### DIFF
--- a/pkg/workloads/upgrade/applier.go
+++ b/pkg/workloads/upgrade/applier.go
@@ -1,0 +1,472 @@
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package upgrade
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"maps"
+	"slices"
+	"time"
+
+	regtypes "github.com/stacklok/toolhive-core/registry/types"
+	"github.com/stacklok/toolhive/pkg/config"
+	"github.com/stacklok/toolhive/pkg/container/templates"
+	"github.com/stacklok/toolhive/pkg/runner"
+	"github.com/stacklok/toolhive/pkg/runner/retriever"
+	"github.com/stacklok/toolhive/pkg/secrets"
+	"github.com/stacklok/toolhive/pkg/workloads"
+)
+
+// resolveFunc resolves an MCP server definition from the registry and verifies
+// its image provenance. It mirrors retriever.ResolveMCPServer so the real
+// implementation can be swapped for a stub in tests.
+type resolveFunc func(
+	ctx context.Context,
+	serverOrImage string,
+	rawCACertPath string,
+	verificationType string,
+	groupName string,
+	runtimeOverride *templates.RuntimeConfig,
+) (string, regtypes.ServerMetadata, error)
+
+// enforcePullFunc runs the policy gate and performs a verified image pull. It
+// mirrors retriever.EnforcePolicyAndPullImage so the real implementation can be
+// swapped for a stub in tests.
+type enforcePullFunc func(
+	ctx context.Context,
+	runConfig *runner.RunConfig,
+	serverMetadata regtypes.ServerMetadata,
+	imageURL string,
+	puller retriever.ImagePuller,
+	pullTimeout time.Duration,
+	locallyBuilt bool,
+) error
+
+// loadStateFunc loads a workload's persisted RunConfig. It mirrors
+// runner.LoadState so the real implementation can be swapped in tests.
+type loadStateFunc func(ctx context.Context, name string) (*runner.RunConfig, error)
+
+// ErrApplyAfterDestroy marks an Apply failure that occurred AFTER the
+// destructive recreate began (the manager has already started to stop/delete
+// the workload). Unlike preparation failures — which leave the running workload
+// untouched — a failure tagged with this sentinel means the workload may be
+// stopped, deleted, or only partially recreated: its state is uncertain and the
+// failure is NOT safely retryable against an intact workload. Callers use
+// errors.Is(err, ErrApplyAfterDestroy) to distinguish this 5xx-class condition
+// from the 4xx-class "candidate could not be prepared" failures.
+var ErrApplyAfterDestroy = errors.New("upgrade failed after workload recreate began; workload state is uncertain")
+
+// Applier is the canonical, security-critical path for applying an available
+// registry-sourced upgrade to a running workload. It re-resolves and verifies
+// the candidate image, pulls it, and only then asks the workload manager to
+// recreate the workload with the new image.
+//
+// Applier is the single place where an upgrade is materialized; both the CLI
+// (Phase D2) and the API (Phase D3) delegate here so that the verify-then-pull
+// ordering and TOCTOU guard live in exactly one place.
+type Applier struct {
+	manager   workloads.Manager
+	checker   *Checker
+	appConfig config.Provider
+
+	// resolveFn, enforcePullFn, and loadStateFn wrap the corresponding
+	// package-level functions in pkg/runner and pkg/runner/retriever. They are
+	// always populated in production (set in NewApplier) and exist purely so the
+	// package-level functions can be substituted in unit tests. They are NOT
+	// optional hooks: NewApplier never leaves them nil.
+	resolveFn     resolveFunc
+	enforcePullFn enforcePullFunc
+	loadStateFn   loadStateFunc
+}
+
+// NewApplier creates an Applier.
+//
+// All dependencies are required and validated; the constructor fails loudly
+// rather than producing an Applier that would panic or silently no-op at apply
+// time. The appConfig provider supplies the registry source URLs recorded on
+// the upgraded workload's config.
+func NewApplier(manager workloads.Manager, checker *Checker, appConfig config.Provider) (*Applier, error) {
+	if manager == nil {
+		return nil, fmt.Errorf("workload manager must not be nil")
+	}
+	if checker == nil {
+		return nil, fmt.Errorf("checker must not be nil")
+	}
+	if appConfig == nil {
+		return nil, fmt.Errorf("config provider must not be nil")
+	}
+	return &Applier{
+		manager:       manager,
+		checker:       checker,
+		appConfig:     appConfig,
+		resolveFn:     retriever.ResolveMCPServer,
+		enforcePullFn: retriever.EnforcePolicyAndPullImage,
+		loadStateFn:   runner.LoadState,
+	}, nil
+}
+
+// Apply upgrades the named workload to the candidate image the registry
+// currently reports for the workload's registry server.
+//
+// Sequence (see RFC THV-0068 design §4; step numbers match the inline comments):
+//  1. Load the workload's current RunConfig (treated as read-only).
+//  2. Re-run the upgrade check against the registry. If the workload is not in
+//     StatusUpgradeAvailable, the current CheckResult is returned unchanged as a
+//     no-op (NOT an error) so the caller can decide how to message it. The check
+//     is ALWAYS re-derived here; a CheckResult computed earlier by the caller is
+//     never trusted, closing the time-of-check/time-of-use window.
+//  3. Re-resolve and VERIFY the candidate image from the registry by server
+//     name (passing the name, not the image ref, is what triggers provenance
+//     verification inside ResolveMCPServer).
+//  4. Reject non-image (remote) registry entries: there is nothing to pull and
+//     recreate, so refuse rather than risk destroying the workload.
+//  5. Build a merged RunConfig that preserves the workload's user configuration
+//     while bumping the image to the candidate and re-validating env vars
+//     against the candidate's fresh metadata.
+//  6. Run the policy gate and perform a verified pull of the candidate image.
+//  7. Only after all of the above succeed, ask the manager to recreate the
+//     workload with the new config.
+//
+// No rollback: steps 3-6 all happen BEFORE the destructive recreate in step 7,
+// so any failure while preparing the candidate (resolution, verification,
+// policy, pull) leaves the running workload completely untouched. Once step 7
+// begins, the manager deletes and recreates the workload; there is no automatic
+// revert to the previous image or configuration if recreation fails. Recovery
+// is a forward operation (re-running the previous configuration explicitly).
+//
+// Runtime boundary: the "verified pull before destruction" guarantee is precise
+// only for local container runtimes. On Kubernetes, EnforcePolicyAndPullImage
+// runs the verification and policy gate but DELEGATES the byte-level image pull
+// to the kubelet, which happens AFTER the workload is recreated. In all cases,
+// verification and the policy gate always precede destruction; only the local
+// runtime additionally guarantees the bytes are present before destruction.
+// (Local runtimes are the scope of this phase; the boundary is documented for
+// completeness.)
+//
+// On success the *CheckResult that drove the upgrade is returned (including any
+// detected drift) so the caller can report what changed.
+func (a *Applier) Apply(ctx context.Context, name string, opts ApplyOptions) (*CheckResult, error) {
+	// 1. Load current state. Treat as strictly read-only: never mutate old or
+	// any of its maps/slices.
+	old, err := a.loadStateFn(ctx, name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load state for workload %q: %w", name, err)
+	}
+
+	// 2. Re-check against the registry. Never trust a CheckResult supplied by the
+	// caller; always re-derive here (TOCTOU guard).
+	res, err := a.checker.Check(ctx, old)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check workload %q for upgrade: %w", name, err)
+	}
+	if res.Status != StatusUpgradeAvailable {
+		// No-op: nothing to apply. Return the result, not an error, so the caller
+		// decides how to message "already up to date" / "not upgradable".
+		return res, nil
+	}
+
+	// 3. Resolve + verify the candidate image from the registry. Passing the
+	// registry SERVER NAME (not the image ref) is what triggers provenance
+	// verification inside ResolveMCPServer. A failure here leaves the running
+	// workload untouched.
+	imageURL, serverMeta, err := a.resolveFn(
+		ctx,
+		old.RegistryServerName,
+		opts.CACertPath,
+		opts.defaultVerifySetting(),
+		"", // registry-based group lookups are not supported
+		nil,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve candidate image for workload %q: %w", name, err)
+	}
+
+	// 4. Only container-image servers can be upgraded in place. A remote
+	// (non-image) entry has nothing to pull/recreate; refuse rather than risk
+	// destroying the workload.
+	imgMeta, ok := serverMeta.(*regtypes.ImageMetadata)
+	if !ok || imgMeta == nil {
+		return nil, fmt.Errorf(
+			"registry server %q is not a container image; cannot upgrade workload %q in place",
+			old.RegistryServerName, name,
+		)
+	}
+
+	// 5. Build the merged config off copies of the caller's/old config's data.
+	newConfig, err := a.buildUpgradedConfig(ctx, old, imgMeta, opts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build upgraded config for workload %q: %w", name, err)
+	}
+
+	// 6. Policy gate + verified pull BEFORE any destruction. EnforcePolicyAndPullImage
+	// runs the policy gate AND the pull, so we deliberately do NOT also call
+	// EagerCheckCreateServer. This is an intentional deviation from design v2 §4
+	// step 5 (which listed a separate EagerCheckCreateServer call): running both
+	// would double-gate the same config against the same policy. A failure here
+	// still leaves the running workload untouched.
+	if err := a.enforcePullFn(ctx, newConfig, serverMeta, imageURL, retriever.PullMCPServerImage, 0, false); err != nil {
+		return nil, fmt.Errorf("failed to prepare candidate image for workload %q: %w", name, err)
+	}
+
+	// 7. Destructive apply. The manager stops, deletes, and recreates the
+	// workload with the new config. We sever request-scoped cancellation with
+	// context.WithoutCancel so an upgrade in progress is not aborted mid-recreate
+	// by a client disconnect or handler deadline, while still carrying the OTel
+	// trace span and request-scoped values (which context.Background would drop).
+	//
+	// Errors from here on are tagged with ErrApplyAfterDestroy: the workload may
+	// already be stopped/deleted, so the caller must treat its state as uncertain
+	// rather than assuming the running workload was left untouched.
+	completion, err := a.manager.UpdateWorkload(context.WithoutCancel(ctx), name, newConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to update workload %q: %w", name, errors.Join(err, ErrApplyAfterDestroy))
+	}
+
+	// Block until the stop/delete/save/start cycle finishes. UpdateWorkload runs
+	// it asynchronously and returns a CompletionFunc; both callers are
+	// synchronous (the CLI prints success and the API responds 200 only once the
+	// upgrade has actually taken effect), and the new RunConfig — including the
+	// upgraded image — is only persisted once this completes. Returning before it
+	// finishes would surface a stale, pre-upgrade workload to the caller.
+	if completion != nil {
+		if err := completion(); err != nil {
+			return nil, fmt.Errorf("failed to complete upgrade for workload %q: %w", name, errors.Join(err, ErrApplyAfterDestroy))
+		}
+	}
+
+	return res, nil
+}
+
+// buildUpgradedConfig constructs the RunConfig for the upgraded workload.
+//
+// An upgrade PRESERVES the entire user configuration and changes ONLY:
+//   - the image (bumped to the candidate),
+//   - the environment variables and secrets (old merged with the caller's
+//     ApplyOptions),
+//   - the registry source URLs (re-resolved from the current app config).
+//
+// Everything else is byte-identical to the workload's current config: a
+// round-trip upgrade of a fully-configured workload must not silently drop
+// fields such as OIDC/authz/audit/telemetry config, tool filters, middleware,
+// transport/posture, etc. Dropping a field like ToolsFilter (which would
+// broaden the exposed tool surface) or the authz/audit config is a security
+// regression, not mere behavior drift.
+//
+// Posture fields (transport, permission profile, network isolation) are
+// PRESERVED from the current config and merely SURFACED as drift by the checker
+// (preserve-and-warn); they are NOT converged to the candidate's posture here.
+//
+// The builder is still given the candidate imageMetadata so the env-var
+// validator runs against the FRESH metadata: newly-required env vars on the
+// candidate are detected/handled (the env-var drift goal of RFC THV-0068).
+//
+// It never mutates old or any of its maps/slices: caller-visible data is cloned
+// before use, and fields copied post-build are either value types or pointers
+// that the upgraded config and old config may safely share read-only (neither
+// the manager nor the proxy mutates them in place).
+func (a *Applier) buildUpgradedConfig(
+	ctx context.Context,
+	old *runner.RunConfig,
+	imgMeta *regtypes.ImageMetadata,
+	opts ApplyOptions,
+) (*runner.RunConfig, error) {
+	// Copy-before-mutate: never touch the caller's/old config's underlying data.
+	mergedEnv := maps.Clone(old.EnvVars)
+	if mergedEnv == nil {
+		mergedEnv = make(map[string]string, len(opts.EnvVars))
+	}
+	maps.Copy(mergedEnv, opts.EnvVars)
+
+	mergedSecrets := mergeSecrets(old.Secrets, opts.Secrets)
+
+	cfg := a.appConfig.GetConfig()
+	regAPIURL, regURL := runner.ResolveRegistrySourceURLs(imgMeta, cfg)
+
+	options := []runner.RunConfigBuilderOption{
+		// WithImage performs the version bump: NewRunConfigBuilder does NOT derive
+		// RunConfig.Image from the imageMetadata argument, so it must be set
+		// explicitly to the candidate image (mirrors workload_service.go).
+		runner.WithImage(imgMeta.Image),
+		runner.WithName(old.Name),
+		runner.WithGroup(old.Group),
+		// Transport/ports/posture are preserved from old (preserve-and-warn). The
+		// builder still resolves/normalizes them (and sets transport env vars)
+		// against the same values old already had.
+		runner.WithTransportAndPorts(old.Transport.String(), old.Port, old.TargetPort),
+		runner.WithExistingPort(old.Port),
+		runner.WithHost(old.Host),
+		runner.WithVolumes(slices.Clone(old.Volumes)),
+		runner.WithSecrets(mergedSecrets),
+		runner.WithNetworkIsolation(old.IsolateNetwork),
+		runner.WithAllowDockerGateway(old.AllowDockerGateway),
+		runner.WithTrustProxyHeaders(old.TrustProxyHeaders),
+		runner.WithProxyMode(old.ProxyMode),
+		runner.WithCmdArgs(slices.Clone(old.CmdArgs)),
+		runner.WithStateless(old.Stateless),
+		runner.WithEndpointPrefix(old.EndpointPrefix),
+		runner.WithRegistrySourceURLs(regAPIURL, regURL),
+		runner.WithRegistryServerName(old.RegistryServerName),
+	}
+
+	// Permission profile: if the workload pinned a named/path profile, preserve
+	// that name/path (do NOT re-pin to the resolved object or to the candidate's
+	// profile) so it stays consistent with what the checker reports as drift
+	// (the checker compares PermissionProfileNameOrPath). Otherwise preserve the
+	// resolved profile object.
+	if old.PermissionProfileNameOrPath != "" {
+		options = append(options, runner.WithPermissionProfileNameOrPath(old.PermissionProfileNameOrPath))
+	} else if old.PermissionProfile != nil {
+		// Clone before handing it over: processVolumeMounts appends to Read/Write,
+		// which would otherwise mutate old's profile through the shared pointer and
+		// break this builder's "never mutates old" contract. The clone is shallow
+		// except for Read/Write: the builder only ever appends to those two slices
+		// here. The shared Network pointer is safe today because the builder mutates
+		// it solely via WithNetworkMode, which buildUpgradedConfig never sets; if a
+		// future change adds WithNetworkMode (or the builder starts touching Network
+		// unconditionally), Network must be cloned here too.
+		cloned := *old.PermissionProfile
+		cloned.Read = slices.Clone(old.PermissionProfile.Read)
+		cloned.Write = slices.Clone(old.PermissionProfile.Write)
+		options = append(options, runner.WithPermissionProfile(&cloned))
+	} else {
+		options = append(options, runner.WithPermissionProfile(old.PermissionProfile))
+	}
+
+	newConfig, err := runner.NewRunConfigBuilder(ctx, imgMeta, mergedEnv, opts.EnvVarValidator, options...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build run config: %w", err)
+	}
+
+	// Preserve the remaining user-owned fields that have no clean builder option
+	// (or whose option carries side effects we don't want). Without this, any
+	// such field would be silently dropped on upgrade because UpdateWorkload
+	// persists newConfig verbatim.
+	preserveUserConfigFields(newConfig, old)
+
+	return newConfig, nil
+}
+
+// preserveUserConfigFields copies user-owned RunConfig fields from old onto the
+// freshly-built upgraded config. It covers every persisted, user-configurable
+// field that the builder-option list above does NOT already set, so a
+// round-trip upgrade changes only the image, env/secrets, and registry URLs.
+//
+// SchemaVersion, Image, Name, Group, Transport, Host, Port, TargetPort,
+// Volumes, Secrets, EnvVars, ProxyMode, CmdArgs, Stateless, EndpointPrefix,
+// network/posture flags, permission profile, container name/labels (standard
+// labels), and registry fields are intentionally NOT copied here: they are
+// produced by the builder above (with image/env/secrets/registry URLs being the
+// deliberate deltas).
+//
+// It does not mutate old. Pointer and slice/map fields are shared read-only;
+// neither the workload manager nor the proxy mutates these structures in place.
+func preserveUserConfigFields(dst, old *runner.RunConfig) {
+	// Middleware-driving / security-relevant config.
+	dst.OIDCConfig = old.OIDCConfig
+	dst.AuthzConfig = old.AuthzConfig
+	dst.AuthzConfigPath = old.AuthzConfigPath
+	dst.AuditConfig = old.AuditConfig
+	dst.AuditConfigPath = old.AuditConfigPath
+	dst.TelemetryConfig = old.TelemetryConfig
+	dst.TokenExchangeConfig = old.TokenExchangeConfig
+	dst.AWSStsConfig = old.AWSStsConfig
+	dst.UpstreamSwapConfig = old.UpstreamSwapConfig
+	dst.EmbeddedAuthServerConfig = old.EmbeddedAuthServerConfig
+
+	// Tool exposure. Dropping these would broaden the exposed tool surface.
+	// ToolsFilter is replaced wholesale by the manager/proxy (never appended to),
+	// so sharing the slice is safe; ToolsOverride is cloned so the contract holds
+	// strictly even if a future caller mutates the map in place.
+	dst.ToolsFilter = old.ToolsFilter
+	dst.ToolsOverride = maps.Clone(old.ToolsOverride)
+
+	// The pre-built middleware chain. It is derived from the fields above; carry
+	// it over verbatim so the upgraded workload keeps the exact same chain rather
+	// than silently losing all middleware (the builder only rebuilds the chain
+	// via WithMiddlewareFromFlags, which we do not call).
+	dst.MiddlewareConfigs = old.MiddlewareConfigs
+	dst.ValidatingWebhooks = old.ValidatingWebhooks
+	dst.MutatingWebhooks = old.MutatingWebhooks
+
+	// Rate limiting.
+	dst.RateLimitConfig = old.RateLimitConfig
+	dst.RateLimitNamespace = old.RateLimitNamespace
+
+	// Remote server config (preserved for completeness; image upgrades are local,
+	// but a workload may carry these and they must not be dropped).
+	dst.RemoteURL = old.RemoteURL
+	dst.RemoteAuthConfig = old.RemoteAuthConfig
+	dst.HeaderForward = old.HeaderForward
+
+	// TargetHost and Publish: the builder never sets TargetHost (WithTargetHost
+	// re-derives it from RemoteURL, which is not what we want), and Publish is
+	// not passed as a builder option, so both must be copied directly from old.
+	dst.TargetHost = old.TargetHost
+	dst.Publish = old.Publish
+
+	// Proxy session / runtime / scheduling knobs.
+	dst.SessionTTL = old.SessionTTL
+	dst.RuntimeConfig = old.RuntimeConfig
+	dst.IgnoreConfig = old.IgnoreConfig
+	dst.K8sPodTemplatePatch = old.K8sPodTemplatePatch
+	dst.ScalingConfig = old.ScalingConfig
+	dst.MCPServerGeneration = old.MCPServerGeneration
+
+	// Debug flag and any user-set container labels not produced by the builder's
+	// standard-label step.
+	dst.Debug = old.Debug
+	for k, v := range old.ContainerLabels {
+		if _, ok := dst.ContainerLabels[k]; !ok {
+			dst.ContainerLabels[k] = v
+		}
+	}
+
+	// Deprecated/no-longer-used fields, preserved for byte-level fidelity.
+	dst.EnvFileDir = old.EnvFileDir
+	dst.ThvCABundle = old.ThvCABundle
+	dst.JWKSAuthTokenFile = old.JWKSAuthTokenFile
+}
+
+// mergeSecrets returns a new slice containing the old secret parameters plus any
+// of the additional parameters whose target is not already covered. It never
+// mutates the input slices. Parameters that fail to parse are preserved as-is
+// from old and skipped from additions (a malformed addition can't be deduped
+// safely and is dropped rather than silently shadowing a valid existing one).
+func mergeSecrets(oldSecrets, additional []string) []string {
+	merged := slices.Clone(oldSecrets)
+
+	existingTargets := make(map[string]struct{}, len(oldSecrets))
+	for _, s := range oldSecrets {
+		parsed, err := secrets.ParseSecretParameter(s)
+		if err != nil {
+			continue
+		}
+		if parsed.Target != "" {
+			existingTargets[parsed.Target] = struct{}{}
+		}
+	}
+
+	for _, s := range additional {
+		parsed, err := secrets.ParseSecretParameter(s)
+		if err != nil {
+			// A malformed addition can't be deduped; drop it rather than risk
+			// shadowing an existing valid target. This is explicit user input, so
+			// warn (logging only the parameter string, never any secret value).
+			slog.Warn("dropping malformed secret parameter from upgrade", "parameter", s)
+			continue
+		}
+		if parsed.Target != "" {
+			if _, ok := existingTargets[parsed.Target]; ok {
+				continue
+			}
+			existingTargets[parsed.Target] = struct{}{}
+		}
+		merged = append(merged, s)
+	}
+
+	return merged
+}

--- a/pkg/workloads/upgrade/applier_test.go
+++ b/pkg/workloads/upgrade/applier_test.go
@@ -1,0 +1,622 @@
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package upgrade
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/stacklok/toolhive-core/permissions"
+	regtypes "github.com/stacklok/toolhive-core/registry/types"
+	"github.com/stacklok/toolhive/pkg/auth"
+	appconfig "github.com/stacklok/toolhive/pkg/config"
+	configmocks "github.com/stacklok/toolhive/pkg/config/mocks"
+	"github.com/stacklok/toolhive/pkg/container/templates"
+	registrymocks "github.com/stacklok/toolhive/pkg/registry/mocks"
+	"github.com/stacklok/toolhive/pkg/runner"
+	"github.com/stacklok/toolhive/pkg/runner/retriever"
+	"github.com/stacklok/toolhive/pkg/telemetry"
+	transporttypes "github.com/stacklok/toolhive/pkg/transport/types"
+	"github.com/stacklok/toolhive/pkg/workloads"
+	workloadmocks "github.com/stacklok/toolhive/pkg/workloads/mocks"
+)
+
+const applyServerName = "example-server"
+
+// applierHarness wires an Applier with mocked dependencies and swappable
+// resolve/enforce/load function fields for deterministic, disk-free tests.
+type applierHarness struct {
+	applier    *Applier
+	manager    *workloadmocks.MockManager
+	provider   *registrymocks.MockProvider
+	configMock *configmocks.MockProvider
+
+	// loadState is what loadStateFn returns.
+	loadConfig *runner.RunConfig
+	loadErr    error
+
+	// resolve controls resolveFn.
+	resolveImageURL string
+	resolveMeta     regtypes.ServerMetadata
+	resolveErr      error
+
+	// enforce controls enforcePullFn.
+	enforceErr error
+
+	// captured records ordering and the config passed to each stage.
+	calls          []string
+	enforcedConfig *runner.RunConfig
+	updatedConfig  *runner.RunConfig
+}
+
+func newApplierHarness(t *testing.T) *applierHarness {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+
+	h := &applierHarness{
+		manager:    workloadmocks.NewMockManager(ctrl),
+		provider:   registrymocks.NewMockProvider(ctrl),
+		configMock: configmocks.NewMockProvider(ctrl),
+	}
+
+	checker, err := NewChecker(h.provider)
+	require.NoError(t, err)
+
+	applier, err := NewApplier(h.manager, checker, h.configMock)
+	require.NoError(t, err)
+
+	// Swap the package-level function wrappers for stubs that record ordering.
+	applier.loadStateFn = func(_ context.Context, _ string) (*runner.RunConfig, error) {
+		h.calls = append(h.calls, "load")
+		return h.loadConfig, h.loadErr
+	}
+	applier.resolveFn = func(
+		_ context.Context, _ string, _ string, _ string, _ string, _ *templates.RuntimeConfig,
+	) (string, regtypes.ServerMetadata, error) {
+		h.calls = append(h.calls, "resolve")
+		return h.resolveImageURL, h.resolveMeta, h.resolveErr
+	}
+	applier.enforcePullFn = func(
+		_ context.Context, rc *runner.RunConfig, _ regtypes.ServerMetadata, _ string,
+		_ retriever.ImagePuller, _ time.Duration, _ bool,
+	) error {
+		h.calls = append(h.calls, "enforce")
+		h.enforcedConfig = rc
+		return h.enforceErr
+	}
+
+	h.applier = applier
+	return h
+}
+
+// expectUpdate sets up the UpdateWorkload mock to record the config and order.
+func (h *applierHarness) expectUpdate() {
+	h.manager.EXPECT().
+		UpdateWorkload(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ string, cfg *runner.RunConfig) (workloads.CompletionFunc, error) {
+			h.calls = append(h.calls, "update")
+			h.updatedConfig = cfg
+			// The completion func records that Apply awaited it. UpdateWorkload
+			// persists the new config asynchronously, so Apply must block on this
+			// before returning or callers observe a stale, pre-upgrade workload.
+			return func() error { h.calls = append(h.calls, "complete"); return nil }, nil
+		})
+}
+
+func upgradeableConfig(t *testing.T) *runner.RunConfig {
+	t.Helper()
+	// Use a real directory for the volume source: the run config builder
+	// validates volume source paths against the filesystem.
+	volSrc := t.TempDir()
+	return &runner.RunConfig{
+		Name:               "wl",
+		Image:              "ghcr.io/example/server:1.0.0",
+		RegistryServerName: applyServerName,
+		Group:              "default",
+		Transport:          transporttypes.TransportTypeStdio,
+		ProxyMode:          transporttypes.ProxyModeStreamableHTTP,
+		Port:               8080,
+		EnvVars:            map[string]string{"LOG_LEVEL": "info"},
+		Secrets:            []string{"mykey,target=API_KEY"},
+		Volumes:            []string{volSrc + ":/container"},
+	}
+}
+
+func TestNewApplier(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	mgr := workloadmocks.NewMockManager(ctrl)
+	checker, err := NewChecker(registrymocks.NewMockProvider(ctrl))
+	require.NoError(t, err)
+	cfgProvider := configmocks.NewMockProvider(ctrl)
+
+	t.Run("nil manager fails", func(t *testing.T) {
+		t.Parallel()
+		a, err := NewApplier(nil, checker, cfgProvider)
+		require.Error(t, err)
+		assert.Nil(t, a)
+	})
+
+	t.Run("nil checker fails", func(t *testing.T) {
+		t.Parallel()
+		a, err := NewApplier(mgr, nil, cfgProvider)
+		require.Error(t, err)
+		assert.Nil(t, a)
+	})
+
+	t.Run("nil config provider fails", func(t *testing.T) {
+		t.Parallel()
+		a, err := NewApplier(mgr, checker, nil)
+		require.Error(t, err)
+		assert.Nil(t, a)
+	})
+
+	t.Run("valid inputs succeed with real funcs populated", func(t *testing.T) {
+		t.Parallel()
+		a, err := NewApplier(mgr, checker, cfgProvider)
+		require.NoError(t, err)
+		require.NotNil(t, a)
+		assert.NotNil(t, a.resolveFn)
+		assert.NotNil(t, a.enforcePullFn)
+		assert.NotNil(t, a.loadStateFn)
+	})
+}
+
+func TestApplier_Apply_NoOpWhenNotUpgradeAvailable(t *testing.T) {
+	t.Parallel()
+	h := newApplierHarness(t)
+
+	// up-to-date: candidate equals current => StatusUpToDate.
+	h.loadConfig = upgradeableConfig(t)
+	h.provider.EXPECT().
+		GetServer(applyServerName).
+		Return(&regtypes.ImageMetadata{Image: "ghcr.io/example/server:1.0.0"}, nil)
+
+	// UpdateWorkload, resolve, enforce must NEVER be called.
+	res, err := h.applier.Apply(context.Background(), "wl", ApplyOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	assert.Equal(t, StatusUpToDate, res.Status)
+	assert.NotContains(t, h.calls, "resolve")
+	assert.NotContains(t, h.calls, "enforce")
+	assert.NotContains(t, h.calls, "update")
+}
+
+func TestApplier_Apply_NoOpWhenNotRegistrySourced(t *testing.T) {
+	t.Parallel()
+	h := newApplierHarness(t)
+
+	cfg := upgradeableConfig(t)
+	cfg.RegistryServerName = "" // not registry-sourced
+	h.loadConfig = cfg
+
+	res, err := h.applier.Apply(context.Background(), "wl", ApplyOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	assert.Equal(t, StatusNotRegistrySourced, res.Status)
+	assert.NotContains(t, h.calls, "resolve")
+	assert.NotContains(t, h.calls, "update")
+}
+
+func TestApplier_Apply_LoadStateFailure(t *testing.T) {
+	t.Parallel()
+	h := newApplierHarness(t)
+	h.loadErr = errors.New("no such workload")
+
+	res, err := h.applier.Apply(context.Background(), "wl", ApplyOptions{})
+	require.Error(t, err)
+	assert.Nil(t, res)
+	assert.NotContains(t, h.calls, "update")
+}
+
+func TestApplier_Apply_ResolveFailureLeavesWorkloadUntouched(t *testing.T) {
+	t.Parallel()
+	h := newApplierHarness(t)
+
+	h.loadConfig = upgradeableConfig(t)
+	h.provider.EXPECT().
+		GetServer(applyServerName).
+		Return(&regtypes.ImageMetadata{Image: "ghcr.io/example/server:1.2.0"}, nil)
+	h.resolveErr = errors.New("verification failed")
+
+	res, err := h.applier.Apply(context.Background(), "wl", ApplyOptions{})
+	require.Error(t, err)
+	assert.Nil(t, res)
+	// resolve attempted, but no enforce and no destructive update.
+	assert.Contains(t, h.calls, "resolve")
+	assert.NotContains(t, h.calls, "enforce")
+	assert.NotContains(t, h.calls, "update")
+}
+
+func TestApplier_Apply_RemoteMetadataIsRejected(t *testing.T) {
+	t.Parallel()
+	h := newApplierHarness(t)
+
+	h.loadConfig = upgradeableConfig(t)
+	h.provider.EXPECT().
+		GetServer(applyServerName).
+		Return(&regtypes.ImageMetadata{Image: "ghcr.io/example/server:1.2.0"}, nil)
+	// Resolve succeeds but returns a non-image (remote) metadata.
+	h.resolveImageURL = "ghcr.io/example/server:1.2.0"
+	h.resolveMeta = &regtypes.RemoteServerMetadata{}
+
+	res, err := h.applier.Apply(context.Background(), "wl", ApplyOptions{})
+	require.Error(t, err)
+	assert.Nil(t, res)
+	assert.Contains(t, h.calls, "resolve")
+	assert.NotContains(t, h.calls, "enforce")
+	assert.NotContains(t, h.calls, "update")
+}
+
+func TestApplier_Apply_EnforcePullFailureLeavesWorkloadUntouched(t *testing.T) {
+	t.Parallel()
+	h := newApplierHarness(t)
+
+	h.loadConfig = upgradeableConfig(t)
+	h.provider.EXPECT().
+		GetServer(applyServerName).
+		Return(&regtypes.ImageMetadata{Image: "ghcr.io/example/server:1.2.0"}, nil)
+	h.resolveImageURL = "ghcr.io/example/server:1.2.0"
+	h.resolveMeta = &regtypes.ImageMetadata{Image: "ghcr.io/example/server:1.2.0"}
+	h.configMock.EXPECT().GetConfig().Return(&appconfig.Config{}).AnyTimes()
+	h.enforceErr = errors.New("policy denied")
+
+	res, err := h.applier.Apply(context.Background(), "wl", ApplyOptions{
+		EnvVarValidator: &runner.DetachedEnvVarValidator{},
+	})
+	require.Error(t, err)
+	assert.Nil(t, res)
+	assert.Contains(t, h.calls, "enforce")
+	assert.NotContains(t, h.calls, "update")
+}
+
+func TestApplier_Apply_HappyPath(t *testing.T) {
+	t.Parallel()
+	h := newApplierHarness(t)
+
+	old := upgradeableConfig(t)
+	h.loadConfig = old
+	h.provider.EXPECT().
+		GetServer(applyServerName).
+		Return(&regtypes.ImageMetadata{Image: "ghcr.io/example/server:1.2.0"}, nil)
+	candidate := &regtypes.ImageMetadata{Image: "ghcr.io/example/server:1.2.0"}
+	candidate.Name = applyServerName
+	h.resolveImageURL = "ghcr.io/example/server:1.2.0"
+	h.resolveMeta = candidate
+	h.configMock.EXPECT().
+		GetConfig().
+		Return(&appconfig.Config{RegistryApiUrl: "https://api.example", RegistryUrl: "https://reg.example"}).
+		AnyTimes()
+	h.expectUpdate()
+
+	res, err := h.applier.Apply(context.Background(), "wl", ApplyOptions{
+		EnvVars:         map[string]string{"EXTRA": "val"},
+		Secrets:         []string{"othersecret,target=OTHER"},
+		EnvVarValidator: &runner.DetachedEnvVarValidator{},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	assert.Equal(t, StatusUpgradeAvailable, res.Status)
+
+	// The destructive update must have run with the candidate image.
+	require.NotNil(t, h.updatedConfig)
+	assert.Equal(t, "ghcr.io/example/server:1.2.0", h.updatedConfig.Image, "image must be the candidate")
+	assert.Equal(t, applyServerName, h.updatedConfig.RegistryServerName, "registry server name preserved")
+	assert.Equal(t, "wl", h.updatedConfig.Name, "name preserved")
+	assert.Equal(t, "default", h.updatedConfig.Group, "group preserved")
+
+	// User env vars preserved + opts merged.
+	assert.Equal(t, "info", h.updatedConfig.EnvVars["LOG_LEVEL"], "existing env preserved")
+	assert.Equal(t, "val", h.updatedConfig.EnvVars["EXTRA"], "opts env merged")
+
+	// Secrets preserved + opts merged.
+	assert.Contains(t, h.updatedConfig.Secrets, "mykey,target=API_KEY", "existing secret preserved")
+	assert.Contains(t, h.updatedConfig.Secrets, "othersecret,target=OTHER", "opts secret merged")
+
+	// Registry source URLs recorded from app config.
+	assert.Equal(t, "https://api.example", h.updatedConfig.RegistryAPIURL)
+	assert.Equal(t, "https://reg.example", h.updatedConfig.RegistryURL)
+
+	// Security guarantee: the exact config that was gated+pulled is the one that
+	// gets deployed, so the verified image is the one that runs.
+	assert.Same(t, h.enforcedConfig, h.updatedConfig, "pulled config must be the deployed config")
+}
+
+func TestApplier_Apply_OptsEnvOverridesExisting(t *testing.T) {
+	t.Parallel()
+	h := newApplierHarness(t)
+
+	h.loadConfig = upgradeableConfig(t)
+	h.provider.EXPECT().
+		GetServer(applyServerName).
+		Return(&regtypes.ImageMetadata{Image: "ghcr.io/example/server:1.2.0"}, nil)
+	h.resolveImageURL = "ghcr.io/example/server:1.2.0"
+	h.resolveMeta = &regtypes.ImageMetadata{Image: "ghcr.io/example/server:1.2.0"}
+	h.configMock.EXPECT().GetConfig().Return(&appconfig.Config{}).AnyTimes()
+	h.expectUpdate()
+
+	_, err := h.applier.Apply(context.Background(), "wl", ApplyOptions{
+		EnvVars:         map[string]string{"LOG_LEVEL": "debug"}, // overrides existing "info"
+		EnvVarValidator: &runner.DetachedEnvVarValidator{},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, h.updatedConfig)
+	assert.Equal(t, "debug", h.updatedConfig.EnvVars["LOG_LEVEL"], "opts env overrides existing")
+}
+
+func TestApplier_Apply_DoesNotMutateOldConfig(t *testing.T) {
+	t.Parallel()
+	h := newApplierHarness(t)
+
+	old := upgradeableConfig(t)
+	// A non-named profile object plus a volume is what exposes the mutation: the
+	// builder's processVolumeMounts appends the volume to PermissionProfile.Read
+	// or .Write. If the builder is handed old's profile by pointer, those appends
+	// leak back into old. (upgradeableConfig already sets a Volume.)
+	old.PermissionProfile = &permissions.Profile{Name: "custom"}
+	wantVolumes := slices.Clone(old.Volumes)
+	wantProfileRead := slices.Clone(old.PermissionProfile.Read)
+	wantProfileWrite := slices.Clone(old.PermissionProfile.Write)
+	wantOverride := map[string]runner.ToolOverride{"a": {Name: "b"}}
+	old.ToolsOverride = map[string]runner.ToolOverride{"a": {Name: "b"}}
+	h.loadConfig = old
+	h.provider.EXPECT().
+		GetServer(applyServerName).
+		Return(&regtypes.ImageMetadata{Image: "ghcr.io/example/server:1.2.0"}, nil)
+	h.resolveImageURL = "ghcr.io/example/server:1.2.0"
+	h.resolveMeta = &regtypes.ImageMetadata{Image: "ghcr.io/example/server:1.2.0"}
+	h.configMock.EXPECT().GetConfig().Return(&appconfig.Config{}).AnyTimes()
+	h.expectUpdate()
+
+	_, err := h.applier.Apply(context.Background(), "wl", ApplyOptions{
+		EnvVars:         map[string]string{"EXTRA": "val"},
+		Secrets:         []string{"othersecret,target=OTHER"},
+		EnvVarValidator: &runner.DetachedEnvVarValidator{},
+	})
+	require.NoError(t, err)
+
+	// old must be untouched: image, env map, secrets slice, volumes slice.
+	assert.Equal(t, "ghcr.io/example/server:1.0.0", old.Image, "old image unchanged")
+	assert.Equal(t, map[string]string{"LOG_LEVEL": "info"}, old.EnvVars, "old EnvVars unchanged")
+	assert.Equal(t, []string{"mykey,target=API_KEY"}, old.Secrets, "old Secrets unchanged")
+	assert.Equal(t, wantVolumes, old.Volumes, "old Volumes unchanged")
+	// old's permission profile must not gain mounts from the volume processing.
+	assert.Equal(t, wantProfileRead, old.PermissionProfile.Read, "old profile Read unchanged")
+	assert.Equal(t, wantProfileWrite, old.PermissionProfile.Write, "old profile Write unchanged")
+	assert.Equal(t, wantOverride, old.ToolsOverride, "old ToolsOverride unchanged")
+}
+
+func TestApplier_Apply_VerifyAndPullHappenBeforeUpdate(t *testing.T) {
+	t.Parallel()
+	h := newApplierHarness(t)
+
+	h.loadConfig = upgradeableConfig(t)
+	h.provider.EXPECT().
+		GetServer(applyServerName).
+		Return(&regtypes.ImageMetadata{Image: "ghcr.io/example/server:1.2.0"}, nil)
+	h.resolveImageURL = "ghcr.io/example/server:1.2.0"
+	h.resolveMeta = &regtypes.ImageMetadata{Image: "ghcr.io/example/server:1.2.0"}
+	h.configMock.EXPECT().GetConfig().Return(&appconfig.Config{}).AnyTimes()
+	h.expectUpdate()
+
+	_, err := h.applier.Apply(context.Background(), "wl", ApplyOptions{
+		EnvVarValidator: &runner.DetachedEnvVarValidator{},
+	})
+	require.NoError(t, err)
+
+	// Ordering: load -> resolve -> enforce(verify+pull) -> update -> await completion.
+	assert.Equal(t, []string{"load", "resolve", "enforce", "update", "complete"}, h.calls)
+}
+
+func TestApplier_Apply_CompletionFailureSurfaces(t *testing.T) {
+	t.Parallel()
+	h := newApplierHarness(t)
+
+	h.loadConfig = upgradeableConfig(t)
+	h.provider.EXPECT().
+		GetServer(applyServerName).
+		Return(&regtypes.ImageMetadata{Image: "ghcr.io/example/server:1.2.0"}, nil)
+	h.resolveImageURL = "ghcr.io/example/server:1.2.0"
+	h.resolveMeta = &regtypes.ImageMetadata{Image: "ghcr.io/example/server:1.2.0"}
+	h.configMock.EXPECT().GetConfig().Return(&appconfig.Config{}).AnyTimes()
+
+	// UpdateWorkload starts the recreate but its completion reports a failure
+	// (e.g. the new workload failed to start). Apply must await completion and
+	// surface that error rather than reporting a successful upgrade.
+	h.manager.EXPECT().
+		UpdateWorkload(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ string, _ *runner.RunConfig) (workloads.CompletionFunc, error) {
+			h.calls = append(h.calls, "update")
+			return func() error { return errors.New("new workload failed to start") }, nil
+		})
+
+	_, err := h.applier.Apply(context.Background(), "wl", ApplyOptions{
+		EnvVarValidator: &runner.DetachedEnvVarValidator{},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to complete upgrade")
+	// The error MUST carry ErrApplyAfterDestroy: the recreate already began, so
+	// callers (e.g. the API handler) map this to 5xx, not a 422 "nothing changed".
+	assert.ErrorIs(t, err, ErrApplyAfterDestroy)
+	assert.Contains(t, h.calls, "update")
+}
+
+func TestApplier_Apply_UpdateFailureIsTaggedAfterDestroy(t *testing.T) {
+	t.Parallel()
+	h := newApplierHarness(t)
+
+	h.loadConfig = upgradeableConfig(t)
+	h.provider.EXPECT().
+		GetServer(applyServerName).
+		Return(&regtypes.ImageMetadata{Image: "ghcr.io/example/server:1.2.0"}, nil)
+	h.resolveImageURL = "ghcr.io/example/server:1.2.0"
+	h.resolveMeta = &regtypes.ImageMetadata{Image: "ghcr.io/example/server:1.2.0"}
+	h.configMock.EXPECT().GetConfig().Return(&appconfig.Config{}).AnyTimes()
+
+	// UpdateWorkload itself fails after initiating the stop/delete: the workload
+	// state is uncertain, so the error must carry ErrApplyAfterDestroy.
+	h.manager.EXPECT().
+		UpdateWorkload(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ string, _ *runner.RunConfig) (workloads.CompletionFunc, error) {
+			h.calls = append(h.calls, "update")
+			return nil, errors.New("stop/delete failed mid-recreate")
+		})
+
+	_, err := h.applier.Apply(context.Background(), "wl", ApplyOptions{
+		EnvVarValidator: &runner.DetachedEnvVarValidator{},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to update workload")
+	assert.ErrorIs(t, err, ErrApplyAfterDestroy)
+}
+
+// fullyConfiguredOld builds a workload config exercising the breadth of
+// user-owned RunConfig fields, including HTTP transport with explicit ports and
+// a named permission profile, to guard against the config-loss regression.
+func fullyConfiguredOld(t *testing.T) *runner.RunConfig {
+	t.Helper()
+	volSrc := t.TempDir()
+
+	mw, err := transporttypes.NewMiddlewareConfig(auth.MiddlewareType, auth.MiddlewareParams{})
+	require.NoError(t, err)
+
+	return &runner.RunConfig{
+		Name:                        "wl",
+		Image:                       "ghcr.io/example/server:1.0.0",
+		RegistryServerName:          applyServerName,
+		Group:                       "prod",
+		Transport:                   transporttypes.TransportTypeStreamableHTTP,
+		ProxyMode:                   transporttypes.ProxyModeStreamableHTTP,
+		Host:                        "127.0.0.1",
+		Port:                        18080,
+		TargetPort:                  19090,
+		TargetHost:                  "10.0.0.5",
+		Publish:                     []string{"18080:18080"},
+		EnvVars:                     map[string]string{"LOG_LEVEL": "info"},
+		Secrets:                     []string{"mykey,target=API_KEY"},
+		Volumes:                     []string{volSrc + ":/container"},
+		CmdArgs:                     []string{"--flag", "value"},
+		PermissionProfileNameOrPath: "none",
+		IsolateNetwork:              true,
+		TrustProxyHeaders:           true,
+		Stateless:                   true,
+		EndpointPrefix:              "/mcp",
+		SessionTTL:                  "30m",
+		Debug:                       true,
+		ContainerLabels:             map[string]string{"team": "platform"},
+		OIDCConfig:                  &auth.TokenValidatorConfig{Issuer: "https://issuer.example", Audience: "aud"},
+		AuthzConfigPath:             "/etc/thv/authz.yaml",
+		AuditConfigPath:             "/etc/thv/audit.yaml",
+		TelemetryConfig:             &telemetry.Config{Endpoint: "otel.example:4317", ServiceName: "wl"},
+		ToolsFilter:                 []string{"safe_tool"},
+		ToolsOverride:               map[string]runner.ToolOverride{"a": {Name: "b"}},
+		MiddlewareConfigs:           []transporttypes.MiddlewareConfig{*mw},
+	}
+}
+
+func TestApplier_Apply_PreservesFullUserConfig(t *testing.T) {
+	t.Parallel()
+	h := newApplierHarness(t)
+
+	old := fullyConfiguredOld(t)
+	h.loadConfig = old
+	h.provider.EXPECT().
+		GetServer(applyServerName).
+		Return(&regtypes.ImageMetadata{Image: "ghcr.io/example/server:1.2.0"}, nil)
+	// The candidate metadata advertises the same HTTP transport so the builder
+	// does not need to invent transport/ports; ports come from old.
+	candidate := &regtypes.ImageMetadata{Image: "ghcr.io/example/server:1.2.0"}
+	candidate.Transport = string(transporttypes.TransportTypeStreamableHTTP)
+	h.resolveImageURL = "ghcr.io/example/server:1.2.0"
+	h.resolveMeta = candidate
+	h.configMock.EXPECT().
+		GetConfig().
+		Return(&appconfig.Config{RegistryApiUrl: "https://api.example", RegistryUrl: "https://reg.example"}).
+		AnyTimes()
+	h.expectUpdate()
+
+	_, err := h.applier.Apply(context.Background(), "wl", ApplyOptions{
+		EnvVarValidator: &runner.DetachedEnvVarValidator{},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, h.updatedConfig)
+	got := h.updatedConfig
+
+	// The ONLY changes are image and registry URLs (no env/secret opts here).
+	assert.Equal(t, "ghcr.io/example/server:1.2.0", got.Image, "image is candidate")
+	assert.Equal(t, "https://api.example", got.RegistryAPIURL)
+	assert.Equal(t, "https://reg.example", got.RegistryURL)
+
+	// Everything else preserved from old (the config-loss regression guard).
+	assert.Equal(t, old.Name, got.Name)
+	assert.Equal(t, old.Group, got.Group)
+	assert.Equal(t, old.Transport, got.Transport, "HTTP transport preserved")
+	assert.Equal(t, old.Host, got.Host)
+	assert.Equal(t, old.Port, got.Port, "HTTP proxy port preserved")
+	assert.Equal(t, old.TargetPort, got.TargetPort, "HTTP target port preserved")
+	assert.Equal(t, "10.0.0.5", got.TargetHost, "target host preserved (not re-derived)")
+	assert.Equal(t, old.Publish, got.Publish, "published ports preserved")
+	assert.Equal(t, old.ProxyMode, got.ProxyMode)
+	assert.Equal(t, old.CmdArgs, got.CmdArgs)
+	assert.Equal(t, old.PermissionProfileNameOrPath, got.PermissionProfileNameOrPath, "named profile preserved")
+	assert.Equal(t, old.IsolateNetwork, got.IsolateNetwork)
+	assert.Equal(t, old.TrustProxyHeaders, got.TrustProxyHeaders)
+	assert.Equal(t, old.Stateless, got.Stateless)
+	assert.Equal(t, old.EndpointPrefix, got.EndpointPrefix)
+	assert.Equal(t, old.SessionTTL, got.SessionTTL)
+	assert.Equal(t, old.Debug, got.Debug)
+	assert.Equal(t, "platform", got.ContainerLabels["team"], "user label preserved")
+	assert.Equal(t, old.OIDCConfig, got.OIDCConfig, "OIDC config preserved")
+	assert.Equal(t, old.AuthzConfigPath, got.AuthzConfigPath, "authz path preserved")
+	assert.Equal(t, old.AuditConfigPath, got.AuditConfigPath, "audit path preserved")
+	assert.Equal(t, old.TelemetryConfig, got.TelemetryConfig, "telemetry preserved")
+	assert.Equal(t, old.ToolsFilter, got.ToolsFilter, "tools filter preserved (security)")
+	assert.Equal(t, old.ToolsOverride, got.ToolsOverride)
+	assert.Equal(t, old.MiddlewareConfigs, got.MiddlewareConfigs, "middleware chain preserved")
+}
+
+func TestApplier_Apply_PreservesHTTPTransportPorts(t *testing.T) {
+	t.Parallel()
+	h := newApplierHarness(t)
+
+	old := &runner.RunConfig{
+		Name:               "wl",
+		Image:              "ghcr.io/example/server:1.0.0",
+		RegistryServerName: applyServerName,
+		Group:              "default",
+		Transport:          transporttypes.TransportTypeStreamableHTTP,
+		ProxyMode:          transporttypes.ProxyModeStreamableHTTP,
+		Port:               21000,
+		TargetPort:         22000,
+		EnvVars:            map[string]string{},
+	}
+	h.loadConfig = old
+	h.provider.EXPECT().
+		GetServer(applyServerName).
+		Return(&regtypes.ImageMetadata{Image: "ghcr.io/example/server:1.2.0"}, nil)
+	candidate := &regtypes.ImageMetadata{Image: "ghcr.io/example/server:1.2.0"}
+	candidate.Transport = string(transporttypes.TransportTypeStreamableHTTP)
+	// Candidate advertises DIFFERENT registry ports; old's ports must win.
+	candidate.ProxyPort = 30000
+	candidate.TargetPort = 31000
+	h.resolveImageURL = "ghcr.io/example/server:1.2.0"
+	h.resolveMeta = candidate
+	h.configMock.EXPECT().GetConfig().Return(&appconfig.Config{}).AnyTimes()
+	h.expectUpdate()
+
+	_, err := h.applier.Apply(context.Background(), "wl", ApplyOptions{
+		EnvVarValidator: &runner.DetachedEnvVarValidator{},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, h.updatedConfig)
+	assert.Equal(t, 21000, h.updatedConfig.Port, "existing proxy port preserved over candidate's")
+	assert.Equal(t, 22000, h.updatedConfig.TargetPort, "existing target port preserved over candidate's")
+}


### PR DESCRIPTION
## Summary

Detecting an available upgrade is only useful if users can apply it while keeping their configuration. This adds the apply core that the CLI and API drive in the next PR. Part of [RFC THV-0068](https://github.com/stacklok/toolhive-rfcs/blob/main/rfcs/THV-0068-workload-upgrade.md), local scope.

- Add `upgrade.Applier`: it reloads the workload's saved config, **re-runs the check on fresh state** (so a stale result can never drive an apply — closes the TOCTOU window), resolves the candidate from the registry, and rebuilds the run config **preserving the full user configuration** (auth, authz, audit, telemetry, tools filters, volumes, secrets, ports, permission profile, …), changing only the image, merged env/secrets, and re-resolved registry URLs. Newly required env vars surface through the injected validator.
- **Security-critical ordering:** the candidate image is verified and pulled (and the policy gate runs) **before** the destructive stop/delete/start, so a missing or unverifiable image leaves the running workload untouched — there is no rollback once `UpdateWorkload` begins. Verification uses the same path as `thv run`.
- Apply awaits `UpdateWorkload`'s completion so the upgraded config is durably persisted before returning (both CLI and API are synchronous).

## Type of change

- [x] New feature

## Test plan

- [x] Unit tests (`task test`) — no-op when up-to-date; resolve/verify/pull failure leaves the workload untouched (`UpdateWorkload` never called); ordering assertion (verify+pull before update, completion awaited); the exact gated+pulled config is the deployed one; full-config preservation; copy-before-mutate; completion-failure surfaces as an error.
- [x] Linting (`task lint-fix`)

## Changes

| File | Change |
|------|--------|
| `pkg/workloads/upgrade/applier.go` | `Applier`, `Apply`, config merge/preservation |
| `pkg/workloads/upgrade/applier_test.go` | Unit tests (manager + retriever seams mocked) |

## Does this introduce a user-facing change?

No — internal apply path. The `thv upgrade apply` command and `POST .../upgrade` endpoint that drive it land in PR 5.

## Large PR Justification

This PR is ~1,015 lines, but **576 are unit tests** and **439 are a single source file** (`applier.go`).

- **The apply path must be atomic to be reviewable.** `Apply` is one sequence — load → re-check → resolve+verify → rebuild (preserving every user-owned field) → pull → recreate → await completion. Splitting it would create half-built intermediate states that neither compile meaningfully nor convey the security-critical ordering that is the whole point of the change.
- **This is the highest-risk code in the feature**, so its tests are intentionally exhaustive (the 576 lines cover every failure point, the verify-before-destroy ordering, full-config preservation, and copy-before-mutate). They must ship with the code under review.
- No generated code; the size is genuinely source+tests for one cohesive unit.

## Special notes for reviewers

**PR 4 of 6** in the RFC THV-0068 stack; based on #5409. This is the highest-risk change — the destructive recreate path. The verify-then-pull-before-destroy ordering and full-config preservation were the focus of the security/Go review (an earlier draft silently dropped auth/audit/tools-filter config on upgrade; now every user-owned field is preserved). On Kubernetes the byte-level pull is delegated to the kubelet, but verification + policy gate still precede destruction; local runtime is the RFC's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)