### PR TITLE
Renew public client TTL on successful token exchange

### DIFF
--- a/pkg/authserver/server/handlers/helpers_test.go
+++ b/pkg/authserver/server/handlers/helpers_test.go
@@ -91,7 +91,7 @@ type testStorageState struct {
 	authCodeSessions   map[string]fosite.Requester          // authorize code sessions for token exchange
 	pkceSessions       map[string]fosite.Requester          // PKCE sessions for token exchange
 	idpTokenCount      int
-	renewedClients     []string                             // client IDs passed to RenewClientTTL
+	renewedClients     []string // client IDs passed to RenewClientTTL
 }
 
 // baseTestSetupOption configures optional behavior overrides for baseTestSetup.

--- a/pkg/authserver/server/handlers/helpers_test.go
+++ b/pkg/authserver/server/handlers/helpers_test.go
@@ -91,6 +91,7 @@ type testStorageState struct {
 	authCodeSessions   map[string]fosite.Requester          // authorize code sessions for token exchange
 	pkceSessions       map[string]fosite.Requester          // PKCE sessions for token exchange
 	idpTokenCount      int
+	renewedClients     []string                             // client IDs passed to RenewClientTTL
 }
 
 // baseTestSetupOption configures optional behavior overrides for baseTestSetup.
@@ -184,6 +185,14 @@ func baseTestSetup(t *testing.T, opts ...baseTestSetupOption) (fosite.OAuth2Prov
 		return nil, fosite.ErrNotFound
 	}).AnyTimes()
 	stor.EXPECT().GetClient(gomock.Any(), gomock.Not(testAuthClientID)).Return(nil, fosite.ErrNotFound).AnyTimes()
+
+	// Token issuance renews the public client's registration TTL (best-effort).
+	// Record the calls so tests can assert the renewal fired on success.
+	stor.EXPECT().RenewClientTTL(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, c fosite.Client) error {
+			storState.renewedClients = append(storState.renewedClients, c.GetID())
+			return nil
+		}).AnyTimes()
 
 	// Setup mock expectations for pending authorization storage
 	if setupCfg.storePendingErr != nil {

--- a/pkg/authserver/server/handlers/token.go
+++ b/pkg/authserver/server/handlers/token.go
@@ -98,6 +98,20 @@ func (h *Handler) TokenHandler(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	// Renew the registration TTL for public (DCR) clients on a successful token
+	// exchange/refresh. This is the proven-use signal — unlike the unauthenticated
+	// /oauth/authorize client read — so an actively-used public client is not evicted
+	// mid-lifecycle and forced to re-register. Best-effort: a renewal failure must not
+	// fail the token that was just issued. Storage renews only public clients.
+	if client := accessRequest.GetClient(); client != nil {
+		if err := h.storage.RenewClientTTL(ctx, client); err != nil {
+			slog.Warn("failed to renew client registration TTL",
+				"client_id", client.GetID(),
+				"error", err,
+			)
+		}
+	}
+
 	// Write the token response
 	h.provider.WriteAccessResponse(ctx, w, accessRequest, response)
 }

--- a/pkg/authserver/server/handlers/token_test.go
+++ b/pkg/authserver/server/handlers/token_test.go
@@ -176,6 +176,35 @@ func TestTokenHandler_Success(t *testing.T) {
 	assert.Contains(t, body, "expires_in")
 }
 
+// TestTokenHandler_Success_RenewsClientTTL asserts that a successful token
+// exchange renews the registration TTL of the public client — the proven-use
+// signal that keeps an active client from being evicted and forced to
+// re-register. Renewal must run on the token path, not the unauthenticated
+// authorize read.
+func TestTokenHandler_Success_RenewsClientTTL(t *testing.T) {
+	t.Parallel()
+	handler, storState, _ := handlerTestSetup(t)
+
+	authorizeCode := simulateAuthorizeFlow(t, handler, storState)
+
+	form := url.Values{
+		"grant_type":    {"authorization_code"},
+		"client_id":     {testAuthClientID},
+		"redirect_uri":  {testAuthRedirectURI},
+		"code":          {authorizeCode},
+		"code_verifier": {testPKCEVerifier},
+	}
+	req := httptest.NewRequest(http.MethodPost, "/oauth/token", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+
+	handler.TokenHandler(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code, "got %d: %s", rec.Code, rec.Body.String())
+	assert.Contains(t, storState.renewedClients, testAuthClientID,
+		"successful token exchange should renew the public client's registration TTL")
+}
+
 func TestTokenHandler_AudienceClaim(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/authserver/storage/memory.go
+++ b/pkg/authserver/storage/memory.go
@@ -346,6 +346,13 @@ func (s *MemoryStorage) RegisterClient(_ context.Context, client fosite.Client) 
 	return nil
 }
 
+// RenewClientTTL is a no-op for the in-memory backend: clients are held for the
+// process lifetime with no TTL, so there is nothing to renew. The behavior that
+// matters for distributed deployments lives in RedisStorage.RenewClientTTL.
+func (*MemoryStorage) RenewClientTTL(_ context.Context, _ fosite.Client) error {
+	return nil
+}
+
 // -----------------------
 // fosite.ClientManager
 // -----------------------

--- a/pkg/authserver/storage/memory_test.go
+++ b/pkg/authserver/storage/memory_test.go
@@ -221,6 +221,19 @@ func TestMemoryStorage_RegisterClient(t *testing.T) {
 	})
 }
 
