### PR TITLE
Fix incorrect elicitation template paths in comment

### DIFF
--- a/pkg/vmcp/composer/composer.go
+++ b/pkg/vmcp/composer/composer.go
@@ -89,8 +89,8 @@ type WorkflowStep struct {
 	// Templates use Go text/template syntax with access to:
 	//   - {{.params.name}}: Input parameters
 	//   - {{.steps.stepid.output}}: Previous step outputs
-	//   - {{.steps.stepid.content}}: Elicitation response data
-	//   - {{.steps.stepid.action}}: Elicitation action (accept/decline/cancel)
+	//   - {{.steps.stepid.output.content}}: Elicitation response data
+	//   - {{.steps.stepid.output.action}}: Elicitation action (accept/decline/cancel)
 	Arguments map[string]any
 
 	// Condition is an optional condition for conditional execution.


### PR DESCRIPTION
## Summary

The comment on the `Arguments` field of `WorkflowStep` documented the wrong template paths for accessing elicitation results. The `action` and `content` fields are stored inside the step's `output` map, so `.steps.stepid.action` and `.steps.stepid.content` resolve to empty strings at runtime. The correct paths are `.steps.stepid.output.action` and `.steps.stepid.output.content`, which is consistent with how `workflow_engine.go` already documents them.

Relates to stacklok/docs-website#629

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [x] Documentation
- [ ] Other (describe):

## Test plan

- [x] Manual testing (describe below)

Comment-only change; verified against `handleElicitationAccept` in `elicitation_handler.go` and the integration tests in `elicitation_integration_test.go` which already use the correct paths.

## API Compatibility

- [x] This PR does not break the `v1beta1` API, OR the `api-break-allowed` label is applied and the migration guidance is described above.

## Does this introduce a user-facing change?

No.