### PR TITLE
feat(llm): add --skip-browser to llm setup/token/proxy start

### DIFF
--- a/cmd/thv/app/llm.go
+++ b/cmd/thv/app/llm.go
@@ -22,6 +22,11 @@ import (
 	pkgsecrets "github.com/stacklok/toolhive/pkg/secrets"
 )
 
+// skipBrowserFlagUsage is the shared help text for the --skip-browser flag on
+// the login-capable llm subcommands (setup, token, proxy start).
+const skipBrowserFlagUsage = "Print the OIDC authorization URL instead of opening a browser, then wait for the " +
+	"callback. Use in headless/SSH/CI environments where no system browser is available."
+
 func newLLMCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "llm",
@@ -164,7 +169,7 @@ tokens from the secrets provider.`,
 // runLLMToken prints a fresh LLM gateway access token to stdout.
 // All diagnostic output goes to stderr so the caller can capture the token
 // cleanly (e.g. apiKeyHelper or auth.command in Claude Code / Cursor).
-func runLLMToken(ctx context.Context) error {
+func runLLMToken(ctx context.Context, skipBrowser bool) error {
 	provider := config.NewDefaultProvider()
 	llmCfg := provider.GetConfig().LLM
 
@@ -176,7 +181,7 @@ func runLLMToken(ctx context.Context) error {
 	// launches the OIDC browser flow — the same flow "thv llm setup" runs — so a
 	// prior "thv llm setup --lazy" signs the user in transparently on first use.
 	// A cached or refreshable token is served without any browser prompt.
-	ts, err := buildLLMTokenSource(&llmCfg, true /* interactive */)
+	ts, err := buildLLMTokenSource(&llmCfg, true /* interactive */, skipBrowser)
 	if err != nil {
 		return err
 	}
@@ -193,7 +198,7 @@ func runLLMToken(ctx context.Context) error {
 // system secrets provider → ScopeLLM scoped provider → config-persisting updater.
 // This is the single place that wires ScopeLLM and the refresh-token persistence
 // logic; runLLMToken, runLLMProxyForeground, and future callers all use it.
-func buildLLMTokenSource(cfg *llm.Config, interactive bool) (*llm.TokenSource, error) {
+func buildLLMTokenSource(cfg *llm.Config, interactive, skipBrowser bool) (*llm.TokenSource, error) {
 	secretsProvider, err := secrets.GetSystemSecretsProvider()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get secrets provider: %w", err)
@@ -210,7 +215,7 @@ func buildLLMTokenSource(cfg *llm.Config, interactive bool) (*llm.TokenSource, e
 		}
 	}
 
-	return llm.NewTokenSource(cfg, scoped, interactive, updater), nil
+	return llm.NewTokenSource(cfg, scoped, interactive, skipBrowser, updater), nil
 }
 
 // ── setup / teardown ─────────────────────────────────────────────────────────
@@ -222,6 +227,7 @@ func newLLMSetupCommand() *cobra.Command {
 		targetClient        string
 		anthropicPathPrefix string
 		lazy                bool
+		skipBrowser         bool
 	)
 
 	cmd := &cobra.Command{
@@ -253,9 +259,12 @@ Run "thv llm teardown" to revert all changes.`,
 			if err != nil {
 				return fmt.Errorf("initializing client manager: %w", err)
 			}
+			login := func(ctx context.Context, cfg *llm.Config) error {
+				return oidcLogin(ctx, cfg, skipBrowser)
+			}
 			return runLLMSetup(
 				cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(),
-				cm, config.NewDefaultProvider(), oidcLogin, opts,
+				cm, config.NewDefaultProvider(), login, opts,
 				anthropicPathPrefix, cmd.Flags().Changed("anthropic-path-prefix"), targetClient, lazy,
 			)
 		},
