### PR TITLE
Migrate MCPRemoteProxy test fixtures to v1beta1test

### DIFF
--- a/cmd/thv-operator/controllers/mcpauthzconfig_controller_test.go
+++ b/cmd/thv-operator/controllers/mcpauthzconfig_controller_test.go
@@ -322,13 +322,10 @@ func TestMCPAuthzConfigReconciler_handleDeletion(t *testing.T) {
 			name:        "referencing MCPRemoteProxy blocks deletion",
 			authzConfig: deletingConfig(),
 			existingWorkloads: []client.Object{
-				&mcpv1beta1.MCPRemoteProxy{
-					ObjectMeta: metav1.ObjectMeta{Name: "referencing-proxy", Namespace: "default"},
-					Spec: mcpv1beta1.MCPRemoteProxySpec{
-						RemoteURL:      "https://example.com",
-						AuthzConfigRef: &mcpv1beta1.MCPAuthzConfigReference{Name: "test-config"},
-					},
-				},
+				v1beta1test.NewMCPRemoteProxy("referencing-proxy", "default",
+					v1beta1test.WithRemoteProxyURL("https://example.com"),
+					v1beta1test.WithRemoteProxyAuthzConfigRef("test-config"),
+				),
 			},
 			expectRequeue: true,
 		},
@@ -673,13 +670,10 @@ func TestMCPAuthzConfigReconciler_findReferencingWorkloads(t *testing.T) {
 						},
 					},
 				},
-				&mcpv1beta1.MCPRemoteProxy{
-					ObjectMeta: metav1.ObjectMeta{Name: "my-proxy", Namespace: "default"},
-					Spec: mcpv1beta1.MCPRemoteProxySpec{
-						RemoteURL:      "https://example.com",
-						AuthzConfigRef: &mcpv1beta1.MCPAuthzConfigReference{Name: "shared-config"},
-					},
-				},
+				v1beta1test.NewMCPRemoteProxy("my-proxy", "default",
+					v1beta1test.WithRemoteProxyURL("https://example.com"),
+					v1beta1test.WithRemoteProxyAuthzConfigRef("shared-config"),
+				),
 			},
 			expectedRefs: []mcpv1beta1.WorkloadReference{
 				{Kind: mcpv1beta1.WorkloadKindMCPRemoteProxy, Name: "my-proxy"},
@@ -701,10 +695,9 @@ func TestMCPAuthzConfigReconciler_findReferencingWorkloads(t *testing.T) {
 						IncomingAuth: &mcpv1beta1.IncomingAuthConfig{Type: "anonymous"},
 					},
 				},
-				&mcpv1beta1.MCPRemoteProxy{
-					ObjectMeta: metav1.ObjectMeta{Name: "unrelated-proxy", Namespace: "default"},
-					Spec:       mcpv1beta1.MCPRemoteProxySpec{RemoteURL: "https://example.com"},
-				},
+				v1beta1test.NewMCPRemoteProxy("unrelated-proxy", "default",
+					v1beta1test.WithRemoteProxyURL("https://example.com"),
+				),
 			},
 			expectEmpty: true,
 		},
@@ -781,13 +774,10 @@ func TestMCPAuthzConfigReconciler_watchHandlers(t *testing.T) {
 		},
 		{
 			name: "MCPRemoteProxy with ref enqueues current and stale configs",
-			obj: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{Name: "proxy", Namespace: "default"},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					RemoteURL:      "https://example.com",
-					AuthzConfigRef: &mcpv1beta1.MCPAuthzConfigReference{Name: "current-config"},
-				},
-			},
+			obj: v1beta1test.NewMCPRemoteProxy("proxy", "default",
+				v1beta1test.WithRemoteProxyURL("https://example.com"),
+				v1beta1test.WithRemoteProxyAuthzConfigRef("current-config"),
+			),
 			expected: map[string]struct{}{"current-config": {}, "stale-config": {}},
 		},
 		{

--- a/cmd/thv-operator/controllers/mcpexternalauthconfig_controller_test.go
+++ b/cmd/thv-operator/controllers/mcpexternalauthconfig_controller_test.go
@@ -1016,44 +1016,21 @@ func TestMCPExternalAuthConfigReconciler_findReferencingWorkloads_mcpRemoteProxy
 	}
 
 	// MCPRemoteProxy referencing via externalAuthConfigRef
-	proxyViaExtAuth := &mcpv1beta1.MCPRemoteProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "proxy-via-extauth",
-			Namespace: "default",
-		},
-		Spec: mcpv1beta1.MCPRemoteProxySpec{
-			RemoteURL: "https://remote.example.com",
-			ExternalAuthConfigRef: &mcpv1beta1.ExternalAuthConfigRef{
-				Name: "auth-config",
-			},
-		},
-	}
+	proxyViaExtAuth := v1beta1test.NewMCPRemoteProxy("proxy-via-extauth", "default",
+		v1beta1test.WithRemoteProxyURL("https://remote.example.com"),
+		v1beta1test.WithRemoteProxyExternalAuthConfigRef("auth-config"),
+	)
 
 	// MCPRemoteProxy referencing via authServerRef
-	proxyViaAuthServerRef := &mcpv1beta1.MCPRemoteProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "proxy-via-authserverref",
-			Namespace: "default",
-		},
-		Spec: mcpv1beta1.MCPRemoteProxySpec{
-			RemoteURL: "https://remote.example.com",
-			AuthServerRef: &mcpv1beta1.AuthServerRef{
-				Kind: "MCPExternalAuthConfig",
-				Name: "auth-config",
-			},
-		},
-	}
+	proxyViaAuthServerRef := v1beta1test.NewMCPRemoteProxy("proxy-via-authserverref", "default",
+		v1beta1test.WithRemoteProxyURL("https://remote.example.com"),
+		v1beta1test.WithRemoteProxyAuthServerRef("MCPExternalAuthConfig", "auth-config"),
+	)
 
 	// MCPRemoteProxy not referencing this config
