### PR TITLE
Wire OBO SecretEnvVars into MCPServer and MCPRemoteProxy

### DIFF
--- a/cmd/thv-operator/controllers/mcpremoteproxy_deployment.go
+++ b/cmd/thv-operator/controllers/mcpremoteproxy_deployment.go
@@ -211,6 +211,23 @@ func (r *MCPRemoteProxyReconciler) buildEnvVarsForProxy(
 		} else {
 			env = append(env, bearerTokenEnvVars...)
 		}
+
+		// Add OBO secret environment variables. Dispatched through the
+		// registered OBO handler; inert (no env vars) in builds without one.
+		// This function feeds both the deployment builder and containerNeedsUpdate,
+		// so builder/drift symmetry is automatic.
+		oboEnvVars, err := ctrlutil.AddExternalAuthConfigSecretEnvVars(
+			ctx,
+			r.Client,
+			proxy.Namespace,
+			proxy.Spec.ExternalAuthConfigRef,
+		)
+		if err != nil {
+			ctxLogger := log.FromContext(ctx)
+			ctxLogger.Error(err, "Failed to generate OBO secret environment variables")
+		} else {
+			env = append(env, oboEnvVars...)
+		}
 	}
 
 	// Add header forward secret environment variables

--- a/cmd/thv-operator/controllers/mcpremoteproxy_deployment.go
+++ b/cmd/thv-operator/controllers/mcpremoteproxy_deployment.go
@@ -216,15 +216,14 @@ func (r *MCPRemoteProxyReconciler) buildEnvVarsForProxy(
 		// registered OBO handler; inert (no env vars) in builds without one.
 		// This function feeds both the deployment builder and containerNeedsUpdate,
 		// so builder/drift symmetry is automatic.
-		oboEnvVars, err := ctrlutil.AddExternalAuthConfigSecretEnvVars(
+		oboEnvVars, err := ctrlutil.AddOBOSecretEnvVars(
 			ctx,
 			r.Client,
 			proxy.Namespace,
 			proxy.Spec.ExternalAuthConfigRef,
 		)
 		if err != nil {
-			ctxLogger := log.FromContext(ctx)
-			ctxLogger.Error(err, "Failed to generate OBO secret environment variables")
+			logOBOSecretEnvVarError(ctx, err)
 		} else {
 			env = append(env, oboEnvVars...)
 		}

--- a/cmd/thv-operator/controllers/mcpremoteproxy_deployment_test.go
+++ b/cmd/thv-operator/controllers/mcpremoteproxy_deployment_test.go
@@ -882,6 +882,81 @@ func TestMCPRemoteProxyDeploymentNeedsUpdate_TokenExchangeDoesNotDrift(t *testin
 	assert.False(t, reconciler.deploymentNeedsUpdate(t.Context(), deployment, proxy, "test-checksum"))
 }
 
+// TestMCPRemoteProxyDeployment_OBOSecretEnvVars verifies that an obo-typed
+// MCPExternalAuthConfig referenced from an MCPRemoteProxy injects the registered
+// OBOHandler.SecretEnvVars output into the proxy container, and that the
+// deployment builder and drift check agree on it so a correctly-configured
+// resource does not hot-loop. A stub OBO handler stands in for the out-of-tree
+// enterprise handler.
+//
+//nolint:paralleltest // Mutates package-level oboHandler via RegisterOBOHandler.
+func TestMCPRemoteProxyDeployment_OBOSecretEnvVars(t *testing.T) {
+	t.Cleanup(func() { ctrlutil.RegisterOBOHandler(defaultOBOHandlerStub()) })
+
+	oboEnvVar := corev1.EnvVar{
+		Name: "TOOLHIVE_OBO_CLIENT_SECRET",
+		ValueFrom: &corev1.EnvVarSource{
+			SecretKeyRef: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: "obo-secret"},
+				Key:                  "client-secret",
+			},
+		},
+	}
+	stub := defaultOBOHandlerStub()
+	stub.SecretEnvVars = func(*mcpv1beta1.MCPExternalAuthConfig) ([]corev1.EnvVar, error) {
+		return []corev1.EnvVar{oboEnvVar}, nil
+	}
+	ctrlutil.RegisterOBOHandler(stub)
+
+	scheme := createRunConfigTestScheme()
+
+	authConfig := &mcpv1beta1.MCPExternalAuthConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "obo-config",
+			Namespace: "default",
+		},
+		Spec: mcpv1beta1.MCPExternalAuthConfigSpec{
+			Type: mcpv1beta1.ExternalAuthTypeOBO,
+			OBO:  &mcpv1beta1.OBOConfig{},
+		},
+	}
+
+	proxy := &mcpv1beta1.MCPRemoteProxy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-proxy",
+			Namespace: "default",
+		},
+		Spec: mcpv1beta1.MCPRemoteProxySpec{
+			RemoteURL: "https://mcp.example.com",
+			ProxyPort: 8080,
+			ExternalAuthConfigRef: &mcpv1beta1.ExternalAuthConfigRef{
+				Name: authConfig.Name,
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithRuntimeObjects(authConfig).
+		Build()
+
+	reconciler := &MCPRemoteProxyReconciler{
+		Client:           fakeClient,
+		Scheme:           scheme,
+		PlatformDetector: ctrlutil.NewSharedPlatformDetector(),
+	}
+
+	deployment := reconciler.deploymentForMCPRemoteProxy(t.Context(), proxy, "test-checksum")
+	require.NotNil(t, deployment)
+
+	container := deployment.Spec.Template.Spec.Containers[0]
+	assert.Contains(t, container.Env, oboEnvVar,
+		"OBO handler SecretEnvVars output must be injected into the proxy container")
+
+	assert.False(t, reconciler.deploymentNeedsUpdate(t.Context(), deployment, proxy, "test-checksum"),
+		"freshly built deployment with an OBO env var must not be seen as drifted")
+}
+
 func TestMCPRemoteProxyDeploymentNeedsUpdate_ImagePullSecretsDrift(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/thv-operator/controllers/mcpserver_controller.go
+++ b/cmd/thv-operator/controllers/mcpserver_controller.go
@@ -8,6 +8,7 @@ package controllers
 import (
 	"context"
 	"encoding/json"
+	stderrors "errors"
 	"fmt"
 	"maps"
 	"os"
@@ -41,6 +42,7 @@ import (
 	"github.com/stacklok/toolhive/cmd/thv-operator/pkg/kubernetes/rbac"
 	"github.com/stacklok/toolhive/cmd/thv-operator/pkg/runconfig/configmap/checksum"
 	"github.com/stacklok/toolhive/cmd/thv-operator/pkg/validation"
+	"github.com/stacklok/toolhive/pkg/auth/obo"
 	"github.com/stacklok/toolhive/pkg/container/kubernetes"
 	"github.com/stacklok/toolhive/pkg/transport"
 	"github.com/stacklok/toolhive/pkg/transport/session"
@@ -1003,6 +1005,26 @@ func (r *MCPServerReconciler) imagePullSecretsForMCPServer(
 	return r.ImagePullSecretsDefaults.Merge(crLevel)
 }
 
+// logOBOSecretEnvVarError logs an error from OBO secret env var generation
+// without leaking sensitive detail. The OBOHandler error contract only
+// guarantees *obo.ValidationError.Message is safe to surface; the transient
+// bucket (e.g. "secret obo-secret/client-secret not found", JWKS URLs) carries
+// no such guarantee, so anything that is not a ValidationError is logged
+// generically with a pointer to the MCPExternalAuthConfig status, which the
+// MCPExternalAuthConfig reconciler populates with the triaged detail. Shared by
+// the MCPServer and MCPRemoteProxy proxy-env builders.
+func logOBOSecretEnvVarError(ctx context.Context, err error) {
+	logger := log.FromContext(ctx)
+	var validationErr *obo.ValidationError
+	if stderrors.As(err, &validationErr) {
+		logger.Error(err, "Failed to generate OBO secret environment variables")
+		return
+	}
+	logger.Error(nil,
+		"Failed to generate OBO secret environment variables; "+
+			"see the referenced MCPExternalAuthConfig status for details")
+}
+
 // deploymentForMCPServer returns a MCPServer Deployment object
 //
 //nolint:gocyclo
@@ -1104,12 +1126,11 @@ func (r *MCPServerReconciler) deploymentForMCPServer(
 		// Add OBO secret environment variables. Dispatched through the
 		// registered OBO handler; inert (no env vars) in builds without one.
 		// Must mirror deploymentNeedsUpdate exactly to avoid reconcile drift.
-		oboEnvVars, err := ctrlutil.AddExternalAuthConfigSecretEnvVars(
+		oboEnvVars, err := ctrlutil.AddOBOSecretEnvVars(
 			ctx, r.Client, m.Namespace, m.Spec.ExternalAuthConfigRef,
 		)
 		if err != nil {
-			ctxLogger := log.FromContext(ctx)
-			ctxLogger.Error(err, "Failed to generate OBO secret environment variables")
+			logOBOSecretEnvVarError(ctx, err)
 		} else {
 			env = append(env, oboEnvVars...)
 		}
@@ -1761,10 +1782,12 @@ func (r *MCPServerReconciler) deploymentNeedsUpdate(
 			// In handler-less builds the dispatcher swallows ErrEnterpriseRequired
 			// to (nil, nil), keeping this path symmetric with the builder. A
 			// genuine handler error returns true here while the builder logs and
-			// continues — the same transient builder/drift divergence the
-			// token-exchange block above has; it self-resolves once the handler
-			// succeeds and is out of scope to unify here.
-			oboEnvVars, err := ctrlutil.AddExternalAuthConfigSecretEnvVars(
+			// continues, so as long as the handler keeps erroring the operator
+			// re-applies an identical (OBO-env-less) Deployment each reconcile; it
+			// stops only once the handler succeeds. This mirrors the token-exchange
+			// block above; unifying both (requeue on genuine error so neither side
+			// acts) is out of scope for this change.
+			oboEnvVars, err := ctrlutil.AddOBOSecretEnvVars(
 				ctx, r.Client, mcpServer.Namespace, mcpServer.Spec.ExternalAuthConfigRef,
 			)
 			if err != nil {

--- a/cmd/thv-operator/controllers/mcpserver_controller.go
+++ b/cmd/thv-operator/controllers/mcpserver_controller.go
@@ -1100,6 +1100,19 @@ func (r *MCPServerReconciler) deploymentForMCPServer(
 		} else {
 			env = append(env, tokenExchangeEnvVars...)
 		}
+
+		// Add OBO secret environment variables. Dispatched through the
+		// registered OBO handler; inert (no env vars) in builds without one.
+		// Must mirror deploymentNeedsUpdate exactly to avoid reconcile drift.
+		oboEnvVars, err := ctrlutil.AddExternalAuthConfigSecretEnvVars(
+			ctx, r.Client, m.Namespace, m.Spec.ExternalAuthConfigRef,
+		)
+		if err != nil {
+			ctxLogger := log.FromContext(ctx)
+			ctxLogger.Error(err, "Failed to generate OBO secret environment variables")
+		} else {
+			env = append(env, oboEnvVars...)
+		}
 	}
 
 	// Validate webhook config and add mounted webhook secrets.
@@ -1741,6 +1754,17 @@ func (r *MCPServerReconciler) deploymentNeedsUpdate(
 				return true
 			}
 			expectedProxyEnv = append(expectedProxyEnv, tokenExchangeEnvVars...)
+
+			// Add OBO secret environment variables. Must mirror
+			// deploymentForMCPServer exactly (same call, same position) so a
+			// correctly-configured resource does not look perpetually drifted.
+			oboEnvVars, err := ctrlutil.AddExternalAuthConfigSecretEnvVars(
+				ctx, r.Client, mcpServer.Namespace, mcpServer.Spec.ExternalAuthConfigRef,
+			)
+			if err != nil {
+				return true
+			}
+			expectedProxyEnv = append(expectedProxyEnv, oboEnvVars...)
 		}
 
 		// Validate webhook config. Webhook secrets are mounted as files when the deployment is built.

--- a/cmd/thv-operator/controllers/mcpserver_controller.go
+++ b/cmd/thv-operator/controllers/mcpserver_controller.go
@@ -1758,6 +1758,12 @@ func (r *MCPServerReconciler) deploymentNeedsUpdate(
 			// Add OBO secret environment variables. Must mirror
 			// deploymentForMCPServer exactly (same call, same position) so a
 			// correctly-configured resource does not look perpetually drifted.
+			// In handler-less builds the dispatcher swallows ErrEnterpriseRequired
+			// to (nil, nil), keeping this path symmetric with the builder. A
+			// genuine handler error returns true here while the builder logs and
+			// continues — the same transient builder/drift divergence the
+			// token-exchange block above has; it self-resolves once the handler
+			// succeeds and is out of scope to unify here.
 			oboEnvVars, err := ctrlutil.AddExternalAuthConfigSecretEnvVars(
 				ctx, r.Client, mcpServer.Namespace, mcpServer.Spec.ExternalAuthConfigRef,
 			)

--- a/cmd/thv-operator/controllers/mcpserver_externalauth_test.go
+++ b/cmd/thv-operator/controllers/mcpserver_externalauth_test.go
@@ -16,6 +16,7 @@ package controllers
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -783,4 +784,62 @@ func TestMCPServerDeployment_OBOSecretEnvVars(t *testing.T) {
 
 	assert.False(t, reconciler.deploymentNeedsUpdate(t.Context(), deployment, mcpServer, "test-checksum"),
 		"builder and drift check must agree on the OBO env var (no reconcile hot-loop)")
+}
+
+// TestMCPServerDeployment_OBOSecretEnvVars_GenuineErrorDivergence locks in the
+// documented MCPServer builder/drift behavior when the registered OBO handler
+// returns a genuine (non-ErrEnterpriseRequired) error: the builder logs and
+// continues, producing an OBO-env-less Deployment without failing, while
+// deploymentNeedsUpdate reports the Deployment needs an update. This divergence
+// is described at the drift site and exercised nowhere else at the controller
+// level. (The inert ErrEnterpriseRequired path stays symmetric — see the test
+// above — because AddOBOSecretEnvVars swallows it.)
+//
+//nolint:paralleltest // Mutates package-level oboHandler via RegisterOBOHandler.
+func TestMCPServerDeployment_OBOSecretEnvVars_GenuineErrorDivergence(t *testing.T) {
+	t.Cleanup(func() { ctrlutil.RegisterOBOHandler(defaultOBOHandlerStub()) })
+
+	stub := defaultOBOHandlerStub()
+	stub.SecretEnvVars = func(*mcpv1beta1.MCPExternalAuthConfig) ([]corev1.EnvVar, error) {
+		return nil, errors.New("secret not yet available")
+	}
+	ctrlutil.RegisterOBOHandler(stub)
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	authConfig := &mcpv1beta1.MCPExternalAuthConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "obo-config", Namespace: "default"},
+		Spec: mcpv1beta1.MCPExternalAuthConfigSpec{
+			Type: mcpv1beta1.ExternalAuthTypeOBO,
+			OBO:  &mcpv1beta1.OBOConfig{},
+		},
+	}
+	mcpServer := &mcpv1beta1.MCPServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-server", Namespace: "default"},
+		Spec: mcpv1beta1.MCPServerSpec{
+			Image:                 "test-image:latest",
+			Transport:             "stdio",
+			ProxyPort:             8080,
+			ExternalAuthConfigRef: &mcpv1beta1.ExternalAuthConfigRef{Name: authConfig.Name},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(authConfig).
+		Build()
+
+	reconciler := newTestMCPServerReconciler(fakeClient, scheme, kubernetes.PlatformKubernetes)
+
+	// Builder logs-and-continues: a Deployment is still produced (no error, no
+	// panic), with no OBO env var injected.
+	deployment, err := reconciler.deploymentForMCPServer(t.Context(), mcpServer, "test-checksum")
+	require.NoError(t, err, "builder must log-and-continue on a genuine OBO handler error, not fail")
+	require.NotNil(t, deployment)
+
+	// Drift check returns true on the same error — the documented divergence.
+	assert.True(t, reconciler.deploymentNeedsUpdate(t.Context(), deployment, mcpServer, "test-checksum"),
+		"deploymentNeedsUpdate reports drift while the OBO handler errors")
 }

--- a/cmd/thv-operator/controllers/mcpserver_externalauth_test.go
+++ b/cmd/thv-operator/controllers/mcpserver_externalauth_test.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	ctrlutil "github.com/stacklok/toolhive/cmd/thv-operator/pkg/controllerutil"
 	"github.com/stacklok/toolhive/pkg/container/kubernetes"
 )
 
@@ -715,4 +716,71 @@ func TestMCPServerReconciler_handleExternalAuthConfig_ClearsMirrorOnSourceNotFou
 	assert.Nil(t,
 		meta.FindStatusCondition(mcpServer.Status.Conditions, mcpv1beta1.ConditionTypeExternalAuthConfigValidated),
 		"stale mirror must be cleared when the referenced source is NotFound")
+}
+
+// TestMCPServerDeployment_OBOSecretEnvVars verifies that an obo-typed
+// MCPExternalAuthConfig referenced from an MCPServer injects the registered
+// OBOHandler.SecretEnvVars output into the proxy container, and that the
+// deployment builder (deploymentForMCPServer) and the drift check
+// (deploymentNeedsUpdate) agree on it. MCPServer assembles env in two separate
+// functions, so this guards the builder/drift symmetry that prevents a reconcile
+// hot-loop. A stub OBO handler stands in for the out-of-tree enterprise handler.
+//
+//nolint:paralleltest // Mutates package-level oboHandler via RegisterOBOHandler.
+func TestMCPServerDeployment_OBOSecretEnvVars(t *testing.T) {
+	t.Cleanup(func() { ctrlutil.RegisterOBOHandler(defaultOBOHandlerStub()) })
+
+	oboEnvVar := corev1.EnvVar{
+		Name: "TOOLHIVE_OBO_CLIENT_SECRET",
+		ValueFrom: &corev1.EnvVarSource{
+			SecretKeyRef: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: "obo-secret"},
+				Key:                  "client-secret",
+			},
+		},
+	}
+	stub := defaultOBOHandlerStub()
+	stub.SecretEnvVars = func(*mcpv1beta1.MCPExternalAuthConfig) ([]corev1.EnvVar, error) {
+		return []corev1.EnvVar{oboEnvVar}, nil
+	}
+	ctrlutil.RegisterOBOHandler(stub)
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	authConfig := &mcpv1beta1.MCPExternalAuthConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "obo-config", Namespace: "default"},
+		Spec: mcpv1beta1.MCPExternalAuthConfigSpec{
+			Type: mcpv1beta1.ExternalAuthTypeOBO,
+			OBO:  &mcpv1beta1.OBOConfig{},
+		},
+	}
+	mcpServer := &mcpv1beta1.MCPServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-server", Namespace: "default"},
+		Spec: mcpv1beta1.MCPServerSpec{
+			Image:                 "test-image:latest",
+			Transport:             "stdio",
+			ProxyPort:             8080,
+			ExternalAuthConfigRef: &mcpv1beta1.ExternalAuthConfigRef{Name: authConfig.Name},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(authConfig).
+		Build()
+
+	reconciler := newTestMCPServerReconciler(fakeClient, scheme, kubernetes.PlatformKubernetes)
+
+	deployment, err := reconciler.deploymentForMCPServer(t.Context(), mcpServer, "test-checksum")
+	require.NoError(t, err)
+	require.NotNil(t, deployment)
+
+	container := deployment.Spec.Template.Spec.Containers[0]
+	assert.Contains(t, container.Env, oboEnvVar,
+		"OBO handler SecretEnvVars output must be injected into the proxy container")
+
+	assert.False(t, reconciler.deploymentNeedsUpdate(t.Context(), deployment, mcpServer, "test-checksum"),
+		"builder and drift check must agree on the OBO env var (no reconcile hot-loop)")
 }

--- a/cmd/thv-operator/controllers/virtualmcpserver_deployment.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_deployment.go
@@ -492,14 +492,14 @@ func (r *VirtualMCPServerReconciler) buildOutgoingAuthEnvVars(
 
 	// Mount secret from Default ExternalAuthConfigRef
 	if vmcp.Spec.OutgoingAuth.Default != nil && vmcp.Spec.OutgoingAuth.Default.ExternalAuthConfigRef != nil {
-		defaultSecret, err := r.getExternalAuthConfigSecretEnvVar(
+		defaultSecrets, err := r.getExternalAuthConfigSecretEnvVars(
 			ctx, vmcp.Namespace, vmcp.Spec.OutgoingAuth.Default.ExternalAuthConfigRef.Name)
 		if err != nil {
 			ctxLogger := log.FromContext(ctx)
 			ctxLogger.V(1).Info("Failed to get Default ExternalAuthConfig secret, continuing without it",
 				"error", err)
-		} else if defaultSecret != nil {
-			env = append(env, *defaultSecret)
+		} else {
+			env = append(env, defaultSecrets...)
 		}
 	}
 
@@ -697,16 +697,14 @@ func (r *VirtualMCPServerReconciler) discoverExternalAuthConfigSecrets(
 		seenConfigs[configName] = true
 
 		// Get the secret env var for this ExternalAuthConfig
-		secretEnvVar, err := r.getExternalAuthConfigSecretEnvVar(ctx, vmcp.Namespace, configName)
+		secretEnvVars, err := r.getExternalAuthConfigSecretEnvVars(ctx, vmcp.Namespace, configName)
 		if err != nil {
 			ctxLogger.V(1).Info("Failed to get ExternalAuthConfig secret, skipping",
 				"externalAuthConfig", configName,
 				"error", err)
 			continue
 		}
-		if secretEnvVar != nil {
-			envVars = append(envVars, *secretEnvVar)
-		}
+		envVars = append(envVars, secretEnvVars...)
 	}
 
 	// Sort by name for deterministic ordering. The Kubernetes informer cache returns
@@ -744,7 +742,7 @@ func (r *VirtualMCPServerReconciler) discoverInlineExternalAuthConfigSecrets(
 		seenConfigs[configName] = true
 
 		// Get the secret env var for this ExternalAuthConfig
-		secretEnvVar, err := r.getExternalAuthConfigSecretEnvVar(ctx, vmcp.Namespace, configName)
+		secretEnvVars, err := r.getExternalAuthConfigSecretEnvVars(ctx, vmcp.Namespace, configName)
 		if err != nil {
 			ctxLogger := log.FromContext(ctx)
 			ctxLogger.V(1).Info("Failed to get ExternalAuthConfig secret, skipping",
@@ -752,9 +750,7 @@ func (r *VirtualMCPServerReconciler) discoverInlineExternalAuthConfigSecrets(
 				"error", err)
 			continue
 		}
-		if secretEnvVar != nil {
-			envVars = append(envVars, *secretEnvVar)
-		}
+		envVars = append(envVars, secretEnvVars...)
 	}
 
 	// Sort by name for the same reason as discoverExternalAuthConfigSecrets: Go map
@@ -767,15 +763,21 @@ func (r *VirtualMCPServerReconciler) discoverInlineExternalAuthConfigSecrets(
 	return envVars
 }
 
-// getExternalAuthConfigSecretEnvVar returns an environment variable for secrets
-// from an ExternalAuthConfig (token exchange client secrets or header injection values).
-// Generates unique env var names per ExternalAuthConfig to avoid conflicts when multiple
-// configs of the same type reference different secrets.
-func (r *VirtualMCPServerReconciler) getExternalAuthConfigSecretEnvVar(
+// getExternalAuthConfigSecretEnvVars returns the environment variables for
+// secrets from an ExternalAuthConfig (token exchange client secrets, header
+// injection values, or — for obo — whatever the registered OBO handler asks
+// for). Generates unique env var names per ExternalAuthConfig to avoid conflicts
+// when multiple configs of the same type reference different secrets.
+//
+// The obo arm forwards every env var the handler returns (matching MCPServer and
+// MCPRemoteProxy) and propagates obo.ErrEnterpriseRequired so the wired-but-
+// disabled state is not masked as a no-op (see #5328); callers log-and-continue
+// on error.
+func (r *VirtualMCPServerReconciler) getExternalAuthConfigSecretEnvVars(
 	ctx context.Context,
 	namespace string,
 	externalAuthConfigName string,
-) (*corev1.EnvVar, error) {
+) ([]corev1.EnvVar, error) {
 	// Fetch the MCPExternalAuthConfig
 	externalAuthConfig, err := ctrlutil.GetExternalAuthConfigByName(
 		ctx, r.Client, namespace, externalAuthConfigName)
@@ -832,13 +834,19 @@ func (r *VirtualMCPServerReconciler) getExternalAuthConfigSecretEnvVar(
 		return nil, nil
 
 	case mcpv1beta1.ExternalAuthTypeOBO:
-		return firstOBOSecretEnvVar(externalAuthConfig)
+		// Dispatch through the registered OBO handler, forwarding every env var
+		// it returns. OBOSecretEnvVars propagates obo.ErrEnterpriseRequired in
+		// upstream-only builds (unlike ctrlutil.AddOBOSecretEnvVars, which
+		// swallows it for MCPServer/MCPRemoteProxy builder/drift symmetry); vMCP
+		// must propagate it per #5328 so the wired-but-disabled state is not
+		// masked as a no-op.
+		return ctrlutil.OBOSecretEnvVars(externalAuthConfig)
 
 	default:
 		return nil, nil // Not applicable
 	}
 
-	return &corev1.EnvVar{
+	return []corev1.EnvVar{{
 		Name: envVarName,
 		ValueFrom: &corev1.EnvVarSource{
 			SecretKeyRef: &corev1.SecretKeySelector{
@@ -848,21 +856,7 @@ func (r *VirtualMCPServerReconciler) getExternalAuthConfigSecretEnvVar(
 				Key: secretRef.Key,
 			},
 		},
-	}, nil
-}
-
-// firstOBOSecretEnvVar dispatches through the registered OBO handler and
-// returns the first env var (if any) or the dispatch error. In upstream-only
-// builds the default handler returns obo.ErrEnterpriseRequired; an out-of-tree
-// build registers a real handler via controllerutil.RegisterOBOHandler.
-// Extracted from getExternalAuthConfigSecretEnvVar to keep its cyclomatic
-// complexity below the project threshold.
-func firstOBOSecretEnvVar(cfg *mcpv1beta1.MCPExternalAuthConfig) (*corev1.EnvVar, error) {
-	envVars, err := ctrlutil.OBOSecretEnvVars(cfg)
-	if err != nil || len(envVars) == 0 {
-		return nil, err
-	}
-	return &envVars[0], nil
+	}}, nil
 }
 
 // buildDeploymentMetadataForVmcp builds deployment-level labels and annotations

--- a/cmd/thv-operator/controllers/virtualmcpserver_externalauth_test.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_externalauth_test.go
@@ -1516,7 +1516,7 @@ func TestDiscoverExternalAuthConfigSecrets_DeterministicOrdering(t *testing.T) {
 			}
 
 			// One MCPExternalAuthConfig per MCPServer, each with a client secret ref so
-			// getExternalAuthConfigSecretEnvVar returns a non-nil env var.
+			// getExternalAuthConfigSecretEnvVars returns a non-empty env var slice.
 			authConfigs := []client.Object{
 				&mcpv1beta1.MCPExternalAuthConfig{
 					ObjectMeta: metav1.ObjectMeta{Name: "alpha-auth", Namespace: "default"},
@@ -1827,12 +1827,14 @@ func TestBuildOutgoingAuthConfig_InlineBackendSubjectProviderInjection(t *testin
 		"inline backend SubjectProviderName should be injected from first upstream")
 }
 
-// TestGetExternalAuthConfigSecretEnvVar_OBO proves the obo arm of the
-// getExternalAuthConfigSecretEnvVar switch dispatches through the registered
+// TestGetExternalAuthConfigSecretEnvVars_OBO proves the obo arm of the
+// getExternalAuthConfigSecretEnvVars switch dispatches through the registered
 // OBO handler. With the default handler the method must return an error
 // wrapping obo.ErrEnterpriseRequired AND must not silently fall through to
-// nil, nil — that would mask the wired-but-disabled state behind a no-op.
-func TestGetExternalAuthConfigSecretEnvVar_OBO(t *testing.T) {
+// nil, nil — that would mask the wired-but-disabled state behind a no-op. This
+// propagate-on-disabled contract is why vMCP calls OBOSecretEnvVars directly
+// rather than the swallowing ctrlutil.AddOBOSecretEnvVars wrapper.
+func TestGetExternalAuthConfigSecretEnvVars_OBO(t *testing.T) {
 	t.Parallel()
 
 	scheme := runtime.NewScheme()
@@ -1861,11 +1863,11 @@ func TestGetExternalAuthConfigSecretEnvVar_OBO(t *testing.T) {
 		PlatformDetector: ctrlutil.NewSharedPlatformDetector(),
 	}
 
-	envVar, err := r.getExternalAuthConfigSecretEnvVar(t.Context(), "default", authCfg.Name)
+	envVars, err := r.getExternalAuthConfigSecretEnvVars(t.Context(), "default", authCfg.Name)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, obo.ErrEnterpriseRequired,
 		"the default OBO handler returns obo.ErrEnterpriseRequired; the dispatch arm must propagate it")
-	assert.Nil(t, envVar, "no env var should be returned on the error path")
+	assert.Empty(t, envVars, "no env var should be returned on the error path")
 
 	// Generic-error guard: per issue #5328 AC, neither generic substring may
 	// leak from any of the three consumer dispatch paths.

--- a/cmd/thv-operator/pkg/controllerutil/tokenexchange.go
+++ b/cmd/thv-operator/pkg/controllerutil/tokenexchange.go
@@ -5,6 +5,7 @@ package controllerutil
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -260,6 +261,62 @@ func AddExternalAuthConfigOptions(
 	default:
 		return fmt.Errorf("unsupported external auth type: %s", externalAuthConfig.Spec.Type)
 	}
+}
+
+// AddExternalAuthConfigSecretEnvVars resolves ref to an MCPExternalAuthConfig
+// and returns the pod environment variables its auth type needs at runtime. It
+// is the secret-env counterpart of AddExternalAuthConfigOptions, which wires the
+// same configs into the RunConfig/middleware path; this helper exists so every
+// consumer (MCPServer, MCPRemoteProxy, VirtualMCPServer) reaches the OBO
+// handler's SecretEnvVars through one shared dispatch point instead of each
+// remembering to call it.
+//
+// Scope: this dispatches only the obo type. Its env var name is defined by the
+// registered OBOHandler and is therefore identical across every consumer, which
+// is what makes a single shared dispatcher correct for it. The other auth types
+// deliberately return no env vars here — each consuming controller already
+// produces them through its own per-type helpers (GenerateTokenExchangeEnvVars,
+// GenerateBearerTokenEnvVar, VirtualMCPServer's getExternalAuthConfigSecretEnvVar
+// switch), which use consumer-specific env var names that must stay byte
+// identical. Do NOT move those types here, and do NOT drop the existing per-type
+// calls assuming this helper covers them.
+//
+// A build without a registered OBO handler yields obo.ErrEnterpriseRequired from
+// the dispatch; that is treated as "no env vars" (obo is inert) rather than an
+// error, so the deployment builder and drift-check paths compute identical env
+// and the Deployment does not enter a reconcile hot-loop. The
+// MCPExternalAuthConfig reconciler is what surfaces the enterprise-required state
+// to the user.
+func AddExternalAuthConfigSecretEnvVars(
+	ctx context.Context,
+	c client.Client,
+	namespace string,
+	ref *mcpv1beta1.ExternalAuthConfigRef,
+) ([]corev1.EnvVar, error) {
+	if ref == nil {
+		return nil, nil
+	}
+
+	externalAuthConfig, err := GetExternalAuthConfigByName(ctx, c, namespace, ref.Name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get MCPExternalAuthConfig: %w", err)
+	}
+
+	// Only the obo type contributes secret env vars through this shared
+	// dispatcher; every other type is handled by the consumer's own per-type
+	// helpers (see the doc comment).
+	if externalAuthConfig.Spec.Type != mcpv1beta1.ExternalAuthTypeOBO {
+		return nil, nil
+	}
+
+	envVars, err := OBOSecretEnvVars(externalAuthConfig)
+	if errors.Is(err, obo.ErrEnterpriseRequired) {
+		// No OBO handler registered (upstream-only build): obo is inert. Return
+		// no env vars so the builder and drift paths agree; the
+		// MCPExternalAuthConfig reconciler surfaces EnterpriseRequired.
+		return nil, nil
+	}
+	return envVars, err
 }
 
 func addTokenExchangeConfig(

--- a/cmd/thv-operator/pkg/controllerutil/tokenexchange.go
+++ b/cmd/thv-operator/pkg/controllerutil/tokenexchange.go
@@ -263,31 +263,33 @@ func AddExternalAuthConfigOptions(
 	}
 }
 
-// AddExternalAuthConfigSecretEnvVars resolves ref to an MCPExternalAuthConfig
-// and returns the pod environment variables its auth type needs at runtime. It
-// is the secret-env counterpart of AddExternalAuthConfigOptions, which wires the
-// same configs into the RunConfig/middleware path; this helper exists so every
-// consumer (MCPServer, MCPRemoteProxy, VirtualMCPServer) reaches the OBO
-// handler's SecretEnvVars through one shared dispatch point instead of each
-// remembering to call it.
+// AddOBOSecretEnvVars resolves ref to an MCPExternalAuthConfig and, if it is the
+// obo type, returns the pod environment variables the registered OBOHandler asks
+// for at runtime. For every other type it returns no env vars: this is the
+// OBO-only secret-env dispatcher, deliberately narrower than its sibling
+// AddExternalAuthConfigOptions (which switches on every ExternalAuthType). The
+// name says "OBO" precisely so it is not mistaken for full type coverage —
+// MCPServer / MCPRemoteProxy / VirtualMCPServer each produce the non-obo types'
+// secret env vars through their own per-type helpers (GenerateTokenExchangeEnvVars,
+// GenerateBearerTokenEnvVar, VirtualMCPServer's getExternalAuthConfigSecretEnvVars
+// switch), using consumer-specific env var names that must stay byte-identical.
+// Do NOT add the other types here, and do NOT drop the existing per-type calls
+// assuming this helper covers them.
 //
-// Scope: this dispatches only the obo type. Its env var name is defined by the
-// registered OBOHandler and is therefore identical across every consumer, which
-// is what makes a single shared dispatcher correct for it. The other auth types
-// deliberately return no env vars here — each consuming controller already
-// produces them through its own per-type helpers (GenerateTokenExchangeEnvVars,
-// GenerateBearerTokenEnvVar, VirtualMCPServer's getExternalAuthConfigSecretEnvVar
-// switch), which use consumer-specific env var names that must stay byte
-// identical. Do NOT move those types here, and do NOT drop the existing per-type
-// calls assuming this helper covers them.
+// obo is the one type a single dispatcher can own, because its env var name is
+// defined by the handler and is therefore identical across consumers; the others
+// are not. Routing the obo path through here is what keeps consumers from
+// drifting — the failure mode #5537 fixed.
 //
 // A build without a registered OBO handler yields obo.ErrEnterpriseRequired from
 // the dispatch; that is treated as "no env vars" (obo is inert) rather than an
 // error, so the deployment builder and drift-check paths compute identical env
 // and the Deployment does not enter a reconcile hot-loop. The
 // MCPExternalAuthConfig reconciler is what surfaces the enterprise-required state
-// to the user.
-func AddExternalAuthConfigSecretEnvVars(
+// to the user. (VirtualMCPServer intentionally does NOT route through this
+// wrapper: its dispatch must propagate ErrEnterpriseRequired per #5328, so it
+// calls OBOSecretEnvVars directly — but it likewise forwards every env var.)
+func AddOBOSecretEnvVars(
 	ctx context.Context,
 	c client.Client,
 	namespace string,
@@ -302,9 +304,6 @@ func AddExternalAuthConfigSecretEnvVars(
 		return nil, fmt.Errorf("failed to get MCPExternalAuthConfig: %w", err)
 	}
 
-	// Only the obo type contributes secret env vars through this shared
-	// dispatcher; every other type is handled by the consumer's own per-type
-	// helpers (see the doc comment).
 	if externalAuthConfig.Spec.Type != mcpv1beta1.ExternalAuthTypeOBO {
 		return nil, nil
 	}
@@ -316,9 +315,7 @@ func AddExternalAuthConfigSecretEnvVars(
 		// MCPExternalAuthConfig reconciler surfaces EnterpriseRequired.
 		return nil, nil
 	}
-	// Forward every env var the handler returns. Note VirtualMCPServer's
-	// firstOBOSecretEnvVar keeps only the first; harmless while handlers return
-	// a single var, but the two should be reconciled if that ever changes.
+	// Forward every env var the handler returns.
 	return envVars, err
 }
 

--- a/cmd/thv-operator/pkg/controllerutil/tokenexchange.go
+++ b/cmd/thv-operator/pkg/controllerutil/tokenexchange.go
@@ -316,6 +316,9 @@ func AddExternalAuthConfigSecretEnvVars(
 		// MCPExternalAuthConfig reconciler surfaces EnterpriseRequired.
 		return nil, nil
 	}
+	// Forward every env var the handler returns. Note VirtualMCPServer's
+	// firstOBOSecretEnvVar keeps only the first; harmless while handlers return
+	// a single var, but the two should be reconciled if that ever changes.
 	return envVars, err
 }
 

--- a/cmd/thv-operator/pkg/controllerutil/tokenexchange_test.go
+++ b/cmd/thv-operator/pkg/controllerutil/tokenexchange_test.go
@@ -290,12 +290,18 @@ func TestAddExternalAuthConfigOptions_OBO(t *testing.T) {
 	assert.Empty(t, options, "default OBO handler must not append to the options slice")
 }
 
-// TestAddExternalAuthConfigSecretEnvVars covers the shared secret-env dispatcher
-// across every ExternalAuthType. Only obo contributes env vars (and only when a
-// handler is registered); every other type, plus a nil ref, yields no env vars.
-// A build with the default OBO handler treats obo as inert (no env vars, no
-// error) so the deployment builder and drift-check paths stay byte-identical.
-func TestAddExternalAuthConfigSecretEnvVars(t *testing.T) {
+// TestAddOBOSecretEnvVars covers the OBO-only secret-env dispatcher across every
+// ExternalAuthType. Only obo contributes env vars (and only when a handler is
+// registered); every other type, plus a nil ref, yields no env vars. A build
+// with the default OBO handler treats obo as inert (no env vars, no error) so the
+// deployment builder and drift-check paths stay byte-identical.
+//
+// Regression guard: newConfig populates the secret-bearing sub-spec for the
+// non-obo types that have one (tokenExchange, bearerToken, headerInjection), so
+// the "must stay empty" assertions below would fail if a future dev ever wired
+// one of those types into AddOBOSecretEnvVars — the empty result is then a real
+// invariant, not an artifact of an absent secret ref.
+func TestAddOBOSecretEnvVars(t *testing.T) {
 	t.Parallel()
 
 	scheme := runtime.NewScheme()
@@ -309,8 +315,26 @@ func TestAddExternalAuthConfigSecretEnvVars(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
 			Spec:       mcpv1beta1.MCPExternalAuthConfigSpec{Type: typ},
 		}
-		if typ == mcpv1beta1.ExternalAuthTypeOBO {
+		switch typ {
+		case mcpv1beta1.ExternalAuthTypeTokenExchange:
+			cfg.Spec.TokenExchange = &mcpv1beta1.TokenExchangeConfig{
+				ClientSecretRef: &mcpv1beta1.SecretKeyRef{Name: name + "-secret", Key: "client-secret"},
+			}
+		case mcpv1beta1.ExternalAuthTypeBearerToken:
+			cfg.Spec.BearerToken = &mcpv1beta1.BearerTokenConfig{
+				TokenSecretRef: &mcpv1beta1.SecretKeyRef{Name: name + "-secret", Key: "token"},
+			}
+		case mcpv1beta1.ExternalAuthTypeHeaderInjection:
+			cfg.Spec.HeaderInjection = &mcpv1beta1.HeaderInjectionConfig{
+				ValueSecretRef: &mcpv1beta1.SecretKeyRef{Name: name + "-secret", Key: "value"},
+			}
+		case mcpv1beta1.ExternalAuthTypeOBO:
 			cfg.Spec.OBO = &mcpv1beta1.OBOConfig{}
+		case mcpv1beta1.ExternalAuthTypeUnauthenticated,
+			mcpv1beta1.ExternalAuthTypeEmbeddedAuthServer,
+			mcpv1beta1.ExternalAuthTypeAWSSts,
+			mcpv1beta1.ExternalAuthTypeUpstreamInject:
+			// No secret-bearing sub-spec to populate for these types.
 		}
 		return cfg
 	}
@@ -381,7 +405,7 @@ func TestAddExternalAuthConfigSecretEnvVars(t *testing.T) {
 				builder = builder.WithObjects(tt.seed)
 			}
 
-			envVars, err := AddExternalAuthConfigSecretEnvVars(t.Context(), builder.Build(), ns, tt.ref)
+			envVars, err := AddOBOSecretEnvVars(t.Context(), builder.Build(), ns, tt.ref)
 			if tt.wantErr {
 				require.Error(t, err)
 				return
@@ -392,12 +416,12 @@ func TestAddExternalAuthConfigSecretEnvVars(t *testing.T) {
 	}
 }
 
-// TestAddExternalAuthConfigSecretEnvVars_OBOHandlerRegistered proves the obo arm
-// forwards a registered handler's env vars verbatim and propagates a genuine
+// TestAddOBOSecretEnvVars_OBOHandlerRegistered proves the obo arm forwards a
+// registered handler's env vars verbatim and propagates a genuine
 // (non-enterprise) handler error, while still swallowing ErrEnterpriseRequired.
 //
 //nolint:paralleltest // Mutates package-level oboHandler; must not race other tests.
-func TestAddExternalAuthConfigSecretEnvVars_OBOHandlerRegistered(t *testing.T) {
+func TestAddOBOSecretEnvVars_OBOHandlerRegistered(t *testing.T) {
 	withDefaultOBOHandler(t)
 
 	scheme := runtime.NewScheme()
@@ -441,7 +465,7 @@ func TestAddExternalAuthConfigSecretEnvVars_OBOHandlerRegistered(t *testing.T) {
 		},
 	})
 
-	envVars, err := AddExternalAuthConfigSecretEnvVars(t.Context(), fakeClient, ns, ref)
+	envVars, err := AddOBOSecretEnvVars(t.Context(), fakeClient, ns, ref)
 	require.NoError(t, err)
 	assert.Equal(t, expected, envVars, "the dispatcher must forward the handler's env vars verbatim")
 
@@ -455,7 +479,7 @@ func TestAddExternalAuthConfigSecretEnvVars_OBOHandlerRegistered(t *testing.T) {
 		},
 	})
 
-	envVars, err = AddExternalAuthConfigSecretEnvVars(t.Context(), fakeClient, ns, ref)
+	envVars, err = AddOBOSecretEnvVars(t.Context(), fakeClient, ns, ref)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, sentinel, "a genuine handler error must propagate, not be swallowed")
 	assert.Nil(t, envVars)

--- a/cmd/thv-operator/pkg/controllerutil/tokenexchange_test.go
+++ b/cmd/thv-operator/pkg/controllerutil/tokenexchange_test.go
@@ -289,3 +289,174 @@ func TestAddExternalAuthConfigOptions_OBO(t *testing.T) {
 	assert.NotContains(t, err.Error(), "unknown middleware type")
 	assert.Empty(t, options, "default OBO handler must not append to the options slice")
 }
+
+// TestAddExternalAuthConfigSecretEnvVars covers the shared secret-env dispatcher
+// across every ExternalAuthType. Only obo contributes env vars (and only when a
+// handler is registered); every other type, plus a nil ref, yields no env vars.
+// A build with the default OBO handler treats obo as inert (no env vars, no
+// error) so the deployment builder and drift-check paths stay byte-identical.
+func TestAddExternalAuthConfigSecretEnvVars(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	const ns = "default"
+
+	newConfig := func(name string, typ mcpv1beta1.ExternalAuthType) *mcpv1beta1.MCPExternalAuthConfig {
+		cfg := &mcpv1beta1.MCPExternalAuthConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+			Spec:       mcpv1beta1.MCPExternalAuthConfigSpec{Type: typ},
+		}
+		if typ == mcpv1beta1.ExternalAuthTypeOBO {
+			cfg.Spec.OBO = &mcpv1beta1.OBOConfig{}
+		}
+		return cfg
+	}
+
+	tests := []struct {
+		name    string
+		seed    *mcpv1beta1.MCPExternalAuthConfig // object stored in the fake client (nil = none)
+		ref     *mcpv1beta1.ExternalAuthConfigRef
+		wantErr bool
+	}{
+		{
+			name: "nil ref returns no env vars",
+			ref:  nil,
+		},
+		{
+			name:    "missing config returns error",
+			ref:     &mcpv1beta1.ExternalAuthConfigRef{Name: "does-not-exist"},
+			wantErr: true,
+		},
+		{
+			name: "tokenExchange type contributes no env vars here",
+			seed: newConfig("te", mcpv1beta1.ExternalAuthTypeTokenExchange),
+			ref:  &mcpv1beta1.ExternalAuthConfigRef{Name: "te"},
+		},
+		{
+			name: "bearerToken type contributes no env vars here",
+			seed: newConfig("bt", mcpv1beta1.ExternalAuthTypeBearerToken),
+			ref:  &mcpv1beta1.ExternalAuthConfigRef{Name: "bt"},
+		},
+		{
+			name: "headerInjection type contributes no env vars here",
+			seed: newConfig("hi", mcpv1beta1.ExternalAuthTypeHeaderInjection),
+			ref:  &mcpv1beta1.ExternalAuthConfigRef{Name: "hi"},
+		},
+		{
+			name: "unauthenticated type contributes no env vars here",
+			seed: newConfig("un", mcpv1beta1.ExternalAuthTypeUnauthenticated),
+			ref:  &mcpv1beta1.ExternalAuthConfigRef{Name: "un"},
+		},
+		{
+			name: "embeddedAuthServer type contributes no env vars here",
+			seed: newConfig("eas", mcpv1beta1.ExternalAuthTypeEmbeddedAuthServer),
+			ref:  &mcpv1beta1.ExternalAuthConfigRef{Name: "eas"},
+		},
+		{
+			name: "awsSts type contributes no env vars here",
+			seed: newConfig("aws", mcpv1beta1.ExternalAuthTypeAWSSts),
+			ref:  &mcpv1beta1.ExternalAuthConfigRef{Name: "aws"},
+		},
+		{
+			name: "upstreamInject type contributes no env vars here",
+			seed: newConfig("ui", mcpv1beta1.ExternalAuthTypeUpstreamInject),
+			ref:  &mcpv1beta1.ExternalAuthConfigRef{Name: "ui"},
+		},
+		{
+			name: "obo with default handler is inert",
+			seed: newConfig("obo", mcpv1beta1.ExternalAuthTypeOBO),
+			ref:  &mcpv1beta1.ExternalAuthConfigRef{Name: "obo"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			builder := fake.NewClientBuilder().WithScheme(scheme)
+			if tt.seed != nil {
+				builder = builder.WithObjects(tt.seed)
+			}
+
+			envVars, err := AddExternalAuthConfigSecretEnvVars(t.Context(), builder.Build(), ns, tt.ref)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Empty(t, envVars, "only a registered OBO handler contributes env vars through this dispatcher")
+		})
+	}
+}
+
+// TestAddExternalAuthConfigSecretEnvVars_OBOHandlerRegistered proves the obo arm
+// forwards a registered handler's env vars verbatim and propagates a genuine
+// (non-enterprise) handler error, while still swallowing ErrEnterpriseRequired.
+//
+//nolint:paralleltest // Mutates package-level oboHandler; must not race other tests.
+func TestAddExternalAuthConfigSecretEnvVars_OBOHandlerRegistered(t *testing.T) {
+	withDefaultOBOHandler(t)
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	const ns = "default"
+	authCfg := &mcpv1beta1.MCPExternalAuthConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "obo-config", Namespace: ns},
+		Spec: mcpv1beta1.MCPExternalAuthConfigSpec{
+			Type: mcpv1beta1.ExternalAuthTypeOBO,
+			OBO:  &mcpv1beta1.OBOConfig{},
+		},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(authCfg).Build()
+	ref := &mcpv1beta1.ExternalAuthConfigRef{Name: authCfg.Name}
+
+	noopValidate := func(*mcpv1beta1.MCPExternalAuthConfig) error { return nil }
+	noopApply := func(
+		context.Context, client.Client, string,
+		*mcpv1beta1.MCPExternalAuthConfig, *[]runner.RunConfigBuilderOption,
+	) error {
+		return nil
+	}
+
+	// A registered handler's env vars are forwarded verbatim.
+	expected := []corev1.EnvVar{{
+		Name: "OBO_CLIENT_SECRET",
+		ValueFrom: &corev1.EnvVarSource{
+			SecretKeyRef: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: "obo-secret"},
+				Key:                  "token",
+			},
+		},
+	}}
+	RegisterOBOHandler(OBOHandler{
+		Validate:       noopValidate,
+		ApplyRunConfig: noopApply,
+		SecretEnvVars: func(*mcpv1beta1.MCPExternalAuthConfig) ([]corev1.EnvVar, error) {
+			return expected, nil
+		},
+	})
+
+	envVars, err := AddExternalAuthConfigSecretEnvVars(t.Context(), fakeClient, ns, ref)
+	require.NoError(t, err)
+	assert.Equal(t, expected, envVars, "the dispatcher must forward the handler's env vars verbatim")
+
+	// A genuine (non-enterprise) handler error propagates to the caller.
+	sentinel := errors.New("secret not found")
+	RegisterOBOHandler(OBOHandler{
+		Validate:       noopValidate,
+		ApplyRunConfig: noopApply,
+		SecretEnvVars: func(*mcpv1beta1.MCPExternalAuthConfig) ([]corev1.EnvVar, error) {
+			return nil, sentinel
+		},
+	})
+
+	envVars, err = AddExternalAuthConfigSecretEnvVars(t.Context(), fakeClient, ns, ref)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, sentinel, "a genuine handler error must propagate, not be swallowed")
+	assert.Nil(t, envVars)
+}


### PR DESCRIPTION
## Summary

The operator's `OBOHandler` extension point exposes three dispatch points — `Validate`, `ApplyRunConfig`, and `SecretEnvVars`. `Validate` and `ApplyRunConfig` are reached uniformly from every `MCPExternalAuthConfig` consumer, but `SecretEnvVars` was dispatched from only one of the three (`VirtualMCPServer`). As a result, in a build with a registered (enterprise) OBO handler, an `obo`-typed `MCPExternalAuthConfig` referenced from an `MCPServer` or `MCPRemoteProxy` had its OBO middleware wired into the RunConfig but never received the env var(s) the handler's `SecretEnvVars` returns — so the middleware could not read its credential at startup. (This is inert in stock builds: the default handler returns `obo.ErrEnterpriseRequired`.)

This PR closes that gap by giving the secret-env path a shared OBO dispatcher and wiring it into the two missing consumers.

- **Why:** the secret-env path lacked the single shared dispatch point that the middleware path (`AddExternalAuthConfigOptions`) already has, so two of three consumers silently omitted the OBO env vars — a "every consumer must remember to call it" failure mode.
- **What:** added `controllerutil.AddOBOSecretEnvVars` and wired it into the `MCPServer` deployment builder + drift check and into `MCPRemoteProxy`'s `buildEnvVarsForProxy`. `VirtualMCPServer`'s obo arm was also reconciled to forward **all** handler env vars (it previously kept only the first).

Closes #5537

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)
- [x] Manual testing (describe below)

Validation run: full `task operator-test` passes; `golangci-lint` is clean on all changed files. (One repo-wide pre-existing gosec finding in `cmd/thv/app/upgrade.go` is unrelated and untouched.)

Test coverage added/updated:

- Dispatcher unit tests (`tokenexchange_test.go`): every `ExternalAuthType` (nil ref, missing config, and `tokenExchange`/`bearerToken`/`headerInjection`/`unauthenticated`/`embeddedAuthServer`/`awsSts`/`upstreamInject` all contribute no env vars here; `obo` with the default handler is inert), plus a registered-handler case asserting the handler's env vars are forwarded verbatim and a genuine-error case. The non-obo rows now seed real secret refs so the "must stay empty" assertions act as regression guards.
- Controller tests: `TestMCPServerDeployment_OBOSecretEnvVars` and `TestMCPRemoteProxyDeployment_OBOSecretEnvVars` assert the OBO env var is injected into the proxy container and that the freshly built deployment does not drift; `TestMCPServerDeployment_OBOSecretEnvVars_GenuineErrorDivergence` locks in the documented builder/drift behavior on a genuine (non-enterprise) handler error.
- `VirtualMCPServer`: its obo dispatch test is updated for the slice return and still asserts `obo.ErrEnterpriseRequired` is propagated (the wired-but-disabled contract from #5328).

## Changes

| File | Change |
|------|--------|
| `cmd/thv-operator/pkg/controllerutil/tokenexchange.go` | Add `AddOBOSecretEnvVars` — resolves the ref, dispatches only the `obo` type through `OBOSecretEnvVars`, swallows `obo.ErrEnterpriseRequired` to `(nil, nil)`. Name carries the obo-only scope so it isn't mistaken for full type coverage. |
| `cmd/thv-operator/controllers/mcpserver_controller.go` | Call `AddOBOSecretEnvVars` in both `deploymentForMCPServer` (builder) and `deploymentNeedsUpdate` (drift check), at the same position, to keep the two symmetric. Add a shared `logOBOSecretEnvVarError` helper that logs verbatim only for `*obo.ValidationError` and generically otherwise (avoids leaking Secret names). |
| `cmd/thv-operator/controllers/mcpremoteproxy_deployment.go` | Call `AddOBOSecretEnvVars` in `buildEnvVarsForProxy`, which feeds both builder and drift paths; log errors via the shared `logOBOSecretEnvVarError`. |
| `cmd/thv-operator/controllers/virtualmcpserver_deployment.go` | Rename `getExternalAuthConfigSecretEnvVar` → `getExternalAuthConfigSecretEnvVars` (slice return); its obo arm now forwards **all** handler env vars via `OBOSecretEnvVars` (propagating `ErrEnterpriseRequired` per #5328); remove `firstOBOSecretEnvVar`. |
| `cmd/thv-operator/pkg/controllerutil/tokenexchange_test.go` | Table-driven unit tests for the dispatcher across every auth type (with secret-ref regression guards), plus registered-handler and error cases. |
| `cmd/thv-operator/controllers/mcpserver_externalauth_test.go` | Controller tests asserting OBO env injection + no drift for `MCPServer`, and the genuine-error builder/drift divergence. |
| `cmd/thv-operator/controllers/mcpremoteproxy_deployment_test.go` | Controller test asserting OBO env injection and no drift for `MCPRemoteProxy`. |
| `cmd/thv-operator/controllers/virtualmcpserver_externalauth_test.go` | Update the obo dispatch test for the slice return; assert `ErrEnterpriseRequired` is still propagated. |

## Does this introduce a user-facing change?

No upstream behavior change — `obo` is inert in stock builds. For out-of-tree builds with a registered OBO handler, an `obo`-typed `MCPExternalAuthConfig` referenced from an `MCPServer` or `MCPRemoteProxy` now correctly injects the handler's secret env var(s) into the proxy container, matching `VirtualMCPServer`. `VirtualMCPServer` itself now forwards **all** of a handler's env vars rather than only the first — a no-op for today's single-var handlers, but it removes a latent divergence.

## Implementation plan

<details>
<summary>Approved implementation plan (+ PR-review updates)</summary>

The issue's literal proposal was to lift `VirtualMCPServer`'s whole env-var switch into a shared dispatcher and route all three consumers through it. That is not safe: the consumers use different env var naming for the same non-`obo` types — `MCPServer`/`MCPRemoteProxy` rely on the fixed name `TOOLHIVE_TOKEN_EXCHANGE_CLIENT_SECRET` that the runtime middleware hardcodes (`pkg/oauthproto/tokenexchange/middleware.go`), while `VirtualMCPServer` uses unique per-config names. Routing them through vMCP's switch would break the runtime and violate the issue's own "byte-identical pod env per consumer" acceptance criterion.

The dispatcher is therefore scoped to only the `obo` type, whose env var name is handler-defined and identical across consumers. Every other type keeps its existing per-consumer helper. This scoping ("Option A") was explicitly approved before implementation.

`AddOBOSecretEnvVars` swallows `obo.ErrEnterpriseRequired` (returns `nil, nil`), so the `MCPServer` builder and drift check stay symmetric in handler-less builds and there is no reconcile hot-loop.

**Updated after PR review (#5540):** five non-blocking findings (0 HIGH · 2 MEDIUM · 3 LOW) were addressed in two commits:

- **F2 (MEDIUM)** — renamed `AddExternalAuthConfigSecretEnvVars` → `AddOBOSecretEnvVars` so the identifier reflects the obo-only scope.
- **F1 (MEDIUM)** — corrected the drift-site comment: the builder/drift divergence on a genuine handler error persists every reconcile while the handler keeps erroring (it does not "self-resolve" for persistent errors).
- **F5 (LOW)** — log raw handler errors verbatim only for `*obo.ValidationError`; otherwise a generic message pointing at the `MCPExternalAuthConfig` status, so transient errors don't leak Secret names.
- **F3 (LOW)** — secret-ref regression guards in the dispatcher table + a controller test locking in the genuine-error divergence.
- **F4 (LOW)** — reconciled `VirtualMCPServer` rather than deferring: it now forwards **all** obo env vars. It still calls `OBOSecretEnvVars` directly (not `AddOBOSecretEnvVars`), because that wrapper swallows `ErrEnterpriseRequired` and vMCP must *propagate* it per #5328 (its test enforces the wired-but-disabled contract). So all three consumers now forward all obo env vars and differ only in the intentional, separately-tested `ErrEnterpriseRequired` handling.

All five acceptance criteria from the issue are met and verified by the tests above.

</details>

## Special notes for reviewers

- **Scoping is deliberate.** `AddOBOSecretEnvVars` handles only the `obo` type by design; the doc comment explains why the other types must stay on their per-consumer helpers (consumer-specific env var names that must remain byte-identical). Please do not "complete" the switch by moving other types into it — that would reintroduce the runtime breakage described in the implementation plan.
- **Builder/drift symmetry.** In `MCPServer`, the dispatcher is called at the same position in both `deploymentForMCPServer` and `deploymentNeedsUpdate`; in `MCPRemoteProxy` the single `buildEnvVarsForProxy` feeds both paths. The `ErrEnterpriseRequired`-to-`(nil, nil)` swallow is what keeps the two sides computing identical env in handler-less builds. On a *genuine* handler error the `MCPServer` builder logs-and-continues while the drift check reports drift — a pre-existing pattern (token-exchange behaves the same), documented at the drift site and out of scope to unify here.
- **`VirtualMCPServer` keeps a separate dispatch on purpose.** It calls `OBOSecretEnvVars` directly rather than `AddOBOSecretEnvVars`, because it must propagate `ErrEnterpriseRequired` (the swallowing wrapper would mask the wired-but-disabled state, breaking the #5328 contract its test enforces). All three consumers now forward every handler env var; only the `ErrEnterpriseRequired` handling differs, and that difference is intentional and tested on both sides.
