### PR TITLE
Trigger release notes via workflow_run not release event

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -57,10 +57,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          # For workflow_run, check out the exact commit the tag workflow ran
-          # against so the VERSION file matches the release being announced. For
-          # workflow_dispatch this is empty and the default branch is used.
-          ref: ${{ github.event.workflow_run.head_sha }}
+          # Always check out the default branch, never the workflow_run head ref.
+          # Checking out an event-supplied ref in a secrets-bearing workflow_run
+          # is the "untrusted checkout" anti-pattern (CodeQL actions/untrusted-
+          # checkout). It is safe here too: "Create Release Tag" only runs on a
+          # VERSION push to main, so main HEAD already is the release commit and
+          # its VERSION matches the tag being announced.
+          #
           # Full history + tags are required: the skill lists/sorts tags and
           # compares ranges between the current and previous release.
           fetch-depth: 0
@@ -71,8 +74,8 @@ jobs:
           INPUT_TAG: ${{ inputs.tag }}
         run: |
           # Manual runs pass the tag explicitly; workflow_run derives it from the
-          # VERSION file at the checked-out commit (same source the tag workflow
-          # uses to create the tag), prefixed with "v".
+          # VERSION file on the default branch (the release commit that triggered
+          # the tag workflow), prefixed with "v".
           if [ -n "$INPUT_TAG" ]; then
             TAG="$INPUT_TAG"
           else

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -1,11 +1,18 @@
 # Generate Release Notes workflow
 #
-# When a GitHub Release is published (by create-release-tag.yml after a release
-# PR merges), this workflow runs the `release-notes` Claude skill to produce
-# polished, copy-pasteable release notes:
+# Runs after "Create Release Tag" completes (that workflow creates the git tag
+# and GitHub Release once a release PR merges). It then runs the `release-notes`
+# Claude skill to produce polished, copy-pasteable release notes:
 #   - analyzes every merged PR between the previous tag and this one
 #   - cross-references linked issues
 #   - dispatches expert subagents to assess breaking changes
+#
+# Why workflow_run and not the `release` event: anthropics/claude-code-action
+# only accepts a fixed set of event types (issues, pull_request*, comments,
+# workflow_dispatch, repository_dispatch, schedule, workflow_run). A `release`
+# trigger makes the action fail immediately with "Unsupported event type:
+# release". workflow_run is supported and is not subject to the GITHUB_TOKEN
+# downstream-trigger limitation, so it fires reliably after the tag workflow.
 #
 # Delivery is REVIEW-THEN-PUBLISH: the public release notes are NOT overwritten.
 # The generated markdown is uploaded as a build artifact, written to the job
@@ -17,8 +24,9 @@
 name: Generate Release Notes
 
 on:
-  release:
-    types: [published]
+  workflow_run:
+    workflows: ["Create Release Tag"]
+    types: [completed]
   workflow_dispatch:
     inputs:
       tag:
@@ -36,31 +44,47 @@ jobs:
     name: Generate Release Notes
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    # On workflow_run, only proceed if the tag workflow actually succeeded.
+    # Manual dispatch always proceeds.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
     env:
       # Mapped to a job-level env var so the Slack step can gate on it: the
       # `secrets` context is not available in step-level `if:` conditions.
       SLACK_WEBHOOK: ${{ secrets.SLACK_TOOLHIVE_RELEASE_WEBHOOK_URL }}
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          # For workflow_run, check out the exact commit the tag workflow ran
+          # against so the VERSION file matches the release being announced. For
+          # workflow_dispatch this is empty and the default branch is used.
+          ref: ${{ github.event.workflow_run.head_sha }}
+          # Full history + tags are required: the skill lists/sorts tags and
+          # compares ranges between the current and previous release.
+          fetch-depth: 0
+
       - name: Resolve release tag
         id: tag
         env:
-          EVENT_TAG: ${{ github.event.release.tag_name }}
           INPUT_TAG: ${{ inputs.tag }}
         run: |
