### PR TITLE
Allow private IPs for in-cluster OIDC and OAuth2 upstream providers

### DIFF
--- a/docs/server/docs.go
+++ b/docs/server/docs.go
@@ -422,6 +422,10 @@ const docTemplate = `{
                         "description": "AdditionalAuthorizationParams are extra query parameters to include in\nauthorization requests. Useful for provider-specific parameters like\nGoogle's access_type=offline.",
                         "type": "object"
                     },
+                    "allow_private_ips": {
+                        "description": "AllowPrivateIPs permits the upstream provider's HTTP client to connect to\nprivate IP ranges (RFC-1918, link-local). Use only when the upstream is\nhosted inside the same cluster and has no public endpoint. HTTP-scheme\nrestrictions are unchanged — HTTPS is still required for non-localhost hosts.\nDefaults to false.",
+                        "type": "boolean"
+                    },
                     "authorization_endpoint": {
                         "description": "AuthorizationEndpoint is the URL for the OAuth authorization endpoint.",
                         "type": "string"
@@ -478,6 +482,10 @@ const docTemplate = `{
                         },
                         "description": "AdditionalAuthorizationParams are extra query parameters to include in\nauthorization requests. Useful for provider-specific parameters like\nGoogle's access_type=offline.",
                         "type": "object"
+                    },
+                    "allow_private_ips": {
+                        "description": "AllowPrivateIPs permits the OIDC discovery and token HTTP clients to\nconnect to private IP ranges (RFC-1918, link-local). Use only when the\nupstream is hosted inside the same cluster and has no public endpoint.\nHTTP-scheme restrictions are unchanged — HTTPS is still required for\nnon-localhost hosts. Defaults to false.",
+                        "type": "boolean"
                     },
                     "client_id": {
                         "description": "ClientID is the OAuth 2.0 client identifier registered with the upstream IDP.",

--- a/docs/server/swagger.json
+++ b/docs/server/swagger.json
@@ -415,6 +415,10 @@
                         "description": "AdditionalAuthorizationParams are extra query parameters to include in\nauthorization requests. Useful for provider-specific parameters like\nGoogle's access_type=offline.",
                         "type": "object"
                     },
+                    "allow_private_ips": {
+                        "description": "AllowPrivateIPs permits the upstream provider's HTTP client to connect to\nprivate IP ranges (RFC-1918, link-local). Use only when the upstream is\nhosted inside the same cluster and has no public endpoint. HTTP-scheme\nrestrictions are unchanged — HTTPS is still required for non-localhost hosts.\nDefaults to false.",
+                        "type": "boolean"
+                    },
                     "authorization_endpoint": {
                         "description": "AuthorizationEndpoint is the URL for the OAuth authorization endpoint.",
                         "type": "string"
@@ -471,6 +475,10 @@
                         },
                         "description": "AdditionalAuthorizationParams are extra query parameters to include in\nauthorization requests. Useful for provider-specific parameters like\nGoogle's access_type=offline.",
                         "type": "object"
