### PR TITLE
Accept 401/403 in runner readiness probe when auth configured

### DIFF
--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -529,8 +529,11 @@ func (r *Runner) Run(ctx context.Context) error {
 	// can cause issues as the behavior is not specified by the MCP spec
 	if transportType != "stdio" {
 		// Repeatedly try calling initialize until it succeeds (up to 5 minutes)
-		// Some servers (like mcp-optimizer) can take significant time to start up
-		if err := waitForInitializeSuccess(ctx, serverURL, transportType, 5*time.Minute); err != nil {
+		// Some servers (like mcp-optimizer) can take significant time to start up.
+		// When OIDC auth is configured, the local proxy rejects the unauthenticated
+		// probe with 401/403, which still indicates the server is ready.
+		authExpected := r.Config.OIDCConfig != nil
+		if err := waitForInitializeSuccess(ctx, serverURL, transportType, authExpected, 5*time.Minute); err != nil {
 			slog.Warn("initialize not successful, but continuing", "error", err)
 			// Continue anyway to maintain backward compatibility, but log a warning
 		}
@@ -872,11 +875,33 @@ func (r *Runner) Cleanup(ctx context.Context) error {
 	return lastErr
 }
 
+// isReadyStatus reports whether an HTTP status code from the readiness probe indicates
+// the MCP server is ready. A 200 always means ready. When authExpected is true, a 401 or
+// 403 also means ready: it proves the local proxy listener is up and its auth middleware
+// is enforcing credentials against the unauthenticated probe.
+func isReadyStatus(statusCode int, authExpected bool) bool {
+	if statusCode == http.StatusOK {
+		return true
+	}
+	return authExpected && (statusCode == http.StatusUnauthorized || statusCode == http.StatusForbidden)
+}
+
 // waitForInitializeSuccess repeatedly checks if the MCP server is ready to accept requests.
 // This prevents timing issues where clients try to connect before the server is fully ready.
 // It makes repeated attempts with exponential backoff up to a maximum timeout.
+//
+// The probe is unauthenticated and targets ToolHive's own local proxy. When authExpected
+// is true (the workload has OIDC configured), an HTTP 401 or 403 is treated as "ready":
+// it proves the proxy listener is up and the auth middleware is enforcing credentials. When
+// authExpected is false, only HTTP 200 is accepted.
+//
 // Note: This function should not be called for STDIO transport.
-func waitForInitializeSuccess(ctx context.Context, serverURL, transportType string, maxWaitTime time.Duration) error {
+func waitForInitializeSuccess(
+	ctx context.Context,
+	serverURL, transportType string,
+	authExpected bool,
+	maxWaitTime time.Duration,
+) error {
 	// Determine the endpoint and method to use based on transport type
 	var endpoint string
 	var method string
@@ -948,11 +973,10 @@ func waitForInitializeSuccess(ctx context.Context, serverURL, transportType stri
 				//nolint:errcheck // Ignoring close error on response body in error path
 				defer resp.Body.Close()
 
-				// For GET (SSE), accept 200 OK
-				// For POST (streamable-http), also accept 200 OK
-				if resp.StatusCode == http.StatusOK {
+				if isReadyStatus(resp.StatusCode, authExpected) {
 					elapsed := time.Since(startTime)
-					slog.Debug("MCP server is ready", "elapsed", elapsed, "attempt", attempt)
+					slog.Debug("MCP server is ready", //nolint:gosec // G706: status code and attempt are integers
+						"elapsed", elapsed, "attempt", attempt, "status_code", resp.StatusCode)
 					return nil
 				}
 

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -879,6 +879,9 @@ func (r *Runner) Cleanup(ctx context.Context) error {
 // the MCP server is ready. A 200 always means ready. When authExpected is true, a 401 or
 // 403 also means ready: it proves the local proxy listener is up and its auth middleware
 // is enforcing credentials against the unauthenticated probe.
+//
+// Today ToolHive's OIDC validator rejects the tokenless probe with 401; 403 is accepted
+// defensively to cover upstream IdP or edge behavior, not any current ToolHive code path.
 func isReadyStatus(statusCode int, authExpected bool) bool {
 	if statusCode == http.StatusOK {
 		return true
@@ -894,6 +897,10 @@ func isReadyStatus(statusCode int, authExpected bool) bool {
 // is true (the workload has OIDC configured), an HTTP 401 or 403 is treated as "ready":
 // it proves the proxy listener is up and the auth middleware is enforcing credentials. When
 // authExpected is false, only HTTP 200 is accepted.
+//
+// Note that in the OIDC case readiness reflects only the proxy/auth layer being up — the
+// auth middleware rejects the probe before the request reaches the backend, so this probe
+// does not confirm backend MCP server initialization.
 //
 // Note: This function should not be called for STDIO transport.
 func waitForInitializeSuccess(

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -315,33 +315,6 @@ func TestWaitForInitializeSuccess(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("Auth expected accepts 403 as ready", func(t *testing.T) {
-		t.Parallel()
-
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			w.WriteHeader(http.StatusForbidden)
-		}))
-		t.Cleanup(server.Close)
-
-		ctx := context.Background()
-		err := waitForInitializeSuccess(ctx, server.URL, "streamable-http", true, 5*time.Second)
-		assert.NoError(t, err)
-	})
-
-	t.Run("No auth expected still times out on 401", func(t *testing.T) {
-		t.Parallel()
-
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			w.WriteHeader(http.StatusUnauthorized)
-		}))
-		t.Cleanup(server.Close)
-
-		ctx := context.Background()
-		err := waitForInitializeSuccess(ctx, server.URL, "streamable-http", false, 500*time.Millisecond)
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "initialize not successful")
-	})
-
 	t.Run("Context cancelled", func(t *testing.T) {
 		t.Parallel()
 
@@ -357,6 +330,33 @@ func TestWaitForInitializeSuccess(t *testing.T) {
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "context cancelled")
 	})
+}
+
+func TestIsReadyStatus(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		statusCode   int
+		authExpected bool
+		want         bool
+	}{
+		{"200 ready without auth", http.StatusOK, false, true},
+		{"200 ready with auth", http.StatusOK, true, true},
+		{"401 not ready without auth", http.StatusUnauthorized, false, false},
+		{"401 ready with auth", http.StatusUnauthorized, true, true},
+		{"403 not ready without auth", http.StatusForbidden, false, false},
+		{"403 ready with auth", http.StatusForbidden, true, true},
+		{"500 not ready without auth", http.StatusInternalServerError, false, false},
+		{"500 not ready with auth", http.StatusInternalServerError, true, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, isReadyStatus(tt.statusCode, tt.authExpected))
+		})
+	}
 }
 
 func TestHandleRemoteAuthentication(t *testing.T) {

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -242,7 +242,7 @@ func TestWaitForInitializeSuccess(t *testing.T) {
 		defer server.Close()
 
 		ctx := context.Background()
-		err := waitForInitializeSuccess(ctx, server.URL, "streamable-http", 5*time.Second)
+		err := waitForInitializeSuccess(ctx, server.URL, "streamable-http", false, 5*time.Second)
 		assert.NoError(t, err)
 	})
 
@@ -259,7 +259,7 @@ func TestWaitForInitializeSuccess(t *testing.T) {
 		defer server.Close()
 
 		ctx := context.Background()
-		err := waitForInitializeSuccess(ctx, server.URL, "streamable", 5*time.Second)
+		err := waitForInitializeSuccess(ctx, server.URL, "streamable", false, 5*time.Second)
 		assert.NoError(t, err)
 	})
 
@@ -276,7 +276,7 @@ func TestWaitForInitializeSuccess(t *testing.T) {
 		defer server.Close()
 
 		ctx := context.Background()
-		err := waitForInitializeSuccess(ctx, server.URL+"#container-name", "sse", 5*time.Second)
+		err := waitForInitializeSuccess(ctx, server.URL+"#container-name", "sse", false, 5*time.Second)
 		assert.NoError(t, err)
 	})
 
