### PR TITLE
Serve OAuth discovery endpoints on stdio transport

### DIFF
--- a/pkg/transport/factory.go
+++ b/pkg/transport/factory.go
@@ -56,6 +56,12 @@ func (*Factory) Create(config types.Config, opts ...Option) (types.Transport, er
 			stdio.SetSessionStorage(config.SessionStorage)
 		}
 		stdio.SetSessionTTL(config.SessionTTL)
+		if config.AuthInfoHandler != nil {
+			stdio.SetAuthInfoHandler(config.AuthInfoHandler)
+		}
+		if len(config.PrefixHandlers) > 0 {
+			stdio.SetPrefixHandlers(config.PrefixHandlers)
+		}
 		tr = stdio
 	case types.TransportTypeSSE:
 		httpTransport := NewHTTPTransport(

--- a/pkg/transport/proxy/httpsse/http_proxy.go
+++ b/pkg/transport/proxy/httpsse/http_proxy.go
@@ -22,6 +22,7 @@ import (
 	"github.com/google/uuid"
 	"golang.org/x/exp/jsonrpc2"
 
+	"github.com/stacklok/toolhive/pkg/auth"
 	"github.com/stacklok/toolhive/pkg/healthcheck"
 	"github.com/stacklok/toolhive/pkg/transport/proxy/socket"
 	"github.com/stacklok/toolhive/pkg/transport/session"
@@ -70,6 +71,15 @@ type HTTPSSEProxy struct {
 
 	// Optional Prometheus metrics handler
 	prometheusHandler http.Handler
+
+	// authInfoHandler serves RFC 9728 OAuth protected-resource metadata under
+	// /.well-known/oauth-protected-resource. Set via WithAuthInfoHandler.
+	authInfoHandler http.Handler
+
+	// prefixHandlers maps path prefixes to handlers mounted on the proxy mux
+	// (e.g. the embedded auth server's discovery and /oauth/ routes).
+	// Set via WithPrefixHandlers.
+	prefixHandlers map[string]http.Handler
 
 	// Session manager for SSE clients
 	sessionManager *session.Manager
@@ -144,6 +154,23 @@ func WithSessionTTL(ttl time.Duration) Option {
 	}
 }
 
+// WithAuthInfoHandler sets the handler for RFC 9728 OAuth protected-resource
+// metadata, served under /.well-known/oauth-protected-resource (and subpaths).
+func WithAuthInfoHandler(handler http.Handler) Option {
+	return func(p *HTTPSSEProxy) {
+		p.authInfoHandler = handler
+	}
+}
+
+// WithPrefixHandlers mounts the given path-prefix handlers on the proxy mux
+// (e.g. the embedded auth server's discovery and /oauth/ routes). ServeMux
+// longest-match routing resolves precedence against the other endpoints.
+func WithPrefixHandlers(handlers map[string]http.Handler) Option {
+	return func(p *HTTPSSEProxy) {
+		p.prefixHandlers = handlers
+	}
+}
+
 // NewHTTPSSEProxy creates a new HTTP SSE proxy for transports.
 func NewHTTPSSEProxy(
 	host string,
@@ -193,9 +220,10 @@ func applyMiddlewares(handler http.Handler, middlewares ...types.NamedMiddleware
 	return handler
 }
 
-// Start starts the HTTP SSE proxy.
-func (p *HTTPSSEProxy) Start(_ context.Context) error {
-	// Create a new HTTP server
+// buildMux constructs the proxy's HTTP routing table. ServeMux longest-match
+// routing ensures more specific paths take precedence regardless of
+// registration order.
+func (p *HTTPSSEProxy) buildMux() *http.ServeMux {
 	mux := http.NewServeMux()
 
 	// Add handlers for SSE and JSON-RPC with middlewares
@@ -222,6 +250,28 @@ func (p *HTTPSSEProxy) Start(_ context.Context) error {
 		mux.Handle("/metrics", p.prometheusHandler)
 		slog.Debug("prometheus metrics endpoint enabled at /metrics")
 	}
+
+	// Mount prefix handlers (e.g. the embedded auth server's discovery and
+	// /oauth/ routes), mirroring the transparent proxy.
+	for prefix, prefixHandler := range p.prefixHandlers {
+		mux.Handle(prefix, prefixHandler)
+		slog.Debug("mounted prefix handler", "prefix", prefix)
+	}
+
+	// Mount RFC 9728 OAuth Protected Resource discovery endpoint (no middlewares).
+	// Always registered so OAuth discovery clients get a clean JSON 404 when auth
+	// is not configured, matching the transparent proxy's behavior.
+	mux.Handle("/.well-known/", auth.NewWellKnownHandler(p.authInfoHandler))
+	if p.authInfoHandler != nil {
+		slog.Debug("rfc 9728 OAuth discovery endpoint enabled at /.well-known/oauth-protected-resource")
+	}
+
+	return mux
+}
+
+// Start starts the HTTP SSE proxy.
+func (p *HTTPSSEProxy) Start(_ context.Context) error {
+	mux := p.buildMux()
 
 	// Create a listener to get the actual port when using port 0
 	// Use ListenConfig with SO_REUSEADDR to allow port reuse after unclean shutdown

--- a/pkg/transport/proxy/httpsse/http_proxy_test.go
+++ b/pkg/transport/proxy/httpsse/http_proxy_test.go
@@ -633,3 +633,90 @@ func TestStartStop(t *testing.T) {
 		t.Fatal("Shutdown channel was not closed")
 	}
 }
+
+// TestBuildMuxOAuthRouting verifies the proxy mux routes OAuth discovery
+// requests and mounted prefix handlers.
+func TestBuildMuxOAuthRouting(t *testing.T) {
+	t.Parallel()
+
+	authHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"resource":"test"}`))
+	})
+	prefixHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"handler":"prefix"}`))
+	})
+
+	tests := []struct {
+		name     string
+		opts     []Option
+		path     string
+		wantCode int
+		wantBody string
+	}{
+		{
+			name:     "well-known returns JSON 404 when auth is not configured",
+			path:     "/.well-known/oauth-protected-resource",
+			wantCode: http.StatusNotFound,
+			wantBody: `{"error":"not_found"}`,
+		},
+		{
+			name:     "auth info handler serves protected-resource metadata",
+			opts:     []Option{WithAuthInfoHandler(authHandler)},
+			path:     "/.well-known/oauth-protected-resource",
+			wantCode: http.StatusOK,
+			wantBody: `{"resource":"test"}`,
+		},
+		{
+			name:     "auth info handler serves protected-resource subpaths",
+			opts:     []Option{WithAuthInfoHandler(authHandler)},
+			path:     "/.well-known/oauth-protected-resource/mcp",
+			wantCode: http.StatusOK,
+			wantBody: `{"resource":"test"}`,
+		},
+		{
+			name:     "prefix handlers are mounted on the mux",
+			opts:     []Option{WithPrefixHandlers(map[string]http.Handler{"/oauth/": prefixHandler})},
+			path:     "/oauth/authorize",
+			wantCode: http.StatusOK,
+			wantBody: `{"handler":"prefix"}`,
+		},
+		{
+			name:     "exact-path prefix handler wins over the well-known subtree",
+			opts:     []Option{WithPrefixHandlers(map[string]http.Handler{"/.well-known/openid-configuration": prefixHandler})},
+			path:     "/.well-known/openid-configuration",
+			wantCode: http.StatusOK,
+			wantBody: `{"handler":"prefix"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			proxy := NewHTTPSSEProxy("localhost", 0, false, nil, nil, tt.opts...)
+
+			rec := httptest.NewRecorder()
+			proxy.buildMux().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, tt.path, nil))
+
+			assert.Equal(t, tt.wantCode, rec.Code)
+			assert.JSONEq(t, tt.wantBody, rec.Body.String())
+		})
+	}
+}
+
+// TestBuildMuxKeepsSSEEndpoints verifies the SSE and messages endpoints still
+// route when OAuth discovery and prefix handlers are mounted.
+func TestBuildMuxKeepsSSEEndpoints(t *testing.T) {
+	t.Parallel()
+	proxy := NewHTTPSSEProxy("localhost", 0, false, nil, nil,
+		WithAuthInfoHandler(http.NotFoundHandler()),
+		WithPrefixHandlers(map[string]http.Handler{"/oauth/": http.NotFoundHandler()}),
+	)
+	mux := proxy.buildMux()
+
+	for _, endpoint := range []string{ssecommon.HTTPSSEEndpoint, ssecommon.HTTPMessagesEndpoint} {
+		_, pattern := mux.Handler(httptest.NewRequest(http.MethodGet, endpoint, nil))
+		assert.Equal(t, endpoint, pattern)
+	}
+}

--- a/pkg/transport/proxy/streamable/streamable_proxy.go
+++ b/pkg/transport/proxy/streamable/streamable_proxy.go
@@ -21,6 +21,7 @@ import (
 	"github.com/google/uuid"
 	"golang.org/x/exp/jsonrpc2"
 
+	"github.com/stacklok/toolhive/pkg/auth"
 	"github.com/stacklok/toolhive/pkg/healthcheck"
 	"github.com/stacklok/toolhive/pkg/transport/session"
 	"github.com/stacklok/toolhive/pkg/transport/types"
@@ -47,6 +48,15 @@ type HTTPProxy struct {
 	shutdownCh        chan struct{}
 	prometheusHandler http.Handler
 	middlewares       []types.NamedMiddleware
+
+	// authInfoHandler serves RFC 9728 OAuth protected-resource metadata under
+	// /.well-known/oauth-protected-resource. Set via WithAuthInfoHandler.
+	authInfoHandler http.Handler
+
+	// prefixHandlers maps path prefixes to handlers mounted on the proxy mux
+	// (e.g. the embedded auth server's discovery and /oauth/ routes).
+	// Set via WithPrefixHandlers.
+	prefixHandlers map[string]http.Handler
 
 	// Message channel for sending JSON-RPC to the container (from HTTP -> runner)
 	messageCh chan jsonrpc2.Message
@@ -105,6 +115,23 @@ func WithSessionTTL(ttl time.Duration) Option {
 	}
 }
 
+// WithAuthInfoHandler sets the handler for RFC 9728 OAuth protected-resource
+// metadata, served under /.well-known/oauth-protected-resource (and subpaths).
+func WithAuthInfoHandler(handler http.Handler) Option {
+	return func(p *HTTPProxy) {
+		p.authInfoHandler = handler
+	}
+}
+
+// WithPrefixHandlers mounts the given path-prefix handlers on the proxy mux
+// (e.g. the embedded auth server's discovery and /oauth/ routes). ServeMux
+// longest-match routing resolves precedence against the other endpoints.
+func WithPrefixHandlers(handlers map[string]http.Handler) Option {
+	return func(p *HTTPProxy) {
+		p.prefixHandlers = handlers
+	}
+}
+
 // NewHTTPProxy creates a new HTTPProxy for streamable HTTP transport.
 func NewHTTPProxy(
 	host string,
@@ -146,8 +173,10 @@ func NewHTTPProxy(
 	return proxy
 }
 
-// Start starts the HTTPProxy server.
-func (p *HTTPProxy) Start(_ context.Context) error {
+// buildMux constructs the proxy's HTTP routing table. ServeMux longest-match
+// routing ensures more specific paths take precedence regardless of
+// registration order.
+func (p *HTTPProxy) buildMux() *http.ServeMux {
 	mux := http.NewServeMux()
 	mux.Handle(StreamableHTTPEndpoint, p.applyMiddlewares(http.HandlerFunc(p.handleStreamableRequest)))
 
@@ -159,6 +188,28 @@ func (p *HTTPProxy) Start(_ context.Context) error {
 	if p.prometheusHandler != nil {
 		mux.Handle("/metrics", p.prometheusHandler)
 	}
+
+	// Mount prefix handlers (e.g. the embedded auth server's discovery and
+	// /oauth/ routes), mirroring the transparent proxy.
+	for prefix, prefixHandler := range p.prefixHandlers {
+		mux.Handle(prefix, prefixHandler)
+		slog.Debug("mounted prefix handler", "prefix", prefix)
+	}
+
+	// Mount RFC 9728 OAuth Protected Resource discovery endpoint (no middlewares).
+	// Always registered so OAuth discovery clients get a clean JSON 404 when auth
+	// is not configured, matching the transparent proxy's behavior.
+	mux.Handle("/.well-known/", auth.NewWellKnownHandler(p.authInfoHandler))
+	if p.authInfoHandler != nil {
+		slog.Debug("rfc 9728 OAuth discovery endpoint enabled at /.well-known/oauth-protected-resource")
+	}
+
+	return mux
+}
+
+// Start starts the HTTPProxy server.
+func (p *HTTPProxy) Start(_ context.Context) error {
+	mux := p.buildMux()
 
 	p.server = &http.Server{
 		Addr:              fmt.Sprintf("%s:%d", p.host, p.port),

--- a/pkg/transport/proxy/streamable/streamable_proxy_test.go
+++ b/pkg/transport/proxy/streamable/streamable_proxy_test.go
@@ -6,6 +6,8 @@ package streamable
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -213,4 +215,88 @@ func TestNewHTTPProxyWithSessionStorage(t *testing.T) {
 	proxy := NewHTTPProxy("localhost", 0, nil, nil, WithSessionStorage(storage))
 	require.NotNil(t, proxy)
 	require.NotNil(t, proxy.sessionManager)
+}
+
+// TestBuildMuxOAuthRouting verifies the proxy mux routes OAuth discovery
+// requests and mounted prefix handlers.
+func TestBuildMuxOAuthRouting(t *testing.T) {
+	t.Parallel()
+
+	authHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"resource":"test"}`))
+	})
+	prefixHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"handler":"prefix"}`))
+	})
+
+	tests := []struct {
+		name     string
+		opts     []Option
+		path     string
+		wantCode int
+		wantBody string
+	}{
+		{
+			name:     "well-known returns JSON 404 when auth is not configured",
+			path:     "/.well-known/oauth-protected-resource",
+			wantCode: http.StatusNotFound,
+			wantBody: `{"error":"not_found"}`,
+		},
+		{
+			name:     "auth info handler serves protected-resource metadata",
+			opts:     []Option{WithAuthInfoHandler(authHandler)},
+			path:     "/.well-known/oauth-protected-resource",
+			wantCode: http.StatusOK,
+			wantBody: `{"resource":"test"}`,
+		},
+		{
+			name:     "auth info handler serves protected-resource subpaths",
+			opts:     []Option{WithAuthInfoHandler(authHandler)},
+			path:     "/.well-known/oauth-protected-resource/mcp",
+			wantCode: http.StatusOK,
+			wantBody: `{"resource":"test"}`,
+		},
+		{
+			name:     "prefix handlers are mounted on the mux",
+			opts:     []Option{WithPrefixHandlers(map[string]http.Handler{"/oauth/": prefixHandler})},
+			path:     "/oauth/authorize",
+			wantCode: http.StatusOK,
+			wantBody: `{"handler":"prefix"}`,
+		},
+		{
+			name:     "exact-path prefix handler wins over the well-known subtree",
+			opts:     []Option{WithPrefixHandlers(map[string]http.Handler{"/.well-known/openid-configuration": prefixHandler})},
+			path:     "/.well-known/openid-configuration",
+			wantCode: http.StatusOK,
+			wantBody: `{"handler":"prefix"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			proxy := NewHTTPProxy("localhost", 0, nil, nil, tt.opts...)
+
+			rec := httptest.NewRecorder()
+			proxy.buildMux().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, tt.path, nil))
+
+			assert.Equal(t, tt.wantCode, rec.Code)
+			assert.JSONEq(t, tt.wantBody, rec.Body.String())
+		})
+	}
+}
+
+// TestBuildMuxKeepsMCPEndpoint verifies the MCP endpoint still routes when
+// OAuth discovery and prefix handlers are mounted.
+func TestBuildMuxKeepsMCPEndpoint(t *testing.T) {
+	t.Parallel()
+	proxy := NewHTTPProxy("localhost", 0, nil, nil,
+		WithAuthInfoHandler(http.NotFoundHandler()),
+		WithPrefixHandlers(map[string]http.Handler{"/oauth/": http.NotFoundHandler()}),
+	)
+
+	_, pattern := proxy.buildMux().Handler(httptest.NewRequest(http.MethodPost, StreamableHTTPEndpoint, nil))
+	assert.Equal(t, StreamableHTTPEndpoint, pattern)
 }