+                    },
+                    "allow_private_ips": {
+                        "description": "AllowPrivateIPs permits the OIDC discovery and token HTTP clients to\nconnect to private IP ranges (RFC-1918, link-local). Use only when the\nupstream is hosted inside the same cluster and has no public endpoint.\nHTTP-scheme restrictions are unchanged — HTTPS is still required for\nnon-localhost hosts. Defaults to false.",
+                        "type": "boolean"
                     },
                     "client_id": {
                         "description": "ClientID is the OAuth 2.0 client identifier registered with the upstream IDP.",

--- a/docs/server/swagger.yaml
+++ b/docs/server/swagger.yaml
@@ -466,6 +466,14 @@ components:
             authorization requests. Useful for provider-specific parameters like
             Google's access_type=offline.
           type: object
+        allow_private_ips:
+          description: |-
+            AllowPrivateIPs permits the upstream provider's HTTP client to connect to
+            private IP ranges (RFC-1918, link-local). Use only when the upstream is
+            hosted inside the same cluster and has no public endpoint. HTTP-scheme
+            restrictions are unchanged — HTTPS is still required for non-localhost hosts.
+            Defaults to false.
+          type: boolean
         authorization_endpoint:
           description: AuthorizationEndpoint is the URL for the OAuth authorization
             endpoint.
@@ -522,6 +530,14 @@ components:
             authorization requests. Useful for provider-specific parameters like
             Google's access_type=offline.
           type: object
+        allow_private_ips:
+          description: |-
+            AllowPrivateIPs permits the OIDC discovery and token HTTP clients to
+            connect to private IP ranges (RFC-1918, link-local). Use only when the
+            upstream is hosted inside the same cluster and has no public endpoint.
+            HTTP-scheme restrictions are unchanged — HTTPS is still required for
+            non-localhost hosts. Defaults to false.
+          type: boolean
         client_id:
           description: ClientID is the OAuth 2.0 client identifier registered with
             the upstream IDP.

--- a/pkg/authserver/config.go
+++ b/pkg/authserver/config.go
@@ -296,6 +296,13 @@ type OIDCUpstreamRunConfig struct {
 	// subject. Defaults to "sub" when empty. Set for IdPs where "sub" isn't
 	// stable per user (e.g. Entra/Azure AD's "oid"). See upstream.OIDCConfig.
 	SubjectClaim string `json:"subject_claim,omitempty" yaml:"subject_claim,omitempty"`
+
+	// AllowPrivateIPs permits the OIDC discovery and token HTTP clients to
+	// connect to private IP ranges (RFC-1918, link-local). Use only when the
+	// upstream is hosted inside the same cluster and has no public endpoint.
+	// HTTP-scheme restrictions are unchanged — HTTPS is still required for
+	// non-localhost hosts. Defaults to false.
+	AllowPrivateIPs bool `json:"allow_private_ips,omitempty" yaml:"allow_private_ips,omitempty"`
 }
 
 // OAuth2UpstreamRunConfig contains configuration for pure OAuth 2.0 providers.
@@ -360,6 +367,13 @@ type OAuth2UpstreamRunConfig struct {
 	// ClientSecretFile / ClientSecretEnvVar, and ClientID must be left empty.
 	// Mutually exclusive with ClientID.
 	DCRConfig *DCRUpstreamConfig `json:"dcr_config,omitempty" yaml:"dcr_config,omitempty"`
+
+	// AllowPrivateIPs permits the upstream provider's HTTP client to connect to
+	// private IP ranges (RFC-1918, link-local). Use only when the upstream is
+	// hosted inside the same cluster and has no public endpoint. HTTP-scheme
+	// restrictions are unchanged — HTTPS is still required for non-localhost hosts.
+	// Defaults to false.
+	AllowPrivateIPs bool `json:"allow_private_ips,omitempty" yaml:"allow_private_ips,omitempty"`
 }
 
 // DCRUpstreamConfig configures RFC 7591 Dynamic Client Registration for an

--- a/pkg/authserver/runner/embeddedauthserver.go
+++ b/pkg/authserver/runner/embeddedauthserver.go
@@ -576,8 +576,9 @@ func buildOIDCConfig(rc *authserver.UpstreamRunConfig) (*upstream.OIDCConfig, er
 			Scopes:                        scopes,
 			AdditionalAuthorizationParams: oidc.AdditionalAuthorizationParams,
 		},
-		Issuer:       oidc.IssuerURL,
-		SubjectClaim: oidc.SubjectClaim,
+		Issuer:          oidc.IssuerURL,
+		SubjectClaim:    oidc.SubjectClaim,
+		AllowPrivateIPs: oidc.AllowPrivateIPs,
 	}, nil
 }
 
