### PR TITLE
Consolidate operator envtest suite bootstrap

### DIFF
--- a/cmd/thv-operator/test-integration/embedding-server/suite_test.go
+++ b/cmd/thv-operator/test-integration/embedding-server/suite_test.go
@@ -1,3 +1,4 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package controllers contains integration tests for the EmbeddingServer controller.
@@ -5,36 +6,21 @@ package controllers
 
 import (
 	"context"
-	"path/filepath"
 	"testing"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"go.uber.org/zap/zapcore"
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/rest"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/envtest"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
-	mcpv1alpha1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1alpha1"
-	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
 	"github.com/stacklok/toolhive/cmd/thv-operator/controllers"
 	ctrlutil "github.com/stacklok/toolhive/cmd/thv-operator/pkg/controllerutil"
+	"github.com/stacklok/toolhive/cmd/thv-operator/test-integration/testutil"
 )
 
 var (
-	cfg       *rest.Config
 	k8sClient client.Client
-	testEnv   *envtest.Environment
 	ctx       context.Context
-	cancel    context.CancelFunc
+	suiteEnv  *testutil.SuiteEnv
 )
 
 func TestControllers(t *testing.T) {
@@ -51,76 +37,22 @@ func TestControllers(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	// Only log errors unless a test fails
-	logLevel := zapcore.ErrorLevel
-
-	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true), zap.Level(logLevel)))
-
-	ctx, cancel = context.WithCancel(context.Background())
-
-	By("bootstrapping test environment")
-	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "..", "deploy", "charts", "operator-crds", "files", "crds")},
-		ErrorIfCRDPathMissing: true,
-	}
-
-	var err error
-	// cfg is defined in this file globally.
-	cfg, err = testEnv.Start()
-	Expect(err).NotTo(HaveOccurred())
-	Expect(cfg).NotTo(BeNil())
-
-	err = mcpv1alpha1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	err = mcpv1beta1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	// Add other schemes that the controllers use
-	err = appsv1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	err = corev1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	//+kubebuilder:scaffold:scheme
-
-	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
-	Expect(err).NotTo(HaveOccurred())
-	Expect(k8sClient).NotTo(BeNil())
-
-	// Start the controller manager
-	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
-		Scheme: scheme.Scheme,
-		Metrics: metricsserver.Options{
-			BindAddress: "0", // Disable metrics server for tests to avoid port conflicts
-		},
-		HealthProbeBindAddress: "0", // Disable health probe for tests
-	})
-	Expect(err).ToNot(HaveOccurred())
+	suiteEnv = testutil.StartSuite(testutil.SuiteOptions{})
+	k8sClient = suiteEnv.Client
+	ctx = suiteEnv.Ctx
 
 	// Register the EmbeddingServer controller
-	err = (&controllers.EmbeddingServerReconciler{
-		Client:           k8sManager.GetClient(),
-		Scheme:           k8sManager.GetScheme(),
-		Recorder:         k8sManager.GetEventRecorder("embeddingserver-controller"),
+	err := (&controllers.EmbeddingServerReconciler{
+		Client:           suiteEnv.Manager.GetClient(),
+		Scheme:           suiteEnv.Manager.GetScheme(),
+		Recorder:         suiteEnv.Manager.GetEventRecorder("embeddingserver-controller"),
 		PlatformDetector: ctrlutil.NewSharedPlatformDetector(),
-	}).SetupWithManager(k8sManager)
+	}).SetupWithManager(suiteEnv.Manager)
 	Expect(err).ToNot(HaveOccurred())
 
-	// Start the manager in a goroutine
-	go func() {
-		defer GinkgoRecover()
-		err = k8sManager.Start(ctx)
-		Expect(err).ToNot(HaveOccurred(), "failed to run manager")
-	}()
+	suiteEnv.StartManager()
 })
 
 var _ = AfterSuite(func() {
-	By("tearing down the test environment")
-	cancel()
-	// Give it some time to shut down gracefully
-	time.Sleep(100 * time.Millisecond)
-	err := testEnv.Stop()
-	Expect(err).NotTo(HaveOccurred())
+	suiteEnv.Stop()
 })

--- a/cmd/thv-operator/test-integration/mcp-external-auth/suite_test.go
+++ b/cmd/thv-operator/test-integration/mcp-external-auth/suite_test.go
@@ -6,37 +6,23 @@ package controllers
 
 import (
 	"context"
-	"path/filepath"
 	"testing"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"go.uber.org/zap/zapcore"
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
-	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/envtest"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
-	mcpv1alpha1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1alpha1"
-	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
 	"github.com/stacklok/toolhive/cmd/thv-operator/controllers"
 	ctrlutil "github.com/stacklok/toolhive/cmd/thv-operator/pkg/controllerutil"
+	"github.com/stacklok/toolhive/cmd/thv-operator/test-integration/testutil"
 )
 
 var (
 	cfg       *rest.Config
 	k8sClient client.Client
-	testEnv   *envtest.Environment
 	ctx       context.Context
-	cancel    context.CancelFunc
+	suiteEnv  *testutil.SuiteEnv
 )
 
 func TestControllers(t *testing.T) {
@@ -53,85 +39,29 @@ func TestControllers(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	// Only log errors unless a test fails
-	logLevel := zapcore.ErrorLevel
-	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true), zap.Level(logLevel)))
-
-	ctx, cancel = context.WithCancel(context.TODO())
-
-	By("bootstrapping test environment")
-	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "..", "deploy", "charts", "operator-crds", "files", "crds")},
-		ErrorIfCRDPathMissing: true,
-	}
-
-	var err error
-	// cfg is defined in this file globally.
-	cfg, err = testEnv.Start()
-	Expect(err).NotTo(HaveOccurred())
-	Expect(cfg).NotTo(BeNil())
-
-	err = mcpv1alpha1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	err = mcpv1beta1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	// Add other schemes that the controllers use
-	err = appsv1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	err = corev1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	err = rbacv1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	//+kubebuilder:scaffold:scheme
-
-	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
-	Expect(err).NotTo(HaveOccurred())
-	Expect(k8sClient).NotTo(BeNil())
-
-	// Start the controller manager
-	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
-		Scheme: scheme.Scheme,
-		Metrics: metricsserver.Options{
-			BindAddress: "0", // Disable metrics server for tests to avoid port conflicts
-		},
-		HealthProbeBindAddress: "0", // Disable health probe for tests
-	})
-	Expect(err).ToNot(HaveOccurred())
+	suiteEnv = testutil.StartSuite(testutil.SuiteOptions{})
+	cfg = suiteEnv.Cfg
+	k8sClient = suiteEnv.Client
+	ctx = suiteEnv.Ctx
 
 	// Register the MCPExternalAuthConfig controller
-	err = (&controllers.MCPExternalAuthConfigReconciler{
-		Client: k8sManager.GetClient(),
-		Scheme: k8sManager.GetScheme(),
-	}).SetupWithManager(k8sManager)
+	err := (&controllers.MCPExternalAuthConfigReconciler{
+		Client: suiteEnv.Manager.GetClient(),
+		Scheme: suiteEnv.Manager.GetScheme(),
+	}).SetupWithManager(suiteEnv.Manager)
 	Expect(err).ToNot(HaveOccurred())
 
 	// Register the MCPServer controller (needed for testing integration)
 	err = (&controllers.MCPServerReconciler{
-		Client:           k8sManager.GetClient(),
-		Scheme:           k8sManager.GetScheme(),
+		Client:           suiteEnv.Manager.GetClient(),
+		Scheme:           suiteEnv.Manager.GetScheme(),
 		PlatformDetector: ctrlutil.NewSharedPlatformDetector(),
-	}).SetupWithManager(k8sManager)
+	}).SetupWithManager(suiteEnv.Manager)
 	Expect(err).ToNot(HaveOccurred())
 
-	// Start the manager in a goroutine
-	go func() {
-		defer GinkgoRecover()
-		err = k8sManager.Start(ctx)
-		Expect(err).ToNot(HaveOccurred(), "failed to run manager")
-	}()
-
+	suiteEnv.StartManager()
 })
 
 var _ = AfterSuite(func() {
-	By("tearing down the test environment")
-	cancel()
-	// Give it some time to shut down gracefully
-	time.Sleep(100 * time.Millisecond)
-	err := testEnv.Stop()
-	Expect(err).NotTo(HaveOccurred())
+	suiteEnv.Stop()
 })