+func TestMemoryStorage_RenewClientTTL_NoOp(t *testing.T) {
+	withStorage(t, func(ctx context.Context, s *MemoryStorage) {
+		// In-memory clients have no TTL, so renewal is a documented no-op: it must
+		// not error and must leave the client retrievable.
+		client := &mockClient{id: "public-client", public: true}
+		require.NoError(t, s.RegisterClient(ctx, client))
+		require.NoError(t, s.RenewClientTTL(ctx, client))
+		retrieved, err := s.GetClient(ctx, "public-client")
+		require.NoError(t, err)
+		assert.Equal(t, "public-client", retrieved.GetID())
+	})
+}
+
 func TestMemoryStorage_ClientAssertionJWT(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/pkg/authserver/storage/mocks/mock_storage.go
+++ b/pkg/authserver/storage/mocks/mock_storage.go
@@ -206,6 +206,20 @@ func (mr *MockClientRegistryMockRecorder) RegisterClient(ctx, client any) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterClient", reflect.TypeOf((*MockClientRegistry)(nil).RegisterClient), ctx, client)
 }
 
+// RenewClientTTL mocks base method.
+func (m *MockClientRegistry) RenewClientTTL(ctx context.Context, client fosite.Client) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RenewClientTTL", ctx, client)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RenewClientTTL indicates an expected call of RenewClientTTL.
+func (mr *MockClientRegistryMockRecorder) RenewClientTTL(ctx, client any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RenewClientTTL", reflect.TypeOf((*MockClientRegistry)(nil).RenewClientTTL), ctx, client)
+}
+
 // SetClientAssertionJWT mocks base method.
 func (m *MockClientRegistry) SetClientAssertionJWT(ctx context.Context, jti string, exp time.Time) error {
 	m.ctrl.T.Helper()
@@ -921,6 +935,20 @@ func (m *MockStorage) RegisterClient(ctx context.Context, client fosite.Client) 
 func (mr *MockStorageMockRecorder) RegisterClient(ctx, client any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterClient", reflect.TypeOf((*MockStorage)(nil).RegisterClient), ctx, client)
+}
+
+// RenewClientTTL mocks base method.
+func (m *MockStorage) RenewClientTTL(ctx context.Context, client fosite.Client) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RenewClientTTL", ctx, client)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RenewClientTTL indicates an expected call of RenewClientTTL.
+func (mr *MockStorageMockRecorder) RenewClientTTL(ctx, client any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RenewClientTTL", reflect.TypeOf((*MockStorage)(nil).RenewClientTTL), ctx, client)
 }
 
 // RevokeAccessToken mocks base method.

--- a/pkg/authserver/storage/redis.go
+++ b/pkg/authserver/storage/redis.go
@@ -181,7 +181,8 @@ func (s *RedisStorage) RegisterClient(ctx context.Context, client fosite.Client)
 		return fmt.Errorf("failed to marshal client: %w", err)
 	}
 
