### PR TITLE
Add helm-unittest baseline for operator chart

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -37,6 +37,7 @@ tasks:
         helm plugin list | grep -q unittest ||
         helm plugin install https://github.com/helm-unittest/helm-unittest --version {{.HELM_UNITTEST_VERSION}}
       - helm unittest deploy/charts/operator-crds
+      - helm unittest deploy/charts/operator
 
   mock-install:
     desc: Install the mockgen tool for mock generation

--- a/deploy/charts/operator/.helmignore
+++ b/deploy/charts/operator/.helmignore
@@ -21,3 +21,5 @@
 .idea/
 *.tmproj
 .vscode/
+# helm-unittest test suites (not part of the packaged chart)
+tests/

--- a/deploy/charts/operator/tests/default_install_test.yaml
+++ b/deploy/charts/operator/tests/default_install_test.yaml
@@ -1,0 +1,131 @@
+suite: default install
+# Renders the operator chart with NO value overrides and asserts the expected
+# output for every resource it creates by default. This is the baseline
+# regression net: any template change that silently alters a default resource
+# turns one of these tests red. Each test scopes to one template with `template:`
+# so its asserts don't bleed across the other kinds in the suite.
+release:
+  name: toolhive-operator        # install context only — not a chart value
+  namespace: toolhive-system
+templates:
+  - deployment.yaml
+  - hpa.yaml
+  - serviceaccount.yaml
+  - clusterrole/role.yaml
+  - clusterrole/rolebinding.yaml
+  - leader-election-role.yaml
+tests:
+  # ---- Deployment -------------------------------------------------------
+  - it: renders one operator Deployment with the expected identity
+    template: deployment.yaml
+    asserts:
+      - hasDocuments: { count: 1 }
+      - isKind: { of: Deployment }
+      - equal: { path: metadata.name, value: toolhive-operator }
+      - equal: { path: spec.replicas, value: 1 }
+      - equal: { path: spec.template.spec.serviceAccountName, value: toolhive-operator }
+
+  - it: configures the manager container with the default image and policy
+    template: deployment.yaml
+    asserts:
+      - equal: { path: 'spec.template.spec.containers[0].name', value: manager }
+      # Match the repo path but not the tag, so image bumps don't break the suite.
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: '^ghcr\.io/stacklok/toolhive/operator:'
+      - equal: { path: 'spec.template.spec.containers[0].imagePullPolicy', value: IfNotPresent }
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --leader-elect
+
+  - it: exposes the metrics and health ports
+    template: deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content: { containerPort: 8080, name: metrics, protocol: TCP }
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content: { containerPort: 8081, name: health, protocol: TCP }
+
+  - it: sets the expected default environment variables
+    template: deployment.yaml
+    asserts:
+      - contains: { path: 'spec.template.spec.containers[0].env', content: { name: ENABLE_EXPERIMENTAL_FEATURES, value: "false" } }
+      - contains: { path: 'spec.template.spec.containers[0].env', content: { name: TOOLHIVE_ENABLE_STORAGE_VERSION_MIGRATOR, value: "false" } }
+      - contains: { path: 'spec.template.spec.containers[0].env', content: { name: UNSTRUCTURED_LOGS, value: "false" } }
+      - contains: { path: 'spec.template.spec.containers[0].env', content: { name: TOOLHIVE_USE_CONFIGMAP, value: "true" } }
+      - contains: { path: 'spec.template.spec.containers[0].env', content: { name: GOGC, value: "75" } }
+      - contains: { path: 'spec.template.spec.containers[0].env', content: { name: GOMEMLIMIT, value: "110MiB" } }
+      - contains: { path: 'spec.template.spec.containers[0].env', content: { name: TOOLHIVE_PROXY_HOST, value: "0.0.0.0" } }
+
+  - it: points the image env vars at the expected repos (tag-agnostic)
+    template: deployment.yaml
+    asserts:
+      - matchRegex:
+          path: "spec.template.spec.containers[0].env[?(@.name=='TOOLHIVE_RUNNER_IMAGE')].value"
+          pattern: '^ghcr\.io/stacklok/toolhive/proxyrunner:'
+      - matchRegex:
+          path: "spec.template.spec.containers[0].env[?(@.name=='VMCP_IMAGE')].value"
+          pattern: '^ghcr\.io/stacklok/toolhive/vmcp:'
+      - matchRegex:
+          path: "spec.template.spec.containers[0].env[?(@.name=='TOOLHIVE_REGISTRY_API_IMAGE')].value"
+          pattern: '^ghcr\.io/stacklok/thv-registry-api:'
+
+  - it: does not set scope- or secret-gated env vars on defaults
+    template: deployment.yaml
+    asserts:
+      - notExists: { path: 'spec.template.spec.containers[0].env[?(@.name=="WATCH_NAMESPACE")]' }
+      - notExists: { path: 'spec.template.spec.containers[0].env[?(@.name=="TOOLHIVE_DEFAULT_IMAGE_PULL_SECRETS")]' }
+
+  # ---- HPA --------------------------------------------------------------
+  - it: renders no HorizontalPodAutoscaler when autoscaling is disabled
+    template: hpa.yaml
+    asserts:
+      - hasDocuments: { count: 0 }
+
+  # ---- ServiceAccount ---------------------------------------------------
+  - it: creates the operator ServiceAccount
+    template: serviceaccount.yaml
+    asserts:
+      - hasDocuments: { count: 1 }
+      - isKind: { of: ServiceAccount }
+      - equal: { path: metadata.name, value: toolhive-operator }
+      - equal: { path: automountServiceAccountToken, value: true }
+
+  # ---- ClusterRole ------------------------------------------------------
+  - it: creates the manager ClusterRole
+    template: clusterrole/role.yaml
+    asserts:
+      - hasDocuments: { count: 1 }
+      - isKind: { of: ClusterRole }
+      - equal: { path: metadata.name, value: toolhive-operator-manager-role }
+
+  # ---- ClusterRoleBinding ----------------------------------------------
+  - it: binds the manager ClusterRole to the operator ServiceAccount
+    template: clusterrole/rolebinding.yaml
+    asserts:
+      - hasDocuments: { count: 1 }
+      - isKind: { of: ClusterRoleBinding }
+      - equal: { path: roleRef.name, value: toolhive-operator-manager-role }
+      - equal: { path: 'subjects[0].name', value: toolhive-operator }
+      - equal: { path: 'subjects[0].namespace', value: toolhive-system }
+
+  # ---- Leader election Role + RoleBinding ------------------------------
+  - it: provisions the leader-election Role and RoleBinding
+    template: leader-election-role.yaml
+    asserts:
+      - hasDocuments: { count: 2 }
+
+  - it: names the leader-election Role
+    template: leader-election-role.yaml
+    documentSelector: { path: kind, value: Role }
+    asserts:
+      - equal: { path: metadata.name, value: toolhive-operator-leader-election-role }
+
+  - it: binds leader election to the operator ServiceAccount
+    template: leader-election-role.yaml
+    documentSelector: { path: kind, value: RoleBinding }
+    asserts:
+      - equal: { path: metadata.name, value: toolhive-operator-leader-election-rolebinding }
+      - equal: { path: 'subjects[0].name', value: toolhive-operator }