@@ -612,6 +613,7 @@ func buildPureOAuth2Config(rc *authserver.UpstreamRunConfig) (*upstream.OAuth2Co
 		AuthorizationEndpoint: oauth2.AuthorizationEndpoint,
 		TokenEndpoint:         oauth2.TokenEndpoint,
 		UserInfo:              convertUserInfoConfig(oauth2.UserInfo),
+		AllowPrivateIPs:       oauth2.AllowPrivateIPs,
 	}
 
 	if oauth2.TokenResponseMapping != nil {

--- a/pkg/authserver/runner/embeddedauthserver_test.go
+++ b/pkg/authserver/runner/embeddedauthserver_test.go
@@ -595,6 +595,27 @@ func TestBuildPureOAuth2Config(t *testing.T) {
 		require.NotNil(t, cfg)
 		assert.Empty(t, cfg.ClientID)
 	})
+
+	t.Run("propagates AllowPrivateIPs", func(t *testing.T) {
+		t.Parallel()
+
+		rc := &authserver.UpstreamRunConfig{
+			Type: authserver.UpstreamProviderTypeOAuth2,
+			OAuth2Config: &authserver.OAuth2UpstreamRunConfig{
+				AuthorizationEndpoint: "https://example.com/authorize",
+				TokenEndpoint:         "https://example.com/token",
+				ClientID:              "my-client-id",
+				RedirectURI:           "https://my-app.com/callback",
+				AllowPrivateIPs:       true,
+			},
+		}
+
+		cfg, err := buildPureOAuth2Config(rc)
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+
+		assert.True(t, cfg.AllowPrivateIPs)
+	})
 }
 
 // TestBuildPureOAuth2ConfigWithEnvVar tests buildPureOAuth2Config with environment variables.
@@ -1126,6 +1147,26 @@ func TestBuildOIDCConfig(t *testing.T) {
 		require.NotNil(t, cfg)
 
 		assert.Equal(t, "oid", cfg.SubjectClaim)
+	})
+
+	t.Run("propagates AllowPrivateIPs", func(t *testing.T) {
+		t.Parallel()
+
+		rc := &authserver.UpstreamRunConfig{
+			Type: authserver.UpstreamProviderTypeOIDC,
+			OIDCConfig: &authserver.OIDCUpstreamRunConfig{
+				IssuerURL:       "https://idp.example.com",
+				ClientID:        "my-client-id",
+				RedirectURI:     "http://localhost:8080/callback",
+				AllowPrivateIPs: true,
+			},
+		}
+
+		cfg, err := buildOIDCConfig(rc)
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+
+		assert.True(t, cfg.AllowPrivateIPs)
 	})
 }
 

--- a/pkg/authserver/upstream/oauth2.go
+++ b/pkg/authserver/upstream/oauth2.go
@@ -162,6 +162,13 @@ type OAuth2Config struct {
 	// (cmd/thv-operator/api/v1beta1.IdentityFromTokenConfig) for the
 	// authoritative trust-model and uniqueness documentation.
 	IdentityFromToken *IdentityFromTokenConfig `json:"identity_from_token,omitempty" yaml:"identity_from_token,omitempty"`
+
+	// AllowPrivateIPs permits the upstream provider's HTTP client to connect to
+	// private IP ranges (RFC-1918, link-local). Use only when the upstream is
+	// hosted inside the same cluster and has no public endpoint. HTTP-scheme
+	// restrictions are unchanged — HTTPS is still required for non-localhost hosts.
+	// Defaults to false.
+	AllowPrivateIPs bool `json:"allow_private_ips,omitempty" yaml:"allow_private_ips,omitempty"`
 }
 
 // TokenResponseMapping configures extraction of token fields from non-standard
@@ -280,7 +287,7 @@ func newBaseOAuth2Provider(config *OAuth2Config, hostForClient string) (*BaseOAu
 		return nil, fmt.Errorf("invalid config: %w", err)
 	}
 
-	httpClient, err := newHTTPClientForHost(hostForClient)
+	httpClient, err := newHTTPClientForHost(hostForClient, config.AllowPrivateIPs)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create HTTP client: %w", err)
 	}
