### PR TITLE
fix(api): add X-Content-Type-Options and Cross-Origin-Resource-Policy headers

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -378,6 +378,8 @@ func headersMiddleware(next http.Handler) http.Handler {
 		if strings.HasPrefix(r.URL.Path, "/api/") {
 			w.Header().Set("Content-Type", "application/json")
 		}
+		w.Header().Set("X-Content-Type-Options", "nosniff")
+		w.Header().Set("Cross-Origin-Resource-Policy", "same-origin")
 		next.ServeHTTP(w, r)
 	})
 }

--- a/pkg/api/server_test.go
+++ b/pkg/api/server_test.go
@@ -4,9 +4,11 @@
 package api
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"regexp"
 	"testing"
 
@@ -95,6 +97,21 @@ func TestListenURL(t *testing.T) {
 // downstream repositories that this module's analyzer cannot see. Without
 // this test, a future deadcode pass would flag them as unreachable (as
 // happened in #5355) even though external callers depend on them.
+func TestSecurityHeaders(t *testing.T) {
+	t.Parallel()
+
+	b := NewServerBuilder()
+	router, err := b.Build(context.Background())
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	assert.Equal(t, "nosniff", rec.Header().Get("X-Content-Type-Options"))
+	assert.Equal(t, "same-origin", rec.Header().Get("Cross-Origin-Resource-Policy"))
+}
+
 func TestServerBuilderExtensionPoints(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What

Adds two baseline security headers to every HTTP response via the existing `headersMiddleware` in `BuildRouter`:

- `X-Content-Type-Options: nosniff` — prevents browsers from MIME-sniffing response content types
- `Cross-Origin-Resource-Policy: same-origin` — guards against Spectre-style cross-origin resource inclusion

## Why

Both headers were surfaced by DAST scanning (ZAP) as Low-severity findings on the thv REST API. They are standard baseline security headers with no downside for an API server.

## How

Added to the existing `headersMiddleware` function which already handles per-response header logic. This keeps all header-setting co-located rather than adding a new `r.Use()` call.