### PR TITLE
Add scenario helm-unittest suites for operator chart

### DIFF
--- a/deploy/charts/operator/tests/autoscaling_test.yaml
+++ b/deploy/charts/operator/tests/autoscaling_test.yaml
@@ -1,0 +1,63 @@
+suite: autoscaling enabled
+# Exercises the autoscaling.enabled coupling across two templates: when the HPA
+# owns scaling, the Deployment must NOT pin a static replica count, and the HPA's
+# CPU/memory metrics are each gated on their target being set. Suite-level `set`
+# turns autoscaling on for every test; each test scopes to one template.
+set:
+  operator.autoscaling.enabled: true
+  operator.autoscaling.minReplicas: 2
+  operator.autoscaling.maxReplicas: 5
+templates:
+  - deployment.yaml
+  - hpa.yaml
+tests:
+  - it: drops the static replica count so the HPA owns scaling
+    template: deployment.yaml
+    asserts:
+      - notExists: { path: spec.replicas }
+
+  - it: renders an HPA with the configured bounds
+    template: hpa.yaml
+    asserts:
+      - hasDocuments: { count: 1 }
+      - isKind: { of: HorizontalPodAutoscaler }
+      - equal: { path: spec.minReplicas, value: 2 }
+      - equal: { path: spec.maxReplicas, value: 5 }
+
+  - it: omits the CPU and memory metrics when no targets are set
+    template: hpa.yaml
+    asserts:
+      - notContains:
+          path: spec.metrics
+          content: { type: Resource, resource: { name: cpu, target: { type: Utilization } } }
+          any: true
+      - notContains:
+          path: spec.metrics
+          content: { type: Resource, resource: { name: memory, target: { type: Utilization } } }
+          any: true
+
+  - it: adds a CPU metric only when its target is set
+    template: hpa.yaml
+    set:
+      operator.autoscaling.targetCPUUtilizationPercentage: 80
+    asserts:
+      - contains:
+          path: spec.metrics
+          content:
+            type: Resource
+            resource:
+              name: cpu
+              target: { type: Utilization, averageUtilization: 80 }
+
+  - it: adds a memory metric only when its target is set
+    template: hpa.yaml
+    set:
+      operator.autoscaling.targetMemoryUtilizationPercentage: 70
+    asserts:
+      - contains:
+          path: spec.metrics
+          content:
+            type: Resource
+            resource:
+              name: memory
+              target: { type: Utilization, averageUtilization: 70 }

--- a/deploy/charts/operator/tests/default_image_pull_secrets_test.yaml
+++ b/deploy/charts/operator/tests/default_image_pull_secrets_test.yaml
@@ -1,0 +1,45 @@
+suite: default image pull secrets
+# The defaultImagePullSecrets block accepts either plain strings or objects with
+# a `name` field, joins them into TOOLHIVE_DEFAULT_IMAGE_PULL_SECRETS, and calls
+# `fail` on anything else. The fail paths are the high-value part: `ct lint` and
+# `ct install` cannot exercise template `fail` calls, but helm-unittest can.
+templates:
+  - deployment.yaml
+tests:
+  - it: omits the env var when none are configured
+    asserts:
+      - notExists:
+          path: 'spec.template.spec.containers[0].env[?(@.name=="TOOLHIVE_DEFAULT_IMAGE_PULL_SECRETS")]'
+
+  - it: joins string entries with commas
+    set:
+      operator.defaultImagePullSecrets: [regcred, otherscred]
+    asserts:
+      - contains:
+          path: 'spec.template.spec.containers[0].env'
+          content: { name: TOOLHIVE_DEFAULT_IMAGE_PULL_SECRETS, value: "regcred,otherscred" }
+
+  - it: extracts names from object-form entries
+    set:
+      operator.defaultImagePullSecrets:
+        - name: regcred
+        - name: otherscred
+    asserts:
+      - contains:
+          path: 'spec.template.spec.containers[0].env'
+          content: { name: TOOLHIVE_DEFAULT_IMAGE_PULL_SECRETS, value: "regcred,otherscred" }
+
+  - it: fails the render when an object entry omits name
+    set:
+      operator.defaultImagePullSecrets:
+        - foo: bar
+    asserts:
+      - failedTemplate:
+          errorPattern: 'must have a non-empty .name. field'
+
+  - it: fails the render on an invalid entry kind
+    set:
+      operator.defaultImagePullSecrets: [123]
+    asserts:
+      - failedTemplate:
+          errorPattern: 'must be a string or an object'

--- a/deploy/charts/operator/tests/feature_flags_test.yaml
+++ b/deploy/charts/operator/tests/feature_flags_test.yaml
@@ -1,0 +1,19 @@
+suite: opt-in feature flags
+# The experimental and storage-version-migrator features are quoted-boolean env
+# vars. A dropped quote or a renamed var silently disables the feature, so pin
+# both the enabled and (in the baseline suite) disabled states.
+set:
+  operator.features.experimental: true
+  operator.features.storageVersionMigrator: true
+templates:
+  - deployment.yaml
+tests:
+  - it: flips both feature-flag env vars to the quoted string "true"
+    template: deployment.yaml
+    asserts:
+      - contains:
+          path: 'spec.template.spec.containers[0].env'
+          content: { name: ENABLE_EXPERIMENTAL_FEATURES, value: "true" }
+      - contains:
+          path: 'spec.template.spec.containers[0].env'
+          content: { name: TOOLHIVE_ENABLE_STORAGE_VERSION_MIGRATOR, value: "true" }