@@ -804,11 +811,14 @@ func formatOAuth2Error(err error, prefix string) error {
 // newHTTPClientForHost creates an HTTP client configured for the given host.
 // It enables HTTP and private IPs only for localhost (development/testing),
 // or when INSECURE_DISABLE_URL_VALIDATION is set (e.g. Kubernetes dev environments).
-func newHTTPClientForHost(host string) (*http.Client, error) {
+// allowPrivateIPs widens only the private-IP gate: it permits connections to
+// RFC-1918/link-local addresses (e.g. in-cluster providers) without enabling
+// the HTTP scheme for non-localhost hosts.
+func newHTTPClientForHost(host string, allowPrivateIPs bool) (*http.Client, error) {
 	allowInsecure := networking.IsLocalhost(host) ||
 		strings.EqualFold(os.Getenv("INSECURE_DISABLE_URL_VALIDATION"), "true")
 	return networking.NewHttpClientBuilder().
 		WithInsecureAllowHTTP(allowInsecure).
-		WithPrivateIPs(allowInsecure).
+		WithPrivateIPs(allowInsecure || allowPrivateIPs).
 		Build()
 }

--- a/pkg/authserver/upstream/oauth2_test.go
+++ b/pkg/authserver/upstream/oauth2_test.go
@@ -2579,9 +2579,14 @@ func TestNewHTTPClientForHost(t *testing.T) {
 			req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://"+privateIP+":9999", nil)
 			require.NoError(t, err)
 
-			// Attempt a connection to the private IP. The request will always
-			// fail — we only care whether the failure is "private IP blocked"
-			// or something else (TLS, connection refused, context deadline, etc.).
+			// The private-IP guard fires synchronously inside the dialer's control
+			// function, before any TCP packets are sent, so the "private IP address"
+			// error is immediate and deterministic when the guard is active.
+			// When the guard is absent the dial proceeds over the network; the
+			// 500 ms context deadline bounds the test. Any non-guard error
+			// (context deadline exceeded, connection refused, TLS) does not contain
+			// "private IP address", so the NotContains assertion is not vacuous:
+			// an incorrectly-active guard would fail the check immediately.
 			_, dialErr := client.Do(req)
 			require.Error(t, dialErr)
 

--- a/pkg/authserver/upstream/oauth2_test.go
+++ b/pkg/authserver/upstream/oauth2_test.go
@@ -2525,3 +2525,117 @@ func TestBaseOAuth2Provider_ExchangeCodeForIdentity_IdentityFromToken(t *testing
 			"error message must not contain token body content")
 	})
 }
