### PR TITLE
Migrate EmbeddingServer test fixtures to v1beta1test

### DIFF
--- a/cmd/thv-operator/controllers/embeddingserver_controller_test.go
+++ b/cmd/thv-operator/controllers/embeddingserver_controller_test.go
@@ -21,6 +21,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1/v1beta1test"
 	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 	ctrlutil "github.com/stacklok/toolhive/cmd/thv-operator/pkg/controllerutil"
 )
@@ -333,17 +334,13 @@ func TestEmbeddingServer_ModelCacheConfig(t *testing.T) {
 // Test helpers
 
 func createTestEmbeddingServer(name, namespace, image, model string) *mcpv1beta1.EmbeddingServer {
-	return &mcpv1beta1.EmbeddingServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:       name,
-			Namespace:  namespace,
-			Generation: 1,
-		},
-		Spec: mcpv1beta1.EmbeddingServerSpec{
-			Image: image,
-			Model: model,
-		},
-	}
+	return v1beta1test.NewEmbeddingServer(name, namespace,
+		v1beta1test.WithEmbeddingImage(image),
+		v1beta1test.WithEmbeddingModel(model),
+		v1beta1test.MutateEmbedding(func(e *mcpv1beta1.EmbeddingServer) {
+			e.Generation = 1
+		}),
+	)
 }
 
 // TestReconcile_NotFound tests reconciliation when resource is not found
@@ -479,14 +476,14 @@ func TestStatefulSetNeedsUpdate(t *testing.T) {
 		},
 		{
 			name: "update needed - port changed",
-			embedding: &mcpv1beta1.EmbeddingServer{
-				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: testNamespaceDefault, Generation: 1},
-				Spec: mcpv1beta1.EmbeddingServerSpec{
-					Image: "image:v1",
-					Model: "model1",
-					Port:  9090,
-				},
-			},
+			embedding: v1beta1test.NewEmbeddingServer("test", testNamespaceDefault,
+				v1beta1test.WithEmbeddingImage("image:v1"),
+				v1beta1test.WithEmbeddingModel("model1"),
+				v1beta1test.WithEmbeddingPort(9090),
+				v1beta1test.MutateEmbedding(func(e *mcpv1beta1.EmbeddingServer) {
+					e.Generation = 1
+				}),
+			),
 			existingSts:    generateSts(createTestEmbeddingServer("test", testNamespaceDefault, "image:v1", "model1")),
 			expectedUpdate: true,
 			updateReason:   "port changed",
@@ -517,35 +514,24 @@ func TestHandleDeletion(t *testing.T) {
 	}{
 		{
 			name: "not being deleted",
-			embedding: &mcpv1beta1.EmbeddingServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:       "test",
-					Namespace:  testNamespaceDefault,
-					Finalizers: []string{embeddingFinalizerName},
-				},
-				Spec: mcpv1beta1.EmbeddingServerSpec{
-					Image: "test:latest",
-					Model: "test-model",
-				},
-			},
+			embedding: v1beta1test.NewEmbeddingServer("test", testNamespaceDefault,
+				v1beta1test.WithEmbeddingImage("test:latest"),
+				v1beta1test.WithEmbeddingModel("test-model"),
+				v1beta1test.MutateEmbedding(func(e *mcpv1beta1.EmbeddingServer) {
+					e.Finalizers = []string{embeddingFinalizerName}
+				}),
+			),
 			expectDone:      false,
 			expectError:     false,
 			expectFinalizer: true,
 		},
 		{
 			name: "being deleted with finalizer",
-			embedding: &mcpv1beta1.EmbeddingServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:              "test",
-					Namespace:         testNamespaceDefault,
-					Finalizers:        []string{embeddingFinalizerName},
-					DeletionTimestamp: &metav1.Time{Time: time.Now()},
-				},
-				Spec: mcpv1beta1.EmbeddingServerSpec{
-					Image: "test:latest",
-					Model: "test-model",
-				},
-			},
+			embedding: v1beta1test.NewEmbeddingServer("test", testNamespaceDefault,
+				v1beta1test.WithEmbeddingImage("test:latest"),
+				v1beta1test.WithEmbeddingModel("test-model"),
+				v1beta1test.WithEmbeddingDeletionTimestamp(metav1.Time{Time: time.Now()}, embeddingFinalizerName),
+			),
 			expectDone:      true,
 			expectError:     false,
 			expectFinalizer: false,
@@ -625,12 +611,14 @@ func TestEnsureStatefulSet(t *testing.T) {
 		},
 		{
 			name: "update replicas",
-			embedding: func() *mcpv1beta1.EmbeddingServer {
-				e := createTestEmbeddingServer("test", testNamespaceDefault, "image:v1", "model1")
-				replicas := int32(3)
-				e.Spec.Replicas = &replicas
-				return e
-			}(),
+			embedding: v1beta1test.NewEmbeddingServer("test", testNamespaceDefault,
+				v1beta1test.WithEmbeddingImage("image:v1"),
+				v1beta1test.WithEmbeddingModel("model1"),
+				v1beta1test.WithEmbeddingReplicas(3),
+				v1beta1test.MutateEmbedding(func(e *mcpv1beta1.EmbeddingServer) {
+					e.Generation = 1
+				}),
+			),
 			existingSts: &appsv1.StatefulSet{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test",

--- a/cmd/thv-operator/controllers/virtualmcpserver_controller_test.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_controller_test.go
@@ -2976,16 +2976,12 @@ func TestVirtualMCPServerValidateEmbeddingServerRef(t *testing.T) {
 					},
 				},
 			},
-			embeddingServer: &mcpv1beta1.EmbeddingServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "shared-embedding",
-					Namespace: "default",
-				},
-				Status: mcpv1beta1.EmbeddingServerStatus{
+			embeddingServer: v1beta1test.NewEmbeddingServer("shared-embedding", "default",
+				v1beta1test.WithEmbeddingStatus(mcpv1beta1.EmbeddingServerStatus{
 					Phase:         mcpv1beta1.EmbeddingServerPhaseReady,
 					ReadyReplicas: 1,
-				},
-			},
+				}),
+			),
 			expectError: false,
 		},
 		{
@@ -3020,16 +3016,12 @@ func TestVirtualMCPServerValidateEmbeddingServerRef(t *testing.T) {
 					},
 				},
 			},