@@ -284,7 +284,7 @@ func TestWaitForInitializeSuccess(t *testing.T) {
 		t.Parallel()
 
 		ctx := context.Background()
-		err := waitForInitializeSuccess(ctx, "http://localhost:9999", "unknown-transport", 5*time.Second)
+		err := waitForInitializeSuccess(ctx, "http://localhost:9999", "unknown-transport", false, 5*time.Second)
 		assert.NoError(t, err)
 	})
 
@@ -297,7 +297,47 @@ func TestWaitForInitializeSuccess(t *testing.T) {
 		defer server.Close()
 
 		ctx := context.Background()
-		err := waitForInitializeSuccess(ctx, server.URL, "streamable-http", 500*time.Millisecond)
+		err := waitForInitializeSuccess(ctx, server.URL, "streamable-http", false, 500*time.Millisecond)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "initialize not successful")
+	})
+
+	t.Run("Auth expected accepts 401 as ready", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		}))
+		t.Cleanup(server.Close)
+
+		ctx := context.Background()
+		err := waitForInitializeSuccess(ctx, server.URL, "streamable-http", true, 5*time.Second)
+		assert.NoError(t, err)
+	})
+
+	t.Run("Auth expected accepts 403 as ready", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusForbidden)
+		}))
+		t.Cleanup(server.Close)
+
+		ctx := context.Background()
+		err := waitForInitializeSuccess(ctx, server.URL, "streamable-http", true, 5*time.Second)
+		assert.NoError(t, err)
+	})
+
+	t.Run("No auth expected still times out on 401", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		}))
+		t.Cleanup(server.Close)
+
+		ctx := context.Background()
+		err := waitForInitializeSuccess(ctx, server.URL, "streamable-http", false, 500*time.Millisecond)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "initialize not successful")
 	})
