### PR TITLE
Add integration test for MCPOIDCConfig → oidcConfigRef → runconfig path 

### DIFF
--- a/cmd/thv-operator/test-integration/mcp-server/mcpserver_runconfig_integration_test.go
+++ b/cmd/thv-operator/test-integration/mcp-server/mcpserver_runconfig_integration_test.go
@@ -19,6 +19,7 @@ import (
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
 	ctrlutil "github.com/stacklok/toolhive/cmd/thv-operator/pkg/controllerutil"
 	"github.com/stacklok/toolhive/cmd/thv-operator/pkg/runconfig/configmap/checksum"
+	"github.com/stacklok/toolhive/pkg/auth"
 	"github.com/stacklok/toolhive/pkg/authz"
 	"github.com/stacklok/toolhive/pkg/authz/authorizers/cedar"
 	"github.com/stacklok/toolhive/pkg/runner"
@@ -540,6 +541,103 @@ var _ = Describe("RunConfig ConfigMap Integration Tests", func() {
 			Expect(runConfig.TelemetryConfig.MetricsEnabled).To(BeTrue())
 			Expect(runConfig.TelemetryConfig.SamplingRate).To(Equal("0.1"))
 			Expect(runConfig.TelemetryConfig.EnablePrometheusMetricsPath).To(BeTrue())
+		})
+
+		It("Should handle MCPServer with oidcConfigRef", func() {
+			namespace := "oidc-ref-runconfig-ns"
+			mcpServerName := "oidc-ref-runconfig-server"
+			configMapName := mcpServerName + "-runconfig"
+
+			ns := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: namespace,
+				},
+			}
+			_ = k8sClient.Create(ctx, ns)
+
+			oidcConfig := &mcpv1beta1.MCPOIDCConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "shared-oidc-config",
+					Namespace: namespace,
+				},
+				Spec: mcpv1beta1.MCPOIDCConfigSpec{
+					Type: mcpv1beta1.MCPOIDCConfigTypeInline,
+					Inline: &mcpv1beta1.InlineOIDCSharedConfig{
+						Issuer:  "https://issuer.example.com",
+						JWKSURL: "https://issuer.example.com/.well-known/jwks.json",
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, oidcConfig)).To(Succeed())
+			defer k8sClient.Delete(ctx, oidcConfig) //nolint:errcheck
+
+			Eventually(func() bool {
+				fetched := &mcpv1beta1.MCPOIDCConfig{}
+				err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      oidcConfig.Name,
+					Namespace: oidcConfig.Namespace,
+				}, fetched)
+				return err == nil && fetched.Status.ConfigHash != ""
+			}, timeout, interval).Should(BeTrue())
+
+			resourceURL := "https://mcp.example.com/oauth/resource"
+			mcpServer := &mcpv1beta1.MCPServer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      mcpServerName,
+					Namespace: namespace,
+				},
+				Spec: mcpv1beta1.MCPServerSpec{
+					Image:     "oidc/mcp-server:latest",
+					Transport: "stdio",
+					ProxyPort: 8080,
+					OIDCConfigRef: &mcpv1beta1.MCPOIDCConfigReference{
+						Name:        oidcConfig.Name,
+						Audience:    "test-audience",
+						Scopes:      []string{"openid", "profile"},
+						ResourceURL: resourceURL,
+					},
+				},
+			}
+
+			Expect(k8sClient.Create(ctx, mcpServer)).Should(Succeed())
+			defer k8sClient.Delete(ctx, mcpServer) //nolint:errcheck
+
+			configMap := &corev1.ConfigMap{}
+			Eventually(func() error {
+				return k8sClient.Get(ctx, types.NamespacedName{
+					Name:      configMapName,
+					Namespace: namespace,
+				}, configMap)
+			}, timeout, interval).Should(Succeed())
+
+			Expect(configMap.Data).To(HaveKey("runconfig.json"))
+
+			var runConfig runner.RunConfig
+			err := json.Unmarshal([]byte(configMap.Data["runconfig.json"]), &runConfig)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(runConfig.OIDCConfig).NotTo(BeNil())
+			Expect(runConfig.OIDCConfig.Issuer).To(Equal("https://issuer.example.com"))
+			Expect(runConfig.OIDCConfig.Audience).To(Equal("test-audience"))
+			Expect(runConfig.OIDCConfig.JWKSURL).To(Equal("https://issuer.example.com/.well-known/jwks.json"))
+			Expect(runConfig.OIDCConfig.ResourceURL).To(Equal(resourceURL))
+			Expect(runConfig.OIDCConfig.Scopes).To(Equal([]string{"openid", "profile"}))
+
+			var authConfig *transporttypes.MiddlewareConfig
+			for i := range runConfig.MiddlewareConfigs {
+				if runConfig.MiddlewareConfigs[i].Type == auth.MiddlewareType {
+					authConfig = &runConfig.MiddlewareConfigs[i]
+					break
+				}
+			}
+			Expect(authConfig).NotTo(BeNil())
+
+			var authParams auth.MiddlewareParams
+			Expect(json.Unmarshal(authConfig.Parameters, &authParams)).To(Succeed())
+			Expect(authParams.OIDCConfig).NotTo(BeNil())
+			Expect(authParams.OIDCConfig.Issuer).To(Equal(runConfig.OIDCConfig.Issuer))
+			Expect(authParams.OIDCConfig.Audience).To(Equal(runConfig.OIDCConfig.Audience))
+			Expect(authParams.OIDCConfig.JWKSURL).To(Equal(runConfig.OIDCConfig.JWKSURL))
 		})
 
 		It("Should use server name as default service name when telemetryConfigRef has no override", func() {


### PR DESCRIPTION
## Summary

- Adds missing integration coverage for the `MCPOIDCConfig` -> `MCPServer.spec.oidcConfigRef` -> generated `runconfig.json` path.
- Creates a shared `MCPOIDCConfig`, waits for it to reconcile, creates an `MCPServer` that references it, and verifies the generated runconfig contains the resolved OIDC settings.
- Verifies the auth middleware config in `middleware_configs` also receives the resolved OIDC config, so the serialized runconfig matches what the proxyrunner will consume.

Fixes #4833 

## Type of change

<!-- REQUIRED. Check exactly one. -->

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [x] Other (describe): Test coverage

## Test plan

<!--
REQUIRED. Check every verification step you actually ran.
You MUST check at least one item. If you only did manual testing,
describe exactly what you tested below the checkbox.
-->

- [ ] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [ ] Linting (`task lint-fix`)
- [x] Manual testing (describe below)

Ran:

```sh
env GOCACHE=/tmp/toolhive-gocache-vmcp-fix go test ./cmd/thv-operator/test-integration/mcp-server -run '^$'
```
## API Compatibility

- [x] This PR does not break the `v1beta1` API, OR the `api-break-allowed` label is applied and the migration guidance is described above.

## Changes

| File | Change |
|------|--------|
| `cmd/thv-operator/test-integration/mcp-server/mcpserver_runconfig_integration_test.go` | Adds an `oidcConfigRef` runconfig integration test for `MCPServer`. |

## Does this introduce a user-facing change?

No.

<!--
If yes, describe the change from the user's perspective. This helps with release notes.
If no, write "No".
Remove this section entirely if not applicable.
-->

## Implementation plan

<details>
<summary>Approved implementation plan</summary>

1. Reuse the existing `mcp-server` envtest integration suite because it already registers the MCPServer and MCPOIDCConfig controllers and has equivalent telemetry runconfig coverage.
2. Add one focused test next to the telemetryConfigRef runconfig test.
3. Create an inline `MCPOIDCConfig` with issuer and JWKS URL, then wait for `status.configHash` to confirm reconciliation.
4. Create an `MCPServer` with `spec.oidcConfigRef` containing audience, scopes, and resource URL overrides.
5. Wait for the runconfig ConfigMap, parse `runconfig.json`, and assert the resolved OIDC config is present.
6. Verify the serialized auth middleware parameters also include the resolved OIDC config.

</details>

## Special notes for reviewers

The issue text mentioned a `ServiceName` override, but the current `MCPOIDCConfigReference` API exposes `ResourceURL`, `Audience`, and `Scopes`; this test verifies the per-reference override fields available in the current API.
