### PR TITLE
Implement stateless core VMCP constructor

### DIFF
--- a/pkg/vmcp/composer/elicitation_handler.go
+++ b/pkg/vmcp/composer/elicitation_handler.go
@@ -65,6 +65,11 @@ var (
 
 	// ErrContentTooLarge is returned when response content exceeds size limits.
 	ErrContentTooLarge = errors.New("response content too large")
+
+	// ErrElicitationNotConfigured is returned when a workflow reaches an elicitation
+	// step but the handler was constructed without a requester (nil). It converts
+	// what would be a nil-pointer dereference into a clean, recoverable error.
+	ErrElicitationNotConfigured = errors.New("elicitation requester not configured")
 )
 
 // DefaultElicitationHandler implements ElicitationProtocolHandler as a thin wrapper around the MCP SDK.
@@ -122,6 +127,12 @@ func (h *DefaultElicitationHandler) RequestElicitation(
 	config *ElicitationConfig,
 ) (*ElicitationResponse, error) {
 	slog.Debug("requesting elicitation", "workflow", workflowID, "step", stepID)
+
+	// A nil requester means elicitation was never wired (e.g. the core was built
+	// with a nil ElicitationRequester). Fail cleanly instead of dereferencing nil.
+	if h.requester == nil {
+		return nil, fmt.Errorf("%w: step %s", ErrElicitationNotConfigured, stepID)
+	}
 
 	// Validate configuration
 	if err := validateConfig(config); err != nil {

--- a/pkg/vmcp/composer/elicitation_handler_test.go
+++ b/pkg/vmcp/composer/elicitation_handler_test.go
@@ -253,6 +253,24 @@ func TestDefaultElicitationHandler_TimeoutCappedToMax(t *testing.T) {
 	assert.Equal(t, "accept", response.Action)
 }
 
+func TestDefaultElicitationHandler_NilRequester(t *testing.T) {
+	t.Parallel()
+
+	// A handler built without a requester (e.g. a core constructed with a nil
+	// ElicitationRequester) must fail cleanly rather than nil-dereference when a
+	// workflow reaches an elicitation step.
+	handler := NewDefaultElicitationHandler(nil)
+
+	resp, err := handler.RequestElicitation(context.Background(), "workflow-1", "step-1", &ElicitationConfig{
+		Message: "Confirm?",
+		Schema:  map[string]any{"type": "object"},
+	})
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.ErrorIs(t, err, ErrElicitationNotConfigured)
+	assert.Contains(t, err.Error(), "step-1")
+}
+
 func TestValidateSchemaSize(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/vmcp/core/core.go
+++ b/pkg/vmcp/core/core.go
@@ -152,6 +152,7 @@ type Config struct {
 	// consumed by the composer's elicitation handler during composite-tool
 	// workflows. The composition root supplies the SDK-backed adapter; the core
 	// only forwards it to the workflow engine. May be nil when no configured
-	// workflow performs elicitation.
+	// workflow performs elicitation; New rejects a nil Elicitation when any
+	// configured workflow contains an elicitation step.
 	Elicitation vmcp.ElicitationRequester
 }

--- a/pkg/vmcp/core/core.go
+++ b/pkg/vmcp/core/core.go
@@ -147,9 +147,11 @@ type Config struct {
 	// composition root. Nil means no health filtering (all backends included).
 	HealthStatusProvider health.StatusProvider
 
-	// Elicitation (the domain-typed ElicitationRequester) is added once that
-	// domain type is introduced; it is intentionally omitted here.
-
-	// The exact field set is finalized when New is implemented; this change
-	// declares the shape (typed fields), not the construction logic.
+	// Elicitation sends MCP elicitation requests to the client and blocks for the
+	// response. It is the domain-typed seam (vmcp anti-pattern #5: no mcp-go types)
+	// consumed by the composer's elicitation handler during composite-tool
+	// workflows. The composition root supplies the SDK-backed adapter; the core
+	// only forwards it to the workflow engine. May be nil when no configured
+	// workflow performs elicitation.
+	Elicitation vmcp.ElicitationRequester
 }

--- a/pkg/vmcp/core/core_calls.go
+++ b/pkg/vmcp/core/core_calls.go
@@ -85,7 +85,9 @@ func (c *coreVMCP) ReadResource(
 		}
 		return nil, fmt.Errorf("routing resource %q: %w", uri, err)
 	}
-	return c.backendClient.ReadResource(ctx, target, target.GetBackendCapabilityName(uri))
+	// Pass the advertised URI; the backend client owns the single translation to
+	// the backend's capability name (client.go:874), matching CallTool.
+	return c.backendClient.ReadResource(ctx, target, uri)
 }
 
 // GetPrompt retrieves the named prompt from its backend. args is treated as
@@ -109,7 +111,9 @@ func (c *coreVMCP) GetPrompt(
 		}
 		return nil, fmt.Errorf("routing prompt %q: %w", name, err)
 	}
-	return c.backendClient.GetPrompt(ctx, target, target.GetBackendCapabilityName(name), maps.Clone(args))
+	// Pass the advertised name; the backend client owns the single translation to
+	// the backend's capability name (client.go:927), matching CallTool.
+	return c.backendClient.GetPrompt(ctx, target, name, maps.Clone(args))
 }
 
 // executeComposite runs a composite-tool workflow and converts the result to a

--- a/pkg/vmcp/core/core_calls.go
+++ b/pkg/vmcp/core/core_calls.go
@@ -14,7 +14,6 @@ import (
 	"github.com/stacklok/toolhive/pkg/auth"
 	"github.com/stacklok/toolhive/pkg/vmcp"
 	"github.com/stacklok/toolhive/pkg/vmcp/composer"
-	"github.com/stacklok/toolhive/pkg/vmcp/internal/compositetools"
 	"github.com/stacklok/toolhive/pkg/vmcp/router"
 )
 
@@ -42,13 +41,12 @@ func (c *coreVMCP) CallTool(
 		return nil, err
 	}
 
-	// Composite tool: execute the workflow when the tool is defined AND reachable
-	// in the current view (same accessibility filter ListTools advertises with).
-	if def, ok := c.workflowDefs[name]; ok {
-		accessible := compositetools.FilterWorkflowDefsForSession(c.workflowDefs, agg.RoutingTable)
-		if _, ok := accessible[name]; !ok {
-			return nil, fmt.Errorf("%w: composite tool %q", vmcp.ErrNotFound, name)
-		}
+	// Composite tool: execute only when the workflow is actually advertised in the
+	// current view — accessible AND not shadowed by a conflicting backend tool. This
+	// uses the same gate as ListTools (accessibleComposites), so advertised equals
+	// executed. A name that collides with a backend tool is NOT in the set and falls
+	// through to backend routing, matching the legacy decorator.
+	if def, ok := c.accessibleComposites(agg)[name]; ok {
 		engine := c.composerFactory(agg.RoutingTable, agg.Tools)
 		return executeComposite(ctx, engine, def, argsCopy)
 	}

--- a/pkg/vmcp/core/core_calls.go
+++ b/pkg/vmcp/core/core_calls.go
@@ -1,0 +1,159 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package core
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"maps"
+
+	"github.com/stacklok/toolhive/pkg/auth"
+	"github.com/stacklok/toolhive/pkg/vmcp"
+	"github.com/stacklok/toolhive/pkg/vmcp/composer"
+	"github.com/stacklok/toolhive/pkg/vmcp/internal/compositetools"
+	"github.com/stacklok/toolhive/pkg/vmcp/router"
+)
+
+// CallTool invokes the named tool. Composite tools (those defined as workflows)
+// execute through a per-call composer bound to the freshly aggregated routing
+// table; all other names route to a single backend via a session router built
+// from the same table. Returns vmcp.ErrNotFound for an unadvertised name.
+//
+// args and meta are treated as read-only and copied before being forwarded
+// (go-style: copy before mutating caller input). identity is accepted for the
+// admission seam (#5438); the core performs no identity-based filtering yet and
+// never logs identity. See ListTools for the nil/anonymous semantics.
+func (c *coreVMCP) CallTool(
+	ctx context.Context,
+	_ *auth.Identity,
+	name string,
+	args map[string]any,
+	meta map[string]any,
+) (*vmcp.ToolCallResult, error) {
+	argsCopy := maps.Clone(args)
+	metaCopy := maps.Clone(meta)
+
+	agg, err := c.aggregatedView(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Composite tool: execute the workflow when the tool is defined AND reachable
+	// in the current view (same accessibility filter ListTools advertises with).
+	if def, ok := c.workflowDefs[name]; ok {
+		accessible := compositetools.FilterWorkflowDefsForSession(c.workflowDefs, agg.RoutingTable)
+		if _, ok := accessible[name]; !ok {
+			return nil, fmt.Errorf("%w: composite tool %q", vmcp.ErrNotFound, name)
+		}
+		engine := c.composerFactory(agg.RoutingTable, agg.Tools)
+		return executeComposite(ctx, engine, def, argsCopy)
+	}
+
+	// Backend tool: route through a session router bound to the fresh table. The
+	// backend client translates the advertised name to the backend's capability
+	// name internally (client.go:772), mirroring the legacy tool handler.
+	target, err := router.NewSessionRouter(agg.RoutingTable).RouteTool(ctx, name)
+	if err != nil {
+		if errors.Is(err, router.ErrToolNotFound) {
+			return nil, fmt.Errorf("%w: tool %q", vmcp.ErrNotFound, name)
+		}
+		return nil, fmt.Errorf("routing tool %q: %w", name, err)
+	}
+	return c.backendClient.CallTool(ctx, target, name, argsCopy, metaCopy)
+}
+
+// ReadResource reads the resource at uri from its backend. Returns
+// vmcp.ErrNotFound for an unadvertised URI. See ListTools for identity semantics.
+func (c *coreVMCP) ReadResource(
+	ctx context.Context,
+	_ *auth.Identity,
+	uri string,
+) (*vmcp.ResourceReadResult, error) {
+	agg, err := c.aggregatedView(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	target, err := router.NewSessionRouter(agg.RoutingTable).RouteResource(ctx, uri)
+	if err != nil {
+		if errors.Is(err, router.ErrResourceNotFound) {
+			return nil, fmt.Errorf("%w: resource %q", vmcp.ErrNotFound, uri)
+		}
+		return nil, fmt.Errorf("routing resource %q: %w", uri, err)
+	}
+	return c.backendClient.ReadResource(ctx, target, target.GetBackendCapabilityName(uri))
+}
+
+// GetPrompt retrieves the named prompt from its backend. args is treated as
+// read-only and copied before being forwarded. Returns vmcp.ErrNotFound for an
+// unadvertised name. See ListTools for identity semantics.
+func (c *coreVMCP) GetPrompt(
+	ctx context.Context,
+	_ *auth.Identity,
+	name string,
+	args map[string]any,
+) (*vmcp.PromptGetResult, error) {
+	agg, err := c.aggregatedView(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	target, err := router.NewSessionRouter(agg.RoutingTable).RoutePrompt(ctx, name)
+	if err != nil {
+		if errors.Is(err, router.ErrPromptNotFound) {
+			return nil, fmt.Errorf("%w: prompt %q", vmcp.ErrNotFound, name)
+		}
+		return nil, fmt.Errorf("routing prompt %q: %w", name, err)
+	}
+	return c.backendClient.GetPrompt(ctx, target, target.GetBackendCapabilityName(name), maps.Clone(args))
+}
+
+// executeComposite runs a composite-tool workflow and converts the result to a
+// ToolCallResult. Workflow failures are returned as an IsError result (not a
+// transport error), mirroring the legacy compositeToolsDecorator
+// (internal/compositetools/decorator.go:76-114).
+func executeComposite(
+	ctx context.Context,
+	engine composer.Composer,
+	def *composer.WorkflowDefinition,
+	params map[string]any,
+) (*vmcp.ToolCallResult, error) {
+	result, err := engine.ExecuteWorkflow(ctx, def, params)
+	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			slog.Warn("workflow execution timeout", "tool", def.Name, "error", err)
+			return compositeErrorResult("Workflow execution timeout exceeded"), nil
+		}
+		slog.Error("workflow execution failed", "tool", def.Name, "error", err)
+		return compositeErrorResult(fmt.Sprintf("Workflow execution failed: %v", err)), nil
+	}
+	if result == nil {
+		slog.Error("workflow executor returned nil result", "tool", def.Name)
+		return compositeErrorResult("Workflow executor returned nil result"), nil
+	}
+	if result.Error != nil {
+		slog.Error("workflow completed with error", "tool", def.Name, "error", result.Error)
+		return compositeErrorResult(fmt.Sprintf("Workflow error: %v", result.Error)), nil
+	}
+
+	jsonBytes, err := json.Marshal(result.Output)
+	if err != nil {
+		return compositeErrorResult(fmt.Sprintf("failed to marshal output: %v", err)), nil
+	}
+	return &vmcp.ToolCallResult{
+		Content:           []vmcp.Content{{Type: vmcp.ContentTypeText, Text: string(jsonBytes)}},
+		StructuredContent: result.Output,
+	}, nil
+}
+
+// compositeErrorResult builds a tool-level error result for a failed workflow.
+func compositeErrorResult(msg string) *vmcp.ToolCallResult {
+	return &vmcp.ToolCallResult{
+		Content: []vmcp.Content{{Type: vmcp.ContentTypeText, Text: msg}},
+		IsError: true,
+	}
+}

--- a/pkg/vmcp/core/core_calls_test.go
+++ b/pkg/vmcp/core/core_calls_test.go
@@ -196,6 +196,34 @@ func TestGetPrompt(t *testing.T) {
 	assert.Equal(t, want, got)
 }
 
+func TestGetPrompt_CopyBeforeMutate(t *testing.T) {
+	t.Parallel()
+	cfg, m := baseConfig(t)
+
+	target := backendTarget()
+	expectAggregation(m, &aggregator.AggregatedCapabilities{
+		RoutingTable: &vmcp.RoutingTable{Prompts: map[string]*vmcp.BackendTarget{"p1": target}},
+	})
+
+	// The backend client mutates the args it receives; the caller's original must be
+	// untouched because GetPrompt forwards a clone (parity with CallTool).
+	m.client.EXPECT().
+		GetPrompt(gomock.Any(), gomock.Any(), "p1", gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ *vmcp.BackendTarget, _ string, args map[string]any) (*vmcp.PromptGetResult, error) {
+			args["injected"] = true
+			return &vmcp.PromptGetResult{}, nil
+		})
+
+	c, err := New(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = c.Close() })
+
+	args := map[string]any{"x": 1}
+	_, err = c.GetPrompt(context.Background(), nil, "p1", args)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]any{"x": 1}, args, "caller args must not be mutated")
+}
+
 func TestGetPrompt_NotFound(t *testing.T) {
 	t.Parallel()
 	cfg, m := baseConfig(t)
@@ -344,6 +372,13 @@ func TestExecuteComposite(t *testing.T) {
 			composer:    stubComposer{result: &composer.WorkflowResult{Error: errors.New("step failed")}},
 			wantIsError: true,
 			wantMsg:     "Workflow error",
+		},
+		{
+			name: "marshal failure",
+			// A channel is not JSON-serializable, forcing json.Marshal(Output) to fail.
+			composer:    stubComposer{result: &composer.WorkflowResult{Output: map[string]any{"ch": make(chan int)}}},
+			wantIsError: true,
+			wantMsg:     "failed to marshal output",
 		},
 	}
 