@@ -281,12 +290,13 @@ Run "thv llm teardown" to revert all changes.`,
 		"Skip the interactive OIDC login and defer it until the first time a configured tool "+
 			"accesses the gateway. Tool config and persisted settings are written normally. "+
 			"Useful for unattended provisioning (e.g. an MDM profile).")
+	cmd.Flags().BoolVar(&skipBrowser, "skip-browser", false, skipBrowserFlagUsage)
 
 	return cmd
 }
 
-func oidcLogin(ctx context.Context, cfg *llm.Config) error {
-	ts, err := buildLLMTokenSource(cfg, true /* interactive */)
+func oidcLogin(ctx context.Context, cfg *llm.Config, skipBrowser bool) error {
+	ts, err := buildLLMTokenSource(cfg, true /* interactive */, skipBrowser)
 	if err != nil {
 		return fmt.Errorf("building token source: %w", err)
 	}
@@ -430,7 +440,10 @@ func newLLMProxyCommand() *cobra.Command {
 }
 
 func newLLMProxyStartCommand() *cobra.Command {
-	var tlsSkipVerify bool
+	var (
+		tlsSkipVerify bool
+		skipBrowser   bool
+	)
 
 	cmd := &cobra.Command{
 		Use:   "start",
@@ -460,19 +473,20 @@ To run it in the background, use your shell or a process manager:
 				llmCfg.TLSSkipVerify = tlsSkipVerify
 			}
 
-			return runLLMProxyForeground(cmd.Context(), &llmCfg)
+			return runLLMProxyForeground(cmd.Context(), &llmCfg, skipBrowser)
 		},
 	}
 
 	cmd.Flags().BoolVar(&tlsSkipVerify, "tls-skip-verify", false,
 		"Skip TLS certificate verification for the upstream gateway (overrides stored config; local dev only)")
+	cmd.Flags().BoolVar(&skipBrowser, "skip-browser", false, skipBrowserFlagUsage)
 
 	return cmd
 }
 
 // runLLMProxyForeground builds a TokenSource and starts the proxy in this process.
-func runLLMProxyForeground(ctx context.Context, llmCfg *llm.Config) error {
-	ts, err := buildLLMTokenSource(llmCfg, true /* interactive: proxy is foreground, browser flow is acceptable */)
+func runLLMProxyForeground(ctx context.Context, llmCfg *llm.Config, skipBrowser bool) error {
+	ts, err := buildLLMTokenSource(llmCfg, true /* interactive: proxy is foreground, browser flow is acceptable */, skipBrowser)
 	if err != nil {
 		return err
 	}
@@ -488,6 +502,8 @@ func runLLMProxyForeground(ctx context.Context, llmCfg *llm.Config) error {
 // ── token helper ──────────────────────────────────────────────────────────────
 
 func newLLMTokenCommand() *cobra.Command {
+	var skipBrowser bool
+
 	cmd := &cobra.Command{
 		Use:   "token",
 		Short: "Print a fresh LLM gateway access token to stdout",
@@ -499,9 +515,11 @@ A cached or refreshable token is printed without prompting. If none exists
 launched automatically and the resulting token is printed once login completes.`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return runLLMToken(cmd.Context())
+			return runLLMToken(cmd.Context(), skipBrowser)
 		},
 	}
+
+	cmd.Flags().BoolVar(&skipBrowser, "skip-browser", false, skipBrowserFlagUsage)
 
 	return cmd
 }

--- a/cmd/thv/app/llm_test.go
+++ b/cmd/thv/app/llm_test.go
@@ -618,3 +618,23 @@ func TestLLMTeardownCommand_ClientFlagAndPositionalArgMutuallyExclusive(t *testi
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cannot use --client and a positional tool-name argument at the same time")
 }
+
+// TestLLMCommands_SkipBrowserFlag verifies that the login-capable llm subcommands
+// register the --skip-browser flag as an opt-in boolean (default false), so a
+// default invocation preserves the browser-opening behavior.
+func TestLLMCommands_SkipBrowserFlag(t *testing.T) {
+	t.Parallel()
+
+	root := newLLMCommand()
+	for _, path := range [][]string{
+		{"setup"},
+		{"token"},
+		{"proxy", "start"},
+	} {
+		sub, _, err := root.Find(path)
+		require.NoErrorf(t, err, "resolving llm subcommand %v", path)
+		flag := sub.Flags().Lookup("skip-browser")
+		require.NotNilf(t, flag, "llm %v must register --skip-browser", path)
+		assert.Equalf(t, "false", flag.DefValue, "llm %v --skip-browser must default to false", path)
+	}
+}