-	// Public clients (from DCR) expire to prevent unbounded growth.
+	// Public clients (from DCR) expire to prevent unbounded growth; GetClient
+	// renews this TTL on use so actively-used clients are not evicted.
 	// Confidential clients don't expire.
 	ttl := time.Duration(0)
 	if client.IsPublic() {
@@ -192,6 +193,16 @@ func (s *RedisStorage) RegisterClient(ctx context.Context, client fosite.Client)
 }
 
 // GetClient loads the client by its ID.
+//
+// For public (DCR) clients, a successful load renews the registration TTL to
+// DefaultPublicClientTTL, making expiry a sliding window of inactivity rather than
+// a fixed window from registration time. Without this, an actively-used public
+// client is evicted DefaultPublicClientTTL after it registered regardless of use,
+// which surfaces to the client as invalid_client on its next token request and
+// forces a full re-registration. Abandoned clients still expire after the
+// inactivity window, preserving the anti-bloat intent of RegisterClient.
+// Confidential clients are stored without a TTL and are left untouched. TTL
+// renewal is best-effort: a failure is logged and does not fail the lookup.
 func (s *RedisStorage) GetClient(ctx context.Context, id string) (fosite.Client, error) {
 	key := redisKey(s.keyPrefix, KeyTypeClient, id)
 
@@ -206,6 +217,15 @@ func (s *RedisStorage) GetClient(ctx context.Context, id string) (fosite.Client,
 	var stored storedClient
 	if err := json.Unmarshal(data, &stored); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal client: %w", err)
+	}
+
+	// Renew the registration TTL on use so actively-used public (DCR) clients are
+	// not evicted mid-lifecycle. Mirrors the TTL set in RegisterClient; confidential
+	// clients have no TTL and are left untouched.
+	if stored.Public {
+		if err := s.client.Expire(ctx, key, DefaultPublicClientTTL).Err(); err != nil {
+			slog.Warn("failed to renew public client TTL", "client_id", id, "error", err)
+		}
 	}
 
 	return &redisClient{storedClient: stored}, nil

--- a/pkg/authserver/storage/redis.go
+++ b/pkg/authserver/storage/redis.go
@@ -181,8 +181,8 @@ func (s *RedisStorage) RegisterClient(ctx context.Context, client fosite.Client)
 		return fmt.Errorf("failed to marshal client: %w", err)
 	}
 
-	// Public clients (from DCR) expire to prevent unbounded growth; GetClient
-	// renews this TTL on use so actively-used clients are not evicted.
+	// Public clients (from DCR) expire to prevent unbounded growth; RenewClientTTL
+	// refreshes this on proven use so actively-used clients are not evicted.
 	// Confidential clients don't expire.
 	ttl := time.Duration(0)
 	if client.IsPublic() {
@@ -193,16 +193,6 @@ func (s *RedisStorage) RegisterClient(ctx context.Context, client fosite.Client)
 }
 
 // GetClient loads the client by its ID.
