### PR TITLE
Add MCPServer and MCPToolConfig integration tests

### DIFF
--- a/cmd/thv-operator/test-integration/mcp-server/mcpserver_error_recovery_integration_test.go
+++ b/cmd/thv-operator/test-integration/mcp-server/mcpserver_error_recovery_integration_test.go
@@ -1,0 +1,132 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package controllers
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+
+	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+)
+
+// An MCPServer that starts with an invalid PodTemplateSpec is blocked
+// (PodTemplateValid=False, no Deployment). Once the spec is corrected the
+// controller must re-process it: the PodTemplateValid condition flips to True
+// and the Deployment is created. Those two signals are the recovery proof that
+// is observable under envtest — phase/Ready stay stale because no kubelet runs
+// pods (the reconciler preserves Failed while zero backend pods exist), so this
+// test deliberately does not assert on Status.Phase.
+var _ = Describe("MCPServer recovery from an invalid configuration", Ordered, func() {
+	const (
+		timeout  = time.Second * 30
+		interval = time.Millisecond * 250
+	)
+
+	var (
+		namespace     string
+		mcpServerName string
+		mcpServer     *mcpv1beta1.MCPServer
+		ns            *corev1.Namespace
+	)
+
+	BeforeAll(func() {
+		ns = &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{GenerateName: "test-mcpserver-recovery-"},
+		}
+		Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
+		namespace = ns.Name
+		mcpServerName = "test-mcpserver-recovery"
+
+		mcpServer = &mcpv1beta1.MCPServer{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      mcpServerName,
+				Namespace: namespace,
+			},
+			Spec: mcpv1beta1.MCPServerSpec{
+				Image:     "example/mcp-server:latest",
+				Transport: "stdio",
+				ProxyPort: 8080,
+				// containers must be an array - this is rejected during validation.
+				PodTemplateSpec: &runtime.RawExtension{
+					Raw: []byte(`{"spec": {"containers": "invalid-not-an-array"}}`),
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, mcpServer)).Should(Succeed())
+	})
+
+	AfterAll(func() {
+		_ = k8sClient.Delete(ctx, mcpServer)
+		Expect(k8sClient.Delete(ctx, ns)).Should(Succeed())
+	})
+
+	It("blocks the Deployment while the PodTemplateSpec is invalid", func() {
+		Eventually(func() bool {
+			updated := &mcpv1beta1.MCPServer{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{
+				Name:      mcpServerName,
+				Namespace: namespace,
+			}, updated); err != nil {
+				return false
+			}
+			cond := apimeta.FindStatusCondition(updated.Status.Conditions, mcpv1beta1.ConditionPodTemplateValid)
+			return cond != nil && cond.Status == metav1.ConditionFalse
+		}, timeout, interval).Should(BeTrue())
+
+		// No Deployment should exist while validation is failing.
+		Consistently(func() bool {
+			err := k8sClient.Get(ctx, types.NamespacedName{
+				Name:      mcpServerName,
+				Namespace: namespace,
+			}, &appsv1.Deployment{})
+			return err != nil
+		}, 3*time.Second, interval).Should(BeTrue())
+	})
+
+	It("recovers once the PodTemplateSpec is corrected", func() {
+		// Correct the spec with a valid PodTemplateSpec.
+		Eventually(func() error {
+			updated := &mcpv1beta1.MCPServer{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{
+				Name:      mcpServerName,
+				Namespace: namespace,
+			}, updated); err != nil {
+				return err
+			}
+			updated.Spec.PodTemplateSpec = &runtime.RawExtension{
+				Raw: []byte(`{"spec": {"containers": [{"name": "mcp"}]}}`),
+			}
+			return k8sClient.Update(ctx, updated)
+		}, timeout, interval).Should(Succeed())
+
+		// The validation condition flips to True.
+		Eventually(func() bool {
+			updated := &mcpv1beta1.MCPServer{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{
+				Name:      mcpServerName,
+				Namespace: namespace,
+			}, updated); err != nil {
+				return false
+			}
+			cond := apimeta.FindStatusCondition(updated.Status.Conditions, mcpv1beta1.ConditionPodTemplateValid)
+			return cond != nil && cond.Status == metav1.ConditionTrue
+		}, timeout, interval).Should(BeTrue())
+
+		// The Deployment that was blocked is now created.
+		Eventually(func() error {
+			return k8sClient.Get(ctx, types.NamespacedName{
+				Name:      mcpServerName,
+				Namespace: namespace,
+			}, &appsv1.Deployment{})
+		}, timeout, interval).Should(Succeed())
+	})
+})

