### PR TITLE
Add lazy mode to thv llm setup

### DIFF
--- a/cmd/thv/app/llm.go
+++ b/cmd/thv/app/llm.go
@@ -172,7 +172,11 @@ func runLLMToken(ctx context.Context) error {
 		return fmt.Errorf("LLM gateway is not configured — run \"thv llm config set\" first")
 	}
 
-	ts, err := buildLLMTokenSource(&llmCfg, false /* non-interactive */)
+	// Interactive: on a genuine cache miss (no cached or refreshable token) this
+	// launches the OIDC browser flow — the same flow "thv llm setup" runs — so a
+	// prior "thv llm setup --lazy" signs the user in transparently on first use.
+	// A cached or refreshable token is served without any browser prompt.
+	ts, err := buildLLMTokenSource(&llmCfg, true /* interactive */)
 	if err != nil {
 		return err
 	}
@@ -217,6 +221,7 @@ func newLLMSetupCommand() *cobra.Command {
 		tlsSkipVerify       bool
 		targetClient        string
 		anthropicPathPrefix string
+		lazy                bool
 	)
 
 	cmd := &cobra.Command{
@@ -251,7 +256,7 @@ Run "thv llm teardown" to revert all changes.`,
 			return runLLMSetup(
 				cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(),
 				cm, config.NewDefaultProvider(), oidcLogin, opts,
-				anthropicPathPrefix, cmd.Flags().Changed("anthropic-path-prefix"), targetClient,
+				anthropicPathPrefix, cmd.Flags().Changed("anthropic-path-prefix"), targetClient, lazy,
 			)
 		},
 	}
@@ -272,6 +277,10 @@ Run "thv llm teardown" to revert all changes.`,
 			"(e.g. /anthropic). When omitted, the gateway is probed automatically.")
 	cmd.Flags().StringVar(&targetClient, "client", "",
 		"Configure only this AI tool by name (e.g. claude-code, cursor). Omit to configure all detected tools.")
+	cmd.Flags().BoolVar(&lazy, "lazy", false,
+		"Skip the interactive OIDC login and defer it until the first time a configured tool "+
+			"accesses the gateway. Tool config and persisted settings are written normally. "+
+			"Useful for unattended provisioning (e.g. an MDM profile).")
 
 	return cmd
 }
@@ -291,12 +300,12 @@ func runLLMSetup(
 	ctx context.Context, out, errOut io.Writer,
 	cm *client.ClientManager, provider config.Provider, login llm.LoginFunc,
 	inlineOpts llm.SetOptions, anthropicPathPrefix string, anthropicPathPrefixSet bool, targetClient string,
+	lazy bool,
 ) error {
 	return llm.Setup(
 		ctx, out, errOut,
 		&clientManagerAdapter{cm}, &configUpdaterAdapter{provider}, login,
-		inlineOpts, anthropicPathPrefix, anthropicPathPrefixSet, targetClient,
-		false, // lazy: wired to the --lazy flag in a later change
+		inlineOpts, anthropicPathPrefix, anthropicPathPrefixSet, targetClient, lazy,
 	)
 }
 