-//
-// For public (DCR) clients, a successful load renews the registration TTL to
-// DefaultPublicClientTTL, making expiry a sliding window of inactivity rather than
-// a fixed window from registration time. Without this, an actively-used public
-// client is evicted DefaultPublicClientTTL after it registered regardless of use,
-// which surfaces to the client as invalid_client on its next token request and
-// forces a full re-registration. Abandoned clients still expire after the
-// inactivity window, preserving the anti-bloat intent of RegisterClient.
-// Confidential clients are stored without a TTL and are left untouched. TTL
-// renewal is best-effort: a failure is logged and does not fail the lookup.
 func (s *RedisStorage) GetClient(ctx context.Context, id string) (fosite.Client, error) {
 	key := redisKey(s.keyPrefix, KeyTypeClient, id)
 
@@ -219,16 +209,27 @@ func (s *RedisStorage) GetClient(ctx context.Context, id string) (fosite.Client,
 		return nil, fmt.Errorf("failed to unmarshal client: %w", err)
 	}
 
-	// Renew the registration TTL on use so actively-used public (DCR) clients are
-	// not evicted mid-lifecycle. Mirrors the TTL set in RegisterClient; confidential
-	// clients have no TTL and are left untouched.
-	if stored.Public {
-		if err := s.client.Expire(ctx, key, DefaultPublicClientTTL).Err(); err != nil {
-			slog.Warn("failed to renew public client TTL", "client_id", id, "error", err)
-		}
-	}
-
 	return &redisClient{storedClient: stored}, nil
+}
+
+// RenewClientTTL extends a public client's registration TTL to DefaultPublicClientTTL.
+//
+// Call this on a proven-use signal — a successful token exchange/refresh — not on a
+// client read. GetClient is reached from the unauthenticated front-channel
+// /oauth/authorize handler before any authentication, and public clients have no
+// secret, so renewing there would let any caller who knows a public client_id keep
+// its row alive indefinitely and defeat the anti-bloat TTL. Renewing on token
+// issuance ties registration survival to actual use.
+//
+// Only public clients carry a TTL; confidential clients are stored without one and
+// are left untouched. EXPIRE on a missing key is a no-op, so a client whose row has
+// already been evicted (or a non-persisted CIMD client) is safely ignored.
+func (s *RedisStorage) RenewClientTTL(ctx context.Context, client fosite.Client) error {
+	if client == nil || !client.IsPublic() {
+		return nil
+	}
+	key := redisKey(s.keyPrefix, KeyTypeClient, client.GetID())
+	return s.client.Expire(ctx, key, DefaultPublicClientTTL).Err()
 }
 
 // ClientAssertionJWTValid returns an error if the JTI is known.

--- a/pkg/authserver/storage/redis_test.go
+++ b/pkg/authserver/storage/redis_test.go
@@ -261,6 +261,52 @@ func TestRedisStorage_RegisterClient(t *testing.T) {
 	})
 }
 
+// TestRedisStorage_GetClientTTLRenewal verifies that GetClient renews the
+// registration TTL for public (DCR) clients on use — making expiry a sliding
+// window of inactivity — while leaving confidential clients (which have no TTL)
+// untouched. Without renewal an actively-used public client is evicted
+// DefaultPublicClientTTL after registration and the client then fails with
+// invalid_client on its next token request.
+func TestRedisStorage_GetClientTTLRenewal(t *testing.T) {
+	t.Parallel()
+
+	t.Run("public client TTL is renewed on read", func(t *testing.T) {
+		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, mr *miniredis.Miniredis) {
+			key := redisKey(s.keyPrefix, KeyTypeClient, "public-client")
+			require.NoError(t, s.RegisterClient(ctx, &mockClient{id: "public-client", public: true}))
+
+			// Age the registration so only a small slice of the TTL remains.
+			mr.FastForward(DefaultPublicClientTTL - time.Hour)
+			ttlBefore := mr.TTL(key)
+			require.Positive(t, ttlBefore)
+			require.Less(t, ttlBefore, 2*time.Hour, "precondition: TTL should be near expiry")
+
+			client, err := s.GetClient(ctx, "public-client")
+			require.NoError(t, err)
+			assert.Equal(t, "public-client", client.GetID())
+
+			ttlAfter := mr.TTL(key)
+			assert.Greater(t, ttlAfter, ttlBefore, "GetClient should renew the public client TTL")
+			assert.InDelta(t, DefaultPublicClientTTL.Seconds(), ttlAfter.Seconds(), 60,
+				"renewed TTL should be ~DefaultPublicClientTTL")
+		})
+	})
+
+	t.Run("confidential client stays persistent on read", func(t *testing.T) {
+		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, mr *miniredis.Miniredis) {
+			key := redisKey(s.keyPrefix, KeyTypeClient, "conf-client")
+			require.NoError(t, s.RegisterClient(ctx, &mockClient{id: "conf-client", public: false}))
+			require.Equal(t, time.Duration(0), mr.TTL(key), "confidential clients must not have a TTL")
+
+			_, err := s.GetClient(ctx, "conf-client")
+			require.NoError(t, err)
+
+			assert.Equal(t, time.Duration(0), mr.TTL(key),
+				"GetClient must not introduce a TTL on a confidential client")
+		})
+	})
+}
+
 func TestRedisStorage_ClientAssertionJWT(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/authserver/storage/redis_test.go
+++ b/pkg/authserver/storage/redis_test.go
@@ -261,19 +261,18 @@ func TestRedisStorage_RegisterClient(t *testing.T) {
 	})
 }
 
