### PR TITLE
Add testutil.NewScheme helper and migrate operator test schemes

### DIFF
--- a/cmd/thv-operator/controllers/config_controller_events_test.go
+++ b/cmd/thv-operator/controllers/config_controller_events_test.go
@@ -19,6 +19,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 )
 
 // drainEvents returns every event currently buffered on the fake recorder
@@ -46,20 +47,12 @@ func countContaining(evts []string, substr string) int {
 	return n
 }
 
-func configEventsScheme(t *testing.T) *runtime.Scheme {
-	t.Helper()
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-	require.NoError(t, corev1.AddToScheme(scheme))
-	return scheme
-}
-
 // ---- MCPOIDCConfig ----
 
 func TestMCPOIDCConfigReconciler_EmitsEvents(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
-	scheme := configEventsScheme(t)
+	scheme := testutil.NewScheme(t)
 
 	// Invalid: type=inline but no inline config.
 	cfg := &mcpv1beta1.MCPOIDCConfig{
@@ -110,7 +103,7 @@ func TestMCPOIDCConfigReconciler_EmitsEvents(t *testing.T) {
 func TestMCPOIDCConfigReconciler_EmitsDeletionBlockedEvent(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
-	scheme := configEventsScheme(t)
+	scheme := testutil.NewScheme(t)
 
 	cfg := &mcpv1beta1.MCPOIDCConfig{
 		ObjectMeta: metav1.ObjectMeta{
@@ -150,7 +143,7 @@ func TestMCPOIDCConfigReconciler_EmitsDeletionBlockedEvent(t *testing.T) {
 func TestMCPOIDCConfigReconciler_NilRecorderNoPanic(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
-	scheme := configEventsScheme(t)
+	scheme := testutil.NewScheme(t)
 
 	cfg := &mcpv1beta1.MCPOIDCConfig{
 		ObjectMeta: metav1.ObjectMeta{
@@ -188,7 +181,7 @@ func validExternalAuthSpec() mcpv1beta1.MCPExternalAuthConfigSpec {
 func TestMCPExternalAuthConfigReconciler_EmitsEvents(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
-	scheme := configEventsScheme(t)
+	scheme := testutil.NewScheme(t)
 
 	// Invalid: type=tokenExchange but no tokenExchange config block.
 	cfg := &mcpv1beta1.MCPExternalAuthConfig{
@@ -235,7 +228,7 @@ func TestMCPExternalAuthConfigReconciler_EmitsEvents(t *testing.T) {
 func TestMCPExternalAuthConfigReconciler_EmitsDeletionBlockedEvent(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
-	scheme := configEventsScheme(t)
+	scheme := testutil.NewScheme(t)
 
 	cfg := &mcpv1beta1.MCPExternalAuthConfig{
 		ObjectMeta: metav1.ObjectMeta{
@@ -284,7 +277,7 @@ func TestMCPExternalAuthConfigReconciler_EmitsDeletionBlockedEvent(t *testing.T)
 func TestMCPExternalAuthConfigReconciler_EmitsRecoveryOnSteadyStatePath(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
-	scheme := configEventsScheme(t)
+	scheme := testutil.NewScheme(t)
 
 	spec := validExternalAuthSpec()
 	hash := (&MCPExternalAuthConfigReconciler{}).calculateConfigHash(spec)
@@ -327,7 +320,7 @@ func TestMCPExternalAuthConfigReconciler_EmitsRecoveryOnSteadyStatePath(t *testi
 func TestMCPAuthzConfigReconciler_EmitsEvents(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
-	scheme := configEventsScheme(t)
+	scheme := testutil.NewScheme(t)
 
 	// Invalid: cedarv1 type but empty policy set (fails backend validation).
 	cfg := &mcpv1beta1.MCPAuthzConfig{
@@ -377,7 +370,7 @@ func TestMCPAuthzConfigReconciler_EmitsEvents(t *testing.T) {
 func TestMCPAuthzConfigReconciler_EmitsDeletionBlockedEvent(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
-	scheme := configEventsScheme(t)
+	scheme := testutil.NewScheme(t)
 
 	cfg := &mcpv1beta1.MCPAuthzConfig{
 		ObjectMeta: metav1.ObjectMeta{

--- a/cmd/thv-operator/controllers/embeddingserver_controller_test.go
+++ b/cmd/thv-operator/controllers/embeddingserver_controller_test.go
@@ -21,6 +21,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 	ctrlutil "github.com/stacklok/toolhive/cmd/thv-operator/pkg/controllerutil"
 )
 
@@ -331,14 +332,6 @@ func TestEmbeddingServer_ModelCacheConfig(t *testing.T) {
 
 // Test helpers
 
-func createEmbeddingServerTestScheme() *runtime.Scheme {
-	testScheme := runtime.NewScheme()
-	_ = corev1.AddToScheme(testScheme)
-	_ = appsv1.AddToScheme(testScheme)
-	_ = mcpv1beta1.AddToScheme(testScheme)
-	return testScheme
-}
-
 func createTestEmbeddingServer(name, namespace, image, model string) *mcpv1beta1.EmbeddingServer {
 	return &mcpv1beta1.EmbeddingServer{
 		ObjectMeta: metav1.ObjectMeta{
@@ -357,7 +350,7 @@ func createTestEmbeddingServer(name, namespace, image, model string) *mcpv1beta1
 func TestReconcile_NotFound(t *testing.T) {
 	t.Parallel()
 
-	scheme := createEmbeddingServerTestScheme()
+	scheme := testutil.NewScheme(t)
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(scheme).
 		Build()
@@ -386,7 +379,7 @@ func TestReconcile_CreateResources(t *testing.T) {
 
 	embedding := createTestEmbeddingServer("test-embedding", "test-ns", "test-image:latest", "test-model")
 
-	scheme := createEmbeddingServerTestScheme()
+	scheme := testutil.NewScheme(t)
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithRuntimeObjects(embedding).
@@ -446,7 +439,7 @@ func TestReconcile_CreateResources(t *testing.T) {
 func TestStatefulSetNeedsUpdate(t *testing.T) {
 	t.Parallel()
 
-	scheme := createEmbeddingServerTestScheme()
+	scheme := testutil.NewScheme(t)
 	reconciler := &EmbeddingServerReconciler{
 		Scheme:           scheme,
 		PlatformDetector: ctrlutil.NewSharedPlatformDetector(),
@@ -563,7 +556,7 @@ func TestHandleDeletion(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			scheme := createEmbeddingServerTestScheme()
+			scheme := testutil.NewScheme(t)
 			fakeClient := fake.NewClientBuilder().
 				WithScheme(scheme).
 				WithRuntimeObjects(tt.embedding).
@@ -673,7 +666,7 @@ func TestEnsureStatefulSet(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			scheme := createEmbeddingServerTestScheme()
+			scheme := testutil.NewScheme(t)
 			objects := []runtime.Object{tt.embedding}
 			if tt.existingSts != nil {
 				objects = append(objects, tt.existingSts)
@@ -768,7 +761,7 @@ func TestUpdateEmbeddingServerStatus(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			scheme := createEmbeddingServerTestScheme()
+			scheme := testutil.NewScheme(t)
 			objects := []runtime.Object{tt.embedding}
 			if tt.statefulSet != nil {
 				objects = append(objects, tt.statefulSet)
@@ -1023,7 +1016,7 @@ func TestEmbeddingServer_PodTemplateSpec_PreservesUserFields(t *testing.T) {
 			embedding := createTestEmbeddingServer("test", testNamespaceDefault, "test-image:latest", "test-model")
 			embedding.Spec.PodTemplateSpec = podTemplateSpecToRawExtension(t, tt.userPTS)
 
-			scheme := createEmbeddingServerTestScheme()
+			scheme := testutil.NewScheme(t)
 			fakeClient := fake.NewClientBuilder().
 				WithScheme(scheme).
 				WithRuntimeObjects(embedding).
@@ -1081,7 +1074,7 @@ func TestEmbeddingServer_PodTemplateSpec_SoftFailFallback(t *testing.T) {
 		Raw: []byte(`{"spec":{"containers":[{"name":"embedding","$patch":"invalid"}]}}`),
 	}
 
-	scheme := createEmbeddingServerTestScheme()
+	scheme := testutil.NewScheme(t)
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithRuntimeObjects(embedding).
@@ -1136,7 +1129,7 @@ func TestEmbeddingServer_PodTemplateSpec_EmptyObjectIsNoOp(t *testing.T) {
 	embedding := createTestEmbeddingServer("test", testNamespaceDefault, "test-image:latest", "test-model")
 	embedding.Spec.PodTemplateSpec = &runtime.RawExtension{Raw: []byte(`{}`)}
 
-	scheme := createEmbeddingServerTestScheme()
+	scheme := testutil.NewScheme(t)
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithRuntimeObjects(embedding).

--- a/cmd/thv-operator/controllers/embeddingserver_default_imagepullsecrets_test.go
+++ b/cmd/thv-operator/controllers/embeddingserver_default_imagepullsecrets_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 
+	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 	ctrlutil "github.com/stacklok/toolhive/cmd/thv-operator/pkg/controllerutil"
 	"github.com/stacklok/toolhive/cmd/thv-operator/pkg/imagepullsecrets"
 )
@@ -56,7 +57,7 @@ func TestEmbeddingServer_DefaultImagePullSecrets(t *testing.T) {
 				"model",
 			)
 
-			scheme := createEmbeddingServerTestScheme()
+			scheme := testutil.NewScheme(t)
 			reconciler := &EmbeddingServerReconciler{
 				Scheme:                   scheme,
 				PlatformDetector:         ctrlutil.NewSharedPlatformDetector(),

--- a/cmd/thv-operator/controllers/mcpauthzconfig_controller_test.go
+++ b/cmd/thv-operator/controllers/mcpauthzconfig_controller_test.go
@@ -19,6 +19,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 	ctrlutil "github.com/stacklok/toolhive/cmd/thv-operator/pkg/controllerutil"
 	// Import authorizer backends so they register with the factory registry.
 	_ "github.com/stacklok/toolhive/pkg/authz/authorizers/cedar"
@@ -42,9 +43,7 @@ func validHTTPPDPConfig() runtime.RawExtension {
 func newAuthzTestReconciler(t *testing.T, objs ...client.Object) (*MCPAuthzConfigReconciler, client.Client) {
 	t.Helper()
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-	require.NoError(t, corev1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(scheme).

--- a/cmd/thv-operator/controllers/mcpexternalauthconfig_controller_test.go
+++ b/cmd/thv-operator/controllers/mcpexternalauthconfig_controller_test.go
@@ -15,13 +15,13 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 	ctrlutil "github.com/stacklok/toolhive/cmd/thv-operator/pkg/controllerutil"
 	"github.com/stacklok/toolhive/pkg/auth/obo"
 	"github.com/stacklok/toolhive/pkg/runner"
@@ -202,9 +202,7 @@ func TestMCPExternalAuthConfigReconciler_Reconcile(t *testing.T) {
 
 			ctx := t.Context()
 
-			scheme := runtime.NewScheme()
-			require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-			require.NoError(t, corev1.AddToScheme(scheme))
+			scheme := testutil.NewScheme(t)
 
 			// Create fake client with objects
 			objs := []client.Object{tt.externalAuthConfig}
@@ -272,8 +270,7 @@ func TestMCPExternalAuthConfigReconciler_Reconcile(t *testing.T) {
 func TestMCPExternalAuthConfigReconciler_findReferencingWorkloads(t *testing.T) {
 	t.Parallel()
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	externalAuthConfig := &mcpv1beta1.MCPExternalAuthConfig{
 		ObjectMeta: metav1.ObjectMeta{
@@ -435,8 +432,7 @@ func TestGetExternalAuthConfigForMCPServer(t *testing.T) {
 
 			ctx := t.Context()
 
-			scheme := runtime.NewScheme()
-			require.NoError(t, mcpv1beta1.AddToScheme(scheme))
+			scheme := testutil.NewScheme(t)
 
 			objs := []client.Object{}
 			if tt.existingConfig != nil {
@@ -552,8 +548,7 @@ func TestMCPExternalAuthConfigReconciler_handleDeletion(t *testing.T) {
 
 			ctx := t.Context()
 
-			scheme := runtime.NewScheme()
-			require.NoError(t, mcpv1beta1.AddToScheme(scheme))
+			scheme := testutil.NewScheme(t)
 
 			// Build objects list
 			objs := []client.Object{tt.externalAuthConfig}
@@ -600,9 +595,7 @@ func TestMCPExternalAuthConfigReconciler_ConfigChangeTriggersReconciliation(t *t
 
 	ctx := t.Context()
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-	require.NoError(t, corev1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	externalAuthConfig := &mcpv1beta1.MCPExternalAuthConfig{
 		ObjectMeta: metav1.ObjectMeta{
@@ -707,9 +700,7 @@ func TestMCPExternalAuthConfigReconciler_ReferencingWorkloadsUpdatedWithoutHashC
 
 	ctx := t.Context()
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-	require.NoError(t, corev1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	externalAuthConfig := &mcpv1beta1.MCPExternalAuthConfig{
 		ObjectMeta: metav1.ObjectMeta{
@@ -797,9 +788,7 @@ func TestMCPExternalAuthConfigReconciler_ReferencingWorkloadsRemovedOnServerDele
 
 	ctx := t.Context()
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-	require.NoError(t, corev1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	externalAuthConfig := &mcpv1beta1.MCPExternalAuthConfig{
 		ObjectMeta: metav1.ObjectMeta{
@@ -885,8 +874,7 @@ func TestMCPExternalAuthConfigReconciler_ReferencingWorkloadsRemovedOnServerDele
 func TestMCPExternalAuthConfigReconciler_findReferencingWorkloads_authServerRef(t *testing.T) {
 	t.Parallel()
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	externalAuthConfig := &mcpv1beta1.MCPExternalAuthConfig{
 		ObjectMeta: metav1.ObjectMeta{
@@ -971,8 +959,7 @@ func TestMCPExternalAuthConfigReconciler_findReferencingWorkloads_authServerRef(
 func TestMCPExternalAuthConfigReconciler_findReferencingWorkloads_bothRefsOnSameServer(t *testing.T) {
 	t.Parallel()
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	// A server has externalAuthConfigRef pointing to "token-exchange-config"
 	// AND authServerRef pointing to "embedded-auth-config".
@@ -1074,8 +1061,7 @@ func TestMCPExternalAuthConfigReconciler_findReferencingWorkloads_bothRefsOnSame
 func TestMCPExternalAuthConfigReconciler_findReferencingMCPServers_deduplicates(t *testing.T) {
 	t.Parallel()
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	// A server has both externalAuthConfigRef and authServerRef pointing to the SAME config.
 	// The server should appear only once in the results.
@@ -1135,8 +1121,7 @@ func TestMCPExternalAuthConfigReconciler_findReferencingMCPServers_deduplicates(
 func TestMCPExternalAuthConfigReconciler_findReferencingWorkloads_mcpRemoteProxy(t *testing.T) {
 	t.Parallel()
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	config := &mcpv1beta1.MCPExternalAuthConfig{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1335,9 +1320,7 @@ func TestMCPExternalAuthConfigReconciler_IdentitySynthesizedCondition(t *testing
 				Spec: tt.spec,
 			}
 
-			scheme := runtime.NewScheme()
-			require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-			require.NoError(t, corev1.AddToScheme(scheme))
+			scheme := testutil.NewScheme(t)
 
 			fakeClient := fake.NewClientBuilder().
 				WithScheme(scheme).
@@ -1412,9 +1395,7 @@ func TestMCPExternalAuthConfigReconciler_IdentitySynthesizedTransitionsOnValidat
 		},
 	}
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-	require.NoError(t, corev1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(scheme).
@@ -1493,9 +1474,7 @@ func findCondition(conditions []metav1.Condition, t string) *metav1.Condition {
 func TestMCPExternalAuthConfigReconciler_OBO_DefaultHandler_SetsEnterpriseRequired(t *testing.T) {
 	t.Parallel()
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-	require.NoError(t, corev1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	cfg := &mcpv1beta1.MCPExternalAuthConfig{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1559,9 +1538,7 @@ func TestMCPExternalAuthConfigReconciler_OBO_DefaultHandler_SetsEnterpriseRequir
 func TestMCPExternalAuthConfigReconciler_OBO_ClearsStaleIdentitySynthesized(t *testing.T) {
 	t.Parallel()
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-	require.NoError(t, corev1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	// Construct a config that is already in the obo type but has a stale
 	// IdentitySynthesized condition left over from a prior embeddedAuthServer
@@ -1714,9 +1691,7 @@ func TestMCPExternalAuthConfigReconciler_OBO_ErrorTriageInReconcile(t *testing.T
 			stub.Validate = func(*mcpv1beta1.MCPExternalAuthConfig) error { return tt.validateErr }
 			ctrlutil.RegisterOBOHandler(stub)
 
-			scheme := runtime.NewScheme()
-			require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-			require.NoError(t, corev1.AddToScheme(scheme))
+			scheme := testutil.NewScheme(t)
 
 			cfg := &mcpv1beta1.MCPExternalAuthConfig{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1793,9 +1768,7 @@ func TestMCPExternalAuthConfigReconciler_ReconcileKeepsExistingForeignCondition(
 	t.Parallel()
 
 	ctx := t.Context()
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-	require.NoError(t, corev1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	externalAuthConfig := &mcpv1beta1.MCPExternalAuthConfig{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-config", Namespace: "default", Generation: 1},

--- a/cmd/thv-operator/controllers/mcpgroup_controller_test.go
+++ b/cmd/thv-operator/controllers/mcpgroup_controller_test.go
@@ -8,16 +8,15 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 )
 
 const (
@@ -177,9 +176,7 @@ func TestMCPGroupReconciler_Reconcile_BasicLogic(t *testing.T) {
 			t.Parallel()
 
 			ctx := t.Context()
-			scheme := runtime.NewScheme()
-			require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-			require.NoError(t, corev1.AddToScheme(scheme))
+			scheme := testutil.NewScheme(t)
 
 			// Create fake client with objects
 			objs := []client.Object{tt.mcpGroup}
@@ -322,9 +319,7 @@ func TestMCPGroupReconciler_ServerFiltering(t *testing.T) {
 			t.Parallel()
 
 			ctx := t.Context()
-			scheme := runtime.NewScheme()
-			require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-			require.NoError(t, corev1.AddToScheme(scheme))
+			scheme := testutil.NewScheme(t)
 
 			mcpGroup := &mcpv1beta1.MCPGroup{
 				ObjectMeta: metav1.ObjectMeta{
@@ -516,9 +511,7 @@ func TestMCPGroupReconciler_findMCPGroupForMCPServer(t *testing.T) {
 			t.Parallel()
 
 			ctx := t.Context()
-			scheme := runtime.NewScheme()
-			require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-			require.NoError(t, corev1.AddToScheme(scheme))
+			scheme := testutil.NewScheme(t)
 
 			// Create fake client with objects
 			objs := []client.Object{}
@@ -572,9 +565,7 @@ func TestMCPGroupReconciler_GroupNotFound(t *testing.T) {
 	t.Parallel()
 
 	ctx := t.Context()
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-	require.NoError(t, corev1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(scheme).
@@ -674,9 +665,7 @@ func TestMCPGroupReconciler_Conditions(t *testing.T) {
 			t.Parallel()
 
 			ctx := t.Context()
-			scheme := runtime.NewScheme()
-			require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-			require.NoError(t, corev1.AddToScheme(scheme))
+			scheme := testutil.NewScheme(t)
 
 			objs := []client.Object{tt.mcpGroup}
 			for _, server := range tt.mcpServers {
@@ -760,9 +749,7 @@ func TestMCPGroupReconciler_Finalizer(t *testing.T) {
 	t.Parallel()
 
 	ctx := t.Context()
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-	require.NoError(t, corev1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	mcpGroup := &mcpv1beta1.MCPGroup{
 		ObjectMeta: metav1.ObjectMeta{
@@ -886,9 +873,7 @@ func TestMCPGroupReconciler_Deletion(t *testing.T) {
 			t.Parallel()
 
 			ctx := t.Context()
-			scheme := runtime.NewScheme()
-			require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-			require.NoError(t, corev1.AddToScheme(scheme))
+			scheme := testutil.NewScheme(t)
 
 			// Create group with finalizer and deletion timestamp
 			now := metav1.Now()
@@ -1058,9 +1043,7 @@ func TestMCPGroupReconciler_findReferencingMCPServers(t *testing.T) {
 			t.Parallel()
 
 			ctx := t.Context()
-			scheme := runtime.NewScheme()
-			require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-			require.NoError(t, corev1.AddToScheme(scheme))
+			scheme := testutil.NewScheme(t)
 
 			mcpGroup := &mcpv1beta1.MCPGroup{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1197,9 +1180,7 @@ func TestMCPGroupReconciler_findReferencingMCPRemoteProxies(t *testing.T) {
 			t.Parallel()
 
 			ctx := t.Context()
-			scheme := runtime.NewScheme()
-			require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-			require.NoError(t, corev1.AddToScheme(scheme))
+			scheme := testutil.NewScheme(t)
 
 			mcpGroup := &mcpv1beta1.MCPGroup{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1374,9 +1355,7 @@ func TestMCPGroupReconciler_findMCPGroupForMCPRemoteProxy(t *testing.T) {
 			t.Parallel()
 
 			ctx := t.Context()
-			scheme := runtime.NewScheme()
-			require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-			require.NoError(t, corev1.AddToScheme(scheme))
+			scheme := testutil.NewScheme(t)
 
 			// Create fake client with objects
 			objs := []client.Object{}
@@ -1473,9 +1452,7 @@ func TestMCPGroupReconciler_updateReferencingRemoteProxiesOnDeletion(t *testing.
 			t.Parallel()
 
 			ctx := t.Context()
-			scheme := runtime.NewScheme()
-			require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-			require.NoError(t, corev1.AddToScheme(scheme))
+			scheme := testutil.NewScheme(t)
 
 			objs := []client.Object{}
 			for i := range tt.mcpRemoteProxies {

--- a/cmd/thv-operator/controllers/mcpoidcconfig_controller_test.go
+++ b/cmd/thv-operator/controllers/mcpoidcconfig_controller_test.go
@@ -11,10 +11,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -22,6 +20,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 )
 
 func TestMCPOIDCConfigReconciler_calculateConfigHash(t *testing.T) {
@@ -96,8 +95,7 @@ func TestMCPOIDCConfigReconciler_ReconcileNotFound(t *testing.T) {
 
 	ctx := t.Context()
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	// Empty client — no objects exist
 	fakeClient := fake.NewClientBuilder().
@@ -126,9 +124,7 @@ func TestMCPOIDCConfigReconciler_SteadyStateNoOp(t *testing.T) {
 
 	ctx := t.Context()
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-	require.NoError(t, corev1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	oidcConfig := &mcpv1beta1.MCPOIDCConfig{
 		ObjectMeta: metav1.ObjectMeta{
@@ -195,9 +191,7 @@ func TestMCPOIDCConfigReconciler_ValidationRecovery(t *testing.T) {
 
 	ctx := t.Context()
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-	require.NoError(t, corev1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	// Start with invalid config: type=inline but no inline config
 	oidcConfig := &mcpv1beta1.MCPOIDCConfig{
@@ -314,8 +308,7 @@ func TestMCPOIDCConfigReconciler_handleDeletion(t *testing.T) {
 
 			ctx := t.Context()
 
-			scheme := runtime.NewScheme()
-			require.NoError(t, mcpv1beta1.AddToScheme(scheme))
+			scheme := testutil.NewScheme(t)
 
 			objs := []client.Object{tt.oidcConfig}
 
@@ -347,9 +340,7 @@ func TestMCPOIDCConfigReconciler_ConfigChangeTriggersHashUpdate(t *testing.T) {
 
 	ctx := t.Context()
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-	require.NoError(t, corev1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	oidcConfig := &mcpv1beta1.MCPOIDCConfig{
 		ObjectMeta: metav1.ObjectMeta{
@@ -425,9 +416,7 @@ func TestMCPOIDCConfigReconciler_ValidationFailureSetsCondition(t *testing.T) {
 
 	ctx := t.Context()
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-	require.NoError(t, corev1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	// Invalid config: type is inline but no inline config set
 	oidcConfig := &mcpv1beta1.MCPOIDCConfig{
@@ -576,9 +565,7 @@ func TestMCPOIDCConfigReconciler_ReferenceCountUpdatedWithWorkloads(t *testing.T
 	t.Parallel()
 
 	ctx := t.Context()
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-	require.NoError(t, corev1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	oidcConfig := &mcpv1beta1.MCPOIDCConfig{
 		ObjectMeta: metav1.ObjectMeta{
@@ -659,9 +646,7 @@ func TestMCPOIDCConfigReconciler_ReconcileKeepsExistingForeignCondition(t *testi
 	t.Parallel()
 
 	ctx := t.Context()
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-	require.NoError(t, corev1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	oidcConfig := &mcpv1beta1.MCPOIDCConfig{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-config", Namespace: "default", Generation: 1},
@@ -739,9 +724,7 @@ func TestMCPOIDCConfigReconciler_ConcurrentForeignConditionSurvivesMergePatch(t 
 	t.Parallel()
 
 	ctx := t.Context()
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-	require.NoError(t, corev1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	oidcConfig := &mcpv1beta1.MCPOIDCConfig{
 		ObjectMeta: metav1.ObjectMeta{Name: "concurrent-config", Namespace: "default", Generation: 1},

--- a/cmd/thv-operator/controllers/mcpregistry_controller_test.go
+++ b/cmd/thv-operator/controllers/mcpregistry_controller_test.go
@@ -11,9 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
-	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	k8smeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -26,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 	"github.com/stacklok/toolhive/cmd/thv-operator/pkg/registryapi"
 	registryapimocks "github.com/stacklok/toolhive/cmd/thv-operator/pkg/registryapi/mocks"
 )
@@ -41,17 +40,6 @@ func toRawJSONSlice[T any](t *testing.T, items []T) []apiextensionsv1.JSON {
 		result[i] = apiextensionsv1.JSON{Raw: data}
 	}
 	return result
-}
-
-// newMCPRegistryTestScheme creates a runtime scheme with all required API groups registered.
-func newMCPRegistryTestScheme(t *testing.T) *runtime.Scheme {
-	t.Helper()
-	s := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(s))
-	require.NoError(t, corev1.AddToScheme(s))
-	require.NoError(t, appsv1.AddToScheme(s))
-	require.NoError(t, rbacv1.AddToScheme(s))
-	return s
 }
 
 // newMCPRegistryWithFinalizer creates an MCPRegistry with the controller finalizer
@@ -411,7 +399,7 @@ func TestMCPRegistryReconciler_Reconcile(t *testing.T) {
 
 			// arrange
 			ctx := log.IntoContext(t.Context(), log.Log)
-			s := newMCPRegistryTestScheme(t)
+			s := testutil.NewScheme(t)
 
 			builder, mcpRegistry := tt.setup(t, s)
 			fakeClient := builder.Build()

--- a/cmd/thv-operator/controllers/mcpremoteproxy_authserverref_test.go
+++ b/cmd/thv-operator/controllers/mcpremoteproxy_authserverref_test.go
@@ -10,13 +10,13 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 )
 
 func TestMCPRemoteProxyReconciler_handleAuthServerRef(t *testing.T) {
@@ -174,9 +174,7 @@ func TestMCPRemoteProxyReconciler_handleAuthServerRef(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
 
-			scheme := runtime.NewScheme()
-			require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-			require.NoError(t, corev1.AddToScheme(scheme))
+			scheme := testutil.NewScheme(t)
 
 			proxy := tt.proxy()
 			objs := []runtime.Object{proxy}

--- a/cmd/thv-operator/controllers/mcpremoteproxy_controller_test.go
+++ b/cmd/thv-operator/controllers/mcpremoteproxy_controller_test.go
@@ -34,6 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 	ctrlutil "github.com/stacklok/toolhive/cmd/thv-operator/pkg/controllerutil"
 )
 
@@ -101,7 +102,7 @@ func TestMCPRemoteProxyValidateSpec(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			scheme := createRunConfigTestScheme()
+			scheme := testutil.NewScheme(t)
 			fakeClient := fake.NewClientBuilder().
 				WithScheme(scheme).
 				WithRuntimeObjects(tt.proxy).
@@ -141,7 +142,7 @@ func TestMCPRemoteProxyReconcile_CreateResources(t *testing.T) {
 		},
 	}
 
-	scheme := createRunConfigTestScheme()
+	scheme := testutil.NewScheme(t)
 	// Add RBAC types to scheme
 	_ = rbacv1.AddToScheme(scheme)
 	_ = appsv1.AddToScheme(scheme)
@@ -225,7 +226,7 @@ func TestMCPRemoteProxyReconcile_CreateResources(t *testing.T) {
 func TestMCPRemoteProxyReconcile_NotFound(t *testing.T) {
 	t.Parallel()
 
-	scheme := createRunConfigTestScheme()
+	scheme := testutil.NewScheme(t)
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(scheme).
 		Build()
@@ -412,7 +413,7 @@ func TestHandleToolConfig(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			scheme := createRunConfigTestScheme()
+			scheme := testutil.NewScheme(t)
 			objects := []runtime.Object{tt.proxy}
 			if tt.toolConfig != nil {
 				objects = append(objects, tt.toolConfig)
@@ -761,7 +762,7 @@ func TestHandleExternalAuthConfig(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			scheme := createRunConfigTestScheme()
+			scheme := testutil.NewScheme(t)
 			objects := []runtime.Object{tt.proxy}
 			if tt.externalAuth != nil {
 				objects = append(objects, tt.externalAuth)
@@ -918,7 +919,7 @@ func TestEnsureRBACResources(t *testing.T) {
 		},
 	}
 
-	scheme := createRunConfigTestScheme()
+	scheme := testutil.NewScheme(t)
 	// Add RBAC types to scheme
 	_ = rbacv1.AddToScheme(scheme)
 
@@ -978,7 +979,7 @@ func TestMCPRemoteProxyEnsureRBACResources_Update(t *testing.T) {
 		},
 	}
 
-	scheme := createRunConfigTestScheme()
+	scheme := testutil.NewScheme(t)
 	_ = rbacv1.AddToScheme(scheme)
 
 	saName := proxyRunnerServiceAccountNameForRemoteProxy(proxy.Name)
@@ -1060,7 +1061,7 @@ func TestMCPRemoteProxyEnsureRBACResources_Idempotency(t *testing.T) {
 		},
 	}
 
-	scheme := createRunConfigTestScheme()
+	scheme := testutil.NewScheme(t)
 	_ = rbacv1.AddToScheme(scheme)
 
 	fakeClient := fake.NewClientBuilder().
@@ -1123,7 +1124,7 @@ func TestMCPRemoteProxyEnsureRBACResources_CustomServiceAccount(t *testing.T) {
 		},
 	}
 
-	scheme := createRunConfigTestScheme()
+	scheme := testutil.NewScheme(t)
 	_ = rbacv1.AddToScheme(scheme)
 
 	fakeClient := fake.NewClientBuilder().
@@ -1189,7 +1190,7 @@ func TestMCPRemoteProxyEnsureRBACResources_ImagePullSecrets(t *testing.T) {
 		},
 	}
 
-	scheme := createRunConfigTestScheme()
+	scheme := testutil.NewScheme(t)
 	_ = rbacv1.AddToScheme(scheme)
 
 	fakeClient := fake.NewClientBuilder().
@@ -1332,7 +1333,7 @@ func TestUpdateMCPRemoteProxyStatus(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			scheme := createRunConfigTestScheme()
+			scheme := testutil.NewScheme(t)
 			objects := []runtime.Object{tt.proxy}
 			for i := range tt.pods {
 				objects = append(objects, &tt.pods[i])
@@ -1390,7 +1391,7 @@ func TestGetToolConfigForMCPRemoteProxy(t *testing.T) {
 		},
 	}
 
-	scheme := createRunConfigTestScheme()
+	scheme := testutil.NewScheme(t)
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithRuntimeObjects(toolConfig, proxy).
@@ -1428,7 +1429,7 @@ func TestGetExternalAuthConfigForMCPRemoteProxy(t *testing.T) {
 		},
 	}
 
-	scheme := createRunConfigTestScheme()
+	scheme := testutil.NewScheme(t)
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithRuntimeObjects(externalAuth, proxy).

--- a/cmd/thv-operator/controllers/mcpremoteproxy_default_imagepullsecrets_test.go
+++ b/cmd/thv-operator/controllers/mcpremoteproxy_default_imagepullsecrets_test.go
@@ -15,6 +15,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 	ctrlutil "github.com/stacklok/toolhive/cmd/thv-operator/pkg/controllerutil"
 	"github.com/stacklok/toolhive/cmd/thv-operator/pkg/imagepullsecrets"
 )
@@ -76,7 +77,7 @@ func TestMCPRemoteProxy_DefaultImagePullSecrets(t *testing.T) {
 				}
 			}
 
-			scheme := createRunConfigTestScheme()
+			scheme := testutil.NewScheme(t)
 			_ = rbacv1.AddToScheme(scheme)
 
 			fakeClient := fake.NewClientBuilder().

--- a/cmd/thv-operator/controllers/mcpremoteproxy_deployment_test.go
+++ b/cmd/thv-operator/controllers/mcpremoteproxy_deployment_test.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 	ctrlutil "github.com/stacklok/toolhive/cmd/thv-operator/pkg/controllerutil"
 	"github.com/stacklok/toolhive/pkg/transport/session"
 )
@@ -202,7 +203,7 @@ func TestDeploymentForMCPRemoteProxy(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			scheme := createRunConfigTestScheme()
+			scheme := testutil.NewScheme(t)
 			reconciler := &MCPRemoteProxyReconciler{
 				Scheme:           scheme,
 				PlatformDetector: ctrlutil.NewSharedPlatformDetector(),
@@ -310,7 +311,7 @@ func TestServiceForMCPRemoteProxy(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			scheme := createRunConfigTestScheme()
+			scheme := testutil.NewScheme(t)
 			reconciler := &MCPRemoteProxyReconciler{
 				Scheme: scheme,
 			}
@@ -594,7 +595,7 @@ func TestEnsureDeployment(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			scheme := createRunConfigTestScheme()
+			scheme := testutil.NewScheme(t)
 			// Add RBAC and Apps types to scheme
 			_ = rbacv1.AddToScheme(scheme)
 			_ = appsv1.AddToScheme(scheme)
@@ -672,7 +673,7 @@ func TestEnsureService(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			scheme := createRunConfigTestScheme()
+			scheme := testutil.NewScheme(t)
 			// Add RBAC and Apps types to scheme
 			_ = rbacv1.AddToScheme(scheme)
 			_ = appsv1.AddToScheme(scheme)
@@ -705,7 +706,7 @@ func TestEnsureService(t *testing.T) {
 func TestMCPRemoteProxyDeploymentNeedsUpdate_EmbeddedAuthLegacyEnvStable(t *testing.T) {
 	t.Parallel()
 
-	scheme := createRunConfigTestScheme()
+	scheme := testutil.NewScheme(t)
 
 	authConfig := &mcpv1beta1.MCPExternalAuthConfig{
 		ObjectMeta: metav1.ObjectMeta{
@@ -767,7 +768,7 @@ func TestMCPRemoteProxyDeploymentNeedsUpdate_EmbeddedAuthLegacyEnvStable(t *test
 func TestMCPRemoteProxyDeploymentNeedsUpdate_EmbeddedAuthAuthServerRefEnvStable(t *testing.T) {
 	t.Parallel()
 
-	scheme := createRunConfigTestScheme()
+	scheme := testutil.NewScheme(t)
 
 	authConfig := &mcpv1beta1.MCPExternalAuthConfig{
 		ObjectMeta: metav1.ObjectMeta{
@@ -830,7 +831,7 @@ func TestMCPRemoteProxyDeploymentNeedsUpdate_EmbeddedAuthAuthServerRefEnvStable(
 func TestMCPRemoteProxyDeploymentNeedsUpdate_TokenExchangeDoesNotDrift(t *testing.T) {
 	t.Parallel()
 
-	scheme := createRunConfigTestScheme()
+	scheme := testutil.NewScheme(t)
 
 	authConfig := &mcpv1beta1.MCPExternalAuthConfig{
 		ObjectMeta: metav1.ObjectMeta{
@@ -908,7 +909,7 @@ func TestMCPRemoteProxyDeployment_OBOSecretEnvVars(t *testing.T) {
 	}
 	ctrlutil.RegisterOBOHandler(stub)
 
-	scheme := createRunConfigTestScheme()
+	scheme := testutil.NewScheme(t)
 
 	authConfig := &mcpv1beta1.MCPExternalAuthConfig{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1014,7 +1015,7 @@ func TestMCPRemoteProxyDeploymentNeedsUpdate_ImagePullSecretsDrift(t *testing.T)
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			scheme := createRunConfigTestScheme()
+			scheme := testutil.NewScheme(t)
 			fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 
 			proxy := &mcpv1beta1.MCPRemoteProxy{
@@ -1268,7 +1269,7 @@ func TestBuildEnvVarsForProxy(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			scheme := createRunConfigTestScheme()
+			scheme := testutil.NewScheme(t)
 			objects := []runtime.Object{tt.proxy}
 			if tt.externalAuth != nil {
 				objects = append(objects, tt.externalAuth)

--- a/cmd/thv-operator/controllers/mcpremoteproxy_reconciler_test.go
+++ b/cmd/thv-operator/controllers/mcpremoteproxy_reconciler_test.go
@@ -34,6 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 	ctrlutil "github.com/stacklok/toolhive/cmd/thv-operator/pkg/controllerutil"
 	"github.com/stacklok/toolhive/cmd/thv-operator/pkg/kubernetes/rbac"
 )
@@ -253,7 +254,7 @@ func TestMCPRemoteProxyFullReconciliation(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			scheme := createRunConfigTestScheme()
+			scheme := testutil.NewScheme(t)
 			_ = rbacv1.AddToScheme(scheme)
 			_ = appsv1.AddToScheme(scheme)
 
@@ -342,7 +343,7 @@ func TestMCPRemoteProxyConfigChangePropagation(t *testing.T) {
 		},
 	}
 
-	scheme := createRunConfigTestScheme()
+	scheme := testutil.NewScheme(t)
 	_ = rbacv1.AddToScheme(scheme)
 	_ = appsv1.AddToScheme(scheme)
 
@@ -413,7 +414,7 @@ func TestMCPRemoteProxyStatusProgression(t *testing.T) {
 		},
 	}
 
-	scheme := createRunConfigTestScheme()
+	scheme := testutil.NewScheme(t)
 	_ = rbacv1.AddToScheme(scheme)
 	_ = appsv1.AddToScheme(scheme)
 
@@ -500,7 +501,7 @@ func TestCommonHelpers(t *testing.T) {
 			},
 		}
 
-		scheme := createRunConfigTestScheme()
+		scheme := testutil.NewScheme(t)
 		fakeClient := fake.NewClientBuilder().
 			WithScheme(scheme).
 			WithRuntimeObjects(externalAuth).
@@ -572,7 +573,7 @@ func TestEnsureAuthzConfigMapShared(t *testing.T) {
 		},
 	}
 
-	scheme := createRunConfigTestScheme()
+	scheme := testutil.NewScheme(t)
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithRuntimeObjects(proxy).
@@ -619,7 +620,7 @@ func TestRBACClientIntegration(t *testing.T) {
 		},
 	}
 
-	scheme := createRunConfigTestScheme()
+	scheme := testutil.NewScheme(t)
 	_ = rbacv1.AddToScheme(scheme)
 
 	fakeClient := fake.NewClientBuilder().
@@ -696,7 +697,7 @@ func TestGenerateTokenExchangeEnvVarsShared(t *testing.T) {
 		},
 	}
 
-	scheme := createRunConfigTestScheme()
+	scheme := testutil.NewScheme(t)
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithRuntimeObjects(externalAuth).
@@ -880,7 +881,7 @@ func TestValidateSpecConfigurationConditions(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			scheme := createRunConfigTestScheme()
+			scheme := testutil.NewScheme(t)
 			objects := append([]runtime.Object{tt.proxy}, tt.existingObjects...)
 
 			fakeClient := fake.NewClientBuilder().
@@ -991,7 +992,7 @@ func TestValidateAndHandleConfigs(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			scheme := createRunConfigTestScheme()
+			scheme := testutil.NewScheme(t)
 			objects := []runtime.Object{tt.proxy}
 			if tt.toolConfig != nil {
 				objects = append(objects, tt.toolConfig)

--- a/cmd/thv-operator/controllers/mcpremoteproxy_replicas_test.go
+++ b/cmd/thv-operator/controllers/mcpremoteproxy_replicas_test.go
@@ -13,24 +13,13 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 	"github.com/stacklok/toolhive/cmd/thv-operator/pkg/runconfig/configmap/checksum"
 )
-
-// replicasTestScheme registers the types the replica tests seed into the fake
-// client: the CRDs plus core and apps (Deployments).
-func replicasTestScheme(t *testing.T) *runtime.Scheme {
-	t.Helper()
-	scheme := runtime.NewScheme()
-	require.NoError(t, corev1.AddToScheme(scheme))
-	require.NoError(t, appsv1.AddToScheme(scheme))
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-	return scheme
-}
 
 func replicasTestProxy(replicas *int32) *mcpv1beta1.MCPRemoteProxy {
 	return &mcpv1beta1.MCPRemoteProxy{
@@ -62,7 +51,7 @@ func TestDeploymentForMCPRemoteProxyReplicas(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			scheme := replicasTestScheme(t)
+			scheme := testutil.NewScheme(t)
 			r := &MCPRemoteProxyReconciler{
 				Client: fake.NewClientBuilder().WithScheme(scheme).Build(),
 				Scheme: scheme,
@@ -104,7 +93,7 @@ func TestMCPRemoteProxyDeploymentNeedsUpdateReplicas(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			scheme := replicasTestScheme(t)
+			scheme := testutil.NewScheme(t)
 			r := &MCPRemoteProxyReconciler{
 				Client: fake.NewClientBuilder().WithScheme(scheme).Build(),
 				Scheme: scheme,
@@ -144,7 +133,7 @@ func TestMCPRemoteProxyEnsureDeploymentReplicaSync(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			scheme := replicasTestScheme(t)
+			scheme := testutil.NewScheme(t)
 			proxy := replicasTestProxy(tt.specReplicas)
 
 			// Seed the RunConfig ConfigMap so getRunConfigChecksum resolves the

--- a/cmd/thv-operator/controllers/mcpremoteproxy_runconfig_test.go
+++ b/cmd/thv-operator/controllers/mcpremoteproxy_runconfig_test.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 	"github.com/stacklok/toolhive/pkg/authz"
 	"github.com/stacklok/toolhive/pkg/authz/authorizers/cedar"
 	"github.com/stacklok/toolhive/pkg/runner"
@@ -277,7 +278,7 @@ func TestCreateRunConfigFromMCPRemoteProxy(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			scheme := createRunConfigTestScheme()
+			scheme := testutil.NewScheme(t)
 			objects := []runtime.Object{tt.proxy}
 			if tt.toolConfig != nil {
 				objects = append(objects, tt.toolConfig)
@@ -413,7 +414,7 @@ func TestCreateRunConfigFromMCPRemoteProxy_WithTokenExchange(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			scheme := createRunConfigTestScheme()
+			scheme := testutil.NewScheme(t)
 			objects := []runtime.Object{tt.proxy}
 			if tt.externalAuth != nil {
 				objects = append(objects, tt.externalAuth)
@@ -618,7 +619,7 @@ func TestCreateRunConfigFromMCPRemoteProxy_WithBearerToken(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			scheme := createRunConfigTestScheme()
+			scheme := testutil.NewScheme(t)
 			objects := []runtime.Object{tt.proxy}
 			if tt.externalAuth != nil {
 				objects = append(objects, tt.externalAuth)
@@ -809,7 +810,7 @@ func TestEnsureRunConfigConfigMapForRemoteProxy(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			testScheme := createRunConfigTestScheme()
+			testScheme := testutil.NewScheme(t)
 			objects := []runtime.Object{tt.proxy}
 			if tt.existingCM != nil {
 				objects = append(objects, tt.existingCM)

--- a/cmd/thv-operator/controllers/mcpremoteproxy_telemetryconfig_test.go
+++ b/cmd/thv-operator/controllers/mcpremoteproxy_telemetryconfig_test.go
@@ -9,18 +9,17 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 )
 
 func TestHandleTelemetryConfig_MCPRemoteProxy(t *testing.T) {
 	t.Parallel()
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	tests := []struct {
 		name               string
@@ -259,8 +258,7 @@ func TestHandleTelemetryConfig_MCPRemoteProxy(t *testing.T) {
 func TestMapTelemetryConfigToMCPRemoteProxy(t *testing.T) {
 	t.Parallel()
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	proxy1 := &mcpv1beta1.MCPRemoteProxy{
 		ObjectMeta: metav1.ObjectMeta{Name: "proxy1", Namespace: "default"},

--- a/cmd/thv-operator/controllers/mcpserver_authserverref_test.go
+++ b/cmd/thv-operator/controllers/mcpserver_authserverref_test.go
@@ -10,13 +10,13 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 	"github.com/stacklok/toolhive/pkg/container/kubernetes"
 )
 
@@ -175,9 +175,7 @@ func TestMCPServerReconciler_handleAuthServerRef(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
 
-			scheme := runtime.NewScheme()
-			require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-			require.NoError(t, corev1.AddToScheme(scheme))
+			scheme := testutil.NewScheme(t)
 
 			server := tt.mcpServer()
 			objs := []runtime.Object{server}

--- a/cmd/thv-operator/controllers/mcpserver_authz_test.go
+++ b/cmd/thv-operator/controllers/mcpserver_authz_test.go
@@ -13,11 +13,11 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 	ctrlutil "github.com/stacklok/toolhive/cmd/thv-operator/pkg/controllerutil"
 	"github.com/stacklok/toolhive/pkg/container/kubernetes"
 )
@@ -25,9 +25,7 @@ import (
 func TestEnsureAuthzConfigMap(t *testing.T) {
 	t.Parallel()
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-	require.NoError(t, corev1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	tests := []struct {
 		name               string
@@ -163,9 +161,7 @@ func TestEnsureAuthzConfigMap(t *testing.T) {
 func TestEnsureAuthzConfigMap_Updates(t *testing.T) {
 	t.Parallel()
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-	require.NoError(t, corev1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	// Create MCPServer with initial inline authz config
 	mcpServer := &mcpv1beta1.MCPServer{
@@ -249,10 +245,6 @@ func TestEnsureAuthzConfigMap_Updates(t *testing.T) {
 
 func TestGenerateAuthzVolumeConfig(t *testing.T) {
 	t.Parallel()
-
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-	require.NoError(t, corev1.AddToScheme(scheme))
 
 	tests := []struct {
 		name               string

--- a/cmd/thv-operator/controllers/mcpserver_default_imagepullsecrets_test.go
+++ b/cmd/thv-operator/controllers/mcpserver_default_imagepullsecrets_test.go
@@ -58,7 +58,7 @@ func TestEnsureRBACResources_DefaultImagePullSecrets(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			tc := setupTest("test-server-default-pull-secrets", "default")
+			tc := setupTest(t, "test-server-default-pull-secrets", "default")
 			tc.reconciler.ImagePullSecretsDefaults = imagepullsecrets.NewDefaults(tt.defaults)
 
 			if tt.crSecrets != nil {
@@ -102,7 +102,7 @@ func TestEnsureRBACResources_DefaultImagePullSecrets(t *testing.T) {
 func TestDeploymentNeedsUpdate_DefaultImagePullSecrets(t *testing.T) {
 	t.Parallel()
 
-	tc := setupTest("test-server-drift-pull-secrets", "default")
+	tc := setupTest(t, "test-server-drift-pull-secrets", "default")
 	tc.reconciler.ImagePullSecretsDefaults = imagepullsecrets.NewDefaults([]string{"chart-default"})
 
 	dep, err := tc.reconciler.deploymentForMCPServer(t.Context(), tc.mcpServer, "test-checksum")
@@ -149,7 +149,7 @@ func TestDeploymentForMCPServer_DefaultImagePullSecrets(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			tc := setupTest("test-server-default-pull-secrets-dep", "default")
+			tc := setupTest(t, "test-server-default-pull-secrets-dep", "default")
 			tc.reconciler.ImagePullSecretsDefaults = imagepullsecrets.NewDefaults(tt.defaults)
 
 			if tt.crSecrets != nil {

--- a/cmd/thv-operator/controllers/mcpserver_externalauth_runconfig_test.go
+++ b/cmd/thv-operator/controllers/mcpserver_externalauth_runconfig_test.go
@@ -26,6 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 	ctrlutil "github.com/stacklok/toolhive/cmd/thv-operator/pkg/controllerutil"
 	"github.com/stacklok/toolhive/cmd/thv-operator/pkg/oidc"
 	"github.com/stacklok/toolhive/pkg/container/kubernetes"
@@ -597,7 +598,7 @@ func TestAddExternalAuthConfigOptions(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			scheme := createRunConfigTestScheme()
+			scheme := testutil.NewScheme(t)
 			objects := []runtime.Object{tt.mcpServer}
 			if tt.externalAuth != nil {
 				objects = append(objects, tt.externalAuth)
@@ -830,7 +831,7 @@ func TestCreateRunConfigFromMCPServer_WithExternalAuth(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			scheme := createRunConfigTestScheme()
+			scheme := testutil.NewScheme(t)
 			objects := []runtime.Object{tt.mcpServer}
 			if tt.externalAuth != nil {
 				objects = append(objects, tt.externalAuth)
@@ -1101,7 +1102,7 @@ func TestGenerateTokenExchangeEnvVars(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			scheme := createRunConfigTestScheme()
+			scheme := testutil.NewScheme(t)
 			objects := []runtime.Object{tt.mcpServer}
 			if tt.externalAuth != nil {
 				objects = append(objects, tt.externalAuth)

--- a/cmd/thv-operator/controllers/mcpserver_externalauth_test.go
+++ b/cmd/thv-operator/controllers/mcpserver_externalauth_test.go
@@ -30,6 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 	ctrlutil "github.com/stacklok/toolhive/cmd/thv-operator/pkg/controllerutil"
 	"github.com/stacklok/toolhive/pkg/container/kubernetes"
 )
@@ -221,9 +222,7 @@ func TestMCPServerReconciler_handleExternalAuthConfig(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
 
-			scheme := runtime.NewScheme()
-			require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-			require.NoError(t, corev1.AddToScheme(scheme))
+			scheme := testutil.NewScheme(t)
 
 			// Build objects for fake client
 			objs := []runtime.Object{tt.mcpServer}
@@ -268,9 +267,7 @@ func TestMCPServerReconciler_handleExternalAuthConfig_SameNamespace(t *testing.T
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-	require.NoError(t, corev1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	// External auth config in a different namespace
 	externalAuthConfig := &mcpv1beta1.MCPExternalAuthConfig{
@@ -332,9 +329,7 @@ func TestMCPServerReconciler_handleExternalAuthConfig_HashUpdateTrigger(t *testi
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-	require.NoError(t, corev1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	externalAuthConfig := &mcpv1beta1.MCPExternalAuthConfig{
 		ObjectMeta: metav1.ObjectMeta{
@@ -409,9 +404,7 @@ func TestMCPServerReconciler_handleExternalAuthConfig_NoHashInConfig(t *testing.
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-	require.NoError(t, corev1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	// External auth config without hash in status
 	externalAuthConfig := &mcpv1beta1.MCPExternalAuthConfig{
@@ -561,9 +554,7 @@ func TestMCPServerReconciler_handleExternalAuthConfig_MirrorsInvalidCondition(t 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			scheme := runtime.NewScheme()
-			require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-			require.NoError(t, corev1.AddToScheme(scheme))
+			scheme := testutil.NewScheme(t)
 
 			externalAuthConfig := &mcpv1beta1.MCPExternalAuthConfig{
 				ObjectMeta: metav1.ObjectMeta{Name: authName, Namespace: namespace},
@@ -639,9 +630,7 @@ func TestMCPServerReconciler_handleExternalAuthConfig_ClearsMirrorOnRefRemoved(t
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	t.Cleanup(cancel)
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-	require.NoError(t, corev1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	mcpServer := &mcpv1beta1.MCPServer{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-server", Namespace: "default"},
@@ -682,9 +671,7 @@ func TestMCPServerReconciler_handleExternalAuthConfig_ClearsMirrorOnSourceNotFou
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	t.Cleanup(cancel)
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-	require.NoError(t, corev1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	mcpServer := &mcpv1beta1.MCPServer{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-server", Namespace: "default"},
@@ -746,9 +733,7 @@ func TestMCPServerDeployment_OBOSecretEnvVars(t *testing.T) {
 	}
 	ctrlutil.RegisterOBOHandler(stub)
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-	require.NoError(t, corev1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	authConfig := &mcpv1beta1.MCPExternalAuthConfig{
 		ObjectMeta: metav1.ObjectMeta{Name: "obo-config", Namespace: "default"},
@@ -805,9 +790,7 @@ func TestMCPServerDeployment_OBOSecretEnvVars_GenuineErrorDivergence(t *testing.
 	}
 	ctrlutil.RegisterOBOHandler(stub)
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-	require.NoError(t, corev1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	authConfig := &mcpv1beta1.MCPExternalAuthConfig{
 		ObjectMeta: metav1.ObjectMeta{Name: "obo-config", Namespace: "default"},

--- a/cmd/thv-operator/controllers/mcpserver_groupref_test.go
+++ b/cmd/thv-operator/controllers/mcpserver_groupref_test.go
@@ -9,14 +9,13 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 )
 
 // TestMCPServerReconciler_ValidateGroupRef tests the validateGroupRef function
@@ -159,9 +158,7 @@ func TestMCPServerReconciler_ValidateGroupRef(t *testing.T) {
 			t.Parallel()
 
 			ctx := context.Background()
-			scheme := runtime.NewScheme()
-			require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-			require.NoError(t, corev1.AddToScheme(scheme))
+			scheme := testutil.NewScheme(t)
 
 			objs := []client.Object{}
 			for _, group := range tt.mcpGroups {
@@ -266,9 +263,7 @@ func TestMCPServerReconciler_GroupRefValidation_Integration(t *testing.T) {
 			t.Parallel()
 
 			ctx := context.Background()
-			scheme := runtime.NewScheme()
-			require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-			require.NoError(t, corev1.AddToScheme(scheme))
+			scheme := testutil.NewScheme(t)
 
 			objs := []client.Object{tt.mcpServer}
 			if tt.mcpGroup != nil {
@@ -303,9 +298,7 @@ func TestMCPServerReconciler_GroupRefCrossNamespace(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-	require.NoError(t, corev1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	mcpServer := &mcpv1beta1.MCPServer{
 		ObjectMeta: metav1.ObjectMeta{

--- a/cmd/thv-operator/controllers/mcpserver_invalid_podtemplate_reconcile_test.go
+++ b/cmd/thv-operator/controllers/mcpserver_invalid_podtemplate_reconcile_test.go
@@ -13,7 +13,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -21,6 +20,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 	ctrlutil "github.com/stacklok/toolhive/cmd/thv-operator/pkg/controllerutil"
 )
 
@@ -102,9 +102,7 @@ func TestMCPServerReconciler_InvalidPodTemplateSpec(t *testing.T) {
 			ctx := t.Context()
 
 			// Setup the test environment for each test to avoid race conditions
-			s := runtime.NewScheme()
-			require.NoError(t, scheme.AddToScheme(s))
-			require.NoError(t, mcpv1beta1.AddToScheme(s))
+			s := testutil.NewScheme(t)
 
 			// Create a fake event recorder for each test
 			eventRecorder := events.NewFakeRecorder(10)
@@ -183,9 +181,7 @@ func TestDeploymentArgsWithInvalidPodTemplateSpec(t *testing.T) {
 	t.Parallel()
 
 	ctx := t.Context()
-	s := runtime.NewScheme()
-	require.NoError(t, scheme.AddToScheme(s))
-	require.NoError(t, mcpv1beta1.AddToScheme(s))
+	s := testutil.NewScheme(t)
 
 	// MCPServer with invalid PodTemplateSpec
 	mcpServer := &mcpv1beta1.MCPServer{

--- a/cmd/thv-operator/controllers/mcpserver_oidcconfig_test.go
+++ b/cmd/thv-operator/controllers/mcpserver_oidcconfig_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -17,6 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 	"github.com/stacklok/toolhive/pkg/container/kubernetes"
 )
 
@@ -147,9 +147,7 @@ func TestMCPServerReconciler_handleOIDCConfig(t *testing.T) {
 
 			ctx := t.Context()
 
-			scheme := runtime.NewScheme()
-			require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-			require.NoError(t, corev1.AddToScheme(scheme))
+			scheme := testutil.NewScheme(t)
 
 			objs := []runtime.Object{tt.mcpServer}
 			if tt.oidcConfig != nil {
@@ -240,9 +238,7 @@ func TestMCPServerReconciler_handleOIDCConfig_ConditionPersistedOnRecovery(t *te
 		},
 	}
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-	require.NoError(t, corev1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(scheme).
@@ -269,9 +265,7 @@ func TestMCPOIDCConfigReconciler_handleDeletion_BlocksWhenReferenced(t *testing.
 	t.Parallel()
 	ctx := t.Context()
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-	require.NoError(t, corev1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	now := metav1.Now()
 	cfg := &mcpv1beta1.MCPOIDCConfig{
@@ -319,9 +313,7 @@ func TestMCPOIDCConfigReconciler_handleDeletion_AllowsWhenNotReferenced(t *testi
 	t.Parallel()
 	ctx := t.Context()
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-	require.NoError(t, corev1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	now := metav1.Now()
 	cfg := &mcpv1beta1.MCPOIDCConfig{
@@ -356,9 +348,7 @@ func TestMCPOIDCConfigReconciler_handleDeletion_IgnoresCrossNamespaceRef(t *test
 	t.Parallel()
 	ctx := t.Context()
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-	require.NoError(t, corev1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	now := metav1.Now()
 	cfg := &mcpv1beta1.MCPOIDCConfig{
@@ -411,9 +401,7 @@ func TestMCPServerReconciler_handleOIDCConfig_DoesNotWriteConfigStatus(t *testin
 	t.Parallel()
 	ctx := t.Context()
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-	require.NoError(t, corev1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	// Seed a config whose status carries a condition and a ReferencingWorkloads
 	// entry owned by the MCPOIDCConfig controller — neither must be touched.

--- a/cmd/thv-operator/controllers/mcpserver_platform_test.go
+++ b/cmd/thv-operator/controllers/mcpserver_platform_test.go
@@ -11,9 +11,9 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 	ctrlutil "github.com/stacklok/toolhive/cmd/thv-operator/pkg/controllerutil"
 	"github.com/stacklok/toolhive/pkg/container/kubernetes"
 )
@@ -105,8 +105,7 @@ func TestMCPServerReconciler_DeploymentForMCPServer_Kubernetes(t *testing.T) {
 	}
 
 	// Create reconciler with mock platform detector for Kubernetes
-	scheme := runtime.NewScheme()
-	_ = mcpv1beta1.AddToScheme(scheme)
+	scheme := testutil.NewScheme(t)
 	mockDetector := &mockPlatformDetector{
 		platform: kubernetes.PlatformKubernetes,
 		err:      nil,
@@ -178,8 +177,7 @@ func TestMCPServerReconciler_DeploymentForMCPServer_OpenShift(t *testing.T) {
 	}
 
 	// Create reconciler with mock platform detector for OpenShift
-	scheme := runtime.NewScheme()
-	_ = mcpv1beta1.AddToScheme(scheme)
+	scheme := testutil.NewScheme(t)
 	mockDetector := &mockPlatformDetector{
 		platform: kubernetes.PlatformOpenShift,
 		err:      nil,
@@ -257,8 +255,7 @@ func TestMCPServerReconciler_DeploymentForMCPServer_PlatformDetectionError(t *te
 	}
 
 	// Create reconciler with mock platform detector that returns error
-	scheme := runtime.NewScheme()
-	_ = mcpv1beta1.AddToScheme(scheme)
+	scheme := testutil.NewScheme(t)
 	mockDetector := &mockPlatformDetector{
 		platform: kubernetes.PlatformKubernetes,
 		err:      assert.AnError,

--- a/cmd/thv-operator/controllers/mcpserver_pod_template_test.go
+++ b/cmd/thv-operator/controllers/mcpserver_pod_template_test.go
@@ -14,10 +14,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/kubernetes/scheme"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 	"github.com/stacklok/toolhive/pkg/container/kubernetes"
 )
 
@@ -92,8 +91,7 @@ func TestDeploymentForMCPServerWithPodTemplateSpec(t *testing.T) {
 	}
 
 	// Create a new scheme for this test to avoid race conditions
-	s := runtime.NewScheme()
-	_ = scheme.AddToScheme(s)
+	s := testutil.NewScheme(t)
 	s.AddKnownTypes(mcpv1beta1.GroupVersion, &mcpv1beta1.MCPServer{})
 	s.AddKnownTypes(mcpv1beta1.GroupVersion, &mcpv1beta1.MCPServerList{})
 
@@ -184,8 +182,7 @@ func TestDeploymentForMCPServerSecretsProviderEnv(t *testing.T) {
 	}
 
 	// Create a new scheme for this test to avoid race conditions
-	s := runtime.NewScheme()
-	_ = scheme.AddToScheme(s)
+	s := testutil.NewScheme(t)
 	s.AddKnownTypes(mcpv1beta1.GroupVersion, &mcpv1beta1.MCPServer{})
 	s.AddKnownTypes(mcpv1beta1.GroupVersion, &mcpv1beta1.MCPServerList{})
 
@@ -229,8 +226,7 @@ func TestDeploymentForMCPServerWithSecrets(t *testing.T) {
 	}
 
 	// Create a new scheme for this test to avoid race conditions
-	s := runtime.NewScheme()
-	_ = scheme.AddToScheme(s)
+	s := testutil.NewScheme(t)
 	s.AddKnownTypes(mcpv1beta1.GroupVersion, &mcpv1beta1.MCPServer{})
 	s.AddKnownTypes(mcpv1beta1.GroupVersion, &mcpv1beta1.MCPServerList{})
 
@@ -327,8 +323,7 @@ func TestProxyRunnerSecurityContext(t *testing.T) {
 	}
 
 	// Create a new scheme for this test to avoid race conditions
-	s := runtime.NewScheme()
-	_ = scheme.AddToScheme(s)
+	s := testutil.NewScheme(t)
 	s.AddKnownTypes(mcpv1beta1.GroupVersion, &mcpv1beta1.MCPServer{})
 	s.AddKnownTypes(mcpv1beta1.GroupVersion, &mcpv1beta1.MCPServerList{})
 
@@ -375,8 +370,7 @@ func TestProxyRunnerStructuredLogsEnvVar(t *testing.T) {
 	}
 
 	// Create a new scheme for this test to avoid race conditions
-	s := runtime.NewScheme()
-	_ = scheme.AddToScheme(s)
+	s := testutil.NewScheme(t)
 	s.AddKnownTypes(mcpv1beta1.GroupVersion, &mcpv1beta1.MCPServer{})
 	s.AddKnownTypes(mcpv1beta1.GroupVersion, &mcpv1beta1.MCPServerList{})
 

--- a/cmd/thv-operator/controllers/mcpserver_rbac_test.go
+++ b/cmd/thv-operator/controllers/mcpserver_rbac_test.go
@@ -13,13 +13,12 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 	"github.com/stacklok/toolhive/pkg/container/kubernetes"
 )
 
@@ -30,9 +29,10 @@ type testContext struct {
 	proxyRunnerNameForRBAC string
 }
 
-func setupTest(name, namespace string) *testContext {
+func setupTest(t *testing.T, name, namespace string) *testContext {
+	t.Helper()
 	mcpServer := createTestMCPServer(name, namespace)
-	testScheme := createTestScheme()
+	testScheme := testutil.NewScheme(t)
 	fakeClient := fake.NewClientBuilder().WithScheme(testScheme).Build()
 	proxyRunnerNameForRBAC := fmt.Sprintf("%s-proxy-runner", name)
 	return &testContext{
@@ -109,7 +109,7 @@ func (tc *testContext) assertAllRBACResourcesExist(t *testing.T) {
 
 func TestEnsureRBACResources_ServiceAccount_Creation(t *testing.T) {
 	t.Parallel()
-	tc := setupTest("test-server", "default")
+	tc := setupTest(t, "test-server", "default")
 
 	err := tc.ensureRBACResources()
 	require.NoError(t, err)
@@ -119,7 +119,7 @@ func TestEnsureRBACResources_ServiceAccount_Creation(t *testing.T) {
 
 func TestEnsureRBACResources_ServiceAccount_Update(t *testing.T) {
 	t.Parallel()
-	tc := setupTest("test-server-sa-update", "default")
+	tc := setupTest(t, "test-server-sa-update", "default")
 
 	existingSA := &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
@@ -139,7 +139,7 @@ func TestEnsureRBACResources_ServiceAccount_Update(t *testing.T) {
 
 func TestEnsureRBACResources_Role_Creation(t *testing.T) {
 	t.Parallel()
-	tc := setupTest("test-server", "default")
+	tc := setupTest(t, "test-server", "default")
 
 	err := tc.ensureRBACResources()
 	require.NoError(t, err)
@@ -149,7 +149,7 @@ func TestEnsureRBACResources_Role_Creation(t *testing.T) {
 
 func TestEnsureRBACResources_Role_Update(t *testing.T) {
 	t.Parallel()
-	tc := setupTest("test-server-role-update", "default")
+	tc := setupTest(t, "test-server-role-update", "default")
 
 	existingRole := &rbacv1.Role{
 		ObjectMeta: metav1.ObjectMeta{
@@ -175,7 +175,7 @@ func TestEnsureRBACResources_Role_Update(t *testing.T) {
 
 func TestEnsureRBACResources_RoleBinding_Creation(t *testing.T) {
 	t.Parallel()
-	tc := setupTest("test-server", "default")
+	tc := setupTest(t, "test-server", "default")
 
 	err := tc.ensureRBACResources()
 	require.NoError(t, err)
@@ -185,7 +185,7 @@ func TestEnsureRBACResources_RoleBinding_Creation(t *testing.T) {
 
 func TestEnsureRBACResources_RoleBinding_Update(t *testing.T) {
 	t.Parallel()
-	tc := setupTest("test-server-rb-update", "default")
+	tc := setupTest(t, "test-server-rb-update", "default")
 
 	existingRB := &rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
@@ -228,7 +228,7 @@ func TestEnsureRBACResources_MultipleNamespaces(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name+"-"+testCase.namespace, func(t *testing.T) {
 			t.Parallel()
-			tc := setupTest(testCase.name, testCase.namespace)
+			tc := setupTest(t, testCase.name, testCase.namespace)
 
 			err := tc.ensureRBACResources()
 			require.NoError(t, err)
@@ -249,7 +249,7 @@ func TestEnsureRBACResources_ResourceNames(t *testing.T) {
 	for _, serverName := range testCases {
 		t.Run(serverName, func(t *testing.T) {
 			t.Parallel()
-			tc := setupTest(serverName, "default")
+			tc := setupTest(t, serverName, "default")
 
 			err := tc.ensureRBACResources()
 			require.NoError(t, err)
@@ -261,7 +261,7 @@ func TestEnsureRBACResources_ResourceNames(t *testing.T) {
 
 func TestEnsureRBACResources_NoChangesNeeded(t *testing.T) {
 	t.Parallel()
-	tc := setupTest("test-server-no-changes", "default")
+	tc := setupTest(t, "test-server-no-changes", "default")
 
 	sa := &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
@@ -311,7 +311,7 @@ func TestEnsureRBACResources_NoChangesNeeded(t *testing.T) {
 
 func TestEnsureRBACResources_Idempotency(t *testing.T) {
 	t.Parallel()
-	tc := setupTest("test-server-idempotency", "default")
+	tc := setupTest(t, "test-server-idempotency", "default")
 
 	for i := 0; i < 3; i++ {
 		err := tc.ensureRBACResources()
@@ -338,7 +338,7 @@ func TestEnsureRBACResources_CustomServiceAccount(t *testing.T) {
 		},
 	}
 
-	testScheme := createTestScheme()
+	testScheme := testutil.NewScheme(t)
 	fakeClient := fake.NewClientBuilder().WithScheme(testScheme).WithObjects(mcpServer).Build()
 	reconciler := newTestMCPServerReconciler(fakeClient, testScheme, kubernetes.PlatformKubernetes)
 
@@ -383,7 +383,7 @@ func TestEnsureRBACResources_CustomServiceAccount(t *testing.T) {
 
 func TestEnsureRBACResources_ImagePullSecrets(t *testing.T) {
 	t.Parallel()
-	tc := setupTest("test-server-pull-secrets", "default")
+	tc := setupTest(t, "test-server-pull-secrets", "default")
 
 	// Set ImagePullSecrets via ResourceOverrides
 	tc.mcpServer.Spec.ResourceOverrides = &mcpv1beta1.ResourceOverrides{
@@ -436,11 +436,4 @@ func createTestMCPServer(name, namespace string) *mcpv1beta1.MCPServer {
 			ProxyPort: 8080,
 		},
 	}
-}
-
-func createTestScheme() *runtime.Scheme {
-	s := runtime.NewScheme()
-	_ = scheme.AddToScheme(s)
-	_ = mcpv1beta1.AddToScheme(s)
-	return s
 }

--- a/cmd/thv-operator/controllers/mcpserver_replicas_test.go
+++ b/cmd/thv-operator/controllers/mcpserver_replicas_test.go
@@ -18,6 +18,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 	"github.com/stacklok/toolhive/pkg/container/kubernetes"
 	"github.com/stacklok/toolhive/pkg/transport/session"
 )
@@ -102,7 +103,7 @@ func TestReplicaBehavior(t *testing.T) {
 				},
 			}
 
-			testScheme := createTestScheme()
+			testScheme := testutil.NewScheme(t)
 
 			// Create a deployment with the desired replica count
 			deployment := &appsv1.Deployment{
@@ -195,7 +196,7 @@ func TestConfigUpdatePreservesReplicas(t *testing.T) {
 		},
 	}
 
-	testScheme := createTestScheme()
+	testScheme := testutil.NewScheme(t)
 
 	// Create deployment with 3 replicas and an old image
 	deployment := &appsv1.Deployment{
@@ -281,7 +282,7 @@ func TestUpdateMCPServerStatusScaledToZero(t *testing.T) {
 		},
 	}
 
-	testScheme := createTestScheme()
+	testScheme := testutil.NewScheme(t)
 
 	// Create deployment scaled to zero
 	deployment := &appsv1.Deployment{
@@ -352,7 +353,7 @@ func TestUpdateMCPServerStatusReadyReplicas(t *testing.T) {
 		},
 	}
 
-	testScheme := createTestScheme()
+	testScheme := testutil.NewScheme(t)
 
 	// Create deployment with 3 replicas
 	deployment := &appsv1.Deployment{
@@ -476,7 +477,7 @@ func TestDefaultCreationHasNilReplicas(t *testing.T) {
 		},
 	}
 
-	testScheme := createTestScheme()
+	testScheme := testutil.NewScheme(t)
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(testScheme).
 		WithObjects(mcpServer).
@@ -556,7 +557,7 @@ func TestTerminationGracePeriodSet(t *testing.T) {
 		},
 	}
 
-	testScheme := createTestScheme()
+	testScheme := testutil.NewScheme(t)
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(testScheme).
 		WithObjects(mcpServer).
@@ -590,7 +591,7 @@ func TestSpecDrivenReplicasNil(t *testing.T) {
 		},
 	}
 
-	testScheme := createTestScheme()
+	testScheme := testutil.NewScheme(t)
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(testScheme).
 		WithObjects(mcpServer).
@@ -624,7 +625,7 @@ func TestSpecDrivenReplicas3(t *testing.T) {
 		},
 	}
 
-	testScheme := createTestScheme()
+	testScheme := testutil.NewScheme(t)
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(testScheme).
 		WithObjects(mcpServer).
@@ -661,7 +662,7 @@ func TestStdioCapConditionSet(t *testing.T) {
 		},
 	}
 
-	testScheme := createTestScheme()
+	testScheme := testutil.NewScheme(t)
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(testScheme).
 		WithObjects(mcpServer).
@@ -713,7 +714,7 @@ func TestSessionStorageWarningSet(t *testing.T) {
 		},
 	}
 
-	testScheme := createTestScheme()
+	testScheme := testutil.NewScheme(t)
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(testScheme).
 		WithObjects(mcpServer).
@@ -766,7 +767,7 @@ func TestSessionStorageWarningCleared(t *testing.T) {
 		},
 	}
 
-	testScheme := createTestScheme()
+	testScheme := testutil.NewScheme(t)
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(testScheme).
 		WithObjects(mcpServer).
@@ -884,7 +885,7 @@ func TestUpdateMCPServerStatusExcludesTerminatingPods(t *testing.T) {
 		},
 	}
 
-	testScheme := createTestScheme()
+	testScheme := testutil.NewScheme(t)
 
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1106,7 +1107,7 @@ func TestRateLimitConfigValidation(t *testing.T) {
 				Spec: tt.spec,
 			}
 
-			testScheme := createTestScheme()
+			testScheme := testutil.NewScheme(t)
 			clientBuilder := fake.NewClientBuilder().
 				WithScheme(testScheme).
 				WithObjects(mcpServer).
@@ -1246,7 +1247,7 @@ func TestMCPServerDeploymentInjectsRedisPasswordEnvVar(t *testing.T) {
 		},
 	}
 
-	testScheme := createTestScheme()
+	testScheme := testutil.NewScheme(t)
 	r := newTestMCPServerReconciler(nil, testScheme, kubernetes.PlatformKubernetes)
 
 	deployment, err := r.deploymentForMCPServer(t.Context(), mcpServer, "test-checksum")
@@ -1310,7 +1311,7 @@ func TestMCPServerDeploymentRedisPasswordOverridesUserEnvOnCollision(t *testing.
 		},
 	}
 
-	testScheme := createTestScheme()
+	testScheme := testutil.NewScheme(t)
 	r := newTestMCPServerReconciler(nil, testScheme, kubernetes.PlatformKubernetes)
 
 	deployment, err := r.deploymentForMCPServer(t.Context(), mcpServer, "test-checksum")

--- a/cmd/thv-operator/controllers/mcpserver_resource_overrides_test.go
+++ b/cmd/thv-operator/controllers/mcpserver_resource_overrides_test.go
@@ -21,10 +21,10 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 	ctrlutil "github.com/stacklok/toolhive/cmd/thv-operator/pkg/controllerutil"
 	checksum "github.com/stacklok/toolhive/cmd/thv-operator/pkg/runconfig/configmap/checksum"
 	"github.com/stacklok/toolhive/pkg/container/kubernetes"
@@ -33,9 +33,7 @@ import (
 func TestMCPServerDeploymentNeedsUpdate_EmbeddedAuthLegacyEnvStable(t *testing.T) {
 	t.Parallel()
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, corev1.AddToScheme(scheme))
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	externalAuthConfig := &mcpv1beta1.MCPExternalAuthConfig{
 		ObjectMeta: metav1.ObjectMeta{
@@ -103,9 +101,7 @@ func TestMCPServerDeploymentNeedsUpdate_EmbeddedAuthLegacyEnvStable(t *testing.T
 func TestMCPServerDeploymentNeedsUpdate_EmbeddedAuthAuthServerRefEnvStable(t *testing.T) {
 	t.Parallel()
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, corev1.AddToScheme(scheme))
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	authConfig := &mcpv1beta1.MCPExternalAuthConfig{
 		ObjectMeta: metav1.ObjectMeta{
@@ -165,9 +161,7 @@ func TestMCPServerDeploymentNeedsUpdate_EmbeddedAuthAuthServerRefEnvStable(t *te
 func TestMCPServerDeploymentNeedsUpdate_TokenExchangeDoesNotDrift(t *testing.T) {
 	t.Parallel()
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, corev1.AddToScheme(scheme))
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	authConfig := &mcpv1beta1.MCPExternalAuthConfig{
 		ObjectMeta: metav1.ObjectMeta{
@@ -219,8 +213,7 @@ func TestMCPServerDeploymentNeedsUpdate_TokenExchangeDoesNotDrift(t *testing.T) 
 func TestResourceOverrides(t *testing.T) {
 	t.Parallel()
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	// Note: expectedPodTemplateAnns entries below carry
 	// "toolhive.stacklok.dev/mcpserver-generation": "0" because the controller
@@ -640,9 +633,7 @@ func TestResourceOverrides(t *testing.T) {
 func TestDeploymentForMCPServer_PodTemplateOverridesPreserveRunConfigChecksum(t *testing.T) {
 	t.Parallel()
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-	require.NoError(t, corev1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	client := fake.NewClientBuilder().WithScheme(scheme).Build()
 	r := newTestMCPServerReconciler(client, scheme, kubernetes.PlatformKubernetes)
@@ -683,9 +674,7 @@ func TestDeploymentForMCPServer_PodTemplateOverridesPreserveRunConfigChecksum(t 
 func TestDeploymentNeedsUpdate_StableAfterBuildWithPodTemplateOverrides(t *testing.T) {
 	t.Parallel()
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-	require.NoError(t, corev1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	client := fake.NewClientBuilder().WithScheme(scheme).Build()
 	r := newTestMCPServerReconciler(client, scheme, kubernetes.PlatformKubernetes)
@@ -767,8 +756,7 @@ func TestMergeStringMaps(t *testing.T) {
 func TestDeploymentNeedsUpdateProxyEnv(t *testing.T) {
 	t.Parallel()
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	client := fake.NewClientBuilder().WithScheme(scheme).Build()
 	r := newTestMCPServerReconciler(client, scheme, kubernetes.PlatformKubernetes)
@@ -1008,8 +996,7 @@ func TestMCPServerDeploymentNeedsUpdate_ImagePullSecretsDrift(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			scheme := runtime.NewScheme()
-			require.NoError(t, mcpv1beta1.AddToScheme(scheme))
+			scheme := testutil.NewScheme(t)
 
 			fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 			r := newTestMCPServerReconciler(fakeClient, scheme, kubernetes.PlatformKubernetes)
@@ -1051,8 +1038,7 @@ func TestMCPServerDeploymentNeedsUpdate_ImagePullSecretsDrift(t *testing.T) {
 func TestMCPServerSessionAffinityNone(t *testing.T) {
 	t.Parallel()
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	mcpServer := &mcpv1beta1.MCPServer{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1171,9 +1157,7 @@ func TestMCPServerServiceNeedsUpdate(t *testing.T) {
 func TestDeploymentForMCPServer_MCPServerGenerationDownwardAPI(t *testing.T) {
 	t.Parallel()
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-	require.NoError(t, corev1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	client := fake.NewClientBuilder().WithScheme(scheme).Build()
 	r := newTestMCPServerReconciler(client, scheme, kubernetes.PlatformKubernetes)

--- a/cmd/thv-operator/controllers/mcpserver_restart_test.go
+++ b/cmd/thv-operator/controllers/mcpserver_restart_test.go
@@ -20,6 +20,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 	"github.com/stacklok/toolhive/pkg/container/kubernetes"
 )
 
@@ -35,7 +36,7 @@ func setupRestartTest(t *testing.T) *restartTestContext {
 	name := "test-server"
 	namespace := "default"
 	mcpServer := createTestMCPServer(name, namespace)
-	testScheme := createTestScheme()
+	testScheme := testutil.NewScheme(t)
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(testScheme).
 		WithObjects(mcpServer).

--- a/cmd/thv-operator/controllers/mcpserver_runconfig_test.go
+++ b/cmd/thv-operator/controllers/mcpserver_runconfig_test.go
@@ -19,6 +19,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 	ctrlutil "github.com/stacklok/toolhive/cmd/thv-operator/pkg/controllerutil"
 	"github.com/stacklok/toolhive/cmd/thv-operator/pkg/runconfig/configmap/checksum"
 	"github.com/stacklok/toolhive/pkg/authz"
@@ -33,13 +34,6 @@ const (
 	sseProxyMode            = "sse"
 	streamableHTTPProxyMode = "streamable-http"
 )
-
-func createRunConfigTestScheme() *runtime.Scheme {
-	testScheme := runtime.NewScheme()
-	_ = corev1.AddToScheme(testScheme)
-	_ = mcpv1beta1.AddToScheme(testScheme)
-	return testScheme
-}
 
 func createTestMCPServerWithConfig(name, namespace, image string, envVars []mcpv1beta1.EnvVar) *mcpv1beta1.MCPServer {
 	return &mcpv1beta1.MCPServer{
@@ -478,7 +472,7 @@ func TestCreateRunConfigFromMCPServer(t *testing.T) {
 				tt.mcpServer.Spec.AuthzConfig.Type == mcpv1beta1.AuthzConfigTypeConfigMap &&
 				tt.mcpServer.Spec.AuthzConfig.ConfigMap != nil {
 
-				scheme := createRunConfigTestScheme()
+				scheme := testutil.NewScheme(t)
 
 				// Prepare a ConfigMap with authorization configuration content
 				cm := &corev1.ConfigMap{
@@ -850,7 +844,7 @@ func TestEnsureRunConfigConfigMap(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			testScheme := createRunConfigTestScheme()
+			testScheme := testutil.NewScheme(t)
 			objects := []runtime.Object{tt.mcpServer}
 			if tt.existingCM != nil {
 				objects = append(objects, tt.existingCM)
@@ -899,7 +893,7 @@ func TestEnsureRunConfigConfigMap(t *testing.T) {
 	// Additional test: ConfigMap-based Authz referenced externally should be embedded into runconfig.json
 	t.Run("configmap with external authorization configuration", func(t *testing.T) {
 		t.Parallel()
-		testScheme := createRunConfigTestScheme()
+		testScheme := testutil.NewScheme(t)
 
 		mcpServer := &mcpv1beta1.MCPServer{
 			ObjectMeta: metav1.ObjectMeta{
@@ -1195,7 +1189,7 @@ func TestLabelsForRunConfig(t *testing.T) {
 // TestEnsureRunConfigConfigMapCompleteFlow tests the complete flow from MCPServer changes to ConfigMap updates
 func TestEnsureRunConfigConfigMapCompleteFlow(t *testing.T) {
 	t.Parallel()
-	testScheme := createRunConfigTestScheme()
+	testScheme := testutil.NewScheme(t)
 	fakeClient := fake.NewClientBuilder().WithScheme(testScheme).Build()
 	reconciler := &MCPServerReconciler{
 		Client: fakeClient,
@@ -1377,7 +1371,7 @@ func TestMCPServerModificationScenarios(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			// Setup - create a new scheme for each test to avoid concurrent access
-			testScheme := createRunConfigTestScheme()
+			testScheme := testutil.NewScheme(t)
 
 			fakeClient := fake.NewClientBuilder().WithScheme(testScheme).Build()
 			reconciler := newTestMCPServerReconciler(fakeClient, testScheme, kubernetes.PlatformKubernetes)
@@ -1522,7 +1516,7 @@ func TestEnsureRunConfigConfigMap_WithVaultInjection(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			testScheme := createRunConfigTestScheme()
+			testScheme := testutil.NewScheme(t)
 			fakeClient := fake.NewClientBuilder().
 				WithScheme(testScheme).
 				WithRuntimeObjects(tc.mcpServer).
@@ -1700,7 +1694,7 @@ func TestPopulateScalingConfig(t *testing.T) {
 
 			r := &MCPServerReconciler{
 				Client: fake.NewClientBuilder().
-					WithScheme(createRunConfigTestScheme()).
+					WithScheme(testutil.NewScheme(t)).
 					WithObjects(m).
 					Build(),
 			}
@@ -1752,7 +1746,7 @@ func TestCreateRunConfigFromMCPServer_RateLimiting(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			testScheme := createRunConfigTestScheme()
+			testScheme := testutil.NewScheme(t)
 			k8sClient := fake.NewClientBuilder().WithScheme(testScheme).Build()
 
 			r := &MCPServerReconciler{
@@ -1800,8 +1794,8 @@ func TestCreateRunConfigFromMCPServer_SetsMCPServerGeneration(t *testing.T) {
 	}
 
 	r := newTestMCPServerReconciler(
-		fake.NewClientBuilder().WithScheme(createRunConfigTestScheme()).WithObjects(m).Build(),
-		createRunConfigTestScheme(),
+		fake.NewClientBuilder().WithScheme(testutil.NewScheme(t)).WithObjects(m).Build(),
+		testutil.NewScheme(t),
 		kubernetes.PlatformKubernetes,
 	)
 

--- a/cmd/thv-operator/controllers/mcpserver_spec_patch_test.go
+++ b/cmd/thv-operator/controllers/mcpserver_spec_patch_test.go
@@ -18,6 +18,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 	"github.com/stacklok/toolhive/pkg/container/kubernetes"
 )
 
@@ -157,7 +158,7 @@ func TestMCPServerSpecPatchesAreOptimisticLock(t *testing.T) {
 			t.Parallel()
 
 			seeded := tc.seed()
-			testScheme := createTestScheme()
+			testScheme := testutil.NewScheme(t)
 			fakeClient := fake.NewClientBuilder().
 				WithScheme(testScheme).
 				WithObjects(seeded).

--- a/cmd/thv-operator/controllers/mcpserver_telemetry_cabundle_test.go
+++ b/cmd/thv-operator/controllers/mcpserver_telemetry_cabundle_test.go
@@ -10,10 +10,10 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 	"github.com/stacklok/toolhive/pkg/container/kubernetes"
 )
 
@@ -109,9 +109,7 @@ func TestDeploymentForMCPServer_TelemetryCABundleVolume(t *testing.T) {
 
 			ctx := t.Context()
 
-			scheme := runtime.NewScheme()
-			require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-			require.NoError(t, corev1.AddToScheme(scheme))
+			scheme := testutil.NewScheme(t)
 
 			fakeClient := fake.NewClientBuilder().
 				WithScheme(scheme).
@@ -183,9 +181,7 @@ func TestDeploymentForMCPServer_TelemetryCABundleVolume_FetchError(t *testing.T)
 
 	ctx := t.Context()
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-	require.NoError(t, corev1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	// Build a client that does NOT have the MCPTelemetryConfig object.
 	// The MCPServer references it, so getTelemetryConfigForMCPServer returns nil (not found).

--- a/cmd/thv-operator/controllers/mcpserver_telemetryconfig_test.go
+++ b/cmd/thv-operator/controllers/mcpserver_telemetryconfig_test.go
@@ -9,10 +9,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 )
 
 func TestGetTelemetryConfigForMCPServer(t *testing.T) {
@@ -90,8 +90,7 @@ func TestGetTelemetryConfigForMCPServer(t *testing.T) {
 
 			ctx := t.Context()
 
-			scheme := runtime.NewScheme()
-			require.NoError(t, mcpv1beta1.AddToScheme(scheme))
+			scheme := testutil.NewScheme(t)
 
 			builder := fake.NewClientBuilder().WithScheme(scheme)
 			if tt.telemetryConfig != nil {
@@ -124,8 +123,7 @@ func TestGetTelemetryConfigForMCPServer_NamespacedLookup(t *testing.T) {
 
 	ctx := t.Context()
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	// Config exists in namespace-a but server is in namespace-b
 	telemetryConfig := &mcpv1beta1.MCPTelemetryConfig{

--- a/cmd/thv-operator/controllers/mcpserver_webhook_test.go
+++ b/cmd/thv-operator/controllers/mcpserver_webhook_test.go
@@ -17,6 +17,7 @@ import (
 
 	mcpv1alpha1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1alpha1"
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 	"github.com/stacklok/toolhive/pkg/container/kubernetes"
 )
 
@@ -119,10 +120,7 @@ func TestMCPServerReconciler_handleWebhookConfig(t *testing.T) {
 			t.Parallel()
 			ctx := t.Context()
 
-			scheme := runtime.NewScheme()
-			require.NoError(t, mcpv1alpha1.AddToScheme(scheme))
-			require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-			require.NoError(t, corev1.AddToScheme(scheme))
+			scheme := testutil.NewScheme(t)
 
 			objs := []runtime.Object{tt.mcpServer}
 			if tt.webhookConfig != nil {
@@ -162,10 +160,7 @@ func TestMCPServerReconciler_mapWebhookConfigToServers(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1alpha1.AddToScheme(scheme))
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-	require.NoError(t, corev1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	servers := []runtime.Object{
 		&mcpv1beta1.MCPServer{
@@ -225,10 +220,7 @@ func TestMCPServerReconciler_mapWebhookConfigToServers(t *testing.T) {
 func TestMCPServerReconciler_deploymentForMCPServerWebhookConfigError(t *testing.T) {
 	t.Parallel()
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1alpha1.AddToScheme(scheme))
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-	require.NoError(t, corev1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	mcpServer := &mcpv1beta1.MCPServer{
 		ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "default"},

--- a/cmd/thv-operator/controllers/mcpserverentry_controller_test.go
+++ b/cmd/thv-operator/controllers/mcpserverentry_controller_test.go
@@ -18,6 +18,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 )
 
 const (
@@ -27,15 +28,6 @@ const (
 	testCAConfigMap   = "test-ca-bundle"
 	testEntryGroupRef = "test-group"
 )
-
-// newEntryScheme creates a runtime scheme with the CRD and core types registered.
-func newEntryScheme(t *testing.T) *runtime.Scheme {
-	t.Helper()
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-	require.NoError(t, corev1.AddToScheme(scheme))
-	return scheme
-}
 
 // newEntryFakeClient builds a fake client with all required indexes and status subresources.
 func newEntryFakeClient(t *testing.T, scheme *runtime.Scheme, objs ...client.Object) client.Client {
@@ -484,7 +476,7 @@ func TestMCPServerEntryReconciler_Reconcile(t *testing.T) {
 			t.Parallel()
 
 			ctx := t.Context()
-			scheme := newEntryScheme(t)
+			scheme := testutil.NewScheme(t)
 
 			objs := append([]client.Object{}, tt.objects...)
 			if tt.entry != nil {
@@ -548,7 +540,7 @@ func TestMCPGroupReconciler_MCPServerEntryIntegration(t *testing.T) {
 	t.Parallel()
 
 	ctx := t.Context()
-	scheme := newEntryScheme(t)
+	scheme := testutil.NewScheme(t)
 
 	group := &mcpv1beta1.MCPGroup{
 		ObjectMeta: metav1.ObjectMeta{
@@ -626,7 +618,7 @@ func TestMCPGroupReconciler_EntryDeletionHandler(t *testing.T) {
 	t.Parallel()
 
 	ctx := t.Context()
-	scheme := newEntryScheme(t)
+	scheme := testutil.NewScheme(t)
 
 	entry1 := &mcpv1beta1.MCPServerEntry{
 		ObjectMeta: metav1.ObjectMeta{Name: "entry1", Namespace: testEntryNS},

--- a/cmd/thv-operator/controllers/mcptelemetryconfig_controller_test.go
+++ b/cmd/thv-operator/controllers/mcptelemetryconfig_controller_test.go
@@ -9,14 +9,13 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 )
 
 func TestMCPTelemetryConfigReconciler_calculateConfigHash(t *testing.T) {
@@ -72,8 +71,7 @@ func TestMCPTelemetryConfigReconciler_ReconcileNotFound(t *testing.T) {
 
 	ctx := t.Context()
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	// Empty client — no objects exist
 	fakeClient := fake.NewClientBuilder().
@@ -102,9 +100,7 @@ func TestMCPTelemetryConfigReconciler_SteadyStateNoOp(t *testing.T) {
 
 	ctx := t.Context()
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-	require.NoError(t, corev1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	telemetryConfig := &mcpv1beta1.MCPTelemetryConfig{
 		ObjectMeta: metav1.ObjectMeta{
@@ -165,9 +161,7 @@ func TestMCPTelemetryConfigReconciler_ValidationRecovery(t *testing.T) {
 
 	ctx := t.Context()
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-	require.NoError(t, corev1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	// Start with invalid config: empty sensitive header name
 	telemetryConfig := &mcpv1beta1.MCPTelemetryConfig{
@@ -280,8 +274,7 @@ func TestMCPTelemetryConfigReconciler_handleDeletion(t *testing.T) {
 
 			ctx := t.Context()
 
-			scheme := runtime.NewScheme()
-			require.NoError(t, mcpv1beta1.AddToScheme(scheme))
+			scheme := testutil.NewScheme(t)
 
 			fakeClient := fake.NewClientBuilder().
 				WithScheme(scheme).
@@ -311,9 +304,7 @@ func TestMCPTelemetryConfigReconciler_ConfigChangeTriggersHashUpdate(t *testing.
 
 	ctx := t.Context()
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-	require.NoError(t, corev1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	telemetryConfig := &mcpv1beta1.MCPTelemetryConfig{
 		ObjectMeta: metav1.ObjectMeta{
@@ -383,9 +374,7 @@ func TestMCPTelemetryConfigReconciler_ValidationFailureSetsCondition(t *testing.
 
 	ctx := t.Context()
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-	require.NoError(t, corev1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	// Invalid config: empty sensitive header name
 	telemetryConfig := &mcpv1beta1.MCPTelemetryConfig{
@@ -552,9 +541,7 @@ func TestMCPTelemetryConfigReconciler_ConditionOnlyUpdate(t *testing.T) {
 
 	ctx := t.Context()
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-	require.NoError(t, corev1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	spec := newTelemetrySpec("https://otel-collector:4317", true, true)
 
@@ -622,9 +609,7 @@ func TestMCPTelemetryConfigReconciler_ReferenceTracking(t *testing.T) {
 
 	ctx := t.Context()
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-	require.NoError(t, corev1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	telemetryConfig := &mcpv1beta1.MCPTelemetryConfig{
 		ObjectMeta: metav1.ObjectMeta{
@@ -714,9 +699,7 @@ func TestMCPTelemetryConfigReconciler_handleDeletion_BlocksWhenReferenced(t *tes
 
 	ctx := t.Context()
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-	require.NoError(t, corev1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	now := metav1.Now()
 	telemetryConfig := &mcpv1beta1.MCPTelemetryConfig{
@@ -769,9 +752,7 @@ func TestMCPTelemetryConfigReconciler_handleDeletion_AllowsWhenNotReferenced(t *
 
 	ctx := t.Context()
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-	require.NoError(t, corev1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	now := metav1.Now()
 	telemetryConfig := &mcpv1beta1.MCPTelemetryConfig{
@@ -820,8 +801,7 @@ func TestMCPTelemetryConfigReconciler_handleDeletion_NoFinalizerIsNoOp(t *testin
 
 	ctx := t.Context()
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	// Object with DeletionTimestamp but no finalizers.
 	// We don't add it to the fake client (which rejects such objects)

--- a/cmd/thv-operator/controllers/mcpwebhookconfig_controller_test.go
+++ b/cmd/thv-operator/controllers/mcpwebhookconfig_controller_test.go
@@ -15,7 +15,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -24,6 +23,7 @@ import (
 
 	mcpv1alpha1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1alpha1"
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 )
 
 func TestMCPWebhookConfigReconciler_Reconcile(t *testing.T) {
@@ -94,10 +94,7 @@ func TestMCPWebhookConfigReconciler_Reconcile(t *testing.T) {
 			t.Parallel()
 			ctx := t.Context()
 
-			scheme := runtime.NewScheme()
-			require.NoError(t, mcpv1alpha1.AddToScheme(scheme))
-			require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-			require.NoError(t, corev1.AddToScheme(scheme))
+			scheme := testutil.NewScheme(t)
 
 			objs := []client.Object{tt.webhookConfig}
 			if tt.existingMCPServer != nil {
@@ -160,9 +157,7 @@ func TestMCPWebhookConfigReconciler_Reconcile(t *testing.T) {
 
 	t.Run("resource not found", func(t *testing.T) {
 		t.Parallel()
-		scheme := runtime.NewScheme()
-		require.NoError(t, mcpv1alpha1.AddToScheme(scheme))
-		require.NoError(t, mcpv1beta1.AddToScheme(scheme))
+		scheme := testutil.NewScheme(t)
 		fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 		r := &MCPWebhookConfigReconciler{
 			Client: fakeClient,
@@ -183,9 +178,7 @@ func TestMCPWebhookConfigReconciler_Reconcile(t *testing.T) {
 		t.Parallel()
 		ctx := t.Context()
 
-		scheme := runtime.NewScheme()
-		require.NoError(t, mcpv1alpha1.AddToScheme(scheme))
-		require.NoError(t, mcpv1beta1.AddToScheme(scheme))
+		scheme := testutil.NewScheme(t)
 
 		webhookConfig := &mcpv1alpha1.MCPWebhookConfig{
 			ObjectMeta: metav1.ObjectMeta{
@@ -228,9 +221,7 @@ func TestMCPWebhookConfigReconciler_Reconcile(t *testing.T) {
 func TestMCPWebhookConfigReconciler_handleDeletion(t *testing.T) {
 	t.Parallel()
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1alpha1.AddToScheme(scheme))
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	webhookConfig := &mcpv1alpha1.MCPWebhookConfig{
 		ObjectMeta: metav1.ObjectMeta{
@@ -300,9 +291,7 @@ func TestMCPWebhookConfigReconciler_handleDeletion(t *testing.T) {
 func TestMCPWebhookConfigReconciler_handleDeletionClearsBlockedCondition(t *testing.T) {
 	t.Parallel()
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1alpha1.AddToScheme(scheme))
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	webhookConfig := &mcpv1alpha1.MCPWebhookConfig{
 		ObjectMeta: metav1.ObjectMeta{
@@ -347,10 +336,7 @@ func TestMCPWebhookConfigReconciler_mapMCPServerToWebhookConfig(t *testing.T) {
 	t.Parallel()
 
 	ctx := t.Context()
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1alpha1.AddToScheme(scheme))
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-	require.NoError(t, corev1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	server := &mcpv1beta1.MCPServer{
 		ObjectMeta: metav1.ObjectMeta{Name: "server", Namespace: "default"},
@@ -471,9 +457,7 @@ func TestMCPWebhookConfigReconciler_updateReferencingWorkloads(t *testing.T) {
 	t.Parallel()
 
 	ctx := t.Context()
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1alpha1.AddToScheme(scheme))
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	webhookConfig := &mcpv1alpha1.MCPWebhookConfig{
 		ObjectMeta: metav1.ObjectMeta{Name: "webhook-config", Namespace: "default"},
@@ -527,9 +511,7 @@ func TestMCPWebhookConfigReconciler_updateReferencingWorkloadsListError(t *testi
 	t.Parallel()
 
 	ctx := t.Context()
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1alpha1.AddToScheme(scheme))
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	webhookConfig := &mcpv1alpha1.MCPWebhookConfig{
 		ObjectMeta: metav1.ObjectMeta{Name: "webhook-config", Namespace: "default"},

--- a/cmd/thv-operator/controllers/storageversionmigrator_controller_test.go
+++ b/cmd/thv-operator/controllers/storageversionmigrator_controller_test.go
@@ -26,6 +26,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 )
 
 // migrationCache
@@ -491,8 +493,7 @@ func testCRGVK() schema.GroupVersionKind {
 // fake client requires the kind to be in the scheme on List/Get/Update).
 func schemeForCRD(t *testing.T) *runtime.Scheme {
 	t.Helper()
-	scheme := runtime.NewScheme()
-	require.NoError(t, apiextensionsv1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t, apiextensionsv1.AddToScheme)
 	gvk := testCRGVK()
 	listGVK := gvk
 	listGVK.Kind = testCRListKind

--- a/cmd/thv-operator/controllers/toolconfig_controller_edge_cases_test.go
+++ b/cmd/thv-operator/controllers/toolconfig_controller_edge_cases_test.go
@@ -12,13 +12,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 )
 
 func TestToolConfigReconciler_EdgeCases(t *testing.T) {
@@ -28,8 +28,7 @@ func TestToolConfigReconciler_EdgeCases(t *testing.T) {
 		t.Parallel()
 		ctx := t.Context()
 
-		scheme := runtime.NewScheme()
-		require.NoError(t, mcpv1beta1.AddToScheme(scheme))
+		scheme := testutil.NewScheme(t)
 
 		fakeClient := fake.NewClientBuilder().
 			WithScheme(scheme).
@@ -57,8 +56,7 @@ func TestToolConfigReconciler_EdgeCases(t *testing.T) {
 		t.Parallel()
 		ctx := t.Context()
 
-		scheme := runtime.NewScheme()
-		require.NoError(t, mcpv1beta1.AddToScheme(scheme))
+		scheme := testutil.NewScheme(t)
 
 		toolConfig := &mcpv1beta1.MCPToolConfig{
 			ObjectMeta: metav1.ObjectMeta{
@@ -130,8 +128,7 @@ func TestToolConfigReconciler_EdgeCases(t *testing.T) {
 		t.Parallel()
 		ctx := t.Context()
 
-		scheme := runtime.NewScheme()
-		require.NoError(t, mcpv1beta1.AddToScheme(scheme))
+		scheme := testutil.NewScheme(t)
 
 		toolConfig := &mcpv1beta1.MCPToolConfig{
 			ObjectMeta: metav1.ObjectMeta{
@@ -192,8 +189,7 @@ func TestToolConfigReconciler_ErrorScenarios(t *testing.T) {
 		t.Parallel()
 		ctx := t.Context()
 
-		scheme := runtime.NewScheme()
-		require.NoError(t, mcpv1beta1.AddToScheme(scheme))
+		scheme := testutil.NewScheme(t)
 
 		toolConfig := &mcpv1beta1.MCPToolConfig{
 			ObjectMeta: metav1.ObjectMeta{
@@ -255,8 +251,7 @@ func TestToolConfigReconciler_ComplexScenarios(t *testing.T) {
 		t.Parallel()
 		ctx := t.Context()
 
-		scheme := runtime.NewScheme()
-		require.NoError(t, mcpv1beta1.AddToScheme(scheme))
+		scheme := testutil.NewScheme(t)
 
 		toolConfig := &mcpv1beta1.MCPToolConfig{
 			ObjectMeta: metav1.ObjectMeta{
@@ -364,8 +359,7 @@ func TestToolConfigReconciler_ComplexScenarios(t *testing.T) {
 		t.Parallel()
 		ctx := t.Context()
 
-		scheme := runtime.NewScheme()
-		require.NoError(t, mcpv1beta1.AddToScheme(scheme))
+		scheme := testutil.NewScheme(t)
 
 		// MCPToolConfig with completely empty spec
 		toolConfig := &mcpv1beta1.MCPToolConfig{

--- a/cmd/thv-operator/controllers/toolconfig_controller_test.go
+++ b/cmd/thv-operator/controllers/toolconfig_controller_test.go
@@ -9,16 +9,15 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	corev1 "k8s.io/api/core/v1"
 	k8smeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 )
 
 func TestToolConfigReconciler_calculateConfigHash(t *testing.T) {
@@ -164,9 +163,7 @@ func TestToolConfigReconciler_Reconcile(t *testing.T) {
 
 			ctx := t.Context()
 
-			scheme := runtime.NewScheme()
-			require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-			require.NoError(t, corev1.AddToScheme(scheme))
+			scheme := testutil.NewScheme(t)
 
 			// Create fake client with objects
 			objs := []client.Object{tt.toolConfig}
@@ -241,8 +238,7 @@ func TestToolConfigReconciler_Reconcile(t *testing.T) {
 func TestToolConfigReconciler_findReferencingWorkloads(t *testing.T) {
 	t.Parallel()
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	toolConfig := &mcpv1beta1.MCPToolConfig{
 		ObjectMeta: metav1.ObjectMeta{
@@ -316,9 +312,7 @@ func TestToolConfigReconciler_ReferencingWorkloadsUpdatedWithoutHashChange(t *te
 
 	ctx := t.Context()
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-	require.NoError(t, corev1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	toolConfig := &mcpv1beta1.MCPToolConfig{
 		ObjectMeta: metav1.ObjectMeta{
@@ -401,9 +395,7 @@ func TestToolConfigReconciler_ReferencingWorkloadsRemovedOnServerDeletion(t *tes
 
 	ctx := t.Context()
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-	require.NoError(t, corev1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	toolConfig := &mcpv1beta1.MCPToolConfig{
 		ObjectMeta: metav1.ObjectMeta{
@@ -481,9 +473,7 @@ func TestToolConfigReconciler_ValidConditionObservedGeneration(t *testing.T) {
 
 	ctx := t.Context()
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-	require.NoError(t, corev1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	toolConfig := &mcpv1beta1.MCPToolConfig{
 		ObjectMeta: metav1.ObjectMeta{

--- a/cmd/thv-operator/controllers/virtualmcpserver_authz_configmap_test.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_authz_configmap_test.go
@@ -10,13 +10,13 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 )
 
 func TestMapAuthzConfigMapToVirtualMCPServer(t *testing.T) {
@@ -83,9 +83,7 @@ func TestMapAuthzConfigMapToVirtualMCPServer(t *testing.T) {
 		},
 	}
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-	require.NoError(t, corev1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(scheme).

--- a/cmd/thv-operator/controllers/virtualmcpserver_authz_validation_test.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_authz_validation_test.go
@@ -12,11 +12,11 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 	statusmocks "github.com/stacklok/toolhive/cmd/thv-operator/pkg/virtualmcpserverstatus/mocks"
 )
 
@@ -53,9 +53,7 @@ func vmcpWithAuthzConfigMap(cmName string) *mcpv1beta1.VirtualMCPServer {
 // the supplied objects. The reconciler runs the namespaced-scope branch in tests.
 func reconcilerWithObjects(t *testing.T, objects ...client.Object) *VirtualMCPServerReconciler {
 	t.Helper()
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-	require.NoError(t, corev1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
 	return &VirtualMCPServerReconciler{Client: c, Scheme: scheme}
 }

--- a/cmd/thv-operator/controllers/virtualmcpserver_controller_test.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_controller_test.go
@@ -26,7 +26,6 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/tools/events"
@@ -35,6 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 	ctrlutil "github.com/stacklok/toolhive/cmd/thv-operator/pkg/controllerutil"
 	"github.com/stacklok/toolhive/cmd/thv-operator/pkg/runconfig/configmap/checksum"
 	"github.com/stacklok/toolhive/cmd/thv-operator/pkg/virtualmcpserverstatus"
@@ -152,11 +152,7 @@ func TestVirtualMCPServerValidateGroupRef(t *testing.T) {
 			t.Parallel()
 
 			// Setup fake client with resources
-			scheme := runtime.NewScheme()
-			_ = mcpv1beta1.AddToScheme(scheme)
-			_ = corev1.AddToScheme(scheme)
-			_ = appsv1.AddToScheme(scheme)
-			_ = rbacv1.AddToScheme(scheme)
+			scheme := testutil.NewScheme(t)
 
 			objs := []client.Object{tt.vmcp}
 			if tt.mcpGroup != nil {
@@ -225,10 +221,7 @@ func TestVirtualMCPServerEnsureRBACResources(t *testing.T) {
 		},
 	}
 
-	scheme := runtime.NewScheme()
-	_ = mcpv1beta1.AddToScheme(scheme)
-	_ = corev1.AddToScheme(scheme)
-	_ = rbacv1.AddToScheme(scheme)
+	scheme := testutil.NewScheme(t)
 
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(scheme).
@@ -309,10 +302,7 @@ func TestVirtualMCPServerEnsureRBACResources_ImagePullSecrets(t *testing.T) {
 		},
 	}
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-	require.NoError(t, corev1.AddToScheme(scheme))
-	require.NoError(t, rbacv1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(scheme).
@@ -353,10 +343,7 @@ func TestVirtualMCPServerEnsureRBACResources_Update(t *testing.T) {
 		},
 	}
 
-	scheme := runtime.NewScheme()
-	_ = mcpv1beta1.AddToScheme(scheme)
-	_ = corev1.AddToScheme(scheme)
-	_ = rbacv1.AddToScheme(scheme)
+	scheme := testutil.NewScheme(t)
 
 	saName := vmcpServiceAccountName(vmcp.Name)
 
@@ -436,10 +423,7 @@ func TestVirtualMCPServerEnsureRBACResources_Idempotency(t *testing.T) {
 		},
 	}
 
-	scheme := runtime.NewScheme()
-	_ = mcpv1beta1.AddToScheme(scheme)
-	_ = corev1.AddToScheme(scheme)
-	_ = rbacv1.AddToScheme(scheme)
+	scheme := testutil.NewScheme(t)
 
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(scheme).
@@ -502,10 +486,7 @@ func TestVirtualMCPServerEnsureRBACResources_InlineMode(t *testing.T) {
 		},
 	}
 
-	scheme := runtime.NewScheme()
-	_ = mcpv1beta1.AddToScheme(scheme)
-	_ = corev1.AddToScheme(scheme)
-	_ = rbacv1.AddToScheme(scheme)
+	scheme := testutil.NewScheme(t)
 
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(scheme).
@@ -572,10 +553,7 @@ func TestVirtualMCPServerEnsureRBACResources_DiscoveredMode(t *testing.T) {
 		},
 	}
 
-	scheme := runtime.NewScheme()
-	_ = mcpv1beta1.AddToScheme(scheme)
-	_ = corev1.AddToScheme(scheme)
-	_ = rbacv1.AddToScheme(scheme)
+	scheme := testutil.NewScheme(t)
 
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(scheme).
@@ -638,10 +616,7 @@ func TestVirtualMCPServerEnsureRBACResources_CustomServiceAccount(t *testing.T) 
 		},
 	}
 
-	scheme := runtime.NewScheme()
-	_ = mcpv1beta1.AddToScheme(scheme)
-	_ = corev1.AddToScheme(scheme)
-	_ = rbacv1.AddToScheme(scheme)
+	scheme := testutil.NewScheme(t)
 
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(scheme).
@@ -721,10 +696,7 @@ func TestVirtualMCPServerEnsureDeployment(t *testing.T) {
 		},
 	}
 
-	scheme := runtime.NewScheme()
-	_ = mcpv1beta1.AddToScheme(scheme)
-	_ = corev1.AddToScheme(scheme)
-	_ = appsv1.AddToScheme(scheme)
+	scheme := testutil.NewScheme(t)
 
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(scheme).
@@ -779,9 +751,7 @@ func TestVirtualMCPServerEnsureService(t *testing.T) {
 		},
 	}
 
-	scheme := runtime.NewScheme()
-	_ = mcpv1beta1.AddToScheme(scheme)
-	_ = corev1.AddToScheme(scheme)
+	scheme := testutil.NewScheme(t)
 
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(scheme).
@@ -859,9 +829,7 @@ func TestVirtualMCPServerServiceType(t *testing.T) {
 				},
 			}
 
-			scheme := runtime.NewScheme()
-			_ = mcpv1beta1.AddToScheme(scheme)
-			_ = corev1.AddToScheme(scheme)
+			scheme := testutil.NewScheme(t)
 
 			r := &VirtualMCPServerReconciler{
 				Scheme: scheme,
@@ -1115,9 +1083,7 @@ func TestVirtualMCPServerUpdateStatus(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			scheme := runtime.NewScheme()
-			_ = mcpv1beta1.AddToScheme(scheme)
-			_ = corev1.AddToScheme(scheme)
+			scheme := testutil.NewScheme(t)
 
 			objs := []client.Object{tt.vmcp}
 			for i := range tt.pods {
@@ -1187,9 +1153,7 @@ func TestVirtualMCPServerNaming(t *testing.T) {
 func TestVirtualMCPServerAuthConfiguredCondition(t *testing.T) {
 	t.Parallel()
 
-	scheme := runtime.NewScheme()
-	_ = mcpv1beta1.AddToScheme(scheme)
-	_ = corev1.AddToScheme(scheme)
+	scheme := testutil.NewScheme(t)
 
 	tests := []struct {
 		name                string
@@ -1397,11 +1361,7 @@ func TestVirtualMCPServerReconcile_NotFound(t *testing.T) {
 	t.Parallel()
 
 	// Setup
-	scheme := runtime.NewScheme()
-	_ = mcpv1beta1.AddToScheme(scheme)
-	_ = corev1.AddToScheme(scheme)
-	_ = appsv1.AddToScheme(scheme)
-	_ = rbacv1.AddToScheme(scheme)
+	scheme := testutil.NewScheme(t)
 
 	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 
@@ -1512,11 +1472,7 @@ func TestVirtualMCPServerApplyStatusUpdates(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			scheme := runtime.NewScheme()
-			_ = mcpv1beta1.AddToScheme(scheme)
-			_ = corev1.AddToScheme(scheme)
-			_ = appsv1.AddToScheme(scheme)
-			_ = rbacv1.AddToScheme(scheme)
+			scheme := testutil.NewScheme(t)
 
 			vmcp := tt.setupVMCP()
 			k8sClient := fake.NewClientBuilder().
@@ -1559,11 +1515,7 @@ func TestVirtualMCPServerApplyStatusUpdates(t *testing.T) {
 func TestVirtualMCPServerApplyStatusUpdates_ResourceNotFound(t *testing.T) {
 	t.Parallel()
 
-	scheme := runtime.NewScheme()
-	_ = mcpv1beta1.AddToScheme(scheme)
-	_ = corev1.AddToScheme(scheme)
-	_ = appsv1.AddToScheme(scheme)
-	_ = rbacv1.AddToScheme(scheme)
+	scheme := testutil.NewScheme(t)
 
 	vmcp := &mcpv1beta1.VirtualMCPServer{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1619,11 +1571,7 @@ func TestVirtualMCPServerEnsureAllResources_Errors(t *testing.T) {
 				}
 			},
 			setupClient: func(_ *testing.T, vmcp *mcpv1beta1.VirtualMCPServer) client.Client {
-				scheme := runtime.NewScheme()
-				_ = mcpv1beta1.AddToScheme(scheme)
-				_ = corev1.AddToScheme(scheme)
-				_ = appsv1.AddToScheme(scheme)
-				_ = rbacv1.AddToScheme(scheme)
+				scheme := testutil.NewScheme(t)
 
 				mcpGroup := &mcpv1beta1.MCPGroup{
 					ObjectMeta: metav1.ObjectMeta{
@@ -1672,10 +1620,7 @@ func TestVirtualMCPServerEnsureAllResources_Errors(t *testing.T) {
 func TestVirtualMCPServerContainerNeedsUpdate(t *testing.T) {
 	t.Parallel()
 
-	scheme := runtime.NewScheme()
-	_ = mcpv1beta1.AddToScheme(scheme)
-	_ = corev1.AddToScheme(scheme)
-	_ = appsv1.AddToScheme(scheme)
+	scheme := testutil.NewScheme(t)
 
 	reconciler := &VirtualMCPServerReconciler{
 		Scheme: scheme,
@@ -2022,8 +1967,7 @@ func TestVirtualMCPServerDeploymentMetadataNeedsUpdate(t *testing.T) {
 func TestVirtualMCPServerPodTemplateMetadataNeedsUpdate(t *testing.T) {
 	t.Parallel()
 
-	scheme := runtime.NewScheme()
-	_ = mcpv1beta1.AddToScheme(scheme)
+	scheme := testutil.NewScheme(t)
 
 	reconciler := &VirtualMCPServerReconciler{
 		Scheme: scheme,
@@ -2156,10 +2100,7 @@ func TestVirtualMCPServerPodTemplateMetadataNeedsUpdate(t *testing.T) {
 func TestVirtualMCPServerDeploymentNeedsUpdate(t *testing.T) {
 	t.Parallel()
 
-	scheme := runtime.NewScheme()
-	_ = mcpv1beta1.AddToScheme(scheme)
-	_ = corev1.AddToScheme(scheme)
-	_ = appsv1.AddToScheme(scheme)
+	scheme := testutil.NewScheme(t)
 
 	reconciler := &VirtualMCPServerReconciler{
 		Scheme: scheme,
@@ -2330,11 +2271,7 @@ func TestVirtualMCPServerDeploymentNeedsUpdate(t *testing.T) {
 func TestVirtualMCPServerReconcile_HappyPath(t *testing.T) {
 	t.Parallel()
 
-	scheme := runtime.NewScheme()
-	_ = mcpv1beta1.AddToScheme(scheme)
-	_ = corev1.AddToScheme(scheme)
-	_ = appsv1.AddToScheme(scheme)
-	_ = rbacv1.AddToScheme(scheme)
+	scheme := testutil.NewScheme(t)
 
 	vmcp := &mcpv1beta1.VirtualMCPServer{
 		ObjectMeta: metav1.ObjectMeta{
@@ -2463,11 +2400,7 @@ func TestVirtualMCPServerReconcile_HappyPath(t *testing.T) {
 func TestVirtualMCPServerReconcile_ValidateGroupRefError(t *testing.T) {
 	t.Parallel()
 
-	scheme := runtime.NewScheme()
-	_ = mcpv1beta1.AddToScheme(scheme)
-	_ = corev1.AddToScheme(scheme)
-	_ = appsv1.AddToScheme(scheme)
-	_ = rbacv1.AddToScheme(scheme)
+	scheme := testutil.NewScheme(t)
 
 	vmcp := &mcpv1beta1.VirtualMCPServer{
 		ObjectMeta: metav1.ObjectMeta{
@@ -2519,11 +2452,7 @@ func TestVirtualMCPServerReconcile_ValidateGroupRefError(t *testing.T) {
 func TestVirtualMCPServerReconcile_GroupNotReady(t *testing.T) {
 	t.Parallel()
 
-	scheme := runtime.NewScheme()
-	_ = mcpv1beta1.AddToScheme(scheme)
-	_ = corev1.AddToScheme(scheme)
-	_ = appsv1.AddToScheme(scheme)
-	_ = rbacv1.AddToScheme(scheme)
+	scheme := testutil.NewScheme(t)
 
 	vmcp := &mcpv1beta1.VirtualMCPServer{
 		ObjectMeta: metav1.ObjectMeta{
@@ -2584,8 +2513,7 @@ func TestVirtualMCPServerReconcile_GroupNotReady(t *testing.T) {
 func TestVirtualMCPServerReconcile_GetError(t *testing.T) {
 	t.Parallel()
 
-	scheme := runtime.NewScheme()
-	_ = mcpv1beta1.AddToScheme(scheme)
+	scheme := testutil.NewScheme(t)
 
 	// Create empty client - resource won't be found but we'll test non-NotFound errors
 	// by using a client that returns a generic error
@@ -2615,10 +2543,7 @@ func TestVirtualMCPServerReconcile_GetError(t *testing.T) {
 func TestVirtualMCPServerEnsureDeployment_ConfigMapNotFound(t *testing.T) {
 	t.Parallel()
 
-	scheme := runtime.NewScheme()
-	_ = mcpv1beta1.AddToScheme(scheme)
-	_ = corev1.AddToScheme(scheme)
-	_ = appsv1.AddToScheme(scheme)
+	scheme := testutil.NewScheme(t)
 
 	vmcp := &mcpv1beta1.VirtualMCPServer{
 		ObjectMeta: metav1.ObjectMeta{
@@ -2651,10 +2576,7 @@ func TestVirtualMCPServerEnsureDeployment_ConfigMapNotFound(t *testing.T) {
 func TestVirtualMCPServerEnsureDeployment_CreateDeployment(t *testing.T) {
 	t.Parallel()
 
-	scheme := runtime.NewScheme()
-	_ = mcpv1beta1.AddToScheme(scheme)
-	_ = corev1.AddToScheme(scheme)
-	_ = appsv1.AddToScheme(scheme)
+	scheme := testutil.NewScheme(t)
 
 	vmcp := &mcpv1beta1.VirtualMCPServer{
 		ObjectMeta: metav1.ObjectMeta{
@@ -2708,10 +2630,7 @@ func TestVirtualMCPServerEnsureDeployment_CreateDeployment(t *testing.T) {
 func TestVirtualMCPServerEnsureDeployment_UpdateDeployment(t *testing.T) {
 	t.Parallel()
 
-	scheme := runtime.NewScheme()
-	_ = mcpv1beta1.AddToScheme(scheme)
-	_ = corev1.AddToScheme(scheme)
-	_ = appsv1.AddToScheme(scheme)
+	scheme := testutil.NewScheme(t)
 
 	vmcp := &mcpv1beta1.VirtualMCPServer{
 		ObjectMeta: metav1.ObjectMeta{
@@ -2791,10 +2710,7 @@ func TestVirtualMCPServerEnsureDeployment_UpdateDeployment(t *testing.T) {
 func TestVirtualMCPServerEnsureDeployment_NoUpdateNeeded(t *testing.T) {
 	t.Parallel()
 
-	scheme := runtime.NewScheme()
-	_ = mcpv1beta1.AddToScheme(scheme)
-	_ = corev1.AddToScheme(scheme)
-	_ = appsv1.AddToScheme(scheme)
+	scheme := testutil.NewScheme(t)
 
 	vmcp := &mcpv1beta1.VirtualMCPServer{
 		ObjectMeta: metav1.ObjectMeta{
@@ -2878,9 +2794,7 @@ func TestVirtualMCPServerEnsureDeployment_NoUpdateNeeded(t *testing.T) {
 func TestVirtualMCPServerEnsureService_CreateService(t *testing.T) {
 	t.Parallel()
 
-	scheme := runtime.NewScheme()
-	_ = mcpv1beta1.AddToScheme(scheme)
-	_ = corev1.AddToScheme(scheme)
+	scheme := testutil.NewScheme(t)
 
 	vmcp := &mcpv1beta1.VirtualMCPServer{
 		ObjectMeta: metav1.ObjectMeta{
@@ -2920,9 +2834,7 @@ func TestVirtualMCPServerEnsureService_CreateService(t *testing.T) {
 func TestVirtualMCPServerEnsureService_UpdateService(t *testing.T) {
 	t.Parallel()
 
-	scheme := runtime.NewScheme()
-	_ = mcpv1beta1.AddToScheme(scheme)
-	_ = corev1.AddToScheme(scheme)
+	scheme := testutil.NewScheme(t)
 
 	vmcp := &mcpv1beta1.VirtualMCPServer{
 		ObjectMeta: metav1.ObjectMeta{
@@ -2982,9 +2894,7 @@ func TestVirtualMCPServerEnsureService_UpdateService(t *testing.T) {
 func TestVirtualMCPServerEnsureService_NoUpdateNeeded(t *testing.T) {
 	t.Parallel()
 
-	scheme := runtime.NewScheme()
-	_ = mcpv1beta1.AddToScheme(scheme)
-	_ = corev1.AddToScheme(scheme)
+	scheme := testutil.NewScheme(t)
 
 	vmcp := &mcpv1beta1.VirtualMCPServer{
 		ObjectMeta: metav1.ObjectMeta{
@@ -3162,11 +3072,7 @@ func TestVirtualMCPServerValidateEmbeddingServerRef(t *testing.T) {
 			t.Parallel()
 
 			// Setup fake client with resources
-			scheme := runtime.NewScheme()
-			_ = mcpv1beta1.AddToScheme(scheme)
-			_ = corev1.AddToScheme(scheme)
-			_ = appsv1.AddToScheme(scheme)
-			_ = rbacv1.AddToScheme(scheme)
+			scheme := testutil.NewScheme(t)
 
 			objs := []client.Object{tt.vmcp}
 			if tt.embeddingServer != nil {
@@ -3262,10 +3168,7 @@ func TestVirtualMCPServerEnsureDeployment_ReplicaSync_SpecDriven(t *testing.T) {
 		},
 	}
 
-	scheme := runtime.NewScheme()
-	_ = mcpv1beta1.AddToScheme(scheme)
-	_ = corev1.AddToScheme(scheme)
-	_ = appsv1.AddToScheme(scheme)
+	scheme := testutil.NewScheme(t)
 
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(scheme).
@@ -3341,10 +3244,7 @@ func TestVirtualMCPServerEnsureDeployment_ReplicaSync_NilPassthrough(t *testing.
 		},
 	}
 
-	scheme := runtime.NewScheme()
-	_ = mcpv1beta1.AddToScheme(scheme)
-	_ = corev1.AddToScheme(scheme)
-	_ = appsv1.AddToScheme(scheme)
+	scheme := testutil.NewScheme(t)
 
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(scheme).

--- a/cmd/thv-operator/controllers/virtualmcpserver_default_imagepullsecrets_test.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_default_imagepullsecrets_test.go
@@ -9,13 +9,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 	ctrlutil "github.com/stacklok/toolhive/cmd/thv-operator/pkg/controllerutil"
 	"github.com/stacklok/toolhive/cmd/thv-operator/pkg/imagepullsecrets"
 	"github.com/stacklok/toolhive/pkg/vmcp/workloads"
@@ -71,10 +70,7 @@ func TestVirtualMCPServer_DefaultImagePullSecrets(t *testing.T) {
 				},
 			}
 
-			scheme := runtime.NewScheme()
-			require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-			require.NoError(t, corev1.AddToScheme(scheme))
-			require.NoError(t, rbacv1.AddToScheme(scheme))
+			scheme := testutil.NewScheme(t)
 
 			fakeClient := fake.NewClientBuilder().
 				WithScheme(scheme).

--- a/cmd/thv-operator/controllers/virtualmcpserver_deployment_test.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_deployment_test.go
@@ -30,6 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 	ctrlutil "github.com/stacklok/toolhive/cmd/thv-operator/pkg/controllerutil"
 	"github.com/stacklok/toolhive/cmd/thv-operator/pkg/runconfig/configmap/checksum"
 	vmcpconfig "github.com/stacklok/toolhive/pkg/vmcp/config"
@@ -50,8 +51,7 @@ func TestDeploymentForVirtualMCPServer(t *testing.T) {
 		},
 	}
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	r := &VirtualMCPServerReconciler{
 		Scheme:           scheme,
@@ -113,8 +113,7 @@ func TestDeploymentForVirtualMCPServer_WithRedisPassword(t *testing.T) {
 		},
 	}
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	r := &VirtualMCPServerReconciler{
 		Scheme:           scheme,
@@ -413,9 +412,7 @@ func TestServiceForVirtualMCPServer(t *testing.T) {
 		},
 	}
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-	require.NoError(t, corev1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	r := &VirtualMCPServerReconciler{
 		Scheme: scheme,
@@ -454,9 +451,7 @@ func TestServiceForVirtualMCPServerSessionAffinityNone(t *testing.T) {
 		},
 	}
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-	require.NoError(t, corev1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	r := &VirtualMCPServerReconciler{
 		Scheme: scheme,
@@ -837,9 +832,7 @@ func TestBuildCABundleVolumesForEntries(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			scheme := runtime.NewScheme()
-			require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-			require.NoError(t, corev1.AddToScheme(scheme))
+			scheme := testutil.NewScheme(t)
 
 			objs := make([]client.Object, 0, len(tt.entries))
 			for i := range tt.entries {
@@ -947,9 +940,7 @@ func TestDeploymentForVirtualMCPServer_ImagePullSecrets(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			scheme := runtime.NewScheme()
-			require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-			require.NoError(t, corev1.AddToScheme(scheme))
+			scheme := testutil.NewScheme(t)
 
 			vmcp := &mcpv1beta1.VirtualMCPServer{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1034,9 +1025,7 @@ func TestDeploymentForVirtualMCPServer_ImagePullSecrets_UpdatePath(t *testing.T)
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			scheme := runtime.NewScheme()
-			require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-			require.NoError(t, corev1.AddToScheme(scheme))
+			scheme := testutil.NewScheme(t)
 
 			r := &VirtualMCPServerReconciler{
 				Scheme:           scheme,
@@ -1307,9 +1296,7 @@ func TestBuildHeaderForwardEnvVarsForEntries(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			scheme := runtime.NewScheme()
-			require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-			require.NoError(t, corev1.AddToScheme(scheme))
+			scheme := testutil.NewScheme(t)
 
 			objs := make([]client.Object, 0, len(tt.entries))
 			for i := range tt.entries {
@@ -1395,9 +1382,7 @@ func TestBuildHeaderForwardEnvVarsForEntries_ShuffledInputDeterministic(t *testi
 		{Name: "alpha", Type: workloads.WorkloadTypeMCPServerEntry},
 	}
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-	require.NoError(t, corev1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	objs := make([]client.Object, 0, len(entries))
 	for i := range entries {

--- a/cmd/thv-operator/controllers/virtualmcpserver_externalauth_test.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_externalauth_test.go
@@ -12,13 +12,12 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 	ctrlutil "github.com/stacklok/toolhive/cmd/thv-operator/pkg/controllerutil"
 	"github.com/stacklok/toolhive/pkg/auth/obo"
 	"github.com/stacklok/toolhive/pkg/authserver"
@@ -182,9 +181,7 @@ func TestConvertExternalAuthConfigToStrategy(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			scheme := runtime.NewScheme()
-			_ = mcpv1beta1.AddToScheme(scheme)
-			_ = corev1.AddToScheme(scheme)
+			scheme := testutil.NewScheme(t)
 
 			// Set up fake client (no secrets needed - secrets are mounted as env vars, not resolved)
 			fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
@@ -710,8 +707,7 @@ func TestBuildOutgoingAuthConfig(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			scheme := runtime.NewScheme()
-			_ = mcpv1beta1.AddToScheme(scheme)
+			scheme := testutil.NewScheme(t)
 
 			// Build objects list for fake client
 			objects := []client.Object{tt.vmcp}
@@ -815,8 +811,7 @@ func TestConvertBackendAuthConfigToVMCP(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			scheme := runtime.NewScheme()
-			_ = mcpv1beta1.AddToScheme(scheme)
+			scheme := testutil.NewScheme(t)
 
 			objects := []client.Object{}
 			for i := range tt.authConfigs {
@@ -861,8 +856,7 @@ func TestConvertBackendAuthConfigToVMCP(t *testing.T) {
 func TestConvertBackendAuthConfigToVMCP_MirrorsInvalidExternalAuthConfig(t *testing.T) {
 	t.Parallel()
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	invalidSource := &mcpv1beta1.MCPExternalAuthConfig{
 		ObjectMeta: metav1.ObjectMeta{Name: "obo-source", Namespace: "default"},
@@ -1313,8 +1307,7 @@ func TestInjectSubjectProviderIfNeeded(t *testing.T) {
 func TestBuildOutgoingAuthConfig_SubjectProviderInjection(t *testing.T) {
 	t.Parallel()
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	// A shared MCPExternalAuthConfig with token_exchange and no SubjectProviderName.
 	defaultAuthConfig := &mcpv1beta1.MCPExternalAuthConfig{
@@ -1471,8 +1464,7 @@ func TestDiscoverExternalAuthConfigSecrets_DeterministicOrdering(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			scheme := runtime.NewScheme()
-			require.NoError(t, mcpv1beta1.AddToScheme(scheme))
+			scheme := testutil.NewScheme(t)
 
 			vmcp := &mcpv1beta1.VirtualMCPServer{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1624,8 +1616,7 @@ func TestDiscoverInlineExternalAuthConfigSecrets_DeterministicOrdering(t *testin
 	//
 	// Alphabetical order: ALPHA < BETA < MU < ZETA
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	vmcp := &mcpv1beta1.VirtualMCPServer{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1755,8 +1746,7 @@ func TestDiscoverInlineExternalAuthConfigSecrets_DeterministicOrdering(t *testin
 func TestBuildOutgoingAuthConfig_InlineBackendSubjectProviderInjection(t *testing.T) {
 	t.Parallel()
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	// MCPExternalAuthConfig referenced by the inline Backends override.
 	inlineAuthConfig := &mcpv1beta1.MCPExternalAuthConfig{
@@ -1837,9 +1827,7 @@ func TestBuildOutgoingAuthConfig_InlineBackendSubjectProviderInjection(t *testin
 func TestGetExternalAuthConfigSecretEnvVars_OBO(t *testing.T) {
 	t.Parallel()
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-	require.NoError(t, corev1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	authCfg := &mcpv1beta1.MCPExternalAuthConfig{
 		ObjectMeta: metav1.ObjectMeta{

--- a/cmd/thv-operator/controllers/virtualmcpserver_podtemplatespec_reconcile_test.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_podtemplatespec_reconcile_test.go
@@ -18,6 +18,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 	"github.com/stacklok/toolhive/cmd/thv-operator/pkg/runconfig/configmap/checksum"
 	"github.com/stacklok/toolhive/pkg/vmcp/workloads"
 )
@@ -32,10 +33,7 @@ const (
 // twice with the same PodTemplateSpec produces identical results (no spurious updates)
 func TestVirtualMCPServerPodTemplateSpecDeterministic(t *testing.T) {
 	t.Parallel()
-	scheme := runtime.NewScheme()
-	_ = mcpv1beta1.AddToScheme(scheme)
-	_ = corev1.AddToScheme(scheme)
-	_ = appsv1.AddToScheme(scheme)
+	scheme := testutil.NewScheme(t)
 
 	namespace := testPodTemplateNamespace
 	vmcpName := testPodTemplateVmcpName
@@ -110,10 +108,7 @@ func TestVirtualMCPServerPodTemplateSpecDeterministic(t *testing.T) {
 // This is a regression test for the nil-slice-becomes-empty-array bug.
 func TestVirtualMCPServerPodTemplateSpecPreservesContainer(t *testing.T) {
 	t.Parallel()
-	scheme := runtime.NewScheme()
-	_ = mcpv1beta1.AddToScheme(scheme)
-	_ = corev1.AddToScheme(scheme)
-	_ = appsv1.AddToScheme(scheme)
+	scheme := testutil.NewScheme(t)
 
 	namespace := testPodTemplateNamespace
 	vmcpName := testPodTemplateVmcpName
@@ -289,10 +284,7 @@ func TestVirtualMCPServerPodTemplateSpecNeedsUpdate(t *testing.T) {
 // the default resource requirements via PodTemplateSpec using strategic merge patch.
 func TestVirtualMCPServerPodTemplateSpecResourceOverride(t *testing.T) {
 	t.Parallel()
-	scheme := runtime.NewScheme()
-	_ = mcpv1beta1.AddToScheme(scheme)
-	_ = corev1.AddToScheme(scheme)
-	_ = appsv1.AddToScheme(scheme)
+	scheme := testutil.NewScheme(t)
 
 	namespace := testPodTemplateNamespace
 	vmcpName := testPodTemplateVmcpName

--- a/cmd/thv-operator/controllers/virtualmcpserver_telemetryconfig_test.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_telemetryconfig_test.go
@@ -9,19 +9,18 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 	"github.com/stacklok/toolhive/cmd/thv-operator/pkg/virtualmcpserverstatus"
 )
 
 func TestHandleTelemetryConfig_VirtualMCPServer(t *testing.T) {
 	t.Parallel()
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	tests := []struct {
 		name               string
@@ -211,8 +210,7 @@ func TestHandleTelemetryConfig_VirtualMCPServer(t *testing.T) {
 func TestMapTelemetryConfigToVirtualMCPServer(t *testing.T) {
 	t.Parallel()
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	vmcp1 := &mcpv1beta1.VirtualMCPServer{
 		ObjectMeta: metav1.ObjectMeta{Name: "vmcp1", Namespace: "default"},

--- a/cmd/thv-operator/controllers/virtualmcpserver_vmcpconfig_test.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_vmcpconfig_test.go
@@ -22,6 +22,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 	oidcmocks "github.com/stacklok/toolhive/cmd/thv-operator/pkg/oidc/mocks"
 	"github.com/stacklok/toolhive/cmd/thv-operator/pkg/virtualmcpserverstatus"
 	statusmocks "github.com/stacklok/toolhive/cmd/thv-operator/pkg/virtualmcpserverstatus/mocks"
@@ -44,8 +45,7 @@ func newNoOpMockResolver(t *testing.T) *oidcmocks.MockResolver {
 // newTestConverter creates a Converter with the given resolver, failing the test if creation fails.
 func newTestConverter(t *testing.T, resolver *oidcmocks.MockResolver) *vmcpconfigconv.Converter {
 	t.Helper()
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 	converter, err := vmcpconfigconv.NewConverter(resolver, fakeClient)
 	require.NoError(t, err)
@@ -233,8 +233,7 @@ func TestConvertBackendAuthConfig(t *testing.T) {
 				}
 
 				// Create converter with fake client that has the external auth config
-				scheme := runtime.NewScheme()
-				require.NoError(t, mcpv1beta1.AddToScheme(scheme))
+				scheme := testutil.NewScheme(t)
 				fakeClient := fake.NewClientBuilder().
 					WithScheme(scheme).
 					WithObjects(externalAuthConfig).
@@ -471,9 +470,7 @@ func TestEnsureVmcpConfigConfigMap(t *testing.T) {
 		Spec: mcpv1beta1.MCPGroupSpec{},
 	}
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-	require.NoError(t, corev1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(scheme).
@@ -1181,7 +1178,7 @@ func TestVirtualMCPServerReconciler_CompositeToolRefs_EndToEnd(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	testScheme := createRunConfigTestScheme()
+	testScheme := testutil.NewScheme(t)
 
 	// Create a VirtualMCPCompositeToolDefinition
 	compositeToolDef := &mcpv1beta1.VirtualMCPCompositeToolDefinition{
@@ -1303,7 +1300,7 @@ func TestVirtualMCPServerReconciler_CompositeToolRefs_MergeInlineAndReferenced(t
 	t.Parallel()
 
 	ctx := context.Background()
-	testScheme := createRunConfigTestScheme()
+	testScheme := testutil.NewScheme(t)
 
 	// Create a referenced VirtualMCPCompositeToolDefinition
 	referencedTool := &mcpv1beta1.VirtualMCPCompositeToolDefinition{
@@ -1421,7 +1418,7 @@ func TestVirtualMCPServerReconciler_CompositeToolRefs_NotFound(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	testScheme := createRunConfigTestScheme()
+	testScheme := testutil.NewScheme(t)
 
 	// Create MCPGroup
 	mcpGroup := &mcpv1beta1.MCPGroup{
@@ -1484,7 +1481,7 @@ func TestConfigMapContent_DynamicMode(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	testScheme := createRunConfigTestScheme()
+	testScheme := testutil.NewScheme(t)
 
 	// Create MCPGroup for workload discovery
 	mcpGroup := &mcpv1beta1.MCPGroup{
@@ -1568,7 +1565,7 @@ func TestConfigMapContent_StaticMode_InlineOverrides(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	testScheme := createRunConfigTestScheme()
+	testScheme := testutil.NewScheme(t)
 
 	// Create MCPGroup for workload discovery
 	mcpGroup := &mcpv1beta1.MCPGroup{
@@ -1675,7 +1672,7 @@ func TestConfigMapContent_StaticModeWithDiscovery(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	testScheme := createRunConfigTestScheme()
+	testScheme := testutil.NewScheme(t)
 
 	// Create MCPGroup for workload discovery
 	mcpGroup := &mcpv1beta1.MCPGroup{
@@ -1942,7 +1939,7 @@ func TestOptimizerEmbeddingServiceURL(t *testing.T) {
 			t.Parallel()
 
 			ctx := context.Background()
-			testScheme := createRunConfigTestScheme()
+			testScheme := testutil.NewScheme(t)
 
 			mcpGroup := &mcpv1beta1.MCPGroup{
 				ObjectMeta: metav1.ObjectMeta{
@@ -2093,7 +2090,7 @@ func TestConfigMapContent_SessionStorage(t *testing.T) {
 			t.Parallel()
 
 			ctx := context.Background()
-			testScheme := createRunConfigTestScheme()
+			testScheme := testutil.NewScheme(t)
 
 			mcpGroup := &mcpv1beta1.MCPGroup{
 				ObjectMeta: metav1.ObjectMeta{Name: testGroup, Namespace: testNamespace},
@@ -2211,9 +2208,7 @@ func TestEnsureVmcpConfigConfigMap_AuthServerIntegrationValidationError(t *testi
 		},
 	}
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-	require.NoError(t, corev1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(scheme).
@@ -2495,9 +2490,7 @@ func TestBuildCABundlePathMap(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			scheme := runtime.NewScheme()
-			require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-			require.NoError(t, corev1.AddToScheme(scheme))
+			scheme := testutil.NewScheme(t)
 
 			objs := make([]client.Object, 0, len(tt.entries))
 			for i := range tt.entries {

--- a/cmd/thv-operator/controllers/virtualmcpserver_watch_test.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_watch_test.go
@@ -19,13 +19,12 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 	vmcpconfig "github.com/stacklok/toolhive/pkg/vmcp/config"
 )
 
@@ -153,9 +152,7 @@ func TestMapMCPGroupToVirtualMCPServer(t *testing.T) {
 			t.Parallel()
 
 			// Create scheme
-			scheme := runtime.NewScheme()
-			err := mcpv1beta1.AddToScheme(scheme)
-			require.NoError(t, err)
+			scheme := testutil.NewScheme(t)
 
 			// Create objects slice
 			objs := []client.Object{tt.mcpGroup}
@@ -197,9 +194,7 @@ func TestMapMCPGroupToVirtualMCPServer(t *testing.T) {
 func TestMapMCPGroupToVirtualMCPServer_InvalidObject(t *testing.T) {
 	t.Parallel()
 
-	scheme := runtime.NewScheme()
-	err := mcpv1beta1.AddToScheme(scheme)
-	require.NoError(t, err)
+	scheme := testutil.NewScheme(t)
 
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 	r := &VirtualMCPServerReconciler{
@@ -397,9 +392,7 @@ func TestMapMCPServerToVirtualMCPServer(t *testing.T) {
 			t.Parallel()
 
 			// Create scheme
-			scheme := runtime.NewScheme()
-			err := mcpv1beta1.AddToScheme(scheme)
-			require.NoError(t, err)
+			scheme := testutil.NewScheme(t)
 
 			// Create objects slice
 			objs := []client.Object{tt.mcpServer}
@@ -447,9 +440,7 @@ func TestMapMCPServerToVirtualMCPServer(t *testing.T) {
 func TestMapMCPServerToVirtualMCPServer_InvalidObject(t *testing.T) {
 	t.Parallel()
 
-	scheme := runtime.NewScheme()
-	err := mcpv1beta1.AddToScheme(scheme)
-	require.NoError(t, err)
+	scheme := testutil.NewScheme(t)
 
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 	r := &VirtualMCPServerReconciler{
@@ -647,9 +638,7 @@ func TestMapMCPRemoteProxyToVirtualMCPServer(t *testing.T) {
 			t.Parallel()
 
 			// Create scheme
-			scheme := runtime.NewScheme()
-			err := mcpv1beta1.AddToScheme(scheme)
-			require.NoError(t, err)
+			scheme := testutil.NewScheme(t)
 
 			// Create objects slice
 			objs := []client.Object{tt.mcpRemoteProxy}
@@ -697,9 +686,7 @@ func TestMapMCPRemoteProxyToVirtualMCPServer(t *testing.T) {
 func TestMapMCPRemoteProxyToVirtualMCPServer_InvalidObject(t *testing.T) {
 	t.Parallel()
 
-	scheme := runtime.NewScheme()
-	err := mcpv1beta1.AddToScheme(scheme)
-	require.NoError(t, err)
+	scheme := testutil.NewScheme(t)
 
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 	r := &VirtualMCPServerReconciler{
@@ -1057,9 +1044,7 @@ func TestMapExternalAuthConfigToVirtualMCPServer(t *testing.T) {
 			t.Parallel()
 
 			// Create scheme
-			scheme := runtime.NewScheme()
-			err := mcpv1beta1.AddToScheme(scheme)
-			require.NoError(t, err)
+			scheme := testutil.NewScheme(t)
 
 			// Create objects slice
 			objs := []client.Object{tt.authConfig}
@@ -1248,9 +1233,7 @@ func TestMapToolConfigToVirtualMCPServer(t *testing.T) {
 			t.Parallel()
 
 			// Create scheme
-			scheme := runtime.NewScheme()
-			err := mcpv1beta1.AddToScheme(scheme)
-			require.NoError(t, err)
+			scheme := testutil.NewScheme(t)
 
 			// Create objects slice
 			objs := []client.Object{tt.toolConfig}
@@ -1741,9 +1724,7 @@ func TestVmcpReferencesExternalAuthConfig(t *testing.T) {
 			t.Parallel()
 
 			// Create scheme
-			scheme := runtime.NewScheme()
-			err := mcpv1beta1.AddToScheme(scheme)
-			require.NoError(t, err)
+			scheme := testutil.NewScheme(t)
 
 			// Create objects slice
 			objs := []client.Object{}
@@ -1889,9 +1870,7 @@ func TestMapEmbeddingServerToVirtualMCPServer(t *testing.T) {
 			t.Parallel()
 
 			// Create scheme
-			scheme := runtime.NewScheme()
-			err := mcpv1beta1.AddToScheme(scheme)
-			require.NoError(t, err)
+			scheme := testutil.NewScheme(t)
 
 			// Create objects slice
 			objs := []client.Object{tt.embeddingServer}
@@ -1933,9 +1912,7 @@ func TestMapEmbeddingServerToVirtualMCPServer(t *testing.T) {
 func TestMapEmbeddingServerToVirtualMCPServer_InvalidObject(t *testing.T) {
 	t.Parallel()
 
-	scheme := runtime.NewScheme()
-	err := mcpv1beta1.AddToScheme(scheme)
-	require.NoError(t, err)
+	scheme := testutil.NewScheme(t)
 
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 	r := &VirtualMCPServerReconciler{

--- a/cmd/thv-operator/internal/testutil/scheme.go
+++ b/cmd/thv-operator/internal/testutil/scheme.go
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package testutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+
+	mcpv1alpha1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1alpha1"
+	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+)
+
+// NewScheme builds a runtime.Scheme registered with all built-in Kubernetes
+// types (corev1, appsv1, rbacv1, …) via client-go's scheme, plus both ToolHive
+// operator API versions (v1alpha1 and v1beta1). Any extra AddToScheme functions
+// are applied on top of that default set, in order.
+//
+// It replaces the per-test boilerplate of calling runtime.NewScheme() followed
+// by individual AddToScheme calls. The built-in superset is harmless for fake
+// clients: registering types a given test does not use has no effect, so almost
+// every caller wants the bare NewScheme(t). Pass extras only when a test needs
+// an API outside the default set, e.g.:
+//
+//	scheme := testutil.NewScheme(t, apiextensionsv1.AddToScheme)
+//
+// A test that must assert behavior when a type is deliberately unregistered
+// should build its scheme inline with runtime.NewScheme(); that is a rare,
+// self-documenting exception this helper intentionally does not serve.
+func NewScheme(t *testing.T, extra ...func(*runtime.Scheme) error) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	adders := append([]func(*runtime.Scheme) error{
+		clientgoscheme.AddToScheme,
+		mcpv1beta1.AddToScheme,
+		mcpv1alpha1.AddToScheme,
+	}, extra...)
+	for _, add := range adders {
+		require.NoError(t, add(scheme))
+	}
+	return scheme
+}

--- a/cmd/thv-operator/internal/testutil/scheme_test.go
+++ b/cmd/thv-operator/internal/testutil/scheme_test.go
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package testutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+
+	mcpv1alpha1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1alpha1"
+	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+)
+
+func TestNewScheme_RegistersOperatorAndBuiltinTypes(t *testing.T) {
+	t.Parallel()
+
+	scheme := NewScheme(t)
+
+	// Operator API versions.
+	assert.True(t, scheme.Recognizes(mcpv1beta1.GroupVersion.WithKind("MCPServer")),
+		"v1beta1 MCPServer must be registered")
+	assert.True(t, scheme.Recognizes(mcpv1alpha1.GroupVersion.WithKind("MCPServer")),
+		"v1alpha1 MCPServer must be registered")
+
+	// Built-in Kubernetes types pulled in via client-go's scheme.
+	assert.True(t, scheme.Recognizes(corev1.SchemeGroupVersion.WithKind("ConfigMap")),
+		"corev1 ConfigMap must be registered")
+	assert.True(t, scheme.Recognizes(appsv1.SchemeGroupVersion.WithKind("Deployment")),
+		"appsv1 Deployment must be registered")
+	assert.True(t, scheme.Recognizes(rbacv1.SchemeGroupVersion.WithKind("Role")),
+		"rbacv1 Role must be registered")
+}
+
+func TestNewScheme_AppliesExtraAddersOnTopOfDefault(t *testing.T) {
+	t.Parallel()
+
+	scheme := NewScheme(t, apiextensionsv1.AddToScheme)
+
+	// Default set is still present.
+	assert.True(t, scheme.Recognizes(mcpv1beta1.GroupVersion.WithKind("MCPServer")),
+		"default operator types must remain registered")
+	// The extra adder's types are now registered too.
+	assert.True(t, scheme.Recognizes(apiextensionsv1.SchemeGroupVersion.WithKind("CustomResourceDefinition")),
+		"extra adder types must be registered alongside the default set")
+}

--- a/cmd/thv-operator/pkg/controllerutil/authserver_test.go
+++ b/cmd/thv-operator/pkg/controllerutil/authserver_test.go
@@ -19,6 +19,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 	"github.com/stacklok/toolhive/cmd/thv-operator/pkg/oidc"
 	"github.com/stacklok/toolhive/pkg/authserver"
 	authrunner "github.com/stacklok/toolhive/pkg/authserver/runner"
@@ -638,9 +639,7 @@ func TestGenerateAuthServerEnvVars(t *testing.T) {
 func TestGenerateAuthServerConfigByName(t *testing.T) {
 	t.Parallel()
 
-	scheme := runtime.NewScheme()
-	err := mcpv1beta1.AddToScheme(scheme)
-	require.NoError(t, err)
+	scheme := testutil.NewScheme(t)
 
 	tests := []struct {
 		name            string
@@ -1653,9 +1652,7 @@ func TestBuildAuthServerRunConfig_InvalidDCR(t *testing.T) {
 func TestAddEmbeddedAuthServerConfigOptions_Validation(t *testing.T) {
 	t.Parallel()
 
-	scheme := runtime.NewScheme()
-	err := mcpv1beta1.AddToScheme(scheme)
-	require.NoError(t, err)
+	scheme := testutil.NewScheme(t)
 
 	// Helper function to create a fresh external auth config for each test
 	// This avoids data races when running subtests in parallel
@@ -2345,9 +2342,7 @@ func TestBuildAuthServerRunConfig_WithRedisStorage(t *testing.T) {
 func TestAddAuthServerRefOptions(t *testing.T) {
 	t.Parallel()
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-	require.NoError(t, corev1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	newValidEmbeddedAuthConfig := func() *mcpv1beta1.MCPExternalAuthConfig {
 		return &mcpv1beta1.MCPExternalAuthConfig{
@@ -2521,9 +2516,7 @@ func TestAddAuthServerRefOptions(t *testing.T) {
 func TestValidateAndAddAuthServerRefOptions(t *testing.T) {
 	t.Parallel()
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-	require.NoError(t, corev1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	newEmbeddedAuthConfig := func() *mcpv1beta1.MCPExternalAuthConfig {
 		return &mcpv1beta1.MCPExternalAuthConfig{

--- a/cmd/thv-operator/pkg/controllerutil/authz_ref_test.go
+++ b/cmd/thv-operator/pkg/controllerutil/authz_ref_test.go
@@ -10,12 +10,12 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 	// Blank-imported so the cedarv1 and httpv1 authorizer factories register
 	// themselves; BuildFullAuthzConfigJSON / AddAuthzConfigRefOptions resolve
 	// the backend via the authorizers registry.
@@ -29,14 +29,6 @@ const cedarRefConfig = `{"policies":["permit(principal, action, resource);"],"en
 
 // httpRefConfig is the backend-specific config blob an httpv1 MCPAuthzConfig holds.
 const httpRefConfig = `{"http":{"url":"https://pdp.example.com"},"claim_mapping":"standard"}`
-
-func authzScheme(t *testing.T) *runtime.Scheme {
-	t.Helper()
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-	require.NoError(t, corev1.AddToScheme(scheme))
-	return scheme
-}
 
 func newAuthzConfig(name, typ, rawConfig string, valid bool) *mcpv1beta1.MCPAuthzConfig {
 	cfg := &mcpv1beta1.MCPAuthzConfig{
@@ -117,7 +109,7 @@ func TestBuildFullAuthzConfigJSON(t *testing.T) {
 func TestGetAuthzConfigForWorkload(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	scheme := authzScheme(t)
+	scheme := testutil.NewScheme(t)
 
 	cfg := newAuthzConfig("authz", "cedarv1", cedarRefConfig, true)
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cfg).Build()
@@ -173,7 +165,7 @@ func TestValidateAuthzConfigReady(t *testing.T) {
 func TestAddAuthzConfigRefOptions(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	scheme := authzScheme(t)
+	scheme := testutil.NewScheme(t)
 
 	cedarCfg := newAuthzConfig("cedar-authz", "cedarv1", cedarRefConfig, true)
 	httpCfg := newAuthzConfig("http-authz", "httpv1", httpRefConfig, true)

--- a/cmd/thv-operator/pkg/controllerutil/authz_test.go
+++ b/cmd/thv-operator/pkg/controllerutil/authz_test.go
@@ -12,10 +12,10 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 	"github.com/stacklok/toolhive/pkg/authz"
 	"github.com/stacklok/toolhive/pkg/authz/authorizers/cedar"
 	"github.com/stacklok/toolhive/pkg/runner"
@@ -159,9 +159,7 @@ func TestGenerateAuthzVolumeConfigInlineConfigMapName(t *testing.T) {
 func TestEnsureAuthzConfigMap(t *testing.T) {
 	t.Parallel()
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, corev1.AddToScheme(scheme))
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	t.Run("Nil authz config returns nil", func(t *testing.T) {
 		t.Parallel()
@@ -324,9 +322,7 @@ func TestEnsureAuthzConfigMap(t *testing.T) {
 func TestAddAuthzConfigOptions(t *testing.T) {
 	t.Parallel()
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, corev1.AddToScheme(scheme))
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	t.Run("Nil authz ref returns nil", func(t *testing.T) {
 		t.Parallel()

--- a/cmd/thv-operator/pkg/controllerutil/config_test.go
+++ b/cmd/thv-operator/pkg/controllerutil/config_test.go
@@ -9,10 +9,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 )
 
 func TestCalculateConfigHash(t *testing.T) {
@@ -92,8 +92,7 @@ func TestCalculateConfigHash(t *testing.T) {
 func TestFindReferencingMCPServers(t *testing.T) {
 	t.Parallel()
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	t.Run("finds servers referencing toolconfig", func(t *testing.T) {
 		t.Parallel()
@@ -397,8 +396,7 @@ func TestWorkloadRefsEqual(t *testing.T) {
 func TestFindWorkloadRefsFromMCPServers(t *testing.T) {
 	t.Parallel()
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	t.Run("returns sorted refs", func(t *testing.T) {
 		t.Parallel()
@@ -463,8 +461,7 @@ func TestFindWorkloadRefsFromMCPServers(t *testing.T) {
 func TestGetTelemetryConfigForMCPRemoteProxy(t *testing.T) {
 	t.Parallel()
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	tests := []struct {
 		name            string
@@ -558,8 +555,7 @@ func TestGetTelemetryConfigForMCPRemoteProxy(t *testing.T) {
 func TestGetTelemetryConfigForVirtualMCPServer(t *testing.T) {
 	t.Parallel()
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	tests := []struct {
 		name            string

--- a/cmd/thv-operator/pkg/controllerutil/oidc_test.go
+++ b/cmd/thv-operator/pkg/controllerutil/oidc_test.go
@@ -11,10 +11,10 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 )
 
 func TestGenerateOIDCClientSecretEnvVar(t *testing.T) {
@@ -96,11 +96,7 @@ func TestGenerateOIDCClientSecretEnvVar(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			scheme := runtime.NewScheme()
-			err := corev1.AddToScheme(scheme)
-			require.NoError(t, err)
-			err = mcpv1beta1.AddToScheme(scheme)
-			require.NoError(t, err)
+			scheme := testutil.NewScheme(t)
 
 			var fakeClient *fake.ClientBuilder
 			if tt.secret != nil {

--- a/cmd/thv-operator/pkg/controllerutil/patch_test.go
+++ b/cmd/thv-operator/pkg/controllerutil/patch_test.go
@@ -11,12 +11,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 )
 
 // specPatchRecordingClient wraps a client.Client and intercepts top-level
@@ -54,8 +54,7 @@ func (c *specPatchRecordingClient) lastBody() string {
 
 func buildSpecTestClient(t *testing.T, seed *mcpv1beta1.MCPServer) (*specPatchRecordingClient, client.Client) {
 	t.Helper()
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 	inner := fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithObjects(seed).

--- a/cmd/thv-operator/pkg/controllerutil/status_test.go
+++ b/cmd/thv-operator/pkg/controllerutil/status_test.go
@@ -18,6 +18,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 )
 
 // statusPatchRecordingClient wraps a client.Client and intercepts
@@ -81,8 +82,7 @@ func (c *statusPatchRecordingClient) lastBody() string {
 
 func buildStatusTestClient(t *testing.T, seed *mcpv1beta1.MCPServer) (*statusPatchRecordingClient, client.Client) {
 	t.Helper()
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 	inner := fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithObjects(seed).

--- a/cmd/thv-operator/pkg/controllerutil/tokenexchange_test.go
+++ b/cmd/thv-operator/pkg/controllerutil/tokenexchange_test.go
@@ -12,11 +12,11 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 	"github.com/stacklok/toolhive/pkg/auth/obo"
 	"github.com/stacklok/toolhive/pkg/runner"
 )
@@ -248,9 +248,7 @@ func TestRegisterOBOHandler_PanicsOnNilField(t *testing.T) {
 func TestAddExternalAuthConfigOptions_OBO(t *testing.T) {
 	t.Parallel()
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-	require.NoError(t, corev1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	authCfg := &mcpv1beta1.MCPExternalAuthConfig{
 		ObjectMeta: metav1.ObjectMeta{
@@ -304,9 +302,7 @@ func TestAddExternalAuthConfigOptions_OBO(t *testing.T) {
 func TestAddOBOSecretEnvVars(t *testing.T) {
 	t.Parallel()
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-	require.NoError(t, corev1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	const ns = "default"
 
@@ -424,9 +420,7 @@ func TestAddOBOSecretEnvVars(t *testing.T) {
 func TestAddOBOSecretEnvVars_OBOHandlerRegistered(t *testing.T) {
 	withDefaultOBOHandler(t)
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-	require.NoError(t, corev1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	const ns = "default"
 	authCfg := &mcpv1beta1.MCPExternalAuthConfig{

--- a/cmd/thv-operator/pkg/controllerutil/tools_config_test.go
+++ b/cmd/thv-operator/pkg/controllerutil/tools_config_test.go
@@ -9,15 +9,14 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 )
 
 func TestGetToolConfigForMCPServer(t *testing.T) {
@@ -95,8 +94,7 @@ func TestGetToolConfigForMCPServer(t *testing.T) {
 
 			ctx := t.Context()
 
-			scheme := runtime.NewScheme()
-			require.NoError(t, mcpv1beta1.AddToScheme(scheme))
+			scheme := testutil.NewScheme(t)
 
 			objs := []client.Object{}
 			if tt.existingConfig != nil {
@@ -150,8 +148,7 @@ func TestGetToolConfigForMCPServer_ErrorScenarios(t *testing.T) {
 		t.Parallel()
 		ctx := t.Context()
 
-		scheme := runtime.NewScheme()
-		require.NoError(t, mcpv1beta1.AddToScheme(scheme))
+		scheme := testutil.NewScheme(t)
 
 		mcpServer := &mcpv1beta1.MCPServer{
 			ObjectMeta: metav1.ObjectMeta{
@@ -182,8 +179,7 @@ func TestGetToolConfigForMCPServer_ErrorScenarios(t *testing.T) {
 
 		ctx := t.Context()
 
-		scheme := runtime.NewScheme()
-		require.NoError(t, mcpv1beta1.AddToScheme(scheme))
+		scheme := testutil.NewScheme(t)
 
 		mcpServer := &mcpv1beta1.MCPServer{
 			ObjectMeta: metav1.ObjectMeta{

--- a/cmd/thv-operator/pkg/controllerutil/webhook_test.go
+++ b/cmd/thv-operator/pkg/controllerutil/webhook_test.go
@@ -9,23 +9,19 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	mcpv1alpha1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1alpha1"
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 	"github.com/stacklok/toolhive/pkg/runner"
 	"github.com/stacklok/toolhive/pkg/webhook"
 )
 
 func TestWebhookConfigHelpers(t *testing.T) {
 	t.Parallel()
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1alpha1.AddToScheme(scheme))
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-	require.NoError(t, corev1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	timeout := metav1.Duration{Duration: 10 * time.Second}
 

--- a/cmd/thv-operator/pkg/kubernetes/configmaps/configmaps_test.go
+++ b/cmd/thv-operator/pkg/kubernetes/configmaps/configmaps_test.go
@@ -12,17 +12,17 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 )
 
 func TestGet(t *testing.T) {
 	t.Parallel()
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, corev1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	t.Run("successfully retrieves existing configmap", func(t *testing.T) {
 		t.Parallel()
@@ -115,8 +115,7 @@ func TestGet(t *testing.T) {
 func TestGetValue(t *testing.T) {
 	t.Parallel()
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, corev1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	t.Run("successfully retrieves configmap value", func(t *testing.T) {
 		t.Parallel()
@@ -297,7 +296,7 @@ func TestNewClient(t *testing.T) {
 	t.Run("creates client successfully", func(t *testing.T) {
 		t.Parallel()
 
-		scheme := runtime.NewScheme()
+		scheme := testutil.NewScheme(t)
 		fakeClient := fake.NewClientBuilder().
 			WithScheme(scheme).
 			Build()
@@ -311,8 +310,7 @@ func TestNewClient(t *testing.T) {
 func TestUpsert(t *testing.T) {
 	t.Parallel()
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, corev1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	t.Run("successfully creates a new configmap", func(t *testing.T) {
 		t.Parallel()
@@ -450,8 +448,7 @@ func TestUpsert(t *testing.T) {
 func TestUpsertWithOwnerReference(t *testing.T) {
 	t.Parallel()
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, corev1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	t.Run("successfully creates configmap with owner reference", func(t *testing.T) {
 		t.Parallel()

--- a/cmd/thv-operator/pkg/kubernetes/rbac/rbac_test.go
+++ b/cmd/thv-operator/pkg/kubernetes/rbac/rbac_test.go
@@ -13,21 +13,13 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
-)
 
-// setupTestScheme creates and initializes a test scheme with core and RBAC types.
-func setupTestScheme(t *testing.T) *runtime.Scheme {
-	t.Helper()
-	scheme := runtime.NewScheme()
-	require.NoError(t, corev1.AddToScheme(scheme))
-	require.NoError(t, rbacv1.AddToScheme(scheme))
-	return scheme
-}
+	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
+)
 
 // createTestOwner creates a ConfigMap to use as an owner for testing owner references.
 // All test owners are created in the "default" namespace.
@@ -65,7 +57,7 @@ func assertOwnerReference(t *testing.T, refs []metav1.OwnerReference, owner clie
 func TestGetServiceAccount(t *testing.T) {
 	t.Parallel()
 
-	scheme := setupTestScheme(t)
+	scheme := testutil.NewScheme(t)
 
 	t.Run("successfully retrieves existing ServiceAccount", func(t *testing.T) {
 		t.Parallel()
@@ -145,7 +137,7 @@ func TestGetServiceAccount(t *testing.T) {
 func TestUpsertServiceAccount(t *testing.T) {
 	t.Parallel()
 
-	scheme := setupTestScheme(t)
+	scheme := testutil.NewScheme(t)
 
 	t.Run("successfully creates new ServiceAccount", func(t *testing.T) {
 		t.Parallel()
@@ -262,7 +254,7 @@ func TestUpsertServiceAccount(t *testing.T) {
 func TestUpsertServiceAccountWithOwnerReference(t *testing.T) {
 	t.Parallel()
 
-	scheme := setupTestScheme(t)
+	scheme := testutil.NewScheme(t)
 
 	t.Run("successfully creates ServiceAccount with owner reference", func(t *testing.T) {
 		t.Parallel()
@@ -609,7 +601,7 @@ func TestUpsertServiceAccountWithOwnerReference(t *testing.T) {
 func TestGetRole(t *testing.T) {
 	t.Parallel()
 
-	scheme := setupTestScheme(t)
+	scheme := testutil.NewScheme(t)
 
 	t.Run("successfully retrieves existing Role", func(t *testing.T) {
 		t.Parallel()
@@ -697,7 +689,7 @@ func TestGetRole(t *testing.T) {
 func TestUpsertRole(t *testing.T) {
 	t.Parallel()
 
-	scheme := setupTestScheme(t)
+	scheme := testutil.NewScheme(t)
 
 	t.Run("successfully creates new Role", func(t *testing.T) {
 		t.Parallel()
@@ -833,7 +825,7 @@ func TestUpsertRole(t *testing.T) {
 func TestUpsertRoleWithOwnerReference(t *testing.T) {
 	t.Parallel()
 
-	scheme := setupTestScheme(t)
+	scheme := testutil.NewScheme(t)
 
 	t.Run("successfully creates Role with owner reference", func(t *testing.T) {
 		t.Parallel()
@@ -1035,7 +1027,7 @@ func TestUpsertRoleWithOwnerReference(t *testing.T) {
 func TestGetRoleBinding(t *testing.T) {
 	t.Parallel()
 
-	scheme := setupTestScheme(t)
+	scheme := testutil.NewScheme(t)
 
 	t.Run("successfully retrieves existing RoleBinding", func(t *testing.T) {
 		t.Parallel()
@@ -1140,7 +1132,7 @@ func TestGetRoleBinding(t *testing.T) {
 func TestUpsertRoleBinding(t *testing.T) {
 	t.Parallel()
 
-	scheme := setupTestScheme(t)
+	scheme := testutil.NewScheme(t)
 
 	t.Run("successfully creates new RoleBinding", func(t *testing.T) {
 		t.Parallel()
@@ -1392,7 +1384,7 @@ func TestUpsertRoleBinding(t *testing.T) {
 func TestUpsertRoleBindingWithOwnerReference(t *testing.T) {
 	t.Parallel()
 
-	scheme := setupTestScheme(t)
+	scheme := testutil.NewScheme(t)
 
 	t.Run("successfully creates RoleBinding with owner reference", func(t *testing.T) {
 		t.Parallel()
@@ -1623,7 +1615,7 @@ func TestNewClient(t *testing.T) {
 	t.Run("creates client successfully", func(t *testing.T) {
 		t.Parallel()
 
-		scheme := runtime.NewScheme()
+		scheme := testutil.NewScheme(t)
 		fakeClient := fake.NewClientBuilder().
 			WithScheme(scheme).
 			Build()
@@ -1637,7 +1629,7 @@ func TestNewClient(t *testing.T) {
 func TestEnsureRBACResources(t *testing.T) {
 	t.Parallel()
 
-	scheme := setupTestScheme(t)
+	scheme := testutil.NewScheme(t)
 
 	t.Run("creates all RBAC resources when none exist", func(t *testing.T) {
 		t.Parallel()
@@ -1938,7 +1930,7 @@ func TestEnsureRBACResources(t *testing.T) {
 func TestGetAllRBACResources(t *testing.T) {
 	t.Parallel()
 
-	scheme := setupTestScheme(t)
+	scheme := testutil.NewScheme(t)
 
 	t.Run("successfully retrieves all RBAC resources", func(t *testing.T) {
 		t.Parallel()

--- a/cmd/thv-operator/pkg/kubernetes/secrets/secrets_test.go
+++ b/cmd/thv-operator/pkg/kubernetes/secrets/secrets_test.go
@@ -12,17 +12,17 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 )
 
 func TestGet(t *testing.T) {
 	t.Parallel()
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, corev1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	t.Run("successfully retrieves existing secret", func(t *testing.T) {
 		t.Parallel()
@@ -115,8 +115,7 @@ func TestGet(t *testing.T) {
 func TestGetValue(t *testing.T) {
 	t.Parallel()
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, corev1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	t.Run("successfully retrieves secret value", func(t *testing.T) {
 		t.Parallel()
@@ -297,7 +296,7 @@ func TestNewClient(t *testing.T) {
 	t.Run("creates client successfully", func(t *testing.T) {
 		t.Parallel()
 
-		scheme := runtime.NewScheme()
+		scheme := testutil.NewScheme(t)
 		fakeClient := fake.NewClientBuilder().
 			WithScheme(scheme).
 			Build()
@@ -311,8 +310,7 @@ func TestNewClient(t *testing.T) {
 func TestUpsert(t *testing.T) {
 	t.Parallel()
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, corev1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	t.Run("successfully creates a new secret", func(t *testing.T) {
 		t.Parallel()
@@ -512,8 +510,7 @@ func TestUpsert(t *testing.T) {
 func TestUpsertWithOwnerReference(t *testing.T) {
 	t.Parallel()
 
-	scheme := runtime.NewScheme()
-	require.NoError(t, corev1.AddToScheme(scheme))
+	scheme := testutil.NewScheme(t)
 
 	t.Run("successfully creates secret with owner reference", func(t *testing.T) {
 		t.Parallel()

--- a/cmd/thv-operator/pkg/registryapi/manager_test.go
+++ b/cmd/thv-operator/pkg/registryapi/manager_test.go
@@ -14,14 +14,13 @@ import (
 	"go.uber.org/mock/gomock"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 	"github.com/stacklok/toolhive/cmd/thv-operator/pkg/imagepullsecrets"
 )
 
@@ -44,7 +43,7 @@ func TestNewManager(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 
-			scheme := runtime.NewScheme()
+			scheme := testutil.NewScheme(t)
 
 			// Create manager
 			manager := NewManager(nil, scheme, imagepullsecrets.Defaults{})
@@ -67,11 +66,7 @@ func TestReconcileAPIService(t *testing.T) {
 		defer ctrl.Finish()
 
 		// Create scheme and fake client
-		scheme := runtime.NewScheme()
-		_ = mcpv1beta1.AddToScheme(scheme)
-		_ = appsv1.AddToScheme(scheme)
-		_ = corev1.AddToScheme(scheme)
-		_ = rbacv1.AddToScheme(scheme)
+		scheme := testutil.NewScheme(t)
 
 		fakeClient := fake.NewClientBuilder().
 			WithScheme(scheme).
@@ -131,10 +126,7 @@ func TestReconcileAPIService(t *testing.T) {
 		defer ctrl.Finish()
 
 		// Create scheme and a client that will fail on ConfigMap operations
-		scheme := runtime.NewScheme()
-		_ = mcpv1beta1.AddToScheme(scheme)
-		_ = appsv1.AddToScheme(scheme)
-		_ = corev1.AddToScheme(scheme)
+		scheme := testutil.NewScheme(t)
 
 		// Create a fake client that will return an error when trying to create ConfigMaps
 		err := errors.New("simulated ConfigMap operation failure")

--- a/cmd/thv-operator/pkg/registryapi/rbac_test.go
+++ b/cmd/thv-operator/pkg/registryapi/rbac_test.go
@@ -13,13 +13,13 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 )
 
 func createTestMCPRegistry() *mcpv1beta1.MCPRegistry {
@@ -33,14 +33,6 @@ func createTestMCPRegistry() *mcpv1beta1.MCPRegistry {
 			ConfigYAML: "sources:\n  - name: default\n    format: toolhive\nregistries:\n  - name: default\n    sources: [\"default\"]\n",
 		},
 	}
-}
-
-func createTestScheme() *runtime.Scheme {
-	scheme := runtime.NewScheme()
-	_ = mcpv1beta1.AddToScheme(scheme)
-	_ = corev1.AddToScheme(scheme)
-	_ = rbacv1.AddToScheme(scheme)
-	return scheme
 }
 
 func TestEnsureRBACResources(t *testing.T) {
@@ -58,7 +50,7 @@ func TestEnsureRBACResources(t *testing.T) {
 			mcpRegistry: createTestMCPRegistry(),
 			setupClient: func(t *testing.T) client.Client {
 				t.Helper()
-				return fake.NewClientBuilder().WithScheme(createTestScheme()).Build()
+				return fake.NewClientBuilder().WithScheme(testutil.NewScheme(t)).Build()
 			},
 			validate: func(t *testing.T, c client.Client, mcpRegistry *mcpv1beta1.MCPRegistry) {
 				t.Helper()
@@ -100,7 +92,7 @@ func TestEnsureRBACResources(t *testing.T) {
 				mcpRegistry := createTestMCPRegistry()
 				resourceName := mcpRegistry.Name + "-registry-api"
 				return fake.NewClientBuilder().
-					WithScheme(createTestScheme()).
+					WithScheme(testutil.NewScheme(t)).
 					WithObjects(
 						&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: resourceName, Namespace: mcpRegistry.Namespace}},
 						&rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: resourceName, Namespace: mcpRegistry.Namespace}, Rules: registryAPIRBACRules},
@@ -121,7 +113,7 @@ func TestEnsureRBACResources(t *testing.T) {
 			setupClient: func(t *testing.T) client.Client {
 				t.Helper()
 				return fake.NewClientBuilder().
-					WithScheme(createTestScheme()).
+					WithScheme(testutil.NewScheme(t)).
 					WithInterceptorFuncs(interceptor.Funcs{
 						Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
 							if _, ok := obj.(*corev1.ServiceAccount); ok {
@@ -139,7 +131,7 @@ func TestEnsureRBACResources(t *testing.T) {
 			setupClient: func(t *testing.T) client.Client {
 				t.Helper()
 				return fake.NewClientBuilder().
-					WithScheme(createTestScheme()).
+					WithScheme(testutil.NewScheme(t)).
 					WithInterceptorFuncs(interceptor.Funcs{
 						Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
 							if _, ok := obj.(*rbacv1.Role); ok {
@@ -157,7 +149,7 @@ func TestEnsureRBACResources(t *testing.T) {
 			setupClient: func(t *testing.T) client.Client {
 				t.Helper()
 				return fake.NewClientBuilder().
-					WithScheme(createTestScheme()).
+					WithScheme(testutil.NewScheme(t)).
 					WithInterceptorFuncs(interceptor.Funcs{
 						Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
 							if _, ok := obj.(*rbacv1.RoleBinding); ok {
@@ -175,7 +167,7 @@ func TestEnsureRBACResources(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			c := tt.setupClient(t)
-			m := &manager{client: c, scheme: createTestScheme()}
+			m := &manager{client: c, scheme: testutil.NewScheme(t)}
 
 			err := m.ensureRBACResources(context.Background(), tt.mcpRegistry)
 
@@ -237,7 +229,7 @@ func TestEnsureRBACResources_ImagePullSecrets(t *testing.T) {
 		{Name: "extra-creds"},
 	}
 
-	scheme := createTestScheme()
+	scheme := testutil.NewScheme(t)
 	c := fake.NewClientBuilder().WithScheme(scheme).Build()
 	m := &manager{client: c, scheme: scheme}
 
@@ -281,7 +273,7 @@ func TestEnsureRBACResources_EmptyImagePullSecretsPreservesSAPullSecrets(t *test
 		},
 	}
 
-	scheme := createTestScheme()
+	scheme := testutil.NewScheme(t)
 	c := fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithObjects(mcpRegistry, preexistingSA).

--- a/cmd/thv-operator/pkg/vmcpconfig/converter_authz_configmap_test.go
+++ b/cmd/thv-operator/pkg/vmcpconfig/converter_authz_configmap_test.go
@@ -13,12 +13,12 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 	vmcpconfig "github.com/stacklok/toolhive/pkg/vmcp/config"
 )
 
@@ -111,10 +111,7 @@ func newCedarV1Payload(mutate func(m map[string]any)) string {
 // dependencies (OIDC resolver) and arbitrary k8s objects (ConfigMaps for authz).
 func converterWithObjects(t *testing.T, objects ...client.Object) *Converter {
 	t.Helper()
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-	require.NoError(t, corev1.AddToScheme(scheme))
-	k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
+	k8sClient := fake.NewClientBuilder().WithScheme(testutil.NewScheme(t)).WithObjects(objects...).Build()
 	converter, err := NewConverter(newNoOpMockResolver(t), k8sClient)
 	require.NoError(t, err)
 	return converter

--- a/cmd/thv-operator/pkg/vmcpconfig/converter_test.go
+++ b/cmd/thv-operator/pkg/vmcpconfig/converter_test.go
@@ -16,12 +16,12 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 	"github.com/stacklok/toolhive/cmd/thv-operator/pkg/controllerutil"
 	"github.com/stacklok/toolhive/cmd/thv-operator/pkg/oidc"
 	oidcmocks "github.com/stacklok/toolhive/cmd/thv-operator/pkg/oidc/mocks"
@@ -42,9 +42,7 @@ func newNoOpMockResolver(t *testing.T) *oidcmocks.MockResolver {
 // newTestK8sClient creates a fake Kubernetes client for testing.
 func newTestK8sClient(t *testing.T, objects ...client.Object) client.Client {
 	t.Helper()
-	scheme := runtime.NewScheme()
-	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
-	return fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
+	return fake.NewClientBuilder().WithScheme(testutil.NewScheme(t)).WithObjects(objects...).Build()
 }
 
 // newTestConverter creates a Converter with the given resolver, failing the test if creation fails.
@@ -454,13 +452,6 @@ func TestConverter_IncomingAuthRequired(t *testing.T) {
 	}
 }
 
-// createTestScheme creates a test scheme with required types
-func createTestScheme() *runtime.Scheme {
-	s := runtime.NewScheme()
-	_ = mcpv1beta1.AddToScheme(s)
-	return s
-}
-
 func TestConverter_CompositeToolRefs(t *testing.T) {
 	t.Parallel()
 
@@ -812,7 +803,7 @@ func TestConverter_CompositeToolRefs(t *testing.T) {
 				fakeClient = tt.k8sClient
 			} else {
 				// Create fake client with objects (or nil if we want to test nil client behavior)
-				testScheme := createTestScheme()
+				testScheme := testutil.NewScheme(t)
 				objects := []client.Object{tt.vmcp}
 				for _, def := range tt.compositeDefs {
 					objects = append(objects, def)
@@ -936,7 +927,7 @@ func TestConverter_CompositeToolDefinitionFieldsPreserved(t *testing.T) {
 	}
 
 	// Setup fake Kubernetes client
-	testScheme := createTestScheme()
+	testScheme := testutil.NewScheme(t)
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(testScheme).
 		WithObjects(vmcpServer, compositeDef).


### PR DESCRIPTION
## Summary

Operator unit tests hand-rolled `runtime.NewScheme()` + per-type `AddToScheme` blocks in ~57 files, plus 11 near-identical package-level scheme-builder helpers (`createTestScheme`, `newEntryScheme`, `authzScheme`, …). The same registration set was copy-pasted hundreds of times and drifted in which types each test bothered to register — exactly the kind of test-scaffolding duplication a DRY pass should remove.

This introduces a single shared helper and migrates every scheme-construction site to it.

<details>
<summary><strong>What changed</strong></summary>

- Add `cmd/thv-operator/internal/testutil/scheme.go` — `testutil.NewScheme(t, extra ...func(*runtime.Scheme) error)` registers the client-go built-in types plus both operator API versions (`v1beta1` + `v1alpha1`), with a variadic to layer on extras (e.g. `apiextensionsv1`) for the rare test that needs them.
- Add `scheme_test.go` covering the default registration set and the augment path.
- Migrate ~57 test files (controllers + `pkg/`) off inline `runtime.NewScheme()` blocks to `testutil.NewScheme(t)`.
- Delete 11 redundant package-level scheme builders and update all their callers.
- Net **+540 / −965 (−425 LOC)**. No behavior change — the built-in superset is a no-op for fake clients that don't use the extra types.

</details>

<details>
<summary><strong>File-level overview</strong></summary>

| Area | Change |
|------|--------|
| `cmd/thv-operator/internal/testutil/scheme.go` | New shared helper (the only non-test file) |
| `cmd/thv-operator/internal/testutil/scheme_test.go` | Helper unit tests |
| `controllers/*_test.go` (~40 files) | Inline scheme blocks → `testutil.NewScheme(t)`; 7 local builders deleted |
| `pkg/controllerutil/*_test.go` (10 files) | Inline blocks migrated; `authzScheme` deleted |
| `pkg/registryapi`, `pkg/vmcpconfig`, `pkg/kubernetes/{configmaps,secrets,rbac}` `*_test.go` | Inline blocks migrated; `createTestScheme`/`setupTestScheme` deleted |

</details>

## Type of change

- [x] Refactoring (no behavior change)

## Test plan

- [x] Unit tests (`task operator-test`) — passes (operator subset of `task test`; this PR touches only `cmd/thv-operator/`)
- [x] Linting (`task lint-fix`) — no issues in any file this PR touches

## Does this introduce a user-facing change?

No. Test-only change plus a test-only helper package (`internal/testutil`).

## Implementation plan

<details>
<summary>Approved implementation plan</summary>

Part of a larger DRY effort across `cmd/thv-operator/`. This PR is the first, lowest-risk slice:

1. Add `testutil.NewScheme(t, extra...)` — a single augmenting constructor (no separate builder fn, no option-type machinery; the repo's go-style "start without intermediate config types" rule applies).
2. Migrate all ~230 scheme-construction sites across ~57 files in one mechanical PR (test-only, identical-everywhere, so reviewable despite the file count).
3. Delete the 11 redundant local builders.

Follow-up slices (separate PRs): status-condition assertion helper, imagePullSecrets test consolidation, CRD fixture builders, and envtest `suite_test.go` consolidation.

</details>

## Large PR Justification

- A lot of find and replace, so very easy to review

## Special notes for reviewers

- **Mechanical, identical-everywhere change** — the 70-file count is large but the test-only diff is one find-and-replace pattern repeated. Migration was done by subagents and verified by a full operator test-binary compile + `task operator-test`.
- Two judgment calls worth a glance:
  - `schemeForCRD(t)` (storageversionmigrator) was **kept**, not inlined — it also calls `AddKnownTypeWithName(...)` for synthetic CR kinds; only its scheme construction was swapped to `testutil.NewScheme(t, apiextensionsv1.AddToScheme)`.
  - `setupTest` in `mcpserver_rbac_test.go` gained a `t *testing.T` first param (14 callers updated) since it previously lacked `t` in scope.
- **Heads-up on CI lint:** the branch base already carries 4 pre-existing lint failures (3 gosec, 1 staticcheck) in `mcpserver_controller.go`, `oauthproto/grants.go`, `vmcp/client/client.go`, `security/security.go` — none touched by this PR. They may show up in CI lint independent of this change.

Generated with [Claude Code](https://claude.com/claude-code)