### PR TITLE
Bump Go toolchain to 1.26.4 to address stdlib CVEs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/stacklok/toolhive
 
 go 1.26
 
+toolchain go1.26.4
+
 require (
 	dario.cat/mergo v1.0.2
 	github.com/1password/onepassword-sdk-go v0.3.1


### PR DESCRIPTION
## Summary

Pins the Go toolchain to 1.26.4 in \`go.mod\` to fix three stdlib CVEs introduced since go1.26.3:

- \`GO-2026-5037\` (CVE-2026-27145) — \`crypto/x509\` \`VerifyHostname\` quadratic-cost perf
- \`GO-2026-5038\` (CVE-2026-42504) — \`mime\` \`WordDecoder.DecodeHeader\` excessive CPU
- \`GO-2026-5039\` (CVE-2026-42507) — \`net/textproto\` user input in error messages

This is the clean fix. Once merged, the exclusions added in #5425 can be reverted and Renovate will handle future toolchain bumps automatically (the \`toolchain\` depType is enabled by default in the \`gomod\` manager).

## Type of change

- [x] Other (dependency / toolchain bump)

## Test plan

- [x] Go Vulnerability Check expected to pass on this PR

Generated with [Claude Code](https://claude.com/claude-code)