-// TestRedisStorage_GetClientTTLRenewal verifies that GetClient renews the
-// registration TTL for public (DCR) clients on use — making expiry a sliding
-// window of inactivity — while leaving confidential clients (which have no TTL)
-// untouched. Without renewal an actively-used public client is evicted
-// DefaultPublicClientTTL after registration and the client then fails with
-// invalid_client on its next token request.
-func TestRedisStorage_GetClientTTLRenewal(t *testing.T) {
+// TestRedisStorage_RenewClientTTL verifies that RenewClientTTL extends the
+// registration TTL for public (DCR) clients — keeping actively-used clients from
+// being evicted mid-lifecycle — while leaving confidential clients (which have no
+// TTL) untouched, and that renewing an unknown/evicted client is a safe no-op.
+func TestRedisStorage_RenewClientTTL(t *testing.T) {
 	t.Parallel()
 
-	t.Run("public client TTL is renewed on read", func(t *testing.T) {
+	t.Run("public client TTL is renewed", func(t *testing.T) {
 		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, mr *miniredis.Miniredis) {
 			key := redisKey(s.keyPrefix, KeyTypeClient, "public-client")
-			require.NoError(t, s.RegisterClient(ctx, &mockClient{id: "public-client", public: true}))
+			client := &mockClient{id: "public-client", public: true}
+			require.NoError(t, s.RegisterClient(ctx, client))
 
 			// Age the registration so only a small slice of the TTL remains.
 			mr.FastForward(DefaultPublicClientTTL - time.Hour)
@@ -281,28 +280,34 @@ func TestRedisStorage_GetClientTTLRenewal(t *testing.T) {
 			require.Positive(t, ttlBefore)
 			require.Less(t, ttlBefore, 2*time.Hour, "precondition: TTL should be near expiry")
 
-			client, err := s.GetClient(ctx, "public-client")
-			require.NoError(t, err)
-			assert.Equal(t, "public-client", client.GetID())
+			require.NoError(t, s.RenewClientTTL(ctx, client))
 
 			ttlAfter := mr.TTL(key)
-			assert.Greater(t, ttlAfter, ttlBefore, "GetClient should renew the public client TTL")
+			assert.Greater(t, ttlAfter, ttlBefore, "RenewClientTTL should extend the public client TTL")
 			assert.InDelta(t, DefaultPublicClientTTL.Seconds(), ttlAfter.Seconds(), 60,
 				"renewed TTL should be ~DefaultPublicClientTTL")
 		})
 	})
 
-	t.Run("confidential client stays persistent on read", func(t *testing.T) {
+	t.Run("confidential client is left without a TTL", func(t *testing.T) {
 		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, mr *miniredis.Miniredis) {
 			key := redisKey(s.keyPrefix, KeyTypeClient, "conf-client")
-			require.NoError(t, s.RegisterClient(ctx, &mockClient{id: "conf-client", public: false}))
+			client := &mockClient{id: "conf-client", public: false}
+			require.NoError(t, s.RegisterClient(ctx, client))
 			require.Equal(t, time.Duration(0), mr.TTL(key), "confidential clients must not have a TTL")
 
-			_, err := s.GetClient(ctx, "conf-client")
-			require.NoError(t, err)
+			require.NoError(t, s.RenewClientTTL(ctx, client))
 
 			assert.Equal(t, time.Duration(0), mr.TTL(key),
-				"GetClient must not introduce a TTL on a confidential client")
+				"RenewClientTTL must not introduce a TTL on a confidential client")
+		})
+	})
+
+	t.Run("unknown client is a safe no-op", func(t *testing.T) {
+		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, mr *miniredis.Miniredis) {
+			key := redisKey(s.keyPrefix, KeyTypeClient, "ghost")
+			require.NoError(t, s.RenewClientTTL(ctx, &mockClient{id: "ghost", public: true}))
+			assert.False(t, mr.Exists(key), "renewing an unknown client must not create a key")
 		})
 	})
 }