--- a/cmd/thv-operator/test-integration/mcp-server/mcpserver_serviceaccount_integration_test.go
+++ b/cmd/thv-operator/test-integration/mcp-server/mcpserver_serviceaccount_integration_test.go
@@ -1,0 +1,116 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package controllers
+
+import (
+	"encoding/json"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+
+	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+)
+
+// When spec.serviceAccount names an existing account, the operator must NOT
+// create the auto-managed "<name>-sa" backend ServiceAccount, must still create
+// the proxy-runner ServiceAccount (which is always operator-managed), and must
+// inject the custom account into the backend pod via the --k8s-pod-patch arg.
+// Only the default-creation path was covered before this test.
+var _ = Describe("MCPServer with a custom ServiceAccount", Ordered, func() {
+	const (
+		timeout              = time.Second * 30
+		interval             = time.Millisecond * 250
+		customServiceAccount = "my-existing-sa"
+	)
+
+	var (
+		namespace     string
+		mcpServerName string
+		mcpServer     *mcpv1beta1.MCPServer
+		ns            *corev1.Namespace
+	)
+
+	BeforeAll(func() {
+		ns = &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{GenerateName: "test-mcpserver-customsa-"},
+		}
+		Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
+		namespace = ns.Name
+		mcpServerName = "test-mcpserver-customsa"
+
+		mcpServer = &mcpv1beta1.MCPServer{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      mcpServerName,
+				Namespace: namespace,
+			},
+			Spec: mcpv1beta1.MCPServerSpec{
+				Image:          "example/mcp-server:latest",
+				Transport:      "stdio",
+				ProxyPort:      8080,
+				ServiceAccount: ptr.To(customServiceAccount),
+			},
+		}
+		Expect(k8sClient.Create(ctx, mcpServer)).Should(Succeed())
+	})
+
+	AfterAll(func() {
+		_ = k8sClient.Delete(ctx, mcpServer)
+		Expect(k8sClient.Delete(ctx, ns)).Should(Succeed())
+	})
+
+	It("still creates the operator-managed proxy-runner ServiceAccount", func() {
+		Eventually(func() error {
+			return k8sClient.Get(ctx, types.NamespacedName{
+				Name:      mcpServerName + "-proxy-runner",
+				Namespace: namespace,
+			}, &corev1.ServiceAccount{})
+		}, timeout, interval).Should(Succeed())
+	})
+
+	It("does not create the auto-managed backend ServiceAccount", func() {
+		// The "<name>-sa" account is only created when spec.serviceAccount is
+		// unset; with a custom account it must never appear.
+		Consistently(func() bool {
+			err := k8sClient.Get(ctx, types.NamespacedName{
+				Name:      mcpServerName + "-sa",
+				Namespace: namespace,
+			}, &corev1.ServiceAccount{})
+			return apierrors.IsNotFound(err)
+		}, 3*time.Second, interval).Should(BeTrue())
+	})
+
+	It("injects the custom ServiceAccount into the backend pod patch", func() {
+		deployment := &appsv1.Deployment{}
+		Eventually(func() error {
+			return k8sClient.Get(ctx, types.NamespacedName{
+				Name:      mcpServerName,
+				Namespace: namespace,
+			}, deployment)
+		}, timeout, interval).Should(Succeed())
+
+		Expect(deployment.Spec.Template.Spec.Containers).NotTo(BeEmpty())
+		var podPatchJSON string
+		for _, arg := range deployment.Spec.Template.Spec.Containers[0].Args {
+			if strings.HasPrefix(arg, "--k8s-pod-patch=") {
+				podPatchJSON = strings.TrimPrefix(arg, "--k8s-pod-patch=")
+				break
+			}
+		}
+		Expect(podPatchJSON).NotTo(BeEmpty(), "Deployment should have --k8s-pod-patch argument")
+
+		var patch map[string]any
+		Expect(json.Unmarshal([]byte(podPatchJSON), &patch)).Should(Succeed())
+		spec, ok := patch["spec"].(map[string]any)
+		Expect(ok).To(BeTrue(), "pod patch should have a spec")
+		Expect(spec["serviceAccountName"]).To(Equal(customServiceAccount))
+	})
+})

