### PR TITLE
Fix IdentityFromContext typed-nil *Identity returns (nil, true)

### DIFF
--- a/pkg/auth/context.go
+++ b/pkg/auth/context.go
@@ -38,6 +38,13 @@ func WithIdentity(ctx context.Context, identity *Identity) context.Context {
 // IdentityFromContext retrieves an Identity from the context.
 // Returns the identity and true if present, nil and false otherwise.
 //
+// A typed-nil *Identity stored via context.WithValue (instead of the
+// canonical WithIdentity helper, which guards against nil) is treated as
+// "no identity" — the function returns (nil, false) rather than (nil, true).
+// This prevents callers that gate on the bool (e.g. identity round-trippers)
+// from suppressing fallback logic and allowing a nil pointer to flow
+// downstream.
+//
 // This function is typically called by authorization middleware or handlers that need
 // to check who the authenticated user is.
 //
@@ -50,7 +57,7 @@ func WithIdentity(ctx context.Context, identity *Identity) context.Context {
 //	log.Printf("Request from user: %s", identity.Subject)
 func IdentityFromContext(ctx context.Context) (*Identity, bool) {
 	identity, ok := ctx.Value(IdentityContextKey{}).(*Identity)
-	return identity, ok
+	return identity, ok && identity != nil
 }
 
 // PlatformUserContextKey is the key used to store the platform's canonical user

--- a/pkg/auth/context_test.go
+++ b/pkg/auth/context_test.go
@@ -91,9 +91,10 @@ func TestIdentityContext_ExplicitNilValue(t *testing.T) {
 	// Explicitly store nil Identity pointer in context (edge case)
 	ctx = context.WithValue(ctx, IdentityContextKey{}, (*Identity)(nil))
 
-	// Retrieval should detect the nil pointer
+	// Retrieval should treat the typed-nil as "no identity" to prevent
+	// callers that gate on the bool from suppressing fallback logic.
 	identity, ok := IdentityFromContext(ctx)
-	assert.True(t, ok, "expected value to be present")
+	assert.False(t, ok, "expected typed-nil *Identity to be treated as absent")
 	assert.Nil(t, identity, "expected nil identity")
 }
 


### PR DESCRIPTION
## Summary

`IdentityFromContext` returns `(nil, true)` when a typed-nil `*Identity` is stored via `context.WithValue`, because the type assertion succeeds with `ok==true` even though the pointed-to value is `nil`.

Callers that gate on the bool (e.g. vMCP identity round-trippers introduced by #5323) suppress their fallback logic and allow a nil pointer to flow downstream, causing nil-dereference panics on `identity.UpstreamTokens[providerName]`.

`WithIdentity` is nil-safe so this is latent rather than active today — no in-tree caller currently stores a typed-nil — but the hazard is sharp enough that defending at the read site is worthwhile.

## Changes

- `pkg/auth/context.go`: Add `identity != nil` to the bool return of `IdentityFromContext`. Update doc comment to document the defensive behavior.
- `pkg/auth/context_test.go`: Update `TestIdentityContext_ExplicitNilValue` to assert `(nil, false)` instead of `(nil, true)`.

## Testing

- All `pkg/auth/...` tests pass (`go test ./pkg/auth/... -count=1`)
- All `pkg/vmcp/...` tests pass (`go test ./pkg/vmcp/... -count=1`)
- All `pkg/webhook/...` tests pass (`go test ./pkg/webhook/... -count=1`)
- `go vet ./pkg/auth/...` clean
- `gofmt` clean

Closes #5337