### PR TITLE
Isolate skills client discovery in default-client test

### DIFF
--- a/pkg/skills/client/client.go
+++ b/pkg/skills/client/client.go
@@ -83,18 +83,26 @@ func NewClient(baseURL string, opts ...Option) *Client {
 //
 // The context is used for the server discovery health check; it is not stored.
 func NewDefaultClient(ctx context.Context, opts ...Option) *Client {
-	return newDefaultClientWithEnv(ctx, &env.OSReader{}, opts...)
+	return newDefaultClientWithEnv(ctx, &env.OSReader{}, resolveViaDiscovery, opts...)
 }
 
-// newDefaultClientWithEnv is the testable core of NewDefaultClient.
-func newDefaultClientWithEnv(ctx context.Context, envReader env.Reader, opts ...Option) *Client {
+// discoverFunc resolves a running server's base URL and any transport options
+// (e.g. a Unix socket client). It returns an empty base URL when no running
+// server is found. resolveViaDiscovery is the production implementation; tests
+// inject a stub so the discovery step does not read real local state.
+type discoverFunc func(ctx context.Context) (string, []Option)
+
+// newDefaultClientWithEnv is the testable core of NewDefaultClient. The
+// envReader and discover dependencies are injected so each resolution step
+// can be exercised in isolation.
+func newDefaultClientWithEnv(ctx context.Context, envReader env.Reader, discover discoverFunc, opts ...Option) *Client {
 	// 1. Explicit env var override always wins.
 	if base := envReader.Getenv(envAPIURL); base != "" {
 		return NewClient(base, opts...)
 	}
 
 	// 2. Try server discovery.
-	if base, httpOpts := resolveViaDiscovery(ctx); base != "" {
+	if base, httpOpts := discover(ctx); base != "" {
 		// Discovery opts go first so caller-supplied opts can override them
 		// (e.g. a caller-provided WithTimeout replaces the discovery default).
 		merged := make([]Option, 0, len(httpOpts)+len(opts))

--- a/pkg/skills/client/client_test.go
+++ b/pkg/skills/client/client_test.go
@@ -4,6 +4,7 @@
 package client
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"io"
@@ -636,13 +637,27 @@ func TestConnectionError(t *testing.T) {
 func TestNewDefaultClient(t *testing.T) {
 	t.Parallel()
 
+	// noDiscovery stubs server discovery to report no running server, isolating
+	// the test from any real local server (e.g. a running Desktop app).
+	noDiscovery := func(context.Context) (string, []Option) { return "", nil }
+
+	// failDiscovery fails the test if discovery is consulted, asserting that an
+	// earlier resolution step short-circuited.
+	failDiscovery := func(t *testing.T) discoverFunc {
+		t.Helper()
+		return func(context.Context) (string, []Option) {
+			t.Error("discovery should not be called when TOOLHIVE_API_URL is set")
+			return "", nil
+		}
+	}
+
 	t.Run("falls back to default URL when env is empty", func(t *testing.T) {
 		t.Parallel()
 		ctrl := gomock.NewController(t)
 		mockEnv := envmocks.NewMockReader(ctrl)
 		mockEnv.EXPECT().Getenv(envAPIURL).Return("")
 
-		c := newDefaultClientWithEnv(t.Context(), mockEnv)
+		c := newDefaultClientWithEnv(t.Context(), mockEnv, noDiscovery)
 		assert.Equal(t, defaultBaseURL, c.baseURL)
 	})
 
@@ -652,8 +667,21 @@ func TestNewDefaultClient(t *testing.T) {
 		mockEnv := envmocks.NewMockReader(ctrl)
 		mockEnv.EXPECT().Getenv(envAPIURL).Return("http://localhost:9999")
 
-		c := newDefaultClientWithEnv(t.Context(), mockEnv)
+		c := newDefaultClientWithEnv(t.Context(), mockEnv, failDiscovery(t))
 		assert.Equal(t, "http://localhost:9999", c.baseURL)
+	})
+
+	t.Run("uses discovered server when env is empty", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		mockEnv := envmocks.NewMockReader(ctrl)
+		mockEnv.EXPECT().Getenv(envAPIURL).Return("")
+
+		discover := func(context.Context) (string, []Option) {
+			return "http://127.0.0.1:54321", nil
+		}
+		c := newDefaultClientWithEnv(t.Context(), mockEnv, discover)
+		assert.Equal(t, "http://127.0.0.1:54321", c.baseURL)
 	})
 
 	t.Run("applies options", func(t *testing.T) {
@@ -662,7 +690,7 @@ func TestNewDefaultClient(t *testing.T) {
 		mockEnv := envmocks.NewMockReader(ctrl)
 		mockEnv.EXPECT().Getenv(envAPIURL).Return("")
 
-		c := newDefaultClientWithEnv(t.Context(), mockEnv, WithTimeout(5*time.Second))
+		c := newDefaultClientWithEnv(t.Context(), mockEnv, noDiscovery, WithTimeout(5*time.Second))
 		assert.Equal(t, 5*time.Second, c.httpClient.Timeout)
 	})
 }


### PR DESCRIPTION
## Summary

`TestNewDefaultClient` stubbed the `TOOLHIVE_API_URL` env reader but let the server-discovery step run against real local state. When a `thv serve` or Desktop server was running, discovery found it and returned its base URL (`http://localhost` for a Unix socket), so the "falls back to default URL when env is empty" and "applies options" subtests saw the discovered URL instead of `http://127.0.0.1:8080` and failed. CI passed only because no server runs there, making this a confusing local-only failure.

`newDefaultClientWithEnv` already injects an `env.Reader` so the env-var step is testable; the discovery step just wasn't given the same treatment.

- Add a `discoverFunc` parameter to `newDefaultClientWithEnv`, mirroring the existing `env.Reader` injection. `NewDefaultClient` passes the real `resolveViaDiscovery`; no production behavior change.
- Stub discovery in the subtests so each resolution step (env var, discovery, default fallback) is tested in isolation, with no dependency on real local state.
- Add a subtest covering the discovered-server path, which was previously untested.

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)
- [x] Manual testing (describe below)

Manual: ran `go test -count=1 -run TestNewDefaultClient ./pkg/skills/client/`; all four subtests pass. The discovery step is now fully stubbed, so the test is robust to a running local server by construction.

## Does this introduce a user-facing change?

No. The change adds a test-injection seam; `NewDefaultClient` behaves identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)