### PR TITLE
Fail closed on unpersisted rotated refresh token

### DIFF
--- a/pkg/authserver/refresher.go
+++ b/pkg/authserver/refresher.go
@@ -21,6 +21,18 @@ import (
 // triggering request's context so that waiting callers are not abandoned.
 const refreshTimeout = 30 * time.Second
 
+// upstreamStoreMaxAttempts is the maximum number of attempts to store refreshed
+// upstream tokens before giving up.
+const upstreamStoreMaxAttempts = 3
+
+// upstreamStoreRetryBackoff is the fixed delay between store retry attempts.
+const upstreamStoreRetryBackoff = 50 * time.Millisecond
+
+// upstreamDeleteTimeout bounds how long the best-effort per-provider delete may
+// take. A fresh detached context is used so a ctx deadline/cancel on the store
+// attempts does not also kill the delete, which would leave the stale row behind.
+const upstreamDeleteTimeout = 5 * time.Second
+
 // upstreamTokenRefresher implements storage.UpstreamTokenRefresher by wrapping
 // a set of upstream OAuth2Providers (keyed by provider name) and
 // UpstreamTokenStorage (for persisting the refreshed tokens). On each refresh
@@ -127,20 +139,47 @@ func (r *upstreamTokenRefresher) refreshAndStore(
 		ClientID:         expired.ClientID,
 	}
 
-	// If the provider didn't rotate the refresh token, keep the original
+	// Detect rotation BEFORE the old-RT backfill below so the original
+	// (provider-issued) value is compared, not the backfilled fallback.
+	rotated := updated.RefreshToken != "" && updated.RefreshToken != expired.RefreshToken
+
+	// If the provider didn't rotate the refresh token, keep the original.
 	if updated.RefreshToken == "" {
 		updated.RefreshToken = expired.RefreshToken
 	}
 
-	// Store the refreshed tokens
-	if err := r.storage.StoreUpstreamTokens(ctx, sessionID, expired.ProviderID, updated); err != nil {
-		// Log but still return the refreshed tokens — the current request can
-		// proceed even if storage fails. The next request will retry the refresh.
-		slog.Warn("failed to store refreshed upstream tokens",
-			"session_id", sessionID,
-			"error", err,
+	if err := r.storeWithRetry(ctx, sessionID, expired.ProviderID, updated); err != nil {
+		if !rotated {
+			// The old refresh token is still valid in storage; the caller can
+			// proceed with the refreshed access token for this request.
+			slog.Warn("failed to persist refreshed upstream tokens; old refresh token still valid",
+				"session_id", sessionID,
+				"provider_id", expired.ProviderID,
+				"error", err,
+			)
+			return updated, nil
+		}
+
+		// The IdP rotated the refresh token: the new RT was redeemed but could
+		// not be persisted. The old RT is now dead in storage and will trigger
+		// reuse-detection lockout on the next refresh attempt.
+		//
+		// Residual window: if the process crashes here, the dead old RT stays in
+		// storage. ErrNotFound on the next refresh attempt forces re-auth, which
+		// is the backstop. Store-intent-before-redeem is out of scope for this fix.
+		deleteCtx, deleteCancel := context.WithTimeout(context.WithoutCancel(ctx), upstreamDeleteTimeout)
+		defer deleteCancel()
+		if delErr := r.storage.DeleteUpstreamTokensForProvider(deleteCtx, sessionID, expired.ProviderID); delErr != nil {
+			slog.Error("failed to delete stale upstream token row after rotation persist failure",
+				"session_id", sessionID,
+				"provider_id", expired.ProviderID,
+				"error", delErr,
+			)
+		}
+		return nil, fmt.Errorf(
+			"failed to persist rotated upstream refresh token for session %q provider %q: %w",
+			sessionID, expired.ProviderID, err,
 		)
-		return updated, nil
 	}
 
 	slog.Debug("upstream tokens refreshed successfully",
@@ -149,4 +188,37 @@ func (r *upstreamTokenRefresher) refreshAndStore(
 	)
 
 	return updated, nil
+}
+
+// storeWithRetry attempts to store updated tokens up to upstreamStoreMaxAttempts times,
+// waiting upstreamStoreRetryBackoff between attempts. Returns nil on first success.
+// Returns the last error after all attempts are exhausted. Ctx-cancellation short-circuits
+// between attempts and returns the last store error (not ctx.Err()).
+func (r *upstreamTokenRefresher) storeWithRetry(
+	ctx context.Context,
+	sessionID, providerID string,
+	updated *storage.UpstreamTokens,
+) error {
+	var lastErr error
+	for attempt := 1; attempt <= upstreamStoreMaxAttempts; attempt++ {
+		storeErr := r.storage.StoreUpstreamTokens(ctx, sessionID, providerID, updated)
+		if storeErr == nil {
+			return nil
+		}
+		lastErr = storeErr
+		slog.Debug("failed to store refreshed upstream tokens",
+			"session_id", sessionID,
+			"provider_id", providerID,
+			"attempt", attempt,
+			"error", lastErr,
+		)
+		if attempt < upstreamStoreMaxAttempts {
+			select {
+			case <-ctx.Done():
+				return lastErr
+			case <-time.After(upstreamStoreRetryBackoff):
+			}
+		}
+	}
+	return lastErr
 }

--- a/pkg/authserver/refresher_test.go
+++ b/pkg/authserver/refresher_test.go
@@ -254,7 +254,9 @@ func TestUpstreamTokenRefresher_RefreshAndStore(t *testing.T) {
 			wantErrContain: "upstream token refresh failed",
 		},
 		{
-			name:      "storage fails after refresh - returns refreshed tokens anyway",
+			// Rotated RT + all store attempts fail → best-effort delete + error.
+			// Provider returns a new (different) RefreshToken so rotation is detected.
+			name:      "rotated RT and storage fails - deletes stale row and returns error",
 			sessionID: "session-6",
 			expired:   baseExpired,
 			setupProvider: func(_ *testing.T, p *upstreammocks.MockOAuth2Provider) {
@@ -268,20 +270,70 @@ func TestUpstreamTokenRefresher_RefreshAndStore(t *testing.T) {
 			},
 			setupStorage: func(_ *testing.T, s *storagemocks.MockUpstreamTokenStorage) {
 				s.EXPECT().StoreUpstreamTokens(gomock.Any(), "session-6", "github", gomock.Any()).
+					Times(3).
 					Return(errors.New("redis connection lost"))
+				s.EXPECT().DeleteUpstreamTokensForProvider(gomock.Any(), "session-6", "github").
+					Return(nil)
 			},
+			wantErr:        true,
+			wantErrContain: "failed to persist rotated upstream refresh token",
+		},
+		{
+			// Not-rotated RT (provider returns empty RefreshToken → backfill) +
+			// all store attempts fail → proceed-anyway (old RT still valid in storage).
+			name:      "not-rotated RT and storage fails - returns tokens without error",
+			sessionID: "session-7",
+			expired:   baseExpired,
+			setupProvider: func(_ *testing.T, p *upstreammocks.MockOAuth2Provider) {
+				p.EXPECT().RefreshTokens(gomock.Any(), "old-refresh", "upstream-sub-456").
+					Return(&upstream.Tokens{
+						AccessToken:  "new-access",
+						RefreshToken: "", // provider did not rotate
+						IDToken:      "new-id-token",
+						ExpiresAt:    newExpiry,
+					}, nil)
+			},
+			setupStorage: func(_ *testing.T, s *storagemocks.MockUpstreamTokenStorage) {
+				s.EXPECT().StoreUpstreamTokens(gomock.Any(), "session-7", "github", gomock.Any()).
+					Times(3).
+					Return(errors.New("redis connection lost"))
+				// No DeleteUpstreamTokensForProvider call expected.
+			},
+			wantErr: false,
 			checkResult: func(t *testing.T, result *storage.UpstreamTokens) {
 				t.Helper()
-				// Tokens should still be returned despite storage failure
 				assert.Equal(t, "new-access", result.AccessToken)
+				// The old refresh token must be backfilled (provider returned "").
+				assert.Equal(t, "old-refresh", result.RefreshToken)
+			},
+		},
+		{
+			// Rotated RT: first store attempt fails, second succeeds → no delete, result returned.
+			name:      "rotated RT and store succeeds on retry - no delete",
+			sessionID: "session-8",
+			expired:   baseExpired,
+			setupProvider: func(_ *testing.T, p *upstreammocks.MockOAuth2Provider) {
+				p.EXPECT().RefreshTokens(gomock.Any(), "old-refresh", "upstream-sub-456").
+					Return(&upstream.Tokens{
+						AccessToken:  "new-access",
+						RefreshToken: "new-refresh",
+						IDToken:      "new-id-token",
+						ExpiresAt:    newExpiry,
+					}, nil)
+			},
+			setupStorage: func(_ *testing.T, s *storagemocks.MockUpstreamTokenStorage) {
+				gomock.InOrder(
+					s.EXPECT().StoreUpstreamTokens(gomock.Any(), "session-8", "github", gomock.Any()).
+						Return(errors.New("transient error")),
+					s.EXPECT().StoreUpstreamTokens(gomock.Any(), "session-8", "github", gomock.Any()).
+						Return(nil),
+				)
+				// No DeleteUpstreamTokensForProvider expected.
+			},
+			wantErr: false,
+			checkResult: func(t *testing.T, result *storage.UpstreamTokens) {
+				t.Helper()
 				assert.Equal(t, "new-refresh", result.RefreshToken)
-				assert.Equal(t, "new-id-token", result.IDToken)
-				assert.Equal(t, newExpiry, result.ExpiresAt)
-				// Binding fields preserved
-				assert.Equal(t, "github", result.ProviderID)
-				assert.Equal(t, "user-123", result.UserID)
-				assert.Equal(t, "upstream-sub-456", result.UpstreamSubject)
-				assert.Equal(t, "client-abc", result.ClientID)
 			},
 		},
 	}

--- a/pkg/authserver/storage/memory.go
+++ b/pkg/authserver/storage/memory.go
@@ -860,6 +860,23 @@ func (s *MemoryStorage) DeleteUpstreamTokens(_ context.Context, sessionID string
 	return nil
 }
 
+// DeleteUpstreamTokensForProvider removes tokens for a single (sessionID, providerName),
+// leaving sibling providers' rows intact. Absent row returns nil (not ErrNotFound).
+func (s *MemoryStorage) DeleteUpstreamTokensForProvider(_ context.Context, sessionID, providerName string) error {
+	if sessionID == "" {
+		return fosite.ErrInvalidRequest.WithHint("session ID cannot be empty")
+	}
+	if providerName == "" {
+		return fosite.ErrInvalidRequest.WithHint("provider name cannot be empty")
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	delete(s.upstreamTokens, upstreamKey{sessionID, providerName})
+	return nil
+}
+
 // compareExpiry orders ExpiresAt values for the GetLatestUpstreamTokensForUser
 // tie-breaker. Non-expiring rows (zero ExpiresAt — "alive forever") rank latest;
 // among finite expiries, later ranks latest. Mirrors time.Compare but with the

--- a/pkg/authserver/storage/memory_test.go
+++ b/pkg/authserver/storage/memory_test.go
@@ -833,6 +833,32 @@ func TestMemoryStorage_GetLatestUpstreamTokensForUser(t *testing.T) {
 			require.Equal(t, fixture, *got)
 		})
 	})
+
+	t.Run("DeleteUpstreamTokensForProvider leaves sibling intact", func(t *testing.T) {
+		withStorage(t, func(ctx context.Context, s *MemoryStorage) {
+			require.NoError(t, s.StoreUpstreamTokens(ctx, "session-1", "provider-a", &UpstreamTokens{AccessToken: "a"}))
+			require.NoError(t, s.StoreUpstreamTokens(ctx, "session-1", "provider-b", &UpstreamTokens{AccessToken: "b"}))
+
+			require.NoError(t, s.DeleteUpstreamTokensForProvider(ctx, "session-1", "provider-a"))
+
+			_, err := s.GetUpstreamTokens(ctx, "session-1", "provider-a")
+			requireNotFoundError(t, err)
+
+			got, err := s.GetUpstreamTokens(ctx, "session-1", "provider-b")
+			require.NoError(t, err)
+			assert.Equal(t, "b", got.AccessToken)
+
+			all, err := s.GetAllUpstreamTokens(ctx, "session-1")
+			require.NoError(t, err)
+			assert.Len(t, all, 1)
+		})
+	})
+
+	t.Run("DeleteUpstreamTokensForProvider absent row is non-fatal", func(t *testing.T) {
+		withStorage(t, func(ctx context.Context, s *MemoryStorage) {
+			require.NoError(t, s.DeleteUpstreamTokensForProvider(ctx, "no-such-session", "provider-a"))
+		})
+	})
 }
 
 // --- Pending Authorization Tests ---