--- a/docs/cli/thv_llm_proxy_start.md
+++ b/docs/cli/thv_llm_proxy_start.md
@@ -31,6 +31,7 @@ thv llm proxy start [flags]
 
 ```
   -h, --help              help for start
+      --skip-browser      Print the OIDC authorization URL instead of opening a browser, then wait for the callback. Use in headless/SSH/CI environments where no system browser is available.
       --tls-skip-verify   Skip TLS certificate verification for the upstream gateway (overrides stored config; local dev only)
 ```
 

--- a/docs/cli/thv_llm_setup.md
+++ b/docs/cli/thv_llm_setup.md
@@ -50,6 +50,7 @@ thv llm setup [flags]
       --issuer string                  OIDC issuer URL
       --lazy                           Skip the interactive OIDC login and defer it until the first time a configured tool accesses the gateway. Tool config and persisted settings are written normally. Useful for unattended provisioning (e.g. an MDM profile).
       --proxy-port int                 Localhost proxy listen port (omit to keep current; default: 14000)
+      --skip-browser                   Print the OIDC authorization URL instead of opening a browser, then wait for the callback. Use in headless/SSH/CI environments where no system browser is available.
       --tls-skip-verify                Skip TLS certificate verification for the upstream gateway (local dev only). For direct-mode tools (Claude Code, Gemini CLI) this sets NODE_TLS_REJECT_UNAUTHORIZED=0, disabling TLS for ALL of that tool's outbound connections. For proxy-mode tools only the proxy-to-gateway connection is affected.
 ```
 

--- a/docs/cli/thv_llm_token.md
+++ b/docs/cli/thv_llm_token.md
@@ -29,7 +29,8 @@ thv llm token [flags]
 ### Options
 
 ```
