### PR TITLE
Add vMCP Serve skeleton and ServerConfig

### DIFF
--- a/pkg/vmcp/server/serve.go
+++ b/pkg/vmcp/server/serve.go
@@ -112,16 +112,16 @@ type ServerConfig struct {
 	AuditConfig *audit.Config
 }
 
-// Serve builds the mcp-go server and HTTP transport skeleton around an
-// already-constructed core [core.VMCP], returning the existing *Server.
+// Serve is the transport-side entry point of the New/Serve split: it wraps an
+// already-constructed core [core.VMCP] and returns the existing *Server.
 //
-// This is the transport-side entry point of the New/Serve split. At this phase it
-// performs only the self-contained transport construction: applying the transport
-// defaults (mirroring server.New), building the mcp-go server, and wiring the core's
-// Close into the server's shutdown sequence. The route mux and HTTP lifecycle are
-// provided by the carried-forward (*Server).Handler/Start/Stop, which register the
-// unauthenticated routes (/health, /ping, /readyz, /status, /api/backends/health,
-// the metrics and .well-known endpoints, and any embedded auth-server routes).
+// At this phase Serve constructs only the self-contained transport pieces: it
+// applies the transport defaults (mirroring server.New), builds the mcp-go server,
+// and wires the core's Close into the server's shutdown sequence. It does NOT build
+// the route mux or the HTTP lifecycle here — those remain in the carried-forward
+// (*Server).Handler/Start/Stop, which register the unauthenticated routes (/health,
+// /ping, /readyz, /status, /api/backends/health, the metrics and .well-known
+// endpoints, and any embedded auth-server routes) when Serve's *Server is served.
 //
 // The remaining transport concerns — the SDK session hooks and two-phase session
 // creation, the authenticated middleware chain, the direct VMCP request path, and
