### PR TITLE
Dedup upstream-token refresh on a shared refresher

### DIFF
--- a/pkg/auth/upstreamtoken/service.go
+++ b/pkg/auth/upstreamtoken/service.go
@@ -10,23 +10,17 @@ import (
 	"log/slog"
 	"time"
 
-	"golang.org/x/sync/singleflight"
-
 	"github.com/stacklok/toolhive/pkg/authserver/storage"
 )
 
-// refreshTimeout bounds how long a singleflight-deduplicated token refresh
-// may take before being cancelled. It is deliberately detached from the
-// triggering request's context so that waiting callers are not abandoned.
-const refreshTimeout = 30 * time.Second
-
 // InProcessService implements the Service interface for in-process use.
-// It composes storage (read), refresher (refresh + persist), and singleflight
-// (dedup) to provide a single GetValidTokens call.
+// It composes storage (read) and refresher (refresh + persist) to provide a
+// single GetValidTokens call. Concurrent-refresh deduplication is delegated to
+// the refresher's own singleflight.Group so the same Group covers both the
+// handler's chain-walk path and the runtime token-swap path.
 type InProcessService struct {
 	storage   storage.UpstreamTokenStorage
 	refresher storage.UpstreamTokenRefresher
-	sfGroup   singleflight.Group
 }
 
 // Compile-time checks.