-			embeddingServer: &mcpv1beta1.EmbeddingServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "pending-embedding",
-					Namespace: "default",
-				},
-				Status: mcpv1beta1.EmbeddingServerStatus{
+			embeddingServer: v1beta1test.NewEmbeddingServer("pending-embedding", "default",
+				v1beta1test.WithEmbeddingStatus(mcpv1beta1.EmbeddingServerStatus{
 					Phase:         mcpv1beta1.EmbeddingServerPhasePending,
 					ReadyReplicas: 0,
-				},
-			},
+				}),
+			),
 			expectError: false,
 		},
 		{
@@ -3046,16 +3038,12 @@ func TestVirtualMCPServerValidateEmbeddingServerRef(t *testing.T) {
 					},
 				},
 			},
-			embeddingServer: &mcpv1beta1.EmbeddingServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "no-replicas-embedding",
-					Namespace: "default",
-				},
-				Status: mcpv1beta1.EmbeddingServerStatus{
+			embeddingServer: v1beta1test.NewEmbeddingServer("no-replicas-embedding", "default",
+				v1beta1test.WithEmbeddingStatus(mcpv1beta1.EmbeddingServerStatus{
 					Phase:         mcpv1beta1.EmbeddingServerPhaseReady,
 					ReadyReplicas: 0,
-				},
-			},
+				}),
+			),
 			expectError: false,
 		},
 	}

--- a/cmd/thv-operator/controllers/virtualmcpserver_vmcpconfig_test.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_vmcpconfig_test.go
@@ -1941,23 +1941,17 @@ func TestOptimizerEmbeddingServiceURL(t *testing.T) {
 
 			// Create the EmbeddingServer with Status.URL if one is expected
 			if tt.esName != "" {
-				es := &mcpv1beta1.EmbeddingServer{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      tt.esName,
-						Namespace: testNamespace,
-					},
-					Spec: mcpv1beta1.EmbeddingServerSpec{
-						Image: "ghcr.io/huggingface/text-embeddings-inference:cpu-1.5",
-						Model: "BAAI/bge-small-en-v1.5",
-						Port:  tt.esPort,
-					},
-					Status: mcpv1beta1.EmbeddingServerStatus{
+				es := v1beta1test.NewEmbeddingServer(tt.esName, testNamespace,
+					v1beta1test.WithEmbeddingImage("ghcr.io/huggingface/text-embeddings-inference:cpu-1.5"),
+					v1beta1test.WithEmbeddingModel("BAAI/bge-small-en-v1.5"),
+					v1beta1test.WithEmbeddingPort(tt.esPort),
+					v1beta1test.WithEmbeddingStatus(mcpv1beta1.EmbeddingServerStatus{
 						Phase:         mcpv1beta1.EmbeddingServerPhaseReady,
 						ReadyReplicas: 1,
 						URL: fmt.Sprintf("http://%s.%s.svc.cluster.local:%d",
 							tt.esName, testNamespace, tt.esPort),
-					},
-				}
+					}),
+				)
 				objects = append(objects, es)
 			}
 