--- a/cmd/thv-operator/test-integration/mcp-group/suite_test.go
+++ b/cmd/thv-operator/test-integration/mcp-group/suite_test.go
@@ -5,39 +5,23 @@ package operator_test
 
 import (
 	"context"
-	"path/filepath"
 	"testing"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"go.uber.org/zap/zapcore"
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
-	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/rest"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/envtest"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
-	mcpv1alpha1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1alpha1"
-	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
 	"github.com/stacklok/toolhive/cmd/thv-operator/controllers"
+	"github.com/stacklok/toolhive/cmd/thv-operator/test-integration/testutil"
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
 var (
-	cfg       *rest.Config
 	k8sClient client.Client
-	testEnv   *envtest.Environment
 	ctx       context.Context
-	cancel    context.CancelFunc
+	suiteEnv  *testutil.SuiteEnv
 )
 
 func TestControllers(t *testing.T) {
@@ -54,131 +38,28 @@ func TestControllers(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	// Only log errors unless a test fails
-	logLevel := zapcore.ErrorLevel
-	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true), zap.Level(logLevel)))
-
-	ctx, cancel = context.WithCancel(context.TODO())
-
-	By("bootstrapping test environment")
-	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "..", "deploy", "charts", "operator-crds", "files", "crds")},
-		ErrorIfCRDPathMissing: true,
-	}
-
-	var err error
-	// cfg is defined in this file globally.
-	cfg, err = testEnv.Start()
-	Expect(err).NotTo(HaveOccurred())
-	Expect(cfg).NotTo(BeNil())
-
-	err = mcpv1alpha1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	err = mcpv1beta1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	// Add other schemes that the controllers use
-	err = appsv1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	err = corev1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	err = rbacv1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	//+kubebuilder:scaffold:scheme
-
-	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
-	Expect(err).NotTo(HaveOccurred())
-	Expect(k8sClient).NotTo(BeNil())
-
-	// Start the controller manager
-	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
-		Scheme: scheme.Scheme,
-		Metrics: metricsserver.Options{
-			BindAddress: "0", // Disable metrics server for tests to avoid port conflicts
-		},
-		HealthProbeBindAddress: "0", // Disable health probe for tests
+	suiteEnv = testutil.StartSuite(testutil.SuiteOptions{
+		RegisterGroupRefIndexers: true,
 	})
-	Expect(err).ToNot(HaveOccurred())
-
-	// Set up field indexing for MCPServer.Spec.GroupRef
-	err = k8sManager.GetFieldIndexer().IndexField(
-		context.Background(),
-		&mcpv1beta1.MCPServer{},
-		"spec.groupRef",
-		func(obj client.Object) []string {
-			mcpServer := obj.(*mcpv1beta1.MCPServer)
-			name := mcpServer.Spec.GroupRef.GetName()
-			if name == "" {
-				return nil
-			}
-			return []string{name}
-		},
-	)
-	Expect(err).ToNot(HaveOccurred())
-
-	// Set up field indexing for MCPRemoteProxy.Spec.GroupRef
-	err = k8sManager.GetFieldIndexer().IndexField(
-		context.Background(),
-		&mcpv1beta1.MCPRemoteProxy{},
-		"spec.groupRef",
-		func(obj client.Object) []string {
-			mcpRemoteProxy := obj.(*mcpv1beta1.MCPRemoteProxy)
-			name := mcpRemoteProxy.Spec.GroupRef.GetName()
-			if name == "" {
-				return nil
-			}
-			return []string{name}
-		},
-	)
-	Expect(err).ToNot(HaveOccurred())
-
-	// Set up field indexing for MCPServerEntry.Spec.GroupRef
-	err = k8sManager.GetFieldIndexer().IndexField(
-		context.Background(),
-		&mcpv1beta1.MCPServerEntry{},
-		"spec.groupRef",
-		func(obj client.Object) []string {
-			mcpServerEntry := obj.(*mcpv1beta1.MCPServerEntry)
-			name := mcpServerEntry.Spec.GroupRef.GetName()
-			if name == "" {
-				return nil
-			}
-			return []string{name}
-		},
-	)
-	Expect(err).ToNot(HaveOccurred())
+	k8sClient = suiteEnv.Client
+	ctx = suiteEnv.Ctx
 
 	// Register the MCPGroup controller
-	err = (&controllers.MCPGroupReconciler{
-		Client: k8sManager.GetClient(),
-	}).SetupWithManager(k8sManager)
+	err := (&controllers.MCPGroupReconciler{
+		Client: suiteEnv.Manager.GetClient(),
+	}).SetupWithManager(suiteEnv.Manager)
 	Expect(err).ToNot(HaveOccurred())
 
 	// Register the MCPServer controller (needed for watch tests)
 	err = (&controllers.MCPServerReconciler{
-		Client: k8sManager.GetClient(),
-		Scheme: k8sManager.GetScheme(),
-	}).SetupWithManager(k8sManager)
+		Client: suiteEnv.Manager.GetClient(),
+		Scheme: suiteEnv.Manager.GetScheme(),
+	}).SetupWithManager(suiteEnv.Manager)
 	Expect(err).ToNot(HaveOccurred())
 
-	// Start the manager in a goroutine
-	go func() {
-		defer GinkgoRecover()
-		err = k8sManager.Start(ctx)
-		Expect(err).ToNot(HaveOccurred(), "failed to run manager")
-	}()
-
+	suiteEnv.StartManager()
 })
 
 var _ = AfterSuite(func() {
-	By("tearing down the test environment")
-	cancel()
-	// Give it some time to shut down gracefully
-	time.Sleep(100 * time.Millisecond)
-	err := testEnv.Stop()
-	Expect(err).NotTo(HaveOccurred())
+	suiteEnv.Stop()
 })

--- a/cmd/thv-operator/test-integration/mcp-oidc-config/suite_test.go
+++ b/cmd/thv-operator/test-integration/mcp-oidc-config/suite_test.go
@@ -6,37 +6,23 @@ package controllers
 
 import (
 	"context"
-	"path/filepath"
 	"testing"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"go.uber.org/zap/zapcore"
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
-	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/envtest"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
-	mcpv1alpha1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1alpha1"
-	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
 	"github.com/stacklok/toolhive/cmd/thv-operator/controllers"
 	ctrlutil "github.com/stacklok/toolhive/cmd/thv-operator/pkg/controllerutil"
+	"github.com/stacklok/toolhive/cmd/thv-operator/test-integration/testutil"
 )
 
 var (
 	cfg       *rest.Config
 	k8sClient client.Client
-	testEnv   *envtest.Environment
 	ctx       context.Context
-	cancel    context.CancelFunc
+	suiteEnv  *testutil.SuiteEnv
 )
 
 func TestControllers(t *testing.T) {
@@ -52,144 +38,56 @@ func TestControllers(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	logLevel := zapcore.ErrorLevel
-	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true), zap.Level(logLevel)))
-
-	ctx, cancel = context.WithCancel(context.TODO())
-
-	By("bootstrapping test environment")
-	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "..", "deploy", "charts", "operator-crds", "files", "crds")},
-		ErrorIfCRDPathMissing: true,
-	}
-
-	var err error
-	cfg, err = testEnv.Start()
-	Expect(err).NotTo(HaveOccurred())
-	Expect(cfg).NotTo(BeNil())
-
-	err = mcpv1alpha1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	err = mcpv1beta1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	// Add other schemes that the controllers use
-	err = appsv1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	err = corev1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	err = rbacv1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
-	Expect(err).NotTo(HaveOccurred())
-	Expect(k8sClient).NotTo(BeNil())
-
-	// Start the controller manager
-	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
-		Scheme: scheme.Scheme,
-		Metrics: metricsserver.Options{
-			BindAddress: "0", // Disable metrics server for tests
-		},
-		HealthProbeBindAddress: "0", // Disable health probe for tests
+	suiteEnv = testutil.StartSuite(testutil.SuiteOptions{
+		RegisterGroupRefIndexers: true,
 	})
-	Expect(err).ToNot(HaveOccurred())
+	cfg = suiteEnv.Cfg
+	k8sClient = suiteEnv.Client
+	ctx = suiteEnv.Ctx
 
 	// Register the MCPOIDCConfig controller
