### PR TITLE
Carry RateLimitMiddleware through vMCP buildServeConfig

### DIFF
--- a/pkg/vmcp/server/serve.go
+++ b/pkg/vmcp/server/serve.go
@@ -69,6 +69,10 @@ type ServerConfig struct {
 	// If nil, no authentication is required.
 	AuthMiddleware func(http.Handler) http.Handler
 
+	// RateLimitMiddleware is the optional rate-limit middleware to apply after
+	// authentication and MCP request parsing.
+	RateLimitMiddleware func(http.Handler) http.Handler
+
 	// AuthInfoHandler is the optional handler for the
 	// /.well-known/oauth-protected-resource endpoint.
 	AuthInfoHandler http.Handler
@@ -302,6 +306,7 @@ func buildServeConfig(cfg *ServerConfig) *Config {
 		EndpointPath:            cmp.Or(cfg.EndpointPath, defaultEndpointPath),
 		SessionTTL:              cmp.Or(cfg.SessionTTL, defaultSessionTTL),
 		AuthMiddleware:          cfg.AuthMiddleware,
+		RateLimitMiddleware:     cfg.RateLimitMiddleware,
 		AuthInfoHandler:         cfg.AuthInfoHandler,
 		AuthServer:              cfg.AuthServer,
 		TelemetryProvider:       cfg.TelemetryProvider,

--- a/pkg/vmcp/server/serve_test.go
+++ b/pkg/vmcp/server/serve_test.go
@@ -347,6 +347,7 @@ func TestBuildServeConfigMapsSharedFields(t *testing.T) {
 		EndpointPath:            "/e",
 		SessionTTL:              time.Second,
 		AuthMiddleware:          func(h http.Handler) http.Handler { return h },
+		RateLimitMiddleware:     func(h http.Handler) http.Handler { return h },
 		AuthInfoHandler:         http.NewServeMux(),
 		AuthServer:              &asrunner.EmbeddedAuthServer{},
 		HealthMonitor:           &health.Monitor{},


### PR DESCRIPTION
## Summary

`main` is currently red: `TestBuildServeConfigMapsSharedFields` fails with `Config.RateLimitMiddleware was not populated by buildServeConfig` (see the `run-on-main` failure on `8da9029d`).

#5276 added `Config.RateLimitMiddleware` and wired it on the `New`/`Config` path (`pkg/vmcp/cli/serve.go`), but the parallel `Serve`/`ServerConfig` migration API was not extended: `ServerConfig` had no `RateLimitMiddleware` field and `buildServeConfig` did not map it. The field-completeness test (which exists precisely to catch a dropped mapping during the ServerConfig→Config migration) therefore fails, and the Serve path would silently drop rate limiting.

<details>
<summary><strong>Medium level</strong></summary>

- Add `RateLimitMiddleware func(http.Handler) http.Handler` to `ServerConfig` (mirrors the existing field on `Config`).
- Map it in `buildServeConfig` (`RateLimitMiddleware: cfg.RateLimitMiddleware`).
- Set it in `TestBuildServeConfigMapsSharedFields`'s source config so a future dropped mapping keeps failing the test.

</details>

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

## Test plan

- [x] `task test` / `go test ./pkg/vmcp/server/...` passes (`TestBuildServeConfigMapsSharedFields` now green; full package green with `-race`)
- [x] `task build` passes
- [x] `task lint-fix` clean

## Special notes for reviewers

Production rate limiting already works via the `New`/`Config` path; this only completes the Serve-path migration helper so the field isn't dropped when call sites move to `Serve(ServerConfig)`. Unblocks `main` (and PR #5492, which picked up the breakage via a branch update).

Generated with [Claude Code](https://claude.com/claude-code)