### PR TITLE
fix(runner): do not validate container target port on host

### DIFF
--- a/pkg/runner/config.go
+++ b/pkg/runner/config.go
@@ -537,14 +537,20 @@ func (c *RunConfig) WithPorts(proxyPort, targetPort int) (*RunConfig, error) {
 	}
 	c.Port = selectedPort
 
-	// Select a target port for the container if using SSE or Streamable HTTP transport
+	// Select a target port for the container if using SSE or Streamable HTTP transport.
+	// Target ports are container-internal; do not validate them against host availability.
 	if c.Transport == types.TransportTypeSSE || c.Transport == types.TransportTypeStreamableHTTP {
-		selectedTargetPort, err := networking.FindOrUsePort(targetPort)
-		if err != nil {
-			return c, fmt.Errorf("target port error: %w", err)
+		if targetPort != 0 {
+			slog.Debug("using target port", "port", targetPort)
+			c.TargetPort = targetPort
+		} else {
+			selectedTargetPort, err := networking.FindOrUsePort(0)
+			if err != nil {
+				return c, fmt.Errorf("target port error: %w", err)
+			}
+			slog.Debug("using target port", "port", selectedTargetPort)
+			c.TargetPort = selectedTargetPort
 		}
-		slog.Debug("using target port", "port", selectedTargetPort)
-		c.TargetPort = selectedTargetPort
 	}
 
 	return c, nil

--- a/pkg/runner/config_test.go
+++ b/pkg/runner/config_test.go
@@ -242,6 +242,26 @@ func TestRunConfig_WithPorts(t *testing.T) {
 	}
 }
 
+// TestRunConfig_WithPorts_TargetPortIgnoresHostAvailability ensures container target
+// ports are not validated against host availability.
+//
+//nolint:tparallel,paralleltest // Subtests share a listener occupying the target port on the host
+func TestRunConfig_WithPorts_TargetPortIgnoresHostAvailability(t *testing.T) {
+	t.Parallel()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err, "Should be able to occupy a port on host")
+	defer listener.Close()
+
+	targetPort := listener.Addr().(*net.TCPAddr).Port
+	config := &RunConfig{Transport: types.TransportTypeSSE}
+	result, err := config.WithPorts(0, targetPort)
+
+	require.NoError(t, err)
+	assert.Equal(t, config, result)
+	assert.Equal(t, targetPort, config.TargetPort, "TargetPort should remain the requested container port")
+}
+
 func TestRunConfig_WithEnvironmentVariables(t *testing.T) {
 	t.Parallel()
 	testCases := []struct {


### PR DESCRIPTION
## Summary

`WithPorts()` was validating container-internal target ports against host availability via `FindOrUsePort`. When the requested target port (e.g. 3000 from registry metadata) was busy on the host, ToolHive silently substituted a random port, causing flaky tests and runtime proxy misconfiguration.

This change preserves explicitly requested target ports and only uses host-based port selection when no target port is specified (`targetPort == 0`).

Fixes #4761

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [x] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [ ] Linting (`task lint-fix`)
- [ ] Manual testing (describe below)

Ran locally:

```bash
go test -count=1 ./pkg/runner/...
go test -count=1 -run 'TestRunConfig_WithPorts|TestRunConfigBuilder_MetadataOverrides' ./pkg/runner/
```

Both pass. Reproduced the original flaky failure by occupying the target port on the host before the fix.

## API Compatibility

- [x] This PR does not break the `v1beta1` API, OR the `api-break-allowed` label is applied and the migration guidance is described above.

## Changes

| File | Change |
|------|--------|
| `pkg/runner/config.go` | Skip host availability checks for explicit container target ports |
| `pkg/runner/config_test.go` | Add regression test for busy-host target port preservation |

## Does this introduce a user-facing change?

Yes. SSE/streamable-http workloads with registry-defined target ports now keep the intended container port even when that port number is already in use on the host.

## Special notes for reviewers

Proxy ports still validate host availability as before; only container target ports are affected.