--- a/deploy/charts/operator/tests/namespace_scope_test.yaml
+++ b/deploy/charts/operator/tests/namespace_scope_test.yaml
@@ -1,0 +1,44 @@
+suite: namespace-scoped install
+# Exercises the rbac.scope=namespace coupling: the Deployment must learn the
+# watched namespaces via WATCH_NAMESPACE, and the binding template must emit one
+# RoleBinding per allowedNamespaces entry (and no ClusterRoleBinding). An empty
+# allowlist must produce zero bindings rather than silently binding nothing.
+set:
+  operator.rbac.scope: namespace
+  operator.rbac.allowedNamespaces: [team-a, team-b]
+templates:
+  - deployment.yaml
+  - clusterrole/rolebinding.yaml
+tests:
+  - it: sets WATCH_NAMESPACE to the comma-joined allowlist
+    template: deployment.yaml
+    asserts:
+      - contains:
+          path: 'spec.template.spec.containers[0].env'
+          content: { name: WATCH_NAMESPACE, value: "team-a,team-b" }
+
+  - it: emits one RoleBinding per namespace and no ClusterRoleBinding
+    template: clusterrole/rolebinding.yaml
+    asserts:
+      - hasDocuments: { count: 2 }
+      - isKind: { of: RoleBinding }
+
+  - it: scopes and targets the team-a RoleBinding correctly
+    template: clusterrole/rolebinding.yaml
+    documentSelector: { path: metadata.namespace, value: team-a }
+    asserts:
+      - isKind: { of: RoleBinding }
+      - equal: { path: roleRef.name, value: toolhive-operator-manager-role }
+
+  - it: scopes the team-b RoleBinding correctly
+    template: clusterrole/rolebinding.yaml
+    documentSelector: { path: metadata.namespace, value: team-b }
+    asserts:
+      - isKind: { of: RoleBinding }
+
+  - it: emits zero bindings when the allowlist is empty
+    template: clusterrole/rolebinding.yaml
+    set:
+      operator.rbac.allowedNamespaces: []
+    asserts:
+      - hasDocuments: { count: 0 }


### PR DESCRIPTION
## Summary

The default-install baseline (#5473) locks in the happy path, but the operator chart's real regression risks are value-driven couplings that span multiple templates — a break in any of them passes `ct lint`/`ct install` silently because `helm install` still succeeds on subtly wrong output. This adds scenario coverage for those couplings, each suite modelling one realistic install configuration.

<details>
<summary><strong>Medium level</strong></summary>

Four new scenario suites under `deploy/charts/operator/tests/`, each setting one configuration at suite level and asserting the resulting behaviour across the templates it touches:

- **`autoscaling_test.yaml`** — with `autoscaling.enabled`, the HPA renders with the configured bounds **and** the Deployment drops its static `spec.replicas` (so the two don't fight); the CPU and memory metrics are each gated on their target being set.
- **`namespace_scope_test.yaml`** — with `rbac.scope=namespace`, the Deployment's `WATCH_NAMESPACE` carries the comma-joined allowlist **and** one `RoleBinding` renders per `allowedNamespaces` entry (no `ClusterRoleBinding`); an empty allowlist produces zero bindings rather than silently binding nothing.
- **`default_image_pull_secrets_test.yaml`** — string and object-`name` forms join into `TOOLHIVE_DEFAULT_IMAGE_PULL_SECRETS`, the env var is absent when unset, and invalid entries (object without `name`, non-string/non-map) **fail the render**. The `fail` paths are the high-value part — `ct lint`/`ct install` can't exercise template `fail` calls.
- **`feature_flags_test.yaml`** — `experimental` and `storageVersionMigrator` flip their quoted-boolean env vars to `"true"` (the disabled state is already pinned by the baseline suite).

</details>

<details>
<summary><strong>Low level</strong></summary>

| File | Change |
|------|--------|
| `deploy/charts/operator/tests/autoscaling_test.yaml` | HPA + Deployment replica coupling, metric gates (5 tests) |
| `deploy/charts/operator/tests/namespace_scope_test.yaml` | WATCH_NAMESPACE + per-namespace RoleBindings (5 tests) |
| `deploy/charts/operator/tests/default_image_pull_secrets_test.yaml` | join forms + `failedTemplate` paths (5 tests) |
| `deploy/charts/operator/tests/feature_flags_test.yaml` | opt-in feature env vars (1 test) |

No production code or wiring changes — the operator chart is already in the `helm-unittest` task and `.helmignore` from #5473.

</details>

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [x] Other (test coverage)

## Test plan

- [x] `task helm-unittest` passes for both charts (operator-crds 3/3, operator 29/29)
- [x] All four new suites pass on a clean run; `failedTemplate` assertions confirmed to trigger the template's `fail` calls

## Special notes for reviewers

- These build on the baseline from #5473; the operator chart was wired into CI there, so no Taskfile/workflow change is needed here.
- **Still deferred (separate PR):** the ServiceAccount-name seam — `clusterrole/rolebinding.yaml` hardcodes the subject `name: toolhive-operator` while the Deployment resolves its SA via the `serviceAccountName` helper. On defaults they agree; overriding `operator.serviceAccount.name` makes them diverge (silent RBAC break). The fix plus a custom-naming scenario that asserts they agree is the next item.

Generated with [Claude Code](https://claude.com/claude-code)