@@ -95,7 +89,7 @@ func (s *InProcessService) GetAllValidTokens(ctx context.Context, sessionID stri
 
 	result := make(map[string]string, len(allTokens))
 	// TODO(auth): Refresh providers in parallel using errgroup to avoid
-	// worst-case latency of N * refreshTimeout when multiple providers need refresh.
+	// worst-case latency of N refreshes when multiple providers need refresh.
 	for providerName, tokens := range allTokens {
 		if tokens == nil {
 			continue
@@ -124,8 +118,9 @@ func (s *InProcessService) GetAllValidTokens(ctx context.Context, sessionID stri
 	return result, nil
 }
 
-// refreshOrFail attempts a singleflight-deduplicated refresh and maps errors
-// to the service's sentinel errors.
+// refreshOrFail attempts a refresh via the shared refresher and maps errors to
+// the service's sentinel errors. Deduplication of concurrent refreshes for the
+// same (session, provider) pair is handled inside the refresher.
 func (s *InProcessService) refreshOrFail(
 	ctx context.Context,
 	sessionID string,
@@ -144,18 +139,7 @@ func (s *InProcessService) refreshOrFail(
 		return nil, ErrNoRefreshToken
 	}
 
-	result, err, _ := s.sfGroup.Do(sessionID+":"+providerName, func() (any, error) {
-		// Detach from the triggering request's context so that if the first
-		// caller disconnects, the refresh still completes for waiting callers.
-		refreshCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), refreshTimeout)
-		defer cancel()
-
-		refreshed, refreshErr := s.refresher.RefreshAndStore(refreshCtx, sessionID, expired)
-		if refreshErr != nil {
-			return nil, refreshErr
-		}
-		return refreshed, nil
-	})
+	refreshed, err := s.refresher.RefreshAndStore(ctx, sessionID, expired)
 	if err != nil {
 		slog.Warn("upstream token refresh failed",
 			"session_id", sessionID,
@@ -165,8 +149,7 @@ func (s *InProcessService) refreshOrFail(
 		return nil, fmt.Errorf("%w: %w", ErrRefreshFailed, err)
 	}
 
-	refreshed, ok := result.(*storage.UpstreamTokens)
-	if !ok || refreshed == nil {
+	if refreshed == nil {
 		return nil, ErrRefreshFailed
 	}
 

--- a/pkg/authserver/refresher.go
+++ b/pkg/authserver/refresher.go
@@ -10,32 +10,37 @@ import (
 	"log/slog"
 	"time"
 
+	"golang.org/x/sync/singleflight"
+
 	"github.com/stacklok/toolhive/pkg/authserver/storage"
 	"github.com/stacklok/toolhive/pkg/authserver/upstream"
 )
+
+// refreshTimeout bounds how long a singleflight-deduplicated token refresh
+// may take before being cancelled. It is deliberately detached from the
+// triggering request's context so that waiting callers are not abandoned.
+const refreshTimeout = 30 * time.Second
 
 // upstreamTokenRefresher implements storage.UpstreamTokenRefresher by wrapping
 // a set of upstream OAuth2Providers (keyed by provider name) and
 // UpstreamTokenStorage (for persisting the refreshed tokens). On each refresh
 // call it dispatches to the correct provider based on the expired token's
-// ProviderID.
-//
-// refreshTokenLifespan is used as the defensive re-anchor value for
-// SessionExpiresAt when the persisted row pre-dates the unconditional callback
-// write (legacy data) and the upstream provider drops expires_in on the
-// refresh response. Without this, both bounds would be zero and the row would
-// be persisted with no TTL — see RefreshAndStore.
+// ProviderID, deduplicating concurrent refreshes for the same
+// (session, provider) pair via sfGroup.
 type upstreamTokenRefresher struct {
 	providers            map[string]upstream.OAuth2Provider
 	storage              storage.UpstreamTokenStorage
 	refreshTokenLifespan time.Duration
+	sfGroup              singleflight.Group
 }
 
 // Compile-time check that upstreamTokenRefresher implements storage.UpstreamTokenRefresher.
 var _ storage.UpstreamTokenRefresher = (*upstreamTokenRefresher)(nil)
 
-// RefreshAndStore refreshes expired upstream tokens using the stored refresh token,
-// persists the new tokens, and returns them.
+// RefreshAndStore deduplicates concurrent refreshes for the same (session,
+// provider) pair, then delegates to refreshAndStore. The detached-context
+// timeout ensures waiting callers are not abandoned if the initiating request
+// cancels before the upstream round-trip completes.
 func (r *upstreamTokenRefresher) RefreshAndStore(
 	ctx context.Context,
 	sessionID string,
@@ -44,6 +49,31 @@ func (r *upstreamTokenRefresher) RefreshAndStore(
 	if expired == nil {
 		return nil, errors.New("expired tokens are required")
 	}
+
+	// providerName == ProviderID throughout the authserver; both originate from
+	// UpstreamConfig.Name and are stored verbatim in UpstreamTokens.ProviderID.
+	key := sessionID + ":" + expired.ProviderID
+	result, err, _ := r.sfGroup.Do(key, func() (any, error) {
+		refreshCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), refreshTimeout)
+		defer cancel()
+		return r.refreshAndStore(refreshCtx, sessionID, expired)
+	})
+	if err != nil {
+		return nil, err
+	}
+	refreshed, ok := result.(*storage.UpstreamTokens)
+	if !ok || refreshed == nil {
+		return nil, errors.New("unexpected nil result from upstream token refresh")
+	}
+	return refreshed, nil
+}
+
+// refreshAndStore performs the actual token refresh and storage write.
+func (r *upstreamTokenRefresher) refreshAndStore(
+	ctx context.Context,
+	sessionID string,
+	expired *storage.UpstreamTokens,
+) (*storage.UpstreamTokens, error) {
 	if expired.RefreshToken == "" {
 		return nil, errors.New("no refresh token available for upstream token refresh")
 	}

--- a/pkg/authserver/refresher_test.go
+++ b/pkg/authserver/refresher_test.go
@@ -6,6 +6,8 @@ package authserver
 import (
 	"context"
 	"errors"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -318,4 +320,217 @@ func TestUpstreamTokenRefresher_RefreshAndStore(t *testing.T) {
 			}
 		})
 	}
+}
+
+// waitGroupTimeout blocks until wg is done, failing the test if that takes
+// longer than d. Without it, a synchronization regression (or a panicking
+// goroutine) would hang the test until the global go test timeout instead of
+// failing fast with a clear message.
+func waitGroupTimeout(t *testing.T, wg *sync.WaitGroup, d time.Duration, msg string) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(d):
+		t.Fatal(msg)
+	}
+}
+
+// TestUpstreamTokenRefresher_SingleflightDedup proves that concurrent
+// RefreshAndStore calls for the same (session, provider) key result in exactly
+// one upstream redemption, and that distinct keys are independent.
+//
+// The same-key sub-test holds the leader's in-flight call open on a
+// test-controlled release channel while the followers join it, then asserts the
+// provider was invoked exactly once. singleflight exposes no hook for "a
+// follower is now parked in Do", so the test cannot be made fully deterministic;
+// it gates release on every goroutine having reached RefreshAndStore plus a
+// short settle for the followers to park — the same strategy used by
+// golang.org/x/sync/singleflight's own dup-suppression test. The leader holding
+// the key open for the whole window (rather than releasing as soon as the
+// callers are merely counted) is what keeps it robust.
+func TestUpstreamTokenRefresher_SingleflightDedup(t *testing.T) {
+	t.Parallel()
+
+	const n = 10
+	newExpiry := time.Now().Add(1 * time.Hour)
+
+	expired := &storage.UpstreamTokens{
+		ProviderID:       "github",
+		AccessToken:      "old-access",
+		RefreshToken:     "old-refresh",
+		ExpiresAt:        time.Now().Add(-1 * time.Hour),
+		SessionExpiresAt: time.Now().Add(7 * 24 * time.Hour),
+		UserID:           "user-1",
+		UpstreamSubject:  "sub-1",
+		ClientID:         "client-1",
+	}
+
+	t.Run("same key deduplicated to one redemption", func(t *testing.T) {
+		t.Parallel()
+
+		ctrl := gomock.NewController(t)
+		mockStorage := storagemocks.NewMockUpstreamTokenStorage(ctrl)
+		mockProvider := upstreammocks.NewMockOAuth2Provider(ctrl)
+
+		// inFlight is closed once the leader (goroutine 0) is inside the provider
+		// callback, so the followers start only after the singleflight key is
+		// already held in the group's map.
+		inFlight := make(chan struct{})
+
+		// release keeps the leader parked inside the callback — and therefore
+		// keeps the in-flight call open in the singleflight map — until the TEST
+		// closes it. Crucially the leader's exit is gated on the test, not on the
+		// followers (the previous version released as soon as all goroutines had
+		// merely reached their body, which let the leader clear the map entry
+		// before a follower had actually entered Do — a real flake). singleflight
+		// gives us no public hook for "follower is parked in Do", so determinism
+		// rests on the leader holding the entry open across the followers' join;
+		// the same approach golang.org/x/sync/singleflight's own dup-suppression
+		// test uses.
+		release := make(chan struct{})
+
+		// invokeCount tracks actual provider invocations.
+		var invokeCount atomic.Int64
+
+		mockProvider.EXPECT().
+			RefreshTokens(gomock.Any(), "old-refresh", "sub-1").
+			Times(1).
+			DoAndReturn(func(_ context.Context, _, _ string) (*upstream.Tokens, error) {
+				invokeCount.Add(1)
+				close(inFlight)
+				<-release
+				return &upstream.Tokens{
+					AccessToken:  "new-access",
+					RefreshToken: "new-refresh",
+					ExpiresAt:    newExpiry,
+				}, nil
+			})
+		mockStorage.EXPECT().
+			StoreUpstreamTokens(gomock.Any(), "session-1", "github", gomock.Any()).
+			Times(1).
+			Return(nil)
+
+		refresher := &upstreamTokenRefresher{
+			providers:            map[string]upstream.OAuth2Provider{"github": mockProvider},
+			storage:              mockStorage,
+			refreshTokenLifespan: 24 * time.Hour,
+		}
+
+		results := make([]*storage.UpstreamTokens, n)
+		errs := make([]error, n)
+		var entered atomic.Int64
+		var wg sync.WaitGroup
+		wg.Add(n)
+
+		// Leader: enters the provider callback (closing inFlight) and parks on
+		// release.
+		go func() {
+			defer wg.Done()
+			entered.Add(1)
+			results[0], errs[0] = refresher.RefreshAndStore(
+				context.Background(), "session-1", expired,
+			)
+		}()
+
+		// Start the followers only once the leader holds the singleflight key.
+		select {
+		case <-inFlight:
+		case <-time.After(5 * time.Second):
+			t.Fatal("timeout waiting for the first refresh to enter the provider")
+		}
+		for i := 1; i < n; i++ {
+			go func(idx int) {
+				defer wg.Done()
+				entered.Add(1)
+				results[idx], errs[idx] = refresher.RefreshAndStore(
+					context.Background(), "session-1", expired,
+				)
+			}(i)
+		}
+
+		// Wait for every goroutine to have reached RefreshAndStore, then give the
+		// followers a brief settle to park inside sfGroup.Do before releasing the
+		// leader. The leader holds the key open the whole time, so once released
+		// it returns the single shared result to all joined followers.
+		require.Eventually(t, func() bool { return entered.Load() == n }, 5*time.Second, time.Millisecond,
+			"all goroutines should reach RefreshAndStore")
+		time.Sleep(100 * time.Millisecond)
+		close(release)
+
+		waitGroupTimeout(t, &wg, 5*time.Second,
+			"timeout waiting for concurrent RefreshAndStore callers to complete")
+
+		for i := range n {
+			require.NoError(t, errs[i], "goroutine %d got error", i)
+			require.NotNil(t, results[i], "goroutine %d got nil result", i)
+			assert.Equal(t, "new-access", results[i].AccessToken,
+				"goroutine %d got wrong access token", i)
+		}
+		assert.Equal(t, int64(1), invokeCount.Load(),
+			"upstream provider must be invoked exactly once despite %d concurrent callers", n)
+		// mockStorage Times(1) independently enforces exactly one store write.
+	})
+
+	t.Run("distinct keys are independent", func(t *testing.T) {
+		t.Parallel()
+
+		const numProviders = 3
+		ctrl := gomock.NewController(t)
+		mockStorage := storagemocks.NewMockUpstreamTokenStorage(ctrl)
+
+		providers := make(map[string]upstream.OAuth2Provider, numProviders)
+		for i := range numProviders {
+			providerID := "provider-" + string(rune('a'+i))
+			mockProvider := upstreammocks.NewMockOAuth2Provider(ctrl)
+			mockProvider.EXPECT().
+				RefreshTokens(gomock.Any(), "rt-"+providerID, gomock.Any()).
+				Times(1).
+				Return(&upstream.Tokens{
+					AccessToken: "at-" + providerID,
+					ExpiresAt:   newExpiry,
+				}, nil)
+			mockStorage.EXPECT().
+				StoreUpstreamTokens(gomock.Any(), "session-x", providerID, gomock.Any()).
+				Times(1).
+				Return(nil)
+			providers[providerID] = mockProvider
+		}
+
+		refresher := &upstreamTokenRefresher{
+			providers:            providers,
+			storage:              mockStorage,
+			refreshTokenLifespan: 24 * time.Hour,
+		}
+
+		var wg sync.WaitGroup
+		for i := range numProviders {
+			providerID := "provider-" + string(rune('a'+i))
+			tok := &storage.UpstreamTokens{
+				ProviderID:       providerID,
+				AccessToken:      "old",
+				RefreshToken:     "rt-" + providerID,
+				ExpiresAt:        time.Now().Add(-1 * time.Hour),
+				SessionExpiresAt: time.Now().Add(24 * time.Hour),
+				UserID:           "u",
+				UpstreamSubject:  "s",
+				ClientID:         "c",
+			}
+			wg.Add(1)
+			go func(tok *storage.UpstreamTokens) {
+				defer wg.Done()
+				result, err := refresher.RefreshAndStore(context.Background(), "session-x", tok)
+				assert.NoError(t, err)
+				assert.NotNil(t, result)
+			}(tok)
+		}
+		waitGroupTimeout(t, &wg, 5*time.Second,
+			"timeout waiting for distinct-key RefreshAndStore callers to complete")
+		// gomock Times(1) per mock provider asserts each distinct key ran
+		// exactly once through the actual upstream call.
+	})
 }

