### PR TITLE
fix(operator): mirror Redis password env in deploymentNeedsUpdate

### DIFF
--- a/cmd/thv-operator/controllers/mcpserver_controller.go
+++ b/cmd/thv-operator/controllers/mcpserver_controller.go
@@ -1851,6 +1851,11 @@ func (r *MCPServerReconciler) deploymentNeedsUpdate(
 			}
 		}
 
+		// Mount Redis password secret when session storage provider is Redis.
+		// Must mirror deploymentForMCPServer exactly (same call, same position)
+		// so a correctly-configured resource does not look perpetually drifted.
+		expectedProxyEnv = append(expectedProxyEnv, r.buildRedisPasswordEnvVar(mcpServer)...)
+
 		// Project the MCPServer generation pod-template annotation into the
 		// proxyrunner container via the downward API. Position must come
 		// before the embedded-auth env vars below so the slice order matches

--- a/cmd/thv-operator/controllers/mcpserver_replicas_test.go
+++ b/cmd/thv-operator/controllers/mcpserver_replicas_test.go
@@ -1213,3 +1213,30 @@ func TestMCPServerDeploymentRedisPasswordOverridesUserEnvOnCollision(t *testing.
 	assert.Equal(t, passwordRef.Name, last.ValueFrom.SecretKeyRef.Name)
 	assert.Equal(t, passwordRef.Key, last.ValueFrom.SecretKeyRef.Key)
 }
+
+// TestDeploymentNeedsUpdate_RedisPasswordEnvVar is a regression test for #5365:
+// deploymentNeedsUpdate must mirror buildRedisPasswordEnvVar at the same position
+// as deploymentForMCPServer, otherwise Redis session storage causes perpetual drift.
+func TestDeploymentNeedsUpdate_RedisPasswordEnvVar(t *testing.T) {
+	t.Parallel()
+
+	passwordRef := &mcpv1beta1.SecretKeyRef{Name: "redis-secret", Key: "password"}
+
+	mcpServer := v1beta1test.NewMCPServer("test-mcp-redis-drift", "default",
+		v1beta1test.WithTransport("streamable-http"),
+		v1beta1test.WithSessionStorage(&mcpv1beta1.SessionStorageConfig{
+			Provider:    mcpv1beta1.SessionStorageProviderRedis,
+			Address:     "redis:6379",
+			PasswordRef: passwordRef,
+		}))
+
+	testScheme := testutil.NewScheme(t)
+	r := newTestMCPServerReconciler(nil, testScheme, kubernetes.PlatformKubernetes)
+
+	deployment, err := r.deploymentForMCPServer(t.Context(), mcpServer, "test-checksum")
+	require.NoError(t, err)
+	require.NotNil(t, deployment)
+
+	assert.False(t, r.deploymentNeedsUpdate(t.Context(), deployment, mcpServer, "test-checksum"),
+		"freshly built Deployment with Redis passwordRef must not be flagged for update by drift detection")
+}


### PR DESCRIPTION
## Summary

Mirror `buildRedisPasswordEnvVar` in `deploymentNeedsUpdate` so the drift check matches `deploymentForMCPServer` for MCPServers using Redis session storage with a `passwordRef`.

## Motivation

When `sessionStorage.provider == "redis"` and `passwordRef` is set, the proxy Deployment carries `THV_SESSION_REDIS_PASSWORD`, but `deploymentNeedsUpdate` rebuilt `expectedProxyEnv` without that entry. `equality.Semantic.DeepEqual` therefore flagged drift on every reconcile, incrementing `resourceVersion` and potentially destabilizing rolling updates.

Fixes #5365

## Changes

- Append `r.buildRedisPasswordEnvVar(mcpServer)` in `deploymentNeedsUpdate` after user `ResourceOverrides.Env` and before the `THV_MCPSERVER_GENERATION` downward-API env var — same position as `deploymentForMCPServer`.
- Add `TestDeploymentNeedsUpdate_RedisPasswordEnvVar` regression test asserting a freshly built Deployment is not flagged for update.

## Tests

```bash
go test ./cmd/thv-operator/controllers/ -run 'TestDeploymentNeedsUpdate_RedisPasswordEnvVar|TestMCPServerDeploymentInjectsRedisPasswordEnvVar' -count=1 -v
```

Result: **PASS**

## Notes

- Follows the same builder/drift symmetry pattern used for OBO env vars and default image pull secrets.
- No behavior change for MCPServers without Redis password refs.
