### PR TITLE
Cover Serve-path lifecycle for AS runner, status, optimizer, health

### DIFF
--- a/pkg/vmcp/server/serve.go
+++ b/pkg/vmcp/server/serve.go
@@ -165,11 +165,16 @@ type ServerConfig struct {
 // admission seam (#5438). The injected core is stored on the *Server, which makes the
 // "/" MCP route serveable: the shared Handler guards the discovery middleware to the
 // legacy path (s.core == nil), and on the Serve path session registration and request
-// handlers call the core directly (#5442). The remaining transport concern — the AS
-// runner / status reporter / optimizer / health monitor lifecycle (#5443) — is
-// relocated under Serve by the next Phase 2 task. server.New is not yet routed through
-// Serve and keeps its own copy of the session wiring until Phase 3, so this is purely
-// additive and observable behavior is unchanged.
+// handlers call the core directly (#5442). The last transport subsystems — the embedded
+// AS runner routes, the status reporter (and its periodic goroutine), the optimizer
+// cleanup, and the health monitor's Start/Stop (#5443) — are driven from the
+// carried-forward shared (*Server).Handler/Start/Stop using the fields Serve populates
+// from ServerConfig below. Serve does NOT construct the health monitor: it receives the
+// pre-built *health.Monitor via ServerConfig (nil ⇒ disabled) and owns only its
+// lifecycle, while the composition root injects the same instance into the core as a
+// health.StatusProvider. server.New is not yet routed through Serve and keeps its own
+// copy of the session wiring until Phase 3, so this is purely additive and observable
+// behavior is unchanged.
 //
 // Serve returns a vmcp.ErrInvalidConfig-wrapped error for a nil cfg, a nil core, or a
 // nil required collaborator (SessionManagerConfig or BackendRegistry). The session
@@ -180,8 +185,9 @@ type ServerConfig struct {
 // but a nil discovery manager, router, and backend client — the request path goes
 // through the core, so those legacy collaborators are unused on the Serve path. The
 // shared Handler skips the discovery middleware when s.core != nil, so serving the "/"
-// MCP route no longer nil-derefs. The AS runner / status reporter / optimizer / health
-// monitor lifecycle is still wired by #5443.
+// MCP route no longer nil-derefs. The embedded AS runner routes, the status reporter,
+// the optimizer cleanup, and the health monitor's Start/Stop are driven from the shared
+// Handler/Start/Stop via the fields Serve populates from ServerConfig (#5443).
 func Serve(ctx context.Context, v core.VMCP, cfg *ServerConfig) (*Server, error) {
 	if cfg == nil {
 		return nil, fmt.Errorf("%w: nil server config", vmcp.ErrInvalidConfig)

--- a/pkg/vmcp/server/serve_lifecycle_test.go
+++ b/pkg/vmcp/server/serve_lifecycle_test.go
@@ -5,6 +5,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -30,11 +31,17 @@ import (
 // status_reporting_test.go, and server_test.go). server.New behavior is unchanged.
 
 // startServeInBackground starts srv on a fresh cancelable context and waits for it to
-// become ready, failing fast on early error or timeout. It returns the cancel func and
-// the error channel carrying Start's eventual return value (Start blocks until the
-// context is cancelled, then returns Stop's result). Mirrors the start/ready dance the
-// New-path lifecycle tests use.
-func startServeInBackground(t *testing.T, srv *Server) (context.CancelFunc, <-chan error) {
+// become ready, failing fast on early error or timeout. It returns an idempotent stop
+// function that cancels the server and waits for Start to return, yielding Start's result
+// (Stop's error) so callers can assert a clean shutdown with require.NoError(t, stop()).
+//
+// stop is also registered with t.Cleanup, so the Start goroutine and the bound HTTP
+// listener are always torn down even when a mid-test require aborts via runtime.Goexit
+// before the test reaches its explicit stop (testing.md: tie resource teardown for a
+// started server in a parallel test to t.Cleanup, not to a code path a failing require can
+// skip). The sync.Once lets the explicit call and the cleanup safety net coexist without
+// double-draining errCh.
+func startServeInBackground(t *testing.T, srv *Server) (stop func() error) {
 	t.Helper()
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -50,20 +57,22 @@ func startServeInBackground(t *testing.T, srv *Server) (context.CancelFunc, <-ch
 		cancel()
 		t.Fatal("timeout waiting for server to become ready")
 	}
-	return cancel, errCh
-}
 
-// stopAndWait cancels the server and waits for Start to return, asserting a clean stop.
-func stopAndWait(t *testing.T, cancel context.CancelFunc, errCh <-chan error) {
-	t.Helper()
-
-	cancel()
-	select {
-	case err := <-errCh:
-		require.NoError(t, err)
-	case <-time.After(2 * time.Second):
-		t.Fatal("timeout waiting for server to stop")
+	var once sync.Once
+	var stopErr error
+	stop = func() error {
+		once.Do(func() {
+			cancel()
+			select {
+			case stopErr = <-errCh:
+			case <-time.After(2 * time.Second):
+				stopErr = errors.New("timeout waiting for server to stop")
+			}
+		})
+		return stopErr
 	}
+	t.Cleanup(func() { _ = stop() })
+	return stop
 }
 
 // TestServeHealthMonitorDisabledWhenNil verifies that a nil ServerConfig.HealthMonitor
@@ -122,14 +131,14 @@ func TestServeStartsAndStopsInjectedHealthMonitor(t *testing.T) {
 	// call health.NewMonitor).
 	assert.Same(t, mon, srv.healthMonitor)
 
-	cancel, errCh := startServeInBackground(t, srv)
+	stop := startServeInBackground(t, srv)
 
 	require.Eventually(t, func() bool {
 		status, statusErr := srv.GetBackendHealthStatus("backend-1")
 		return statusErr == nil && status == vmcp.BackendHealthy
 	}, 2*time.Second, 10*time.Millisecond, "backend-1 should become healthy via the Serve-started monitor")
 
-	stopAndWait(t, cancel, errCh)
+	require.NoError(t, stop())
 
 	// The monitor is stopped but the struct is retained (pointer stays valid).
 	srv.healthMonitorMu.RLock()
@@ -168,7 +177,7 @@ func TestServeDisablesHealthMonitorOnStartFailure(t *testing.T) {
 	srv, err := Serve(context.Background(), &stubVMCP{}, cfg)
 	require.NoError(t, err)
 
-	cancel, errCh := startServeInBackground(t, srv)
+	stop := startServeInBackground(t, srv)
 
 	// Start must not fail; the un-restartable monitor is disabled (set to nil) instead.
 	require.Eventually(t, func() bool {
@@ -180,7 +189,7 @@ func TestServeDisablesHealthMonitorOnStartFailure(t *testing.T) {
 	_, getErr := srv.GetBackendHealthStatus("backend-1")
 	assert.ErrorContains(t, getErr, "health monitoring is disabled")
 
-	stopAndWait(t, cancel, errCh)
+	require.NoError(t, stop())
 }
 
 // recordingReporter is a vmcpstatus.Reporter that records whether Start and its returned
@@ -233,24 +242,29 @@ func TestServeStartsAndStopsStatusReporter(t *testing.T) {
 	srv, err := Serve(context.Background(), &stubVMCP{}, cfg)
 	require.NoError(t, err)
 
-	cancel, errCh := startServeInBackground(t, srv)
+	stop := startServeInBackground(t, srv)
 
 	require.Eventually(t, func() bool {
 		started, _, count := reporter.snapshot()
 		return started && count >= 1
 	}, 2*time.Second, 10*time.Millisecond, "Start must run the reporter and emit at least one status report")
 
-	stopAndWait(t, cancel, errCh)
+	require.NoError(t, stop())
 
 	_, shutdownCalled, _ := reporter.snapshot()
 	assert.True(t, shutdownCalled, "the status reporter shutdown func must run on Stop via shutdownFuncs")
 }
 
-// TestServeStopClosesOptimizerStore verifies that the optimizer cleanup returned by
-// sessionmanager.New is appended to shutdownFuncs on the Serve path and runs cleanly on
-// Stop. Mirrors the New-path TestServerStopClosesOptimizerStore: an empty optimizer
-// config builds a (shared in-memory) SQLite store whose Close runs during shutdown.
-func TestServeStopClosesOptimizerStore(t *testing.T) {
+// TestServeWithOptimizerStartsAndStopsCleanly exercises the optimizer-configured Serve
+// path end to end: a non-nil OptimizerConfig drives sessionmanager.New into building a
+// real SQLite-backed optimizer factory whose cleanup (store.Close, not the no-op) Serve
+// appends to shutdownFuncs, and Start/Stop runs that construct→teardown path without
+// error. The cleanup's store.Close is internal to sessionmanager/optimizer, so it is not
+// observed here (asserting it would reach across the package boundary, see testing.md
+// "Test Scope"); that shutdownFuncs are drained on Stop is proven observably by
+// TestServeStopClosesCore. This test guards that configuring an optimizer does not break
+// Serve construction or shutdown — which the no-optimizer path would not exercise.
+func TestServeWithOptimizerStartsAndStopsCleanly(t *testing.T) {
 	t.Parallel()
 
 	cfg := testMinimalServeConfig()
@@ -262,10 +276,8 @@ func TestServeStopClosesOptimizerStore(t *testing.T) {
 	srv, err := Serve(context.Background(), &stubVMCP{}, cfg)
 	require.NoError(t, err)
 
-	cancel, errCh := startServeInBackground(t, srv)
-
-	// Stop must drain shutdownFuncs (including the optimizer store cleanup) without error.
-	stopAndWait(t, cancel, errCh)
+	stop := startServeInBackground(t, srv)
+	require.NoError(t, stop())
 }
 
 // TestServeWiresAuthServerIntoConfig verifies the embedded AS runner wiring on the Serve

--- a/pkg/vmcp/server/serve_lifecycle_test.go
+++ b/pkg/vmcp/server/serve_lifecycle_test.go
@@ -1,0 +1,291 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package server
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	asrunner "github.com/stacklok/toolhive/pkg/authserver/runner"
+	"github.com/stacklok/toolhive/pkg/vmcp"
+	"github.com/stacklok/toolhive/pkg/vmcp/health"
+	"github.com/stacklok/toolhive/pkg/vmcp/mocks"
+	"github.com/stacklok/toolhive/pkg/vmcp/optimizer"
+	"github.com/stacklok/toolhive/pkg/vmcp/server/sessionmanager"
+)
+
+// This file covers the four transport subsystems relocated under Serve in #5443:
+// the embedded AS runner routes, the status reporter (+ its periodic goroutine), the
+// optimizer cleanup, and the health monitor's Start/Stop. The wiring itself lives in
+// ServerConfig and the carried-forward shared (*Server).Handler/Start/Stop; these tests
+// prove a Serve-built *Server drives each subsystem's lifecycle the same way the
+// server.New path does (whose New-path coverage lives in health_monitoring_test.go,
+// status_reporting_test.go, and server_test.go). server.New behavior is unchanged.
+
+// startServeInBackground starts srv on a fresh cancelable context and waits for it to
+// become ready, failing fast on early error or timeout. It returns the cancel func and
+// the error channel carrying Start's eventual return value (Start blocks until the
+// context is cancelled, then returns Stop's result). Mirrors the start/ready dance the
+// New-path lifecycle tests use.
+func startServeInBackground(t *testing.T, srv *Server) (context.CancelFunc, <-chan error) {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() { errCh <- srv.Start(ctx) }()
+
+	select {
+	case <-srv.Ready():
+	case err := <-errCh:
+		cancel()
+		t.Fatalf("server failed to start: %v", err)
+	case <-time.After(2 * time.Second):
+		cancel()
+		t.Fatal("timeout waiting for server to become ready")
+	}
+	return cancel, errCh
+}
+
+// stopAndWait cancels the server and waits for Start to return, asserting a clean stop.
+func stopAndWait(t *testing.T, cancel context.CancelFunc, errCh <-chan error) {
+	t.Helper()
+
+	cancel()
+	select {
+	case err := <-errCh:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for server to stop")
+	}
+}
+
+// TestServeHealthMonitorDisabledWhenNil verifies that a nil ServerConfig.HealthMonitor
+// leaves monitoring disabled on the Serve path: Serve stores no monitor and the getters
+// report "disabled" without error, matching the no-monitor behavior of server.New.
+func TestServeHealthMonitorDisabledWhenNil(t *testing.T) {
+	t.Parallel()
+
+	srv, err := Serve(context.Background(), &stubVMCP{}, testMinimalServeConfig())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = srv.Stop(context.Background()) })
+
+	assert.Nil(t, srv.healthMonitor, "nil ServerConfig.HealthMonitor must leave the monitor unset")
+
+	status, err := srv.GetBackendHealthStatus("backend-1")
+	require.Error(t, err)
+	assert.Equal(t, vmcp.BackendUnknown, status)
+	assert.Contains(t, err.Error(), "health monitoring is disabled")
+
+	assert.Equal(t, health.Summary{}, srv.GetHealthSummary())
+}
+
+// TestServeStartsAndStopsInjectedHealthMonitor verifies the health-monitor lifecycle on
+// the Serve path: Serve stores the pre-built *health.Monitor it is given (it does NOT
+// construct one), Start runs it (backends report healthy), and Stop stops it while
+// retaining the struct so getters keep working — mirroring TestServer_Stop_StopsHealthMonitor
+// for a monitor Serve was handed rather than one it built.
+func TestServeStartsAndStopsInjectedHealthMonitor(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	mockBackendClient := mocks.NewMockBackendClient(ctrl)
+	mockBackendClient.EXPECT().
+		ListCapabilities(gomock.Any(), gomock.Any()).
+		Return(&vmcp.CapabilityList{}, nil).
+		AnyTimes()
+
+	backends := []vmcp.Backend{
+		{ID: "backend-1", Name: "Backend 1", BaseURL: "http://localhost:8080", TransportType: "sse"},
+	}
+	mon, err := health.NewMonitor(mockBackendClient, backends, health.MonitorConfig{
+		CheckInterval:      50 * time.Millisecond,
+		UnhealthyThreshold: 1,
+		Timeout:            5 * time.Second,
+	})
+	require.NoError(t, err)
+
+	cfg := testMinimalServeConfig()
+	cfg.HealthMonitor = mon
+	cfg.BackendRegistry = vmcp.NewImmutableRegistry(backends)
+
+	srv, err := Serve(context.Background(), &stubVMCP{}, cfg)
+	require.NoError(t, err)
+
+	// Serve must reuse the injected instance, not build a new one (AC2: Serve does not
+	// call health.NewMonitor).
+	assert.Same(t, mon, srv.healthMonitor)
+
+	cancel, errCh := startServeInBackground(t, srv)
+
+	require.Eventually(t, func() bool {
+		status, statusErr := srv.GetBackendHealthStatus("backend-1")
+		return statusErr == nil && status == vmcp.BackendHealthy
+	}, 2*time.Second, 10*time.Millisecond, "backend-1 should become healthy via the Serve-started monitor")
+
+	stopAndWait(t, cancel, errCh)
+
+	// The monitor is stopped but the struct is retained (pointer stays valid).
+	srv.healthMonitorMu.RLock()
+	assert.Same(t, mon, srv.healthMonitor, "health monitor should still exist after Stop")
+	srv.healthMonitorMu.RUnlock()
+
+	status, err := srv.GetBackendHealthStatus("backend-1")
+	assert.NoError(t, err, "getter should not error after Stop")
+	assert.NotEqual(t, vmcp.BackendUnknown, status, "should return last known status")
+}
+
+// TestServeDisablesHealthMonitorOnStartFailure verifies graceful degradation when the
+// injected monitor cannot start: Start logs a WARN and sets healthMonitor to nil so the
+// getters report "disabled", and Serve.Start itself does not fail. The failure is forced
+// with a monitor that has already been stopped — health.Monitor.Start refuses to restart.
+func TestServeDisablesHealthMonitorOnStartFailure(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	mockBackendClient := mocks.NewMockBackendClient(ctrl)
+
+	// No backends => Start spawns no health-check goroutines (ListCapabilities is never
+	// called) and Stop returns immediately, leaving the monitor in the "stopped" state.
+	mon, err := health.NewMonitor(mockBackendClient, nil, health.MonitorConfig{
+		CheckInterval:      time.Second,
+		UnhealthyThreshold: 1,
+		Timeout:            time.Second,
+	})
+	require.NoError(t, err)
+	require.NoError(t, mon.Start(context.Background()))
+	require.NoError(t, mon.Stop())
+
+	cfg := testMinimalServeConfig()
+	cfg.HealthMonitor = mon
+
+	srv, err := Serve(context.Background(), &stubVMCP{}, cfg)
+	require.NoError(t, err)
+
+	cancel, errCh := startServeInBackground(t, srv)
+
+	// Start must not fail; the un-restartable monitor is disabled (set to nil) instead.
+	require.Eventually(t, func() bool {
+		srv.healthMonitorMu.RLock()
+		defer srv.healthMonitorMu.RUnlock()
+		return srv.healthMonitor == nil
+	}, 2*time.Second, 10*time.Millisecond, "a monitor whose Start fails must be disabled")
+
+	_, getErr := srv.GetBackendHealthStatus("backend-1")
+	assert.ErrorContains(t, getErr, "health monitoring is disabled")
+
+	stopAndWait(t, cancel, errCh)
+}
+
+// recordingReporter is a vmcpstatus.Reporter that records whether Start and its returned
+// shutdown func ran and counts ReportStatus calls, so the status-reporter lifecycle can
+// be asserted on the Serve path.
+type recordingReporter struct {
+	mu             sync.Mutex
+	started        bool
+	shutdownCalled bool
+	reportCount    int
+}
+
+func (r *recordingReporter) Start(context.Context) (func(context.Context) error, error) {
+	r.mu.Lock()
+	r.started = true
+	r.mu.Unlock()
+	return func(context.Context) error {
+		r.mu.Lock()
+		r.shutdownCalled = true
+		r.mu.Unlock()
+		return nil
+	}, nil
+}
+
+func (r *recordingReporter) ReportStatus(context.Context, *vmcp.Status) error {
+	r.mu.Lock()
+	r.reportCount++
+	r.mu.Unlock()
+	return nil
+}
+
+func (r *recordingReporter) snapshot() (started, shutdownCalled bool, reportCount int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.started, r.shutdownCalled, r.reportCount
+}
+
+// TestServeStartsAndStopsStatusReporter verifies the status-reporter lifecycle on the
+// Serve path: Start invokes ServerConfig.StatusReporter.Start, launches
+// periodicStatusReporting (at least one report fires), and appends the reporter shutdown
+// + the goroutine cancel to shutdownFuncs so both run on Stop.
+func TestServeStartsAndStopsStatusReporter(t *testing.T) {
+	t.Parallel()
+
+	reporter := &recordingReporter{}
+	cfg := testMinimalServeConfig()
+	cfg.StatusReporter = reporter
+	cfg.StatusReportingInterval = 20 * time.Millisecond
+
+	srv, err := Serve(context.Background(), &stubVMCP{}, cfg)
+	require.NoError(t, err)
+
+	cancel, errCh := startServeInBackground(t, srv)
+
+	require.Eventually(t, func() bool {
+		started, _, count := reporter.snapshot()
+		return started && count >= 1
+	}, 2*time.Second, 10*time.Millisecond, "Start must run the reporter and emit at least one status report")
+
+	stopAndWait(t, cancel, errCh)
+
+	_, shutdownCalled, _ := reporter.snapshot()
+	assert.True(t, shutdownCalled, "the status reporter shutdown func must run on Stop via shutdownFuncs")
+}
+
+// TestServeStopClosesOptimizerStore verifies that the optimizer cleanup returned by
+// sessionmanager.New is appended to shutdownFuncs on the Serve path and runs cleanly on
+// Stop. Mirrors the New-path TestServerStopClosesOptimizerStore: an empty optimizer
+// config builds a (shared in-memory) SQLite store whose Close runs during shutdown.
+func TestServeStopClosesOptimizerStore(t *testing.T) {
+	t.Parallel()
+
+	cfg := testMinimalServeConfig()
+	cfg.SessionManagerConfig = &sessionmanager.FactoryConfig{
+		Base:            testMinimalFactory(),
+		OptimizerConfig: &optimizer.Config{},
+	}
+
+	srv, err := Serve(context.Background(), &stubVMCP{}, cfg)
+	require.NoError(t, err)
+
+	cancel, errCh := startServeInBackground(t, srv)
+
+	// Stop must drain shutdownFuncs (including the optimizer store cleanup) without error.
+	stopAndWait(t, cancel, errCh)
+}
+
+// TestServeWiresAuthServerIntoConfig verifies the embedded AS runner wiring on the Serve
+// path: Serve carries ServerConfig.AuthServer into the *Config the shared Handler reads,
+// where `if s.config.AuthServer != nil { RegisterHandlers(mux) }` registers the routes.
+// The RegisterHandlers code path itself is covered by TestRegisterHandlers in
+// pkg/authserver/runner — the concrete *EmbeddedAuthServer cannot be meaningfully
+// constructed here (see the note in server_test.go), so this asserts the Serve-specific
+// mapping with a zero-value instance rather than building the route mux.
+func TestServeWiresAuthServerIntoConfig(t *testing.T) {
+	t.Parallel()
+
+	as := &asrunner.EmbeddedAuthServer{}
+	cfg := testMinimalServeConfig()
+	cfg.AuthServer = as
+
+	srv, err := Serve(context.Background(), &stubVMCP{}, cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = srv.Stop(context.Background()) })
+
+	assert.Same(t, as, srv.config.AuthServer,
+		"Serve must carry ServerConfig.AuthServer into the Config the shared Handler registers routes from")
+}


### PR DESCRIPTION
## Summary

This is the final Phase 2 relocation of the vMCP `New`/`Serve` split (epic #5419,
story #5431). It makes the four remaining transport subsystems — the embedded
authorization-server (AS) runner routes, the status reporter and its periodic
goroutine, the optimizer cleanup, and the health monitor's `Start`/`Stop`
lifecycle — run under `Serve`'s orchestration.

The production wiring was already in place: the `ServerConfig` fields and
struct-literal wiring for all four landed with the `Serve` skeleton in #5439, and
the carried-forward shared `(*Server).Handler`/`Start`/`Stop` drive their lifecycles
for any `Serve`-built server once #5442 made the `Serve` path serveable. So this
task is intentionally a near-no-op for production — exactly like sibling task
#5441 — and its deliverable is **Serve-path test coverage** that proves a
`Serve`-built `*Server` drives each subsystem, plus syncing the now-stale #5443 doc
comments. `server.New`'s signature and observable behavior are unchanged, and the
shared `Stop` teardown order is untouched.

`Serve` still does **not** construct the `health.Monitor`: it receives the pre-built
`*health.Monitor` via `ServerConfig` (nil ⇒ disabled) and owns only its lifecycle,
while the composition root injects the same instance into the core as a
`health.StatusProvider`.

- **Add `pkg/vmcp/server/serve_lifecycle_test.go`** — 6 Serve-path lifecycle tests:
  health monitor disabled-when-nil; started + stopped (asserting the injected
  instance is reused, never reconstructed — AC2); start-failure graceful degradation
  (disabled, not fatal); status reporter started + its shutdown run via
  `shutdownFuncs` on `Stop`; optimizer-configured path constructs and tears down
  cleanly; `AuthServer` carried into the `Config` the shared `Handler` reads.
- **Sync two stale #5443 doc comments in `pkg/vmcp/server/serve.go`** — from future
  tense ("relocated by the next Phase 2 task") to present (the subsystems are driven
  from the shared `Handler`/`Start`/`Stop` via the fields `Serve` populates).

Closes #5443

## Type of change

- [x] Other (describe): Test coverage + doc-comment sync (no production logic change)

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)
- [x] Manual testing (describe below)

`task test` exits 0 (full suite green, including the previously Docker-gated
`TestBuildServerConfig`). The 6 new tests were additionally verified under the race
detector via `go test -race ./pkg/vmcp/server/...`. `task lint-fix` is clean for the
changed files (the lone pre-existing `cmd/thv/app/upgrade.go` G115 finding is on
`main` and unrelated to this PR).

## Does this introduce a user-facing change?

No.

## Implementation plan

<details>
<summary>Approved implementation plan</summary>

Issue #5443 relocates the last four transport lifecycle concerns under `Serve`'s
`Start`/`Stop` orchestration. The production-side wiring (the `ServerConfig` fields,
the struct-literal wiring, and the shared `Handler`/`Start`/`Stop`) already landed
across #5439 and #5442, so the in-scope deliverable here is the Serve-path test
coverage that proves it, mirroring how sibling task #5441 was a near-no-op + tests.

Plan:
1. Add `serve_lifecycle_test.go` exercising a `Serve`-built `*Server` against each of
   the four subsystems via the observable boundary (`Start`/`Ready`/`Stop` and the
   public getters), reusing the existing minimal-Serve-config test helpers.
2. Health monitor: cover disabled-when-nil, start+stop (asserting `assert.Same` on the
   injected `*health.Monitor` to prove AC2 — `Serve` never calls `health.NewMonitor`),
   and start-failure graceful degradation (monitor disabled, `Serve.Start` not fatal).
3. Status reporter: a recording `Reporter` stub asserts `Start` ran, at least one
   periodic report fired, and the returned shutdown func ran on `Stop` via
   `shutdownFuncs`.
4. Optimizer: a non-nil `OptimizerConfig` drives a real SQLite-backed factory; assert
   clean construct→teardown (the internal `store.Close` is cross-referenced to
   `TestServeStopClosesCore` for the observable `shutdownFuncs`-drain proof).
5. AS runner: assert the `ServerConfig` → `Config` mapping the shared `Handler` reads,
   rather than constructing an `EmbeddedAuthServer` (deliberately avoided in this
   package; `RegisterHandlers` itself is covered in `pkg/authserver/runner`).
6. Sync the two stale #5443 doc comments in `serve.go` to present tense.
7. Verify: `task test`, `go test -race ./pkg/vmcp/server/...`, `task lint-fix`.

Developed and reviewed via the dev workflow over 2 review rounds; round 2 by a fresh
reviewer returned 0 CRITICAL / HIGH / MEDIUM findings.

</details>

## Special notes for reviewers

1. **Near-no-op for production.** The production wiring for these four subsystems
   landed in #5439 (and the `Serve` path was made serveable by #5442, merged via
   #5491); this PR adds the Serve-path coverage that proves it, mirroring how #5441
   was a near-no-op + tests.
2. **AS-runner coverage** asserts the `ServerConfig` → `Config` mapping rather than
   constructing an `EmbeddedAuthServer` — the codebase deliberately avoids building one
   here (see the note in `server_test.go`); `RegisterHandlers` itself is covered by
   `pkg/authserver/runner`.
3. **Optimizer cleanup's `store.Close`** is internal to `sessionmanager`; the test
   asserts clean construct + teardown and cross-references `TestServeStopClosesCore`
   for the observable `shutdownFuncs`-drain proof.
