### PR TITLE
Deprecate MCPRegistry CRD with runtime warning

### DIFF
--- a/cmd/thv-operator/api/v1alpha1/types.go
+++ b/cmd/thv-operator/api/v1alpha1/types.go
@@ -128,17 +128,22 @@ type MCPOIDCConfigList struct {
 
 // ─── MCPRegistry ─────────────────────────────────────────────────────────────
 
-//+kubebuilder:object:root=true
-//+kubebuilder:deprecatedversion:warning="toolhive.stacklok.dev/v1alpha1 is deprecated; use v1beta1"
-//+kubebuilder:subresource:status
-//+kubebuilder:resource:shortName=mcpreg;registry,scope=Namespaced,categories=toolhive
-//+kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.phase"
-//+kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"
-//+kubebuilder:printcolumn:name="Replicas",type="integer",JSONPath=".status.readyReplicas"
-//+kubebuilder:printcolumn:name="URL",type="string",JSONPath=".status.url"
-//+kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
-
 // MCPRegistry is the deprecated v1alpha1 version of the MCPRegistry resource.
+// The MCPRegistry CRD as a whole is deprecated and will be removed in a future
+// release; install the ToolHive registry server via the toolhive-registry-server
+// Helm chart instead: https://github.com/stacklok/toolhive-registry-server
+//
+// +kubebuilder:object:root=true
+// +kubebuilder:deprecatedversion:warning="MCPRegistry is deprecated and will be removed in a future release; install the ToolHive registry server via the toolhive-registry-server Helm chart (https://github.com/stacklok/toolhive-registry-server) instead"
+// +kubebuilder:subresource:status
+// +kubebuilder:resource:shortName=mcpreg;registry,scope=Namespaced,categories=toolhive
+// +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.phase"
+// +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"
+// +kubebuilder:printcolumn:name="Replicas",type="integer",JSONPath=".status.readyReplicas"
+// +kubebuilder:printcolumn:name="URL",type="string",JSONPath=".status.url"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
+//
+//nolint:lll // kubebuilder deprecatedversion marker cannot be line-wrapped
 type MCPRegistry struct {
 	metav1.TypeMeta   `json:",inline"` // nolint:revive
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/cmd/thv-operator/api/v1beta1/mcpregistry_types.go
+++ b/cmd/thv-operator/api/v1beta1/mcpregistry_types.go
@@ -202,18 +202,31 @@ const (
 	ConditionReasonRegistryNotReady = "NotReady"
 )
 
-//+kubebuilder:object:root=true
-//+kubebuilder:storageversion
-//+kubebuilder:subresource:status
-//+kubebuilder:metadata:labels=toolhive.stacklok.dev/auto-migrate-storage-version=true
-//+kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.phase"
-//+kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"
-//+kubebuilder:printcolumn:name="Replicas",type="integer",JSONPath=".status.readyReplicas"
-//+kubebuilder:printcolumn:name="URL",type="string",JSONPath=".status.url"
-//+kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
-//+kubebuilder:resource:shortName=mcpreg;registry,scope=Namespaced,categories=toolhive
+// Developer note: the MCPRegistry deprecation is expressed as prose in the type
+// doc comment below, NOT via the Go "Deprecated:" convention. The operator still
+// reconciles this type, so the staticcheck SA1019 analyzer must not flag the
+// operator's own internal uses. The kubectl-visible deprecation comes from the
+// +kubebuilder:deprecatedversion:warning marker below.
 
-// MCPRegistry is the Schema for the mcpregistries API
+// MCPRegistry is the Schema for the mcpregistries API.
+//
+// The MCPRegistry CRD is deprecated and will be removed in a future release.
+// Install the ToolHive registry server via the toolhive-registry-server Helm chart
+// instead: https://github.com/stacklok/toolhive-registry-server
+//
+// +kubebuilder:object:root=true
+// +kubebuilder:storageversion
+// +kubebuilder:deprecatedversion:warning="MCPRegistry is deprecated and will be removed in a future release; install the ToolHive registry server via the toolhive-registry-server Helm chart (https://github.com/stacklok/toolhive-registry-server) instead"
+// +kubebuilder:subresource:status
+// +kubebuilder:metadata:labels=toolhive.stacklok.dev/auto-migrate-storage-version=true
+// +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.phase"
+// +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"
+// +kubebuilder:printcolumn:name="Replicas",type="integer",JSONPath=".status.readyReplicas"
+// +kubebuilder:printcolumn:name="URL",type="string",JSONPath=".status.url"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:resource:shortName=mcpreg;registry,scope=Namespaced,categories=toolhive
+//
+//nolint:lll // kubebuilder deprecatedversion marker cannot be line-wrapped
 type MCPRegistry struct {
 	metav1.TypeMeta   `json:",inline"` // nolint:revive
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/cmd/thv-operator/app/app.go
+++ b/cmd/thv-operator/app/app.go
@@ -364,7 +364,8 @@ func setupServerControllers(mgr ctrl.Manager, imagePullSecretsDefaults imagepull
 // imagePullSecretsDefaults are merged with mcpRegistry.Spec.ImagePullSecrets
 // when the registry-api workload is constructed.
 func setupRegistryController(mgr ctrl.Manager, imagePullSecretsDefaults imagepullsecrets.Defaults) error {
-	rec := controllers.NewMCPRegistryReconciler(mgr.GetClient(), mgr.GetScheme(), imagePullSecretsDefaults)
+	rec := controllers.NewMCPRegistryReconciler(
+		mgr.GetClient(), mgr.GetScheme(), mgr.GetEventRecorder("mcpregistry-controller"), imagePullSecretsDefaults)
 	if err := rec.SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("unable to create controller MCPRegistry: %w", err)
 	}

--- a/cmd/thv-operator/controllers/mcpregistry_controller.go
+++ b/cmd/thv-operator/controllers/mcpregistry_controller.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -44,23 +45,29 @@ var (
 type MCPRegistryReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
+	// Recorder emits Kubernetes events (e.g. the CRD deprecation warning).
+	// May be nil in tests; all uses must nil-guard.
+	Recorder events.EventRecorder
 	// Registry API manager handles API deployment operations
 	registryAPIManager registryapi.Manager
 }
 
 // NewMCPRegistryReconciler creates a new MCPRegistryReconciler with required
-// dependencies. imagePullSecretsDefaults are cluster-wide pull-secret defaults
-// from the operator chart that are merged with the per-CR list at registry-api
-// workload-construction time.
+// dependencies. recorder emits Kubernetes events such as the MCPRegistry
+// deprecation warning. imagePullSecretsDefaults are cluster-wide pull-secret
+// defaults from the operator chart that are merged with the per-CR list at
+// registry-api workload-construction time.
 func NewMCPRegistryReconciler(
 	k8sClient client.Client,
 	scheme *runtime.Scheme,
+	recorder events.EventRecorder,
 	imagePullSecretsDefaults imagepullsecrets.Defaults,
 ) *MCPRegistryReconciler {
 	registryAPIManager := registryapi.NewManager(k8sClient, scheme, imagePullSecretsDefaults)
 	return &MCPRegistryReconciler{
 		Client:             k8sClient,
 		Scheme:             scheme,
+		Recorder:           recorder,
 		registryAPIManager: registryAPIManager,
 	}
 }
@@ -109,6 +116,10 @@ func (r *MCPRegistryReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 	ctxLogger.Info("Reconciling MCPRegistry", "MCPRegistry.Name", mcpRegistry.Name,
 		"phase", mcpRegistry.Status.Phase, "url", mcpRegistry.Status.URL)
+
+	// The MCPRegistry CRD is deprecated; warn the user (once per spec change)
+	// and steer them to the toolhive-registry-server Helm chart.
+	r.emitDeprecationWarning(ctx, mcpRegistry)
 
 	// Validate PodTemplateSpec early - before other operations
 	var podTemplateCondition *metav1.Condition
@@ -218,6 +229,34 @@ func (r *MCPRegistryReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	}
 
 	return result, reconcileErr
+}
+
+// EventReasonMCPRegistryDeprecated is the reason used for the Warning event that
+// announces the deprecation of the MCPRegistry CRD.
+const EventReasonMCPRegistryDeprecated = "MCPRegistryDeprecated"
+
+// emitDeprecationWarning logs and emits a Warning event telling the user the
+// MCPRegistry CRD is deprecated and to install the toolhive-registry-server Helm
+// chart instead. It only emits when the spec has changed since the last observed
+// generation, so the event fires once per spec change rather than on every
+// reconcile (K8s event aggregation would dedupe within its window anyway, but
+// spec changes are the signal users care about). No-op when Recorder is nil.
+func (r *MCPRegistryReconciler) emitDeprecationWarning(ctx context.Context, mcpRegistry *mcpv1beta1.MCPRegistry) {
+	const message = "The MCPRegistry CRD is deprecated and will be removed in a future release; " +
+		"install the ToolHive registry server via the toolhive-registry-server Helm chart " +
+		"(https://github.com/stacklok/toolhive-registry-server) instead"
+
+	if mcpRegistry.Generation == mcpRegistry.Status.ObservedGeneration {
+		return
+	}
+
+	log.FromContext(ctx).Info(message, "MCPRegistry.Name", mcpRegistry.Name)
+
+	if r.Recorder == nil {
+		return
+	}
+	r.Recorder.Eventf(mcpRegistry, nil, corev1.EventTypeWarning,
+		EventReasonMCPRegistryDeprecated, "Reconcile", message)
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/cmd/thv-operator/controllers/mcpregistry_controller_test.go
+++ b/cmd/thv-operator/controllers/mcpregistry_controller_test.go
@@ -19,6 +19,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -440,6 +441,80 @@ func TestMCPRegistryReconciler_Reconcile(t *testing.T) {
 			assert.Equal(t, tt.expErr, err)
 			if tt.assertRegistry != nil {
 				tt.assertRegistry(t, fakeClient)
+			}
+		})
+	}
+}
+
+func TestMCPRegistryReconciler_emitDeprecationWarning(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		generation  int64
+		observedGen int64
+		nilRecorder bool
+		wantEvent   bool
+	}{
+		{
+			name:        "emits warning on first reconcile (generation not yet observed)",
+			generation:  1,
+			observedGen: 0,
+			wantEvent:   true,
+		},
+		{
+			name:        "suppresses warning once generation is observed",
+			generation:  1,
+			observedGen: 1,
+			wantEvent:   false,
+		},
+		{
+			name:        "emits warning again after a spec change",
+			generation:  2,
+			observedGen: 1,
+			wantEvent:   true,
+		},
+		{
+			name:        "no-op (no panic) when recorder is nil",
+			generation:  1,
+			observedGen: 0,
+			nilRecorder: true,
+			wantEvent:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := log.IntoContext(t.Context(), log.Log)
+			reg := &mcpv1beta1.MCPRegistry{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-registry",
+					Namespace:  "default",
+					Generation: tt.generation,
+				},
+				Status: mcpv1beta1.MCPRegistryStatus{
+					ObservedGeneration: tt.observedGen,
+				},
+			}
+
+			recorder := events.NewFakeRecorder(10)
+			r := &MCPRegistryReconciler{}
+			if !tt.nilRecorder {
+				r.Recorder = recorder
+			}
+
+			r.emitDeprecationWarning(ctx, reg)
+
+			select {
+			case msg := <-recorder.Events:
+				assert.True(t, tt.wantEvent, "did not expect an event but got: %s", msg)
+				assert.Contains(t, msg, corev1.EventTypeWarning)
+				assert.Contains(t, msg, EventReasonMCPRegistryDeprecated)
+				assert.Contains(t, msg, "toolhive-registry-server")
+			default:
+				assert.False(t, tt.wantEvent, "expected a deprecation event but none was emitted")
 			}
 		})
 	}

