### PR TITLE
Deprecate Roo Code client integration

### DIFF
--- a/cmd/thv/app/client.go
+++ b/cmd/thv/app/client.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"os"
 	"sort"
 
 	"github.com/spf13/cobra"
@@ -162,6 +163,7 @@ func registerSelectedClients(cmd *cobra.Command, clientsToRegister []client.Clie
 	clients := make([]client.Client, len(clientsToRegister))
 	for i, cli := range clientsToRegister {
 		clients[i] = client.Client{Name: cli.ClientType}
+		warnIfDeprecatedClient(cli.ClientType)
 	}
 
 	return performClientRegistration(cmd.Context(), clients, selectedGroups)
@@ -175,6 +177,8 @@ func clientRegisterCmdFunc(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("invalid client type: %s (valid types: %s)", clientType, client.GetClientListCSV())
 	}
 
+	warnIfDeprecatedClient(client.ClientApp(clientType))
+
 	return performClientRegistration(cmd.Context(), []client.Client{{Name: client.ClientApp(clientType)}}, groupAddNames)
 }
 
@@ -186,7 +190,17 @@ func clientRemoveCmdFunc(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("invalid client type: %s (valid types: %s)", clientType, client.GetClientListCSV())
 	}
 
+	warnIfDeprecatedClient(client.ClientApp(clientType))
+
 	return performClientRemoval(cmd.Context(), client.Client{Name: client.ClientApp(clientType)}, groupRmNames)
+}
+
+// warnIfDeprecatedClient prints a deprecation warning to stderr when the given
+// client integration is deprecated. It is a no-op for active clients.
+func warnIfDeprecatedClient(clientType client.ClientApp) {
+	if message, deprecated := client.GetClientDeprecation(clientType); deprecated {
+		fmt.Fprintf(os.Stderr, "Warning: %s\n", message)
+	}
 }
 
 func listRegisteredClientsCmdFunc(cmd *cobra.Command, _ []string) error {

--- a/docs/cli/thv_client_register.md
+++ b/docs/cli/thv_client_register.md
@@ -38,7 +38,7 @@ Valid clients:
   - lm-studio: LM Studio application
   - mistral-vibe: Mistral Vibe IDE
   - opencode: OpenCode editor
-  - roo-code: VS Code Roo Code extension
+  - roo-code: VS Code Roo Code extension (deprecated)
   - trae: Trae IDE
   - vscode: Visual Studio Code
   - vscode-insider: Visual Studio Code Insiders

--- a/docs/cli/thv_client_remove.md
+++ b/docs/cli/thv_client_remove.md
@@ -38,7 +38,7 @@ Valid clients:
   - lm-studio: LM Studio application
   - mistral-vibe: Mistral Vibe IDE
   - opencode: OpenCode editor
-  - roo-code: VS Code Roo Code extension
+  - roo-code: VS Code Roo Code extension (deprecated)
   - trae: Trae IDE
   - vscode: Visual Studio Code
   - vscode-insider: Visual Studio Code Insiders

--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -203,8 +203,15 @@ type LLMEnvFileKeySpec struct {
 
 // clientAppConfig represents a configuration path for a supported MCP client.
 type clientAppConfig struct {
-	ClientType                    ClientApp
-	Description                   string
+	ClientType  ClientApp
+	Description string
+	// Deprecated marks a client integration whose upstream tool is no longer
+	// maintained. Deprecated clients still function but are flagged in the CLI
+	// client list and trigger a warning when registered or removed.
+	Deprecated bool
+	// DeprecationMessage is the full warning text shown to users (on stderr)
+	// when they touch a deprecated client. Only set when Deprecated is true.
+	DeprecationMessage            string
 	RelPath                       []string
 	SettingsFile                  string
 	PlatformPrefix                map[Platform][]string
@@ -294,8 +301,13 @@ var (
 
 var supportedClientIntegrations = []clientAppConfig{
 	{
-		ClientType:   RooCode,
-		Description:  "VS Code Roo Code extension",
+		ClientType:  RooCode,
+		Description: "VS Code Roo Code extension",
+		Deprecated:  true,
+		DeprecationMessage: "The Roo Code VS Code extension has been discontinued (last release May 15, 2026)\n" +
+			"and its repository has been archived. Support for this client will be removed in a\n" +
+			"future ToolHive release. The Roo Code team recommends migrating to Cline:\n" +
+			"  thv client register cline",
 		SettingsFile: "mcp_settings.json",
 		RelPath: []string{
 			"Code", "User", "globalStorage", "rooveterinaryinc.roo-cline", "settings",
@@ -1080,6 +1092,18 @@ func GetClientDescription(clientType ClientApp) string {
 	return ""
 }
 
+// GetClientDeprecation returns the deprecation warning message for a client type
+// and whether the client is deprecated. The message is empty when the client is
+// not deprecated.
+func GetClientDeprecation(clientType ClientApp) (string, bool) {
+	for _, config := range supportedClientIntegrations {
+		if config.ClientType == clientType {
+			return config.DeprecationMessage, config.Deprecated
+		}
+	}
+	return "", false
+}
+
 // GetClientListFormatted returns a formatted multi-line string listing all supported clients
 // with their descriptions, sorted alphabetically. This is suitable for use in CLI help text.
 func GetClientListFormatted() string {
@@ -1096,7 +1120,11 @@ func GetClientListFormatted() string {
 
 	var sb strings.Builder
 	for _, config := range configs {
-		fmt.Fprintf(&sb, "  - %s: %s\n", config.ClientType, config.Description)
+		description := config.Description
+		if config.Deprecated {
+			description += " (deprecated)"
+		}
+		fmt.Fprintf(&sb, "  - %s: %s\n", config.ClientType, description)
 	}
 	return strings.TrimSuffix(sb.String(), "\n")
 }


### PR DESCRIPTION
## Summary

The Roo Code VS Code extension was discontinued on May 15, 2026 and its repository archived, with the upstream team officially recommending Cline as the migration path. ToolHive still shipped the `roo-code` integration with no indication it's unmaintained, which falsely signals it's supported. This is Phase 1 of the sunset plan in #5017: deprecate now, remove in a later release.

What changed:
- Added `Deprecated` and `DeprecationMessage` fields to the client config plus a `GetClientDeprecation()` helper in `pkg/client`.
- `thv client register roo-code`, `thv client remove roo-code`, and the interactive `thv client setup` flow now print a deprecation warning to stderr pointing users to `thv client register cline`.
- The CLI client list marks the entry `roo-code: VS Code Roo Code extension (deprecated)`; regenerated `docs/cli/thv_client_register.md` and `thv_client_remove.md`.

Phase 2 (full removal) is intentionally out of scope; it's gated to a later release per the issue.

Part of #5017

## Type of change

- [x] Refactor/maintenance (deprecation; no functional change to working code paths)

## Test plan

- [x] Built with `task build`, ran `task lint-fix` (clean), and verified the warning and `(deprecated)` marker via `thv client register roo-code` / `--help`
- [x] `task test` passes for affected packages (one pre-existing, environment-dependent failure in `pkg/skills/client` unrelated to this change)

## Does this introduce a user-facing change?

Yes. Users who register, remove, or set up the `roo-code` client now see a deprecation warning recommending Cline. The client still functions; nothing is removed yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