--- a/pkg/transport/stdio.go
+++ b/pkg/transport/stdio.go
@@ -65,6 +65,15 @@ type StdioTransport struct {
 	sessionStorage    session.Storage
 	sessionTTL        time.Duration
 
+	// authInfoHandler serves RFC 9728 OAuth protected-resource metadata under
+	// /.well-known/oauth-protected-resource on the proxy. Set via SetAuthInfoHandler.
+	authInfoHandler http.Handler
+
+	// prefixHandlers maps path prefixes to handlers mounted on the proxy mux
+	// (e.g. the embedded auth server's discovery and /oauth/ routes).
+	// Set via SetPrefixHandlers.
+	prefixHandlers map[string]http.Handler
+
 	// Mutex for protecting shared state
 	mutex sync.Mutex
 
@@ -149,6 +158,18 @@ func (t *StdioTransport) SetSessionTTL(ttl time.Duration) {
 	t.sessionTTL = ttl
 }
 
+// SetAuthInfoHandler configures the handler for RFC 9728 OAuth protected-resource
+// metadata, served by the underlying proxy under /.well-known/oauth-protected-resource.
+func (t *StdioTransport) SetAuthInfoHandler(handler http.Handler) {
+	t.authInfoHandler = handler
+}
+
+// SetPrefixHandlers configures path-prefix handlers mounted on the underlying
+// proxy's mux (e.g. the embedded auth server's discovery and /oauth/ routes).
+func (t *StdioTransport) SetPrefixHandlers(handlers map[string]http.Handler) {
+	t.prefixHandlers = handlers
+}
+
 // Mode returns the transport mode.
 func (*StdioTransport) Mode() types.TransportType {
 	return types.TransportTypeStdio
@@ -198,33 +219,21 @@ func (t *StdioTransport) Start(ctx context.Context) error {
 	// Create and start the correct proxy with middlewares
 	switch t.proxyMode {
 	case types.ProxyModeStreamableHTTP:
-		var streamableOpts []streamable.Option
-		if t.sessionTTL > 0 {
-			streamableOpts = append(streamableOpts, streamable.WithSessionTTL(t.sessionTTL))
-		}
-		if t.sessionStorage != nil {
-			streamableOpts = append(streamableOpts, streamable.WithSessionStorage(t.sessionStorage))
-		}
-		t.httpProxy = streamable.NewHTTPProxy(t.host, t.proxyPort, t.prometheusHandler, t.middlewares, streamableOpts...)
+		t.httpProxy = streamable.NewHTTPProxy(
+			t.host, t.proxyPort, t.prometheusHandler, t.middlewares, t.streamableProxyOptions()...,
+		)
 		if err := t.httpProxy.Start(ctx); err != nil {
 			return err
 		}
 		slog.Debug("streamable HTTP proxy started, processing messages")
 	case types.ProxyModeSSE:
-		var sseOpts []httpsse.Option
-		if t.sessionTTL > 0 {
-			sseOpts = append(sseOpts, httpsse.WithSessionTTL(t.sessionTTL))
-		}
-		if t.sessionStorage != nil {
-			sseOpts = append(sseOpts, httpsse.WithSessionStorage(t.sessionStorage))
-		}
 		t.httpProxy = httpsse.NewHTTPSSEProxy(
 			t.host,
 			t.proxyPort,
 			t.trustProxyHeaders,
 			t.prometheusHandler,
 			t.middlewares,
-			sseOpts...,
+			t.sseProxyOptions()...,
 		)
 		if err := t.httpProxy.Start(ctx); err != nil {
 			return err
@@ -254,6 +263,44 @@ func (t *StdioTransport) Start(ctx context.Context) error {
 	go t.handleContainerExit(ctx) //nolint:gosec // G118 - background goroutine manages container lifecycle, outlives request
 
 	return nil
+}
+
+// streamableProxyOptions collects the configured options for the streamable
+// HTTP proxy created in Start.
+func (t *StdioTransport) streamableProxyOptions() []streamable.Option {
+	var opts []streamable.Option
+	if t.sessionTTL > 0 {
+		opts = append(opts, streamable.WithSessionTTL(t.sessionTTL))
+	}
+	if t.sessionStorage != nil {
+		opts = append(opts, streamable.WithSessionStorage(t.sessionStorage))
+	}
+	if t.authInfoHandler != nil {
+		opts = append(opts, streamable.WithAuthInfoHandler(t.authInfoHandler))
+	}
+	if len(t.prefixHandlers) > 0 {
+		opts = append(opts, streamable.WithPrefixHandlers(t.prefixHandlers))
+	}
+	return opts
+}
+
+// sseProxyOptions collects the configured options for the SSE proxy created
+// in Start.
+func (t *StdioTransport) sseProxyOptions() []httpsse.Option {
+	var opts []httpsse.Option
+	if t.sessionTTL > 0 {
+		opts = append(opts, httpsse.WithSessionTTL(t.sessionTTL))
+	}
+	if t.sessionStorage != nil {
+		opts = append(opts, httpsse.WithSessionStorage(t.sessionStorage))
+	}
+	if t.authInfoHandler != nil {
+		opts = append(opts, httpsse.WithAuthInfoHandler(t.authInfoHandler))
+	}
+	if len(t.prefixHandlers) > 0 {
+		opts = append(opts, httpsse.WithPrefixHandlers(t.prefixHandlers))
+	}
+	return opts
 }
 
 // Stop gracefully shuts down the transport and the container.


### PR DESCRIPTION
## Summary

Workloads on the stdio transport silently lose OAuth discovery: `types.Config.AuthInfoHandler` and `types.Config.PrefixHandlers` are populated by the runner but dropped in the factory's stdio branch, so clients get 404 for RFC 9728 protected-resource metadata (`/.well-known/oauth-protected-resource`) and for the embedded auth server's endpoints. SSE and streamable-http workloads already serve these through the transparent proxy.

- Add typed `WithAuthInfoHandler` / `WithPrefixHandlers` functional options to both the streamable and SSE proxies, and mount them in the mux the same way the transparent proxy does: prefix handlers first, then an always-registered `/.well-known/` handler via `auth.NewWellKnownHandler` so OAuth discovery clients get a clean JSON 404 when auth is not configured.
- Add `SetAuthInfoHandler` / `SetPrefixHandlers` on `StdioTransport` (matching the existing `SetProxyMode` / `SetSessionStorage` precedent) and wire both through in the factory's stdio branch.
- Extract mux construction in both proxies into `buildMux()` so routing is unit-testable without binding a port; this also resolved a gocyclo lint failure on `StdioTransport.Start` by collecting proxy options in small helpers.

Fixes #5472

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [x] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [x] Linting (`task lint-fix`)
- [ ] Manual testing (describe below)

## Changes

| File | Change |
|------|--------|
| `pkg/transport/proxy/streamable/streamable_proxy.go` | Options, fields, `buildMux()` with prefix + well-known mounting |
| `pkg/transport/proxy/httpsse/http_proxy.go` | Same shape as streamable |
| `pkg/transport/stdio.go` | Fields, setters, options threaded into both proxy constructions |
| `pkg/transport/factory.go` | Wire `config.AuthInfoHandler` / `config.PrefixHandlers` in the stdio branch |
| `pkg/transport/proxy/streamable/streamable_proxy_test.go` | Table-driven routing tests via `buildMux()` + `httptest` |
| `pkg/transport/proxy/httpsse/http_proxy_test.go` | Same coverage for the SSE proxy |

## Does this introduce a user-facing change?

Yes. MCP servers run with `--transport stdio` and OAuth middleware now serve `/.well-known/oauth-protected-resource` (RFC 9728) and the embedded auth server's discovery and `/oauth/` endpoints, matching SSE and streamable-http workloads. Without auth configured, `/.well-known/` paths return a parseable JSON 404 instead of falling through to the MCP handler.

## Special notes for reviewers

- `EmbeddedAuthServer.Routes()` registers exact paths (`/.well-known/openid-configuration` etc.), so it never collides with the always-registered `/.well-known/` subtree handler; ServeMux longest-match resolves precedence. There is a test asserting this.
- Verification was run scoped to the affected packages: `golangci-lint run --fix ./pkg/transport/... ./pkg/auth/...` with the repo config (0 issues) and `go test` for `pkg/transport`, `pkg/transport/proxy/streamable`, `pkg/transport/proxy/httpsse` (all pass). This machine has no C compiler, so the `-race` variant runs in CI only.

Generated with [Claude Code](https://claude.com/claude-code)