@@ -181,6 +181,14 @@ func Serve(_ context.Context, v core.VMCP, cfg *ServerConfig) (*Server, error) {
 // defaults server.New applies today. Defaults are applied here rather than by
 // mutating the caller's ServerConfig (go-style: copy before mutating caller input).
 // Port 0 is left untouched to mean "OS-assigned".
+//
+// Two Config fields are deliberately NOT mapped at this phase (see
+// TestBuildServeConfigMapsSharedFields, which guards this list against drift):
+//   - AuthzMiddleware: the authenticated/authz middleware chain is relocated under
+//     Serve by #5441, after which authorization moves to the core admission seam.
+//   - HealthMonitorConfig: Serve receives the already-built *health.Monitor via
+//     ServerConfig.HealthMonitor (A2) and assigns it to the Server directly, so it
+//     never needs the monitor's construction config.
 func buildServeConfig(cfg *ServerConfig) *Config {
 	return &Config{
 		Name:                    cmp.Or(cfg.Name, "toolhive-vmcp"),

--- a/pkg/vmcp/server/serve.go
+++ b/pkg/vmcp/server/serve.go
@@ -133,6 +133,12 @@ type ServerConfig struct {
 // Serve returns a vmcp.ErrInvalidConfig-wrapped error for a nil cfg, a nil core, or
 // a nil required collaborator (SessionFactory). The ctx parameter is reserved for
 // the transport wiring relocated by later phases.
+//
+// Contract: the returned *Server has nil session manager, discovery manager, and
+// backend registry at this phase. It must NOT be Start()ed or served on the "/" MCP
+// route until #5440/#5441/#5442 wire those fields — the carried-forward Handler
+// passes them to WithSessionIdManager and discovery.Middleware, which would nil-deref.
+// The unauthenticated routes (registered as direct mux entries) are safe to serve.
 func Serve(_ context.Context, v core.VMCP, cfg *ServerConfig) (*Server, error) {
 	if cfg == nil {
 		return nil, fmt.Errorf("%w: nil server config", vmcp.ErrInvalidConfig)
@@ -182,21 +188,24 @@ func Serve(_ context.Context, v core.VMCP, cfg *ServerConfig) (*Server, error) {
 // mutating the caller's ServerConfig (go-style: copy before mutating caller input).
 // Port 0 is left untouched to mean "OS-assigned".
 //
-// Two Config fields are deliberately NOT mapped at this phase (see
+// Three Config fields are deliberately NOT mapped at this phase (see
 // TestBuildServeConfigMapsSharedFields, which guards this list against drift):
 //   - AuthzMiddleware: the authenticated/authz middleware chain is relocated under
 //     Serve by #5441, after which authorization moves to the core admission seam.
 //   - HealthMonitorConfig: Serve receives the already-built *health.Monitor via
 //     ServerConfig.HealthMonitor (A2) and assigns it to the Server directly, so it
 //     never needs the monitor's construction config.
+//   - StatusReporter: Serve assigns ServerConfig.StatusReporter to the Server field
+//     directly (like HealthMonitor); nothing reads Config.StatusReporter on the Serve
+//     path, so mapping it here would be dead.
 func buildServeConfig(cfg *ServerConfig) *Config {
 	return &Config{
-		Name:                    cmp.Or(cfg.Name, "toolhive-vmcp"),
-		Version:                 cmp.Or(cfg.Version, "0.1.0"),
+		Name:                    cmp.Or(cfg.Name, defaultServerName),
+		Version:                 cmp.Or(cfg.Version, defaultServerVersion),
 		GroupRef:                cfg.GroupRef,
-		Host:                    cmp.Or(cfg.Host, "127.0.0.1"),
+		Host:                    cmp.Or(cfg.Host, defaultHost),
 		Port:                    cfg.Port,
-		EndpointPath:            cmp.Or(cfg.EndpointPath, "/mcp"),
+		EndpointPath:            cmp.Or(cfg.EndpointPath, defaultEndpointPath),
 		SessionTTL:              cmp.Or(cfg.SessionTTL, defaultSessionTTL),
 		AuthMiddleware:          cfg.AuthMiddleware,
 		AuthInfoHandler:         cfg.AuthInfoHandler,
@@ -207,7 +216,6 @@ func buildServeConfig(cfg *ServerConfig) *Config {
 		Watcher:                 cfg.Watcher,
 		OptimizerFactory:        cfg.OptimizerFactory,
 		OptimizerConfig:         cfg.OptimizerConfig,
-		StatusReporter:          cfg.StatusReporter,
 		SessionFactory:          cfg.SessionFactory,
 		SessionStorage:          cfg.SessionStorage,
 	}

--- a/pkg/vmcp/server/serve.go
+++ b/pkg/vmcp/server/serve.go
@@ -1,0 +1,206 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package server
+
+import (
+	"cmp"
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/mark3labs/mcp-go/server"
+
+	"github.com/stacklok/toolhive/pkg/audit"
+	asrunner "github.com/stacklok/toolhive/pkg/authserver/runner"
+	"github.com/stacklok/toolhive/pkg/telemetry"
+	"github.com/stacklok/toolhive/pkg/vmcp"
+	vmcpconfig "github.com/stacklok/toolhive/pkg/vmcp/config"
+	"github.com/stacklok/toolhive/pkg/vmcp/core"
+	"github.com/stacklok/toolhive/pkg/vmcp/health"
+	"github.com/stacklok/toolhive/pkg/vmcp/optimizer"
+	vmcpsession "github.com/stacklok/toolhive/pkg/vmcp/session"
+	vmcpstatus "github.com/stacklok/toolhive/pkg/vmcp/status"
+)
+
+// ServerConfig holds the transport-only runtime configuration for Serve.
+//
+// It carries the subset of the legacy server.Config that configures the HTTP/SDK
+// runtime, plus the cross-cutting TelemetryProvider/AuditConfig that are consumed
+// by both the core (core.New) and the transport (Serve) — not a clean partition.
+// The fields the core owns (Aggregator, Router, BackendRegistry, BackendClient,
+// WorkflowDefs, Authz) live on core.Config instead and are absent here.
+//
+// The name intentionally stutters as server.ServerConfig: it is mandated by the
+// New/Serve split, and the package's existing Config is the legacy transport
+// config being decomposed, so it cannot be reused for this transport-only type.
+//
+//nolint:revive // exported-stutter is intentional; see the doc comment above.
+type ServerConfig struct {
+	// Name and Version are exposed in the MCP protocol via the mcp-go server.
+	Name    string
+	Version string
+
+	// GroupRef is the name of the MCPGroup containing backend workloads, used for
+	// operational visibility in the status endpoint and logging.
+	GroupRef string
+
+	// Host is the bind address (default: "127.0.0.1").
+	Host string
+
+	// Port is the bind port. A zero value means "let the OS assign a random port".
+	Port int
+
+	// EndpointPath is the MCP endpoint path (default: "/mcp").
+	EndpointPath string
+
+	// SessionTTL is the session time-to-live duration (default: 30 minutes).
+	SessionTTL time.Duration
+
+	// AuthMiddleware is the optional authentication middleware applied to MCP routes.
+	// If nil, no authentication is required.
+	AuthMiddleware func(http.Handler) http.Handler
+
+	// AuthInfoHandler is the optional handler for the
+	// /.well-known/oauth-protected-resource endpoint.
+	AuthInfoHandler http.Handler
+
+	// AuthServer is the optional embedded authorization server. When non-nil, its
+	// routes are registered on the mux alongside the protected resource metadata.
+	AuthServer *asrunner.EmbeddedAuthServer
+
+	// HealthMonitor is the already-built backend health monitor (constructed at the
+	// composition root so the same instance's StatusProvider can be injected into the
+	// core). Serve owns only its Start/Stop lifecycle. Nil disables health monitoring.
+	HealthMonitor *health.Monitor
+
+	// StatusReportingInterval is the interval for reporting status updates.
+	// If zero, the default reporting interval is used.
+	StatusReportingInterval time.Duration
+
+	// StatusReporter enables the vMCP runtime to report operational status.
+	// If nil, status reporting is disabled.
+	StatusReporter vmcpstatus.Reporter
+
+	// Watcher is the optional Kubernetes backend watcher for dynamic mode, used by
+	// the /readyz endpoint to gate readiness on cache sync.
+	Watcher Watcher
+
+	// SessionFactory creates MultiSessions for session management. Required; Serve
+	// returns an error when it is nil.
+	SessionFactory vmcpsession.MultiSessionFactory
+
+	// SessionStorage configures the session storage backend. When nil or provider is
+	// "memory", local in-process storage is used.
+	SessionStorage *vmcpconfig.SessionStorageConfig
+
+	// OptimizerFactory builds an optimizer from a list of tools. If nil, the
+	// optimizer is disabled.
+	OptimizerFactory func(context.Context, []server.ServerTool) (optimizer.Optimizer, error)
+
+	// OptimizerConfig holds the parsed optimizer search parameters. A nil value
+	// disables the optimizer.
+	OptimizerConfig *optimizer.Config
+
+	// TelemetryProvider is the cross-cutting telemetry provider (also consumed by
+	// core.New). If nil, no telemetry is recorded.
+	TelemetryProvider *telemetry.Provider
+
+	// AuditConfig is the cross-cutting audit configuration (also consumed by
+	// core.New). If nil, no audit logging is performed.
+	AuditConfig *audit.Config
+}
+
+// Serve builds the mcp-go server and HTTP transport skeleton around an
+// already-constructed core [core.VMCP], returning the existing *Server.
+//
+// This is the transport-side entry point of the New/Serve split. At this phase it
+// performs only the self-contained transport construction: applying the transport
+// defaults (mirroring server.New), building the mcp-go server, and wiring the core's
+// Close into the server's shutdown sequence. The route mux and HTTP lifecycle are
+// provided by the carried-forward (*Server).Handler/Start/Stop, which register the
+// unauthenticated routes (/health, /ping, /readyz, /status, /api/backends/health,
+// the metrics and .well-known endpoints, and any embedded auth-server routes).
+//
+// The remaining transport concerns — the SDK session hooks and two-phase session
+// creation, the authenticated middleware chain, the direct VMCP request path, and
+// the AS runner / status reporter / optimizer / health monitor lifecycle — are
+// relocated under Serve by the subsequent Phase 2 tasks. server.New is not yet
+// routed through Serve, so this is purely additive and observable behavior is
+// unchanged.
+//
+// Serve returns a vmcp.ErrInvalidConfig-wrapped error for a nil cfg, a nil core, or
+// a nil required collaborator (SessionFactory). The ctx parameter is reserved for
+// the transport wiring relocated by later phases.
+func Serve(_ context.Context, v core.VMCP, cfg *ServerConfig) (*Server, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("%w: nil server config", vmcp.ErrInvalidConfig)
+	}
+	if v == nil {
+		return nil, fmt.Errorf("%w: VMCP is required", vmcp.ErrInvalidConfig)
+	}
+	if cfg.SessionFactory == nil {
+		return nil, fmt.Errorf("%w: SessionFactory is required", vmcp.ErrInvalidConfig)
+	}
+
+	serveCfg := buildServeConfig(cfg)
+
+	// Build the mcp-go server (mirrors server.New): tools and resources are
+	// registered dynamically, so capabilities start disabled. Hooks are empty for
+	// now; the session hooks are relocated here by a later Phase 2 task.
+	mcpServer := server.NewMCPServer(
+		serveCfg.Name,
+		serveCfg.Version,
+		server.WithToolCapabilities(false),
+		server.WithResourceCapabilities(false, false),
+		server.WithLogging(),
+		server.WithHooks(&server.Hooks{}),
+	)
+
+	srv := &Server{
+		config:         serveCfg,
+		mcpServer:      mcpServer,
+		ready:          make(chan struct{}),
+		healthMonitor:  cfg.HealthMonitor,
+		statusReporter: cfg.StatusReporter,
+	}
+
+	// Serve owns the injected core's lifecycle: release its backend connections
+	// when the server stops. core.VMCP.Close is idempotent, so this is safe even
+	// if Stop runs before Start.
+	srv.shutdownFuncs = append(srv.shutdownFuncs, func(context.Context) error {
+		return v.Close()
+	})
+
+	return srv, nil
+}
+
+// buildServeConfig maps the transport-only ServerConfig onto the existing *Config
+// the carried-forward (*Server) methods read from, applying the same transport
+// defaults server.New applies today. Defaults are applied here rather than by
+// mutating the caller's ServerConfig (go-style: copy before mutating caller input).
+// Port 0 is left untouched to mean "OS-assigned".
+func buildServeConfig(cfg *ServerConfig) *Config {
+	return &Config{
+		Name:                    cmp.Or(cfg.Name, "toolhive-vmcp"),
+		Version:                 cmp.Or(cfg.Version, "0.1.0"),
+		GroupRef:                cfg.GroupRef,
+		Host:                    cmp.Or(cfg.Host, "127.0.0.1"),
+		Port:                    cfg.Port,
+		EndpointPath:            cmp.Or(cfg.EndpointPath, "/mcp"),
+		SessionTTL:              cmp.Or(cfg.SessionTTL, defaultSessionTTL),
+		AuthMiddleware:          cfg.AuthMiddleware,
+		AuthInfoHandler:         cfg.AuthInfoHandler,
+		AuthServer:              cfg.AuthServer,
+		TelemetryProvider:       cfg.TelemetryProvider,
+		AuditConfig:             cfg.AuditConfig,
+		StatusReportingInterval: cfg.StatusReportingInterval,
+		Watcher:                 cfg.Watcher,
+		OptimizerFactory:        cfg.OptimizerFactory,
+		OptimizerConfig:         cfg.OptimizerConfig,
+		StatusReporter:          cfg.StatusReporter,
+		SessionFactory:          cfg.SessionFactory,
+		SessionStorage:          cfg.SessionStorage,
+	}
+}

--- a/pkg/vmcp/server/serve_test.go
+++ b/pkg/vmcp/server/serve_test.go
@@ -7,14 +7,23 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"testing"
+	"time"
 
+	"github.com/mark3labs/mcp-go/server"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/stacklok/toolhive/pkg/audit"
 	"github.com/stacklok/toolhive/pkg/auth"
+	asrunner "github.com/stacklok/toolhive/pkg/authserver/runner"
+	"github.com/stacklok/toolhive/pkg/telemetry"
 	"github.com/stacklok/toolhive/pkg/vmcp"
+	vmcpconfig "github.com/stacklok/toolhive/pkg/vmcp/config"
 	"github.com/stacklok/toolhive/pkg/vmcp/core"
+	"github.com/stacklok/toolhive/pkg/vmcp/health"
+	"github.com/stacklok/toolhive/pkg/vmcp/optimizer"
 )
 
 // stubVMCP is a no-op core.VMCP for Serve tests. The Serve skeleton never invokes
@@ -54,6 +63,20 @@ func (*stubVMCP) LookupPrompt(context.Context, *auth.Identity, string) (*vmcp.Pr
 	return nil, nil
 }
 func (s *stubVMCP) Close() error { s.closed = true; return nil }
+
+// stubWatcher is a non-nil Watcher for the drift-guard test; its behavior is not
+// exercised there.
+type stubWatcher struct{}
+
+func (stubWatcher) WaitForCacheSync(context.Context) bool { return true }
+
+// stubServeReporter is a non-nil vmcpstatus.Reporter for the drift-guard test.
+type stubServeReporter struct{}
+
+func (stubServeReporter) ReportStatus(context.Context, *vmcp.Status) error { return nil }
+func (stubServeReporter) Start(context.Context) (func(context.Context) error, error) {
+	return func(context.Context) error { return nil }, nil
+}
 
 func TestServeAppliesTransportDefaults(t *testing.T) {
 	t.Parallel()
@@ -180,5 +203,57 @@ func TestServeValidation(t *testing.T) {
 			assert.ErrorIs(t, err, vmcp.ErrInvalidConfig)
 			assert.Nil(t, srv)
 		})
+	}
+}
+
+// TestBuildServeConfigMapsSharedFields guards the ServerConfig -> Config mapping
+// against silent drift: every Config field except the documented intentionally-
+// unmapped set must be populated by buildServeConfig. If a future field is added to
+// Config and forgotten in buildServeConfig, this test fails (the field is zero).
+// When a field is deliberately not mapped, add it to intentionallyUnmapped with a
+// reason, mirroring the buildServeConfig doc comment.
+func TestBuildServeConfigMapsSharedFields(t *testing.T) {
+	t.Parallel()
+
+	intentionallyUnmapped := map[string]struct{}{
+		"AuthzMiddleware":     {}, // authenticated/authz chain relocated by #5441
+		"HealthMonitorConfig": {}, // monitor injected pre-built via ServerConfig.HealthMonitor (A2)
+	}
+
+	// Every field set to a non-zero value so a dropped mapping surfaces as a zero
+	// field on the resulting Config.
+	src := &ServerConfig{
+		Name:                    "n",
+		Version:                 "v",
+		GroupRef:                "g",
+		Host:                    "h",
+		Port:                    1,
+		EndpointPath:            "/e",
+		SessionTTL:              time.Second,
+		AuthMiddleware:          func(h http.Handler) http.Handler { return h },
+		AuthInfoHandler:         http.NewServeMux(),
+		AuthServer:              &asrunner.EmbeddedAuthServer{},
+		HealthMonitor:           &health.Monitor{},
+		StatusReportingInterval: time.Second,
+		StatusReporter:          stubServeReporter{},
+		Watcher:                 stubWatcher{},
+		SessionFactory:          testMinimalFactory(),
+		SessionStorage:          &vmcpconfig.SessionStorageConfig{},
+		OptimizerFactory: func(context.Context, []server.ServerTool) (optimizer.Optimizer, error) {
+			return nil, nil
+		},
+		OptimizerConfig:   &optimizer.Config{},
+		TelemetryProvider: &telemetry.Provider{},
+		AuditConfig:       &audit.Config{},
+	}
+
+	got := reflect.ValueOf(*buildServeConfig(src))
+	gotType := got.Type()
+	for i := range gotType.NumField() {
+		name := gotType.Field(i).Name
+		if _, skip := intentionallyUnmapped[name]; skip {
+			continue
+		}
+		assert.Falsef(t, got.Field(i).IsZero(), "Config.%s was not populated by buildServeConfig", name)
 	}
 }

--- a/pkg/vmcp/server/serve_test.go
+++ b/pkg/vmcp/server/serve_test.go
@@ -90,31 +90,37 @@ func TestServeAppliesTransportDefaults(t *testing.T) {
 	require.NotNil(t, srv.MCPServer())
 
 	// Defaults mirror server.New and are applied to the server's own config,
-	// leaving the caller's ServerConfig untouched.
-	assert.Equal(t, "toolhive-vmcp", srv.config.Name)
-	assert.Equal(t, "0.1.0", srv.config.Version)
-	assert.Equal(t, "127.0.0.1", srv.config.Host)
-	assert.Equal(t, "/mcp", srv.config.EndpointPath)
+	// leaving the caller's ServerConfig untouched. Asserting against the shared
+	// consts (not literals) keeps this test from being a third copy that can drift.
+	assert.Equal(t, defaultServerName, srv.config.Name)
+	assert.Equal(t, defaultServerVersion, srv.config.Version)
+	assert.Equal(t, defaultHost, srv.config.Host)
+	assert.Equal(t, defaultEndpointPath, srv.config.EndpointPath)
 	assert.Equal(t, defaultSessionTTL, srv.config.SessionTTL)
 	assert.Equal(t, 0, srv.config.Port) // Port 0 => OS-assigned
 
 	assert.Empty(t, cfg.Host, "caller config must not be mutated")
 
 	// Address reflects the defaulted host and unassigned port (no listener yet).
-	assert.Equal(t, "127.0.0.1:0", srv.Address())
+	assert.Equal(t, defaultHost+":0", srv.Address())
 }
 
 func TestServePreservesExplicitConfig(t *testing.T) {
 	t.Parallel()
 
+	// Distinct values per scalar field so a wrong-source mapping (e.g. Host:
+	// cfg.GroupRef) is caught here — this test carries value-correctness for the
+	// pass-through scalars that the presence-only drift guard cannot.
 	cfg := &ServerConfig{
-		Name:           "custom",
-		Version:        "9.9.9",
-		Host:           "0.0.0.0",
-		Port:           8080,
-		EndpointPath:   "/rpc",
-		GroupRef:       "my-group",
-		SessionFactory: testMinimalFactory(),
+		Name:                    "custom",
+		Version:                 "9.9.9",
+		Host:                    "0.0.0.0",
+		Port:                    8080,
+		EndpointPath:            "/rpc",
+		GroupRef:                "my-group",
+		SessionTTL:              7 * time.Minute,
+		StatusReportingInterval: 11 * time.Second,
+		SessionFactory:          testMinimalFactory(),
 	}
 
 	srv, err := Serve(context.Background(), &stubVMCP{}, cfg)
@@ -126,6 +132,8 @@ func TestServePreservesExplicitConfig(t *testing.T) {
 	assert.Equal(t, 8080, srv.config.Port)
 	assert.Equal(t, "/rpc", srv.config.EndpointPath)
 	assert.Equal(t, "my-group", srv.config.GroupRef)
+	assert.Equal(t, 7*time.Minute, srv.config.SessionTTL)
+	assert.Equal(t, 11*time.Second, srv.config.StatusReportingInterval)
 }
 
 func TestServeHandlerRegistersUnauthenticatedRoutes(t *testing.T) {
@@ -138,8 +146,9 @@ func TestServeHandlerRegistersUnauthenticatedRoutes(t *testing.T) {
 	handler, err := srv.Handler(context.Background())
 	require.NoError(t, err)
 
-	// The unauthenticated routes are direct mux entries and respond without the
-	// not-yet-relocated authenticated MCP chain or its dependencies.
+	// These routes are registered as direct mux entries, so they bypass the
+	// authenticated middleware chain that Handler still builds and mounts at "/"
+	// (the chain itself is relocated under Serve by a later phase).
 	for _, path := range []string{"/health", "/ping", "/readyz", "/status", "/api/backends/health"} {
 		req := httptest.NewRequest(http.MethodGet, path, nil)
 		rec := httptest.NewRecorder()
@@ -147,13 +156,48 @@ func TestServeHandlerRegistersUnauthenticatedRoutes(t *testing.T) {
 		assert.Equalf(t, http.StatusOK, rec.Code, "route %s", path)
 	}
 
+	// .well-known is always registered; with no AuthInfoHandler it returns a clean
+	// JSON 404, distinct from the catch-all MCP handler's 406 on a bare GET.
+	req := httptest.NewRequest(http.MethodGet, "/.well-known/oauth-protected-resource", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Header().Get("Content-Type"), "application/json")
+
 	// /metrics is only registered when a telemetry provider with a Prometheus
 	// handler is configured; absent here the request falls through to the catch-all
 	// MCP handler and must not return 200.
+	req = httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	assert.NotEqual(t, http.StatusOK, rec.Code)
+}
+
+func TestServeHandlerRegistersMetricsWhenTelemetryEnabled(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	provider, err := telemetry.NewProvider(ctx, telemetry.Config{
+		ServiceName:                 "vmcp-serve-test",
+		ServiceVersion:              "0.0.0",
+		EnablePrometheusMetricsPath: true,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = provider.Shutdown(ctx) })
+
+	srv, err := Serve(ctx, &stubVMCP{}, &ServerConfig{
+		SessionFactory:    testMinimalFactory(),
+		TelemetryProvider: provider,
+	})
+	require.NoError(t, err)
+
+	handler, err := srv.Handler(ctx)
+	require.NoError(t, err)
+
 	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
-	assert.NotEqual(t, http.StatusOK, rec.Code)
+	assert.Equal(t, http.StatusOK, rec.Code)
 }
 
 func TestServeStopClosesCore(t *testing.T) {
@@ -192,6 +236,13 @@ func TestServeValidation(t *testing.T) {
 			v:    &stubVMCP{},
 			cfg:  &ServerConfig{},
 		},
+		{
+			// Both nil: cfg is checked first, so this must fail cleanly (no panic
+			// from dereferencing the nil cfg) rather than depending on check order.
+			name: "nil config and nil vmcp",
+			v:    nil,
+			cfg:  nil,
+		},
 	}
 
 	for _, tc := range tests {
@@ -212,12 +263,18 @@ func TestServeValidation(t *testing.T) {
 // Config and forgotten in buildServeConfig, this test fails (the field is zero).
 // When a field is deliberately not mapped, add it to intentionallyUnmapped with a
 // reason, mirroring the buildServeConfig doc comment.
+//
+// This is a PRESENCE check only — with every source field non-zero it cannot catch a
+// wrong-source mapping or default-value drift. Value correctness is carried by
+// TestServePreservesExplicitConfig (pass-through scalars) and
+// TestServeAppliesTransportDefaults (the cmp.Or defaults).
 func TestBuildServeConfigMapsSharedFields(t *testing.T) {
 	t.Parallel()
 
 	intentionallyUnmapped := map[string]struct{}{
 		"AuthzMiddleware":     {}, // authenticated/authz chain relocated by #5441
 		"HealthMonitorConfig": {}, // monitor injected pre-built via ServerConfig.HealthMonitor (A2)
+		"StatusReporter":      {}, // set directly on Server; Config.StatusReporter only read by New
 	}
 
 	// Every field set to a non-zero value so a dropped mapping surfaces as a zero

--- a/pkg/vmcp/server/serve_test.go
+++ b/pkg/vmcp/server/serve_test.go
@@ -1,0 +1,184 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package server
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stacklok/toolhive/pkg/auth"
+	"github.com/stacklok/toolhive/pkg/vmcp"
+	"github.com/stacklok/toolhive/pkg/vmcp/core"
+)
+
+// stubVMCP is a no-op core.VMCP for Serve tests. The Serve skeleton never invokes
+// its capability methods; Close records invocation so the shutdown wiring can be
+// asserted.
+type stubVMCP struct {
+	closed bool
+}
+
+var _ core.VMCP = (*stubVMCP)(nil)
+
+func (*stubVMCP) ListTools(context.Context, *auth.Identity) ([]vmcp.Tool, error) { return nil, nil }
+func (*stubVMCP) CallTool(
+	context.Context, *auth.Identity, string, map[string]any, map[string]any,
+) (*vmcp.ToolCallResult, error) {
+	return nil, nil
+}
+func (*stubVMCP) ListResources(context.Context, *auth.Identity) ([]vmcp.Resource, error) {
+	return nil, nil
+}
+func (*stubVMCP) ReadResource(context.Context, *auth.Identity, string) (*vmcp.ResourceReadResult, error) {
+	return nil, nil
+}
+func (*stubVMCP) ListPrompts(context.Context, *auth.Identity) ([]vmcp.Prompt, error) { return nil, nil }
+func (*stubVMCP) GetPrompt(
+	context.Context, *auth.Identity, string, map[string]any,
+) (*vmcp.PromptGetResult, error) {
+	return nil, nil
+}
+func (*stubVMCP) LookupTool(context.Context, *auth.Identity, string) (*vmcp.Tool, error) {
+	return nil, nil
+}
+func (*stubVMCP) LookupResource(context.Context, *auth.Identity, string) (*vmcp.Resource, error) {
+	return nil, nil
+}
+func (*stubVMCP) LookupPrompt(context.Context, *auth.Identity, string) (*vmcp.Prompt, error) {
+	return nil, nil
+}
+func (s *stubVMCP) Close() error { s.closed = true; return nil }
+
+func TestServeAppliesTransportDefaults(t *testing.T) {
+	t.Parallel()
+
+	// Empty transport fields exercise every default; Port is left zero.
+	cfg := &ServerConfig{SessionFactory: testMinimalFactory()}
+
+	srv, err := Serve(context.Background(), &stubVMCP{}, cfg)
+	require.NoError(t, err)
+	require.NotNil(t, srv)
+	require.NotNil(t, srv.MCPServer())
+
+	// Defaults mirror server.New and are applied to the server's own config,
+	// leaving the caller's ServerConfig untouched.
+	assert.Equal(t, "toolhive-vmcp", srv.config.Name)
+	assert.Equal(t, "0.1.0", srv.config.Version)
+	assert.Equal(t, "127.0.0.1", srv.config.Host)
+	assert.Equal(t, "/mcp", srv.config.EndpointPath)
+	assert.Equal(t, defaultSessionTTL, srv.config.SessionTTL)
+	assert.Equal(t, 0, srv.config.Port) // Port 0 => OS-assigned
+
+	assert.Empty(t, cfg.Host, "caller config must not be mutated")
+
+	// Address reflects the defaulted host and unassigned port (no listener yet).
+	assert.Equal(t, "127.0.0.1:0", srv.Address())
+}
+
+func TestServePreservesExplicitConfig(t *testing.T) {
+	t.Parallel()
+
+	cfg := &ServerConfig{
+		Name:           "custom",
+		Version:        "9.9.9",
+		Host:           "0.0.0.0",
+		Port:           8080,
+		EndpointPath:   "/rpc",
+		GroupRef:       "my-group",
+		SessionFactory: testMinimalFactory(),
+	}
+
+	srv, err := Serve(context.Background(), &stubVMCP{}, cfg)
+	require.NoError(t, err)
+
+	assert.Equal(t, "custom", srv.config.Name)
+	assert.Equal(t, "9.9.9", srv.config.Version)
+	assert.Equal(t, "0.0.0.0", srv.config.Host)
+	assert.Equal(t, 8080, srv.config.Port)
+	assert.Equal(t, "/rpc", srv.config.EndpointPath)
+	assert.Equal(t, "my-group", srv.config.GroupRef)
+}
+
+func TestServeHandlerRegistersUnauthenticatedRoutes(t *testing.T) {
+	t.Parallel()
+
+	cfg := &ServerConfig{SessionFactory: testMinimalFactory()}
+	srv, err := Serve(context.Background(), &stubVMCP{}, cfg)
+	require.NoError(t, err)
+
+	handler, err := srv.Handler(context.Background())
+	require.NoError(t, err)
+
+	// The unauthenticated routes are direct mux entries and respond without the
+	// not-yet-relocated authenticated MCP chain or its dependencies.
+	for _, path := range []string{"/health", "/ping", "/readyz", "/status", "/api/backends/health"} {
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		assert.Equalf(t, http.StatusOK, rec.Code, "route %s", path)
+	}
+
+	// /metrics is only registered when a telemetry provider with a Prometheus
+	// handler is configured; absent here the request falls through to the catch-all
+	// MCP handler and must not return 200.
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	assert.NotEqual(t, http.StatusOK, rec.Code)
+}
+
+func TestServeStopClosesCore(t *testing.T) {
+	t.Parallel()
+
+	stub := &stubVMCP{}
+	srv, err := Serve(context.Background(), stub, &ServerConfig{SessionFactory: testMinimalFactory()})
+	require.NoError(t, err)
+
+	// Stop on a never-started server still runs the shutdown funcs, which release
+	// the injected core.
+	require.NoError(t, srv.Stop(context.Background()))
+	assert.True(t, stub.closed, "Serve must wire core.Close into the shutdown sequence")
+}
+
+func TestServeValidation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		v    core.VMCP
+		cfg  *ServerConfig
+	}{
+		{
+			name: "nil config",
+			v:    &stubVMCP{},
+			cfg:  nil,
+		},
+		{
+			name: "nil vmcp",
+			v:    nil,
+			cfg:  &ServerConfig{SessionFactory: testMinimalFactory()},
+		},
+		{
+			name: "nil session factory",
+			v:    &stubVMCP{},
+			cfg:  &ServerConfig{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv, err := Serve(context.Background(), tc.v, tc.cfg)
+			require.Error(t, err)
+			assert.ErrorIs(t, err, vmcp.ErrInvalidConfig)
+			assert.Nil(t, srv)
+		})
+	}
+}

--- a/pkg/vmcp/server/server.go
+++ b/pkg/vmcp/server/server.go
@@ -76,6 +76,13 @@ const (
 	// defaultSessionTTL is the default session time-to-live duration.
 	// Sessions that are inactive for this duration will be automatically cleaned up.
 	defaultSessionTTL = 30 * time.Minute
+
+	// Transport defaults shared by New and Serve (buildServeConfig) so the two
+	// entry points cannot drift while New is not yet routed through Serve.
+	defaultServerName    = "toolhive-vmcp"
+	defaultServerVersion = "0.1.0"
+	defaultHost          = "127.0.0.1"
+	defaultEndpointPath  = "/mcp"
 )
 
 //go:generate mockgen -destination=mocks/mock_watcher.go -package=mocks -source=server.go Watcher
@@ -310,18 +317,18 @@ func New(
 ) (*Server, error) {
 	// Apply defaults
 	if cfg.Host == "" {
-		cfg.Host = "127.0.0.1"
+		cfg.Host = defaultHost
 	}
 	// Note: Port 0 means "let OS assign random port" - intentionally no default applied here.
 	// CLI provides default via flag (4483), so Port is only 0 in tests for dynamic port assignment.
 	if cfg.EndpointPath == "" {
-		cfg.EndpointPath = "/mcp"
+		cfg.EndpointPath = defaultEndpointPath
 	}
 	if cfg.Name == "" {
-		cfg.Name = "toolhive-vmcp"
+		cfg.Name = defaultServerName
 	}
 	if cfg.Version == "" {
-		cfg.Version = "0.1.0"
+		cfg.Version = defaultServerVersion
 	}
 	if cfg.SessionTTL == 0 {
 		cfg.SessionTTL = defaultSessionTTL

--- a/pkg/vmcp/server/status.go
+++ b/pkg/vmcp/server/status.go
@@ -63,10 +63,15 @@ func (s *Server) buildStatusResponse(ctx context.Context) StatusResponse {
 	// Get current backends from registry (supports dynamic backend changes).
 	// The registry is owned by the core and may not be wired into the transport
 	// yet (the Serve skeleton, before later Phase 2 tasks relocate it); a nil
-	// registry yields an empty backend view rather than a panic.
+	// registry yields an empty backend view rather than a panic. This is expected
+	// only on a Serve-built skeleton — on the server.New path the registry is a
+	// required arg, so a nil there is a wiring bug; log at Debug so it is
+	// observable when investigating without spamming routine /status polls.
 	var backends []vmcp.Backend
 	if s.backendRegistry != nil {
 		backends = s.backendRegistry.List(ctx)
+	} else {
+		slog.Debug("status: backend registry not wired; reporting empty backend view")
 	}
 	backendStatuses := make([]BackendStatus, 0, len(backends))
 

--- a/pkg/vmcp/server/status.go
+++ b/pkg/vmcp/server/status.go
@@ -60,8 +60,14 @@ func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 // buildStatusResponse builds the StatusResponse from server state.
 // Uses the provided context for request cancellation and tracing propagation.
 func (s *Server) buildStatusResponse(ctx context.Context) StatusResponse {
-	// Get current backends from registry (supports dynamic backend changes)
-	backends := s.backendRegistry.List(ctx)
+	// Get current backends from registry (supports dynamic backend changes).
+	// The registry is owned by the core and may not be wired into the transport
+	// yet (the Serve skeleton, before later Phase 2 tasks relocate it); a nil
+	// registry yields an empty backend view rather than a panic.
+	var backends []vmcp.Backend
+	if s.backendRegistry != nil {
+		backends = s.backendRegistry.List(ctx)
+	}
 	backendStatuses := make([]BackendStatus, 0, len(backends))
 
 	// Get live health states from the health monitor (if enabled) so that


### PR DESCRIPTION
## Summary

This is the transport-side entry point of the New/Serve split that the rest of
the vMCP Phase 2 refactor (epic #5419) builds on. Today `server.New` is a
god-object that constructs both the identity-parameterized core domain logic and
the HTTP/SDK transport in one call. This PR lands the additive `Serve` skeleton so
later tasks can relocate the remaining transport concerns onto it without churning
`server.New`.

- Add `Serve(ctx, core.VMCP, *ServerConfig) (*Server, error)` in the new
  `pkg/vmcp/server/serve.go`. `Serve` wraps an already-constructed core `VMCP` and
  returns the **existing** `*Server` struct, so all carried-forward accessors
  (`Handler`/`Start`/`Stop`/`Address`/`MCPServer`/`Ready`) keep working unchanged.
- Add the transport-only `ServerConfig` struct — the subset of the legacy
  `server.Config` that configures the HTTP/SDK runtime, plus the cross-cutting
  `TelemetryProvider`/`AuditConfig` consumed by both the core and the transport.
- `Serve` applies the same transport defaults `server.New` applies today
  (`Host` → `127.0.0.1`, `EndpointPath` → `/mcp`, `Name`/`Version`/`SessionTTL`
  defaults; `Port == 0` stays "OS-assigned"), builds the mcp-go server, and wires
  the core's `Close` into the server's shutdown sequence.
- Guard the `/status` handler against a nil backend registry, since the transport
  does not yet own the registry at this phase.

`server.New` is intentionally **not** routed through `Serve` in this PR, so the
change is purely additive and observable behavior is unchanged. This keeps the PR
small and the parity surface flat; Phase 3 (#5444/#5445) reduces `server.New` to a
wrapper over `Serve`.

> **Stacked PR.** This branch is stacked on #5459 (admission seam, `Closes #5438`),
> which is itself stacked on the `New`/`VMCP` work (#5437). It should target the
> parent branch `vmcp-core-p1-5_issue_5438` for review, not `main`. The
> `pkg/vmcp/core/*` changes visible in a diff against `main` are inherited from
> those upstream PRs and are not part of this change. The only files this PR
> introduces are `pkg/vmcp/server/serve.go`, `pkg/vmcp/server/serve_test.go`, and
> the `pkg/vmcp/server/status.go` nil-registry guard.

Closes #5439

## Type of change

- [x] Refactoring (no behavior change)

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)

Added `pkg/vmcp/server/serve_test.go` covering:
- `Serve` applies transport defaults identically to `server.New` and leaves the
  caller's `ServerConfig` unmutated and `Port == 0` OS-assigned.
- `Serve` preserves explicitly set config values.
- The returned `*Server` exposes a usable `MCPServer()`, and `Handler(ctx)`
  registers the unauthenticated routes (`/health`, `/ping`, `/readyz`, `/status`,
  `/api/backends/health`); `/metrics` is absent without a telemetry provider.
- `Stop` runs the shutdown funcs and closes the injected core.
- Validation returns a `vmcp.ErrInvalidConfig`-wrapped error for nil `cfg`, nil
  core, and nil `SessionFactory`.
- A reflection-based drift guard asserts every `Config` field is populated by
  `buildServeConfig` except the documented intentionally-unmapped set
  (`AuthzMiddleware`, `HealthMonitorConfig`).

The existing `server.New`-driven behavioral-parity suite stays green; `server.New`
is untouched and not routed through `Serve`. Repo-wide lint is clean apart from a
pre-existing, unrelated gosec G115 finding in `cmd/thv/app/upgrade.go`.

## Changes

| File | Change |
|------|--------|
| `pkg/vmcp/server/serve.go` | New `Serve` entry point and transport-only `ServerConfig`; `buildServeConfig` maps config and applies defaults |
| `pkg/vmcp/server/serve_test.go` | Unit tests for defaults, config preservation, route registration, shutdown wiring, validation, and mapping drift |
| `pkg/vmcp/server/status.go` | Nil-registry guard in `buildStatusResponse` so the Serve skeleton returns an empty backend view instead of panicking |

## Does this introduce a user-facing change?

No.

## Special notes for reviewers

- **Relocate, don't rewrite.** `Serve` returns the same `*Server` struct rather
  than a new type, and mirrors the defaults and mcp-go construction that
  `server.New` performs today. No mcp-go types cross the `VMCP` boundary.
- **Why `ServerConfig` exists.** These fields configure the HTTP/SDK runtime and
  are meaningless to the core (R3). The stutter `server.ServerConfig` is
  intentional and `nolint`-annotated: the split mandates the name and the package's
  existing `Config` is the legacy type being decomposed.
- **Deferred follow-ups.** SDK session hooks and two-phase creation (#5440), the
  authenticated middleware chain and direct `VMCP` request path (#5441), and the AS
  runner / status reporter / optimizer / health monitor lifecycle (#5443) are moved
  under `Serve` by later Phase 2 tasks. The `buildServeConfig` drift-guard test
  documents the two fields deliberately unmapped until then.
