### PR TITLE
Mount and validate OIDC CA bundle on remote proxy

### DIFF
--- a/cmd/thv-operator/api/v1beta1/mcpremoteproxy_types.go
+++ b/cmd/thv-operator/api/v1beta1/mcpremoteproxy_types.go
@@ -292,6 +292,9 @@ const (
 	// ConditionTypeMCPRemoteProxyAuthServerRefValidated indicates whether the AuthServerRef is valid
 	ConditionTypeMCPRemoteProxyAuthServerRefValidated = "AuthServerRefValidated"
 
+	// ConditionTypeMCPRemoteProxyCABundleRefValidated indicates whether the OIDC CA bundle reference is valid
+	ConditionTypeMCPRemoteProxyCABundleRefValidated = "CABundleRefValidated"
+
 	// ConditionTypeConfigurationValid indicates whether the proxy spec has passed all pre-deployment validation checks
 	ConditionTypeConfigurationValid = "ConfigurationValid"
 )
@@ -379,6 +382,15 @@ const (
 
 	// ConditionReasonMCPRemoteProxyAuthServerRefMultiUpstream indicates multi-upstream is not supported
 	ConditionReasonMCPRemoteProxyAuthServerRefMultiUpstream = "MultiUpstreamNotSupported"
+
+	// ConditionReasonMCPRemoteProxyCABundleRefValid indicates the CA bundle ref is valid and the ConfigMap exists
+	ConditionReasonMCPRemoteProxyCABundleRefValid = "CABundleRefValid"
+
+	// ConditionReasonMCPRemoteProxyCABundleRefNotFound indicates the referenced CA bundle ConfigMap was not found
+	ConditionReasonMCPRemoteProxyCABundleRefNotFound = "CABundleRefNotFound"
+
+	// ConditionReasonMCPRemoteProxyCABundleRefInvalid indicates the CA bundle ref configuration is invalid
+	ConditionReasonMCPRemoteProxyCABundleRefInvalid = "CABundleRefInvalid"
 
 	// ConditionReasonConfigurationValid indicates all configuration validations passed
 	ConditionReasonConfigurationValid = "ConfigurationValid"

--- a/cmd/thv-operator/controllers/mcpremoteproxy_cabundle_test.go
+++ b/cmd/thv-operator/controllers/mcpremoteproxy_cabundle_test.go
@@ -148,6 +148,25 @@ func TestMCPRemoteProxyValidateCABundleRef(t *testing.T) {
 			oidcConfig:        newOIDCConfigWithCABundle(nil),
 			expectNoCondition: true,
 		},
+		{
+			// OIDCConfig cannot be resolved (object absent → fetch error). The existing
+			// condition must NOT be cleared on a transient failure; handleOIDCConfig owns
+			// the OIDCConfigRef failure and requeues.
+			name: "transient OIDCConfig fetch error leaves the existing condition untouched",
+			proxy: v1beta1test.NewMCPRemoteProxy("p", testCABundleNamespace,
+				v1beta1test.WithRemoteProxyOIDCConfigRef(testProxyOIDCConfigName, "aud"),
+				v1beta1test.WithRemoteProxyStatus(mcpv1beta1.MCPRemoteProxyStatus{
+					Conditions: []metav1.Condition{{
+						Type:   mcpv1beta1.ConditionTypeMCPRemoteProxyCABundleRefValidated,
+						Status: metav1.ConditionTrue,
+						Reason: mcpv1beta1.ConditionReasonMCPRemoteProxyCABundleRefValid,
+					}},
+				}),
+			),
+			oidcConfig:         nil, // absent from the client → GetOIDCConfigForServer errors
+			expectedCondStatus: metav1.ConditionTrue,
+			expectedCondReason: mcpv1beta1.ConditionReasonMCPRemoteProxyCABundleRefValid,
+		},
 	}
 
 	for _, tt := range tests {
@@ -202,6 +221,7 @@ func TestAddOIDCCABundleVolumes(t *testing.T) {
 		proxy       *mcpv1beta1.MCPRemoteProxy
 		oidcConfig  *mcpv1beta1.MCPOIDCConfig
 		expectMount bool
+		expectNilM  bool // build aborts (returns nil) on a transient OIDCConfig fetch error
 	}{
 		{
 			name:        "no OIDCConfigRef mounts nothing",
@@ -217,12 +237,13 @@ func TestAddOIDCCABundleVolumes(t *testing.T) {
 		},
 		{
 			// OIDCConfigRef set but the MCPOIDCConfig object is absent: the fetch
-			// errors, addOIDCCABundleVolumes logs and returns, so nothing is mounted.
-			name: "OIDCConfigRef set but MCPOIDCConfig missing mounts nothing",
+			// errors, so the build aborts (returns nil) rather than producing a
+			// CA-less Deployment that would crash-loop.
+			name: "OIDCConfigRef set but MCPOIDCConfig missing aborts the build",
 			proxy: v1beta1test.NewMCPRemoteProxy("p", testCABundleNamespace,
 				v1beta1test.WithRemoteProxyOIDCConfigRef(testProxyOIDCConfigName, "aud")),
-			oidcConfig:  nil,
-			expectMount: false,
+			oidcConfig: nil,
+			expectNilM: true,
 		},
 		{
 			name: "OIDCConfig with CA bundle mounts the ConfigMap",
@@ -251,6 +272,10 @@ func TestAddOIDCCABundleVolumes(t *testing.T) {
 			}
 
 			dep := reconciler.deploymentForMCPRemoteProxy(t.Context(), tt.proxy, "test-checksum")
+			if tt.expectNilM {
+				assert.Nil(t, dep, "build should abort (nil) on a transient OIDCConfig fetch error")
+				return
+			}
 			require.NotNil(t, dep)
 
 			expectedVolumeName := validation.OIDCCABundleVolumePrefix + testCABundleConfigMapName

--- a/cmd/thv-operator/controllers/mcpremoteproxy_cabundle_test.go
+++ b/cmd/thv-operator/controllers/mcpremoteproxy_cabundle_test.go
@@ -46,12 +46,12 @@ func newOIDCConfigWithCABundle(caRef *mcpv1beta1.CABundleSource) *mcpv1beta1.MCP
 	}
 }
 
-// caBundleConfigMap builds the CA bundle ConfigMap in the test namespace with the
-// given key holding a dummy certificate.
-func caBundleConfigMap(key string) *corev1.ConfigMap {
+// caBundleConfigMap builds the CA bundle ConfigMap in the test namespace holding a
+// dummy certificate under the default CA bundle key.
+func caBundleConfigMap() *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{Name: testCABundleConfigMapName, Namespace: testCABundleNamespace},
-		Data:       map[string]string{key: "cert"},
+		Data:       map[string]string{validation.OIDCCABundleDefaultKey: "cert"},
 	}
 }
 
@@ -95,7 +95,7 @@ func TestMCPRemoteProxyValidateCABundleRef(t *testing.T) {
 			proxy: v1beta1test.NewMCPRemoteProxy("p", testCABundleNamespace,
 				v1beta1test.WithRemoteProxyOIDCConfigRef(testProxyOIDCConfigName, "aud")),
 			oidcConfig:         newOIDCConfigWithCABundle(configMapCABundleRef(testCABundleConfigMapName, "ca.crt")),
-			configMap:          caBundleConfigMap("ca.crt"),
+			configMap:          caBundleConfigMap(),
 			expectedCondStatus: metav1.ConditionTrue,
 			expectedCondReason: mcpv1beta1.ConditionReasonMCPRemoteProxyCABundleRefValid,
 		},
@@ -104,7 +104,7 @@ func TestMCPRemoteProxyValidateCABundleRef(t *testing.T) {
 			proxy: v1beta1test.NewMCPRemoteProxy("p", testCABundleNamespace,
 				v1beta1test.WithRemoteProxyOIDCConfigRef(testProxyOIDCConfigName, "aud")),
 			oidcConfig:         newOIDCConfigWithCABundle(configMapCABundleRef(testCABundleConfigMapName, "")),
-			configMap:          caBundleConfigMap(validation.OIDCCABundleDefaultKey),
+			configMap:          caBundleConfigMap(),
 			expectedCondStatus: metav1.ConditionTrue,
 			expectedCondReason: mcpv1beta1.ConditionReasonMCPRemoteProxyCABundleRefValid,
 		},
@@ -129,7 +129,7 @@ func TestMCPRemoteProxyValidateCABundleRef(t *testing.T) {
 			proxy: v1beta1test.NewMCPRemoteProxy("p", testCABundleNamespace,
 				v1beta1test.WithRemoteProxyOIDCConfigRef(testProxyOIDCConfigName, "aud")),
 			oidcConfig:         newOIDCConfigWithCABundle(configMapCABundleRef(testCABundleConfigMapName, "missing-key")),
-			configMap:          caBundleConfigMap("ca.crt"),
+			configMap:          caBundleConfigMap(),
 			expectedCondStatus: metav1.ConditionFalse,
 			expectedCondReason: mcpv1beta1.ConditionReasonMCPRemoteProxyCABundleRefInvalid,
 		},
@@ -216,6 +216,15 @@ func TestAddOIDCCABundleVolumes(t *testing.T) {
 			expectMount: false,
 		},
 		{
+			// OIDCConfigRef set but the MCPOIDCConfig object is absent: the fetch
+			// errors, addOIDCCABundleVolumes logs and returns, so nothing is mounted.
+			name: "OIDCConfigRef set but MCPOIDCConfig missing mounts nothing",
+			proxy: v1beta1test.NewMCPRemoteProxy("p", testCABundleNamespace,
+				v1beta1test.WithRemoteProxyOIDCConfigRef(testProxyOIDCConfigName, "aud")),
+			oidcConfig:  nil,
+			expectMount: false,
+		},
+		{
 			name: "OIDCConfig with CA bundle mounts the ConfigMap",
 			proxy: v1beta1test.NewMCPRemoteProxy("p", testCABundleNamespace,
 				v1beta1test.WithRemoteProxyOIDCConfigRef(testProxyOIDCConfigName, "aud")),
@@ -276,4 +285,48 @@ func containerVolumeMounts(dep *appsv1.Deployment) []corev1.VolumeMount {
 		return nil
 	}
 	return dep.Spec.Template.Spec.Containers[0].VolumeMounts
+}
+
+// TestMCPRemoteProxyValidateCABundleRefIdempotent asserts that a second validation
+// pass over a steady-state proxy performs no status write (resourceVersion unchanged),
+// per the operator idempotency rule.
+func TestMCPRemoteProxyValidateCABundleRefIdempotent(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	scheme := testutil.NewScheme(t)
+	proxy := v1beta1test.NewMCPRemoteProxy("p", testCABundleNamespace,
+		v1beta1test.WithRemoteProxyOIDCConfigRef(testProxyOIDCConfigName, "aud"))
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&mcpv1beta1.MCPRemoteProxy{}).
+		WithObjects(
+			proxy,
+			newOIDCConfigWithCABundle(configMapCABundleRef(testCABundleConfigMapName, "ca.crt")),
+			caBundleConfigMap(),
+		).
+		Build()
+
+	reconciler := &MCPRemoteProxyReconciler{Client: fakeClient, Scheme: scheme}
+	key := types.NamespacedName{Name: proxy.Name, Namespace: proxy.Namespace}
+
+	// First pass reconciles to steady state and persists the True condition.
+	first := &mcpv1beta1.MCPRemoteProxy{}
+	require.NoError(t, fakeClient.Get(ctx, key, first))
+	reconciler.validateCABundleRef(ctx, first)
+
+	afterFirst := &mcpv1beta1.MCPRemoteProxy{}
+	require.NoError(t, fakeClient.Get(ctx, key, afterFirst))
+	require.NotNil(t,
+		meta.FindStatusCondition(afterFirst.Status.Conditions, mcpv1beta1.ConditionTypeMCPRemoteProxyCABundleRefValidated),
+		"first pass should set the CABundleRefValidated condition")
+	steadyRV := afterFirst.ResourceVersion
+
+	// Second pass over the now-steady object must not write status again.
+	reconciler.validateCABundleRef(ctx, afterFirst)
+
+	afterSecond := &mcpv1beta1.MCPRemoteProxy{}
+	require.NoError(t, fakeClient.Get(ctx, key, afterSecond))
+	assert.Equal(t, steadyRV, afterSecond.ResourceVersion,
+		"steady-state reconcile must not bump resourceVersion")
 }