-          TAG="${EVENT_TAG:-$INPUT_TAG}"
-          if [ -z "$TAG" ]; then
-            echo "::error::No release tag resolved from event or input"
+          # Manual runs pass the tag explicitly; workflow_run derives it from the
+          # VERSION file at the checked-out commit (same source the tag workflow
+          # uses to create the tag), prefixed with "v".
+          if [ -n "$INPUT_TAG" ]; then
+            TAG="$INPUT_TAG"
+          else
+            VERSION=$(tr -d '[:space:]' < VERSION)
+            TAG="v$VERSION"
+          fi
+          if [ -z "$TAG" ] || [ "$TAG" = "v" ]; then
+            echo "::error::No release tag resolved from input or VERSION file"
             exit 1
           fi
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "Generating release notes for: $TAG"
-
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          # Full history + tags are required: the skill lists/sorts tags and
-          # compares ranges between the current and previous release.
-          fetch-depth: 0
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -103,6 +103,11 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Hand the action a token explicitly so it does not try to mint one via
+          # OIDC (the Claude GitHub App flow), which would require `id-token: write`
+          # and the app installed. We only need the API key for Anthropic auth and
+          # GH_TOKEN for the skill's read-only gh calls.
+          github_token: ${{ github.token }}
           prompt: |
             You are generating GitHub release notes for the ToolHive release ${{ steps.tag.outputs.tag }}.
 


### PR DESCRIPTION
## Summary

The **Generate Release Notes** workflow (added in #5487) failed on every release. Two bugs, fixed here:

1. **Unsupported event type.** It triggered `anthropics/claude-code-action` from the `release: published` event, but that action validates `GITHUB_EVENT_NAME` against a fixed set (`issues`, `pull_request*`, comments, `workflow_dispatch`, `repository_dispatch`, `schedule`, `workflow_run`) and throws **`Unsupported event type: release`** for anything else — dying at startup before the `release-notes` skill ran. Original failure: https://github.com/stacklok/toolhive/actions/runs/27301291308/job/80647489553
2. **OIDC token failure (previously masked by #1).** Without a `github_token` input, the action tries to mint its own token via OIDC (the Claude GitHub App flow), failing with **`Could not fetch an OIDC token`** unless the workflow has `id-token: write` and the app installed.

### Changes

- Switch the trigger to **`workflow_run`** on **"Create Release Tag"** (the workflow that creates the git tag and GitHub Release). `workflow_run` is a supported event and is not subject to the `GITHUB_TOKEN` downstream-trigger limitation, so it fires reliably. The tag is derived from the `VERSION` file at the run's head commit — the same source the tag workflow uses — and `workflow_dispatch` with an explicit `tag` input is preserved for manual runs. A job-level `if` gates on `workflow_run.conclusion == 'success'`.
- Pass `github_token: ${{ github.token }}` to the action so it skips OIDC. We only need the API key for Anthropic auth and `GH_TOKEN` for the skill's read-only `gh` calls.

Since all jobs in a run share one `GITHUB_EVENT_NAME`, reshuffling jobs couldn't fix #1; the trigger itself had to change.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Test plan

- [x] Validated the workflow YAML parses and resolves the expected triggers (`workflow_run`, `workflow_dispatch`) and job `if` guard.
- [x] End-to-end dispatch of the branch against `v0.29.3` ([run 27302219050](https://github.com/stacklok/toolhive/actions/runs/27302219050)) — **all steps green**: action runs past event validation and token setup, the skill generates notes, and the artifact / job summary / release-PR comment / Slack announce steps all succeed. (This run also backfilled the v0.29.3 notes that the original failure skipped.)

## Does this introduce a user-facing change?

No. This only affects the internal release-automation pipeline.

## Special notes for reviewers

The `workflow_run` auto-trigger can only be exercised once this is on the default branch (GitHub reads `workflow_run` config from the default branch only); it was validated indirectly via the `workflow_dispatch` path, which runs the identical job body under a supported event.

Generated with [Claude Code](https://claude.com/claude-code)
