### PR TITLE
Sync LLM token refresh window with helper TTL

### DIFF
--- a/pkg/auth/tokensource/preemptive_test.go
+++ b/pkg/auth/tokensource/preemptive_test.go
@@ -69,7 +69,7 @@ func TestPreemptiveTokenSource_ShiftsExpiry(t *testing.T) {
 	realExpiry := time.Now().Add(2 * time.Minute)
 	inner := &staticTokenSource{tok: &oauth2.Token{AccessToken: "access", Expiry: realExpiry}}
 
-	pts := &preemptiveTokenSource{inner: inner}
+	pts := &preemptiveTokenSource{inner: inner, window: preemptiveRefreshWindow}
 	tok, err := pts.Token()
 	require.NoError(t, err)
 
@@ -81,7 +81,7 @@ func TestPreemptiveTokenSource_ZeroExpiry_Unchanged(t *testing.T) {
 	t.Parallel()
 
 	inner := &staticTokenSource{tok: &oauth2.Token{AccessToken: "access", Expiry: time.Time{}}}
-	pts := &preemptiveTokenSource{inner: inner}
+	pts := &preemptiveTokenSource{inner: inner, window: preemptiveRefreshWindow}
 	tok, err := pts.Token()
 	require.NoError(t, err)
 	assert.True(t, tok.Expiry.IsZero())
@@ -99,7 +99,82 @@ func TestPreemptiveTokenSource_PropagatesError(t *testing.T) {
 func TestPreemptiveRefreshWindow_Is30s(t *testing.T) {
 	t.Parallel()
 	assert.Equal(t, 30*time.Second, preemptiveRefreshWindow,
-		"preemptiveRefreshWindow must be 30 s — token helpers and proxy workers depend on this value")
+		"30 s is the default window for callers that don't override it (e.g. registry auth); "+
+			"the LLM gateway path widens it via Options.PreemptiveRefreshWindow")
+}
+
+// TestRefreshWindow_DefaultAndOverride verifies that the per-source window
+// resolves to the package default when Options.PreemptiveRefreshWindow is unset
+// and to the configured value when it is set. This is what lets the LLM gateway
+// path refresh well before expiry while registry auth keeps the 30 s default.
+func TestRefreshWindow_DefaultAndOverride(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		configured time.Duration
+		want       time.Duration
+	}{
+		{name: "unset_uses_default", configured: 0, want: preemptiveRefreshWindow},
+		{name: "override_honored", configured: 10 * time.Minute, want: 10 * time.Minute},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ts := New(Options{
+				KeyProvider:             func() string { return "key" },
+				PreemptiveRefreshWindow: tc.configured,
+			})
+			assert.Equal(t, tc.want, ts.refreshWindow())
+		})
+	}
+}
+
+// TestRefreshWindow_OverrideShiftsExpiry confirms the configured window actually
+// drives how far before expiry a token is treated as expired: a 10-minute window
+// forces a refresh on a token with 5 minutes of real life left, whereas the 30 s
+// default would still serve it.
+func TestRefreshWindow_OverrideShiftsExpiry(t *testing.T) {
+	t.Parallel()
+
+	const window = 10 * time.Minute
+	fake := &countingTokenSource{
+		tokenFn: func(call int) *oauth2.Token {
+			if call == 1 {
+				// 5 min of real life: outside the 30 s default, inside the 10 min window.
+				return &oauth2.Token{AccessToken: "near-expiry", Expiry: time.Now().Add(5 * time.Minute)}
+			}
+			return &oauth2.Token{AccessToken: "fresh", Expiry: time.Now().Add(time.Hour)}
+		},
+	}
+
+	src := withPreemptiveRefresh(fake, window)
+
+	// First call returns the near-expiry token (the seed), second call must trigger
+	// a refresh because the 10 min window already covers the 5 min of remaining life.
+	tok, err := src.Token()
+	require.NoError(t, err)
+	assert.Equal(t, "near-expiry", tok.AccessToken)
+
+	tok, err = src.Token()
+	require.NoError(t, err)
+	assert.Equal(t, "fresh", tok.AccessToken,
+		"a 10 min window must refresh a token with only 5 min of life left")
+	assert.Equal(t, 2, fake.calls)
+}
+
+// TestNew_NegativePreemptiveWindowPanics verifies the constructor fails loudly
+// on an invalid (negative) window rather than silently producing surprising
+// expiry math.
+func TestNew_NegativePreemptiveWindowPanics(t *testing.T) {
+	t.Parallel()
+	assert.Panics(t, func() {
+		New(Options{
+			KeyProvider:             func() string { return "key" },
+			PreemptiveRefreshWindow: -1 * time.Second,
+		})
+	})
 }
 
 // ── withPreemptiveRefresh ─────────────────────────────────────────────────────
