### PR TITLE
Document level-triggered operator reconciliation rules

### DIFF
--- a/.claude/rules/operator.md
+++ b/.claude/rules/operator.md
@@ -80,7 +80,7 @@ you're in the exception.
   `ctrl.Result{RequeueAfter: D}, nil`, not a returned error.
 
 - **Separate terminal from transient errors.** A malformed or invalid spec (bad
-  URL, unparseable policy, schema violation) is NOT retryable: surface it via a
+  URL, malformed policy, schema violation) is NOT retryable: surface it via a
   `Valid=False` condition with `ObservedGeneration` set, optionally emit a
   one-shot Warning on the false-transition, and `return ctrl.Result{}, nil`.
   Returning the error instead requeues forever with backoff and buries the

--- a/.claude/rules/operator.md
+++ b/.claude/rules/operator.md
@@ -22,6 +22,15 @@ read-your-write need, and skipping `observedGeneration` on a CR with no
 generation semantics. Knowing *why* each rule exists is what tells you when
 you're in the exception.
 
+> **On the file references below.** Rules cite specific files as exemplars
+> ("the pattern to copy") and as counter-examples ("do not copy", "being
+> migrated", "fix first"). The *pattern* is authoritative; the file pointer is an
+> illustration accurate as of this rule's last edit. If a cited counter-example
+> has since been fixed, that is success, not a contradiction — apply the
+> structural rule and update or drop the stale pointer. Never treat a "do not
+> copy" pointer as license to assume the named file is still broken without
+> checking it.
+
 ## Reconciliation core
 
 - **Recompute, don't diff on the event.** Read the world, compute desired state,
@@ -112,8 +121,11 @@ write-path mechanics.)
   `kubectl apply` round-trip does not flip the hash and cause spurious writes.
 
 - **Use `metav1.Condition` + `meta.SetStatusCondition`.** Express discrete state
-  facts as conditions with `+listType=map`/`+listMapKey=type` markers and
-  condition-type constants centralized in `api/v1beta1/conditions.go`. Do not
+  facts as conditions with `+listType=map`/`+listMapKey=type` markers. Truly
+  shared condition types (`Valid`, `DeletionBlocked`) live in
+  `api/v1beta1/conditions.go`; per-CRD condition types are defined alongside their
+  own status struct in the respective `*_types.go` file — follow that convention,
+  don't dump CRD-specific types into the shared file. Do not
   invent a bespoke status string for something a condition already covers. A
   coarse `Phase` enum (validated with `+kubebuilder:validation:Enum`, shown via
   `+kubebuilder:printcolumn`) is acceptable *in addition to* conditions as a
@@ -144,8 +156,8 @@ write-path mechanics.)
 
 - **Owner-reference everything you create** so Kubernetes garbage-collects it on
   cascade delete — use `controllerutil.SetControllerReference`, or the upsert
-  helpers in `pkg/kubernetes/{configmaps,secrets,rbac}` and `pkg/registryapi`
-  that wire it in centrally. Do not write manual deletion logic in a finalizer
+  helpers in `cmd/thv-operator/pkg/kubernetes/{configmaps,secrets,rbac}` and
+  `cmd/thv-operator/pkg/registryapi` that wire it in centrally. Do not write manual deletion logic in a finalizer
   for same-namespace, same-or-narrower-scope children; GC already reclaims them,
   and the manual delete only adds RBAC surface and a finalizer failure path.
   Owner refs do not work cross-namespace or namespaced→cluster-scoped — for those
@@ -227,10 +239,11 @@ write-path mechanics.)
   `mcpwebhookconfig_controller.go`). Do NOT use a generation predicate on objects
   whose generation is meaningless or whose status changes you must react to
   (ConfigMaps, an MCPGroup readiness flip) — write a field-specific predicate
-  instead (see `configMapDataChangedPredicate`). Because status writes go through
-  `MutateAndPatchStatus` and don't bump `metadata.generation`, an explicit
-  self-loop predicate on the primary `For()` type is belt-and-suspenders here,
-  not mandatory.
+  instead (see `configMapDataChangedPredicate`). Do NOT add a
+  `GenerationChangedPredicate` to the primary `For()` type to "avoid self-reconcile
+  loops": status writes go through `MutateAndPatchStatus` and don't bump
+  `metadata.generation`, so the loop it guards against can't happen and the
+  predicate would only suppress legitimate spec reconciles.
 
 - **Bound concurrency explicitly.** Controller-runtime defaults to
   `MaxConcurrentReconciles: 1` and a bucketed exponential rate limiter — safe but