@@ -484,7 +493,10 @@ func newLLMTokenCommand() *cobra.Command {
 		Short: "Print a fresh LLM gateway access token to stdout",
 		Long: `Print a fresh OIDC access token to stdout (all other output on stderr).
 Intended for use as apiKeyHelper or auth.command in OIDC-capable AI tools.
-Runs non-interactively — will not launch a browser flow.`,
+
+A cached or refreshable token is printed without prompting. If none exists
+(for example after "thv llm setup --lazy"), the OIDC browser login flow is
+launched automatically and the resulting token is printed once login completes.`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runLLMToken(cmd.Context())

--- a/cmd/thv/app/llm.go
+++ b/cmd/thv/app/llm.go
@@ -296,6 +296,7 @@ func runLLMSetup(
 		ctx, out, errOut,
 		&clientManagerAdapter{cm}, &configUpdaterAdapter{provider}, login,
 		inlineOpts, anthropicPathPrefix, anthropicPathPrefixSet, targetClient,
+		false, // lazy: wired to the --lazy flag in a later change
 	)
 }
 

--- a/cmd/thv/app/llm_test.go
+++ b/cmd/thv/app/llm_test.go
@@ -71,7 +71,7 @@ func TestRunLLMSetup_NotConfigured(t *testing.T) {
 	provider := llmProvider(t, llm.Config{}) // no gateway URL
 
 	var stdout, stderr bytes.Buffer
-	err := runLLMSetup(context.Background(), &stdout, &stderr, cm, provider, noopLogin, llm.SetOptions{}, "", false, "")
+	err := runLLMSetup(context.Background(), &stdout, &stderr, cm, provider, noopLogin, llm.SetOptions{}, "", false, "", false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not configured")
 }
@@ -98,7 +98,7 @@ func TestRunLLMSetup_NoDetectedTools(t *testing.T) {
 	})
 
 	var stdout, stderr bytes.Buffer
-	err := runLLMSetup(context.Background(), &stdout, &stderr, cm, provider, noopLogin, llm.SetOptions{}, "", false, "")
+	err := runLLMSetup(context.Background(), &stdout, &stderr, cm, provider, noopLogin, llm.SetOptions{}, "", false, "", false)
 	require.NoError(t, err)
 	assert.Contains(t, stdout.String(), "No supported AI tools detected")
 }
@@ -142,7 +142,7 @@ func TestRunLLMSetup_PartialFailure(t *testing.T) {
 	})
 
 	var stdout, stderr bytes.Buffer
-	err := runLLMSetup(context.Background(), &stdout, &stderr, cm, provider, noopLogin, llm.SetOptions{}, "", false, "")
+	err := runLLMSetup(context.Background(), &stdout, &stderr, cm, provider, noopLogin, llm.SetOptions{}, "", false, "", false)
 	require.NoError(t, err)
 	assert.Contains(t, stderr.String(), "Warning: failed to configure claude-code")
 	assert.Contains(t, stdout.String(), "Configured gemini-cli")
@@ -176,7 +176,7 @@ func TestRunLLMSetup_RollbackOnConfigUpdateFailure(t *testing.T) {
 	provider := &errOnUpdateProvider{cfg: c, updateErr: errors.New("disk full")}
 
 	var stdout, stderr bytes.Buffer
-	err := runLLMSetup(context.Background(), &stdout, &stderr, cm, provider, noopLogin, llm.SetOptions{}, "", false, "")
+	err := runLLMSetup(context.Background(), &stdout, &stderr, cm, provider, noopLogin, llm.SetOptions{}, "", false, "", false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "persisting tool configuration")
 
@@ -226,7 +226,7 @@ func TestRunLLMSetup_RollbackBothToolsOnConfigUpdateFailure(t *testing.T) {
 	provider := &errOnUpdateProvider{cfg: c, updateErr: errors.New("disk full")}
 
 	var stdout, stderr bytes.Buffer
-	err := runLLMSetup(context.Background(), &stdout, &stderr, cm, provider, noopLogin, llm.SetOptions{}, "", false, "")
+	err := runLLMSetup(context.Background(), &stdout, &stderr, cm, provider, noopLogin, llm.SetOptions{}, "", false, "", false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "persisting tool configuration")
 
@@ -273,7 +273,7 @@ func TestRunLLMSetup_LoginFailureLeavesNoState(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	err := runLLMSetup(context.Background(), &stdout, &stderr, cm, provider,
 		func(_ context.Context, _ *llm.Config) error { return loginErr },
-		llm.SetOptions{}, "", false, "",
+		llm.SetOptions{}, "", false, "", false,
 	)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "OIDC login failed")
@@ -474,7 +474,7 @@ func TestRunLLMSetup_ClientFlag_ConfiguresSingleTool(t *testing.T) {
 	})
 
 	var stdout, stderr bytes.Buffer
-	err := runLLMSetup(context.Background(), &stdout, &stderr, cm, provider, noopLogin, llm.SetOptions{}, "", false, "claude-code")
+	err := runLLMSetup(context.Background(), &stdout, &stderr, cm, provider, noopLogin, llm.SetOptions{}, "", false, "claude-code", false)
 	require.NoError(t, err)
 	assert.Contains(t, stdout.String(), "Configured claude-code")
 	assert.NotContains(t, stdout.String(), "gemini-cli")
@@ -484,6 +484,55 @@ func TestRunLLMSetup_ClientFlag_ConfiguresSingleTool(t *testing.T) {
 	assert.NoError(t, statErr, "claude-code settings.json must be created")
 	_, statErr = os.Stat(filepath.Join(geminiDir, "settings.json"))
 	assert.True(t, os.IsNotExist(statErr), "gemini-cli settings.json must not be created")
+}
+
+func TestRunLLMSetup_Lazy_SkipsLoginButConfiguresTools(t *testing.T) {
+	t.Parallel()
+	// In lazy mode the login function must never be called, yet the tool is still
+	// detected, patched, and persisted just like a normal setup.
+	dir := t.TempDir()
+	claudeDir := filepath.Join(dir, ".claude")
+	require.NoError(t, os.MkdirAll(claudeDir, 0o700))
+
+	cfgs := client.LLMTestIntegrations([]client.LLMTestEntry{
+		{
+			ClientType:   client.ClaudeCode,
+			Mode:         "direct",
+			SettingsDir:  []string{".claude"},
+			SettingsFile: "settings.json",
+			JSONPointers: []string{"/apiKeyHelper"},
+			ValueFields:  []string{"TokenHelperCommand"},
+		},
+	})
+	cm := client.NewTestClientManager(dir, nil, cfgs, nil)
+	provider := llmProvider(t, llm.Config{
+		GatewayURL: "https://gw.example.com",
+		OIDC:       llm.OIDCConfig{Issuer: "https://auth.example.com", ClientID: "id"},
+	})
+
+	loginCalled := false
+	recordingLogin := func(context.Context, *llm.Config) error {
+		loginCalled = true
+		return nil
+	}
+
+	var stdout, stderr bytes.Buffer
+	// anthropicPathPrefixSet=true skips the network probe; lazy=true.
+	err := runLLMSetup(context.Background(), &stdout, &stderr, cm, provider,
+		recordingLogin, llm.SetOptions{}, "", true, "", true)
+	require.NoError(t, err)
+
+	assert.False(t, loginCalled, "lazy mode must not invoke the OIDC login")
+	assert.Contains(t, stdout.String(), "Lazy mode")
+	assert.Contains(t, stdout.String(), "Configured claude-code")
+
+	// Tool settings file must still be written.
+	_, statErr := os.Stat(filepath.Join(claudeDir, "settings.json"))
+	assert.NoError(t, statErr, "claude-code settings.json must be created in lazy mode")
+
+	// ConfiguredTools must still be persisted.
+	cfg := provider.GetConfig()
+	assert.NotEmpty(t, cfg.LLM.ConfiguredTools, "ConfiguredTools must be persisted in lazy mode")
 }
 
 func TestRunLLMSetup_ClientFlag_NotInstalled(t *testing.T) {
@@ -509,7 +558,7 @@ func TestRunLLMSetup_ClientFlag_NotInstalled(t *testing.T) {
 
 	var stdout, stderr bytes.Buffer
 	// cursor is not installed (no dir); expect an error.
-	err := runLLMSetup(context.Background(), &stdout, &stderr, cm, provider, noopLogin, llm.SetOptions{}, "", false, "cursor")
+	err := runLLMSetup(context.Background(), &stdout, &stderr, cm, provider, noopLogin, llm.SetOptions{}, "", false, "cursor", false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), `"cursor" is not installed or not detected`)
 }

--- a/docs/cli/thv_llm_setup.md
+++ b/docs/cli/thv_llm_setup.md
@@ -48,6 +48,7 @@ thv llm setup [flags]
       --gateway-url string             LLM gateway base URL (must use HTTPS)
   -h, --help                           help for setup
       --issuer string                  OIDC issuer URL
+      --lazy                           Skip the interactive OIDC login and defer it until the first time a configured tool accesses the gateway. Tool config and persisted settings are written normally. Useful for unattended provisioning (e.g. an MDM profile).
       --proxy-port int                 Localhost proxy listen port (omit to keep current; default: 14000)
       --tls-skip-verify                Skip TLS certificate verification for the upstream gateway (local dev only). For direct-mode tools (Claude Code, Gemini CLI) this sets NODE_TLS_REJECT_UNAUTHORIZED=0, disabling TLS for ALL of that tool's outbound connections. For proxy-mode tools only the proxy-to-gateway connection is affected.
 ```

--- a/docs/cli/thv_llm_token.md
+++ b/docs/cli/thv_llm_token.md
@@ -17,7 +17,10 @@ Print a fresh LLM gateway access token to stdout
 
 Print a fresh OIDC access token to stdout (all other output on stderr).
 Intended for use as apiKeyHelper or auth.command in OIDC-capable AI tools.
-Runs non-interactively — will not launch a browser flow.
+
+A cached or refreshable token is printed without prompting. If none exists
+(for example after "thv llm setup --lazy"), the OIDC browser login flow is
+launched automatically and the resulting token is printed once login completes.
 
 ```
 thv llm token [flags]

--- a/pkg/llm/proxy/proxy.go
+++ b/pkg/llm/proxy/proxy.go
@@ -21,6 +21,14 @@ import (
 	"github.com/stacklok/toolhive/pkg/networking"
 )
 
+// tokenFetchTimeout bounds the per-request token fetch. It is deliberately
+// generous: the first request after a lazy setup ("thv llm setup --lazy") drives
+// the interactive OIDC browser login through the token source, and a human needs
+// time to complete it. Once a token is cached, subsequent requests are served
+// from cache and return well within this bound, so the only request that ever
+// approaches it is the initial login.
+const tokenFetchTimeout = 3 * time.Minute
+
 // TokenSource obtains fresh OIDC access tokens for the LLM gateway.
 // *llm.TokenSource satisfies this interface.
 type TokenSource interface {
@@ -159,7 +167,7 @@ func (p *Proxy) handler() http.Handler {
 			return
 		}
 
-		tokenCtx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+		tokenCtx, cancel := context.WithTimeout(r.Context(), tokenFetchTimeout)
 		defer cancel()
 		token, err := p.tokenSource.Token(tokenCtx)
 		if err != nil {

--- a/pkg/llm/setup.go
+++ b/pkg/llm/setup.go
@@ -59,10 +59,17 @@ type ConfigUpdater interface {
 // It applies inlineOpts in-memory before login so a failed login leaves no
 // persisted state. Tool config files are patched only after login succeeds;
 // on any persistence failure the patches are rolled back.
+//
+// When lazy is true, the interactive OIDC login (login) is skipped entirely:
+// tool detection, config-file patching, and config persistence still run, and a
+// message is printed telling the user that login will occur on first gateway
+// access. lazy is intended for unattended provisioning (e.g. an MDM profile);
+// it is opt-in and does not change behaviour for interactive users.
 func Setup(
 	ctx context.Context, out, errOut io.Writer,
 	gm GatewayManager, provider ConfigUpdater, login LoginFunc,
 	inlineOpts SetOptions, anthropicPathPrefix string, anthropicPathPrefixSet bool, targetClient string,
+	lazy bool,
 ) error {
 	llmCfg := provider.GetLLMConfig()
 
@@ -85,8 +92,9 @@ func Setup(
 	proxyBaseURL := fmt.Sprintf("http://localhost:%d/v1", llmCfg.EffectiveProxyPort())
 
 	// Detect tools before login so we skip the interactive browser flow when
-	// there is nothing to configure. Login still runs before any files are
-	// patched, preserving the guarantee that a failed login leaves no state.
+	// there is nothing to configure. In non-lazy mode login still runs before any
+	// files are patched, preserving the guarantee that a failed login leaves no
+	// state.
 	detected, err := filterDetectedClients(gm.DetectedLLMGatewayClients(), targetClient)
 	if err != nil {
 		return err
@@ -96,11 +104,21 @@ func Setup(
 		return nil
 	}
 
-	_, _ = fmt.Fprintln(out, "Ensuring you are logged in to the LLM gateway…")
-	if err := login(ctx, &llmCfg); err != nil {
-		return fmt.Errorf("OIDC login failed: %s", SanitizeTokenError(err))
+	// In lazy mode the interactive login is deferred until a configured tool
+	// first accesses the gateway (via "thv llm token" or the proxy). Everything
+	// below — tool detection, file patching, config persistence — is
+	// non-interactive and still runs, so the on-disk result is identical to a
+	// normal setup except that no OIDC token is obtained yet.
+	if lazy {
+		_, _ = fmt.Fprintln(out, "Lazy mode: skipping OIDC login. You'll be signed in automatically")
+		_, _ = fmt.Fprintln(out, "the first time a configured tool accesses the LLM gateway.")
+	} else {
+		_, _ = fmt.Fprintln(out, "Ensuring you are logged in to the LLM gateway…")
+		if err := login(ctx, &llmCfg); err != nil {
+			return fmt.Errorf("OIDC login failed: %s", SanitizeTokenError(err))
+		}
+		_, _ = fmt.Fprintln(out, "Login successful.")
 	}
-	_, _ = fmt.Fprintln(out, "Login successful.")
 
 	// Resolve the effective path prefix for ANTHROPIC_BASE_URL.
 	// If the caller supplied --anthropic-path-prefix, use it directly.

--- a/pkg/llm/setup_test.go
+++ b/pkg/llm/setup_test.go
@@ -178,6 +178,91 @@ func TestTeardown_NoPurge_LeavesTokenRefsIntact(t *testing.T) {
 	assert.Equal(t, expiry, provider.cfg.OIDC.CachedTokenExpiry)
 }
 
+// ── Setup --lazy path ─────────────────────────────────────────────────────────
+
+// setupGatewayManager reports one or more detected clients and patches them
+// successfully, for Setup-level tests. mode is returned by LLMGatewayModeFor;
+// use "proxy" to avoid the direct-mode Anthropic-prefix probe.
+type setupGatewayManager struct {
+	detected []string
+	mode     string
+}
+
+func (g *setupGatewayManager) DetectedLLMGatewayClients() []string { return g.detected }
+func (*setupGatewayManager) ConfigureLLMGateway(_ string, _ llmgateway.ApplyConfig) (string, error) {
+	return "/tmp/settings.json", nil
+}
+func (g *setupGatewayManager) LLMGatewayModeFor(_ string) string { return g.mode }
+func (*setupGatewayManager) ConfigureEnvFile(_ string, _ llmgateway.ApplyConfig) (string, error) {
+	return "", nil
+}
+func (*setupGatewayManager) RevertEnvFile(_, _ string) error    { return nil }
+func (*setupGatewayManager) RevertLLMGateway(_, _ string) error { return nil }
+
+// configuredSetupProvider returns a ConfigUpdater whose config satisfies
+// IsConfigured()/Validate() so Setup proceeds past its configuration checks.
+func configuredSetupProvider() *stubConfigUpdater {
+	return &stubConfigUpdater{cfg: Config{
+		GatewayURL: "https://llm.example.com",
+		OIDC: OIDCConfig{
+			Issuer:   "https://auth.example.com",
+			ClientID: "test-client",
+		},
+	}}
+}
+
+func TestSetup_Lazy_SkipsLoginAndPersistsTools(t *testing.T) {
+	t.Parallel()
+
+	gm := &setupGatewayManager{detected: []string{"cursor"}, mode: "proxy"}
+	provider := configuredSetupProvider()
+
+	loginCalled := false
+	login := func(_ context.Context, _ *Config) error {
+		loginCalled = true
+		return nil
+	}
+
+	var stdout, stderr bytes.Buffer
+	// anthropicPathPrefixSet=true skips the network probe; lazy=true.
+	err := Setup(
+		context.Background(), &stdout, &stderr, gm, provider, login,
+		SetOptions{}, "", true, "", true,
+	)
+	require.NoError(t, err)
+
+	assert.False(t, loginCalled, "lazy mode must not invoke the OIDC login")
+	// Tool config must still be persisted even though login was skipped.
+	require.Len(t, provider.cfg.ConfiguredTools, 1)
+	assert.Equal(t, "cursor", provider.cfg.ConfiguredTools[0].Tool)
+	// User must be told that login is deferred to first use.
+	assert.Contains(t, stdout.String(), "Lazy mode")
+	assert.Contains(t, stdout.String(), "first time")
+}
+
+func TestSetup_NonLazy_InvokesLogin(t *testing.T) {
+	t.Parallel()
+
+	gm := &setupGatewayManager{detected: []string{"cursor"}, mode: "proxy"}
+	provider := configuredSetupProvider()
+
+	loginCalled := false
+	login := func(_ context.Context, _ *Config) error {
+		loginCalled = true
+		return nil
+	}
+
+	var stdout, stderr bytes.Buffer
+	err := Setup(
+		context.Background(), &stdout, &stderr, gm, provider, login,
+		SetOptions{}, "", true, "", false,
+	)
+	require.NoError(t, err)
+
+	assert.True(t, loginCalled, "non-lazy mode must invoke the OIDC login")
+	require.Len(t, provider.cfg.ConfiguredTools, 1)
+}
+
 // ── AnthropicPathPrefix / configureDetectedTools ──────────────────────────────
 
 // capturingGatewayManager records the ApplyConfig passed to ConfigureLLMGateway.

--- a/test/e2e/cli_llm_all_clients_test.go
+++ b/test/e2e/cli_llm_all_clients_test.go
@@ -990,21 +990,19 @@ var _ = Describe("thv llm — all-client matrix", Label("cli", "llm", "clients",
 				}
 
 				By("running thv llm token with the expired token in the environment")
-				tokenOut, _, tokenErr := thvCmdWithExpired("llm", "token").Run()
+				// The cached access token is expired and the read-only environment
+				// provider holds no refresh token, so "thv llm token" falls through to
+				// the interactive OIDC browser flow. runWithOIDCCompletion satisfies the
+				// callback so the command obtains a fresh token instead of blocking.
+				tokenOut, stderrOut, tokenErr := runWithOIDCCompletion(thvCmdWithExpired, oidcServer, "llm", "token")
+				Expect(tokenErr).ToNot(HaveOccurred(),
+					"deferred re-auth should succeed; stdout=%q stderr=%q", tokenOut, stderrOut)
 
-				// The expired token must never be printed, regardless of whether
-				// re-auth succeeded or failed (no refresh token is available with
-				// the read-only environment secrets provider).
+				// The expired token must never be printed; a fresh one must be returned.
 				Expect(strings.TrimSpace(tokenOut)).ToNot(Equal(expiredToken),
 					"expired token must not be returned directly")
-
-				if tokenErr == nil {
-					// Re-auth via OIDC browser flow succeeded (mock OIDC auto-completes).
-					Expect(strings.TrimSpace(tokenOut)).ToNot(BeEmpty(),
-						"a fresh token should have been obtained after expiry")
-				}
-				// If tokenErr != nil the command failed (expected when no refresh
-				// token is cached), which is also correct behaviour.
+				Expect(strings.TrimSpace(tokenOut)).ToNot(BeEmpty(),
+					"a fresh token should have been obtained after expiry")
 			})
 		})
 	})

--- a/test/e2e/cli_llm_setup_test.go
+++ b/test/e2e/cli_llm_setup_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -29,13 +30,26 @@ func runSetupWithOIDCCompletion(
 	oidcServer *e2e.OIDCMockServer,
 	extraArgs ...string,
 ) (string, string, error) {
+	return runWithOIDCCompletion(thvCmd, oidcServer, append([]string{"llm", "setup"}, extraArgs...)...)
+}
+
+// runWithOIDCCompletion runs an arbitrary "thv" command in a goroutine and
+// concurrently satisfies the OIDC authorization request it triggers, so a
+// command that performs the interactive browser login flow (e.g. "thv llm
+// token" after a lazy setup) completes without a real browser. It returns an
+// error if the command exits before an auth request arrives — i.e. it did not
+// actually start the browser flow.
+func runWithOIDCCompletion(
+	thvCmd func(args ...string) *e2e.THVCommand,
+	oidcServer *e2e.OIDCMockServer,
+	args ...string,
+) (string, string, error) {
 	type result struct {
 		stdout, stderr string
 		err            error
 	}
 	done := make(chan result, 1)
 
-	args := append([]string{"llm", "setup"}, extraArgs...)
 	cmd := thvCmd(args...)
 	go func() {
 		stdout, stderr, err := cmd.RunWithTimeout(60 * time.Second)
@@ -382,6 +396,84 @@ var _ = Describe("thv llm setup / teardown", Label("cli", "llm", "setup", "e2e")
 				"ConfiguredTools should be empty after teardown --purge-tokens")
 			Expect(cfg.OIDC.CachedRefreshTokenRef).To(BeEmpty(),
 				"cached token reference should be cleared after purge")
+		})
+	})
+
+	// ── Test 6 ────────────────────────────────────────────────────────────────
+
+	Describe("thv llm setup --lazy", func() {
+		It("configures tools without logging in and prints a deferred-login message", func() {
+			// Create ~/.claude/ and stub the claude binary so Claude Code is detected.
+			claudeDir := filepath.Join(tempDir, ".claude")
+			Expect(os.MkdirAll(claudeDir, 0750)).To(Succeed())
+			Expect(createFakeBinary(binDir, "claude")).To(Succeed())
+
+			issuerURL := fmt.Sprintf("http://localhost:%d", oidcPort)
+
+			By("Running thv llm setup --lazy (must complete with no browser flow)")
+			// Run directly: lazy mode must finish without ever triggering OIDC, so
+			// there is no auth request to satisfy. A bounded timeout guards against a
+			// regression that re-introduces the inline login.
+			stdout, stderr, err := thvCmd(
+				"llm", "setup", "--lazy",
+				"--gateway-url", gatewayURL,
+				"--issuer", issuerURL,
+				"--client-id", clientID,
+			).RunWithTimeout(30 * time.Second)
+			Expect(err).ToNot(HaveOccurred(),
+				"lazy setup should succeed without a browser; stdout=%q stderr=%q", stdout, stderr)
+
+			By("Verifying the deferred-login message was printed")
+			Expect(stdout).To(ContainSubstring("Lazy mode"),
+				"lazy mode should tell the user login is deferred")
+
+			By("Verifying ~/.claude/settings.json was patched just like a normal setup")
+			settingsPath := filepath.Join(tempDir, ".claude", "settings.json")
+			data, err := os.ReadFile(settingsPath)
+			Expect(err).ToNot(HaveOccurred(), "settings.json should exist after lazy setup")
+			var settings map[string]any
+			Expect(json.Unmarshal(data, &settings)).To(Succeed())
+			Expect(settings).To(HaveKey("apiKeyHelper"),
+				"apiKeyHelper should be set even in lazy mode")
+
+			By("Verifying ConfiguredTools was persisted")
+			showOut, _ := thvCmd("llm", "config", "show", "--format", "json").ExpectSuccess()
+			var cfg llm.Config
+			Expect(json.Unmarshal([]byte(showOut), &cfg)).To(Succeed())
+			Expect(cfg.ConfiguredTools).ToNot(BeEmpty(),
+				"at least one tool should be configured after lazy setup")
+		})
+	})
+
+	// ── Test 7 ────────────────────────────────────────────────────────────────
+
+	Describe("thv llm token after a lazy setup", func() {
+		It("triggers the deferred OIDC login and prints a fresh token", func() {
+			claudeDir := filepath.Join(tempDir, ".claude")
+			Expect(os.MkdirAll(claudeDir, 0750)).To(Succeed())
+			Expect(createFakeBinary(binDir, "claude")).To(Succeed())
+
+			issuerURL := fmt.Sprintf("http://localhost:%d", oidcPort)
+
+			By("Running thv llm setup --lazy")
+			stdout, stderr, err := thvCmd(
+				"llm", "setup", "--lazy",
+				"--gateway-url", gatewayURL,
+				"--issuer", issuerURL,
+				"--client-id", clientID,
+			).RunWithTimeout(30 * time.Second)
+			Expect(err).ToNot(HaveOccurred(),
+				"lazy setup should succeed; stdout=%q stderr=%q", stdout, stderr)
+
+			By("Running thv llm token — must launch the deferred OIDC browser flow")
+			// With no cached token after a lazy setup, "thv llm token" launches the
+			// same browser flow setup would have run. The fake browser triggers the
+			// auth request; runWithOIDCCompletion satisfies the callback.
+			tokenOut, tokenStderr, err := runWithOIDCCompletion(thvCmd, oidcServer, "llm", "token")
+			Expect(err).ToNot(HaveOccurred(),
+				"deferred login via token should succeed; stdout=%q stderr=%q", tokenOut, tokenStderr)
+			Expect(strings.TrimSpace(tokenOut)).ToNot(BeEmpty(),
+				"a fresh token should be printed to stdout after deferred login")
 		})
 	})
 })


### PR DESCRIPTION
## Summary

`thv llm setup` runs the interactive OIDC browser login inline, which makes it
unusable in unattended provisioning — e.g. an MDM profile running it at first
login to pre-configure Claude Code, Cursor, etc. across a fleet of laptops. The
browser flow cannot complete without a human present, so setup hangs or fails.
Everything else setup does (flag validation, tool detection, config patching,
persistence) is non-interactive and safe to run unattended.

This PR adds an opt-in `--lazy` flag that skips only the inline login and defers
it to first gateway access, where the same browser flow fires transparently.

Closes #5386

<details>
<summary><strong>Medium level</strong></summary>

- **`pkg/llm.Setup`** gains a `lazy` parameter: when set it skips the `login()`
  call and prints a deferred-login message, while still detecting tools, patching
  config files, and persisting `ConfiguredTools` — the on-disk result is identical
  to a normal setup except no token is obtained yet.
- **`thv llm setup --lazy`** flag wires that parameter through the CLI.
- **`thv llm token` is now interactive**: on a genuine cache miss it launches the
  same OIDC browser flow setup would have run, so a prior `--lazy` setup signs the
  user in on first use with no extra command. A cached/refreshable token is still
  printed without prompting.
- **LLM proxy per-request token-fetch timeout** widened from 10s to a 3-minute
  `tokenFetchTimeout` constant, so the first request after a lazy setup can drive
  an interactive browser login without being cut off mid-login.
- E2E coverage for the lazy setup path and the deferred token-login path, plus
  regenerated CLI docs.

</details>

<details>
<summary><strong>Low level</strong></summary>

| File | Change |
|------|--------|
| `pkg/llm/setup.go` | Add `lazy bool` param to `Setup`; skip login + print deferred-login message when set |
| `cmd/thv/app/llm.go` | Add `--lazy` flag; make `runLLMToken` build an interactive token source; update token help text |
| `pkg/llm/proxy/proxy.go` | Introduce `tokenFetchTimeout = 3 * time.Minute`, replacing the inline 10s per-request timeout |
| `docs/cli/thv_llm_setup.md`, `docs/cli/thv_llm_token.md` | Regenerated via `task docs` |
| `pkg/llm/setup_test.go`, `cmd/thv/app/llm_test.go` | Unit tests for lazy skip-login + tool persistence |
| `test/e2e/cli_llm_setup_test.go` | Generalize `runSetupWithOIDCCompletion` → `runWithOIDCCompletion`; add lazy setup + deferred token-login specs |
| `test/e2e/cli_llm_all_clients_test.go` | Drive OIDC completion in the expired-token test (token is now interactive) |

</details>

## Type of change

- [x] New feature

## Test plan

- [x] Unit tests (`task test`) — `pkg/llm`, `pkg/llm/proxy`, `cmd/thv/app` pass
- [x] E2E tests — lazy setup, deferred token-login, expired-token, and cached-token specs pass (green on CI across kind v1.33/1.34/1.35)
- [x] Linting (`task lint-fix`) — could not run locally (golangci-lint/go toolchain mismatch); confirmed passing on CI
- [x] Manual testing (see below)

E2E specifically exercises the real flow end to end: `thv llm setup --lazy` completes with no browser (guarded by a 30s timeout), patches tool config identically to a normal setup, and the subsequent `thv llm token` launches the deferred OIDC browser flow (fake browser + mock OIDC) and prints a fresh token.

<details>
<summary><strong>Manual test results</strong> (built binary, isolated <code>HOME</code>/<code>XDG_CONFIG_HOME</code> sandbox)</summary>

Sandbox setup: a fake-browser stub for <code>open</code>/<code>xdg-open</code> that records any invocation to a log file (so an opened browser is detectable), a fake <code>claude</code> binary + <code>~/.claude</code> dir for tool detection, and the environment secrets provider (no keychain).

**1. `thv llm setup --lazy` — must configure tools without logging in**

```
$ thv llm setup --lazy
Lazy mode: skipping OIDC login. You'll be signed in automatically
the first time a configured tool accesses the LLM gateway.
Configured claude-code (direct mode)  →  <sandbox>/.claude/settings.json
exit code: 0
```

- ✅ No browser opened — the fake-browser log file never appeared.
- ✅ `~/.claude/settings.json` patched with `apiKeyHelper` → `"…/thv" llm token` and `ANTHROPIC_BASE_URL`, identical to a normal setup.
- ✅ `thv llm config show --format json` lists the persisted `claude-code` entry in `configured_tools`.

**2. `thv llm token` — must now engage the interactive OIDC flow on a cache miss**

With no cached token and the issuer pointed at a refused port (so OIDC discovery fails instantly, with no hang and no browser):

```
$ thv llm token
Error: OIDC browser flow failed: failed to discover OIDC endpoints: unable to
discover OIDC endpoints at "http://127.0.0.1:9/.well-known/openid-configuration" …
connection refused
exit code: 1
```

- ✅ The `OIDC browser flow failed: …` error originates from the **interactive tier-4 path** in `pkg/auth/tokensource/tokensource.go`. The previous non-interactive `thv llm token` never reached it — it returned `ErrTokenRequired` (“no cached credentials found; run "thv llm setup" to log in”) immediately. This confirms the deferred-login browser path is now engaged on a cache miss.

**Coverage note:** the full browser-completed deferred login (browser opens → callback → token printed) requires a live OIDC server and is covered by the green E2E suite; reproducing it by hand just rebuilds the mock-OIDC harness. The lazy setup path and the `thv llm token` interactive-engagement were both verified manually as above.

</details>

## Does this introduce a user-facing change?

Yes. A new opt-in `--lazy` flag on `thv llm setup` skips the interactive OIDC
login and defers it to first gateway access. Default behavior for interactive
users is unchanged. Separately, `thv llm token` now launches the OIDC browser
flow on a cache miss instead of failing fast — a cached or refreshable token is
still printed without prompting.

## Implementation plan

<details>
<summary>Approved implementation plan</summary>

Designed via `/plan-design` for #5386. Four stages, single PR:

1. **`pkg/llm.Setup` lazy support** — add trailing `lazy bool`; when set, skip the
   `login()` block and print the deferred-login message; tool detection, patching,
   and persistence still run. Unit test asserts the injected `LoginFunc` is not
   called yet tools are persisted.
2. **CLI wiring** — `--lazy` flag threaded through `runLLMSetup` → `llm.Setup`;
   `runLLMToken` switched to an interactive token source (browser only on a real
   cache miss); token/setup help text updated; CLI docs regenerated.
3. **Proxy timeout** — replace the inline 10s per-request token-fetch timeout with
   a 3-minute `tokenFetchTimeout` constant so a human can complete the first
   interactive login through the proxy. (Decision: a single generous timeout for
   all requests, for simplicity.)
4. **E2E + docs** — lazy setup spec (no browser) and deferred token-login spec
   (drives the browser flow to completion via the generalized
   `runWithOIDCCompletion` helper).

Key decision: `thv llm token` is always interactive rather than flag-gated — the
4-tier token source only opens a browser on a genuine cache miss, so this is
transparent for cached/refreshable tokens and needs no extra flag.

Non-goals (per issue): headless/device-code flows; changing the default
interactive `thv llm setup` behavior (lazy is strictly opt-in).

</details>

## Special notes for reviewers

- **Proxy timeout tradeoff:** the 3-minute bound applies to every request, not
  just first-login. A genuinely hung upstream token endpoint now holds a request
  up to 3 min instead of 10s. This was the chosen simplicity tradeoff over
  first-login-only detection.
- **No proxy-through-browser E2E:** the deferred-login proxy path is covered by
  the timeout change plus existing proxy tests; an E2E that drives a browser login
  *through the proxy* was deemed optional and not added. The token-helper deferred
  path is fully E2E-covered. Happy to add the proxy variant if reviewers want it.
- **`thv llm token` behavior change:** it is now interactive. This is intended
  (it's what makes lazy transparent) and does not affect callers that already have
  a cached or refreshable token.

Generated with [Claude Code](https://claude.com/claude-code)