--- a/cmd/thv-operator/controllers/mcpremoteproxy_cabundle_test.go
+++ b/cmd/thv-operator/controllers/mcpremoteproxy_cabundle_test.go
@@ -1,0 +1,279 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package controllers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1/v1beta1test"
+	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
+	ctrlutil "github.com/stacklok/toolhive/cmd/thv-operator/pkg/controllerutil"
+	"github.com/stacklok/toolhive/cmd/thv-operator/pkg/validation"
+)
+
+const (
+	testCABundleConfigMapName = "oidc-ca-bundle-cm"
+	testProxyOIDCConfigName   = "proxy-oidc"
+	testCABundleNamespace     = "default"
+)
+
+// newOIDCConfigWithCABundle builds an inline MCPOIDCConfig in the test namespace,
+// optionally carrying a CA bundle reference. A nil caRef produces an inline config
+// with no CA bundle.
+func newOIDCConfigWithCABundle(caRef *mcpv1beta1.CABundleSource) *mcpv1beta1.MCPOIDCConfig {
+	return &mcpv1beta1.MCPOIDCConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: testProxyOIDCConfigName, Namespace: testCABundleNamespace},
+		Spec: mcpv1beta1.MCPOIDCConfigSpec{
+			Type: mcpv1beta1.MCPOIDCConfigTypeInline,
+			Inline: &mcpv1beta1.InlineOIDCSharedConfig{
+				Issuer:      "https://auth.example.com",
+				ClientID:    "test-client",
+				CABundleRef: caRef,
+			},
+		},
+	}
+}
+
+// caBundleConfigMap builds the CA bundle ConfigMap in the test namespace with the
+// given key holding a dummy certificate.
+func caBundleConfigMap(key string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: testCABundleConfigMapName, Namespace: testCABundleNamespace},
+		Data:       map[string]string{key: "cert"},
+	}
+}
+
+func configMapCABundleRef(name, key string) *mcpv1beta1.CABundleSource {
+	return &mcpv1beta1.CABundleSource{
+		ConfigMapRef: &corev1.ConfigMapKeySelector{
+			LocalObjectReference: corev1.LocalObjectReference{Name: name},
+			Key:                  key,
+		},
+	}
+}
+
+// TestMCPRemoteProxyValidateCABundleRef covers the OIDC CA bundle reference validation
+// that mirrors MCPServer, including the persisted CABundleRefValidated condition.
+func TestMCPRemoteProxyValidateCABundleRef(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name               string
+		proxy              *mcpv1beta1.MCPRemoteProxy
+		oidcConfig         *mcpv1beta1.MCPOIDCConfig
+		configMap          *corev1.ConfigMap
+		expectNoCondition  bool
+		expectedCondStatus metav1.ConditionStatus
+		expectedCondReason string
+	}{
+		{
+			name:              "no OIDCConfigRef sets no condition",
+			proxy:             v1beta1test.NewMCPRemoteProxy("p", testCABundleNamespace),
+			expectNoCondition: true,
+		},
+		{
+			name: "OIDCConfig without CA bundle sets no condition",
+			proxy: v1beta1test.NewMCPRemoteProxy("p", testCABundleNamespace,
+				v1beta1test.WithRemoteProxyOIDCConfigRef(testProxyOIDCConfigName, "aud")),
+			oidcConfig:        newOIDCConfigWithCABundle(nil),
+			expectNoCondition: true,
+		},
+		{
+			name: "valid CA bundle with existing ConfigMap and key",
+			proxy: v1beta1test.NewMCPRemoteProxy("p", testCABundleNamespace,
+				v1beta1test.WithRemoteProxyOIDCConfigRef(testProxyOIDCConfigName, "aud")),
+			oidcConfig:         newOIDCConfigWithCABundle(configMapCABundleRef(testCABundleConfigMapName, "ca.crt")),
+			configMap:          caBundleConfigMap("ca.crt"),
+			expectedCondStatus: metav1.ConditionTrue,
+			expectedCondReason: mcpv1beta1.ConditionReasonMCPRemoteProxyCABundleRefValid,
+		},
+		{
+			name: "valid CA bundle with empty key defaults to ca.crt",
+			proxy: v1beta1test.NewMCPRemoteProxy("p", testCABundleNamespace,
+				v1beta1test.WithRemoteProxyOIDCConfigRef(testProxyOIDCConfigName, "aud")),
+			oidcConfig:         newOIDCConfigWithCABundle(configMapCABundleRef(testCABundleConfigMapName, "")),
+			configMap:          caBundleConfigMap(validation.OIDCCABundleDefaultKey),
+			expectedCondStatus: metav1.ConditionTrue,
+			expectedCondReason: mcpv1beta1.ConditionReasonMCPRemoteProxyCABundleRefValid,
+		},
+		{
+			name: "CA bundle with empty ConfigMap name is invalid",
+			proxy: v1beta1test.NewMCPRemoteProxy("p", testCABundleNamespace,
+				v1beta1test.WithRemoteProxyOIDCConfigRef(testProxyOIDCConfigName, "aud")),
+			oidcConfig:         newOIDCConfigWithCABundle(configMapCABundleRef("", "ca.crt")),
+			expectedCondStatus: metav1.ConditionFalse,
+			expectedCondReason: mcpv1beta1.ConditionReasonMCPRemoteProxyCABundleRefInvalid,
+		},
+		{
+			name: "CA bundle referencing missing ConfigMap is not found",
+			proxy: v1beta1test.NewMCPRemoteProxy("p", testCABundleNamespace,
+				v1beta1test.WithRemoteProxyOIDCConfigRef(testProxyOIDCConfigName, "aud")),
+			oidcConfig:         newOIDCConfigWithCABundle(configMapCABundleRef("does-not-exist", "ca.crt")),
+			expectedCondStatus: metav1.ConditionFalse,
+			expectedCondReason: mcpv1beta1.ConditionReasonMCPRemoteProxyCABundleRefNotFound,
+		},
+		{
+			name: "CA bundle with missing key in ConfigMap is invalid",
+			proxy: v1beta1test.NewMCPRemoteProxy("p", testCABundleNamespace,
+				v1beta1test.WithRemoteProxyOIDCConfigRef(testProxyOIDCConfigName, "aud")),
+			oidcConfig:         newOIDCConfigWithCABundle(configMapCABundleRef(testCABundleConfigMapName, "missing-key")),
+			configMap:          caBundleConfigMap("ca.crt"),
+			expectedCondStatus: metav1.ConditionFalse,
+			expectedCondReason: mcpv1beta1.ConditionReasonMCPRemoteProxyCABundleRefInvalid,
+		},
+		{
+			name: "stale condition is cleared when CA bundle is removed",
+			proxy: v1beta1test.NewMCPRemoteProxy("p", testCABundleNamespace,
+				v1beta1test.WithRemoteProxyOIDCConfigRef(testProxyOIDCConfigName, "aud"),
+				v1beta1test.WithRemoteProxyStatus(mcpv1beta1.MCPRemoteProxyStatus{
+					Conditions: []metav1.Condition{{
+						Type:   mcpv1beta1.ConditionTypeMCPRemoteProxyCABundleRefValidated,
+						Status: metav1.ConditionTrue,
+						Reason: mcpv1beta1.ConditionReasonMCPRemoteProxyCABundleRefValid,
+					}},
+				}),
+			),
+			oidcConfig:        newOIDCConfigWithCABundle(nil),
+			expectNoCondition: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := t.Context()
+
+			scheme := testutil.NewScheme(t)
+			builder := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithStatusSubresource(&mcpv1beta1.MCPRemoteProxy{}).
+				WithObjects(tt.proxy)
+			if tt.oidcConfig != nil {
+				builder = builder.WithObjects(tt.oidcConfig)
+			}
+			if tt.configMap != nil {
+				builder = builder.WithObjects(tt.configMap)
+			}
+			fakeClient := builder.Build()
+
+			reconciler := &MCPRemoteProxyReconciler{Client: fakeClient, Scheme: scheme}
+			reconciler.validateCABundleRef(ctx, tt.proxy)
+
+			persisted := &mcpv1beta1.MCPRemoteProxy{}
+			require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{
+				Name: tt.proxy.Name, Namespace: tt.proxy.Namespace,
+			}, persisted))
+
+			cond := meta.FindStatusCondition(persisted.Status.Conditions,
+				mcpv1beta1.ConditionTypeMCPRemoteProxyCABundleRefValidated)
+
+			if tt.expectNoCondition {
+				assert.Nil(t, cond, "CABundleRefValidated condition should not be present")
+				return
+			}
+
+			require.NotNil(t, cond, "expected CABundleRefValidated condition to be set")
+			assert.Equal(t, tt.expectedCondStatus, cond.Status)
+			assert.Equal(t, tt.expectedCondReason, cond.Reason)
+		})
+	}
+}
+
+// TestAddOIDCCABundleVolumes verifies the deployment mounts the OIDC CA bundle
+// ConfigMap when the referenced MCPOIDCConfig declares one, so the runner pod can
+// read the CA file at the path the RunConfig points it at.
+func TestAddOIDCCABundleVolumes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		proxy       *mcpv1beta1.MCPRemoteProxy
+		oidcConfig  *mcpv1beta1.MCPOIDCConfig
+		expectMount bool
+	}{
+		{
+			name:        "no OIDCConfigRef mounts nothing",
+			proxy:       v1beta1test.NewMCPRemoteProxy("p", testCABundleNamespace),
+			expectMount: false,
+		},
+		{
+			name: "OIDCConfig without CA bundle mounts nothing",
+			proxy: v1beta1test.NewMCPRemoteProxy("p", testCABundleNamespace,
+				v1beta1test.WithRemoteProxyOIDCConfigRef(testProxyOIDCConfigName, "aud")),
+			oidcConfig:  newOIDCConfigWithCABundle(nil),
+			expectMount: false,
+		},
+		{
+			name: "OIDCConfig with CA bundle mounts the ConfigMap",
+			proxy: v1beta1test.NewMCPRemoteProxy("p", testCABundleNamespace,
+				v1beta1test.WithRemoteProxyOIDCConfigRef(testProxyOIDCConfigName, "aud")),
+			oidcConfig:  newOIDCConfigWithCABundle(configMapCABundleRef(testCABundleConfigMapName, "ca.crt")),
+			expectMount: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			scheme := testutil.NewScheme(t)
+			builder := fake.NewClientBuilder().WithScheme(scheme).WithObjects(tt.proxy)
+			if tt.oidcConfig != nil {
+				builder = builder.WithObjects(tt.oidcConfig)
+			}
+			var fakeClient client.Client = builder.Build()
+
+			reconciler := &MCPRemoteProxyReconciler{
+				Client:           fakeClient,
+				Scheme:           scheme,
+				PlatformDetector: ctrlutil.NewSharedPlatformDetector(),
+			}
+
+			dep := reconciler.deploymentForMCPRemoteProxy(t.Context(), tt.proxy, "test-checksum")
+			require.NotNil(t, dep)
+
+			expectedVolumeName := validation.OIDCCABundleVolumePrefix + testCABundleConfigMapName
+			expectedMountPath := validation.OIDCCABundleMountBasePath + "/" + testCABundleConfigMapName
+
+			hasVolume := false
+			for _, v := range dep.Spec.Template.Spec.Volumes {
+				if v.Name == expectedVolumeName {
+					hasVolume = true
+					require.NotNil(t, v.ConfigMap, "CA bundle volume must source from a ConfigMap")
+					assert.Equal(t, testCABundleConfigMapName, v.ConfigMap.Name)
+				}
+			}
+
+			hasMount := false
+			for _, m := range containerVolumeMounts(dep) {
+				if m.Name == expectedVolumeName {
+					hasMount = true
+					assert.Equal(t, expectedMountPath, m.MountPath)
+					assert.True(t, m.ReadOnly, "CA bundle mount must be read-only")
+				}
+			}
+
+			assert.Equal(t, tt.expectMount, hasVolume, "volume presence mismatch")
+			assert.Equal(t, tt.expectMount, hasMount, "mount presence mismatch")
+		})
+	}
+}
+
+func containerVolumeMounts(dep *appsv1.Deployment) []corev1.VolumeMount {
+	if len(dep.Spec.Template.Spec.Containers) == 0 {
+		return nil
+	}
+	return dep.Spec.Template.Spec.Containers[0].VolumeMounts
+}