### PR DESCRIPTION
## Summary

The `operator` chart had no helm-unittest coverage, so a template change could silently alter a default-install resource and still pass `ct lint`/`ct install` — `helm install` succeeds even when the rendered manifest is subtly wrong. The `operator-crds` chart already gained a suite in #5468; this brings the same regression safety to the `operator` chart, starting with the default install.

<details>
<summary><strong>Medium level</strong></summary>

- Adds `deploy/charts/operator/tests/default_install_test.yaml` — renders the chart with **no value overrides** and asserts the expected output for every resource a default install creates: the Deployment (identity, image, pull policy, `serviceAccountName`, `--leader-elect`, ports, default env vars, and gated env vars *absent*), the ServiceAccount, the ClusterRole, the ClusterRoleBinding (roleRef + subject), and the leader-election Role/RoleBinding — plus that the HPA is absent when autoscaling is off.
- Image assertions use `matchRegex` on the **repo path only**, so routine image-tag bumps (operator, proxyrunner, vmcp, registry-api) don't break the suite — only a repo path change would.
- Wires the `operator` chart into the existing `helm-unittest` Taskfile target; CI already runs `task helm-unittest`, so no workflow change is needed.
- Adds `tests/` to the operator chart's `.helmignore` so the suite isn't shipped in the packaged chart (verified the `.tgz` contains zero `tests/` entries).
- This is a deliberately small first increment — a baseline regression net. Toggle/scenario suites (autoscaling, namespace scope, `defaultImagePullSecrets` validation, feature flags) are planned as follow-ups.

</details>

<details>
<summary><strong>Low level</strong></summary>

| File | Change |
|------|--------|
| `deploy/charts/operator/tests/default_install_test.yaml` | New suite: 13 tests across all six default-rendered resources |
| `Taskfile.yml` | Add `helm unittest deploy/charts/operator` to the `helm-unittest` task |
| `deploy/charts/operator/.helmignore` | Ignore `tests/` when packaging the chart |

</details>

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [x] Other (test coverage / CI)

## Test plan

- [x] `task helm-unittest` passes for both charts (operator-crds 3/3, operator 13/13)
- [x] `helm package deploy/charts/operator` produces a `.tgz` with no `tests/` entries
- [x] Confirmed `matchRegex` image assertions and `env[?(@.name=="…")]` `notExists` filters work in helm-unittest v1.0.3

## Special notes for reviewers

- **Why scenario-light:** this is the first increment by design — a default-install baseline that later toggle/scenario suites build on.
- **Known finding for a follow-up (not in this PR):** `clusterrole/rolebinding.yaml` hardcodes the binding subject `name: toolhive-operator` while the Deployment resolves its SA via the `toolhive-operator.serviceAccountName` helper. On default values everything resolves to `toolhive-operator` (so this suite passes), but overriding `operator.serviceAccount.name` makes them diverge. Worth routing all SA references through the helper and adding a custom-naming scenario then.
- **helm-unittest gotcha:** bracketed paths (`containers[0]`, `subjects[0]`, JSONPath filters) must be quoted inside inline-flow `{ }` asserts, or YAML parses `[0]` as a nested sequence.

Generated with [Claude Code](https://claude.com/claude-code)