### PR TITLE
Fix operator ServiceAccount name consistency

### DIFF
--- a/deploy/charts/operator/templates/clusterrole/rolebinding.yaml
+++ b/deploy/charts/operator/templates/clusterrole/rolebinding.yaml
@@ -12,7 +12,7 @@ roleRef:
   name: toolhive-operator-manager-role
 subjects:
 - kind: ServiceAccount
-  name: toolhive-operator
+  name: {{ include "toolhive-operator.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
 {{- end }}
 
@@ -28,7 +28,7 @@ metadata:
     {{- include "toolhive.labels" $ | nindent 4 }}
 subjects:
 - kind: ServiceAccount
-  name: toolhive-operator
+  name: {{ include "toolhive-operator.serviceAccountName" $ }}
   namespace: {{ $.Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/deploy/charts/operator/templates/leader-election-role.yaml
+++ b/deploy/charts/operator/templates/leader-election-role.yaml
@@ -22,5 +22,5 @@ roleRef:
   name: {{ .Values.operator.leaderElectionRole.name }}
 subjects:
 - kind: ServiceAccount
-  name: {{ .Values.operator.serviceAccount.name }}
+  name: {{ include "toolhive-operator.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}

--- a/deploy/charts/operator/templates/serviceaccount.yaml
+++ b/deploy/charts/operator/templates/serviceaccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "toolhive-operator.fullname" . }}
+  name: {{ include "toolhive-operator.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: toolhive-operator

--- a/deploy/charts/operator/tests/custom_naming_test.yaml
+++ b/deploy/charts/operator/tests/custom_naming_test.yaml
@@ -33,3 +33,27 @@ tests:
     documentSelector: { path: kind, value: RoleBinding }
     asserts:
       - equal: { path: 'subjects[0].name', value: my-sa }
+
+  # When the name is left empty, all references fall back to the generated name
+  # (fullname) via the helper — the leader-election subject must not render empty.
+  - it: creates the SA under the generated name when serviceAccount.name is empty
+    template: serviceaccount.yaml
+    set:
+      operator.serviceAccount.name: ""
+    asserts:
+      - equal: { path: metadata.name, value: toolhive-operator }
+
+  - it: binds the cluster subject to the generated name when name is empty
+    template: clusterrole/rolebinding.yaml
+    set:
+      operator.serviceAccount.name: ""
+    asserts:
+      - equal: { path: 'subjects[0].name', value: toolhive-operator }
+
+  - it: binds the leader-election subject to the generated name when name is empty
+    template: leader-election-role.yaml
+    documentSelector: { path: kind, value: RoleBinding }
+    set:
+      operator.serviceAccount.name: ""
+    asserts:
+      - equal: { path: 'subjects[0].name', value: toolhive-operator }

--- a/deploy/charts/operator/tests/custom_naming_test.yaml
+++ b/deploy/charts/operator/tests/custom_naming_test.yaml
@@ -1,0 +1,35 @@
+suite: custom service account name
+# When operator.serviceAccount.name is overridden, the name must stay consistent
+# across the resources that reference it: the ServiceAccount that gets created,
+# the Pod's identity, and every role binding subject. If they diverge, the
+# Deployment references an SA that does not exist (pod is never admitted) and/or
+# the binding grants the wrong identity. All four assertions must resolve to the
+# same overridden name.
+set:
+  operator.serviceAccount.name: my-sa
+templates:
+  - serviceaccount.yaml
+  - deployment.yaml
+  - clusterrole/rolebinding.yaml
+  - leader-election-role.yaml
+tests:
+  - it: creates the ServiceAccount under the overridden name
+    template: serviceaccount.yaml
+    asserts:
+      - equal: { path: metadata.name, value: my-sa }
+
+  - it: points the Deployment at the overridden name
+    template: deployment.yaml
+    asserts:
+      - equal: { path: spec.template.spec.serviceAccountName, value: my-sa }
+
+  - it: binds the cluster subject to the overridden name
+    template: clusterrole/rolebinding.yaml
+    asserts:
+      - equal: { path: 'subjects[0].name', value: my-sa }
+
+  - it: binds the leader-election subject to the overridden name
+    template: leader-election-role.yaml
+    documentSelector: { path: kind, value: RoleBinding }
+    asserts:
+      - equal: { path: 'subjects[0].name', value: my-sa }


### PR DESCRIPTION
## Summary

Overriding `operator.serviceAccount.name` in the operator chart breaks the deployment. The chart referenced the ServiceAccount three different ways — `serviceaccount.yaml` named it from `fullname`, `clusterrole/rolebinding.yaml` hardcoded the subject as `toolhive-operator`, and `leader-election-role.yaml` used the raw `serviceAccount.name` — so an override made them diverge while the Deployment (which uses the `serviceAccountName` helper) pointed somewhere else. Verified live in a kind cluster: with `--set operator.serviceAccount.name=my-sa`, the operator Deployment got **zero pods** (`error looking up service account toolhive-system/my-sa: serviceaccount "my-sa" not found`). This routes every reference through the existing `toolhive-operator.serviceAccountName` helper.

<details>
<summary><strong>Medium level</strong></summary>

- **`serviceaccount.yaml`** — `metadata.name` now uses `toolhive-operator.serviceAccountName` instead of `toolhive-operator.fullname`, so the created SA matches what the Deployment references.
- **`clusterrole/rolebinding.yaml`** — both the cluster-scope `ClusterRoleBinding` subject and the per-namespace `RoleBinding` subject (inside the `range`, via `$`) now use the helper instead of the hardcoded `toolhive-operator`.
- **`leader-election-role.yaml`** — the `RoleBinding` subject now uses the helper instead of the raw `serviceAccount.name`, fixing the same divergence (and the empty-name case, where it would otherwise render an empty subject and break leader-election RBAC).
- **No-op on default values**: with `fullnameOverride` and `serviceAccount.name` both defaulting to `toolhive-operator`, every reference still renders `toolhive-operator`. Confirmed by `helm template` and the unchanged baseline suite.
- Adds a `custom_naming` helm-unittest suite asserting all four references agree — both for an overridden name and for the empty-name generated-fallback path.

</details>

<details>
<summary><strong>Low level</strong></summary>

| File | Change |
|------|--------|
| `deploy/charts/operator/templates/serviceaccount.yaml` | `metadata.name` → `serviceAccountName` helper |
| `deploy/charts/operator/templates/clusterrole/rolebinding.yaml` | both binding subjects → helper (`$` inside range) |
| `deploy/charts/operator/templates/leader-election-role.yaml` | binding subject → helper |
| `deploy/charts/operator/tests/custom_naming_test.yaml` | new suite: override + empty-name consistency (7 tests) |

</details>

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

## Test plan

- [x] `task helm-unittest` passes (operator-crds 3/3, operator 36/36)
- [x] New `custom_naming` suite added; committed first as a red test (2 of 4 assertions failed against the old templates), then made green by the fix
- [x] **Manually verified in a kind cluster** via `task kind-setup` → `task operator-install-crds` → `helm upgrade --install ... --set operator.serviceAccount.name=my-sa`:
  - Before: operator Deployment had 0 pods (`serviceaccount "my-sa" not found`)
  - After: SA `my-sa` created; Deployment, ClusterRoleBinding, and leader-election RoleBinding subjects all `my-sa`; pod `1/1 Running`
- [x] `helm template` confirms the default render is unchanged (all references still `toolhive-operator`)

## Special notes for reviewers

- The fix is intentionally render-stable on defaults — it only changes behaviour when naming is overridden, which is exactly the broken path.
- Commit history is deliberately red→green: the failing test is its own commit so the bug is captured before the fix.
- The leader-election binding was included after a code-review pass flagged it as the same divergence class (it would render an empty subject when `serviceAccount.name` is left empty and a name is generated).

Generated with [Claude Code](https://claude.com/claude-code)