-	proxyNoRef := &mcpv1beta1.MCPRemoteProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "proxy-no-ref",
-			Namespace: "default",
-		},
-		Spec: mcpv1beta1.MCPRemoteProxySpec{
-			RemoteURL: "https://remote.example.com",
-		},
-	}
+	proxyNoRef := v1beta1test.NewMCPRemoteProxy("proxy-no-ref", "default",
+		v1beta1test.WithRemoteProxyURL("https://remote.example.com"),
+	)
 
 	// MCPServer also referencing the same config
 	server := v1beta1test.NewMCPServer("server-ref", "default",

--- a/cmd/thv-operator/controllers/mcpgroup_controller_test.go
+++ b/cmd/thv-operator/controllers/mcpgroup_controller_test.go
@@ -997,18 +997,9 @@ func TestMCPGroupReconciler_findReferencingMCPRemoteProxies(t *testing.T) {
 			groupName: testGroupName,
 			namespace: "default",
 			mcpRemoteProxies: []*mcpv1beta1.MCPRemoteProxy{
-				{
-					ObjectMeta: metav1.ObjectMeta{Name: "proxy1", Namespace: "default"},
-					Spec:       mcpv1beta1.MCPRemoteProxySpec{GroupRef: &mcpv1beta1.MCPGroupRef{Name: testGroupName}},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{Name: "proxy2", Namespace: "default"},
-					Spec:       mcpv1beta1.MCPRemoteProxySpec{GroupRef: &mcpv1beta1.MCPGroupRef{Name: "other-group"}},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{Name: "proxy3", Namespace: "default"},
-					Spec:       mcpv1beta1.MCPRemoteProxySpec{GroupRef: &mcpv1beta1.MCPGroupRef{Name: testGroupName}},
-				},
+				v1beta1test.NewMCPRemoteProxy("proxy1", "default", v1beta1test.WithRemoteProxyGroupRef(testGroupName)),
+				v1beta1test.NewMCPRemoteProxy("proxy2", "default", v1beta1test.WithRemoteProxyGroupRef("other-group")),
+				v1beta1test.NewMCPRemoteProxy("proxy3", "default", v1beta1test.WithRemoteProxyGroupRef(testGroupName)),
 			},
 			expectedCount: 2,
 			expectedNames: []string{"proxy1", "proxy3"},
@@ -1018,10 +1009,7 @@ func TestMCPGroupReconciler_findReferencingMCPRemoteProxies(t *testing.T) {
 			groupName: testGroupName,
 			namespace: "default",
 			mcpRemoteProxies: []*mcpv1beta1.MCPRemoteProxy{
-				{
-					ObjectMeta: metav1.ObjectMeta{Name: "proxy1", Namespace: "default"},
-					Spec:       mcpv1beta1.MCPRemoteProxySpec{GroupRef: &mcpv1beta1.MCPGroupRef{Name: "other-group"}},
-				},
+				v1beta1test.NewMCPRemoteProxy("proxy1", "default", v1beta1test.WithRemoteProxyGroupRef("other-group")),
 			},
 			expectedCount: 0,
 			expectedNames: []string{},
@@ -1031,14 +1019,8 @@ func TestMCPGroupReconciler_findReferencingMCPRemoteProxies(t *testing.T) {
 			groupName: testGroupName,
 			namespace: "namespace-a",
 			mcpRemoteProxies: []*mcpv1beta1.MCPRemoteProxy{
-				{
-					ObjectMeta: metav1.ObjectMeta{Name: "proxy1", Namespace: "namespace-a"},
-					Spec:       mcpv1beta1.MCPRemoteProxySpec{GroupRef: &mcpv1beta1.MCPGroupRef{Name: testGroupName}},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{Name: "proxy2", Namespace: "namespace-b"},
-					Spec:       mcpv1beta1.MCPRemoteProxySpec{GroupRef: &mcpv1beta1.MCPGroupRef{Name: testGroupName}},
-				},
+				v1beta1test.NewMCPRemoteProxy("proxy1", "namespace-a", v1beta1test.WithRemoteProxyGroupRef(testGroupName)),
+				v1beta1test.NewMCPRemoteProxy("proxy2", "namespace-b", v1beta1test.WithRemoteProxyGroupRef(testGroupName)),
 			},
 			expectedCount: 1,
 			expectedNames: []string{"proxy1"},
@@ -1130,15 +1112,9 @@ func TestMCPGroupReconciler_findMCPGroupForMCPRemoteProxy(t *testing.T) {
 	}{
 		{
 			name: "remote proxy with groupRef finds matching group",
-			mcpRemoteProxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-proxy",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					GroupRef: &mcpv1beta1.MCPGroupRef{Name: testGroupName},
-				},
-			},
+			mcpRemoteProxy: v1beta1test.NewMCPRemoteProxy("test-proxy", "default",
+				v1beta1test.WithRemoteProxyGroupRef(testGroupName),
+			),
 			mcpGroups: []*mcpv1beta1.MCPGroup{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -1151,16 +1127,8 @@ func TestMCPGroupReconciler_findMCPGroupForMCPRemoteProxy(t *testing.T) {
 			expectedGroupName: testGroupName,
 		},
 		{
-			name: "remote proxy without groupRef returns empty",
-			mcpRemoteProxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-proxy",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					// No GroupRef
-				},
-			},
+			name:           "remote proxy without groupRef returns empty",
+			mcpRemoteProxy: v1beta1test.NewMCPRemoteProxy("test-proxy", "default"),
 			mcpGroups: []*mcpv1beta1.MCPGroup{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -1173,15 +1141,9 @@ func TestMCPGroupReconciler_findMCPGroupForMCPRemoteProxy(t *testing.T) {
 		},
 		{
 			name: "remote proxy with non-existent groupRef returns empty",
-			mcpRemoteProxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-proxy",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					GroupRef: &mcpv1beta1.MCPGroupRef{Name: "non-existent-group"},
-				},
-			},
+			mcpRemoteProxy: v1beta1test.NewMCPRemoteProxy("test-proxy", "default",
+				v1beta1test.WithRemoteProxyGroupRef("non-existent-group"),
+			),
 			mcpGroups: []*mcpv1beta1.MCPGroup{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -1194,15 +1156,9 @@ func TestMCPGroupReconciler_findMCPGroupForMCPRemoteProxy(t *testing.T) {
 		},
 		{
 			name: "remote proxy finds correct group among multiple groups",
-			mcpRemoteProxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-proxy",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					GroupRef: &mcpv1beta1.MCPGroupRef{Name: "group-b"},
-				},
-			},
+			mcpRemoteProxy: v1beta1test.NewMCPRemoteProxy("test-proxy", "default",
+				v1beta1test.WithRemoteProxyGroupRef("group-b"),
+			),
 			mcpGroups: []*mcpv1beta1.MCPGroup{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -1296,24 +1252,8 @@ func TestMCPGroupReconciler_updateReferencingRemoteProxiesOnDeletion(t *testing.
 			name:      "updates conditions on remote proxies",
 			groupName: testGroupName,
 			mcpRemoteProxies: []mcpv1beta1.MCPRemoteProxy{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "proxy1",
-						Namespace: "default",
-					},
-					Spec: mcpv1beta1.MCPRemoteProxySpec{
-						GroupRef: &mcpv1beta1.MCPGroupRef{Name: testGroupName},
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "proxy2",
-						Namespace: "default",
-					},
-					Spec: mcpv1beta1.MCPRemoteProxySpec{
-						GroupRef: &mcpv1beta1.MCPGroupRef{Name: testGroupName},
-					},
-				},
+				*v1beta1test.NewMCPRemoteProxy("proxy1", "default", v1beta1test.WithRemoteProxyGroupRef(testGroupName)),
+				*v1beta1test.NewMCPRemoteProxy("proxy2", "default", v1beta1test.WithRemoteProxyGroupRef(testGroupName)),
 			},
 			expectedUpdates: 2,
 		},

--- a/cmd/thv-operator/controllers/mcpremoteproxy_authserverref_test.go
+++ b/cmd/thv-operator/controllers/mcpremoteproxy_authserverref_test.go
@@ -16,6 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1/v1beta1test"
 	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 )
 
@@ -35,26 +36,22 @@ func TestMCPRemoteProxyReconciler_handleAuthServerRef(t *testing.T) {
 		{
 			name: "nil authServerRef removes condition and clears hash",
 			proxy: func() *mcpv1beta1.MCPRemoteProxy {
-				return &mcpv1beta1.MCPRemoteProxy{
-					ObjectMeta: metav1.ObjectMeta{Name: "proxy", Namespace: "default"},
-					Spec:       mcpv1beta1.MCPRemoteProxySpec{RemoteURL: "https://remote.example.com"},
-					Status: mcpv1beta1.MCPRemoteProxyStatus{
+				return v1beta1test.NewMCPRemoteProxy("proxy", "default",
+					v1beta1test.WithRemoteProxyURL("https://remote.example.com"),
+					v1beta1test.WithRemoteProxyStatus(mcpv1beta1.MCPRemoteProxyStatus{
 						AuthServerConfigHash: "old-hash",
-					},
-				}
+					}),
+				)
 			},
 			expectHash: "",
 		},
 		{
 			name: "unsupported kind sets InvalidKind condition",
 			proxy: func() *mcpv1beta1.MCPRemoteProxy {
-				return &mcpv1beta1.MCPRemoteProxy{
-					ObjectMeta: metav1.ObjectMeta{Name: "proxy", Namespace: "default"},
-					Spec: mcpv1beta1.MCPRemoteProxySpec{
-						RemoteURL:     "https://remote.example.com",
-						AuthServerRef: &mcpv1beta1.AuthServerRef{Kind: "Secret", Name: "foo"},
-					},
-				}
+				return v1beta1test.NewMCPRemoteProxy("proxy", "default",
+					v1beta1test.WithRemoteProxyURL("https://remote.example.com"),
+					v1beta1test.WithRemoteProxyAuthServerRef("Secret", "foo"),
+				)
 			},
 			expectError:     true,
 			errContains:     "unsupported authServerRef kind",
@@ -64,13 +61,10 @@ func TestMCPRemoteProxyReconciler_handleAuthServerRef(t *testing.T) {
 		{
 			name: "not found sets NotFound condition",
 			proxy: func() *mcpv1beta1.MCPRemoteProxy {
-				return &mcpv1beta1.MCPRemoteProxy{
-					ObjectMeta: metav1.ObjectMeta{Name: "proxy", Namespace: "default"},
-					Spec: mcpv1beta1.MCPRemoteProxySpec{
-						RemoteURL:     "https://remote.example.com",
-						AuthServerRef: &mcpv1beta1.AuthServerRef{Kind: "MCPExternalAuthConfig", Name: "missing"},
-					},
-				}
+				return v1beta1test.NewMCPRemoteProxy("proxy", "default",
+					v1beta1test.WithRemoteProxyURL("https://remote.example.com"),
+					v1beta1test.WithRemoteProxyAuthServerRef("MCPExternalAuthConfig", "missing"),
+				)
 			},
 			expectError:     true,
 			errContains:     "not found",
@@ -80,13 +74,10 @@ func TestMCPRemoteProxyReconciler_handleAuthServerRef(t *testing.T) {
 		{
 			name: "wrong type sets InvalidType condition",
 			proxy: func() *mcpv1beta1.MCPRemoteProxy {
-				return &mcpv1beta1.MCPRemoteProxy{
-					ObjectMeta: metav1.ObjectMeta{Name: "proxy", Namespace: "default"},
-					Spec: mcpv1beta1.MCPRemoteProxySpec{
-						RemoteURL:     "https://remote.example.com",
-						AuthServerRef: &mcpv1beta1.AuthServerRef{Kind: "MCPExternalAuthConfig", Name: "sts-config"},
-					},
-				}
+				return v1beta1test.NewMCPRemoteProxy("proxy", "default",
+					v1beta1test.WithRemoteProxyURL("https://remote.example.com"),
+					v1beta1test.WithRemoteProxyAuthServerRef("MCPExternalAuthConfig", "sts-config"),
+				)
 			},
 			authConfig: func() *mcpv1beta1.MCPExternalAuthConfig {
 				return &mcpv1beta1.MCPExternalAuthConfig{
@@ -107,13 +98,10 @@ func TestMCPRemoteProxyReconciler_handleAuthServerRef(t *testing.T) {
 		{
 			name: "multi-upstream sets MultiUpstream condition",
 			proxy: func() *mcpv1beta1.MCPRemoteProxy {
-				return &mcpv1beta1.MCPRemoteProxy{
-					ObjectMeta: metav1.ObjectMeta{Name: "proxy", Namespace: "default"},
-					Spec: mcpv1beta1.MCPRemoteProxySpec{
-						RemoteURL:     "https://remote.example.com",
-						AuthServerRef: &mcpv1beta1.AuthServerRef{Kind: "MCPExternalAuthConfig", Name: "multi"},
-					},
-				}
+				return v1beta1test.NewMCPRemoteProxy("proxy", "default",
+					v1beta1test.WithRemoteProxyURL("https://remote.example.com"),
+					v1beta1test.WithRemoteProxyAuthServerRef("MCPExternalAuthConfig", "multi"),
+				)
 			},
 			authConfig: func() *mcpv1beta1.MCPExternalAuthConfig {
 				return &mcpv1beta1.MCPExternalAuthConfig{
@@ -139,13 +127,10 @@ func TestMCPRemoteProxyReconciler_handleAuthServerRef(t *testing.T) {
 		{
 			name: "valid ref sets Valid condition and updates hash",
 			proxy: func() *mcpv1beta1.MCPRemoteProxy {
-				return &mcpv1beta1.MCPRemoteProxy{
-					ObjectMeta: metav1.ObjectMeta{Name: "proxy", Namespace: "default"},
-					Spec: mcpv1beta1.MCPRemoteProxySpec{
-						RemoteURL:     "https://remote.example.com",
-						AuthServerRef: &mcpv1beta1.AuthServerRef{Kind: "MCPExternalAuthConfig", Name: "valid"},
-					},
-				}
+				return v1beta1test.NewMCPRemoteProxy("proxy", "default",
+					v1beta1test.WithRemoteProxyURL("https://remote.example.com"),
+					v1beta1test.WithRemoteProxyAuthServerRef("MCPExternalAuthConfig", "valid"),
+				)
 			},
 			authConfig: func() *mcpv1beta1.MCPExternalAuthConfig {
 				return &mcpv1beta1.MCPExternalAuthConfig{

--- a/cmd/thv-operator/controllers/mcpremoteproxy_authzconfig_test.go
+++ b/cmd/thv-operator/controllers/mcpremoteproxy_authzconfig_test.go
@@ -15,6 +15,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1/v1beta1test"
 )
 
 func TestMCPRemoteProxyReconciler_handleAuthzConfig(t *testing.T) {
@@ -34,28 +35,24 @@ func TestMCPRemoteProxyReconciler_handleAuthzConfig(t *testing.T) {
 	}{
 		{
 			name: "no ref clears stored hash and condition",
-			proxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "default"},
-				Status: mcpv1beta1.MCPRemoteProxyStatus{
+			proxy: v1beta1test.NewMCPRemoteProxy("p", "default",
+				v1beta1test.WithRemoteProxyStatus(mcpv1beta1.MCPRemoteProxyStatus{
 					AuthzConfigHash: "old",
 					Conditions: []metav1.Condition{{
 						Type:   mcpv1beta1.ConditionAuthzConfigRefValidated,
 						Status: metav1.ConditionTrue,
 						Reason: mcpv1beta1.ConditionReasonAuthzConfigRefValid,
 					}},
-				},
-			},
+				}),
+			),
 			expectHashCleared:   true,
 			expectConditionGone: true,
 		},
 		{
 			name: "referenced config not found sets NotFound condition",
-			proxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "default"},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					AuthzConfigRef: &mcpv1beta1.MCPAuthzConfigReference{Name: "missing"},
-				},
-			},
+			proxy: v1beta1test.NewMCPRemoteProxy("p", "default",
+				v1beta1test.WithRemoteProxyAuthzConfigRef("missing"),
+			),
 			expectError:           true,
 			expectErrContains:     "not found",
 			expectConditionStatus: conditionStatusPtr(metav1.ConditionFalse),
@@ -63,12 +60,9 @@ func TestMCPRemoteProxyReconciler_handleAuthzConfig(t *testing.T) {
 		},
 		{
 			name: "referenced config not valid sets NotValid condition",
-			proxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "default"},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					AuthzConfigRef: &mcpv1beta1.MCPAuthzConfigReference{Name: "bad"},
-				},
-			},
+			proxy: v1beta1test.NewMCPRemoteProxy("p", "default",
+				v1beta1test.WithRemoteProxyAuthzConfigRef("bad"),
+			),
 			authzConfig:           authzConfigForTest("bad", false, ""),
 			expectError:           true,
 			expectErrContains:     "not valid",
@@ -77,12 +71,9 @@ func TestMCPRemoteProxyReconciler_handleAuthzConfig(t *testing.T) {
 		},
 		{
 			name: "valid ref sets condition True and tracks hash",
-			proxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "default"},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					AuthzConfigRef: &mcpv1beta1.MCPAuthzConfigReference{Name: "ok"},
-				},
-			},
+			proxy: v1beta1test.NewMCPRemoteProxy("p", "default",
+				v1beta1test.WithRemoteProxyAuthzConfigRef("ok"),
+			),
 			authzConfig:           authzConfigForTest("ok", true, "hash-123"),
 			expectHash:            "hash-123",
 			expectConditionStatus: conditionStatusPtr(metav1.ConditionTrue),
@@ -154,12 +145,9 @@ func TestMCPRemoteProxyReconciler_handleAuthzConfig_Transitions(t *testing.T) {
 	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
 
 	authzConfig := authzConfigForTest("cfg", true, "h1")
-	proxy := &mcpv1beta1.MCPRemoteProxy{
-		ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "default"},
-		Spec: mcpv1beta1.MCPRemoteProxySpec{
-			AuthzConfigRef: &mcpv1beta1.MCPAuthzConfigReference{Name: "cfg"},
-		},
-	}
+	proxy := v1beta1test.NewMCPRemoteProxy("p", "default",
+		v1beta1test.WithRemoteProxyAuthzConfigRef("cfg"),
+	)
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithObjects(proxy, authzConfig).
@@ -210,22 +198,13 @@ func TestMapAuthzConfigToMCPRemoteProxy(t *testing.T) {
 	scheme := runtime.NewScheme()
 	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
 
-	proxy1 := &mcpv1beta1.MCPRemoteProxy{
-		ObjectMeta: metav1.ObjectMeta{Name: "proxy1", Namespace: "default"},
-		Spec: mcpv1beta1.MCPRemoteProxySpec{
-			AuthzConfigRef: &mcpv1beta1.MCPAuthzConfigReference{Name: "shared-authz"},
-		},
-	}
-	proxy2 := &mcpv1beta1.MCPRemoteProxy{
-		ObjectMeta: metav1.ObjectMeta{Name: "proxy2", Namespace: "default"},
-		Spec: mcpv1beta1.MCPRemoteProxySpec{
-			AuthzConfigRef: &mcpv1beta1.MCPAuthzConfigReference{Name: "other-authz"},
-		},
-	}
-	proxy3 := &mcpv1beta1.MCPRemoteProxy{
-		ObjectMeta: metav1.ObjectMeta{Name: "proxy3", Namespace: "default"},
-		Spec:       mcpv1beta1.MCPRemoteProxySpec{}, // no ref
-	}
+	proxy1 := v1beta1test.NewMCPRemoteProxy("proxy1", "default",
+		v1beta1test.WithRemoteProxyAuthzConfigRef("shared-authz"),
+	)
+	proxy2 := v1beta1test.NewMCPRemoteProxy("proxy2", "default",
+		v1beta1test.WithRemoteProxyAuthzConfigRef("other-authz"),
+	)
+	proxy3 := v1beta1test.NewMCPRemoteProxy("proxy3", "default") // no ref
 
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(scheme).

--- a/cmd/thv-operator/controllers/mcpremoteproxy_controller_test.go
+++ b/cmd/thv-operator/controllers/mcpremoteproxy_controller_test.go
@@ -34,6 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1/v1beta1test"
 	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 	ctrlutil "github.com/stacklok/toolhive/cmd/thv-operator/pkg/controllerutil"
 )
@@ -49,30 +50,14 @@ func TestMCPRemoteProxyValidateSpec(t *testing.T) {
 		errContains string
 	}{
 		{
-			name: "valid spec",
-			proxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "valid-proxy",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					RemoteURL: "https://mcp.salesforce.com",
-					ProxyPort: 8080,
-				},
-			},
+			name:        "valid spec",
+			proxy:       v1beta1test.NewMCPRemoteProxy("valid-proxy", "default", v1beta1test.WithRemoteProxyURL("https://mcp.salesforce.com")),
 			expectError: false,
 		},
 		{
 			name: "missing remote URL",
-			proxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "no-url-proxy",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					ProxyPort: 8080,
-				},
-			},
+			proxy: v1beta1test.NewMCPRemoteProxy("no-url-proxy", "default",
+				v1beta1test.WithRemoteProxyURL("")),
 			expectError: true,
 			errContains: "remote URL must not be empty",
 		},
@@ -80,19 +65,8 @@ func TestMCPRemoteProxyValidateSpec(t *testing.T) {
 		// with kubebuilder:validation:Required, so the API server prevents resources without it
 		{
 			name: "with valid external auth config",
-			proxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "external-auth-proxy",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					RemoteURL: "https://mcp.example.com",
-					ProxyPort: 8080,
-					ExternalAuthConfigRef: &mcpv1beta1.ExternalAuthConfigRef{
-						Name: "exchange-config",
-					},
-				},
-			},
+			proxy: v1beta1test.NewMCPRemoteProxy("external-auth-proxy", "default",
+				v1beta1test.WithRemoteProxyExternalAuthConfigRef("exchange-config")),
 			expectError: true,
 			errContains: "failed to validate external auth config",
 		},
@@ -131,16 +105,8 @@ func TestMCPRemoteProxyValidateSpec(t *testing.T) {
 func TestMCPRemoteProxyReconcile_CreateResources(t *testing.T) {
 	t.Parallel()
 
-	proxy := &mcpv1beta1.MCPRemoteProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-proxy",
-			Namespace: "test-ns",
-		},
-		Spec: mcpv1beta1.MCPRemoteProxySpec{
-			RemoteURL: "https://mcp.salesforce.com",
-			ProxyPort: 8080,
-		},
-	}
+	proxy := v1beta1test.NewMCPRemoteProxy("test-proxy", "test-ns",
+		v1beta1test.WithRemoteProxyURL("https://mcp.salesforce.com"))
 
 	scheme := testutil.NewScheme(t)
 	// Add RBAC types to scheme
@@ -264,33 +230,15 @@ func TestHandleToolConfig(t *testing.T) {
 		expectedCondReason string
 	}{
 		{
-			name: "no tool config reference",
-			proxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "no-tools-proxy",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					RemoteURL: "https://mcp.example.com",
-				},
-			},
+			name:            "no tool config reference",
+			proxy:           v1beta1test.NewMCPRemoteProxy("no-tools-proxy", "default"),
 			expectError:     false,
 			expectCondition: false, // Condition should be removed when no reference
 		},
 		{
 			name: "valid tool config reference",
-			proxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "tools-proxy",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					RemoteURL: "https://mcp.example.com",
-					ToolConfigRef: &mcpv1beta1.ToolConfigRef{
-						Name: "tool-config",
-					},
-				},
-			},
+			proxy: v1beta1test.NewMCPRemoteProxy("tools-proxy", "default",
+				v1beta1test.WithRemoteProxyToolConfigRef("tool-config")),
 			toolConfig: &mcpv1beta1.MCPToolConfig{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "tool-config",
@@ -310,21 +258,11 @@ func TestHandleToolConfig(t *testing.T) {
 		},
 		{
 			name: "tool config hash update",
-			proxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "tools-proxy",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					RemoteURL: "https://mcp.example.com",
-					ToolConfigRef: &mcpv1beta1.ToolConfigRef{
-						Name: "tool-config",
-					},
-				},
-				Status: mcpv1beta1.MCPRemoteProxyStatus{
+			proxy: v1beta1test.NewMCPRemoteProxy("tools-proxy", "default",
+				v1beta1test.WithRemoteProxyToolConfigRef("tool-config"),
+				v1beta1test.WithRemoteProxyStatus(mcpv1beta1.MCPRemoteProxyStatus{
 					ToolConfigHash: "old-hash",
-				},
-			},
+				})),
 			toolConfig: &mcpv1beta1.MCPToolConfig{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "tool-config",
@@ -344,35 +282,17 @@ func TestHandleToolConfig(t *testing.T) {
 		},
 		{
 			name: "tool config reference removed",
-			proxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "tools-proxy",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					RemoteURL: "https://mcp.example.com",
-				},
-				Status: mcpv1beta1.MCPRemoteProxyStatus{
+			proxy: v1beta1test.NewMCPRemoteProxy("tools-proxy", "default",
+				v1beta1test.WithRemoteProxyStatus(mcpv1beta1.MCPRemoteProxyStatus{
 					ToolConfigHash: "old-hash",
-				},
-			},
+				})),
 			expectError:     false,
 			expectCondition: false, // Condition should be removed when reference is removed
 		},
 		{
 			name: "tool config not found",
-			proxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "broken-proxy",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					RemoteURL: "https://mcp.example.com",
-					ToolConfigRef: &mcpv1beta1.ToolConfigRef{
-						Name: "non-existent",
-					},
-				},
-			},
+			proxy: v1beta1test.NewMCPRemoteProxy("broken-proxy", "default",
+				v1beta1test.WithRemoteProxyToolConfigRef("non-existent")),
 			expectError:        true,
 			errContains:        "not found in namespace",
 			expectCondition:    true,
@@ -381,18 +301,8 @@ func TestHandleToolConfig(t *testing.T) {
 		},
 		{
 			name: "tool config fetch error",
-			proxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "error-proxy",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					RemoteURL: "https://mcp.example.com",
-					ToolConfigRef: &mcpv1beta1.ToolConfigRef{
-						Name: "tool-config",
-					},
-				},
-			},
+			proxy: v1beta1test.NewMCPRemoteProxy("error-proxy", "default",
+				v1beta1test.WithRemoteProxyToolConfigRef("tool-config")),
 			interceptorFuncs: &interceptor.Funcs{
 				Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
 					if _, ok := obj.(*mcpv1beta1.MCPToolConfig); ok {
@@ -512,33 +422,15 @@ func TestHandleExternalAuthConfig(t *testing.T) {
 		expectedCondMessage string // when set, asserts the condition's Message verbatim
 	}{
 		{
-			name: "no external auth reference",
-			proxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "no-auth-proxy",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					RemoteURL: "https://mcp.example.com",
-				},
-			},
+			name:            "no external auth reference",
+			proxy:           v1beta1test.NewMCPRemoteProxy("no-auth-proxy", "default"),
 			expectError:     false,
 			expectCondition: false, // Condition should be removed when no reference
 		},
 		{
 			name: "valid external auth reference",
-			proxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "auth-proxy",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					RemoteURL: "https://mcp.example.com",
-					ExternalAuthConfigRef: &mcpv1beta1.ExternalAuthConfigRef{
-						Name: "auth-config",
-					},
-				},
-			},
+			proxy: v1beta1test.NewMCPRemoteProxy("auth-proxy", "default",
+				v1beta1test.WithRemoteProxyExternalAuthConfigRef("auth-config")),
 			externalAuth: &mcpv1beta1.MCPExternalAuthConfig{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "auth-config",
@@ -567,21 +459,11 @@ func TestHandleExternalAuthConfig(t *testing.T) {
 		},
 		{
 			name: "external auth config hash update",
-			proxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "auth-proxy",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					RemoteURL: "https://mcp.example.com",
-					ExternalAuthConfigRef: &mcpv1beta1.ExternalAuthConfigRef{
-						Name: "auth-config",
-					},
-				},
-				Status: mcpv1beta1.MCPRemoteProxyStatus{
+			proxy: v1beta1test.NewMCPRemoteProxy("auth-proxy", "default",
+				v1beta1test.WithRemoteProxyExternalAuthConfigRef("auth-config"),
+				v1beta1test.WithRemoteProxyStatus(mcpv1beta1.MCPRemoteProxyStatus{
 					ExternalAuthConfigHash: "old-hash",
-				},
-			},
+				})),
 			externalAuth: &mcpv1beta1.MCPExternalAuthConfig{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "auth-config",
@@ -610,35 +492,17 @@ func TestHandleExternalAuthConfig(t *testing.T) {
 		},
 		{
 			name: "external auth config reference removed",
-			proxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "auth-proxy",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					RemoteURL: "https://mcp.example.com",
-				},
-				Status: mcpv1beta1.MCPRemoteProxyStatus{
+			proxy: v1beta1test.NewMCPRemoteProxy("auth-proxy", "default",
+				v1beta1test.WithRemoteProxyStatus(mcpv1beta1.MCPRemoteProxyStatus{
 					ExternalAuthConfigHash: "old-hash",
-				},
-			},
+				})),
 			expectError:     false,
 			expectCondition: false, // Condition should be removed when reference is removed
 		},
 		{
 			name: "external auth config not found",
-			proxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "broken-proxy",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					RemoteURL: "https://mcp.example.com",
-					ExternalAuthConfigRef: &mcpv1beta1.ExternalAuthConfigRef{
-						Name: "non-existent",
-					},
-				},
-			},
+			proxy: v1beta1test.NewMCPRemoteProxy("broken-proxy", "default",
+				v1beta1test.WithRemoteProxyExternalAuthConfigRef("non-existent")),
 			expectError:        true,
 			errContains:        "not found in namespace",
 			expectCondition:    true,