--- a/pkg/vmcp/core/core_calls_test.go
+++ b/pkg/vmcp/core/core_calls_test.go
@@ -1,0 +1,209 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/stacklok/toolhive/pkg/vmcp"
+	"github.com/stacklok/toolhive/pkg/vmcp/aggregator"
+	"github.com/stacklok/toolhive/pkg/vmcp/composer"
+)
+
+// expectAggregation wires reg.List + agg.AggregateCapabilities to return agg once.
+func expectAggregation(m *coreMocks, agg *aggregator.AggregatedCapabilities) {
+	m.reg.EXPECT().List(gomock.Any()).Return([]vmcp.Backend{{ID: "be1", HealthStatus: vmcp.BackendHealthy}})
+	m.agg.EXPECT().AggregateCapabilities(gomock.Any(), gomock.Any()).Return(agg, nil)
+}
+
+func TestCallTool_RoutesToBackend(t *testing.T) {
+	t.Parallel()
+	cfg, m := baseConfig(t)
+
+	target := backendTarget()
+	expectAggregation(m, &aggregator.AggregatedCapabilities{
+		Tools:        []vmcp.Tool{backendTool("tool_a")},
+		RoutingTable: &vmcp.RoutingTable{Tools: map[string]*vmcp.BackendTarget{"tool_a": target}},
+	})
+
+	want := &vmcp.ToolCallResult{StructuredContent: map[string]any{"result": "ok"}}
+	m.client.EXPECT().
+		CallTool(gomock.Any(), gomock.Any(), "tool_a", gomock.Any(), gomock.Any()).
+		Return(want, nil)
+
+	c, err := New(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = c.Close() })
+
+	got, err := c.CallTool(context.Background(), nil, "tool_a", map[string]any{"a": 1}, nil)
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
+}
+
+func TestCallTool_NotFound(t *testing.T) {
+	t.Parallel()
+	cfg, m := baseConfig(t)
+
+	expectAggregation(m, &aggregator.AggregatedCapabilities{RoutingTable: &vmcp.RoutingTable{}})
+
+	c, err := New(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = c.Close() })
+
+	_, err = c.CallTool(context.Background(), nil, "missing", nil, nil)
+	assert.ErrorIs(t, err, vmcp.ErrNotFound)
+}
+
+func TestCallTool_CopyBeforeMutate(t *testing.T) {
+	t.Parallel()
+	cfg, m := baseConfig(t)
+
+	target := backendTarget()
+	expectAggregation(m, &aggregator.AggregatedCapabilities{
+		RoutingTable: &vmcp.RoutingTable{Tools: map[string]*vmcp.BackendTarget{"tool_a": target}},
+	})
+
+	// The backend client mutates the maps it receives; the caller's originals
+	// must be untouched because CallTool forwards clones.
+	m.client.EXPECT().
+		CallTool(gomock.Any(), gomock.Any(), "tool_a", gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ *vmcp.BackendTarget, _ string, args, meta map[string]any) (*vmcp.ToolCallResult, error) {
+			args["injected"] = true
+			meta["injected"] = true
+			return &vmcp.ToolCallResult{}, nil
+		})
+
+	c, err := New(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = c.Close() })
+
+	args := map[string]any{"a": 1}
+	meta := map[string]any{"m": "n"}
+	_, err = c.CallTool(context.Background(), nil, "tool_a", args, meta)
+	require.NoError(t, err)
+
+	assert.Equal(t, map[string]any{"a": 1}, args, "caller args must not be mutated")
+	assert.Equal(t, map[string]any{"m": "n"}, meta, "caller meta must not be mutated")
+}
+
+func TestCallTool_CompositeWorkflow(t *testing.T) {
+	t.Parallel()
+	cfg, m := baseConfig(t)
+	cfg.WorkflowDefs = map[string]*composer.WorkflowDefinition{
+		"wf": {Name: "wf", Steps: []composer.WorkflowStep{{ID: "s1", Type: composer.StepTypeTool, Tool: "be1.echo"}}},
+	}
+
+	target := backendTarget()
+	expectAggregation(m, &aggregator.AggregatedCapabilities{
+		Tools:        []vmcp.Tool{backendTool("be1.echo")},
+		RoutingTable: &vmcp.RoutingTable{Tools: map[string]*vmcp.BackendTarget{"be1.echo": target}},
+	})
+
+	// The composite workflow's single tool step routes to the backend through the
+	// per-call composer built from the aggregated routing table.
+	m.client.EXPECT().
+		CallTool(gomock.Any(), gomock.Any(), "be1.echo", gomock.Any(), gomock.Any()).
+		Return(&vmcp.ToolCallResult{StructuredContent: map[string]any{"ok": true}}, nil)
+
+	c, err := New(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = c.Close() })
+
+	got, err := c.CallTool(context.Background(), nil, "wf", nil, nil)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.False(t, got.IsError)
+	assert.Equal(t, true, got.StructuredContent["ok"])
+}
+
+func TestCallTool_CompositeNotAccessible(t *testing.T) {
+	t.Parallel()
+	cfg, m := baseConfig(t)
+	cfg.WorkflowDefs = map[string]*composer.WorkflowDefinition{
+		"wf": {Name: "wf", Steps: []composer.WorkflowStep{{ID: "s1", Type: composer.StepTypeTool, Tool: "be1.echo"}}},
+	}
+
+	// Routing table does not contain be1.echo, so the composite is not reachable.
+	expectAggregation(m, &aggregator.AggregatedCapabilities{RoutingTable: &vmcp.RoutingTable{}})
+
+	c, err := New(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = c.Close() })
+
+	_, err = c.CallTool(context.Background(), nil, "wf", nil, nil)
+	assert.ErrorIs(t, err, vmcp.ErrNotFound)
+}
+
+func TestReadResource(t *testing.T) {
+	t.Parallel()
+	cfg, m := baseConfig(t)
+
+	target := backendTarget()
+	expectAggregation(m, &aggregator.AggregatedCapabilities{
+		RoutingTable: &vmcp.RoutingTable{Resources: map[string]*vmcp.BackendTarget{"file://a": target}},
+	})
+
+	want := &vmcp.ResourceReadResult{Contents: []vmcp.ResourceContent{{URI: "file://a", Text: "hi"}}}
+	m.client.EXPECT().ReadResource(gomock.Any(), gomock.Any(), "file://a").Return(want, nil)
+
+	c, err := New(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = c.Close() })
+
+	got, err := c.ReadResource(context.Background(), nil, "file://a")
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
+}
+
+func TestReadResource_NotFound(t *testing.T) {
+	t.Parallel()
+	cfg, m := baseConfig(t)
+	expectAggregation(m, &aggregator.AggregatedCapabilities{RoutingTable: &vmcp.RoutingTable{}})
+
+	c, err := New(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = c.Close() })
+
+	_, err = c.ReadResource(context.Background(), nil, "file://missing")
+	assert.ErrorIs(t, err, vmcp.ErrNotFound)
+}
+
+func TestGetPrompt(t *testing.T) {
+	t.Parallel()
+	cfg, m := baseConfig(t)
+
+	target := backendTarget()
+	expectAggregation(m, &aggregator.AggregatedCapabilities{
+		RoutingTable: &vmcp.RoutingTable{Prompts: map[string]*vmcp.BackendTarget{"p1": target}},
+	})
+
+	want := &vmcp.PromptGetResult{Description: "a prompt"}
+	m.client.EXPECT().GetPrompt(gomock.Any(), gomock.Any(), "p1", gomock.Any()).Return(want, nil)
+
+	c, err := New(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = c.Close() })
+
+	got, err := c.GetPrompt(context.Background(), nil, "p1", map[string]any{"x": 1})
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
+}
+
+func TestGetPrompt_NotFound(t *testing.T) {
+	t.Parallel()
+	cfg, m := baseConfig(t)
+	expectAggregation(m, &aggregator.AggregatedCapabilities{RoutingTable: &vmcp.RoutingTable{}})
+
+	c, err := New(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = c.Close() })
+
+	_, err = c.GetPrompt(context.Background(), nil, "missing", nil)
+	assert.ErrorIs(t, err, vmcp.ErrNotFound)
+}

