### PR TITLE
Fix data race in TestMCPAuthzConfigReconciler_watchHandlers

### DIFF
--- a/cmd/thv-operator/controllers/mcpauthzconfig_controller_test.go
+++ b/cmd/thv-operator/controllers/mcpauthzconfig_controller_test.go
@@ -914,7 +914,11 @@ func TestMCPAuthzConfigReconciler_watchHandlers(t *testing.T) {
 			t.Parallel()
 
 			ctx := t.Context()
-			r, _ := newAuthzTestReconciler(t, staleConfig, tt.obj)
+			// DeepCopy the shared fixture: newAuthzTestReconciler builds a fake
+			// client whose versionedTracker.Add mutates ObjectMeta.ResourceVersion
+			// in place. Passing the same staleConfig pointer into parallel subtests
+			// would race on that write (#5502); each subtest gets its own copy.
+			r, _ := newAuthzTestReconciler(t, staleConfig.DeepCopy(), tt.obj)
 
 			requests := func() []reconcile.Request {
 				switch tt.obj.(type) {


### PR DESCRIPTION
## Summary

Since #4777, `Tests / Test Go Code` has failed intermittently with `race detected during execution of test` across the whole `cmd/thv-operator/controllers` package. `TestMCPAuthzConfigReconciler_watchHandlers` declared one `staleConfig` fixture at function scope and passed the **same pointer** into `newAuthzTestReconciler` from `t.Parallel()` subtests; the fake client builder's `versionedTracker.Add` mutates `ObjectMeta.ResourceVersion` in place, so parallel subtests raced on that write. The race detector aborts the whole test binary, so every parallel test in the package was reported as `race detected` — making the flake look far broader than its single cause.

Closes #5502

<details>
<summary><strong>Medium level</strong></summary>

- The shared `staleConfig` pointer is the only fixture shared across parallel subtests in this file — the other parallel table tests (`handleDeletion`, the reference-aggregation test) build distinct objects per table case, so they don't race.
- Fix: pass `staleConfig.DeepCopy()` into `newAuthzTestReconciler` so each subtest's fake client owns its own copy, with a comment explaining why.
- No production code changes; test-only.

</details>

<details>
<summary><strong>Low level</strong></summary>

| File | Change |
|------|--------|
| `cmd/thv-operator/controllers/mcpauthzconfig_controller_test.go` | Pass `staleConfig.DeepCopy()` per parallel subtest in `TestMCPAuthzConfigReconciler_watchHandlers`; add explanatory comment |

</details>

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

## Test plan

- [x] Reproduced the race first: `go test -race -run TestMCPAuthzConfigReconciler_watchHandlers -count=20 ./cmd/thv-operator/controllers/` tripped `WARNING: DATA RACE` on iteration 1 (on `staleConfig.ObjectMeta` Set/Get via `versionedTracker.Add`).
- [x] After the fix: `go test -race -run TestMCPAuthzConfigReconciler_watchHandlers -count=50 ./cmd/thv-operator/controllers/` — clean.
- [x] `go test -race -count=5 ./cmd/thv-operator/controllers/` (full package) — clean, no other races surface.
- [x] `go build ./cmd/thv-operator/...`, `go vet`, and `gofmt` clean.

## Special notes for reviewers

Scoped the audit to the whole file as the issue suggested: `TestMCPAuthzConfigReconciler_watchHandlers` is the only test sharing a function-scope fixture pointer across `t.Parallel()` subtests. The other parallel tables construct fresh per-case objects, so no other `DeepCopy` is needed.

Generated with [Claude Code](https://claude.com/claude-code)