--- a/cmd/thv-operator/test-integration/mcp-registry/suite_test.go
+++ b/cmd/thv-operator/test-integration/mcp-registry/suite_test.go
@@ -120,7 +120,8 @@ var _ = BeforeSuite(func() {
 		// Set up MCPRegistry controller
 		By("setting up MCPRegistry controller")
 		err = controllers.NewMCPRegistryReconciler(
-			testMgr.GetClient(), testMgr.GetScheme(), imagepullsecrets.Defaults{},
+			testMgr.GetClient(), testMgr.GetScheme(),
+			testMgr.GetEventRecorder("mcpregistry-controller"), imagepullsecrets.Defaults{},
 		).SetupWithManager(testMgr)
 		Expect(err).NotTo(HaveOccurred())
 

--- a/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpregistries.yaml
+++ b/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpregistries.yaml
@@ -38,12 +38,17 @@ spec:
       name: Age
       type: date
     deprecated: true
-    deprecationWarning: toolhive.stacklok.dev/v1alpha1 is deprecated; use v1beta1
+    deprecationWarning: MCPRegistry is deprecated and will be removed in a future
+      release; install the ToolHive registry server via the toolhive-registry-server
+      Helm chart (https://github.com/stacklok/toolhive-registry-server) instead
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: MCPRegistry is the deprecated v1alpha1 version of the MCPRegistry
-          resource.
+        description: |-
+          MCPRegistry is the deprecated v1alpha1 version of the MCPRegistry resource.
+          The MCPRegistry CRD as a whole is deprecated and will be removed in a future
+          release; install the ToolHive registry server via the toolhive-registry-server
+          Helm chart instead: https://github.com/stacklok/toolhive-registry-server
         properties:
           apiVersion:
             description: |-
@@ -326,10 +331,19 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: MCPRegistry is deprecated and will be removed in a future
+      release; install the ToolHive registry server via the toolhive-registry-server
+      Helm chart (https://github.com/stacklok/toolhive-registry-server) instead
     name: v1beta1
     schema:
       openAPIV3Schema:
-        description: MCPRegistry is the Schema for the mcpregistries API
+        description: |-
+          MCPRegistry is the Schema for the mcpregistries API.
+
+          The MCPRegistry CRD is deprecated and will be removed in a future release.
+          Install the ToolHive registry server via the toolhive-registry-server Helm chart
+          instead: https://github.com/stacklok/toolhive-registry-server
         properties:
           apiVersion:
             description: |-

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpregistries.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpregistries.yaml
@@ -41,12 +41,17 @@ spec:
       name: Age
       type: date
     deprecated: true
-    deprecationWarning: toolhive.stacklok.dev/v1alpha1 is deprecated; use v1beta1
+    deprecationWarning: MCPRegistry is deprecated and will be removed in a future
+      release; install the ToolHive registry server via the toolhive-registry-server
+      Helm chart (https://github.com/stacklok/toolhive-registry-server) instead
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: MCPRegistry is the deprecated v1alpha1 version of the MCPRegistry
-          resource.
+        description: |-
+          MCPRegistry is the deprecated v1alpha1 version of the MCPRegistry resource.
+          The MCPRegistry CRD as a whole is deprecated and will be removed in a future
+          release; install the ToolHive registry server via the toolhive-registry-server
+          Helm chart instead: https://github.com/stacklok/toolhive-registry-server
         properties:
           apiVersion:
             description: |-
@@ -329,10 +334,19 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: MCPRegistry is deprecated and will be removed in a future
+      release; install the ToolHive registry server via the toolhive-registry-server
+      Helm chart (https://github.com/stacklok/toolhive-registry-server) instead
     name: v1beta1
     schema:
       openAPIV3Schema:
-        description: MCPRegistry is the Schema for the mcpregistries API
+        description: |-
+          MCPRegistry is the Schema for the mcpregistries API.
+
+          The MCPRegistry CRD is deprecated and will be removed in a future release.
+          Install the ToolHive registry server via the toolhive-registry-server Helm chart
+          instead: https://github.com/stacklok/toolhive-registry-server
         properties:
           apiVersion:
             description: |-

--- a/docs/operator/crd-api.md
+++ b/docs/operator/crd-api.md
@@ -1972,7 +1972,11 @@ _Appears in:_
 
 
 
-MCPRegistry is the Schema for the mcpregistries API
+MCPRegistry is the Schema for the mcpregistries API.
+
+The MCPRegistry CRD is deprecated and will be removed in a future release.
+Install the ToolHive registry server via the toolhive-registry-server Helm chart
+instead: https://github.com/stacklok/toolhive-registry-server
 
 
 


### PR DESCRIPTION
## Summary

The `MCPRegistry` CRD is superseded by the [`toolhive-registry-server`](https://github.com/stacklok/toolhive-registry-server) Helm chart, which installs the registry server directly. This PR signals the deprecation so users can migrate before the CRD is removed in a future release, **while keeping the CRD fully functional** (signal-only — no behavior change, no gating).

This is PR 1 of 2. PR 2 will add user-facing docs, example-manifest banners, and a migration guide.

<details>
<summary><strong>Medium level</strong></summary>

- **API-level signal**: the live `v1beta1` `MCPRegistry` type gains `+kubebuilder:deprecatedversion:warning`, so `kubectl` warns on every apply/get. `v1beta1` remains the storage version (Kubernetes permits a deprecated storage version — it only warns). The stale `v1alpha1` warning (previously "use v1beta1", now itself deprecated) is repointed at the Helm chart.
- **Runtime signal**: the reconciler emits a `Warning` event plus a log line steering users to the chart, throttled to once per spec change via the `Generation == Status.ObservedGeneration` guard (mirrors `VirtualMCPServerReconciler.emitPrimaryUpstreamProviderDeprecatedEvent`). An `events.EventRecorder` is wired into `MCPRegistryReconciler`, matching the other operator controllers. No RBAC change — the controller already declares `events.k8s.io … create;patch`.
- **Doc-comment form**: the deprecation is expressed as **prose**, not the Go `Deprecated:` convention, so staticcheck SA1019 does not flag the operator's own internal uses of the still-reconciled type. The prose still flows into the generated `crd-api.md`.
- **Generated artifacts**: CRD YAML (`operator-crds` chart) and `crd-api.md` regenerated via `operator-manifests` / `crdref-gen`.

</details>

<details>
<summary><strong>Low level</strong></summary>

| File | Change |
|------|--------|
| `cmd/thv-operator/api/v1beta1/mcpregistry_types.go` | Add `deprecatedversion:warning` marker + deprecation prose to the `MCPRegistry` type; `nolint:lll` for the unwrappable marker |
| `cmd/thv-operator/api/v1alpha1/types.go` | Repoint the `MCPRegistry` `deprecatedversion` warning + doc comment at the Helm chart |
| `cmd/thv-operator/controllers/mcpregistry_controller.go` | Add `Recorder events.EventRecorder` field + constructor param; add `EventReasonMCPRegistryDeprecated` const and `emitDeprecationWarning` helper; call it in `Reconcile` |
| `cmd/thv-operator/controllers/mcpregistry_controller_test.go` | Table-driven test for `emitDeprecationWarning` (emit / suppress-once-observed / re-emit on spec change / nil-recorder no-op) |
| `cmd/thv-operator/app/app.go` | Pass `mgr.GetEventRecorder("mcpregistry-controller")` into the reconciler |
| `cmd/thv-operator/test-integration/mcp-registry/suite_test.go` | Wire the recorder in the envtest suite |
| `deploy/charts/operator-crds/.../toolhive.stacklok.dev_mcpregistries.yaml` (files + templates) | Regenerated: `deprecated: true` + `deprecationWarning` on the `v1beta1` version |
| `docs/operator/crd-api.md` | Regenerated API reference reflecting the deprecation |

</details>

<details>
<summary><strong>Implementation plan</strong></summary>

Deprecate the `MCPRegistry` CRD (signal-only, keep functional), superseded by the `toolhive-registry-server` Helm chart, aiming to remove it later. PR 1 covers code + generated artifacts:

- **Stage 1 — markers/doc comments**: add `+kubebuilder:deprecatedversion:warning` to the live `v1beta1` type (kubectl warning); repoint the stale `v1alpha1` warning at the chart. Deprecation expressed as prose, not the Go `Deprecated:` token, to avoid staticcheck SA1019 flagging the operator's own internal uses.
- **Stage 2 — runtime warning**: add `events.EventRecorder` to `MCPRegistryReconciler` (field + constructor param + `app.go` wiring), an `emitDeprecationWarning` helper that emits a `Warning` event + log once per spec change (generation guard, mirroring the VirtualMCPServer pattern), called early in `Reconcile`. No RBAC change needed.
- **Stage 3 — regenerate**: `operator-generate`, `operator-manifests`, `crdref-gen`. Verify exactly one `storage: true` remains and the `auto-migrate-storage-version` label is untouched.

PR 2 (follow-up): deprecation banners in `docs/arch/*`, headers on the 6 example manifests, `REGISTRY.md`, and a new `docs/operator/mcpregistry-deprecation.md` migration guide.

</details>

## Type of change

- [x] New feature (deprecation signalling)
- [ ] Bug fix
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

## Test plan

- [x] `task lint-fix` passes (0 issues)
- [x] `task test` — operator unit packages (`controllers`, `api/v1alpha1`, `api/v1beta1`, `app`) pass
- [x] `task build` passes
- [x] New unit test `TestMCPRegistryReconciler_emitDeprecationWarning` covers emit / suppress / re-emit / nil-recorder
- [x] `test-integration/mcp-registry` envtest suite passes (recorder wiring exercised)
- [x] Verified generated CRD has `deprecated: true` + `deprecationWarning` on `v1beta1` with exactly one storage version retained

## Does this introduce a user-facing change?

Yes. `kubectl` now prints a deprecation warning when interacting with `MCPRegistry` resources, and the operator emits a `Warning` event recommending the `toolhive-registry-server` Helm chart. The CRD continues to function unchanged.

## Special notes for reviewers

- The deprecation is intentionally **prose**, not the Go `Deprecated:` doc convention — the latter trips staticcheck SA1019 on the operator's own ~30 internal uses of a type it must keep reconciling. The kubectl-visible signal comes from the `deprecatedversion:warning` marker.
- `v1beta1` stays the storage version; Kubernetes allows a deprecated storage version. The `auto-migrate-storage-version` label is preserved.
- Follow-up PR 2 will add docs/examples/migration-guide.

Generated with [Claude Code](https://claude.com/claude-code)