### PR TITLE
Clarify lazy-mode deferred-login message

### DIFF
--- a/pkg/llm/setup.go
+++ b/pkg/llm/setup.go
@@ -110,8 +110,8 @@ func Setup(
 	// non-interactive and still runs, so the on-disk result is identical to a
 	// normal setup except that no OIDC token is obtained yet.
 	if lazy {
-		_, _ = fmt.Fprintln(out, "Lazy mode: skipping OIDC login. You'll be signed in automatically")
-		_, _ = fmt.Fprintln(out, "the first time a configured tool accesses the LLM gateway.")
+		_, _ = fmt.Fprintln(out, "Lazy mode: skipping OIDC login. You'll be signed in on the first")
+		_, _ = fmt.Fprintln(out, "request a configured tool makes to the LLM gateway.")
 	} else {
 		_, _ = fmt.Fprintln(out, "Ensuring you are logged in to the LLM gateway…")
 		if err := login(ctx, &llmCfg); err != nil {

--- a/pkg/llm/setup_test.go
+++ b/pkg/llm/setup_test.go
@@ -235,9 +235,9 @@ func TestSetup_Lazy_SkipsLoginAndPersistsTools(t *testing.T) {
 	// Tool config must still be persisted even though login was skipped.
 	require.Len(t, provider.cfg.ConfiguredTools, 1)
 	assert.Equal(t, "cursor", provider.cfg.ConfiguredTools[0].Tool)
-	// User must be told that login is deferred to first use.
+	// User must be told that login is deferred to the first request.
 	assert.Contains(t, stdout.String(), "Lazy mode")
-	assert.Contains(t, stdout.String(), "first time")
+	assert.Contains(t, stdout.String(), "first")
 }
 
 func TestSetup_NonLazy_InvokesLogin(t *testing.T) {


### PR DESCRIPTION
## Summary

Follow-up to #5427 addressing review feedback ([comment](https://github.com/stacklok/toolhive/pull/5427#discussion_r3350185895)).

The `thv llm setup --lazy` message told the user they'd be *"signed in automatically the first time a configured tool accesses the LLM gateway"*. As @jerm-dro noted, "signed in automatically" isn't quite accurate — the deferred login still opens a browser for the user to complete on the first request. This rewords the message so it accurately describes when login happens.

Before:
```
Lazy mode: skipping OIDC login. You'll be signed in automatically
the first time a configured tool accesses the LLM gateway.
```

After:
```
Lazy mode: skipping OIDC login. You'll be signed in on the first
request a configured tool makes to the LLM gateway.
```

## Type of change

- [x] Documentation (user-facing message wording; no behavior change)

## Test plan

- [x] Unit tests (`task test`) — `pkg/llm`, `cmd/thv/app` pass (updated the lazy-message assertion in `setup_test.go`)
- [x] `task build` passes
- [x] Manual: `thv llm setup --lazy` prints the reworded message

## Does this introduce a user-facing change?

Yes — the wording of the `thv llm setup --lazy` informational message changes. No behavior change.

Generated with [Claude Code](https://claude.com/claude-code)