-	err = (&controllers.MCPOIDCConfigReconciler{
-		Client: k8sManager.GetClient(),
-		Scheme: k8sManager.GetScheme(),
-	}).SetupWithManager(k8sManager)
-	Expect(err).ToNot(HaveOccurred())
-
-	// Set up field indexing for MCPServer.Spec.GroupRef (required by VirtualMCPServer controller)
-	if err := k8sManager.GetFieldIndexer().IndexField(ctx, &mcpv1beta1.MCPServer{}, "spec.groupRef", func(obj client.Object) []string {
-		mcpServer := obj.(*mcpv1beta1.MCPServer)
-		name := mcpServer.Spec.GroupRef.GetName()
-		if name == "" {
-			return nil
-		}
-		return []string{name}
-	}); err != nil {
-		Expect(err).ToNot(HaveOccurred())
-	}
-
-	// Set up field indexing for MCPRemoteProxy.Spec.GroupRef (required by VirtualMCPServer controller)
-	if err := k8sManager.GetFieldIndexer().IndexField(ctx, &mcpv1beta1.MCPRemoteProxy{}, "spec.groupRef", func(obj client.Object) []string {
-		mcpRemoteProxy := obj.(*mcpv1beta1.MCPRemoteProxy)
-		name := mcpRemoteProxy.Spec.GroupRef.GetName()
-		if name == "" {
-			return nil
-		}
-		return []string{name}
-	}); err != nil {
-		Expect(err).ToNot(HaveOccurred())
-	}
-
-	// Set up field indexing for MCPServerEntry.Spec.GroupRef
-	err = k8sManager.GetFieldIndexer().IndexField(
-		context.Background(),
-		&mcpv1beta1.MCPServerEntry{},
-		"spec.groupRef",
-		func(obj client.Object) []string {
-			mcpServerEntry := obj.(*mcpv1beta1.MCPServerEntry)
-			name := mcpServerEntry.Spec.GroupRef.GetName()
-			if name == "" {
-				return nil
-			}
-			return []string{name}
-		},
-	)
+	err := (&controllers.MCPOIDCConfigReconciler{
+		Client: suiteEnv.Manager.GetClient(),
+		Scheme: suiteEnv.Manager.GetScheme(),
+	}).SetupWithManager(suiteEnv.Manager)
 	Expect(err).ToNot(HaveOccurred())
 
 	// Register the MCPServer controller (needed because MCPOIDCConfig watches
 	// MCPServer changes and we test cross-resource interactions)
 	err = (&controllers.MCPServerReconciler{
-		Client:           k8sManager.GetClient(),
-		Scheme:           k8sManager.GetScheme(),
+		Client:           suiteEnv.Manager.GetClient(),
+		Scheme:           suiteEnv.Manager.GetScheme(),
 		PlatformDetector: ctrlutil.NewSharedPlatformDetector(),
-	}).SetupWithManager(k8sManager)
+	}).SetupWithManager(suiteEnv.Manager)
 	Expect(err).ToNot(HaveOccurred())
 
 	// Register the MCPGroup controller (VirtualMCPServer depends on MCPGroup)
 	err = (&controllers.MCPGroupReconciler{
-		Client: k8sManager.GetClient(),
-	}).SetupWithManager(k8sManager)
+		Client: suiteEnv.Manager.GetClient(),
+	}).SetupWithManager(suiteEnv.Manager)
 	Expect(err).ToNot(HaveOccurred())
 
 	// Register the VirtualMCPServer controller (needed because MCPOIDCConfig watches
 	// VirtualMCPServer changes and we test cross-resource interactions)
 	err = (&controllers.VirtualMCPServerReconciler{
-		Client:           k8sManager.GetClient(),
-		Scheme:           k8sManager.GetScheme(),
+		Client:           suiteEnv.Manager.GetClient(),
+		Scheme:           suiteEnv.Manager.GetScheme(),
 		PlatformDetector: ctrlutil.NewSharedPlatformDetector(),
-	}).SetupWithManager(k8sManager)
+	}).SetupWithManager(suiteEnv.Manager)
 	Expect(err).ToNot(HaveOccurred())
 
 	// Register the MCPRemoteProxy controller (needed because MCPOIDCConfig watches
 	// MCPRemoteProxy changes and we test cross-resource interactions)
 	err = (&controllers.MCPRemoteProxyReconciler{
-		Client:           k8sManager.GetClient(),
-		Scheme:           k8sManager.GetScheme(),
+		Client:           suiteEnv.Manager.GetClient(),
+		Scheme:           suiteEnv.Manager.GetScheme(),
 		PlatformDetector: ctrlutil.NewSharedPlatformDetector(),
-	}).SetupWithManager(k8sManager)
+	}).SetupWithManager(suiteEnv.Manager)
 	Expect(err).ToNot(HaveOccurred())
 
-	// Start the manager in a goroutine
-	go func() {
-		defer GinkgoRecover()
-		err = k8sManager.Start(ctx)
-		Expect(err).ToNot(HaveOccurred(), "failed to run manager")
-	}()
+	suiteEnv.StartManager()
 })
 
 var _ = AfterSuite(func() {
-	By("tearing down the test environment")
-	cancel()
-	time.Sleep(100 * time.Millisecond)
-	err := testEnv.Stop()
-	Expect(err).NotTo(HaveOccurred())
+	suiteEnv.Stop()
 })

--- a/cmd/thv-operator/test-integration/mcp-registry/suite_test.go
+++ b/cmd/thv-operator/test-integration/mcp-registry/suite_test.go
@@ -5,35 +5,23 @@ package operator_test
 
 import (
 	"context"
-	"fmt"
-	"os"
-	"path/filepath"
 	"testing"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"go.uber.org/zap/zapcore"
-	"k8s.io/client-go/kubernetes/scheme"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/envtest"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
-	mcpv1alpha1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1alpha1"
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
 	"github.com/stacklok/toolhive/cmd/thv-operator/controllers"
 	"github.com/stacklok/toolhive/cmd/thv-operator/pkg/imagepullsecrets"
+	"github.com/stacklok/toolhive/cmd/thv-operator/test-integration/testutil"
 )
 
 var (
 	k8sClient client.Client
-	testEnv   *envtest.Environment
-	testMgr   ctrl.Manager
 	ctx       context.Context
-	cancel    context.CancelFunc
+	suiteEnv  *testutil.SuiteEnv
 )
 
 func TestOperatorE2E(t *testing.T) { //nolint:paralleltest // E2E tests should not run in parallel
@@ -49,51 +37,9 @@ func TestOperatorE2E(t *testing.T) { //nolint:paralleltest // E2E tests should n
 }
 
 var _ = BeforeSuite(func() {
-	// Only log errors unless a test fails
-	logLevel := zapcore.ErrorLevel
-	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true), zap.Level(logLevel)))
-
-	ctx, cancel = context.WithCancel(context.TODO())
-
-	By("bootstrapping test environment")
-
-	// Check if we should use an existing cluster (for CI/CD)
-	useExistingCluster := os.Getenv("USE_EXISTING_CLUSTER") == "true"
-
-	// // Get kubebuilder assets path
-	kubebuilderAssets := os.Getenv("KUBEBUILDER_ASSETS")
-
-	if !useExistingCluster {
-		By(fmt.Sprintf("using kubebuilder assets from: %s", kubebuilderAssets))
-		if kubebuilderAssets == "" {
-			By("WARNING: no kubebuilder assets found, test may fail")
-		}
-	}
-
-	testEnv = &envtest.Environment{
-		UseExistingCluster: &useExistingCluster,
-		CRDDirectoryPaths: []string{
-			filepath.Join("..", "..", "..", "..", "deploy", "charts", "operator-crds", "files", "crds"),
-		},
-		ErrorIfCRDPathMissing: true,
-		BinaryAssetsDirectory: kubebuilderAssets,
-	}
-
-	cfg, err := testEnv.Start()
-	Expect(err).NotTo(HaveOccurred())
-	Expect(cfg).NotTo(BeNil())
-
-	// Add MCPRegistry scheme
-	err = mcpv1alpha1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	err = mcpv1beta1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	// Create controller-runtime client
-	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
-	Expect(err).NotTo(HaveOccurred())
-	Expect(k8sClient).NotTo(BeNil())
+	suiteEnv = testutil.StartSuite(testutil.SuiteOptions{})
+	k8sClient = suiteEnv.Client
+	ctx = suiteEnv.Ctx
 
 	// Verify MCPRegistry CRD is available
 	By("verifying MCPRegistry CRD is available")
@@ -105,45 +51,25 @@ var _ = BeforeSuite(func() {
 		}, mcpRegistry)
 	}, time.Minute, time.Second).Should(MatchError(ContainSubstring("not found")))
 
-	// Set up the manager for controllers (only for envtest, not existing cluster)
-	if !useExistingCluster {
-		By("setting up controller manager for envtest")
-		testMgr, err = ctrl.NewManager(cfg, ctrl.Options{
-			Scheme: scheme.Scheme,
-			Metrics: metricsserver.Options{
-				BindAddress: "0", // Disable metrics server for tests
-			},
-			HealthProbeBindAddress: "0", // Disable health probe for tests
-		})
-		Expect(err).NotTo(HaveOccurred())
+	// Set up MCPRegistry controller
+	By("setting up MCPRegistry controller")
+	err := controllers.NewMCPRegistryReconciler(
+		suiteEnv.Manager.GetClient(), suiteEnv.Manager.GetScheme(),
+		suiteEnv.Manager.GetEventRecorder("mcpregistry-controller"), imagepullsecrets.Defaults{},
+	).SetupWithManager(suiteEnv.Manager)
+	Expect(err).NotTo(HaveOccurred())
 
-		// Set up MCPRegistry controller
-		By("setting up MCPRegistry controller")
-		err = controllers.NewMCPRegistryReconciler(
-			testMgr.GetClient(), testMgr.GetScheme(),
-			testMgr.GetEventRecorder("mcpregistry-controller"), imagepullsecrets.Defaults{},
-		).SetupWithManager(testMgr)
-		Expect(err).NotTo(HaveOccurred())
+	// Start the manager in the background
+	By("starting controller manager")
+	suiteEnv.StartManager()
 
-		// Start the manager in the background
-		By("starting controller manager")
-		go func() {
-			defer GinkgoRecover()
-			err = testMgr.Start(ctx)
-			Expect(err).NotTo(HaveOccurred(), "failed to run manager")
-		}()
-
-		// Wait for the manager to be ready
-		By("waiting for controller manager to be ready")
-		Eventually(func() bool {
-			return testMgr.GetCache().WaitForCacheSync(ctx)
-		}, time.Minute, time.Second).Should(BeTrue())
-	}
+	// Wait for the manager to be ready
+	By("waiting for controller manager to be ready")
+	Eventually(func() bool {
+		return suiteEnv.Manager.GetCache().WaitForCacheSync(ctx)
+	}, time.Minute, time.Second).Should(BeTrue())
 })
 
 var _ = AfterSuite(func() {
-	cancel()
-	By("tearing down the test environment")
-	err := testEnv.Stop()
-	Expect(err).NotTo(HaveOccurred())
+	suiteEnv.Stop()
 })

