### PR TITLE
Thread VirtualMCPServer name into Cedar authz middleware

### DIFF
--- a/pkg/vmcp/auth/factory/authz_not_wired_test.go
+++ b/pkg/vmcp/auth/factory/authz_not_wired_test.go
@@ -6,6 +6,7 @@ package factory
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -47,7 +48,7 @@ func TestNewIncomingAuthMiddleware_AuthzEnforced(t *testing.T) {
 			},
 		}
 
-		authMw, authzMw, _, err := NewIncomingAuthMiddleware(t.Context(), cfg, nil, nil, nil)
+		authMw, authzMw, _, err := NewIncomingAuthMiddleware(t.Context(), cfg, "test-server", nil, nil, nil)
 		require.NoError(t, err, "middleware creation should succeed")
 		require.NotNil(t, authMw, "auth middleware should not be nil")
 		require.NotNil(t, authzMw, "authz middleware should not be nil")
@@ -105,7 +106,7 @@ func TestNewIncomingAuthMiddleware_AuthzEnforced(t *testing.T) {
 			},
 		}
 
-		authMw, authzMw, _, err := NewIncomingAuthMiddleware(t.Context(), cfg, nil, nil, nil)
+		authMw, authzMw, _, err := NewIncomingAuthMiddleware(t.Context(), cfg, "test-server", nil, nil, nil)
 		require.NoError(t, err, "middleware creation should succeed")
 		require.NotNil(t, authMw, "auth middleware should not be nil")
 		require.NotNil(t, authzMw, "authz middleware should not be nil")
@@ -163,7 +164,7 @@ func TestNewIncomingAuthMiddleware_AuthzApproveAndBlock(t *testing.T) {
 		},
 	}
 
-	authMw, authzMw, _, err := NewIncomingAuthMiddleware(t.Context(), cfg, nil, nil, nil)
+	authMw, authzMw, _, err := NewIncomingAuthMiddleware(t.Context(), cfg, "test-server", nil, nil, nil)
 	require.NoError(t, err, "middleware creation should succeed")
 	require.NotNil(t, authMw, "auth middleware should not be nil")
 	require.NotNil(t, authzMw, "authz middleware should not be nil")
@@ -346,5 +347,128 @@ func TestNewIncomingAuthMiddleware_AuthzApproveAndBlock(t *testing.T) {
 			"handler should NOT be called - no permit policy for prompts/get (default deny)")
 		assert.Equal(t, http.StatusForbidden, recorder.Code,
 			"response should be 403 Forbidden when no policy permits the request")