--- a/cmd/thv-operator/test-integration/mcp-toolconfig/mcptoolconfig_controller_integration_test.go
+++ b/cmd/thv-operator/test-integration/mcp-toolconfig/mcptoolconfig_controller_integration_test.go
@@ -5,6 +5,7 @@
 package mcptoolconfig_test
 
 import (
+	"encoding/json"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -16,6 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/pkg/runner"
 )
 
 const (
@@ -472,6 +474,256 @@ var _ = Describe("MCPToolConfig Controller Integration Tests", func() {
 				}, updated)
 				return errors.IsNotFound(err)
 			}, timeout, interval).Should(BeTrue())
+		})
+	})
+
+	// These tests assert that an MCPToolConfig's ToolsFilter and ToolsOverride are
+	// not merely tracked via Status.ReferencingWorkloads, but actually propagate
+	// into the referencing MCPServer's rendered RunConfig ConfigMap. Both ride the
+	// same code path in createRunConfigFromMCPServer (WithToolsFilter /
+	// WithToolsOverride), so this single context covers filtering and renaming.
+	Context("When a referencing MCPServer renders its RunConfig", Ordered, func() {
+		var (
+			namespace     string
+			configName    string
+			mcpServerName string
+			toolConfig    *mcpv1beta1.MCPToolConfig
+			mcpServer     *mcpv1beta1.MCPServer
+			ns            *corev1.Namespace
+		)
+
+		BeforeAll(func() {
+			ns = &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-toolconfig-propagation-",
+				},
+			}
+			Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
+			namespace = ns.Name
+
+			configName = "propagation-config"
+			mcpServerName = "propagation-server"
+
+			// MCPToolConfig with both a filter (allow list) and an override
+			// (rename "fetch" -> "web_fetch" plus a new description).
+			toolConfig = &mcpv1beta1.MCPToolConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      configName,
+					Namespace: namespace,
+				},
+				Spec: mcpv1beta1.MCPToolConfigSpec{
+					ToolsFilter: []string{"fetch", "search"},
+					ToolsOverride: map[string]mcpv1beta1.ToolOverride{
+						"fetch": {
+							Name:        "web_fetch",
+							Description: "Fetch a URL over HTTP",
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, toolConfig)).Should(Succeed())
+
+			// Wait for the hash to be set before creating the MCPServer so the
+			// reference is resolvable on first reconcile.
+			Eventually(func() bool {
+				updated := &mcpv1beta1.MCPToolConfig{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      configName,
+					Namespace: namespace,
+				}, updated); err != nil {
+					return false
+				}
+				return updated.Status.ConfigHash != ""
+			}, timeout, interval).Should(BeTrue())
+
+			mcpServer = &mcpv1beta1.MCPServer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      mcpServerName,
+					Namespace: namespace,
+				},
+				Spec: mcpv1beta1.MCPServerSpec{
+					Image: testImage,
+					ToolConfigRef: &mcpv1beta1.ToolConfigRef{
+						Name: configName,
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, mcpServer)).Should(Succeed())
+		})
+
+		AfterAll(func() {
+			_ = k8sClient.Delete(ctx, mcpServer)
+			_ = k8sClient.Delete(ctx, toolConfig)
+			Expect(k8sClient.Delete(ctx, ns)).Should(Succeed())
+		})
+
+		It("writes the ToolsFilter and ToolsOverride into the RunConfig ConfigMap", func() {
+			Eventually(func(g Gomega) {
+				configMap := &corev1.ConfigMap{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name:      mcpServerName + "-runconfig",
+					Namespace: namespace,
+				}, configMap)).Should(Succeed())
+
+				raw, ok := configMap.Data["runconfig.json"]
+				g.Expect(ok).To(BeTrue(), "ConfigMap should contain runconfig.json")
+
+				runConfig := &runner.RunConfig{}
+				g.Expect(json.Unmarshal([]byte(raw), runConfig)).Should(Succeed())
+
+				// Filter must propagate verbatim.
+				g.Expect(runConfig.ToolsFilter).To(Equal([]string{"fetch", "search"}))
+
+				// Override (renaming) must propagate, keyed by the real tool name.
+				g.Expect(runConfig.ToolsOverride).To(HaveKey("fetch"))
+				g.Expect(runConfig.ToolsOverride["fetch"].Name).To(Equal("web_fetch"))
+				g.Expect(runConfig.ToolsOverride["fetch"].Description).To(Equal("Fetch a URL over HTTP"))
+			}, timeout, interval).Should(Succeed())
+		})
+	})
+
+	// A single MCPToolConfig may be referenced by several MCPServers. The
+	// reconciler must track every referencing workload and, when the config
+	// changes, fan the new hash out to all of them so each MCPServer re-renders
+	// its RunConfig.
+	Context("When referenced by multiple MCPServers", Ordered, func() {
+		var (
+			namespace   string
+			configName  string
+			serverNames []string
+			toolConfig  *mcpv1beta1.MCPToolConfig
+			servers     []*mcpv1beta1.MCPServer
+			ns          *corev1.Namespace
+		)
+
+		BeforeAll(func() {
+			ns = &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-toolconfig-multiref-",
+				},
+			}
+			Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
+			namespace = ns.Name
+
+			configName = "shared-config"
+			serverNames = []string{"shared-server-a", "shared-server-b"}
+
+			toolConfig = &mcpv1beta1.MCPToolConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      configName,
+					Namespace: namespace,
+				},
+				Spec: mcpv1beta1.MCPToolConfigSpec{
+					ToolsFilter: []string{"tool1"},
+				},
+			}
+			Expect(k8sClient.Create(ctx, toolConfig)).Should(Succeed())
+
+			Eventually(func() bool {
+				updated := &mcpv1beta1.MCPToolConfig{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      configName,
+					Namespace: namespace,
+				}, updated); err != nil {
+					return false
+				}
+				return updated.Status.ConfigHash != ""
+			}, timeout, interval).Should(BeTrue())
+
+			for _, name := range serverNames {
+				server := &mcpv1beta1.MCPServer{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      name,
+						Namespace: namespace,
+					},
+					Spec: mcpv1beta1.MCPServerSpec{
+						Image: testImage,
+						ToolConfigRef: &mcpv1beta1.ToolConfigRef{
+							Name: configName,
+						},
+					},
+				}
+				Expect(k8sClient.Create(ctx, server)).Should(Succeed())
+				servers = append(servers, server)
+			}
+		})
+
+		AfterAll(func() {
+			for _, server := range servers {
+				_ = k8sClient.Delete(ctx, server)
+			}
+			_ = k8sClient.Delete(ctx, toolConfig)
+			Expect(k8sClient.Delete(ctx, ns)).Should(Succeed())
+		})
+
+		It("tracks every referencing MCPServer in status", func() {
+			Eventually(func() []string {
+				updated := &mcpv1beta1.MCPToolConfig{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      configName,
+					Namespace: namespace,
+				}, updated); err != nil {
+					return nil
+				}
+				var names []string
+				for _, ref := range updated.Status.ReferencingWorkloads {
+					if ref.Kind == "MCPServer" {
+						names = append(names, ref.Name)
+					}
+				}
+				return names
+			}, timeout, interval).Should(ConsistOf(serverNames))
+		})
+
+		It("propagates a config change to every referencing MCPServer", func() {
+			// Capture the initial hash the servers converged on.
+			initial := &mcpv1beta1.MCPToolConfig{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      configName,
+				Namespace: namespace,
+			}, initial)).Should(Succeed())
+			initialHash := initial.Status.ConfigHash
+
+			// Change the tool config; its hash must change.
+			Eventually(func() error {
+				updated := &mcpv1beta1.MCPToolConfig{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      configName,
+					Namespace: namespace,
+				}, updated); err != nil {
+					return err
+				}
+				updated.Spec.ToolsFilter = []string{"tool1", "tool2"}
+				return k8sClient.Update(ctx, updated)
+			}, timeout, interval).Should(Succeed())
+
+			var newHash string
+			Eventually(func() string {
+				updated := &mcpv1beta1.MCPToolConfig{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      configName,
+					Namespace: namespace,
+				}, updated); err != nil {
+					return ""
+				}
+				newHash = updated.Status.ConfigHash
+				return newHash
+			}, timeout, interval).ShouldNot(Or(BeEmpty(), Equal(initialHash)))
+
+			// Both MCPServers must pick up the new hash, proving the change
+			// fanned out to every referencing workload.
+			for _, name := range serverNames {
+				Eventually(func() string {
+					server := &mcpv1beta1.MCPServer{}
+					if err := k8sClient.Get(ctx, types.NamespacedName{
+						Name:      name,
+						Namespace: namespace,
+					}, server); err != nil {
+						return ""
+					}
+					return server.Status.ToolConfigHash
+				}, timeout, interval).Should(Equal(newHash), "server %s should converge on the new ToolConfig hash", name)
+			}
 		})
 	})
 })