--- a/cmd/thv-operator/test-integration/mcp-remote-proxy/suite_test.go
+++ b/cmd/thv-operator/test-integration/mcp-remote-proxy/suite_test.go
@@ -6,29 +6,16 @@ package controllers
 
 import (
 	"context"
-	"path/filepath"
 	"testing"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"go.uber.org/zap/zapcore"
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
-	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/envtest"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
-	mcpv1alpha1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1alpha1"
-	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
 	"github.com/stacklok/toolhive/cmd/thv-operator/controllers"
 	ctrlutil "github.com/stacklok/toolhive/cmd/thv-operator/pkg/controllerutil"
+	"github.com/stacklok/toolhive/cmd/thv-operator/test-integration/testutil"
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
@@ -37,9 +24,8 @@ import (
 var (
 	cfg       *rest.Config
 	k8sClient client.Client
-	testEnv   *envtest.Environment
 	ctx       context.Context
-	cancel    context.CancelFunc
+	suiteEnv  *testutil.SuiteEnv
 )
 
 func TestControllers(t *testing.T) {
@@ -56,147 +42,52 @@ func TestControllers(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	// Only log errors unless a test fails
-	logLevel := zapcore.ErrorLevel
-
-	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true), zap.Level(logLevel)))
-
-	ctx, cancel = context.WithCancel(context.TODO())
-
-	By("bootstrapping test environment")
-	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "..", "deploy", "charts", "operator-crds", "files", "crds")},
-		ErrorIfCRDPathMissing: true,
-	}
-
-	var err error
-	// cfg is defined in this file globally.
-	cfg, err = testEnv.Start()
-	Expect(err).NotTo(HaveOccurred())
-	Expect(cfg).NotTo(BeNil())
-
-	err = mcpv1alpha1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	err = mcpv1beta1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	// Add other schemes that the controllers use
-	err = appsv1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	err = corev1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	err = rbacv1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	//+kubebuilder:scaffold:scheme
-
-	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
-	Expect(err).NotTo(HaveOccurred())
-	Expect(k8sClient).NotTo(BeNil())
-
-	// Start the controller manager
-	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
-		Scheme: scheme.Scheme,
-		Metrics: metricsserver.Options{
-			BindAddress: "0", // Disable metrics server for tests to avoid port conflicts
-		},
-		HealthProbeBindAddress: "0", // Disable health probe for tests
+	suiteEnv = testutil.StartSuite(testutil.SuiteOptions{
+		RegisterGroupRefIndexers: true,
 	})
-	Expect(err).ToNot(HaveOccurred())
-
-	// Set up field indexing for MCPServer.Spec.GroupRef (required by MCPGroup controller)
-	if err := k8sManager.GetFieldIndexer().IndexField(ctx, &mcpv1beta1.MCPServer{}, "spec.groupRef", func(obj client.Object) []string {
-		mcpServer := obj.(*mcpv1beta1.MCPServer)
-		name := mcpServer.Spec.GroupRef.GetName()
-		if name == "" {
-			return nil
-		}
-		return []string{name}
-	}); err != nil {
-		Expect(err).ToNot(HaveOccurred())
-	}
-
-	// Set up field indexing for MCPRemoteProxy.Spec.GroupRef
-	if err := k8sManager.GetFieldIndexer().IndexField(ctx, &mcpv1beta1.MCPRemoteProxy{}, "spec.groupRef", func(obj client.Object) []string {
-		mcpRemoteProxy := obj.(*mcpv1beta1.MCPRemoteProxy)
-		name := mcpRemoteProxy.Spec.GroupRef.GetName()
-		if name == "" {
-			return nil
-		}
-		return []string{name}
-	}); err != nil {
-		Expect(err).ToNot(HaveOccurred())
-	}
-
-	// Set up field indexing for MCPServerEntry.Spec.GroupRef
-	err = k8sManager.GetFieldIndexer().IndexField(
-		context.Background(),
-		&mcpv1beta1.MCPServerEntry{},
-		"spec.groupRef",
-		func(obj client.Object) []string {
-			mcpServerEntry := obj.(*mcpv1beta1.MCPServerEntry)
-			name := mcpServerEntry.Spec.GroupRef.GetName()
-			if name == "" {
-				return nil
-			}
-			return []string{name}
-		},
-	)
-	Expect(err).ToNot(HaveOccurred())
+	cfg = suiteEnv.Cfg
+	k8sClient = suiteEnv.Client
+	ctx = suiteEnv.Ctx
 
 	// Register the MCPGroup controller
-	err = (&controllers.MCPGroupReconciler{
-		Client: k8sManager.GetClient(),
-	}).SetupWithManager(k8sManager)
+	err := (&controllers.MCPGroupReconciler{
+		Client: suiteEnv.Manager.GetClient(),
+	}).SetupWithManager(suiteEnv.Manager)
 	Expect(err).ToNot(HaveOccurred())
 
 	// Register the MCPRemoteProxy controller
 	err = (&controllers.MCPRemoteProxyReconciler{
-		Client:           k8sManager.GetClient(),
-		Scheme:           k8sManager.GetScheme(),
-		Recorder:         k8sManager.GetEventRecorder("mcpremoteproxy-controller"),
+		Client:           suiteEnv.Manager.GetClient(),
+		Scheme:           suiteEnv.Manager.GetScheme(),
+		Recorder:         suiteEnv.Manager.GetEventRecorder("mcpremoteproxy-controller"),
 		PlatformDetector: ctrlutil.NewSharedPlatformDetector(),
-	}).SetupWithManager(k8sManager)
+	}).SetupWithManager(suiteEnv.Manager)
 	Expect(err).ToNot(HaveOccurred())
 
 	// Register the ToolConfig controller
 	err = (&controllers.ToolConfigReconciler{
-		Client: k8sManager.GetClient(),
-		Scheme: k8sManager.GetScheme(),
-	}).SetupWithManager(k8sManager)
+		Client: suiteEnv.Manager.GetClient(),
+		Scheme: suiteEnv.Manager.GetScheme(),
+	}).SetupWithManager(suiteEnv.Manager)
 	Expect(err).ToNot(HaveOccurred())
 
 	// Register the MCPExternalAuthConfig controller
 	err = (&controllers.MCPExternalAuthConfigReconciler{
-		Client: k8sManager.GetClient(),
-		Scheme: k8sManager.GetScheme(),
-	}).SetupWithManager(k8sManager)
+		Client: suiteEnv.Manager.GetClient(),
+		Scheme: suiteEnv.Manager.GetScheme(),
+	}).SetupWithManager(suiteEnv.Manager)
 	Expect(err).ToNot(HaveOccurred())
 
 	// Register the MCPOIDCConfig controller (needed for authServerRef tests that use OIDCConfigRef)
 	err = (&controllers.MCPOIDCConfigReconciler{
-		Client: k8sManager.GetClient(),
-		Scheme: k8sManager.GetScheme(),
-	}).SetupWithManager(k8sManager)
+		Client: suiteEnv.Manager.GetClient(),
+		Scheme: suiteEnv.Manager.GetScheme(),
+	}).SetupWithManager(suiteEnv.Manager)
 	Expect(err).ToNot(HaveOccurred())
 
-	// Start the manager in a goroutine
-	go func() {
-		defer GinkgoRecover()
-		err = k8sManager.Start(ctx)
-		Expect(err).ToNot(HaveOccurred(), "failed to run manager")
-	}()
-
+	suiteEnv.StartManager()
 })
 
 var _ = AfterSuite(func() {
-	By("tearing down the test environment")
-	cancel()
-	// Give it some time to shut down gracefully
-	time.Sleep(100 * time.Millisecond)
-	err := testEnv.Stop()
-	Expect(err).NotTo(HaveOccurred())
+	suiteEnv.Stop()
 })

