### PR TITLE
Isolate TestWorkloadFromContainerInfo state writes

### DIFF
--- a/pkg/workloads/types/workload_test.go
+++ b/pkg/workloads/types/workload_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/adrg/xdg"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -21,9 +22,15 @@ import (
 func TestWorkloadFromContainerInfo(t *testing.T) {
 	ctx := context.Background()
 
-	// Create a temporary directory for XDG_STATE_HOME
+	// Create a temporary directory for XDG_STATE_HOME.
+	// xdg caches XDG_STATE_HOME at package init, so t.Setenv alone is not
+	// enough: we must call xdg.Reload() to re-read the env var before
+	// constructing the store, otherwise it writes to the developer's real
+	// state dir. Restore the cached value on cleanup.
 	tmpBase := t.TempDir()
 	t.Setenv("XDG_STATE_HOME", tmpBase)
+	xdg.Reload()
+	t.Cleanup(xdg.Reload)
 
 	// Initialize the run config store
 	store, err := state.NewRunConfigStore(state.DefaultAppName)


### PR DESCRIPTION
## Summary

`TestWorkloadFromContainerInfo` was writing synthetic runconfigs into the developer's **real** ToolHive state directory instead of the temp dir it intended to use. The leaked files (`test-workload.json`, `test-workload-sse.json`, `test-workload-direct.json`) persist across runs and reboots, so `thv list` logs a WARN line for each one on every invocation because no container backs them.

The root cause is the `github.com/adrg/xdg` cache: `xdg.StateHome` is read once at package init, and `state.NewLocalStore` resolves its `basePath` from it at construction time. The test set `XDG_STATE_HOME` via `t.Setenv` but never called `xdg.Reload()`, so the store was built against the original (developer) state dir.

Closes #5545

<details>
<summary><strong>Medium level</strong></summary>

- Call `xdg.Reload()` immediately after `t.Setenv("XDG_STATE_HOME", tmpBase)` and before `state.NewRunConfigStore`, so the store resolves its base path from the temp dir.
- Register `t.Cleanup(xdg.Reload)` to restore the cached value for any subsequent tests in the package.
- Add the `github.com/adrg/xdg` import.

</details>

<details>
<summary><strong>Low level</strong></summary>

| File | Change |
|------|--------|
| `pkg/workloads/types/workload_test.go` | Add `xdg.Reload()` + `t.Cleanup(xdg.Reload)` after `t.Setenv` and import `adrg/xdg` |

</details>

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

## Test plan

- [x] `task test` passes for `./pkg/workloads/types/`
- [x] `task build` passes
- [x] Manually verified: deleted the leaked `test-workload*.json` files from the real state dir, re-ran `go test -run '^TestWorkloadFromContainerInfo$'`, and confirmed the real state dir stays clean (files are written only under `t.TempDir()`)

## Special notes for reviewers

- `xdg.Reload()` in the vendored version returns no value, so it is called directly (and passed straight to `t.Cleanup`) rather than wrapped with `require.NoError`.
- During investigation, `TestWorkloadFromContainerInfo` was confirmed to be the **only** in-process test with this `Setenv`-without-`Reload` leak. The e2e tests pass XDG vars to spawned `thv` subprocesses (fresh process init, unaffected). One adjacent fragile spot worth a possible follow-up: `pkg/workloads/statuses/pid_test.go` writes into the real `xdg.DataHome` and relies on cleanup-based removal rather than redirection.

Generated with [Claude Code](https://claude.com/claude-code)