### PR TITLE
Use compound listMapKey on sibling config statuses

### DIFF
--- a/cmd/thv-operator/api/v1beta1/mcpexternalauthconfig_types.go
+++ b/cmd/thv-operator/api/v1beta1/mcpexternalauthconfig_types.go
@@ -1290,8 +1290,12 @@ type MCPExternalAuthConfigStatus struct {
 	ReferenceCount int32 `json:"referenceCount,omitempty"`
 
 	// ReferencingWorkloads is a list of workload resources that reference this MCPExternalAuthConfig.
-	// Each entry identifies the workload by kind and name.
+	// Each entry identifies the workload by kind and name. The map key is the
+	// (kind, name) pair so two workloads of different kinds that share a name
+	// (e.g., an MCPServer "foo" and a VirtualMCPServer "foo") are distinct
+	// entries rather than colliding under merge-patch semantics.
 	// +listType=map
+	// +listMapKey=kind
 	// +listMapKey=name
 	// +optional
 	ReferencingWorkloads []WorkloadReference `json:"referencingWorkloads,omitempty"`

--- a/cmd/thv-operator/api/v1beta1/mcpoidcconfig_types.go
+++ b/cmd/thv-operator/api/v1beta1/mcpoidcconfig_types.go
@@ -190,8 +190,12 @@ type MCPOIDCConfigStatus struct {
 	ReferenceCount int32 `json:"referenceCount,omitempty"`
 
 	// ReferencingWorkloads is a list of workload resources that reference this MCPOIDCConfig.
-	// Each entry identifies the workload by kind and name.
+	// Each entry identifies the workload by kind and name. The map key is the
+	// (kind, name) pair so two workloads of different kinds that share a name
+	// (e.g., an MCPServer "foo" and a VirtualMCPServer "foo") are distinct
+	// entries rather than colliding under merge-patch semantics.
 	// +listType=map
+	// +listMapKey=kind
 	// +listMapKey=name
 	// +optional
 	ReferencingWorkloads []WorkloadReference `json:"referencingWorkloads,omitempty"`

--- a/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpexternalauthconfigs.yaml
+++ b/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpexternalauthconfigs.yaml
@@ -1432,7 +1432,10 @@ spec:
               referencingWorkloads:
                 description: |-
                   ReferencingWorkloads is a list of workload resources that reference this MCPExternalAuthConfig.
-                  Each entry identifies the workload by kind and name.
+                  Each entry identifies the workload by kind and name. The map key is the
+                  (kind, name) pair so two workloads of different kinds that share a name
+                  (e.g., an MCPServer "foo" and a VirtualMCPServer "foo") are distinct
+                  entries rather than colliding under merge-patch semantics.
                 items:
                   description: |-
                     WorkloadReference identifies a workload that references a shared configuration resource.
@@ -1455,6 +1458,7 @@ spec:
                   type: object
                 type: array
                 x-kubernetes-list-map-keys:
+                - kind
                 - name
                 x-kubernetes-list-type: map
             type: object
@@ -2875,7 +2879,10 @@ spec:
               referencingWorkloads:
                 description: |-
                   ReferencingWorkloads is a list of workload resources that reference this MCPExternalAuthConfig.
-                  Each entry identifies the workload by kind and name.
+                  Each entry identifies the workload by kind and name. The map key is the
+                  (kind, name) pair so two workloads of different kinds that share a name
+                  (e.g., an MCPServer "foo" and a VirtualMCPServer "foo") are distinct
+                  entries rather than colliding under merge-patch semantics.
                 items:
                   description: |-
                     WorkloadReference identifies a workload that references a shared configuration resource.
@@ -2898,6 +2905,7 @@ spec:
                   type: object
                 type: array
                 x-kubernetes-list-map-keys:
+                - kind
                 - name
                 x-kubernetes-list-type: map
             type: object

--- a/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpoidcconfigs.yaml
+++ b/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpoidcconfigs.yaml
@@ -289,7 +289,10 @@ spec:
               referencingWorkloads:
                 description: |-
                   ReferencingWorkloads is a list of workload resources that reference this MCPOIDCConfig.
-                  Each entry identifies the workload by kind and name.
+                  Each entry identifies the workload by kind and name. The map key is the
+                  (kind, name) pair so two workloads of different kinds that share a name
+                  (e.g., an MCPServer "foo" and a VirtualMCPServer "foo") are distinct
+                  entries rather than colliding under merge-patch semantics.
                 items:
                   description: |-
                     WorkloadReference identifies a workload that references a shared configuration resource.
@@ -312,6 +315,7 @@ spec:
                   type: object
                 type: array
                 x-kubernetes-list-map-keys:
+                - kind
                 - name
                 x-kubernetes-list-type: map
             type: object
@@ -590,7 +594,10 @@ spec:
               referencingWorkloads:
                 description: |-
                   ReferencingWorkloads is a list of workload resources that reference this MCPOIDCConfig.
-                  Each entry identifies the workload by kind and name.
+                  Each entry identifies the workload by kind and name. The map key is the
+                  (kind, name) pair so two workloads of different kinds that share a name
+                  (e.g., an MCPServer "foo" and a VirtualMCPServer "foo") are distinct
+                  entries rather than colliding under merge-patch semantics.
                 items:
                   description: |-
                     WorkloadReference identifies a workload that references a shared configuration resource.
@@ -613,6 +620,7 @@ spec:
                   type: object
                 type: array
                 x-kubernetes-list-map-keys:
+                - kind
                 - name
                 x-kubernetes-list-type: map
             type: object

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpexternalauthconfigs.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpexternalauthconfigs.yaml
@@ -1435,7 +1435,10 @@ spec:
               referencingWorkloads:
                 description: |-
                   ReferencingWorkloads is a list of workload resources that reference this MCPExternalAuthConfig.
-                  Each entry identifies the workload by kind and name.
+                  Each entry identifies the workload by kind and name. The map key is the
+                  (kind, name) pair so two workloads of different kinds that share a name
+                  (e.g., an MCPServer "foo" and a VirtualMCPServer "foo") are distinct
+                  entries rather than colliding under merge-patch semantics.
                 items:
                   description: |-
                     WorkloadReference identifies a workload that references a shared configuration resource.
@@ -1458,6 +1461,7 @@ spec:
                   type: object
                 type: array
                 x-kubernetes-list-map-keys:
+                - kind
                 - name
                 x-kubernetes-list-type: map
             type: object
@@ -2878,7 +2882,10 @@ spec:
               referencingWorkloads:
                 description: |-
                   ReferencingWorkloads is a list of workload resources that reference this MCPExternalAuthConfig.
-                  Each entry identifies the workload by kind and name.
+                  Each entry identifies the workload by kind and name. The map key is the
+                  (kind, name) pair so two workloads of different kinds that share a name
+                  (e.g., an MCPServer "foo" and a VirtualMCPServer "foo") are distinct
+                  entries rather than colliding under merge-patch semantics.
                 items:
                   description: |-
                     WorkloadReference identifies a workload that references a shared configuration resource.
@@ -2901,6 +2908,7 @@ spec:
                   type: object
                 type: array
                 x-kubernetes-list-map-keys:
+                - kind
                 - name
                 x-kubernetes-list-type: map
             type: object

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpoidcconfigs.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpoidcconfigs.yaml
@@ -292,7 +292,10 @@ spec:
               referencingWorkloads:
                 description: |-
                   ReferencingWorkloads is a list of workload resources that reference this MCPOIDCConfig.
-                  Each entry identifies the workload by kind and name.
+                  Each entry identifies the workload by kind and name. The map key is the
+                  (kind, name) pair so two workloads of different kinds that share a name
+                  (e.g., an MCPServer "foo" and a VirtualMCPServer "foo") are distinct
+                  entries rather than colliding under merge-patch semantics.
                 items:
                   description: |-
                     WorkloadReference identifies a workload that references a shared configuration resource.
@@ -315,6 +318,7 @@ spec:
                   type: object
                 type: array
                 x-kubernetes-list-map-keys:
+                - kind
                 - name
                 x-kubernetes-list-type: map
             type: object
@@ -593,7 +597,10 @@ spec:
               referencingWorkloads:
                 description: |-
                   ReferencingWorkloads is a list of workload resources that reference this MCPOIDCConfig.
-                  Each entry identifies the workload by kind and name.
+                  Each entry identifies the workload by kind and name. The map key is the
+                  (kind, name) pair so two workloads of different kinds that share a name
+                  (e.g., an MCPServer "foo" and a VirtualMCPServer "foo") are distinct
+                  entries rather than colliding under merge-patch semantics.
                 items:
                   description: |-
                     WorkloadReference identifies a workload that references a shared configuration resource.
@@ -616,6 +623,7 @@ spec:
                   type: object
                 type: array
                 x-kubernetes-list-map-keys:
+                - kind
                 - name
                 x-kubernetes-list-type: map
             type: object

--- a/docs/operator/crd-api.md
+++ b/docs/operator/crd-api.md
@@ -1833,7 +1833,7 @@ _Appears in:_
 | `observedGeneration` _integer_ | ObservedGeneration is the most recent generation observed for this MCPExternalAuthConfig.<br />It corresponds to the MCPExternalAuthConfig's generation, which is updated on mutation by the API Server. |  | Optional: \{\} <br /> |
 | `configHash` _string_ | ConfigHash is a hash of the current configuration for change detection |  | Optional: \{\} <br /> |
 | `referenceCount` _integer_ | ReferenceCount is the number of workloads referencing this config. |  | Optional: \{\} <br /> |
-| `referencingWorkloads` _[api.v1beta1.WorkloadReference](#apiv1beta1workloadreference) array_ | ReferencingWorkloads is a list of workload resources that reference this MCPExternalAuthConfig.<br />Each entry identifies the workload by kind and name. |  | Optional: \{\} <br /> |
+| `referencingWorkloads` _[api.v1beta1.WorkloadReference](#apiv1beta1workloadreference) array_ | ReferencingWorkloads is a list of workload resources that reference this MCPExternalAuthConfig.<br />Each entry identifies the workload by kind and name. The map key is the<br />(kind, name) pair so two workloads of different kinds that share a name<br />(e.g., an MCPServer "foo" and a VirtualMCPServer "foo") are distinct<br />entries rather than colliding under merge-patch semantics. |  | Optional: \{\} <br /> |
 
 
 #### api.v1beta1.MCPGroup
@@ -2078,7 +2078,7 @@ _Appears in:_
 | `observedGeneration` _integer_ | ObservedGeneration is the most recent generation observed for this MCPOIDCConfig. |  | Optional: \{\} <br /> |
 | `configHash` _string_ | ConfigHash is a hash of the current configuration for change detection |  | Optional: \{\} <br /> |
 | `referenceCount` _integer_ | ReferenceCount is the number of workloads referencing this config. |  | Optional: \{\} <br /> |
-| `referencingWorkloads` _[api.v1beta1.WorkloadReference](#apiv1beta1workloadreference) array_ | ReferencingWorkloads is a list of workload resources that reference this MCPOIDCConfig.<br />Each entry identifies the workload by kind and name. |  | Optional: \{\} <br /> |
+| `referencingWorkloads` _[api.v1beta1.WorkloadReference](#apiv1beta1workloadreference) array_ | ReferencingWorkloads is a list of workload resources that reference this MCPOIDCConfig.<br />Each entry identifies the workload by kind and name. The map key is the<br />(kind, name) pair so two workloads of different kinds that share a name<br />(e.g., an MCPServer "foo" and a VirtualMCPServer "foo") are distinct<br />entries rather than colliding under merge-patch semantics. |  | Optional: \{\} <br /> |
 
 
 #### api.v1beta1.MCPRegistry


### PR DESCRIPTION
## Summary

In #4777, `MCPAuthzConfigStatus.ReferencingWorkloads` was changed from a single `+listMapKey=name` to a compound `+listMapKey=kind` + `+listMapKey=name` ([commit 193ff756](https://github.com/stacklok/toolhive/commit/193ff756)) so two workloads of different kinds that share a name (e.g., an MCPServer `foo` and a VirtualMCPServer `foo`) stay distinct rather than colliding under merge-patch semantics. The two sibling status types had the same single-key asymmetry and were filed as a parity follow-up. This PR applies the same fix to them.

Closes #5498

<details>
<summary><strong>Medium level</strong></summary>

- Changed the `ReferencingWorkloads` listMapKey on `MCPOIDCConfigStatus` and `MCPExternalAuthConfigStatus` from `name` alone to the compound `(kind, name)` pair, matching the established `MCPAuthzConfig` pattern. Both share the same `WorkloadReference` type.
- Updated the field doc comments to explain the compound-key rationale (cross-kind name reuse stays distinct under merge-patch).
- Regenerated the CRD manifests (`files/crds` + Helm `templates`) and the CRD API reference docs via `task operator-generate`, `task operator-manifests`, and `task crdref-gen`.

</details>

<details>
<summary><strong>Low level</strong></summary>

| File | Change |
|------|--------|
| `cmd/thv-operator/api/v1beta1/mcpoidcconfig_types.go` | Add `+listMapKey=kind` marker + doc comment on `ReferencingWorkloads` |
| `cmd/thv-operator/api/v1beta1/mcpexternalauthconfig_types.go` | Add `+listMapKey=kind` marker + doc comment on `ReferencingWorkloads` |
| `deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpoidcconfigs.yaml` | Regenerated: `x-kubernetes-list-map-keys: [kind, name]` |
| `deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpexternalauthconfigs.yaml` | Regenerated: `x-kubernetes-list-map-keys: [kind, name]` |
| `deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpoidcconfigs.yaml` | Regenerated Helm template |
| `deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpexternalauthconfigs.yaml` | Regenerated Helm template |
| `docs/operator/crd-api.md` | Regenerated API docs with updated field description |

</details>

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

## Test plan

- [x] `task build` passes
- [x] `task test` passes for operator unit tests (`cmd/thv-operator/...` excluding envtest integration suites, which require the `etcd` envtest binary not present locally)
- [x] Verified the regenerated CRD YAML declares `x-kubernetes-list-map-keys: [kind, name]` for `referencingWorkloads` in both sibling types (files/crds and Helm templates)
- [x] Confirmed Go changes are comment/marker-only (no logic change); CI runs `task lint` (local lint is blocked by a known golangci-lint go1.24-vs-go1.26 toolchain mismatch)

## Special notes for reviewers

This is technically a CRD schema change, but it is data-safe: existing stored `ReferencingWorkloads` entries already contain both `kind` and `name`, so they remain valid. The change only tightens the apiserver's merge-patch interpretation going forward. The diff mirrors #4777's commit 193ff756 exactly, applied to the two sibling types.

Generated with [Claude Code](https://claude.com/claude-code)