--- a/cmd/thv-operator/test-integration/mcp-server/suite_test.go
+++ b/cmd/thv-operator/test-integration/mcp-server/suite_test.go
@@ -6,29 +6,16 @@ package controllers
 
 import (
 	"context"
-	"path/filepath"
 	"testing"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"go.uber.org/zap/zapcore"
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
-	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/envtest"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
-	mcpv1alpha1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1alpha1"
-	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
 	"github.com/stacklok/toolhive/cmd/thv-operator/controllers"
 	ctrlutil "github.com/stacklok/toolhive/cmd/thv-operator/pkg/controllerutil"
+	"github.com/stacklok/toolhive/cmd/thv-operator/test-integration/testutil"
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
@@ -37,9 +24,8 @@ import (
 var (
 	cfg       *rest.Config
 	k8sClient client.Client
-	testEnv   *envtest.Environment
 	ctx       context.Context
-	cancel    context.CancelFunc
+	suiteEnv  *testutil.SuiteEnv
 )
 
 func TestControllers(t *testing.T) {
@@ -56,146 +42,51 @@ func TestControllers(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	// Only log errors unless a test fails
-	logLevel := zapcore.ErrorLevel
-
-	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true), zap.Level(logLevel)))
-
-	ctx, cancel = context.WithCancel(context.TODO())
-
-	By("bootstrapping test environment")
-	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "..", "deploy", "charts", "operator-crds", "files", "crds")},
-		ErrorIfCRDPathMissing: true,
-	}
-
-	var err error
-	// cfg is defined in this file globally.
-	cfg, err = testEnv.Start()
-	Expect(err).NotTo(HaveOccurred())
-	Expect(cfg).NotTo(BeNil())
-
-	err = mcpv1alpha1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	err = mcpv1beta1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	// Add other schemes that the controllers use
-	err = appsv1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	err = corev1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	err = rbacv1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	//+kubebuilder:scaffold:scheme
-
-	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
-	Expect(err).NotTo(HaveOccurred())
-	Expect(k8sClient).NotTo(BeNil())
-
-	// Start the controller manager
-	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
-		Scheme: scheme.Scheme,
-		Metrics: metricsserver.Options{
-			BindAddress: "0", // Disable metrics server for tests to avoid port conflicts
-		},
-		HealthProbeBindAddress: "0", // Disable health probe for tests
+	suiteEnv = testutil.StartSuite(testutil.SuiteOptions{
+		RegisterGroupRefIndexers: true,
 	})
-	Expect(err).ToNot(HaveOccurred())
-
-	// Set up field indexing for MCPServer.Spec.GroupRef
-	if err := k8sManager.GetFieldIndexer().IndexField(ctx, &mcpv1beta1.MCPServer{}, "spec.groupRef", func(obj client.Object) []string {
-		mcpServer := obj.(*mcpv1beta1.MCPServer)
-		name := mcpServer.Spec.GroupRef.GetName()
-		if name == "" {
-			return nil
-		}
-		return []string{name}
-	}); err != nil {
-		Expect(err).ToNot(HaveOccurred())
-	}
-
-	// Set up field indexing for MCPRemoteProxy.Spec.GroupRef
-	if err := k8sManager.GetFieldIndexer().IndexField(ctx, &mcpv1beta1.MCPRemoteProxy{}, "spec.groupRef", func(obj client.Object) []string {
-		mcpRemoteProxy := obj.(*mcpv1beta1.MCPRemoteProxy)
-		name := mcpRemoteProxy.Spec.GroupRef.GetName()
-		if name == "" {
-			return nil
-		}
-		return []string{name}
-	}); err != nil {
-		Expect(err).ToNot(HaveOccurred())
-	}
-
-	// Set up field indexing for MCPServerEntry.Spec.GroupRef
-	err = k8sManager.GetFieldIndexer().IndexField(
-		context.Background(),
-		&mcpv1beta1.MCPServerEntry{},
-		"spec.groupRef",
-		func(obj client.Object) []string {
-			mcpServerEntry := obj.(*mcpv1beta1.MCPServerEntry)
-			name := mcpServerEntry.Spec.GroupRef.GetName()
-			if name == "" {
-				return nil
-			}
-			return []string{name}
-		},
-	)
-	Expect(err).ToNot(HaveOccurred())
+	cfg = suiteEnv.Cfg
+	k8sClient = suiteEnv.Client
+	ctx = suiteEnv.Ctx
 
 	// Register the MCPGroup controller
-	err = (&controllers.MCPGroupReconciler{
-		Client: k8sManager.GetClient(),
-	}).SetupWithManager(k8sManager)
+	err := (&controllers.MCPGroupReconciler{
+		Client: suiteEnv.Manager.GetClient(),
+	}).SetupWithManager(suiteEnv.Manager)
 	Expect(err).ToNot(HaveOccurred())
 
 	// Register the MCPServer controller
 	err = (&controllers.MCPServerReconciler{
-		Client:           k8sManager.GetClient(),
-		Scheme:           k8sManager.GetScheme(),
+		Client:           suiteEnv.Manager.GetClient(),
+		Scheme:           suiteEnv.Manager.GetScheme(),
 		PlatformDetector: ctrlutil.NewSharedPlatformDetector(),
-	}).SetupWithManager(k8sManager)
+	}).SetupWithManager(suiteEnv.Manager)
 	Expect(err).ToNot(HaveOccurred())
 
 	// Register the ToolConfig controller
 	err = (&controllers.ToolConfigReconciler{
-		Client: k8sManager.GetClient(),
-		Scheme: k8sManager.GetScheme(),
-	}).SetupWithManager(k8sManager)
+		Client: suiteEnv.Manager.GetClient(),
+		Scheme: suiteEnv.Manager.GetScheme(),
+	}).SetupWithManager(suiteEnv.Manager)
 	Expect(err).ToNot(HaveOccurred())
 
 	// Register the MCPTelemetryConfig controller (needed for telemetryConfigRef tests)
 	err = (&controllers.MCPTelemetryConfigReconciler{
-		Client: k8sManager.GetClient(),
-		Scheme: k8sManager.GetScheme(),
-	}).SetupWithManager(k8sManager)
+		Client: suiteEnv.Manager.GetClient(),
+		Scheme: suiteEnv.Manager.GetScheme(),
+	}).SetupWithManager(suiteEnv.Manager)
 	Expect(err).ToNot(HaveOccurred())
 
 	// Register the MCPOIDCConfig controller (needed for authServerRef tests that use OIDCConfigRef)
 	err = (&controllers.MCPOIDCConfigReconciler{
-		Client: k8sManager.GetClient(),
-		Scheme: k8sManager.GetScheme(),
-	}).SetupWithManager(k8sManager)
+		Client: suiteEnv.Manager.GetClient(),
+		Scheme: suiteEnv.Manager.GetScheme(),
+	}).SetupWithManager(suiteEnv.Manager)
 	Expect(err).ToNot(HaveOccurred())
 
-	// Start the manager in a goroutine
-	go func() {
-		defer GinkgoRecover()
-		err = k8sManager.Start(ctx)
-		Expect(err).ToNot(HaveOccurred(), "failed to run manager")
-	}()
-
+	suiteEnv.StartManager()
 })
 
 var _ = AfterSuite(func() {
-	By("tearing down the test environment")
-	cancel()
-	// Give it some time to shut down gracefully
-	time.Sleep(100 * time.Millisecond)
-	err := testEnv.Stop()
-	Expect(err).NotTo(HaveOccurred())
+	suiteEnv.Stop()
 })

--- a/cmd/thv-operator/test-integration/mcp-telemetry-config/suite_test.go
+++ b/cmd/thv-operator/test-integration/mcp-telemetry-config/suite_test.go
@@ -6,34 +6,20 @@ package controllers
 
 import (
 	"context"
-	"path/filepath"
 	"testing"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"go.uber.org/zap/zapcore"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/rest"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/envtest"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
-	mcpv1alpha1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1alpha1"
-	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
 	"github.com/stacklok/toolhive/cmd/thv-operator/controllers"
+	"github.com/stacklok/toolhive/cmd/thv-operator/test-integration/testutil"
 )
 
 var (
-	cfg       *rest.Config
 	k8sClient client.Client
-	testEnv   *envtest.Environment
 	ctx       context.Context
-	cancel    context.CancelFunc
+	suiteEnv  *testutil.SuiteEnv
 )
 
 func TestControllers(t *testing.T) {
@@ -49,64 +35,20 @@ func TestControllers(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	logLevel := zapcore.ErrorLevel
-	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true), zap.Level(logLevel)))
-
-	ctx, cancel = context.WithCancel(context.TODO())
-
-	By("bootstrapping test environment")
-	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "..", "deploy", "charts", "operator-crds", "files", "crds")},
-		ErrorIfCRDPathMissing: true,
-	}
-
-	var err error
-	cfg, err = testEnv.Start()
-	Expect(err).NotTo(HaveOccurred())
-	Expect(cfg).NotTo(BeNil())
-
-	err = mcpv1alpha1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	err = mcpv1beta1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	err = corev1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
-	Expect(err).NotTo(HaveOccurred())
-	Expect(k8sClient).NotTo(BeNil())
-
-	// Start the controller manager
-	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
-		Scheme: scheme.Scheme,
-		Metrics: metricsserver.Options{
-			BindAddress: "0", // Disable metrics server for tests
-		},
-		HealthProbeBindAddress: "0", // Disable health probe for tests
-	})
-	Expect(err).ToNot(HaveOccurred())
+	suiteEnv = testutil.StartSuite(testutil.SuiteOptions{})
+	k8sClient = suiteEnv.Client
+	ctx = suiteEnv.Ctx
 
 	// Register the MCPTelemetryConfig controller
