### PR TITLE
Cover Serve-path authz and annotation-enrichment omission

### DIFF
--- a/pkg/vmcp/core/admission.go
+++ b/pkg/vmcp/core/admission.go
@@ -174,8 +174,8 @@ func (a *cedarAdmission) FilterTools(
 // the tool's annotations for when-clause evaluation. It authorizes the tool named in
 // `tool.Name` — there is no optimizer meta-tool special-casing here (see the
 // [Admission] doc): the optimizer's call_tool inner-target authorization is deferred
-// to a dedicated optimizer-admission PR, and the (Authz + optimizer) fail-fast (#5442)
-// keeps that combination from reaching this seam in the meantime.
+// to a dedicated optimizer-admission PR; the (Authz + optimizer) fail-fast that keeps that
+// combination from reaching this seam lands with the core-enforcement switch in #5442.
 func (a *cedarAdmission) AllowToolCall(
 	ctx context.Context, identity *auth.Identity, tool *vmcp.Tool, args map[string]any,
 ) (bool, error) {

--- a/pkg/vmcp/core/admission.go
+++ b/pkg/vmcp/core/admission.go
@@ -30,9 +30,11 @@ import (
 // The optimizer-admission integration the HTTP path performs today — call_tool
 // inner-target authorization, find_tool response filtering, and inner-target
 // annotation sourcing — is deliberately NOT in this seam; it is deferred to its own
-// focused PR. Until then the optimizer keeps the HTTP middleware, and #5441's
-// composition root fails fast (vmcp.ErrInvalidConfig) when Authz is set together
-// with the optimizer, so the combination can never silently route through this seam.
+// focused PR. Until then the optimizer keeps the HTTP middleware, and the composition
+// root that wires core.New must fail fast (vmcp.ErrInvalidConfig) when Authz is set
+// together with the optimizer, so the combination can never silently route through this
+// seam. That fail-fast lands with the core-enforcement switch in #5442 (#5441 keeps the
+// legacy server.New path, which retains the HTTP authz middleware).
 type Admission interface {
 	// FilterTools returns the subset of tools the identity may call. Mirrors
 	// pkg/authz filterToolsByPolicy: a per-tool AuthorizeWithJWTClaims(call) using
@@ -60,8 +62,8 @@ type Admission interface {
 // A non-nil authzCfg with zero policies is NOT treated as allow-all here: it falls
 // through to CreateAuthorizer, which returns ErrNoPolicies, so the core fails
 // CLOSED. This is a deliberate divergence from the live HTTP path, which allows-all
-// for the same input. Fail-closed is the safer default; #5441 reconciles the two
-// when it collapses the construction paths into one shared constructor.
+// for the same input. Fail-closed is the safer default; Phase 3 (#5445) reconciles the
+// two when it collapses the construction paths into one shared constructor.
 //
 // When authzCfg is set, the authorizer is built via the same registry path the
 // HTTP middleware uses (authorizers.GetFactory + CreateAuthorizer, the construction
@@ -73,7 +75,7 @@ type Admission interface {
 // defaulting an empty EntitiesJSON to "[]") belongs to whoever builds authzCfg, not
 // to this generic factory path, which consumes RawConfig as-is. newCedarAuthzMiddleware
 // is the sibling construction path; the two must stay in lockstep (notably the
-// empty-serverName check below) until #5441 collapses them.
+// empty-serverName check below) until Phase 3 (#5445) collapses them.
 func newAdmission(authzCfg *authorizers.Config, serverName string) (Admission, error) {
 	if authzCfg == nil {
 		return allowAllAdmission{}, nil
@@ -172,8 +174,8 @@ func (a *cedarAdmission) FilterTools(
 // the tool's annotations for when-clause evaluation. It authorizes the tool named in
 // `tool.Name` — there is no optimizer meta-tool special-casing here (see the
 // [Admission] doc): the optimizer's call_tool inner-target authorization is deferred
-// to a dedicated optimizer-admission PR, and #5441 fails fast on (Authz + optimizer)
-// so that combination never reaches this seam in the meantime.
+// to a dedicated optimizer-admission PR, and the (Authz + optimizer) fail-fast (#5442)
+// keeps that combination from reaching this seam in the meantime.
 func (a *cedarAdmission) AllowToolCall(
 	ctx context.Context, identity *auth.Identity, tool *vmcp.Tool, args map[string]any,
 ) (bool, error) {
@@ -295,8 +297,8 @@ func (allowAllAdmission) AllowPromptGet(_ context.Context, _ *auth.Identity, _ *
 // than reusing it: that copy lives in package server, which imports this core
 // package, so importing it here would create a cycle (server -> core). Like the
 // filterHealthyBackends C2 duplication in this package, it is intentional and
-// temporary — #5441 retires the server-side middleware (and its copy) on the domain
-// path. Keep the two in sync until then.
+// temporary — Phase 3 (#5445) retires the server-side middleware (and its copy) on the
+// domain path. Keep the two in sync until then.
 func convertAnnotations(ann *vmcp.ToolAnnotations) *authorizers.ToolAnnotations {
 	if ann == nil {
 		return nil

--- a/pkg/vmcp/server/annotation_enrichment.go
+++ b/pkg/vmcp/server/annotation_enrichment.go
@@ -92,7 +92,9 @@ func findToolAnnotations(toolName string, caps *aggregator.AggregatedCapabilitie
 //
 // Kept identical to core.convertAnnotations (pkg/vmcp/core/admission.go), including
 // the nil guard below — the two are intentional, temporary duplicates (the core
-// cannot import this package: server imports core) and #5441 deletes this copy.
+// cannot import this package: server imports core). #5441 makes this middleware inert
+// on the Serve path via the AuthzMiddleware nil-guard; physical removal of this copy
+// is deferred to Phase 3 (#5445).
 func convertAnnotations(ann *vmcp.ToolAnnotations) *authorizers.ToolAnnotations {
 	if ann == nil {
 		return nil

--- a/pkg/vmcp/server/annotation_enrichment.go
+++ b/pkg/vmcp/server/annotation_enrichment.go
@@ -94,7 +94,9 @@ func findToolAnnotations(toolName string, caps *aggregator.AggregatedCapabilitie
 // the nil guard below — the two are intentional, temporary duplicates (the core
 // cannot import this package: server imports core). #5441 makes this middleware inert
 // on the Serve path via the AuthzMiddleware nil-guard; physical removal of this copy
-// is deferred to Phase 3 (#5445).
+// is deferred to Phase 3 (#5445). Do NOT delete it early on the import-cycle reasoning
+// alone: the core admission seam (#5438) reuses the conversion logic, so this copy must
+// stay in lockstep with core.convertAnnotations until the middleware itself is retired.
 func convertAnnotations(ann *vmcp.ToolAnnotations) *authorizers.ToolAnnotations {
 	if ann == nil {
 		return nil

--- a/pkg/vmcp/server/serve.go
+++ b/pkg/vmcp/server/serve.go
@@ -144,12 +144,14 @@ type ServerConfig struct {
 // .well-known endpoints, and any embedded auth-server routes) when Serve's *Server
 // is served.
 //
-// The remaining transport concerns — the authenticated middleware chain (#5441), the
-// direct VMCP request path (#5442), and the AS runner / status reporter / optimizer /
-// health monitor lifecycle (#5443) — are relocated under Serve by the subsequent
-// Phase 2 tasks. server.New is not yet routed through Serve and keeps its own copy of
-// the session wiring until Phase 3, so this is purely additive and observable behavior
-// is unchanged.
+// The authenticated middleware chain is produced by the shared (*Server).Handler that
+// the Serve-built *Server already uses, with the authz and annotation-enrichment layers
+// guarded off via a nil AuthzMiddleware (#5441); authorization moves to the core
+// admission seam (#5438). The remaining transport concerns — the direct VMCP request
+// path (#5442) and the AS runner / status reporter / optimizer / health monitor
+// lifecycle (#5443) — are relocated under Serve by the subsequent Phase 2 tasks.
+// server.New is not yet routed through Serve and keeps its own copy of the session
+// wiring until Phase 3, so this is purely additive and observable behavior is unchanged.
 //
 // Serve returns a vmcp.ErrInvalidConfig-wrapped error for a nil cfg, a nil core, or a
 // nil required collaborator (SessionManagerConfig or BackendRegistry). The session
@@ -158,10 +160,9 @@ type ServerConfig struct {
 //
 // Contract: the returned *Server now has a live session manager and backend registry,
 // but a nil discovery manager, router, and backend client at this phase. It must NOT
-// be Start()ed or served on the "/" MCP route until #5441/#5442 wire those fields —
-// the carried-forward Handler passes them to discovery.Middleware, which would
-// nil-deref. The unauthenticated routes (registered as direct mux entries) are safe
-// to serve.
+// be Start()ed or served on the "/" MCP route until #5442 wires those fields — the
+// carried-forward Handler passes them to discovery.Middleware, which would nil-deref.
+// The unauthenticated routes (registered as direct mux entries) are safe to serve.
 func Serve(ctx context.Context, v core.VMCP, cfg *ServerConfig) (*Server, error) {
 	if cfg == nil {
 		return nil, fmt.Errorf("%w: nil server config", vmcp.ErrInvalidConfig)
@@ -277,8 +278,10 @@ func Serve(ctx context.Context, v core.VMCP, cfg *ServerConfig) (*Server, error)
 //
 // Several Config fields are deliberately NOT mapped at this phase (see
 // TestBuildServeConfigMapsSharedFields, which guards this list against drift):
-//   - AuthzMiddleware: the authenticated/authz middleware chain is relocated under
-//     Serve by #5441, after which authorization moves to the core admission seam.
+//   - AuthzMiddleware: intentionally left nil on the Serve path. The shared
+//     (*Server).Handler omits both the authz and annotation-enrichment blocks when
+//     AuthzMiddleware is nil; authorization moves to the core admission seam (#5438).
+//     The inert blocks stay in the shared Handler until Phase 3 (#5445) removes them.
 //   - HealthMonitorConfig: Serve receives the already-built *health.Monitor via
 //     ServerConfig.HealthMonitor (A2) and assigns it to the Server directly, so it
 //     never needs the monitor's construction config.

--- a/pkg/vmcp/server/serve_session_test.go
+++ b/pkg/vmcp/server/serve_session_test.go
@@ -33,7 +33,7 @@ import (
 // These tests exercise the session-creation wiring and SDK hooks relocated into
 // Serve (#5440). They drive the SDK session lifecycle through the relocated
 // vmcpSessionMgr + mcpServer directly, mounting the Streamable HTTP server WITHOUT
-// the authenticated discovery middleware (relocated by #5441/#5442). That keeps the
+// the authenticated discovery middleware (relocated by #5442). That keeps the
 // test within this task's scope while proving the hooks fire and two-phase session
 // creation runs identically when Serve is exercised directly. The full HTTP suite
 // stays on server.New (its parity gate) in session_management_integration_test.go.
@@ -110,7 +110,7 @@ func TestServeRegistersSessionHooks(t *testing.T) {
 	t.Cleanup(func() { _ = srv.Stop(context.Background()) })
 
 	// Mount the Streamable HTTP server on the relocated mcpServer + vmcpSessionMgr,
-	// bypassing the not-yet-relocated discovery middleware (#5441/#5442).
+	// bypassing the not-yet-relocated discovery middleware (#5442).
 	streamable := server.NewStreamableHTTPServer(
 		srv.mcpServer,
 		server.WithEndpointPath("/mcp"),

--- a/pkg/vmcp/server/serve_test.go
+++ b/pkg/vmcp/server/serve_test.go
@@ -194,6 +194,32 @@ func TestServeHandlerRegistersUnauthenticatedRoutes(t *testing.T) {
 	assert.NotEqual(t, http.StatusOK, rec.Code)
 }
 
+// TestServeOmitsAuthzAndAnnotation proves the Serve path produces the MCP middleware
+// chain WITHOUT the authz and annotation-enrichment layers. The mechanism is the shared
+// (*Server).Handler guard `s.config.AuthzMiddleware != nil`: Serve leaves AuthzMiddleware
+// nil (buildServeConfig does not map it — see TestBuildServeConfigMapsSharedFields), so
+// both the authz block (server.go:614) and the AnnotationEnrichmentMiddleware block
+// (:622) are skipped on the Serve path. Authorization instead runs through the core
+// admission seam (#5438). The blocks are NOT deleted here — they stay in the shared
+// Handler so the still-live server.New path keeps enforcing authz; physical removal is
+// Phase 3 (#5445). The companion TestHandlerAppliesAuthzAndAnnotationOnlyWhenConfigured
+// proves the same shared Handler DOES apply both layers when AuthzMiddleware is non-nil.
+func TestServeOmitsAuthzAndAnnotation(t *testing.T) {
+	t.Parallel()
+
+	srv, err := Serve(context.Background(), &stubVMCP{}, testMinimalServeConfig())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = srv.Stop(context.Background()) })
+
+	assert.Nil(t, srv.config.AuthzMiddleware,
+		"Serve must leave AuthzMiddleware nil so the shared Handler omits authz + annotation-enrichment")
+
+	// The Serve path still produces the rest of the chain: Handler builds without error.
+	handler, err := srv.Handler(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, handler)
+}
+
 func TestServeHandlerRegistersMetricsWhenTelemetryEnabled(t *testing.T) {
 	t.Parallel()
 
@@ -300,7 +326,7 @@ func TestBuildServeConfigMapsSharedFields(t *testing.T) {
 	t.Parallel()
 
 	intentionallyUnmapped := map[string]struct{}{
-		"AuthzMiddleware":     {}, // authenticated/authz chain relocated by #5441
+		"AuthzMiddleware":     {}, // intentionally nil on Serve path; authz moves to core admission seam (#5438), shared Handler skips it
 		"HealthMonitorConfig": {}, // monitor injected pre-built via ServerConfig.HealthMonitor (A2)
 		"StatusReporter":      {}, // set directly on Server; Config.StatusReporter only read by New
 		"SessionFactory":      {}, // session manager built in Serve from ServerConfig.SessionManagerConfig

--- a/pkg/vmcp/server/serve_test.go
+++ b/pkg/vmcp/server/serve_test.go
@@ -198,8 +198,8 @@ func TestServeHandlerRegistersUnauthenticatedRoutes(t *testing.T) {
 // chain WITHOUT the authz and annotation-enrichment layers. The mechanism is the shared
 // (*Server).Handler guard `s.config.AuthzMiddleware != nil`: Serve leaves AuthzMiddleware
 // nil (buildServeConfig does not map it — see TestBuildServeConfigMapsSharedFields), so
-// both the authz block (server.go:614) and the AnnotationEnrichmentMiddleware block
-// (:622) are skipped on the Serve path. Authorization instead runs through the core
+// both the authz block and the AnnotationEnrichmentMiddleware block — each gated on that
+// guard in Handler — are skipped on the Serve path. Authorization instead runs through the core
 // admission seam (#5438). The blocks are NOT deleted here — they stay in the shared
 // Handler so the still-live server.New path keeps enforcing authz; physical removal is
 // Phase 3 (#5445). The companion TestHandlerAppliesAuthzAndAnnotationOnlyWhenConfigured

--- a/pkg/vmcp/server/server.go
+++ b/pkg/vmcp/server/server.go
@@ -585,6 +585,13 @@ func (s *Server) Handler(_ context.Context) (http.Handler, error) {
 	// Execution order: recovery → header-val → auth+parser → audit →
 	//   discovery → annotation-enrichment → authz → backend-enrichment →
 	//   MCP-parsing → telemetry → handler
+	//
+	// The authz and annotation-enrichment layers are both guarded by
+	// s.config.AuthzMiddleware != nil: applied on the server.New path (authz on) and
+	// omitted on the Serve path, which leaves AuthzMiddleware nil so authorization
+	// moves to the core admission seam (#5438). Both blocks remain in this shared
+	// Handler — physical removal is deferred to Phase 3 (#5445), after server.New is
+	// routed through Serve and the legacy authz path is gone.
 
 	var mcpHandler http.Handler = streamableServer
 

--- a/pkg/vmcp/server/server_test.go
+++ b/pkg/vmcp/server/server_test.go
@@ -17,7 +17,11 @@ import (
 	"go.uber.org/mock/gomock"
 
 	"github.com/stacklok/toolhive/pkg/audit"
+	"github.com/stacklok/toolhive/pkg/authz/authorizers"
+	mcpparser "github.com/stacklok/toolhive/pkg/mcp"
 	"github.com/stacklok/toolhive/pkg/vmcp"
+	"github.com/stacklok/toolhive/pkg/vmcp/aggregator"
+	"github.com/stacklok/toolhive/pkg/vmcp/discovery"
 	discoveryMocks "github.com/stacklok/toolhive/pkg/vmcp/discovery/mocks"
 	"github.com/stacklok/toolhive/pkg/vmcp/mocks"
 	"github.com/stacklok/toolhive/pkg/vmcp/optimizer"
@@ -781,6 +785,125 @@ func TestAcceptHeaderValidation(t *testing.T) {
 
 				assert.NotEqual(t, http.StatusNotAcceptable, rec.Code,
 					"expected request to pass Accept validation but got 406")
+			}
+		})
+	}
+}
+
+// TestHandlerAppliesAuthzAndAnnotationOnlyWhenConfigured proves the shared
+// (*Server).Handler applies BOTH the authz layer and the annotation-enrichment layer
+// exactly when config.AuthzMiddleware != nil. This is the single guard that lets the
+// same Handler serve both modes: the server.New path (AuthzMiddleware set) keeps
+// enforcing authz with no regression, while the Serve path (AuthzMiddleware nil; see
+// TestServeOmitsAuthzAndAnnotation) omits both layers and defers authorization to the
+// core admission seam (#5438). The blocks are not deleted here — physical removal is
+// Phase 3 (#5445).
+func TestHandlerAppliesAuthzAndAnnotationOnlyWhenConfigured(t *testing.T) {
+	t.Parallel()
+
+	// Distinctive status only the observable authz layer writes, so its presence in the
+	// chain is unambiguous.
+	const sentinelStatus = http.StatusTeapot
+
+	readOnly := true
+	caps := &aggregator.AggregatedCapabilities{
+		Tools: []vmcp.Tool{{
+			Name:        "my_tool",
+			Annotations: &vmcp.ToolAnnotations{ReadOnlyHint: &readOnly},
+		}},
+	}
+
+	tests := []struct {
+		name             string
+		withAuthz        bool
+		wantAuthzApplied bool
+	}{
+		{name: "applied when AuthzMiddleware set (server.New path)", withAuthz: true, wantAuthzApplied: true},
+		{name: "omitted when AuthzMiddleware nil (Serve path)", withAuthz: false, wantAuthzApplied: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctrl := gomock.NewController(t)
+			t.Cleanup(ctrl.Finish)
+			mockRouter := routerMocks.NewMockRouter(ctrl)
+			mockBackendClient := mocks.NewMockBackendClient(ctrl)
+			mockDiscoveryMgr := discoveryMocks.NewMockManager(ctrl)
+			mockBackendRegistry := mocks.NewMockBackendRegistry(ctrl)
+			mockBackendRegistry.EXPECT().List(gomock.Any()).Return(nil).AnyTimes()
+			mockDiscoveryMgr.EXPECT().Discover(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+			mockDiscoveryMgr.EXPECT().Stop().AnyTimes()
+
+			var (
+				authzApplied    bool
+				annotationsSeen bool
+			)
+			// Observable authz layer: records that it ran AND whether the
+			// annotation-enrichment layer (which executes immediately before it) injected
+			// the tool's annotations into ctx, then short-circuits with the sentinel.
+			authz := func(_ http.Handler) http.Handler {
+				return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					authzApplied = true
+					annotationsSeen = authorizers.ToolAnnotationsFromContext(r.Context()) != nil
+					w.WriteHeader(sentinelStatus)
+				})
+			}
+
+			cfg := &server.Config{Host: "127.0.0.1", Port: 0, SessionFactory: newNoopMockFactory(t)}
+			if tt.withAuthz {
+				cfg.AuthzMiddleware = authz
+			}
+
+			srv, err := server.New(t.Context(), cfg, mockRouter, mockBackendClient, mockDiscoveryMgr, mockBackendRegistry, nil)
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = srv.Stop(context.Background()) })
+
+			handler, err := srv.Handler(t.Context())
+			require.NoError(t, err)
+
+			// Craft a tools/call request. This chain has no auth-parser, so inject the
+			// parsed request and discovered capabilities directly into ctx (as
+			// ParsingMiddleware and the discovery middleware would). With no Mcp-Session-Id
+			// and session-scoped routing, the discovery layer passes through without using
+			// the manager, preserving the injected ctx for annotation-enrichment.
+			ctx := context.WithValue(t.Context(), mcpparser.MCPRequestContextKey,
+				&mcpparser.ParsedMCPRequest{Method: "tools/call", ResourceID: "my_tool"})
+			ctx = discovery.WithDiscoveredCapabilities(ctx, caps)
+			reqCtx, reqCancel := context.WithCancel(ctx)
+			t.Cleanup(reqCancel)
+
+			req := httptest.NewRequest(http.MethodPost, "/mcp", nil).WithContext(reqCtx)
+			rec := httptest.NewRecorder()
+
+			// The observable authz layer short-circuits; without it the request falls
+			// through to the inner SDK handler, so run in a goroutine and cancel after the
+			// short-circuit window. rec/markers are read only after the goroutine returns.
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				handler.ServeHTTP(rec, req)
+			}()
+			select {
+			case <-done:
+			case <-time.After(200 * time.Millisecond):
+				reqCancel()
+				select {
+				case <-done:
+				case <-time.After(2 * time.Second):
+					t.Fatal("handler goroutine did not return after context cancellation")
+				}
+			}
+
+			assert.Equal(t, tt.wantAuthzApplied, authzApplied)
+			if tt.wantAuthzApplied {
+				assert.Equal(t, sentinelStatus, rec.Code, "observable authz layer should have written the sentinel status")
+				assert.True(t, annotationsSeen,
+					"annotation-enrichment must run before authz and inject the tool annotations")
+			} else {
+				assert.NotEqual(t, sentinelStatus, rec.Code,
+					"no authz layer should run on the Serve-style (nil AuthzMiddleware) path")
 			}
 		})
 	}

--- a/pkg/vmcp/server/server_test.go
+++ b/pkg/vmcp/server/server_test.go
@@ -832,6 +832,9 @@ func TestHandlerAppliesAuthzAndAnnotationOnlyWhenConfigured(t *testing.T) {
 			mockBackendClient := mocks.NewMockBackendClient(ctrl)
 			mockDiscoveryMgr := discoveryMocks.NewMockManager(ctrl)
 			mockBackendRegistry := mocks.NewMockBackendRegistry(ctrl)
+			// List/Discover stay permissive (AnyTimes) but do not fire on this path: with
+			// WithSessionScopedRouting() and no Mcp-Session-Id, discovery.Middleware returns
+			// before aggregating. Stop fires via srv.Stop in the cleanup below.
 			mockBackendRegistry.EXPECT().List(gomock.Any()).Return(nil).AnyTimes()
 			mockDiscoveryMgr.EXPECT().Discover(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 			mockDiscoveryMgr.EXPECT().Stop().AnyTimes()
@@ -865,36 +868,30 @@ func TestHandlerAppliesAuthzAndAnnotationOnlyWhenConfigured(t *testing.T) {
 
 			// Craft a tools/call request. This chain has no auth-parser, so inject the
 			// parsed request and discovered capabilities directly into ctx (as
-			// ParsingMiddleware and the discovery middleware would). With no Mcp-Session-Id
-			// and session-scoped routing, the discovery layer passes through without using
-			// the manager, preserving the injected ctx for annotation-enrichment.
+			// ParsingMiddleware and the discovery middleware would).
+			//
+			// Load-bearing dependency: discovery.Middleware is built with
+			// WithSessionScopedRouting(), so a request with no Mcp-Session-Id passes straight
+			// through without touching the (mock) manager and WITHOUT rewriting ctx —
+			// preserving the injected capabilities for the annotation-enrichment layer. If
+			// that session-scoped pass-through ever changes to overwrite ctx, annotationsSeen
+			// silently goes false; the positive-case assert.True below is the guard.
 			ctx := context.WithValue(t.Context(), mcpparser.MCPRequestContextKey,
 				&mcpparser.ParsedMCPRequest{Method: "tools/call", ResourceID: "my_tool"})
 			ctx = discovery.WithDiscoveredCapabilities(ctx, caps)
-			reqCtx, reqCancel := context.WithCancel(ctx)
-			t.Cleanup(reqCancel)
 
-			req := httptest.NewRequest(http.MethodPost, "/mcp", nil).WithContext(reqCtx)
+			req := httptest.NewRequest(http.MethodPost, "/mcp", nil).WithContext(ctx)
+			// Set Content-Type so the nil-authz request reaches a representative chain point
+			// (the inner SDK handler) rather than being rejected during content negotiation;
+			// both cases then exercise the chain identically.
+			req.Header.Set("Content-Type", "application/json")
 			rec := httptest.NewRecorder()
 
-			// The observable authz layer short-circuits; without it the request falls
-			// through to the inner SDK handler, so run in a goroutine and cancel after the
-			// short-circuit window. rec/markers are read only after the goroutine returns.
-			done := make(chan struct{})
-			go func() {
-				defer close(done)
-				handler.ServeHTTP(rec, req)
-			}()
-			select {
-			case <-done:
-			case <-time.After(200 * time.Millisecond):
-				reqCancel()
-				select {
-				case <-done:
-				case <-time.After(2 * time.Second):
-					t.Fatal("handler goroutine did not return after context cancellation")
-				}
-			}
+			// Both paths return synchronously: the configured case short-circuits at the
+			// observable authz layer (sentinel), and the nil case falls through to the inner
+			// SDK handler, which answers this POST without blocking. A direct call suffices —
+			// no goroutine/timeout scaffolding needed.
+			handler.ServeHTTP(rec, req)
 
 			assert.Equal(t, tt.wantAuthzApplied, authzApplied)
 			if tt.wantAuthzApplied {


### PR DESCRIPTION
## Summary

Part of the vMCP core refactor (epic #5419, parent story #5431; blocks #5442). This is
P2.3.

The `Serve`-built `*Server` must produce the MCP middleware chain **without** the HTTP
authz and annotation-enrichment layers — authorization is moving to the core admission
seam (#5438) — while the still-live `server.New` path must keep enforcing authz with no
regression. The nil-guard that makes this possible already exists from dependency #5439:
`Serve` leaves `cfg.AuthzMiddleware` nil (`buildServeConfig` does not map it), so the two
`s.config.AuthzMiddleware != nil` guards in the **shared** `(*Server).Handler` skip both
the authz block and the annotation-enrichment block on the `Serve` path, while the
`server.New` path (which still sets `AuthzMiddleware`) continues to run both.

Because the mechanism already exists, the production-code delta here is
comment-synchronization only; the substance of this PR is two new tests that lock in the
behavior and prove the single shared `Handler` correctly serves both modes.

- **Why:** Lock in and document that the `Serve` path omits HTTP authz/annotation via the
  existing nil-guard, without opening an authz-regression window on the still-live
  `server.New` path. Per the issue's "guard, don't delete (yet)" strategy, the blocks stay
  in the shared `Handler`; physical removal is deferred to Phase 3 (#5445).
- **What:** Added two tests covering both sides of the guard, and synchronized stale
  forward-reference comments left behind by earlier phases.

Closes #5441

## Type of change

- [x] Refactoring (no behavior change)

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)

`pkg/vmcp/server` and `pkg/vmcp/core` pass with `-race`. `task lint-fix` is clean (only a
pre-existing, unrelated gosec G115 finding in `cmd/thv/app/upgrade.go` remains, untouched
by this PR).

## Changes

| File | Change |
|------|--------|
| `pkg/vmcp/server/server_test.go` | New `TestHandlerAppliesAuthzAndAnnotationOnlyWhenConfigured`: drives the shared `Handler` with `AuthzMiddleware` set vs. nil and observes that both authz and annotation-enrichment run iff configured — proving the same `Handler` serves both modes and the blocks are not deleted. |
| `pkg/vmcp/server/serve_test.go` | New `TestServeOmitsAuthzAndAnnotation`: asserts a `Serve`-built server has `config.AuthzMiddleware == nil` and still builds its `Handler`. Updated the `intentionallyUnmapped` comment for `AuthzMiddleware` in `TestBuildServeConfigMapsSharedFields`. |
| `pkg/vmcp/server/server.go` | Added an explanatory comment in `Handler` documenting that the authz/annotation layers are guarded by `AuthzMiddleware != nil` (on for `server.New`, off for `Serve`) and remain in the shared `Handler` until Phase 3 (#5445). |
| `pkg/vmcp/server/serve.go` | Synced `Serve`/`buildServeConfig` comments to describe the now-current middleware-chain wiring and the deliberate nil `AuthzMiddleware`. |
| `pkg/vmcp/server/annotation_enrichment.go` | Corrected the `convertAnnotations` comment: #5441 makes the middleware inert via the nil-guard; physical removal of the duplicated converter is Phase 3 (#5445). |
| `pkg/vmcp/core/admission.go` | Corrected stale #5441 attributions: the (Authz + optimizer) fail-fast lands with the core-enforcement switch in #5442; the shared-constructor reconciliation lands in Phase 3 (#5445). |
| `pkg/vmcp/server/serve_session_test.go` | Corrected discovery-middleware relocation attribution from #5441/#5442 to #5442. |

## Does this introduce a user-facing change?

No. `server.New`'s signature and observable behavior are unchanged, and the `Serve` path
is not yet wired into any production composition root.

## Special notes for reviewers

Per the issue's "guard, don't delete (yet)" strategy, several items are deliberately
deferred — please review with these scope boundaries in mind:

- **Authz/annotation blocks are NOT deleted here.** They remain in the shared
  `(*Server).Handler` so the still-live `server.New` path keeps enforcing authz. Physical
  removal is Phase 3 (#5445), after `server.New` is routed through `Serve`.
  `annotation_enrichment.go` (including `convertAnnotations`) is intentionally left in
  place — the core admission seam reuses `convertAnnotations` per #5438.
- **AC #6 (optimizer + authz fail-fast at the `core.New` composition root) is deferred to
  #5442.** There is no production composition root wiring `core.New` yet — `cli/serve.go`
  still uses the legacy `server.New`, which retains HTTP authz, so the (Authz + optimizer)
  combination is handled correctly there. The issue's AC #6 parenthetical explicitly
  permits carrying this criterion to #5442 if the core-enforcement switch lands there.
- **AC #5's `Serve`-path admission-seam parity lands with the request path in #5442.**
  Guarding/retiring the discovery middleware is out of scope here. The `server.New`
  parity surface is unchanged and green.
