### PR TITLE
Fix vMCP Deployment update loop with embedded auth server

### DIFF
--- a/cmd/thv-operator/controllers/virtualmcpserver_deployment.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_deployment.go
@@ -174,13 +174,13 @@ func (r *VirtualMCPServerReconciler) deploymentForVirtualMCPServer(
 		volumeMounts = append(volumeMounts, telMounts...)
 	}
 
-	// Add embedded auth server volumes and env vars if configured (inline config)
+	// Add embedded auth server volumes if configured (inline config). The matching
+	// env vars are injected by buildEnvVarsForVmcp above so the drift check stays
+	// symmetric with what is built here (see #5616).
 	if vmcp.Spec.AuthServerConfig != nil {
 		authServerVolumes, authServerMounts := ctrlutil.GenerateAuthServerVolumes(vmcp.Spec.AuthServerConfig)
-		authServerEnvVars := ctrlutil.GenerateAuthServerEnvVars(vmcp.Spec.AuthServerConfig)
 		volumes = append(volumes, authServerVolumes...)
 		volumeMounts = append(volumeMounts, authServerMounts...)
-		env = append(env, authServerEnvVars...)
 	}
 	deploymentLabels, deploymentAnnotations := r.buildDeploymentMetadataForVmcp(ls, vmcp)
 	deploymentTemplateLabels, deploymentTemplateAnnotations := r.buildPodTemplateMetadata(ls, vmcp, vmcpConfigChecksum)
@@ -382,6 +382,16 @@ func (r *VirtualMCPServerReconciler) buildEnvVarsForVmcp(
 		otelEnv := ctrlutil.GenerateOpenTelemetryEnvVarsFromRef(
 			telemetryCfg, vmcp.Spec.TelemetryConfigRef, vmcp.Name, vmcp.Namespace)
 		env = append(env, otelEnv...)
+	}
+
+	// Mount embedded auth server upstream client secrets (and Redis ACL creds).
+	// This must live here, not only in deploymentForVirtualMCPServer, so that the
+	// env-var drift check in containerNeedsUpdate compares against the same set.
+	// Otherwise the live container carries these env vars but the expected set
+	// does not, reflect.DeepEqual never matches, and the operator updates the
+	// Deployment on every reconcile (see #5616).
+	if vmcp.Spec.AuthServerConfig != nil {
+		env = append(env, ctrlutil.GenerateAuthServerEnvVars(vmcp.Spec.AuthServerConfig)...)
 	}
 
 	return ctrlutil.EnsureRequiredEnvVars(ctx, env), nil

--- a/cmd/thv-operator/controllers/virtualmcpserver_deployment_test.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_deployment_test.go
@@ -1039,6 +1039,70 @@ func TestDeploymentForVirtualMCPServer_ImagePullSecrets_UpdatePath(t *testing.T)
 	}
 }
 