-	err = (&controllers.MCPTelemetryConfigReconciler{
-		Client: k8sManager.GetClient(),
-		Scheme: k8sManager.GetScheme(),
-	}).SetupWithManager(k8sManager)
+	err := (&controllers.MCPTelemetryConfigReconciler{
+		Client: suiteEnv.Manager.GetClient(),
+		Scheme: suiteEnv.Manager.GetScheme(),
+	}).SetupWithManager(suiteEnv.Manager)
 	Expect(err).ToNot(HaveOccurred())
 
-	// Start the manager in a goroutine
-	go func() {
-		defer GinkgoRecover()
-		err = k8sManager.Start(ctx)
-		Expect(err).ToNot(HaveOccurred(), "failed to run manager")
-	}()
+	suiteEnv.StartManager()
 })
 
 var _ = AfterSuite(func() {
-	By("tearing down the test environment")
-	cancel()
-	time.Sleep(100 * time.Millisecond)
-	err := testEnv.Stop()
-	Expect(err).NotTo(HaveOccurred())
+	suiteEnv.Stop()
 })

--- a/cmd/thv-operator/test-integration/mcp-toolconfig/suite_test.go
+++ b/cmd/thv-operator/test-integration/mcp-toolconfig/suite_test.go
@@ -6,37 +6,21 @@ package mcptoolconfig_test
 
 import (
 	"context"
-	"path/filepath"
 	"testing"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"go.uber.org/zap/zapcore"
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
-	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/rest"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/envtest"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
-	mcpv1alpha1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1alpha1"
-	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
 	"github.com/stacklok/toolhive/cmd/thv-operator/controllers"
 	ctrlutil "github.com/stacklok/toolhive/cmd/thv-operator/pkg/controllerutil"
+	"github.com/stacklok/toolhive/cmd/thv-operator/test-integration/testutil"
 )
 
 var (
-	cfg       *rest.Config
 	k8sClient client.Client
-	testEnv   *envtest.Environment
 	ctx       context.Context
-	cancel    context.CancelFunc
+	suiteEnv  *testutil.SuiteEnv
 )
 
 func TestMCPToolConfig(t *testing.T) {
@@ -53,86 +37,29 @@ func TestMCPToolConfig(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	// Only log errors unless a test fails
-	logLevel := zapcore.ErrorLevel
-	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true), zap.Level(logLevel)))
-
-	ctx, cancel = context.WithCancel(context.TODO())
-
-	By("bootstrapping test environment")
-	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "..", "deploy", "charts", "operator-crds", "files", "crds")},
-		ErrorIfCRDPathMissing: true,
-	}
-
-	var err error
-	// cfg is defined in this file globally.
-	cfg, err = testEnv.Start()
-	Expect(err).NotTo(HaveOccurred())
-	Expect(cfg).NotTo(BeNil())
-
-	err = mcpv1alpha1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	err = mcpv1beta1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	// Add other schemes that the controllers use
-	err = appsv1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	err = corev1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	err = rbacv1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	//+kubebuilder:scaffold:scheme
-
-	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
-	Expect(err).NotTo(HaveOccurred())
-	Expect(k8sClient).NotTo(BeNil())
-
-	// Start the controller manager
-	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
-		Scheme: scheme.Scheme,
-		Metrics: metricsserver.Options{
-			BindAddress: "0", // Disable metrics server for tests to avoid port conflicts
-		},
-		HealthProbeBindAddress: "0", // Disable health probe for tests
-	})
-	Expect(err).ToNot(HaveOccurred())
+	suiteEnv = testutil.StartSuite(testutil.SuiteOptions{})
+	k8sClient = suiteEnv.Client
+	ctx = suiteEnv.Ctx
 
 	// Register the MCPToolConfig controller (the controller under test)
-	err = (&controllers.ToolConfigReconciler{
-		Client: k8sManager.GetClient(),
-		Scheme: k8sManager.GetScheme(),
-	}).SetupWithManager(k8sManager)
+	err := (&controllers.ToolConfigReconciler{
+		Client: suiteEnv.Manager.GetClient(),
+		Scheme: suiteEnv.Manager.GetScheme(),
+	}).SetupWithManager(suiteEnv.Manager)
 	Expect(err).ToNot(HaveOccurred())
 
 	// Register the MCPServer controller (needed because ToolConfig watches
 	// MCPServer changes and we test cross-resource interactions)
 	err = (&controllers.MCPServerReconciler{
-		Client:           k8sManager.GetClient(),
-		Scheme:           k8sManager.GetScheme(),
+		Client:           suiteEnv.Manager.GetClient(),
+		Scheme:           suiteEnv.Manager.GetScheme(),
 		PlatformDetector: ctrlutil.NewSharedPlatformDetector(),
-	}).SetupWithManager(k8sManager)
+	}).SetupWithManager(suiteEnv.Manager)
 	Expect(err).ToNot(HaveOccurred())
 
-	// Start the manager in a goroutine
-	go func() {
-		defer GinkgoRecover()
-		err = k8sManager.Start(ctx)
-		Expect(err).ToNot(HaveOccurred(), "failed to run manager")
-	}()
-
+	suiteEnv.StartManager()
 })
 
 var _ = AfterSuite(func() {
-	By("tearing down the test environment")
-	cancel()
-	// Give it some time to shut down gracefully
-	time.Sleep(100 * time.Millisecond)
-	err := testEnv.Stop()
-	Expect(err).NotTo(HaveOccurred())
+	suiteEnv.Stop()
 })

--- a/cmd/thv-operator/test-integration/storageversionmigrator/suite_test.go
+++ b/cmd/thv-operator/test-integration/storageversionmigrator/suite_test.go
@@ -22,23 +22,15 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"go.uber.org/zap/zapcore"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/envtest"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"github.com/stacklok/toolhive/cmd/thv-operator/test-integration/testutil"
 )
 
 var (
-	cfg       *rest.Config
 	k8sClient client.Client
-	testEnv   *envtest.Environment
 	ctx       context.Context
-	cancel    context.CancelFunc
+	suiteEnv  *testutil.SuiteEnv
 )
 
 func TestStorageVersionMigrator(t *testing.T) {
@@ -54,30 +46,11 @@ func TestStorageVersionMigrator(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	logLevel := zapcore.ErrorLevel
-	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true), zap.Level(logLevel)))
-
-	ctx, cancel = context.WithCancel(context.TODO())
-
-	By("bootstrapping envtest")
-	testEnv = &envtest.Environment{
-		ErrorIfCRDPathMissing: false, // tests install CRDs on demand
-	}
-
-	var err error
-	cfg, err = testEnv.Start()
-	Expect(err).NotTo(HaveOccurred())
-	Expect(cfg).NotTo(BeNil())
-
-	utilruntime.Must(apiextensionsv1.AddToScheme(scheme.Scheme))
-
-	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
-	Expect(err).NotTo(HaveOccurred())
-	Expect(k8sClient).NotTo(BeNil())
+	suiteEnv = testutil.StartMinimalSuite()
+	k8sClient = suiteEnv.Client
+	ctx = suiteEnv.Ctx
 })
 
 var _ = AfterSuite(func() {
-	By("tearing down envtest")
-	cancel()
-	Expect(testEnv.Stop()).NotTo(HaveOccurred())
+	suiteEnv.Stop()
 })

