### PR TITLE
Replace discovery-into-context with direct VMCP calls

### DIFF
--- a/pkg/vmcp/server/backend_enrichment.go
+++ b/pkg/vmcp/server/backend_enrichment.go
@@ -85,33 +85,52 @@ func (s *Server) resolveBackendName(ctx context.Context, method string, params m
 }
 
 // coreLookupBackendName resolves the backend for an MCP request via the core's
-// Lookup* methods and returns the resolved capability's Tool/Resource/Prompt
-// BackendID (the logical backend identifier). Identity is read from the request
-// context at this transport boundary and passed explicitly to the core. Returns
-// "" when the capability is unknown, unadvertised, or denied to the caller.
+// Lookup* methods, derives the backend from the resolved capability's BackendID,
+// and returns the backend's human-readable name. Identity is read from the request
+// context at this transport boundary and passed explicitly to the core. Returns ""
+// when the capability is unknown, unadvertised, or denied to the caller.
+//
+// The name (not the raw BackendID) is returned for parity with the legacy path,
+// which records BackendTarget.WorkloadName (= backend.Name); recording the same value
+// on both paths keeps audit events correlatable across the Serve and server.New paths.
 func (s *Server) coreLookupBackendName(ctx context.Context, method string, params map[string]any) string {
 	identity, _ := auth.IdentityFromContext(ctx)
 	switch method {
 	case "tools/call":
 		if name, ok := params["name"].(string); ok {
 			if tool, err := s.core.LookupTool(ctx, identity, name); err == nil && tool != nil {
-				return tool.BackendID
+				return s.backendDisplayName(ctx, tool.BackendID)
 			}
 		}
 	case "resources/read":
 		if uri, ok := params["uri"].(string); ok {
 			if res, err := s.core.LookupResource(ctx, identity, uri); err == nil && res != nil {
-				return res.BackendID
+				return s.backendDisplayName(ctx, res.BackendID)
 			}
 		}
 	case "prompts/get":
 		if name, ok := params["name"].(string); ok {
 			if prompt, err := s.core.LookupPrompt(ctx, identity, name); err == nil && prompt != nil {
-				return prompt.BackendID
+				return s.backendDisplayName(ctx, prompt.BackendID)
 			}
 		}
 	}
 	return ""
+}
+
+// backendDisplayName resolves a logical backend ID to its human-readable name via
+// the registry, so the Serve path records the same audit value (backend.Name) the
+// legacy path's WorkloadName carries. It falls back to the ID when the backend is
+// not in the registry (mirroring the aggregator's minimal-target fallback), so audit
+// still records an identifier rather than dropping the backend entirely.
+func (s *Server) backendDisplayName(ctx context.Context, backendID string) string {
+	if backendID == "" {
+		return ""
+	}
+	if backend := s.backendRegistry.Get(ctx, backendID); backend != nil {
+		return backend.Name
+	}
+	return backendID
 }
 
 // lookupBackendName looks up which backend handles a given MCP request.

--- a/pkg/vmcp/server/backend_enrichment.go
+++ b/pkg/vmcp/server/backend_enrichment.go
@@ -5,19 +5,26 @@ package server
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"log/slog"
 	"net/http"
 
 	"github.com/stacklok/toolhive/pkg/audit"
+	"github.com/stacklok/toolhive/pkg/auth"
 	"github.com/stacklok/toolhive/pkg/vmcp"
 	"github.com/stacklok/toolhive/pkg/vmcp/discovery"
 )
 
 // backendEnrichmentMiddleware wraps an HTTP handler to add backend routing information