--- a/pkg/authserver/server_impl.go
+++ b/pkg/authserver/server_impl.go
@@ -32,12 +32,13 @@ type server struct {
 	// (newServer) so DCRStore() is a field read rather than re-asserting on
 	// every call, and a backend that does not implement DCRCredentialStore
 	// is rejected at boot rather than at first DCR resolve.
-	dcrStore  storage.DCRCredentialStore
-	upstreams []handlers.NamedUpstream
-	// refreshTokenLifespan mirrors the validated Config.RefreshTokenLifespan.
-	// It is threaded into upstreamTokenRefresher so the refresh path can
-	// re-anchor SessionExpiresAt for legacy storage rows missing that field.
-	refreshTokenLifespan time.Duration
+	dcrStore storage.DCRCredentialStore
+	// upstreamRefresher is the single shared refresher instance constructed in
+	// newServer. Storing the interface type (not *upstreamTokenRefresher) keeps
+	// the nil-return contract: newUpstreamTokenRefresher returns a true nil
+	// interface when there are no upstreams, so callers can check == nil safely.
+	upstreamRefresher storage.UpstreamTokenRefresher
+	upstreams         []handlers.NamedUpstream
 }
 
 // upstreamProviderFactory creates an upstream OAuth2Provider from configuration.
@@ -201,7 +202,9 @@ func newServer(ctx context.Context, cfg Config, stor storage.Storage, opts ...se
 
 	// Give the handler a refresher so the authorization chain can transparently
 	// refresh an expired upstream leg during login instead of skipping it and
-	// failing later at MCP-request token-swap time.
+	// failing later at MCP-request token-swap time. The same instance is stored
+	// on the server so UpstreamTokenRefresher() returns the identical object,
+	// ensuring both paths share one singleflight.Group.
 	refresher := newUpstreamTokenRefresher(upstreams, stor, cfg.RefreshTokenLifespan)
 	handlerInstance, err := handlers.NewHandler(fositeProvider, authServerConfig, stor, upstreams,
 		handlers.WithUpstreamRefresher(refresher))
@@ -217,11 +220,11 @@ func newServer(ctx context.Context, cfg Config, stor storage.Storage, opts ...se
 	)
 
 	return &server{
-		handler:              router,
-		storage:              stor,
-		dcrStore:             dcrStore,
-		upstreams:            upstreams,
-		refreshTokenLifespan: cfg.RefreshTokenLifespan,
+		handler:           router,
+		storage:           stor,
+		dcrStore:          dcrStore,
+		upstreams:         upstreams,
+		upstreamRefresher: refresher,
 	}, nil
 }
 