@@ -272,14 +285,20 @@ write-path mechanics.)
   endpoint (`Metrics.BindAddress`, default `:8080`), a health-probe endpoint
   (`HealthProbeBindAddress`, default `:8081`) with both `AddHealthzCheck` and
   `AddReadyzCheck`, and leader election (`LeaderElection` + `LeaderElectionID` +
-  `LeaderElectionNamespace`). Leader election is opt-in via `--leader-elect` and
-  must be enabled by the Helm chart whenever `replicaCount > 1`; the chart also
-  owns the leases/configmaps RBAC and the probe definitions against the health
-  port (see `deploy/charts/operator/tests/probes_test.yaml`).
+  `LeaderElectionNamespace`). The binary takes a `--leader-elect` flag, which the
+  Helm chart currently passes unconditionally (`deploy/charts/operator/templates/deployment.yaml`),
+  so leader election is on even at the default `replicaCount: 1` — do not "fix"
+  this into a `replicaCount`-gated conditional, which would disable it by default.
+  The chart also owns the leases/configmaps RBAC and the probe definitions against
+  the health port (see `deploy/charts/operator/tests/probes_test.yaml`).
 - "Reconcile metrics" are provided automatically by controller-runtime
   (`controller_runtime_reconcile_*`, workqueue metrics) once the metrics endpoint
-  is enabled — do not hand-roll them. Reserve custom instrumentation for domain
-  metrics, which here live in the leader-only OTEL telemetry service.
+  is enabled — do not hand-roll them. The operator currently exposes no custom
+  OTEL domain metrics; its only leader-only runnable
+  (`pkg/operator/telemetry`, `LeaderTelemetryRunnable`) is a usage/update-check
+  worker that polls the ToolHive update API and persists an instance-id ConfigMap —
+  not a metrics emitter. If you add domain metrics, register them on the
+  controller-runtime metrics registry.
 
 ## CRD vs PodTemplateSpec
 

--- a/.claude/rules/operator.md
+++ b/.claude/rules/operator.md
@@ -8,6 +8,279 @@ paths:
 
 Applies to Kubernetes operator code and CRD definitions.
 