--- a/cmd/thv-operator/controllers/mcpremoteproxy_controller.go
+++ b/cmd/thv-operator/controllers/mcpremoteproxy_controller.go
@@ -124,6 +124,9 @@ func (r *MCPRemoteProxyReconciler) validateAndHandleConfigs(ctx context.Context,
 	// Validate the GroupRef if specified
 	r.validateGroupRef(ctx, proxy)
 
+	// Validate the OIDC CA bundle reference if specified
+	r.validateCABundleRef(ctx, proxy)
+
 	// Surface advisory condition when primaryUpstreamProvider is set but ignored
 	r.validateAuthzPrimaryUpstreamProviderIgnored(proxy)
 
@@ -1074,6 +1077,111 @@ func (r *MCPRemoteProxyReconciler) validateGroupRef(ctx context.Context, proxy *
 			Message:            fmt.Sprintf("MCPGroup '%s' is valid and ready", groupName),
 			ObservedGeneration: proxy.Generation,
 		})
+	}
+}
+
+// validateCABundleRef validates the OIDC CA bundle ConfigMap reference if specified.
+// The CA bundle is sourced from the referenced MCPOIDCConfig's inline configuration.
+// It mirrors MCPServer.validateCABundleRef so the proxy surfaces the same
+// CABundleRefValidated condition (see the Status Condition Parity rule). Like
+// validateGroupRef this sets the condition, but — like MCPServer — it also persists
+// status itself so a CA bundle ConfigMap appearing or disappearing is reflected even
+// when no other handler triggers a status write this reconcile.
+func (r *MCPRemoteProxyReconciler) validateCABundleRef(ctx context.Context, proxy *mcpv1beta1.MCPRemoteProxy) {
+	caBundleRef := r.resolveOIDCCABundleRef(ctx, proxy)
+	if caBundleRef == nil || caBundleRef.ConfigMapRef == nil {
+		// No CA bundle configured - clear any stale condition from a prior reconcile.
+		if meta.FindStatusCondition(proxy.Status.Conditions, mcpv1beta1.ConditionTypeMCPRemoteProxyCABundleRefValidated) != nil {
+			meta.RemoveStatusCondition(&proxy.Status.Conditions, mcpv1beta1.ConditionTypeMCPRemoteProxyCABundleRefValidated)
+			r.updateCABundleStatus(ctx, proxy)
+		}
+		return
+	}
+
+	ctxLogger := log.FromContext(ctx)
+
+	// Validate the CABundleRef configuration
+	if err := validation.ValidateCABundleSource(caBundleRef); err != nil {
+		ctxLogger.Error(err, "Invalid CABundleRef configuration")
+		setRemoteProxyCABundleRefCondition(proxy, metav1.ConditionFalse,
+			mcpv1beta1.ConditionReasonMCPRemoteProxyCABundleRefInvalid, err.Error())
+		r.updateCABundleStatus(ctx, proxy)
+		return
+	}
+
+	// Check if the referenced ConfigMap exists
+	cmName := caBundleRef.ConfigMapRef.Name
+	configMap := &corev1.ConfigMap{}
+	if err := r.Get(ctx, types.NamespacedName{Namespace: proxy.Namespace, Name: cmName}, configMap); err != nil {
+		ctxLogger.Error(err, "Failed to find CA bundle ConfigMap", "configMap", cmName)
+		setRemoteProxyCABundleRefCondition(proxy, metav1.ConditionFalse,
+			mcpv1beta1.ConditionReasonMCPRemoteProxyCABundleRefNotFound,
+			fmt.Sprintf("CA bundle ConfigMap '%s' not found in namespace '%s'", cmName, proxy.Namespace))
+		r.updateCABundleStatus(ctx, proxy)
+		return
+	}
+
+	// Verify the key exists in the ConfigMap
+	key := caBundleRef.ConfigMapRef.Key
+	if key == "" {
+		key = validation.OIDCCABundleDefaultKey
+	}
+	if _, exists := configMap.Data[key]; !exists {
+		ctxLogger.Error(nil, "CA bundle key not found in ConfigMap", "configMap", cmName, "key", key)
+		setRemoteProxyCABundleRefCondition(proxy, metav1.ConditionFalse,
+			mcpv1beta1.ConditionReasonMCPRemoteProxyCABundleRefInvalid,
+			fmt.Sprintf("Key '%s' not found in ConfigMap '%s'", key, cmName))
+		r.updateCABundleStatus(ctx, proxy)
+		return
+	}
+
+	// Validation passed
+	setRemoteProxyCABundleRefCondition(proxy, metav1.ConditionTrue,
+		mcpv1beta1.ConditionReasonMCPRemoteProxyCABundleRefValid,
+		fmt.Sprintf("CA bundle ConfigMap '%s' is valid (key: %s)", cmName, key))
+	r.updateCABundleStatus(ctx, proxy)
+}
+
+// resolveOIDCCABundleRef returns the CA bundle reference from the proxy's referenced
+// MCPOIDCConfig inline configuration, or nil if none is configured or the config
+// cannot be resolved. A fetch error returns nil: the OIDCConfigRef lookup is
+// validated authoritatively in handleOIDCConfig, so this avoids a duplicate failure
+// surface on the CABundleRefValidated condition.
+func (r *MCPRemoteProxyReconciler) resolveOIDCCABundleRef(
+	ctx context.Context, proxy *mcpv1beta1.MCPRemoteProxy,
+) *mcpv1beta1.CABundleSource {
+	if proxy.Spec.OIDCConfigRef == nil {
+		return nil
+	}
+	oidcCfg, err := ctrlutil.GetOIDCConfigForServer(ctx, r.Client, proxy.Namespace, proxy.Spec.OIDCConfigRef)
+	if err != nil || oidcCfg == nil {
+		return nil
+	}
+	if oidcCfg.Spec.Type != mcpv1beta1.MCPOIDCConfigTypeInline || oidcCfg.Spec.Inline == nil {
+		return nil
+	}
+	return oidcCfg.Spec.Inline.CABundleRef
+}
+
+// setRemoteProxyCABundleRefCondition sets the CA bundle ref validation condition on the proxy.
+func setRemoteProxyCABundleRefCondition(
+	proxy *mcpv1beta1.MCPRemoteProxy, status metav1.ConditionStatus, reason, message string,
+) {
+	meta.SetStatusCondition(&proxy.Status.Conditions, metav1.Condition{
+		Type:               mcpv1beta1.ConditionTypeMCPRemoteProxyCABundleRefValidated,
+		Status:             status,
+		Reason:             reason,
+		Message:            message,
+		ObservedGeneration: proxy.Generation,
+	})
+}
+
+// updateCABundleStatus persists the proxy status after CA bundle validation. The error
+// is logged and swallowed: the CABundleRefValidated condition is advisory, and a failed
+// write is healed on the next reconcile rather than blocking the reconcile's objective.
+func (r *MCPRemoteProxyReconciler) updateCABundleStatus(ctx context.Context, proxy *mcpv1beta1.MCPRemoteProxy) {
+	if err := r.Status().Update(ctx, proxy); err != nil {
+		log.FromContext(ctx).Error(err, "Failed to update MCPRemoteProxy status after CABundleRef validation")
 	}
 }
 