--- a/cmd/thv-operator/test-integration/testutil/envtest.go
+++ b/cmd/thv-operator/test-integration/testutil/envtest.go
@@ -1,0 +1,231 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package testutil provides shared envtest bootstrap helpers for the operator
+// integration suites under cmd/thv-operator/test-integration. Each suite
+// delegates its BeforeSuite/AfterSuite plumbing here and keeps only its
+// per-suite controller registrations.
+package testutil
+
+import (
+	"context"
+	"path/filepath"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive,staticcheck // dot-import is the Ginkgo convention
+	. "github.com/onsi/gomega"    //nolint:revive,staticcheck // dot-import is the Gomega convention
+	"go.uber.org/zap/zapcore"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+
+	mcpv1alpha1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1alpha1"
+	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+)
+
+// gracefulShutdownDelay gives a running manager a moment to stop cleanly after
+// the suite context is cancelled, before the envtest control plane is torn down.
+const gracefulShutdownDelay = 100 * time.Millisecond
+
+// SuiteOptions configures the envtest bootstrap performed by StartSuite. Add
+// fields only as concrete suites require them.
+type SuiteOptions struct {
+	// RegisterGroupRefIndexers installs the spec.groupRef field indexers for
+	// MCPServer, MCPRemoteProxy, and MCPServerEntry. Suites whose controllers
+	// list by GroupRef (anything that wires up the MCPGroup or VirtualMCPServer
+	// controllers) need these; the rest leave it false.
+	RegisterGroupRefIndexers bool
+}
+
+// SuiteEnv holds the shared envtest infrastructure for an operator integration
+// suite. It is produced by StartSuite (full bootstrap with a manager) or
+// StartMinimalSuite (envtest + client only) and torn down by Stop.
+type SuiteEnv struct {
+	// Cfg is the rest config for the running envtest control plane.
+	Cfg *rest.Config
+	// Client is a controller-runtime client wired to the global scheme.
+	Client client.Client
+	// Manager is the controller manager. It is nil for StartMinimalSuite and is
+	// created but not started by StartSuite — call StartManager to launch it.
+	Manager ctrl.Manager
+	// Ctx is the suite-scoped context cancelled by Stop. Specs and indexers that
+	// need a context should use it.
+	Ctx context.Context
+
+	testEnv *envtest.Environment
+	cancel  context.CancelFunc
+}
+
+// StartSuite bootstraps a full operator integration suite: it starts an envtest
+// control plane loaded with the operator CRDs, registers the operator API
+// versions plus the built-in Kubernetes types on the global client-go scheme,
+// creates a client and a controller manager (metrics and health probes
+// disabled), and optionally installs the GroupRef field indexers.
+//
+// The returned manager is not started — callers register their controllers on
+// it and then call StartManager. Pair every StartSuite with a deferred or
+// AfterSuite call to Stop. It must be called from within a Ginkgo node
+// (BeforeSuite or a spec) because it uses Ginkgo/Gomega for logging and
+// assertions.
+func StartSuite(opts SuiteOptions) *SuiteEnv {
+	setupLogger()
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	By("bootstrapping test environment")
+	testEnv := &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "..", "deploy", "charts", "operator-crds", "files", "crds")},
+		ErrorIfCRDPathMissing: true,
+	}
+
+	cfg, err := testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	registerOperatorScheme()
+
+	k8sClient, err := client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient).NotTo(BeNil())
+
+	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme: scheme.Scheme,
+		Metrics: metricsserver.Options{
+			BindAddress: "0", // Disable metrics server for tests to avoid port conflicts
+		},
+		HealthProbeBindAddress: "0", // Disable health probe for tests
+	})
+	Expect(err).ToNot(HaveOccurred())
+
+	if opts.RegisterGroupRefIndexers {
+		registerGroupRefIndexers(ctx, k8sManager)
+	}
+
+	return &SuiteEnv{
+		Cfg:     cfg,
+		Client:  k8sClient,
+		Manager: k8sManager,
+		Ctx:     ctx,
+		testEnv: testEnv,
+		cancel:  cancel,
+	}
+}
+
+// StartMinimalSuite bootstraps an envtest control plane with no operator CRDs
+// and no controller manager: just the API server, the apiextensions scheme (so
+// tests can install CRDs on demand), and a client. It exists for the
+// StorageVersionMigrator suite, which installs its own CRDs per-test and drives
+// reconcilers directly. It must be called from within a Ginkgo node.
+func StartMinimalSuite() *SuiteEnv {
+	setupLogger()
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	By("bootstrapping envtest")
+	testEnv := &envtest.Environment{
+		ErrorIfCRDPathMissing: false, // tests install CRDs on demand
+	}
+
+	cfg, err := testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	Expect(apiextensionsv1.AddToScheme(scheme.Scheme)).To(Succeed())
+
+	k8sClient, err := client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient).NotTo(BeNil())
+
+	return &SuiteEnv{
+		Cfg:     cfg,
+		Client:  k8sClient,
+		Ctx:     ctx,
+		testEnv: testEnv,
+		cancel:  cancel,
+	}
+}
+
+// StartManager launches the controller manager in a background goroutine. Call
+// it after registering all controllers on Manager. It is a no-op when there is
+// no manager (i.e. for StartMinimalSuite).
+func (e *SuiteEnv) StartManager() {
+	if e.Manager == nil {
+		return
+	}
+	go func() {
+		defer GinkgoRecover()
+		Expect(e.Manager.Start(e.Ctx)).To(Succeed(), "failed to run manager")
+	}()
+}
+
+// Stop cancels the suite context and tears down the envtest control plane. When
+// a manager is running it first waits a short grace period so the manager can
+// shut down cleanly before the API server goes away.
+func (e *SuiteEnv) Stop() {
+	By("tearing down the test environment")
+	e.cancel()
+	if e.Manager != nil {
+		// Give the manager some time to shut down gracefully.
+		time.Sleep(gracefulShutdownDelay)
+	}
+	Expect(e.testEnv.Stop()).NotTo(HaveOccurred())
+}
+
+// setupLogger configures the controller-runtime logger to emit only errors
+// unless a test fails, matching the behavior every suite relied on.
+func setupLogger() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true), zap.Level(zapcore.ErrorLevel)))
+}
+
+// registerOperatorScheme adds the operator API versions and the built-in
+// Kubernetes types used by the controllers to the global client-go scheme.
+// Registering types a given suite does not use is harmless.
+func registerOperatorScheme() {
+	for _, add := range []func(s *runtime.Scheme) error{
+		mcpv1alpha1.AddToScheme,
+		mcpv1beta1.AddToScheme,
+		appsv1.AddToScheme,
+		corev1.AddToScheme,
+		rbacv1.AddToScheme,
+	} {
+		Expect(add(scheme.Scheme)).To(Succeed())
+	}
+}
+
+// registerGroupRefIndexers installs the spec.groupRef field indexers for the
+// MCPServer, MCPRemoteProxy, and MCPServerEntry types so controllers can list
+// objects by their owning group.
+func registerGroupRefIndexers(ctx context.Context, mgr ctrl.Manager) {
+	indexer := mgr.GetFieldIndexer()
+
+	Expect(indexer.IndexField(ctx, &mcpv1beta1.MCPServer{}, "spec.groupRef", func(obj client.Object) []string {
+		return groupRefValue(obj.(*mcpv1beta1.MCPServer).Spec.GroupRef.GetName())
+	})).To(Succeed())
+
+	Expect(indexer.IndexField(ctx, &mcpv1beta1.MCPRemoteProxy{}, "spec.groupRef", func(obj client.Object) []string {
+		return groupRefValue(obj.(*mcpv1beta1.MCPRemoteProxy).Spec.GroupRef.GetName())
+	})).To(Succeed())
+
+	Expect(indexer.IndexField(ctx, &mcpv1beta1.MCPServerEntry{}, "spec.groupRef", func(obj client.Object) []string {
+		return groupRefValue(obj.(*mcpv1beta1.MCPServerEntry).Spec.GroupRef.GetName())
+	})).To(Succeed())
+}
+
+// groupRefValue returns the index value for a groupRef name, or nil when unset
+// so the object is left out of the index.
+func groupRefValue(name string) []string {
+	if name == "" {
+		return nil
+	}
+	return []string{name}
+}

--- a/cmd/thv-operator/test-integration/virtualmcp/suite_test.go
+++ b/cmd/thv-operator/test-integration/virtualmcp/suite_test.go
@@ -6,29 +6,16 @@ package controllers
 
 import (
 	"context"
-	"path/filepath"
 	"testing"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"go.uber.org/zap/zapcore"
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
-	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/envtest"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
-	mcpv1alpha1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1alpha1"
-	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
 	"github.com/stacklok/toolhive/cmd/thv-operator/controllers"
 	ctrlutil "github.com/stacklok/toolhive/cmd/thv-operator/pkg/controllerutil"
+	"github.com/stacklok/toolhive/cmd/thv-operator/test-integration/testutil"
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
@@ -37,9 +24,8 @@ import (
 var (
 	cfg       *rest.Config
 	k8sClient client.Client
-	testEnv   *envtest.Environment
 	ctx       context.Context
-	cancel    context.CancelFunc
+	suiteEnv  *testutil.SuiteEnv
 )
 
 func TestControllers(t *testing.T) {
@@ -56,132 +42,37 @@ func TestControllers(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	// Only log errors unless a test fails
-	logLevel := zapcore.ErrorLevel
-
-	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true), zap.Level(logLevel)))
-
-	ctx, cancel = context.WithCancel(context.TODO())
-
-	By("bootstrapping test environment")
-	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "..", "deploy", "charts", "operator-crds", "files", "crds")},
-		ErrorIfCRDPathMissing: true,
-	}
-
-	var err error
-	// cfg is defined in this file globally.
-	cfg, err = testEnv.Start()
-	Expect(err).NotTo(HaveOccurred())
-	Expect(cfg).NotTo(BeNil())
-
-	err = mcpv1alpha1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	err = mcpv1beta1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	// Add other schemes that the controllers use
-	err = appsv1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	err = corev1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	err = rbacv1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	//+kubebuilder:scaffold:scheme
-
-	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
-	Expect(err).NotTo(HaveOccurred())
-	Expect(k8sClient).NotTo(BeNil())
-
-	// Start the controller manager
-	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
-		Scheme: scheme.Scheme,
-		Metrics: metricsserver.Options{
-			BindAddress: "0", // Disable metrics server for tests to avoid port conflicts
-		},
-		HealthProbeBindAddress: "0", // Disable health probe for tests
+	suiteEnv = testutil.StartSuite(testutil.SuiteOptions{
+		RegisterGroupRefIndexers: true,
 	})