-// to audit events by parsing MCP requests and looking up backends in the routing table.
-func (*Server) backendEnrichmentMiddleware(next http.Handler) http.Handler {
+// to audit events by parsing MCP requests and resolving the target backend.
+//
+// The resolution source depends on the path: on the Serve path (s.core != nil) it
+// asks the core (LookupTool/LookupResource/LookupPrompt) and derives the backend from
+// Tool.BackendID; on the legacy server.New path it reads the routing table the discovery
+// middleware injected into the request context.
+func (s *Server) backendEnrichmentMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Read and parse the request body to extract MCP method and parameters
 		var requestBody []byte
@@ -43,16 +50,12 @@ func (*Server) backendEnrichmentMiddleware(next http.Handler) http.Handler {
 		}
 
 		if len(requestBody) > 0 && json.Unmarshal(requestBody, &mcpRequest) == nil {
-			// Get routing table from discovered capabilities in context
-			caps, ok := discovery.DiscoveredCapabilitiesFromContext(r.Context())
-			if ok && caps != nil && caps.RoutingTable != nil {
-				backendName := lookupBackendName(mcpRequest.Method, mcpRequest.Params, caps.RoutingTable)
+			backendName := s.resolveBackendName(r.Context(), mcpRequest.Method, mcpRequest.Params)
 
-				// Mutate the existing BackendInfo from audit middleware
-				if backendName != "" {
-					if backendInfo, ok := audit.BackendInfoFromContext(r.Context()); ok && backendInfo != nil {
-						backendInfo.BackendName = backendName
-					}
+			// Mutate the existing BackendInfo from audit middleware
+			if backendName != "" {
+				if backendInfo, ok := audit.BackendInfoFromContext(r.Context()); ok && backendInfo != nil {
+					backendInfo.BackendName = backendName
 				}
 			}
 		}
@@ -60,6 +63,55 @@ func (*Server) backendEnrichmentMiddleware(next http.Handler) http.Handler {
 		// Call next handler
 		next.ServeHTTP(w, r)
 	})
+}
+
+// resolveBackendName resolves the backend handling an MCP request, dispatching on
+// whether the core is wired (Serve path) or not (legacy path).
+func (s *Server) resolveBackendName(ctx context.Context, method string, params map[string]any) string {
+	// Serve path: the core is the source of truth. Lookup* applies the same admission
+	// filter as List*, so a denied or unadvertised capability resolves to nothing (the
+	// backend name is never derived from a capability the caller cannot reach). The
+	// discovery-into-context seam is not populated on this path.
+	if s.core != nil {
+		return s.coreLookupBackendName(ctx, method, params)
+	}
+
+	// Legacy path: read the routing table the discovery middleware injected into context.
+	caps, ok := discovery.DiscoveredCapabilitiesFromContext(ctx)
+	if !ok || caps == nil || caps.RoutingTable == nil {
+		return ""
+	}
+	return lookupBackendName(method, params, caps.RoutingTable)
+}
+
+// coreLookupBackendName resolves the backend for an MCP request via the core's
+// Lookup* methods and returns the resolved capability's Tool/Resource/Prompt
+// BackendID (the logical backend identifier). Identity is read from the request
+// context at this transport boundary and passed explicitly to the core. Returns
+// "" when the capability is unknown, unadvertised, or denied to the caller.
+func (s *Server) coreLookupBackendName(ctx context.Context, method string, params map[string]any) string {
+	identity, _ := auth.IdentityFromContext(ctx)
+	switch method {
+	case "tools/call":
+		if name, ok := params["name"].(string); ok {
+			if tool, err := s.core.LookupTool(ctx, identity, name); err == nil && tool != nil {
+				return tool.BackendID
+			}
+		}
+	case "resources/read":
+		if uri, ok := params["uri"].(string); ok {
+			if res, err := s.core.LookupResource(ctx, identity, uri); err == nil && res != nil {
+				return res.BackendID
+			}
+		}
+	case "prompts/get":
+		if name, ok := params["name"].(string); ok {
+			if prompt, err := s.core.LookupPrompt(ctx, identity, name); err == nil && prompt != nil {
+				return prompt.BackendID
+			}
+		}
+	}
+	return ""
 }
 
 // lookupBackendName looks up which backend handles a given MCP request.

--- a/pkg/vmcp/server/backend_enrichment.go
+++ b/pkg/vmcp/server/backend_enrichment.go
@@ -93,6 +93,21 @@ func (s *Server) resolveBackendName(ctx context.Context, method string, params m
 // The name (not the raw BackendID) is returned for parity with the legacy path,
 // which records BackendTarget.WorkloadName (= backend.Name); recording the same value
 // on both paths keeps audit events correlatable across the Serve and server.New paths.
+//
+// Why the core, not the session's routing table: the core's Lookup* applies conflict
+// resolution and the admission filter, so it resolves the advertised (possibly renamed)
+// name a client actually calls and never resolves a denied capability. The Serve-path
+// session's routing table is built without the core's aggregation (it must not
+// double-aggregate, AC2), so it holds raw pre-resolution names that would miss whenever
+// a tool was renamed — it is not a reliable source here.
+//
+// Cost: Lookup* re-aggregates backend capabilities (the core is intentionally
+// stateless, core_vmcp.go:287-298), so an audited request triggers an aggregation here
+// in addition to the one the call itself performs. This is acceptable for now — the
+// Serve path has no production composition root yet — and is deferred rather than
+// optimized speculatively (vmcp anti-pattern #9: optimize with evidence). When the Serve
+// path goes live, a per-session advertised-set cache ("Serve caches, core is stateless")
+// is the place to remove the second aggregation.
 func (s *Server) coreLookupBackendName(ctx context.Context, method string, params map[string]any) string {
 	identity, _ := auth.IdentityFromContext(ctx)
 	switch method {

--- a/pkg/vmcp/server/backend_enrichment_test.go
+++ b/pkg/vmcp/server/backend_enrichment_test.go
@@ -562,7 +562,12 @@ func TestBackendEnrichmentMiddleware_ServePath(t *testing.T) {
 			"Serve path must record the backend name, not the raw BackendID")
 	})
 
-	t.Run("no-op for unadvertised or denied tool (LookupTool returns not found)", func(t *testing.T) {
+	// The real core's LookupTool delegates to ListTools, which applies the admission
+	// filter, so BOTH an unadvertised name and an advertised-but-denied capability surface
+	// as ErrNotFound — indistinguishable at this layer. This asserts that ErrNotFound
+	// resolves to no backend name (so a denied capability is never labeled); the admission
+	// deny semantics themselves are covered by the core's admission_test.go.
+	t.Run("no-op when LookupTool returns not-found (unadvertised or admission-denied)", func(t *testing.T) {
 		t.Parallel()
 		nextHandler, handlerCalled := createTestHandler()
 		backendInfo := &audit.BackendInfo{}
@@ -575,7 +580,7 @@ func TestBackendEnrichmentMiddleware_ServePath(t *testing.T) {
 
 		assert.True(t, *handlerCalled)
 		assert.Empty(t, backendInfo.BackendName,
-			"a tool the core does not advertise/admit must not resolve a backend name")
+			"a tool the core does not resolve (unadvertised or denied) must not resolve a backend name")
 	})
 
 	t.Run("ignores the discovery context and resolves via the core", func(t *testing.T) {

--- a/pkg/vmcp/server/backend_enrichment_test.go
+++ b/pkg/vmcp/server/backend_enrichment_test.go
@@ -534,6 +534,68 @@ func TestBackendEnrichmentMiddleware(t *testing.T) {
 	})
 }
 
+// TestBackendEnrichmentMiddleware_ServePath verifies the Serve path (s.core != nil):
+// backend identity is resolved via the core's Lookup* methods and derived from
+// Tool.BackendID, with no reliance on the discovery-into-context routing table.
+func TestBackendEnrichmentMiddleware_ServePath(t *testing.T) {
+	t.Parallel()
+
+	fc := &fakeCore{tools: []vmcp.Tool{{Name: "test-tool", BackendID: "backend-x"}}}
+	srv := &Server{core: fc}
+
+	t.Run("derives backend name from Tool.BackendID via core LookupTool", func(t *testing.T) {
+		t.Parallel()
+		nextHandler, handlerCalled := createTestHandler()
+		backendInfo := &audit.BackendInfo{}
+
+		req := httptest.NewRequest(http.MethodPost, "/mcp", bytes.NewReader([]byte(toolsCallRequest)))
+		req = req.WithContext(audit.WithBackendInfo(req.Context(), backendInfo))
+
+		srv.backendEnrichmentMiddleware(nextHandler).ServeHTTP(httptest.NewRecorder(), req)
+
+		assert.True(t, *handlerCalled)
+		assert.Equal(t, "backend-x", backendInfo.BackendName)
+	})
+
+	t.Run("no-op for unadvertised or denied tool (LookupTool returns not found)", func(t *testing.T) {
+		t.Parallel()
+		nextHandler, handlerCalled := createTestHandler()
+		backendInfo := &audit.BackendInfo{}
+
+		body := `{"method":"tools/call","params":{"name":"unknown-tool"}}`
+		req := httptest.NewRequest(http.MethodPost, "/mcp", bytes.NewReader([]byte(body)))
+		req = req.WithContext(audit.WithBackendInfo(req.Context(), backendInfo))
+
+		srv.backendEnrichmentMiddleware(nextHandler).ServeHTTP(httptest.NewRecorder(), req)
+
+		assert.True(t, *handlerCalled)
+		assert.Empty(t, backendInfo.BackendName,
+			"a tool the core does not advertise/admit must not resolve a backend name")
+	})
+
+	t.Run("ignores the discovery context and resolves via the core", func(t *testing.T) {
+		t.Parallel()
+		nextHandler, handlerCalled := createTestHandler()
+		backendInfo := &audit.BackendInfo{}
+
+		// A legacy routing table is present in context but must be ignored on the Serve
+		// path: resolution comes from the core (BackendID), not the context (WorkloadName).
+		caps := &aggregator.AggregatedCapabilities{RoutingTable: &vmcp.RoutingTable{
+			Tools: map[string]*vmcp.BackendTarget{"test-tool": {WorkloadName: "legacy-backend"}},
+		}}
+		req := httptest.NewRequest(http.MethodPost, "/mcp", bytes.NewReader([]byte(toolsCallRequest)))
+		ctx := discovery.WithDiscoveredCapabilities(req.Context(), caps)
+		ctx = audit.WithBackendInfo(ctx, backendInfo)
+		req = req.WithContext(ctx)
+
+		srv.backendEnrichmentMiddleware(nextHandler).ServeHTTP(httptest.NewRecorder(), req)
+
+		assert.True(t, *handlerCalled)
+		assert.Equal(t, "backend-x", backendInfo.BackendName,
+			"Serve path must resolve via the core (BackendID), not the discovery context (WorkloadName)")
+	})
+}
+
 func TestLookupBackendName(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/vmcp/server/backend_enrichment_test.go
+++ b/pkg/vmcp/server/backend_enrichment_test.go
@@ -535,15 +535,19 @@ func TestBackendEnrichmentMiddleware(t *testing.T) {
 }
 
 // TestBackendEnrichmentMiddleware_ServePath verifies the Serve path (s.core != nil):
-// backend identity is resolved via the core's Lookup* methods and derived from
-// Tool.BackendID, with no reliance on the discovery-into-context routing table.
+// backend identity is resolved via the core's Lookup* methods (derived from
+// Tool.BackendID) and recorded as the backend's human-readable name — matching the
+// legacy path's WorkloadName — with no reliance on the discovery-into-context table.
 func TestBackendEnrichmentMiddleware_ServePath(t *testing.T) {
 	t.Parallel()
 
+	// BackendID ("backend-x") differs from the human-readable Name ("github-mcp") so the
+	// test proves the Serve path resolves the ID to the name (audit parity), not the raw ID.
 	fc := &fakeCore{tools: []vmcp.Tool{{Name: "test-tool", BackendID: "backend-x"}}}
-	srv := &Server{core: fc}
+	reg := vmcp.NewImmutableRegistry([]vmcp.Backend{{ID: "backend-x", Name: "github-mcp"}})
+	srv := &Server{core: fc, backendRegistry: reg}
 
-	t.Run("derives backend name from Tool.BackendID via core LookupTool", func(t *testing.T) {
+	t.Run("resolves Tool.BackendID to the backend name (parity with legacy WorkloadName)", func(t *testing.T) {
 		t.Parallel()
 		nextHandler, handlerCalled := createTestHandler()
 		backendInfo := &audit.BackendInfo{}
@@ -554,7 +558,8 @@ func TestBackendEnrichmentMiddleware_ServePath(t *testing.T) {
 		srv.backendEnrichmentMiddleware(nextHandler).ServeHTTP(httptest.NewRecorder(), req)
 
 		assert.True(t, *handlerCalled)
-		assert.Equal(t, "backend-x", backendInfo.BackendName)
+		assert.Equal(t, "github-mcp", backendInfo.BackendName,
+			"Serve path must record the backend name, not the raw BackendID")
 	})
 
 	t.Run("no-op for unadvertised or denied tool (LookupTool returns not found)", func(t *testing.T) {
@@ -591,8 +596,26 @@ func TestBackendEnrichmentMiddleware_ServePath(t *testing.T) {
 		srv.backendEnrichmentMiddleware(nextHandler).ServeHTTP(httptest.NewRecorder(), req)
 
 		assert.True(t, *handlerCalled)
-		assert.Equal(t, "backend-x", backendInfo.BackendName,
-			"Serve path must resolve via the core (BackendID), not the discovery context (WorkloadName)")
+		assert.Equal(t, "github-mcp", backendInfo.BackendName,
+			"Serve path must resolve via the core/registry (BackendID→name), not the discovery context (legacy-backend)")
+	})
+
+	t.Run("falls back to the BackendID when the backend is not in the registry", func(t *testing.T) {
+		t.Parallel()
+		// "ghost" is advertised by the core but absent from reg; audit still records an identifier.
+		orphanCore := &fakeCore{tools: []vmcp.Tool{{Name: "orphan-tool", BackendID: "ghost"}}}
+		orphanSrv := &Server{core: orphanCore, backendRegistry: reg}
+		nextHandler, handlerCalled := createTestHandler()
+		backendInfo := &audit.BackendInfo{}
+
+		body := `{"method":"tools/call","params":{"name":"orphan-tool"}}`
+		req := httptest.NewRequest(http.MethodPost, "/mcp", bytes.NewReader([]byte(body)))
+		req = req.WithContext(audit.WithBackendInfo(req.Context(), backendInfo))
+
+		orphanSrv.backendEnrichmentMiddleware(nextHandler).ServeHTTP(httptest.NewRecorder(), req)
+
+		assert.True(t, *handlerCalled)
+		assert.Equal(t, "ghost", backendInfo.BackendName)
 	})
 }
 

--- a/pkg/vmcp/server/serve.go
+++ b/pkg/vmcp/server/serve.go
@@ -147,22 +147,26 @@ type ServerConfig struct {
 // The authenticated middleware chain is produced by the shared (*Server).Handler that
 // the Serve-built *Server already uses, with the authz and annotation-enrichment layers
 // guarded off via a nil AuthzMiddleware (#5441); authorization moves to the core
-// admission seam (#5438). The remaining transport concerns — the direct VMCP request
-// path (#5442) and the AS runner / status reporter / optimizer / health monitor
-// lifecycle (#5443) — are relocated under Serve by the subsequent Phase 2 tasks.
-// server.New is not yet routed through Serve and keeps its own copy of the session
-// wiring until Phase 3, so this is purely additive and observable behavior is unchanged.
+// admission seam (#5438). The injected core is stored on the *Server, which makes the
+// "/" MCP route serveable: the shared Handler guards the discovery middleware to the
+// legacy path (s.core == nil), and on the Serve path session registration and request
+// handlers call the core directly (#5442). The remaining transport concern — the AS
+// runner / status reporter / optimizer / health monitor lifecycle (#5443) — is
+// relocated under Serve by the next Phase 2 task. server.New is not yet routed through
+// Serve and keeps its own copy of the session wiring until Phase 3, so this is purely
+// additive and observable behavior is unchanged.
 //
 // Serve returns a vmcp.ErrInvalidConfig-wrapped error for a nil cfg, a nil core, or a
 // nil required collaborator (SessionManagerConfig or BackendRegistry). The session
 // hooks close over the constructed *Server, so they are registered after it is
 // assembled.
 //
-// Contract: the returned *Server now has a live session manager and backend registry,
-// but a nil discovery manager, router, and backend client at this phase. It must NOT
-// be Start()ed or served on the "/" MCP route until #5442 wires those fields — the
-// carried-forward Handler passes them to discovery.Middleware, which would nil-deref.
-// The unauthenticated routes (registered as direct mux entries) are safe to serve.
+// Contract: the returned *Server has a live session manager, backend registry, and core,
+// but a nil discovery manager, router, and backend client — the request path goes
+// through the core, so those legacy collaborators are unused on the Serve path. The
+// shared Handler skips the discovery middleware when s.core != nil, so serving the "/"
+// MCP route no longer nil-derefs. The AS runner / status reporter / optimizer / health
+// monitor lifecycle is still wired by #5443.
 func Serve(ctx context.Context, v core.VMCP, cfg *ServerConfig) (*Server, error) {
 	if cfg == nil {
 		return nil, fmt.Errorf("%w: nil server config", vmcp.ErrInvalidConfig)
@@ -230,6 +234,7 @@ func Serve(ctx context.Context, v core.VMCP, cfg *ServerConfig) (*Server, error)
 
 	srv := &Server{
 		config:             serveCfg,
+		core:               v,
 		mcpServer:          mcpServer,
 		backendRegistry:    cfg.BackendRegistry,
 		sessionManager:     sessionManager,

--- a/pkg/vmcp/server/serve.go
+++ b/pkg/vmcp/server/serve.go
@@ -119,6 +119,17 @@ type ServerConfig struct {
 	// definitions before assembling this config (sessionmanager.New only checks the
 	// WorkflowDefs/ComposerFactory pairing). This responsibility moves here with the
 	// relocation and matters when server.New is routed through Serve in Phase 3.
+	//
+	// Caller responsibility (AC2, the single-aggregation contract): FactoryConfig.Base
+	// MUST be constructed WITHOUT a session.WithAggregator option on the Serve path. On
+	// this path the core is the single source of truth — session registration sources the
+	// advertised set from core.ListTools/ListResources and routes calls through the core
+	// (handleSessionRegistrationImpl/serve_handlers.go); the factory's role is reduced to
+	// opening the session's backend connections and binding identity. A factory that also
+	// aggregates would produce a second, divergent capability set (drift) whose routing
+	// table this path discards — exactly the double-aggregation AC2 forbids. This is an
+	// unenforced contract today because no production composition root wires the Serve path
+	// yet; it becomes load-bearing when one does.
 	SessionManagerConfig *sessionmanager.FactoryConfig
 
 	// TelemetryProvider is the cross-cutting telemetry provider (also consumed by

--- a/pkg/vmcp/server/serve_handlers.go
+++ b/pkg/vmcp/server/serve_handlers.go
@@ -1,0 +1,233 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+
+	"github.com/stacklok/toolhive/pkg/auth"
+	"github.com/stacklok/toolhive/pkg/vmcp"
+	"github.com/stacklok/toolhive/pkg/vmcp/conversion"
+	vmcpsession "github.com/stacklok/toolhive/pkg/vmcp/session"
+	sessiontypes "github.com/stacklok/toolhive/pkg/vmcp/session/types"
+)
+
+// This file holds the Serve-path (s.core != nil) capability wiring. On the Serve
+// path the core VMCP is the single authoritative aggregation: session
+// registration sources the advertised tool/resource set from core.ListTools /
+// core.ListResources (admission-filtered, composites included) and installs SDK
+// handlers that route invocations through core.CallTool / core.ReadResource with
+// an explicit *auth.Identity. The session factory does NOT aggregate on this path,
+// so there is no second aggregation and no drift between the advertised set and
+// the call path. Identity binding is still enforced by the session layer via
+// enforceSessionBinding before each call reaches the core.
+//
+// The legacy server.New path (s.core == nil) is untouched: it sources capabilities
+// from the session factory's aggregation via Manager.GetAdaptedTools/Resources and
+// routes through the session's own MultiSession.
+
+// injectCoreSessionCapabilities sources the session's advertised capability set
+// from the core and installs it on the SDK session. It is invoked from
+// handleSessionRegistrationImpl on the Serve path, after the bound session record
+// has been created. The core.ListTools / core.ListResources calls here are the
+// single per-session aggregation point ("called exactly once per session").
+//
+// Prompts are intentionally not injected: per-session prompt injection is not yet
+// supported by the SDK (parity with the legacy path, which also omits them).
+func (s *Server) injectCoreSessionCapabilities(ctx context.Context, session server.ClientSession) error {
+	sessionID := session.SessionID()
+
+	// Identity is read from the SDK hook context here, at the transport boundary,
+	// and passed explicitly to the core — the core never reads it from context.
+	identity, _ := auth.IdentityFromContext(ctx)
+
+	tools, err := s.coreSessionTools(ctx, sessionID, identity)
+	if err != nil {
+		slog.Error("failed to list core tools for session", "session_id", sessionID, "error", err)
+		return err
+	}
+	resources, err := s.coreSessionResources(ctx, sessionID, identity)
+	if err != nil {
+		slog.Error("failed to list core resources for session", "session_id", sessionID, "error", err)
+		return err
+	}
+
+	if len(resources) > 0 {
+		if err := setSessionResourcesDirect(session, resources); err != nil {
+			slog.Error("failed to add session resources", "session_id", sessionID, "error", err)
+			return err
+		}
+	}
+	if len(tools) > 0 {
+		if err := setSessionToolsDirect(session, tools); err != nil {
+			slog.Error("failed to add session tools", "session_id", sessionID, "error", err)
+			return err
+		}
+	}
+
+	slog.Info("session capabilities injected from core",
+		"session_id", sessionID,
+		"tool_count", len(tools))
+	return nil
+}
+
+// coreSessionTools queries the core for the tools advertised to identity and
+// adapts them to SDK ServerTools whose handlers route through core.CallTool. The
+// core owns conflict resolution and backend-name translation, so the SDK tool name
+// is forwarded as-is to core.CallTool.
+func (s *Server) coreSessionTools(
+	ctx context.Context, sessionID string, identity *auth.Identity,
+) ([]server.ServerTool, error) {
+	domainTools, err := s.core.ListTools(ctx, identity)
+	if err != nil {
+		return nil, fmt.Errorf("core ListTools: %w", err)
+	}
+
+	sdkTools := make([]server.ServerTool, 0, len(domainTools))
+	for _, domainTool := range domainTools {
+		schemaJSON, err := json.Marshal(domainTool.InputSchema)
+		if err != nil {
+			return nil, fmt.Errorf("marshal schema for tool %s: %w", domainTool.Name, err)
+		}
+
+		tool := mcp.Tool{
+			Name:           domainTool.Name,
+			Description:    domainTool.Description,
+			RawInputSchema: schemaJSON,
+			Annotations:    conversion.ToMCPToolAnnotations(domainTool.Annotations),
+		}
+		if domainTool.OutputSchema != nil {
+			if outputSchemaJSON, marshalErr := json.Marshal(domainTool.OutputSchema); marshalErr != nil {
+				slog.Warn("failed to marshal tool output schema", "tool", domainTool.Name, "error", marshalErr)
+			} else {
+				tool.RawOutputSchema = outputSchemaJSON
+			}
+		}
+
+		sdkTools = append(sdkTools, server.ServerTool{
+			Tool:    tool,
+			Handler: s.coreToolHandler(sessionID, domainTool.Name),
+		})
+	}
+	return sdkTools, nil
+}
+
+// coreSessionResources queries the core for the resources advertised to identity
+// and adapts them to SDK ServerResources whose handlers route through
+// core.ReadResource.
+func (s *Server) coreSessionResources(
+	ctx context.Context, sessionID string, identity *auth.Identity,
+) ([]server.ServerResource, error) {
+	domainResources, err := s.core.ListResources(ctx, identity)
+	if err != nil {
+		return nil, fmt.Errorf("core ListResources: %w", err)
+	}
+
+	sdkResources := make([]server.ServerResource, 0, len(domainResources))
+	for _, domainResource := range domainResources {
+		sdkResources = append(sdkResources, server.ServerResource{
+			Resource: mcp.Resource{
+				Name:        domainResource.Name,
+				URI:         domainResource.URI,
+				Description: domainResource.Description,
+				MIMEType:    domainResource.MimeType,
+			},
+			Handler: s.coreResourceHandler(sessionID, domainResource.URI),
+		})
+	}
+	return sdkResources, nil
+}
+
+// coreToolHandler builds the SDK handler for a Serve-path tool. It enforces the
+// session's identity binding, then delegates to core.CallTool with the caller's
+// explicit identity. Admission (authorization) is the core's responsibility.
+func (s *Server) coreToolHandler(sessionID, toolName string) server.ToolHandlerFunc {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		args, ok := req.Params.Arguments.(map[string]any)
+		if !ok {
+			wrappedErr := fmt.Errorf("%w: arguments must be object, got %T", vmcp.ErrInvalidInput, req.Params.Arguments)
+			slog.Warn("invalid arguments for tool", "tool", toolName, "error", wrappedErr)
+			return mcp.NewToolResultError(wrappedErr.Error()), nil
+		}
+
+		caller, _ := auth.IdentityFromContext(ctx)
+		if err := s.enforceSessionBinding(sessionID, caller); err != nil {
+			s.terminateOnBindingFailure(sessionID, toolName, err)
+			return mcp.NewToolResultError(fmt.Sprintf("Unauthorized: %v", err)), nil
+		}
+
+		result, err := s.core.CallTool(ctx, caller, toolName, args, conversion.FromMCPMeta(req.Params.Meta))
+		if err != nil {
+			// Admission denial returns a generic message so the underlying authorizer
+			// error is never forwarded to the client.
+			if errors.Is(err, vmcp.ErrAuthorizationFailed) {
+				return mcp.NewToolResultError("call denied by authorization policy"), nil
+			}
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+
+		return &mcp.CallToolResult{
+			Result:            mcp.Result{Meta: conversion.ToMCPMeta(result.Meta)},
+			Content:           conversion.ToMCPContents(result.Content),
+			StructuredContent: result.StructuredContent,
+			IsError:           result.IsError,
+		}, nil
+	}
+}
+
+// coreResourceHandler builds the SDK handler for a Serve-path resource. It mirrors
+// coreToolHandler: binding check, then core.ReadResource with explicit identity.
+func (s *Server) coreResourceHandler(
+	sessionID, uri string,
+) func(ctx context.Context, req mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+	return func(ctx context.Context, _ mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+		caller, _ := auth.IdentityFromContext(ctx)
+		if err := s.enforceSessionBinding(sessionID, caller); err != nil {
+			s.terminateOnBindingFailure(sessionID, uri, err)
+			return nil, fmt.Errorf("unauthorized: %w", err)
+		}
+
+		result, err := s.core.ReadResource(ctx, caller, uri)
+		if err != nil {
+			if errors.Is(err, vmcp.ErrAuthorizationFailed) {
+				return nil, fmt.Errorf("read denied by authorization policy")
+			}
+			return nil, err
+		}
+		return conversion.ToMCPResourceContents(result.Contents), nil
+	}
+}
+
+// enforceSessionBinding validates caller against the session's stored identity
+// binding, reproducing the session layer's hijack-prevention check (normally
+// applied by the BindSession decorator on MultiSession.CallTool) for the Serve
+// call path, where requests reach the core directly rather than through that
+// decorator. It fails closed: a missing session record rejects the caller.
+func (s *Server) enforceSessionBinding(sessionID string, caller *auth.Identity) error {
+	sess, ok := s.vmcpSessionMgr.GetMultiSession(sessionID)
+	if !ok {
+		// No live or restorable session record — Validate would normally have
+		// rejected the request already; fail closed rather than allow the call.
+		return sessiontypes.ErrUnauthorizedCaller
+	}
+	return vmcpsession.ValidateCaller(sess.GetMetadata()[vmcpsession.MetadataKeyIdentityBinding], caller)
+}
+
+// terminateOnBindingFailure logs the hijack-prevention event and terminates the
+// session, mirroring GetAdaptedTools' handling of ErrUnauthorizedCaller/ErrNilCaller.
+func (s *Server) terminateOnBindingFailure(sessionID, capability string, err error) {
+	slog.Warn("caller authorization failed, terminating session",
+		"session_id", sessionID, "capability", capability, "error", err)
+	if _, termErr := s.vmcpSessionMgr.Terminate(sessionID); termErr != nil {
+		slog.Error("failed to terminate session after auth failure",
+			"session_id", sessionID, "error", termErr)
+	}
+}

--- a/pkg/vmcp/server/serve_handlers.go
+++ b/pkg/vmcp/server/serve_handlers.go
@@ -207,18 +207,25 @@ func (s *Server) coreResourceHandler(
 }
 
 // enforceSessionBinding validates caller against the session's stored identity
-// binding, reproducing the session layer's hijack-prevention check (normally
-// applied by the BindSession decorator on MultiSession.CallTool) for the Serve
-// call path, where requests reach the core directly rather than through that
-// decorator. It fails closed: a missing session record rejects the caller.
+// binding. It is the SOLE identity-binding enforcement point on the Serve call
+// path: requests reach the core directly, bypassing the BindSession decorator that
+// performs this check on MultiSession.CallTool on the legacy path. The SDK's
+// SessionIdManager.Validate only gates session existence/termination, not caller
+// identity, so without this check a different principal could reuse the session ID.
+//
+// It fails closed in two ways: a missing session record (already terminated/expired)
+// rejects the caller, and ValidateCaller rejects an empty/unparsable binding with
+// ErrSessionOwnerUnknown. Unlike the legacy GetAdaptedTools handler, which terminates
+// only on ErrUnauthorizedCaller/ErrNilCaller, terminateOnBindingFailure terminates on
+// any rejection here — intentional fail-closed behavior, not a bug.
 func (s *Server) enforceSessionBinding(sessionID string, caller *auth.Identity) error {
 	sess, ok := s.vmcpSessionMgr.GetMultiSession(sessionID)
 	if !ok {
-		// No live or restorable session record — Validate would normally have
-		// rejected the request already; fail closed rather than allow the call.
 		return sessiontypes.ErrUnauthorizedCaller
 	}
-	return vmcpsession.ValidateCaller(sess.GetMetadata()[vmcpsession.MetadataKeyIdentityBinding], caller)
+	// Single-key read: avoid GetMetadata()'s per-call full-map copy on this hot path.
+	storedBinding, _ := sess.GetMetadataValue(vmcpsession.MetadataKeyIdentityBinding)
+	return vmcpsession.ValidateCaller(storedBinding, caller)
 }
 
 // terminateOnBindingFailure logs the hijack-prevention event and terminates the

--- a/pkg/vmcp/server/serve_handlers.go
+++ b/pkg/vmcp/server/serve_handlers.go
@@ -75,7 +75,8 @@ func (s *Server) injectCoreSessionCapabilities(ctx context.Context, session serv
 
 	slog.Info("session capabilities injected from core",
 		"session_id", sessionID,
-		"tool_count", len(tools))
+		"tool_count", len(tools),
+		"resource_count", len(resources))
 	return nil
 }
 
@@ -104,6 +105,9 @@ func (s *Server) coreSessionTools(
 			RawInputSchema: schemaJSON,
 			Annotations:    conversion.ToMCPToolAnnotations(domainTool.Annotations),
 		}
+		// Unlike the required InputSchema (a marshal failure aborts registration above),
+		// the optional OutputSchema is best-effort: on failure the tool is still advertised
+		// without it. Mirrors the legacy GetAdaptedTools adapter.
 		if domainTool.OutputSchema != nil {
 			if outputSchemaJSON, marshalErr := json.Marshal(domainTool.OutputSchema); marshalErr != nil {
 				slog.Warn("failed to marshal tool output schema", "tool", domainTool.Name, "error", marshalErr)

--- a/pkg/vmcp/server/serve_handlers.go
+++ b/pkg/vmcp/server/serve_handlers.go
@@ -38,7 +38,14 @@ import (
 // from the core and installs it on the SDK session. It is invoked from
 // handleSessionRegistrationImpl on the Serve path, after the bound session record
 // has been created. The core.ListTools / core.ListResources calls here are the
-// single per-session aggregation point ("called exactly once per session").
+// single CORE aggregation per session.
+//
+// "Single core aggregation" — not "the only backend work per session" — because the
+// preceding CreateSession opens the session's backend connections via the factory.
+// To honor AC2 (no double-aggregation, no drift), the composition root MUST configure
+// the Serve-path session factory WITHOUT its own aggregator (see the contract on
+// ServerConfig.SessionManagerConfig); otherwise the factory would aggregate a second,
+// divergent set whose routing table this path discards.
 //
 // Prompts are intentionally not injected: per-session prompt injection is not yet
 // supported by the SDK (parity with the legacy path, which also omits them).
@@ -202,7 +209,7 @@ func (s *Server) coreResourceHandler(
 		result, err := s.core.ReadResource(ctx, caller, uri)
 		if err != nil {
 			if errors.Is(err, vmcp.ErrAuthorizationFailed) {
-				return nil, fmt.Errorf("read denied by authorization policy")
+				return nil, errors.New("read denied by authorization policy")
 			}
 			return nil, err
 		}

--- a/pkg/vmcp/server/serve_session_test.go
+++ b/pkg/vmcp/server/serve_session_test.go
@@ -69,6 +69,9 @@ func newToolSessionFactory(
 			mock.EXPECT().GetMetadata().Return(map[string]string{
 				vmcpsession.MetadataKeyIdentityBinding: "unauthenticated",
 			}).AnyTimes()
+			// enforceSessionBinding reads the binding via the single-key accessor.
+			mock.EXPECT().GetMetadataValue(vmcpsession.MetadataKeyIdentityBinding).
+				Return("unauthenticated", true).AnyTimes()
 			mock.EXPECT().SetMetadata(gomock.Any(), gomock.Any()).AnyTimes()
 			toolsCopy := make([]vmcp.Tool, len(tools))
 			copy(toolsCopy, tools)

--- a/pkg/vmcp/server/serve_session_test.go
+++ b/pkg/vmcp/server/serve_session_test.go
@@ -24,9 +24,11 @@ import (
 	transportsession "github.com/stacklok/toolhive/pkg/transport/session"
 	"github.com/stacklok/toolhive/pkg/vmcp"
 	vmcpconfig "github.com/stacklok/toolhive/pkg/vmcp/config"
+	"github.com/stacklok/toolhive/pkg/vmcp/core"
 	"github.com/stacklok/toolhive/pkg/vmcp/server/sessionmanager"
 	vmcpsession "github.com/stacklok/toolhive/pkg/vmcp/session"
 	sessionfactorymocks "github.com/stacklok/toolhive/pkg/vmcp/session/mocks"
+	sessiontypes "github.com/stacklok/toolhive/pkg/vmcp/session/types"
 	sessionmocks "github.com/stacklok/toolhive/pkg/vmcp/session/types/mocks"
 )
 
@@ -90,27 +92,111 @@ func newToolSessionFactory(
 	return factory, state
 }
 
+// fakeCore is a configurable core.VMCP for Serve-path tests. It advertises a fixed
+// tool/resource set, counts ListTools/ListResources/CallTool invocations (so tests
+// can assert the "exactly once per session" aggregation contract), and resolves
+// Lookup* against the advertised set. It is the Serve-path counterpart to the mock
+// session factory: the factory establishes the session record, the core supplies the
+// advertised set and call routing.
+type fakeCore struct {
+	tools     []vmcp.Tool
+	resources []vmcp.Resource
+
+	listToolsCalls     atomic.Int32
+	listResourcesCalls atomic.Int32
+	callToolCalls      atomic.Int32
+	lastCallToolName   atomic.Value // string
+
+	callErr error // when set, CallTool returns it (e.g. vmcp.ErrAuthorizationFailed)
+}
+
+var _ core.VMCP = (*fakeCore)(nil)
+
+func (f *fakeCore) ListTools(context.Context, *auth.Identity) ([]vmcp.Tool, error) {
+	f.listToolsCalls.Add(1)
+	return f.tools, nil
+}
+
+func (f *fakeCore) CallTool(
+	_ context.Context, _ *auth.Identity, name string, _ map[string]any, _ map[string]any,
+) (*vmcp.ToolCallResult, error) {
+	f.callToolCalls.Add(1)
+	f.lastCallToolName.Store(name)
+	if f.callErr != nil {
+		return nil, f.callErr
+	}
+	return &vmcp.ToolCallResult{Content: []vmcp.Content{{Type: vmcp.ContentTypeText, Text: "ok"}}}, nil
+}
+
+func (f *fakeCore) ListResources(context.Context, *auth.Identity) ([]vmcp.Resource, error) {
+	f.listResourcesCalls.Add(1)
+	return f.resources, nil
+}
+
+func (*fakeCore) ReadResource(context.Context, *auth.Identity, string) (*vmcp.ResourceReadResult, error) {
+	return &vmcp.ResourceReadResult{}, nil
+}
+
+func (*fakeCore) ListPrompts(context.Context, *auth.Identity) ([]vmcp.Prompt, error) { return nil, nil }
+
+func (*fakeCore) GetPrompt(
+	context.Context, *auth.Identity, string, map[string]any,
+) (*vmcp.PromptGetResult, error) {
+	return &vmcp.PromptGetResult{}, nil
+}
+
+func (f *fakeCore) LookupTool(_ context.Context, _ *auth.Identity, name string) (*vmcp.Tool, error) {
+	for i := range f.tools {
+		if f.tools[i].Name == name {
+			tool := f.tools[i]
+			return &tool, nil
+		}
+	}
+	return nil, vmcp.ErrNotFound
+}
+
+func (f *fakeCore) LookupResource(_ context.Context, _ *auth.Identity, uri string) (*vmcp.Resource, error) {
+	for i := range f.resources {
+		if f.resources[i].URI == uri {
+			res := f.resources[i]
+			return &res, nil
+		}
+	}
+	return nil, vmcp.ErrNotFound
+}
+
+func (*fakeCore) LookupPrompt(context.Context, *auth.Identity, string) (*vmcp.Prompt, error) {
+	return nil, vmcp.ErrNotFound
+}
+
+func (*fakeCore) Close() error { return nil }
+
 // TestServeRegistersSessionHooks verifies that Serve registers the OnRegisterSession
 // hook and wires two-phase session creation: an MCP initialize triggers the hook,
-// which creates the session (MakeSessionWithID) and injects its tools, so a
-// subsequent tools/list advertises them. The OnBeforeListTools hook also runs (and
-// no-ops, since the tools are already present on this pod).
+// which creates the session record (MakeSessionWithID) and injects the core's advertised
+// tools, so a subsequent tools/list advertises them. The OnBeforeListTools hook also runs
+// (and no-ops, since the tools are already present on this pod). On the Serve path the
+// advertised set comes from the core, called exactly once at registration.
 func TestServeRegistersSessionHooks(t *testing.T) {
 	t.Parallel()
 
 	ctrl := gomock.NewController(t)
 	testTool := vmcp.Tool{Name: "serve-tool", Description: "a relocated-wiring test tool"}
 	factory, state := newToolSessionFactory(t, ctrl, []vmcp.Tool{testTool})
+	// The advertised set comes from the core, not the factory; the factory only
+	// establishes the bound session record.
+	fc := &fakeCore{tools: []vmcp.Tool{testTool}}
 
-	srv, err := Serve(context.Background(), &stubVMCP{}, &ServerConfig{
+	srv, err := Serve(context.Background(), fc, &ServerConfig{
 		SessionManagerConfig: &sessionmanager.FactoryConfig{Base: factory},
 		BackendRegistry:      vmcp.NewImmutableRegistry([]vmcp.Backend{}),
 	})
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = srv.Stop(context.Background()) })
 
-	// Mount the Streamable HTTP server on the relocated mcpServer + vmcpSessionMgr,
-	// bypassing the not-yet-relocated discovery middleware (#5442).
+	// Mount the Streamable HTTP server on the relocated mcpServer + vmcpSessionMgr.
+	// The discovery middleware is guarded off on the Serve path (s.core != nil), so
+	// the "/" MCP route is exercised here directly against the core-sourced session.
 	streamable := server.NewStreamableHTTPServer(
 		srv.mcpServer,
 		server.WithEndpointPath("/mcp"),
@@ -140,8 +226,14 @@ func TestServeRegistersSessionHooks(t *testing.T) {
 	require.Eventually(t, state.makeWithIDCalled.Load, 2*time.Second, 10*time.Millisecond,
 		"OnRegisterSession hook should have created the session via MakeSessionWithID")
 
+	// Source-of-truth (A3): the core's ListTools is the single aggregation, called
+	// exactly once at registration — not once per advertised tool, not re-run by the factory.
+	require.Eventually(t, func() bool { return fc.listToolsCalls.Load() == 1 }, 2*time.Second, 10*time.Millisecond,
+		"core.ListTools should be called exactly once per session at registration")
+
 	// tools/list runs the OnBeforeListTools hook and returns the per-session tools
-	// injected during registration.
+	// injected during registration (sourced from the core). It must not trigger another
+	// core aggregation — the set is fixed at initialize.
 	listResp := postServeMCP(t, ts.URL, map[string]any{
 		"jsonrpc": "2.0",
 		"id":      2,
@@ -154,7 +246,9 @@ func TestServeRegistersSessionHooks(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, listResp.StatusCode, "tools/list should succeed; body: %s", string(body))
 	assert.Contains(t, string(body), testTool.Name,
-		"tools/list should advertise the tool injected by the OnRegisterSession hook")
+		"tools/list should advertise the tool the core supplied at registration")
+	assert.Equal(t, int32(1), fc.listToolsCalls.Load(),
+		"tools/list must reuse the fixed-at-initialize set, not re-aggregate via the core")
 }
 
 // fakeSDKSession is a minimal server.ClientSession + server.SessionWithTools used to
@@ -189,8 +283,9 @@ func TestServeLazyInjectsToolsForRehydratedSession(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	testTool := vmcp.Tool{Name: "serve-tool", Description: "a relocated-wiring test tool"}
 	factory, _ := newToolSessionFactory(t, ctrl, []vmcp.Tool{testTool})
+	fc := &fakeCore{tools: []vmcp.Tool{testTool}}
 
-	srv, err := Serve(context.Background(), &stubVMCP{}, &ServerConfig{
+	srv, err := Serve(context.Background(), fc, &ServerConfig{
 		SessionManagerConfig: &sessionmanager.FactoryConfig{Base: factory},
 		BackendRegistry:      vmcp.NewImmutableRegistry([]vmcp.Backend{}),
 	})
@@ -332,6 +427,127 @@ func TestBuildSessionDataStorageRedis(t *testing.T) {
 	// error can't satisfy this test. ("redis" alone is unsuitable — the unsupported-
 	// provider error text also lists "redis".)
 	assert.ErrorContains(t, err, "redis: failed to connect")
+}
+
+// TestServeHandlerSkipsDiscoveryAndRoutesCallThroughCore drives the FULL shared
+// Handler (not the bare streamable server) against a Serve-built server. It proves
+// the discovery middleware is guarded off on the Serve path: a Serve-built server
+// has a nil discoveryMgr, so applying discovery would nil-deref — serving succeeds
+// only because s.core != nil skips it. It also proves a tools/call is routed through
+// core.CallTool with the advertised tool name.
+func TestServeHandlerSkipsDiscoveryAndRoutesCallThroughCore(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	testTool := vmcp.Tool{Name: "serve-tool", Description: "a Serve-path test tool"}
+	factory, _ := newToolSessionFactory(t, ctrl, []vmcp.Tool{testTool})
+	fc := &fakeCore{tools: []vmcp.Tool{testTool}}
+
+	srv, err := Serve(context.Background(), fc, &ServerConfig{
+		SessionManagerConfig: &sessionmanager.FactoryConfig{Base: factory},
+		BackendRegistry:      vmcp.NewImmutableRegistry([]vmcp.Backend{}),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = srv.Stop(context.Background()) })
+
+	// Build the full middleware chain + mux. On the Serve path this MUST NOT apply
+	// the discovery middleware (which would nil-deref on the nil discoveryMgr).
+	handler, err := srv.Handler(context.Background())
+	require.NoError(t, err)
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+
+	initResp := postServeMCP(t, ts.URL, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "initialize",
+		"params": map[string]any{
+			"protocolVersion": "2025-06-18",
+			"capabilities":    map[string]any{},
+			"clientInfo":      map[string]any{"name": "test", "version": "1.0"},
+		},
+	}, "")
+	defer initResp.Body.Close()
+	require.Equal(t, http.StatusOK, initResp.StatusCode,
+		"initialize should succeed through the full Handler (discovery middleware skipped on the Serve path)")
+	sessionID := initResp.Header.Get("Mcp-Session-Id")
+	require.NotEmpty(t, sessionID)
+
+	require.Eventually(t, func() bool { return fc.listToolsCalls.Load() >= 1 }, 2*time.Second, 10*time.Millisecond,
+		"OnRegisterSession should source the advertised set from the core")
+
+	callResp := postServeMCP(t, ts.URL, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      2,
+		"method":  "tools/call",
+		"params":  map[string]any{"name": "serve-tool", "arguments": map[string]any{}},
+	}, sessionID)
+	defer callResp.Body.Close()
+	body, err := io.ReadAll(callResp.Body)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, callResp.StatusCode, "tools/call should succeed; body: %s", string(body))
+
+	assert.Equal(t, int32(1), fc.callToolCalls.Load(), "tools/call must route through core.CallTool")
+	name, _ := fc.lastCallToolName.Load().(string)
+	assert.Equal(t, "serve-tool", name, "core.CallTool must receive the advertised tool name")
+	assert.Contains(t, string(body), "ok", "the core's tool result should reach the client")
+}
+
+// TestServeEnforcesSessionBinding verifies the Serve call path enforces the session's
+// identity binding (via the session layer) before reaching the core, even though calls
+// route through core.CallTool rather than the binding-enforcing MultiSession decorator.
+// The factory binds the session as anonymous, so a caller presenting a token is a
+// session-upgrade attack and must be rejected.
+func TestServeEnforcesSessionBinding(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	testTool := vmcp.Tool{Name: "serve-tool"}
+	factory, _ := newToolSessionFactory(t, ctrl, []vmcp.Tool{testTool})
+	fc := &fakeCore{tools: []vmcp.Tool{testTool}}
+
+	srv, err := Serve(context.Background(), fc, &ServerConfig{
+		SessionManagerConfig: &sessionmanager.FactoryConfig{Base: factory},
+		BackendRegistry:      vmcp.NewImmutableRegistry([]vmcp.Backend{}),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = srv.Stop(context.Background()) })
+
+	streamable := server.NewStreamableHTTPServer(
+		srv.mcpServer,
+		server.WithEndpointPath("/mcp"),
+		server.WithSessionIdManager(srv.vmcpSessionMgr),
+	)
+	ts := httptest.NewServer(streamable)
+	t.Cleanup(ts.Close)
+
+	initResp := postServeMCP(t, ts.URL, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "initialize",
+		"params": map[string]any{
+			"protocolVersion": "2025-06-18",
+			"capabilities":    map[string]any{},
+			"clientInfo":      map[string]any{"name": "test", "version": "1.0"},
+		},
+	}, "")
+	defer initResp.Body.Close()
+	require.Equal(t, http.StatusOK, initResp.StatusCode)
+	sessionID := initResp.Header.Get("Mcp-Session-Id")
+	require.NotEmpty(t, sessionID)
+
+	require.Eventually(t, func() bool { _, ok := srv.vmcpSessionMgr.GetMultiSession(sessionID); return ok },
+		2*time.Second, 10*time.Millisecond, "session should be registered")
+
+	// Anonymous caller (no token) matches the anonymous binding — allowed.
+	require.NoError(t, srv.enforceSessionBinding(sessionID, nil),
+		"anonymous caller must be permitted on an anonymous session")
+
+	// A caller presenting a token on an anonymous session is a session-upgrade attack.
+	err = srv.enforceSessionBinding(sessionID, &auth.Identity{Token: "attacker-token"})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, sessiontypes.ErrUnauthorizedCaller,
+		"a token presented to an anonymous session must be rejected by the session-layer binding check")
 }
 
 // postServeMCP sends a JSON-RPC POST to the given Streamable HTTP base URL. It is the

--- a/pkg/vmcp/server/serve_session_test.go
+++ b/pkg/vmcp/server/serve_session_test.go
@@ -7,6 +7,8 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -104,13 +106,17 @@ func newToolSessionFactory(
 type fakeCore struct {
 	tools     []vmcp.Tool
 	resources []vmcp.Resource
+	prompts   []vmcp.Prompt
 
 	listToolsCalls     atomic.Int32
 	listResourcesCalls atomic.Int32
 	callToolCalls      atomic.Int32
+	readResourceCalls  atomic.Int32
 	lastCallToolName   atomic.Value // string
+	lastReadURI        atomic.Value // string
 
 	callErr error // when set, CallTool returns it (e.g. vmcp.ErrAuthorizationFailed)
+	readErr error // when set, ReadResource returns it
 }
 
 var _ core.VMCP = (*fakeCore)(nil)
@@ -136,11 +142,18 @@ func (f *fakeCore) ListResources(context.Context, *auth.Identity) ([]vmcp.Resour
 	return f.resources, nil
 }
 
-func (*fakeCore) ReadResource(context.Context, *auth.Identity, string) (*vmcp.ResourceReadResult, error) {
-	return &vmcp.ResourceReadResult{}, nil
+func (f *fakeCore) ReadResource(_ context.Context, _ *auth.Identity, uri string) (*vmcp.ResourceReadResult, error) {
+	f.readResourceCalls.Add(1)
+	f.lastReadURI.Store(uri)
+	if f.readErr != nil {
+		return nil, f.readErr
+	}
+	return &vmcp.ResourceReadResult{Contents: []vmcp.ResourceContent{{URI: uri, Text: "resource-body"}}}, nil
 }
 
-func (*fakeCore) ListPrompts(context.Context, *auth.Identity) ([]vmcp.Prompt, error) { return nil, nil }
+func (f *fakeCore) ListPrompts(context.Context, *auth.Identity) ([]vmcp.Prompt, error) {
+	return f.prompts, nil
+}
 
 func (*fakeCore) GetPrompt(
 	context.Context, *auth.Identity, string, map[string]any,
@@ -551,6 +564,192 @@ func TestServeEnforcesSessionBinding(t *testing.T) {
 	require.Error(t, err)
 	assert.ErrorIs(t, err, sessiontypes.ErrUnauthorizedCaller,
 		"a token presented to an anonymous session must be rejected by the session-layer binding check")
+}
+
+// registerServeSession builds a Serve server backed by fc plus a mock session factory,
+// registers one anonymous session via the SDK initialize path, and returns the server,
+// the session ID, and the test HTTP base URL. The mock factory only establishes the
+// (anonymous-bound) session record; capabilities come from fc (the core).
+func registerServeSession(t *testing.T, fc *fakeCore) (*Server, string, string) {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	factory, _ := newToolSessionFactory(t, ctrl, fc.tools)
+
+	srv, err := Serve(context.Background(), fc, &ServerConfig{
+		SessionManagerConfig: &sessionmanager.FactoryConfig{Base: factory},
+		BackendRegistry:      vmcp.NewImmutableRegistry([]vmcp.Backend{}),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = srv.Stop(context.Background()) })
+
+	streamable := server.NewStreamableHTTPServer(
+		srv.mcpServer,
+		server.WithEndpointPath("/mcp"),
+		server.WithSessionIdManager(srv.vmcpSessionMgr),
+	)
+	ts := httptest.NewServer(streamable)
+	t.Cleanup(ts.Close)
+
+	initResp := postServeMCP(t, ts.URL, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "initialize",
+		"params": map[string]any{
+			"protocolVersion": "2025-06-18",
+			"capabilities":    map[string]any{},
+			"clientInfo":      map[string]any{"name": "test", "version": "1.0"},
+		},
+	}, "")
+	defer initResp.Body.Close()
+	require.Equal(t, http.StatusOK, initResp.StatusCode)
+	sessionID := initResp.Header.Get("Mcp-Session-Id")
+	require.NotEmpty(t, sessionID)
+	require.Eventually(t, func() bool { _, ok := srv.vmcpSessionMgr.GetMultiSession(sessionID); return ok },
+		2*time.Second, 10*time.Millisecond, "session should be registered")
+	return srv, sessionID, ts.URL
+}
+
+// TestServeCoreToolHandler exercises the Serve tool handler's error/denial branches by
+// invoking the handler closure directly against a registered (anonymous) session:
+// the happy path returns the core result; an ErrAuthorizationFailed is genericized so the
+// underlying authorizer detail never leaks; any other core error is forwarded; and a
+// non-map arguments payload is rejected before the core is reached.
+func TestServeCoreToolHandler(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		args            any
+		callErr         error
+		wantIsError     bool
+		wantContains    string
+		wantNotContains string
+		wantCoreCalled  bool
+	}{
+		{"happy path returns the core result", map[string]any{}, nil, false, "ok", "", true},
+		{
+			"authz denial is genericized", map[string]any{},
+			fmt.Errorf("%w: cedar said no", vmcp.ErrAuthorizationFailed), true,
+			"call denied by authorization policy", "cedar said no", true,
+		},
+		{"non-auth error is forwarded", map[string]any{}, errors.New("backend boom"), true, "backend boom", "", true},
+		{"non-map arguments rejected before the core", "not-an-object", nil, true, "invalid input", "", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			fc := &fakeCore{tools: []vmcp.Tool{{Name: "t"}}, callErr: tc.callErr}
+			srv, sessionID, _ := registerServeSession(t, fc)
+
+			req := mcp.CallToolRequest{Params: mcp.CallToolParams{Name: "t", Arguments: tc.args}}
+			res, err := srv.coreToolHandler(sessionID, "t")(context.Background(), req)
+			// Tool errors/denials surface as IsError results, not Go errors.
+			require.NoError(t, err)
+			require.NotNil(t, res)
+			assert.Equal(t, tc.wantIsError, res.IsError)
+
+			body, mErr := json.Marshal(res)
+			require.NoError(t, mErr)
+			assert.Contains(t, string(body), tc.wantContains)
+			if tc.wantNotContains != "" {
+				assert.NotContains(t, string(body), tc.wantNotContains,
+					"the underlying authorizer error must not leak to the client")
+			}
+
+			want := int32(0)
+			if tc.wantCoreCalled {
+				want = 1
+			}
+			assert.Equal(t, want, fc.callToolCalls.Load())
+		})
+	}
+}
+
+// TestServeToolCallTerminatesOnBindingFailure proves the documented fail-closed side
+// effect: a binding rejection on the Serve call path terminates the session and never
+// reaches the core. The session is anonymous, so a caller presenting a token is a
+// session-upgrade attack.
+func TestServeToolCallTerminatesOnBindingFailure(t *testing.T) {
+	t.Parallel()
+
+	fc := &fakeCore{tools: []vmcp.Tool{{Name: "t"}}}
+	srv, sessionID, _ := registerServeSession(t, fc)
+
+	ctx := auth.WithIdentity(context.Background(), &auth.Identity{Token: "attacker-token"})
+	req := mcp.CallToolRequest{Params: mcp.CallToolParams{Name: "t", Arguments: map[string]any{}}}
+	res, err := srv.coreToolHandler(sessionID, "t")(ctx, req)
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	assert.True(t, res.IsError)
+	body, _ := json.Marshal(res)
+	assert.Contains(t, string(body), "Unauthorized")
+	assert.Equal(t, int32(0), fc.callToolCalls.Load(), "core.CallTool must not be reached on a binding failure")
+
+	require.Eventually(t, func() bool { _, ok := srv.vmcpSessionMgr.GetMultiSession(sessionID); return !ok },
+		2*time.Second, 10*time.Millisecond, "a binding failure must terminate the session (fail-closed)")
+}
+
+// TestServeCoreResourceHandler covers the Serve resource path: the core's resource is
+// advertised by the registration builder, the handler routes a read through
+// core.ReadResource, and an ErrAuthorizationFailed is genericized.
+func TestServeCoreResourceHandler(t *testing.T) {
+	t.Parallel()
+
+	const uri = "file:///doc.txt"
+
+	t.Run("advertises and routes the resource through core.ReadResource", func(t *testing.T) {
+		t.Parallel()
+		fc := &fakeCore{resources: []vmcp.Resource{{Name: "doc", URI: uri}}}
+		srv, sessionID, _ := registerServeSession(t, fc)
+
+		resources, err := srv.coreSessionResources(context.Background(), sessionID, nil)
+		require.NoError(t, err)
+		require.Len(t, resources, 1)
+		assert.Equal(t, uri, resources[0].Resource.URI)
+
+		contents, err := srv.coreResourceHandler(sessionID, uri)(context.Background(), mcp.ReadResourceRequest{})
+		require.NoError(t, err)
+		require.NotEmpty(t, contents)
+		gotURI, _ := fc.lastReadURI.Load().(string)
+		assert.Equal(t, uri, gotURI, "the handler must route the read through core.ReadResource with the URI")
+	})
+
+	t.Run("authorization denial yields a generic message", func(t *testing.T) {
+		t.Parallel()
+		fc := &fakeCore{
+			resources: []vmcp.Resource{{Name: "doc", URI: uri}},
+			readErr:   fmt.Errorf("%w: cedar said no", vmcp.ErrAuthorizationFailed),
+		}
+		srv, sessionID, _ := registerServeSession(t, fc)
+
+		_, err := srv.coreResourceHandler(sessionID, uri)(context.Background(), mcp.ReadResourceRequest{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "read denied by authorization policy")
+		assert.NotContains(t, err.Error(), "cedar said no", "the underlying authorizer error must not leak")
+	})
+}
+
+// TestServeOmitsPrompts locks in the intentional prompt omission: even when the core
+// advertises a prompt, the Serve path injects only tools/resources (the SDK has no
+// per-session prompt support), so a prompts/list does not surface it.
+func TestServeOmitsPrompts(t *testing.T) {
+	t.Parallel()
+
+	const promptName = "serve-only-prompt"
+	fc := &fakeCore{prompts: []vmcp.Prompt{{Name: promptName}}}
+	_, sessionID, baseURL := registerServeSession(t, fc)
+
+	resp := postServeMCP(t, baseURL, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      2,
+		"method":  "prompts/list",
+		"params":  map[string]any{},
+	}, sessionID)
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.NotContains(t, string(body), promptName,
+		"the Serve path must not advertise prompts even when the core supplies them")
 }
 
 // postServeMCP sends a JSON-RPC POST to the given Streamable HTTP base URL. It is the

--- a/pkg/vmcp/server/serve_test.go
+++ b/pkg/vmcp/server/serve_test.go
@@ -25,9 +25,11 @@ import (
 	"github.com/stacklok/toolhive/pkg/vmcp/server/sessionmanager"
 )
 
-// stubVMCP is a no-op core.VMCP for Serve tests. The Serve skeleton never invokes
-// its capability methods; Close records invocation so the shutdown wiring can be
-// asserted.
+// stubVMCP is a no-op core.VMCP for Serve tests that do not drive the request
+// path (construction, config-mapping, and shutdown-wiring tests). Its capability
+// methods return empty; Close records invocation so the shutdown wiring can be
+// asserted. Tests that exercise session registration or request handling use the
+// configurable fakeCore (serve_session_test.go) instead.
 type stubVMCP struct {
 	closed bool
 }

--- a/pkg/vmcp/server/server.go
+++ b/pkg/vmcp/server/server.go
@@ -1130,6 +1130,13 @@ func (s *Server) lazyInjectSessionTools(ctx context.Context) {
 	// core.ListTools for the request identity (the core is stateless, so re-deriving on
 	// pod B is the cache-miss equivalent of the once-per-session registration call); on
 	// the legacy path it reads the factory-built session's tools via GetAdaptedTools.
+	//
+	// Note: on the Serve path this lists under the CURRENT request identity, not the
+	// session's bound identity. For the realistic same-principal load-balanced case they
+	// are equal, so the advertised set is identical across pods. A cross-identity re-hydration
+	// would advertise the requester's own filtered set, but the call-time binding check
+	// (enforceSessionBinding, run before core.CallTool/ReadResource) is the backstop — it
+	// rejects a mismatched caller, so no other principal's capabilities can be invoked.
 	adaptedTools, err := func() ([]server.ServerTool, error) {
 		if s.core != nil {
 			identity, _ := auth.IdentityFromContext(ctx)

--- a/pkg/vmcp/server/server.go
+++ b/pkg/vmcp/server/server.go
@@ -36,6 +36,7 @@ import (
 	"github.com/stacklok/toolhive/pkg/vmcp"
 	"github.com/stacklok/toolhive/pkg/vmcp/composer"
 	vmcpconfig "github.com/stacklok/toolhive/pkg/vmcp/config"
+	"github.com/stacklok/toolhive/pkg/vmcp/core"
 	"github.com/stacklok/toolhive/pkg/vmcp/discovery"
 	"github.com/stacklok/toolhive/pkg/vmcp/health"
 	"github.com/stacklok/toolhive/pkg/vmcp/internal/backendtelemetry"
@@ -195,6 +196,16 @@ type Config struct {
 // Server is the Virtual MCP Server that aggregates multiple backends.
 type Server struct {
 	config *Config
+
+	// core is the domain VMCP, set only on the Serve path (nil on the legacy
+	// server.New path). When non-nil it is the single source of truth for the
+	// advertised capability set and call routing: session registration sources
+	// tools/resources from core.ListTools/ListResources, request handlers
+	// delegate to core.CallTool/ReadResource, and the discovery middleware +
+	// context-based audit enrichment are guarded off (the core applies the
+	// admission filter the legacy authz/discovery path applied). The nil/non-nil
+	// value is the branch selector throughout this file ("s.core == nil" == legacy).
+	core core.VMCP
 
 	// MCP protocol server (mark3labs/mcp-go)
 	mcpServer *server.MCPServer
@@ -631,25 +642,35 @@ func (s *Server) Handler(_ context.Context) (http.Handler, error) {
 		slog.Info("annotation enrichment middleware enabled for MCP endpoints")
 	}
 
-	// Apply discovery middleware (runs after audit/auth middleware)
-	// Discovery middleware performs per-request capability aggregation with user context.
+	// Apply discovery middleware (runs after audit/auth middleware) — legacy path only.
+	// Discovery middleware performs per-request capability aggregation with user context,
+	// injecting the routing table into the request context (the discovery-into-context seam).
 	// vmcpSessionMgr (MultiSessionGetter) is used to retrieve the fully-formed MultiSession
 	// for subsequent requests so the routing table can be injected into context.
 	// The backend registry provides a dynamic backend list (supports DynamicRegistry for K8s).
 	// The health monitor enables filtering based on current health status (respects circuit breaker).
-	s.healthMonitorMu.RLock()
-	healthMon := s.healthMonitor
-	s.healthMonitorMu.RUnlock()
+	//
+	// Guarded to the legacy server.New path (s.core == nil). On the Serve path the core is
+	// the single source of truth: session registration aggregates once via core.ListTools and
+	// handlers route through the core (#5442), so discovery is skipped — applying it would
+	// also nil-deref, since a Serve-built server has a nil discoveryMgr. WithSessionScopedRouting's
+	// initialize-skip behavior is preserved here on the legacy path; physical removal of the
+	// middleware and the context seam is deferred to Phase 3 (#5445).
+	if s.core == nil {
+		s.healthMonitorMu.RLock()
+		healthMon := s.healthMonitor
+		s.healthMonitorMu.RUnlock()
 
-	var healthStatusProvider health.StatusProvider
-	if healthMon != nil {
-		healthStatusProvider = healthMon
+		var healthStatusProvider health.StatusProvider
+		if healthMon != nil {
+			healthStatusProvider = healthMon
+		}
+		mcpHandler = discovery.Middleware(
+			s.discoveryMgr, s.backendRegistry, s.vmcpSessionMgr, healthStatusProvider,
+			discovery.WithSessionScopedRouting(),
+		)(mcpHandler)
+		slog.Info("discovery middleware enabled for lazy per-user capability discovery")
 	}
-	mcpHandler = discovery.Middleware(
-		s.discoveryMgr, s.backendRegistry, s.vmcpSessionMgr, healthStatusProvider,
-		discovery.WithSessionScopedRouting(),
-	)(mcpHandler)
-	slog.Info("discovery middleware enabled for lazy per-user capability discovery")
 
 	// Apply audit middleware if configured (runs after auth, before discovery)
 	if s.config.AuditConfig != nil {
@@ -1103,7 +1124,19 @@ func (s *Server) lazyInjectSessionTools(ctx context.Context) {
 		return // tools already registered (normal pod-local case)
 	}
 	sessionID := sess.SessionID()
-	adaptedTools, err := s.vmcpSessionMgr.GetAdaptedTools(sessionID)
+
+	// Re-derive the tool set the same way registration did, so cross-pod re-injection
+	// matches the advertised set. On the Serve path (s.core != nil) that means a fresh
+	// core.ListTools for the request identity (the core is stateless, so re-deriving on
+	// pod B is the cache-miss equivalent of the once-per-session registration call); on
+	// the legacy path it reads the factory-built session's tools via GetAdaptedTools.
+	adaptedTools, err := func() ([]server.ServerTool, error) {
+		if s.core != nil {
+			identity, _ := auth.IdentityFromContext(ctx)
+			return s.coreSessionTools(ctx, sessionID, identity)
+		}
+		return s.vmcpSessionMgr.GetAdaptedTools(sessionID)
+	}()
 	if err != nil || len(adaptedTools) == 0 {
 		slog.Debug("lazyInjectSessionTools: no tools available for session", "session_id", sessionID)
 		return
@@ -1177,8 +1210,19 @@ func (s *Server) handleSessionRegistrationImpl(ctx context.Context, session serv
 		return retErr
 	}
 
-	// Uniform registration — same code path regardless of which decorators are active.
-	// session.Tools() returns the final decorated tool list.
+	// Serve path: the core is the single authoritative aggregation. Source the
+	// advertised tool/resource set from core.ListTools/ListResources (called once
+	// per session here) and install handlers that route through the core; the
+	// session factory's own aggregation is not used. CreateSession above still
+	// establishes the bound session record (identity binding, TTL, Validate). The
+	// returned error becomes retErr (named return), so the defer terminates the
+	// session on failure.
+	if s.core != nil {
+		return s.injectCoreSessionCapabilities(ctx, session)
+	}
+
+	// Legacy server.New path: uniform registration — same code path regardless of
+	// which decorators are active. session.Tools() returns the final decorated tool list.
 	adaptedTools, retErr := s.vmcpSessionMgr.GetAdaptedTools(sessionID)
 	if retErr != nil {
 		slog.Error("failed to get session-scoped tools",

--- a/pkg/vmcp/session/internal/security/security.go
+++ b/pkg/vmcp/session/internal/security/security.go
@@ -104,17 +104,39 @@ func extractBindingID(identity *auth.Identity) (string, error) {
 }
 
 // validateCaller checks the caller against the session's bound identity.
+// It delegates to the free-function validateCallerBinding so the same audited
+// logic backs both the decorator path and the exported [ValidateCaller] seam.
+func (d sessionBindingDecorator) validateCaller(caller *auth.Identity) error {
+	return validateCallerBinding(d.boundIdentity, d.allowAnonymous, caller)
+}
+
+// ValidateCaller checks caller against a stored identity-binding string (the
+// value persisted under MetadataKeyIdentityBinding). It reproduces the
+// decorator's per-request check for call paths that do not go through the
+// [sessionBindingDecorator] — notably the Serve transport path, where the
+// advertised set and call routing are owned by the core but identity binding
+// must still be enforced by the session layer.
+//
+// allowAnonymous is derived from storedBinding: an anonymous session stores the
+// UnauthenticatedSentinel, so IsUnauthenticated(storedBinding) is exactly the
+// allowAnonymous flag BindSession recorded (BindSession writes the sentinel iff
+// ShouldAllowAnonymous(identity)).
+func ValidateCaller(storedBinding string, caller *auth.Identity) error {
+	return validateCallerBinding(storedBinding, binding.IsUnauthenticated(storedBinding), caller)
+}
+
+// validateCallerBinding checks caller against a bound identity.
 //
 // Returns:
-//   - ErrSessionOwnerUnknown when the decorator was constructed with neither
-//     an anonymous marker nor a real binding (programming error).
+//   - ErrSessionOwnerUnknown when neither an anonymous marker nor a real binding
+//     is present (programming error / corrupted metadata).
 //   - ErrNilCaller when a bound session receives nil.
 //   - ErrUnauthorizedCaller when:
 //   - an anonymous session receives a caller presenting a token (upgrade attack),
 //   - the caller's identity binding does not match the session's bound identity.
-func (d sessionBindingDecorator) validateCaller(caller *auth.Identity) error {
+func validateCallerBinding(boundIdentity string, allowAnonymous bool, caller *auth.Identity) error {
 	// Anonymous path: sessions that were created without a bound identity.
-	if d.allowAnonymous && binding.IsUnauthenticated(d.boundIdentity) {
+	if allowAnonymous && binding.IsUnauthenticated(boundIdentity) {
 		// Prevent session upgrade attack: anonymous sessions cannot accept tokens.
 		if caller != nil && caller.Token != "" {
 			slog.Warn("identity binding validation failed: session upgrade attack prevented",
@@ -136,8 +158,8 @@ func (d sessionBindingDecorator) validateCaller(caller *auth.Identity) error {
 	// Defensive check: the stored binding must be parsable. An unparsable value
 	// means the session was misconfigured at construction time — fail closed
 	// rather than accepting or rejecting based on garbage state.
-	if !binding.IsUnauthenticated(d.boundIdentity) {
-		if _, _, ok := binding.Parse(d.boundIdentity); !ok {
+	if !binding.IsUnauthenticated(boundIdentity) {
+		if _, _, ok := binding.Parse(boundIdentity); !ok {
 			slog.Error("identity binding validation failed: stored binding is not parsable",
 				"reason", "misconfigured_session",
 			)
@@ -159,7 +181,7 @@ func (d sessionBindingDecorator) validateCaller(caller *auth.Identity) error {
 	// length mismatch. Leaking binding length is acceptable: iss is the OIDC
 	// issuer (public, in the discovery document) and sub is an opaque
 	// identifier whose length is typically per-issuer. Neither is secret.
-	if subtle.ConstantTimeCompare([]byte(d.boundIdentity), []byte(callerBinding)) != 1 {
+	if subtle.ConstantTimeCompare([]byte(boundIdentity), []byte(callerBinding)) != 1 {
 		slog.Warn("identity binding validation failed: identity binding mismatch",
 			"reason", "identity_binding_mismatch",
 		)

--- a/pkg/vmcp/session/internal/security/validate_caller_test.go
+++ b/pkg/vmcp/session/internal/security/validate_caller_test.go
@@ -15,12 +15,15 @@ import (
 	sessiontypes "github.com/stacklok/toolhive/pkg/vmcp/session/types"
 )
 
-// boundIdentity builds an authenticated identity carrying the given (iss, sub) claims.
-func boundIdentity(token, iss, sub string) *auth.Identity {
+// testIssuer is the fixed OIDC issuer used to build test identities/bindings.
+const testIssuer = "https://idp.example"
+
+// boundIdentity builds an authenticated identity carrying the testIssuer/sub claims.
+func boundIdentity(token, sub string) *auth.Identity {
 	return &auth.Identity{
 		Token: token,
 		PrincipalInfo: auth.PrincipalInfo{
-			Claims: map[string]any{"iss": iss, "sub": sub},
+			Claims: map[string]any{"iss": testIssuer, "sub": sub},
 		},
 	}
 }
@@ -33,8 +36,8 @@ func boundIdentity(token, iss, sub string) *auth.Identity {
 func TestValidateCaller(t *testing.T) {
 	t.Parallel()
 
-	const iss, sub = "https://idp.example", "user-42"
-	bound, err := binding.Format(iss, sub)
+	const sub = "user-42"
+	bound, err := binding.Format(testIssuer, sub)
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -43,12 +46,17 @@ func TestValidateCaller(t *testing.T) {
 		caller        *auth.Identity
 		wantErr       error
 	}{
-		{"authenticated match (refreshed token, same identity)", bound, boundIdentity("AT2", iss, sub), nil},
-		{"authenticated mismatch", bound, boundIdentity("AT", iss, "someone-else"), sessiontypes.ErrUnauthorizedCaller},
+		{"authenticated match (refreshed token, same identity)", bound, boundIdentity("AT2", sub), nil},
+		{"authenticated mismatch", bound, boundIdentity("AT", "someone-else"), sessiontypes.ErrUnauthorizedCaller},
 		{"authenticated nil caller", bound, nil, sessiontypes.ErrNilCaller},
 		{"anonymous nil caller", binding.UnauthenticatedSentinel, nil, nil},
 		{"anonymous caller without token", binding.UnauthenticatedSentinel, &auth.Identity{}, nil},
 		{"anonymous upgrade attack", binding.UnauthenticatedSentinel, &auth.Identity{Token: "tok"}, sessiontypes.ErrUnauthorizedCaller},
+		// Fail-closed on corrupted metadata: a non-sentinel binding that does not parse
+		// (empty string, or a value with no NUL separator) must reject, never be treated
+		// as anonymous. This is the only binding check on the Serve call path.
+		{"empty binding fails closed", "", boundIdentity("AT", sub), sessiontypes.ErrSessionOwnerUnknown},
+		{"unparsable binding fails closed", "garbage-no-separator", boundIdentity("AT", sub), sessiontypes.ErrSessionOwnerUnknown},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/vmcp/session/internal/security/validate_caller_test.go
+++ b/pkg/vmcp/session/internal/security/validate_caller_test.go
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package security_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stacklok/toolhive/pkg/auth"
+	"github.com/stacklok/toolhive/pkg/vmcp/session/binding"
+	"github.com/stacklok/toolhive/pkg/vmcp/session/internal/security"
+	sessiontypes "github.com/stacklok/toolhive/pkg/vmcp/session/types"
+)
+
+// boundIdentity builds an authenticated identity carrying the given (iss, sub) claims.
+func boundIdentity(token, iss, sub string) *auth.Identity {
+	return &auth.Identity{
+		Token: token,
+		PrincipalInfo: auth.PrincipalInfo{
+			Claims: map[string]any{"iss": iss, "sub": sub},
+		},
+	}
+}
+
+// TestValidateCaller covers the exported binding-validation seam used by call paths
+// that do not flow through the BindSession decorator (the Serve transport path). It
+// verifies that allowAnonymous is derived correctly from the stored binding string:
+// the sentinel admits anonymous callers and rejects token-upgrade attacks, while a
+// real binding requires a matching (iss, sub) caller.
+func TestValidateCaller(t *testing.T) {
+	t.Parallel()
+
+	const iss, sub = "https://idp.example", "user-42"
+	bound, err := binding.Format(iss, sub)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name          string
+		storedBinding string
+		caller        *auth.Identity
+		wantErr       error
+	}{
+		{"authenticated match (refreshed token, same identity)", bound, boundIdentity("AT2", iss, sub), nil},
+		{"authenticated mismatch", bound, boundIdentity("AT", iss, "someone-else"), sessiontypes.ErrUnauthorizedCaller},
+		{"authenticated nil caller", bound, nil, sessiontypes.ErrNilCaller},
+		{"anonymous nil caller", binding.UnauthenticatedSentinel, nil, nil},
+		{"anonymous caller without token", binding.UnauthenticatedSentinel, &auth.Identity{}, nil},
+		{"anonymous upgrade attack", binding.UnauthenticatedSentinel, &auth.Identity{Token: "tok"}, sessiontypes.ErrUnauthorizedCaller},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := security.ValidateCaller(tc.storedBinding, tc.caller)
+			if tc.wantErr == nil {
+				assert.NoError(t, err)
+				return
+			}
+			assert.ErrorIs(t, err, tc.wantErr)
+		})
+	}
+}

--- a/pkg/vmcp/session/session.go
+++ b/pkg/vmcp/session/session.go
@@ -4,12 +4,32 @@
 package session
 
 import (
+	"github.com/stacklok/toolhive/pkg/auth"
+	"github.com/stacklok/toolhive/pkg/vmcp/session/internal/security"
 	sessiontypes "github.com/stacklok/toolhive/pkg/vmcp/session/types"
 )
 
 // MultiSession is an alias for sessiontypes.MultiSession, re-exported here for
 // backward compatibility and convenience.
 type MultiSession = sessiontypes.MultiSession
+
+// ValidateCaller checks caller against a stored identity-binding string (the
+// value persisted under MetadataKeyIdentityBinding) and returns nil when the
+// caller is permitted, or ErrNilCaller / ErrUnauthorizedCaller / ErrSessionOwnerUnknown
+// otherwise.
+//
+// It exposes the session layer's hijack-prevention check (normally applied by
+// the BindSession decorator on MultiSession.CallTool) for call paths that do
+// not flow through that decorator. The Serve transport path uses it: there the
+// advertised set and call routing are owned by the core, but identity binding
+// must still be enforced by the session layer before a request reaches the core.
+//
+// The audited implementation lives in the internal security package, which only
+// packages under pkg/vmcp/session may import; this is the exported seam for
+// callers outside that subtree (e.g. pkg/vmcp/server).
+func ValidateCaller(storedBinding string, caller *auth.Identity) error {
+	return security.ValidateCaller(storedBinding, caller)
+}
 
 // Re-exports from the types package for convenience. See the types package for
 // authoritative documentation.


### PR DESCRIPTION
## Summary

P2.4 of the vMCP core-extraction epic (parent story #5431, epic #5419). On the `Serve`
path the core VMCP is now the single authoritative, admission-filtered source of truth
for the advertised capability set and call routing. Capability aggregation must therefore
stop flowing through the discovery-into-context middleware, which applies no admission and
would bypass authorization now that authz lives in the core admission seam (#5438).

This PR wires the `Serve` path through the core's explicit-identity methods and guards the
legacy discovery path to `server.New` only:

- Store the injected core on `*Server`; the `s.core == nil` / `s.core != nil` value is the
  branch selector for legacy vs. Serve throughout the server. The discovery middleware is
  guarded to the legacy path (`s.core == nil`), left intact rather than deleted — physical
  removal is Phase 3 (#5445).
- Source session capabilities from `core.ListTools` / `core.ListResources` once at
  `OnRegisterSession`; route tool/resource invocations through `core.CallTool` /
  `core.ReadResource` with an explicit `*auth.Identity` (new `serve_handlers.go`).
- Enforce identity binding on the core call path via a new exported
  `session.ValidateCaller` seam (audited check stays in
  `pkg/vmcp/session/internal/security`). Requests reach the core directly, bypassing the
  `BindSession` decorator, so this is the sole binding-enforcement point on the Serve path.
- Resolve Serve-path audit backend enrichment from `Tool.BackendID` → `backend.Name` via
  `core.LookupTool` + the registry, for parity with the legacy path's `WorkloadName`. The
  legacy context-based enrichment path is unchanged.

Closes #5442

## Type of change

- [x] Refactoring (no behavior change)

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)
- [x] Manual testing (describe below)

`task build` passes. Changed-package unit tests pass under the race detector:
`go test -race ./pkg/vmcp/server/... ./pkg/vmcp/session/...`, including the new Serve-path
tests: discovery-guard branch coverage, `tools/call` routed through the core, the
once-per-session core call, identity-binding enforcement on the call path, audit-enrichment
parity (`BackendName` resolved from `BackendID`), and `ValidateCaller` fail-closed cases.

`task lint-fix` is clean except a pre-existing, unrelated gosec G115 in
`cmd/thv/app/upgrade.go` (untouched by this PR).

Note on `task test`: two unrelated environment failures, neither touched by this PR —
Docker-dependent tests ("no available runtime") and the flaky `TestTransparentProxy_*`
tests in `pkg/transport/proxy/transparent` (pass in isolation). The packages this PR
changes pass.

## Changes

| File | Change |
|------|--------|
| `pkg/vmcp/server/serve_handlers.go` | New. Serve-path capability wiring: `injectCoreSessionCapabilities` sources tools/resources from the core once per session; `coreToolHandler` / `coreResourceHandler` route through `core.CallTool` / `core.ReadResource`; `enforceSessionBinding` is the sole identity-binding check on the Serve call path. |
| `pkg/vmcp/server/server.go` | Store `core` on `*Server`; guard the discovery middleware application to `s.core == nil`; branch `handleSessionRegistrationImpl` and `lazyInjectSessionTools` (cross-pod re-injection) onto the core on the Serve path. |
| `pkg/vmcp/server/backend_enrichment.go` | Serve-path audit enrichment resolves the backend via `core.LookupTool` / `LookupResource` / `LookupPrompt` and `Tool.BackendID`, then maps to `backend.Name` via the registry. Legacy context-based resolution unchanged. |
| `pkg/vmcp/server/serve.go` | Assign the injected core to `srv.core`; update the `Serve` contract docs (the "/" MCP route is now serveable because the shared Handler skips discovery when `s.core != nil`). |
| `pkg/vmcp/session/session.go` | New exported `ValidateCaller` seam delegating to the internal security package. |
| `pkg/vmcp/session/internal/security/security.go` | Extract `validateCallerBinding` free function so the same audited check backs both the decorator and the exported `ValidateCaller`. |

## Does this introduce a user-facing change?

No. The legacy `server.New` path is unchanged; the Serve path is not yet routed in
production (no composition root until a later phase).

## Implementation plan

<details>
<summary>Approved implementation plan</summary>

The issue's literal AC2 prescribes feeding `core.ListTools` into the session factory as
the `ProcessPreQueriedCapabilities` input. Planning analysis found this infeasible:

- `ProcessPreQueriedCapabilities` takes **per-backend raw tools**, while `core.ListTools`
  returns a **flat, already-aggregated** slice.
- The flat slice drops `BackendTarget.OriginalCapabilityName`, which the factory needs for
  backend-name translation.

The approved alternative ("C1"), discussed with and approved by the issue author/owner
before implementation:

1. **Core-sourced advertising.** Use the core's output directly as the SDK session's
   fixed-at-initialize capability set; the factory does not re-aggregate on the Serve path.
   `core.ListTools` / `core.ListResources` are called once per session at
   `OnRegisterSession`.
2. **Core-routed calls.** Install SDK handlers that route `tools/call` / `resources/read`
   through `core.CallTool` / `core.ReadResource` with an explicit `*auth.Identity` read at
   the transport boundary (never from context inside the core).
3. **Discovery guard.** Wrap the discovery-middleware application in `if s.core == nil`,
   leaving the middleware, `handleSubsequentRequest`, and the context seam in place for the
   legacy path. Physical removal is deferred to Phase 3 (#5445).
4. **Audit enrichment via `LookupTool`.** Derive the backend from `Tool.BackendID` (via the
   core's admission-filtered `Lookup*`) → `backend.Name` via the registry, matching the
   legacy `WorkloadName`. This re-aggregates per audited request; documented and deferred
   per anti-pattern #9 (no production composition root yet).
5. **`ValidateCaller` binding seam.** Add an exported `session.ValidateCaller` so the Serve
   path can enforce identity binding without the `BindSession` decorator; the audited check
   stays in `pkg/vmcp/session/internal/security`.

</details>

## Special notes for reviewers

- **AC2 was implemented via an approved alternative, not literally.** The issue's AC2 asks
  for `core.ListTools` to feed the factory as the `ProcessPreQueriedCapabilities` input.
  That is infeasible: `ProcessPreQueriedCapabilities` consumes per-backend raw tools, but
  `core.ListTools` returns a flat aggregated slice, and that flat slice drops
  `BackendTarget.OriginalCapabilityName` needed for backend-name translation. So the core's
  output is used directly as the SDK session's fixed-at-initialize set and the factory does
  not re-aggregate on the Serve path. This was discussed with and approved by the issue
  author/owner before implementation.
- **Audit-enrichment re-aggregation is a known, deferred cost.** `LookupTool` re-aggregates
  per audited request (the core is intentionally stateless). This is documented inline and
  deferred per vMCP anti-pattern #9 (optimize with evidence): the Serve path has no
  production composition root yet. The fix when the path goes live is a per-session
  advertised-set cache ("Serve caches, core is stateless").
- **`enforceSessionBinding` fails closed in two ways** — a missing session record and an
  empty/unparsable binding both reject the caller, and any rejection terminates the session.
  This is intentionally stricter than the legacy `GetAdaptedTools` handler.
- **Scope:** the discovery middleware, `handleSubsequentRequest` injection, and the
  `DiscoveredCapabilities` context seam are deliberately left in place for the legacy path;
  physical removal is Phase 3 (#5445). `server.New`'s signature and observable behavior are
  unchanged.
- This PR went through two review rounds (1 HIGH + 2 MEDIUM, then 2 MEDIUM + 2 LOW), all
  addressed; the final review pass found 0 critical/high/medium findings.


## Large PR Justification

The production change is small and cohesive: a single logical refactor (route the Serve path through the core VMCP), ~255 lines of non-comment code across 6 source files — within the ≤400 LOC / ≤10 file guideline.

The ~1085-line total is dominated by:
- **Tests (594 lines):** Serve-path handler coverage (tool/resource handlers, binding enforcement, fail-closed cases, prompts omission, audit enrichment) added per code-review feedback. Splitting these from the code they cover would reduce reviewability.
- **Architectural doc comments:** this is the Phase 2 join point of the core-extraction epic; the comments capture non-obvious contracts (AC2 single-aggregation, the C1 deviation from the literal spec, the binding seam) for future maintainers.

Per CONTRIBUTING/CLAUDE.md, large PRs are acceptable for test-heavy changes. This is one atomic refactor that should not be split from its tests.