+
+func TestNewHTTPClientForHost(t *testing.T) {
+	t.Parallel()
+
+	// privateIP is an RFC-1918 address unlikely to have a listener; used to
+	// trigger the private-IP dial-block without needing a real server.
+	const privateIP = "10.255.255.1"
+
+	tests := []struct {
+		name            string
+		host            string
+		allowPrivateIPs bool
+		// wantPrivateIPBlocked: when true, dialing privateIP must produce the
+		// "private IP address" error; when false, it must not (any other error,
+		// e.g. connection refused or TLS, is fine).
+		wantPrivateIPBlocked bool
+	}{
+		{
+			name:                 "external host with private IPs disallowed blocks private IP dial",
+			host:                 "external.example.com",
+			allowPrivateIPs:      false,
+			wantPrivateIPBlocked: true,
+		},
+		{
+			name:                 "external host with private IPs allowed passes dial guard",
+			host:                 "external.example.com",
+			allowPrivateIPs:      true,
+			wantPrivateIPBlocked: false,
+		},
+		{
+			name:            "localhost always allows private IPs regardless of flag",
+			host:            "localhost",
+			allowPrivateIPs: false,
+			// localhost sets allowInsecure=true which already sets WithPrivateIPs(true)
+			wantPrivateIPBlocked: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			client, err := newHTTPClientForHost(tt.host, tt.allowPrivateIPs)
+			require.NoError(t, err)
+			require.NotNil(t, client)
+
+			// Use a short deadline so "allowed" cases don't wait for a real TCP
+			// timeout when dialing the unreachable private IP.
+			ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+			t.Cleanup(cancel)
+
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://"+privateIP+":9999", nil)
+			require.NoError(t, err)
+
+			// Attempt a connection to the private IP. The request will always
+			// fail — we only care whether the failure is "private IP blocked"
+			// or something else (TLS, connection refused, context deadline, etc.).
+			_, dialErr := client.Do(req)
+			require.Error(t, dialErr)
+
+			if tt.wantPrivateIPBlocked {
+				assert.Contains(t, dialErr.Error(), "private IP address",
+					"expected private IP to be blocked")
+			} else {
+				assert.NotContains(t, dialErr.Error(), "private IP address",
+					"expected private IP dial to pass the IP guard")
+			}
+		})
+	}
+}
+
+func TestOAuth2Config_AllowPrivateIPs(t *testing.T) {
+	t.Parallel()
+
+	mock := newMockOAuth2Server()
+	t.Cleanup(mock.Close)
+
+	t.Run("AllowPrivateIPs field is propagated to provider", func(t *testing.T) {
+		t.Parallel()
+
+		config := &OAuth2Config{
+			CommonOAuthConfig: CommonOAuthConfig{
+				ClientID:    "test-client",
+				RedirectURI: "http://localhost:8080/callback",
+			},
+			AuthorizationEndpoint: mock.URL + "/authorize",
+			TokenEndpoint:         mock.URL + "/token",
+			AllowPrivateIPs:       true,
+		}
+
+		provider, err := NewOAuth2Provider(config)
+		require.NoError(t, err)
+		require.NotNil(t, provider)
+		assert.True(t, provider.config.AllowPrivateIPs)
+	})
+
+	t.Run("AllowPrivateIPs defaults to false", func(t *testing.T) {
+		t.Parallel()
+
+		config := &OAuth2Config{
+			CommonOAuthConfig: CommonOAuthConfig{
+				ClientID:    "test-client",
+				RedirectURI: "http://localhost:8080/callback",
+			},
+			AuthorizationEndpoint: mock.URL + "/authorize",
+			TokenEndpoint:         mock.URL + "/token",
+		}
+
+		provider, err := NewOAuth2Provider(config)
+		require.NoError(t, err)
+		require.NotNil(t, provider)
+		assert.False(t, provider.config.AllowPrivateIPs)
+	})
+}

--- a/pkg/authserver/upstream/oidc.go
+++ b/pkg/authserver/upstream/oidc.go
@@ -233,6 +233,7 @@ func NewOIDCProvider(
 		CommonOAuthConfig:     commonCfg,
 		AuthorizationEndpoint: p.endpoints.AuthorizationEndpoint,
 		TokenEndpoint:         p.endpoints.TokenEndpoint,
+		AllowPrivateIPs:       config.AllowPrivateIPs,
 	}
 	p.config = oauth2Config
 

--- a/pkg/authserver/upstream/oidc.go
+++ b/pkg/authserver/upstream/oidc.go
@@ -47,6 +47,13 @@ type OIDCConfig struct {
 	// The claim must also be present on refreshed ID tokens — RefreshTokens
 	// resolves through the same path and fails closed if the IdP drops it.
 	SubjectClaim string `json:"subject_claim,omitempty" yaml:"subject_claim,omitempty"`
+
+	// AllowPrivateIPs permits the OIDC discovery and token HTTP clients to
+	// connect to private IP ranges (RFC-1918, link-local). Use only when the
+	// upstream is hosted inside the same cluster and has no public endpoint.
+	// HTTP-scheme restrictions are unchanged — HTTPS is still required for
+	// non-localhost hosts. Defaults to false.
+	AllowPrivateIPs bool `json:"allow_private_ips,omitempty" yaml:"allow_private_ips,omitempty"`
 }
 
 // subjectClaimPattern is the allowed shape for SubjectClaim: a claim-name token
