### PR TITLE
Move SDK hooks and two-phase session creation under Serve

### DIFF
--- a/pkg/vmcp/server/serve.go
+++ b/pkg/vmcp/server/serve.go
@@ -10,17 +10,18 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 
 	"github.com/stacklok/toolhive/pkg/audit"
 	asrunner "github.com/stacklok/toolhive/pkg/authserver/runner"
 	"github.com/stacklok/toolhive/pkg/telemetry"
+	transportsession "github.com/stacklok/toolhive/pkg/transport/session"
 	"github.com/stacklok/toolhive/pkg/vmcp"
 	vmcpconfig "github.com/stacklok/toolhive/pkg/vmcp/config"
 	"github.com/stacklok/toolhive/pkg/vmcp/core"
 	"github.com/stacklok/toolhive/pkg/vmcp/health"
-	"github.com/stacklok/toolhive/pkg/vmcp/optimizer"
-	vmcpsession "github.com/stacklok/toolhive/pkg/vmcp/session"
+	"github.com/stacklok/toolhive/pkg/vmcp/server/sessionmanager"
 	vmcpstatus "github.com/stacklok/toolhive/pkg/vmcp/status"
 )
 
@@ -29,8 +30,14 @@ import (
 // It carries the subset of the legacy server.Config that configures the HTTP/SDK
 // runtime, plus the cross-cutting TelemetryProvider/AuditConfig that are consumed
 // by both the core (core.New) and the transport (Serve) — not a clean partition.
-// The fields the core owns (Aggregator, Router, BackendRegistry, BackendClient,
-// WorkflowDefs, Authz) live on core.Config instead and are absent here.
+// The fields the core exclusively owns (Aggregator, Router, BackendClient, Authz)
+// live on core.Config instead and are absent here. Two collaborators are shared
+// rather than core-owned, so they appear on both configs: BackendRegistry (the
+// Serve session layer also enumerates backends when creating a session) and the
+// composite-tool WorkflowDefs (carried indirectly via SessionManagerConfig, whose
+// ComposerFactory closes over the core-owned router/backend client). The
+// composition root passes the same BackendRegistry instance to both core.New and
+// Serve and assembles SessionManagerConfig.
 //
 // The name intentionally stutters as server.ServerConfig: it is mandated by the
 // New/Serve split, and the package's existing Config is the legacy transport
@@ -87,21 +94,26 @@ type ServerConfig struct {
 	// the /readyz endpoint to gate readiness on cache sync.
 	Watcher Watcher
 
-	// SessionFactory creates MultiSessions for session management. Required; Serve
-	// returns an error when it is nil.
-	SessionFactory vmcpsession.MultiSessionFactory
+	// BackendRegistry enumerates the configured backends. It is a shared
+	// collaborator: the core (core.Config.BackendRegistry) consumes it for
+	// capability aggregation, and the Serve session layer consumes it here — when
+	// the OnRegisterSession hook fires, sessionmanager.CreateSession lists the
+	// registry's backends to open the session's backend connections. The
+	// composition root passes the same instance to both core.New and Serve.
+	BackendRegistry vmcp.BackendRegistry
 
 	// SessionStorage configures the session storage backend. When nil or provider is
 	// "memory", local in-process storage is used.
 	SessionStorage *vmcpconfig.SessionStorageConfig
 
-	// OptimizerFactory builds an optimizer from a list of tools. If nil, the
-	// optimizer is disabled.
-	OptimizerFactory func(context.Context, []server.ServerTool) (optimizer.Optimizer, error)
-
-	// OptimizerConfig holds the parsed optimizer search parameters. A nil value
-	// disables the optimizer.
-	OptimizerConfig *optimizer.Config
+	// SessionManagerConfig is the pre-built construction config for the vMCP session
+	// manager (sessionmanager.New). FactoryConfig.Base is the required underlying
+	// MultiSessionFactory; the config also carries the composite-tool WorkflowDefs and
+	// ComposerFactory, the optimizer factory/config, and the telemetry provider.
+	// Required; Serve returns an error when it is nil. The composition root assembles
+	// it because the ComposerFactory closes over the core-owned router and backend
+	// client.
+	SessionManagerConfig *sessionmanager.FactoryConfig
 
 	// TelemetryProvider is the cross-cutting telemetry provider (also consumed by
 	// core.New). If nil, no telemetry is recorded.
@@ -115,61 +127,104 @@ type ServerConfig struct {
 // Serve is the transport-side entry point of the New/Serve split: it wraps an
 // already-constructed core [core.VMCP] and returns the existing *Server.
 //
-// At this phase Serve constructs only the self-contained transport pieces: it
-// applies the transport defaults (mirroring server.New), builds the mcp-go server,
-// and wires the core's Close into the server's shutdown sequence. It does NOT build
-// the route mux or the HTTP lifecycle here — those remain in the carried-forward
-// (*Server).Handler/Start/Stop, which register the unauthenticated routes (/health,
-// /ping, /readyz, /status, /api/backends/health, the metrics and .well-known
-// endpoints, and any embedded auth-server routes) when Serve's *Server is served.
+// At this phase Serve constructs the self-contained transport pieces — it applies
+// the transport defaults (mirroring server.New), builds the mcp-go server, and wires
+// the core's Close into the server's shutdown sequence — plus the SDK session layer:
+// the three session hooks and the two-phase session-creation wiring (the transport
+// session manager, the session data storage backend, and the vMCP session manager).
+// It does NOT build the route mux or the HTTP lifecycle here — those remain in the
+// carried-forward (*Server).Handler/Start/Stop, which register the unauthenticated
+// routes (/health, /ping, /readyz, /status, /api/backends/health, the metrics and
+// .well-known endpoints, and any embedded auth-server routes) when Serve's *Server
+// is served.
 //
-// The remaining transport concerns — the SDK session hooks and two-phase session
-// creation, the authenticated middleware chain, the direct VMCP request path, and
-// the AS runner / status reporter / optimizer / health monitor lifecycle — are
-// relocated under Serve by the subsequent Phase 2 tasks. server.New is not yet
-// routed through Serve, so this is purely additive and observable behavior is
-// unchanged.
+// The remaining transport concerns — the authenticated middleware chain (#5441), the
+// direct VMCP request path (#5442), and the AS runner / status reporter / optimizer /
+// health monitor lifecycle (#5443) — are relocated under Serve by the subsequent
+// Phase 2 tasks. server.New is not yet routed through Serve and keeps its own copy of
+// the session wiring until Phase 3, so this is purely additive and observable behavior
+// is unchanged.
 //
-// Serve returns a vmcp.ErrInvalidConfig-wrapped error for a nil cfg, a nil core, or
-// a nil required collaborator (SessionFactory). The ctx parameter is reserved for
-// the transport wiring relocated by later phases.
+// Serve returns a vmcp.ErrInvalidConfig-wrapped error for a nil cfg, a nil core, or a
+// nil required collaborator (SessionManagerConfig). The session hooks close over the
+// constructed *Server, so they are registered after it is assembled.
 //
-// Contract: the returned *Server has nil session manager, discovery manager, and
-// backend registry at this phase. It must NOT be Start()ed or served on the "/" MCP
-// route until #5440/#5441/#5442 wire those fields — the carried-forward Handler
-// passes them to WithSessionIdManager and discovery.Middleware, which would nil-deref.
-// The unauthenticated routes (registered as direct mux entries) are safe to serve.
-func Serve(_ context.Context, v core.VMCP, cfg *ServerConfig) (*Server, error) {
+// Contract: the returned *Server now has a live session manager and backend registry,
+// but a nil discovery manager, router, and backend client at this phase. It must NOT
+// be Start()ed or served on the "/" MCP route until #5441/#5442 wire those fields —
+// the carried-forward Handler passes them to discovery.Middleware, which would
+// nil-deref. The unauthenticated routes (registered as direct mux entries) are safe
+// to serve.
+func Serve(ctx context.Context, v core.VMCP, cfg *ServerConfig) (*Server, error) {
 	if cfg == nil {
 		return nil, fmt.Errorf("%w: nil server config", vmcp.ErrInvalidConfig)
 	}
 	if v == nil {
 		return nil, fmt.Errorf("%w: VMCP is required", vmcp.ErrInvalidConfig)
 	}
-	if cfg.SessionFactory == nil {
-		return nil, fmt.Errorf("%w: SessionFactory is required", vmcp.ErrInvalidConfig)
+	if cfg.SessionManagerConfig == nil {
+		return nil, fmt.Errorf("%w: SessionManagerConfig is required", vmcp.ErrInvalidConfig)
 	}
 
 	serveCfg := buildServeConfig(cfg)
 
+	// Build the SDK hooks up front so they can be passed to NewMCPServer, but
+	// register their callbacks after srv is assembled below — the callbacks close
+	// over srv (relocated from server.New, where the hooks object is co-located with
+	// the mcp-go server for the same reason).
+	hooks := &server.Hooks{}
+
 	// Build the mcp-go server (mirrors server.New): tools and resources are
-	// registered dynamically, so capabilities start disabled. Hooks are empty for
-	// now; the session hooks are relocated here by a later Phase 2 task.
+	// registered dynamically, so capabilities start disabled.
 	mcpServer := server.NewMCPServer(
 		serveCfg.Name,
 		serveCfg.Version,
 		server.WithToolCapabilities(false),
 		server.WithResourceCapabilities(false, false),
 		server.WithLogging(),
-		server.WithHooks(&server.Hooks{}),
+		server.WithHooks(hooks),
 	)
 
+	// Two-phase session-creation wiring (relocated from server.New). The transport
+	// session manager holds the lightweight Streamable HTTP placeholders; the
+	// pluggable data storage holds serialisable session metadata (memory or Redis,
+	// reading THV_SESSION_REDIS_PASSWORD); the vMCP session manager owns the live,
+	// node-local MultiSessions.
+	sessionManager := transportsession.NewManager(serveCfg.SessionTTL, transportsession.NewStreamableSession)
+
+	sessionDataStorage, err := buildSessionDataStorage(ctx, serveCfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create session data storage: %w", err)
+	}
+	// Close sessionDataStorage if Serve returns an error after this point so the
+	// background cleanup goroutine does not leak (go-style: pair acquisition with
+	// release).
+	closeStorageOnErr := true
+	defer func() {
+		if closeStorageOnErr {
+			_ = sessionDataStorage.Close()
+		}
+	}()
+
+	vmcpSessMgr, optimizerCleanup, err := sessionmanager.New(sessionDataStorage, cfg.SessionManagerConfig, cfg.BackendRegistry)
+	if err != nil {
+		return nil, err
+	}
+
 	srv := &Server{
-		config:         serveCfg,
-		mcpServer:      mcpServer,
-		ready:          make(chan struct{}),
-		healthMonitor:  cfg.HealthMonitor,
-		statusReporter: cfg.StatusReporter,
+		config:             serveCfg,
+		mcpServer:          mcpServer,
+		backendRegistry:    cfg.BackendRegistry,
+		sessionManager:     sessionManager,
+		sessionDataStorage: sessionDataStorage,
+		vmcpSessionMgr:     vmcpSessMgr,
+		ready:              make(chan struct{}),
+		healthMonitor:      cfg.HealthMonitor,
+		statusReporter:     cfg.StatusReporter,
+	}
+
+	if optimizerCleanup != nil {
+		srv.shutdownFuncs = append(srv.shutdownFuncs, optimizerCleanup)
 	}
 
 	// Serve owns the injected core's lifecycle: release its backend connections
@@ -179,6 +234,22 @@ func Serve(_ context.Context, v core.VMCP, cfg *ServerConfig) (*Server, error) {
 		return v.Close()
 	})
 
+	// Register the three SDK hooks against the assembled *Server (relocated from
+	// server.New). They drive phase-2 of two-phase creation (OnRegisterSession) and
+	// the cross-pod Redis re-hydration of per-session tools (OnBeforeListTools /
+	// OnBeforeCallTool); the *Server receiver methods are unchanged.
+	hooks.AddOnRegisterSession(func(hookCtx context.Context, session server.ClientSession) {
+		srv.handleSessionRegistration(hookCtx, session)
+	})
+	hooks.AddBeforeListTools(func(hookCtx context.Context, _ any, _ *mcp.ListToolsRequest) {
+		srv.lazyInjectSessionTools(hookCtx)
+	})
+	hooks.AddBeforeCallTool(func(hookCtx context.Context, _ any, _ *mcp.CallToolRequest) {
+		srv.lazyInjectSessionTools(hookCtx)
+	})
+
+	// Disarm the close-on-error guard: the Server is fully constructed.
+	closeStorageOnErr = false
 	return srv, nil
 }
 
@@ -188,7 +259,7 @@ func Serve(_ context.Context, v core.VMCP, cfg *ServerConfig) (*Server, error) {
 // mutating the caller's ServerConfig (go-style: copy before mutating caller input).
 // Port 0 is left untouched to mean "OS-assigned".
 //
-// Three Config fields are deliberately NOT mapped at this phase (see
+// Several Config fields are deliberately NOT mapped at this phase (see
 // TestBuildServeConfigMapsSharedFields, which guards this list against drift):
 //   - AuthzMiddleware: the authenticated/authz middleware chain is relocated under
 //     Serve by #5441, after which authorization moves to the core admission seam.
@@ -198,6 +269,10 @@ func Serve(_ context.Context, v core.VMCP, cfg *ServerConfig) (*Server, error) {
 //   - StatusReporter: Serve assigns ServerConfig.StatusReporter to the Server field
 //     directly (like HealthMonitor); nothing reads Config.StatusReporter on the Serve
 //     path, so mapping it here would be dead.
+//   - SessionFactory, OptimizerFactory, OptimizerConfig: the vMCP session manager is
+//     built directly in Serve from ServerConfig.SessionManagerConfig (a pre-built
+//     *sessionmanager.FactoryConfig that carries the session factory and optimizer
+//     wiring), not via Config→New, so these Config fields are unused on the Serve path.
 func buildServeConfig(cfg *ServerConfig) *Config {
 	return &Config{
 		Name:                    cmp.Or(cfg.Name, defaultServerName),
@@ -214,9 +289,6 @@ func buildServeConfig(cfg *ServerConfig) *Config {
 		AuditConfig:             cfg.AuditConfig,
 		StatusReportingInterval: cfg.StatusReportingInterval,
 		Watcher:                 cfg.Watcher,
-		OptimizerFactory:        cfg.OptimizerFactory,
-		OptimizerConfig:         cfg.OptimizerConfig,
-		SessionFactory:          cfg.SessionFactory,
 		SessionStorage:          cfg.SessionStorage,
 	}
 }

--- a/pkg/vmcp/server/serve.go
+++ b/pkg/vmcp/server/serve.go
@@ -113,6 +113,12 @@ type ServerConfig struct {
 	// Required; Serve returns an error when it is nil. The composition root assembles
 	// it because the ComposerFactory closes over the core-owned router and backend
 	// client.
+	//
+	// Caller responsibility: unlike server.New, Serve does NOT run validateWorkflows on
+	// FactoryConfig.WorkflowDefs — the composition root must validate composite-tool
+	// definitions before assembling this config (sessionmanager.New only checks the
+	// WorkflowDefs/ComposerFactory pairing). This responsibility moves here with the
+	// relocation and matters when server.New is routed through Serve in Phase 3.
 	SessionManagerConfig *sessionmanager.FactoryConfig
 
 	// TelemetryProvider is the cross-cutting telemetry provider (also consumed by
@@ -146,8 +152,9 @@ type ServerConfig struct {
 // is unchanged.
 //
 // Serve returns a vmcp.ErrInvalidConfig-wrapped error for a nil cfg, a nil core, or a
-// nil required collaborator (SessionManagerConfig). The session hooks close over the
-// constructed *Server, so they are registered after it is assembled.
+// nil required collaborator (SessionManagerConfig or BackendRegistry). The session
+// hooks close over the constructed *Server, so they are registered after it is
+// assembled.
 //
 // Contract: the returned *Server now has a live session manager and backend registry,
 // but a nil discovery manager, router, and backend client at this phase. It must NOT
@@ -164,6 +171,12 @@ func Serve(ctx context.Context, v core.VMCP, cfg *ServerConfig) (*Server, error)
 	}
 	if cfg.SessionManagerConfig == nil {
 		return nil, fmt.Errorf("%w: SessionManagerConfig is required", vmcp.ErrInvalidConfig)
+	}
+	if cfg.BackendRegistry == nil {
+		// Required: the OnRegisterSession hook enumerates the registry to open the
+		// session's backend connections, so a nil registry would nil-panic inside the
+		// hook goroutine (where the error is swallowed) rather than here. Fail loudly.
+		return nil, fmt.Errorf("%w: BackendRegistry is required", vmcp.ErrInvalidConfig)
 	}
 
 	serveCfg := buildServeConfig(cfg)

--- a/pkg/vmcp/server/serve.go
+++ b/pkg/vmcp/server/serve.go
@@ -198,13 +198,11 @@ func Serve(ctx context.Context, v core.VMCP, cfg *ServerConfig) (*Server, error)
 		server.WithHooks(hooks),
 	)
 
-	// Two-phase session-creation wiring (relocated from server.New). The transport
-	// session manager holds the lightweight Streamable HTTP placeholders; the
-	// pluggable data storage holds serialisable session metadata (memory or Redis,
-	// reading THV_SESSION_REDIS_PASSWORD); the vMCP session manager owns the live,
-	// node-local MultiSessions.
-	sessionManager := transportsession.NewManager(serveCfg.SessionTTL, transportsession.NewStreamableSession)
-
+	// Two-phase session-creation wiring (relocated from server.New). The pluggable
+	// data storage holds serialisable session metadata (memory or Redis, reading
+	// THV_SESSION_REDIS_PASSWORD); the vMCP session manager owns the live, node-local
+	// MultiSessions; the transport session manager (built last, below) holds the
+	// lightweight Streamable HTTP placeholders.
 	sessionDataStorage, err := buildSessionDataStorage(ctx, serveCfg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create session data storage: %w", err)
@@ -223,6 +221,11 @@ func Serve(ctx context.Context, v core.VMCP, cfg *ServerConfig) (*Server, error)
 	if err != nil {
 		return nil, err
 	}
+
+	// Built last — after the fallible calls above — because NewManager starts a cleanup
+	// goroutine on construction (released only by Stop), so an early error return cannot
+	// leak it (mirroring the closeStorageOnErr guard on the sibling sessionDataStorage).
+	sessionManager := transportsession.NewManager(serveCfg.SessionTTL, transportsession.NewStreamableSession)
 
 	srv := &Server{
 		config:             serveCfg,

--- a/pkg/vmcp/server/serve_session_test.go
+++ b/pkg/vmcp/server/serve_session_test.go
@@ -10,11 +10,11 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -41,8 +41,6 @@ import (
 // toolSessionState tracks observable behaviour of the mock session factory below.
 type toolSessionState struct {
 	makeWithIDCalled atomic.Bool
-	mu               sync.Mutex
-	lastSession      *sessionmocks.MockMultiSession
 }
 
 // newToolSessionFactory creates a MockMultiSessionFactory whose MakeSessionWithID
@@ -87,9 +85,6 @@ func newToolSessionFactory(
 			mock.EXPECT().CallTool(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 				Return(&vmcp.ToolCallResult{Content: []vmcp.Content{{Type: "text", Text: "ok"}}}, nil).AnyTimes()
 			mock.EXPECT().Close().Return(nil).AnyTimes()
-			state.mu.Lock()
-			state.lastSession = mock
-			state.mu.Unlock()
 			return mock, nil
 		}).AnyTimes()
 	return factory, state
@@ -162,11 +157,100 @@ func TestServeRegistersSessionHooks(t *testing.T) {
 		"tools/list should advertise the tool injected by the OnRegisterSession hook")
 }
 
-// TestServeClosesStorageOnSessionManagerError verifies the closeStorageOnErr guard:
-// when sessionmanager.New fails after the session data storage is built, Serve
-// returns the error (so the deferred guard closes the storage and its cleanup
-// goroutine does not leak). A negative CacheCapacity is the cheapest forced failure.
-func TestServeClosesStorageOnSessionManagerError(t *testing.T) {
+// fakeSDKSession is a minimal server.ClientSession + server.SessionWithTools used to
+// drive lazyInjectSessionTools directly (the SDK's session-context plumbing is otherwise
+// only reachable over HTTP, via MCPServer.WithContext). Its tool store is the observable
+// surface the injection asserts against.
+type fakeSDKSession struct {
+	id    string
+	tools map[string]server.ServerTool
+}
+
+var (
+	_ server.ClientSession    = (*fakeSDKSession)(nil)
+	_ server.SessionWithTools = (*fakeSDKSession)(nil)
+)
+
+func (f *fakeSDKSession) SessionID() string                                 { return f.id }
+func (*fakeSDKSession) Initialize()                                         {}
+func (*fakeSDKSession) Initialized() bool                                   { return true }
+func (*fakeSDKSession) NotificationChannel() chan<- mcp.JSONRPCNotification { return nil }
+func (f *fakeSDKSession) GetSessionTools() map[string]server.ServerTool     { return f.tools }
+func (f *fakeSDKSession) SetSessionTools(t map[string]server.ServerTool)    { f.tools = t }
+
+// TestServeLazyInjectsToolsForRehydratedSession exercises the cross-pod re-injection
+// branch of lazyInjectSessionTools that TestServeRegistersSessionHooks does not reach:
+// a session exists in the vMCP session manager, but a fresh SDK ClientSession (as on a
+// second pod, where OnRegisterSession never fired) has an empty per-session tool store.
+// The before-list/before-call hooks must re-inject the tools from the session manager.
+func TestServeLazyInjectsToolsForRehydratedSession(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	testTool := vmcp.Tool{Name: "serve-tool", Description: "a relocated-wiring test tool"}
+	factory, _ := newToolSessionFactory(t, ctrl, []vmcp.Tool{testTool})
+
+	srv, err := Serve(context.Background(), &stubVMCP{}, &ServerConfig{
+		SessionManagerConfig: &sessionmanager.FactoryConfig{Base: factory},
+		BackendRegistry:      vmcp.NewImmutableRegistry([]vmcp.Backend{}),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = srv.Stop(context.Background()) })
+
+	// Register a session in the vMCP session manager via the SDK initialize path.
+	streamable := server.NewStreamableHTTPServer(
+		srv.mcpServer,
+		server.WithEndpointPath("/mcp"),
+		server.WithSessionIdManager(srv.vmcpSessionMgr),
+	)
+	ts := httptest.NewServer(streamable)
+	t.Cleanup(ts.Close)
+
+	initResp := postServeMCP(t, ts.URL, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "initialize",
+		"params": map[string]any{
+			"protocolVersion": "2025-06-18",
+			"capabilities":    map[string]any{},
+			"clientInfo":      map[string]any{"name": "test", "version": "1.0"},
+		},
+	}, "")
+	defer initResp.Body.Close()
+	require.Equal(t, http.StatusOK, initResp.StatusCode)
+	sessionID := initResp.Header.Get("Mcp-Session-Id")
+	require.NotEmpty(t, sessionID)
+
+	// Wait until the session is fully registered with adapted tools in the manager.
+	require.Eventually(t, func() bool {
+		tools, gErr := srv.vmcpSessionMgr.GetAdaptedTools(sessionID)
+		return gErr == nil && len(tools) > 0
+	}, 2*time.Second, 10*time.Millisecond, "session should be registered with adapted tools")
+
+	// Empty-store (cross-pod) branch: a fresh SDK session with no tools gets them injected.
+	rehydrated := &fakeSDKSession{id: sessionID, tools: map[string]server.ServerTool{}}
+	srv.lazyInjectSessionTools(srv.mcpServer.WithContext(context.Background(), rehydrated))
+	assert.Contains(t, rehydrated.tools, testTool.Name,
+		"an empty per-session store should be re-injected from the vMCP session manager")
+
+	// No-op branch: a populated store is left untouched (early return before GetAdaptedTools).
+	populated := &fakeSDKSession{id: sessionID, tools: map[string]server.ServerTool{
+		"preexisting": {Tool: mcp.Tool{Name: "preexisting"}},
+	}}
+	srv.lazyInjectSessionTools(srv.mcpServer.WithContext(context.Background(), populated))
+	assert.NotContains(t, populated.tools, testTool.Name, "a populated store must not be modified (no-op)")
+	assert.Contains(t, populated.tools, "preexisting")
+}
+
+// TestServeReturnsErrorWhenSessionManagerConstructionFails verifies Serve surfaces a
+// sessionmanager.New failure — the path the closeStorageOnErr guard protects. It
+// confirms the guarded path is reached (the failure occurs AFTER session data storage
+// is built, distinct from config validation: ErrorContains("CacheCapacity") +
+// NotErrorIs(ErrInvalidConfig)). It does NOT directly observe sessionDataStorage.Close()
+// — the storage is constructed internally and the test holds no handle to it; the
+// close itself is the same defer-guard pattern carried over verbatim from server.New.
+// A negative CacheCapacity is the cheapest forced failure.
+func TestServeReturnsErrorWhenSessionManagerConstructionFails(t *testing.T) {
 	t.Parallel()
 
 	srv, err := Serve(context.Background(), &stubVMCP{}, &ServerConfig{
@@ -244,6 +328,10 @@ func TestBuildSessionDataStorageRedis(t *testing.T) {
 	})
 	require.Error(t, err)
 	assert.Nil(t, ds)
+	// Bind to the Redis connection-failure wrap so a future config/unsupported-provider
+	// error can't satisfy this test. ("redis" alone is unsuitable — the unsupported-
+	// provider error text also lists "redis".)
+	assert.ErrorContains(t, err, "redis: failed to connect")
 }
 
 // postServeMCP sends a JSON-RPC POST to the given Streamable HTTP base URL. It is the

--- a/pkg/vmcp/server/serve_session_test.go
+++ b/pkg/vmcp/server/serve_session_test.go
@@ -1,0 +1,263 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/stacklok/toolhive/pkg/auth"
+	transportsession "github.com/stacklok/toolhive/pkg/transport/session"
+	"github.com/stacklok/toolhive/pkg/vmcp"
+	vmcpconfig "github.com/stacklok/toolhive/pkg/vmcp/config"
+	"github.com/stacklok/toolhive/pkg/vmcp/server/sessionmanager"
+	vmcpsession "github.com/stacklok/toolhive/pkg/vmcp/session"
+	sessionfactorymocks "github.com/stacklok/toolhive/pkg/vmcp/session/mocks"
+	sessionmocks "github.com/stacklok/toolhive/pkg/vmcp/session/types/mocks"
+)
+
+// These tests exercise the session-creation wiring and SDK hooks relocated into
+// Serve (#5440). They drive the SDK session lifecycle through the relocated
+// vmcpSessionMgr + mcpServer directly, mounting the Streamable HTTP server WITHOUT
+// the authenticated discovery middleware (relocated by #5441/#5442). That keeps the
+// test within this task's scope while proving the hooks fire and two-phase session
+// creation runs identically when Serve is exercised directly. The full HTTP suite
+// stays on server.New (its parity gate) in session_management_integration_test.go.
+
+// toolSessionState tracks observable behaviour of the mock session factory below.
+type toolSessionState struct {
+	makeWithIDCalled atomic.Bool
+	mu               sync.Mutex
+	lastSession      *sessionmocks.MockMultiSession
+}
+
+// newToolSessionFactory creates a MockMultiSessionFactory whose MakeSessionWithID
+// returns a MockMultiSession advertising the given tools, mirroring the proven mock
+// in session_management_integration_test.go so GetAdaptedTools produces SDK tools.
+func newToolSessionFactory(
+	t *testing.T, ctrl *gomock.Controller, tools []vmcp.Tool,
+) (*sessionfactorymocks.MockMultiSessionFactory, *toolSessionState) {
+	t.Helper()
+	state := &toolSessionState{}
+	factory := sessionfactorymocks.NewMockMultiSessionFactory(ctrl)
+	factory.EXPECT().MakeSessionWithID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, id string, _ *auth.Identity, _ []*vmcp.Backend) (vmcpsession.MultiSession, error) {
+			state.makeWithIDCalled.Store(true)
+			mock := sessionmocks.NewMockMultiSession(ctrl)
+			mock.EXPECT().ID().Return(id).AnyTimes()
+			mock.EXPECT().UpdatedAt().Return(time.Time{}).AnyTimes()
+			mock.EXPECT().CreatedAt().Return(time.Time{}).AnyTimes()
+			mock.EXPECT().Type().Return(transportsession.SessionType("")).AnyTimes()
+			mock.EXPECT().GetData().Return(nil).AnyTimes()
+			mock.EXPECT().SetData(gomock.Any()).AnyTimes()
+			// Identity binding so Terminate takes the storage.Delete path; the sentinel
+			// value is sufficient for tests that do not validate the binding content.
+			mock.EXPECT().GetMetadata().Return(map[string]string{
+				vmcpsession.MetadataKeyIdentityBinding: "unauthenticated",
+			}).AnyTimes()
+			mock.EXPECT().SetMetadata(gomock.Any(), gomock.Any()).AnyTimes()
+			toolsCopy := make([]vmcp.Tool, len(tools))
+			copy(toolsCopy, tools)
+			mock.EXPECT().Tools().Return(toolsCopy).AnyTimes()
+			mock.EXPECT().AllTools().Return(toolsCopy).AnyTimes()
+			mock.EXPECT().Resources().Return(nil).AnyTimes()
+			mock.EXPECT().Prompts().Return(nil).AnyTimes()
+			mock.EXPECT().BackendSessions().Return(nil).AnyTimes()
+			rt := &vmcp.RoutingTable{Tools: make(map[string]*vmcp.BackendTarget, len(tools))}
+			for _, tool := range tools {
+				rt.Tools[tool.Name] = &vmcp.BackendTarget{WorkloadID: tool.Name}
+			}
+			mock.EXPECT().GetRoutingTable().Return(rt).AnyTimes()
+			mock.EXPECT().ReadResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+			mock.EXPECT().GetPrompt(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+			mock.EXPECT().CallTool(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(&vmcp.ToolCallResult{Content: []vmcp.Content{{Type: "text", Text: "ok"}}}, nil).AnyTimes()
+			mock.EXPECT().Close().Return(nil).AnyTimes()
+			state.mu.Lock()
+			state.lastSession = mock
+			state.mu.Unlock()
+			return mock, nil
+		}).AnyTimes()
+	return factory, state
+}
+
+// TestServeRegistersSessionHooks verifies that Serve registers the OnRegisterSession
+// hook and wires two-phase session creation: an MCP initialize triggers the hook,
+// which creates the session (MakeSessionWithID) and injects its tools, so a
+// subsequent tools/list advertises them. The OnBeforeListTools hook also runs (and
+// no-ops, since the tools are already present on this pod).
+func TestServeRegistersSessionHooks(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	testTool := vmcp.Tool{Name: "serve-tool", Description: "a relocated-wiring test tool"}
+	factory, state := newToolSessionFactory(t, ctrl, []vmcp.Tool{testTool})
+
+	srv, err := Serve(context.Background(), &stubVMCP{}, &ServerConfig{
+		SessionManagerConfig: &sessionmanager.FactoryConfig{Base: factory},
+		BackendRegistry:      vmcp.NewImmutableRegistry([]vmcp.Backend{}),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = srv.Stop(context.Background()) })
+
+	// Mount the Streamable HTTP server on the relocated mcpServer + vmcpSessionMgr,
+	// bypassing the not-yet-relocated discovery middleware (#5441/#5442).
+	streamable := server.NewStreamableHTTPServer(
+		srv.mcpServer,
+		server.WithEndpointPath("/mcp"),
+		server.WithSessionIdManager(srv.vmcpSessionMgr),
+	)
+	ts := httptest.NewServer(streamable)
+	t.Cleanup(ts.Close)
+
+	// initialize → fires OnRegisterSession → CreateSession → tool injection.
+	initResp := postServeMCP(t, ts.URL, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "initialize",
+		"params": map[string]any{
+			"protocolVersion": "2025-06-18",
+			"capabilities":    map[string]any{},
+			"clientInfo":      map[string]any{"name": "test", "version": "1.0"},
+		},
+	}, "")
+	defer initResp.Body.Close()
+	require.Equal(t, http.StatusOK, initResp.StatusCode, "initialize should succeed")
+
+	sessionID := initResp.Header.Get("Mcp-Session-Id")
+	require.NotEmpty(t, sessionID, "session ID should be returned in Mcp-Session-Id header")
+
+	// The OnRegisterSession hook may complete asynchronously after the response.
+	require.Eventually(t, state.makeWithIDCalled.Load, 2*time.Second, 10*time.Millisecond,
+		"OnRegisterSession hook should have created the session via MakeSessionWithID")
+
+	// tools/list runs the OnBeforeListTools hook and returns the per-session tools
+	// injected during registration.
+	listResp := postServeMCP(t, ts.URL, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      2,
+		"method":  "tools/list",
+		"params":  map[string]any{},
+	}, sessionID)
+	defer listResp.Body.Close()
+
+	body, err := io.ReadAll(listResp.Body)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, listResp.StatusCode, "tools/list should succeed; body: %s", string(body))
+	assert.Contains(t, string(body), testTool.Name,
+		"tools/list should advertise the tool injected by the OnRegisterSession hook")
+}
+
+// TestServeClosesStorageOnSessionManagerError verifies the closeStorageOnErr guard:
+// when sessionmanager.New fails after the session data storage is built, Serve
+// returns the error (so the deferred guard closes the storage and its cleanup
+// goroutine does not leak). A negative CacheCapacity is the cheapest forced failure.
+func TestServeClosesStorageOnSessionManagerError(t *testing.T) {
+	t.Parallel()
+
+	srv, err := Serve(context.Background(), &stubVMCP{}, &ServerConfig{
+		SessionManagerConfig: &sessionmanager.FactoryConfig{Base: testMinimalFactory(), CacheCapacity: -1},
+	})
+	require.Error(t, err)
+	assert.Nil(t, srv)
+	// Construction failure, not a config-validation error.
+	assert.NotErrorIs(t, err, vmcp.ErrInvalidConfig)
+	assert.ErrorContains(t, err, "CacheCapacity")
+}
+
+// TestBuildSessionDataStorage verifies provider selection: nil/empty/"memory"
+// (case-insensitive) yields in-process storage; "redis" takes the Redis path
+// (reading THV_SESSION_REDIS_PASSWORD); any other provider is rejected.
+func TestBuildSessionDataStorage(t *testing.T) {
+	// Not parallel: the redis subtest uses t.Setenv, which Go forbids in tests with
+	// a parallel ancestor.
+
+	t.Run("in-process providers", func(t *testing.T) {
+		t.Parallel()
+		cases := []struct {
+			name    string
+			storage *vmcpconfig.SessionStorageConfig
+		}{
+			{"nil config", nil},
+			{"empty provider", &vmcpconfig.SessionStorageConfig{Provider: ""}},
+			{"memory provider", &vmcpconfig.SessionStorageConfig{Provider: "memory"}},
+			{"mixed-case memory provider", &vmcpconfig.SessionStorageConfig{Provider: "Memory"}},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				ds, err := buildSessionDataStorage(context.Background(), &Config{
+					SessionTTL:     time.Minute,
+					SessionStorage: tc.storage,
+				})
+				require.NoError(t, err)
+				require.NotNil(t, ds)
+				assert.IsType(t, &transportsession.LocalSessionDataStorage{}, ds)
+				t.Cleanup(func() { _ = ds.Close() })
+			})
+		}
+	})
+
+	t.Run("redis provider takes the redis path", func(t *testing.T) {
+		// No t.Parallel: t.Setenv is incompatible with parallel tests.
+		t.Setenv(vmcpconfig.RedisPasswordEnvVar, "test-password")
+		// Unreachable address so the construction-time Ping fails fast, proving the
+		// redis branch was taken (in-process storage would not error here).
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		ds, err := buildSessionDataStorage(ctx, &Config{
+			SessionTTL: time.Minute,
+			SessionStorage: &vmcpconfig.SessionStorageConfig{
+				Provider: "redis",
+				Address:  "127.0.0.1:1",
+			},
+		})
+		require.Error(t, err)
+		assert.Nil(t, ds)
+	})
+
+	t.Run("unsupported provider is rejected", func(t *testing.T) {
+		t.Parallel()
+		ds, err := buildSessionDataStorage(context.Background(), &Config{
+			SessionTTL:     time.Minute,
+			SessionStorage: &vmcpconfig.SessionStorageConfig{Provider: "postgres"},
+		})
+		require.Error(t, err)
+		assert.Nil(t, ds)
+		assert.ErrorContains(t, err, "unsupported session storage provider")
+	})
+}
+
+// postServeMCP sends a JSON-RPC POST to the given Streamable HTTP base URL. It is the
+// package-server-internal analogue of the postMCP helper in the external suite.
+func postServeMCP(t *testing.T, baseURL string, body map[string]any, sessionID string) *http.Response {
+	t.Helper()
+	rawBody, err := json.Marshal(body)
+	require.NoError(t, err)
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, baseURL+"/mcp", bytes.NewReader(rawBody))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	if sessionID != "" {
+		req.Header.Set("Mcp-Session-Id", sessionID)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	return resp
+}

--- a/pkg/vmcp/server/serve_session_test.go
+++ b/pkg/vmcp/server/serve_session_test.go
@@ -171,20 +171,22 @@ func TestServeClosesStorageOnSessionManagerError(t *testing.T) {
 
 	srv, err := Serve(context.Background(), &stubVMCP{}, &ServerConfig{
 		SessionManagerConfig: &sessionmanager.FactoryConfig{Base: testMinimalFactory(), CacheCapacity: -1},
+		BackendRegistry:      vmcp.NewImmutableRegistry([]vmcp.Backend{}),
 	})
 	require.Error(t, err)
 	assert.Nil(t, srv)
-	// Construction failure, not a config-validation error.
+	// Construction failure from sessionmanager.New (after the storage is built, so the
+	// closeStorageOnErr guard runs) — not a config-validation error.
 	assert.NotErrorIs(t, err, vmcp.ErrInvalidConfig)
 	assert.ErrorContains(t, err, "CacheCapacity")
 }
 
 // TestBuildSessionDataStorage verifies provider selection: nil/empty/"memory"
-// (case-insensitive) yields in-process storage; "redis" takes the Redis path
-// (reading THV_SESSION_REDIS_PASSWORD); any other provider is rejected.
+// (case-insensitive) yields in-process storage; any unknown provider is rejected.
+// The "redis" path is covered separately by TestBuildSessionDataStorageRedis, which
+// cannot be parallel (it uses t.Setenv).
 func TestBuildSessionDataStorage(t *testing.T) {
-	// Not parallel: the redis subtest uses t.Setenv, which Go forbids in tests with
-	// a parallel ancestor.
+	t.Parallel()
 
 	t.Run("in-process providers", func(t *testing.T) {
 		t.Parallel()
@@ -212,24 +214,6 @@ func TestBuildSessionDataStorage(t *testing.T) {
 		}
 	})
 
-	t.Run("redis provider takes the redis path", func(t *testing.T) {
-		// No t.Parallel: t.Setenv is incompatible with parallel tests.
-		t.Setenv(vmcpconfig.RedisPasswordEnvVar, "test-password")
-		// Unreachable address so the construction-time Ping fails fast, proving the
-		// redis branch was taken (in-process storage would not error here).
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-		defer cancel()
-		ds, err := buildSessionDataStorage(ctx, &Config{
-			SessionTTL: time.Minute,
-			SessionStorage: &vmcpconfig.SessionStorageConfig{
-				Provider: "redis",
-				Address:  "127.0.0.1:1",
-			},
-		})
-		require.Error(t, err)
-		assert.Nil(t, ds)
-	})
-
 	t.Run("unsupported provider is rejected", func(t *testing.T) {
 		t.Parallel()
 		ds, err := buildSessionDataStorage(context.Background(), &Config{
@@ -240,6 +224,26 @@ func TestBuildSessionDataStorage(t *testing.T) {
 		assert.Nil(t, ds)
 		assert.ErrorContains(t, err, "unsupported session storage provider")
 	})
+}
+
+// TestBuildSessionDataStorageRedis verifies the "redis" provider takes the Redis path
+// (reading THV_SESSION_REDIS_PASSWORD). It is a separate, non-parallel test because
+// t.Setenv is incompatible with parallel tests (and any parallel ancestor).
+func TestBuildSessionDataStorageRedis(t *testing.T) {
+	t.Setenv(vmcpconfig.RedisPasswordEnvVar, "test-password")
+	// Unreachable address so the construction-time Ping fails fast, proving the redis
+	// branch was taken (in-process storage would not error here).
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	ds, err := buildSessionDataStorage(ctx, &Config{
+		SessionTTL: time.Minute,
+		SessionStorage: &vmcpconfig.SessionStorageConfig{
+			Provider: "redis",
+			Address:  "127.0.0.1:1",
+		},
+	})
+	require.Error(t, err)
+	assert.Nil(t, ds)
 }
 
 // postServeMCP sends a JSON-RPC POST to the given Streamable HTTP base URL. It is the

--- a/pkg/vmcp/server/serve_test.go
+++ b/pkg/vmcp/server/serve_test.go
@@ -85,11 +85,21 @@ func testMinimalSessionManagerConfig() *sessionmanager.FactoryConfig {
 	return &sessionmanager.FactoryConfig{Base: testMinimalFactory()}
 }
 
+// testMinimalServeConfig returns a minimal valid ServerConfig for Serve tests that do
+// not exercise session creation: a non-nil SessionManagerConfig and an empty
+// BackendRegistry, the two required collaborators Serve validates.
+func testMinimalServeConfig() *ServerConfig {
+	return &ServerConfig{
+		SessionManagerConfig: testMinimalSessionManagerConfig(),
+		BackendRegistry:      vmcp.NewImmutableRegistry([]vmcp.Backend{}),
+	}
+}
+
 func TestServeAppliesTransportDefaults(t *testing.T) {
 	t.Parallel()
 
 	// Empty transport fields exercise every default; Port is left zero.
-	cfg := &ServerConfig{SessionManagerConfig: testMinimalSessionManagerConfig()}
+	cfg := testMinimalServeConfig()
 
 	srv, err := Serve(context.Background(), &stubVMCP{}, cfg)
 	require.NoError(t, err)
@@ -129,6 +139,7 @@ func TestServePreservesExplicitConfig(t *testing.T) {
 		SessionTTL:              7 * time.Minute,
 		StatusReportingInterval: 11 * time.Second,
 		SessionManagerConfig:    testMinimalSessionManagerConfig(),
+		BackendRegistry:         vmcp.NewImmutableRegistry([]vmcp.Backend{}),
 	}
 
 	srv, err := Serve(context.Background(), &stubVMCP{}, cfg)
@@ -148,7 +159,7 @@ func TestServePreservesExplicitConfig(t *testing.T) {
 func TestServeHandlerRegistersUnauthenticatedRoutes(t *testing.T) {
 	t.Parallel()
 
-	cfg := &ServerConfig{SessionManagerConfig: testMinimalSessionManagerConfig()}
+	cfg := testMinimalServeConfig()
 	srv, err := Serve(context.Background(), &stubVMCP{}, cfg)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = srv.Stop(context.Background()) })
@@ -197,6 +208,7 @@ func TestServeHandlerRegistersMetricsWhenTelemetryEnabled(t *testing.T) {
 
 	srv, err := Serve(ctx, &stubVMCP{}, &ServerConfig{
 		SessionManagerConfig: testMinimalSessionManagerConfig(),
+		BackendRegistry:      vmcp.NewImmutableRegistry([]vmcp.Backend{}),
 		TelemetryProvider:    provider,
 	})
 	require.NoError(t, err)
@@ -215,7 +227,7 @@ func TestServeStopClosesCore(t *testing.T) {
 	t.Parallel()
 
 	stub := &stubVMCP{}
-	srv, err := Serve(context.Background(), stub, &ServerConfig{SessionManagerConfig: testMinimalSessionManagerConfig()})
+	srv, err := Serve(context.Background(), stub, testMinimalServeConfig())
 	require.NoError(t, err)
 
 	// Stop on a never-started server still runs the shutdown funcs, which release
@@ -240,12 +252,17 @@ func TestServeValidation(t *testing.T) {
 		{
 			name: "nil vmcp",
 			v:    nil,
-			cfg:  &ServerConfig{SessionManagerConfig: testMinimalSessionManagerConfig()},
+			cfg:  testMinimalServeConfig(),
 		},
 		{
 			name: "nil session manager config",
 			v:    &stubVMCP{},
-			cfg:  &ServerConfig{},
+			cfg:  &ServerConfig{BackendRegistry: vmcp.NewImmutableRegistry([]vmcp.Backend{})},
+		},
+		{
+			name: "nil backend registry",
+			v:    &stubVMCP{},
+			cfg:  &ServerConfig{SessionManagerConfig: testMinimalSessionManagerConfig()},
 		},
 		{
 			// Both nil: cfg is checked first, so this must fail cleanly (no panic

--- a/pkg/vmcp/server/serve_test.go
+++ b/pkg/vmcp/server/serve_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/mark3labs/mcp-go/server"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -23,7 +22,7 @@ import (
 	vmcpconfig "github.com/stacklok/toolhive/pkg/vmcp/config"
 	"github.com/stacklok/toolhive/pkg/vmcp/core"
 	"github.com/stacklok/toolhive/pkg/vmcp/health"
-	"github.com/stacklok/toolhive/pkg/vmcp/optimizer"
+	"github.com/stacklok/toolhive/pkg/vmcp/server/sessionmanager"
 )
 
 // stubVMCP is a no-op core.VMCP for Serve tests. The Serve skeleton never invokes
@@ -78,14 +77,23 @@ func (stubServeReporter) Start(context.Context) (func(context.Context) error, er
 	return func(context.Context) error { return nil }, nil
 }
 
+// testMinimalSessionManagerConfig returns a minimal valid SessionManagerConfig for
+// Serve tests that need a non-nil session-manager config but do not exercise session
+// creation. Base is the only required FactoryConfig field; the minimal factory's
+// MakeSessionWithID returns an error if a test accidentally triggers registration.
+func testMinimalSessionManagerConfig() *sessionmanager.FactoryConfig {
+	return &sessionmanager.FactoryConfig{Base: testMinimalFactory()}
+}
+
 func TestServeAppliesTransportDefaults(t *testing.T) {
 	t.Parallel()
 
 	// Empty transport fields exercise every default; Port is left zero.
-	cfg := &ServerConfig{SessionFactory: testMinimalFactory()}
+	cfg := &ServerConfig{SessionManagerConfig: testMinimalSessionManagerConfig()}
 
 	srv, err := Serve(context.Background(), &stubVMCP{}, cfg)
 	require.NoError(t, err)
+	t.Cleanup(func() { _ = srv.Stop(context.Background()) })
 	require.NotNil(t, srv)
 	require.NotNil(t, srv.MCPServer())
 
@@ -120,11 +128,12 @@ func TestServePreservesExplicitConfig(t *testing.T) {
 		GroupRef:                "my-group",
 		SessionTTL:              7 * time.Minute,
 		StatusReportingInterval: 11 * time.Second,
-		SessionFactory:          testMinimalFactory(),
+		SessionManagerConfig:    testMinimalSessionManagerConfig(),
 	}
 
 	srv, err := Serve(context.Background(), &stubVMCP{}, cfg)
 	require.NoError(t, err)
+	t.Cleanup(func() { _ = srv.Stop(context.Background()) })
 
 	assert.Equal(t, "custom", srv.config.Name)
 	assert.Equal(t, "9.9.9", srv.config.Version)
@@ -139,9 +148,10 @@ func TestServePreservesExplicitConfig(t *testing.T) {
 func TestServeHandlerRegistersUnauthenticatedRoutes(t *testing.T) {
 	t.Parallel()
 
-	cfg := &ServerConfig{SessionFactory: testMinimalFactory()}
+	cfg := &ServerConfig{SessionManagerConfig: testMinimalSessionManagerConfig()}
 	srv, err := Serve(context.Background(), &stubVMCP{}, cfg)
 	require.NoError(t, err)
+	t.Cleanup(func() { _ = srv.Stop(context.Background()) })
 
 	handler, err := srv.Handler(context.Background())
 	require.NoError(t, err)
@@ -186,10 +196,11 @@ func TestServeHandlerRegistersMetricsWhenTelemetryEnabled(t *testing.T) {
 	t.Cleanup(func() { _ = provider.Shutdown(ctx) })
 
 	srv, err := Serve(ctx, &stubVMCP{}, &ServerConfig{
-		SessionFactory:    testMinimalFactory(),
-		TelemetryProvider: provider,
+		SessionManagerConfig: testMinimalSessionManagerConfig(),
+		TelemetryProvider:    provider,
 	})
 	require.NoError(t, err)
+	t.Cleanup(func() { _ = srv.Stop(context.Background()) })
 
 	handler, err := srv.Handler(ctx)
 	require.NoError(t, err)
@@ -204,7 +215,7 @@ func TestServeStopClosesCore(t *testing.T) {
 	t.Parallel()
 
 	stub := &stubVMCP{}
-	srv, err := Serve(context.Background(), stub, &ServerConfig{SessionFactory: testMinimalFactory()})
+	srv, err := Serve(context.Background(), stub, &ServerConfig{SessionManagerConfig: testMinimalSessionManagerConfig()})
 	require.NoError(t, err)
 
 	// Stop on a never-started server still runs the shutdown funcs, which release
@@ -229,10 +240,10 @@ func TestServeValidation(t *testing.T) {
 		{
 			name: "nil vmcp",
 			v:    nil,
-			cfg:  &ServerConfig{SessionFactory: testMinimalFactory()},
+			cfg:  &ServerConfig{SessionManagerConfig: testMinimalSessionManagerConfig()},
 		},
 		{
-			name: "nil session factory",
+			name: "nil session manager config",
 			v:    &stubVMCP{},
 			cfg:  &ServerConfig{},
 		},
@@ -275,10 +286,15 @@ func TestBuildServeConfigMapsSharedFields(t *testing.T) {
 		"AuthzMiddleware":     {}, // authenticated/authz chain relocated by #5441
 		"HealthMonitorConfig": {}, // monitor injected pre-built via ServerConfig.HealthMonitor (A2)
 		"StatusReporter":      {}, // set directly on Server; Config.StatusReporter only read by New
+		"SessionFactory":      {}, // session manager built in Serve from ServerConfig.SessionManagerConfig
+		"OptimizerFactory":    {}, // optimizer wiring carried on ServerConfig.SessionManagerConfig (FactoryConfig)
+		"OptimizerConfig":     {}, // optimizer wiring carried on ServerConfig.SessionManagerConfig (FactoryConfig)
 	}
 
 	// Every field set to a non-zero value so a dropped mapping surfaces as a zero
-	// field on the resulting Config.
+	// field on the resulting Config. SessionManagerConfig and BackendRegistry are
+	// ServerConfig-only (consumed directly by Serve, not mapped into Config), so they
+	// are set for completeness but are not part of this destination-field assertion.
 	src := &ServerConfig{
 		Name:                    "n",
 		Version:                 "v",
@@ -294,14 +310,11 @@ func TestBuildServeConfigMapsSharedFields(t *testing.T) {
 		StatusReportingInterval: time.Second,
 		StatusReporter:          stubServeReporter{},
 		Watcher:                 stubWatcher{},
-		SessionFactory:          testMinimalFactory(),
+		BackendRegistry:         vmcp.NewImmutableRegistry([]vmcp.Backend{}),
 		SessionStorage:          &vmcpconfig.SessionStorageConfig{},
-		OptimizerFactory: func(context.Context, []server.ServerTool) (optimizer.Optimizer, error) {
-			return nil, nil
-		},
-		OptimizerConfig:   &optimizer.Config{},
-		TelemetryProvider: &telemetry.Provider{},
-		AuditConfig:       &audit.Config{},
+		SessionManagerConfig:    testMinimalSessionManagerConfig(),
+		TelemetryProvider:       &telemetry.Provider{},
+		AuditConfig:             &audit.Config{},
 	}
 
 	got := reflect.ValueOf(*buildServeConfig(src))


### PR DESCRIPTION
## Summary

This is step **P2.2** of the vMCP New/Serve split (Phase 2). The mcp-go SDK hooks and the
two-phase session-creation wiring are SDK-lifecycle concerns that belong in the transport
layer of the New/Serve split, not in the core `VMCP` domain object — but they still lived in
`server.New`. This PR relocates them under `Serve` so they execute identically when `Serve` is
exercised directly, keeping the mcp-go two-phase dance (anti-pattern #5) isolated behind the
transport boundary and out of the core interface.

- **Why**: Finish moving the SDK session layer behind `Serve` so the core `VMCP` object stays
  free of mcp-go session concepts (hooks, two-phase creation, cross-pod Redis re-hydration).
- **What**: Move the three SDK hooks (`OnRegisterSession`, `OnBeforeListTools`,
  `OnBeforeCallTool`) and the session-creation wiring (transport session manager, session data
  storage, vMCP session manager) from `server.New` into `Serve` in `pkg/vmcp/server/serve.go`.
- **Scope**: Purely additive. `server.New` keeps its own copy until Phase 3, so its signature
  and observable behavior are **unchanged**; the relocated callbacks and collaborators keep
  their existing shapes.

Closes #5440

## Type of change

- [x] Refactoring (no behavior change)

## Test plan

- [x] Unit tests (`task test`) — `pkg/vmcp/server` passes with `-race`
- [x] Linting — `golangci-lint run ./pkg/vmcp/server/...` reports 0 issues
- [x] Manual testing (describe below)

New `Serve`-level tests drive the relocated hooks and two-phase session creation through the
SDK lifecycle directly (mounting the Streamable HTTP server on the relocated `mcpServer` +
`vmcpSessionMgr`, bypassing the not-yet-relocated discovery middleware that #5441/#5442 own):

- `TestServeRegistersSessionHooks` — an MCP `initialize` fires `OnRegisterSession`, which runs
  two-phase creation (`MakeSessionWithID`) and injects the per-session tools so a subsequent
  `tools/list` advertises them; the `OnBeforeListTools` hook runs and no-ops on the pod-local
  path.
- `TestServeLazyInjectsToolsForRehydratedSession` — covers the cross-pod re-injection branch:
  with a session registered in the vMCP session manager, a fresh SDK `ClientSession` whose
  per-session tool store is empty (as on a second pod, where `OnRegisterSession` never fired)
  gets its tools re-injected by `lazyInjectSessionTools`; a populated store is left untouched.
- `TestServeReturnsErrorWhenSessionManagerConstructionFails` — asserts Serve surfaces a
  `sessionmanager.New` failure that occurs after the session data storage is built (the path
  the `closeStorageOnErr` guard protects). It confirms the guarded path is reached; it does not
  directly observe `Close()` (the storage is built internally).
- `TestBuildSessionDataStorage` / `TestBuildSessionDataStorageRedis` — provider selection:
  nil/empty/`memory` (case-insensitive) yields in-process storage; `redis` takes the Redis path
  reading `THV_SESSION_REDIS_PASSWORD`; unknown providers are rejected.

The ~1.2k-line HTTP session-management integration suite stays on `server.New` (unchanged) as
the behavioral-parity gate.

> Note on repo-wide checks: `task lint-fix` has a pre-existing, **unrelated** gosec G115 failure
> in `cmd/thv/app/upgrade.go`, and `task test` has a pre-existing, **unrelated**
> Docker-dependent failure in `pkg/mcp/server` (`TestBuildServerConfig` "no available runtime
> found"). Neither is caused by this change; the affected packages are untouched here.

## Changes

| File | Change |
|------|--------|
| `pkg/vmcp/server/serve.go` | Relocate the three SDK hooks and two-phase session-creation wiring (transport session manager, `buildSessionDataStorage` with the `closeStorageOnErr` guard, vMCP session manager) into `Serve`; rework `ServerConfig` (see below). |
| `pkg/vmcp/server/serve_session_test.go` | New: `Serve`-level coverage of the relocated hooks + two-phase creation driven through the SDK lifecycle, plus `buildSessionDataStorage` provider selection. |
| `pkg/vmcp/server/serve_test.go` | Update existing `Serve` tests for the new `ServerConfig` shape (`SessionManagerConfig` + `BackendRegistry`); add nil-`BackendRegistry` validation case; register `t.Cleanup` teardown. |

## Implementation details

- **`ServerConfig` reshaped**: added a pre-built `*sessionmanager.FactoryConfig` slot
  (`SessionManagerConfig`) and a shared `BackendRegistry`. The now-redundant standalone
  `SessionFactory` / `OptimizerFactory` / `OptimizerConfig` slots were folded into the
  `FactoryConfig`. Both new collaborators are validated and fail loudly with
  `vmcp.ErrInvalidConfig` when nil — `BackendRegistry` in particular, because the
  `OnRegisterSession` hook enumerates it inside a goroutine where the error would otherwise be
  swallowed.
- **Mechanical relocation**: the hook callbacks and the `*Server` receiver methods
  (`handleSessionRegistration`, `lazyInjectSessionTools`) are unchanged — they already operate
  against `s.vmcpSessionMgr` and the SDK `server.ClientSession`. The hooks object is built up
  front (so it can be passed to `NewMCPServer`) but its callbacks are registered after `srv` is
  assembled, since they close over `srv`.
- **Resource-leak guard preserved**: `buildSessionDataStorage` keeps the `closeStorageOnErr`
  defer so the storage's background cleanup goroutine is released on any error path out of
  `Serve` (pairs acquisition with release).
- **Boundary held**: no mcp-go types cross the `VMCP` interface; the "fixed at initialize"
  capability set, identity binding, and the cross-pod Redis re-hydration path stay in
  Serve/session.

## Does this introduce a user-facing change?

No. This relocates internal transport wiring within `pkg/vmcp/server`; `server.New`'s signature
and observable behavior are unchanged.

## Special notes for reviewers

- **Stacked PR**: this branch is stacked on its dependency #5439. The base branch is
  `vmcp-core-p2-1_issue_5439` (not `main`) so the diff contains only this issue's two commits.
- The returned `*Server` has a live session manager and backend registry but a still-nil
  discovery manager / router / backend client at this phase. It must not be `Start()`ed or
  served on the `/` MCP route until #5441/#5442 wire those fields; the unauthenticated routes
  remain safe to serve. The new tests mount the Streamable HTTP server directly to stay within
  this task's scope.
- Follow-up tasks relocate the remaining transport concerns: the authenticated middleware chain
  (#5441), the direct `VMCP` request path (#5442), and the AS runner / status reporter /
  optimizer / health monitor lifecycle (#5443). Phase 3 (#5444) reduces `server.New` to a
  `Serve(ctx, New(...), ...)` wrapper.