@@ -647,18 +511,8 @@ func TestHandleExternalAuthConfig(t *testing.T) {
 		},
 		{
 			name: "external auth config fetch error",
-			proxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "error-proxy",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					RemoteURL: "https://mcp.example.com",
-					ExternalAuthConfigRef: &mcpv1beta1.ExternalAuthConfigRef{
-						Name: "auth-config",
-					},
-				},
-			},
+			proxy: v1beta1test.NewMCPRemoteProxy("error-proxy", "default",
+				v1beta1test.WithRemoteProxyExternalAuthConfigRef("auth-config")),
 			interceptorFuncs: &interceptor.Funcs{
 				Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
 					if _, ok := obj.(*mcpv1beta1.MCPExternalAuthConfig); ok {
@@ -681,19 +535,11 @@ func TestHandleExternalAuthConfig(t *testing.T) {
 			// parallel ExternalAuthConfigValidated=False with the same reason
 			// and message.
 			name: "referenced config Valid=False is mirrored onto the proxy",
-			proxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:       "obo-mirror-proxy",
-					Namespace:  "default",
-					Generation: 7,
-				},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					RemoteURL: "https://mcp.example.com",
-					ExternalAuthConfigRef: &mcpv1beta1.ExternalAuthConfigRef{
-						Name: "obo-config",
-					},
-				},
-			},
+			proxy: v1beta1test.NewMCPRemoteProxy("obo-mirror-proxy", "default",
+				v1beta1test.WithRemoteProxyExternalAuthConfigRef("obo-config"),
+				v1beta1test.MutateRemoteProxy(func(p *mcpv1beta1.MCPRemoteProxy) {
+					p.Generation = 7
+				})),
 			externalAuth: &mcpv1beta1.MCPExternalAuthConfig{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "obo-config",
@@ -721,18 +567,8 @@ func TestHandleExternalAuthConfig(t *testing.T) {
 		},
 		{
 			name: "embedded auth server with multiple upstreams rejected",
-			proxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "multi-upstream-proxy",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					RemoteURL: "https://mcp.example.com",
-					ExternalAuthConfigRef: &mcpv1beta1.ExternalAuthConfigRef{
-						Name: "multi-upstream-config",
-					},
-				},
-			},
+			proxy: v1beta1test.NewMCPRemoteProxy("multi-upstream-proxy", "default",
+				v1beta1test.WithRemoteProxyExternalAuthConfigRef("multi-upstream-config")),
 			externalAuth: &mcpv1beta1.MCPExternalAuthConfig{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "multi-upstream-config",
@@ -908,16 +744,7 @@ func TestServiceNameGeneration(t *testing.T) {
 func TestEnsureRBACResources(t *testing.T) {
 	t.Parallel()
 
-	proxy := &mcpv1beta1.MCPRemoteProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "rbac-proxy",
-			Namespace: "default",
-		},
-		Spec: mcpv1beta1.MCPRemoteProxySpec{
-			RemoteURL: "https://mcp.example.com",
-			ProxyPort: 8080,
-		},
-	}
+	proxy := v1beta1test.NewMCPRemoteProxy("rbac-proxy", "default")
 
 	scheme := testutil.NewScheme(t)
 	// Add RBAC types to scheme
@@ -967,17 +794,10 @@ func TestEnsureRBACResources(t *testing.T) {
 func TestMCPRemoteProxyEnsureRBACResources_Update(t *testing.T) {
 	t.Parallel()
 
-	proxy := &mcpv1beta1.MCPRemoteProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "update-proxy",
-			Namespace: "default",
-			UID:       "test-uid",
-		},
-		Spec: mcpv1beta1.MCPRemoteProxySpec{
-			RemoteURL: "https://mcp.example.com",
-			ProxyPort: 8080,
-		},
-	}
+	proxy := v1beta1test.NewMCPRemoteProxy("update-proxy", "default",
+		v1beta1test.MutateRemoteProxy(func(p *mcpv1beta1.MCPRemoteProxy) {
+			p.UID = "test-uid"
+		}))
 
 	scheme := testutil.NewScheme(t)
 	_ = rbacv1.AddToScheme(scheme)
@@ -1050,16 +870,7 @@ func TestMCPRemoteProxyEnsureRBACResources_Update(t *testing.T) {
 func TestMCPRemoteProxyEnsureRBACResources_Idempotency(t *testing.T) {
 	t.Parallel()
 
-	proxy := &mcpv1beta1.MCPRemoteProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "idempotent-proxy",
-			Namespace: "default",
-		},
-		Spec: mcpv1beta1.MCPRemoteProxySpec{
-			RemoteURL: "https://mcp.example.com",
-			ProxyPort: 8080,
-		},
-	}
+	proxy := v1beta1test.NewMCPRemoteProxy("idempotent-proxy", "default")
 
 	scheme := testutil.NewScheme(t)
 	_ = rbacv1.AddToScheme(scheme)
@@ -1111,18 +922,8 @@ func TestMCPRemoteProxyEnsureRBACResources_Idempotency(t *testing.T) {
 func TestMCPRemoteProxyEnsureRBACResources_CustomServiceAccount(t *testing.T) {
 	t.Parallel()
 
-	customSA := "custom-proxy-sa"
-	proxy := &mcpv1beta1.MCPRemoteProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "custom-sa-proxy",
-			Namespace: "default",
-		},
-		Spec: mcpv1beta1.MCPRemoteProxySpec{
-			RemoteURL:      "https://mcp.example.com",
-			ProxyPort:      8080,
-			ServiceAccount: &customSA,
-		},
-	}
+	proxy := v1beta1test.NewMCPRemoteProxy("custom-sa-proxy", "default",
+		v1beta1test.WithRemoteProxyServiceAccount("custom-proxy-sa"))
 
 	scheme := testutil.NewScheme(t)
 	_ = rbacv1.AddToScheme(scheme)
@@ -1172,23 +973,16 @@ func TestMCPRemoteProxyEnsureRBACResources_CustomServiceAccount(t *testing.T) {
 func TestMCPRemoteProxyEnsureRBACResources_ImagePullSecrets(t *testing.T) {
 	t.Parallel()
 
-	proxy := &mcpv1beta1.MCPRemoteProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "pull-secrets-proxy",
-			Namespace: "default",
-		},
-		Spec: mcpv1beta1.MCPRemoteProxySpec{
-			RemoteURL: "https://mcp.example.com",
-			ProxyPort: 8080,
-			ResourceOverrides: &mcpv1beta1.ResourceOverrides{
+	proxy := v1beta1test.NewMCPRemoteProxy("pull-secrets-proxy", "default",
+		v1beta1test.MutateRemoteProxy(func(p *mcpv1beta1.MCPRemoteProxy) {
+			p.Spec.ResourceOverrides = &mcpv1beta1.ResourceOverrides{
 				ProxyDeployment: &mcpv1beta1.ProxyDeploymentOverrides{
 					ImagePullSecrets: []corev1.LocalObjectReference{
 						{Name: "my-registry-secret"},
 					},
 				},
-			},
-		},
-	}
+			}
+		}))
 
 	scheme := testutil.NewScheme(t)
 	_ = rbacv1.AddToScheme(scheme)
@@ -1239,16 +1033,8 @@ func TestUpdateMCPRemoteProxyStatus(t *testing.T) {
 		expectedPhase mcpv1beta1.MCPRemoteProxyPhase
 	}{
 		{
-			name: "running pod",
-			proxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "running-proxy",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					RemoteURL: "https://mcp.example.com",
-				},
-			},
+			name:  "running pod",
+			proxy: v1beta1test.NewMCPRemoteProxy("running-proxy", "default"),
 			pods: []corev1.Pod{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -1264,16 +1050,8 @@ func TestUpdateMCPRemoteProxyStatus(t *testing.T) {
 			expectedPhase: mcpv1beta1.MCPRemoteProxyPhaseReady,
 		},
 		{
-			name: "pending pod",
-			proxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "pending-proxy",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					RemoteURL: "https://mcp.example.com",
-				},
-			},
+			name:  "pending pod",
+			proxy: v1beta1test.NewMCPRemoteProxy("pending-proxy", "default"),
 			pods: []corev1.Pod{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -1289,16 +1067,8 @@ func TestUpdateMCPRemoteProxyStatus(t *testing.T) {
 			expectedPhase: mcpv1beta1.MCPRemoteProxyPhasePending,
 		},
 		{
-			name: "failed pod",
-			proxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "failed-proxy",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					RemoteURL: "https://mcp.example.com",
-				},
-			},
+			name:  "failed pod",
+			proxy: v1beta1test.NewMCPRemoteProxy("failed-proxy", "default"),
 			pods: []corev1.Pod{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -1314,16 +1084,8 @@ func TestUpdateMCPRemoteProxyStatus(t *testing.T) {
 			expectedPhase: mcpv1beta1.MCPRemoteProxyPhaseFailed,
 		},
 		{
-			name: "no pods",
-			proxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "no-pods-proxy",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					RemoteURL: "https://mcp.example.com",
-				},
-			},
+			name:          "no pods",
+			proxy:         v1beta1test.NewMCPRemoteProxy("no-pods-proxy", "default"),
 			pods:          []corev1.Pod{},
 			expectedPhase: mcpv1beta1.MCPRemoteProxyPhasePending,
 		},
@@ -1379,17 +1141,10 @@ func TestGetToolConfigForMCPRemoteProxy(t *testing.T) {
 		},
 	}
 
-	proxy := &mcpv1beta1.MCPRemoteProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-proxy",
-			Namespace: "default",
-		},
-		Spec: mcpv1beta1.MCPRemoteProxySpec{
-			ToolConfigRef: &mcpv1beta1.ToolConfigRef{
-				Name: "test-tools",
-			},
-		},
-	}
+	proxy := v1beta1test.NewMCPRemoteProxy("test-proxy", "default",
+		v1beta1test.WithRemoteProxyURL(""),
+		v1beta1test.WithRemoteProxyPort(0),
+		v1beta1test.WithRemoteProxyToolConfigRef("test-tools"))
 
 	scheme := testutil.NewScheme(t)
 	fakeClient := fake.NewClientBuilder().
@@ -1417,17 +1172,10 @@ func TestGetExternalAuthConfigForMCPRemoteProxy(t *testing.T) {
 		},
 	}
 
-	proxy := &mcpv1beta1.MCPRemoteProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-proxy",
-			Namespace: "default",
-		},
-		Spec: mcpv1beta1.MCPRemoteProxySpec{
-			ExternalAuthConfigRef: &mcpv1beta1.ExternalAuthConfigRef{
-				Name: "test-auth",
-			},
-		},
-	}
+	proxy := v1beta1test.NewMCPRemoteProxy("test-proxy", "default",
+		v1beta1test.WithRemoteProxyURL(""),
+		v1beta1test.WithRemoteProxyPort(0),
+		v1beta1test.WithRemoteProxyExternalAuthConfigRef("test-auth"))
 
 	scheme := testutil.NewScheme(t)
 	fakeClient := fake.NewClientBuilder().

--- a/cmd/thv-operator/controllers/mcpremoteproxy_default_imagepullsecrets_test.go
+++ b/cmd/thv-operator/controllers/mcpremoteproxy_default_imagepullsecrets_test.go
@@ -10,11 +10,11 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1/v1beta1test"
 	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 	ctrlutil "github.com/stacklok/toolhive/cmd/thv-operator/pkg/controllerutil"
 	"github.com/stacklok/toolhive/cmd/thv-operator/pkg/imagepullsecrets"
