### PR TITLE
Wire RFC 9728 discovery into HTTP and stdio transports

### DIFF
--- a/pkg/transport/factory.go
+++ b/pkg/transport/factory.go
@@ -56,6 +56,12 @@ func (*Factory) Create(config types.Config, opts ...Option) (types.Transport, er
 			stdio.SetSessionStorage(config.SessionStorage)
 		}
 		stdio.SetSessionTTL(config.SessionTTL)
+		if config.AuthInfoHandler != nil {
+			stdio.SetAuthInfoHandler(config.AuthInfoHandler)
+		}
+		if len(config.PrefixHandlers) > 0 {
+			stdio.SetPrefixHandlers(config.PrefixHandlers)
+		}
 		tr = stdio
 	case types.TransportTypeSSE:
 		httpTransport := NewHTTPTransport(

--- a/pkg/transport/proxy/httpsse/http_proxy.go
+++ b/pkg/transport/proxy/httpsse/http_proxy.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"maps"
 	"net"
 	"net/http"
 	"net/url"
@@ -22,6 +23,7 @@ import (
 	"github.com/google/uuid"
 	"golang.org/x/exp/jsonrpc2"
 
+	"github.com/stacklok/toolhive/pkg/auth"
 	"github.com/stacklok/toolhive/pkg/healthcheck"
 	"github.com/stacklok/toolhive/pkg/transport/proxy/socket"
 	"github.com/stacklok/toolhive/pkg/transport/session"
@@ -81,6 +83,14 @@ type HTTPSSEProxy struct {
 	// sessionStorage is the optional custom storage backend for the session manager.
 	// When nil, in-memory LocalStorage is used. Set via WithSessionStorage.
 	sessionStorage session.Storage
+
+	// authInfoHandler is the optional RFC 9728 OAuth protected resource discovery handler.
+	// When nil, /.well-known/ returns a clean JSON 404. Set via WithAuthInfoHandler.
+	authInfoHandler http.Handler
+
+	// prefixHandlers contains additional HTTP handlers mounted outside the middleware chain.
+	// Keys are URL path prefixes. Set via WithPrefixHandlers.
+	prefixHandlers map[string]http.Handler
 
 	// liveSSESessions tracks active SSE connections local to this instance.
 	// Keys are clientID strings; values are *session.SSESession.
@@ -144,6 +154,22 @@ func WithSessionTTL(ttl time.Duration) Option {
 	}
 }
 
+// WithAuthInfoHandler sets the RFC 9728 OAuth protected resource discovery handler.
+// When nil (the default), requests to /.well-known/ return a clean JSON 404.
+func WithAuthInfoHandler(h http.Handler) Option {
+	return func(p *HTTPSSEProxy) {
+		p.authInfoHandler = h
+	}
+}
+
+// WithPrefixHandlers sets additional HTTP handlers that are mounted outside the
+// middleware chain, keyed by URL path prefix.
+func WithPrefixHandlers(handlers map[string]http.Handler) Option {
+	return func(p *HTTPSSEProxy) {
+		p.prefixHandlers = maps.Clone(handlers)
+	}
+}
+
 // NewHTTPSSEProxy creates a new HTTP SSE proxy for transports.
 func NewHTTPSSEProxy(
 	host string,
@@ -197,6 +223,21 @@ func applyMiddlewares(handler http.Handler, middlewares ...types.NamedMiddleware
 func (p *HTTPSSEProxy) Start(_ context.Context) error {
 	// Create a new HTTP server
 	mux := http.NewServeMux()
+
+	// Mount prefix handlers (e.g. embedded auth server routes) outside the middleware chain.
+	// RFC 9728 requires discovery endpoints to be reachable without authentication.
+	for prefix, h := range p.prefixHandlers {
+		mux.Handle(prefix, h)
+		slog.Debug("mounted prefix handler", "prefix", prefix)
+	}
+
+	// Mount RFC 9728 OAuth protected resource discovery endpoint (no middlewares).
+	// Always register so OAuth discovery gets a clean JSON 404 when auth is off.
+	wellKnownHandler := auth.NewWellKnownHandler(p.authInfoHandler)
+	mux.Handle("/.well-known/", wellKnownHandler)
+	if p.authInfoHandler != nil {
+		slog.Debug("rfc 9728 OAuth discovery endpoint enabled at /.well-known/oauth-protected-resource")
+	}
 
 	// Add handlers for SSE and JSON-RPC with middlewares
 	// At some point we should add support for Streamable HTTP transport here

--- a/pkg/transport/proxy/httpsse/http_proxy_integration_test.go
+++ b/pkg/transport/proxy/httpsse/http_proxy_integration_test.go
@@ -6,6 +6,7 @@ package httpsse
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -378,4 +379,46 @@ func extractSessionID(body io.Reader) (string, error) {
 	}
 
 	return string(buf[start:end]), nil
+}
+
+// TestHTTPSSEProxy_StartMountsAuthDiscoveryEndpoint is an integration test that
+// starts a real SSE proxy with an authInfoHandler and verifies the RFC 9728
+// discovery endpoint responds correctly.
+func TestHTTPSSEProxy_StartMountsAuthDiscoveryEndpoint(t *testing.T) {
+	t.Parallel()
+
+	const wantBody = `{"resource":"https://example.com"}`
+
+	sentinel := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(wantBody))
+	})
+
+	proxy := NewHTTPSSEProxy("localhost", 0, false, nil, nil, WithAuthInfoHandler(sentinel))
+	ctx := context.Background()
+
+	require.NoError(t, proxy.Start(ctx))
+	t.Cleanup(func() {
+		stopCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = proxy.Stop(stopCtx)
+	})
+
+	// Poll until the server is ready (Start returns before the goroutine binds).
+	url := fmt.Sprintf("http://%s/.well-known/oauth-protected-resource", proxy.server.Addr)
+	var resp *http.Response
+	require.Eventually(t, func() bool {
+		var err error
+		resp, err = http.Get(url) //nolint:gosec // test-only URL construction
+		return err == nil
+	}, 500*time.Millisecond, 10*time.Millisecond, "server did not become ready")
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Contains(t, resp.Header.Get("Content-Type"), "application/json")
+
+	var body map[string]string
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	assert.Equal(t, "https://example.com", body["resource"])
 }

--- a/pkg/transport/proxy/httpsse/http_proxy_integration_test.go
+++ b/pkg/transport/proxy/httpsse/http_proxy_integration_test.go
@@ -27,8 +27,7 @@ func TestIntegrationSSEProxyStressTest(t *testing.T) {
 
 	// Create proxy with a random port
 	proxy := NewHTTPSSEProxy("localhost", 0, false, nil, nil)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	// Start the proxy
 	err := proxy.Start(ctx)
@@ -174,8 +173,7 @@ func TestIntegrationConcurrentClientsWithLongRunning(t *testing.T) {
 
 	// Create and start proxy
 	proxy := NewHTTPSSEProxy("localhost", 0, false, nil, nil)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	err := proxy.Start(ctx)
 	require.NoError(t, err)
@@ -320,7 +318,7 @@ func TestIntegrationConcurrentClientsWithLongRunning(t *testing.T) {
 func TestIntegrationLiveSessionsCleanup(t *testing.T) {
 	t.Parallel()
 	proxy := NewHTTPSSEProxy("localhost", 0, false, nil, nil)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	err := proxy.Start(ctx)
 	require.NoError(t, err)
@@ -396,7 +394,7 @@ func TestHTTPSSEProxy_StartMountsAuthDiscoveryEndpoint(t *testing.T) {
 	})
 
 	proxy := NewHTTPSSEProxy("localhost", 0, false, nil, nil, WithAuthInfoHandler(sentinel))
-	ctx := context.Background()
+	ctx := t.Context()
 
 	require.NoError(t, proxy.Start(ctx))
 	t.Cleanup(func() {

--- a/pkg/transport/proxy/httpsse/http_proxy_test.go
+++ b/pkg/transport/proxy/httpsse/http_proxy_test.go
@@ -181,7 +181,7 @@ func TestConcurrentClientRemoval(t *testing.T) {
 //nolint:paralleltest // Test modifies shared proxy state
 func TestForwardResponseToClients(t *testing.T) {
 	proxy := NewHTTPSSEProxy("localhost", 8080, false, nil, nil)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Create a client session
 	clientID := testClientID
@@ -220,7 +220,7 @@ func TestForwardResponseToClients(t *testing.T) {
 //nolint:paralleltest // Test modifies shared proxy state
 func TestForwardResponseToClients_NoClients(t *testing.T) {
 	proxy := NewHTTPSSEProxy("localhost", 8080, false, nil, nil)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Create a test response
 	response, err := jsonrpc2.NewResponse(jsonrpc2.StringID("test"), "test result", nil)
@@ -609,7 +609,7 @@ func TestNewHTTPSSEProxyWithSessionStorage(t *testing.T) {
 //nolint:paralleltest // Test starts/stops HTTP server
 func TestNewHTTPSSEProxy_AuthInfoHandlerNil(t *testing.T) {
 	proxy := NewHTTPSSEProxy("localhost", 0, false, nil, nil) // no WithAuthInfoHandler
-	ctx := context.Background()
+	ctx := t.Context()
 
 	require.NoError(t, proxy.Start(ctx))
 	t.Cleanup(func() {
@@ -643,7 +643,7 @@ func TestNewHTTPSSEProxy_PrefixHandlerMounted(t *testing.T) {
 	proxy := NewHTTPSSEProxy("localhost", 0, false, nil, nil,
 		WithPrefixHandlers(map[string]http.Handler{"/oauth/token": sentinel}),
 	)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	require.NoError(t, proxy.Start(ctx))
 	t.Cleanup(func() {
@@ -676,7 +676,7 @@ func TestNewHTTPSSEProxy_PrefixHandlerDoesNotShadowSSE(t *testing.T) {
 	proxy := NewHTTPSSEProxy("localhost", 0, false, nil, nil,
 		WithPrefixHandlers(map[string]http.Handler{"/oauth/token": sentinel}),
 	)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	require.NoError(t, proxy.Start(ctx))
 	t.Cleanup(func() {
@@ -698,12 +698,58 @@ func TestNewHTTPSSEProxy_PrefixHandlerDoesNotShadowSSE(t *testing.T) {
 	assert.Equal(t, "text/event-stream", resp.Header.Get("Content-Type"))
 }
 
+// TestNewHTTPSSEProxy_ExactWellKnownBeatsSubtree verifies that Go ServeMux
+// specificity applies: an exact path registered via WithPrefixHandlers wins
+// over the /.well-known/ subtree mount used by WithAuthInfoHandler.
+//
+//nolint:paralleltest // Test starts/stops HTTP server
+func TestNewHTTPSSEProxy_ExactWellKnownBeatsSubtree(t *testing.T) {
+	exactHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTeapot)
+	})
+	authInfoHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	proxy := NewHTTPSSEProxy("localhost", 0, false, nil, nil,
+		WithPrefixHandlers(map[string]http.Handler{"/.well-known/openid-configuration": exactHandler}),
+		WithAuthInfoHandler(authInfoHandler),
+	)
+	ctx := t.Context()
+
+	require.NoError(t, proxy.Start(ctx))
+	t.Cleanup(func() {
+		stopCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = proxy.Stop(stopCtx)
+	})
+
+	base := fmt.Sprintf("http://%s", proxy.server.Addr)
+
+	// Poll until the server is ready.
+	var oidcResp *http.Response
+	require.Eventually(t, func() bool {
+		var err error
+		oidcResp, err = http.Get(base + "/.well-known/openid-configuration") //nolint:gosec // test-only URL construction
+		return err == nil
+	}, 500*time.Millisecond, 10*time.Millisecond, "server did not become ready")
+	defer oidcResp.Body.Close()
+
+	assert.Equal(t, http.StatusTeapot, oidcResp.StatusCode, "exact handler must win over subtree mount")
+
+	prmResp, err := http.Get(base + "/.well-known/oauth-protected-resource") //nolint:gosec // test-only URL construction
+	require.NoError(t, err)
+	defer prmResp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, prmResp.StatusCode, "subtree handler must serve other /.well-known/ paths")
+}
+
 // TestStartStop tests starting and stopping the proxy
 //
 //nolint:paralleltest // Test starts/stops HTTP server
 func TestStartStop(t *testing.T) {
 	proxy := NewHTTPSSEProxy("localhost", 0, false, nil, nil) // Use port 0 for auto-assignment
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Start the proxy
 	err := proxy.Start(ctx)

--- a/pkg/transport/proxy/httpsse/http_proxy_test.go
+++ b/pkg/transport/proxy/httpsse/http_proxy_test.go
@@ -603,6 +603,101 @@ func TestNewHTTPSSEProxyWithSessionStorage(t *testing.T) {
 	require.NotNil(t, proxy.sessionManager)
 }
 
+// TestNewHTTPSSEProxy_AuthInfoHandlerNil verifies that when no authInfoHandler is set,
+// requests to /.well-known/oauth-protected-resource return a JSON 404.
+//
+//nolint:paralleltest // Test starts/stops HTTP server
+func TestNewHTTPSSEProxy_AuthInfoHandlerNil(t *testing.T) {
+	proxy := NewHTTPSSEProxy("localhost", 0, false, nil, nil) // no WithAuthInfoHandler
+	ctx := context.Background()
+
+	require.NoError(t, proxy.Start(ctx))
+	t.Cleanup(func() {
+		stopCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = proxy.Stop(stopCtx)
+	})
+
+	url := fmt.Sprintf("http://%s/.well-known/oauth-protected-resource", proxy.server.Addr)
+	var resp *http.Response
+	require.Eventually(t, func() bool {
+		var err error
+		resp, err = http.Get(url) //nolint:gosec // test-only URL construction
+		return err == nil
+	}, 500*time.Millisecond, 10*time.Millisecond, "server did not become ready")
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	assert.Contains(t, resp.Header.Get("Content-Type"), "application/json")
+}
+
+// TestNewHTTPSSEProxy_PrefixHandlerMounted verifies that a handler registered via
+// WithPrefixHandlers is reachable at its declared path prefix.
+//
+//nolint:paralleltest // Test starts/stops HTTP server
+func TestNewHTTPSSEProxy_PrefixHandlerMounted(t *testing.T) {
+	sentinel := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	proxy := NewHTTPSSEProxy("localhost", 0, false, nil, nil,
+		WithPrefixHandlers(map[string]http.Handler{"/oauth/token": sentinel}),
+	)
+	ctx := context.Background()
+
+	require.NoError(t, proxy.Start(ctx))
+	t.Cleanup(func() {
+		stopCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = proxy.Stop(stopCtx)
+	})
+
+	url := fmt.Sprintf("http://%s/oauth/token", proxy.server.Addr)
+	var resp *http.Response
+	require.Eventually(t, func() bool {
+		var err error
+		resp, err = http.Get(url) //nolint:gosec // test-only URL construction
+		return err == nil
+	}, 500*time.Millisecond, 10*time.Millisecond, "server did not become ready")
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+// TestNewHTTPSSEProxy_PrefixHandlerDoesNotShadowSSE verifies that registering prefix
+// handlers does not prevent the /sse endpoint from being reachable.
+//
+//nolint:paralleltest // Test starts/stops HTTP server
+func TestNewHTTPSSEProxy_PrefixHandlerDoesNotShadowSSE(t *testing.T) {
+	sentinel := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	proxy := NewHTTPSSEProxy("localhost", 0, false, nil, nil,
+		WithPrefixHandlers(map[string]http.Handler{"/oauth/token": sentinel}),
+	)
+	ctx := context.Background()
+
+	require.NoError(t, proxy.Start(ctx))
+	t.Cleanup(func() {
+		stopCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = proxy.Stop(stopCtx)
+	})
+
+	// /sse returns text/event-stream for GET requests, which proves it is registered.
+	url := fmt.Sprintf("http://%s/sse", proxy.server.Addr)
+	var resp *http.Response
+	require.Eventually(t, func() bool {
+		var err error
+		resp, err = http.Get(url) //nolint:gosec // test-only URL construction
+		return err == nil
+	}, 500*time.Millisecond, 10*time.Millisecond, "server did not become ready")
+	defer resp.Body.Close()
+
+	assert.Equal(t, "text/event-stream", resp.Header.Get("Content-Type"))
+}
+
 // TestStartStop tests starting and stopping the proxy
 //
 //nolint:paralleltest // Test starts/stops HTTP server

--- a/pkg/transport/proxy/streamable/streamable_proxy.go
+++ b/pkg/transport/proxy/streamable/streamable_proxy.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"maps"
 	"net/http"
 	"os"
 	"strings"
@@ -21,6 +22,7 @@ import (
 	"github.com/google/uuid"
 	"golang.org/x/exp/jsonrpc2"
 
+	"github.com/stacklok/toolhive/pkg/auth"
 	"github.com/stacklok/toolhive/pkg/healthcheck"
 	"github.com/stacklok/toolhive/pkg/transport/session"
 	"github.com/stacklok/toolhive/pkg/transport/types"
@@ -64,6 +66,14 @@ type HTTPProxy struct {
 	// When nil, in-memory LocalStorage is used. Set via WithSessionStorage.
 	sessionStorage session.Storage
 
+	// authInfoHandler is the optional RFC 9728 OAuth protected resource discovery handler.
+	// When nil, /.well-known/ returns a clean JSON 404. Set via WithAuthInfoHandler.
+	authInfoHandler http.Handler
+
+	// prefixHandlers contains additional HTTP handlers mounted outside the middleware chain.
+	// Keys are URL path prefixes. Set via WithPrefixHandlers.
+	prefixHandlers map[string]http.Handler
+
 	// Waiters keyed by compositeKey(sessID, idKey) -> one-shot channel for response delivery.
 	// The composite key MUST be unique per concurrent request; sharing it across requests
 	// (e.g. with sessID="" for sessionless requests) silently overwrites entries and crosses
@@ -102,6 +112,23 @@ func WithSessionTTL(ttl time.Duration) Option {
 			return
 		}
 		p.sessionTTL = ttl
+	}
+}
+
+// WithAuthInfoHandler sets the handler for RFC 9728 OAuth protected resource discovery.
+// When set, the handler is mounted at /.well-known/ outside the middleware chain.
+// When nil, /.well-known/ returns a clean JSON 404 so OAuth clients parse it cleanly.
+func WithAuthInfoHandler(h http.Handler) Option {
+	return func(p *HTTPProxy) {
+		p.authInfoHandler = h
+	}
+}
+
+// WithPrefixHandlers registers additional HTTP handlers mounted before the MCP endpoint.
+// These are mounted outside the middleware chain (RFC 9728, embedded auth server routes).
+func WithPrefixHandlers(handlers map[string]http.Handler) Option {
+	return func(p *HTTPProxy) {
+		p.prefixHandlers = maps.Clone(handlers)
 	}
 }
 
@@ -158,6 +185,21 @@ func (p *HTTPProxy) Start(_ context.Context) error {
 
 	if p.prometheusHandler != nil {
 		mux.Handle("/metrics", p.prometheusHandler)
+	}
+
+	// Mount prefix handlers (e.g. embedded auth server routes) outside the middleware chain.
+	// RFC 9728 requires discovery endpoints to be reachable without authentication.
+	for prefix, h := range p.prefixHandlers {
+		mux.Handle(prefix, h)
+		slog.Debug("mounted prefix handler", "prefix", prefix)
+	}
+
+	// Mount RFC 9728 OAuth protected resource discovery endpoint (no middlewares).
+	// Always register so OAuth discovery gets a clean JSON 404 when auth is off.
+	wellKnownHandler := auth.NewWellKnownHandler(p.authInfoHandler)
+	mux.Handle("/.well-known/", wellKnownHandler)
+	if p.authInfoHandler != nil {
+		slog.Debug("rfc 9728 OAuth discovery endpoint enabled at /.well-known/oauth-protected-resource")
 	}
 
 	p.server = &http.Server{

--- a/pkg/transport/proxy/streamable/streamable_proxy_integration_test.go
+++ b/pkg/transport/proxy/streamable/streamable_proxy_integration_test.go
@@ -35,7 +35,7 @@ func TestHTTPRequestIgnoresNotifications(t *testing.T) {
 	// Get an available port dynamically
 	port := getFreePort(t)
 	proxy := NewHTTPProxy("localhost", port, nil, nil)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Start the proxy server
 	err := proxy.Start(ctx)
@@ -123,7 +123,7 @@ func TestHTTPProxy_StartMountsAuthDiscoveryEndpoint(t *testing.T) {
 
 	port := getFreePort(t)
 	proxy := NewHTTPProxy("localhost", port, nil, nil, WithAuthInfoHandler(sentinel))
-	ctx := context.Background()
+	ctx := t.Context()
 
 	require.NoError(t, proxy.Start(ctx))
 	t.Cleanup(func() {

--- a/pkg/transport/proxy/streamable/streamable_proxy_integration_test.go
+++ b/pkg/transport/proxy/streamable/streamable_proxy_integration_test.go
@@ -106,3 +106,46 @@ func TestHTTPRequestIgnoresNotifications(t *testing.T) {
 	assert.Equal(t, "batch-1", batchResponse[0]["id"])
 	assert.Equal(t, "operation complete", batchResponse[0]["result"])
 }
+
+// TestHTTPProxy_StartMountsAuthDiscoveryEndpoint is an integration test that
+// starts a real proxy with an authInfoHandler and verifies the RFC 9728
+// discovery endpoint responds correctly.
+//
+//nolint:paralleltest // Test starts/stops HTTP server
+func TestHTTPProxy_StartMountsAuthDiscoveryEndpoint(t *testing.T) {
+	const wantBody = `{"resource":"https://example.com"}`
+
+	sentinel := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(wantBody))
+	})
+
+	port := getFreePort(t)
+	proxy := NewHTTPProxy("localhost", port, nil, nil, WithAuthInfoHandler(sentinel))
+	ctx := context.Background()
+
+	require.NoError(t, proxy.Start(ctx))
+	t.Cleanup(func() {
+		stopCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = proxy.Stop(stopCtx)
+	})
+
+	// streamable Start() returns before the goroutine binds — poll until ready.
+	url := fmt.Sprintf("http://localhost:%d/.well-known/oauth-protected-resource", port)
+	var resp *http.Response
+	require.Eventually(t, func() bool {
+		var err error
+		resp, err = http.Get(url) //nolint:gosec // test-only URL construction
+		return err == nil
+	}, 500*time.Millisecond, 10*time.Millisecond, "server did not become ready in time")
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Contains(t, resp.Header.Get("Content-Type"), "application/json")
+
+	var body map[string]string
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	assert.Equal(t, "https://example.com", body["resource"])
+}

--- a/pkg/transport/proxy/streamable/streamable_proxy_test.go
+++ b/pkg/transport/proxy/streamable/streamable_proxy_test.go
@@ -6,6 +6,7 @@ package streamable
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"testing"
 	"time"
 
@@ -213,4 +214,138 @@ func TestNewHTTPProxyWithSessionStorage(t *testing.T) {
 	proxy := NewHTTPProxy("localhost", 0, nil, nil, WithSessionStorage(storage))
 	require.NotNil(t, proxy)
 	require.NotNil(t, proxy.sessionManager)
+}
+
+// TestNewHTTPProxy_AuthInfoHandlerMounted verifies that a sentinel authInfoHandler
+// registered via WithAuthInfoHandler is reachable at /.well-known/oauth-protected-resource
+// after Start is called.
+//
+//nolint:paralleltest // Test starts/stops HTTP server
+func TestNewHTTPProxy_AuthInfoHandlerMounted(t *testing.T) {
+	sentinel := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	port := getFreePort(t)
+	proxy := NewHTTPProxy("localhost", port, nil, nil, WithAuthInfoHandler(sentinel))
+	ctx := context.Background()
+
+	require.NoError(t, proxy.Start(ctx))
+	t.Cleanup(func() {
+		stopCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = proxy.Stop(stopCtx)
+	})
+
+	// Poll until server is ready (max 500 ms).
+	url := fmt.Sprintf("http://localhost:%d/.well-known/oauth-protected-resource", port)
+	var resp *http.Response
+	require.Eventually(t, func() bool {
+		var err error
+		resp, err = http.Get(url) //nolint:gosec // test-only URL construction
+		return err == nil
+	}, 500*time.Millisecond, 10*time.Millisecond, "server did not become ready")
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+// TestNewHTTPProxy_AuthInfoHandlerNil verifies that when no authInfoHandler is set,
+// requests to /.well-known/oauth-protected-resource return a JSON 404 (not a Go default 404).
+//
+//nolint:paralleltest // Test starts/stops HTTP server
+func TestNewHTTPProxy_AuthInfoHandlerNil(t *testing.T) {
+	port := getFreePort(t)
+	proxy := NewHTTPProxy("localhost", port, nil, nil) // no WithAuthInfoHandler
+	ctx := context.Background()
+
+	require.NoError(t, proxy.Start(ctx))
+	t.Cleanup(func() {
+		stopCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = proxy.Stop(stopCtx)
+	})
+
+	url := fmt.Sprintf("http://localhost:%d/.well-known/oauth-protected-resource", port)
+	var resp *http.Response
+	require.Eventually(t, func() bool {
+		var err error
+		resp, err = http.Get(url) //nolint:gosec // test-only URL construction
+		return err == nil
+	}, 500*time.Millisecond, 10*time.Millisecond, "server did not become ready")
+	defer resp.Body.Close()
+
+	// WellKnownHandler returns a JSON 404, not 200.
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	assert.Contains(t, resp.Header.Get("Content-Type"), "application/json")
+}
+
+// TestNewHTTPProxy_PrefixHandlerMounted verifies that a handler registered via
+// WithPrefixHandlers is reachable at its declared path prefix.
+//
+//nolint:paralleltest // Test starts/stops HTTP server
+func TestNewHTTPProxy_PrefixHandlerMounted(t *testing.T) {
+	sentinel := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	port := getFreePort(t)
+	proxy := NewHTTPProxy("localhost", port, nil, nil,
+		WithPrefixHandlers(map[string]http.Handler{"/oauth/token": sentinel}),
+	)
+	ctx := context.Background()
+
+	require.NoError(t, proxy.Start(ctx))
+	t.Cleanup(func() {
+		stopCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = proxy.Stop(stopCtx)
+	})
+
+	url := fmt.Sprintf("http://localhost:%d/oauth/token", port)
+	var resp *http.Response
+	require.Eventually(t, func() bool {
+		var err error
+		resp, err = http.Get(url) //nolint:gosec // test-only URL construction
+		return err == nil
+	}, 500*time.Millisecond, 10*time.Millisecond, "server did not become ready")
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+// TestNewHTTPProxy_PrefixHandlerDoesNotShadowMCP verifies that registering prefix
+// handlers does not prevent the /mcp endpoint from being reachable.
+//
+//nolint:paralleltest // Test starts/stops HTTP server
+func TestNewHTTPProxy_PrefixHandlerDoesNotShadowMCP(t *testing.T) {
+	sentinel := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	port := getFreePort(t)
+	proxy := NewHTTPProxy("localhost", port, nil, nil,
+		WithPrefixHandlers(map[string]http.Handler{"/oauth/token": sentinel}),
+	)
+	ctx := context.Background()
+
+	require.NoError(t, proxy.Start(ctx))
+	t.Cleanup(func() {
+		stopCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = proxy.Stop(stopCtx)
+	})
+
+	// /mcp returns 405 for GET (only POST is accepted), which proves the
+	// endpoint is registered — a missing route would be 404.
+	url := fmt.Sprintf("http://localhost:%d%s", port, StreamableHTTPEndpoint)
+	var resp *http.Response
+	require.Eventually(t, func() bool {
+		var err error
+		resp, err = http.Get(url) //nolint:gosec // test-only URL construction
+		return err == nil
+	}, 500*time.Millisecond, 10*time.Millisecond, "server did not become ready")
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusMethodNotAllowed, resp.StatusCode)
 }

--- a/pkg/transport/proxy/streamable/streamable_proxy_test.go
+++ b/pkg/transport/proxy/streamable/streamable_proxy_test.go
@@ -35,7 +35,7 @@ func TestNewHTTPProxy(t *testing.T) {
 //nolint:paralleltest // Test modifies shared proxy state
 func TestProxyChannelCommunication(t *testing.T) {
 	proxy := NewHTTPProxy("localhost", 8080, nil, nil)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Test that we can send a message to the destination
 	request, err := jsonrpc2.NewCall(jsonrpc2.StringID("test"), "test.method", nil)
@@ -115,7 +115,7 @@ func TestSendMessageToDestination_ChannelFull(t *testing.T) {
 //nolint:paralleltest // Test starts/stops HTTP server
 func TestStartStop(t *testing.T) {
 	proxy := NewHTTPProxy("localhost", 0, nil, nil) // Use port 0 for auto-assignment
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Start the proxy
 	err := proxy.Start(ctx)
@@ -228,7 +228,7 @@ func TestNewHTTPProxy_AuthInfoHandlerMounted(t *testing.T) {
 
 	port := getFreePort(t)
 	proxy := NewHTTPProxy("localhost", port, nil, nil, WithAuthInfoHandler(sentinel))
-	ctx := context.Background()
+	ctx := t.Context()
 
 	require.NoError(t, proxy.Start(ctx))
 	t.Cleanup(func() {
@@ -257,7 +257,7 @@ func TestNewHTTPProxy_AuthInfoHandlerMounted(t *testing.T) {
 func TestNewHTTPProxy_AuthInfoHandlerNil(t *testing.T) {
 	port := getFreePort(t)
 	proxy := NewHTTPProxy("localhost", port, nil, nil) // no WithAuthInfoHandler
-	ctx := context.Background()
+	ctx := t.Context()
 
 	require.NoError(t, proxy.Start(ctx))
 	t.Cleanup(func() {
@@ -293,7 +293,7 @@ func TestNewHTTPProxy_PrefixHandlerMounted(t *testing.T) {
 	proxy := NewHTTPProxy("localhost", port, nil, nil,
 		WithPrefixHandlers(map[string]http.Handler{"/oauth/token": sentinel}),
 	)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	require.NoError(t, proxy.Start(ctx))
 	t.Cleanup(func() {
@@ -327,7 +327,7 @@ func TestNewHTTPProxy_PrefixHandlerDoesNotShadowMCP(t *testing.T) {
 	proxy := NewHTTPProxy("localhost", port, nil, nil,
 		WithPrefixHandlers(map[string]http.Handler{"/oauth/token": sentinel}),
 	)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	require.NoError(t, proxy.Start(ctx))
 	t.Cleanup(func() {
@@ -348,4 +348,52 @@ func TestNewHTTPProxy_PrefixHandlerDoesNotShadowMCP(t *testing.T) {
 	defer resp.Body.Close()
 
 	assert.Equal(t, http.StatusMethodNotAllowed, resp.StatusCode)
+}
+
+// TestNewHTTPProxy_ExactWellKnownBeatsSubtree verifies that Go's http.ServeMux
+// specificity rule causes an exact /.well-known/openid-configuration prefix handler
+// to win over the /.well-known/ subtree authInfoHandler (PRM endpoint), ensuring
+// the two registrations coexist without collision.
+//
+//nolint:paralleltest // Test starts/stops HTTP server
+func TestNewHTTPProxy_ExactWellKnownBeatsSubtree(t *testing.T) {
+	oidcHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTeapot) // sentinel: exact match wins
+	})
+	prmHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	port := getFreePort(t)
+	proxy := NewHTTPProxy("localhost", port, nil, nil,
+		WithPrefixHandlers(map[string]http.Handler{"/.well-known/openid-configuration": oidcHandler}),
+		WithAuthInfoHandler(prmHandler),
+	)
+	ctx := t.Context()
+
+	require.NoError(t, proxy.Start(ctx))
+	t.Cleanup(func() {
+		stopCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = proxy.Stop(stopCtx)
+	})
+
+	// Poll until server is ready.
+	oidcURL := fmt.Sprintf("http://localhost:%d/.well-known/openid-configuration", port)
+	var resp *http.Response
+	require.Eventually(t, func() bool {
+		var err error
+		resp, err = http.Get(oidcURL) //nolint:gosec // test-only URL construction
+		return err == nil
+	}, 500*time.Millisecond, 10*time.Millisecond, "server did not become ready")
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusTeapot, resp.StatusCode, "exact /.well-known/openid-configuration must win")
+
+	prmURL := fmt.Sprintf("http://localhost:%d/.well-known/oauth-protected-resource", port)
+	resp2, err := http.Get(prmURL) //nolint:gosec // test-only URL construction
+	require.NoError(t, err)
+	defer resp2.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp2.StatusCode, "/.well-known/ subtree must still reach authInfoHandler")
 }

--- a/pkg/transport/stdio.go
+++ b/pkg/transport/stdio.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"maps"
 	"net"
 	"net/http"
 	"strings"
@@ -64,6 +65,8 @@ type StdioTransport struct {
 	trustProxyHeaders bool
 	sessionStorage    session.Storage
 	sessionTTL        time.Duration
+	authInfoHandler   http.Handler
+	prefixHandlers    map[string]http.Handler
 
 	// Mutex for protecting shared state
 	mutex sync.Mutex
@@ -149,6 +152,16 @@ func (t *StdioTransport) SetSessionTTL(ttl time.Duration) {
 	t.sessionTTL = ttl
 }
 
+// SetAuthInfoHandler sets the RFC 9728 OAuth protected resource discovery handler.
+func (t *StdioTransport) SetAuthInfoHandler(h http.Handler) {
+	t.authInfoHandler = h
+}
+
+// SetPrefixHandlers sets additional HTTP handlers mounted outside the middleware chain.
+func (t *StdioTransport) SetPrefixHandlers(m map[string]http.Handler) {
+	t.prefixHandlers = maps.Clone(m)
+}
+
 // Mode returns the transport mode.
 func (*StdioTransport) Mode() types.TransportType {
 	return types.TransportTypeStdio
@@ -205,6 +218,10 @@ func (t *StdioTransport) Start(ctx context.Context) error {
 		if t.sessionStorage != nil {
 			streamableOpts = append(streamableOpts, streamable.WithSessionStorage(t.sessionStorage))
 		}
+		streamableOpts = append(streamableOpts,
+			streamable.WithAuthInfoHandler(t.authInfoHandler),
+			streamable.WithPrefixHandlers(t.prefixHandlers),
+		)
 		t.httpProxy = streamable.NewHTTPProxy(t.host, t.proxyPort, t.prometheusHandler, t.middlewares, streamableOpts...)
 		if err := t.httpProxy.Start(ctx); err != nil {
 			return err
@@ -218,6 +235,10 @@ func (t *StdioTransport) Start(ctx context.Context) error {
 		if t.sessionStorage != nil {
 			sseOpts = append(sseOpts, httpsse.WithSessionStorage(t.sessionStorage))
 		}
+		sseOpts = append(sseOpts,
+			httpsse.WithAuthInfoHandler(t.authInfoHandler),
+			httpsse.WithPrefixHandlers(t.prefixHandlers),
+		)
 		t.httpProxy = httpsse.NewHTTPSSEProxy(
 			t.host,
 			t.proxyPort,

--- a/pkg/transport/stdio_test.go
+++ b/pkg/transport/stdio_test.go
@@ -1073,161 +1073,125 @@ func TestNewStdioTransport_PreservesPrefixHandlers(t *testing.T) {
 	require.Contains(t, tr.prefixHandlers, "/oauth/token")
 }
 
-// TestFactory_Create_StdioPreservesAuthInfoHandler verifies that the factory
-// forwards AuthInfoHandler from Config to the StdioTransport it creates.
-func TestFactory_Create_StdioPreservesAuthInfoHandler(t *testing.T) {
+func TestFactory_Create_PreservesAuthFields(t *testing.T) {
 	t.Parallel()
 
 	sentinel := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
-
-	cfg := types.Config{
-		Type:            types.TransportTypeStdio,
-		Host:            "localhost",
-		ProxyPort:       8080,
-		AuthInfoHandler: sentinel,
+	prefixHandlers := map[string]http.Handler{
+		"/oauth/token": http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}),
 	}
 
-	factory := NewFactory()
-	tr, err := factory.Create(cfg)
-	require.NoError(t, err)
-
-	stdio, ok := tr.(*StdioTransport)
-	require.True(t, ok, "expected *StdioTransport")
-	require.NotNil(t, stdio.authInfoHandler)
-}
-
-// TestFactory_Create_StdioPreservesPrefixHandlers verifies that the factory
-// forwards PrefixHandlers from Config to the StdioTransport it creates.
-func TestFactory_Create_StdioPreservesPrefixHandlers(t *testing.T) {
-	t.Parallel()
-
-	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	})
-
-	cfg := types.Config{
-		Type:      types.TransportTypeStdio,
-		Host:      "localhost",
-		ProxyPort: 8080,
-		PrefixHandlers: map[string]http.Handler{
-			"/oauth/token": handler,
+	tests := []struct {
+		name  string
+		cfg   types.Config
+		check func(t *testing.T, tr types.Transport)
+	}{
+		{
+			name: "stdio/authInfoHandler",
+			cfg: types.Config{
+				Type:            types.TransportTypeStdio,
+				Host:            "localhost",
+				ProxyPort:       8080,
+				AuthInfoHandler: sentinel,
+			},
+			check: func(t *testing.T, tr types.Transport) {
+				t.Helper()
+				stdio, ok := tr.(*StdioTransport)
+				require.True(t, ok, "expected *StdioTransport")
+				require.NotNil(t, stdio.authInfoHandler)
+			},
+		},
+		{
+			name: "stdio/prefixHandlers",
+			cfg: types.Config{
+				Type:           types.TransportTypeStdio,
+				Host:           "localhost",
+				ProxyPort:      8080,
+				PrefixHandlers: prefixHandlers,
+			},
+			check: func(t *testing.T, tr types.Transport) {
+				t.Helper()
+				stdio, ok := tr.(*StdioTransport)
+				require.True(t, ok, "expected *StdioTransport")
+				require.Len(t, stdio.prefixHandlers, 1)
+				require.Contains(t, stdio.prefixHandlers, "/oauth/token")
+			},
+		},
+		{
+			name: "sse/authInfoHandler",
+			cfg: types.Config{
+				Type:            types.TransportTypeSSE,
+				Host:            "localhost",
+				ProxyPort:       8080,
+				AuthInfoHandler: sentinel,
+			},
+			check: func(t *testing.T, tr types.Transport) {
+				t.Helper()
+				ht, ok := tr.(*HTTPTransport)
+				require.True(t, ok, "expected *HTTPTransport")
+				require.NotNil(t, ht.authInfoHandler)
+			},
+		},
+		{
+			name: "sse/prefixHandlers",
+			cfg: types.Config{
+				Type:           types.TransportTypeSSE,
+				Host:           "localhost",
+				ProxyPort:      8080,
+				PrefixHandlers: prefixHandlers,
+			},
+			check: func(t *testing.T, tr types.Transport) {
+				t.Helper()
+				ht, ok := tr.(*HTTPTransport)
+				require.True(t, ok, "expected *HTTPTransport")
+				require.Len(t, ht.prefixHandlers, 1)
+				require.Contains(t, ht.prefixHandlers, "/oauth/token")
+			},
+		},
+		{
+			name: "streamable-http/authInfoHandler",
+			cfg: types.Config{
+				Type:            types.TransportTypeStreamableHTTP,
+				Host:            "localhost",
+				ProxyPort:       8080,
+				AuthInfoHandler: sentinel,
+			},
+			check: func(t *testing.T, tr types.Transport) {
+				t.Helper()
+				ht, ok := tr.(*HTTPTransport)
+				require.True(t, ok, "expected *HTTPTransport")
+				require.NotNil(t, ht.authInfoHandler)
+			},
+		},
+		{
+			name: "streamable-http/prefixHandlers",
+			cfg: types.Config{
+				Type:           types.TransportTypeStreamableHTTP,
+				Host:           "localhost",
+				ProxyPort:      8080,
+				PrefixHandlers: prefixHandlers,
+			},
+			check: func(t *testing.T, tr types.Transport) {
+				t.Helper()
+				ht, ok := tr.(*HTTPTransport)
+				require.True(t, ok, "expected *HTTPTransport")
+				require.Len(t, ht.prefixHandlers, 1)
+				require.Contains(t, ht.prefixHandlers, "/oauth/token")
+			},
 		},
 	}
 
-	factory := NewFactory()
-	tr, err := factory.Create(cfg)
-	require.NoError(t, err)
-
-	stdio, ok := tr.(*StdioTransport)
-	require.True(t, ok, "expected *StdioTransport")
-	require.Len(t, stdio.prefixHandlers, 1)
-	require.Contains(t, stdio.prefixHandlers, "/oauth/token")
-}
-
-// TestFactory_Create_SSEPreservesAuthInfoHandler verifies that the factory
-// forwards AuthInfoHandler from Config to the HTTPTransport it creates for SSE.
-func TestFactory_Create_SSEPreservesAuthInfoHandler(t *testing.T) {
-	t.Parallel()
-
-	sentinel := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	})
-
-	cfg := types.Config{
-		Type:            types.TransportTypeSSE,
-		Host:            "localhost",
-		ProxyPort:       8080,
-		AuthInfoHandler: sentinel,
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			factory := NewFactory()
+			tr, err := factory.Create(tt.cfg)
+			require.NoError(t, err)
+			tt.check(t, tr)
+		})
 	}
-
-	factory := NewFactory()
-	tr, err := factory.Create(cfg)
-	require.NoError(t, err)
-
-	ht, ok := tr.(*HTTPTransport)
-	require.True(t, ok, "expected *HTTPTransport")
-	require.NotNil(t, ht.authInfoHandler)
-}
-
-// TestFactory_Create_SSEPreservesPrefixHandlers verifies that the factory
-// forwards PrefixHandlers from Config to the HTTPTransport it creates for SSE.
-func TestFactory_Create_SSEPreservesPrefixHandlers(t *testing.T) {
-	t.Parallel()
-
-	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	})
-
-	cfg := types.Config{
-		Type:      types.TransportTypeSSE,
-		Host:      "localhost",
-		ProxyPort: 8080,
-		PrefixHandlers: map[string]http.Handler{
-			"/oauth/token": handler,
-		},
-	}
-
-	factory := NewFactory()
-	tr, err := factory.Create(cfg)
-	require.NoError(t, err)
-
-	ht, ok := tr.(*HTTPTransport)
-	require.True(t, ok, "expected *HTTPTransport")
-	require.Len(t, ht.prefixHandlers, 1)
-	require.Contains(t, ht.prefixHandlers, "/oauth/token")
-}
-
-// TestFactory_Create_StreamableHTTPPreservesAuthInfoHandler verifies that the factory
-// forwards AuthInfoHandler from Config to the HTTPTransport it creates for StreamableHTTP.
-func TestFactory_Create_StreamableHTTPPreservesAuthInfoHandler(t *testing.T) {
-	t.Parallel()
-
-	sentinel := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	})
-
-	cfg := types.Config{
-		Type:            types.TransportTypeStreamableHTTP,
-		Host:            "localhost",
-		ProxyPort:       8080,
-		AuthInfoHandler: sentinel,
-	}
-
-	factory := NewFactory()
-	tr, err := factory.Create(cfg)
-	require.NoError(t, err)
-
-	ht, ok := tr.(*HTTPTransport)
-	require.True(t, ok, "expected *HTTPTransport")
-	require.NotNil(t, ht.authInfoHandler)
-}
-
-// TestFactory_Create_StreamableHTTPPreservesPrefixHandlers verifies that the factory
-// forwards PrefixHandlers from Config to the HTTPTransport it creates for StreamableHTTP.
-func TestFactory_Create_StreamableHTTPPreservesPrefixHandlers(t *testing.T) {
-	t.Parallel()
-
-	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	})
-
-	cfg := types.Config{
-		Type:      types.TransportTypeStreamableHTTP,
-		Host:      "localhost",
-		ProxyPort: 8080,
-		PrefixHandlers: map[string]http.Handler{
-			"/oauth/token": handler,
-		},
-	}
-
-	factory := NewFactory()
-	tr, err := factory.Create(cfg)
-	require.NoError(t, err)
-
-	ht, ok := tr.(*HTTPTransport)
-	require.True(t, ok, "expected *HTTPTransport")
-	require.Len(t, ht.prefixHandlers, 1)
-	require.Contains(t, ht.prefixHandlers, "/oauth/token")
 }

--- a/pkg/transport/stdio_test.go
+++ b/pkg/transport/stdio_test.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"sync"
 	"testing"
 	"time"
@@ -21,6 +22,7 @@ import (
 
 	rt "github.com/stacklok/toolhive/pkg/container/runtime"
 	"github.com/stacklok/toolhive/pkg/container/runtime/mocks"
+	"github.com/stacklok/toolhive/pkg/transport/types"
 )
 
 // MockHTTPProxy is a mock implementation of types.Proxy
@@ -1035,4 +1037,197 @@ func TestStdioTransport_ShouldRestart(t *testing.T) {
 			assert.Equal(t, tt.expectedResult, result)
 		})
 	}
+}
+
+// TestNewStdioTransport_PreservesAuthInfoHandler verifies that SetAuthInfoHandler
+// stores the handler on the struct (no networking required).
+func TestNewStdioTransport_PreservesAuthInfoHandler(t *testing.T) {
+	t.Parallel()
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	tr := NewStdioTransport("localhost", 8080, nil, false, false, nil)
+	tr.SetAuthInfoHandler(handler)
+
+	// authInfoHandler is unexported but accessible within the same package.
+	require.NotNil(t, tr.authInfoHandler)
+}
+
+// TestNewStdioTransport_PreservesPrefixHandlers verifies that SetPrefixHandlers
+// stores the map on the struct (no networking required).
+func TestNewStdioTransport_PreservesPrefixHandlers(t *testing.T) {
+	t.Parallel()
+
+	handlers := map[string]http.Handler{
+		"/oauth/token": http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}),
+	}
+
+	tr := NewStdioTransport("localhost", 8080, nil, false, false, nil)
+	tr.SetPrefixHandlers(handlers)
+
+	require.Len(t, tr.prefixHandlers, 1)
+	require.Contains(t, tr.prefixHandlers, "/oauth/token")
+}
+
+// TestFactory_Create_StdioPreservesAuthInfoHandler verifies that the factory
+// forwards AuthInfoHandler from Config to the StdioTransport it creates.
+func TestFactory_Create_StdioPreservesAuthInfoHandler(t *testing.T) {
+	t.Parallel()
+
+	sentinel := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	cfg := types.Config{
+		Type:            types.TransportTypeStdio,
+		Host:            "localhost",
+		ProxyPort:       8080,
+		AuthInfoHandler: sentinel,
+	}
+
+	factory := NewFactory()
+	tr, err := factory.Create(cfg)
+	require.NoError(t, err)
+
+	stdio, ok := tr.(*StdioTransport)
+	require.True(t, ok, "expected *StdioTransport")
+	require.NotNil(t, stdio.authInfoHandler)
+}
+
+// TestFactory_Create_StdioPreservesPrefixHandlers verifies that the factory
+// forwards PrefixHandlers from Config to the StdioTransport it creates.
+func TestFactory_Create_StdioPreservesPrefixHandlers(t *testing.T) {
+	t.Parallel()
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	cfg := types.Config{
+		Type:      types.TransportTypeStdio,
+		Host:      "localhost",
+		ProxyPort: 8080,
+		PrefixHandlers: map[string]http.Handler{
+			"/oauth/token": handler,
+		},
+	}
+
+	factory := NewFactory()
+	tr, err := factory.Create(cfg)
+	require.NoError(t, err)
+
+	stdio, ok := tr.(*StdioTransport)
+	require.True(t, ok, "expected *StdioTransport")
+	require.Len(t, stdio.prefixHandlers, 1)
+	require.Contains(t, stdio.prefixHandlers, "/oauth/token")
+}
+
+// TestFactory_Create_SSEPreservesAuthInfoHandler verifies that the factory
+// forwards AuthInfoHandler from Config to the HTTPTransport it creates for SSE.
+func TestFactory_Create_SSEPreservesAuthInfoHandler(t *testing.T) {
+	t.Parallel()
+
+	sentinel := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	cfg := types.Config{
+		Type:            types.TransportTypeSSE,
+		Host:            "localhost",
+		ProxyPort:       8080,
+		AuthInfoHandler: sentinel,
+	}
+
+	factory := NewFactory()
+	tr, err := factory.Create(cfg)
+	require.NoError(t, err)
+
+	ht, ok := tr.(*HTTPTransport)
+	require.True(t, ok, "expected *HTTPTransport")
+	require.NotNil(t, ht.authInfoHandler)
+}
+
+// TestFactory_Create_SSEPreservesPrefixHandlers verifies that the factory
+// forwards PrefixHandlers from Config to the HTTPTransport it creates for SSE.
+func TestFactory_Create_SSEPreservesPrefixHandlers(t *testing.T) {
+	t.Parallel()
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	cfg := types.Config{
+		Type:      types.TransportTypeSSE,
+		Host:      "localhost",
+		ProxyPort: 8080,
+		PrefixHandlers: map[string]http.Handler{
+			"/oauth/token": handler,
+		},
+	}
+
+	factory := NewFactory()
+	tr, err := factory.Create(cfg)
+	require.NoError(t, err)
+
+	ht, ok := tr.(*HTTPTransport)
+	require.True(t, ok, "expected *HTTPTransport")
+	require.Len(t, ht.prefixHandlers, 1)
+	require.Contains(t, ht.prefixHandlers, "/oauth/token")
+}
+
+// TestFactory_Create_StreamableHTTPPreservesAuthInfoHandler verifies that the factory
+// forwards AuthInfoHandler from Config to the HTTPTransport it creates for StreamableHTTP.
+func TestFactory_Create_StreamableHTTPPreservesAuthInfoHandler(t *testing.T) {
+	t.Parallel()
+
+	sentinel := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	cfg := types.Config{
+		Type:            types.TransportTypeStreamableHTTP,
+		Host:            "localhost",
+		ProxyPort:       8080,
+		AuthInfoHandler: sentinel,
+	}
+
+	factory := NewFactory()
+	tr, err := factory.Create(cfg)
+	require.NoError(t, err)
+
+	ht, ok := tr.(*HTTPTransport)
+	require.True(t, ok, "expected *HTTPTransport")
+	require.NotNil(t, ht.authInfoHandler)
+}
+
+// TestFactory_Create_StreamableHTTPPreservesPrefixHandlers verifies that the factory
+// forwards PrefixHandlers from Config to the HTTPTransport it creates for StreamableHTTP.
+func TestFactory_Create_StreamableHTTPPreservesPrefixHandlers(t *testing.T) {
+	t.Parallel()
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	cfg := types.Config{
+		Type:      types.TransportTypeStreamableHTTP,
+		Host:      "localhost",
+		ProxyPort: 8080,
+		PrefixHandlers: map[string]http.Handler{
+			"/oauth/token": handler,
+		},
+	}
+
+	factory := NewFactory()
+	tr, err := factory.Create(cfg)
+	require.NoError(t, err)
+
+	ht, ok := tr.(*HTTPTransport)
+	require.True(t, ok, "expected *HTTPTransport")
+	require.Len(t, ht.prefixHandlers, 1)
+	require.Contains(t, ht.prefixHandlers, "/oauth/token")
 }


### PR DESCRIPTION
## Summary

Before this change, `transport.Factory.Create` never passed `authInfoHandler` or `prefixHandlers` to `StdioTransport`. For any stdio-backed `MCPServer` with an embedded auth server (`spec.authServerRef`), every OAuth/OIDC discovery endpoint returned 404 — the RFC 9728 protected-resource document, the RFC 8414 authorization server metadata, the OIDC discovery document, and the JWKS endpoint were all unreachable. MCP clients that follow the OAuth discovery chain could not bootstrap auth against stdio-backed servers.

- Add `authInfoHandler` and `prefixHandlers` fields to `StdioTransport`; forward both to the underlying streamable/SSE proxy in `Start()`
- Add the same two fields and matching functional options to `HTTPSSEProxy` (`pkg/transport/proxy/httpsse/http_proxy.go`) and `HTTPProxy` (`pkg/transport/proxy/streamable/streamable_proxy.go`)
- Mount `/.well-known/` in both proxy backends so OAuth clients always get JSON rather than Go's plain-text 404 when auth is off
- Wire both fields through `factory.Create` for the stdio case (SSE and streamable-HTTP were already wired on main; this PR adds the 6-line stdio path)
- Add factory-level tests for SSE and streamable-HTTP confirming `authInfoHandler` and `prefixHandlers` survive the `Create` call

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)
- [x] Manual testing (describe below)

Deployed a stdio-backed `MCPServer` (`transport: stdio`, `proxyMode: streamable-http`) with `spec.authServerRef` pointing to an embedded auth server backed by Okta in a kind cluster. Port-forwarded the proxy service and verified all four endpoints return HTTP 200 with valid JSON:

| Endpoint | Result |
|---|---|
| `/.well-known/oauth-protected-resource` | ✅ 200 — `resource` + `authorization_servers` fields present |
| `/.well-known/oauth-authorization-server` | ✅ 200 — full RFC 8414 document |
| `/.well-known/openid-configuration` | ✅ 200 — full OIDC discovery document |
| `/.well-known/jwks.json` | ✅ 200 — EC P-256 signing key |

## Changes

| File | Change |
|------|--------|
| `pkg/transport/stdio.go` | Add `authInfoHandler`/`prefixHandlers` fields and setters; forward to proxy in `Start()` |
| `pkg/transport/factory.go` | Wire both fields from `Config` into `StdioTransport` (the stdio-only path) |
| `pkg/transport/proxy/httpsse/http_proxy.go` | Add `authInfoHandler`/`prefixHandlers` fields + `WithAuthInfoHandler`/`WithPrefixHandlers` options; mount `/.well-known/` in `Start()` |
| `pkg/transport/proxy/streamable/streamable_proxy.go` | Same as httpsse |
| `pkg/transport/stdio_test.go` | Factory tests for SSE and streamable-HTTP preserving both fields |
| `pkg/transport/proxy/httpsse/http_proxy_integration_test.go` | Add `TestHTTPSSEProxy_StartMountsAuthDiscoveryEndpoint` |
| `pkg/transport/proxy/streamable/streamable_proxy_integration_test.go` | Integration test for streamable proxy auth discovery endpoint |
| `pkg/transport/proxy/streamable/streamable_proxy_test.go` | Unit tests for streamable proxy options |

## Does this introduce a user-facing change?

Yes. For `MCPServer` resources using `transport: stdio` with `spec.authServerRef`, the OAuth/OIDC discovery endpoints (`/.well-known/oauth-protected-resource`, `/.well-known/oauth-authorization-server`, `/.well-known/openid-configuration`, `/.well-known/jwks.json`) now return correct responses instead of 404. MCP clients that follow RFC 9728 discovery can now bootstrap OAuth against stdio-backed servers.

Generated with [Claude Code](https://claude.com/claude-code)