### PR TITLE
Send OTLP export headers delivered via EnvVars

### DIFF
--- a/pkg/runner/telemetry_config.go
+++ b/pkg/runner/telemetry_config.go
@@ -11,15 +11,23 @@ import (
 	"github.com/stacklok/toolhive/pkg/telemetry"
 )
 
+// otelHeadersEnvVar is the standard OpenTelemetry environment variable carrying
+// OTLP export headers as a comma-separated list (e.g. "key1=val1,key2=val2").
+// A config source may deliver headers through this variable in the app config's
+// EnvVars instead of as header flags.
+const otelHeadersEnvVar = "OTEL_EXPORTER_OTLP_HEADERS"
+
 // BuildTelemetryConfigFromAppConfig builds a *telemetry.Config from an
 // application OpenTelemetry config (read from ~/.config/toolhive/config.yaml
-// or pushed by an enterprise config server).
+// or supplied by a config source).
 //
 // Both the "thv run" CLI and the "POST /api/v1/workloads" API path call this
 // so workloads created via either surface inherit the same telemetry
-// settings. Headers and customAttributes have no equivalent in the
-// application config and are passed through from the caller when available
-// (the CLI surfaces them as flags; the API does not yet).
+// settings. Export headers come from two sources: the caller's header flags
+// (the CLI surfaces "--otel-headers"; the API passes none) and an
+// OTEL_EXPORTER_OTLP_HEADERS entry in the config's EnvVars. Flags take
+// precedence. customAttributes has no equivalent in the application config
+// and is passed through by the caller.
 //
 // Returns nil when no telemetry should be enabled: either no endpoint and no
 // Prometheus metrics path, or both tracing and metrics disabled with no
@@ -55,13 +63,7 @@ func BuildTelemetryConfigFromAppConfig(
 		return nil
 	}
 
-	parsedHeaders := make(map[string]string)
-	for _, h := range headers {
-		parts := strings.SplitN(h, "=", 2)
-		if len(parts) == 2 {
-			parsedHeaders[parts[0]] = parts[1]
-		}
-	}
+	parsedHeaders := mergeTelemetryHeaders(headers, otel.EnvVars)
 
 	var processedEnvVars []string
 	for _, entry := range otel.EnvVars {
@@ -94,4 +96,33 @@ func BuildTelemetryConfigFromAppConfig(
 	}
 	cfg.SetSamplingRateFromFloat(otel.SamplingRate)
 	return cfg
+}
+
+// mergeTelemetryHeaders builds the OTLP export header map from two sources:
+// an OTEL_EXPORTER_OTLP_HEADERS entry in the config's EnvVars (used when the
+// caller passes no header flags, such as the API path) and caller-supplied
+// header flags ("key=value", from the CLI's --otel-headers). Env headers are
+// applied first so flags override them on conflict. Values are split on the
+// first '=' only, so a value containing '=' (e.g. base64 padding) or spaces
+// (e.g. "Basic <token>") is preserved intact.
+func mergeTelemetryHeaders(flagHeaders, envVars []string) map[string]string {
+	headers := make(map[string]string)
+	for _, entry := range envVars {
+		name, value, ok := strings.Cut(entry, "=")
+		if !ok || name != otelHeadersEnvVar {
+			continue
+		}
+		for pair := range strings.SplitSeq(value, ",") {
+			if key, val, ok := strings.Cut(strings.TrimSpace(pair), "="); ok && key != "" {
+				headers[key] = val
+			}
+		}
+	}
+
+	for _, h := range flagHeaders {
+		if key, val, ok := strings.Cut(h, "="); ok {
+			headers[key] = val
+		}
+	}
+	return headers
 }

--- a/pkg/runner/telemetry_config_test.go
+++ b/pkg/runner/telemetry_config_test.go
@@ -108,6 +108,53 @@ func TestBuildTelemetryConfigFromAppConfig_AppliesAllFields(t *testing.T) {
 	assert.NotEmpty(t, cfg.SamplingRate)
 }
 