--- a/cmd/thv-operator/controllers/mcpremoteproxy_controller.go
+++ b/cmd/thv-operator/controllers/mcpremoteproxy_controller.go
@@ -1083,34 +1083,38 @@ func (r *MCPRemoteProxyReconciler) validateGroupRef(ctx context.Context, proxy *
 // validateCABundleRef validates the OIDC CA bundle ConfigMap reference if specified.
 // The CA bundle is sourced from the referenced MCPOIDCConfig's inline configuration.
 // It mirrors MCPServer.validateCABundleRef so the proxy surfaces the same
-// CABundleRefValidated condition (see the Status Condition Parity rule), but persists
-// status only when the condition actually changes so a steady-state reconcile is a
-// no-op — matching the needsUpdate idiom used by handleOIDCConfig in this file and the
-// idempotency rule in operator.md, rather than MCPServer's unconditional status write.
+// CABundleRefValidated condition (see the Status Condition Parity rule).
+//
+// Writes go through MutateAndPatchStatus (per the operator.md Status Writes rule),
+// which diffs and skips the wire call when nothing changed, so a steady-state
+// reconcile is a no-op (idempotency) and only the condition is patched rather than
+// the whole status PUT.
+//
+// This validator runs before handleOIDCConfig, which is the authoritative validator
+// for the OIDCConfigRef itself. So when the MCPOIDCConfig cannot be resolved (e.g. a
+// transient apiserver/cache error), it leaves the existing condition untouched and
+// lets handleOIDCConfig's requeue drive recovery — clearing the condition only when
+// the config resolves and genuinely has no CA bundle.
 func (r *MCPRemoteProxyReconciler) validateCABundleRef(ctx context.Context, proxy *mcpv1beta1.MCPRemoteProxy) {
 	condType := mcpv1beta1.ConditionTypeMCPRemoteProxyCABundleRefValidated
-	prev := meta.FindStatusCondition(proxy.Status.Conditions, condType)
 
-	caBundleRef := r.resolveOIDCCABundleRef(ctx, proxy)
+	caBundleRef, resolved := r.resolveOIDCCABundleRef(ctx, proxy)
+	if !resolved {
+		// Could not resolve the MCPOIDCConfig; leave any existing condition in place.
+		return
+	}
 	if caBundleRef == nil || caBundleRef.ConfigMapRef == nil {
-		// No CA bundle configured - clear any stale condition from a prior reconcile.
-		if prev != nil {
-			meta.RemoveStatusCondition(&proxy.Status.Conditions, condType)
-			r.updateCABundleStatus(ctx, proxy)
-		}
+		// Config resolved and has no CA bundle: clear any stale condition.
+		r.patchCABundleStatus(ctx, proxy, func(p *mcpv1beta1.MCPRemoteProxy) {
+			meta.RemoveStatusCondition(&p.Status.Conditions, condType)
+		})
 		return
 	}
 
 	status, reason, message := r.evaluateCABundleRef(ctx, proxy, caBundleRef)
-	setRemoteProxyCABundleRefCondition(proxy, status, reason, message)
-
-	if prev == nil ||
-		prev.Status != status ||
-		prev.Reason != reason ||
-		prev.Message != message ||
-		prev.ObservedGeneration != proxy.Generation {
-		r.updateCABundleStatus(ctx, proxy)
-	}
+	r.patchCABundleStatus(ctx, proxy, func(p *mcpv1beta1.MCPRemoteProxy) {
+		setRemoteProxyCABundleRefCondition(p, status, reason, message)
+	})
 }
 
 // evaluateCABundleRef checks the referenced CA bundle ConfigMap and returns the
@@ -1154,24 +1158,27 @@ func (r *MCPRemoteProxyReconciler) evaluateCABundleRef(
 }
 
 // resolveOIDCCABundleRef returns the CA bundle reference from the proxy's referenced
-// MCPOIDCConfig inline configuration, or nil if none is configured or the config
-// cannot be resolved. A fetch error returns nil: the OIDCConfigRef lookup is
-// validated authoritatively in handleOIDCConfig, so this avoids a duplicate failure
-// surface on the CABundleRefValidated condition.
+// MCPOIDCConfig inline configuration. The bool reports whether the OIDC config was
+// successfully resolved: (nil, true) means "resolved, no CA bundle" and (nil, false)
+// means "could not resolve" (no ref, or a transient fetch error). The caller must not
+// clear the condition when resolved is false, to avoid flapping it on a transient
+// apiserver/cache error — handleOIDCConfig is the authoritative validator for the ref.
 func (r *MCPRemoteProxyReconciler) resolveOIDCCABundleRef(
 	ctx context.Context, proxy *mcpv1beta1.MCPRemoteProxy,
-) *mcpv1beta1.CABundleSource {
+) (ref *mcpv1beta1.CABundleSource, resolved bool) {
 	if proxy.Spec.OIDCConfigRef == nil {
-		return nil
+		// No OIDC reference at all: there is nothing to resolve and no CA bundle, so
+		// the condition should be cleared. Treat as resolved with no CA bundle.
+		return nil, true
 	}
 	oidcCfg, err := ctrlutil.GetOIDCConfigForServer(ctx, r.Client, proxy.Namespace, proxy.Spec.OIDCConfigRef)
 	if err != nil || oidcCfg == nil {
-		return nil
+		return nil, false
 	}
 	if oidcCfg.Spec.Type != mcpv1beta1.MCPOIDCConfigTypeInline || oidcCfg.Spec.Inline == nil {
-		return nil
+		return nil, true
 	}
-	return oidcCfg.Spec.Inline.CABundleRef
+	return oidcCfg.Spec.Inline.CABundleRef, true
 }
 
 // setRemoteProxyCABundleRefCondition sets the CA bundle ref validation condition on the proxy.
@@ -1187,11 +1194,14 @@ func setRemoteProxyCABundleRefCondition(
 	})
 }
 