--- a/pkg/vmcp/core/core_calls_test.go
+++ b/pkg/vmcp/core/core_calls_test.go
@@ -5,6 +5,7 @@ package core
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -206,4 +207,114 @@ func TestGetPrompt_NotFound(t *testing.T) {
 
 	_, err = c.GetPrompt(context.Background(), nil, "missing", nil)
 	assert.ErrorIs(t, err, vmcp.ErrNotFound)
+}
+
+// TestCallTool_ResolvesRenamedTool exercises the conflict-resolution name path:
+// the advertised name uses the dot convention ("be1.echo") while the routing
+// table is keyed by the prefixed resolved name ("be1_echo") whose target carries
+// a non-empty OriginalCapabilityName. The session router resolves it via
+// GetBackendCapabilityName, and the core forwards the advertised name to the
+// client (the client owns the translation to the backend's capability name).
+func TestCallTool_ResolvesRenamedTool(t *testing.T) {
+	t.Parallel()
+	cfg, m := baseConfig(t)
+
+	target := &vmcp.BackendTarget{WorkloadID: "be1", OriginalCapabilityName: "echo", BaseURL: "http://be1:8080"}
+	expectAggregation(m, &aggregator.AggregatedCapabilities{
+		Tools:        []vmcp.Tool{{Name: "be1_echo", BackendID: "be1"}},
+		RoutingTable: &vmcp.RoutingTable{Tools: map[string]*vmcp.BackendTarget{"be1_echo": target}},
+	})
+
+	m.client.EXPECT().
+		CallTool(gomock.Any(), target, "be1.echo", gomock.Any(), gomock.Any()).
+		Return(&vmcp.ToolCallResult{}, nil)
+
+	c, err := New(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = c.Close() })
+
+	_, err = c.CallTool(context.Background(), nil, "be1.echo", nil, nil)
+	require.NoError(t, err)
+}
+
+// stubComposer is a configurable composer.Composer for unit-testing
+// executeComposite's result/error conversion without the real workflow engine.
+type stubComposer struct {
+	result *composer.WorkflowResult
+	err    error
+}
+
+func (s stubComposer) ExecuteWorkflow(
+	_ context.Context, _ *composer.WorkflowDefinition, _ map[string]any,
+) (*composer.WorkflowResult, error) {
+	return s.result, s.err
+}
+func (stubComposer) ValidateWorkflow(_ context.Context, _ *composer.WorkflowDefinition) error {
+	return nil
+}
+func (stubComposer) GetWorkflowStatus(_ context.Context, _ string) (*composer.WorkflowStatus, error) {
+	return nil, nil
+}
+func (stubComposer) CancelWorkflow(_ context.Context, _ string) error { return nil }
+
+func TestExecuteComposite(t *testing.T) {
+	t.Parallel()
+
+	def := &composer.WorkflowDefinition{Name: "wf"}
+
+	tests := []struct {
+		name        string
+		composer    stubComposer
+		wantIsError bool
+		wantMsg     string // substring expected in the error content
+		wantOutput  map[string]any
+	}{
+		{
+			name:        "success",
+			composer:    stubComposer{result: &composer.WorkflowResult{Output: map[string]any{"k": "v"}}},
+			wantIsError: false,
+			wantOutput:  map[string]any{"k": "v"},
+		},
+		{
+			name:        "execution error",
+			composer:    stubComposer{err: errors.New("boom")},
+			wantIsError: true,
+			wantMsg:     "Workflow execution failed",
+		},
+		{
+			name:        "timeout",
+			composer:    stubComposer{err: context.DeadlineExceeded},
+			wantIsError: true,
+			wantMsg:     "timeout",
+		},
+		{
+			name:        "nil result",
+			composer:    stubComposer{},
+			wantIsError: true,
+			wantMsg:     "nil result",
+		},
+		{
+			name:        "result carries error",
+			composer:    stubComposer{result: &composer.WorkflowResult{Error: errors.New("step failed")}},
+			wantIsError: true,
+			wantMsg:     "Workflow error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := executeComposite(context.Background(), tt.composer, def, nil)
+			require.NoError(t, err) // workflow failures are returned as IsError results, not errors
+			require.NotNil(t, got)
+			assert.Equal(t, tt.wantIsError, got.IsError)
+			if tt.wantMsg != "" {
+				require.NotEmpty(t, got.Content)
+				assert.Contains(t, got.Content[0].Text, tt.wantMsg)
+			}
+			if tt.wantOutput != nil {
+				assert.Equal(t, tt.wantOutput, got.StructuredContent)
+			}
+		})
+	}
 }