--- a/pkg/authserver/storage/mocks/mock_storage.go
+++ b/pkg/authserver/storage/mocks/mock_storage.go
@@ -272,6 +272,20 @@ func (mr *MockUpstreamTokenStorageMockRecorder) DeleteUpstreamTokens(ctx, sessio
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteUpstreamTokens", reflect.TypeOf((*MockUpstreamTokenStorage)(nil).DeleteUpstreamTokens), ctx, sessionID)
 }
 
+// DeleteUpstreamTokensForProvider mocks base method.
+func (m *MockUpstreamTokenStorage) DeleteUpstreamTokensForProvider(ctx context.Context, sessionID, providerName string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteUpstreamTokensForProvider", ctx, sessionID, providerName)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteUpstreamTokensForProvider indicates an expected call of DeleteUpstreamTokensForProvider.
+func (mr *MockUpstreamTokenStorageMockRecorder) DeleteUpstreamTokensForProvider(ctx, sessionID, providerName any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteUpstreamTokensForProvider", reflect.TypeOf((*MockUpstreamTokenStorage)(nil).DeleteUpstreamTokensForProvider), ctx, sessionID, providerName)
+}
+
 // GetAllUpstreamTokens mocks base method.
 func (m *MockUpstreamTokenStorage) GetAllUpstreamTokens(ctx context.Context, sessionID string) (map[string]*storage.UpstreamTokens, error) {
 	m.ctrl.T.Helper()
@@ -699,6 +713,20 @@ func (m *MockStorage) DeleteUpstreamTokens(ctx context.Context, sessionID string
 func (mr *MockStorageMockRecorder) DeleteUpstreamTokens(ctx, sessionID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteUpstreamTokens", reflect.TypeOf((*MockStorage)(nil).DeleteUpstreamTokens), ctx, sessionID)
+}
+
+// DeleteUpstreamTokensForProvider mocks base method.
+func (m *MockStorage) DeleteUpstreamTokensForProvider(ctx context.Context, sessionID, providerName string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteUpstreamTokensForProvider", ctx, sessionID, providerName)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteUpstreamTokensForProvider indicates an expected call of DeleteUpstreamTokensForProvider.
+func (mr *MockStorageMockRecorder) DeleteUpstreamTokensForProvider(ctx, sessionID, providerName any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteUpstreamTokensForProvider", reflect.TypeOf((*MockStorage)(nil).DeleteUpstreamTokensForProvider), ctx, sessionID, providerName)
 }
 
 // DeleteUser mocks base method.

--- a/pkg/authserver/storage/redis.go
+++ b/pkg/authserver/storage/redis.go
@@ -1044,6 +1044,48 @@ func (s *RedisStorage) DeleteUpstreamTokens(ctx context.Context, sessionID strin
 	return nil
 }
 
+// DeleteUpstreamTokensForProvider removes tokens for a single (sessionID, providerName),
+// leaving sibling providers' rows intact. Absent row returns nil.
+func (s *RedisStorage) DeleteUpstreamTokensForProvider(ctx context.Context, sessionID, providerName string) error {
+	if sessionID == "" {
+		return fosite.ErrInvalidRequest.WithHint("session ID cannot be empty")
+	}
+	if providerName == "" {
+		return fosite.ErrInvalidRequest.WithHint("provider name cannot be empty")
+	}
+
+	key := redisUpstreamKey(s.keyPrefix, sessionID, providerName)
+	idxKey := redisSetKey(s.keyPrefix, KeyTypeUpstreamIdx, sessionID)
+
+	// Best-effort: read UserID for reverse-index cleanup before deleting.
+	var userID string
+	data, err := s.client.Get(ctx, key).Bytes()
+	if err == nil && string(data) != nullMarker {
+		var stored storedUpstreamTokens
+		if unmarshalErr := json.Unmarshal(data, &stored); unmarshalErr == nil {
+			userID = stored.UserID
+		}
+	}
+	// redis.Nil (key absent) or any error on GET: skip user-index cleanup gracefully.
+
+	// Del returns count 0 on absent key — treat as nil (not ErrNotFound).
+	if delErr := s.client.Del(ctx, key).Err(); delErr != nil {
+		return fmt.Errorf("failed to delete upstream tokens for provider: %w", delErr)
+	}
+
+	// Best-effort secondary index cleanup — leave sibling members in idxKey intact.
+	// If this was the last provider for the session, the set becomes empty and
+	// expires by its own TTL; we do not delete the set key itself (intentional,
+	// matching the best-effort cleanup posture of DeleteUpstreamTokens).
+	warnOnCleanupErr(s.client.SRem(ctx, idxKey, key).Err(), "SRem", idxKey)
+	if userID != "" {
+		userUpstreamSetKey := redisSetKey(s.keyPrefix, KeyTypeUserUpstream, userID)
+		warnOnCleanupErr(s.client.SRem(ctx, userUpstreamSetKey, key).Err(), "SRem", userUpstreamSetKey)
+	}
+
+	return nil
+}
+
 // GetLatestUpstreamTokensForUser returns the upstream token row for (userID, providerID)
 // with the highest ExpiresAt across all sessions.
 //

--- a/pkg/authserver/storage/redis_test.go
+++ b/pkg/authserver/storage/redis_test.go
@@ -1150,6 +1150,36 @@ func TestRedisStorage_UpstreamTokens(t *testing.T) {
 		})
 	})
 
+	t.Run("DeleteUpstreamTokensForProvider leaves sibling intact", func(t *testing.T) {
+		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, _ *miniredis.Miniredis) {
+			require.NoError(t, s.StoreUpstreamTokens(ctx, "session-1", "provider-a", &UpstreamTokens{
+				ProviderID: "provider-a", AccessToken: "a", ExpiresAt: time.Now().Add(time.Hour),
+			}))
+			require.NoError(t, s.StoreUpstreamTokens(ctx, "session-1", "provider-b", &UpstreamTokens{
+				ProviderID: "provider-b", AccessToken: "b", ExpiresAt: time.Now().Add(time.Hour),
+			}))
+
+			require.NoError(t, s.DeleteUpstreamTokensForProvider(ctx, "session-1", "provider-a"))
+
+			_, err := s.GetUpstreamTokens(ctx, "session-1", "provider-a")
+			requireRedisNotFoundError(t, err)
+
+			got, err := s.GetUpstreamTokens(ctx, "session-1", "provider-b")
+			require.NoError(t, err)
+			assert.Equal(t, "b", got.AccessToken)
+
+			all, err := s.GetAllUpstreamTokens(ctx, "session-1")
+			require.NoError(t, err)
+			assert.Len(t, all, 1)
+		})
+	})
+
+	t.Run("DeleteUpstreamTokensForProvider absent row is non-fatal", func(t *testing.T) {
+		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, _ *miniredis.Miniredis) {
+			require.NoError(t, s.DeleteUpstreamTokensForProvider(ctx, "no-such-session", "provider-a"))
+		})
+	})
+
 }
 
 // --- Bulk Migration Tests ---

