### PR TITLE
Add good-first-issue and good-tenth-issue contribution guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,9 +49,24 @@ sample project that reproduces the problem.
 
 ### Not sure how to start contributing?
 
-PRs to resolve existing issues are greatly appreciated, and issues labeled as
-["good first issue"](https://github.com/stacklok/toolhive/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22)
-are a great place to start!
+PRs to resolve existing issues are greatly appreciated! We use labels to help
+you find issues that match your experience level:
+
+**New to ToolHive?** Issues labeled
+[`good-first-issue`](https://github.com/stacklok/toolhive/issues?q=is%3Aopen+is%3Aissue+label%3A%22good-first-issue%22)
+are a great place to start. These are self-contained tasks with clear scope and
+limited surface area — perfect for getting familiar with the codebase and the
+contribution workflow without needing deep knowledge of the overall architecture.
+
+**Ready for a bigger challenge?** Issues labeled
+[`good-tenth-issue`](https://github.com/stacklok/toolhive/issues?q=is%3Aopen+is%3Aissue+label%3A%22good-tenth-issue%22)
+are for contributors who have already found their footing in the codebase. These
+tasks require deeper knowledge of ToolHive's architecture, involve more design
+thinking, and may span multiple components or subsystems. This label also covers
+features we are more than happy to accept community PRs for, even if they are
+not currently on our roadmap — if you have an idea that fits, open an issue to
+discuss it first. Either way, we recommend picking up a few `good-first-issue`
+items first to build context.
 
 ### Claiming an issue
 


### PR DESCRIPTION
## Summary

- The "Not sure how to start contributing?" section previously had a single line pointing to the `good first issue` label. This expands it to properly guide community contributors at different experience levels.
- Adds descriptions for both `good-first-issue` (self-contained, limited surface area, good for new contributors) and `good-tenth-issue` (architecture-spanning, design-heavy, also covers community-driven features not on the roadmap).
- Updates label names to use hyphenated format (`good-first-issue`, `good-tenth-issue`) and corrects the GitHub issue filter URLs.

## Type of change

- [x] Documentation update

## Test plan

- [x] Manually reviewed the rendered markdown for clarity and correct link targets

Generated with [Claude Code](https://claude.com/claude-code)