### PR TITLE
Index referencing-workload lookups across config controllers

### DIFF
--- a/cmd/thv-operator/controllers/mcpauthzconfig_controller.go
+++ b/cmd/thv-operator/controllers/mcpauthzconfig_controller.go
@@ -308,46 +308,83 @@ func (r *MCPAuthzConfigReconciler) handleDeletion(
 	return ctrl.Result{}, nil
 }
 
+// Field-index keys backing findReferencingWorkloads. MCPServer and MCPRemoteProxy
+// both reference the config via spec.authzConfigRef; VirtualMCPServer nests it
+// under spec.incomingAuth. The indexes are registered in SetupWithManager.
+const (
+	authzConfigRefIndexKey     = "spec.authzConfigRef"
+	vmcpAuthzConfigRefIndexKey = "spec.incomingAuth.authzConfigRef"
+)
+
+// indexMCPServerByAuthzConfigRef extracts the MCPAuthzConfig name an MCPServer
+// references, for the field index. Returns nil when there is no reference so
+// unreferencing servers are not indexed under the empty key.
+func indexMCPServerByAuthzConfigRef(obj client.Object) []string {
+	server, ok := obj.(*mcpv1beta1.MCPServer)
+	if !ok || server.Spec.AuthzConfigRef == nil || server.Spec.AuthzConfigRef.Name == "" {
+		return nil
+	}
+	return []string{server.Spec.AuthzConfigRef.Name}
+}
+
+// indexMCPRemoteProxyByAuthzConfigRef extracts the MCPAuthzConfig name an
+// MCPRemoteProxy references, for the field index.
+func indexMCPRemoteProxyByAuthzConfigRef(obj client.Object) []string {
+	proxy, ok := obj.(*mcpv1beta1.MCPRemoteProxy)
+	if !ok || proxy.Spec.AuthzConfigRef == nil || proxy.Spec.AuthzConfigRef.Name == "" {
+		return nil
+	}
+	return []string{proxy.Spec.AuthzConfigRef.Name}
+}
+
+// indexVirtualMCPServerByAuthzConfigRef extracts the MCPAuthzConfig name a
+// VirtualMCPServer references via spec.incomingAuth, for the field index.
+func indexVirtualMCPServerByAuthzConfigRef(obj client.Object) []string {
+	vmcp, ok := obj.(*mcpv1beta1.VirtualMCPServer)
+	if !ok || vmcp.Spec.IncomingAuth == nil ||
+		vmcp.Spec.IncomingAuth.AuthzConfigRef == nil || vmcp.Spec.IncomingAuth.AuthzConfigRef.Name == "" {
+		return nil
+	}
+	return []string{vmcp.Spec.IncomingAuth.AuthzConfigRef.Name}
+}
+
 // findReferencingWorkloads returns the workload resources (MCPServer, VirtualMCPServer,
 // and MCPRemoteProxy) that reference this MCPAuthzConfig via their AuthzConfigRef field.