-  -h, --help   help for token
+  -h, --help           help for token
+      --skip-browser   Print the OIDC authorization URL instead of opening a browser, then wait for the callback. Use in headless/SSH/CI environments where no system browser is available.
 ```
 
 ### Options inherited from parent commands

--- a/pkg/auth/tokensource/export_test.go
+++ b/pkg/auth/tokensource/export_test.go
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package tokensource
+
+import (
+	"context"
+
+	"github.com/stacklok/toolhive/pkg/auth/oauth"
+)
+
+// SetStartFlowForTest overrides the OAuth flow starter used by performBrowserFlow
+// and returns a function that restores the original. Tests use this to assert how
+// the SkipBrowser option is forwarded without standing up a real browser or
+// callback listener. Callers must restore the original (e.g. via t.Cleanup) and
+// must not run in parallel with other tests that exercise the interactive flow.
+func SetStartFlowForTest(
+	fn func(ctx context.Context, flow *oauth.Flow, skipBrowser bool) (*oauth.TokenResult, error),
+) func() {
+	orig := startFlow
+	startFlow = fn
+	return func() { startFlow = orig }
+}

--- a/pkg/auth/tokensource/tokensource.go
+++ b/pkg/auth/tokensource/tokensource.go
@@ -69,6 +69,11 @@ type Options struct {
 	SecretsProvider secrets.Provider
 	// Interactive controls whether the browser OIDC+PKCE flow is allowed.
 	Interactive bool
+	// SkipBrowser, when true, makes the interactive flow print the authorization
+	// URL to stderr and wait for the callback instead of opening a browser. It
+	// only has effect when Interactive is true. Useful for headless/SSH/CI
+	// environments where no system browser is available.
+	SkipBrowser bool
 	// KeyProvider returns the secrets-provider key for the refresh token.
 	// May be called multiple times per Token() invocation; must be deterministic
 	// and free of side effects. Typically returns a cached config ref if set,
@@ -244,6 +249,13 @@ func (t *OAuthTokenSource) tryRestoreFromCache(ctx context.Context) error {
 	return nil
 }
 
+// startFlow runs the interactive OAuth flow to completion. It is a package var
+// so tests can stub the browser/callback round-trip and assert how skipBrowser
+// is forwarded without standing up a real browser or callback listener.
+var startFlow = func(ctx context.Context, flow *oauth.Flow, skipBrowser bool) (*oauth.TokenResult, error) {
+	return flow.Start(ctx, skipBrowser)
+}
+
 // performBrowserFlow runs the interactive OIDC+PKCE browser flow and persists
 // the resulting refresh token for future non-interactive use.
 func (t *OAuthTokenSource) performBrowserFlow(ctx context.Context) error {
@@ -257,7 +269,7 @@ func (t *OAuthTokenSource) performBrowserFlow(ctx context.Context) error {
 		return fmt.Errorf("creating OAuth flow: %w", err)
 	}
 
-	tokenResult, err := flow.Start(ctx, false)
+	tokenResult, err := startFlow(ctx, flow, t.opts.SkipBrowser)
 	if err != nil {
 		return fmt.Errorf("OAuth flow start failed: %w", err)
 	}

--- a/pkg/auth/tokensource/tokensource_test.go
+++ b/pkg/auth/tokensource/tokensource_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	"github.com/stacklok/toolhive/pkg/auth/oauth"
 	"github.com/stacklok/toolhive/pkg/auth/tokensource"
 	secretsmocks "github.com/stacklok/toolhive/pkg/secrets/mocks"
 )
@@ -623,4 +624,65 @@ func TestToken_Interactive_OIDCDiscoveryFails_ReturnsError(t *testing.T) {
 	assert.False(t, errors.Is(err, errTestFallback),
 		"browser flow OIDC failure must not collapse to FallbackErr")
 	assert.Contains(t, err.Error(), "OIDC browser flow failed")
+}
+
+// ── SkipBrowser is forwarded to the OAuth flow ────────────────────────────────
+
+// TestToken_Interactive_SkipBrowser_ForwardedToFlow verifies that the SkipBrowser
+// option reaches flow.Start unchanged. The OAuth flow itself is stubbed via the
+// startFlow seam so the assertion holds without opening a browser or binding a
+// callback listener; the rest of performBrowserFlow runs against the fake OIDC
+// token endpoint.
+//
+//nolint:paralleltest // overrides the package-global startFlow seam; must not race other tests
+func TestToken_Interactive_SkipBrowser_ForwardedToFlow(t *testing.T) {
+	cases := []struct {
+		name        string
+		skipBrowser bool
+	}{
+		{name: "skip browser", skipBrowser: true},
+		{name: "open browser", skipBrowser: false},
+	}
+	for _, tc := range cases {
+		//nolint:paralleltest // shares the package-global startFlow seam with the parent
+		t.Run(tc.name, func(t *testing.T) {
+			expiry := time.Now().Add(time.Hour)
+			srv := fakeOIDCServerSimple(t, "at-skip", expiry, "rt-skip")
+
+			ctrl := gomock.NewController(t)
+			t.Cleanup(ctrl.Finish)
+			mock := secretsmocks.NewMockProvider(ctrl)
+			mock.EXPECT().GetSecret(gomock.Any(), gomock.Any()).Return("", errors.New("not found")).AnyTimes()
+			mock.EXPECT().SetSecret(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
+			var (
+				called  bool
+				gotSkip bool
+			)
+			restore := tokensource.SetStartFlowForTest(
+				func(_ context.Context, _ *oauth.Flow, skipBrowser bool) (*oauth.TokenResult, error) {
+					called = true
+					gotSkip = skipBrowser
+					return &oauth.TokenResult{
+						AccessToken:  "at-skip",
+						RefreshToken: "rt-skip",
+						Expiry:       expiry,
+						TokenType:    "Bearer",
+					}, nil
+				},
+			)
+			t.Cleanup(restore)
+
+			opts := optsWithFakeOIDC(srv, mock)
+			opts.Interactive = true
+			opts.SkipBrowser = tc.skipBrowser
+			ts := tokensource.New(opts)
+
+			tok, err := ts.Token(context.Background())
+			require.NoError(t, err)
+			assert.True(t, called, "interactive flow must invoke the OAuth flow starter")
+			assert.Equal(t, "at-skip", tok, "the access token from the flow must be returned")
+			assert.Equal(t, tc.skipBrowser, gotSkip, "SkipBrowser option must be forwarded to flow.Start verbatim")
+		})
+	}
 }

--- a/pkg/llm/tokensource.go
+++ b/pkg/llm/tokensource.go
@@ -39,8 +39,11 @@ type TokenSource = tokensource.OAuthTokenSource
 // tokenRefUpdater is called after login/refresh to persist the token reference
 // into config — pass nil to skip config persistence (useful in tests).
 // Set interactive to false for non-interactive callers such as thv llm token.
+// When skipBrowser is true, an interactive login prints the authorization URL
+// instead of opening a browser (headless/SSH/CI use); it has no effect unless
+// interactive is also true.
 func NewTokenSource(
-	cfg *Config, secretsProvider secrets.Provider, interactive bool, tokenRefUpdater TokenRefUpdater,
+	cfg *Config, secretsProvider secrets.Provider, interactive, skipBrowser bool, tokenRefUpdater TokenRefUpdater,
 ) *TokenSource {
 	return tokensource.New(tokensource.Options{
 		OIDC: tokensource.OIDCParams{
@@ -52,6 +55,7 @@ func NewTokenSource(
 		},
 		SecretsProvider: secretsProvider,
 		Interactive:     interactive,
+		SkipBrowser:     skipBrowser,
 		KeyProvider: func() string {
 			if cfg.OIDC.CachedRefreshTokenRef != "" {
 				return cfg.OIDC.CachedRefreshTokenRef

--- a/pkg/llm/tokensource_test.go
+++ b/pkg/llm/tokensource_test.go
@@ -58,7 +58,7 @@ func TestTokenSource_NonInteractive_NoCache_ReturnsErrTokenRequired(t *testing.T
 	mockSecrets.EXPECT().GetSecret(gomock.Any(), gomock.Any()).
 		Return("", errors.New("not found")).AnyTimes()
 
-	ts := NewTokenSource(minimalConfig(), mockSecrets, false, nil)
+	ts := NewTokenSource(minimalConfig(), mockSecrets, false, false, nil)
 	_, err := ts.Token(context.Background())
 	require.ErrorIs(t, err, ErrTokenRequired)
 }
@@ -74,7 +74,7 @@ func TestTokenSource_NonInteractive_BackendError_ReturnsLastErr(t *testing.T) {
 	mockSecrets.EXPECT().GetSecret(gomock.Any(), gomock.Any()).
 		Return("", backendErr).AnyTimes()
 
-	ts := NewTokenSource(minimalConfig(), mockSecrets, false, nil)
+	ts := NewTokenSource(minimalConfig(), mockSecrets, false, false, nil)
 	_, err := ts.Token(context.Background())
 
 	require.Error(t, err)
@@ -87,7 +87,7 @@ func TestTokenSource_NonInteractive_BackendError_ReturnsLastErr(t *testing.T) {
 func TestTokenSource_NonInteractive_NilSecrets_ReturnsActionableError(t *testing.T) {
 	t.Parallel()
 
-	ts := NewTokenSource(minimalConfig(), nil, false, nil)
+	ts := NewTokenSource(minimalConfig(), nil, false, false, nil)
 	_, err := ts.Token(context.Background())
 
 	require.Error(t, err)
@@ -118,7 +118,7 @@ func TestTokenSource_UsesCachedRefreshTokenRef(t *testing.T) {
 		GetSecret(gomock.Any(), persistedKey).
 		Return("", errors.New("not found"))
 
-	ts := NewTokenSource(cfg, mockSecrets, false, nil)
+	ts := NewTokenSource(cfg, mockSecrets, false, false, nil)
 	_, _ = ts.Token(context.Background())
 	// Expectations verify that persistedKey was used.
 }
@@ -141,7 +141,7 @@ func TestTokenSource_DerivesKeyWhenNoCachedRef(t *testing.T) {
 		GetSecret(gomock.Any(), expectedBase).
 		Return("", errors.New("not found"))
 
-	ts := NewTokenSource(cfg, mockSecrets, false, nil)
+	ts := NewTokenSource(cfg, mockSecrets, false, false, nil)
 	_, _ = ts.Token(context.Background())
 }
 
@@ -173,7 +173,7 @@ func TestTokenSource_TokenRefUpdater_WiredAsConfigPersister(t *testing.T) {
 
 	cfg := minimalConfig()
 	cfg.OIDC.Issuer = srv.URL
-	ts := NewTokenSource(cfg, mock, false, updater)
+	ts := NewTokenSource(cfg, mock, false, false, updater)
 
 	tok, err := ts.Token(context.Background())
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

The interactive OIDC login for the LLM gateway always opened a system browser:
`pkg/auth/tokensource` hardcoded `flow.Start(ctx, false)`. That makes
`thv llm setup` (and the on-demand login in `thv llm token` / `thv llm proxy
start`) unusable in headless/SSH/CI environments where no browser is available
— even though the underlying OAuth flow already supports printing the
authorization URL and waiting on the callback (the `--remote-auth-skip-browser`
path uses exactly this).

This exposes that existing capability on the login-capable `llm` subcommands.

- `pkg/auth/tokensource`: add `Options.SkipBrowser`, forwarded to `flow.Start`.
  Default `false` preserves current behavior for every caller (including the
  registry auth path).
- `pkg/llm.NewTokenSource`: thread a `skipBrowser` parameter through to the
  shared token source.
- `cmd/thv/app`: add a transient `--skip-browser` flag to `llm setup`,
  `llm token`, and `llm proxy start`. When set, the OIDC URL is printed and the
  flow waits for the callback instead of opening a browser.

Motivation: the Stacklok Enterprise cross-surface e2e harness needs to drive a
real `thv llm proxy start` against an in-cluster mock OIDC with no human at a
browser (enterprise issue #1605). This flag is the headless seam that makes
that — and any SSH/CI/MDM login — possible.

## Type of change

- [x] New feature

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)

Ran (Go 1.26):
- `go test ./pkg/auth/tokensource/... ./pkg/llm/... ./cmd/thv/app/` — all pass.
- `golangci-lint run` on the changed packages — 0 issues.

New coverage:
- `pkg/auth/tokensource`: `SkipBrowser` is forwarded to the OAuth flow verbatim
  (both true and false), verified via a stubbed flow starter against a fake OIDC
  server — no real browser or callback listener.
- `cmd/thv/app`: `--skip-browser` is registered as an opt-in bool (default
  `false`) on `llm setup`, `llm token`, and `llm proxy start`.

## API Compatibility

- [x] This PR does not break the `v1beta1` API.

## Does this introduce a user-facing change?

Yes. `thv llm setup`, `thv llm token`, and `thv llm proxy start` gain a
`--skip-browser` flag: instead of opening a browser for OIDC login, thv prints
the authorization URL and waits for the callback. Intended for headless/SSH/CI
environments. Default behavior is unchanged.

## Special notes for reviewers

- The flag is intentionally **transient** (not persisted to `config.yaml`) — it
  describes how *this* invocation should log in, not durable gateway config.
- `--skip-browser` only has effect when an interactive login actually runs; with
  a cached/refreshable token (or `thv llm setup --lazy`) there is no browser
  step to skip.
- `startFlow` in `pkg/auth/tokensource` is a small package-var seam so the
  forwarding test can stub the browser/callback round-trip; production behavior
  is unchanged.
