### PR TITLE
Migrate VirtualMCPServer test fixtures to v1beta1test

### DIFF
--- a/cmd/thv-operator/controllers/mcpauthzconfig_controller_test.go
+++ b/cmd/thv-operator/controllers/mcpauthzconfig_controller_test.go
@@ -295,15 +295,12 @@ func TestMCPAuthzConfigReconciler_handleDeletion(t *testing.T) {
 			name:        "referencing VirtualMCPServer blocks deletion",
 			authzConfig: deletingConfig(),
 			existingWorkloads: []client.Object{
-				&mcpv1beta1.VirtualMCPServer{
-					ObjectMeta: metav1.ObjectMeta{Name: "referencing-vmcp", Namespace: "default"},
-					Spec: mcpv1beta1.VirtualMCPServerSpec{
-						IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-							Type:           "anonymous",
-							AuthzConfigRef: &mcpv1beta1.MCPAuthzConfigReference{Name: "test-config"},
-						},
-					},
-				},
+				v1beta1test.NewVirtualMCPServer("referencing-vmcp", "default",
+					v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+						Type:           "anonymous",
+						AuthzConfigRef: &mcpv1beta1.MCPAuthzConfigReference{Name: "test-config"},
+					}),
+				),
 			},
 			expectRequeue: true,
 		},
@@ -650,15 +647,12 @@ func TestMCPAuthzConfigReconciler_findReferencingWorkloads(t *testing.T) {
 					v1beta1test.WithImage("example/mcp:latest"),
 					v1beta1test.WithAuthzConfigRef("shared-config"),
 				),
-				&mcpv1beta1.VirtualMCPServer{
-					ObjectMeta: metav1.ObjectMeta{Name: "my-vmcp", Namespace: "default"},
-					Spec: mcpv1beta1.VirtualMCPServerSpec{
-						IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-							Type:           "anonymous",
-							AuthzConfigRef: &mcpv1beta1.MCPAuthzConfigReference{Name: "shared-config"},
-						},
-					},
-				},
+				v1beta1test.NewVirtualMCPServer("my-vmcp", "default",
+					v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+						Type:           "anonymous",
+						AuthzConfigRef: &mcpv1beta1.MCPAuthzConfigReference{Name: "shared-config"},
+					}),
+				),
 				v1beta1test.NewMCPRemoteProxy("my-proxy", "default",
 					v1beta1test.WithRemoteProxyURL("https://example.com"),
 					v1beta1test.WithRemoteProxyAuthzConfigRef("shared-config"),
@@ -678,12 +672,9 @@ func TestMCPAuthzConfigReconciler_findReferencingWorkloads(t *testing.T) {
 					v1beta1test.WithImage("example/mcp:latest"),
 					v1beta1test.WithAuthzConfigRef("other-config"),
 				),
-				&mcpv1beta1.VirtualMCPServer{
-					ObjectMeta: metav1.ObjectMeta{Name: "unrelated-vmcp", Namespace: "default"},
-					Spec: mcpv1beta1.VirtualMCPServerSpec{
-						IncomingAuth: &mcpv1beta1.IncomingAuthConfig{Type: "anonymous"},
-					},
-				},
+				v1beta1test.NewVirtualMCPServer("unrelated-vmcp", "default",
+					v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{Type: "anonymous"}),
+				),
 				v1beta1test.NewMCPRemoteProxy("unrelated-proxy", "default",
 					v1beta1test.WithRemoteProxyURL("https://example.com"),
 				),
@@ -750,15 +741,12 @@ func TestMCPAuthzConfigReconciler_watchHandlers(t *testing.T) {
 		},
 		{
 			name: "VirtualMCPServer with ref enqueues current and stale configs",
-			obj: &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{Name: "vmcp", Namespace: "default"},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-						Type:           "anonymous",
-						AuthzConfigRef: &mcpv1beta1.MCPAuthzConfigReference{Name: "current-config"},
-					},
-				},
-			},
+			obj: v1beta1test.NewVirtualMCPServer("vmcp", "default",
+				v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+					Type:           "anonymous",
+					AuthzConfigRef: &mcpv1beta1.MCPAuthzConfigReference{Name: "current-config"},
+				}),
+			),
 			expected: map[string]struct{}{"current-config": {}, "stale-config": {}},
 		},
 		{

--- a/cmd/thv-operator/controllers/virtualmcpserver_authz_configmap_test.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_authz_configmap_test.go
@@ -16,6 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1/v1beta1test"
 	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 )
 
@@ -26,62 +27,47 @@ func TestMapAuthzConfigMapToVirtualMCPServer(t *testing.T) {
 	const cmName = "shared-authz"
 
 	// vmcpWithConfigMapRef references cmName via configMap.
-	vmcpWithConfigMapRef := &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{Name: "vmcp-cm", Namespace: ns},
-		Spec: mcpv1beta1.VirtualMCPServerSpec{
-			IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-				Type: "oidc",
-				AuthzConfig: &mcpv1beta1.AuthzConfigRef{
-					Type:      mcpv1beta1.AuthzConfigTypeConfigMap,
-					ConfigMap: &mcpv1beta1.ConfigMapAuthzRef{Name: cmName, Key: "authz.json"},
-				},
+	vmcpWithConfigMapRef := v1beta1test.NewVirtualMCPServer("vmcp-cm", ns,
+		v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+			Type: "oidc",
+			AuthzConfig: &mcpv1beta1.AuthzConfigRef{
+				Type:      mcpv1beta1.AuthzConfigTypeConfigMap,
+				ConfigMap: &mcpv1beta1.ConfigMapAuthzRef{Name: cmName, Key: "authz.json"},
 			},
-		},
-	}
+		}),
+	)
 	// vmcpDifferentCM references a different ConfigMap by the same type.
-	vmcpDifferentCM := &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{Name: "vmcp-other-cm", Namespace: ns},
-		Spec: mcpv1beta1.VirtualMCPServerSpec{
-			IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-				Type: "oidc",
-				AuthzConfig: &mcpv1beta1.AuthzConfigRef{
-					Type:      mcpv1beta1.AuthzConfigTypeConfigMap,
-					ConfigMap: &mcpv1beta1.ConfigMapAuthzRef{Name: "other-authz"},
-				},
+	vmcpDifferentCM := v1beta1test.NewVirtualMCPServer("vmcp-other-cm", ns,
+		v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+			Type: "oidc",
+			AuthzConfig: &mcpv1beta1.AuthzConfigRef{
+				Type:      mcpv1beta1.AuthzConfigTypeConfigMap,
+				ConfigMap: &mcpv1beta1.ConfigMapAuthzRef{Name: "other-authz"},
 			},
-		},
-	}
+		}),
+	)
 	// vmcpInline uses inline authz — same name on Inline.something should not match.
-	vmcpInline := &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{Name: "vmcp-inline", Namespace: ns},
-		Spec: mcpv1beta1.VirtualMCPServerSpec{
-			IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-				Type: "oidc",
-				AuthzConfig: &mcpv1beta1.AuthzConfigRef{
-					Type:   mcpv1beta1.AuthzConfigTypeInline,
-					Inline: &mcpv1beta1.InlineAuthzConfig{Policies: []string{"permit(principal, action, resource);"}},
-				},
+	vmcpInline := v1beta1test.NewVirtualMCPServer("vmcp-inline", ns,
+		v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+			Type: "oidc",
+			AuthzConfig: &mcpv1beta1.AuthzConfigRef{
+				Type:   mcpv1beta1.AuthzConfigTypeInline,
+				Inline: &mcpv1beta1.InlineAuthzConfig{Policies: []string{"permit(principal, action, resource);"}},
 			},
-		},
-	}
+		}),
+	)
 	// vmcpNoIncomingAuth has no incoming auth configured.
-	vmcpNoIncomingAuth := &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{Name: "vmcp-no-auth", Namespace: ns},
-		Spec:       mcpv1beta1.VirtualMCPServerSpec{},
-	}
+	vmcpNoIncomingAuth := v1beta1test.NewVirtualMCPServer("vmcp-no-auth", ns)
 	// vmcpInOtherNamespace references the same name in a different namespace.
-	vmcpInOtherNamespace := &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{Name: "vmcp-other-ns", Namespace: "other"},
-		Spec: mcpv1beta1.VirtualMCPServerSpec{
-			IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-				Type: "oidc",
-				AuthzConfig: &mcpv1beta1.AuthzConfigRef{
-					Type:      mcpv1beta1.AuthzConfigTypeConfigMap,
-					ConfigMap: &mcpv1beta1.ConfigMapAuthzRef{Name: cmName},
-				},
+	vmcpInOtherNamespace := v1beta1test.NewVirtualMCPServer("vmcp-other-ns", "other",
+		v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+			Type: "oidc",
+			AuthzConfig: &mcpv1beta1.AuthzConfigRef{
+				Type:      mcpv1beta1.AuthzConfigTypeConfigMap,
+				ConfigMap: &mcpv1beta1.ConfigMapAuthzRef{Name: cmName},
 			},
-		},
-	}
+		}),
+	)
 
 	scheme := testutil.NewScheme(t)
 

--- a/cmd/thv-operator/controllers/virtualmcpserver_authz_validation_test.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_authz_validation_test.go
@@ -16,6 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1/v1beta1test"
 	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 	statusmocks "github.com/stacklok/toolhive/cmd/thv-operator/pkg/virtualmcpserverstatus/mocks"
 )
@@ -34,19 +35,16 @@ const validAuthzPayload = `{
 // authz ConfigMap. Other fields are omitted; tests only exercise the authz CM validation
 // path so most spec fields are not relevant.
 func vmcpWithAuthzConfigMap(cmName string) *mcpv1beta1.VirtualMCPServer {
-	return &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{Name: "vmcp", Namespace: "default"},
-		Spec: mcpv1beta1.VirtualMCPServerSpec{
-			GroupRef: &mcpv1beta1.MCPGroupRef{Name: "g"},
-			IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-				Type: "anonymous",
-				AuthzConfig: &mcpv1beta1.AuthzConfigRef{
-					Type:      mcpv1beta1.AuthzConfigTypeConfigMap,
-					ConfigMap: &mcpv1beta1.ConfigMapAuthzRef{Name: cmName, Key: "authz.json"},
-				},
+	return v1beta1test.NewVirtualMCPServer("vmcp", "default",
+		v1beta1test.WithVMCPGroupRef("g"),
+		v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+			Type: "anonymous",
+			AuthzConfig: &mcpv1beta1.AuthzConfigRef{
+				Type:      mcpv1beta1.AuthzConfigTypeConfigMap,
+				ConfigMap: &mcpv1beta1.ConfigMapAuthzRef{Name: cmName, Key: "authz.json"},
 			},
-		},
-	}
+		}),
+	)
 }
 
 // reconcilerWithObjects wires a VirtualMCPServerReconciler with a fake client containing
@@ -71,22 +69,19 @@ func TestValidateAuthzConfigMapRef(t *testing.T) {
 	}{
 		{
 			name:          "nil authzConfig is a no-op",
-			vmcp:          &mcpv1beta1.VirtualMCPServer{ObjectMeta: metav1.ObjectMeta{Name: "v", Namespace: "default"}},
+			vmcp:          v1beta1test.NewVirtualMCPServer("v", "default"),
 			expectNoError: true,
 		},
 		{
 			name: "inline authzConfig is a no-op",
-			vmcp: &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{Name: "v", Namespace: "default"},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-						AuthzConfig: &mcpv1beta1.AuthzConfigRef{
-							Type:   mcpv1beta1.AuthzConfigTypeInline,
-							Inline: &mcpv1beta1.InlineAuthzConfig{Policies: []string{"permit(principal, action, resource);"}},
-						},
+			vmcp: v1beta1test.NewVirtualMCPServer("v", "default",
+				v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+					AuthzConfig: &mcpv1beta1.AuthzConfigRef{
+						Type:   mcpv1beta1.AuthzConfigTypeInline,
+						Inline: &mcpv1beta1.InlineAuthzConfig{Policies: []string{"permit(principal, action, resource);"}},
 					},
-				},
-			},
+				}),
+			),
 			expectNoError: true,
 		},
 		{

--- a/cmd/thv-operator/controllers/virtualmcpserver_controller_test.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_controller_test.go
@@ -63,15 +63,9 @@ func TestVirtualMCPServerValidateGroupRef(t *testing.T) {
 	}{
 		{
 			name: "valid group ref with ready group",
-			vmcp: &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      testVmcpName,
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef: &mcpv1beta1.MCPGroupRef{Name: testGroupName},
-				},
-			},
+			vmcp: v1beta1test.NewVirtualMCPServer(testVmcpName, "default",
+				v1beta1test.WithVMCPGroupRef(testGroupName),
+			),
 			mcpGroup: &mcpv1beta1.MCPGroup{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      testGroupName,
@@ -101,30 +95,18 @@ func TestVirtualMCPServerValidateGroupRef(t *testing.T) {
 		},
 		{
 			name: "group ref not found",
-			vmcp: &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      testVmcpName,
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef: &mcpv1beta1.MCPGroupRef{Name: "missing-group"},
-				},
-			},
+			vmcp: v1beta1test.NewVirtualMCPServer(testVmcpName, "default",
+				v1beta1test.WithVMCPGroupRef("missing-group"),
+			),
 			expectError:    true,
 			expectedPhase:  mcpv1beta1.VirtualMCPServerPhaseFailed,
 			expectedReason: mcpv1beta1.ConditionReasonVirtualMCPServerGroupRefNotFound,
 		},
 		{
 			name: "group ref not ready",
-			vmcp: &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      testVmcpName,
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef: &mcpv1beta1.MCPGroupRef{Name: "pending-group"},
-				},
-			},
+			vmcp: v1beta1test.NewVirtualMCPServer(testVmcpName, "default",
+				v1beta1test.WithVMCPGroupRef("pending-group"),
+			),
 			mcpGroup: &mcpv1beta1.MCPGroup{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "pending-group",
@@ -192,15 +174,9 @@ func TestVirtualMCPServerValidateGroupRef(t *testing.T) {
 func TestVirtualMCPServerEnsureRBACResources(t *testing.T) {
 	t.Parallel()
 
-	vmcp := &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      testVmcpName,
-			Namespace: "default",
-		},
-		Spec: mcpv1beta1.VirtualMCPServerSpec{
-			GroupRef: &mcpv1beta1.MCPGroupRef{Name: testGroupName},
-		},
-	}
+	vmcp := v1beta1test.NewVirtualMCPServer(testVmcpName, "default",
+		v1beta1test.WithVMCPGroupRef(testGroupName),
+	)
 
 	scheme := testutil.NewScheme(t)
 
@@ -269,19 +245,15 @@ func TestVirtualMCPServerEnsureRBACResources(t *testing.T) {
 func TestVirtualMCPServerEnsureRBACResources_ImagePullSecrets(t *testing.T) {
 	t.Parallel()
 
-	vmcp := &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      testVmcpName,
-			Namespace: "default",
-		},
-		Spec: mcpv1beta1.VirtualMCPServerSpec{
-			GroupRef: &mcpv1beta1.MCPGroupRef{Name: testGroupName},
-			ImagePullSecrets: []corev1.LocalObjectReference{
+	vmcp := v1beta1test.NewVirtualMCPServer(testVmcpName, "default",
+		v1beta1test.WithVMCPGroupRef(testGroupName),
+		v1beta1test.MutateVMCP(func(v *mcpv1beta1.VirtualMCPServer) {
+			v.Spec.ImagePullSecrets = []corev1.LocalObjectReference{
 				{Name: "vmcp-creds"},
 				{Name: "extra-creds"},
-			},
-		},
-	}
+			}
+		}),
+	)
 
 	scheme := testutil.NewScheme(t)
 
@@ -313,16 +285,12 @@ func TestVirtualMCPServerEnsureRBACResources_ImagePullSecrets(t *testing.T) {
 func TestVirtualMCPServerEnsureRBACResources_Update(t *testing.T) {
 	t.Parallel()
 
-	vmcp := &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "update-vmcp",
-			Namespace: "default",
-			UID:       "test-uid",
-		},
-		Spec: mcpv1beta1.VirtualMCPServerSpec{
-			GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-		},
-	}
+	vmcp := v1beta1test.NewVirtualMCPServer("update-vmcp", "default",
+		v1beta1test.WithVMCPGroupRef("test-group"),
+		v1beta1test.MutateVMCP(func(v *mcpv1beta1.VirtualMCPServer) {
+			v.UID = "test-uid"
+		}),
+	)
 
 	scheme := testutil.NewScheme(t)
 
@@ -394,15 +362,9 @@ func TestVirtualMCPServerEnsureRBACResources_Update(t *testing.T) {
 func TestVirtualMCPServerEnsureRBACResources_Idempotency(t *testing.T) {
 	t.Parallel()
 
-	vmcp := &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "idempotent-vmcp",
-			Namespace: "default",
-		},
-		Spec: mcpv1beta1.VirtualMCPServerSpec{
-			GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-		},
-	}
+	vmcp := v1beta1test.NewVirtualMCPServer("idempotent-vmcp", "default",
+		v1beta1test.WithVMCPGroupRef("test-group"),
+	)
 
 	scheme := testutil.NewScheme(t)
 
@@ -453,19 +415,15 @@ func TestVirtualMCPServerEnsureRBACResources_Idempotency(t *testing.T) {
 func TestVirtualMCPServerEnsureRBACResources_InlineMode(t *testing.T) {
 	t.Parallel()
 
-	vmcp := &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "inline-mode-vmcp",
-			Namespace: "default",
-			UID:       "test-uid",
-		},
-		Spec: mcpv1beta1.VirtualMCPServerSpec{
-			GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-			OutgoingAuth: &mcpv1beta1.OutgoingAuthConfig{
-				Source: "inline",
-			},
-		},
-	}
+	vmcp := v1beta1test.NewVirtualMCPServer("inline-mode-vmcp", "default",
+		v1beta1test.WithVMCPGroupRef("test-group"),
+		v1beta1test.WithVMCPOutgoingAuth(&mcpv1beta1.OutgoingAuthConfig{
+			Source: "inline",
+		}),
+		v1beta1test.MutateVMCP(func(v *mcpv1beta1.VirtualMCPServer) {
+			v.UID = "test-uid"
+		}),
+	)
 
 	scheme := testutil.NewScheme(t)
 
@@ -520,19 +478,15 @@ func TestVirtualMCPServerEnsureRBACResources_InlineMode(t *testing.T) {
 func TestVirtualMCPServerEnsureRBACResources_DiscoveredMode(t *testing.T) {
 	t.Parallel()
 
-	vmcp := &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "discovered-mode-vmcp",
-			Namespace: "default",
-			UID:       "test-uid",
-		},
-		Spec: mcpv1beta1.VirtualMCPServerSpec{
-			GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-			OutgoingAuth: &mcpv1beta1.OutgoingAuthConfig{
-				Source: "discovered",
-			},
-		},
-	}
+	vmcp := v1beta1test.NewVirtualMCPServer("discovered-mode-vmcp", "default",
+		v1beta1test.WithVMCPGroupRef("test-group"),
+		v1beta1test.WithVMCPOutgoingAuth(&mcpv1beta1.OutgoingAuthConfig{
+			Source: "discovered",
+		}),
+		v1beta1test.MutateVMCP(func(v *mcpv1beta1.VirtualMCPServer) {
+			v.UID = "test-uid"
+		}),
+	)
 
 	scheme := testutil.NewScheme(t)
 
@@ -585,17 +539,13 @@ func TestVirtualMCPServerEnsureRBACResources_CustomServiceAccount(t *testing.T) 
 	t.Parallel()
 
 	customSA := "custom-vmcp-sa"
-	vmcp := &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "custom-sa-vmcp",
-			Namespace: "default",
-			UID:       "test-uid",
-		},
-		Spec: mcpv1beta1.VirtualMCPServerSpec{
-			GroupRef:       &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-			ServiceAccount: &customSA,
-		},
-	}
+	vmcp := v1beta1test.NewVirtualMCPServer("custom-sa-vmcp", "default",
+		v1beta1test.WithVMCPGroupRef("test-group"),
+		v1beta1test.WithVMCPServiceAccount(customSA),
+		v1beta1test.MutateVMCP(func(v *mcpv1beta1.VirtualMCPServer) {
+			v.UID = "test-uid"
+		}),
+	)
 
 	scheme := testutil.NewScheme(t)
 
@@ -642,15 +592,9 @@ func TestVirtualMCPServerEnsureRBACResources_CustomServiceAccount(t *testing.T) 
 func TestVirtualMCPServerEnsureDeployment(t *testing.T) {
 	t.Parallel()
 
-	vmcp := &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      testVmcpName,
-			Namespace: "default",
-		},
-		Spec: mcpv1beta1.VirtualMCPServerSpec{
-			GroupRef: &mcpv1beta1.MCPGroupRef{Name: testGroupName},
-		},
-	}
+	vmcp := v1beta1test.NewVirtualMCPServer(testVmcpName, "default",
+		v1beta1test.WithVMCPGroupRef(testGroupName),
+	)
 
 	// Create MCPGroup that the VirtualMCPServer references
 	mcpGroup := &mcpv1beta1.MCPGroup{
@@ -722,15 +666,9 @@ func TestVirtualMCPServerEnsureDeployment(t *testing.T) {
 func TestVirtualMCPServerEnsureService(t *testing.T) {
 	t.Parallel()
 
-	vmcp := &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      testVmcpName,
-			Namespace: "default",
-		},
-		Spec: mcpv1beta1.VirtualMCPServerSpec{
-			GroupRef: &mcpv1beta1.MCPGroupRef{Name: testGroupName},
-		},
-	}
+	vmcp := v1beta1test.NewVirtualMCPServer(testVmcpName, "default",
+		v1beta1test.WithVMCPGroupRef(testGroupName),
+	)
 
 	scheme := testutil.NewScheme(t)
 
@@ -799,16 +737,12 @@ func TestVirtualMCPServerServiceType(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			vmcp := &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      testVmcpName,
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef:    &mcpv1beta1.MCPGroupRef{Name: testGroupName},
-					ServiceType: tt.serviceType,
-				},
-			}
+			vmcp := v1beta1test.NewVirtualMCPServer(testVmcpName, "default",
+				v1beta1test.WithVMCPGroupRef(testGroupName),
+				v1beta1test.MutateVMCP(func(v *mcpv1beta1.VirtualMCPServer) {
+					v.Spec.ServiceType = tt.serviceType
+				}),
+			)
 
 			scheme := testutil.NewScheme(t)
 
@@ -828,16 +762,12 @@ func TestVirtualMCPServerServiceType(t *testing.T) {
 func TestVirtualMCPServerServiceNeedsUpdate(t *testing.T) {
 	t.Parallel()
 
-	baseVmcp := &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      testVmcpName,
-			Namespace: "default",
-		},
-		Spec: mcpv1beta1.VirtualMCPServerSpec{
-			GroupRef:    &mcpv1beta1.MCPGroupRef{Name: testGroupName},
-			ServiceType: "ClusterIP",
-		},
-	}
+	baseVmcp := v1beta1test.NewVirtualMCPServer(testVmcpName, "default",
+		v1beta1test.WithVMCPGroupRef(testGroupName),
+		v1beta1test.MutateVMCP(func(v *mcpv1beta1.VirtualMCPServer) {
+			v.Spec.ServiceType = "ClusterIP"
+		}),
+	)
 
 	baseService := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
@@ -959,12 +889,7 @@ func TestVirtualMCPServerUpdateStatus(t *testing.T) {
 	}{
 		{
 			name: "ready pods",
-			vmcp: &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      testVmcpName,
-					Namespace: "default",
-				},
-			},
+			vmcp: v1beta1test.NewVirtualMCPServer(testVmcpName, "default"),
 			pods: []corev1.Pod{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -987,12 +912,7 @@ func TestVirtualMCPServerUpdateStatus(t *testing.T) {
 		},
 		{
 			name: "running but not ready pods",
-			vmcp: &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      testVmcpName,
-					Namespace: "default",
-				},
-			},
+			vmcp: v1beta1test.NewVirtualMCPServer(testVmcpName, "default"),
 			pods: []corev1.Pod{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -1016,12 +936,7 @@ func TestVirtualMCPServerUpdateStatus(t *testing.T) {
 		},
 		{
 			name: "pending pods",
-			vmcp: &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      testVmcpName,
-					Namespace: "default",
-				},
-			},
+			vmcp: v1beta1test.NewVirtualMCPServer(testVmcpName, "default"),
 			pods: []corev1.Pod{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -1038,12 +953,7 @@ func TestVirtualMCPServerUpdateStatus(t *testing.T) {
 		},
 		{
 			name: "failed pods",
-			vmcp: &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      testVmcpName,
-					Namespace: "default",
-				},
-			},
+			vmcp: v1beta1test.NewVirtualMCPServer(testVmcpName, "default"),
 			pods: []corev1.Pod{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -1134,18 +1044,12 @@ func TestVirtualMCPServerAuthConfiguredCondition(t *testing.T) {
 	}{
 		{
 			name: "valid auth with no secrets required (anonymous)",
-			vmcp: &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      testVmcpName,
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef: &mcpv1beta1.MCPGroupRef{Name: testGroupName},
-					IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-						Type: "anonymous",
-					},
-				},
-			},
+			vmcp: v1beta1test.NewVirtualMCPServer(testVmcpName, "default",
+				v1beta1test.WithVMCPGroupRef(testGroupName),
+				v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+					Type: "anonymous",
+				}),
+			),
 			secrets:             []client.Object{},
 			expectAuthCondition: true,
 			expectedAuthStatus:  metav1.ConditionTrue,
@@ -1154,19 +1058,13 @@ func TestVirtualMCPServerAuthConfiguredCondition(t *testing.T) {
 		},
 		{
 			name: "OIDC with missing client secret via MCPOIDCConfig",
-			vmcp: &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      testVmcpName,
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef: &mcpv1beta1.MCPGroupRef{Name: testGroupName},
-					IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-						Type:          "oidc",
-						OIDCConfigRef: &mcpv1beta1.MCPOIDCConfigReference{Name: "test-oidc", Audience: "test-audience"},
-					},
-				},
-			},
+			vmcp: v1beta1test.NewVirtualMCPServer(testVmcpName, "default",
+				v1beta1test.WithVMCPGroupRef(testGroupName),
+				v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+					Type:          "oidc",
+					OIDCConfigRef: &mcpv1beta1.MCPOIDCConfigReference{Name: "test-oidc", Audience: "test-audience"},
+				}),
+			),
 			secrets: []client.Object{
 				&mcpv1beta1.MCPOIDCConfig{
 					ObjectMeta: metav1.ObjectMeta{Name: "test-oidc", Namespace: "default"},
@@ -1189,19 +1087,13 @@ func TestVirtualMCPServerAuthConfiguredCondition(t *testing.T) {
 		},
 		{
 			name: "OIDC with valid client secret via MCPOIDCConfig",
-			vmcp: &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      testVmcpName,
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef: &mcpv1beta1.MCPGroupRef{Name: testGroupName},
-					IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-						Type:          "oidc",
-						OIDCConfigRef: &mcpv1beta1.MCPOIDCConfigReference{Name: "test-oidc", Audience: "test-audience"},
-					},
-				},
-			},
+			vmcp: v1beta1test.NewVirtualMCPServer(testVmcpName, "default",
+				v1beta1test.WithVMCPGroupRef(testGroupName),
+				v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+					Type:          "oidc",
+					OIDCConfigRef: &mcpv1beta1.MCPOIDCConfigReference{Name: "test-oidc", Audience: "test-audience"},
+				}),
+			),
 			secrets: []client.Object{
 				&mcpv1beta1.MCPOIDCConfig{
 					ObjectMeta: metav1.ObjectMeta{Name: "test-oidc", Namespace: "default"},
@@ -1233,19 +1125,13 @@ func TestVirtualMCPServerAuthConfiguredCondition(t *testing.T) {
 		},
 		{
 			name: "OIDC secret exists but missing required key via MCPOIDCConfig",
-			vmcp: &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      testVmcpName,
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef: &mcpv1beta1.MCPGroupRef{Name: testGroupName},
-					IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-						Type:          "oidc",
-						OIDCConfigRef: &mcpv1beta1.MCPOIDCConfigReference{Name: "test-oidc", Audience: "test-audience"},
-					},
-				},
-			},
+			vmcp: v1beta1test.NewVirtualMCPServer(testVmcpName, "default",
+				v1beta1test.WithVMCPGroupRef(testGroupName),
+				v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+					Type:          "oidc",
+					OIDCConfigRef: &mcpv1beta1.MCPOIDCConfigReference{Name: "test-oidc", Audience: "test-audience"},
+				}),
+			),
 			secrets: []client.Object{
 				&mcpv1beta1.MCPOIDCConfig{
 					ObjectMeta: metav1.ObjectMeta{Name: "test-oidc", Namespace: "default"},
@@ -1356,16 +1242,12 @@ func TestVirtualMCPServerApplyStatusUpdates(t *testing.T) {
 		{
 			name: "successful status update",
 			setupVMCP: func() *mcpv1beta1.VirtualMCPServer {
-				return &mcpv1beta1.VirtualMCPServer{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:       testVmcpName,
-						Namespace:  "default",
-						Generation: 1,
-					},
-					Spec: mcpv1beta1.VirtualMCPServerSpec{
-						GroupRef: &mcpv1beta1.MCPGroupRef{Name: testGroupName},
-					},
-				}
+				return v1beta1test.NewVirtualMCPServer(testVmcpName, "default",
+					v1beta1test.WithVMCPGroupRef(testGroupName),
+					v1beta1test.MutateVMCP(func(v *mcpv1beta1.VirtualMCPServer) {
+						v.Generation = 1
+					}),
+				)
 			},
 			setupCollector: func(vmcp *mcpv1beta1.VirtualMCPServer) virtualmcpserverstatus.StatusManager {
 				collector := virtualmcpserverstatus.NewStatusManager(vmcp)
@@ -1379,16 +1261,12 @@ func TestVirtualMCPServerApplyStatusUpdates(t *testing.T) {
 		{
 			name: "no changes to apply",
 			setupVMCP: func() *mcpv1beta1.VirtualMCPServer {
-				return &mcpv1beta1.VirtualMCPServer{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:       testVmcpName,
-						Namespace:  "default",
-						Generation: 1,
-					},
-					Spec: mcpv1beta1.VirtualMCPServerSpec{
-						GroupRef: &mcpv1beta1.MCPGroupRef{Name: testGroupName},
-					},
-				}
+				return v1beta1test.NewVirtualMCPServer(testVmcpName, "default",
+					v1beta1test.WithVMCPGroupRef(testGroupName),
+					v1beta1test.MutateVMCP(func(v *mcpv1beta1.VirtualMCPServer) {
+						v.Generation = 1
+					}),
+				)
 			},
 			setupCollector: func(vmcp *mcpv1beta1.VirtualMCPServer) virtualmcpserverstatus.StatusManager {
 				return virtualmcpserverstatus.NewStatusManager(vmcp)
@@ -1399,16 +1277,12 @@ func TestVirtualMCPServerApplyStatusUpdates(t *testing.T) {
 		{
 			name: "batch update with multiple changes",
 			setupVMCP: func() *mcpv1beta1.VirtualMCPServer {
-				return &mcpv1beta1.VirtualMCPServer{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:       testVmcpName,
-						Namespace:  "default",
-						Generation: 1,
-					},
-					Spec: mcpv1beta1.VirtualMCPServerSpec{
-						GroupRef: &mcpv1beta1.MCPGroupRef{Name: testGroupName},
-					},
-				}
+				return v1beta1test.NewVirtualMCPServer(testVmcpName, "default",
+					v1beta1test.WithVMCPGroupRef(testGroupName),
+					v1beta1test.MutateVMCP(func(v *mcpv1beta1.VirtualMCPServer) {
+						v.Generation = 1
+					}),
+				)
 			},
 			setupCollector: func(vmcp *mcpv1beta1.VirtualMCPServer) virtualmcpserverstatus.StatusManager {
 				collector := virtualmcpserverstatus.NewStatusManager(vmcp)
@@ -1464,16 +1338,12 @@ func TestVirtualMCPServerApplyStatusUpdates_ResourceNotFound(t *testing.T) {
 
 	scheme := testutil.NewScheme(t)
 
-	vmcp := &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:       testVmcpName,
-			Namespace:  "default",
-			Generation: 1,
-		},
-		Spec: mcpv1beta1.VirtualMCPServerSpec{
-			GroupRef: &mcpv1beta1.MCPGroupRef{Name: testGroupName},
-		},
-	}
+	vmcp := v1beta1test.NewVirtualMCPServer(testVmcpName, "default",
+		v1beta1test.WithVMCPGroupRef(testGroupName),
+		v1beta1test.MutateVMCP(func(v *mcpv1beta1.VirtualMCPServer) {
+			v.Generation = 1
+		}),
+	)
 
 	// Create client WITHOUT the resource
 	k8sClient := fake.NewClientBuilder().
@@ -1506,16 +1376,12 @@ func TestVirtualMCPServerEnsureAllResources_Errors(t *testing.T) {
 		{
 			name: "no auth configured - valid",
 			setupVMCP: func() *mcpv1beta1.VirtualMCPServer {
-				return &mcpv1beta1.VirtualMCPServer{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:       testVmcpName,
-						Namespace:  "default",
-						Generation: 1,
-					},
-					Spec: mcpv1beta1.VirtualMCPServerSpec{
-						GroupRef: &mcpv1beta1.MCPGroupRef{Name: testGroupName},
-					},
-				}
+				return v1beta1test.NewVirtualMCPServer(testVmcpName, "default",
+					v1beta1test.WithVMCPGroupRef(testGroupName),
+					v1beta1test.MutateVMCP(func(v *mcpv1beta1.VirtualMCPServer) {
+						v.Generation = 1
+					}),
+				)
 			},
 			setupClient: func(_ *testing.T, vmcp *mcpv1beta1.VirtualMCPServer) client.Client {
 				scheme := testutil.NewScheme(t)
@@ -1573,15 +1439,9 @@ func TestVirtualMCPServerContainerNeedsUpdate(t *testing.T) {
 		Scheme: scheme,
 	}
 
-	vmcp := &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      testVmcpName,
-			Namespace: "default",
-		},
-		Spec: mcpv1beta1.VirtualMCPServerSpec{
-			GroupRef: &mcpv1beta1.MCPGroupRef{Name: testGroupName},
-		},
-	}
+	vmcp := v1beta1test.NewVirtualMCPServer(testVmcpName, "default",
+		v1beta1test.WithVMCPGroupRef(testGroupName),
+	)
 
 	tests := []struct {
 		name           string
@@ -1749,21 +1609,15 @@ func TestVirtualMCPServerContainerNeedsUpdate(t *testing.T) {
 					},
 				},
 			},
-			vmcp: &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      testVmcpName,
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef: &mcpv1beta1.MCPGroupRef{Name: testGroupName},
-					Config: vmcpconfig.Config{
-						Group: testGroupName,
-						Operational: &vmcpconfig.OperationalConfig{
-							LogLevel: "debug",
-						},
+			vmcp: v1beta1test.NewVirtualMCPServer(testVmcpName, "default",
+				v1beta1test.WithVMCPGroupRef(testGroupName),
+				v1beta1test.WithVMCPConfig(vmcpconfig.Config{
+					Group: testGroupName,
+					Operational: &vmcpconfig.OperationalConfig{
+						LogLevel: "debug",
 					},
-				},
-			},
+				}),
+			),
 			expectedUpdate: true,
 		},
 		{
@@ -1833,12 +1687,7 @@ func TestVirtualMCPServerDeploymentMetadataNeedsUpdate(t *testing.T) {
 
 	reconciler := &VirtualMCPServerReconciler{}
 
-	vmcp := &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      testVmcpName,
-			Namespace: "default",
-		},
-	}
+	vmcp := v1beta1test.NewVirtualMCPServer(testVmcpName, "default")
 
 	tests := []struct {
 		name           string
@@ -1920,12 +1769,7 @@ func TestVirtualMCPServerPodTemplateMetadataNeedsUpdate(t *testing.T) {
 		Scheme: scheme,
 	}
 
-	vmcp := &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      testVmcpName,
-			Namespace: "default",
-		},
-	}
+	vmcp := v1beta1test.NewVirtualMCPServer(testVmcpName, "default")
 
 	vmcpConfigChecksum := testChecksumValue
 	expectedLabels, expectedAnnotations := reconciler.buildPodTemplateMetadata(
@@ -2053,15 +1897,9 @@ func TestVirtualMCPServerDeploymentNeedsUpdate(t *testing.T) {
 		Scheme: scheme,
 	}
 
-	vmcp := &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      testVmcpName,
-			Namespace: "default",
-		},
-		Spec: mcpv1beta1.VirtualMCPServerSpec{
-			GroupRef: &mcpv1beta1.MCPGroupRef{Name: testGroupName},
-		},
-	}
+	vmcp := v1beta1test.NewVirtualMCPServer(testVmcpName, "default",
+		v1beta1test.WithVMCPGroupRef(testGroupName),
+	)
 
 	vmcpConfigChecksum := testChecksumValue
 	expectedLabels, expectedAnnotations := reconciler.buildPodTemplateMetadata(
@@ -2218,16 +2056,12 @@ func TestVirtualMCPServerDeploymentNeedsUpdate(t *testing.T) {
 func TestVirtualMCPServerReconcile_HappyPath(t *testing.T) {
 	t.Parallel()
 
-	vmcp := &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:       testVmcpName,
-			Namespace:  "default",
-			Generation: 1,
-		},
-		Spec: mcpv1beta1.VirtualMCPServerSpec{
-			GroupRef: &mcpv1beta1.MCPGroupRef{Name: testGroupName},
-		},
-	}
+	vmcp := v1beta1test.NewVirtualMCPServer(testVmcpName, "default",
+		v1beta1test.WithVMCPGroupRef(testGroupName),
+		v1beta1test.MutateVMCP(func(v *mcpv1beta1.VirtualMCPServer) {
+			v.Generation = 1
+		}),
+	)
 
 	mcpGroup := &mcpv1beta1.MCPGroup{
 		ObjectMeta: metav1.ObjectMeta{
@@ -2336,16 +2170,12 @@ func TestVirtualMCPServerReconcile_HappyPath(t *testing.T) {
 func TestVirtualMCPServerReconcile_ValidateGroupRefError(t *testing.T) {
 	t.Parallel()
 
-	vmcp := &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:       testVmcpName,
-			Namespace:  "default",
-			Generation: 1,
-		},
-		Spec: mcpv1beta1.VirtualMCPServerSpec{
-			GroupRef: &mcpv1beta1.MCPGroupRef{Name: "nonexistent-group"},
-		},
-	}
+	vmcp := v1beta1test.NewVirtualMCPServer(testVmcpName, "default",
+		v1beta1test.WithVMCPGroupRef("nonexistent-group"),
+		v1beta1test.MutateVMCP(func(v *mcpv1beta1.VirtualMCPServer) {
+			v.Generation = 1
+		}),
+	)
 
 	// Don't create the MCPGroup so validation fails
 	reconciler, k8sClient := newTestVirtualMCPServerReconciler(t, vmcp)
@@ -2377,16 +2207,12 @@ func TestVirtualMCPServerReconcile_ValidateGroupRefError(t *testing.T) {
 func TestVirtualMCPServerReconcile_GroupNotReady(t *testing.T) {
 	t.Parallel()
 
-	vmcp := &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:       testVmcpName,
-			Namespace:  "default",
-			Generation: 1,
-		},
-		Spec: mcpv1beta1.VirtualMCPServerSpec{
-			GroupRef: &mcpv1beta1.MCPGroupRef{Name: testGroupName},
-		},
-	}
+	vmcp := v1beta1test.NewVirtualMCPServer(testVmcpName, "default",
+		v1beta1test.WithVMCPGroupRef(testGroupName),
+		v1beta1test.MutateVMCP(func(v *mcpv1beta1.VirtualMCPServer) {
+			v.Generation = 1
+		}),
+	)
 
 	mcpGroup := &mcpv1beta1.MCPGroup{
 		ObjectMeta: metav1.ObjectMeta{
@@ -2459,15 +2285,9 @@ func TestVirtualMCPServerEnsureDeployment_ConfigMapNotFound(t *testing.T) {
 
 	scheme := testutil.NewScheme(t)
 
-	vmcp := &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      testVmcpName,
-			Namespace: "default",
-		},
-		Spec: mcpv1beta1.VirtualMCPServerSpec{
-			GroupRef: &mcpv1beta1.MCPGroupRef{Name: testGroupName},
-		},
-	}
+	vmcp := v1beta1test.NewVirtualMCPServer(testVmcpName, "default",
+		v1beta1test.WithVMCPGroupRef(testGroupName),
+	)
 
 	// Don't create ConfigMap - it won't be found
 	k8sClient := fake.NewClientBuilder().
@@ -2492,15 +2312,9 @@ func TestVirtualMCPServerEnsureDeployment_CreateDeployment(t *testing.T) {
 
 	scheme := testutil.NewScheme(t)
 
-	vmcp := &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      testVmcpName,
-			Namespace: "default",
-		},
-		Spec: mcpv1beta1.VirtualMCPServerSpec{
-			GroupRef: &mcpv1beta1.MCPGroupRef{Name: testGroupName},
-		},
-	}
+	vmcp := v1beta1test.NewVirtualMCPServer(testVmcpName, "default",
+		v1beta1test.WithVMCPGroupRef(testGroupName),
+	)
 
 	// Create ConfigMap so checksum can be retrieved
 	configMap := &corev1.ConfigMap{
@@ -2546,15 +2360,9 @@ func TestVirtualMCPServerEnsureDeployment_UpdateDeployment(t *testing.T) {
 
 	scheme := testutil.NewScheme(t)
 
-	vmcp := &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      testVmcpName,
-			Namespace: "default",
-		},
-		Spec: mcpv1beta1.VirtualMCPServerSpec{
-			GroupRef: &mcpv1beta1.MCPGroupRef{Name: testGroupName},
-		},
-	}
+	vmcp := v1beta1test.NewVirtualMCPServer(testVmcpName, "default",
+		v1beta1test.WithVMCPGroupRef(testGroupName),
+	)
 
 	configMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
@@ -2626,15 +2434,9 @@ func TestVirtualMCPServerEnsureDeployment_NoUpdateNeeded(t *testing.T) {
 
 	scheme := testutil.NewScheme(t)
 
-	vmcp := &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      testVmcpName,
-			Namespace: "default",
-		},
-		Spec: mcpv1beta1.VirtualMCPServerSpec{
-			GroupRef: &mcpv1beta1.MCPGroupRef{Name: testGroupName},
-		},
-	}
+	vmcp := v1beta1test.NewVirtualMCPServer(testVmcpName, "default",
+		v1beta1test.WithVMCPGroupRef(testGroupName),
+	)
 
 	configMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
@@ -2710,15 +2512,9 @@ func TestVirtualMCPServerEnsureService_CreateService(t *testing.T) {
 
 	scheme := testutil.NewScheme(t)
 
-	vmcp := &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      testVmcpName,
-			Namespace: "default",
-		},
-		Spec: mcpv1beta1.VirtualMCPServerSpec{
-			GroupRef: &mcpv1beta1.MCPGroupRef{Name: testGroupName},
-		},
-	}
+	vmcp := v1beta1test.NewVirtualMCPServer(testVmcpName, "default",
+		v1beta1test.WithVMCPGroupRef(testGroupName),
+	)
 
 	k8sClient := fake.NewClientBuilder().
 		WithScheme(scheme).
@@ -2750,16 +2546,12 @@ func TestVirtualMCPServerEnsureService_UpdateService(t *testing.T) {
 
 	scheme := testutil.NewScheme(t)
 
-	vmcp := &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      testVmcpName,
-			Namespace: "default",
-		},
-		Spec: mcpv1beta1.VirtualMCPServerSpec{
-			GroupRef:    &mcpv1beta1.MCPGroupRef{Name: testGroupName},
-			ServiceType: "LoadBalancer",
-		},
-	}
+	vmcp := v1beta1test.NewVirtualMCPServer(testVmcpName, "default",
+		v1beta1test.WithVMCPGroupRef(testGroupName),
+		v1beta1test.MutateVMCP(func(v *mcpv1beta1.VirtualMCPServer) {
+			v.Spec.ServiceType = "LoadBalancer"
+		}),
+	)
 
 	// Create existing service with wrong type
 	oldService := &corev1.Service{
@@ -2810,15 +2602,9 @@ func TestVirtualMCPServerEnsureService_NoUpdateNeeded(t *testing.T) {
 
 	scheme := testutil.NewScheme(t)
 
-	vmcp := &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      testVmcpName,
-			Namespace: "default",
-		},
-		Spec: mcpv1beta1.VirtualMCPServerSpec{
-			GroupRef: &mcpv1beta1.MCPGroupRef{Name: testGroupName},
-		},
-	}
+	vmcp := v1beta1test.NewVirtualMCPServer(testVmcpName, "default",
+		v1beta1test.WithVMCPGroupRef(testGroupName),
+	)
 
 	// Create service matching current spec
 	correctService := &corev1.Service{
@@ -2872,31 +2658,17 @@ func TestVirtualMCPServerValidateEmbeddingServerRef(t *testing.T) {
 	}{
 		{
 			name: "no ref configured (skip validation)",
-			vmcp: &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      testVmcpName,
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef: &mcpv1beta1.MCPGroupRef{Name: testGroupName},
-				},
-			},
+			vmcp: v1beta1test.NewVirtualMCPServer(testVmcpName, "default",
+				v1beta1test.WithVMCPGroupRef(testGroupName),
+			),
 			expectError: false,
 		},
 		{
 			name: "referenced EmbeddingServer exists and is running",
-			vmcp: &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      testVmcpName,
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef: &mcpv1beta1.MCPGroupRef{Name: testGroupName},
-					EmbeddingServerRef: &mcpv1beta1.EmbeddingServerRef{
-						Name: "shared-embedding",
-					},
-				},
-			},
+			vmcp: v1beta1test.NewVirtualMCPServer(testVmcpName, "default",
+				v1beta1test.WithVMCPGroupRef(testGroupName),
+				v1beta1test.WithVMCPEmbeddingServerRef("shared-embedding"),
+			),
 			embeddingServer: v1beta1test.NewEmbeddingServer("shared-embedding", "default",
 				v1beta1test.WithEmbeddingStatus(mcpv1beta1.EmbeddingServerStatus{
 					Phase:         mcpv1beta1.EmbeddingServerPhaseReady,
@@ -2907,36 +2679,20 @@ func TestVirtualMCPServerValidateEmbeddingServerRef(t *testing.T) {
 		},
 		{
 			name: "referenced EmbeddingServer not found",
-			vmcp: &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      testVmcpName,
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef: &mcpv1beta1.MCPGroupRef{Name: testGroupName},
-					EmbeddingServerRef: &mcpv1beta1.EmbeddingServerRef{
-						Name: "missing-embedding",
-					},
-				},
-			},
+			vmcp: v1beta1test.NewVirtualMCPServer(testVmcpName, "default",
+				v1beta1test.WithVMCPGroupRef(testGroupName),
+				v1beta1test.WithVMCPEmbeddingServerRef("missing-embedding"),
+			),
 			expectError:    true,
 			expectedPhase:  mcpv1beta1.VirtualMCPServerPhaseFailed,
 			expectedReason: mcpv1beta1.ConditionReasonEmbeddingServerNotFound,
 		},
 		{
 			name: "referenced EmbeddingServer exists but not ready (pending) - existence validated",
-			vmcp: &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      testVmcpName,
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef: &mcpv1beta1.MCPGroupRef{Name: testGroupName},
-					EmbeddingServerRef: &mcpv1beta1.EmbeddingServerRef{
-						Name: "pending-embedding",
-					},
-				},
-			},
+			vmcp: v1beta1test.NewVirtualMCPServer(testVmcpName, "default",
+				v1beta1test.WithVMCPGroupRef(testGroupName),
+				v1beta1test.WithVMCPEmbeddingServerRef("pending-embedding"),
+			),
 			embeddingServer: v1beta1test.NewEmbeddingServer("pending-embedding", "default",
 				v1beta1test.WithEmbeddingStatus(mcpv1beta1.EmbeddingServerStatus{
 					Phase:         mcpv1beta1.EmbeddingServerPhasePending,
@@ -2947,18 +2703,10 @@ func TestVirtualMCPServerValidateEmbeddingServerRef(t *testing.T) {
 		},
 		{
 			name: "referenced EmbeddingServer running but zero ready replicas - existence validated",
-			vmcp: &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      testVmcpName,
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef: &mcpv1beta1.MCPGroupRef{Name: testGroupName},
-					EmbeddingServerRef: &mcpv1beta1.EmbeddingServerRef{
-						Name: "no-replicas-embedding",
-					},
-				},
-			},
+			vmcp: v1beta1test.NewVirtualMCPServer(testVmcpName, "default",
+				v1beta1test.WithVMCPGroupRef(testGroupName),
+				v1beta1test.WithVMCPEmbeddingServerRef("no-replicas-embedding"),
+			),
 			embeddingServer: v1beta1test.NewEmbeddingServer("no-replicas-embedding", "default",
 				v1beta1test.WithEmbeddingStatus(mcpv1beta1.EmbeddingServerStatus{
 					Phase:         mcpv1beta1.EmbeddingServerPhaseReady,
@@ -3025,16 +2773,10 @@ func TestVirtualMCPServerEnsureDeployment_ReplicaSync_SpecDriven(t *testing.T) {
 	t.Parallel()
 
 	specReplicas := int32(3)
-	vmcp := &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "vmcp-replica-sync",
-			Namespace: "default",
-		},
-		Spec: mcpv1beta1.VirtualMCPServerSpec{
-			GroupRef: &mcpv1beta1.MCPGroupRef{Name: testGroupName},
-			Replicas: &specReplicas,
-		},
-	}
+	vmcp := v1beta1test.NewVirtualMCPServer("vmcp-replica-sync", "default",
+		v1beta1test.WithVMCPGroupRef(testGroupName),
+		v1beta1test.WithVMCPReplicas(specReplicas),
+	)
 
 	mcpGroup := &mcpv1beta1.MCPGroup{
 		ObjectMeta: metav1.ObjectMeta{Name: testGroupName, Namespace: "default"},
@@ -3101,16 +2843,10 @@ func TestVirtualMCPServerEnsureDeployment_ReplicaSync_SpecDriven(t *testing.T) {
 func TestVirtualMCPServerEnsureDeployment_ReplicaSync_NilPassthrough(t *testing.T) {
 	t.Parallel()
 
-	vmcp := &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "vmcp-nil-passthrough",
-			Namespace: "default",
-		},
-		Spec: mcpv1beta1.VirtualMCPServerSpec{
-			GroupRef: &mcpv1beta1.MCPGroupRef{Name: testGroupName},
-			Replicas: nil, // HPA manages replicas
-		},
-	}
+	// Replicas left nil — HPA manages replicas.
+	vmcp := v1beta1test.NewVirtualMCPServer("vmcp-nil-passthrough", "default",
+		v1beta1test.WithVMCPGroupRef(testGroupName),
+	)
 
 	mcpGroup := &mcpv1beta1.MCPGroup{
 		ObjectMeta: metav1.ObjectMeta{Name: testGroupName, Namespace: "default"},
@@ -3533,18 +3269,14 @@ func TestVirtualMCPServerValidateAuthzUpstreamAvailable(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			vmcp := &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:       testVmcpName,
-					Namespace:  "default",
-					Generation: 1,
-				},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef:         &mcpv1beta1.MCPGroupRef{Name: testGroupName},
-					IncomingAuth:     tt.incomingAuth,
-					AuthServerConfig: tt.authServerConfig,
-				},
-			}
+			vmcp := v1beta1test.NewVirtualMCPServer(testVmcpName, "default",
+				v1beta1test.WithVMCPGroupRef(testGroupName),
+				v1beta1test.WithVMCPIncomingAuth(tt.incomingAuth),
+				v1beta1test.WithVMCPAuthServerConfig(tt.authServerConfig),
+				v1beta1test.MutateVMCP(func(v *mcpv1beta1.VirtualMCPServer) {
+					v.Generation = 1
+				}),
+			)
 
 			r := &VirtualMCPServerReconciler{}
 			statusManager := virtualmcpserverstatus.NewStatusManager(vmcp)
@@ -3720,21 +3452,17 @@ func TestVirtualMCPServerValidateAuthzUpstreamAvailable_DeprecationEvent(t *test
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			vmcp := &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:       testVmcpName,
-					Namespace:  "default",
-					Generation: 1,
-				},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef:         &mcpv1beta1.MCPGroupRef{Name: testGroupName},
-					IncomingAuth:     tt.incomingAuth,
-					AuthServerConfig: tt.authServerConfig,
-				},
-				Status: mcpv1beta1.VirtualMCPServerStatus{
+			vmcp := v1beta1test.NewVirtualMCPServer(testVmcpName, "default",
+				v1beta1test.WithVMCPGroupRef(testGroupName),
+				v1beta1test.WithVMCPIncomingAuth(tt.incomingAuth),
+				v1beta1test.WithVMCPAuthServerConfig(tt.authServerConfig),
+				v1beta1test.WithVMCPStatus(mcpv1beta1.VirtualMCPServerStatus{
 					ObservedGeneration: tt.observedGeneration,
-				},
-			}
+				}),
+				v1beta1test.MutateVMCP(func(v *mcpv1beta1.VirtualMCPServer) {
+					v.Generation = 1
+				}),
+			)
 
 			recorder := events.NewFakeRecorder(10)
 			r := &VirtualMCPServerReconciler{Recorder: recorder}
@@ -3779,29 +3507,22 @@ func TestVirtualMCPServerValidateAuthzUpstreamAvailable_ClearsStaleWarning(t *te
 		},
 	}
 
-	vmcp := &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:       testVmcpName,
-			Namespace:  "default",
-			Generation: 2,
-		},
-		Spec: mcpv1beta1.VirtualMCPServerSpec{
-			GroupRef: &mcpv1beta1.MCPGroupRef{Name: testGroupName},
-			IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-				Type:        "oidc",
-				AuthzConfig: inlineAuthzRef,
+	vmcp := v1beta1test.NewVirtualMCPServer(testVmcpName, "default",
+		v1beta1test.WithVMCPGroupRef(testGroupName),
+		v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+			Type:        "oidc",
+			AuthzConfig: inlineAuthzRef,
+		}),
+		// Single upstream now — the advisory should be cleared.
+		v1beta1test.WithVMCPAuthServerConfig(&mcpv1beta1.EmbeddedAuthServerConfig{
+			Issuer: "https://authserver.example.com",
+			UpstreamProviders: []mcpv1beta1.UpstreamProviderConfig{
+				{Name: "okta", Type: mcpv1beta1.UpstreamProviderTypeOIDC},
 			},
-			// Single upstream now — the advisory should be cleared.
-			AuthServerConfig: &mcpv1beta1.EmbeddedAuthServerConfig{
-				Issuer: "https://authserver.example.com",
-				UpstreamProviders: []mcpv1beta1.UpstreamProviderConfig{
-					{Name: "okta", Type: mcpv1beta1.UpstreamProviderTypeOIDC},
-				},
-			},
-		},
-		Status: mcpv1beta1.VirtualMCPServerStatus{
-			// Simulate a stale True advisory from a previous multi-upstream
-			// reconciliation.
+		}),
+		// Simulate a stale True advisory from a previous multi-upstream
+		// reconciliation.
+		v1beta1test.WithVMCPStatus(mcpv1beta1.VirtualMCPServerStatus{
 			Conditions: []metav1.Condition{
 				{
 					Type:    mcpv1beta1.ConditionTypeAuthzUpstreamSelectionWarning,
@@ -3810,8 +3531,11 @@ func TestVirtualMCPServerValidateAuthzUpstreamAvailable_ClearsStaleWarning(t *te
 					Message: `multiple upstreamProviders configured; Cedar policies will evaluate claims from the first upstream ("okta").`,
 				},
 			},
-		},
-	}
+		}),
+		v1beta1test.MutateVMCP(func(v *mcpv1beta1.VirtualMCPServer) {
+			v.Generation = 2
+		}),
+	)
 
 	r := &VirtualMCPServerReconciler{}
 	statusManager := virtualmcpserverstatus.NewStatusManager(vmcp)
@@ -3845,27 +3569,23 @@ func TestVirtualMCPServerValidateAuthzUpstreamAvailable_ConfigMapFallThrough(t *
 		},
 	}
 
-	vmcp := &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:       testVmcpName,
-			Namespace:  "default",
-			Generation: 1,
-		},
-		Spec: mcpv1beta1.VirtualMCPServerSpec{
-			GroupRef: &mcpv1beta1.MCPGroupRef{Name: testGroupName},
-			IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-				Type:        "oidc",
-				AuthzConfig: configMapAuthzRef,
+	vmcp := v1beta1test.NewVirtualMCPServer(testVmcpName, "default",
+		v1beta1test.WithVMCPGroupRef(testGroupName),
+		v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+			Type:        "oidc",
+			AuthzConfig: configMapAuthzRef,
+		}),
+		v1beta1test.WithVMCPAuthServerConfig(&mcpv1beta1.EmbeddedAuthServerConfig{
+			Issuer: "https://authserver.example.com",
+			UpstreamProviders: []mcpv1beta1.UpstreamProviderConfig{
+				{Name: "okta", Type: mcpv1beta1.UpstreamProviderTypeOIDC},
+				{Name: "entra", Type: mcpv1beta1.UpstreamProviderTypeOIDC},
 			},
-			AuthServerConfig: &mcpv1beta1.EmbeddedAuthServerConfig{
-				Issuer: "https://authserver.example.com",
-				UpstreamProviders: []mcpv1beta1.UpstreamProviderConfig{
-					{Name: "okta", Type: mcpv1beta1.UpstreamProviderTypeOIDC},
-					{Name: "entra", Type: mcpv1beta1.UpstreamProviderTypeOIDC},
-				},
-			},
-		},
-	}
+		}),
+		v1beta1test.MutateVMCP(func(v *mcpv1beta1.VirtualMCPServer) {
+			v.Generation = 1
+		}),
+	)
 
 	r := &VirtualMCPServerReconciler{}
 	statusManager := virtualmcpserverstatus.NewStatusManager(vmcp)
@@ -3928,28 +3648,21 @@ func TestVirtualMCPServerValidateAuthzUpstreamAvailable_ClearsStaleAuthzUnknown(
 				},
 			}
 
-			vmcp := &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:       testVmcpName,
-					Namespace:  "default",
-					Generation: 2,
-				},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef: &mcpv1beta1.MCPGroupRef{Name: testGroupName},
-					IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-						Type:        "oidc",
-						AuthzConfig: authzRef,
+			vmcp := v1beta1test.NewVirtualMCPServer(testVmcpName, "default",
+				v1beta1test.WithVMCPGroupRef(testGroupName),
+				v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+					Type:        "oidc",
+					AuthzConfig: authzRef,
+				}),
+				// Spec is now valid: explicit "okta" matches the single declared upstream.
+				v1beta1test.WithVMCPAuthServerConfig(&mcpv1beta1.EmbeddedAuthServerConfig{
+					Issuer: "https://authserver.example.com",
+					UpstreamProviders: []mcpv1beta1.UpstreamProviderConfig{
+						{Name: "okta", Type: mcpv1beta1.UpstreamProviderTypeOIDC},
 					},
-					// Spec is now valid: explicit "okta" matches the single declared upstream.
-					AuthServerConfig: &mcpv1beta1.EmbeddedAuthServerConfig{
-						Issuer: "https://authserver.example.com",
-						UpstreamProviders: []mcpv1beta1.UpstreamProviderConfig{
-							{Name: "okta", Type: mcpv1beta1.UpstreamProviderTypeOIDC},
-						},
-						PrimaryUpstreamProvider: "okta",
-					},
-				},
-				Status: mcpv1beta1.VirtualMCPServerStatus{
+					PrimaryUpstreamProvider: "okta",
+				}),
+				v1beta1test.WithVMCPStatus(mcpv1beta1.VirtualMCPServerStatus{
 					Phase: mcpv1beta1.VirtualMCPServerPhaseFailed,
 					Conditions: []metav1.Condition{
 						{
@@ -3959,8 +3672,11 @@ func TestVirtualMCPServerValidateAuthzUpstreamAvailable_ClearsStaleAuthzUnknown(
 							Message: "previous rejection from before the spec was fixed",
 						},
 					},
-				},
-			}
+				}),
+				v1beta1test.MutateVMCP(func(v *mcpv1beta1.VirtualMCPServer) {
+					v.Generation = 2
+				}),
+			)
 
 			r := &VirtualMCPServerReconciler{}
 			statusManager := virtualmcpserverstatus.NewStatusManager(vmcp)
@@ -4033,20 +3749,16 @@ func TestVirtualMCPServerValidateAuthServerConfig_IdentitySynthesizedCondition(t
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			vmcp := &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:       testVmcpName,
-					Namespace:  "default",
-					Generation: 1,
-				},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef: &mcpv1beta1.MCPGroupRef{Name: testGroupName},
-					AuthServerConfig: &mcpv1beta1.EmbeddedAuthServerConfig{
-						Issuer:            "https://authserver.example.com",
-						UpstreamProviders: tt.upstreams,
-					},
-				},
-			}
+			vmcp := v1beta1test.NewVirtualMCPServer(testVmcpName, "default",
+				v1beta1test.WithVMCPGroupRef(testGroupName),
+				v1beta1test.WithVMCPAuthServerConfig(&mcpv1beta1.EmbeddedAuthServerConfig{
+					Issuer:            "https://authserver.example.com",
+					UpstreamProviders: tt.upstreams,
+				}),
+				v1beta1test.MutateVMCP(func(v *mcpv1beta1.VirtualMCPServer) {
+					v.Generation = 1
+				}),
+			)
 
 			r := &VirtualMCPServerReconciler{}
 			statusManager := virtualmcpserverstatus.NewStatusManager(vmcp)
@@ -4090,20 +3802,16 @@ func TestVirtualMCPServerReconciler_IdentitySynthesizedTransitionsOnValidationFa
 		},
 	}
 
-	vmcp := &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:       testVmcpName,
-			Namespace:  "default",
-			Generation: 1,
-		},
-		Spec: mcpv1beta1.VirtualMCPServerSpec{
-			GroupRef: &mcpv1beta1.MCPGroupRef{Name: testGroupName},
-			AuthServerConfig: &mcpv1beta1.EmbeddedAuthServerConfig{
-				Issuer:            "https://authserver.example.com",
-				UpstreamProviders: []mcpv1beta1.UpstreamProviderConfig{syntheticUpstream},
-			},
-		},
-	}
+	vmcp := v1beta1test.NewVirtualMCPServer(testVmcpName, "default",
+		v1beta1test.WithVMCPGroupRef(testGroupName),
+		v1beta1test.WithVMCPAuthServerConfig(&mcpv1beta1.EmbeddedAuthServerConfig{
+			Issuer:            "https://authserver.example.com",
+			UpstreamProviders: []mcpv1beta1.UpstreamProviderConfig{syntheticUpstream},
+		}),
+		v1beta1test.MutateVMCP(func(v *mcpv1beta1.VirtualMCPServer) {
+			v.Generation = 1
+		}),
+	)
 
 	r := &VirtualMCPServerReconciler{}
 

--- a/cmd/thv-operator/controllers/virtualmcpserver_default_imagepullsecrets_test.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_default_imagepullsecrets_test.go
@@ -9,11 +9,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1/v1beta1test"
 	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 	ctrlutil "github.com/stacklok/toolhive/cmd/thv-operator/pkg/controllerutil"
 	"github.com/stacklok/toolhive/cmd/thv-operator/pkg/imagepullsecrets"
@@ -59,16 +59,12 @@ func TestVirtualMCPServer_DefaultImagePullSecrets(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			vmcp := &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "default-pullsecrets-vmcp",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef:         &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-					ImagePullSecrets: tt.crSecrets,
-				},
-			}
+			vmcp := v1beta1test.NewVirtualMCPServer("default-pullsecrets-vmcp", "default",
+				v1beta1test.WithVMCPGroupRef("test-group"),
+				v1beta1test.MutateVMCP(func(v *mcpv1beta1.VirtualMCPServer) {
+					v.Spec.ImagePullSecrets = tt.crSecrets
+				}),
+			)
 
 			scheme := testutil.NewScheme(t)
 

--- a/cmd/thv-operator/controllers/virtualmcpserver_deployment_test.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_deployment_test.go
@@ -30,6 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1/v1beta1test"
 	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 	ctrlutil "github.com/stacklok/toolhive/cmd/thv-operator/pkg/controllerutil"
 	"github.com/stacklok/toolhive/cmd/thv-operator/pkg/runconfig/configmap/checksum"
@@ -41,15 +42,9 @@ import (
 func TestDeploymentForVirtualMCPServer(t *testing.T) {
 	t.Parallel()
 
-	vmcp := &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-vmcp",
-			Namespace: "default",
-		},
-		Spec: mcpv1beta1.VirtualMCPServerSpec{
-			GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-		},
-	}
+	vmcp := v1beta1test.NewVirtualMCPServer("test-vmcp", "default",
+		v1beta1test.WithVMCPGroupRef("test-group"),
+	)
 
 	scheme := testutil.NewScheme(t)
 
@@ -98,20 +93,14 @@ func TestDeploymentForVirtualMCPServer_WithRedisPassword(t *testing.T) {
 
 	passwordRef := &mcpv1beta1.SecretKeyRef{Name: "redis-secret", Key: "password"}
 
-	vmcp := &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-vmcp-redis",
-			Namespace: "default",
-		},
-		Spec: mcpv1beta1.VirtualMCPServerSpec{
-			GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-			SessionStorage: &mcpv1beta1.SessionStorageConfig{
-				Provider:    mcpv1beta1.SessionStorageProviderRedis,
-				Address:     "redis:6379",
-				PasswordRef: passwordRef,
-			},
-		},
-	}
+	vmcp := v1beta1test.NewVirtualMCPServer("test-vmcp-redis", "default",
+		v1beta1test.WithVMCPGroupRef("test-group"),
+		v1beta1test.WithVMCPSessionStorage(&mcpv1beta1.SessionStorageConfig{
+			Provider:    mcpv1beta1.SessionStorageProviderRedis,
+			Address:     "redis:6379",
+			PasswordRef: passwordRef,
+		}),
+	)
 
 	scheme := testutil.NewScheme(t)
 
@@ -150,33 +139,21 @@ func TestBuildContainerArgsForVmcp(t *testing.T) {
 	}{
 		{
 			name: "without log level",
-			vmcp: &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-vmcp",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-				},
-			},
+			vmcp: v1beta1test.NewVirtualMCPServer("test-vmcp", "default",
+				v1beta1test.WithVMCPGroupRef("test-group"),
+			),
 			wantArgs: []string{"serve", "--config=/etc/vmcp-config/config.yaml", "--host=0.0.0.0", "--port=4483"},
 		},
 		{
 			name: "with log level debug",
-			vmcp: &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-vmcp",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-					Config: vmcpconfig.Config{
-						Operational: &vmcpconfig.OperationalConfig{
-							LogLevel: "debug",
-						},
+			vmcp: v1beta1test.NewVirtualMCPServer("test-vmcp", "default",
+				v1beta1test.WithVMCPGroupRef("test-group"),
+				v1beta1test.WithVMCPConfig(vmcpconfig.Config{
+					Operational: &vmcpconfig.OperationalConfig{
+						LogLevel: "debug",
 					},
-				},
-			},
+				}),
+			),
 			wantArgs: []string{"serve", "--config=/etc/vmcp-config/config.yaml", "--host=0.0.0.0", "--port=4483", "--debug"},
 		},
 	}
@@ -197,15 +174,9 @@ func TestBuildContainerArgsForVmcp(t *testing.T) {
 func TestBuildVolumesForVmcp(t *testing.T) {
 	t.Parallel()
 
-	vmcp := &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-vmcp",
-			Namespace: "default",
-		},
-		Spec: mcpv1beta1.VirtualMCPServerSpec{
-			GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-		},
-	}
+	vmcp := v1beta1test.NewVirtualMCPServer("test-vmcp", "default",
+		v1beta1test.WithVMCPGroupRef("test-group"),
+	)
 
 	r := &VirtualMCPServerReconciler{}
 	volumeMounts, volumes, err := r.buildVolumesForVmcp(context.Background(), vmcp)
@@ -227,15 +198,9 @@ func TestBuildVolumesForVmcp(t *testing.T) {
 func TestBuildEnvVarsForVmcp(t *testing.T) {
 	t.Parallel()
 
-	vmcp := &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-vmcp",
-			Namespace: "test-namespace",
-		},
-		Spec: mcpv1beta1.VirtualMCPServerSpec{
-			GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-		},
-	}
+	vmcp := v1beta1test.NewVirtualMCPServer("test-vmcp", "test-namespace",
+		v1beta1test.WithVMCPGroupRef("test-group"),
+	)
 
 	r := &VirtualMCPServerReconciler{}
 	env, err := r.buildEnvVarsForVmcp(context.Background(), vmcp, nil, []workloads.TypedWorkload{})
@@ -298,10 +263,9 @@ func TestBuildRedisPasswordEnvVar(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			vmcp := &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-vmcp", Namespace: "default"},
-				Spec:       mcpv1beta1.VirtualMCPServerSpec{SessionStorage: tc.storage},
-			}
+			vmcp := v1beta1test.NewVirtualMCPServer("test-vmcp", "default",
+				v1beta1test.WithVMCPSessionStorage(tc.storage),
+			)
 			env := r.buildRedisPasswordEnvVar(vmcp)
 			if tc.expectEnVar {
 				require.Len(t, env, 1)
@@ -323,12 +287,7 @@ func TestBuildDeploymentMetadataForVmcp(t *testing.T) {
 	t.Parallel()
 
 	baseLabels := labelsForVirtualMCPServer("test-vmcp")
-	vmcp := &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-vmcp",
-			Namespace: "default",
-		},
-	}
+	vmcp := v1beta1test.NewVirtualMCPServer("test-vmcp", "default")
 
 	r := &VirtualMCPServerReconciler{}
 	labels, annotations := r.buildDeploymentMetadataForVmcp(baseLabels, vmcp)
@@ -342,12 +301,7 @@ func TestBuildPodTemplateMetadata(t *testing.T) {
 	t.Parallel()
 
 	baseLabels := labelsForVirtualMCPServer("test-vmcp")
-	vmcp := &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-vmcp",
-			Namespace: "default",
-		},
-	}
+	vmcp := v1beta1test.NewVirtualMCPServer("test-vmcp", "default")
 	checksumValue := "test-checksum-123"
 
 	r := &VirtualMCPServerReconciler{}
@@ -361,12 +315,7 @@ func TestBuildPodTemplateMetadata(t *testing.T) {
 func TestBuildSecurityContextsForVmcp(t *testing.T) {
 	t.Parallel()
 
-	vmcp := &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-vmcp",
-			Namespace: "default",
-		},
-	}
+	vmcp := v1beta1test.NewVirtualMCPServer("test-vmcp", "default")
 
 	r := &VirtualMCPServerReconciler{
 		PlatformDetector: ctrlutil.NewSharedPlatformDetector(),
@@ -382,12 +331,7 @@ func TestBuildSecurityContextsForVmcp(t *testing.T) {
 func TestBuildContainerPortsForVmcp(t *testing.T) {
 	t.Parallel()
 
-	vmcp := &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-vmcp",
-			Namespace: "default",
-		},
-	}
+	vmcp := v1beta1test.NewVirtualMCPServer("test-vmcp", "default")
 
 	r := &VirtualMCPServerReconciler{}
 	ports := r.buildContainerPortsForVmcp(vmcp)
@@ -402,15 +346,9 @@ func TestBuildContainerPortsForVmcp(t *testing.T) {
 func TestServiceForVirtualMCPServer(t *testing.T) {
 	t.Parallel()
 
-	vmcp := &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-vmcp",
-			Namespace: "default",
-		},
-		Spec: mcpv1beta1.VirtualMCPServerSpec{
-			GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-		},
-	}
+	vmcp := v1beta1test.NewVirtualMCPServer("test-vmcp", "default",
+		v1beta1test.WithVMCPGroupRef("test-group"),
+	)
 
 	scheme := testutil.NewScheme(t)
 
@@ -440,16 +378,12 @@ func TestServiceForVirtualMCPServer(t *testing.T) {
 func TestServiceForVirtualMCPServerSessionAffinityNone(t *testing.T) {
 	t.Parallel()
 
-	vmcp := &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-vmcp",
-			Namespace: "default",
-		},
-		Spec: mcpv1beta1.VirtualMCPServerSpec{
-			GroupRef:        &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-			SessionAffinity: string(corev1.ServiceAffinityNone),
-		},
-	}
+	vmcp := v1beta1test.NewVirtualMCPServer("test-vmcp", "default",
+		v1beta1test.WithVMCPGroupRef("test-group"),
+		v1beta1test.MutateVMCP(func(v *mcpv1beta1.VirtualMCPServer) {
+			v.Spec.SessionAffinity = string(corev1.ServiceAffinityNone)
+		}),
+	)
 
 	scheme := testutil.NewScheme(t)
 
@@ -468,12 +402,7 @@ func TestBuildServiceMetadataForVmcp(t *testing.T) {
 	t.Parallel()
 
 	baseLabels := labelsForVirtualMCPServer("test-vmcp")
-	vmcp := &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-vmcp",
-			Namespace: "default",
-		},
-	}
+	vmcp := v1beta1test.NewVirtualMCPServer("test-vmcp", "default")
 
 	r := &VirtualMCPServerReconciler{}
 	labels, annotations := r.buildServiceMetadataForVmcp(baseLabels, vmcp)
@@ -533,12 +462,7 @@ func TestDeploymentNeedsUpdate(t *testing.T) {
 	// Test nil inputs
 	assert.True(t, r.deploymentNeedsUpdate(context.Background(), nil, nil, "", nil, []workloads.TypedWorkload{}))
 
-	vmcp := &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-vmcp",
-			Namespace: "default",
-		},
-	}
+	vmcp := v1beta1test.NewVirtualMCPServer("test-vmcp", "default")
 
 	// Test with nil deployment
 	assert.True(t, r.deploymentNeedsUpdate(context.Background(), nil, vmcp, "checksum", nil, []workloads.TypedWorkload{}))
@@ -553,12 +477,7 @@ func TestServiceNeedsUpdate(t *testing.T) {
 	// Test nil inputs
 	assert.True(t, r.serviceNeedsUpdate(nil, nil))
 
-	vmcp := &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-vmcp",
-			Namespace: "default",
-		},
-	}
+	vmcp := v1beta1test.NewVirtualMCPServer("test-vmcp", "default")
 
 	// Test with nil service
 	assert.True(t, r.serviceNeedsUpdate(nil, vmcp))
@@ -942,13 +861,11 @@ func TestDeploymentForVirtualMCPServer_ImagePullSecrets(t *testing.T) {
 
 			scheme := testutil.NewScheme(t)
 
-			vmcp := &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-vmcp",
-					Namespace: "default",
-				},
-				Spec: tt.spec,
-			}
+			vmcp := v1beta1test.NewVirtualMCPServer("test-vmcp", "default",
+				v1beta1test.MutateVMCP(func(v *mcpv1beta1.VirtualMCPServer) {
+					v.Spec = tt.spec
+				}),
+			)
 
 			r := &VirtualMCPServerReconciler{
 				Scheme:           scheme,
@@ -1032,13 +949,12 @@ func TestDeploymentForVirtualMCPServer_ImagePullSecrets_UpdatePath(t *testing.T)
 				PlatformDetector: ctrlutil.NewSharedPlatformDetector(),
 			}
 
-			vmcp := &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-vmcp", Namespace: "default"},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef:         &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-					ImagePullSecrets: tt.initial,
-				},
-			}
+			vmcp := v1beta1test.NewVirtualMCPServer("test-vmcp", "default",
+				v1beta1test.WithVMCPGroupRef("test-group"),
+				v1beta1test.MutateVMCP(func(v *mcpv1beta1.VirtualMCPServer) {
+					v.Spec.ImagePullSecrets = tt.initial
+				}),
+			)
 			if tt.podTemplateRaw != nil {
 				vmcp.Spec.PodTemplateSpec = &runtime.RawExtension{Raw: tt.podTemplateRaw}
 			}

--- a/cmd/thv-operator/controllers/virtualmcpserver_externalauth_test.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_externalauth_test.go
@@ -225,18 +225,12 @@ func TestBuildOutgoingAuthConfig(t *testing.T) {
 	}{
 		{
 			name: "discovered mode with external auth config",
-			vmcp: &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-vmcp",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-					OutgoingAuth: &mcpv1beta1.OutgoingAuthConfig{
-						Source: "discovered",
-					},
-				},
-			},
+			vmcp: v1beta1test.NewVirtualMCPServer("test-vmcp", "default",
+				v1beta1test.WithVMCPGroupRef("test-group"),
+				v1beta1test.WithVMCPOutgoingAuth(&mcpv1beta1.OutgoingAuthConfig{
+					Source: "discovered",
+				}),
+			),
 			mcpServers: []mcpv1beta1.MCPServer{
 				*v1beta1test.NewMCPServer("backend-1", "default",
 					v1beta1test.WithExternalAuthConfigRef("auth-config-1"),
@@ -280,26 +274,20 @@ func TestBuildOutgoingAuthConfig(t *testing.T) {
 		},
 		{
 			name: "discovered mode with inline overrides",
-			vmcp: &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-vmcp",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-					OutgoingAuth: &mcpv1beta1.OutgoingAuthConfig{
-						Source: "discovered",
-						Backends: map[string]mcpv1beta1.BackendAuthConfig{
-							"backend-1": {
-								Type: mcpv1beta1.BackendAuthTypeExternalAuthConfigRef,
-								ExternalAuthConfigRef: &mcpv1beta1.ExternalAuthConfigRef{
-									Name: "auth-config-override",
-								},
+			vmcp: v1beta1test.NewVirtualMCPServer("test-vmcp", "default",
+				v1beta1test.WithVMCPGroupRef("test-group"),
+				v1beta1test.WithVMCPOutgoingAuth(&mcpv1beta1.OutgoingAuthConfig{
+					Source: "discovered",
+					Backends: map[string]mcpv1beta1.BackendAuthConfig{
+						"backend-1": {
+							Type: mcpv1beta1.BackendAuthTypeExternalAuthConfigRef,
+							ExternalAuthConfigRef: &mcpv1beta1.ExternalAuthConfigRef{
+								Name: "auth-config-override",
 							},
 						},
 					},
-				},
-			},
+				}),
+			),
 			mcpServers: []mcpv1beta1.MCPServer{
 				*v1beta1test.NewMCPServer("backend-1", "default",
 					v1beta1test.WithExternalAuthConfigRef("auth-config-1"),
@@ -374,26 +362,20 @@ func TestBuildOutgoingAuthConfig(t *testing.T) {
 		},
 		{
 			name: "inline mode ignores discovered configs",
-			vmcp: &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-vmcp",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-					OutgoingAuth: &mcpv1beta1.OutgoingAuthConfig{
-						Source: "inline",
-						Backends: map[string]mcpv1beta1.BackendAuthConfig{
-							"backend-1": {
-								Type: mcpv1beta1.BackendAuthTypeExternalAuthConfigRef,
-								ExternalAuthConfigRef: &mcpv1beta1.ExternalAuthConfigRef{
-									Name: "auth-config-1",
-								},
+			vmcp: v1beta1test.NewVirtualMCPServer("test-vmcp", "default",
+				v1beta1test.WithVMCPGroupRef("test-group"),
+				v1beta1test.WithVMCPOutgoingAuth(&mcpv1beta1.OutgoingAuthConfig{
+					Source: "inline",
+					Backends: map[string]mcpv1beta1.BackendAuthConfig{
+						"backend-1": {
+							Type: mcpv1beta1.BackendAuthTypeExternalAuthConfigRef,
+							ExternalAuthConfigRef: &mcpv1beta1.ExternalAuthConfigRef{
+								Name: "auth-config-1",
 							},
 						},
 					},
-				},
-			},
+				}),
+			),
 			mcpServers: []mcpv1beta1.MCPServer{
 				*v1beta1test.NewMCPServer("backend-1", "default",
 					v1beta1test.WithExternalAuthConfigRef("auth-config-1"),
@@ -430,24 +412,18 @@ func TestBuildOutgoingAuthConfig(t *testing.T) {
 		},
 		{
 			name: "default auth config",
-			vmcp: &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-vmcp",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-					OutgoingAuth: &mcpv1beta1.OutgoingAuthConfig{
-						Source: "discovered",
-						Default: &mcpv1beta1.BackendAuthConfig{
-							Type: mcpv1beta1.BackendAuthTypeExternalAuthConfigRef,
-							ExternalAuthConfigRef: &mcpv1beta1.ExternalAuthConfigRef{
-								Name: "default-auth-config",
-							},
+			vmcp: v1beta1test.NewVirtualMCPServer("test-vmcp", "default",
+				v1beta1test.WithVMCPGroupRef("test-group"),
+				v1beta1test.WithVMCPOutgoingAuth(&mcpv1beta1.OutgoingAuthConfig{
+					Source: "discovered",
+					Default: &mcpv1beta1.BackendAuthConfig{
+						Type: mcpv1beta1.BackendAuthTypeExternalAuthConfigRef,
+						ExternalAuthConfigRef: &mcpv1beta1.ExternalAuthConfigRef{
+							Name: "default-auth-config",
 						},
 					},
-				},
-			},
+				}),
+			),
 			authConfigs: []mcpv1beta1.MCPExternalAuthConfig{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -472,26 +448,20 @@ func TestBuildOutgoingAuthConfig(t *testing.T) {
 		},
 		{
 			name: "inline mode with ExternalAuthConfigRef",
-			vmcp: &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-vmcp",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-					OutgoingAuth: &mcpv1beta1.OutgoingAuthConfig{
-						Source: "inline",
-						Backends: map[string]mcpv1beta1.BackendAuthConfig{
-							"backend-1": {
-								Type: mcpv1beta1.BackendAuthTypeExternalAuthConfigRef,
-								ExternalAuthConfigRef: &mcpv1beta1.ExternalAuthConfigRef{
-									Name: "auth-config-1",
-								},
+			vmcp: v1beta1test.NewVirtualMCPServer("test-vmcp", "default",
+				v1beta1test.WithVMCPGroupRef("test-group"),
+				v1beta1test.WithVMCPOutgoingAuth(&mcpv1beta1.OutgoingAuthConfig{
+					Source: "inline",
+					Backends: map[string]mcpv1beta1.BackendAuthConfig{
+						"backend-1": {
+							Type: mcpv1beta1.BackendAuthTypeExternalAuthConfigRef,
+							ExternalAuthConfigRef: &mcpv1beta1.ExternalAuthConfigRef{
+								Name: "auth-config-1",
 							},
 						},
 					},
-				},
-			},
+				}),
+			),
 			authConfigs: []mcpv1beta1.MCPExternalAuthConfig{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -520,18 +490,12 @@ func TestBuildOutgoingAuthConfig(t *testing.T) {
 		},
 		{
 			name: "missing ExternalAuthConfig should be skipped gracefully",
-			vmcp: &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-vmcp",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-					OutgoingAuth: &mcpv1beta1.OutgoingAuthConfig{
-						Source: "discovered",
-					},
-				},
-			},
+			vmcp: v1beta1test.NewVirtualMCPServer("test-vmcp", "default",
+				v1beta1test.WithVMCPGroupRef("test-group"),
+				v1beta1test.WithVMCPOutgoingAuth(&mcpv1beta1.OutgoingAuthConfig{
+					Source: "discovered",
+				}),
+			),
 			mcpServers: []mcpv1beta1.MCPServer{
 				*v1beta1test.NewMCPServer("backend-1", "default",
 					v1beta1test.WithExternalAuthConfigRef("missing-auth-config"),
@@ -562,16 +526,10 @@ func TestBuildOutgoingAuthConfig(t *testing.T) {
 		},
 		{
 			name: "defaults to discovered mode when source not specified",
-			vmcp: &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-vmcp",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-					// No OutgoingAuth specified
-				},
-			},
+			vmcp: v1beta1test.NewVirtualMCPServer("test-vmcp", "default",
+				v1beta1test.WithVMCPGroupRef("test-group"),
+				// No OutgoingAuth specified
+			),
 			workloadNames: []workloads.TypedWorkload{},
 			validate: func(t *testing.T, config *vmcpconfig.OutgoingAuthConfig) {
 				t.Helper()
@@ -580,24 +538,18 @@ func TestBuildOutgoingAuthConfig(t *testing.T) {
 		},
 		{
 			name: "default auth config error is collected but doesn't fail reconciliation",
-			vmcp: &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-vmcp",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-					OutgoingAuth: &mcpv1beta1.OutgoingAuthConfig{
-						Source: "discovered",
-						Default: &mcpv1beta1.BackendAuthConfig{
-							Type: "externalAuthConfigRef",
-							ExternalAuthConfigRef: &mcpv1beta1.ExternalAuthConfigRef{
-								Name: "missing-default-auth", // Auth config doesn't exist
-							},
+			vmcp: v1beta1test.NewVirtualMCPServer("test-vmcp", "default",
+				v1beta1test.WithVMCPGroupRef("test-group"),
+				v1beta1test.WithVMCPOutgoingAuth(&mcpv1beta1.OutgoingAuthConfig{
+					Source: "discovered",
+					Default: &mcpv1beta1.BackendAuthConfig{
+						Type: "externalAuthConfigRef",
+						ExternalAuthConfigRef: &mcpv1beta1.ExternalAuthConfigRef{
+							Name: "missing-default-auth", // Auth config doesn't exist
 						},
 					},
-				},
-			},
+				}),
+			),
 			workloadNames:    []workloads.TypedWorkload{},
 			expectAuthErrors: true, // Should collect default auth error
 			validateErrors: func(t *testing.T, errors []AuthConfigError) {
@@ -617,26 +569,20 @@ func TestBuildOutgoingAuthConfig(t *testing.T) {
 		},
 		{
 			name: "backend-specific auth config error is collected but doesn't fail reconciliation",
-			vmcp: &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-vmcp",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-					OutgoingAuth: &mcpv1beta1.OutgoingAuthConfig{
-						Source: "discovered",
-						Backends: map[string]mcpv1beta1.BackendAuthConfig{
-							"api-backend": {
-								Type: "externalAuthConfigRef",
-								ExternalAuthConfigRef: &mcpv1beta1.ExternalAuthConfigRef{
-									Name: "missing-backend-auth",
-								},
+			vmcp: v1beta1test.NewVirtualMCPServer("test-vmcp", "default",
+				v1beta1test.WithVMCPGroupRef("test-group"),
+				v1beta1test.WithVMCPOutgoingAuth(&mcpv1beta1.OutgoingAuthConfig{
+					Source: "discovered",
+					Backends: map[string]mcpv1beta1.BackendAuthConfig{
+						"api-backend": {
+							Type: "externalAuthConfigRef",
+							ExternalAuthConfigRef: &mcpv1beta1.ExternalAuthConfigRef{
+								Name: "missing-backend-auth",
 							},
 						},
 					},
-				},
-			},
+				}),
+			),
 			workloadNames:    []workloads.TypedWorkload{},
 			expectAuthErrors: true, // Should collect backend-specific auth error
 			validateErrors: func(t *testing.T, errors []AuthConfigError) {
@@ -1295,34 +1241,28 @@ func TestBuildOutgoingAuthConfig_SubjectProviderInjection(t *testing.T) {
 		v1beta1test.WithExternalAuthConfigRef("discovered-auth"),
 	)
 
-	vmcp := &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-vmcp",
-			Namespace: "default",
-		},
-		Spec: mcpv1beta1.VirtualMCPServerSpec{
-			GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-			OutgoingAuth: &mcpv1beta1.OutgoingAuthConfig{
-				Source: "discovered",
-				// Default references an MCPExternalAuthConfig (the only supported form
-				// for a default auth in the CRD).
-				Default: &mcpv1beta1.BackendAuthConfig{
-					Type: mcpv1beta1.BackendAuthTypeExternalAuthConfigRef,
-					ExternalAuthConfigRef: &mcpv1beta1.ExternalAuthConfigRef{
-						Name: "default-auth",
-					},
+	vmcp := v1beta1test.NewVirtualMCPServer("test-vmcp", "default",
+		v1beta1test.WithVMCPGroupRef("test-group"),
+		v1beta1test.WithVMCPOutgoingAuth(&mcpv1beta1.OutgoingAuthConfig{
+			Source: "discovered",
+			// Default references an MCPExternalAuthConfig (the only supported form
+			// for a default auth in the CRD).
+			Default: &mcpv1beta1.BackendAuthConfig{
+				Type: mcpv1beta1.BackendAuthTypeExternalAuthConfigRef,
+				ExternalAuthConfigRef: &mcpv1beta1.ExternalAuthConfigRef{
+					Name: "default-auth",
 				},
 			},
-			AuthServerConfig: &mcpv1beta1.EmbeddedAuthServerConfig{
-				UpstreamProviders: []mcpv1beta1.UpstreamProviderConfig{
-					{
-						Name: "myidp",
-						Type: mcpv1beta1.UpstreamProviderTypeOIDC,
-					},
+		}),
+		v1beta1test.WithVMCPAuthServerConfig(&mcpv1beta1.EmbeddedAuthServerConfig{
+			UpstreamProviders: []mcpv1beta1.UpstreamProviderConfig{
+				{
+					Name: "myidp",
+					Type: mcpv1beta1.UpstreamProviderTypeOIDC,
 				},
 			},
-		},
-	}
+		}),
+	)
 
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(scheme).
@@ -1411,17 +1351,11 @@ func TestDiscoverExternalAuthConfigSecrets_DeterministicOrdering(t *testing.T) {
 
 			scheme := testutil.NewScheme(t)
 
-			vmcp := &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-vmcp",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					OutgoingAuth: &mcpv1beta1.OutgoingAuthConfig{
-						Source: "discovered",
-					},
-				},
-			}
+			vmcp := v1beta1test.NewVirtualMCPServer("test-vmcp", "default",
+				v1beta1test.WithVMCPOutgoingAuth(&mcpv1beta1.OutgoingAuthConfig{
+					Source: "discovered",
+				}),
+			)
 
 			// Four MCPServers each referencing a distinct MCPExternalAuthConfig.
 			// The MCPServer names match the workload Names in tt.workloadOrder.
@@ -1547,44 +1481,38 @@ func TestDiscoverInlineExternalAuthConfigSecrets_DeterministicOrdering(t *testin
 
 	scheme := testutil.NewScheme(t)
 
-	vmcp := &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-vmcp",
-			Namespace: "default",
-		},
-		Spec: mcpv1beta1.VirtualMCPServerSpec{
-			OutgoingAuth: &mcpv1beta1.OutgoingAuthConfig{
-				Source: "inline",
-				// Map with four backends — Go map iteration order is non-deterministic.
-				Backends: map[string]mcpv1beta1.BackendAuthConfig{
-					"backend-zeta": {
-						Type: mcpv1beta1.BackendAuthTypeExternalAuthConfigRef,
-						ExternalAuthConfigRef: &mcpv1beta1.ExternalAuthConfigRef{
-							Name: "inline-zeta-auth",
-						},
+	vmcp := v1beta1test.NewVirtualMCPServer("test-vmcp", "default",
+		v1beta1test.WithVMCPOutgoingAuth(&mcpv1beta1.OutgoingAuthConfig{
+			Source: "inline",
+			// Map with four backends — Go map iteration order is non-deterministic.
+			Backends: map[string]mcpv1beta1.BackendAuthConfig{
+				"backend-zeta": {
+					Type: mcpv1beta1.BackendAuthTypeExternalAuthConfigRef,
+					ExternalAuthConfigRef: &mcpv1beta1.ExternalAuthConfigRef{
+						Name: "inline-zeta-auth",
 					},
-					"backend-mu": {
-						Type: mcpv1beta1.BackendAuthTypeExternalAuthConfigRef,
-						ExternalAuthConfigRef: &mcpv1beta1.ExternalAuthConfigRef{
-							Name: "inline-mu-auth",
-						},
+				},
+				"backend-mu": {
+					Type: mcpv1beta1.BackendAuthTypeExternalAuthConfigRef,
+					ExternalAuthConfigRef: &mcpv1beta1.ExternalAuthConfigRef{
+						Name: "inline-mu-auth",
 					},
-					"backend-beta": {
-						Type: mcpv1beta1.BackendAuthTypeExternalAuthConfigRef,
-						ExternalAuthConfigRef: &mcpv1beta1.ExternalAuthConfigRef{
-							Name: "inline-beta-auth",
-						},
+				},
+				"backend-beta": {
+					Type: mcpv1beta1.BackendAuthTypeExternalAuthConfigRef,
+					ExternalAuthConfigRef: &mcpv1beta1.ExternalAuthConfigRef{
+						Name: "inline-beta-auth",
 					},
-					"backend-alpha": {
-						Type: mcpv1beta1.BackendAuthTypeExternalAuthConfigRef,
-						ExternalAuthConfigRef: &mcpv1beta1.ExternalAuthConfigRef{
-							Name: "inline-alpha-auth",
-						},
+				},
+				"backend-alpha": {
+					Type: mcpv1beta1.BackendAuthTypeExternalAuthConfigRef,
+					ExternalAuthConfigRef: &mcpv1beta1.ExternalAuthConfigRef{
+						Name: "inline-alpha-auth",
 					},
 				},
 			},
-		},
-	}
+		}),
+	)
 
 	authConfigs := []client.Object{
 		&mcpv1beta1.MCPExternalAuthConfig{
@@ -1692,35 +1620,29 @@ func TestBuildOutgoingAuthConfig_InlineBackendSubjectProviderInjection(t *testin
 		},
 	}
 
-	vmcp := &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-vmcp",
-			Namespace: "default",
-		},
-		Spec: mcpv1beta1.VirtualMCPServerSpec{
-			GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-			OutgoingAuth: &mcpv1beta1.OutgoingAuthConfig{
-				Source: "discovered",
-				// Inline Backends override — the path exercised by this test.
-				Backends: map[string]mcpv1beta1.BackendAuthConfig{
-					"inline-backend": {
-						Type: mcpv1beta1.BackendAuthTypeExternalAuthConfigRef,
-						ExternalAuthConfigRef: &mcpv1beta1.ExternalAuthConfigRef{
-							Name: "inline-auth",
-						},
+	vmcp := v1beta1test.NewVirtualMCPServer("test-vmcp", "default",
+		v1beta1test.WithVMCPGroupRef("test-group"),
+		v1beta1test.WithVMCPOutgoingAuth(&mcpv1beta1.OutgoingAuthConfig{
+			Source: "discovered",
+			// Inline Backends override — the path exercised by this test.
+			Backends: map[string]mcpv1beta1.BackendAuthConfig{
+				"inline-backend": {
+					Type: mcpv1beta1.BackendAuthTypeExternalAuthConfigRef,
+					ExternalAuthConfigRef: &mcpv1beta1.ExternalAuthConfigRef{
+						Name: "inline-auth",
 					},
 				},
 			},
-			AuthServerConfig: &mcpv1beta1.EmbeddedAuthServerConfig{
-				UpstreamProviders: []mcpv1beta1.UpstreamProviderConfig{
-					{
-						Name: "corporate-idp",
-						Type: mcpv1beta1.UpstreamProviderTypeOIDC,
-					},
+		}),
+		v1beta1test.WithVMCPAuthServerConfig(&mcpv1beta1.EmbeddedAuthServerConfig{
+			UpstreamProviders: []mcpv1beta1.UpstreamProviderConfig{
+				{
+					Name: "corporate-idp",
+					Type: mcpv1beta1.UpstreamProviderTypeOIDC,
 				},
 			},
-		},
-	}
+		}),
+	)
 
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(scheme).

--- a/cmd/thv-operator/controllers/virtualmcpserver_podtemplatespec_reconcile_test.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_podtemplatespec_reconcile_test.go
@@ -18,6 +18,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1/v1beta1test"
 	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 	"github.com/stacklok/toolhive/cmd/thv-operator/pkg/runconfig/configmap/checksum"
 	"github.com/stacklok/toolhive/pkg/vmcp/workloads"
@@ -55,16 +56,10 @@ func TestVirtualMCPServerPodTemplateSpecDeterministic(t *testing.T) {
 		},
 	}
 
-	vmcp := &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      vmcpName,
-			Namespace: namespace,
-		},
-		Spec: mcpv1beta1.VirtualMCPServerSpec{
-			GroupRef:        &mcpv1beta1.MCPGroupRef{Name: groupName},
-			PodTemplateSpec: podTemplateSpecToRawExtension(t, podTemplate),
-		},
-	}
+	vmcp := v1beta1test.NewVirtualMCPServer(vmcpName, namespace,
+		v1beta1test.WithVMCPGroupRef(groupName),
+		v1beta1test.WithVMCPPodTemplateSpec(podTemplateSpecToRawExtension(t, podTemplate)),
+	)
 
 	configMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
@@ -126,18 +121,12 @@ func TestVirtualMCPServerPodTemplateSpecPreservesContainer(t *testing.T) {
 
 	// Use raw JSON directly (simulating real user input) - only nodeSelector, no containers
 	// This is the exact scenario that triggered the original bug
-	vmcp := &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      vmcpName,
-			Namespace: namespace,
-		},
-		Spec: mcpv1beta1.VirtualMCPServerSpec{
-			GroupRef: &mcpv1beta1.MCPGroupRef{Name: groupName},
-			PodTemplateSpec: &runtime.RawExtension{
-				Raw: []byte(`{"spec":{"nodeSelector":{"disktype":"ssd"}}}`),
-			},
-		},
-	}
+	vmcp := v1beta1test.NewVirtualMCPServer(vmcpName, namespace,
+		v1beta1test.WithVMCPGroupRef(groupName),
+		v1beta1test.WithVMCPPodTemplateSpec(&runtime.RawExtension{
+			Raw: []byte(`{"spec":{"nodeSelector":{"disktype":"ssd"}}}`),
+		}),
+	)
 
 	configMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
@@ -261,16 +250,10 @@ func TestVirtualMCPServerPodTemplateSpecNeedsUpdate(t *testing.T) {
 				},
 			}
 
-			vmcp := &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      testPodTemplateVmcpName,
-					Namespace: testPodTemplateNamespace,
-				},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef:        &mcpv1beta1.MCPGroupRef{Name: testPodTemplateGroupName},
-					PodTemplateSpec: tt.newPodTemplateSpec,
-				},
-			}
+			vmcp := v1beta1test.NewVirtualMCPServer(testPodTemplateVmcpName, testPodTemplateNamespace,
+				v1beta1test.WithVMCPGroupRef(testPodTemplateGroupName),
+				v1beta1test.WithVMCPPodTemplateSpec(tt.newPodTemplateSpec),
+			)
 
 			reconciler := &VirtualMCPServerReconciler{}
 			needsUpdate := reconciler.podTemplateSpecNeedsUpdate(
@@ -301,18 +284,12 @@ func TestVirtualMCPServerPodTemplateSpecResourceOverride(t *testing.T) {
 	}
 
 	// Provide custom resources for the vmcp container via PodTemplateSpec
-	vmcp := &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      vmcpName,
-			Namespace: namespace,
-		},
-		Spec: mcpv1beta1.VirtualMCPServerSpec{
-			GroupRef: &mcpv1beta1.MCPGroupRef{Name: groupName},
-			PodTemplateSpec: &runtime.RawExtension{
-				Raw: []byte(`{"spec":{"containers":[{"name":"vmcp","resources":{"requests":{"cpu":"200m","memory":"256Mi"},"limits":{"cpu":"1","memory":"1Gi"}}}]}}`),
-			},
-		},
-	}
+	vmcp := v1beta1test.NewVirtualMCPServer(vmcpName, namespace,
+		v1beta1test.WithVMCPGroupRef(groupName),
+		v1beta1test.WithVMCPPodTemplateSpec(&runtime.RawExtension{
+			Raw: []byte(`{"spec":{"containers":[{"name":"vmcp","resources":{"requests":{"cpu":"200m","memory":"256Mi"},"limits":{"cpu":"1","memory":"1Gi"}}}]}}`),
+		}),
+	)
 
 	configMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{

--- a/cmd/thv-operator/controllers/virtualmcpserver_telemetryconfig_test.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_telemetryconfig_test.go
@@ -13,6 +13,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1/v1beta1test"
 	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 	"github.com/stacklok/toolhive/cmd/thv-operator/pkg/virtualmcpserverstatus"
 )
@@ -37,10 +38,8 @@ func TestHandleTelemetryConfig_VirtualMCPServer(t *testing.T) {
 	}{
 		{
 			name: "nil ref clears hash and removes condition",
-			vmcp: &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-vmcp", Namespace: "default"},
-				Spec:       mcpv1beta1.VirtualMCPServerSpec{TelemetryConfigRef: nil},
-				Status: mcpv1beta1.VirtualMCPServerStatus{
+			vmcp: v1beta1test.NewVirtualMCPServer("test-vmcp", "default",
+				v1beta1test.WithVMCPStatus(mcpv1beta1.VirtualMCPServerStatus{
 					TelemetryConfigHash: "old-hash",
 					Conditions: []metav1.Condition{
 						{
@@ -49,8 +48,8 @@ func TestHandleTelemetryConfig_VirtualMCPServer(t *testing.T) {
 							Reason: mcpv1beta1.ConditionReasonVirtualMCPServerTelemetryConfigRefValid,
 						},
 					},
-				},
-			},
+				}),
+			),
 			expectError:       false,
 			expectTelCfgNil:   true,
 			expectHashCleared: true,
@@ -58,12 +57,9 @@ func TestHandleTelemetryConfig_VirtualMCPServer(t *testing.T) {
 		},
 		{
 			name: "valid ref sets condition true and updates hash",
-			vmcp: &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-vmcp", Namespace: "default"},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					TelemetryConfigRef: &mcpv1beta1.MCPTelemetryConfigReference{Name: "my-telemetry"},
-				},
-			},
+			vmcp: v1beta1test.NewVirtualMCPServer("test-vmcp", "default",
+				v1beta1test.WithVMCPTelemetryConfigRef("my-telemetry"),
+			),
 			telemetryConfig: &mcpv1beta1.MCPTelemetryConfig{
 				ObjectMeta: metav1.ObjectMeta{Name: "my-telemetry", Namespace: "default"},
 				Spec:       newTelemetrySpec("https://otel-collector:4317", true, false),
@@ -79,12 +75,9 @@ func TestHandleTelemetryConfig_VirtualMCPServer(t *testing.T) {
 		},
 		{
 			name: "not found sets condition false",
-			vmcp: &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-vmcp", Namespace: "default"},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					TelemetryConfigRef: &mcpv1beta1.MCPTelemetryConfigReference{Name: "missing"},
-				},
-			},
+			vmcp: v1beta1test.NewVirtualMCPServer("test-vmcp", "default",
+				v1beta1test.WithVMCPTelemetryConfigRef("missing"),
+			),
 			expectError:        true,
 			expectedCondType:   mcpv1beta1.ConditionTypeVirtualMCPServerTelemetryConfigRefValidated,
 			expectedCondStatus: metav1.ConditionFalse,
@@ -92,12 +85,9 @@ func TestHandleTelemetryConfig_VirtualMCPServer(t *testing.T) {
 		},
 		{
 			name: "invalid config sets condition false",
-			vmcp: &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-vmcp", Namespace: "default"},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					TelemetryConfigRef: &mcpv1beta1.MCPTelemetryConfigReference{Name: "invalid-telemetry"},
-				},
-			},
+			vmcp: v1beta1test.NewVirtualMCPServer("test-vmcp", "default",
+				v1beta1test.WithVMCPTelemetryConfigRef("invalid-telemetry"),
+			),
 			// Spec with endpoint but no tracing/metrics enabled -> Validate() fails
 			telemetryConfig: &mcpv1beta1.MCPTelemetryConfig{
 				ObjectMeta: metav1.ObjectMeta{Name: "invalid-telemetry", Namespace: "default"},
@@ -117,15 +107,12 @@ func TestHandleTelemetryConfig_VirtualMCPServer(t *testing.T) {
 		},
 		{
 			name: "hash change triggers update",
-			vmcp: &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-vmcp", Namespace: "default"},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					TelemetryConfigRef: &mcpv1beta1.MCPTelemetryConfigReference{Name: "my-telemetry"},
-				},
-				Status: mcpv1beta1.VirtualMCPServerStatus{
+			vmcp: v1beta1test.NewVirtualMCPServer("test-vmcp", "default",
+				v1beta1test.WithVMCPTelemetryConfigRef("my-telemetry"),
+				v1beta1test.WithVMCPStatus(mcpv1beta1.VirtualMCPServerStatus{
 					TelemetryConfigHash: "old-hash",
-				},
-			},
+				}),
+			),
 			telemetryConfig: &mcpv1beta1.MCPTelemetryConfig{
 				ObjectMeta: metav1.ObjectMeta{Name: "my-telemetry", Namespace: "default"},
 				Spec:       newTelemetrySpec("https://otel-collector:4317", true, false),
@@ -212,22 +199,13 @@ func TestMapTelemetryConfigToVirtualMCPServer(t *testing.T) {
 
 	scheme := testutil.NewScheme(t)
 
-	vmcp1 := &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{Name: "vmcp1", Namespace: "default"},
-		Spec: mcpv1beta1.VirtualMCPServerSpec{
-			TelemetryConfigRef: &mcpv1beta1.MCPTelemetryConfigReference{Name: "shared-telemetry"},
-		},
-	}
-	vmcp2 := &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{Name: "vmcp2", Namespace: "default"},
-		Spec: mcpv1beta1.VirtualMCPServerSpec{
-			TelemetryConfigRef: &mcpv1beta1.MCPTelemetryConfigReference{Name: "other-telemetry"},
-		},
-	}
-	vmcp3 := &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{Name: "vmcp3", Namespace: "default"},
-		Spec:       mcpv1beta1.VirtualMCPServerSpec{}, // no ref
-	}
+	vmcp1 := v1beta1test.NewVirtualMCPServer("vmcp1", "default",
+		v1beta1test.WithVMCPTelemetryConfigRef("shared-telemetry"),
+	)
+	vmcp2 := v1beta1test.NewVirtualMCPServer("vmcp2", "default",
+		v1beta1test.WithVMCPTelemetryConfigRef("other-telemetry"),
+	)
+	vmcp3 := v1beta1test.NewVirtualMCPServer("vmcp3", "default") // no ref
 
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(scheme).

--- a/cmd/thv-operator/controllers/virtualmcpserver_vmcpconfig_test.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_vmcpconfig_test.go
@@ -65,15 +65,9 @@ func TestCreateVmcpConfigFromVirtualMCPServer(t *testing.T) {
 	}{
 		{
 			name: "basic config",
-			vmcp: &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-vmcp",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-				},
-			},
+			vmcp: v1beta1test.NewVirtualMCPServer("test-vmcp", "default",
+				v1beta1test.WithVMCPGroupRef("test-group"),
+			),
 			expectedName:     "test-vmcp",
 			expectedGroupRef: "test-group",
 		},
@@ -148,12 +142,10 @@ func TestConvertOutgoingAuth(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			vmcpServer := &mcpv1beta1.VirtualMCPServer{
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef:     &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-					OutgoingAuth: tt.outgoingAuth,
-				},
-			}
+			vmcpServer := v1beta1test.NewVirtualMCPServer("", "",
+				v1beta1test.WithVMCPGroupRef("test-group"),
+				v1beta1test.WithVMCPOutgoingAuth(tt.outgoingAuth),
+			)
 
 			converter := newTestConverter(t, newNoOpMockResolver(t))
 			config, _, err := converter.Convert(context.Background(), vmcpServer, nil)
@@ -206,18 +198,12 @@ func TestConvertBackendAuthConfig(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			vmcpServer := &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-vmcp",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-					OutgoingAuth: &mcpv1beta1.OutgoingAuthConfig{
-						Default: tt.authConfig,
-					},
-				},
-			}
+			vmcpServer := v1beta1test.NewVirtualMCPServer("test-vmcp", "default",
+				v1beta1test.WithVMCPGroupRef("test-group"),
+				v1beta1test.WithVMCPOutgoingAuth(&mcpv1beta1.OutgoingAuthConfig{
+					Default: tt.authConfig,
+				}),
+			)
 
 			// For externalAuthConfigRef test, create the referenced MCPExternalAuthConfig
 			var converter *vmcpconfigconv.Converter
@@ -330,14 +316,12 @@ func TestConvertAggregation(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			vmcpServer := &mcpv1beta1.VirtualMCPServer{
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-					Config: vmcpconfig.Config{
-						Aggregation: tt.aggregation,
-					},
-				},
-			}
+			vmcpServer := v1beta1test.NewVirtualMCPServer("", "",
+				v1beta1test.WithVMCPGroupRef("test-group"),
+				v1beta1test.WithVMCPConfig(vmcpconfig.Config{
+					Aggregation: tt.aggregation,
+				}),
+			)
 
 			converter := newTestConverter(t, newNoOpMockResolver(t))
 			config, _, err := converter.Convert(context.Background(), vmcpServer, nil)
@@ -423,14 +407,12 @@ func TestConvertCompositeTools(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			vmcpServer := &mcpv1beta1.VirtualMCPServer{
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-					Config: vmcpconfig.Config{
-						CompositeTools: tt.compositeTools,
-					},
-				},
-			}
+			vmcpServer := v1beta1test.NewVirtualMCPServer("", "",
+				v1beta1test.WithVMCPGroupRef("test-group"),
+				v1beta1test.WithVMCPConfig(vmcpconfig.Config{
+					CompositeTools: tt.compositeTools,
+				}),
+			)
 
 			converter := newTestConverter(t, newNoOpMockResolver(t))
 			config, _, err := converter.Convert(context.Background(), vmcpServer, nil)
@@ -452,15 +434,9 @@ func TestConvertCompositeTools(t *testing.T) {
 func TestEnsureVmcpConfigConfigMap(t *testing.T) {
 	t.Parallel()
 
-	testVmcp := &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-vmcp",
-			Namespace: "default",
-		},
-		Spec: mcpv1beta1.VirtualMCPServerSpec{
-			GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-		},
-	}
+	testVmcp := v1beta1test.NewVirtualMCPServer("test-vmcp", "default",
+		v1beta1test.WithVMCPGroupRef("test-group"),
+	)
 
 	// Create MCPGroup for workload discovery
 	mcpGroup := &mcpv1beta1.MCPGroup{
@@ -1072,66 +1048,60 @@ func TestYAMLMarshalingDeterminism(t *testing.T) {
 	t.Parallel()
 
 	// Create a VirtualMCPServer with multiple map fields to test determinism
-	testVmcp := &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-vmcp",
-			Namespace: "default",
-		},
-		Spec: mcpv1beta1.VirtualMCPServerSpec{
-			GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-			Config: vmcpconfig.Config{
-				// Aggregation with tool overrides (map)
-				Aggregation: &vmcpconfig.AggregationConfig{
-					ConflictResolution: vmcp.ConflictStrategyPrefix,
-					Tools: []*vmcpconfig.WorkloadToolConfig{
-						{
-							Workload: "workload-1",
-							Overrides: map[string]*vmcpconfig.ToolOverride{
-								"tool-zebra": {
-									Name:        "renamed-zebra",
-									Description: "Zebra tool",
-								},
-								"tool-alpha": {
-									Name:        "renamed-alpha",
-									Description: "Alpha tool",
-								},
-								"tool-middle": {
-									Name:        "renamed-middle",
-									Description: "Middle tool",
-								},
+	testVmcp := v1beta1test.NewVirtualMCPServer("test-vmcp", "default",
+		v1beta1test.WithVMCPGroupRef("test-group"),
+		v1beta1test.WithVMCPConfig(vmcpconfig.Config{
+			// Aggregation with tool overrides (map)
+			Aggregation: &vmcpconfig.AggregationConfig{
+				ConflictResolution: vmcp.ConflictStrategyPrefix,
+				Tools: []*vmcpconfig.WorkloadToolConfig{
+					{
+						Workload: "workload-1",
+						Overrides: map[string]*vmcpconfig.ToolOverride{
+							"tool-zebra": {
+								Name:        "renamed-zebra",
+								Description: "Zebra tool",
+							},
+							"tool-alpha": {
+								Name:        "renamed-alpha",
+								Description: "Alpha tool",
+							},
+							"tool-middle": {
+								Name:        "renamed-middle",
+								Description: "Middle tool",
 							},
 						},
 					},
 				},
-				// Operational with PerWorkload timeouts (map)
-				Operational: &vmcpconfig.OperationalConfig{
-					Timeouts: &vmcpconfig.TimeoutConfig{
-						Default: vmcpconfig.Duration(30 * time.Second),
-						PerWorkload: map[string]vmcpconfig.Duration{
-							"workload-zebra":  vmcpconfig.Duration(60 * time.Second),
-							"workload-alpha":  vmcpconfig.Duration(45 * time.Second),
-							"workload-middle": vmcpconfig.Duration(50 * time.Second),
-						},
+			},
+			// Operational with PerWorkload timeouts (map)
+			Operational: &vmcpconfig.OperationalConfig{
+				Timeouts: &vmcpconfig.TimeoutConfig{
+					Default: vmcpconfig.Duration(30 * time.Second),
+					PerWorkload: map[string]vmcpconfig.Duration{
+						"workload-zebra":  vmcpconfig.Duration(60 * time.Second),
+						"workload-alpha":  vmcpconfig.Duration(45 * time.Second),
+						"workload-middle": vmcpconfig.Duration(50 * time.Second),
 					},
 				},
 			},
-			// OutgoingAuth with Backends map
-			OutgoingAuth: &mcpv1beta1.OutgoingAuthConfig{
-				Source: "discovered",
-				Backends: map[string]mcpv1beta1.BackendAuthConfig{
-					"backend-zebra": {
-						Type: mcpv1beta1.BackendAuthTypeDiscovered,
-					},
-					"backend-alpha": {
-						Type: mcpv1beta1.BackendAuthTypeDiscovered,
-					},
-					"backend-middle": {
-						Type: mcpv1beta1.BackendAuthTypeDiscovered,
-					},
+		}),
+		// OutgoingAuth with Backends map
+		v1beta1test.WithVMCPOutgoingAuth(&mcpv1beta1.OutgoingAuthConfig{
+			Source: "discovered",
+			Backends: map[string]mcpv1beta1.BackendAuthConfig{
+				"backend-zebra": {
+					Type: mcpv1beta1.BackendAuthTypeDiscovered,
+				},
+				"backend-alpha": {
+					Type: mcpv1beta1.BackendAuthTypeDiscovered,
+				},
+				"backend-middle": {
+					Type: mcpv1beta1.BackendAuthTypeDiscovered,
 				},
 			},
-		},
-	}
+		}),
+	)
 
 	converter := newTestConverter(t, newNoOpMockResolver(t))
 
@@ -1223,23 +1193,17 @@ func TestVirtualMCPServerReconciler_CompositeToolRefs_EndToEnd(t *testing.T) {
 	}
 
 	// Create VirtualMCPServer that references the composite tool
-	vmcpServer := &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-vmcp",
-			Namespace: "default",
-		},
-		Spec: mcpv1beta1.VirtualMCPServerSpec{
-			GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-			Config: vmcpconfig.Config{
-				CompositeToolRefs: []vmcpconfig.CompositeToolRef{
-					{Name: "test-composite-tool"},
-				},
+	vmcpServer := v1beta1test.NewVirtualMCPServer("test-vmcp", "default",
+		v1beta1test.WithVMCPGroupRef("test-group"),
+		v1beta1test.WithVMCPConfig(vmcpconfig.Config{
+			CompositeToolRefs: []vmcpconfig.CompositeToolRef{
+				{Name: "test-composite-tool"},
 			},
-			IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-				Type: "anonymous",
-			},
-		},
-	}
+		}),
+		v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+			Type: "anonymous",
+		}),
+	)
 
 	// Create fake client with all resources
 	fakeClient := fake.NewClientBuilder().
@@ -1337,36 +1301,30 @@ func TestVirtualMCPServerReconciler_CompositeToolRefs_MergeInlineAndReferenced(t
 	}
 
 	// Create VirtualMCPServer with both inline and referenced tools
-	vmcpServer := &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-vmcp",
-			Namespace: "default",
-		},
-		Spec: mcpv1beta1.VirtualMCPServerSpec{
-			GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-			Config: vmcpconfig.Config{
-				CompositeTools: []vmcpconfig.CompositeToolConfig{
-					{
-						Name:        "inline-tool",
-						Description: "An inline composite tool",
-						Steps: []vmcpconfig.WorkflowStepConfig{
-							{
-								ID:   "step1",
-								Type: "tool",
-								Tool: "backend.inline",
-							},
+	vmcpServer := v1beta1test.NewVirtualMCPServer("test-vmcp", "default",
+		v1beta1test.WithVMCPGroupRef("test-group"),
+		v1beta1test.WithVMCPConfig(vmcpconfig.Config{
+			CompositeTools: []vmcpconfig.CompositeToolConfig{
+				{
+					Name:        "inline-tool",
+					Description: "An inline composite tool",
+					Steps: []vmcpconfig.WorkflowStepConfig{
+						{
+							ID:   "step1",
+							Type: "tool",
+							Tool: "backend.inline",
 						},
 					},
 				},
-				CompositeToolRefs: []vmcpconfig.CompositeToolRef{
-					{Name: "referenced-tool"},
-				},
 			},
-			IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-				Type: "anonymous",
+			CompositeToolRefs: []vmcpconfig.CompositeToolRef{
+				{Name: "referenced-tool"},
 			},
-		},
-	}
+		}),
+		v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+			Type: "anonymous",
+		}),
+	)
 
 	// Create fake client
 	fakeClient := fake.NewClientBuilder().
@@ -1434,23 +1392,17 @@ func TestVirtualMCPServerReconciler_CompositeToolRefs_NotFound(t *testing.T) {
 	}
 
 	// Create VirtualMCPServer that references a non-existent composite tool
-	vmcpServer := &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-vmcp",
-			Namespace: "default",
-		},
-		Spec: mcpv1beta1.VirtualMCPServerSpec{
-			GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-			Config: vmcpconfig.Config{
-				CompositeToolRefs: []vmcpconfig.CompositeToolRef{
-					{Name: "non-existent-tool"},
-				},
+	vmcpServer := v1beta1test.NewVirtualMCPServer("test-vmcp", "default",
+		v1beta1test.WithVMCPGroupRef("test-group"),
+		v1beta1test.WithVMCPConfig(vmcpconfig.Config{
+			CompositeToolRefs: []vmcpconfig.CompositeToolRef{
+				{Name: "non-existent-tool"},
 			},
-			IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-				Type: "anonymous",
-			},
-		},
-	}
+		}),
+		v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+			Type: "anonymous",
+		}),
+	)
 
 	// Create fake client WITHOUT the referenced tool
 	fakeClient := fake.NewClientBuilder().
@@ -1497,21 +1449,15 @@ func TestConfigMapContent_DynamicMode(t *testing.T) {
 	}
 
 	// Create VirtualMCPServer in dynamic mode (source: discovered)
-	vmcpServer := &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-vmcp",
-			Namespace: "default",
-		},
-		Spec: mcpv1beta1.VirtualMCPServerSpec{
-			GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-			IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-				Type: "anonymous",
-			},
-			OutgoingAuth: &mcpv1beta1.OutgoingAuthConfig{
-				Source: "discovered", // Dynamic mode
-			},
-		},
-	}
+	vmcpServer := v1beta1test.NewVirtualMCPServer("test-vmcp", "default",
+		v1beta1test.WithVMCPGroupRef("test-group"),
+		v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+			Type: "anonymous",
+		}),
+		v1beta1test.WithVMCPOutgoingAuth(&mcpv1beta1.OutgoingAuthConfig{
+			Source: "discovered", // Dynamic mode
+		}),
+	)
 
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(testScheme).
@@ -1592,26 +1538,20 @@ func TestConfigMapContent_StaticMode_InlineOverrides(t *testing.T) {
 	)
 
 	// Create VirtualMCPServer in static mode (source: inline)
-	vmcpServer := &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-vmcp",
-			Namespace: "default",
-		},
-		Spec: mcpv1beta1.VirtualMCPServerSpec{
-			GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-			IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-				Type: "anonymous",
-			},
-			OutgoingAuth: &mcpv1beta1.OutgoingAuthConfig{
-				Source: "inline", // Static mode
-				Backends: map[string]mcpv1beta1.BackendAuthConfig{
-					"test-backend": {
-						Type: mcpv1beta1.BackendAuthTypeDiscovered,
-					},
+	vmcpServer := v1beta1test.NewVirtualMCPServer("test-vmcp", "default",
+		v1beta1test.WithVMCPGroupRef("test-group"),
+		v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+			Type: "anonymous",
+		}),
+		v1beta1test.WithVMCPOutgoingAuth(&mcpv1beta1.OutgoingAuthConfig{
+			Source: "inline", // Static mode
+			Backends: map[string]mcpv1beta1.BackendAuthConfig{
+				"test-backend": {
+					Type: mcpv1beta1.BackendAuthTypeDiscovered,
 				},
 			},
-		},
-	}
+		}),
+	)
 
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(testScheme).
@@ -1704,21 +1644,15 @@ func TestConfigMapContent_StaticModeWithDiscovery(t *testing.T) {
 	)
 
 	// Create VirtualMCPServer in static mode (source: inline) WITHOUT inline backends
-	vmcpServer := &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-vmcp",
-			Namespace: "default",
-		},
-		Spec: mcpv1beta1.VirtualMCPServerSpec{
-			GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-			IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-				Type: "anonymous",
-			},
-			OutgoingAuth: &mcpv1beta1.OutgoingAuthConfig{
-				Source: "inline", // Static mode - should discover backends
-			},
-		},
-	}
+	vmcpServer := v1beta1test.NewVirtualMCPServer("test-vmcp", "default",
+		v1beta1test.WithVMCPGroupRef("test-group"),
+		v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+			Type: "anonymous",
+		}),
+		v1beta1test.WithVMCPOutgoingAuth(&mcpv1beta1.OutgoingAuthConfig{
+			Source: "inline", // Static mode - should discover backends
+		}),
+	)
 
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(testScheme).
@@ -1881,40 +1815,24 @@ func TestOptimizerEmbeddingServiceURL(t *testing.T) {
 	}{
 		{
 			name: "referenced embedding server populates full URL",
-			vmcp: &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "my-vmcp",
-					Namespace: testNamespace,
-				},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef: &mcpv1beta1.MCPGroupRef{Name: testGroup},
-					Config: vmcpconfig.Config{
-						Optimizer: &vmcpconfig.OptimizerConfig{},
-					},
-					EmbeddingServerRef: &mcpv1beta1.EmbeddingServerRef{
-						Name: "shared-embedding",
-					},
-				},
-			},
+			vmcp: v1beta1test.NewVirtualMCPServer("my-vmcp", testNamespace,
+				v1beta1test.WithVMCPGroupRef(testGroup),
+				v1beta1test.WithVMCPConfig(vmcpconfig.Config{
+					Optimizer: &vmcpconfig.OptimizerConfig{},
+				}),
+				v1beta1test.WithVMCPEmbeddingServerRef("shared-embedding"),
+			),
 			esName:      "shared-embedding",
 			esPort:      customPort,
 			expectedURL: "http://shared-embedding.default.svc.cluster.local:9090",
 		},
 		{
 			name: "ref without optimizer auto-populates optimizer with defaults",
-			vmcp: &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "my-vmcp",
-					Namespace: testNamespace,
-				},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef: &mcpv1beta1.MCPGroupRef{Name: testGroup},
-					// No Optimizer — validation auto-populates it when ref is set
-					EmbeddingServerRef: &mcpv1beta1.EmbeddingServerRef{
-						Name: "shared-embedding",
-					},
-				},
-			},
+			vmcp: v1beta1test.NewVirtualMCPServer("my-vmcp", testNamespace,
+				v1beta1test.WithVMCPGroupRef(testGroup),
+				// No Optimizer — validation auto-populates it when ref is set
+				v1beta1test.WithVMCPEmbeddingServerRef("shared-embedding"),
+			),
 			esName:      "shared-embedding",
 			esPort:      customPort,
 			expectedURL: "http://shared-embedding.default.svc.cluster.local:9090",
@@ -2079,13 +1997,10 @@ func TestConfigMapContent_SessionStorage(t *testing.T) {
 				Status:     mcpv1beta1.MCPGroupStatus{Phase: mcpv1beta1.MCPGroupPhaseReady},
 			}
 
-			vmcpServer := &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-vmcp-session", Namespace: testNamespace},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef:       &mcpv1beta1.MCPGroupRef{Name: testGroup},
-					SessionStorage: tt.sessionStorage,
-				},
-			}
+			vmcpServer := v1beta1test.NewVirtualMCPServer("test-vmcp-session", testNamespace,
+				v1beta1test.WithVMCPGroupRef(testGroup),
+				v1beta1test.WithVMCPSessionStorage(tt.sessionStorage),
+			)
 
 			fakeClient := fake.NewClientBuilder().
 				WithScheme(testScheme).
@@ -2139,36 +2054,32 @@ func TestEnsureVmcpConfigConfigMap_AuthServerIntegrationValidationError(t *testi
 		upstreamIssuerURL = "https://upstream-idp.example.com"
 	)
 
-	testVmcp := &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:       "test-vmcp",
-			Namespace:  "default",
-			Generation: 3,
-		},
-		Spec: mcpv1beta1.VirtualMCPServerSpec{
-			GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-			IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-				Type:          "oidc",
-				OIDCConfigRef: &mcpv1beta1.MCPOIDCConfigReference{Name: "test-oidc", Audience: audience},
+	testVmcp := v1beta1test.NewVirtualMCPServer("test-vmcp", "default",
+		v1beta1test.WithVMCPGroupRef("test-group"),
+		v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+			Type:          "oidc",
+			OIDCConfigRef: &mcpv1beta1.MCPOIDCConfigReference{Name: "test-oidc", Audience: audience},
+		}),
+		v1beta1test.WithVMCPAuthServerConfig(&mcpv1beta1.EmbeddedAuthServerConfig{
+			Issuer: authServerIssuer,
+			SigningKeySecretRefs: []mcpv1beta1.SecretKeyRef{
+				{Name: "signing-key-secret", Key: "key.pem"},
 			},
-			AuthServerConfig: &mcpv1beta1.EmbeddedAuthServerConfig{
-				Issuer: authServerIssuer,
-				SigningKeySecretRefs: []mcpv1beta1.SecretKeyRef{
-					{Name: "signing-key-secret", Key: "key.pem"},
-				},
-				UpstreamProviders: []mcpv1beta1.UpstreamProviderConfig{
-					{
-						Name: "corporate-idp",
-						Type: mcpv1beta1.UpstreamProviderTypeOIDC,
-						OIDCConfig: &mcpv1beta1.OIDCUpstreamConfig{
-							IssuerURL: upstreamIssuerURL,
-							ClientID:  "upstream-client-id",
-						},
+			UpstreamProviders: []mcpv1beta1.UpstreamProviderConfig{
+				{
+					Name: "corporate-idp",
+					Type: mcpv1beta1.UpstreamProviderTypeOIDC,
+					OIDCConfig: &mcpv1beta1.OIDCUpstreamConfig{
+						IssuerURL: upstreamIssuerURL,
+						ClientID:  "upstream-client-id",
 					},
 				},
 			},
-		},
-	}
+		}),
+		v1beta1test.MutateVMCP(func(v *mcpv1beta1.VirtualMCPServer) {
+			v.Generation = 3
+		}),
+	)
 
 	mcpGroup := &mcpv1beta1.MCPGroup{
 		ObjectMeta: metav1.ObjectMeta{

--- a/cmd/thv-operator/controllers/virtualmcpserver_watch_test.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_watch_test.go
@@ -49,15 +49,9 @@ func TestMapMCPGroupToVirtualMCPServer(t *testing.T) {
 				},
 			},
 			virtualMCPServers: []mcpv1beta1.VirtualMCPServer{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "vmcp-1",
-						Namespace: "default",
-					},
-					Spec: mcpv1beta1.VirtualMCPServerSpec{
-						GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-					},
-				},
+				*v1beta1test.NewVirtualMCPServer("vmcp-1", "default",
+					v1beta1test.WithVMCPGroupRef("test-group"),
+				),
 			},
 			expectedRequests: 1,
 			expectedNames:    []string{"vmcp-1"},
@@ -71,24 +65,12 @@ func TestMapMCPGroupToVirtualMCPServer(t *testing.T) {
 				},
 			},
 			virtualMCPServers: []mcpv1beta1.VirtualMCPServer{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "vmcp-1",
-						Namespace: "default",
-					},
-					Spec: mcpv1beta1.VirtualMCPServerSpec{
-						GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "vmcp-2",
-						Namespace: "default",
-					},
-					Spec: mcpv1beta1.VirtualMCPServerSpec{
-						GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-					},
-				},
+				*v1beta1test.NewVirtualMCPServer("vmcp-1", "default",
+					v1beta1test.WithVMCPGroupRef("test-group"),
+				),
+				*v1beta1test.NewVirtualMCPServer("vmcp-2", "default",
+					v1beta1test.WithVMCPGroupRef("test-group"),
+				),
 			},
 			expectedRequests: 2,
 			expectedNames:    []string{"vmcp-1", "vmcp-2"},
@@ -102,15 +84,9 @@ func TestMapMCPGroupToVirtualMCPServer(t *testing.T) {
 				},
 			},
 			virtualMCPServers: []mcpv1beta1.VirtualMCPServer{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "vmcp-1",
-						Namespace: "default",
-					},
-					Spec: mcpv1beta1.VirtualMCPServerSpec{
-						GroupRef: &mcpv1beta1.MCPGroupRef{Name: "other-group"},
-					},
-				},
+				*v1beta1test.NewVirtualMCPServer("vmcp-1", "default",
+					v1beta1test.WithVMCPGroupRef("other-group"),
+				),
 			},
 			expectedRequests: 0,
 			expectedNames:    []string{},
@@ -124,24 +100,12 @@ func TestMapMCPGroupToVirtualMCPServer(t *testing.T) {
 				},
 			},
 			virtualMCPServers: []mcpv1beta1.VirtualMCPServer{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "vmcp-1",
-						Namespace: "default",
-					},
-					Spec: mcpv1beta1.VirtualMCPServerSpec{
-						GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "vmcp-2",
-						Namespace: "default",
-					},
-					Spec: mcpv1beta1.VirtualMCPServerSpec{
-						GroupRef: &mcpv1beta1.MCPGroupRef{Name: "other-group"},
-					},
-				},
+				*v1beta1test.NewVirtualMCPServer("vmcp-1", "default",
+					v1beta1test.WithVMCPGroupRef("test-group"),
+				),
+				*v1beta1test.NewVirtualMCPServer("vmcp-2", "default",
+					v1beta1test.WithVMCPGroupRef("other-group"),
+				),
 			},
 			expectedRequests: 1,
 			expectedNames:    []string{"vmcp-1"},
@@ -237,15 +201,9 @@ func TestMapMCPServerToVirtualMCPServer(t *testing.T) {
 				},
 			},
 			virtualMCPServers: []mcpv1beta1.VirtualMCPServer{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "vmcp-1",
-						Namespace: "default",
-					},
-					Spec: mcpv1beta1.VirtualMCPServerSpec{
-						GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-					},
-				},
+				*v1beta1test.NewVirtualMCPServer("vmcp-1", "default",
+					v1beta1test.WithVMCPGroupRef("test-group"),
+				),
 			},
 			expectedRequests: 1,
 			expectedNames:    []string{"vmcp-1"},
@@ -265,15 +223,9 @@ func TestMapMCPServerToVirtualMCPServer(t *testing.T) {
 				},
 			},
 			virtualMCPServers: []mcpv1beta1.VirtualMCPServer{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "vmcp-1",
-						Namespace: "default",
-					},
-					Spec: mcpv1beta1.VirtualMCPServerSpec{
-						GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-					},
-				},
+				*v1beta1test.NewVirtualMCPServer("vmcp-1", "default",
+					v1beta1test.WithVMCPGroupRef("test-group"),
+				),
 			},
 			expectedRequests: 0,
 			expectedNames:    []string{},
@@ -293,15 +245,9 @@ func TestMapMCPServerToVirtualMCPServer(t *testing.T) {
 				},
 			},
 			virtualMCPServers: []mcpv1beta1.VirtualMCPServer{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "vmcp-1",
-						Namespace: "default",
-					},
-					Spec: mcpv1beta1.VirtualMCPServerSpec{
-						GroupRef: &mcpv1beta1.MCPGroupRef{Name: "other-group"},
-					},
-				},
+				*v1beta1test.NewVirtualMCPServer("vmcp-1", "default",
+					v1beta1test.WithVMCPGroupRef("other-group"),
+				),
 			},
 			expectedRequests: 0,
 			expectedNames:    []string{},
@@ -330,33 +276,15 @@ func TestMapMCPServerToVirtualMCPServer(t *testing.T) {
 				},
 			},
 			virtualMCPServers: []mcpv1beta1.VirtualMCPServer{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "vmcp-1",
-						Namespace: "default",
-					},
-					Spec: mcpv1beta1.VirtualMCPServerSpec{
-						GroupRef: &mcpv1beta1.MCPGroupRef{Name: "group-1"},
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "vmcp-2",
-						Namespace: "default",
-					},
-					Spec: mcpv1beta1.VirtualMCPServerSpec{
-						GroupRef: &mcpv1beta1.MCPGroupRef{Name: "group-2"},
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "vmcp-3",
-						Namespace: "default",
-					},
-					Spec: mcpv1beta1.VirtualMCPServerSpec{
-						GroupRef: &mcpv1beta1.MCPGroupRef{Name: "group-3"},
-					},
-				},
+				*v1beta1test.NewVirtualMCPServer("vmcp-1", "default",
+					v1beta1test.WithVMCPGroupRef("group-1"),
+				),
+				*v1beta1test.NewVirtualMCPServer("vmcp-2", "default",
+					v1beta1test.WithVMCPGroupRef("group-2"),
+				),
+				*v1beta1test.NewVirtualMCPServer("vmcp-3", "default",
+					v1beta1test.WithVMCPGroupRef("group-3"),
+				),
 			},
 			expectedRequests: 2,
 			expectedNames:    []string{"vmcp-1", "vmcp-2"},
@@ -463,15 +391,9 @@ func TestMapMCPRemoteProxyToVirtualMCPServer(t *testing.T) {
 				},
 			},
 			virtualMCPServers: []mcpv1beta1.VirtualMCPServer{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "vmcp-1",
-						Namespace: "default",
-					},
-					Spec: mcpv1beta1.VirtualMCPServerSpec{
-						GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-					},
-				},
+				*v1beta1test.NewVirtualMCPServer("vmcp-1", "default",
+					v1beta1test.WithVMCPGroupRef("test-group"),
+				),
 			},
 			expectedRequests: 1,
 			expectedNames:    []string{"vmcp-1"},
@@ -491,15 +413,9 @@ func TestMapMCPRemoteProxyToVirtualMCPServer(t *testing.T) {
 				},
 			},
 			virtualMCPServers: []mcpv1beta1.VirtualMCPServer{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "vmcp-1",
-						Namespace: "default",
-					},
-					Spec: mcpv1beta1.VirtualMCPServerSpec{
-						GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-					},
-				},
+				*v1beta1test.NewVirtualMCPServer("vmcp-1", "default",
+					v1beta1test.WithVMCPGroupRef("test-group"),
+				),
 			},
 			expectedRequests: 0,
 			expectedNames:    []string{},
@@ -519,15 +435,9 @@ func TestMapMCPRemoteProxyToVirtualMCPServer(t *testing.T) {
 				},
 			},
 			virtualMCPServers: []mcpv1beta1.VirtualMCPServer{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "vmcp-1",
-						Namespace: "default",
-					},
-					Spec: mcpv1beta1.VirtualMCPServerSpec{
-						GroupRef: &mcpv1beta1.MCPGroupRef{Name: "other-group"},
-					},
-				},
+				*v1beta1test.NewVirtualMCPServer("vmcp-1", "default",
+					v1beta1test.WithVMCPGroupRef("other-group"),
+				),
 			},
 			expectedRequests: 0,
 			expectedNames:    []string{},
@@ -556,33 +466,15 @@ func TestMapMCPRemoteProxyToVirtualMCPServer(t *testing.T) {
 				},
 			},
 			virtualMCPServers: []mcpv1beta1.VirtualMCPServer{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "vmcp-1",
-						Namespace: "default",
-					},
-					Spec: mcpv1beta1.VirtualMCPServerSpec{
-						GroupRef: &mcpv1beta1.MCPGroupRef{Name: "group-1"},
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "vmcp-2",
-						Namespace: "default",
-					},
-					Spec: mcpv1beta1.VirtualMCPServerSpec{
-						GroupRef: &mcpv1beta1.MCPGroupRef{Name: "group-2"},
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "vmcp-3",
-						Namespace: "default",
-					},
-					Spec: mcpv1beta1.VirtualMCPServerSpec{
-						GroupRef: &mcpv1beta1.MCPGroupRef{Name: "group-3"},
-					},
-				},
+				*v1beta1test.NewVirtualMCPServer("vmcp-1", "default",
+					v1beta1test.WithVMCPGroupRef("group-1"),
+				),
+				*v1beta1test.NewVirtualMCPServer("vmcp-2", "default",
+					v1beta1test.WithVMCPGroupRef("group-2"),
+				),
+				*v1beta1test.NewVirtualMCPServer("vmcp-3", "default",
+					v1beta1test.WithVMCPGroupRef("group-3"),
+				),
 			},
 			expectedRequests: 2,
 			expectedNames:    []string{"vmcp-1", "vmcp-2"},
@@ -686,22 +578,16 @@ func TestMapExternalAuthConfigToVirtualMCPServer(t *testing.T) {
 				},
 			},
 			virtualMCPServers: []mcpv1beta1.VirtualMCPServer{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "vmcp-1",
-						Namespace: "default",
-					},
-					Spec: mcpv1beta1.VirtualMCPServerSpec{
-						OutgoingAuth: &mcpv1beta1.OutgoingAuthConfig{
-							Default: &mcpv1beta1.BackendAuthConfig{
-								Type: "externalAuthConfigRef",
-								ExternalAuthConfigRef: &mcpv1beta1.ExternalAuthConfigRef{
-									Name: "test-auth",
-								},
+				*v1beta1test.NewVirtualMCPServer("vmcp-1", "default",
+					v1beta1test.WithVMCPOutgoingAuth(&mcpv1beta1.OutgoingAuthConfig{
+						Default: &mcpv1beta1.BackendAuthConfig{
+							Type: "externalAuthConfigRef",
+							ExternalAuthConfigRef: &mcpv1beta1.ExternalAuthConfigRef{
+								Name: "test-auth",
 							},
 						},
-					},
-				},
+					}),
+				),
 			},
 			expectedRequests: 1,
 			expectedNames:    []string{"vmcp-1"},
@@ -715,24 +601,18 @@ func TestMapExternalAuthConfigToVirtualMCPServer(t *testing.T) {
 				},
 			},
 			virtualMCPServers: []mcpv1beta1.VirtualMCPServer{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "vmcp-1",
-						Namespace: "default",
-					},
-					Spec: mcpv1beta1.VirtualMCPServerSpec{
-						OutgoingAuth: &mcpv1beta1.OutgoingAuthConfig{
-							Backends: map[string]mcpv1beta1.BackendAuthConfig{
-								"backend1": {
-									Type: "externalAuthConfigRef",
-									ExternalAuthConfigRef: &mcpv1beta1.ExternalAuthConfigRef{
-										Name: "test-auth",
-									},
+				*v1beta1test.NewVirtualMCPServer("vmcp-1", "default",
+					v1beta1test.WithVMCPOutgoingAuth(&mcpv1beta1.OutgoingAuthConfig{
+						Backends: map[string]mcpv1beta1.BackendAuthConfig{
+							"backend1": {
+								Type: "externalAuthConfigRef",
+								ExternalAuthConfigRef: &mcpv1beta1.ExternalAuthConfigRef{
+									Name: "test-auth",
 								},
 							},
 						},
-					},
-				},
+					}),
+				),
 			},
 			expectedRequests: 1,
 			expectedNames:    []string{"vmcp-1"},
@@ -746,13 +626,7 @@ func TestMapExternalAuthConfigToVirtualMCPServer(t *testing.T) {
 				},
 			},
 			virtualMCPServers: []mcpv1beta1.VirtualMCPServer{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "vmcp-1",
-						Namespace: "default",
-					},
-					Spec: mcpv1beta1.VirtualMCPServerSpec{},
-				},
+				*v1beta1test.NewVirtualMCPServer("vmcp-1", "default"),
 			},
 			expectedRequests: 0,
 			expectedNames:    []string{},
@@ -766,29 +640,17 @@ func TestMapExternalAuthConfigToVirtualMCPServer(t *testing.T) {
 				},
 			},
 			virtualMCPServers: []mcpv1beta1.VirtualMCPServer{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "vmcp-1",
-						Namespace: "default",
-					},
-					Spec: mcpv1beta1.VirtualMCPServerSpec{
-						OutgoingAuth: &mcpv1beta1.OutgoingAuthConfig{
-							Default: &mcpv1beta1.BackendAuthConfig{
-								Type: "externalAuthConfigRef",
-								ExternalAuthConfigRef: &mcpv1beta1.ExternalAuthConfigRef{
-									Name: "test-auth",
-								},
+				*v1beta1test.NewVirtualMCPServer("vmcp-1", "default",
+					v1beta1test.WithVMCPOutgoingAuth(&mcpv1beta1.OutgoingAuthConfig{
+						Default: &mcpv1beta1.BackendAuthConfig{
+							Type: "externalAuthConfigRef",
+							ExternalAuthConfigRef: &mcpv1beta1.ExternalAuthConfigRef{
+								Name: "test-auth",
 							},
 						},
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "vmcp-2",
-						Namespace: "default",
-					},
-					Spec: mcpv1beta1.VirtualMCPServerSpec{},
-				},
+					}),
+				),
+				*v1beta1test.NewVirtualMCPServer("vmcp-2", "default"),
 			},
 			expectedRequests: 1,
 			expectedNames:    []string{"vmcp-1"},
@@ -814,18 +676,12 @@ func TestMapExternalAuthConfigToVirtualMCPServer(t *testing.T) {
 				},
 			},
 			virtualMCPServers: []mcpv1beta1.VirtualMCPServer{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "vmcp-discovered",
-						Namespace: "default",
-					},
-					Spec: mcpv1beta1.VirtualMCPServerSpec{
-						GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-						OutgoingAuth: &mcpv1beta1.OutgoingAuthConfig{
-							Source: "discovered",
-						},
-					},
-				},
+				*v1beta1test.NewVirtualMCPServer("vmcp-discovered", "default",
+					v1beta1test.WithVMCPGroupRef("test-group"),
+					v1beta1test.WithVMCPOutgoingAuth(&mcpv1beta1.OutgoingAuthConfig{
+						Source: "discovered",
+					}),
+				),
 			},
 			mcpGroups: []mcpv1beta1.MCPGroup{
 				{
@@ -853,18 +709,12 @@ func TestMapExternalAuthConfigToVirtualMCPServer(t *testing.T) {
 				},
 			},
 			virtualMCPServers: []mcpv1beta1.VirtualMCPServer{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "vmcp-discovered",
-						Namespace: "default",
-					},
-					Spec: mcpv1beta1.VirtualMCPServerSpec{
-						GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-						OutgoingAuth: &mcpv1beta1.OutgoingAuthConfig{
-							Source: "discovered",
-						},
-					},
-				},
+				*v1beta1test.NewVirtualMCPServer("vmcp-discovered", "default",
+					v1beta1test.WithVMCPGroupRef("test-group"),
+					v1beta1test.WithVMCPOutgoingAuth(&mcpv1beta1.OutgoingAuthConfig{
+						Source: "discovered",
+					}),
+				),
 			},
 			mcpGroups: []mcpv1beta1.MCPGroup{
 				{
@@ -892,18 +742,12 @@ func TestMapExternalAuthConfigToVirtualMCPServer(t *testing.T) {
 				},
 			},
 			virtualMCPServers: []mcpv1beta1.VirtualMCPServer{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "vmcp-discovered",
-						Namespace: "default",
-					},
-					Spec: mcpv1beta1.VirtualMCPServerSpec{
-						GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-						OutgoingAuth: &mcpv1beta1.OutgoingAuthConfig{
-							Source: "discovered",
-						},
-					},
-				},
+				*v1beta1test.NewVirtualMCPServer("vmcp-discovered", "default",
+					v1beta1test.WithVMCPGroupRef("test-group"),
+					v1beta1test.WithVMCPOutgoingAuth(&mcpv1beta1.OutgoingAuthConfig{
+						Source: "discovered",
+					}),
+				),
 			},
 			mcpGroups: []mcpv1beta1.MCPGroup{
 				{
@@ -931,18 +775,12 @@ func TestMapExternalAuthConfigToVirtualMCPServer(t *testing.T) {
 				},
 			},
 			virtualMCPServers: []mcpv1beta1.VirtualMCPServer{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "vmcp-discovered",
-						Namespace: "default",
-					},
-					Spec: mcpv1beta1.VirtualMCPServerSpec{
-						GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-						OutgoingAuth: &mcpv1beta1.OutgoingAuthConfig{
-							Source: "discovered",
-						},
-					},
-				},
+				*v1beta1test.NewVirtualMCPServer("vmcp-discovered", "default",
+					v1beta1test.WithVMCPGroupRef("test-group"),
+					v1beta1test.WithVMCPOutgoingAuth(&mcpv1beta1.OutgoingAuthConfig{
+						Source: "discovered",
+					}),
+				),
 			},
 			mcpGroups: []mcpv1beta1.MCPGroup{
 				{
@@ -1051,25 +889,19 @@ func TestMapToolConfigToVirtualMCPServer(t *testing.T) {
 				},
 			},
 			virtualMCPServers: []mcpv1beta1.VirtualMCPServer{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "vmcp-1",
-						Namespace: "default",
-					},
-					Spec: mcpv1beta1.VirtualMCPServerSpec{
-						Config: vmcpconfig.Config{
-							Aggregation: &vmcpconfig.AggregationConfig{
-								Tools: []*vmcpconfig.WorkloadToolConfig{
-									{
-										ToolConfigRef: &vmcpconfig.ToolConfigRef{
-											Name: "test-tool-config",
-										},
+				*v1beta1test.NewVirtualMCPServer("vmcp-1", "default",
+					v1beta1test.WithVMCPConfig(vmcpconfig.Config{
+						Aggregation: &vmcpconfig.AggregationConfig{
+							Tools: []*vmcpconfig.WorkloadToolConfig{
+								{
+									ToolConfigRef: &vmcpconfig.ToolConfigRef{
+										Name: "test-tool-config",
 									},
 								},
 							},
 						},
-					},
-				},
+					}),
+				),
 			},
 			expectedRequests: 1,
 			expectedNames:    []string{"vmcp-1"},
@@ -1083,13 +915,7 @@ func TestMapToolConfigToVirtualMCPServer(t *testing.T) {
 				},
 			},
 			virtualMCPServers: []mcpv1beta1.VirtualMCPServer{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "vmcp-1",
-						Namespace: "default",
-					},
-					Spec: mcpv1beta1.VirtualMCPServerSpec{},
-				},
+				*v1beta1test.NewVirtualMCPServer("vmcp-1", "default"),
 			},
 			expectedRequests: 0,
 			expectedNames:    []string{},
@@ -1103,49 +929,37 @@ func TestMapToolConfigToVirtualMCPServer(t *testing.T) {
 				},
 			},
 			virtualMCPServers: []mcpv1beta1.VirtualMCPServer{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "vmcp-1",
-						Namespace: "default",
-					},
-					Spec: mcpv1beta1.VirtualMCPServerSpec{
-						Config: vmcpconfig.Config{
-							Aggregation: &vmcpconfig.AggregationConfig{
-								Tools: []*vmcpconfig.WorkloadToolConfig{
-									{
-										ToolConfigRef: &vmcpconfig.ToolConfigRef{
-											Name: "test-tool-config",
-										},
+				*v1beta1test.NewVirtualMCPServer("vmcp-1", "default",
+					v1beta1test.WithVMCPConfig(vmcpconfig.Config{
+						Aggregation: &vmcpconfig.AggregationConfig{
+							Tools: []*vmcpconfig.WorkloadToolConfig{
+								{
+									ToolConfigRef: &vmcpconfig.ToolConfigRef{
+										Name: "test-tool-config",
 									},
 								},
 							},
 						},
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "vmcp-2",
-						Namespace: "default",
-					},
-					Spec: mcpv1beta1.VirtualMCPServerSpec{
-						Config: vmcpconfig.Config{
-							Aggregation: &vmcpconfig.AggregationConfig{
-								Tools: []*vmcpconfig.WorkloadToolConfig{
-									{
-										ToolConfigRef: &vmcpconfig.ToolConfigRef{
-											Name: "test-tool-config",
-										},
+					}),
+				),
+				*v1beta1test.NewVirtualMCPServer("vmcp-2", "default",
+					v1beta1test.WithVMCPConfig(vmcpconfig.Config{
+						Aggregation: &vmcpconfig.AggregationConfig{
+							Tools: []*vmcpconfig.WorkloadToolConfig{
+								{
+									ToolConfigRef: &vmcpconfig.ToolConfigRef{
+										Name: "test-tool-config",
 									},
-									{
-										ToolConfigRef: &vmcpconfig.ToolConfigRef{
-											Name: "other-tool-config",
-										},
+								},
+								{
+									ToolConfigRef: &vmcpconfig.ToolConfigRef{
+										Name: "other-tool-config",
 									},
 								},
 							},
 						},
-					},
-				},
+					}),
+				),
 			},
 			expectedRequests: 2,
 			expectedNames:    []string{"vmcp-1", "vmcp-2"},
@@ -1207,79 +1021,71 @@ func TestVmcpReferencesToolConfig(t *testing.T) {
 	}{
 		{
 			name: "VirtualMCPServer references ToolConfig",
-			vmcp: &mcpv1beta1.VirtualMCPServer{
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					Config: vmcpconfig.Config{
-						Aggregation: &vmcpconfig.AggregationConfig{
-							Tools: []*vmcpconfig.WorkloadToolConfig{
-								{
-									ToolConfigRef: &vmcpconfig.ToolConfigRef{
-										Name: "test-config",
-									},
+			vmcp: v1beta1test.NewVirtualMCPServer("", "",
+				v1beta1test.WithVMCPConfig(vmcpconfig.Config{
+					Aggregation: &vmcpconfig.AggregationConfig{
+						Tools: []*vmcpconfig.WorkloadToolConfig{
+							{
+								ToolConfigRef: &vmcpconfig.ToolConfigRef{
+									Name: "test-config",
 								},
 							},
 						},
 					},
-				},
-			},
+				}),
+			),
 			configName: "test-config",
 			expected:   true,
 		},
 		{
 			name: "VirtualMCPServer does not reference ToolConfig",
-			vmcp: &mcpv1beta1.VirtualMCPServer{
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					Config: vmcpconfig.Config{
-						Aggregation: &vmcpconfig.AggregationConfig{
-							Tools: []*vmcpconfig.WorkloadToolConfig{
-								{
-									ToolConfigRef: &vmcpconfig.ToolConfigRef{
-										Name: "other-config",
-									},
+			vmcp: v1beta1test.NewVirtualMCPServer("", "",
+				v1beta1test.WithVMCPConfig(vmcpconfig.Config{
+					Aggregation: &vmcpconfig.AggregationConfig{
+						Tools: []*vmcpconfig.WorkloadToolConfig{
+							{
+								ToolConfigRef: &vmcpconfig.ToolConfigRef{
+									Name: "other-config",
 								},
 							},
 						},
 					},
-				},
-			},
+				}),
+			),
 			configName: "test-config",
 			expected:   false,
 		},
 		{
-			name: "VirtualMCPServer has no Aggregation",
-			vmcp: &mcpv1beta1.VirtualMCPServer{
-				Spec: mcpv1beta1.VirtualMCPServerSpec{},
-			},
+			name:       "VirtualMCPServer has no Aggregation",
+			vmcp:       v1beta1test.NewVirtualMCPServer("", ""),
 			configName: "test-config",
 			expected:   false,
 		},
 		{
 			name: "VirtualMCPServer references ToolConfig among multiple tools",
-			vmcp: &mcpv1beta1.VirtualMCPServer{
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					Config: vmcpconfig.Config{
-						Aggregation: &vmcpconfig.AggregationConfig{
-							Tools: []*vmcpconfig.WorkloadToolConfig{
-								{
-									ToolConfigRef: &vmcpconfig.ToolConfigRef{
-										Name: "other-config",
-									},
+			vmcp: v1beta1test.NewVirtualMCPServer("", "",
+				v1beta1test.WithVMCPConfig(vmcpconfig.Config{
+					Aggregation: &vmcpconfig.AggregationConfig{
+						Tools: []*vmcpconfig.WorkloadToolConfig{
+							{
+								ToolConfigRef: &vmcpconfig.ToolConfigRef{
+									Name: "other-config",
 								},
-								{
-									ToolConfigRef: &vmcpconfig.ToolConfigRef{
-										Name: "test-config",
-									},
+							},
+							{
+								ToolConfigRef: &vmcpconfig.ToolConfigRef{
+									Name: "test-config",
 								},
-								{
-									ToolConfigRef: &vmcpconfig.ToolConfigRef{
-										Name: "another-config",
-									},
+							},
+							{
+								ToolConfigRef: &vmcpconfig.ToolConfigRef{
+									Name: "another-config",
 								},
 							},
 						},
 					},
-				},
-			},
+				}),
+			),
 			configName: "test-config",
 			expected:   true,
 		},
@@ -1311,117 +1117,97 @@ func TestVmcpReferencesExternalAuthConfig(t *testing.T) {
 	}{
 		{
 			name: "VirtualMCPServer references ExternalAuthConfig in default backend auth",
-			vmcp: &mcpv1beta1.VirtualMCPServer{
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					OutgoingAuth: &mcpv1beta1.OutgoingAuthConfig{
-						Default: &mcpv1beta1.BackendAuthConfig{
+			vmcp: v1beta1test.NewVirtualMCPServer("", "",
+				v1beta1test.WithVMCPOutgoingAuth(&mcpv1beta1.OutgoingAuthConfig{
+					Default: &mcpv1beta1.BackendAuthConfig{
+						Type: "externalAuthConfigRef",
+						ExternalAuthConfigRef: &mcpv1beta1.ExternalAuthConfigRef{
+							Name: "test-auth",
+						},
+					},
+				}),
+			),
+			authConfigName: "test-auth",
+			expected:       true,
+		},
+		{
+			name: "VirtualMCPServer references ExternalAuthConfig in per-backend auth",
+			vmcp: v1beta1test.NewVirtualMCPServer("", "",
+				v1beta1test.WithVMCPOutgoingAuth(&mcpv1beta1.OutgoingAuthConfig{
+					Backends: map[string]mcpv1beta1.BackendAuthConfig{
+						"backend1": {
 							Type: "externalAuthConfigRef",
 							ExternalAuthConfigRef: &mcpv1beta1.ExternalAuthConfigRef{
 								Name: "test-auth",
 							},
 						},
 					},
-				},
-			},
+				}),
+			),
 			authConfigName: "test-auth",
 			expected:       true,
 		},
 		{
-			name: "VirtualMCPServer references ExternalAuthConfig in per-backend auth",
-			vmcp: &mcpv1beta1.VirtualMCPServer{
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					OutgoingAuth: &mcpv1beta1.OutgoingAuthConfig{
-						Backends: map[string]mcpv1beta1.BackendAuthConfig{
-							"backend1": {
-								Type: "externalAuthConfigRef",
-								ExternalAuthConfigRef: &mcpv1beta1.ExternalAuthConfigRef{
-									Name: "test-auth",
-								},
-							},
-						},
-					},
-				},
-			},
-			authConfigName: "test-auth",
-			expected:       true,
-		},
-		{
-			name: "VirtualMCPServer does not reference ExternalAuthConfig",
-			vmcp: &mcpv1beta1.VirtualMCPServer{
-				Spec: mcpv1beta1.VirtualMCPServerSpec{},
-			},
+			name:           "VirtualMCPServer does not reference ExternalAuthConfig",
+			vmcp:           v1beta1test.NewVirtualMCPServer("", ""),
 			authConfigName: "test-auth",
 			expected:       false,
 		},
 		{
-			name: "VirtualMCPServer has no OutgoingAuth",
-			vmcp: &mcpv1beta1.VirtualMCPServer{
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					OutgoingAuth: nil,
-				},
-			},
+			name:           "VirtualMCPServer has no OutgoingAuth",
+			vmcp:           v1beta1test.NewVirtualMCPServer("", ""),
 			authConfigName: "test-auth",
 			expected:       false,
 		},
 		{
 			name: "VirtualMCPServer references different ExternalAuthConfig",
-			vmcp: &mcpv1beta1.VirtualMCPServer{
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					OutgoingAuth: &mcpv1beta1.OutgoingAuthConfig{
-						Default: &mcpv1beta1.BackendAuthConfig{
-							Type: "externalAuthConfigRef",
-							ExternalAuthConfigRef: &mcpv1beta1.ExternalAuthConfigRef{
-								Name: "other-auth",
-							},
+			vmcp: v1beta1test.NewVirtualMCPServer("", "",
+				v1beta1test.WithVMCPOutgoingAuth(&mcpv1beta1.OutgoingAuthConfig{
+					Default: &mcpv1beta1.BackendAuthConfig{
+						Type: "externalAuthConfigRef",
+						ExternalAuthConfigRef: &mcpv1beta1.ExternalAuthConfigRef{
+							Name: "other-auth",
 						},
 					},
-				},
-			},
+				}),
+			),
 			authConfigName: "test-auth",
 			expected:       false,
 		},
 		{
 			name: "VirtualMCPServer references ExternalAuthConfig in multiple backends",
-			vmcp: &mcpv1beta1.VirtualMCPServer{
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					OutgoingAuth: &mcpv1beta1.OutgoingAuthConfig{
-						Backends: map[string]mcpv1beta1.BackendAuthConfig{
-							"backend1": {
-								Type: "externalAuthConfigRef",
-								ExternalAuthConfigRef: &mcpv1beta1.ExternalAuthConfigRef{
-									Name: "other-auth",
-								},
-							},
-							"backend2": {
-								Type: "externalAuthConfigRef",
-								ExternalAuthConfigRef: &mcpv1beta1.ExternalAuthConfigRef{
-									Name: "test-auth",
-								},
-							},
-							"backend3": {
-								Type: "service_account",
+			vmcp: v1beta1test.NewVirtualMCPServer("", "",
+				v1beta1test.WithVMCPOutgoingAuth(&mcpv1beta1.OutgoingAuthConfig{
+					Backends: map[string]mcpv1beta1.BackendAuthConfig{
+						"backend1": {
+							Type: "externalAuthConfigRef",
+							ExternalAuthConfigRef: &mcpv1beta1.ExternalAuthConfigRef{
+								Name: "other-auth",
 							},
 						},
+						"backend2": {
+							Type: "externalAuthConfigRef",
+							ExternalAuthConfigRef: &mcpv1beta1.ExternalAuthConfigRef{
+								Name: "test-auth",
+							},
+						},
+						"backend3": {
+							Type: "service_account",
+						},
 					},
-				},
-			},
+				}),
+			),
 			authConfigName: "test-auth",
 			expected:       true,
 		},
 		{
 			name: "VirtualMCPServer with discovered mode - MCPServer references auth config",
-			vmcp: &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "vmcp-discovered",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-					OutgoingAuth: &mcpv1beta1.OutgoingAuthConfig{
-						Source: "discovered",
-					},
-				},
-			},
+			vmcp: v1beta1test.NewVirtualMCPServer("vmcp-discovered", "default",
+				v1beta1test.WithVMCPGroupRef("test-group"),
+				v1beta1test.WithVMCPOutgoingAuth(&mcpv1beta1.OutgoingAuthConfig{
+					Source: "discovered",
+				}),
+			),
 			mcpGroups: []mcpv1beta1.MCPGroup{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -1441,18 +1227,12 @@ func TestVmcpReferencesExternalAuthConfig(t *testing.T) {
 		},
 		{
 			name: "VirtualMCPServer with discovered mode - no MCPServer references auth config",
-			vmcp: &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "vmcp-discovered",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-					OutgoingAuth: &mcpv1beta1.OutgoingAuthConfig{
-						Source: "discovered",
-					},
-				},
-			},
+			vmcp: v1beta1test.NewVirtualMCPServer("vmcp-discovered", "default",
+				v1beta1test.WithVMCPGroupRef("test-group"),
+				v1beta1test.WithVMCPOutgoingAuth(&mcpv1beta1.OutgoingAuthConfig{
+					Source: "discovered",
+				}),
+			),
 			mcpGroups: []mcpv1beta1.MCPGroup{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -1472,35 +1252,23 @@ func TestVmcpReferencesExternalAuthConfig(t *testing.T) {
 		},
 		{
 			name: "VirtualMCPServer with discovered mode - MCPGroup does not exist",
-			vmcp: &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "vmcp-discovered",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef: &mcpv1beta1.MCPGroupRef{Name: "nonexistent-group"},
-					OutgoingAuth: &mcpv1beta1.OutgoingAuthConfig{
-						Source: "discovered",
-					},
-				},
-			},
+			vmcp: v1beta1test.NewVirtualMCPServer("vmcp-discovered", "default",
+				v1beta1test.WithVMCPGroupRef("nonexistent-group"),
+				v1beta1test.WithVMCPOutgoingAuth(&mcpv1beta1.OutgoingAuthConfig{
+					Source: "discovered",
+				}),
+			),
 			authConfigName: "test-auth",
 			expected:       false,
 		},
 		{
 			name: "VirtualMCPServer with discovered mode - multiple MCPServers, one references auth config",
-			vmcp: &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "vmcp-discovered",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-					OutgoingAuth: &mcpv1beta1.OutgoingAuthConfig{
-						Source: "discovered",
-					},
-				},
-			},
+			vmcp: v1beta1test.NewVirtualMCPServer("vmcp-discovered", "default",
+				v1beta1test.WithVMCPGroupRef("test-group"),
+				v1beta1test.WithVMCPOutgoingAuth(&mcpv1beta1.OutgoingAuthConfig{
+					Source: "discovered",
+				}),
+			),
 			mcpGroups: []mcpv1beta1.MCPGroup{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -1527,18 +1295,12 @@ func TestVmcpReferencesExternalAuthConfig(t *testing.T) {
 		},
 		{
 			name: "VirtualMCPServer with discovered mode - MCPRemoteProxy references auth config",
-			vmcp: &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "vmcp-discovered",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-					OutgoingAuth: &mcpv1beta1.OutgoingAuthConfig{
-						Source: "discovered",
-					},
-				},
-			},
+			vmcp: v1beta1test.NewVirtualMCPServer("vmcp-discovered", "default",
+				v1beta1test.WithVMCPGroupRef("test-group"),
+				v1beta1test.WithVMCPOutgoingAuth(&mcpv1beta1.OutgoingAuthConfig{
+					Source: "discovered",
+				}),
+			),
 			mcpGroups: []mcpv1beta1.MCPGroup{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -1558,18 +1320,12 @@ func TestVmcpReferencesExternalAuthConfig(t *testing.T) {
 		},
 		{
 			name: "VirtualMCPServer with discovered mode - MCPRemoteProxy does not reference auth config",
-			vmcp: &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "vmcp-discovered",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-					OutgoingAuth: &mcpv1beta1.OutgoingAuthConfig{
-						Source: "discovered",
-					},
-				},
-			},
+			vmcp: v1beta1test.NewVirtualMCPServer("vmcp-discovered", "default",
+				v1beta1test.WithVMCPGroupRef("test-group"),
+				v1beta1test.WithVMCPOutgoingAuth(&mcpv1beta1.OutgoingAuthConfig{
+					Source: "discovered",
+				}),
+			),
 			mcpGroups: []mcpv1beta1.MCPGroup{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -1658,16 +1414,10 @@ func TestMapEmbeddingServerToVirtualMCPServer(t *testing.T) {
 			name:            "single VirtualMCPServer references EmbeddingServer",
 			embeddingServer: v1beta1test.NewEmbeddingServer("shared-embedding", "default"),
 			virtualMCPServers: []mcpv1beta1.VirtualMCPServer{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "vmcp-1",
-						Namespace: "default",
-					},
-					Spec: mcpv1beta1.VirtualMCPServerSpec{
-						GroupRef:           &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-						EmbeddingServerRef: &mcpv1beta1.EmbeddingServerRef{Name: "shared-embedding"},
-					},
-				},
+				*v1beta1test.NewVirtualMCPServer("vmcp-1", "default",
+					v1beta1test.WithVMCPGroupRef("test-group"),
+					v1beta1test.WithVMCPEmbeddingServerRef("shared-embedding"),
+				),
 			},
 			expectedRequests: 1,
 			expectedNames:    []string{"vmcp-1"},
@@ -1676,26 +1426,14 @@ func TestMapEmbeddingServerToVirtualMCPServer(t *testing.T) {
 			name:            "multiple VirtualMCPServers share EmbeddingServer",
 			embeddingServer: v1beta1test.NewEmbeddingServer("shared-embedding", "default"),
 			virtualMCPServers: []mcpv1beta1.VirtualMCPServer{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "vmcp-1",
-						Namespace: "default",
-					},
-					Spec: mcpv1beta1.VirtualMCPServerSpec{
-						GroupRef:           &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-						EmbeddingServerRef: &mcpv1beta1.EmbeddingServerRef{Name: "shared-embedding"},
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "vmcp-2",
-						Namespace: "default",
-					},
-					Spec: mcpv1beta1.VirtualMCPServerSpec{
-						GroupRef:           &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-						EmbeddingServerRef: &mcpv1beta1.EmbeddingServerRef{Name: "shared-embedding"},
-					},
-				},
+				*v1beta1test.NewVirtualMCPServer("vmcp-1", "default",
+					v1beta1test.WithVMCPGroupRef("test-group"),
+					v1beta1test.WithVMCPEmbeddingServerRef("shared-embedding"),
+				),
+				*v1beta1test.NewVirtualMCPServer("vmcp-2", "default",
+					v1beta1test.WithVMCPGroupRef("test-group"),
+					v1beta1test.WithVMCPEmbeddingServerRef("shared-embedding"),
+				),
 			},
 			expectedRequests: 2,
 			expectedNames:    []string{"vmcp-1", "vmcp-2"},
@@ -1704,16 +1442,10 @@ func TestMapEmbeddingServerToVirtualMCPServer(t *testing.T) {
 			name:            "no VirtualMCPServers reference EmbeddingServer",
 			embeddingServer: v1beta1test.NewEmbeddingServer("shared-embedding", "default"),
 			virtualMCPServers: []mcpv1beta1.VirtualMCPServer{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "vmcp-1",
-						Namespace: "default",
-					},
-					Spec: mcpv1beta1.VirtualMCPServerSpec{
-						GroupRef:           &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-						EmbeddingServerRef: &mcpv1beta1.EmbeddingServerRef{Name: "other-embedding"},
-					},
-				},
+				*v1beta1test.NewVirtualMCPServer("vmcp-1", "default",
+					v1beta1test.WithVMCPGroupRef("test-group"),
+					v1beta1test.WithVMCPEmbeddingServerRef("other-embedding"),
+				),
 			},
 			expectedRequests: 0,
 			expectedNames:    []string{},

--- a/cmd/thv-operator/pkg/controllerutil/config_test.go
+++ b/cmd/thv-operator/pkg/controllerutil/config_test.go
@@ -483,22 +483,16 @@ func TestGetTelemetryConfigForVirtualMCPServer(t *testing.T) {
 		expectedName    string
 	}{
 		{
-			name: "nil ref returns nil without error",
-			vmcp: &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-vmcp", Namespace: "default"},
-				Spec:       mcpv1beta1.VirtualMCPServerSpec{TelemetryConfigRef: nil},
-			},
+			name:        "nil ref returns nil without error",
+			vmcp:        v1beta1test.NewVirtualMCPServer("test-vmcp", "default"),
 			expectNil:   true,
 			expectError: false,
 		},
 		{
 			name: "fetches referenced config",
-			vmcp: &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-vmcp", Namespace: "default"},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					TelemetryConfigRef: &mcpv1beta1.MCPTelemetryConfigReference{Name: "my-telemetry"},
-				},
-			},
+			vmcp: v1beta1test.NewVirtualMCPServer("test-vmcp", "default",
+				v1beta1test.WithVMCPTelemetryConfigRef("my-telemetry"),
+			),
 			telemetryConfig: &mcpv1beta1.MCPTelemetryConfig{
 				ObjectMeta: metav1.ObjectMeta{Name: "my-telemetry", Namespace: "default"},
 			},
@@ -508,23 +502,17 @@ func TestGetTelemetryConfigForVirtualMCPServer(t *testing.T) {
 		},
 		{
 			name: "not found returns nil without error",
-			vmcp: &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-vmcp", Namespace: "default"},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					TelemetryConfigRef: &mcpv1beta1.MCPTelemetryConfigReference{Name: "missing"},
-				},
-			},
+			vmcp: v1beta1test.NewVirtualMCPServer("test-vmcp", "default",
+				v1beta1test.WithVMCPTelemetryConfigRef("missing"),
+			),
 			expectNil:   true,
 			expectError: false,
 		},
 		{
 			name: "cross-namespace returns nil (not found)",
-			vmcp: &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-vmcp", Namespace: "namespace-b"},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					TelemetryConfigRef: &mcpv1beta1.MCPTelemetryConfigReference{Name: "shared-config"},
-				},
-			},
+			vmcp: v1beta1test.NewVirtualMCPServer("test-vmcp", "namespace-b",
+				v1beta1test.WithVMCPTelemetryConfigRef("shared-config"),
+			),
 			telemetryConfig: &mcpv1beta1.MCPTelemetryConfig{
 				ObjectMeta: metav1.ObjectMeta{Name: "shared-config", Namespace: "namespace-a"},
 			},

--- a/cmd/thv-operator/pkg/virtualmcpserverstatus/collector_test.go
+++ b/cmd/thv-operator/pkg/virtualmcpserverstatus/collector_test.go
@@ -11,6 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1/v1beta1test"
 )
 
 func TestStatusCollector_SetPhase(t *testing.T) {
@@ -280,32 +281,30 @@ func TestStatusCollector_RemoveConditionsWithPrefix(t *testing.T) {
 	t.Parallel()
 
 	// Create a VirtualMCPServer with existing conditions
-	vmcp := &mcpv1beta1.VirtualMCPServer{
-		Status: mcpv1beta1.VirtualMCPServerStatus{
-			Conditions: []metav1.Condition{
-				{
-					Type:   "DiscoveredAuthConfig-backend-1",
-					Status: metav1.ConditionTrue,
-					Reason: "ConversionSucceeded",
-				},
-				{
-					Type:   "DiscoveredAuthConfig-backend-2",
-					Status: metav1.ConditionTrue,
-					Reason: "ConversionSucceeded",
-				},
-				{
-					Type:   "DiscoveredAuthConfig-backend-3",
-					Status: metav1.ConditionFalse,
-					Reason: "ConversionFailed",
-				},
-				{
-					Type:   "Ready",
-					Status: metav1.ConditionTrue,
-					Reason: "DeploymentReady",
-				},
+	vmcp := v1beta1test.NewVirtualMCPServer("", "", v1beta1test.WithVMCPStatus(mcpv1beta1.VirtualMCPServerStatus{
+		Conditions: []metav1.Condition{
+			{
+				Type:   "DiscoveredAuthConfig-backend-1",
+				Status: metav1.ConditionTrue,
+				Reason: "ConversionSucceeded",
+			},
+			{
+				Type:   "DiscoveredAuthConfig-backend-2",
+				Status: metav1.ConditionTrue,
+				Reason: "ConversionSucceeded",
+			},
+			{
+				Type:   "DiscoveredAuthConfig-backend-3",
+				Status: metav1.ConditionFalse,
+				Reason: "ConversionFailed",
+			},
+			{
+				Type:   "Ready",
+				Status: metav1.ConditionTrue,
+				Reason: "DeploymentReady",
 			},
 		},
-	}
+	}))
 	collector := NewStatusManager(vmcp)
 
 	// Remove all DiscoveredAuthConfig conditions except backend-1

--- a/cmd/thv-operator/pkg/vmcpconfig/converter_authz_configmap_test.go
+++ b/cmd/thv-operator/pkg/vmcpconfig/converter_authz_configmap_test.go
@@ -18,6 +18,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1/v1beta1test"
 	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 	vmcpconfig "github.com/stacklok/toolhive/pkg/vmcp/config"
 )
@@ -57,16 +58,13 @@ func newAuthzVmcpForConfigMap(
 		authzRefMutate(authzRef)
 	}
 
-	vmcp := &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{Name: "test-vmcp", Namespace: "default"},
-		Spec: mcpv1beta1.VirtualMCPServerSpec{
-			GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-			IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-				Type:        "anonymous",
-				AuthzConfig: authzRef,
-			},
-		},
-	}
+	vmcp := v1beta1test.NewVirtualMCPServer("test-vmcp", "default",
+		v1beta1test.WithVMCPGroupRef("test-group"),
+		v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+			Type:        "anonymous",
+			AuthzConfig: authzRef,
+		}),
+	)
 	if len(auth.upstreams) > 0 {
 		ups := make([]mcpv1beta1.UpstreamProviderConfig, 0, len(auth.upstreams))
 		for _, name := range auth.upstreams {
@@ -301,25 +299,22 @@ func TestConvertAuthzConfig_ConfigMapPath(t *testing.T) {
 func TestConvertAuthzConfig_InlinePath_NewFieldsSourcedFromAuthzConfigRef(t *testing.T) {
 	t.Parallel()
 
-	vmcp := &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{Name: "test-vmcp", Namespace: "default"},
-		Spec: mcpv1beta1.VirtualMCPServerSpec{
-			GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-			IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-				Type: "anonymous",
-				AuthzConfig: &mcpv1beta1.AuthzConfigRef{
-					Type: mcpv1beta1.AuthzConfigTypeInline,
-					Inline: &mcpv1beta1.InlineAuthzConfig{
-						Policies:     []string{`permit(principal, action, resource);`},
-						EntitiesJSON: `[{"uid":{"type":"ClaimGroup","id":"engineering"}}]`,
-					},
-					GroupClaimName:  "groups",
-					RoleClaimName:   "roles",
-					GroupEntityType: "ClaimGroup",
+	vmcp := v1beta1test.NewVirtualMCPServer("test-vmcp", "default",
+		v1beta1test.WithVMCPGroupRef("test-group"),
+		v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+			Type: "anonymous",
+			AuthzConfig: &mcpv1beta1.AuthzConfigRef{
+				Type: mcpv1beta1.AuthzConfigTypeInline,
+				Inline: &mcpv1beta1.InlineAuthzConfig{
+					Policies:     []string{`permit(principal, action, resource);`},
+					EntitiesJSON: `[{"uid":{"type":"ClaimGroup","id":"engineering"}}]`,
 				},
+				GroupClaimName:  "groups",
+				RoleClaimName:   "roles",
+				GroupEntityType: "ClaimGroup",
 			},
-		},
-	}
+		}),
+	)
 
 	ctx := log.IntoContext(t.Context(), logr.Discard())
 	converter := converterWithObjects(t)
@@ -346,18 +341,15 @@ func TestConvertAuthzConfig_InlinePath_NewFieldsSourcedFromAuthzConfigRef(t *tes
 func TestConvertAuthzConfig_UnknownTypeIsRejected(t *testing.T) {
 	t.Parallel()
 
-	vmcp := &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{Name: "test-vmcp", Namespace: "default"},
-		Spec: mcpv1beta1.VirtualMCPServerSpec{
-			GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-			IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-				Type: "anonymous",
-				AuthzConfig: &mcpv1beta1.AuthzConfigRef{
-					Type: "future-authorizer",
-				},
+	vmcp := v1beta1test.NewVirtualMCPServer("test-vmcp", "default",
+		v1beta1test.WithVMCPGroupRef("test-group"),
+		v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+			Type: "anonymous",
+			AuthzConfig: &mcpv1beta1.AuthzConfigRef{
+				Type: "future-authorizer",
 			},
-		},
-	}
+		}),
+	)
 
 	ctx := log.IntoContext(t.Context(), logr.Discard())
 	converter := converterWithObjects(t)

--- a/cmd/thv-operator/pkg/vmcpconfig/converter_test.go
+++ b/cmd/thv-operator/pkg/vmcpconfig/converter_test.go
@@ -21,6 +21,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1/v1beta1test"
 	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 	"github.com/stacklok/toolhive/cmd/thv-operator/pkg/controllerutil"
 	"github.com/stacklok/toolhive/cmd/thv-operator/pkg/oidc"
@@ -56,13 +57,10 @@ func newTestConverter(t *testing.T, resolver oidc.Resolver) *Converter {
 
 // newTestVMCPServer creates a VirtualMCPServer with an MCPOIDCConfigReference for testing.
 func newTestVMCPServer(oidcConfigRef *mcpv1beta1.MCPOIDCConfigReference) *mcpv1beta1.VirtualMCPServer {
-	return &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{Name: "test-vmcp", Namespace: "default"},
-		Spec: mcpv1beta1.VirtualMCPServerSpec{
-			GroupRef:     &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-			IncomingAuth: &mcpv1beta1.IncomingAuthConfig{Type: "oidc", OIDCConfigRef: oidcConfigRef},
-		},
-	}
+	return v1beta1test.NewVirtualMCPServer("test-vmcp", "default",
+		v1beta1test.WithVMCPGroupRef("test-group"),
+		v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{Type: "oidc", OIDCConfigRef: oidcConfigRef}),
+	)
 }
 
 // newTestMCPOIDCConfig creates an MCPOIDCConfig resource for testing with the given spec type.
@@ -224,37 +222,31 @@ func TestConverter_OIDCResolution(t *testing.T) {
 func TestConverter_CompositeToolsPassThrough(t *testing.T) {
 	t.Parallel()
 
-	vmcpServer := &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-vmcp",
-			Namespace: "default",
-		},
-		Spec: mcpv1beta1.VirtualMCPServerSpec{
-			GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-			Config: vmcpconfig.Config{
-				CompositeTools: []vmcpconfig.CompositeToolConfig{
-					{
-						Name:        "test-composite-tool",
-						Description: "A test composite tool",
-						Timeout:     vmcpconfig.Duration(30 * time.Second),
-						Steps: []vmcpconfig.WorkflowStepConfig{
-							{
-								ID:   "step1",
-								Type: "tool",
-								Tool: "backend.some-tool",
-							},
-							{
-								ID:        "step2",
-								Type:      "tool",
-								Tool:      "backend.other-tool",
-								DependsOn: []string{"step1"},
-							},
+	vmcpServer := v1beta1test.NewVirtualMCPServer("test-vmcp", "default",
+		v1beta1test.WithVMCPGroupRef("test-group"),
+		v1beta1test.WithVMCPConfig(vmcpconfig.Config{
+			CompositeTools: []vmcpconfig.CompositeToolConfig{
+				{
+					Name:        "test-composite-tool",
+					Description: "A test composite tool",
+					Timeout:     vmcpconfig.Duration(30 * time.Second),
+					Steps: []vmcpconfig.WorkflowStepConfig{
+						{
+							ID:   "step1",
+							Type: "tool",
+							Tool: "backend.some-tool",
+						},
+						{
+							ID:        "step2",
+							Type:      "tool",
+							Tool:      "backend.other-tool",
+							DependsOn: []string{"step1"},
 						},
 					},
 				},
 			},
-		},
-	}
+		}),
+	)
 
 	converter := newTestConverter(t, newNoOpMockResolver(t))
 	ctx := log.IntoContext(context.Background(), logr.Discard())
@@ -391,16 +383,10 @@ func TestConverter_IncomingAuthRequired(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			vmcpServer := &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-vmcp",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef:     &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-					IncomingAuth: tt.incomingAuth,
-				},
-			}
+			vmcpServer := v1beta1test.NewVirtualMCPServer("test-vmcp", "default",
+				v1beta1test.WithVMCPGroupRef("test-group"),
+				v1beta1test.WithVMCPIncomingAuth(tt.incomingAuth),
+			)
 
 			// Set up mock resolver based on test expectations
 			ctrl := gomock.NewController(t)
@@ -466,20 +452,14 @@ func TestConverter_CompositeToolRefs(t *testing.T) {
 	}{
 		{
 			name: "successfully fetch and merge referenced composite tool",
-			vmcp: &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-vmcp",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-					Config: vmcpconfig.Config{
-						CompositeToolRefs: []vmcpconfig.CompositeToolRef{
-							{Name: "referenced-tool"},
-						},
+			vmcp: v1beta1test.NewVirtualMCPServer("test-vmcp", "default",
+				v1beta1test.WithVMCPGroupRef("test-group"),
+				v1beta1test.WithVMCPConfig(vmcpconfig.Config{
+					CompositeToolRefs: []vmcpconfig.CompositeToolRef{
+						{Name: "referenced-tool"},
 					},
-				},
-			},
+				}),
+			),
 			compositeDefs: []*mcpv1beta1.VirtualMCPCompositeToolDefinition{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -514,33 +494,27 @@ func TestConverter_CompositeToolRefs(t *testing.T) {
 		},
 		{
 			name: "merge inline and referenced composite tools",
-			vmcp: &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-vmcp",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-					Config: vmcpconfig.Config{
-						CompositeTools: []vmcpconfig.CompositeToolConfig{
-							{
-								Name:        "inline-tool",
-								Description: "An inline composite tool",
-								Steps: []vmcpconfig.WorkflowStepConfig{
-									{
-										ID:   "step1",
-										Type: "tool",
-										Tool: "backend.inline-tool",
-									},
+			vmcp: v1beta1test.NewVirtualMCPServer("test-vmcp", "default",
+				v1beta1test.WithVMCPGroupRef("test-group"),
+				v1beta1test.WithVMCPConfig(vmcpconfig.Config{
+					CompositeTools: []vmcpconfig.CompositeToolConfig{
+						{
+							Name:        "inline-tool",
+							Description: "An inline composite tool",
+							Steps: []vmcpconfig.WorkflowStepConfig{
+								{
+									ID:   "step1",
+									Type: "tool",
+									Tool: "backend.inline-tool",
 								},
 							},
 						},
-						CompositeToolRefs: []vmcpconfig.CompositeToolRef{
-							{Name: "referenced-tool"},
-						},
 					},
-				},
-			},
+					CompositeToolRefs: []vmcpconfig.CompositeToolRef{
+						{Name: "referenced-tool"},
+					},
+				}),
+			),
 			compositeDefs: []*mcpv1beta1.VirtualMCPCompositeToolDefinition{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -577,53 +551,41 @@ func TestConverter_CompositeToolRefs(t *testing.T) {
 		},
 		{
 			name: "error when referenced composite tool not found",
-			vmcp: &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-vmcp",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-					Config: vmcpconfig.Config{
-						CompositeToolRefs: []vmcpconfig.CompositeToolRef{
-							{Name: "non-existent-tool"},
-						},
+			vmcp: v1beta1test.NewVirtualMCPServer("test-vmcp", "default",
+				v1beta1test.WithVMCPGroupRef("test-group"),
+				v1beta1test.WithVMCPConfig(vmcpconfig.Config{
+					CompositeToolRefs: []vmcpconfig.CompositeToolRef{
+						{Name: "non-existent-tool"},
 					},
-				},
-			},
+				}),
+			),
 			compositeDefs: []*mcpv1beta1.VirtualMCPCompositeToolDefinition{},
 			expectError:   true,
 			errorContains: "not found",
 		},
 		{
 			name: "error when duplicate tool names exist",
-			vmcp: &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-vmcp",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-					Config: vmcpconfig.Config{
-						CompositeTools: []vmcpconfig.CompositeToolConfig{
-							{
-								Name:        "duplicate-tool",
-								Description: "An inline tool",
-								Steps: []vmcpconfig.WorkflowStepConfig{
-									{
-										ID:   "step1",
-										Type: "tool",
-										Tool: "backend.tool1",
-									},
+			vmcp: v1beta1test.NewVirtualMCPServer("test-vmcp", "default",
+				v1beta1test.WithVMCPGroupRef("test-group"),
+				v1beta1test.WithVMCPConfig(vmcpconfig.Config{
+					CompositeTools: []vmcpconfig.CompositeToolConfig{
+						{
+							Name:        "duplicate-tool",
+							Description: "An inline tool",
+							Steps: []vmcpconfig.WorkflowStepConfig{
+								{
+									ID:   "step1",
+									Type: "tool",
+									Tool: "backend.tool1",
 								},
 							},
 						},
-						CompositeToolRefs: []vmcpconfig.CompositeToolRef{
-							{Name: "referenced-tool"},
-						},
 					},
-				},
-			},
+					CompositeToolRefs: []vmcpconfig.CompositeToolRef{
+						{Name: "referenced-tool"},
+					},
+				}),
+			),
 			compositeDefs: []*mcpv1beta1.VirtualMCPCompositeToolDefinition{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -650,15 +612,9 @@ func TestConverter_CompositeToolRefs(t *testing.T) {
 		},
 		{
 			name: "error when k8sClient is nil",
-			vmcp: &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-vmcp",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-				},
-			},
+			vmcp: v1beta1test.NewVirtualMCPServer("test-vmcp", "default",
+				v1beta1test.WithVMCPGroupRef("test-group"),
+			),
 			compositeDefs: []*mcpv1beta1.VirtualMCPCompositeToolDefinition{},
 			k8sClient:     nil, // No client provided
 			expectError:   true,
@@ -666,21 +622,15 @@ func TestConverter_CompositeToolRefs(t *testing.T) {
 		},
 		{
 			name: "handle multiple referenced tools",
-			vmcp: &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-vmcp",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-					Config: vmcpconfig.Config{
-						CompositeToolRefs: []vmcpconfig.CompositeToolRef{
-							{Name: "tool1"},
-							{Name: "tool2"},
-						},
+			vmcp: v1beta1test.NewVirtualMCPServer("test-vmcp", "default",
+				v1beta1test.WithVMCPGroupRef("test-group"),
+				v1beta1test.WithVMCPConfig(vmcpconfig.Config{
+					CompositeToolRefs: []vmcpconfig.CompositeToolRef{
+						{Name: "tool1"},
+						{Name: "tool2"},
 					},
-				},
-			},
+				}),
+			),
 			compositeDefs: []*mcpv1beta1.VirtualMCPCompositeToolDefinition{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -735,20 +685,14 @@ func TestConverter_CompositeToolRefs(t *testing.T) {
 		},
 		{
 			name: "convert referenced tool with parameters and timeout",
-			vmcp: &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-vmcp",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-					Config: vmcpconfig.Config{
-						CompositeToolRefs: []vmcpconfig.CompositeToolRef{
-							{Name: "referenced-tool"},
-						},
+			vmcp: v1beta1test.NewVirtualMCPServer("test-vmcp", "default",
+				v1beta1test.WithVMCPGroupRef("test-group"),
+				v1beta1test.WithVMCPConfig(vmcpconfig.Config{
+					CompositeToolRefs: []vmcpconfig.CompositeToolRef{
+						{Name: "referenced-tool"},
 					},
-				},
-			},
+				}),
+			),
 			compositeDefs: []*mcpv1beta1.VirtualMCPCompositeToolDefinition{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -911,20 +855,14 @@ func TestConverter_CompositeToolDefinitionFieldsPreserved(t *testing.T) {
 		},
 	}
 
-	vmcpServer := &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-vmcp",
-			Namespace: "default",
-		},
-		Spec: mcpv1beta1.VirtualMCPServerSpec{
-			GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-			Config: vmcpconfig.Config{
-				CompositeToolRefs: []vmcpconfig.CompositeToolRef{
-					{Name: "comprehensive-tool"},
-				},
+	vmcpServer := v1beta1test.NewVirtualMCPServer("test-vmcp", "default",
+		v1beta1test.WithVMCPGroupRef("test-group"),
+		v1beta1test.WithVMCPConfig(vmcpconfig.Config{
+			CompositeToolRefs: []vmcpconfig.CompositeToolRef{
+				{Name: "comprehensive-tool"},
 			},
-		},
-	}
+		}),
+	)
 
 	// Setup fake Kubernetes client
 	testScheme := testutil.NewScheme(t)
@@ -1268,9 +1206,7 @@ func TestResolveToolConfigRefs(t *testing.T) {
 			converter.k8sClient = k8sClient
 
 			srcAgg := &vmcpconfig.AggregationConfig{Tools: tt.tools}
-			vmcp := &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-vmcp", Namespace: "default"},
-			}
+			vmcp := v1beta1test.NewVirtualMCPServer("test-vmcp", "default")
 
 			agg := &vmcpconfig.AggregationConfig{}
 			err := converter.resolveToolConfigRefs(ctx, vmcp, srcAgg, agg)
@@ -1343,9 +1279,7 @@ func TestResolveToolConfigRefs_FailClosed(t *testing.T) {
 			converter.k8sClient = k8sClient
 
 			srcAgg := &vmcpconfig.AggregationConfig{Tools: tt.tools}
-			vmcp := &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-vmcp", Namespace: "default"},
-			}
+			vmcp := v1beta1test.NewVirtualMCPServer("test-vmcp", "default")
 
 			agg := &vmcpconfig.AggregationConfig{}
 			err := converter.resolveToolConfigRefs(ctx, vmcp, srcAgg, agg)
@@ -1374,51 +1308,42 @@ func TestConvert_MCPToolConfigFailClosed(t *testing.T) {
 	}{
 		{
 			name: "Convert fails when MCPToolConfig not found",
-			vmcp: &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-vmcp", Namespace: "default"},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-					Config: vmcpconfig.Config{
-						Aggregation: &vmcpconfig.AggregationConfig{
-							Tools: []*vmcpconfig.WorkloadToolConfig{{
-								Workload:      "backend1",
-								ToolConfigRef: &vmcpconfig.ToolConfigRef{Name: "missing-config"},
-							}},
-						},
+			vmcp: v1beta1test.NewVirtualMCPServer("test-vmcp", "default",
+				v1beta1test.WithVMCPGroupRef("test-group"),
+				v1beta1test.WithVMCPConfig(vmcpconfig.Config{
+					Aggregation: &vmcpconfig.AggregationConfig{
+						Tools: []*vmcpconfig.WorkloadToolConfig{{
+							Workload:      "backend1",
+							ToolConfigRef: &vmcpconfig.ToolConfigRef{Name: "missing-config"},
+						}},
 					},
-				},
-			},
+				}),
+			),
 			existingConfig: nil,
 			expectError:    true,
 			expectedErrMsg: "failed to convert aggregation config",
 		},
 		{
 			name: "Convert succeeds when MCPToolConfig exists",
-			vmcp: &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-vmcp", Namespace: "default"},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-					Config: vmcpconfig.Config{
-						Aggregation: &vmcpconfig.AggregationConfig{
-							Tools: []*vmcpconfig.WorkloadToolConfig{{
-								Workload:      "backend1",
-								ToolConfigRef: &vmcpconfig.ToolConfigRef{Name: "valid-config"},
-							}},
-						},
+			vmcp: v1beta1test.NewVirtualMCPServer("test-vmcp", "default",
+				v1beta1test.WithVMCPGroupRef("test-group"),
+				v1beta1test.WithVMCPConfig(vmcpconfig.Config{
+					Aggregation: &vmcpconfig.AggregationConfig{
+						Tools: []*vmcpconfig.WorkloadToolConfig{{
+							Workload:      "backend1",
+							ToolConfigRef: &vmcpconfig.ToolConfigRef{Name: "valid-config"},
+						}},
 					},
-				},
-			},
+				}),
+			),
 			existingConfig: newMCPToolConfig("valid-config", "default", []string{"fetch"}, nil),
 			expectError:    false,
 		},
 		{
 			name: "Convert succeeds when no Aggregation specified",
-			vmcp: &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-vmcp", Namespace: "default"},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-				},
-			},
+			vmcp: v1beta1test.NewVirtualMCPServer("test-vmcp", "default",
+				v1beta1test.WithVMCPGroupRef("test-group"),
+			),
 			existingConfig: nil,
 			expectError:    false,
 		},
@@ -1458,24 +1383,18 @@ func TestConvert_MCPToolConfigFailClosed(t *testing.T) {
 func TestConverter_InlineTelemetryIgnored(t *testing.T) {
 	t.Parallel()
 
-	vmcp := &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-vmcp",
-			Namespace: "default",
-		},
-		Spec: mcpv1beta1.VirtualMCPServerSpec{
-			GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-			IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-				Type: "anonymous",
+	vmcp := v1beta1test.NewVirtualMCPServer("test-vmcp", "default",
+		v1beta1test.WithVMCPGroupRef("test-group"),
+		v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+			Type: "anonymous",
+		}),
+		v1beta1test.WithVMCPConfig(vmcpconfig.Config{
+			Telemetry: &telemetry.Config{
+				Endpoint:    "otlp-collector:4317",
+				ServiceName: "should-be-ignored",
 			},
-			Config: vmcpconfig.Config{
-				Telemetry: &telemetry.Config{
-					Endpoint:    "otlp-collector:4317",
-					ServiceName: "should-be-ignored",
-				},
-			},
-		},
-	}
+		}),
+	)
 
 	converter := newTestConverter(t, newNoOpMockResolver(t))
 	ctx := log.IntoContext(context.Background(), logr.Discard())
@@ -1490,21 +1409,15 @@ func TestConverter_InlineTelemetryIgnored(t *testing.T) {
 func TestConverter_TelemetryNil(t *testing.T) {
 	t.Parallel()
 
-	vmcp := &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-vmcp",
-			Namespace: "default",
-		},
-		Spec: mcpv1beta1.VirtualMCPServerSpec{
-			GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-			IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-				Type: "anonymous",
-			},
-			Config: vmcpconfig.Config{
-				Telemetry: nil, // No telemetry config
-			},
-		},
-	}
+	vmcp := v1beta1test.NewVirtualMCPServer("test-vmcp", "default",
+		v1beta1test.WithVMCPGroupRef("test-group"),
+		v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+			Type: "anonymous",
+		}),
+		v1beta1test.WithVMCPConfig(vmcpconfig.Config{
+			Telemetry: nil, // No telemetry config
+		}),
+	)
 
 	converter := newTestConverter(t, newNoOpMockResolver(t))
 	ctx := log.IntoContext(context.Background(), logr.Discard())
@@ -1566,19 +1479,13 @@ func TestConverter_SessionStorage(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			vmcpServer := &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-vmcp",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-					Config: vmcpconfig.Config{
-						SessionStorage: tt.inlineConfig,
-					},
-					SessionStorage: tt.sessionStorage,
-				},
-			}
+			vmcpServer := v1beta1test.NewVirtualMCPServer("test-vmcp", "default",
+				v1beta1test.WithVMCPGroupRef("test-group"),
+				v1beta1test.WithVMCPConfig(vmcpconfig.Config{
+					SessionStorage: tt.inlineConfig,
+				}),
+				v1beta1test.WithVMCPSessionStorage(tt.sessionStorage),
+			)
 
 			converter := newTestConverter(t, newNoOpMockResolver(t))
 			ctx := log.IntoContext(context.Background(), logr.Discard())
@@ -1595,32 +1502,26 @@ func TestConverter_SessionStorage(t *testing.T) {
 func TestConverter_RateLimitingPassThrough(t *testing.T) {
 	t.Parallel()
 
-	vmcpServer := &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-vmcp",
-			Namespace: "default",
-		},
-		Spec: mcpv1beta1.VirtualMCPServerSpec{
-			GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-			Config: vmcpconfig.Config{
-				RateLimiting: &mcpv1beta1.RateLimitConfig{
-					PerUser: &mcpv1beta1.RateLimitBucket{
-						MaxTokens:    2,
-						RefillPeriod: metav1.Duration{Duration: time.Minute},
-					},
-					Tools: []mcpv1beta1.ToolRateLimitConfig{
-						{
-							Name: "backend_a_echo",
-							Shared: &mcpv1beta1.RateLimitBucket{
-								MaxTokens:    5,
-								RefillPeriod: metav1.Duration{Duration: 30 * time.Second},
-							},
+	vmcpServer := v1beta1test.NewVirtualMCPServer("test-vmcp", "default",
+		v1beta1test.WithVMCPGroupRef("test-group"),
+		v1beta1test.WithVMCPConfig(vmcpconfig.Config{
+			RateLimiting: &mcpv1beta1.RateLimitConfig{
+				PerUser: &mcpv1beta1.RateLimitBucket{
+					MaxTokens:    2,
+					RefillPeriod: metav1.Duration{Duration: time.Minute},
+				},
+				Tools: []mcpv1beta1.ToolRateLimitConfig{
+					{
+						Name: "backend_a_echo",
+						Shared: &mcpv1beta1.RateLimitBucket{
+							MaxTokens:    5,
+							RefillPeriod: metav1.Duration{Duration: 30 * time.Second},
 						},
 					},
 				},
 			},
-		},
-	}
+		}),
+	)
 
 	converter := newTestConverter(t, newNoOpMockResolver(t))
 	ctx := log.IntoContext(context.Background(), logr.Discard())
@@ -1824,36 +1725,33 @@ func TestConvert_AuthServerConfigIntegration(t *testing.T) {
 	converter, err := NewConverter(mockResolver, k8sClient)
 	require.NoError(t, err)
 
-	vmcp := &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{Name: "test-vmcp", Namespace: "default"},
-		Spec: mcpv1beta1.VirtualMCPServerSpec{
-			GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-			IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-				Type:          "oidc",
-				OIDCConfigRef: &mcpv1beta1.MCPOIDCConfigReference{Name: "test-oidc", Audience: "https://my-vmcp.example.com"},
+	vmcp := v1beta1test.NewVirtualMCPServer("test-vmcp", "default",
+		v1beta1test.WithVMCPGroupRef("test-group"),
+		v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+			Type:          "oidc",
+			OIDCConfigRef: &mcpv1beta1.MCPOIDCConfigReference{Name: "test-oidc", Audience: "https://my-vmcp.example.com"},
+		}),
+		v1beta1test.WithVMCPAuthServerConfig(&mcpv1beta1.EmbeddedAuthServerConfig{
+			Issuer: "https://authserver.example.com",
+			SigningKeySecretRefs: []mcpv1beta1.SecretKeyRef{
+				{Name: "signing-key", Key: "private.pem"},
 			},
-			AuthServerConfig: &mcpv1beta1.EmbeddedAuthServerConfig{
-				Issuer: "https://authserver.example.com",
-				SigningKeySecretRefs: []mcpv1beta1.SecretKeyRef{
-					{Name: "signing-key", Key: "private.pem"},
-				},
-				UpstreamProviders: []mcpv1beta1.UpstreamProviderConfig{
-					{
-						Name: "corp-idp",
-						Type: mcpv1beta1.UpstreamProviderTypeOIDC,
-						OIDCConfig: &mcpv1beta1.OIDCUpstreamConfig{
-							IssuerURL: "https://corp.example.com",
-							ClientID:  "corp-client-id",
-							ClientSecretRef: &mcpv1beta1.SecretKeyRef{
-								Name: "corp-secret",
-								Key:  "client-secret",
-							},
+			UpstreamProviders: []mcpv1beta1.UpstreamProviderConfig{
+				{
+					Name: "corp-idp",
+					Type: mcpv1beta1.UpstreamProviderTypeOIDC,
+					OIDCConfig: &mcpv1beta1.OIDCUpstreamConfig{
+						IssuerURL: "https://corp.example.com",
+						ClientID:  "corp-client-id",
+						ClientSecretRef: &mcpv1beta1.SecretKeyRef{
+							Name: "corp-secret",
+							Key:  "client-secret",
 						},
 					},
 				},
 			},
-		},
-	}
+		}),
+	)
 
 	ctx := log.IntoContext(context.Background(), logr.Discard())
 	config, runConfig, err := converter.Convert(ctx, vmcp, nil)
@@ -1904,17 +1802,16 @@ func TestConverter_TelemetryConfigRef(t *testing.T) {
 	converter, err := NewConverter(newNoOpMockResolver(t), k8sClient)
 	require.NoError(t, err)
 
-	vmcp := &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{Name: "test-vmcp", Namespace: "default"},
-		Spec: mcpv1beta1.VirtualMCPServerSpec{
-			GroupRef:     &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-			IncomingAuth: &mcpv1beta1.IncomingAuthConfig{Type: "anonymous"},
-			TelemetryConfigRef: &mcpv1beta1.MCPTelemetryConfigReference{
+	vmcp := v1beta1test.NewVirtualMCPServer("test-vmcp", "default",
+		v1beta1test.WithVMCPGroupRef("test-group"),
+		v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{Type: "anonymous"}),
+		v1beta1test.MutateVMCP(func(v *mcpv1beta1.VirtualMCPServer) {
+			v.Spec.TelemetryConfigRef = &mcpv1beta1.MCPTelemetryConfigReference{
 				Name:        "shared-telemetry",
 				ServiceName: "custom-svc",
-			},
-		},
-	}
+			}
+		}),
+	)
 
 	ctx := log.IntoContext(context.Background(), logr.Discard())
 	config, _, err := converter.Convert(ctx, vmcp, telemetryCfg)
@@ -2156,17 +2053,14 @@ func TestConvertIncomingAuth_PrimaryUpstreamProvider(t *testing.T) {
 
 			converter := newTestConverter(t, newNoOpMockResolver(t))
 
-			vmcp := &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-vmcp", Namespace: "default"},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-					IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-						Type:        "anonymous",
-						AuthzConfig: tt.authzConfig,
-					},
-					AuthServerConfig: tt.authServerConfig,
-				},
-			}
+			vmcp := v1beta1test.NewVirtualMCPServer("test-vmcp", "default",
+				v1beta1test.WithVMCPGroupRef("test-group"),
+				v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+					Type:        "anonymous",
+					AuthzConfig: tt.authzConfig,
+				}),
+				v1beta1test.WithVMCPAuthServerConfig(tt.authServerConfig),
+			)
 
 			ctx := log.IntoContext(t.Context(), logr.Discard())
 			incoming, err := converter.convertIncomingAuth(ctx, vmcp)
@@ -2196,15 +2090,14 @@ func TestConverter_PassthroughHeaders(t *testing.T) {
 
 	// newVMCP builds a minimal VirtualMCPServer with the given passthrough header slices.
 	newVMCP := func(topLevel, configLevel []string) *mcpv1beta1.VirtualMCPServer {
-		return &mcpv1beta1.VirtualMCPServer{
-			ObjectMeta: metav1.ObjectMeta{Name: "test-vmcp", Namespace: "default"},
-			Spec: mcpv1beta1.VirtualMCPServerSpec{
-				GroupRef:           &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-				IncomingAuth:       &mcpv1beta1.IncomingAuthConfig{Type: "anonymous"},
-				PassthroughHeaders: topLevel,
-				Config:             vmcpconfig.Config{PassthroughHeaders: configLevel},
-			},
-		}
+		return v1beta1test.NewVirtualMCPServer("test-vmcp", "default",
+			v1beta1test.WithVMCPGroupRef("test-group"),
+			v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{Type: "anonymous"}),
+			v1beta1test.WithVMCPConfig(vmcpconfig.Config{PassthroughHeaders: configLevel}),
+			v1beta1test.MutateVMCP(func(v *mcpv1beta1.VirtualMCPServer) {
+				v.Spec.PassthroughHeaders = topLevel
+			}),
+		)
 	}
 
 	tests := []struct {

--- a/cmd/thv-operator/test-integration/mcp-oidc-config/mcpoidcconfig_virtualmcpserver_integration_test.go
+++ b/cmd/thv-operator/test-integration/mcp-oidc-config/mcpoidcconfig_virtualmcpserver_integration_test.go
@@ -14,6 +14,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1/v1beta1test"
 	vmcpconfig "github.com/stacklok/toolhive/pkg/vmcp/config"
 )
 
@@ -96,25 +97,19 @@ var _ = Describe("MCPOIDCConfig and VirtualMCPServer Cross-Resource Integration 
 			}, timeout, interval).Should(BeTrue())
 
 			// Create VirtualMCPServer with OIDCConfigRef
-			vmcpServer = &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      vmcpName,
-					Namespace: namespace,
-				},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef: &mcpv1beta1.MCPGroupRef{Name: groupName},
-					Config:   vmcpconfig.Config{Group: groupName},
-					IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-						Type: "oidc",
-						OIDCConfigRef: &mcpv1beta1.MCPOIDCConfigReference{
-							Name:        configName,
-							Audience:    "test-vmcp-audience",
-							Scopes:      []string{"openid"},
-							ResourceURL: "https://mcp-gateway.example.com/mcp",
-						},
+			vmcpServer = v1beta1test.NewVirtualMCPServer(vmcpName, namespace,
+				v1beta1test.WithVMCPGroupRef(groupName),
+				v1beta1test.WithVMCPConfig(vmcpconfig.Config{Group: groupName}),
+				v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+					Type: "oidc",
+					OIDCConfigRef: &mcpv1beta1.MCPOIDCConfigReference{
+						Name:        configName,
+						Audience:    "test-vmcp-audience",
+						Scopes:      []string{"openid"},
+						ResourceURL: "https://mcp-gateway.example.com/mcp",
 					},
-				},
-			}
+				}),
+			)
 			Expect(k8sClient.Create(ctx, vmcpServer)).Should(Succeed())
 		})
 
@@ -274,24 +269,18 @@ var _ = Describe("MCPOIDCConfig and VirtualMCPServer Cross-Resource Integration 
 			}, timeout, interval).Should(BeTrue())
 
 			// Create VirtualMCPServer with OIDCConfigRef
-			vmcpServer = &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      vmcpName,
-					Namespace: namespace,
-				},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef: &mcpv1beta1.MCPGroupRef{Name: groupName},
-					Config:   vmcpconfig.Config{Group: groupName},
-					IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-						Type: "oidc",
-						OIDCConfigRef: &mcpv1beta1.MCPOIDCConfigReference{
-							Name:     configName,
-							Audience: "test-vmcp-audience",
-							Scopes:   []string{"openid"},
-						},
+			vmcpServer = v1beta1test.NewVirtualMCPServer(vmcpName, namespace,
+				v1beta1test.WithVMCPGroupRef(groupName),
+				v1beta1test.WithVMCPConfig(vmcpconfig.Config{Group: groupName}),
+				v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+					Type: "oidc",
+					OIDCConfigRef: &mcpv1beta1.MCPOIDCConfigReference{
+						Name:     configName,
+						Audience: "test-vmcp-audience",
+						Scopes:   []string{"openid"},
 					},
-				},
-			}
+				}),
+			)
 			Expect(k8sClient.Create(ctx, vmcpServer)).Should(Succeed())
 
 			// Wait for ReferencingWorkloads to contain the VirtualMCPServer
@@ -410,24 +399,18 @@ var _ = Describe("MCPOIDCConfig and VirtualMCPServer Cross-Resource Integration 
 			}, timeout, interval).Should(BeTrue())
 
 			// Create VirtualMCPServer with OIDCConfigRef
-			vmcpServer = &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      vmcpName,
-					Namespace: namespace,
-				},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef: &mcpv1beta1.MCPGroupRef{Name: groupName},
-					Config:   vmcpconfig.Config{Group: groupName},
-					IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-						Type: "oidc",
-						OIDCConfigRef: &mcpv1beta1.MCPOIDCConfigReference{
-							Name:     configName,
-							Audience: "test-vmcp-audience",
-							Scopes:   []string{"openid"},
-						},
+			vmcpServer = v1beta1test.NewVirtualMCPServer(vmcpName, namespace,
+				v1beta1test.WithVMCPGroupRef(groupName),
+				v1beta1test.WithVMCPConfig(vmcpconfig.Config{Group: groupName}),
+				v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+					Type: "oidc",
+					OIDCConfigRef: &mcpv1beta1.MCPOIDCConfigReference{
+						Name:     configName,
+						Audience: "test-vmcp-audience",
+						Scopes:   []string{"openid"},
 					},
-				},
-			}
+				}),
+			)
 			Expect(k8sClient.Create(ctx, vmcpServer)).Should(Succeed())
 
 			// Wait for ReferencingWorkloads to be populated
@@ -536,24 +519,18 @@ var _ = Describe("MCPOIDCConfig and VirtualMCPServer Cross-Resource Integration 
 			Expect(k8sClient.Create(ctx, mcpGroup)).Should(Succeed())
 
 			// Create VirtualMCPServer with OIDCConfigRef pointing to a non-existent config
-			vmcpServer = &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      vmcpName,
-					Namespace: namespace,
-				},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef: &mcpv1beta1.MCPGroupRef{Name: groupName},
-					Config:   vmcpconfig.Config{Group: groupName},
-					IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-						Type: "oidc",
-						OIDCConfigRef: &mcpv1beta1.MCPOIDCConfigReference{
-							Name:     "does-not-exist",
-							Audience: "test-vmcp-audience",
-							Scopes:   []string{"openid"},
-						},
+			vmcpServer = v1beta1test.NewVirtualMCPServer(vmcpName, namespace,
+				v1beta1test.WithVMCPGroupRef(groupName),
+				v1beta1test.WithVMCPConfig(vmcpconfig.Config{Group: groupName}),
+				v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+					Type: "oidc",
+					OIDCConfigRef: &mcpv1beta1.MCPOIDCConfigReference{
+						Name:     "does-not-exist",
+						Audience: "test-vmcp-audience",
+						Scopes:   []string{"openid"},
 					},
-				},
-			}
+				}),
+			)
 			Expect(k8sClient.Create(ctx, vmcpServer)).Should(Succeed())
 		})
 
@@ -676,24 +653,18 @@ var _ = Describe("MCPOIDCConfig and VirtualMCPServer Cross-Resource Integration 
 			Expect(k8sClient.Create(ctx, mcpServer)).Should(Succeed())
 
 			// Create VirtualMCPServer with OIDCConfigRef
-			vmcpServer = &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      vmcpName,
-					Namespace: namespace,
-				},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef: &mcpv1beta1.MCPGroupRef{Name: groupName},
-					Config:   vmcpconfig.Config{Group: groupName},
-					IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-						Type: "oidc",
-						OIDCConfigRef: &mcpv1beta1.MCPOIDCConfigReference{
-							Name:     configName,
-							Audience: "test-vmcp-audience",
-							Scopes:   []string{"openid"},
-						},
+			vmcpServer = v1beta1test.NewVirtualMCPServer(vmcpName, namespace,
+				v1beta1test.WithVMCPGroupRef(groupName),
+				v1beta1test.WithVMCPConfig(vmcpconfig.Config{Group: groupName}),
+				v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+					Type: "oidc",
+					OIDCConfigRef: &mcpv1beta1.MCPOIDCConfigReference{
+						Name:     configName,
+						Audience: "test-vmcp-audience",
+						Scopes:   []string{"openid"},
 					},
-				},
-			}
+				}),
+			)
 			Expect(k8sClient.Create(ctx, vmcpServer)).Should(Succeed())
 		})
 

--- a/cmd/thv-operator/test-integration/virtualmcp/virtualmcpserver_authzconfig_cel_test.go
+++ b/cmd/thv-operator/test-integration/virtualmcp/virtualmcpserver_authzconfig_cel_test.go
@@ -6,9 +6,9 @@ package controllers
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1/v1beta1test"
 	vmcpconfig "github.com/stacklok/toolhive/pkg/vmcp/config"
 )
 
@@ -20,20 +20,17 @@ func newVirtualMCPServerWithIncomingAuth(
 	authzConfig *mcpv1beta1.AuthzConfigRef,
 	authzConfigRef *mcpv1beta1.MCPAuthzConfigReference,
 ) *mcpv1beta1.VirtualMCPServer {
-	return &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
-		Spec: mcpv1beta1.VirtualMCPServerSpec{
-			GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-			IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-				Type:           "anonymous",
-				AuthzConfig:    authzConfig,
-				AuthzConfigRef: authzConfigRef,
-			},
-			Config: vmcpconfig.Config{
-				Group: "test-group",
-			},
-		},
-	}
+	return v1beta1test.NewVirtualMCPServer(name, "default",
+		v1beta1test.WithVMCPGroupRef("test-group"),
+		v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+			Type:           "anonymous",
+			AuthzConfig:    authzConfig,
+			AuthzConfigRef: authzConfigRef,
+		}),
+		v1beta1test.WithVMCPConfig(vmcpconfig.Config{
+			Group: "test-group",
+		}),
+	)
 }
 
 var _ = Describe("CEL Validation for authzConfig vs authzConfigRef on VirtualMCPServer",

--- a/cmd/thv-operator/test-integration/virtualmcp/virtualmcpserver_compositetool_watch_test.go
+++ b/cmd/thv-operator/test-integration/virtualmcp/virtualmcpserver_compositetool_watch_test.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1/v1beta1test"
 	thvjson "github.com/stacklok/toolhive/pkg/json"
 	vmcpconfig "github.com/stacklok/toolhive/pkg/vmcp/config"
 )
@@ -66,24 +67,18 @@ var _ = Describe("VirtualMCPServer CompositeToolDefinition Watch Integration Tes
 
 			// Create VirtualMCPServer that references the composite tool definition
 			// (even though the composite tool doesn't exist yet)
-			vmcp = &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      vmcpName,
-					Namespace: namespace,
-				},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef: &mcpv1beta1.MCPGroupRef{Name: mcpGroupName},
-					Config: vmcpconfig.Config{
-						Group: mcpGroupName,
-						CompositeToolRefs: []vmcpconfig.CompositeToolRef{
-							{Name: compositeToolDefName},
-						},
+			vmcp = v1beta1test.NewVirtualMCPServer(vmcpName, namespace,
+				v1beta1test.WithVMCPGroupRef(mcpGroupName),
+				v1beta1test.WithVMCPConfig(vmcpconfig.Config{
+					Group: mcpGroupName,
+					CompositeToolRefs: []vmcpconfig.CompositeToolRef{
+						{Name: compositeToolDefName},
 					},
-					IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-						Type: "anonymous",
-					},
-				},
-			}
+				}),
+				v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+					Type: "anonymous",
+				}),
+			)
 			Expect(k8sClient.Create(ctx, vmcp)).Should(Succeed())
 
 			// Wait for initial VirtualMCPServer reconciliation
@@ -252,24 +247,18 @@ var _ = Describe("VirtualMCPServer CompositeToolDefinition Watch Integration Tes
 			Expect(k8sClient.Create(ctx, compositeToolDef)).Should(Succeed())
 
 			// Create VirtualMCPServer that references the composite tool definition
-			vmcp = &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      vmcpName,
-					Namespace: namespace,
-				},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef: &mcpv1beta1.MCPGroupRef{Name: mcpGroupName},
-					Config: vmcpconfig.Config{
-						Group: mcpGroupName,
-						CompositeToolRefs: []vmcpconfig.CompositeToolRef{
-							{Name: compositeToolDefName},
-						},
+			vmcp = v1beta1test.NewVirtualMCPServer(vmcpName, namespace,
+				v1beta1test.WithVMCPGroupRef(mcpGroupName),
+				v1beta1test.WithVMCPConfig(vmcpconfig.Config{
+					Group: mcpGroupName,
+					CompositeToolRefs: []vmcpconfig.CompositeToolRef{
+						{Name: compositeToolDefName},
 					},
-					IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-						Type: "anonymous",
-					},
-				},
-			}
+				}),
+				v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+					Type: "anonymous",
+				}),
+			)
 			Expect(k8sClient.Create(ctx, vmcp)).Should(Succeed())
 
 			// Wait for initial reconciliation
@@ -375,20 +364,14 @@ var _ = Describe("VirtualMCPServer CompositeToolDefinition Watch Integration Tes
 			}, timeout, interval).Should(BeTrue())
 
 			// Create VirtualMCPServer WITHOUT referencing the composite tool definition
-			vmcp = &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      vmcpName,
-					Namespace: namespace,
-				},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef: &mcpv1beta1.MCPGroupRef{Name: mcpGroupName},
-					Config:   vmcpconfig.Config{Group: mcpGroupName},
-					IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-						Type: "anonymous",
-					},
-					// No CompositeToolRefs
-				},
-			}
+			vmcp = v1beta1test.NewVirtualMCPServer(vmcpName, namespace,
+				v1beta1test.WithVMCPGroupRef(mcpGroupName),
+				v1beta1test.WithVMCPConfig(vmcpconfig.Config{Group: mcpGroupName}),
+				v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+					Type: "anonymous",
+				}),
+				// No CompositeToolRefs
+			)
 			Expect(k8sClient.Create(ctx, vmcp)).Should(Succeed())
 
 			// Wait for initial reconciliation

--- a/cmd/thv-operator/test-integration/virtualmcp/virtualmcpserver_elicitation_integration_test.go
+++ b/cmd/thv-operator/test-integration/virtualmcp/virtualmcpserver_elicitation_integration_test.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1/v1beta1test"
 	thvjson "github.com/stacklok/toolhive/pkg/json"
 	vmcpconfig "github.com/stacklok/toolhive/pkg/vmcp/config"
 )
@@ -127,24 +128,18 @@ var _ = Describe("VirtualMCPServer Elicitation Integration Tests", func() {
 			Expect(k8sClient.Create(ctx, compositeToolDef)).Should(Succeed())
 
 			// Create VirtualMCPServer that references the composite tool definition
-			vmcp = &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      vmcpName,
-					Namespace: namespace,
-				},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef: &mcpv1beta1.MCPGroupRef{Name: mcpGroupName},
-					Config: vmcpconfig.Config{
-						Group: mcpGroupName,
-						CompositeToolRefs: []vmcpconfig.CompositeToolRef{
-							{Name: compositeToolDefName},
-						},
+			vmcp = v1beta1test.NewVirtualMCPServer(vmcpName, namespace,
+				v1beta1test.WithVMCPGroupRef(mcpGroupName),
+				v1beta1test.WithVMCPConfig(vmcpconfig.Config{
+					Group: mcpGroupName,
+					CompositeToolRefs: []vmcpconfig.CompositeToolRef{
+						{Name: compositeToolDefName},
 					},
-					IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-						Type: "anonymous",
-					},
-				},
-			}
+				}),
+				v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+					Type: "anonymous",
+				}),
+			)
 			Expect(k8sClient.Create(ctx, vmcp)).Should(Succeed())
 
 			// Wait for VirtualMCPServer to reconcile
@@ -331,24 +326,18 @@ var _ = Describe("VirtualMCPServer Elicitation Integration Tests", func() {
 			Expect(k8sClient.Create(ctx, compositeToolDef)).Should(Succeed())
 
 			// Create VirtualMCPServer
-			vmcp = &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      vmcpName,
-					Namespace: namespace,
-				},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef: &mcpv1beta1.MCPGroupRef{Name: mcpGroupName},
-					Config: vmcpconfig.Config{
-						Group: mcpGroupName,
-						CompositeToolRefs: []vmcpconfig.CompositeToolRef{
-							{Name: compositeToolDefName},
-						},
+			vmcp = v1beta1test.NewVirtualMCPServer(vmcpName, namespace,
+				v1beta1test.WithVMCPGroupRef(mcpGroupName),
+				v1beta1test.WithVMCPConfig(vmcpconfig.Config{
+					Group: mcpGroupName,
+					CompositeToolRefs: []vmcpconfig.CompositeToolRef{
+						{Name: compositeToolDefName},
 					},
-					IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-						Type: "anonymous",
-					},
-				},
-			}
+				}),
+				v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+					Type: "anonymous",
+				}),
+			)
 			Expect(k8sClient.Create(ctx, vmcp)).Should(Succeed())
 
 			// Wait for reconciliation
@@ -518,24 +507,18 @@ var _ = Describe("VirtualMCPServer Elicitation Integration Tests", func() {
 			Expect(k8sClient.Create(ctx, compositeToolDef)).Should(Succeed())
 
 			// Create VirtualMCPServer
-			vmcp = &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      vmcpName,
-					Namespace: namespace,
-				},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef: &mcpv1beta1.MCPGroupRef{Name: mcpGroupName},
-					Config: vmcpconfig.Config{
-						Group: mcpGroupName,
-						CompositeToolRefs: []vmcpconfig.CompositeToolRef{
-							{Name: compositeToolDefName},
-						},
+			vmcp = v1beta1test.NewVirtualMCPServer(vmcpName, namespace,
+				v1beta1test.WithVMCPGroupRef(mcpGroupName),
+				v1beta1test.WithVMCPConfig(vmcpconfig.Config{
+					Group: mcpGroupName,
+					CompositeToolRefs: []vmcpconfig.CompositeToolRef{
+						{Name: compositeToolDefName},
 					},
-					IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-						Type: "anonymous",
-					},
-				},
-			}
+				}),
+				v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+					Type: "anonymous",
+				}),
+			)
 			Expect(k8sClient.Create(ctx, vmcp)).Should(Succeed())
 
 			// Wait for reconciliation

--- a/cmd/thv-operator/test-integration/virtualmcp/virtualmcpserver_externalauth_watch_test.go
+++ b/cmd/thv-operator/test-integration/virtualmcp/virtualmcpserver_externalauth_watch_test.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1/v1beta1test"
 	vmcpconfig "github.com/stacklok/toolhive/pkg/vmcp/config"
 )
 
@@ -102,22 +103,16 @@ var _ = Describe("VirtualMCPServer ExternalAuthConfig Watch Integration Tests", 
 			Expect(k8sClient.Create(ctx, mcpServer)).Should(Succeed())
 
 			// Create VirtualMCPServer with discovered mode
-			vmcp = &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      vmcpName,
-					Namespace: namespace,
-				},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef: &mcpv1beta1.MCPGroupRef{Name: mcpGroupName},
-					Config:   vmcpconfig.Config{Group: mcpGroupName},
-					IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-						Type: "anonymous",
-					},
-					OutgoingAuth: &mcpv1beta1.OutgoingAuthConfig{
-						Source: "discovered", // Use discovered mode
-					},
-				},
-			}
+			vmcp = v1beta1test.NewVirtualMCPServer(vmcpName, namespace,
+				v1beta1test.WithVMCPGroupRef(mcpGroupName),
+				v1beta1test.WithVMCPConfig(vmcpconfig.Config{Group: mcpGroupName}),
+				v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+					Type: "anonymous",
+				}),
+				v1beta1test.WithVMCPOutgoingAuth(&mcpv1beta1.OutgoingAuthConfig{
+					Source: "discovered", // Use discovered mode
+				}),
+			)
 			Expect(k8sClient.Create(ctx, vmcp)).Should(Succeed())
 
 			// Wait for initial VirtualMCPServer reconciliation

--- a/cmd/thv-operator/test-integration/virtualmcp/virtualmcpserver_imagepullsecrets_integration_test.go
+++ b/cmd/thv-operator/test-integration/virtualmcp/virtualmcpserver_imagepullsecrets_integration_test.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1/v1beta1test"
 	vmcpconfig "github.com/stacklok/toolhive/pkg/vmcp/config"
 )
 
@@ -69,18 +70,17 @@ var _ = Describe("VirtualMCPServer ImagePullSecrets Integration Tests",
 				}
 				Expect(k8sClient.Create(ctx, mcpGroup)).Should(Succeed())
 
-				virtualMCPServer = &mcpv1beta1.VirtualMCPServer{
-					ObjectMeta: metav1.ObjectMeta{Name: virtualMCPName, Namespace: defaultNamespace},
-					Spec: mcpv1beta1.VirtualMCPServerSpec{
-						GroupRef:     &mcpv1beta1.MCPGroupRef{Name: mcpGroupName},
-						Config:       vmcpconfig.Config{Group: mcpGroupName},
-						IncomingAuth: &mcpv1beta1.IncomingAuthConfig{Type: "anonymous"},
-						ImagePullSecrets: []corev1.LocalObjectReference{
+				virtualMCPServer = v1beta1test.NewVirtualMCPServer(virtualMCPName, defaultNamespace,
+					v1beta1test.WithVMCPGroupRef(mcpGroupName),
+					v1beta1test.WithVMCPConfig(vmcpconfig.Config{Group: mcpGroupName}),
+					v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{Type: "anonymous"}),
+					v1beta1test.MutateVMCP(func(v *mcpv1beta1.VirtualMCPServer) {
+						v.Spec.ImagePullSecrets = []corev1.LocalObjectReference{
 							{Name: "registry-creds-1"},
 							{Name: "registry-creds-2"},
-						},
-					},
-				}
+						}
+					}),
+				)
 				Expect(k8sClient.Create(ctx, virtualMCPServer)).Should(Succeed())
 			})
 
@@ -143,17 +143,16 @@ var _ = Describe("VirtualMCPServer ImagePullSecrets Integration Tests",
 				}
 				Expect(k8sClient.Create(ctx, mcpGroup)).Should(Succeed())
 
-				virtualMCPServer = &mcpv1beta1.VirtualMCPServer{
-					ObjectMeta: metav1.ObjectMeta{Name: virtualMCPName, Namespace: defaultNamespace},
-					Spec: mcpv1beta1.VirtualMCPServerSpec{
-						GroupRef:     &mcpv1beta1.MCPGroupRef{Name: mcpGroupName},
-						Config:       vmcpconfig.Config{Group: mcpGroupName},
-						IncomingAuth: &mcpv1beta1.IncomingAuthConfig{Type: "anonymous"},
-						ImagePullSecrets: []corev1.LocalObjectReference{
+				virtualMCPServer = v1beta1test.NewVirtualMCPServer(virtualMCPName, defaultNamespace,
+					v1beta1test.WithVMCPGroupRef(mcpGroupName),
+					v1beta1test.WithVMCPConfig(vmcpconfig.Config{Group: mcpGroupName}),
+					v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{Type: "anonymous"}),
+					v1beta1test.MutateVMCP(func(v *mcpv1beta1.VirtualMCPServer) {
+						v.Spec.ImagePullSecrets = []corev1.LocalObjectReference{
 							{Name: "secret-a"},
-						},
-					},
-				}
+						}
+					}),
+				)
 				Expect(k8sClient.Create(ctx, virtualMCPServer)).Should(Succeed())
 			})
 
@@ -235,24 +234,23 @@ var _ = Describe("VirtualMCPServer ImagePullSecrets Integration Tests",
 				}
 				Expect(k8sClient.Create(ctx, mcpGroup)).Should(Succeed())
 
-				virtualMCPServer = &mcpv1beta1.VirtualMCPServer{
-					ObjectMeta: metav1.ObjectMeta{Name: virtualMCPName, Namespace: defaultNamespace},
-					Spec: mcpv1beta1.VirtualMCPServerSpec{
-						GroupRef:     &mcpv1beta1.MCPGroupRef{Name: mcpGroupName},
-						Config:       vmcpconfig.Config{Group: mcpGroupName},
-						IncomingAuth: &mcpv1beta1.IncomingAuthConfig{Type: "anonymous"},
-						// "shared" appears in both sources to exercise overlap;
-						// "explicit-only" is unique to spec.imagePullSecrets;
-						// "podtemplate-only" is unique to PodTemplateSpec.
-						ImagePullSecrets: []corev1.LocalObjectReference{
+				virtualMCPServer = v1beta1test.NewVirtualMCPServer(virtualMCPName, defaultNamespace,
+					v1beta1test.WithVMCPGroupRef(mcpGroupName),
+					v1beta1test.WithVMCPConfig(vmcpconfig.Config{Group: mcpGroupName}),
+					v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{Type: "anonymous"}),
+					// "shared" appears in both sources to exercise overlap;
+					// "explicit-only" is unique to spec.imagePullSecrets;
+					// "podtemplate-only" is unique to PodTemplateSpec.
+					v1beta1test.MutateVMCP(func(v *mcpv1beta1.VirtualMCPServer) {
+						v.Spec.ImagePullSecrets = []corev1.LocalObjectReference{
 							{Name: "shared"},
 							{Name: "explicit-only"},
-						},
-						PodTemplateSpec: &runtime.RawExtension{
-							Raw: []byte(`{"spec":{"imagePullSecrets":[{"name":"shared"},{"name":"podtemplate-only"}]}}`),
-						},
-					},
-				}
+						}
+					}),
+					v1beta1test.WithVMCPPodTemplateSpec(&runtime.RawExtension{
+						Raw: []byte(`{"spec":{"imagePullSecrets":[{"name":"shared"},{"name":"podtemplate-only"}]}}`),
+					}),
+				)
 				Expect(k8sClient.Create(ctx, virtualMCPServer)).Should(Succeed())
 			})
 

--- a/cmd/thv-operator/test-integration/virtualmcp/virtualmcpserver_podtemplatespec_integration_test.go
+++ b/cmd/thv-operator/test-integration/virtualmcp/virtualmcpserver_podtemplatespec_integration_test.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1/v1beta1test"
 	vmcpconfig "github.com/stacklok/toolhive/pkg/vmcp/config"
 )
 
@@ -66,23 +67,17 @@ var _ = Describe("VirtualMCPServer PodTemplateSpec Integration Tests", func() {
 			Expect(k8sClient.Create(ctx, mcpGroup)).Should(Succeed())
 
 			// Define the VirtualMCPServer resource with invalid PodTemplateSpec
-			virtualMCPServer = &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      virtualMCPName,
-					Namespace: namespace,
-				},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef: &mcpv1beta1.MCPGroupRef{Name: mcpGroupName},
-					Config:   vmcpconfig.Config{Group: mcpGroupName},
-					IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-						Type: "anonymous",
-					},
-					// Invalid PodTemplateSpec - containers should be an array, not a string
-					PodTemplateSpec: &runtime.RawExtension{
-						Raw: []byte(`{"spec": {"containers": "invalid-not-an-array"}}`),
-					},
-				},
-			}
+			virtualMCPServer = v1beta1test.NewVirtualMCPServer(virtualMCPName, namespace,
+				v1beta1test.WithVMCPGroupRef(mcpGroupName),
+				v1beta1test.WithVMCPConfig(vmcpconfig.Config{Group: mcpGroupName}),
+				v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+					Type: "anonymous",
+				}),
+				// Invalid PodTemplateSpec - containers should be an array, not a string
+				v1beta1test.WithVMCPPodTemplateSpec(&runtime.RawExtension{
+					Raw: []byte(`{"spec": {"containers": "invalid-not-an-array"}}`),
+				}),
+			)
 
 			// Create the VirtualMCPServer
 			Expect(k8sClient.Create(ctx, virtualMCPServer)).Should(Succeed())
@@ -206,22 +201,16 @@ var _ = Describe("VirtualMCPServer PodTemplateSpec Integration Tests", func() {
 			// Define the VirtualMCPServer resource with valid PodTemplateSpec containing nodeSelector
 			// Only specify nodeSelector - don't include containers array
 			// Strategic merge will preserve the controller-generated vmcp container
-			virtualMCPServer = &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      virtualMCPName,
-					Namespace: namespace,
-				},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef: &mcpv1beta1.MCPGroupRef{Name: mcpGroupName},
-					Config:   vmcpconfig.Config{Group: mcpGroupName},
-					IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-						Type: "anonymous",
-					},
-					PodTemplateSpec: &runtime.RawExtension{
-						Raw: []byte(`{"spec":{"nodeSelector":{"disktype":"ssd"}}}`),
-					},
-				},
-			}
+			virtualMCPServer = v1beta1test.NewVirtualMCPServer(virtualMCPName, namespace,
+				v1beta1test.WithVMCPGroupRef(mcpGroupName),
+				v1beta1test.WithVMCPConfig(vmcpconfig.Config{Group: mcpGroupName}),
+				v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+					Type: "anonymous",
+				}),
+				v1beta1test.WithVMCPPodTemplateSpec(&runtime.RawExtension{
+					Raw: []byte(`{"spec":{"nodeSelector":{"disktype":"ssd"}}}`),
+				}),
+			)
 
 			// Create the VirtualMCPServer
 			Expect(k8sClient.Create(ctx, virtualMCPServer)).Should(Succeed())
@@ -310,22 +299,16 @@ var _ = Describe("VirtualMCPServer PodTemplateSpec Integration Tests", func() {
 			// Define the VirtualMCPServer resource with PodTemplateSpec containing nodeSelector
 			// Only specify nodeSelector - don't include containers array
 			// Strategic merge will preserve the controller-generated vmcp container
-			virtualMCPServer = &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      virtualMCPName,
-					Namespace: namespace,
-				},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef: &mcpv1beta1.MCPGroupRef{Name: mcpGroupName},
-					Config:   vmcpconfig.Config{Group: mcpGroupName},
-					IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-						Type: "anonymous",
-					},
-					PodTemplateSpec: &runtime.RawExtension{
-						Raw: []byte(`{"spec":{"nodeSelector":{"disktype":"ssd"}}}`),
-					},
-				},
-			}
+			virtualMCPServer = v1beta1test.NewVirtualMCPServer(virtualMCPName, namespace,
+				v1beta1test.WithVMCPGroupRef(mcpGroupName),
+				v1beta1test.WithVMCPConfig(vmcpconfig.Config{Group: mcpGroupName}),
+				v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+					Type: "anonymous",
+				}),
+				v1beta1test.WithVMCPPodTemplateSpec(&runtime.RawExtension{
+					Raw: []byte(`{"spec":{"nodeSelector":{"disktype":"ssd"}}}`),
+				}),
+			)
 
 			// Create the VirtualMCPServer
 			Expect(k8sClient.Create(ctx, virtualMCPServer)).Should(Succeed())

--- a/cmd/thv-operator/test-integration/virtualmcp/virtualmcpserver_replicas_integration_test.go
+++ b/cmd/thv-operator/test-integration/virtualmcp/virtualmcpserver_replicas_integration_test.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1/v1beta1test"
 	vmcpconfig "github.com/stacklok/toolhive/pkg/vmcp/config"
 )
 
@@ -53,21 +54,14 @@ var _ = Describe("VirtualMCPServer Replicas Integration Tests",
 				}
 				Expect(k8sClient.Create(ctx, mcpGroup)).Should(Succeed())
 
-				replicas := int32(3)
-				virtualMCPServer = &mcpv1beta1.VirtualMCPServer{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "vmcp-replicas-test",
-						Namespace: namespace,
-					},
-					Spec: mcpv1beta1.VirtualMCPServerSpec{
-						GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group-replicas"},
-						Config:   vmcpconfig.Config{Group: "test-group-replicas"},
-						IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-							Type: "anonymous",
-						},
-						Replicas: &replicas,
-					},
-				}
+				virtualMCPServer = v1beta1test.NewVirtualMCPServer("vmcp-replicas-test", namespace,
+					v1beta1test.WithVMCPGroupRef("test-group-replicas"),
+					v1beta1test.WithVMCPConfig(vmcpconfig.Config{Group: "test-group-replicas"}),
+					v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+						Type: "anonymous",
+					}),
+					v1beta1test.WithVMCPReplicas(3),
+				)
 				Expect(k8sClient.Create(ctx, virtualMCPServer)).Should(Succeed())
 			})
 
@@ -108,19 +102,13 @@ var _ = Describe("VirtualMCPServer Replicas Integration Tests",
 				}
 				Expect(k8sClient.Create(ctx, mcpGroup)).Should(Succeed())
 
-				virtualMCPServer = &mcpv1beta1.VirtualMCPServer{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "vmcp-nil-replicas-test",
-						Namespace: namespace,
-					},
-					Spec: mcpv1beta1.VirtualMCPServerSpec{
-						GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group-nil-replicas"},
-						Config:   vmcpconfig.Config{Group: "test-group-nil-replicas"},
-						IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-							Type: "anonymous",
-						},
-					},
-				}
+				virtualMCPServer = v1beta1test.NewVirtualMCPServer("vmcp-nil-replicas-test", namespace,
+					v1beta1test.WithVMCPGroupRef("test-group-nil-replicas"),
+					v1beta1test.WithVMCPConfig(vmcpconfig.Config{Group: "test-group-nil-replicas"}),
+					v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+						Type: "anonymous",
+					}),
+				)
 				Expect(k8sClient.Create(ctx, virtualMCPServer)).Should(Succeed())
 			})
 

--- a/cmd/thv-operator/test-integration/virtualmcp/virtualmcpserver_sessionstorage_cel_test.go
+++ b/cmd/thv-operator/test-integration/virtualmcp/virtualmcpserver_sessionstorage_cel_test.go
@@ -12,26 +12,21 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1/v1beta1test"
 	vmcpconfig "github.com/stacklok/toolhive/pkg/vmcp/config"
 )
 
 func newVirtualMCPServerWithSessionStorage(name string, ss *mcpv1beta1.SessionStorageConfig) *mcpv1beta1.VirtualMCPServer {
-	return &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: "default",
-		},
-		Spec: mcpv1beta1.VirtualMCPServerSpec{
-			GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-			IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-				Type: "anonymous",
-			},
-			Config: vmcpconfig.Config{
-				Group: "test-group",
-			},
-			SessionStorage: ss,
-		},
-	}
+	return v1beta1test.NewVirtualMCPServer(name, "default",
+		v1beta1test.WithVMCPGroupRef("test-group"),
+		v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+			Type: "anonymous",
+		}),
+		v1beta1test.WithVMCPConfig(vmcpconfig.Config{
+			Group: "test-group",
+		}),
+		v1beta1test.WithVMCPSessionStorage(ss),
+	)
 }
 
 var _ = Describe("CEL Validation for SessionStorageConfig on VirtualMCPServer",

--- a/cmd/thv-operator/test-integration/virtualmcp/virtualmcpserver_telemetryconfig_integration_test.go
+++ b/cmd/thv-operator/test-integration/virtualmcp/virtualmcpserver_telemetryconfig_integration_test.go
@@ -17,6 +17,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1/v1beta1test"
 	vmcpconfig "github.com/stacklok/toolhive/pkg/vmcp/config"
 )
 
@@ -79,22 +80,14 @@ var _ = Describe("VirtualMCPServer TelemetryConfig Integration",
 					return err == nil && fetched.Status.ConfigHash != ""
 				}, timeout, interval).Should(BeTrue())
 
-				virtualMCPServer = &mcpv1beta1.VirtualMCPServer{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-vmcp-telemetry-hash",
-						Namespace: namespace,
-					},
-					Spec: mcpv1beta1.VirtualMCPServerSpec{
-						GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group-telemetry-hash"},
-						Config:   vmcpconfig.Config{Group: "test-group-telemetry-hash"},
-						IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-							Type: "anonymous",
-						},
-						TelemetryConfigRef: &mcpv1beta1.MCPTelemetryConfigReference{
-							Name: "test-telemetry-vmcp-hash",
-						},
-					},
-				}
+				virtualMCPServer = v1beta1test.NewVirtualMCPServer("test-vmcp-telemetry-hash", namespace,
+					v1beta1test.WithVMCPGroupRef("test-group-telemetry-hash"),
+					v1beta1test.WithVMCPConfig(vmcpconfig.Config{Group: "test-group-telemetry-hash"}),
+					v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+						Type: "anonymous",
+					}),
+					v1beta1test.WithVMCPTelemetryConfigRef("test-telemetry-vmcp-hash"),
+				)
 				Expect(k8sClient.Create(ctx, virtualMCPServer)).Should(Succeed())
 			})
 
@@ -214,22 +207,14 @@ var _ = Describe("VirtualMCPServer TelemetryConfig Integration",
 					return err == nil && fetched.Status.ConfigHash != ""
 				}, timeout, interval).Should(BeTrue())
 
-				virtualMCPServer = &mcpv1beta1.VirtualMCPServer{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-vmcp-telemetry-update",
-						Namespace: namespace,
-					},
-					Spec: mcpv1beta1.VirtualMCPServerSpec{
-						GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group-telemetry-update"},
-						Config:   vmcpconfig.Config{Group: "test-group-telemetry-update"},
-						IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-							Type: "anonymous",
-						},
-						TelemetryConfigRef: &mcpv1beta1.MCPTelemetryConfigReference{
-							Name: "test-telemetry-vmcp-update",
-						},
-					},
-				}
+				virtualMCPServer = v1beta1test.NewVirtualMCPServer("test-vmcp-telemetry-update", namespace,
+					v1beta1test.WithVMCPGroupRef("test-group-telemetry-update"),
+					v1beta1test.WithVMCPConfig(vmcpconfig.Config{Group: "test-group-telemetry-update"}),
+					v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+						Type: "anonymous",
+					}),
+					v1beta1test.WithVMCPTelemetryConfigRef("test-telemetry-vmcp-update"),
+				)
 				Expect(k8sClient.Create(ctx, virtualMCPServer)).Should(Succeed())
 
 				// Wait for the initial hash to be propagated to the VirtualMCPServer
@@ -324,22 +309,14 @@ var _ = Describe("VirtualMCPServer TelemetryConfig Integration",
 				}
 				Expect(k8sClient.Create(ctx, mcpGroup)).Should(Succeed())
 
-				virtualMCPServer = &mcpv1beta1.VirtualMCPServer{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-vmcp-telemetry-notfound",
-						Namespace: namespace,
-					},
-					Spec: mcpv1beta1.VirtualMCPServerSpec{
-						GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group-telemetry-notfound"},
-						Config:   vmcpconfig.Config{Group: "test-group-telemetry-notfound"},
-						IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-							Type: "anonymous",
-						},
-						TelemetryConfigRef: &mcpv1beta1.MCPTelemetryConfigReference{
-							Name: "nonexistent-telemetry-config",
-						},
-					},
-				}
+				virtualMCPServer = v1beta1test.NewVirtualMCPServer("test-vmcp-telemetry-notfound", namespace,
+					v1beta1test.WithVMCPGroupRef("test-group-telemetry-notfound"),
+					v1beta1test.WithVMCPConfig(vmcpconfig.Config{Group: "test-group-telemetry-notfound"}),
+					v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+						Type: "anonymous",
+					}),
+					v1beta1test.WithVMCPTelemetryConfigRef("nonexistent-telemetry-config"),
+				)
 				Expect(k8sClient.Create(ctx, virtualMCPServer)).Should(Succeed())
 			})
 

--- a/pkg/vmcp/status/k8s_reporter_test.go
+++ b/pkg/vmcp/status/k8s_reporter_test.go
@@ -19,6 +19,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1/v1beta1test"
 	vmcptypes "github.com/stacklok/toolhive/pkg/vmcp"
 	vmcpconfig "github.com/stacklok/toolhive/pkg/vmcp/config"
 )
@@ -653,21 +654,17 @@ func createTestReporter(t *testing.T, name, namespace string) (*K8sReporter, cli
 func createTestVirtualMCPServer(t *testing.T, fakeClient client.Client, name, namespace string) *mcpv1beta1.VirtualMCPServer {
 	t.Helper()
 
-	vmcpServer := &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:       name,
-			Namespace:  namespace,
-			Generation: 1,
-		},
-		Spec: mcpv1beta1.VirtualMCPServerSpec{
-			Config: vmcpconfig.Config{
-				Group: "test-group",
-			},
-			IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-				Type: "anonymous",
-			},
-		},
-	}
+	vmcpServer := v1beta1test.NewVirtualMCPServer(name, namespace,
+		v1beta1test.WithVMCPConfig(vmcpconfig.Config{
+			Group: "test-group",
+		}),
+		v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+			Type: "anonymous",
+		}),
+		v1beta1test.MutateVMCP(func(v *mcpv1beta1.VirtualMCPServer) {
+			v.Generation = 1
+		}),
+	)
 
 	ctx := context.Background()
 	err := fakeClient.Create(ctx, vmcpServer)

--- a/test/e2e/thv-operator/virtualmcp/virtualmcp_aggregation_filtering_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcp_aggregation_filtering_test.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1/v1beta1test"
 	vmcpconfig "github.com/stacklok/toolhive/pkg/vmcp/config"
 	"github.com/stacklok/toolhive/test/e2e/images"
 )
@@ -43,36 +44,32 @@ var _ = Describe("VirtualMCPServer Aggregation Filtering", Ordered, func() {
 		}, timeout, pollingInterval)
 
 		By("Creating VirtualMCPServer with tool filtering - only expose tools from backend1")
-		vmcpServer := &mcpv1beta1.VirtualMCPServer{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      vmcpServerName,
-				Namespace: testNamespace,
-			},
-			Spec: mcpv1beta1.VirtualMCPServerSpec{
-				GroupRef: &mcpv1beta1.MCPGroupRef{Name: mcpGroupName},
-				Config: vmcpconfig.Config{
-					Group: mcpGroupName,
-					Aggregation: &vmcpconfig.AggregationConfig{
-						ConflictResolution: "prefix",
-						// Tool filtering: only allow echo from backend1, nothing from backend2
-						Tools: []*vmcpconfig.WorkloadToolConfig{
-							{
-								Workload: backend1Name,
-								Filter:   []string{"echo"}, // Only expose echo tool
-							},
-							{
-								Workload:   backend2Name,
-								ExcludeAll: true, // Exclude all tools from backend2
-							},
+		vmcpServer := v1beta1test.NewVirtualMCPServer(vmcpServerName, testNamespace,
+			v1beta1test.WithVMCPGroupRef(mcpGroupName),
+			v1beta1test.WithVMCPConfig(vmcpconfig.Config{
+				Group: mcpGroupName,
+				Aggregation: &vmcpconfig.AggregationConfig{
+					ConflictResolution: "prefix",
+					// Tool filtering: only allow echo from backend1, nothing from backend2
+					Tools: []*vmcpconfig.WorkloadToolConfig{
+						{
+							Workload: backend1Name,
+							Filter:   []string{"echo"}, // Only expose echo tool
+						},
+						{
+							Workload:   backend2Name,
+							ExcludeAll: true, // Exclude all tools from backend2
 						},
 					},
 				},
-				IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-					Type: "anonymous",
-				},
-				ServiceType: "NodePort",
-			},
-		}
+			}),
+			v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+				Type: "anonymous",
+			}),
+			v1beta1test.MutateVMCP(func(v *mcpv1beta1.VirtualMCPServer) {
+				v.Spec.ServiceType = "NodePort"
+			}),
+		)
 		Expect(k8sClient.Create(ctx, vmcpServer)).To(Succeed())
 
 		By("Waiting for VirtualMCPServer to be ready")
@@ -86,12 +83,7 @@ var _ = Describe("VirtualMCPServer Aggregation Filtering", Ordered, func() {
 
 	AfterAll(func() {
 		By("Cleaning up VirtualMCPServer")
-		vmcpServer := &mcpv1beta1.VirtualMCPServer{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      vmcpServerName,
-				Namespace: testNamespace,
-			},
-		}
+		vmcpServer := v1beta1test.NewVirtualMCPServer(vmcpServerName, testNamespace)
 		_ = k8sClient.Delete(ctx, vmcpServer)
 
 		By("Cleaning up backend MCPServers")

--- a/test/e2e/thv-operator/virtualmcp/virtualmcp_aggregation_overrides_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcp_aggregation_overrides_test.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1/v1beta1test"
 	vmcpconfig "github.com/stacklok/toolhive/pkg/vmcp/config"
 	"github.com/stacklok/toolhive/test/e2e/images"
 )
@@ -44,40 +45,36 @@ var _ = Describe("VirtualMCPServer Tool Overrides", Ordered, func() {
 			images.YardstickServerImage, timeout, pollingInterval)
 
 		By("Creating VirtualMCPServer with tool overrides")
-		vmcpServer := &mcpv1beta1.VirtualMCPServer{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      vmcpServerName,
-				Namespace: testNamespace,
-			},
-			Spec: mcpv1beta1.VirtualMCPServerSpec{
-				GroupRef: &mcpv1beta1.MCPGroupRef{Name: mcpGroupName},
-				Config: vmcpconfig.Config{
-					Group: mcpGroupName,
-					Aggregation: &vmcpconfig.AggregationConfig{
-						ConflictResolution: "prefix",
-						// Tool overrides: rename echo to custom_echo_tool with new description
-						// Note: Filter uses the user-facing name (after override), so we filter by
-						// the renamed tool name, not the original name.
-						Tools: []*vmcpconfig.WorkloadToolConfig{
-							{
-								Workload: backendName,
-								Filter:   []string{renamedToolName}, // Filter by user-facing name (after override)
-								Overrides: map[string]*vmcpconfig.ToolOverride{
-									originalToolName: {
-										Name:        renamedToolName,
-										Description: newDescription,
-									},
+		vmcpServer := v1beta1test.NewVirtualMCPServer(vmcpServerName, testNamespace,
+			v1beta1test.WithVMCPGroupRef(mcpGroupName),
+			v1beta1test.WithVMCPConfig(vmcpconfig.Config{
+				Group: mcpGroupName,
+				Aggregation: &vmcpconfig.AggregationConfig{
+					ConflictResolution: "prefix",
+					// Tool overrides: rename echo to custom_echo_tool with new description
+					// Note: Filter uses the user-facing name (after override), so we filter by
+					// the renamed tool name, not the original name.
+					Tools: []*vmcpconfig.WorkloadToolConfig{
+						{
+							Workload: backendName,
+							Filter:   []string{renamedToolName}, // Filter by user-facing name (after override)
+							Overrides: map[string]*vmcpconfig.ToolOverride{
+								originalToolName: {
+									Name:        renamedToolName,
+									Description: newDescription,
 								},
 							},
 						},
 					},
 				},
-				IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-					Type: "anonymous",
-				},
-				ServiceType: "NodePort",
-			},
-		}
+			}),
+			v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+				Type: "anonymous",
+			}),
+			v1beta1test.MutateVMCP(func(v *mcpv1beta1.VirtualMCPServer) {
+				v.Spec.ServiceType = "NodePort"
+			}),
+		)
 		Expect(k8sClient.Create(ctx, vmcpServer)).To(Succeed())
 
 		By("Waiting for VirtualMCPServer to be ready")
@@ -91,12 +88,7 @@ var _ = Describe("VirtualMCPServer Tool Overrides", Ordered, func() {
 
 	AfterAll(func() {
 		By("Cleaning up VirtualMCPServer")
-		vmcpServer := &mcpv1beta1.VirtualMCPServer{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      vmcpServerName,
-				Namespace: testNamespace,
-			},
-		}
+		vmcpServer := v1beta1test.NewVirtualMCPServer(vmcpServerName, testNamespace)
 		_ = k8sClient.Delete(ctx, vmcpServer)
 
 		By("Cleaning up backend MCPServer")

--- a/test/e2e/thv-operator/virtualmcp/virtualmcp_auth_discovery_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcp_auth_discovery_test.go
@@ -25,6 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1/v1beta1test"
 	vmcpconfig "github.com/stacklok/toolhive/pkg/vmcp/config"
 	"github.com/stacklok/toolhive/test/e2e/images"
 )
@@ -845,41 +846,37 @@ with socketserver.TCPServer(("", PORT), OIDCHandler) as httpd:
 		podTemplateRaw, err := json.Marshal(podTemplateSpec)
 		Expect(err).ToNot(HaveOccurred())
 
-		vmcpServer := &mcpv1beta1.VirtualMCPServer{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      vmcpServerName,
-				Namespace: testNamespace,
-			},
-			Spec: mcpv1beta1.VirtualMCPServerSpec{
-				GroupRef: &mcpv1beta1.MCPGroupRef{Name: mcpGroupName},
-				Config: vmcpconfig.Config{
-					Group: mcpGroupName,
-					// No TokenCache configured - tokens should be fetched on each request
-					Aggregation: &vmcpconfig.AggregationConfig{
-						ConflictResolution: "prefix",
-					},
+		vmcpServer := v1beta1test.NewVirtualMCPServer(vmcpServerName, testNamespace,
+			v1beta1test.WithVMCPGroupRef(mcpGroupName),
+			v1beta1test.WithVMCPConfig(vmcpconfig.Config{
+				Group: mcpGroupName,
+				// No TokenCache configured - tokens should be fetched on each request
+				Aggregation: &vmcpconfig.AggregationConfig{
+					ConflictResolution: "prefix",
 				},
-				// OIDC incoming auth - clients must present valid OIDC tokens
-				// vMCP will validate tokens and then exchange them for backend-specific tokens
-				IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-					Type: "oidc",
-					OIDCConfigRef: &mcpv1beta1.MCPOIDCConfigReference{
-						Name:     "discovery-oidc-config",
-						Audience: "vmcp-audience",
-					},
+			}),
+			// OIDC incoming auth - clients must present valid OIDC tokens
+			// vMCP will validate tokens and then exchange them for backend-specific tokens
+			v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+				Type: "oidc",
+				OIDCConfigRef: &mcpv1beta1.MCPOIDCConfigReference{
+					Name:     "discovery-oidc-config",
+					Audience: "vmcp-audience",
 				},
-				// DISCOVERED MODE: vMCP will discover outgoing auth from backend MCPServers
-				// Backend has token exchange configured, vMCP will discover and use it
-				OutgoingAuth: &mcpv1beta1.OutgoingAuthConfig{
-					Source: "discovered",
-				},
-				ServiceType: "NodePort",
-				// Enable debug logging via PodTemplateSpec
-				PodTemplateSpec: &runtime.RawExtension{
-					Raw: podTemplateRaw,
-				},
-			},
-		}
+			}),
+			// DISCOVERED MODE: vMCP will discover outgoing auth from backend MCPServers
+			// Backend has token exchange configured, vMCP will discover and use it
+			v1beta1test.WithVMCPOutgoingAuth(&mcpv1beta1.OutgoingAuthConfig{
+				Source: "discovered",
+			}),
+			// Enable debug logging via PodTemplateSpec
+			v1beta1test.WithVMCPPodTemplateSpec(&runtime.RawExtension{
+				Raw: podTemplateRaw,
+			}),
+			v1beta1test.MutateVMCP(func(v *mcpv1beta1.VirtualMCPServer) {
+				v.Spec.ServiceType = "NodePort"
+			}),
+		)
 		Expect(k8sClient.Create(ctx, vmcpServer)).To(Succeed())
 
 		By("Waiting for VirtualMCPServer to be ready")
@@ -967,12 +964,7 @@ with socketserver.TCPServer(("", PORT), OIDCHandler) as httpd:
 		WaitForPodDeletion(ctx, k8sClient, "mock-oidc-server", testNamespace, cleanupTimeout, pollingInterval)
 
 		By("Cleaning up VirtualMCPServer")
-		vmcpServer := &mcpv1beta1.VirtualMCPServer{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      vmcpServerName,
-				Namespace: testNamespace,
-			},
-		}
+		vmcpServer := v1beta1test.NewVirtualMCPServer(vmcpServerName, testNamespace)
 		_ = k8sClient.Delete(ctx, vmcpServer)
 
 		By("Cleaning up backend MCPServers")
@@ -1516,23 +1508,19 @@ var _ = Describe("Auth Config Error Handling", Ordered, func() {
 		}, timeout, pollingInterval).Should(Succeed(), "Valid backend should become Running")
 
 		By("Creating VirtualMCPServer with discovered auth mode")
-		vmcpServer := &mcpv1beta1.VirtualMCPServer{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      vmcpServerName,
-				Namespace: testNamespace,
-			},
-			Spec: mcpv1beta1.VirtualMCPServerSpec{
-				GroupRef: &mcpv1beta1.MCPGroupRef{Name: mcpGroupName},
-				IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-					Type: "anonymous",
-				},
-				// Use discovered mode to trigger auth discovery
-				OutgoingAuth: &mcpv1beta1.OutgoingAuthConfig{
-					Source: "discovered",
-				},
-				ServiceType: "NodePort",
-			},
-		}
+		vmcpServer := v1beta1test.NewVirtualMCPServer(vmcpServerName, testNamespace,
+			v1beta1test.WithVMCPGroupRef(mcpGroupName),
+			v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+				Type: "anonymous",
+			}),
+			// Use discovered mode to trigger auth discovery
+			v1beta1test.WithVMCPOutgoingAuth(&mcpv1beta1.OutgoingAuthConfig{
+				Source: "discovered",
+			}),
+			v1beta1test.MutateVMCP(func(v *mcpv1beta1.VirtualMCPServer) {
+				v.Spec.ServiceType = "NodePort"
+			}),
+		)
 		Expect(k8sClient.Create(ctx, vmcpServer)).To(Succeed())
 
 		// Wait briefly for controller to reconcile
@@ -1541,9 +1529,7 @@ var _ = Describe("Auth Config Error Handling", Ordered, func() {
 
 	AfterAll(func() {
 		By("Cleaning up VirtualMCPServer")
-		_ = k8sClient.Delete(ctx, &mcpv1beta1.VirtualMCPServer{
-			ObjectMeta: metav1.ObjectMeta{Name: vmcpServerName, Namespace: testNamespace},
-		})
+		_ = k8sClient.Delete(ctx, v1beta1test.NewVirtualMCPServer(vmcpServerName, testNamespace))
 
 		By("Cleaning up MCPServers")
 		_ = k8sClient.Delete(ctx, &mcpv1beta1.MCPServer{

--- a/test/e2e/thv-operator/virtualmcp/virtualmcp_authserver_config_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcp_authserver_config_test.go
@@ -12,6 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1/v1beta1test"
 )
 
 var _ = Describe("VirtualMCPServer AuthServerConfig Validation", Ordered, func() {
@@ -52,43 +53,35 @@ var _ = Describe("VirtualMCPServer AuthServerConfig Validation", Ordered, func()
 			})).To(Succeed())
 
 			By("Creating VirtualMCPServer with valid inline AuthServerConfig")
-			vmcp := &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      vmcpName,
-					Namespace: testNamespace,
-				},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-						Type: "oidc",
-						OIDCConfigRef: &mcpv1beta1.MCPOIDCConfigReference{
-							Name: "authserver-oidc-config",
-							// Audience must match the auth server's allowed audience (the vMCP service URL)
-							Audience: fmt.Sprintf("http://%s.%s.svc.cluster.local:4483", vmcpName, testNamespace),
-						},
+			vmcp := v1beta1test.NewVirtualMCPServer(vmcpName, testNamespace,
+				v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+					Type: "oidc",
+					OIDCConfigRef: &mcpv1beta1.MCPOIDCConfigReference{
+						Name: "authserver-oidc-config",
+						// Audience must match the auth server's allowed audience (the vMCP service URL)
+						Audience: fmt.Sprintf("http://%s.%s.svc.cluster.local:4483", vmcpName, testNamespace),
 					},
-					GroupRef: &mcpv1beta1.MCPGroupRef{Name: mcpGroupName},
-					AuthServerConfig: &mcpv1beta1.EmbeddedAuthServerConfig{
-						Issuer: "http://localhost:9090",
-						UpstreamProviders: []mcpv1beta1.UpstreamProviderConfig{
-							{
-								Name: "test-provider",
-								Type: mcpv1beta1.UpstreamProviderTypeOIDC,
-								OIDCConfig: &mcpv1beta1.OIDCUpstreamConfig{
-									IssuerURL: "https://accounts.google.com",
-									ClientID:  "test-client-id",
-								},
+				}),
+				v1beta1test.WithVMCPGroupRef(mcpGroupName),
+				v1beta1test.WithVMCPAuthServerConfig(&mcpv1beta1.EmbeddedAuthServerConfig{
+					Issuer: "http://localhost:9090",
+					UpstreamProviders: []mcpv1beta1.UpstreamProviderConfig{
+						{
+							Name: "test-provider",
+							Type: mcpv1beta1.UpstreamProviderTypeOIDC,
+							OIDCConfig: &mcpv1beta1.OIDCUpstreamConfig{
+								IssuerURL: "https://accounts.google.com",
+								ClientID:  "test-client-id",
 							},
 						},
 					},
-				},
-			}
+				}),
+			)
 			Expect(k8sClient.Create(ctx, vmcp)).To(Succeed())
 		})
 
 		AfterAll(func() {
-			_ = k8sClient.Delete(ctx, &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{Name: vmcpName, Namespace: testNamespace},
-			})
+			_ = k8sClient.Delete(ctx, v1beta1test.NewVirtualMCPServer(vmcpName, testNamespace))
 		})
 
 		It("should set AuthServerConfigValidated condition to True", func() {

--- a/test/e2e/thv-operator/virtualmcp/virtualmcp_circuit_breaker_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcp_circuit_breaker_test.go
@@ -17,6 +17,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1/v1beta1test"
 	vmcpconfig "github.com/stacklok/toolhive/pkg/vmcp/config"
 	"github.com/stacklok/toolhive/test/e2e/images"
 )
@@ -149,41 +150,37 @@ var _ = Describe("VirtualMCPServer Circuit Breaker Lifecycle", Ordered, func() {
 
 	It("should configure circuit breaker from VirtualMCPServer spec", func() {
 		By("Creating VirtualMCPServer with circuit breaker enabled")
-		vmcpServer := &mcpv1beta1.VirtualMCPServer{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      vmcpServerName,
-				Namespace: testNamespace,
-			},
-			Spec: mcpv1beta1.VirtualMCPServerSpec{
-				GroupRef: &mcpv1beta1.MCPGroupRef{Name: mcpGroupName},
-				IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-					Type: "anonymous",
+		vmcpServer := v1beta1test.NewVirtualMCPServer(vmcpServerName, testNamespace,
+			v1beta1test.WithVMCPGroupRef(mcpGroupName),
+			v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+				Type: "anonymous",
+			}),
+			v1beta1test.WithVMCPOutgoingAuth(&mcpv1beta1.OutgoingAuthConfig{
+				Source: "discovered",
+			}),
+			v1beta1test.WithVMCPConfig(vmcpconfig.Config{
+				Name:  vmcpServerName,
+				Group: mcpGroupName,
+				Aggregation: &vmcpconfig.AggregationConfig{
+					ConflictResolution: "prefix",
 				},
-				OutgoingAuth: &mcpv1beta1.OutgoingAuthConfig{
-					Source: "discovered",
-				},
-				ServiceType: "NodePort",
-				Config: vmcpconfig.Config{
-					Name:  vmcpServerName,
-					Group: mcpGroupName,
-					Aggregation: &vmcpconfig.AggregationConfig{
-						ConflictResolution: "prefix",
-					},
-					Operational: &vmcpconfig.OperationalConfig{
-						FailureHandling: &vmcpconfig.FailureHandlingConfig{
-							HealthCheckInterval: vmcpconfig.Duration(cbHealthCheckInterval),
-							HealthCheckTimeout:  vmcpconfig.Duration(cbHealthCheckTimeout),
-							UnhealthyThreshold:  cbUnhealthyThreshold,
-							CircuitBreaker: &vmcpconfig.CircuitBreakerConfig{
-								Enabled:          true,
-								FailureThreshold: cbFailureThreshold,
-								Timeout:          vmcpconfig.Duration(cbTimeout),
-							},
+				Operational: &vmcpconfig.OperationalConfig{
+					FailureHandling: &vmcpconfig.FailureHandlingConfig{
+						HealthCheckInterval: vmcpconfig.Duration(cbHealthCheckInterval),
+						HealthCheckTimeout:  vmcpconfig.Duration(cbHealthCheckTimeout),
+						UnhealthyThreshold:  cbUnhealthyThreshold,
+						CircuitBreaker: &vmcpconfig.CircuitBreakerConfig{
+							Enabled:          true,
+							FailureThreshold: cbFailureThreshold,
+							Timeout:          vmcpconfig.Duration(cbTimeout),
 						},
 					},
 				},
-			},
-		}
+			}),
+			v1beta1test.MutateVMCP(func(v *mcpv1beta1.VirtualMCPServer) {
+				v.Spec.ServiceType = "NodePort"
+			}),
+		)
 		Expect(k8sClient.Create(ctx, vmcpServer)).To(Succeed())
 
 		By("Verifying circuit breaker configuration in ConfigMap")

--- a/test/e2e/thv-operator/virtualmcp/virtualmcp_composite_defaultresults_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcp_composite_defaultresults_test.go
@@ -13,6 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1/v1beta1test"
 	thvjson "github.com/stacklok/toolhive/pkg/json"
 	vmcpconfig "github.com/stacklok/toolhive/pkg/vmcp/config"
 	"github.com/stacklok/toolhive/test/e2e/images"
@@ -42,74 +43,70 @@ var _ = Describe("VirtualMCPServer Composite Tool DefaultResults", Ordered, func
 			images.YardstickServerImage, timeout, pollingInterval)
 
 		By("Creating VirtualMCPServer with composite tool using defaultResults")
-		vmcpServer := &mcpv1beta1.VirtualMCPServer{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      vmcpServerName,
-				Namespace: testNamespace,
-			},
-			Spec: mcpv1beta1.VirtualMCPServerSpec{
-				GroupRef: &mcpv1beta1.MCPGroupRef{Name: mcpGroupName},
-				Config: vmcpconfig.Config{
-					Group: mcpGroupName,
-					Aggregation: &vmcpconfig.AggregationConfig{
-						ConflictResolution: "prefix",
-					},
-					// Define a composite tool with a conditional step that has defaultResults
-					CompositeTools: []vmcpconfig.CompositeToolConfig{
-						{
-							Name:        compositeToolName,
-							Description: "Conditionally echoes input, uses default when skipped",
-							Parameters: thvjson.NewMap(map[string]any{
-								"type": "object",
-								"properties": map[string]any{
-									"run_step": map[string]any{
-										"type":        "boolean",
-										"description": "Whether to run the conditional step",
-									},
-									"message": map[string]any{
-										"type":        "string",
-										"description": "Message to echo if step runs",
-									},
+		vmcpServer := v1beta1test.NewVirtualMCPServer(vmcpServerName, testNamespace,
+			v1beta1test.WithVMCPGroupRef(mcpGroupName),
+			v1beta1test.WithVMCPConfig(vmcpconfig.Config{
+				Group: mcpGroupName,
+				Aggregation: &vmcpconfig.AggregationConfig{
+					ConflictResolution: "prefix",
+				},
+				// Define a composite tool with a conditional step that has defaultResults
+				CompositeTools: []vmcpconfig.CompositeToolConfig{
+					{
+						Name:        compositeToolName,
+						Description: "Conditionally echoes input, uses default when skipped",
+						Parameters: thvjson.NewMap(map[string]any{
+							"type": "object",
+							"properties": map[string]any{
+								"run_step": map[string]any{
+									"type":        "boolean",
+									"description": "Whether to run the conditional step",
 								},
-								"required": []any{"run_step", "message"},
-							}),
-							Timeout: vmcpconfig.Duration(30 * time.Second),
-							Steps: []vmcpconfig.WorkflowStepConfig{
-								{
-									ID:   "conditional_step",
-									Type: "tool",
-									Tool: fmt.Sprintf("%s_echo", backendName),
-									// Only run when run_step=true
-									Condition: "{{.params.run_step}}",
-									Arguments: thvjson.NewMap(map[string]any{
-										"input": "{{ .params.message }}",
-									}),
-									// When skipped, use this default value
-									// Uses "output" key to match yardstick 1.1.1 EchoResponse format
-									DefaultResults: thvjson.NewMap(map[string]any{
-										"output": "default_value_when_skipped",
-									}),
+								"message": map[string]any{
+									"type":        "string",
+									"description": "Message to echo if step runs",
 								},
 							},
-							// Output references the conditional step's output.output
-							Output: &vmcpconfig.OutputConfig{
-								Properties: map[string]vmcpconfig.OutputProperty{
-									"result": {
-										Type:        "string",
-										Description: "Result from conditional step",
-										Value:       "{{.steps.conditional_step.output.output}}",
-									},
+							"required": []any{"run_step", "message"},
+						}),
+						Timeout: vmcpconfig.Duration(30 * time.Second),
+						Steps: []vmcpconfig.WorkflowStepConfig{
+							{
+								ID:   "conditional_step",
+								Type: "tool",
+								Tool: fmt.Sprintf("%s_echo", backendName),
+								// Only run when run_step=true
+								Condition: "{{.params.run_step}}",
+								Arguments: thvjson.NewMap(map[string]any{
+									"input": "{{ .params.message }}",
+								}),
+								// When skipped, use this default value
+								// Uses "output" key to match yardstick 1.1.1 EchoResponse format
+								DefaultResults: thvjson.NewMap(map[string]any{
+									"output": "default_value_when_skipped",
+								}),
+							},
+						},
+						// Output references the conditional step's output.output
+						Output: &vmcpconfig.OutputConfig{
+							Properties: map[string]vmcpconfig.OutputProperty{
+								"result": {
+									Type:        "string",
+									Description: "Result from conditional step",
+									Value:       "{{.steps.conditional_step.output.output}}",
 								},
 							},
 						},
 					},
 				},
-				IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-					Type: "anonymous",
-				},
-				ServiceType: "NodePort",
-			},
-		}
+			}),
+			v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+				Type: "anonymous",
+			}),
+			v1beta1test.MutateVMCP(func(v *mcpv1beta1.VirtualMCPServer) {
+				v.Spec.ServiceType = "NodePort"
+			}),
+		)
 		Expect(k8sClient.Create(ctx, vmcpServer)).To(Succeed())
 
 		By("Waiting for VirtualMCPServer to be ready")
@@ -124,12 +121,7 @@ var _ = Describe("VirtualMCPServer Composite Tool DefaultResults", Ordered, func
 
 	AfterAll(func() {
 		By("Cleaning up VirtualMCPServer")
-		vmcpServer := &mcpv1beta1.VirtualMCPServer{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      vmcpServerName,
-				Namespace: testNamespace,
-			},
-		}
+		vmcpServer := v1beta1test.NewVirtualMCPServer(vmcpServerName, testNamespace)
 		_ = k8sClient.Delete(ctx, vmcpServer)
 
 		By("Cleaning up backend MCPServer")

--- a/test/e2e/thv-operator/virtualmcp/virtualmcp_composite_hidden_tools_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcp_composite_hidden_tools_test.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1/v1beta1test"
 	thvjson "github.com/stacklok/toolhive/pkg/json"
 	vmcpconfig "github.com/stacklok/toolhive/pkg/vmcp/config"
 	"github.com/stacklok/toolhive/test/e2e/images"
@@ -60,77 +61,73 @@ var _ = Describe("VirtualMCPServer Composite with Hidden Backend Tools", Ordered
 			images.YardstickServerImage, timeout, pollingInterval)
 
 		By("Creating VirtualMCPServer with mixed ExcludeAll and Filter configuration")
-		vmcpServer := &mcpv1beta1.VirtualMCPServer{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      vmcpServerName,
-				Namespace: testNamespace,
-			},
-			Spec: mcpv1beta1.VirtualMCPServerSpec{
-				GroupRef: &mcpv1beta1.MCPGroupRef{Name: mcpGroupName},
-				Config: vmcpconfig.Config{
-					Group: mcpGroupName,
-					Aggregation: &vmcpconfig.AggregationConfig{
-						ConflictResolution: "prefix",
-						Tools: []*vmcpconfig.WorkloadToolConfig{
-							{
-								// Backend A: Hide ALL tools using ExcludeAll
-								Workload:   backendAName,
-								ExcludeAll: true,
-							},
-							{
-								// Backend B: Hide tools using Filter (only expose non-existent tool name)
-								// This effectively hides all backend tools while keeping them in routing table
-								Workload: backendBName,
-								Filter:   []string{"nonexistent_tool_for_filter_test"},
-							},
-						},
-					},
-					// Define a composite tool that uses tools from BOTH hidden backends
-					CompositeTools: []vmcpconfig.CompositeToolConfig{
+		vmcpServer := v1beta1test.NewVirtualMCPServer(vmcpServerName, testNamespace,
+			v1beta1test.WithVMCPGroupRef(mcpGroupName),
+			v1beta1test.WithVMCPConfig(vmcpconfig.Config{
+				Group: mcpGroupName,
+				Aggregation: &vmcpconfig.AggregationConfig{
+					ConflictResolution: "prefix",
+					Tools: []*vmcpconfig.WorkloadToolConfig{
 						{
-							Name:        compositeToolName,
-							Description: "A composite tool that echoes via both hidden backends",
-							Parameters: thvjson.NewMap(map[string]any{
-								"type": "object",
-								"properties": map[string]any{
-									"message": map[string]any{
-										"type":        "string",
-										"description": "The message to echo through both backends",
-									},
+							// Backend A: Hide ALL tools using ExcludeAll
+							Workload:   backendAName,
+							ExcludeAll: true,
+						},
+						{
+							// Backend B: Hide tools using Filter (only expose non-existent tool name)
+							// This effectively hides all backend tools while keeping them in routing table
+							Workload: backendBName,
+							Filter:   []string{"nonexistent_tool_for_filter_test"},
+						},
+					},
+				},
+				// Define a composite tool that uses tools from BOTH hidden backends
+				CompositeTools: []vmcpconfig.CompositeToolConfig{
+					{
+						Name:        compositeToolName,
+						Description: "A composite tool that echoes via both hidden backends",
+						Parameters: thvjson.NewMap(map[string]any{
+							"type": "object",
+							"properties": map[string]any{
+								"message": map[string]any{
+									"type":        "string",
+									"description": "The message to echo through both backends",
 								},
-								"required": []any{"message"},
-							}),
-							Timeout: vmcpconfig.Duration(30 * time.Second),
-							Steps: []vmcpconfig.WorkflowStepConfig{
-								{
-									// Step 1: Echo through Backend A (ExcludeAll)
-									ID:   "echo_backend_a",
-									Type: "tool",
-									Tool: fmt.Sprintf("%s_echo", backendAName),
-									Arguments: thvjson.NewMap(map[string]any{
-										"input": "{{ .params.message }}",
-									}),
-								},
-								{
-									// Step 2: Echo through Backend B (Filter)
-									ID:   "echo_backend_b",
-									Type: "tool",
-									Tool: fmt.Sprintf("%s_echo", backendBName),
-									Arguments: thvjson.NewMap(map[string]any{
-										"input": "{{ .params.message }}",
-									}),
-									DependsOn: []string{"echo_backend_a"},
-								},
+							},
+							"required": []any{"message"},
+						}),
+						Timeout: vmcpconfig.Duration(30 * time.Second),
+						Steps: []vmcpconfig.WorkflowStepConfig{
+							{
+								// Step 1: Echo through Backend A (ExcludeAll)
+								ID:   "echo_backend_a",
+								Type: "tool",
+								Tool: fmt.Sprintf("%s_echo", backendAName),
+								Arguments: thvjson.NewMap(map[string]any{
+									"input": "{{ .params.message }}",
+								}),
+							},
+							{
+								// Step 2: Echo through Backend B (Filter)
+								ID:   "echo_backend_b",
+								Type: "tool",
+								Tool: fmt.Sprintf("%s_echo", backendBName),
+								Arguments: thvjson.NewMap(map[string]any{
+									"input": "{{ .params.message }}",
+								}),
+								DependsOn: []string{"echo_backend_a"},
 							},
 						},
 					},
 				},
-				IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-					Type: "anonymous",
-				},
-				ServiceType: "NodePort",
-			},
-		}
+			}),
+			v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+				Type: "anonymous",
+			}),
+			v1beta1test.MutateVMCP(func(v *mcpv1beta1.VirtualMCPServer) {
+				v.Spec.ServiceType = "NodePort"
+			}),
+		)
 		Expect(k8sClient.Create(ctx, vmcpServer)).To(Succeed())
 
 		By("Waiting for VirtualMCPServer to be ready")
@@ -144,12 +141,7 @@ var _ = Describe("VirtualMCPServer Composite with Hidden Backend Tools", Ordered
 
 	AfterAll(func() {
 		By("Cleaning up VirtualMCPServer")
-		vmcpServer := &mcpv1beta1.VirtualMCPServer{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      vmcpServerName,
-				Namespace: testNamespace,
-			},
-		}
+		vmcpServer := v1beta1test.NewVirtualMCPServer(vmcpServerName, testNamespace)
 		_ = k8sClient.Delete(ctx, vmcpServer)
 
 		By("Cleaning up backend A MCPServer")

--- a/test/e2e/thv-operator/virtualmcp/virtualmcp_composite_parallel_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcp_composite_parallel_test.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1/v1beta1test"
 	thvjson "github.com/stacklok/toolhive/pkg/json"
 	vmcpconfig "github.com/stacklok/toolhive/pkg/vmcp/config"
 	"github.com/stacklok/toolhive/test/e2e/images"
@@ -46,74 +47,70 @@ var _ = Describe("VirtualMCPServer Composite Parallel Workflow", Ordered, func()
 		}, timeout, pollingInterval)
 
 		By("Creating VirtualMCPServer with composite parallel workflow")
-		vmcpServer := &mcpv1beta1.VirtualMCPServer{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      vmcpServerName,
-				Namespace: testNamespace,
-			},
-			Spec: mcpv1beta1.VirtualMCPServerSpec{
-				GroupRef: &mcpv1beta1.MCPGroupRef{Name: mcpGroupName},
-				Config: vmcpconfig.Config{
-					Group: mcpGroupName,
-					Aggregation: &vmcpconfig.AggregationConfig{
-						ConflictResolution: "prefix",
-					},
-					// Define a composite tool that echoes to both backends in parallel
-					// Steps without DependsOn can execute concurrently
-					CompositeTools: []vmcpconfig.CompositeToolConfig{
-						{
-							Name:        compositeToolName,
-							Description: "Echoes message to both backends in parallel, then combines results",
-							Parameters: thvjson.NewMap(map[string]any{
-								"type": "object",
-								"properties": map[string]any{
-									"message": map[string]any{
-										"type":        "string",
-										"description": "The message to echo in parallel to both backends",
-									},
+		vmcpServer := v1beta1test.NewVirtualMCPServer(vmcpServerName, testNamespace,
+			v1beta1test.WithVMCPGroupRef(mcpGroupName),
+			v1beta1test.WithVMCPConfig(vmcpconfig.Config{
+				Group: mcpGroupName,
+				Aggregation: &vmcpconfig.AggregationConfig{
+					ConflictResolution: "prefix",
+				},
+				// Define a composite tool that echoes to both backends in parallel
+				// Steps without DependsOn can execute concurrently
+				CompositeTools: []vmcpconfig.CompositeToolConfig{
+					{
+						Name:        compositeToolName,
+						Description: "Echoes message to both backends in parallel, then combines results",
+						Parameters: thvjson.NewMap(map[string]any{
+							"type": "object",
+							"properties": map[string]any{
+								"message": map[string]any{
+									"type":        "string",
+									"description": "The message to echo in parallel to both backends",
 								},
-								"required": []any{"message"},
-							}),
-							Timeout: vmcpconfig.Duration(60 * time.Second),
-							Steps: []vmcpconfig.WorkflowStepConfig{
-								{
-									// Step 1: Echo to backend1 (no dependencies - runs in parallel)
-									ID:   "echo_backend1",
-									Type: "tool",
-									Tool: fmt.Sprintf("%s.echo", backend1Name),
-									Arguments: thvjson.NewMap(map[string]any{
-										"input": "backend1: {{ .params.message }}",
-									}),
-								},
-								{
-									// Step 2: Echo to backend2 (no dependencies - runs in parallel with step 1)
-									ID:   "echo_backend2",
-									Type: "tool",
-									Tool: fmt.Sprintf("%s.echo", backend2Name),
-									Arguments: thvjson.NewMap(map[string]any{
-										"input": "backend2: {{ .params.message }}",
-									}),
-								},
-								{
-									// Step 3: Final aggregation - depends on both parallel steps
-									ID:        "combine_results",
-									Type:      "tool",
-									Tool:      fmt.Sprintf("%s.echo", backend1Name),
-									DependsOn: []string{"echo_backend1", "echo_backend2"},
-									Arguments: thvjson.NewMap(map[string]any{
-										"input": "Combined: [{{ .steps.echo_backend1.result }}] + [{{ .steps.echo_backend2.result }}]",
-									}),
-								},
+							},
+							"required": []any{"message"},
+						}),
+						Timeout: vmcpconfig.Duration(60 * time.Second),
+						Steps: []vmcpconfig.WorkflowStepConfig{
+							{
+								// Step 1: Echo to backend1 (no dependencies - runs in parallel)
+								ID:   "echo_backend1",
+								Type: "tool",
+								Tool: fmt.Sprintf("%s.echo", backend1Name),
+								Arguments: thvjson.NewMap(map[string]any{
+									"input": "backend1: {{ .params.message }}",
+								}),
+							},
+							{
+								// Step 2: Echo to backend2 (no dependencies - runs in parallel with step 1)
+								ID:   "echo_backend2",
+								Type: "tool",
+								Tool: fmt.Sprintf("%s.echo", backend2Name),
+								Arguments: thvjson.NewMap(map[string]any{
+									"input": "backend2: {{ .params.message }}",
+								}),
+							},
+							{
+								// Step 3: Final aggregation - depends on both parallel steps
+								ID:        "combine_results",
+								Type:      "tool",
+								Tool:      fmt.Sprintf("%s.echo", backend1Name),
+								DependsOn: []string{"echo_backend1", "echo_backend2"},
+								Arguments: thvjson.NewMap(map[string]any{
+									"input": "Combined: [{{ .steps.echo_backend1.result }}] + [{{ .steps.echo_backend2.result }}]",
+								}),
 							},
 						},
 					},
 				},
-				IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-					Type: "anonymous",
-				},
-				ServiceType: "NodePort",
-			},
-		}
+			}),
+			v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+				Type: "anonymous",
+			}),
+			v1beta1test.MutateVMCP(func(v *mcpv1beta1.VirtualMCPServer) {
+				v.Spec.ServiceType = "NodePort"
+			}),
+		)
 		Expect(k8sClient.Create(ctx, vmcpServer)).To(Succeed())
 
 		By("Waiting for VirtualMCPServer to be ready")
@@ -127,12 +124,7 @@ var _ = Describe("VirtualMCPServer Composite Parallel Workflow", Ordered, func()
 
 	AfterAll(func() {
 		By("Cleaning up VirtualMCPServer")
-		vmcpServer := &mcpv1beta1.VirtualMCPServer{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      vmcpServerName,
-				Namespace: testNamespace,
-			},
-		}
+		vmcpServer := v1beta1test.NewVirtualMCPServer(vmcpServerName, testNamespace)
 		_ = k8sClient.Delete(ctx, vmcpServer)
 
 		By("Cleaning up backend MCPServers")

--- a/test/e2e/thv-operator/virtualmcp/virtualmcp_composite_referenced_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcp_composite_referenced_test.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1/v1beta1test"
 	thvjson "github.com/stacklok/toolhive/pkg/json"
 	vmcpconfig "github.com/stacklok/toolhive/pkg/vmcp/config"
 	"github.com/stacklok/toolhive/test/e2e/images"
@@ -100,31 +101,27 @@ var _ = Describe("VirtualMCPServer Composite Referenced Workflow", Ordered, func
 		}, 30*time.Second, pollingInterval).Should(BeTrue(), "VirtualMCPCompositeToolDefinition should exist")
 
 		By("Creating VirtualMCPServer with referenced composite tool")
-		vmcpServer := &mcpv1beta1.VirtualMCPServer{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      vmcpServerName,
-				Namespace: testNamespace,
-			},
-			Spec: mcpv1beta1.VirtualMCPServerSpec{
-				GroupRef: &mcpv1beta1.MCPGroupRef{Name: mcpGroupName},
-				Config: vmcpconfig.Config{
-					Group: mcpGroupName,
-					Aggregation: &vmcpconfig.AggregationConfig{
-						ConflictResolution: "prefix",
-					},
-					// Reference the composite tool definition instead of defining inline
-					CompositeToolRefs: []vmcpconfig.CompositeToolRef{
-						{
-							Name: compositeToolDefName,
-						},
+		vmcpServer := v1beta1test.NewVirtualMCPServer(vmcpServerName, testNamespace,
+			v1beta1test.WithVMCPGroupRef(mcpGroupName),
+			v1beta1test.WithVMCPConfig(vmcpconfig.Config{
+				Group: mcpGroupName,
+				Aggregation: &vmcpconfig.AggregationConfig{
+					ConflictResolution: "prefix",
+				},
+				// Reference the composite tool definition instead of defining inline
+				CompositeToolRefs: []vmcpconfig.CompositeToolRef{
+					{
+						Name: compositeToolDefName,
 					},
 				},
-				IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-					Type: "anonymous",
-				},
-				ServiceType: "NodePort",
-			},
-		}
+			}),
+			v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+				Type: "anonymous",
+			}),
+			v1beta1test.MutateVMCP(func(v *mcpv1beta1.VirtualMCPServer) {
+				v.Spec.ServiceType = "NodePort"
+			}),
+		)
 		Expect(k8sClient.Create(ctx, vmcpServer)).To(Succeed())
 
 		By("Waiting for VirtualMCPServer to be ready")
@@ -138,12 +135,7 @@ var _ = Describe("VirtualMCPServer Composite Referenced Workflow", Ordered, func
 
 	AfterAll(func() {
 		By("Cleaning up VirtualMCPServer")
-		vmcpServer := &mcpv1beta1.VirtualMCPServer{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      vmcpServerName,
-				Namespace: testNamespace,
-			},
-		}
+		vmcpServer := v1beta1test.NewVirtualMCPServer(vmcpServerName, testNamespace)
 		_ = k8sClient.Delete(ctx, vmcpServer)
 
 		By("Cleaning up VirtualMCPCompositeToolDefinition")

--- a/test/e2e/thv-operator/virtualmcp/virtualmcp_composite_sequential_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcp_composite_sequential_test.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1/v1beta1test"
 	thvjson "github.com/stacklok/toolhive/pkg/json"
 	vmcpconfig "github.com/stacklok/toolhive/pkg/vmcp/config"
 	"github.com/stacklok/toolhive/test/e2e/images"
@@ -43,62 +44,58 @@ var _ = Describe("VirtualMCPServer Composite Sequential Workflow", Ordered, func
 			images.YardstickServerImage, timeout, pollingInterval)
 
 		By("Creating VirtualMCPServer with composite sequential workflow")
-		vmcpServer := &mcpv1beta1.VirtualMCPServer{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      vmcpServerName,
-				Namespace: testNamespace,
-			},
-			Spec: mcpv1beta1.VirtualMCPServerSpec{
-				GroupRef: &mcpv1beta1.MCPGroupRef{Name: mcpGroupName},
-				Config: vmcpconfig.Config{
-					Group: mcpGroupName,
-					Aggregation: &vmcpconfig.AggregationConfig{
-						ConflictResolution: "prefix",
-					},
-					// Define a composite tool that echoes input, then echoes the result again
-					CompositeTools: []vmcpconfig.CompositeToolConfig{
-						{
-							Name:        compositeToolName,
-							Description: "Echoes the input message twice in sequence",
-							Parameters: thvjson.NewMap(map[string]any{
-								"type": "object",
-								"properties": map[string]any{
-									"message": map[string]any{
-										"type":        "string",
-										"description": "The message to echo twice",
-									},
+		vmcpServer := v1beta1test.NewVirtualMCPServer(vmcpServerName, testNamespace,
+			v1beta1test.WithVMCPGroupRef(mcpGroupName),
+			v1beta1test.WithVMCPConfig(vmcpconfig.Config{
+				Group: mcpGroupName,
+				Aggregation: &vmcpconfig.AggregationConfig{
+					ConflictResolution: "prefix",
+				},
+				// Define a composite tool that echoes input, then echoes the result again
+				CompositeTools: []vmcpconfig.CompositeToolConfig{
+					{
+						Name:        compositeToolName,
+						Description: "Echoes the input message twice in sequence",
+						Parameters: thvjson.NewMap(map[string]any{
+							"type": "object",
+							"properties": map[string]any{
+								"message": map[string]any{
+									"type":        "string",
+									"description": "The message to echo twice",
 								},
-								"required": []any{"message"},
-							}),
-							Timeout: vmcpconfig.Duration(30 * time.Second),
-							Steps: []vmcpconfig.WorkflowStepConfig{
-								{
-									ID:   "first_echo",
-									Type: "tool",
-									Tool: fmt.Sprintf("%s.echo", backendName),
-									Arguments: thvjson.NewMap(map[string]any{
-										"input": "{{ .params.message }}",
-									}),
-								},
-								{
-									ID:        "second_echo",
-									Type:      "tool",
-									Tool:      fmt.Sprintf("%s.echo", backendName),
-									DependsOn: []string{"first_echo"},
-									Arguments: thvjson.NewMap(map[string]any{
-										"input": "{{ .steps.first_echo.result }}",
-									}),
-								},
+							},
+							"required": []any{"message"},
+						}),
+						Timeout: vmcpconfig.Duration(30 * time.Second),
+						Steps: []vmcpconfig.WorkflowStepConfig{
+							{
+								ID:   "first_echo",
+								Type: "tool",
+								Tool: fmt.Sprintf("%s.echo", backendName),
+								Arguments: thvjson.NewMap(map[string]any{
+									"input": "{{ .params.message }}",
+								}),
+							},
+							{
+								ID:        "second_echo",
+								Type:      "tool",
+								Tool:      fmt.Sprintf("%s.echo", backendName),
+								DependsOn: []string{"first_echo"},
+								Arguments: thvjson.NewMap(map[string]any{
+									"input": "{{ .steps.first_echo.result }}",
+								}),
 							},
 						},
 					},
 				},
-				IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-					Type: "anonymous",
-				},
-				ServiceType: "NodePort",
-			},
-		}
+			}),
+			v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+				Type: "anonymous",
+			}),
+			v1beta1test.MutateVMCP(func(v *mcpv1beta1.VirtualMCPServer) {
+				v.Spec.ServiceType = "NodePort"
+			}),
+		)
 		Expect(k8sClient.Create(ctx, vmcpServer)).To(Succeed())
 
 		By("Waiting for VirtualMCPServer to be ready")
@@ -112,12 +109,7 @@ var _ = Describe("VirtualMCPServer Composite Sequential Workflow", Ordered, func
 
 	AfterAll(func() {
 		By("Cleaning up VirtualMCPServer")
-		vmcpServer := &mcpv1beta1.VirtualMCPServer{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      vmcpServerName,
-				Namespace: testNamespace,
-			},
-		}
+		vmcpServer := v1beta1test.NewVirtualMCPServer(vmcpServerName, testNamespace)
 		_ = k8sClient.Delete(ctx, vmcpServer)
 
 		By("Cleaning up backend MCPServer")

--- a/test/e2e/thv-operator/virtualmcp/virtualmcp_composite_validation_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcp_composite_validation_test.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1/v1beta1test"
 	thvjson "github.com/stacklok/toolhive/pkg/json"
 	vmcpconfig "github.com/stacklok/toolhive/pkg/vmcp/config"
 	"github.com/stacklok/toolhive/test/e2e/images"
@@ -101,30 +102,26 @@ var _ = Describe("VirtualMCPServer Composite Tool Template Functions", Ordered, 
 		}, 30*time.Second, pollingInterval).Should(BeTrue(), "VirtualMCPCompositeToolDefinition should exist")
 
 		By("Creating VirtualMCPServer with referenced composite tool")
-		vmcpServer := &mcpv1beta1.VirtualMCPServer{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      vmcpServerName,
-				Namespace: testNamespace,
-			},
-			Spec: mcpv1beta1.VirtualMCPServerSpec{
-				GroupRef: &mcpv1beta1.MCPGroupRef{Name: mcpGroupName},
-				Config: vmcpconfig.Config{
-					Group: mcpGroupName,
-					Aggregation: &vmcpconfig.AggregationConfig{
-						ConflictResolution: "prefix",
-					},
-					CompositeToolRefs: []vmcpconfig.CompositeToolRef{
-						{
-							Name: compositeToolDefName,
-						},
+		vmcpServer := v1beta1test.NewVirtualMCPServer(vmcpServerName, testNamespace,
+			v1beta1test.WithVMCPGroupRef(mcpGroupName),
+			v1beta1test.WithVMCPConfig(vmcpconfig.Config{
+				Group: mcpGroupName,
+				Aggregation: &vmcpconfig.AggregationConfig{
+					ConflictResolution: "prefix",
+				},
+				CompositeToolRefs: []vmcpconfig.CompositeToolRef{
+					{
+						Name: compositeToolDefName,
 					},
 				},
-				IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-					Type: "anonymous",
-				},
-				ServiceType: "NodePort",
-			},
-		}
+			}),
+			v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+				Type: "anonymous",
+			}),
+			v1beta1test.MutateVMCP(func(v *mcpv1beta1.VirtualMCPServer) {
+				v.Spec.ServiceType = "NodePort"
+			}),
+		)
 		Expect(k8sClient.Create(ctx, vmcpServer)).To(Succeed())
 
 		By("Waiting for VirtualMCPServer to be ready")
@@ -138,12 +135,7 @@ var _ = Describe("VirtualMCPServer Composite Tool Template Functions", Ordered, 
 
 	AfterAll(func() {
 		By("Cleaning up VirtualMCPServer")
-		vmcpServer := &mcpv1beta1.VirtualMCPServer{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      vmcpServerName,
-				Namespace: testNamespace,
-			},
-		}
+		vmcpServer := v1beta1test.NewVirtualMCPServer(vmcpServerName, testNamespace)
 		_ = k8sClient.Delete(ctx, vmcpServer)
 
 		By("Cleaning up VirtualMCPCompositeToolDefinition")

--- a/test/e2e/thv-operator/virtualmcp/virtualmcp_conflict_resolution_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcp_conflict_resolution_test.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1/v1beta1test"
 	vmcp "github.com/stacklok/toolhive/pkg/vmcp"
 	vmcpconfig "github.com/stacklok/toolhive/pkg/vmcp/config"
 	"github.com/stacklok/toolhive/test/e2e/images"
@@ -47,23 +48,19 @@ func setupConflictResolutionTest(setup conflictResolutionTestSetup) int32 {
 	}, setup.timeout, setup.pollingInterval)
 
 	By(fmt.Sprintf("Creating VirtualMCPServer: %s with %s conflict resolution", setup.vmcpName, setup.aggregation.ConflictResolution))
-	vmcpServer := &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      setup.vmcpName,
-			Namespace: setup.namespace,
-		},
-		Spec: mcpv1beta1.VirtualMCPServerSpec{
-			GroupRef: &mcpv1beta1.MCPGroupRef{Name: setup.groupName},
-			Config: vmcpconfig.Config{
-				Group:       setup.groupName,
-				Aggregation: setup.aggregation,
-			},
-			IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-				Type: "anonymous",
-			},
-			ServiceType: "NodePort",
-		},
-	}
+	vmcpServer := v1beta1test.NewVirtualMCPServer(setup.vmcpName, setup.namespace,
+		v1beta1test.WithVMCPGroupRef(setup.groupName),
+		v1beta1test.WithVMCPConfig(vmcpconfig.Config{
+			Group:       setup.groupName,
+			Aggregation: setup.aggregation,
+		}),
+		v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+			Type: "anonymous",
+		}),
+		v1beta1test.MutateVMCP(func(v *mcpv1beta1.VirtualMCPServer) {
+			v.Spec.ServiceType = "NodePort"
+		}),
+	)
 	Expect(k8sClient.Create(ctx, vmcpServer)).To(Succeed())
 
 	By("Waiting for VirtualMCPServer to be ready")
@@ -79,12 +76,7 @@ func setupConflictResolutionTest(setup conflictResolutionTestSetup) int32 {
 // cleanupConflictResolutionTest cleans up VirtualMCPServer, backend MCPServers, and MCPGroup
 func cleanupConflictResolutionTest(groupName, vmcpName, backend1Name, backend2Name, namespace string) {
 	By("Cleaning up VirtualMCPServer")
-	vmcpServer := &mcpv1beta1.VirtualMCPServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      vmcpName,
-			Namespace: namespace,
-		},
-	}
+	vmcpServer := v1beta1test.NewVirtualMCPServer(vmcpName, namespace)
 	_ = k8sClient.Delete(ctx, vmcpServer)
 
 	By("Cleaning up backend MCPServers")

--- a/test/e2e/thv-operator/virtualmcp/virtualmcp_discovered_mode_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcp_discovered_mode_test.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1/v1beta1test"
 	vmcpconfig "github.com/stacklok/toolhive/pkg/vmcp/config"
 	"github.com/stacklok/toolhive/test/e2e/images"
 )
@@ -120,26 +121,22 @@ var _ = Describe("VirtualMCPServer Discovered Mode", Ordered, func() {
 		By("Backend MCPServers are running (ClusterIP services)")
 
 		By("Creating VirtualMCPServer in discovered mode")
-		vmcpServer := &mcpv1beta1.VirtualMCPServer{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      vmcpServerName,
-				Namespace: testNamespace,
-			},
-			Spec: mcpv1beta1.VirtualMCPServerSpec{
-				GroupRef: &mcpv1beta1.MCPGroupRef{Name: mcpGroupName},
-				Config: vmcpconfig.Config{
-					Group: mcpGroupName,
-					// Discovered mode is the default - tools from all backends in the group are automatically discovered
-					Aggregation: &vmcpconfig.AggregationConfig{
-						ConflictResolution: "prefix", // Use prefix strategy to avoid conflicts
-					},
+		vmcpServer := v1beta1test.NewVirtualMCPServer(vmcpServerName, testNamespace,
+			v1beta1test.WithVMCPGroupRef(mcpGroupName),
+			v1beta1test.WithVMCPConfig(vmcpconfig.Config{
+				Group: mcpGroupName,
+				// Discovered mode is the default - tools from all backends in the group are automatically discovered
+				Aggregation: &vmcpconfig.AggregationConfig{
+					ConflictResolution: "prefix", // Use prefix strategy to avoid conflicts
 				},
-				IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-					Type: "anonymous",
-				},
-				ServiceType: "NodePort",
-			},
-		}
+			}),
+			v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+				Type: "anonymous",
+			}),
+			v1beta1test.MutateVMCP(func(v *mcpv1beta1.VirtualMCPServer) {
+				v.Spec.ServiceType = "NodePort"
+			}),
+		)
 		Expect(k8sClient.Create(ctx, vmcpServer)).To(Succeed())
 
 		By("Waiting for VirtualMCPServer to be ready")
@@ -159,12 +156,7 @@ var _ = Describe("VirtualMCPServer Discovered Mode", Ordered, func() {
 
 	AfterAll(func() {
 		By("Cleaning up VirtualMCPServer")
-		vmcpServer := &mcpv1beta1.VirtualMCPServer{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      vmcpServerName,
-				Namespace: testNamespace,
-			},
-		}
+		vmcpServer := v1beta1test.NewVirtualMCPServer(vmcpServerName, testNamespace)
 		if err := k8sClient.Delete(ctx, vmcpServer); err != nil {
 			GinkgoWriter.Printf("Warning: failed to delete VirtualMCPServer: %v\n", err)
 		}

--- a/test/e2e/thv-operator/virtualmcp/virtualmcp_excludeall_global_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcp_excludeall_global_test.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1/v1beta1test"
 	vmcpconfig "github.com/stacklok/toolhive/pkg/vmcp/config"
 	"github.com/stacklok/toolhive/test/e2e/images"
 )
@@ -42,27 +43,23 @@ var _ = Describe("VirtualMCPServer Global ExcludeAllTools", Ordered, func() {
 		}, timeout, pollingInterval)
 
 		By("Creating VirtualMCPServer with global excludeAllTools: true")
-		vmcpServer := &mcpv1beta1.VirtualMCPServer{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      vmcpServerName,
-				Namespace: testNamespace,
-			},
-			Spec: mcpv1beta1.VirtualMCPServerSpec{
-				GroupRef: &mcpv1beta1.MCPGroupRef{Name: mcpGroupName},
-				Config: vmcpconfig.Config{
-					Group: mcpGroupName,
-					Aggregation: &vmcpconfig.AggregationConfig{
-						ConflictResolution: "prefix",
-						// Global flag to exclude all tools from all backends
-						ExcludeAllTools: true,
-					},
+		vmcpServer := v1beta1test.NewVirtualMCPServer(vmcpServerName, testNamespace,
+			v1beta1test.WithVMCPGroupRef(mcpGroupName),
+			v1beta1test.WithVMCPConfig(vmcpconfig.Config{
+				Group: mcpGroupName,
+				Aggregation: &vmcpconfig.AggregationConfig{
+					ConflictResolution: "prefix",
+					// Global flag to exclude all tools from all backends
+					ExcludeAllTools: true,
 				},
-				IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-					Type: "anonymous",
-				},
-				ServiceType: "NodePort",
-			},
-		}
+			}),
+			v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+				Type: "anonymous",
+			}),
+			v1beta1test.MutateVMCP(func(v *mcpv1beta1.VirtualMCPServer) {
+				v.Spec.ServiceType = "NodePort"
+			}),
+		)
 		Expect(k8sClient.Create(ctx, vmcpServer)).To(Succeed())
 
 		By("Waiting for VirtualMCPServer to be ready")
@@ -76,12 +73,7 @@ var _ = Describe("VirtualMCPServer Global ExcludeAllTools", Ordered, func() {
 
 	AfterAll(func() {
 		By("Cleaning up VirtualMCPServer")
-		vmcpServer := &mcpv1beta1.VirtualMCPServer{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      vmcpServerName,
-				Namespace: testNamespace,
-			},
-		}
+		vmcpServer := v1beta1test.NewVirtualMCPServer(vmcpServerName, testNamespace)
 		_ = k8sClient.Delete(ctx, vmcpServer)
 
 		By("Cleaning up backend MCPServers")

--- a/test/e2e/thv-operator/virtualmcp/virtualmcp_external_auth_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcp_external_auth_test.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1/v1beta1test"
 	vmcpconfig "github.com/stacklok/toolhive/pkg/vmcp/config"
 	"github.com/stacklok/toolhive/test/e2e/images"
 )
@@ -95,22 +96,18 @@ var _ = Describe("VirtualMCPServer Unauthenticated Backend Auth", Ordered, func(
 		}, timeout, pollingInterval).Should(Succeed())
 
 		By("Creating VirtualMCPServer with discovered auth mode (should use unauthenticated)")
-		vmcpServer := &mcpv1beta1.VirtualMCPServer{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      vmcpServerName,
-				Namespace: testNamespace,
-			},
-			Spec: mcpv1beta1.VirtualMCPServerSpec{
-				GroupRef: &mcpv1beta1.MCPGroupRef{Name: mcpGroupName},
-				IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-					Type: "anonymous",
-				},
-				OutgoingAuth: &mcpv1beta1.OutgoingAuthConfig{
-					Source: "discovered", // Will discover unauthenticated from backend
-				},
-				ServiceType: "NodePort",
-			},
-		}
+		vmcpServer := v1beta1test.NewVirtualMCPServer(vmcpServerName, testNamespace,
+			v1beta1test.WithVMCPGroupRef(mcpGroupName),
+			v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+				Type: "anonymous",
+			}),
+			v1beta1test.WithVMCPOutgoingAuth(&mcpv1beta1.OutgoingAuthConfig{
+				Source: "discovered", // Will discover unauthenticated from backend
+			}),
+			v1beta1test.MutateVMCP(func(v *mcpv1beta1.VirtualMCPServer) {
+				v.Spec.ServiceType = "NodePort"
+			}),
+		)
 		Expect(k8sClient.Create(ctx, vmcpServer)).To(Succeed())
 
 		By("Waiting for VirtualMCPServer to be ready")
@@ -127,9 +124,7 @@ var _ = Describe("VirtualMCPServer Unauthenticated Backend Auth", Ordered, func(
 
 	AfterAll(func() {
 		By("Cleaning up test resources")
-		_ = k8sClient.Delete(ctx, &mcpv1beta1.VirtualMCPServer{
-			ObjectMeta: metav1.ObjectMeta{Name: vmcpServerName, Namespace: testNamespace},
-		})
+		_ = k8sClient.Delete(ctx, v1beta1test.NewVirtualMCPServer(vmcpServerName, testNamespace))
 		_ = k8sClient.Delete(ctx, &mcpv1beta1.MCPServer{
 			ObjectMeta: metav1.ObjectMeta{Name: backendName, Namespace: testNamespace},
 		})
@@ -266,31 +261,27 @@ var _ = Describe("VirtualMCPServer Inline Unauthenticated Backend Auth", Ordered
 		}, timeout, pollingInterval).Should(Succeed())
 
 		By("Creating VirtualMCPServer with inline unauthenticated auth")
-		vmcpServer := &mcpv1beta1.VirtualMCPServer{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      vmcpServerName,
-				Namespace: testNamespace,
-			},
-			Spec: mcpv1beta1.VirtualMCPServerSpec{
-				GroupRef: &mcpv1beta1.MCPGroupRef{Name: mcpGroupName},
-				IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-					Type: "anonymous",
-				},
-				OutgoingAuth: &mcpv1beta1.OutgoingAuthConfig{
-					Source: "inline",
-					// Explicitly configure unauthenticated for specific backend
-					Backends: map[string]mcpv1beta1.BackendAuthConfig{
-						backendName: {
-							Type: "externalAuthConfigRef",
-							ExternalAuthConfigRef: &mcpv1beta1.ExternalAuthConfigRef{
-								Name: externalAuthConfigName,
-							},
+		vmcpServer := v1beta1test.NewVirtualMCPServer(vmcpServerName, testNamespace,
+			v1beta1test.WithVMCPGroupRef(mcpGroupName),
+			v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+				Type: "anonymous",
+			}),
+			v1beta1test.WithVMCPOutgoingAuth(&mcpv1beta1.OutgoingAuthConfig{
+				Source: "inline",
+				// Explicitly configure unauthenticated for specific backend
+				Backends: map[string]mcpv1beta1.BackendAuthConfig{
+					backendName: {
+						Type: "externalAuthConfigRef",
+						ExternalAuthConfigRef: &mcpv1beta1.ExternalAuthConfigRef{
+							Name: externalAuthConfigName,
 						},
 					},
 				},
-				ServiceType: "NodePort",
-			},
-		}
+			}),
+			v1beta1test.MutateVMCP(func(v *mcpv1beta1.VirtualMCPServer) {
+				v.Spec.ServiceType = "NodePort"
+			}),
+		)
 		Expect(k8sClient.Create(ctx, vmcpServer)).To(Succeed())
 
 		By("Waiting for VirtualMCPServer to be ready")
@@ -307,9 +298,7 @@ var _ = Describe("VirtualMCPServer Inline Unauthenticated Backend Auth", Ordered
 
 	AfterAll(func() {
 		By("Cleaning up test resources")
-		_ = k8sClient.Delete(ctx, &mcpv1beta1.VirtualMCPServer{
-			ObjectMeta: metav1.ObjectMeta{Name: vmcpServerName, Namespace: testNamespace},
-		})
+		_ = k8sClient.Delete(ctx, v1beta1test.NewVirtualMCPServer(vmcpServerName, testNamespace))
 		_ = k8sClient.Delete(ctx, &mcpv1beta1.MCPServer{
 			ObjectMeta: metav1.ObjectMeta{Name: backendName, Namespace: testNamespace},
 		})
@@ -446,22 +435,18 @@ var _ = Describe("VirtualMCPServer HeaderInjection Backend Auth", Ordered, func(
 		}, timeout, pollingInterval).Should(Succeed())
 
 		By("Creating VirtualMCPServer with discovered auth mode (should use headerInjection)")
-		vmcpServer := &mcpv1beta1.VirtualMCPServer{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      vmcpServerName,
-				Namespace: testNamespace,
-			},
-			Spec: mcpv1beta1.VirtualMCPServerSpec{
-				GroupRef: &mcpv1beta1.MCPGroupRef{Name: mcpGroupName},
-				IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-					Type: "anonymous",
-				},
-				OutgoingAuth: &mcpv1beta1.OutgoingAuthConfig{
-					Source: "discovered", // Will discover headerInjection from backend
-				},
-				ServiceType: "NodePort",
-			},
-		}
+		vmcpServer := v1beta1test.NewVirtualMCPServer(vmcpServerName, testNamespace,
+			v1beta1test.WithVMCPGroupRef(mcpGroupName),
+			v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+				Type: "anonymous",
+			}),
+			v1beta1test.WithVMCPOutgoingAuth(&mcpv1beta1.OutgoingAuthConfig{
+				Source: "discovered", // Will discover headerInjection from backend
+			}),
+			v1beta1test.MutateVMCP(func(v *mcpv1beta1.VirtualMCPServer) {
+				v.Spec.ServiceType = "NodePort"
+			}),
+		)
 		Expect(k8sClient.Create(ctx, vmcpServer)).To(Succeed())
 
 		By("Waiting for VirtualMCPServer to be ready")
@@ -478,9 +463,7 @@ var _ = Describe("VirtualMCPServer HeaderInjection Backend Auth", Ordered, func(
 
 	AfterAll(func() {
 		By("Cleaning up test resources")
-		_ = k8sClient.Delete(ctx, &mcpv1beta1.VirtualMCPServer{
-			ObjectMeta: metav1.ObjectMeta{Name: vmcpServerName, Namespace: testNamespace},
-		})
+		_ = k8sClient.Delete(ctx, v1beta1test.NewVirtualMCPServer(vmcpServerName, testNamespace))
 		_ = k8sClient.Delete(ctx, &mcpv1beta1.MCPServer{
 			ObjectMeta: metav1.ObjectMeta{Name: backendName, Namespace: testNamespace},
 		})
@@ -665,31 +648,27 @@ var _ = Describe("VirtualMCPServer Inline HeaderInjection Backend Auth", Ordered
 		}, timeout, pollingInterval).Should(Succeed())
 
 		By("Creating VirtualMCPServer with inline headerInjection auth")
-		vmcpServer := &mcpv1beta1.VirtualMCPServer{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      vmcpServerName,
-				Namespace: testNamespace,
-			},
-			Spec: mcpv1beta1.VirtualMCPServerSpec{
-				GroupRef: &mcpv1beta1.MCPGroupRef{Name: mcpGroupName},
-				IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-					Type: "anonymous",
-				},
-				OutgoingAuth: &mcpv1beta1.OutgoingAuthConfig{
-					Source: "inline",
-					// Explicitly configure headerInjection for specific backend
-					Backends: map[string]mcpv1beta1.BackendAuthConfig{
-						backendName: {
-							Type: "externalAuthConfigRef",
-							ExternalAuthConfigRef: &mcpv1beta1.ExternalAuthConfigRef{
-								Name: externalAuthConfigName,
-							},
+		vmcpServer := v1beta1test.NewVirtualMCPServer(vmcpServerName, testNamespace,
+			v1beta1test.WithVMCPGroupRef(mcpGroupName),
+			v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+				Type: "anonymous",
+			}),
+			v1beta1test.WithVMCPOutgoingAuth(&mcpv1beta1.OutgoingAuthConfig{
+				Source: "inline",
+				// Explicitly configure headerInjection for specific backend
+				Backends: map[string]mcpv1beta1.BackendAuthConfig{
+					backendName: {
+						Type: "externalAuthConfigRef",
+						ExternalAuthConfigRef: &mcpv1beta1.ExternalAuthConfigRef{
+							Name: externalAuthConfigName,
 						},
 					},
 				},
-				ServiceType: "NodePort",
-			},
-		}
+			}),
+			v1beta1test.MutateVMCP(func(v *mcpv1beta1.VirtualMCPServer) {
+				v.Spec.ServiceType = "NodePort"
+			}),
+		)
 		Expect(k8sClient.Create(ctx, vmcpServer)).To(Succeed())
 
 		By("Waiting for VirtualMCPServer to be ready")
@@ -706,9 +685,7 @@ var _ = Describe("VirtualMCPServer Inline HeaderInjection Backend Auth", Ordered
 
 	AfterAll(func() {
 		By("Cleaning up test resources")
-		_ = k8sClient.Delete(ctx, &mcpv1beta1.VirtualMCPServer{
-			ObjectMeta: metav1.ObjectMeta{Name: vmcpServerName, Namespace: testNamespace},
-		})
+		_ = k8sClient.Delete(ctx, v1beta1test.NewVirtualMCPServer(vmcpServerName, testNamespace))
 		_ = k8sClient.Delete(ctx, &mcpv1beta1.MCPServer{
 			ObjectMeta: metav1.ObjectMeta{Name: backendName, Namespace: testNamespace},
 		})
@@ -861,33 +838,29 @@ var _ = Describe("VirtualMCPServer Health Check with HeaderInjection Auth", Orde
 		}, timeout, pollingInterval).Should(Succeed())
 
 		By("Creating VirtualMCPServer with discovered auth and health monitoring enabled")
-		vmcpServer := &mcpv1beta1.VirtualMCPServer{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      vmcpServerName,
-				Namespace: testNamespace,
-			},
-			Spec: mcpv1beta1.VirtualMCPServerSpec{
-				GroupRef: &mcpv1beta1.MCPGroupRef{Name: mcpGroupName},
-				Config: vmcpconfig.Config{
-					Group: mcpGroupName,
-					Operational: &vmcpconfig.OperationalConfig{
-						FailureHandling: &vmcpconfig.FailureHandlingConfig{
-							// Short interval so several health checks run within the test timeout.
-							HealthCheckInterval: vmcpconfig.Duration(healthCheckAuthInterval),
-							HealthCheckTimeout:  vmcpconfig.Duration(2 * time.Second),
-							UnhealthyThreshold:  3,
-						},
+		vmcpServer := v1beta1test.NewVirtualMCPServer(vmcpServerName, testNamespace,
+			v1beta1test.WithVMCPGroupRef(mcpGroupName),
+			v1beta1test.WithVMCPConfig(vmcpconfig.Config{
+				Group: mcpGroupName,
+				Operational: &vmcpconfig.OperationalConfig{
+					FailureHandling: &vmcpconfig.FailureHandlingConfig{
+						// Short interval so several health checks run within the test timeout.
+						HealthCheckInterval: vmcpconfig.Duration(healthCheckAuthInterval),
+						HealthCheckTimeout:  vmcpconfig.Duration(2 * time.Second),
+						UnhealthyThreshold:  3,
 					},
 				},
-				IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-					Type: "anonymous",
-				},
-				OutgoingAuth: &mcpv1beta1.OutgoingAuthConfig{
-					Source: "discovered",
-				},
-				ServiceType: "NodePort",
-			},
-		}
+			}),
+			v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+				Type: "anonymous",
+			}),
+			v1beta1test.WithVMCPOutgoingAuth(&mcpv1beta1.OutgoingAuthConfig{
+				Source: "discovered",
+			}),
+			v1beta1test.MutateVMCP(func(v *mcpv1beta1.VirtualMCPServer) {
+				v.Spec.ServiceType = "NodePort"
+			}),
+		)
 		Expect(k8sClient.Create(ctx, vmcpServer)).To(Succeed())
 
 		By("Waiting for VirtualMCPServer to be ready")
@@ -902,9 +875,7 @@ var _ = Describe("VirtualMCPServer Health Check with HeaderInjection Auth", Orde
 
 	AfterAll(func() {
 		By("Cleaning up test resources")
-		_ = k8sClient.Delete(ctx, &mcpv1beta1.VirtualMCPServer{
-			ObjectMeta: metav1.ObjectMeta{Name: vmcpServerName, Namespace: testNamespace},
-		})
+		_ = k8sClient.Delete(ctx, v1beta1test.NewVirtualMCPServer(vmcpServerName, testNamespace))
 		_ = k8sClient.Delete(ctx, &mcpv1beta1.MCPServer{
 			ObjectMeta: metav1.ObjectMeta{Name: backendName, Namespace: testNamespace},
 		})
@@ -1078,32 +1049,28 @@ var _ = Describe("VirtualMCPServer Health Check with TokenExchange Auth", Ordere
 		}, timeout, pollingInterval).Should(Succeed())
 
 		By("Creating VirtualMCPServer with discovered auth and health monitoring enabled")
-		vmcpServer := &mcpv1beta1.VirtualMCPServer{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      vmcpServerName,
-				Namespace: testNamespace,
-			},
-			Spec: mcpv1beta1.VirtualMCPServerSpec{
-				GroupRef: &mcpv1beta1.MCPGroupRef{Name: mcpGroupName},
-				Config: vmcpconfig.Config{
-					Group: mcpGroupName,
-					Operational: &vmcpconfig.OperationalConfig{
-						FailureHandling: &vmcpconfig.FailureHandlingConfig{
-							HealthCheckInterval: vmcpconfig.Duration(healthCheckAuthInterval),
-							HealthCheckTimeout:  vmcpconfig.Duration(2 * time.Second),
-							UnhealthyThreshold:  3,
-						},
+		vmcpServer := v1beta1test.NewVirtualMCPServer(vmcpServerName, testNamespace,
+			v1beta1test.WithVMCPGroupRef(mcpGroupName),
+			v1beta1test.WithVMCPConfig(vmcpconfig.Config{
+				Group: mcpGroupName,
+				Operational: &vmcpconfig.OperationalConfig{
+					FailureHandling: &vmcpconfig.FailureHandlingConfig{
+						HealthCheckInterval: vmcpconfig.Duration(healthCheckAuthInterval),
+						HealthCheckTimeout:  vmcpconfig.Duration(2 * time.Second),
+						UnhealthyThreshold:  3,
 					},
 				},
-				IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-					Type: "anonymous",
-				},
-				OutgoingAuth: &mcpv1beta1.OutgoingAuthConfig{
-					Source: "discovered",
-				},
-				ServiceType: "NodePort",
-			},
-		}
+			}),
+			v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+				Type: "anonymous",
+			}),
+			v1beta1test.WithVMCPOutgoingAuth(&mcpv1beta1.OutgoingAuthConfig{
+				Source: "discovered",
+			}),
+			v1beta1test.MutateVMCP(func(v *mcpv1beta1.VirtualMCPServer) {
+				v.Spec.ServiceType = "NodePort"
+			}),
+		)
 		Expect(k8sClient.Create(ctx, vmcpServer)).To(Succeed())
 
 		By("Waiting for VirtualMCPServer to be ready")
@@ -1115,9 +1082,7 @@ var _ = Describe("VirtualMCPServer Health Check with TokenExchange Auth", Ordere
 
 	AfterAll(func() {
 		By("Cleaning up test resources")
-		_ = k8sClient.Delete(ctx, &mcpv1beta1.VirtualMCPServer{
-			ObjectMeta: metav1.ObjectMeta{Name: vmcpServerName, Namespace: testNamespace},
-		})
+		_ = k8sClient.Delete(ctx, v1beta1test.NewVirtualMCPServer(vmcpServerName, testNamespace))
 		_ = k8sClient.Delete(ctx, &mcpv1beta1.MCPServer{
 			ObjectMeta: metav1.ObjectMeta{Name: backendName, Namespace: testNamespace},
 		})

--- a/test/e2e/thv-operator/virtualmcp/virtualmcp_optimizer_circuit_breaker_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcp_optimizer_circuit_breaker_test.go
@@ -12,7 +12,6 @@ import (
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -56,44 +55,38 @@ var _ = Describe("VirtualMCPServer Optimizer with Circuit Breaker", Ordered, fun
 		Expect(k8sClient.Create(ctx, embeddingServer)).To(Succeed())
 
 		By("Creating VirtualMCPServer with optimizer and circuit breaker enabled")
-		vmcpServer := &mcpv1beta1.VirtualMCPServer{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      vmcpServerName,
-				Namespace: testNamespace,
-			},
-			Spec: mcpv1beta1.VirtualMCPServerSpec{
-				GroupRef:    &mcpv1beta1.MCPGroupRef{Name: mcpGroupName},
-				ServiceType: "NodePort",
-				IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-					Type: "anonymous",
+		vmcpServer := v1beta1test.NewVirtualMCPServer(vmcpServerName, testNamespace,
+			v1beta1test.WithVMCPGroupRef(mcpGroupName),
+			v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+				Type: "anonymous",
+			}),
+			v1beta1test.WithVMCPOutgoingAuth(&mcpv1beta1.OutgoingAuthConfig{
+				Source: "discovered",
+			}),
+			v1beta1test.WithVMCPEmbeddingServerRef(embeddingName),
+			v1beta1test.WithVMCPConfig(vmcpconfig.Config{
+				Group:     mcpGroupName,
+				Optimizer: &vmcpconfig.OptimizerConfig{},
+				Aggregation: &vmcpconfig.AggregationConfig{
+					ConflictResolution: "prefix",
 				},
-				OutgoingAuth: &mcpv1beta1.OutgoingAuthConfig{
-					Source: "discovered",
-				},
-				EmbeddingServerRef: &mcpv1beta1.EmbeddingServerRef{
-					Name: embeddingName,
-				},
-				Config: vmcpconfig.Config{
-					Group:     mcpGroupName,
-					Optimizer: &vmcpconfig.OptimizerConfig{},
-					Aggregation: &vmcpconfig.AggregationConfig{
-						ConflictResolution: "prefix",
-					},
-					Operational: &vmcpconfig.OperationalConfig{
-						FailureHandling: &vmcpconfig.FailureHandlingConfig{
-							HealthCheckInterval: vmcpconfig.Duration(cbHealthCheckInterval),
-							HealthCheckTimeout:  vmcpconfig.Duration(cbHealthCheckTimeout),
-							UnhealthyThreshold:  cbUnhealthyThreshold,
-							CircuitBreaker: &vmcpconfig.CircuitBreakerConfig{
-								Enabled:          true,
-								FailureThreshold: cbFailureThreshold,
-								Timeout:          vmcpconfig.Duration(cbTimeout),
-							},
+				Operational: &vmcpconfig.OperationalConfig{
+					FailureHandling: &vmcpconfig.FailureHandlingConfig{
+						HealthCheckInterval: vmcpconfig.Duration(cbHealthCheckInterval),
+						HealthCheckTimeout:  vmcpconfig.Duration(cbHealthCheckTimeout),
+						UnhealthyThreshold:  cbUnhealthyThreshold,
+						CircuitBreaker: &vmcpconfig.CircuitBreakerConfig{
+							Enabled:          true,
+							FailureThreshold: cbFailureThreshold,
+							Timeout:          vmcpconfig.Duration(cbTimeout),
 						},
 					},
 				},
-			},
-		}
+			}),
+			v1beta1test.MutateVMCP(func(v *mcpv1beta1.VirtualMCPServer) {
+				v.Spec.ServiceType = "NodePort"
+			}),
+		)
 		Expect(k8sClient.Create(ctx, vmcpServer)).To(Succeed())
 
 		By("Waiting for VirtualMCPServer to be ready")

--- a/test/e2e/thv-operator/virtualmcp/virtualmcp_optimizer_composite_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcp_optimizer_composite_test.go
@@ -11,10 +11,10 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1/v1beta1test"
 	thvjson "github.com/stacklok/toolhive/pkg/json"
 	vmcpconfig "github.com/stacklok/toolhive/pkg/vmcp/config"
 	"github.com/stacklok/toolhive/test/e2e/images"
@@ -78,75 +78,71 @@ var _ = Describe("VirtualMCPServer Optimizer Composite Tools", Ordered, func() {
 		// original backend capability name via the dot convention.
 		fetchStepTool := backendName + "." + backendFetchToolName // "backend-opt-composite.fetch"
 
-		vmcpServer := &mcpv1beta1.VirtualMCPServer{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      vmcpServerName,
-				Namespace: testNamespace,
-			},
-			Spec: mcpv1beta1.VirtualMCPServerSpec{
-				GroupRef:    &mcpv1beta1.MCPGroupRef{Name: mcpGroupName},
-				ServiceType: "NodePort",
-				IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-					Type: "anonymous",
+		vmcpServer := v1beta1test.NewVirtualMCPServer(vmcpServerName, testNamespace,
+			v1beta1test.WithVMCPGroupRef(mcpGroupName),
+			v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+				Type: "anonymous",
+			}),
+			v1beta1test.WithVMCPOutgoingAuth(&mcpv1beta1.OutgoingAuthConfig{
+				Source: "discovered",
+			}),
+			// Use embeddingService directly instead of EmbeddingServerRef
+			// to avoid depending on the heavyweight TEI image.
+			v1beta1test.WithVMCPConfig(vmcpconfig.Config{
+				Group: mcpGroupName,
+				Optimizer: &vmcpconfig.OptimizerConfig{
+					EmbeddingService: embeddingURL,
 				},
-				OutgoingAuth: &mcpv1beta1.OutgoingAuthConfig{
-					Source: "discovered",
-				},
-				// Use embeddingService directly instead of EmbeddingServerRef
-				// to avoid depending on the heavyweight TEI image.
-				Config: vmcpconfig.Config{
-					Group: mcpGroupName,
-					Optimizer: &vmcpconfig.OptimizerConfig{
-						EmbeddingService: embeddingURL,
-					},
-					CompositeTools: []vmcpconfig.CompositeToolConfig{
-						{
-							Name:        compositeToolName,
-							Description: "Fetches a URL twice in sequence for verification",
-							Parameters: thvjson.NewMap(map[string]interface{}{
-								"type": "object",
-								"properties": map[string]interface{}{
-									"url": map[string]interface{}{
-										"type":        "string",
-										"description": "URL to fetch twice",
-									},
-								},
-								"required": []string{"url"},
-							}),
-							Steps: []vmcpconfig.WorkflowStepConfig{
-								{
-									ID:        "first_fetch",
-									Type:      "tool",
-									Tool:      fetchStepTool,
-									Arguments: thvjson.NewMap(stepArgs),
-								},
-								{
-									ID:        "second_fetch",
-									Type:      "tool",
-									Tool:      fetchStepTool,
-									DependsOn: []string{"first_fetch"},
-									Arguments: thvjson.NewMap(stepArgs),
+				CompositeTools: []vmcpconfig.CompositeToolConfig{
+					{
+						Name:        compositeToolName,
+						Description: "Fetches a URL twice in sequence for verification",
+						Parameters: thvjson.NewMap(map[string]interface{}{
+							"type": "object",
+							"properties": map[string]interface{}{
+								"url": map[string]interface{}{
+									"type":        "string",
+									"description": "URL to fetch twice",
 								},
 							},
-						},
-					},
-					Aggregation: &vmcpconfig.AggregationConfig{
-						ConflictResolution: "prefix",
-						Tools: []*vmcpconfig.WorkloadToolConfig{
+							"required": []string{"url"},
+						}),
+						Steps: []vmcpconfig.WorkflowStepConfig{
 							{
-								Workload: backendName,
-								Overrides: map[string]*vmcpconfig.ToolOverride{
-									backendFetchToolName: {
-										Name:        vmcpFetchToolName,
-										Description: vmcpFetchToolDescription,
-									},
+								ID:        "first_fetch",
+								Type:      "tool",
+								Tool:      fetchStepTool,
+								Arguments: thvjson.NewMap(stepArgs),
+							},
+							{
+								ID:        "second_fetch",
+								Type:      "tool",
+								Tool:      fetchStepTool,
+								DependsOn: []string{"first_fetch"},
+								Arguments: thvjson.NewMap(stepArgs),
+							},
+						},
+					},
+				},
+				Aggregation: &vmcpconfig.AggregationConfig{
+					ConflictResolution: "prefix",
+					Tools: []*vmcpconfig.WorkloadToolConfig{
+						{
+							Workload: backendName,
+							Overrides: map[string]*vmcpconfig.ToolOverride{
+								backendFetchToolName: {
+									Name:        vmcpFetchToolName,
+									Description: vmcpFetchToolDescription,
 								},
 							},
 						},
 					},
 				},
-			},
-		}
+			}),
+			v1beta1test.MutateVMCP(func(v *mcpv1beta1.VirtualMCPServer) {
+				v.Spec.ServiceType = "NodePort"
+			}),
+		)
 		Expect(k8sClient.Create(ctx, vmcpServer)).To(Succeed())
 
 		By("Waiting for VirtualMCPServer to be ready")

--- a/test/e2e/thv-operator/virtualmcp/virtualmcp_optimizer_multibackend_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcp_optimizer_multibackend_test.go
@@ -172,35 +172,29 @@ var _ = Describe("VirtualMCPServer Optimizer Multi-Backend", Ordered, func() {
 		Expect(k8sClient.Create(ctx, embeddingServer)).To(Succeed())
 
 		By("Creating VirtualMCPServer with optimizer enabled and prefix aggregation")
-		vmcpServer := &mcpv1beta1.VirtualMCPServer{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      vmcpServerName,
-				Namespace: testNamespace,
-			},
-			Spec: mcpv1beta1.VirtualMCPServerSpec{
-				GroupRef:    &mcpv1beta1.MCPGroupRef{Name: mcpGroupName},
-				ServiceType: "NodePort",
-				IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-					Type: "anonymous",
-				},
-				OutgoingAuth: &mcpv1beta1.OutgoingAuthConfig{
-					Source: "discovered",
-				},
-				EmbeddingServerRef: &mcpv1beta1.EmbeddingServerRef{
-					Name: embeddingName,
-				},
-				Config: vmcpconfig.Config{
-					Group:     mcpGroupName,
-					Optimizer: &vmcpconfig.OptimizerConfig{},
-					Aggregation: &vmcpconfig.AggregationConfig{
-						ConflictResolution: vmcp.ConflictStrategyPrefix,
-						ConflictResolutionConfig: &vmcpconfig.ConflictResolutionConfig{
-							PrefixFormat: "{workload}_",
-						},
+		vmcpServer := v1beta1test.NewVirtualMCPServer(vmcpServerName, testNamespace,
+			v1beta1test.WithVMCPGroupRef(mcpGroupName),
+			v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+				Type: "anonymous",
+			}),
+			v1beta1test.WithVMCPOutgoingAuth(&mcpv1beta1.OutgoingAuthConfig{
+				Source: "discovered",
+			}),
+			v1beta1test.WithVMCPEmbeddingServerRef(embeddingName),
+			v1beta1test.WithVMCPConfig(vmcpconfig.Config{
+				Group:     mcpGroupName,
+				Optimizer: &vmcpconfig.OptimizerConfig{},
+				Aggregation: &vmcpconfig.AggregationConfig{
+					ConflictResolution: vmcp.ConflictStrategyPrefix,
+					ConflictResolutionConfig: &vmcpconfig.ConflictResolutionConfig{
+						PrefixFormat: "{workload}_",
 					},
 				},
-			},
-		}
+			}),
+			v1beta1test.MutateVMCP(func(v *mcpv1beta1.VirtualMCPServer) {
+				v.Spec.ServiceType = "NodePort"
+			}),
+		)
 		Expect(k8sClient.Create(ctx, vmcpServer)).To(Succeed())
 
 		By("Waiting for VirtualMCPServer to be ready")

--- a/test/e2e/thv-operator/virtualmcp/virtualmcp_optimizer_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcp_optimizer_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
@@ -71,78 +70,71 @@ var _ = Describe("VirtualMCPServer Optimizer Mode", Ordered, func() {
 		// vmcpFetchToolName for clients, but steps must reference the original.
 		fetchStepTool := backendName + "." + backendFetchToolName // "backend-optimizer-fetch.fetch"
 
-		vmcpServer := &mcpv1beta1.VirtualMCPServer{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      vmcpServerName,
-				Namespace: testNamespace,
-			},
-			Spec: mcpv1beta1.VirtualMCPServerSpec{
-				GroupRef:    &mcpv1beta1.MCPGroupRef{Name: mcpGroupName},
-				ServiceType: "NodePort",
-				IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-					Type: "anonymous",
-				},
-				OutgoingAuth: &mcpv1beta1.OutgoingAuthConfig{
-					Source: "discovered",
-				},
-				// Reference to the standalone EmbeddingServer created above.
-				// The controller auto-populates optimizer.embeddingService from EmbeddingServer status.
-				EmbeddingServerRef: &mcpv1beta1.EmbeddingServerRef{
-					Name: embeddingName,
-				},
-
-				Config: vmcpconfig.Config{
-					Group:     mcpGroupName,
-					Optimizer: &vmcpconfig.OptimizerConfig{},
-					// Define a composite tool that calls fetch twice
-					CompositeTools: []vmcpconfig.CompositeToolConfig{
-						{
-							Name:        compositeToolName,
-							Description: "Fetches a URL twice in sequence for verification",
-							Parameters: thvjson.NewMap(map[string]interface{}{
-								"type": "object",
-								"properties": map[string]interface{}{
-									"url": map[string]interface{}{
-										"type":        "string",
-										"description": "URL to fetch twice",
-									},
-								},
-								"required": []string{"url"},
-							}),
-							Steps: []vmcpconfig.WorkflowStepConfig{
-								{
-									ID:        "first_fetch",
-									Type:      "tool",
-									Tool:      fetchStepTool,
-									Arguments: thvjson.NewMap(stepArgs),
-								},
-								{
-									ID:        "second_fetch",
-									Type:      "tool",
-									Tool:      fetchStepTool,
-									DependsOn: []string{"first_fetch"},
-									Arguments: thvjson.NewMap(stepArgs),
+		vmcpServer := v1beta1test.NewVirtualMCPServer(vmcpServerName, testNamespace,
+			v1beta1test.WithVMCPGroupRef(mcpGroupName),
+			v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+				Type: "anonymous",
+			}),
+			v1beta1test.WithVMCPOutgoingAuth(&mcpv1beta1.OutgoingAuthConfig{
+				Source: "discovered",
+			}),
+			// Reference to the standalone EmbeddingServer created above.
+			// The controller auto-populates optimizer.embeddingService from EmbeddingServer status.
+			v1beta1test.WithVMCPEmbeddingServerRef(embeddingName),
+			v1beta1test.WithVMCPConfig(vmcpconfig.Config{
+				Group:     mcpGroupName,
+				Optimizer: &vmcpconfig.OptimizerConfig{},
+				// Define a composite tool that calls fetch twice
+				CompositeTools: []vmcpconfig.CompositeToolConfig{
+					{
+						Name:        compositeToolName,
+						Description: "Fetches a URL twice in sequence for verification",
+						Parameters: thvjson.NewMap(map[string]interface{}{
+							"type": "object",
+							"properties": map[string]interface{}{
+								"url": map[string]interface{}{
+									"type":        "string",
+									"description": "URL to fetch twice",
 								},
 							},
-						},
-					},
-					Aggregation: &vmcpconfig.AggregationConfig{
-						ConflictResolution: "prefix",
-						Tools: []*vmcpconfig.WorkloadToolConfig{
+							"required": []string{"url"},
+						}),
+						Steps: []vmcpconfig.WorkflowStepConfig{
 							{
-								Workload: backendName,
-								Overrides: map[string]*vmcpconfig.ToolOverride{
-									backendFetchToolName: {
-										Name:        vmcpFetchToolName,
-										Description: vmcpFetchToolDescription,
-									},
+								ID:        "first_fetch",
+								Type:      "tool",
+								Tool:      fetchStepTool,
+								Arguments: thvjson.NewMap(stepArgs),
+							},
+							{
+								ID:        "second_fetch",
+								Type:      "tool",
+								Tool:      fetchStepTool,
+								DependsOn: []string{"first_fetch"},
+								Arguments: thvjson.NewMap(stepArgs),
+							},
+						},
+					},
+				},
+				Aggregation: &vmcpconfig.AggregationConfig{
+					ConflictResolution: "prefix",
+					Tools: []*vmcpconfig.WorkloadToolConfig{
+						{
+							Workload: backendName,
+							Overrides: map[string]*vmcpconfig.ToolOverride{
+								backendFetchToolName: {
+									Name:        vmcpFetchToolName,
+									Description: vmcpFetchToolDescription,
 								},
 							},
 						},
 					},
 				},
-			},
-		}
+			}),
+			v1beta1test.MutateVMCP(func(v *mcpv1beta1.VirtualMCPServer) {
+				v.Spec.ServiceType = "NodePort"
+			}),
+		)
 		Expect(k8sClient.Create(ctx, vmcpServer)).To(Succeed())
 
 		By("Waiting for VirtualMCPServer to be ready")

--- a/test/e2e/thv-operator/virtualmcp/virtualmcp_rate_limiting_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcp_rate_limiting_test.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1/v1beta1test"
 	vmcpconfig "github.com/stacklok/toolhive/pkg/vmcp/config"
 	"github.com/stacklok/toolhive/test/e2e/images"
 )
@@ -112,32 +113,29 @@ var _ = ginkgo.Describe("VirtualMCPServer Rate Limiting", ginkgo.Ordered, func()
 
 		redisAddr := fmt.Sprintf("%s.%s.svc.cluster.local:6379", redisName, defaultNamespace)
 		ginkgo.By("Creating VirtualMCPServer with per-user rate limiting")
-		gomega.Expect(k8sClient.Create(ctx, &mcpv1beta1.VirtualMCPServer{
-			ObjectMeta: metav1.ObjectMeta{Name: vmcpName, Namespace: defaultNamespace},
-			Spec: mcpv1beta1.VirtualMCPServerSpec{
-				GroupRef: &mcpv1beta1.MCPGroupRef{Name: mcpGroupName},
-				Config: vmcpconfig.Config{
-					Group: mcpGroupName,
-					RateLimiting: &mcpv1beta1.RateLimitConfig{
-						PerUser: &mcpv1beta1.RateLimitBucket{
-							MaxTokens:    1,
-							RefillPeriod: metav1.Duration{Duration: time.Minute},
-						},
+		gomega.Expect(k8sClient.Create(ctx, v1beta1test.NewVirtualMCPServer(vmcpName, defaultNamespace,
+			v1beta1test.WithVMCPGroupRef(mcpGroupName),
+			v1beta1test.WithVMCPConfig(vmcpconfig.Config{
+				Group: mcpGroupName,
+				RateLimiting: &mcpv1beta1.RateLimitConfig{
+					PerUser: &mcpv1beta1.RateLimitBucket{
+						MaxTokens:    1,
+						RefillPeriod: metav1.Duration{Duration: time.Minute},
 					},
 				},
-				IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-					Type: "oidc",
-					OIDCConfigRef: &mcpv1beta1.MCPOIDCConfigReference{
-						Name:     oidcName,
-						Audience: oidcAudience,
-					},
+			}),
+			v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+				Type: "oidc",
+				OIDCConfigRef: &mcpv1beta1.MCPOIDCConfigReference{
+					Name:     oidcName,
+					Audience: oidcAudience,
 				},
-				SessionStorage: &mcpv1beta1.SessionStorageConfig{
-					Provider: mcpv1beta1.SessionStorageProviderRedis,
-					Address:  redisAddr,
-				},
-			},
-		})).To(gomega.Succeed())
+			}),
+			v1beta1test.WithVMCPSessionStorage(&mcpv1beta1.SessionStorageConfig{
+				Provider: mcpv1beta1.SessionStorageProviderRedis,
+				Address:  redisAddr,
+			}),
+		))).To(gomega.Succeed())
 
 		ginkgo.By("Waiting for VirtualMCPServer to be ready")
 		WaitForVirtualMCPServerReady(ctx, k8sClient, vmcpName, defaultNamespace, timeout, pollInterval)
@@ -157,9 +155,7 @@ var _ = ginkgo.Describe("VirtualMCPServer Rate Limiting", ginkgo.Ordered, func()
 		if oidcCleanup != nil {
 			oidcCleanup()
 		}
-		_ = k8sClient.Delete(ctx, &mcpv1beta1.VirtualMCPServer{
-			ObjectMeta: metav1.ObjectMeta{Name: vmcpName, Namespace: defaultNamespace},
-		})
+		_ = k8sClient.Delete(ctx, v1beta1test.NewVirtualMCPServer(vmcpName, defaultNamespace))
 		_ = k8sClient.Delete(ctx, &mcpv1beta1.MCPServer{
 			ObjectMeta: metav1.ObjectMeta{Name: backendName, Namespace: defaultNamespace},
 		})

--- a/test/e2e/thv-operator/virtualmcp/virtualmcp_redis_session_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcp_redis_session_test.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1/v1beta1test"
 	"github.com/stacklok/toolhive/test/e2e/images"
 )
 
@@ -88,20 +89,19 @@ var _ = ginkgo.Describe("VirtualMCPServer Redis-Backed Session Sharing", func() 
 			redisAddr := fmt.Sprintf("%s.%s.svc.cluster.local:6379", redisName, defaultNamespace)
 
 			ginkgo.By("Creating VirtualMCPServer with replicas=2 and Redis")
-			gomega.Expect(k8sClient.Create(ctx, &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{Name: vmcpName, Namespace: defaultNamespace},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef:        &mcpv1beta1.MCPGroupRef{Name: mcpGroupName},
-					IncomingAuth:    &mcpv1beta1.IncomingAuthConfig{Type: "anonymous"},
-					Replicas:        &replicas,
-					SessionAffinity: "None",
-					SessionStorage: &mcpv1beta1.SessionStorageConfig{
-						Provider:  mcpv1beta1.SessionStorageProviderRedis,
-						Address:   redisAddr,
-						KeyPrefix: "thv:vmcp:e2e:",
-					},
-				},
-			})).To(gomega.Succeed())
+			gomega.Expect(k8sClient.Create(ctx, v1beta1test.NewVirtualMCPServer(vmcpName, defaultNamespace,
+				v1beta1test.WithVMCPGroupRef(mcpGroupName),
+				v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{Type: "anonymous"}),
+				v1beta1test.WithVMCPReplicas(replicas),
+				v1beta1test.WithVMCPSessionStorage(&mcpv1beta1.SessionStorageConfig{
+					Provider:  mcpv1beta1.SessionStorageProviderRedis,
+					Address:   redisAddr,
+					KeyPrefix: "thv:vmcp:e2e:",
+				}),
+				v1beta1test.MutateVMCP(func(v *mcpv1beta1.VirtualMCPServer) {
+					v.Spec.SessionAffinity = "None"
+				}),
+			))).To(gomega.Succeed())
 
 			ginkgo.By("Waiting for 2 ready pods")
 			gomega.Eventually(func() (int, error) {
@@ -113,9 +113,7 @@ var _ = ginkgo.Describe("VirtualMCPServer Redis-Backed Session Sharing", func() 
 		})
 
 		ginkgo.AfterAll(func() {
-			_ = k8sClient.Delete(ctx, &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{Name: vmcpName, Namespace: defaultNamespace},
-			})
+			_ = k8sClient.Delete(ctx, v1beta1test.NewVirtualMCPServer(vmcpName, defaultNamespace))
 			_ = k8sClient.Delete(ctx, &mcpv1beta1.MCPServer{
 				ObjectMeta: metav1.ObjectMeta{Name: backendName, Namespace: defaultNamespace},
 			})
@@ -199,20 +197,19 @@ var _ = ginkgo.Describe("VirtualMCPServer Redis-Backed Session Sharing", func() 
 			redisAddr := fmt.Sprintf("%s.%s.svc.cluster.local:6379", redisName, defaultNamespace)
 
 			ginkgo.By("Creating VirtualMCPServer with replicas=2 and Redis")
-			gomega.Expect(k8sClient.Create(ctx, &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{Name: vmcpName, Namespace: defaultNamespace},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef:        &mcpv1beta1.MCPGroupRef{Name: mcpGroupName},
-					IncomingAuth:    &mcpv1beta1.IncomingAuthConfig{Type: "anonymous"},
-					Replicas:        &replicas,
-					SessionAffinity: "None",
-					SessionStorage: &mcpv1beta1.SessionStorageConfig{
-						Provider:  mcpv1beta1.SessionStorageProviderRedis,
-						Address:   redisAddr,
-						KeyPrefix: "thv:vmcp:e2e:",
-					},
-				},
-			})).To(gomega.Succeed())
+			gomega.Expect(k8sClient.Create(ctx, v1beta1test.NewVirtualMCPServer(vmcpName, defaultNamespace,
+				v1beta1test.WithVMCPGroupRef(mcpGroupName),
+				v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{Type: "anonymous"}),
+				v1beta1test.WithVMCPReplicas(replicas),
+				v1beta1test.WithVMCPSessionStorage(&mcpv1beta1.SessionStorageConfig{
+					Provider:  mcpv1beta1.SessionStorageProviderRedis,
+					Address:   redisAddr,
+					KeyPrefix: "thv:vmcp:e2e:",
+				}),
+				v1beta1test.MutateVMCP(func(v *mcpv1beta1.VirtualMCPServer) {
+					v.Spec.SessionAffinity = "None"
+				}),
+			))).To(gomega.Succeed())
 
 			ginkgo.By("Waiting for 2 ready pods")
 			gomega.Eventually(func() (int, error) {
@@ -224,9 +221,7 @@ var _ = ginkgo.Describe("VirtualMCPServer Redis-Backed Session Sharing", func() 
 		})
 
 		ginkgo.AfterAll(func() {
-			_ = k8sClient.Delete(ctx, &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{Name: vmcpName, Namespace: defaultNamespace},
-			})
+			_ = k8sClient.Delete(ctx, v1beta1test.NewVirtualMCPServer(vmcpName, defaultNamespace))
 			_ = k8sClient.Delete(ctx, &mcpv1beta1.MCPServer{
 				ObjectMeta: metav1.ObjectMeta{Name: backendName, Namespace: defaultNamespace},
 			})
@@ -380,30 +375,27 @@ var _ = ginkgo.Describe("VirtualMCPServer Redis-Backed Session Sharing", func() 
 			redisAddr := fmt.Sprintf("%s.%s.svc.cluster.local:6379", redisName, defaultNamespace)
 
 			ginkgo.By("Creating VirtualMCPServer with replicas=1, Redis, and NodePort")
-			gomega.Expect(k8sClient.Create(ctx, &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{Name: vmcpName, Namespace: defaultNamespace},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef:        &mcpv1beta1.MCPGroupRef{Name: mcpGroupName},
-					IncomingAuth:    &mcpv1beta1.IncomingAuthConfig{Type: "anonymous"},
-					Replicas:        &replicas,
-					ServiceType:     "NodePort",
-					SessionAffinity: "None",
-					SessionStorage: &mcpv1beta1.SessionStorageConfig{
-						Provider:  mcpv1beta1.SessionStorageProviderRedis,
-						Address:   redisAddr,
-						KeyPrefix: "thv:vmcp:e2e:",
-					},
-				},
-			})).To(gomega.Succeed())
+			gomega.Expect(k8sClient.Create(ctx, v1beta1test.NewVirtualMCPServer(vmcpName, defaultNamespace,
+				v1beta1test.WithVMCPGroupRef(mcpGroupName),
+				v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{Type: "anonymous"}),
+				v1beta1test.WithVMCPReplicas(replicas),
+				v1beta1test.WithVMCPSessionStorage(&mcpv1beta1.SessionStorageConfig{
+					Provider:  mcpv1beta1.SessionStorageProviderRedis,
+					Address:   redisAddr,
+					KeyPrefix: "thv:vmcp:e2e:",
+				}),
+				v1beta1test.MutateVMCP(func(v *mcpv1beta1.VirtualMCPServer) {
+					v.Spec.ServiceType = "NodePort"
+					v.Spec.SessionAffinity = "None"
+				}),
+			))).To(gomega.Succeed())
 
 			ginkgo.By("Waiting for VirtualMCPServer to be ready")
 			WaitForVirtualMCPServerReady(ctx, k8sClient, vmcpName, defaultNamespace, timeout, pollInterval)
 		})
 
 		ginkgo.AfterAll(func() {
-			_ = k8sClient.Delete(ctx, &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{Name: vmcpName, Namespace: defaultNamespace},
-			})
+			_ = k8sClient.Delete(ctx, v1beta1test.NewVirtualMCPServer(vmcpName, defaultNamespace))
 			_ = k8sClient.Delete(ctx, &mcpv1beta1.MCPServer{
 				ObjectMeta: metav1.ObjectMeta{Name: backendName, Namespace: defaultNamespace},
 			})
@@ -571,20 +563,19 @@ var _ = ginkgo.Describe("VirtualMCPServer Redis-Backed Session Sharing", func() 
 			redisAddr := fmt.Sprintf("%s.%s.svc.cluster.local:6379", redisName, defaultNamespace)
 
 			ginkgo.By("Creating VirtualMCPServer with replicas=2, Redis, and SessionAffinity=None")
-			gomega.Expect(k8sClient.Create(ctx, &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{Name: vmcpName, Namespace: defaultNamespace},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef:        &mcpv1beta1.MCPGroupRef{Name: mcpGroupName},
-					IncomingAuth:    &mcpv1beta1.IncomingAuthConfig{Type: "anonymous"},
-					Replicas:        &replicas,
-					SessionAffinity: "None",
-					SessionStorage: &mcpv1beta1.SessionStorageConfig{
-						Provider:  mcpv1beta1.SessionStorageProviderRedis,
-						Address:   redisAddr,
-						KeyPrefix: "thv:vmcp:e2e:",
-					},
-				},
-			})).To(gomega.Succeed())
+			gomega.Expect(k8sClient.Create(ctx, v1beta1test.NewVirtualMCPServer(vmcpName, defaultNamespace,
+				v1beta1test.WithVMCPGroupRef(mcpGroupName),
+				v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{Type: "anonymous"}),
+				v1beta1test.WithVMCPReplicas(replicas),
+				v1beta1test.WithVMCPSessionStorage(&mcpv1beta1.SessionStorageConfig{
+					Provider:  mcpv1beta1.SessionStorageProviderRedis,
+					Address:   redisAddr,
+					KeyPrefix: "thv:vmcp:e2e:",
+				}),
+				v1beta1test.MutateVMCP(func(v *mcpv1beta1.VirtualMCPServer) {
+					v.Spec.SessionAffinity = "None"
+				}),
+			))).To(gomega.Succeed())
 
 			ginkgo.By("Waiting for 2 ready pods")
 			gomega.Eventually(func() (int, error) {
@@ -596,9 +587,7 @@ var _ = ginkgo.Describe("VirtualMCPServer Redis-Backed Session Sharing", func() 
 		})
 
 		ginkgo.AfterAll(func() {
-			_ = k8sClient.Delete(ctx, &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{Name: vmcpName, Namespace: defaultNamespace},
-			})
+			_ = k8sClient.Delete(ctx, v1beta1test.NewVirtualMCPServer(vmcpName, defaultNamespace))
 			_ = k8sClient.Delete(ctx, &mcpv1beta1.MCPServer{
 				ObjectMeta: metav1.ObjectMeta{Name: backendName, Namespace: defaultNamespace},
 			})

--- a/test/e2e/thv-operator/virtualmcp/virtualmcp_session_management_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcp_session_management_test.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1/v1beta1test"
 	vmcpconfig "github.com/stacklok/toolhive/pkg/vmcp/config"
 	"github.com/stacklok/toolhive/test/e2e/images"
 )
@@ -76,17 +77,16 @@ var _ = ginkgo.Describe("VirtualMCPServer Session Management", func() {
 			})).To(gomega.Succeed())
 
 			ginkgo.By("Creating VirtualMCPServer")
-			gomega.Expect(k8sClient.Create(ctx, &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{Name: virtualMCPName, Namespace: defaultNamespace},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef: &mcpv1beta1.MCPGroupRef{Name: mcpGroupName},
-					Config: vmcpconfig.Config{
-						Group: mcpGroupName,
-					},
-					IncomingAuth: &mcpv1beta1.IncomingAuthConfig{Type: "anonymous"},
-					ServiceType:  "NodePort",
-				},
-			})).To(gomega.Succeed())
+			gomega.Expect(k8sClient.Create(ctx, v1beta1test.NewVirtualMCPServer(virtualMCPName, defaultNamespace,
+				v1beta1test.WithVMCPGroupRef(mcpGroupName),
+				v1beta1test.WithVMCPConfig(vmcpconfig.Config{
+					Group: mcpGroupName,
+				}),
+				v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{Type: "anonymous"}),
+				v1beta1test.MutateVMCP(func(v *mcpv1beta1.VirtualMCPServer) {
+					v.Spec.ServiceType = "NodePort"
+				}),
+			))).To(gomega.Succeed())
 
 			ginkgo.By("Waiting for VirtualMCPServer to be ready")
 			WaitForVirtualMCPServerReady(ctx, k8sClient, virtualMCPName, defaultNamespace, timeout, pollInterval)
@@ -96,9 +96,7 @@ var _ = ginkgo.Describe("VirtualMCPServer Session Management", func() {
 		})
 
 		ginkgo.AfterAll(func() {
-			_ = k8sClient.Delete(ctx, &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{Name: virtualMCPName, Namespace: defaultNamespace},
-			})
+			_ = k8sClient.Delete(ctx, v1beta1test.NewVirtualMCPServer(virtualMCPName, defaultNamespace))
 			_ = k8sClient.Delete(ctx, &mcpv1beta1.MCPServer{
 				ObjectMeta: metav1.ObjectMeta{Name: backendName, Namespace: defaultNamespace},
 			})
@@ -306,19 +304,14 @@ var _ = ginkgo.Describe("VirtualMCPServer Session Management", func() {
 			})).To(gomega.Succeed())
 
 			ginkgo.By("Creating VirtualMCPServer with default configuration")
-			gomega.Expect(k8sClient.Create(ctx, &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{Name: virtualMCPName, Namespace: defaultNamespace},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef:     &mcpv1beta1.MCPGroupRef{Name: mcpGroupName},
-					IncomingAuth: &mcpv1beta1.IncomingAuthConfig{Type: "anonymous"},
-				},
-			})).To(gomega.Succeed())
+			gomega.Expect(k8sClient.Create(ctx, v1beta1test.NewVirtualMCPServer(virtualMCPName, defaultNamespace,
+				v1beta1test.WithVMCPGroupRef(mcpGroupName),
+				v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{Type: "anonymous"}),
+			))).To(gomega.Succeed())
 		})
 
 		ginkgo.AfterAll(func() {
-			_ = k8sClient.Delete(ctx, &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{Name: virtualMCPName, Namespace: defaultNamespace},
-			})
+			_ = k8sClient.Delete(ctx, v1beta1test.NewVirtualMCPServer(virtualMCPName, defaultNamespace))
 			_ = k8sClient.Delete(ctx, &mcpv1beta1.MCPGroup{
 				ObjectMeta: metav1.ObjectMeta{Name: mcpGroupName, Namespace: defaultNamespace},
 			})
@@ -467,23 +460,22 @@ var _ = ginkgo.Describe("VirtualMCPServer Session Management", func() {
 
 			// ---- Deploy VirtualMCPServer with OIDC incoming auth ----
 			ginkgo.By("Creating VirtualMCPServer with OIDC incoming auth")
-			gomega.Expect(k8sClient.Create(ctx, &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{Name: vmcpName, Namespace: defaultNamespace},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef: &mcpv1beta1.MCPGroupRef{Name: mcpGroupName},
-					Config: vmcpconfig.Config{
-						Group: mcpGroupName,
+			gomega.Expect(k8sClient.Create(ctx, v1beta1test.NewVirtualMCPServer(vmcpName, defaultNamespace,
+				v1beta1test.WithVMCPGroupRef(mcpGroupName),
+				v1beta1test.WithVMCPConfig(vmcpconfig.Config{
+					Group: mcpGroupName,
+				}),
+				v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+					Type: "oidc",
+					OIDCConfigRef: &mcpv1beta1.MCPOIDCConfigReference{
+						Name:     "session-oidc-config",
+						Audience: "vmcp-audience",
 					},
-					IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-						Type: "oidc",
-						OIDCConfigRef: &mcpv1beta1.MCPOIDCConfigReference{
-							Name:     "session-oidc-config",
-							Audience: "vmcp-audience",
-						},
-					},
-					ServiceType: "NodePort",
-				},
-			})).To(gomega.Succeed())
+				}),
+				v1beta1test.MutateVMCP(func(v *mcpv1beta1.VirtualMCPServer) {
+					v.Spec.ServiceType = "NodePort"
+				}),
+			))).To(gomega.Succeed())
 
 			ginkgo.By("Waiting for VirtualMCPServer to be ready")
 			WaitForVirtualMCPServerReady(ctx, k8sClient, vmcpName, defaultNamespace, timeout, pollInterval)
@@ -493,9 +485,7 @@ var _ = ginkgo.Describe("VirtualMCPServer Session Management", func() {
 		})
 
 		ginkgo.AfterAll(func() {
-			_ = k8sClient.Delete(ctx, &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{Name: vmcpName, Namespace: defaultNamespace},
-			})
+			_ = k8sClient.Delete(ctx, v1beta1test.NewVirtualMCPServer(vmcpName, defaultNamespace))
 			_ = k8sClient.Delete(ctx, &mcpv1beta1.MCPServer{
 				ObjectMeta: metav1.ObjectMeta{Name: backendName, Namespace: defaultNamespace},
 			})

--- a/test/e2e/thv-operator/virtualmcp/virtualmcp_telemetry_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcp_telemetry_test.go
@@ -15,6 +15,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1/v1beta1test"
 	vmcpconfig "github.com/stacklok/toolhive/pkg/vmcp/config"
 	"github.com/stacklok/toolhive/test/e2e/images"
 )
@@ -102,26 +103,22 @@ var _ = Describe("VirtualMCPServer Telemetry Config", Ordered, func() {
 		}, timeout, pollingInterval).Should(BeTrue())
 
 		By("Creating VirtualMCPServer with telemetryConfigRef")
-		vmcp := &mcpv1beta1.VirtualMCPServer{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      vmcpServerName,
-				Namespace: testNamespace,
-			},
-			Spec: mcpv1beta1.VirtualMCPServerSpec{
-				GroupRef:    &mcpv1beta1.MCPGroupRef{Name: mcpGroupName},
-				ServiceType: "NodePort",
-				IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-					Type: "anonymous",
-				},
-				TelemetryConfigRef: &mcpv1beta1.MCPTelemetryConfigReference{
+		vmcp := v1beta1test.NewVirtualMCPServer(vmcpServerName, testNamespace,
+			v1beta1test.WithVMCPGroupRef(mcpGroupName),
+			v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+				Type: "anonymous",
+			}),
+			v1beta1test.WithVMCPConfig(vmcpconfig.Config{
+				Group: mcpGroupName,
+			}),
+			v1beta1test.MutateVMCP(func(v *mcpv1beta1.VirtualMCPServer) {
+				v.Spec.ServiceType = "NodePort"
+				v.Spec.TelemetryConfigRef = &mcpv1beta1.MCPTelemetryConfigReference{
 					Name:        "e2e-telemetry-config",
 					ServiceName: "custom-service-name",
-				},
-				Config: vmcpconfig.Config{
-					Group: mcpGroupName,
-				},
-			},
-		}
+				}
+			}),
+		)
 		Expect(k8sClient.Create(ctx, vmcp)).To(Succeed())
 
 		By("Waiting for VirtualMCPServer to be ready")
@@ -142,12 +139,7 @@ var _ = Describe("VirtualMCPServer Telemetry Config", Ordered, func() {
 
 	AfterAll(func() {
 		By("Cleaning up VirtualMCPServer")
-		vmcp := &mcpv1beta1.VirtualMCPServer{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      vmcpServerName,
-				Namespace: testNamespace,
-			},
-		}
+		vmcp := v1beta1test.NewVirtualMCPServer(vmcpServerName, testNamespace)
 		Expect(k8sClient.Delete(ctx, vmcp)).To(Succeed())
 
 		By("Cleaning up backend MCPServer")

--- a/test/e2e/thv-operator/virtualmcp/virtualmcp_toolconfig_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcp_toolconfig_test.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1/v1beta1test"
 	vmcpconfig "github.com/stacklok/toolhive/pkg/vmcp/config"
 	"github.com/stacklok/toolhive/test/e2e/images"
 )
@@ -65,39 +66,35 @@ var _ = Describe("VirtualMCPServer Tool Filtering via MCPToolConfig", Ordered, f
 		Expect(k8sClient.Create(ctx, toolConfig)).To(Succeed())
 
 		By("Creating VirtualMCPServer with MCPToolConfig reference for backend1")
-		vmcpServer := &mcpv1beta1.VirtualMCPServer{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      vmcpServerName,
-				Namespace: testNamespace,
-			},
-			Spec: mcpv1beta1.VirtualMCPServerSpec{
-				GroupRef: &mcpv1beta1.MCPGroupRef{Name: mcpGroupName},
-				Config: vmcpconfig.Config{
-					Group: mcpGroupName,
-					Aggregation: &vmcpconfig.AggregationConfig{
-						ConflictResolution: "prefix",
-						Tools: []*vmcpconfig.WorkloadToolConfig{
-							{
-								Workload: backend1Name,
-								// Reference MCPToolConfig instead of inline Filter
-								ToolConfigRef: &vmcpconfig.ToolConfigRef{
-									Name: toolConfigName,
-								},
+		vmcpServer := v1beta1test.NewVirtualMCPServer(vmcpServerName, testNamespace,
+			v1beta1test.WithVMCPGroupRef(mcpGroupName),
+			v1beta1test.WithVMCPConfig(vmcpconfig.Config{
+				Group: mcpGroupName,
+				Aggregation: &vmcpconfig.AggregationConfig{
+					ConflictResolution: "prefix",
+					Tools: []*vmcpconfig.WorkloadToolConfig{
+						{
+							Workload: backend1Name,
+							// Reference MCPToolConfig instead of inline Filter
+							ToolConfigRef: &vmcpconfig.ToolConfigRef{
+								Name: toolConfigName,
 							},
-							{
-								Workload: backend2Name,
-								// Use inline filter to exclude all tools from backend2
-								Filter: []string{"nonexistent_tool"},
-							},
+						},
+						{
+							Workload: backend2Name,
+							// Use inline filter to exclude all tools from backend2
+							Filter: []string{"nonexistent_tool"},
 						},
 					},
 				},
-				IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-					Type: "anonymous",
-				},
-				ServiceType: "NodePort",
-			},
-		}
+			}),
+			v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+				Type: "anonymous",
+			}),
+			v1beta1test.MutateVMCP(func(v *mcpv1beta1.VirtualMCPServer) {
+				v.Spec.ServiceType = "NodePort"
+			}),
+		)
 		Expect(k8sClient.Create(ctx, vmcpServer)).To(Succeed())
 
 		By("Waiting for VirtualMCPServer to be ready")
@@ -111,12 +108,7 @@ var _ = Describe("VirtualMCPServer Tool Filtering via MCPToolConfig", Ordered, f
 
 	AfterAll(func() {
 		By("Cleaning up VirtualMCPServer")
-		vmcpServer := &mcpv1beta1.VirtualMCPServer{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      vmcpServerName,
-				Namespace: testNamespace,
-			},
-		}
+		vmcpServer := v1beta1test.NewVirtualMCPServer(vmcpServerName, testNamespace)
 		_ = k8sClient.Delete(ctx, vmcpServer)
 
 		By("Cleaning up MCPToolConfig")
@@ -356,33 +348,29 @@ var _ = Describe("VirtualMCPServer MCPToolConfig Dynamic Updates", Ordered, func
 		Expect(k8sClient.Create(ctx, toolConfig)).To(Succeed())
 
 		By("Creating VirtualMCPServer with MCPToolConfig reference")
-		vmcpServer := &mcpv1beta1.VirtualMCPServer{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      vmcpServerName,
-				Namespace: testNamespace,
-			},
-			Spec: mcpv1beta1.VirtualMCPServerSpec{
-				GroupRef: &mcpv1beta1.MCPGroupRef{Name: mcpGroupName},
-				Config: vmcpconfig.Config{
-					Group: mcpGroupName,
-					Aggregation: &vmcpconfig.AggregationConfig{
-						ConflictResolution: "prefix",
-						Tools: []*vmcpconfig.WorkloadToolConfig{
-							{
-								Workload: backendName,
-								ToolConfigRef: &vmcpconfig.ToolConfigRef{
-									Name: toolConfigName,
-								},
+		vmcpServer := v1beta1test.NewVirtualMCPServer(vmcpServerName, testNamespace,
+			v1beta1test.WithVMCPGroupRef(mcpGroupName),
+			v1beta1test.WithVMCPConfig(vmcpconfig.Config{
+				Group: mcpGroupName,
+				Aggregation: &vmcpconfig.AggregationConfig{
+					ConflictResolution: "prefix",
+					Tools: []*vmcpconfig.WorkloadToolConfig{
+						{
+							Workload: backendName,
+							ToolConfigRef: &vmcpconfig.ToolConfigRef{
+								Name: toolConfigName,
 							},
 						},
 					},
 				},
-				IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-					Type: "anonymous",
-				},
-				ServiceType: "NodePort",
-			},
-		}
+			}),
+			v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+				Type: "anonymous",
+			}),
+			v1beta1test.MutateVMCP(func(v *mcpv1beta1.VirtualMCPServer) {
+				v.Spec.ServiceType = "NodePort"
+			}),
+		)
 		Expect(k8sClient.Create(ctx, vmcpServer)).To(Succeed())
 
 		By("Waiting for VirtualMCPServer to be ready")
@@ -396,12 +384,7 @@ var _ = Describe("VirtualMCPServer MCPToolConfig Dynamic Updates", Ordered, func
 
 	AfterAll(func() {
 		By("Cleaning up VirtualMCPServer")
-		vmcpServer := &mcpv1beta1.VirtualMCPServer{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      vmcpServerName,
-				Namespace: testNamespace,
-			},
-		}
+		vmcpServer := v1beta1test.NewVirtualMCPServer(vmcpServerName, testNamespace)
 		_ = k8sClient.Delete(ctx, vmcpServer)
 
 		By("Cleaning up MCPToolConfig")

--- a/test/e2e/thv-operator/virtualmcp/virtualmcp_yardstick_base_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcp_yardstick_base_test.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1/v1beta1test"
 	vmcpconfig "github.com/stacklok/toolhive/pkg/vmcp/config"
 	"github.com/stacklok/toolhive/test/e2e/images"
 )
@@ -105,25 +106,21 @@ var _ = Describe("VirtualMCPServer Yardstick Base", Ordered, func() {
 		}, timeout, pollingInterval).Should(Succeed(), "Both MCPServers should be running")
 
 		By("Creating VirtualMCPServer with prefix conflict resolution")
-		vmcpServer := &mcpv1beta1.VirtualMCPServer{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      vmcpServerName,
-				Namespace: testNamespace,
-			},
-			Spec: mcpv1beta1.VirtualMCPServerSpec{
-				GroupRef: &mcpv1beta1.MCPGroupRef{Name: mcpGroupName},
-				Config: vmcpconfig.Config{
-					Group: mcpGroupName,
-					Aggregation: &vmcpconfig.AggregationConfig{
-						ConflictResolution: "prefix",
-					},
+		vmcpServer := v1beta1test.NewVirtualMCPServer(vmcpServerName, testNamespace,
+			v1beta1test.WithVMCPGroupRef(mcpGroupName),
+			v1beta1test.WithVMCPConfig(vmcpconfig.Config{
+				Group: mcpGroupName,
+				Aggregation: &vmcpconfig.AggregationConfig{
+					ConflictResolution: "prefix",
 				},
-				IncomingAuth: &mcpv1beta1.IncomingAuthConfig{
-					Type: "anonymous",
-				},
-				ServiceType: "NodePort",
-			},
-		}
+			}),
+			v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+				Type: "anonymous",
+			}),
+			v1beta1test.MutateVMCP(func(v *mcpv1beta1.VirtualMCPServer) {
+				v.Spec.ServiceType = "NodePort"
+			}),
+		)
 		Expect(k8sClient.Create(ctx, vmcpServer)).To(Succeed())
 
 		By("Waiting for VirtualMCPServer to be ready")
@@ -137,12 +134,7 @@ var _ = Describe("VirtualMCPServer Yardstick Base", Ordered, func() {
 
 	AfterAll(func() {
 		By("Cleaning up VirtualMCPServer")
-		vmcpServer := &mcpv1beta1.VirtualMCPServer{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      vmcpServerName,
-				Namespace: testNamespace,
-			},
-		}
+		vmcpServer := v1beta1test.NewVirtualMCPServer(vmcpServerName, testNamespace)
 		_ = k8sClient.Delete(ctx, vmcpServer)
 
 		By("Cleaning up backend MCPServers")

--- a/test/e2e/thv-operator/virtualmcp/virtualmcpserver_scaling_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcpserver_scaling_test.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1/v1beta1test"
 	"github.com/stacklok/toolhive/test/e2e/images"
 )
 
@@ -83,20 +84,15 @@ var _ = ginkgo.Describe("VirtualMCPServer Horizontal Scaling", func() {
 
 			replicas := int32(2)
 			ginkgo.By("Creating VirtualMCPServer with replicas=2")
-			gomega.Expect(k8sClient.Create(ctx, &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{Name: vmcpName, Namespace: defaultNamespace},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef:     &mcpv1beta1.MCPGroupRef{Name: mcpGroupName},
-					IncomingAuth: &mcpv1beta1.IncomingAuthConfig{Type: "anonymous"},
-					Replicas:     &replicas,
-				},
-			})).To(gomega.Succeed())
+			gomega.Expect(k8sClient.Create(ctx, v1beta1test.NewVirtualMCPServer(vmcpName, defaultNamespace,
+				v1beta1test.WithVMCPGroupRef(mcpGroupName),
+				v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{Type: "anonymous"}),
+				v1beta1test.WithVMCPReplicas(replicas),
+			))).To(gomega.Succeed())
 		})
 
 		ginkgo.AfterAll(func() {
-			_ = k8sClient.Delete(ctx, &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{Name: vmcpName, Namespace: defaultNamespace},
-			})
+			_ = k8sClient.Delete(ctx, v1beta1test.NewVirtualMCPServer(vmcpName, defaultNamespace))
 			_ = k8sClient.Delete(ctx, &mcpv1beta1.MCPServer{
 				ObjectMeta: metav1.ObjectMeta{Name: backendName, Namespace: defaultNamespace},
 			})
@@ -183,24 +179,21 @@ var _ = ginkgo.Describe("VirtualMCPServer Horizontal Scaling", func() {
 
 			replicas := int32(1)
 			ginkgo.By("Creating VirtualMCPServer with replicas=1")
-			gomega.Expect(k8sClient.Create(ctx, &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{Name: vmcpName, Namespace: defaultNamespace},
-				Spec: mcpv1beta1.VirtualMCPServerSpec{
-					GroupRef:     &mcpv1beta1.MCPGroupRef{Name: mcpGroupName},
-					IncomingAuth: &mcpv1beta1.IncomingAuthConfig{Type: "anonymous"},
-					Replicas:     &replicas,
-					ServiceType:  "NodePort",
-				},
-			})).To(gomega.Succeed())
+			gomega.Expect(k8sClient.Create(ctx, v1beta1test.NewVirtualMCPServer(vmcpName, defaultNamespace,
+				v1beta1test.WithVMCPGroupRef(mcpGroupName),
+				v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{Type: "anonymous"}),
+				v1beta1test.WithVMCPReplicas(replicas),
+				v1beta1test.MutateVMCP(func(v *mcpv1beta1.VirtualMCPServer) {
+					v.Spec.ServiceType = "NodePort"
+				}),
+			))).To(gomega.Succeed())
 
 			ginkgo.By("Waiting for VirtualMCPServer to be ready with 1 replica")
 			WaitForVirtualMCPServerReady(ctx, k8sClient, vmcpName, defaultNamespace, timeout, pollInterval)
 		})
 
 		ginkgo.AfterAll(func() {
-			_ = k8sClient.Delete(ctx, &mcpv1beta1.VirtualMCPServer{
-				ObjectMeta: metav1.ObjectMeta{Name: vmcpName, Namespace: defaultNamespace},
-			})
+			_ = k8sClient.Delete(ctx, v1beta1test.NewVirtualMCPServer(vmcpName, defaultNamespace))
 			_ = k8sClient.Delete(ctx, &mcpv1beta1.MCPServer{
 				ObjectMeta: metav1.ObjectMeta{Name: backendName, Namespace: defaultNamespace},
 			})


### PR DESCRIPTION
## Summary

VirtualMCPServer test fixtures were hand-rolled struct literals duplicated across the suite, repeating the same `ObjectMeta` + spec boilerplate hundreds of times. This converts every manual `VirtualMCPServer` construction in tests to the `v1beta1test.NewVirtualMCPServer` builder (added in #5576), removing ~1,400 lines of boilerplate with no behavior change.

Scope is the **whole repo**: unit tests, envtest integration tests, and e2e tests.

<details>
<summary><strong>Medium level</strong></summary>

- Replaces `&mcpv1beta1.VirtualMCPServer{...}` literals with `v1beta1test.NewVirtualMCPServer(name, ns, opts...)` across:
  - `cmd/thv-operator/controllers/*` and `cmd/thv-operator/pkg/*` unit tests
  - `cmd/thv-operator/test-integration/*` envtest suites
  - `pkg/vmcp/status` unit tests
  - `test/e2e/thv-operator/virtualmcp/*` e2e tests
- Each literal maps faithfully: `ObjectMeta{Name,Namespace}` → constructor args; set spec fields → matching `WithVMCP*` option; fields without a dedicated option (`PassthroughHeaders`, `ServiceType`, `SessionAffinity`, `ImagePullSecrets`) → `MutateVMCP`.
- VirtualMCPServer has **no builder defaults**, so the builder injects nothing a literal didn't set — the migration is purely faithful, with no apiserver-defaulting hazard in envtest/e2e.
- Left inline (by design): empty `&VirtualMCPServer{}` Get/decode targets, `WithStatusSubresource`/`WithIndex` type references, and `[]VirtualMCPServer{}` slice-type headers (their elements are migrated).
- Only `VirtualMCPServer` constructions are touched; `MCPServer`/`MCPRemoteProxy`/`EmbeddingServer`/`MCPGroup` literals in shared files are left for their own changes.
- No assertions, table values, or test logic changed — pure construction swap.

</details>

## Known exception

`cmd/thv-operator/api/v1beta1/virtualmcpserver_types_test.go` (16 literals) is **not** migrated: it is a white-box `package v1beta1` test that uses unexported helpers, so it cannot import `v1beta1test` without an import cycle. This matches how #5566 left MCPServer's white-box test inline.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring
- [ ] Documentation
- [ ] Other

## Test plan

- [x] `task operator-test` passes (unit gate)
- [x] `go test -count=1 -run '^$' ./...` compiles all test binaries (incl. e2e)
- [x] `go test -tags integration -run '^$' ./cmd/thv-operator/... ./pkg/vmcp/...` compiles envtest suites
- [x] `task lint-fix` clean (no new issues in changed files)

## Special notes for reviewers

Large but test-only and mechanical, applied via per-file agents and verified by the unit suite. e2e fixtures are migrated and compile-checked; they require a Kind cluster to run, which CI/runtime validates.

## Large PR Justification

This PR is large but is a **test-only, mechanical migration** that must be applied broadly:

- **Pure construction swap, no behavior change.** Every `VirtualMCPServer` struct literal in the test suite is replaced with the `v1beta1test.NewVirtualMCPServer(...)` builder. No assertions, table values, or test logic are changed — verified by the operator unit suite passing unchanged.
- **The value is in the breadth.** The whole point of the change is to remove duplicated `ObjectMeta`/spec boilerplate across the entire suite (unit, envtest, e2e). Splitting it would leave the codebase half-migrated, defeating the DRY goal and creating two competing fixture styles during the gap.
- **Net reduction.** The diff is ~+2,600/−3,990 (net ≈ −1,390 lines) — most of the "size" is deletions of boilerplate.
- **Mechanical and reviewable per-file.** Each file is an independent, identical-pattern swap; the migration faithfulness was already confirmed in review (no over/under-migration, coverage preserved).
- **Builder already merged separately.** The builder itself landed in #5576; this PR is only the call-site adoption, so it cannot be meaningfully decomposed further without arbitrary file-group splits.


Generated with [Claude Code](https://claude.com/claude-code)