+	})
+}
+
+// TestNewIncomingAuthMiddleware_ServerNameThreaded verifies that the serverName
+// parameter is used as the Cedar resource entity name, not a hard-coded constant.
+// Regression test for: VirtualMCPServer Cedar authz uses hard-coded "vmcp" resource name.
+//
+// The policy uses `resource in MCP::"<name>"` (membership traversal) because the
+// resource entity's UID is the tool type (e.g. Tool::"some_tool"), not the MCP
+// server entity itself. The `in` operator traverses the parent chain to reach the
+// MCP parent entity that carries the server name.
+func TestNewIncomingAuthMiddleware_ServerNameThreaded(t *testing.T) {
+	t.Parallel()
+
+	const actualServerName = "my-production-vmcp"
+
+	// The MCP parent entity must be present in the entity store for Cedar's `in`
+	// operator to traverse the parent chain and match the policy.
+	mcpEntityJSON := fmt.Sprintf(`[{"uid":{"type":"MCP","id":"%s"},"parents":[],"attrs":{}}]`, actualServerName)
+
+	// Policy uses `resource in MCP::"<name>"` — the tool resource is a child of
+	// the MCP server entity, so `in` traversal reaches MCP::"my-production-vmcp".
+	// If the middleware hard-codes "vmcp" instead of using actualServerName,
+	// the resource entity will not have the right MCP parent and Cedar's
+	// default-deny will fire, returning 403 even though the principal should be permitted.
+	cfg := &config.IncomingAuthConfig{
+		Type: "anonymous",
+		Authz: &config.AuthzConfig{
+			Type: "cedar",
+			Policies: []string{
+				fmt.Sprintf(`permit(principal, action == Action::"call_tool", resource in MCP::"%s");`, actualServerName),
+			},
+			EntitiesJSON: mcpEntityJSON,
+		},
+	}
+
+	authMw, authzMw, _, err := NewIncomingAuthMiddleware(t.Context(), cfg, actualServerName, nil, nil, nil)
+	require.NoError(t, err, "middleware creation should succeed")
+	require.NotNil(t, authMw, "auth middleware should not be nil")
+	require.NotNil(t, authzMw, "authz middleware should not be nil")
+
+	t.Run("correct_server_name_permits_call_tool", func(t *testing.T) {
+		t.Parallel()
+
+		handlerCalled := false
+		testHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			handlerCalled = true
+			w.WriteHeader(http.StatusOK)
+		})
+
+		wrapped := authMw(authzMw(testHandler))
+
+		mcpRequest := map[string]any{
+			"jsonrpc": "2.0",
+			"method":  "tools/call",
+			"id":      1,
+			"params": map[string]any{
+				"name":      "some_tool",
+				"arguments": map[string]any{},
+			},
+		}
+		body, err := json.Marshal(mcpRequest)
+		require.NoError(t, err)
+
+		req := httptest.NewRequest(http.MethodPost, "/mcp", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		recorder := httptest.NewRecorder()
+
+		wrapped.ServeHTTP(recorder, req)
+
+		assert.True(t, handlerCalled,
+			"handler SHOULD be called — serverName must match the Cedar resource entity name")
+		assert.Equal(t, http.StatusOK, recorder.Code,
+			"call_tool should be permitted when serverName matches the Cedar resource")
+	})
+
+	t.Run("wrong_server_name_denies_call_tool", func(t *testing.T) {
+		t.Parallel()
+
+		wrongCfg := &config.IncomingAuthConfig{
+			Type: "anonymous",
+			Authz: &config.AuthzConfig{
+				Type: "cedar",
+				Policies: []string{
+					fmt.Sprintf(`permit(principal, action == Action::"call_tool", resource in MCP::"%s");`, actualServerName),
+				},
+				EntitiesJSON: mcpEntityJSON,
+			},
+		}
+
+		wrongAuthMw, wrongAuthzMw, _, err := NewIncomingAuthMiddleware(t.Context(), wrongCfg, "wrong-server", nil, nil, nil)
+		require.NoError(t, err, "middleware creation should succeed")
+
+		handlerCalled := false
+		testHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			handlerCalled = true
+			w.WriteHeader(http.StatusOK)
+		})
+
+		wrapped := wrongAuthMw(wrongAuthzMw(testHandler))
+
+		mcpRequest := map[string]any{
+			"jsonrpc": "2.0",
+			"method":  "tools/call",
+			"id":      1,
+			"params": map[string]any{
+				"name":      "some_tool",
+				"arguments": map[string]any{},
+			},
+		}
+		body, err := json.Marshal(mcpRequest)
+		require.NoError(t, err)
+
+		req := httptest.NewRequest(http.MethodPost, "/mcp", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		recorder := httptest.NewRecorder()
+
+		wrapped.ServeHTTP(recorder, req)
+
+		assert.False(t, handlerCalled,
+			"handler should NOT be called — wrong serverName means resource has a different MCP parent")
+		assert.Equal(t, http.StatusForbidden, recorder.Code,
+			"call_tool should be denied when serverName does not match the Cedar resource policy")
 	})
 }