@@ -59,16 +59,7 @@ func TestMCPRemoteProxy_DefaultImagePullSecrets(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			proxy := &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "default-pullsecrets-proxy",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					RemoteURL: "https://mcp.example.com",
-					ProxyPort: 8080,
-				},
-			}
+			proxy := v1beta1test.NewMCPRemoteProxy("default-pullsecrets-proxy", "default")
 			if tt.crSecrets != nil {
 				proxy.Spec.ResourceOverrides = &mcpv1beta1.ResourceOverrides{
 					ProxyDeployment: &mcpv1beta1.ProxyDeploymentOverrides{

--- a/cmd/thv-operator/controllers/mcpremoteproxy_deployment_test.go
+++ b/cmd/thv-operator/controllers/mcpremoteproxy_deployment_test.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1/v1beta1test"
 	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 	ctrlutil "github.com/stacklok/toolhive/cmd/thv-operator/pkg/controllerutil"
 	"github.com/stacklok/toolhive/pkg/transport/session"
@@ -44,17 +45,8 @@ func TestDeploymentForMCPRemoteProxy(t *testing.T) {
 		validate func(*testing.T, *appsv1.Deployment)
 	}{
 		{
-			name: "basic deployment",
-			proxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "basic-proxy",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					RemoteURL: "https://mcp.example.com",
-					ProxyPort: 8080,
-				},
-			},
+			name:  "basic deployment",
+			proxy: v1beta1test.NewMCPRemoteProxy("basic-proxy", "default"),
 			validate: func(t *testing.T, dep *appsv1.Deployment) {
 				t.Helper()
 				assert.Equal(t, "basic-proxy", dep.Name)
@@ -90,15 +82,9 @@ func TestDeploymentForMCPRemoteProxy(t *testing.T) {
 		},
 		{
 			name: "with resource limits",
-			proxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "resources-proxy",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					RemoteURL: "https://mcp.example.com",
-					ProxyPort: 8080,
-					Resources: mcpv1beta1.ResourceRequirements{
+			proxy: v1beta1test.NewMCPRemoteProxy("resources-proxy", "default",
+				v1beta1test.MutateRemoteProxy(func(p *mcpv1beta1.MCPRemoteProxy) {
+					p.Spec.Resources = mcpv1beta1.ResourceRequirements{
 						Limits: mcpv1beta1.ResourceList{
 							CPU:    "1",
 							Memory: "512Mi",
@@ -107,9 +93,9 @@ func TestDeploymentForMCPRemoteProxy(t *testing.T) {
 							CPU:    "100m",
 							Memory: "128Mi",
 						},
-					},
-				},
-			},
+					}
+				}),
+			),
 			validate: func(t *testing.T, dep *appsv1.Deployment) {
 				t.Helper()
 				container := dep.Spec.Template.Spec.Containers[0]
@@ -121,15 +107,9 @@ func TestDeploymentForMCPRemoteProxy(t *testing.T) {
 		},
 		{
 			name: "with resource overrides",
-			proxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "override-proxy",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					RemoteURL: "https://mcp.example.com",
-					ProxyPort: 8080,
-					ResourceOverrides: &mcpv1beta1.ResourceOverrides{
+			proxy: v1beta1test.NewMCPRemoteProxy("override-proxy", "default",
+				v1beta1test.MutateRemoteProxy(func(p *mcpv1beta1.MCPRemoteProxy) {
+					p.Spec.ResourceOverrides = &mcpv1beta1.ResourceOverrides{
 						ProxyDeployment: &mcpv1beta1.ProxyDeploymentOverrides{
 							ResourceMetadataOverrides: mcpv1beta1.ResourceMetadataOverrides{
 								Labels: map[string]string{
@@ -144,9 +124,9 @@ func TestDeploymentForMCPRemoteProxy(t *testing.T) {
 								{Name: "TOOLHIVE_DEBUG", Value: "true"},
 							},
 						},
-					},
-				},
-			},
+					}
+				}),
+			),
 			validate: func(t *testing.T, dep *appsv1.Deployment) {
 				t.Helper()
 				// Verify custom labels
@@ -181,16 +161,9 @@ func TestDeploymentForMCPRemoteProxy(t *testing.T) {
 		},
 		{
 			name: "custom proxyPort",
-			proxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "custom-port-proxy",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					RemoteURL: "https://mcp.example.com",
-					ProxyPort: 9090,
-				},
-			},
+			proxy: v1beta1test.NewMCPRemoteProxy("custom-port-proxy", "default",
+				v1beta1test.WithRemoteProxyPort(9090),
+			),
 			validate: func(t *testing.T, dep *appsv1.Deployment) {
 				t.Helper()
 				container := dep.Spec.Template.Spec.Containers[0]
@@ -229,17 +202,8 @@ func TestServiceForMCPRemoteProxy(t *testing.T) {
 		validate func(*testing.T, *corev1.Service)
 	}{
 		{
-			name: "basic service",
-			proxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "basic-proxy",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					RemoteURL: "https://mcp.example.com",
-					ProxyPort: 8080,
-				},
-			},
+			name:  "basic service",
+			proxy: v1beta1test.NewMCPRemoteProxy("basic-proxy", "default"),
 			validate: func(t *testing.T, svc *corev1.Service) {
 				t.Helper()
 				assert.Equal(t, createProxyServiceName("basic-proxy"), svc.Name)
@@ -259,17 +223,11 @@ func TestServiceForMCPRemoteProxy(t *testing.T) {
 		},
 		{
 			name: "service with session affinity None",
-			proxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "basic-proxy",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					RemoteURL:       "https://mcp.example.com",
-					ProxyPort:       8080,
-					SessionAffinity: string(corev1.ServiceAffinityNone),
-				},
-			},
+			proxy: v1beta1test.NewMCPRemoteProxy("basic-proxy", "default",
+				v1beta1test.MutateRemoteProxy(func(p *mcpv1beta1.MCPRemoteProxy) {
+					p.Spec.SessionAffinity = string(corev1.ServiceAffinityNone)
+				}),
+			),
 			validate: func(t *testing.T, svc *corev1.Service) {
 				t.Helper()
 				assert.Equal(t, corev1.ServiceAffinityNone, svc.Spec.SessionAffinity)
@@ -277,15 +235,10 @@ func TestServiceForMCPRemoteProxy(t *testing.T) {
 		},
 		{
 			name: "service with overrides",
-			proxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "override-proxy",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					RemoteURL: "https://mcp.example.com",
-					ProxyPort: 9090,
-					ResourceOverrides: &mcpv1beta1.ResourceOverrides{
+			proxy: v1beta1test.NewMCPRemoteProxy("override-proxy", "default",
+				v1beta1test.WithRemoteProxyPort(9090),
+				v1beta1test.MutateRemoteProxy(func(p *mcpv1beta1.MCPRemoteProxy) {
+					p.Spec.ResourceOverrides = &mcpv1beta1.ResourceOverrides{
 						ProxyService: &mcpv1beta1.ResourceMetadataOverrides{
 							Labels: map[string]string{
 								"svc-label": "svc-value",
@@ -294,9 +247,9 @@ func TestServiceForMCPRemoteProxy(t *testing.T) {
 								"svc-annotation": "svc-annotation-value",
 							},
 						},
-					},
-				},
-			},
+					}
+				}),
+			),
 			validate: func(t *testing.T, svc *corev1.Service) {
 				t.Helper()
 				assert.Equal(t, "svc-value", svc.Labels["svc-label"])
@@ -390,25 +343,19 @@ func TestBuildHeaderForwardSecretEnvVars(t *testing.T) {
 	}{
 		{
 			name: "single header secret",
-			proxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-proxy",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					HeaderForward: &mcpv1beta1.HeaderForwardConfig{
-						AddHeadersFromSecret: []mcpv1beta1.HeaderFromSecret{
-							{
-								HeaderName: "X-API-Key",
-								ValueSecretRef: &mcpv1beta1.SecretKeyRef{
-									Name: "my-secret",
-									Key:  "api-key",
-								},
+			proxy: v1beta1test.NewMCPRemoteProxy("test-proxy", "default",
+				v1beta1test.WithRemoteProxyHeaderForward(&mcpv1beta1.HeaderForwardConfig{
+					AddHeadersFromSecret: []mcpv1beta1.HeaderFromSecret{
+						{
+							HeaderName: "X-API-Key",
+							ValueSecretRef: &mcpv1beta1.SecretKeyRef{
+								Name: "my-secret",
+								Key:  "api-key",
 							},
 						},
 					},
-				},
-			},
+				}),
+			),
 			validate: func(t *testing.T, envVars []corev1.EnvVar) {
 				t.Helper()
 				require.Len(t, envVars, 1)
@@ -421,32 +368,26 @@ func TestBuildHeaderForwardSecretEnvVars(t *testing.T) {
 		},
 		{
 			name: "multiple header secrets",
-			proxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "multi-proxy",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					HeaderForward: &mcpv1beta1.HeaderForwardConfig{
-						AddHeadersFromSecret: []mcpv1beta1.HeaderFromSecret{
-							{
-								HeaderName: "X-API-Key",
-								ValueSecretRef: &mcpv1beta1.SecretKeyRef{
-									Name: "secret-a",
-									Key:  "key-a",
-								},
+			proxy: v1beta1test.NewMCPRemoteProxy("multi-proxy", "default",
+				v1beta1test.WithRemoteProxyHeaderForward(&mcpv1beta1.HeaderForwardConfig{
+					AddHeadersFromSecret: []mcpv1beta1.HeaderFromSecret{
+						{
+							HeaderName: "X-API-Key",
+							ValueSecretRef: &mcpv1beta1.SecretKeyRef{
+								Name: "secret-a",
+								Key:  "key-a",
 							},
-							{
-								HeaderName: "X-Token",
-								ValueSecretRef: &mcpv1beta1.SecretKeyRef{
-									Name: "secret-b",
-									Key:  "key-b",
-								},
+						},
+						{
+							HeaderName: "X-Token",
+							ValueSecretRef: &mcpv1beta1.SecretKeyRef{
+								Name: "secret-b",
+								Key:  "key-b",
 							},
 						},
 					},
-				},
-			},
+				}),
+			),
 			validate: func(t *testing.T, envVars []corev1.EnvVar) {
 				t.Helper()
 				require.Len(t, envVars, 2)
@@ -460,29 +401,23 @@ func TestBuildHeaderForwardSecretEnvVars(t *testing.T) {
 		},
 		{
 			name: "skip entries with nil ValueSecretRef",
-			proxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "skip-proxy",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					HeaderForward: &mcpv1beta1.HeaderForwardConfig{
-						AddHeadersFromSecret: []mcpv1beta1.HeaderFromSecret{
-							{
-								HeaderName:     "X-Invalid",
-								ValueSecretRef: nil, // Should be skipped
-							},
-							{
-								HeaderName: "X-Valid",
-								ValueSecretRef: &mcpv1beta1.SecretKeyRef{
-									Name: "valid-secret",
-									Key:  "valid-key",
-								},
+			proxy: v1beta1test.NewMCPRemoteProxy("skip-proxy", "default",
+				v1beta1test.WithRemoteProxyHeaderForward(&mcpv1beta1.HeaderForwardConfig{
+					AddHeadersFromSecret: []mcpv1beta1.HeaderFromSecret{
+						{
+							HeaderName:     "X-Invalid",
+							ValueSecretRef: nil, // Should be skipped
+						},
+						{
+							HeaderName: "X-Valid",
+							ValueSecretRef: &mcpv1beta1.SecretKeyRef{
+								Name: "valid-secret",
+								Key:  "valid-key",
 							},
 						},
 					},
-				},
-			},
+				}),
+			),
 			validate: func(t *testing.T, envVars []corev1.EnvVar) {
 				t.Helper()
 				require.Len(t, envVars, 1)
@@ -491,17 +426,11 @@ func TestBuildHeaderForwardSecretEnvVars(t *testing.T) {
 		},
 		{
 			name: "empty AddHeadersFromSecret",
-			proxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "empty-proxy",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					HeaderForward: &mcpv1beta1.HeaderForwardConfig{
-						AddHeadersFromSecret: []mcpv1beta1.HeaderFromSecret{},
-					},
-				},
-			},
+			proxy: v1beta1test.NewMCPRemoteProxy("empty-proxy", "default",
+				v1beta1test.WithRemoteProxyHeaderForward(&mcpv1beta1.HeaderForwardConfig{
+					AddHeadersFromSecret: []mcpv1beta1.HeaderFromSecret{},
+				}),
+			),
 			validate: func(t *testing.T, envVars []corev1.EnvVar) {
 				t.Helper()
 				assert.Empty(t, envVars)
@@ -549,32 +478,14 @@ func TestEnsureDeployment(t *testing.T) {
 		expectRequeue      bool
 	}{
 		{
-			name: "create new deployment",
-			proxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "new-proxy",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					RemoteURL: "https://mcp.example.com",
-					ProxyPort: 8080,
-				},
-			},
+			name:               "create new deployment",
+			proxy:              v1beta1test.NewMCPRemoteProxy("new-proxy", "default"),
 			existingDeployment: nil,
 			expectRequeue:      true,
 		},
 		{
-			name: "deployment exists - no update to allow HPA",
-			proxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "replica-proxy",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					RemoteURL: "https://mcp.example.com",
-					ProxyPort: 8080,
-				},
-			},
+			name:  "deployment exists - no update to allow HPA",
+			proxy: v1beta1test.NewMCPRemoteProxy("replica-proxy", "default"),
 			existingDeployment: &appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "replica-proxy",
@@ -653,17 +564,8 @@ func TestEnsureService(t *testing.T) {
 		expectRequeue   bool
 	}{
 		{
-			name: "create new service",
-			proxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "new-svc-proxy",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					RemoteURL: "https://mcp.example.com",
-					ProxyPort: 8080,
-				},
-			},
+			name:            "create new service",
+			proxy:           v1beta1test.NewMCPRemoteProxy("new-svc-proxy", "default"),
 			existingService: nil,
 			expectRequeue:   true,
 		},
@@ -734,19 +636,9 @@ func TestMCPRemoteProxyDeploymentNeedsUpdate_EmbeddedAuthLegacyEnvStable(t *test
 		},
 	}
 
-	proxy := &mcpv1beta1.MCPRemoteProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-proxy",
-			Namespace: "default",
-		},
-		Spec: mcpv1beta1.MCPRemoteProxySpec{
-			RemoteURL: "https://mcp.example.com",
-			ProxyPort: 8080,
-			ExternalAuthConfigRef: &mcpv1beta1.ExternalAuthConfigRef{
-				Name: authConfig.Name,
-			},
-		},
-	}
+	proxy := v1beta1test.NewMCPRemoteProxy("test-proxy", "default",
+		v1beta1test.WithRemoteProxyExternalAuthConfigRef(authConfig.Name),
+	)
 
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(scheme).
@@ -796,20 +688,9 @@ func TestMCPRemoteProxyDeploymentNeedsUpdate_EmbeddedAuthAuthServerRefEnvStable(
 		},
 	}
 
-	proxy := &mcpv1beta1.MCPRemoteProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-proxy",
-			Namespace: "default",
-		},
-		Spec: mcpv1beta1.MCPRemoteProxySpec{
-			RemoteURL: "https://mcp.example.com",
-			ProxyPort: 8080,
-			AuthServerRef: &mcpv1beta1.AuthServerRef{
-				Kind: "MCPExternalAuthConfig",
-				Name: authConfig.Name,
-			},
-		},
-	}
+	proxy := v1beta1test.NewMCPRemoteProxy("test-proxy", "default",
+		v1beta1test.WithRemoteProxyAuthServerRef("MCPExternalAuthConfig", authConfig.Name),
+	)
 
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(scheme).
@@ -852,19 +733,9 @@ func TestMCPRemoteProxyDeploymentNeedsUpdate_TokenExchangeDoesNotDrift(t *testin
 		},
 	}
 
-	proxy := &mcpv1beta1.MCPRemoteProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-proxy",
-			Namespace: "default",
-		},
-		Spec: mcpv1beta1.MCPRemoteProxySpec{
-			RemoteURL: "https://mcp.example.com",
-			ProxyPort: 8080,
-			ExternalAuthConfigRef: &mcpv1beta1.ExternalAuthConfigRef{
-				Name: authConfig.Name,
-			},
-		},
-	}
+	proxy := v1beta1test.NewMCPRemoteProxy("test-proxy", "default",
+		v1beta1test.WithRemoteProxyExternalAuthConfigRef(authConfig.Name),
+	)
 
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(scheme).
@@ -922,19 +793,9 @@ func TestMCPRemoteProxyDeployment_OBOSecretEnvVars(t *testing.T) {
 		},
 	}
 
-	proxy := &mcpv1beta1.MCPRemoteProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-proxy",
-			Namespace: "default",
-		},
-		Spec: mcpv1beta1.MCPRemoteProxySpec{
-			RemoteURL: "https://mcp.example.com",
-			ProxyPort: 8080,
-			ExternalAuthConfigRef: &mcpv1beta1.ExternalAuthConfigRef{
-				Name: authConfig.Name,
-			},
-		},
-	}
+	proxy := v1beta1test.NewMCPRemoteProxy("test-proxy", "default",
+		v1beta1test.WithRemoteProxyExternalAuthConfigRef(authConfig.Name),
+	)
 
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(scheme).
@@ -1018,16 +879,7 @@ func TestMCPRemoteProxyDeploymentNeedsUpdate_ImagePullSecretsDrift(t *testing.T)
 			scheme := testutil.NewScheme(t)
 			fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 
-			proxy := &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-proxy",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					RemoteURL: "https://mcp.example.com",
-					ProxyPort: 8080,
-				},
-			}
+			proxy := v1beta1test.NewMCPRemoteProxy("test-proxy", "default")
 			if tt.specSecrets != nil {
 				proxy.Spec.ResourceOverrides = &mcpv1beta1.ResourceOverrides{
 					ProxyDeployment: &mcpv1beta1.ProxyDeploymentOverrides{
@@ -1068,16 +920,8 @@ func TestBuildEnvVarsForProxy(t *testing.T) {
 		validate     func(*testing.T, []corev1.EnvVar)
 	}{
 		{
-			name: "basic env vars",
-			proxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "basic-proxy",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					RemoteURL: "https://mcp.example.com",
-				},
-			},
+			name:  "basic env vars",
+			proxy: v1beta1test.NewMCPRemoteProxy("basic-proxy", "default"),
 			validate: func(t *testing.T, envVars []corev1.EnvVar) {
 				t.Helper()
 				// Should have required env vars
@@ -1094,18 +938,9 @@ func TestBuildEnvVarsForProxy(t *testing.T) {
 		},
 		{
 			name: "with token exchange",
-			proxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "exchange-proxy",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					RemoteURL: "https://mcp.example.com",
-					ExternalAuthConfigRef: &mcpv1beta1.ExternalAuthConfigRef{
-						Name: "exchange-config",
-					},
-				},
-			},
+			proxy: v1beta1test.NewMCPRemoteProxy("exchange-proxy", "default",
+				v1beta1test.WithRemoteProxyExternalAuthConfigRef("exchange-config"),
+			),
 			externalAuth: &mcpv1beta1.MCPExternalAuthConfig{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "exchange-config",
@@ -1151,33 +986,26 @@ func TestBuildEnvVarsForProxy(t *testing.T) {
 		},
 		{
 			name: "with header forward secrets",
-			proxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "header-forward-proxy",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					RemoteURL: "https://mcp.example.com",
-					HeaderForward: &mcpv1beta1.HeaderForwardConfig{
-						AddHeadersFromSecret: []mcpv1beta1.HeaderFromSecret{
-							{
-								HeaderName: "X-API-Key",
-								ValueSecretRef: &mcpv1beta1.SecretKeyRef{
-									Name: "api-key-secret",
-									Key:  "api-key",
-								},
+			proxy: v1beta1test.NewMCPRemoteProxy("header-forward-proxy", "default",
+				v1beta1test.WithRemoteProxyHeaderForward(&mcpv1beta1.HeaderForwardConfig{
+					AddHeadersFromSecret: []mcpv1beta1.HeaderFromSecret{
+						{
+							HeaderName: "X-API-Key",
+							ValueSecretRef: &mcpv1beta1.SecretKeyRef{
+								Name: "api-key-secret",
+								Key:  "api-key",
 							},
-							{
-								HeaderName: "Authorization",
-								ValueSecretRef: &mcpv1beta1.SecretKeyRef{
-									Name: "auth-secret",
-									Key:  "token",
-								},
+						},
+						{
+							HeaderName: "Authorization",
+							ValueSecretRef: &mcpv1beta1.SecretKeyRef{
+								Name: "auth-secret",
+								Key:  "token",
 							},
 						},
 					},
-				},
-			},
+				}),
+			),
 			validate: func(t *testing.T, envVars []corev1.EnvVar) {
 				t.Helper()
 				// Should have env vars for both header secrets and TOOLHIVE_SECRETS_PROVIDER
@@ -1211,18 +1039,9 @@ func TestBuildEnvVarsForProxy(t *testing.T) {
 		},
 		{
 			name: "with bearer token",
-			proxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "bearer-proxy",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					RemoteURL: "https://mcp.example.com",
-					ExternalAuthConfigRef: &mcpv1beta1.ExternalAuthConfigRef{
-						Name: "bearer-config",
-					},
-				},
-			},
+			proxy: v1beta1test.NewMCPRemoteProxy("bearer-proxy", "default",
+				v1beta1test.WithRemoteProxyExternalAuthConfigRef("bearer-config"),
+			),
 			externalAuth: &mcpv1beta1.MCPExternalAuthConfig{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "bearer-config",
@@ -1300,16 +1119,7 @@ func TestBuildEnvVarsForProxy(t *testing.T) {
 func TestMCPRemoteProxyServiceNeedsUpdate(t *testing.T) {
 	t.Parallel()
 
-	baseProxy := &mcpv1beta1.MCPRemoteProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-proxy",
-			Namespace: "default",
-		},
-		Spec: mcpv1beta1.MCPRemoteProxySpec{
-			RemoteURL: "https://mcp.example.com",
-			ProxyPort: 8080,
-		},
-	}
+	baseProxy := v1beta1test.NewMCPRemoteProxy("test-proxy", "default")
 
 	baseService := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1427,10 +1237,9 @@ func TestBuildRedisPasswordEnvVarForRemoteProxy(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			proxy := &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-proxy", Namespace: "default"},
-				Spec:       mcpv1beta1.MCPRemoteProxySpec{SessionStorage: tc.storage},
-			}
+			proxy := v1beta1test.NewMCPRemoteProxy("test-proxy", "default",
+				v1beta1test.WithRemoteProxySessionStorage(tc.storage),
+			)
 			env := buildRedisPasswordEnvVarForRemoteProxy(proxy)
 			if tc.expectEnVar {
 				require.Len(t, env, 1)

--- a/cmd/thv-operator/controllers/mcpremoteproxy_reconciler_test.go
+++ b/cmd/thv-operator/controllers/mcpremoteproxy_reconciler_test.go
@@ -34,6 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1/v1beta1test"
 	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 	ctrlutil "github.com/stacklok/toolhive/cmd/thv-operator/pkg/controllerutil"
 	"github.com/stacklok/toolhive/cmd/thv-operator/pkg/kubernetes/rbac"
@@ -53,17 +54,9 @@ func TestMCPRemoteProxyFullReconciliation(t *testing.T) {
 	}{
 		{
 			name: "basic proxy with inline OIDC",
-			proxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "basic-proxy",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					RemoteURL: "https://mcp.salesforce.com",
-					ProxyPort: 8080,
-					Transport: "streamable-http",
-				},
-			},
+			proxy: v1beta1test.NewMCPRemoteProxy("basic-proxy", "default",
+				v1beta1test.WithRemoteProxyURL("https://mcp.salesforce.com"),
+				v1beta1test.WithRemoteProxyTransport("streamable-http")),
 			validateResult: func(t *testing.T, proxy *mcpv1beta1.MCPRemoteProxy, c client.Client) {
 				t.Helper()
 
@@ -119,34 +112,22 @@ func TestMCPRemoteProxyFullReconciliation(t *testing.T) {
 		},
 		{
 			name: "proxy with all features",
-			proxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "full-proxy",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					RemoteURL: "https://mcp.example.com",
-					ProxyPort: 9090,
-					Transport: "sse",
-					ExternalAuthConfigRef: &mcpv1beta1.ExternalAuthConfigRef{
-						Name: "token-exchange",
-					},
-					ToolConfigRef: &mcpv1beta1.ToolConfigRef{
-						Name: "tool-filter",
-					},
-					AuthzConfig: &mcpv1beta1.AuthzConfigRef{
-						Type: mcpv1beta1.AuthzConfigTypeInline,
-						Inline: &mcpv1beta1.InlineAuthzConfig{
-							Policies: []string{
-								`permit(principal, action == Action::"tools/list", resource);`,
-							},
+			proxy: v1beta1test.NewMCPRemoteProxy("full-proxy", "default",
+				v1beta1test.WithRemoteProxyPort(9090),
+				v1beta1test.WithRemoteProxyTransport("sse"),
+				v1beta1test.WithRemoteProxyExternalAuthConfigRef("token-exchange"),
+				v1beta1test.WithRemoteProxyToolConfigRef("tool-filter"),
+				v1beta1test.WithRemoteProxyAuthzConfig(&mcpv1beta1.AuthzConfigRef{
+					Type: mcpv1beta1.AuthzConfigTypeInline,
+					Inline: &mcpv1beta1.InlineAuthzConfig{
+						Policies: []string{
+							`permit(principal, action == Action::"tools/list", resource);`,
 						},
 					},
-					Audit: &mcpv1beta1.AuditConfig{
-						Enabled: true,
-					},
-				},
-			},
+				}),
+				v1beta1test.WithRemoteProxyAudit(&mcpv1beta1.AuditConfig{
+					Enabled: true,
+				})),
 			toolConfig: &mcpv1beta1.MCPToolConfig{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "tool-filter",
@@ -221,19 +202,8 @@ func TestMCPRemoteProxyFullReconciliation(t *testing.T) {
 		},
 		{
 			name: "proxy with validation failure",
-			proxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "invalid-proxy",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					RemoteURL: "https://mcp.example.com",
-					ProxyPort: 8080,
-					ExternalAuthConfigRef: &mcpv1beta1.ExternalAuthConfigRef{
-						Name: "non-existent",
-					},
-				},
-			},
+			proxy: v1beta1test.NewMCPRemoteProxy("invalid-proxy", "default",
+				v1beta1test.WithRemoteProxyExternalAuthConfigRef("non-existent")),
 			validateResult: func(t *testing.T, proxy *mcpv1beta1.MCPRemoteProxy, c client.Client) {
 				t.Helper()
 
@@ -329,19 +299,8 @@ func TestMCPRemoteProxyConfigChangePropagation(t *testing.T) {
 		},
 	}
 
-	proxy := &mcpv1beta1.MCPRemoteProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "config-watch-proxy",
-			Namespace: "default",
-		},
-		Spec: mcpv1beta1.MCPRemoteProxySpec{
-			RemoteURL: "https://mcp.example.com",
-			ProxyPort: 8080,
-			ToolConfigRef: &mcpv1beta1.ToolConfigRef{
-				Name: "dynamic-tools",
-			},
-		},
-	}
+	proxy := v1beta1test.NewMCPRemoteProxy("config-watch-proxy", "default",
+		v1beta1test.WithRemoteProxyToolConfigRef("dynamic-tools"))
 
 	scheme := testutil.NewScheme(t)
 	_ = rbacv1.AddToScheme(scheme)
@@ -403,16 +362,7 @@ func TestMCPRemoteProxyConfigChangePropagation(t *testing.T) {
 func TestMCPRemoteProxyStatusProgression(t *testing.T) {
 	t.Parallel()
 
-	proxy := &mcpv1beta1.MCPRemoteProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "status-proxy",
-			Namespace: "default",
-		},
-		Spec: mcpv1beta1.MCPRemoteProxySpec{
-			RemoteURL: "https://mcp.example.com",
-			ProxyPort: 8080,
-		},
-	}
+	proxy := v1beta1test.NewMCPRemoteProxy("status-proxy", "default")
 
 	scheme := testutil.NewScheme(t)
 	_ = rbacv1.AddToScheme(scheme)
@@ -553,15 +503,7 @@ func TestCommonHelpers(t *testing.T) {
 func TestEnsureAuthzConfigMapShared(t *testing.T) {
 	t.Parallel()
 
-	proxy := &mcpv1beta1.MCPRemoteProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "authz-test-proxy",
-			Namespace: "default",
-		},
-		Spec: mcpv1beta1.MCPRemoteProxySpec{
-			RemoteURL: "https://mcp.example.com",
-		},
-	}
+	proxy := v1beta1test.NewMCPRemoteProxy("authz-test-proxy", "default")
 
 	authzConfig := &mcpv1beta1.AuthzConfigRef{
 		Type: mcpv1beta1.AuthzConfigTypeInline,
@@ -609,16 +551,10 @@ func TestEnsureAuthzConfigMapShared(t *testing.T) {
 func TestRBACClientIntegration(t *testing.T) {
 	t.Parallel()
 
-	proxy := &mcpv1beta1.MCPRemoteProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "rbac-test-proxy",
-			Namespace: "default",
-			UID:       "test-uid",
-		},
-		Spec: mcpv1beta1.MCPRemoteProxySpec{
-			RemoteURL: "https://mcp.example.com",
-		},
-	}
+	proxy := v1beta1test.NewMCPRemoteProxy("rbac-test-proxy", "default",
+		v1beta1test.MutateRemoteProxy(func(p *mcpv1beta1.MCPRemoteProxy) {
+			p.UID = "test-uid"
+		}))
 
 	scheme := testutil.NewScheme(t)
 	_ = rbacv1.AddToScheme(scheme)
@@ -737,31 +673,21 @@ func TestValidateSpecConfigurationConditions(t *testing.T) {
 		conditionStatus metav1.ConditionStatus
 	}{
 		{
-			name: "valid proxy with no OIDC config",
-			proxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{Name: "no-oidc-proxy", Namespace: "default"},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					RemoteURL: "https://mcp.example.com",
-				},
-			},
+			name:            "valid proxy with no OIDC config",
+			proxy:           v1beta1test.NewMCPRemoteProxy("no-oidc-proxy", "default"),
 			expectError:     false,
 			expectCondition: mcpv1beta1.ConditionReasonConfigurationValid,
 			conditionStatus: metav1.ConditionTrue,
 		},
 		{
 			name: "invalid Cedar policy syntax is rejected",
-			proxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{Name: "invalid-cedar-proxy", Namespace: "default"},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					RemoteURL: "https://mcp.example.com",
-					AuthzConfig: &mcpv1beta1.AuthzConfigRef{
-						Type: mcpv1beta1.AuthzConfigTypeInline,
-						Inline: &mcpv1beta1.InlineAuthzConfig{
-							Policies: []string{"not valid cedar"},
-						},
+			proxy: v1beta1test.NewMCPRemoteProxy("invalid-cedar-proxy", "default",
+				v1beta1test.WithRemoteProxyAuthzConfig(&mcpv1beta1.AuthzConfigRef{
+					Type: mcpv1beta1.AuthzConfigTypeInline,
+					Inline: &mcpv1beta1.InlineAuthzConfig{
+						Policies: []string{"not valid cedar"},
 					},
-				},
-			},
+				})),
 			expectError:     true,
 			errContains:     "invalid syntax",
 			expectCondition: mcpv1beta1.ConditionReasonAuthzPolicySyntaxInvalid,
@@ -769,18 +695,13 @@ func TestValidateSpecConfigurationConditions(t *testing.T) {
 		},
 		{
 			name: "referenced authz ConfigMap not found is rejected",
-			proxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{Name: "missing-configmap-proxy", Namespace: "default"},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					RemoteURL: "https://mcp.example.com",
-					AuthzConfig: &mcpv1beta1.AuthzConfigRef{
-						Type: mcpv1beta1.AuthzConfigTypeConfigMap,
-						ConfigMap: &mcpv1beta1.ConfigMapAuthzRef{
-							Name: "does-not-exist",
-						},
+			proxy: v1beta1test.NewMCPRemoteProxy("missing-configmap-proxy", "default",
+				v1beta1test.WithRemoteProxyAuthzConfig(&mcpv1beta1.AuthzConfigRef{
+					Type: mcpv1beta1.AuthzConfigTypeConfigMap,
+					ConfigMap: &mcpv1beta1.ConfigMapAuthzRef{
+						Name: "does-not-exist",
 					},
-				},
-			},
+				})),
 			expectError:     true,
 			errContains:     "not found",
 			expectCondition: mcpv1beta1.ConditionReasonAuthzConfigMapNotFound,
@@ -788,23 +709,18 @@ func TestValidateSpecConfigurationConditions(t *testing.T) {
 		},
 		{
 			name: "referenced header secret not found is rejected",
-			proxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{Name: "missing-header-secret-proxy", Namespace: "default"},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					RemoteURL: "https://mcp.example.com",
-					HeaderForward: &mcpv1beta1.HeaderForwardConfig{
-						AddHeadersFromSecret: []mcpv1beta1.HeaderFromSecret{
-							{
-								HeaderName: "X-API-Key",
-								ValueSecretRef: &mcpv1beta1.SecretKeyRef{
-									Name: "missing-secret",
-									Key:  "api-key",
-								},
+			proxy: v1beta1test.NewMCPRemoteProxy("missing-header-secret-proxy", "default",
+				v1beta1test.WithRemoteProxyHeaderForward(&mcpv1beta1.HeaderForwardConfig{
+					AddHeadersFromSecret: []mcpv1beta1.HeaderFromSecret{
+						{
+							HeaderName: "X-API-Key",
+							ValueSecretRef: &mcpv1beta1.SecretKeyRef{
+								Name: "missing-secret",
+								Key:  "api-key",
 							},
 						},
 					},
-				},
-			},
+				})),
 			expectError:     true,
 			errContains:     "not found",
 			expectCondition: mcpv1beta1.ConditionReasonHeaderSecretNotFound,
@@ -812,18 +728,13 @@ func TestValidateSpecConfigurationConditions(t *testing.T) {
 		},
 		{
 			name: "referenced authz ConfigMap with malformed payload is rejected",
-			proxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{Name: "malformed-configmap-proxy", Namespace: "default"},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					RemoteURL: "https://mcp.example.com",
-					AuthzConfig: &mcpv1beta1.AuthzConfigRef{
-						Type: mcpv1beta1.AuthzConfigTypeConfigMap,
-						ConfigMap: &mcpv1beta1.ConfigMapAuthzRef{
-							Name: "malformed-authz",
-						},
+			proxy: v1beta1test.NewMCPRemoteProxy("malformed-configmap-proxy", "default",
+				v1beta1test.WithRemoteProxyAuthzConfig(&mcpv1beta1.AuthzConfigRef{
+					Type: mcpv1beta1.AuthzConfigTypeConfigMap,
+					ConfigMap: &mcpv1beta1.ConfigMapAuthzRef{
+						Name: "malformed-authz",
 					},
-				},
-			},
+				})),
 			existingObjects: []runtime.Object{
 				&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{Name: "malformed-authz", Namespace: "default"},
@@ -837,18 +748,13 @@ func TestValidateSpecConfigurationConditions(t *testing.T) {
 		},
 		{
 			name: "referenced authz ConfigMap with non-Cedar payload is rejected",
-			proxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{Name: "non-cedar-configmap-proxy", Namespace: "default"},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					RemoteURL: "https://mcp.example.com",
-					AuthzConfig: &mcpv1beta1.AuthzConfigRef{
-						Type: mcpv1beta1.AuthzConfigTypeConfigMap,
-						ConfigMap: &mcpv1beta1.ConfigMapAuthzRef{
-							Name: "non-cedar-authz",
-						},
+			proxy: v1beta1test.NewMCPRemoteProxy("non-cedar-configmap-proxy", "default",
+				v1beta1test.WithRemoteProxyAuthzConfig(&mcpv1beta1.AuthzConfigRef{
+					Type: mcpv1beta1.AuthzConfigTypeConfigMap,
+					ConfigMap: &mcpv1beta1.ConfigMapAuthzRef{
+						Name: "non-cedar-authz",
 					},
-				},
-			},
+				})),
 			existingObjects: []runtime.Object{
 				&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{Name: "non-cedar-authz", Namespace: "default"},
@@ -864,12 +770,8 @@ func TestValidateSpecConfigurationConditions(t *testing.T) {
 		},
 		{
 			name: "malformed remote URL is rejected",
-			proxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{Name: "bad-scheme-proxy", Namespace: "default"},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					RemoteURL: "ftp://bad-scheme.example.com",
-				},
-			},
+			proxy: v1beta1test.NewMCPRemoteProxy("bad-scheme-proxy", "default",
+				v1beta1test.WithRemoteProxyURL("ftp://bad-scheme.example.com")),
 			expectError:     true,
 			errContains:     "scheme",
 			expectCondition: mcpv1beta1.ConditionReasonRemoteURLInvalid,
@@ -941,19 +843,8 @@ func TestValidateAndHandleConfigs(t *testing.T) {
 	}{
 		{
 			name: "valid configs",
-			proxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "valid-proxy",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					RemoteURL: "https://mcp.example.com",
-					ProxyPort: 8080,
-					ToolConfigRef: &mcpv1beta1.ToolConfigRef{
-						Name: "valid-tools",
-					},
-				},
-			},
+			proxy: v1beta1test.NewMCPRemoteProxy("valid-proxy", "default",
+				v1beta1test.WithRemoteProxyToolConfigRef("valid-tools")),
 			toolConfig: &mcpv1beta1.MCPToolConfig{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "valid-tools",
@@ -970,19 +861,8 @@ func TestValidateAndHandleConfigs(t *testing.T) {
 		},
 		{
 			name: "missing tool config",
-			proxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "missing-tool-proxy",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					RemoteURL: "https://mcp.example.com",
-					ProxyPort: 8080,
-					ToolConfigRef: &mcpv1beta1.ToolConfigRef{
-						Name: "non-existent",
-					},
-				},
-			},
+			proxy: v1beta1test.NewMCPRemoteProxy("missing-tool-proxy", "default",
+				v1beta1test.WithRemoteProxyToolConfigRef("non-existent")),
 			expectError: true,
 			expectPhase: mcpv1beta1.MCPRemoteProxyPhaseFailed,
 		},
@@ -1110,10 +990,13 @@ func TestMCPRemoteProxy_ValidateAuthzPrimaryUpstreamProviderIgnored(t *testing.T
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			proxy := &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "default", Generation: 7},
-				Spec:       mcpv1beta1.MCPRemoteProxySpec{AuthzConfig: tt.authzConfig},
-			}
+			proxy := v1beta1test.NewMCPRemoteProxy("p", "default",
+				v1beta1test.WithRemoteProxyURL(""),
+				v1beta1test.WithRemoteProxyPort(0),
+				v1beta1test.WithRemoteProxyAuthzConfig(tt.authzConfig),
+				v1beta1test.MutateRemoteProxy(func(p *mcpv1beta1.MCPRemoteProxy) {
+					p.Generation = 7
+				}))
 			if tt.preexisting != nil {
 				proxy.Status.Conditions = []metav1.Condition{*tt.preexisting}
 			}

--- a/cmd/thv-operator/controllers/mcpremoteproxy_replicas_test.go
+++ b/cmd/thv-operator/controllers/mcpremoteproxy_replicas_test.go
@@ -17,19 +17,17 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1/v1beta1test"
 	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 	"github.com/stacklok/toolhive/cmd/thv-operator/pkg/runconfig/configmap/checksum"
 )
 
 func replicasTestProxy(replicas *int32) *mcpv1beta1.MCPRemoteProxy {
-	return &mcpv1beta1.MCPRemoteProxy{
-		ObjectMeta: metav1.ObjectMeta{Name: "replicas-proxy", Namespace: "default"},
-		Spec: mcpv1beta1.MCPRemoteProxySpec{
-			RemoteURL: "https://mcp.example.com",
-			ProxyPort: 8080,
-			Replicas:  replicas,
-		},
-	}
+	return v1beta1test.NewMCPRemoteProxy("replicas-proxy", "default",
+		v1beta1test.MutateRemoteProxy(func(p *mcpv1beta1.MCPRemoteProxy) {
+			p.Spec.Replicas = replicas
+		}),
+	)
 }
 
 // TestDeploymentForMCPRemoteProxyReplicas verifies spec.replicas flows into

--- a/cmd/thv-operator/controllers/mcpremoteproxy_runconfig_test.go
+++ b/cmd/thv-operator/controllers/mcpremoteproxy_runconfig_test.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1/v1beta1test"
 	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 	"github.com/stacklok/toolhive/pkg/authz"
 	"github.com/stacklok/toolhive/pkg/authz/authorizers/cedar"
@@ -48,16 +49,9 @@ func TestCreateRunConfigFromMCPRemoteProxy(t *testing.T) {
 	}{
 		{
 			name: "basic remote proxy",
-			proxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "salesforce-proxy",
-					Namespace: "mcp-proxies",
-				},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					RemoteURL: "https://mcp.salesforce.com",
-					ProxyPort: 8080,
-				},
-			},
+			proxy: v1beta1test.NewMCPRemoteProxy("salesforce-proxy", "mcp-proxies",
+				v1beta1test.WithRemoteProxyURL("https://mcp.salesforce.com"),
+			),
 			expectError: false,
 			validate: func(t *testing.T, config *runner.RunConfig) {
 				t.Helper()
@@ -71,19 +65,9 @@ func TestCreateRunConfigFromMCPRemoteProxy(t *testing.T) {
 		},
 		{
 			name: "with tool filtering",
-			proxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "filtered-proxy",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					RemoteURL: "https://mcp.example.com",
-					ProxyPort: 8080,
-					ToolConfigRef: &mcpv1beta1.ToolConfigRef{
-						Name: "filter-config",
-					},
-				},
-			},
+			proxy: v1beta1test.NewMCPRemoteProxy("filtered-proxy", "default",
+				v1beta1test.WithRemoteProxyToolConfigRef("filter-config"),
+			),
 			toolConfig: &mcpv1beta1.MCPToolConfig{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "filter-config",
@@ -112,26 +96,18 @@ func TestCreateRunConfigFromMCPRemoteProxy(t *testing.T) {
 		},
 		{
 			name: "with inline authorization",
-			proxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "authz-proxy",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					RemoteURL: "https://mcp.example.com",
-					ProxyPort: 8080,
-					AuthzConfig: &mcpv1beta1.AuthzConfigRef{
-						Type: mcpv1beta1.AuthzConfigTypeInline,
-						Inline: &mcpv1beta1.InlineAuthzConfig{
-							Policies: []string{
-								`permit(principal, action == Action::"tools/list", resource);`,
-								`forbid(principal, action == Action::"tools/call", resource) when { resource.tool == "delete_resource" };`,
-							},
-							EntitiesJSON: `[]`,
+			proxy: v1beta1test.NewMCPRemoteProxy("authz-proxy", "default",
+				v1beta1test.WithRemoteProxyAuthzConfig(&mcpv1beta1.AuthzConfigRef{
+					Type: mcpv1beta1.AuthzConfigTypeInline,
+					Inline: &mcpv1beta1.InlineAuthzConfig{
+						Policies: []string{
+							`permit(principal, action == Action::"tools/list", resource);`,
+							`forbid(principal, action == Action::"tools/call", resource) when { resource.tool == "delete_resource" };`,
 						},
+						EntitiesJSON: `[]`,
 					},
-				},
-			},
+				}),
+			),
 			expectError: false,
 			validate: func(t *testing.T, config *runner.RunConfig) {
 				t.Helper()
@@ -147,17 +123,11 @@ func TestCreateRunConfigFromMCPRemoteProxy(t *testing.T) {
 		},
 		{
 			name: "with trust proxy headers",
-			proxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "trust-headers-proxy",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					RemoteURL:         "https://mcp.example.com",
-					ProxyPort:         8080,
-					TrustProxyHeaders: true,
-				},
-			},
+			proxy: v1beta1test.NewMCPRemoteProxy("trust-headers-proxy", "default",
+				v1beta1test.MutateRemoteProxy(func(p *mcpv1beta1.MCPRemoteProxy) {
+					p.Spec.TrustProxyHeaders = true
+				}),
+			),
 			expectError: false,
 			validate: func(t *testing.T, config *runner.RunConfig) {
 				t.Helper()
@@ -167,22 +137,14 @@ func TestCreateRunConfigFromMCPRemoteProxy(t *testing.T) {
 		},
 		{
 			name: "with header forward plaintext only",
-			proxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "plaintext-headers-proxy",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					RemoteURL: "https://mcp.example.com",
-					ProxyPort: 8080,
-					HeaderForward: &mcpv1beta1.HeaderForwardConfig{
-						AddPlaintextHeaders: map[string]string{
-							"X-Tenant-ID":   "tenant-123",
-							"X-Correlation": "corr-abc",
-						},
+			proxy: v1beta1test.NewMCPRemoteProxy("plaintext-headers-proxy", "default",
+				v1beta1test.WithRemoteProxyHeaderForward(&mcpv1beta1.HeaderForwardConfig{
+					AddPlaintextHeaders: map[string]string{
+						"X-Tenant-ID":   "tenant-123",
+						"X-Correlation": "corr-abc",
 					},
-				},
-			},
+				}),
+			),
 			expectError: false,
 			validate: func(t *testing.T, config *runner.RunConfig) {
 				t.Helper()
@@ -195,34 +157,26 @@ func TestCreateRunConfigFromMCPRemoteProxy(t *testing.T) {
 		},
 		{
 			name: "with header forward secrets",
-			proxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "secret-headers-proxy",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					RemoteURL: "https://mcp.example.com",
-					ProxyPort: 8080,
-					HeaderForward: &mcpv1beta1.HeaderForwardConfig{
-						AddHeadersFromSecret: []mcpv1beta1.HeaderFromSecret{
-							{
-								HeaderName: "X-API-Key",
-								ValueSecretRef: &mcpv1beta1.SecretKeyRef{
-									Name: "api-secret",
-									Key:  "key",
-								},
+			proxy: v1beta1test.NewMCPRemoteProxy("secret-headers-proxy", "default",
+				v1beta1test.WithRemoteProxyHeaderForward(&mcpv1beta1.HeaderForwardConfig{
+					AddHeadersFromSecret: []mcpv1beta1.HeaderFromSecret{
+						{
+							HeaderName: "X-API-Key",
+							ValueSecretRef: &mcpv1beta1.SecretKeyRef{
+								Name: "api-secret",
+								Key:  "key",
 							},
-							{
-								HeaderName: "Authorization",
-								ValueSecretRef: &mcpv1beta1.SecretKeyRef{
-									Name: "auth-secret",
-									Key:  "token",
-								},
+						},
+						{
+							HeaderName: "Authorization",
+							ValueSecretRef: &mcpv1beta1.SecretKeyRef{
+								Name: "auth-secret",
+								Key:  "token",
 							},
 						},
 					},
-				},
-			},
+				}),
+			),
 			expectError: false,
 			validate: func(t *testing.T, config *runner.RunConfig) {
 				t.Helper()
@@ -237,30 +191,22 @@ func TestCreateRunConfigFromMCPRemoteProxy(t *testing.T) {
 		},
 		{
 			name: "with header forward mixed plaintext and secrets",
-			proxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "mixed-headers-proxy",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					RemoteURL: "https://mcp.example.com",
-					ProxyPort: 8080,
-					HeaderForward: &mcpv1beta1.HeaderForwardConfig{
-						AddPlaintextHeaders: map[string]string{
-							"X-Tenant-ID": "tenant-456",
-						},
-						AddHeadersFromSecret: []mcpv1beta1.HeaderFromSecret{
-							{
-								HeaderName: "X-API-Key",
-								ValueSecretRef: &mcpv1beta1.SecretKeyRef{
-									Name: "api-secret",
-									Key:  "key",
-								},
+			proxy: v1beta1test.NewMCPRemoteProxy("mixed-headers-proxy", "default",
+				v1beta1test.WithRemoteProxyHeaderForward(&mcpv1beta1.HeaderForwardConfig{
+					AddPlaintextHeaders: map[string]string{
+						"X-Tenant-ID": "tenant-456",
+					},
+					AddHeadersFromSecret: []mcpv1beta1.HeaderFromSecret{
+						{
+							HeaderName: "X-API-Key",
+							ValueSecretRef: &mcpv1beta1.SecretKeyRef{
+								Name: "api-secret",
+								Key:  "key",
 							},
 						},
 					},
-				},
-			},
+				}),
+			),
 			expectError: false,
 			validate: func(t *testing.T, config *runner.RunConfig) {
 				t.Helper()
@@ -324,19 +270,10 @@ func TestCreateRunConfigFromMCPRemoteProxy_WithTokenExchange(t *testing.T) {
 	}{
 		{
 			name: "with token exchange",
-			proxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "exchange-proxy",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					RemoteURL: "https://mcp.salesforce.com",
-					ProxyPort: 8080,
-					ExternalAuthConfigRef: &mcpv1beta1.ExternalAuthConfigRef{
-						Name: "salesforce-exchange",
-					},
-				},
-			},
+			proxy: v1beta1test.NewMCPRemoteProxy("exchange-proxy", "default",
+				v1beta1test.WithRemoteProxyURL("https://mcp.salesforce.com"),
+				v1beta1test.WithRemoteProxyExternalAuthConfigRef("salesforce-exchange"),
+			),
 			externalAuth: &mcpv1beta1.MCPExternalAuthConfig{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "salesforce-exchange",
@@ -393,19 +330,9 @@ func TestCreateRunConfigFromMCPRemoteProxy_WithTokenExchange(t *testing.T) {
 		},
 		{
 			name: "external auth config not found",
-			proxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "broken-proxy",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					RemoteURL: "https://mcp.example.com",
-					ProxyPort: 8080,
-					ExternalAuthConfigRef: &mcpv1beta1.ExternalAuthConfigRef{
-						Name: "non-existent",
-					},
-				},
-			},
+			proxy: v1beta1test.NewMCPRemoteProxy("broken-proxy", "default",
+				v1beta1test.WithRemoteProxyExternalAuthConfigRef("non-existent"),
+			),
 			expectError: true,
 		},
 	}
@@ -462,19 +389,10 @@ func TestCreateRunConfigFromMCPRemoteProxy_WithBearerToken(t *testing.T) {
 	}{
 		{
 			name: "with bearer token",
-			proxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "bearer-proxy",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					RemoteURL: "https://mcp.example.com/api",
-					ProxyPort: 8080,
-					ExternalAuthConfigRef: &mcpv1beta1.ExternalAuthConfigRef{
-						Name: "api-bearer-auth",
-					},
-				},
-			},
+			proxy: v1beta1test.NewMCPRemoteProxy("bearer-proxy", "default",
+				v1beta1test.WithRemoteProxyURL("https://mcp.example.com/api"),
+				v1beta1test.WithRemoteProxyExternalAuthConfigRef("api-bearer-auth"),
+			),
 			externalAuth: &mcpv1beta1.MCPExternalAuthConfig{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "api-bearer-auth",
@@ -512,19 +430,9 @@ func TestCreateRunConfigFromMCPRemoteProxy_WithBearerToken(t *testing.T) {
 		},
 		{
 			name: "missing TokenSecretRef",
-			proxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "broken-proxy",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					RemoteURL: "https://mcp.example.com",
-					ProxyPort: 8080,
-					ExternalAuthConfigRef: &mcpv1beta1.ExternalAuthConfigRef{
-						Name: "broken-bearer",
-					},
-				},
-			},
+			proxy: v1beta1test.NewMCPRemoteProxy("broken-proxy", "default",
+				v1beta1test.WithRemoteProxyExternalAuthConfigRef("broken-bearer"),
+			),
 			externalAuth: &mcpv1beta1.MCPExternalAuthConfig{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "broken-bearer",
@@ -541,19 +449,9 @@ func TestCreateRunConfigFromMCPRemoteProxy_WithBearerToken(t *testing.T) {
 		},
 		{
 			name: "secret not found",
-			proxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "missing-secret-proxy",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					RemoteURL: "https://mcp.example.com",
-					ProxyPort: 8080,
-					ExternalAuthConfigRef: &mcpv1beta1.ExternalAuthConfigRef{
-						Name: "missing-secret-bearer",
-					},
-				},
-			},
+			proxy: v1beta1test.NewMCPRemoteProxy("missing-secret-proxy", "default",
+				v1beta1test.WithRemoteProxyExternalAuthConfigRef("missing-secret-bearer"),
+			),
 			externalAuth: &mcpv1beta1.MCPExternalAuthConfig{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "missing-secret-bearer",
@@ -573,19 +471,9 @@ func TestCreateRunConfigFromMCPRemoteProxy_WithBearerToken(t *testing.T) {
 		},
 		{
 			name: "secret missing key",
-			proxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "missing-key-proxy",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					RemoteURL: "https://mcp.example.com",
-					ProxyPort: 8080,
-					ExternalAuthConfigRef: &mcpv1beta1.ExternalAuthConfigRef{
-						Name: "missing-key-bearer",
-					},
-				},
-			},
+			proxy: v1beta1test.NewMCPRemoteProxy("missing-key-proxy", "default",
+				v1beta1test.WithRemoteProxyExternalAuthConfigRef("missing-key-bearer"),
+			),
 			externalAuth: &mcpv1beta1.MCPExternalAuthConfig{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "missing-key-bearer",
@@ -777,17 +665,8 @@ func TestEnsureRunConfigConfigMapForRemoteProxy(t *testing.T) {
 		validateContent func(*testing.T, *corev1.ConfigMap)
 	}{
 		{
-			name: "create new configmap for remote proxy",
-			proxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "new-proxy",
-					Namespace: "default",
-				},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					RemoteURL: "https://mcp.example.com",
-					ProxyPort: 8080,
-				},
-			},
+			name:        "create new configmap for remote proxy",
+			proxy:       v1beta1test.NewMCPRemoteProxy("new-proxy", "default"),
 			existingCM:  nil,
 			expectError: false,
 			validateContent: func(t *testing.T, cm *corev1.ConfigMap) {
@@ -933,11 +812,9 @@ func TestPopulateScalingConfigForRemoteProxy(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			runConfig := &runner.RunConfig{}
-			proxy := &mcpv1beta1.MCPRemoteProxy{
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					SessionStorage: tt.storage,
-				},
-			}
+			proxy := v1beta1test.NewMCPRemoteProxy("", "",
+				v1beta1test.WithRemoteProxySessionStorage(tt.storage),
+			)
 			populateScalingConfigForRemoteProxy(runConfig, proxy)
 			tt.expected(t, runConfig.ScalingConfig)
 		})

--- a/cmd/thv-operator/controllers/mcpremoteproxy_telemetryconfig_test.go
+++ b/cmd/thv-operator/controllers/mcpremoteproxy_telemetryconfig_test.go
@@ -13,6 +13,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1/v1beta1test"
 	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 )
 
@@ -35,25 +36,20 @@ func TestHandleTelemetryConfig_MCPRemoteProxy(t *testing.T) {
 	}{
 		{
 			name: "nil ref clears hash and removes condition",
-			proxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-proxy", Namespace: "default"},
-				Spec:       mcpv1beta1.MCPRemoteProxySpec{TelemetryConfigRef: nil},
-				Status: mcpv1beta1.MCPRemoteProxyStatus{
+			proxy: v1beta1test.NewMCPRemoteProxy("test-proxy", "default",
+				v1beta1test.WithRemoteProxyStatus(mcpv1beta1.MCPRemoteProxyStatus{
 					TelemetryConfigHash: "old-hash",
-				},
-			},
+				}),
+			),
 			expectError:       false,
 			expectNoCondition: true,
 			expectHashCleared: true,
 		},
 		{
 			name: "valid ref sets condition true and updates hash",
-			proxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-proxy", Namespace: "default"},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					TelemetryConfigRef: &mcpv1beta1.MCPTelemetryConfigReference{Name: "my-telemetry"},
-				},
-			},
+			proxy: v1beta1test.NewMCPRemoteProxy("test-proxy", "default",
+				v1beta1test.WithRemoteProxyTelemetryConfigRef("my-telemetry"),
+			),
 			telemetryConfig: &mcpv1beta1.MCPTelemetryConfig{
 				ObjectMeta: metav1.ObjectMeta{Name: "my-telemetry", Namespace: "default"},
 				Spec:       newTelemetrySpec("https://otel-collector:4317", true, false),
@@ -69,12 +65,9 @@ func TestHandleTelemetryConfig_MCPRemoteProxy(t *testing.T) {
 		},
 		{
 			name: "not found sets condition false",
-			proxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-proxy", Namespace: "default"},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					TelemetryConfigRef: &mcpv1beta1.MCPTelemetryConfigReference{Name: "missing"},
-				},
-			},
+			proxy: v1beta1test.NewMCPRemoteProxy("test-proxy", "default",
+				v1beta1test.WithRemoteProxyTelemetryConfigRef("missing"),
+			),
 			expectError:        true,
 			expectedCondType:   mcpv1beta1.ConditionTypeMCPRemoteProxyTelemetryConfigRefValidated,
 			expectedCondStatus: metav1.ConditionFalse,
@@ -82,12 +75,9 @@ func TestHandleTelemetryConfig_MCPRemoteProxy(t *testing.T) {
 		},
 		{
 			name: "invalid config sets condition false",
-			proxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-proxy", Namespace: "default"},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					TelemetryConfigRef: &mcpv1beta1.MCPTelemetryConfigReference{Name: "invalid-telemetry"},
-				},
-			},
+			proxy: v1beta1test.NewMCPRemoteProxy("test-proxy", "default",
+				v1beta1test.WithRemoteProxyTelemetryConfigRef("invalid-telemetry"),
+			),
 			// Spec with endpoint but no tracing/metrics enabled → Validate() fails
 			telemetryConfig: &mcpv1beta1.MCPTelemetryConfig{
 				ObjectMeta: metav1.ObjectMeta{Name: "invalid-telemetry", Namespace: "default"},
@@ -107,15 +97,12 @@ func TestHandleTelemetryConfig_MCPRemoteProxy(t *testing.T) {
 		},
 		{
 			name: "hash change triggers update",
-			proxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-proxy", Namespace: "default"},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					TelemetryConfigRef: &mcpv1beta1.MCPTelemetryConfigReference{Name: "my-telemetry"},
-				},
-				Status: mcpv1beta1.MCPRemoteProxyStatus{
+			proxy: v1beta1test.NewMCPRemoteProxy("test-proxy", "default",
+				v1beta1test.WithRemoteProxyTelemetryConfigRef("my-telemetry"),
+				v1beta1test.WithRemoteProxyStatus(mcpv1beta1.MCPRemoteProxyStatus{
 					TelemetryConfigHash: "old-hash",
-				},
-			},
+				}),
+			),
 			telemetryConfig: &mcpv1beta1.MCPTelemetryConfig{
 				ObjectMeta: metav1.ObjectMeta{Name: "my-telemetry", Namespace: "default"},
 				Spec:       newTelemetrySpec("https://otel-collector:4317", true, false),
@@ -131,12 +118,9 @@ func TestHandleTelemetryConfig_MCPRemoteProxy(t *testing.T) {
 		},
 		{
 			name: "recovery from False condition persists True",
-			proxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-proxy", Namespace: "default"},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					TelemetryConfigRef: &mcpv1beta1.MCPTelemetryConfigReference{Name: "my-telemetry"},
-				},
-				Status: mcpv1beta1.MCPRemoteProxyStatus{
+			proxy: v1beta1test.NewMCPRemoteProxy("test-proxy", "default",
+				v1beta1test.WithRemoteProxyTelemetryConfigRef("my-telemetry"),
+				v1beta1test.WithRemoteProxyStatus(mcpv1beta1.MCPRemoteProxyStatus{
 					TelemetryConfigHash: "abc123",
 					Conditions: []metav1.Condition{
 						{
@@ -145,8 +129,8 @@ func TestHandleTelemetryConfig_MCPRemoteProxy(t *testing.T) {
 							Reason: mcpv1beta1.ConditionReasonMCPRemoteProxyTelemetryConfigRefFetchError,
 						},
 					},
-				},
-			},
+				}),
+			),
 			telemetryConfig: &mcpv1beta1.MCPTelemetryConfig{
 				ObjectMeta: metav1.ObjectMeta{Name: "my-telemetry", Namespace: "default"},
 				Spec:       newTelemetrySpec("https://otel-collector:4317", true, false),
@@ -162,10 +146,8 @@ func TestHandleTelemetryConfig_MCPRemoteProxy(t *testing.T) {
 		},
 		{
 			name: "nil ref with stale condition persists removal",
-			proxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-proxy", Namespace: "default"},
-				Spec:       mcpv1beta1.MCPRemoteProxySpec{TelemetryConfigRef: nil},
-				Status: mcpv1beta1.MCPRemoteProxyStatus{
+			proxy: v1beta1test.NewMCPRemoteProxy("test-proxy", "default",
+				v1beta1test.WithRemoteProxyStatus(mcpv1beta1.MCPRemoteProxyStatus{
 					Conditions: []metav1.Condition{
 						{
 							Type:   mcpv1beta1.ConditionTypeMCPRemoteProxyTelemetryConfigRefValidated,
@@ -173,8 +155,8 @@ func TestHandleTelemetryConfig_MCPRemoteProxy(t *testing.T) {
 							Reason: mcpv1beta1.ConditionReasonMCPRemoteProxyTelemetryConfigRefNotFound,
 						},
 					},
-				},
-			},
+				}),
+			),
 			expectError:       false,
 			expectNoCondition: true,
 			expectHashCleared: true,
@@ -260,22 +242,13 @@ func TestMapTelemetryConfigToMCPRemoteProxy(t *testing.T) {
 
 	scheme := testutil.NewScheme(t)
 
-	proxy1 := &mcpv1beta1.MCPRemoteProxy{
-		ObjectMeta: metav1.ObjectMeta{Name: "proxy1", Namespace: "default"},
-		Spec: mcpv1beta1.MCPRemoteProxySpec{
-			TelemetryConfigRef: &mcpv1beta1.MCPTelemetryConfigReference{Name: "shared-telemetry"},
-		},
-	}
-	proxy2 := &mcpv1beta1.MCPRemoteProxy{
-		ObjectMeta: metav1.ObjectMeta{Name: "proxy2", Namespace: "default"},
-		Spec: mcpv1beta1.MCPRemoteProxySpec{
-			TelemetryConfigRef: &mcpv1beta1.MCPTelemetryConfigReference{Name: "other-telemetry"},
-		},
-	}
-	proxy3 := &mcpv1beta1.MCPRemoteProxy{
-		ObjectMeta: metav1.ObjectMeta{Name: "proxy3", Namespace: "default"},
-		Spec:       mcpv1beta1.MCPRemoteProxySpec{}, // no ref
-	}
+	proxy1 := v1beta1test.NewMCPRemoteProxy("proxy1", "default",
+		v1beta1test.WithRemoteProxyTelemetryConfigRef("shared-telemetry"),
+	)
+	proxy2 := v1beta1test.NewMCPRemoteProxy("proxy2", "default",
+		v1beta1test.WithRemoteProxyTelemetryConfigRef("other-telemetry"),
+	)
+	proxy3 := v1beta1test.NewMCPRemoteProxy("proxy3", "default") // no ref
 
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(scheme).

--- a/cmd/thv-operator/controllers/virtualmcpserver_controller_test.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_controller_test.go
@@ -3292,13 +3292,9 @@ func TestGetExternalAuthConfigNameFromWorkload(t *testing.T) {
 	}
 
 	mcpRemoteProxyMap := map[string]*mcpv1beta1.MCPRemoteProxy{
-		"proxy-with-auth": {
-			Spec: mcpv1beta1.MCPRemoteProxySpec{
-				ExternalAuthConfigRef: &mcpv1beta1.ExternalAuthConfigRef{
-					Name: "proxy-auth-config",
-				},
-			},
-		},
+		"proxy-with-auth": v1beta1test.NewMCPRemoteProxy("proxy-with-auth", "default",
+			v1beta1test.WithRemoteProxyExternalAuthConfigRef("proxy-auth-config"),
+		),
 	}
 
 	mcpServerEntryMap := map[string]*mcpv1beta1.MCPServerEntry{

--- a/cmd/thv-operator/controllers/virtualmcpserver_watch_test.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_watch_test.go
@@ -449,13 +449,8 @@ func TestMapMCPRemoteProxyToVirtualMCPServer(t *testing.T) {
 		expectedNames     []string
 	}{
 		{
-			name: "MCPRemoteProxy is member of MCPGroup referenced by VirtualMCPServer",
-			mcpRemoteProxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-proxy",
-					Namespace: "default",
-				},
-			},
+			name:           "MCPRemoteProxy is member of MCPGroup referenced by VirtualMCPServer",
+			mcpRemoteProxy: v1beta1test.NewMCPRemoteProxy("test-proxy", "default"),
 			mcpGroups: []mcpv1beta1.MCPGroup{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -482,13 +477,8 @@ func TestMapMCPRemoteProxyToVirtualMCPServer(t *testing.T) {
 			expectedNames:    []string{"vmcp-1"},
 		},
 		{
-			name: "MCPRemoteProxy is not member of any MCPGroup",
-			mcpRemoteProxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-proxy",
-					Namespace: "default",
-				},
-			},
+			name:           "MCPRemoteProxy is not member of any MCPGroup",
+			mcpRemoteProxy: v1beta1test.NewMCPRemoteProxy("test-proxy", "default"),
 			mcpGroups: []mcpv1beta1.MCPGroup{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -515,13 +505,8 @@ func TestMapMCPRemoteProxyToVirtualMCPServer(t *testing.T) {
 			expectedNames:    []string{},
 		},
 		{
-			name: "MCPRemoteProxy is member of MCPGroup but no VirtualMCPServers reference it",
-			mcpRemoteProxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-proxy",
-					Namespace: "default",
-				},
-			},
+			name:           "MCPRemoteProxy is member of MCPGroup but no VirtualMCPServers reference it",
+			mcpRemoteProxy: v1beta1test.NewMCPRemoteProxy("test-proxy", "default"),
 			mcpGroups: []mcpv1beta1.MCPGroup{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -548,13 +533,8 @@ func TestMapMCPRemoteProxyToVirtualMCPServer(t *testing.T) {
 			expectedNames:    []string{},
 		},
 		{
-			name: "MCPRemoteProxy is member of multiple MCPGroups with multiple VirtualMCPServers",
-			mcpRemoteProxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-proxy",
-					Namespace: "default",
-				},
-			},
+			name:           "MCPRemoteProxy is member of multiple MCPGroups with multiple VirtualMCPServers",
+			mcpRemoteProxy: v1beta1test.NewMCPRemoteProxy("test-proxy", "default"),
 			mcpGroups: []mcpv1beta1.MCPGroup{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -934,18 +914,10 @@ func TestMapExternalAuthConfigToVirtualMCPServer(t *testing.T) {
 				},
 			},
 			mcpRemoteProxies: []mcpv1beta1.MCPRemoteProxy{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "backend-proxy",
-						Namespace: "default",
-					},
-					Spec: mcpv1beta1.MCPRemoteProxySpec{
-						GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-						ExternalAuthConfigRef: &mcpv1beta1.ExternalAuthConfigRef{
-							Name: "test-auth",
-						},
-					},
-				},
+				*v1beta1test.NewMCPRemoteProxy("backend-proxy", "default",
+					v1beta1test.WithRemoteProxyGroupRef("test-group"),
+					v1beta1test.WithRemoteProxyExternalAuthConfigRef("test-auth"),
+				),
 			},
 			expectedRequests: 1,
 			expectedNames:    []string{"vmcp-discovered"},
@@ -981,18 +953,10 @@ func TestMapExternalAuthConfigToVirtualMCPServer(t *testing.T) {
 				},
 			},
 			mcpRemoteProxies: []mcpv1beta1.MCPRemoteProxy{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "backend-proxy",
-						Namespace: "default",
-					},
-					Spec: mcpv1beta1.MCPRemoteProxySpec{
-						GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-						ExternalAuthConfigRef: &mcpv1beta1.ExternalAuthConfigRef{
-							Name: "other-auth",
-						},
-					},
-				},
+				*v1beta1test.NewMCPRemoteProxy("backend-proxy", "default",
+					v1beta1test.WithRemoteProxyGroupRef("test-group"),
+					v1beta1test.WithRemoteProxyExternalAuthConfigRef("other-auth"),
+				),
 			},
 			expectedRequests: 0,
 			expectedNames:    []string{},
@@ -1584,18 +1548,10 @@ func TestVmcpReferencesExternalAuthConfig(t *testing.T) {
 				},
 			},
 			mcpRemoteProxies: []mcpv1beta1.MCPRemoteProxy{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "backend-proxy",
-						Namespace: "default",
-					},
-					Spec: mcpv1beta1.MCPRemoteProxySpec{
-						GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-						ExternalAuthConfigRef: &mcpv1beta1.ExternalAuthConfigRef{
-							Name: "test-auth",
-						},
-					},
-				},
+				*v1beta1test.NewMCPRemoteProxy("backend-proxy", "default",
+					v1beta1test.WithRemoteProxyGroupRef("test-group"),
+					v1beta1test.WithRemoteProxyExternalAuthConfigRef("test-auth"),
+				),
 			},
 			authConfigName: "test-auth",
 			expected:       true,
@@ -1623,18 +1579,10 @@ func TestVmcpReferencesExternalAuthConfig(t *testing.T) {
 				},
 			},
 			mcpRemoteProxies: []mcpv1beta1.MCPRemoteProxy{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "backend-proxy",
-						Namespace: "default",
-					},
-					Spec: mcpv1beta1.MCPRemoteProxySpec{
-						GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-						ExternalAuthConfigRef: &mcpv1beta1.ExternalAuthConfigRef{
-							Name: "other-auth",
-						},
-					},
-				},
+				*v1beta1test.NewMCPRemoteProxy("backend-proxy", "default",
+					v1beta1test.WithRemoteProxyGroupRef("test-group"),
+					v1beta1test.WithRemoteProxyExternalAuthConfigRef("other-auth"),
+				),
 			},
 			authConfigName: "test-auth",
 			expected:       false,

--- a/cmd/thv-operator/pkg/controllerutil/config_test.go
+++ b/cmd/thv-operator/pkg/controllerutil/config_test.go
@@ -401,22 +401,16 @@ func TestGetTelemetryConfigForMCPRemoteProxy(t *testing.T) {
 		expectedName    string
 	}{
 		{
-			name: "nil ref returns nil without error",
-			proxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-proxy", Namespace: "default"},
-				Spec:       mcpv1beta1.MCPRemoteProxySpec{TelemetryConfigRef: nil},
-			},
+			name:        "nil ref returns nil without error",
+			proxy:       v1beta1test.NewMCPRemoteProxy("test-proxy", "default"),
 			expectNil:   true,
 			expectError: false,
 		},
 		{
 			name: "fetches referenced config",
-			proxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-proxy", Namespace: "default"},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					TelemetryConfigRef: &mcpv1beta1.MCPTelemetryConfigReference{Name: "my-telemetry"},
-				},
-			},
+			proxy: v1beta1test.NewMCPRemoteProxy("test-proxy", "default",
+				v1beta1test.WithRemoteProxyTelemetryConfigRef("my-telemetry"),
+			),
 			telemetryConfig: &mcpv1beta1.MCPTelemetryConfig{
 				ObjectMeta: metav1.ObjectMeta{Name: "my-telemetry", Namespace: "default"},
 			},
@@ -426,23 +420,17 @@ func TestGetTelemetryConfigForMCPRemoteProxy(t *testing.T) {
 		},
 		{
 			name: "not found returns nil without error",
-			proxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-proxy", Namespace: "default"},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					TelemetryConfigRef: &mcpv1beta1.MCPTelemetryConfigReference{Name: "missing"},
-				},
-			},
+			proxy: v1beta1test.NewMCPRemoteProxy("test-proxy", "default",
+				v1beta1test.WithRemoteProxyTelemetryConfigRef("missing"),
+			),
 			expectNil:   true,
 			expectError: false,
 		},
 		{
 			name: "cross-namespace returns nil (not found)",
-			proxy: &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-proxy", Namespace: "namespace-b"},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					TelemetryConfigRef: &mcpv1beta1.MCPTelemetryConfigReference{Name: "shared-config"},
-				},
-			},
+			proxy: v1beta1test.NewMCPRemoteProxy("test-proxy", "namespace-b",
+				v1beta1test.WithRemoteProxyTelemetryConfigRef("shared-config"),
+			),
 			telemetryConfig: &mcpv1beta1.MCPTelemetryConfig{
 				ObjectMeta: metav1.ObjectMeta{Name: "shared-config", Namespace: "namespace-a"},
 			},

--- a/cmd/thv-operator/test-integration/mcp-oidc-config/mcpoidcconfig_mcpremoteproxy_integration_test.go
+++ b/cmd/thv-operator/test-integration/mcp-oidc-config/mcpoidcconfig_mcpremoteproxy_integration_test.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1/v1beta1test"
 )
 
 const (
@@ -23,27 +24,21 @@ const (
 // newTestMCPRemoteProxy creates an MCPRemoteProxy with an optional OIDCConfigRef pointing
 // to a shared MCPOIDCConfig (when oidcConfigRefName is non-empty).
 func newTestMCPRemoteProxy(name, namespace string, oidcConfigRefName string) *mcpv1beta1.MCPRemoteProxy {
-	proxy := &mcpv1beta1.MCPRemoteProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-		},
-		Spec: mcpv1beta1.MCPRemoteProxySpec{
-			RemoteURL: testRemoteURL,
-			ProxyPort: 8080,
-			Transport: "streamable-http",
-		},
+	opts := []v1beta1test.MCPRemoteProxyOption{
+		v1beta1test.WithRemoteProxyURL(testRemoteURL),
+		v1beta1test.WithRemoteProxyTransport("streamable-http"),
 	}
 
 	if oidcConfigRefName != "" {
-		proxy.Spec.OIDCConfigRef = &mcpv1beta1.MCPOIDCConfigReference{
-			Name:     oidcConfigRefName,
-			Audience: "test-proxy-audience",
-			Scopes:   []string{"openid"},
-		}
+		opts = append(opts,
+			v1beta1test.WithRemoteProxyOIDCConfigRef(oidcConfigRefName, "test-proxy-audience"),
+			v1beta1test.MutateRemoteProxy(func(p *mcpv1beta1.MCPRemoteProxy) {
+				p.Spec.OIDCConfigRef.Scopes = []string{"openid"}
+			}),
+		)
 	}
 
-	return proxy
+	return v1beta1test.NewMCPRemoteProxy(name, namespace, opts...)
 }
 
 var _ = Describe("MCPOIDCConfig and MCPRemoteProxy Cross-Resource Integration Tests", func() {

--- a/cmd/thv-operator/test-integration/mcp-remote-proxy/mcpremoteproxy_authzconfig_cel_test.go
+++ b/cmd/thv-operator/test-integration/mcp-remote-proxy/mcpremoteproxy_authzconfig_cel_test.go
@@ -8,9 +8,9 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1/v1beta1test"
 )
 
 // newRemoteProxyWithAuthz builds a minimal MCPRemoteProxy whose authz pair is
@@ -20,14 +20,14 @@ func newRemoteProxyWithAuthz(
 	authzConfig *mcpv1beta1.AuthzConfigRef,
 	authzConfigRef *mcpv1beta1.MCPAuthzConfigReference,
 ) *mcpv1beta1.MCPRemoteProxy {
-	return &mcpv1beta1.MCPRemoteProxy{
-		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
-		Spec: mcpv1beta1.MCPRemoteProxySpec{
-			RemoteURL:      "https://example.com",
-			AuthzConfig:    authzConfig,
-			AuthzConfigRef: authzConfigRef,
-		},
-	}
+	return v1beta1test.NewMCPRemoteProxy(name, namespace,
+		v1beta1test.WithRemoteProxyURL("https://example.com"),
+		v1beta1test.WithRemoteProxyPort(0),
+		v1beta1test.WithRemoteProxyAuthzConfig(authzConfig),
+		v1beta1test.MutateRemoteProxy(func(p *mcpv1beta1.MCPRemoteProxy) {
+			p.Spec.AuthzConfigRef = authzConfigRef
+		}),
+	)
 }
 
 var _ = Describe("CEL Validation for authzConfig vs authzConfigRef on MCPRemoteProxy",

--- a/cmd/thv-operator/test-integration/mcp-remote-proxy/mcpremoteproxy_authzconfigref_integration_test.go
+++ b/cmd/thv-operator/test-integration/mcp-remote-proxy/mcpremoteproxy_authzconfigref_integration_test.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1/v1beta1test"
 )
 
 // The MCPAuthzConfig controller is not registered in this suite, so we pre-seed
@@ -53,14 +54,12 @@ var _ = Describe("MCPRemoteProxy AuthzConfigRef Integration Tests", func() {
 	}
 
 	newProxy := func(name, namespace, authzRefName string) *mcpv1beta1.MCPRemoteProxy {
-		return &mcpv1beta1.MCPRemoteProxy{
-			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
-			Spec: mcpv1beta1.MCPRemoteProxySpec{
-				RemoteURL:      "https://example.com",
-				Transport:      "streamable-http",
-				AuthzConfigRef: &mcpv1beta1.MCPAuthzConfigReference{Name: authzRefName},
-			},
-		}
+		return v1beta1test.NewMCPRemoteProxy(name, namespace,
+			v1beta1test.WithRemoteProxyURL("https://example.com"),
+			v1beta1test.WithRemoteProxyPort(0),
+			v1beta1test.WithRemoteProxyTransport("streamable-http"),
+			v1beta1test.WithRemoteProxyAuthzConfigRef(authzRefName),
+		)
 	}
 
 	const (

--- a/cmd/thv-operator/test-integration/mcp-telemetry-config/mcptelemetryconfig_controller_integration_test.go
+++ b/cmd/thv-operator/test-integration/mcp-telemetry-config/mcptelemetryconfig_controller_integration_test.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1/v1beta1test"
 )
 
 const (
@@ -351,18 +352,11 @@ var _ = Describe("MCPTelemetryConfig Controller", func() {
 		}, timeout, interval).Should(BeTrue())
 
 		// Create an MCPRemoteProxy that references this config
-		proxy := &mcpv1beta1.MCPRemoteProxy{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "proxy-ref-tracking",
-				Namespace: "default",
-			},
-			Spec: mcpv1beta1.MCPRemoteProxySpec{
-				RemoteURL: "https://example.com/mcp",
-				TelemetryConfigRef: &mcpv1beta1.MCPTelemetryConfigReference{
-					Name: "test-proxy-ref-tracking",
-				},
-			},
-		}
+		proxy := v1beta1test.NewMCPRemoteProxy("proxy-ref-tracking", "default",
+			v1beta1test.WithRemoteProxyURL("https://example.com/mcp"),
+			v1beta1test.WithRemoteProxyPort(0),
+			v1beta1test.WithRemoteProxyTelemetryConfigRef("test-proxy-ref-tracking"),
+		)
 		Expect(k8sClient.Create(ctx, proxy)).To(Succeed())
 
 		// The MCPRemoteProxy watch should trigger reconciliation of MCPTelemetryConfig.
@@ -418,18 +412,11 @@ var _ = Describe("MCPTelemetryConfig Controller", func() {
 		}, timeout, interval).Should(BeTrue())
 
 		// Create an MCPRemoteProxy that references this config
-		proxy := &mcpv1beta1.MCPRemoteProxy{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "proxy-deletion-blocker",
-				Namespace: "default",
-			},
-			Spec: mcpv1beta1.MCPRemoteProxySpec{
-				RemoteURL: "https://example.com/mcp",
-				TelemetryConfigRef: &mcpv1beta1.MCPTelemetryConfigReference{
-					Name: "test-proxy-deletion-protection",
-				},
-			},
-		}
+		proxy := v1beta1test.NewMCPRemoteProxy("proxy-deletion-blocker", "default",
+			v1beta1test.WithRemoteProxyURL("https://example.com/mcp"),
+			v1beta1test.WithRemoteProxyPort(0),
+			v1beta1test.WithRemoteProxyTelemetryConfigRef("test-proxy-deletion-protection"),
+		)
 		Expect(k8sClient.Create(ctx, proxy)).To(Succeed())
 
 		// Wait for ReferencingWorkloads to include the proxy

--- a/pkg/vmcp/k8s/backend_reconciler_integration_test.go
+++ b/pkg/vmcp/k8s/backend_reconciler_integration_test.go
@@ -25,6 +25,7 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1/v1beta1test"
 	"github.com/stacklok/toolhive/pkg/vmcp"
 	"github.com/stacklok/toolhive/pkg/vmcp/k8s"
 	"github.com/stacklok/toolhive/pkg/vmcp/workloads"
@@ -93,10 +94,10 @@ var _ = Describe("BackendReconciler Integration Tests", func() {
 	)
 
 	var (
-		registry         vmcp.DynamicRegistry
-		reconcilerMgr    ctrl.Manager
-		reconcilerCtx    context.Context
-		reconcilerStop   context.CancelFunc
+		registry          vmcp.DynamicRegistry
+		reconcilerMgr     ctrl.Manager
+		reconcilerCtx     context.Context
+		reconcilerStop    context.CancelFunc
 		reconcilerStopped chan struct{}
 	)
 
@@ -254,16 +255,11 @@ var _ = Describe("BackendReconciler Integration Tests", func() {
 	Context("MCPRemoteProxy Lifecycle", func() {
 		It("should add MCPRemoteProxy to registry when created with matching groupRef", func() {
 			// Create MCPRemoteProxy
-			proxy := &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-proxy-add",
-					Namespace: testNamespace,
-				},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					GroupRef:  &mcpv1beta1.MCPGroupRef{Name: testGroupRef},
-					RemoteURL: "https://example.com/mcp",
-				},
-			}
+			proxy := v1beta1test.NewMCPRemoteProxy("test-proxy-add", testNamespace,
+				v1beta1test.WithRemoteProxyGroupRef(testGroupRef),
+				v1beta1test.WithRemoteProxyURL("https://example.com/mcp"),
+				v1beta1test.WithRemoteProxyPort(0),
+			)
 
 			Expect(k8sClient.Create(ctx, proxy)).Should(Succeed())
 			defer func() {
@@ -279,16 +275,11 @@ var _ = Describe("BackendReconciler Integration Tests", func() {
 
 		It("should NOT add MCPRemoteProxy with mismatched groupRef", func() {
 			// Create MCPRemoteProxy with different groupRef
-			proxy := &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-proxy-mismatch",
-					Namespace: testNamespace,
-				},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					GroupRef:  &mcpv1beta1.MCPGroupRef{Name: "other-group"},
-					RemoteURL: "https://example.com/mcp",
-				},
-			}
+			proxy := v1beta1test.NewMCPRemoteProxy("test-proxy-mismatch", testNamespace,
+				v1beta1test.WithRemoteProxyGroupRef("other-group"),
+				v1beta1test.WithRemoteProxyURL("https://example.com/mcp"),
+				v1beta1test.WithRemoteProxyPort(0),
+			)
 
 			Expect(k8sClient.Create(ctx, proxy)).Should(Succeed())
 			defer func() {
@@ -313,8 +304,8 @@ var _ = Describe("BackendReconciler Integration Tests", func() {
 					Namespace: testNamespace,
 				},
 				Spec: mcpv1beta1.MCPServerSpec{
-					GroupRef: &mcpv1beta1.MCPGroupRef{Name: testGroupRef},
-					Image:    "test-image:latest",
+					GroupRef:  &mcpv1beta1.MCPGroupRef{Name: testGroupRef},
+					Image:     "test-image:latest",
 					Transport: "streamable-http",
 				},
 			}

--- a/pkg/vmcp/k8s/backend_reconciler_test.go
+++ b/pkg/vmcp/k8s/backend_reconciler_test.go
@@ -18,6 +18,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1/v1beta1test"
 	"github.com/stacklok/toolhive/pkg/vmcp"
 	"github.com/stacklok/toolhive/pkg/vmcp/k8s"
 	"github.com/stacklok/toolhive/pkg/vmcp/workloads"
@@ -297,15 +298,11 @@ func TestReconcile_MCPRemoteProxy_Success(t *testing.T) {
 	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
 
 	// Create MCPRemoteProxy with matching groupRef
-	mcpRemoteProxy := &mcpv1beta1.MCPRemoteProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-proxy",
-			Namespace: "default",
-		},
-		Spec: mcpv1beta1.MCPRemoteProxySpec{
-			GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group"},
-		},
-	}
+	mcpRemoteProxy := v1beta1test.NewMCPRemoteProxy("test-proxy", "default",
+		v1beta1test.WithRemoteProxyGroupRef("test-group"),
+		v1beta1test.WithRemoteProxyURL(""),
+		v1beta1test.WithRemoteProxyPort(0),
+	)
 
 	k8sClient := fake.NewClientBuilder().
 		WithScheme(scheme).

--- a/pkg/vmcp/workloads/k8s_test.go
+++ b/pkg/vmcp/workloads/k8s_test.go
@@ -17,6 +17,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1/v1beta1test"
 	"github.com/stacklok/toolhive/pkg/vmcp"
 )
 
@@ -518,35 +519,21 @@ func TestListWorkloadsInGroup_MCPRemoteProxies(t *testing.T) {
 	namespace := testNamespace
 
 	// Create multiple MCPRemoteProxies in different groups
-	proxy1 := &mcpv1beta1.MCPRemoteProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "proxy1",
-			Namespace: namespace,
-		},
-		Spec: mcpv1beta1.MCPRemoteProxySpec{
-			GroupRef: &mcpv1beta1.MCPGroupRef{Name: "group-a"},
-		},
-	}
-
-	proxy2 := &mcpv1beta1.MCPRemoteProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "proxy2",
-			Namespace: namespace,
-		},
-		Spec: mcpv1beta1.MCPRemoteProxySpec{
-			GroupRef: &mcpv1beta1.MCPGroupRef{Name: "group-a"},
-		},
-	}
-
-	proxy3 := &mcpv1beta1.MCPRemoteProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "proxy3",
-			Namespace: namespace,
-		},
-		Spec: mcpv1beta1.MCPRemoteProxySpec{
-			GroupRef: &mcpv1beta1.MCPGroupRef{Name: "group-b"},
-		},
-	}
+	proxy1 := v1beta1test.NewMCPRemoteProxy("proxy1", namespace,
+		v1beta1test.WithRemoteProxyGroupRef("group-a"),
+		v1beta1test.WithRemoteProxyURL(""),
+		v1beta1test.WithRemoteProxyPort(0),
+	)
+	proxy2 := v1beta1test.NewMCPRemoteProxy("proxy2", namespace,
+		v1beta1test.WithRemoteProxyGroupRef("group-a"),
+		v1beta1test.WithRemoteProxyURL(""),
+		v1beta1test.WithRemoteProxyPort(0),
+	)
+	proxy3 := v1beta1test.NewMCPRemoteProxy("proxy3", namespace,
+		v1beta1test.WithRemoteProxyGroupRef("group-b"),
+		v1beta1test.WithRemoteProxyURL(""),
+		v1beta1test.WithRemoteProxyPort(0),
+	)
 
 	k8sClient := setupTestClient(t, proxy1, proxy2, proxy3)
 	discoverer := NewK8SDiscovererWithClient(k8sClient, namespace)
@@ -601,25 +588,16 @@ func TestListWorkloadsInGroup_MixedWorkloads(t *testing.T) {
 	}
 
 	// Create MCPRemoteProxies
-	proxy1 := &mcpv1beta1.MCPRemoteProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "proxy1",
-			Namespace: namespace,
-		},
-		Spec: mcpv1beta1.MCPRemoteProxySpec{
-			GroupRef: &mcpv1beta1.MCPGroupRef{Name: "group-a"},
-		},
-	}
-
-	proxy2 := &mcpv1beta1.MCPRemoteProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "proxy2",
-			Namespace: namespace,
-		},
-		Spec: mcpv1beta1.MCPRemoteProxySpec{
-			GroupRef: &mcpv1beta1.MCPGroupRef{Name: "group-a"},
-		},
-	}
+	proxy1 := v1beta1test.NewMCPRemoteProxy("proxy1", namespace,
+		v1beta1test.WithRemoteProxyGroupRef("group-a"),
+		v1beta1test.WithRemoteProxyURL(""),
+		v1beta1test.WithRemoteProxyPort(0),
+	)
+	proxy2 := v1beta1test.NewMCPRemoteProxy("proxy2", namespace,
+		v1beta1test.WithRemoteProxyGroupRef("group-a"),
+		v1beta1test.WithRemoteProxyURL(""),
+		v1beta1test.WithRemoteProxyPort(0),
+	)
 
 	k8sClient := setupTestClient(t, server1, server2, proxy1, proxy2)
 	discoverer := NewK8SDiscovererWithClient(k8sClient, namespace)
@@ -698,20 +676,15 @@ func TestMCPRemoteProxyToBackend_EmptyStatusURL(t *testing.T) {
 	namespace := testNamespace
 
 	// MCPRemoteProxy is Ready with transport, but Status.URL is empty.
-	proxy := &mcpv1beta1.MCPRemoteProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "pending-proxy",
-			Namespace: namespace,
-		},
-		Spec: mcpv1beta1.MCPRemoteProxySpec{
-			RemoteURL: "https://remote-mcp.example.com",
-			Transport: "streamable-http",
-		},
-		Status: mcpv1beta1.MCPRemoteProxyStatus{
+	proxy := v1beta1test.NewMCPRemoteProxy("pending-proxy", namespace,
+		v1beta1test.WithRemoteProxyURL("https://remote-mcp.example.com"),
+		v1beta1test.WithRemoteProxyPort(0),
+		v1beta1test.WithRemoteProxyTransport("streamable-http"),
+		v1beta1test.WithRemoteProxyStatus(mcpv1beta1.MCPRemoteProxyStatus{
 			Phase: mcpv1beta1.MCPRemoteProxyPhaseReady,
 			// URL intentionally empty — not yet assigned by the operator
-		},
-	}
+		}),
+	)
 
 	k8sClient := setupTestClient(t, proxy)
 	discoverer := NewK8SDiscovererWithClient(k8sClient, namespace)
@@ -732,20 +705,15 @@ func TestMCPRemoteProxyToBackend_BasicFields(t *testing.T) {
 
 	namespace := testNamespace
 
-	proxy := &mcpv1beta1.MCPRemoteProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-proxy",
-			Namespace: namespace,
-		},
-		Spec: mcpv1beta1.MCPRemoteProxySpec{
-			RemoteURL: "https://remote-mcp.example.com",
-			Transport: "streamable-http",
-		},
-		Status: mcpv1beta1.MCPRemoteProxyStatus{
+	proxy := v1beta1test.NewMCPRemoteProxy("test-proxy", namespace,
+		v1beta1test.WithRemoteProxyURL("https://remote-mcp.example.com"),
+		v1beta1test.WithRemoteProxyPort(0),
+		v1beta1test.WithRemoteProxyTransport("streamable-http"),
+		v1beta1test.WithRemoteProxyStatus(mcpv1beta1.MCPRemoteProxyStatus{
 			Phase: mcpv1beta1.MCPRemoteProxyPhaseReady,
 			URL:   "http://proxy-service:8080",
-		},
-	}
+		}),
+	)
 
 	k8sClient := setupTestClient(t, proxy)
 	discoverer := NewK8SDiscovererWithClient(k8sClient, namespace).(*k8sDiscoverer)