+// TestBuildTelemetryConfigFromAppConfig_OTLPHeadersFromEnvVars verifies that an
+// OTEL_EXPORTER_OTLP_HEADERS entry in the app config's EnvVars is parsed into
+// cfg.Headers, which is what the OTLP exporter actually sends (via WithHeaders).
+// This is the path taken when headers are configured rather than passed as
+// flags (e.g. the API call site passes no header flags). Without this, the
+// headers are silently dropped and an auth-gated collector rejects every
+// export (401).
+func TestBuildTelemetryConfigFromAppConfig_OTLPHeadersFromEnvVars(t *testing.T) {
+	t.Parallel()
+
+	t.Run("single header with scheme and base64 padding is preserved", func(t *testing.T) {
+		t.Parallel()
+		otel := appconfig.OpenTelemetryConfig{
+			Endpoint: "https://otel.example.com",
+			EnvVars:  []string{"OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic dG9rZW46cHc="},
+		}
+		cfg := BuildTelemetryConfigFromAppConfig(otel, "thv-osv", nil, "")
+		require.NotNil(t, cfg)
+		// The value contains a space and '=' padding; both must survive parsing.
+		assert.Equal(t, "Basic dG9rZW46cHc=", cfg.Headers["Authorization"])
+	})
+
+	t.Run("multiple comma-separated headers are all parsed", func(t *testing.T) {
+		t.Parallel()
+		otel := appconfig.OpenTelemetryConfig{
+			Endpoint: "https://otel.example.com",
+			EnvVars:  []string{"OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic abc,x-tenant-id=acme"},
+		}
+		cfg := BuildTelemetryConfigFromAppConfig(otel, "thv-osv", nil, "")
+		require.NotNil(t, cfg)
+		assert.Equal(t, "Basic abc", cfg.Headers["Authorization"])
+		assert.Equal(t, "acme", cfg.Headers["x-tenant-id"])
+	})
+
+	t.Run("explicit header flag wins, other env headers still applied", func(t *testing.T) {
+		t.Parallel()
+		otel := appconfig.OpenTelemetryConfig{
+			Endpoint: "https://otel.example.com",
+			EnvVars:  []string{"OTEL_EXPORTER_OTLP_HEADERS=Authorization=fromenv,x-env=prod"},
+		}
+		cfg := BuildTelemetryConfigFromAppConfig(otel, "thv-osv", []string{"Authorization=fromflag"}, "")
+		require.NotNil(t, cfg)
+		assert.Equal(t, "fromflag", cfg.Headers["Authorization"], "explicit --otel-headers flag must take precedence")
+		assert.Equal(t, "prod", cfg.Headers["x-env"], "env-provided headers other than the overridden one must still apply")
+	})
+}
+
 // TestBuildTelemetryConfigFromAppConfig_DefaultsForNilBools verifies the CLI-style
 // defaults: when bool fields are not set in the config, tracing/metrics/legacy
 // attributes default to true. This is what makes "just configure an endpoint"


### PR DESCRIPTION
## Summary

**Why:** OTLP exporters configured with request headers via `OTEL_EXPORTER_OTLP_HEADERS` had those headers silently dropped on the `POST /api/v1/workloads` path. Any header set this way — auth (`Authorization`), tenant routing (`x-tenant-id`), environment tags, etc. — never reached the collector. When the collector requires a header (e.g. basic auth), every trace/metric export is rejected (`401 Unauthorized`), so no telemetry lands.

Root cause: `BuildTelemetryConfigFromAppConfig` populated `cfg.Headers` (the only field the OTLP exporter sends, via `otlptracehttp.WithHeaders` / `otlpmetrichttp.WithHeaders`) **solely from the caller's `--otel-headers` flags**. The CLI passes those flags; the API path passes `nil`. Headers supplied instead through an `OTEL_EXPORTER_OTLP_HEADERS` entry in the config's `EnvVars` were only copied into the workload's `EnvironmentVariables` and never into `cfg.Headers`, so they were dropped regardless of value.

**What changed:**
- Parse `OTEL_EXPORTER_OTLP_HEADERS` from `otel.EnvVars` into the structured `Headers` map, so the exporter sends every configured header on both the CLI and API paths.
- Split each header on the **first `=` only**, so values containing `=` (base64 padding) or spaces (`Basic <token>`) survive intact.
- Explicit `--otel-headers` flags still take precedence on conflict.
- Extracted header assembly into a `mergeTelemetryHeaders` helper (keeps `BuildTelemetryConfigFromAppConfig` under the gocyclo threshold).

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests — added `TestBuildTelemetryConfigFromAppConfig_OTLPHeadersFromEnvVars` (single header with scheme + base64 padding; multiple comma-separated headers; flag-precedence with a second env-only header still applied). Ran `go test ./pkg/runner/` — all pass. Confirmed the new cases fail on the pre-fix code (RED) before implementing.
- [x] Linting — `golangci-lint run ./pkg/runner/` reports 0 issues. (Run directly rather than via `task lint-fix` due to a local Go toolchain mismatch — `1.26.3` vs a workspace pinning `1.26.4`; unrelated to this change.)
- [x] Manual testing — diagnosed against a live reproduction: a managed MCP server exporting to a basic-auth-gated collector logged a continuous `401 Unauthorized (no basic auth provided)` on every trace/metric export, with the header present in the run config's `OTEL_EXPORTER_OTLP_HEADERS` but absent from the proxy exporter's headers. This change routes that header into `cfg.Headers`.

## Special notes for reviewers

- Pre-existing behavior left intact: the `OTEL_EXPORTER_OTLP_HEADERS` entry is still also passed through in `EnvironmentVariables`. If that surfaces a sensitive header value somewhere it shouldn't (e.g. injected into the workload container env), it's worth a separate follow-up — out of scope here to keep the fix focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
