### PR TITLE
Ignore go1.26.4 stdlib vulns in govulncheck until toolchain bump

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -56,8 +56,16 @@ jobs:
 
       - name: Check for vulnerabilities (with exclusions)
         run: |
-          # Ignored vulnerabilities with justification: none currently.
-          IGNORED_VULNS=""
+          # Ignored vulnerabilities with justification:
+          # Go stdlib advisories published 2026-06-02, all fixed in go1.26.4 /
+          # go1.25.11 (DoS / log-injection class, no RCE):
+          #   GO-2026-5037 (CVE-2026-27145, crypto/x509 VerifyHostname)
+          #   GO-2026-5038 (CVE-2026-42504, mime WordDecoder.DecodeHeader)
+          #   GO-2026-5039 (CVE-2026-42507, net/textproto error messages)
+          # CI's `setup-go: stable` still resolves to go1.26.3 because the
+          # actions/go-versions manifest lags the Go release. Temporary
+          # exclusion; remove once CI builds on go1.26.4 or later.
+          IGNORED_VULNS="GO-2026-5037 GO-2026-5038 GO-2026-5039"
 
           # Show the raw output for debugging
           echo "::group::govulncheck raw output"


### PR DESCRIPTION
## Summary

The daily **Security Scan** and **every open PR** have been failing the `Go Vulnerability Check` since 2026-06-03 03:03 UTC. On 2026-06-02 three Go **standard-library** advisories were published, and govulncheck flags them because CI builds with `setup-go: stable`, which still resolves to **go1.26.3** (the `actions/go-versions` manifest lags the release):

- `GO-2026-5037` (CVE-2026-27145) — `crypto/x509` `VerifyHostname` quadratic-cost perf
- `GO-2026-5038` (CVE-2026-42504) — `mime` `WordDecoder.DecodeHeader` excessive CPU
- `GO-2026-5039` (CVE-2026-42507) — `net/textproto` user input in error messages

All three are stdlib DoS / log-injection issues (no RCE) **fixed in go1.26.4 / go1.25.11** — code we do not own. This PR adds the three OSV IDs to the existing, documented `IGNORED_VULNS` exclusion list to unblock CI. It is explicitly **temporary**: the comment instructs removing the exclusion once CI builds on go1.26.4 or later (at which point `stable` will resolve to a patched toolchain and the findings disappear on their own).

## Type of change

- [x] Other (CI / security tooling)

## Test plan

- [x] Manual testing (describe below)

- Confirmed each OSV maps to a Go stdlib advisory fixed in go1.26.4 / go1.25.11 via `pkg.go.dev/vuln`.
- Verified the failing job lists exactly these three IDs: `❌ Vulnerabilities need attention: GO-2026-5037 GO-2026-5038 GO-2026-5039`.
- Validated `security-scan.yml` still parses as YAML.
- Authoritative check is this PR's own `Go Vulnerability Check` run going green.

## API Compatibility

- [x] This PR does not break the `v1beta1` API.

## Does this introduce a user-facing change?

No.

## Special notes for reviewers

This is a stop-gap. The clean fix is to get CI onto go1.26.4 (e.g. pin the version or wait for the `actions/go-versions` `stable` manifest to catch up). Once that lands, delete the three IDs from `IGNORED_VULNS` and restore the comment to "none currently."

Generated with [Claude Code](https://claude.com/claude-code)