@@ -771,24 +739,21 @@ func TestMCPRemoteProxyToBackend_WithAnnotations(t *testing.T) {
 
 	namespace := testNamespace
 
-	proxy := &mcpv1beta1.MCPRemoteProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-proxy",
-			Namespace: namespace,
-			Annotations: map[string]string{
-				"custom-annotation":         "custom-value",
-				"kubectl.kubernetes.io/foo": "should-be-filtered",
-			},
-		},
-		Spec: mcpv1beta1.MCPRemoteProxySpec{
-			RemoteURL: "https://remote-mcp.example.com",
-			Transport: "streamable-http",
-		},
-		Status: mcpv1beta1.MCPRemoteProxyStatus{
+	proxy := v1beta1test.NewMCPRemoteProxy("test-proxy", namespace,
+		v1beta1test.WithRemoteProxyURL("https://remote-mcp.example.com"),
+		v1beta1test.WithRemoteProxyPort(0),
+		v1beta1test.WithRemoteProxyTransport("streamable-http"),
+		v1beta1test.WithRemoteProxyStatus(mcpv1beta1.MCPRemoteProxyStatus{
 			Phase: mcpv1beta1.MCPRemoteProxyPhaseReady,
 			URL:   "http://proxy-service:8080",
-		},
-	}
+		}),
+		v1beta1test.MutateRemoteProxy(func(p *mcpv1beta1.MCPRemoteProxy) {
+			p.Annotations = map[string]string{
+				"custom-annotation":         "custom-value",
+				"kubectl.kubernetes.io/foo": "should-be-filtered",
+			}
+		}),
+	)
 
 	k8sClient := setupTestClient(t, proxy)
 	discoverer := NewK8SDiscovererWithClient(k8sClient, namespace).(*k8sDiscoverer)
