### PR TITLE
fix(upstreamswap): strip client auth for custom header

### DIFF
--- a/pkg/auth/upstreamswap/middleware.go
+++ b/pkg/auth/upstreamswap/middleware.go
@@ -132,6 +132,7 @@ func createReplaceInjector() injectionFunc {
 func createCustomInjector(headerName string) injectionFunc {
 	return func(r *http.Request, token string) {
 		r.Header.Set(headerName, fmt.Sprintf("Bearer %s", token))
+		r.Header.Del("Authorization")
 	}
 }
 

--- a/pkg/auth/upstreamswap/middleware_test.go
+++ b/pkg/auth/upstreamswap/middleware_test.go
@@ -259,7 +259,7 @@ func TestMiddleware_SuccessfulSwap_CustomHeader(t *testing.T) {
 	handler.ServeHTTP(rr, req)
 
 	assert.Equal(t, "Bearer upstream-access-token", capturedCustomHeader)
-	assert.Equal(t, "Bearer original-token", capturedAuthHeader)
+	assert.Empty(t, capturedAuthHeader)
 }
 
 func TestMiddleware_Close(t *testing.T) {
@@ -298,7 +298,7 @@ func TestCreateInjectors(t *testing.T) {
 		req.Header.Set("Authorization", "Bearer original")
 		injector(req, "test-token")
 		assert.Equal(t, "Bearer test-token", req.Header.Get("X-Custom-Header"))
-		assert.Equal(t, "Bearer original", req.Header.Get("Authorization"))
+		assert.Empty(t, req.Header.Get("Authorization"))
 	})
 }
 


### PR DESCRIPTION
## Summary
- strip the original client Authorization header after upstreamswap injects an upstream token into a custom header
- update custom-header middleware/injector tests to assert only the upstream custom header is forwarded

Fixes #5504.

## Testing
- Not run: local environment does not have the Go toolchain available (`go test ./pkg/auth/upstreamswap` could not spawn `go`).
- Ran `git diff --check`.