@@ -160,7 +167,7 @@ func NewOIDCProvider(
 
 	// Create HTTP client for the issuer host
 	issuerURL, _ := url.Parse(config.Issuer) // Error already checked in config.Validate()
-	httpClient, err := newHTTPClientForHost(issuerURL.Host)
+	httpClient, err := newHTTPClientForHost(issuerURL.Host, config.AllowPrivateIPs)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create HTTP client: %w", err)
 	}


### PR DESCRIPTION
## Summary

- In-cluster OIDC and OAuth2 providers (e.g. Dex, Keycloak deployed as ClusterIP services) were unreachable because `newHTTPClientForHost()` unconditionally set `WithPrivateIPs(false)` for any non-localhost host. OIDC providers failed immediately at startup during discovery; OAuth2 providers failed at first token exchange. Both failures block in-cluster deployments.
- Adds an `AllowPrivateIPs` boolean flag to `OIDCUpstreamRunConfig`, `OAuth2UpstreamRunConfig`, `upstream.OIDCConfig`, and `upstream.OAuth2Config`. When true, the upstream HTTP clients accept RFC-1918 and link-local addresses. The flag widens only the private-IP gate — the HTTP-scheme restriction is unchanged, so HTTPS remains required for non-localhost hosts.

Closes #5614

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)

New tests cover:
- `TestNewHTTPClientForHost` extended with `allowPrivateIPs` parameter cases
- `TestOAuth2Config_AllowPrivateIPs` — field propagated through `NewOAuth2Provider` and defaults to false
- `buildOIDCConfig` / `buildPureOAuth2Config` propagation tests asserting the flag flows from `RunConfig` to the upstream config struct

## API Compatibility

- [x] This PR does not break the `v1beta1` API, OR the `api-break-allowed` label is applied and the migration guidance is described above.

## Changes

| File | Change |
|------|--------|
| `pkg/authserver/config.go` | Add `AllowPrivateIPs bool` to `OIDCUpstreamRunConfig` and `OAuth2UpstreamRunConfig` |
| `pkg/authserver/upstream/oauth2.go` | Add `AllowPrivateIPs` to `OAuth2Config`; update `newHTTPClientForHost` signature and logic |
| `pkg/authserver/upstream/oidc.go` | Pass `config.AllowPrivateIPs` to `newHTTPClientForHost` and propagate into internal oauth2 config |
| `pkg/authserver/runner/embeddedauthserver.go` | Propagate `AllowPrivateIPs` in `buildOIDCConfig` and `buildPureOAuth2Config` |
| `pkg/authserver/runner/embeddedauthserver_test.go` | Tests for flag propagation through both builder functions |
| `pkg/authserver/upstream/oauth2_test.go` | Tests for `newHTTPClientForHost` with the new parameter and `AllowPrivateIPs` field propagation |

## Does this introduce a user-facing change?

Yes. Operators can now set `allow_private_ips: true` on an OIDC or OAuth2 upstream config block to allow the embedded auth server to reach providers hosted at private IP addresses inside the same Kubernetes cluster.

```yaml
upstreams:
  - name: in-cluster-oidc
    type: oidc
    oidc_config:
      issuer_url: https://dex.my-namespace.svc.cluster.local:5556
      client_id: my-client
      client_secret_file: /var/run/secrets/client_secret
      allow_private_ips: true
```

## Special notes for reviewers

The fix intentionally does not widen the HTTP-scheme gate. `WithInsecureAllowHTTP` is still keyed only on localhost or `INSECURE_DISABLE_URL_VALIDATION`, so `AllowPrivateIPs: true` permits `https://10.96.x.x:5556` but still rejects `http://10.96.x.x:5556`. The two properties are orthogonal: private-IP reachability vs. plaintext transport.

The pattern follows the existing serializable security-override convention used for Redis TLS (`InsecureSkipVerify` in `storage/config.go`).

Generated with [Claude Code](https://claude.com/claude-code)