+//
+// Each lookup is served by a field index (registered in SetupWithManager) so the
+// query returns only the referencing workloads instead of listing every workload
+// in the namespace and filtering in memory.
 func (r *MCPAuthzConfigReconciler) findReferencingWorkloads(
 	ctx context.Context,
 	authzConfig *mcpv1beta1.MCPAuthzConfig,
 ) ([]mcpv1beta1.WorkloadReference, error) {
-	// Find referencing MCPServers
-	refs, err := ctrlutil.FindWorkloadRefsFromMCPServers(ctx, r.Client, authzConfig.Namespace, authzConfig.Name,
-		func(server *mcpv1beta1.MCPServer) *string {
-			if server.Spec.AuthzConfigRef != nil {
-				return &server.Spec.AuthzConfigRef.Name
-			}
-			return nil
-		})
-	if err != nil {
-		return nil, err
+	var refs []mcpv1beta1.WorkloadReference
+
+	serverList := &mcpv1beta1.MCPServerList{}
+	if err := r.List(ctx, serverList, client.InNamespace(authzConfig.Namespace),
+		client.MatchingFields{authzConfigRefIndexKey: authzConfig.Name}); err != nil {
+		return nil, fmt.Errorf("failed to list MCPServers by authzConfigRef: %w", err)
+	}
+	for i := range serverList.Items {
+		refs = append(refs, mcpv1beta1.WorkloadReference{Kind: mcpv1beta1.WorkloadKindMCPServer, Name: serverList.Items[i].Name})
 	}
 
-	// Check VirtualMCPServers
 	vmcpList := &mcpv1beta1.VirtualMCPServerList{}
-	if err := r.List(ctx, vmcpList, client.InNamespace(authzConfig.Namespace)); err != nil {
-		return nil, fmt.Errorf("failed to list VirtualMCPServers: %w", err)
+	if err := r.List(ctx, vmcpList, client.InNamespace(authzConfig.Namespace),
+		client.MatchingFields{vmcpAuthzConfigRefIndexKey: authzConfig.Name}); err != nil {
+		return nil, fmt.Errorf("failed to list VirtualMCPServers by authzConfigRef: %w", err)
 	}
-	for _, vmcp := range vmcpList.Items {
-		if vmcp.Spec.IncomingAuth != nil &&
-			vmcp.Spec.IncomingAuth.AuthzConfigRef != nil &&
-			vmcp.Spec.IncomingAuth.AuthzConfigRef.Name == authzConfig.Name {
-			refs = append(refs, mcpv1beta1.WorkloadReference{Kind: mcpv1beta1.WorkloadKindVirtualMCPServer, Name: vmcp.Name})
-		}
+	for i := range vmcpList.Items {
+		refs = append(refs, mcpv1beta1.WorkloadReference{Kind: mcpv1beta1.WorkloadKindVirtualMCPServer, Name: vmcpList.Items[i].Name})
 	}
 
-	// Check MCPRemoteProxies
 	proxyList := &mcpv1beta1.MCPRemoteProxyList{}
-	if err := r.List(ctx, proxyList, client.InNamespace(authzConfig.Namespace)); err != nil {
-		return nil, fmt.Errorf("failed to list MCPRemoteProxies: %w", err)
+	if err := r.List(ctx, proxyList, client.InNamespace(authzConfig.Namespace),
+		client.MatchingFields{authzConfigRefIndexKey: authzConfig.Name}); err != nil {
+		return nil, fmt.Errorf("failed to list MCPRemoteProxies by authzConfigRef: %w", err)
 	}
-	for _, proxy := range proxyList.Items {
-		if proxy.Spec.AuthzConfigRef != nil && proxy.Spec.AuthzConfigRef.Name == authzConfig.Name {
-			refs = append(refs, mcpv1beta1.WorkloadReference{Kind: mcpv1beta1.WorkloadKindMCPRemoteProxy, Name: proxy.Name})
-		}
+	for i := range proxyList.Items {
+		refs = append(refs, mcpv1beta1.WorkloadReference{Kind: mcpv1beta1.WorkloadKindMCPRemoteProxy, Name: proxyList.Items[i].Name})
 	}
 
 	ctrlutil.SortWorkloadRefs(refs)
@@ -358,6 +395,25 @@ func (r *MCPAuthzConfigReconciler) findReferencingWorkloads(
 // Watches MCPServer, VirtualMCPServer, and MCPRemoteProxy changes to maintain
 // accurate ReferencingWorkloads status.
 func (r *MCPAuthzConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	// Field indexes backing findReferencingWorkloads: each lets the controller
+	// query only the workloads referencing a given config rather than listing
+	// every workload in the namespace and filtering in memory.
+	if err := mgr.GetFieldIndexer().IndexField(
+		context.Background(), &mcpv1beta1.MCPServer{}, authzConfigRefIndexKey, indexMCPServerByAuthzConfigRef,
+	); err != nil {
+		return fmt.Errorf("failed to set up MCPServer authzConfigRef index: %w", err)
+	}
+	if err := mgr.GetFieldIndexer().IndexField(
+		context.Background(), &mcpv1beta1.MCPRemoteProxy{}, authzConfigRefIndexKey, indexMCPRemoteProxyByAuthzConfigRef,
+	); err != nil {
+		return fmt.Errorf("failed to set up MCPRemoteProxy authzConfigRef index: %w", err)
+	}
+	if err := mgr.GetFieldIndexer().IndexField(
+		context.Background(), &mcpv1beta1.VirtualMCPServer{}, vmcpAuthzConfigRefIndexKey, indexVirtualMCPServerByAuthzConfigRef,
+	); err != nil {
+		return fmt.Errorf("failed to set up VirtualMCPServer authzConfigRef index: %w", err)
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&mcpv1beta1.MCPAuthzConfig{}).
 		Watches(&mcpv1beta1.MCPServer{},

--- a/cmd/thv-operator/controllers/mcpexternalauthconfig_controller.go
+++ b/cmd/thv-operator/controllers/mcpexternalauthconfig_controller.go
@@ -450,103 +450,116 @@ func (r *MCPExternalAuthConfigReconciler) handleDeletion(
 	return ctrl.Result{}, nil
 }
 
+// externalAuthConfigRefIndexKey is the field-index key backing the reverse
+// lookups in findReferencingMCPServers / findReferencingMCPRemoteProxies. A
+// workload references an MCPExternalAuthConfig through EITHER spec field, so a
+// single combined index covers both: the extractors below return every config
+// name the object names via either field, deduplicated. The index is registered
+// per workload type in SetupWithManager.
+const externalAuthConfigRefIndexKey = "spec.externalAuthConfigRef+authServerRef"
+
+// indexMCPServerByExternalAuthConfigRef extracts the MCPExternalAuthConfig
+// name(s) an MCPServer references, for the combined field index. It covers both
+// spec.externalAuthConfigRef and spec.authServerRef (the latter only when its
+// Kind identifies an MCPExternalAuthConfig), deduplicating so a server naming the
+// same config via both fields is indexed once. Returns nil when there is no
+// reference so unreferencing servers are not indexed under the empty key.
+func indexMCPServerByExternalAuthConfigRef(obj client.Object) []string {
+	server, ok := obj.(*mcpv1beta1.MCPServer)
+	if !ok {
+		return nil
+	}
+	names := map[string]struct{}{}
+	if server.Spec.ExternalAuthConfigRef != nil && server.Spec.ExternalAuthConfigRef.Name != "" {
+		names[server.Spec.ExternalAuthConfigRef.Name] = struct{}{}
+	}
+	if server.Spec.AuthServerRef != nil &&
+		server.Spec.AuthServerRef.Kind == authServerRefKindMCPExternalAuthConfig &&
+		server.Spec.AuthServerRef.Name != "" {
+		names[server.Spec.AuthServerRef.Name] = struct{}{}
+	}
+	if len(names) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(names))
+	for n := range names {
+		out = append(out, n)
+	}
+	return out
+}
+
+// indexMCPRemoteProxyByExternalAuthConfigRef extracts the MCPExternalAuthConfig
+// name(s) an MCPRemoteProxy references, for the combined field index. It mirrors
+// indexMCPServerByExternalAuthConfigRef: it covers both spec.externalAuthConfigRef
+// and spec.authServerRef (the latter only when its Kind identifies an
+// MCPExternalAuthConfig), deduplicating so a proxy naming the same config via both
+// fields is indexed once. Returns nil when there is no reference.
+func indexMCPRemoteProxyByExternalAuthConfigRef(obj client.Object) []string {
+	proxy, ok := obj.(*mcpv1beta1.MCPRemoteProxy)
+	if !ok {
+		return nil
+	}
+	names := map[string]struct{}{}
+	if proxy.Spec.ExternalAuthConfigRef != nil && proxy.Spec.ExternalAuthConfigRef.Name != "" {
+		names[proxy.Spec.ExternalAuthConfigRef.Name] = struct{}{}
+	}
+	if proxy.Spec.AuthServerRef != nil &&
+		proxy.Spec.AuthServerRef.Kind == authServerRefKindMCPExternalAuthConfig &&
+		proxy.Spec.AuthServerRef.Name != "" {
+		names[proxy.Spec.AuthServerRef.Name] = struct{}{}
+	}
+	if len(names) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(names))
+	for n := range names {
+		out = append(out, n)
+	}
+	return out
+}
+
 // findReferencingMCPServers finds all MCPServers that reference the given MCPExternalAuthConfig
 // via either externalAuthConfigRef or authServerRef.
-// It queries separately for each ref field and merges with deduplication, so a server
-// that has externalAuthConfigRef pointing to config "A" and authServerRef pointing to
-// config "B" will be found when reconciling either config.
+//
+// The combined field index (externalAuthConfigRefIndexKey, registered in
+// SetupWithManager) returns each server once regardless of which field — or both —
+// names the config, so a single indexed query replaces the prior two-query merge
+// and dedup.
 func (r *MCPExternalAuthConfigReconciler) findReferencingMCPServers(
 	ctx context.Context,
 	externalAuthConfig *mcpv1beta1.MCPExternalAuthConfig,
 ) ([]mcpv1beta1.MCPServer, error) {
-	byExtAuth, err := ctrlutil.FindReferencingMCPServers(ctx, r.Client, externalAuthConfig.Namespace, externalAuthConfig.Name,
-		func(server *mcpv1beta1.MCPServer) *string {
-			if server.Spec.ExternalAuthConfigRef != nil {
-				return &server.Spec.ExternalAuthConfigRef.Name
-			}
-			return nil
-		})
-	if err != nil {
-		return nil, err
+	serverList := &mcpv1beta1.MCPServerList{}
+	if err := r.List(ctx, serverList, client.InNamespace(externalAuthConfig.Namespace),
+		client.MatchingFields{externalAuthConfigRefIndexKey: externalAuthConfig.Name}); err != nil {
+		return nil, fmt.Errorf("failed to list MCPServers by externalAuthConfigRef: %w", err)
 	}
-
-	byAuthServer, err := ctrlutil.FindReferencingMCPServers(ctx, r.Client, externalAuthConfig.Namespace, externalAuthConfig.Name,
-		func(server *mcpv1beta1.MCPServer) *string {
-			if server.Spec.AuthServerRef != nil && server.Spec.AuthServerRef.Kind == authServerRefKindMCPExternalAuthConfig {
-				return &server.Spec.AuthServerRef.Name
-			}
-			return nil
-		})
-	if err != nil {
-		return nil, err
-	}
-
-	// Merge and deduplicate
-	seen := make(map[string]struct{}, len(byExtAuth))
-	result := make([]mcpv1beta1.MCPServer, 0, len(byExtAuth)+len(byAuthServer))
-	for _, s := range byExtAuth {
-		seen[s.Name] = struct{}{}
-		result = append(result, s)
-	}
-	for _, s := range byAuthServer {
-		if _, ok := seen[s.Name]; !ok {
-			result = append(result, s)
-		}
-	}
-	return result, nil
+	return serverList.Items, nil
 }
 
 // findReferencingMCPRemoteProxies finds all MCPRemoteProxies that reference the given MCPExternalAuthConfig
 // via either externalAuthConfigRef or authServerRef.
-// It queries separately for each ref field and merges with deduplication, so a proxy
-// that has externalAuthConfigRef pointing to config "A" and authServerRef pointing to
-// config "B" will be found when reconciling either config.
+//
+// The combined field index (externalAuthConfigRefIndexKey, registered in
+// SetupWithManager) returns each proxy once regardless of which field — or both —
+// names the config, so a single indexed query replaces the prior two-query merge
+// and dedup.
 func (r *MCPExternalAuthConfigReconciler) findReferencingMCPRemoteProxies(
 	ctx context.Context,
 	externalAuthConfig *mcpv1beta1.MCPExternalAuthConfig,
 ) ([]mcpv1beta1.MCPRemoteProxy, error) {
-	byExtAuth, err := ctrlutil.FindReferencingMCPRemoteProxies(
-		ctx, r.Client, externalAuthConfig.Namespace, externalAuthConfig.Name,
-		func(proxy *mcpv1beta1.MCPRemoteProxy) *string {
-			if proxy.Spec.ExternalAuthConfigRef != nil {
-				return &proxy.Spec.ExternalAuthConfigRef.Name
-			}
-			return nil
-		})
-	if err != nil {
-		return nil, err
+	proxyList := &mcpv1beta1.MCPRemoteProxyList{}
+	if err := r.List(ctx, proxyList, client.InNamespace(externalAuthConfig.Namespace),
+		client.MatchingFields{externalAuthConfigRefIndexKey: externalAuthConfig.Name}); err != nil {
+		return nil, fmt.Errorf("failed to list MCPRemoteProxies by externalAuthConfigRef: %w", err)
 	}
-
-	byAuthServer, err := ctrlutil.FindReferencingMCPRemoteProxies(
-		ctx, r.Client, externalAuthConfig.Namespace, externalAuthConfig.Name,
-		func(proxy *mcpv1beta1.MCPRemoteProxy) *string {
-			if proxy.Spec.AuthServerRef != nil && proxy.Spec.AuthServerRef.Kind == authServerRefKindMCPExternalAuthConfig {
-				return &proxy.Spec.AuthServerRef.Name
-			}
-			return nil
-		})
-	if err != nil {
-		return nil, err
-	}
-
-	// Merge and deduplicate
-	seen := make(map[string]struct{}, len(byExtAuth))
-	result := make([]mcpv1beta1.MCPRemoteProxy, 0, len(byExtAuth)+len(byAuthServer))
-	for _, p := range byExtAuth {
-		seen[p.Name] = struct{}{}
-		result = append(result, p)
-	}
-	for _, p := range byAuthServer {
-		if _, ok := seen[p.Name]; !ok {
-			result = append(result, p)
-		}
-	}
-	return result, nil
+	return proxyList.Items, nil
 }
 
 // findReferencingWorkloads returns the workload resources (MCPServer and MCPRemoteProxy)
 // that reference this MCPExternalAuthConfig via their ExternalAuthConfigRef or AuthServerRef field.
-// It queries separately for each ref field and merges the results, so both fields are always checked.
+// Both fields are covered by a single combined field index per workload type, so each
+// workload type is found with one indexed query.
 func (r *MCPExternalAuthConfigReconciler) findReferencingWorkloads(
 	ctx context.Context,
 	externalAuthConfig *mcpv1beta1.MCPExternalAuthConfig,
@@ -575,6 +588,23 @@ func (r *MCPExternalAuthConfigReconciler) findReferencingWorkloads(
 // SetupWithManager sets up the controller with the Manager.
 // Watches MCPServer and MCPRemoteProxy changes to maintain accurate ReferencingWorkloads status.
 func (r *MCPExternalAuthConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	// Field indexes backing findReferencingMCPServers / findReferencingMCPRemoteProxies.
+	// Each is a combined index covering both spec.externalAuthConfigRef and
+	// spec.authServerRef, so a single MatchingFields query returns every workload
+	// referencing a given config via either field rather than listing every
+	// workload in the namespace and filtering in memory.
+	if err := mgr.GetFieldIndexer().IndexField(
+		context.Background(), &mcpv1beta1.MCPServer{}, externalAuthConfigRefIndexKey, indexMCPServerByExternalAuthConfigRef,
+	); err != nil {
+		return fmt.Errorf("failed to set up MCPServer externalAuthConfigRef index: %w", err)
+	}
+	if err := mgr.GetFieldIndexer().IndexField(
+		context.Background(), &mcpv1beta1.MCPRemoteProxy{}, externalAuthConfigRefIndexKey,
+		indexMCPRemoteProxyByExternalAuthConfigRef,
+	); err != nil {
+		return fmt.Errorf("failed to set up MCPRemoteProxy externalAuthConfigRef index: %w", err)
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&mcpv1beta1.MCPExternalAuthConfig{}).
 		Watches(

--- a/cmd/thv-operator/controllers/mcpexternalauthconfig_controller_test.go
+++ b/cmd/thv-operator/controllers/mcpexternalauthconfig_controller_test.go
@@ -288,8 +288,7 @@ func TestMCPExternalAuthConfigReconciler_findReferencingWorkloads(t *testing.T) 
 		// No ExternalAuthConfigRef
 	)
 
-	fakeClient := fake.NewClientBuilder().
-		WithScheme(scheme).
+	fakeClient := withExternalAuthConfigRefIndexes(fake.NewClientBuilder().WithScheme(scheme)).
 		WithObjects(externalAuthConfig, mcpServer1, mcpServer2, mcpServer3).
 		Build()
 
@@ -775,8 +774,7 @@ func TestMCPExternalAuthConfigReconciler_findReferencingWorkloads_authServerRef(
 		v1beta1test.WithImage("test-image"),
 	)
 
-	fakeClient := fake.NewClientBuilder().
-		WithScheme(scheme).
+	fakeClient := withExternalAuthConfigRefIndexes(fake.NewClientBuilder().WithScheme(scheme)).
 		WithObjects(externalAuthConfig, serverViaAuthServerRef, serverViaExtAuth, serverNoRef).
 		Build()
 
@@ -850,8 +848,7 @@ func TestMCPExternalAuthConfigReconciler_findReferencingWorkloads_bothRefsOnSame
 		v1beta1test.WithAuthServerRef("MCPExternalAuthConfig", "embedded-auth-config"),
 	)
 
-	fakeClient := fake.NewClientBuilder().
-		WithScheme(scheme).
+	fakeClient := withExternalAuthConfigRefIndexes(fake.NewClientBuilder().WithScheme(scheme)).
 		WithObjects(tokenExchangeConfig, embeddedAuthConfig, serverWithBothRefs).
 		Build()
 
@@ -918,8 +915,7 @@ func TestMCPExternalAuthConfigReconciler_findReferencingMCPServers_deduplicates(
 		v1beta1test.WithAuthServerRef("MCPExternalAuthConfig", "shared-config"),
 	)
 
-	fakeClient := fake.NewClientBuilder().
-		WithScheme(scheme).
+	fakeClient := withExternalAuthConfigRefIndexes(fake.NewClientBuilder().WithScheme(scheme)).
 		WithObjects(config, server).
 		Build()
 
@@ -983,8 +979,7 @@ func TestMCPExternalAuthConfigReconciler_findReferencingWorkloads_mcpRemoteProxy
 		v1beta1test.WithExternalAuthConfigRef("auth-config"),
 	)
 
-	fakeClient := fake.NewClientBuilder().
-		WithScheme(scheme).
+	fakeClient := withExternalAuthConfigRefIndexes(fake.NewClientBuilder().WithScheme(scheme)).
 		WithObjects(config, proxyViaExtAuth, proxyViaAuthServerRef, proxyNoRef, server).
 		Build()
 

--- a/cmd/thv-operator/controllers/mcptelemetryconfig_controller.go
+++ b/cmd/thv-operator/controllers/mcptelemetryconfig_controller.go
@@ -139,9 +139,64 @@ func (r *MCPTelemetryConfigReconciler) Reconcile(ctx context.Context, req ctrl.R
 	return ctrl.Result{}, nil
 }
 
+// Field-index keys backing findReferencingWorkloads. MCPServer, MCPRemoteProxy,
+// and VirtualMCPServer all reference the config via a top-level
+// spec.telemetryConfigRef. The indexes are registered in SetupWithManager.
+const telemetryConfigRefIndexKey = "spec.telemetryConfigRef"
+
+// indexMCPServerByTelemetryConfigRef extracts the MCPTelemetryConfig name an
+// MCPServer references, for the field index. Returns nil when there is no
+// reference so unreferencing servers are not indexed under the empty key.
+func indexMCPServerByTelemetryConfigRef(obj client.Object) []string {
+	server, ok := obj.(*mcpv1beta1.MCPServer)
+	if !ok || server.Spec.TelemetryConfigRef == nil || server.Spec.TelemetryConfigRef.Name == "" {
+		return nil
+	}
+	return []string{server.Spec.TelemetryConfigRef.Name}
+}
+
+// indexMCPRemoteProxyByTelemetryConfigRef extracts the MCPTelemetryConfig name an
+// MCPRemoteProxy references, for the field index.
+func indexMCPRemoteProxyByTelemetryConfigRef(obj client.Object) []string {
+	proxy, ok := obj.(*mcpv1beta1.MCPRemoteProxy)
+	if !ok || proxy.Spec.TelemetryConfigRef == nil || proxy.Spec.TelemetryConfigRef.Name == "" {
+		return nil
+	}
+	return []string{proxy.Spec.TelemetryConfigRef.Name}
+}
+
+// indexVirtualMCPServerByTelemetryConfigRef extracts the MCPTelemetryConfig name a
+// VirtualMCPServer references via its top-level spec.telemetryConfigRef.
+func indexVirtualMCPServerByTelemetryConfigRef(obj client.Object) []string {
+	vmcp, ok := obj.(*mcpv1beta1.VirtualMCPServer)
+	if !ok || vmcp.Spec.TelemetryConfigRef == nil || vmcp.Spec.TelemetryConfigRef.Name == "" {
+		return nil
+	}
+	return []string{vmcp.Spec.TelemetryConfigRef.Name}
+}
+
 // SetupWithManager sets up the controller with the Manager.
 // Watches MCPServer changes to maintain accurate ReferencingWorkloads status.
 func (r *MCPTelemetryConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	// Field indexes backing findReferencingWorkloads: each lets the controller
+	// query only the workloads referencing a given config rather than listing
+	// every workload in the namespace and filtering in memory.
+	if err := mgr.GetFieldIndexer().IndexField(
+		context.Background(), &mcpv1beta1.MCPServer{}, telemetryConfigRefIndexKey, indexMCPServerByTelemetryConfigRef,
+	); err != nil {
+		return fmt.Errorf("failed to set up MCPServer telemetryConfigRef index: %w", err)
+	}
+	if err := mgr.GetFieldIndexer().IndexField(
+		context.Background(), &mcpv1beta1.MCPRemoteProxy{}, telemetryConfigRefIndexKey, indexMCPRemoteProxyByTelemetryConfigRef,
+	); err != nil {
+		return fmt.Errorf("failed to set up MCPRemoteProxy telemetryConfigRef index: %w", err)
+	}
+	if err := mgr.GetFieldIndexer().IndexField(
+		context.Background(), &mcpv1beta1.VirtualMCPServer{}, telemetryConfigRefIndexKey, indexVirtualMCPServerByTelemetryConfigRef,
+	); err != nil {
+		return fmt.Errorf("failed to set up VirtualMCPServer telemetryConfigRef index: %w", err)
+	}
+
 	// Watch MCPServer changes to update ReferencingWorkloads on referenced MCPTelemetryConfigs.
 	// This handler enqueues both the currently-referenced MCPTelemetryConfig AND any
 	// MCPTelemetryConfig that still lists this server in ReferencingWorkloads (covers the
@@ -351,50 +406,46 @@ func (r *MCPTelemetryConfigReconciler) handleDeletion(
 	return ctrl.Result{}, nil
 }
 
-// findReferencingWorkloads returns a sorted list of workload references in the same namespace
-// that reference this MCPTelemetryConfig via TelemetryConfigRef.
+// findReferencingWorkloads returns a sorted list of workload references
+// (MCPServer, MCPRemoteProxy, and VirtualMCPServer) in the same namespace that
+// reference this MCPTelemetryConfig via TelemetryConfigRef.
+//
+// Each lookup is served by a field index (registered in SetupWithManager) so the
+// query returns only the referencing workloads instead of listing every workload
+// in the namespace and filtering in memory.
 func (r *MCPTelemetryConfigReconciler) findReferencingWorkloads(
 	ctx context.Context,
 	telemetryConfig *mcpv1beta1.MCPTelemetryConfig,
 ) ([]mcpv1beta1.WorkloadReference, error) {
-	serverRefs, err := ctrlutil.FindWorkloadRefsFromMCPServers(ctx, r.Client, telemetryConfig.Namespace, telemetryConfig.Name,
-		func(server *mcpv1beta1.MCPServer) *string {
-			if server.Spec.TelemetryConfigRef != nil {
-				return &server.Spec.TelemetryConfigRef.Name
-			}
-			return nil
-		})
-	if err != nil {
-		return nil, err
+	var refs []mcpv1beta1.WorkloadReference
+
+	serverList := &mcpv1beta1.MCPServerList{}
+	if err := r.List(ctx, serverList, client.InNamespace(telemetryConfig.Namespace),
+		client.MatchingFields{telemetryConfigRefIndexKey: telemetryConfig.Name}); err != nil {
+		return nil, fmt.Errorf("failed to list MCPServers by telemetryConfigRef: %w", err)
+	}
+	for i := range serverList.Items {
+		refs = append(refs, mcpv1beta1.WorkloadReference{Kind: mcpv1beta1.WorkloadKindMCPServer, Name: serverList.Items[i].Name})
 	}
 
-	proxies, err := ctrlutil.FindReferencingMCPRemoteProxies(ctx, r.Client, telemetryConfig.Namespace, telemetryConfig.Name,
-		func(proxy *mcpv1beta1.MCPRemoteProxy) *string {
-			if proxy.Spec.TelemetryConfigRef != nil {
-				return &proxy.Spec.TelemetryConfigRef.Name
-			}
-			return nil
-		})
-	if err != nil {
-		return nil, err
+	proxyList := &mcpv1beta1.MCPRemoteProxyList{}
+	if err := r.List(ctx, proxyList, client.InNamespace(telemetryConfig.Namespace),
+		client.MatchingFields{telemetryConfigRefIndexKey: telemetryConfig.Name}); err != nil {
+		return nil, fmt.Errorf("failed to list MCPRemoteProxies by telemetryConfigRef: %w", err)
+	}
+	for i := range proxyList.Items {
+		refs = append(refs, mcpv1beta1.WorkloadReference{Kind: mcpv1beta1.WorkloadKindMCPRemoteProxy, Name: proxyList.Items[i].Name})
 	}
 
-	// Check VirtualMCPServers
 	vmcpList := &mcpv1beta1.VirtualMCPServerList{}
-	if err := r.List(ctx, vmcpList, client.InNamespace(telemetryConfig.Namespace)); err != nil {
-		return nil, fmt.Errorf("failed to list VirtualMCPServers: %w", err)
+	if err := r.List(ctx, vmcpList, client.InNamespace(telemetryConfig.Namespace),
+		client.MatchingFields{telemetryConfigRefIndexKey: telemetryConfig.Name}); err != nil {
+		return nil, fmt.Errorf("failed to list VirtualMCPServers by telemetryConfigRef: %w", err)
+	}
+	for i := range vmcpList.Items {
+		refs = append(refs, mcpv1beta1.WorkloadReference{Kind: mcpv1beta1.WorkloadKindVirtualMCPServer, Name: vmcpList.Items[i].Name})
 	}
 
-	refs := make([]mcpv1beta1.WorkloadReference, 0, len(serverRefs)+len(proxies)+len(vmcpList.Items))
-	refs = append(refs, serverRefs...)
-	for _, proxy := range proxies {
-		refs = append(refs, mcpv1beta1.WorkloadReference{Kind: mcpv1beta1.WorkloadKindMCPRemoteProxy, Name: proxy.Name})
-	}
-	for _, vmcp := range vmcpList.Items {
-		if vmcp.Spec.TelemetryConfigRef != nil && vmcp.Spec.TelemetryConfigRef.Name == telemetryConfig.Name {
-			refs = append(refs, mcpv1beta1.WorkloadReference{Kind: mcpv1beta1.WorkloadKindVirtualMCPServer, Name: vmcp.Name})
-		}
-	}
 	ctrlutil.SortWorkloadRefs(refs)
 	return refs, nil
 }

--- a/cmd/thv-operator/controllers/mcptelemetryconfig_controller_test.go
+++ b/cmd/thv-operator/controllers/mcptelemetryconfig_controller_test.go
@@ -112,8 +112,7 @@ func TestMCPTelemetryConfigReconciler_SteadyStateNoOp(t *testing.T) {
 		Spec: newTelemetrySpec("https://otel-collector:4317", true, true),
 	}
 
-	fakeClient := fake.NewClientBuilder().
-		WithScheme(scheme).
+	fakeClient := withTelemetryConfigRefIndexes(fake.NewClientBuilder().WithScheme(scheme)).
 		WithObjects(telemetryConfig).
 		WithStatusSubresource(&mcpv1beta1.MCPTelemetryConfig{}).
 		Build()
@@ -182,8 +181,7 @@ func TestMCPTelemetryConfigReconciler_ValidationRecovery(t *testing.T) {
 		}(),
 	}
 
-	fakeClient := fake.NewClientBuilder().
-		WithScheme(scheme).
+	fakeClient := withTelemetryConfigRefIndexes(fake.NewClientBuilder().WithScheme(scheme)).
 		WithObjects(telemetryConfig).
 		WithStatusSubresource(&mcpv1beta1.MCPTelemetryConfig{}).
 		Build()
@@ -277,8 +275,7 @@ func TestMCPTelemetryConfigReconciler_handleDeletion(t *testing.T) {
 
 			scheme := testutil.NewScheme(t)
 
-			fakeClient := fake.NewClientBuilder().
-				WithScheme(scheme).
+			fakeClient := withTelemetryConfigRefIndexes(fake.NewClientBuilder().WithScheme(scheme)).
 				WithObjects(tt.telemetryConfig).
 				Build()
 
@@ -316,8 +313,7 @@ func TestMCPTelemetryConfigReconciler_ConfigChangeTriggersHashUpdate(t *testing.
 		Spec: newTelemetrySpec("https://otel-collector:4317", true, false),
 	}
 
-	fakeClient := fake.NewClientBuilder().
-		WithScheme(scheme).
+	fakeClient := withTelemetryConfigRefIndexes(fake.NewClientBuilder().WithScheme(scheme)).
 		WithObjects(telemetryConfig).
 		WithStatusSubresource(&mcpv1beta1.MCPTelemetryConfig{}).
 		Build()
@@ -566,8 +562,7 @@ func TestMCPTelemetryConfigReconciler_ConditionOnlyUpdate(t *testing.T) {
 		},
 	}
 
-	fakeClient := fake.NewClientBuilder().
-		WithScheme(scheme).
+	fakeClient := withTelemetryConfigRefIndexes(fake.NewClientBuilder().WithScheme(scheme)).
 		WithObjects(telemetryConfig).
 		WithStatusSubresource(&mcpv1beta1.MCPTelemetryConfig{}).
 		Build()
@@ -635,8 +630,7 @@ func TestMCPTelemetryConfigReconciler_ReferenceTracking(t *testing.T) {
 		// No TelemetryConfigRef
 	)
 
-	fakeClient := fake.NewClientBuilder().
-		WithScheme(scheme).
+	fakeClient := withTelemetryConfigRefIndexes(fake.NewClientBuilder().WithScheme(scheme)).
 		WithObjects(telemetryConfig, server1, server2, server3).
 		WithStatusSubresource(&mcpv1beta1.MCPTelemetryConfig{}).
 		Build()
@@ -698,8 +692,7 @@ func TestMCPTelemetryConfigReconciler_handleDeletion_BlocksWhenReferenced(t *tes
 		v1beta1test.WithTelemetryConfigRef("referenced-config"),
 	)
 
-	fakeClient := fake.NewClientBuilder().
-		WithScheme(scheme).
+	fakeClient := withTelemetryConfigRefIndexes(fake.NewClientBuilder().WithScheme(scheme)).
 		WithObjects(telemetryConfig, server).
 		WithStatusSubresource(&mcpv1beta1.MCPTelemetryConfig{}).
 		Build()
@@ -743,8 +736,7 @@ func TestMCPTelemetryConfigReconciler_handleDeletion_AllowsWhenNotReferenced(t *
 		// No TelemetryConfigRef
 	)
 
-	fakeClient := fake.NewClientBuilder().
-		WithScheme(scheme).
+	fakeClient := withTelemetryConfigRefIndexes(fake.NewClientBuilder().WithScheme(scheme)).
 		WithObjects(telemetryConfig, server).
 		Build()
 

--- a/cmd/thv-operator/controllers/mcpwebhookconfig_controller.go
+++ b/cmd/thv-operator/controllers/mcpwebhookconfig_controller.go
@@ -260,18 +260,38 @@ func (r *MCPWebhookConfigReconciler) handleDeletion(
 	return ctrl.Result{}, nil
 }
 
-// findReferencingMCPServers finds all MCPServers that reference the given MCPWebhookConfig
+// webhookConfigRefIndexKey is the field-index key backing the reverse lookup in
+// findReferencingMCPServers. MCPServer references the config via
+// spec.webhookConfigRef; the index is registered in SetupWithManager. The
+// MCPWebhookConfig CR is v1alpha1, but the index is on the v1beta1 MCPServer.
+const webhookConfigRefIndexKey = "spec.webhookConfigRef"
+
+// indexMCPServerByWebhookConfigRef extracts the MCPWebhookConfig name an MCPServer
+// references, for the field index. Returns nil when there is no reference so
+// unreferencing servers are not indexed under the empty key.
+func indexMCPServerByWebhookConfigRef(obj client.Object) []string {
+	server, ok := obj.(*mcpv1beta1.MCPServer)
+	if !ok || server.Spec.WebhookConfigRef == nil || server.Spec.WebhookConfigRef.Name == "" {
+		return nil
+	}
+	return []string{server.Spec.WebhookConfigRef.Name}
+}
+
+// findReferencingMCPServers finds all MCPServers that reference the given MCPWebhookConfig.
+//
+// The lookup is served by a field index (registered in SetupWithManager) so the
+// query returns only the referencing MCPServers instead of listing every MCPServer
+// in the namespace and filtering in memory.
 func (r *MCPWebhookConfigReconciler) findReferencingMCPServers(
 	ctx context.Context,
 	webhookConfig *mcpv1alpha1.MCPWebhookConfig,
 ) ([]mcpv1beta1.MCPServer, error) {
-	return ctrlutil.FindReferencingMCPServers(ctx, r.Client, webhookConfig.Namespace, webhookConfig.Name,
-		func(server *mcpv1beta1.MCPServer) *string {
-			if server.Spec.WebhookConfigRef != nil {
-				return &server.Spec.WebhookConfigRef.Name
-			}
-			return nil
-		})
+	serverList := &mcpv1beta1.MCPServerList{}
+	if err := r.List(ctx, serverList, client.InNamespace(webhookConfig.Namespace),
+		client.MatchingFields{webhookConfigRefIndexKey: webhookConfig.Name}); err != nil {
+		return nil, fmt.Errorf("failed to list MCPServers by webhookConfigRef: %w", err)
+	}
+	return serverList.Items, nil
 }
 
 // updateReferencingWorkloads updates the list of workloads referencing this config
@@ -317,6 +337,15 @@ func conditionWouldChange(conditions []metav1.Condition, desired metav1.Conditio
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *MCPWebhookConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	// Field index backing findReferencingMCPServers: lets the controller query only
+	// the MCPServers referencing a given config rather than listing every MCPServer
+	// in the namespace and filtering in memory.
+	if err := mgr.GetFieldIndexer().IndexField(
+		context.Background(), &mcpv1beta1.MCPServer{}, webhookConfigRefIndexKey, indexMCPServerByWebhookConfigRef,
+	); err != nil {
+		return fmt.Errorf("failed to set up MCPServer webhookConfigRef index: %w", err)
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&mcpv1alpha1.MCPWebhookConfig{}).
 		Watches(

--- a/cmd/thv-operator/controllers/mcpwebhookconfig_controller_test.go
+++ b/cmd/thv-operator/controllers/mcpwebhookconfig_controller_test.go
@@ -93,8 +93,7 @@ func TestMCPWebhookConfigReconciler_Reconcile(t *testing.T) {
 			if tt.existingMCPServer != nil {
 				objs = append(objs, tt.existingMCPServer)
 			}
-			fakeClient := fake.NewClientBuilder().
-				WithScheme(scheme).
+			fakeClient := withWebhookConfigRefIndex(fake.NewClientBuilder().WithScheme(scheme)).
 				WithObjects(objs...).
 				WithStatusSubresource(&mcpv1alpha1.MCPWebhookConfig{}).
 				Build()
@@ -232,8 +231,7 @@ func TestMCPWebhookConfigReconciler_handleDeletion(t *testing.T) {
 		v1beta1test.WithWebhookConfigRef("test-config"),
 	)
 
-	fakeClient := fake.NewClientBuilder().
-		WithScheme(scheme).
+	fakeClient := withWebhookConfigRefIndex(fake.NewClientBuilder().WithScheme(scheme)).
 		WithObjects(webhookConfig, mcpServer).
 		WithStatusSubresource(&mcpv1alpha1.MCPWebhookConfig{}).
 		Build()
@@ -297,8 +295,7 @@ func TestMCPWebhookConfigReconciler_handleDeletionClearsBlockedCondition(t *test
 		},
 	}
 
-	fakeClient := fake.NewClientBuilder().
-		WithScheme(scheme).
+	fakeClient := withWebhookConfigRefIndex(fake.NewClientBuilder().WithScheme(scheme)).
 		WithObjects(webhookConfig).
 		WithStatusSubresource(&mcpv1alpha1.MCPWebhookConfig{}).
 		Build()
@@ -455,8 +452,7 @@ func TestMCPWebhookConfigReconciler_updateReferencingWorkloads(t *testing.T) {
 		v1beta1test.WithImage("test-image"),
 		v1beta1test.WithWebhookConfigRef("other-config"),
 	)
-	fakeClient := fake.NewClientBuilder().
-		WithScheme(scheme).
+	fakeClient := withWebhookConfigRefIndex(fake.NewClientBuilder().WithScheme(scheme)).
 		WithObjects(webhookConfig, referencingServer, otherServer).
 		WithStatusSubresource(&mcpv1alpha1.MCPWebhookConfig{}).
 		Build()

--- a/cmd/thv-operator/controllers/reconciler_test_helpers_test.go
+++ b/cmd/thv-operator/controllers/reconciler_test_helpers_test.go
@@ -127,6 +127,31 @@ func withOIDCConfigRefIndexes(b *fake.ClientBuilder) *fake.ClientBuilder {
 		WithIndex(&mcpv1beta1.MCPRemoteProxy{}, oidcConfigRefIndexKey, indexMCPRemoteProxyByOIDCConfigRef)
 }
 
+// withTelemetryConfigRefIndexes registers the field indexes that
+// MCPTelemetryConfigReconciler.findReferencingWorkloads relies on, so fake-client
+// MatchingFields lookups (which the real cache populates via SetupWithManager)
+// work in unit tests. Without these, the fake client returns "no index with
+// name spec.telemetryConfigRef has been registered" for
+// MCPServer/MCPRemoteProxy/VirtualMCPServer.
+func withTelemetryConfigRefIndexes(b *fake.ClientBuilder) *fake.ClientBuilder {
+	return b.
+		WithIndex(&mcpv1beta1.MCPServer{}, telemetryConfigRefIndexKey, indexMCPServerByTelemetryConfigRef).
+		WithIndex(&mcpv1beta1.MCPRemoteProxy{}, telemetryConfigRefIndexKey, indexMCPRemoteProxyByTelemetryConfigRef).
+		WithIndex(&mcpv1beta1.VirtualMCPServer{}, telemetryConfigRefIndexKey, indexVirtualMCPServerByTelemetryConfigRef)
+}
+
+// withAuthzConfigRefIndexes registers the field indexes that
+// MCPAuthzConfigReconciler.findReferencingWorkloads relies on, so fake-client
+// MatchingFields lookups (which the real cache populates via SetupWithManager)
+// work in unit tests. Without these, the fake client returns "no index with
+// name ... has been registered" for MCPServer/MCPRemoteProxy/VirtualMCPServer.
+func withAuthzConfigRefIndexes(b *fake.ClientBuilder) *fake.ClientBuilder {
+	return b.
+		WithIndex(&mcpv1beta1.MCPServer{}, authzConfigRefIndexKey, indexMCPServerByAuthzConfigRef).
+		WithIndex(&mcpv1beta1.MCPRemoteProxy{}, authzConfigRefIndexKey, indexMCPRemoteProxyByAuthzConfigRef).
+		WithIndex(&mcpv1beta1.VirtualMCPServer{}, vmcpAuthzConfigRefIndexKey, indexVirtualMCPServerByAuthzConfigRef)
+}
+
 // withToolConfigRefIndex registers the field index that
 // ToolConfigReconciler.findReferencingWorkloads / findReferencingMCPServers rely
 // on, so fake-client MatchingFields lookups (which the real cache populates via
@@ -163,11 +188,16 @@ func newTestMCPOIDCConfigReconciler(t *testing.T, objs ...client.Object) (*MCPOI
 }
 
 // newTestMCPAuthzConfigReconciler builds an MCPAuthzConfigReconciler backed by a
-// fake client seeded with objs, with the MCPAuthzConfig status subresource enabled.
+// fake client seeded with objs, with the MCPAuthzConfig status subresource enabled
+// and the authz config-ref field indexes registered (see withAuthzConfigRefIndexes).
 // See newTestMCPExternalAuthConfigReconciler for the Recorder convention.
 func newTestMCPAuthzConfigReconciler(t *testing.T, objs ...client.Object) (*MCPAuthzConfigReconciler, client.Client) {
 	t.Helper()
-	fakeClient, scheme := newTestFakeClient(t, &mcpv1beta1.MCPAuthzConfig{}, objs...)
+	scheme := testutil.NewScheme(t)
+	fakeClient := withAuthzConfigRefIndexes(fake.NewClientBuilder().WithScheme(scheme)).
+		WithObjects(objs...).
+		WithStatusSubresource(&mcpv1beta1.MCPAuthzConfig{}).
+		Build()
 	return &MCPAuthzConfigReconciler{
 		Client: fakeClient,
 		Scheme: scheme,

--- a/cmd/thv-operator/controllers/reconciler_test_helpers_test.go
+++ b/cmd/thv-operator/controllers/reconciler_test_helpers_test.go
@@ -108,11 +108,28 @@ func newTestMCPExternalAuthConfigReconciler(
 	t *testing.T, objs ...client.Object,
 ) (*MCPExternalAuthConfigReconciler, client.Client) {
 	t.Helper()
-	fakeClient, scheme := newTestFakeClient(t, &mcpv1beta1.MCPExternalAuthConfig{}, objs...)
+	scheme := testutil.NewScheme(t)
+	fakeClient := withExternalAuthConfigRefIndexes(fake.NewClientBuilder().WithScheme(scheme)).
+		WithObjects(objs...).
+		WithStatusSubresource(&mcpv1beta1.MCPExternalAuthConfig{}).
+		Build()
 	return &MCPExternalAuthConfigReconciler{
 		Client: fakeClient,
 		Scheme: scheme,
 	}, fakeClient
+}
+
+// withExternalAuthConfigRefIndexes registers the combined field indexes that
+// MCPExternalAuthConfigReconciler.findReferencingMCPServers /
+// findReferencingMCPRemoteProxies rely on, so fake-client MatchingFields lookups
+// (which the real cache populates via SetupWithManager) work in unit tests.
+// Without these, the fake client returns "no index with name ... has been
+// registered" for MCPServer/MCPRemoteProxy. The index covers both
+// spec.externalAuthConfigRef and spec.authServerRef.
+func withExternalAuthConfigRefIndexes(b *fake.ClientBuilder) *fake.ClientBuilder {
+	return b.
+		WithIndex(&mcpv1beta1.MCPServer{}, externalAuthConfigRefIndexKey, indexMCPServerByExternalAuthConfigRef).
+		WithIndex(&mcpv1beta1.MCPRemoteProxy{}, externalAuthConfigRefIndexKey, indexMCPRemoteProxyByExternalAuthConfigRef)
 }
 
 // withOIDCConfigRefIndexes registers the field indexes that

--- a/cmd/thv-operator/controllers/reconciler_test_helpers_test.go
+++ b/cmd/thv-operator/controllers/reconciler_test_helpers_test.go
@@ -127,6 +127,24 @@ func withOIDCConfigRefIndexes(b *fake.ClientBuilder) *fake.ClientBuilder {
 		WithIndex(&mcpv1beta1.MCPRemoteProxy{}, oidcConfigRefIndexKey, indexMCPRemoteProxyByOIDCConfigRef)
 }
 
+// withToolConfigRefIndex registers the field index that
+// ToolConfigReconciler.findReferencingWorkloads / findReferencingMCPServers rely
+// on, so fake-client MatchingFields lookups (which the real cache populates via
+// SetupWithManager) work in unit tests. Without it, the fake client returns "no
+// index with name spec.toolConfigRef has been registered".
+func withToolConfigRefIndex(b *fake.ClientBuilder) *fake.ClientBuilder {
+	return b.WithIndex(&mcpv1beta1.MCPServer{}, toolConfigRefIndexKey, indexMCPServerByToolConfigRef)
+}
+
+// withWebhookConfigRefIndex registers the field index that
+// MCPWebhookConfigReconciler.findReferencingMCPServers relies on, so fake-client
+// MatchingFields lookups (which the real cache populates via SetupWithManager)
+// work in unit tests. Without it, the fake client returns "no index with name
+// spec.webhookConfigRef has been registered".
+func withWebhookConfigRefIndex(b *fake.ClientBuilder) *fake.ClientBuilder {
+	return b.WithIndex(&mcpv1beta1.MCPServer{}, webhookConfigRefIndexKey, indexMCPServerByWebhookConfigRef)
+}
+
 // newTestMCPOIDCConfigReconciler builds an MCPOIDCConfigReconciler backed by a
 // fake client seeded with objs, with the MCPOIDCConfig status subresource enabled
 // and the OIDC config-ref field indexes registered (see withOIDCConfigRefIndexes).

--- a/cmd/thv-operator/controllers/toolconfig_controller.go
+++ b/cmd/thv-operator/controllers/toolconfig_controller.go
@@ -226,39 +226,74 @@ func (r *ToolConfigReconciler) handleDeletion(ctx context.Context, toolConfig *m
 	return ctrl.Result{}, nil
 }
 
+// toolConfigRefIndexKey is the field-index key backing the reverse lookups in
+// findReferencingWorkloads and findReferencingMCPServers. MCPServer references the
+// config via spec.toolConfigRef; the index is registered in SetupWithManager.
+const toolConfigRefIndexKey = "spec.toolConfigRef"
+
+// indexMCPServerByToolConfigRef extracts the MCPToolConfig name an MCPServer
+// references, for the field index. Returns nil when there is no reference so
+// unreferencing servers are not indexed under the empty key.
+func indexMCPServerByToolConfigRef(obj client.Object) []string {
+	server, ok := obj.(*mcpv1beta1.MCPServer)
+	if !ok || server.Spec.ToolConfigRef == nil || server.Spec.ToolConfigRef.Name == "" {
+		return nil
+	}
+	return []string{server.Spec.ToolConfigRef.Name}
+}
+
 // findReferencingWorkloads returns the workload resources (MCPServer)
 // that reference this MCPToolConfig via their ToolConfigRef field.
+//
+// The lookup is served by a field index (registered in SetupWithManager) so the
+// query returns only the referencing workloads instead of listing every workload
+// in the namespace and filtering in memory.
 func (r *ToolConfigReconciler) findReferencingWorkloads(
 	ctx context.Context,
 	toolConfig *mcpv1beta1.MCPToolConfig,
 ) ([]mcpv1beta1.WorkloadReference, error) {
-	return ctrlutil.FindWorkloadRefsFromMCPServers(ctx, r.Client, toolConfig.Namespace, toolConfig.Name,
-		func(server *mcpv1beta1.MCPServer) *string {
-			if server.Spec.ToolConfigRef != nil {
-				return &server.Spec.ToolConfigRef.Name
-			}
-			return nil
-		})
+	serverList := &mcpv1beta1.MCPServerList{}
+	if err := r.List(ctx, serverList, client.InNamespace(toolConfig.Namespace),
+		client.MatchingFields{toolConfigRefIndexKey: toolConfig.Name}); err != nil {
+		return nil, fmt.Errorf("failed to list MCPServers by toolConfigRef: %w", err)
+	}
+	refs := make([]mcpv1beta1.WorkloadReference, 0, len(serverList.Items))
+	for i := range serverList.Items {
+		refs = append(refs, mcpv1beta1.WorkloadReference{Kind: mcpv1beta1.WorkloadKindMCPServer, Name: serverList.Items[i].Name})
+	}
+	ctrlutil.SortWorkloadRefs(refs)
+	return refs, nil
 }
 
 // findReferencingMCPServers finds all MCPServers that reference the given MCPToolConfig.
 // Returns the full MCPServer objects, used by handleConfigHashChange to update server annotations.
+//
+// The lookup is served by the same field index as findReferencingWorkloads
+// (registered in SetupWithManager), querying by spec.toolConfigRef.
 func (r *ToolConfigReconciler) findReferencingMCPServers(
 	ctx context.Context,
 	toolConfig *mcpv1beta1.MCPToolConfig,
 ) ([]mcpv1beta1.MCPServer, error) {
-	return ctrlutil.FindReferencingMCPServers(ctx, r.Client, toolConfig.Namespace, toolConfig.Name,
-		func(server *mcpv1beta1.MCPServer) *string {
-			if server.Spec.ToolConfigRef != nil {
-				return &server.Spec.ToolConfigRef.Name
-			}
-			return nil
-		})
+	serverList := &mcpv1beta1.MCPServerList{}
+	if err := r.List(ctx, serverList, client.InNamespace(toolConfig.Namespace),
+		client.MatchingFields{toolConfigRefIndexKey: toolConfig.Name}); err != nil {
+		return nil, fmt.Errorf("failed to list MCPServers by toolConfigRef: %w", err)
+	}
+	return serverList.Items, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.
 // Watches MCPServer changes to maintain accurate ReferencingWorkloads status.
 func (r *ToolConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	// Field index backing findReferencingWorkloads / findReferencingMCPServers: lets
+	// the controller query only the MCPServers referencing a given config rather than
+	// listing every MCPServer in the namespace and filtering in memory.
+	if err := mgr.GetFieldIndexer().IndexField(
+		context.Background(), &mcpv1beta1.MCPServer{}, toolConfigRefIndexKey, indexMCPServerByToolConfigRef,
+	); err != nil {
+		return fmt.Errorf("failed to set up MCPServer toolConfigRef index: %w", err)
+	}
+
 	// Watch MCPServer changes to update ReferencingWorkloads on referenced MCPToolConfigs.
 	// This handler enqueues both the currently-referenced MCPToolConfig AND any
 	// MCPToolConfig that still lists this server in ReferencingWorkloads (covers the

--- a/cmd/thv-operator/controllers/toolconfig_controller_edge_cases_test.go
+++ b/cmd/thv-operator/controllers/toolconfig_controller_edge_cases_test.go
@@ -80,8 +80,7 @@ func TestToolConfigReconciler_EdgeCases(t *testing.T) {
 			v1beta1test.WithToolConfigRef("test-config"),
 		)
 
-		fakeClient := fake.NewClientBuilder().
-			WithScheme(scheme).
+		fakeClient := withToolConfigRefIndex(fake.NewClientBuilder().WithScheme(scheme)).
 			WithObjects(toolConfig, mcpServer).
 			WithStatusSubresource(&mcpv1beta1.MCPToolConfig{}).
 			Build()
@@ -137,8 +136,7 @@ func TestToolConfigReconciler_EdgeCases(t *testing.T) {
 			},
 		}
 
-		fakeClient := fake.NewClientBuilder().
-			WithScheme(scheme).
+		fakeClient := withToolConfigRefIndex(fake.NewClientBuilder().WithScheme(scheme)).
 			WithObjects(toolConfig).
 			WithStatusSubresource(&mcpv1beta1.MCPToolConfig{}).
 			Build()
@@ -283,8 +281,7 @@ func TestToolConfigReconciler_ComplexScenarios(t *testing.T) {
 			objs = append(objs, server)
 		}
 
-		fakeClient := fake.NewClientBuilder().
-			WithScheme(scheme).
+		fakeClient := withToolConfigRefIndex(fake.NewClientBuilder().WithScheme(scheme)).
 			WithObjects(objs...).
 			WithStatusSubresource(&mcpv1beta1.MCPToolConfig{}).
 			Build()
@@ -341,8 +338,7 @@ func TestToolConfigReconciler_ComplexScenarios(t *testing.T) {
 			},
 		}
 
-		fakeClient := fake.NewClientBuilder().
-			WithScheme(scheme).
+		fakeClient := withToolConfigRefIndex(fake.NewClientBuilder().WithScheme(scheme)).
 			WithObjects(toolConfig).
 			WithStatusSubresource(&mcpv1beta1.MCPToolConfig{}).
 			Build()

--- a/cmd/thv-operator/controllers/toolconfig_controller_test.go
+++ b/cmd/thv-operator/controllers/toolconfig_controller_test.go
@@ -163,8 +163,7 @@ func TestToolConfigReconciler_Reconcile(t *testing.T) {
 			if tt.existingMCPServer != nil {
 				objs = append(objs, tt.existingMCPServer)
 			}
-			fakeClient := fake.NewClientBuilder().
-				WithScheme(scheme).
+			fakeClient := withToolConfigRefIndex(fake.NewClientBuilder().WithScheme(scheme)).
 				WithObjects(objs...).
 				WithStatusSubresource(&mcpv1beta1.MCPToolConfig{}).
 				Build()
@@ -258,8 +257,7 @@ func TestToolConfigReconciler_findReferencingWorkloads(t *testing.T) {
 		// No ToolConfigRef
 	)
 
-	fakeClient := fake.NewClientBuilder().
-		WithScheme(scheme).
+	fakeClient := withToolConfigRefIndex(fake.NewClientBuilder().WithScheme(scheme)).
 		WithObjects(toolConfig, mcpServer1, mcpServer2, mcpServer3).
 		Build()
 
@@ -295,8 +293,7 @@ func TestToolConfigReconciler_ReferencingWorkloadsUpdatedWithoutHashChange(t *te
 		},
 	}
 
-	fakeClient := fake.NewClientBuilder().
-		WithScheme(scheme).
+	fakeClient := withToolConfigRefIndex(fake.NewClientBuilder().WithScheme(scheme)).
 		WithObjects(toolConfig).
 		WithStatusSubresource(&mcpv1beta1.MCPToolConfig{}).
 		Build()
@@ -375,8 +372,7 @@ func TestToolConfigReconciler_ReferencingWorkloadsRemovedOnServerDeletion(t *tes
 		v1beta1test.WithToolConfigRef("test-config"),
 	)
 
-	fakeClient := fake.NewClientBuilder().
-		WithScheme(scheme).
+	fakeClient := withToolConfigRefIndex(fake.NewClientBuilder().WithScheme(scheme)).
 		WithObjects(toolConfig, mcpServer).
 		WithStatusSubresource(&mcpv1beta1.MCPToolConfig{}).
 		Build()
@@ -441,8 +437,7 @@ func TestToolConfigReconciler_ValidConditionObservedGeneration(t *testing.T) {
 		},
 	}
 
-	fakeClient := fake.NewClientBuilder().
-		WithScheme(scheme).
+	fakeClient := withToolConfigRefIndex(fake.NewClientBuilder().WithScheme(scheme)).
 		WithObjects(toolConfig).
 		WithStatusSubresource(&mcpv1beta1.MCPToolConfig{}).
 		Build()


### PR DESCRIPTION
## Summary

The config-CRD controllers rebuild their `Status.ReferencingWorkloads` — on every reconcile and every deletion check — by listing **all** MCPServers / VirtualMCPServers / MCPRemoteProxies in the namespace and filtering in memory (O(all workloads) on the hot path). This replaces those scans with **field-indexed `MatchingFields` lookups** that return only the referencing workloads.

This completes **step 1 of #5607** for the five remaining controllers; MCPOIDCConfig already landed in #5608 and is the template followed here. Behavior is unchanged — same reference lists, computed by indexed lookup instead of a full scan.

(This PR's branch previously held a superseded "share the stale-ref scan" refactor; it has been repurposed onto current `main` for the indexer rollout.)

<details>
<summary><strong>Per-controller detail</strong></summary>

Each controller registers its field indexes in `SetupWithManager` (co-located, like `mcpserverentry_controller`; applies in prod and the integration suites automatically) and rewrites `findReferencing*` to query them. Index extractors return `nil` for unreferencing objects so they aren't indexed under the empty key. Every `(workload type, index key)` pair is unique across all controllers — no double-registration.

| Controller | Indexes |
|------------|---------|
| **ToolConfig** | MCPServer `spec.toolConfigRef` |
| **Webhook** | MCPServer `spec.webhookConfigRef` (config CR is v1alpha1; index is on the v1beta1 MCPServer) |
| **Telemetry** | MCPServer / MCPRemoteProxy / VirtualMCPServer, all `spec.telemetryConfigRef` (VMCP ref is top-level) |
| **Authz** | MCPServer / MCPRemoteProxy `spec.authzConfigRef`; VirtualMCPServer `spec.incomingAuth.authzConfigRef` (nested) |
| **ExternalAuth** | One **combined** index per type (MCPServer, MCPRemoteProxy) whose extractor returns both `externalAuthConfigRef` and `authServerRef` (kind-filtered) names, deduplicated — collapsing the old two-query-and-merge into a single indexed query |

Watch map functions, their inline stale-ref scans, and `Watches(...)` wiring are unchanged (the stale-scan simplification is a separate follow-up — #5607 step 2). `pkg/controllerutil/` and `app/app.go` are untouched.

Commits are per-batch (ToolConfig+Webhook, Telemetry+Authz, ExternalAuth) so the PR can be split by controller if review prefers smaller pieces.

</details>

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring
- [ ] Documentation
- [ ] Other

## Test plan

- [x] `task operator-test` (full operator unit suite) passes
- [x] Integration suites pass for every affected controller, exercising the real `SetupWithManager` index registration: MCPOIDCConfig 29/29 (via #5608), MCPToolConfig, MCPTelemetryConfig 7/7, MCPExternalAuth. (In the full parallel run, the only failure was the known envtest `kube-apiserver` teardown timeout in `AfterSuite` — no spec failures; passes on isolated re-run.)
- [x] `golangci-lint` clean on changed packages (only the pre-existing `mcpserver_controller.go:1645` finding remains)
- [x] `go build ./cmd/thv-operator/...` passes
- [x] Independent code review: PASS (behavior preservation per controller, no double-registration, dual-ref dedup preserved, scope confined)

## Special notes for reviewers

- **Behavior-preserving**: `Status.ReferencingWorkloads`, `ReferenceCount`, the printer column, and finalizer-based deletion protection are all identical — only *how* the list is computed changes. It's an efficiency change, so it adds net lines (extractors + registration) to remove per-reconcile CPU/allocations.
- Conforms to the new "Reverse References" section in `.claude/rules/operator.md`.
- **Size**: this is larger than the usual PR limit (5 controllers). Per-batch commits make a `/split-pr` into per-controller PRs straightforward if preferred.
- Follow-ups (#5607): step 2 deletes the hand-rolled stale-ref scans (lean on the framework's old+new enqueue); step 3 reconsiders storing `Status.ReferencingWorkloads` at all.

Generated with [Claude Code](https://claude.com/claude-code)