--- a/pkg/authserver/storage/types.go
+++ b/pkg/authserver/storage/types.go
@@ -481,6 +481,15 @@ type ClientRegistry interface {
 	// This supports both static configuration and dynamic client registration (RFC 7591).
 	// Returns ErrAlreadyExists if a client with the same ID already exists.
 	RegisterClient(ctx context.Context, client fosite.Client) error
+
+	// RenewClientTTL extends the registration TTL of a public (DCR) client so an
+	// actively-used client is not evicted mid-lifecycle and forced to re-register.
+	// Call it on a proven-use signal (e.g. a successful token exchange), NOT on an
+	// unauthenticated client read such as the /oauth/authorize lookup. Implementations
+	// renew only public clients; confidential clients have no TTL. Backends without a
+	// native TTL (the in-memory backend) treat this as a no-op. A renewal failure is
+	// non-fatal to the caller's primary operation.
+	RenewClientTTL(ctx context.Context, client fosite.Client) error
 }
 
 // UpstreamTokenStorage provides storage for tokens obtained from upstream identity providers.


### PR DESCRIPTION
## Summary

Public clients registered through Dynamic Client Registration (DCR) get `DefaultPublicClientTTL` (30 days) stamped on their Redis registration at registration time, and nothing refreshes it. An actively-used public client — e.g. a long-lived MCP desktop/IDE client that caches its `client_id` indefinitely — is therefore evicted 30 days after it registered, regardless of use. Its next token request then fails at the token endpoint with `invalid_client`, and the only recovery is to fully re-register the client (which silently recurs ~monthly).

- Add `RenewClientTTL` to the `ClientRegistry` storage interface. The Redis backend `EXPIRE`s the public client's key back to `DefaultPublicClientTTL`; the in-memory backend is a documented no-op (its clients have no TTL).
- Call it best-effort from the token endpoint after a successful exchange/refresh, so registration survival tracks *proven use*. Confidential clients (which have no TTL) and already-evicted keys are left untouched.
- Renewal deliberately runs on the token path, **not** on the client read. `GetClient` is reached from the unauthenticated front-channel `GET /oauth/authorize` before any auth, and public clients have no secret, so renewing there would let any caller who knows a public `client_id` keep its registration alive indefinitely and defeat the anti-bloat TTL.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [x] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [ ] Linting (`task lint-fix`)
- [x] Manual testing (describe below)

Ran the `pkg/authserver/storage` and `pkg/authserver/server/handlers` unit tests with `-race` (the Taskfile's `go test` invocation, scoped to those packages) — all pass. The storage test exercises `RenewClientTTL` directly (public renews, confidential stays TTL-less, unknown key is a safe no-op); a handler test asserts a successful token exchange renews the public client's TTL, and I verified it fails without the wiring. Ran `go vet` and `go build ./...`. golangci-lint was not run locally; leaving the full lint to CI.

## Does this introduce a user-facing change?

Yes. Long-lived public OAuth/MCP clients (e.g. Claude Desktop, Claude Code, Cursor, VS Code) backed by the Redis storage no longer stop working ~30 days after they were first authorized; an in-use client's registration is refreshed on each successful token exchange. No configuration change is required. The in-memory backend is unaffected.

## Special notes for reviewers

- Renewal lives on the token-endpoint success path rather than in `GetClient` specifically so an unauthenticated `/oauth/authorize` probe cannot keep a public client alive — raised in review on the first revision.
- The in-memory backend stores clients in a bare map with no TTL, so public clients there never expire; `RenewClientTTL` is a no-op for it. The two backends already diverge on this and this PR does not change in-memory behavior.