--- a/pkg/vmcp/auth/factory/incoming.go
+++ b/pkg/vmcp/auth/factory/incoming.go
@@ -35,6 +35,10 @@ import (
 // All middleware types now directly create and inject Identity into the context,
 // eliminating the need for a separate conversion layer.
 //
+// The serverName parameter is the VirtualMCPServer name and is used as the Cedar
+// resource entity name in authorization policy evaluation. It must match the
+// resource name used when compiling Cedar policies for this server.
+//
 // The passThroughTools parameter is optional (pass nil for none). Tool names in
 // this set bypass the response filter's policy check in tools/list responses.
 // This is used when the optimizer is enabled: its meta-tools (find_tool, call_tool)
@@ -50,6 +54,7 @@ import (
 func NewIncomingAuthMiddleware(
 	ctx context.Context,
 	cfg *config.IncomingAuthConfig,
+	serverName string,
 	passThroughTools map[string]struct{},
 	upstreamReader upstreamtoken.TokenReader,
 	keyProvider keys.PublicKeyProvider,
@@ -86,11 +91,11 @@ func NewIncomingAuthMiddleware(
 	// Cedar policies access to discovered tool annotations.
 	var authzMiddleware func(http.Handler) http.Handler
 	if cfg.Authz != nil && cfg.Authz.Type == "cedar" && len(cfg.Authz.Policies) > 0 {
-		authzMiddleware, err = newCedarAuthzMiddleware(cfg.Authz, passThroughTools)
+		authzMiddleware, err = newCedarAuthzMiddleware(cfg.Authz, serverName, passThroughTools)
 		if err != nil {
 			return nil, nil, nil, fmt.Errorf("failed to create authorization middleware: %w", err)
 		}
-		slog.Info("authorization middleware enabled with Cedar policies")
+		slog.Debug("authorization middleware enabled with Cedar policies", "server_name", serverName)
 	}
 
 	// Auth middleware composes auth + parser.
@@ -105,11 +110,15 @@ func NewIncomingAuthMiddleware(
 }
 
 // newCedarAuthzMiddleware creates Cedar authorization middleware from vMCP config.
+// serverName is forwarded to CreateMiddlewareFromConfig as the Cedar resource entity name.
 func newCedarAuthzMiddleware(
-	authzCfg *config.AuthzConfig, passThroughTools map[string]struct{},
+	authzCfg *config.AuthzConfig, serverName string, passThroughTools map[string]struct{},
 ) (func(http.Handler) http.Handler, error) {
 	if authzCfg == nil || len(authzCfg.Policies) == 0 {
 		return nil, fmt.Errorf("cedar authorization requires at least one policy")
+	}
+	if serverName == "" {
+		return nil, fmt.Errorf("serverName must not be empty: Cedar resource-scoped policies require a non-empty server name")
 	}
 
 	slog.Info("creating Cedar authorization middleware", "policies", len(authzCfg.Policies))
@@ -147,7 +156,7 @@ func newCedarAuthzMiddleware(
 	}
 
 	// Create the middleware using the existing factory
-	middlewareFn, err := authz.CreateMiddlewareFromConfig(authzConfig, "vmcp", passThroughTools)
+	middlewareFn, err := authz.CreateMiddlewareFromConfig(authzConfig, serverName, passThroughTools)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Cedar middleware: %w", err)
 	}

--- a/pkg/vmcp/auth/factory/incoming_test.go
+++ b/pkg/vmcp/auth/factory/incoming_test.go
@@ -135,7 +135,7 @@ func TestNewIncomingAuthMiddleware(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			authMw, authzMw, authInfo, err := NewIncomingAuthMiddleware(t.Context(), tt.cfg, nil, nil, nil)
+			authMw, authzMw, authInfo, err := NewIncomingAuthMiddleware(t.Context(), tt.cfg, "test-server", nil, nil, nil)
 
 			if tt.wantErr {
 				require.Error(t, err)
@@ -171,7 +171,7 @@ func TestNewCedarAuthzMiddleware_PropagatesPrimaryUpstreamProvider(t *testing.T)
 		PrimaryUpstreamProvider: providerName,
 	}
 
-	mw, err := newCedarAuthzMiddleware(authzCfg, nil)
+	mw, err := newCedarAuthzMiddleware(authzCfg, "test-server", nil)
 	require.NoError(t, err)
 	require.NotNil(t, mw, "middleware function should not be nil")
 

--- a/pkg/vmcp/cli/serve.go
+++ b/pkg/vmcp/cli/serve.go
@@ -372,7 +372,7 @@ func Serve(ctx context.Context, cfg ServeConfig) error {
 	}
 
 	authMiddleware, authzMiddleware, authInfoHandler, err :=
-		factory.NewIncomingAuthMiddleware(ctx, vmcpCfg.IncomingAuth, passThroughTools, upstreamReader, keyProvider)
+		factory.NewIncomingAuthMiddleware(ctx, vmcpCfg.IncomingAuth, vmcpCfg.Name, passThroughTools, upstreamReader, keyProvider)
 	if err != nil {
 		return fmt.Errorf("failed to create authentication middleware: %w", err)
 	}


### PR DESCRIPTION
## Summary

- Cedar authorization policies reference the actual `VirtualMCPServer` name as the resource entity (e.g. `MCP::"my-vmcp"`). The factory hard-coded the string `"vmcp"` when calling `authz.CreateMiddlewareFromConfig`, so resource entities never matched and Cedar's default-deny fired on every request — 403 for all principals regardless of policy.
- Fix by adding a `serverName` parameter to `NewIncomingAuthMiddleware` and `newCedarAuthzMiddleware`, passing `vmcpCfg.Name` at the `serve.go` call site.
- Add an empty-string guard in `newCedarAuthzMiddleware` so a misconfigured (empty) server name fails loudly at startup rather than silently mismatching all resource-scoped policies.

Fixes #5428

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test plan

- [x] Added regression test `TestNewIncomingAuthMiddleware_ServerNameThreaded` that compiles a Cedar `permit` policy scoped to `resource in MCP::"my-production-vmcp"`, calls `NewIncomingAuthMiddleware` with `serverName = "my-production-vmcp"`, and asserts the request is permitted (200).
- [x] Negative sub-test with `serverName = "wrong-server"` asserts 403 — verifies that the server name is actually threaded through to Cedar evaluation, not hardcoded.
- [x] `task test` passes on the affected package.

## Does this introduce a user-facing change?

Yes: `VirtualMCPServer` Cedar authorization now correctly evaluates resource-scoped policies using the server's actual name. Previously all Cedar-gated requests returned 403 when policies used `resource in MCP::"<name>"` scoping.

Generated with [Claude Code](https://claude.com/claude-code)