### PR TITLE
Replace retest action with inline gh api script

### DIFF
--- a/.github/workflows/retest.yaml
+++ b/.github/workflows/retest.yaml
@@ -7,17 +7,20 @@
 #     default branch, never the version in the PR. A malicious PR cannot alter
 #     this workflow to steal the token. Review/protect this file on `main`.
 #   - The job uses the ephemeral, auto-revoked GITHUB_TOKEN (NOT a PAT/App key).
-#     Its only powers here are: re-run/cancel workflow runs in THIS repo, and
-#     react/comment on the triggering comment. It cannot read secrets, push
-#     code, or change settings.
+#     Its only powers here are: re-run workflow runs in THIS repo, and
+#     react to the triggering comment. It cannot read secrets, push code, or
+#     change settings.
 #   - Triggering is gated to org members/collaborators so arbitrary public
-#     users cannot replay CI.
-#   - The action is a third-party node action holding the token, so it is
-#     pinned to a full commit SHA. Treat any bump as a code-review event.
+#     users cannot replay CI, and the comment body must contain "/retest".
+#   - No third-party action holds the token: the re-run is a few lines of
+#     `gh api` calls owned in this repo. (We previously used
+#     envoyproxy/toolshed retest, but that action assumes check runs carry a
+#     populated output.title/text — true for its AZP/App checks but null for
+#     plain GitHub Actions checks — so it crashed on a null dereference.)
 #
 # BEFORE enabling, confirm there is NO privileged/side-effecting workflow
 # (pull_request_target, deploy, release, publish, etc.) on this repo's PRs that
-# a /retest could replay with secrets. retest re-runs existing runs on the PR
+# a /retest could replay with secrets. We re-run existing failed runs on the PR
 # head; for normal fork pull_request runs that is sandboxed and safe.
 
 name: Retest Action on PR Comment
@@ -34,11 +37,13 @@ jobs:
   retest:
     name: Retest
     runs-on: ubuntu-24.04
-    # Only run for PR comments, in this repo, from a trusted author, and not bots.
+    # Only run for PR comments containing "/retest", in this repo, from a
+    # trusted author, and not bots.
     if: >-
       ${{
         github.event.issue.pull_request
         && github.repository == 'stacklok/toolhive'
+        && contains(github.event.comment.body, '/retest')
         && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'),
                     github.event.comment.author_association)
         && github.actor != 'dependabot[bot]'
@@ -46,14 +51,50 @@ jobs:
       }}
     permissions:
       actions: write         # re-run failed workflow runs
-      checks: write
-      pull-requests: write   # react/comment on the triggering comment
+      pull-requests: write   # react to the triggering comment
     steps:
-      - name: Retest
-        # actions-v0.4.17 -> pinned to its commit SHA. Bump deliberately.
-        uses: envoyproxy/toolshed/actions/retest@1f5b552c6749502b885cb8cf23549b929e745547
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          comment-id: ${{ github.event.comment.id }}
-          pr-url: ${{ github.event.issue.pull_request.url }}
-          app-owner: github-actions
+      - name: Re-run failed workflow runs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.issue.pull_request.url }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          react() { gh api -X POST "repos/$REPO/issues/comments/$COMMENT_ID/reactions" -f content="$1" >/dev/null; }
+
+          # Acknowledge immediately so the commenter gets feedback.
+          react eyes
+
+          head_sha=$(gh api "$PR_URL" --jq '.head.sha')
+
+          # Capture the query separately so a transient API failure surfaces as
+          # an error (set -e) rather than being mistaken for "nothing to retry".
+          runs_json=$(gh api "repos/$REPO/actions/runs?head_sha=$head_sha&per_page=100")
+          mapfile -t run_ids < <(jq -r \
+            '.workflow_runs[] | select(.conclusion=="failure" or .conclusion=="cancelled" or .conclusion=="timed_out") | .id' \
+            <<<"$runs_json")
+
+          if [ ${#run_ids[@]} -eq 0 ]; then
+            echo "No failed runs to retry"
+            react confused
+            exit 0
+          fi
+
+          failures=0
+          for id in "${run_ids[@]}"; do
+            echo "Re-running failed jobs for run $id"
+            if ! gh api -X POST "repos/$REPO/actions/runs/$id/rerun-failed-jobs" >/dev/null; then
+              echo "::warning::Could not re-run $id (too old or not retryable)"
+              failures=$((failures + 1))
+            fi
+          done
+
+          if [ "$failures" -eq "${#run_ids[@]}" ]; then
+            echo "All re-run attempts failed"
+            react confused
+            exit 1
+          fi
+
+          react rocket


### PR DESCRIPTION
## Summary

**Why:** The `/retest` workflow has never actually re-run anything — it fails on every invocation. The `envoyproxy/toolshed` retest action (v0.4.17) is built for Envoy's Azure Pipelines / GitHub App checks and is incompatible with plain GitHub Actions checks:

- After queuing the re-run, it tries to mark the old check "restarted" via `check.output.title.replace(...)` and `check.output.text.split(...)`, assuming both are populated strings.
- GitHub Actions check runs leave `output.title`/`output.text` **null**, so this is a null dereference. Because it runs inside a floating `async` callback, it surfaces as an unhandled promise rejection and the job dies with a raw Node stack dump (e.g. [run 27448026432](https://github.com/stacklok/toolhive/actions/runs/27448026432/job/81137267776)).
- The same code is present on the action's `main` branch, so bumping the pinned SHA would not fix it.

Earlier symptoms in this saga were the same root incompatibility: a harmless `No creds for AZP` warning (we don't use Azure Pipelines), and a 😕 "nothing retested" reaction caused by the action's `app-owner` filter matching zero checks when left unset.

**What:** Remove the third-party action and inline the re-run as a few `gh api` calls we own and can read:

- Resolve the PR head SHA, list its workflow runs, and re-run any with conclusion `failure`, `cancelled`, or `timed_out` via `rerun-failed-jobs`.
- Reactions: 👀 on start, 🚀 on success, 😕 when there's nothing to retry or all re-runs fail.
- Tighten the trigger to require `/retest` in the comment body — the action ignored the body, so previously any member comment triggered the job.
- Drop the now-unneeded `checks: write` permission (only `actions: write` + `pull-requests: write` remain).

This also removes the AZP code path, the `app-owner` quirk, and the standing maintenance/security burden of a third-party node action holding the token.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Test plan

- [x] Validated the workflow YAML parses and the embedded shell passes `bash -n`.
- [x] Confirmed via the GitHub API that GitHub Actions check runs in this repo have null `output.title`/`output.text` (the trigger for the action's crash).

Note: an `issue_comment` workflow only executes from the default branch, so an end-to-end `/retest` can only be exercised once this is merged to `main`.

## Special notes for reviewers

- `issue_comment` workflows always run the copy of this file on `main`, never the PR's version — review this file on `main` accordingly.
- The job uses the ephemeral `GITHUB_TOKEN`; its only powers are re-running workflow runs and reacting to the triggering comment.
- The trusted-author gating (`OWNER`/`MEMBER`/`COLLABORATOR`, no bots) is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)