-// updateCABundleStatus persists the proxy status after CA bundle validation. The error
-// is logged and swallowed: the CABundleRefValidated condition is advisory, and a failed
-// write is healed on the next reconcile rather than blocking the reconcile's objective.
-func (r *MCPRemoteProxyReconciler) updateCABundleStatus(ctx context.Context, proxy *mcpv1beta1.MCPRemoteProxy) {
-	if err := r.Status().Update(ctx, proxy); err != nil {
+// patchCABundleStatus applies the CA bundle condition mutation via MutateAndPatchStatus
+// (diff-only merge patch, skipped when nothing changed). The error is logged and
+// swallowed: the CABundleRefValidated condition is advisory, and a failed write is
+// healed on the next reconcile rather than blocking the reconcile's objective.
+func (r *MCPRemoteProxyReconciler) patchCABundleStatus(
+	ctx context.Context, proxy *mcpv1beta1.MCPRemoteProxy, mutate func(*mcpv1beta1.MCPRemoteProxy),
+) {
+	if err := ctrlutil.MutateAndPatchStatus(ctx, r.Client, proxy, mutate); err != nil {
 		log.FromContext(ctx).Error(err, "Failed to update MCPRemoteProxy status after CABundleRef validation")
 	}
 }

--- a/cmd/thv-operator/controllers/mcpremoteproxy_controller.go
+++ b/cmd/thv-operator/controllers/mcpremoteproxy_controller.go
@@ -1083,30 +1083,48 @@ func (r *MCPRemoteProxyReconciler) validateGroupRef(ctx context.Context, proxy *
 // validateCABundleRef validates the OIDC CA bundle ConfigMap reference if specified.
 // The CA bundle is sourced from the referenced MCPOIDCConfig's inline configuration.
 // It mirrors MCPServer.validateCABundleRef so the proxy surfaces the same
-// CABundleRefValidated condition (see the Status Condition Parity rule). Like
-// validateGroupRef this sets the condition, but — like MCPServer — it also persists
-// status itself so a CA bundle ConfigMap appearing or disappearing is reflected even
-// when no other handler triggers a status write this reconcile.
+// CABundleRefValidated condition (see the Status Condition Parity rule), but persists
+// status only when the condition actually changes so a steady-state reconcile is a
+// no-op — matching the needsUpdate idiom used by handleOIDCConfig in this file and the
+// idempotency rule in operator.md, rather than MCPServer's unconditional status write.
 func (r *MCPRemoteProxyReconciler) validateCABundleRef(ctx context.Context, proxy *mcpv1beta1.MCPRemoteProxy) {
+	condType := mcpv1beta1.ConditionTypeMCPRemoteProxyCABundleRefValidated
+	prev := meta.FindStatusCondition(proxy.Status.Conditions, condType)
+
 	caBundleRef := r.resolveOIDCCABundleRef(ctx, proxy)
 	if caBundleRef == nil || caBundleRef.ConfigMapRef == nil {
 		// No CA bundle configured - clear any stale condition from a prior reconcile.
-		if meta.FindStatusCondition(proxy.Status.Conditions, mcpv1beta1.ConditionTypeMCPRemoteProxyCABundleRefValidated) != nil {
-			meta.RemoveStatusCondition(&proxy.Status.Conditions, mcpv1beta1.ConditionTypeMCPRemoteProxyCABundleRefValidated)
+		if prev != nil {
+			meta.RemoveStatusCondition(&proxy.Status.Conditions, condType)
 			r.updateCABundleStatus(ctx, proxy)
 		}
 		return
 	}
 
+	status, reason, message := r.evaluateCABundleRef(ctx, proxy, caBundleRef)
+	setRemoteProxyCABundleRefCondition(proxy, status, reason, message)
+
+	if prev == nil ||
+		prev.Status != status ||
+		prev.Reason != reason ||
+		prev.Message != message ||
+		prev.ObservedGeneration != proxy.Generation {
+		r.updateCABundleStatus(ctx, proxy)
+	}
+}
+
+// evaluateCABundleRef checks the referenced CA bundle ConfigMap and returns the
+// resulting CABundleRefValidated condition status, reason, and message. It performs
+// no status mutation or persistence. Mirrors MCPServer.validateCABundleRef's checks.
+func (r *MCPRemoteProxyReconciler) evaluateCABundleRef(
+	ctx context.Context, proxy *mcpv1beta1.MCPRemoteProxy, caBundleRef *mcpv1beta1.CABundleSource,
+) (metav1.ConditionStatus, string, string) {
 	ctxLogger := log.FromContext(ctx)
 
 	// Validate the CABundleRef configuration
 	if err := validation.ValidateCABundleSource(caBundleRef); err != nil {
 		ctxLogger.Error(err, "Invalid CABundleRef configuration")
-		setRemoteProxyCABundleRefCondition(proxy, metav1.ConditionFalse,
-			mcpv1beta1.ConditionReasonMCPRemoteProxyCABundleRefInvalid, err.Error())
-		r.updateCABundleStatus(ctx, proxy)
-		return
+		return metav1.ConditionFalse, mcpv1beta1.ConditionReasonMCPRemoteProxyCABundleRefInvalid, err.Error()
 	}
 
 	// Check if the referenced ConfigMap exists
@@ -1114,32 +1132,25 @@ func (r *MCPRemoteProxyReconciler) validateCABundleRef(ctx context.Context, prox
 	configMap := &corev1.ConfigMap{}
 	if err := r.Get(ctx, types.NamespacedName{Namespace: proxy.Namespace, Name: cmName}, configMap); err != nil {
 		ctxLogger.Error(err, "Failed to find CA bundle ConfigMap", "configMap", cmName)
-		setRemoteProxyCABundleRefCondition(proxy, metav1.ConditionFalse,
-			mcpv1beta1.ConditionReasonMCPRemoteProxyCABundleRefNotFound,
-			fmt.Sprintf("CA bundle ConfigMap '%s' not found in namespace '%s'", cmName, proxy.Namespace))
-		r.updateCABundleStatus(ctx, proxy)
-		return
+		return metav1.ConditionFalse, mcpv1beta1.ConditionReasonMCPRemoteProxyCABundleRefNotFound,
+			fmt.Sprintf("CA bundle ConfigMap '%s' not found in namespace '%s'", cmName, proxy.Namespace)
 	}
 
-	// Verify the key exists in the ConfigMap
+	// Verify the key exists in the ConfigMap. A missing key is a configuration state
+	// surfaced through the condition, not a Go error, so it logs at Info (the two
+	// branches above carry a real error and log at Error).
 	key := caBundleRef.ConfigMapRef.Key
 	if key == "" {
 		key = validation.OIDCCABundleDefaultKey
 	}
 	if _, exists := configMap.Data[key]; !exists {
-		ctxLogger.Error(nil, "CA bundle key not found in ConfigMap", "configMap", cmName, "key", key)
-		setRemoteProxyCABundleRefCondition(proxy, metav1.ConditionFalse,
-			mcpv1beta1.ConditionReasonMCPRemoteProxyCABundleRefInvalid,
-			fmt.Sprintf("Key '%s' not found in ConfigMap '%s'", key, cmName))
-		r.updateCABundleStatus(ctx, proxy)
-		return
+		ctxLogger.Info("CA bundle key not found in ConfigMap", "configMap", cmName, "key", key)
+		return metav1.ConditionFalse, mcpv1beta1.ConditionReasonMCPRemoteProxyCABundleRefInvalid,
+			fmt.Sprintf("Key '%s' not found in ConfigMap '%s'", key, cmName)
 	}
 
-	// Validation passed
-	setRemoteProxyCABundleRefCondition(proxy, metav1.ConditionTrue,
-		mcpv1beta1.ConditionReasonMCPRemoteProxyCABundleRefValid,
-		fmt.Sprintf("CA bundle ConfigMap '%s' is valid (key: %s)", cmName, key))
-	r.updateCABundleStatus(ctx, proxy)
+	return metav1.ConditionTrue, mcpv1beta1.ConditionReasonMCPRemoteProxyCABundleRefValid,
+		fmt.Sprintf("CA bundle ConfigMap '%s' is valid (key: %s)", cmName, key)
 }
 
 // resolveOIDCCABundleRef returns the CA bundle reference from the proxy's referenced

--- a/cmd/thv-operator/controllers/mcpremoteproxy_deployment.go
+++ b/cmd/thv-operator/controllers/mcpremoteproxy_deployment.go
@@ -32,7 +32,13 @@ func (r *MCPRemoteProxyReconciler) deploymentForMCPRemoteProxy(
 	args := r.buildContainerArgs()
 	volumeMounts, volumes := r.buildVolumesForProxy(proxy)
 	r.addTelemetryCABundleVolumes(ctx, proxy, &volumes, &volumeMounts)
-	r.addOIDCCABundleVolumes(ctx, proxy, &volumes, &volumeMounts)
+	if err := r.addOIDCCABundleVolumes(ctx, proxy, &volumes, &volumeMounts); err != nil {
+		// Returning nil aborts the build so ensureDeployment requeues with backoff and
+		// leaves the existing Deployment untouched, rather than building a CA-less pod
+		// that would crash-loop and flip the RunConfig checksum (restart flap).
+		log.FromContext(ctx).Error(err, "Failed to add OIDC CA bundle volumes")
+		return nil
+	}
 	env := r.buildEnvVarsForProxy(ctx, proxy)
 
 	// Add embedded auth server volumes and env vars. AuthServerRef takes precedence;
@@ -179,9 +185,12 @@ func (r *MCPRemoteProxyReconciler) addTelemetryCABundleVolumes(
 // addOIDCCABundleVolumes appends the CA bundle volume and mount for the referenced
 // MCPOIDCConfig's inline CA bundle, so the runner pod can read the CA file at the
 // path the RunConfig points it at (resolved.ThvCABundlePath). Mirrors MCPServer's
-// OIDC CA bundle mount. The CA bundle reference is validated separately in
-// validateCABundleRef; failures here are advisory and log-and-continue so a
-// transient fetch error does not abort the deployment build.
+// OIDC CA bundle mount.
+//
+// A fetch error is returned (not swallowed) so the caller can abort the build: a
+// transient failure must not produce a CA-less Deployment, which would flip the
+// RunConfig checksum and crash-loop the pod (restart flap). The CA bundle reference
+// content is validated separately in validateCABundleRef.
 //
 // Must be called from deploymentForMCPRemoteProxy where the client is available.
 func (r *MCPRemoteProxyReconciler) addOIDCCABundleVolumes(
@@ -189,20 +198,20 @@ func (r *MCPRemoteProxyReconciler) addOIDCCABundleVolumes(
 	proxy *mcpv1beta1.MCPRemoteProxy,
 	volumes *[]corev1.Volume,
 	volumeMounts *[]corev1.VolumeMount,
-) {
+) error {
 	if proxy.Spec.OIDCConfigRef == nil {
-		return
+		return nil
 	}
 	oidcCfg, err := ctrlutil.GetOIDCConfigForServer(ctx, r.Client, proxy.Namespace, proxy.Spec.OIDCConfigRef)
 	if err != nil {
-		log.FromContext(ctx).Error(err, "Failed to fetch MCPOIDCConfig for CA bundle volume")
-		return
+		return fmt.Errorf("failed to fetch MCPOIDCConfig for CA bundle volume: %w", err)
 	}
 	if oidcCfg != nil {
 		caVolumes, caMounts := ctrlutil.AddOIDCConfigRefCABundleVolumes(oidcCfg)
 		*volumes = append(*volumes, caVolumes...)
 		*volumeMounts = append(*volumeMounts, caMounts...)
 	}
+	return nil
 }
 
 // buildEnvVarsForProxy builds environment variables for the proxy container

--- a/cmd/thv-operator/controllers/mcpremoteproxy_deployment.go
+++ b/cmd/thv-operator/controllers/mcpremoteproxy_deployment.go
@@ -32,6 +32,7 @@ func (r *MCPRemoteProxyReconciler) deploymentForMCPRemoteProxy(
 	args := r.buildContainerArgs()
 	volumeMounts, volumes := r.buildVolumesForProxy(proxy)
 	r.addTelemetryCABundleVolumes(ctx, proxy, &volumes, &volumeMounts)
+	r.addOIDCCABundleVolumes(ctx, proxy, &volumes, &volumeMounts)
 	env := r.buildEnvVarsForProxy(ctx, proxy)
 
 	// Add embedded auth server volumes and env vars. AuthServerRef takes precedence;
@@ -170,6 +171,35 @@ func (r *MCPRemoteProxyReconciler) addTelemetryCABundleVolumes(
 	}
 	if telCfg != nil {
 		caVolumes, caMounts := ctrlutil.AddTelemetryCABundleVolumes(telCfg)
+		*volumes = append(*volumes, caVolumes...)
+		*volumeMounts = append(*volumeMounts, caMounts...)
+	}
+}
+
+// addOIDCCABundleVolumes appends the CA bundle volume and mount for the referenced
+// MCPOIDCConfig's inline CA bundle, so the runner pod can read the CA file at the
+// path the RunConfig points it at (resolved.ThvCABundlePath). Mirrors MCPServer's
+// OIDC CA bundle mount. The CA bundle reference is validated separately in
+// validateCABundleRef; failures here are advisory and log-and-continue so a
+// transient fetch error does not abort the deployment build.
+//
+// Must be called from deploymentForMCPRemoteProxy where the client is available.
+func (r *MCPRemoteProxyReconciler) addOIDCCABundleVolumes(
+	ctx context.Context,
+	proxy *mcpv1beta1.MCPRemoteProxy,
+	volumes *[]corev1.Volume,
+	volumeMounts *[]corev1.VolumeMount,
+) {
+	if proxy.Spec.OIDCConfigRef == nil {
+		return
+	}
+	oidcCfg, err := ctrlutil.GetOIDCConfigForServer(ctx, r.Client, proxy.Namespace, proxy.Spec.OIDCConfigRef)
+	if err != nil {
+		log.FromContext(ctx).Error(err, "Failed to fetch MCPOIDCConfig for CA bundle volume")
+		return
+	}
+	if oidcCfg != nil {
+		caVolumes, caMounts := ctrlutil.AddOIDCConfigRefCABundleVolumes(oidcCfg)
 		*volumes = append(*volumes, caVolumes...)
 		*volumeMounts = append(*volumeMounts, caMounts...)
 	}

--- a/cmd/thv-operator/test-integration/mcp-remote-proxy/mcpremoteproxy_cabundle_integration_test.go
+++ b/cmd/thv-operator/test-integration/mcp-remote-proxy/mcpremoteproxy_cabundle_integration_test.go
@@ -1,0 +1,181 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package controllers
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/pkg/validation"
+)
+
+// newMCPOIDCConfigWithCABundle builds an inline MCPOIDCConfig whose inline config
+// references a CA bundle ConfigMap by name and key.
+func newMCPOIDCConfigWithCABundle(name, namespace, cmName, key string) *mcpv1beta1.MCPOIDCConfig {
+	return &mcpv1beta1.MCPOIDCConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: mcpv1beta1.MCPOIDCConfigSpec{
+			Type: mcpv1beta1.MCPOIDCConfigTypeInline,
+			Inline: &mcpv1beta1.InlineOIDCSharedConfig{
+				Issuer: "http://localhost:9090",
+				CABundleRef: &mcpv1beta1.CABundleSource{
+					ConfigMapRef: &corev1.ConfigMapKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{Name: cmName},
+						Key:                  key,
+					},
+				},
+			},
+		},
+	}
+}
+
+func caBundleConfigMap(name, namespace, key string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Data: map[string]string{
+			key: "-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----",
+		},
+	}
+}
+
+// waitForOIDCConfigReady waits until the referenced MCPOIDCConfig has been validated
+// (ConfigHash populated), so the proxy's OIDCConfigRef handling does not fail-closed.
+func waitForOIDCConfigReady(ctx context.Context, name, namespace string) {
+	Eventually(func() bool {
+		cfg := &mcpv1beta1.MCPOIDCConfig{}
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, cfg); err != nil {
+			return false
+		}
+		return cfg.Status.ConfigHash != ""
+	}, MediumTimeout, DefaultPollingInterval).Should(BeTrue())
+}
+
+var _ = Describe("MCPRemoteProxy OIDC CA bundle", Label("k8s", "remoteproxy", "cabundle"), func() {
+	var (
+		testCtx       context.Context
+		proxyHelper   *MCPRemoteProxyTestHelper
+		statusHelper  *RemoteProxyStatusTestHelper
+		testNamespace string
+	)
+
+	BeforeEach(func() {
+		testCtx = context.Background()
+		testNamespace = createTestNamespace(testCtx)
+		proxyHelper = NewMCPRemoteProxyTestHelper(testCtx, k8sClient, testNamespace)
+		statusHelper = NewRemoteProxyStatusTestHelper(proxyHelper)
+	})
+
+	AfterEach(func() {
+		Expect(proxyHelper.CleanupRemoteProxies()).To(Succeed())
+		deleteTestNamespace(testCtx, testNamespace)
+	})
+
+	Context("when the referenced MCPOIDCConfig declares a valid CA bundle", func() {
+		It("validates the CABundleRef and mounts the ConfigMap into the Deployment", func() {
+			const cmName = "ca-bundle"
+			const oidcName = "oidc-ca"
+
+			By("creating the CA bundle ConfigMap")
+			Expect(k8sClient.Create(testCtx, caBundleConfigMap(cmName, testNamespace, "ca.crt"))).To(Succeed())
+
+			By("creating the MCPOIDCConfig referencing the CA bundle")
+			oidcConfig := newMCPOIDCConfigWithCABundle(oidcName, testNamespace, cmName, "ca.crt")
+			Expect(k8sClient.Create(testCtx, oidcConfig)).To(Succeed())
+			waitForOIDCConfigReady(testCtx, oidcName, testNamespace)
+
+			By("creating the MCPRemoteProxy referencing the MCPOIDCConfig")
+			proxy := proxyHelper.NewRemoteProxyBuilder("proxy-ca-valid").
+				WithOIDCConfigRef(oidcName, "https://resource.example.com").
+				Create(proxyHelper)
+
+			By("waiting for CABundleRefValidated to be True")
+			statusHelper.WaitForCondition(
+				proxy.Name,
+				mcpv1beta1.ConditionTypeMCPRemoteProxyCABundleRefValidated,
+				metav1.ConditionTrue,
+				MediumTimeout,
+			)
+			statusHelper.WaitForConditionReason(
+				proxy.Name,
+				mcpv1beta1.ConditionTypeMCPRemoteProxyCABundleRefValidated,
+				mcpv1beta1.ConditionReasonMCPRemoteProxyCABundleRefValid,
+				MediumTimeout,
+			)
+
+			By("verifying the Deployment mounts the CA bundle ConfigMap")
+			deployment := proxyHelper.WaitForDeployment(proxy.Name, MediumTimeout)
+			expectedVolume := validation.OIDCCABundleVolumePrefix + cmName
+			expectedMountPath := validation.OIDCCABundleMountBasePath + "/" + cmName
+
+			volume := findVolume(deployment, expectedVolume)
+			Expect(volume).NotTo(BeNil(), "expected CA bundle volume %q", expectedVolume)
+			Expect(volume.ConfigMap).NotTo(BeNil())
+			Expect(volume.ConfigMap.Name).To(Equal(cmName))
+
+			mount := findVolumeMount(deployment, expectedVolume)
+			Expect(mount).NotTo(BeNil(), "expected CA bundle volume mount %q", expectedVolume)
+			Expect(mount.MountPath).To(Equal(expectedMountPath))
+			Expect(mount.ReadOnly).To(BeTrue())
+		})
+	})
+
+	Context("when the referenced CA bundle ConfigMap does not exist", func() {
+		It("sets CABundleRefValidated to False with the NotFound reason", func() {
+			const oidcName = "oidc-ca-missing"
+
+			By("creating the MCPOIDCConfig referencing a non-existent ConfigMap")
+			oidcConfig := newMCPOIDCConfigWithCABundle(oidcName, testNamespace, "missing-cm", "ca.crt")
+			Expect(k8sClient.Create(testCtx, oidcConfig)).To(Succeed())
+			waitForOIDCConfigReady(testCtx, oidcName, testNamespace)
+
+			By("creating the MCPRemoteProxy referencing the MCPOIDCConfig")
+			proxy := proxyHelper.NewRemoteProxyBuilder("proxy-ca-missing").
+				WithOIDCConfigRef(oidcName, "https://resource.example.com").
+				Create(proxyHelper)
+
+			By("waiting for CABundleRefValidated to be False with NotFound reason")
+			statusHelper.WaitForCondition(
+				proxy.Name,
+				mcpv1beta1.ConditionTypeMCPRemoteProxyCABundleRefValidated,
+				metav1.ConditionFalse,
+				MediumTimeout,
+			)
+			statusHelper.WaitForConditionReason(
+				proxy.Name,
+				mcpv1beta1.ConditionTypeMCPRemoteProxyCABundleRefValidated,
+				mcpv1beta1.ConditionReasonMCPRemoteProxyCABundleRefNotFound,
+				MediumTimeout,
+			)
+		})
+	})
+})
+
+func findVolume(dep *appsv1.Deployment, name string) *corev1.Volume {
+	for i := range dep.Spec.Template.Spec.Volumes {
+		if dep.Spec.Template.Spec.Volumes[i].Name == name {
+			return &dep.Spec.Template.Spec.Volumes[i]
+		}
+	}
+	return nil
+}
+
+func findVolumeMount(dep *appsv1.Deployment, name string) *corev1.VolumeMount {
+	if len(dep.Spec.Template.Spec.Containers) == 0 {
+		return nil
+	}
+	mounts := dep.Spec.Template.Spec.Containers[0].VolumeMounts
+	for i := range mounts {
+		if mounts[i].Name == name {
+			return &mounts[i]
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

The `MCPRemoteProxy` runconfig builder already emits the resolved OIDC CA bundle file path (`resolved.ThvCABundlePath`), but the controller never mounted the referenced ConfigMap into the runner pod and never validated the reference. The runner was pointed at a CA file it could not read — a silent TLS failure — and, unlike `MCPServer`, there was no kubectl-visible signal that the CA bundle was misconfigured.

This mirrors `MCPServer`'s existing behaviour on `MCPRemoteProxy`, closing both halves of the gap and the Status Condition Parity gap between the two types.

Closes #4113

<details>
<summary><strong>Medium level</strong></summary>

- **Volume mount**: new `addOIDCCABundleVolumes` is wired into `deploymentForMCPRemoteProxy` and reuses the shared `ctrlutil.AddOIDCConfigRefCABundleVolumes` helper, so the runner pod mounts the CA bundle ConfigMap at the path the runconfig references. A transient OIDCConfig fetch error returns up and aborts the build (requeue with backoff, existing Deployment untouched) rather than producing a CA-less pod that would crash-loop and flip the RunConfig checksum.
- **Validation**: new `validateCABundleRef` (+ `evaluateCABundleRef` + `resolveOIDCCABundleRef`) runs in `validateAndHandleConfigs` and surfaces a `CABundleRefValidated` condition (Valid / NotFound / Invalid), matching `MCPServer`. On a transient OIDCConfig fetch error it leaves the existing condition untouched and defers to `handleOIDCConfig` (the authoritative ref validator), instead of flapping the condition to absent.
- **Status writes** go through `controllerutil.MutateAndPatchStatus` per the `operator.md` Status Writes rule — a diff-only merge patch that skips the wire call when nothing changed, giving steady-state idempotency for free. It also clears the condition when the CA bundle is genuinely removed.
- **Constants**: new `CABundleRefValidated` condition type + three reason constants on the `MCPRemoteProxy` API.

</details>

<details>
<summary><strong>Low level</strong></summary>

| File | Change |
|------|--------|
| `cmd/thv-operator/api/v1beta1/mcpremoteproxy_types.go` | New `CABundleRefValidated` condition type + `CABundleRefValid`/`NotFound`/`Invalid` reasons |
| `cmd/thv-operator/controllers/mcpremoteproxy_deployment.go` | `addOIDCCABundleVolumes` (returns error → build aborts on transient fetch failure) + call in `deploymentForMCPRemoteProxy` |
| `cmd/thv-operator/controllers/mcpremoteproxy_controller.go` | `validateCABundleRef` / `evaluateCABundleRef` / `resolveOIDCCABundleRef` (reports resolved vs transient) / `setRemoteProxyCABundleRefCondition` / `patchCABundleStatus` (MutateAndPatchStatus); wired into `validateAndHandleConfigs` |
| `cmd/thv-operator/controllers/mcpremoteproxy_cabundle_test.go` | Unit tests: validation branches, transient-error no-flap, deployment mount + build-abort, idempotency |
| `cmd/thv-operator/test-integration/mcp-remote-proxy/mcpremoteproxy_cabundle_integration_test.go` | envtest: happy path (condition True + real Deployment mount) and missing-ConfigMap (False/NotFound) |

</details>

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

## Test plan

- [x] `task test` (affected operator unit packages: `controllers`, `api/v1beta1`)
- [x] Unit tests: `TestMCPRemoteProxyValidateCABundleRef` (all branches incl. transient-fetch-error no-flap), `TestAddOIDCCABundleVolumes` (mount present/absent + build-abort on transient error), `TestMCPRemoteProxyValidateCABundleRefIdempotent` (steady-state reconcile issues no status write)
- [x] envtest integration (full `mcp-remote-proxy` suite passes): CA bundle validated True with the ConfigMap mounted into the Deployment, and `CABundleRefValidated` False / NotFound when the ConfigMap is missing
- [x] `task build` passes
- [x] No generated-code drift (`operator-generate` + `operator-manifests` produce no diff — condition constants aren't part of the CRD schema)

## Does this introduce a user-facing change?

Yes. `MCPRemoteProxy` resources that reference an `MCPOIDCConfig` with an inline CA bundle now (a) actually mount that CA bundle into the runner pod so TLS to the OIDC provider works, and (b) report a `CABundleRefValidated` status condition describing whether the referenced ConfigMap/key is valid.

## Special notes for reviewers

- **Mirrors `MCPServer`** (`validateCABundleRef` at `mcpserver_controller.go:598-663`, volume mount at `mcpserver_controller.go:1266-1274`) with three deliberate improvements over the reference: status writes use `MutateAndPatchStatus` (the rule-compliant path) instead of `r.Status().Update`; the condition is not flapped on transient OIDCConfig fetch errors; and a transient fetch error aborts the Deployment build instead of mounting a non-existent CA ConfigMap.
- **Known parity gap — `VirtualMCPServer` (follow-up #5632)**: `VirtualMCPServer` also mounts the OIDC CA bundle (`virtualmcpserver_deployment.go:321`) but has no `CABundleRefValidated` validation. Deliberately left out of scope to keep this PR focused on #4113; tracked in #5632.
- **Advisory, not terminal (by design)**: a bad CA bundle sets `CABundleRefValidated=False` but does not set `Phase=Failed` or block the Deployment — identical to `MCPServer`. Making the CA bundle fail-closed would be a deliberate cross-type decision and is intentionally not introduced for one type only.
- **Path safety**: the CA bundle ConfigMap name/key flow into the volume mount path via the shared helper. `validation.ValidateCABundleSource` does presence/length checks; path safety is otherwise bounded by Kubernetes admission (RFC-1123 ConfigMap names + `KeyToPath` rejecting `..`/`/`). No additional sanitisation added here; matches existing `MCPServer`/`VirtualMCPServer` behaviour.
- A prior attempt (PR #4190, closed unmerged) targeted the old `v1alpha1` value-type OIDC spec; this PR targets the current `v1beta1` `OIDCConfigRef` → `MCPOIDCConfig` model.

Generated with [Claude Code](https://claude.com/claude-code)