+## The governing principle
+
+**A reconciler is an idempotent, level-triggered function from observed state to
+desired state; everything else is plumbing in service of that.**
+
+`Reconcile` must produce the correct result regardless of how it was triggered,
+how many events were missed, or how many times it runs. Most operator bugs are a
+violation of that sentence wearing a different costume. The rules below are
+defaults with known failure modes, not laws — the two places people most often
+*correctly* break them are bypassing the cache via `APIReader` for a genuine
+read-your-write need, and skipping `observedGeneration` on a CR with no
+generation semantics. Knowing *why* each rule exists is what tells you when
+you're in the exception.
+
+## Reconciliation core
+
+- **Recompute, don't diff on the event.** Read the world, compute desired state,
+  and converge — never branch on *which* event triggered the run or on
+  old-vs-new event payloads. Diffing your freshly-built desired object against
+  the live actual object is correct and expected (that *is* recompute); see
+  `deploymentNeedsUpdate`/`serviceNeedsUpdate` in `mcpserver_controller.go`. When
+  a feature is conceptually an event (a restart request, a one-shot migration),
+  represent it as durable state and compare against it — see
+  `handleRestartAnnotation` comparing `restartedAt` against a persisted
+  `lastProcessedRestart` annotation. If cache lag could corrupt the recompute,
+  read uncached via `APIReader` (see `storageversionmigrator_controller.go`).
+
+- **Idempotent always.** Reconciling twice with no intervening change must be a
+  no-op. Prove it in a unit test: reconcile to steady state, capture
+  `ResourceVersion`, reconcile again, and assert `RequeueAfter == 0` *and*
+  `ResourceVersion` is unchanged — an unchanged RV proves no spurious write
+  occurred. See the steady-state assertions in `mcptelemetryconfig_controller_test.go`,
+  `mcpoidcconfig_controller_test.go`, and `mcpauthzconfig_controller_test.go`.
+  Guard every write behind a desired-vs-actual comparison.
+
+- **One object per request.** The workqueue carries only a `NamespacedName` —
+  *what* to reconcile, never *why*. Cross-resource watches map the triggering
+  object to the set of owner `reconcile.Request`s and discard all other context;
+  the mapper may List/filter to find affected objects (see the `mapXToY`
+  functions in `virtualmcpserver_controller.go`), but `Reconcile` must re-derive
+  every relationship from the named object alone. Never attach event details to
+  the request or to controller fields to "remember" why a reconcile was
+  scheduled.
+
+- **Never sleep, block, or spawn goroutines that outlive the call.** To retry,
+  return the error (controller-runtime backs off exponentially). To come back
+  later on purpose, return `RequeueAfter`. Use `RequeueAfter` — never a tight
+  `Requeue: true` loop — when polling for external readiness (see the 30s
+  readiness requeue in `mcpregistry_controller.go`). `Requeue: true` (or the
+  preferred `RequeueAfter: 0`) is acceptable only to immediately re-run after a
+  write so the next pass sees fresh state. Critically: for an *expected*
+  not-ready/contention condition, return `nil` error with `RequeueAfter`, not an
+  error — returning an error applies exponential backoff and records a phantom
+  failure (see the rationale comment in `storageversionmigrator_controller.go`).
+
+## Errors and requeue
+
+- **Return error → requeue with backoff. That is the retry mechanism.** Never
+  build your own retry loop or sleep-and-retry. Reserve returned errors for
+  genuine transient failures; for *waiting on external convergence* return
+  `ctrl.Result{RequeueAfter: D}, nil`, not a returned error.
+
+- **Separate terminal from transient errors.** A malformed or invalid spec (bad
+  URL, unparseable policy, schema violation) is NOT retryable: surface it via a
+  `Valid=False` condition with `ObservedGeneration` set, optionally emit a
+  one-shot Warning on the false-transition, and `return ctrl.Result{}, nil`.
+  Returning the error instead requeues forever with backoff and buries the
+  signal. Transient errors (apiserver conflicts, dependency `Get` failures,
+  network) must be returned so controller-runtime retries. Reference patterns:
+  `MCPOIDCConfigReconciler.handleValidationFailure` and `VirtualMCPServer`'s
+  typed `SpecValidationError` peeled off with `errors.As` in
+  `handleSpecValidationError`. Counter-example — do NOT copy:
+  `MCPRemoteProxyReconciler.validateSpec` currently returns terminal spec errors
+  (`RemoteURLInvalid`, bad Cedar syntax) and requeues forever.
+
+- **No log-and-swallow.** A reconcile that logs an error then reports success
+  leaves the cluster diverged with no signal. Either return the error (transient
+  → backoff) or record it as a condition (terminal → `return nil`). Two patterns
+  are explicitly *not* swallows: (1) a best-effort status update inside an error
+  branch may be logged-and-skipped as long as the operative error is still
+  returned; (2) an advisory enrichment whose failure does not block the
+  reconcile's objective may log-and-continue *with a comment saying why*.
+  Cleanup errors during finalization must be returned so the finalizer is
+  retained and retried (see `finalizeMCPServer`). Advisory validators that
+  swallow errors must still not paint a *transient* API error as a *terminal*
+  reason. Use controller-runtime's `log.FromContext(ctx)` for reconcile logging,
+  not `pkg/logger`.
+
+## Status and conditions
+
+(See also **Status Condition Parity** and **Status Writes** below for the
+write-path mechanics.)
+
+- **Spec is desired; status is observed and must be reconstructable.** Status
+  must be fully derivable from spec plus the observed cluster on every reconcile —
+  never treat your own status as the authoritative source of intent. Reading
+  prior status back is allowed only for change-detection and idempotency (e.g.
+  comparing a freshly recomputed `Status.ConfigHash`, or short-circuiting a side
+  effect on `ObservedGeneration`), where the compared value is re-derived each
+  reconcile, not carried forward as truth. When hashing for this purpose,
+  canonicalize the spec first (see `mcpauthzconfig_controller.go`) so a no-op
+  `kubectl apply` round-trip does not flip the hash and cause spurious writes.
+
+- **Use `metav1.Condition` + `meta.SetStatusCondition`.** Express discrete state
+  facts as conditions with `+listType=map`/`+listMapKey=type` markers and
+  condition-type constants centralized in `api/v1beta1/conditions.go`. Do not
+  invent a bespoke status string for something a condition already covers. A
+  coarse `Phase` enum (validated with `+kubebuilder:validation:Enum`, shown via
+  `+kubebuilder:printcolumn`) is acceptable *in addition to* conditions as a
+  single human-facing lifecycle summary — the Kubernetes phase+conditions
+  convention — but conditions remain the machine-readable source of detail.
+
+- **Set `observedGeneration`.** Every CRD status type carries
+  `ObservedGeneration int64` and the controller stamps it to `<obj>.Generation`
+  on each successful status write, so consumers can tell whether status reflects
+  the current spec. The config-controller family additionally stamps
+  per-condition `ObservedGeneration` via `metav1.Condition.ObservedGeneration` —
+  prefer that richer form for new condition writers. The theoretical exception
+  for a CR with no spec→status reconciliation is not used anywhere in toolhive;
+  omitting it requires explicit justification.
+
+- **Write status through the `/status` subresource.** Every CRD carries
+  `+kubebuilder:subresource:status`, so status writes are separate API calls and
+  cannot zero spec fields. Route every status write through
+  `controllerutil.MutateAndPatchStatus` (see **Status Writes** for the
+  authoritative rules on fresh-`Get`, sole array ownership, and scalar
+  co-ownership) — never write spec and status in the same call. New controllers
+  MUST use the helper; the legacy `r.Status().Update` call sites in
+  `mcpserver_controller.go`, `mcpremoteproxy_controller.go`, and
+  `mcpregistry_controller.go` predate this rule and are being migrated — do not
+  copy them.
+
+## Ownership and GC
+
+- **Owner-reference everything you create** so Kubernetes garbage-collects it on
+  cascade delete — use `controllerutil.SetControllerReference`, or the upsert
+  helpers in `pkg/kubernetes/{configmaps,secrets,rbac}` and `pkg/registryapi`
+  that wire it in centrally. Do not write manual deletion logic in a finalizer
+  for same-namespace, same-or-narrower-scope children; GC already reclaims them,
+  and the manual delete only adds RBAC surface and a finalizer failure path.
+  Owner refs do not work cross-namespace or namespaced→cluster-scoped — for those
+  you need a finalizer or a label-based sweep. Note: `finalizeMCPServer`
+  currently deletes owned StatefulSet/Service/ConfigMap children manually; treat
+  that as legacy, not a pattern to copy.
+
+## Finalizers
+
+- Add a finalizer **only for cleanup GC cannot do**: external-system teardown,
+  cross-namespace deletion, or cross-resource reference bookkeeping (e.g.
+  updating or blocking on resources that *reference* this one, as the config
+  controllers and `MCPGroup` do). Do not add a finalizer solely to delete
+  same-namespace owned children — owner references already handle that.
+- Add and remove finalizers through `ctrlutil.MutateAndPatchSpec`, never bare
+  `r.Update` (see **Spec / metadata patching** — `r.Update` is a full PUT that
+  can clobber finalizers or spec fields written by sibling controllers; the
+  `mcpgroup` and `mcpregistry` controllers still use raw `r.Update` and should be
+  migrated).
+- The handler MUST be idempotent and tolerate the target already being gone (use
+  a NotFound-swallowing delete like `deleteIfExists`), and every code path MUST
+  eventually remove the finalizer on success — a handler that can return without
+  removing it makes the object permanently undeletable. A deletion-block that
+  withholds removal while references still exist is acceptable only if it
+  requeues and is guaranteed to clear once the references disappear.
+
+## API hygiene and concurrency
+
+(See also **Spec / metadata patching** and **Status Writes** below.)
+
+- **Optimistic concurrency, always — never force a write past a conflict.** On a
+  409 `Conflict`, return the error and let controller-runtime requeue with a
+  fresh `Get` — exactly what `MutateAndPatchSpec` relies on. Never call
+  `obj.SetResourceVersion("")` (or otherwise drop the precondition) to make a
+  write "go through": that silently overwrites whatever a concurrent writer just
+  committed. A 409 is the guard doing its job; treat it as routine.
+
+- **Cache reads, API-server writes, no read-after-write.** Reconcilers read
+  through the manager's cached client and write to the API server. Do not `Get`
+  an object you just wrote and assert on your own change within the same
+  reconcile — the informer cache is eventually consistent and will lag; rely on
+  the resulting watch event to re-enqueue you. The one sanctioned exception is
+  `APIReader` (`mgr.GetAPIReader()`), used today only by the StorageVersionMigrator
+  for a genuine read-true-stored-state need. Do not reach for `APIReader` on a
+  hot path — it hits the apiserver directly and does not scale.
+
+- **Own your fields; don't blind-PUT.** When more than one writer (another
+  controller, a user, kube-apiserver) may touch the same object, only write the
+  fields you own. This repo's mechanism is **optimistic-lock JSON merge-patch,
+  not server-side apply**: `MutateAndPatchSpec` for spec/metadata and
+  `MutateAndPatchStatus` for status. The patch body carries only the fields the
+  mutate closure changed, so co-owned fields are never sent and never clobbered.
+  Do NOT introduce server-side apply (`client.Apply`, `FieldOwner`) as a one-off —
+  toolhive has standardized on the merge-patch helpers, and mixing the two
+  field-ownership models invites confusion. A full-PUT `r.Update` on a CR's spec
+  or metadata is the anti-pattern this replaces. Selective-field `r.Update` on
+  operator-exclusive child objects (Deployments, Services) is tolerated because
+  the operator is the sole writer of the touched fields and the preceding `Get`
+  supplies the resourceVersion precondition.
+
+## Scale and event plumbing
+
+- **Index every field you `List`-filter by.** When a watch handler or reconcile
+  path filters `List` results by a field on a referenced object (especially
+  reverse-reference lookups — "find every X that references this Y"), register a
+  field index with `mgr.GetFieldIndexer().IndexField` and query with
+  `client.MatchingFields`. List-everything-then-filter-in-memory turns a single
+  config change into an O(all-CRs-in-namespace) scan on every event. The
+  `spec.groupRef` indexes in `app.go` and the ref indexes in
+  `mcpserverentry_controller.go` are the pattern to copy. The config-fan-out
+  controllers (`mcpserver`, `mcpoidcconfig`, `mcptelemetryconfig`,
+  `mcpauthzconfig`, `mcpexternalauthconfig`) currently list-and-filter and are
+  the place to fix first.
+
+- **Watch and map, don't poll; filter watches with predicates.** Use
+  `Owns`/`Watches` + `handler.EnqueueRequestsFromMapFunc` for related objects.
+  Add `predicate.GenerationChangedPredicate{}` to a `Watches` of a spec-driven
+  CRD so status-only churn doesn't trigger a full fan-out reconcile (see
+  `mcpwebhookconfig_controller.go`). Do NOT use a generation predicate on objects
+  whose generation is meaningless or whose status changes you must react to
+  (ConfigMaps, an MCPGroup readiness flip) — write a field-specific predicate
+  instead (see `configMapDataChangedPredicate`). Because status writes go through
+  `MutateAndPatchStatus` and don't bump `metadata.generation`, an explicit
+  self-loop predicate on the primary `For()` type is belt-and-suspenders here,
+  not mandatory.
+
+- **Bound concurrency explicitly.** Controller-runtime defaults to
+  `MaxConcurrentReconciles: 1` and a bucketed exponential rate limiter — safe but
+  serial. Leave the default unless a specific CRD's reconcile throughput is
+  demonstrably the bottleneck; then raise `MaxConcurrentReconciles` via
+  `WithOptions(controller.Options{...})` and keep the default rate limiter. Never
+  spawn your own unbounded reconcile goroutines. No toolhive controller sets this
+  today; raise it only *after* the indexes above are in place, since concurrency
+  multiplies the cost of any list-and-filter still present.
+
+- **Periodic `RequeueAfter` as a correctness backstop** — only when the
+  controller has a genuine missed-event failure mode (a dependency it cannot
+  watch, external readiness it polls, deletes-during-downtime). Events drive
+  promptness; the timer guarantees eventual convergence. Tie the requeue to the
+  unconverged condition and drop it once satisfied (see `mcpregistry_controller.go`
+  requeuing only while not-ready, and the EmbeddingServer "safety net" comment in
+  `virtualmcpserver_controller.go`). Do NOT add an unconditional periodic requeue
+  to a controller whose inputs are all watched. Short (sub-second) requeues after
+  a finalizer/metadata patch are a separate "re-run with a fresh Get" pattern, not
+  a backstop; keep them gated on a condition that will clear.
+
+## Validation
+
+- **Push spec validation into the API.** Express constraints as OpenAPI schema
+  markers (`+kubebuilder:validation:Enum/Minimum/Maximum/Pattern/Required`) and,
+  for cross-field rules, discriminated unions, and mutual exclusions, as CEL via
+  `+kubebuilder:validation:XValidation`. See `mcpexternalauthconfig_types.go` and
+  `mcpserver_types.go` for the established patterns. Bad specs must be rejected at
+  admission, not discovered mid-reconcile. Reconcile-time Go validation is
+  reserved for (a) what CEL genuinely cannot express and (b) checks on
+  *derived/assembled* config (e.g. the `runner.RunConfig` built by the
+  controller) that does not exist at admission time — it is not a substitute for
+  schema markers on the raw spec. When a Go check intentionally mirrors a CEL rule
+  for defense-in-depth, say so in a comment.
+
+## Manager bootstrap and operation
+
+- The manager bootstrap (`cmd/thv-operator/app/app.go`) must wire: a metrics
+  endpoint (`Metrics.BindAddress`, default `:8080`), a health-probe endpoint
+  (`HealthProbeBindAddress`, default `:8081`) with both `AddHealthzCheck` and
+  `AddReadyzCheck`, and leader election (`LeaderElection` + `LeaderElectionID` +
+  `LeaderElectionNamespace`). Leader election is opt-in via `--leader-elect` and
+  must be enabled by the Helm chart whenever `replicaCount > 1`; the chart also
+  owns the leases/configmaps RBAC and the probe definitions against the health
+  port (see `deploy/charts/operator/tests/probes_test.yaml`).
+- "Reconcile metrics" are provided automatically by controller-runtime
+  (`controller_runtime_reconcile_*`, workqueue metrics) once the metrics endpoint
+  is enabled — do not hand-roll them. Reserve custom instrumentation for domain
+  metrics, which here live in the leader-only OTEL telemetry service.
+
 ## CRD vs PodTemplateSpec
 
 **Rule of thumb**: If it affects how the operator behaves or how the MCP server operates, it's a **CRD attribute**. If it affects where/how pods run, it's **PodTemplateSpec**.