### PR DESCRIPTION
## Summary

Issue #3363 tracks integration coverage for MCPServer edge cases and MCPToolConfig scenarios. Triaging the codebase showed a large fraction had already landed, but four scenarios the issue lists exercise real operator behavior that no test covered. This PR closes those gaps. It is test-only — no production code changes.

The four added integration tests:

- **MCPToolConfig propagation into the RunConfig** — asserts an MCPToolConfig's `ToolsFilter` *and* `ToolsOverride` (tool renaming) actually land in the referencing MCPServer's rendered RunConfig ConfigMap. Previously only `Status.ReferencingWorkloads` tracking was verified, never the config content itself. This also covers the "tool renaming is untested" gap, since both ride the same code path.
- **Custom ServiceAccount** — when `spec.serviceAccount` names an existing account, the operator must skip the auto-managed `-sa` account, still create the proxy-runner account, and inject the custom account into the backend pod patch. Only the default-creation path was covered before.
- **Recovery from an invalid configuration** — an MCPServer that starts with an invalid `PodTemplateSpec` is blocked; once corrected, `PodTemplateValid` flips back to `True` and the previously-blocked Deployment is created.
- **Multiple MCPServers referencing one MCPToolConfig** — every referencing workload is tracked, and a config change fans the new hash out to all of them.