--- a/cmd/thv-operator/controllers/virtualmcpserver_watch_test.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_watch_test.go
@@ -1707,13 +1707,8 @@ func TestMapEmbeddingServerToVirtualMCPServer(t *testing.T) {
 		expectedNames     []string
 	}{
 		{
-			name: "single VirtualMCPServer references EmbeddingServer",
-			embeddingServer: &mcpv1beta1.EmbeddingServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "shared-embedding",
-					Namespace: "default",
-				},
-			},
+			name:            "single VirtualMCPServer references EmbeddingServer",
+			embeddingServer: v1beta1test.NewEmbeddingServer("shared-embedding", "default"),
 			virtualMCPServers: []mcpv1beta1.VirtualMCPServer{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -1730,13 +1725,8 @@ func TestMapEmbeddingServerToVirtualMCPServer(t *testing.T) {
 			expectedNames:    []string{"vmcp-1"},
 		},
 		{
-			name: "multiple VirtualMCPServers share EmbeddingServer",
-			embeddingServer: &mcpv1beta1.EmbeddingServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "shared-embedding",
-					Namespace: "default",
-				},
-			},
+			name:            "multiple VirtualMCPServers share EmbeddingServer",
+			embeddingServer: v1beta1test.NewEmbeddingServer("shared-embedding", "default"),
 			virtualMCPServers: []mcpv1beta1.VirtualMCPServer{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -1763,13 +1753,8 @@ func TestMapEmbeddingServerToVirtualMCPServer(t *testing.T) {
 			expectedNames:    []string{"vmcp-1", "vmcp-2"},
 		},
 		{
-			name: "no VirtualMCPServers reference EmbeddingServer",
-			embeddingServer: &mcpv1beta1.EmbeddingServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "shared-embedding",
-					Namespace: "default",
-				},
-			},
+			name:            "no VirtualMCPServers reference EmbeddingServer",
+			embeddingServer: v1beta1test.NewEmbeddingServer("shared-embedding", "default"),
 			virtualMCPServers: []mcpv1beta1.VirtualMCPServer{
 				{
 					ObjectMeta: metav1.ObjectMeta{

--- a/cmd/thv-operator/test-integration/embedding-server/embeddingserver_creation_test.go
+++ b/cmd/thv-operator/test-integration/embedding-server/embeddingserver_creation_test.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1/v1beta1test"
 )
 
 // TestCase defines a table-driven test case for EmbeddingServer controller
@@ -154,17 +155,7 @@ var _ = Describe("EmbeddingServer Controller Integration Tests", func() {
 		{
 			Name: "When creating an EmbeddingServer with minimal config (verifies defaults)",
 			InitialState: InitialState{
-				EmbeddingServer: &mcpv1beta1.EmbeddingServer{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-defaults",
-						Namespace: defaultNamespace,
-					},
-					Spec: mcpv1beta1.EmbeddingServerSpec{
-						// Only required fields - model and image
-						Model: "sentence-transformers/all-MiniLM-L6-v2",
-						Image: "ghcr.io/huggingface/text-embeddings-inference:latest",
-					},
-				},
+				EmbeddingServer: v1beta1test.NewEmbeddingServer("test-defaults", defaultNamespace),
 			},
 			FinalState: FinalState{
 				StatefulSet: &appsv1.StatefulSet{
@@ -217,17 +208,7 @@ var _ = Describe("EmbeddingServer Controller Integration Tests", func() {
 		{
 			Name: "When creating a basic EmbeddingServer",
 			InitialState: InitialState{
-				EmbeddingServer: &mcpv1beta1.EmbeddingServer{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-basic",
-						Namespace: defaultNamespace,
-					},
-					Spec: mcpv1beta1.EmbeddingServerSpec{
-						Model: "sentence-transformers/all-MiniLM-L6-v2",
-						Image: "ghcr.io/huggingface/text-embeddings-inference:latest",
-						Port:  8080,
-					},
-				},
+				EmbeddingServer: v1beta1test.NewEmbeddingServer("test-basic", defaultNamespace),
 			},
 			FinalState: FinalState{
 				StatefulSet: &appsv1.StatefulSet{
@@ -272,21 +253,12 @@ var _ = Describe("EmbeddingServer Controller Integration Tests", func() {
 		{
 			Name: "When creating an EmbeddingServer with model cache enabled",
 			InitialState: InitialState{
-				EmbeddingServer: &mcpv1beta1.EmbeddingServer{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-with-cache",
-						Namespace: defaultNamespace,
-					},
-					Spec: mcpv1beta1.EmbeddingServerSpec{
-						Model: "sentence-transformers/all-MiniLM-L6-v2",
-						Image: "ghcr.io/huggingface/text-embeddings-inference:latest",
-						Port:  8080,
-						ModelCache: &mcpv1beta1.ModelCacheConfig{
-							Enabled: true,
-							Size:    "20Gi",
-						},
-					},
-				},
+				EmbeddingServer: v1beta1test.NewEmbeddingServer("test-with-cache", defaultNamespace,
+					v1beta1test.WithEmbeddingModelCache(&mcpv1beta1.ModelCacheConfig{
+						Enabled: true,
+						Size:    "20Gi",
+					}),
+				),
 			},
 			FinalState: FinalState{
 				StatefulSet: &appsv1.StatefulSet{
@@ -318,21 +290,14 @@ var _ = Describe("EmbeddingServer Controller Integration Tests", func() {
 		{
 			Name: "When creating an EmbeddingServer with resource requirements",
 			InitialState: InitialState{
-				EmbeddingServer: &mcpv1beta1.EmbeddingServer{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-resources",
-						Namespace: defaultNamespace,
-					},
-					Spec: mcpv1beta1.EmbeddingServerSpec{
-						Model: "sentence-transformers/all-MiniLM-L6-v2",
-						Image: "ghcr.io/huggingface/text-embeddings-inference:latest",
-						Port:  8080,
-						Resources: mcpv1beta1.ResourceRequirements{
+				EmbeddingServer: v1beta1test.NewEmbeddingServer("test-resources", defaultNamespace,
+					v1beta1test.MutateEmbedding(func(e *mcpv1beta1.EmbeddingServer) {
+						e.Spec.Resources = mcpv1beta1.ResourceRequirements{
 							Limits:   mcpv1beta1.ResourceList{CPU: "2", Memory: "4Gi"},
 							Requests: mcpv1beta1.ResourceList{CPU: "500m", Memory: "1Gi"},
-						},
-					},
-				},
+						}
+					}),
+				),
 			},
 			FinalState: FinalState{
 				StatefulSet: &appsv1.StatefulSet{
@@ -355,18 +320,9 @@ var _ = Describe("EmbeddingServer Controller Integration Tests", func() {
 		{
 			Name: "When creating an EmbeddingServer with custom replicas",
 			InitialState: InitialState{
-				EmbeddingServer: &mcpv1beta1.EmbeddingServer{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-replicas",
-						Namespace: defaultNamespace,
-					},
-					Spec: mcpv1beta1.EmbeddingServerSpec{
-						Model:    "sentence-transformers/all-MiniLM-L6-v2",
-						Image:    "ghcr.io/huggingface/text-embeddings-inference:latest",
-						Port:     8080,
-						Replicas: ptr.To(int32(3)),
-					},
-				},
+				EmbeddingServer: v1beta1test.NewEmbeddingServer("test-replicas", defaultNamespace,
+					v1beta1test.WithEmbeddingReplicas(3),
+				),
 			},
 			FinalState: FinalState{
 				StatefulSet: &appsv1.StatefulSet{
@@ -379,20 +335,11 @@ var _ = Describe("EmbeddingServer Controller Integration Tests", func() {
 		{
 			Name: "When creating an EmbeddingServer with invalid PodTemplateSpec",
 			InitialState: InitialState{
-				EmbeddingServer: &mcpv1beta1.EmbeddingServer{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-invalid-podtemplate",
-						Namespace: defaultNamespace,
-					},
-					Spec: mcpv1beta1.EmbeddingServerSpec{
-						Model: "sentence-transformers/all-MiniLM-L6-v2",
-						Image: "ghcr.io/huggingface/text-embeddings-inference:latest",
-						Port:  8080,
-						PodTemplateSpec: &runtime.RawExtension{
-							Raw: []byte(`{"spec": {"containers": "invalid-not-an-array"}}`),
-						},
-					},
-				},
+				EmbeddingServer: v1beta1test.NewEmbeddingServer("test-invalid-podtemplate", defaultNamespace,
+					v1beta1test.WithEmbeddingPodTemplateSpec(&runtime.RawExtension{
+						Raw: []byte(`{"spec": {"containers": "invalid-not-an-array"}}`),
+					}),
+				),
 			},
 			FinalState: FinalState{
 				Status: &mcpv1beta1.EmbeddingServerStatus{
@@ -408,20 +355,11 @@ var _ = Describe("EmbeddingServer Controller Integration Tests", func() {
 		{
 			Name: "When creating an EmbeddingServer with valid PodTemplateSpec (nodeSelector)",
 			InitialState: InitialState{
-				EmbeddingServer: &mcpv1beta1.EmbeddingServer{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-valid-podtemplate",
-						Namespace: defaultNamespace,
-					},
-					Spec: mcpv1beta1.EmbeddingServerSpec{
-						Model: "sentence-transformers/all-MiniLM-L6-v2",
-						Image: "ghcr.io/huggingface/text-embeddings-inference:latest",
-						Port:  8080,
-						PodTemplateSpec: &runtime.RawExtension{
-							Raw: []byte(`{"spec":{"nodeSelector":{"disktype":"ssd"}}}`),
-						},
-					},
-				},
+				EmbeddingServer: v1beta1test.NewEmbeddingServer("test-valid-podtemplate", defaultNamespace,
+					v1beta1test.WithEmbeddingPodTemplateSpec(&runtime.RawExtension{
+						Raw: []byte(`{"spec":{"nodeSelector":{"disktype":"ssd"}}}`),
+					}),
+				),
 			},
 			FinalState: FinalState{
 				StatefulSet: &appsv1.StatefulSet{
@@ -444,21 +382,12 @@ var _ = Describe("EmbeddingServer Controller Integration Tests", func() {
 		{
 			Name: "When creating an EmbeddingServer with HuggingFace token secret",
 			InitialState: InitialState{
-				EmbeddingServer: &mcpv1beta1.EmbeddingServer{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-hf-token",
-						Namespace: defaultNamespace,
-					},
-					Spec: mcpv1beta1.EmbeddingServerSpec{
-						Model: "sentence-transformers/all-MiniLM-L6-v2",
-						Image: "ghcr.io/huggingface/text-embeddings-inference:latest",
-						Port:  8080,
-						HFTokenSecretRef: &mcpv1beta1.SecretKeyRef{
-							Name: "hf-token-secret",
-							Key:  "token",
-						},
-					},
-				},
+				EmbeddingServer: v1beta1test.NewEmbeddingServer("test-hf-token", defaultNamespace,
+					v1beta1test.WithEmbeddingHFTokenSecretRef(&mcpv1beta1.SecretKeyRef{
+						Name: "hf-token-secret",
+						Key:  "token",
+					}),
+				),
 				Secrets: []*corev1.Secret{{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "hf-token-secret",
@@ -493,21 +422,12 @@ var _ = Describe("EmbeddingServer Controller Integration Tests", func() {
 		{
 			Name: "When creating an EmbeddingServer with custom environment variables",
 			InitialState: InitialState{
-				EmbeddingServer: &mcpv1beta1.EmbeddingServer{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-custom-env",
-						Namespace: defaultNamespace,
-					},
-					Spec: mcpv1beta1.EmbeddingServerSpec{
-						Model: "sentence-transformers/all-MiniLM-L6-v2",
-						Image: "ghcr.io/huggingface/text-embeddings-inference:latest",
-						Port:  8080,
-						Env: []mcpv1beta1.EnvVar{
-							{Name: "CUSTOM_VAR_1", Value: "value1"},
-							{Name: "CUSTOM_VAR_2", Value: "value2"},
-						},
-					},
-				},
+				EmbeddingServer: v1beta1test.NewEmbeddingServer("test-custom-env", defaultNamespace,
+					v1beta1test.WithEmbeddingEnv(
+						mcpv1beta1.EnvVar{Name: "CUSTOM_VAR_1", Value: "value1"},
+						mcpv1beta1.EnvVar{Name: "CUSTOM_VAR_2", Value: "value2"},
+					),
+				),
 			},
 			FinalState: FinalState{
 				StatefulSet: &appsv1.StatefulSet{
@@ -530,18 +450,9 @@ var _ = Describe("EmbeddingServer Controller Integration Tests", func() {
 		{
 			Name: "When creating an EmbeddingServer with custom args",
 			InitialState: InitialState{
-				EmbeddingServer: &mcpv1beta1.EmbeddingServer{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-custom-args",
-						Namespace: defaultNamespace,
-					},
-					Spec: mcpv1beta1.EmbeddingServerSpec{
-						Model: "sentence-transformers/all-MiniLM-L6-v2",
-						Image: "ghcr.io/huggingface/text-embeddings-inference:latest",
-						Port:  8080,
-						Args:  []string{"--max-concurrent-requests", "512", "--tokenization-workers", "4"},
-					},
-				},
+				EmbeddingServer: v1beta1test.NewEmbeddingServer("test-custom-args", defaultNamespace,
+					v1beta1test.WithEmbeddingArgs("--max-concurrent-requests", "512", "--tokenization-workers", "4"),
+				),
 			},
 			FinalState: FinalState{
 				StatefulSet: &appsv1.StatefulSet{
@@ -561,17 +472,9 @@ var _ = Describe("EmbeddingServer Controller Integration Tests", func() {
 		{
 			Name: "When creating an EmbeddingServer with custom port",
 			InitialState: InitialState{
-				EmbeddingServer: &mcpv1beta1.EmbeddingServer{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-custom-port",
-						Namespace: defaultNamespace,
-					},
-					Spec: mcpv1beta1.EmbeddingServerSpec{
-						Model: "sentence-transformers/all-MiniLM-L6-v2",
-						Image: "ghcr.io/huggingface/text-embeddings-inference:latest",
-						Port:  9090,
-					},
-				},
+				EmbeddingServer: v1beta1test.NewEmbeddingServer("test-custom-port", defaultNamespace,
+					v1beta1test.WithEmbeddingPort(9090),
+				),
 			},
 			FinalState: FinalState{
 				StatefulSet: &appsv1.StatefulSet{
@@ -593,17 +496,9 @@ var _ = Describe("EmbeddingServer Controller Integration Tests", func() {
 		{
 			Name: "When creating an EmbeddingServer with ImagePullPolicy Always",
 			InitialState: InitialState{
-				EmbeddingServer: &mcpv1beta1.EmbeddingServer{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-imagepullpolicy-always",
-						Namespace: defaultNamespace,
-					},
-					Spec: mcpv1beta1.EmbeddingServerSpec{
-						Model:           "sentence-transformers/all-MiniLM-L6-v2",
-						Image:           "ghcr.io/huggingface/text-embeddings-inference:latest",
-						ImagePullPolicy: corev1.PullAlways,
-					},
-				},
+				EmbeddingServer: v1beta1test.NewEmbeddingServer("test-imagepullpolicy-always", defaultNamespace,
+					v1beta1test.WithEmbeddingImagePullPolicy(corev1.PullAlways),
+				),
 			},
 			FinalState: FinalState{
 				StatefulSet: &appsv1.StatefulSet{
@@ -623,17 +518,9 @@ var _ = Describe("EmbeddingServer Controller Integration Tests", func() {
 		{
 			Name: "When creating an EmbeddingServer with ImagePullPolicy Never",
 			InitialState: InitialState{
-				EmbeddingServer: &mcpv1beta1.EmbeddingServer{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-imagepullpolicy-never",
-						Namespace: defaultNamespace,
-					},
-					Spec: mcpv1beta1.EmbeddingServerSpec{
-						Model:           "sentence-transformers/all-MiniLM-L6-v2",
-						Image:           "ghcr.io/huggingface/text-embeddings-inference:latest",
-						ImagePullPolicy: corev1.PullNever,
-					},
-				},
+				EmbeddingServer: v1beta1test.NewEmbeddingServer("test-imagepullpolicy-never", defaultNamespace,
+					v1beta1test.WithEmbeddingImagePullPolicy(corev1.PullNever),
+				),
 			},
 			FinalState: FinalState{
 				StatefulSet: &appsv1.StatefulSet{
@@ -653,21 +540,13 @@ var _ = Describe("EmbeddingServer Controller Integration Tests", func() {
 		{
 			Name: "When creating an EmbeddingServer with model cache and custom storage class",
 			InitialState: InitialState{
-				EmbeddingServer: &mcpv1beta1.EmbeddingServer{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-cache-storageclass",
-						Namespace: defaultNamespace,
-					},
-					Spec: mcpv1beta1.EmbeddingServerSpec{
-						Model: "sentence-transformers/all-MiniLM-L6-v2",
-						Image: "ghcr.io/huggingface/text-embeddings-inference:latest",
-						ModelCache: &mcpv1beta1.ModelCacheConfig{
-							Enabled:          true,
-							Size:             "50Gi",
-							StorageClassName: ptr.To("fast-ssd"),
-						},
-					},
-				},
+				EmbeddingServer: v1beta1test.NewEmbeddingServer("test-cache-storageclass", defaultNamespace,
+					v1beta1test.WithEmbeddingModelCache(&mcpv1beta1.ModelCacheConfig{
+						Enabled:          true,
+						Size:             "50Gi",
+						StorageClassName: ptr.To("fast-ssd"),
+					}),
+				),
 			},
 			FinalState: FinalState{
 				StatefulSet: &appsv1.StatefulSet{
@@ -689,21 +568,13 @@ var _ = Describe("EmbeddingServer Controller Integration Tests", func() {
 		{
 			Name: "When creating an EmbeddingServer with model cache ReadWriteMany access mode",
 			InitialState: InitialState{
-				EmbeddingServer: &mcpv1beta1.EmbeddingServer{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-cache-rwx",
-						Namespace: defaultNamespace,
-					},
-					Spec: mcpv1beta1.EmbeddingServerSpec{
-						Model: "sentence-transformers/all-MiniLM-L6-v2",
-						Image: "ghcr.io/huggingface/text-embeddings-inference:latest",
-						ModelCache: &mcpv1beta1.ModelCacheConfig{
-							Enabled:    true,
-							Size:       "10Gi",
-							AccessMode: "ReadWriteMany",
-						},
-					},
-				},
+				EmbeddingServer: v1beta1test.NewEmbeddingServer("test-cache-rwx", defaultNamespace,
+					v1beta1test.WithEmbeddingModelCache(&mcpv1beta1.ModelCacheConfig{
+						Enabled:    true,
+						Size:       "10Gi",
+						AccessMode: "ReadWriteMany",
+					}),
+				),
 			},
 			FinalState: FinalState{
 				StatefulSet: &appsv1.StatefulSet{
@@ -721,19 +592,11 @@ var _ = Describe("EmbeddingServer Controller Integration Tests", func() {
 		{
 			Name: "When creating an EmbeddingServer with PodTemplateSpec tolerations",
 			InitialState: InitialState{
-				EmbeddingServer: &mcpv1beta1.EmbeddingServer{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-tolerations",
-						Namespace: defaultNamespace,
-					},
-					Spec: mcpv1beta1.EmbeddingServerSpec{
-						Model: "sentence-transformers/all-MiniLM-L6-v2",
-						Image: "ghcr.io/huggingface/text-embeddings-inference:latest",
-						PodTemplateSpec: &runtime.RawExtension{
-							Raw: []byte(`{"spec":{"tolerations":[{"key":"gpu","operator":"Exists","effect":"NoSchedule"}]}}`),
-						},
-					},
-				},
+				EmbeddingServer: v1beta1test.NewEmbeddingServer("test-tolerations", defaultNamespace,
+					v1beta1test.WithEmbeddingPodTemplateSpec(&runtime.RawExtension{
+						Raw: []byte(`{"spec":{"tolerations":[{"key":"gpu","operator":"Exists","effect":"NoSchedule"}]}}`),
+					}),
+				),
 			},
 			FinalState: FinalState{
 				StatefulSet: &appsv1.StatefulSet{
@@ -754,19 +617,11 @@ var _ = Describe("EmbeddingServer Controller Integration Tests", func() {
 		{
 			Name: "When creating an EmbeddingServer with PodTemplateSpec serviceAccountName",
 			InitialState: InitialState{
-				EmbeddingServer: &mcpv1beta1.EmbeddingServer{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-serviceaccount",
-						Namespace: defaultNamespace,
-					},
-					Spec: mcpv1beta1.EmbeddingServerSpec{
-						Model: "sentence-transformers/all-MiniLM-L6-v2",
-						Image: "ghcr.io/huggingface/text-embeddings-inference:latest",
-						PodTemplateSpec: &runtime.RawExtension{
-							Raw: []byte(`{"spec":{"serviceAccountName":"custom-sa"}}`),
-						},
-					},
-				},
+				EmbeddingServer: v1beta1test.NewEmbeddingServer("test-serviceaccount", defaultNamespace,
+					v1beta1test.WithEmbeddingPodTemplateSpec(&runtime.RawExtension{
+						Raw: []byte(`{"spec":{"serviceAccountName":"custom-sa"}}`),
+					}),
+				),
 			},
 			FinalState: FinalState{
 				StatefulSet: &appsv1.StatefulSet{
@@ -784,24 +639,18 @@ var _ = Describe("EmbeddingServer Controller Integration Tests", func() {
 		{
 			Name: "When creating an EmbeddingServer with ResourceOverrides on StatefulSet",
 			InitialState: InitialState{
-				EmbeddingServer: &mcpv1beta1.EmbeddingServer{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-resource-overrides-sts",
-						Namespace: defaultNamespace,
-					},
-					Spec: mcpv1beta1.EmbeddingServerSpec{
-						Model: "sentence-transformers/all-MiniLM-L6-v2",
-						Image: "ghcr.io/huggingface/text-embeddings-inference:latest",
-						ResourceOverrides: &mcpv1beta1.EmbeddingResourceOverrides{
+				EmbeddingServer: v1beta1test.NewEmbeddingServer("test-resource-overrides-sts", defaultNamespace,
+					v1beta1test.MutateEmbedding(func(e *mcpv1beta1.EmbeddingServer) {
+						e.Spec.ResourceOverrides = &mcpv1beta1.EmbeddingResourceOverrides{
 							StatefulSet: &mcpv1beta1.EmbeddingStatefulSetOverrides{
 								ResourceMetadataOverrides: mcpv1beta1.ResourceMetadataOverrides{
 									Annotations: map[string]string{"custom-annotation": "sts-value"},
 									Labels:      map[string]string{"custom-label": "sts-value"},
 								},
 							},
-						},
-					},
-				},
+						}
+					}),
+				),
 			},
 			FinalState: FinalState{
 				StatefulSet: &appsv1.StatefulSet{
@@ -823,22 +672,16 @@ var _ = Describe("EmbeddingServer Controller Integration Tests", func() {
 		{
 			Name: "When creating an EmbeddingServer with ResourceOverrides on Service",
 			InitialState: InitialState{
-				EmbeddingServer: &mcpv1beta1.EmbeddingServer{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-resource-overrides-svc",
-						Namespace: defaultNamespace,
-					},
-					Spec: mcpv1beta1.EmbeddingServerSpec{
-						Model: "sentence-transformers/all-MiniLM-L6-v2",
-						Image: "ghcr.io/huggingface/text-embeddings-inference:latest",
-						ResourceOverrides: &mcpv1beta1.EmbeddingResourceOverrides{
+				EmbeddingServer: v1beta1test.NewEmbeddingServer("test-resource-overrides-svc", defaultNamespace,
+					v1beta1test.MutateEmbedding(func(e *mcpv1beta1.EmbeddingServer) {
+						e.Spec.ResourceOverrides = &mcpv1beta1.EmbeddingResourceOverrides{
 							Service: &mcpv1beta1.ResourceMetadataOverrides{
 								Annotations: map[string]string{"service-annotation": "svc-value"},
 								Labels:      map[string]string{"service-label": "svc-value"},
 							},
-						},
-					},
-				},
+						}
+					}),
+				),
 			},
 			FinalState: FinalState{
 				Service: &corev1.Service{
@@ -863,24 +706,18 @@ var _ = Describe("EmbeddingServer Controller Integration Tests", func() {
 		{
 			Name: "When creating an EmbeddingServer with ResourceOverrides on pod template",
 			InitialState: InitialState{
-				EmbeddingServer: &mcpv1beta1.EmbeddingServer{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-resource-overrides-pod",
-						Namespace: defaultNamespace,
-					},
-					Spec: mcpv1beta1.EmbeddingServerSpec{
-						Model: "sentence-transformers/all-MiniLM-L6-v2",
-						Image: "ghcr.io/huggingface/text-embeddings-inference:latest",
-						ResourceOverrides: &mcpv1beta1.EmbeddingResourceOverrides{
+				EmbeddingServer: v1beta1test.NewEmbeddingServer("test-resource-overrides-pod", defaultNamespace,
+					v1beta1test.MutateEmbedding(func(e *mcpv1beta1.EmbeddingServer) {
+						e.Spec.ResourceOverrides = &mcpv1beta1.EmbeddingResourceOverrides{
 							StatefulSet: &mcpv1beta1.EmbeddingStatefulSetOverrides{
 								PodTemplateMetadataOverrides: &mcpv1beta1.ResourceMetadataOverrides{
 									Annotations: map[string]string{"pod-annotation": "pod-value"},
 									Labels:      map[string]string{"pod-label": "pod-value"},
 								},
 							},
-						},
-					},
-				},
+						}
+					}),
+				),
 			},
 			FinalState: FinalState{
 				StatefulSet: &appsv1.StatefulSet{
@@ -905,17 +742,7 @@ var _ = Describe("EmbeddingServer Controller Integration Tests", func() {
 		{
 			Name: "When creating an EmbeddingServer verifies container port",
 			InitialState: InitialState{
-				EmbeddingServer: &mcpv1beta1.EmbeddingServer{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-container-port",
-						Namespace: defaultNamespace,
-					},
-					Spec: mcpv1beta1.EmbeddingServerSpec{
-						Model: "sentence-transformers/all-MiniLM-L6-v2",
-						Image: "ghcr.io/huggingface/text-embeddings-inference:latest",
-						Port:  8080,
-					},
-				},
+				EmbeddingServer: v1beta1test.NewEmbeddingServer("test-container-port", defaultNamespace),
 			},
 			FinalState: FinalState{
 				StatefulSet: &appsv1.StatefulSet{
@@ -939,16 +766,7 @@ var _ = Describe("EmbeddingServer Controller Integration Tests", func() {
 		{
 			Name: "When creating an EmbeddingServer verifies Service selector and type",
 			InitialState: InitialState{
-				EmbeddingServer: &mcpv1beta1.EmbeddingServer{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-service-selector",
-						Namespace: defaultNamespace,
-					},
-					Spec: mcpv1beta1.EmbeddingServerSpec{
-						Model: "sentence-transformers/all-MiniLM-L6-v2",
-						Image: "ghcr.io/huggingface/text-embeddings-inference:latest",
-					},
-				},
+				EmbeddingServer: v1beta1test.NewEmbeddingServer("test-service-selector", defaultNamespace),
 			},
 			FinalState: FinalState{
 				Service: &corev1.Service{

--- a/cmd/thv-operator/test-integration/embedding-server/embeddingserver_update_test.go
+++ b/cmd/thv-operator/test-integration/embedding-server/embeddingserver_update_test.go
@@ -16,6 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1/v1beta1test"
 )
 
 // UpdateTestCase defines a test case for EmbeddingServer update scenarios.
@@ -46,17 +47,9 @@ var _ = Describe("EmbeddingServer Controller Update Tests", func() {
 	updateTestCases := []UpdateTestCase{
 		{
 			Name: "When updating EmbeddingServer image",
-			InitialState: &mcpv1beta1.EmbeddingServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-update-image",
-					Namespace: defaultNamespace,
-				},
-				Spec: mcpv1beta1.EmbeddingServerSpec{
-					Model: "sentence-transformers/all-MiniLM-L6-v2",
-					Image: "ghcr.io/huggingface/text-embeddings-inference:v1.0",
-					Port:  8080,
-				},
-			},
+			InitialState: v1beta1test.NewEmbeddingServer("test-update-image", defaultNamespace,
+				v1beta1test.WithEmbeddingImage("ghcr.io/huggingface/text-embeddings-inference:v1.0"),
+			),
 			Updates: []UpdateStep{
 				{
 					Name: "Should update StatefulSet when image changes to v2.0",
@@ -96,18 +89,9 @@ var _ = Describe("EmbeddingServer Controller Update Tests", func() {
 		},
 		{
 			Name: "When updating EmbeddingServer replicas",
-			InitialState: &mcpv1beta1.EmbeddingServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-update-replicas",
-					Namespace: defaultNamespace,
-				},
-				Spec: mcpv1beta1.EmbeddingServerSpec{
-					Model:    "sentence-transformers/all-MiniLM-L6-v2",
-					Image:    "ghcr.io/huggingface/text-embeddings-inference:latest",
-					Port:     8080,
-					Replicas: ptr.To(int32(1)),
-				},
-			},
+			InitialState: v1beta1test.NewEmbeddingServer("test-update-replicas", defaultNamespace,
+				v1beta1test.WithEmbeddingReplicas(1),
+			),
 			Updates: []UpdateStep{
 				{
 					Name: "Should scale up to 3 replicas",
@@ -134,18 +118,8 @@ var _ = Describe("EmbeddingServer Controller Update Tests", func() {
 			},
 		},
 		{
-			Name: "When updating EmbeddingServer model",
-			InitialState: &mcpv1beta1.EmbeddingServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-update-model",
-					Namespace: defaultNamespace,
-				},
-				Spec: mcpv1beta1.EmbeddingServerSpec{
-					Model: "sentence-transformers/all-MiniLM-L6-v2",
-					Image: "ghcr.io/huggingface/text-embeddings-inference:latest",
-					Port:  8080,
-				},
-			},
+			Name:         "When updating EmbeddingServer model",
+			InitialState: v1beta1test.NewEmbeddingServer("test-update-model", defaultNamespace),
 			Updates: []UpdateStep{
 				{
 					Name: "Should update StatefulSet args when model changes",
@@ -168,20 +142,11 @@ var _ = Describe("EmbeddingServer Controller Update Tests", func() {
 		},
 		{
 			Name: "When updating EmbeddingServer environment variables",
-			InitialState: &mcpv1beta1.EmbeddingServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-update-env",
-					Namespace: defaultNamespace,
-				},
-				Spec: mcpv1beta1.EmbeddingServerSpec{
-					Model: "sentence-transformers/all-MiniLM-L6-v2",
-					Image: "ghcr.io/huggingface/text-embeddings-inference:latest",
-					Port:  8080,
-					Env: []mcpv1beta1.EnvVar{
-						{Name: "LOG_LEVEL", Value: "info"},
-					},
-				},
-			},
+			InitialState: v1beta1test.NewEmbeddingServer("test-update-env", defaultNamespace,
+				v1beta1test.WithEmbeddingEnv(
+					mcpv1beta1.EnvVar{Name: "LOG_LEVEL", Value: "info"},
+				),
+			),
 			Updates: []UpdateStep{
 				{
 					Name: "Should update StatefulSet when env var value changes",
@@ -228,18 +193,8 @@ var _ = Describe("EmbeddingServer Controller Update Tests", func() {
 			},
 		},
 		{
-			Name: "When updating EmbeddingServer port",
-			InitialState: &mcpv1beta1.EmbeddingServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-update-port",
-					Namespace: defaultNamespace,
-				},
-				Spec: mcpv1beta1.EmbeddingServerSpec{
-					Model: "sentence-transformers/all-MiniLM-L6-v2",
-					Image: "ghcr.io/huggingface/text-embeddings-inference:latest",
-					Port:  8080,
-				},
-			},
+			Name:         "When updating EmbeddingServer port",
+			InitialState: v1beta1test.NewEmbeddingServer("test-update-port", defaultNamespace),
 			Updates: []UpdateStep{
 				{
 					Name: "Should update StatefulSet and Service when port changes",
@@ -267,20 +222,14 @@ var _ = Describe("EmbeddingServer Controller Update Tests", func() {
 		},
 		{
 			Name: "When updating EmbeddingServer resources",
-			InitialState: &mcpv1beta1.EmbeddingServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-update-resources",
-					Namespace: defaultNamespace,
-				},
-				Spec: mcpv1beta1.EmbeddingServerSpec{
-					Model: "sentence-transformers/all-MiniLM-L6-v2",
-					Image: "ghcr.io/huggingface/text-embeddings-inference:latest",
-					Resources: mcpv1beta1.ResourceRequirements{
+			InitialState: v1beta1test.NewEmbeddingServer("test-update-resources", defaultNamespace,
+				v1beta1test.MutateEmbedding(func(e *mcpv1beta1.EmbeddingServer) {
+					e.Spec.Resources = mcpv1beta1.ResourceRequirements{
 						Limits:   mcpv1beta1.ResourceList{CPU: "1", Memory: "2Gi"},
 						Requests: mcpv1beta1.ResourceList{CPU: "500m", Memory: "1Gi"},
-					},
-				},
-			},
+					}
+				}),
+			),
 			Updates: []UpdateStep{
 				{
 					Name: "Should update StatefulSet when resource limits change",
@@ -315,17 +264,9 @@ var _ = Describe("EmbeddingServer Controller Update Tests", func() {
 		},
 		{
 			Name: "When updating EmbeddingServer args",
-			InitialState: &mcpv1beta1.EmbeddingServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-update-args",
-					Namespace: defaultNamespace,
-				},
-				Spec: mcpv1beta1.EmbeddingServerSpec{
-					Model: "sentence-transformers/all-MiniLM-L6-v2",
-					Image: "ghcr.io/huggingface/text-embeddings-inference:latest",
-					Args:  []string{"--max-concurrent-requests", "256"},
-				},
-			},
+			InitialState: v1beta1test.NewEmbeddingServer("test-update-args", defaultNamespace,
+				v1beta1test.WithEmbeddingArgs("--max-concurrent-requests", "256"),
+			),
 			Updates: []UpdateStep{
 				{
 					Name: "Should update StatefulSet when args change",
@@ -365,17 +306,9 @@ var _ = Describe("EmbeddingServer Controller Update Tests", func() {
 		},
 		{
 			Name: "When updating EmbeddingServer ImagePullPolicy",
-			InitialState: &mcpv1beta1.EmbeddingServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-update-imagepullpolicy",
-					Namespace: defaultNamespace,
-				},
-				Spec: mcpv1beta1.EmbeddingServerSpec{
-					Model:           "sentence-transformers/all-MiniLM-L6-v2",
-					Image:           "ghcr.io/huggingface/text-embeddings-inference:latest",
-					ImagePullPolicy: corev1.PullIfNotPresent,
-				},
-			},
+			InitialState: v1beta1test.NewEmbeddingServer("test-update-imagepullpolicy", defaultNamespace,
+				v1beta1test.WithEmbeddingImagePullPolicy(corev1.PullIfNotPresent),
+			),
 			Updates: []UpdateStep{
 				{
 					Name: "Should update StatefulSet when ImagePullPolicy changes",
@@ -397,17 +330,8 @@ var _ = Describe("EmbeddingServer Controller Update Tests", func() {
 			},
 		},
 		{
-			Name: "When updating EmbeddingServer ResourceOverrides",
-			InitialState: &mcpv1beta1.EmbeddingServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-update-resourceoverrides",
-					Namespace: defaultNamespace,
-				},
-				Spec: mcpv1beta1.EmbeddingServerSpec{
-					Model: "sentence-transformers/all-MiniLM-L6-v2",
-					Image: "ghcr.io/huggingface/text-embeddings-inference:latest",
-				},
-			},
+			Name:         "When updating EmbeddingServer ResourceOverrides",
+			InitialState: v1beta1test.NewEmbeddingServer("test-update-resourceoverrides", defaultNamespace),
 			Updates: []UpdateStep{
 				{
 					Name: "Should update StatefulSet when adding annotations",

--- a/test/e2e/thv-operator/virtualmcp/virtualmcp_optimizer_circuit_breaker_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcp_optimizer_circuit_breaker_test.go
@@ -17,6 +17,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1/v1beta1test"
 	vmcpconfig "github.com/stacklok/toolhive/pkg/vmcp/config"
 	"github.com/stacklok/toolhive/test/e2e/images"
 )
@@ -48,16 +49,10 @@ var _ = Describe("VirtualMCPServer Optimizer with Circuit Breaker", Ordered, fun
 			mcpGroupName, images.YardstickServerImage, timeout, pollingInterval)
 
 		By("Creating EmbeddingServer for optimizer")
-		embeddingServer := &mcpv1beta1.EmbeddingServer{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      embeddingName,
-				Namespace: testNamespace,
-			},
-			Spec: mcpv1beta1.EmbeddingServerSpec{
-				Model: "BAAI/bge-small-en-v1.5",
-				Image: images.TextEmbeddingsInferenceImage,
-			},
-		}
+		embeddingServer := v1beta1test.NewEmbeddingServer(embeddingName, testNamespace,
+			v1beta1test.WithEmbeddingModel("BAAI/bge-small-en-v1.5"),
+			v1beta1test.WithEmbeddingImage(images.TextEmbeddingsInferenceImage),
+		)
 		Expect(k8sClient.Create(ctx, embeddingServer)).To(Succeed())
 
 		By("Creating VirtualMCPServer with optimizer and circuit breaker enabled")

--- a/test/e2e/thv-operator/virtualmcp/virtualmcp_optimizer_multibackend_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcp_optimizer_multibackend_test.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1/v1beta1test"
 	vmcp "github.com/stacklok/toolhive/pkg/vmcp"
 	vmcpconfig "github.com/stacklok/toolhive/pkg/vmcp/config"
 	"github.com/stacklok/toolhive/test/e2e/images"
@@ -164,16 +165,10 @@ var _ = Describe("VirtualMCPServer Optimizer Multi-Backend", Ordered, func() {
 		CreateMultipleMCPServersInParallel(ctx, k8sClient, allBackends, timeout, pollingInterval)
 
 		By("Creating EmbeddingServer for optimizer multi-backend")
-		embeddingServer := &mcpv1beta1.EmbeddingServer{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      embeddingName,
-				Namespace: testNamespace,
-			},
-			Spec: mcpv1beta1.EmbeddingServerSpec{
-				Model: "BAAI/bge-small-en-v1.5",
-				Image: images.TextEmbeddingsInferenceImage,
-			},
-		}
+		embeddingServer := v1beta1test.NewEmbeddingServer(embeddingName, testNamespace,
+			v1beta1test.WithEmbeddingModel("BAAI/bge-small-en-v1.5"),
+			v1beta1test.WithEmbeddingImage(images.TextEmbeddingsInferenceImage),
+		)
 		Expect(k8sClient.Create(ctx, embeddingServer)).To(Succeed())
 
 		By("Creating VirtualMCPServer with optimizer enabled and prefix aggregation")

--- a/test/e2e/thv-operator/virtualmcp/virtualmcp_optimizer_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcp_optimizer_test.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1/v1beta1test"
 	thvjson "github.com/stacklok/toolhive/pkg/json"
 	vmcpconfig "github.com/stacklok/toolhive/pkg/vmcp/config"
 	"github.com/stacklok/toolhive/test/e2e/images"
@@ -50,16 +51,10 @@ var _ = Describe("VirtualMCPServer Optimizer Mode", Ordered, func() {
 			mcpGroupName, images.GofetchServerImage, timeout, pollingInterval)
 
 		By("Creating EmbeddingServer for optimizer")
-		embeddingServer := &mcpv1beta1.EmbeddingServer{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      embeddingName,
-				Namespace: testNamespace,
-			},
-			Spec: mcpv1beta1.EmbeddingServerSpec{
-				Model: "BAAI/bge-small-en-v1.5",
-				Image: images.TextEmbeddingsInferenceImage,
-			},
-		}
+		embeddingServer := v1beta1test.NewEmbeddingServer(embeddingName, testNamespace,
+			v1beta1test.WithEmbeddingModel("BAAI/bge-small-en-v1.5"),
+			v1beta1test.WithEmbeddingImage(images.TextEmbeddingsInferenceImage),
+		)
 		Expect(k8sClient.Create(ctx, embeddingServer)).To(Succeed())
 
 		By("Creating VirtualMCPServer with optimizer enabled and a composite tool")


### PR DESCRIPTION
## Summary

`EmbeddingServer` test fixtures repeat the same `ObjectMeta` + `Model`/`Image`/`Port` boilerplate across the controller, integration (envtest), and e2e tests. This PR converts them to the `v1beta1test.NewEmbeddingServer` builder (added in #5576), removing the duplication with no behavior change.

Now rebased onto `main` (the builder landed in #5576), so this is a clean test-only diff with no conflicts.

<details>
<summary><strong>Medium level</strong></summary>

- Routes the central `createTestEmbeddingServer` helper and the standalone fixtures through `v1beta1test.NewEmbeddingServer(name, ns, opts...)`, so the transitive call sites pick up the builder.
- Builder defaults `Model`/`Image`/`Port=8080` match the dominant literal values; non-default values pin via `WithEmbedding*` options. `Replicas`, args, env, model cache, image pull policy, HF token, pod template, status, and deletion timestamps use their respective options; anything without a dedicated option (Resources, ResourceOverrides, Labels, …) uses `MutateEmbedding`.
- Covers all three test tiers: controller unit tests, `test-integration/embedding-server` envtest suites, and the `test/e2e/.../virtualmcp` optimizer e2e tests. EmbeddingServer literals embedded in VirtualMCPServer test files are converted too, while the surrounding VirtualMCPServer fixtures are left untouched (scoped to EmbeddingServer only).
- Left inline (per design): single-field getter unit tests (`GetPort`/`GetReplicas`/`IsModelCacheEnabled`/`GetImagePullPolicy`, which assert the type's own default-resolution and would break against the builder's baked-in defaults) and empty `&EmbeddingServer{}` decode/Get targets.
- No assertions or test logic changed.

</details>

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring
- [ ] Documentation
- [ ] Other

## Test plan

- [x] `task operator-test` passes (the behavior gate)
- [x] `go test -count=1 -run '^$' ./cmd/thv-operator/test-integration/... ./test/e2e/thv-operator/virtualmcp/...` compiles the integration and e2e test binaries
- [x] `golangci-lint` clean on all changed packages

## Special notes for reviewers

Test-only, mechanical migration following the identical pattern as #5566. Scoped strictly to `EmbeddingServer` construction — no other CRD fixtures changed. Builder defined in #5576.

Generated with [Claude Code](https://claude.com/claude-code)