@@ -127,7 +202,7 @@ func TestWithPreemptiveRefresh_ExactlyOneRefreshPerWindow(t *testing.T) {
 		},
 	}
 
-	src := withPreemptiveRefresh(fake)
+	src := withPreemptiveRefresh(fake, preemptiveRefreshWindow)
 
 	tok, err := src.Token()
 	require.NoError(t, err)
@@ -168,7 +243,7 @@ func TestWithPreemptiveRefresh_NonCachingRefresher_NoResource(t *testing.T) {
 		Endpoint: oauth2.Endpoint{TokenURL: srv.URL, AuthStyle: oauth2.AuthStyleInParams},
 	}
 	ncr := oauth.NewNonCachingRefresher(cfg, "refresh-token", "")
-	src := withPreemptiveRefresh(ncr)
+	src := withPreemptiveRefresh(ncr, preemptiveRefreshWindow)
 
 	tok, err := src.Token()
 	require.NoError(t, err)
@@ -196,7 +271,7 @@ func TestWithPreemptiveRefresh_CachingInnerSource_Thrashes(t *testing.T) {
 		},
 	}
 
-	src := withPreemptiveRefresh(cachingInner)
+	src := withPreemptiveRefresh(cachingInner, preemptiveRefreshWindow)
 
 	const iterations = 10
 	for range iterations {
@@ -219,7 +294,7 @@ func TestWithPreemptiveRefreshFrom_PreSeededToken(t *testing.T) {
 	}
 	initial := &oauth2.Token{AccessToken: "initial", Expiry: time.Now().Add(2 * time.Minute)}
 
-	src := withPreemptiveRefreshFrom(initial, fake)
+	src := withPreemptiveRefreshFrom(initial, fake, preemptiveRefreshWindow)
 
 	for i := range 5 {
 		tok, err := src.Token()
@@ -242,7 +317,7 @@ func TestWithPreemptiveRefreshFrom_ShortLivedInitial_NoSeed(t *testing.T) {
 		Expiry:      time.Now().Add(preemptiveRefreshWindow / 2),
 	}
 
-	src := withPreemptiveRefreshFrom(initial, fake)
+	src := withPreemptiveRefreshFrom(initial, fake, preemptiveRefreshWindow)
 
 	tok, err := src.Token()
 	require.NoError(t, err)
@@ -259,7 +334,7 @@ func TestWithPreemptiveRefreshFrom_NilInitial(t *testing.T) {
 		},
 	}
 
-	src := withPreemptiveRefreshFrom(nil, fake)
+	src := withPreemptiveRefreshFrom(nil, fake, preemptiveRefreshWindow)
 
 	tok, err := src.Token()
 	require.NoError(t, err)

--- a/pkg/auth/tokensource/tokensource.go
+++ b/pkg/auth/tokensource/tokensource.go
@@ -40,8 +40,11 @@ import (
 // from real backend errors. It is never exposed to callers.
 var errCacheMiss = errors.New("no cached refresh token")
 
-// preemptiveRefreshWindow is how far before actual expiry a token is treated as
-// expired, triggering a proactive refresh before the upstream rejects it.
+// preemptiveRefreshWindow is the default distance before actual expiry at which
+// a token is treated as expired, triggering a proactive refresh before the
+// upstream rejects it. Callers that re-invoke the token source on a fixed
+// cadence (e.g. the LLM gateway's apiKeyHelper) widen this via
+// Options.PreemptiveRefreshWindow so a refresh always lands before expiry.
 const preemptiveRefreshWindow = 30 * time.Second
 
 // OIDCParams holds the OIDC connection parameters for a token source.
@@ -85,6 +88,13 @@ type Options struct {
 	// FallbackErr is returned in non-interactive mode when no cached credentials
 	// exist and no actionable lastErr is available. Defaults to a generic error.
 	FallbackErr error
+	// PreemptiveRefreshWindow overrides how far before expiry a token is
+	// proactively refreshed. Zero uses the default (preemptiveRefreshWindow,
+	// 30 s); a negative value panics in New. Widen this when the caller polls
+	// the token source on a fixed cadence (e.g. the LLM gateway apiKeyHelper) so
+	// the window comfortably exceeds that cadence and a refresh always lands
+	// before expiry.
+	PreemptiveRefreshWindow time.Duration
 }
 
 // OAuthTokenSource provides OIDC-backed access tokens via a four-tier strategy.
@@ -96,11 +106,16 @@ type OAuthTokenSource struct {
 }
 
 // New creates an OAuthTokenSource from the given Options.
-// It panics if opts.KeyProvider is nil, as this is a required field.
+// It panics if opts.KeyProvider is nil, as this is a required field, or if
+// opts.PreemptiveRefreshWindow is negative.
 // If opts.OIDC.CallbackPort is zero, it defaults to remote.DefaultCallbackPort.
+// If opts.PreemptiveRefreshWindow is zero, it defaults to preemptiveRefreshWindow.
 func New(opts Options) *OAuthTokenSource {
 	if opts.KeyProvider == nil {
 		panic("tokensource.New: Options.KeyProvider must not be nil")
+	}
+	if opts.PreemptiveRefreshWindow < 0 {
+		panic("tokensource.New: Options.PreemptiveRefreshWindow must not be negative")
 	}
 	if opts.FallbackErr == nil {
 		opts.FallbackErr = errors.New("authentication required: no cached credentials found; complete an interactive login first")
@@ -225,9 +240,9 @@ func (t *OAuthTokenSource) tryRestoreFromCache(ctx context.Context) error {
 	//
 	// oauth2Cfg.TokenSource caches internally and only refreshes when the real
 	// expiry passes. When the outer ReuseTokenSource enters the preemptive window
-	// (30 s before real expiry) it calls preemptiveTokenSource, which calls the
-	// inner source; the inner source sees the real token as still valid and returns
-	// it unchanged; preemptiveTokenSource shifts the expiry back by 30 s, producing
+	// (refreshWindow before real expiry) it calls preemptiveTokenSource, which calls
+	// the inner source; the inner source sees the real token as still valid and returns
+	// it unchanged; preemptiveTokenSource shifts the expiry back by the window, producing
 	// an already-expired token; the outer ReuseTokenSource then re-enters the chain
 	// on every subsequent call — an infinite non-refreshing loop.
 	//
@@ -244,8 +259,8 @@ func (t *OAuthTokenSource) tryRestoreFromCache(ctx context.Context) error {
 	// old token on refresh (common with OIDC providers that rotate refresh tokens).
 	base := remote.NewPersistingTokenSource(rawRefresher, t.makeTokenPersister(key))
 
-	// Wrap with preemptive refresh so tokens are renewed 30 s before real expiry.
-	t.tokenSource = withPreemptiveRefresh(base)
+	// Wrap with preemptive refresh so tokens are renewed before real expiry.
+	t.tokenSource = withPreemptiveRefresh(base, t.refreshWindow())
 	return nil
 }
 
@@ -304,7 +319,7 @@ func (t *OAuthTokenSource) performBrowserFlow(ctx context.Context) error {
 
 	// Pre-seed the outer ReuseTokenSource with the shifted initial token so the
 	// just-obtained access token is served without an immediate network round-trip.
-	t.tokenSource = withPreemptiveRefreshFrom(initialToken, base)
+	t.tokenSource = withPreemptiveRefreshFrom(initialToken, base, t.refreshWindow())
 	return nil
 }
 
@@ -455,10 +470,21 @@ func EnsureOfflineAccess(scopes []string) []string {
 	return append(scopes[:len(scopes):len(scopes)], "offline_access")
 }
 
+// refreshWindow returns the configured preemptive refresh window, falling back
+// to the package default when the caller left Options.PreemptiveRefreshWindow
+// unset. New rejects negative values, so this is always > 0.
+func (t *OAuthTokenSource) refreshWindow() time.Duration {
+	if t.opts.PreemptiveRefreshWindow > 0 {
+		return t.opts.PreemptiveRefreshWindow
+	}
+	return preemptiveRefreshWindow
+}
+
 // preemptiveTokenSource wraps an oauth2.TokenSource and shifts each returned
-// token's expiry back by preemptiveRefreshWindow.
+// token's expiry back by window.
 type preemptiveTokenSource struct {
-	inner oauth2.TokenSource
+	inner  oauth2.TokenSource
+	window time.Duration
 }
 
 func (p *preemptiveTokenSource) Token() (*oauth2.Token, error) {
@@ -468,29 +494,29 @@ func (p *preemptiveTokenSource) Token() (*oauth2.Token, error) {
 	}
 	if !tok.Expiry.IsZero() {
 		shifted := *tok
-		shifted.Expiry = tok.Expiry.Add(-preemptiveRefreshWindow)
+		shifted.Expiry = tok.Expiry.Add(-p.window)
 		return &shifted, nil
 	}
 	return tok, nil
 }
 
-// withPreemptiveRefresh wraps src so tokens appear expired preemptiveRefreshWindow
-// before they actually expire, then re-wraps with ReuseTokenSource so the refresh
-// is only triggered once per window.
-func withPreemptiveRefresh(src oauth2.TokenSource) oauth2.TokenSource {
-	return withPreemptiveRefreshFrom(nil, src)
+// withPreemptiveRefresh wraps src so tokens appear expired window before they
+// actually expire, then re-wraps with ReuseTokenSource so the refresh is only
+// triggered once per window.
+func withPreemptiveRefresh(src oauth2.TokenSource, window time.Duration) oauth2.TokenSource {
+	return withPreemptiveRefreshFrom(nil, src, window)
 }
 
 // withPreemptiveRefreshFrom is like withPreemptiveRefresh but pre-seeds the outer
 // ReuseTokenSource with a shifted copy of initial (if non-nil and valid).
-func withPreemptiveRefreshFrom(initial *oauth2.Token, src oauth2.TokenSource) oauth2.TokenSource {
+func withPreemptiveRefreshFrom(initial *oauth2.Token, src oauth2.TokenSource, window time.Duration) oauth2.TokenSource {
 	var seeded *oauth2.Token
 	if initial != nil && initial.Valid() && !initial.Expiry.IsZero() {
 		shifted := *initial
-		shifted.Expiry = initial.Expiry.Add(-preemptiveRefreshWindow)
+		shifted.Expiry = initial.Expiry.Add(-window)
 		if shifted.Valid() {
 			seeded = &shifted
 		}
 	}
-	return oauth2.ReuseTokenSource(seeded, &preemptiveTokenSource{inner: src})
+	return oauth2.ReuseTokenSource(seeded, &preemptiveTokenSource{inner: src, window: window})
 }

--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -165,9 +165,9 @@ const (
 // Exactly one of ValueField or Literal must be set:
 //   - ValueField names which ApplyConfig field to write. Valid values:
 //     "GatewayURL", "AnthropicBaseURL", "ProxyBaseURL", "ProxyOrigin",
-//     "TokenHelperCommand", "PlaceholderAPIKey", "NodeTLSRejectUnauthorized".
-//     An unrecognised ValueField is a programming error and causes
-//     ConfigureLLMGateway to return an error.
+//     "TokenHelperCommand", "PlaceholderAPIKey", "ClaudeCodeHelperTTLMillis",
+//     "NodeTLSRejectUnauthorized". An unrecognised ValueField is a programming
+//     error and causes ConfigureLLMGateway to return an error.
 //   - Literal is written verbatim into the settings key (e.g. a fixed auth
 //     type string). Use Literal instead of ValueField for constant values so
 //     that typos in ValueField are caught as errors rather than silently
@@ -180,7 +180,8 @@ const (
 type LLMGatewayKeySpec struct {
 	JSONPointer string // RFC 6901 path
 	// ValueField: "GatewayURL" | "AnthropicBaseURL" | "ProxyBaseURL" | "ProxyOrigin" |
-	// "TokenHelperCommand" | "PlaceholderAPIKey" | "NodeTLSRejectUnauthorized"
+	// "TokenHelperCommand" | "PlaceholderAPIKey" | "ClaudeCodeHelperTTLMillis" |
+	// "NodeTLSRejectUnauthorized"
 	ValueField     string
 	Literal        string // constant value written verbatim; mutually exclusive with ValueField
 	ClearWhenEmpty bool   // remove the key when the resolved value is empty (ignored for Literal)
@@ -516,6 +517,10 @@ var supportedClientIntegrations = []clientAppConfig{
 		LLMGatewayKeys: []LLMGatewayKeySpec{
 			{JSONPointer: "/apiKeyHelper", ValueField: "TokenHelperCommand"},
 			{JSONPointer: "/env/ANTHROPIC_BASE_URL", ValueField: "AnthropicBaseURL"},
+			// Pin the apiKeyHelper re-invocation cadence so it stays below the token
+			// source's preemptive refresh window — together they guarantee the helper
+			// never returns an about-to-expire token.
+			{JSONPointer: "/env/CLAUDE_CODE_API_KEY_HELPER_TTL_MS", ValueField: "ClaudeCodeHelperTTLMillis"},
 			// NODE_TLS_REJECT_UNAUTHORIZED is only written when --tls-skip-verify is set.
 			// ClearWhenEmpty ensures it is removed when the flag is later cleared.
 			{JSONPointer: "/env/NODE_TLS_REJECT_UNAUTHORIZED", ValueField: "NodeTLSRejectUnauthorized", ClearWhenEmpty: true},

--- a/pkg/client/llm_gateway.go
+++ b/pkg/client/llm_gateway.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/tailscale/hujson"
@@ -296,6 +297,11 @@ func resolveApplyConfigField(valueField string, cfg llmgateway.ApplyConfig) (str
 		return cfg.TokenHelperCommand, true
 	case "PlaceholderAPIKey":
 		return llmPlaceholderAPIKey, true
+	case "ClaudeCodeHelperTTLMillis":
+		// Constant, independent of cfg: how often Claude Code re-invokes the
+		// apiKeyHelper. Kept in sync with the token source's preemptive refresh
+		// window (see pkg/llmgateway constants).
+		return strconv.FormatInt(llmgateway.ClaudeCodeHelperTTL.Milliseconds(), 10), true
 	case "NodeTLSRejectUnauthorized":
 		if cfg.TLSSkipVerify {
 			return "0", true

--- a/pkg/client/llm_gateway_test.go
+++ b/pkg/client/llm_gateway_test.go
@@ -84,8 +84,9 @@ func TestRealClientConfigs_ConfigureAndRevert(t *testing.T) {
 			// ~/.claude/settings.json
 			clientType: ClaudeCode,
 			wantPointers: map[string]string{
-				"/apiKeyHelper":           `"thv" llm token`,
-				"/env/ANTHROPIC_BASE_URL": "https://gw.example.com",
+				"/apiKeyHelper":                          `"thv" llm token`,
+				"/env/ANTHROPIC_BASE_URL":                "https://gw.example.com",
+				"/env/CLAUDE_CODE_API_KEY_HELPER_TTL_MS": "300000",
 			},
 		},
 		{

--- a/pkg/llm/tokensource.go
+++ b/pkg/llm/tokensource.go
@@ -10,6 +10,7 @@ import (
 	"golang.org/x/oauth2"
 
 	"github.com/stacklok/toolhive/pkg/auth/tokensource"
+	"github.com/stacklok/toolhive/pkg/llmgateway"
 	"github.com/stacklok/toolhive/pkg/secrets"
 )
 
@@ -64,6 +65,11 @@ func NewTokenSource(
 		},
 		ConfigPersister: tokenRefUpdater,
 		FallbackErr:     ErrTokenRequired,
+		// Widen the preemptive refresh window past Claude Code's apiKeyHelper TTL
+		// so every helper invocation in the final window forces a refresh and the
+		// helper never hands back an about-to-expire token. Kept in sync with the
+		// TTL written to settings.json (see pkg/llmgateway constants).
+		PreemptiveRefreshWindow: llmgateway.LLMTokenRefreshWindow,
 	})
 }
 

--- a/pkg/llmgateway/config.go
+++ b/pkg/llmgateway/config.go
@@ -5,7 +5,24 @@
 // imported by both pkg/llm and pkg/client to avoid an import cycle.
 package llmgateway
 
-import "net/url"
+import (
+	"net/url"
+	"time"
+)
+
+// ClaudeCodeHelperTTL is written to settings.json as
+// CLAUDE_CODE_API_KEY_HELPER_TTL_MS: how often Claude Code re-invokes the
+// apiKeyHelper ("thv llm token"). Pinned to Claude Code's documented default so
+// the cadence is deterministic rather than relying on the implicit default.
+const ClaudeCodeHelperTTL = 5 * time.Minute
+
+// LLMTokenRefreshWindow is how far before expiry the LLM gateway token source
+// proactively refreshes. It is derived as 2x ClaudeCodeHelperTTL so that every
+// helper invocation in the final window forces a refresh, meaning Claude Code
+// never receives an about-to-expire token. The invariant
+// LLMTokenRefreshWindow > ClaudeCodeHelperTTL is what makes this belt-and-
+// suspenders pairing work; keep the two values in sync (guarded by a test).
+const LLMTokenRefreshWindow = 2 * ClaudeCodeHelperTTL
 
 // ProxyOriginOf returns rawURL with its path, query, fragment, and userinfo
 // stripped so only the scheme and host remain (the "origin"). Tools like

--- a/pkg/llmgateway/config_test.go
+++ b/pkg/llmgateway/config_test.go
@@ -5,11 +5,30 @@ package llmgateway_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/stacklok/toolhive/pkg/llmgateway"
 )
+
+// TestRefreshWindowExceedsHelperTTL guards the belt-and-suspenders invariant
+// between the two values ToolHive writes for Claude Code: the token source's
+// preemptive refresh window MUST exceed the apiKeyHelper TTL, so that every
+// helper invocation in the final window forces a proactive refresh and Claude
+// Code never receives an about-to-expire token. If either constant changes and
+// the invariant breaks, this test fails before the regression ships.
+func TestRefreshWindowExceedsHelperTTL(t *testing.T) {
+	t.Parallel()
+
+	assert.Greater(t, llmgateway.LLMTokenRefreshWindow, llmgateway.ClaudeCodeHelperTTL,
+		"refresh window must exceed the helper TTL so a helper call always lands inside it")
+	assert.Equal(t, 2*llmgateway.ClaudeCodeHelperTTL, llmgateway.LLMTokenRefreshWindow,
+		"refresh window is derived as 2x the helper TTL")
+	assert.Equal(t, int64(300000), llmgateway.ClaudeCodeHelperTTL.Milliseconds(),
+		"helper TTL is written to settings.json in milliseconds")
+	assert.Equal(t, 10*time.Minute, llmgateway.LLMTokenRefreshWindow)
+}
 
 func TestProxyOriginOf(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Summary

When ToolHive configures Claude Code as an LLM gateway client, it writes an `apiKeyHelper` (`thv llm token`) into `~/.claude/settings.json`. Claude Code re-invokes that helper on a fixed cadence (default 5 min) and on any HTTP 401. The token source only refreshed a token 30s before its real expiry, far shorter than that cadence, so a helper call landing near the hourly token boundary could be handed an about-to-expire token. It expires moments later, in-flight requests 401 (amplified under parallel agent traffic where several requests hit the boundary at once), and the next helper re-invoke recovers. The 401 retry self-heals, but the blip is visible.

This fixes it belt-and-suspenders: pin Claude Code's helper TTL and widen the token source's preemptive refresh window so the window always exceeds the TTL. With `window > TTL`, every helper invocation in the final window forces a proactive refresh, so Claude Code always holds a token with plenty of life left and never presents an expired one. The two values share one source of truth and are locked together by a guard test so they can't drift.

The widened window applies only to the LLM gateway path. `tokensource.New` has two callers (LLM gateway and registry auth); registry auth keeps the existing 30s default, so its refresh cadence is unchanged.

- Add `ClaudeCodeHelperTTL` (5m) and `LLMTokenRefreshWindow` (2x TTL) to `pkg/llmgateway` as the single source of truth, with a test asserting `window > TTL`.
- Add an optional per-source `Options.PreemptiveRefreshWindow` to the token source (0 = default 30s, negative panics in `New`); the LLM gateway path sets the wider value.
- Write `CLAUDE_CODE_API_KEY_HELPER_TTL_MS` into `~/.claude/settings.json` via a new `ClaudeCodeHelperTTLMillis` ValueField; `RevertLLMGateway` removes it on teardown automatically.

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)

Targeted packages (`pkg/auth/tokensource`, `pkg/llm`, `pkg/client`, `pkg/llmgateway`) pass with `-race`. Added tests:
- `pkg/llmgateway`: guard test asserting `LLMTokenRefreshWindow > ClaudeCodeHelperTTL`, the 2x derivation, and the 300000ms value (fails if the two drift out of sync).
- `pkg/auth/tokensource`: default-vs-override resolution, a configured window shifting expiry (10m window refreshes a token with 5m of life left), and negative-window panic.
- `pkg/client`: extended the real-config configure/revert test to assert `CLAUDE_CODE_API_KEY_HELPER_TTL_MS=300000` lands in settings.json and is removed on revert.

## Does this introduce a user-facing change?

Yes. After `thv llm setup`, Claude Code's `~/.claude/settings.json` gains `env.CLAUDE_CODE_API_KEY_HELPER_TTL_MS=300000`, and the LLM gateway token is refreshed further ahead of expiry. Together these eliminate the occasional 401 blip at the hourly token boundary. `thv llm setup` teardown removes the new key.

## Implementation plan

<details>
<summary>Approved implementation plan</summary>

The token source (`pkg/auth/tokensource`) refreshed only 30s before expiry (`preemptiveRefreshWindow`), far shorter than Claude Code's ~5 min helper cadence, leaving an unguarded gap at the hourly token boundary. Fix: pin the helper TTL and widen the window so `window > TTL`, with both values sharing one source of truth and a guard test.

Scope (confirmed with user): widen only the LLM gateway path. `tokensource.New` has two callers (LLM gateway, registry auth); registry auth keeps 30s via an optional per-source override rather than bumping the shared constant.

- `pkg/llmgateway/config.go`: add `ClaudeCodeHelperTTL = 5m` and `LLMTokenRefreshWindow = 2 * ClaudeCodeHelperTTL` (shared, cycle-free package imported by both `pkg/llm` and `pkg/client`).
- `pkg/auth/tokensource`: add `Options.PreemptiveRefreshWindow` (0 = default 30s, negative panics in `New`); plumb the window through `preemptiveTokenSource` / `withPreemptiveRefresh(From)` and the two call sites; keep 30s as the default.
- `pkg/llm/tokensource.go`: set `PreemptiveRefreshWindow: llmgateway.LLMTokenRefreshWindow`.
- `pkg/client/llm_gateway.go` + `config.go`: add `ClaudeCodeHelperTTLMillis` ValueField returning the TTL in ms; add `/env/CLAUDE_CODE_API_KEY_HELPER_TTL_MS` to the Claude Code `LLMGatewayKeys`. Revert reuses the same key list.
- Tests: synergy guard in `pkg/llmgateway`; window override behavior in `pkg/auth/tokensource`; end-to-end settings write/revert in `pkg/client`.

</details>

## Special notes for reviewers

- `LLMTokenRefreshWindow` is derived as `2 * ClaudeCodeHelperTTL` so the two values can't drift; the `pkg/llmgateway` guard test enforces `window > TTL`.
- Unrelated pre-existing lint finding: `task lint-fix` reports a gosec G115 in `cmd/thv/app/upgrade.go`, which this PR does not touch. Left it out to keep scope clean.

Generated with [Claude Code](https://claude.com/claude-code)