### PR TITLE
Persist config backward-compat migrations to load path

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -190,8 +190,11 @@ func createNewConfigWithDefaults() Config {
 	}
 }
 
-// applyBackwardCompatibility applies backward compatibility fixes to existing configs
-func applyBackwardCompatibility(config *Config) error {
+// applyBackwardCompatibility applies backward compatibility fixes to existing configs.
+// Any migration that needs to be persisted is written back to configPath, the same
+// path the config was loaded from, so that path-based loads (e.g. PathProvider) stay
+// isolated. An empty configPath falls back to the default path via saveToPath.
+func applyBackwardCompatibility(config *Config, configPath string) error {
 	// Hack - if the secrets provider type is set to the old `basic` type,
 	// just change it to `encrypted`.
 	if config.Secrets.ProviderType == "basic" {
@@ -202,7 +205,7 @@ func applyBackwardCompatibility(config *Config) error {
 			_ = os.Remove(oldPath)
 		}
 		config.Secrets.ProviderType = string(secrets.EncryptedType)
-		err = config.save()
+		err = config.saveToPath(configPath)
 		if err != nil {
 			return fmt.Errorf("error updating config: %w", err)
 		}
@@ -212,7 +215,7 @@ func applyBackwardCompatibility(config *Config) error {
 	// consider it as setup completed (for existing users)
 	if config.Secrets.ProviderType != "" && !config.Secrets.SetupCompleted {
 		config.Secrets.SetupCompleted = true
-		err := config.save()
+		err := config.saveToPath(configPath)
 		if err != nil {
 			return fmt.Errorf("error updating config for backward compatibility: %w", err)
 		}
@@ -291,19 +294,15 @@ func LoadOrCreateConfigFromPath(configPath string) (*Config, error) {
 			return nil, fmt.Errorf("failed to parse config file yaml: %w", err)
 		}
 
-		// Apply backward compatibility fixes
-		err = applyBackwardCompatibility(&config)
+		// Apply backward compatibility fixes, persisting any migration back to the
+		// same path the config was loaded from.
+		err = applyBackwardCompatibility(&config, configPath)
 		if err != nil {
 			return nil, fmt.Errorf("failed to apply backward compatibility fixes: %w", err)
 		}
 	}
 
 	return &config, nil
-}
-
-// Save serializes the config struct and writes it to disk.
-func (c *Config) save() error {
-	return c.saveToPath("")
 }
 
 // saveToPath serializes the config struct and writes it to a specific path.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -282,6 +282,46 @@ func TestUpdateConfigAtPath_CallbackError(t *testing.T) {
 		"config should not be written to disk when the callback returns an error")
 }
 
+// TestLoadFromPath_BackwardCompatMigrationStaysOnPath guards the test-isolation
+// regression from issue #894: a path-based load that triggers a backward-compat
+// migration must persist the migration back to the same path, never to the
+// default (real) config path. See applyBackwardCompatibility.
+//
+//nolint:paralleltest // swaps the package-level getConfigPath; must not run in parallel
+func TestLoadFromPath_BackwardCompatMigrationStaysOnPath(t *testing.T) {
+	// Not parallel: this test swaps the package-level getConfigPath sentinel.
+
+	// Point the default path generator at a sentinel that must never be written.
+	sentinelPath := filepath.Join(t.TempDir(), "should-never-exist", "config.yaml")
+	originalGetConfigPath := getConfigPath
+	getConfigPath = func() (string, error) { return sentinelPath, nil }
+	t.Cleanup(func() { getConfigPath = originalGetConfigPath })
+
+	// A config that triggers the "provider set but setup_completed false" migration.
+	_, configPath := SetupTestConfig(t, &Config{
+		Secrets: Secrets{
+			ProviderType:   string(secrets.EncryptedType),
+			SetupCompleted: false,
+		},
+	})
+
+	config, err := LoadOrCreateConfigWithPath(configPath)
+	require.NoError(t, err)
+	assert.True(t, config.Secrets.SetupCompleted,
+		"backward-compat migration should mark setup as completed")
+
+	// The migration must be persisted to the path we loaded from.
+	reloaded, err := LoadOrCreateConfigWithPath(configPath)
+	require.NoError(t, err)
+	assert.True(t, reloaded.Secrets.SetupCompleted,
+		"migration should be persisted back to the loaded path")
+
+	// The default/real config path must never have been touched.
+	_, statErr := os.Stat(sentinelPath)
+	assert.ErrorIs(t, statErr, os.ErrNotExist,
+		"backward-compat migration must not write to the default config path")
+}
+
 func TestSecrets_GetProviderType_EnvironmentVariable(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Loading a config from an explicit path (`PathProvider`, `LoadOrCreateConfigWithPath`) that needed a backward-compatibility migration wrote the migrated result to the default XDG path instead of the path it was loaded from. `applyBackwardCompatibility` called the path-agnostic `save()`, which always resolves to `getConfigPath()`.

For tests this clobbered the developer's real config file whenever a `PathProvider` loaded a temp config with a secrets provider set but `setup_completed` false. This defeated the test isolation that #894 was supposed to deliver: running the full unit suite (e.g. `pkg/client`'s `TestSuccessfulClientConfigOperations` and `TestFindClientConfigs`) silently overwrote `~/Library/Application Support/toolhive/config.yaml` with a test fixture. It was also a latent correctness bug for any path-based load in production.

- Thread the load path through `applyBackwardCompatibility` and persist via `saveToPath(configPath)` so migrations stay on the path the config was loaded from.
- Remove the now-unused `save()` helper.
- Add a `pkg/config` regression test that points `getConfigPath` at a sentinel and asserts a migration-triggering load never touches the default path.

Closes #894

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)
- [x] Manual testing (describe below)

Manual: backed up the real config, ran `go test -count=1 ./pkg/config/... ./pkg/client/...`, and confirmed the config file hash was unchanged afterward. Verified the new regression test fails on the pre-fix code and passes with the fix. Confirmed the full `task test` suite leaves the real config byte-identical.

## Does this introduce a user-facing change?

No. There are no production callers of `NewPathProvider` today, so the visible impact was limited to test pollution. The fix also closes the latent production bug for any future path-based load.

## Special notes for reviewers

While verifying the full suite I found a separate, pre-existing test-isolation gap unrelated to this change: `pkg/skills/client`'s `TestNewDefaultClient/falls_back_to_default_URL_when_env_is_empty` fails locally when a `thv`/Desktop server is running, because it stubs the env var but not server discovery. CI is unaffected. I'll address that in a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)