@@ -313,7 +353,7 @@ func TestWaitForInitializeSuccess(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel() // Cancel immediately
 
-		err := waitForInitializeSuccess(ctx, server.URL, "streamable-http", 5*time.Second)
+		err := waitForInitializeSuccess(ctx, server.URL, "streamable-http", false, 5*time.Second)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "context cancelled")
 	})


### PR DESCRIPTION
## Summary

The runner's MCP readiness probe (`waitForInitializeSuccess`) hangs for the full 5-minute timeout on every startup of an auth-protected workload, delaying readiness and emitting a misleading failure log. The probe sends an **unauthenticated** request to ToolHive's own local proxy and accepts only HTTP 200 — but when a workload has OIDC configured (`oidcConfigRef`), the auth middleware correctly rejects the tokenless probe with 401, which the probe treated as "not ready."

This change teaches the probe that a 401/403 from the local proxy is actually positive evidence of readiness when auth is expected: it proves the proxy listener is up and the auth middleware is enforcing credentials.

Closes #5553

<details>
<summary><strong>Medium level</strong></summary>

- Added an `authExpected bool` parameter to `waitForInitializeSuccess`, derived at the call site in `Runner.Run` from `r.Config.OIDCConfig != nil`.
- When `authExpected` is true, HTTP 401 and 403 are now treated as "ready". When false, behavior is unchanged (only 200 is accepted), so an unexpected 401 without auth still surfaces as a probe failure.
- Extracted the status-code decision into a small `isReadyStatus` helper to keep the probe loop's cyclomatic complexity within limits.
- The 401-handling is gated on OIDC specifically; non-OIDC auth modes are out of scope (see reviewer notes).

</details>

<details>
<summary><strong>Low level</strong></summary>

| File | Change |
|------|--------|
| `pkg/runner/runner.go` | Add `isReadyStatus` helper; add `authExpected` param to `waitForInitializeSuccess` and accept 401/403 when set; pass `OIDCConfig != nil` at the call site; update doc comments |
| `pkg/runner/runner_test.go` | Update existing call sites for the new signature; add subtests for 401→ready, 403→ready (auth expected), and 401→timeout (no auth) |

</details>

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

## Test plan

- [x] `task lint-fix` passes for the touched package (`pkg/runner`)
- [x] `task test` passes (full race-enabled unit suite)
- [x] `task build` passes
- [x] New unit tests: `Auth expected accepts 401 as ready`, `Auth expected accepts 403 as ready`, `No auth expected still times out on 401`

## Special notes for reviewers

- **Scope of the signal:** 401/403 is accepted only when OIDC is configured (`OIDCConfig != nil`). Other auth modes (e.g. remote auth) won't set `authExpected` and would still hit the timeout — left out of scope since the probe failure is non-fatal (`Run` logs a warning and continues). Happy to broaden the signal if reviewers prefer.
- **Why not authenticate the probe instead:** the probe is machine-local with no client token; a 401 from the local proxy already proves the listener and middleware chain are up, which is exactly the readiness condition this probe exists to detect.

Generated with [Claude Code](https://claude.com/claude-code)