### PR TITLE
Prevent path traversal in LocalStore.getFilePath

### DIFF
--- a/pkg/state/local.go
+++ b/pkg/state/local.go
@@ -52,20 +52,28 @@ func NewLocalStore(appName string, storeName string) (*LocalStore, error) {
 	}, nil
 }
 
-// getFilePath returns the full file path for a configuration
-func (s *LocalStore) getFilePath(name string) string {
-	// Ensure the name has the correct extension
+// getFilePath returns the full file path for a configuration, validating that
+// the resolved path stays within the store's base directory.
+func (s *LocalStore) getFilePath(name string) (string, error) {
 	if !strings.HasSuffix(name, FileExtension) {
 		name = name + FileExtension
 	}
-	return filepath.Join(s.basePath, name)
+	filePath := filepath.Join(s.basePath, name)
+	// filepath.Join calls filepath.Clean, which resolves ".." components.
+	// Verify the result is still within basePath to prevent path traversal.
+	if !strings.HasPrefix(filePath, s.basePath+string(filepath.Separator)) {
+		return "", fmt.Errorf("path traversal detected: name escapes state directory")
+	}
+	return filePath, nil
 }
 
 // GetReader returns a reader for the state data
 func (s *LocalStore) GetReader(_ context.Context, name string) (io.ReadCloser, error) {
-	// Open the file
-	filePath := s.getFilePath(name)
-	// #nosec G304 - filePath is controlled by getFilePath which ensures it's within our designated directory
+	filePath, err := s.getFilePath(name)
+	if err != nil {
+		return nil, err
+	}
+	// #nosec G304 - path traversal is prevented by the containment check in getFilePath
 	file, err := os.Open(filePath)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -79,9 +87,11 @@ func (s *LocalStore) GetReader(_ context.Context, name string) (io.ReadCloser, e
 
 // GetWriter returns a writer for the state data
 func (s *LocalStore) GetWriter(_ context.Context, name string) (io.WriteCloser, error) {
-	// Create the file
-	filePath := s.getFilePath(name)
-	// #nosec G304 - filePath is controlled by getFilePath which ensures it's within our designated directory
+	filePath, err := s.getFilePath(name)
+	if err != nil {
+		return nil, err
+	}
+	// #nosec G304 - path traversal is prevented by the containment check in getFilePath
 	file, err := os.OpenFile(filePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create file: %w", err)
@@ -93,9 +103,12 @@ func (s *LocalStore) GetWriter(_ context.Context, name string) (io.WriteCloser, 
 // CreateExclusive creates a new state entry exclusively, failing if it already exists.
 // This provides atomic check-and-create semantics using O_EXCL to prevent race conditions.
 func (s *LocalStore) CreateExclusive(_ context.Context, name string) (io.WriteCloser, error) {
-	filePath := s.getFilePath(name)
-	// O_EXCL with O_CREATE provides atomic check-and-create behavior
-	// #nosec G304 - filePath is controlled by getFilePath which ensures it's within our designated directory
+	filePath, err := s.getFilePath(name)
+	if err != nil {
+		return nil, err
+	}
+	// O_EXCL with O_CREATE provides atomic check-and-create behavior.
+	// #nosec G304 - path traversal is prevented by the containment check in getFilePath
 	file, err := os.OpenFile(filePath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
 	if err != nil {
 		if os.IsExist(err) {
@@ -112,8 +125,10 @@ func (s *LocalStore) CreateExclusive(_ context.Context, name string) (io.WriteCl
 
 // Delete removes the data for the given name
 func (s *LocalStore) Delete(_ context.Context, name string) error {
-	filePath := s.getFilePath(name)
-	// #nosec G304 - filePath is controlled by getFilePath which ensures it's within our designated directory
+	filePath, err := s.getFilePath(name)
+	if err != nil {
+		return err
+	}
 	if err := os.Remove(filePath); err != nil {
 		if os.IsNotExist(err) {
 			return fmt.Errorf("state '%s' not found", name)
@@ -154,8 +169,11 @@ func (s *LocalStore) List(_ context.Context) ([]string, error) {
 
 // Exists checks if data exists for the given name
 func (s *LocalStore) Exists(_ context.Context, name string) (bool, error) {
-	filePath := s.getFilePath(name)
-	_, err := os.Stat(filePath)
+	filePath, err := s.getFilePath(name)
+	if err != nil {
+		return false, err
+	}
+	_, err = os.Stat(filePath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return false, nil

--- a/pkg/state/local_test.go
+++ b/pkg/state/local_test.go
@@ -1,0 +1,114 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package state
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestLocalStore creates a LocalStore rooted at a temp directory for testing.
+func newTestLocalStore(t *testing.T) *LocalStore {
+	t.Helper()
+	dir := t.TempDir()
+	return &LocalStore{basePath: dir}
+}
+
+func TestLocalStore_PathTraversalPrevented(t *testing.T) {
+	t.Parallel()
+
+	traversalNames := []string{
+		"../escape",
+		"../../etc/passwd",
+		"../../../root/.ssh/authorized_keys",
+		"./../escape",
+		"subdir/../../escape",
+	}
+
+	for _, name := range traversalNames {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			store := newTestLocalStore(t)
+
+			_, err := store.GetReader(ctx, name)
+			assert.ErrorContains(t, err, "path traversal detected", "GetReader should reject %q", name)
+
+			_, err = store.GetWriter(ctx, name)
+			assert.ErrorContains(t, err, "path traversal detected", "GetWriter should reject %q", name)
+
+			_, err = store.CreateExclusive(ctx, name)
+			assert.ErrorContains(t, err, "path traversal detected", "CreateExclusive should reject %q", name)
+
+			err = store.Delete(ctx, name)
+			assert.ErrorContains(t, err, "path traversal detected", "Delete should reject %q", name)
+
+			_, err = store.Exists(ctx, name)
+			assert.ErrorContains(t, err, "path traversal detected", "Exists should reject %q", name)
+		})
+	}
+}
+
+func TestLocalStore_ValidNamesWork(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := newTestLocalStore(t)
+
+	// Write via CreateExclusive
+	w, err := store.CreateExclusive(ctx, "mystate")
+	require.NoError(t, err)
+	_, err = w.Write([]byte(`{"key":"value"}`))
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+
+	// File should exist inside basePath
+	exists, err := store.Exists(ctx, "mystate")
+	require.NoError(t, err)
+	assert.True(t, exists)
+
+	// Read it back
+	r, err := store.GetReader(ctx, "mystate")
+	require.NoError(t, err)
+	require.NoError(t, r.Close())
+
+	// List should return it
+	names, err := store.List(ctx)
+	require.NoError(t, err)
+	assert.Contains(t, names, "mystate")
+
+	// Delete it
+	require.NoError(t, store.Delete(ctx, "mystate"))
+	exists, err = store.Exists(ctx, "mystate")
+	require.NoError(t, err)
+	assert.False(t, exists)
+}
+
+func TestLocalStore_FileStaysInsideBasePath(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := newTestLocalStore(t)
+
+	w, err := store.GetWriter(ctx, "config")
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+
+	// The written file must be inside the base directory
+	entries, err := os.ReadDir(store.basePath)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "config"+FileExtension, entries[0].Name())
+
+	// Absolute path of the file must start with basePath
+	absPath := filepath.Join(store.basePath, entries[0].Name())
+	assert.True(t, filepath.IsAbs(absPath))
+	assert.Contains(t, absPath, store.basePath)
+}


### PR DESCRIPTION
## Summary

- `LocalStore.getFilePath` used `filepath.Join` to build file paths but never verified the result stayed within `basePath`. A name like `../../../etc/passwd` would escape the state directory, making `GetReader`, `GetWriter`, `CreateExclusive`, `Delete`, and `Exists` all vulnerable to path traversal
- Add a containment check after `filepath.Join` (which calls `filepath.Clean` to resolve `..` components) using the `strings.HasPrefix(path, basePath+separator)` pattern already established in `pkg/fileutils/contained.go`
- Change `getFilePath` to return `(string, error)` so callers can propagate the error
- Update the `#nosec G304` comments to accurately reflect that containment is now actually enforced
- Add `local_test.go` with tests covering path traversal rejection across all five affected methods, normal operations, and a check that written files stay inside `basePath`

Fixes #4736

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)

New test `TestLocalStore_PathTraversalPrevented` exercises five traversal patterns (`../escape`, `../../etc/passwd`, `../../../root/.ssh/authorized_keys`, `./../escape`, `subdir/../../escape`) against all five public methods and asserts each returns a "path traversal detected" error.