### PR TITLE
Fix codespell failure: unparseable -> unparsable

### DIFF
--- a/pkg/networking/utilities.go
+++ b/pkg/networking/utilities.go
@@ -22,7 +22,7 @@ import (
 // reach internal addresses for that deployment.
 //
 // IP literals and "localhost" are classified without DNS. Hostnames are resolved
-// and reported private if ANY resolved address is private. Unparseable input or
+// and reported private if ANY resolved address is private. Unparsable input or
 // resolution failure returns false (treat as public — the SSRF guard then stays
 // engaged, failing secure).
 func TargetIsPrivate(ctx context.Context, rawURL string) bool {

--- a/pkg/networking/utilities_test.go
+++ b/pkg/networking/utilities_test.go
@@ -24,7 +24,7 @@ func TestTargetIsPrivate(t *testing.T) {
 		{name: "loopback IPv4 literal", url: "http://127.0.0.1:8080", want: true},
 		{name: "localhost hostname", url: "http://localhost:9000", want: true},
 		{name: "public IPv4 literal", url: "https://8.8.8.8", want: false},
-		{name: "unparseable", url: "://nope", want: false},
+		{name: "unparsable", url: "://nope", want: false},
 		{name: "empty host", url: "/just/a/path", want: false},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

The Spellcheck (Codespell) CI job is failing on `main` because codespell flags `unparseable` in favour of `unparsable`. The misspelling lives in `pkg/networking/utilities.go` (a doc comment on `TargetIsPrivate`) and a matching test-case name — both introduced with the recent SSRF/CIMD changes, unrelated to whatever PR happens to be open. This corrects both so the spellcheck gate goes green again.

## Type of change

- [x] Bug fix (CI breakage)
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

## Test plan

- [x] `codespell pkg/networking/utilities.go pkg/networking/utilities_test.go` reports clean
- [x] `git grep -ni unparseable` returns no remaining occurrences
- [x] `go build ./pkg/networking/` passes
- [x] Comment/test-name only — no behavior change

## Does this introduce a user-facing change?

No.

Generated with [Claude Code](https://claude.com/claude-code)