### PR TITLE
Fix multi-upstream authorization chain flows

### DIFF
--- a/pkg/authserver/server/handlers/callback.go
+++ b/pkg/authserver/server/handlers/callback.go
@@ -396,6 +396,19 @@ func (h *Handler) continueChainOrComplete(
 	name string,
 	email string,
 ) {
+	// SingleLeg authorizations intentionally bypass chain continuation: the caller
+	// scoped this flow to one specific upstream (e.g. a UI-initiated "connect one
+	// backend" request), so other configured-but-tokenless upstreams must not
+	// hijack it into a full chain walk. Issue the authorization code immediately.
+	if pending.SingleLeg {
+		if err := h.writeAuthorizationResponse(ctx, w, pending, sessionID, subject, name, email); err != nil {
+			slog.Error("failed to create authorization response", "error", err)
+			_ = h.storage.DeleteUpstreamTokens(ctx, sessionID)
+			h.provider.WriteAuthorizeError(ctx, w, ar, fosite.ErrServerError.WithHint("failed to create authorization code"))
+		}
+		return
+	}
+
 	nextProvider, err := h.nextMissingUpstream(ctx, sessionID)
 	if err != nil {
 		slog.Error("failed to determine next upstream", "error", err)

--- a/pkg/authserver/server/handlers/callback.go
+++ b/pkg/authserver/server/handlers/callback.go
@@ -417,10 +417,17 @@ func (h *Handler) continueChainOrComplete(
 	// scoped this flow to one specific upstream (e.g. a UI-initiated "connect one
 	// backend" request), so other configured-but-tokenless upstreams must not
 	// hijack it into a full chain walk. Issue the authorization code immediately.
+	//
+	// On failure we deliberately do NOT delete the stored upstream tokens. The
+	// leg's token was already fetched and stored validly before we got here; the
+	// errors writeAuthorizationResponse can return are all server-side and
+	// unrelated to that credential (client lookup, redirect-URI parse, or fosite
+	// failing to mint the authorization code). Wiping a good upstream token would
+	// force a needless re-auth on what is a retryable error, so we keep it and
+	// just surface the failure to the client.
 	if pending.SingleLeg {
 		if err := h.writeAuthorizationResponse(ctx, w, pending, sessionID, subject, name, email); err != nil {
 			slog.Error("failed to create authorization response", "error", err)
-			_ = h.storage.DeleteUpstreamTokens(ctx, sessionID)
 			h.provider.WriteAuthorizeError(ctx, w, ar, fosite.ErrServerError.WithHint("failed to create authorization code"))
 		}
 		return

--- a/pkg/authserver/server/handlers/callback.go
+++ b/pkg/authserver/server/handlers/callback.go
@@ -168,7 +168,7 @@ func (h *Handler) CallbackHandler(w http.ResponseWriter, req *http.Request) {
 		UpstreamSubject:  providerSubject, // Upstream IDP's subject claim
 	}
 
-	h.maybeCarryForwardRefreshToken(ctx, storageTokens, subject, providerSubject, providerID)
+	h.maybeCarryForwardRefreshToken(ctx, storageTokens, subject, providerSubject, providerID, result.Synthetic)
 
 	if err := h.storage.StoreUpstreamTokens(ctx, sessionID, providerID, storageTokens); err != nil {
 		slog.Error("failed to store upstream tokens",
@@ -191,13 +191,18 @@ func (h *Handler) CallbackHandler(w http.ResponseWriter, req *http.Request) {
 //
 // The UpstreamSubject == providerSubject guard is defense-in-depth against account-linking
 // edge cases where one internal user might have two distinct upstream subjects on the
-// same provider.
+// same provider. It is skipped for synthetic providers: a synthetic identity (OAuth2 with
+// no userinfo/identity config) mints a fresh rotating subject every flow, so the equality
+// can never hold and would block carry-forward entirely. There is no stable upstream
+// subject to link by in that case, so the guard protects nothing — gating on a non-empty
+// prior refresh token is sufficient.
 //
 // storageTokens is mutated in-place only when a carry-forward is warranted.
 func (h *Handler) maybeCarryForwardRefreshToken(
 	ctx context.Context,
 	storageTokens *storage.UpstreamTokens,
 	subject, providerSubject, providerID string,
+	synthetic bool,
 ) {
 	if storageTokens.RefreshToken != "" {
 		return
@@ -205,10 +210,22 @@ func (h *Handler) maybeCarryForwardRefreshToken(
 	prior, err := h.storage.GetLatestUpstreamTokensForUser(ctx, subject, providerID)
 	switch {
 	case err == nil:
-		if prior != nil && prior.UpstreamSubject == providerSubject && prior.RefreshToken != "" {
+		// Defensive: the contract returns ErrNotFound (handled below) on a miss
+		// rather than a nil row, but guard anyway so a (nil, nil) return — or an
+		// empty prior refresh token — can never be carried forward or panic. This
+		// runs before the synthetic branch precisely so "synthetic" can never imply
+		// "carry forward from a non-existent prior row".
+		if prior == nil || prior.RefreshToken == "" {
+			return
+		}
+		// Non-synthetic: defense-in-depth account-linking guard requires the prior
+		// row's upstream subject to match. Synthetic providers mint a fresh rotating
+		// subject every flow, so that equality can never hold and there is no stable
+		// subject to link by — skip the guard and rely on the prior RT alone.
+		if synthetic || prior.UpstreamSubject == providerSubject {
 			storageTokens.RefreshToken = prior.RefreshToken
 			slog.Debug("preserved upstream refresh token from prior row",
-				"user_id", subject, "provider_id", providerID,
+				"user_id", subject, "provider_id", providerID, "synthetic", synthetic,
 			)
 		}
 	case errors.Is(err, storage.ErrNotFound):

--- a/pkg/authserver/server/handlers/callback_test.go
+++ b/pkg/authserver/server/handlers/callback_test.go
@@ -897,6 +897,7 @@ func TestCallbackHandler_RefreshTokenCarryForward(t *testing.T) {
 		priorRow         *priorRow // nil = no prior row
 		idpRefreshToken  string    // RT returned by upstream exchange
 		idpSubject       string    // subject claim returned by upstream
+		synthetic        bool      // upstream identity is synthetic (rotating subject)
 		lookupErr        error     // if non-nil, storage lookup returns this error
 		expectedStoredRT string    // expected RefreshToken on the new row
 	}{
@@ -906,6 +907,29 @@ func TestCallbackHandler_RefreshTokenCarryForward(t *testing.T) {
 			idpRefreshToken:  "",
 			idpSubject:       "user-123",
 			expectedStoredRT: "rt-prior",
+		},
+		{
+			// Synthetic providers mint a fresh rotating subject every flow, so the
+			// UpstreamSubject equality guard can never hold even though the stable
+			// user identity (carried from the first leg) does match. The RT must
+			// still be carried forward — otherwise refresh silently breaks for every
+			// userinfo-less OAuth2 backend.
+			name:             "synthetic carries prior RT despite rotating subject",
+			priorRow:         &priorRow{sessionID: "old-session", upstreamSubject: "tk-oldrotatingsubject", refreshToken: "rt-prior"},
+			idpRefreshToken:  "",
+			idpSubject:       "tk-newrotatingsubject",
+			synthetic:        true,
+			expectedStoredRT: "rt-prior",
+		},
+		{
+			// Guards the error state where the synthetic branch must not carry forward
+			// (or panic) when there is no prior row to read from.
+			name:             "synthetic with no prior row accepts empty RT",
+			priorRow:         nil,
+			idpRefreshToken:  "",
+			idpSubject:       "tk-newrotatingsubject",
+			synthetic:        true,
+			expectedStoredRT: "",
 		},
 		{
 			name:             "no carry across different upstream subjects",
@@ -969,7 +993,8 @@ func TestCallbackHandler_RefreshTokenCarryForward(t *testing.T) {
 					IDToken:      "new-id-token",
 					ExpiresAt:    time.Now().Add(time.Hour),
 				},
-				Subject: tc.idpSubject,
+				Subject:   tc.idpSubject,
+				Synthetic: tc.synthetic,
 			}
 
 			// Pre-populate user + identity so ResolveUser is deterministic.
@@ -999,7 +1024,7 @@ func TestCallbackHandler_RefreshTokenCarryForward(t *testing.T) {
 			}
 
 			internalState := testInternalState
-			storState.pendingAuths[internalState] = &storage.PendingAuthorization{
+			pendingAuth := &storage.PendingAuthorization{
 				ClientID:             testAuthClientID,
 				RedirectURI:          testAuthRedirectURI,
 				State:                "client-state",
@@ -1012,6 +1037,15 @@ func TestCallbackHandler_RefreshTokenCarryForward(t *testing.T) {
 				UpstreamProviderName: providerName,
 				CreatedAt:            time.Now(),
 			}
+			if tc.synthetic {
+				// Synthetic carry-forward only applies on a subsequent leg, where the
+				// stable user identity is carried from the first leg (so the prior row
+				// is found by UserID) while the provider's own subject rotates per flow.
+				pendingAuth.ResolvedUserID = existingUserID
+				pendingAuth.ResolvedUserName = "First Leg User"
+				pendingAuth.ResolvedUserEmail = "firstleg@example.com"
+			}
+			storState.pendingAuths[internalState] = pendingAuth
 
 			req := httptest.NewRequest(http.MethodGet, "/oauth/callback?code=test-code&state="+internalState, nil)
 			rec := httptest.NewRecorder()

--- a/pkg/authserver/server/handlers/callback_test.go
+++ b/pkg/authserver/server/handlers/callback_test.go
@@ -515,6 +515,57 @@ func TestCallbackHandler_TwoUpstreams_SecondLeg_IssuesCode(t *testing.T) {
 	assert.False(t, ok, "second leg pending should be consumed")
 }
 
+func TestCallbackHandler_SingleLeg_IssuesCodeWithoutChaining(t *testing.T) {
+	t.Parallel()
+	handler, storState, provider1, _ := multiUpstreamTestSetup(t)
+
+	// A SingleLeg pending targets provider-1 only. provider-2 is configured but has
+	// no tokens for this session, so the default chain logic would redirect into it.
+	// SingleLeg must suppress that and issue the authorization code immediately.
+	sessionID := "single-leg-session"
+	legState := "single-leg-state-abc"
+	legVerifier := "single-leg-pkce-verifier-12345678901234567890"
+
+	pending := &storage.PendingAuthorization{
+		ClientID:             testAuthClientID,
+		RedirectURI:          testAuthRedirectURI,
+		State:                "client-original-state",
+		PKCEChallenge:        "client-challenge",
+		PKCEMethod:           "S256",
+		Scopes:               []string{"openid", "profile"},
+		InternalState:        legState,
+		UpstreamPKCEVerifier: legVerifier,
+		UpstreamNonce:        "single-leg-nonce",
+		UpstreamProviderName: "provider-1",
+		SessionID:            sessionID,
+		SingleLeg:            true,
+		CreatedAt:            time.Now(),
+	}
+	storState.pendingAuths[legState] = pending
+
+	req := httptest.NewRequest(http.MethodGet, "/oauth/callback?code=provider1-code&state="+legState, nil)
+	rec := httptest.NewRecorder()
+
+	handler.CallbackHandler(rec, req)
+
+	// Should issue the authorization code (HTTP 303), not redirect to provider-2 (HTTP 302).
+	assert.Equal(t, http.StatusSeeOther, rec.Code, "single-leg flow should issue auth code, not chain to provider-2")
+	location := rec.Header().Get("Location")
+	assert.Contains(t, location, testAuthRedirectURI, "redirect should be to client's redirect_uri")
+	assert.Contains(t, location, "code=", "redirect should include authorization code")
+	assert.NotContains(t, location, "idp2.example.com", "must not redirect into the second upstream")
+
+	// provider-1's code should have been exchanged and its tokens stored.
+	assert.Equal(t, "provider1-code", provider1.capturedCode, "provider-1 should have exchanged the code")
+	assert.Contains(t, storState.upstreamTokens, sessionID+":provider-1", "provider-1 tokens should be stored")
+
+	// No second-leg pending authorization should have been created for provider-2.
+	for state, p := range storState.pendingAuths {
+		assert.NotEqualf(t, "provider-2", p.UpstreamProviderName,
+			"no chain leg should be created for provider-2 (state=%s)", state)
+	}
+}
+
 func TestCallbackHandler_TwoUpstreams_IdentityFromFirstLeg(t *testing.T) {
 	t.Parallel()
 	handler, storState, _, _ := multiUpstreamTestSetup(t)

--- a/pkg/authserver/server/handlers/handler.go
+++ b/pkg/authserver/server/handlers/handler.go
@@ -188,6 +188,9 @@ func (h *Handler) refreshExpiredLeg(
 	if h.refresher == nil || expired.RefreshToken == "" {
 		return false
 	}
+	// RefreshAndStore persists the refreshed token to storage as its side effect;
+	// the token-swap path re-reads it from storage at MCP-request time, so the
+	// returned *UpstreamTokens is intentionally discarded here.
 	if _, err := h.refresher.RefreshAndStore(ctx, sessionID, expired); err != nil {
 		slog.WarnContext(ctx, "upstream token refresh failed during chain evaluation; re-prompting",
 			"session_id", sessionID,

--- a/pkg/authserver/server/handlers/handler.go
+++ b/pkg/authserver/server/handlers/handler.go
@@ -17,7 +17,9 @@ package handlers
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"net/http"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/ory/fosite"
@@ -41,6 +43,23 @@ type Handler struct {
 	storage      storage.Storage
 	upstreams    []NamedUpstream
 	userResolver *UserResolver
+	// refresher, when set, lets nextMissingUpstream transparently refresh an
+	// expired upstream leg during chain evaluation instead of re-prompting. Nil
+	// when no refresher is configured; an expired leg is then treated as missing.
+	refresher storage.UpstreamTokenRefresher
+}
+
+// Option configures optional Handler behavior at construction time.
+type Option func(*Handler)
+
+// WithUpstreamRefresher injects a refresher used by nextMissingUpstream to
+// transparently refresh expired upstream tokens while evaluating the
+// authorization chain. When unset, an expired leg is treated as missing and the
+// user is re-prompted — the behavior before this option existed.
+func WithUpstreamRefresher(r storage.UpstreamTokenRefresher) Option {
+	return func(h *Handler) {
+		h.refresher = r
+	}
 }
 
 // NewHandler creates a new Handler with the given dependencies.
@@ -56,6 +75,7 @@ func NewHandler(
 	config *server.AuthorizationServerConfig,
 	stor storage.Storage,
 	upstreams []NamedUpstream,
+	opts ...Option,
 ) (*Handler, error) {
 	if config == nil || config.Config == nil {
 		return nil, fmt.Errorf(
@@ -72,13 +92,17 @@ func NewHandler(
 			return nil, fmt.Errorf("handlers: upstream %q has nil provider", u.Name)
 		}
 	}
-	return &Handler{
+	h := &Handler{
 		provider:     provider,
 		config:       config,
 		storage:      stor,
 		upstreams:    upstreams,
 		userResolver: NewUserResolver(stor),
-	}, nil
+	}
+	for _, o := range opts {
+		o(h)
+	}
+	return h, nil
 }
 
 // Routes returns a router with all OAuth/OIDC endpoints registered.
@@ -116,20 +140,67 @@ func (h *Handler) WellKnownRoutes(r chi.Router) {
 }
 
 // nextMissingUpstream returns the name of the next upstream provider in the
-// authorization chain that does not yet have stored tokens for this session.
-// Returns empty string if all upstreams are satisfied.
-// Returns an error if the storage lookup fails.
+// authorization chain that the user must (re-)authenticate with for this session.
+// Returns empty string if all upstreams are satisfied, or an error if the storage
+// lookup fails.
+//
+// A leg is satisfied when it has a stored token that is live (or asserts no
+// expiry). A present-but-expired token is NOT treated as satisfied by presence
+// alone: the leg is refreshed transparently (mirroring upstreamtoken
+// InProcessService.GetAllValidTokens) and only counts as satisfied if the refresh
+// succeeds. If refresh is impossible or fails, the leg is reported as missing so
+// the user is re-prompted up front, rather than the stale token surfacing as a
+// runtime auth error later at MCP-request token-swap time.
 func (h *Handler) nextMissingUpstream(ctx context.Context, sessionID string) (string, error) {
 	stored, err := h.storage.GetAllUpstreamTokens(ctx, sessionID)
 	if err != nil {
 		return "", fmt.Errorf("failed to check upstream token state: %w", err)
 	}
 	for _, u := range h.upstreams {
-		if _, ok := stored[u.Name]; !ok {
+		tokens, ok := stored[u.Name]
+		if !ok || tokens == nil {
+			// No token stored for this leg — prompt.
+			return u.Name, nil
+		}
+		// A live token (or one with no asserted expiry) satisfies the leg.
+		if tokens.ExpiresAt.IsZero() || !tokens.IsExpired(time.Now()) {
+			continue
+		}
+		// Expired — attempt a transparent refresh; prompt now if it can't be done.
+		if !h.refreshExpiredLeg(ctx, sessionID, u.Name, tokens) {
 			return u.Name, nil
 		}
 	}
 	return "", nil
+}
+
+// refreshExpiredLeg attempts to refresh an expired upstream token for one chain
+// leg. It returns true when the leg can be treated as authenticated (refresh
+// succeeded) and false when the user must be re-prompted: no refresher configured,
+// no refresh token on the row, or the refresh itself failed (expired/revoked
+// refresh token, provider error). Mirrors the refresh-then-classify behavior in
+// upstreamtoken.InProcessService.GetAllValidTokens.
+func (h *Handler) refreshExpiredLeg(
+	ctx context.Context,
+	sessionID, providerName string,
+	expired *storage.UpstreamTokens,
+) bool {
+	if h.refresher == nil || expired.RefreshToken == "" {
+		return false
+	}
+	if _, err := h.refresher.RefreshAndStore(ctx, sessionID, expired); err != nil {
+		slog.WarnContext(ctx, "upstream token refresh failed during chain evaluation; re-prompting",
+			"session_id", sessionID,
+			"provider", providerName,
+			"error", err,
+		)
+		return false
+	}
+	slog.DebugContext(ctx, "refreshed expired upstream token during chain evaluation",
+		"session_id", sessionID,
+		"provider", providerName,
+	)
+	return true
 }
 
 // upstreamByName returns the upstream provider with the given name.

--- a/pkg/authserver/server/handlers/handler_chain_test.go
+++ b/pkg/authserver/server/handlers/handler_chain_test.go
@@ -81,6 +81,99 @@ func TestNextMissingUpstream(t *testing.T) {
 	}
 }
 
+func TestNextMissingUpstream_RefreshExpired(t *testing.T) {
+	t.Parallel()
+
+	// provider-1 has an expired token (with a refresh token); provider-2 is live.
+	// Presence alone would mark provider-1 satisfied; the refresh-then-classify
+	// path must decide based on whether the expired leg can be refreshed.
+	expiredProvider1 := func(st *testStorageState) {
+		st.upstreamTokens["test-session:provider-1"] = &storage.UpstreamTokens{
+			ProviderID:   "provider-1",
+			AccessToken:  "tok-1",
+			RefreshToken: "rt-1",
+			ExpiresAt:    time.Now().Add(-time.Minute),
+		}
+		st.upstreamTokens["test-session:provider-2"] = &storage.UpstreamTokens{
+			ProviderID:  "provider-2",
+			AccessToken: "tok-2",
+			ExpiresAt:   time.Now().Add(time.Hour),
+		}
+	}
+
+	tests := []struct {
+		name string
+		// setupRefresher configures the mock refresher's expectations. Nil means no
+		// refresher is wired into the handler at all.
+		setupRefresher func(*mocks.MockUpstreamTokenRefresher)
+		setupTokens    func(*testStorageState)
+		want           string
+	}{
+		{
+			name: "expired leg refreshed successfully is satisfied",
+			setupRefresher: func(r *mocks.MockUpstreamTokenRefresher) {
+				r.EXPECT().RefreshAndStore(gomock.Any(), "test-session", gomock.Any()).
+					Return(&storage.UpstreamTokens{ProviderID: "provider-1", AccessToken: "tok-1-new"}, nil).
+					Times(1)
+			},
+			setupTokens: expiredProvider1,
+			want:        "",
+		},
+		{
+			name: "expired leg whose refresh fails is reported missing",
+			setupRefresher: func(r *mocks.MockUpstreamTokenRefresher) {
+				r.EXPECT().RefreshAndStore(gomock.Any(), "test-session", gomock.Any()).
+					Return(nil, errors.New("refresh token expired")).
+					Times(1)
+			},
+			setupTokens: expiredProvider1,
+			want:        "provider-1",
+		},
+		{
+			name: "expired leg with no refresh token is reported missing without calling refresher",
+			setupRefresher: func(_ *mocks.MockUpstreamTokenRefresher) {
+				// RefreshAndStore must not be called when there is no refresh token.
+			},
+			setupTokens: func(st *testStorageState) {
+				st.upstreamTokens["test-session:provider-1"] = &storage.UpstreamTokens{
+					ProviderID:  "provider-1",
+					AccessToken: "tok-1",
+					ExpiresAt:   time.Now().Add(-time.Minute),
+				}
+			},
+			want: "provider-1",
+		},
+		{
+			name:           "expired leg with no refresher configured is reported missing",
+			setupRefresher: nil,
+			setupTokens:    expiredProvider1,
+			want:           "provider-1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var opts []Option
+			if tt.setupRefresher != nil {
+				ctrl := gomock.NewController(t)
+				t.Cleanup(ctrl.Finish)
+				refresher := mocks.NewMockUpstreamTokenRefresher(ctrl)
+				tt.setupRefresher(refresher)
+				opts = append(opts, WithUpstreamRefresher(refresher))
+			}
+
+			handler, storState, _, _ := multiUpstreamTestSetup(t, opts...)
+			tt.setupTokens(storState)
+
+			got, err := handler.nextMissingUpstream(context.Background(), "test-session")
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestNextMissingUpstream_StorageError(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/authserver/server/handlers/helpers_test.go
+++ b/pkg/authserver/server/handlers/helpers_test.go
@@ -451,8 +451,8 @@ func handlerTestSetup(t *testing.T, opts ...baseTestSetupOption) (*Handler, *tes
 }
 
 // multiUpstreamTestSetup creates a test setup with two upstream providers ("provider-1" and "provider-2")
-// for testing multi-upstream authorization chain logic.
-func multiUpstreamTestSetup(t *testing.T) (*Handler, *testStorageState, *mockIDPProvider, *mockIDPProvider) {
+// for testing multi-upstream authorization chain logic. Any Option values are forwarded to NewHandler.
+func multiUpstreamTestSetup(t *testing.T, opts ...Option) (*Handler, *testStorageState, *mockIDPProvider, *mockIDPProvider) {
 	t.Helper()
 
 	provider, oauth2Config, stor, storState := baseTestSetup(t)
@@ -493,7 +493,7 @@ func multiUpstreamTestSetup(t *testing.T) (*Handler, *testStorageState, *mockIDP
 		{Name: "provider-1", Provider: mockProvider1},
 		{Name: "provider-2", Provider: mockProvider2},
 	}
-	handler, err := NewHandler(provider, oauth2Config, stor, upstreams)
+	handler, err := NewHandler(provider, oauth2Config, stor, upstreams, opts...)
 	require.NoError(t, err)
 
 	return handler, storState, mockProvider1, mockProvider2

--- a/pkg/authserver/server_impl.go
+++ b/pkg/authserver/server_impl.go
@@ -199,7 +199,12 @@ func newServer(ctx context.Context, cfg Config, stor storage.Storage, opts ...se
 	slog.Debug("creating fosite OAuth2 provider")
 	fositeProvider := createProvider(authServerConfig, stor)
 
-	handlerInstance, err := handlers.NewHandler(fositeProvider, authServerConfig, stor, upstreams)
+	// Give the handler a refresher so the authorization chain can transparently
+	// refresh an expired upstream leg during login instead of skipping it and
+	// failing later at MCP-request token-swap time.
+	refresher := newUpstreamTokenRefresher(upstreams, stor, cfg.RefreshTokenLifespan)
+	handlerInstance, err := handlers.NewHandler(fositeProvider, authServerConfig, stor, upstreams,
+		handlers.WithUpstreamRefresher(refresher))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create handler: %w", err)
 	}
@@ -240,17 +245,29 @@ func (s *server) DCRStore() storage.DCRCredentialStore {
 // and storage to transparently refresh expired upstream tokens. The refresher
 // dispatches to the correct provider based on each token's ProviderID.
 func (s *server) UpstreamTokenRefresher() storage.UpstreamTokenRefresher {
-	if len(s.upstreams) == 0 {
+	return newUpstreamTokenRefresher(s.upstreams, s.storage, s.refreshTokenLifespan)
+}
+
+// newUpstreamTokenRefresher builds a refresher over the given upstreams, or nil
+// when there are none. Shared by the Handler (chain-evaluation refresh) and the
+// server's UpstreamTokenRefresher() accessor so both observe identical provider
+// wiring.
+func newUpstreamTokenRefresher(
+	upstreams []handlers.NamedUpstream,
+	stor storage.UpstreamTokenStorage,
+	refreshTokenLifespan time.Duration,
+) storage.UpstreamTokenRefresher {
+	if len(upstreams) == 0 {
 		return nil
 	}
-	providers := make(map[string]upstream.OAuth2Provider, len(s.upstreams))
-	for _, u := range s.upstreams {
+	providers := make(map[string]upstream.OAuth2Provider, len(upstreams))
+	for _, u := range upstreams {
 		providers[u.Name] = u.Provider
 	}
 	return &upstreamTokenRefresher{
 		providers:            providers,
-		storage:              s.storage,
-		refreshTokenLifespan: s.refreshTokenLifespan,
+		storage:              stor,
+		refreshTokenLifespan: refreshTokenLifespan,
 	}
 }
 

--- a/pkg/authserver/storage/memory.go
+++ b/pkg/authserver/storage/memory.go
@@ -947,6 +947,7 @@ func (s *MemoryStorage) StorePendingAuthorization(_ context.Context, state strin
 		ResolvedUserID:       pending.ResolvedUserID,
 		ResolvedUserName:     pending.ResolvedUserName,
 		ResolvedUserEmail:    pending.ResolvedUserEmail,
+		SingleLeg:            pending.SingleLeg,
 		CreatedAt:            pending.CreatedAt,
 	}
 
@@ -996,6 +997,7 @@ func (s *MemoryStorage) LoadPendingAuthorization(_ context.Context, state string
 		ResolvedUserID:       pending.ResolvedUserID,
 		ResolvedUserName:     pending.ResolvedUserName,
 		ResolvedUserEmail:    pending.ResolvedUserEmail,
+		SingleLeg:            pending.SingleLeg,
 		CreatedAt:            pending.CreatedAt,
 	}, nil
 }

--- a/pkg/authserver/storage/memory_test.go
+++ b/pkg/authserver/storage/memory_test.go
@@ -844,7 +844,8 @@ func TestMemoryStorage_PendingAuthorization(t *testing.T) {
 			ClientID: "test-client", RedirectURI: "https://example.com/callback",
 			State: "client-state", PKCEChallenge: "challenge", PKCEMethod: "S256",
 			Scopes: []string{"openid", "profile"}, InternalState: state,
-			UpstreamPKCEVerifier: "verifier", UpstreamNonce: "nonce", CreatedAt: time.Now(),
+			UpstreamPKCEVerifier: "verifier", UpstreamNonce: "nonce",
+			SingleLeg: true, CreatedAt: time.Now(),
 		}
 	}
 
@@ -858,6 +859,7 @@ func TestMemoryStorage_PendingAuthorization(t *testing.T) {
 			assert.Equal(t, pending.ClientID, retrieved.ClientID)
 			assert.Equal(t, pending.PKCEChallenge, retrieved.PKCEChallenge)
 			assert.Equal(t, pending.Scopes, retrieved.Scopes)
+			assert.Equal(t, pending.SingleLeg, retrieved.SingleLeg)
 		})
 	})
 

--- a/pkg/authserver/storage/redis.go
+++ b/pkg/authserver/storage/redis.go
@@ -1377,6 +1377,7 @@ type storedPendingAuthorization struct {
 	ResolvedUserID       string   `json:"resolved_user_id,omitempty"`
 	ResolvedUserName     string   `json:"resolved_user_name,omitempty"`
 	ResolvedUserEmail    string   `json:"resolved_user_email,omitempty"`
+	SingleLeg            bool     `json:"single_leg,omitempty"`
 	CreatedAt            int64    `json:"created_at"`
 }
 
@@ -1406,6 +1407,7 @@ func (s *RedisStorage) StorePendingAuthorization(ctx context.Context, state stri
 		ResolvedUserID:       pending.ResolvedUserID,
 		ResolvedUserName:     pending.ResolvedUserName,
 		ResolvedUserEmail:    pending.ResolvedUserEmail,
+		SingleLeg:            pending.SingleLeg,
 		CreatedAt:            pending.CreatedAt.Unix(),
 	}
 
@@ -1456,6 +1458,7 @@ func (s *RedisStorage) LoadPendingAuthorization(ctx context.Context, state strin
 		ResolvedUserID:       stored.ResolvedUserID,
 		ResolvedUserName:     stored.ResolvedUserName,
 		ResolvedUserEmail:    stored.ResolvedUserEmail,
+		SingleLeg:            stored.SingleLeg,
 		CreatedAt:            createdAt,
 	}, nil
 }

--- a/pkg/authserver/storage/redis_test.go
+++ b/pkg/authserver/storage/redis_test.go
@@ -1362,7 +1362,8 @@ func TestRedisStorage_PendingAuthorization(t *testing.T) {
 			ClientID: "test-client", RedirectURI: "https://example.com/callback",
 			State: "client-state", PKCEChallenge: "challenge", PKCEMethod: "S256",
 			Scopes: []string{"openid", "profile"}, InternalState: state,
-			UpstreamPKCEVerifier: "verifier", UpstreamNonce: "nonce", CreatedAt: time.Now(),
+			UpstreamPKCEVerifier: "verifier", UpstreamNonce: "nonce",
+			SingleLeg: true, CreatedAt: time.Now(),
 		}
 	}
 
@@ -1376,6 +1377,7 @@ func TestRedisStorage_PendingAuthorization(t *testing.T) {
 			assert.Equal(t, pending.ClientID, retrieved.ClientID)
 			assert.Equal(t, pending.PKCEChallenge, retrieved.PKCEChallenge)
 			assert.Equal(t, pending.Scopes, retrieved.Scopes)
+			assert.Equal(t, pending.SingleLeg, retrieved.SingleLeg)
 		})
 	})
 

--- a/pkg/authserver/storage/types.go
+++ b/pkg/authserver/storage/types.go
@@ -450,6 +450,14 @@ type PendingAuthorization struct {
 	// Empty on the first leg; populated after the first callback for subsequent legs.
 	ResolvedUserEmail string
 
+	// SingleLeg scopes this authorization to exactly one upstream. When true, the
+	// callback issues the authorization code as soon as this leg completes instead
+	// of consulting nextMissingUpstream to continue the chain. This lets a caller
+	// connect a single specific provider without other configured-but-tokenless
+	// upstreams hijacking the flow into a full chain walk. Defaults to false, which
+	// preserves the multi-upstream chaining behavior.
+	SingleLeg bool
+
 	// CreatedAt is when the pending authorization was created.
 	CreatedAt time.Time
 }


### PR DESCRIPTION
## Summary

Three independent fixes to the auth server's multi-upstream authorization chain (`pkg/authserver/...`), all OSS prerequisites for the connector gateway. Each defaults to today's behavior when its new field/flag is unset, so existing deployments are unaffected.

- **`PendingAuthorization.SingleLeg` (flow #9):** a UI-initiated "connect one backend" flow was hijacked into a full chain walk, because `continueChainOrComplete` always consulted `nextMissingUpstream` and redirected into any other configured-but-tokenless upstream. A new `SingleLeg` flag short-circuits to issuing the authorization code once the single leg completes. Threaded through the Redis and in-memory storage marshaling.
- **Synthetic refresh-token carry-forward (flow #8):** `maybeCarryForwardRefreshToken` gated preservation of a prior refresh token on `prior.UpstreamSubject == providerSubject`. Synthetic providers (OAuth2 with no identity config) mint a fresh rotating subject every flow, so that equality never holds and the prior refresh token was silently dropped — breaking refresh for userinfo-less OAuth2 backends. The subject-equality guard is now skipped for synthetic providers; the lookup stays scoped to the same internal user and provider, so nothing real is given up.
- **Refresh-on-expired during chain evaluation (flow #10):** `nextMissingUpstream` treated a present-but-expired token as satisfied, so a stale leg was skipped and surfaced later as a runtime auth error at MCP-request token-swap time instead of a clean re-prompt during login. It now mirrors `upstreamtoken.GetAllValidTokens`: live (or non-expiring) → use; expired → refresh transparently; refresh impossible/fails → report missing and re-prompt up front. The `Handler` receives an optional `UpstreamTokenRefresher` via a functional option (unset → expired leg treated as missing).

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests
- [x] Linting (`task lint-fix`)

Ran `go test -race ./pkg/authserver/...` (same race ldflags as the Taskfile); all pass. Each of the three fixes was developed red-green (test fails against the old behavior, passes after the fix), including a regression test pinning the synthetic-with-no-prior-row safety case. `task lint-fix` is clean for every changed file. Full CI (Go tests, all E2E Core + Operator E2E suites, lint, vuln, helm, codegen) passed on the prior `oidc-subject-claim` base.

## API Compatibility

- [x] This PR does not break the `v1beta1` API, OR the `api-break-allowed` label is applied and the migration guidance is described above.

## Does this introduce a user-facing change?

Yes. Multi-upstream login chains now refresh an expired upstream leg during login instead of skipping it and failing later at request time; userinfo-less OAuth2 backends keep working refresh tokens across re-authorization; and integrations can issue a single-leg authorization that connects one specific provider without walking the full chain. All three are opt-in/no-op by default.

## Special notes for reviewers

Originally stacked on #5589 (per-OIDC-provider SubjectClaim); now that #5589 has merged, this PR is rebased directly onto `main`, so the diff is exactly the three commits below.

- `Add PendingAuthorization.SingleLeg flag`
- `Carry refresh token forward for synthetic IdPs`
- `Refresh expired upstream legs during chain walk`

The three are independent and each is its own commit.