### PR DESCRIPTION
## Summary

The operator rules in `.claude/rules/operator.md` covered CRD conventions and the status/spec patching *mechanics*, but said nothing about the reconciliation *principles* those mechanics serve — so contributors (and Claude) had no codified guidance on the single idea most operator bugs violate: a reconciler is an idempotent, level-triggered function from observed state to desired state. This adds that governing principle and the supporting rules, each verified against the actual `cmd/thv-operator` code rather than generic Kubernetes lore.

<details>
<summary><strong>Medium level</strong></summary>

- Adds a **governing-principle** section stating the level-triggered, idempotent reconcile invariant, with an explicit note that the rules are defaults-with-known-failure-modes (and where the two legitimate exceptions — `APIReader` reads and skipping `observedGeneration` — apply).
- Adds nine rule sections placed ahead of the existing CRD/patching content: **Reconciliation core**, **Errors and requeue**, **Status and conditions**, **Ownership and GC**, **Finalizers**, **API hygiene and concurrency**, **Scale and event plumbing**, **Validation**, and **Manager bootstrap and operation**.
- Cross-references (rather than duplicates) the existing **Status Writes** and **Spec / metadata patching** sections for the `MutateAndPatch*` write-path mechanics.
- Each rule cites a real in-repo exemplar (e.g. `storageversionmigrator_controller.go` for `APIReader`/conflict-retry, `mcpserverentry_controller.go` for field indexes, `virtualmcpserver`'s `configMapDataChangedPredicate`) and names the codebase's tolerated exceptions so the rules apply without over-flagging conformant patterns.
- Notably reframes the "own your fields" rule away from server-side apply: the house style is optimistic-lock merge-patch via `MutateAndPatch*`, not SSA, so the rule steers contributors toward the existing helpers.

</details>

<details>
<summary><strong>Low level</strong></summary>

| File | Change |
|------|--------|
| `.claude/rules/operator.md` | +273 lines: governing principle + 9 new rule sections, inserted before the existing "CRD vs PodTemplateSpec" content |

</details>

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [x] Documentation
- [ ] Other

## Test plan

- [x] Docs/rules-only change — no code, tests, or generated artifacts affected
- [x] Rules verified against current `cmd/thv-operator` source (exemplars and tolerated exceptions confirmed to exist)

## Does this introduce a user-facing change?

No. This updates contributor/agent guidance only.

## Special notes for reviewers

- This is a rules-doc-only PR; it exceeds the line-count guideline but falls under the docs-only exemption.
- The rules deliberately name several current violations as "do not copy" counter-examples (e.g. `mcpremoteproxy_controller.go`'s `validateSpec` returning terminal errors and requeueing forever; config controllers' list-and-filter without field indexes). Those are described as known/legacy, not fixed here — a follow-up audit catalogued them and they can be filed as separate issues.

Generated with [Claude Code](https://claude.com/claude-code)