@@ -840,20 +805,15 @@ func TestMCPRemoteProxyToBackend_HealthStatusMapping(t *testing.T) {
 
 			namespace := testNamespace
 
-			proxy := &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-proxy",
-					Namespace: namespace,
-				},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					RemoteURL: "https://remote-mcp.example.com",
-					Transport: "streamable-http",
-				},
-				Status: mcpv1beta1.MCPRemoteProxyStatus{
+			proxy := v1beta1test.NewMCPRemoteProxy("test-proxy", namespace,
+				v1beta1test.WithRemoteProxyURL("https://remote-mcp.example.com"),
+				v1beta1test.WithRemoteProxyPort(0),
+				v1beta1test.WithRemoteProxyTransport("streamable-http"),
+				v1beta1test.WithRemoteProxyStatus(mcpv1beta1.MCPRemoteProxyStatus{
 					Phase: tt.phase,
 					URL:   "http://proxy-service:8080",
-				},
-			}
+				}),
+			)
 
 			k8sClient := setupTestClient(t, proxy)
 			discoverer := NewK8SDiscovererWithClient(k8sClient, namespace).(*k8sDiscoverer)
@@ -872,20 +832,15 @@ func TestGetWorkloadAsVMCPBackend_MCPRemoteProxy(t *testing.T) {
 
 	namespace := testNamespace
 
-	proxy := &mcpv1beta1.MCPRemoteProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-proxy",
-			Namespace: namespace,
-		},
-		Spec: mcpv1beta1.MCPRemoteProxySpec{
-			RemoteURL: "https://remote-mcp.example.com",
-			Transport: "streamable-http",
-		},
-		Status: mcpv1beta1.MCPRemoteProxyStatus{
+	proxy := v1beta1test.NewMCPRemoteProxy("test-proxy", namespace,
+		v1beta1test.WithRemoteProxyURL("https://remote-mcp.example.com"),
+		v1beta1test.WithRemoteProxyPort(0),
+		v1beta1test.WithRemoteProxyTransport("streamable-http"),
+		v1beta1test.WithRemoteProxyStatus(mcpv1beta1.MCPRemoteProxyStatus{
 			Phase: mcpv1beta1.MCPRemoteProxyPhaseReady,
 			URL:   "http://proxy-service:8080",
-		},
-	}
+		}),
+	)
 
 	k8sClient := setupTestClient(t, proxy)
 	discoverer := NewK8SDiscovererWithClient(k8sClient, namespace)
