### PR TITLE
Fix X-Forwarded-Proto for TLS remote upstreams

### DIFF
--- a/pkg/transport/proxy/transparent/transparent_proxy.go
+++ b/pkg/transport/proxy/transparent/transparent_proxy.go
@@ -1063,14 +1063,59 @@ func (p *TransparentProxy) modifyResponse(resp *http.Response) error {
 // setXForwardedHeaders populates the standard X-Forwarded-* headers on the
 // outbound request. For remote upstreams X-Forwarded-Host is removed: a
 // third-party server may use it to construct redirect URLs pointing back at
-// the proxy, producing 307 redirect loops. X-Forwarded-For and
-// X-Forwarded-Proto are kept so remote backends can still log the client IP
-// and scheme. Client-supplied X-Forwarded-* values never pass through either
-// way — httputil strips them from the outbound request before Rewrite runs.
+// the proxy, producing 307 redirect loops. X-Forwarded-For is kept so remote
+// backends can still log the client IP. Client-supplied X-Forwarded-* values
+// never pass through either way — httputil strips them from the outbound
+// request before Rewrite runs.
+//
+// X-Forwarded-Proto needs special handling for remote upstreams.
+// httputil.SetXForwarded() derives the scheme from the pod-local inbound
+// connection, which is always HTTP when the proxy runs behind a
+// TLS-terminating load balancer (e.g. an AWS ALB). Forwarding
+// "X-Forwarded-Proto: http" to an HTTPS upstream that enforces TLS based on
+// that header triggers an infinite HTTP->HTTPS redirect loop (#5567). For
+// remote upstreams the proxy therefore rewrites X-Forwarded-Proto to the
+// trusted inbound value (when trustProxyHeaders is enabled) or, failing that,
+// to the actual upstream connection scheme.
 func (p *TransparentProxy) setXForwardedHeaders(pr *httputil.ProxyRequest) {
+	// Capture the client-supplied X-Forwarded-Proto before SetXForwarded()
+	// overwrites it with the pod-local inbound scheme.
+	inboundProto := pr.In.Header.Get("X-Forwarded-Proto")
+
 	pr.SetXForwarded()
-	if p.isRemote {
-		pr.Out.Header.Del("X-Forwarded-Host")
+
+	if !p.isRemote {
+		return
+	}
+
+	pr.Out.Header.Del("X-Forwarded-Host")
+
+	if proto := p.upstreamForwardedProto(inboundProto); proto != "" {
+		pr.Out.Header.Set("X-Forwarded-Proto", proto)
+	}
+}
+
+// upstreamForwardedProto returns the X-Forwarded-Proto value to forward to a
+// remote upstream. When trustProxyHeaders is enabled and the inbound request
+// carried an X-Forwarded-Proto (e.g. set by a trusted load balancer), that
+// value is honored so the original client scheme survives the pod-local hop.
+// Otherwise the proxy falls back to the upstream connection scheme parsed from
+// the target URI, which always reflects the protocol the upstream actually
+// receives. Returns an empty string when no usable scheme is found, leaving
+// the value SetXForwarded() already set untouched.
+func (p *TransparentProxy) upstreamForwardedProto(inboundProto string) string {
+	if p.trustProxyHeaders && inboundProto != "" {
+		return inboundProto
+	}
+	u, err := url.Parse(p.targetURI)
+	if err != nil {
+		return ""
+	}
+	switch u.Scheme {
+	case "http", "https":
+		return u.Scheme
+	default:
+		return ""
 	}
 }
 

--- a/pkg/transport/proxy/transparent/transparent_proxy.go
+++ b/pkg/transport/proxy/transparent/transparent_proxy.go
@@ -132,7 +132,13 @@ type TransparentProxy struct {
 	// from the original registration URL are never silently dropped.
 	remoteRawQuery string
 
-	// Deprecated: trustProxyHeaders indicates whether to trust X-Forwarded-* headers (moved to SSEResponseProcessor)
+	// trustProxyHeaders indicates whether to trust inbound X-Forwarded-* headers
+	// from a fronting reverse proxy (e.g. a load balancer). It has two live read
+	// sites and is therefore load-bearing in both directions:
+	//   - SSEResponseProcessor reads X-Forwarded-Proto/Host/Prefix to rewrite SSE
+	//     endpoint URLs returned to the client (a copy is passed at construction); and
+	//   - setXForwardedHeaders honors a trusted inbound X-Forwarded-Proto when
+	//     forwarding requests to remote upstreams.
 	trustProxyHeaders bool
 
 	// Health check interval (default: 10 seconds)
@@ -1076,10 +1082,21 @@ func (p *TransparentProxy) modifyResponse(resp *http.Response) error {
 // that header triggers an infinite HTTP->HTTPS redirect loop (#5567). For
 // remote upstreams the proxy therefore rewrites X-Forwarded-Proto to the
 // trusted inbound value (when trustProxyHeaders is enabled) or, failing that,
-// to the actual upstream connection scheme.
-func (p *TransparentProxy) setXForwardedHeaders(pr *httputil.ProxyRequest) {
-	// Capture the client-supplied X-Forwarded-Proto before SetXForwarded()
-	// overwrites it with the pod-local inbound scheme.
+// to the upstream connection scheme.
+//
+// upstreamScheme is the scheme of the statically-configured target URL, passed
+// in by the caller (already parsed in Start) to avoid re-parsing per request.
+// It is used deliberately instead of pr.Out.URL.Scheme: the per-session
+// backend_url override that can rewrite pr.Out.URL runs *after* this function,
+// so reading pr.Out.URL.Scheme here would observe a pre-override value. The
+// override only ever swaps the host for HTTP targets and preserves the scheme
+// for HTTPS targets (see podBackendURL), so upstreamScheme always matches the
+// wire protocol. Do not "simplify" this to read pr.Out.URL.Scheme.
+func (p *TransparentProxy) setXForwardedHeaders(pr *httputil.ProxyRequest, upstreamScheme string) {
+	// Read the client-supplied X-Forwarded-Proto from pr.In. We must read it
+	// from the inbound request (not pr.Out) because httputil.ReverseProxy strips
+	// all client-supplied X-Forwarded-* headers from the outbound request before
+	// Rewrite runs, so pr.Out never carries the original client value.
 	inboundProto := pr.In.Header.Get("X-Forwarded-Proto")
 
 	pr.SetXForwarded()
@@ -1090,33 +1107,48 @@ func (p *TransparentProxy) setXForwardedHeaders(pr *httputil.ProxyRequest) {
 
 	pr.Out.Header.Del("X-Forwarded-Host")
 
-	if proto := p.upstreamForwardedProto(inboundProto); proto != "" {
+	if proto := p.upstreamForwardedProto(inboundProto, upstreamScheme); proto != "" {
 		pr.Out.Header.Set("X-Forwarded-Proto", proto)
 	}
 }
 
 // upstreamForwardedProto returns the X-Forwarded-Proto value to forward to a
 // remote upstream. When trustProxyHeaders is enabled and the inbound request
-// carried an X-Forwarded-Proto (e.g. set by a trusted load balancer), that
-// value is honored so the original client scheme survives the pod-local hop.
-// Otherwise the proxy falls back to the upstream connection scheme parsed from
-// the target URI, which always reflects the protocol the upstream actually
-// receives. Returns an empty string when no usable scheme is found, leaving
-// the value SetXForwarded() already set untouched.
-func (p *TransparentProxy) upstreamForwardedProto(inboundProto string) string {
-	if p.trustProxyHeaders && inboundProto != "" {
+// carried a valid HTTP(S) X-Forwarded-Proto (e.g. set by a trusted load
+// balancer), that value is honored so the original client scheme survives the
+// pod-local hop. Otherwise the proxy falls back to upstreamScheme, the actual
+// upstream connection scheme.
+//
+// Both the trusted inbound value and the fallback are validated against
+// {http, https}. inboundProto is client-controllable (the proxy listener is
+// plain HTTP), so even on the trusted path an unvalidated value would let a
+// caller reflect arbitrary tokens — or "http" against an HTTPS upstream,
+// re-creating the redirect loop this fix exists to prevent. Validation bounds
+// the reflected value regardless of where the proxy is deployed.
+//
+// The value is computed once on the first hop; followRedirects re-issues
+// requests without re-running Rewrite, so a same-host HTTP->HTTPS upgrade
+// redirect within a chain would carry the first-hop scheme. That is acceptable:
+// the proxy refuses HTTPS->HTTP downgrades, and same-scheme redirects need no
+// recomputation.
+//
+// Returns an empty string when no usable scheme is found, leaving the value
+// SetXForwarded() already set untouched.
+func (p *TransparentProxy) upstreamForwardedProto(inboundProto, upstreamScheme string) string {
+	if p.trustProxyHeaders && isHTTPScheme(inboundProto) {
 		return inboundProto
 	}
-	u, err := url.Parse(p.targetURI)
-	if err != nil {
-		return ""
+	if isHTTPScheme(upstreamScheme) {
+		return upstreamScheme
 	}
-	switch u.Scheme {
-	case "http", "https":
-		return u.Scheme
-	default:
-		return ""
-	}
+	return ""
+}
+
+// isHTTPScheme reports whether s is the "http" or "https" URL scheme. It bounds
+// the X-Forwarded-Proto value forwarded to upstreams to known-safe schemes,
+// rejecting client-controlled junk even on the trusted path.
+func isHTTPScheme(s string) bool {
+	return s == "http" || s == "https"
 }
 
 // Start starts the transparent proxy.
@@ -1141,7 +1173,7 @@ func (p *TransparentProxy) Start(ctx context.Context) error {
 		FlushInterval: -1,
 		Rewrite: func(pr *httputil.ProxyRequest) {
 			pr.SetURL(targetURL)
-			p.setXForwardedHeaders(pr)
+			p.setXForwardedHeaders(pr, targetURL.Scheme)
 
 			// Route to the originating backend pod when session metadata contains backend_url.
 			// Falls back to static targetURL when the session doesn't exist or has no backend_url.

--- a/pkg/transport/proxy/transparent/xforwarded_test.go
+++ b/pkg/transport/proxy/transparent/xforwarded_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -89,6 +90,26 @@ func TestSetXForwardedHeaders(t *testing.T) {
 			wantHost:     false,
 			wantProto:    "https",
 		},
+		{
+			// A client-controlled junk scheme must not be reflected even when
+			// trust is enabled; the proxy falls back to the upstream scheme.
+			name:              "junk trusted inbound proto is rejected, falls back to upstream scheme",
+			targetURI:         "https://mcp.example.com/mcp",
+			isRemote:          true,
+			trustProxyHeaders: true,
+			inboundProto:      "httpx",
+			wantHost:          false,
+			wantProto:         "https",
+		},
+		{
+			// A non-HTTP(S) upstream scheme yields no override, so the value
+			// SetXForwarded() set from the inbound HTTP hop is left intact.
+			name:      "non-http upstream scheme leaves SetXForwarded default",
+			targetURI: "ftp://mcp.example.com/mcp",
+			isRemote:  true,
+			wantHost:  false,
+			wantProto: "http",
+		},
 	}
 
 	for _, tt := range tests {
@@ -106,7 +127,9 @@ func TestSetXForwardedHeaders(t *testing.T) {
 			}
 			pr := &httputil.ProxyRequest{In: in, Out: in.Clone(in.Context())}
 
-			p.setXForwardedHeaders(pr)
+			upstreamURL, err := url.Parse(tt.targetURI)
+			assert.NoError(t, err)
+			p.setXForwardedHeaders(pr, upstreamURL.Scheme)
 
 			if tt.wantHost {
 				assert.Equal(t, "proxy.example.com", pr.Out.Header.Get("X-Forwarded-Host"))

--- a/pkg/transport/proxy/transparent/xforwarded_test.go
+++ b/pkg/transport/proxy/transparent/xforwarded_test.go
@@ -13,21 +13,82 @@ import (
 )
 
 // TestSetXForwardedHeaders verifies the remote/local split for X-Forwarded-*
-// headers: a remote upstream must not receive X-Forwarded-Host (third-party
+// headers. A remote upstream must not receive X-Forwarded-Host (third-party
 // servers can echo it into redirect URLs, creating 307 loops back to the
-// proxy), while X-Forwarded-For and X-Forwarded-Proto are always set so
-// backends can still see the client IP and scheme. Local backends receive
-// the full set.
+// proxy), while X-Forwarded-For is always set so backends can see the client
+// IP. Local backends receive the full set.
+//
+// X-Forwarded-Proto must reflect the real client/upstream scheme rather than
+// the pod-local inbound HTTP hop: behind a TLS-terminating load balancer the
+// inbound connection is always HTTP, and forwarding "http" to a TLS upstream
+// that enforces HTTPS via the header causes infinite redirect loops (#5567).
 func TestSetXForwardedHeaders(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name     string
-		isRemote bool
-		wantHost bool
+		name              string
+		targetURI         string
+		isRemote          bool
+		trustProxyHeaders bool
+		inboundProto      string
+		wantHost          bool
+		wantProto         string
 	}{
-		{name: "local backend keeps X-Forwarded-Host", isRemote: false, wantHost: true},
-		{name: "remote upstream omits X-Forwarded-Host", isRemote: true, wantHost: false},
+		{
+			name:      "local backend keeps X-Forwarded-Host and http proto",
+			targetURI: "http://backend.svc:8080",
+			isRemote:  false,
+			wantHost:  true,
+			wantProto: "http",
+		},
+		{
+			name:      "remote https upstream omits X-Forwarded-Host and sets https proto",
+			targetURI: "https://mcp.example.com/mcp",
+			isRemote:  true,
+			wantHost:  false,
+			wantProto: "https",
+		},
+		{
+			name:      "remote http upstream keeps http proto",
+			targetURI: "http://mcp.example.com/mcp",
+			isRemote:  true,
+			wantHost:  false,
+			wantProto: "http",
+		},
+		{
+			name:              "remote upstream honors trusted inbound X-Forwarded-Proto",
+			targetURI:         "https://mcp.example.com/mcp",
+			isRemote:          true,
+			trustProxyHeaders: true,
+			inboundProto:      "https",
+			wantHost:          false,
+			wantProto:         "https",
+		},
+		{
+			name:              "trusted inbound proto wins over upstream scheme",
+			targetURI:         "http://mcp.example.com/mcp",
+			isRemote:          true,
+			trustProxyHeaders: true,
+			inboundProto:      "https",
+			wantHost:          false,
+			wantProto:         "https",
+		},
+		{
+			name:              "trust enabled but no inbound proto falls back to upstream scheme",
+			targetURI:         "https://mcp.example.com/mcp",
+			isRemote:          true,
+			trustProxyHeaders: true,
+			wantHost:          false,
+			wantProto:         "https",
+		},
+		{
+			name:         "untrusted inbound proto is ignored in favor of upstream scheme",
+			targetURI:    "https://mcp.example.com/mcp",
+			isRemote:     true,
+			inboundProto: "http",
+			wantHost:     false,
+			wantProto:    "https",
+		},
 	}
 
 	for _, tt := range tests {
@@ -35,11 +96,14 @@ func TestSetXForwardedHeaders(t *testing.T) {
 			t.Parallel()
 
 			p := NewTransparentProxy(
-				"127.0.0.1", 0, "", nil, nil, nil, false,
-				tt.isRemote, "streamable-http", nil, nil, "", false,
+				"127.0.0.1", 0, tt.targetURI, nil, nil, nil, false,
+				tt.isRemote, "streamable-http", nil, nil, "", tt.trustProxyHeaders,
 			)
 
 			in := httptest.NewRequest(http.MethodPost, "http://proxy.example.com/mcp", nil)
+			if tt.inboundProto != "" {
+				in.Header.Set("X-Forwarded-Proto", tt.inboundProto)
+			}
 			pr := &httputil.ProxyRequest{In: in, Out: in.Clone(in.Context())}
 
 			p.setXForwardedHeaders(pr)
@@ -52,7 +116,7 @@ func TestSetXForwardedHeaders(t *testing.T) {
 			}
 			assert.NotEmpty(t, pr.Out.Header.Get("X-Forwarded-For"),
 				"client IP must be forwarded for both local and remote backends")
-			assert.Equal(t, "http", pr.Out.Header.Get("X-Forwarded-Proto"))
+			assert.Equal(t, tt.wantProto, pr.Out.Header.Get("X-Forwarded-Proto"))
 		})
 	}
 }


### PR DESCRIPTION
## Summary

Behind a TLS-terminating load balancer (e.g. an AWS ALB), the proxy's pod-local inbound connection is plain HTTP. `httputil.SetXForwarded()` derives `X-Forwarded-Proto` from that inbound hop, so remote upstreams always received `X-Forwarded-Proto: http`. Upstreams that enforce HTTPS based on this header respond with 301 redirects, and because every forwarded request keeps reporting `http`, the proxy loops until it hits the redirect limit — preventing MCP session initialization.

- Rewrite `X-Forwarded-Proto` for **remote** upstreams in `setXForwardedHeaders`. The value is now either:
  - the trusted inbound `X-Forwarded-Proto` (e.g. set by the ALB) when `trustProxyHeaders` is enabled, or
  - the actual upstream connection scheme parsed from the target URI (fallback).
- Local backends are unchanged (still derive from the inbound hop).
- Add a new `upstreamForwardedProto` helper and expand the table-driven test coverage.

Fixes #5567

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)

`TestSetXForwardedHeaders` was expanded into a table covering: local backend (unchanged `http`), remote https/http upstreams (derive from upstream scheme), trusted inbound proto honored (and winning over upstream scheme), trust enabled without an inbound header (falls back to upstream scheme), and untrusted inbound proto ignored.

## API Compatibility

- [x] This PR does not break the `v1beta1` API, OR the `api-break-allowed` label is applied and the migration guidance is described above.

## Does this introduce a user-facing change?

Yes. `MCPRemoteProxy` (and any remote HTTP/SSE proxy) deployed behind a TLS-terminating load balancer now forwards a correct `X-Forwarded-Proto` to TLS upstreams, fixing infinite HTTP→HTTPS redirect loops during MCP session initialization. When `trustProxyHeaders` is enabled, a trusted inbound `X-Forwarded-Proto` (e.g. from an ALB) is honored; otherwise the proxy uses the upstream connection scheme.

## Implementation plan

<details>
<summary>Approved implementation plan</summary>

Root cause: `setXForwardedHeaders` calls `httputil.ProxyRequest.SetXForwarded()`, which sets `X-Forwarded-Proto` from the pod-local inbound connection (`pr.In.TLS == nil` → `http`). Client-supplied forwarded headers are stripped by httputil before `Rewrite` runs, so the original HTTPS scheme is lost.

Fix (in `pkg/transport/proxy/transparent/transparent_proxy.go`):
1. Capture the inbound `X-Forwarded-Proto` before `SetXForwarded()` overwrites it.
2. For remote upstreams only, set `X-Forwarded-Proto` to:
   - the captured inbound value when `trustProxyHeaders` is enabled and present, else
   - the scheme parsed from the configured target URI (validated to `http`/`https`).
3. Leave local-backend behavior untouched.
4. Expand `xforwarded_test.go` into a table-driven test for the matrix above.

</details>

## Special notes for reviewers

- The fix is scoped to remote upstreams (`p.isRemote`), matching the issue (MCPRemoteProxy). Local pod-to-pod backends keep the existing inbound-derived scheme.
- The fallback derives the scheme from the configured target URI, which for remote upstreams always reflects the protocol the upstream actually receives (the session `backend_url` override keeps the original scheme for HTTPS targets).
- Reusing the existing `trustProxyHeaders` knob means no new config surface is introduced; the documented option now also governs `X-Forwarded-Proto` passthrough, consistent with the SSE response processor's existing use of it.

Generated with [Claude Code](https://claude.com/claude-code)