--- a/pkg/authserver/storage/types.go
+++ b/pkg/authserver/storage/types.go
@@ -533,6 +533,11 @@ type UpstreamTokenStorage interface {
 	// Returns ErrNotFound if the session does not exist.
 	DeleteUpstreamTokens(ctx context.Context, sessionID string) error
 
+	// DeleteUpstreamTokensForProvider removes tokens for a single (sessionID, providerName),
+	// leaving sibling providers' rows intact. Deleting an absent row is NOT an error (nil).
+	// Used as best-effort cleanup of a refresh token rotated at the IdP but not persisted.
+	DeleteUpstreamTokensForProvider(ctx context.Context, sessionID, providerName string) error
+
 	// GetLatestUpstreamTokensForUser returns the most recently stored upstream tokens
 	// for (userID, providerID) across any session. The "latest" winner is determined
 	// by treating non-expiring rows (zero ExpiresAt — providers like Slack and GitHub


### PR DESCRIPTION
## Summary

> **Stacked on #5635** (`fix-upstream-refresh-singleflight`). Review and merge that first; this PR targets that branch, so its diff will collapse to just the persistence change once the base merges.

`RefreshAndStore` redeemed the stored refresh token at the IdP, persisted the result, but swallowed any storage-write failure and returned the refreshed tokens anyway. With refresh-token rotation (the common case) that strands a dead token in storage and gets the user's whole token family revoked:

1. read stored row → `RT(v1)`
2. `provider.RefreshTokens(RT v1)` → IdP rotates: `RT(v1)` now **dead**, returns `AT'`, `RT(v2)` (irreversible — it happened at the IdP)
3. `StoreUpstreamTokens(RT v2)` **fails** (Redis blip, timeout, …)
4. old code logs and `return updated, nil` — swallows the failure; caller gets `AT'`/`RT(v2)` and the request succeeds, but storage still holds `RT(v1)` (poisoned)
5. next refresh reads the stale row → `RT(v1)`
6. `provider.RefreshTokens(RT v1)` → IdP: "already used → replay → breach" → revokes the whole family
7. user hard-logged-out of the upstream; full re-auth required

The damage is done at step 2 (rotation is irreversible), but only detonates at step 6 when the stale row is replayed. No concurrency is needed — one failed write plus any later refresh.

- Detect rotation (provider returned a new, non-empty refresh token that differs from the stored one).
- **Not rotated**: keep today's behavior — the stored token is still valid, so proceed and let the next request retry.
- **Rotated + store failed**: retry the store briefly; if it still fails, best-effort delete the stale per-provider row so the next read misses and forces a clean re-auth instead of replaying a dead token, then return an error so callers fail closed.
- Add `DeleteUpstreamTokensForProvider` to the storage interface (memory + redis); deleting an absent row is a no-op and siblings are untouched.

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)

## Does this introduce a user-facing change?

No API change. A storage-write failure during a rotated-token refresh now surfaces as a clean re-authentication on the next request, rather than silently poisoning the stored token and triggering an IdP-side revocation of the user's entire upstream token family.

## Special notes for reviewers

- **Residual window**: a crash between the IdP redemption and the stale-row delete still strands a dead token; the `ErrNotFound → re-auth` read path is the backstop. A write-ahead (store-intent-before-redeem) design would close it entirely and is left as future work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