@@ -942,23 +897,16 @@ func TestDiscoverAuth_MCPRemoteProxy_TokenExchange(t *testing.T) {
 	}
 
 	// Create MCPRemoteProxy that references the auth config
-	proxy := &mcpv1beta1.MCPRemoteProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-proxy",
-			Namespace: namespace,
-		},
-		Spec: mcpv1beta1.MCPRemoteProxySpec{
-			RemoteURL: "https://remote-mcp.example.com",
-			Transport: "streamable-http",
-			ExternalAuthConfigRef: &mcpv1beta1.ExternalAuthConfigRef{
-				Name: "test-token-exchange",
-			},
-		},
-		Status: mcpv1beta1.MCPRemoteProxyStatus{
+	proxy := v1beta1test.NewMCPRemoteProxy("test-proxy", namespace,
+		v1beta1test.WithRemoteProxyURL("https://remote-mcp.example.com"),
+		v1beta1test.WithRemoteProxyPort(0),
+		v1beta1test.WithRemoteProxyTransport("streamable-http"),
+		v1beta1test.WithRemoteProxyExternalAuthConfigRef("test-token-exchange"),
+		v1beta1test.WithRemoteProxyStatus(mcpv1beta1.MCPRemoteProxyStatus{
 			Phase: mcpv1beta1.MCPRemoteProxyPhaseReady,
 			URL:   "http://proxy-service:8080",
-		},
-	}
+		}),
+	)
 
 	k8sClient := setupTestClient(t, secret, authConfig, proxy)
 	discoverer := NewK8SDiscovererWithClient(k8sClient, namespace)
