### PR TITLE
Address network isolation review follow-ups

### DIFF
--- a/docs/server/docs.go
+++ b/docs/server/docs.go
@@ -2747,7 +2747,7 @@ const docTemplate = `{
                         "type": "string"
                     },
                     "network_isolation": {
-                        "description": "Whether network isolation is turned on. This applies the rules in the permission profile.\nPointer so that omitting the field defaults to network isolation ENABLED (matching the\n` + "`" + `thv run` + "`" + ` CLI default); set it explicitly to false to disable network isolation.",
+                        "description": "Whether network isolation is turned on. This applies the rules in the permission profile.\nPointer so that omitting the field defaults to network isolation ENABLED (matching the\n` + "`" + `thv run` + "`" + ` CLI default); set it explicitly to false to disable network isolation.\nThis also applies on update: a request that omits this field enables isolation, so\nclients that build update requests from scratch should send it explicitly to avoid\nunintentionally turning isolation on for a workload that had it off.",
                         "type": "boolean"
                     },
                     "oauth_config": {
@@ -3429,7 +3429,7 @@ const docTemplate = `{
                         "type": "string"
                     },
                     "network_isolation": {
-                        "description": "Whether network isolation is turned on. This applies the rules in the permission profile.\nPointer so that omitting the field defaults to network isolation ENABLED (matching the\n` + "`" + `thv run` + "`" + ` CLI default); set it explicitly to false to disable network isolation.",
+                        "description": "Whether network isolation is turned on. This applies the rules in the permission profile.\nPointer so that omitting the field defaults to network isolation ENABLED (matching the\n` + "`" + `thv run` + "`" + ` CLI default); set it explicitly to false to disable network isolation.\nThis also applies on update: a request that omits this field enables isolation, so\nclients that build update requests from scratch should send it explicitly to avoid\nunintentionally turning isolation on for a workload that had it off.",
                         "type": "boolean"
                     },
                     "oauth_config": {

--- a/docs/server/swagger.json
+++ b/docs/server/swagger.json
@@ -2740,7 +2740,7 @@
                         "type": "string"
                     },
                     "network_isolation": {
-                        "description": "Whether network isolation is turned on. This applies the rules in the permission profile.\nPointer so that omitting the field defaults to network isolation ENABLED (matching the\n`thv run` CLI default); set it explicitly to false to disable network isolation.",
+                        "description": "Whether network isolation is turned on. This applies the rules in the permission profile.\nPointer so that omitting the field defaults to network isolation ENABLED (matching the\n`thv run` CLI default); set it explicitly to false to disable network isolation.\nThis also applies on update: a request that omits this field enables isolation, so\nclients that build update requests from scratch should send it explicitly to avoid\nunintentionally turning isolation on for a workload that had it off.",
                         "type": "boolean"
                     },
                     "oauth_config": {
@@ -3422,7 +3422,7 @@
                         "type": "string"
                     },
                     "network_isolation": {
-                        "description": "Whether network isolation is turned on. This applies the rules in the permission profile.\nPointer so that omitting the field defaults to network isolation ENABLED (matching the\n`thv run` CLI default); set it explicitly to false to disable network isolation.",
+                        "description": "Whether network isolation is turned on. This applies the rules in the permission profile.\nPointer so that omitting the field defaults to network isolation ENABLED (matching the\n`thv run` CLI default); set it explicitly to false to disable network isolation.\nThis also applies on update: a request that omits this field enables isolation, so\nclients that build update requests from scratch should send it explicitly to avoid\nunintentionally turning isolation on for a workload that had it off.",
                         "type": "boolean"
                     },
                     "oauth_config": {

--- a/docs/server/swagger.yaml
+++ b/docs/server/swagger.yaml
@@ -2553,6 +2553,9 @@ components:
             Whether network isolation is turned on. This applies the rules in the permission profile.
             Pointer so that omitting the field defaults to network isolation ENABLED (matching the
             `thv run` CLI default); set it explicitly to false to disable network isolation.
+            This also applies on update: a request that omits this field enables isolation, so
+            clients that build update requests from scratch should send it explicitly to avoid
+            unintentionally turning isolation on for a workload that had it off.
           type: boolean
         oauth_config:
           $ref: '#/components/schemas/pkg_api_v1.remoteOAuthConfig'
@@ -3079,6 +3082,9 @@ components:
             Whether network isolation is turned on. This applies the rules in the permission profile.
             Pointer so that omitting the field defaults to network isolation ENABLED (matching the
             `thv run` CLI default); set it explicitly to false to disable network isolation.
+            This also applies on update: a request that omits this field enables isolation, so
+            clients that build update requests from scratch should send it explicitly to avoid
+            unintentionally turning isolation on for a workload that had it off.
           type: boolean
         oauth_config:
           $ref: '#/components/schemas/pkg_api_v1.remoteOAuthConfig'

--- a/pkg/api/v1/workload_types.go
+++ b/pkg/api/v1/workload_types.go
@@ -74,6 +74,9 @@ type updateRequest struct {
 	// Whether network isolation is turned on. This applies the rules in the permission profile.
 	// Pointer so that omitting the field defaults to network isolation ENABLED (matching the
 	// `thv run` CLI default); set it explicitly to false to disable network isolation.
+	// This also applies on update: a request that omits this field enables isolation, so
+	// clients that build update requests from scratch should send it explicitly to avoid
+	// unintentionally turning isolation on for a workload that had it off.
 	NetworkIsolation *bool `json:"network_isolation,omitempty"`
 	// Whether to trust X-Forwarded-* headers from reverse proxies
 	TrustProxyHeaders bool `json:"trust_proxy_headers"`

--- a/test/e2e/network_isolation_test.go
+++ b/test/e2e/network_isolation_test.go
@@ -20,13 +20,11 @@ import (
 var _ = Describe("NetworkIsolation", Label("proxy", "network", "isolation", "e2e"), func() {
 	var (
 		config               *e2e.TestConfig
-		serverName           string
 		permissionProfileDir string
 	)
 
 	BeforeEach(func() {
 		config = e2e.NewTestConfig()
-		serverName = fmt.Sprintf("network-isolation-test-%d", GinkgoRandomSeed())
 
 		// Create temporary directory for permission profiles
 		var err error
@@ -39,91 +37,108 @@ var _ = Describe("NetworkIsolation", Label("proxy", "network", "isolation", "e2e
 	})
 
 	AfterEach(func() {
-		if config.CleanupAfter {
-			// Clean up the server if it exists
-			err := e2e.StopAndRemoveMCPServer(config, serverName)
-			Expect(err).ToNot(HaveOccurred(), "Should be able to stop and remove server")
-		}
-
 		// Clean up temporary permission profile directory
 		if permissionProfileDir != "" {
 			os.RemoveAll(permissionProfileDir)
 		}
 	})
 
-	Describe("Running MCP server with network isolation", func() {
-		It("should enforce both inbound and outbound network restrictions", func() {
-			By("Creating a permission profile with restricted inbound and outbound rules")
-			permissionProfile := `{
-				"name": "test-network-isolation",
-				"network": {
-					"inbound": {
-						"allow_host": ["localhost", "127.0.0.1"]
-					},
-					"outbound": {
-						"insecure_allow_all": false,
-						"allow_host": ["example.com"],
-						"allow_port": [80, 443]
-					}
-				}
-			}`
-			profilePath := filepath.Join(permissionProfileDir, "network-isolation.json")
-			err := os.WriteFile(profilePath, []byte(permissionProfile), 0644)
-			Expect(err).ToNot(HaveOccurred(), "Should be able to create permission profile")
-
-			By("Starting the fetch MCP server with network isolation")
-			e2e.NewTHVCommand(config, "run",
-				"--name", serverName,
-				"--isolate-network",
-				"--permission-profile", profilePath,
-				"fetch").ExpectSuccess()
-
-			By("Waiting for the server to be running")
-			err = e2e.WaitForMCPServer(config, serverName, 60*time.Second)
-			Expect(err).ToNot(HaveOccurred(), "Server should be running within 60 seconds")
-
-			By("Getting server URL for testing")
-			serverURL, err := e2e.GetMCPServerURL(config, serverName)
-			Expect(err).ToNot(HaveOccurred(), "Should be able to get server URL")
-
-			err = e2e.WaitForMCPServerReady(config, serverURL, "streamable-http", 60*time.Second)
-			Expect(err).ToNot(HaveOccurred(), "Server should be ready")
-
-			By("Creating MCP client to test network isolation")
-			mcpClient, err := e2e.NewMCPClientForStreamableHTTP(config, serverURL)
-			Expect(err).ToNot(HaveOccurred(), "Should be able to create MCP client")
-			defer mcpClient.Close()
-
-			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-			defer cancel()
-
-			err = mcpClient.Initialize(ctx)
-			Expect(err).ToNot(HaveOccurred(), "Should be able to initialize MCP client")
-
-			By("Testing outbound network isolation - blocked URL should fail")
-			blockedArgs := map[string]interface{}{
-				"url": "https://google.com",
+	// verifyNetworkRestrictions starts the fetch MCP server with a restrictive
+	// permission profile plus any extra run args, then asserts that both the
+	// outbound and inbound network rules are enforced. The restrictions only take
+	// effect when the egress proxy is running, so a passing assertion proves
+	// network isolation is active. Pass "--isolate-network" to exercise the
+	// explicit opt-in; pass no extra args to exercise the default (network
+	// isolation is on by default).
+	verifyNetworkRestrictions := func(nameSuffix string, extraRunArgs ...string) {
+		serverName := fmt.Sprintf("network-isolation-%s-%d", nameSuffix, GinkgoRandomSeed())
+		DeferCleanup(func() {
+			if config.CleanupAfter {
+				err := e2e.StopAndRemoveMCPServer(config, serverName)
+				Expect(err).ToNot(HaveOccurred(), "Should be able to stop and remove server")
 			}
-			result, err := mcpClient.CallTool(ctx, "fetch", blockedArgs)
-			Expect(err).ToNot(HaveOccurred(), "CallTool should complete without error")
+		})
 
-			// The fetch tool returns an error result when the URL is blocked
-			Expect(result.IsError).To(BeTrue(), "Should return error result for blocked URL")
+		By("Creating a permission profile with restricted inbound and outbound rules")
+		permissionProfile := `{
+			"name": "test-network-isolation",
+			"network": {
+				"inbound": {
+					"allow_host": ["localhost", "127.0.0.1"]
+				},
+				"outbound": {
+					"insecure_allow_all": false,
+					"allow_host": ["example.com"],
+					"allow_port": [80, 443]
+				}
+			}
+		}`
+		profilePath := filepath.Join(permissionProfileDir, nameSuffix+".json")
+		err := os.WriteFile(profilePath, []byte(permissionProfile), 0644)
+		Expect(err).ToNot(HaveOccurred(), "Should be able to create permission profile")
 
-			By("Testing inbound network isolation - connection with non-allowed Host header should be blocked")
-			client := &http.Client{Timeout: 10 * time.Second}
+		By("Starting the fetch MCP server")
+		runArgs := append([]string{"run", "--name", serverName}, extraRunArgs...)
+		runArgs = append(runArgs, "--permission-profile", profilePath, "fetch")
+		e2e.NewTHVCommand(config, runArgs...).ExpectSuccess()
 
-			req, err := http.NewRequest("GET", serverURL, nil)
-			Expect(err).ToNot(HaveOccurred(), "Should be able to create HTTP request")
+		By("Waiting for the server to be running")
+		err = e2e.WaitForMCPServer(config, serverName, 60*time.Second)
+		Expect(err).ToNot(HaveOccurred(), "Server should be running within 60 seconds")
 
-			// Set Host header to something not in the allow list
-			req.Host = "example.org"
+		By("Getting server URL for testing")
+		serverURL, err := e2e.GetMCPServerURL(config, serverName)
+		Expect(err).ToNot(HaveOccurred(), "Should be able to get server URL")
 
-			resp, err := client.Do(req)
-			Expect(err).ToNot(HaveOccurred(), "Request should complete without connection error")
-			defer resp.Body.Close()
-			Expect(resp.StatusCode).ToNot(Equal(http.StatusOK),
-				"Request with non-allowed Host header should be blocked")
+		err = e2e.WaitForMCPServerReady(config, serverURL, "streamable-http", 60*time.Second)
+		Expect(err).ToNot(HaveOccurred(), "Server should be ready")
+
+		By("Creating MCP client to test network isolation")
+		mcpClient, err := e2e.NewMCPClientForStreamableHTTP(config, serverURL)
+		Expect(err).ToNot(HaveOccurred(), "Should be able to create MCP client")
+		defer mcpClient.Close()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		err = mcpClient.Initialize(ctx)
+		Expect(err).ToNot(HaveOccurred(), "Should be able to initialize MCP client")
+
+		By("Testing outbound network isolation - blocked URL should fail")
+		blockedArgs := map[string]interface{}{
+			"url": "https://google.com",
+		}
+		result, err := mcpClient.CallTool(ctx, "fetch", blockedArgs)
+		Expect(err).ToNot(HaveOccurred(), "CallTool should complete without error")
+
+		// The fetch tool returns an error result when the URL is blocked
+		Expect(result.IsError).To(BeTrue(), "Should return error result for blocked URL")
+
+		By("Testing inbound network isolation - connection with non-allowed Host header should be blocked")
+		client := &http.Client{Timeout: 10 * time.Second}
+
+		req, err := http.NewRequest("GET", serverURL, nil)
+		Expect(err).ToNot(HaveOccurred(), "Should be able to create HTTP request")
+
+		// Set Host header to something not in the allow list
+		req.Host = "example.org"
+
+		resp, err := client.Do(req)
+		Expect(err).ToNot(HaveOccurred(), "Request should complete without connection error")
+		defer resp.Body.Close()
+		Expect(resp.StatusCode).ToNot(Equal(http.StatusOK),
+			"Request with non-allowed Host header should be blocked")
+	}
+
+	Describe("Running MCP server with network isolation", func() {
+		It("should enforce both inbound and outbound network restrictions when --isolate-network is set", func() {
+			verifyNetworkRestrictions("explicit", "--isolate-network")
+		})
+
+		// Network isolation is on by default, so omitting the flag must still
+		// enforce the permission profile's network rules.
+		It("should enforce both inbound and outbound network restrictions by default", func() {
+			verifyNetworkRestrictions("default")
 		})
 	})
 })


### PR DESCRIPTION
## Summary

Follow-ups from the review of #5583 (network isolation defaulting to on for local MCP servers). Addresses the two actionable review comments; the third (OpenAPI nullable) is answered inline on #5583 because it isn't achievable with our generator.

- **Two-sided e2e coverage**: after #5583 the suite explicitly covered the non-isolated path (`--isolate-network=false` on the proxy/vmcp/osv plumbing servers) but nothing asserted that the new *default* actually isolates. Add an e2e case that runs the fetch server with a restrictive permission profile **without** `--isolate-network` and asserts the inbound/outbound rules are still enforced — which only happens when the egress proxy is running, proving isolation is on by default. The existing explicit-flag case is kept; the shared assertion is extracted into a helper to avoid duplication.
- **Update-path documentation**: a PUT/update request that omits `network_isolation` now enables isolation (the `nil -> true` default). Document this on the API field so clients that build update requests from scratch send the field explicitly.

## Type of change

- [x] Other (describe): Test coverage + documentation follow-up (no behavior change)

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)
- [ ] E2E tests (`task test-e2e`)

`task docs` regenerated the swagger description for the updated field doc. Build + `go vet ./test/e2e/...` clean. The new e2e case mirrors the existing isolation test (which passes in CI), just without the explicit flag. The 4 lint findings reported by `task lint-fix` are pre-existing on `main` in files this PR does not touch.

## API Compatibility

- [x] This PR does not break the `v1beta1` API, OR the `api-break-allowed` label is applied and the migration guidance is described above.

Does not touch the operator CRD surface. Only the REST API field's doc comment changed (swagger description text); the schema is unchanged.

## Does this introduce a user-facing change?

**Migration note for REST API consumers (update/PUT requests):** `network_isolation` is optional and defaults to enabled when omitted — this applies to update requests too. A client that builds a PUT body from scratch and omits `network_isolation` will enable isolation on a workload that previously had it off. Round-trip clients (GET, modify, PUT) are unaffected because GET always returns an explicit value. Send `network_isolation: false` explicitly if you need isolation off.

## Special notes for reviewers

- The OpenAPI nullable comment is answered on #5583: `swag init --v3.1` (swaggo v2) cannot emit OAS 3.1 nullable (`type: [boolean, "null"]`) — its only option is the Swagger-2.0 vendor extension `x-nullable`, which 3.1 generators ignore. The server-side `nil -> true` default remains the source of truth; the field description documents the omit-=-enabled semantics.

Generated with [Claude Code](https://claude.com/claude-code)