--- a/pkg/vmcp/core/core_calls_test.go
+++ b/pkg/vmcp/core/core_calls_test.go
@@ -237,6 +237,52 @@ func TestCallTool_ResolvesRenamedTool(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// TestCompositeNameConflict_AdvertisedEqualsExecuted is the F1 parity guard: when a
+// composite tool name collides with a backend tool name, ListTools advertises the
+// backend tool (composites dropped) and CallTool must ALSO route that name to the
+// backend — never execute the withheld composite. The single accessibleComposites
+// gate keeps advertised == executed (matching the legacy decorator).
+func TestCompositeNameConflict_AdvertisedEqualsExecuted(t *testing.T) {
+	t.Parallel()
+	cfg, m := baseConfig(t)
+	// Composite "shared" is accessible (its step routes), but its name also collides
+	// with an advertised backend tool "shared".
+	cfg.WorkflowDefs = map[string]*composer.WorkflowDefinition{
+		"shared": {Name: "shared", Steps: []composer.WorkflowStep{{ID: "s1", Type: composer.StepTypeTool, Tool: "be1.echo"}}},
+	}
+
+	beTarget := &vmcp.BackendTarget{WorkloadID: "be1", BaseURL: "http://be1:8080"}
+	agg := &aggregator.AggregatedCapabilities{
+		Tools: []vmcp.Tool{{Name: "shared", BackendID: "be1"}},
+		RoutingTable: &vmcp.RoutingTable{Tools: map[string]*vmcp.BackendTarget{
+			"shared":   beTarget,
+			"be1.echo": beTarget,
+		}},
+	}
+	// Two aggregations: one for ListTools, one for CallTool.
+	m.reg.EXPECT().List(gomock.Any()).Return(nil).Times(2)
+	m.agg.EXPECT().AggregateCapabilities(gomock.Any(), gomock.Any()).Return(agg, nil).Times(2)
+
+	c, err := New(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = c.Close() })
+
+	// ListTools advertises only the backend tool; the conflicting composite is dropped.
+	tools, err := c.ListTools(context.Background(), nil)
+	require.NoError(t, err)
+	require.Len(t, tools, 1)
+	assert.Equal(t, "shared", tools[0].Name)
+	assert.Equal(t, "be1", tools[0].BackendID)
+
+	// CallTool("shared") must route to the backend, not execute the composite.
+	want := &vmcp.ToolCallResult{StructuredContent: map[string]any{"from": "backend"}}
+	m.client.EXPECT().CallTool(gomock.Any(), beTarget, "shared", gomock.Any(), gomock.Any()).Return(want, nil)
+
+	got, err := c.CallTool(context.Background(), nil, "shared", nil, nil)
+	require.NoError(t, err)
+	assert.Equal(t, want, got, "conflicting name must resolve to the backend tool, not the composite")
+}
+
 // stubComposer is a configurable composer.Composer for unit-testing
 // executeComposite's result/error conversion without the real workflow engine.
 type stubComposer struct {

--- a/pkg/vmcp/core/core_vmcp.go
+++ b/pkg/vmcp/core/core_vmcp.go
@@ -60,9 +60,10 @@ type coreVMCP struct {
 	// table, generalizing server.New's sessionComposerFactory (server.go:393).
 	composerFactory func(sessionRT *vmcp.RoutingTable, sessionTools []vmcp.Tool) composer.Composer
 
-	// stateStore backs the workflow engine and owns a background cleanup
-	// goroutine that Close stops.
-	stateStore composer.WorkflowStateStore
+	// stopStore stops the workflow state store's background cleanup goroutine.
+	// Captured at construction (the store is created internally, not injected) so
+	// Close is not a silent capability assertion. Guarded by closeOnce.
+	stopStore func()
 
 	closeOnce sync.Once
 }
@@ -137,8 +138,24 @@ func New(cfg *Config) (VMCP, error) {
 	// must stop it to avoid a leak.
 	stateStore := composer.NewInMemoryStateStore(stateStoreCleanupInterval, stateStoreMaxAge)
 
+	// NewInMemoryStateStore returns *inMemoryStateStore, which owns that cleanup
+	// goroutine. Capture its Stop here so Close releases it; warn loudly (rather
+	// than a silent no-op, per go-style) if a future store swap drops the
+	// capability, so a leaked goroutine is diagnosable instead of invisible.
+	stopStore := func() {}
+	if s, ok := stateStore.(interface{ Stop() }); ok {
+		stopStore = s.Stop
+	} else {
+		slog.Warn("workflow state store exposes no Stop(); its cleanup goroutine will leak on Close",
+			"type", fmt.Sprintf("%T", stateStore))
+	}
+
 	// composerFactory builds a composite-tool engine bound to a specific routing
 	// table, generalizing server.New's sessionComposerFactory (server.go:393-398).
+	// Workflow-level telemetry (toolhive_vmcp_workflow_*) is intentionally NOT wired
+	// here: that instrumentation lives in the session/Serve layer
+	// (sessionmanager/factory.go:174-176) and is added when the core is wired into
+	// Serve (#5439). This mirrors server.go:393-398, which is also uninstrumented.
 	composerFactory := func(sessionRT *vmcp.RoutingTable, sessionTools []vmcp.Tool) composer.Composer {
 		return composer.NewWorkflowEngine(
 			router.NewSessionRouter(sessionRT), backendClient, elicitationHandler,
@@ -154,7 +171,7 @@ func New(cfg *Config) (VMCP, error) {
 	)
 	workflowDefs, err := validateWorkflowDefs(validationEngine, cfg.WorkflowDefs)
 	if err != nil {
-		stopStateStore(stateStore)
+		stopStore()
 		return nil, fmt.Errorf("workflow validation failed: %w", err)
 	}
 
@@ -165,7 +182,7 @@ func New(cfg *Config) (VMCP, error) {
 		health:          cfg.HealthStatusProvider,
 		workflowDefs:    workflowDefs,
 		composerFactory: composerFactory,
-		stateStore:      stateStore,
+		stopStore:       stopStore,
 	}, nil
 }
 
@@ -256,9 +273,7 @@ func (c *coreVMCP) LookupPrompt(ctx context.Context, identity *auth.Identity, na
 // the underlying Stop closes a channel that cannot be closed twice, so the work
 // is guarded by sync.Once and subsequent calls return nil.
 func (c *coreVMCP) Close() error {
-	c.closeOnce.Do(func() {
-		stopStateStore(c.stateStore)
-	})
+	c.closeOnce.Do(c.stopStore)
 	return nil
 }
 
@@ -348,16 +363,6 @@ func validateWorkflowDefs(
 	return validDefs, nil
 }
 
-// stopStateStore stops the state store's background cleanup goroutine when the
-// concrete implementation supports it. The WorkflowStateStore interface does not
-// expose Stop, so the in-memory implementation is detected via a capability
-// assertion; other stores (no goroutine to stop) are a no-op.
-func stopStateStore(store composer.WorkflowStateStore) {
-	if s, ok := store.(interface{ Stop() }); ok {
-		s.Stop()
-	}
-}
-
 // filterHealthyBackends filters backends to only include those that are healthy
 // or degraded. Backends that are unhealthy, unknown, or unauthenticated are
 // excluded from capability aggregation to prevent exposing tools from
@@ -417,7 +422,13 @@ func filterHealthyBackends(backends []vmcp.Backend, healthStatusProvider health.
 			slog.Debug("excluding backend from capability aggregation due to health status",
 				"backend_name", backend.Name,
 				"backend_id", backend.ID,
-				"health_status", healthStatus)
+				"health_status", healthStatus,
+				"source", func() string {
+					if healthStatusProvider != nil {
+						return "health_monitor"
+					}
+					return "registry"
+				}())
 		}
 	}
 

--- a/pkg/vmcp/core/core_vmcp.go
+++ b/pkg/vmcp/core/core_vmcp.go
@@ -264,7 +264,9 @@ func (c *coreVMCP) Close() error {
 
 // aggregatedView health-filters the backend registry and aggregates capabilities
 // on demand. The core holds no per-session capability cache (the core filters,
-// Serve caches): every List/Lookup/Call re-derives the advertised view.
+// Serve caches): every List/Lookup/Call re-derives the advertised view, so a
+// lookup-then-call flow aggregates twice. This is intentional — caching is the
+// Serve layer's responsibility, not the core's (vmcp anti-patterns #8/#9).
 func (c *coreVMCP) aggregatedView(ctx context.Context) (*aggregator.AggregatedCapabilities, error) {
 	backends := filterHealthyBackends(c.backendRegistry.List(ctx), c.health)
 	agg, err := c.aggregator.AggregateCapabilities(ctx, backends)
@@ -312,6 +314,8 @@ func validateWorkflowDefs(
 	workflowDefs map[string]*composer.WorkflowDefinition,
 ) (map[string]*composer.WorkflowDefinition, error) {
 	if len(workflowDefs) == 0 {
+		// Nil-when-empty, mirroring legacy server.New; all readers guard for it
+		// (advertisedTools' len check and the c.workflowDefs[name] lookup).
 		return nil, nil
 	}
 

--- a/pkg/vmcp/core/core_vmcp.go
+++ b/pkg/vmcp/core/core_vmcp.go
@@ -1,0 +1,411 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package core
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/stacklok/toolhive/pkg/audit"
+	"github.com/stacklok/toolhive/pkg/auth"
+	"github.com/stacklok/toolhive/pkg/vmcp"
+	"github.com/stacklok/toolhive/pkg/vmcp/aggregator"
+	"github.com/stacklok/toolhive/pkg/vmcp/composer"
+	"github.com/stacklok/toolhive/pkg/vmcp/health"
+	"github.com/stacklok/toolhive/pkg/vmcp/internal/backendtelemetry"
+	"github.com/stacklok/toolhive/pkg/vmcp/internal/compositetools"
+	"github.com/stacklok/toolhive/pkg/vmcp/router"
+)
+
+const (
+	// stateStoreCleanupInterval is how often the in-memory workflow state store
+	// purges stale entries. Matches the legacy server.New value (server.go:386).
+	stateStoreCleanupInterval = 5 * time.Minute
+
+	// stateStoreMaxAge is how long completed/failed workflows are retained.
+	// Matches the legacy server.New value (server.go:386).
+	stateStoreMaxAge = 1 * time.Hour
+)
+
+// coreVMCP is the concrete, identity-parameterized [VMCP] assembled by [New].
+//
+// It is stateless with respect to MCP sessions: every List/Lookup/Call
+// re-derives the advertised capability view by health-filtering the backend
+// registry and aggregating on demand ("the core filters, Serve caches" — caching
+// is added by a Serve decorator, not here). It holds no context-coupled router:
+// routing is performed through a [router.NewSessionRouter] bound to the freshly
+// aggregated routing table, removing composite tools' dependency on
+// context-injected capabilities (vmcp anti-pattern #1).
+//
+// Safe for concurrent use: all fields are read-only after construction except
+// the cleanup guarded by closeOnce.
+type coreVMCP struct {
+	aggregator      aggregator.Aggregator
+	backendRegistry vmcp.BackendRegistry
+	backendClient   vmcp.BackendClient
+
+	// health is the injected read-only backend health view. Nil means no health
+	// filtering (all backends included), matching today's no-monitor behavior.
+	health health.StatusProvider
+
+	// workflowDefs holds the validated composite-tool workflow definitions keyed
+	// by advertised tool name.
+	workflowDefs map[string]*composer.WorkflowDefinition
+
+	// composerFactory builds a per-call composite-tool engine bound to a routing
+	// table, generalizing server.New's sessionComposerFactory (server.go:393).
+	composerFactory func(sessionRT *vmcp.RoutingTable, sessionTools []vmcp.Tool) composer.Composer
+
+	// stateStore backs the workflow engine and owns a background cleanup
+	// goroutine that Close stops.
+	stateStore composer.WorkflowStateStore
+
+	closeOnce sync.Once
+}
+
+var _ VMCP = (*coreVMCP)(nil)
+
+// New constructs the core [VMCP] by relocating the domain wiring that lives in
+// server.New today (server.go:330-405): telemetry backend-client decoration, the
+// optional workflow auditor, the in-memory state store and workflow engine, the
+// per-session composer factory, and fail-fast workflow validation.
+//
+// cfg.Router is consumed only to build the workflow-validation engine (parity
+// with server.New); the core does not route through it at request time. cfg's
+// Aggregator, BackendRegistry, and BackendClient are required and New fails
+// loudly when any is nil. The admission seam (cfg.Authz) is NOT wired here — it
+// lands in #5438.
+func New(cfg *Config) (VMCP, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("%w: nil core config", vmcp.ErrInvalidConfig)
+	}
+	if cfg.Aggregator == nil {
+		return nil, fmt.Errorf("%w: Aggregator is required", vmcp.ErrInvalidConfig)
+	}
+	if cfg.Router == nil {
+		return nil, fmt.Errorf("%w: Router is required", vmcp.ErrInvalidConfig)
+	}
+	if cfg.BackendRegistry == nil {
+		return nil, fmt.Errorf("%w: BackendRegistry is required", vmcp.ErrInvalidConfig)
+	}
+	if cfg.BackendClient == nil {
+		return nil, fmt.Errorf("%w: BackendClient is required", vmcp.ErrInvalidConfig)
+	}
+
+	backendClient := cfg.BackendClient
+
+	// Telemetry backend-client decoration must happen BEFORE building the workflow
+	// engine so that workflow backend calls are instrumented (server.go:350-367).
+	if cfg.TelemetryProvider != nil {
+		decorated, err := backendtelemetry.MonitorBackends(
+			context.Background(),
+			cfg.TelemetryProvider.MeterProvider(),
+			cfg.TelemetryProvider.TracerProvider(),
+			cfg.BackendRegistry.List(context.Background()),
+			backendClient,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to monitor backends: %w", err)
+		}
+		backendClient = decorated
+	}
+
+	// Workflow auditor (server.go:370-381).
+	var workflowAuditor *audit.WorkflowAuditor
+	if cfg.AuditConfig != nil {
+		if err := cfg.AuditConfig.Validate(); err != nil {
+			return nil, fmt.Errorf("invalid audit configuration: %w", err)
+		}
+		var err error
+		workflowAuditor, err = audit.NewWorkflowAuditor(cfg.AuditConfig)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create workflow auditor: %w", err)
+		}
+		slog.Info("workflow audit logging enabled")
+	}
+
+	// The elicitation handler depends only on the domain-typed ElicitationRequester
+	// (#5436); no mcp-go types cross this boundary (vmcp anti-pattern #5).
+	elicitationHandler := composer.NewDefaultElicitationHandler(cfg.Elicitation)
+
+	// State store + workflow engine (server.go:386-387). The state store starts a
+	// background cleanup goroutine immediately, so any error path after this point
+	// must stop it to avoid a leak.
+	stateStore := composer.NewInMemoryStateStore(stateStoreCleanupInterval, stateStoreMaxAge)
+
+	// composerFactory builds a composite-tool engine bound to a specific routing
+	// table, generalizing server.New's sessionComposerFactory (server.go:393-398).
+	composerFactory := func(sessionRT *vmcp.RoutingTable, sessionTools []vmcp.Tool) composer.Composer {
+		return composer.NewWorkflowEngine(
+			router.NewSessionRouter(sessionRT), backendClient, elicitationHandler,
+			stateStore, workflowAuditor, sessionTools,
+		)
+	}
+
+	// Validate workflows fail-fast (server.go:400-405). The validation engine uses
+	// cfg.Router; ValidateWorkflow checks structure (cycles, references) and does
+	// not route, so the context-coupled default router is acceptable here.
+	validationEngine := composer.NewWorkflowEngine(
+		cfg.Router, backendClient, elicitationHandler, stateStore, workflowAuditor, nil,
+	)
+	workflowDefs, err := validateWorkflowDefs(validationEngine, cfg.WorkflowDefs)
+	if err != nil {
+		stopStateStore(stateStore)
+		return nil, fmt.Errorf("workflow validation failed: %w", err)
+	}
+
+	return &coreVMCP{
+		aggregator:      cfg.Aggregator,
+		backendRegistry: cfg.BackendRegistry,
+		backendClient:   backendClient,
+		health:          cfg.HealthStatusProvider,
+		workflowDefs:    workflowDefs,
+		composerFactory: composerFactory,
+		stateStore:      stateStore,
+	}, nil
+}
+
+// ListTools health-filters the registry, aggregates backend capabilities on
+// demand, and appends the composite tools reachable in the current view.
+//
+// identity is accepted for the admission seam wired in #5438; this core performs
+// no identity-based filtering yet. A nil identity is treated as anonymous,
+// consistent with session/types.ShouldAllowAnonymous — bound-session caller
+// enforcement (ErrNilCaller/ErrUnauthorizedCaller) lives in the Serve session
+// layer, not here. identity is never logged.
+func (c *coreVMCP) ListTools(ctx context.Context, _ *auth.Identity) ([]vmcp.Tool, error) {
+	agg, err := c.aggregatedView(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return c.advertisedTools(agg), nil
+}
+
+// ListResources health-filters the registry and aggregates resources on demand.
+func (c *coreVMCP) ListResources(ctx context.Context, _ *auth.Identity) ([]vmcp.Resource, error) {
+	agg, err := c.aggregatedView(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return agg.Resources, nil
+}
+
+// ListPrompts health-filters the registry and aggregates prompts on demand.
+func (c *coreVMCP) ListPrompts(ctx context.Context, _ *auth.Identity) ([]vmcp.Prompt, error) {
+	agg, err := c.aggregatedView(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return agg.Prompts, nil
+}
+
+// LookupTool resolves an advertised tool name (incl. composite tools) to its
+// capability without invoking it. It applies the same health/advertising view as
+// ListTools and returns vmcp.ErrNotFound for an unknown or unadvertised name.
+func (c *coreVMCP) LookupTool(ctx context.Context, identity *auth.Identity, name string) (*vmcp.Tool, error) {
+	tools, err := c.ListTools(ctx, identity)
+	if err != nil {
+		return nil, err
+	}
+	for i := range tools {
+		if tools[i].Name == name {
+			tool := tools[i]
+			return &tool, nil
+		}
+	}
+	return nil, fmt.Errorf("%w: tool %q", vmcp.ErrNotFound, name)
+}
+
+// LookupResource resolves an advertised resource URI to its capability without
+// reading it. Returns vmcp.ErrNotFound for an unknown or unadvertised URI.
+func (c *coreVMCP) LookupResource(ctx context.Context, identity *auth.Identity, uri string) (*vmcp.Resource, error) {
+	resources, err := c.ListResources(ctx, identity)
+	if err != nil {
+		return nil, err
+	}
+	for i := range resources {
+		if resources[i].URI == uri {
+			resource := resources[i]
+			return &resource, nil
+		}
+	}
+	return nil, fmt.Errorf("%w: resource %q", vmcp.ErrNotFound, uri)
+}
+
+// LookupPrompt resolves an advertised prompt name to its capability without
+// retrieving it. Returns vmcp.ErrNotFound for an unknown or unadvertised name.
+func (c *coreVMCP) LookupPrompt(ctx context.Context, identity *auth.Identity, name string) (*vmcp.Prompt, error) {
+	prompts, err := c.ListPrompts(ctx, identity)
+	if err != nil {
+		return nil, err
+	}
+	for i := range prompts {
+		if prompts[i].Name == name {
+			prompt := prompts[i]
+			return &prompt, nil
+		}
+	}
+	return nil, fmt.Errorf("%w: prompt %q", vmcp.ErrNotFound, name)
+}
+
+// Close stops the workflow state store's cleanup goroutine. It is idempotent:
+// the underlying Stop closes a channel that cannot be closed twice, so the work
+// is guarded by sync.Once and subsequent calls return nil.
+func (c *coreVMCP) Close() error {
+	c.closeOnce.Do(func() {
+		stopStateStore(c.stateStore)
+	})
+	return nil
+}
+
+// aggregatedView health-filters the backend registry and aggregates capabilities
+// on demand. The core holds no per-session capability cache (the core filters,
+// Serve caches): every List/Lookup/Call re-derives the advertised view.
+func (c *coreVMCP) aggregatedView(ctx context.Context) (*aggregator.AggregatedCapabilities, error) {
+	backends := filterHealthyBackends(c.backendRegistry.List(ctx), c.health)
+	agg, err := c.aggregator.AggregateCapabilities(ctx, backends)
+	if err != nil {
+		return nil, fmt.Errorf("capability aggregation failed: %w", err)
+	}
+	return agg, nil
+}
+
+// advertisedTools returns the aggregated backend tools followed by the composite
+// tools reachable in agg's routing table.
+//
+// Composite tools must be added here rather than by a Serve decorator: decorators
+// may only SUBTRACT reachability ([VMCP] contract), so the core is the only layer
+// that can advertise them. The accessibility filter and conflict check mirror the
+// legacy compositeToolsDecorator (sessionmanager/factory.go:158-180).
+func (c *coreVMCP) advertisedTools(agg *aggregator.AggregatedCapabilities) []vmcp.Tool {
+	if len(c.workflowDefs) == 0 {
+		return agg.Tools
+	}
+
+	accessibleDefs := compositetools.FilterWorkflowDefsForSession(c.workflowDefs, agg.RoutingTable)
+	composite := compositetools.ConvertWorkflowDefsToTools(accessibleDefs)
+	if len(composite) == 0 {
+		return agg.Tools
+	}
+	if err := compositetools.ValidateNoToolConflicts(agg.Tools, composite); err != nil {
+		slog.Warn("composite tool name conflict detected; omitting composite tools", "error", err)
+		return agg.Tools
+	}
+
+	out := make([]vmcp.Tool, 0, len(agg.Tools)+len(composite))
+	out = append(out, agg.Tools...)
+	out = append(out, composite...)
+	return out
+}
+
+// validateWorkflowDefs validates each workflow definition, returning only the
+// valid ones. It fails fast on the first invalid definition.
+//
+// Relocated from server.New (server.go:1211); the legacy path keeps its own copy
+// until server.New is reduced to a wrapper (Phase 3, #5432/#5445).
+func validateWorkflowDefs(
+	validator composer.Composer,
+	workflowDefs map[string]*composer.WorkflowDefinition,
+) (map[string]*composer.WorkflowDefinition, error) {
+	if len(workflowDefs) == 0 {
+		return nil, nil
+	}
+
+	validDefs := make(map[string]*composer.WorkflowDefinition, len(workflowDefs))
+	for name, def := range workflowDefs {
+		if err := validator.ValidateWorkflow(context.Background(), def); err != nil {
+			return nil, fmt.Errorf("invalid workflow definition %q: %w", name, err)
+		}
+		validDefs[name] = def
+	}
+	slog.Info("loaded valid composite tool workflows", "count", len(validDefs))
+	return validDefs, nil
+}
+
+// stopStateStore stops the state store's background cleanup goroutine when the
+// concrete implementation supports it. The WorkflowStateStore interface does not
+// expose Stop, so the in-memory implementation is detected via a capability
+// assertion; other stores (no goroutine to stop) are a no-op.
+func stopStateStore(store composer.WorkflowStateStore) {
+	if s, ok := store.(interface{ Stop() }); ok {
+		s.Stop()
+	}
+}
+
+// filterHealthyBackends filters backends to only include those that are healthy
+// or degraded. Backends that are unhealthy, unknown, or unauthenticated are
+// excluded from capability aggregation to prevent exposing tools from
+// unavailable backends.
+//
+// Health status filtering:
+//   - healthy: included (fully operational)
+//   - degraded: included (slow but working)
+//   - empty/zero-value: included (assume healthy when health monitoring is disabled)
+//   - unhealthy: excluded (not responding, circuit breaker may be open)
+//   - unknown: excluded (status not yet determined)
+//   - unauthenticated: excluded (misconfiguration: backend requires auth but none configured)
+//
+// When healthStatusProvider is provided, the current health status from the
+// health monitor is used (respects circuit breaker state). When nil, falls back
+// to the initial health status from the backend registry.
+//
+// This is an intentional, temporary duplication of discovery.filterHealthyBackends
+// (discovery/middleware.go:157, rules at 185-188): the discovery middleware keeps
+// its own copy on the legacy server.New path until that path is removed in Phase 3
+// (#5442/#5445). Keep the include/exclude rules identical across both copies.
+func filterHealthyBackends(backends []vmcp.Backend, healthStatusProvider health.StatusProvider) []vmcp.Backend {
+	if len(backends) == 0 {
+		return backends
+	}
+
+	healthy := make([]vmcp.Backend, 0, len(backends))
+	excluded := 0
+
+	for i := range backends {
+		backend := &backends[i]
+
+		// Get current health status from health monitor if available so the
+		// circuit breaker state is respected during capability aggregation.
+		var healthStatus vmcp.BackendHealthStatus
+		if healthStatusProvider != nil {
+			if status, exists := healthStatusProvider.QueryBackendStatus(backend.ID); exists {
+				healthStatus = status
+			} else {
+				// Backend not tracked by health monitor - use registry status.
+				healthStatus = backend.HealthStatus
+			}
+		} else {
+			// Health monitoring disabled - use registry status.
+			healthStatus = backend.HealthStatus
+		}
+
+		// Include healthy, degraded, and empty/zero-value (assume healthy) backends.
+		// Explicitly exclude unhealthy, unknown, and unauthenticated backends.
+		if healthStatus == "" ||
+			healthStatus == vmcp.BackendHealthy ||
+			healthStatus == vmcp.BackendDegraded {
+			healthy = append(healthy, *backend)
+		} else {
+			excluded++
+			//nolint:gosec // G706: backend fields are internal, not user-controlled
+			slog.Debug("excluding backend from capability aggregation due to health status",
+				"backend_name", backend.Name,
+				"backend_id", backend.ID,
+				"health_status", healthStatus)
+		}
+	}
+
+	if excluded > 0 {
+		//nolint:gosec // G706: values are internal counts, not user-controlled
+		slog.Debug("filtered backends for capability aggregation",
+			"total_backends", len(backends),
+			"healthy_backends", len(healthy),
+			"excluded_backends", excluded)
+	}
+
+	return healthy
+}

--- a/pkg/vmcp/core/core_vmcp.go
+++ b/pkg/vmcp/core/core_vmcp.go
@@ -281,27 +281,45 @@ func (c *coreVMCP) aggregatedView(ctx context.Context) (*aggregator.AggregatedCa
 //
 // Composite tools must be added here rather than by a Serve decorator: decorators
 // may only SUBTRACT reachability ([VMCP] contract), so the core is the only layer
-// that can advertise them. The accessibility filter and conflict check mirror the
-// legacy compositeToolsDecorator (sessionmanager/factory.go:158-180).
+// that can advertise them.
 func (c *coreVMCP) advertisedTools(agg *aggregator.AggregatedCapabilities) []vmcp.Tool {
-	if len(c.workflowDefs) == 0 {
+	defs := c.accessibleComposites(agg)
+	if len(defs) == 0 {
 		return agg.Tools
 	}
 
-	accessibleDefs := compositetools.FilterWorkflowDefsForSession(c.workflowDefs, agg.RoutingTable)
-	composite := compositetools.ConvertWorkflowDefsToTools(accessibleDefs)
-	if len(composite) == 0 {
-		return agg.Tools
-	}
-	if err := compositetools.ValidateNoToolConflicts(agg.Tools, composite); err != nil {
-		slog.Warn("composite tool name conflict detected; omitting composite tools", "error", err)
-		return agg.Tools
-	}
-
+	composite := compositetools.ConvertWorkflowDefsToTools(defs)
 	out := make([]vmcp.Tool, 0, len(agg.Tools)+len(composite))
 	out = append(out, agg.Tools...)
 	out = append(out, composite...)
 	return out
+}
+
+// accessibleComposites returns the composite-tool definitions the core advertises
+// (and therefore executes) for agg's view: those whose every tool step is reachable
+// in the routing table AND whose names do not collide with a backend tool. On a name
+// collision ALL composites are dropped so the backend tool wins, matching the legacy
+// compositeToolsDecorator (sessionmanager/factory.go:158-168, decorator.go:83-86).
+//
+// This is the single source of truth shared by advertisedTools (what ListTools shows)
+// and CallTool (what executes), so a withheld composite is never executed — advertised
+// equals executed. Returns nil when there are no composites or a conflict drops them.
+func (c *coreVMCP) accessibleComposites(
+	agg *aggregator.AggregatedCapabilities,
+) map[string]*composer.WorkflowDefinition {
+	if len(c.workflowDefs) == 0 {
+		return nil
+	}
+
+	defs := compositetools.FilterWorkflowDefsForSession(c.workflowDefs, agg.RoutingTable)
+	if len(defs) == 0 {
+		return nil
+	}
+	if err := compositetools.ValidateNoToolConflicts(agg.Tools, compositetools.ConvertWorkflowDefsToTools(defs)); err != nil {
+		slog.Warn("composite tool name conflict detected; omitting composite tools", "error", err)
+		return nil
+	}
+	return defs
 }
 
 // validateWorkflowDefs validates each workflow definition, returning only the

--- a/pkg/vmcp/core/core_vmcp.go
+++ b/pkg/vmcp/core/core_vmcp.go
@@ -96,6 +96,14 @@ func New(cfg *Config) (VMCP, error) {
 	if cfg.BackendClient == nil {
 		return nil, fmt.Errorf("%w: BackendClient is required", vmcp.ErrInvalidConfig)
 	}
+	// Fail fast on the elicitation contract: a workflow with an elicitation step run
+	// against a nil Elicitation would nil-deref deep inside the engine at call time
+	// (the legacy server.New path always wired a non-nil adapter). Reject it at
+	// construction so the misconfiguration surfaces at startup, not mid-workflow.
+	if cfg.Elicitation == nil && workflowsRequireElicitation(cfg.WorkflowDefs) {
+		return nil, fmt.Errorf(
+			"%w: Elicitation is required when a workflow contains an elicitation step", vmcp.ErrInvalidConfig)
+	}
 
 	backendClient := cfg.BackendClient
 
@@ -361,6 +369,25 @@ func validateWorkflowDefs(
 	}
 	slog.Info("loaded valid composite tool workflows", "count", len(validDefs))
 	return validDefs, nil
+}
+
+// workflowsRequireElicitation reports whether any workflow definition contains an
+// elicitation step, directly or as a forEach inner step. New uses it to enforce
+// that a non-nil Elicitation is supplied whenever a workflow could request it.
+func workflowsRequireElicitation(defs map[string]*composer.WorkflowDefinition) bool {
+	for _, def := range defs {
+		for i := range def.Steps {
+			step := &def.Steps[i]
+			if step.Type == composer.StepTypeElicitation {
+				return true
+			}
+			if step.Type == composer.StepTypeForEach && step.InnerStep != nil &&
+				step.InnerStep.Type == composer.StepTypeElicitation {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // filterHealthyBackends filters backends to only include those that are healthy

--- a/pkg/vmcp/core/core_vmcp_test.go
+++ b/pkg/vmcp/core/core_vmcp_test.go
@@ -395,7 +395,14 @@ func TestIdentityNotLogged(t *testing.T) {
 
 	const secret = "super-secret-token-value"
 
-	m.reg.EXPECT().List(gomock.Any()).Return(nil).AnyTimes()
+	// An excluded backend makes filterHealthyBackends emit a DEBUG log on every
+	// aggregatedView, guaranteeing the buffer is non-empty so the assertion below
+	// is not vacuous (it would otherwise pass if every path short-circuited).
+	cfg.HealthStatusProvider = fakeStatusProvider{"bad": vmcp.BackendUnhealthy}
+	m.reg.EXPECT().List(gomock.Any()).Return([]vmcp.Backend{
+		{ID: "ok", HealthStatus: vmcp.BackendHealthy},
+		{ID: "bad", HealthStatus: vmcp.BackendHealthy},
+	}).AnyTimes()
 	m.agg.EXPECT().AggregateCapabilities(gomock.Any(), gomock.Any()).Return(&aggregator.AggregatedCapabilities{
 		RoutingTable: &vmcp.RoutingTable{},
 	}, nil).AnyTimes()
@@ -409,9 +416,22 @@ func TestIdentityNotLogged(t *testing.T) {
 	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
 	t.Cleanup(func() { slog.SetDefault(prev) })
 
-	identity := &auth.Identity{Token: secret, UpstreamTokens: map[string]string{"github": secret}}
-	_, _ = c.ListTools(context.Background(), identity)
-	_, _ = c.CallTool(context.Background(), identity, "missing", nil, nil)
+	id := &auth.Identity{Token: secret, UpstreamTokens: map[string]string{"github": secret}}
+	ctx := context.Background()
 
-	assert.NotContains(t, buf.String(), secret, "identity token must never be logged")
+	// Drive every identity-taking method; return values are irrelevant — we only
+	// inspect the captured logs.
+	_, _ = c.ListTools(ctx, id)
+	_, _ = c.ListResources(ctx, id)
+	_, _ = c.ListPrompts(ctx, id)
+	_, _ = c.LookupTool(ctx, id, "missing")
+	_, _ = c.LookupResource(ctx, id, "missing")
+	_, _ = c.LookupPrompt(ctx, id, "missing")
+	_, _ = c.CallTool(ctx, id, "missing", nil, nil)
+	_, _ = c.ReadResource(ctx, id, "missing")
+	_, _ = c.GetPrompt(ctx, id, "missing", nil)
+
+	logs := buf.String()
+	require.NotEmpty(t, logs, "expected the driven methods to emit logs, else the assertion is vacuous")
+	assert.NotContains(t, logs, secret, "identity token must never be logged")
 }

--- a/pkg/vmcp/core/core_vmcp_test.go
+++ b/pkg/vmcp/core/core_vmcp_test.go
@@ -155,6 +155,57 @@ func TestNew_ValidatesWorkflows(t *testing.T) {
 	}
 }
 
+func TestNew_ElicitationRequiredWhenWorkflowElicits(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		steps   []composer.WorkflowStep
+		wantErr bool
+	}{
+		{
+			name:    "elicitation step requires a requester",
+			steps:   []composer.WorkflowStep{{ID: "s1", Type: composer.StepTypeElicitation}},
+			wantErr: true,
+		},
+		{
+			name: "forEach inner elicitation step requires a requester",
+			steps: []composer.WorkflowStep{{
+				ID:        "s1",
+				Type:      composer.StepTypeForEach,
+				InnerStep: &composer.WorkflowStep{ID: "inner", Type: composer.StepTypeElicitation},
+			}},
+			wantErr: true,
+		},
+		{
+			name:    "tool-only workflow needs no requester",
+			steps:   []composer.WorkflowStep{{ID: "s1", Type: composer.StepTypeTool, Tool: "be1.tool"}},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cfg, _ := baseConfig(t)
+			cfg.Elicitation = nil // explicit: no requester wired
+			cfg.WorkflowDefs = map[string]*composer.WorkflowDefinition{
+				"wf": {Name: "wf", Steps: tt.steps},
+			}
+
+			c, err := New(cfg)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, vmcp.ErrInvalidConfig)
+				assert.Nil(t, c)
+				return
+			}
+			require.NoError(t, err)
+			require.NoError(t, c.Close())
+		})
+	}
+}
+
 func TestListTools_AggregatesOnDemand(t *testing.T) {
 	t.Parallel()
 	cfg, m := baseConfig(t)

--- a/pkg/vmcp/core/core_vmcp_test.go
+++ b/pkg/vmcp/core/core_vmcp_test.go
@@ -1,0 +1,417 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package core
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/stacklok/toolhive/pkg/auth"
+	"github.com/stacklok/toolhive/pkg/vmcp"
+	"github.com/stacklok/toolhive/pkg/vmcp/aggregator"
+	aggmocks "github.com/stacklok/toolhive/pkg/vmcp/aggregator/mocks"
+	"github.com/stacklok/toolhive/pkg/vmcp/composer"
+	vmcpmocks "github.com/stacklok/toolhive/pkg/vmcp/mocks"
+	routermocks "github.com/stacklok/toolhive/pkg/vmcp/router/mocks"
+)
+
+// fakeStatusProvider is a map-backed health.StatusProvider for tests. A missing
+// key reports (zero, false), mirroring a backend untracked by the health monitor.
+type fakeStatusProvider map[string]vmcp.BackendHealthStatus
+
+func (f fakeStatusProvider) QueryBackendStatus(id string) (vmcp.BackendHealthStatus, bool) {
+	s, ok := f[id]
+	return s, ok
+}
+
+// coreMocks bundles the gomock collaborators wired into a test Config.
+type coreMocks struct {
+	agg    *aggmocks.MockAggregator
+	reg    *vmcpmocks.MockBackendRegistry
+	client *vmcpmocks.MockBackendClient
+	router *routermocks.MockRouter
+}
+
+// baseConfig returns a Config with the four required collaborators mocked.
+func baseConfig(t *testing.T) (*Config, *coreMocks) {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	m := &coreMocks{
+		agg:    aggmocks.NewMockAggregator(ctrl),
+		reg:    vmcpmocks.NewMockBackendRegistry(ctrl),
+		client: vmcpmocks.NewMockBackendClient(ctrl),
+		router: routermocks.NewMockRouter(ctrl),
+	}
+	cfg := &Config{
+		Aggregator:      m.agg,
+		Router:          m.router,
+		BackendRegistry: m.reg,
+		BackendClient:   m.client,
+	}
+	return cfg, m
+}
+
+// testBackendID is the single backend ID used across these tests.
+const testBackendID = "be1"
+
+func backendTool(name string) vmcp.Tool {
+	return vmcp.Tool{Name: name, BackendID: testBackendID}
+}
+
+func backendTarget() *vmcp.BackendTarget {
+	return &vmcp.BackendTarget{WorkloadID: testBackendID, BaseURL: "http://" + testBackendID + ":8080"}
+}
+
+func TestNew_RequiredCollaborators(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		mutate  func(*Config)
+		wantErr bool
+	}{
+		{"valid", func(*Config) {}, false},
+		{"nil aggregator", func(c *Config) { c.Aggregator = nil }, true},
+		{"nil router", func(c *Config) { c.Router = nil }, true},
+		{"nil backend registry", func(c *Config) { c.BackendRegistry = nil }, true},
+		{"nil backend client", func(c *Config) { c.BackendClient = nil }, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cfg, _ := baseConfig(t)
+			tt.mutate(cfg)
+
+			c, err := New(cfg)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, vmcp.ErrInvalidConfig)
+				assert.Nil(t, c)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, c)
+			require.NoError(t, c.Close())
+		})
+	}
+}
+
+func TestNew_NilConfig(t *testing.T) {
+	t.Parallel()
+	c, err := New(nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, vmcp.ErrInvalidConfig)
+	assert.Nil(t, c)
+}
+
+func TestNew_ValidatesWorkflows(t *testing.T) {
+	t.Parallel()
+
+	valid := &composer.WorkflowDefinition{
+		Name:  "wf",
+		Steps: []composer.WorkflowStep{{ID: "s1", Type: composer.StepTypeTool, Tool: "be1.tool"}},
+	}
+	circular := &composer.WorkflowDefinition{
+		Name: "wf",
+		Steps: []composer.WorkflowStep{
+			{ID: "s1", Type: composer.StepTypeTool, Tool: "be1.tool", DependsOn: []string{"s2"}},
+			{ID: "s2", Type: composer.StepTypeTool, Tool: "be1.tool", DependsOn: []string{"s1"}},
+		},
+	}
+
+	tests := []struct {
+		name    string
+		defs    map[string]*composer.WorkflowDefinition
+		wantErr bool
+	}{
+		{"valid workflow", map[string]*composer.WorkflowDefinition{"wf": valid}, false},
+		{"invalid workflow fails fast", map[string]*composer.WorkflowDefinition{"wf": circular}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cfg, _ := baseConfig(t)
+			cfg.WorkflowDefs = tt.defs
+
+			c, err := New(cfg)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Nil(t, c)
+				return
+			}
+			require.NoError(t, err)
+			require.NoError(t, c.Close())
+		})
+	}
+}
+
+func TestListTools_AggregatesOnDemand(t *testing.T) {
+	t.Parallel()
+	cfg, m := baseConfig(t)
+
+	backends := []vmcp.Backend{{ID: "be1", HealthStatus: vmcp.BackendHealthy}}
+	m.reg.EXPECT().List(gomock.Any()).Return(backends)
+	m.agg.EXPECT().AggregateCapabilities(gomock.Any(), backends).Return(&aggregator.AggregatedCapabilities{
+		Tools:        []vmcp.Tool{backendTool("tool_a"), backendTool("tool_b")},
+		RoutingTable: &vmcp.RoutingTable{},
+	}, nil)
+
+	c, err := New(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = c.Close() })
+
+	tools, err := c.ListTools(context.Background(), nil)
+	require.NoError(t, err)
+	require.Len(t, tools, 2)
+	assert.Equal(t, "be1", tools[0].BackendID)
+}
+
+func TestListTools_AdvertisesAccessibleCompositeTools(t *testing.T) {
+	t.Parallel()
+	cfg, m := baseConfig(t)
+	cfg.WorkflowDefs = map[string]*composer.WorkflowDefinition{
+		"wf": {Name: "wf", Steps: []composer.WorkflowStep{{ID: "s1", Type: composer.StepTypeTool, Tool: "be1.tool_a"}}},
+	}
+
+	rt := &vmcp.RoutingTable{Tools: map[string]*vmcp.BackendTarget{"be1.tool_a": backendTarget()}}
+	m.reg.EXPECT().List(gomock.Any()).Return([]vmcp.Backend{{ID: "be1"}})
+	m.agg.EXPECT().AggregateCapabilities(gomock.Any(), gomock.Any()).Return(&aggregator.AggregatedCapabilities{
+		Tools:        []vmcp.Tool{backendTool("be1.tool_a")},
+		RoutingTable: rt,
+	}, nil)
+
+	c, err := New(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = c.Close() })
+
+	tools, err := c.ListTools(context.Background(), nil)
+	require.NoError(t, err)
+
+	names := make([]string, 0, len(tools))
+	for _, tl := range tools {
+		names = append(names, tl.Name)
+	}
+	assert.Contains(t, names, "be1.tool_a")
+	assert.Contains(t, names, "wf", "accessible composite tool should be advertised")
+}
+
+func TestListResourcesAndPrompts(t *testing.T) {
+	t.Parallel()
+	cfg, m := baseConfig(t)
+
+	m.reg.EXPECT().List(gomock.Any()).Return(nil).Times(2)
+	m.agg.EXPECT().AggregateCapabilities(gomock.Any(), gomock.Any()).Return(&aggregator.AggregatedCapabilities{
+		Resources: []vmcp.Resource{{URI: "file://a", BackendID: "be1"}},
+		Prompts:   []vmcp.Prompt{{Name: "p1", BackendID: "be1"}},
+	}, nil).Times(2)
+
+	c, err := New(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = c.Close() })
+
+	resources, err := c.ListResources(context.Background(), nil)
+	require.NoError(t, err)
+	require.Len(t, resources, 1)
+	assert.Equal(t, "file://a", resources[0].URI)
+
+	prompts, err := c.ListPrompts(context.Background(), nil)
+	require.NoError(t, err)
+	require.Len(t, prompts, 1)
+	assert.Equal(t, "p1", prompts[0].Name)
+}
+
+func TestListTools_AggregationError(t *testing.T) {
+	t.Parallel()
+	cfg, m := baseConfig(t)
+
+	m.reg.EXPECT().List(gomock.Any()).Return(nil)
+	m.agg.EXPECT().AggregateCapabilities(gomock.Any(), gomock.Any()).Return(nil, errors.New("boom"))
+
+	c, err := New(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = c.Close() })
+
+	_, err = c.ListTools(context.Background(), nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "aggregation failed")
+}
+
+func TestListTools_HealthFiltersBeforeAggregating(t *testing.T) {
+	t.Parallel()
+	cfg, m := baseConfig(t)
+
+	backends := []vmcp.Backend{
+		{ID: "healthy", HealthStatus: vmcp.BackendHealthy},
+		{ID: "degraded", HealthStatus: vmcp.BackendDegraded},
+		{ID: "unhealthy", HealthStatus: vmcp.BackendHealthy}, // overridden by provider below
+		{ID: "unknown", HealthStatus: vmcp.BackendHealthy},   // overridden by provider below
+	}
+	cfg.HealthStatusProvider = fakeStatusProvider{
+		"unhealthy": vmcp.BackendUnhealthy,
+		"unknown":   vmcp.BackendUnknown,
+	}
+
+	m.reg.EXPECT().List(gomock.Any()).Return(backends)
+	var got []vmcp.Backend
+	m.agg.EXPECT().AggregateCapabilities(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, b []vmcp.Backend) (*aggregator.AggregatedCapabilities, error) {
+			got = b
+			return &aggregator.AggregatedCapabilities{}, nil
+		})
+
+	c, err := New(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = c.Close() })
+
+	_, err = c.ListTools(context.Background(), nil)
+	require.NoError(t, err)
+
+	gotIDs := make([]string, 0, len(got))
+	for _, b := range got {
+		gotIDs = append(gotIDs, b.ID)
+	}
+	assert.ElementsMatch(t, []string{"healthy", "degraded"}, gotIDs,
+		"only healthy/degraded backends should reach the aggregator")
+}
+
+func TestFilterHealthyBackends(t *testing.T) {
+	t.Parallel()
+
+	backends := []vmcp.Backend{
+		{ID: "healthy", HealthStatus: vmcp.BackendHealthy},
+		{ID: "degraded", HealthStatus: vmcp.BackendDegraded},
+		{ID: "empty", HealthStatus: ""},
+		{ID: "unhealthy", HealthStatus: vmcp.BackendUnhealthy},
+		{ID: "unknown", HealthStatus: vmcp.BackendUnknown},
+		{ID: "unauthenticated", HealthStatus: vmcp.BackendUnauthenticated},
+	}
+
+	tests := []struct {
+		name     string
+		provider fakeStatusProvider
+		wantIDs  []string
+	}{
+		{
+			name:    "nil provider uses registry status",
+			wantIDs: []string{"healthy", "degraded", "empty"},
+		},
+		{
+			name:     "provider overrides registry status",
+			provider: fakeStatusProvider{"healthy": vmcp.BackendUnhealthy, "unhealthy": vmcp.BackendHealthy},
+			// "healthy" demoted, "unhealthy" promoted; untracked backends fall back to registry.
+			wantIDs: []string{"degraded", "empty", "unhealthy"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var provider interface {
+				QueryBackendStatus(string) (vmcp.BackendHealthStatus, bool)
+			}
+			if tt.provider != nil {
+				provider = tt.provider
+			}
+			got := filterHealthyBackends(backends, provider)
+			ids := make([]string, 0, len(got))
+			for _, b := range got {
+				ids = append(ids, b.ID)
+			}
+			assert.ElementsMatch(t, tt.wantIDs, ids)
+		})
+	}
+}
+
+func TestFilterHealthyBackends_Empty(t *testing.T) {
+	t.Parallel()
+	assert.Empty(t, filterHealthyBackends(nil, nil))
+}
+
+func TestLookup(t *testing.T) {
+	t.Parallel()
+	cfg, m := baseConfig(t)
+
+	m.reg.EXPECT().List(gomock.Any()).Return(nil).Times(6)
+	m.agg.EXPECT().AggregateCapabilities(gomock.Any(), gomock.Any()).Return(&aggregator.AggregatedCapabilities{
+		Tools:     []vmcp.Tool{backendTool("tool_a")},
+		Resources: []vmcp.Resource{{URI: "file://a", BackendID: "be1"}},
+		Prompts:   []vmcp.Prompt{{Name: "p1", BackendID: "be1"}},
+	}, nil).Times(6)
+
+	c, err := New(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = c.Close() })
+	ctx := context.Background()
+
+	tool, err := c.LookupTool(ctx, nil, "tool_a")
+	require.NoError(t, err)
+	assert.Equal(t, "be1", tool.BackendID)
+	_, err = c.LookupTool(ctx, nil, "missing")
+	assert.ErrorIs(t, err, vmcp.ErrNotFound)
+
+	res, err := c.LookupResource(ctx, nil, "file://a")
+	require.NoError(t, err)
+	assert.Equal(t, "be1", res.BackendID)
+	_, err = c.LookupResource(ctx, nil, "file://missing")
+	assert.ErrorIs(t, err, vmcp.ErrNotFound)
+
+	prompt, err := c.LookupPrompt(ctx, nil, "p1")
+	require.NoError(t, err)
+	assert.Equal(t, "be1", prompt.BackendID)
+	_, err = c.LookupPrompt(ctx, nil, "missing")
+	assert.ErrorIs(t, err, vmcp.ErrNotFound)
+}
+
+func TestClose_Idempotent(t *testing.T) {
+	t.Parallel()
+	cfg, _ := baseConfig(t)
+
+	c, err := New(cfg)
+	require.NoError(t, err)
+
+	require.NoError(t, c.Close())
+	assert.NotPanics(t, func() {
+		require.NoError(t, c.Close())
+		require.NoError(t, c.Close())
+	})
+}
+
+// Must run serially: it swaps the global slog default to capture output into a
+// non-thread-safe buffer, which is unsafe if other tests log concurrently.
+//
+//nolint:paralleltest // installs a global slog default + non-thread-safe buffer; must not run in parallel
+func TestIdentityNotLogged(t *testing.T) {
+	cfg, m := baseConfig(t)
+
+	const secret = "super-secret-token-value"
+
+	m.reg.EXPECT().List(gomock.Any()).Return(nil).AnyTimes()
+	m.agg.EXPECT().AggregateCapabilities(gomock.Any(), gomock.Any()).Return(&aggregator.AggregatedCapabilities{
+		RoutingTable: &vmcp.RoutingTable{},
+	}, nil).AnyTimes()
+
+	c, err := New(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = c.Close() })
+
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	identity := &auth.Identity{Token: secret, UpstreamTokens: map[string]string{"github": secret}}
+	_, _ = c.ListTools(context.Background(), identity)
+	_, _ = c.CallTool(context.Background(), identity, "missing", nil, nil)
+
+	assert.NotContains(t, buf.String(), secret, "identity token must never be logged")
+}