Part of #3363

<details>
<summary><strong>Scope notes</strong></summary>

Two scenarios from the issue checklist are intentionally **not** implemented because they target behavior the operator does not have:

- **Port-conflict handling** — there is no port-conflict detection anywhere in the operator (no CEL rule, webhook, or controller check). A test would assert behavior that does not exist; this is a feature request, not a test gap.
- **Typed Secret/ConfigMap volume mounts** — the `Volume` type is HostPath-only (no source discriminator), and secrets reach pods via a separate `spec.secrets` path. Source-typed volume tests would exercise nonexistent code paths; the existing HostPath pass-through test already covers the real behavior.

</details>

<details>
<summary><strong>Files</strong></summary>

Tests are placed to match each directory's convention: `mcp-server/` favors one focused file per scenario, while `mcp-toolconfig/` keeps related scenarios as `Context` blocks in its single controller test file.

| File | Change |
|------|--------|
| `test-integration/mcp-server/mcpserver_serviceaccount_integration_test.go` | New: custom `spec.serviceAccount` behavior |
| `test-integration/mcp-server/mcpserver_error_recovery_integration_test.go` | New: recovery from an invalid PodTemplateSpec |
| `test-integration/mcp-toolconfig/mcptoolconfig_controller_integration_test.go` | Added two `Context` blocks: RunConfig propagation (filter + override) and multiple MCPServers sharing one MCPToolConfig |

</details>

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [x] Other (test-only: integration coverage)

## Test plan

- [x] `task lint-fix` passes for the added/changed files (remaining reported issues are pre-existing, in files this PR does not touch)
- [x] New integration tests pass via envtest: `ginkgo ./cmd/thv-operator/test-integration/...` — full suite green, and the 8 new specs pass under `--focus` (5 in mcp-server, 3 in mcp-toolconfig), 0 failures

## Special notes for reviewers

The recovery test deliberately does not assert on `Status.Phase`. Under envtest there is no kubelet, so zero backend pods ever run and the reconciler preserves the `Failed` phase while no pods exist (`mcpserver_controller.go`). The observable recovery signals are the `PodTemplateValid` condition flipping to `True` and the blocked Deployment being created — those are what the test asserts.

Generated with [Claude Code](https://claude.com/claude-code)