-	Expect(err).ToNot(HaveOccurred())
-
-	// Set up field indexing for MCPServer.Spec.GroupRef
-	if err := k8sManager.GetFieldIndexer().IndexField(ctx, &mcpv1beta1.MCPServer{}, "spec.groupRef", func(obj client.Object) []string {
-		mcpServer := obj.(*mcpv1beta1.MCPServer)
-		name := mcpServer.Spec.GroupRef.GetName()
-		if name == "" {
-			return nil
-		}
-		return []string{name}
-	}); err != nil {
-		Expect(err).ToNot(HaveOccurred())
-	}
-
-	// Set up field indexing for MCPRemoteProxy.Spec.GroupRef
-	if err := k8sManager.GetFieldIndexer().IndexField(ctx, &mcpv1beta1.MCPRemoteProxy{}, "spec.groupRef", func(obj client.Object) []string {
-		mcpRemoteProxy := obj.(*mcpv1beta1.MCPRemoteProxy)
-		name := mcpRemoteProxy.Spec.GroupRef.GetName()
-		if name == "" {
-			return nil
-		}
-		return []string{name}
-	}); err != nil {
-		Expect(err).ToNot(HaveOccurred())
-	}
-
-	// Set up field indexing for MCPServerEntry.Spec.GroupRef
-	err = k8sManager.GetFieldIndexer().IndexField(
-		context.Background(),
-		&mcpv1beta1.MCPServerEntry{},
-		"spec.groupRef",
-		func(obj client.Object) []string {
-			mcpServerEntry := obj.(*mcpv1beta1.MCPServerEntry)
-			name := mcpServerEntry.Spec.GroupRef.GetName()
-			if name == "" {
-				return nil
-			}
-			return []string{name}
-		},
-	)
-	Expect(err).ToNot(HaveOccurred())
+	cfg = suiteEnv.Cfg
+	k8sClient = suiteEnv.Client
+	ctx = suiteEnv.Ctx
 
 	// Register the MCPGroup controller (required by VirtualMCPServer)
-	err = (&controllers.MCPGroupReconciler{
-		Client: k8sManager.GetClient(),
-	}).SetupWithManager(k8sManager)
+	err := (&controllers.MCPGroupReconciler{
+		Client: suiteEnv.Manager.GetClient(),
+	}).SetupWithManager(suiteEnv.Manager)
 	Expect(err).ToNot(HaveOccurred())
 
 	// Register the MCPTelemetryConfig controller (required for telemetryConfigRef tests)
 	err = (&controllers.MCPTelemetryConfigReconciler{
-		Client: k8sManager.GetClient(),
-		Scheme: k8sManager.GetScheme(),
-	}).SetupWithManager(k8sManager)
+		Client: suiteEnv.Manager.GetClient(),
+		Scheme: suiteEnv.Manager.GetScheme(),
+	}).SetupWithManager(suiteEnv.Manager)
 	Expect(err).ToNot(HaveOccurred())
 
 	// Register the VirtualMCPServer controller
 	err = (&controllers.VirtualMCPServerReconciler{
-		Client:           k8sManager.GetClient(),
-		Scheme:           k8sManager.GetScheme(),
+		Client:           suiteEnv.Manager.GetClient(),
+		Scheme:           suiteEnv.Manager.GetScheme(),
 		PlatformDetector: ctrlutil.NewSharedPlatformDetector(),
-	}).SetupWithManager(k8sManager)
+	}).SetupWithManager(suiteEnv.Manager)
 	Expect(err).ToNot(HaveOccurred())
 
-	// Start the manager in a goroutine
-	go func() {
-		defer GinkgoRecover()
-		err = k8sManager.Start(ctx)
-		Expect(err).ToNot(HaveOccurred(), "failed to run manager")
-	}()
-
+	suiteEnv.StartManager()
 })
 
 var _ = AfterSuite(func() {
-	By("tearing down the test environment")
-	cancel()
-	// Give it some time to shut down gracefully
-	time.Sleep(100 * time.Millisecond)
-	err := testEnv.Stop()
-	Expect(err).NotTo(HaveOccurred())
+	suiteEnv.Stop()
 })


### PR DESCRIPTION
## Summary

The 11 operator envtest integration suites each carried ~80–200 lines of near-identical `BeforeSuite`/`AfterSuite` boilerplate (logger setup, envtest start, scheme registration, client + manager creation, GroupRef field indexers, the manager goroutine, teardown). Only the controller registrations actually differed per suite, so the duplication was pure copy-paste that drifts over time and makes shared changes a 11-file edit.

This extracts that shared core into a new `cmd/thv-operator/test-integration/testutil` package so each suite delegates the bootstrap and keeps only its per-suite controller registrations — removing ~900 lines of duplicated setup and giving the suites one place to evolve shared integration-test infrastructure.

<details>
<summary><strong>Medium level</strong></summary>

- New `cmd/thv-operator/test-integration/testutil/envtest.go`: `SuiteEnv` (exposes `Cfg`, `Client`, `Manager`, `Ctx`) plus `StartSuite`, `StartMinimalSuite`, `StartManager`, and `Stop`. `SuiteOptions{RegisterGroupRefIndexers}` is the only knob — added because the 5 suites whose controllers list by `spec.groupRef` need the indexers and the rest don't.
- `StartSuite` performs the full bootstrap (envtest control plane + operator CRDs, scheme registration on the global client-go scheme, client, manager with metrics/health probes disabled, optional GroupRef indexers) and returns an unstarted manager so callers register their controllers and then call `StartManager`.
- `StartMinimalSuite` covers `storageversionmigrator` (no CRDs, no manager, installs its own CRDs per-test).
- All 11 suites reduced to bootstrap delegation + controller registrations.
- `mcp-registry` is routed through `StartSuite` with its CRD-availability check and `WaitForCacheSync` kept local; the dead `USE_EXISTING_CLUSTER` branch (referenced nowhere else in the repo) is dropped.

</details>

<details>
<summary><strong>Low level</strong></summary>

| File | Change |
|------|--------|
| `test-integration/testutil/envtest.go` | New shared bootstrap (`SuiteEnv`, `SuiteOptions`, `StartSuite`, `StartMinimalSuite`, `StartManager`, `Stop`, GroupRef indexer + scheme helpers) |
| `test-integration/{embedding-server,mcp-external-auth,mcp-group,mcp-oidc-config,mcp-remote-proxy,mcp-server,mcp-telemetry-config,mcp-toolconfig,virtualmcp}/suite_test.go` | Delegate bootstrap to `StartSuite`; keep only controller registrations |
| `test-integration/mcp-registry/suite_test.go` | Route through `StartSuite`; keep CRD-availability check + `WaitForCacheSync`; drop dead `USE_EXISTING_CLUSTER` branch |
| `test-integration/storageversionmigrator/suite_test.go` | Route through `StartMinimalSuite` |

</details>

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring
- [ ] Documentation
- [ ] Other

## Test plan

- [x] `golangci-lint` on the touched packages — 0 issues
- [x] `go test -run '^$'` — all touched packages compile
- [x] `task operator-test-integration` — all 11 suites pass (Test Suite Passed)

## Special notes for reviewers

Test-infrastructure only — no production code changes. The diff is large (−1,104 / +417) but it is entirely test bootstrap consolidation across the 11 suite files plus the new shared helper.

The helper lives under `test-integration/` (not `internal/testutil`) so it stays out of `task test` and is colocated with its only consumers. It has no standalone test of its own: it's exercised end-to-end by all 11 integration suites on every `task operator-test-integration` run, and adding a 12th envtest-spinning suite just to assert non-nil was both redundant and a source of parallel-load flakiness.

Generated with [Claude Code](https://claude.com/claude-code)

## Large PR Justification

This is a **test-infrastructure-only refactor that must be atomic**: the shared `test-integration/testutil` bootstrap helper and its 11 consuming suites have to land in the same change, or the suites fail to compile (they reference `testutil.StartSuite`/`StartMinimalSuite`).

The size is misleading — the diff is **−1,104 / +417**, i.e. a net **~900-line reduction**. The bulk is deleting near-identical copy-pasted `BeforeSuite`/`AfterSuite` boilerplate from each suite; the only real new code is the ~230-line helper. No production code is touched.

Splitting it would mean either landing the helper with no callers (dead code) or migrating suites one-per-PR against a helper that does not yet exist — both worse to review than the single mechanical consolidation. Per-suite the change is trivially verifiable (each suite keeps only its controller registrations), and `task operator-test-integration` passes green (all 11 suites).