--- a/pkg/vmcp/internal/backendtelemetry/backendtelemetry.go
+++ b/pkg/vmcp/internal/backendtelemetry/backendtelemetry.go
@@ -1,7 +1,14 @@
 // SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-package server
+// Package backendtelemetry decorates a [vmcp.BackendClient] so each backend MCP
+// call records OpenTelemetry traces and metrics.
+//
+// It lives in pkg/vmcp/internal so that both the transport server (server.New)
+// and the core constructor (core.New) can share a single decorator without an
+// import cycle: server and core both depend on this leaf package, and it depends
+// on neither.
+package backendtelemetry
 
 import (
 	"context"
@@ -23,9 +30,9 @@ const (
 	instrumentationName = "github.com/stacklok/toolhive/pkg/vmcp"
 )
 
-// monitorBackends decorates the backend client so it records telemetry on each method call.
+// MonitorBackends decorates the backend client so it records telemetry on each method call.
 // It also emits a gauge for the number of backends discovered once, since the number of backends is static.
-func monitorBackends(
+func MonitorBackends(
 	ctx context.Context,
 	meterProvider metric.MeterProvider,
 	tracerProvider trace.TracerProvider,

--- a/pkg/vmcp/internal/backendtelemetry/backendtelemetry_test.go
+++ b/pkg/vmcp/internal/backendtelemetry/backendtelemetry_test.go
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-package server
+package backendtelemetry
 
 import (
 	"testing"

--- a/pkg/vmcp/server/server.go
+++ b/pkg/vmcp/server/server.go
@@ -38,6 +38,7 @@ import (
 	vmcpconfig "github.com/stacklok/toolhive/pkg/vmcp/config"
 	"github.com/stacklok/toolhive/pkg/vmcp/discovery"
 	"github.com/stacklok/toolhive/pkg/vmcp/health"
+	"github.com/stacklok/toolhive/pkg/vmcp/internal/backendtelemetry"
 	"github.com/stacklok/toolhive/pkg/vmcp/optimizer"
 	"github.com/stacklok/toolhive/pkg/vmcp/router"
 	"github.com/stacklok/toolhive/pkg/vmcp/server/adapter"
@@ -354,7 +355,7 @@ func New(
 		var err error
 		// Get initial backends list from registry for telemetry setup
 		initialBackends := backendRegistry.List(ctx)
-		backendClient, err = monitorBackends(
+		backendClient, err = backendtelemetry.MonitorBackends(
 			ctx,
 			cfg.TelemetryProvider.MeterProvider(),
 			cfg.TelemetryProvider.TracerProvider(),

--- a/pkg/vmcp/server/telemetry_integration_test.go
+++ b/pkg/vmcp/server/telemetry_integration_test.go
@@ -388,7 +388,7 @@ func TestIntegration_TelemetryMiddleware(t *testing.T) {
 		assert.Contains(t, metrics, "toolhive_mcp_request_duration",
 			"Should record request duration histogram")
 
-		// --- Backend metrics (from monitorBackends in vmcp/server/telemetry.go) ---
+		// --- Backend metrics (from backendtelemetry.MonitorBackends) ---
 
 		// Backend request counter — recorded when the tool call was routed to the backend
 		assert.Contains(t, metrics, "toolhive_vmcp_backend_requests",


### PR DESCRIPTION
## Summary

RFC Phase 1 of the vMCP refactor (epic #5419, story #5430) extracts a stateless, identity-explicit domain core out of the `server.New` god-object. This turns the `VMCP` contract from #5434 into a working core that aggregates backend capabilities, routes calls, and drives composite-tool workflows — without mcp-go types crossing the boundary and without changing `server.New`'s signature or observable behavior.

- **Why**: The domain wiring (telemetry decoration, workflow engine, composer factory, health filtering, workflow validation) is currently buried in `server.New`'s body, coupling the domain logic to the transport god-object and to context-injected capabilities. Phase 1 relocates that wiring behind a clean, identity-parameterized contract so later phases can re-home the transport (`Serve`, #5439) and wire the Cedar admission seam (#5438) without untangling it again.
- **What**:
  - New `pkg/vmcp/core` implements `*coreVMCP` and `New(cfg *Config) (VMCP, error)` with all 10 interface methods, relocating (not rewriting) the domain wiring from `server.New`: telemetry backend-client decoration, the optional workflow auditor, the in-memory state store + workflow engine, the per-call composer factory, and fail-fast workflow validation.
  - The core is stateless with respect to sessions: `List`/`Lookup`/`Call` health-filter the registry and aggregate on demand, then route through a per-call `router.NewSessionRouter` bound to the freshly aggregated routing table. This removes composite tools' dependency on context-injected capabilities (vmcp anti-pattern #1). The core filters; `Serve` caches (a later decorator).
  - An injected `health.StatusProvider` drives `filterHealthyBackends` before aggregation, preserving today's exact include/exclude rules (healthy/degraded/empty included; unhealthy/unknown/unauthenticated excluded). A nil provider means no filtering (all backends included), matching today's no-monitor behavior.
  - Composite tools are advertised in `ListTools` (the core is the only layer that can add them, since decorators may only subtract reachability) and executed in `CallTool` through the relocated per-session composer pattern.
  - `Close()` stops the state-store cleanup goroutine and is idempotent (`sync.Once`).
  - The backend-client telemetry decorator moved from `pkg/vmcp/server/telemetry.go` to a new shared leaf package `pkg/vmcp/internal/backendtelemetry` (exported as `MonitorBackends`) so both `server` and `core` can use it without an import cycle.
  - Identity is an explicit `*auth.Identity` on every method, never read from context and never logged. The Cedar admission seam (#5438) is intentionally not wired here.

Closes #5437

## Type of change

- [x] Refactoring (no behavior change)

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)

Unit tests for `pkg/vmcp/core` cover: constructor validation (loud failure on nil required collaborators), on-demand aggregation, health-filtering parity with `discovery/middleware.go`, lookups (including renamed/prefixed capability names and unknown-name errors), copy-before-mutate of `args`/`meta`, composite-tool execution across all `executeComposite` branches, idempotent `Close`, and verification that identity is never logged. Existing `pkg/vmcp/server` and the relocated `pkg/vmcp/internal/backendtelemetry` tests pass unchanged. `golangci-lint` reports 0 issues for the changed packages.

## Changes

| File | Change |
|------|--------|
| `pkg/vmcp/core/core_vmcp.go` | New: `*coreVMCP`, `New` constructor, list/lookup paths, health filtering, workflow validation, idempotent `Close`. |
| `pkg/vmcp/core/core_calls.go` | New: `CallTool`/`ReadResource`/`GetPrompt` call paths and composite-tool execution. |
| `pkg/vmcp/core/core.go` | Wire `New` to the previously contract-only `Config`. |
| `pkg/vmcp/elicitation.go` | New: domain-typed `ElicitationRequester` seam (no mcp-go types). |
| `pkg/vmcp/internal/backendtelemetry/` | Relocated backend-client telemetry decorator from `server/telemetry.go`; exported as `MonitorBackends`. |
| `pkg/vmcp/server/server.go` | Call the relocated `backendtelemetry.MonitorBackends`; signature and behavior unchanged. |
| `pkg/vmcp/composer/`, `pkg/vmcp/server/sdk_elicitation_adapter*.go` | Consume the domain-typed `ElicitationRequester`; SDK translation stays confined to the adapter. |

## Does this introduce a user-facing change?

No. The core is additive and not yet wired into the request path; `server.New`'s signature and observable behavior are unchanged.

## Special notes for reviewers

- **Approved scope exception (exceeds the 400-LOC criterion).** This PR intentionally implements both pre-planned sub-tasks (TASK-104a list/lookup/constructor + TASK-104b call/read/get) in one change, totaling roughly 580 net-new production LOC across 4 production files — over the 400-LOC acceptance criterion but within the 10-file limit. This was an explicit, up-front decision; the alternative was a 104a PR plus a 104b follow-up.
- **Intentional temporary duplication (C2).** `filterHealthyBackends` is a deliberate copy of `discovery/middleware.go`'s implementation. The discovery middleware keeps its own copy on the legacy `server.New` path until that path is removed in Phase 3 (#5442/#5445). The include/exclude rules are kept identical across both copies — this is not accidental duplication.
- **Pre-existing, unrelated findings observed during verification (not introduced by this PR):**
  - The only repo-wide `task lint-fix` finding is a pre-existing gosec G115 in `cmd/thv/app/upgrade.go` (the `.golangci.yml` gosec exclude list omits G115).
  - The only `task test` failures are `pkg/mcp/server/TestBuildServerConfig`, which require a container runtime (Docker/Podman) not present locally.

## Large PR Justification

This PR is large for three reasons, none of which are net-new production logic:

  - **Atomic full-scope implementation (multiple related changes that would break if separated).**
    Issue #5437 pre-planned a split into TASK-104a (constructor + wiring + list/lookup +
    `Close`) and TASK-104b (the call/read/get paths + composite execution). Per an explicit
    up-front decision, both land here as one change. Splitting them would leave `*coreVMCP`
    not satisfying the `VMCP` interface between PRs (the interface requires all ten methods),
    so the halves are not independently mergeable as working code. Actual net-new production
    logic is ~580 LOC across 4 files (`core_vmcp.go`, `core_calls.go`, `core.go`, `server.go`).

  - **A file move inflates the diff (refactor that must be atomic).**
    The backend-client telemetry decorator was relocated from `pkg/vmcp/server/telemetry.go`
    to a shared `pkg/vmcp/internal/backendtelemetry/` package so both `server` and `core` can
    use it without an import cycle. Git counts this as ~500 added + deleted lines, but it is a
    near-verbatim move (≈94% similarity) with net-zero behavior change — `server.New`'s
    signature and observable behavior are unchanged.

  - **Comprehensive unit tests (test-only, low review risk).**
    The remaining bulk is table-driven tests for the new core package (constructor validation,
    on-demand aggregation, health-filtering parity, lookups, copy-before-mutate, composite
    execution, advertise-vs-execute conflict parity, idempotent `Close`, identity-not-logged)
    plus the relocated telemetry tests.

  Splitting further would either ship non-compiling intermediate states or separate tests from
  the code they cover, both of which reduce reviewability rather than improve it.