### PR TITLE
Make Kubernetes security contexts satisfy restricted PSS

### DIFF
--- a/pkg/container/kubernetes/security.go
+++ b/pkg/container/kubernetes/security.go
@@ -25,12 +25,16 @@ func NewSecurityContextBuilder(platform Platform) *SecurityContextBuilder {
 
 // BuildPodSecurityContext creates a platform-appropriate pod security context
 func (b *SecurityContextBuilder) BuildPodSecurityContext() *corev1.PodSecurityContext {
-	// Start with base security context
+	// Start with base security context. The seccomp profile is set unconditionally
+	// so the pod satisfies the restricted Pod Security Standard on all platforms.
 	podSecurityContext := &corev1.PodSecurityContext{
 		RunAsNonRoot: ptr.To(true),
 		RunAsUser:    ptr.To(int64(1000)),
 		RunAsGroup:   ptr.To(int64(1000)),
 		FSGroup:      ptr.To(int64(1000)),
+		SeccompProfile: &corev1.SeccompProfile{
+			Type: corev1.SeccompProfileTypeRuntimeDefault,
+		},
 	}
 
 	// Apply platform-specific modifications
@@ -41,11 +45,6 @@ func (b *SecurityContextBuilder) BuildPodSecurityContext() *corev1.PodSecurityCo
 		podSecurityContext.RunAsUser = nil
 		podSecurityContext.RunAsGroup = nil
 		podSecurityContext.FSGroup = nil
-
-		// OpenShift requires explicit seccomp profile
-		podSecurityContext.SeccompProfile = &corev1.SeccompProfile{
-			Type: corev1.SeccompProfileTypeRuntimeDefault,
-		}
 	} else {
 		slog.Info("configuring pod security context for Kubernetes")
 	}
@@ -55,7 +54,9 @@ func (b *SecurityContextBuilder) BuildPodSecurityContext() *corev1.PodSecurityCo
 
 // BuildContainerSecurityContext creates a platform-appropriate container security context
 func (b *SecurityContextBuilder) BuildContainerSecurityContext() *corev1.SecurityContext {
-	// Start with base security context
+	// Start with base security context. The seccomp profile and dropped capabilities
+	// are set unconditionally so the container satisfies the restricted Pod Security
+	// Standard on all platforms.
 	containerSecurityContext := &corev1.SecurityContext{
 		Privileged:               ptr.To(false),
 		RunAsNonRoot:             ptr.To(true),
@@ -63,6 +64,12 @@ func (b *SecurityContextBuilder) BuildContainerSecurityContext() *corev1.Securit
 		RunAsGroup:               ptr.To(int64(1000)),
 		AllowPrivilegeEscalation: ptr.To(false),
 		ReadOnlyRootFilesystem:   ptr.To(true),
+		SeccompProfile: &corev1.SeccompProfile{
+			Type: corev1.SeccompProfileTypeRuntimeDefault,
+		},
+		Capabilities: &corev1.Capabilities{
+			Drop: []corev1.Capability{"ALL"},
+		},
 	}
 
 	// Apply platform-specific modifications
@@ -72,16 +79,6 @@ func (b *SecurityContextBuilder) BuildContainerSecurityContext() *corev1.Securit
 		// Setting these to nil allows OpenShift to assign them dynamically
 		containerSecurityContext.RunAsUser = nil
 		containerSecurityContext.RunAsGroup = nil
-
-		// OpenShift requires explicit seccomp profile
-		containerSecurityContext.SeccompProfile = &corev1.SeccompProfile{
-			Type: corev1.SeccompProfileTypeRuntimeDefault,
-		}
-
-		// OpenShift security best practices: drop all capabilities
-		containerSecurityContext.Capabilities = &corev1.Capabilities{
-			Drop: []corev1.Capability{"ALL"},
-		}
 	} else {
 		slog.Info("configuring container security context for Kubernetes")
 	}

--- a/pkg/container/kubernetes/security_test.go
+++ b/pkg/container/kubernetes/security_test.go
@@ -81,7 +81,7 @@ func TestSecurityContextBuilder_BuildPodSecurityContext_OpenShift(t *testing.T) 
 	assert.Nil(t, podCtx.RunAsGroup)
 	assert.Nil(t, podCtx.FSGroup)
 
-	// SeccompProfile should be explicitly set for OpenShift
+	// SeccompProfile must be set to RuntimeDefault for restricted Pod Security Standard compliance
 	require.NotNil(t, podCtx.SeccompProfile)
 	assert.Equal(t, corev1.SeccompProfileTypeRuntimeDefault, podCtx.SeccompProfile.Type)
 }