+// TestDeploymentForVirtualMCPServer_AuthServerConfig_NoUpdateLoop is a regression
+// test for #5616: a VirtualMCPServer with an embedded auth server (AuthServerConfig)
+// hot-looped Deployment updates forever. deploymentForVirtualMCPServer injected the
+// auth-server client-secret env var into the container, but buildEnvVarsForVmcp (used
+// by containerNeedsUpdate to compute the expected env) did not, so the reflect.DeepEqual
+// drift check never matched and the operator issued a no-op Update on every reconcile.
+//
+// The test builds a Deployment for a vMCP with AuthServerConfig set, then asserts that
+// a drift check against that freshly-built Deployment reports no update needed. Before
+// the fix this fails (deploymentNeedsUpdate returns true); after it, the env is symmetric
+// and the check settles.
+func TestDeploymentForVirtualMCPServer_AuthServerConfig_NoUpdateLoop(t *testing.T) {
+	t.Parallel()
+
+	scheme := testutil.NewScheme(t)
+
+	r := &VirtualMCPServerReconciler{
+		Scheme:           scheme,
+		PlatformDetector: ctrlutil.NewSharedPlatformDetector(),
+	}
+
+	// An OIDC upstream provider with a ClientSecretRef makes GenerateAuthServerEnvVars
+	// emit TOOLHIVE_UPSTREAM_CLIENT_SECRET_OKTA — the env var that was present on the
+	// built container but absent from the expected set.
+	vmcp := v1beta1test.NewVirtualMCPServer("test-vmcp", "default",
+		v1beta1test.WithVMCPGroupRef("test-group"),
+		v1beta1test.WithVMCPAuthServerConfig(&mcpv1beta1.EmbeddedAuthServerConfig{
+			UpstreamProviders: []mcpv1beta1.UpstreamProviderConfig{
+				{
+					Name: "okta",
+					Type: mcpv1beta1.UpstreamProviderTypeOIDC,
+					OIDCConfig: &mcpv1beta1.OIDCUpstreamConfig{
+						IssuerURL:       "https://example.okta.com",
+						ClientID:        "test-client",
+						ClientSecretRef: &mcpv1beta1.SecretKeyRef{Name: "okta-secret", Key: "client-secret"},
+					},
+				},
+			},
+		}),
+	)
+
+	const cfgChecksum = "test-checksum"
+	dep := r.deploymentForVirtualMCPServer(t.Context(), vmcp, cfgChecksum, nil, []workloads.TypedWorkload{})
+	require.NotNil(t, dep)
+
+	// Sanity: the auth-server client-secret env var must actually be on the built
+	// container, otherwise this test isn't exercising the asymmetry it guards against.
+	require.NotEmpty(t, dep.Spec.Template.Spec.Containers)
+	var hasAuthEnv bool
+	for _, e := range dep.Spec.Template.Spec.Containers[0].Env {
+		if e.Name == "TOOLHIVE_UPSTREAM_CLIENT_SECRET_OKTA" {
+			hasAuthEnv = true
+			break
+		}
+	}
+	require.True(t, hasAuthEnv, "built container must carry the auth-server client-secret env var")
+
+	// The freshly-built Deployment is steady state: a drift check against it must
+	// not request an update. Before the fix this returned true on every reconcile.
+	needsUpdate := r.deploymentNeedsUpdate(t.Context(), dep, vmcp, cfgChecksum, nil, []workloads.TypedWorkload{})
+	assert.False(t, needsUpdate,
+		"deploymentNeedsUpdate must not loop on a vMCP with AuthServerConfig (regression #5616)")
+}
+
 // TestImagePullSecretsHash verifies the hash helper normalizes order, treats an
 // empty list as the sentinel "" hash, and produces stable hashes across calls.
 func TestImagePullSecretsHash(t *testing.T) {


### PR DESCRIPTION
## Summary

A `VirtualMCPServer` with `spec.authServerConfig` set caused the operator to issue a no-op Deployment `Update` on every reconcile, indefinitely. With the controller's periodic backend re-discovery driving reconciles every ~30s, this was a steady stream of Deployment updates per affected vMCP. On a small cluster the API churn is very visible (kube-apiserver pinned at ~125m CPU with no user traffic); the pods never restart, so it reads as pure control-plane churn.

Root cause is an env-var build/diff asymmetry. `deploymentForVirtualMCPServer` injected the auth-server client-secret env vars (`TOOLHIVE_UPSTREAM_CLIENT_SECRET_<PROVIDER>`) into the built container, but `buildEnvVarsForVmcp` (which `containerNeedsUpdate` uses to compute the *expected* env) did not. The live container always carried those env vars, the expected set never did, so `reflect.DeepEqual` never matched, `deploymentNeedsUpdate` returned true every pass, and the operator updated the Deployment forever.

- Move the auth-server env injection into `buildEnvVarsForVmcp` so the build path and the drift-check path share one source of truth. The volume/mount injection stays in `deploymentForVirtualMCPServer`.
- Add a regression test that builds the Deployment for a vMCP with `authServerConfig` and asserts `deploymentNeedsUpdate` reports no drift on the freshly-built object.

Fixes #5616

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)
- [x] Manual testing (describe below)

Verified the new regression test fails against the unfixed code (the exact loop assertion) and passes with the fix. Ran the full `controllers` and `controllerutil` packages plus `go vet`; all clean. Originally diagnosed on a live kind cluster where two `authServerConfig` vMCPs were driving ~8 Deployment updates/minute each.

## API Compatibility

- [x] This PR does not break the `v1beta1` API.

## Does this introduce a user-facing change?

No. This is an internal reconciliation correctness fix; no CRD or config changes. Users with embedded-auth-server vMCPs will see the operator stop continuously updating those Deployments.

## Special notes for reviewers

There's a related latent gap noted in #5616 (the drift check never compares volumes/volumeMounts at all, so auth-server volume changes wouldn't self-heal). It's a different failure mode and intentionally out of scope here; opened #5619 to track.

🤖 Generated with [Claude Code](https://claude.com/claude-code)