@@ -241,17 +244,17 @@ func (s *server) DCRStore() storage.DCRCredentialStore {
 	return s.dcrStore
 }
 
-// UpstreamTokenRefresher returns a refresher that wraps the upstream providers
-// and storage to transparently refresh expired upstream tokens. The refresher
-// dispatches to the correct provider based on each token's ProviderID.
+// UpstreamTokenRefresher returns the single shared refresher constructed in
+// newServer. Both the handler's chain-walk path and the runtime token-swap
+// path use this instance, ensuring concurrent refreshes for the same
+// (session, provider) pair are deduplicated by a single singleflight.Group.
 func (s *server) UpstreamTokenRefresher() storage.UpstreamTokenRefresher {
-	return newUpstreamTokenRefresher(s.upstreams, s.storage, s.refreshTokenLifespan)
+	return s.upstreamRefresher
 }
 
 // newUpstreamTokenRefresher builds a refresher over the given upstreams, or nil
-// when there are none. Shared by the Handler (chain-evaluation refresh) and the
-// server's UpstreamTokenRefresher() accessor so both observe identical provider
-// wiring.
+// when there are none. Called once during newServer so the returned instance
+// can be shared between the handler and the UpstreamTokenRefresher() accessor.
 func newUpstreamTokenRefresher(
 	upstreams []handlers.NamedUpstream,
 	stor storage.UpstreamTokenStorage,

--- a/pkg/authserver/server_test.go
+++ b/pkg/authserver/server_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
 	servercrypto "github.com/stacklok/toolhive/pkg/authserver/server/crypto"
@@ -221,5 +223,65 @@ func TestNewServer_CIMDEnabled_WrapsStorage(t *testing.T) {
 	_, ok := srv.storage.(*storage.CIMDStorageDecorator)
 	if !ok {
 		t.Errorf("expected storage to be *storage.CIMDStorageDecorator when CIMDEnabled=true, got %T", srv.storage)
+	}
+}
+
+// TestNewServer_UpstreamRefresherSharedInstance verifies the wiring this PR
+// fixes: UpstreamTokenRefresher() must return the single refresher constructed
+// in newServer rather than reallocating one per call. The pre-fix accessor
+// rebuilt the refresher (and its singleflight.Group) on every call, so the
+// handler chain-walk path and the runtime token-swap path ended up with
+// independent groups and cross-path refresh deduplication was impossible.
+// A regression that reintroduced per-call allocation would leave the
+// refresher's own singleflight test green, so this asserts instance identity
+// at the server boundary instead.
+func TestNewServer_UpstreamRefresherSharedInstance(t *testing.T) {
+	t.Parallel()
+
+	mockUpstream := upstreammocks.NewMockOAuth2Provider(gomock.NewController(t))
+	stor := storage.NewMemoryStorage()
+	t.Cleanup(func() { _ = stor.Close() })
+
+	cfg := Config{
+		Issuer:           "https://example.com",
+		KeyProvider:      keys.NewGeneratingProvider(keys.DefaultAlgorithm),
+		HMACSecrets:      &servercrypto.HMACSecrets{Current: validHMACSecret()},
+		Upstreams:        []UpstreamConfig{{Name: "default", Type: UpstreamProviderTypeOAuth2, OAuth2Config: validUpstreamConfig()}},
+		AllowedAudiences: []string{"https://mcp.example.com"},
+	}
+	mockFactory := func(_ context.Context, _ *UpstreamConfig) (upstream.OAuth2Provider, error) {
+		return mockUpstream, nil
+	}
+
+	srv, err := newServer(context.Background(), cfg, stor, withUpstreamFactory(mockFactory))
+	require.NoError(t, err)
+
+	first := srv.UpstreamTokenRefresher()
+	require.NotNil(t, first, "refresher must be non-nil when upstreams are configured")
+	// Repeated calls must return the identical instance — i.e. the same
+	// singleflight.Group — not a freshly allocated one.
+	assert.Same(t, first, srv.UpstreamTokenRefresher(),
+		"UpstreamTokenRefresher() must return the shared instance, not reallocate per call")
+	// That instance must be the field stored on the server, which is the same
+	// value wired into the handler via WithUpstreamRefresher in newServer.
+	assert.Same(t, srv.upstreamRefresher, first,
+		"accessor must return the stored instance shared with the handler")
+}
+
+// TestNewUpstreamTokenRefresher_NilWhenNoUpstreams verifies the true-nil
+// interface contract: with no upstreams the constructor must return a nil
+// interface value, not a typed nil (*upstreamTokenRefresher)(nil) wrapped in an
+// interface, so that callers' `== nil` checks (runner, service, handler) work.
+func TestNewUpstreamTokenRefresher_NilWhenNoUpstreams(t *testing.T) {
+	t.Parallel()
+
+	stor := storage.NewMemoryStorage()
+	t.Cleanup(func() { _ = stor.Close() })
+
+	refresher := newUpstreamTokenRefresher(nil, stor, 24*time.Hour)
+	// Direct == nil comparison, not assert.Nil: testify's Nil also passes for a
+	// typed nil pointer, which would hide exactly the bug this guards against.
+	if refresher != nil {
+		t.Fatalf("expected a true nil interface, got non-nil %T", refresher)
 	}
 }


### PR DESCRIPTION
## Summary

Two code paths refresh an expired upstream token for the same `(session, provider)`: the runtime token-swap path (`pkg/auth/upstreamtoken`), which deduplicated concurrent refreshes through a `singleflight.Group`, and the authorization-chain walk (`pkg/authserver/server/handlers`), which called the refresher directly, outside that group. On top of that, `UpstreamTokenRefresher()` reallocated a fresh refresher (and a brand-new `singleflight.Group`) on every call, so the group could never have deduplicated across callers regardless.

That gap matters for corporate IdPs that rotate refresh tokens and detect reuse. Two callers can redeem the same stored `RT(v1)` at once — one rotates to `RT(v2)`, the other replays `v1`, the IdP treats the replay as a breach and revokes the entire token family, silently logging the user out of that upstream.

- Construct a single shared refresher in `newServer` and store it on the `server`; `UpstreamTokenRefresher()` now returns that one instance instead of reallocating per call.
- Move the `singleflight.Group` (and the detached-context refresh timeout) onto the refresher, so the handler chain-walk path and the runtime token-swap path share one group. Concurrent refreshes of the same `(session, provider)` collapse to a single redemption; distinct keys stay independent.
- Add a server-level regression test asserting `UpstreamTokenRefresher()` returns the shared instance (guards against reintroducing per-call allocation), plus a true-nil-interface contract test.

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)

Also race-stressed the singleflight dedup test (`go test -race -count=200 -cpu=4`) to confirm it deduplicates deterministically and no longer flakes.

## Does this introduce a user-facing change?

No behavioral API change. Operationally, users authenticated against IdPs that rotate refresh tokens with reuse detection will no longer be spuriously logged out of an upstream when two requests trigger a refresh of the same token at the same time.

## Special notes for reviewers

- The shared instance is stored as the `storage.UpstreamTokenRefresher` interface type (not the concrete pointer) to preserve the true-nil contract: with no upstreams the constructor returns a nil interface, so callers' `== nil` checks still work.
- The dedup test was rewritten to hold the leader's in-flight call open on a test-controlled release channel (mirroring `golang.org/x/sync/singleflight`'s own dup-suppression test) — singleflight exposes no hook for "a follower is parked in `Do`", so the comment is explicit that full determinism isn't possible and explains what keeps it robust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