@@ -1062,15 +1010,11 @@ func TestListWorkloadsInGroup_AllWorkloadTypes(t *testing.T) {
 		},
 	}
 
-	proxy := &mcpv1beta1.MCPRemoteProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "proxy1",
-			Namespace: namespace,
-		},
-		Spec: mcpv1beta1.MCPRemoteProxySpec{
-			GroupRef: &mcpv1beta1.MCPGroupRef{Name: "group-a"},
-		},
-	}
+	proxy := v1beta1test.NewMCPRemoteProxy("proxy1", namespace,
+		v1beta1test.WithRemoteProxyGroupRef("group-a"),
+		v1beta1test.WithRemoteProxyURL(""),
+		v1beta1test.WithRemoteProxyPort(0),
+	)
 
 	entry := &mcpv1beta1.MCPServerEntry{
 		ObjectMeta: metav1.ObjectMeta{

--- a/test/e2e/thv-operator/virtualmcp/mcpremoteproxy_scaling_test.go
+++ b/test/e2e/thv-operator/virtualmcp/mcpremoteproxy_scaling_test.go
@@ -21,6 +21,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1/v1beta1test"
 	"github.com/stacklok/toolhive/test/e2e/images"
 	"github.com/stacklok/toolhive/test/e2e/thv-operator/testutil"
 )
@@ -102,21 +103,20 @@ var _ = ginkgo.Describe("MCPRemoteProxy Cross-Replica Session Routing with Redis
 				backendName, defaultNamespace, proxyPort)
 
 			ginkgo.By("Creating MCPRemoteProxy with replicas=2, Redis session storage, and sessionAffinity=None")
-			gomega.Expect(k8sClient.Create(ctx, &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{Name: proxyName, Namespace: defaultNamespace},
-				Spec: mcpv1beta1.MCPRemoteProxySpec{
-					RemoteURL:       backendURL,
-					Transport:       "streamable-http",
-					ProxyPort:       proxyPort,
-					Replicas:        &replicas,
-					SessionAffinity: "None",
-					SessionStorage: &mcpv1beta1.SessionStorageConfig{
-						Provider:  mcpv1beta1.SessionStorageProviderRedis,
-						Address:   redisAddr,
-						KeyPrefix: "thv:remoteproxy:e2e:",
-					},
-				},
-			})).To(gomega.Succeed())
+			gomega.Expect(k8sClient.Create(ctx, v1beta1test.NewMCPRemoteProxy(proxyName, defaultNamespace,
+				v1beta1test.WithRemoteProxyURL(backendURL),
+				v1beta1test.WithRemoteProxyTransport("streamable-http"),
+				v1beta1test.WithRemoteProxyPort(proxyPort),
+				v1beta1test.WithRemoteProxyReplicas(replicas),
+				v1beta1test.MutateRemoteProxy(func(p *mcpv1beta1.MCPRemoteProxy) {
+					p.Spec.SessionAffinity = "None"
+				}),
+				v1beta1test.WithRemoteProxySessionStorage(&mcpv1beta1.SessionStorageConfig{
+					Provider:  mcpv1beta1.SessionStorageProviderRedis,
+					Address:   redisAddr,
+					KeyPrefix: "thv:remoteproxy:e2e:",
+				}),
+			))).To(gomega.Succeed())
 
 			ginkgo.By("Waiting for MCPRemoteProxy to reach the Ready phase")
 			gomega.Eventually(func() error {
@@ -144,9 +144,7 @@ var _ = ginkgo.Describe("MCPRemoteProxy Cross-Replica Session Routing with Redis
 		})
 
 		ginkgo.AfterAll(func() {
-			_ = k8sClient.Delete(ctx, &mcpv1beta1.MCPRemoteProxy{
-				ObjectMeta: metav1.ObjectMeta{Name: proxyName, Namespace: defaultNamespace},
-			})
+			_ = k8sClient.Delete(ctx, v1beta1test.NewMCPRemoteProxy(proxyName, defaultNamespace))
 			_ = k8sClient.Delete(ctx, &mcpv1beta1.MCPServer{
 				ObjectMeta: metav1.ObjectMeta{Name: backendName, Namespace: defaultNamespace},
 			})


### PR DESCRIPTION
## Summary

`MCPRemoteProxy` test fixtures repeat the same `ObjectMeta` + `RemoteURL`/`ProxyPort` (and auth/telemetry/group ref) boilerplate across the operator unit tests, the envtest integration tests, the vMCP package tests, and the operator e2e tests. This PR converts **all** manual `MCPRemoteProxy` object construction to the `v1beta1test.NewMCPRemoteProxy` builder (merged in #5576), removing ~1,700 lines of test boilerplate with no behavior change.

Rebased onto `main` — the builder (#5576) and the MCPServer migration (#5566) it was previously stacked on are now merged, so this PR is a single self-contained commit.

<details>
<summary><strong>What changed</strong></summary>

- Replaces `MCPRemoteProxy` literals with `v1beta1test.NewMCPRemoteProxy(name, ns, opts...)` across:
  - operator unit tests (`cmd/thv-operator/controllers/`, `cmd/thv-operator/pkg/controllerutil/`)
  - envtest integration tests (`cmd/thv-operator/test-integration/`)
  - vMCP package tests (`pkg/vmcp/k8s/`, `pkg/vmcp/workloads/`)
  - operator e2e tests (`test/e2e/thv-operator/virtualmcp/`)
- Builder defaults `RemoteURL="https://mcp.example.com"` and `ProxyPort=8080` (the dominant literal values); call sites that used those omit the option, others pin via `WithRemoteProxyURL` / `WithRemoteProxyPort`. Ref fields use their respective options (`WithRemoteProxyGroupRef`, `WithRemoteProxyAuthzConfig`/`WithRemoteProxyAuthzConfigRef`, `WithRemoteProxyExternalAuthConfigRef`, `WithRemoteProxyTelemetryConfigRef`, `WithRemoteProxyOIDCConfigRef`, `WithRemoteProxyStatus`, `WithRemoteProxyReplicas`, …). Fields without a dedicated option (e.g. `SessionAffinity`, `Scopes`, annotations) use `MutateRemoteProxy`.
- Defaults hazard handled: where a literal omitted `RemoteURL`/`ProxyPort` and the value is observed, the original zero value is pinned explicitly so constructed objects stay semantically identical.
- Left inline (per design): empty `&MCPRemoteProxy{}` decode/Get targets, `WithStatusSubresource`/`WithIndex`/`IndexField` type references.
- Only `MCPRemoteProxy` construction is touched; no other CRD type, no assertions, and no production code changed.

</details>

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring
- [ ] Documentation
- [ ] Other

## Test plan

- [x] `task operator-test` passes (the behavior gate)
- [x] `go test -count=1 -run '^$' ./cmd/thv-operator/... ./pkg/vmcp/... ./test/e2e/thv-operator/...` compiles all affected test binaries (incl. `-tags integration` for `pkg/vmcp/k8s`)
- [x] `task lint-fix` reports no new issues in the changed files

## Large PR Justification
- Is a large mechanical PR. Lots of changing of function call sites

## Special notes for reviewers

Test-only, mechanical, agent-driven migration following the same pattern as #5566. Builder defined in #5576. Rebased onto `main`; the diff is a single commit.

Generated with [Claude Code](https://claude.com/claude-code)
