### PR TITLE
Mint Homebrew tap token from a GitHub App

### DIFF
--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -184,6 +184,15 @@ jobs:
           done
           set -e
 
+      - name: Generate Homebrew tap token
+        id: homebrew-tap-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          client-id: ${{ vars.HOMEBREW_TAP_APP_CLIENT_ID }}
+          private-key: ${{ secrets.HOMEBREW_TAP_APP_PRIVATE_KEY }}
+          owner: stacklok
+          repositories: homebrew-tap
+
       - name: Run GoReleaser
         id: run-goreleaser
         uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7
@@ -194,7 +203,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           WINGET_GITHUB_TOKEN: ${{ secrets.WINGET_GITHUB_TOKEN }}
-          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ steps.homebrew-tap-token.outputs.token }}
           VERSION: ${{ needs.compute-build-flags.outputs.version }}
           COMMIT: ${{ needs.compute-build-flags.outputs.commit }}
           COMMIT_DATE: ${{ needs.compute-build-flags.outputs.commit-date }}


### PR DESCRIPTION
## Summary

The toolhive release pipeline publishes the Homebrew formula to
`stacklok/homebrew-tap` via GoReleaser, authenticating with a classic PAT
stored in the repo secret `HOMEBREW_TAP_GITHUB_TOKEN`. That PAT expired and
broke the `v0.30.0` release (`401 Bad credentials`). This replaces the
long-lived, human-owned PAT with a short-lived GitHub App installation token
minted at job time — so the credential is non-expiring (auto-rotated),
scoped to just the tap repo, and not tied to an individual's account.

This follows the existing `actions/create-github-app-token` pattern already
used in `create-release-tag.yml` / `create-release-pr.yml`.

Fixes #4912 (stacklok/infra)

## What changed

- Added a **Generate Homebrew tap token** step in the `release-binaries`
  job that mints an installation token via
  `actions/create-github-app-token@v3.1.1`, scoped with
  `owner: stacklok` / `repositories: homebrew-tap`.
- `HOMEBREW_TAP_GITHUB_TOKEN` passed to GoReleaser now comes from the minted
  token (`steps.homebrew-tap-token.outputs.token`) instead of the PAT secret.

The `owner`/`repositories` inputs are required because the tap is a different
repo than the one running the workflow; without them the minted token would
be scoped to `stacklok/toolhive`.

## Type of change

- [x] Other (CI/release configuration)

## Required infra setup before this can merge/work

These are GitHub org operations tracked in stacklok/infra#4912:

1. Create a GitHub App in `stacklok` with **Contents: write**, installed on
   `stacklok/homebrew-tap` only.
2. Add repo variable `HOMEBREW_TAP_APP_CLIENT_ID` and secret
   `HOMEBREW_TAP_APP_PRIVATE_KEY` to `stacklok/toolhive`.
3. After a verified release, remove the old `HOMEBREW_TAP_GITHUB_TOKEN` PAT
   secret.

## Test plan

- [x] Validated the workflow change against the existing
      `create-github-app-token` usage in the repo.
- [ ] End-to-end verification happens at the next release (the workflow only
      triggers on `release: published`).

## Special notes for reviewers

- Uses a **dedicated** app rather than reusing `RELEASE_APP`, to keep the
  credential scoped to `stacklok/homebrew-tap` only (infra#4912 acceptance
  criterion). Easy to switch to `RELEASE_APP` if preferred.
- `WINGET_GITHUB_TOKEN` uses the same PAT pattern and is left untouched —
  it's an explicit follow-up in the issue, not in scope here.

Generated with [Claude Code](https://claude.com/claude-code)