@@ -147,13 +147,48 @@ func TestSecurityContextBuilder_BuildContainerSecurityContext_OpenShift(t *testi
 	assert.NotNil(t, containerCtx.ReadOnlyRootFilesystem)
 	assert.True(t, *containerCtx.ReadOnlyRootFilesystem)
 
-	// SeccompProfile should be explicitly set for OpenShift
+	// SeccompProfile must be set to RuntimeDefault for restricted Pod Security Standard compliance
 	require.NotNil(t, containerCtx.SeccompProfile)
 	assert.Equal(t, corev1.SeccompProfileTypeRuntimeDefault, containerCtx.SeccompProfile.Type)
 
-	// Capabilities should drop all for OpenShift
+	// Capabilities must drop ALL for restricted Pod Security Standard compliance
 	require.NotNil(t, containerCtx.Capabilities)
 	assert.Equal(t, []corev1.Capability{"ALL"}, containerCtx.Capabilities.Drop)
+}
+
+func TestSecurityContextBuilder_ApplyConfiguration_RestrictedPSS(t *testing.T) {
+	t.Parallel()
+
+	// The cluster only ever consumes the ApplyConfiguration builders, so assert that the
+	// restricted Pod Security Standard fields survive the conversion on every platform.
+	tests := []struct {
+		name     string
+		platform Platform
+	}{
+		{name: "Kubernetes platform", platform: PlatformKubernetes},
+		{name: "OpenShift platform", platform: PlatformOpenShift},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			builder := NewSecurityContextBuilder(tt.platform)
+
+			podApply := builder.BuildPodSecurityContextApplyConfiguration()
+			require.NotNil(t, podApply)
+			require.NotNil(t, podApply.SeccompProfile)
+			require.NotNil(t, podApply.SeccompProfile.Type)
+			assert.Equal(t, corev1.SeccompProfileTypeRuntimeDefault, *podApply.SeccompProfile.Type)
+
+			containerApply := builder.BuildContainerSecurityContextApplyConfiguration()
+			require.NotNil(t, containerApply)
+			require.NotNil(t, containerApply.SeccompProfile)
+			require.NotNil(t, containerApply.SeccompProfile.Type)
+			assert.Equal(t, corev1.SeccompProfileTypeRuntimeDefault, *containerApply.SeccompProfile.Type)
+			require.NotNil(t, containerApply.Capabilities)
+			assert.Equal(t, []corev1.Capability{"ALL"}, containerApply.Capabilities.Drop)
+		})
+	}
 }
 
 func TestSecurityContextBuilder_ConsistentBehavior(t *testing.T) {
@@ -173,6 +208,7 @@ func TestSecurityContextBuilder_ConsistentBehavior(t *testing.T) {
 	assert.Equal(t, podCtx1.RunAsGroup, podCtx2.RunAsGroup)
 	assert.Equal(t, podCtx1.FSGroup, podCtx2.FSGroup)
 	assert.Equal(t, podCtx1.RunAsNonRoot, podCtx2.RunAsNonRoot)
+	assert.Equal(t, podCtx1.SeccompProfile, podCtx2.SeccompProfile)
 
 	// Container contexts should be equal
 	assert.Equal(t, containerCtx1.RunAsUser, containerCtx2.RunAsUser)
@@ -181,4 +217,6 @@ func TestSecurityContextBuilder_ConsistentBehavior(t *testing.T) {
 	assert.Equal(t, containerCtx1.RunAsNonRoot, containerCtx2.RunAsNonRoot)
 	assert.Equal(t, containerCtx1.AllowPrivilegeEscalation, containerCtx2.AllowPrivilegeEscalation)
 	assert.Equal(t, containerCtx1.ReadOnlyRootFilesystem, containerCtx2.ReadOnlyRootFilesystem)
+	assert.Equal(t, containerCtx1.SeccompProfile, containerCtx2.SeccompProfile)
+	assert.Equal(t, containerCtx1.Capabilities, containerCtx2.Capabilities)
 }

--- a/pkg/container/kubernetes/security_test.go
+++ b/pkg/container/kubernetes/security_test.go
@@ -59,8 +59,9 @@ func TestSecurityContextBuilder_BuildPodSecurityContext_Kubernetes(t *testing.T)
 	assert.NotNil(t, podCtx.FSGroup)
 	assert.Equal(t, int64(1000), *podCtx.FSGroup)
 
-	// SeccompProfile should not be explicitly set for standard Kubernetes
-	assert.Nil(t, podCtx.SeccompProfile)
+	// SeccompProfile must be set to RuntimeDefault for restricted Pod Security Standard compliance
+	require.NotNil(t, podCtx.SeccompProfile)
+	assert.Equal(t, corev1.SeccompProfileTypeRuntimeDefault, podCtx.SeccompProfile.Type)
 }
 
 func TestSecurityContextBuilder_BuildPodSecurityContext_OpenShift(t *testing.T) {
@@ -112,9 +113,13 @@ func TestSecurityContextBuilder_BuildContainerSecurityContext_Kubernetes(t *test
 	assert.NotNil(t, containerCtx.ReadOnlyRootFilesystem)
 	assert.True(t, *containerCtx.ReadOnlyRootFilesystem)
 
-	// SeccompProfile and Capabilities should not be explicitly set for standard Kubernetes
-	assert.Nil(t, containerCtx.SeccompProfile)
-	assert.Nil(t, containerCtx.Capabilities)
+	// SeccompProfile must be set to RuntimeDefault for restricted Pod Security Standard compliance
+	require.NotNil(t, containerCtx.SeccompProfile)
+	assert.Equal(t, corev1.SeccompProfileTypeRuntimeDefault, containerCtx.SeccompProfile.Type)
+
+	// Capabilities must drop ALL for restricted Pod Security Standard compliance
+	require.NotNil(t, containerCtx.Capabilities)
+	assert.Equal(t, []corev1.Capability{"ALL"}, containerCtx.Capabilities.Drop)
 }
 
 func TestSecurityContextBuilder_BuildContainerSecurityContext_OpenShift(t *testing.T) {


### PR DESCRIPTION
## Summary

The pod and container security contexts built by the operator's `SecurityContextBuilder` were incompatible with the [restricted Pod Security Standard](https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted): `seccompProfile` was unset and `capabilities.drop` did not include `ALL`. These settings were only applied on the OpenShift code path, so workloads on standard Kubernetes could not run in a namespace that enforces the restricted standard.

This moves the `seccompProfile` (`RuntimeDefault`) and `capabilities.drop=[ALL]` settings into the base context so they apply on every platform.

Closes #5546

<details>
<summary><strong>Medium level</strong></summary>

- `BuildPodSecurityContext` now sets `seccompProfile: RuntimeDefault` in the base pod context (all platforms).
- `BuildContainerSecurityContext` now sets `seccompProfile: RuntimeDefault` and `capabilities.drop: [ALL]` in the base container context (all platforms).
- The OpenShift branch is simplified to only null out `RunAsUser`/`RunAsGroup`/`FSGroup` for SCC dynamic assignment, since seccomp and capability dropping are now unconditional.
- The `*ApplyConfiguration` builders derive from these base functions, so the cluster-applied path picks up the new fields automatically; tests now assert that explicitly.

</details>

<details>
<summary><strong>Low level</strong></summary>

| File | Change |
|------|--------|
| `pkg/container/kubernetes/security.go` | Move `seccompProfile` (pod + container) and `capabilities.drop=[ALL]` (container) into the base contexts; trim the now-redundant OpenShift-only assignments |
| `pkg/container/kubernetes/security_test.go` | Update Kubernetes-path assertions for the new fields, add `TestSecurityContextBuilder_ApplyConfiguration_RestrictedPSS` covering the apply-config path on both platforms, extend the consistency test, and align stale OpenShift comments |

</details>

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

## Test plan

- [x] `task test` passes (`pkg/container/kubernetes` package green)
- [x] `golangci-lint` reports 0 issues for the changed package
- [x] `task build` passes
- [x] Added unit tests asserting `RuntimeDefault` seccomp + drop-`ALL` on both the `Build*SecurityContext` and `Build*SecurityContextApplyConfiguration` paths for Kubernetes and OpenShift

## Does this introduce a user-facing change?

Yes. Operator-managed proxy/runner pods on standard Kubernetes now set `seccompProfile: RuntimeDefault` and drop `ALL` capabilities. This is required for restricted-PSS namespaces. Containers that previously relied on default Linux capabilities would be affected, but the proxy/runner containers do not require any.

## Special notes for reviewers

Scope is intentionally limited to `SecurityContextBuilder`, the two functions named in the issue. The registry API deployment (`cmd/thv-operator/pkg/registryapi/podtemplatespec.go`) builds its pod through a separate path that does not use `SecurityContextBuilder` and remains non-compliant (no pod-level context, no seccomp on the pgpass sidecar). That is a distinct change and is left for a follow-up to keep this PR single-scoped.

Generated with [Claude Code](https://claude.com/claude-code)