### PR TITLE
Wire Cedar admission seam into vMCP core

### DIFF
--- a/pkg/vmcp/core/admission.go
+++ b/pkg/vmcp/core/admission.go
@@ -53,11 +53,27 @@ type Admission interface {
 // HTTP middleware uses (authorizers.GetFactory + CreateAuthorizer, the
 // construction inside newCedarAuthzMiddleware). The Cedar factory is registered by
 // pkg/authz's blank import, which the core package already pulls in.
+//
+// authzCfg is an already-built, authorizer-agnostic config: the cedar-specific
+// normalization the live path performs at construction time (e.g. defaulting an
+// empty EntitiesJSON to "[]", incoming.go:128) belongs to whoever builds
+// authzCfg, not to this generic factory path, which consumes RawConfig as-is.
 func newAdmission(
 	authzCfg *authorizers.Config, serverName string, passThroughTools map[string]struct{},
 ) (Admission, error) {
 	if authzCfg == nil {
 		return allowAllAdmission{}, nil
+	}
+
+	// Fail loudly on an empty server name, mirroring the live factory
+	// (incoming.go:120). Cedar attaches the MCP::"<serverName>" parent UID to
+	// resource entities only when serverName is non-empty
+	// (cedar/entity.go:170-174), so an empty name silently changes resource-scoped
+	// policy semantics rather than erroring (go-style: fail loudly on invalid input).
+	if serverName == "" {
+		return nil, fmt.Errorf(
+			"%w: ServerName must not be empty when Authz is set (Cedar resource-scoped policies require it)",
+			vmcp.ErrInvalidConfig)
 	}
 
 	factory := authorizers.GetFactory(string(authzCfg.Type))
@@ -122,8 +138,16 @@ func (a *cedarAdmission) FilterTools(
 }
 
 // AllowToolCall mirrors pkg/authz authorizeToolCall (tool_filter.go:64). Pass-through
-// meta-tools are exempt: their inner backend tool is authorized by the optimizer
-// decorator, matching their exemption through the HTTP middleware today.
+// meta-tools are exempt from the seam's decision, matching how they bypass the HTTP
+// authz path's tool checks today (#5438 AC: "passThroughTools remain exempt").
+//
+// call_tool parity note: the HTTP middleware's handleToolsCall (middleware.go:276)
+// additionally RE-TARGETS authorization at the inner backend tool wrapped inside a
+// call_tool request (reading args["tool_name"]). This seam deliberately does NOT
+// replicate that inner-tool authorization — it only exempts the meta-tool name, per
+// this task's scope. Ensuring the unwrapped inner call is authorized is a call-path
+// wiring requirement for #5441 (which removes the HTTP middleware): that wiring must
+// route the inner call through a path that consults this seam with the real tool name.
 func (a *cedarAdmission) AllowToolCall(
 	ctx context.Context, identity *auth.Identity, tool *vmcp.Tool, args map[string]any,
 ) (bool, error) {
@@ -240,11 +264,16 @@ func (allowAllAdmission) AllowPromptGet(_ context.Context, _ *auth.Identity, _ *
 
 // convertAnnotations maps vmcp.ToolAnnotations to authorizers.ToolAnnotations,
 // returning nil when no hint field is set so the adapter only writes annotation
-// ctx when a hint exists (matching the existing hasAnyHint gate). It mirrors
-// server.convertAnnotations (annotation_enrichment.go:92): an intentional,
-// temporary duplication — the server-side middleware copy is retired on the
-// domain path in #5441. Only authorization-relevant hints are mapped;
-// informational fields like Title are not used in policy evaluation.
+// ctx when a hint exists (matching the existing hasAnyHint gate). Only
+// authorization-relevant hints are mapped; informational fields like Title are not
+// used in policy evaluation.
+//
+// This duplicates server.convertAnnotations (annotation_enrichment.go:92) rather
+// than reusing it: that copy lives in package server, which imports this core
+// package, so importing it here would create a cycle (server -> core). Like the
+// filterHealthyBackends C2 duplication in this package, it is intentional and
+// temporary — #5441 retires the server-side middleware (and its copy) on the domain
+// path. Keep the two in sync until then.
 func convertAnnotations(ann *vmcp.ToolAnnotations) *authorizers.ToolAnnotations {
 	if ann == nil {
 		return nil

--- a/pkg/vmcp/core/admission.go
+++ b/pkg/vmcp/core/admission.go
@@ -1,0 +1,276 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package core
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/stacklok/toolhive/pkg/auth"
+	"github.com/stacklok/toolhive/pkg/authz/authorizers"
+	"github.com/stacklok/toolhive/pkg/vmcp"
+)
+
+// Admission decides whether an identity may see or use a capability. It wraps the
+// existing [authorizers.Authorizer] (Cedar in the vMCP path); it does NOT define a
+// new policy model.
+//
+// The seam re-platforms the authorization decision that runs as HTTP middleware
+// today (AuthzMiddleware + AnnotationEnrichmentMiddleware) into the core, so that
+// List* (filter) and Call/Read/Get (deny) enforce the SAME decision from one
+// source — closing the "list says yes / call says no" gap. Identity is an explicit
+// parameter (never read from ctx, vmcp anti-pattern #1); the adapter re-injects it
+// into the ctx the wrapped authorizer reads. A seam can only SUBTRACT reachability
+// (filter list output / refuse a call), never widen it ([VMCP] contract).
+type Admission interface {
+	// FilterTools returns the subset of tools the identity may call. Mirrors
+	// pkg/authz filterToolsByPolicy: a per-tool AuthorizeWithJWTClaims(call) using
+	// the tool's annotations; a per-tool authorizer error skips that tool
+	// (log-and-continue), it is not a hard failure.
+	FilterTools(ctx context.Context, identity *auth.Identity, tools []vmcp.Tool) ([]vmcp.Tool, error)
+	// AllowToolCall mirrors pkg/authz authorizeToolCall (MCPFeatureTool/Call),
+	// sourcing the tool's annotations for when-clause evaluation.
+	AllowToolCall(ctx context.Context, identity *auth.Identity, tool *vmcp.Tool, args map[string]any) (bool, error)
+	// FilterResources / AllowResourceRead use MCPFeatureResource/Read.
+	FilterResources(ctx context.Context, identity *auth.Identity, resources []vmcp.Resource) ([]vmcp.Resource, error)
+	AllowResourceRead(ctx context.Context, identity *auth.Identity, resource *vmcp.Resource) (bool, error)
+	// FilterPrompts / AllowPromptGet use MCPFeaturePrompt/Get.
+	FilterPrompts(ctx context.Context, identity *auth.Identity, prompts []vmcp.Prompt) ([]vmcp.Prompt, error)
+	AllowPromptGet(ctx context.Context, identity *auth.Identity, prompt *vmcp.Prompt) (bool, error)
+}
+
+// newAdmission builds the admission seam New wires into the core.
+//
+// A nil authzCfg means authorization is unconfigured and the seam is allow-all,
+// preserving today's `cfg.AuthzMiddleware != nil` guard (server.go:606): the
+// composition root only populates Authz when Cedar policies exist (mirroring
+// newCedarAuthzMiddleware's `len(Policies) > 0` check), so "no policies" reaches
+// the core as a nil Authz, not an empty authorizer.
+//
+// When authzCfg is set, the authorizer is built via the same registry path the
+// HTTP middleware uses (authorizers.GetFactory + CreateAuthorizer, the
+// construction inside newCedarAuthzMiddleware). The Cedar factory is registered by
+// pkg/authz's blank import, which the core package already pulls in.
+func newAdmission(
+	authzCfg *authorizers.Config, serverName string, passThroughTools map[string]struct{},
+) (Admission, error) {
+	if authzCfg == nil {
+		return allowAllAdmission{}, nil
+	}
+
+	factory := authorizers.GetFactory(string(authzCfg.Type))
+	if factory == nil {
+		return nil, fmt.Errorf("%w: unsupported authz type %q", vmcp.ErrInvalidConfig, authzCfg.Type)
+	}
+	authorizer, err := factory.CreateAuthorizer(authzCfg.RawConfig(), serverName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build admission authorizer: %w", err)
+	}
+	return newCedarAdmission(authorizer, passThroughTools), nil
+}
+
+// cedarAdmission enforces the wrapped [authorizers.Authorizer]'s decision. It is
+// named for the Cedar authorizer it backs in the vMCP path, but wraps the
+// single-method Authorizer interface generically. passThroughTools (optimizer
+// meta-tools) bypass the decision exactly as they do in the HTTP response filter.
+type cedarAdmission struct {
+	authorizer       authorizers.Authorizer
+	passThroughTools map[string]struct{}
+}
+
+// newCedarAdmission wraps an already-built authorizer. Separated from newAdmission
+// so tests can inject a stub authorizer (or a real cedar.NewCedarAuthorizer)
+// without round-tripping through the config/factory.
+func newCedarAdmission(a authorizers.Authorizer, passThroughTools map[string]struct{}) *cedarAdmission {
+	return &cedarAdmission{authorizer: a, passThroughTools: passThroughTools}
+}
+
+// FilterTools mirrors pkg/authz filterToolsByPolicy (tool_filter.go:19) and the
+// response filter's tool split (response_filter.go:306): pass-through tools are
+// kept unconditionally; every other tool is authorized for call with its
+// annotations injected, and a per-tool authorizer error skips that tool.
+func (a *cedarAdmission) FilterTools(
+	ctx context.Context, identity *auth.Identity, tools []vmcp.Tool,
+) ([]vmcp.Tool, error) {
+	ctx = auth.WithIdentity(ctx, identity)
+	// Instantiate so an empty result marshals as [] rather than null on the wire.
+	filtered := make([]vmcp.Tool, 0, len(tools))
+	for i := range tools {
+		tool := &tools[i]
+		if _, passThrough := a.passThroughTools[tool.Name]; passThrough {
+			filtered = append(filtered, *tool)
+			continue
+		}
+
+		toolCtx := ctx
+		if ann := convertAnnotations(tool.Annotations); ann != nil {
+			toolCtx = authorizers.WithToolAnnotations(toolCtx, ann)
+		}
+		allowed, err := a.authorizer.AuthorizeWithJWTClaims(
+			toolCtx, authorizers.MCPFeatureTool, authorizers.MCPOperationCall, tool.Name, nil)
+		if err != nil {
+			slog.Warn("admission: tool authorization check failed, skipping", "tool", tool.Name, "error", err)
+			continue
+		}
+		if allowed {
+			filtered = append(filtered, *tool)
+		}
+	}
+	return filtered, nil
+}
+
+// AllowToolCall mirrors pkg/authz authorizeToolCall (tool_filter.go:64). Pass-through
+// meta-tools are exempt: their inner backend tool is authorized by the optimizer
+// decorator, matching their exemption through the HTTP middleware today.
+func (a *cedarAdmission) AllowToolCall(
+	ctx context.Context, identity *auth.Identity, tool *vmcp.Tool, args map[string]any,
+) (bool, error) {
+	if _, passThrough := a.passThroughTools[tool.Name]; passThrough {
+		return true, nil
+	}
+	ctx = auth.WithIdentity(ctx, identity)
+	if ann := convertAnnotations(tool.Annotations); ann != nil {
+		ctx = authorizers.WithToolAnnotations(ctx, ann)
+	}
+	return a.authorizer.AuthorizeWithJWTClaims(
+		ctx, authorizers.MCPFeatureTool, authorizers.MCPOperationCall, tool.Name, args)
+}
+
+// FilterResources mirrors the response filter's filterResourcesResponse
+// (response_filter.go:407): per-resource read authorization, skipping on error.
+func (a *cedarAdmission) FilterResources(
+	ctx context.Context, identity *auth.Identity, resources []vmcp.Resource,
+) ([]vmcp.Resource, error) {
+	ctx = auth.WithIdentity(ctx, identity)
+	filtered := make([]vmcp.Resource, 0, len(resources))
+	for i := range resources {
+		allowed, err := a.authorizer.AuthorizeWithJWTClaims(
+			ctx, authorizers.MCPFeatureResource, authorizers.MCPOperationRead, resources[i].URI, nil)
+		if err != nil {
+			slog.Warn("admission: resource authorization check failed, skipping",
+				"resource", resources[i].URI, "error", err)
+			continue
+		}
+		if allowed {
+			filtered = append(filtered, resources[i])
+		}
+	}
+	return filtered, nil
+}
+
+// AllowResourceRead authorizes a single resource read (MCPFeatureResource/Read).
+func (a *cedarAdmission) AllowResourceRead(
+	ctx context.Context, identity *auth.Identity, resource *vmcp.Resource,
+) (bool, error) {
+	ctx = auth.WithIdentity(ctx, identity)
+	return a.authorizer.AuthorizeWithJWTClaims(
+		ctx, authorizers.MCPFeatureResource, authorizers.MCPOperationRead, resource.URI, nil)
+}
+
+// FilterPrompts mirrors the response filter's filterPromptsResponse
+// (response_filter.go:346): per-prompt get authorization, skipping on error.
+func (a *cedarAdmission) FilterPrompts(
+	ctx context.Context, identity *auth.Identity, prompts []vmcp.Prompt,
+) ([]vmcp.Prompt, error) {
+	ctx = auth.WithIdentity(ctx, identity)
+	filtered := make([]vmcp.Prompt, 0, len(prompts))
+	for i := range prompts {
+		allowed, err := a.authorizer.AuthorizeWithJWTClaims(
+			ctx, authorizers.MCPFeaturePrompt, authorizers.MCPOperationGet, prompts[i].Name, nil)
+		if err != nil {
+			slog.Warn("admission: prompt authorization check failed, skipping",
+				"prompt", prompts[i].Name, "error", err)
+			continue
+		}
+		if allowed {
+			filtered = append(filtered, prompts[i])
+		}
+	}
+	return filtered, nil
+}
+
+// AllowPromptGet authorizes a single prompt get (MCPFeaturePrompt/Get).
+func (a *cedarAdmission) AllowPromptGet(
+	ctx context.Context, identity *auth.Identity, prompt *vmcp.Prompt,
+) (bool, error) {
+	ctx = auth.WithIdentity(ctx, identity)
+	return a.authorizer.AuthorizeWithJWTClaims(
+		ctx, authorizers.MCPFeaturePrompt, authorizers.MCPOperationGet, prompt.Name, nil)
+}
+
+// allowAllAdmission is the no-op seam used when authorization is unconfigured. It
+// preserves today's behavior when AuthzMiddleware is nil: Filter* return their
+// input unchanged and Allow* return true (the nil-authorizer no-ops at
+// tool_filter.go:20,67).
+type allowAllAdmission struct{}
+
+func (allowAllAdmission) FilterTools(
+	_ context.Context, _ *auth.Identity, tools []vmcp.Tool,
+) ([]vmcp.Tool, error) {
+	return tools, nil
+}
+
+func (allowAllAdmission) AllowToolCall(
+	_ context.Context, _ *auth.Identity, _ *vmcp.Tool, _ map[string]any,
+) (bool, error) {
+	return true, nil
+}
+
+func (allowAllAdmission) FilterResources(
+	_ context.Context, _ *auth.Identity, resources []vmcp.Resource,
+) ([]vmcp.Resource, error) {
+	return resources, nil
+}
+
+func (allowAllAdmission) AllowResourceRead(_ context.Context, _ *auth.Identity, _ *vmcp.Resource) (bool, error) {
+	return true, nil
+}
+
+func (allowAllAdmission) FilterPrompts(
+	_ context.Context, _ *auth.Identity, prompts []vmcp.Prompt,
+) ([]vmcp.Prompt, error) {
+	return prompts, nil
+}
+
+func (allowAllAdmission) AllowPromptGet(_ context.Context, _ *auth.Identity, _ *vmcp.Prompt) (bool, error) {
+	return true, nil
+}
+
+// convertAnnotations maps vmcp.ToolAnnotations to authorizers.ToolAnnotations,
+// returning nil when no hint field is set so the adapter only writes annotation
+// ctx when a hint exists (matching the existing hasAnyHint gate). It mirrors
+// server.convertAnnotations (annotation_enrichment.go:92): an intentional,
+// temporary duplication — the server-side middleware copy is retired on the
+// domain path in #5441. Only authorization-relevant hints are mapped;
+// informational fields like Title are not used in policy evaluation.
+func convertAnnotations(ann *vmcp.ToolAnnotations) *authorizers.ToolAnnotations {
+	if ann == nil {
+		return nil
+	}
+	if ann.ReadOnlyHint == nil && ann.DestructiveHint == nil &&
+		ann.IdempotentHint == nil && ann.OpenWorldHint == nil {
+		return nil
+	}
+	return &authorizers.ToolAnnotations{
+		ReadOnlyHint:    ann.ReadOnlyHint,
+		DestructiveHint: ann.DestructiveHint,
+		IdempotentHint:  ann.IdempotentHint,
+		OpenWorldHint:   ann.OpenWorldHint,
+	}
+}
+
+// findAdvertisedTool returns a pointer to the advertised tool with the given name,
+// or nil. CallTool uses it to source the tool's annotations for the admission
+// decision — mirroring the annotation cache the HTTP middleware populates from
+// tools/list. A name absent from the advertised set carries no annotations
+// (nil), and routing remains the authority on whether the call resolves.
+func findAdvertisedTool(tools []vmcp.Tool, name string) *vmcp.Tool {
+	for i := range tools {
+		if tools[i].Name == name {
+			return &tools[i]
+		}
+	}
+	return nil
+}

--- a/pkg/vmcp/core/admission.go
+++ b/pkg/vmcp/core/admission.go
@@ -58,6 +58,9 @@ type Admission interface {
 // normalization the live path performs at construction time (e.g. defaulting an
 // empty EntitiesJSON to "[]", incoming.go:128) belongs to whoever builds
 // authzCfg, not to this generic factory path, which consumes RawConfig as-is.
+// newCedarAuthzMiddleware (incoming.go:114) is the sibling construction path; the
+// two must stay in lockstep (notably the empty-serverName check below) until #5441
+// collapses them into a single shared constructor.
 func newAdmission(
 	authzCfg *authorizers.Config, serverName string, passThroughTools map[string]struct{},
 ) (Admission, error) {
@@ -111,7 +114,10 @@ func (a *cedarAdmission) FilterTools(
 	ctx context.Context, identity *auth.Identity, tools []vmcp.Tool,
 ) ([]vmcp.Tool, error) {
 	ctx = auth.WithIdentity(ctx, identity)
-	// Instantiate so an empty result marshals as [] rather than null on the wire.
+	// A filter returns a subset, so build a fresh non-nil slice — mirroring
+	// pkg/authz filterToolsByPolicy (its configured-authorizer path is also
+	// non-nil; its nil-authorizer no-op, like the allow-all seam here, returns the
+	// input as-is). nil-vs-[] wire normalization is the Serve layer's concern.
 	filtered := make([]vmcp.Tool, 0, len(tools))
 	for i := range tools {
 		tool := &tools[i]

--- a/pkg/vmcp/core/admission.go
+++ b/pkg/vmcp/core/admission.go
@@ -44,23 +44,27 @@ type Admission interface {
 // newAdmission builds the admission seam New wires into the core.
 //
 // A nil authzCfg means authorization is unconfigured and the seam is allow-all,
-// preserving today's `cfg.AuthzMiddleware != nil` guard (server.go:606): the
-// composition root only populates Authz when Cedar policies exist (mirroring
-// newCedarAuthzMiddleware's `len(Policies) > 0` check), so "no policies" reaches
-// the core as a nil Authz, not an empty authorizer.
+// preserving today's `AuthzMiddleware != nil` guard: the composition root only
+// populates Authz when Cedar policies exist (mirroring newCedarAuthzMiddleware's
+// `len(Policies) > 0` check), so "no policies" reaches the core as a nil Authz.
+//
+// A non-nil authzCfg with zero policies is NOT treated as allow-all here: it falls
+// through to CreateAuthorizer, which returns ErrNoPolicies, so the core fails
+// CLOSED. This is a deliberate divergence from the live HTTP path, which allows-all
+// for the same input. Fail-closed is the safer default; #5441 reconciles the two
+// when it collapses the construction paths into one shared constructor.
 //
 // When authzCfg is set, the authorizer is built via the same registry path the
-// HTTP middleware uses (authorizers.GetFactory + CreateAuthorizer, the
-// construction inside newCedarAuthzMiddleware). The Cedar factory is registered by
-// pkg/authz's blank import, which the core package already pulls in.
+// HTTP middleware uses (authorizers.GetFactory + CreateAuthorizer, the construction
+// inside newCedarAuthzMiddleware). The Cedar factory is registered by pkg/authz's
+// blank import, which the core package already pulls in.
 //
 // authzCfg is an already-built, authorizer-agnostic config: the cedar-specific
-// normalization the live path performs at construction time (e.g. defaulting an
-// empty EntitiesJSON to "[]", incoming.go:128) belongs to whoever builds
-// authzCfg, not to this generic factory path, which consumes RawConfig as-is.
-// newCedarAuthzMiddleware (incoming.go:114) is the sibling construction path; the
-// two must stay in lockstep (notably the empty-serverName check below) until #5441
-// collapses them into a single shared constructor.
+// normalization newCedarAuthzMiddleware performs at construction time (e.g.
+// defaulting an empty EntitiesJSON to "[]") belongs to whoever builds authzCfg, not
+// to this generic factory path, which consumes RawConfig as-is. newCedarAuthzMiddleware
+// is the sibling construction path; the two must stay in lockstep (notably the
+// empty-serverName check below) until #5441 collapses them.
 func newAdmission(
 	authzCfg *authorizers.Config, serverName string, passThroughTools map[string]struct{},
 ) (Admission, error) {
@@ -68,11 +72,11 @@ func newAdmission(
 		return allowAllAdmission{}, nil
 	}
 
-	// Fail loudly on an empty server name, mirroring the live factory
-	// (incoming.go:120). Cedar attaches the MCP::"<serverName>" parent UID to
-	// resource entities only when serverName is non-empty
-	// (cedar/entity.go:170-174), so an empty name silently changes resource-scoped
-	// policy semantics rather than erroring (go-style: fail loudly on invalid input).
+	// Fail loudly on an empty server name, mirroring newCedarAuthzMiddleware's check.
+	// The Cedar entity factory attaches the MCP::"<serverName>" parent UID to resource
+	// entities only when serverName is non-empty, so an empty name silently changes
+	// resource-scoped policy semantics rather than erroring (go-style: fail loudly on
+	// invalid input).
 	if serverName == "" {
 		return nil, fmt.Errorf(
 			"%w: ServerName must not be empty when Authz is set (Cedar resource-scoped policies require it)",
@@ -85,7 +89,10 @@ func newAdmission(
 	}
 	authorizer, err := factory.CreateAuthorizer(authzCfg.RawConfig(), serverName)
 	if err != nil {
-		return nil, fmt.Errorf("failed to build admission authorizer: %w", err)
+		// Classify with ErrInvalidConfig so callers (errors.Is) treat a bad policy /
+		// malformed RawConfig the same as the unsupported-type and empty-serverName
+		// failures above — all are invalid-config conditions.
+		return nil, fmt.Errorf("%w: failed to build admission authorizer: %w", vmcp.ErrInvalidConfig, err)
 	}
 	return newCedarAdmission(authorizer, passThroughTools), nil
 }
@@ -97,13 +104,33 @@ func newAdmission(
 type cedarAdmission struct {
 	authorizer       authorizers.Authorizer
 	passThroughTools map[string]struct{}
+	// logger receives the per-item "skipping" warnings. It defaults to
+	// slog.Default(); tests inject a buffer-backed logger (via withLogger) so they
+	// can assert on output WITHOUT swapping the process-global slog default — that
+	// global swap races (-race) against parallel sibling tests that also log.
+	logger *slog.Logger
+}
+
+// cedarOption configures a cedarAdmission at construction.
+type cedarOption func(*cedarAdmission)
+
+// withLogger overrides the logger the seam emits skip warnings to. Used by tests
+// to capture log output without mutating the global slog default.
+func withLogger(logger *slog.Logger) cedarOption {
+	return func(c *cedarAdmission) { c.logger = logger }
 }
 
 // newCedarAdmission wraps an already-built authorizer. Separated from newAdmission
 // so tests can inject a stub authorizer (or a real cedar.NewCedarAuthorizer)
 // without round-tripping through the config/factory.
-func newCedarAdmission(a authorizers.Authorizer, passThroughTools map[string]struct{}) *cedarAdmission {
-	return &cedarAdmission{authorizer: a, passThroughTools: passThroughTools}
+func newCedarAdmission(
+	a authorizers.Authorizer, passThroughTools map[string]struct{}, opts ...cedarOption,
+) *cedarAdmission {
+	adm := &cedarAdmission{authorizer: a, passThroughTools: passThroughTools, logger: slog.Default()}
+	for _, opt := range opts {
+		opt(adm)
+	}
+	return adm
 }
 
 // FilterTools mirrors pkg/authz filterToolsByPolicy (tool_filter.go:19) and the
@@ -133,7 +160,7 @@ func (a *cedarAdmission) FilterTools(
 		allowed, err := a.authorizer.AuthorizeWithJWTClaims(
 			toolCtx, authorizers.MCPFeatureTool, authorizers.MCPOperationCall, tool.Name, nil)
 		if err != nil {
-			slog.Warn("admission: tool authorization check failed, skipping", "tool", tool.Name, "error", err)
+			a.logger.Warn("admission: tool authorization check failed, skipping", "tool", tool.Name, "error", err)
 			continue
 		}
 		if allowed {
@@ -147,7 +174,7 @@ func (a *cedarAdmission) FilterTools(
 // meta-tools are exempt from the seam's decision, matching how they bypass the HTTP
 // authz path's tool checks today (#5438 AC: "passThroughTools remain exempt").
 //
-// call_tool parity note: the HTTP middleware's handleToolsCall (middleware.go:276)
+// call_tool parity note: the HTTP middleware's handleToolsCall (pkg/authz/middleware.go)
 // additionally RE-TARGETS authorization at the inner backend tool wrapped inside a
 // call_tool request (reading args["tool_name"]). This seam deliberately does NOT
 // replicate that inner-tool authorization — it only exempts the meta-tool name, per
@@ -179,7 +206,7 @@ func (a *cedarAdmission) FilterResources(
 		allowed, err := a.authorizer.AuthorizeWithJWTClaims(
 			ctx, authorizers.MCPFeatureResource, authorizers.MCPOperationRead, resources[i].URI, nil)
 		if err != nil {
-			slog.Warn("admission: resource authorization check failed, skipping",
+			a.logger.Warn("admission: resource authorization check failed, skipping",
 				"resource", resources[i].URI, "error", err)
 			continue
 		}
@@ -210,7 +237,7 @@ func (a *cedarAdmission) FilterPrompts(
 		allowed, err := a.authorizer.AuthorizeWithJWTClaims(
 			ctx, authorizers.MCPFeaturePrompt, authorizers.MCPOperationGet, prompts[i].Name, nil)
 		if err != nil {
-			slog.Warn("admission: prompt authorization check failed, skipping",
+			a.logger.Warn("admission: prompt authorization check failed, skipping",
 				"prompt", prompts[i].Name, "error", err)
 			continue
 		}

--- a/pkg/vmcp/core/admission.go
+++ b/pkg/vmcp/core/admission.go
@@ -24,6 +24,15 @@ import (
 // parameter (never read from ctx, vmcp anti-pattern #1); the adapter re-injects it
 // into the ctx the wrapped authorizer reads. A seam can only SUBTRACT reachability
 // (filter list output / refuse a call), never widen it ([VMCP] contract).
+//
+// The seam is optimizer-agnostic: it authorizes every capability uniformly by name
+// and has no special handling for the optimizer's meta-tools (find_tool/call_tool).
+// The optimizer-admission integration the HTTP path performs today — call_tool
+// inner-target authorization, find_tool response filtering, and inner-target
+// annotation sourcing — is deliberately NOT in this seam; it is deferred to its own
+// focused PR. Until then the optimizer keeps the HTTP middleware, and #5441's
+// composition root fails fast (vmcp.ErrInvalidConfig) when Authz is set together
+// with the optimizer, so the combination can never silently route through this seam.
 type Admission interface {
 	// FilterTools returns the subset of tools the identity may call. Mirrors
 	// pkg/authz filterToolsByPolicy: a per-tool AuthorizeWithJWTClaims(call) using
@@ -65,9 +74,7 @@ type Admission interface {
 // to this generic factory path, which consumes RawConfig as-is. newCedarAuthzMiddleware
 // is the sibling construction path; the two must stay in lockstep (notably the
 // empty-serverName check below) until #5441 collapses them.
-func newAdmission(
-	authzCfg *authorizers.Config, serverName string, passThroughTools map[string]struct{},
-) (Admission, error) {
+func newAdmission(authzCfg *authorizers.Config, serverName string) (Admission, error) {
 	if authzCfg == nil {
 		return allowAllAdmission{}, nil
 	}
@@ -94,16 +101,15 @@ func newAdmission(
 		// failures above — all are invalid-config conditions.
 		return nil, fmt.Errorf("%w: failed to build admission authorizer: %w", vmcp.ErrInvalidConfig, err)
 	}
-	return newCedarAdmission(authorizer, passThroughTools), nil
+	return newCedarAdmission(authorizer), nil
 }
 
 // cedarAdmission enforces the wrapped [authorizers.Authorizer]'s decision. It is
 // named for the Cedar authorizer it backs in the vMCP path, but wraps the
-// single-method Authorizer interface generically. passThroughTools (optimizer
-// meta-tools) bypass the decision exactly as they do in the HTTP response filter.
+// single-method Authorizer interface generically. It authorizes every capability
+// uniformly — no optimizer meta-tool carve-out (see the [Admission] doc).
 type cedarAdmission struct {
-	authorizer       authorizers.Authorizer
-	passThroughTools map[string]struct{}
+	authorizer authorizers.Authorizer
 	// logger receives the per-item "skipping" warnings. It defaults to
 	// slog.Default(); tests inject a buffer-backed logger (via withLogger) so they
 	// can assert on output WITHOUT swapping the process-global slog default — that
@@ -123,20 +129,17 @@ func withLogger(logger *slog.Logger) cedarOption {
 // newCedarAdmission wraps an already-built authorizer. Separated from newAdmission
 // so tests can inject a stub authorizer (or a real cedar.NewCedarAuthorizer)
 // without round-tripping through the config/factory.
-func newCedarAdmission(
-	a authorizers.Authorizer, passThroughTools map[string]struct{}, opts ...cedarOption,
-) *cedarAdmission {
-	adm := &cedarAdmission{authorizer: a, passThroughTools: passThroughTools, logger: slog.Default()}
+func newCedarAdmission(a authorizers.Authorizer, opts ...cedarOption) *cedarAdmission {
+	adm := &cedarAdmission{authorizer: a, logger: slog.Default()}
 	for _, opt := range opts {
 		opt(adm)
 	}
 	return adm
 }
 
-// FilterTools mirrors pkg/authz filterToolsByPolicy (tool_filter.go:19) and the
-// response filter's tool split (response_filter.go:306): pass-through tools are
-// kept unconditionally; every other tool is authorized for call with its
-// annotations injected, and a per-tool authorizer error skips that tool.
+// FilterTools mirrors pkg/authz filterToolsByPolicy: each tool is authorized for
+// call with its annotations injected, and a per-tool authorizer error skips that
+// tool (log-and-continue).
 func (a *cedarAdmission) FilterTools(
 	ctx context.Context, identity *auth.Identity, tools []vmcp.Tool,
 ) ([]vmcp.Tool, error) {
@@ -148,11 +151,6 @@ func (a *cedarAdmission) FilterTools(
 	filtered := make([]vmcp.Tool, 0, len(tools))
 	for i := range tools {
 		tool := &tools[i]
-		if _, passThrough := a.passThroughTools[tool.Name]; passThrough {
-			filtered = append(filtered, *tool)
-			continue
-		}
-
 		toolCtx := ctx
 		if ann := convertAnnotations(tool.Annotations); ann != nil {
 			toolCtx = authorizers.WithToolAnnotations(toolCtx, ann)
@@ -170,23 +168,15 @@ func (a *cedarAdmission) FilterTools(
 	return filtered, nil
 }
 
-// AllowToolCall mirrors pkg/authz authorizeToolCall (tool_filter.go:64). Pass-through
-// meta-tools are exempt from the seam's decision, matching how they bypass the HTTP
-// authz path's tool checks today (#5438 AC: "passThroughTools remain exempt").
-//
-// call_tool parity note: the HTTP middleware's handleToolsCall (pkg/authz/middleware.go)
-// additionally RE-TARGETS authorization at the inner backend tool wrapped inside a
-// call_tool request (reading args["tool_name"]). This seam deliberately does NOT
-// replicate that inner-tool authorization — it only exempts the meta-tool name, per
-// this task's scope. Ensuring the unwrapped inner call is authorized is a call-path
-// wiring requirement for #5441 (which removes the HTTP middleware): that wiring must
-// route the inner call through a path that consults this seam with the real tool name.
+// AllowToolCall mirrors pkg/authz authorizeToolCall (MCPFeatureTool/Call), sourcing
+// the tool's annotations for when-clause evaluation. It authorizes the tool named in
+// `tool.Name` — there is no optimizer meta-tool special-casing here (see the
+// [Admission] doc): the optimizer's call_tool inner-target authorization is deferred
+// to a dedicated optimizer-admission PR, and #5441 fails fast on (Authz + optimizer)
+// so that combination never reaches this seam in the meantime.
 func (a *cedarAdmission) AllowToolCall(
 	ctx context.Context, identity *auth.Identity, tool *vmcp.Tool, args map[string]any,
 ) (bool, error) {
-	if _, passThrough := a.passThroughTools[tool.Name]; passThrough {
-		return true, nil
-	}
 	ctx = auth.WithIdentity(ctx, identity)
 	if ann := convertAnnotations(tool.Annotations); ann != nil {
 		ctx = authorizers.WithToolAnnotations(ctx, ann)

--- a/pkg/vmcp/core/admission_test.go
+++ b/pkg/vmcp/core/admission_test.go
@@ -40,6 +40,7 @@ type mockCall struct {
 	feature         authorizers.MCPFeature
 	operation       authorizers.MCPOperation
 	resourceID      string
+	args            map[string]interface{}
 	identitySubject string // "" when no identity was present in ctx
 	identityPresent bool
 	annotations     *authorizers.ToolAnnotations
@@ -50,13 +51,14 @@ func (m *mockAuthorizer) AuthorizeWithJWTClaims(
 	feature authorizers.MCPFeature,
 	operation authorizers.MCPOperation,
 	resourceID string,
-	_ map[string]interface{},
+	args map[string]interface{},
 ) (bool, error) {
 	id, present := auth.IdentityFromContext(ctx)
 	call := mockCall{
 		feature:         feature,
 		operation:       operation,
 		resourceID:      resourceID,
+		args:            args,
 		identityPresent: present,
 		annotations:     authorizers.ToolAnnotationsFromContext(ctx),
 	}
@@ -235,6 +237,71 @@ func TestCedarAdmission_AllowToolCall(t *testing.T) {
 			assert.Equal(t, authorizers.MCPFeatureTool, mock.calls[0].feature)
 			assert.Equal(t, authorizers.MCPOperationCall, mock.calls[0].operation)
 			assert.True(t, mock.calls[0].identityPresent)
+		})
+	}
+}
+
+// TestCedarAdmission_AllowToolCall_ForwardsArgs asserts the call's args reach the
+// authorizer (the arg-gated-policy input path), both via the mock and against a
+// real Cedar arg-gated policy (mirroring pkg/authz TestAuthorizeToolCall_WithArguments).
+func TestCedarAdmission_AllowToolCall_ForwardsArgs(t *testing.T) {
+	t.Parallel()
+
+	t.Run("args reach the authorizer", func(t *testing.T) {
+		t.Parallel()
+		mock := &mockAuthorizer{results: map[string]mockResult{"deploy": {authorized: true}}}
+		adm := newCedarAdmission(mock, nil)
+		args := map[string]any{"mode": "safe"}
+
+		_, err := adm.AllowToolCall(context.Background(), cedarIdentity(), &vmcp.Tool{Name: "deploy"}, args)
+		require.NoError(t, err)
+		require.Len(t, mock.calls, 1)
+		assert.Equal(t, args, mock.calls[0].args, "call args must flow through to the authorizer")
+	})
+
+	t.Run("cedar arg-gated policy evaluates the args", func(t *testing.T) {
+		t.Parallel()
+		// Cedar sees args under an "arg_" prefix (preprocessed by the authorizer);
+		// permit only when arg_mode == "safe".
+		adm := cedarAdmissionWith(t,
+			`permit(principal, action == Action::"call_tool", resource == Tool::"deploy") when { context.arg_mode == "safe" };`)
+		id := cedarIdentity()
+
+		ok, err := adm.AllowToolCall(context.Background(), id, &vmcp.Tool{Name: "deploy"}, map[string]any{"mode": "safe"})
+		require.NoError(t, err)
+		assert.True(t, ok, "permitted when args satisfy the policy")
+
+		ok, _ = adm.AllowToolCall(context.Background(), id, &vmcp.Tool{Name: "deploy"}, map[string]any{"mode": "dangerous"})
+		assert.False(t, ok, "denied when args do not satisfy the policy")
+	})
+}
+
+func TestFindAdvertisedTool(t *testing.T) {
+	t.Parallel()
+	tools := []vmcp.Tool{{Name: "a"}, {Name: "b"}}
+
+	tests := []struct {
+		name      string
+		tools     []vmcp.Tool
+		find      string
+		wantFound bool
+	}{
+		{"present first", tools, "a", true},
+		{"present last", tools, "b", true},
+		{"absent", tools, "missing", false},
+		{"empty list", nil, "a", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := findAdvertisedTool(tc.tools, tc.find)
+			if tc.wantFound {
+				require.NotNil(t, got)
+				assert.Equal(t, tc.find, got.Name)
+			} else {
+				assert.Nil(t, got)
+			}
 		})
 	}
 }
@@ -625,29 +692,96 @@ func TestAdmission_ResourceAndPromptDenyThroughCore(t *testing.T) {
 	assert.ErrorIs(t, err, vmcp.ErrAuthorizationFailed)
 }
 
+// TestAdmission_CallToolForwardsArgsToAuthorizer proves call arguments flow the full
+// chain CallTool -> AllowToolCall -> authorizer: an arg-gated Cedar policy permits the
+// call only when the args satisfy it, so the permitted args route to the backend and
+// the failing args are denied with ErrAuthorizationFailed.
+func TestAdmission_CallToolForwardsArgsToAuthorizer(t *testing.T) {
+	t.Parallel()
+	cfg, m := baseConfig(t)
+	cfg.ServerName = "test-vmcp"
+	cfg.Authz = cedarAuthzConfig(t,
+		`permit(principal, action == Action::"call_tool", resource == Tool::"deploy") when { context.arg_mode == "safe" };`)
+
+	rt := &vmcp.RoutingTable{Tools: map[string]*vmcp.BackendTarget{"deploy": backendTarget()}}
+	m.reg.EXPECT().List(gomock.Any()).
+		Return([]vmcp.Backend{{ID: testBackendID, HealthStatus: vmcp.BackendHealthy}}).AnyTimes()
+	m.agg.EXPECT().AggregateCapabilities(gomock.Any(), gomock.Any()).Return(&aggregator.AggregatedCapabilities{
+		Tools:        []vmcp.Tool{backendTool("deploy")},
+		RoutingTable: rt,
+	}, nil).AnyTimes()
+
+	// Only the args-satisfying call reaches the backend.
+	want := &vmcp.ToolCallResult{StructuredContent: map[string]any{"ok": true}}
+	m.client.EXPECT().CallTool(gomock.Any(), gomock.Any(), "deploy", gomock.Any(), gomock.Any()).Return(want, nil)
+
+	c, err := New(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = c.Close() })
+	ctx := context.Background()
+	id := cedarIdentity()
+
+	got, err := c.CallTool(ctx, id, "deploy", map[string]any{"mode": "safe"}, nil)
+	require.NoError(t, err)
+	assert.Equal(t, want, got, "args satisfying the policy flow through and the call routes")
+
+	_, err = c.CallTool(ctx, id, "deploy", map[string]any{"mode": "dangerous"}, nil)
+	assert.ErrorIs(t, err, vmcp.ErrAuthorizationFailed, "args failing the policy deny the call — args reached the authorizer")
+}
+
+// TestAdmission_CallToolNilAdvertisedToolDeniesUnderAnnotationPolicy exercises
+// findAdvertisedTool's nil branch end-to-end: a name that is routable but absent from
+// the advertised Tools is called with a synthesized bare Tool{Name} carrying no
+// annotations, so an annotation-gated policy evaluates with no hints and denies —
+// proving routing is not reached (no backend client call) and correcting the prior
+// "unroutable" assumption.
+func TestAdmission_CallToolNilAdvertisedToolDeniesUnderAnnotationPolicy(t *testing.T) {
+	t.Parallel()
+	cfg, m := baseConfig(t)
+	cfg.ServerName = "test-vmcp"
+	cfg.Authz = cedarAuthzConfig(t,
+		`permit(principal, action == Action::"call_tool", resource) when { resource.readOnlyHint == true };`)
+
+	// "ghost" is in the routing table but NOT in the advertised Tools.
+	rt := &vmcp.RoutingTable{Tools: map[string]*vmcp.BackendTarget{"ghost": backendTarget()}}
+	m.reg.EXPECT().List(gomock.Any()).
+		Return([]vmcp.Backend{{ID: testBackendID, HealthStatus: vmcp.BackendHealthy}}).AnyTimes()
+	m.agg.EXPECT().AggregateCapabilities(gomock.Any(), gomock.Any()).Return(&aggregator.AggregatedCapabilities{
+		Tools:        nil,
+		RoutingTable: rt,
+	}, nil).AnyTimes()
+	// No client.CallTool expectation: the call is denied before routing.
+
+	c, err := New(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = c.Close() })
+
+	_, err = c.CallTool(context.Background(), cedarIdentity(), "ghost", nil, nil)
+	assert.ErrorIs(t, err, vmcp.ErrAuthorizationFailed,
+		"a routable name absent from the advertised set is evaluated with no hints and denied")
+}
+
 // TestAdmission_IdentityNeverLogged covers R1(5): the seam passes *auth.Identity
 // through unchanged and never logs identity/token material, even on the per-tool
-// skip path. Serial: it swaps the global slog default into a non-thread-safe buffer.
-//
-//nolint:paralleltest // installs a global slog default + non-thread-safe buffer; must not run in parallel
+// skip path. The seam logs through an injected logger (withLogger), so the test
+// captures output WITHOUT swapping the process-global slog default — that global
+// swap raced (-race) against parallel sibling tests that also log.
 func TestAdmission_IdentityNeverLogged(t *testing.T) {
+	t.Parallel()
 	const secret = "super-secret-token-value"
 
 	// An erroring authorizer drives the FilterTools skip-warning so the assertion
 	// is not vacuous.
 	mock := &mockAuthorizer{results: map[string]mockResult{"boom": {err: errors.New("policy eval failed")}}}
-	adm := newCedarAdmission(mock, nil)
+	var buf bytes.Buffer
+	adm := newCedarAdmission(mock, nil,
+		withLogger(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))))
 
 	id := &auth.Identity{
 		PrincipalInfo:  auth.PrincipalInfo{Subject: "user", Claims: map[string]interface{}{"secret": secret}},
 		Token:          secret,
 		UpstreamTokens: map[string]string{"github": secret},
 	}
-
-	var buf bytes.Buffer
-	prev := slog.Default()
-	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
-	t.Cleanup(func() { slog.SetDefault(prev) })
 
 	_, _ = adm.FilterTools(context.Background(), id, []vmcp.Tool{{Name: "boom"}})
 

--- a/pkg/vmcp/core/admission_test.go
+++ b/pkg/vmcp/core/admission_test.go
@@ -241,7 +241,9 @@ func TestCedarAdmission_AllowToolCall(t *testing.T) {
 
 // TestCedarAdmission_PassThroughExempt covers R1(4): optimizer meta-tools
 // (find_tool/call_tool) are never denied by the seam, matching their exemption
-// through the HTTP middleware today.
+// through the HTTP middleware today. Exemption is the seam's contract here; the
+// inner-tool authorization the HTTP middleware performs for call_tool is a #5441
+// call-path wiring concern (see AllowToolCall's doc), not the seam's.
 func TestCedarAdmission_PassThroughExempt(t *testing.T) {
 	t.Parallel()
 
@@ -451,7 +453,7 @@ func TestNewAdmission(t *testing.T) {
 		t.Parallel()
 		adm, err := newAdmission(
 			cedarAuthzConfig(t, `permit(principal, action == Action::"call_tool", resource == Tool::"weather");`),
-			"", nil)
+			"test-vmcp", nil)
 		require.NoError(t, err)
 
 		ok, err := adm.AllowToolCall(context.Background(), cedarIdentity(), &vmcp.Tool{Name: "weather"}, nil)
@@ -460,6 +462,15 @@ func TestNewAdmission(t *testing.T) {
 		ok, err = adm.AllowToolCall(context.Background(), cedarIdentity(), &vmcp.Tool{Name: "calculator"}, nil)
 		require.NoError(t, err)
 		assert.False(t, ok)
+	})
+
+	t.Run("empty server name with authz errors", func(t *testing.T) {
+		t.Parallel()
+		_, err := newAdmission(
+			cedarAuthzConfig(t, `permit(principal, action == Action::"call_tool", resource == Tool::"weather");`),
+			"", nil)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, vmcp.ErrInvalidConfig)
 	})
 
 	t.Run("unsupported authz type errors", func(t *testing.T) {
@@ -482,6 +493,7 @@ func TestNewAdmission(t *testing.T) {
 func TestAdmission_ListCallLookupEnforceSameDecision(t *testing.T) {
 	t.Parallel()
 	cfg, m := baseConfig(t)
+	cfg.ServerName = "test-vmcp"
 	cfg.Authz = cedarAuthzConfig(t,
 		`permit(principal, action == Action::"call_tool", resource == Tool::"weather");`)
 
@@ -524,12 +536,60 @@ func TestAdmission_ListCallLookupEnforceSameDecision(t *testing.T) {
 	assert.Equal(t, "weather", tool.Name)
 }
 
+// TestAdmission_AnnotationGatedDecisionMatchesListAndCall confirms (MEDIUM follow-up)
+// that an annotation-gated policy (resource.readOnlyHint) reaches the same verdict
+// for ListTools and CallTool through the core: CallTool sources the tool's
+// annotations from the advertised set (findAdvertisedTool), so the read-only tool is
+// both advertised and callable while the writable tool is both filtered and denied.
+func TestAdmission_AnnotationGatedDecisionMatchesListAndCall(t *testing.T) {
+	t.Parallel()
+	cfg, m := baseConfig(t)
+	cfg.ServerName = "test-vmcp"
+	cfg.Authz = cedarAuthzConfig(t,
+		`permit(principal, action == Action::"call_tool", resource) when { resource.readOnlyHint == true };`)
+
+	ro := backendTool("ro")
+	ro.Annotations = &vmcp.ToolAnnotations{ReadOnlyHint: boolPtr(true)}
+	rw := backendTool("rw")
+	rw.Annotations = &vmcp.ToolAnnotations{ReadOnlyHint: boolPtr(false)}
+
+	rt := &vmcp.RoutingTable{Tools: map[string]*vmcp.BackendTarget{"ro": backendTarget(), "rw": backendTarget()}}
+	m.reg.EXPECT().List(gomock.Any()).
+		Return([]vmcp.Backend{{ID: testBackendID, HealthStatus: vmcp.BackendHealthy}}).AnyTimes()
+	m.agg.EXPECT().AggregateCapabilities(gomock.Any(), gomock.Any()).Return(&aggregator.AggregatedCapabilities{
+		Tools:        []vmcp.Tool{ro, rw},
+		RoutingTable: rt,
+	}, nil).AnyTimes()
+
+	// Only the read-only tool is callable, so only it reaches the backend.
+	want := &vmcp.ToolCallResult{StructuredContent: map[string]any{"ok": true}}
+	m.client.EXPECT().CallTool(gomock.Any(), gomock.Any(), "ro", gomock.Any(), gomock.Any()).Return(want, nil)
+
+	c, err := New(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = c.Close() })
+	ctx := context.Background()
+	id := cedarIdentity()
+
+	tools, err := c.ListTools(ctx, id)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"ro"}, toolNames(tools), "only the read-only tool is advertised")
+
+	got, err := c.CallTool(ctx, id, "ro", nil, nil)
+	require.NoError(t, err)
+	assert.Equal(t, want, got, "the read-only tool is callable — annotations flow through CallTool")
+
+	_, err = c.CallTool(ctx, id, "rw", nil, nil)
+	assert.ErrorIs(t, err, vmcp.ErrAuthorizationFailed, "the writable tool is denied identically to the list filter")
+}
+
 // TestAdmission_ResourceAndPromptDenyThroughCore confirms the deny wiring is
 // present on the resource and prompt call paths (the seam refuses before routing,
 // so no backend client call is made).
 func TestAdmission_ResourceAndPromptDenyThroughCore(t *testing.T) {
 	t.Parallel()
 	cfg, m := baseConfig(t)
+	cfg.ServerName = "test-vmcp"
 	cfg.Authz = cedarAuthzConfig(t,
 		`permit(principal, action == Action::"read_resource", resource == Resource::"res-a");`,
 		`permit(principal, action == Action::"get_prompt", resource == Prompt::"p-a");`,

--- a/pkg/vmcp/core/admission_test.go
+++ b/pkg/vmcp/core/admission_test.go
@@ -87,12 +87,12 @@ func cedarIdentity() *auth.Identity {
 }
 
 // cedarAdmissionWith builds a cedarAdmission backed by a real Cedar authorizer
-// compiled from the given policies (no pass-through tools).
+// compiled from the given policies.
 func cedarAdmissionWith(t *testing.T, policies ...string) *cedarAdmission {
 	t.Helper()
 	a, err := cedar.NewCedarAuthorizer(cedar.ConfigOptions{Policies: policies, EntitiesJSON: "[]"}, "")
 	require.NoError(t, err)
-	return newCedarAdmission(a, nil)
+	return newCedarAdmission(a)
 }
 
 // cedarAuthzConfig builds the generic authz.Config New consumes, wrapping the
@@ -169,7 +169,7 @@ func TestCedarAdmission_FilterTools(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			adm := newCedarAdmission(&mockAuthorizer{results: tc.results}, nil)
+			adm := newCedarAdmission(&mockAuthorizer{results: tc.results})
 			got, err := adm.FilterTools(context.Background(), cedarIdentity(), tc.tools)
 			require.NoError(t, err)
 			assert.Equal(t, tc.wantNames, toolNames(got))
@@ -181,7 +181,7 @@ func TestCedarAdmission_InvokesToolAuthorizerCorrectly(t *testing.T) {
 	t.Parallel()
 
 	mock := &mockAuthorizer{results: map[string]mockResult{"hinted": {authorized: true}, "plain": {authorized: true}}}
-	adm := newCedarAdmission(mock, nil)
+	adm := newCedarAdmission(mock)
 
 	tools := []vmcp.Tool{
 		{Name: "hinted", Annotations: &vmcp.ToolAnnotations{ReadOnlyHint: boolPtr(true)}},
@@ -225,7 +225,7 @@ func TestCedarAdmission_AllowToolCall(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			mock := &mockAuthorizer{results: tc.results}
-			adm := newCedarAdmission(mock, nil)
+			adm := newCedarAdmission(mock)
 			ok, err := adm.AllowToolCall(context.Background(), cedarIdentity(), &vmcp.Tool{Name: tc.tool}, nil)
 			assert.Equal(t, tc.wantOK, ok)
 			if tc.wantErr != nil {
@@ -250,7 +250,7 @@ func TestCedarAdmission_AllowToolCall_ForwardsArgs(t *testing.T) {
 	t.Run("args reach the authorizer", func(t *testing.T) {
 		t.Parallel()
 		mock := &mockAuthorizer{results: map[string]mockResult{"deploy": {authorized: true}}}
-		adm := newCedarAdmission(mock, nil)
+		adm := newCedarAdmission(mock)
 		args := map[string]any{"mode": "safe"}
 
 		_, err := adm.AllowToolCall(context.Background(), cedarIdentity(), &vmcp.Tool{Name: "deploy"}, args)
@@ -306,35 +306,6 @@ func TestFindAdvertisedTool(t *testing.T) {
 	}
 }
 
-// TestCedarAdmission_PassThroughExempt covers R1(4): optimizer meta-tools
-// (find_tool/call_tool) are never denied by the seam, matching their exemption
-// through the HTTP middleware today. Exemption is the seam's contract here; the
-// inner-tool authorization the HTTP middleware performs for call_tool is a #5441
-// call-path wiring concern (see AllowToolCall's doc), not the seam's.
-func TestCedarAdmission_PassThroughExempt(t *testing.T) {
-	t.Parallel()
-
-	passThrough := map[string]struct{}{"find_tool": {}, "call_tool": {}}
-	// Authorizer denies everything (empty results -> default deny).
-	mock := &mockAuthorizer{results: map[string]mockResult{}}
-	adm := newCedarAdmission(mock, passThrough)
-
-	got, err := adm.FilterTools(context.Background(), cedarIdentity(),
-		[]vmcp.Tool{{Name: "find_tool"}, {Name: "call_tool"}, {Name: "regular"}})
-	require.NoError(t, err)
-	assert.Equal(t, []string{"find_tool", "call_tool"}, toolNames(got),
-		"pass-through tools survive; the regular tool is denied")
-
-	ok, err := adm.AllowToolCall(context.Background(), cedarIdentity(), &vmcp.Tool{Name: "find_tool"}, nil)
-	require.NoError(t, err)
-	assert.True(t, ok, "pass-through tool call is exempt")
-
-	// The authorizer is never consulted for pass-through tools.
-	for _, c := range mock.calls {
-		assert.Equal(t, "regular", c.resourceID)
-	}
-}
-
 func TestCedarAdmission_FilterResourcesAndPrompts(t *testing.T) {
 	t.Parallel()
 
@@ -345,7 +316,7 @@ func TestCedarAdmission_FilterResourcesAndPrompts(t *testing.T) {
 			"res-b": {authorized: false},
 			"res-c": {err: errors.New("boom")}, // skipped
 		}}
-		adm := newCedarAdmission(mock, nil)
+		adm := newCedarAdmission(mock)
 		got, err := adm.FilterResources(context.Background(), cedarIdentity(),
 			[]vmcp.Resource{{URI: "res-a"}, {URI: "res-b"}, {URI: "res-c"}})
 		require.NoError(t, err)
@@ -361,7 +332,7 @@ func TestCedarAdmission_FilterResourcesAndPrompts(t *testing.T) {
 			"p-a": {authorized: true},
 			"p-b": {authorized: false},
 		}}
-		adm := newCedarAdmission(mock, nil)
+		adm := newCedarAdmission(mock)
 		got, err := adm.FilterPrompts(context.Background(), cedarIdentity(),
 			[]vmcp.Prompt{{Name: "p-a"}, {Name: "p-b"}})
 		require.NoError(t, err)
@@ -379,7 +350,7 @@ func TestCedarAdmission_AllowResourceReadAndPromptGet(t *testing.T) {
 		"res-a": {authorized: true},
 		"p-a":   {authorized: false},
 	}}
-	adm := newCedarAdmission(mock, nil)
+	adm := newCedarAdmission(mock)
 
 	ok, err := adm.AllowResourceRead(context.Background(), cedarIdentity(), &vmcp.Resource{URI: "res-a"})
 	require.NoError(t, err)
@@ -486,7 +457,7 @@ func TestNewAdmission(t *testing.T) {
 
 	t.Run("nil config is allow-all", func(t *testing.T) {
 		t.Parallel()
-		adm, err := newAdmission(nil, "", nil)
+		adm, err := newAdmission(nil, "")
 		require.NoError(t, err)
 		ctx := context.Background()
 
@@ -520,7 +491,7 @@ func TestNewAdmission(t *testing.T) {
 		t.Parallel()
 		adm, err := newAdmission(
 			cedarAuthzConfig(t, `permit(principal, action == Action::"call_tool", resource == Tool::"weather");`),
-			"test-vmcp", nil)
+			"test-vmcp")
 		require.NoError(t, err)
 
 		ok, err := adm.AllowToolCall(context.Background(), cedarIdentity(), &vmcp.Tool{Name: "weather"}, nil)
@@ -535,7 +506,7 @@ func TestNewAdmission(t *testing.T) {
 		t.Parallel()
 		_, err := newAdmission(
 			cedarAuthzConfig(t, `permit(principal, action == Action::"call_tool", resource == Tool::"weather");`),
-			"", nil)
+			"")
 		require.Error(t, err)
 		assert.ErrorIs(t, err, vmcp.ErrInvalidConfig)
 	})
@@ -548,7 +519,7 @@ func TestNewAdmission(t *testing.T) {
 		}{Version: "1.0", Type: "definitely-not-registered"})
 		require.NoError(t, err)
 
-		_, err = newAdmission(bad, "", nil)
+		_, err = newAdmission(bad, "")
 		require.Error(t, err)
 		assert.ErrorIs(t, err, vmcp.ErrInvalidConfig)
 	})
@@ -774,7 +745,7 @@ func TestAdmission_IdentityNeverLogged(t *testing.T) {
 	// is not vacuous.
 	mock := &mockAuthorizer{results: map[string]mockResult{"boom": {err: errors.New("policy eval failed")}}}
 	var buf bytes.Buffer
-	adm := newCedarAdmission(mock, nil,
+	adm := newCedarAdmission(mock,
 		withLogger(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))))
 
 	id := &auth.Identity{

--- a/pkg/vmcp/core/admission_test.go
+++ b/pkg/vmcp/core/admission_test.go
@@ -1,0 +1,597 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package core
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/stacklok/toolhive/pkg/auth"
+	"github.com/stacklok/toolhive/pkg/authz/authorizers"
+	"github.com/stacklok/toolhive/pkg/authz/authorizers/cedar"
+	"github.com/stacklok/toolhive/pkg/vmcp"
+	"github.com/stacklok/toolhive/pkg/vmcp/aggregator"
+)
+
+// mockAuthorizer is a hand-rolled stub for the single-method authorizers.Authorizer
+// (no generated mock exists; the issue specifies a hand-rolled stub, as
+// pkg/authz/tool_filter_test.go does). It records each call — including what it
+// observed in the context — so tests can assert the adapter re-injects identity
+// and annotations before delegating.
+type mockAuthorizer struct {
+	results map[string]mockResult // keyed by resourceID
+	calls   []mockCall
+}
+
+type mockResult struct {
+	authorized bool
+	err        error
+}
+
+type mockCall struct {
+	feature         authorizers.MCPFeature
+	operation       authorizers.MCPOperation
+	resourceID      string
+	identitySubject string // "" when no identity was present in ctx
+	identityPresent bool
+	annotations     *authorizers.ToolAnnotations
+}
+
+func (m *mockAuthorizer) AuthorizeWithJWTClaims(
+	ctx context.Context,
+	feature authorizers.MCPFeature,
+	operation authorizers.MCPOperation,
+	resourceID string,
+	_ map[string]interface{},
+) (bool, error) {
+	id, present := auth.IdentityFromContext(ctx)
+	call := mockCall{
+		feature:         feature,
+		operation:       operation,
+		resourceID:      resourceID,
+		identityPresent: present,
+		annotations:     authorizers.ToolAnnotationsFromContext(ctx),
+	}
+	if present && id != nil {
+		call.identitySubject = id.Subject
+	}
+	m.calls = append(m.calls, call)
+
+	r, ok := m.results[resourceID]
+	if !ok {
+		return false, nil // default-deny for unlisted resources
+	}
+	return r.authorized, r.err
+}
+
+func boolPtr(b bool) *bool { return &b }
+
+// cedarIdentity returns an identity the Cedar authorizer can resolve to a client
+// ID, mirroring pkg/authz/tool_filter_test.go's cedarCtx.
+func cedarIdentity() *auth.Identity {
+	return &auth.Identity{PrincipalInfo: auth.PrincipalInfo{
+		Subject: "user123",
+		Name:    "Test User",
+		Claims:  map[string]interface{}{"sub": "user123", "name": "Test User"},
+	}}
+}
+
+// cedarAdmissionWith builds a cedarAdmission backed by a real Cedar authorizer
+// compiled from the given policies (no pass-through tools).
+func cedarAdmissionWith(t *testing.T, policies ...string) *cedarAdmission {
+	t.Helper()
+	a, err := cedar.NewCedarAuthorizer(cedar.ConfigOptions{Policies: policies, EntitiesJSON: "[]"}, "")
+	require.NoError(t, err)
+	return newCedarAdmission(a, nil)
+}
+
+// cedarAuthzConfig builds the generic authz.Config New consumes, wrapping the
+// given Cedar policies (mirrors factory/incoming.go's newCedarAuthzMiddleware).
+func cedarAuthzConfig(t *testing.T, policies ...string) *authorizers.Config {
+	t.Helper()
+	cfg, err := authorizers.NewConfig(cedar.Config{
+		Version: "1.0",
+		Type:    cedar.ConfigType,
+		Options: &cedar.ConfigOptions{Policies: policies, EntitiesJSON: "[]"},
+	})
+	require.NoError(t, err)
+	return cfg
+}
+
+func toolNames(tools []vmcp.Tool) []string {
+	names := make([]string, len(tools))
+	for i, t := range tools {
+		names[i] = t.Name
+	}
+	return names
+}
+
+func TestCedarAdmission_FilterTools(t *testing.T) {
+	t.Parallel()
+
+	errAuth := errors.New("authorization failure")
+
+	tests := []struct {
+		name      string
+		results   map[string]mockResult
+		tools     []vmcp.Tool
+		wantNames []string
+	}{
+		{
+			name:      "empty tool list returns empty",
+			results:   map[string]mockResult{},
+			tools:     []vmcp.Tool{},
+			wantNames: []string{},
+		},
+		{
+			name: "filters out denied tools",
+			results: map[string]mockResult{
+				"allowed":  {authorized: true},
+				"denied":   {authorized: false},
+				"allowed2": {authorized: true},
+			},
+			tools:     []vmcp.Tool{{Name: "allowed"}, {Name: "denied"}, {Name: "allowed2"}},
+			wantNames: []string{"allowed", "allowed2"},
+		},
+		{
+			name: "skips tools whose authorizer errors (log-and-continue)",
+			results: map[string]mockResult{
+				"good":  {authorized: true},
+				"error": {err: errAuth},
+			},
+			tools:     []vmcp.Tool{{Name: "good"}, {Name: "error"}},
+			wantNames: []string{"good"},
+		},
+		{
+			name: "annotated tools are still filtered",
+			results: map[string]mockResult{
+				"readonly": {authorized: true},
+				"writable": {authorized: false},
+			},
+			tools: []vmcp.Tool{
+				{Name: "readonly", Annotations: &vmcp.ToolAnnotations{ReadOnlyHint: boolPtr(true)}},
+				{Name: "writable", Annotations: &vmcp.ToolAnnotations{DestructiveHint: boolPtr(true)}},
+			},
+			wantNames: []string{"readonly"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			adm := newCedarAdmission(&mockAuthorizer{results: tc.results}, nil)
+			got, err := adm.FilterTools(context.Background(), cedarIdentity(), tc.tools)
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantNames, toolNames(got))
+		})
+	}
+}
+
+func TestCedarAdmission_InvokesToolAuthorizerCorrectly(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockAuthorizer{results: map[string]mockResult{"hinted": {authorized: true}, "plain": {authorized: true}}}
+	adm := newCedarAdmission(mock, nil)
+
+	tools := []vmcp.Tool{
+		{Name: "hinted", Annotations: &vmcp.ToolAnnotations{ReadOnlyHint: boolPtr(true)}},
+		{Name: "plain"},
+	}
+	_, err := adm.FilterTools(context.Background(), cedarIdentity(), tools)
+	require.NoError(t, err)
+
+	require.Len(t, mock.calls, 2)
+	for _, c := range mock.calls {
+		assert.Equal(t, authorizers.MCPFeatureTool, c.feature)
+		assert.Equal(t, authorizers.MCPOperationCall, c.operation)
+		assert.True(t, c.identityPresent, "adapter must re-inject identity into ctx")
+		assert.Equal(t, "user123", c.identitySubject)
+	}
+	// Annotations are injected only for the tool that carries a hint.
+	byName := map[string]mockCall{mock.calls[0].resourceID: mock.calls[0], mock.calls[1].resourceID: mock.calls[1]}
+	require.NotNil(t, byName["hinted"].annotations)
+	assert.Equal(t, boolPtr(true), byName["hinted"].annotations.ReadOnlyHint)
+	assert.Nil(t, byName["plain"].annotations, "no annotation ctx written when the tool has no hints")
+}
+
+func TestCedarAdmission_AllowToolCall(t *testing.T) {
+	t.Parallel()
+
+	errAuth := errors.New("auth error")
+
+	tests := []struct {
+		name    string
+		results map[string]mockResult
+		tool    string
+		wantOK  bool
+		wantErr error
+	}{
+		{"allowed", map[string]mockResult{"t": {authorized: true}}, "t", true, nil},
+		{"denied", map[string]mockResult{"t": {authorized: false}}, "t", false, nil},
+		{"error propagated", map[string]mockResult{"t": {err: errAuth}}, "t", false, errAuth},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			mock := &mockAuthorizer{results: tc.results}
+			adm := newCedarAdmission(mock, nil)
+			ok, err := adm.AllowToolCall(context.Background(), cedarIdentity(), &vmcp.Tool{Name: tc.tool}, nil)
+			assert.Equal(t, tc.wantOK, ok)
+			if tc.wantErr != nil {
+				require.ErrorIs(t, err, tc.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Len(t, mock.calls, 1)
+			assert.Equal(t, authorizers.MCPFeatureTool, mock.calls[0].feature)
+			assert.Equal(t, authorizers.MCPOperationCall, mock.calls[0].operation)
+			assert.True(t, mock.calls[0].identityPresent)
+		})
+	}
+}
+
+// TestCedarAdmission_PassThroughExempt covers R1(4): optimizer meta-tools
+// (find_tool/call_tool) are never denied by the seam, matching their exemption
+// through the HTTP middleware today.
+func TestCedarAdmission_PassThroughExempt(t *testing.T) {
+	t.Parallel()
+
+	passThrough := map[string]struct{}{"find_tool": {}, "call_tool": {}}
+	// Authorizer denies everything (empty results -> default deny).
+	mock := &mockAuthorizer{results: map[string]mockResult{}}
+	adm := newCedarAdmission(mock, passThrough)
+
+	got, err := adm.FilterTools(context.Background(), cedarIdentity(),
+		[]vmcp.Tool{{Name: "find_tool"}, {Name: "call_tool"}, {Name: "regular"}})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"find_tool", "call_tool"}, toolNames(got),
+		"pass-through tools survive; the regular tool is denied")
+
+	ok, err := adm.AllowToolCall(context.Background(), cedarIdentity(), &vmcp.Tool{Name: "find_tool"}, nil)
+	require.NoError(t, err)
+	assert.True(t, ok, "pass-through tool call is exempt")
+
+	// The authorizer is never consulted for pass-through tools.
+	for _, c := range mock.calls {
+		assert.Equal(t, "regular", c.resourceID)
+	}
+}
+
+func TestCedarAdmission_FilterResourcesAndPrompts(t *testing.T) {
+	t.Parallel()
+
+	t.Run("resources", func(t *testing.T) {
+		t.Parallel()
+		mock := &mockAuthorizer{results: map[string]mockResult{
+			"res-a": {authorized: true},
+			"res-b": {authorized: false},
+			"res-c": {err: errors.New("boom")}, // skipped
+		}}
+		adm := newCedarAdmission(mock, nil)
+		got, err := adm.FilterResources(context.Background(), cedarIdentity(),
+			[]vmcp.Resource{{URI: "res-a"}, {URI: "res-b"}, {URI: "res-c"}})
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		assert.Equal(t, "res-a", got[0].URI)
+		assert.Equal(t, authorizers.MCPFeatureResource, mock.calls[0].feature)
+		assert.Equal(t, authorizers.MCPOperationRead, mock.calls[0].operation)
+	})
+
+	t.Run("prompts", func(t *testing.T) {
+		t.Parallel()
+		mock := &mockAuthorizer{results: map[string]mockResult{
+			"p-a": {authorized: true},
+			"p-b": {authorized: false},
+		}}
+		adm := newCedarAdmission(mock, nil)
+		got, err := adm.FilterPrompts(context.Background(), cedarIdentity(),
+			[]vmcp.Prompt{{Name: "p-a"}, {Name: "p-b"}})
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		assert.Equal(t, "p-a", got[0].Name)
+		assert.Equal(t, authorizers.MCPFeaturePrompt, mock.calls[0].feature)
+		assert.Equal(t, authorizers.MCPOperationGet, mock.calls[0].operation)
+	})
+}
+
+func TestCedarAdmission_AllowResourceReadAndPromptGet(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockAuthorizer{results: map[string]mockResult{
+		"res-a": {authorized: true},
+		"p-a":   {authorized: false},
+	}}
+	adm := newCedarAdmission(mock, nil)
+
+	ok, err := adm.AllowResourceRead(context.Background(), cedarIdentity(), &vmcp.Resource{URI: "res-a"})
+	require.NoError(t, err)
+	assert.True(t, ok)
+	assert.Equal(t, authorizers.MCPFeatureResource, mock.calls[0].feature)
+	assert.Equal(t, authorizers.MCPOperationRead, mock.calls[0].operation)
+
+	ok, err = adm.AllowPromptGet(context.Background(), cedarIdentity(), &vmcp.Prompt{Name: "p-a"})
+	require.NoError(t, err)
+	assert.False(t, ok)
+	assert.Equal(t, authorizers.MCPFeaturePrompt, mock.calls[1].feature)
+	assert.Equal(t, authorizers.MCPOperationGet, mock.calls[1].operation)
+}
+
+// TestCedarAdmission_WithCedarAuthorizer exercises the seam against a real Cedar
+// authorizer, mirroring pkg/authz/tool_filter_test.go's Cedar cases, and covers
+// the nil-identity edge: the adapter re-injects identity, so ErrMissingPrincipal
+// only surfaces for a genuinely nil identity — and filter/call agree (both deny).
+func TestCedarAdmission_WithCedarAuthorizer(t *testing.T) {
+	t.Parallel()
+
+	adm := cedarAdmissionWith(t,
+		`permit(principal, action == Action::"call_tool", resource == Tool::"weather");`,
+		`permit(principal, action == Action::"read_resource", resource == Resource::"res-a");`,
+		`permit(principal, action == Action::"get_prompt", resource == Prompt::"p-a");`,
+	)
+	id := cedarIdentity()
+	ctx := context.Background()
+
+	t.Run("tools filter and call agree", func(t *testing.T) {
+		t.Parallel()
+		got, err := adm.FilterTools(ctx, id, []vmcp.Tool{{Name: "weather"}, {Name: "calculator"}})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"weather"}, toolNames(got))
+
+		ok, err := adm.AllowToolCall(ctx, id, &vmcp.Tool{Name: "weather"}, nil)
+		require.NoError(t, err)
+		assert.True(t, ok)
+		ok, err = adm.AllowToolCall(ctx, id, &vmcp.Tool{Name: "calculator"}, nil)
+		require.NoError(t, err)
+		assert.False(t, ok)
+	})
+
+	t.Run("resource and prompt parity", func(t *testing.T) {
+		t.Parallel()
+		ok, err := adm.AllowResourceRead(ctx, id, &vmcp.Resource{URI: "res-a"})
+		require.NoError(t, err)
+		assert.True(t, ok)
+		ok, err = adm.AllowResourceRead(ctx, id, &vmcp.Resource{URI: "res-b"})
+		require.NoError(t, err)
+		assert.False(t, ok)
+
+		ok, err = adm.AllowPromptGet(ctx, id, &vmcp.Prompt{Name: "p-a"})
+		require.NoError(t, err)
+		assert.True(t, ok)
+		ok, err = adm.AllowPromptGet(ctx, id, &vmcp.Prompt{Name: "p-b"})
+		require.NoError(t, err)
+		assert.False(t, ok)
+	})
+
+	t.Run("nil identity denies consistently", func(t *testing.T) {
+		t.Parallel()
+		// FilterTools skips the tool (per-tool ErrMissingPrincipal -> log-and-continue).
+		got, err := adm.FilterTools(ctx, nil, []vmcp.Tool{{Name: "weather"}})
+		require.NoError(t, err)
+		assert.Empty(t, got)
+		// AllowToolCall surfaces the missing-principal error (deny).
+		ok, err := adm.AllowToolCall(ctx, nil, &vmcp.Tool{Name: "weather"}, nil)
+		require.Error(t, err)
+		assert.False(t, ok)
+	})
+}
+
+// TestCedarAdmission_AnnotationWhenClause covers R1(2): policies keyed on
+// annotations (resource.readOnlyHint) evaluate using core-sourced Tool.Annotations
+// identically for both the list filter and the call.
+func TestCedarAdmission_AnnotationWhenClause(t *testing.T) {
+	t.Parallel()
+
+	adm := cedarAdmissionWith(t,
+		`permit(principal, action == Action::"call_tool", resource) when { resource.readOnlyHint == true };`)
+	id := cedarIdentity()
+	ctx := context.Background()
+
+	readOnly := vmcp.Tool{Name: "ro", Annotations: &vmcp.ToolAnnotations{ReadOnlyHint: boolPtr(true)}}
+	writable := vmcp.Tool{Name: "rw", Annotations: &vmcp.ToolAnnotations{ReadOnlyHint: boolPtr(false)}}
+
+	got, err := adm.FilterTools(ctx, id, []vmcp.Tool{readOnly, writable})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"ro"}, toolNames(got), "readOnlyHint-gated allow keeps only the read-only tool")
+
+	ok, err := adm.AllowToolCall(ctx, id, &readOnly, nil)
+	require.NoError(t, err)
+	assert.True(t, ok)
+	ok, err = adm.AllowToolCall(ctx, id, &writable, nil)
+	require.NoError(t, err)
+	assert.False(t, ok, "the call enforces the same readOnlyHint decision as the filter")
+}
+
+// TestNewAdmission covers construction and R1(3): a nil Authz yields an allow-all
+// seam (every Filter* returns its input unchanged, every Allow* returns true).
+func TestNewAdmission(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil config is allow-all", func(t *testing.T) {
+		t.Parallel()
+		adm, err := newAdmission(nil, "", nil)
+		require.NoError(t, err)
+		ctx := context.Background()
+
+		tools := []vmcp.Tool{{Name: "a"}, {Name: "b"}}
+		gotTools, err := adm.FilterTools(ctx, nil, tools)
+		require.NoError(t, err)
+		assert.Equal(t, tools, gotTools)
+
+		resources := []vmcp.Resource{{URI: "r"}}
+		gotRes, err := adm.FilterResources(ctx, nil, resources)
+		require.NoError(t, err)
+		assert.Equal(t, resources, gotRes)
+
+		prompts := []vmcp.Prompt{{Name: "p"}}
+		gotPrompts, err := adm.FilterPrompts(ctx, nil, prompts)
+		require.NoError(t, err)
+		assert.Equal(t, prompts, gotPrompts)
+
+		ok, err := adm.AllowToolCall(ctx, nil, &vmcp.Tool{Name: "a"}, nil)
+		require.NoError(t, err)
+		assert.True(t, ok)
+		ok, err = adm.AllowResourceRead(ctx, nil, &vmcp.Resource{URI: "r"})
+		require.NoError(t, err)
+		assert.True(t, ok)
+		ok, err = adm.AllowPromptGet(ctx, nil, &vmcp.Prompt{Name: "p"})
+		require.NoError(t, err)
+		assert.True(t, ok)
+	})
+
+	t.Run("cedar config builds an enforcing seam", func(t *testing.T) {
+		t.Parallel()
+		adm, err := newAdmission(
+			cedarAuthzConfig(t, `permit(principal, action == Action::"call_tool", resource == Tool::"weather");`),
+			"", nil)
+		require.NoError(t, err)
+
+		ok, err := adm.AllowToolCall(context.Background(), cedarIdentity(), &vmcp.Tool{Name: "weather"}, nil)
+		require.NoError(t, err)
+		assert.True(t, ok)
+		ok, err = adm.AllowToolCall(context.Background(), cedarIdentity(), &vmcp.Tool{Name: "calculator"}, nil)
+		require.NoError(t, err)
+		assert.False(t, ok)
+	})
+
+	t.Run("unsupported authz type errors", func(t *testing.T) {
+		t.Parallel()
+		bad, err := authorizers.NewConfig(struct {
+			Version string `json:"version"`
+			Type    string `json:"type"`
+		}{Version: "1.0", Type: "definitely-not-registered"})
+		require.NoError(t, err)
+
+		_, err = newAdmission(bad, "", nil)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, vmcp.ErrInvalidConfig)
+	})
+}
+
+// TestAdmission_ListCallLookupEnforceSameDecision covers R1(1) end-to-end through
+// the core: a tool denied by Cedar is omitted from ListTools, refused by CallTool,
+// and unresolvable via LookupTool — closing the "list says yes / call says no" gap.
+func TestAdmission_ListCallLookupEnforceSameDecision(t *testing.T) {
+	t.Parallel()
+	cfg, m := baseConfig(t)
+	cfg.Authz = cedarAuthzConfig(t,
+		`permit(principal, action == Action::"call_tool", resource == Tool::"weather");`)
+
+	rt := &vmcp.RoutingTable{Tools: map[string]*vmcp.BackendTarget{"weather": backendTarget()}}
+	m.reg.EXPECT().List(gomock.Any()).
+		Return([]vmcp.Backend{{ID: testBackendID, HealthStatus: vmcp.BackendHealthy}}).AnyTimes()
+	m.agg.EXPECT().AggregateCapabilities(gomock.Any(), gomock.Any()).Return(&aggregator.AggregatedCapabilities{
+		Tools:        []vmcp.Tool{backendTool("weather"), backendTool("calculator")},
+		RoutingTable: rt,
+	}, nil).AnyTimes()
+
+	// Only the permitted tool ever reaches the backend.
+	want := &vmcp.ToolCallResult{StructuredContent: map[string]any{"ok": true}}
+	m.client.EXPECT().CallTool(gomock.Any(), gomock.Any(), "weather", gomock.Any(), gomock.Any()).Return(want, nil)
+
+	c, err := New(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = c.Close() })
+	ctx := context.Background()
+	id := cedarIdentity()
+
+	// List: the denied tool is omitted.
+	tools, err := c.ListTools(ctx, id)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"weather"}, toolNames(tools))
+
+	// Call: the permitted tool routes; the denied tool is refused (same decision).
+	got, err := c.CallTool(ctx, id, "weather", nil, nil)
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
+
+	_, err = c.CallTool(ctx, id, "calculator", nil, nil)
+	assert.ErrorIs(t, err, vmcp.ErrAuthorizationFailed)
+
+	// Lookup: the denied tool is unresolvable; the permitted one resolves.
+	_, err = c.LookupTool(ctx, id, "calculator")
+	assert.ErrorIs(t, err, vmcp.ErrNotFound)
+	tool, err := c.LookupTool(ctx, id, "weather")
+	require.NoError(t, err)
+	assert.Equal(t, "weather", tool.Name)
+}
+
+// TestAdmission_ResourceAndPromptDenyThroughCore confirms the deny wiring is
+// present on the resource and prompt call paths (the seam refuses before routing,
+// so no backend client call is made).
+func TestAdmission_ResourceAndPromptDenyThroughCore(t *testing.T) {
+	t.Parallel()
+	cfg, m := baseConfig(t)
+	cfg.Authz = cedarAuthzConfig(t,
+		`permit(principal, action == Action::"read_resource", resource == Resource::"res-a");`,
+		`permit(principal, action == Action::"get_prompt", resource == Prompt::"p-a");`,
+	)
+
+	m.reg.EXPECT().List(gomock.Any()).Return(nil).AnyTimes()
+	m.agg.EXPECT().AggregateCapabilities(gomock.Any(), gomock.Any()).Return(&aggregator.AggregatedCapabilities{
+		Resources:    []vmcp.Resource{{URI: "res-a", BackendID: testBackendID}, {URI: "res-b", BackendID: testBackendID}},
+		Prompts:      []vmcp.Prompt{{Name: "p-a", BackendID: testBackendID}, {Name: "p-b", BackendID: testBackendID}},
+		RoutingTable: &vmcp.RoutingTable{},
+	}, nil).AnyTimes()
+
+	c, err := New(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = c.Close() })
+	ctx := context.Background()
+	id := cedarIdentity()
+
+	resources, err := c.ListResources(ctx, id)
+	require.NoError(t, err)
+	require.Len(t, resources, 1)
+	assert.Equal(t, "res-a", resources[0].URI)
+
+	_, err = c.ReadResource(ctx, id, "res-b")
+	assert.ErrorIs(t, err, vmcp.ErrAuthorizationFailed)
+
+	prompts, err := c.ListPrompts(ctx, id)
+	require.NoError(t, err)
+	require.Len(t, prompts, 1)
+	assert.Equal(t, "p-a", prompts[0].Name)
+
+	_, err = c.GetPrompt(ctx, id, "p-b", nil)
+	assert.ErrorIs(t, err, vmcp.ErrAuthorizationFailed)
+}
+
+// TestAdmission_IdentityNeverLogged covers R1(5): the seam passes *auth.Identity
+// through unchanged and never logs identity/token material, even on the per-tool
+// skip path. Serial: it swaps the global slog default into a non-thread-safe buffer.
+//
+//nolint:paralleltest // installs a global slog default + non-thread-safe buffer; must not run in parallel
+func TestAdmission_IdentityNeverLogged(t *testing.T) {
+	const secret = "super-secret-token-value"
+
+	// An erroring authorizer drives the FilterTools skip-warning so the assertion
+	// is not vacuous.
+	mock := &mockAuthorizer{results: map[string]mockResult{"boom": {err: errors.New("policy eval failed")}}}
+	adm := newCedarAdmission(mock, nil)
+
+	id := &auth.Identity{
+		PrincipalInfo:  auth.PrincipalInfo{Subject: "user", Claims: map[string]interface{}{"secret": secret}},
+		Token:          secret,
+		UpstreamTokens: map[string]string{"github": secret},
+	}
+
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	_, _ = adm.FilterTools(context.Background(), id, []vmcp.Tool{{Name: "boom"}})
+
+	logs := buf.String()
+	require.NotEmpty(t, logs, "expected a skip warning so the assertion is not vacuous")
+	assert.NotContains(t, logs, secret, "identity token must never be logged")
+}

--- a/pkg/vmcp/core/core.go
+++ b/pkg/vmcp/core/core.go
@@ -133,9 +133,23 @@ type Config struct {
 	// WorkflowDefs holds the composite-tool workflow definitions, keyed by name.
 	WorkflowDefs map[string]*composer.WorkflowDefinition
 
-	// Authz feeds the admission seam (wired in a later change). A nil Authz
-	// means authorization is unconfigured (allow-all).
+	// Authz feeds the admission seam New builds. A nil Authz means authorization
+	// is unconfigured (allow-all), matching today's `AuthzMiddleware != nil` guard:
+	// the composition root only populates this when Cedar policies exist (mirroring
+	// newCedarAuthzMiddleware's `len(Policies) > 0` check).
 	Authz *authz.Config
+
+	// ServerName is the VirtualMCPServer name used as the Cedar resource entity
+	// name in authorization policy evaluation — parity with the serverName threaded
+	// into the HTTP authz middleware (factory/incoming.go:94). Consulted only when
+	// Authz is set.
+	ServerName string
+
+	// PassThroughTools names the optimizer meta-tools (find_tool/call_tool) that are
+	// exempt from admission filtering and denial, mirroring how they bypass the HTTP
+	// authz response filter today (cli/serve.go:356-362). Nil when the optimizer is
+	// disabled.
+	PassThroughTools map[string]struct{}
 
 	// TelemetryProvider is the cross-cutting telemetry provider (also consumed by Serve).
 	TelemetryProvider *telemetry.Provider

--- a/pkg/vmcp/core/core.go
+++ b/pkg/vmcp/core/core.go
@@ -136,19 +136,21 @@ type Config struct {
 	// Authz feeds the admission seam New builds. A nil Authz means authorization
 	// is unconfigured (allow-all), matching today's `AuthzMiddleware != nil` guard:
 	// the composition root only populates this when Cedar policies exist (mirroring
-	// newCedarAuthzMiddleware's `len(Policies) > 0` check).
+	// newCedarAuthzMiddleware's `len(Policies) > 0` check). When Authz is non-nil,
+	// ServerName is REQUIRED (New fails fast with vmcp.ErrInvalidConfig otherwise).
 	Authz *authz.Config
 
-	// ServerName is the VirtualMCPServer name used as the Cedar resource entity
-	// name in authorization policy evaluation — parity with the serverName threaded
-	// into the HTTP authz middleware (factory/incoming.go:94). Consulted only when
-	// Authz is set.
+	// ServerName is the VirtualMCPServer name used as the Cedar resource entity name
+	// in authorization policy evaluation — parity with the serverName threaded into
+	// the HTTP authz middleware. It is REQUIRED when Authz is non-nil (New returns
+	// vmcp.ErrInvalidConfig on an empty value, since Cedar resource-scoped policies
+	// depend on it) and ignored when Authz is nil.
 	ServerName string
 
 	// PassThroughTools names the optimizer meta-tools (find_tool/call_tool) that are
 	// exempt from admission filtering and denial, mirroring how they bypass the HTTP
-	// authz response filter today (cli/serve.go:356-362). Nil when the optimizer is
-	// disabled.
+	// authz response filter today. Nil when the optimizer is disabled; ignored when
+	// Authz is nil (the allow-all seam exempts everything).
 	PassThroughTools map[string]struct{}
 
 	// TelemetryProvider is the cross-cutting telemetry provider (also consumed by Serve).

--- a/pkg/vmcp/core/core.go
+++ b/pkg/vmcp/core/core.go
@@ -147,12 +147,6 @@ type Config struct {
 	// depend on it) and ignored when Authz is nil.
 	ServerName string
 
-	// PassThroughTools names the optimizer meta-tools (find_tool/call_tool) that are
-	// exempt from admission filtering and denial, mirroring how they bypass the HTTP
-	// authz response filter today. Nil when the optimizer is disabled; ignored when
-	// Authz is nil (the allow-all seam exempts everything).
-	PassThroughTools map[string]struct{}
-
 	// TelemetryProvider is the cross-cutting telemetry provider (also consumed by Serve).
 	TelemetryProvider *telemetry.Provider
 

--- a/pkg/vmcp/core/core_calls.go
+++ b/pkg/vmcp/core/core_calls.go
@@ -46,15 +46,22 @@ func (c *coreVMCP) CallTool(
 	// tool's annotations from the advertised set (mirroring the annotation cache the
 	// HTTP middleware populates from tools/list) so annotation-gated policies
 	// evaluate. advertisedTools includes composites, so their annotations are sourced
-	// too. A name absent from the recomputed advertised set carries no annotations:
-	// an annotation-gated decision then evaluates with no hints (and may deny) — but
-	// such a name is also unroutable below, so it would not resolve regardless.
+	// too. A name absent from the advertised set carries no annotations, so an
+	// annotation-gated decision evaluates with no hints (and may deny). In normal
+	// operation the advertised set and the routing table are derived from the same
+	// aggregation, so this only arises if they diverge.
 	tool := findAdvertisedTool(c.advertisedTools(agg), name)
 	if tool == nil {
 		tool = &vmcp.Tool{Name: name}
 	}
+	// An authorizer ERROR is treated as a denial (fail closed), classified as
+	// ErrAuthorizationFailed so the Serve adapter can distinguish it from a transport
+	// failure via errors.Is — mirroring the live authorizeAndServe, which routes both
+	// err and !authorized to the unauthorized response. The underlying error is
+	// preserved in the chain for server-side diagnostics; Serve decides what reaches
+	// the client.
 	if allowed, err := c.admission.AllowToolCall(ctx, identity, tool, argsCopy); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: tool %q: %w", vmcp.ErrAuthorizationFailed, name, err)
 	} else if !allowed {
 		return nil, fmt.Errorf("%w: tool %q", vmcp.ErrAuthorizationFailed, name)
 	}
@@ -96,9 +103,10 @@ func (c *coreVMCP) ReadResource(
 	}
 
 	// Admission deny: mirror ListResources' filter for the single read. Resources
-	// carry no annotations, so the URI alone identifies the decision.
+	// carry no annotations, so the URI alone identifies the decision. An authorizer
+	// error fails closed, classified as ErrAuthorizationFailed (see CallTool).
 	if allowed, err := c.admission.AllowResourceRead(ctx, identity, &vmcp.Resource{URI: uri}); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: resource %q: %w", vmcp.ErrAuthorizationFailed, uri, err)
 	} else if !allowed {
 		return nil, fmt.Errorf("%w: resource %q", vmcp.ErrAuthorizationFailed, uri)
 	}
@@ -131,9 +139,10 @@ func (c *coreVMCP) GetPrompt(
 	}
 
 	// Admission deny: mirror ListPrompts' filter for the single get. Prompts carry
-	// no annotations, so the name alone identifies the decision.
+	// no annotations, so the name alone identifies the decision. An authorizer error
+	// fails closed, classified as ErrAuthorizationFailed (see CallTool).
 	if allowed, err := c.admission.AllowPromptGet(ctx, identity, &vmcp.Prompt{Name: name}); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: prompt %q: %w", vmcp.ErrAuthorizationFailed, name, err)
 	} else if !allowed {
 		return nil, fmt.Errorf("%w: prompt %q", vmcp.ErrAuthorizationFailed, name)
 	}

--- a/pkg/vmcp/core/core_calls.go
+++ b/pkg/vmcp/core/core_calls.go
@@ -45,8 +45,10 @@ func (c *coreVMCP) CallTool(
 	// Admission deny: enforce the same decision ListTools filters on, sourcing the
 	// tool's annotations from the advertised set (mirroring the annotation cache the
 	// HTTP middleware populates from tools/list) so annotation-gated policies
-	// evaluate. A name absent from the advertised set carries no annotations;
-	// routing below remains the authority on whether the call resolves.
+	// evaluate. advertisedTools includes composites, so their annotations are sourced
+	// too. A name absent from the recomputed advertised set carries no annotations:
+	// an annotation-gated decision then evaluates with no hints (and may deny) — but
+	// such a name is also unroutable below, so it would not resolve regardless.
 	tool := findAdvertisedTool(c.advertisedTools(agg), name)
 	if tool == nil {
 		tool = &vmcp.Tool{Name: name}

--- a/pkg/vmcp/core/core_calls.go
+++ b/pkg/vmcp/core/core_calls.go
@@ -20,15 +20,16 @@ import (
 // CallTool invokes the named tool. Composite tools (those defined as workflows)
 // execute through a per-call composer bound to the freshly aggregated routing
 // table; all other names route to a single backend via a session router built
-// from the same table. Returns vmcp.ErrNotFound for an unadvertised name.
+// from the same table. Returns vmcp.ErrNotFound for an unadvertised name and
+// vmcp.ErrAuthorizationFailed when admission denies identity the call.
 //
 // args and meta are treated as read-only and copied before being forwarded
-// (go-style: copy before mutating caller input). identity is accepted for the
-// admission seam (#5438); the core performs no identity-based filtering yet and
-// never logs identity. See ListTools for the nil/anonymous semantics.
+// (go-style: copy before mutating caller input). The admission decision enforces
+// the same policy ListTools filters on. identity is never logged. See ListTools
+// for the nil/anonymous semantics.
 func (c *coreVMCP) CallTool(
 	ctx context.Context,
-	_ *auth.Identity,
+	identity *auth.Identity,
 	name string,
 	args map[string]any,
 	meta map[string]any,
@@ -39,6 +40,21 @@ func (c *coreVMCP) CallTool(
 	agg, err := c.aggregatedView(ctx)
 	if err != nil {
 		return nil, err
+	}
+
+	// Admission deny: enforce the same decision ListTools filters on, sourcing the
+	// tool's annotations from the advertised set (mirroring the annotation cache the
+	// HTTP middleware populates from tools/list) so annotation-gated policies
+	// evaluate. A name absent from the advertised set carries no annotations;
+	// routing below remains the authority on whether the call resolves.
+	tool := findAdvertisedTool(c.advertisedTools(agg), name)
+	if tool == nil {
+		tool = &vmcp.Tool{Name: name}
+	}
+	if allowed, err := c.admission.AllowToolCall(ctx, identity, tool, argsCopy); err != nil {
+		return nil, err
+	} else if !allowed {
+		return nil, fmt.Errorf("%w: tool %q", vmcp.ErrAuthorizationFailed, name)
 	}
 
 	// Composite tool: execute only when the workflow is actually advertised in the
@@ -65,15 +81,24 @@ func (c *coreVMCP) CallTool(
 }
 
 // ReadResource reads the resource at uri from its backend. Returns
-// vmcp.ErrNotFound for an unadvertised URI. See ListTools for identity semantics.
+// vmcp.ErrNotFound for an unadvertised URI and vmcp.ErrAuthorizationFailed when
+// admission denies identity the read. See ListTools for identity semantics.
 func (c *coreVMCP) ReadResource(
 	ctx context.Context,
-	_ *auth.Identity,
+	identity *auth.Identity,
 	uri string,
 ) (*vmcp.ResourceReadResult, error) {
 	agg, err := c.aggregatedView(ctx)
 	if err != nil {
 		return nil, err
+	}
+
+	// Admission deny: mirror ListResources' filter for the single read. Resources
+	// carry no annotations, so the URI alone identifies the decision.
+	if allowed, err := c.admission.AllowResourceRead(ctx, identity, &vmcp.Resource{URI: uri}); err != nil {
+		return nil, err
+	} else if !allowed {
+		return nil, fmt.Errorf("%w: resource %q", vmcp.ErrAuthorizationFailed, uri)
 	}
 
 	target, err := router.NewSessionRouter(agg.RoutingTable).RouteResource(ctx, uri)
@@ -90,16 +115,25 @@ func (c *coreVMCP) ReadResource(
 
 // GetPrompt retrieves the named prompt from its backend. args is treated as
 // read-only and copied before being forwarded. Returns vmcp.ErrNotFound for an
-// unadvertised name. See ListTools for identity semantics.
+// unadvertised name and vmcp.ErrAuthorizationFailed when admission denies identity
+// the get. See ListTools for identity semantics.
 func (c *coreVMCP) GetPrompt(
 	ctx context.Context,
-	_ *auth.Identity,
+	identity *auth.Identity,
 	name string,
 	args map[string]any,
 ) (*vmcp.PromptGetResult, error) {
 	agg, err := c.aggregatedView(ctx)
 	if err != nil {
 		return nil, err
+	}
+
+	// Admission deny: mirror ListPrompts' filter for the single get. Prompts carry
+	// no annotations, so the name alone identifies the decision.
+	if allowed, err := c.admission.AllowPromptGet(ctx, identity, &vmcp.Prompt{Name: name}); err != nil {
+		return nil, err
+	} else if !allowed {
+		return nil, fmt.Errorf("%w: prompt %q", vmcp.ErrAuthorizationFailed, name)
 	}
 
 	target, err := router.NewSessionRouter(agg.RoutingTable).RoutePrompt(ctx, name)

--- a/pkg/vmcp/core/core_vmcp.go
+++ b/pkg/vmcp/core/core_vmcp.go
@@ -87,28 +87,8 @@ var _ VMCP = (*coreVMCP)(nil)
 // cfg.ServerName and cfg.PassThroughTools); a nil cfg.Authz yields an allow-all
 // seam.
 func New(cfg *Config) (VMCP, error) {
-	if cfg == nil {
-		return nil, fmt.Errorf("%w: nil core config", vmcp.ErrInvalidConfig)
-	}
-	if cfg.Aggregator == nil {
-		return nil, fmt.Errorf("%w: Aggregator is required", vmcp.ErrInvalidConfig)
-	}
-	if cfg.Router == nil {
-		return nil, fmt.Errorf("%w: Router is required", vmcp.ErrInvalidConfig)
-	}
-	if cfg.BackendRegistry == nil {
-		return nil, fmt.Errorf("%w: BackendRegistry is required", vmcp.ErrInvalidConfig)
-	}
-	if cfg.BackendClient == nil {
-		return nil, fmt.Errorf("%w: BackendClient is required", vmcp.ErrInvalidConfig)
-	}
-	// Fail fast on the elicitation contract: a workflow with an elicitation step run
-	// against a nil Elicitation would nil-deref deep inside the engine at call time
-	// (the legacy server.New path always wired a non-nil adapter). Reject it at
-	// construction so the misconfiguration surfaces at startup, not mid-workflow.
-	if cfg.Elicitation == nil && workflowsRequireElicitation(cfg.WorkflowDefs) {
-		return nil, fmt.Errorf(
-			"%w: Elicitation is required when a workflow contains an elicitation step", vmcp.ErrInvalidConfig)
+	if err := validateConfig(cfg); err != nil {
+		return nil, err
 	}
 
 	// Build the admission seam before acquiring resources so a bad policy fails
@@ -363,6 +343,36 @@ func (c *coreVMCP) accessibleComposites(
 		return nil
 	}
 	return defs
+}
+
+// validateConfig checks New's required inputs and the elicitation contract,
+// keeping New itself within the cyclomatic-complexity budget. Returns a
+// vmcp.ErrInvalidConfig-wrapped error on the first violation.
+func validateConfig(cfg *Config) error {
+	if cfg == nil {
+		return fmt.Errorf("%w: nil core config", vmcp.ErrInvalidConfig)
+	}
+	if cfg.Aggregator == nil {
+		return fmt.Errorf("%w: Aggregator is required", vmcp.ErrInvalidConfig)
+	}
+	if cfg.Router == nil {
+		return fmt.Errorf("%w: Router is required", vmcp.ErrInvalidConfig)
+	}
+	if cfg.BackendRegistry == nil {
+		return fmt.Errorf("%w: BackendRegistry is required", vmcp.ErrInvalidConfig)
+	}
+	if cfg.BackendClient == nil {
+		return fmt.Errorf("%w: BackendClient is required", vmcp.ErrInvalidConfig)
+	}
+	// Fail fast on the elicitation contract: a workflow with an elicitation step run
+	// against a nil Elicitation would nil-deref deep inside the engine at call time
+	// (the legacy server.New path always wired a non-nil adapter). Reject it at
+	// construction so the misconfiguration surfaces at startup, not mid-workflow.
+	if cfg.Elicitation == nil && workflowsRequireElicitation(cfg.WorkflowDefs) {
+		return fmt.Errorf(
+			"%w: Elicitation is required when a workflow contains an elicitation step", vmcp.ErrInvalidConfig)
+	}
+	return nil
 }
 
 // validateWorkflowDefs validates each workflow definition, returning only the

--- a/pkg/vmcp/core/core_vmcp.go
+++ b/pkg/vmcp/core/core_vmcp.go
@@ -52,6 +52,11 @@ type coreVMCP struct {
 	// filtering (all backends included), matching today's no-monitor behavior.
 	health health.StatusProvider
 
+	// admission enforces the authorization decision for List* (filter) and
+	// Call/Read/Get (deny) from one source. Never nil: New installs an allow-all
+	// seam when authz is unconfigured.
+	admission Admission
+
 	// workflowDefs holds the validated composite-tool workflow definitions keyed
 	// by advertised tool name.
 	workflowDefs map[string]*composer.WorkflowDefinition
@@ -78,8 +83,9 @@ var _ VMCP = (*coreVMCP)(nil)
 // cfg.Router is consumed only to build the workflow-validation engine (parity
 // with server.New); the core does not route through it at request time. cfg's
 // Aggregator, BackendRegistry, and BackendClient are required and New fails
-// loudly when any is nil. The admission seam (cfg.Authz) is NOT wired here — it
-// lands in #5438.
+// loudly when any is nil. The admission seam is built here from cfg.Authz (with
+// cfg.ServerName and cfg.PassThroughTools); a nil cfg.Authz yields an allow-all
+// seam.
 func New(cfg *Config) (VMCP, error) {
 	if cfg == nil {
 		return nil, fmt.Errorf("%w: nil core config", vmcp.ErrInvalidConfig)
@@ -103,6 +109,13 @@ func New(cfg *Config) (VMCP, error) {
 	if cfg.Elicitation == nil && workflowsRequireElicitation(cfg.WorkflowDefs) {
 		return nil, fmt.Errorf(
 			"%w: Elicitation is required when a workflow contains an elicitation step", vmcp.ErrInvalidConfig)
+	}
+
+	// Build the admission seam before acquiring resources so a bad policy fails
+	// fast without leaking the state store's cleanup goroutine.
+	admission, err := newAdmission(cfg.Authz, cfg.ServerName, cfg.PassThroughTools)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build admission seam: %w", err)
 	}
 
 	backendClient := cfg.BackendClient
@@ -188,6 +201,7 @@ func New(cfg *Config) (VMCP, error) {
 		backendRegistry: cfg.BackendRegistry,
 		backendClient:   backendClient,
 		health:          cfg.HealthStatusProvider,
+		admission:       admission,
 		workflowDefs:    workflowDefs,
 		composerFactory: composerFactory,
 		stopStore:       stopStore,
@@ -195,42 +209,46 @@ func New(cfg *Config) (VMCP, error) {
 }
 
 // ListTools health-filters the registry, aggregates backend capabilities on
-// demand, and appends the composite tools reachable in the current view.
+// demand, appends the composite tools reachable in the current view, and returns
+// only the subset identity is admitted to call (the admission seam — the same
+// decision CallTool enforces).
 //
-// identity is accepted for the admission seam wired in #5438; this core performs
-// no identity-based filtering yet. A nil identity is treated as anonymous,
-// consistent with session/types.ShouldAllowAnonymous — bound-session caller
-// enforcement (ErrNilCaller/ErrUnauthorizedCaller) lives in the Serve session
-// layer, not here. identity is never logged.
-func (c *coreVMCP) ListTools(ctx context.Context, _ *auth.Identity) ([]vmcp.Tool, error) {
+// A nil identity is treated as anonymous, consistent with
+// session/types.ShouldAllowAnonymous — bound-session caller enforcement
+// (ErrNilCaller/ErrUnauthorizedCaller) lives in the Serve session layer, not
+// here. identity is never logged.
+func (c *coreVMCP) ListTools(ctx context.Context, identity *auth.Identity) ([]vmcp.Tool, error) {
 	agg, err := c.aggregatedView(ctx)
 	if err != nil {
 		return nil, err
 	}
-	return c.advertisedTools(agg), nil
+	return c.admission.FilterTools(ctx, identity, c.advertisedTools(agg))
 }
 
-// ListResources health-filters the registry and aggregates resources on demand.
-func (c *coreVMCP) ListResources(ctx context.Context, _ *auth.Identity) ([]vmcp.Resource, error) {
+// ListResources health-filters the registry, aggregates resources on demand, and
+// returns only those identity is admitted to read.
+func (c *coreVMCP) ListResources(ctx context.Context, identity *auth.Identity) ([]vmcp.Resource, error) {
 	agg, err := c.aggregatedView(ctx)
 	if err != nil {
 		return nil, err
 	}
-	return agg.Resources, nil
+	return c.admission.FilterResources(ctx, identity, agg.Resources)
 }
 
-// ListPrompts health-filters the registry and aggregates prompts on demand.
-func (c *coreVMCP) ListPrompts(ctx context.Context, _ *auth.Identity) ([]vmcp.Prompt, error) {
+// ListPrompts health-filters the registry, aggregates prompts on demand, and
+// returns only those identity is admitted to get.
+func (c *coreVMCP) ListPrompts(ctx context.Context, identity *auth.Identity) ([]vmcp.Prompt, error) {
 	agg, err := c.aggregatedView(ctx)
 	if err != nil {
 		return nil, err
 	}
-	return agg.Prompts, nil
+	return c.admission.FilterPrompts(ctx, identity, agg.Prompts)
 }
 
 // LookupTool resolves an advertised tool name (incl. composite tools) to its
-// capability without invoking it. It applies the same health/advertising view as
-// ListTools and returns vmcp.ErrNotFound for an unknown or unadvertised name.
+// capability without invoking it. It delegates to ListTools, so it applies the
+// same health/advertising AND admission view: a name that is unknown, unadvertised,
+// or denied to identity returns vmcp.ErrNotFound (a denied tool is never resolved).
 func (c *coreVMCP) LookupTool(ctx context.Context, identity *auth.Identity, name string) (*vmcp.Tool, error) {
 	tools, err := c.ListTools(ctx, identity)
 	if err != nil {
@@ -246,7 +264,8 @@ func (c *coreVMCP) LookupTool(ctx context.Context, identity *auth.Identity, name
 }
 
 // LookupResource resolves an advertised resource URI to its capability without
-// reading it. Returns vmcp.ErrNotFound for an unknown or unadvertised URI.
+// reading it. Delegates to ListResources, so a URI that is unknown, unadvertised,
+// or denied to identity returns vmcp.ErrNotFound.
 func (c *coreVMCP) LookupResource(ctx context.Context, identity *auth.Identity, uri string) (*vmcp.Resource, error) {
 	resources, err := c.ListResources(ctx, identity)
 	if err != nil {
@@ -262,7 +281,8 @@ func (c *coreVMCP) LookupResource(ctx context.Context, identity *auth.Identity, 
 }
 
 // LookupPrompt resolves an advertised prompt name to its capability without
-// retrieving it. Returns vmcp.ErrNotFound for an unknown or unadvertised name.
+// retrieving it. Delegates to ListPrompts, so a name that is unknown, unadvertised,
+// or denied to identity returns vmcp.ErrNotFound.
 func (c *coreVMCP) LookupPrompt(ctx context.Context, identity *auth.Identity, name string) (*vmcp.Prompt, error) {
 	prompts, err := c.ListPrompts(ctx, identity)
 	if err != nil {

--- a/pkg/vmcp/core/core_vmcp.go
+++ b/pkg/vmcp/core/core_vmcp.go
@@ -84,8 +84,7 @@ var _ VMCP = (*coreVMCP)(nil)
 // with server.New); the core does not route through it at request time. cfg's
 // Aggregator, BackendRegistry, and BackendClient are required and New fails
 // loudly when any is nil. The admission seam is built here from cfg.Authz (with
-// cfg.ServerName and cfg.PassThroughTools); a nil cfg.Authz yields an allow-all
-// seam.
+// cfg.ServerName); a nil cfg.Authz yields an allow-all seam.
 func New(cfg *Config) (VMCP, error) {
 	if err := validateConfig(cfg); err != nil {
 		return nil, err
@@ -93,7 +92,7 @@ func New(cfg *Config) (VMCP, error) {
 
 	// Build the admission seam before acquiring resources so a bad policy fails
 	// fast without leaking the state store's cleanup goroutine.
-	admission, err := newAdmission(cfg.Authz, cfg.ServerName, cfg.PassThroughTools)
+	admission, err := newAdmission(cfg.Authz, cfg.ServerName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build admission seam: %w", err)
 	}

--- a/pkg/vmcp/server/annotation_enrichment.go
+++ b/pkg/vmcp/server/annotation_enrichment.go
@@ -88,8 +88,15 @@ func findToolAnnotations(toolName string, caps *aggregator.AggregatedCapabilitie
 // convertAnnotations converts vmcp.ToolAnnotations to authorizers.ToolAnnotations.
 // Only authorization-relevant hint fields are mapped; informational fields like
 // Title are intentionally omitted since they are not used in policy evaluation.
-// Returns nil if the source annotations contain no hint fields.
+// Returns nil if the source annotations are nil or contain no hint fields.
+//
+// Kept identical to core.convertAnnotations (pkg/vmcp/core/admission.go), including
+// the nil guard below — the two are intentional, temporary duplicates (the core
+// cannot import this package: server imports core) and #5441 deletes this copy.
 func convertAnnotations(ann *vmcp.ToolAnnotations) *authorizers.ToolAnnotations {
+	if ann == nil {
+		return nil
+	}
 	if ann.ReadOnlyHint == nil && ann.DestructiveHint == nil &&
 		ann.IdempotentHint == nil && ann.OpenWorldHint == nil {
 		return nil


### PR DESCRIPTION
## Summary

Today vMCP authorization runs **only as HTTP middleware** (`AuthzMiddleware` +
`AnnotationEnrichmentMiddleware`), applied on a single request path. Because the
list path and the call path are enforced by separate mechanisms, the policy
model permits a "list says yes / call says no" gap and depends on
annotation-enrichment middleware running first to inject `Tool.Annotations` for
Cedar `when`-clauses. RFC THV-0076 requires `ListTools` and `CallTool` to enforce
the **same** decision from one source.

This PR adds the `Admission` seam — bounded rewrite **R1**, the
highest-regression-risk change in the core refactor — and wires it into the
`VMCP` core implemented in #5437. It re-platforms the existing Cedar decision into
the core without changing the policy model: it wraps the existing
`authorizers.Authorizer` (no new policy language), so `List*` filter and
`Call`/`Read`/`Get` deny on one shared decision, and `Lookup*` never resolve a
denied capability.

- **Why:** close the list/call enforcement gap and give the core a single
  authorization source, unblocking #5441 (which removes the HTTP authz +
  annotation-enrichment middleware in Phase 2).
- **What:** new `Admission` interface + Cedar-backed adapter in
  `pkg/vmcp/core/admission.go`; `New` builds the seam from `cfg.Authz`
  (allow-all when unconfigured) and the core methods consult it.

Closes #5438

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

The shipped `server.New` path is unchanged: the HTTP authz middleware still runs
in Phase 1, so observable behavior is identical. The new core seam is exercised
directly by unit tests and goes live when #5441 retires the middleware.

## Test plan

- [x] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [x] Linting (`task lint-fix`)
- [x] Manual testing (describe below)

Verification performed:

- `go test -race ./pkg/vmcp/core/...` passes (new `admission_test.go` covers all
  R1 acceptance criteria — see Changes below).
- `golangci-lint run ./pkg/vmcp/core/...` reports 0 issues.
- `task build` succeeds.
- Full `task test` passes. The only repo-wide lint failure (gosec G115 in
  `cmd/thv/app/upgrade.go`) is pre-existing and unrelated to this change.

## Changes

| File | Change |
|------|--------|
| `pkg/vmcp/core/admission.go` (new) | `Admission` interface (`FilterTools`/`AllowToolCall`/`FilterResources`/`AllowResourceRead`/`FilterPrompts`/`AllowPromptGet`, domain-typed); `cedarAdmission` adapter wrapping `authorizers.Authorizer`; `allowAllAdmission` no-op; `newAdmission` factory; annotation converter and advertised-tool lookup helpers. |
| `pkg/vmcp/core/core.go` | `Config` gains `ServerName` and `PassThroughTools`; clarified `Authz` doc to describe the allow-all-when-nil parity. |
| `pkg/vmcp/core/core_vmcp.go` | `coreVMCP` gains an `admission` field; `New` builds the seam (before acquiring resources, so a bad policy fails fast without leaking the state-store goroutine); `List*` now filter through the seam and `Lookup*` inherit that view. |
| `pkg/vmcp/core/core_calls.go` | `CallTool`/`ReadResource`/`GetPrompt` consult the seam to deny, returning `vmcp.ErrAuthorizationFailed`; `CallTool` sources the tool's annotations from the advertised set so annotation-gated policies evaluate. |
| `pkg/vmcp/core/admission_test.go` (new) | R1 parity tests: list/call/lookup agree on the same decision; annotation-gated `when`-clauses (`readOnlyHint`); allow-all when unconfigured; `passThroughTools` exempt; identity never logged; correct feature/operation per method; per-tool error skips (log-and-continue); resource/prompt parity; `newAdmission` config validation. |

## Implementation details

- **No new policy model.** The adapter wraps the existing
  `authorizers.Authorizer`, built via the same registry path the HTTP middleware
  uses (`authorizers.GetFactory` + `CreateAuthorizer`). Cedar's `when`-clause and
  feature/operation semantics are unchanged.
- **Identity is explicit, never read from ctx on the public path** (vMCP
  anti-pattern #1). The adapter re-injects identity into the ctx the wrapped
  authorizer reads — an internal adapter detail only.
- **Annotations sourced from the core.** `CallTool` looks up the tool in the
  recomputed advertised set and the adapter injects its annotations via
  `authorizers.WithToolAnnotations`, replacing the annotation-enrichment
  middleware on the domain path. The converter only writes annotation ctx when a
  hint is set (matching the existing `hasAnyHint` gate).
- **Allow-all parity.** A nil `cfg.Authz` yields an `allowAllAdmission`: `Filter*`
  return input unchanged and `Allow*` return `true`, preserving today's
  `AuthzMiddleware != nil` guard.

## Does this introduce a user-facing change?

No. `server.New`'s signature and observable behavior are unchanged; the seam is
not yet on the shipped request path.

## Special notes for reviewers

1. **Deferred to #5441 (security-relevant).** This seam intentionally exempts the
   optimizer meta-tools (`find_tool`/`call_tool`) from its decision, per AC R1(4).
   It does **not** replicate the HTTP middleware's `call_tool` inner-tool
   authorization (`handleToolsCall` re-authorizes the wrapped inner tool). This is
   harmless today because the optimizer decorator calls the backend handler
   directly and never routes an unwrapped inner name through `core.CallTool`.
   **#5441 (which removes the HTTP authz middleware) MUST carry an explicit
   acceptance criterion** that the inner `call_tool` target is authorized through
   `Admission.AllowToolCall` with the real tool name, with a test for a
   `call_tool`-wrapped denied tool. This is documented in `admission.go`'s
   `AllowToolCall` comment.

2. **Follow-up for #5441.** Two authorizer-construction paths (core `newAdmission`
   vs the live `newCedarAuthzMiddleware`) now both carry the empty-`ServerName`
   check; consolidate them into one shared constructor when #5441 collapses the
   middleware.

3. **PR sizing.** Production (non-test) change is ~436 net lines (489 added / 53
   removed) across 4 files (within the ≤10-file cap) — modestly over the 400-line
   guideline. The overage is reviewer-requested documentation comments and a small
   `validateConfig` extraction added to keep `New` under the gocyclo limit after
   rebasing onto the merged #5437. Tests (~790 lines, the majority of the diff) are
   excluded from the cap. Kept as one PR because the interface + adapter + wiring are
   one cohesive change; see the Large PR Justification section below.

4. **File location.** The issue text referenced `pkg/vmcp/admission.go`, but the
   core moved to its own `pkg/vmcp/core` package in #5437; the seam lives at
   `pkg/vmcp/core/admission.go` because the Cedar adapter imports `pkg/authz`,
   which would create an import cycle with the root `pkg/vmcp` package.

No separate AI-generated plan document exists for this change — the issue's own
"Technical Approach" served as the plan, so the optional implementation-plan
section is omitted.

## Large PR Justification

The total diff (~1280 insertions) exceeds the 1000-line threshold, but this is a
single, cohesive, bounded change — the R1 core admission seam (#5438): the `Admission`
interface, its Cedar-backed adapter, and the core wire-in (`List*` filter,
`Call`/`Read`/`Get` deny, `Lookup*`). The issue explicitly scoped it as one PR and
flagged the size as "borderline".

- **The majority (~790 lines) is the new test file** `pkg/vmcp/core/admission_test.go`,
  covering the R1.1–R1.5 security-parity matrix (list/call enforce the same decision,
  annotation-gated policies, allow-all parity, pass-through exemption, identity never
  logged) plus construction, error-classification, and args-flow cases. Tests are
  excluded from the project's 400-line production cap.
- **Production code is ~436 net lines across 4 files** (within the ≤10-file cap),
  modestly over the 400-line guideline; the overage is reviewer-requested doc comments
  and a small `validateConfig` extraction (to keep `New` under the gocyclo limit after
  rebasing onto the merged #5437).
- **Splitting is not warranted:** the interface, adapter, and wire-in are one bounded
  contract that reviews more clearly together than in fragments, and the PR has already
  completed two human/multi-agent review rounds.

Generated with [Claude Code](https://claude.com/claude-code)

