### PR TITLE
Add WithDialControl option to vMCP backend client

### DIFF
--- a/pkg/vmcp/client/client.go
+++ b/pkg/vmcp/client/client.go
@@ -18,6 +18,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"syscall"
 	"time"
 
 	"github.com/mark3labs/mcp-go/client"
@@ -56,6 +57,49 @@ const (
 	maxResponseSize = 100 * 1024 * 1024 // 100 MB
 )
 
+// Option configures an httpBackendClient.
+type Option func(*httpBackendClient)
+
+// WithDialControl installs a per-connection Control hook on the dialer used to
+// reach every backend. The hook fires after DNS resolution and before the TCP
+// handshake, receiving the resolved peer IP in address — which is why it
+// defeats DNS-rebinding attacks that a host-name–based allow/deny check cannot:
+// a hostname can legitimately resolve to a blocked IP after the name-based check
+// passes.
+//
+// The hook composes with per-backend CA-bundle handling: it augments the
+// internally built *http.Transport rather than replacing it. Supplying it
+// implies the standard dial timeouts (30 s Timeout, 30 s KeepAlive) used
+// throughout this package.
+//
+// The signature matches net.Dialer.Control exactly.
+//
+// Security limitations embedders must understand:
+//
+//   - Per-TCP-dial, not per-request: the hook fires once per TCP connection.
+//     A pooled connection is reused without re-invoking the hook until it is
+//     recycled. Because each backend gets its own isolated transport and
+//     connection pool, a reused connection is always one this hook already
+//     approved on its first dial — reuse cannot reach an unclassified peer.
+//     This client does not offer per-request re-classification.
+//
+//   - Proxy transparency: when http.ProxyFromEnvironment selects a proxy
+//     (HTTP_PROXY/HTTPS_PROXY set), the dial target is the proxy server, so
+//     the hook receives the proxy's IP, not the backend's. Embedders relying
+//     on this hook for SSRF or IP allow-listing must either unset the proxy
+//     env vars or additionally validate the request URL's host before dialing.
+//
+//   - Both IP families: the address argument may be an IPv4 or IPv6 literal
+//     (host:port form); embedders must handle both families — including
+//     IPv4-mapped IPv6 such as ::ffff:127.0.0.1 — in their check. See the
+//     OWASP SSRF Prevention Cheat Sheet for the full set of ranges to deny
+//     (loopback, RFC 1918, link-local 169.254/16, CGNAT 100.64/10, IPv6 ULA).
+func WithDialControl(control func(network, address string, c syscall.RawConn) error) Option {
+	return func(h *httpBackendClient) {
+		h.dialControl = control
+	}
+}
+
 // httpBackendClient implements vmcp.BackendClient using mark3labs/mcp-go HTTP client.
 // It supports streamable-HTTP and SSE transports for backend MCP servers.
 type httpBackendClient struct {
@@ -71,6 +115,12 @@ type httpBackendClient struct {
 	// time for per-backend header-forward injection. Nil when no backends declare
 	// headerForward.AddHeadersFromSecret — plaintext-only backends do not require it.
 	secretsProvider secrets.Provider
+
+	// dialControl is an optional per-connection hook injected via WithDialControl.
+	// When non-nil it is installed on the net.Dialer used by every backend transport,
+	// receiving the resolved peer IP before the TCP handshake. Nil reproduces the
+	// default dialer behavior with no hook.
+	dialControl func(network, address string, c syscall.RawConn) error
 }
 
 // NewHTTPBackendClient creates a new HTTP-based backend client.
@@ -80,8 +130,12 @@ type httpBackendClient struct {
 // It must not be nil. To disable authentication, use a registry configured with the
 // "unauthenticated" strategy.
 //
+// Options are additive: nil or absent options reproduce the default behavior exactly.
+// See [WithDialControl] to install a per-connection dial hook for SSRF /
+// DNS-rebinding defense.
+//
 // Returns an error if registry is nil.
-func NewHTTPBackendClient(registry vmcpauth.OutgoingAuthRegistry) (vmcp.BackendClient, error) {
+func NewHTTPBackendClient(registry vmcpauth.OutgoingAuthRegistry, opts ...Option) (vmcp.BackendClient, error) {
 	if registry == nil {
 		return nil, fmt.Errorf("registry cannot be nil; use UnauthenticatedStrategy for no authentication")
 	}
@@ -90,8 +144,23 @@ func NewHTTPBackendClient(registry vmcpauth.OutgoingAuthRegistry) (vmcp.BackendC
 		registry:        registry,
 		secretsProvider: secrets.NewEnvironmentProvider(),
 	}
+	for _, o := range opts {
+		o(c)
+	}
 	c.clientFactory = c.defaultClientFactory
 	return c, nil
+}
+
+// backendDialer returns a net.Dialer with the standard backend timeouts and an
+// optional Control hook. Centralising the timeout constants here ensures the
+// fallback-construction branch and the dial-control replacement branch always
+// stay in sync — no "kept in sync with the branch below" promise required.
+func backendDialer(control func(network, address string, c syscall.RawConn) error) *net.Dialer {
+	return &net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+		Control:   control,
+	}
 }
 
 // newBackendTransport creates a *http.Transport with the same defaults as http.DefaultTransport.
@@ -107,7 +176,18 @@ func NewHTTPBackendClient(registry vmcpauth.OutgoingAuthRegistry) (vmcp.BackendC
 // If caBundleData is non-empty, the raw PEM bytes are used directly instead of reading
 // from a file. This is used in dynamic mode where CA bundles are fetched from K8s
 // ConfigMaps at discovery time. caBundleData takes precedence over caBundlePath.
-func newBackendTransport(caBundlePath string, caBundleData []byte) (*http.Transport, error) {
+//
+// If dialControl is non-nil, a fresh net.Dialer carrying the hook is installed on the
+// transport. The hook fires per-connection on the resolved peer IP, which is what
+// defeats DNS-rebinding attacks — a name-based check cannot, because the name can
+// resolve to a blocked IP after the check passes. A cloned *http.Transport exposes
+// DialContext only as an opaque func, so we cannot read back the original dialer's
+// settings; we reconstruct the dialer via backendDialer instead.
+func newBackendTransport(
+	caBundlePath string,
+	caBundleData []byte,
+	dialControl func(network, address string, c syscall.RawConn) error,
+) (*http.Transport, error) {
 	var t *http.Transport
 	if dt, ok := http.DefaultTransport.(*http.Transport); ok {
 		t = dt.Clone()
@@ -116,17 +196,18 @@ func newBackendTransport(caBundlePath string, caBundleData []byte) (*http.Transp
 		// Construct a transport with the same defaults as the Go standard library uses for
 		// http.DefaultTransport so we don't silently drop proxy, timeout, or HTTP/2 settings.
 		t = &http.Transport{
-			Proxy: http.ProxyFromEnvironment,
-			DialContext: (&net.Dialer{
-				Timeout:   30 * time.Second,
-				KeepAlive: 30 * time.Second,
-			}).DialContext,
+			Proxy:                 http.ProxyFromEnvironment,
+			DialContext:           backendDialer(nil).DialContext,
 			ForceAttemptHTTP2:     true,
 			MaxIdleConns:          100,
 			IdleConnTimeout:       90 * time.Second,
 			TLSHandshakeTimeout:   10 * time.Second,
 			ExpectContinueTimeout: 1 * time.Second,
 		}
+	}
+
+	if dialControl != nil {
+		t.DialContext = backendDialer(dialControl).DialContext
 	}
 
 	// Resolve CA certificate PEM data: caBundleData takes precedence over caBundlePath
@@ -321,9 +402,9 @@ func (h *httpBackendClient) defaultClientFactory(ctx context.Context, target *vm
 	// Build transport chain (outermost to innermost, request execution order):
 	// size limit (response body) → trace propagation → identity propagation → authentication → HTTP
 	//
-	// Clone DefaultTransport per call so each client gets an isolated connection pool,
+	// Build an isolated per-call transport so each client gets its own connection pool,
 	// preventing stale keep-alive connections from one backend affecting others.
-	httpTransport, err := newBackendTransport(target.CABundlePath, target.CABundleData)
+	httpTransport, err := newBackendTransport(target.CABundlePath, target.CABundleData, h.dialControl)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create transport for backend %s: %w", target.WorkloadID, err)
 	}

--- a/pkg/vmcp/client/client_test.go
+++ b/pkg/vmcp/client/client_test.go
@@ -17,15 +17,20 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"syscall"
 	"testing"
 	"time"
 
 	"github.com/mark3labs/mcp-go/client"
 	"github.com/mark3labs/mcp-go/client/transport"
+	mcpserver "github.com/mark3labs/mcp-go/server"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/propagation"
@@ -110,9 +115,9 @@ func TestQueryHelpers_PartialCapabilities(t *testing.T) {
 func TestNewBackendTransport_IsolatesFromDefault(t *testing.T) {
 	t.Parallel()
 
-	t1, err1 := newBackendTransport("", nil)
+	t1, err1 := newBackendTransport("", nil, nil)
 	require.NoError(t, err1)
-	t2, err2 := newBackendTransport("", nil)
+	t2, err2 := newBackendTransport("", nil, nil)
 	require.NoError(t, err2)
 
 	// Each call must return a distinct transport — not the shared DefaultTransport.
@@ -256,7 +261,7 @@ func TestNewBackendTransport_CustomCA(t *testing.T) {
 			t.Parallel()
 
 			caPath := tt.setupFile(t)
-			tr, err := newBackendTransport(caPath, tt.caBundleData)
+			tr, err := newBackendTransport(caPath, tt.caBundleData, nil)
 
 			if tt.expectError {
 				require.Error(t, err)
@@ -1258,4 +1263,201 @@ func TestIdentityPropagatingRoundTripper_HealthCheckClose_OriginalRequestContext
 	require.NotNil(t, base.capturedReq)
 	assert.True(t, healthcontext.IsHealthCheck(base.capturedReq.Context()),
 		"downstream request must carry health check marker")
+}
+
+// ---------------------------------------------------------------------------
+// WithDialControl / newBackendTransport — dial hook
+// ---------------------------------------------------------------------------
+
+// TestNewBackendTransport_WithDialControl verifies that a non-nil dialControl
+// causes newBackendTransport to wire a hook that fires on dial. The control
+// hook fires BEFORE the TCP handshake completes, so no accepting server is
+// needed — we open a listener for the address but don't accept, then assert
+// the hook fired regardless of the dial outcome.
+func TestNewBackendTransport_WithDialControl(t *testing.T) {
+	t.Parallel()
+
+	var hookFired atomic.Bool
+	control := func(_, _ string, _ syscall.RawConn) error {
+		hookFired.Store(true)
+		return nil
+	}
+
+	// Open a listener to obtain a valid address; we don't need to accept.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ln.Close() })
+
+	tr, err := newBackendTransport("", nil, control)
+	require.NoError(t, err)
+
+	conn, dialErr := tr.DialContext(t.Context(), "tcp", ln.Addr().String())
+	if dialErr == nil && conn != nil {
+		_ = conn.Close()
+	}
+	assert.True(t, hookFired.Load(), "control hook must fire during DialContext")
+}
+
+// TestWithDialControl_EndToEnd verifies that a Control hook installed via
+// WithDialControl is invoked on every TCP dial made by the client constructed
+// with NewHTTPBackendClient.
+func TestWithDialControl_EndToEnd(t *testing.T) {
+	t.Parallel()
+
+	t.Run("control hook fires on successful dial", func(t *testing.T) {
+		t.Parallel()
+
+		var hookFired atomic.Bool
+		control := func(_, _ string, _ syscall.RawConn) error {
+			hookFired.Store(true)
+			return nil
+		}
+
+		mcpSrv := mcpserver.NewMCPServer("test", "1.0.0")
+		streamSrv := mcpserver.NewStreamableHTTPServer(mcpSrv)
+		ts := httptest.NewServer(streamSrv)
+		t.Cleanup(ts.Close)
+
+		registry := auth.NewDefaultOutgoingAuthRegistry()
+		err := registry.RegisterStrategy(authtypes.StrategyTypeUnauthenticated, &strategies.UnauthenticatedStrategy{})
+		require.NoError(t, err)
+
+		backendClient, err := NewHTTPBackendClient(registry, WithDialControl(control))
+		require.NoError(t, err)
+
+		target := &vmcp.BackendTarget{
+			WorkloadID:    "test-backend",
+			WorkloadName:  "Test Backend",
+			BaseURL:       ts.URL,
+			TransportType: "streamable-http",
+		}
+
+		ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+		defer cancel()
+
+		_, err = backendClient.ListCapabilities(ctx, target)
+		require.NoError(t, err)
+		assert.True(t, hookFired.Load(), "dial control hook must fire on connection to backend")
+	})
+
+	t.Run("control hook returning error blocks the dial", func(t *testing.T) {
+		t.Parallel()
+
+		dialErr := errors.New("dial blocked by control hook")
+		control := func(_, _ string, _ syscall.RawConn) error {
+			return dialErr
+		}
+
+		mcpSrv := mcpserver.NewMCPServer("test", "1.0.0")
+		streamSrv := mcpserver.NewStreamableHTTPServer(mcpSrv)
+		ts := httptest.NewServer(streamSrv)
+		t.Cleanup(ts.Close)
+
+		registry := auth.NewDefaultOutgoingAuthRegistry()
+		err := registry.RegisterStrategy(authtypes.StrategyTypeUnauthenticated, &strategies.UnauthenticatedStrategy{})
+		require.NoError(t, err)
+
+		backendClient, err := NewHTTPBackendClient(registry, WithDialControl(control))
+		require.NoError(t, err)
+
+		target := &vmcp.BackendTarget{
+			WorkloadID:    "test-backend",
+			WorkloadName:  "Test Backend",
+			BaseURL:       ts.URL,
+			TransportType: "streamable-http",
+		}
+
+		ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+		defer cancel()
+
+		_, err = backendClient.ListCapabilities(ctx, target)
+		require.Error(t, err, "ListCapabilities must fail when the dial control hook blocks the connection")
+		assert.Contains(t, err.Error(), dialErr.Error())
+	})
+
+	t.Run("control hook receives resolved IP not hostname", func(t *testing.T) {
+		t.Parallel()
+
+		var capturedAddr atomic.Value
+		control := func(_, address string, _ syscall.RawConn) error {
+			capturedAddr.Store(address)
+			return nil
+		}
+
+		mcpSrv := mcpserver.NewMCPServer("test", "1.0.0")
+		streamSrv := mcpserver.NewStreamableHTTPServer(mcpSrv)
+		ts := httptest.NewServer(streamSrv)
+		t.Cleanup(ts.Close)
+
+		registry := auth.NewDefaultOutgoingAuthRegistry()
+		err := registry.RegisterStrategy(authtypes.StrategyTypeUnauthenticated, &strategies.UnauthenticatedStrategy{})
+		require.NoError(t, err)
+
+		backendClient, err := NewHTTPBackendClient(registry, WithDialControl(control))
+		require.NoError(t, err)
+
+		// Force DNS resolution by using "localhost" instead of the literal 127.0.0.1
+		// that httptest.NewServer embeds in ts.URL. Without this substitution the
+		// hook would receive 127.0.0.1 regardless, making the assertion tautological.
+		baseURL := strings.Replace(ts.URL, "127.0.0.1", "localhost", 1)
+		target := &vmcp.BackendTarget{
+			WorkloadID:    "test-backend",
+			WorkloadName:  "Test Backend",
+			BaseURL:       baseURL,
+			TransportType: "streamable-http",
+		}
+
+		ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+		defer cancel()
+
+		_, err = backendClient.ListCapabilities(ctx, target)
+		require.NoError(t, err)
+
+		addr, _ := capturedAddr.Load().(string)
+		require.NotEmpty(t, addr, "control hook must receive the address")
+		host, _, err := net.SplitHostPort(addr)
+		require.NoError(t, err)
+		// The hook must see the resolved IP, not the name "localhost".
+		// net.ParseIP returns non-nil only for valid IP literals.
+		assert.NotNil(t, net.ParseIP(host),
+			"control hook address %q must be an IP literal (resolved), not a hostname", host)
+		assert.NotEqual(t, "localhost", host,
+			"control hook must receive the resolved IP, not the original hostname (DNS-rebinding defense point)")
+	})
+}
+
+// ExampleWithDialControl shows how an embedder installs a dial-control hook
+// that rejects connections to non-public IP ranges — the building block of an
+// SSRF / DNS-rebinding defense. The hook receives the resolved peer IP, so it
+// classifies the address the kernel is about to connect to rather than the
+// (re-resolvable) hostname. A production check should additionally cover the
+// ranges listed in the WithDialControl doc comment (CGNAT, IPv6 ULA, etc.).
+func ExampleWithDialControl() {
+	denyNonPublic := func(_, address string, _ syscall.RawConn) error {
+		host, _, err := net.SplitHostPort(address)
+		if err != nil {
+			return err
+		}
+		ip := net.ParseIP(host)
+		if ip == nil {
+			return fmt.Errorf("unresolved dial address %q", address)
+		}
+		if ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() {
+			return fmt.Errorf("blocked connection to non-public IP %s", ip)
+		}
+		return nil
+	}
+
+	registry := auth.NewDefaultOutgoingAuthRegistry()
+	if err := registry.RegisterStrategy(
+		authtypes.StrategyTypeUnauthenticated, &strategies.UnauthenticatedStrategy{},
+	); err != nil {
+		panic(err)
+	}
+
+	backendClient, err := NewHTTPBackendClient(registry, WithDialControl(denyNonPublic))
+	if err != nil {
+		panic(err)
+	}
+	_ = backendClient
 }


### PR DESCRIPTION
## Summary

When embedding `pkg/vmcp/core` as a library (the `core.New` → `core.VMCP` surface from v0.30.0), it's natural to adopt the full `client.NewHTTPBackendClient` — including its outgoing-auth strategy registry and the trace/identity RoundTripper chain — rather than reimplement a `vmcp.BackendClient`. One thing blocked that: an embedder couldn't preserve a custom SSRF posture on the outbound connection, because the per-backend `*http.Client` was built entirely internally (`clientFactory` was unexported; `newBackendTransport` accepted only CA-bundle params, with no way to supply a custom dialer `Control` hook).

A robust SSRF defense is a dialer-level `Control` hook that classifies the **resolved peer IP per connection** — which is what defeats DNS rebinding (a host-string check does not: the name can resolve to a blocked IP after the check passes). Without this, an embedder needing a custom dialer had to abandon `NewHTTPBackendClient` and hand-roll its own client, losing the auth registry and RoundTripper chain.

- Add a functional-option `WithDialControl(func(network, address string, c syscall.RawConn) error)` to `NewHTTPBackendClient` (signature matches `net.Dialer.Control` exactly).
- The hook is installed on the `net.Dialer` of every per-backend transport, firing after DNS resolution and before the TCP handshake on the resolved peer IP.
- Additive: nil/absent options reproduce today's behavior exactly. The hook **augments** the internally built transport, composing with per-backend CA-bundle handling rather than replacing it.
- Doc comment spells out the security limitations embedders must understand (per-TCP-dial not per-request; proxy transparency; IPv4/IPv6 address families).

Closes #5550

## Type of change

- [x] New feature

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)

New tests cover: the hook fires on dial; a hook returning an error blocks the dial and surfaces through `ListCapabilities`; and — using `localhost` to force real DNS resolution — the hook receives a resolved IP literal, not the hostname (the DNS-rebinding-defense invariant).

## Changes

| File | Change |
|------|--------|
| `pkg/vmcp/client/client.go` | Add `Option`/`WithDialControl`, `dialControl` field, variadic constructor, `backendDialer` helper; thread the hook through `newBackendTransport`/`defaultClientFactory` |
| `pkg/vmcp/client/client_test.go` | Tests for the dial hook (fires / blocks / resolved-IP) |

## Does this introduce a user-facing change?

Yes — a new optional `WithDialControl` option on `NewHTTPBackendClient` for embedders. No change for existing callers (the variadic is additive and nil/absent reproduces current behavior).

## Special notes for reviewers

- Scope was deliberately limited to `WithDialControl`. `WithBaseTransport` (also floated in #5550) was **not** added: there's no concrete consumer yet, and it would bypass the per-backend CA-bundle logic. It can follow additively if a need arises.
- Two SSRF caveats are documented rather than coded around (HTTP/2 / keep-alive connection reuse means the hook is per-TCP-dial not per-request; `HTTP(S)_PROXY` makes the hook see the proxy IP). Forcing HTTP/2 off or `Proxy=nil` would be an unwarranted behavior change for the common case; embedders are pointed at the remediations instead.

Generated with [Claude Code](https://claude.com/claude-code)